### PR TITLE
fix(hermes): avoid AF_UNIX socket path overflow

### DIFF
--- a/server/pkg/agent/hermes.go
+++ b/server/pkg/agent/hermes.go
@@ -13,6 +13,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"regexp"
+	"runtime"
 	"sort"
 	"strconv"
 	"strings"
@@ -35,6 +36,23 @@ var hermesBlockedArgs = map[string]blockedArgMode{
 // the Codex-specific JSON-RPC methods.
 type hermesBackend struct {
 	cfg Config
+}
+
+func withHermesTempDir(env []string, tempDir string) []string {
+	filtered := make([]string, 0, len(env)+3)
+	for _, entry := range env {
+		key, _, _ := strings.Cut(entry, "=")
+		switch key {
+		case "TMPDIR", "TMP", "TEMP":
+			continue
+		}
+		filtered = append(filtered, entry)
+	}
+	return append(filtered,
+		"TMPDIR="+tempDir,
+		"TMP="+tempDir,
+		"TEMP="+tempDir,
+	)
 }
 
 func (b *hermesBackend) Execute(ctx context.Context, prompt string, opts ExecOptions) (*Session, error) {
@@ -74,11 +92,6 @@ func (b *hermesBackend) Execute(ctx context.Context, prompt string, opts ExecOpt
 		b.cfg.Logger.Debug("hermes ignoring ExecOptions.SystemPrompt; using cwd-scoped context files", "cwd", opts.Cwd)
 	}
 
-	env := buildEnv(b.cfg.Env)
-	// Enable yolo mode so Hermes auto-approves all tool executions.
-	env = append(env, "HERMES_YOLO_MODE=1")
-	cmd.Env = env
-
 	stdout, err := cmd.StdoutPipe()
 	if err != nil {
 		cancel()
@@ -113,7 +126,31 @@ func (b *hermesBackend) Execute(ctx context.Context, prompt string, opts ExecOpt
 		return nil, fmt.Errorf("hermes stderr pipe: %w", err)
 	}
 
+	env := buildEnv(b.cfg.Env)
+	cleanupTempDir := func() {}
+	if runtime.GOOS != "windows" {
+		// Hermes execute_code binds an AF_UNIX RPC socket beneath Python's
+		// tempfile.gettempdir(). Multica's task-private TMPDIR can exceed the
+		// sockaddr_un path limit before Hermes appends its socket filename, so
+		// give only the Hermes child a short, private directory for its lifetime.
+		shortTempDir, err := os.MkdirTemp("/tmp", "multica-hermes-")
+		if err != nil {
+			cancel()
+			return nil, fmt.Errorf("prepare hermes temp dir: %w", err)
+		}
+		env = withHermesTempDir(env, shortTempDir)
+		cleanupTempDir = func() {
+			if err := os.RemoveAll(shortTempDir); err != nil {
+				b.cfg.Logger.Warn("hermes temp dir cleanup failed", "path", shortTempDir, "error", err)
+			}
+		}
+	}
+	// Enable yolo mode so Hermes auto-approves all tool executions.
+	env = append(env, "HERMES_YOLO_MODE=1")
+	cmd.Env = env
+
 	if err := cmd.Start(); err != nil {
+		cleanupTempDir()
 		cancel()
 		return nil, fmt.Errorf("start hermes: %w", err)
 	}
@@ -192,6 +229,7 @@ func (b *hermesBackend) Execute(ctx context.Context, prompt string, opts ExecOpt
 		defer cancel()
 		defer close(msgCh)
 		defer close(resCh)
+		defer cleanupTempDir()
 		defer func() {
 			stdin.Close()
 			_ = cmd.Wait()

--- a/server/pkg/agent/hermes_test.go
+++ b/server/pkg/agent/hermes_test.go
@@ -7,6 +7,7 @@ import (
 	"log/slog"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"sync"
 	"testing"
@@ -1350,6 +1351,123 @@ while IFS= read -r line; do
   esac
 done
 `
+}
+
+func fakeHermesACPTempEnvScript() string {
+	return `#!/bin/sh
+printf 'TMPDIR=%s\nTMP=%s\nTEMP=%s\n' "$TMPDIR" "$TMP" "$TEMP" > "$CAPTURE_FILE"
+while IFS= read -r line; do
+  id=$(printf '%s' "$line" | sed -n 's/.*"id":\([0-9]*\).*/\1/p')
+  case "$line" in
+    *'"method":"initialize"'*)
+      printf '{"jsonrpc":"2.0","id":%s,"result":{"protocolVersion":1,"agentCapabilities":{}}}\n' "$id"
+      ;;
+    *'"method":"session/new"'*)
+      printf '{"jsonrpc":"2.0","id":%s,"result":{"sessionId":"ses_temp"}}\n' "$id"
+      ;;
+    *'"method":"session/prompt"'*)
+      printf '{"jsonrpc":"2.0","id":%s,"result":{"stopReason":"end_turn"}}\n' "$id"
+      exit 0
+      ;;
+  esac
+done
+`
+}
+
+func TestHermesBackendUsesShortPrivateTempDir(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Hermes uses a TCP code-execution transport on Windows")
+	}
+	t.Parallel()
+
+	longTempDir := filepath.Join(t.TempDir(), strings.Repeat("deep-path-", 12))
+	if err := os.MkdirAll(longTempDir, 0o700); err != nil {
+		t.Fatalf("create long temp dir: %v", err)
+	}
+	const socketName = "hermes_rpc_0123456789abcdef0123456789abcdef.sock"
+	if socketPath := filepath.Join(longTempDir, socketName); len(socketPath) <= 107 {
+		t.Fatalf("test setup: socket path length = %d, want > 107: %q", len(socketPath), socketPath)
+	}
+
+	capturePath := filepath.Join(t.TempDir(), "temp-env.txt")
+	fakePath := filepath.Join(t.TempDir(), "hermes")
+	writeTestExecutable(t, fakePath, []byte(fakeHermesACPTempEnvScript()))
+
+	backend, err := New("hermes", Config{
+		ExecutablePath: fakePath,
+		Logger:         slog.Default(),
+		Env: map[string]string{
+			"CAPTURE_FILE": capturePath,
+			"TMPDIR":       longTempDir,
+			"TMP":          longTempDir,
+			"TEMP":         longTempDir,
+		},
+	})
+	if err != nil {
+		t.Fatalf("new hermes backend: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	session, err := backend.Execute(ctx, "prompt-ignored", ExecOptions{Timeout: 5 * time.Second})
+	if err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	go func() {
+		for range session.Messages {
+		}
+	}()
+	select {
+	case result := <-session.Result:
+		if result.Status != "completed" {
+			t.Fatalf("expected completed result, got %q: %s", result.Status, result.Error)
+		}
+	case <-time.After(10 * time.Second):
+		t.Fatal("timeout waiting for result")
+	}
+
+	raw, err := os.ReadFile(capturePath)
+	if err != nil {
+		t.Fatalf("read captured temp env: %v", err)
+	}
+	captured := make(map[string]string)
+	for _, line := range strings.Split(strings.TrimSpace(string(raw)), "\n") {
+		key, value, ok := strings.Cut(line, "=")
+		if !ok {
+			t.Fatalf("malformed captured env line %q", line)
+		}
+		captured[key] = value
+	}
+	shortTempDir := captured["TMPDIR"]
+	if shortTempDir == "" {
+		t.Fatal("TMPDIR was empty")
+	}
+	if shortTempDir == longTempDir {
+		t.Fatalf("TMPDIR was not shortened: %q", shortTempDir)
+	}
+	for _, key := range []string{"TMP", "TEMP"} {
+		if captured[key] != shortTempDir {
+			t.Fatalf("%s = %q, want %q", key, captured[key], shortTempDir)
+		}
+	}
+	if socketPath := filepath.Join(shortTempDir, socketName); len(socketPath) > 107 {
+		t.Fatalf("short temp dir still produces an overlong socket path (%d bytes): %q", len(socketPath), socketPath)
+	}
+
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		_, statErr := os.Stat(shortTempDir)
+		if os.IsNotExist(statErr) {
+			break
+		}
+		if statErr != nil {
+			t.Fatalf("stat short temp dir: %v", statErr)
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("short temp dir was not cleaned up: %q", shortTempDir)
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
 }
 
 func TestHermesBackendAttributesUsageToACPDefaultModel(t *testing.T) {


### PR DESCRIPTION
## What does this PR do?

Fixes Hermes tasks on Linux that fail in `execute_code` with `OSError: AF_UNIX path too long` after Multica injects a deeply nested task-private `TMPDIR`.

This is a narrower alternative to #5116. Instead of changing the temp-directory policy for every runtime, it keeps Multica's existing per-task isolation unchanged and handles the constraint at the Hermes backend boundary:

- create a random private `/tmp/multica-hermes-*` directory for the Hermes child on Unix
- replace `TMPDIR`, `TMP`, and `TEMP` only in that child environment
- remove the directory after the Hermes process exits, including launch-failure cleanup

The resulting `hermes_rpc_<uuid>.sock` path stays below the Unix `sun_path` limit without changing other providers' temp behavior.

## Related Issue

Closes #5112

Alternative implementation to #5116, which currently changes the daemon-wide task temp location and is conflicting with `main`.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Refactor / code improvement (no behavior change)
- [ ] Documentation update
- [x] Tests (adding or improving test coverage)
- [ ] CI / infrastructure

## Changes Made

- `server/pkg/agent/hermes.go`: give the Hermes child a short private temp directory on Unix and clean it up after `cmd.Wait` or a failed start.
- `server/pkg/agent/hermes_test.go`: add an ACP regression fixture that starts with an overlong task temp path and verifies the child receives a socket-safe path that is cleaned up.

## How to Test

1. Reproduce the pre-fix failure with the new regression test: it reports `TMPDIR was not shortened` because the derived socket path exceeds 107 bytes.
2. Run the regression repeatedly:
   `go test ./pkg/agent -run '^TestHermesBackendUsesShortPrivateTempDir$' -count=10`
3. Run the affected packages and vet:
   `go test ./pkg/agent -count=1`
   `go test ./internal/daemon -count=1`
   `go vet ./pkg/agent`

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [ ] I have updated relevant documentation to reflect my changes
- [ ] If I added a new runtime / coding tool / UI tab, I synced the change to **landing copy** (`apps/web/features/landing/i18n/`) and **relevant docs** (`apps/docs/content/docs/`)
- [ ] If this PR touches Chinese product copy, I checked it against `apps/docs/content/docs/developers/conventions.zh.mdx` (terminology, mixed-rule for `task` / `issue` / `skill`)
- [x] I have considered and documented any risks above
- [x] I will address all reviewer comments before requesting merge

## AI Disclosure

**AI tool used:** OpenAI Codex

**Prompt / approach:**
Traced the daemon-provided temp environment into Hermes' `tempfile.gettempdir()`-derived AF_UNIX socket path, reproduced the overflow with a failing ACP backend test, then implemented the smallest provider-scoped fix and verified cleanup and package-level behavior.

## Screenshots (optional)

N/A
