### PR TITLE
WS-1673: bound background daemon logs

### DIFF
--- a/docs/plans/2026-07-09-daemon-log-rotation-design.md
+++ b/docs/plans/2026-07-09-daemon-log-rotation-design.md
@@ -1,0 +1,32 @@
+# Daemon Log Rotation Design
+
+## Context
+
+The default Multica daemon log reached 188 MiB and two named-profile logs reached 94 MiB and 9.6 MiB. Background daemons inherit stdout and stderr as append-only file descriptors, so renaming the active file alone would not reclaim space: the daemon would continue writing to the renamed inode.
+
+## Options considered
+
+1. Rotate only at daemon startup. This is simple and lossless, but a long-running daemon can still grow without bound between restarts.
+2. Replace every daemon logger and stderr writer with a third-party rolling writer. This gives precise rotation but is invasive and does not automatically cover panic or direct stderr output.
+3. Periodically copy the active log to numbered backups and truncate the original inode. This preserves the file descriptor used by stdout and stderr, works across default and named profiles, and bounds growth without changing daemon logging call sites.
+
+Option 3 is selected. It is the smallest change that addresses the actual append-only descriptor behavior.
+
+## Design
+
+- The background parent passes the resolved log path to the foreground daemon through `MULTICA_DAEMON_LOG_PATH`.
+- The foreground daemon performs one rotation check before starting work, then checks periodically while running.
+- When the active log exceeds 25 MiB, the daemon copies it to `daemon.log.1`, shifts the previous archive to `daemon.log.2`, and truncates the active file in place.
+- Rotation failures are warnings and never prevent the daemon from running.
+- Manual foreground runs do not rotate because they have no background log path environment variable.
+
+## Correctness and failure handling
+
+- The archive copy is written to a temporary file and synced before backup names change.
+- The active log is truncated only after the archive has been installed, so a pre-truncate failure preserves the source log.
+- In-place truncation keeps inherited append-only file descriptors valid.
+- Tests cover below-threshold no-op behavior, archive shifting, content preservation, and active-file truncation.
+
+## Operational companion
+
+The CPA capture job is a separate growth source. Its existing disk watermark disables raw-log storage only below 10 GiB, while the system alert threshold is 15 GiB. The cutoff will be aligned to 15 GiB with a regression test so raw capture stops before the host reaches the critical alert boundary.

--- a/docs/plans/2026-07-09-daemon-log-rotation-design.md
+++ b/docs/plans/2026-07-09-daemon-log-rotation-design.md
@@ -16,7 +16,7 @@ Option 3 is selected. It is the smallest change that addresses the actual append
 
 - The background parent passes the resolved log path to the foreground daemon through `MULTICA_DAEMON_LOG_PATH`.
 - The foreground daemon performs one rotation check before starting work, then checks periodically while running.
-- When the active log exceeds 25 MiB, the daemon copies it to `daemon.log.1`, shifts the previous archive to `daemon.log.2`, and truncates the active file in place.
+- When the active log exceeds 25 MiB, the daemon copies only its most recent 25 MiB to `daemon.log.1`, shifts the previous archive to `daemon.log.2`, and truncates the active file in place. Bounding the temporary copy and every numbered archive avoids needing free space proportional to an already-oversized source log.
 - Rotation failures are warnings and never prevent the daemon from running.
 - Manual foreground runs do not rotate because they have no background log path environment variable.
 
@@ -24,8 +24,9 @@ Option 3 is selected. It is the smallest change that addresses the actual append
 
 - The archive copy is written to a temporary file and synced before backup names change.
 - The active log is truncated only after the archive has been installed, so a pre-truncate failure preserves the source log.
-- In-place truncation keeps inherited append-only file descriptors valid.
-- Tests cover below-threshold no-op behavior, archive shifting, content preservation, and active-file truncation.
+- The rotator truncates the source through its opened descriptor rather than resolving the pathname again. This keeps inherited append-only file descriptors on the same active inode even if the path changes concurrently.
+- Copy-truncate has an accepted small race window: bytes appended after the source size snapshot are outside the bounded archive and may be removed by truncation. Daemon logs are best-effort operational output, and preserving the inherited inode without introducing a process-wide logging rewrite is the chosen tradeoff.
+- Tests cover below-threshold no-op behavior, bounded-tail archive shifting, and appending through a descriptor held open across in-place truncation.
 
 ## Operational companion
 

--- a/docs/superpowers/plans/2026-07-09-daemon-log-rotation.md
+++ b/docs/superpowers/plans/2026-07-09-daemon-log-rotation.md
@@ -1,0 +1,65 @@
+# Daemon Log Rotation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Bound background Multica daemon logs and stop CPA raw-log capture before disk free space falls below 15 GiB.
+
+**Architecture:** Add a small copy-truncate rotator at the CLI daemon lifecycle boundary. Pass the profile-specific log path to background children, run an initial check, and keep checking on a ticker. Separately align the existing CPA disk watermark with the host critical threshold.
+
+**Tech Stack:** Go standard library, Go tests, Python unittest, launchd plist configuration.
+
+---
+
+### Task 1: Specify daemon log rotation behavior
+
+**Files:**
+- Modify: `server/cmd/multica/cmd_daemon_test.go`
+- Test: `server/cmd/multica/cmd_daemon_test.go`
+
+- [ ] **Step 1: Write failing tests** for a below-limit no-op and an over-limit copy-truncate rotation that keeps two numbered backups.
+- [ ] **Step 2: Run the focused tests** with `go test ./cmd/multica -run 'TestRotateDaemonLog' -count=1` and confirm they fail because the helper does not exist.
+
+### Task 2: Implement and wire daemon log rotation
+
+**Files:**
+- Modify: `server/cmd/multica/cmd_daemon.go`
+- Modify: `server/cmd/multica/cmd_daemon_test.go`
+
+- [ ] **Step 1: Implement the minimal helper** using a temporary archive, `io.Copy`, `Sync`, numbered backup shifting, and in-place truncation.
+- [ ] **Step 2: Pass the profile log path** to every spawned background/restart child with `MULTICA_DAEMON_LOG_PATH`.
+- [ ] **Step 3: Run an initial rotation check and ticker** only when that environment variable is present.
+- [ ] **Step 4: Run focused tests** and confirm they pass.
+- [ ] **Step 5: Run `gofmt` and `git diff --check`.**
+
+### Task 3: Align CPA capture with the critical disk threshold
+
+**Files:**
+- Modify: `/Users/tangyuanjc/.openclaw/cpa-capture/test_puller.py`
+- Modify: `/Users/tangyuanjc/.openclaw/cpa-capture/puller.py`
+
+- [ ] **Step 1: Add a failing assertion** that the default critical watermark is 15 GiB.
+- [ ] **Step 2: Run the focused unittest** and confirm it fails against the current 10 GiB value.
+- [ ] **Step 3: Change only the default critical watermark** to 15 GiB.
+- [ ] **Step 4: Re-run the focused and full CPA test suites.**
+
+### Task 4: Reclaim disk safely and verify
+
+**Files:**
+- Runtime cache/log data only; no source file creation.
+
+- [ ] **Step 1: Record pre-cleanup sizes and free space.**
+- [ ] **Step 2: Remove reproducible caches** while preserving Chrome data, CloudKit user state, Pictures, GBrain model/runtime data, Claude VM bundles, active Hermes runtime files, and Multica workspace ledgers.
+- [ ] **Step 3: Preserve recent daemon log tails and truncate active logs in place.**
+- [ ] **Step 4: Re-run disk census and verify free space exceeds 30 GiB.**
+- [ ] **Step 5: Kick the daemon-health launchd job and verify the disk check is loaded and reports the post-cleanup state.
+
+### Task 5: Handoff
+
+**Files:**
+- Commit the Multica repo changes on the task branch.
+- Commit only the CPA files touched, preserving unrelated dirty files.
+
+- [ ] **Step 1: Run final focused verification.**
+- [ ] **Step 2: Open a PR whose title/body contains `WS-1673`.**
+- [ ] **Step 3: Create the required Allen follow-up issue.**
+- [ ] **Step 4: Post exactly one concise final comment on WS-1673 and move it to `in_review`.**

--- a/docs/superpowers/plans/2026-07-09-daemon-log-rotation.md
+++ b/docs/superpowers/plans/2026-07-09-daemon-log-rotation.md
@@ -51,7 +51,7 @@
 - [ ] **Step 2: Remove reproducible caches** while preserving Chrome data, CloudKit user state, Pictures, GBrain model/runtime data, Claude VM bundles, active Hermes runtime files, and Multica workspace ledgers.
 - [ ] **Step 3: Preserve recent daemon log tails and truncate active logs in place.**
 - [ ] **Step 4: Re-run disk census and verify free space exceeds 30 GiB.**
-- [ ] **Step 5: Kick the daemon-health launchd job and verify the disk check is loaded and reports the post-cleanup state.
+- [ ] **Step 5: Kick the daemon-health launchd job and verify the disk check is loaded and reports the post-cleanup state.**
 
 ### Task 5: Handoff
 

--- a/docs/superpowers/plans/2026-07-09-daemon-log-rotation.md
+++ b/docs/superpowers/plans/2026-07-09-daemon-log-rotation.md
@@ -16,7 +16,7 @@
 - Modify: `server/cmd/multica/cmd_daemon_test.go`
 - Test: `server/cmd/multica/cmd_daemon_test.go`
 
-- [ ] **Step 1: Write failing tests** for a below-limit no-op and an over-limit copy-truncate rotation that keeps two numbered backups.
+- [ ] **Step 1: Write failing tests** for a below-limit no-op and an over-limit copy-truncate rotation that keeps a bounded tail in two numbered backups.
 - [ ] **Step 2: Run the focused tests** with `go test ./cmd/multica -run 'TestRotateDaemonLog' -count=1` and confirm they fail because the helper does not exist.
 
 ### Task 2: Implement and wire daemon log rotation
@@ -25,7 +25,7 @@
 - Modify: `server/cmd/multica/cmd_daemon.go`
 - Modify: `server/cmd/multica/cmd_daemon_test.go`
 
-- [ ] **Step 1: Implement the minimal helper** using a temporary archive, `io.Copy`, `Sync`, numbered backup shifting, and in-place truncation.
+- [ ] **Step 1: Implement the minimal helper** using a bounded tail copy, `Sync`, numbered backup shifting, and truncation through the opened source descriptor. Document the accepted copy-truncate concurrent-write loss window.
 - [ ] **Step 2: Pass the profile log path** to every spawned background/restart child with `MULTICA_DAEMON_LOG_PATH`.
 - [ ] **Step 3: Run an initial rotation check and ticker** only when that environment variable is present.
 - [ ] **Step 4: Run focused tests** and confirm they pass.

--- a/server/cmd/multica/cmd_daemon.go
+++ b/server/cmd/multica/cmd_daemon.go
@@ -149,31 +149,40 @@ const (
 	daemonLogPathEnv       = "MULTICA_DAEMON_LOG_PATH"
 )
 
-// rotateDaemonLogIfNeeded archives an oversized daemon log and truncates the
-// active file in place. In-place truncation is intentional: background daemon
-// stdout/stderr hold append-only descriptors for the active inode, so renaming
-// the file alone would let the process keep writing to an unbounded archive.
+// rotateDaemonLogIfNeeded archives the bounded tail of an oversized daemon log
+// and truncates the active file in place. In-place truncation is intentional:
+// background daemon stdout/stderr hold append-only descriptors for the active
+// inode, so renaming the file alone would let the process keep writing to an
+// unbounded archive.
+//
+// Copy-truncate has a small accepted loss window: bytes appended after the
+// source size is captured are not included in the archive and may be removed by
+// the subsequent truncation. Keeping the existing inode is more important here
+// because daemon output is best-effort operational logging.
 func rotateDaemonLogIfNeeded(logPath string, maxBytes int64, backupCount int) (bool, error) {
 	if logPath == "" || maxBytes <= 0 || backupCount < 1 {
 		return false, nil
 	}
 
-	info, err := os.Stat(logPath)
+	source, err := os.OpenFile(logPath, os.O_RDWR, 0)
 	if errors.Is(err, os.ErrNotExist) {
 		return false, nil
 	}
+	if err != nil {
+		return false, fmt.Errorf("open daemon log for rotation: %w", err)
+	}
+	defer source.Close()
+
+	info, err := source.Stat()
 	if err != nil {
 		return false, fmt.Errorf("stat daemon log: %w", err)
 	}
 	if info.Size() <= maxBytes {
 		return false, nil
 	}
-
-	source, err := os.Open(logPath)
-	if err != nil {
-		return false, fmt.Errorf("open daemon log for rotation: %w", err)
+	if _, err := source.Seek(info.Size()-maxBytes, io.SeekStart); err != nil {
+		return false, fmt.Errorf("seek daemon log tail: %w", err)
 	}
-	defer source.Close()
 
 	temp, err := os.CreateTemp(filepath.Dir(logPath), ".daemon-log-rotate-*")
 	if err != nil {
@@ -188,8 +197,8 @@ func rotateDaemonLogIfNeeded(logPath string, maxBytes int64, backupCount int) (b
 	if err := temp.Chmod(info.Mode().Perm()); err != nil {
 		return false, fmt.Errorf("set daemon log archive mode: %w", err)
 	}
-	if _, err := io.Copy(temp, source); err != nil {
-		return false, fmt.Errorf("copy daemon log archive: %w", err)
+	if _, err := io.CopyN(temp, source, maxBytes); err != nil {
+		return false, fmt.Errorf("copy daemon log tail: %w", err)
 	}
 	if err := temp.Sync(); err != nil {
 		return false, fmt.Errorf("sync daemon log archive: %w", err)
@@ -214,7 +223,7 @@ func rotateDaemonLogIfNeeded(logPath string, maxBytes int64, backupCount int) (b
 	}
 	tempPath = ""
 
-	if err := os.Truncate(logPath, 0); err != nil {
+	if err := source.Truncate(0); err != nil {
 		return false, fmt.Errorf("truncate active daemon log: %w", err)
 	}
 	return true, nil

--- a/server/cmd/multica/cmd_daemon.go
+++ b/server/cmd/multica/cmd_daemon.go
@@ -142,6 +142,97 @@ func daemonLogPathForProfile(profile string) string {
 	return filepath.Join(daemonDirForProfile(profile), "daemon.log")
 }
 
+const (
+	daemonLogMaxBytes      = 25 * 1024 * 1024
+	daemonLogBackupCount   = 2
+	daemonLogCheckInterval = time.Minute
+	daemonLogPathEnv       = "MULTICA_DAEMON_LOG_PATH"
+)
+
+// rotateDaemonLogIfNeeded archives an oversized daemon log and truncates the
+// active file in place. In-place truncation is intentional: background daemon
+// stdout/stderr hold append-only descriptors for the active inode, so renaming
+// the file alone would let the process keep writing to an unbounded archive.
+func rotateDaemonLogIfNeeded(logPath string, maxBytes int64, backupCount int) (bool, error) {
+	if logPath == "" || maxBytes <= 0 || backupCount < 1 {
+		return false, nil
+	}
+
+	info, err := os.Stat(logPath)
+	if errors.Is(err, os.ErrNotExist) {
+		return false, nil
+	}
+	if err != nil {
+		return false, fmt.Errorf("stat daemon log: %w", err)
+	}
+	if info.Size() <= maxBytes {
+		return false, nil
+	}
+
+	source, err := os.Open(logPath)
+	if err != nil {
+		return false, fmt.Errorf("open daemon log for rotation: %w", err)
+	}
+	defer source.Close()
+
+	temp, err := os.CreateTemp(filepath.Dir(logPath), ".daemon-log-rotate-*")
+	if err != nil {
+		return false, fmt.Errorf("create daemon log archive: %w", err)
+	}
+	tempPath := temp.Name()
+	defer func() {
+		_ = temp.Close()
+		_ = os.Remove(tempPath)
+	}()
+
+	if err := temp.Chmod(info.Mode().Perm()); err != nil {
+		return false, fmt.Errorf("set daemon log archive mode: %w", err)
+	}
+	if _, err := io.Copy(temp, source); err != nil {
+		return false, fmt.Errorf("copy daemon log archive: %w", err)
+	}
+	if err := temp.Sync(); err != nil {
+		return false, fmt.Errorf("sync daemon log archive: %w", err)
+	}
+	if err := temp.Close(); err != nil {
+		return false, fmt.Errorf("close daemon log archive: %w", err)
+	}
+
+	oldest := fmt.Sprintf("%s.%d", logPath, backupCount)
+	if err := os.Remove(oldest); err != nil && !errors.Is(err, os.ErrNotExist) {
+		return false, fmt.Errorf("remove oldest daemon log archive: %w", err)
+	}
+	for i := backupCount - 1; i >= 1; i-- {
+		from := fmt.Sprintf("%s.%d", logPath, i)
+		to := fmt.Sprintf("%s.%d", logPath, i+1)
+		if err := os.Rename(from, to); err != nil && !errors.Is(err, os.ErrNotExist) {
+			return false, fmt.Errorf("shift daemon log archive %d: %w", i, err)
+		}
+	}
+	if err := os.Rename(tempPath, logPath+".1"); err != nil {
+		return false, fmt.Errorf("install daemon log archive: %w", err)
+	}
+	tempPath = ""
+
+	if err := os.Truncate(logPath, 0); err != nil {
+		return false, fmt.Errorf("truncate active daemon log: %w", err)
+	}
+	return true, nil
+}
+
+func daemonChildEnv(logPath string) []string {
+	prefix := daemonLogPathEnv + "="
+	env := os.Environ()
+	result := make([]string, 0, len(env)+1)
+	for _, entry := range env {
+		if strings.HasPrefix(entry, prefix) {
+			continue
+		}
+		result = append(result, entry)
+	}
+	return append(result, prefix+logPath)
+}
+
 // healthPortForProfile returns the health check port for the given profile.
 // Default profile uses the standard port (19514). Named profiles get a
 // deterministic offset derived from the profile name.
@@ -206,6 +297,7 @@ func runDaemonBackground(cmd *cobra.Command) error {
 	}
 
 	child := exec.Command(exePath, args...)
+	child.Env = daemonChildEnv(logPath)
 	child.Stdout = logFile
 	child.Stderr = logFile
 	// On Windows we want to break the child out of the parent shell's Job
@@ -220,6 +312,7 @@ func runDaemonBackground(cmd *cobra.Command) error {
 			// Retry without breakaway. Reset the cmd state — exec.Cmd is
 			// not safe to Start() twice, so build a fresh one.
 			child = exec.Command(exePath, args...)
+			child.Env = daemonChildEnv(logPath)
 			child.Stdout = logFile
 			child.Stderr = logFile
 			child.SysProcAttr = daemonSysProcAttr(false)
@@ -388,7 +481,35 @@ func runDaemonForeground(cmd *cobra.Command) error {
 	ctx, stop := notifyShutdownContext(context.Background())
 	defer stop()
 
+	logPath := os.Getenv(daemonLogPathEnv)
+	if logPath != "" {
+		if rotated, err := rotateDaemonLogIfNeeded(logPath, daemonLogMaxBytes, daemonLogBackupCount); err != nil {
+			fmt.Fprintf(os.Stderr, "Warning: could not rotate daemon log: %v\n", err)
+		} else if rotated {
+			fmt.Fprintf(os.Stderr, "Rotated daemon log at %s\n", logPath)
+		}
+	}
+
 	logger := logger_pkg.NewLogger("daemon")
+	if logPath != "" {
+		go func() {
+			ticker := time.NewTicker(daemonLogCheckInterval)
+			defer ticker.Stop()
+			for {
+				select {
+				case <-ctx.Done():
+					return
+				case <-ticker.C:
+					rotated, err := rotateDaemonLogIfNeeded(logPath, daemonLogMaxBytes, daemonLogBackupCount)
+					if err != nil {
+						logger.Warn("daemon log rotation failed", "error", err)
+					} else if rotated {
+						logger.Info("daemon log rotated", "path", logPath)
+					}
+				}
+			}
+		}()
+	}
 
 	d := daemon.New(cfg, logger)
 
@@ -419,6 +540,7 @@ func runDaemonForeground(cmd *cobra.Command) error {
 			// duplicate cleanup here.
 			return fmt.Errorf("failed to open daemon log file %s for restart: %w", logPath, err)
 		}
+		child.Env = daemonChildEnv(logPath)
 		child.Stdout = logFile
 		child.Stderr = logFile
 		// Break out of the parent's Job Object on Windows; see the
@@ -431,6 +553,7 @@ func runDaemonForeground(cmd *cobra.Command) error {
 			// duplicate cleanup here.
 			if isAccessDeniedSpawnErr(err) {
 				child = exec.Command(restartBin, args...)
+				child.Env = daemonChildEnv(logPath)
 				child.Stdout = logFile
 				child.Stderr = logFile
 				child.SysProcAttr = daemonSysProcAttr(false)

--- a/server/cmd/multica/cmd_daemon_test.go
+++ b/server/cmd/multica/cmd_daemon_test.go
@@ -10,6 +10,95 @@ import (
 	"github.com/multica-ai/multica/server/internal/daemon"
 )
 
+func TestRotateDaemonLogBelowLimitIsNoop(t *testing.T) {
+	t.Parallel()
+
+	logPath := filepath.Join(t.TempDir(), "daemon.log")
+	if err := os.WriteFile(logPath, []byte("small log\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	rotated, err := rotateDaemonLogIfNeeded(logPath, 1024, 2)
+	if err != nil {
+		t.Fatalf("rotateDaemonLogIfNeeded: %v", err)
+	}
+	if rotated {
+		t.Fatal("rotateDaemonLogIfNeeded rotated a below-limit log")
+	}
+	got, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != "small log\n" {
+		t.Fatalf("active log = %q, want unchanged content", got)
+	}
+}
+
+func TestRotateDaemonLogCopiesTruncatesAndShiftsBackups(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	logPath := filepath.Join(dir, "daemon.log")
+	if err := os.WriteFile(logPath, []byte("current log content\n"), 0o640); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(logPath+".1", []byte("previous archive\n"), 0o640); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(logPath+".2", []byte("expired archive\n"), 0o640); err != nil {
+		t.Fatal(err)
+	}
+
+	rotated, err := rotateDaemonLogIfNeeded(logPath, 8, 2)
+	if err != nil {
+		t.Fatalf("rotateDaemonLogIfNeeded: %v", err)
+	}
+	if !rotated {
+		t.Fatal("rotateDaemonLogIfNeeded did not rotate an over-limit log")
+	}
+
+	active, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(active) != 0 {
+		t.Fatalf("active log length = %d, want 0 after in-place truncation", len(active))
+	}
+	archive1, err := os.ReadFile(logPath + ".1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(archive1) != "current log content\n" {
+		t.Fatalf("archive .1 = %q, want current log content", archive1)
+	}
+	archive2, err := os.ReadFile(logPath + ".2")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(archive2) != "previous archive\n" {
+		t.Fatalf("archive .2 = %q, want previous .1 content", archive2)
+	}
+}
+
+func TestDaemonChildEnvReplacesExistingLogPath(t *testing.T) {
+	t.Setenv(daemonLogPathEnv, "/tmp/old.log")
+
+	env := daemonChildEnv("/tmp/new.log")
+	prefix := daemonLogPathEnv + "="
+	count := 0
+	for _, entry := range env {
+		if strings.HasPrefix(entry, prefix) {
+			count++
+			if entry != prefix+"/tmp/new.log" {
+				t.Fatalf("daemon log env = %q, want replacement path", entry)
+			}
+		}
+	}
+	if count != 1 {
+		t.Fatalf("daemon log env count = %d, want exactly one entry", count)
+	}
+}
+
 // TestDaemonAlive locks in the liveness predicate the lifecycle commands rely
 // on: both a ready ("running") and a still-booting ("starting") daemon count as
 // alive, so `daemon start` won't double-spawn over a starting daemon and

--- a/server/cmd/multica/cmd_daemon_test.go
+++ b/server/cmd/multica/cmd_daemon_test.go
@@ -39,7 +39,7 @@ func TestRotateDaemonLogCopiesTruncatesAndShiftsBackups(t *testing.T) {
 
 	dir := t.TempDir()
 	logPath := filepath.Join(dir, "daemon.log")
-	if err := os.WriteFile(logPath, []byte("current log content\n"), 0o640); err != nil {
+	if err := os.WriteFile(logPath, []byte("0123456789abcdef"), 0o640); err != nil {
 		t.Fatal(err)
 	}
 	if err := os.WriteFile(logPath+".1", []byte("previous archive\n"), 0o640); err != nil {
@@ -68,8 +68,8 @@ func TestRotateDaemonLogCopiesTruncatesAndShiftsBackups(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if string(archive1) != "current log content\n" {
-		t.Fatalf("archive .1 = %q, want current log content", archive1)
+	if string(archive1) != "89abcdef" {
+		t.Fatalf("archive .1 = %q, want bounded tail", archive1)
 	}
 	archive2, err := os.ReadFile(logPath + ".2")
 	if err != nil {
@@ -77,6 +77,46 @@ func TestRotateDaemonLogCopiesTruncatesAndShiftsBackups(t *testing.T) {
 	}
 	if string(archive2) != "previous archive\n" {
 		t.Fatalf("archive .2 = %q, want previous .1 content", archive2)
+	}
+}
+
+func TestRotateDaemonLogKeepsOpenAppendHandleOnActiveInode(t *testing.T) {
+	t.Parallel()
+
+	logPath := filepath.Join(t.TempDir(), "daemon.log")
+	if err := os.WriteFile(logPath, []byte("before rotation"), 0o640); err != nil {
+		t.Fatal(err)
+	}
+	writer, err := os.OpenFile(logPath, os.O_WRONLY|os.O_APPEND, 0o640)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer writer.Close()
+
+	rotated, err := rotateDaemonLogIfNeeded(logPath, 6, 2)
+	if err != nil {
+		t.Fatalf("rotateDaemonLogIfNeeded: %v", err)
+	}
+	if !rotated {
+		t.Fatal("rotateDaemonLogIfNeeded did not rotate an over-limit log")
+	}
+	if _, err := writer.WriteString("after rotation\n"); err != nil {
+		t.Fatalf("append through pre-rotation descriptor: %v", err)
+	}
+
+	active, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(active) != "after rotation\n" {
+		t.Fatalf("active log = %q, want append through original descriptor", active)
+	}
+	archive, err := os.ReadFile(logPath + ".1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(archive) != "tation" {
+		t.Fatalf("archive = %q, want bounded pre-rotation tail", archive)
 	}
 }
 


### PR DESCRIPTION
## Summary

- rotate default and named-profile background daemon logs after they exceed 25 MiB, retaining two numbered archives
- archive only the most recent 25 MiB and truncate the opened source inode so existing append descriptors keep writing to the active log
- pass the resolved log path through background and restart handoffs, with startup and periodic warning-only rotation checks

## Verification

- `go test ./cmd/multica -run 'TestRotateDaemonLog' -count=1`
- clean `git archive` followed by `go test ./cmd/multica -count=1`
- `git diff --check`

Closes WS-1673
