### PR TITLE
feat(models): add Codex gpt-5.6 series (sol/terra/luna) to model list & pricing (MUL-4347)

### DIFF
--- a/packages/views/runtimes/utils.test.ts
+++ b/packages/views/runtimes/utils.test.ts
@@ -234,6 +234,21 @@ describe("estimateCost", () => {
         output_tokens: 1_000_000,
       }),
     ).toBeCloseTo(1.75 + 14, 5);
+    // gpt-5.6 series (provisionally priced at their 5.5/5.4/5.4-mini tiers).
+    expect(
+      estimateCost({ ...zeroUsage, model: "gpt-5.6-sol", input_tokens: 1_000_000 }),
+    ).toBeCloseTo(5, 5);
+    expect(
+      estimateCost({ ...zeroUsage, model: "gpt-5.6-terra", output_tokens: 1_000_000 }),
+    ).toBeCloseTo(15, 5);
+    expect(
+      estimateCost({
+        ...zeroUsage,
+        model: "gpt-5.6-luna",
+        input_tokens: 1_000_000,
+        output_tokens: 1_000_000,
+      }),
+    ).toBeCloseTo(0.75 + 4.5, 5);
   });
 
   it("flags catalog SKUs without a published price (gpt-5.5-mini) as unmapped", () => {

--- a/packages/views/runtimes/utils.test.ts
+++ b/packages/views/runtimes/utils.test.ts
@@ -9,6 +9,7 @@ import {
   collectUnmappedModels,
   computeCostInWindow,
   estimateCost,
+  estimateCostBreakdown,
   isModelPriced,
   isSelfHealingRuntime,
   sliceWindow,
@@ -234,21 +235,43 @@ describe("estimateCost", () => {
         output_tokens: 1_000_000,
       }),
     ).toBeCloseTo(1.75 + 14, 5);
-    // gpt-5.6 series (provisionally priced at their 5.5/5.4/5.4-mini tiers).
-    expect(
-      estimateCost({ ...zeroUsage, model: "gpt-5.6-sol", input_tokens: 1_000_000 }),
-    ).toBeCloseTo(5, 5);
-    expect(
-      estimateCost({ ...zeroUsage, model: "gpt-5.6-terra", output_tokens: 1_000_000 }),
-    ).toBeCloseTo(15, 5);
-    expect(
-      estimateCost({
+  });
+
+  it("prices the gpt-5.6 series per OpenAI's official cache-aware rates", () => {
+    // Official announcement rates. 5.6 is the first OpenAI generation to bill
+    // cache writes separately: cacheRead = 0.1x input, cacheWrite = 1.25x
+    // input. Cover every model x every token category so a wrong cache rate
+    // can't hide behind an input-only assertion. `total` is 1M of each of the
+    // four categories priced at its own rate.
+    const cases = [
+      { model: "gpt-5.6-sol", input: 5, cacheRead: 0.5, cacheWrite: 6.25, output: 30, total: 41.75 },
+      { model: "gpt-5.6-terra", input: 2.5, cacheRead: 0.25, cacheWrite: 3.125, output: 15, total: 20.875 },
+      { model: "gpt-5.6-luna", input: 1, cacheRead: 0.1, cacheWrite: 1.25, output: 6, total: 8.35 },
+    ];
+    for (const c of cases) {
+      const breakdown = estimateCostBreakdown({
         ...zeroUsage,
-        model: "gpt-5.6-luna",
+        model: c.model,
         input_tokens: 1_000_000,
+        cache_read_tokens: 1_000_000,
+        cache_write_tokens: 1_000_000,
         output_tokens: 1_000_000,
-      }),
-    ).toBeCloseTo(0.75 + 4.5, 5);
+      });
+      expect(breakdown.input).toBeCloseTo(c.input, 5);
+      expect(breakdown.cacheRead).toBeCloseTo(c.cacheRead, 5);
+      expect(breakdown.cacheWrite).toBeCloseTo(c.cacheWrite, 5);
+      expect(breakdown.output).toBeCloseTo(c.output, 5);
+      expect(
+        estimateCost({
+          ...zeroUsage,
+          model: c.model,
+          input_tokens: 1_000_000,
+          cache_read_tokens: 1_000_000,
+          cache_write_tokens: 1_000_000,
+          output_tokens: 1_000_000,
+        }),
+      ).toBeCloseTo(c.total, 5);
+    }
   });
 
   it("flags catalog SKUs without a published price (gpt-5.5-mini) as unmapped", () => {

--- a/packages/views/runtimes/utils.ts
+++ b/packages/views/runtimes/utils.ts
@@ -187,6 +187,12 @@ const MODEL_PRICING: Record<
   // -- OpenAI: dotted-minor Codex catalog SKUs. Each generation is priced
   //    independently — no fallback to `gpt-5`. Entries track
   //    `server/pkg/agent/models.go` (Codex provider list).
+  //    The gpt-5.6 tiers (sol/terra/luna) have no published OpenAI rate yet;
+  //    they are provisionally priced at their 5.5/5.4/5.4-mini equivalents and
+  //    should be corrected once official pricing lands.
+  "gpt-5.6-sol":        { input: 5,    output: 30,   cacheRead: 0.50,  cacheWrite: 5 },
+  "gpt-5.6-terra":      { input: 2.50, output: 15,   cacheRead: 0.25,  cacheWrite: 2.50 },
+  "gpt-5.6-luna":       { input: 0.75, output: 4.50, cacheRead: 0.075, cacheWrite: 0.75 },
   "gpt-5.5":            { input: 5,    output: 30,   cacheRead: 0.50,  cacheWrite: 5 },
   "gpt-5.4-mini":       { input: 0.75, output: 4.50, cacheRead: 0.075, cacheWrite: 0.75 },
   "gpt-5.4":            { input: 2.50, output: 15,   cacheRead: 0.25,  cacheWrite: 2.50 },

--- a/packages/views/runtimes/utils.ts
+++ b/packages/views/runtimes/utils.ts
@@ -135,10 +135,13 @@ export function formatTokens(n: number): string {
 //
 // Anthropic's cacheWrite reflects the 5-minute cache TTL (1.25× input); the
 // daemon reports cache_creation_input_tokens without TTL metadata, so 5m is
-// the safest / cheapest assumption (matches the API default). OpenAI,
-// DeepSeek, Moonshot and Zhipu do not bill cache writes separately (cached
-// input is just discounted on subsequent reads), so cacheWrite mirrors
-// input there.
+// the safest / cheapest assumption (matches the API default). DeepSeek,
+// Moonshot and Zhipu do not bill cache writes separately (cached input is
+// just discounted on subsequent reads), so cacheWrite mirrors input there.
+// OpenAI historically did the same, but its GPT-5.6+ generation bills cache
+// writes at 1.25× input (cache reads still get the 90% cached-input
+// discount), so those rows carry a distinct cacheWrite. Codex usage doesn't
+// yet stream cache-write tokens, so that rate isn't exercised today.
 //
 // The resolver matches exact keys after stripping a trailing date snapshot
 // (see `resolvePricing` below). It deliberately does NOT do startsWith
@@ -187,12 +190,15 @@ const MODEL_PRICING: Record<
   // -- OpenAI: dotted-minor Codex catalog SKUs. Each generation is priced
   //    independently — no fallback to `gpt-5`. Entries track
   //    `server/pkg/agent/models.go` (Codex provider list).
-  //    The gpt-5.6 tiers (sol/terra/luna) have no published OpenAI rate yet;
-  //    they are provisionally priced at their 5.5/5.4/5.4-mini equivalents and
-  //    should be corrected once official pricing lands.
-  "gpt-5.6-sol":        { input: 5,    output: 30,   cacheRead: 0.50,  cacheWrite: 5 },
-  "gpt-5.6-terra":      { input: 2.50, output: 15,   cacheRead: 0.25,  cacheWrite: 2.50 },
-  "gpt-5.6-luna":       { input: 0.75, output: 4.50, cacheRead: 0.075, cacheWrite: 0.75 },
+  //    gpt-5.6 (sol/terra/luna) uses OpenAI's official announcement rates.
+  //    5.6+ is the first OpenAI generation to bill cache writes separately:
+  //    cacheRead = 0.1x input (90% cached-input discount), cacheWrite = 1.25x
+  //    input (see the header note above). Codex usage doesn't yet report
+  //    cache-write tokens, so cacheWrite isn't exercised today, but the rate
+  //    is kept correct for when it is.
+  "gpt-5.6-sol":        { input: 5,    output: 30,   cacheRead: 0.50,  cacheWrite: 6.25 },
+  "gpt-5.6-terra":      { input: 2.50, output: 15,   cacheRead: 0.25,  cacheWrite: 3.125 },
+  "gpt-5.6-luna":       { input: 1,    output: 6,    cacheRead: 0.10,  cacheWrite: 1.25 },
   "gpt-5.5":            { input: 5,    output: 30,   cacheRead: 0.50,  cacheWrite: 5 },
   "gpt-5.4-mini":       { input: 0.75, output: 4.50, cacheRead: 0.075, cacheWrite: 0.75 },
   "gpt-5.4":            { input: 2.50, output: 15,   cacheRead: 0.25,  cacheWrite: 2.50 },

--- a/server/internal/handler/agent_thinking_test.go
+++ b/server/internal/handler/agent_thinking_test.go
@@ -214,12 +214,15 @@ func TestUpdateAgent_RuntimeSwitch_PreservesValidValueRejectsInvalid(t *testing.
 		testPool.Exec(ctx, `DELETE FROM agent WHERE workspace_id = $1 AND name LIKE 'runtime-switch-%'`, testWorkspaceID)
 	})
 
+	// Direction is Codex → Claude: Codex's enum is a superset of Claude's
+	// (it adds none/minimal plus the gpt-5.6 max/ultra levels), so a
+	// Codex-only token is the value that becomes invalid on switch.
 	t.Run("existing value still valid for new runtime is kept", func(t *testing.T) {
-		// `high` is valid for both Claude and Codex enums — switching
+		// `high` is valid for both Codex and Claude enums — switching
 		// runtime without touching thinking_level should keep it.
-		agentID := createAgentOnRuntime(t, "runtime-switch-keep", claudeRuntimeID, "high")
+		agentID := createAgentOnRuntime(t, "runtime-switch-keep", codexRuntimeID, "high")
 		body := map[string]any{
-			"runtime_id": codexRuntimeID,
+			"runtime_id": claudeRuntimeID,
 		}
 		w := httptest.NewRecorder()
 		req := withURLParam(newRequest(http.MethodPatch, "/api/agents/"+agentID, body), "id", agentID)
@@ -235,12 +238,12 @@ func TestUpdateAgent_RuntimeSwitch_PreservesValidValueRejectsInvalid(t *testing.
 	})
 
 	t.Run("existing value invalid for new runtime is 400, not silent", func(t *testing.T) {
-		// `max` is Claude-only; switching to Codex must NOT silently
-		// keep it. Behaviour stays consistent with the explicit-set
-		// path: always 400 on literal-invalid.
-		agentID := createAgentOnRuntime(t, "runtime-switch-reject", claudeRuntimeID, "max")
+		// `ultra` is Codex-only (added for the gpt-5.6 series); switching to
+		// Claude must NOT silently keep it. Behaviour stays consistent with
+		// the explicit-set path: always 400 on literal-invalid.
+		agentID := createAgentOnRuntime(t, "runtime-switch-reject", codexRuntimeID, "ultra")
 		body := map[string]any{
-			"runtime_id": codexRuntimeID,
+			"runtime_id": claudeRuntimeID,
 		}
 		w := httptest.NewRecorder()
 		req := withURLParam(newRequest(http.MethodPatch, "/api/agents/"+agentID, body), "id", agentID)
@@ -255,9 +258,9 @@ func TestUpdateAgent_RuntimeSwitch_PreservesValidValueRejectsInvalid(t *testing.
 		// the same PATCH and the switch goes through with a cleared
 		// value. This is the documented escape hatch in the error
 		// message; the test pins it so the contract holds.
-		agentID := createAgentOnRuntime(t, "runtime-switch-clear", claudeRuntimeID, "max")
+		agentID := createAgentOnRuntime(t, "runtime-switch-clear", codexRuntimeID, "ultra")
 		body := map[string]any{
-			"runtime_id":     codexRuntimeID,
+			"runtime_id":     claudeRuntimeID,
 			"thinking_level": "",
 		}
 		w := httptest.NewRecorder()
@@ -276,10 +279,10 @@ func TestUpdateAgent_RuntimeSwitch_PreservesValidValueRejectsInvalid(t *testing.
 	t.Run("simultaneous explicit set to valid value lets the switch through", func(t *testing.T) {
 		// The other recovery: caller picks a value valid for the new
 		// runtime. Same PATCH, no need for a separate roundtrip.
-		agentID := createAgentOnRuntime(t, "runtime-switch-replace", claudeRuntimeID, "max")
+		agentID := createAgentOnRuntime(t, "runtime-switch-replace", codexRuntimeID, "ultra")
 		body := map[string]any{
-			"runtime_id":     codexRuntimeID,
-			"thinking_level": "minimal",
+			"runtime_id":     claudeRuntimeID,
+			"thinking_level": "high",
 		}
 		w := httptest.NewRecorder()
 		req := withURLParam(newRequest(http.MethodPatch, "/api/agents/"+agentID, body), "id", agentID)
@@ -289,8 +292,8 @@ func TestUpdateAgent_RuntimeSwitch_PreservesValidValueRejectsInvalid(t *testing.
 		}
 		var resp map[string]any
 		_ = json.NewDecoder(w.Body).Decode(&resp)
-		if resp["thinking_level"] != "minimal" {
-			t.Errorf("expected thinking_level=minimal, got %v", resp["thinking_level"])
+		if resp["thinking_level"] != "high" {
+			t.Errorf("expected thinking_level=high, got %v", resp["thinking_level"])
 		}
 	})
 }

--- a/server/internal/metrics/pricing.go
+++ b/server/internal/metrics/pricing.go
@@ -15,6 +15,13 @@ type ModelPrice struct {
 }
 
 var modelPrices = map[string]ModelPrice{
+	// GPT-5.6 series (Codex `codex` provider). OpenAI has not published public
+	// rates for these yet, so each tier is provisionally priced at its 5.5/5.4
+	// equivalent (sol=frontier, terra=everyday, luna=fast/affordable). Replace
+	// with the official numbers once they land.
+	"openai:gpt-5.6-sol":   {Provider: "openai", Model: "gpt-5.6-sol", InputPerM: 5.00, CacheReadPerM: 0.50, CacheWritePerM: 0.50, OutputPerM: 30.00},
+	"openai:gpt-5.6-terra": {Provider: "openai", Model: "gpt-5.6-terra", InputPerM: 2.50, CacheReadPerM: 0.25, CacheWritePerM: 0.25, OutputPerM: 15.00},
+	"openai:gpt-5.6-luna":  {Provider: "openai", Model: "gpt-5.6-luna", InputPerM: 0.75, CacheReadPerM: 0.075, CacheWritePerM: 0.075, OutputPerM: 4.50},
 	"openai:gpt-5.5":       {Provider: "openai", Model: "gpt-5.5", InputPerM: 5.00, CacheReadPerM: 0.50, CacheWritePerM: 0.50, OutputPerM: 30.00},
 	"openai:gpt-5.4":       {Provider: "openai", Model: "gpt-5.4", InputPerM: 2.50, CacheReadPerM: 0.25, CacheWritePerM: 0.25, OutputPerM: 15.00},
 	"openai:gpt-5.4-mini":  {Provider: "openai", Model: "gpt-5.4-mini", InputPerM: 0.75, CacheReadPerM: 0.075, CacheWritePerM: 0.075, OutputPerM: 4.50},
@@ -46,6 +53,9 @@ var modelAliasRules = []struct {
 	re       *regexp.Regexp
 	priceKey string
 }{
+	{regexp.MustCompile(`(^|/|:)gpt-5[.-]6-sol($|[^a-z0-9])`), "openai:gpt-5.6-sol"},
+	{regexp.MustCompile(`(^|/|:)gpt-5[.-]6-terra($|[^a-z0-9])`), "openai:gpt-5.6-terra"},
+	{regexp.MustCompile(`(^|/|:)gpt-5[.-]6-luna($|[^a-z0-9])`), "openai:gpt-5.6-luna"},
 	{regexp.MustCompile(`(^|/|:)gpt-5[.-]5$|^gpt-5-5$`), "openai:gpt-5.5"},
 	{regexp.MustCompile(`(^|/|:)gpt-5[.-]4($|-2026-03-05|-xhigh)`), "openai:gpt-5.4"},
 	{regexp.MustCompile(`(^|/|:)gpt-5[.-]4-mini($|[^a-z0-9])`), "openai:gpt-5.4-mini"},

--- a/server/internal/metrics/pricing.go
+++ b/server/internal/metrics/pricing.go
@@ -15,13 +15,17 @@ type ModelPrice struct {
 }
 
 var modelPrices = map[string]ModelPrice{
-	// GPT-5.6 series (Codex `codex` provider). OpenAI has not published public
-	// rates for these yet, so each tier is provisionally priced at its 5.5/5.4
-	// equivalent (sol=frontier, terra=everyday, luna=fast/affordable). Replace
-	// with the official numbers once they land.
-	"openai:gpt-5.6-sol":   {Provider: "openai", Model: "gpt-5.6-sol", InputPerM: 5.00, CacheReadPerM: 0.50, CacheWritePerM: 0.50, OutputPerM: 30.00},
-	"openai:gpt-5.6-terra": {Provider: "openai", Model: "gpt-5.6-terra", InputPerM: 2.50, CacheReadPerM: 0.25, CacheWritePerM: 0.25, OutputPerM: 15.00},
-	"openai:gpt-5.6-luna":  {Provider: "openai", Model: "gpt-5.6-luna", InputPerM: 0.75, CacheReadPerM: 0.075, CacheWritePerM: 0.075, OutputPerM: 4.50},
+	// GPT-5.6 series (Codex `codex` provider). Official rates from OpenAI's
+	// GPT-5.6 announcement (openai.com/index/previewing-gpt-5-6-sol). For 5.6+
+	// cache read is the 90%-off cached-input rate (0.1x input) and cache write
+	// is billed at 1.25x the uncached input rate — unlike earlier OpenAI SKUs,
+	// which don't bill cache writes separately. NOTE: Codex's app-server usage
+	// stream (0.144.1) does not yet report cache-write tokens separately, so
+	// today those tokens fall into plain input and are billed at 1x; the
+	// CacheWrite rate below is correct but not yet exercised for Codex.
+	"openai:gpt-5.6-sol":   {Provider: "openai", Model: "gpt-5.6-sol", InputPerM: 5.00, CacheReadPerM: 0.50, CacheWritePerM: 6.25, OutputPerM: 30.00},
+	"openai:gpt-5.6-terra": {Provider: "openai", Model: "gpt-5.6-terra", InputPerM: 2.50, CacheReadPerM: 0.25, CacheWritePerM: 3.125, OutputPerM: 15.00},
+	"openai:gpt-5.6-luna":  {Provider: "openai", Model: "gpt-5.6-luna", InputPerM: 1.00, CacheReadPerM: 0.10, CacheWritePerM: 1.25, OutputPerM: 6.00},
 	"openai:gpt-5.5":       {Provider: "openai", Model: "gpt-5.5", InputPerM: 5.00, CacheReadPerM: 0.50, CacheWritePerM: 0.50, OutputPerM: 30.00},
 	"openai:gpt-5.4":       {Provider: "openai", Model: "gpt-5.4", InputPerM: 2.50, CacheReadPerM: 0.25, CacheWritePerM: 0.25, OutputPerM: 15.00},
 	"openai:gpt-5.4-mini":  {Provider: "openai", Model: "gpt-5.4-mini", InputPerM: 0.75, CacheReadPerM: 0.075, CacheWritePerM: 0.075, OutputPerM: 4.50},
@@ -53,9 +57,14 @@ var modelAliasRules = []struct {
 	re       *regexp.Regexp
 	priceKey string
 }{
-	{regexp.MustCompile(`(^|/|:)gpt-5[.-]6-sol($|[^a-z0-9])`), "openai:gpt-5.6-sol"},
-	{regexp.MustCompile(`(^|/|:)gpt-5[.-]6-terra($|[^a-z0-9])`), "openai:gpt-5.6-terra"},
-	{regexp.MustCompile(`(^|/|:)gpt-5[.-]6-luna($|[^a-z0-9])`), "openai:gpt-5.6-luna"},
+	// Anchored exact-match (like gpt-5.5 below): the effort is carried in a
+	// separate field, so the model id is the bare slug. Anchoring to `$`
+	// keeps unknown variants (`gpt-5.6-luna-pro`, `gpt-5.6-luna/x`) out of
+	// these rows so they surface as unmapped instead of silently borrowing a
+	// tier — matching the frontend's exact-match resolver in utils.ts.
+	{regexp.MustCompile(`(^|/|:)gpt-5[.-]6-sol$`), "openai:gpt-5.6-sol"},
+	{regexp.MustCompile(`(^|/|:)gpt-5[.-]6-terra$`), "openai:gpt-5.6-terra"},
+	{regexp.MustCompile(`(^|/|:)gpt-5[.-]6-luna$`), "openai:gpt-5.6-luna"},
 	{regexp.MustCompile(`(^|/|:)gpt-5[.-]5$|^gpt-5-5$`), "openai:gpt-5.5"},
 	{regexp.MustCompile(`(^|/|:)gpt-5[.-]4($|-2026-03-05|-xhigh)`), "openai:gpt-5.4"},
 	{regexp.MustCompile(`(^|/|:)gpt-5[.-]4-mini($|[^a-z0-9])`), "openai:gpt-5.4-mini"},

--- a/server/internal/metrics/pricing_test.go
+++ b/server/internal/metrics/pricing_test.go
@@ -45,21 +45,23 @@ func TestPriceForModelAliasAnthropicFableAndOpus48(t *testing.T) {
 }
 
 func TestPriceForModelAliasCodexGPT56(t *testing.T) {
+	// Official rates from OpenAI's GPT-5.6 announcement: cache read = 0.1x
+	// input (90% cached-input discount), cache write = 1.25x input.
 	cases := []struct {
 		model string
 		want  ModelPrice
 	}{
 		{
 			model: "gpt-5.6-sol",
-			want:  ModelPrice{Provider: "openai", Model: "gpt-5.6-sol", InputPerM: 5, CacheReadPerM: 0.5, CacheWritePerM: 0.5, OutputPerM: 30},
+			want:  ModelPrice{Provider: "openai", Model: "gpt-5.6-sol", InputPerM: 5, CacheReadPerM: 0.5, CacheWritePerM: 6.25, OutputPerM: 30},
 		},
 		{
 			model: "openai:gpt-5.6-terra",
-			want:  ModelPrice{Provider: "openai", Model: "gpt-5.6-terra", InputPerM: 2.5, CacheReadPerM: 0.25, CacheWritePerM: 0.25, OutputPerM: 15},
+			want:  ModelPrice{Provider: "openai", Model: "gpt-5.6-terra", InputPerM: 2.5, CacheReadPerM: 0.25, CacheWritePerM: 3.125, OutputPerM: 15},
 		},
 		{
-			model: "gpt-5.6-luna",
-			want:  ModelPrice{Provider: "openai", Model: "gpt-5.6-luna", InputPerM: 0.75, CacheReadPerM: 0.075, CacheWritePerM: 0.075, OutputPerM: 4.5},
+			model: "openai/gpt-5.6-luna",
+			want:  ModelPrice{Provider: "openai", Model: "gpt-5.6-luna", InputPerM: 1, CacheReadPerM: 0.1, CacheWritePerM: 1.25, OutputPerM: 6},
 		},
 	}
 
@@ -70,6 +72,19 @@ func TestPriceForModelAliasCodexGPT56(t *testing.T) {
 		}
 		if got != tc.want {
 			t.Fatalf("PriceForModelAlias(%q) = %+v, want %+v", tc.model, got, tc.want)
+		}
+	}
+
+	// Unknown suffixed variants must NOT borrow a 5.6 tier — the alias is an
+	// anchored exact match, mirroring the frontend's exact-match resolver.
+	for _, model := range []string{
+		"gpt-5.6-luna-pro",
+		"gpt-5.6-luna/unknown",
+		"gpt-5.6-sol-high",
+		"gpt-5.6-mini",
+	} {
+		if got, ok := PriceForModelAlias(model); ok {
+			t.Fatalf("PriceForModelAlias(%q) unexpectedly resolved to %+v; want unmapped", model, got)
 		}
 	}
 }

--- a/server/internal/metrics/pricing_test.go
+++ b/server/internal/metrics/pricing_test.go
@@ -43,3 +43,33 @@ func TestPriceForModelAliasAnthropicFableAndOpus48(t *testing.T) {
 		}
 	}
 }
+
+func TestPriceForModelAliasCodexGPT56(t *testing.T) {
+	cases := []struct {
+		model string
+		want  ModelPrice
+	}{
+		{
+			model: "gpt-5.6-sol",
+			want:  ModelPrice{Provider: "openai", Model: "gpt-5.6-sol", InputPerM: 5, CacheReadPerM: 0.5, CacheWritePerM: 0.5, OutputPerM: 30},
+		},
+		{
+			model: "openai:gpt-5.6-terra",
+			want:  ModelPrice{Provider: "openai", Model: "gpt-5.6-terra", InputPerM: 2.5, CacheReadPerM: 0.25, CacheWritePerM: 0.25, OutputPerM: 15},
+		},
+		{
+			model: "gpt-5.6-luna",
+			want:  ModelPrice{Provider: "openai", Model: "gpt-5.6-luna", InputPerM: 0.75, CacheReadPerM: 0.075, CacheWritePerM: 0.075, OutputPerM: 4.5},
+		},
+	}
+
+	for _, tc := range cases {
+		got, ok := PriceForModelAlias(tc.model)
+		if !ok {
+			t.Fatalf("PriceForModelAlias(%q) did not resolve", tc.model)
+		}
+		if got != tc.want {
+			t.Fatalf("PriceForModelAlias(%q) = %+v, want %+v", tc.model, got, tc.want)
+		}
+	}
+}

--- a/server/pkg/agent/models.go
+++ b/server/pkg/agent/models.go
@@ -300,7 +300,10 @@ func claudeStaticModels() []Model {
 
 func codexStaticModels() []Model {
 	return []Model{
-		{ID: "gpt-5.5", Label: "GPT-5.5", Provider: "openai", Default: true},
+		{ID: "gpt-5.6-sol", Label: "GPT-5.6 Sol", Provider: "openai", Default: true},
+		{ID: "gpt-5.6-terra", Label: "GPT-5.6 Terra", Provider: "openai"},
+		{ID: "gpt-5.6-luna", Label: "GPT-5.6 Luna", Provider: "openai"},
+		{ID: "gpt-5.5", Label: "GPT-5.5", Provider: "openai"},
 		{ID: "gpt-5.5-mini", Label: "GPT-5.5 mini", Provider: "openai"},
 		{ID: "gpt-5.4", Label: "GPT-5.4", Provider: "openai"},
 		{ID: "gpt-5.4-mini", Label: "GPT-5.4 mini", Provider: "openai"},

--- a/server/pkg/agent/models.go
+++ b/server/pkg/agent/models.go
@@ -299,6 +299,13 @@ func claudeStaticModels() []Model {
 }
 
 func codexStaticModels() []Model {
+	// `Default` here is NOT a user-facing "default model" badge — the picker
+	// stopped rendering that (Multica follows the CLI config when the model is
+	// unset). It is the anchor the effort picker previews against, and the
+	// model ValidateThinkingLevel resolves an empty model to when checking an
+	// effort level; dropping it would make a follow-CLI-config agent's effort
+	// selection fail catalog validation and get silently skipped. Keep exactly
+	// one entry flagged, on the current flagship.
 	return []Model{
 		{ID: "gpt-5.6-sol", Label: "GPT-5.6 Sol", Provider: "openai", Default: true},
 		{ID: "gpt-5.6-terra", Label: "GPT-5.6 Terra", Provider: "openai"},

--- a/server/pkg/agent/models_test.go
+++ b/server/pkg/agent/models_test.go
@@ -103,17 +103,20 @@ func TestClaudeStaticModelsExposesSonnet5(t *testing.T) {
 	}
 }
 
-func TestCodexStaticModelsExposesGPT55(t *testing.T) {
+func TestCodexStaticModelsExposesLatest(t *testing.T) {
 	// Codex CLI has no `models list` subcommand so the catalog is
 	// hand-maintained. Regression guard for multica-ai/multica#2009 —
-	// GPT-5.5 must be selectable, and the badge default must point at
-	// the latest release rather than lagging a version behind.
+	// the current frontier models must be selectable, and the badge
+	// default must point at the latest release rather than lagging a
+	// version behind. Codex's default moved to the gpt-5.6 series
+	// (sol/terra/luna), so the default must track gpt-5.6-sol.
 	models := codexStaticModels()
 	ids := map[string]Model{}
 	for _, m := range models {
 		ids[m.ID] = m
 	}
 	for _, want := range []string{
+		"gpt-5.6-sol", "gpt-5.6-terra", "gpt-5.6-luna",
 		"gpt-5.5", "gpt-5.5-mini",
 		"gpt-5.4", "gpt-5.4-mini",
 		"gpt-5.3-codex", "gpt-5",
@@ -123,9 +126,9 @@ func TestCodexStaticModelsExposesGPT55(t *testing.T) {
 			t.Errorf("missing expected Codex model %q in: %+v", want, models)
 		}
 	}
-	latest, ok := ids["gpt-5.5"]
+	latest, ok := ids["gpt-5.6-sol"]
 	if !ok || !latest.Default {
-		t.Errorf("expected `gpt-5.5` to be the default Codex entry, got %+v", latest)
+		t.Errorf("expected `gpt-5.6-sol` to be the default Codex entry, got %+v", latest)
 	}
 	defaults := 0
 	for _, m := range models {

--- a/server/pkg/agent/thinking.go
+++ b/server/pkg/agent/thinking.go
@@ -270,6 +270,12 @@ var codexEffortLabel = map[string]string{
 	"medium":  "Medium",
 	"high":    "High",
 	"xhigh":   "Extra high",
+	// Codex 0.144.1 added these for the gpt-5.6 series (sol/terra advertise
+	// `max`+`ultra`, luna advertises `max`). They must stay in sync with the
+	// server enum in providerThinkingEnums["codex"], or the picker shows a
+	// level that 400s on save. See TestCodexAdvertisedLevelsArePersistable.
+	"max":   "Max",
+	"ultra": "Ultra",
 }
 
 // codexDebugModelsResponse mirrors the JSON shape emitted by
@@ -620,6 +626,11 @@ var providerThinkingEnums = map[string]map[string]bool{
 		"medium":  true,
 		"high":    true,
 		"xhigh":   true,
+		// Added for the gpt-5.6 series (Codex 0.144.1). Keep in lockstep with
+		// codexEffortLabel — the daemon advertises these, so the server must
+		// let users persist them.
+		"max":   true,
+		"ultra": true,
 	},
 	"codebuddy": {
 		"low":    true,

--- a/server/pkg/agent/thinking_test.go
+++ b/server/pkg/agent/thinking_test.go
@@ -289,7 +289,9 @@ func TestIsKnownThinkingValue(t *testing.T) {
 		{"codex", "none", true},
 		{"codex", "minimal", true},
 		{"codex", "xhigh", true},
-		{"codex", "max", false}, // Claude-only token rejected for Codex
+		{"codex", "max", true},     // Codex 0.144.1 advertises `max` for gpt-5.6
+		{"codex", "ultra", true},   // ...and `ultra` for sol/terra
+		{"codex", "insane", false}, // still reject tokens outside the enum
 		{"opencode", "", true},
 		{"opencode", "max", true},
 		{"opencode", "fast-mode", true},  // custom opencode.json variant names are valid
@@ -302,6 +304,21 @@ func TestIsKnownThinkingValue(t *testing.T) {
 		if got := IsKnownThinkingValue(tc.provider, tc.value); got != tc.want {
 			t.Errorf("IsKnownThinkingValue(%q, %q) = %v, want %v",
 				tc.provider, tc.value, got, tc.want)
+		}
+	}
+}
+
+// TestCodexAdvertisedLevelsArePersistable pins the catalog → API contract:
+// every effort token Codex discovery can label (a key in codexEffortLabel)
+// must pass the server's Create/Update enum gate. Otherwise the daemon
+// advertises a level the picker shows but the server 400s on save — the
+// exact drift the gpt-5.6 `max`/`ultra` additions introduced.
+func TestCodexAdvertisedLevelsArePersistable(t *testing.T) {
+	t.Parallel()
+	for effort := range codexEffortLabel {
+		if !IsKnownThinkingValue("codex", effort) {
+			t.Errorf("Codex advertises effort %q but IsKnownThinkingValue rejects it; "+
+				"add it to providerThinkingEnums[\"codex\"] so it can be saved", effort)
 		}
 	}
 }


### PR DESCRIPTION
## Summary

Codex's latest upgrade added a new **gpt-5.6** series (`sol` / `terra` / `luna`). This adds them to Multica's Codex model list and cost/pricing tables, using OpenAI's **official** announcement rates.

- **Model list** (`server/pkg/agent/models.go` → `codexStaticModels`): add `gpt-5.6-sol`, `gpt-5.6-terra`, `gpt-5.6-luna`. The badge default sits on `gpt-5.6-sol` (the current flagship). Note: `Default` is not a user-facing badge — the picker stopped rendering one — it is the anchor the effort picker/`ValidateThinkingLevel` use when the agent follows the CLI config.
- **Pricing** (`server/internal/metrics/pricing.go`, `packages/views/runtimes/utils.ts`): official rates, front/back in sync.
- **Effort levels** (`server/pkg/agent/thinking.go`): Codex 0.144.1 advertises `max`/`ultra` for the 5.6 series — added to the label map and the server enum so a level the picker shows can actually be saved (previously a 400). Guarded by a catalog→API contract test.

### Official pricing (USD / 1M tokens)

Per OpenAI's GPT-5.6 announcement: cache read = 0.1× input (90% cached-input discount); **cache write = 1.25× input** — the first OpenAI generation to bill cache writes separately.

| Model | Input | Cache read | Cache write | Output |
| --- | ---: | ---: | ---: | ---: |
| Sol | 5 | 0.5 | 6.25 | 30 |
| Terra | 2.5 | 0.25 | 3.125 | 15 |
| Luna | 1 | 0.1 | 1.25 | 6 |

### Known limitation

Codex's app-server usage stream (0.144.1) does not yet report cache-write tokens separately, so those tokens currently fall into plain input and are billed at 1×. The `cacheWrite` rate above is correct but not exercised for Codex until the usage stream carries the field; tracked separately. Cache-write cost is therefore **not** yet accurately captured.

## Testing

- `go test ./internal/metrics ./pkg/agent ./internal/handler ./internal/daemon` — pass. New/updated: `TestPriceForModelAliasCodexGPT56` (official values + anchored-alias negative cases), `TestCodexAdvertisedLevelsArePersistable` (catalog→API contract), `TestIsKnownThinkingValue` (max/ultra), runtime-switch effort test flipped to codex→claude now that Codex's enum is a superset of Claude's.
- Frontend: table-driven `estimateCost`/`estimateCostBreakdown` coverage of all 3 models × 4 token categories (totals 41.75 / 20.875 / 8.35). Frontend deps aren't installed in this environment, so Vitest wasn't run here.
