### PR TITLE
fix(lark): tolerate binding token clock skew

### DIFF
--- a/server/internal/integrations/lark/binding_token.go
+++ b/server/internal/integrations/lark/binding_token.go
@@ -104,16 +104,17 @@ func (s *BindingTokenService) Mint(ctx context.Context, workspaceID, installatio
 	hash := hashToken(raw)
 	expiresAt := s.now().Add(BindingTokenTTL)
 
-	if _, err := s.queries.CreateLarkBindingToken(ctx, CreateBindingTokenParams{
+	row, err := s.queries.CreateLarkBindingToken(ctx, CreateBindingTokenParams{
 		TokenHash:      hash,
 		WorkspaceID:    workspaceID,
 		InstallationID: installationID,
 		ChannelUserID:  string(openID),
 		ExpiresAt:      pgtype.Timestamptz{Time: expiresAt, Valid: true},
-	}); err != nil {
+	})
+	if err != nil {
 		return BindingToken{}, fmt.Errorf("persist token: %w", err)
 	}
-	return BindingToken{Raw: raw, ExpiresAt: expiresAt}, nil
+	return BindingToken{Raw: raw, ExpiresAt: row.ExpiresAt.Time}, nil
 }
 
 // RedeemAndBind atomically consumes a raw token and writes the

--- a/server/internal/integrations/lark/binding_token_test.go
+++ b/server/internal/integrations/lark/binding_token_test.go
@@ -16,7 +16,7 @@ import (
 // These tests cover the pure-Go halves of BindingTokenService — token
 // generation entropy/encoding, deterministic hashing — without
 // touching the database. DB-backed mint/redeem invariants (single use,
-// expiry) are covered by the DB CHECK on lark_binding_token plus the
+// expiry) are covered by the DB CHECK on channel_binding_token plus the
 // ConsumeLarkBindingToken query, which require an integration test
 // against a real Postgres and are added in a follow-up.
 

--- a/server/internal/integrations/lark/binding_token_test.go
+++ b/server/internal/integrations/lark/binding_token_test.go
@@ -5,8 +5,12 @@ import (
 	"errors"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/jackc/pgx/v5/pgtype"
+
+	"github.com/multica-ai/multica/server/internal/util"
+	db "github.com/multica-ai/multica/server/pkg/db/generated"
 )
 
 // These tests cover the pure-Go halves of BindingTokenService — token
@@ -97,5 +101,49 @@ func TestHashTokenDeterministic(t *testing.T) {
 	}
 	if len(a) != 64 {
 		t.Fatalf("expected sha256 hex (64 chars), got %d chars", len(a))
+	}
+}
+
+// TestBindingTokenMintClampsAppClockSkew protects the production binding-card
+// path. Application and database clocks can differ slightly; computing the
+// full 15-minute TTL from an app clock that is ahead of Postgres used to trip
+// channel_binding_token_ttl_cap, so unbound Feishu users received no card.
+func TestBindingTokenMintClampsAppClockSkew(t *testing.T) {
+	pool := channelScopeTestDB(t)
+	ctx := context.Background()
+	installationID := util.MustParseUUID("5c09e000-0000-4000-8000-000000000101")
+	workspaceID := util.MustParseUUID("5c09e000-0000-4000-8000-000000000102")
+
+	clean := func() {
+		_, _ = pool.Exec(context.Background(),
+			`DELETE FROM channel_binding_token WHERE installation_id = $1`, installationID)
+	}
+	clean()
+	t.Cleanup(clean)
+
+	service := NewBindingTokenServiceWithClock(db.New(pool), nil, func() time.Time {
+		return time.Now().Add(time.Hour)
+	})
+	token, err := service.Mint(ctx, workspaceID, installationID, OpenID("ou_clock_skew"))
+	if err != nil {
+		t.Fatalf("Mint with app clock ahead of database: %v", err)
+	}
+
+	var storedExpiresAt, createdAt time.Time
+	if err := pool.QueryRow(ctx, `
+		SELECT expires_at, created_at
+		FROM channel_binding_token
+		WHERE installation_id = $1
+	`, installationID).Scan(&storedExpiresAt, &createdAt); err != nil {
+		t.Fatalf("read minted token: %v", err)
+	}
+	if storedExpiresAt.After(createdAt.Add(BindingTokenTTL)) {
+		t.Fatalf("stored TTL exceeds cap: created=%s expires=%s", createdAt, storedExpiresAt)
+	}
+	if storedExpiresAt.Before(createdAt.Add(BindingTokenTTL - time.Second)) {
+		t.Fatalf("stored TTL was shortened unexpectedly: created=%s expires=%s", createdAt, storedExpiresAt)
+	}
+	if !token.ExpiresAt.Equal(storedExpiresAt) {
+		t.Fatalf("returned expiry %s does not match stored expiry %s", token.ExpiresAt, storedExpiresAt)
 	}
 }

--- a/server/internal/integrations/lark/types.go
+++ b/server/internal/integrations/lark/types.go
@@ -122,7 +122,7 @@ const (
 )
 
 // BindingTokenTTL caps the lifetime of a member-binding token. The DB
-// CHECK on lark_binding_token (`expires_at <= created_at + INTERVAL '15
+// CHECK on channel_binding_token (`expires_at <= created_at + INTERVAL '15
 // minutes'`) enforces the same bound at the storage layer, so a
 // misconfigured caller or a hand-inserted SQL row cannot exceed it.
 // Keep these two values in sync if the product value changes.

--- a/server/pkg/db/generated/channel.sql.go
+++ b/server/pkg/db/generated/channel.sql.go
@@ -145,7 +145,8 @@ INSERT INTO channel_binding_token (
     token_hash, workspace_id, installation_id, channel_type,
     channel_user_id, expires_at
 ) VALUES (
-    $1, $2, $3, $4, $5, $6
+    $1, $2, $3, $4, $5,
+    LEAST($6::timestamptz, now() + INTERVAL '15 minutes')
 )
 RETURNING token_hash, workspace_id, installation_id, channel_type, channel_user_id, expires_at, consumed_at, created_at
 `
@@ -164,7 +165,9 @@ type CreateChannelBindingTokenParams struct {
 // =====================
 // Mints a single-use binding token for an unbound platform user. TTL cap
 // (15 min) enforced by the table CHECK in lockstep with
-// channel.BindingTokenTTL. The HASH is stored, never the raw token.
+// channel.BindingTokenTTL. Clamp against the database clock so small clock
+// skew between an app node and Postgres cannot reject an otherwise valid
+// 15-minute token. The HASH is stored, never the raw token.
 func (q *Queries) CreateChannelBindingToken(ctx context.Context, arg CreateChannelBindingTokenParams) (ChannelBindingToken, error) {
 	row := q.db.QueryRow(ctx, createChannelBindingToken,
 		arg.TokenHash,

--- a/server/pkg/db/queries/channel.sql
+++ b/server/pkg/db/queries/channel.sql
@@ -597,12 +597,15 @@ WHERE chat_session_id = $1;
 -- name: CreateChannelBindingToken :one
 -- Mints a single-use binding token for an unbound platform user. TTL cap
 -- (15 min) enforced by the table CHECK in lockstep with
--- channel.BindingTokenTTL. The HASH is stored, never the raw token.
+-- channel.BindingTokenTTL. Clamp against the database clock so small clock
+-- skew between an app node and Postgres cannot reject an otherwise valid
+-- 15-minute token. The HASH is stored, never the raw token.
 INSERT INTO channel_binding_token (
     token_hash, workspace_id, installation_id, channel_type,
     channel_user_id, expires_at
 ) VALUES (
-    $1, $2, $3, $4, $5, $6
+    $1, $2, $3, $4, $5,
+    LEAST(sqlc.arg('expires_at')::timestamptz, now() + INTERVAL '15 minutes')
 )
 RETURNING *;
 


### PR DESCRIPTION
## Summary

- clamp binding-token expiry against the PostgreSQL clock while preserving the existing 15-minute TTL cap
- return the persisted expiry so callers receive the value actually enforced by the database
- add a DB-backed regression test where the application clock is ahead of PostgreSQL

## Background

`BindingTokenService.Mint` computes `expires_at` from the application clock, while `channel_binding_token_ttl_cap` compares it with a `created_at` value generated from the database clock. Because both sides use the exact same 15-minute boundary, even a tiny positive application clock skew can reject the insert. Unbound channel users then cannot receive a binding token.

The SQL now stores the earlier of the requested expiry and `now() + 15 minutes`. This keeps the defense-in-depth TTL invariant introduced in #3277 and carried forward by #4412 without requiring synchronized clocks.

## Testing

- `go test ./internal/integrations/lark -run TestBindingTokenMintClampsAppClockSkew -count=1`
- `go test ./internal/integrations/lark -count=1`
- `go build ./...`
- `go test ./...`
- `git diff --check`