### PR TITLE
fix(models): codex empty-model effort validation + exact 5.6 aliases (MUL-4347)

### DIFF
--- a/packages/views/agents/components/agent-detail-inspector.tsx
+++ b/packages/views/agents/components/agent-detail-inspector.tsx
@@ -142,6 +142,7 @@ export function AgentDetailInspector({
         <ThinkingPropRow
           runtimeId={agent.runtime_id}
           runtimeOnline={!!isOnline}
+          provider={runtime?.provider ?? ""}
           model={agent.model ?? ""}
           value={agent.thinking_level ?? ""}
           canEdit={canEdit}

--- a/packages/views/agents/components/inspector/thinking-prop-row.test.tsx
+++ b/packages/views/agents/components/inspector/thinking-prop-row.test.tsx
@@ -60,6 +60,25 @@ const NO_THINKING_MODEL: RuntimeModel = {
   default: true,
 };
 
+// Codex flagship: flagged Default and advertises the widest catalog
+// (up to `ultra`). For an empty (follow-config) codex model the row must NOT
+// borrow this entry's levels — that's the MUL-4347 fix.
+const CODEX_DEFAULT_MODEL: RuntimeModel = {
+  id: "gpt-5.6-sol",
+  label: "GPT-5.6 Sol",
+  default: true,
+  thinking: {
+    supported_levels: [
+      { value: "low", label: "Low" },
+      { value: "medium", label: "Medium" },
+      { value: "high", label: "High" },
+      { value: "max", label: "Max" },
+      { value: "ultra", label: "Ultra" },
+    ],
+    default_level: "high",
+  },
+};
+
 function listResult(models: RuntimeModel[]): RuntimeModelListRequest {
   return {
     id: "req-1",
@@ -90,6 +109,7 @@ function renderRow(
           <ThinkingPropRow
             runtimeId="runtime-1"
             runtimeOnline
+            provider="claude"
             model="claude-sonnet-4-6"
             value=""
             canEdit
@@ -188,6 +208,64 @@ describe("ThinkingPropRow", () => {
     await screen.findByText("Thinking");
     // Empty value means Multica omits --effort, so the local CLI's
     // config decides — chip + tooltip both read "Follow CLI config".
+    expect((await screen.findAllByText("Follow CLI config")).length).toBeGreaterThan(0);
+  });
+
+  it("hides the picker for an empty codex model — it must not borrow the Default's catalog (MUL-4347)", async () => {
+    // Empty model on codex follows config.toml, which can resolve to any
+    // installed model. Previewing gpt-5.6-sol's levels (the flagged Default,
+    // the only one with `ultra`) would offer a level the real model may not
+    // support. With no persisted value the row hides entirely.
+    mockInitiateListModels.mockResolvedValue(
+      listResult([CODEX_DEFAULT_MODEL]),
+    );
+    mockGetListModelsResult.mockResolvedValue(
+      listResult([CODEX_DEFAULT_MODEL]),
+    );
+    renderRow({ provider: "codex", model: "", value: "" });
+
+    await waitFor(() => {
+      expect(mockInitiateListModels).toHaveBeenCalled();
+    });
+    await waitFor(() => {
+      expect(screen.queryByText("Thinking")).toBeNull();
+    });
+    // Crucially, `Ultra` from the Default entry is never offered.
+    expect(screen.queryByText("Ultra")).toBeNull();
+  });
+
+  it("still surfaces a persisted level on an empty codex model so it can be cleared", async () => {
+    // The clear-stale path must survive: an already-persisted `ultra` (set
+    // before the model was cleared) renders the row so the user can drop it,
+    // even though the picker offers no per-model levels.
+    mockInitiateListModels.mockResolvedValue(
+      listResult([CODEX_DEFAULT_MODEL]),
+    );
+    mockGetListModelsResult.mockResolvedValue(
+      listResult([CODEX_DEFAULT_MODEL]),
+    );
+    const { onChange } = renderRow({
+      provider: "codex",
+      model: "",
+      value: "ultra",
+    });
+
+    await screen.findByText("Thinking");
+    expect(await screen.findByText("ultra")).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button"));
+    const clearButton = await screen.findByTitle(/Clear the override/i);
+    fireEvent.click(clearButton);
+    expect(onChange).toHaveBeenCalledWith("");
+  });
+
+  it("still previews the Default model's levels for an empty non-codex model", async () => {
+    // Non-codex providers keep the existing behavior: an empty model previews
+    // the flagged Default entry's catalog. Only codex is fenced off, because
+    // only its empty-model resolution is config-driven and unknowable here.
+    renderRow({ provider: "claude", model: "", value: "" });
+
+    await screen.findByText("Thinking");
+    // CLAUDE_MODEL (Default) advertises Low/Medium/High — the picker shows them.
     expect((await screen.findAllByText("Follow CLI config")).length).toBeGreaterThan(0);
   });
 });

--- a/packages/views/agents/components/inspector/thinking-prop-row.tsx
+++ b/packages/views/agents/components/inspector/thinking-prop-row.tsx
@@ -28,6 +28,7 @@ import { ThinkingPicker } from "./thinking-picker";
 export function ThinkingPropRow({
   runtimeId,
   runtimeOnline,
+  provider,
   model,
   value,
   canEdit,
@@ -35,6 +36,9 @@ export function ThinkingPropRow({
 }: {
   runtimeId: string | null;
   runtimeOnline: boolean;
+  /** Runtime provider type (e.g. "codex", "claude"). Used to decide whether an
+   *  empty model can safely preview a default model's effort catalog. */
+  provider: string;
   model: string;
   value: string;
   canEdit: boolean;
@@ -46,7 +50,7 @@ export function ThinkingPropRow({
   );
 
   const models = modelsQuery.data?.models ?? [];
-  const entry = pickModelEntry(models, model);
+  const entry = pickModelEntry(models, model, provider);
   const levels = entry?.thinking?.supported_levels ?? [];
   if (levels.length === 0 && !value) return null;
 
@@ -65,7 +69,16 @@ export function ThinkingPropRow({
 function pickModelEntry(
   models: RuntimeModel[],
   model: string,
+  provider: string,
 ): RuntimeModel | undefined {
   if (model) return models.find((m) => m.id === model);
+  // Empty model = "follow the runtime's own default". For codex that default
+  // comes from the local config.toml and can be any installed model, so we
+  // must NOT preview the flagged Default entry's effort catalog — gpt-5.6-sol
+  // alone advertises `ultra`, which the actually-configured model may not
+  // support. Fail closed (no preview): the row hides unless a stale level is
+  // persisted, in which case it still renders so the orphan can be cleared.
+  // Mirrors the backend ValidateThinkingLevel. (MUL-4347)
+  if (provider === "codex") return undefined;
   return models.find((m) => m.default) ?? models[0];
 }

--- a/packages/views/runtimes/utils.test.ts
+++ b/packages/views/runtimes/utils.test.ts
@@ -294,6 +294,12 @@ describe("estimateCost", () => {
     // silently inherit `gpt-5` pricing.
     expect(isModelPriced("gpt-5.99-codex")).toBe(false);
     expect(isModelPriced("gpt-5-foo")).toBe(false);
+    // Dash-normalized 5.6 ids must also miss: the real Codex slug is dotted
+    // (`gpt-5.6-luna`) and this resolver does NOT dash-normalize non-claude
+    // ids, so a dashed variant surfaces as unmapped — matching the backend's
+    // literal-dot alias in server/internal/metrics/pricing.go (MUL-4347).
+    expect(isModelPriced("gpt-5-6-luna")).toBe(false);
+    expect(isModelPriced("gpt-5-6-sol")).toBe(false);
     expect(
       estimateCost({
         ...zeroUsage,

--- a/server/internal/daemon/daemon.go
+++ b/server/internal/daemon/daemon.go
@@ -3866,11 +3866,12 @@ func (d *Daemon) runTask(ctx context.Context, task Task, provider string, slot i
 	// model, Codex's per-model `supported_reasoning_levels`) only resolve
 	// here, against the daemon's local CLI catalog. Invalid combinations
 	// log a warning and drop the level rather than failing the task, so a
-	// stale persisted value never blocks execution. Empty model is passed
-	// through unchanged — ValidateThinkingLevel resolves it to the
-	// provider's default model internally so default-model tasks aren't
-	// misjudged. Discovery errors fail open: if we can't list models, we
-	// keep the persisted level and let the CLI surface any objection.
+	// stale persisted value never blocks execution. An empty model is
+	// resolved by ValidateThinkingLevel to the provider's default model so
+	// default-model tasks aren't misjudged — except for codex, whose empty
+	// model follows config.toml (any model) and so fails closed, dropping the
+	// level here. Discovery errors fail open for resolved models: if we can't
+	// list models, we keep the persisted level and let the CLI object.
 	if thinkingLevel != "" {
 		ok, err := agent.ValidateThinkingLevel(ctx, provider, entry.Path, model, thinkingLevel)
 		if err != nil {

--- a/server/internal/metrics/pricing.go
+++ b/server/internal/metrics/pricing.go
@@ -57,14 +57,16 @@ var modelAliasRules = []struct {
 	re       *regexp.Regexp
 	priceKey string
 }{
-	// Anchored exact-match (like gpt-5.5 below): the effort is carried in a
-	// separate field, so the model id is the bare slug. Anchoring to `$`
-	// keeps unknown variants (`gpt-5.6-luna-pro`, `gpt-5.6-luna/x`) out of
-	// these rows so they surface as unmapped instead of silently borrowing a
-	// tier — matching the frontend's exact-match resolver in utils.ts.
-	{regexp.MustCompile(`(^|/|:)gpt-5[.-]6-sol$`), "openai:gpt-5.6-sol"},
-	{regexp.MustCompile(`(^|/|:)gpt-5[.-]6-terra$`), "openai:gpt-5.6-terra"},
-	{regexp.MustCompile(`(^|/|:)gpt-5[.-]6-luna$`), "openai:gpt-5.6-luna"},
+	// Anchored exact-match: the effort is carried in a separate field, so the
+	// model id is the bare slug. Anchoring to `$` keeps unknown variants
+	// (`gpt-5.6-luna-pro`, `gpt-5.6-luna/x`) out of these rows. The `.` is a
+	// LITERAL dot, not the `[.-]` class the older rows use — the real Codex
+	// slug is always dotted (`gpt-5.6-luna`), and the frontend resolver in
+	// utils.ts does NOT dash-normalize, so a dashed `gpt-5-6-luna` must surface
+	// as unmapped on both sides rather than silently borrowing a tier here.
+	{regexp.MustCompile(`(^|/|:)gpt-5\.6-sol$`), "openai:gpt-5.6-sol"},
+	{regexp.MustCompile(`(^|/|:)gpt-5\.6-terra$`), "openai:gpt-5.6-terra"},
+	{regexp.MustCompile(`(^|/|:)gpt-5\.6-luna$`), "openai:gpt-5.6-luna"},
 	{regexp.MustCompile(`(^|/|:)gpt-5[.-]5$|^gpt-5-5$`), "openai:gpt-5.5"},
 	{regexp.MustCompile(`(^|/|:)gpt-5[.-]4($|-2026-03-05|-xhigh)`), "openai:gpt-5.4"},
 	{regexp.MustCompile(`(^|/|:)gpt-5[.-]4-mini($|[^a-z0-9])`), "openai:gpt-5.4-mini"},

--- a/server/internal/metrics/pricing_test.go
+++ b/server/internal/metrics/pricing_test.go
@@ -77,11 +77,17 @@ func TestPriceForModelAliasCodexGPT56(t *testing.T) {
 
 	// Unknown suffixed variants must NOT borrow a 5.6 tier — the alias is an
 	// anchored exact match, mirroring the frontend's exact-match resolver.
+	// The dash-normalized ids (`gpt-5-6-luna`) must also miss: the real Codex
+	// slug is always dotted and the frontend does not dash-normalize, so both
+	// sides surface these as unmapped instead of silently pricing them.
 	for _, model := range []string{
 		"gpt-5.6-luna-pro",
 		"gpt-5.6-luna/unknown",
 		"gpt-5.6-sol-high",
 		"gpt-5.6-mini",
+		"gpt-5-6-luna",
+		"gpt-5-6-sol",
+		"gpt-5-6-terra",
 	} {
 		if got, ok := PriceForModelAlias(model); ok {
 			t.Fatalf("PriceForModelAlias(%q) unexpectedly resolved to %+v; want unmapped", model, got)

--- a/server/pkg/agent/models.go
+++ b/server/pkg/agent/models.go
@@ -301,11 +301,13 @@ func claudeStaticModels() []Model {
 func codexStaticModels() []Model {
 	// `Default` here is NOT a user-facing "default model" badge — the picker
 	// stopped rendering that (Multica follows the CLI config when the model is
-	// unset). It is the anchor the effort picker previews against, and the
-	// model ValidateThinkingLevel resolves an empty model to when checking an
-	// effort level; dropping it would make a follow-CLI-config agent's effort
-	// selection fail catalog validation and get silently skipped. Keep exactly
-	// one entry flagged, on the current flagship.
+	// unset). It only marks the current flagship for the "default must track
+	// the latest release" catalog guard (TestCodexStaticModelsExposesLatest,
+	// multica#2009). It is deliberately NOT used to validate effort for an
+	// empty (follow-CLI-config) model: that config can resolve to any model,
+	// so ValidateThinkingLevel fails an empty codex model closed rather than
+	// borrowing this entry's catalog (which alone advertises `ultra`) — see
+	// ValidateThinkingLevel and MUL-4347. Keep exactly one entry flagged.
 	return []Model{
 		{ID: "gpt-5.6-sol", Label: "GPT-5.6 Sol", Provider: "openai", Default: true},
 		{ID: "gpt-5.6-terra", Label: "GPT-5.6 Terra", Provider: "openai"},

--- a/server/pkg/agent/thinking.go
+++ b/server/pkg/agent/thinking.go
@@ -360,9 +360,18 @@ func parseCodexDebugModels(raw []byte) map[string]*ModelThinking {
 			if lvl.Effort == "" {
 				continue
 			}
+			// Only surface efforts we have a label for. codexEffortLabel is
+			// the single source of truth for "a Codex effort Multica knows",
+			// and TestCodexAdvertisedLevelsArePersistable guarantees every key
+			// here is also in providerThinkingEnums["codex"] — so a labelled
+			// effort is always persistable. Dropping unlabelled tokens (a
+			// future Codex release advertising a new level we haven't taught
+			// the server yet) keeps the picker from ever offering a level the
+			// Create/Update enum gate would 400 on save. Fail closed until the
+			// maps learn it, rather than showing an unsaveable option. (MUL-4347)
 			label, ok := codexEffortLabel[lvl.Effort]
 			if !ok {
-				label = strings.Title(lvl.Effort) //nolint:staticcheck
+				continue
 			}
 			levels = append(levels, ThinkingLevel{
 				Value:       lvl.Effort,
@@ -522,13 +531,26 @@ func parseCodebuddyEffortHelp(helpText string) []string {
 // catalog for the given (provider, model) pair. Empty value is always
 // valid — it means "use the runtime default".
 //
-// Empty model is treated as "use the provider's default model"; we
-// resolve it through ListModels so the daemon's pre-execution guard
-// behaves the same whether the agent picked an explicit model or
-// inherited the runtime default. Without this, a default-model task
-// with a valid thinking_level would be rejected on the grounds that
-// the empty string is not in the catalog — exactly the misjudgement
-// Elon flagged in the PR1 review.
+// Empty model means "follow the runtime's own default", resolved at task
+// time. How safely we can validate an effort against that depends on the
+// provider:
+//
+//   - codex: the effective model comes from the user's local config.toml
+//     and can be ANY installed model, not necessarily the catalog's flagged
+//     Default. Borrowing the Default entry (gpt-5.6-sol, the only one
+//     advertising `ultra`) would green-light levels the actually-configured
+//     model may not support — Luna tops out at `max`, gpt-5.5/5.4 at `xhigh`
+//     — and Codex does not reject the mismatch itself. We can't know the
+//     effective model without parsing config.toml in the task cwd (see this
+//     file's Codex header for why that's avoided), so an empty codex model
+//     fails closed: the daemon drops the level rather than injecting one that
+//     may not fit. Users who need a specific effort must pick an explicit
+//     model. (MUL-4347 review.)
+//   - other providers: empty model resolves to the catalog's Default entry
+//     so a default-model task with a valid thinking_level isn't misjudged as
+//     "unknown model → reject" (the misjudgement flagged in an earlier
+//     review). opencode has no single default, so it accepts a level any
+//     advertised model supports.
 //
 // The lookup goes through ListModels so it sees the *current* CLI
 // catalog (including dynamic discovery for codex), not just a static
@@ -538,6 +560,13 @@ func parseCodebuddyEffortHelp(helpText string) []string {
 func ValidateThinkingLevel(ctx context.Context, providerType, executablePath, model, value string) (bool, error) {
 	if value == "" {
 		return true, nil
+	}
+	// Codex empty-model fail-closed (see doc comment). Checked before
+	// ListModels so the outcome is deterministic even when discovery would
+	// error — an errored lookup makes the daemon pass the level through, which
+	// is exactly what we must NOT do for an unresolved codex model.
+	if model == "" && providerType == "codex" {
+		return false, nil
 	}
 	models, err := ListModels(ctx, providerType, executablePath)
 	if err != nil {

--- a/server/pkg/agent/thinking_test.go
+++ b/server/pkg/agent/thinking_test.go
@@ -271,6 +271,84 @@ func TestParseCodexDebugModels_Malformed(t *testing.T) {
 	}
 }
 
+// TestParseCodexDebugModels_DropsNonPersistableEfforts drives the REAL parser
+// against a catalog that mixes known gpt-5.6 levels with a bogus future token,
+// then asserts every level the parser surfaces is persistable by the server
+// enum. This is the contract TestCodexAdvertisedLevelsArePersistable checks
+// statically (two hand-written maps); doing it through parseCodexDebugModels
+// closes the gap Elon flagged: a future Codex release advertising an effort we
+// haven't taught the server would otherwise reach the picker and 400 on save.
+func TestParseCodexDebugModels_DropsNonPersistableEfforts(t *testing.T) {
+	t.Parallel()
+	// sol advertises max+ultra (plus a made-up `hyper`); luna tops out at max.
+	raw := []byte(`{
+		"models": [
+			{
+				"slug": "gpt-5.6-sol",
+				"default_reasoning_level": "high",
+				"supported_reasoning_levels": [
+					{"effort": "medium"},
+					{"effort": "high"},
+					{"effort": "max"},
+					{"effort": "ultra"},
+					{"effort": "hyper"}
+				]
+			},
+			{
+				"slug": "gpt-5.6-luna",
+				"default_reasoning_level": "medium",
+				"supported_reasoning_levels": [
+					{"effort": "medium"},
+					{"effort": "max"}
+				]
+			}
+		]
+	}`)
+	got := parseCodexDebugModels(raw)
+
+	// Contract: nothing the parser surfaces may be unsaveable.
+	for slug, mt := range got {
+		for _, lvl := range mt.SupportedLevels {
+			if !IsKnownThinkingValue("codex", lvl.Value) {
+				t.Errorf("parser surfaced non-persistable effort %q for %q; the picker would 400 it on save", lvl.Value, slug)
+			}
+		}
+	}
+
+	sol := got["gpt-5.6-sol"]
+	if sol == nil {
+		t.Fatalf("missing gpt-5.6-sol entry: %+v", got)
+	}
+	// The bogus token is dropped, not Title-cased through to the picker.
+	if hasThinkingLevel(sol, "hyper") {
+		t.Errorf("unknown effort 'hyper' leaked into sol picker: %+v", sol.SupportedLevels)
+	}
+	// Known per-model levels survive, with the real per-model gap preserved:
+	// sol keeps ultra, luna must not advertise it.
+	if !hasThinkingLevel(sol, "ultra") {
+		t.Errorf("sol should keep ultra: %+v", sol.SupportedLevels)
+	}
+	luna := got["gpt-5.6-luna"]
+	if luna == nil {
+		t.Fatalf("missing gpt-5.6-luna entry: %+v", got)
+	}
+	if hasThinkingLevel(luna, "ultra") {
+		t.Errorf("luna must not advertise ultra (Codex 0.144.1 tops it out at max): %+v", luna.SupportedLevels)
+	}
+	if !hasThinkingLevel(luna, "max") {
+		t.Errorf("luna should keep max: %+v", luna.SupportedLevels)
+	}
+}
+
+func hasThinkingLevel(mt *ModelThinking, value string) bool {
+	for _, lvl := range mt.SupportedLevels {
+		if lvl.Value == value {
+			return true
+		}
+	}
+	return false
+}
+
 // ── IsKnownThinkingValue (server-side enum gate) ─────────────────────
 
 func TestIsKnownThinkingValue(t *testing.T) {
@@ -426,6 +504,53 @@ func TestValidateThinkingLevel_ExplicitModel(t *testing.T) {
 	}
 }
 
+// TestValidateThinkingLevel_CodexEmptyModelFailsClosed pins the MUL-4347
+// fix: an explicit codex model is validated against its own per-model
+// catalog, but an EMPTY model (follow config.toml, which can resolve to any
+// installed model) must NOT borrow the flagged Default entry's catalog. The
+// Default (gpt-5.6-sol) alone advertises `ultra`; letting an empty model
+// inherit it would green-light a level Luna / gpt-5.5 don't support and Codex
+// won't reject. So an empty codex model fails closed for every level and the
+// daemon drops it — users must pick an explicit model to pin an effort.
+func TestValidateThinkingLevel_CodexEmptyModelFailsClosed(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell-script fake binary requires a POSIX shell")
+	}
+
+	fakeCodex := writeFakeCodexModelsBinary(t)
+	ctx := context.Background()
+
+	check := func(model, value string, want bool) {
+		t.Helper()
+		ok, err := ValidateThinkingLevel(ctx, "codex", fakeCodex, model, value)
+		if err != nil {
+			t.Fatalf("ValidateThinkingLevel(codex, %q, %q): unexpected err: %v", model, value, err)
+		}
+		if ok != want {
+			t.Errorf("ValidateThinkingLevel(codex, %q, %q) = %v, want %v", model, value, ok, want)
+		}
+	}
+
+	// Explicit models resolve against their own per-model catalog.
+	check("gpt-5.6-sol", "ultra", true)   // sol advertises ultra
+	check("gpt-5.6-terra", "ultra", true) // ...and so does terra
+	check("gpt-5.6-luna", "ultra", false) // luna tops out at max
+	check("gpt-5.6-luna", "max", true)    // ...which is valid
+	check("gpt-5.6-luna", "medium", true) // as are the base levels
+
+	// Empty model cannot be validated per-model, so it fails closed for EVERY
+	// level — including `ultra` (must not pass via the Sol Default) and even a
+	// level every model supports (`medium`). The daemon drops it.
+	check("", "ultra", false)
+	check("", "medium", false)
+
+	// Empty VALUE always means "use runtime default" and stays valid — this is
+	// the path a follow-CLI-config agent takes, and the honest orphan/clear
+	// flow relies on it (an already-persisted level round-trips to empty).
+	check("", "", true)
+	check("gpt-5.6-luna", "", true)
+}
+
 func TestValidateThinkingLevel_PreEffortCLIRejectsAllLevels(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("shell-script fake binary requires a POSIX shell")
@@ -552,6 +677,31 @@ func writeFakeClaudePreEffortHelpBinary(t *testing.T) string {
 		"  --model <model>     Model to use\n" +
 		"  --verbose\n" +
 		"EOF\n"
+	writeTestExecutable(t, path, []byte(script))
+	return path
+}
+
+// writeFakeCodexModelsBinary writes a stand-in `codex` that answers
+// `debug models --bundled` with a Codex 0.144.1-shaped gpt-5.6 catalog
+// (sol/terra advertise max+ultra, luna tops out at max) and prints a version
+// string for any other invocation (DetectVersion's probe). Used to exercise
+// ValidateThinkingLevel against a real per-model catalog without a codex install.
+func writeFakeCodexModelsBinary(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "codex")
+	script := "#!/bin/sh\n" +
+		"if [ \"$1\" = \"debug\" ]; then\n" +
+		"cat <<'EOF'\n" +
+		`{"models":[` +
+		`{"slug":"gpt-5.6-sol","default_reasoning_level":"high","supported_reasoning_levels":[{"effort":"low"},{"effort":"medium"},{"effort":"high"},{"effort":"xhigh"},{"effort":"max"},{"effort":"ultra"}]},` +
+		`{"slug":"gpt-5.6-terra","default_reasoning_level":"high","supported_reasoning_levels":[{"effort":"low"},{"effort":"medium"},{"effort":"high"},{"effort":"xhigh"},{"effort":"max"},{"effort":"ultra"}]},` +
+		`{"slug":"gpt-5.6-luna","default_reasoning_level":"medium","supported_reasoning_levels":[{"effort":"low"},{"effort":"medium"},{"effort":"high"},{"effort":"xhigh"},{"effort":"max"}]}` +
+		`]}` + "\n" +
+		"EOF\n" +
+		"exit 0\n" +
+		"fi\n" +
+		"echo 'codex-cli 0.144.1'\n"
 	writeTestExecutable(t, path, []byte(script))
 	return path
 }


### PR DESCRIPTION
Follow-up to #5188 addressing the second-round review on MUL-4347. #5188 already merged, so this is a separate fix PR.

## What & why

### 1. Empty codex model no longer borrows the Default's effort catalog (P1)
An empty `agent.model` means "follow the runtime's own default". For codex that default comes from the local `config.toml` and can resolve to **any** installed model. The previous code resolved an empty model to the catalog's flagged `Default` (`gpt-5.6-sol`) for effort validation/preview — but Sol is the only model advertising `ultra`, so this green-lit levels the actually-configured model may not support (Luna tops out at `max`, gpt-5.5/5.4 at `xhigh`), and Codex does not reject the mismatch itself.

- **Backend** `ValidateThinkingLevel`: an empty codex model now fails closed (the daemon drops the level rather than injecting one that may not fit). The check runs **before** `ListModels` so a discovery error can't fail it open. Claude / opencode keep their existing empty-model behavior.
- **Frontend** `pickModelEntry`: an empty codex model no longer previews the Default entry's levels — the row hides. The persisted-orphan **clear path is preserved**: an already-saved level still renders the row so it can be cleared.
- Users who want a specific effort must pick an explicit model (matches the reviewer's "require explicit model selection" recommendation).

### 2. Parser-enforced effort contract (P2)
`parseCodexDebugModels` now drops efforts that have no known label instead of Title-casing them through. Because the label map is a subset of the server enum (guaranteed by `TestCodexAdvertisedLevelsArePersistable`), the picker can never advertise a level that would 400 on save — closing the "future catalog drift reintroduces the 400" gap. The contract test now drives the **real parser** with an unknown effort rather than comparing two hand-written maps.

### 3. Exact-match 5.6 price aliases (P2)
The gpt-5.6 alias regexes used `[.-]`, which matched dashed ids like `gpt-5-6-luna` and priced them as official SKUs — while the frontend resolver does not dash-normalize. Anchored them to a **literal dot** so dashed variants surface as unmapped on both sides. Added negative cases on backend and frontend.

Cache-write telemetry (Codex usage doesn't stream cache-write tokens yet) is a separate known limitation, already noted in the code — not touched here.

## Verification
- `go test ./internal/metrics ./pkg/agent` — green (new `TestValidateThinkingLevel_CodexEmptyModelFailsClosed`, `TestParseCodexDebugModels_DropsNonPersistableEfforts`, plus updated pricing negatives).
- `packages/views` Vitest (`thinking-prop-row.test.tsx`, `utils.test.ts`) — 68 passed, incl. empty-codex hide/clear cases and dashed-id unmapped cases.
- `pnpm --filter @multica/views typecheck`, `gofmt`, `go vet`, `git diff --check` — clean.
