### PR TITLE
[MUL-4348] Route coalesced replies per root thread

### DIFF
--- a/server/internal/daemon/daemon.go
+++ b/server/internal/daemon/daemon.go
@@ -3523,6 +3523,7 @@ func (d *Daemon) runTask(ctx context.Context, task Task, provider string, slot i
 		IssueID:                          task.IssueID,
 		TriggerCommentID:                 task.TriggerCommentID,
 		TriggerThreadID:                  task.TriggerThreadID,
+		CommentReplyTargets:              commentReplyThreads(task),
 		NewCommentCount:                  task.NewCommentCount,
 		NewCommentsSince:                 task.NewCommentsSince,
 		PriorSessionResumed:              task.PriorSessionID != "",

--- a/server/internal/daemon/execenv/execenv.go
+++ b/server/internal/daemon/execenv/execenv.go
@@ -69,9 +69,18 @@ type PrepareParams struct {
 
 // TaskContextForEnv is the subset of task context used for writing context files.
 type TaskContextForEnv struct {
-	IssueID                 string
-	TriggerCommentID        string // comment that triggered this task (empty for on_assign)
-	TriggerThreadID         string // root comment ID for the triggering thread; falls back to TriggerCommentID when empty
+	IssueID          string
+	TriggerCommentID string // comment that triggered this task (empty for on_assign)
+	TriggerThreadID  string // root comment ID for the triggering thread; falls back to TriggerCommentID when empty
+	// CommentReplyTargets is set for a comment run that coalesced comments
+	// spanning MORE THAN ONE root thread (MUL-4348). When it has >=2 entries the
+	// workflow's reply step fans out — one reply per thread — instead of the
+	// single --parent=trigger cookbook, keeping this persistent brief in sync
+	// with the per-turn prompt so a cross-thread run cannot get one source
+	// telling it "one comment" and the other "one per thread". Same-thread
+	// follow-ups collapse to a single group upstream, so this stays empty and
+	// the single-parent path is used (no duplicate replies).
+	CommentReplyTargets     []ThreadReplyTarget
 	NewCommentCount         int    // issue-wide comments since this agent's last run (excludes its own and the injected trigger)
 	NewCommentsSince        string // RFC3339 anchor (last run's started_at) the count is measured from; empty on cold start
 	PriorSessionResumed     bool   // true when the daemon will resume an existing provider session for this task

--- a/server/internal/daemon/execenv/reply_instructions.go
+++ b/server/internal/daemon/execenv/reply_instructions.go
@@ -239,17 +239,21 @@ func BuildMultiThreadCommentReplyInstructions(issueID string, targets []ThreadRe
 	var cookbook string
 	if runtimeGOOS == "windows" {
 		cookbook = fmt.Sprintf(
-			"For EACH thread above, write that reply's body to its own UTF-8 file with your file-write tool, then post it with `--content-file` (do NOT use inline `--content` or a `--content-stdin` HEREDOC — see ## Comment Formatting above for why). Use one file per thread and remove each after posting:\n\n"+
-				"    multica issue comment add %s --parent <thread-parent-from-the-list-above> --content-file ./reply-1.md\n"+
-				"    Remove-Item ./reply-1.md\n\n",
-			issueID,
+			"For EACH thread above, write that reply's body to its own UTF-8 file with your file-write tool, then post it with `--content-file` (do NOT use inline `--content` or a `--content-stdin` HEREDOC — see ## Comment Formatting above for why). Use a DISTINCT file per thread (never reuse one file) and remove each after posting:\n\n"+
+				"    multica issue comment add %s --parent <thread-1-parent> --content-file ./reply-1.md\n"+
+				"    Remove-Item ./reply-1.md\n"+
+				"    multica issue comment add %s --parent <thread-2-parent> --content-file ./reply-2.md\n"+
+				"    Remove-Item ./reply-2.md\n\n",
+			issueID, issueID,
 		)
 	} else {
 		cookbook = fmt.Sprintf(
-			"For EACH thread above, write that reply's body to its own UTF-8 file with your file-write tool, then post it with `--content-file` (do NOT use inline `--content` or a `--content-stdin` HEREDOC — see ## Comment Formatting above for why). Use one file per thread and remove each after posting:\n\n"+
-				"    multica issue comment add %s --parent <thread-parent-from-the-list-above> --content-file ./reply-1.md\n"+
-				"    rm ./reply-1.md\n\n",
-			issueID,
+			"For EACH thread above, write that reply's body to its own UTF-8 file with your file-write tool, then post it with `--content-file` (do NOT use inline `--content` or a `--content-stdin` HEREDOC — see ## Comment Formatting above for why). Use a DISTINCT file per thread (never reuse one file) and remove each after posting:\n\n"+
+				"    multica issue comment add %s --parent <thread-1-parent> --content-file ./reply-1.md\n"+
+				"    rm ./reply-1.md\n"+
+				"    multica issue comment add %s --parent <thread-2-parent> --content-file ./reply-2.md\n"+
+				"    rm ./reply-2.md\n\n",
+			issueID, issueID,
 		)
 	}
 

--- a/server/internal/daemon/execenv/reply_instructions.go
+++ b/server/internal/daemon/execenv/reply_instructions.go
@@ -199,3 +199,66 @@ func buildCommentReplyInstructionsSlim(provider, issueID, triggerCommentID strin
 		issueID, triggerCommentID,
 	)
 }
+
+// ThreadReplyTarget is one root-thread group a coalesced run must answer.
+// ThreadID labels the conversation (its root comment id); ParentID is the exact
+// `--parent` the agent must pass so its reply lands inside that thread.
+type ThreadReplyTarget struct {
+	ThreadID string
+	ParentID string
+}
+
+// BuildMultiThreadCommentReplyInstructions is the reply cookbook for a run whose
+// coalesced comments span MORE THAN ONE root thread (MUL-4348). It deliberately
+// overrides the general "post exactly one comment per run" guidance for this
+// specific run: three unrelated questions raised in three separate threads must
+// land as three in-thread answers, not one merged blob posted under a single
+// thread (or as a stray root comment).
+//
+// The grouping is computed server-side, so same-thread follow-ups never reach
+// here — they collapse to a single target upstream and take the ordinary
+// single-parent path. That is why the agent is told, unconditionally, to post
+// exactly one reply per listed thread and never more than one reply in the same
+// thread: the "multiple @mentions in one thread" case is already consolidated
+// before this instruction is emitted, so a per-thread fan-out cannot split it.
+//
+// Returns "" for fewer than two targets; callers keep the single-parent path.
+func BuildMultiThreadCommentReplyInstructions(issueID string, targets []ThreadReplyTarget) string {
+	if issueID == "" || len(targets) < 2 {
+		return ""
+	}
+
+	targetLines := ""
+	for _, tgt := range targets {
+		targetLines += fmt.Sprintf("- thread %s → reply with `--parent %s`\n", tgt.ThreadID, tgt.ParentID)
+	}
+
+	// File-hygiene guidance mirrors buildCommentReplyInstructionsSlim, but the
+	// agent must use a DISTINCT body file per thread so one reply's content can
+	// never leak into another's.
+	var cookbook string
+	if runtimeGOOS == "windows" {
+		cookbook = fmt.Sprintf(
+			"For EACH thread above, write that reply's body to its own UTF-8 file with your file-write tool, then post it with `--content-file` (do NOT use inline `--content` or a `--content-stdin` HEREDOC — see ## Comment Formatting above for why). Use one file per thread and remove each after posting:\n\n"+
+				"    multica issue comment add %s --parent <thread-parent-from-the-list-above> --content-file ./reply-1.md\n"+
+				"    Remove-Item ./reply-1.md\n\n",
+			issueID,
+		)
+	} else {
+		cookbook = fmt.Sprintf(
+			"For EACH thread above, write that reply's body to its own UTF-8 file with your file-write tool, then post it with `--content-file` (do NOT use inline `--content` or a `--content-stdin` HEREDOC — see ## Comment Formatting above for why). Use one file per thread and remove each after posting:\n\n"+
+				"    multica issue comment add %s --parent <thread-parent-from-the-list-above> --content-file ./reply-1.md\n"+
+				"    rm ./reply-1.md\n\n",
+			issueID,
+		)
+	}
+
+	return fmt.Sprintf(
+		"This run coalesced comments from %d DISTINCT threads. Post ONE reply per thread — %d replies in total — each threaded under its own conversation. This OVERRIDES the general \"post exactly one comment per run\" guidance: for THIS run multiple replies are required and correct. Do NOT merge separate threads into a single comment, and do NOT post more than one reply in the same thread.\n\n"+
+			"Reply targets (use the exact `--parent` for each — do NOT reuse `--parent` values from previous turns in this session):\n"+
+			"%s\n"+
+			"%s"+
+			"Do NOT write literal `\\n` escapes to simulate line breaks; each file preserves real newlines.\n",
+		len(targets), len(targets), targetLines, cookbook,
+	)
+}

--- a/server/internal/daemon/execenv/runtime_config_sections.go
+++ b/server/internal/daemon/execenv/runtime_config_sections.go
@@ -382,7 +382,13 @@ func writeWorkflowComment(b *strings.Builder, provider string, ctx TaskContextFo
 	}
 	b.WriteString("6. If a reply IS warranted: do any requested work first, then **decide whether to include any `@mention` link.** The default is NO mention. Only mention when you are escalating to a human owner who is not yet involved, delegating a concrete new sub-task to another agent for the first time, or the user explicitly asked you to loop someone in. Never @mention the agent you are replying to as a thank-you or sign-off.\n")
 	b.WriteString("7. **If you reply, post it as a comment — this step is mandatory when you reply.** Text in your terminal or run logs is NOT delivered to the user. ")
-	b.WriteString(buildCommentReplyInstructionsSlim(provider, ctx.IssueID, ctx.TriggerCommentID))
+	if len(ctx.CommentReplyTargets) >= 2 {
+		// Cross-thread coalesced run: fan out one reply per root thread, matching
+		// the per-turn prompt so the two reply-instruction sources agree (MUL-4348).
+		b.WriteString(BuildMultiThreadCommentReplyInstructions(ctx.IssueID, ctx.CommentReplyTargets))
+	} else {
+		b.WriteString(buildCommentReplyInstructionsSlim(provider, ctx.IssueID, ctx.TriggerCommentID))
+	}
 	b.WriteString("8. Before exiting: only if this run produced a fact that clears the high bar (important AND likely to be re-read by future runs on this same issue, e.g. a new PR URL or deploy URL), or you noticed a metadata key from entry that is now stale, pin or clear it via `multica issue metadata set`/`delete`. Most runs write nothing here — that is the expected outcome, not a gap. When in doubt, do not write. See the `## Issue Metadata` section above for the full bar.\n")
 	b.WriteString("9. Do NOT change the issue status unless the comment explicitly asks for it\n\n")
 }

--- a/server/internal/daemon/execenv/runtime_config_test.go
+++ b/server/internal/daemon/execenv/runtime_config_test.go
@@ -1409,3 +1409,53 @@ func TestWriteRuntimeConfigFileAlwaysInsertsFixedManagedSeparator(t *testing.T) 
 		})
 	}
 }
+
+// TestCommentTriggeredBriefFansOutAcrossThreads pins the second reply-instruction
+// source (the persistent workflow brief) in sync with the per-turn prompt
+// (MUL-4348). When a coalesced run spans >=2 root threads, the workflow's reply
+// step must emit the per-thread fan-out plan — not the single --parent=trigger
+// cookbook — so a cross-thread run never gets one surface saying "one comment"
+// and the other "one per thread".
+func TestCommentTriggeredBriefFansOutAcrossThreads(t *testing.T) {
+	t.Parallel()
+	ctx := TaskContextForEnv{
+		IssueID:          "55555555-6666-7777-8888-999999999999",
+		TriggerCommentID: "c3",
+		TriggerThreadID:  "c3",
+		CommentReplyTargets: []ThreadReplyTarget{
+			{ThreadID: "c1", ParentID: "c1"},
+			{ThreadID: "c2", ParentID: "c2"},
+			{ThreadID: "c3", ParentID: "c3"},
+		},
+	}
+	out := buildMetaSkillContent("claude", ctx)
+
+	for _, want := range []string{"3 DISTINCT threads", "Post ONE reply per thread", "--parent c1", "--parent c2", "--parent c3"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("cross-thread brief must contain %q, got:\n%s", want, out)
+		}
+	}
+}
+
+// TestCommentTriggeredBriefSingleThreadKeepsSingleReply pins the hard
+// requirement on the brief surface too: a run with no multi-thread targets
+// (ordinary comment, or same-thread follow-ups that collapsed upstream) keeps
+// the single --parent=trigger cookbook and never emits the fan-out block.
+func TestCommentTriggeredBriefSingleThreadKeepsSingleReply(t *testing.T) {
+	t.Parallel()
+	ctx := TaskContextForEnv{
+		IssueID:          "55555555-6666-7777-8888-999999999999",
+		TriggerCommentID: "c3",
+		TriggerThreadID:  "thread-A",
+		// CommentReplyTargets deliberately empty: same-thread follow-ups collapse
+		// to a single group upstream, so no fan-out targets reach the brief.
+	}
+	out := buildMetaSkillContent("claude", ctx)
+
+	if strings.Contains(out, "DISTINCT threads") {
+		t.Errorf("single/same-thread brief must not emit the multi-thread fan-out block, got:\n%s", out)
+	}
+	if !strings.Contains(out, "--parent c3 --content-file ./reply.md") {
+		t.Errorf("single/same-thread brief must keep the single --parent=trigger cookbook, got:\n%s", out)
+	}
+}

--- a/server/internal/daemon/prompt.go
+++ b/server/internal/daemon/prompt.go
@@ -241,11 +241,14 @@ func buildCommentPrompt(task Task, provider string) string {
 // threads yield one group each so the agent replies inside each thread instead
 // of merging them into one blob (MUL-4348).
 //
-// The trigger's own thread replies under the trigger comment itself, matching
-// the long-standing single-thread behaviour (--parent = trigger comment id);
-// every other thread replies under its root comment id. Returns nil when there
-// is no trigger or only a single distinct thread — the caller then keeps the
-// existing single-parent reply path unchanged.
+// The reply for each thread targets the NEWEST comment that triggered this run
+// in that thread (coalesced comments arrive oldest-first and the trigger is the
+// newest overall, so a simple last-write-wins yields the newest per thread).
+// That nests the answer next to the most recent question in the thread rather
+// than at the thread root, and makes the trigger's own thread (--parent =
+// trigger comment) consistent with every other thread instead of a special
+// case. Returns nil when there is no trigger or only a single distinct thread —
+// the caller then keeps the existing single-parent reply path unchanged.
 func commentReplyThreads(task Task) []execenv.ThreadReplyTarget {
 	if task.TriggerCommentID == "" {
 		return nil
@@ -261,6 +264,9 @@ func commentReplyThreads(task Task) []execenv.ThreadReplyTarget {
 
 	order := make([]string, 0, len(task.CoalescedComments)+1)
 	parentByThread := make(map[string]string, len(task.CoalescedComments)+1)
+	// note records first-seen order but lets the newest comment win the reply
+	// target: inputs are chronological (coalesced oldest-first, trigger last),
+	// so the last write for a thread is its newest triggering comment.
 	note := func(threadID, parentID string) {
 		if _, ok := parentByThread[threadID]; !ok {
 			order = append(order, threadID)
@@ -268,16 +274,14 @@ func commentReplyThreads(task Task) []execenv.ThreadReplyTarget {
 		parentByThread[threadID] = parentID
 	}
 
-	// Coalesced (older) comments first: each replies under its own thread root.
+	// Coalesced (older) comments first: reply under the specific comment that
+	// mentioned the agent, not the thread root, so a mid-thread mention gets its
+	// answer next to the question.
 	for _, cc := range task.CoalescedComments {
-		tid := threadKey(cc.ThreadID, cc.ID)
-		if _, ok := parentByThread[tid]; ok {
-			continue // thread already represented; keep its first parent
-		}
-		note(tid, tid)
+		note(threadKey(cc.ThreadID, cc.ID), cc.ID)
 	}
-	// The newest trigger last: its thread replies under the trigger comment,
-	// overriding any coalesced comment that shared the trigger's thread.
+	// The newest trigger last: it always wins its own thread's reply target,
+	// overriding any earlier coalesced comment that shared the trigger's thread.
 	note(threadKey(task.TriggerThreadID, task.TriggerCommentID), task.TriggerCommentID)
 
 	if len(order) <= 1 {

--- a/server/internal/daemon/prompt.go
+++ b/server/internal/daemon/prompt.go
@@ -220,8 +220,74 @@ func buildCommentPrompt(task Task, provider string) string {
 	} else {
 		fmt.Fprintf(&b, "Read the discussion: `multica issue comment list %s --recent 10 --output json` (resolved threads come back folded — `--full` to expand).\n\n", task.IssueID)
 	}
-	b.WriteString(execenv.BuildCommentReplyInstructions(provider, task.IssueID, task.TriggerCommentID))
+	// Reply routing. When this run coalesced comments spanning MORE THAN ONE
+	// root thread, answer each thread in its own thread instead of dumping one
+	// merged comment (MUL-4348). Same-thread follow-ups collapse to a single
+	// group upstream, so they keep the ordinary single-parent path below and can
+	// never be split into duplicate replies.
+	if targets := commentReplyThreads(task); len(targets) >= 2 {
+		b.WriteString(execenv.BuildMultiThreadCommentReplyInstructions(task.IssueID, targets))
+	} else {
+		b.WriteString(execenv.BuildCommentReplyInstructions(provider, task.IssueID, task.TriggerCommentID))
+	}
 	return b.String()
+}
+
+// commentReplyThreads groups this run's trigger + coalesced comments by their
+// root thread, in first-seen order (coalesced comments oldest-first, the newest
+// trigger last). A run that coalesced several @mentions from the SAME thread
+// yields a single group, so same-thread follow-ups get exactly one consolidated
+// reply and can never be split into duplicates; comments from different root
+// threads yield one group each so the agent replies inside each thread instead
+// of merging them into one blob (MUL-4348).
+//
+// The trigger's own thread replies under the trigger comment itself, matching
+// the long-standing single-thread behaviour (--parent = trigger comment id);
+// every other thread replies under its root comment id. Returns nil when there
+// is no trigger or only a single distinct thread — the caller then keeps the
+// existing single-parent reply path unchanged.
+func commentReplyThreads(task Task) []execenv.ThreadReplyTarget {
+	if task.TriggerCommentID == "" {
+		return nil
+	}
+	// A comment with no explicit thread id is a root comment: it is its own
+	// thread, so fall back to the comment id itself as the thread key.
+	threadKey := func(threadID, commentID string) string {
+		if threadID != "" {
+			return threadID
+		}
+		return commentID
+	}
+
+	order := make([]string, 0, len(task.CoalescedComments)+1)
+	parentByThread := make(map[string]string, len(task.CoalescedComments)+1)
+	note := func(threadID, parentID string) {
+		if _, ok := parentByThread[threadID]; !ok {
+			order = append(order, threadID)
+		}
+		parentByThread[threadID] = parentID
+	}
+
+	// Coalesced (older) comments first: each replies under its own thread root.
+	for _, cc := range task.CoalescedComments {
+		tid := threadKey(cc.ThreadID, cc.ID)
+		if _, ok := parentByThread[tid]; ok {
+			continue // thread already represented; keep its first parent
+		}
+		note(tid, tid)
+	}
+	// The newest trigger last: its thread replies under the trigger comment,
+	// overriding any coalesced comment that shared the trigger's thread.
+	note(threadKey(task.TriggerThreadID, task.TriggerCommentID), task.TriggerCommentID)
+
+	if len(order) <= 1 {
+		return nil
+	}
+	targets := make([]execenv.ThreadReplyTarget, 0, len(order))
+	for _, tid := range order {
+		targets = append(targets, execenv.ThreadReplyTarget{ThreadID: tid, ParentID: parentByThread[tid]})
+	}
+	return targets
 }
 
 // buildChatPrompt constructs a prompt for interactive chat tasks.

--- a/server/internal/daemon/prompt_test.go
+++ b/server/internal/daemon/prompt_test.go
@@ -741,8 +741,11 @@ func TestCommentReplyThreadsGrouping(t *testing.T) {
 		if got["thread-A"] != "c3" {
 			t.Errorf("trigger thread parent = %q, want c3 (the trigger comment)", got["thread-A"])
 		}
-		if got["thread-B"] != "thread-B" {
-			t.Errorf("other thread parent = %q, want its root thread-B", got["thread-B"])
+		// The other thread replies under the specific comment that mentioned the
+		// agent (a mid-thread reply), not the thread root — fixes the placement
+		// asymmetry from the first cut.
+		if got["thread-B"] != "c2" {
+			t.Errorf("other thread parent = %q, want c2 (the specific mentioning comment)", got["thread-B"])
 		}
 	})
 
@@ -750,6 +753,30 @@ func TestCommentReplyThreadsGrouping(t *testing.T) {
 		task := Task{TriggerCommentID: "c1", TriggerThreadID: "thread-A"}
 		if targets := commentReplyThreads(task); targets != nil {
 			t.Fatalf("ordinary single-comment run must not fan out; got %+v", targets)
+		}
+	})
+
+	t.Run("non-trigger thread replies under its newest mention, not root", func(t *testing.T) {
+		// Two mid-thread mentions in thread-B (oldest c1, newer c2); the reply
+		// should target the newest specific comment (c2), not the root thread-B.
+		task := Task{
+			TriggerCommentID: "c9",
+			TriggerThreadID:  "thread-A",
+			CoalescedComments: []CoalescedCommentData{
+				{ID: "c1", ThreadID: "thread-B", Content: "older mention", CreatedAt: "2026-07-10T01:00:00Z"},
+				{ID: "c2", ThreadID: "thread-B", Content: "newer mention", CreatedAt: "2026-07-10T02:00:00Z"},
+			},
+		}
+		targets := commentReplyThreads(task)
+		got := map[string]string{}
+		for _, tgt := range targets {
+			got[tgt.ThreadID] = tgt.ParentID
+		}
+		if got["thread-B"] != "c2" {
+			t.Errorf("thread-B parent = %q, want newest mention c2 (not root)", got["thread-B"])
+		}
+		if got["thread-A"] != "c9" {
+			t.Errorf("trigger thread parent = %q, want trigger c9", got["thread-A"])
 		}
 	})
 }

--- a/server/internal/daemon/prompt_test.go
+++ b/server/internal/daemon/prompt_test.go
@@ -676,3 +676,147 @@ func TestBuildCommentPromptCoalescedIDsOnlyFallback(t *testing.T) {
 		}
 	}
 }
+
+// TestCommentReplyThreadsGrouping pins the server-side grouping that drives
+// per-thread reply routing (MUL-4348). The invariants:
+//   - three distinct root threads → three targets, each replying to its own
+//     thread (the trigger's thread replies under the trigger comment itself).
+//   - multiple coalesced follow-ups in the SAME thread → a single group, so the
+//     caller keeps the single-parent path and the reply is never duplicated.
+//   - no coalesced comments (ordinary single comment) → nil.
+func TestCommentReplyThreadsGrouping(t *testing.T) {
+	t.Run("three distinct root threads fan out", func(t *testing.T) {
+		task := Task{
+			TriggerCommentID: "c3",
+			TriggerThreadID:  "c3", // a root comment is its own thread
+			CoalescedComments: []CoalescedCommentData{
+				{ID: "c1", ThreadID: "c1", Content: "背一首宋词"},
+				{ID: "c2", ThreadID: "c2", Content: "毛泽东诗词背一首"},
+			},
+		}
+		targets := commentReplyThreads(task)
+		if len(targets) != 3 {
+			t.Fatalf("want 3 targets, got %d: %+v", len(targets), targets)
+		}
+		wantParent := map[string]string{"c1": "c1", "c2": "c2", "c3": "c3"}
+		for _, tgt := range targets {
+			if wantParent[tgt.ThreadID] != tgt.ParentID {
+				t.Errorf("thread %s: parent = %s, want %s", tgt.ThreadID, tgt.ParentID, wantParent[tgt.ThreadID])
+			}
+		}
+	})
+
+	t.Run("same-thread follow-ups consolidate to a single group", func(t *testing.T) {
+		task := Task{
+			TriggerCommentID: "c3",
+			TriggerThreadID:  "thread-A",
+			CoalescedComments: []CoalescedCommentData{
+				{ID: "c1", ThreadID: "thread-A", Content: "追问 1"},
+				{ID: "c2", ThreadID: "thread-A", Content: "追问 2"},
+			},
+		}
+		if targets := commentReplyThreads(task); targets != nil {
+			t.Fatalf("same-thread follow-ups must not fan out; got %d targets: %+v", len(targets), targets)
+		}
+	})
+
+	t.Run("mixed: trigger thread plus one other thread", func(t *testing.T) {
+		task := Task{
+			TriggerCommentID: "c3",
+			TriggerThreadID:  "thread-A",
+			CoalescedComments: []CoalescedCommentData{
+				{ID: "c1", ThreadID: "thread-A", Content: "same-thread follow-up"},
+				{ID: "c2", ThreadID: "thread-B", Content: "other thread"},
+			},
+		}
+		targets := commentReplyThreads(task)
+		if len(targets) != 2 {
+			t.Fatalf("want 2 targets (thread-A, thread-B), got %d: %+v", len(targets), targets)
+		}
+		got := map[string]string{}
+		for _, tgt := range targets {
+			got[tgt.ThreadID] = tgt.ParentID
+		}
+		// The trigger's own thread replies under the trigger comment, not its root.
+		if got["thread-A"] != "c3" {
+			t.Errorf("trigger thread parent = %q, want c3 (the trigger comment)", got["thread-A"])
+		}
+		if got["thread-B"] != "thread-B" {
+			t.Errorf("other thread parent = %q, want its root thread-B", got["thread-B"])
+		}
+	})
+
+	t.Run("no coalesced comments → nil", func(t *testing.T) {
+		task := Task{TriggerCommentID: "c1", TriggerThreadID: "thread-A"}
+		if targets := commentReplyThreads(task); targets != nil {
+			t.Fatalf("ordinary single-comment run must not fan out; got %+v", targets)
+		}
+	})
+}
+
+// TestBuildCommentPromptCrossThreadFansOutReplies is the end-to-end prompt
+// assertion for the screenshot scenario: three separate root comments coalesced
+// into one run must produce a per-thread reply plan (one reply per thread),
+// explicitly overriding the "one comment per run" rule, instead of the single
+// --parent cookbook.
+func TestBuildCommentPromptCrossThreadFansOutReplies(t *testing.T) {
+	task := Task{
+		IssueID:               "issue-xthread-2",
+		TriggerCommentID:      "c3",
+		TriggerThreadID:       "c3",
+		TriggerCommentContent: "莎士比亚名言来一句",
+		TriggerAuthorType:     "member",
+		CoalescedCommentIDs:   []string{"c1", "c2"},
+		CoalescedComments: []CoalescedCommentData{
+			{ID: "c1", ThreadID: "c1", AuthorType: "member", AuthorName: "Yushen", Content: "背一首宋词", CreatedAt: "2026-07-10T01:00:00Z"},
+			{ID: "c2", ThreadID: "c2", AuthorType: "member", AuthorName: "Yushen", Content: "毛泽东诗词背一首", CreatedAt: "2026-07-10T02:00:00Z"},
+		},
+	}
+	out := BuildPrompt(task, "claude")
+
+	for _, want := range []string{
+		"3 DISTINCT threads",
+		"Post ONE reply per thread",
+		"OVERRIDES",
+		"--parent c1",
+		"--parent c2",
+		"--parent c3",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("cross-thread prompt must contain %q, got:\n%s", want, out)
+		}
+	}
+	// The single-parent cookbook must NOT be used when fanning out.
+	if strings.Contains(out, "always use the trigger comment ID below") {
+		t.Errorf("cross-thread prompt must not emit the single-parent reply cookbook, got:\n%s", out)
+	}
+}
+
+// TestBuildCommentPromptSameThreadKeepsSingleReply pins the hard requirement:
+// multiple @mentions coalesced from the SAME thread must keep the ordinary
+// single-parent reply path (one reply, under the trigger comment) and must NOT
+// trigger the multi-thread fan-out.
+func TestBuildCommentPromptSameThreadKeepsSingleReply(t *testing.T) {
+	task := Task{
+		IssueID:               "issue-samethread-1",
+		TriggerCommentID:      "c3",
+		TriggerThreadID:       "thread-A",
+		TriggerCommentContent: "追问 3",
+		TriggerAuthorType:     "member",
+		CoalescedCommentIDs:   []string{"c1", "c2"},
+		CoalescedComments: []CoalescedCommentData{
+			{ID: "c1", ThreadID: "thread-A", AuthorType: "member", AuthorName: "Yushen", Content: "追问 1", CreatedAt: "2026-07-10T01:00:00Z"},
+			{ID: "c2", ThreadID: "thread-A", AuthorType: "member", AuthorName: "Yushen", Content: "追问 2", CreatedAt: "2026-07-10T02:00:00Z"},
+		},
+	}
+	out := BuildPrompt(task, "claude")
+
+	if strings.Contains(out, "DISTINCT threads") {
+		t.Errorf("same-thread coalescing must not emit the multi-thread fan-out block, got:\n%s", out)
+	}
+	// The single-parent cookbook is used, threading the one reply under the
+	// trigger comment.
+	if !strings.Contains(out, "--parent c3 --content-file ./reply.md") {
+		t.Errorf("same-thread run must keep the single --parent=trigger reply cookbook, got:\n%s", out)
+	}
+}


### PR DESCRIPTION
## What & why

When a busy agent coalesces multiple `@mention` comments into a single run (MUL-4195/4348), the run replied with a **single** `--parent` (the newest trigger). If those comments were raised as **separate root threads**, all answers were dumped into one merged comment and the other threads were left with no in-thread reply:

> 三条独立的 root comment（背宋词 / 背毛泽东诗词 / 莎士比亚名言）合并成一个 run 后，只在一个 thread 里回了一条，另外两个 thread 一直空着。

The fix decouples **execution coalescing** (still one run — unchanged) from **reply routing** (now per thread).

## How

- **`prompt.go` — `commentReplyThreads(task)`**: groups the trigger + coalesced comments by their root thread (a root comment is its own thread), in first-seen order. The trigger's own thread replies under the trigger comment (matching the long-standing single-thread behaviour); every other thread replies under its root.
- **`reply_instructions.go` — `BuildMultiThreadCommentReplyInstructions`**: when a run spans **≥2 distinct threads**, emits a per-thread reply plan — one reply per thread with the exact `--parent` — and **explicitly overrides** the general "post exactly one comment per run" guidance for that run. OS-aware (Windows/unix) file-hygiene cookbook, one body file per thread.
- **`buildCommentPrompt`**: `≥2` threads → multi-thread instruction; otherwise the existing single-`--parent` path, byte-for-byte unchanged.

## The same-thread guarantee (hard requirement)

Multiple `@mentions` from the **same** thread collapse to a **single group** in `commentReplyThreads` before any instruction is emitted, so:

- same-thread follow-ups keep the ordinary `--parent = trigger` path,
- they get **exactly one consolidated reply**, and
- the per-thread fan-out can **never** split them into duplicate replies.

This is enforced by construction (grouping key = root thread id) and pinned by tests.

## Tests

`server/internal/daemon/prompt_test.go`:
- `TestCommentReplyThreadsGrouping`: 3 distinct root threads → 3 targets with correct parents; same-thread follow-ups → nil (no fan-out); mixed (trigger thread + one other) → 2 targets; no coalesced → nil.
- `TestBuildCommentPromptCrossThreadFansOutReplies`: the screenshot scenario — asserts the per-thread plan, the override wording, and all three `--parent` ids; asserts the single-parent cookbook is NOT used.
- `TestBuildCommentPromptSameThreadKeepsSingleReply`: same-thread coalescing keeps the single `--parent=trigger` cookbook and never emits the fan-out block.

## Verification

- `go build ./...` → 0
- `go vet ./internal/daemon/...` → 0
- `go test ./internal/daemon/...` → all pass (daemon, execenv, repocache)
- `gofmt` clean

## Notes / scope

- No data-model or protocol change: routing is derived from data already delivered to the run (`trigger_thread_id` + each coalesced comment's `thread_id`).
- The global "one comment per run" phrase in the runtime brief (`runtime_config_sections.go`, pinned by `TestOutputForbidsMidRunProgressComments`) is intentionally left unchanged; the exception is scoped to the task-specific prompt.
- Fan-out means N notifications for N independent questions — expected, since they were N distinct asks; the same-thread consolidation above is what prevents notification spam for follow-ups.

Related: MUL-4348, builds on the coalesced-comments infrastructure (MUL-4195, PR #5192).
