### PR TITLE
MUL-4369: fix(daemon): keep the task transcript ordered and complete

### DIFF
--- a/server/internal/daemon/daemon.go
+++ b/server/internal/daemon/daemon.go
@@ -3941,7 +3941,10 @@ func (d *Daemon) runTask(ctx context.Context, task Task, provider string, slot i
 		"timeout", execOpts.Timeout,
 	)
 
-	result, tools, err := d.executeAndDrain(ctx, backend, prompt, execOpts, taskLog, task.ID)
+	// Shared across the resume-retry below so the retry's transcript rows
+	// keep ascending seq values for the same task.
+	var msgSeq atomic.Int32
+	result, tools, err := d.executeAndDrain(ctx, backend, prompt, execOpts, taskLog, task.ID, &msgSeq)
 	if err != nil {
 		return TaskResult{}, err
 	}
@@ -3953,7 +3956,7 @@ func (d *Daemon) runTask(ctx context.Context, task Task, provider string, slot i
 		firstUsage := result.Usage
 		taskLog.Warn("session resume failed, retrying with fresh session", "error", result.Error)
 		execOpts.ResumeSessionID = ""
-		retryResult, retryTools, retryErr := d.executeAndDrain(ctx, backend, prompt, execOpts, taskLog, task.ID)
+		retryResult, retryTools, retryErr := d.executeAndDrain(ctx, backend, prompt, execOpts, taskLog, task.ID, &msgSeq)
 		if retryErr != nil {
 			taskLog.Error("fresh session also failed to start", "error", retryErr)
 		} else {
@@ -4145,8 +4148,11 @@ func (d *Daemon) runTask(ctx context.Context, task Task, provider string, slot i
 }
 
 // executeAndDrain runs a backend, drains its message stream (forwarding to the
-// server), and waits for the final result.
-func (d *Daemon) executeAndDrain(ctx context.Context, backend agent.Backend, prompt string, opts agent.ExecOptions, taskLog *slog.Logger, taskID string) (agent.Result, int32, error) {
+// server), and waits for the final result. msgSeq numbers the reported task
+// messages and is owned by the caller so a same-task retry continues the
+// sequence instead of restarting at 1 — the server orders the transcript by
+// seq alone, and duplicate seqs would interleave the two attempts' rows.
+func (d *Daemon) executeAndDrain(ctx context.Context, backend agent.Backend, prompt string, opts agent.ExecOptions, taskLog *slog.Logger, taskID string, msgSeq *atomic.Int32) (agent.Result, int32, error) {
 	// Wrap the caller's ctx so the idle watchdog (below) can interrupt both
 	// the agent subprocess (via the ctx passed to backend.Execute) AND the
 	// drain loop with a single cancel. Without this layer the backend would
@@ -4211,7 +4217,6 @@ func (d *Daemon) executeAndDrain(ctx context.Context, backend agent.Backend, pro
 	drainFinished := make(chan struct{})
 	go func() {
 		defer close(drainFinished)
-		var seq atomic.Int32
 		var mu sync.Mutex
 		var pendingText strings.Builder
 		var pendingThinking strings.Builder
@@ -4221,7 +4226,7 @@ func (d *Daemon) executeAndDrain(ctx context.Context, backend agent.Backend, pro
 		flush := func() {
 			mu.Lock()
 			if pendingThinking.Len() > 0 {
-				s := seq.Add(1)
+				s := msgSeq.Add(1)
 				batch = append(batch, TaskMessageData{
 					Seq:     int(s),
 					Type:    "thinking",
@@ -4230,7 +4235,7 @@ func (d *Daemon) executeAndDrain(ctx context.Context, backend agent.Backend, pro
 				pendingThinking.Reset()
 			}
 			if pendingText.Len() > 0 {
-				s := seq.Add(1)
+				s := msgSeq.Add(1)
 				batch = append(batch, TaskMessageData{
 					Seq:     int(s),
 					Type:    "text",
@@ -4309,7 +4314,7 @@ func (d *Daemon) executeAndDrain(ctx context.Context, backend agent.Backend, pro
 						callIDToTool[msg.CallID] = msg.Tool
 						mu.Unlock()
 					}
-					s := seq.Add(1)
+					s := msgSeq.Add(1)
 					mu.Lock()
 					batch = append(batch, TaskMessageData{
 						Seq:   int(s),
@@ -4333,7 +4338,7 @@ func (d *Daemon) executeAndDrain(ctx context.Context, backend agent.Backend, pro
 							break
 						}
 					}
-					s := seq.Add(1)
+					s := msgSeq.Add(1)
 					output := msg.Output
 					if len(output) > 8192 {
 						output = output[:8192]
@@ -4368,7 +4373,7 @@ func (d *Daemon) executeAndDrain(ctx context.Context, backend agent.Backend, pro
 					}
 				case agent.MessageError:
 					taskLog.Error("agent error", "content", msg.Content)
-					s := seq.Add(1)
+					s := msgSeq.Add(1)
 					mu.Lock()
 					batch = append(batch, TaskMessageData{
 						Seq:     int(s),

--- a/server/internal/daemon/daemon.go
+++ b/server/internal/daemon/daemon.go
@@ -4395,22 +4395,20 @@ func (d *Daemon) executeAndDrain(ctx context.Context, backend agent.Backend, pro
 		flush()
 	}()
 
-	select {
-	case result := <-session.Result:
-		// Wait for the drain goroutine to flush the transcript tail before
-		// handing the result back: a consumer that reads the task's messages
-		// on completion would otherwise see a transcript that is non-empty but
-		// truncated, indistinguishable from a complete one. Bounded so a
-		// backend that never closes its message channel cannot stall
-		// completion.
+	// waitForDrain blocks until the drain goroutine has flushed the transcript
+	// tail, so every terminal return below hands control back only after the
+	// task's reported messages are persisted — a consumer reading them at the
+	// terminal transition would otherwise see a transcript that is non-empty
+	// but truncated, indistinguishable from a complete one. Bounded so a
+	// backend that never closes its message channel cannot stall the terminal
+	// transition: after 10s the drain loop is cancelled and given a window
+	// wide enough for its worst-case exit — an in-flight tick flush plus the
+	// final one, each capped by the 5s ReportTaskMessages timeout and neither
+	// interruptible by the cancel (they post on context.Background()).
+	waitForDrain := func() {
 		select {
 		case <-drainFinished:
 		case <-time.After(10 * time.Second):
-			// Stop the drain loop and give it a bounded window to land its
-			// last batch, wide enough for its worst-case exit: an in-flight
-			// tick flush plus the final one, each capped by the 5s
-			// ReportTaskMessages timeout and neither interruptible by the
-			// cancel below (they post on context.Background()).
 			drainCancel()
 			select {
 			case <-drainFinished:
@@ -4418,6 +4416,11 @@ func (d *Daemon) executeAndDrain(ctx context.Context, backend agent.Backend, pro
 				taskLog.Warn("transcript drain did not stop after cancel; completing anyway")
 			}
 		}
+	}
+
+	select {
+	case result := <-session.Result:
+		waitForDrain()
 		if idleWatchdogFired.Load() {
 			// The backend's wait goroutine (e.g. claude.go) translates the
 			// SIGKILL we delivered via agentCancel into Status="aborted".
@@ -4431,6 +4434,11 @@ func (d *Daemon) executeAndDrain(ctx context.Context, backend agent.Backend, pro
 		}
 		return result, toolCount.Load(), nil
 	case <-drainCtx.Done():
+		// The drain loop is exiting on this same Done signal; wait for its
+		// final flush so the timeout/watchdog/cancel terminals below cannot
+		// hand back (and let runTask fail-and-broadcast) a still-flushing
+		// transcript either.
+		waitForDrain()
 		// Idle watchdog cancels via agentCancel(), which propagates here as
 		// context.Canceled. Check this BEFORE the generic cancelled/timeout
 		// classifiers so a watchdog-induced stop isn't misreported as

--- a/server/internal/daemon/daemon.go
+++ b/server/internal/daemon/daemon.go
@@ -4205,7 +4205,12 @@ func (d *Daemon) executeAndDrain(ctx context.Context, backend agent.Backend, pro
 		go d.runIdleWatchdog(agentCtx, idleWindow, d.cfg.AgentToolWatchdog, &lastActivityAt, &inFlightTools, &idleWatchdogFired, &idleWatchdogThreshold, agentCancel, session.Messages, taskLog, taskID)
 	}
 
+	// drainFinished closes after the drain goroutine has flushed the last
+	// message batch, so the result hand-off below can wait for the transcript
+	// tail to be persisted.
+	drainFinished := make(chan struct{})
 	go func() {
+		defer close(drainFinished)
 		var seq atomic.Int32
 		var mu sync.Mutex
 		var pendingText strings.Builder
@@ -4252,7 +4257,9 @@ func (d *Daemon) executeAndDrain(ctx context.Context, backend agent.Backend, pro
 		defer ticker.Stop()
 
 		done := make(chan struct{})
+		tickerDone := make(chan struct{})
 		go func() {
+			defer close(tickerDone)
 			for {
 				select {
 				case <-ticker.C:
@@ -4376,11 +4383,36 @@ func (d *Daemon) executeAndDrain(ctx context.Context, backend agent.Backend, pro
 		}
 	drainDone:
 		close(done)
+		// Let any tick-driven flush finish before the final one: a flush still
+		// in flight would otherwise keep posting batches after this goroutine
+		// signalled that the transcript tail was persisted.
+		<-tickerDone
 		flush()
 	}()
 
 	select {
 	case result := <-session.Result:
+		// Wait for the drain goroutine to flush the transcript tail before
+		// handing the result back: a consumer that reads the task's messages
+		// on completion would otherwise see a transcript that is non-empty but
+		// truncated, indistinguishable from a complete one. Bounded so a
+		// backend that never closes its message channel cannot stall
+		// completion.
+		select {
+		case <-drainFinished:
+		case <-time.After(10 * time.Second):
+			// Stop the drain loop and give it a bounded window to land its
+			// last batch, wide enough for its worst-case exit: an in-flight
+			// tick flush plus the final one, each capped by the 5s
+			// ReportTaskMessages timeout and neither interruptible by the
+			// cancel below (they post on context.Background()).
+			drainCancel()
+			select {
+			case <-drainFinished:
+			case <-time.After(12 * time.Second):
+				taskLog.Warn("transcript drain did not stop after cancel; completing anyway")
+			}
+		}
 		if idleWatchdogFired.Load() {
 			// The backend's wait goroutine (e.g. claude.go) translates the
 			// SIGKILL we delivered via agentCancel into Status="aborted".

--- a/server/internal/daemon/daemon_test.go
+++ b/server/internal/daemon/daemon_test.go
@@ -13,6 +13,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"runtime"
+	"slices"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -1100,6 +1101,84 @@ func TestExecuteAndDrain_ResumeFailureFallback(t *testing.T) {
 	// Second call should NOT have ResumeSessionID.
 	if fb.calls[1].ResumeSessionID != "" {
 		t.Fatal("retry should not have ResumeSessionID")
+	}
+}
+
+// transcriptBackend emits a tool_use and a text message before returning its
+// result — the first call fails like a broken resume, the second completes.
+type transcriptBackend struct {
+	calls atomic.Int32
+}
+
+func (b *transcriptBackend) Execute(_ context.Context, _ string, _ agent.ExecOptions) (*agent.Session, error) {
+	n := b.calls.Add(1)
+	msgCh := make(chan agent.Message, 2)
+	msgCh <- agent.Message{Type: agent.MessageToolUse, Tool: "bash"}
+	msgCh <- agent.Message{Type: agent.MessageText, Content: fmt.Sprintf("attempt %d", n)}
+	close(msgCh)
+	resCh := make(chan agent.Result, 1)
+	if n == 1 {
+		resCh <- agent.Result{Status: "failed", Error: "session not found"}
+	} else {
+		resCh <- agent.Result{Status: "completed", Output: "done", SessionID: "sess-2"}
+	}
+	return &agent.Session{Messages: msgCh, Result: resCh}, nil
+}
+
+// transcriptRecorder collects the task messages a daemon reports to its
+// message endpoint.
+type transcriptRecorder struct {
+	mu       sync.Mutex
+	messages []TaskMessageData
+}
+
+func (r *transcriptRecorder) snapshot() []TaskMessageData {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return slices.Clone(r.messages)
+}
+
+// newTranscriptRecorder returns a daemon whose message endpoint appends every
+// reported batch to the returned recorder.
+func newTranscriptRecorder(t *testing.T) (*Daemon, *transcriptRecorder) {
+	t.Helper()
+	rec := &transcriptRecorder{}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.HasSuffix(r.URL.Path, "/messages") {
+			var body struct {
+				Messages []TaskMessageData `json:"messages"`
+			}
+			if err := json.NewDecoder(r.Body).Decode(&body); err == nil {
+				rec.mu.Lock()
+				rec.messages = append(rec.messages, body.Messages...)
+				rec.mu.Unlock()
+			}
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(srv.Close)
+	return &Daemon{client: NewClient(srv.URL), logger: slog.Default()}, rec
+}
+
+// TestExecuteAndDrain_FlushesTranscriptBeforeReturningResult pins the
+// completion contract: once the agent result is handed back, the task's
+// messages have been reported. Without the wait the drain goroutine is still
+// in flight, so a consumer reading the transcript sees it truncated.
+func TestExecuteAndDrain_FlushesTranscriptBeforeReturningResult(t *testing.T) {
+	t.Parallel()
+
+	d, rec := newTranscriptRecorder(t)
+
+	result, _, err := d.executeAndDrain(context.Background(), &transcriptBackend{}, "p", agent.ExecOptions{}, slog.Default(), "task-flush")
+	if err != nil {
+		t.Fatalf("executeAndDrain: %v", err)
+	}
+	if result.Status != "failed" {
+		t.Fatalf("expected the backend's result, got %+v", result)
+	}
+
+	if got := rec.snapshot(); len(got) != 2 {
+		t.Fatalf("expected the transcript flushed before the result hand-off, got %d messages: %+v", len(got), got)
 	}
 }
 

--- a/server/internal/daemon/daemon_test.go
+++ b/server/internal/daemon/daemon_test.go
@@ -1221,6 +1221,62 @@ func TestExecuteAndDrain_SeqContinuesAcrossRetry(t *testing.T) {
 	}
 }
 
+// sessionBackend hands out a pre-built session, leaving the test in control
+// of message and result delivery.
+type sessionBackend struct {
+	session *agent.Session
+}
+
+func (b sessionBackend) Execute(_ context.Context, _ string, _ agent.ExecOptions) (*agent.Session, error) {
+	return b.session, nil
+}
+
+// TestExecuteAndDrain_ContextCancelled_FlushesPendingTranscript pins the same
+// flush-before-return contract for the drainCtx.Done() terminal: when a
+// cancellation (or timeout/watchdog) ends the run with a message still
+// pending, executeAndDrain must not return until that tail is reported —
+// otherwise runTask fails-and-broadcasts while the last batch is in flight.
+func TestExecuteAndDrain_ContextCancelled_FlushesPendingTranscript(t *testing.T) {
+	t.Parallel()
+
+	d, rec := newTranscriptRecorder(t)
+
+	// Unbuffered: the send below returns only once the drain loop has
+	// consumed the message. The result channel never delivers, so only the
+	// context cancellation can end the drain.
+	msgCh := make(chan agent.Message)
+	b := sessionBackend{session: &agent.Session{Messages: msgCh, Result: make(chan agent.Result)}}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	type ret struct {
+		result agent.Result
+		err    error
+	}
+	retCh := make(chan ret, 1)
+	go func() {
+		result, _, err := d.executeAndDrain(ctx, b, "p", agent.ExecOptions{}, slog.Default(), "task-cancel-flush", new(atomic.Int32))
+		retCh <- ret{result, err}
+	}()
+
+	msgCh <- agent.Message{Type: agent.MessageText, Content: "pending tail"}
+	cancel()
+
+	r := <-retCh
+	if r.err != nil {
+		t.Fatalf("executeAndDrain: %v", r.err)
+	}
+	if r.result.Status != "cancelled" {
+		t.Fatalf("expected status=cancelled, got %q (err=%q)", r.result.Status, r.result.Error)
+	}
+
+	got := rec.snapshot()
+	if len(got) != 1 || got[0].Type != "text" || got[0].Content != "pending tail" {
+		t.Fatalf("expected the pending tail flushed before the cancelled return, got %+v", got)
+	}
+}
+
 func TestExecuteAndDrain_NoRetryWhenSessionEstablished(t *testing.T) {
 	t.Parallel()
 

--- a/server/internal/daemon/daemon_test.go
+++ b/server/internal/daemon/daemon_test.go
@@ -1068,7 +1068,8 @@ func TestExecuteAndDrain_ResumeFailureFallback(t *testing.T) {
 
 	// First attempt: resume fails (no SessionID in result).
 	opts := agent.ExecOptions{ResumeSessionID: "stale-id"}
-	result, _, err := d.executeAndDrain(ctx, fb, "prompt", opts, taskLog, "task-1")
+	var msgSeq atomic.Int32
+	result, _, err := d.executeAndDrain(ctx, fb, "prompt", opts, taskLog, "task-1", &msgSeq)
 	if err != nil {
 		t.Fatalf("first call error: %v", err)
 	}
@@ -1080,7 +1081,7 @@ func TestExecuteAndDrain_ResumeFailureFallback(t *testing.T) {
 	if result.Status == "failed" && result.SessionID == "" {
 		firstUsage := result.Usage
 		opts.ResumeSessionID = ""
-		retryResult, _, retryErr := d.executeAndDrain(ctx, fb, "prompt", opts, taskLog, "task-1")
+		retryResult, _, retryErr := d.executeAndDrain(ctx, fb, "prompt", opts, taskLog, "task-1", &msgSeq)
 		if retryErr != nil {
 			t.Fatalf("retry error: %v", retryErr)
 		}
@@ -1169,7 +1170,7 @@ func TestExecuteAndDrain_FlushesTranscriptBeforeReturningResult(t *testing.T) {
 
 	d, rec := newTranscriptRecorder(t)
 
-	result, _, err := d.executeAndDrain(context.Background(), &transcriptBackend{}, "p", agent.ExecOptions{}, slog.Default(), "task-flush")
+	result, _, err := d.executeAndDrain(context.Background(), &transcriptBackend{}, "p", agent.ExecOptions{}, slog.Default(), "task-flush", new(atomic.Int32))
 	if err != nil {
 		t.Fatalf("executeAndDrain: %v", err)
 	}
@@ -1179,6 +1180,44 @@ func TestExecuteAndDrain_FlushesTranscriptBeforeReturningResult(t *testing.T) {
 
 	if got := rec.snapshot(); len(got) != 2 {
 		t.Fatalf("expected the transcript flushed before the result hand-off, got %d messages: %+v", len(got), got)
+	}
+}
+
+// TestExecuteAndDrain_SeqContinuesAcrossRetry pins the transcript's ordering
+// key: the server sorts a task's messages by seq alone, so a same-task resume
+// retry must keep numbering upwards instead of restarting at 1 and
+// interleaving its rows with the failed attempt's.
+func TestExecuteAndDrain_SeqContinuesAcrossRetry(t *testing.T) {
+	t.Parallel()
+
+	d, rec := newTranscriptRecorder(t)
+	fb := &transcriptBackend{}
+	var msgSeq atomic.Int32
+
+	result, _, err := d.executeAndDrain(context.Background(), fb, "p", agent.ExecOptions{ResumeSessionID: "stale"}, slog.Default(), "task-seq", &msgSeq)
+	if err != nil {
+		t.Fatalf("first call: %v", err)
+	}
+	if result.Status != "failed" {
+		t.Fatalf("expected failed first result, got %+v", result)
+	}
+
+	result, _, err = d.executeAndDrain(context.Background(), fb, "p", agent.ExecOptions{}, slog.Default(), "task-seq", &msgSeq)
+	if err != nil {
+		t.Fatalf("retry: %v", err)
+	}
+	if result.Status != "completed" {
+		t.Fatalf("expected completed retry result, got %+v", result)
+	}
+
+	got := rec.snapshot()
+	if len(got) != 4 {
+		t.Fatalf("expected 4 messages total, got %d: %+v", len(got), got)
+	}
+	for i, m := range got {
+		if m.Seq != i+1 {
+			t.Fatalf("expected strictly ascending seq across the retry, got %+v", got)
+		}
 	}
 }
 
@@ -1194,7 +1233,7 @@ func TestExecuteAndDrain_NoRetryWhenSessionEstablished(t *testing.T) {
 	}
 
 	opts := agent.ExecOptions{ResumeSessionID: "some-id"}
-	result, _, err := d.executeAndDrain(context.Background(), fb, "p", opts, slog.Default(), "t")
+	result, _, err := d.executeAndDrain(context.Background(), fb, "p", opts, slog.Default(), "t", new(atomic.Int32))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1264,7 +1303,7 @@ func TestExecuteAndDrain_CodexInactivityReportsToolResultTranscript(t *testing.T
 	result, tools, err := d.executeAndDrain(context.Background(), backend, "prompt", agent.ExecOptions{
 		Timeout:                   5 * time.Second,
 		SemanticInactivityTimeout: 100 * time.Millisecond,
-	}, slog.Default(), "task-stale")
+	}, slog.Default(), "task-stale", new(atomic.Int32))
 	if err != nil {
 		t.Fatalf("executeAndDrain: %v", err)
 	}
@@ -1319,7 +1358,7 @@ func TestExecuteAndDrain_ContextCancelled_ReportsCancelled(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 
-	result, _, err := d.executeAndDrain(ctx, blockingBackend{}, "p", agent.ExecOptions{}, slog.Default(), "t")
+	result, _, err := d.executeAndDrain(ctx, blockingBackend{}, "p", agent.ExecOptions{}, slog.Default(), "t", new(atomic.Int32))
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -1358,7 +1397,7 @@ func TestExecuteAndDrain_IdleWatchdog_FiresOnInactivity(t *testing.T) {
 	t.Cleanup(cancel)
 
 	start := time.Now()
-	result, _, err := d.executeAndDrain(ctx, idleWatchdogBackend{emitOne: true}, "p", agent.ExecOptions{}, slog.Default(), "t-idle")
+	result, _, err := d.executeAndDrain(ctx, idleWatchdogBackend{emitOne: true}, "p", agent.ExecOptions{}, slog.Default(), "t-idle", new(atomic.Int32))
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -1388,7 +1427,7 @@ func TestExecuteAndDrain_IdleWatchdog_FiresWhenNoMessageEverArrives(t *testing.T
 	// emitOne=false models a backend that hangs before sending any message.
 	// lastActivityAt is initialised at executeAndDrain entry, so the same
 	// window applies even with zero traffic.
-	result, _, err := d.executeAndDrain(ctx, idleWatchdogBackend{emitOne: false}, "p", agent.ExecOptions{}, slog.Default(), "t-idle-zero")
+	result, _, err := d.executeAndDrain(ctx, idleWatchdogBackend{emitOne: false}, "p", agent.ExecOptions{}, slog.Default(), "t-idle-zero", new(atomic.Int32))
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -1409,7 +1448,7 @@ func TestExecuteAndDrain_IdleWatchdog_DisabledWhenZero(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	time.AfterFunc(80*time.Millisecond, cancel)
 
-	result, _, err := d.executeAndDrain(ctx, idleWatchdogBackend{emitOne: true}, "p", agent.ExecOptions{}, slog.Default(), "t-idle-off")
+	result, _, err := d.executeAndDrain(ctx, idleWatchdogBackend{emitOne: true}, "p", agent.ExecOptions{}, slog.Default(), "t-idle-off", new(atomic.Int32))
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -1435,7 +1474,7 @@ func TestExecuteAndDrain_IdleWatchdog_HappyPathDoesNotFire(t *testing.T) {
 		},
 	}
 
-	result, _, err := d.executeAndDrain(context.Background(), fb, "p", agent.ExecOptions{}, slog.Default(), "t-idle-happy")
+	result, _, err := d.executeAndDrain(context.Background(), fb, "p", agent.ExecOptions{}, slog.Default(), "t-idle-happy", new(atomic.Int32))
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -1508,6 +1547,7 @@ func TestExecuteAndDrain_IdleWatchdog_DoesNotFireDuringInFlightToolCall(t *testi
 		agent.ExecOptions{},
 		slog.Default(),
 		"t-long-tool",
+		new(atomic.Int32),
 	)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -1547,7 +1587,7 @@ func TestExecuteAndDrain_IdleWatchdog_FiresOnStuckInFlightTool(t *testing.T) {
 	t.Cleanup(cancel)
 
 	start := time.Now()
-	result, _, err := d.executeAndDrain(ctx, stuckInFlightToolBackend{}, "p", agent.ExecOptions{}, slog.Default(), "t-stuck-tool")
+	result, _, err := d.executeAndDrain(ctx, stuckInFlightToolBackend{}, "p", agent.ExecOptions{}, slog.Default(), "t-stuck-tool", new(atomic.Int32))
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -1583,7 +1623,7 @@ func TestExecuteAndDrain_IdleWatchdog_FiresAfterToolResultIfBackendStaysSilent(t
 	ctx, cancel := context.WithCancel(context.Background())
 	t.Cleanup(cancel)
 
-	result, _, err := d.executeAndDrain(ctx, tailIdleAfterToolBackend{}, "p", agent.ExecOptions{}, slog.Default(), "t-tail-idle")
+	result, _, err := d.executeAndDrain(ctx, tailIdleAfterToolBackend{}, "p", agent.ExecOptions{}, slog.Default(), "t-tail-idle", new(atomic.Int32))
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}


### PR DESCRIPTION
## What does this PR do?

Fixes two daemon-side gaps that let a task's persisted transcript misrepresent the run:

1. **Flush the transcript before reporting any terminal state.** `executeAndDrain` handed control back while the drain goroutine was still flushing its final message batch — on the `session.Result` hand-off and equally on the `drainCtx.Done()` exits (wall-clock timeout, idle watchdog, upstream cancellation), where `runTask` could call `FailTask` and broadcast while the tail was still posting. A consumer reading the task's messages at the terminal transition (e.g. the web client refetching on `task:completed`) could see a transcript that is non-empty but missing its tail, with no way to tell it apart from a complete one. The fix waits for the drain to land its last batch before returning from **both** terminal branches, via a shared bounded helper (10s, then cancel + 12s) so a backend that never closes its message channel cannot stall the terminal transition. The drain also joins its tick-flush goroutine before the final flush, so an in-flight tick flush cannot post a batch after the drain has signalled that the tail is persisted.

   **Scope note:** this guarantees the transcript is flushed before the *daemon* reports a terminal state. It does not cover server-initiated cancellation: `finalizeCancelledChatMessage` reads the transcript on the server when the cancellation is committed, before the daemon observes it, so that read can still see a truncated transcript. That needs a server-side coordination mechanism and is tracked separately in #5219.

2. **Continue the seq counter across a resume retry.** The counter numbering reported messages was local to `executeAndDrain`, so the resume-failure retry in `runTask` restarted it at 1 for the same task. `task_message` has no unique `(task_id, seq)` constraint and `ListTaskMessages` orders by `seq` alone, so the two attempts' rows interleaved nondeterministically. The counter is now owned by `runTask` and shared across both attempts, so the retry keeps numbering upwards from where the failed attempt stopped.

Waiting on the drain (rather than, say, having the server tolerate late messages) is the right layer because the daemon is the only party that knows when the tail is persisted; the alternative would push an "is this transcript complete yet?" protocol onto every consumer. Sharing the counter from the caller (rather than adding a DB-side unique constraint plus conflict handling) fixes the ordering at its source and keeps `seq` meaningful as a total order per task.

## Related Issue

Closes #5209

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Refactor / code improvement (no behavior change)
- [ ] Documentation update
- [ ] Tests (adding or improving test coverage)
- [ ] CI / infrastructure

## Changes Made

- `server/internal/daemon/daemon.go`
  - `executeAndDrain`: added a `drainFinished` channel closed after the drain goroutine's final flush, and a `waitForDrain` helper (10s, then `drainCancel()` + 12s, then a warning log) called from **both** terminal branches — the `session.Result` hand-off and the `drainCtx.Done()` exit — so no terminal return can precede the transcript tail.
  - The drain goroutine now joins its tick-flush goroutine (`tickerDone`) before running the final flush.
  - `executeAndDrain` takes a caller-owned `msgSeq *atomic.Int32`; `runTask` creates it once and passes the same counter to both the initial attempt and the resume-failure retry.
- `server/internal/daemon/daemon_test.go`
  - `TestExecuteAndDrain_FlushesTranscriptBeforeReturningResult`: pins that the reported messages are persisted before the result is handed back.
  - `TestExecuteAndDrain_ContextCancelled_FlushesPendingTranscript`: pins the same contract for the `drainCtx.Done()` terminal — cancels with a message pending (unbuffered channel, so the drain loop has provably consumed it) and asserts the tail is reported before the cancelled return.
  - `TestExecuteAndDrain_SeqContinuesAcrossRetry`: pins that seq values stay strictly ascending across a same-task retry.
  - Shared fixtures: `transcriptBackend` (emits a tool_use + text before its result), `sessionBackend` (test-controlled message/result channels), and `newTranscriptRecorder` (a daemon whose message endpoint records every reported batch behind a `snapshot()` accessor).

## How to Test

1. `cd server && go test -race -run 'TestExecuteAndDrain' ./internal/daemon/` — the flush tests fail without the terminal-branch waits (verified by removing the wait and re-running), and the seq test fails without the shared counter.
2. `cd server && go test -race ./internal/daemon/` — full package passes.
3. Manual: run a chat/issue task against a daemon whose session state was wiped (forcing the resume-retry), then open the task transcript — messages appear once, in order, with no interleaving; the transcript is already complete when the `task:completed` event arrives.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots (N/A — daemon-only)
- [ ] I have updated relevant documentation to reflect my changes (N/A — no documented behavior changes)
- [ ] If I added a new runtime / coding tool / UI tab, I synced the change to **landing copy** (`apps/web/features/landing/i18n/`) and **relevant docs** (`apps/docs/content/docs/`) (N/A)
- [ ] If this PR touches Chinese product copy, I checked it against `apps/docs/content/docs/developers/conventions.zh.mdx` (terminology, mixed-rule for `task` / `issue` / `skill`) (N/A)
- [x] I have considered and documented any risks above
- [x] I will address all reviewer comments before requesting merge

**Thinking path:** the server persists task messages (`task_message`) as the durable record of an agent run, and both the web client and server-side flows read that record at terminal transitions. Tracing who writes it led to `executeAndDrain`'s drain goroutine, which revealed (a) the terminal returns do not synchronize with the final flush, and (b) the seq counter's lifetime is one `executeAndDrain` call while a task can span two (resume + retry). Each gap independently breaks the invariant "the persisted transcript faithfully represents the run"; review then caught that the flush wait initially covered only the `session.Result` branch, so it was factored into a helper shared with the `drainCtx.Done()` branch.

**Risk considered:** the new wait sits on every terminal path. It is bounded twice (10s + 12s) and both timeouts only trigger when the drain is stuck past its own flush caps, in which case the previous behavior (terminal transition with a possibly-truncated transcript) is preserved, now with a warning log. On the `drainCtx.Done()` path the drain loop exits on the same signal, so the wait normally lasts only as long as the final flush.

## AI Disclosure

**AI tool used:** Claude Code

**Prompt / approach:** Asked Claude Code to investigate why task transcripts occasionally rendered incomplete or out of order, starting from the transcript consumers (`ListTaskMessages`, the web realtime invalidation) and tracing back to the daemon's drain loop. It identified the two races, wrote the failing regression tests first, then the fixes. Review-fix round: verified the reviewer's finding that the `drainCtx.Done()` branch skipped the wait, factored the bounded wait into a shared helper, added the pending-tail cancellation regression test (confirmed to fail without the fix), and narrowed the cancellation claim in this description.
