### PR TITLE
[MUL-4348] Authorize + chronologically order per-thread coalesced replies

### DIFF
--- a/server/internal/daemon/execenv/reply_instructions.go
+++ b/server/internal/daemon/execenv/reply_instructions.go
@@ -229,8 +229,8 @@ func BuildMultiThreadCommentReplyInstructions(issueID string, targets []ThreadRe
 	}
 
 	targetLines := ""
-	for _, tgt := range targets {
-		targetLines += fmt.Sprintf("- thread %s → reply with `--parent %s`\n", tgt.ThreadID, tgt.ParentID)
+	for i, tgt := range targets {
+		targetLines += fmt.Sprintf("%d. thread %s → reply with `--parent %s`\n", i+1, tgt.ThreadID, tgt.ParentID)
 	}
 
 	// File-hygiene guidance mirrors buildCommentReplyInstructionsSlim, but the
@@ -259,7 +259,8 @@ func BuildMultiThreadCommentReplyInstructions(issueID string, targets []ThreadRe
 
 	return fmt.Sprintf(
 		"This run coalesced comments from %d DISTINCT threads. Post ONE reply per thread — %d replies in total — each threaded under its own conversation. This OVERRIDES the general \"post exactly one comment per run\" guidance: for THIS run multiple replies are required and correct. Do NOT merge separate threads into a single comment, and do NOT post more than one reply in the same thread.\n\n"+
-			"Reply targets (use the exact `--parent` for each — do NOT reuse `--parent` values from previous turns in this session):\n"+
+			"Post the replies in the order listed below — OLDEST thread first, the newest (triggering) thread LAST — so they land in chronological order. Do NOT answer the newest/triggering comment first.\n\n"+
+			"Reply targets, in the order to post them (use the exact `--parent` for each — do NOT reuse `--parent` values from previous turns in this session):\n"+
 			"%s\n"+
 			"%s"+
 			"Do NOT write literal `\\n` escapes to simulate line breaks; each file preserves real newlines.\n",

--- a/server/internal/daemon/prompt_test.go
+++ b/server/internal/daemon/prompt_test.go
@@ -817,6 +817,19 @@ func TestBuildCommentPromptCrossThreadFansOutReplies(t *testing.T) {
 	if strings.Contains(out, "always use the trigger comment ID below") {
 		t.Errorf("cross-thread prompt must not emit the single-parent reply cookbook, got:\n%s", out)
 	}
+
+	// Chronological ordering (MUL-4348 test-round-2 problem #1): replies must be
+	// posted oldest thread first, the newest (triggering) thread last — so the
+	// coalesced comments c1 (oldest) and c2 come before the trigger c3.
+	if !strings.Contains(out, "OLDEST thread first") {
+		t.Errorf("cross-thread prompt must instruct oldest-first chronological order, got:\n%s", out)
+	}
+	posC1 := strings.Index(out, "--parent c1")
+	posC2 := strings.Index(out, "--parent c2")
+	posC3 := strings.Index(out, "--parent c3")
+	if !(posC1 >= 0 && posC1 < posC2 && posC2 < posC3) {
+		t.Errorf("reply targets must be listed oldest-first (c1 < c2 < c3); got positions c1=%d c2=%d c3=%d\n%s", posC1, posC2, posC3, out)
+	}
 }
 
 // TestBuildCommentPromptSameThreadKeepsSingleReply pins the hard requirement:

--- a/server/internal/handler/comment.go
+++ b/server/internal/handler/comment.go
@@ -1155,6 +1155,33 @@ func (h *Handler) PreviewCommentTriggers(w http.ResponseWriter, r *http.Request)
 	writeJSON(w, http.StatusOK, resp)
 }
 
+// taskCoversReplyParent reports whether parentID is a comment this task is
+// authorized to reply under. A comment-triggered task may reply to its trigger
+// comment OR to any earlier comment that was folded into the same run while it
+// was still queued (coalesced_comment_ids). A coalesced run answers each root
+// thread it covered inside that thread, so its replies legitimately target
+// those threads' comments — not just the trigger (MUL-4348 per-thread fan-out).
+//
+// Every other parent on the task's own issue is still rejected: this is the
+// defense against resumed-session --parent drift and cross-thread misplacement.
+// The allow-list is exactly the set the run was given to answer, so it cannot
+// reach arbitrary comments.
+func taskCoversReplyParent(task db.AgentTaskQueue, parentID pgtype.UUID) bool {
+	if !parentID.Valid {
+		return false
+	}
+	target := uuidToString(parentID)
+	if task.TriggerCommentID.Valid && uuidToString(task.TriggerCommentID) == target {
+		return true
+	}
+	for _, id := range task.CoalescedCommentIds {
+		if id.Valid && uuidToString(id) == target {
+			return true
+		}
+	}
+	return false
+}
+
 func (h *Handler) CreateComment(w http.ResponseWriter, r *http.Request) {
 	issueID := chi.URLParam(r, "id")
 	issue, ok := h.loadIssueForUser(w, r, issueID)
@@ -1237,9 +1264,9 @@ func (h *Handler) CreateComment(w http.ResponseWriter, r *http.Request) {
 				task, err := h.Queries.GetAgentTask(r.Context(), taskUUID)
 				if err == nil && task.IssueID.Valid && uuidToString(task.IssueID) == uuidToString(issue.ID) {
 					if task.TriggerCommentID.Valid {
-						if uuidToString(parentID) != uuidToString(task.TriggerCommentID) {
+						if !taskCoversReplyParent(task, parentID) {
 							writeError(w, http.StatusConflict,
-								"parent_id must equal this task's trigger comment id ("+uuidToString(task.TriggerCommentID)+")")
+								"parent_id must be this task's trigger comment id ("+uuidToString(task.TriggerCommentID)+") or one of the earlier comments it coalesced")
 							return
 						}
 					}

--- a/server/internal/handler/comment_reply_authz_test.go
+++ b/server/internal/handler/comment_reply_authz_test.go
@@ -1,0 +1,55 @@
+package handler
+
+import (
+	"testing"
+
+	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/multica-ai/multica/server/internal/util"
+	db "github.com/multica-ai/multica/server/pkg/db/generated"
+)
+
+// TestTaskCoversReplyParent pins the comment-reply authorization allow-list
+// (MUL-4348): a comment-triggered task may reply under its trigger comment OR
+// under any earlier comment it coalesced, and nothing else. This is what lets
+// a coalesced cross-thread run answer each thread in its own thread instead of
+// being rejected with "parent_id must equal this task's trigger comment id".
+func TestTaskCoversReplyParent(t *testing.T) {
+	trigger := "11111111-1111-1111-1111-111111111111"
+	c1 := "22222222-2222-2222-2222-222222222222"
+	c2 := "33333333-3333-3333-3333-333333333333"
+	stranger := "99999999-9999-9999-9999-999999999999"
+
+	task := db.AgentTaskQueue{
+		TriggerCommentID: util.MustParseUUID(trigger),
+		CoalescedCommentIds: []pgtype.UUID{
+			util.MustParseUUID(c1),
+			util.MustParseUUID(c2),
+		},
+	}
+
+	cases := []struct {
+		name   string
+		parent pgtype.UUID
+		want   bool
+	}{
+		{"trigger comment allowed", util.MustParseUUID(trigger), true},
+		{"first coalesced comment allowed", util.MustParseUUID(c1), true},
+		{"second coalesced comment allowed", util.MustParseUUID(c2), true},
+		{"unrelated comment rejected", util.MustParseUUID(stranger), false},
+		{"invalid/empty parent rejected", pgtype.UUID{}, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := taskCoversReplyParent(task, tc.parent); got != tc.want {
+				t.Errorf("taskCoversReplyParent(%s) = %v, want %v", uuidToString(tc.parent), got, tc.want)
+			}
+		})
+	}
+
+	// An assignment-triggered task (no trigger comment, no coalesced set) covers
+	// nothing here; the caller only consults this when TriggerCommentID is valid.
+	empty := db.AgentTaskQueue{}
+	if taskCoversReplyParent(empty, util.MustParseUUID(trigger)) {
+		t.Errorf("a task with no trigger/coalesced comments must not authorize any parent")
+	}
+}


### PR DESCRIPTION
## What & why

Follow-up to #5202 (per-thread coalesced reply routing), which merged **without** these two fixes — they were pushed to the branch but GitHub Actions never scheduled a run for that commit, so the merge landed at the earlier SHA. Testing on the merged code surfaced two problems this PR closes.

### 1. Authorization (the actual blocker)

`CreateComment` (`server/internal/handler/comment.go`) has a resumed-session `--parent` drift guard: when an agent posts via a task token on the task's **own** issue, `parent_id` had to equal `task.TriggerCommentID`, else 409. That rejected the fan-out replies to every **other** coalesced thread, so those threads never got a reply (`"parent_id must equal this task's trigger comment id"`).

Fix: `taskCoversReplyParent(task, parentID)` allows the trigger comment **OR any comment the task coalesced** (`coalesced_comment_ids`) — exactly the set the run was delivered to answer. Every other parent on the issue is still rejected, so this stays scoped (no arbitrary-comment access) and preserves the anti-drift / anti-misplacement guarantee.

### 2. Reply ordering

The agent answered the newest (triggering) comment first. The fan-out instruction now **numbers** the targets and explicitly requires posting **oldest thread first, the newest/triggering thread last**, so replies land in chronological order. The grouping already lists oldest-first.

## Deployment note

Unlike #5202 (daemon-only), this touches **server** code (`handler/comment.go`). The per-thread fan-out only works end-to-end when **both** are deployed: the daemon builds the per-thread `--parent`s + ordering, and the server authorizes them.

## Tests

- `server/internal/handler/comment_reply_authz_test.go` — `TestTaskCoversReplyParent`: trigger + each coalesced comment allowed; unrelated comment and empty parent rejected; a task with no trigger/coalesced authorizes nothing.
- `server/internal/daemon/prompt_test.go` — cross-thread prompt test now asserts the `OLDEST thread first` wording and that targets are listed in chronological order (c1 < c2 < c3).

## Verification

- `gofmt` clean, `go build ./...` = 0, `go vet ./internal/handler ./internal/daemon/...` = 0
- `go test ./internal/handler -run TestTaskCoversReplyParent` and `go test ./internal/daemon -run 'TestCommentReplyThreads|TestBuildCommentPrompt'` pass

Related: MUL-4348, follows #5202.
