### PR TITLE
WS-1690: restore lost local fork fixes on v0.3.42

### DIFF
--- a/server/internal/daemon/execenv/codex_user_skills.go
+++ b/server/internal/daemon/execenv/codex_user_skills.go
@@ -79,6 +79,32 @@ func seedUserCodexSkills(codexHome string, workspaceSkills []SkillContextForEnv,
 			logger.Warn("execenv: codex user-skill copy failed", "name", name, "error", err)
 			continue
 		}
+		if err := normalizeCopiedCodexUserSkill(dst, name); err != nil {
+			_ = os.RemoveAll(dst)
+			logger.Warn("execenv: codex user-skill frontmatter normalization failed", "name", name, "error", err)
+			continue
+		}
+	}
+	return nil
+}
+
+// normalizeCopiedCodexUserSkill is the cold-start guard for user-installed
+// Codex skills. Unlike workspace skills, user skills arrive from ~/.codex/skills
+// and used to be copied byte-for-byte into the per-task CODEX_HOME. A missing
+// or malformed frontmatter block makes Codex reject that SKILL.md during startup,
+// which can stall unrelated task prompts before they produce a fallback answer.
+func normalizeCopiedCodexUserSkill(skillDir, name string) error {
+	path := filepath.Join(skillDir, "SKILL.md")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return fmt.Errorf("read SKILL.md: %w", err)
+	}
+	normalized := ensureSkillFrontmatter(string(data), sanitizeSkillName(name), "")
+	if normalized == string(data) {
+		return nil
+	}
+	if err := os.WriteFile(path, []byte(normalized), 0o644); err != nil {
+		return fmt.Errorf("write SKILL.md: %w", err)
 	}
 	return nil
 }

--- a/server/internal/daemon/execenv/execenv_test.go
+++ b/server/internal/daemon/execenv/execenv_test.go
@@ -2949,8 +2949,15 @@ func TestPrepareCodexSeedsUserSkills(t *testing.T) {
 
 	if data, err := os.ReadFile(filepath.Join(env.CodexHome, "skills", "summarize", "SKILL.md")); err != nil {
 		t.Fatalf("user skill SKILL.md not seeded: %v", err)
-	} else if string(data) != "summarize" {
-		t.Errorf("summarize SKILL.md = %q, want %q", data, "summarize")
+	} else {
+		got := string(data)
+		fm := parseFrontmatter(t, got)
+		if name, _ := fm["name"].(string); name != "summarize" {
+			t.Errorf("frontmatter name = %#v, want %q", fm["name"], "summarize")
+		}
+		if !strings.Contains(got, "summarize") {
+			t.Errorf("summarize body was dropped:\n%s", got)
+		}
 	}
 	if data, err := os.ReadFile(filepath.Join(env.CodexHome, "skills", "summarize", "examples", "ex.md")); err != nil {
 		t.Fatalf("user skill support file not seeded: %v", err)
@@ -2959,11 +2966,65 @@ func TestPrepareCodexSeedsUserSkills(t *testing.T) {
 	}
 	if data, err := os.ReadFile(filepath.Join(env.CodexHome, "skills", "translate", "SKILL.md")); err != nil {
 		t.Fatalf("second user skill not seeded: %v", err)
-	} else if string(data) != "translate" {
-		t.Errorf("translate SKILL.md = %q, want %q", data, "translate")
+	} else {
+		fm := parseFrontmatter(t, string(data))
+		if name, _ := fm["name"].(string); name != "translate" {
+			t.Errorf("frontmatter name = %#v, want %q", fm["name"], "translate")
+		}
 	}
 	if _, err := os.Stat(filepath.Join(env.CodexHome, "skills", ".DS_Store")); !os.IsNotExist(err) {
 		t.Errorf("ignored dotfile leaked into codex-home/skills: err=%v", err)
+	}
+}
+
+// TestPrepareCodexNormalizesUserSkillFrontmatter covers the WS-1494 failure
+// mode: user-installed Codex skills are copied into the per-task CODEX_HOME.
+// If their SKILL.md lacks YAML frontmatter, Codex logs "missing YAML
+// frontmatter delimited by ---" while loading skills and the task can stall
+// before the daily-report prompt produces any fallback text.
+func TestPrepareCodexNormalizesUserSkillFrontmatter(t *testing.T) {
+	// Cannot use t.Parallel() with t.Setenv.
+
+	sharedHome := t.TempDir()
+	t.Setenv("CODEX_HOME", sharedHome)
+
+	for _, name := range []string{"koc-publish-registration", "koc-sample-registration"} {
+		dir := filepath.Join(sharedHome, "skills", name)
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatalf("seed user skill dir: %v", err)
+		}
+		body := "# " + name + "\n\nPlain-text guidance without frontmatter.\n"
+		if err := os.WriteFile(filepath.Join(dir, "SKILL.md"), []byte(body), 0o644); err != nil {
+			t.Fatalf("seed user SKILL.md: %v", err)
+		}
+	}
+
+	env, err := Prepare(PrepareParams{
+		WorkspacesRoot: t.TempDir(),
+		WorkspaceID:    "ws-koc-user-skills",
+		TaskID:         "0f1e2d3c-4b5a-6978-90ab-cdef12345678",
+		AgentName:      "Codex Agent",
+		Provider:       "codex",
+		Task:           TaskContextForEnv{IssueID: "koc-frontmatter-test"},
+	}, testLogger())
+	if err != nil {
+		t.Fatalf("Prepare failed: %v", err)
+	}
+	defer env.Cleanup(true)
+
+	for _, name := range []string{"koc-publish-registration", "koc-sample-registration"} {
+		data, err := os.ReadFile(filepath.Join(env.CodexHome, "skills", name, "SKILL.md"))
+		if err != nil {
+			t.Fatalf("seeded %s missing: %v", name, err)
+		}
+		got := string(data)
+		fm := parseFrontmatter(t, got)
+		if fmName, _ := fm["name"].(string); fmName != name {
+			t.Errorf("%s frontmatter name = %#v, want %q", name, fm["name"], name)
+		}
+		if !strings.Contains(got, "Plain-text guidance without frontmatter.") {
+			t.Errorf("%s body was dropped during normalization:\n%s", name, got)
+		}
 	}
 }
 
@@ -3100,8 +3161,13 @@ func TestPrepareCodexResolvesUserSkillSymlinks(t *testing.T) {
 	if err != nil {
 		t.Fatalf("seeded SKILL.md missing: %v", err)
 	}
-	if string(data) != "lark" {
-		t.Errorf("seeded SKILL.md = %q, want %q", data, "lark")
+	got := string(data)
+	fm := parseFrontmatter(t, got)
+	if name, _ := fm["name"].(string); name != "lark-mail" {
+		t.Errorf("frontmatter name = %#v, want %q", fm["name"], "lark-mail")
+	}
+	if !strings.Contains(got, "lark") {
+		t.Errorf("seeded SKILL.md body was dropped:\n%s", got)
 	}
 }
 
@@ -3149,8 +3215,13 @@ func TestReuseSeedsUserSkillUpdates(t *testing.T) {
 	if err != nil {
 		t.Fatalf("user skill not refreshed on reuse: %v", err)
 	}
-	if string(data) != "v2" {
-		t.Errorf("after Reuse, user skill content = %q, want %q", data, "v2")
+	got := string(data)
+	fm := parseFrontmatter(t, got)
+	if name, _ := fm["name"].(string); name != "summarize" {
+		t.Errorf("frontmatter name = %#v, want %q", fm["name"], "summarize")
+	}
+	if !strings.Contains(got, "v2") {
+		t.Errorf("after Reuse, user skill body was not refreshed:\n%s", got)
 	}
 }
 

--- a/server/internal/handler/dashboard_test.go
+++ b/server/internal/handler/dashboard_test.go
@@ -1316,6 +1316,146 @@ func TestDashboardUsageDailyCrossMidnightFullPipeline(t *testing.T) {
 	}
 }
 
+// TestDashboardUsageExcludesStaleRuntimeBuckets covers the WS-1494 attribution
+// canary: a runtime whose last heartbeat is older than the activity bucket by
+// more than 24h must not make an employee look active "today" just because a
+// stray usage row was attached to that runtime.
+func TestDashboardUsageExcludesStaleRuntimeBuckets(t *testing.T) {
+	if testHandler == nil {
+		t.Skip("database not available")
+	}
+	ctx := context.Background()
+
+	insertRuntime := func(name string, lastSeen time.Time) string {
+		var id string
+		if err := testPool.QueryRow(ctx, `
+			INSERT INTO agent_runtime (
+				workspace_id, daemon_id, name, runtime_mode, provider, status, device_info, metadata, last_seen_at
+			)
+			VALUES ($1, NULL, $2, 'cloud', 'claude', 'online', '{}'::jsonb, '{}'::jsonb, $3)
+			RETURNING id
+		`, testWorkspaceID, name, lastSeen).Scan(&id); err != nil {
+			t.Fatalf("create runtime %s: %v", name, err)
+		}
+		t.Cleanup(func() { testPool.Exec(ctx, `DELETE FROM agent_runtime WHERE id = $1`, id) })
+		return id
+	}
+	now := time.Now().UTC()
+	staleRuntimeID := insertRuntime("stale-window-runtime", now.Add(-48*time.Hour))
+	freshRuntimeID := insertRuntime("fresh-window-runtime", now)
+
+	insertAgent := func(name, runtimeID string) string {
+		var id string
+		if err := testPool.QueryRow(ctx, `
+			INSERT INTO agent (
+				workspace_id, name, description, runtime_mode, runtime_config,
+				runtime_id, visibility, max_concurrent_tasks, owner_id,
+				instructions, custom_env, custom_args, mcp_config
+			)
+			VALUES ($1, $2, '', 'cloud', '{}'::jsonb, $3, 'private', 1, $4, '', '{}'::jsonb, '[]'::jsonb, '[]'::jsonb)
+			RETURNING id
+		`, testWorkspaceID, name, runtimeID, testUserID).Scan(&id); err != nil {
+			t.Fatalf("create agent %s: %v", name, err)
+		}
+		t.Cleanup(func() { testPool.Exec(ctx, `DELETE FROM agent WHERE id = $1`, id) })
+		return id
+	}
+	staleAgentID := insertAgent("stale-window-agent", staleRuntimeID)
+	freshAgentID := insertAgent("fresh-window-agent", freshRuntimeID)
+
+	var issueID string
+	if err := testPool.QueryRow(ctx, `
+		INSERT INTO issue (workspace_id, title, creator_id, creator_type, number)
+		VALUES ($1, 'stale runtime attribution test', $2, 'member',
+		        (SELECT COALESCE(MAX(number), 0) + 1 FROM issue WHERE workspace_id = $1))
+		RETURNING id
+	`, testWorkspaceID, testUserID).Scan(&issueID); err != nil {
+		t.Fatalf("create issue: %v", err)
+	}
+	t.Cleanup(func() { testPool.Exec(ctx, `DELETE FROM issue WHERE id = $1`, issueID) })
+
+	insertUsage := func(agentID, runtimeID, model string, tokens int) {
+		var taskID string
+		if err := testPool.QueryRow(ctx, `
+			INSERT INTO agent_task_queue (agent_id, issue_id, runtime_id, status, created_at)
+			VALUES ($1, $2, $3, 'completed', now()) RETURNING id
+		`, agentID, issueID, runtimeID).Scan(&taskID); err != nil {
+			t.Fatalf("insert task %s: %v", model, err)
+		}
+		t.Cleanup(func() { testPool.Exec(ctx, `DELETE FROM agent_task_queue WHERE id = $1`, taskID) })
+		if _, err := testPool.Exec(ctx, `
+			INSERT INTO task_usage (task_id, provider, model, input_tokens, output_tokens, created_at, updated_at)
+			VALUES ($1, 'claude', $2, $3, 0, now(), now())
+		`, taskID, model, tokens); err != nil {
+			t.Fatalf("insert usage %s: %v", model, err)
+		}
+	}
+	insertUsage(staleAgentID, staleRuntimeID, "m-stale-runtime-window", 111)
+	insertUsage(freshAgentID, freshRuntimeID, "m-fresh-runtime-window", 222)
+	t.Cleanup(func() {
+		testPool.Exec(ctx, `DELETE FROM task_usage_hourly WHERE model IN ('m-stale-runtime-window', 'm-fresh-runtime-window')`)
+		testPool.Exec(ctx, `DELETE FROM task_usage_hourly_dirty WHERE model IN ('m-stale-runtime-window', 'm-fresh-runtime-window')`)
+	})
+
+	if _, err := testPool.Exec(ctx, `
+		SELECT rollup_task_usage_hourly_window('1970-01-01'::timestamptz, now() + interval '1 hour')
+	`); err != nil {
+		t.Fatalf("rollup: %v", err)
+	}
+
+	w := httptest.NewRecorder()
+	testHandler.GetDashboardUsageDaily(w, newRequest("GET", "/api/dashboard/usage/daily?days=1&tz=UTC", nil))
+	if w.Code != http.StatusOK {
+		t.Fatalf("daily: expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	var dailyRows []struct {
+		Model       string `json:"model"`
+		InputTokens int64  `json:"input_tokens"`
+	}
+	if err := json.NewDecoder(w.Body).Decode(&dailyRows); err != nil {
+		t.Fatalf("decode daily: %v", err)
+	}
+	assertModelPresence := func(label string, rows []struct {
+		Model       string `json:"model"`
+		InputTokens int64  `json:"input_tokens"`
+	}) {
+		t.Helper()
+		var fresh, stale bool
+		for _, row := range rows {
+			if row.Model == "m-fresh-runtime-window" {
+				fresh = true
+				if row.InputTokens != 222 {
+					t.Errorf("%s: fresh tokens = %d, want 222", label, row.InputTokens)
+				}
+			}
+			if row.Model == "m-stale-runtime-window" {
+				stale = true
+			}
+		}
+		if !fresh {
+			t.Errorf("%s: fresh runtime usage row missing in %v", label, rows)
+		}
+		if stale {
+			t.Errorf("%s: stale runtime usage row should be excluded: %v", label, rows)
+		}
+	}
+	assertModelPresence("daily", dailyRows)
+
+	w = httptest.NewRecorder()
+	testHandler.GetDashboardUsageByAgent(w, newRequest("GET", "/api/dashboard/usage/by-agent?days=1&tz=UTC", nil))
+	if w.Code != http.StatusOK {
+		t.Fatalf("by-agent: expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	var byAgentRows []struct {
+		Model       string `json:"model"`
+		InputTokens int64  `json:"input_tokens"`
+	}
+	if err := json.NewDecoder(w.Body).Decode(&byAgentRows); err != nil {
+		t.Fatalf("decode by-agent: %v", err)
+	}
+	assertModelPresence("by-agent", byAgentRows)
+}
+
 // TestRollupTaskUsageHourlyConvergesOnTaskUsageDelete covers the
 // `trg_tu_dirty_hourly` trigger — a BEFORE DELETE trigger on task_usage.
 // Migration 102 notes it has no production callers today and exists purely

--- a/server/pkg/agent/codex.go
+++ b/server/pkg/agent/codex.go
@@ -622,8 +622,8 @@ func (b *codexBackend) Execute(ctx context.Context, prompt string, opts ExecOpti
 	// this, killing the leader leaves grandchildren as orphans that
 	// keep consuming memory until the OS reaps them; see #4520, where a
 	// scanner overflow during thread/resume otherwise leaked Codex
-	// processes indefinitely. configureProcessGroup is a no-op on
-	// Windows.
+	// processes indefinitely. On Windows, startProcessGroup creates a
+	// kill-on-close Job Object for the same tree-cleanup contract.
 	configureProcessGroup(cmd)
 	// Override the default exec.CommandContext cancel behaviour. The
 	// default sends SIGKILL only to cmd.Process (the leader); we instead
@@ -659,7 +659,7 @@ func (b *codexBackend) Execute(ctx context.Context, prompt string, opts ExecOpti
 	stderrBuf := newStderrTail(newLogWriter(b.cfg.Logger, "[codex:stderr] "), codexStderrTailBytes)
 	cmd.Stderr = stderrBuf
 
-	if err := cmd.Start(); err != nil {
+	if err := startProcessGroup(cmd); err != nil {
 		cancel()
 		return nil, fmt.Errorf("start codex: %w", err)
 	}
@@ -799,6 +799,7 @@ func (b *codexBackend) Execute(ctx context.Context, prompt string, opts ExecOpti
 			waitCh := make(chan struct{})
 			go func() {
 				_ = cmd.Wait()
+				releaseProcessGroup(cmd.Process)
 				close(waitCh)
 			}()
 			select {

--- a/server/pkg/agent/opencode.go
+++ b/server/pkg/agent/opencode.go
@@ -164,7 +164,7 @@ func (b *opencodeBackend) Execute(ctx context.Context, prompt string, opts ExecO
 	}
 	cmd.Stderr = newLogWriter(b.cfg.Logger, "[opencode:stderr] ")
 
-	if err := cmd.Start(); err != nil {
+	if err := startProcessGroup(cmd); err != nil {
 		cancel()
 		return nil, fmt.Errorf("start opencode: %w", err)
 	}
@@ -215,6 +215,7 @@ func (b *opencodeBackend) Execute(ctx context.Context, prompt string, opts ExecO
 
 		// Wait for process exit, then release the cancellation handler.
 		exitErr := cmd.Wait()
+		releaseProcessGroup(cmd.Process)
 		close(procDone)
 		duration := time.Since(startTime)
 

--- a/server/pkg/agent/opencode.go
+++ b/server/pkg/agent/opencode.go
@@ -182,12 +182,13 @@ func (b *opencodeBackend) Execute(ctx context.Context, prompt string, opts ExecO
 	// it spawned) BEFORE unblocking the scanner. The previous implementation
 	// closed the stdout read end immediately, which left opencode writing into
 	// a closed pipe: every write returns EPIPE and, per anomalyco/opencode#33653,
-	// can spin the orphaned process at 100% CPU. Instead we SIGTERM the whole
+	// can spin the orphaned process at 100% CPU. On Unix we SIGTERM the whole
 	// process group, give it a grace period to exit cleanly, then SIGKILL it.
-	// SIGKILL is uncatchable, so once it is delivered no group member can run
-	// (or write) again — only then is it safe to close the stdout read end as a
-	// last-resort unblock for a scanner that a wedged descendant still keeps
-	// open. WaitDelay is the final backstop (#4533).
+	// On Windows, signalProcessGroup closes the kill-on-close Job Object on
+	// the first call, so cancellation immediately terminates the process tree;
+	// the grace window is a no-op there. Only after tree termination do we close
+	// the stdout read end as a last-resort unblock for a scanner that a wedged
+	// descendant still keeps open. WaitDelay is the final backstop (#4533).
 	go func() {
 		select {
 		case <-procDone:

--- a/server/pkg/agent/proc_other.go
+++ b/server/pkg/agent/proc_other.go
@@ -24,6 +24,12 @@ func configureProcessGroup(cmd *exec.Cmd) {
 	cmd.SysProcAttr.Setpgid = true
 }
 
+func startProcessGroup(cmd *exec.Cmd) error {
+	return cmd.Start()
+}
+
+func releaseProcessGroup(_ *os.Process) {}
+
 // signalProcessGroup sends sig to the whole process group led by p (when the
 // command was started with configureProcessGroup), falling back to the single
 // process if the group send fails. Targeting the group (negative pid) reaches

--- a/server/pkg/agent/proc_windows.go
+++ b/server/pkg/agent/proc_windows.go
@@ -3,9 +3,15 @@
 package agent
 
 import (
+	"errors"
+	"fmt"
 	"os"
 	"os/exec"
+	"sync"
 	"syscall"
+	"unsafe"
+
+	"golang.org/x/sys/windows"
 )
 
 // createNewConsole allocates a fresh console for the child process. Combined
@@ -18,7 +24,12 @@ import (
 // which forces Windows to allocate a new visible console per grandchild
 // when the grandchild is a console-subsystem program that doesn't itself
 // pass CREATE_NO_WINDOW — the exact popup storm reported in #1521.
-const createNewConsole = 0x00000010
+const (
+	createNewConsole = 0x00000010
+	createSuspended  = 0x00000004
+)
+
+var processGroupJobs sync.Map // map[int]windows.Handle
 
 // hideAgentWindow configures cmd to suppress the console window on Windows
 // while still giving descendant processes a hidden console to inherit.
@@ -33,16 +44,134 @@ func hideAgentWindow(cmd *exec.Cmd) {
 }
 
 // configureProcessGroup is a no-op on Windows: there is no Setpgid/process-group
-// signalling. Descendant cleanup relies on the hidden console group set up by
-// hideAgentWindow plus exec.CommandContext / WaitDelay terminating the child.
+// signalling. Callers that need descendant cleanup must start with
+// startProcessGroup, which assigns the child to a kill-on-close Job Object.
 func configureProcessGroup(cmd *exec.Cmd) {}
 
-// signalProcessGroup terminates the process on Windows. Windows has no
+func prepareProcessGroup(cmd *exec.Cmd) (windows.Handle, error) {
+	job, err := windows.CreateJobObject(nil, nil)
+	if err != nil {
+		return 0, fmt.Errorf("create job object: %w", err)
+	}
+	info := windows.JOBOBJECT_EXTENDED_LIMIT_INFORMATION{}
+	info.BasicLimitInformation.LimitFlags = windows.JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE
+	if _, err := windows.SetInformationJobObject(
+		job,
+		windows.JobObjectExtendedLimitInformation,
+		uintptr(unsafe.Pointer(&info)),
+		uint32(unsafe.Sizeof(info)),
+	); err != nil {
+		_ = windows.CloseHandle(job)
+		return 0, fmt.Errorf("set job object kill-on-close: %w", err)
+	}
+
+	if cmd.SysProcAttr == nil {
+		cmd.SysProcAttr = &syscall.SysProcAttr{}
+	}
+	cmd.SysProcAttr.CreationFlags |= createSuspended
+	return job, nil
+}
+
+func startProcessGroup(cmd *exec.Cmd) error {
+	job, err := prepareProcessGroup(cmd)
+	if err != nil {
+		return err
+	}
+	if err := cmd.Start(); err != nil {
+		_ = windows.CloseHandle(job)
+		return err
+	}
+
+	var assignErr error
+	if err := cmd.Process.WithHandle(func(handle uintptr) {
+		assignErr = windows.AssignProcessToJobObject(job, windows.Handle(handle))
+	}); err != nil {
+		assignErr = err
+	}
+	if assignErr != nil {
+		_ = windows.CloseHandle(job)
+		_ = cmd.Process.Kill()
+		_ = cmd.Wait()
+		return fmt.Errorf("assign process to job object: %w", assignErr)
+	}
+
+	processGroupJobs.Store(cmd.Process.Pid, job)
+	if err := resumeProcess(cmd.Process.Pid); err != nil {
+		releaseProcessGroup(cmd.Process)
+		_ = cmd.Wait()
+		return fmt.Errorf("resume suspended process: %w", err)
+	}
+	return nil
+}
+
+func resumeProcess(pid int) error {
+	snapshot, err := windows.CreateToolhelp32Snapshot(windows.TH32CS_SNAPTHREAD, 0)
+	if err != nil {
+		return fmt.Errorf("create thread snapshot: %w", err)
+	}
+	defer windows.CloseHandle(snapshot)
+
+	entry := windows.ThreadEntry32{Size: uint32(unsafe.Sizeof(windows.ThreadEntry32{}))}
+	if err := windows.Thread32First(snapshot, &entry); err != nil {
+		return fmt.Errorf("read first thread: %w", err)
+	}
+
+	found := false
+	for {
+		if entry.OwnerProcessID == uint32(pid) {
+			found = true
+			if err := resumeThread(entry.ThreadID); err != nil {
+				return err
+			}
+		}
+
+		err := windows.Thread32Next(snapshot, &entry)
+		if err == nil {
+			continue
+		}
+		if errors.Is(err, windows.ERROR_NO_MORE_FILES) {
+			break
+		}
+		return fmt.Errorf("read next thread: %w", err)
+	}
+	if !found {
+		return fmt.Errorf("no threads found for pid %d", pid)
+	}
+	return nil
+}
+
+func resumeThread(threadID uint32) error {
+	thread, err := windows.OpenThread(windows.THREAD_SUSPEND_RESUME, false, threadID)
+	if err != nil {
+		return fmt.Errorf("open thread %d: %w", threadID, err)
+	}
+	defer windows.CloseHandle(thread)
+	if _, err := windows.ResumeThread(thread); err != nil {
+		return fmt.Errorf("resume thread %d: %w", threadID, err)
+	}
+	return nil
+}
+
+func releaseProcessGroup(p *os.Process) {
+	if p == nil {
+		return
+	}
+	if job, ok := processGroupJobs.LoadAndDelete(p.Pid); ok {
+		_ = windows.CloseHandle(job.(windows.Handle))
+	}
+}
+
+// signalProcessGroup terminates the process tree on Windows by closing the
+// kill-on-close Job Object created by startProcessGroup. Windows has no
 // SIGTERM/SIGKILL distinction or process-group signalling, so the signal is
-// ignored and the process is killed directly (TerminateProcess via Kill). The
-// caller's grace window still applies before this is invoked with SIGKILL.
+// ignored. If the process was not started through startProcessGroup, fall back
+// to killing the direct child.
 func signalProcessGroup(p *os.Process, _ syscall.Signal) {
 	if p == nil {
+		return
+	}
+	if _, ok := processGroupJobs.Load(p.Pid); ok {
+		releaseProcessGroup(p)
 		return
 	}
 	_ = p.Kill()

--- a/server/pkg/agent/proc_windows_test.go
+++ b/server/pkg/agent/proc_windows_test.go
@@ -6,6 +6,9 @@ import (
 	"os/exec"
 	"syscall"
 	"testing"
+	"unsafe"
+
+	"golang.org/x/sys/windows"
 )
 
 // TestHideAgentWindowSetsCreateNewConsole guards against a regression where
@@ -61,5 +64,35 @@ func TestHideAgentWindowPreservesExistingSysProcAttr(t *testing.T) {
 	}
 	if cmd.SysProcAttr.CreationFlags&createNewConsole == 0 {
 		t.Error("CREATE_NEW_CONSOLE should be OR'd into existing flags")
+	}
+}
+
+func TestPrepareProcessGroupCreatesKillOnCloseSuspendedJob(t *testing.T) {
+	cmd := exec.Command("cmd.exe", "/c", "echo", "hi")
+	hideAgentWindow(cmd)
+
+	job, err := prepareProcessGroup(cmd)
+	if err != nil {
+		t.Fatalf("prepareProcessGroup failed: %v", err)
+	}
+	defer windows.CloseHandle(job)
+
+	if cmd.SysProcAttr == nil {
+		t.Fatal("SysProcAttr should be initialized")
+	}
+	if cmd.SysProcAttr.CreationFlags&createSuspended == 0 {
+		t.Errorf("CreationFlags should include CREATE_SUSPENDED (0x%x), got 0x%x",
+			createSuspended, cmd.SysProcAttr.CreationFlags)
+	}
+
+	var info windows.JOBOBJECT_EXTENDED_LIMIT_INFORMATION
+	err = windows.QueryInformationJobObject(job, windows.JobObjectExtendedLimitInformation,
+		uintptr(unsafe.Pointer(&info)), uint32(unsafe.Sizeof(info)), nil)
+	if err != nil {
+		t.Fatalf("QueryInformationJobObject failed: %v", err)
+	}
+	if info.BasicLimitInformation.LimitFlags&windows.JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE == 0 {
+		t.Errorf("job LimitFlags should include KILL_ON_JOB_CLOSE (0x%x), got 0x%x",
+			windows.JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE, info.BasicLimitInformation.LimitFlags)
 	}
 }

--- a/server/pkg/agent/proc_windows_test.go
+++ b/server/pkg/agent/proc_windows_test.go
@@ -3,13 +3,22 @@
 package agent
 
 import (
+	"errors"
+	"fmt"
+	"os"
 	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
 	"syscall"
 	"testing"
+	"time"
 	"unsafe"
 
 	"golang.org/x/sys/windows"
 )
+
+const windowsProcessGroupHostJobHelperEnv = "MULTICA_WINDOWS_PROCESS_GROUP_HOST_JOB_HELPER"
 
 // TestHideAgentWindowSetsCreateNewConsole guards against a regression where
 // hideAgentWindow reverts to CREATE_NO_WINDOW. CREATE_NO_WINDOW strips the
@@ -95,4 +104,150 @@ func TestPrepareProcessGroupCreatesKillOnCloseSuspendedJob(t *testing.T) {
 		t.Errorf("job LimitFlags should include KILL_ON_JOB_CLOSE (0x%x), got 0x%x",
 			windows.JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE, info.BasicLimitInformation.LimitFlags)
 	}
+}
+
+func TestStartProcessGroupKillsGrandchildWhenLeaderExits(t *testing.T) {
+	runProcessGroupGrandchildCleanup(t)
+}
+
+func TestStartProcessGroupWorksWhenHostAlreadyInJob(t *testing.T) {
+	exe, err := os.Executable()
+	if err != nil {
+		t.Fatalf("os.Executable failed: %v", err)
+	}
+
+	cmd := exec.Command(exe, "-test.run=^TestStartProcessGroupHostJobHelper$", "-test.v")
+	cmd.Env = append(os.Environ(), windowsProcessGroupHostJobHelperEnv+"=1")
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("host-job helper failed: %v\n%s", err, output)
+	}
+}
+
+func TestStartProcessGroupHostJobHelper(t *testing.T) {
+	if os.Getenv(windowsProcessGroupHostJobHelperEnv) != "1" {
+		t.Skip("helper process only")
+	}
+
+	parentJob, err := windows.CreateJobObject(nil, nil)
+	if err != nil {
+		t.Fatalf("CreateJobObject parent failed: %v", err)
+	}
+	defer windows.CloseHandle(parentJob)
+
+	if err := windows.AssignProcessToJobObject(parentJob, windows.CurrentProcess()); err != nil {
+		t.Fatalf("assign helper process to parent job: %v", err)
+	}
+
+	runProcessGroupGrandchildCleanup(t)
+}
+
+func runProcessGroupGrandchildCleanup(t *testing.T) {
+	t.Helper()
+
+	pidFile := filepath.Join(t.TempDir(), "grandchild.pid")
+	leaderScript := strings.Join([]string{
+		"$ErrorActionPreference = 'Stop'",
+		"$child = Start-Process -FilePath powershell.exe -WindowStyle Hidden -PassThru -ArgumentList @(",
+		"  '-NoProfile',",
+		"  '-ExecutionPolicy', 'Bypass',",
+		"  '-Command', 'Start-Sleep -Seconds 60'",
+		")",
+		"$child.Id | Set-Content -Path $env:MULTICA_TEST_GRANDCHILD_PID_FILE -NoNewline -Encoding ascii",
+	}, "\n")
+
+	cmd := exec.Command("powershell.exe", "-NoProfile", "-ExecutionPolicy", "Bypass", "-Command", leaderScript)
+	cmd.Env = append(os.Environ(), "MULTICA_TEST_GRANDCHILD_PID_FILE="+pidFile)
+	hideAgentWindow(cmd)
+	configureProcessGroup(cmd)
+
+	var waited bool
+	cleaned := false
+	t.Cleanup(func() {
+		if cleaned || cmd.Process == nil {
+			return
+		}
+		signalProcessGroup(cmd.Process, syscall.SIGKILL)
+		releaseProcessGroup(cmd.Process)
+		if !waited {
+			_ = cmd.Wait()
+		}
+	})
+
+	if err := startProcessGroup(cmd); err != nil {
+		t.Fatalf("startProcessGroup failed: %v", err)
+	}
+
+	grandchildPID := waitForPIDFile(t, pidFile)
+	if running, err := windowsProcessRunning(grandchildPID); err != nil {
+		t.Fatalf("checking grandchild before release: %v", err)
+	} else if !running {
+		t.Fatalf("grandchild process %d exited before job release", grandchildPID)
+	}
+
+	if err := cmd.Wait(); err != nil {
+		t.Fatalf("leader process failed: %v", err)
+	}
+	waited = true
+
+	releaseProcessGroup(cmd.Process)
+	cleaned = true
+	waitForProcessExit(t, grandchildPID)
+}
+
+func waitForPIDFile(t *testing.T, path string) int {
+	t.Helper()
+
+	deadline := time.Now().Add(10 * time.Second)
+	for time.Now().Before(deadline) {
+		data, err := os.ReadFile(path)
+		if err == nil {
+			pid, err := strconv.Atoi(strings.TrimSpace(string(data)))
+			if err != nil {
+				t.Fatalf("parse pid file %s: %v", path, err)
+			}
+			if pid <= 0 {
+				t.Fatalf("pid file %s contained invalid pid %d", path, pid)
+			}
+			return pid
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	t.Fatalf("timed out waiting for pid file %s", path)
+	return 0
+}
+
+func waitForProcessExit(t *testing.T, pid int) {
+	t.Helper()
+
+	deadline := time.Now().Add(10 * time.Second)
+	for time.Now().Before(deadline) {
+		running, err := windowsProcessRunning(pid)
+		if err != nil {
+			t.Fatalf("checking process %d: %v", pid, err)
+		}
+		if !running {
+			return
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	t.Fatalf("process %d still running after job release", pid)
+}
+
+func windowsProcessRunning(pid int) (bool, error) {
+	handle, err := windows.OpenProcess(windows.PROCESS_QUERY_LIMITED_INFORMATION, false, uint32(pid))
+	if err != nil {
+		if errors.Is(err, windows.ERROR_INVALID_PARAMETER) {
+			return false, nil
+		}
+		return false, fmt.Errorf("open process: %w", err)
+	}
+	defer windows.CloseHandle(handle)
+
+	const stillActive = 259
+	var exitCode uint32
+	if err := windows.GetExitCodeProcess(handle, &exitCode); err != nil {
+		return false, fmt.Errorf("get exit code: %w", err)
+	}
+	return exitCode == stillActive, nil
 }

--- a/server/pkg/db/generated/task_usage.sql.go
+++ b/server/pkg/db/generated/task_usage.sql.go
@@ -230,20 +230,27 @@ func (q *Queries) ListDashboardRunTimeDaily(ctx context.Context, arg ListDashboa
 
 const listDashboardUsageByAgent = `-- name: ListDashboardUsageByAgent :many
 SELECT
-    agent_id,
-    LOWER(provider) AS provider,
-    model,
-    SUM(input_tokens)::bigint        AS input_tokens,
-    SUM(output_tokens)::bigint       AS output_tokens,
-    SUM(cache_read_tokens)::bigint   AS cache_read_tokens,
-    SUM(cache_write_tokens)::bigint  AS cache_write_tokens,
-    SUM(task_count)::int             AS task_count
-FROM task_usage_hourly
-WHERE workspace_id = $1
-  AND bucket_hour >= $2::timestamptz
-  AND ($3::uuid IS NULL OR project_id = $3)
-GROUP BY agent_id, LOWER(provider), model
-ORDER BY agent_id, LOWER(provider), model
+    tuh.agent_id,
+    LOWER(tuh.provider) AS provider,
+    tuh.model,
+    SUM(tuh.input_tokens)::bigint        AS input_tokens,
+    SUM(tuh.output_tokens)::bigint       AS output_tokens,
+    SUM(tuh.cache_read_tokens)::bigint   AS cache_read_tokens,
+    SUM(tuh.cache_write_tokens)::bigint  AS cache_write_tokens,
+    SUM(tuh.task_count)::int             AS task_count
+FROM task_usage_hourly tuh
+JOIN agent_runtime ar ON ar.id = tuh.runtime_id
+WHERE tuh.workspace_id = $1
+  AND tuh.bucket_hour >= $2::timestamptz
+  -- Treat usage buckets more than 24h after the runtime's last heartbeat as
+  -- stale attribution noise. This keeps "active today" employee reports from
+  -- counting a machine that has not been seen since an earlier day while still
+  -- preserving historical buckets before the runtime went stale.
+  AND ar.last_seen_at IS NOT NULL
+  AND tuh.bucket_hour <= ar.last_seen_at + INTERVAL '24 hours'
+  AND ($3::uuid IS NULL OR tuh.project_id = $3)
+GROUP BY tuh.agent_id, LOWER(tuh.provider), tuh.model
+ORDER BY tuh.agent_id, LOWER(tuh.provider), tuh.model
 `
 
 type ListDashboardUsageByAgentParams struct {
@@ -308,20 +315,27 @@ func (q *Queries) ListDashboardUsageByAgent(ctx context.Context, arg ListDashboa
 
 const listDashboardUsageDaily = `-- name: ListDashboardUsageDaily :many
 SELECT
-    DATE(bucket_hour AT TIME ZONE $2::text) AS date,
-    LOWER(provider) AS provider,
-    model,
-    SUM(input_tokens)::bigint        AS input_tokens,
-    SUM(output_tokens)::bigint       AS output_tokens,
-    SUM(cache_read_tokens)::bigint   AS cache_read_tokens,
-    SUM(cache_write_tokens)::bigint  AS cache_write_tokens,
-    SUM(task_count)::int             AS task_count
-FROM task_usage_hourly
-WHERE workspace_id = $1
-  AND bucket_hour >= $3::timestamptz
-  AND ($4::uuid IS NULL OR project_id = $4)
-GROUP BY DATE(bucket_hour AT TIME ZONE $2::text), LOWER(provider), model
-ORDER BY DATE(bucket_hour AT TIME ZONE $2::text) DESC, LOWER(provider), model
+    DATE(tuh.bucket_hour AT TIME ZONE $2::text) AS date,
+    LOWER(tuh.provider) AS provider,
+    tuh.model,
+    SUM(tuh.input_tokens)::bigint        AS input_tokens,
+    SUM(tuh.output_tokens)::bigint       AS output_tokens,
+    SUM(tuh.cache_read_tokens)::bigint   AS cache_read_tokens,
+    SUM(tuh.cache_write_tokens)::bigint  AS cache_write_tokens,
+    SUM(tuh.task_count)::int             AS task_count
+FROM task_usage_hourly tuh
+JOIN agent_runtime ar ON ar.id = tuh.runtime_id
+WHERE tuh.workspace_id = $1
+  AND tuh.bucket_hour >= $3::timestamptz
+  -- Treat usage buckets more than 24h after the runtime's last heartbeat as
+  -- stale attribution noise. This keeps "active today" employee reports from
+  -- counting a machine that has not been seen since an earlier day while still
+  -- preserving historical buckets before the runtime went stale.
+  AND ar.last_seen_at IS NOT NULL
+  AND tuh.bucket_hour <= ar.last_seen_at + INTERVAL '24 hours'
+  AND ($4::uuid IS NULL OR tuh.project_id = $4)
+GROUP BY DATE(tuh.bucket_hour AT TIME ZONE $2::text), LOWER(tuh.provider), tuh.model
+ORDER BY DATE(tuh.bucket_hour AT TIME ZONE $2::text) DESC, LOWER(tuh.provider), tuh.model
 `
 
 type ListDashboardUsageDailyParams struct {

--- a/server/pkg/db/queries/task_usage.sql
+++ b/server/pkg/db/queries/task_usage.sql
@@ -48,20 +48,27 @@ WHERE atq.issue_id = $1;
 -- before the handler lowercased provider on write) merge with new rows
 -- instead of forming a separate case-variant bucket.
 SELECT
-    DATE(bucket_hour AT TIME ZONE sqlc.arg('tz')::text) AS date,
-    LOWER(provider) AS provider,
-    model,
-    SUM(input_tokens)::bigint        AS input_tokens,
-    SUM(output_tokens)::bigint       AS output_tokens,
-    SUM(cache_read_tokens)::bigint   AS cache_read_tokens,
-    SUM(cache_write_tokens)::bigint  AS cache_write_tokens,
-    SUM(task_count)::int             AS task_count
-FROM task_usage_hourly
-WHERE workspace_id = $1
-  AND bucket_hour >= sqlc.arg('since')::timestamptz
-  AND (sqlc.narg('project_id')::uuid IS NULL OR project_id = sqlc.narg('project_id'))
-GROUP BY DATE(bucket_hour AT TIME ZONE sqlc.arg('tz')::text), LOWER(provider), model
-ORDER BY DATE(bucket_hour AT TIME ZONE sqlc.arg('tz')::text) DESC, LOWER(provider), model;
+    DATE(tuh.bucket_hour AT TIME ZONE sqlc.arg('tz')::text) AS date,
+    LOWER(tuh.provider) AS provider,
+    tuh.model,
+    SUM(tuh.input_tokens)::bigint        AS input_tokens,
+    SUM(tuh.output_tokens)::bigint       AS output_tokens,
+    SUM(tuh.cache_read_tokens)::bigint   AS cache_read_tokens,
+    SUM(tuh.cache_write_tokens)::bigint  AS cache_write_tokens,
+    SUM(tuh.task_count)::int             AS task_count
+FROM task_usage_hourly tuh
+JOIN agent_runtime ar ON ar.id = tuh.runtime_id
+WHERE tuh.workspace_id = $1
+  AND tuh.bucket_hour >= sqlc.arg('since')::timestamptz
+  -- Treat usage buckets more than 24h after the runtime's last heartbeat as
+  -- stale attribution noise. This keeps "active today" employee reports from
+  -- counting a machine that has not been seen since an earlier day while still
+  -- preserving historical buckets before the runtime went stale.
+  AND ar.last_seen_at IS NOT NULL
+  AND tuh.bucket_hour <= ar.last_seen_at + INTERVAL '24 hours'
+  AND (sqlc.narg('project_id')::uuid IS NULL OR tuh.project_id = sqlc.narg('project_id'))
+GROUP BY DATE(tuh.bucket_hour AT TIME ZONE sqlc.arg('tz')::text), LOWER(tuh.provider), tuh.model
+ORDER BY DATE(tuh.bucket_hour AT TIME ZONE sqlc.arg('tz')::text) DESC, LOWER(tuh.provider), tuh.model;
 
 -- name: ListDashboardUsageByAgent :many
 -- Per-(agent, provider, model) token aggregates from `task_usage_hourly`. No
@@ -79,20 +86,27 @@ ORDER BY DATE(bucket_hour AT TIME ZONE sqlc.arg('tz')::text) DESC, LOWER(provide
 -- provider is LOWER()-normalized so mixed-case historical rows merge with
 -- new rows (see ListDashboardUsageDaily).
 SELECT
-    agent_id,
-    LOWER(provider) AS provider,
-    model,
-    SUM(input_tokens)::bigint        AS input_tokens,
-    SUM(output_tokens)::bigint       AS output_tokens,
-    SUM(cache_read_tokens)::bigint   AS cache_read_tokens,
-    SUM(cache_write_tokens)::bigint  AS cache_write_tokens,
-    SUM(task_count)::int             AS task_count
-FROM task_usage_hourly
-WHERE workspace_id = $1
-  AND bucket_hour >= @since::timestamptz
-  AND (sqlc.narg('project_id')::uuid IS NULL OR project_id = sqlc.narg('project_id'))
-GROUP BY agent_id, LOWER(provider), model
-ORDER BY agent_id, LOWER(provider), model;
+    tuh.agent_id,
+    LOWER(tuh.provider) AS provider,
+    tuh.model,
+    SUM(tuh.input_tokens)::bigint        AS input_tokens,
+    SUM(tuh.output_tokens)::bigint       AS output_tokens,
+    SUM(tuh.cache_read_tokens)::bigint   AS cache_read_tokens,
+    SUM(tuh.cache_write_tokens)::bigint  AS cache_write_tokens,
+    SUM(tuh.task_count)::int             AS task_count
+FROM task_usage_hourly tuh
+JOIN agent_runtime ar ON ar.id = tuh.runtime_id
+WHERE tuh.workspace_id = $1
+  AND tuh.bucket_hour >= @since::timestamptz
+  -- Treat usage buckets more than 24h after the runtime's last heartbeat as
+  -- stale attribution noise. This keeps "active today" employee reports from
+  -- counting a machine that has not been seen since an earlier day while still
+  -- preserving historical buckets before the runtime went stale.
+  AND ar.last_seen_at IS NOT NULL
+  AND tuh.bucket_hour <= ar.last_seen_at + INTERVAL '24 hours'
+  AND (sqlc.narg('project_id')::uuid IS NULL OR tuh.project_id = sqlc.narg('project_id'))
+GROUP BY tuh.agent_id, LOWER(tuh.provider), tuh.model
+ORDER BY tuh.agent_id, LOWER(tuh.provider), tuh.model;
 
 -- name: ListDashboardRunTimeDaily :many
 -- Daily per-date run time + task counts for the workspace, optionally


### PR DESCRIPTION
Closes WS-1690

Rebases the two local fork fixes that were lost when the machine moved to the official v0.3.42 binary:

- WS-1274 Windows process-tree containment and popup prevention
- WS-1494 Codex user-skill frontmatter hardening and stale runtime usage filtering

The combined fork was built and deployed locally as v0.3.42-fork-ws1690. Binary pinning and a local checksum/mtime watcher are installed separately as machine-local operations.

Verification:

- go test ./internal/daemon/execenv -run '^TestPrepareCodexNormalizesUserSkillFrontmatter$' -count=1
- go test ./internal/handler -run '^TestDashboardUsageExcludesStaleRuntimeBuckets$' -count=1
- GOOS=windows GOARCH=amd64 go test -c ./pkg/agent
