### PR TITLE
fix(chat): remove unread-count badge from chat FAB (MUL-4374)

### DIFF
--- a/packages/views/chat/components/chat-fab.tsx
+++ b/packages/views/chat/components/chat-fab.tsx
@@ -41,7 +41,8 @@ export function ChatFab() {
     toggle();
   };
 
-  // Tooltip text communicates the state that isn't carried by the icon/badge.
+  // Tooltip text carries the running/unread state on hover; the FAB itself no
+  // longer shows an unread-count badge (it duplicated the chat tab's, MUL-4374).
   const tooltip = isRunning
     ? t(($) => $.fab.running)
     : unreadSessionCount > 0
@@ -60,11 +61,6 @@ export function ChatFab() {
         )}
       >
         <MessageCircle className="size-5" />
-        {unreadSessionCount > 0 && (
-          <span className="pointer-events-none absolute -top-0.5 -right-0.5 flex min-w-4 h-4 items-center justify-center rounded-full bg-brand px-1 text-xs font-semibold leading-none text-background">
-            {unreadSessionCount > 9 ? "9+" : unreadSessionCount}
-          </span>
-        )}
       </TooltipTrigger>
       <TooltipContent side="top" sideOffset={10}>{tooltip}</TooltipContent>
     </Tooltip>


### PR DESCRIPTION
## What

Removes the unread-count badge from the floating chat bubble (FAB) in the bottom-right corner.

## Why

The FAB's blue unread-count badge duplicated the chat tab's unread indicator in the left sidebar and visually overlapped with it. Per user request (MUL-4374), the FAB no longer needs to surface this number.

## Change

- Drop the conditional unread-count `<span>` badge from `ChatFab` (`packages/views/chat/components/chat-fab.tsx`). This component is shared by both the web and desktop shells, so both are covered.
- `unreadSessionCount` is still computed and used by the hover tooltip and the click logger, so unread/running state is still communicated on hover — just no persistent overlapping badge.

## Verification

- `pnpm --filter @multica/views typecheck` — passes
- `pnpm --filter @multica/views lint` — 0 errors (only pre-existing unrelated warnings)
- `pnpm --filter @multica/views test` — all 1752 tests pass
