### PR TITLE
fix(cli): decode /api/tokens defensively for reverse-proxy POST→GET rewrites (#3177)

### DIFF
--- a/server/cmd/multica/cmd_auth.go
+++ b/server/cmd/multica/cmd_auth.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"crypto/rand"
 	"encoding/hex"
+	"encoding/json"
 	"fmt"
 	"net"
 	"net/http"
@@ -320,19 +321,26 @@ func runAuthLoginBrowser(cmd *cobra.Command) error {
 	patName := fmt.Sprintf("CLI (%s)", hostname)
 	expiresInDays := 90
 
-	var patResp struct {
-		Token string `json:"token"`
-	}
-	err = client.PostJSON(ctx, "/api/tokens", map[string]any{
+	raw, err := client.PostJSONRaw(ctx, "/api/tokens", map[string]any{
 		"name":            patName,
 		"expires_in_days": expiresInDays,
-	}, &patResp)
+	})
 	if err != nil {
 		return cli.WithUserMessage("Sign-in did not complete: the server could not issue an access token for the CLI. Run `multica login` again.", err)
 	}
 
+	patToken, err := parseAccessTokenResponse(raw)
+	if err != nil {
+		return cli.WithUserMessage(
+			"Sign-in did not complete: the server returned an unexpected response when issuing an access token "+
+				"(this can happen when a reverse proxy rewrites the POST /api/tokens request into a GET). "+
+				"Check your reverse proxy configuration and run `multica login` again.",
+			err,
+		)
+	}
+
 	// Verify the PAT works.
-	patClient := cli.NewAPIClient(serverURL, "", patResp.Token)
+	patClient := cli.NewAPIClient(serverURL, "", patToken)
 	var me struct {
 		Name  string `json:"name"`
 		Email string `json:"email"`
@@ -346,7 +354,7 @@ func runAuthLoginBrowser(cmd *cobra.Command) error {
 	profile := resolveProfile(cmd)
 	cfg, _ := cli.LoadCLIConfigForProfile(profile)
 	cfg.WorkspaceID = ""
-	cfg.Token = patResp.Token
+	cfg.Token = patToken
 	cfg.ServerURL = serverURL
 	cfg.AppURL = appURL
 	if err := cli.SaveCLIConfigForProfile(cfg, profile); err != nil {
@@ -355,6 +363,29 @@ func runAuthLoginBrowser(cmd *cobra.Command) error {
 
 	fmt.Fprintf(os.Stderr, "Authenticated as %s (%s)\nToken saved to config.\n", me.Name, me.Email)
 	return nil
+}
+
+// parseAccessTokenResponse extracts the token field from a POST /api/tokens
+// response. The endpoint normally returns an object like {"token": "mul_..."},
+// but a misconfigured self-hosted reverse proxy (nginx/Traefik/Cloudflare) can
+// rewrite the POST into a GET against the token-list endpoint, which returns an
+// array. Decoding such a payload directly into a struct fails with an opaque
+// "json: cannot unmarshal array into Go value of type struct { Token string }".
+// Decode defensively so the caller can surface an actionable error instead.
+func parseAccessTokenResponse(raw []byte) (string, error) {
+	var obj map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &obj); err != nil {
+		return "", fmt.Errorf("access token response is not a JSON object")
+	}
+	field, ok := obj["token"]
+	if !ok {
+		return "", fmt.Errorf("access token response did not contain a %q field", "token")
+	}
+	var token string
+	if err := json.Unmarshal(field, &token); err != nil || token == "" {
+		return "", fmt.Errorf("access token response contained an empty or invalid %q field", "token")
+	}
+	return token, nil
 }
 
 func runningInSSHSession() bool {

--- a/server/cmd/multica/cmd_auth_test.go
+++ b/server/cmd/multica/cmd_auth_test.go
@@ -353,3 +353,61 @@ func TestValidateLoginTokenPrefix(t *testing.T) {
 		}
 	}
 }
+
+// TestParseAccessTokenResponse pins the defensive decode for the POST
+// /api/tokens response added for #3177: a misconfigured self-hosted reverse
+// proxy can rewrite the POST into a GET against the token-list endpoint, which
+// returns an array and used to fail with an opaque
+// "json: cannot unmarshal array into Go value of type struct { Token string }".
+func TestParseAccessTokenResponse(t *testing.T) {
+	t.Run("object with token", func(t *testing.T) {
+		token, err := parseAccessTokenResponse([]byte(`{"token":"mul_abc123"}`))
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if token != "mul_abc123" {
+			t.Errorf("expected mul_abc123, got %q", token)
+		}
+	})
+
+	t.Run("array surfaces an actionable error", func(t *testing.T) {
+		_, err := parseAccessTokenResponse([]byte(`[{"id":"1","name":"x"}]`))
+		if err == nil {
+			t.Fatal("expected error for array response, got nil")
+		}
+		if !strings.Contains(err.Error(), "not a JSON object") {
+			t.Errorf("expected 'not a JSON object' error, got %q", err.Error())
+		}
+	})
+
+	t.Run("missing token field", func(t *testing.T) {
+		_, err := parseAccessTokenResponse([]byte(`{"id":"1","name":"x"}`))
+		if err == nil {
+			t.Fatal("expected error for missing token, got nil")
+		}
+		if !strings.Contains(err.Error(), "did not contain") {
+			t.Errorf("expected 'did not contain' error, got %q", err.Error())
+		}
+	})
+
+	t.Run("empty token", func(t *testing.T) {
+		_, err := parseAccessTokenResponse([]byte(`{"token":""}`))
+		if err == nil {
+			t.Fatal("expected error for empty token, got nil")
+		}
+	})
+
+	t.Run("empty body", func(t *testing.T) {
+		_, err := parseAccessTokenResponse([]byte(``))
+		if err == nil {
+			t.Fatal("expected error for empty body, got nil")
+		}
+	})
+
+	t.Run("non-json body", func(t *testing.T) {
+		_, err := parseAccessTokenResponse([]byte(`not json`))
+		if err == nil {
+			t.Fatal("expected error for non-json body, got nil")
+		}
+	})
+}

--- a/server/internal/cli/client.go
+++ b/server/internal/cli/client.go
@@ -341,6 +341,39 @@ func (c *APIClient) PostJSON(ctx context.Context, path string, body any, out any
 	return json.NewDecoder(resp.Body).Decode(out)
 }
 
+// PostJSONRaw performs a POST request with a JSON body and returns the raw
+// response body without decoding it. It is intended for endpoints whose
+// response shape may vary — for example, when a self-hosted reverse proxy
+// rewrites POST /api/tokens into a GET against the list endpoint, the server
+// returns an array instead of the expected object and a direct struct decode
+// fails with an opaque "cannot unmarshal array" error. Callers can inspect the
+// raw payload and surface an actionable error instead.
+func (c *APIClient) PostJSONRaw(ctx context.Context, path string, body any) ([]byte, error) {
+	data, err := json.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.BaseURL+path, bytes.NewReader(data))
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	c.setHeaders(req)
+
+	resp, err := c.HTTPClient.Do(req)
+	err = wrapTransport(req, err)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode >= 400 {
+		return nil, newHTTPError(http.MethodPost, path, resp)
+	}
+	return io.ReadAll(resp.Body)
+}
+
 // PutJSON performs a PUT request with a JSON body.
 func (c *APIClient) PutJSON(ctx context.Context, path string, body any, out any) error {
 	data, err := json.Marshal(body)

--- a/server/internal/cli/client_test.go
+++ b/server/internal/cli/client_test.go
@@ -166,6 +166,71 @@ func TestPostJSON(t *testing.T) {
 	})
 }
 
+func TestPostJSONRaw(t *testing.T) {
+	t.Run("returns raw object body", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.Method != http.MethodPost {
+				t.Errorf("expected POST, got %s", r.Method)
+			}
+			w.Header().Set("Content-Type", "application/json")
+			io.WriteString(w, `{"token":"mul_xyz"}`)
+		}))
+		defer srv.Close()
+
+		client := NewAPIClient(srv.URL, "", "test-token")
+		raw, err := client.PostJSONRaw(context.Background(), "/api/tokens", map[string]any{"name": "x"})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if !strings.Contains(string(raw), "mul_xyz") {
+			t.Errorf("expected raw body to contain the token, got %q", raw)
+		}
+	})
+
+	t.Run("returns raw array body without failing", func(t *testing.T) {
+		// Reproduces #3177: a reverse proxy rewrites POST /api/tokens into a GET
+		// against the list endpoint, returning an array. PostJSONRaw must hand back
+		// the raw bytes so the caller can decode defensively — the previous
+		// PostJSON(path, body, &struct{Token string}) would have failed here with
+		// "json: cannot unmarshal array into Go value of type struct { Token string }".
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			io.WriteString(w, `[{"id":"1","name":"x"}]`)
+		}))
+		defer srv.Close()
+
+		client := NewAPIClient(srv.URL, "", "test-token")
+		raw, err := client.PostJSONRaw(context.Background(), "/api/tokens", map[string]any{"name": "x"})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		var arr []map[string]any
+		if err := json.Unmarshal(raw, &arr); err != nil {
+			t.Fatalf("expected array body the caller can decode, got %q: %v", raw, err)
+		}
+		if len(arr) != 1 {
+			t.Errorf("expected 1 element, got %d", len(arr))
+		}
+	})
+
+	t.Run("error status", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusBadRequest)
+			io.WriteString(w, "bad request")
+		}))
+		defer srv.Close()
+
+		client := NewAPIClient(srv.URL, "", "test-token")
+		_, err := client.PostJSONRaw(context.Background(), "/api/tokens", map[string]any{"name": "x"})
+		if err == nil {
+			t.Fatal("expected error, got nil")
+		}
+		if got := err.Error(); got != "POST /api/tokens returned 400: bad request" {
+			t.Errorf("unexpected error message: %s", got)
+		}
+	})
+}
+
 func TestDeleteJSONResponse(t *testing.T) {
 	type respBody struct {
 		ID string `json:"id"`


### PR DESCRIPTION
## What does this PR do?

`multica login` decoded the `POST /api/tokens` response directly into `struct{ Token string }`. When a self-hosted reverse proxy (nginx/Traefik/Cloudflare) rewrites the `POST /api/tokens` into a `GET` against the token-list endpoint, the server returns an array and the decode fails with an opaque `json: cannot unmarshal array into Go value of type struct { Token string }`, breaking login with no actionable hint.

This PR reads the raw response body (new `APIClient.PostJSONRaw` helper) and decodes defensively: extract the token from a JSON object, otherwise surface a clear `WithUserMessage` that names the reverse-proxy cause. Object responses are unchanged, so it is backward compatible.

## Related Issue

Closes #3177

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `server/internal/cli/client.go` — new `PostJSONRaw(ctx, path, body) ([]byte, error)` returning the raw response body without decoding (mirrors `PostJSON` but lets the caller interpret the payload).
- `server/cmd/multica/cmd_auth.go` — the browser-login flow now calls `PostJSONRaw` + a new `parseAccessTokenResponse` instead of decoding into a struct; on a non-object / missing-token / empty payload it returns an error that names the reverse-proxy rewrite as a likely cause (instead of leaking the Go json error).
- Unit tests added to both packages.

## How to Test

1. `cd server`
2. `go test ./internal/cli/ -run TestPostJSONRaw -v` → 3 subtests pass.
3. `go test ./cmd/multica/ -run TestParseAccessTokenResponse -v` → 6 subtests pass.
4. `gofmt -l` clean on all four changed files.

`TestPostJSONRaw/returns_raw_array_body_without_failing` and `TestParseAccessTokenResponse/array_surfaces_an_actionable_error` reproduce the #3177 scenario (an array body from a reverse-proxy POST→GET rewrite) and would have failed with the old opaque error.

Risks: none expected — `PostJSON` is untouched (other callers unaffected); the new path only changes behavior for responses that previously crashed login.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots *(N/A — CLI only)*
- [ ] I have updated relevant documentation to reflect my changes *(N/A)*
- [x] I have considered and documented any risks above
- [x] I will address all reviewer comments before requesting merge

## AI Disclosure

**AI tool used:** Claude Code

**Prompt / approach:** I used Claude Code to triage multica's open bug issues (filtering for maintainer-acknowledged, no conflicting PR, unit-testable fixes), locate the root cause in `cmd_auth.go` / `client.go`, implement the defensive decode, and write the unit tests. Verified locally with `go test` + `gofmt` before pushing.