### PR TITLE
fix(daemon): inherit workdir across agents on the same runtime (#3933)

### DIFF
--- a/server/internal/handler/daemon.go
+++ b/server/internal/handler/daemon.go
@@ -1703,6 +1703,22 @@ func (h *Handler) ClaimTaskByRuntime(w http.ResponseWriter, r *http.Request) {
 					resp.PriorWorkDir = prior.WorkDir.String
 				}
 			}
+
+			// Cross-agent workdir fallback: if no (agent, issue) prior yielded a
+			// workdir, inherit the most recent workdir for this issue on the same
+			// runtime even if a different agent produced it. The conversation
+			// session is intentionally NOT inherited across agents (kept
+			// agent-scoped above) — only the file artifacts are shared so a
+			// verification/review agent can continue from what the producing
+			// agent left on disk. See #3933.
+			if resp.PriorWorkDir == "" {
+				if issueWork, err := h.Queries.GetLastIssueWorkDir(r.Context(), db.GetLastIssueWorkDirParams{
+					IssueID:   task.IssueID,
+					RuntimeID: task.RuntimeID,
+				}); err == nil && issueWork.WorkDir.Valid {
+					resp.PriorWorkDir = issueWork.WorkDir.String
+				}
+			}
 		}
 	}
 

--- a/server/internal/handler/daemon_test.go
+++ b/server/internal/handler/daemon_test.go
@@ -3136,6 +3136,88 @@ func createRuntimeGuardRuntime(t *testing.T, ctx context.Context, provider strin
 	return runtimeID
 }
 
+// TestClaimTask_IssueCrossAgentWorkDirInherited pins the cross-agent workdir
+// fallback added for #3933: when a verification/review agent takes over an
+// issue from a producing agent (same issue, same runtime, different agent_id),
+// it must inherit the producer's work directory (file artifacts) — but the
+// conversation session must NOT cross agents. Before the fix, PriorWorkDir was
+// empty because GetLastTaskSession keys on (agent_id, issue_id) and the
+// verifier had no prior task of its own.
+func TestClaimTask_IssueCrossAgentWorkDirInherited(t *testing.T) {
+	if testHandler == nil {
+		t.Skip("database not available")
+	}
+
+	ctx := context.Background()
+
+	producerAgentID, runtimeID, daemonID := createRuntimeGuardAgent(t, ctx)
+
+	// A second agent sharing the same runtime — the verification/review agent.
+	var verifierAgentID string
+	if err := testPool.QueryRow(ctx, `
+		INSERT INTO agent (
+			workspace_id, name, runtime_mode, runtime_config,
+			runtime_id, visibility, max_concurrent_tasks
+		)
+		VALUES ($1, $2, 'local', '{}'::jsonb, $3, 'workspace', 3)
+		RETURNING id
+	`, testWorkspaceID, "Cross-Agent Verifier "+t.Name(), runtimeID).Scan(&verifierAgentID); err != nil {
+		t.Fatalf("setup: create verifier agent: %v", err)
+	}
+	t.Cleanup(func() { testPool.Exec(ctx, `DELETE FROM agent WHERE id = $1`, verifierAgentID) })
+
+	var issueID string
+	if err := testPool.QueryRow(ctx, `
+		INSERT INTO issue (workspace_id, title, status, priority, creator_id, creator_type, number, position)
+		VALUES ($1, 'cross-agent-workdir fixture', 'in_progress', 'none', $2, 'member', 81210, 0)
+		RETURNING id
+	`, testWorkspaceID, testUserID).Scan(&issueID); err != nil {
+		t.Fatalf("setup: create issue: %v", err)
+	}
+	t.Cleanup(func() { testPool.Exec(ctx, `DELETE FROM issue WHERE id = $1`, issueID) })
+
+	// The producer completed a task on this runtime, leaving a workdir and a
+	// poison-free session that is agent-scoped (it must NOT be inherited by the
+	// verifier).
+	if _, err := testPool.Exec(ctx, `
+		INSERT INTO agent_task_queue (
+			agent_id, runtime_id, issue_id, status, priority,
+			started_at, completed_at, session_id, work_dir
+		)
+		VALUES ($1, $2, $3, 'completed', 0, now(), now(), 'producer-session', '/tmp/producer-workdir')
+	`, producerAgentID, runtimeID, issueID); err != nil {
+		t.Fatalf("setup: create producer task: %v", err)
+	}
+
+	// The verifier has a fresh queued task for the same issue on the same runtime.
+	if _, err := testPool.Exec(ctx, `
+		INSERT INTO agent_task_queue (agent_id, runtime_id, issue_id, status, priority)
+		VALUES ($1, $2, $3, 'queued', 0)
+	`, verifierAgentID, runtimeID, issueID); err != nil {
+		t.Fatalf("setup: create verifier task: %v", err)
+	}
+
+	task := claimTaskForRuntimeGuard(t, runtimeID, daemonID)
+
+	// #3933: the verifier inherits the producer's workdir (file artifacts)...
+	if task.PriorWorkDir != "/tmp/producer-workdir" {
+		t.Fatalf("cross-agent workdir lost: expected PriorWorkDir='/tmp/producer-workdir', got %q", task.PriorWorkDir)
+	}
+	// ...but the conversation session is NOT inherited across agents.
+	if task.PriorSessionID != "" {
+		t.Fatalf("cross-agent session must NOT inherit, got PriorSessionID=%q", task.PriorSessionID)
+	}
+
+	// Cleanup the claimed task so it doesn't leak into other tests.
+	if _, err := testPool.Exec(ctx, `
+		UPDATE agent_task_queue
+		SET status = 'completed', completed_at = now()
+		WHERE issue_id = $1 AND status IN ('dispatched', 'running')
+	`, issueID); err != nil {
+		t.Fatalf("cleanup: complete claimed task: %v", err)
+	}
+}
+
 func TestChatSessionRuntimeBackfillRequiresMatchingSessionID(t *testing.T) {
 	if testHandler == nil {
 		t.Skip("database not available")

--- a/server/pkg/db/generated/agent.sql.go
+++ b/server/pkg/db/generated/agent.sql.go
@@ -2105,6 +2105,53 @@ func (q *Queries) GetAgentTaskInWorkspace(ctx context.Context, arg GetAgentTaskI
 	return i, err
 }
 
+const getLastIssueWorkDir = `-- name: GetLastIssueWorkDir :one
+SELECT work_dir, runtime_id FROM agent_task_queue
+WHERE issue_id = $1 AND runtime_id = $2
+  AND work_dir IS NOT NULL
+  AND (
+    status = 'completed'
+    OR (
+      status = 'failed'
+      AND COALESCE(failure_reason, '') NOT IN ('iteration_limit', 'agent_fallback_message', 'api_invalid_request', 'codex_semantic_inactivity')
+      AND NOT (COALESCE(error, '') ILIKE '%400%' AND COALESCE(error, '') ILIKE '%invalid_request_error%')
+    )
+  )
+ORDER BY COALESCE(completed_at, started_at, dispatched_at, created_at) DESC
+LIMIT 1
+`
+
+type GetLastIssueWorkDirParams struct {
+	IssueID   pgtype.UUID `json:"issue_id"`
+	RuntimeID pgtype.UUID `json:"runtime_id"`
+}
+
+type GetLastIssueWorkDirRow struct {
+	WorkDir   pgtype.Text `json:"work_dir"`
+	RuntimeID pgtype.UUID `json:"runtime_id"`
+}
+
+// GetLastIssueWorkDir returns the most recent usable work directory for an
+// issue on a given runtime, independent of which agent produced it. It is the
+// cross-agent fallback for workdir continuity: when a verification/review
+// agent takes over an issue from a producing agent (same issue, same runtime,
+// different agent_id), it should reuse the producer's work directory (file
+// artifacts) even though the conversation session must NOT be inherited across
+// agents.
+//
+// Unlike GetLastTaskSession, this lookup intentionally drops the agent_id
+// filter and does not require session_id to be non-null: a task that produced
+// files but whose session was poisoned/empty still has a valid work_dir worth
+// continuing from. The same poisoned-terminal and Anthropic-400 guards apply
+// so a bad run's workdir is not silently inherited. runtime_id must match to
+// avoid reusing a workdir path produced on a different machine.
+func (q *Queries) GetLastIssueWorkDir(ctx context.Context, arg GetLastIssueWorkDirParams) (GetLastIssueWorkDirRow, error) {
+	row := q.db.QueryRow(ctx, getLastIssueWorkDir, arg.IssueID, arg.RuntimeID)
+	var i GetLastIssueWorkDirRow
+	err := row.Scan(&i.WorkDir, &i.RuntimeID)
+	return i, err
+}
+
 const getLastTaskSession = `-- name: GetLastTaskSession :one
 SELECT session_id, work_dir, runtime_id FROM agent_task_queue
 WHERE agent_id = $1 AND issue_id = $2

--- a/server/pkg/db/queries/agent.sql
+++ b/server/pkg/db/queries/agent.sql
@@ -506,6 +506,35 @@ WHERE agent_id = $1 AND issue_id = $2
 ORDER BY COALESCE(completed_at, started_at, dispatched_at, created_at) DESC
 LIMIT 1;
 
+-- name: GetLastIssueWorkDir :one
+-- GetLastIssueWorkDir returns the most recent usable work directory for an
+-- issue on a given runtime, independent of which agent produced it. It is the
+-- cross-agent fallback for workdir continuity: when a verification/review
+-- agent takes over an issue from a producing agent (same issue, same runtime,
+-- different agent_id), it should reuse the producer's work directory (file
+-- artifacts) even though the conversation session must NOT be inherited across
+-- agents.
+--
+-- Unlike GetLastTaskSession, this lookup intentionally drops the agent_id
+-- filter and does not require session_id to be non-null: a task that produced
+-- files but whose session was poisoned/empty still has a valid work_dir worth
+-- continuing from. The same poisoned-terminal and Anthropic-400 guards apply
+-- so a bad run's workdir is not silently inherited. runtime_id must match to
+-- avoid reusing a workdir path produced on a different machine.
+SELECT work_dir, runtime_id FROM agent_task_queue
+WHERE issue_id = $1 AND runtime_id = $2
+  AND work_dir IS NOT NULL
+  AND (
+    status = 'completed'
+    OR (
+      status = 'failed'
+      AND COALESCE(failure_reason, '') NOT IN ('iteration_limit', 'agent_fallback_message', 'api_invalid_request', 'codex_semantic_inactivity')
+      AND NOT (COALESCE(error, '') ILIKE '%400%' AND COALESCE(error, '') ILIKE '%invalid_request_error%')
+    )
+  )
+ORDER BY COALESCE(completed_at, started_at, dispatched_at, created_at) DESC
+LIMIT 1;
+
 -- name: GetLastTaskStartedAtForIssueAndAgent :one
 -- Returns the started_at of the most recent prior task for this (agent, issue)
 -- pair, used as the "since" anchor for counting comments that arrived since the


### PR DESCRIPTION
## What does this PR do?

When an agent task is claimed, the daemon looks up the prior session via \`GetLastTaskSession\`, which keys on \`(agent_id, issue_id)\`. If a verification/review agent takes over an issue from a producing agent (same issue, same runtime, **different agent_id**), the verifier has no prior task of its own, so \`PriorWorkDir\` is empty and the daemon points it at a fresh temp directory — the verifier loses continuity with the files the producer left on disk (#3933).

This PR adds a cross-agent workdir fallback \`GetLastIssueWorkDir\` (keys on \`issue_id + runtime_id\`, agent-agnostic, same poisoned-session / Anthropic-400 guards, \`runtime_id\` must match so a workdir path from another machine is never reused). When the \`(agent, issue)\` lookup yields no workdir, the daemon inherits the most recent workdir for the issue on the same runtime. **The conversation session stays agent-scoped** — \`PriorSessionID\` is not inherited across agents; only the file artifacts are shared.

## Related Issue

Closes #3933

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- \`server/pkg/db/queries/agent.sql\` — new \`GetLastIssueWorkDir :one\` query (agent-agnostic, \`runtime_id\`-scoped, reuses the poisoned-terminal + Anthropic-400 guards from \`GetLastTaskSession\`).
- \`server/pkg/db/generated/agent.sql.go\` — regenerated via \`sqlc generate\` (sqlc v1.31.1).
- \`server/internal/handler/daemon.go\` — when \`PriorWorkDir\` is still empty after the \`(agent, issue)\` lookup, fall back to \`GetLastIssueWorkDir\`. \`PriorSessionID\` logic is untouched (stays agent-scoped).
- \`server/internal/handler/daemon_test.go\` — \`TestClaimTask_IssueCrossAgentWorkDirInherited\`: a producer agent completes a task (leaving \`/tmp/producer-workdir\` + a session), then a second agent sharing the runtime claims a task for the same issue; asserts \`PriorWorkDir == "/tmp/producer-workdir"\` and \`PriorSessionID == ""\`.

## How to Test

1. \`cd server\`
2. \`go vet ./internal/handler/\` — clean.
3. \`go build ./internal/handler/\` — clean.
4. \`go test ./internal/handler/ -run TestClaimTask_IssueCrossAgentWorkDirInherited -v\` — requires a reachable PostgreSQL (\`DATABASE_URL\` or the default \`postgres://multica:multica@localhost:5432/multica\`); the suite skips with exit 0 when no DB is available. CI runs it against a real database.
5. \`gofmt -l\` clean on the hand-written Go files.

Risks: the fallback only changes behavior when the existing \`(agent, issue)\` lookup produced **no** workdir (previously \`PriorWorkDir == ""\`, i.e. a fresh temp dir); the session-inheritance contract is unchanged. \`runtime_id\` matching prevents reusing a workdir path produced on a different machine.

Note: this is a deliberate, narrowly-scoped behavior change (workdir continuity across agents on the same runtime). The session remains agent-scoped by design, so cross-agent conversation context is not leaked — only file artifacts are shared.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have run tests locally and they pass *(go vet/build clean; the DB-backed test skips locally without a PostgreSQL and runs in CI)*
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots *(N/A)*
- [ ] I have updated relevant documentation to reflect my changes *(N/A)*
- [x] I have considered and documented any risks above
- [x] I will address all reviewer comments before requesting merge

## AI Disclosure

**AI tool used:** Claude Code

**Prompt / approach:** I used Claude Code to triage multica's open bug issues, locate the workdir-inheritance root cause in \`daemon.go\` + \`agent.sql\`, add the \`GetLastIssueWorkDir\` query + regenerate sqlc, implement the fallback, and write the regression test following the existing \`TestClaimTask_IssuePriorSessionRuntimeGuard\` pattern. Verified with \`go vet\` + \`go build\` + \`gofmt\`; the DB-backed test runs in CI.