### PR TITLE
refactor(views): remove Runtimes tab CLI-update red dot (MUL-4387)

### DIFF
--- a/packages/core/runtimes/hooks.ts
+++ b/packages/core/runtimes/hooks.ts
@@ -42,23 +42,6 @@ function runtimeNeedsUpdate(
 }
 
 /**
- * Returns true if the current user has any local runtime with an outdated CLI version.
- * Accepts wsId as parameter so callers outside WorkspaceIdProvider can use it safely.
- */
-export function useMyRuntimesNeedUpdate(wsId: string | undefined): boolean {
-  const userId = useAuthStore((s) => s.user?.id);
-  const { data: runtimes } = useQuery({
-    ...runtimeListOptions(wsId ?? ""),
-    enabled: !!wsId,
-  });
-  const { data: latestVersion } = useQuery(latestCliVersionOptions());
-
-  if (!runtimes || !latestVersion || !userId) return false;
-
-  return runtimes.some((rt) => runtimeNeedsUpdate(rt, latestVersion, userId));
-}
-
-/**
  * Returns a Set of runtime IDs that belong to the current user and have updates available.
  * Accepts wsId as parameter so callers outside WorkspaceIdProvider can use it safely.
  */

--- a/packages/views/layout/app-sidebar.test.tsx
+++ b/packages/views/layout/app-sidebar.test.tsx
@@ -149,7 +149,6 @@ vi.mock("@multica/core/modals", () => ({ useModalStore: { getState: () => ({ mod
 vi.mock("@multica/core/pins/mutations", () => ({ useDeletePin: () => ({ mutate: deletePin }), useReorderPins: () => ({ mutate: vi.fn() }) }));
 vi.mock("@multica/core/pins/queries", () => ({ pinListOptions: () => ({ queryKey: ["pins"] }) }));
 vi.mock("@multica/core/projects/queries", () => ({ projectDetailOptions: () => ({ queryKey: ["project"] }) }));
-vi.mock("@multica/core/runtimes/hooks", () => ({ useMyRuntimesNeedUpdate: () => false }));
 vi.mock("@multica/core/workspace/queries", () => ({
   myInvitationListOptions: () => ({ queryKey: ["invitations"] }),
   workspaceKeys: { myInvitations: () => ["invitations"] },

--- a/packages/views/layout/app-sidebar.tsx
+++ b/packages/views/layout/app-sidebar.tsx
@@ -76,7 +76,6 @@ import { chatSessionsOptions } from "@multica/core/chat/queries";
 import { api, ApiError } from "@multica/core/api";
 import { useModalStore } from "@multica/core/modals";
 import { useConfigStore } from "@multica/core/config";
-import { useMyRuntimesNeedUpdate } from "@multica/core/runtimes/hooks";
 import { pinListOptions } from "@multica/core/pins/queries";
 import { useDeletePin, useReorderPins } from "@multica/core/pins/mutations";
 import { issueDetailOptions } from "@multica/core/issues/queries";
@@ -394,7 +393,6 @@ export function AppSidebar({ topSlot, searchSlot, headerClassName, headerStyle }
   // Which workspaces have unread, so the switcher dropdown can point at the
   // specific one(s) rather than just the aggregate avatar dot.
   const unreadWsIds = React.useMemo(() => unreadWorkspaceIds(unreadSummary), [unreadSummary]);
-  const hasRuntimeUpdates = useMyRuntimesNeedUpdate(wsId);
   const { data: pinnedItems = EMPTY_PINS } = useQuery({
     ...pinListOptions(wsId ?? "", userId ?? ""),
     enabled: !!wsId && !!userId,
@@ -772,9 +770,6 @@ export function AppSidebar({ topSlot, searchSlot, headerClassName, headerStyle }
                       >
                         <item.icon />
                         <span>{t(($) => $.nav[item.labelKey])}</span>
-                        {item.key === "runtimes" && hasRuntimeUpdates && (
-                          <span className="ml-auto size-1.5 rounded-full bg-destructive" />
-                        )}
                       </SidebarMenuButton>
                     </SidebarMenuItem>
                   );


### PR DESCRIPTION
## Summary

Removes the red dot on the sidebar **Runtimes** nav item (MUL-4387).

### What the logic did (research)

Introduced in #533 (`feat(runtime): point-to-point update notifications via registered_by`), the dot was a **CLI update notification**:

- `latestCliVersionOptions()` fetched the latest release tag from the GitHub Releases API (10-min cache).
- `useMyRuntimesNeedUpdate(wsId)` returned true when the current user owned a **local** runtime (not launched by the Desktop app, which self-updates) whose reported `metadata.cli_version` was older than that tag.
- `app-sidebar.tsx` rendered a `bg-destructive` dot on the Runtimes item when true.

### Changes

- Remove the dot rendering + `useMyRuntimesNeedUpdate` usage from `packages/views/layout/app-sidebar.tsx`.
- Delete the now-unused `useMyRuntimesNeedUpdate` hook from `packages/core/runtimes/hooks.ts`.
- Drop the corresponding mock in `app-sidebar.test.tsx`.

**Not touched:** the per-runtime update arrow on the Runtimes page (`useUpdatableRuntimeIds`) still works, so update availability remains visible there.

### Verification

- `pnpm typecheck` — all 6 packages pass
- `packages/views` app-sidebar tests: 13/13 pass
- `packages/core` runtimes tests: 18/18 pass
- Lint: no issues in changed files

Closes MUL-4387
