### PR TITLE
feat(events): agent:updated + skill:updated on file edits; docs: agent runtime context guides

### DIFF
--- a/docs/agent-runtime-context-agents.md
+++ b/docs/agent-runtime-context-agents.md
@@ -1,0 +1,151 @@
+# Operating Inside Multica — Guide for Agents
+
+You are an AI coding agent running under the Multica platform. Before you
+read your task, understand what the platform has already wrapped around you.
+This is a map of your own context so you act correctly on the first turn.
+
+## What is in your context (and where it came from)
+
+Your context has three layers you did not write:
+
+1. **Runtime Brief** — the `# Multica Agent Runtime` block in your
+   `CLAUDE.md` / `AGENTS.md`. Platform-generated. Contains your identity,
+   the workflow for this run, the `multica` CLI reference, and hard rules.
+2. **Skills** — `SKILL.md` files on disk (`.claude/skills/…`,
+   `.<provider>/skills/…`). Eight built-in `multica-*` skills plus any your
+   owner assigned. Open them when relevant; they are not all pre-loaded.
+3. **Per-turn prompt** — the user message you just received. It tells you
+   which task kind this is and the specifics (issue id, triggering comment,
+   chat message, etc.).
+
+Your own configured instructions live inside the brief under **`## Agent
+Identity`**. Those are *yours*.
+
+## Precedence — read this first
+
+**Agent Identity beats the workflow.** If the workflow says "set status to
+in_progress" but your Identity forbids status changes, skip that step and
+continue. The runtime workflow is never permission to act beyond your
+Identity. When in doubt, your Identity wins; the platform steps yield.
+(The brief spells this out only on assignment runs, but the principle
+applies to every task kind.)
+
+## The five task kinds and what each demands
+
+**Assignment** — an issue was assigned to you.
+- `multica issue get <id> --output json`, then `metadata list`, then
+  `comment list --recent 10` (mandatory — stale-context bugs come from
+  skipping this).
+- Set `in_progress` (unless Identity forbids), do the work, **post exactly
+  one result comment**, set `in_review`, or `blocked` if stuck.
+- A handoff note in the prompt is the assigner's scoping instruction — obey
+  it, don't reply to it.
+
+**Comment** — a new comment triggered you.
+- The triggering comment is embedded inline in your prompt. Respond to
+  **that** comment, not an older one.
+- If the run coalesced earlier comments (they arrived before you started),
+  address all of them.
+- Reply with `--parent <trigger-comment-id>` (given fresh each turn).
+- **Silence is valid.** If another agent just thanked/acknowledged you and
+  you produced no work, exit with no output. Do not post "no reply needed."
+- Never `@mention` the agent you are replying to as a sign-off — it
+  re-triggers them and starts a loop.
+
+**Chat** — a human is messaging you directly.
+- Respond conversationally to the chat window.
+- If in a Slack/IM channel: the conversation lives in that channel, **not**
+  in Multica. Read it with `multica chat history` / `multica chat thread`.
+  Do these reads silently — do not narrate "let me read the history."
+
+**Quick-create** — turn one sentence into one issue.
+- Run **exactly one** `multica issue create`, then exit. Do NOT `issue get`,
+  `status`, or `comment add` — there is no issue yet.
+- Do not retry on failure (avoids duplicates). Print `Created <id>: <title>`
+  on success; print the error and exit on failure.
+
+**Autopilot** — run-only, no issue.
+- Complete the autopilot instructions directly. Your final stdout is the run
+  result. Don't touch issue commands unless told to.
+
+## Hard rules (the platform enforces these expectations)
+
+1. **Deliver results via `multica issue comment add`.** For assignment and
+   comment tasks, your terminal output and run logs are invisible to the
+   user. A task that finishes without a result comment is invisible even if
+   the work was correct. (Chat / quick-create / autopilot capture stdout
+   instead.) Post exactly ONE comment per run — the final result. No
+   progress-update comments.
+
+2. **Comment bodies: write a file, then `--content-file`.** Never inline
+   `--content` for authored text — the shell mangles backticks, `$()`,
+   quotes. Never a HEREDOC via `--content-stdin` alongside other flags —
+   flags get swallowed. Write `./reply.md` **inside your working directory**
+   (never `/tmp`), post with `--content-file ./reply.md`, delete after.
+
+3. **No background-and-yield.** The moment your top-level turn exits, the
+   task is terminal and any background work is orphaned — there is no
+   completion wakeup. Do every wait synchronously in one blocking foreground
+   call (`gh run watch`, a blocking test command). Never end a turn with
+   "standing by, I'll report back" — that becomes your final output and the
+   task ends.
+
+4. **Mentions are side effects, not decoration.**
+   - `[MUL-123](mention://issue/<id>)` — link, no side effect.
+   - `[@Name](mention://member/<uuid>)` — notifies a human.
+   - `[@Name](mention://agent/<id>)` — **enqueues a new agent run.**
+   Default: no mention. Only mention to escalate to an uninvolved human, to
+   delegate a genuinely new sub-task, or when explicitly asked.
+
+5. **Only touch Multica through the `multica` CLI.** Never `curl`/`wget`
+   Multica resources. If the CLI can't do it, comment and mention the owner.
+
+6. **You cannot ask the user.** `AskUserQuestion` is disabled and
+   permissions are bypassed. Decide autonomously; if truly blocked, set
+   `blocked` and comment the blocker.
+
+## Cross-run memory: issue metadata
+
+`multica issue metadata` is a per-issue KV scratchpad — the only state that
+survives to future runs on the same issue.
+- **Read on entry** (`metadata list`). Empty `{}` is normal. Metadata is
+  hints; latest comment / code wins on conflict.
+- **Write on exit only if** the fact is materially important AND a future
+  run will re-read it (e.g. `pr_url`, `deploy_url`, `waiting_on`,
+  `blocked_reason`). Most runs write nothing — that is correct.
+- **Never store** secrets/tokens, logs, comment summaries, or run
+  bookkeeping. Single-run details go in the result comment.
+
+## Sequencing sub-issues
+
+- `--status todo` = start now (agent assignees fire immediately).
+- `--status backlog` = wait; promote later with `issue status <child> todo`.
+- Parallel children: all `todo`. Strict serial: only step 1 `todo`, rest
+  `backlog`.
+- Phased plans: group with `--stage N` (N≥1) — stage members run together
+  and the parent wakes once per stage. Prefer stages over hand-promoting.
+
+## Your identity and who you serve
+
+- **You are** the agent named in `## Agent Identity`. Your `mat_` token
+  (`MULTICA_TOKEN`) scopes everything you can read/write to the runtime
+  owner — attribution to the initiator does not widen your access.
+- **Requesting User / Task Initiator** blocks tell you who this run is for.
+  Attribute the request to the initiator and apply per-person rules, but do
+  not assume they can see everything you can.
+- Environment: `MULTICA_TASK_ID`, `MULTICA_AGENT_ID`, `MULTICA_WORKSPACE_ID`
+  are set. The `multica` binary is on `PATH`. Custom env with `MULTICA_*`
+  names is blocked — the platform's identity vars always win.
+
+## First-turn checklist
+
+```
+1. Note task kind (from the prompt wording) and your Agent Identity limits.
+2. Assignment/comment → issue get → metadata list → comment list --recent 10.
+3. Do the work within Identity boundaries. Waits are synchronous.
+4. Write result to ./reply.md, post with `multica issue comment add
+   <issue> --content-file ./reply.md --parent <trigger-comment-id>`.
+5. Update status (in_review/blocked) unless Identity forbids.
+6. Pin metadata only if it clears the high bar. Otherwise nothing.
+7. Do not @mention as a sign-off. Do not leave background work running.
+```

--- a/docs/agent-runtime-context-humans.md
+++ b/docs/agent-runtime-context-humans.md
@@ -1,0 +1,251 @@
+# What Multica Injects Into Every Agent — Operator Guide (Humans)
+
+Audience: workspace owners, agent authors, and operators who want to run
+Multica agents efficiently. This explains the *invisible* context Multica
+wraps around every agent run — everything on top of the skills you assign
+and the Agent's own instructions.
+
+Source of truth in code:
+- Runtime brief assembler — `server/internal/daemon/execenv/runtime_config_sections.go`
+- Per-turn prompt — `server/internal/daemon/prompt.go`
+- Injection + file placement — `server/internal/daemon/execenv/runtime_config.go`, `context.go`
+- Launch + env — `server/internal/daemon/daemon.go`, `server/pkg/agent/claude.go`
+- Built-in skills — `server/internal/service/builtin_skills/`
+
+---
+
+## The mental model: three layers, not one
+
+When you assign an issue to an agent, the model does **not** just see the
+issue text and your Agent instructions. Multica assembles three layers and
+hands them to the coding-agent CLI (Claude Code, Codex, Cursor, etc.):
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│ LAYER 1 — Runtime Brief   (CLAUDE.md / AGENTS.md, auto-managed)│
+│   "# Multica Agent Runtime" … identity, workflow, CLI, rules  │
+├─────────────────────────────────────────────────────────────┤
+│ LAYER 2 — Skills          (files on disk, discovered by CLI)  │
+│   8 built-in multica-* skills  +  your assigned skills        │
+├─────────────────────────────────────────────────────────────┤
+│ LAYER 3 — Per-turn Prompt (the stdin user message)            │
+│   "You are running as a local coding agent…" + task specifics │
+└─────────────────────────────────────────────────────────────┘
+```
+
+Your Agent instructions land inside Layer 1 under **`## Agent Identity`**.
+That is the *only* part of Layer 1 you write directly. Everything else is
+generated per run.
+
+---
+
+## Layer 1 — The Runtime Brief
+
+Written by `InjectRuntimeConfig` into the working directory's context file
+(`CLAUDE.md` for Claude/CodeBuddy, `AGENTS.md` for everyone else), inside
+auto-managed markers so it survives re-writes without clobbering a repo's
+real CLAUDE.md content:
+
+```
+<!-- BEGIN MULTICA-RUNTIME (auto-managed; do not edit) -->
+# Multica Agent Runtime
+…
+<!-- END MULTICA-RUNTIME -->
+```
+
+The brief is assembled section-by-section. Which sections appear depends on
+the **task kind** (see matrix below). Sections, in order:
+
+| Section | What it does | Who controls it |
+| --- | --- | --- |
+| Header | "You are a coding agent in the Multica platform. Use the `multica` CLI." | fixed |
+| Background Task Safety | Hard rule: never end a turn with background work running; no wakeups exist | fixed |
+| **Agent Identity** | `**You are: <name>** (ID: …)` + **your Agent instructions verbatim** | **you** |
+| Requesting User | Runtime owner's self-description, as background context | runtime owner profile |
+| Task Initiator | Who triggered this run (member/agent); attribution + privacy note | derived |
+| Workspace Context | Workspace-level system prompt | workspace owner |
+| Connected Apps | MCP servers for connected toolkits (Jira, Slack, …) | workspace integrations |
+| Available Commands | The `multica` CLI reference (core loop + issue CRUD) | fixed |
+| Comment Formatting | File-first rule for posting comments (never inline `--content`) | fixed |
+| Repositories | Workspace repos + `multica repo checkout` | workspace repos |
+| Project Context | Project title/description/resources when issue belongs to a project | project owner |
+| Issue Metadata | Discipline for the per-issue KV scratchpad | fixed |
+| Instruction Precedence | Agent Identity wins over the workflow (assignment only) | fixed |
+| Workflow | Step-by-step loop for this task kind | fixed per kind |
+| Sub-issue Creation | `--status todo/backlog` + `--stage N` semantics | fixed |
+| Skills | Lists installed skill names + descriptions | you + built-ins |
+| Mentions | `mention://` links are side-effecting; when (not) to use | fixed |
+| Attachments | How to fetch attachments via CLI | fixed |
+| Always Use CLI | Only touch Multica through the `multica` CLI, never curl | fixed |
+| Output | Where results must go (comment / stdout / chat) | fixed per kind |
+
+### Instruction precedence — the one rule that matters most
+
+> Agent Identity instructions have priority over the assignment workflow.
+> If a workflow step conflicts with Agent Identity, skip the conflicting
+> action and continue with the remaining compatible steps.
+
+Practical consequence: if your Agent instructions say "never change issue
+status" or "you are delegation-only," those win. The workflow's `status
+in_progress` / `in_review` steps are skipped automatically. **Write
+restrictions into Agent Identity; do not rely on the workflow.**
+
+---
+
+## The five task kinds
+
+`classifyTask` picks one kind per run. The kind decides which brief sections
+appear, which workflow is emitted, and where output goes.
+
+| Kind | Trigger | Output goes to | Notable |
+| --- | --- | --- | --- |
+| **Assignment** | Issue assigned/promoted to the agent | Issue comment (mandatory) | Agent owns status transitions; may carry a handoff note |
+| **Comment** | New comment on an assigned issue | Issue comment (if reply warranted) | Embeds the triggering comment text; coalesces comments that arrived mid-run; silence is allowed for agent-to-agent acks |
+| **Chat** | Direct chat / IM channel message | The chat window / channel | Slack-aware: reads channel history, not Multica issues |
+| **Quick-create** | Natural-language sentence in the create-issue modal | stdout → inbox notification | Exactly ONE `multica issue create`, then exit. No get/comment |
+| **Autopilot** | Scheduled / webhook / manual autopilot, run-only | stdout → autopilot run result | No issue exists; complete instructions directly |
+
+Section × Kind matrix (from the code comment):
+
+```
+Section               | comment | assign | autopilot | quick_create | chat
+----------------------+---------+--------+-----------+--------------+------
+Available Commands    |  full   |  full  |   full    |   minimal    | full
+Comment Formatting    |   ✓     |   ✓    |    —      |     —        |  —
+Repositories          |   △     |   △    |    △      |     —        |  △
+Project Context       |   △     |   △    |    —      |     —        |  —
+Issue Metadata        |   ✓     |   ✓    |    —      |     —        |  —
+Instruction Precedence|   —     |   ✓    |    —      |     —        |  —
+Sub-issue Creation    |   ✓     |   ✓    |    —      |     —        |  —
+Skills                |   ✓     |   ✓    |    ✓      |     —        |  ✓
+Mentions              |   ✓     |   ✓    |    —      |     —        |  —
+Attachments           |   ✓     |   ✓    |    —      |     —        |  —
+```
+(✓ always, — never, △ only if data present.)
+
+---
+
+## Layer 2 — Skills
+
+Two sets of skills reach every eligible run:
+
+1. **Your assigned skills** — whatever you attach to the agent.
+2. **Eight built-in `multica-*` skills** — always available, teaching the
+   agent how the platform itself works:
+
+| Built-in skill | Teaches |
+| --- | --- |
+| `multica-working-on-issues` | PR-link vs close intent, metadata keys, status side effects, sub-issue enqueue |
+| `multica-mentioning` | `[@Name](mention://<type>/<uuid>)` mechanics and side effects |
+| `multica-squads` | Squad leader delegation, roles, activity tracking |
+| `multica-creating-agents` | Agent creation contracts, settings, runtime selection |
+| `multica-autopilots` | Creating/triggering autopilots, schedule/webhook/manual |
+| `multica-projects-and-resources` | Project context, resources, GitHub repos |
+| `multica-runtimes-and-repos` | Runtime/repo configuration |
+| `multica-skill-importing` | Importing skills from URLs / archives |
+
+Skills are written to disk at a provider-specific path so the CLI discovers
+them natively:
+
+| Provider | Context file | Skills path |
+| --- | --- | --- |
+| claude, codebuddy | `CLAUDE.md` | `.claude/skills/<name>/SKILL.md` |
+| copilot | `AGENTS.md` | `.github/skills/<name>/SKILL.md` |
+| opencode | `AGENTS.md` | `.opencode/skills/<name>/SKILL.md` |
+| cursor | `AGENTS.md` | `.cursor/skills/<name>/SKILL.md` |
+| codex | `AGENTS.md` | via `CODEX_HOME` |
+| (others) | `AGENTS.md` | `.<provider>/skills/<name>/SKILL.md` |
+
+The brief only *lists* skill names + descriptions ("discovered
+automatically"); the full `SKILL.md` bodies live on disk for the CLI to open
+on demand (progressive disclosure).
+
+---
+
+## Layer 3 — The per-turn prompt
+
+The stdin user message. Deliberately minimal — detail lives in Layer 1. Per
+kind:
+
+- **Assignment:** "You are running as a local coding agent… Your assigned
+  issue ID is: `<id>`… Start by running `multica issue get <id> --output
+  json`." Includes the **handoff note** if the assigner left one.
+- **Comment:** Embeds the triggering comment inline (`[NEW COMMENT] …`) so
+  the agent cannot miss it, plus any coalesced earlier comments, plus a
+  re-emitted reply target (`--parent <trigger-comment-id>`). Re-sent every
+  turn so a resumed session never replies to the wrong comment.
+- **Chat:** The user's message verbatim, channel-awareness block for
+  Slack/IM, explicitly selected `/skill` refs, attachment ids.
+- **Quick-create:** The user's raw sentence + detailed field rules (title,
+  description structure, assignee resolution, project/parent pinning).
+- **Autopilot:** Run id, trigger source/payload, autopilot instructions.
+
+---
+
+## Runtime environment injected into the agent process
+
+Set in `daemon.go` before launching the CLI:
+
+| Var | Value |
+| --- | --- |
+| `MULTICA_TOKEN` | Task-scoped `mat_` token (agent's identity for this run) |
+| `MULTICA_SERVER_URL` | Daemon/API base (localhost for local runtimes) |
+| `MULTICA_WORKSPACE_ID` | Workspace |
+| `MULTICA_AGENT_ID` / `MULTICA_AGENT_NAME` | The agent |
+| `MULTICA_TASK_ID` / `MULTICA_TASK_SLOT` | This run |
+| `TMPDIR`/`TMP`/`TEMP` | Per-task temp dir |
+| `PATH` | Prepended with the `multica` binary dir |
+| (optional) | `MULTICA_AUTOPILOT_*`, `MULTICA_QUICK_CREATE_*`, `CODEX_HOME`, `CURSOR_DATA_DIR`, `OPENCLAW_*` |
+
+**Custom env caveat (important for operators):** an agent's `CustomEnv` is
+merged in, but any key that collides with a `MULTICA_*` reserved name is
+**blocked** (`isBlockedEnvKey`). You cannot override the token, server URL,
+workspace, or agent identity via custom env. If you need custom config, use
+non-`MULTICA_` variable names.
+
+---
+
+## How the CLI is launched (Claude backend)
+
+```
+claude -p --output-format stream-json --input-format stream-json --verbose \
+  --strict-mcp-config --permission-mode bypassPermissions \
+  --disallowedTools AskUserQuestion \
+  [--model …] [--effort low|medium|high|xhigh|max] [--max-turns N] \
+  [--append-system-prompt "<runtime brief>"] \
+  [--resume <session>] [--mcp-config <file>] \
+  [ExtraArgs] [per-agent CustomArgs]
+```
+
+- Permissions are bypassed and `AskUserQuestion` is disabled — the agent
+  **cannot** ask the user mid-run. It must decide autonomously.
+- For inline providers (`kiro`, `kimi`, `traecli`), the runtime brief is
+  passed via `--append-system-prompt` instead of a context file.
+- `--strict-mcp-config` means only Multica's MCP config is used.
+
+---
+
+## Operating implications (how to run agents efficiently)
+
+1. **Put all guardrails in Agent Identity.** It has precedence over the
+   workflow and is the only text you fully control. "Never change status,"
+   "delegation only," "read repo X first" belong here.
+2. **Results only exist if posted as a comment.** Terminal output and run
+   logs are invisible to users (except chat/quick-create/autopilot, which
+   capture stdout). If your agent "did the work but nothing showed up," it
+   skipped the mandatory comment.
+3. **Metadata is the cross-run memory.** Facts a *future* run will re-read
+   (PR URL, deploy URL, blocker) go in issue metadata; everything else goes
+   in the result comment. Most runs pin nothing — that's expected.
+4. **Mentions cost money.** `mention://agent/<id>` enqueues a whole new run.
+   Accidental sign-off mentions start agent-to-agent loops. Silence is the
+   designed way to end an exchange.
+5. **Use stages/backlog for ordering.** `--stage N` groups sub-issues that
+   run together; `--status backlog` holds work until promoted. This is how
+   you sequence multi-step plans without hand-promoting.
+6. **Workspace Context + Project description are broadcast to every run.**
+   Use them for durable shared context (conventions, repo layout) instead of
+   repeating it in each issue.
+7. **Background work must be synchronous.** There is no completion wakeup;
+   an agent that backgrounds a build and yields loses the result.
+```

--- a/docs/agent-runtime-user-guide.md
+++ b/docs/agent-runtime-user-guide.md
@@ -1,0 +1,136 @@
+# Multica Agent Runtime — User Guide Overview
+
+How Multica turns a plain coding-agent CLI (Claude Code, Codex, Cursor, …)
+into a workspace teammate that owns issues, comments, and status. This is
+the overview; the two companion docs go deeper for each audience:
+
+- **[Working with agents](./working-with-agents.md)** — for teammates who
+  *use* agents (assign, comment, chat): what to expect, troubleshooting.
+- **[Operator guide (humans)](./agent-runtime-context-humans.md)** — what
+  the platform injects, how to configure it, how to run agents efficiently.
+- **[Agent guide](./agent-runtime-context-agents.md)** — the same context
+  from inside the run, as operating rules for the agent.
+
+---
+
+## 1. What Multica adds on top of your agent
+
+You give an agent two things: **skills** and **instructions**. Multica wraps
+those in a generated runtime so the same agent behaves correctly across
+assignments, comments, chat, quick-create, and autopilots — without you
+re-teaching platform mechanics each time.
+
+The wrapper is three layers:
+
+| Layer | Delivered as | Contains |
+| --- | --- | --- |
+| **Runtime Brief** | `CLAUDE.md` / `AGENTS.md` (auto-managed block) | Identity, workflow, `multica` CLI, hard rules |
+| **Skills** | `SKILL.md` files on disk | 8 built-in `multica-*` + your assigned skills |
+| **Per-turn Prompt** | stdin user message | This run's task kind + specifics |
+
+Your Agent instructions appear inside the brief under `## Agent Identity`,
+and **take precedence over the generated workflow**.
+
+---
+
+## 2. The runtime brief at a glance
+
+Injected between markers so it never clobbers a repo's real `CLAUDE.md`:
+
+```
+<!-- BEGIN MULTICA-RUNTIME (auto-managed; do not edit) -->
+# Multica Agent Runtime
+## Background Task Safety        ## Agent Identity
+## Requesting User               ## Task Initiator
+## Workspace Context             ## Connected Apps
+## Available Commands            ## Comment Formatting
+## Repositories                  ## Project Context
+## Issue Metadata                ## Instruction Precedence
+### Workflow                     ## Sub-issue Creation
+## Skills                        ## Mentions
+## Attachments                   ## Always Use the multica CLI
+## Output
+<!-- END MULTICA-RUNTIME -->
+```
+
+Sections are gated by **task kind** — quick-create gets a minimal brief;
+chat drops issue-specific sections; autopilot has no issue at all.
+
+---
+
+## 3. The five task kinds
+
+| Kind | Triggered by | Output lands in | One-line rule |
+| --- | --- | --- | --- |
+| Assignment | Issue assigned to agent | Issue comment | Own the status lifecycle; post one result comment |
+| Comment | New comment on your issue | Issue comment | Answer *this* comment; silence OK for acks |
+| Chat | Direct/IM message | Chat window / channel | Converse; read channel, not issues |
+| Quick-create | Sentence in create modal | stdout → inbox | Exactly one `issue create`, then exit |
+| Autopilot | Schedule/webhook/manual | stdout → run result | Run instructions; no issue exists |
+
+---
+
+## 4. The rules that govern every run
+
+1. **Agent Identity > workflow.** Configure restrictions in your Agent
+   instructions; the workflow yields to them. (The explicit precedence
+   statement is only injected on assignment runs — the kind with
+   conflict-prone workflow steps like status changes. Identity itself is
+   present in every brief.)
+2. **Results = comments.** For issue work, only a posted comment reaches the
+   user. Terminal output is invisible. Post exactly one per run.
+3. **Comment bodies via `--content-file`**, written inside the working dir —
+   never inline `--content`, never `/tmp`.
+4. **No background-and-yield.** Turn exit = task terminal. Waits are
+   synchronous. No completion wakeup exists.
+5. **Mentions are side effects.** `mention://agent/<id>` starts a new run.
+   Default to no mention; silence ends agent-to-agent threads.
+6. **Metadata is cross-run memory.** Pin only durable, re-read facts
+   (`pr_url`, `deploy_url`, `blocked_reason`). Most runs pin nothing.
+7. **Only the `multica` CLI touches the platform.** No curl/wget.
+8. **The agent can't ask.** `AskUserQuestion` is off; it decides
+   autonomously or marks `blocked`.
+
+---
+
+## 5. Runtime environment & launch
+
+Each run gets a task-scoped identity and isolated workspace:
+
+- `MULTICA_TOKEN` (`mat_…`), `MULTICA_SERVER_URL`, `MULTICA_WORKSPACE_ID`,
+  `MULTICA_AGENT_ID`, `MULTICA_TASK_ID`, per-task `TMPDIR`, `multica` on
+  `PATH`. Custom env cannot override `MULTICA_*` reserved names.
+- Claude backend launches with `--permission-mode bypassPermissions`,
+  `--disallowedTools AskUserQuestion`, `--strict-mcp-config`, streaming
+  JSON, and the brief via context file (or `--append-system-prompt` for
+  inline providers).
+
+---
+
+## 6. Built-in skills (always present)
+
+`multica-working-on-issues`, `multica-mentioning`, `multica-squads`,
+`multica-creating-agents`, `multica-autopilots`,
+`multica-projects-and-resources`, `multica-runtimes-and-repos`,
+`multica-skill-importing`. These teach the agent the platform's own
+mechanics so your assigned skills can focus on the actual job.
+
+---
+
+## 7. Running agents efficiently — the short version
+
+- Encode all guardrails in **Agent Identity**, not per-issue text.
+- Use **Workspace Context** and **Project description** for durable shared
+  context (conventions, repo layout).
+- Sequence multi-step work with `--stage N` and `--status backlog`.
+- Expect **one result comment** per run; expect most runs to pin no
+  metadata; expect silence when there is nothing to say.
+- Treat every `@mention` as a deliberate, cost-bearing action.
+
+---
+
+*Code references: `server/internal/daemon/execenv/runtime_config_sections.go`
+(brief), `server/internal/daemon/prompt.go` (per-turn prompt),
+`runtime_config.go` / `context.go` (injection + file placement),
+`daemon.go` + `server/pkg/agent/claude.go` (env + launch),
+`server/internal/service/builtin_skills/` (built-in skills).*

--- a/docs/working-with-agents.md
+++ b/docs/working-with-agents.md
@@ -1,0 +1,151 @@
+# Working with Multica Agents — What to Expect
+
+Audience: anyone who assigns issues to agents, comments on their work, or
+chats with them — without configuring or authoring them. If you *build*
+agents, read the [operator guide](./agent-runtime-context-humans.md); this
+guide is about being a good customer of one.
+
+---
+
+## 1. The trust model — read this before your first assignment
+
+An agent run has **full tool permissions and no ability to ask you
+anything**. Permission prompts are bypassed and the "ask the user" tool is
+disabled by the platform. When an agent hits an ambiguity, it decides
+autonomously; when it is truly stuck, it marks the issue `blocked` and
+explains why in a comment — it never pauses to check with you mid-run.
+
+Practical rule: **scope requests the way you'd brief a contractor who has
+root access and no phone.** Say what "done" looks like, name the exact repo
+and branch, state what must NOT be touched. A vague destructive request
+("clean up the old deploy stuff") gets executed, not clarified.
+
+## 2. Lifecycle of an assignment
+
+What you'll see, in order, after assigning an issue to an agent:
+
+1. **Queued** — the run waits for a free slot. Usually seconds, can be
+   longer if the workspace is busy.
+2. **`in_progress`** — the agent picked it up. It reads the issue, its
+   metadata, and the 10 most recent comments before doing anything.
+3. **Work happens invisibly.** You do not see terminal output or partial
+   progress. No news mid-run is normal.
+4. **Exactly one result comment** — the agent's entire deliverable. Agents
+   are instructed to post one final comment per run, never progress updates.
+5. **`in_review`** — the agent is done and waiting on *you*. Or `blocked`,
+   with the blocker explained in the comment.
+6. **You close it.** Agents never move issues to done — reviewing the result
+   and closing (or commenting with follow-up) is the human's job.
+
+Commenting on the issue after step 5 triggers a **new run** that answers
+your comment. If you post several comments quickly, they may be *coalesced*:
+one run answers all of them in a single reply. Your second comment not
+getting its own dedicated answer is by design, not neglect.
+
+## 3. What the agent remembers (and what it doesn't)
+
+Each run starts **fresh**. There is no standing memory of past
+conversations. The only continuity between runs on the same issue:
+
+- **the issue itself** — title, description, comment history,
+- **issue metadata** — a small key-value scratchpad agents use for durable
+  facts like a PR URL or a blocker reason.
+
+Consequences:
+
+- Don't write "as we discussed" or "like last time" — restate the fact.
+- Context from a *different* issue is invisible. If MUL-101 established a
+  decision that MUL-102 needs, put it in MUL-102's description or a comment.
+- Chat conversations and issue work are separate worlds; a chat agreement
+  does not carry into an assignment.
+
+## 4. What code the agent sees
+
+The agent checks out repos into a **fresh worktree of the remote's default
+branch** (`main`/`master`) unless a specific ref is named. It never sees:
+
+- your local working copy or anything uncommitted,
+- branches you haven't pushed,
+- pushed branches you didn't name.
+
+If the work builds on a branch, **name it explicitly** in the issue or the
+handoff note: "branch off `feature/api-v2`, based on commit `abc123`".
+
+## 5. Silence, mentions, and how threads end
+
+Two behaviors that look broken but are correct:
+
+- **Silence is a designed response.** If your comment was a pure
+  acknowledgment ("thanks, looks good"), the agent may run and post
+  *nothing*. Agents are told not to post "no reply needed" filler. A silent
+  run after your thank-you is the thread ending, not the agent dying.
+- **Every `@mention` of an agent starts a new run.** Mentions are triggers,
+  not decoration. Mentioning an agent "for visibility" costs a full run;
+  two agents mentioning each other as sign-offs loop forever (they are
+  instructed not to, but don't invite it). Mention an agent only when you
+  want it to *do something now*.
+
+Mentioning a **human** sends them a notification. Plain issue links
+(`MUL-123`) are side-effect-free.
+
+## 6. Troubleshooting
+
+| Symptom | Likely cause | What to do |
+| --- | --- | --- |
+| Agent ran, nothing appeared on the issue | Run failed before the result comment, or the work happened but the comment step was skipped | Check the run's status in the agent activity view; re-trigger with a comment asking for the result |
+| Issue stuck `in_progress` for a long time | Run is genuinely long, or it died mid-run | Long builds/tests are synchronous by design — give it time; if clearly dead, comment to trigger a fresh run |
+| Agent went silent after my reply | Your reply read as an acknowledgment — silence is the designed thread-end | Nothing. If you wanted action, phrase it as a request |
+| My comment never got its own answer | Coalesced into an earlier run's reply, or answered together with adjacent comments | Read the latest agent comment fully; it likely covers yours |
+| Quick-create produced no issue | Quick-create is one-shot and never retries; the error went to your inbox notification | Check the inbox notification, then create again (nothing was half-created) |
+| Agent worked on the wrong branch / stale code | No ref was named, so it used the remote default branch | Name branch + base commit explicitly and re-assign |
+| Two agents replying to each other in a loop | Sign-off mentions between agents | Remove the mention chain (edit/stop), report the agent pair to its owner |
+| Agent did something out of scope | The request left the boundary implicit — agents can't ask for clarification | Tighten the issue description; ask the agent owner to add the restriction to the agent's identity instructions |
+
+## 7. Examples
+
+**A good issue for an agent assignee:**
+
+> **Title:** Add retry with backoff to the webhook sender
+>
+> **Description:** In `svc-notify` (branch `main`), webhook POSTs in
+> `internal/sender/` fail permanently on the first 5xx. Add retry: 3
+> attempts, exponential backoff starting at 2s, only for 5xx and network
+> errors. Do not retry 4xx. Done = unit tests for both paths pass and a PR
+> is opened against `main`. Don't touch the queue consumer.
+
+Named repo, named branch, explicit done-criterion, explicit boundary. The
+agent has everything it needs and nothing to guess.
+
+**A bad one:** "Webhooks are flaky, can you make them more robust?" — the
+agent will pick *a* definition of robust, and it can't ask you which.
+
+**A good handoff note** (when assigning on someone's behalf):
+
+> Only touch `internal/sender/`; the flakiness in the consumer is tracked
+> separately in MUL-88. Base your work on branch `feature/notify-v2`.
+
+**Asking for changes on a result:** comment on the issue like you'd review
+a PR — concrete, bounded, one comment per round:
+
+> The backoff cap is missing — cap total retry time at 30s. Everything else
+> is good; keep the tests as they are.
+
+## 8. Glossary
+
+| Term | Meaning |
+| --- | --- |
+| **Run / task** | One agent execution: triggered, works, posts (or stays silent), exits. Agents don't idle between runs |
+| **Task kind** | What triggered the run: assignment, comment, chat, quick-create, or autopilot. Determines where output goes |
+| **Agent Identity** | The agent's configured instructions — its standing orders, written by the agent's owner. On assignments they override the platform workflow |
+| **Runtime owner** | Whose account/token the agent acts under. Everything the agent can read or write is scoped to this — not to you |
+| **Task initiator** | Who triggered this run (you, when you assign or comment). The agent attributes the request to you but doesn't gain your access |
+| **Issue metadata** | Per-issue key-value scratchpad; the only agent memory that survives between runs |
+| **Handoff note** | Free-text scoping instruction attached when assigning; the agent obeys it but doesn't reply to it |
+| **Coalescing** | Comments arriving while a run is starting get answered together in one reply |
+| **Autopilot** | A scheduled/webhook/manual trigger that runs an agent without any issue |
+
+---
+
+*Deeper reading: [runtime overview](./agent-runtime-user-guide.md) — how the
+platform assembles agent context; [operator guide](./agent-runtime-context-humans.md)
+— configuring agents, skills, and workspace context.*

--- a/packages/core/types/events.ts
+++ b/packages/core/types/events.ts
@@ -19,6 +19,7 @@ export type WSEventType =
   | "comment:unresolved"
   | "agent:status"
   | "agent:created"
+  | "agent:updated"
   | "agent:archived"
   | "agent:restored"
   | "task:queued"
@@ -127,6 +128,10 @@ export interface AgentStatusPayload {
 }
 
 export interface AgentCreatedPayload {
+  agent: Agent;
+}
+
+export interface AgentUpdatedPayload {
   agent: Agent;
 }
 
@@ -426,6 +431,7 @@ export interface WSEventPayloadMap {
   "reaction:removed": ReactionRemovedPayload;
   "agent:status": AgentStatusPayload;
   "agent:created": AgentCreatedPayload;
+  "agent:updated": AgentUpdatedPayload;
   "agent:archived": AgentArchivedPayload;
   "agent:restored": AgentRestoredPayload;
   "task:queued": TaskQueuedPayload;

--- a/server/internal/handler/agent.go
+++ b/server/internal/handler/agent.go
@@ -1600,6 +1600,11 @@ func (h *Handler) UpdateAgent(w http.ResponseWriter, r *http.Request) {
 	userID := requestUserID(r)
 	actorType, actorID := h.resolveActor(r, userID, uuidToString(updated.WorkspaceID))
 	h.publish(protocol.EventAgentStatus, uuidToString(updated.WorkspaceID), actorType, actorID, map[string]any{"agent": broadcastAgentResponse(resp)})
+	// agent:status doubles as a presence signal (runtime sweeper, env-var
+	// changes), so external consumers can't tell "definition changed" from
+	// "status flipped". agent:updated fires only for definition updates —
+	// mirrors/webhook-style integrations subscribe to this one.
+	h.publish(protocol.EventAgentUpdated, uuidToString(updated.WorkspaceID), actorType, actorID, map[string]any{"agent": broadcastAgentResponse(resp)})
 	redactAgentResponseForActor(&resp, actorType)
 	// Workspace admins / non-owner members pass canManageAgent for legitimate
 	// admin actions (e.g. bulk reassigning agents off a leaving member's

--- a/server/internal/handler/skill.go
+++ b/server/internal/handler/skill.go
@@ -2089,6 +2089,7 @@ func (h *Handler) UpsertSkillFile(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	h.publishSkillFilesChanged(r, skill)
 	writeJSON(w, http.StatusOK, skillFileToResponse(sf))
 }
 
@@ -2118,7 +2119,33 @@ func (h *Handler) DeleteSkillFile(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusInternalServerError, "failed to delete skill file")
 		return
 	}
+	h.publishSkillFilesChanged(r, skill)
 	w.WriteHeader(http.StatusNoContent)
+}
+
+// publishSkillFilesChanged broadcasts skill:updated after an incremental
+// file mutation (UpsertSkillFile / DeleteSkillFile). UpdateSkill already
+// publishes the same event with the same payload shape when it replaces
+// files wholesale; without this, per-file edits are invisible to WS
+// consumers (stale skill lists, external mirrors). Best-effort: a failed
+// reload skips the broadcast rather than failing the completed mutation.
+func (h *Handler) publishSkillFilesChanged(r *http.Request, skill db.Skill) {
+	files, err := h.Queries.ListSkillFiles(r.Context(), skill.ID)
+	if err != nil {
+		slog.Warn("list skill files for skill:updated broadcast failed", "error", err, "skill_id", uuidToString(skill.ID))
+		return
+	}
+	fileResps := make([]SkillFileResponse, len(files))
+	for i, f := range files {
+		fileResps[i] = skillFileToResponse(f)
+	}
+	resp := SkillWithFilesResponse{
+		SkillResponse: skillToResponse(skill),
+		Files:         fileResps,
+	}
+	wsID := uuidToString(skill.WorkspaceID)
+	actorType, actorID := h.resolveActor(r, requestUserID(r), wsID)
+	h.publish(protocol.EventSkillUpdated, wsID, actorType, actorID, map[string]any{"skill": resp})
 }
 
 // --- Agent-Skill junction ---

--- a/server/pkg/protocol/events.go
+++ b/server/pkg/protocol/events.go
@@ -22,6 +22,7 @@ const (
 	// Agent events
 	EventAgentStatus   = "agent:status"
 	EventAgentCreated  = "agent:created"
+	EventAgentUpdated  = "agent:updated"
 	EventAgentArchived = "agent:archived"
 	EventAgentRestored = "agent:restored"
 


### PR DESCRIPTION
## What does this PR do?

Closes two blind spots in the workspace event feed that make external consumers (git mirrors, webhook-style integrations, headless WS clients) miss changes:

1. **`agent:updated` did not exist.** `UpdateAgent` only published `agent:status`, which doubles as a presence signal (runtime sweeper, env-var changes), so consumers could not distinguish "agent definition changed" from "status flipped". This PR adds a dedicated `agent:updated` event, published alongside the existing `agent:status` broadcast — existing `agent:status` consumers (mobile presence hooks, sweeper tests) are unaffected.

2. **Incremental skill-file mutations were silent.** `PUT /api/skills/{id}/files` and `DELETE /api/skills/{id}/files/{fileId}` mutated files without publishing anything; file edits were only visible to WS consumers when they went through wholesale `UpdateSkill`. They now publish `skill:updated` with the same full skill+files payload `UpdateSkill` already uses, via a shared `publishSkillFilesChanged` helper (best-effort: a failed file reload logs and skips the broadcast rather than failing the completed mutation).

Context: we are building a workspace→git mirror on top of the WS feed and hit both gaps; they seem worth fixing for any external consumer, independent of our use case.

## Related Issue

None — small additive change; happy to open one if preferred.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `server/pkg/protocol/events.go` — add `EventAgentUpdated = "agent:updated"`
- `server/internal/handler/agent.go` — `UpdateAgent` publishes `agent:updated` in addition to `agent:status` (comment documents why both exist)
- `server/internal/handler/skill.go` — `UpsertSkillFile` / `DeleteSkillFile` publish `skill:updated`; new `publishSkillFilesChanged` helper
- `packages/core/types/events.ts` — add `agent:updated` to `WSEventType`, `AgentUpdatedPayload`, payload map entry

## How to Test

1. Connect a WS client to `/ws?workspace_id=...` (PAT first-message auth).
2. `PUT /api/agents/{id}` with a changed `instructions` → observe both `agent:status` and `agent:updated` frames with the full (secret-redacted) agent payload.
3. `PUT /api/skills/{id}/files` with a new file → observe `skill:updated` with full skill content + files array; same for `DELETE /api/skills/{id}/files/{fileId}`.
4. `go build ./... && go vet ./...` and `go test ./cmd/server/` pass; `tsc --noEmit` clean in `packages/core`.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have run tests locally and they pass
- [ ] I have added or updated tests where applicable (no existing handler-level event tests to extend; can add if maintainers point at a preferred harness)
- [ ] UI screenshots — n/a, no UI change
- [x] I have updated relevant documentation to reflect my changes (TS event types are the consumer-facing contract)
- [x] I have considered and documented any risks above
- [x] I will address all reviewer comments before requesting merge

Known related gap left out deliberately to keep this PR minimal: incremental file mutations still don't touch `skill.updated_at`, so timestamp-based pollers remain blind to them (needs an sqlc query change + regeneration). Can follow up if there's interest.

## Docs added (second commit)

While building on the runtime we reverse-engineered what the platform injects around every agent run and wrote it up as `docs/` guides — included here since the same investigation produced both the event fix and the docs:

- `docs/agent-runtime-user-guide.md` — overview of the three-layer runtime (brief / skills / per-turn prompt), links to the audience-specific guides
- `docs/agent-runtime-context-humans.md` — operator guide: brief sections and who controls each, task-kind × section matrix, injected env, launch flags, operating implications
- `docs/agent-runtime-context-agents.md` — the same context as operating rules from inside a run (suitable as agent-facing distilled context)
- `docs/working-with-agents.md` — for end users who assign/comment/chat without configuring agents: trust model, assignment lifecycle, memory model, code visibility, silence/mention etiquette, troubleshooting table

All content is traced to source (`runtime_config_sections.go`, `prompt.go`, `daemon.go`, `claude.go`, `builtin_skills/`). Happy to split the docs into a separate PR if you prefer the event fix reviewed standalone.

## AI Disclosure

**AI tool used:** Claude Code

**Prompt / approach:** Mapped the event bus and handler publish sites with read-only exploration agents while designing an external workspace→git mirror, found the two gaps, then hand-reviewed the minimal additive patch. Verified existing `agent:status` consumers before deciding to add a new event rather than rename.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
