### PR TITLE
MUL-4385: guard Mod-Enter submit against open IME composition

### DIFF
--- a/packages/views/editor/extensions/submit-shortcut.test.ts
+++ b/packages/views/editor/extensions/submit-shortcut.test.ts
@@ -25,7 +25,7 @@ describe("createSubmitExtension", () => {
     isActive: () => false,
   } as Partial<Editor>;
 
-  it("Mod-Enter always submits", () => {
+  it("Mod-Enter submits when no composition is open", () => {
     const onSubmit = vi.fn(() => true);
     const shortcuts = getShortcuts(
       createSubmitExtension(onSubmit, { submitOnEnter: false }),
@@ -33,8 +33,22 @@ describe("createSubmitExtension", () => {
     );
 
     expect(shortcuts["Mod-Enter"]).toBeDefined();
-    shortcuts["Mod-Enter"]!();
+    expect(shortcuts["Mod-Enter"]!()).toBe(true);
     expect(onSubmit).toHaveBeenCalledTimes(1);
+  });
+
+  it("Mod-Enter is suppressed during IME composition", () => {
+    const onSubmit = vi.fn(() => true);
+    const shortcuts = getShortcuts(
+      createSubmitExtension(onSubmit, { submitOnEnter: false }),
+      {
+        view: { composing: true } as unknown as Editor["view"],
+        isActive: () => false,
+      },
+    );
+
+    expect(shortcuts["Mod-Enter"]!()).toBe(false);
+    expect(onSubmit).not.toHaveBeenCalled();
   });
 
   it("bare Enter is not bound when submitOnEnter is false", () => {

--- a/packages/views/editor/extensions/submit-shortcut.ts
+++ b/packages/views/editor/extensions/submit-shortcut.ts
@@ -16,7 +16,15 @@ export function createSubmitExtension(
     name: "submitShortcut",
     addKeyboardShortcuts() {
       const shortcuts: Record<string, () => boolean> = {
-        "Mod-Enter": () => onSubmit(),
+        "Mod-Enter": () => {
+          // IME guard — same as Enter below. While a composition is open the
+          // composed text is not in the document yet, so submitting here
+          // would send the doc WITHOUT what the user just typed (e.g. paste
+          // a screenshot, type a pinyin sentence, hit ⌘↵ before the buffer
+          // commits — the submission carries only the screenshot).
+          if (this.editor.view.composing) return false;
+          return onSubmit();
+        },
       };
       if (submitOnEnter) {
         shortcuts.Enter = () => {


### PR DESCRIPTION
## What

Add the IME composition guard (`editor.view.composing`) to the `Mod-Enter` submit shortcut in `ContentEditor`. Bare Enter (chat-style submit) already had this guard; `Mod-Enter` did not.

## Why

Reported in MUL-4385: the user quick-created an issue with a screenshot **and a typed Chinese explanation**, but the submitted prompt contained only the screenshot markdown — the text never reached the server (verified from the intake task's transcript and the full server/daemon pass-through chain, which is verbatim end to end).

Root cause: while a pinyin/kana composition is open, the composed text is rendered inline (the user sees it) but is **not yet part of the ProseMirror document**. `Mod-Enter` fired `onSubmit()` unconditionally, so `getMarkdown()` serialized the document without the composed sentence — the submission carried only the pasted screenshot. The very next quick-create by the same user worked because the composition had been committed before submitting.

This affects every `ContentEditor` surface that submits on ⌘↵ (quick-create modal, comment composers, chat's Mod-Enter path).

## Fix

Mirror the existing bare-Enter behavior: refuse to submit while `view.composing` is true. The user's ⌘↵ mid-composition becomes a no-op; once the buffer commits (or on blur/click, which commits it natively), submit works as usual.

## Tests

`packages/views/editor/extensions/submit-shortcut.test.ts`: added "Mod-Enter is suppressed during IME composition", tightened the existing Mod-Enter case to assert the return value. All 6 pass.
