### PR TITLE
fix(comments): log mention drops at the canInvokeAgent gate

### DIFF
--- a/server/internal/handler/comment.go
+++ b/server/internal/handler/comment.go
@@ -1964,6 +1964,13 @@ func (h *Handler) resolveMentionedAgentCommentTriggers(ctx context.Context, issu
 			}
 			// Private-agent gate: prevent triggering a private leader via squad mention.
 			if !h.canInvokeAgent(ctx, agent, authorType, authorID, opts.OriginatorUserID, wsID) {
+				slog.Info("comment mention dropped: actor cannot invoke agent",
+					"mention_kind", "squad_leader",
+					"issue_id", uuidToString(issue.ID),
+					"target_agent_id", uuidToString(agent.ID),
+					"actor_type", authorType,
+					"originator_resolved", opts.OriginatorUserID != "",
+				)
 				continue
 			}
 			hasPending, err := h.hasPendingTaskForIssueAndAgent(ctx, issue.ID, leaderID, opts)
@@ -1993,6 +2000,13 @@ func (h *Handler) resolveMentionedAgentCommentTriggers(ctx context.Context, issu
 		// Private-agent gate (member→private requires allowed_principals;
 		// agent→agent always passes).
 		if !h.canInvokeAgent(ctx, agent, authorType, authorID, opts.OriginatorUserID, wsID) {
+			slog.Info("comment mention dropped: actor cannot invoke agent",
+				"mention_kind", "agent",
+				"issue_id", uuidToString(issue.ID),
+				"target_agent_id", uuidToString(agent.ID),
+				"actor_type", authorType,
+				"originator_resolved", opts.OriginatorUserID != "",
+			)
 			continue
 		}
 		hasPending, err := h.hasPendingTaskForIssueAndAgent(ctx, issue.ID, agentUUID, opts)


### PR DESCRIPTION
## What does this PR do?

> **Rescoped** per [maintainer feedback](https://github.com/multica-ai/multica/pull/5232#issuecomment-4950045670): the `originator_user_id` stamp is dropped from this PR — "who a member-created autopilot acts as" will be decided once, inside the unified attribution rework (MUL-4302), which also covers the hop-2 `source_task_id` gap. What remains here is the operator-signal half, wanted regardless. The original full description is preserved in the edit history.

Both silent deny sites in `resolveMentionedAgentCommentTriggers` (squad-leader mention and direct agent mention) drop an `@`-mention with a bare `continue` and no log line, so operators have zero signal that the permission gate swallowed a mention. This PR emits a `slog.Info` at each deny site, tagged with `mention_kind`, the issue/target ids, the actor type, and `originator_resolved` — the exact fields that distinguish a NULL-originator drop (the #5230 shape, e.g. autopilot `run_only` → `private` agent) from a legitimate permission deny.

No behavior change: the gate's semantics (MUL-3963) are untouched; the drop just stops being invisible.

## Related Issue

Refs #5230 — the underlying `run_only` → private-agent attribution fix is deferred to the MUL-4302 unified attribution work; this PR only makes the drop observable in the meantime.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue) — observability at the deny sites

## Changes Made

- `server/internal/handler/comment.go` — `slog.Info` drop-log at both `canInvokeAgent` deny sites in `resolveMentionedAgentCommentTriggers` (squad-leader mention and direct agent mention). 14 lines, log-only.

## How to Test

Behavior is unchanged; the log line fires whenever the gate drops a mention. Using the reproduction from #5230: an agent running an autopilot `run_only` task `@`-mentions a `private` agent → previously silent, now logs
`comment mention dropped: actor cannot invoke agent` with `mention_kind`, `actor_type=agent`, `originator_resolved=false`.

Automated: `cd server && go build ./... && go vet ./internal/handler/` — clean (the change is two structured log statements over variables already in scope; no new test surface).

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have run tests locally and they pass (build + vet; log-only change, no behavioral test surface)
- [ ] I have added or updated tests where applicable (N/A — log-only)
- [ ] If this change affects the UI, I have included before/after screenshots (N/A — server-only)
- [ ] I have updated relevant documentation to reflect my changes (N/A)
- [ ] If I added a new runtime / coding tool / UI tab, I synced the change to landing copy and docs (N/A)
- [ ] If this PR touches Chinese product copy, I checked it against the conventions doc (N/A)
- [x] I have considered and documented any risks above
- [x] I will address all reviewer comments before requesting merge

## AI Disclosure

**AI tool used:** Claude Code

**Prompt / approach:** Root cause traced and verified as described in #5230; per maintainer direction the identity fix was split out to the MUL-4302 attribution rework and this PR was rebased onto current `main`, retaining only the deny-site logging commit. Build + vet verified locally after the rebase.
