### PR TITLE
fix(agent): fail opencode runs whose stream ends without a terminal signal

### DIFF
--- a/server/pkg/agent/opencode.go
+++ b/server/pkg/agent/opencode.go
@@ -227,6 +227,11 @@ func (b *opencodeBackend) Execute(ctx context.Context, prompt string, opts ExecO
 		} else if exitErr != nil && scanResult.status == "completed" {
 			scanResult.status = "failed"
 			scanResult.errMsg = fmt.Sprintf("opencode exited with error: %v", exitErr)
+		} else if exitErr != nil && scanResult.noTerminalSignal {
+			// Status is already "failed" from the terminal-signal guard; append
+			// the process exit detail so a mid-step crash still surfaces the
+			// signal / exit code that killed it.
+			scanResult.errMsg = fmt.Sprintf("%s; opencode exited with error: %v", scanResult.errMsg, exitErr)
 		}
 
 		b.cfg.Logger.Info("opencode finished", "pid", cmd.Process.Pid, "status", scanResult.status, "duration", duration.Round(time.Millisecond).String())
@@ -260,11 +265,12 @@ func (b *opencodeBackend) Execute(ctx context.Context, prompt string, opts ExecO
 
 // eventResult holds the accumulated state from processing the event stream.
 type eventResult struct {
-	status    string
-	errMsg    string
-	output    string
-	sessionID string
-	usage     TokenUsage // accumulated token usage across all steps
+	status           string
+	errMsg           string
+	output           string
+	sessionID        string
+	usage            TokenUsage // accumulated token usage across all steps
+	noTerminalSignal bool       // guard fired: stream reached EOF with a step still open
 }
 
 // processEvents reads JSON lines from r, dispatches events to ch, and returns
@@ -275,6 +281,15 @@ func (b *opencodeBackend) processEvents(r io.Reader, ch chan<- Message) eventRes
 	var usage TokenUsage
 	finalStatus := "completed"
 	var finalError string
+
+	// Track step bracketing so a stream that ends mid-step is not mistaken for a
+	// clean completion. OpenCode's JSON stream has no terminal result event
+	// (unlike Claude's type:"result"), so "no error seen" is not proof the run
+	// finished. opencode emits tool_use only on terminal states (completed or
+	// error), so a dangling tool call implies an unclosed step — step bracketing
+	// is the positive terminal signal. Recovered tool errors (state.status ==
+	// "error") are normal in healthy runs and must not affect status.
+	openStep := false // between a step_start and its step_finish
 
 	scanner := bufio.NewScanner(r)
 	scanner.Buffer(make([]byte, 0, 1024*1024), 10*1024*1024)
@@ -302,8 +317,10 @@ func (b *opencodeBackend) processEvents(r io.Reader, ch chan<- Message) eventRes
 		case "error":
 			b.handleErrorEvent(event, ch, &finalStatus, &finalError)
 		case "step_start":
+			openStep = true
 			trySend(ch, Message{Type: MessageStatus, Status: "running"})
 		case "step_finish":
+			openStep = false
 			// Accumulate token usage from step_finish events.
 			if t := event.Part.Tokens; t != nil {
 				usage.InputTokens += t.Input
@@ -325,12 +342,24 @@ func (b *opencodeBackend) processEvents(r io.Reader, ch chan<- Message) eventRes
 		}
 	}
 
+	// Require a positive terminal signal. A clean EOF while a step is still open
+	// means the run did not finish — its provider stream died and `opencode run`
+	// exited without emitting an error event. Fail closed on that structural
+	// evidence rather than reporting a false-green completion.
+	noTerminalSignal := false
+	if finalStatus == "completed" && openStep {
+		finalStatus = "failed"
+		finalError = "opencode stream ended without a terminal signal (step still open at EOF)"
+		noTerminalSignal = true
+	}
+
 	return eventResult{
-		status:    finalStatus,
-		errMsg:    finalError,
-		output:    output.String(),
-		sessionID: sessionID,
-		usage:     usage,
+		status:           finalStatus,
+		errMsg:           finalError,
+		output:           output.String(),
+		sessionID:        sessionID,
+		usage:            usage,
+		noTerminalSignal: noTerminalSignal,
 	}
 }
 

--- a/server/pkg/agent/opencode.go
+++ b/server/pkg/agent/opencode.go
@@ -289,7 +289,17 @@ func (b *opencodeBackend) processEvents(r io.Reader, ch chan<- Message) eventRes
 	// error), so a dangling tool call implies an unclosed step — step bracketing
 	// is the positive terminal signal. Recovered tool errors (state.status ==
 	// "error") are normal in healthy runs and must not affect status.
-	openStep := false // between a step_start and its step_finish
+	//
+	// Step bracketing alone is not enough: step_finish carries a reason
+	// (FinishReason: "stop", "tool-calls", …), and a run that still has tool
+	// results to feed back closes its step with reason "tool-calls" before the
+	// next step_start. A stream that ends in that gap did not finish either, so
+	// a "tool-calls" finish keeps the run non-terminal until the next step
+	// opens. Any other reason — including absent, for older opencode versions
+	// whose step_finish parts predate the reason field — is treated as terminal
+	// so healthy runs on old protocols are not mass-failed.
+	openStep := false             // between a step_start and its step_finish
+	awaitingContinuation := false // last step_finish was reason "tool-calls"; next step never started
 
 	scanner := bufio.NewScanner(r)
 	scanner.Buffer(make([]byte, 0, 1024*1024), 10*1024*1024)
@@ -318,9 +328,11 @@ func (b *opencodeBackend) processEvents(r io.Reader, ch chan<- Message) eventRes
 			b.handleErrorEvent(event, ch, &finalStatus, &finalError)
 		case "step_start":
 			openStep = true
+			awaitingContinuation = false
 			trySend(ch, Message{Type: MessageStatus, Status: "running"})
 		case "step_finish":
 			openStep = false
+			awaitingContinuation = event.Part.Reason == "tool-calls"
 			// Accumulate token usage from step_finish events.
 			if t := event.Part.Tokens; t != nil {
 				usage.InputTokens += t.Input
@@ -342,14 +354,20 @@ func (b *opencodeBackend) processEvents(r io.Reader, ch chan<- Message) eventRes
 		}
 	}
 
-	// Require a positive terminal signal. A clean EOF while a step is still open
-	// means the run did not finish — its provider stream died and `opencode run`
-	// exited without emitting an error event. Fail closed on that structural
-	// evidence rather than reporting a false-green completion.
+	// Require a positive terminal signal. A clean EOF while a step is still
+	// open — or right after a step that finished with reason "tool-calls",
+	// whose continuation step never started — means the run did not finish:
+	// its provider stream died and `opencode run` exited without emitting an
+	// error event. Fail closed on that structural evidence rather than
+	// reporting a false-green completion.
 	noTerminalSignal := false
-	if finalStatus == "completed" && openStep {
+	if finalStatus == "completed" && (openStep || awaitingContinuation) {
 		finalStatus = "failed"
-		finalError = "opencode stream ended without a terminal signal (step still open at EOF)"
+		if openStep {
+			finalError = "opencode stream ended without a terminal signal (step still open at EOF)"
+		} else {
+			finalError = `opencode stream ended without a terminal signal (last step finished with reason "tool-calls" and its continuation never started)`
+		}
 		noTerminalSignal = true
 	}
 
@@ -522,6 +540,10 @@ type opencodeEventPart struct {
 
 	// step_finish token usage
 	Tokens *opencodeTokens `json:"tokens,omitempty"`
+
+	// step_finish reason (FinishReason: "stop", "tool-calls", …). Absent on
+	// older opencode versions whose step-finish parts predate the field.
+	Reason string `json:"reason,omitempty"`
 }
 
 // opencodeTokens represents token usage in a step_finish event.

--- a/server/pkg/agent/opencode.go
+++ b/server/pkg/agent/opencode.go
@@ -270,7 +270,7 @@ type eventResult struct {
 	output           string
 	sessionID        string
 	usage            TokenUsage // accumulated token usage across all steps
-	noTerminalSignal bool       // guard fired: stream reached EOF with a step still open
+	noTerminalSignal bool       // guard fired: stream reached EOF before a step or required continuation completed
 }
 
 // processEvents reads JSON lines from r, dispatches events to ch, and returns
@@ -292,14 +292,15 @@ func (b *opencodeBackend) processEvents(r io.Reader, ch chan<- Message) eventRes
 	//
 	// Step bracketing alone is not enough: step_finish carries a reason
 	// (FinishReason: "stop", "tool-calls", …), and a run that still has tool
-	// results to feed back closes its step with reason "tool-calls" before the
-	// next step_start. A stream that ends in that gap did not finish either, so
-	// a "tool-calls" finish keeps the run non-terminal until the next step
-	// opens. Any other reason — including absent, for older opencode versions
-	// whose step_finish parts predate the reason field — is treated as terminal
-	// so healthy runs on old protocols are not mass-failed.
-	openStep := false             // between a step_start and its step_finish
-	awaitingContinuation := false // last step_finish was reason "tool-calls"; next step never started
+	// results to feed back normally closes its step with reason "tool-calls"
+	// before the next step_start. Some providers return "stop" despite emitting
+	// tool calls, though, and OpenCode deliberately continues those runs when a
+	// non-provider-executed tool result must be fed back to the model. Track both
+	// signals so EOF in either continuation gap fails closed. A missing reason
+	// retains the older step-bracketing behavior for protocol compatibility.
+	openStep := false                // between a step_start and its step_finish
+	stepHasContinuationTool := false // current step has a local tool result OpenCode must feed back
+	awaitingContinuation := false    // the last step_finish still required another step
 
 	scanner := bufio.NewScanner(r)
 	scanner.Buffer(make([]byte, 0, 1024*1024), 10*1024*1024)
@@ -324,15 +325,21 @@ func (b *opencodeBackend) processEvents(r io.Reader, ch chan<- Message) eventRes
 			b.handleTextEvent(event, ch, &output)
 		case "tool_use":
 			b.handleToolUseEvent(event, ch)
+			if event.Part.Metadata == nil || !event.Part.Metadata.ProviderExecuted {
+				stepHasContinuationTool = true
+			}
 		case "error":
 			b.handleErrorEvent(event, ch, &finalStatus, &finalError)
 		case "step_start":
 			openStep = true
+			stepHasContinuationTool = false
 			awaitingContinuation = false
 			trySend(ch, Message{Type: MessageStatus, Status: "running"})
 		case "step_finish":
 			openStep = false
-			awaitingContinuation = event.Part.Reason == "tool-calls"
+			awaitingContinuation = event.Part.Reason == "tool-calls" ||
+				(event.Part.Reason != "" && stepHasContinuationTool)
+			stepHasContinuationTool = false
 			// Accumulate token usage from step_finish events.
 			if t := event.Part.Tokens; t != nil {
 				usage.InputTokens += t.Input
@@ -366,7 +373,7 @@ func (b *opencodeBackend) processEvents(r io.Reader, ch chan<- Message) eventRes
 		if openStep {
 			finalError = "opencode stream ended without a terminal signal (step still open at EOF)"
 		} else {
-			finalError = `opencode stream ended without a terminal signal (last step finished with reason "tool-calls" and its continuation never started)`
+			finalError = "opencode stream ended without a terminal signal (last step required a continuation that never started)"
 		}
 		noTerminalSignal = true
 	}
@@ -537,6 +544,9 @@ type opencodeEventPart struct {
 	Tool   string             `json:"tool,omitempty"`
 	CallID string             `json:"callID,omitempty"`
 	State  *opencodeToolState `json:"state,omitempty"`
+	// OpenCode excludes provider-executed tools when deciding whether a tool
+	// result requires another model step.
+	Metadata *opencodePartMetadata `json:"metadata,omitempty"`
 
 	// step_finish token usage
 	Tokens *opencodeTokens `json:"tokens,omitempty"`
@@ -544,6 +554,10 @@ type opencodeEventPart struct {
 	// step_finish reason (FinishReason: "stop", "tool-calls", …). Absent on
 	// older opencode versions whose step-finish parts predate the field.
 	Reason string `json:"reason,omitempty"`
+}
+
+type opencodePartMetadata struct {
+	ProviderExecuted bool `json:"providerExecuted,omitempty"`
 }
 
 // opencodeTokens represents token usage in a step_finish event.

--- a/server/pkg/agent/opencode_test.go
+++ b/server/pkg/agent/opencode_test.go
@@ -839,6 +839,92 @@ func TestOpencodeProcessEventsStreamEndsAfterToolCallsStepFinish(t *testing.T) {
 	close(ch)
 }
 
+func TestOpencodeProcessEventsStreamEndsAfterToolWithStopFinish(t *testing.T) {
+	t.Parallel()
+
+	b := &opencodeBackend{cfg: Config{Logger: slog.Default()}}
+	ch := make(chan Message, 256)
+
+	// Some providers return reason "stop" even when the assistant step contains
+	// tool calls. OpenCode still continues the run so it can feed the tool result
+	// back to the model. EOF before that continuation step is therefore not a
+	// successful run-level terminal signal.
+	lines := strings.Join([]string{
+		`{"type":"step_start","timestamp":1000,"sessionID":"ses_stop_tool","part":{"type":"step-start"}}`,
+		`{"type":"tool_use","timestamp":1001,"sessionID":"ses_stop_tool","part":{"type":"tool","tool":"bash","callID":"call_1","state":{"status":"completed","input":{"command":"go test ./..."},"output":"ok\n"}}}`,
+		`{"type":"step_finish","timestamp":1002,"sessionID":"ses_stop_tool","part":{"type":"step-finish","reason":"stop"}}`,
+	}, "\n")
+
+	result := b.processEvents(strings.NewReader(lines), ch)
+
+	if result.status != "failed" {
+		t.Errorf("status: got %q, want %q", result.status, "failed")
+	}
+	if !strings.Contains(result.errMsg, "terminal signal") {
+		t.Errorf("errMsg: got %q, want it to mention the missing terminal signal", result.errMsg)
+	}
+	if !result.noTerminalSignal {
+		t.Error("noTerminalSignal: got false, want true")
+	}
+
+	close(ch)
+}
+
+func TestOpencodeProcessEventsToolWithStopFinishThenContinuation(t *testing.T) {
+	t.Parallel()
+
+	b := &opencodeBackend{cfg: Config{Logger: slog.Default()}}
+	ch := make(chan Message, 256)
+
+	// The provider-specific "stop" quirk must not false-fail a healthy run once
+	// OpenCode starts the continuation step and reaches a real terminal finish.
+	lines := strings.Join([]string{
+		`{"type":"step_start","timestamp":1000,"sessionID":"ses_stop_continue","part":{"type":"step-start"}}`,
+		`{"type":"tool_use","timestamp":1001,"sessionID":"ses_stop_continue","part":{"type":"tool","tool":"bash","callID":"call_1","state":{"status":"completed","input":{"command":"echo ok"},"output":"ok\n"}}}`,
+		`{"type":"step_finish","timestamp":1002,"sessionID":"ses_stop_continue","part":{"type":"step-finish","reason":"stop"}}`,
+		`{"type":"step_start","timestamp":1003,"sessionID":"ses_stop_continue","part":{"type":"step-start"}}`,
+		`{"type":"text","timestamp":1004,"sessionID":"ses_stop_continue","part":{"type":"text","text":"done"}}`,
+		`{"type":"step_finish","timestamp":1005,"sessionID":"ses_stop_continue","part":{"type":"step-finish","reason":"stop"}}`,
+	}, "\n")
+
+	result := b.processEvents(strings.NewReader(lines), ch)
+
+	if result.status != "completed" {
+		t.Errorf("status: got %q, want %q", result.status, "completed")
+	}
+	if result.errMsg != "" {
+		t.Errorf("errMsg: got %q, want empty", result.errMsg)
+	}
+
+	close(ch)
+}
+
+func TestOpencodeProcessEventsProviderExecutedToolWithStopFinish(t *testing.T) {
+	t.Parallel()
+
+	b := &opencodeBackend{cfg: Config{Logger: slog.Default()}}
+	ch := make(chan Message, 256)
+
+	// Provider-executed tools do not require OpenCode to feed a local tool
+	// result back to the model, so a "stop" finish remains terminal.
+	lines := strings.Join([]string{
+		`{"type":"step_start","timestamp":1000,"sessionID":"ses_provider_tool","part":{"type":"step-start"}}`,
+		`{"type":"tool_use","timestamp":1001,"sessionID":"ses_provider_tool","part":{"type":"tool","tool":"web_search","callID":"call_1","metadata":{"providerExecuted":true},"state":{"status":"completed","input":{"query":"weather"},"output":"sunny"}}}`,
+		`{"type":"step_finish","timestamp":1002,"sessionID":"ses_provider_tool","part":{"type":"step-finish","reason":"stop"}}`,
+	}, "\n")
+
+	result := b.processEvents(strings.NewReader(lines), ch)
+
+	if result.status != "completed" {
+		t.Errorf("status: got %q, want %q", result.status, "completed")
+	}
+	if result.errMsg != "" {
+		t.Errorf("errMsg: got %q, want empty", result.errMsg)
+	}
+
+	close(ch)
+}
+
 func TestOpencodeProcessEventsStepFinishWithoutReasonBackcompat(t *testing.T) {
 	t.Parallel()
 

--- a/server/pkg/agent/opencode_test.go
+++ b/server/pkg/agent/opencode_test.go
@@ -715,6 +715,127 @@ func TestOpencodeProcessEventsErrorDoesNotRevertToCompleted(t *testing.T) {
 	close(ch)
 }
 
+func TestOpencodeProcessEventsStreamEndsMidStep(t *testing.T) {
+	t.Parallel()
+
+	b := &opencodeBackend{cfg: Config{Logger: slog.Default()}}
+	ch := make(chan Message, 256)
+
+	// Regression for production run B: the provider stream died right after a
+	// mid-step planning message. opencode reaches a clean EOF and exits 0 with
+	// the step still open (no step_finish, no error event), which previously
+	// reported "completed" — a false-green with all work lost.
+	lines := strings.Join([]string{
+		`{"type":"step_start","timestamp":1000,"sessionID":"ses_midstep","part":{"type":"step-start"}}`,
+		`{"type":"text","timestamp":1001,"sessionID":"ses_midstep","part":{"type":"text","text":"Let me plan the work..."}}`,
+	}, "\n")
+
+	result := b.processEvents(strings.NewReader(lines), ch)
+
+	if result.status != "failed" {
+		t.Errorf("status: got %q, want %q", result.status, "failed")
+	}
+	if !strings.Contains(result.errMsg, "terminal signal") {
+		t.Errorf("errMsg: got %q, want it to mention the missing terminal signal", result.errMsg)
+	}
+	// Text emitted before the stream died must still be captured.
+	if result.output != "Let me plan the work..." {
+		t.Errorf("output: got %q", result.output)
+	}
+
+	close(ch)
+}
+
+func TestOpencodeProcessEventsStreamEndsAfterToolBeforeStepFinish(t *testing.T) {
+	t.Parallel()
+
+	b := &opencodeBackend{cfg: Config{Logger: slog.Default()}}
+	ch := make(chan Message, 256)
+
+	// Regression for production run A: the stream died after a tool ran but
+	// before the step closed. opencode emits tool_use only on terminal states
+	// (here completed), so unfinished work manifests as an unclosed step, not a
+	// pending tool — the open step at EOF is what fails the run.
+	lines := strings.Join([]string{
+		`{"type":"step_start","timestamp":1000,"sessionID":"ses_tool","part":{"type":"step-start"}}`,
+		`{"type":"tool_use","timestamp":1001,"sessionID":"ses_tool","part":{"type":"tool","tool":"bash","callID":"call_1","state":{"status":"completed","input":{"command":"go test ./..."},"output":"ok\n"}}}`,
+	}, "\n")
+
+	result := b.processEvents(strings.NewReader(lines), ch)
+
+	if result.status != "failed" {
+		t.Errorf("status: got %q, want %q", result.status, "failed")
+	}
+	if !strings.Contains(result.errMsg, "terminal signal") {
+		t.Errorf("errMsg: got %q, want it to mention the missing terminal signal", result.errMsg)
+	}
+
+	close(ch)
+}
+
+func TestOpencodeProcessEventsMultiStepHappyPath(t *testing.T) {
+	t.Parallel()
+
+	b := &opencodeBackend{cfg: Config{Logger: slog.Default()}}
+	ch := make(chan Message, 256)
+
+	// Two fully bracketed steps (step_start … step_finish ×2) must stay
+	// "completed" — the terminal-signal guard only fires on an unclosed step.
+	lines := strings.Join([]string{
+		`{"type":"step_start","timestamp":1000,"sessionID":"ses_multi","part":{"type":"step-start"}}`,
+		`{"type":"text","timestamp":1001,"sessionID":"ses_multi","part":{"type":"text","text":"step one"}}`,
+		`{"type":"step_finish","timestamp":1002,"sessionID":"ses_multi","part":{"type":"step-finish"}}`,
+		`{"type":"step_start","timestamp":1003,"sessionID":"ses_multi","part":{"type":"step-start"}}`,
+		`{"type":"text","timestamp":1004,"sessionID":"ses_multi","part":{"type":"text","text":" step two"}}`,
+		`{"type":"step_finish","timestamp":1005,"sessionID":"ses_multi","part":{"type":"step-finish"}}`,
+	}, "\n")
+
+	result := b.processEvents(strings.NewReader(lines), ch)
+
+	if result.status != "completed" {
+		t.Errorf("status: got %q, want %q", result.status, "completed")
+	}
+	if result.output != "step one step two" {
+		t.Errorf("output: got %q", result.output)
+	}
+	if result.errMsg != "" {
+		t.Errorf("errMsg: got %q, want empty", result.errMsg)
+	}
+
+	close(ch)
+}
+
+func TestOpencodeProcessEventsToolErrorThenCleanFinish(t *testing.T) {
+	t.Parallel()
+
+	b := &opencodeBackend{cfg: Config{Logger: slog.Default()}}
+	ch := make(chan Message, 256)
+
+	// A recovered tool error is normal in a healthy run: opencode emits tool_use
+	// only on terminal states, and a failed tool arrives with state.status=="error"
+	// (real wire shape from `opencode run --format json`). The run continues and
+	// closes every step with step_finish, so status must stay "completed". The
+	// earlier pending-tool heuristic recorded the error tool's callID, never
+	// drained it, and wrongly reported this healthy run as failed.
+	lines := strings.Join([]string{
+		`{"type":"step_start","timestamp":1000,"sessionID":"ses_toolerr","part":{"type":"step-start"}}`,
+		`{"type":"tool_use","timestamp":1001,"sessionID":"ses_toolerr","part":{"type":"tool","tool":"read","callID":"functions.read:1","state":{"status":"error","input":{"filePath":"/nonexistent-path-xyz/also-missing.md"},"error":"File not found: /nonexistent-path-xyz/also-missing.md"}}}`,
+		`{"type":"tool_use","timestamp":1002,"sessionID":"ses_toolerr","part":{"type":"tool","tool":"bash","callID":"functions.bash:0","state":{"status":"completed","input":{"command":"echo hi"},"output":"hi\n"}}}`,
+		`{"type":"step_finish","timestamp":1003,"sessionID":"ses_toolerr","part":{"type":"step-finish"}}`,
+	}, "\n")
+
+	result := b.processEvents(strings.NewReader(lines), ch)
+
+	if result.status != "completed" {
+		t.Errorf("status: got %q, want %q (recovered tool error must not fail a healthy run)", result.status, "completed")
+	}
+	if result.errMsg != "" {
+		t.Errorf("errMsg: got %q, want empty", result.errMsg)
+	}
+
+	close(ch)
+}
+
 // ── Windows native-binary resolution tests ──
 
 // fakeStat returns a statFn that reports any path in `present` as existing
@@ -1178,6 +1299,118 @@ func TestOpencodeBackendBlocksDirOverride(t *testing.T) {
 		if a == bogusDir {
 			t.Errorf("custom --dir value %q leaked into argv: %q", bogusDir, args)
 		}
+	}
+}
+
+// fakeOpencodeMidToolScript impersonates an `opencode run` whose provider
+// stream dies mid-step: it prints a step_start and a terminal-error tool_use,
+// then exits 0 on a clean EOF with no step_finish and no error event. This is
+// the false-green shape from production — the recovered tool error does not
+// rescue the run; the unclosed step is what fails it.
+func fakeOpencodeMidToolScript() string {
+	return `#!/bin/sh
+printf '{"type":"step_start","timestamp":1,"sessionID":"ses_fake","part":{"type":"step-start"}}\n'
+printf '{"type":"tool_use","timestamp":2,"sessionID":"ses_fake","part":{"type":"tool","tool":"read","callID":"functions.read:1","state":{"status":"error","input":{"filePath":"/nope.md"},"error":"File not found"}}}\n'
+exit 0
+`
+}
+
+// TestOpencodeBackendFailsOnStreamEndingMidTool proves the terminal-signal
+// guard over the full clean-EOF/exit-0 path, not just the scanner loop: a run
+// whose stream ends with an open step must surface as Result.Status == "failed"
+// even though opencode exited 0 with no error event and its last tool merely
+// reported a recovered error.
+func TestOpencodeBackendFailsOnStreamEndingMidTool(t *testing.T) {
+	t.Parallel()
+
+	tempDir := t.TempDir()
+	fakePath := filepath.Join(tempDir, "opencode")
+	writeTestExecutable(t, fakePath, []byte(fakeOpencodeMidToolScript()))
+
+	backend, err := New("opencode", Config{
+		ExecutablePath: fakePath,
+		Logger:         slog.Default(),
+	})
+	if err != nil {
+		t.Fatalf("new opencode backend: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	session, err := backend.Execute(ctx, "prompt-ignored", ExecOptions{
+		Timeout: 5 * time.Second,
+	})
+	if err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	go func() {
+		for range session.Messages {
+		}
+	}()
+	result := <-session.Result
+
+	if result.Status != "failed" {
+		t.Fatalf("result status = %q, error = %q; want failed", result.Status, result.Error)
+	}
+	if !strings.Contains(result.Error, "terminal signal") {
+		t.Errorf("result error = %q, want it to mention the missing terminal signal", result.Error)
+	}
+}
+
+// fakeOpencodeStepThenExit1Script impersonates an `opencode run` that crashes
+// mid-step: it opens a step, then the process itself dies nonzero with no
+// step_finish and no error event.
+func fakeOpencodeStepThenExit1Script() string {
+	return `#!/bin/sh
+printf '{"type":"step_start","timestamp":1,"sessionID":"ses_fake","part":{"type":"step-start"}}\n'
+exit 1
+`
+}
+
+// TestOpencodeBackendAppendsExitDetailOnMidStepCrash pins the second fix: when
+// the terminal-signal guard has already failed the run AND the process exited
+// nonzero, the exit detail is appended so the crash signal / exit code is not
+// lost — the errMsg carries both the missing-terminal-signal reason and the
+// process exit status.
+func TestOpencodeBackendAppendsExitDetailOnMidStepCrash(t *testing.T) {
+	t.Parallel()
+
+	tempDir := t.TempDir()
+	fakePath := filepath.Join(tempDir, "opencode")
+	writeTestExecutable(t, fakePath, []byte(fakeOpencodeStepThenExit1Script()))
+
+	backend, err := New("opencode", Config{
+		ExecutablePath: fakePath,
+		Logger:         slog.Default(),
+	})
+	if err != nil {
+		t.Fatalf("new opencode backend: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	session, err := backend.Execute(ctx, "prompt-ignored", ExecOptions{
+		Timeout: 5 * time.Second,
+	})
+	if err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	go func() {
+		for range session.Messages {
+		}
+	}()
+	result := <-session.Result
+
+	if result.Status != "failed" {
+		t.Fatalf("result status = %q, error = %q; want failed", result.Status, result.Error)
+	}
+	if !strings.Contains(result.Error, "terminal signal") {
+		t.Errorf("result error = %q, want it to mention the missing terminal signal", result.Error)
+	}
+	if !strings.Contains(result.Error, "exit status 1") {
+		t.Errorf("result error = %q, want it to include the process exit status", result.Error)
 	}
 }
 

--- a/server/pkg/agent/opencode_test.go
+++ b/server/pkg/agent/opencode_test.go
@@ -779,15 +779,18 @@ func TestOpencodeProcessEventsMultiStepHappyPath(t *testing.T) {
 	b := &opencodeBackend{cfg: Config{Logger: slog.Default()}}
 	ch := make(chan Message, 256)
 
-	// Two fully bracketed steps (step_start … step_finish ×2) must stay
-	// "completed" — the terminal-signal guard only fires on an unclosed step.
+	// A full tool loop as it appears on the real wire (live-probed against
+	// opencode 1.17.16): the tool step closes with reason "tool-calls", the
+	// continuation step opens and closes with the final reason "stop". Must
+	// stay "completed" — "stop" is the run-level terminal signal.
 	lines := strings.Join([]string{
 		`{"type":"step_start","timestamp":1000,"sessionID":"ses_multi","part":{"type":"step-start"}}`,
 		`{"type":"text","timestamp":1001,"sessionID":"ses_multi","part":{"type":"text","text":"step one"}}`,
-		`{"type":"step_finish","timestamp":1002,"sessionID":"ses_multi","part":{"type":"step-finish"}}`,
-		`{"type":"step_start","timestamp":1003,"sessionID":"ses_multi","part":{"type":"step-start"}}`,
-		`{"type":"text","timestamp":1004,"sessionID":"ses_multi","part":{"type":"text","text":" step two"}}`,
-		`{"type":"step_finish","timestamp":1005,"sessionID":"ses_multi","part":{"type":"step-finish"}}`,
+		`{"type":"tool_use","timestamp":1002,"sessionID":"ses_multi","part":{"type":"tool","tool":"bash","callID":"call_1","state":{"status":"completed","input":{"command":"echo ok"},"output":"ok\n"}}}`,
+		`{"type":"step_finish","timestamp":1003,"sessionID":"ses_multi","part":{"type":"step-finish","reason":"tool-calls"}}`,
+		`{"type":"step_start","timestamp":1004,"sessionID":"ses_multi","part":{"type":"step-start"}}`,
+		`{"type":"text","timestamp":1005,"sessionID":"ses_multi","part":{"type":"text","text":" step two"}}`,
+		`{"type":"step_finish","timestamp":1006,"sessionID":"ses_multi","part":{"type":"step-finish","reason":"stop"}}`,
 	}, "\n")
 
 	result := b.processEvents(strings.NewReader(lines), ch)
@@ -797,6 +800,65 @@ func TestOpencodeProcessEventsMultiStepHappyPath(t *testing.T) {
 	}
 	if result.output != "step one step two" {
 		t.Errorf("output: got %q", result.output)
+	}
+	if result.errMsg != "" {
+		t.Errorf("errMsg: got %q, want empty", result.errMsg)
+	}
+
+	close(ch)
+}
+
+func TestOpencodeProcessEventsStreamEndsAfterToolCallsStepFinish(t *testing.T) {
+	t.Parallel()
+
+	b := &opencodeBackend{cfg: Config{Logger: slog.Default()}}
+	ch := make(chan Message, 256)
+
+	// A step_finish with reason "tool-calls" is not a run-level terminal
+	// signal: tool results still have to be fed back in a continuation step.
+	// If the stream dies in the gap between that finish and the next
+	// step_start, the run did not complete — even though no step is open.
+	lines := strings.Join([]string{
+		`{"type":"step_start","timestamp":1000,"sessionID":"ses_toolcalls","part":{"type":"step-start"}}`,
+		`{"type":"tool_use","timestamp":1001,"sessionID":"ses_toolcalls","part":{"type":"tool","tool":"bash","callID":"call_1","state":{"status":"completed","input":{"command":"go test ./..."},"output":"ok\n"}}}`,
+		`{"type":"step_finish","timestamp":1002,"sessionID":"ses_toolcalls","part":{"type":"step-finish","reason":"tool-calls"}}`,
+	}, "\n")
+
+	result := b.processEvents(strings.NewReader(lines), ch)
+
+	if result.status != "failed" {
+		t.Errorf("status: got %q, want %q", result.status, "failed")
+	}
+	if !strings.Contains(result.errMsg, "terminal signal") {
+		t.Errorf("errMsg: got %q, want it to mention the missing terminal signal", result.errMsg)
+	}
+	if !result.noTerminalSignal {
+		t.Error("noTerminalSignal: got false, want true")
+	}
+
+	close(ch)
+}
+
+func TestOpencodeProcessEventsStepFinishWithoutReasonBackcompat(t *testing.T) {
+	t.Parallel()
+
+	b := &opencodeBackend{cfg: Config{Logger: slog.Default()}}
+	ch := make(chan Message, 256)
+
+	// Older opencode versions emit step-finish parts without a reason field.
+	// A missing (or unknown) reason must be treated as terminal so healthy
+	// runs on old protocols are not mass-failed; only an explicit
+	// "tool-calls" keeps the run non-terminal.
+	lines := strings.Join([]string{
+		`{"type":"step_start","timestamp":1000,"sessionID":"ses_noreason","part":{"type":"step-start"}}`,
+		`{"type":"text","timestamp":1001,"sessionID":"ses_noreason","part":{"type":"text","text":"legacy run"}}`,
+		`{"type":"step_finish","timestamp":1002,"sessionID":"ses_noreason","part":{"type":"step-finish"}}`,
+	}, "\n")
+
+	result := b.processEvents(strings.NewReader(lines), ch)
+
+	if result.status != "completed" {
+		t.Errorf("status: got %q, want %q", result.status, "completed")
 	}
 	if result.errMsg != "" {
 		t.Errorf("errMsg: got %q, want empty", result.errMsg)


### PR DESCRIPTION
## What does this PR do?

Fixes a false-green completion in the OpenCode agent backend: a run whose provider stream dies mid-run is reported `completed` with `error: null`, so the daemon completes the task, the workdir is GC'd, and nothing downstream retries — the work is silently lost.

**Root cause.** `processEvents` initializes `finalStatus := "completed"` and only degrades it on an explicit `error` event, a scanner error, timeout/cancel, or a nonzero exit. The consumed JSON event protocol has no terminal result event (unlike the Claude backend's `type:"result"` + `IsError`), so when the provider stream dies and `opencode run --format json` exits 0 after a clean stdout EOF, none of those degrade paths fire. We lost two full production builder runs to this (a 97-message run that died launching its final test suite, and a 75-message run that died mid-implementation) — both `completed, error: null`.

**Fix: require a positive terminal signal via step bracketing.** `processEvents` now tracks `openStep` (between a `step_start` and its `step_finish`). A stream that reaches EOF with a step still open did not terminate: status becomes `failed` with an explanatory error, and `Execute` appends the process exit detail (`exit status N` / `signal: killed`) when the process also exited nonzero, so crash root causes stay visible.

**Why step bracketing is the right signal:**
- Every healthy stream closes its final step: `step_finish` (reason `stop`) is where usage tokens arrive, the repo's own `fakeOpencodeScript()` fixture brackets each step, and we verified it against live `opencode run --format json` output.
- The existing comment on `handleErrorEvent` already concedes exit codes are unreliable ("OpenCode can exit with RC=0 even on errors (e.g. invalid model), so error events are the reliable signal for failures"). This PR extends that logic symmetrically: error events are the reliable failure signal; step bracketing is the reliable success signal.
- We deliberately did **not** track tool-call states: `tool_use` events are emitted only on terminal states (`completed` | `error`) — a dying tool call emits no event at all and manifests as an unclosed step, while a recovered tool error (`state.status == "error"`, e.g. a file-not-found the model recovers from) is a normal part of healthy completed runs. An earlier draft of this fix tracked pending tool calls and a live-protocol probe showed it false-failed healthy runs; the shipped guard has no such false-positive path.

**Precedence is preserved:** the guard fires only when status is still `completed`, so error events, scanner errors, timeout, and cancel all keep priority; the existing nonzero-exit arm is untouched.

**Why it matters for mixed fleets:** the Claude backend is structurally immune (explicit terminal `type:"result"`), so today this failure mode asymmetrically penalizes OpenCode-runtime agents. Related recent work doesn't cover it: MUL-4351's `no_response` outcome (v0.3.43) is direct-chat-only, and MUL-4369 fixes transcript truncation but not run status.

**Documented residual (pre-existing, out of scope here):** a zero-event stream (exit 0, nothing parsed, no `step_start` at all) is still reported `completed`. The Claude backend has a partial early-death guard for that class; happy to follow up with the same for OpenCode if maintainers want it.

## Related Issue

Closes #5233

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Refactor / code improvement (no behavior change)
- [ ] Documentation update
- [x] Tests (adding or improving test coverage)
- [ ] CI / infrastructure

## Changes Made

- `server/pkg/agent/opencode.go` — track step bracketing in `processEvents` (`openStep` on `step_start`/`step_finish`); after the scan loop, fail runs still marked `completed` with a step open at EOF; new `eventResult.noTerminalSignal` field; new fourth arm in `Execute`'s post-exit chain appending exit detail to the structural error when the process also exited nonzero.
- `server/pkg/agent/opencode_test.go` — new/updated coverage:
  - `TestOpencodeProcessEventsStreamEndsMidStep` — `step_start` → `text` → EOF ⇒ `failed` (regression for production run B)
  - `TestOpencodeProcessEventsStreamEndsAfterToolBeforeStepFinish` — completed tool, then EOF before `step_finish` ⇒ `failed`
  - `TestOpencodeProcessEventsToolErrorThenCleanFinish` — recovered tool error (`state.status:"error"`, real wire shape) then clean `step_finish` ⇒ still `completed` (pins the no-false-positive guarantee)
  - `TestOpencodeProcessEventsMultiStepHappyPath` — two bracketed steps ⇒ `completed`
  - Execute-level (real subprocess via `writeTestExecutable`): fake opencode emitting `step_start` + terminal-error tool then exiting 0 without `step_finish` ⇒ `Result.Status == "failed"` (proves the clean-EOF/exit-0 path end to end); fake emitting `step_start` then exiting 1 ⇒ `failed` with both the terminal-signal message and `exit status 1` in the error.

## How to Test

1. `cd server && go test -race -p 2 -parallel 2 ./pkg/agent/...` — full package passes (the `-p 2 -parallel 2` flags follow the repo convention for the subprocess fixtures).
2. Bug repro on pre-fix code: check out `main`, apply only the test file, run `TestOpencodeProcessEventsStreamEndsMidStep` — it fails with `status: got "completed"` (the false-green). On this branch it passes.
3. False-positive guard: `TestOpencodeProcessEventsToolErrorThenCleanFinish` feeds a healthy run containing a recovered tool error (captured from real `opencode run --format json` output) and asserts it still completes.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots — n/a (backend only)
- [ ] I have updated relevant documentation to reflect my changes — n/a (no doc surface for this internal behavior)
- [ ] If I added a new runtime / coding tool / UI tab, I synced the change to landing copy and relevant docs — n/a
- [ ] If this PR touches Chinese product copy, I checked it against the conventions doc — n/a
- [x] I have considered and documented any risks above
- [x] I will address all reviewer comments before requesting merge

## AI Disclosure

**AI tool used:** Claude Code

**Prompt / approach:** Bug was confirmed in source (fail-open `finalStatus := "completed"` path) and written up as issue #5233, then the fix was implemented from a file:line-verified plan. The step-bracketing invariant and the tool-state wire format were both validated against live `opencode run --format json` transcripts (healthy run ends with `step_finish` reason `stop`; `tool_use` is emitted only on terminal states). A cross-model review pass on the draft caught that tracking pending tool calls would false-fail healthy runs containing recovered tool errors — that machinery was removed in favor of the step-bracketing-only guard before submission, with a regression test pinning the behavior. The design mirrors the Claude backend's positive-terminal-signal requirement.

## Screenshots (optional)

n/a
