### PR TITLE
fix(inbox): align inbox list left padding with chat list

### DIFF
--- a/packages/views/inbox/components/inbox-list-item.tsx
+++ b/packages/views/inbox/components/inbox-list-item.tsx
@@ -44,7 +44,7 @@ export function InboxListItem({
     <button
       type="button"
       onClick={onClick}
-      className={`group flex w-full items-center gap-3 rounded-md px-3 py-2.5 text-left transition-colors ${
+      className={`group flex w-full items-center gap-3 rounded-md px-2 py-2.5 text-left transition-colors ${
         isSelected ? "bg-accent" : "hover:bg-accent/50"
       }`}
     >

--- a/packages/views/inbox/components/inbox-page.tsx
+++ b/packages/views/inbox/components/inbox-page.tsx
@@ -375,7 +375,7 @@ export function InboxPage() {
           </div>
           <div className="flex-1 min-h-0 overflow-y-auto space-y-1 p-2">
             {Array.from({ length: 5 }).map((_, i) => (
-              <div key={i} className="flex items-center gap-3 px-4 py-2.5">
+              <div key={i} className="flex items-center gap-3 px-2 py-2.5">
                 <Skeleton className="h-7 w-7 shrink-0 rounded-full" />
                 <div className="flex-1 space-y-2">
                   <Skeleton className="h-4 w-3/4" />
@@ -433,7 +433,7 @@ export function InboxPage() {
             </div>
             <div className="flex-1 min-h-0 overflow-y-auto space-y-1 p-2">
               {Array.from({ length: 5 }).map((_, i) => (
-                <div key={i} className="flex items-center gap-3 px-4 py-2.5">
+                <div key={i} className="flex items-center gap-3 px-2 py-2.5">
                   <Skeleton className="h-7 w-7 shrink-0 rounded-full" />
                   <div className="flex-1 space-y-2">
                     <Skeleton className="h-4 w-3/4" />


### PR DESCRIPTION
## Summary

Fixes MUL-4396: the Chat list and Inbox list rails had different left insets, so switching between the two pages made the avatar/text column visibly jump.

- Both list containers use `px-2`, but the inbox row added `px-3` (20px total content inset) while the chat thread row uses `px-2` (16px).
- Aligned the inbox row to `px-2`. Avatars in both rails now sit at 16px from the panel edge, flush with the shared `PageHeader` title (`px-4` = 16px), and matching the prevailing row convention (sidebar, pickers, chat archived footer).
- Also aligned the two inbox loading-skeleton rows (`px-4` → `px-2`) so the list doesn't shift horizontally when real rows load in.

Both rows use `ActorAvatar size="lg"` + `gap-3`, so the title/text column now starts at the same x in both lists.

## Verification

- `pnpm typecheck` in `packages/views` — clean
- `pnpm vitest run inbox chat` — 9 files, 60 tests passed
