### PR TITLE
perf(daemon): gzip-compress daemon API responses (#4072)

### DIFF
--- a/server/cmd/server/router.go
+++ b/server/cmd/server/router.go
@@ -722,6 +722,16 @@ func NewRouterWithOptions(pool *pgxpool.Pool, hub *realtime.Hub, bus *events.Bus
 	r.Route("/api/daemon", func(r chi.Router) {
 		r.Use(middleware.DaemonAuth(queries, patCache, daemonTokenCache, cloudPATVerifier))
 
+		// Compress large daemon API responses — most importantly the task-claim
+		// payload, which inlines every bound skill's full content and can reach
+		// many MB. Without compression a slow link blows past the daemon client's
+		// 30s read timeout while streaming the body ("context deadline exceeded
+		// ... while reading body"), see #4072. The daemon client uses the default
+		// Go transport (http.DefaultTransport.Clone), which transparently
+		// advertises Accept-Encoding: gzip and decompresses the response, so no
+		// client change is needed. chi's Compress skips WebSocket upgrades.
+		r.Use(chimw.Compress(5))
+
 		r.Post("/register", h.DaemonRegister)
 		r.Post("/deregister", h.DaemonDeregister)
 		r.Post("/heartbeat", h.DaemonHeartbeat)

--- a/server/internal/middleware/compress_test.go
+++ b/server/internal/middleware/compress_test.go
@@ -1,0 +1,88 @@
+package middleware
+
+import (
+	"compress/gzip"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/go-chi/chi/v5"
+	chimw "github.com/go-chi/chi/v5/middleware"
+)
+
+// TestCompressMiddlewareGzipsLargeDaemonResponse verifies the gzip compression
+// wired onto the /api/daemon route group for #4072: a large daemon response
+// (the task-claim payload inlines every bound skill's full content and can
+// reach many MB) is returned gzip-compressed when the client advertises
+// Accept-Encoding: gzip. The daemon client uses http.DefaultTransport.Clone(),
+// which sends that header transparently and decompresses the response, so
+// compression keeps large claim bodies inside the 30s read-timeout window.
+//
+// The assertion is over the middleware wiring used in cmd/server/router.go
+// (chimw.Compress(5) applied to the daemon route group), reproduced here with a
+// minimal router so the test does not require a database.
+func TestCompressMiddlewareGzipsLargeDaemonResponse(t *testing.T) {
+	r := chi.NewRouter()
+	r.Route("/api/daemon", func(r chi.Router) {
+		r.Use(chimw.Compress(5))
+		r.Post("/runtimes/{runtimeId}/tasks/claim", func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			// Simulate a large claim payload (e.g. many inlined skills).
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"skills": strings.Repeat("a", 64*1024),
+			})
+		})
+	})
+
+	req := httptest.NewRequest(http.MethodPost, "/api/daemon/runtimes/rt-1/tasks/claim", nil)
+	req.Header.Set("Accept-Encoding", "gzip") // sent by the daemon's default Go transport
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rec.Code)
+	}
+	if got := rec.Header().Get("Content-Encoding"); got != "gzip" {
+		t.Fatalf("expected Content-Encoding gzip for large daemon response, got %q (compression not applied?)", got)
+	}
+
+	gr, err := gzip.NewReader(rec.Result().Body)
+	if err != nil {
+		t.Fatalf("gzip reader: %v", err)
+	}
+	defer gr.Close()
+	decoded, err := io.ReadAll(gr)
+	if err != nil {
+		t.Fatalf("gunzip: %v", err)
+	}
+	if !strings.Contains(string(decoded), "skills") {
+		t.Fatalf("decompressed body missing payload: %q", decoded)
+	}
+}
+
+// TestCompressMiddlewareRespectsAcceptEncoding confirms the wiring only
+// compresses when the client advertises Accept-Encoding: gzip — a request
+// without it (e.g. a plain curl, or a client that opts out) gets an
+// uncompressed response, so compression never breaks non-gzip clients.
+func TestCompressMiddlewareRespectsAcceptEncoding(t *testing.T) {
+	r := chi.NewRouter()
+	r.Route("/api/daemon", func(r chi.Router) {
+		r.Use(chimw.Compress(5))
+		r.Get("/tasks/{taskId}/status", func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{"status": "running"})
+		})
+	})
+
+	// No Accept-Encoding header -> the response must stay uncompressed.
+	req := httptest.NewRequest(http.MethodGet, "/api/daemon/tasks/t-1/status", nil)
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+
+	if got := rec.Header().Get("Content-Encoding"); got == "gzip" {
+		t.Fatalf("response should not be gzip-compressed without Accept-Encoding: gzip, got Content-Encoding: gzip")
+	}
+}


### PR DESCRIPTION
## What does this PR do?

The task-claim response inlines every bound skill's full content (including attached files) and can reach many MB. On slower links the daemon client's 30s read timeout is blown while streaming the response body — \`context deadline exceeded ... while reading body\` — so an agent bound to many skills can never be claimed (#4072). The maintainer's triage identified this root cause and listed "compress the API response" as one of the planned fix directions.

This PR applies chi's \`Compress\` middleware to the \`/api/daemon\` route group. The daemon client is built on \`http.DefaultTransport.Clone()\` (DisableCompression stays false), so it transparently advertises \`Accept-Encoding: gzip\` and decompresses the response — **no client change is needed**. JSON (skill content) compresses well, so a multi-MB claim body shrinks to a fraction and fits within the read-timeout window. chi's \`Compress\` skips WebSocket upgrades, so \`/api/daemon/ws\` is unaffected.

This is the "compress the response" lever from the issue; it composes with (and does not replace) the other planned levers (stop inlining skill full-text, split the client timeout).

## Related Issue

Relates to #4072

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- \`server/cmd/server/router.go\` — \`r.Use(chimw.Compress(5))\` on the \`/api/daemon\` route group (after \`DaemonAuth\`).
- \`server/internal/middleware/compress_test.go\` — unit tests (no DB needed) asserting a large daemon response is gzip-compressed when \`Accept-Encoding: gzip\` is sent, and that a response stays uncompressed when the client does not advertise gzip.

## How to Test

1. \`cd server\`
2. \`go vet ./cmd/server/ ./internal/middleware/\` — clean.
3. \`go test ./internal/middleware/ -run TestCompressMiddleware -v\` → both tests pass (large response gzipped; no-Accept-Encoding response not gzipped). These are pure unit tests (chi router + httptest), no PostgreSQL required.
4. \`gofmt -l\` clean.

Risks: low. gzip is negotiated via \`Accept-Encoding\`; non-gzip clients get an uncompressed response. WebSocket upgrades are skipped by chi's \`Compress\`. The daemon client already handles gzip transparently (default Go transport).

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots *(N/A)*
- [ ] I have updated relevant documentation to reflect my changes *(N/A)*
- [x] I have considered and documented any risks above
- [x] I will address all reviewer comments before requesting merge

## AI Disclosure

**AI tool used:** Claude Code

**Prompt / approach:** I used Claude Code to triage multica's open bug issues, confirm the maintainer's root-cause analysis for #4072 (claim body size vs. read timeout), verify the daemon client transparently handles gzip (DefaultTransport.Clone, DisableCompression=false), wire `chimw.Compress` onto the daemon route group, and write unit tests. Verified locally with `go test` + `go vet` + `gofmt`.