### PR TITLE
fix(handler): include issue stage in list and grouped board queries (#5235)

### DIFF
--- a/server/internal/handler/issue.go
+++ b/server/internal/handler/issue.go
@@ -1023,7 +1023,7 @@ func (h *Handler) ListIssues(w http.ResponseWriter, r *http.Request) {
 
 	query := fmt.Sprintf(`SELECT i.id, i.workspace_id, i.title, i.description, i.status, i.priority,
        i.assignee_type, i.assignee_id, i.creator_type, i.creator_id,
-       i.parent_issue_id, i.position, i.start_date, i.due_date, i.created_at, i.updated_at, i.number, i.project_id, i.metadata
+       i.parent_issue_id, i.position, i.start_date, i.due_date, i.created_at, i.updated_at, i.number, i.project_id, i.metadata, i.stage
 FROM issue i
 WHERE %s
 ORDER BY %s
@@ -1060,6 +1060,7 @@ LIMIT %s OFFSET %s`, whereSql, orderBy, limitRef, offsetRef)
 			&row.Number,
 			&row.ProjectID,
 			&row.Metadata,
+			&row.Stage,
 		); err != nil {
 			slog.Warn("ListIssues scan failed", "error", err)
 			writeError(w, http.StatusInternalServerError, "failed to list issues")
@@ -1520,7 +1521,7 @@ WITH ranked AS (
 		i.id, i.workspace_id, i.title, i.description, i.status, i.priority,
 		i.assignee_type, i.assignee_id, i.creator_type, i.creator_id,
 		i.parent_issue_id, i.position, i.due_date, i.created_at, i.updated_at,
-		i.number, i.project_id, i.metadata,
+		i.number, i.project_id, i.metadata, i.stage,
 		COUNT(*) OVER (PARTITION BY i.assignee_type, i.assignee_id) AS group_total,
 		ROW_NUMBER() OVER (
 			PARTITION BY i.assignee_type, i.assignee_id
@@ -1533,7 +1534,7 @@ SELECT
 	id, workspace_id, title, description, status, priority,
 	assignee_type, assignee_id, creator_type, creator_id,
 	parent_issue_id, position, due_date, created_at, updated_at,
-	number, project_id, metadata, group_total
+	number, project_id, metadata, stage, group_total
 FROM ranked
 WHERE rn > %s AND rn <= %s + %s
 ORDER BY
@@ -1577,6 +1578,7 @@ ORDER BY
 			&row.Number,
 			&row.ProjectID,
 			&row.Metadata,
+			&row.Stage,
 			&row.GroupTotal,
 		); err != nil {
 			slog.Warn("ListGroupedIssues scan failed", "error", err)

--- a/server/internal/handler/issue_list_stage_test.go
+++ b/server/internal/handler/issue_list_stage_test.go
@@ -1,0 +1,80 @@
+package handler
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/jackc/pgx/v5/pgtype"
+	db "github.com/multica-ai/multica/server/pkg/db/generated"
+)
+
+// Regression for #5235: the hand-written ListIssues / ListGroupedIssues SQL
+// must SELECT and Scan stage. When stage was added (MUL-3508 / #4410) only the
+// sqlc queries and DTO mappers were updated; the dynamic handlers were left
+// with a dual source of truth and silently returned stage:null for every row.
+
+func TestIssueListRowToResponse_PropagatesStage(t *testing.T) {
+	row := db.ListIssuesRow{
+		Title:  "staged child",
+		Status: "todo",
+		Stage:  pgtype.Int4{Int32: 2, Valid: true},
+	}
+	got := issueListRowToResponse(row, "MUL")
+	if got.Stage == nil {
+		t.Fatal("expected Stage to be set, got nil")
+	}
+	if *got.Stage != 2 {
+		t.Fatalf("Stage = %d, want 2", *got.Stage)
+	}
+}
+
+func TestIssueListRowToResponse_UnstagedIsNil(t *testing.T) {
+	row := db.ListIssuesRow{
+		Title:  "unstaged",
+		Status: "todo",
+		Stage:  pgtype.Int4{Valid: false},
+	}
+	got := issueListRowToResponse(row, "MUL")
+	if got.Stage != nil {
+		t.Fatalf("expected Stage nil for unstaged issue, got %v", *got.Stage)
+	}
+}
+
+func TestHandwrittenIssueListSQLIncludesStage(t *testing.T) {
+	// Pin the dual-source-of-truth surface: if someone rewrites the dynamic
+	// SELECT lists without stage again, this fails before a production board
+	// goes stage-blind.
+	_, thisFile, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("runtime.Caller failed")
+	}
+	src, err := os.ReadFile(filepath.Join(filepath.Dir(thisFile), "issue.go"))
+	if err != nil {
+		t.Fatalf("read issue.go: %v", err)
+	}
+	text := string(src)
+
+	// ListIssues SELECT must end its issue column list with stage.
+	if !strings.Contains(text, "i.number, i.project_id, i.metadata, i.stage") {
+		t.Fatal("ListIssues hand-written SELECT is missing i.stage after i.metadata (#5235)")
+	}
+	// ListIssues Scan must include &row.Stage after &row.Metadata.
+	if !strings.Contains(text, "&row.Metadata,\n\t\t\t&row.Stage,") &&
+		!strings.Contains(text, "&row.Metadata,\n\t\t\t&row.Stage,\n\t\t)") {
+		// Accept either Stage-before-close or Stage-before-GroupTotal patterns.
+		if !strings.Contains(text, "&row.Metadata,\n\t\t\t&row.Stage") {
+			t.Fatal("ListIssues / ListGroupedIssues Scan is missing &row.Stage after &row.Metadata (#5235)")
+		}
+	}
+	// ListGroupedIssues outer SELECT must project stage before group_total.
+	if !strings.Contains(text, "number, project_id, metadata, stage, group_total") {
+		t.Fatal("ListGroupedIssues outer SELECT is missing stage before group_total (#5235)")
+	}
+	// Inner CTE SELECT must include i.stage.
+	if !strings.Contains(text, "i.number, i.project_id, i.metadata, i.stage,") {
+		t.Fatal("ListGroupedIssues CTE SELECT is missing i.stage (#5235)")
+	}
+}

--- a/server/internal/handler/issue_list_stage_test.go
+++ b/server/internal/handler/issue_list_stage_test.go
@@ -1,22 +1,25 @@
 package handler
 
 import (
-	"os"
-	"path/filepath"
-	"runtime"
-	"strings"
 	"testing"
 
 	"github.com/jackc/pgx/v5/pgtype"
 	db "github.com/multica-ai/multica/server/pkg/db/generated"
 )
 
-// Regression for #5235: the hand-written ListIssues / ListGroupedIssues SQL
-// must SELECT and Scan stage. When stage was added (MUL-3508 / #4410) only the
-// sqlc queries and DTO mappers were updated; the dynamic handlers were left
-// with a dual source of truth and silently returned stage:null for every row.
+// DB-aware companion tests for #5235. package handler's TestMain skips the
+// entire package when Postgres is unreachable (os.Exit(0)), so pure SQL
+// regression coverage lives in the sibling package:
+//
+//	go test ./internal/handler/liststage/ -v
+//
+// These tests exercise the real unexported mapper issueListRowToResponse and
+// only run when a database is available (TestMain successfully connected).
 
 func TestIssueListRowToResponse_PropagatesStage(t *testing.T) {
+	if testHandler == nil {
+		t.Skip("database not available (handler.TestMain skipped package setup)")
+	}
 	row := db.ListIssuesRow{
 		Title:  "staged child",
 		Status: "todo",
@@ -32,6 +35,9 @@ func TestIssueListRowToResponse_PropagatesStage(t *testing.T) {
 }
 
 func TestIssueListRowToResponse_UnstagedIsNil(t *testing.T) {
+	if testHandler == nil {
+		t.Skip("database not available (handler.TestMain skipped package setup)")
+	}
 	row := db.ListIssuesRow{
 		Title:  "unstaged",
 		Status: "todo",
@@ -40,41 +46,5 @@ func TestIssueListRowToResponse_UnstagedIsNil(t *testing.T) {
 	got := issueListRowToResponse(row, "MUL")
 	if got.Stage != nil {
 		t.Fatalf("expected Stage nil for unstaged issue, got %v", *got.Stage)
-	}
-}
-
-func TestHandwrittenIssueListSQLIncludesStage(t *testing.T) {
-	// Pin the dual-source-of-truth surface: if someone rewrites the dynamic
-	// SELECT lists without stage again, this fails before a production board
-	// goes stage-blind.
-	_, thisFile, _, ok := runtime.Caller(0)
-	if !ok {
-		t.Fatal("runtime.Caller failed")
-	}
-	src, err := os.ReadFile(filepath.Join(filepath.Dir(thisFile), "issue.go"))
-	if err != nil {
-		t.Fatalf("read issue.go: %v", err)
-	}
-	text := string(src)
-
-	// ListIssues SELECT must end its issue column list with stage.
-	if !strings.Contains(text, "i.number, i.project_id, i.metadata, i.stage") {
-		t.Fatal("ListIssues hand-written SELECT is missing i.stage after i.metadata (#5235)")
-	}
-	// ListIssues Scan must include &row.Stage after &row.Metadata.
-	if !strings.Contains(text, "&row.Metadata,\n\t\t\t&row.Stage,") &&
-		!strings.Contains(text, "&row.Metadata,\n\t\t\t&row.Stage,\n\t\t)") {
-		// Accept either Stage-before-close or Stage-before-GroupTotal patterns.
-		if !strings.Contains(text, "&row.Metadata,\n\t\t\t&row.Stage") {
-			t.Fatal("ListIssues / ListGroupedIssues Scan is missing &row.Stage after &row.Metadata (#5235)")
-		}
-	}
-	// ListGroupedIssues outer SELECT must project stage before group_total.
-	if !strings.Contains(text, "number, project_id, metadata, stage, group_total") {
-		t.Fatal("ListGroupedIssues outer SELECT is missing stage before group_total (#5235)")
-	}
-	// Inner CTE SELECT must include i.stage.
-	if !strings.Contains(text, "i.number, i.project_id, i.metadata, i.stage,") {
-		t.Fatal("ListGroupedIssues CTE SELECT is missing i.stage (#5235)")
 	}
 }

--- a/server/internal/handler/liststage/mapper_stage_test.go
+++ b/server/internal/handler/liststage/mapper_stage_test.go
@@ -1,0 +1,30 @@
+package liststage
+
+import (
+	"testing"
+
+	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/multica-ai/multica/server/internal/util"
+)
+
+// The list handlers map pgtype.Int4 stage via int4ToPtr → util.Int4ToPtr.
+// These tests exercise that real conversion on the shipped util path so a
+// valid stage never becomes nil and an invalid stage stays nil — the
+// behavior issueListRowToResponse relies on after the SQL fix lands a value
+// in row.Stage.
+func TestInt4ToPtr_ValidStage(t *testing.T) {
+	got := util.Int4ToPtr(pgtype.Int4{Int32: 2, Valid: true})
+	if got == nil {
+		t.Fatal("expected non-nil pointer for Valid stage")
+	}
+	if *got != 2 {
+		t.Fatalf("stage = %d, want 2", *got)
+	}
+}
+
+func TestInt4ToPtr_InvalidStageIsNil(t *testing.T) {
+	got := util.Int4ToPtr(pgtype.Int4{Valid: false})
+	if got != nil {
+		t.Fatalf("expected nil for invalid stage, got %v", *got)
+	}
+}

--- a/server/internal/handler/liststage/stage_sql_test.go
+++ b/server/internal/handler/liststage/stage_sql_test.go
@@ -1,0 +1,102 @@
+// Package liststage holds pure regression tests for the hand-written issue
+// list SQL (#5235). It lives outside package handler so it is NOT gated by
+// handler.TestMain, which os.Exit(0)s the entire package when Postgres is
+// unreachable.
+package liststage
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+func issueGoPath(t *testing.T) string {
+	t.Helper()
+	_, thisFile, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("runtime.Caller failed")
+	}
+	// liststage/ → handler/issue.go
+	return filepath.Join(filepath.Dir(thisFile), "..", "issue.go")
+}
+
+func readIssueGo(t *testing.T) string {
+	t.Helper()
+	src, err := os.ReadFile(issueGoPath(t))
+	if err != nil {
+		t.Fatalf("read issue.go: %v", err)
+	}
+	return string(src)
+}
+
+// containsInOrder reports whether needles appear in order (allowing any
+// whitespace between them). Used so CRLF vs LF / tab width cannot flake.
+func containsInOrder(text string, needles ...string) bool {
+	pos := 0
+	for _, n := range needles {
+		i := strings.Index(text[pos:], n)
+		if i < 0 {
+			return false
+		}
+		pos += i + len(n)
+	}
+	return true
+}
+
+// TestListIssuesHandwrittenSQLSelectsAndScansStage is the primary regression
+// for #5235: ListIssues dynamic SQL must include stage in both SELECT and Scan.
+func TestListIssuesHandwrittenSQLSelectsAndScansStage(t *testing.T) {
+	text := readIssueGo(t)
+
+	if !strings.Contains(text, "i.number, i.project_id, i.metadata, i.stage") {
+		t.Fatal("ListIssues hand-written SELECT is missing i.stage after i.metadata (#5235)")
+	}
+	if !containsInOrder(text, "&row.Metadata,", "&row.Stage,") &&
+		!containsInOrder(text, "&row.Metadata,", "&row.Stage") {
+		t.Fatal("ListIssues Scan is missing &row.Stage after &row.Metadata (#5235)")
+	}
+}
+
+// TestListGroupedIssuesHandwrittenSQLSelectsAndScansStage covers the board
+// endpoint, which had the same dual-source-of-truth bug as ListIssues.
+func TestListGroupedIssuesHandwrittenSQLSelectsAndScansStage(t *testing.T) {
+	text := readIssueGo(t)
+
+	if !strings.Contains(text, "i.number, i.project_id, i.metadata, i.stage,") {
+		t.Fatal("ListGroupedIssues CTE SELECT is missing i.stage (#5235)")
+	}
+	if !strings.Contains(text, "number, project_id, metadata, stage, group_total") {
+		t.Fatal("ListGroupedIssues outer SELECT is missing stage before group_total (#5235)")
+	}
+	// Scan must pass Stage before GroupTotal.
+	if !containsInOrder(text, "&row.Metadata,", "&row.Stage,", "&row.GroupTotal,") &&
+		!containsInOrder(text, "&row.Metadata,", "&row.Stage,", "&row.GroupTotal") {
+		t.Fatal("ListGroupedIssues Scan is missing &row.Stage before &row.GroupTotal (#5235)")
+	}
+}
+
+// TestIssueListRowToResponseMapsStage ensures the DTO mapper (already correct
+// before #5235) still wires Stage from ListIssuesRow. Guards against someone
+// "fixing" the query but dropping the mapper field.
+func TestIssueListRowToResponseMapsStage(t *testing.T) {
+	text := readIssueGo(t)
+
+	// Find issueListRowToResponse and require it sets Stage from i.Stage.
+	const fn = "func issueListRowToResponse"
+	idx := strings.Index(text, fn)
+	if idx < 0 {
+		t.Fatal("issueListRowToResponse not found in issue.go")
+	}
+	// Slice until the next top-level func (approximate).
+	rest := text[idx:]
+	end := strings.Index(rest[len(fn):], "\nfunc ")
+	if end < 0 {
+		end = len(rest) - len(fn)
+	}
+	body := rest[:len(fn)+end]
+	if !strings.Contains(body, "Stage:") || !strings.Contains(body, "i.Stage") {
+		t.Fatal("issueListRowToResponse must set Stage from i.Stage (#5235)")
+	}
+}


### PR DESCRIPTION
## What does this PR do?

`GET /api/issues` (`multica issue list`) and `GET /api/issues/grouped` (workspace board) always returned `"stage": null`, even when an issue had a stage set. `GET /api/issues/:id` was correct.

Root cause: the hand-written dynamic SQL in the list/grouped handlers never selected or scanned `stage` after MUL-3508 / #4410 added the column. Only the sqlc queries and DTO mappers were updated, leaving a dual source of truth.

This PR adds `i.stage` to both SELECT lists and `&row.Stage` to both Scan blocks so list/board consumers see the real stage.

## Related Issue

Closes #5235

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `server/internal/handler/issue.go` — ListIssues SELECT/Scan includes `stage`
- `server/internal/handler/issue.go` — ListGroupedIssues CTE + outer SELECT/Scan includes `stage`
- `server/internal/handler/liststage/` — **pure** regression tests (no Postgres; not gated by `handler.TestMain`)
- `server/internal/handler/issue_list_stage_test.go` — optional mapper tests when DB is available

## How to Test

**Primary (no DB required):**

```bash
cd server
go test ./internal/handler/liststage/ -v
```

Expect `=== RUN ===` / `--- PASS` for all five tests:
- `TestInt4ToPtr_ValidStage`
- `TestInt4ToPtr_InvalidStageIsNil`
- `TestListIssuesHandwrittenSQLSelectsAndScansStage`
- `TestListGroupedIssuesHandwrittenSQLSelectsAndScansStage`
- `TestIssueListRowToResponseMapsStage`

**Note:** `go test ./internal/handler/ -run …` is **not** a no-DB path. `handler.TestMain` connects to Postgres and, if unreachable, prints `Skipping tests` and `os.Exit(0)` before any test function runs. Use `./internal/handler/liststage/` for offline verification.

**Optional (requires Postgres + migrations, e.g. `make db-up`):**

```bash
cd server
go test ./internal/handler/ -run "TestIssueListRowToResponse_" -v
```

**Manual / integration:** set `--stage 2` on a sub-issue; `multica issue list --output json` should show `"stage": 2` (not null).

Risks: low — only populates a field that was always null on these endpoints; open_only / get paths already returned stage correctly.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots *(N/A — API field only)*
- [ ] I have updated relevant documentation to reflect my changes *(N/A)*
- [x] I have considered and documented any risks above
- [x] I will address all reviewer comments before requesting merge

## AI Disclosure

**AI tool used:** Grok Build

**Prompt / approach:** Triaged open Multica bugs for maintainer-diagnosed, unit-testable fixes; applied the SELECT/Scan alignment from #5235; moved pure regressions into `liststage` after discovering `handler.TestMain` skips the whole package without Postgres.