### PR TITLE
fix(cli): stop pflag from garbling login --token help output (MUL-4410)

### DIFF
--- a/server/cmd/multica/cmd_auth_test.go
+++ b/server/cmd/multica/cmd_auth_test.go
@@ -198,6 +198,47 @@ func TestLoginTokenFlagWiring(t *testing.T) {
 	}
 }
 
+// TestLoginTokenHelpOutputRendersCleanly renders loginCmd's flag help through
+// the same pflag path `multica login -h` uses (FlagUsagesWrapped) and locks the
+// user-visible help contract that regressed. The original bug had two causes,
+// both invisible to the flag-wiring/parsing tests above:
+//   - The NoOptDefVal sentinel was "\x00prompt". pflag renders NoOptDefVal
+//     verbatim into the flag column AND uses "\x00" as its own column-alignment
+//     marker, so the split-at-first-NUL logic mispadded the line and printed a
+//     raw NUL to the terminal.
+//   - The usage string wrapped the PAT example in backticks, so pflag's
+//     UnquoteUsage hijacked it as the flag's value placeholder and stripped a
+//     backtick pair from the description.
+//
+// A comment can't prevent either from recurring; only rendering the real output
+// and asserting on it can. This is the regression guard for that output.
+func TestLoginTokenHelpOutputRendersCleanly(t *testing.T) {
+	help := loginCmd.Flags().FlagUsages()
+
+	// No control byte may reach the terminal. pflag emits only spaces and
+	// newlines for layout, so any other sub-0x20 rune (notably the NUL the old
+	// "\x00prompt" sentinel leaked) means the help rendering is corrupted.
+	for _, r := range help {
+		if r < 0x20 && r != '\n' && r != '\t' {
+			t.Fatalf("login help contains control byte %#x; rendered flag usage:\n%q", r, help)
+		}
+	}
+
+	// The --token line must show the standard optional-value form. This single
+	// assertion pins both root causes: the placeholder is `string` (backticks
+	// removed, so UnquoteUsage no longer hijacks the PAT example) and the
+	// optional value is the printable `prompt` (no NUL-prefixed sentinel).
+	if want := `--token string[="prompt"]`; !strings.Contains(help, want) {
+		t.Fatalf("login help missing %q; rendered flag usage:\n%q", want, help)
+	}
+
+	// The description must survive intact — a swallowed backtick pair used to
+	// truncate it, so assert the tail of the sentence is still present.
+	if want := "to be prompted interactively."; !strings.Contains(help, want) {
+		t.Fatalf("login help missing description tail %q; rendered flag usage:\n%q", want, help)
+	}
+}
+
 // TestLoginTokenFlagParsing exercises every documented invocation form
 // against a cobra command wired up exactly the same way as the production
 // loginCmd, then runs runAuthLogin's flag-resolution logic to confirm the

--- a/server/cmd/multica/cmd_login.go
+++ b/server/cmd/multica/cmd_login.go
@@ -44,10 +44,18 @@ var loginCmd = &cobra.Command{
 // "prompt me interactively", preserving the legacy `multica login --token`
 // no-value form alongside the documented `--token mul_...` / `--token mcn_...`
 // value form.
-const tokenPromptSentinel = "\x00prompt"
+//
+// The sentinel must be printable: pflag renders NoOptDefVal verbatim in help
+// output ("--token string[=\"prompt\"]") and uses "\x00" internally as its
+// column-alignment marker, so a NUL-prefixed sentinel corrupts `login -h`.
+// Colliding with a user literally typing `--token prompt` is harmless — that
+// string is never a valid PAT, and prompting is a reasonable response.
+const tokenPromptSentinel = "prompt"
 
 func init() {
-	loginCmd.Flags().String("token", "", "Authenticate using a personal access token (`mul_...` user PAT or `mcn_...` Cloud Node PAT). Pass `--token mul_...` / `--token mcn_...` to supply it inline, or `--token` alone to be prompted interactively.")
+	// No backticks in the usage string: pflag's UnquoteUsage treats the first
+	// backquoted segment as the flag's value placeholder in help output.
+	loginCmd.Flags().String("token", "", "Authenticate using a personal access token (mul_... user PAT or mcn_... Cloud Node PAT). Pass --token mul_... / --token mcn_... to supply it inline, or --token alone to be prompted interactively.")
 	// NoOptDefVal lets `--token` (no value) keep its old prompt-mode behavior
 	// while `--token mul_...` / `--token mcn_...` and the `=value` form
 	// consume the value normally.


### PR DESCRIPTION
## Problem

`multica login -h` renders the `--token` flag line garbled:

```
--token mul_...[="            prompt"]^@Authenticate using a personal access token ...
```

(the `^@` is a raw NUL byte printed to the terminal)

## Root cause

Two implementation details collide with pflag's help-rendering conventions:

1. The `NoOptDefVal` sentinel was `"\x00prompt"`. pflag renders `NoOptDefVal` verbatim into the flag column (`[="\x00prompt"]`), but pflag **also uses `\x00` internally as its column-alignment marker** in `FlagUsagesWrapped`. The alignment logic splits at the *first* NUL — the sentinel's — so padding is injected mid-`[="..."]` and the real marker prints as a raw NUL.
2. The usage string wrapped `mul_...` in backticks. pflag's `UnquoteUsage` extracts the first backquoted segment as the flag's value placeholder, so help showed `--token mul_...` and stripped that one backtick pair from the description, leaving the remaining backticks asymmetric.

## Fix

- Change the sentinel to the printable `"prompt"`. Help now renders the standard optional-value form `--token string[="prompt"]`. A user literally typing `--token prompt` gets the interactive prompt, which is harmless — `prompt` can never be a valid PAT (they must start with `mul_`/`mcn_`).
- Drop backticks from the usage string so the placeholder defaults to `string`.

The sentinel comparison sites (`cmd_auth.go`) use the constant, so no logic changes.

## After

```
--token string[="prompt"]   Authenticate using a personal access token (mul_... user PAT or mcn_... Cloud Node PAT). Pass --token mul_... / --token mcn_... to supply it inline, or --token alone to be prompted interactively.
```

## Verification

- `go test ./cmd/multica/` (includes `TestLoginTokenFlagWiring` / `TestLoginTokenFlagParsing`, which assert against the constant)
- `go vet`, `gofmt` clean
- Manually verified `login -h` output through `cat -v`: no control characters, correct alignment

🤖 Generated with [Claude Code](https://claude.com/claude-code)