### PR TITLE
fix(issues): keep detail content column centered under classic scrollbars (MUL-4404)

### DIFF
--- a/packages/views/issues/components/issue-detail.tsx
+++ b/packages/views/issues/components/issue-detail.tsx
@@ -1420,7 +1420,9 @@ export function IssueDetail({ issueId, onDelete, onDone, defaultSidebarOpen = tr
           <Skeleton className="h-4 w-24" />
         </div>
         <div className="flex flex-1 min-h-0">
-          <div className="flex-1 overflow-y-auto">
+          {/* Same scrollbar-gutter as the loaded scroller below, so the skeleton
+              column doesn't shift sideways when real content mounts. */}
+          <div className="flex-1 overflow-y-auto [scrollbar-gutter:stable_both-edges]">
             <div className="mx-auto w-full max-w-4xl px-8 py-8 space-y-6">
               <Skeleton className="h-8 w-3/4" />
               <div className="space-y-2">
@@ -1952,10 +1954,16 @@ export function IssueDetail({ issueId, onDelete, onDone, defaultSidebarOpen = tr
           }
         />
 
+        {/* scrollbar-gutter both-edges: with classic (space-taking) scrollbars —
+            macOS with a mouse or "always show", Windows, Linux — the global
+            `scrollbar-width: thin` carves ~11px off the right side only, so the
+            centered column reads 32px left vs 43px right (MUL-4404). Mirroring
+            the gutter restores symmetry; overlay-scrollbar platforms reserve
+            nothing and render unchanged. */}
         <div
           ref={setScrollContainerEl}
           data-tab-scroll-root
-          className="relative flex-1 overflow-y-auto"
+          className="relative flex-1 overflow-y-auto [scrollbar-gutter:stable_both-edges]"
         >
         <div className="mx-auto w-full max-w-4xl px-8 py-8">
           <TitleEditor


### PR DESCRIPTION
## Problem

On platforms where scrollbars take layout space — macOS with a mouse connected (or "always show scroll bars"), Windows, Linux — the issue detail main content column sits asymmetrically: **32px** whitespace on the left vs **43px** on the right.

Root cause chain:

- `packages/ui/styles/base.css` applies `scrollbar-width: thin` globally, so every scroll container gets a classic (space-taking) scrollbar, ~11px wide in Chromium, whenever the OS paints classic scrollbars.
- The detail page's scroll container carves those 11px off its right edge only, shifting the centered `max-w-4xl px-8` column left.
- The scrollbar track is transparent (`--scrollbar-track: transparent`), so the reserved strip reads as extra right padding.

Trackpad-only Macs use overlay scrollbars (zero width), which is why the page looks symmetric in most dev setups and this went unnoticed.

## Fix

Add `scrollbar-gutter: stable both-edges` to the issue detail scroll container and its loading skeleton. The gutter is mirrored on the left edge, so the column stays visually centered:

- classic-scrollbar platforms: 32/43 → **43/43**
- overlay-scrollbar platforms: unchanged (32/32, gutter reserves nothing)

Matching the skeleton scroller also removes the sideways shift when real content mounts.

## Verification

Measured in a real render (Chromium, headed, macOS with mouse connected → legacy scrollbars), issue page with overflowing timeline:

| | left | right |
|---|---|---|
| before | 32px | 43px |
| after | 43px | 43px |

`pnpm typecheck --filter=@multica/views` and `pnpm lint --filter=@multica/views` pass.

Closes MUL-4404
