### PR TITLE
Add confirmation toasts for auto-saved settings

### DIFF
--- a/apps/desktop/src/renderer/src/components/daemon-settings-tab.tsx
+++ b/apps/desktop/src/renderer/src/components/daemon-settings-tab.tsx
@@ -3,6 +3,7 @@ import { AlertCircle, Info, LogIn } from "lucide-react";
 import { Button } from "@multica/ui/components/ui/button";
 import { Switch } from "@multica/ui/components/ui/switch";
 import { cn } from "@multica/ui/lib/utils";
+import { toast } from "sonner";
 import {
   SettingsCard,
   SettingsRow,
@@ -67,9 +68,17 @@ export function DaemonSettingsTab() {
   const updatePref = useCallback(
     async (key: keyof DaemonPrefs, value: boolean) => {
       setSaving(true);
-      const updated = await window.daemonAPI.setPrefs({ [key]: value });
-      setPrefs(updated);
-      setSaving(false);
+      try {
+        const updated = await window.daemonAPI.setPrefs({ [key]: value });
+        setPrefs(updated);
+        toast.success("Daemon settings saved", { id: "settings-auto-save" });
+      } catch (error) {
+        toast.error(
+          error instanceof Error ? error.message : "Failed to save daemon settings",
+        );
+      } finally {
+        setSaving(false);
+      }
     },
     [],
   );

--- a/packages/views/locales/en/settings.json
+++ b/packages/views/locales/en/settings.json
@@ -2,7 +2,8 @@
   "auto_save": {
     "saving": "Saving…",
     "saved": "Saved",
-    "failed": "Couldn't save"
+    "failed": "Couldn't save",
+    "toast_saved": "Changes saved"
   },
   "preferences": {
     "general_title": "General",

--- a/packages/views/locales/ja/settings.json
+++ b/packages/views/locales/ja/settings.json
@@ -2,7 +2,8 @@
   "auto_save": {
     "saving": "保存中…",
     "saved": "保存済み",
-    "failed": "保存できませんでした"
+    "failed": "保存できませんでした",
+    "toast_saved": "変更を保存しました"
   },
   "preferences": {
     "general_title": "一般",

--- a/packages/views/locales/ko/settings.json
+++ b/packages/views/locales/ko/settings.json
@@ -2,7 +2,8 @@
   "auto_save": {
     "saving": "저장 중…",
     "saved": "저장됨",
-    "failed": "저장하지 못했습니다"
+    "failed": "저장하지 못했습니다",
+    "toast_saved": "변경사항을 저장했습니다"
   },
   "preferences": {
     "general_title": "일반",

--- a/packages/views/locales/zh-Hans/settings.json
+++ b/packages/views/locales/zh-Hans/settings.json
@@ -2,7 +2,8 @@
   "auto_save": {
     "saving": "正在保存…",
     "saved": "已保存",
-    "failed": "保存失败"
+    "failed": "保存失败",
+    "toast_saved": "更改已保存"
   },
   "preferences": {
     "general_title": "常规",

--- a/packages/views/settings/components/account-tab.tsx
+++ b/packages/views/settings/components/account-tab.tsx
@@ -77,6 +77,10 @@ export function AccountTab() {
     value: draft,
     savedValue: savedDraft,
     onSave: saveProfile,
+    onSuccess: () =>
+      toast.success(t(($) => $.account.toast_profile_updated), {
+        id: "settings-auto-save",
+      }),
     onError: (error) =>
       toast.error(
         error instanceof Error
@@ -113,8 +117,19 @@ export function AccountTab() {
                 name={user?.name ?? ""}
                 size={64}
                 onUploaded={async (url) => {
-                  const updated = await api.updateMe({ avatar_url: url });
-                  setUser(updated);
+                  try {
+                    const updated = await api.updateMe({ avatar_url: url });
+                    setUser(updated);
+                    toast.success(t(($) => $.account.toast_avatar_updated), {
+                      id: "settings-auto-save",
+                    });
+                  } catch (error) {
+                    toast.error(
+                      error instanceof Error
+                        ? error.message
+                        : t(($) => $.account.toast_avatar_failed),
+                    );
+                  }
                 }}
               />
             </div>

--- a/packages/views/settings/components/chat-tab.tsx
+++ b/packages/views/settings/components/chat-tab.tsx
@@ -2,6 +2,7 @@
 
 import { Switch } from "@multica/ui/components/ui/switch";
 import { useChatStore } from "@multica/core/chat";
+import { toast } from "sonner";
 import { useT } from "../../i18n";
 import {
   SettingsCard,
@@ -32,7 +33,12 @@ export function ChatTab() {
           >
           <Switch
             checked={enabled}
-            onCheckedChange={setEnabled}
+            onCheckedChange={(checked) => {
+              setEnabled(checked);
+              toast.success(t(($) => $.auto_save.toast_saved), {
+                id: "settings-auto-save",
+              });
+            }}
             aria-label={t(($) => $.chat.floating_label)}
           />
           </SettingsRow>

--- a/packages/views/settings/components/github-tab.test.tsx
+++ b/packages/views/settings/components/github-tab.test.tsx
@@ -12,6 +12,7 @@ const mockGetConnectURL = vi.hoisted(() => vi.fn());
 const mockInvalidate = vi.hoisted(() => vi.fn());
 const mockNavPush = vi.hoisted(() => vi.fn());
 const mockSetQueryData = vi.hoisted(() => vi.fn());
+const mockToastSuccess = vi.hoisted(() => vi.fn());
 
 const workspaceRef = vi.hoisted(() => ({
   current: {
@@ -107,7 +108,7 @@ vi.mock("../../navigation", () => ({
 }));
 
 vi.mock("sonner", () => ({
-  toast: { success: vi.fn(), error: vi.fn() },
+  toast: { success: mockToastSuccess, error: vi.fn() },
 }));
 
 import { GitHubTab } from "./github-tab";
@@ -186,6 +187,9 @@ describe("GitHubTab", () => {
     await waitFor(() => {
       expect(mockUpdateWorkspace).toHaveBeenCalledWith("workspace-1", {
         settings: { co_authored_by_enabled: true, github_enabled: false },
+      });
+      expect(mockToastSuccess).toHaveBeenCalledWith("Changes saved", {
+        id: "settings-auto-save",
       });
     });
   });

--- a/packages/views/settings/components/github-tab.tsx
+++ b/packages/views/settings/components/github-tab.tsx
@@ -83,6 +83,9 @@ export function GitHubTab() {
       qc.setQueryData(workspaceKeys.list(), (old: Workspace[] | undefined) =>
         old?.map((ws) => (ws.id === updated.id ? updated : ws)),
       );
+      toast.success(t(($) => $.auto_save.toast_saved), {
+        id: "settings-auto-save",
+      });
     } catch (e) {
       toast.error(e instanceof Error ? e.message : t(($) => $.github.toast_failed));
     } finally {

--- a/packages/views/settings/components/notifications-tab.tsx
+++ b/packages/views/settings/components/notifications-tab.tsx
@@ -45,6 +45,10 @@ export function NotificationsTab() {
       delete updated[key];
     }
     mutation.mutate(updated, {
+      onSuccess: () =>
+        toast.success(t(($) => $.auto_save.toast_saved), {
+          id: "settings-auto-save",
+        }),
       onError: (err) =>
         toast.error(
           err instanceof Error && err.message

--- a/packages/views/settings/components/preferences-tab.test.tsx
+++ b/packages/views/settings/components/preferences-tab.test.tsx
@@ -12,13 +12,15 @@ const mockUpdateMe = vi.hoisted(() => vi.fn());
 const mockReload = vi.hoisted(() => vi.fn());
 const mockToastWarning = vi.hoisted(() => vi.fn());
 const mockToastError = vi.hoisted(() => vi.fn());
+const mockToastSuccess = vi.hoisted(() => vi.fn());
+const mockSetTheme = vi.hoisted(() => vi.fn());
 const mockSetUser = vi.hoisted(() => vi.fn());
 const userRef = vi.hoisted(() => ({
   current: null as { id: string; timezone?: string | null } | null,
 }));
 
 vi.mock("@multica/ui/components/common/theme-provider", () => ({
-  useTheme: () => ({ theme: "light", setTheme: vi.fn() }),
+  useTheme: () => ({ theme: "light", setTheme: mockSetTheme }),
 }));
 
 vi.mock("@multica/core/i18n/react", async () => {
@@ -41,7 +43,11 @@ vi.mock("@multica/core/api", () => ({
 }));
 
 vi.mock("sonner", () => ({
-  toast: { warning: mockToastWarning, error: mockToastError },
+  toast: {
+    warning: mockToastWarning,
+    error: mockToastError,
+    success: mockToastSuccess,
+  },
 }));
 
 vi.mock("@multica/core/auth", async () => {
@@ -114,6 +120,17 @@ describe("PreferencesTab — Language switcher", () => {
     expect(mockReload).not.toHaveBeenCalled();
   });
 
+  it("shows a confirmation toast when the theme is saved locally", async () => {
+    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+    render(<PreferencesTab />, { wrapper: I18nWrapper });
+
+    await user.click(screen.getByRole("combobox", { name: "Theme" }));
+    await user.click(await screen.findByRole("option", { name: "Dark" }));
+
+    expect(mockSetTheme).toHaveBeenCalledWith("dark");
+    expect(mockToastSuccess).toHaveBeenCalledTimes(1);
+  });
+
   it("when not logged in: persists + reloads, no PATCH", async () => {
     const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
     render(<PreferencesTab />, { wrapper: I18nWrapper });
@@ -122,6 +139,9 @@ describe("PreferencesTab — Language switcher", () => {
 
     expect(mockPersist).toHaveBeenCalledWith("ko");
     expect(mockUpdateMe).not.toHaveBeenCalled();
+    expect(mockToastSuccess).toHaveBeenCalledTimes(1);
+    expect(mockReload).not.toHaveBeenCalled();
+    act(() => vi.advanceTimersByTime(900));
     expect(mockReload).toHaveBeenCalledTimes(1);
     expect(mockToastWarning).not.toHaveBeenCalled();
   });
@@ -134,11 +154,14 @@ describe("PreferencesTab — Language switcher", () => {
 
     expect(mockPersist).toHaveBeenCalledWith("ja");
     expect(mockUpdateMe).not.toHaveBeenCalled();
+    expect(mockToastSuccess).toHaveBeenCalledTimes(1);
+    expect(mockReload).not.toHaveBeenCalled();
+    act(() => vi.advanceTimersByTime(900));
     expect(mockReload).toHaveBeenCalledTimes(1);
     expect(mockToastWarning).not.toHaveBeenCalled();
   });
 
-  it("when logged in + PATCH success: persists + PATCH + reload immediately", async () => {
+  it("when logged in + PATCH success: confirms the save before reloading", async () => {
     userRef.current = { id: "user-1" };
     mockUpdateMe.mockResolvedValueOnce({});
     const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
@@ -149,6 +172,9 @@ describe("PreferencesTab — Language switcher", () => {
     expect(mockPersist).toHaveBeenCalledWith("zh-Hans");
     expect(mockUpdateMe).toHaveBeenCalledWith({ language: "zh-Hans" });
     expect(mockToastWarning).not.toHaveBeenCalled();
+    expect(mockToastSuccess).toHaveBeenCalledTimes(1);
+    expect(mockReload).not.toHaveBeenCalled();
+    act(() => vi.advanceTimersByTime(900));
     expect(mockReload).toHaveBeenCalledTimes(1);
   });
 
@@ -223,6 +249,7 @@ describe("PreferencesTab — Timezone section", () => {
     await waitFor(() => {
       expect(mockUpdateMe).toHaveBeenCalledWith({ timezone: "Asia/Tokyo" });
       expect(mockSetUser).toHaveBeenCalledWith(updatedUser);
+      expect(mockToastSuccess).toHaveBeenCalledTimes(1);
     });
   }, 20000);
 

--- a/packages/views/settings/components/preferences-tab.tsx
+++ b/packages/views/settings/components/preferences-tab.tsx
@@ -83,7 +83,11 @@ export function PreferencesTab() {
       setTimeout(() => window.location.reload(), 2500);
       return;
     }
-    window.location.reload();
+    toast.success(t(($) => $.auto_save.toast_saved), {
+      id: "settings-auto-save",
+    });
+    // Keep the confirmation visible before the locale reload replaces the UI.
+    setTimeout(() => window.location.reload(), 900);
   };
 
   return (
@@ -97,7 +101,11 @@ export function PreferencesTab() {
             <Select
               value={theme}
               onValueChange={(next) => {
-                if (next) setTheme(next as (typeof themeOptions)[number]["value"]);
+                if (!next || next === theme) return;
+                setTheme(next as (typeof themeOptions)[number]["value"]);
+                toast.success(t(($) => $.auto_save.toast_saved), {
+                  id: "settings-auto-save",
+                });
               }}
             >
               <SelectTrigger
@@ -181,6 +189,9 @@ function TimezoneRow() {
     try {
       const updated = await api.updateMe({ timezone: payload });
       setUser(updated);
+      toast.success(t(($) => $.auto_save.toast_saved), {
+        id: "settings-auto-save",
+      });
     } catch (err) {
       toast.error(
         err instanceof Error && err.message

--- a/packages/views/settings/components/repositories-tab.test.tsx
+++ b/packages/views/settings/components/repositories-tab.test.tsx
@@ -7,6 +7,7 @@ import enCommon from "../../locales/en/common.json";
 import enSettings from "../../locales/en/settings.json";
 
 const mockUpdateWorkspace = vi.hoisted(() => vi.fn());
+const mockToastSuccess = vi.hoisted(() => vi.fn());
 const workspaceRef = vi.hoisted(() => ({
   current: {
     id: "workspace-1",
@@ -54,7 +55,7 @@ vi.mock("@multica/core/auth", () => {
 });
 
 vi.mock("sonner", () => ({
-  toast: { success: vi.fn(), error: vi.fn() },
+  toast: { success: mockToastSuccess, error: vi.fn() },
 }));
 
 import { RepositoriesTab } from "./repositories-tab";
@@ -119,6 +120,9 @@ describe("RepositoriesTab — automatic updates", () => {
     await waitFor(() => {
       expect(mockUpdateWorkspace).toHaveBeenCalledWith("workspace-1", {
         repos: [{ url: "https://github.com/multica-ai/edited" }],
+      });
+      expect(mockToastSuccess).toHaveBeenCalledWith("Repositories saved", {
+        id: "settings-auto-save",
       });
     });
   });

--- a/packages/views/settings/components/repositories-tab.tsx
+++ b/packages/views/settings/components/repositories-tab.tsx
@@ -84,6 +84,10 @@ export function RepositoriesTab() {
     value: draft,
     savedValue: savedRepositories,
     onSave: saveRepositories,
+    onSuccess: () =>
+      toast.success(t(($) => $.repositories.toast_saved), {
+        id: "settings-auto-save",
+      }),
     onError: (error) =>
       toast.error(
         error instanceof Error

--- a/packages/views/settings/components/use-auto-save.test.tsx
+++ b/packages/views/settings/components/use-auto-save.test.tsx
@@ -1,0 +1,85 @@
+import { act, render, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { useAutoSave } from "./use-auto-save";
+
+function deferred<T>() {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+  return { promise, resolve, reject };
+}
+
+function AutoSaveHarness({
+  value,
+  onSave,
+  onSuccess,
+}: {
+  value: string;
+  onSave: (value: string) => Promise<void>;
+  onSuccess: (value: string) => void;
+}) {
+  useAutoSave({
+    value,
+    savedValue: "",
+    onSave,
+    onSuccess,
+    delay: 650,
+    isEqual: (left, right) => left === right,
+  });
+  return null;
+}
+
+describe("useAutoSave success feedback", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("reports success after the persisted value resolves", async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    const onSave = vi.fn(async () => undefined);
+    const onSuccess = vi.fn();
+    render(
+      <AutoSaveHarness value="saved" onSave={onSave} onSuccess={onSuccess} />,
+    );
+
+    act(() => vi.advanceTimersByTime(650));
+
+    await waitFor(() => {
+      expect(onSave).toHaveBeenCalledWith("saved");
+      expect(onSuccess).toHaveBeenCalledWith("saved");
+    });
+  });
+
+  it("waits for the latest queued value before reporting success", async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    const first = deferred<void>();
+    const second = deferred<void>();
+    const onSave = vi
+      .fn<(value: string) => Promise<void>>()
+      .mockReturnValueOnce(first.promise)
+      .mockReturnValueOnce(second.promise);
+    const onSuccess = vi.fn();
+    const { rerender } = render(
+      <AutoSaveHarness value="first" onSave={onSave} onSuccess={onSuccess} />,
+    );
+
+    act(() => vi.advanceTimersByTime(650));
+    await waitFor(() => expect(onSave).toHaveBeenCalledWith("first"));
+
+    rerender(
+      <AutoSaveHarness value="second" onSave={onSave} onSuccess={onSuccess} />,
+    );
+    act(() => vi.advanceTimersByTime(650));
+
+    await act(async () => first.resolve());
+    await waitFor(() => expect(onSave).toHaveBeenCalledWith("second"));
+    expect(onSuccess).not.toHaveBeenCalled();
+
+    await act(async () => second.resolve());
+    await waitFor(() => expect(onSuccess).toHaveBeenCalledWith("second"));
+    expect(onSuccess).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/views/settings/components/use-auto-save.ts
+++ b/packages/views/settings/components/use-auto-save.ts
@@ -7,6 +7,7 @@ interface UseAutoSaveOptions<T> {
   value: T;
   savedValue: T;
   onSave: (value: T) => Promise<void>;
+  onSuccess?: (value: T) => void;
   onError?: (error: unknown) => void;
   enabled?: boolean;
   delay?: number;
@@ -28,6 +29,7 @@ export function useAutoSave<T>({
   value,
   savedValue,
   onSave,
+  onSuccess,
   onError,
   enabled = true,
   delay = 650,
@@ -43,12 +45,14 @@ export function useAutoSave<T>({
   const observedSavedRef = useRef(savedValue);
   const enabledRef = useRef(enabled);
   const onSaveRef = useRef(onSave);
+  const onSuccessRef = useRef(onSuccess);
   const onErrorRef = useRef(onError);
   const isEqualRef = useRef(isEqual);
 
   latestValueRef.current = value;
   enabledRef.current = enabled;
   onSaveRef.current = onSave;
+  onSuccessRef.current = onSuccess;
   onErrorRef.current = onError;
   isEqualRef.current = isEqual;
 
@@ -67,11 +71,12 @@ export function useAutoSave<T>({
     }
 
     savingRef.current = true;
+    let succeeded = false;
     if (mountedRef.current) setStatus("saving");
     try {
       await onSaveRef.current(next);
       persistedRef.current = next;
-      if (mountedRef.current) setStatus("saved");
+      succeeded = true;
     } catch (error) {
       if (mountedRef.current) setStatus("error");
       onErrorRef.current?.(error);
@@ -81,6 +86,9 @@ export function useAutoSave<T>({
       queuedRef.current = null;
       if (queued && !isEqualRef.current(queued, persistedRef.current)) {
         void runSave(queued);
+      } else if (succeeded && mountedRef.current) {
+        setStatus("saved");
+        onSuccessRef.current?.(next);
       }
     }
   }, []);

--- a/packages/views/settings/components/workspace-tab.test.tsx
+++ b/packages/views/settings/components/workspace-tab.test.tsx
@@ -8,6 +8,7 @@ import enSettings from "../../locales/en/settings.json";
 
 const mockUpdateWorkspace = vi.hoisted(() => vi.fn());
 const mockInvalidateQueries = vi.hoisted(() => vi.fn());
+const mockToastSuccess = vi.hoisted(() => vi.fn());
 const workspaceRef = vi.hoisted(() => ({
   current: {
     id: "workspace-1",
@@ -82,7 +83,7 @@ vi.mock("./delete-workspace-dialog", () => ({
 }));
 
 vi.mock("sonner", () => ({
-  toast: { success: vi.fn(), error: vi.fn() },
+  toast: { success: mockToastSuccess, error: vi.fn() },
 }));
 
 import { WorkspaceTab } from "./workspace-tab";
@@ -164,6 +165,10 @@ describe("WorkspaceTab — automatic updates", () => {
         description: "",
         context: "",
       });
+      expect(mockToastSuccess).toHaveBeenCalledWith(
+        "Workspace settings saved",
+        { id: "settings-auto-save" },
+      );
     });
     expect(mockInvalidateQueries).not.toHaveBeenCalled();
   });
@@ -192,6 +197,10 @@ describe("WorkspaceTab — automatic updates", () => {
     expect(mockInvalidateQueries).toHaveBeenCalledWith({
       queryKey: ["issues", "workspace-1"],
     });
+    expect(mockToastSuccess).toHaveBeenCalledWith(
+      "Workspace settings saved",
+      { id: "settings-auto-save" },
+    );
   });
 
   it("does not persist a prefix when the confirmation is cancelled", async () => {

--- a/packages/views/settings/components/workspace-tab.tsx
+++ b/packages/views/settings/components/workspace-tab.tsx
@@ -202,6 +202,10 @@ export function WorkspaceTab() {
     value: detailsDraft,
     savedValue: savedDetails,
     onSave: saveDetails,
+    onSuccess: () =>
+      toast.success(t(($) => $.workspace.toast_saved), {
+        id: "settings-auto-save",
+      }),
     onError: (error) =>
       toast.error(
         error instanceof Error
@@ -226,6 +230,9 @@ export function WorkspaceTab() {
       // so every cached issue key is stale after this confirmed change.
       await qc.invalidateQueries({ queryKey: issueKeys.all(updated.id) });
       setPrefixSaveStatus("saved");
+      toast.success(t(($) => $.workspace.toast_saved), {
+        id: "settings-auto-save",
+      });
     } catch (error) {
       setPrefixSaveStatus("error");
       toast.error(
@@ -327,14 +334,25 @@ export function WorkspaceTab() {
                 disabled={!canManageWorkspace}
                 ariaLabel={t(($) => $.workspace.change_logo_aria)}
                 onUploaded={async (url) => {
-                  const updated = await api.updateWorkspace(workspace.id, {
-                    avatar_url: url,
-                  });
-                  qc.setQueryData(
-                    workspaceKeys.list(),
-                    (old: Workspace[] | undefined) =>
-                      old?.map((ws) => (ws.id === updated.id ? updated : ws)),
-                  );
+                  try {
+                    const updated = await api.updateWorkspace(workspace.id, {
+                      avatar_url: url,
+                    });
+                    qc.setQueryData(
+                      workspaceKeys.list(),
+                      (old: Workspace[] | undefined) =>
+                        old?.map((ws) => (ws.id === updated.id ? updated : ws)),
+                    );
+                    toast.success(t(($) => $.workspace.toast_logo_updated), {
+                      id: "settings-auto-save",
+                    });
+                  } catch (error) {
+                    toast.error(
+                      error instanceof Error
+                        ? error.message
+                        : t(($) => $.workspace.toast_logo_failed),
+                    );
+                  }
                 }}
               />
             </div>


### PR DESCRIPTION
## What changed

- show a success toast after automatic Settings updates are actually persisted
- cover Profile, Workspace, Repositories, Preferences, Notifications, GitHub, Chat, and desktop Daemon settings
- reuse a stable toast ID so rapid updates replace the existing confirmation instead of stacking notifications
- delay the language reload briefly so its save confirmation remains visible
- only report success after the latest queued auto-save request completes
- preserve explicit error feedback for failed saves

## Why

Follow-up to #5257. Automatic updates removed the manual Save action, but without confirmation users could not tell whether a change had reached storage.

## Validation

- `pnpm --filter @multica/views typecheck`
- `pnpm --filter @multica/views exec vitest run settings/components --reporter=dot` — 84 tests passed
- `pnpm --filter @multica/desktop typecheck`
- Views/Desktop lint — no errors; pre-existing warnings only
