### PR TITLE
fix(issues): float find bar above sticky resolve collapse bars (MUL-4414)

### DIFF
--- a/packages/views/issues/components/issue-detail.tsx
+++ b/packages/views/issues/components/issue-detail.tsx
@@ -1852,9 +1852,13 @@ export function IssueDetail({ issueId, onDelete, onDone, defaultSidebarOpen = tr
     <div className="relative flex h-full min-w-0 flex-1 flex-col">
         {/* In-page find bar — floats over the top-right of the content column
             (below the breadcrumb header), outside the scroll container so it
-            stays put while the timeline scrolls and its own text isn't walked. */}
+            stays put while the timeline scrolls and its own text isn't walked.
+            z-30: must beat every sticky affordance pinned at the timeline's
+            top-0 (comment headers z-10, resolve collapse bars z-20) — at equal
+            z the later-in-DOM sticky bar paints over the find bar and orphans
+            its close button (MUL-4414). */}
         {find.open && (
-          <FindBar find={find} className="absolute right-4 top-14 z-20" />
+          <FindBar find={find} className="absolute right-4 top-14 z-30" />
         )}
         <BreadcrumbHeader
           segments={breadcrumbSegments}


### PR DESCRIPTION
## Summary

Fixes MUL-4414: on the issue detail page, the Cmd+F find bar and the sticky "收起" (collapse resolved thread) bar overlapped — the collapse bar painted over the find bar, half-hiding it and orphaning its close button.

**Root cause.** The find bar floats at `absolute right-4 top-14 z-20` over the top of the scroll container, where the resolve collapse bars pin at `sticky top-0 z-20` (`comment-card.tsx`). Equal z-index in the same stacking context → DOM order decides, and the scroll container comes later, so the collapse bar wins the paint order.

**Fix.** Raise the find bar to `z-30` so the transient overlay paints above every sticky affordance in the content column (comment headers `z-10`, resolve collapse bars `z-20`) — matching the original intent (it already floated above the `z-10` sticky headers) and standard find-in-page overlay behavior (Chrome/VS Code float their find widgets above pinned page content). The collapse bar's label and icon are left-aligned, so it stays visible and clickable while find is open.

Stacking-context check: `Card` (`overflow-clip`), the scroll container (`relative`, no z-index), and the flat-render wrappers create no intermediate stacking contexts, and find-open always uses the flat (non-Virtuoso) render path — so the z-30 vs z-20 comparison is direct and deterministic.

## Screenshot (before)

The reported overlap — collapse bar covering the find bar, close button orphaned:

![before](https://multica-app.copilothub.ai/api/attachments/019f508c-062a-720e-9060-685cc8700b68/download)

## Verification

- `pnpm typecheck --filter @multica/views` passes.
- No visual run: one-class z-index change, verified by the stacking analysis above.
