### PR TITLE
fix(attachments): in-page find for the maximized HTML preview

### DIFF
--- a/packages/views/attachments/attachment-preview-page.test.tsx
+++ b/packages/views/attachments/attachment-preview-page.test.tsx
@@ -1,0 +1,58 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { I18nProvider } from "@multica/core/i18n/react";
+import enEditor from "../locales/en/editor.json";
+
+// The HTML body is fetched via this hook; stub it so the page renders the iframe
+// branch without a network/query-client.
+vi.mock("../editor/hooks/use-attachment-html-text", () => ({
+  useAttachmentHtmlText: () => ({
+    data: { text: "<p>searchable body</p>" },
+    isLoading: false,
+    error: null,
+  }),
+}));
+
+import { AttachmentPreviewPage } from "./attachment-preview-page";
+
+const resources = { en: { editor: enEditor } };
+
+function renderPage() {
+  return render(
+    <I18nProvider locale="en" resources={resources}>
+      <AttachmentPreviewPage attachmentId="att-1" filename="report.html" />
+    </I18nProvider>,
+  );
+}
+
+describe("AttachmentPreviewPage — in-page find (#5259)", () => {
+  it("does not show the find bar until requested", () => {
+    renderPage();
+    expect(screen.queryByPlaceholderText("Find in page")).not.toBeInTheDocument();
+  });
+
+  it("opens the find bar on Ctrl+F and closes it on Escape", () => {
+    renderPage();
+
+    fireEvent.keyDown(window, { key: "f", ctrlKey: true });
+    expect(screen.getByPlaceholderText("Find in page")).toBeInTheDocument();
+
+    fireEvent.keyDown(window, { key: "Escape" });
+    expect(screen.queryByPlaceholderText("Find in page")).not.toBeInTheDocument();
+  });
+
+  it("opens the find bar on Cmd+F (macOS)", () => {
+    renderPage();
+    fireEvent.keyDown(window, { key: "f", metaKey: true });
+    expect(screen.getByPlaceholderText("Find in page")).toBeInTheDocument();
+  });
+
+  it("renders the sandboxed iframe with the injected find shim in srcDoc", () => {
+    const { container } = renderPage();
+    const iframe = container.querySelector("iframe");
+    expect(iframe).toBeTruthy();
+    // Sandbox posture preserved: allow-scripts, never allow-same-origin.
+    expect(iframe!.getAttribute("sandbox")).toBe("allow-scripts");
+    expect(iframe!.getAttribute("srcdoc")).toContain("multica-find-cmd");
+  });
+});

--- a/packages/views/attachments/attachment-preview-page.test.tsx
+++ b/packages/views/attachments/attachment-preview-page.test.tsx
@@ -1,13 +1,17 @@
 import { describe, expect, it, vi } from "vitest";
-import { render } from "@testing-library/react";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { I18nProvider } from "@multica/core/i18n/react";
 import type { ScrollRestorationAdapter } from "../platform";
 import { ScrollRestorationProvider } from "../platform";
 import { AttachmentPreviewPage } from "./attachment-preview-page";
 import { hashString } from "../editor/utils/hash-string";
 import { buildScrollBridge } from "../editor/utils/iframe-scroll-bridge";
+import enEditor from "../locales/en/editor.json";
 
 const htmlText = "<html><body><h1>Report</h1></body></html>";
 
+// The HTML body is fetched via this hook; stub it so the page renders the iframe
+// branch without a network/query-client.
 vi.mock("../editor/hooks/use-attachment-html-text", () => ({
   useAttachmentHtmlText: () => ({
     data: { text: htmlText },
@@ -16,10 +20,25 @@ vi.mock("../editor/hooks/use-attachment-html-text", () => ({
   }),
 }));
 
-vi.mock("../i18n", () => ({
-  useT: () => (fn: (d: Record<string, unknown>) => string) =>
-    fn({ attachment: { preview_loading: "l", preview_failed: "f" } }),
-}));
+const resources = { en: { editor: enEditor } };
+
+/** Real i18n (not a `useT` stub) — the find bar reads its placeholder from it. */
+function renderPage(adapter?: ScrollRestorationAdapter) {
+  const page = (
+    <I18nProvider locale="en" resources={resources}>
+      <AttachmentPreviewPage attachmentId="att-1" filename="report.html" />
+    </I18nProvider>
+  );
+  return render(
+    adapter ? (
+      <ScrollRestorationProvider adapter={adapter}>
+        {page}
+      </ScrollRestorationProvider>
+    ) : (
+      page
+    ),
+  );
+}
 
 describe("AttachmentPreviewPage", () => {
   it("injects the scroll bridge under the desktop adapter and keys the iframe on contentKey", () => {
@@ -27,11 +46,7 @@ describe("AttachmentPreviewPage", () => {
       get: () => undefined,
       registerExternalSource: vi.fn(),
     };
-    const { container } = render(
-      <ScrollRestorationProvider adapter={adapter}>
-        <AttachmentPreviewPage attachmentId="att-1" />
-      </ScrollRestorationProvider>,
-    );
+    const { container } = renderPage(adapter);
     const iframe = container.querySelector("iframe")!;
     expect(iframe).toBeTruthy();
     expect(iframe.getAttribute("srcdoc")).toContain(
@@ -48,15 +63,56 @@ describe("AttachmentPreviewPage", () => {
 
   it("does NOT inject the bridge or register a source on web (adapter without registerExternalSource)", () => {
     const webAdapter: ScrollRestorationAdapter = { get: () => undefined };
-    const { container } = render(
-      <ScrollRestorationProvider adapter={webAdapter}>
-        <AttachmentPreviewPage attachmentId="att-1" />
-      </ScrollRestorationProvider>,
-    );
+    const { container } = renderPage(webAdapter);
     const iframe = container.querySelector("iframe")!;
     expect(iframe.getAttribute("srcdoc")).not.toContain("__multica");
     expect(iframe.getAttribute("srcdoc")).not.toContain(buildScrollBridge("x"));
     // Still applies the fragment-nav shim on both surfaces.
     expect(iframe.getAttribute("srcdoc")).toContain("scrollIntoView");
+  });
+});
+
+describe("AttachmentPreviewPage — in-page find (#5259)", () => {
+  it("does not show the find bar until requested", () => {
+    renderPage();
+    expect(screen.queryByPlaceholderText("Find in page")).not.toBeInTheDocument();
+  });
+
+  it("opens the find bar on Ctrl+F and closes it on Escape", () => {
+    renderPage();
+
+    fireEvent.keyDown(window, { key: "f", ctrlKey: true });
+    expect(screen.getByPlaceholderText("Find in page")).toBeInTheDocument();
+
+    fireEvent.keyDown(window, { key: "Escape" });
+    expect(screen.queryByPlaceholderText("Find in page")).not.toBeInTheDocument();
+  });
+
+  it("opens the find bar on Cmd+F (macOS)", () => {
+    renderPage();
+    fireEvent.keyDown(window, { key: "f", metaKey: true });
+    expect(screen.getByPlaceholderText("Find in page")).toBeInTheDocument();
+  });
+
+  it("renders the sandboxed iframe with the injected find shim in srcDoc", () => {
+    const { container } = renderPage();
+    const iframe = container.querySelector("iframe");
+    expect(iframe).toBeTruthy();
+    // Sandbox posture preserved: allow-scripts, never allow-same-origin.
+    expect(iframe!.getAttribute("sandbox")).toBe("allow-scripts");
+    expect(iframe!.getAttribute("srcdoc")).toContain("multica-find-cmd");
+  });
+
+  // The find shim rides on top of the scroll-restore srcDoc (multica-ai#6405),
+  // so both must survive under the desktop adapter.
+  it("keeps both the scroll bridge and the find shim under the desktop adapter", () => {
+    const adapter: ScrollRestorationAdapter = {
+      get: () => undefined,
+      registerExternalSource: vi.fn(),
+    };
+    const { container } = renderPage(adapter);
+    const srcdoc = container.querySelector("iframe")!.getAttribute("srcdoc")!;
+    expect(srcdoc).toContain(buildScrollBridge(hashString(htmlText)));
+    expect(srcdoc).toContain("multica-find-cmd");
   });
 });

--- a/packages/views/attachments/attachment-preview-page.tsx
+++ b/packages/views/attachments/attachment-preview-page.tsx
@@ -13,15 +13,24 @@
  * iframe runs in an opaque origin and cannot reach cookies, localStorage,
  * parent, or top-level navigation.
  *
+ * Because that opaque origin also blocks the browser's native Ctrl+F from
+ * searching the document (#5259), we inject a find shim (withFindShim) into the
+ * srcdoc and drive it from an in-app find bar over postMessage.
+ *
  * The route is workspace-scoped (`/{slug}/attachments/{id}/preview`) for
  * tenancy isolation; the `/api/attachments/{id}/content` proxy itself is
  * already auth-checked, so the slug is purely a URL contract.
  */
 
-import { useEffect } from "react";
+import { useEffect, useRef, useState } from "react";
 import { useT } from "../i18n";
 import { useAttachmentHtmlText } from "../editor/hooks/use-attachment-html-text";
 import { withFragmentNavShim } from "../editor/utils/iframe-fragment-nav";
+import { withFindShim, FIND_RESULT, FIND_OPEN } from "../editor/utils/iframe-find";
+import {
+  HtmlPreviewFindBar,
+  type FindResult,
+} from "../editor/html-preview-find-bar";
 
 interface AttachmentPreviewPageProps {
   attachmentId: string;
@@ -37,6 +46,11 @@ export function AttachmentPreviewPage({
   const { t } = useT("editor");
   const query = useAttachmentHtmlText(attachmentId);
 
+  const iframeRef = useRef<HTMLIFrameElement>(null);
+  const [findOpen, setFindOpen] = useState(false);
+  const [findQuery, setFindQuery] = useState("");
+  const [findResult, setFindResult] = useState<FindResult | null>(null);
+
   // Set document.title so desktop's MutationObserver-based tab title picks
   // up the filename. Web shows the same string in the browser tab.
   useEffect(() => {
@@ -46,6 +60,47 @@ export function AttachmentPreviewPage({
   const text = query.data?.text;
   const isLoading = query.isLoading;
   const isError = !isLoading && (!!query.error || !text);
+  const hasContent = !isLoading && !isError;
+
+  // Intercept Ctrl/Cmd+F at the page level so it opens our in-app find bar
+  // instead of the browser's native find (which cannot reach the opaque-origin
+  // iframe anyway). The shim posts FIND_OPEN when the iframe itself has focus.
+  useEffect(() => {
+    if (!hasContent) return;
+    const handler = (e: KeyboardEvent) => {
+      if ((e.ctrlKey || e.metaKey) && (e.key === "f" || e.key === "F")) {
+        e.preventDefault();
+        setFindOpen(true);
+      } else if (e.key === "Escape" && findOpen) {
+        setFindOpen(false);
+      }
+    };
+    window.addEventListener("keydown", handler);
+    return () => window.removeEventListener("keydown", handler);
+  }, [hasContent, findOpen]);
+
+  // Receive match counts / open requests from the injected shim. Only trust
+  // messages from THIS iframe's window and carrying our own source tag.
+  useEffect(() => {
+    const handler = (e: MessageEvent) => {
+      if (e.source !== iframeRef.current?.contentWindow) return;
+      const d = e.data as
+        | { source?: string; found?: boolean; total?: number; current?: number }
+        | undefined;
+      if (!d || typeof d !== "object") return;
+      if (d.source === FIND_RESULT) {
+        setFindResult({
+          found: !!d.found,
+          total: d.total ?? 0,
+          current: d.current ?? 0,
+        });
+      } else if (d.source === FIND_OPEN) {
+        setFindOpen(true);
+      }
+    };
+    window.addEventListener("message", handler);
+    return () => window.removeEventListener("message", handler);
+  }, []);
 
   return (
     <div className="flex h-full w-full flex-col bg-background">
@@ -61,12 +116,24 @@ export function AttachmentPreviewPage({
           {t(($) => $.attachment.preview_failed)}
         </div>
       ) : (
-        <iframe
-          srcDoc={withFragmentNavShim(text)}
-          sandbox="allow-scripts"
-          title={filename ?? "HTML attachment"}
-          className="flex-1 w-full border-0 bg-background"
-        />
+        <div className="relative flex-1">
+          <iframe
+            ref={iframeRef}
+            srcDoc={withFindShim(withFragmentNavShim(text))}
+            sandbox="allow-scripts"
+            title={filename ?? "HTML attachment"}
+            className="h-full w-full border-0 bg-background"
+          />
+          {findOpen && (
+            <HtmlPreviewFindBar
+              iframeRef={iframeRef}
+              result={findResult}
+              query={findQuery}
+              onQueryChange={setFindQuery}
+              onClose={() => setFindOpen(false)}
+            />
+          )}
+        </div>
       )}
     </div>
   );

--- a/packages/views/attachments/attachment-preview-page.tsx
+++ b/packages/views/attachments/attachment-preview-page.tsx
@@ -13,15 +13,24 @@
  * iframe runs in an opaque origin and cannot reach cookies, localStorage,
  * parent, or top-level navigation.
  *
+ * Because that opaque origin also blocks the browser's native Ctrl+F from
+ * searching the document (#5259), we inject a find shim (withFindShim) into the
+ * srcdoc and drive it from an in-app find bar over postMessage.
+ *
  * The route is workspace-scoped (`/{slug}/attachments/{id}/preview`) for
  * tenancy isolation; the `/api/attachments/{id}/content` proxy itself is
  * already auth-checked, so the slug is purely a URL contract.
  */
 
-import { useEffect } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { useT } from "../i18n";
 import { useAttachmentHtmlText } from "../editor/hooks/use-attachment-html-text";
 import { useHtmlPreviewScrollRestore } from "./use-html-preview-scroll-restore";
+import { withFindShim, FIND_RESULT, FIND_OPEN } from "../editor/utils/iframe-find";
+import {
+  HtmlPreviewFindBar,
+  type FindResult,
+} from "../editor/html-preview-find-bar";
 
 interface AttachmentPreviewPageProps {
   attachmentId: string;
@@ -44,8 +53,27 @@ export function AttachmentPreviewPage({
   // content change (re-upload) structurally remounts a fresh document; the
   // hook reports y=0 with the new key until that document scrolls, and
   // messages from the previous document are dropped by token.
-  const { contentKey, buildSrcDoc, iframeRef, onLoad } =
-    useHtmlPreviewScrollRestore(text);
+  const {
+    contentKey,
+    buildSrcDoc,
+    iframeRef: attachScrollBridge,
+    onLoad,
+  } = useHtmlPreviewScrollRestore(text);
+
+  // The scroll-restore hook owns a callback ref; the find bar needs an object
+  // ref to postMessage into the same iframe. Fan the element out to both.
+  const iframeRef = useRef<HTMLIFrameElement | null>(null);
+  const setIframeRef = useCallback(
+    (el: HTMLIFrameElement | null) => {
+      iframeRef.current = el;
+      attachScrollBridge(el);
+    },
+    [attachScrollBridge],
+  );
+
+  const [findOpen, setFindOpen] = useState(false);
+  const [findQuery, setFindQuery] = useState("");
+  const [findResult, setFindResult] = useState<FindResult | null>(null);
 
   // Set document.title so desktop's MutationObserver-based tab title picks
   // up the filename. Web shows the same string in the browser tab.
@@ -55,6 +83,47 @@ export function AttachmentPreviewPage({
 
   const isLoading = query.isLoading;
   const isError = !isLoading && (!!query.error || !text);
+  const hasContent = !isLoading && !isError;
+
+  // Intercept Ctrl/Cmd+F at the page level so it opens our in-app find bar
+  // instead of the browser's native find (which cannot reach the opaque-origin
+  // iframe anyway). The shim posts FIND_OPEN when the iframe itself has focus.
+  useEffect(() => {
+    if (!hasContent) return;
+    const handler = (e: KeyboardEvent) => {
+      if ((e.ctrlKey || e.metaKey) && (e.key === "f" || e.key === "F")) {
+        e.preventDefault();
+        setFindOpen(true);
+      } else if (e.key === "Escape" && findOpen) {
+        setFindOpen(false);
+      }
+    };
+    window.addEventListener("keydown", handler);
+    return () => window.removeEventListener("keydown", handler);
+  }, [hasContent, findOpen]);
+
+  // Receive match counts / open requests from the injected shim. Only trust
+  // messages from THIS iframe's window and carrying our own source tag.
+  useEffect(() => {
+    const handler = (e: MessageEvent) => {
+      if (e.source !== iframeRef.current?.contentWindow) return;
+      const d = e.data as
+        | { source?: string; found?: boolean; total?: number; current?: number }
+        | undefined;
+      if (!d || typeof d !== "object") return;
+      if (d.source === FIND_RESULT) {
+        setFindResult({
+          found: !!d.found,
+          total: d.total ?? 0,
+          current: d.current ?? 0,
+        });
+      } else if (d.source === FIND_OPEN) {
+        setFindOpen(true);
+      }
+    };
+    window.addEventListener("message", handler);
+    return () => window.removeEventListener("message", handler);
+  }, []);
 
   return (
     <div className="flex h-full w-full flex-col bg-background">
@@ -70,15 +139,26 @@ export function AttachmentPreviewPage({
           {t(($) => $.attachment.preview_failed)}
         </div>
       ) : (
-        <iframe
-          key={contentKey}
-          ref={iframeRef}
-          onLoad={onLoad}
-          srcDoc={buildSrcDoc(text as string)}
-          sandbox="allow-scripts"
-          title={filename ?? "HTML attachment"}
-          className="flex-1 w-full border-0 bg-background"
-        />
+        <div className="relative flex-1">
+          <iframe
+            key={contentKey}
+            ref={setIframeRef}
+            onLoad={onLoad}
+            srcDoc={withFindShim(buildSrcDoc(text as string))}
+            sandbox="allow-scripts"
+            title={filename ?? "HTML attachment"}
+            className="h-full w-full border-0 bg-background"
+          />
+          {findOpen && (
+            <HtmlPreviewFindBar
+              iframeRef={iframeRef}
+              result={findResult}
+              query={findQuery}
+              onQueryChange={setFindQuery}
+              onClose={() => setFindOpen(false)}
+            />
+          )}
+        </div>
       )}
     </div>
   );

--- a/packages/views/editor/html-preview-find-bar.test.tsx
+++ b/packages/views/editor/html-preview-find-bar.test.tsx
@@ -1,0 +1,104 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { useRef, useState, type RefObject } from "react";
+import { I18nProvider } from "@multica/core/i18n/react";
+import enEditor from "../locales/en/editor.json";
+import { HtmlPreviewFindBar, type FindResult } from "./html-preview-find-bar";
+import { FIND_CMD } from "./utils/iframe-find";
+
+const resources = { en: { editor: enEditor } };
+
+function Harness({
+  post,
+  result,
+  onClose = () => {},
+}: {
+  post: ReturnType<typeof vi.fn>;
+  result: FindResult | null;
+  onClose?: () => void;
+}) {
+  // Real query state so the controlled `query` prop updates on type — the count
+  // label depends on query.length > 0.
+  const [query, setQuery] = useState("");
+  const iframeRef = useRef<HTMLIFrameElement | null>(
+    { contentWindow: { postMessage: post } } as unknown as HTMLIFrameElement,
+  );
+  return (
+    <I18nProvider locale="en" resources={resources}>
+      <HtmlPreviewFindBar
+        iframeRef={iframeRef as RefObject<HTMLIFrameElement | null>}
+        result={result}
+        query={query}
+        onQueryChange={setQuery}
+        onClose={onClose}
+      />
+    </I18nProvider>
+  );
+}
+
+describe("HtmlPreviewFindBar", () => {
+  let post: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    post = vi.fn();
+  });
+
+  it("sends a search command to the iframe as the user types", () => {
+    render(<Harness post={post} result={null} />);
+    fireEvent.change(screen.getByPlaceholderText("Find in page"), {
+      target: { value: "hello" },
+    });
+    expect(post).toHaveBeenCalledWith(
+      { source: FIND_CMD, action: "search", query: "hello", caseSensitive: false },
+      "*",
+    );
+  });
+
+  it("renders the current/total count from result once a query is entered", () => {
+    render(<Harness post={post} result={{ found: true, total: 5, current: 2 }} />);
+    fireEvent.change(screen.getByPlaceholderText("Find in page"), { target: { value: "x" } });
+    expect(screen.getByText("2/5")).toBeInTheDocument();
+  });
+
+  it("shows a no-results label when total is 0", () => {
+    render(<Harness post={post} result={{ found: false, total: 0, current: 0 }} />);
+    fireEvent.change(screen.getByPlaceholderText("Find in page"), { target: { value: "zzz" } });
+    expect(screen.getByText("No results")).toBeInTheDocument();
+  });
+
+  it("Enter steps next, Shift+Enter steps prev", () => {
+    render(<Harness post={post} result={{ found: true, total: 3, current: 1 }} />);
+    const input = screen.getByPlaceholderText("Find in page");
+    fireEvent.change(input, { target: { value: "a" } });
+    post.mockClear();
+    fireEvent.keyDown(input, { key: "Enter" });
+    expect(post).toHaveBeenLastCalledWith(
+      expect.objectContaining({ action: "next", query: "a" }),
+      "*",
+    );
+    fireEvent.keyDown(input, { key: "Enter", shiftKey: true });
+    expect(post).toHaveBeenLastCalledWith(
+      expect.objectContaining({ action: "prev", query: "a" }),
+      "*",
+    );
+  });
+
+  it("clicking the next/prev buttons steps in that direction", () => {
+    render(<Harness post={post} result={{ found: true, total: 3, current: 1 }} />);
+    fireEvent.change(screen.getByPlaceholderText("Find in page"), { target: { value: "a" } });
+    post.mockClear();
+    fireEvent.click(screen.getByLabelText("Next match"));
+    expect(post).toHaveBeenLastCalledWith(expect.objectContaining({ action: "next" }), "*");
+    fireEvent.click(screen.getByLabelText("Previous match"));
+    expect(post).toHaveBeenLastCalledWith(expect.objectContaining({ action: "prev" }), "*");
+  });
+
+  it("close clears the selection in the iframe and calls onClose", () => {
+    const onClose = vi.fn();
+    render(<Harness post={post} result={null} onClose={onClose} />);
+    post.mockClear();
+    fireEvent.click(screen.getByLabelText("Close find"));
+    expect(post).toHaveBeenCalledWith(expect.objectContaining({ action: "clear" }), "*");
+    expect(onClose).toHaveBeenCalled();
+  });
+});

--- a/packages/views/editor/html-preview-find-bar.tsx
+++ b/packages/views/editor/html-preview-find-bar.tsx
@@ -1,0 +1,143 @@
+"use client";
+
+/**
+ * HtmlPreviewFindBar — an in-app find bar for sandboxed HTML preview iframes
+ * (#5259). Native Ctrl+F cannot search into an opaque-origin sandbox iframe, so
+ * this bar drives the injected find shim (see utils/iframe-find.ts) over
+ * postMessage instead: typing searches, Enter / arrows step through matches, and
+ * the shim reports back a `current/total` count the caller feeds in via `result`.
+ *
+ * The bar owns only the query/UI; the actual find + scroll happens inside the
+ * iframe's own document. Keep it presentational so both the full-page viewer and
+ * the modal can reuse it.
+ */
+
+import { useEffect, useRef, type RefObject } from "react";
+import { ChevronDown, ChevronUp, X } from "lucide-react";
+import { useT } from "../i18n";
+import { FIND_CMD } from "./utils/iframe-find";
+
+export interface FindResult {
+  found: boolean;
+  total: number;
+  current: number;
+}
+
+interface HtmlPreviewFindBarProps {
+  /** The sandboxed preview iframe to drive over postMessage. */
+  iframeRef: RefObject<HTMLIFrameElement | null>;
+  /** Latest count reported by the iframe shim, or null before the first search. */
+  result: FindResult | null;
+  /** Current query (controlled by the caller so it survives bar remounts). */
+  query: string;
+  onQueryChange: (query: string) => void;
+  onClose: () => void;
+}
+
+export function HtmlPreviewFindBar({
+  iframeRef,
+  result,
+  query,
+  onQueryChange,
+  onClose,
+}: HtmlPreviewFindBarProps) {
+  const { t } = useT("editor");
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  // Focus the input whenever the bar mounts so Ctrl+F feels native.
+  useEffect(() => {
+    inputRef.current?.focus();
+    inputRef.current?.select();
+  }, []);
+
+  const send = (action: "search" | "next" | "prev" | "clear", q: string) => {
+    iframeRef.current?.contentWindow?.postMessage(
+      { source: FIND_CMD, action, query: q, caseSensitive: false },
+      "*",
+    );
+  };
+
+  const handleChange = (value: string) => {
+    onQueryChange(value);
+    send("search", value);
+  };
+
+  const step = (dir: "next" | "prev") => {
+    if (query) send(dir, query);
+  };
+
+  const close = () => {
+    send("clear", "");
+    onClose();
+  };
+
+  const hasQuery = query.length > 0;
+  const noResults = hasQuery && result != null && result.total === 0;
+  const count =
+    hasQuery && result != null && result.total > 0
+      ? t(($) => $.attachment.find_count, {
+          current: String(result.current),
+          total: String(result.total),
+        })
+      : noResults
+      ? t(($) => $.attachment.find_no_results)
+      : "";
+
+  return (
+    <div
+      className="absolute right-3 top-3 z-10 flex items-center gap-1 rounded-md border border-border bg-background/95 px-2 py-1 shadow-md backdrop-blur"
+      role="search"
+    >
+      <input
+        ref={inputRef}
+        type="text"
+        value={query}
+        onChange={(e) => handleChange(e.target.value)}
+        onKeyDown={(e) => {
+          if (e.key === "Enter") {
+            e.preventDefault();
+            step(e.shiftKey ? "prev" : "next");
+          } else if (e.key === "Escape") {
+            e.preventDefault();
+            close();
+          }
+        }}
+        placeholder={t(($) => $.attachment.find_placeholder)}
+        aria-label={t(($) => $.attachment.find_placeholder)}
+        className="w-40 bg-transparent text-sm text-foreground outline-none placeholder:text-muted-foreground"
+      />
+      <span className="min-w-[3rem] shrink-0 text-right text-xs tabular-nums text-muted-foreground">
+        {count}
+      </span>
+      <button
+        type="button"
+        className="rounded p-1 text-muted-foreground transition-colors hover:bg-secondary hover:text-foreground disabled:opacity-40"
+        title={t(($) => $.attachment.find_prev)}
+        aria-label={t(($) => $.attachment.find_prev)}
+        disabled={!hasQuery}
+        onClick={() => step("prev")}
+      >
+        <ChevronUp className="size-4" />
+      </button>
+      <button
+        type="button"
+        className="rounded p-1 text-muted-foreground transition-colors hover:bg-secondary hover:text-foreground disabled:opacity-40"
+        title={t(($) => $.attachment.find_next)}
+        aria-label={t(($) => $.attachment.find_next)}
+        disabled={!hasQuery}
+        onClick={() => step("next")}
+      >
+        <ChevronDown className="size-4" />
+      </button>
+      <button
+        type="button"
+        className="rounded p-1 text-muted-foreground transition-colors hover:bg-secondary hover:text-foreground"
+        title={t(($) => $.attachment.find_close)}
+        aria-label={t(($) => $.attachment.find_close)}
+        onClick={close}
+      >
+        <X className="size-4" />
+      </button>
+    </div>
+  );
+}

--- a/packages/views/editor/html-preview-find-bar.tsx
+++ b/packages/views/editor/html-preview-find-bar.tsx
@@ -104,9 +104,9 @@ export function HtmlPreviewFindBar({
         }}
         placeholder={t(($) => $.attachment.find_placeholder)}
         aria-label={t(($) => $.attachment.find_placeholder)}
-        className="w-40 bg-transparent text-sm text-foreground outline-none placeholder:text-muted-foreground"
+        className="w-40 bg-transparent text-body text-foreground outline-none placeholder:text-muted-foreground"
       />
-      <span className="min-w-[3rem] shrink-0 text-right text-xs tabular-nums text-muted-foreground">
+      <span className="min-w-[3rem] shrink-0 text-right text-caption tabular-nums text-muted-foreground">
         {count}
       </span>
       <button

--- a/packages/views/editor/utils/iframe-find.test.ts
+++ b/packages/views/editor/utils/iframe-find.test.ts
@@ -1,0 +1,253 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  __IFRAME_FIND_SHIM__,
+  withFindShim,
+  FIND_CMD,
+  FIND_RESULT,
+  FIND_OPEN,
+} from "./iframe-find";
+
+describe("withFindShim", () => {
+  it("appends the shim verbatim at the end of the original HTML", () => {
+    const html = "<p>hello world</p>";
+    const out = withFindShim(html);
+    expect(out.startsWith(html)).toBe(true);
+    expect(out.endsWith(__IFRAME_FIND_SHIM__)).toBe(true);
+    expect(out).toBe(html + __IFRAME_FIND_SHIM__);
+  });
+
+  it("does not mutate the input string", () => {
+    const html = "<p>hi</p>";
+    withFindShim(html);
+    expect(html).toBe("<p>hi</p>");
+  });
+
+  it("handles empty input", () => {
+    expect(withFindShim("")).toBe(__IFRAME_FIND_SHIM__);
+  });
+
+  it("carries the postMessage protocol tags so parent and iframe agree", () => {
+    expect(__IFRAME_FIND_SHIM__).toContain(FIND_CMD);
+    expect(__IFRAME_FIND_SHIM__).toContain(FIND_RESULT);
+    expect(__IFRAME_FIND_SHIM__).toContain(FIND_OPEN);
+  });
+});
+
+// The shim ships as a <script> string injected into a srcdoc iframe. To
+// exercise its runtime behavior, evaluate the inner script against the current
+// jsdom document — close enough to what runs inside the iframe.
+function loadShimIntoDocument() {
+  const inner = __IFRAME_FIND_SHIM__
+    .replace(/^<script>/, "")
+    .replace(/<\/script>$/, "");
+  new Function(inner)();
+}
+
+describe("find shim runtime behavior", () => {
+  let postSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    document.body.innerHTML =
+      "<p>alpha beta ALPHA</p><div>alpha gamma</div>"; // 3 case-insensitive "alpha"
+    // scrollIntoView isn't implemented in jsdom; the shim guards it but stub it
+    // anyway so the select+scroll path runs cleanly.
+    Object.defineProperty(window.Element.prototype, "scrollIntoView", {
+      configurable: true,
+      writable: true,
+      value: vi.fn(),
+    });
+    postSpy = vi.spyOn(window, "postMessage");
+    loadShimIntoDocument();
+  });
+
+  afterEach(() => {
+    document.body.innerHTML = "";
+    postSpy.mockRestore();
+  });
+
+  function lastResult() {
+    for (let i = postSpy.mock.calls.length - 1; i >= 0; i--) {
+      const msg = postSpy.mock.calls[i][0] as {
+        source?: string;
+        found?: boolean;
+        total?: number;
+        current?: number;
+      };
+      if (msg && msg.source === FIND_RESULT) return msg;
+    }
+    return undefined;
+  }
+
+  function send(action: string, query = "alpha", caseSensitive = false) {
+    window.dispatchEvent(
+      new MessageEvent("message", {
+        data: { source: FIND_CMD, action, query, caseSensitive },
+      }),
+    );
+  }
+
+  it("counts total case-insensitive matches across text nodes and reports found+current", () => {
+    send("search");
+    const res = lastResult();
+    expect(res).toBeDefined();
+    expect(res!.total).toBe(3); // alpha, ALPHA, alpha
+    expect(res!.found).toBe(true);
+    expect(res!.current).toBe(1);
+  });
+
+  it("does not count matches inside <script>/<style>/<noscript> text", () => {
+    // Regression for the count-inflation bug: the TreeWalker must skip the
+    // injected shim's own <script> text and style/noscript nodes.
+    document.body.innerHTML =
+      "<p>alpha</p><script>var s='alpha alpha';</script><style>.alpha{color:red}</style>";
+    send("search");
+    expect(lastResult()!.total).toBe(1); // only the <p>, not script/style text
+  });
+
+  it("respects caseSensitive when counting", () => {
+    send("search", "alpha", true);
+    expect(lastResult()!.total).toBe(2); // "ALPHA" excluded
+  });
+
+  it("reports zero + not-found for a query with no matches", () => {
+    send("search", "zzz");
+    const res = lastResult()!;
+    expect(res.total).toBe(0);
+    expect(res.found).toBe(false);
+    expect(res.current).toBe(0);
+  });
+
+  it("advances the current index on next and wraps at the end", () => {
+    send("search"); // current=1
+    send("next");   // 2
+    send("next");   // 3
+    expect(lastResult()!.current).toBe(3);
+    send("next");   // wraps to 1
+    expect(lastResult()!.current).toBe(1);
+  });
+
+  it("steps backwards with prev and wraps at the start", () => {
+    send("search"); // current=1
+    send("prev");   // wraps to 3
+    expect(lastResult()!.current).toBe(3);
+    send("prev");   // 2
+    expect(lastResult()!.current).toBe(2);
+  });
+
+  it("ignores messages that are not find commands", () => {
+    postSpy.mockClear();
+    window.dispatchEvent(new MessageEvent("message", { data: { source: "something-else" } }));
+    expect(lastResult()).toBeUndefined();
+  });
+
+  it("posts an open signal and preventDefaults on Ctrl+F inside the iframe", () => {
+    const evt = new KeyboardEvent("keydown", { key: "f", ctrlKey: true, cancelable: true });
+    window.dispatchEvent(evt);
+    expect(evt.defaultPrevented).toBe(true);
+    const openMsg = postSpy.mock.calls
+      .map((c: unknown[]) => c[0] as { source?: string })
+      .find((m: { source?: string }) => m && m.source === FIND_OPEN);
+    expect(openMsg).toBeDefined();
+  });
+
+  // --- Cross-node matching ---
+
+  it("finds a match that spans across an inline element boundary", () => {
+    // The old per-node approach would miss "hello world" because "hello " is
+    // in one text node and "world" is in the <b>'s text node.
+    document.body.innerHTML = "<p>hello <b>world</b></p>";
+    send("search", "hello world");
+    const res = lastResult()!;
+    expect(res.total).toBe(1);
+    expect(res.found).toBe(true);
+  });
+
+  it("counts overlapping cross-node and single-node matches correctly", () => {
+    // "ab" appears: once spanning the boundary (text "a" + text "b") and once
+    // inside the second <span>'s own text node ("ab").
+    document.body.innerHTML = "<span>a</span><span>b ab</span>";
+    send("search", "ab");
+    expect(lastResult()!.total).toBe(2);
+  });
+
+  // --- Stale cache / MutationObserver ---
+
+  it("re-indexes after a DOM mutation before the next search", async () => {
+    // Initial search — 3 "alpha" matches.
+    send("search");
+    expect(lastResult()!.total).toBe(3);
+
+    // Mutate the DOM (add a fourth match) and let MutationObserver fire.
+    document.body.appendChild(
+      Object.assign(document.createElement("p"), { textContent: "alpha extra" }),
+    );
+    // MutationObserver callbacks run as microtasks; yield to let them fire.
+    await Promise.resolve();
+
+    // Repeat the exact same query — the cache must be rebuilt.
+    send("search");
+    expect(lastResult()!.total).toBe(4);
+  });
+
+  it("does not re-index when the DOM is unchanged between identical queries", async () => {
+    send("search");
+    expect(lastResult()!.total).toBe(3);
+    // No mutation — a second identical search reuses the cache.
+    // Spy on buildFlatMap indirectly: if total is still 3, caching held.
+    send("search");
+    expect(lastResult()!.total).toBe(3);
+  });
+
+  // --- Origin / source guard ---
+
+  it("ignores messages whose e.source is a foreign window", () => {
+    // jsdom runs at top-level (parent === window) so the origin guard is a
+    // no-op there by design. Simulate the iframe scenario by temporarily
+    // patching window.parent to a sentinel different from window so the guard
+    // activates, then send a message whose e.source is neither sentinel nor window.
+    const realParent = Object.getOwnPropertyDescriptor(window, "parent");
+    const sentinel = {} as Window;
+    Object.defineProperty(window, "parent", { configurable: true, get: () => sentinel });
+    try {
+      postSpy.mockClear();
+      // e.source defaults to null in MessageEvent when not set — not the sentinel.
+      window.dispatchEvent(
+        new MessageEvent("message", {
+          data: { source: FIND_CMD, action: "search", query: "alpha", caseSensitive: false },
+        }),
+      );
+      // The guard should have rejected the message before posting a result.
+      expect(lastResult()).toBeUndefined();
+    } finally {
+      if (realParent) Object.defineProperty(window, "parent", realParent);
+      else delete (window as { parent?: unknown }).parent;
+    }
+  });
+
+  it("in top-level context (parent === window) the source guard is inactive and all messages are accepted", () => {
+    // The guard `parent !== window && e.source !== parent` is intentionally a
+    // no-op when not embedded in an iframe so that the shim stays fully usable
+    // in jsdom tests and top-level windows.  jsdom does not allow setting
+    // MessageEvent.source to an arbitrary WindowProxy object, so the iframe
+    // acceptance branch (parent !== window, e.source === parent) cannot be
+    // driven at runtime here — it is verified structurally below.
+    postSpy.mockClear();
+    window.dispatchEvent(
+      new MessageEvent("message", {
+        data: { source: FIND_CMD, action: "search", query: "alpha", caseSensitive: false },
+        // window IS a valid MessageEventSource in jsdom.
+        source: window,
+      }),
+    );
+    expect(lastResult()).toBeDefined();
+    expect(lastResult()!.total).toBe(3);
+  });
+
+  it("shim source guard expression is present and guards both conditions", () => {
+    // Structural check: the shim must contain both halves of the compound guard
+    // so that an iframe-hosted shim rejects commands from any window other than
+    // its hosting parent, while remaining fully open in a top-level context.
+    expect(__IFRAME_FIND_SHIM__).toContain("parent !== window");
+    expect(__IFRAME_FIND_SHIM__).toContain("e.source !== parent");
+  });
+});

--- a/packages/views/editor/utils/iframe-find.ts
+++ b/packages/views/editor/utils/iframe-find.ts
@@ -1,0 +1,219 @@
+/**
+ * In-page find shim for sandboxed HTML attachment iframes (#5259).
+ *
+ * HTML attachment previews mount user HTML inside a
+ * `<iframe sandbox="allow-scripts" srcdoc={...}>` WITHOUT `allow-same-origin`
+ * (see code-block-iframe.tsx / attachment-preview-page.tsx). That opaque-origin
+ * sandbox is deliberate — it isolates untrusted uploads — but it has a side
+ * effect: the browser's native Ctrl+F / Cmd+F find-in-page cannot search into
+ * an opaque-origin iframe, and the parent document cannot reach the iframe's
+ * DOM across the origin boundary either. So maximizing an HTML preview left the
+ * user with no way to search a large document.
+ *
+ * The fix mirrors withFragmentNavShim: inject a tiny script into the srcdoc that
+ * runs in the iframe's own opaque origin (same capability `allow-scripts`
+ * already grants) and does the search on its own document, driven by the parent
+ * over postMessage. It adds NO new capability and does NOT relax the sandbox.
+ *
+ * Protocol:
+ *   parent -> iframe: { source: FIND_CMD, action: "search"|"next"|"prev"|"clear",
+ *                       query, caseSensitive }
+ *   iframe -> parent: { source: FIND_RESULT, found, total, current }
+ *                     { source: FIND_OPEN }   // Ctrl/Cmd+F pressed inside iframe
+ *
+ * Security model:
+ *   The shim rejects any message whose e.source is not the parent window. This
+ *   prevents sandboxed content (which can call window.parent.postMessage) or a
+ *   third-party frame from faking find commands or injecting spurious results.
+ *   The guard is skipped when parent === window (top-level context, not an
+ *   iframe) so the shim stays fully functional in unit tests running in jsdom.
+ *
+ * Matching:
+ *   Matches are collected across the flat concatenated text of all visible text
+ *   nodes (cross-node matching). A MutationObserver marks the cache dirty on any
+ *   DOM change so dynamic HTML content is always re-indexed before the next
+ *   search.
+ */
+
+/** postMessage `source` tag for parent -> iframe commands. */
+export const FIND_CMD = "multica-find-cmd";
+/** postMessage `source` tag for iframe -> parent result updates. */
+export const FIND_RESULT = "multica-find-result";
+/** postMessage `source` tag for iframe -> parent "open the find bar" signal. */
+export const FIND_OPEN = "multica-find-open";
+
+const FIND_SHIM = `<script>
+(function(){
+  var CMD=${JSON.stringify(FIND_CMD)};
+  var RESULT=${JSON.stringify(FIND_RESULT)};
+  var OPEN=${JSON.stringify(FIND_OPEN)};
+
+  // matches[i] = { startNode, startOffset, endNode, endOffset }
+  // Built from a flat concatenation of all visible text nodes so matches can
+  // span inline element boundaries (e.g. "hello <b>world</b>").
+  var matches = [];
+  var idx = -1;
+  var lastQuery = null;
+  var lastCase = false;
+  // Set to true by MutationObserver when the DOM changes after a search.
+  var dirty = false;
+
+  // Invalidate the match cache whenever the document content changes so dynamic
+  // HTML (e.g. a <script> in the srcdoc that mutates the DOM) always produces
+  // an up-to-date result on the next search.
+  try {
+    var _mo = new MutationObserver(function(){ dirty = true; });
+    _mo.observe(document.documentElement || document.body, {
+      childList: true, subtree: true, characterData: true
+    });
+  } catch(_) {}
+
+  // Collect all visible text nodes into a flat string and a parallel node list
+  // so we can map flat character offsets back to (node, charOffset) pairs.
+  // Skips <script>/<style>/<noscript> — including this injected shim itself.
+  function buildFlatMap(){
+    var nodes = [], offsets = [], flat = "";
+    var root = document.body || document.documentElement;
+    if(!root) return { nodes: nodes, offsets: offsets, flat: flat };
+    var walker = document.createTreeWalker(root, NodeFilter.SHOW_TEXT, {
+      acceptNode: function(node){
+        var tag = node.parentNode && node.parentNode.nodeName;
+        if(tag === "SCRIPT" || tag === "STYLE" || tag === "NOSCRIPT") return NodeFilter.FILTER_REJECT;
+        return NodeFilter.FILTER_ACCEPT;
+      }
+    });
+    var node;
+    while((node = walker.nextNode())){
+      offsets.push(flat.length);
+      flat += node.nodeValue || "";
+      nodes.push(node);
+    }
+    return { nodes: nodes, offsets: offsets, flat: flat };
+  }
+
+  // First index i in sorted arr where arr[i] > val (binary search).
+  function upperBound(arr, val){
+    var lo = 0, hi = arr.length;
+    while(lo < hi){ var mid = (lo + hi) >> 1; if(arr[mid] <= val) lo = mid + 1; else hi = mid; }
+    return lo;
+  }
+
+  function collect(query, caseSensitive){
+    matches = [];
+    lastQuery = query;
+    lastCase = caseSensitive;
+    dirty = false;
+    if(!query) return;
+    var map = buildFlatMap();
+    if(!map.nodes.length) return;
+    var needle = caseSensitive ? query : query.toLowerCase();
+    var hay = caseSensitive ? map.flat : map.flat.toLowerCase();
+    var i = 0;
+    while((i = hay.indexOf(needle, i)) !== -1){
+      var end = i + needle.length;
+      var sni = upperBound(map.offsets, i) - 1;
+      var eni = upperBound(map.offsets, end - 1) - 1;
+      matches.push({
+        startNode: map.nodes[sni], startOffset: i - map.offsets[sni],
+        endNode:   map.nodes[eni], endOffset:   end - map.offsets[eni]
+      });
+      i = end;
+    }
+  }
+
+  function clearSelection(){
+    var s = window.getSelection && window.getSelection();
+    if(s && s.removeAllRanges){ try { s.removeAllRanges(); } catch(_){} }
+  }
+
+  function highlightCurrent(){
+    clearSelection();
+    if(idx < 0 || idx >= matches.length) return;
+    var m = matches[idx];
+    try {
+      var range = document.createRange();
+      range.setStart(m.startNode, m.startOffset);
+      range.setEnd(m.endNode, m.endOffset);
+      var sel = window.getSelection && window.getSelection();
+      if(sel && sel.addRange) sel.addRange(range);
+      var el = m.startNode.parentElement ||
+        (m.startNode.parentNode && m.startNode.parentNode.nodeType === 1 ? m.startNode.parentNode : null);
+      if(el && el.scrollIntoView) el.scrollIntoView({ block: "center", inline: "nearest" });
+    } catch(_){}
+  }
+
+  function post(){
+    try {
+      parent.postMessage({
+        source: RESULT,
+        found: idx >= 0,
+        total: matches.length,
+        current: idx >= 0 ? idx + 1 : 0
+      }, "*");
+    } catch(_){}
+  }
+
+  // Rebuild only when query/case changed or the DOM was mutated.
+  function ensure(query, caseSensitive){
+    if(!dirty && query === lastQuery && caseSensitive === lastCase) return false;
+    collect(query, caseSensitive);
+    idx = matches.length ? 0 : -1;
+    return true;
+  }
+
+  function doSearch(query, caseSensitive){
+    ensure(query, caseSensitive);
+    idx = matches.length ? 0 : -1;
+    highlightCurrent();
+    post();
+  }
+
+  function step(query, caseSensitive, backwards){
+    var rebuilt = ensure(query, caseSensitive);
+    if(!matches.length){ idx = -1; post(); return; }
+    if(!rebuilt){
+      idx = backwards
+        ? (idx <= 0 ? matches.length - 1 : idx - 1)
+        : (idx >= matches.length - 1 ? 0 : idx + 1);
+    }
+    highlightCurrent();
+    post();
+  }
+
+  window.addEventListener("message", function(e){
+    // Only accept commands from the hosting parent window. This prevents
+    // sandboxed content or a third-party frame from injecting find commands.
+    // Skip the check in a top-level context (parent === window) where there is
+    // no meaningful "parent" to verify against — this keeps the shim testable
+    // in jsdom without relaxing the guard in real browser iframe use.
+    if(parent !== window && e.source !== parent) return;
+    var d = e && e.data;
+    if(!d || d.source !== CMD) return;
+    if(d.action === "search") doSearch(d.query || "", !!d.caseSensitive);
+    else if(d.action === "next") step(d.query || "", !!d.caseSensitive, false);
+    else if(d.action === "prev") step(d.query || "", !!d.caseSensitive, true);
+    else if(d.action === "clear"){
+      matches = []; idx = -1; lastQuery = null; dirty = false; clearSelection();
+    }
+  });
+
+  window.addEventListener("keydown", function(e){
+    if((e.ctrlKey || e.metaKey) && (e.key === "f" || e.key === "F")){
+      e.preventDefault();
+      try { parent.postMessage({ source: OPEN }, "*"); } catch(_){}
+    }
+  });
+})();
+</script>`;
+
+/**
+ * Appends the find shim to an HTML document string destined for a sandboxed
+ * srcdoc iframe. Compose with withFragmentNavShim, e.g.
+ * `withFindShim(withFragmentNavShim(text))`.
+ */
+export function withFindShim(html: string | undefined): string {
+  return (html ?? "") + FIND_SHIM;
+}
+
+/** Exposed for unit tests so they can assert the shim was appended verbatim. */
+export const __IFRAME_FIND_SHIM__ = FIND_SHIM;

--- a/packages/views/locales/en/editor.json
+++ b/packages/views/locales/en/editor.json
@@ -45,6 +45,12 @@
     "preview_unsupported": "This file type can't be previewed.",
     "close": "Close",
     "open_in_new_tab": "Open in new tab",
+    "find_placeholder": "Find in page",
+    "find_count": "{{current}}/{{total}}",
+    "find_no_results": "No results",
+    "find_prev": "Previous match",
+    "find_next": "Next match",
+    "find_close": "Close find",
     "remove": "Remove attachment"
   },
   "link_hover": {

--- a/packages/views/locales/en/editor.json
+++ b/packages/views/locales/en/editor.json
@@ -61,6 +61,12 @@
     "preview_unsupported": "This file type can't be previewed.",
     "close": "Close",
     "open_in_new_tab": "Open in new tab",
+    "find_placeholder": "Find in page",
+    "find_count": "{{current}}/{{total}}",
+    "find_no_results": "No results",
+    "find_prev": "Previous match",
+    "find_next": "Next match",
+    "find_close": "Close find",
     "remove": "Remove attachment"
   },
   "link_hover": {

--- a/packages/views/locales/ja/editor.json
+++ b/packages/views/locales/ja/editor.json
@@ -45,6 +45,12 @@
     "preview_unsupported": "このファイル形式はプレビューできません。",
     "close": "閉じる",
     "open_in_new_tab": "新しいタブで開く",
+    "find_placeholder": "ページ内を検索",
+    "find_count": "{{current}}/{{total}}",
+    "find_no_results": "結果なし",
+    "find_prev": "前の一致",
+    "find_next": "次の一致",
+    "find_close": "検索を閉じる",
     "remove": "添付ファイルを削除"
   },
   "link_hover": {

--- a/packages/views/locales/ja/editor.json
+++ b/packages/views/locales/ja/editor.json
@@ -61,6 +61,12 @@
     "preview_unsupported": "このファイル形式はプレビューできません。",
     "close": "閉じる",
     "open_in_new_tab": "新しいタブで開く",
+    "find_placeholder": "ページ内を検索",
+    "find_count": "{{current}}/{{total}}",
+    "find_no_results": "結果なし",
+    "find_prev": "前の一致",
+    "find_next": "次の一致",
+    "find_close": "検索を閉じる",
     "remove": "添付ファイルを削除"
   },
   "link_hover": {

--- a/packages/views/locales/ko/editor.json
+++ b/packages/views/locales/ko/editor.json
@@ -45,6 +45,12 @@
     "preview_unsupported": "이 파일 형식은 미리보기를 지원하지 않습니다.",
     "close": "닫기",
     "open_in_new_tab": "새 탭에서 열기",
+    "find_placeholder": "페이지에서 찾기",
+    "find_count": "{{current}}/{{total}}",
+    "find_no_results": "결과 없음",
+    "find_prev": "이전 일치",
+    "find_next": "다음 일치",
+    "find_close": "찾기 닫기",
     "remove": "첨부 파일 제거"
   },
   "link_hover": {

--- a/packages/views/locales/ko/editor.json
+++ b/packages/views/locales/ko/editor.json
@@ -61,6 +61,12 @@
     "preview_unsupported": "이 파일 형식은 미리보기를 지원하지 않습니다.",
     "close": "닫기",
     "open_in_new_tab": "새 탭에서 열기",
+    "find_placeholder": "페이지에서 찾기",
+    "find_count": "{{current}}/{{total}}",
+    "find_no_results": "결과 없음",
+    "find_prev": "이전 일치",
+    "find_next": "다음 일치",
+    "find_close": "찾기 닫기",
     "remove": "첨부 파일 제거"
   },
   "link_hover": {

--- a/packages/views/locales/zh-Hans/editor.json
+++ b/packages/views/locales/zh-Hans/editor.json
@@ -45,6 +45,12 @@
     "preview_unsupported": "该文件类型暂不支持预览。",
     "close": "关闭",
     "open_in_new_tab": "在新标签页打开",
+    "find_placeholder": "在页面中查找",
+    "find_count": "{{current}}/{{total}}",
+    "find_no_results": "无结果",
+    "find_prev": "上一个匹配",
+    "find_next": "下一个匹配",
+    "find_close": "关闭查找",
     "remove": "移除附件"
   },
   "link_hover": {

--- a/packages/views/locales/zh-Hans/editor.json
+++ b/packages/views/locales/zh-Hans/editor.json
@@ -61,6 +61,12 @@
     "preview_unsupported": "该文件类型暂不支持预览。",
     "close": "关闭",
     "open_in_new_tab": "在新标签页打开",
+    "find_placeholder": "在页面中查找",
+    "find_count": "{{current}}/{{total}}",
+    "find_no_results": "无结果",
+    "find_prev": "上一个匹配",
+    "find_next": "下一个匹配",
+    "find_close": "关闭查找",
     "remove": "移除附件"
   },
   "link_hover": {


### PR DESCRIPTION
Fixes #5259

### Problem

The full-page HTML attachment preview renders inside a `sandbox="allow-scripts"` (opaque-origin) iframe — deliberately, to isolate untrusted uploads. The browser's native Ctrl+F / Cmd+F cannot search into an opaque-origin iframe, so maximizing a large HTML document leaves no way to search it.

### Fix

Mirror the existing `withFragmentNavShim` pattern (`packages/views/editor/utils/iframe-fragment-nav.ts`): inject a find shim into the srcdoc that runs in the iframe's own origin, driven by an in-app find bar in the parent over `postMessage`.

- shim collects matches as Selection `Range`s via a `TreeWalker`, selects + scrolls them, and reports `current`/`total`;
- deliberately avoids `window.find()` — it operates on the *focused* window and returns `false` inside the unfocused sandbox iframe; the Range approach is focus-independent and standard;
- skips `<script>`/`<style>` text when counting so the injected shim's own script doesn't inflate the count;
- **no change to the sandbox / security posture** (`allow-scripts`, never `allow-same-origin`).

Desktop (Electron) reuses the same `packages/views` component and benefits automatically.

### Tests

- unit tests for the shim (count, script/style exclusion, wrap, Ctrl+F) and the find bar;
- a page test for Ctrl+F/ESC that also asserts the sandbox attr is preserved;
- `pnpm --filter @multica/views exec vitest run editor/ attachments/` → all green; typecheck + eslint clean;
- verified end-to-end in the running app (Playwright): upload an HTML attachment → open the maximized preview → Ctrl+F → find bar shows `1/8`, Enter → `2/8`, first match highlighted.