### PR TITLE
fix(redact): cover credential formats that leaked unredacted

### DIFF
--- a/server/pkg/redact/redact.go
+++ b/server/pkg/redact/redact.go
@@ -26,17 +26,39 @@ var patterns = []secretPattern{
 	// PEM private keys (multi-line)
 	{regexp.MustCompile(`(?s)-----BEGIN[A-Z\s]*PRIVATE KEY-----.*?-----END[A-Z\s]*PRIVATE KEY-----`), "[REDACTED PRIVATE KEY]"},
 
-	// GitHub tokens (classic PAT, fine-grained, OAuth, etc.)
+	// GitHub tokens (classic PAT, OAuth, user-to-server, server-to-server, refresh)
 	{regexp.MustCompile(`\b(ghp|gho|ghu|ghs|ghr)_[A-Za-z0-9_]{36,255}\b`), "[REDACTED GITHUB TOKEN]"},
+
+	// GitHub fine-grained personal access tokens use the github_pat_ prefix,
+	// which the classic ghp_/gho_/... pattern above does not cover. Without
+	// this line a fine-grained PAT emitted in agent output leaks unredacted
+	// to the database and WebSocket broadcast.
+	{regexp.MustCompile(`\bgithub_pat_[A-Za-z0-9_]{20,255}\b`), "[REDACTED GITHUB TOKEN]"},
 
 	// OpenAI / Anthropic API keys
 	{regexp.MustCompile(`\bsk-[A-Za-z0-9_-]{20,}\b`), "[REDACTED API KEY]"},
 
-	// Slack tokens
-	{regexp.MustCompile(`\bxox[bporas]-[A-Za-z0-9\-]{10,}\b`), "[REDACTED SLACK TOKEN]"},
+	// Slack bot/user/legacy tokens. The char class includes 'e' so the
+	// newer xoxe- config/refresh tokens are covered alongside xoxb/p/o/r/a/s.
+	{regexp.MustCompile(`\bxox[bporase]-[A-Za-z0-9\-]{10,}\b`), "[REDACTED SLACK TOKEN]"},
+
+	// Slack app-level tokens use the xapp- prefix, which the xox*- rule above
+	// does not match. Without this an app-level token echoed in agent output
+	// leaks unredacted to the DB / WebSocket broadcast.
+	{regexp.MustCompile(`\bxapp-[A-Za-z0-9-]{10,}\b`), "[REDACTED SLACK TOKEN]"},
 
 	// GitLab personal access tokens
 	{regexp.MustCompile(`\bglpat-[A-Za-z0-9_-]{20,}\b`), "[REDACTED GITLAB TOKEN]"},
+
+	// Google API keys always start with the AIza prefix and are 39 chars total
+	// (AIza + 35). Not covered by any rule above, so they would otherwise leak.
+	{regexp.MustCompile(`\bAIza[0-9A-Za-z_\-]{35}\b`), "[REDACTED GOOGLE API KEY]"},
+
+	// Stripe secret / restricted live keys (sk_live_ / rk_live_). The sk-
+	// rule above only matches the hyphen form used by OpenAI/Anthropic; Stripe
+	// uses an underscore, so live keys are not covered without this. Publishable
+	// keys (pk_live_) are intentionally excluded — they are not secret.
+	{regexp.MustCompile(`\b(?:sk|rk)_live_[0-9A-Za-z]{16,}\b`), "[REDACTED STRIPE KEY]"},
 
 	// JWT tokens (three base64url segments)
 	{regexp.MustCompile(`\bey[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\b`), "[REDACTED JWT]"},

--- a/server/pkg/redact/redact_test.go
+++ b/server/pkg/redact/redact_test.go
@@ -47,6 +47,29 @@ func TestRedactGitHubToken(t *testing.T) {
 	}
 }
 
+// asm joins fragments into a credential-shaped test fixture. The token is kept
+// split across fragments so the full value never appears as a contiguous
+// literal in source — otherwise secret scanners (including GitHub push
+// protection) flag these redaction-test fixtures as real credentials. The
+// runtime string is identical, so the patterns are exercised exactly the same.
+func asm(parts ...string) string { return strings.Join(parts, "") }
+
+// TestRedactGitHubFineGrainedToken guards the github_pat_ prefix used by
+// GitHub fine-grained personal access tokens. The classic-token pattern only
+// covers ghp_/gho_/ghu_/ghs_/ghr_, so before the dedicated pattern was added a
+// fine-grained PAT reached the DB / WS broadcast unredacted.
+func TestRedactGitHubFineGrainedToken(t *testing.T) {
+	t.Parallel()
+	input := "cloning with token " + asm("github_", "pat_", "11ABCDE0Q0abcdefghijkl_MNOPQRSTUVWXYZ0123456789abcdefghijklmnopqrstuvwxyzABCD")
+	got := Text(input)
+	if strings.Contains(got, asm("github_", "pat_", "11ABCDE0Q0")) {
+		t.Fatalf("fine-grained GitHub PAT not redacted: %s", got)
+	}
+	if !strings.Contains(got, "[REDACTED GITHUB TOKEN]") {
+		t.Fatalf("expected [REDACTED GITHUB TOKEN] placeholder, got: %s", got)
+	}
+}
+
 func TestRedactOpenAIKey(t *testing.T) {
 	t.Parallel()
 	input := "OPENAI_API_KEY=sk-proj-abc123def456ghi789jkl012mno345"
@@ -62,6 +85,55 @@ func TestRedactSlackToken(t *testing.T) {
 	got := Text(input)
 	if strings.Contains(got, "xoxb-") {
 		t.Fatalf("Slack token not redacted: %s", got)
+	}
+}
+
+// TestRedactSlackAppAndConfigTokens guards the xapp- (app-level) and xoxe-
+// (config/refresh) prefixes that the original xox[bporas]- rule did not cover.
+func TestRedactSlackAppAndConfigTokens(t *testing.T) {
+	t.Parallel()
+	for _, tc := range []struct{ name, in, leak string }{
+		{"app-level xapp-", "connecting with " + asm("xa", "pp-1-A0000000000-1111111111-abcdefdeadbeefcafe") + " now", asm("xa", "pp-1-A0000000000")},
+		{"config xoxe-", "refresh with " + asm("xo", "xe-1-My0abcdefghijklmnopqrstuvwx") + " now", asm("xo", "xe-1-My0abcdef")},
+	} {
+		got := Text(tc.in)
+		if strings.Contains(got, tc.leak) {
+			t.Fatalf("%s not redacted: %s", tc.name, got)
+		}
+		if !strings.Contains(got, "[REDACTED SLACK TOKEN]") {
+			t.Fatalf("%s: expected [REDACTED SLACK TOKEN], got: %s", tc.name, got)
+		}
+	}
+}
+
+// TestRedactGoogleAPIKey guards the AIza-prefixed Google API key format, which
+// no prior pattern covered.
+func TestRedactGoogleAPIKey(t *testing.T) {
+	t.Parallel()
+	input := "calling gemini with " + asm("AIza", "SyD1234567890abcdefghijklmnopqrstuv") + " now"
+	got := Text(input)
+	if strings.Contains(got, asm("AIza", "SyD1234567890")) {
+		t.Fatalf("Google API key not redacted: %s", got)
+	}
+	if !strings.Contains(got, "[REDACTED GOOGLE API KEY]") {
+		t.Fatalf("expected [REDACTED GOOGLE API KEY], got: %s", got)
+	}
+}
+
+// TestRedactStripeLiveKey guards Stripe secret/restricted live keys, which use
+// an underscore (sk_live_) and so are missed by the hyphen-form sk- rule.
+// Publishable keys (pk_live_) are intentionally NOT redacted — they are public.
+func TestRedactStripeLiveKey(t *testing.T) {
+	t.Parallel()
+	if got := Text("STRIPE_SECRET_KEY=" + asm("sk_", "live_", "51Abcdef0000000000000000")); strings.Contains(got, asm("sk_", "live_51Abcdef")) {
+		t.Fatalf("Stripe live key not redacted: %s", got)
+	}
+	if got := Text("restricted " + asm("rk_", "live_", "51Abcdef0000000000000000")); !strings.Contains(got, "[REDACTED STRIPE KEY]") {
+		t.Fatalf("Stripe restricted key not redacted: %s", got)
+	}
+	// Publishable keys are public and must survive untouched.
+	if got := Text(asm("pk_", "live_", "51Abcdef0000000000000000")); !strings.Contains(got, asm("pk_", "live_51Abcdef")) {
+		t.Fatalf("publishable key should NOT be redacted: %s", got)
 	}
 }
 


### PR DESCRIPTION
Fixes #5270

### Problem

`redact.Text()` scrubs secrets from agent output before it reaches the database and the WebSocket broadcast, but several common formats slip through and leak verbatim:

| Credential | Prefix | Why it leaked |
|---|---|---|
| GitHub fine-grained PAT | `github_pat_` | the classic rule only matches `ghp_/gho_/…`; its comment even claims to cover fine-grained tokens |
| Slack app-level token | `xapp-` | the `xox[bporas]-` rule doesn't match it |
| Slack config/refresh token | `xoxe-` | `e` missing from the char class |
| Google API key | `AIza…` | no rule |
| Stripe live secret/restricted key | `sk_live_` / `rk_live_` | the `sk-` rule is the hyphen form; Stripe uses `_` |

### Fix

Add dedicated patterns for each (and `e` to the Slack char class for `xoxe-`). Stripe **publishable** keys (`pk_live_`) are intentionally **not** redacted — they're public.

### Tests

Regression tests for every new shape, plus a positive test that `pk_live_` stays unredacted. `go test ./pkg/redact/` passes. (Test fixtures are assembled from fragments so the fake tokens don't trip secret scanners.)