### PR TITLE
fix(agents): pin capability/settings sub-nav while content scrolls (MUL-4426)

### DIFF
--- a/packages/views/agents/components/agent-overview-pane.tsx
+++ b/packages/views/agents/components/agent-overview-pane.tsx
@@ -297,6 +297,7 @@ export function AgentOverviewPane({
   const activeSecondaryTab = secondaryTabs.find(
     (tab) => tab.id === effectiveView,
   );
+  const isSecondaryLayout = secondaryTabs.length > 0 && activeSecondaryTab != null;
 
   return (
     <div className="flex min-h-0 flex-1 flex-col bg-background">
@@ -326,7 +327,15 @@ export function AgentOverviewPane({
         </div>
       </div>
 
-      <div className="min-h-0 flex-1 overflow-y-auto">
+      {/* Overview/Work scroll as one page. Sidebar views split scrolling on
+          md+ (nav rail pinned, content pane scrolls) like settings-page.tsx;
+          below md the rail is a horizontal strip and the page scrolls whole. */}
+      <div
+        className={cn(
+          "min-h-0 flex-1 overflow-y-auto",
+          isSecondaryLayout && "md:overflow-hidden",
+        )}
+      >
         {effectiveView === "overview" && (
           <div className="mx-auto max-w-[1440px] p-4 sm:p-6">
             <div className="grid gap-6 xl:grid-cols-[minmax(0,1fr)_320px]">
@@ -347,8 +356,8 @@ export function AgentOverviewPane({
         )}
 
         {secondaryTabs.length > 0 && activeSecondaryTab && (
-          <div className="flex min-h-full flex-col md:flex-row">
-            <aside className="shrink-0 overflow-x-auto border-b border-surface-border bg-app-shell/70 p-2 md:w-52 md:overflow-x-visible md:border-b-0 md:border-r md:p-4">
+          <div className="flex min-h-full flex-col md:h-full md:flex-row">
+            <aside className="shrink-0 overflow-x-auto border-b border-surface-border bg-app-shell/70 p-2 md:w-52 md:overflow-y-auto md:border-b-0 md:border-r md:p-4">
               <div
                 className="flex w-max min-w-full items-center gap-1 md:w-full md:flex-col md:items-stretch"
                 role="tablist"
@@ -378,7 +387,7 @@ export function AgentOverviewPane({
               </div>
             </aside>
 
-            <section className="min-w-0 flex-1">
+            <section className="min-w-0 flex-1 md:overflow-y-auto">
               <div className="mx-auto w-full max-w-3xl p-4 sm:p-6 md:p-8">
                 <header>
                   <h2 className="text-base font-medium text-balance">


### PR DESCRIPTION
Fixes MUL-4426.

## Problem

On the agent detail page, the Capabilities tab (Instructions / Skills / MCP / MCP Apps / Integrations) and the Settings tab (General / Access / Environment / Custom Args / Runtime Config) wrap both the left sub-nav rail and the content pane in a single scroll container, so scrolling the content drags the rail out of view.

## Fix

`agent-overview-pane.tsx` now follows the split-scroll pattern already used by `settings-page.tsx`, `skill-detail-page.tsx`, and `squad-detail-page.tsx`:

- **md+**: the outer container becomes `overflow-hidden` while a sidebar view is active; the rail and the content pane each scroll themselves. The rail stays pinned and keeps its full-height border.
- **below md**: unchanged — the rail is a horizontal strip and the page scrolls as one, matching workspace settings.
- **Overview / Work** views keep whole-page scrolling (the `md:overflow-hidden` is conditional on a sidebar view being active).

## Audit of similar pages

- `settings-page.tsx`, `skill-detail-page.tsx`, `squad-detail-page.tsx`, `autopilot-dialog.tsx` — already split scrolling correctly.
- `runtime-detail.tsx` — single scroll container is intentional (right rail is content cards, not navigation; documented in-code).

## Verification

- `pnpm --filter @multica/views exec vitest run agents/components/agent-overview-pane.test.tsx` — 14/14 pass
- `pnpm --filter @multica/views typecheck` — clean
- Playwright against a local stack (1280×620 and 480×700):
  - Capabilities→Skills and Settings→General: content pane scrolls, outer container stays at 0, rail pinned (tab y unchanged), rail spans full pane height
  - Overview: still scrolls as one page
  - Mobile: whole page scrolls, strip scrolls away (pre-existing behavior preserved)
