### PR TITLE
fix: harden project route renderers against missing names

### DIFF
--- a/packages/views/issues/components/issues-header.tsx
+++ b/packages/views/issues/components/issues-header.tsx
@@ -207,15 +207,18 @@ function ActorSubContent({
   const { data: agents = [] } = useQuery(agentListOptions(wsId));
   const { data: squads = [] } = useQuery(squadListOptions(wsId));
   const query = search.trim().toLowerCase();
-  const filteredMembers = members.filter((m) =>
-    m.name.toLowerCase().includes(query) || matchesPinyin(m.name, query),
-  );
-  const filteredAgents = agents.filter((a) =>
-    !a.archived_at && (a.name.toLowerCase().includes(query) || matchesPinyin(a.name, query)),
-  );
-  const filteredSquads = squads.filter((s) =>
-    !s.archived_at && (s.name.toLowerCase().includes(query) || matchesPinyin(s.name, query)),
-  );
+  const filteredMembers = members.filter((m) => {
+    const name = m.name ?? "";
+    return name.toLowerCase().includes(query) || matchesPinyin(name, query);
+  });
+  const filteredAgents = agents.filter((a) => {
+    const name = a.name ?? "";
+    return !a.archived_at && (name.toLowerCase().includes(query) || matchesPinyin(name, query));
+  });
+  const filteredSquads = squads.filter((s) => {
+    const name = s.name ?? "";
+    return !s.archived_at && (name.toLowerCase().includes(query) || matchesPinyin(name, query));
+  });
 
   const isSelected = (type: "member" | "agent" | "squad", id: string) =>
     selected.some((f) => f.type === type && f.id === id);
@@ -374,7 +377,7 @@ function ProjectSubContent({
   const { data: projects = [] } = useQuery(projectListOptions(wsId));
   const query = search.trim().toLowerCase();
   const filtered = projects.filter((p) =>
-    p.title.toLowerCase().includes(query),
+    (p.title ?? "").toLowerCase().includes(query),
   );
 
   return (
@@ -458,7 +461,7 @@ function LabelSubContent({
   const wsId = useWorkspaceId();
   const { data: labels = [] } = useQuery(labelListOptions(wsId));
   const query = search.trim().toLowerCase();
-  const filtered = labels.filter((l) => l.name.toLowerCase().includes(query));
+  const filtered = labels.filter((l) => (l.name ?? "").toLowerCase().includes(query));
 
   return (
     <>

--- a/packages/views/projects/components/project-detail.tsx
+++ b/packages/views/projects/components/project-detail.tsx
@@ -195,8 +195,14 @@ export function ProjectDetail({ projectId }: { projectId: string }) {
   const [leadOpen, setLeadOpen] = useState(false);
   const [leadFilter, setLeadFilter] = useState("");
   const leadQuery = leadFilter.toLowerCase();
-  const filteredMembers = members.filter((m) => m.name.toLowerCase().includes(leadQuery) || matchesPinyin(m.name, leadQuery));
-  const filteredAgents = agents.filter((a) => !a.archived_at && (a.name.toLowerCase().includes(leadQuery) || matchesPinyin(a.name, leadQuery)));
+  const filteredMembers = members.filter((m) => {
+    const name = m.name ?? "";
+    return name.toLowerCase().includes(leadQuery) || matchesPinyin(name, leadQuery);
+  });
+  const filteredAgents = agents.filter((a) => {
+    const name = a.name ?? "";
+    return !a.archived_at && (name.toLowerCase().includes(leadQuery) || matchesPinyin(name, leadQuery));
+  });
 
   const handleUpdateField = useCallback(
     (data: Parameters<typeof updateProject.mutate>[0] extends { id: string } & infer R ? R : never) => {

--- a/packages/views/projects/components/project-resources-section.tsx
+++ b/packages/views/projects/components/project-resources-section.tsx
@@ -45,6 +45,13 @@ import {
 } from "../../platform";
 import { useT } from "../../i18n";
 
+type WorkspaceRepoLike = { url?: string | null } | string | null | undefined;
+
+function repoUrl(repo: WorkspaceRepoLike): string {
+  if (typeof repo === "string") return repo;
+  return repo?.url ?? "";
+}
+
 // Project Resources sidebar section.
 //
 // Type-dispatched at the row + add-flow level. Add a new resource_type by:
@@ -108,7 +115,7 @@ export function ProjectResourcesSection({ projectId }: { projectId: string }) {
 
   const repoQuery = repoSearch.trim().toLowerCase();
   const filteredRepos =
-    workspace?.repos?.filter((repo) => repo.url.toLowerCase().includes(repoQuery)) ?? [];
+    workspace?.repos?.filter((repo) => repoUrl(repo).toLowerCase().includes(repoQuery)) ?? [];
 
   const handleAttach = async (url: string) => {
     try {
@@ -305,19 +312,21 @@ export function ProjectResourcesSection({ projectId }: { projectId: string }) {
                       </p>
                     )}
                     {filteredRepos.map((repo) => {
-                      const isAttached = attachedUrls.has(repo.url);
+                      const url = repoUrl(repo);
+                      if (!url) return null;
+                      const isAttached = attachedUrls.has(url);
                       const isDisabled = isAttached || createResource.isPending;
                       return (
                         // Use aria-disabled instead of the native `disabled` attribute so
                         // hover events still reach the tooltip trigger on attached rows
                         // (browsers suppress pointer events on disabled form controls).
                         <button
-                          key={repo.url}
+                          key={url}
                           type="button"
                           aria-disabled={isDisabled}
                           onClick={async () => {
                             if (isDisabled) return;
-                            await handleAttach(repo.url);
+                            await handleAttach(url);
                             setAddOpen(false);
                           }}
                           className="flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-xs text-left hover:bg-accent transition-colors aria-disabled:opacity-50 aria-disabled:cursor-not-allowed aria-disabled:hover:bg-transparent"
@@ -326,10 +335,10 @@ export function ProjectResourcesSection({ projectId }: { projectId: string }) {
                           <Tooltip>
                             <TooltipTrigger
                               render={
-                                <span className="truncate flex-1">{repo.url}</span>
+                                <span className="truncate flex-1">{url}</span>
                               }
                             />
-                            <TooltipContent side="top">{repo.url}</TooltipContent>
+                            <TooltipContent side="top">{url}</TooltipContent>
                           </Tooltip>
                           {isAttached && (
                             <span className="text-[10px] text-muted-foreground">

--- a/packages/views/projects/components/projects-page.tsx
+++ b/packages/views/projects/components/projects-page.tsx
@@ -845,7 +845,8 @@ export function ProjectsPage() {
   const visible = useMemo(() => {
     const q = search.trim().toLowerCase();
     const filtered = projects.filter((p) => {
-      if (q && !p.title.toLowerCase().includes(q) && !matchesPinyin(p.title, q)) {
+      const title = p.title ?? "";
+      if (q && !title.toLowerCase().includes(q) && !matchesPinyin(title, q)) {
         return false;
       }
       if (filters.statuses.length && !filters.statuses.includes(p.status)) return false;

--- a/packages/views/search/search-command.tsx
+++ b/packages/views/search/search-command.tsx
@@ -97,11 +97,13 @@ function memberInitials(name: string) {
 }
 
 function matchesMember(member: MemberWithUser, query: string) {
+  const name = member.name ?? "";
+  const email = member.email ?? "";
   return (
-    member.name.toLowerCase().includes(query) ||
-    member.email.toLowerCase().includes(query) ||
+    name.toLowerCase().includes(query) ||
+    email.toLowerCase().includes(query) ||
     (query.length >= 3 && member.role.startsWith(query)) ||
-    matchesPinyin(member.name, query)
+    matchesPinyin(name, query)
   );
 }
 


### PR DESCRIPTION
## Summary
- Guard project/issue/search renderer filters against missing member, agent, squad, project, label, and email fields before calling `toLowerCase()` or pinyin matching.
- Handle workspace repo entries defensively in project resources so missing or string-form repo values do not crash the add-repo picker.

## Verification
- `pnpm typecheck`
- `pnpm lint` (passes with existing warnings only)

## Notes
- Extracted from the local AIA-1210 NEXUS fix and rebased onto current `origin/main` in a clean worktree.
- No unrelated dirty worktree changes included.
