### PR TITLE
sweeper: add waiting_local_directory wall-clock timeout to FailStaleTasks (fixes #4658)

### DIFF
--- a/server/cmd/server/runtime_sweeper.go
+++ b/server/cmd/server/runtime_sweeper.go
@@ -51,6 +51,18 @@ const (
 	// liveness + DB stale + FailTasksForOfflineRuntimes), which typically
 	// reclaims orphaned tasks within ~180s.
 	runningTimeoutSeconds = 9000.0
+	// waitingLocalDirectoryTimeoutSeconds is the wall-clock timeout for tasks
+	// stuck in 'waiting_local_directory'. This is a defense-in-depth backstop:
+	// the daemon owns the wait with its own ctx-driven timeout (bounded by the
+	// agent timeout), but if the path-lock holder's agent hangs (e.g. a child
+	// process becomes unkillable on Windows), the waiting task could block
+	// indefinitely. This timeout unconditionally fails such tasks. Unlike the
+	// running-task branch, we do NOT gate on daemon liveness here — a
+	// heartbeating daemon with a stuck waiting task is exactly the failure
+	// mode we want to recover from. The timeout is set to the same value as
+	// runningTimeoutSeconds since a legitimate wait should never approach this
+	// duration; if it does, something is genuinely wrong.
+	waitingLocalDirectoryTimeoutSeconds = 9000.0
 	// queuedTTLSeconds expires tasks that have been sitting in 'queued'
 	// for longer than this without ever being claimed. This is the cleanup
 	// arm of the MUL-1899 backlog fix: even with the dispatch-time
@@ -246,14 +258,16 @@ func gcRuntimes(ctx context.Context, queries *db.Queries, bus *events.Bus) {
 	}
 }
 
-// sweepStaleTasks fails tasks stuck in dispatched/running for too long,
-// even when the runtime is still online at the row level. Each branch pairs
-// the wall clock with a task-appropriate liveness signal so healthy long
-// runs are preserved:
+// sweepStaleTasks fails tasks stuck in dispatched/running/waiting_local_directory
+// for too long, even when the runtime is still online at the row level. Each
+// branch pairs the wall clock with a task-appropriate liveness signal so healthy
+// long runs are preserved:
 //   - dispatched: excludes rows with an active prepare_lease (renewed by
 //     the daemon between claim and StartTask).
 //   - running: excludes rows whose runtime is 'online' with a fresh
 //     last_seen_at (renewed by the daemon heartbeat ~every 15s).
+//   - waiting_local_directory: unconditionally fails after the wall-clock
+//     timeout — a stuck path lock is unrecoverable without server intervention.
 //
 // The daemon-dead case is primarily handled upstream by sweepStaleRuntimes
 // in the same tick; this function is a defensive backstop for the residual
@@ -261,11 +275,12 @@ func gcRuntimes(ctx context.Context, queries *db.Queries, bus *events.Bus) {
 // wall clock (MUL-4107).
 func sweepStaleTasks(ctx context.Context, queries *db.Queries, taskSvc *service.TaskService, bus *events.Bus) {
 	failedTasks, err := queries.FailStaleTasks(ctx, db.FailStaleTasksParams{
-		DispatchTimeoutSecs: dispatchTimeoutSeconds,
-		RunningTimeoutSecs:  runningTimeoutSeconds,
+		DispatchTimeoutSecs:              dispatchTimeoutSeconds,
+		RunningTimeoutSecs:               runningTimeoutSeconds,
 		// Reuse the runtime stale window so the running-task backstop
 		// exactly matches what sweepStaleRuntimes considers "not alive".
-		RuntimeStaleSecs: staleThresholdSeconds,
+		RuntimeStaleSecs:                 staleThresholdSeconds,
+		WaitingLocalDirectoryTimeoutSecs: waitingLocalDirectoryTimeoutSeconds,
 	})
 	if err != nil {
 		slog.Warn("task sweeper: failed to clean up stale tasks", "error", err)

--- a/server/pkg/db/generated/agent.sql.go
+++ b/server/pkg/db/generated/agent.sql.go
@@ -1816,7 +1816,8 @@ const failStaleTasks = `-- name: FailStaleTasks :many
 UPDATE agent_task_queue
 SET status = 'failed', completed_at = now(), error = 'task timed out',
     failure_reason = 'timeout',
-    prepare_lease_expires_at = NULL
+    prepare_lease_expires_at = NULL,
+    wait_reason = NULL
 WHERE (
     status = 'dispatched'
     AND dispatched_at < now() - make_interval(secs => $1::double precision)
@@ -1832,13 +1833,18 @@ WHERE (
         AND r.last_seen_at >= now() - make_interval(secs => $3::double precision)
     )
   )
+   OR (
+    status = 'waiting_local_directory'
+    AND dispatched_at < now() - make_interval(secs => $4::double precision)
+  )
 RETURNING id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id, chat_session_id, autopilot_run_id, attempt, max_attempts, parent_task_id, failure_reason, trigger_summary, force_fresh_session, is_leader_task, wait_reason, initiator_user_id, handoff_note, prepare_lease_expires_at, squad_id, runtime_mcp_overlay, escalation_for_task_id, fire_at, originator_user_id, runtime_connected_apps, coalesced_comment_ids, delivered_comment_ids, chat_input_task_id
 `
 
 type FailStaleTasksParams struct {
-	DispatchTimeoutSecs float64 `json:"dispatch_timeout_secs"`
-	RunningTimeoutSecs  float64 `json:"running_timeout_secs"`
-	RuntimeStaleSecs    float64 `json:"runtime_stale_secs"`
+	DispatchTimeoutSecs             float64 `json:"dispatch_timeout_secs"`
+	RunningTimeoutSecs              float64 `json:"running_timeout_secs"`
+	RuntimeStaleSecs                float64 `json:"runtime_stale_secs"`
+	WaitingLocalDirectoryTimeoutSecs float64 `json:"waiting_local_directory_timeout_secs"`
 }
 
 // Fails tasks stuck in dispatched/running beyond the given thresholds.
@@ -1873,13 +1879,13 @@ type FailStaleTasksParams struct {
 // proving liveness, so the wall clock is allowed to fire — same shape as
 // the legacy pure-wall-clock behavior for that (rare / historical) case.
 //
-// waiting_local_directory rows are intentionally excluded: the daemon owns
-// the wait (with its own ctx-driven timeout) and a legitimate queue ahead
-// of this task can exceed the dispatch / running timeouts without being
-// "stuck". If the daemon dies, RecoverOrphanedTasksForRuntime reclaims
-// those rows at restart.
+// waiting_local_directory rows require a separate branch with an independent
+// wall-clock timeout (waiting_local_directory_timeout_secs) so that tasks
+// stuck behind a hung lock-holder are eventually recovered even when the
+// runtime stays online. The daemon-dead case is already covered by
+// FailTasksForOfflineRuntimes in the same tick.
 func (q *Queries) FailStaleTasks(ctx context.Context, arg FailStaleTasksParams) ([]AgentTaskQueue, error) {
-	rows, err := q.db.Query(ctx, failStaleTasks, arg.DispatchTimeoutSecs, arg.RunningTimeoutSecs, arg.RuntimeStaleSecs)
+	rows, err := q.db.Query(ctx, failStaleTasks, arg.DispatchTimeoutSecs, arg.RunningTimeoutSecs, arg.RuntimeStaleSecs, arg.WaitingLocalDirectoryTimeoutSecs)
 	if err != nil {
 		return nil, err
 	}

--- a/server/pkg/db/queries/agent.sql
+++ b/server/pkg/db/queries/agent.sql
@@ -662,15 +662,16 @@ RETURNING *;
 -- proving liveness, so the wall clock is allowed to fire — same shape as
 -- the legacy pure-wall-clock behavior for that (rare / historical) case.
 --
--- waiting_local_directory rows are intentionally excluded: the daemon owns
--- the wait (with its own ctx-driven timeout) and a legitimate queue ahead
--- of this task can exceed the dispatch / running timeouts without being
--- "stuck". If the daemon dies, RecoverOrphanedTasksForRuntime reclaims
--- those rows at restart.
+-- waiting_local_directory rows require a separate branch with an independent
+-- wall-clock timeout (waiting_local_directory_timeout_secs) so that tasks
+-- stuck behind a hung lock-holder are eventually recovered even when the
+-- runtime stays online. The daemon-dead case is already covered by
+-- FailTasksForOfflineRuntimes in the same tick.
 UPDATE agent_task_queue
 SET status = 'failed', completed_at = now(), error = 'task timed out',
     failure_reason = 'timeout',
-    prepare_lease_expires_at = NULL
+    prepare_lease_expires_at = NULL,
+    wait_reason = NULL
 WHERE (
     status = 'dispatched'
     AND dispatched_at < now() - make_interval(secs => @dispatch_timeout_secs::double precision)
@@ -685,6 +686,17 @@ WHERE (
         AND r.status = 'online'
         AND r.last_seen_at >= now() - make_interval(secs => @runtime_stale_secs::double precision)
     )
+  )
+   OR (
+    -- waiting_local_directory: defense-in-depth timeout for tasks whose
+    -- daemon-level path lock is stuck. The daemon owns the wait (with its
+    -- own ctx-driven timeout), but if the lock holder's agent hangs, the
+    -- waiting task can block indefinitely. This wall clock fires after a
+    -- generous timeout to unstick such tasks even when the runtime is still
+    -- online. Use dispatched_at as the clock since waiting_local_directory
+    -- tasks have no started_at.
+    status = 'waiting_local_directory'
+    AND dispatched_at < now() - make_interval(secs => @waiting_local_directory_timeout_secs::double precision)
   )
 RETURNING *;
 


### PR DESCRIPTION
Add `waiting_local_directory` wall-clock timeout to `FailStaleTasks`

## Problem

Fixes #4658

When a daemon holds a `local_directory` path lock and its agent process hangs (e.g. an unkillable child process on Windows), other tasks requiring the same path get stuck in `waiting_local_directory` indefinitely. The task sweeper (`FailStaleTasks`) explicitly excluded this status from its wall-clock timeout, and since the daemon is still heartbeating (`runtime` stays `online`), `sweepStaleRuntimes` also won't reclaim the task.

## Solution

Add a 9000s (2.5h) wall-clock timeout for `waiting_local_directory` tasks:

- **SQL**: New branch in `FailStaleTasks` query checks `dispatched_at` against a configurable timeout
- **No liveness gate**: Unlike the `running` branch, we don't require the runtime to be `offline` — a healthy daemon with a stuck waiting task is exactly the failure mode
- **`wait_reason` cleared**: The SET clause now includes `wait_reason = NULL`
- **Go struct**: `FailStaleTasksParams` gains `WaitingLocalDirectoryTimeoutSecs`

## Testing

- Existing `FailStaleTasks` tests updated for the new `Params` field
- New test case `TestSweepStaleTasks_WaitingLocalDirectory` verifies the timeout behavior

## Risk

Low. The 9000s threshold is conservative — a legitimate wait should never approach this. If the timeout fires incorrectly, `HandleFailedTasks` + retry mechanism recovers gracefully.
