### PR TITLE
feat(views): unify reply and comment send buttons to the circular chat style

### DIFF
--- a/packages/ui/components/common/submit-button.tsx
+++ b/packages/ui/components/common/submit-button.tsx
@@ -3,7 +3,6 @@
 import type { ReactNode } from "react";
 import { ArrowUp, Loader2, Square } from "lucide-react";
 import { Button } from "@multica/ui/components/ui/button";
-import { cn } from "@multica/ui/lib/utils";
 import {
   Tooltip,
   TooltipContent,
@@ -16,12 +15,6 @@ interface SubmitButtonProps {
   loading?: boolean;
   running?: boolean;
   onStop?: () => void;
-  /**
-   * Button silhouette. `"rounded"` (default) keeps the rounded-square used by
-   * issue comment composers; `"circle"` makes it a fully-round pill — the
-   * Chat V2 look. Opt-in so shared callers keep their existing shape.
-   */
-  shape?: "rounded" | "circle";
   /**
    * Tooltip shown over the send button when idle. Pass a string or a node
    * (e.g. `Send · ⌘↵`). Omit to render no tooltip.
@@ -41,12 +34,10 @@ function SubmitButton({
   onStop,
   tooltip,
   stopTooltip,
-  shape = "rounded",
 }: SubmitButtonProps) {
-  const shapeClass = shape === "circle" ? "rounded-full" : undefined;
   if (running) {
     const stopButton = (
-      <Button size="icon-sm" className={cn(shapeClass)} onClick={onStop}>
+      <Button size="icon-sm" className="rounded-full" onClick={onStop}>
         <Square className="fill-current" />
       </Button>
     );
@@ -62,7 +53,7 @@ function SubmitButton({
   const submitButton = (
     <Button
       size="icon-sm"
-      className={cn(shapeClass)}
+      className="rounded-full"
       disabled={disabled || loading}
       onClick={onClick}
     >

--- a/packages/views/chat/components/chat-input.tsx
+++ b/packages/views/chat/components/chat-input.tsx
@@ -425,7 +425,6 @@ export function ChatInput({
         )}
         <div className="absolute bottom-1 right-1.5 flex items-center gap-1">
           <SubmitButton
-            shape="circle"
             onClick={handleSend}
             disabled={isEmpty || isSubmitting || !!disabled || !!noAgent || pendingUploads > 0}
             loading={isSubmitting}

--- a/packages/views/issues/components/reply-input.tsx
+++ b/packages/views/issues/components/reply-input.tsx
@@ -1,15 +1,15 @@
 "use client";
 
 import { useRef, useState, useCallback, useEffect } from "react";
-import { ArrowUp, Loader2 } from "lucide-react";
 import { ContentEditor, type ContentEditorRef, useFileDropZone, FileDropOverlay } from "../../editor";
 import { FileUploadButton } from "@multica/ui/components/common/file-upload-button";
-import { Button } from "@multica/ui/components/ui/button";
+import { SubmitButton } from "@multica/ui/components/common/submit-button";
 import { ActorAvatar } from "../../common/actor-avatar";
 import { useFileUpload } from "@multica/core/hooks/use-file-upload";
 import { api } from "@multica/core/api";
 import type { Attachment } from "@multica/core/types";
 import { contentReferencesAttachment } from "@multica/core/types";
+import { enterKey, formatShortcut, modKey } from "@multica/core/platform";
 import { useCommentDraftStore, type CommentDraftKey } from "@multica/core/issues/stores";
 import { cn } from "@multica/ui/lib/utils";
 import type { AvatarSize } from "@multica/ui/lib/avatar-size";
@@ -212,19 +212,12 @@ function ReplyInput({
             multiple
             onSelect={(file) => editorRef.current?.uploadFile(file)}
           />
-          <Button
-            type="button"
-            variant={isEmpty ? "ghost" : "default"}
-            size="icon-xs"
-            disabled={isEmpty || submitting}
+          <SubmitButton
             onClick={handleSubmit}
-          >
-            {submitting ? (
-              <Loader2 className="h-3.5 w-3.5 animate-spin" />
-            ) : (
-              <ArrowUp className="h-3.5 w-3.5" />
-            )}
-          </Button>
+            disabled={isEmpty}
+            loading={submitting}
+            tooltip={`${t(($) => $.comment.send_tooltip)} · ${formatShortcut(modKey, enterKey)}`}
+          />
         </div>
         {isDragOver && <FileDropOverlay />}
       </div>


### PR DESCRIPTION
## Summary

统一发送按钮：reply 和 comment 的发送按钮改为 chat 里的圆形样式（MUL-4433）。

- `SubmitButton` 现在始终为圆形（`rounded-full`），移除了 `shape` prop——所有调用方都用同一个形状，未来的调用方也不会再拿到方形默认值。
- `ReplyInput` 弃用内联的 `icon-xs` 方形 `Button`，改用共享的 `SubmitButton`——与评论输入框、chat 一致的尺寸（28px）、禁用态和发送 tooltip（`发送 · ⌘↵`）。
- `ChatInput` 只是去掉了已删除的 `shape="circle"` 传参，外观不变。

## Verification

- `tsc --noEmit`（ui + views）通过
- `@multica/views` 全量 vitest：175 files / 1793 tests 全部通过
- lint：改动文件 0 errors / 0 warnings
- 本地起了完整 dev 环境，实际截图确认 chat / comment / reply 三处按钮一致（截图见 MUL-4433 评论）

MUL-4433
