### PR TITLE
fix(settings): unify form control widths with SettingsRow size tiers

### DIFF
--- a/packages/views/agents/components/agent-detail-inspector.tsx
+++ b/packages/views/agents/components/agent-detail-inspector.tsx
@@ -125,7 +125,7 @@ export function AgentDetailInspector({
           <SettingsRow
             label={t(($) => $.inspector.avatar_label)}
             description={t(($) => $.inspector.avatar_hint)}
-            controlClassName="sm:max-w-none"
+            size="none"
           >
             <div className="flex justify-start sm:justify-end">
               <AvatarUploadControl
@@ -141,7 +141,7 @@ export function AgentDetailInspector({
 
           <SettingsRow
             label={t(($) => $.inspector.name_label)}
-            controlClassName="sm:w-80"
+            size="text"
           >
             <div>
               <Input
@@ -165,7 +165,7 @@ export function AgentDetailInspector({
 
           <SettingsRow
             label={t(($) => $.inspector.description_label)}
-            controlClassName="sm:w-96"
+            size="text"
             align="start"
           >
             <div>
@@ -191,7 +191,7 @@ export function AgentDetailInspector({
           <SettingsRow
             label={t(($) => $.inspector.labels_label)}
             description={t(($) => $.inspector.labels_hint)}
-            controlClassName="sm:w-96"
+            size="text"
             align="start"
           >
             <ResourceLabelPicker
@@ -210,7 +210,7 @@ export function AgentDetailInspector({
         <SettingsCard>
           <SettingsRow
             label={t(($) => $.inspector.prop_runtime)}
-            controlClassName="sm:w-80"
+            size="select-wide"
           >
             <RuntimePicker
               variant="field"
@@ -225,7 +225,7 @@ export function AgentDetailInspector({
           </SettingsRow>
           <SettingsRow
             label={t(($) => $.inspector.prop_model)}
-            controlClassName="sm:w-80"
+            size="select-wide"
           >
             <ModelPicker
               variant="field"
@@ -251,7 +251,7 @@ export function AgentDetailInspector({
           />
           <SettingsRow
             label={t(($) => $.inspector.prop_concurrency)}
-            controlClassName="sm:w-80"
+            size="select-wide"
           >
             <ConcurrencyField
               value={agent.max_concurrent_tasks}

--- a/packages/views/agents/components/inspector/thinking-prop-row.tsx
+++ b/packages/views/agents/components/inspector/thinking-prop-row.tsx
@@ -98,7 +98,7 @@ export function ThinkingSettingField({
   if (levels.length === 0 && !value) return null;
 
   return (
-    <SettingsRow label={label} controlClassName="sm:w-80">
+    <SettingsRow label={label} size="select-wide">
       <ThinkingPicker
         variant="field"
         showLabel={false}

--- a/packages/views/settings/components/account-tab.tsx
+++ b/packages/views/settings/components/account-tab.tsx
@@ -108,7 +108,7 @@ export function AccountTab() {
           <SettingsRow
             label={t(($) => $.account.avatar_label)}
             description={t(($) => $.account.click_avatar_hint)}
-            controlClassName="sm:max-w-none"
+            size="none"
           >
             <div className="flex justify-start sm:justify-end">
               <AvatarUploadControl
@@ -137,7 +137,7 @@ export function AccountTab() {
 
           <SettingsRow
             label={t(($) => $.account.name_label)}
-            controlClassName="sm:w-80"
+            size="text"
           >
             <Input
               type="text"
@@ -153,7 +153,7 @@ export function AccountTab() {
           <SettingsRow
             label={t(($) => $.account.profile_description_label)}
             description={t(($) => $.account.profile_description_hint)}
-            controlClassName="sm:w-96"
+            size="text"
             align="start"
           >
             <div>

--- a/packages/views/settings/components/preferences-tab.tsx
+++ b/packages/views/settings/components/preferences-tab.tsx
@@ -96,7 +96,7 @@ export function PreferencesTab() {
         <SettingsCard>
           <SettingsRow
             label={t(($) => $.preferences.theme.title)}
-            controlClassName="sm:w-48"
+            size="select"
           >
             <Select
               value={theme}
@@ -129,7 +129,7 @@ export function PreferencesTab() {
 
           <SettingsRow
             label={t(($) => $.preferences.language.title)}
-            controlClassName="sm:w-48"
+            size="select"
           >
             <Select
               value={currentLocale}
@@ -212,7 +212,7 @@ function TimezoneRow() {
     <SettingsRow
       label={t(($) => $.preferences.timezone.title)}
       description={t(($) => $.preferences.timezone.hint)}
-      controlClassName="sm:w-72"
+      size="select-wide"
     >
       <Select
         value={value}

--- a/packages/views/settings/components/settings-layout.tsx
+++ b/packages/views/settings/components/settings-layout.tsx
@@ -78,19 +78,42 @@ export function SettingsCard({
   );
 }
 
+/**
+ * Width tiers for the control column. Within a card, every text-entry
+ * control shares the `text` tier so their edges align; a row may only
+ * drop to a smaller tier when the field is deliberately short (a code,
+ * an enum select) — the difference must read as intentional. Pick a
+ * tier instead of adding per-row ad-hoc widths.
+ */
+const SETTINGS_CONTROL_WIDTHS = {
+  /** Text inputs and textareas — the standard control column. */
+  text: "sm:w-96",
+  /** Selects/pickers with long option labels (timezone, model). */
+  "select-wide": "sm:w-72",
+  /** Compact enum selects (theme, language). */
+  select: "sm:w-48",
+  /** Short fixed-format codes (issue prefix). */
+  code: "sm:w-40",
+  /** Unconstrained — non-input content like avatar uploads. */
+  none: "sm:max-w-none",
+} as const;
+
+export type SettingsControlSize = keyof typeof SETTINGS_CONTROL_WIDTHS;
+
 export function SettingsRow({
   label,
   description,
   children,
   className,
-  controlClassName,
+  size,
   align = "center",
 }: {
   label: ReactNode;
   description?: ReactNode;
   children: ReactNode;
   className?: string;
-  controlClassName?: string;
+  /** Control column width tier; omit for content-hugging controls (buttons, switches). */
+  size?: SettingsControlSize;
   align?: "center" | "start";
 }) {
   return (
@@ -112,7 +135,7 @@ export function SettingsRow({
       <div
         className={cn(
           "w-full shrink-0 sm:w-auto sm:max-w-[56%]",
-          controlClassName,
+          size ? SETTINGS_CONTROL_WIDTHS[size] : undefined,
         )}
       >
         {children}

--- a/packages/views/settings/components/workspace-tab.tsx
+++ b/packages/views/settings/components/workspace-tab.tsx
@@ -323,7 +323,7 @@ export function WorkspaceTab() {
           <SettingsRow
             label={t(($) => $.workspace.logo_label)}
             description={t(($) => $.workspace.click_logo_hint)}
-            controlClassName="sm:max-w-none"
+            size="none"
           >
             <div className="flex justify-start sm:justify-end">
               <AvatarUploadControl
@@ -360,7 +360,7 @@ export function WorkspaceTab() {
 
           <SettingsRow
             label={t(($) => $.workspace.name_label)}
-            controlClassName="sm:w-80"
+            size="text"
           >
             <Input
               type="text"
@@ -376,7 +376,7 @@ export function WorkspaceTab() {
 
           <SettingsRow
             label={t(($) => $.workspace.description_label)}
-            controlClassName="sm:w-96"
+            size="text"
             align="start"
           >
             <Textarea
@@ -395,7 +395,7 @@ export function WorkspaceTab() {
 
           <SettingsRow
             label={t(($) => $.workspace.context_label)}
-            controlClassName="sm:w-96"
+            size="text"
             align="start"
           >
             <Textarea
@@ -414,7 +414,7 @@ export function WorkspaceTab() {
 
           <SettingsRow
             label={t(($) => $.workspace.slug_label)}
-            controlClassName="sm:w-80"
+            size="text"
           >
               <div className="rounded-lg border border-input bg-muted/50 px-2.5 py-1.5 font-mono text-xs text-muted-foreground">
                 {workspace.slug}
@@ -426,7 +426,7 @@ export function WorkspaceTab() {
             description={t(($) => $.workspace.issue_prefix_hint, {
               example: `${normalizedPrefix || workspace.issue_prefix}-123`,
             })}
-            controlClassName="sm:w-40"
+            size="code"
           >
               <Input
                 type="text"


### PR DESCRIPTION
## Summary

Settings form controls had five ad-hoc width classes chosen per call site via `controlClassName`, producing an "almost aligned" zigzag on the General/Profile tabs: Name/Slug rendered at 320px while Description/Context rendered at ~375px (`sm:w-96` silently clamped by the row's `sm:max-w-[56%]`).

This PR replaces `controlClassName` with a tokenized `size` prop on `SettingsRow`:

| Tier | Class | Used for |
| --- | --- | --- |
| `text` | `sm:w-96` | Text inputs and textareas (standard control column) |
| `select-wide` | `sm:w-72` | Pickers with long labels (timezone, runtime, model) |
| `select` | `sm:w-48` | Compact enum selects (theme, language) |
| `code` | `sm:w-40` | Short fixed-format codes (issue prefix) |
| `none` | `sm:max-w-none` | Non-input content (avatar uploads) |

Visible change: on Settings → General, Name and Slug now share the `text` tier with Description/Context, so all text-entry controls in the card align on both edges; Issue prefix stays deliberately small. Same fix on Profile (Name vs About you) and the agent inspector. Rows without `size` (buttons, switches) keep hugging their content.

Design rationale and before/after screenshots: MUL-4428.

## Testing

- `pnpm typecheck` — 6/6 tasks pass
- `pnpm --filter @multica/views test` — 175 files, 1788 tests pass
- `pnpm --filter @multica/views lint` — 0 errors (16 pre-existing warnings in unrelated files)
- Verified in the running web app: before/after screenshots of Settings → General and Profile attached to MUL-4428
