### PR TITLE
fix(comments): clarify 409 for top-level comment from a comment-triggered task (MUL-4417)

### DIFF
--- a/server/cmd/multica/cmd_issue.go
+++ b/server/cmd/multica/cmd_issue.go
@@ -540,7 +540,7 @@ func init() {
 	issueCommentAddCmd.Flags().Bool("content-stdin", false, "Read comment content from stdin (preserves multi-line content verbatim)")
 	issueCommentAddCmd.Flags().String("content-file", "", "Read comment content from a UTF-8 file (preserves multi-line content verbatim; use this on Windows when stdin piping mangles non-ASCII bytes). The path must be inside the current working directory unless --allow-external-file is set.")
 	issueCommentAddCmd.Flags().Bool("allow-external-file", false, "Allow --content-file / --attachment to read a path outside the current working directory. Off by default so a stale file from another run/environment can't be picked up (MUL-4252).")
-	issueCommentAddCmd.Flags().String("parent", "", "Parent comment ID (reply to a specific comment)")
+	issueCommentAddCmd.Flags().String("parent", "", "Parent comment ID to reply under. A comment-triggered agent task must reply under its trigger comment; omitting --parent to post a top-level comment is rejected")
 	issueCommentAddCmd.Flags().StringSlice("attachment", nil, "File path(s) to attach (can be specified multiple times)")
 	issueCommentAddCmd.Flags().String("output", "json", "Output format: table or json")
 

--- a/server/internal/handler/comment.go
+++ b/server/internal/handler/comment.go
@@ -1265,13 +1265,9 @@ func (h *Handler) CreateComment(w http.ResponseWriter, r *http.Request) {
 				if err == nil && task.IssueID.Valid && uuidToString(task.IssueID) == uuidToString(issue.ID) {
 					if task.TriggerCommentID.Valid {
 						if !taskCoversReplyParent(task, parentID) {
-							// Spell out that a parentless top-level comment is the
-							// rejected case and give the exact fix, so an agent does
-							// not misread this 409 as the issue being locked and
-							// delete a good reply trying to "reset" it
-							// (MUL-4417 / GH #5266).
+							// Keep this error actionable for agents (MUL-4417 / GH #5266).
 							writeError(w, http.StatusConflict,
-								"this comment-triggered task must reply under its trigger comment; top-level comments are not allowed while it is active — set parent_id (--parent) to the trigger comment id "+uuidToString(task.TriggerCommentID)+", or to an earlier comment it coalesced")
+								"comment-triggered tasks cannot create top-level comments; set parent_id (--parent) to "+uuidToString(task.TriggerCommentID)+" or a coalesced comment id")
 							return
 						}
 					}

--- a/server/internal/handler/comment.go
+++ b/server/internal/handler/comment.go
@@ -1265,8 +1265,13 @@ func (h *Handler) CreateComment(w http.ResponseWriter, r *http.Request) {
 				if err == nil && task.IssueID.Valid && uuidToString(task.IssueID) == uuidToString(issue.ID) {
 					if task.TriggerCommentID.Valid {
 						if !taskCoversReplyParent(task, parentID) {
+							// Spell out that a parentless top-level comment is the
+							// rejected case and give the exact fix, so an agent does
+							// not misread this 409 as the issue being locked and
+							// delete a good reply trying to "reset" it
+							// (MUL-4417 / GH #5266).
 							writeError(w, http.StatusConflict,
-								"parent_id must be this task's trigger comment id ("+uuidToString(task.TriggerCommentID)+") or one of the earlier comments it coalesced")
+								"this comment-triggered task must reply under its trigger comment; top-level comments are not allowed while it is active — set parent_id (--parent) to the trigger comment id "+uuidToString(task.TriggerCommentID)+", or to an earlier comment it coalesced")
 							return
 						}
 					}

--- a/server/internal/handler/comment_reply_authz_handler_test.go
+++ b/server/internal/handler/comment_reply_authz_handler_test.go
@@ -1,0 +1,78 @@
+package handler
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// TestCreateComment_TriggeredTaskRejectsTopLevelComment exercises the full
+// CreateComment handler path (not just taskCoversReplyParent) for the trap
+// reported in MUL-4417 / GH #5266: a comment-triggered task that posts a
+// parentless, top-level comment on its own issue is rejected with a 409 whose
+// message names the trigger comment and states that top-level comments are not
+// allowed. Pinning the message here keeps it from silently drifting away from
+// the behavior the CLI help now documents.
+func TestCreateComment_TriggeredTaskRejectsTopLevelComment(t *testing.T) {
+	if testHandler == nil || testPool == nil {
+		t.Skip("database not available")
+	}
+
+	fx := newRunningSquadLeaderTaskFixture(t)
+
+	w := httptest.NewRecorder()
+	r := newRequest("POST", "/api/issues/"+fx.IssueID+"/comments", map[string]any{
+		"content": "dispatching a squad from this task",
+	})
+	r = withURLParam(r, "id", fx.IssueID)
+	r.Header.Set("X-Agent-ID", fx.LeaderID)
+	r.Header.Set("X-Task-ID", fx.TaskID)
+
+	testHandler.CreateComment(w, r)
+	if w.Code != http.StatusConflict {
+		t.Fatalf("CreateComment top-level: expected 409, got %d: %s", w.Code, w.Body.String())
+	}
+	if got := countAgentCommentsForIssue(t, fx.IssueID, fx.LeaderID); got != 0 {
+		t.Fatalf("expected rejected top-level comment not to be stored, got %d", got)
+	}
+
+	var body map[string]any
+	if err := json.NewDecoder(w.Body).Decode(&body); err != nil {
+		t.Fatalf("decode error response: %v", err)
+	}
+	msg, _ := body["error"].(string)
+	if !strings.Contains(msg, fx.TriggerCommentID) {
+		t.Fatalf("409 message should name the trigger comment %q, got %q", fx.TriggerCommentID, msg)
+	}
+	if !strings.Contains(msg, "top-level comments are not allowed") {
+		t.Fatalf("409 message should explain that top-level comments are not allowed, got %q", msg)
+	}
+}
+
+// TestCreateComment_TriggeredTaskAllowsReplyUnderTrigger is the positive half:
+// the same task replying under its trigger comment succeeds, proving the guard
+// rejects only the top-level case and does not lock the whole issue for
+// comments (MUL-4417 / GH #5266).
+func TestCreateComment_TriggeredTaskAllowsReplyUnderTrigger(t *testing.T) {
+	if testHandler == nil || testPool == nil {
+		t.Skip("database not available")
+	}
+
+	fx := newRunningSquadLeaderTaskFixture(t)
+
+	w := httptest.NewRecorder()
+	r := newRequest("POST", "/api/issues/"+fx.IssueID+"/comments", map[string]any{
+		"content":   "replying under the trigger comment",
+		"parent_id": fx.TriggerCommentID,
+	})
+	r = withURLParam(r, "id", fx.IssueID)
+	r.Header.Set("X-Agent-ID", fx.LeaderID)
+	r.Header.Set("X-Task-ID", fx.TaskID)
+
+	testHandler.CreateComment(w, r)
+	if w.Code != http.StatusCreated {
+		t.Fatalf("CreateComment reply-under-trigger: expected 201, got %d: %s", w.Code, w.Body.String())
+	}
+}

--- a/server/internal/handler/comment_reply_authz_handler_test.go
+++ b/server/internal/handler/comment_reply_authz_handler_test.go
@@ -43,11 +43,17 @@ func TestCreateComment_TriggeredTaskRejectsTopLevelComment(t *testing.T) {
 		t.Fatalf("decode error response: %v", err)
 	}
 	msg, _ := body["error"].(string)
-	if !strings.Contains(msg, fx.TriggerCommentID) {
-		t.Fatalf("409 message should name the trigger comment %q, got %q", fx.TriggerCommentID, msg)
-	}
-	if !strings.Contains(msg, "top-level comments are not allowed") {
-		t.Fatalf("409 message should explain that top-level comments are not allowed, got %q", msg)
+	// Pin the three semantic pieces without locking the exact wording: why it
+	// was rejected, the comment to reply under, and the actionable fix. The last
+	// one guards against the guidance being dropped in a future edit.
+	for _, want := range []string{
+		"top-level comments",   // reason
+		fx.TriggerCommentID,    // the comment to reply under
+		"parent_id (--parent)", // actionable fix
+	} {
+		if !strings.Contains(msg, want) {
+			t.Fatalf("409 message should contain %q, got %q", want, msg)
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary

A comment-triggered agent task that posts a **parentless (top-level)** comment on its own issue is rejected with `409 Conflict` by the anti-drift guard in `CreateComment`. The old error only named the required parent id — it never said that top-level comments are disallowed — so agents misread the 409 as the issue being locked and retried, or deleted a good reply trying to "reset" the state (delete is irreversible).

This keeps the guard intact (a comment-triggered task must reply under its trigger comment, which prevents resumed-session `--parent` drift), but makes the constraint self-explanatory instead of a trap:

- **Server** (`server/internal/handler/comment.go`): the 409 message now states that top-level comments are not allowed while the task is active and tells the caller exactly what to set `parent_id` (`--parent`) to.
- **CLI** (`server/cmd/multica/cmd_issue.go`): the `multica issue comment add --parent` help now documents that a comment-triggered task must reply under its trigger comment and that omitting `--parent` to post a top-level comment is rejected.
- **Tests** (`server/internal/handler/comment_reply_authz_handler_test.go`): new handler-level regression tests covering the full `CreateComment` path — the rejected top-level case (asserts 409 + the new message) and the allowed reply-under-trigger case (asserts 201) — so the message and behavior can't silently drift apart again.

No behavior change: the same requests succeed/fail as before; only the error contract and docs are clarified.

Confirmed workaround note: dispatching a squad from a triggered task works fine when written as a reply under the trigger comment — the mention still enqueues the squad leader identically — so no legitimate capability is lost by keeping the guard.

## How tested

- `go build` + `gofmt` + `go vet` clean.
- Ran against the test database (not skipped):
  - `TestCreateComment_TriggeredTaskRejectsTopLevelComment` — top-level comment from a triggered task → 409, asserts the clarified message.
  - `TestCreateComment_TriggeredTaskAllowsReplyUnderTrigger` — reply under the trigger comment → 201.
  - `TestTaskCoversReplyParent` — existing unit cases still pass.

Fixes #5266
