### PR TITLE
fix(settings): align read-only slug and flatten cards

### DIFF
--- a/packages/views/settings/components/settings-layout.tsx
+++ b/packages/views/settings/components/settings-layout.tsx
@@ -70,7 +70,7 @@ export function SettingsCard({
   className?: string;
 }) {
   return (
-    <Card className={cn("gap-0 py-0", className)}>
+    <Card className={cn("gap-0 py-0 shadow-none", className)}>
       <CardContent className="divide-y divide-surface-border px-0">
         {children}
       </CardContent>

--- a/packages/views/settings/components/workspace-tab.test.tsx
+++ b/packages/views/settings/components/workspace-tab.test.tsx
@@ -139,6 +139,14 @@ describe("WorkspaceTab — automatic updates", () => {
     expect(screen.queryByRole("button", { name: /^Save$/ })).toBeNull();
   });
 
+  it("renders the workspace slug in the shared read-only input control", () => {
+    render(<WorkspaceTab />, { wrapper: I18nWrapper });
+
+    const input = screen.getByRole("textbox", { name: "Slug" }) as HTMLInputElement;
+    expect(input.value).toBe("test-workspace");
+    expect(input.readOnly).toBe(true);
+  });
+
   it("uppercases and strips non-alphanumeric prefix input", async () => {
     const user = setupUser();
     render(<WorkspaceTab />, { wrapper: I18nWrapper });

--- a/packages/views/settings/components/workspace-tab.tsx
+++ b/packages/views/settings/components/workspace-tab.tsx
@@ -416,9 +416,16 @@ export function WorkspaceTab() {
             label={t(($) => $.workspace.slug_label)}
             size="text"
           >
-              <div className="rounded-lg border border-input bg-muted/50 px-2.5 py-1.5 font-mono text-xs text-muted-foreground">
-                {workspace.slug}
-              </div>
+            <Input
+              type="text"
+              name="workspace-slug"
+              autoComplete="off"
+              spellCheck={false}
+              aria-label={t(($) => $.workspace.slug_label)}
+              value={workspace.slug}
+              readOnly
+              className="bg-muted/50 font-mono text-muted-foreground dark:bg-muted/50"
+            />
           </SettingsRow>
 
           <SettingsRow


### PR DESCRIPTION
## Summary

- render the workspace slug with the shared read-only `Input` primitive
- remove the shadow from `SettingsCard` while keeping the global `Card` unchanged
- cover the slug's read-only textbox semantics with a focused component test

## Why

The workspace slug used a hand-rolled input-shaped `div`, which rendered at 30px with smaller typography next to the shared 32px `Input`. Settings cards also inherited the generic card shadow, adding visual weight to an already bordered and divided layout.

This aligns the read-only slug with editable form controls and makes settings sections visually flatter without changing cards elsewhere in the product.

Related to #5304.

## Validation

- `pnpm --filter @multica/views exec vitest run settings/components/workspace-tab.test.tsx`
- `pnpm --filter @multica/views typecheck`
- `pnpm --filter @multica/views exec eslint settings/components/settings-layout.tsx settings/components/workspace-tab.tsx settings/components/workspace-tab.test.tsx`
- `git diff --check`
