### PR TITLE
MUL-4393: return stage from issue list APIs

### DIFF
--- a/server/internal/handler/issue.go
+++ b/server/internal/handler/issue.go
@@ -1025,7 +1025,7 @@ func (h *Handler) ListIssues(w http.ResponseWriter, r *http.Request) {
 
 	query := fmt.Sprintf(`SELECT i.id, i.workspace_id, i.title, i.description, i.status, i.priority,
        i.assignee_type, i.assignee_id, i.creator_type, i.creator_id,
-       i.parent_issue_id, i.position, i.start_date, i.due_date, i.created_at, i.updated_at, i.number, i.project_id, i.metadata
+       i.parent_issue_id, i.position, i.start_date, i.due_date, i.created_at, i.updated_at, i.number, i.project_id, i.metadata, i.stage
 FROM issue i
 WHERE %s
 ORDER BY %s
@@ -1062,6 +1062,7 @@ LIMIT %s OFFSET %s`, whereSql, orderBy, limitRef, offsetRef)
 			&row.Number,
 			&row.ProjectID,
 			&row.Metadata,
+			&row.Stage,
 		); err != nil {
 			slog.Warn("ListIssues scan failed", "error", err)
 			writeError(w, http.StatusInternalServerError, "failed to list issues")
@@ -1521,8 +1522,8 @@ WITH ranked AS (
 	SELECT
 		i.id, i.workspace_id, i.title, i.description, i.status, i.priority,
 		i.assignee_type, i.assignee_id, i.creator_type, i.creator_id,
-		i.parent_issue_id, i.position, i.due_date, i.created_at, i.updated_at,
-		i.number, i.project_id, i.metadata,
+		i.parent_issue_id, i.position, i.start_date, i.due_date, i.created_at, i.updated_at,
+		i.number, i.project_id, i.metadata, i.stage,
 		COUNT(*) OVER (PARTITION BY i.assignee_type, i.assignee_id) AS group_total,
 		ROW_NUMBER() OVER (
 			PARTITION BY i.assignee_type, i.assignee_id
@@ -1534,8 +1535,8 @@ WITH ranked AS (
 SELECT
 	id, workspace_id, title, description, status, priority,
 	assignee_type, assignee_id, creator_type, creator_id,
-	parent_issue_id, position, due_date, created_at, updated_at,
-	number, project_id, metadata, group_total
+	parent_issue_id, position, start_date, due_date, created_at, updated_at,
+	number, project_id, metadata, stage, group_total
 FROM ranked
 WHERE rn > %s AND rn <= %s + %s
 ORDER BY
@@ -1573,12 +1574,14 @@ ORDER BY
 			&row.CreatorID,
 			&row.ParentIssueID,
 			&row.Position,
+			&row.StartDate,
 			&row.DueDate,
 			&row.CreatedAt,
 			&row.UpdatedAt,
 			&row.Number,
 			&row.ProjectID,
 			&row.Metadata,
+			&row.Stage,
 			&row.GroupTotal,
 		); err != nil {
 			slog.Warn("ListGroupedIssues scan failed", "error", err)

--- a/server/internal/handler/issue_grouped_test.go
+++ b/server/internal/handler/issue_grouped_test.go
@@ -48,7 +48,7 @@ func TestListGroupedIssuesAssigneePaginatesPerGroup(t *testing.T) {
 		_, _ = testPool.Exec(context.Background(), `DELETE FROM agent WHERE id = $1`, agentID)
 	})
 
-	createIssue := func(title, assigneeType, assigneeID string, position float64) string {
+	createIssue := func(title, assigneeType, assigneeID string, position float64, startDate *time.Time, stage *int32) string {
 		t.Helper()
 		var number int32
 		if err := testPool.QueryRow(ctx, `
@@ -68,11 +68,11 @@ func TestListGroupedIssuesAssigneePaginatesPerGroup(t *testing.T) {
 			INSERT INTO issue (
 				workspace_id, title, description, status, priority,
 				assignee_type, assignee_id, creator_type, creator_id,
-				position, number
+				position, number, start_date, stage
 			)
-			VALUES ($1, $2, NULL, 'todo', 'none', $3, $4, 'member', $5, $6, $7)
+			VALUES ($1, $2, NULL, 'todo', 'none', $3, $4, 'member', $5, $6, $7, $8, $9)
 			RETURNING id
-		`, testWorkspaceID, title, assigneeType, assigneeID, testUserID, position, number).Scan(&id); err != nil {
+		`, testWorkspaceID, title, assigneeType, assigneeID, testUserID, position, number, startDate, stage).Scan(&id); err != nil {
 			t.Fatalf("create issue %q: %v", title, err)
 		}
 		t.Cleanup(func() {
@@ -81,10 +81,12 @@ func TestListGroupedIssuesAssigneePaginatesPerGroup(t *testing.T) {
 		return id
 	}
 
-	createIssue("Grouped member one", "member", assigneeID, 1)
-	createIssue("Grouped member two", "member", assigneeID, 2)
-	createIssue("Grouped member three", "member", assigneeID, 3)
-	createIssue("Grouped agent one", "agent", agentID, 1)
+	stageTwo := int32(2)
+	startDate := time.Date(2026, 3, 1, 0, 0, 0, 0, time.UTC)
+	createIssue("Grouped member one", "member", assigneeID, 1, &startDate, &stageTwo)
+	createIssue("Grouped member two", "member", assigneeID, 2, nil, nil)
+	createIssue("Grouped member three", "member", assigneeID, 3, nil, nil)
+	createIssue("Grouped agent one", "agent", agentID, 1, nil, nil)
 
 	path := fmt.Sprintf(
 		"/api/issues/grouped?workspace_id=%s&group_by=assignee&statuses=todo&limit=2&assignee_filters=member:%s,agent:%s",
@@ -119,6 +121,12 @@ func TestListGroupedIssuesAssigneePaginatesPerGroup(t *testing.T) {
 	}
 	if memberGroup.Issues[0].Title != "Grouped member one" || memberGroup.Issues[1].Title != "Grouped member two" {
 		t.Fatalf("member group order mismatch: %#v", memberGroup.Issues)
+	}
+	if memberGroup.Issues[0].Stage == nil || *memberGroup.Issues[0].Stage != stageTwo {
+		t.Fatalf("member group first issue stage = %#v, want %d", memberGroup.Issues[0].Stage, stageTwo)
+	}
+	if memberGroup.Issues[0].StartDate == nil || *memberGroup.Issues[0].StartDate != "2026-03-01" {
+		t.Fatalf("member group first issue start_date = %#v, want 2026-03-01", memberGroup.Issues[0].StartDate)
 	}
 
 	agentGroup, ok := groups[agentGroupID]

--- a/server/internal/handler/issue_scheduled_test.go
+++ b/server/internal/handler/issue_scheduled_test.go
@@ -102,3 +102,59 @@ func TestListIssues_ScheduledFilter(t *testing.T) {
 		t.Fatalf("scheduled total: want 3, got %d", scheduledTotal)
 	}
 }
+
+func TestListIssuesReturnsStage(t *testing.T) {
+	ctx := context.Background()
+	suffix := time.Now().UnixNano()
+
+	var projectID string
+	if err := testPool.QueryRow(ctx, `
+		INSERT INTO project (workspace_id, title) VALUES ($1, $2) RETURNING id
+	`, testWorkspaceID, fmt.Sprintf("Stage List %d", suffix)).Scan(&projectID); err != nil {
+		t.Fatalf("create project: %v", err)
+	}
+	t.Cleanup(func() { testPool.Exec(context.Background(), `DELETE FROM project WHERE id = $1`, projectID) })
+
+	var number int
+	if err := testPool.QueryRow(ctx, `
+		UPDATE workspace
+		SET issue_counter = GREATEST(issue_counter, (SELECT COALESCE(MAX(number), 0) FROM issue WHERE workspace_id = $1)) + 1
+		WHERE id = $1 RETURNING issue_counter
+	`, testWorkspaceID).Scan(&number); err != nil {
+		t.Fatalf("next issue number: %v", err)
+	}
+
+	var issueID string
+	if err := testPool.QueryRow(ctx, `
+		INSERT INTO issue (workspace_id, title, status, priority, creator_type, creator_id, position, number, project_id, stage)
+		VALUES ($1, $2, 'todo', 'none', 'member', $3, 0, $4, $5, 2)
+		RETURNING id
+	`, testWorkspaceID, fmt.Sprintf("stage-list-%d", suffix), testUserID, number, projectID).Scan(&issueID); err != nil {
+		t.Fatalf("create issue: %v", err)
+	}
+	t.Cleanup(func() { testPool.Exec(context.Background(), `DELETE FROM issue WHERE id = $1`, issueID) })
+
+	path := fmt.Sprintf("/api/issues?workspace_id=%s&project_id=%s&limit=500", testWorkspaceID, projectID)
+	w := httptest.NewRecorder()
+	testHandler.ListIssues(w, newRequest("GET", path, nil))
+	if w.Code != http.StatusOK {
+		t.Fatalf("ListIssues: expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var resp struct {
+		Issues []IssueResponse `json:"issues"`
+		Total  int64           `json:"total"`
+	}
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode list response: %v", err)
+	}
+	if resp.Total != 1 || len(resp.Issues) != 1 {
+		t.Fatalf("expected one staged issue, total=%d len=%d", resp.Total, len(resp.Issues))
+	}
+	if resp.Issues[0].ID != issueID {
+		t.Fatalf("returned issue id = %s, want %s", resp.Issues[0].ID, issueID)
+	}
+	if resp.Issues[0].Stage == nil || *resp.Issues[0].Stage != 2 {
+		t.Fatalf("stage = %#v, want 2", resp.Issues[0].Stage)
+	}
+}


### PR DESCRIPTION
Summary:
- Return `stage` from the hand-written `/api/issues` dynamic query.
- Return `start_date` and `stage` from `/api/issues/grouped` so grouped issues carry the same response fields as normal list rows.
- Add handler regressions for staged list and grouped responses.

Tests:
- `go test ./internal/handler -run 'TestListIssuesReturnsStage|TestListGroupedIssuesAssigneePaginatesPerGroup'`

Full package note:
- `go test ./internal/handler` is currently blocked by the local test database schema being stale (`agent_invocation_target.kind` and `attachment.task_id` missing), causing unrelated agent/squad/webhook failures before completion.

Closes MUL-4393
