### PR TITLE
SNDBX-424: cover stage consistency in issue serializers

### DIFF
--- a/server/internal/handler/issue_scheduled_test.go
+++ b/server/internal/handler/issue_scheduled_test.go
@@ -158,3 +158,116 @@ func TestListIssuesReturnsStage(t *testing.T) {
 		t.Fatalf("stage = %#v, want 2", resp.Issues[0].Stage)
 	}
 }
+
+func TestIssueStageConsistentAcrossListGetAndChildren(t *testing.T) {
+	ctx := context.Background()
+	suffix := time.Now().UnixNano()
+
+	var projectID string
+	if err := testPool.QueryRow(ctx, `
+		INSERT INTO project (workspace_id, title) VALUES ($1, $2) RETURNING id
+	`, testWorkspaceID, fmt.Sprintf("Stage Consistency %d", suffix)).Scan(&projectID); err != nil {
+		t.Fatalf("create project: %v", err)
+	}
+	t.Cleanup(func() { testPool.Exec(context.Background(), `DELETE FROM project WHERE id = $1`, projectID) })
+
+	nextNumber := func() int {
+		var number int
+		if err := testPool.QueryRow(ctx, `
+			UPDATE workspace
+			SET issue_counter = GREATEST(issue_counter, (SELECT COALESCE(MAX(number), 0) FROM issue WHERE workspace_id = $1)) + 1
+			WHERE id = $1 RETURNING issue_counter
+		`, testWorkspaceID).Scan(&number); err != nil {
+			t.Fatalf("next issue number: %v", err)
+		}
+		return number
+	}
+
+	var parentID string
+	if err := testPool.QueryRow(ctx, `
+		INSERT INTO issue (workspace_id, title, status, priority, creator_type, creator_id, position, number, project_id)
+		VALUES ($1, $2, 'in_progress', 'none', 'member', $3, 0, $4, $5)
+		RETURNING id
+	`, testWorkspaceID, fmt.Sprintf("stage-parent-%d", suffix), testUserID, nextNumber(), projectID).Scan(&parentID); err != nil {
+		t.Fatalf("create parent issue: %v", err)
+	}
+
+	var childID string
+	if err := testPool.QueryRow(ctx, `
+		INSERT INTO issue (workspace_id, title, status, priority, creator_type, creator_id, parent_issue_id, position, number, project_id, stage)
+		VALUES ($1, $2, 'todo', 'none', 'member', $3, $4, 0, $5, $6, 2)
+		RETURNING id
+	`, testWorkspaceID, fmt.Sprintf("stage-child-%d", suffix), testUserID, parentID, nextNumber(), projectID).Scan(&childID); err != nil {
+		t.Fatalf("create child issue: %v", err)
+	}
+	t.Cleanup(func() {
+		testPool.Exec(context.Background(), `DELETE FROM issue WHERE id = $1`, childID)
+		testPool.Exec(context.Background(), `DELETE FROM issue WHERE id = $1`, parentID)
+	})
+
+	findIssue := func(issues []IssueResponse, id string) IssueResponse {
+		t.Helper()
+		for _, issue := range issues {
+			if issue.ID == id {
+				return issue
+			}
+		}
+		t.Fatalf("issue %s not found in response", id)
+		return IssueResponse{}
+	}
+
+	wantStage := int32(2)
+
+	listReq := fmt.Sprintf("/api/issues?workspace_id=%s&project_id=%s&limit=500", testWorkspaceID, projectID)
+	listW := httptest.NewRecorder()
+	testHandler.ListIssues(listW, newRequest("GET", listReq, nil))
+	if listW.Code != http.StatusOK {
+		t.Fatalf("ListIssues: expected 200, got %d: %s", listW.Code, listW.Body.String())
+	}
+	var listResp struct {
+		Issues []IssueResponse `json:"issues"`
+	}
+	if err := json.NewDecoder(listW.Body).Decode(&listResp); err != nil {
+		t.Fatalf("decode list response: %v", err)
+	}
+	listIssue := findIssue(listResp.Issues, childID)
+	if listIssue.Stage == nil || *listIssue.Stage != wantStage {
+		t.Fatalf("list stage = %#v, want %d", listIssue.Stage, wantStage)
+	}
+
+	getW := httptest.NewRecorder()
+	testHandler.GetIssue(getW, withURLParam(newRequest("GET", "/api/issues/"+childID, nil), "id", childID))
+	if getW.Code != http.StatusOK {
+		t.Fatalf("GetIssue: expected 200, got %d: %s", getW.Code, getW.Body.String())
+	}
+	var getResp IssueResponse
+	if err := json.NewDecoder(getW.Body).Decode(&getResp); err != nil {
+		t.Fatalf("decode get response: %v", err)
+	}
+	if getResp.Stage == nil || *getResp.Stage != wantStage {
+		t.Fatalf("get stage = %#v, want %d", getResp.Stage, wantStage)
+	}
+
+	childrenW := httptest.NewRecorder()
+	testHandler.ListChildIssues(childrenW, withURLParam(newRequest("GET", "/api/issues/"+parentID+"/children", nil), "id", parentID))
+	if childrenW.Code != http.StatusOK {
+		t.Fatalf("ListChildIssues: expected 200, got %d: %s", childrenW.Code, childrenW.Body.String())
+	}
+	var childrenResp struct {
+		Issues []IssueResponse `json:"issues"`
+	}
+	if err := json.NewDecoder(childrenW.Body).Decode(&childrenResp); err != nil {
+		t.Fatalf("decode children response: %v", err)
+	}
+	childFromChildren := findIssue(childrenResp.Issues, childID)
+	if childFromChildren.Stage == nil || *childFromChildren.Stage != wantStage {
+		t.Fatalf("children stage = %#v, want %d", childFromChildren.Stage, wantStage)
+	}
+
+	if listIssue.Stage == nil || getResp.Stage == nil || childFromChildren.Stage == nil {
+		t.Fatal("expected all three endpoints to include stage")
+	}
+	if *listIssue.Stage != *getResp.Stage || *getResp.Stage != *childFromChildren.Stage {
+		t.Fatalf("stage mismatch: list=%d get=%d children=%d", *listIssue.Stage, *getResp.Stage, *childFromChildren.Stage)
+	}
+}


### PR DESCRIPTION
Adds regression coverage to ensure issue stage stays consistent across list/get/children serializers.

Tested:
- docker run --rm -v /Users/asere-ai/multica_workspaces/09dcbbf0-32e9-4124-a684-39b2d14df57e/60e822ea/workdir/multica:/src -w /src/server -e 'DATABASE_URL=postgres://multica:multica@host.docker.internal:5432/multica?sslmode=disable' golang:1.26.1 go test ./internal/handler -run 'TestListIssuesReturnsStage|TestIssueStageConsistentAcrossListGetAndChildren' -count=1
- result: PASS