### PR TITLE
fix(migrations): make 164_attachment_task_id idempotent (self-heal #5307 renumber drift)

### DIFF
--- a/server/migrations/164_attachment_task_id.up.sql
+++ b/server/migrations/164_attachment_task_id.up.sql
@@ -16,8 +16,14 @@
 --     ON DELETE action here would never fire in practice; adding an FK on the
 --     hot attachment table would only add write overhead and a cascade
 --     dependency the app does not rely on.
+-- IF NOT EXISTS makes this self-heal on databases that applied it under its
+-- pre-#5307 number (161). The renumber to 164 changed the schema_migrations
+-- key, so the runner re-applies the renamed file on those DBs; without the
+-- guard the bare ADD COLUMN aborts with 42701 ("column already exists") and
+-- blocks every later migration (GH #5307's note; the dev deploy that hit it).
+-- Sibling 165 already uses CREATE INDEX ... IF NOT EXISTS for the same reason.
 ALTER TABLE attachment
-  ADD COLUMN task_id UUID;
+  ADD COLUMN IF NOT EXISTS task_id UUID;
 
 -- The task_id lookup index is built CONCURRENTLY in the next migration.
 -- CREATE INDEX CONCURRENTLY cannot share a transaction or multi-command


### PR DESCRIPTION
## Summary

Makes `164_attachment_task_id.up.sql` idempotent (`ADD COLUMN IF NOT EXISTS`) so it self-heals on databases that carry the #5307 renumber drift, instead of crashing container startup and blocking every later migration.

## Why

#5307 renamed `161_attachment_task_id` → `164` and `162_attachment_task_id_index` → `165` to resolve a prefix collision. `schema_migrations` keys on the full stem, so any DB that applied the migration under its **old** `161`/`162` numbers has no `164`/`165` row in the ledger — the runner re-applies the renamed files. `165` already uses `CREATE INDEX ... IF NOT EXISTS`, so it no-ops. But `164` did a bare `ADD COLUMN task_id UUID`, which aborts with:

```
ERROR: column "task_id" of relation "attachment" already exists (SQLSTATE 42701)
```

That is exactly what crashed the **dev deploy of main (`bf288349f`)** at startup — it failed at `164` and never reached `166_project_dates`. On a fresh DB (CI, prod-from-scratch) the old file works fine; only already-migrated environments hit it.

The one-line guard makes the re-run a harmless no-op on already-migrated DBs (dev/staging/prod) with **no manual `schema_migrations` surgery**, and is identical on a fresh DB. The `.down` file already uses `DROP COLUMN IF EXISTS`.

## Testing

Reproduced the dev drift on a throwaway DB (delete `164`/`165` from the ledger while keeping the column + index, add the orphan `161`/`162` rows):

- **Old file** (main): reproduces the exact `42701` crash, exit 1.
- **This file**: 164 re-runs as a no-op, 165 no-ops, both re-recorded, migration completes and reaches `166`.
- Fresh DB: still applies `164 → 165 → 166` cleanly.
- `go test ./internal/migrations/...` (lint) and `go test ./cmd/migrate/...` (concurrent runner) pass.

Once merged, a new main image + redeploy unblocks dev with no DB surgery.

Refs #5307
