### PR TITLE
fix(server): don't cancel active tasks when issue status → cancelled (MUL-4465)

### DIFF
--- a/server/internal/handler/issue.go
+++ b/server/internal/handler/issue.go
@@ -2652,8 +2652,11 @@ func (h *Handler) UpdateIssue(w http.ResponseWriter, r *http.Request) {
 	// and it self-cancelled a run that reassigned the issue from inside itself.
 	// Ownership handoff no longer implies interruption; the new assignee's run,
 	// if any, is enqueued by WillEnqueueRun below and runs alongside whatever
-	// was already in flight. Explicit terminal actions — issue → cancelled and
-	// delete — still cancel active tasks (see below / DeleteIssue).
+	// was already in flight. No status change — not even → cancelled — cancels
+	// active tasks: a user clicking "cancel" on an issue has no expectation that
+	// it stops in-flight agent runs, so that implicit coupling is gone
+	// (MUL-4465). Deleting an issue still cancels its tasks (see DeleteIssue),
+	// because the tasks' owning issue ceases to exist.
 	if trigger, ok := h.IssueService.WillEnqueueRun(r.Context(),
 		service.IssueTriggerInput{
 			Issue:           issue,
@@ -2664,13 +2667,6 @@ func (h *Handler) UpdateIssue(w http.ResponseWriter, r *http.Request) {
 		h.issueTriggerWriteProbe(r, actorType, issue),
 	); ok && !req.SuppressRun {
 		h.dispatchIssueRun(r.Context(), issue, trigger, actorType, actorID, req.HandoffNote)
-	}
-
-	// Cancel active tasks when the issue is cancelled by a user.
-	// This is distinct from agent-managed status transitions — cancellation
-	// is a user-initiated terminal action that should stop execution.
-	if statusChanged && issue.Status == "cancelled" {
-		h.TaskService.CancelTasksForIssue(r.Context(), issue.ID)
 	}
 
 	// Platform-driven parent notification: when this issue transitions into
@@ -3171,10 +3167,8 @@ func (h *Handler) BatchUpdateIssues(w http.ResponseWriter, r *http.Request) {
 			h.dispatchIssueRun(r.Context(), issue, trigger, actorType, actorID, req.Updates.HandoffNote)
 		}
 
-		// Cancel active tasks when the issue is cancelled by a user.
-		if statusChanged && issue.Status == "cancelled" {
-			h.TaskService.CancelTasksForIssue(r.Context(), issue.ID)
-		}
+		// No status change — not even → cancelled — cancels active tasks here,
+		// mirroring UpdateIssue (MUL-4465). See that handler for the rationale.
 
 		// Platform-driven parent notification, mirrored from UpdateIssue
 		// (MUL-2538) but DEFERRED to after the loop. Evaluating the stage

--- a/server/internal/handler/issue_cancel_status_no_cancel_test.go
+++ b/server/internal/handler/issue_cancel_status_no_cancel_test.go
@@ -1,16 +1,52 @@
 package handler
 
 import (
+	"context"
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 )
 
+// activeTaskStatuses are the non-terminal states CancelAgentTasksByIssue sweeps
+// (server/pkg/db/queries/agent.sql). MUL-4465's contract is that a status flip
+// to `cancelled` leaves every one of them untouched, so the tests below drive
+// each state, not just `running`.
+var activeTaskStatuses = []string{"queued", "dispatched", "running", "waiting_local_directory", "deferred"}
+
+// insertIssueTaskWithStatus inserts one active task for the agent on the issue
+// in the given status, populating the per-status columns the schema expects
+// (started_at for running, fire_at for deferred, wait_reason for
+// waiting_local_directory), and registers cleanup.
+func insertIssueTaskWithStatus(t *testing.T, agentID, issueID, status string) string {
+	t.Helper()
+	var startedAt, fireAt, waitReason any // nil => SQL NULL
+	switch status {
+	case "running":
+		startedAt = time.Now()
+	case "deferred":
+		fireAt = time.Now().Add(time.Hour)
+	case "waiting_local_directory":
+		waitReason = "waiting for local directory"
+	}
+	var taskID string
+	if err := testPool.QueryRow(context.Background(), `
+		INSERT INTO agent_task_queue (agent_id, runtime_id, status, priority, issue_id, started_at, fire_at, wait_reason)
+		VALUES ($1, (SELECT runtime_id FROM agent WHERE id = $1), $2, 0, $3, $4, $5, $6)
+		RETURNING id
+	`, agentID, status, issueID, startedAt, fireAt, waitReason).Scan(&taskID); err != nil {
+		t.Fatalf("insert %s task: %v", status, err)
+	}
+	t.Cleanup(func() { testPool.Exec(context.Background(), `DELETE FROM agent_task_queue WHERE id = $1`, taskID) })
+	return taskID
+}
+
 // TestUpdateIssueCancelStatusDoesNotCancelActiveTasks locks in MUL-4465:
-// moving an issue to `cancelled` no longer stops its in-flight agent runs.
-// A user clicking "cancel" has no expectation that it interrupts running
-// tasks, so that implicit coupling was removed. Deleting an issue still
-// cancels its tasks (covered elsewhere); a status change never does.
+// moving an issue to `cancelled` no longer stops its in-flight agent runs. A
+// user clicking "cancel" has no expectation that it interrupts running tasks,
+// so that implicit coupling was removed. Every active task state must survive,
+// as must an unrelated @-mention run for a different agent on the same issue.
+// Deleting an issue still cancels its tasks (covered elsewhere).
 func TestUpdateIssueCancelStatusDoesNotCancelActiveTasks(t *testing.T) {
 	if testHandler == nil {
 		t.Skip("database not available")
@@ -19,45 +55,54 @@ func TestUpdateIssueCancelStatusDoesNotCancelActiveTasks(t *testing.T) {
 	ownerAgent := createHandlerTestAgent(t, "CancelStatusNoCancelOwner", []byte("[]"))
 	mentionAgent := createHandlerTestAgent(t, "CancelStatusNoCancelMention", []byte("[]"))
 
-	issueID := insertAgentAssignedIssue(t, ownerAgent, 92130, "cancel-status-no-cancel")
-	ownerTask := insertRunningIssueTask(t, ownerAgent, issueID)
-	mentionTask := insertRunningIssueTask(t, mentionAgent, issueID)
+	for i, status := range activeTaskStatuses {
+		t.Run(status, func(t *testing.T) {
+			issueID := insertAgentAssignedIssue(t, ownerAgent, 92130+i, "cancel-status-no-cancel-"+status)
+			ownerTask := insertIssueTaskWithStatus(t, ownerAgent, issueID, status)
+			mentionTask := insertRunningIssueTask(t, mentionAgent, issueID)
 
-	w := httptest.NewRecorder()
-	req := newRequest("PUT", "/api/issues/"+issueID, map[string]any{
-		"status": "cancelled",
-	})
-	req = withURLParam(req, "id", issueID)
-	testHandler.UpdateIssue(w, req)
-	if w.Code != http.StatusOK {
-		t.Fatalf("UpdateIssue cancel: expected 200, got %d: %s", w.Code, w.Body.String())
-	}
+			w := httptest.NewRecorder()
+			req := newRequest("PUT", "/api/issues/"+issueID, map[string]any{
+				"status": "cancelled",
+			})
+			req = withURLParam(req, "id", issueID)
+			testHandler.UpdateIssue(w, req)
+			if w.Code != http.StatusOK {
+				t.Fatalf("UpdateIssue cancel: expected 200, got %d: %s", w.Code, w.Body.String())
+			}
 
-	if got := taskStatus(t, ownerTask); got != "running" {
-		t.Fatalf("assignee's own task must survive issue → cancelled, got status %q", got)
-	}
-	if got := taskStatus(t, mentionTask); got != "running" {
-		t.Fatalf("unrelated agent's task must survive issue → cancelled, got status %q", got)
+			if got := taskStatus(t, ownerTask); got != status {
+				t.Fatalf("assignee's %s task must survive issue → cancelled, got status %q", status, got)
+			}
+			if got := taskStatus(t, mentionTask); got != "running" {
+				t.Fatalf("unrelated agent's task must survive issue → cancelled, got status %q", got)
+			}
+		})
 	}
 }
 
 // TestBatchUpdateIssueCancelStatusDoesNotCancelActiveTasks is the batch-path
 // mirror — BatchUpdateIssues shares the same no-cancel-on-cancelled behavior.
+// One issue per active state is cancelled in a single batch call; every task
+// must keep its original status.
 func TestBatchUpdateIssueCancelStatusDoesNotCancelActiveTasks(t *testing.T) {
 	if testHandler == nil {
 		t.Skip("database not available")
 	}
 
 	ownerAgent := createHandlerTestAgent(t, "BatchCancelStatusNoCancelOwner", []byte("[]"))
-	mentionAgent := createHandlerTestAgent(t, "BatchCancelStatusNoCancelMention", []byte("[]"))
 
-	issueID := insertAgentAssignedIssue(t, ownerAgent, 92131, "batch-cancel-status-no-cancel")
-	ownerTask := insertRunningIssueTask(t, ownerAgent, issueID)
-	mentionTask := insertRunningIssueTask(t, mentionAgent, issueID)
+	issueIDs := make([]string, 0, len(activeTaskStatuses))
+	taskByStatus := make(map[string]string, len(activeTaskStatuses))
+	for i, status := range activeTaskStatuses {
+		issueID := insertAgentAssignedIssue(t, ownerAgent, 92140+i, "batch-cancel-status-no-cancel-"+status)
+		taskByStatus[status] = insertIssueTaskWithStatus(t, ownerAgent, issueID, status)
+		issueIDs = append(issueIDs, issueID)
+	}
 
 	w := httptest.NewRecorder()
 	req := newRequest("POST", "/api/issues/batch-update", map[string]any{
-		"issue_ids": []string{issueID},
+		"issue_ids": issueIDs,
 		"updates": map[string]any{
 			"status": "cancelled",
 		},
@@ -67,10 +112,9 @@ func TestBatchUpdateIssueCancelStatusDoesNotCancelActiveTasks(t *testing.T) {
 		t.Fatalf("BatchUpdateIssues cancel: expected 200, got %d: %s", w.Code, w.Body.String())
 	}
 
-	if got := taskStatus(t, ownerTask); got != "running" {
-		t.Fatalf("assignee's own task must survive batch issue → cancelled, got status %q", got)
-	}
-	if got := taskStatus(t, mentionTask); got != "running" {
-		t.Fatalf("unrelated agent's task must survive batch issue → cancelled, got status %q", got)
+	for status, taskID := range taskByStatus {
+		if got := taskStatus(t, taskID); got != status {
+			t.Fatalf("%s task must survive batch issue → cancelled, got status %q", status, got)
+		}
 	}
 }

--- a/server/internal/handler/issue_cancel_status_no_cancel_test.go
+++ b/server/internal/handler/issue_cancel_status_no_cancel_test.go
@@ -1,0 +1,76 @@
+package handler
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// TestUpdateIssueCancelStatusDoesNotCancelActiveTasks locks in MUL-4465:
+// moving an issue to `cancelled` no longer stops its in-flight agent runs.
+// A user clicking "cancel" has no expectation that it interrupts running
+// tasks, so that implicit coupling was removed. Deleting an issue still
+// cancels its tasks (covered elsewhere); a status change never does.
+func TestUpdateIssueCancelStatusDoesNotCancelActiveTasks(t *testing.T) {
+	if testHandler == nil {
+		t.Skip("database not available")
+	}
+
+	ownerAgent := createHandlerTestAgent(t, "CancelStatusNoCancelOwner", []byte("[]"))
+	mentionAgent := createHandlerTestAgent(t, "CancelStatusNoCancelMention", []byte("[]"))
+
+	issueID := insertAgentAssignedIssue(t, ownerAgent, 92130, "cancel-status-no-cancel")
+	ownerTask := insertRunningIssueTask(t, ownerAgent, issueID)
+	mentionTask := insertRunningIssueTask(t, mentionAgent, issueID)
+
+	w := httptest.NewRecorder()
+	req := newRequest("PUT", "/api/issues/"+issueID, map[string]any{
+		"status": "cancelled",
+	})
+	req = withURLParam(req, "id", issueID)
+	testHandler.UpdateIssue(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("UpdateIssue cancel: expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	if got := taskStatus(t, ownerTask); got != "running" {
+		t.Fatalf("assignee's own task must survive issue → cancelled, got status %q", got)
+	}
+	if got := taskStatus(t, mentionTask); got != "running" {
+		t.Fatalf("unrelated agent's task must survive issue → cancelled, got status %q", got)
+	}
+}
+
+// TestBatchUpdateIssueCancelStatusDoesNotCancelActiveTasks is the batch-path
+// mirror — BatchUpdateIssues shares the same no-cancel-on-cancelled behavior.
+func TestBatchUpdateIssueCancelStatusDoesNotCancelActiveTasks(t *testing.T) {
+	if testHandler == nil {
+		t.Skip("database not available")
+	}
+
+	ownerAgent := createHandlerTestAgent(t, "BatchCancelStatusNoCancelOwner", []byte("[]"))
+	mentionAgent := createHandlerTestAgent(t, "BatchCancelStatusNoCancelMention", []byte("[]"))
+
+	issueID := insertAgentAssignedIssue(t, ownerAgent, 92131, "batch-cancel-status-no-cancel")
+	ownerTask := insertRunningIssueTask(t, ownerAgent, issueID)
+	mentionTask := insertRunningIssueTask(t, mentionAgent, issueID)
+
+	w := httptest.NewRecorder()
+	req := newRequest("POST", "/api/issues/batch-update", map[string]any{
+		"issue_ids": []string{issueID},
+		"updates": map[string]any{
+			"status": "cancelled",
+		},
+	})
+	testHandler.BatchUpdateIssues(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("BatchUpdateIssues cancel: expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	if got := taskStatus(t, ownerTask); got != "running" {
+		t.Fatalf("assignee's own task must survive batch issue → cancelled, got status %q", got)
+	}
+	if got := taskStatus(t, mentionTask); got != "running" {
+		t.Fatalf("unrelated agent's task must survive batch issue → cancelled, got status %q", got)
+	}
+}

--- a/server/internal/service/builtin_skills/multica-working-on-issues/SKILL.md
+++ b/server/internal/service/builtin_skills/multica-working-on-issues/SKILL.md
@@ -159,7 +159,10 @@ on it. These are the contracts, not advice:
 - **`done`** on a child issue posts a system comment on its parent. If a PR
   carries close intent (`Closes MUL-XXXX`), it advances the issue to `done`
   itself on merge — you do not also need to flip it manually.
-- **`cancelled`** stops outstanding work; treat it as a user-driven decision.
+- **`cancelled`** is a terminal, user-driven decision to close the issue. Like
+  `done` it enqueues no new agent work, but it does **not** stop tasks already in
+  flight — a run in progress keeps going (MUL-4465). To stop a running task,
+  cancel the task itself.
 
 ## Sub-issues: `todo` starts work now, `backlog` parks it
 

--- a/server/internal/service/builtin_skills/multica-working-on-issues/references/working-on-issues-source-map.md
+++ b/server/internal/service/builtin_skills/multica-working-on-issues/references/working-on-issues-source-map.md
@@ -120,7 +120,7 @@ and is hidden from the PR list.
 | Backlog → non-backlog (not done/cancelled) enqueues on update | `server/internal/handler/issue.go:2537-2540` | `:2523` |
 | Same contract in batch update | `server/internal/handler/issue.go:3021-3024` | new citation |
 | Child → `done` notifies + wakes the parent, gated by the stage barrier | `server/internal/handler/issue_child_done.go:66` (`notifyParentOfChildDone`; doc comment at `:15`; barrier gate at `:115`) | func def `:51` |
-| Status change (incl. → `cancelled`) does NOT cancel in-flight tasks; only issue deletion does (MUL-4465) | no-cancel note in `server/internal/handler/issue.go:2652-2658` (`UpdateIssue`) and `:3170-3171` (`BatchUpdateIssues`); deletion still cancels at `:2863` (`DeleteIssue`) / `:3239` (`BatchDeleteIssues`) via `CancelTasksForIssue` (`server/internal/service/task.go:1224`) | new citation |
+| Status change (incl. → `cancelled`) does NOT cancel in-flight tasks; only issue deletion does (MUL-4465) | no-cancel note in `server/internal/handler/issue.go:2652-2658` (`UpdateIssue`) and `:3170-3171` (`BatchUpdateIssues`); deletion still cancels at `:2863` (`DeleteIssue`) / `:3239` (`BatchDeleteIssues`) via `CancelTasksForIssue` (`server/internal/service/task.go:1229`) | new citation |
 
 Creation with `--status todo` (or any non-backlog status) on an agent-assigned
 issue fires the agent immediately; `--status backlog` parks it with the assignee

--- a/server/internal/service/builtin_skills/multica-working-on-issues/references/working-on-issues-source-map.md
+++ b/server/internal/service/builtin_skills/multica-working-on-issues/references/working-on-issues-source-map.md
@@ -120,11 +120,19 @@ and is hidden from the PR list.
 | Backlog → non-backlog (not done/cancelled) enqueues on update | `server/internal/handler/issue.go:2537-2540` | `:2523` |
 | Same contract in batch update | `server/internal/handler/issue.go:3021-3024` | new citation |
 | Child → `done` notifies + wakes the parent, gated by the stage barrier | `server/internal/handler/issue_child_done.go:66` (`notifyParentOfChildDone`; doc comment at `:15`; barrier gate at `:115`) | func def `:51` |
+| Status change (incl. → `cancelled`) does NOT cancel in-flight tasks; only issue deletion does (MUL-4465) | no-cancel note in `server/internal/handler/issue.go:2652-2658` (`UpdateIssue`) and `:3170-3171` (`BatchUpdateIssues`); deletion still cancels at `:2863` (`DeleteIssue`) / `:3239` (`BatchDeleteIssues`) via `CancelTasksForIssue` (`server/internal/service/task.go:1224`) | new citation |
 
 Creation with `--status todo` (or any non-backlog status) on an agent-assigned
 issue fires the agent immediately; `--status backlog` parks it with the assignee
 set but no trigger. Promoting `backlog → todo` later fires it then (update path,
 line 2537).
+
+Moving an issue to `cancelled` used to call `CancelTasksForIssue` and stop every
+active task on it (the old #940 behavior). MUL-4465 removed that from both
+`UpdateIssue` and `BatchUpdateIssues`: a status flip — `cancelled` included —
+never cancels tasks now. `CancelTasksForIssue` fires only from the issue-deletion
+paths (`DeleteIssue` / `BatchDeleteIssues`), where the owning issue row is going
+away, so no task is left orphaned.
 
 ## Sub-issue stages (barrier wake)
 

--- a/server/internal/service/task.go
+++ b/server/internal/service/task.go
@@ -1216,11 +1216,16 @@ func (s *TaskService) SendDirectChatMessage(ctx context.Context, session db.Chat
 // affected agent's status, and broadcasts task:cancelled events so frontends
 // clear their live cards.
 //
-// Before #1587 this path was "cancel rows and return" — issue-status flips
-// (e.g. user marks the issue `done` or `cancelled` while a task is still
-// running) left the agent stuck at status="working" indefinitely, requiring a
-// manual `multica agent update <id> --status idle` to unwedge. Matches the
-// pattern already used by CancelTask and RerunIssue.
+// Callers are explicit issue-lifecycle cleanup paths only — DeleteIssue and
+// BatchDeleteIssues, where the owning issue row is going away so its tasks
+// must not be left orphaned. A plain status flip, `cancelled` included, no
+// longer routes here (MUL-4465): cancelling an issue is not an implicit "stop
+// all runs" switch. Do not re-add a status-driven caller.
+//
+// Before #1587 this path was "cancel rows and return", which left each affected
+// agent stuck at status="working" indefinitely, requiring a manual
+// `multica agent update <id> --status idle` to unwedge. It now reconciles agent
+// status and broadcasts task:cancelled, matching CancelTask and RerunIssue.
 func (s *TaskService) CancelTasksForIssue(ctx context.Context, issueID pgtype.UUID) error {
 	cancelled, err := s.Queries.CancelAgentTasksByIssue(ctx, issueID)
 	if err != nil {

--- a/server/pkg/db/generated/agent.sql.go
+++ b/server/pkg/db/generated/agent.sql.go
@@ -390,9 +390,9 @@ RETURNING id, agent_id, issue_id, status, priority, dispatched_at, started_at, c
 
 // Cancels every active task on the issue and returns the affected rows so the
 // caller can reconcile each agent's status and broadcast task:cancelled events
-// (#1587). Prior :exec form silently dropped that info, so internal cancel
-// paths (issue status flips to cancelled/done, etc.) left agents stuck at
-// status="working" with no self-correction.
+// (#1587). Prior :exec form silently dropped that info, leaving agents stuck at
+// status="working" with no self-correction. Only issue-deletion cleanup calls
+// this now; a status flip to cancelled/done no longer does (MUL-4465).
 func (q *Queries) CancelAgentTasksByIssue(ctx context.Context, issueID pgtype.UUID) ([]AgentTaskQueue, error) {
 	rows, err := q.db.Query(ctx, cancelAgentTasksByIssue, issueID)
 	if err != nil {

--- a/server/pkg/db/queries/agent.sql
+++ b/server/pkg/db/queries/agent.sql
@@ -322,9 +322,9 @@ RETURNING *;
 -- name: CancelAgentTasksByIssue :many
 -- Cancels every active task on the issue and returns the affected rows so the
 -- caller can reconcile each agent's status and broadcast task:cancelled events
--- (#1587). Prior :exec form silently dropped that info, so internal cancel
--- paths (issue status flips to cancelled/done, etc.) left agents stuck at
--- status="working" with no self-correction.
+-- (#1587). Prior :exec form silently dropped that info, leaving agents stuck at
+-- status="working" with no self-correction. Only issue-deletion cleanup calls
+-- this now; a status flip to cancelled/done no longer does (MUL-4465).
 UPDATE agent_task_queue
 SET status = 'cancelled', completed_at = now(), prepare_lease_expires_at = NULL
 WHERE issue_id = $1 AND status IN ('queued', 'dispatched', 'running', 'waiting_local_directory', 'deferred')


### PR DESCRIPTION
## Summary

Moving an Issue to `cancelled` used to silently auto-cancel **every in-flight agent task** on that issue. A user clicking "cancel" has no expectation that it interrupts running agent runs, so that implicit coupling is removed.

Changes:
- `UpdateIssue` and `BatchUpdateIssues` no longer call `CancelTasksForIssue` on a `status → cancelled` transition.
- `DeleteIssue` / `BatchDeleteIssues` still cancel tasks — deleting an issue removes the tasks' owning row, so that stays.
- Reassignment already didn't cancel tasks (#4963 / MUL-4113); this makes status-cancel consistent with that.

## Behavior

| Action | Before | After |
| --- | --- | --- |
| Issue status → `cancelled` | cancels every active task (queued / dispatched / running / waiting_local_directory / deferred) | **no effect on tasks** |
| Issue deleted | cancels tasks | cancels tasks (unchanged) |
| Cancel a task explicitly | cancels that task | unchanged |

If a user wants to stop a running agent, they cancel the task itself — that path is untouched.

## Testing

- `issue_cancel_status_no_cancel_test.go` is status-table-driven: for both the single (`UpdateIssue`) and batch (`BatchUpdateIssues`) paths it asserts a task survives a `status → cancelled` transition in **every active state** the cancel query sweeps — `queued`, `dispatched`, `running`, `waiting_local_directory`, `deferred`. The single path also asserts an unrelated @-mention run for a different agent is not collaterally cancelled.
- `go test ./internal/handler/ -run CancelStatus` and the related reassign tests pass; `go vet` clean.
- `go test ./internal/service/ -run TestBuiltinSkills` passes after the skill-doc update.
- Full CI green (backend, frontend, installers).

## Docs / source-of-truth

- Updated the `multica-working-on-issues` built-in skill (`SKILL.md`), which previously stated `cancelled` "stops outstanding work", and added the matching anchor row to its `references/working-on-issues-source-map.md`.
- Corrected two stale comments that still described the removed coupling as current: `CancelTasksForIssue`'s doc comment (`task.go`) and the `CancelAgentTasksByIssue` query comment (`agent.sql`, with `sqlc generate` regenerating `agent.sql.go`).

MUL-4465
