### PR TITLE
fix(views): keep in-card side panels on the content surface color

### DIFF
--- a/packages/views/agents/components/agent-overview-pane.tsx
+++ b/packages/views/agents/components/agent-overview-pane.tsx
@@ -357,7 +357,9 @@ export function AgentOverviewPane({
 
         {secondaryTabs.length > 0 && activeSecondaryTab && (
           <div className="flex min-h-full flex-col md:h-full md:flex-row">
-            <aside className="shrink-0 overflow-x-auto border-b border-surface-border bg-app-shell/70 p-2 md:w-52 md:overflow-y-auto md:border-b-0 md:border-r md:p-4">
+            {/* Content-surface color, no shell tint — same rule as the settings
+                nav: in-card panels must not break the desktop tab merge (MUL-4439). */}
+            <aside className="shrink-0 overflow-x-auto border-b border-surface-border p-2 md:w-52 md:overflow-y-auto md:border-b-0 md:border-r md:p-4">
               <div
                 className="flex w-max min-w-full items-center gap-1 md:w-full md:flex-col md:items-stretch"
                 role="tablist"

--- a/packages/views/settings/components/settings-page.tsx
+++ b/packages/views/settings/components/settings-page.tsx
@@ -140,8 +140,11 @@ export function SettingsPage({ extraAccountTabs }: SettingsPageProps = {}) {
       orientation={isMobile ? "horizontal" : "vertical"}
       className="flex flex-1 min-h-0 flex-col gap-0 overflow-y-auto md:flex-row md:overflow-hidden"
     >
-      {/* Structural navigation; bounded setting groups remain in the content surface. */}
-      <div className="shrink-0 overflow-x-auto border-b border-surface-border bg-app-shell/70 p-2 md:w-56 md:overflow-y-auto md:border-b-0 md:border-r md:p-4">
+      {/* Structural navigation; bounded setting groups remain in the content surface.
+          Stays on the content surface color (no shell tint): the desktop's active
+          tab merges into the card top, and a tinted panel under the first tabs
+          breaks that seam (MUL-4439). Zoning comes from the divider instead. */}
+      <div className="shrink-0 overflow-x-auto border-b border-surface-border p-2 md:w-56 md:overflow-y-auto md:border-b-0 md:border-r md:p-4">
         <h1 className="sr-only text-sm font-semibold md:not-sr-only md:mb-4 md:px-2">{t(($) => $.page.title)}</h1>
         <TabsList
           variant="line"


### PR DESCRIPTION
## Summary

Follow-up to #5314 (MUL-4439). The settings left nav and the agent overview aside tinted themselves with `bg-app-shell/70`, pulling the window-chrome tone inside the content card. With the desktop's Chrome-style tabs merging into the card top, an active tab positioned over one of these panels (the first 1–2 tabs) visibly broke the tab→content seam: tab foot at `page-canvas` rgb(251) meeting a rgb(246) panel in light mode (13→17 vs canvas in dark).

Fix: drop the tint so in-card panels stay on the content surface color — the same pattern the inbox list panel already uses. Zone separation is still carried by the hairline divider, the narrow column, and row hover/selected states.

- `packages/views/settings/components/settings-page.tsx` — settings nav
- `packages/views/agents/components/agent-overview-pane.tsx` — agent overview aside (same recipe, same fix)

Pixel-verified in the running desktop app: panel now measures identical to tab/content in both themes; before/after screenshots on MUL-4439.

## Testing

- `pnpm --filter @multica/views test`: 1850 passed
- `pnpm --filter @multica/views typecheck`: clean