### PR TITLE
MUL-4471: refresh workspace repos on demand

### DIFF
--- a/server/internal/daemon/coauthor_enabled_test.go
+++ b/server/internal/daemon/coauthor_enabled_test.go
@@ -18,10 +18,10 @@ import (
 // their historical behavior.
 func TestWorkspaceCoAuthoredByEnabled(t *testing.T) {
 	cases := []struct {
-		name       string
-		register   bool
-		settings   string
-		want       bool
+		name     string
+		register bool
+		settings string
+		want     bool
 	}{
 		{"unknown workspace defaults on", false, "", true},
 		{"registered workspace, nil settings defaults on", true, "", true},
@@ -61,32 +61,29 @@ func TestWorkspaceCoAuthoredByEnabled(t *testing.T) {
 	}
 }
 
-// syncWorkspacesFromAPI must refresh the cached workspace settings on already-
-// tracked workspaces so that toggling `co_authored_by_enabled` (or the
-// `github_enabled` master switch) in the web UI takes effect on the next gated
-// operation without a daemon restart. Reviewed in PR #2847 by Emacs — the
-// original cut only wrote settings during registration, so a running daemon
-// would keep installing the Co-authored-by hook on the next `repo checkout`
-// even after the workspace flipped the switch off.
-func TestSyncWorkspacesRefreshesSettingsOnExistingWorkspace(t *testing.T) {
+// syncWorkspacesFromAPI must not refresh repos or settings for an already-
+// tracked workspace. They are only consumed by repo checkout, whose
+// ensureRepoReady path refreshes them immediately before use. Keeping this
+// periodic sync to workspace/runtime duties prevents idle daemons from
+// repeatedly hitting the workspace repos endpoint.
+func TestSyncWorkspacesSkipsReposRefreshOnExistingWorkspace(t *testing.T) {
 	t.Parallel()
 
 	const workspaceID = "ws-1"
 
-	var settingsPayload atomic.Value
-	settingsPayload.Store(json.RawMessage(`{"github_enabled":true,"co_authored_by_enabled":true}`))
+	var repoCalls atomic.Int32
 
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
 		case "/api/workspaces":
 			json.NewEncoder(w).Encode([]WorkspaceInfo{{ID: workspaceID, Name: "ws"}})
 		case "/api/daemon/workspaces/" + workspaceID + "/repos":
-			raw, _ := settingsPayload.Load().(json.RawMessage)
+			repoCalls.Add(1)
 			json.NewEncoder(w).Encode(WorkspaceReposResponse{
 				WorkspaceID:  workspaceID,
 				Repos:        []RepoData{},
 				ReposVersion: "v1",
-				Settings:     raw,
+				Settings:     json.RawMessage(`{"github_enabled":false,"co_authored_by_enabled":true}`),
 			})
 		default:
 			http.NotFound(w, r)
@@ -116,24 +113,15 @@ func TestSyncWorkspacesRefreshesSettingsOnExistingWorkspace(t *testing.T) {
 		t.Fatalf("precondition: expected co-author hook to start enabled")
 	}
 
-	// The user opens Settings → GitHub and turns the master switch off.
-	settingsPayload.Store(json.RawMessage(`{"github_enabled":false,"co_authored_by_enabled":true}`))
-
 	if err := d.syncWorkspacesFromAPI(context.Background()); err != nil {
 		t.Fatalf("syncWorkspacesFromAPI: %v", err)
 	}
 
-	if d.workspaceCoAuthoredByEnabled(workspaceID) {
-		t.Fatalf("expected co-author hook disabled after toggle; daemon is still using stale cached settings")
+	if got := repoCalls.Load(); got != 0 {
+		t.Fatalf("workspace sync called repos endpoint %d times, want 0", got)
 	}
 
-	// Flipping the master switch back on must take effect the next sync too —
-	// the refresh path is not one-way.
-	settingsPayload.Store(json.RawMessage(`{"github_enabled":true,"co_authored_by_enabled":true}`))
-	if err := d.syncWorkspacesFromAPI(context.Background()); err != nil {
-		t.Fatalf("syncWorkspacesFromAPI (re-enable): %v", err)
-	}
 	if !d.workspaceCoAuthoredByEnabled(workspaceID) {
-		t.Fatalf("expected co-author hook re-enabled after toggling back on")
+		t.Fatal("workspace sync unexpectedly replaced cached settings")
 	}
 }

--- a/server/internal/daemon/daemon.go
+++ b/server/internal/daemon/daemon.go
@@ -1573,10 +1573,10 @@ func (d *Daemon) ensureRepoReady(ctx context.Context, workspaceID, repoURL strin
 	//
 	//   - cacheHitOnEntry=true: the repo is already cloned; we still must
 	//     refresh `workspaceState.settings` because the /repo/checkout
-	//     handler reads workspaceCoAuthoredByEnabled right after this and
-	//     the 30s workspaceSyncLoop tick is too slow for a freshly-flipped
-	//     GitHub master switch / `co_authored_by_enabled` toggle to feel
-	//     live (RFC MUL-2414 §4.8; PR #2847 review by Emacs).
+	//     handler reads workspaceCoAuthoredByEnabled right after this. The
+	//     periodic workspace sync deliberately does not refresh repos or
+	//     settings, so this is the point at which a freshly-flipped GitHub
+	//     master switch / `co_authored_by_enabled` toggle becomes live.
 	//
 	//   - cacheHitOnEntry=false but cache hit *after* we acquire the mutex:
 	//     a sibling goroutine on a concurrent cold-miss already refreshed
@@ -1702,8 +1702,10 @@ func (d *Daemon) tryRenewToken(ctx context.Context) {
 
 // workspaceSyncLoop periodically fetches the user's workspaces from the API
 // and registers runtimes for any new ones. A WS connect/reconnect broadcast
-// triggers an immediate sync so runtime/repo changes the server applied during
-// the WS gap are picked up sub-second instead of after the next 30s tick.
+// triggers an immediate sync so workspace and runtime changes the server
+// applied during the WS gap are picked up sub-second instead of after the
+// next 30s tick. Repository bindings and workspace settings refresh on demand
+// when a checkout needs them.
 func (d *Daemon) workspaceSyncLoop(ctx context.Context) {
 	ticker := time.NewTicker(DefaultWorkspaceSyncInterval)
 	defer ticker.Stop()
@@ -1766,14 +1768,6 @@ func (d *Daemon) syncWorkspacesFromAPI(ctx context.Context) error {
 	var removed int
 	for id, name := range apiIDs {
 		if currentIDs[id] {
-			// Already tracked: refresh the cached workspace settings so
-			// feature toggles flipped in the web UI take effect on the next
-			// gated operation without a daemon restart (see RFC MUL-2414 §4.8;
-			// reviewed in PR #2847). refreshWorkspaceRepos covers settings +
-			// repos in a single round trip.
-			if _, err := d.refreshWorkspaceRepos(ctx, id); err != nil {
-				d.logger.Debug("workspace sync: refresh settings failed", "workspace_id", id, "error", err)
-			}
 			// Pick up custom runtime profiles created/edited/disabled via
 			// the web UI or CLI between sync ticks (MUL-3332). Without this,
 			// a profile added on the server would only become a runtime row

--- a/server/internal/daemon/wakeup.go
+++ b/server/internal/daemon/wakeup.go
@@ -127,10 +127,11 @@ func (d *Daemon) runTaskWakeupConnection(ctx context.Context, runtimeIDs []strin
 	// signalTaskWakeup only wakes idle ClaimTask pollers. In-flight tasks and
 	// the workspace sync loop park on coarse tickers (5s and 30s) that do not
 	// observe the wakeup channel, so anything the server changed during the
-	// WS gap — task cancellation, runtime/repo updates — stays invisible to
-	// them until the next tick. The reconcile broadcaster nudges those loops
-	// to re-check immediately. broadcast() debounces back-to-back calls so a
-	// flapping connection cannot fan out into a request stampede.
+	// WS gap — task cancellation or runtime updates — stays invisible to
+	// them until the next tick. Repository bindings and workspace settings
+	// refresh when a checkout needs them. The reconcile broadcaster nudges
+	// those loops to re-check immediately. broadcast() debounces back-to-back
+	// calls so a flapping connection cannot fan out into a request stampede.
 	if d.reconcile != nil {
 		d.reconcile.broadcast()
 	}


### PR DESCRIPTION
## Summary
- remove periodic workspace repos/settings refreshes for tracked workspaces
- retain the checkout-time refresh that validates bindings and loads current settings
- cover that workspace sync skips the repos endpoint

## Tests
- go test ./internal/daemon -count=1

Closes MUL-4471