### PR TITLE
feat(agents): remove template entry from agent creation ModeChooser (MUL-4481)

### DIFF
--- a/packages/views/agents/components/agent-creation-studio.tsx
+++ b/packages/views/agents/components/agent-creation-studio.tsx
@@ -659,7 +659,6 @@ export function AgentCreationStudio() {
       {mode === "choose" && (
         <ModeChooser
           onBlank={chooseBlank}
-          onTemplate={() => setMode("templates")}
           onAI={() => setMode("ai")}
         />
       )}
@@ -771,11 +770,9 @@ export function AgentCreationStudio() {
 
 function ModeChooser({
   onBlank,
-  onTemplate,
   onAI,
 }: {
   onBlank: () => void;
-  onTemplate: () => void;
   onAI: () => void;
 }) {
   const { t } = useT("agents");
@@ -785,12 +782,6 @@ function ModeChooser({
       title: t(($) => $.creation_studio.modes.blank.title),
       description: t(($) => $.creation_studio.modes.blank.description),
       action: onBlank,
-    },
-    {
-      icon: Bot,
-      title: t(($) => $.creation_studio.modes.template.title),
-      description: t(($) => $.creation_studio.modes.template.description),
-      action: onTemplate,
     },
     {
       icon: MessageSquare,
@@ -814,7 +805,7 @@ function ModeChooser({
             {t(($) => $.creation_studio.choose_description)}
           </p>
         </div>
-        <div className="mt-9 grid gap-4 md:grid-cols-3">
+        <div className="mx-auto mt-9 grid max-w-3xl gap-4 md:grid-cols-2">
           {modes.map(({ icon: Icon, title, description, action, recommended }) => (
             <button
               key={title}


### PR DESCRIPTION
## What

Removes the **"使用模板" (Use Template)** entry card from the agent creation studio's `ModeChooser`, per MUL-4481. The studio now offers only **Blank** and **AI builder** modes.

## Changes

- `packages/views/agents/components/agent-creation-studio.tsx`
  - Drop the template card from the `modes` array in `ModeChooser`.
  - Remove the now-unused `onTemplate` prop (type + destructure) and its `() => setMode("templates")` wiring at the call site.
  - Rebalance the mode grid from `md:grid-cols-3` to a centered `md:grid-cols-2` so the two remaining cards lay out cleanly.

Blank and AI flows are untouched.

## Scope note (known debt)

Per the "quick UI change" scope, only the entry button was removed. `TemplateChooser`, `applyTemplate`, the template-detail queries, and the `createAgentFromTemplate` path remain in the file but are now **unreachable from the UI** (nothing sets `mode === "templates"` anymore). Fully removing the template subsystem is a larger change left as follow-up rather than expanding this PR's scope.

## Verification

- `pnpm turbo typecheck --filter=@multica/views` — passes (core / ui / views)
- `pnpm turbo lint --filter=@multica/views` — 0 errors
- `vitest run agent-creation-studio.test.ts` — 8/8 pass

No behavioral tests existed for `ModeChooser` (only the exported pure helpers are unit-tested), so none were broken.
