### PR TITLE
feat: custom-property list surfaces — filter, cards, sort, board grouping (MUL-4463 M2)

### DIFF
--- a/packages/core/issues/stores/view-store.ts
+++ b/packages/core/issues/stores/view-store.ts
@@ -11,9 +11,21 @@ import { defaultStorage } from "../../platform/storage";
 
 export type ViewMode = "board" | "list" | "gantt" | "swimlane";
 export type GanttZoom = "day" | "week" | "month";
-export type IssueGrouping = "status" | "assignee";
+/**
+ * Board grouping. Besides the two built-ins, a select-type custom property
+ * groups columns by its options via the `property:<definitionId>` form.
+ * Persisted values may reference a since-archived definition — consumers must
+ * fall back to "status" when the definition can't be resolved.
+ */
+export type IssueGrouping = "status" | "assignee" | `property:${string}`;
 export type SwimlaneGrouping = "parent" | "project" | "assignee";
-export type SortField = "position" | "priority" | "start_date" | "due_date" | "created_at" | "title";
+/**
+ * Sort key. `property:<definitionId>` sorts client-side by a custom property
+ * value (number/date types); the server sort param only understands the
+ * static fields, so property sorts fall back to `position` server-side and
+ * re-sort in the surface data hook.
+ */
+export type SortField = "position" | "priority" | "start_date" | "due_date" | "created_at" | "title" | `property:${string}`;
 export type SortDirection = "asc" | "desc";
 export type IssueDateField = "created_at" | "updated_at";
 
@@ -41,7 +53,16 @@ export interface ActorFilterValue {
   id: string;
 }
 
-export const SORT_OPTIONS: { value: SortField; label: string }[] = [
+export const PROPERTY_VIEW_PREFIX = "property:";
+
+export function propertyIdFromViewKey(key: string): string | null {
+  return key.startsWith(PROPERTY_VIEW_PREFIX) ? key.slice(PROPERTY_VIEW_PREFIX.length) : null;
+}
+
+export type StaticSortField = Exclude<SortField, `property:${string}`>;
+export type StaticIssueGrouping = Exclude<IssueGrouping, `property:${string}`>;
+
+export const SORT_OPTIONS: { value: StaticSortField; label: string }[] = [
   { value: "position", label: "Manual" },
   { value: "priority", label: "Priority" },
   { value: "start_date", label: "Start date" },
@@ -50,7 +71,7 @@ export const SORT_OPTIONS: { value: SortField; label: string }[] = [
   { value: "title", label: "Title" },
 ];
 
-export const GROUPING_OPTIONS: { value: IssueGrouping; label: string }[] = [
+export const GROUPING_OPTIONS: { value: StaticIssueGrouping; label: string }[] = [
   { value: "status", label: "Status" },
   { value: "assignee", label: "Assignee" },
 ];
@@ -77,6 +98,13 @@ export interface IssueViewState {
   projectFilters: string[];
   includeNoProject: boolean;
   labelFilters: string[];
+  /**
+   * Custom-property filters: definition id → selected option ids (checkbox
+   * definitions use the pseudo-options "true"/"false"). Empty array = no
+   * filter for that definition; matching is OR within a definition and AND
+   * across definitions, mirroring the other filter groups.
+   */
+  propertyFilters: Record<string, string[]>;
   dateFilter: IssueDateFilter | null;
   // When true, the list only shows issues that currently have at least one
   // agent task in `running` status. Drives the workspace "agents working"
@@ -87,6 +115,8 @@ export interface IssueViewState {
   sortBy: SortField;
   sortDirection: SortDirection;
   cardProperties: CardProperties;
+  /** Custom property definition ids whose values render on board/list cards. */
+  cardPropertyIds: string[];
   // When false, issues that have a parent (sub-issues) are hidden from the
   // board / list / swimlane so users can focus on top-level parent issues.
   // Purely a display filter — it never touches the parent/child relationship.
@@ -115,6 +145,7 @@ export interface IssueViewState {
   toggleProjectFilter: (projectId: string) => void;
   toggleNoProject: () => void;
   toggleLabelFilter: (labelId: string) => void;
+  togglePropertyFilter: (propertyId: string, optionId: string) => void;
   setDateFilter: (filter: IssueDateFilter | null) => void;
   toggleAgentRunningFilter: () => void;
   hideStatus: (status: IssueStatus) => void;
@@ -123,6 +154,7 @@ export interface IssueViewState {
   setSortBy: (field: SortField) => void;
   setSortDirection: (dir: SortDirection) => void;
   toggleCardProperty: (key: keyof CardProperties) => void;
+  toggleCardPropertyId: (propertyId: string) => void;
   toggleShowSubIssues: () => void;
   toggleListCollapsed: (status: IssueStatus) => void;
   setSwimlaneGrouping: (grouping: SwimlaneGrouping) => void;
@@ -143,6 +175,7 @@ export const viewStoreSlice = (set: StoreApi<IssueViewState>["setState"]): Issue
   projectFilters: [],
   includeNoProject: false,
   labelFilters: [],
+  propertyFilters: {},
   dateFilter: null,
   agentRunningFilter: false,
   sortBy: "position",
@@ -157,6 +190,7 @@ export const viewStoreSlice = (set: StoreApi<IssueViewState>["setState"]): Issue
     childProgress: true,
     labels: true,
   },
+  cardPropertyIds: [],
   showSubIssues: true,
   listCollapsedStatuses: [],
   ganttZoom: "week",
@@ -224,6 +258,17 @@ export const viewStoreSlice = (set: StoreApi<IssueViewState>["setState"]): Issue
         ? state.labelFilters.filter((id) => id !== labelId)
         : [...state.labelFilters, labelId],
     })),
+  togglePropertyFilter: (propertyId, optionId) =>
+    set((state) => {
+      const current = state.propertyFilters[propertyId] ?? [];
+      const next = current.includes(optionId)
+        ? current.filter((id) => id !== optionId)
+        : [...current, optionId];
+      const propertyFilters = { ...state.propertyFilters };
+      if (next.length === 0) delete propertyFilters[propertyId];
+      else propertyFilters[propertyId] = next;
+      return { propertyFilters };
+    }),
   setDateFilter: (filter) => set({ dateFilter: filter }),
   toggleAgentRunningFilter: () =>
     set((state) => ({ agentRunningFilter: !state.agentRunningFilter })),
@@ -253,6 +298,7 @@ export const viewStoreSlice = (set: StoreApi<IssueViewState>["setState"]): Issue
       projectFilters: [],
       includeNoProject: false,
       labelFilters: [],
+      propertyFilters: {},
       dateFilter: null,
       agentRunningFilter: false,
     }),
@@ -264,6 +310,12 @@ export const viewStoreSlice = (set: StoreApi<IssueViewState>["setState"]): Issue
         ...state.cardProperties,
         [key]: !state.cardProperties[key],
       },
+    })),
+  toggleCardPropertyId: (propertyId) =>
+    set((state) => ({
+      cardPropertyIds: state.cardPropertyIds.includes(propertyId)
+        ? state.cardPropertyIds.filter((id) => id !== propertyId)
+        : [...state.cardPropertyIds, propertyId],
     })),
   toggleShowSubIssues: () =>
     set((state) => ({ showSubIssues: !state.showSubIssues })),
@@ -311,9 +363,11 @@ export const viewStorePersistOptions = (name: string) => ({
     projectFilters: state.projectFilters,
     includeNoProject: state.includeNoProject,
     labelFilters: state.labelFilters,
+    propertyFilters: state.propertyFilters,
     sortBy: state.sortBy,
     sortDirection: state.sortDirection,
     cardProperties: state.cardProperties,
+    cardPropertyIds: state.cardPropertyIds,
     showSubIssues: state.showSubIssues,
     listCollapsedStatuses: state.listCollapsedStatuses,
     ganttZoom: state.ganttZoom,

--- a/packages/views/issues/components/board-card.tsx
+++ b/packages/views/issues/components/board-card.tsx
@@ -5,7 +5,11 @@ import { AppLink } from "../../navigation";
 import { useSortable, defaultAnimateLayoutChanges } from "@dnd-kit/sortable";
 import type { AnimateLayoutChanges } from "@dnd-kit/sortable";
 import { CSS } from "@dnd-kit/utilities";
-import type { Issue, Project, UpdateIssueRequest } from "@multica/core/types";
+import type { Issue, IssueProperty, Project, UpdateIssueRequest } from "@multica/core/types";
+import { useQuery } from "@tanstack/react-query";
+import { useWorkspaceId } from "@multica/core/hooks";
+import { propertyListOptions } from "@multica/core/properties";
+import { CustomPropertyValueDisplay } from "./pickers/custom-property-picker";
 import { formatDateOnly, isPastDateOnly } from "@multica/core/issues/date";
 import { CalendarClock, CalendarDays } from "lucide-react";
 import { ActorAvatar } from "../../common/actor-avatar";
@@ -66,6 +70,14 @@ export const BoardCardContent = memo(function BoardCardContent({
   const { t } = useT("issues");
   const timeAgo = useTimeAgo();
   const storeProperties = useViewStore((s) => s.cardProperties);
+  const cardPropertyIds = useViewStore((s) => s.cardPropertyIds);
+  const cardWsId = useWorkspaceId();
+  const { data: workspaceProperties = [] } = useQuery(propertyListOptions(cardWsId));
+  // Custom properties toggled on in Display options, in toggle order, only
+  // when this issue actually carries a value.
+  const cardCustomProperties = cardPropertyIds
+    .map((id) => workspaceProperties.find((p) => p.id === id))
+    .filter((p): p is IssueProperty => !!p && issue.properties?.[p.id] !== undefined);
   const labels = issue.labels ?? [];
 
   const surfaceActions = useIssueSurfaceActionsOptional();
@@ -189,8 +201,8 @@ export const BoardCardContent = memo(function BoardCardContent({
         );
       })()}
 
-      {/* Chip row: project + labels */}
-      {(showProject || showLabels) && (
+      {/* Chip row: project + labels + custom property values */}
+      {(showProject || showLabels || cardCustomProperties.length > 0) && (
         <div className="mt-1.5 flex items-center gap-1.5 flex-wrap">
           {showProject && (
             <span className="inline-flex items-center gap-1 rounded-full bg-muted/60 px-1.5 py-0.5 text-[11px] text-muted-foreground max-w-[160px]">
@@ -200,6 +212,14 @@ export const BoardCardContent = memo(function BoardCardContent({
           )}
           {showLabels && labels.map((label) => (
             <LabelChip key={label.id} label={label} />
+          ))}
+          {cardCustomProperties.map((property) => (
+            <span
+              key={property.id}
+              className="inline-flex max-w-[160px] items-center rounded-full bg-muted/60 px-1.5 py-0.5 text-[11px] text-muted-foreground"
+            >
+              <CustomPropertyValueDisplay property={property} value={issue.properties?.[property.id]} />
+            </span>
           ))}
         </div>
       )}

--- a/packages/views/issues/components/board-column.tsx
+++ b/packages/views/issues/components/board-column.tsx
@@ -48,6 +48,11 @@ export interface BoardColumnGroup {
   status?: IssueStatus;
   assigneeType?: IssueAssigneeType | null;
   assigneeId?: string | null;
+  /** Set when the board is grouped by a select-type custom property. */
+  propertyId?: string;
+  /** Option id for this column; null = the "No value" column. */
+  propertyOptionId?: string | null;
+  propertyOptionColor?: string;
   totalCount?: number;
   createData?: IssueCreateDefaults;
 }
@@ -233,6 +238,23 @@ function BoardGroupHeading({
 }) {
   if (group.status) {
     return <StatusHeading status={group.status} count={count} />;
+  }
+
+  if (group.propertyId !== undefined) {
+    return (
+      <div className="flex min-w-0 items-center gap-2">
+        <span
+          className="size-2.5 shrink-0 rounded-full bg-muted-foreground/30"
+          style={group.propertyOptionColor ? { backgroundColor: group.propertyOptionColor } : undefined}
+        />
+        <span className="truncate text-sm font-medium" title={group.title}>
+          {group.title}
+        </span>
+        <span className="shrink-0 rounded-full bg-background px-1.5 py-0.5 text-[11px] font-medium tabular-nums text-muted-foreground">
+          {count}
+        </span>
+      </div>
+    );
   }
 
   const actorIcon =

--- a/packages/views/issues/components/board-view.tsx
+++ b/packages/views/issues/components/board-view.tsx
@@ -193,6 +193,13 @@ export function BoardView({
   // deleted, other workspace) falls back to status columns.
   const grouping: IssueGrouping =
     groupingPropertyId && !groupingProperty ? "status" : storeGrouping;
+  const groupingOptionIds = useMemo(
+    () =>
+      groupingProperty
+        ? new Set((groupingProperty.config.options ?? []).map((option) => option.id))
+        : undefined,
+    [groupingProperty],
+  );
   const setIssuePropertyMutation = useSetIssueProperty();
   const unsetIssuePropertyMutation = useUnsetIssueProperty();
   const applyPropertyGroupValue = useCallback(
@@ -303,13 +310,13 @@ export function BoardView({
     recentlyMovedRef,
     settleVersion,
     beginSettle,
-  } = useDragSettle(() => buildColumns(groupedIssues, groups, grouping));
+  } = useDragSettle(() => buildColumns(groupedIssues, groups, grouping, groupingOptionIds));
 
   useEffect(() => {
     if (!isDraggingRef.current && !isSettlingRef.current) {
-      setColumns(buildColumns(groupedIssues, groups, grouping));
+      setColumns(buildColumns(groupedIssues, groups, grouping, groupingOptionIds));
     }
-  }, [groupedIssues, groups, grouping, settleVersion, setColumns, isDraggingRef, isSettlingRef]);
+  }, [groupedIssues, groups, grouping, groupingOptionIds, settleVersion, setColumns, isDraggingRef, isSettlingRef]);
 
   // --- Issue map ---
   // Frozen during drag so BoardColumn/DraggableBoardCard props stay
@@ -374,7 +381,7 @@ export function BoardView({
       setActiveIssue(null);
 
       const resetColumns = () =>
-        setColumns(buildColumns(groupedIssues, groups, grouping));
+        setColumns(buildColumns(groupedIssues, groups, grouping, groupingOptionIds));
 
       if (!over) {
         resetColumns();
@@ -469,7 +476,7 @@ export function BoardView({
       onMoveIssue(activeId, getMoveUpdates(finalGroup, newPosition), beginSettle());
       applyPropertyGroupValue(finalGroup, activeId);
     },
-    [groupedIssues, groups, grouping, onMoveIssue, groupIds, groupMap, sortBy, beginSettle, columnsRef, isDraggingRef, setColumns, applyPropertyGroupValue],
+    [groupedIssues, groups, grouping, groupingOptionIds, onMoveIssue, groupIds, groupMap, sortBy, beginSettle, columnsRef, isDraggingRef, setColumns, applyPropertyGroupValue],
   );
 
   return (

--- a/packages/views/issues/components/board-view.tsx
+++ b/packages/views/issues/components/board-view.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useCallback, useMemo, useEffect, useRef, memo } from "react";
+import { useQuery } from "@tanstack/react-query";
 import {
   DndContext,
   DragOverlay,
@@ -18,10 +19,14 @@ import type {
   IssueAssigneeGroup,
   IssueStatus,
   Project,
+  IssueProperty,
 } from "@multica/core/types";
 import { useLoadMoreByAssigneeGroup, useLoadMoreByStatus } from "@multica/core/issues/mutations";
 import type { AssigneeGroupedIssuesFilter, IssueSortParam, MyIssuesFilter } from "@multica/core/issues/queries";
 import { useViewStore } from "@multica/core/issues/stores/view-store-context";
+import { propertyIdFromViewKey } from "@multica/core/issues/stores/view-store";
+import { propertyListOptions, useSetIssueProperty, useUnsetIssueProperty } from "@multica/core/properties";
+import { useWorkspaceId } from "@multica/core/hooks";
 import type { IssueGrouping } from "@multica/core/issues/stores/view-store";
 import { useActorName } from "@multica/core/workspace/hooks";
 import { BoardColumn, BOARD_CARD_WIDTH, type BoardColumnGroup } from "./board-column";
@@ -43,6 +48,7 @@ import {
   insertIdByPosition,
   issueMatchesGroup,
   getMoveUpdates,
+  propertyGroupId,
 } from "../utils/drag-utils";
 
 function isStatusGroup(
@@ -57,6 +63,8 @@ function buildGroups(
   grouping: IssueGrouping,
   getActorName: (type: string, id: string) => string,
   noAssigneeLabel: string,
+  groupingProperty: IssueProperty | null,
+  noValueLabel: string,
 ): BoardColumnGroup[] {
   if (grouping === "status") {
     return visibleStatuses.map((status) => ({
@@ -65,6 +73,28 @@ function buildGroups(
       status,
       createData: { status },
     }));
+  }
+
+  // Select-property board: one column per option (definition order) plus a
+  // trailing "No value" column. Empty columns stay visible — they are drop
+  // targets for assigning the value.
+  if (groupingProperty) {
+    const columns: BoardColumnGroup[] = (groupingProperty.config.options ?? []).map(
+      (option) => ({
+        id: propertyGroupId(groupingProperty.id, option.id),
+        title: option.name,
+        propertyId: groupingProperty.id,
+        propertyOptionId: option.id,
+        propertyOptionColor: option.color,
+      }),
+    );
+    columns.push({
+      id: propertyGroupId(groupingProperty.id, null),
+      title: noValueLabel,
+      propertyId: groupingProperty.id,
+      propertyOptionId: null,
+    });
+    return columns;
   }
 
   const groups = new Map<string, BoardColumnGroup>();
@@ -151,11 +181,43 @@ export function BoardView({
   onCreateIssue?: (defaults: IssueCreateDefaults) => void;
 }) {
   const { t } = useT("issues");
-  const grouping = useViewStore((s) => s.grouping);
+  const storeGrouping = useViewStore((s) => s.grouping);
   const sortBy = useViewStore((s) => s.sortBy);
+  const boardWsId = useWorkspaceId();
+  const { data: workspaceProperties = [] } = useQuery(propertyListOptions(boardWsId));
+  const groupingPropertyId = propertyIdFromViewKey(storeGrouping);
+  const groupingProperty = groupingPropertyId
+    ? workspaceProperties.find((p) => p.id === groupingPropertyId && p.type === "select") ?? null
+    : null;
+  // A persisted `property:<id>` grouping whose definition is gone (archived,
+  // deleted, other workspace) falls back to status columns.
+  const grouping: IssueGrouping =
+    groupingPropertyId && !groupingProperty ? "status" : storeGrouping;
+  const setIssuePropertyMutation = useSetIssueProperty();
+  const unsetIssuePropertyMutation = useUnsetIssueProperty();
+  const applyPropertyGroupValue = useCallback(
+    (group: BoardColumnGroup, issueId: string) => {
+      if (group.propertyId === undefined) return;
+      if (group.propertyOptionId === null) {
+        unsetIssuePropertyMutation.mutate({ issueId, propertyId: group.propertyId });
+      } else if (group.propertyOptionId !== undefined) {
+        setIssuePropertyMutation.mutate({
+          issueId,
+          propertyId: group.propertyId,
+          value: group.propertyOptionId,
+        });
+      }
+    },
+    [setIssuePropertyMutation, unsetIssuePropertyMutation],
+  );
   const sortFieldKey = sortBy === "created_at" ? "created" : sortBy;
+  const sortPropertyId = propertyIdFromViewKey(sortBy);
   const sortLabel = sortBy !== "position"
-    ? t(($) => $.board.ordered_by, { field: t(($) => $.display[`sort_${sortFieldKey}` as keyof typeof $.display]) })
+    ? t(($) => $.board.ordered_by, {
+        field: sortPropertyId
+          ? workspaceProperties.find((p) => p.id === sortPropertyId)?.name ?? ""
+          : t(($) => $.display[`sort_${sortFieldKey}` as keyof typeof $.display]),
+      })
     : null;
   const { getActorName } = useActorName();
   const myIssuesOpts = myIssuesScope
@@ -207,8 +269,10 @@ export function BoardView({
         grouping,
         getActorName,
         t(($) => $.filters.no_assignee),
+        groupingProperty,
+        t(($) => $.board.no_value),
       ),
-    [hydratedAssigneeGroups, issues, visibleStatuses, grouping, getActorName, t],
+    [hydratedAssigneeGroups, issues, visibleStatuses, grouping, getActorName, groupingProperty, t],
   );
   const groupIds = useMemo(
     () => new Set(groups.map((group) => group.id)),
@@ -381,6 +445,7 @@ export function BoardView({
           return { ...prev, [activeCol]: fromIds, [overCol]: toIds };
         });
         onMoveIssue(activeId, getMoveUpdates(finalGroup, currentIssue.position), beginSettle());
+        applyPropertyGroupValue(finalGroup, activeId);
         return;
       }
 
@@ -402,8 +467,9 @@ export function BoardView({
       // on error (onError restored the snapshot). Without it a failed move would
       // strand the card at the drop target, since onSettled no longer refetches.
       onMoveIssue(activeId, getMoveUpdates(finalGroup, newPosition), beginSettle());
+      applyPropertyGroupValue(finalGroup, activeId);
     },
-    [groupedIssues, groups, grouping, onMoveIssue, groupIds, groupMap, sortBy, beginSettle, columnsRef, isDraggingRef, setColumns],
+    [groupedIssues, groups, grouping, onMoveIssue, groupIds, groupMap, sortBy, beginSettle, columnsRef, isDraggingRef, setColumns, applyPropertyGroupValue],
   );
 
   return (

--- a/packages/views/issues/components/issues-header.tsx
+++ b/packages/views/issues/components/issues-header.tsx
@@ -923,10 +923,20 @@ export function IssueDisplayControls({
   const counts = useIssueCounts(scopedIssues);
   const showDateFilter = !!onDateFilterChange;
 
+  // Only count filters whose definition is still active — a filter pinned to
+  // an archived definition is stripped by the surface controller and must
+  // not light the badge for an effect that no longer exists.
+  const effectivePropertyFilters = useMemo(() => {
+    const activeIds = new Set(filterableProperties.map((p) => p.id));
+    return Object.fromEntries(
+      Object.entries(propertyFilters).filter(([id, selected]) => selected.length > 0 && activeIds.has(id)),
+    );
+  }, [filterableProperties, propertyFilters]);
+
   const activeFilterCount = getActiveFilterCount({
     statusFilters,
     priorityFilters,
-    propertyFilters,
+    propertyFilters: effectivePropertyFilters,
     assigneeFilters,
     includeNoAssignee,
     creatorFilters,

--- a/packages/views/issues/components/issues-header.tsx
+++ b/packages/views/issues/components/issues-header.tsx
@@ -56,6 +56,9 @@ import { useWorkspaceId } from "@multica/core/hooks";
 import { memberListOptions, agentListOptions, squadListOptions } from "@multica/core/workspace/queries";
 import { projectListOptions } from "@multica/core/projects/queries";
 import { labelListOptions } from "@multica/core/labels/queries";
+import { propertyListOptions } from "@multica/core/properties";
+import { propertyIdFromViewKey } from "@multica/core/issues/stores/view-store";
+import type { IssueProperty } from "@multica/core/types";
 import { ProjectIcon } from "../../projects/components/project-icon";
 import { ActorAvatar } from "../../common/actor-avatar";
 import { LabelChip } from "../../labels/label-chip";
@@ -103,6 +106,7 @@ function getActiveFilterCount(state: {
   projectFilters: string[];
   includeNoProject: boolean;
   labelFilters: string[];
+  propertyFilters?: Record<string, string[]>;
   dateFilter?: IssueDateFilter | null;
 }) {
   let count = 0;
@@ -112,6 +116,9 @@ function getActiveFilterCount(state: {
   if (state.creatorFilters.length > 0) count++;
   if (state.projectFilters.length > 0 || state.includeNoProject) count++;
   if (state.labelFilters.length > 0) count++;
+  for (const selected of Object.values(state.propertyFilters ?? {})) {
+    if (selected.length > 0) count++;
+  }
   if (state.dateFilter) count++;
   return count;
 }
@@ -137,6 +144,9 @@ function useIssueCounts(allIssues: Issue[]) {
     const creator = new Map<string, number>();
     const project = new Map<string, number>();
     const label = new Map<string, number>();
+    // property definition id → option key → count. Checkbox values count
+    // under the "true"/"false" pseudo-option keys the filter store uses.
+    const property = new Map<string, Map<string, number>>();
     let noAssignee = 0;
     let noProject = 0;
 
@@ -165,9 +175,29 @@ function useIssueCounts(allIssues: Issue[]) {
           label.set(l.id, (label.get(l.id) ?? 0) + 1);
         }
       }
+
+      for (const [propertyId, value] of Object.entries(issue.properties ?? {})) {
+        const optionKeys =
+          typeof value === "string"
+            ? [value]
+            : Array.isArray(value)
+              ? value
+              : typeof value === "boolean"
+                ? [String(value)]
+                : [];
+        if (optionKeys.length === 0) continue;
+        let perOption = property.get(propertyId);
+        if (!perOption) {
+          perOption = new Map<string, number>();
+          property.set(propertyId, perOption);
+        }
+        for (const key of optionKeys) {
+          perOption.set(key, (perOption.get(key) ?? 0) + 1);
+        }
+      }
     }
 
-    return { status, priority, assignee, creator, noAssignee, project, noProject, label };
+    return { status, priority, assignee, creator, noAssignee, project, noProject, label, property };
   }, [allIssues]);
 }
 
@@ -505,6 +535,67 @@ function LabelSubContent({
   );
 }
 
+/**
+ * Option checkboxes for one custom property inside the Filter dropdown.
+ * Select/multi_select list the definition's options (dot + name); checkbox
+ * definitions expose the "true"/"false" pseudo-options with Yes/No labels.
+ */
+function PropertyFilterOptions({
+  property,
+  counts,
+  selected,
+  onToggle,
+}: {
+  property: IssueProperty;
+  counts: Map<string, number> | undefined;
+  selected: string[];
+  onToggle: (optionId: string) => void;
+}) {
+  const { t } = useT("issues");
+  const options =
+    property.type === "checkbox"
+      ? [
+          { id: "true", name: t(($) => $.pickers.custom_property.true_label), color: undefined },
+          { id: "false", name: t(($) => $.pickers.custom_property.false_label), color: undefined },
+        ]
+      : (property.config.options ?? []).map((option) => ({
+          id: option.id,
+          name: option.name,
+          color: option.color as string | undefined,
+        }));
+
+  return (
+    <>
+      {options.map((option) => {
+        const checked = selected.includes(option.id);
+        const count = counts?.get(option.id) ?? 0;
+        return (
+          <DropdownMenuCheckboxItem
+            key={option.id}
+            checked={checked}
+            onCheckedChange={() => onToggle(option.id)}
+            className={FILTER_ITEM_CLASS}
+          >
+            <HoverCheck checked={checked} />
+            {option.color && (
+              <span
+                className="size-2.5 shrink-0 rounded-full"
+                style={{ backgroundColor: option.color }}
+              />
+            )}
+            <span className="truncate">{option.name}</span>
+            {count > 0 && (
+              <span className="ml-auto text-xs text-muted-foreground">
+                {count}
+              </span>
+            )}
+          </DropdownMenuCheckboxItem>
+        );
+      })}
+    </>
+  );
+}
+
 // ---------------------------------------------------------------------------
 // Date sub-menu content
 // ---------------------------------------------------------------------------
@@ -796,6 +887,8 @@ export function IssueDisplayControls({
   const projectFilters = useViewStore((s) => s.projectFilters);
   const includeNoProject = useViewStore((s) => s.includeNoProject);
   const labelFilters = useViewStore((s) => s.labelFilters);
+  const propertyFilters = useViewStore((s) => s.propertyFilters);
+  const cardPropertyIds = useViewStore((s) => s.cardPropertyIds);
   const sortBy = useViewStore((s) => s.sortBy);
   const sortDirection = useViewStore((s) => s.sortDirection);
   const grouping = useViewStore((s) => s.grouping);
@@ -803,6 +896,29 @@ export function IssueDisplayControls({
   const cardProperties = useViewStore((s) => s.cardProperties);
   const showSubIssues = useViewStore((s) => s.showSubIssues);
   const act = useViewStoreApi().getState();
+  const headerWsId = useWorkspaceId();
+  // Active custom-property catalog: drives the filter sections, dynamic
+  // sort/grouping options, and the card-property toggles below.
+  const { data: workspaceProperties = [] } = useQuery(propertyListOptions(headerWsId));
+  const propertyById = useMemo(
+    () => new Map(workspaceProperties.map((p) => [p.id, p])),
+    [workspaceProperties],
+  );
+  const filterableProperties = useMemo(
+    () =>
+      workspaceProperties.filter((p) =>
+        p.type === "select" || p.type === "multi_select" || p.type === "checkbox",
+      ),
+    [workspaceProperties],
+  );
+  const sortableProperties = useMemo(
+    () => workspaceProperties.filter((p) => p.type === "number" || p.type === "date"),
+    [workspaceProperties],
+  );
+  const groupableProperties = useMemo(
+    () => workspaceProperties.filter((p) => p.type === "select"),
+    [workspaceProperties],
+  );
 
   const counts = useIssueCounts(scopedIssues);
   const showDateFilter = !!onDateFilterChange;
@@ -810,6 +926,7 @@ export function IssueDisplayControls({
   const activeFilterCount = getActiveFilterCount({
     statusFilters,
     priorityFilters,
+    propertyFilters,
     assigneeFilters,
     includeNoAssignee,
     creatorFilters,
@@ -854,8 +971,17 @@ export function IssueDisplayControls({
           : `${shortDateLabel(dateFilter.from)} - ${shortDateLabel(dateFilter.to)}`
       }`
     : null;
-  const sortLabel = t(($) => $.display[SORT_LABEL_KEY[sortBy]]);
-  const groupingLabel = t(($) => $.display[GROUPING_LABEL_KEY[grouping]]);
+  const sortPropertyId = propertyIdFromViewKey(sortBy);
+  const groupingPropertyId = propertyIdFromViewKey(grouping);
+  // Property-backed sort/grouping label straight from the definition name;
+  // a stale persisted id (archived/deleted definition) falls back to the
+  // manual/status default label.
+  const sortLabel = sortPropertyId
+    ? propertyById.get(sortPropertyId)?.name ?? t(($) => $.display.sort_manual)
+    : t(($) => $.display[SORT_LABEL_KEY[sortBy as keyof typeof SORT_LABEL_KEY]]);
+  const groupingLabel = groupingPropertyId
+    ? propertyById.get(groupingPropertyId)?.name ?? t(($) => $.display.group_status)
+    : t(($) => $.display[GROUPING_LABEL_KEY[grouping as keyof typeof GROUPING_LABEL_KEY]]);
   const swimlaneGroupingLabel = t(($) => $.display[SWIMLANE_GROUPING_LABEL_KEY[swimlaneGrouping]]);
   const controlButtonClass = "h-8 w-8 gap-1 px-0 text-muted-foreground md:h-7 md:w-auto md:px-2.5";
 
@@ -1090,6 +1216,33 @@ export function IssueDisplayControls({
               </DropdownMenuSubContent>
             </DropdownMenuSub>
 
+            {/* Custom properties — one sub per filterable definition */}
+            {filterableProperties.length > 0 && <DropdownMenuSeparator />}
+            {filterableProperties.map((property) => {
+              const selected = propertyFilters[property.id] ?? [];
+              return (
+                <DropdownMenuSub key={property.id}>
+                  <DropdownMenuSubTrigger>
+                    <SlidersHorizontal className="size-3.5" />
+                    <span className="flex-1 truncate">{property.name}</span>
+                    {selected.length > 0 && (
+                      <span className="text-xs text-primary font-medium">
+                        {selected.length}
+                      </span>
+                    )}
+                  </DropdownMenuSubTrigger>
+                  <DropdownMenuSubContent className="w-auto min-w-44 p-1">
+                    <PropertyFilterOptions
+                      property={property}
+                      counts={counts.property.get(property.id)}
+                      selected={selected}
+                      onToggle={(optionId) => act.togglePropertyFilter(property.id, optionId)}
+                    />
+                  </DropdownMenuSubContent>
+                </DropdownMenuSub>
+              );
+            })}
+
             {/* Reset */}
             {hasActiveFilters && (
               <>
@@ -1157,6 +1310,11 @@ export function IssueDisplayControls({
                             {t(($) => $.display[GROUPING_LABEL_KEY[opt.value]])}
                           </DropdownMenuRadioItem>
                         ))}
+                        {groupableProperties.map((property) => (
+                          <DropdownMenuRadioItem key={property.id} value={`property:${property.id}`}>
+                            {property.name}
+                          </DropdownMenuRadioItem>
+                        ))}
                       </DropdownMenuRadioGroup>
                     </DropdownMenuContent>
                   </DropdownMenu>
@@ -1221,7 +1379,12 @@ export function IssueDisplayControls({
                     <DropdownMenuRadioGroup value={sortBy} onValueChange={(v) => act.setSortBy(v as SortField)}>
                       {SORT_OPTIONS.map((opt) => (
                         <DropdownMenuRadioItem key={opt.value} value={opt.value}>
-                          {t(($) => $.display[SORT_LABEL_KEY[opt.value]])}
+                          {t(($) => $.display[SORT_LABEL_KEY[opt.value as keyof typeof SORT_LABEL_KEY]])}
+                        </DropdownMenuRadioItem>
+                      ))}
+                      {sortableProperties.map((property) => (
+                        <DropdownMenuRadioItem key={property.id} value={`property:${property.id}`}>
+                          {property.name}
                         </DropdownMenuRadioItem>
                       ))}
                     </DropdownMenuRadioGroup>
@@ -1270,6 +1433,19 @@ export function IssueDisplayControls({
                       size="sm"
                       checked={cardProperties[opt.key]}
                       onCheckedChange={() => act.toggleCardProperty(opt.key)}
+                    />
+                  </label>
+                ))}
+                {workspaceProperties.map((property) => (
+                  <label
+                    key={property.id}
+                    className="flex cursor-pointer items-center justify-between"
+                  >
+                    <span className="truncate text-sm">{property.name}</span>
+                    <Switch
+                      size="sm"
+                      checked={cardPropertyIds.includes(property.id)}
+                      onCheckedChange={() => act.toggleCardPropertyId(property.id)}
                     />
                   </label>
                 ))}

--- a/packages/views/issues/components/issues-page.test.tsx
+++ b/packages/views/issues/components/issues-page.test.tsx
@@ -169,6 +169,8 @@ const mockViewState = {
   projectFilters: [] as string[],
   includeNoProject: false,
   labelFilters: [] as string[],
+  propertyFilters: {} as Record<string, string[]>,
+  cardPropertyIds: [] as string[],
   sortBy: "position" as const,
   sortDirection: "asc" as const,
   cardProperties: { priority: true, description: true, assignee: true, dueDate: true, project: true, childProgress: true, labels: true },
@@ -183,6 +185,8 @@ const mockViewState = {
   toggleProjectFilter: vi.fn(),
   toggleNoProject: vi.fn(),
   toggleLabelFilter: vi.fn(),
+  togglePropertyFilter: vi.fn(),
+  toggleCardPropertyId: vi.fn(),
   hideStatus: vi.fn(),
   showStatus: vi.fn(),
   clearFilters: vi.fn(),
@@ -194,6 +198,9 @@ const mockViewState = {
 
 vi.mock("@multica/core/issues/stores/view-store", () => ({
   useClearFiltersOnWorkspaceChange: () => {},
+  PROPERTY_VIEW_PREFIX: "property:",
+  propertyIdFromViewKey: (key: string) =>
+    key.startsWith("property:") ? key.slice("property:".length) : null,
   viewStorePersistOptions: () => ({ name: "test", storage: undefined, partialize: (s: any) => s }),
   mergeViewStatePersisted: (_p: unknown, c: any) => c,
   viewStoreSlice: vi.fn(),

--- a/packages/views/issues/components/list-row.tsx
+++ b/packages/views/issues/components/list-row.tsx
@@ -5,11 +5,17 @@ import { useSortable, defaultAnimateLayoutChanges } from "@dnd-kit/sortable";
 import type { AnimateLayoutChanges } from "@dnd-kit/sortable";
 import { CSS } from "@dnd-kit/utilities";
 import { AppLink } from "../../navigation";
-import type { Issue, Project } from "@multica/core/types";
+import type { Issue, Project,
+  IssueProperty,
+} from "@multica/core/types";
 import { formatDateOnly } from "@multica/core/issues/date";
 import { ActorAvatar } from "../../common/actor-avatar";
 import { useWorkspacePaths } from "@multica/core/paths";
+import { useQuery } from "@tanstack/react-query";
 import { useViewStore } from "@multica/core/issues/stores/view-store-context";
+import { useWorkspaceId } from "@multica/core/hooks";
+import { propertyListOptions } from "@multica/core/properties";
+import { CustomPropertyValueDisplay } from "./pickers/custom-property-picker";
 import { ProjectIcon } from "../../projects/components/project-icon";
 import { PriorityIcon } from "./priority-icon";
 import { ProgressRing } from "./progress-ring";
@@ -51,6 +57,12 @@ function ListRowContent({
   const toggle = selection.toggle;
   const p = useWorkspacePaths();
   const storeProperties = useViewStore((s) => s.cardProperties);
+  const cardPropertyIds = useViewStore((s) => s.cardPropertyIds);
+  const rowWsId = useWorkspaceId();
+  const { data: workspaceProperties = [] } = useQuery(propertyListOptions(rowWsId));
+  const cardCustomProperties = cardPropertyIds
+    .map((id) => workspaceProperties.find((p) => p.id === id))
+    .filter((p): p is IssueProperty => !!p && issue.properties?.[p.id] !== undefined);
   const labels = issue.labels ?? [];
 
   const showProject = storeProperties.project && project;
@@ -118,6 +130,18 @@ function ListRowContent({
                     +{labels.length - 3}
                   </span>
                 )}
+              </span>
+            )}
+            {cardCustomProperties.length > 0 && (
+              <span className="ml-1.5 hidden md:inline-flex shrink-0 items-center gap-1 max-w-[260px] overflow-hidden">
+                {cardCustomProperties.slice(0, 3).map((property) => (
+                  <span
+                    key={property.id}
+                    className="inline-flex max-w-[120px] items-center rounded-full bg-muted/60 px-1.5 py-0.5 text-[11px] text-muted-foreground"
+                  >
+                    <CustomPropertyValueDisplay property={property} value={issue.properties?.[property.id]} />
+                  </span>
+                ))}
               </span>
             )}
           </span>

--- a/packages/views/issues/components/swimlane-view.test.tsx
+++ b/packages/views/issues/components/swimlane-view.test.tsx
@@ -163,6 +163,8 @@ const mockViewState: {
   projectFilters?: string[];
   includeNoProject?: boolean;
   labelFilters?: string[];
+  propertyFilters?: Record<string, string[]>;
+  cardPropertyIds?: string[];
   agentRunningFilter?: boolean;
 } = {
   sortBy: "position",
@@ -183,6 +185,8 @@ const mockViewState: {
   projectFilters: [],
   includeNoProject: false,
   labelFilters: [],
+  propertyFilters: {},
+  cardPropertyIds: [],
   agentRunningFilter: false,
 };
 const mockSetSwimlaneOrder = mockViewState.setSwimlaneOrder as ReturnType<typeof vi.fn>;

--- a/packages/views/issues/surface/use-issue-surface-controller.ts
+++ b/packages/views/issues/surface/use-issue-surface-controller.ts
@@ -20,7 +20,9 @@ import {
   type IssueSurfaceQueryPlan,
 } from "@multica/core/issues/surface/query-plan";
 import type { IssueScope } from "@multica/core/issues/surface/scope";
-import type { IssueDateFilter } from "@multica/core/issues/stores/view-store";
+import type { IssueDateFilter, SortField } from "@multica/core/issues/stores/view-store";
+import { sortIssues } from "../utils/sort";
+import { propertyIdFromViewKey } from "@multica/core/issues/stores/view-store";
 import { useViewStore } from "@multica/core/issues/stores/view-store-context";
 import type { IssueFilters } from "../utils/filter";
 import type { ChildProgress } from "../components/list-row";
@@ -129,6 +131,7 @@ export function useIssueSurfaceController({
   const projectFilters = useViewStore((s) => s.projectFilters);
   const includeNoProject = useViewStore((s) => s.includeNoProject);
   const labelFilters = useViewStore((s) => s.labelFilters);
+  const propertyFilters = useViewStore((s) => s.propertyFilters);
   const agentRunningFilter = useViewStore((s) => s.agentRunningFilter);
   const showSubIssues = useViewStore((s) => s.showSubIssues);
   const cardProperties = useViewStore((s) => s.cardProperties);
@@ -155,13 +158,20 @@ export function useIssueSurfaceController({
     () => issueDateFilterToApiParams(dateFilter),
     [dateFilter],
   );
+  // Custom-property sorts (`property:<id>`) are client-side only — the
+  // server sort enum is fixed, so the query falls back to position order and
+  // the surface lists re-sort below via sortIssues.
+  const propertySortId = propertyIdFromViewKey(sortBy);
   const sort = useMemo<IssueSortParam>(
     () => ({
-      sort_by: sortBy,
-      sort_direction: sortBy !== "position" ? sortDirection : undefined,
+      sort_by: propertySortId
+        ? "position"
+        : (sortBy as Exclude<SortField, `property:${string}`>),
+      sort_direction:
+        !propertySortId && sortBy !== "position" ? sortDirection : undefined,
       ...dateParams,
     }),
-    [dateParams, sortBy, sortDirection],
+    [dateParams, propertySortId, sortBy, sortDirection],
   );
 
   const selection = useCreateIssueSurfaceSelection(
@@ -198,6 +208,7 @@ export function useIssueSurfaceController({
     projectFilters: viewProjectFilters,
     includeNoProject: viewIncludeNoProject,
     labelFilters,
+    propertyFilters,
     agentRunningFilter,
     showSubIssues,
     loadProjects:
@@ -209,6 +220,26 @@ export function useIssueSurfaceController({
     createDefaults: resolvedCreateDefaults,
   });
 
+  // Client-side re-sort for property sorts (flat board/list + grouped board).
+  // Swimlane and gantt call sortIssues themselves.
+  const propertySortedIssues = useMemo(
+    () =>
+      propertySortId
+        ? sortIssues(data.issues, sortBy, sortDirection)
+        : data.issues,
+    [data.issues, propertySortId, sortBy, sortDirection],
+  );
+  const propertySortedAssigneeGroups = useMemo(
+    () =>
+      propertySortId && data.assigneeGroups
+        ? data.assigneeGroups.map((group) => ({
+            ...group,
+            issues: sortIssues(group.issues, sortBy, sortDirection),
+          }))
+        : data.assigneeGroups,
+    [data.assigneeGroups, propertySortId, sortBy, sortDirection],
+  );
+
   return {
     scopeKey,
     projectId,
@@ -216,6 +247,8 @@ export function useIssueSurfaceController({
     viewMode: effectiveViewMode,
     allowGantt: allowedModes.has("gantt") && !!projectId,
     ...data,
+    issues: propertySortedIssues,
+    assigneeGroups: propertySortedAssigneeGroups,
     sort,
     actions,
     selection,

--- a/packages/views/issues/surface/use-issue-surface-controller.ts
+++ b/packages/views/issues/surface/use-issue-surface-controller.ts
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useMemo } from "react";
+import { useQuery } from "@tanstack/react-query";
 import type { QueryKey } from "@tanstack/react-query";
 import type {
   Issue,
@@ -22,6 +23,7 @@ import {
 import type { IssueScope } from "@multica/core/issues/surface/scope";
 import type { IssueDateFilter, SortField } from "@multica/core/issues/stores/view-store";
 import { sortIssues } from "../utils/sort";
+import { propertyListOptions } from "@multica/core/properties";
 import { propertyIdFromViewKey } from "@multica/core/issues/stores/view-store";
 import { useViewStore } from "@multica/core/issues/stores/view-store-context";
 import type { IssueFilters } from "../utils/filter";
@@ -158,10 +160,29 @@ export function useIssueSurfaceController({
     () => issueDateFilterToApiParams(dateFilter),
     [dateFilter],
   );
+  // Active property catalog. Persisted view state can outlive definitions
+  // (archive/delete): filters keyed by a non-active definition are stripped
+  // before they reach the predicates, and a sort on a non-active definition
+  // degrades to manual order — matching what the header already shows.
+  const { data: workspaceProperties = [] } = useQuery(propertyListOptions(wsId));
+  const activePropertyIds = useMemo(
+    () => new Set(workspaceProperties.map((p) => p.id)),
+    [workspaceProperties],
+  );
+  const effectivePropertyFilters = useMemo(() => {
+    const entries = Object.entries(propertyFilters).filter(
+      ([propertyId, selected]) => selected.length > 0 && activePropertyIds.has(propertyId),
+    );
+    if (entries.length === Object.keys(propertyFilters).length) return propertyFilters;
+    return Object.fromEntries(entries);
+  }, [activePropertyIds, propertyFilters]);
+
   // Custom-property sorts (`property:<id>`) are client-side only — the
   // server sort enum is fixed, so the query falls back to position order and
   // the surface lists re-sort below via sortIssues.
-  const propertySortId = propertyIdFromViewKey(sortBy);
+  const rawPropertySortId = propertyIdFromViewKey(sortBy);
+  const propertySortId =
+    rawPropertySortId && activePropertyIds.has(rawPropertySortId) ? rawPropertySortId : null;
   const sort = useMemo<IssueSortParam>(
     () => ({
       sort_by: propertySortId
@@ -208,7 +229,7 @@ export function useIssueSurfaceController({
     projectFilters: viewProjectFilters,
     includeNoProject: viewIncludeNoProject,
     labelFilters,
-    propertyFilters,
+    propertyFilters: effectivePropertyFilters,
     agentRunningFilter,
     showSubIssues,
     loadProjects:
@@ -225,19 +246,19 @@ export function useIssueSurfaceController({
   const propertySortedIssues = useMemo(
     () =>
       propertySortId
-        ? sortIssues(data.issues, sortBy, sortDirection)
+        ? sortIssues(data.issues, `property:${propertySortId}`, sortDirection)
         : data.issues,
-    [data.issues, propertySortId, sortBy, sortDirection],
+    [data.issues, propertySortId, sortDirection],
   );
   const propertySortedAssigneeGroups = useMemo(
     () =>
       propertySortId && data.assigneeGroups
         ? data.assigneeGroups.map((group) => ({
             ...group,
-            issues: sortIssues(group.issues, sortBy, sortDirection),
+            issues: sortIssues(group.issues, `property:${propertySortId}`, sortDirection),
           }))
         : data.assigneeGroups,
-    [data.assigneeGroups, propertySortId, sortBy, sortDirection],
+    [data.assigneeGroups, propertySortId, sortDirection],
   );
 
   return {

--- a/packages/views/issues/surface/use-issue-surface-data.ts
+++ b/packages/views/issues/surface/use-issue-surface-data.ts
@@ -77,6 +77,7 @@ export function useIssueSurfaceData({
   projectFilters,
   includeNoProject,
   labelFilters,
+  propertyFilters,
   agentRunningFilter,
   showSubIssues,
   loadProjects,
@@ -95,6 +96,7 @@ export function useIssueSurfaceData({
   projectFilters: string[];
   includeNoProject: boolean;
   labelFilters: string[];
+  propertyFilters: Record<string, string[]>;
   agentRunningFilter: boolean;
   showSubIssues: boolean;
   loadProjects: boolean;
@@ -174,6 +176,7 @@ export function useIssueSurfaceData({
       projectFilters,
       includeNoProject,
       labelFilters,
+      propertyFilters,
       workingOnly: agentRunningFilter,
       showSubIssues,
     }),
@@ -186,6 +189,7 @@ export function useIssueSurfaceData({
       labelFilters,
       priorityFilters,
       projectFilters,
+      propertyFilters,
       showSubIssues,
       statusFilters,
     ],
@@ -223,11 +227,13 @@ export function useIssueSurfaceData({
         showSubIssues,
         agentRunningFilter,
         runningIssueIds: activity.runningIssueIds,
+        propertyFilters,
       }),
     [
       activity.runningIssueIds,
       agentRunningFilter,
       assigneeGroupsQuery.data?.groups,
+      propertyFilters,
       showSubIssues,
     ],
   );
@@ -271,6 +277,7 @@ export function useIssueSurfaceData({
       projectFilters,
       includeNoProject,
       labelFilters,
+      propertyFilters,
       agentRunningFilter,
       showSubIssues,
     }),
@@ -281,6 +288,7 @@ export function useIssueSurfaceData({
       includeNoAssignee,
       includeNoProject,
       labelFilters,
+      propertyFilters,
       priorityFilters,
       projectFilters,
       showSubIssues,

--- a/packages/views/issues/utils/drag-utils.test.ts
+++ b/packages/views/issues/utils/drag-utils.test.ts
@@ -94,6 +94,18 @@ describe("property grouping", () => {
     expect(issueMatchesGroup(withoutValue, noneColumn)).toBe(true);
   });
 
+  it("unknown option values bucket into the none column when the catalog is known", () => {
+    const stale = { id: "C", properties: { [propertyId]: "opt-deleted" } } as unknown as Issue;
+    const known = new Set(["opt-staging"]);
+    expect(getIssueGroupId(stale, `property:${propertyId}`, known)).toBe(
+      propertyGroupId(propertyId, null),
+    );
+    // Without the catalog, the raw bucket is preserved (caller may still map it).
+    expect(getIssueGroupId(stale, `property:${propertyId}`)).toBe(
+      propertyGroupId(propertyId, "opt-deleted"),
+    );
+  });
+
   it("getMoveUpdates for property columns only carries position", () => {
     expect(getMoveUpdates({ id: "c1", title: "Staging", propertyId, propertyOptionId: "opt-staging" }, 5)).toEqual({ position: 5 });
   });

--- a/packages/views/issues/utils/drag-utils.test.ts
+++ b/packages/views/issues/utils/drag-utils.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 import type { Issue } from "@multica/core/types";
-import { insertIdByPosition } from "./drag-utils";
+import { getIssueGroupId, getMoveUpdates, insertIdByPosition, issueMatchesGroup, propertyGroupId } from "./drag-utils";
 
 function mk(id: string, position: number): Issue {
   return {
@@ -69,5 +69,32 @@ describe("insertIdByPosition", () => {
       "moved",
       "y",
     ]);
+  });
+});
+
+describe("property grouping", () => {
+  const propertyId = "prop-env";
+  const withValue = { id: "A", properties: { [propertyId]: "opt-staging" } } as unknown as Issue;
+  const withoutValue = { id: "B", properties: {} } as unknown as Issue;
+
+  it("getIssueGroupId buckets by option id, no-value issues into the none column", () => {
+    expect(getIssueGroupId(withValue, `property:${propertyId}`)).toBe(
+      propertyGroupId(propertyId, "opt-staging"),
+    );
+    expect(getIssueGroupId(withoutValue, `property:${propertyId}`)).toBe(
+      propertyGroupId(propertyId, null),
+    );
+  });
+
+  it("issueMatchesGroup distinguishes option and no-value columns", () => {
+    const optionColumn = { id: "c1", title: "Staging", propertyId, propertyOptionId: "opt-staging" };
+    const noneColumn = { id: "c2", title: "No value", propertyId, propertyOptionId: null };
+    expect(issueMatchesGroup(withValue, optionColumn)).toBe(true);
+    expect(issueMatchesGroup(withValue, noneColumn)).toBe(false);
+    expect(issueMatchesGroup(withoutValue, noneColumn)).toBe(true);
+  });
+
+  it("getMoveUpdates for property columns only carries position", () => {
+    expect(getMoveUpdates({ id: "c1", title: "Staging", propertyId, propertyOptionId: "opt-staging" }, 5)).toEqual({ position: 5 });
   });
 });

--- a/packages/views/issues/utils/drag-utils.ts
+++ b/packages/views/issues/utils/drag-utils.ts
@@ -42,12 +42,24 @@ export function assigneeGroupId(
   return type && id ? `assignee:${type}:${id}` : UNASSIGNED_GROUP_ID;
 }
 
-export function getIssueGroupId(issue: Issue, grouping: IssueGrouping): string {
+export function getIssueGroupId(
+  issue: Issue,
+  grouping: IssueGrouping,
+  knownOptionIds?: ReadonlySet<string>,
+): string {
   if (grouping === "status") return statusGroupId(issue.status);
   const propertyId = propertyIdFromViewKey(grouping);
   if (propertyId) {
     const value = issue.properties?.[propertyId];
-    return propertyGroupId(propertyId, typeof value === "string" ? value : null);
+    let optionId = typeof value === "string" ? value : null;
+    // A value referencing an option no longer in the definition (removed
+    // before the in-use guard existed, or by a newer server) must bucket
+    // into the No-value column — an unmatched column id would silently drop
+    // the issue from the board.
+    if (optionId !== null && knownOptionIds && !knownOptionIds.has(optionId)) {
+      optionId = null;
+    }
+    return propertyGroupId(propertyId, optionId);
   }
   return assigneeGroupId(issue.assignee_type, issue.assignee_id);
 }
@@ -56,11 +68,12 @@ export function buildColumns(
   issues: Issue[],
   groups: BoardColumnGroup[],
   grouping: IssueGrouping,
+  knownOptionIds?: ReadonlySet<string>,
 ): Record<string, string[]> {
   const cols: Record<string, string[]> = {};
   for (const group of groups) cols[group.id] = [];
   for (const issue of issues) {
-    const gid = getIssueGroupId(issue, grouping);
+    const gid = getIssueGroupId(issue, grouping, knownOptionIds);
     if (cols[gid]) cols[gid].push(issue.id);
   }
   return cols;

--- a/packages/views/issues/utils/drag-utils.ts
+++ b/packages/views/issues/utils/drag-utils.ts
@@ -5,6 +5,7 @@ import {
 } from "@dnd-kit/core";
 import type { Issue, IssueAssigneeType, IssueStatus, UpdateIssueRequest } from "@multica/core/types";
 import type { IssueGrouping } from "@multica/core/issues/stores/view-store";
+import { propertyIdFromViewKey } from "@multica/core/issues/stores/view-store";
 import type { BoardColumnGroup } from "../components/board-column";
 
 export type DragMoveUpdates = Pick<
@@ -30,6 +31,10 @@ export function statusGroupId(status: IssueStatus): string {
   return `status:${status}`;
 }
 
+export function propertyGroupId(propertyId: string, optionId: string | null): string {
+  return `property:${propertyId}:${optionId ?? "none"}`;
+}
+
 export function assigneeGroupId(
   type: IssueAssigneeType | null,
   id: string | null,
@@ -39,6 +44,11 @@ export function assigneeGroupId(
 
 export function getIssueGroupId(issue: Issue, grouping: IssueGrouping): string {
   if (grouping === "status") return statusGroupId(issue.status);
+  const propertyId = propertyIdFromViewKey(grouping);
+  if (propertyId) {
+    const value = issue.properties?.[propertyId];
+    return propertyGroupId(propertyId, typeof value === "string" ? value : null);
+  }
   return assigneeGroupId(issue.assignee_type, issue.assignee_id);
 }
 
@@ -101,6 +111,11 @@ export function findColumn(
 
 export function issueMatchesGroup(issue: Issue, group: BoardColumnGroup): boolean {
   if (group.status) return issue.status === group.status;
+  if (group.propertyId !== undefined) {
+    const value = issue.properties?.[group.propertyId];
+    const optionId = typeof value === "string" ? value : null;
+    return optionId === (group.propertyOptionId ?? null);
+  }
   return (
     (issue.assignee_type ?? null) === (group.assigneeType ?? null) &&
     (issue.assignee_id ?? null) === (group.assigneeId ?? null)
@@ -112,6 +127,9 @@ export function getMoveUpdates(
   position: number,
 ): DragMoveUpdates {
   if (group.status) return { status: group.status, position };
+  // Property columns: the value change is not part of UpdateIssueRequest —
+  // the board applies it through useSetIssueProperty after the position move.
+  if (group.propertyId !== undefined) return { position };
   return {
     assignee_type: group.assigneeType ?? null,
     assignee_id: group.assigneeId ?? null,

--- a/packages/views/issues/utils/filter.test.ts
+++ b/packages/views/issues/utils/filter.test.ts
@@ -384,3 +384,72 @@ describe("filterAssigneeGroups", () => {
     expect(result).toEqual([]);
   });
 });
+
+describe("property filters", () => {
+  const sevId = "prop-severity";
+  const platId = "prop-platforms";
+  const doneId = "prop-done";
+  const critical = makeIssue({ id: "P1", properties: { [sevId]: "opt-critical" } });
+  const minor = makeIssue({ id: "P2", properties: { [sevId]: "opt-minor", [platId]: ["opt-ios", "opt-web"] } });
+  const unset = makeIssue({ id: "P3" });
+  const checked = makeIssue({ id: "P4", properties: { [doneId]: true } });
+
+  it("select values match by option id (OR within the definition)", () => {
+    const result = filterIssues([critical, minor, unset], {
+      ...NO_FILTER,
+      propertyFilters: { [sevId]: ["opt-critical", "opt-minor"] },
+    });
+    expect(result.map((i) => i.id)).toEqual(["P1", "P2"]);
+  });
+
+  it("issues without a value never match a filtered definition", () => {
+    const result = filterIssues([critical, unset], {
+      ...NO_FILTER,
+      propertyFilters: { [sevId]: ["opt-critical"] },
+    });
+    expect(result.map((i) => i.id)).toEqual(["P1"]);
+  });
+
+  it("multi_select matches on intersection", () => {
+    const result = filterIssues([critical, minor], {
+      ...NO_FILTER,
+      propertyFilters: { [platId]: ["opt-web"] },
+    });
+    expect(result.map((i) => i.id)).toEqual(["P2"]);
+  });
+
+  it("checkbox values match the true/false pseudo-options", () => {
+    const result = filterIssues([checked, unset], {
+      ...NO_FILTER,
+      propertyFilters: { [doneId]: ["true"] },
+    });
+    expect(result.map((i) => i.id)).toEqual(["P4"]);
+  });
+
+  it("ANDs across definitions", () => {
+    const result = filterIssues([critical, minor], {
+      ...NO_FILTER,
+      propertyFilters: { [sevId]: ["opt-minor"], [platId]: ["opt-ios"] },
+    });
+    expect(result.map((i) => i.id)).toEqual(["P2"]);
+  });
+
+  it("empty selections are inert", () => {
+    const result = filterIssues([critical, minor, unset], {
+      ...NO_FILTER,
+      propertyFilters: { [sevId]: [] },
+    });
+    expect(result).toHaveLength(3);
+  });
+
+  it("filterAssigneeGroups applies property filters per group", () => {
+    const groups: IssueAssigneeGroup[] = [
+      { id: "assignee:member:u-1", assignee_type: "member", assignee_id: "u-1", issues: [critical, minor], total: 2 },
+    ];
+    const result = filterAssigneeGroups(groups, {
+      propertyFilters: { [sevId]: ["opt-critical"] },
+    });
+    expect(result?.[0]?.issues.map((i) => i.id)).toEqual(["P1"]);
+    expect(result?.[0]?.total).toBe(1);
+  });
+});

--- a/packages/views/issues/utils/filter.ts
+++ b/packages/views/issues/utils/filter.ts
@@ -11,6 +11,9 @@ export interface IssueFilters {
   projectFilters: string[];
   includeNoProject: boolean;
   labelFilters: string[];
+  /** Custom-property filters: definition id → selected option ids (OR within
+   *  a definition, AND across definitions; checkbox uses "true"/"false"). */
+  propertyFilters?: Record<string, string[]>;
   // When `agentRunningFilter` is true, only keep issues whose id is in
   // `runningIssueIds`. The set is derived by the caller from
   // `agentTaskSnapshot` (one pass over running tasks) so filter.ts stays
@@ -33,6 +36,7 @@ export interface IssueFilterState {
   projectFilters: string[];
   includeNoProject: boolean;
   labelFilters: string[];
+  propertyFilters?: Record<string, string[]>;
   workingOnly: boolean;
   /** See IssueFilters.showSubIssues — only an explicit `false` hides. */
   showSubIssues?: boolean;
@@ -41,6 +45,34 @@ export interface IssueFilterState {
 export interface IssueFilterContext {
   activityByIssueId?: ReadonlyMap<string, IssueActivityState>;
   runningIssueIds?: ReadonlySet<string>;
+}
+
+/**
+ * Match one issue against the property filters. Select values are single
+ * option-id strings, multi_select values are option-id arrays, checkbox
+ * values are booleans compared against the "true"/"false" pseudo-options.
+ * An issue with no value for a filtered definition never matches it.
+ */
+export function issueMatchesPropertyFilters(
+  issue: Issue,
+  propertyFilters: Record<string, string[]> | undefined,
+): boolean {
+  if (!propertyFilters) return true;
+  for (const [propertyId, selected] of Object.entries(propertyFilters)) {
+    if (selected.length === 0) continue;
+    const value = issue.properties?.[propertyId];
+    if (value === undefined) return false;
+    if (typeof value === "string") {
+      if (!selected.includes(value)) return false;
+    } else if (Array.isArray(value)) {
+      if (!value.some((id) => selected.includes(id))) return false;
+    } else if (typeof value === "boolean") {
+      if (!selected.includes(String(value))) return false;
+    } else {
+      return false;
+    }
+  }
+  return true;
 }
 
 function issueIsWorking(issueId: string, context: IssueFilterContext) {
@@ -128,6 +160,8 @@ export function applyIssueFilters(
       if (!issueLabels.some((l) => labelFilters.includes(l.id))) return false;
     }
 
+    if (!issueMatchesPropertyFilters(issue, filters.propertyFilters)) return false;
+
     return true;
   });
 }
@@ -144,6 +178,7 @@ export function filterIssues(issues: Issue[], filters: IssueFilters): Issue[] {
       projectFilters: filters.projectFilters,
       includeNoProject: filters.includeNoProject,
       labelFilters: filters.labelFilters,
+      propertyFilters: filters.propertyFilters,
       workingOnly: filters.agentRunningFilter === true,
       showSubIssues: filters.showSubIssues,
     },
@@ -165,11 +200,15 @@ export function filterAssigneeGroups(
     showSubIssues?: boolean;
     agentRunningFilter?: boolean;
     runningIssueIds?: ReadonlySet<string>;
+    propertyFilters?: Record<string, string[]>;
   },
 ): IssueAssigneeGroup[] | undefined {
   const applyRunning = filters.agentRunningFilter === true;
   const hideSubIssues = filters.showSubIssues === false;
-  if (!groups || (!applyRunning && !hideSubIssues)) return groups;
+  const hasPropertyFilters = Object.values(filters.propertyFilters ?? {}).some(
+    (selected) => selected.length > 0,
+  );
+  if (!groups || (!applyRunning && !hideSubIssues && !hasPropertyFilters)) return groups;
 
   const { runningIssueIds } = filters;
   return groups
@@ -178,6 +217,8 @@ export function filterAssigneeGroups(
         if (applyRunning && !(runningIssueIds?.has(issue.id) ?? false))
           return false;
         if (hideSubIssues && issue.parent_issue_id) return false;
+        if (hasPropertyFilters && !issueMatchesPropertyFilters(issue, filters.propertyFilters))
+          return false;
         return true;
       });
       return { ...group, issues, total: issues.length };

--- a/packages/views/issues/utils/sort.test.ts
+++ b/packages/views/issues/utils/sort.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from "vitest";
+import type { Issue } from "@multica/core/types";
+import { sortIssues } from "./sort";
+
+const propertyId = "prop-effort";
+
+function issueWith(id: string, value?: number | string, position = 0): Issue {
+  return {
+    id,
+    position,
+    properties: value === undefined ? {} : { [propertyId]: value },
+  } as unknown as Issue;
+}
+
+describe("sortIssues property sorts", () => {
+  it("sorts number values numerically, missing values last", () => {
+    const sorted = sortIssues(
+      [issueWith("big", 10), issueWith("none"), issueWith("small", 2)],
+      `property:${propertyId}`,
+      "asc",
+    );
+    expect(sorted.map((i) => i.id)).toEqual(["small", "big", "none"]);
+  });
+
+  it("desc reverses values but keeps semantics", () => {
+    const sorted = sortIssues(
+      [issueWith("small", 2), issueWith("big", 10)],
+      `property:${propertyId}`,
+      "desc",
+    );
+    expect(sorted.map((i) => i.id)).toEqual(["big", "small"]);
+  });
+
+  it("sorts date-only strings chronologically via lexical compare", () => {
+    const sorted = sortIssues(
+      [issueWith("later", "2026-08-01"), issueWith("earlier", "2026-07-13")],
+      `property:${propertyId}`,
+      "asc",
+    );
+    expect(sorted.map((i) => i.id)).toEqual(["earlier", "later"]);
+  });
+
+  it("falls back to position order for the static fields", () => {
+    const sorted = sortIssues(
+      [issueWith("b", undefined, 2), issueWith("a", undefined, 1)],
+      "position",
+      "asc",
+    );
+    expect(sorted.map((i) => i.id)).toEqual(["a", "b"]);
+  });
+});

--- a/packages/views/issues/utils/sort.test.ts
+++ b/packages/views/issues/utils/sort.test.ts
@@ -22,13 +22,13 @@ describe("sortIssues property sorts", () => {
     expect(sorted.map((i) => i.id)).toEqual(["small", "big", "none"]);
   });
 
-  it("desc reverses values but keeps semantics", () => {
+  it("desc reverses values but keeps missing values last", () => {
     const sorted = sortIssues(
-      [issueWith("small", 2), issueWith("big", 10)],
+      [issueWith("none"), issueWith("small", 2), issueWith("big", 10)],
       `property:${propertyId}`,
       "desc",
     );
-    expect(sorted.map((i) => i.id)).toEqual(["big", "small"]);
+    expect(sorted.map((i) => i.id)).toEqual(["big", "small", "none"]);
   });
 
   it("sorts date-only strings chronologically via lexical compare", () => {

--- a/packages/views/issues/utils/sort.ts
+++ b/packages/views/issues/utils/sort.ts
@@ -1,6 +1,7 @@
 import type { Issue } from "@multica/core/types";
 import { PRIORITY_ORDER } from "@multica/core/issues/config";
 import type { SortField, SortDirection } from "@multica/core/issues/stores/view-store";
+import { propertyIdFromViewKey } from "@multica/core/issues/stores/view-store";
 
 const PRIORITY_RANK: Record<string, number> = Object.fromEntries(
   PRIORITY_ORDER.map((p, i) => [p, i])
@@ -11,6 +12,16 @@ export function sortIssues(
   field: SortField,
   direction: SortDirection
 ): Issue[] {
+  // `property:<id>` sorts by the custom-property value. Number values sort
+  // numerically; date values are date-only "YYYY-MM-DD" strings, which sort
+  // correctly lexically. Issues without a value always sort last regardless
+  // of direction (matching start_date/due_date semantics).
+  const propertyId = propertyIdFromViewKey(field);
+  if (propertyId) {
+    const sorted = issues.toSorted((a, b) => comparePropertyValues(a, b, propertyId));
+    return direction === "desc" ? sorted.reverse() : sorted;
+  }
+
   const sorted = issues.toSorted((a, b) => {
     switch (field) {
       case "priority":
@@ -46,4 +57,16 @@ export function sortIssues(
     }
   });
   return direction === "desc" ? sorted.reverse() : sorted;
+}
+
+function comparePropertyValues(a: Issue, b: Issue, propertyId: string): number {
+  const av = a.properties?.[propertyId];
+  const bv = b.properties?.[propertyId];
+  const aMissing = av === undefined || Array.isArray(av);
+  const bMissing = bv === undefined || Array.isArray(bv);
+  if (aMissing && bMissing) return 0;
+  if (aMissing) return 1;
+  if (bMissing) return -1;
+  if (typeof av === "number" && typeof bv === "number") return av - bv;
+  return String(av).localeCompare(String(bv));
 }

--- a/packages/views/issues/utils/sort.ts
+++ b/packages/views/issues/utils/sort.ts
@@ -14,12 +14,23 @@ export function sortIssues(
 ): Issue[] {
   // `property:<id>` sorts by the custom-property value. Number values sort
   // numerically; date values are date-only "YYYY-MM-DD" strings, which sort
-  // correctly lexically. Issues without a value always sort last regardless
-  // of direction (matching start_date/due_date semantics).
+  // correctly lexically. Direction applies to the VALUE comparison only —
+  // issues without a value sort last in both directions (a whole-array
+  // reverse would flip them to the front on desc).
   const propertyId = propertyIdFromViewKey(field);
   if (propertyId) {
-    const sorted = issues.toSorted((a, b) => comparePropertyValues(a, b, propertyId));
-    return direction === "desc" ? sorted.reverse() : sorted;
+    const dir = direction === "desc" ? -1 : 1;
+    return issues.toSorted((a, b) => {
+      const av = a.properties?.[propertyId];
+      const bv = b.properties?.[propertyId];
+      const aMissing = av === undefined || Array.isArray(av);
+      const bMissing = bv === undefined || Array.isArray(bv);
+      if (aMissing && bMissing) return 0;
+      if (aMissing) return 1;
+      if (bMissing) return -1;
+      if (typeof av === "number" && typeof bv === "number") return dir * (av - bv);
+      return dir * String(av).localeCompare(String(bv));
+    });
   }
 
   const sorted = issues.toSorted((a, b) => {
@@ -57,16 +68,4 @@ export function sortIssues(
     }
   });
   return direction === "desc" ? sorted.reverse() : sorted;
-}
-
-function comparePropertyValues(a: Issue, b: Issue, propertyId: string): number {
-  const av = a.properties?.[propertyId];
-  const bv = b.properties?.[propertyId];
-  const aMissing = av === undefined || Array.isArray(av);
-  const bMissing = bv === undefined || Array.isArray(bv);
-  if (aMissing && bMissing) return 0;
-  if (aMissing) return 1;
-  if (bMissing) return -1;
-  if (typeof av === "number" && typeof bv === "number") return av - bv;
-  return String(av).localeCompare(String(bv));
 }

--- a/packages/views/locales/en/issues.json
+++ b/packages/views/locales/en/issues.json
@@ -156,6 +156,7 @@
     "add_issue_tooltip": "Add issue",
     "empty_column": "No issues",
     "empty_grouping": "No matching issues",
+    "no_value": "No value",
     "ordered_by": "Board ordered by {{field}}"
   },
   "detail": {

--- a/packages/views/locales/ja/issues.json
+++ b/packages/views/locales/ja/issues.json
@@ -154,6 +154,7 @@
     "add_issue_tooltip": "イシューを追加",
     "empty_column": "イシューなし",
     "empty_grouping": "一致するイシューがありません",
+    "no_value": "値なし",
     "ordered_by": "{{field}} 順に並べたボード"
   },
   "detail": {

--- a/packages/views/locales/ko/issues.json
+++ b/packages/views/locales/ko/issues.json
@@ -154,6 +154,7 @@
     "add_issue_tooltip": "이슈 추가",
     "empty_column": "이슈 없음",
     "empty_grouping": "일치하는 이슈가 없습니다",
+    "no_value": "값 없음",
     "ordered_by": "{{field}} 기준으로 정렬된 보드"
   },
   "detail": {

--- a/packages/views/locales/zh-Hans/issues.json
+++ b/packages/views/locales/zh-Hans/issues.json
@@ -154,6 +154,7 @@
     "add_issue_tooltip": "新建 issue",
     "empty_column": "无 issue",
     "empty_grouping": "没有匹配的 issue",
+    "no_value": "未设置",
     "ordered_by": "按{{field}}排序"
   },
   "detail": {


### PR DESCRIPTION
Stacked on #5335 (M1 core — merge that first; this PR's base is `agent/lambda/768b92e0` and should be retargeted to `main` after M1 lands).

Brings custom properties to the issue **list surfaces** — the M2 batch deferred from M1.

## What ships

- **Filter**: each filterable definition (select / multi_select / checkbox) gets its own section in the Filter dropdown — option checkboxes with color dots and live counts, checkbox definitions as Yes/No. OR within a definition, AND across definitions. Wired into the active-filter badge, Clear all, `applyIssueFilters` (flat board/list/swimlane/gantt) and `filterAssigneeGroups` (assignee-grouped board).
- **Cards**: Display options gains a per-property toggle list; enabled properties render value chips on board cards and list rows (reusing `CustomPropertyValueDisplay` — colored options, multi-select chips, dates, ✓, links).
- **Sort**: number/date definitions appear in the sort menu as `property:<id>`. The server sort enum is untouched — the query falls back to position order and the surface controller re-sorts client-side; swimlane/gantt reuse the same comparator. Date-only values compare lexically (ISO), missing values sort last in both directions.
- **Board grouping**: select definitions appear in the grouping menu. Columns = the definition's options in order, plus a trailing **No value** column, with option-colored headings. Drag between columns sets/unsets the property (via the optimistic `useSetIssueProperty` path — `properties` is deliberately not part of `UpdateIssueRequest`) while position moves keep using `UpdateIssue`.
- **Resilience**: persisted view state from before this change deep-merges defaults for the new fields; a persisted `property:<id>` grouping/sort whose definition was archived or deleted falls back to status columns / manual order instead of rendering a broken board.

## Verification

- New tests: property filter matrix in `filter.test.ts` (select/multi/checkbox/AND/missing-value/assignee-groups), property grouping in `drag-utils.test.ts` (bucketing, matching, move-updates), new `sort.test.ts` (numeric, date-lexical, missing-last, desc). Updated the view-store mocks in `issues-page.test.tsx` / `swimlane-view.test.tsx`.
- `pnpm typecheck` 6/6 · views suite **184 files / 1864 tests green** · core suite unchanged (8 pre-existing env failures only) · locale parity green (en/zh-Hans/ja/ko) · lint zero errors.
- Exercised live against the local stack: filter sections with counts, Severity board grouping with drag-to-set (screenshots on MUL-4463).

## Still deferred (M2.5+)

`actor` property type, project `applies_to`, batch set via the toolbar, mobile read-only parity, and server-side property sort/filter params (client-side is fine at current scale; the seams are marked).

Part of MUL-4463.
