### PR TITLE
MUL-4479: harden v0.3.44 release migrations

### DIFF
--- a/docs/feature-flags.md
+++ b/docs/feature-flags.md
@@ -179,6 +179,30 @@ function Checkout() {
 
 Outside a `FeatureFlagsProvider` (Storybook, unit tests, error pages) `useFlag` / `useVariant` return the supplied default. You never have to mount the provider just to render a component in isolation.
 
+### v0.3.44 compatibility rollout
+
+The following release flags default to `false` so the schema can ship before
+the new persisted states are visible to older server pods or a rollback:
+
+```yaml
+# Enable only after every v0.3.43 server pod has drained and rollback reads
+# have been validated against the migrated database.
+agents_agent_builder:
+  default: true
+settings_resource_labels:
+  default: true
+agents_skill_toggles:
+  default: true
+```
+
+Keep all three off for v0.3.44: it is a schema-only deployment for these
+features. A later rollout may enable them only after it ships and verifies a
+rollback normalizer for builder agents, resource-label rows, and disabled
+skill rows. Do not rely on turning the flags off to make a database safe for
+an older binary; it prevents new writes but cannot remove states that already
+exist. Until that normalizer exists, rollbacks must target a version that
+understands these states or happen before any of the flags is enabled.
+
 ### Security note: never rely on the frontend alone
 
 A frontend feature flag controls what the user *sees*. It does NOT enforce access. Any API route exposing the same capability MUST evaluate the matching backend flag independently. The two flags can share a key but they live in two `Service` instances and the backend value is the source of truth.

--- a/packages/core/feature-flags/index.ts
+++ b/packages/core/feature-flags/index.ts
@@ -17,7 +17,12 @@ export type {
 export { FeatureFlagService } from "./service";
 export { StaticProvider } from "./static-provider";
 export { ChainProvider } from "./chain-provider";
-export { COMPOSIO_MCP_APPS_FLAG } from "./keys";
+export {
+  AGENT_BUILDER_FLAG,
+  AGENT_SKILL_TOGGLES_FLAG,
+  COMPOSIO_MCP_APPS_FLAG,
+  RESOURCE_LABELS_FLAG,
+} from "./keys";
 export {
   FeatureFlagsProvider,
   useFeatureFlagService,

--- a/packages/core/feature-flags/keys.ts
+++ b/packages/core/feature-flags/keys.ts
@@ -1,1 +1,4 @@
 export const COMPOSIO_MCP_APPS_FLAG = "composio_mcp_apps";
+export const AGENT_BUILDER_FLAG = "agents_agent_builder";
+export const RESOURCE_LABELS_FLAG = "settings_resource_labels";
+export const AGENT_SKILL_TOGGLES_FLAG = "agents_skill_toggles";

--- a/packages/views/agents/components/agent-creation-studio.tsx
+++ b/packages/views/agents/components/agent-creation-studio.tsx
@@ -15,6 +15,8 @@ import {
 import { toast } from "sonner";
 import { api } from "@multica/core/api";
 import { useAuthStore } from "@multica/core/auth";
+import { useFeatureEnabled } from "@multica/core/config";
+import { AGENT_BUILDER_FLAG } from "@multica/core/feature-flags";
 import {
   agentTemplateDetailOptions,
   agentTemplateListOptions,
@@ -117,6 +119,7 @@ export function AgentCreationStudio() {
   const navigation = useNavigation();
   const qc = useQueryClient();
   const currentUser = useAuthStore((state) => state.user);
+  const agentBuilderEnabled = useFeatureEnabled(AGENT_BUILDER_FLAG, false);
   const duplicateId = navigation.searchParams.get("duplicate");
   const squadId = navigation.searchParams.get("squad");
 
@@ -660,6 +663,7 @@ export function AgentCreationStudio() {
         <ModeChooser
           onBlank={chooseBlank}
           onAI={() => setMode("ai")}
+          agentBuilderEnabled={agentBuilderEnabled}
         />
       )}
 
@@ -771,9 +775,11 @@ export function AgentCreationStudio() {
 function ModeChooser({
   onBlank,
   onAI,
+  agentBuilderEnabled,
 }: {
   onBlank: () => void;
   onAI: () => void;
+  agentBuilderEnabled: boolean;
 }) {
   const { t } = useT("agents");
   const modes = [
@@ -783,13 +789,15 @@ function ModeChooser({
       description: t(($) => $.creation_studio.modes.blank.description),
       action: onBlank,
     },
-    {
-      icon: MessageSquare,
-      title: t(($) => $.creation_studio.modes.ai.title),
-      description: t(($) => $.creation_studio.modes.ai.description),
-      action: onAI,
-      recommended: true,
-    },
+    ...(agentBuilderEnabled
+      ? [{
+          icon: MessageSquare,
+          title: t(($) => $.creation_studio.modes.ai.title),
+          description: t(($) => $.creation_studio.modes.ai.description),
+          action: onAI,
+          recommended: true,
+        }]
+      : []),
   ];
   return (
     <main className="flex min-h-0 flex-1 items-center justify-center overflow-y-auto px-5 py-10">

--- a/packages/views/agents/components/tabs/skills-tab.test.tsx
+++ b/packages/views/agents/components/tabs/skills-tab.test.tsx
@@ -6,6 +6,8 @@ import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import type { Agent, AgentRuntime } from "@multica/core/types";
 import { I18nProvider } from "@multica/core/i18n/react";
+import { configStore } from "@multica/core/config";
+import { AGENT_SKILL_TOGGLES_FLAG } from "@multica/core/feature-flags";
 import enCommon from "../../../locales/en/common.json";
 import enAgents from "../../../locales/en/agents.json";
 
@@ -132,7 +134,8 @@ function renderSkillsTab(
 
 describe("SkillsTab", () => {
   beforeEach(() => {
-    vi.clearAllMocks();
+	vi.clearAllMocks();
+	configStore.getState().setFeatureFlags({ [AGENT_SKILL_TOGGLES_FLAG]: true });
     mockListSkills.mockResolvedValue([]);
     mockSetAgentSkillEnabled.mockResolvedValue(undefined);
     mockRemoveAgentSkill.mockResolvedValue(undefined);

--- a/packages/views/agents/components/tabs/skills-tab.tsx
+++ b/packages/views/agents/components/tabs/skills-tab.tsx
@@ -17,6 +17,8 @@ import type {
   RuntimeLocalSkillSummary,
 } from "@multica/core/types";
 import { api, ApiError } from "@multica/core/api";
+import { useFeatureEnabled } from "@multica/core/config";
+import { AGENT_SKILL_TOGGLES_FLAG } from "@multica/core/feature-flags";
 import { useWorkspaceId } from "@multica/core/hooks";
 import { runtimeCapabilitiesOptions } from "@multica/core/runtimes";
 import {
@@ -55,6 +57,7 @@ export function SkillsTab({
   const { t } = useT("agents");
   const qc = useQueryClient();
   const wsId = useWorkspaceId();
+  const skillTogglesEnabled = useFeatureEnabled(AGENT_SKILL_TOGGLES_FLAG, false);
   const { data: workspaceSkills = [] } = useQuery(skillListOptions(wsId));
   const runtimeId =
     runtime?.runtime_mode === "local" && runtime.status === "online"
@@ -167,7 +170,7 @@ export function SkillsTab({
                     <>
                       {busy ? (
                         <Loader2 className="h-4 w-4 animate-spin text-muted-foreground motion-reduce:animate-none" />
-                      ) : (
+                      ) : skillTogglesEnabled ? (
                         <Switch
                           checked={enabled}
                           onCheckedChange={(checked) => handleToggle(skill.id, checked)}
@@ -175,7 +178,7 @@ export function SkillsTab({
                             name: skill.name,
                           })}
                         />
-                      )}
+                      ) : null}
                       <Button
                         variant="ghost"
                         size="icon-sm"

--- a/packages/views/labels/resource-label-picker.tsx
+++ b/packages/views/labels/resource-label-picker.tsx
@@ -4,6 +4,8 @@ import { useMemo, useState } from "react";
 import { useQuery } from "@tanstack/react-query";
 import { Check, Search, Tag } from "lucide-react";
 import { useWorkspaceId } from "@multica/core/hooks";
+import { useFeatureEnabled } from "@multica/core/config";
+import { RESOURCE_LABELS_FLAG } from "@multica/core/feature-flags";
 import {
   labelListOptions,
   resourceLabelsOptions,
@@ -31,11 +33,18 @@ export function ResourceLabelPicker({
 }) {
   const { t } = useT("labels");
   const wsId = useWorkspaceId();
+  const resourceLabelsEnabled = useFeatureEnabled(RESOURCE_LABELS_FLAG, false);
   const [open, setOpen] = useState(false);
   const [query, setQuery] = useState("");
-  const { data: catalog = [] } = useQuery(labelListOptions(wsId, resourceType));
+  const { data: catalog = [] } = useQuery({
+    ...labelListOptions(wsId, resourceType),
+    enabled: resourceLabelsEnabled,
+  });
   const { data: selected = [] } = useQuery(
-    resourceLabelsOptions(wsId, resourceType, resourceId),
+    {
+      ...resourceLabelsOptions(wsId, resourceType, resourceId),
+      enabled: resourceLabelsEnabled,
+    },
   );
   const attach = useAttachResourceLabel(resourceType, resourceId);
   const detach = useDetachResourceLabel(resourceType, resourceId);
@@ -43,6 +52,8 @@ export function ResourceLabelPicker({
   const filtered = catalog.filter((label) =>
     label.name.toLowerCase().includes(query.trim().toLowerCase()),
   );
+
+  if (!resourceLabelsEnabled) return null;
 
   const content = selected.length > 0 ? (
     <div className="flex flex-wrap justify-start gap-1 sm:justify-end">

--- a/packages/views/settings/components/labels-tab.tsx
+++ b/packages/views/settings/components/labels-tab.tsx
@@ -4,6 +4,8 @@ import { useEffect, useMemo, useState } from "react";
 import { useQuery } from "@tanstack/react-query";
 import { MoreHorizontal, Pencil, Plus, Search, Tag, Trash2 } from "lucide-react";
 import { toast } from "sonner";
+import { useFeatureEnabled } from "@multica/core/config";
+import { RESOURCE_LABELS_FLAG } from "@multica/core/feature-flags";
 import { useWorkspaceId } from "@multica/core/hooks";
 import {
   labelListOptions,
@@ -45,6 +47,7 @@ import { useT } from "../../i18n";
 import { SettingsTab } from "./settings-layout";
 
 const RESOURCE_TYPES: LabelResourceType[] = ["issue", "agent", "skill"];
+const ISSUE_RESOURCE_TYPES: LabelResourceType[] = ["issue"];
 const LABEL_COLORS = [
   "#6b7280",
   "#ef4444",
@@ -73,12 +76,22 @@ const EMPTY_DRAFT: LabelDraft = {
 export function LabelsTab() {
   const { t } = useT("settings");
   const wsId = useWorkspaceId();
+  const resourceLabelsEnabled = useFeatureEnabled(RESOURCE_LABELS_FLAG, false);
 
   const [resourceType, setResourceType] = useState<LabelResourceType>("issue");
   const [query, setQuery] = useState("");
   const [editing, setEditing] = useState<Label | null>(null);
   const [createOpen, setCreateOpen] = useState(false);
   const [pendingDelete, setPendingDelete] = useState<Label | null>(null);
+
+  const resourceTypes = resourceLabelsEnabled ? RESOURCE_TYPES : ISSUE_RESOURCE_TYPES;
+
+  useEffect(() => {
+    if (!resourceLabelsEnabled && resourceType !== "issue") {
+      setResourceType("issue");
+      setQuery("");
+    }
+  }, [resourceLabelsEnabled, resourceType]);
 
   const { data: labels = [], isLoading } = useQuery(
     labelListOptions(wsId, resourceType),
@@ -102,7 +115,7 @@ export function LabelsTab() {
     >
       <div className="space-y-5">
         <div className="flex flex-wrap items-center gap-2 border-b border-surface-border pb-3">
-          {RESOURCE_TYPES.map((type) => (
+          {resourceTypes.map((type) => (
             <Button
               key={type}
               type="button"

--- a/server/internal/featureflags/keys.go
+++ b/server/internal/featureflags/keys.go
@@ -13,14 +13,38 @@ const (
 	// The access model exists to gate Composio sharing, so the two ship on the
 	// same switch.
 	ComposioMCPApps = "composio_mcp_apps"
+	// AgentBuilder controls writes of system builder agents. It stays disabled
+	// through the schema-only rollout so an older server cannot expose them.
+	AgentBuilder = "agents_agent_builder"
+	// ResourceLabels controls the agent- and skill-scoped label namespaces.
+	// Issue labels remain available while this release flag is off.
+	ResourceLabels = "settings_resource_labels"
+	// AgentSkillToggles controls writes of agent_skill.enabled=false. Older
+	// servers do not filter that state when preparing an agent task.
+	AgentSkillToggles = "agents_skill_toggles"
 )
 
 var frontendPublicFlags = []string{
 	ComposioMCPApps,
+	AgentBuilder,
+	ResourceLabels,
+	AgentSkillToggles,
 }
 
 func ComposioMCPAppsEnabled(ctx context.Context, flags *featureflag.Service) bool {
 	return flags.IsEnabled(ctx, ComposioMCPApps, false)
+}
+
+func AgentBuilderEnabled(ctx context.Context, flags *featureflag.Service) bool {
+	return flags.IsEnabled(ctx, AgentBuilder, false)
+}
+
+func ResourceLabelsEnabled(ctx context.Context, flags *featureflag.Service) bool {
+	return flags.IsEnabled(ctx, ResourceLabels, false)
+}
+
+func AgentSkillTogglesEnabled(ctx context.Context, flags *featureflag.Service) bool {
+	return flags.IsEnabled(ctx, AgentSkillToggles, false)
 }
 
 func EvaluateFrontendPublicFlags(ctx context.Context, flags *featureflag.Service) map[string]bool {

--- a/server/internal/featureflags/keys_test.go
+++ b/server/internal/featureflags/keys_test.go
@@ -1,0 +1,19 @@
+package featureflags
+
+import (
+	"context"
+	"testing"
+)
+
+func TestReleaseFlagsDefaultToOff(t *testing.T) {
+	ctx := context.Background()
+	if AgentBuilderEnabled(ctx, nil) {
+		t.Fatal("agent builder release flag must default to off")
+	}
+	if ResourceLabelsEnabled(ctx, nil) {
+		t.Fatal("resource labels release flag must default to off")
+	}
+	if AgentSkillTogglesEnabled(ctx, nil) {
+		t.Fatal("agent skill toggles release flag must default to off")
+	}
+}

--- a/server/internal/handler/agent_builder.go
+++ b/server/internal/handler/agent_builder.go
@@ -9,6 +9,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5/pgtype"
 
+	"github.com/multica-ai/multica/server/internal/featureflags"
 	db "github.com/multica-ai/multica/server/pkg/db/generated"
 )
 
@@ -50,6 +51,10 @@ type CreateAgentBuilderSessionResponse struct {
 // chat/task pipeline is intentionally agent-backed; it never appears in normal
 // agent lists and cannot be selected as an assignee.
 func (h *Handler) CreateAgentBuilderSession(w http.ResponseWriter, r *http.Request) {
+	if !featureflags.AgentBuilderEnabled(r.Context(), h.FeatureFlags) {
+		writeError(w, http.StatusNotFound, "agent builder is not enabled")
+		return
+	}
 	workspaceID := h.resolveWorkspaceID(r)
 	userID, ok := requireUserID(w, r)
 	if !ok {

--- a/server/internal/handler/agent_builder_test.go
+++ b/server/internal/handler/agent_builder_test.go
@@ -25,6 +25,7 @@ func TestCreateAgentBuilderSessionCreatesIsolatedHiddenBuilder(t *testing.T) {
 	if testHandler == nil {
 		t.Skip("database not available")
 	}
+	withAgentBuilderFlag(t, testHandler, true)
 	t.Cleanup(func() {
 		_, _ = testPool.Exec(context.Background(), `
 			DELETE FROM agent
@@ -112,6 +113,17 @@ func TestCreateAgentBuilderSessionCreatesIsolatedHiddenBuilder(t *testing.T) {
 	}
 	if remaining != 0 {
 		t.Fatalf("builder agent survived chat deletion")
+	}
+}
+
+func TestCreateAgentBuilderSessionRequiresReleaseFlag(t *testing.T) {
+	withAgentBuilderFlag(t, testHandler, false)
+	w := httptest.NewRecorder()
+	testHandler.CreateAgentBuilderSession(w, newRequest(http.MethodPost, "/api/agent-builder/sessions", map[string]any{
+		"runtime_id": testRuntimeID,
+	}))
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("CreateAgentBuilderSession without flag: expected 404, got %d: %s", w.Code, w.Body.String())
 	}
 }
 

--- a/server/internal/handler/chat.go
+++ b/server/internal/handler/chat.go
@@ -506,6 +506,10 @@ func (h *Handler) DeleteChatSession(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusInternalServerError, "failed to delete chat session")
 		return
 	}
+	if err := qtx.DeleteAgentLabelAssignmentsByAgent(r.Context(), session.AgentID); err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to remove chat session agent label assignments")
+		return
+	}
 	if err := qtx.DeleteSystemAgentByID(r.Context(), session.AgentID); err != nil {
 		writeError(w, http.StatusInternalServerError, "failed to clean up chat session agent")
 		return

--- a/server/internal/handler/featureflag_test.go
+++ b/server/internal/handler/featureflag_test.go
@@ -8,9 +8,25 @@ import (
 )
 
 func withComposioMCPAppsFlag(t *testing.T, h *Handler, enabled bool) {
+	withFeatureFlag(t, h, featureflags.ComposioMCPApps, enabled)
+}
+
+func withAgentBuilderFlag(t *testing.T, h *Handler, enabled bool) {
+	withFeatureFlag(t, h, featureflags.AgentBuilder, enabled)
+}
+
+func withResourceLabelsFlag(t *testing.T, h *Handler, enabled bool) {
+	withFeatureFlag(t, h, featureflags.ResourceLabels, enabled)
+}
+
+func withAgentSkillTogglesFlag(t *testing.T, h *Handler, enabled bool) {
+	withFeatureFlag(t, h, featureflags.AgentSkillToggles, enabled)
+}
+
+func withFeatureFlag(t *testing.T, h *Handler, key string, enabled bool) {
 	t.Helper()
 	provider := featureflag.NewStaticProvider()
-	provider.Set(featureflags.ComposioMCPApps, featureflag.Rule{Default: enabled})
+	provider.Set(key, featureflag.Rule{Default: enabled})
 	flags := featureflag.NewService(provider)
 
 	origHandlerFlags := h.FeatureFlags

--- a/server/internal/handler/label.go
+++ b/server/internal/handler/label.go
@@ -13,6 +13,7 @@ import (
 	"github.com/go-chi/chi/v5"
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/multica-ai/multica/server/internal/featureflags"
 	"github.com/multica-ai/multica/server/internal/logger"
 	db "github.com/multica-ai/multica/server/pkg/db/generated"
 	"github.com/multica-ai/multica/server/pkg/protocol"
@@ -148,6 +149,10 @@ func (h *Handler) ListLabels(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusBadRequest, err.Error())
 		return
 	}
+	if resourceType != defaultLabelResourceType && !featureflags.ResourceLabelsEnabled(r.Context(), h.FeatureFlags) {
+		writeError(w, http.StatusNotFound, "resource labels are not enabled")
+		return
+	}
 	labels, err := h.Queries.ListLabels(r.Context(), db.ListLabelsParams{
 		WorkspaceID: parseUUID(workspaceID), ResourceType: resourceType,
 	})
@@ -208,6 +213,10 @@ func (h *Handler) CreateLabel(w http.ResponseWriter, r *http.Request) {
 	resourceType, err := parseLabelResourceType(req.ResourceType)
 	if err != nil {
 		writeError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	if resourceType != defaultLabelResourceType && !featureflags.ResourceLabelsEnabled(r.Context(), h.FeatureFlags) {
+		writeError(w, http.StatusNotFound, "resource labels are not enabled")
 		return
 	}
 	workspaceID := h.resolveWorkspaceID(r)
@@ -321,9 +330,31 @@ func (h *Handler) DeleteLabel(w http.ResponseWriter, r *http.Request) {
 	if !ok {
 		return
 	}
+	tx, err := h.TxStarter.Begin(r.Context())
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to start transaction")
+		return
+	}
+	defer tx.Rollback(r.Context())
+	qtx := h.Queries.WithTx(tx)
+
+	// Keep every relationship cleanup and the catalog deletion atomic. The
+	// resource-label junctions intentionally use application-level cleanup
+	// rather than database cascades.
+	for _, cleanup := range []func() error{
+		func() error { return qtx.DeleteIssueLabelAssignmentsByLabel(r.Context(), idUUID) },
+		func() error { return qtx.DeleteAgentLabelAssignmentsByLabel(r.Context(), idUUID) },
+		func() error { return qtx.DeleteSkillLabelAssignmentsByLabel(r.Context(), idUUID) },
+	} {
+		if err := cleanup(); err != nil {
+			writeError(w, http.StatusInternalServerError, "failed to remove label assignments")
+			return
+		}
+	}
+
 	// DeleteLabel is :one RETURNING id — ErrNoRows means the label wasn't in
 	// this workspace (404). Any other error is a real 500.
-	if _, err := h.Queries.DeleteLabel(r.Context(), db.DeleteLabelParams{
+	if _, err := qtx.DeleteLabel(r.Context(), db.DeleteLabelParams{
 		ID: idUUID, WorkspaceID: wsUUID,
 	}); err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
@@ -332,6 +363,10 @@ func (h *Handler) DeleteLabel(w http.ResponseWriter, r *http.Request) {
 		}
 		slog.Warn("DeleteLabel failed", append(logger.RequestAttrs(r), "error", err)...)
 		writeError(w, http.StatusInternalServerError, "failed to delete label")
+		return
+	}
+	if err := tx.Commit(r.Context()); err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to commit label deletion")
 		return
 	}
 	h.publish(protocol.EventLabelDeleted, workspaceID, "member", userID, map[string]any{"label_id": uuidToString(idUUID)})
@@ -522,6 +557,10 @@ func (h *Handler) DetachLabel(w http.ResponseWriter, r *http.Request) {
 // ---------------------------------------------------------------------------
 
 func (h *Handler) ListLabelsForAgent(w http.ResponseWriter, r *http.Request) {
+	if !featureflags.ResourceLabelsEnabled(r.Context(), h.FeatureFlags) {
+		writeError(w, http.StatusNotFound, "resource labels are not enabled")
+		return
+	}
 	agent, ok := h.loadAgentForUser(w, r, chi.URLParam(r, "id"))
 	if !ok {
 		return
@@ -537,6 +576,10 @@ func (h *Handler) ListLabelsForAgent(w http.ResponseWriter, r *http.Request) {
 }
 
 func (h *Handler) AttachLabelToAgent(w http.ResponseWriter, r *http.Request) {
+	if !featureflags.ResourceLabelsEnabled(r.Context(), h.FeatureFlags) {
+		writeError(w, http.StatusNotFound, "resource labels are not enabled")
+		return
+	}
 	agent, ok := h.loadAgentForUser(w, r, chi.URLParam(r, "id"))
 	if !ok || !h.canManageAgent(w, r, agent) {
 		return
@@ -566,6 +609,10 @@ func (h *Handler) AttachLabelToAgent(w http.ResponseWriter, r *http.Request) {
 }
 
 func (h *Handler) DetachLabelFromAgent(w http.ResponseWriter, r *http.Request) {
+	if !featureflags.ResourceLabelsEnabled(r.Context(), h.FeatureFlags) {
+		writeError(w, http.StatusNotFound, "resource labels are not enabled")
+		return
+	}
 	agent, ok := h.loadAgentForUser(w, r, chi.URLParam(r, "id"))
 	if !ok || !h.canManageAgent(w, r, agent) {
 		return
@@ -585,6 +632,10 @@ func (h *Handler) DetachLabelFromAgent(w http.ResponseWriter, r *http.Request) {
 }
 
 func (h *Handler) ListLabelsForSkill(w http.ResponseWriter, r *http.Request) {
+	if !featureflags.ResourceLabelsEnabled(r.Context(), h.FeatureFlags) {
+		writeError(w, http.StatusNotFound, "resource labels are not enabled")
+		return
+	}
 	skill, ok := h.loadSkillForUser(w, r, chi.URLParam(r, "id"))
 	if !ok {
 		return
@@ -600,6 +651,10 @@ func (h *Handler) ListLabelsForSkill(w http.ResponseWriter, r *http.Request) {
 }
 
 func (h *Handler) AttachLabelToSkill(w http.ResponseWriter, r *http.Request) {
+	if !featureflags.ResourceLabelsEnabled(r.Context(), h.FeatureFlags) {
+		writeError(w, http.StatusNotFound, "resource labels are not enabled")
+		return
+	}
 	skill, ok := h.loadSkillForUser(w, r, chi.URLParam(r, "id"))
 	if !ok || !h.canManageSkill(w, r, skill) {
 		return
@@ -629,6 +684,10 @@ func (h *Handler) AttachLabelToSkill(w http.ResponseWriter, r *http.Request) {
 }
 
 func (h *Handler) DetachLabelFromSkill(w http.ResponseWriter, r *http.Request) {
+	if !featureflags.ResourceLabelsEnabled(r.Context(), h.FeatureFlags) {
+		writeError(w, http.StatusNotFound, "resource labels are not enabled")
+		return
+	}
 	skill, ok := h.loadSkillForUser(w, r, chi.URLParam(r, "id"))
 	if !ok || !h.canManageSkill(w, r, skill) {
 		return

--- a/server/internal/handler/label_test.go
+++ b/server/internal/handler/label_test.go
@@ -199,6 +199,7 @@ func TestIssueLabelAttachDetach(t *testing.T) {
 }
 
 func TestIssueLabelRejectsNonIssueScope(t *testing.T) {
+	withResourceLabelsFlag(t, testHandler, true)
 	w := httptest.NewRecorder()
 	req := newRequest("POST", "/api/issues?workspace_id="+testWorkspaceID, map[string]any{
 		"title":    "Issue rejects agent label",
@@ -498,6 +499,7 @@ func TestLabelNameAllowsEmoji(t *testing.T) {
 }
 
 func TestLabelResourceTypesHaveIndependentNamespaces(t *testing.T) {
+	withResourceLabelsFlag(t, testHandler, true)
 	name := "shared-scope-label-" + uuid.NewString()[:8]
 	for _, resourceType := range []string{"issue", "agent", "skill"} {
 		w := httptest.NewRecorder()
@@ -524,6 +526,84 @@ func TestLabelResourceTypesHaveIndependentNamespaces(t *testing.T) {
 			req = withURLParam(req, "id", created.ID)
 			testHandler.DeleteLabel(w, req)
 		})
+	}
+}
+
+func TestResourceLabelWritesRequireReleaseFlag(t *testing.T) {
+	withResourceLabelsFlag(t, testHandler, false)
+	w := httptest.NewRecorder()
+	req := newRequest("POST", "/api/labels", map[string]any{
+		"resource_type": "agent",
+		"name":          "blocked-resource-label-" + uuid.NewString()[:8],
+		"color":         "#3b82f6",
+	})
+	testHandler.CreateLabel(w, req)
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("CreateLabel without release flag: expected 404, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestDeleteResourceLabelCleansAssignments(t *testing.T) {
+	withResourceLabelsFlag(t, testHandler, true)
+	agentID := createHandlerTestAgent(t, "Resource Label Cleanup", nil)
+	skillID := insertHandlerTestSkill(t, "resource-label-cleanup", "# cleanup")
+
+	create := func(resourceType string) LabelResponse {
+		t.Helper()
+		w := httptest.NewRecorder()
+		testHandler.CreateLabel(w, newRequest("POST", "/api/labels", map[string]any{
+			"resource_type": resourceType,
+			"name":          resourceType + "-cleanup-" + uuid.NewString()[:8],
+			"color":         "#3b82f6",
+		}))
+		if w.Code != http.StatusCreated {
+			t.Fatalf("create %s label: expected 201, got %d: %s", resourceType, w.Code, w.Body.String())
+		}
+		var label LabelResponse
+		if err := json.NewDecoder(w.Body).Decode(&label); err != nil {
+			t.Fatalf("decode %s label: %v", resourceType, err)
+		}
+		return label
+	}
+
+	agentLabel := create("agent")
+	skillLabel := create("skill")
+	for _, link := range []struct {
+		query string
+		id    string
+		label string
+	}{
+		{`INSERT INTO agent_to_label (agent_id, label_id) VALUES ($1, $2)`, agentID, agentLabel.ID},
+		{`INSERT INTO skill_to_label (skill_id, label_id) VALUES ($1, $2)`, skillID, skillLabel.ID},
+	} {
+		if _, err := testPool.Exec(context.Background(), link.query, link.id, link.label); err != nil {
+			t.Fatalf("seed resource label assignment: %v", err)
+		}
+	}
+
+	for _, labelID := range []string{agentLabel.ID, skillLabel.ID} {
+		w := httptest.NewRecorder()
+		req := withURLParam(newRequest("DELETE", "/api/labels/"+labelID, nil), "id", labelID)
+		testHandler.DeleteLabel(w, req)
+		if w.Code != http.StatusNoContent {
+			t.Fatalf("delete resource label: expected 204, got %d: %s", w.Code, w.Body.String())
+		}
+	}
+
+	for _, check := range []struct {
+		query string
+		id    string
+	}{
+		{`SELECT COUNT(*) FROM agent_to_label WHERE agent_id = $1`, agentID},
+		{`SELECT COUNT(*) FROM skill_to_label WHERE skill_id = $1`, skillID},
+	} {
+		var count int
+		if err := testPool.QueryRow(context.Background(), check.query, check.id).Scan(&count); err != nil {
+			t.Fatalf("count remaining resource assignments: %v", err)
+		}
+		if count != 0 {
+			t.Fatalf("resource label assignments remain after label deletion: %d", count)
+		}
 	}
 }
 

--- a/server/internal/handler/skill.go
+++ b/server/internal/handler/skill.go
@@ -17,6 +17,7 @@ import (
 	"github.com/go-chi/chi/v5"
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/multica-ai/multica/server/internal/featureflags"
 	skillpkg "github.com/multica-ai/multica/server/internal/skill"
 	db "github.com/multica-ai/multica/server/pkg/db/generated"
 	"github.com/multica-ai/multica/server/pkg/protocol"
@@ -540,11 +541,26 @@ func (h *Handler) DeleteSkill(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if err := h.Queries.DeleteSkill(r.Context(), db.DeleteSkillParams{
+	tx, err := h.TxStarter.Begin(r.Context())
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to start transaction")
+		return
+	}
+	defer tx.Rollback(r.Context())
+	qtx := h.Queries.WithTx(tx)
+	if err := qtx.DeleteSkillLabelAssignmentsBySkill(r.Context(), skill.ID); err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to remove skill label assignments")
+		return
+	}
+	if err := qtx.DeleteSkill(r.Context(), db.DeleteSkillParams{
 		ID:          skill.ID,
 		WorkspaceID: skill.WorkspaceID,
 	}); err != nil {
 		writeError(w, http.StatusInternalServerError, "failed to delete skill")
+		return
+	}
+	if err := tx.Commit(r.Context()); err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to commit skill deletion")
 		return
 	}
 	actorType, actorID := h.resolveActor(r, requestUserID(r), uuidToString(skill.WorkspaceID))
@@ -2274,6 +2290,10 @@ func (h *Handler) SetAgentSkillEnabled(w http.ResponseWriter, r *http.Request) {
 	}
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil || req.Enabled == nil {
 		writeError(w, http.StatusBadRequest, "enabled is required")
+		return
+	}
+	if !featureflags.AgentSkillTogglesEnabled(r.Context(), h.FeatureFlags) {
+		writeError(w, http.StatusNotFound, "agent skill toggles are not enabled")
 		return
 	}
 

--- a/server/internal/handler/skill_list_test.go
+++ b/server/internal/handler/skill_list_test.go
@@ -114,6 +114,7 @@ func TestListAgentSkills_OmitsContent(t *testing.T) {
 }
 
 func TestSetAgentSkillEnabledControlsExecutionWithoutRemovingAssignment(t *testing.T) {
+	withAgentSkillTogglesFlag(t, testHandler, true)
 	agentID := createHandlerTestAgent(t, "Handler Skill Toggle Test", nil)
 	skillID := insertHandlerTestSkill(t, "agent-skill-toggle", "# Toggle me")
 	if _, err := testPool.Exec(context.Background(),
@@ -158,6 +159,27 @@ func TestSetAgentSkillEnabledControlsExecutionWithoutRemovingAssignment(t *testi
 	active, err = testHandler.Queries.ListAgentSkills(context.Background(), parseUUID(agentID))
 	if err != nil || len(active) != 1 || active[0].Name == "" {
 		t.Fatalf("re-enabled skill missing from execution: skills=%+v err=%v", active, err)
+	}
+}
+
+func TestSetAgentSkillEnabledRequiresReleaseFlag(t *testing.T) {
+	withAgentSkillTogglesFlag(t, testHandler, false)
+	agentID := createHandlerTestAgent(t, "Blocked Skill Toggle", nil)
+	skillID := insertHandlerTestSkill(t, "blocked-agent-skill-toggle", "# Toggle me")
+	if _, err := testPool.Exec(context.Background(),
+		`INSERT INTO agent_skill (agent_id, skill_id) VALUES ($1, $2)`,
+		agentID, skillID,
+	); err != nil {
+		t.Fatalf("attach skill to agent: %v", err)
+	}
+	w := httptest.NewRecorder()
+	req := newRequest("PUT", "/api/agents/"+agentID+"/skills/"+skillID+"/enabled", map[string]any{"enabled": false})
+	rctx := chi.NewRouteContext()
+	rctx.URLParams.Add("id", agentID)
+	rctx.URLParams.Add("skillId", skillID)
+	testHandler.SetAgentSkillEnabled(w, req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, rctx)))
+	if w.Code != 404 {
+		t.Fatalf("SetAgentSkillEnabled without flag: expected 404, got %d: %s", w.Code, w.Body.String())
 	}
 }
 

--- a/server/migrations/162_resource_labels.up.sql
+++ b/server/migrations/162_resource_labels.up.sql
@@ -7,27 +7,16 @@ ALTER TABLE issue_label
         CHECK (resource_type IN ('issue', 'agent', 'skill')),
     ADD COLUMN description TEXT NOT NULL DEFAULT '';
 
-DROP INDEX IF EXISTS issue_label_workspace_name_lower_idx;
-
-CREATE UNIQUE INDEX issue_label_workspace_type_name_lower_idx
-    ON issue_label (workspace_id, resource_type, LOWER(name));
-
-CREATE INDEX issue_label_workspace_type_idx
-    ON issue_label (workspace_id, resource_type);
-
 CREATE TABLE agent_to_label (
-    agent_id UUID NOT NULL REFERENCES agent(id) ON DELETE CASCADE,
-    label_id UUID NOT NULL REFERENCES issue_label(id) ON DELETE CASCADE,
+    agent_id UUID NOT NULL,
+    label_id UUID NOT NULL,
     created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
     PRIMARY KEY (agent_id, label_id)
 );
 
 CREATE TABLE skill_to_label (
-    skill_id UUID NOT NULL REFERENCES skill(id) ON DELETE CASCADE,
-    label_id UUID NOT NULL REFERENCES issue_label(id) ON DELETE CASCADE,
+    skill_id UUID NOT NULL,
+    label_id UUID NOT NULL,
     created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
     PRIMARY KEY (skill_id, label_id)
 );
-
-CREATE INDEX agent_to_label_label_idx ON agent_to_label(label_id);
-CREATE INDEX skill_to_label_label_idx ON skill_to_label(label_id);

--- a/server/migrations/163_agent_builder.up.sql
+++ b/server/migrations/163_agent_builder.up.sql
@@ -2,7 +2,3 @@ ALTER TABLE agent
 ADD COLUMN kind TEXT NOT NULL DEFAULT 'user'
     CHECK (kind IN ('user', 'system')),
 ADD COLUMN system_key TEXT;
-
-CREATE UNIQUE INDEX agent_system_identity_unique
-    ON agent (workspace_id, owner_id, runtime_id, system_key)
-    WHERE system_key IS NOT NULL;

--- a/server/migrations/167_resource_label_namespace_index.down.sql
+++ b/server/migrations/167_resource_label_namespace_index.down.sql
@@ -1,0 +1,1 @@
+DROP INDEX CONCURRENTLY IF EXISTS issue_label_workspace_type_name_lower_idx;

--- a/server/migrations/167_resource_label_namespace_index.up.sql
+++ b/server/migrations/167_resource_label_namespace_index.up.sql
@@ -1,0 +1,4 @@
+-- This is intentionally a single statement: concurrent index creation cannot
+-- run in a transaction or a multi-command migration.
+CREATE UNIQUE INDEX CONCURRENTLY IF NOT EXISTS issue_label_workspace_type_name_lower_idx
+    ON issue_label (workspace_id, resource_type, LOWER(name));

--- a/server/migrations/168_resource_label_type_index.down.sql
+++ b/server/migrations/168_resource_label_type_index.down.sql
@@ -1,0 +1,1 @@
+DROP INDEX CONCURRENTLY IF EXISTS issue_label_workspace_type_idx;

--- a/server/migrations/168_resource_label_type_index.up.sql
+++ b/server/migrations/168_resource_label_type_index.up.sql
@@ -1,0 +1,4 @@
+-- This is intentionally a single statement: concurrent index creation cannot
+-- run in a transaction or a multi-command migration.
+CREATE INDEX CONCURRENTLY IF NOT EXISTS issue_label_workspace_type_idx
+    ON issue_label (workspace_id, resource_type);

--- a/server/migrations/169_agent_label_lookup_index.down.sql
+++ b/server/migrations/169_agent_label_lookup_index.down.sql
@@ -1,0 +1,1 @@
+DROP INDEX CONCURRENTLY IF EXISTS agent_to_label_label_idx;

--- a/server/migrations/169_agent_label_lookup_index.up.sql
+++ b/server/migrations/169_agent_label_lookup_index.up.sql
@@ -1,0 +1,4 @@
+-- This is intentionally a single statement: concurrent index creation cannot
+-- run in a transaction or a multi-command migration.
+CREATE INDEX CONCURRENTLY IF NOT EXISTS agent_to_label_label_idx
+    ON agent_to_label(label_id);

--- a/server/migrations/170_skill_label_lookup_index.down.sql
+++ b/server/migrations/170_skill_label_lookup_index.down.sql
@@ -1,0 +1,1 @@
+DROP INDEX CONCURRENTLY IF EXISTS skill_to_label_label_idx;

--- a/server/migrations/170_skill_label_lookup_index.up.sql
+++ b/server/migrations/170_skill_label_lookup_index.up.sql
@@ -1,0 +1,4 @@
+-- This is intentionally a single statement: concurrent index creation cannot
+-- run in a transaction or a multi-command migration.
+CREATE INDEX CONCURRENTLY IF NOT EXISTS skill_to_label_label_idx
+    ON skill_to_label(label_id);

--- a/server/migrations/171_drop_legacy_label_namespace_index.down.sql
+++ b/server/migrations/171_drop_legacy_label_namespace_index.down.sql
@@ -1,0 +1,3 @@
+-- Migration 162 restores the legacy index after it removes non-issue labels.
+-- Recreating it here could fail while those rows still exist during rollback.
+SELECT 1;

--- a/server/migrations/171_drop_legacy_label_namespace_index.up.sql
+++ b/server/migrations/171_drop_legacy_label_namespace_index.up.sql
@@ -1,0 +1,3 @@
+-- The replacement namespace index is created in migration 167 before this
+-- legacy index is removed. Keep this a single statement for online safety.
+DROP INDEX CONCURRENTLY IF EXISTS issue_label_workspace_name_lower_idx;

--- a/server/migrations/172_agent_system_identity_index.down.sql
+++ b/server/migrations/172_agent_system_identity_index.down.sql
@@ -1,0 +1,1 @@
+DROP INDEX CONCURRENTLY IF EXISTS agent_system_identity_unique;

--- a/server/migrations/172_agent_system_identity_index.up.sql
+++ b/server/migrations/172_agent_system_identity_index.up.sql
@@ -1,0 +1,5 @@
+-- This is intentionally a single statement: concurrent index creation cannot
+-- run in a transaction or a multi-command migration.
+CREATE UNIQUE INDEX CONCURRENTLY IF NOT EXISTS agent_system_identity_unique
+    ON agent (workspace_id, owner_id, runtime_id, system_key)
+    WHERE system_key IS NOT NULL;

--- a/server/migrations/173_remove_resource_label_foreign_keys.down.sql
+++ b/server/migrations/173_remove_resource_label_foreign_keys.down.sql
@@ -1,0 +1,2 @@
+-- The original cascading foreign keys are intentionally not recreated.
+SELECT 1;

--- a/server/migrations/173_remove_resource_label_foreign_keys.up.sql
+++ b/server/migrations/173_remove_resource_label_foreign_keys.up.sql
@@ -1,0 +1,7 @@
+-- A short-lived pre-release deployment may already have applied the original
+-- migration 162. Remove those database cascades before this release enables
+-- resource labels; application transactions own cleanup from this point on.
+ALTER TABLE agent_to_label DROP CONSTRAINT IF EXISTS agent_to_label_agent_id_fkey;
+ALTER TABLE agent_to_label DROP CONSTRAINT IF EXISTS agent_to_label_label_id_fkey;
+ALTER TABLE skill_to_label DROP CONSTRAINT IF EXISTS skill_to_label_skill_id_fkey;
+ALTER TABLE skill_to_label DROP CONSTRAINT IF EXISTS skill_to_label_label_id_fkey;

--- a/server/pkg/db/generated/issue_label.sql.go
+++ b/server/pkg/db/generated/issue_label.sql.go
@@ -134,6 +134,37 @@ func (q *Queries) CreateLabel(ctx context.Context, arg CreateLabelParams) (Issue
 	return i, err
 }
 
+const deleteAgentLabelAssignmentsByAgent = `-- name: DeleteAgentLabelAssignmentsByAgent :exec
+DELETE FROM agent_to_label WHERE agent_id = $1
+`
+
+func (q *Queries) DeleteAgentLabelAssignmentsByAgent(ctx context.Context, agentID pgtype.UUID) error {
+	_, err := q.db.Exec(ctx, deleteAgentLabelAssignmentsByAgent, agentID)
+	return err
+}
+
+const deleteAgentLabelAssignmentsByLabel = `-- name: DeleteAgentLabelAssignmentsByLabel :exec
+DELETE FROM agent_to_label WHERE label_id = $1
+`
+
+func (q *Queries) DeleteAgentLabelAssignmentsByLabel(ctx context.Context, labelID pgtype.UUID) error {
+	_, err := q.db.Exec(ctx, deleteAgentLabelAssignmentsByLabel, labelID)
+	return err
+}
+
+const deleteIssueLabelAssignmentsByLabel = `-- name: DeleteIssueLabelAssignmentsByLabel :exec
+
+DELETE FROM issue_to_label WHERE label_id = $1
+`
+
+// The resource-label junctions deliberately have no foreign keys. Keeping
+// their cleanup in the same application transaction as the owner deletion
+// avoids database-level cascades with unreviewed locking and audit behavior.
+func (q *Queries) DeleteIssueLabelAssignmentsByLabel(ctx context.Context, labelID pgtype.UUID) error {
+	_, err := q.db.Exec(ctx, deleteIssueLabelAssignmentsByLabel, labelID)
+	return err
+}
+
 const deleteLabel = `-- name: DeleteLabel :one
 DELETE FROM issue_label
 WHERE id = $1 AND workspace_id = $2
@@ -152,6 +183,24 @@ func (q *Queries) DeleteLabel(ctx context.Context, arg DeleteLabelParams) (pgtyp
 	var id pgtype.UUID
 	err := row.Scan(&id)
 	return id, err
+}
+
+const deleteSkillLabelAssignmentsByLabel = `-- name: DeleteSkillLabelAssignmentsByLabel :exec
+DELETE FROM skill_to_label WHERE label_id = $1
+`
+
+func (q *Queries) DeleteSkillLabelAssignmentsByLabel(ctx context.Context, labelID pgtype.UUID) error {
+	_, err := q.db.Exec(ctx, deleteSkillLabelAssignmentsByLabel, labelID)
+	return err
+}
+
+const deleteSkillLabelAssignmentsBySkill = `-- name: DeleteSkillLabelAssignmentsBySkill :exec
+DELETE FROM skill_to_label WHERE skill_id = $1
+`
+
+func (q *Queries) DeleteSkillLabelAssignmentsBySkill(ctx context.Context, skillID pgtype.UUID) error {
+	_, err := q.db.Exec(ctx, deleteSkillLabelAssignmentsBySkill, skillID)
+	return err
 }
 
 const detachLabelFromAgent = `-- name: DetachLabelFromAgent :exec

--- a/server/pkg/db/queries/issue_label.sql
+++ b/server/pkg/db/queries/issue_label.sql
@@ -36,6 +36,25 @@ DELETE FROM issue_label
 WHERE id = $1 AND workspace_id = $2
 RETURNING id;
 
+-- The resource-label junctions deliberately have no foreign keys. Keeping
+-- their cleanup in the same application transaction as the owner deletion
+-- avoids database-level cascades with unreviewed locking and audit behavior.
+
+-- name: DeleteIssueLabelAssignmentsByLabel :exec
+DELETE FROM issue_to_label WHERE label_id = $1;
+
+-- name: DeleteAgentLabelAssignmentsByLabel :exec
+DELETE FROM agent_to_label WHERE label_id = $1;
+
+-- name: DeleteSkillLabelAssignmentsByLabel :exec
+DELETE FROM skill_to_label WHERE label_id = $1;
+
+-- name: DeleteAgentLabelAssignmentsByAgent :exec
+DELETE FROM agent_to_label WHERE agent_id = $1;
+
+-- name: DeleteSkillLabelAssignmentsBySkill :exec
+DELETE FROM skill_to_label WHERE skill_id = $1;
+
 -- name: AttachLabelToIssue :exec
 -- Workspace-guarded INSERT: the WHERE EXISTS clauses ensure both the issue
 -- and the label belong to the given workspace. A future caller that forgets


### PR DESCRIPTION
## Summary
- move release indexes into isolated concurrent migrations and remove resource-label cascading foreign keys
- clean label relationships in application transactions
- keep incompatible persistent states behind default-off release flags until a rollback normalizer is available

## Verification
- go test -count=1 ./internal/handler ./internal/migrations ./internal/featureflags
- pnpm --filter @multica/web run typecheck
- pnpm --filter @multica/web exec vitest run features/landing/components/changelog-page-client.test.ts
- pnpm --filter @multica/views exec vitest run agents/components/tabs/skills-tab.test.tsx
- pnpm --filter @multica/views run lint

Closes MUL-4479