### PR TITLE
SNDBX-446: validate daemon skill-cache and disk-pressure changes

### DIFF
--- a/server/cmd/multica/cmd_daemon.go
+++ b/server/cmd/multica/cmd_daemon.go
@@ -976,9 +976,10 @@ func printAggregateDiskUsage(w io.Writer, agg daemon.AggregateDiskUsageReport, b
 			printDiskUsageTaskTable(w, root.Report)
 		}
 	}
-	fmt.Fprintf(w, "\nGrand total: %s across %d task(s) in %d root(s); %s reclaimable as artifacts (%.1f%%).\n",
+	fmt.Fprintf(w, "\nGrand total: %s across %d task(s) in %d root(s); %s reclaimable as artifacts (%.1f%%). Shared skill cache: %s across %d bundle(s).\n",
 		formatBytes(agg.TotalSizeBytes), agg.TotalTaskCount, len(agg.Roots),
-		formatBytes(agg.TotalArtifactSizeBytes), agg.TotalArtifactRatio*100)
+		formatBytes(agg.TotalArtifactSizeBytes), agg.TotalArtifactRatio*100,
+		formatBytes(agg.SharedSkillCacheBytes), agg.SharedSkillCacheCount)
 }
 
 func printDiskUsageTaskTable(w io.Writer, report daemon.DiskUsageReport) {
@@ -1002,6 +1003,10 @@ func printDiskUsageTaskTable(w io.Writer, report daemon.DiskUsageReport) {
 		})
 	}
 	cli.PrintTable(w, []string{"PATH", "KIND", "STATUS", "AGE", "SIZE", "ARTIFACTS"}, rows)
+	if report.SharedSkillCacheBytes > 0 {
+		fmt.Fprintf(w, "\nShared skill cache: %s across %d bundle(s).\n",
+			formatBytes(report.SharedSkillCacheBytes), report.SharedSkillCacheCount)
+	}
 
 	if len(report.Tasks) < report.TotalTaskCount {
 		// Report-wide totals stay anchored to the full scan; the displayed
@@ -1040,6 +1045,10 @@ func printDiskUsageWorkspaceTable(w io.Writer, report daemon.DiskUsageReport) {
 		})
 	}
 	cli.PrintTable(w, []string{"WORKSPACE", "TASKS", "SIZE", "ARTIFACTS", "ARTIFACT %", "OLDEST"}, rows)
+	if report.SharedSkillCacheBytes > 0 {
+		fmt.Fprintf(w, "\nShared skill cache: %s across %d bundle(s).\n",
+			formatBytes(report.SharedSkillCacheBytes), report.SharedSkillCacheCount)
+	}
 
 	if len(report.Workspaces) < report.TotalWorkspaceCount {
 		fmt.Fprintf(w, "\nShowing top %d of %d workspace(s). Displayed: %s (%s artifacts). Scan total: %s (%s artifacts, %.1f%% reclaimable).\n",

--- a/server/internal/daemon/config.go
+++ b/server/internal/daemon/config.go
@@ -50,27 +50,27 @@ const (
 	// matching tool_result would otherwise run forever. This is the backstop for
 	// that stuck-tool case (MUL-3064). Set MULTICA_AGENT_TOOL_WATCHDOG=0 to
 	// disable, in which case an in-flight tool never force-stops the run.
-	DefaultAgentToolWatchdog       = 2 * time.Hour
-	DefaultRuntimeName             = "Local Agent"
-	DefaultWorkspaceSyncInterval   = 30 * time.Second
-	DefaultHealthPort              = 19514
-	DefaultMaxConcurrentTasks      = 20
-	DefaultGCInterval              = 1 * time.Hour
-	DefaultGCTTL                   = 24 * time.Hour // 1 day — AI-coding issues rarely stay open long
-	DefaultGCOrphanTTL             = 72 * time.Hour // 3 days — orphans with no meta (crashes, pre-GC leftovers)
-	DefaultGCArtifactTTL           = 12 * time.Hour // 12h — drop regenerable artifacts on completed but still-open issues
+	DefaultAgentToolWatchdog         = 2 * time.Hour
+	DefaultRuntimeName               = "Local Agent"
+	DefaultWorkspaceSyncInterval     = 30 * time.Second
+	DefaultHealthPort                = 19514
+	DefaultMaxConcurrentTasks        = 20
+	DefaultGCInterval                = 1 * time.Hour
+	DefaultGCTTL                     = 24 * time.Hour // 1 day — AI-coding issues rarely stay open long
+	DefaultGCOrphanTTL               = 72 * time.Hour // 3 days — orphans with no meta (crashes, pre-GC leftovers)
+	DefaultGCArtifactTTL             = 12 * time.Hour // 12h — drop regenerable artifacts on completed but still-open issues
 	DefaultDiskPressureCheckInterval = 5 * time.Minute
 	DefaultDiskPressureMinFreeBytes  = int64(5 << 30)
-	DefaultAutoUpdateCheckInterval = 6 * time.Hour  // how often the daemon polls GitHub for a newer CLI release
+	DefaultAutoUpdateCheckInterval   = 6 * time.Hour // how often the daemon polls GitHub for a newer CLI release
 )
 
 // DefaultGCArtifactPatterns lists basename matches that the GC loop treats as
 // regenerable build artifacts. Kept conservative: only directories that are
-// always cheap to recreate (`pnpm install`, `next build`, `turbo build`). Things
-// like `dist/`, `build/`, `.cache/` or `.venv/` may legitimately hold source or
-// release output in some repos and are NOT included by default — set
-// MULTICA_GC_ARTIFACT_PATTERNS to extend the list per deployment.
-var DefaultGCArtifactPatterns = []string{"node_modules", ".next", ".turbo"}
+// always cheap to recreate (`pnpm install`, `next build`, `turbo build`, task-
+// local skill trees). Things like `dist/`, `build/`, `.cache/` or `.venv/` may
+// legitimately hold source or release output in some repos and are NOT included
+// by default — set MULTICA_GC_ARTIFACT_PATTERNS to extend the list per deployment.
+var DefaultGCArtifactPatterns = []string{"node_modules", ".next", ".turbo", "skills"}
 
 // Config holds all daemon configuration.
 type Config struct {

--- a/server/internal/daemon/config.go
+++ b/server/internal/daemon/config.go
@@ -59,6 +59,8 @@ const (
 	DefaultGCTTL                   = 24 * time.Hour // 1 day — AI-coding issues rarely stay open long
 	DefaultGCOrphanTTL             = 72 * time.Hour // 3 days — orphans with no meta (crashes, pre-GC leftovers)
 	DefaultGCArtifactTTL           = 12 * time.Hour // 12h — drop regenerable artifacts on completed but still-open issues
+	DefaultDiskPressureCheckInterval = 5 * time.Minute
+	DefaultDiskPressureMinFreeBytes  = int64(5 << 30)
 	DefaultAutoUpdateCheckInterval = 6 * time.Hour  // how often the daemon polls GitHub for a newer CLI release
 )
 
@@ -91,6 +93,8 @@ type Config struct {
 	GCOrphanTTL                    time.Duration         // clean orphan dirs with no meta, or dirs whose issue gc-check returns 404, once they exceed this age (default: 72h). The 404 path uses the same TTL — a scoped-down token can't instantly wipe live workspaces.
 	GCArtifactTTL                  time.Duration         // when a task has been completed for at least this long but its issue is still open, drop regenerable artifacts (default: 12h, set 0 to disable)
 	GCArtifactPatterns             []string              // basename patterns whose subtrees are removed during artifact cleanup (default: node_modules, .next, .turbo)
+	DiskPressureCheckInterval      time.Duration         // how often the daemon rechecks free disk space and runs GC early when pressure is high
+	DiskPressureMinFreeBytes       int64                 // minimum free bytes before pressure guard triggers GC
 	AutoUpdateEnabled              bool                  // periodically check for a newer CLI release and self-update when idle (default: true on Multica Cloud, false on self-host)
 	AutoUpdateCheckInterval        time.Duration         // how often the auto-update loop polls for a new release (default: 6h)
 	PollInterval                   time.Duration
@@ -475,6 +479,14 @@ func LoadConfig(overrides Overrides) (Config, error) {
 		return Config{}, err
 	}
 	gcArtifactPatterns := patternsFromEnv("MULTICA_GC_ARTIFACT_PATTERNS", DefaultGCArtifactPatterns)
+	diskPressureCheckInterval, err := durationFromEnv("MULTICA_DISK_PRESSURE_CHECK_INTERVAL", DefaultDiskPressureCheckInterval)
+	if err != nil {
+		return Config{}, err
+	}
+	diskPressureMinFreeBytes, err := int64FromEnv("MULTICA_DISK_PRESSURE_MIN_FREE_BYTES", DefaultDiskPressureMinFreeBytes)
+	if err != nil {
+		return Config{}, err
+	}
 
 	// Auto-update config: default -> env override -> CLI override.
 	//
@@ -521,6 +533,8 @@ func LoadConfig(overrides Overrides) (Config, error) {
 		GCOrphanTTL:                    gcOrphanTTL,
 		GCArtifactTTL:                  gcArtifactTTL,
 		GCArtifactPatterns:             gcArtifactPatterns,
+		DiskPressureCheckInterval:      diskPressureCheckInterval,
+		DiskPressureMinFreeBytes:       diskPressureMinFreeBytes,
 		AutoUpdateEnabled:              autoUpdateEnabled,
 		AutoUpdateCheckInterval:        autoUpdateInterval,
 		HealthPort:                     healthPort,

--- a/server/internal/daemon/config.go
+++ b/server/internal/daemon/config.go
@@ -64,12 +64,13 @@ const (
 	DefaultAutoUpdateCheckInterval   = 6 * time.Hour // how often the daemon polls GitHub for a newer CLI release
 )
 
-// DefaultGCArtifactPatterns lists basename matches that the GC loop treats as
+// DefaultGCArtifactPatterns lists artifact names the GC loop treats as
 // regenerable build artifacts. Kept conservative: only directories that are
-// always cheap to recreate (`pnpm install`, `next build`, `turbo build`, task-
-// local skill trees). Things like `dist/`, `build/`, `.cache/` or `.venv/` may
-// legitimately hold source or release output in some repos and are NOT included
-// by default — set MULTICA_GC_ARTIFACT_PATTERNS to extend the list per deployment.
+// always cheap to recreate (`pnpm install`, `next build`, `turbo build`, the
+// Codex provider cache under `codex-home/skills/`). Things like `dist/`,
+// `build/`, `.cache/` or `.venv/` may legitimately hold source or release
+// output in some repos and are NOT included by default — set
+// MULTICA_GC_ARTIFACT_PATTERNS to extend the list per deployment.
 var DefaultGCArtifactPatterns = []string{"node_modules", ".next", ".turbo", "skills"}
 
 // Config holds all daemon configuration.

--- a/server/internal/daemon/config_test.go
+++ b/server/internal/daemon/config_test.go
@@ -16,7 +16,7 @@ import (
 
 func TestPatternsFromEnv_DefaultsWhenUnset(t *testing.T) {
 	t.Setenv("MULTICA_GC_ARTIFACT_PATTERNS", "")
-	defaults := []string{"node_modules", ".next", ".turbo"}
+	defaults := []string{"node_modules", ".next", ".turbo", "skills"}
 	got := patternsFromEnv("MULTICA_GC_ARTIFACT_PATTERNS", defaults)
 	if !reflect.DeepEqual(got, defaults) {
 		t.Fatalf("expected defaults %v, got %v", defaults, got)

--- a/server/internal/daemon/daemon.go
+++ b/server/internal/daemon/daemon.go
@@ -4688,7 +4688,10 @@ func convertSkillsForEnv(workspaceID string, skills []SkillData, skillCache *Ski
 	for i, s := range skills {
 		cacheDir := ""
 		if skillCache != nil {
-			cacheDir = skillCache.bundleDir(workspaceID, skillRefFromBundle(s))
+			candidate := skillCache.bundleDir(workspaceID, skillRefFromBundle(s))
+			if info, err := os.Stat(candidate); err == nil && info.IsDir() {
+				cacheDir = candidate
+			}
 		}
 		result[i] = execenv.SkillContextForEnv{
 			Name:        s.Name,

--- a/server/internal/daemon/daemon.go
+++ b/server/internal/daemon/daemon.go
@@ -247,7 +247,7 @@ type profileLaunchSpec struct {
 // New creates a new Daemon instance.
 func New(cfg Config, logger *slog.Logger) *Daemon {
 	cacheRoot := filepath.Join(cfg.WorkspacesRoot, ".repos")
-	skillCacheRoot := filepath.Join(cfg.WorkspacesRoot, ".skill-cache", "v1")
+	skillCacheRoot := filepath.Join(cfg.WorkspacesRoot, ".skill-cache", "v2")
 	client := NewClient(cfg.ServerBaseURL)
 	// Tag every daemon HTTP request with the daemon's CLI version so the
 	// server can split logs/metrics by client version (parallel to the CLI).
@@ -802,6 +802,7 @@ func (d *Daemon) Run(ctx context.Context) error {
 	go d.taskWakeupLoop(ctx, taskWakeups)
 	go d.heartbeatLoop(ctx)
 	go d.gcLoop(ctx)
+	go d.diskPressureLoop(ctx)
 	go d.autoUpdateLoop(ctx)
 	go d.tokenRenewalLoop(ctx)
 
@@ -811,7 +812,7 @@ func (d *Daemon) Run(ctx context.Context) error {
 	// readiness wait blocks on, so success is reported only after startup
 	// actually completed, not merely because the health port came up.
 	d.ready.Store(true)
-	d.logger.Debug("background loops launched (workspace-sync, task-wakeup, heartbeat, gc, auto-update, token-renewal); health now reporting ready")
+	d.logger.Debug("background loops launched (workspace-sync, task-wakeup, heartbeat, gc, disk-pressure, auto-update, token-renewal); health now reporting ready")
 	err = d.pollLoop(ctx, taskWakeups)
 	d.logger.Debug("daemon main loop returning", "error", err)
 	return err
@@ -3509,6 +3510,10 @@ func (d *Daemon) runTask(ctx context.Context, task Task, provider string, slot i
 	stopPrepareLease := d.startTaskPrepareLeaseExtender(ctx, task, taskLog)
 	defer stopPrepareLease()
 
+	if err := d.guardDiskPressure(ctx, true); err != nil {
+		return TaskResult{}, err
+	}
+
 	if err := d.ensureTaskSkillBundles(ctx, &task); err != nil {
 		return TaskResult{}, err
 	}
@@ -3538,7 +3543,7 @@ func (d *Daemon) runTask(ctx context.Context, task Task, provider string, slot i
 		AgentID:                          agentID,
 		AgentName:                        agentName,
 		AgentInstructions:                instructions,
-		AgentSkills:                      convertSkillsForEnv(skills),
+		AgentSkills:                      convertSkillsForEnv(task.WorkspaceID, skills, d.skillCache),
 		Repos:                            convertReposForEnv(task.Repos),
 		ProjectID:                        task.ProjectID,
 		ProjectTitle:                     task.ProjectTitle,
@@ -4675,16 +4680,21 @@ func truncateLog(s string, maxLen int) string {
 	return s[:maxLen] + "…"
 }
 
-func convertSkillsForEnv(skills []SkillData) []execenv.SkillContextForEnv {
+func convertSkillsForEnv(workspaceID string, skills []SkillData, skillCache *SkillBundleCache) []execenv.SkillContextForEnv {
 	if len(skills) == 0 {
 		return nil
 	}
 	result := make([]execenv.SkillContextForEnv, len(skills))
 	for i, s := range skills {
+		cacheDir := ""
+		if skillCache != nil {
+			cacheDir = skillCache.bundleDir(workspaceID, skillRefFromBundle(s))
+		}
 		result[i] = execenv.SkillContextForEnv{
 			Name:        s.Name,
 			Description: s.Description,
 			Content:     s.Content,
+			CacheDir:    cacheDir,
 		}
 		for _, f := range s.Files {
 			result[i].Files = append(result[i].Files, execenv.SkillFileContextForEnv{

--- a/server/internal/daemon/diskpressure.go
+++ b/server/internal/daemon/diskpressure.go
@@ -1,0 +1,86 @@
+package daemon
+
+import (
+	"context"
+	"fmt"
+	"time"
+)
+
+// freeDiskBytesFunc is swapped in tests so the pressure guard can be exercised
+// without depending on the host filesystem state.
+var freeDiskBytesFunc = freeDiskBytes
+
+func (d *Daemon) diskPressureLoop(ctx context.Context) {
+	if d.cfg.DiskPressureCheckInterval <= 0 || d.cfg.DiskPressureMinFreeBytes <= 0 {
+		d.logger.Info("disk-pressure: disabled")
+		return
+	}
+	d.logger.Info("disk-pressure: started",
+		"interval", d.cfg.DiskPressureCheckInterval,
+		"min_free_bytes", d.cfg.DiskPressureMinFreeBytes,
+	)
+
+	if err := d.guardDiskPressure(ctx, false); err != nil {
+		d.logger.Warn("disk-pressure: initial check failed", "error", err)
+	}
+
+	ticker := time.NewTicker(d.cfg.DiskPressureCheckInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			if err := d.guardDiskPressure(ctx, false); err != nil {
+				d.logger.Warn("disk-pressure: check failed", "error", err)
+			}
+		}
+	}
+}
+
+func (d *Daemon) guardDiskPressure(ctx context.Context, failClosed bool) error {
+	if d.cfg.DiskPressureMinFreeBytes <= 0 {
+		return nil
+	}
+	freeBytes, totalBytes, err := freeDiskBytesFunc(d.cfg.WorkspacesRoot)
+	if err != nil {
+		d.logger.Warn("disk-pressure: measurement unavailable", "error", err)
+		return nil
+	}
+	if freeBytes >= d.cfg.DiskPressureMinFreeBytes {
+		return nil
+	}
+
+	d.logger.Warn("disk-pressure: free space below threshold; running GC",
+		"free_bytes", freeBytes,
+		"total_bytes", totalBytes,
+		"threshold_bytes", d.cfg.DiskPressureMinFreeBytes,
+	)
+	d.runGC(ctx)
+
+	recheckFree, recheckTotal, err := freeDiskBytesFunc(d.cfg.WorkspacesRoot)
+	if err != nil {
+		d.logger.Warn("disk-pressure: remeasure unavailable", "error", err)
+		return nil
+	}
+	if recheckFree >= d.cfg.DiskPressureMinFreeBytes {
+		d.logger.Info("disk-pressure: GC recovered enough space",
+			"free_bytes", recheckFree,
+			"total_bytes", recheckTotal,
+			"threshold_bytes", d.cfg.DiskPressureMinFreeBytes,
+		)
+		return nil
+	}
+
+	err = fmt.Errorf("disk pressure still below threshold after GC: free_bytes=%d threshold_bytes=%d", recheckFree, d.cfg.DiskPressureMinFreeBytes)
+	if failClosed {
+		return err
+	}
+	d.logger.Error("disk-pressure: unable to recover enough space",
+		"free_bytes", recheckFree,
+		"total_bytes", recheckTotal,
+		"threshold_bytes", d.cfg.DiskPressureMinFreeBytes,
+	)
+	return err
+}

--- a/server/internal/daemon/diskpressure.go
+++ b/server/internal/daemon/diskpressure.go
@@ -12,16 +12,16 @@ var freeDiskBytesFunc = freeDiskBytes
 
 func (d *Daemon) diskPressureLoop(ctx context.Context) {
 	if d.cfg.DiskPressureCheckInterval <= 0 || d.cfg.DiskPressureMinFreeBytes <= 0 {
-		d.logger.Info("disk-pressure: disabled")
+		d.diskPressureInfo("disk-pressure: disabled")
 		return
 	}
-	d.logger.Info("disk-pressure: started",
+	d.diskPressureInfo("disk-pressure: started",
 		"interval", d.cfg.DiskPressureCheckInterval,
 		"min_free_bytes", d.cfg.DiskPressureMinFreeBytes,
 	)
 
 	if err := d.guardDiskPressure(ctx, false); err != nil {
-		d.logger.Warn("disk-pressure: initial check failed", "error", err)
+		d.diskPressureWarn("disk-pressure: initial check failed", "error", err)
 	}
 
 	ticker := time.NewTicker(d.cfg.DiskPressureCheckInterval)
@@ -33,7 +33,7 @@ func (d *Daemon) diskPressureLoop(ctx context.Context) {
 			return
 		case <-ticker.C:
 			if err := d.guardDiskPressure(ctx, false); err != nil {
-				d.logger.Warn("disk-pressure: check failed", "error", err)
+				d.diskPressureWarn("disk-pressure: check failed", "error", err)
 			}
 		}
 	}
@@ -45,14 +45,14 @@ func (d *Daemon) guardDiskPressure(ctx context.Context, failClosed bool) error {
 	}
 	freeBytes, totalBytes, err := freeDiskBytesFunc(d.cfg.WorkspacesRoot)
 	if err != nil {
-		d.logger.Warn("disk-pressure: measurement unavailable", "error", err)
+		d.diskPressureWarn("disk-pressure: measurement unavailable", "error", err)
 		return nil
 	}
 	if freeBytes >= d.cfg.DiskPressureMinFreeBytes {
 		return nil
 	}
 
-	d.logger.Warn("disk-pressure: free space below threshold; running GC",
+	d.diskPressureWarn("disk-pressure: free space below threshold; running GC",
 		"free_bytes", freeBytes,
 		"total_bytes", totalBytes,
 		"threshold_bytes", d.cfg.DiskPressureMinFreeBytes,
@@ -61,11 +61,11 @@ func (d *Daemon) guardDiskPressure(ctx context.Context, failClosed bool) error {
 
 	recheckFree, recheckTotal, err := freeDiskBytesFunc(d.cfg.WorkspacesRoot)
 	if err != nil {
-		d.logger.Warn("disk-pressure: remeasure unavailable", "error", err)
+		d.diskPressureWarn("disk-pressure: remeasure unavailable", "error", err)
 		return nil
 	}
 	if recheckFree >= d.cfg.DiskPressureMinFreeBytes {
-		d.logger.Info("disk-pressure: GC recovered enough space",
+		d.diskPressureInfo("disk-pressure: GC recovered enough space",
 			"free_bytes", recheckFree,
 			"total_bytes", recheckTotal,
 			"threshold_bytes", d.cfg.DiskPressureMinFreeBytes,
@@ -77,10 +77,28 @@ func (d *Daemon) guardDiskPressure(ctx context.Context, failClosed bool) error {
 	if failClosed {
 		return err
 	}
-	d.logger.Error("disk-pressure: unable to recover enough space",
+	d.diskPressureError("disk-pressure: unable to recover enough space",
 		"free_bytes", recheckFree,
 		"total_bytes", recheckTotal,
 		"threshold_bytes", d.cfg.DiskPressureMinFreeBytes,
 	)
 	return err
+}
+
+func (d *Daemon) diskPressureInfo(msg string, args ...any) {
+	if d != nil && d.logger != nil {
+		d.logger.Info(msg, args...)
+	}
+}
+
+func (d *Daemon) diskPressureWarn(msg string, args ...any) {
+	if d != nil && d.logger != nil {
+		d.logger.Warn(msg, args...)
+	}
+}
+
+func (d *Daemon) diskPressureError(msg string, args ...any) {
+	if d != nil && d.logger != nil {
+		d.logger.Error(msg, args...)
+	}
 }

--- a/server/internal/daemon/diskpressure_test.go
+++ b/server/internal/daemon/diskpressure_test.go
@@ -1,0 +1,27 @@
+package daemon
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+func TestGuardDiskPressureFailsClosedWhenSpaceRemainsLow(t *testing.T) {
+	orig := freeDiskBytesFunc
+	freeDiskBytesFunc = func(string) (int64, int64, error) {
+		return 10, 100, nil
+	}
+	defer func() { freeDiskBytesFunc = orig }()
+
+	d := &Daemon{
+		cfg: Config{
+			WorkspacesRoot:            t.TempDir(),
+			DiskPressureMinFreeBytes:  20,
+			DiskPressureCheckInterval:  time.Minute,
+		},
+	}
+
+	if err := d.guardDiskPressure(context.Background(), true); err == nil {
+		t.Fatal("expected guardDiskPressure to fail closed when free space stays below threshold")
+	}
+}

--- a/server/internal/daemon/diskpressure_unix.go
+++ b/server/internal/daemon/diskpressure_unix.go
@@ -1,0 +1,26 @@
+//go:build !windows
+
+package daemon
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"golang.org/x/sys/unix"
+)
+
+func freeDiskBytes(path string) (freeBytes, totalBytes int64, err error) {
+	if path == "" {
+		return 0, 0, fmt.Errorf("disk pressure: path is required")
+	}
+	statPath := path
+	if _, statErr := os.Stat(statPath); statErr != nil {
+		statPath = filepath.Dir(statPath)
+	}
+	var stat unix.Statfs_t
+	if err := unix.Statfs(statPath, &stat); err != nil {
+		return 0, 0, err
+	}
+	return int64(stat.Bavail) * int64(stat.Bsize), int64(stat.Blocks) * int64(stat.Bsize), nil
+}

--- a/server/internal/daemon/diskpressure_windows.go
+++ b/server/internal/daemon/diskpressure_windows.go
@@ -1,0 +1,9 @@
+//go:build windows
+
+package daemon
+
+import "fmt"
+
+func freeDiskBytes(path string) (freeBytes, totalBytes int64, err error) {
+	return 0, 0, fmt.Errorf("disk pressure guard is not implemented on windows")
+}

--- a/server/internal/daemon/diskusage.go
+++ b/server/internal/daemon/diskusage.go
@@ -46,6 +46,8 @@ type DiskUsageReport struct {
 	WorkspacesRoot         string               `json:"workspaces_root"`
 	GeneratedAt            time.Time            `json:"generated_at"`
 	ArtifactPatterns       []string             `json:"artifact_patterns"`
+	SharedSkillCacheBytes  int64                `json:"shared_skill_cache_bytes"`
+	SharedSkillCacheCount  int                  `json:"shared_skill_cache_count"`
 	Tasks                  []TaskDiskUsage      `json:"tasks"`
 	Workspaces             []WorkspaceDiskUsage `json:"workspaces"`
 	TotalTaskCount         int                  `json:"total_task_count"`
@@ -78,6 +80,8 @@ type AggregateDiskUsageReport struct {
 	GeneratedAt            time.Time       `json:"generated_at"`
 	ArtifactPatterns       []string        `json:"artifact_patterns"`
 	Roots                  []RootDiskUsage `json:"roots"`
+	SharedSkillCacheBytes  int64           `json:"shared_skill_cache_bytes"`
+	SharedSkillCacheCount  int             `json:"shared_skill_cache_count"`
 	TotalTaskCount         int             `json:"total_task_count"`
 	TotalWorkspaceCount    int             `json:"total_workspace_count"`
 	TotalSizeBytes         int64           `json:"total_size_bytes"`
@@ -100,6 +104,8 @@ func ScanDiskUsageRoots(roots []DiskUsageRoot, artifactPatterns []string) (Aggre
 			return agg, err
 		}
 		agg.Roots = append(agg.Roots, RootDiskUsage{Profile: r.Profile, Report: report})
+		agg.SharedSkillCacheBytes += report.SharedSkillCacheBytes
+		agg.SharedSkillCacheCount += report.SharedSkillCacheCount
 		agg.TotalTaskCount += report.TotalTaskCount
 		agg.TotalWorkspaceCount += report.TotalWorkspaceCount
 		agg.TotalSizeBytes += report.TotalSizeBytes
@@ -133,6 +139,7 @@ func ScanDiskUsage(workspacesRoot string, artifactPatterns []string) (DiskUsageR
 
 	patternSet := buildPatternSet(artifactPatterns)
 	report.ArtifactPatterns = sortedKeys(patternSet)
+	report.SharedSkillCacheBytes, report.SharedSkillCacheCount = scanSharedSkillCache(workspacesRoot)
 
 	wsEntries, err := os.ReadDir(workspacesRoot)
 	if err != nil {
@@ -261,6 +268,39 @@ func buildTaskUsage(taskDir, wsID, taskShort string, patternSet map[string]struc
 
 	usage.SizeBytes, usage.ArtifactSizeBytes = taskSize(taskDir, patternSet)
 	return usage
+}
+
+func scanSharedSkillCache(workspacesRoot string) (bytes int64, bundleCount int) {
+	if workspacesRoot == "" {
+		return 0, 0
+	}
+	cacheRoot := filepath.Join(workspacesRoot, ".skill-cache")
+	_ = filepath.WalkDir(cacheRoot, func(path string, entry os.DirEntry, err error) error {
+		if err != nil {
+			return nil
+		}
+		if entry.Type()&os.ModeSymlink != 0 {
+			return nil
+		}
+		if entry.IsDir() {
+			if entry.Name() == ".git" {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		info, infoErr := entry.Info()
+		if infoErr != nil {
+			return nil
+		}
+		if info.Mode().IsRegular() {
+			bytes += info.Size()
+			if entry.Name() == ".skill-bundle.json" {
+				bundleCount++
+			}
+		}
+		return nil
+	})
+	return bytes, bundleCount
 }
 
 // taskSize walks taskDir and returns (totalBytes, artifactBytes). Both honor

--- a/server/internal/daemon/diskusage.go
+++ b/server/internal/daemon/diskusage.go
@@ -123,10 +123,11 @@ const DiskUsageKindUnknown = "unknown"
 // ScanDiskUsage walks workspacesRoot and returns the disk-usage report. The
 // walk is read-only and follows the same safety contract as the GC artifact
 // cleaner: it never enters .git, never follows symlinks, and counts only
-// regular files. artifactPatterns is filtered through the basename-only check
-// used by cleanTaskArtifacts so the reported "artifact" footprint matches the
-// bytes the GC would actually reclaim. Missing roots return an empty report
-// (not an error) — a daemon that's never run yet has no directory to walk.
+// regular files. artifactPatterns is filtered through the same path-aware
+// check used by cleanTaskArtifacts so the reported "artifact" footprint
+// matches the bytes the GC would actually reclaim. Missing roots return an
+// empty report (not an error) — a daemon that's never run yet has no
+// directory to walk.
 func ScanDiskUsage(workspacesRoot string, artifactPatterns []string) (DiskUsageReport, error) {
 	report := DiskUsageReport{
 		WorkspacesRoot:   workspacesRoot,
@@ -336,11 +337,11 @@ func taskSize(taskDir string, patternSet map[string]struct{}) (totalBytes int64,
 			if entry.Name() == ".git" {
 				return filepath.SkipDir
 			}
-			if _, ok := patternSet[entry.Name()]; ok {
-				rel, relErr := filepath.Rel(absRoot, path)
-				if relErr != nil || rel == "" || rel == "." || strings.HasPrefix(rel, "..") {
-					return filepath.SkipDir
-				}
+			rel, relErr := filepath.Rel(absRoot, path)
+			if relErr != nil || rel == "" || rel == "." || strings.HasPrefix(rel, "..") {
+				return filepath.SkipDir
+			}
+			if _, ok := matchArtifactPattern(rel, entry.Name(), patternSet); ok {
 				size := dirSize(path)
 				totalBytes += size
 				artifactBytes += size

--- a/server/internal/daemon/diskusage_test.go
+++ b/server/internal/daemon/diskusage_test.go
@@ -419,6 +419,7 @@ func TestScanDiskUsageAccountsTaskSkillCache(t *testing.T) {
 	wsID := "11111111-1111-1111-1111-111111111111"
 	taskDir := filepath.Join(root, wsID, "task-skill-cache")
 	writeFile(t, filepath.Join(taskDir, "workdir", "main.go"), 100)
+	writeFile(t, filepath.Join(taskDir, "workdir", "src", "skills", "SKILL.md"), 400)
 	writeFile(t, filepath.Join(taskDir, "codex-home", "skills", "writing", "SKILL.md"), 200)
 	writeFile(t, filepath.Join(taskDir, "codex-home", "skills", "writing", "docs", "guide.md"), 300)
 	mustWriteMeta(t, taskDir, execenv.GCMeta{

--- a/server/internal/daemon/diskusage_test.go
+++ b/server/internal/daemon/diskusage_test.go
@@ -388,6 +388,30 @@ func TestScanDiskUsageRoots_SumsAcrossRoots(t *testing.T) {
 	}
 }
 
+func TestScanDiskUsageAccountsSharedSkillCache(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	cacheDir := filepath.Join(root, ".skill-cache", "v2", "ws-1", "workspace", "skill-1", "sha256-good")
+	if err := os.MkdirAll(filepath.Join(cacheDir, "docs"), 0o755); err != nil {
+		t.Fatalf("seed cache dir: %v", err)
+	}
+	writeFile(t, filepath.Join(cacheDir, ".skill-bundle.json"), 128)
+	writeFile(t, filepath.Join(cacheDir, "SKILL.md"), 512)
+	writeFile(t, filepath.Join(cacheDir, "docs", "guide.md"), 256)
+
+	report, err := ScanDiskUsage(root, []string{"node_modules"})
+	if err != nil {
+		t.Fatalf("ScanDiskUsage: %v", err)
+	}
+	if report.SharedSkillCacheCount != 1 {
+		t.Fatalf("SharedSkillCacheCount = %d, want 1", report.SharedSkillCacheCount)
+	}
+	if report.SharedSkillCacheBytes < 896 {
+		t.Fatalf("SharedSkillCacheBytes = %d, want at least 896", report.SharedSkillCacheBytes)
+	}
+}
+
 func mustWriteMeta(t *testing.T, taskDir string, meta execenv.GCMeta) {
 	t.Helper()
 	data, err := json.Marshal(meta)

--- a/server/internal/daemon/diskusage_test.go
+++ b/server/internal/daemon/diskusage_test.go
@@ -412,6 +412,42 @@ func TestScanDiskUsageAccountsSharedSkillCache(t *testing.T) {
 	}
 }
 
+func TestScanDiskUsageAccountsTaskSkillCache(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	wsID := "11111111-1111-1111-1111-111111111111"
+	taskDir := filepath.Join(root, wsID, "task-skill-cache")
+	writeFile(t, filepath.Join(taskDir, "workdir", "main.go"), 100)
+	writeFile(t, filepath.Join(taskDir, "codex-home", "skills", "writing", "SKILL.md"), 200)
+	writeFile(t, filepath.Join(taskDir, "codex-home", "skills", "writing", "docs", "guide.md"), 300)
+	mustWriteMeta(t, taskDir, execenv.GCMeta{
+		Kind:        execenv.GCKindIssue,
+		IssueID:     "issue-1",
+		WorkspaceID: wsID,
+		CompletedAt: time.Now().Add(-13 * time.Hour),
+	})
+
+	report, err := ScanDiskUsage(root, []string{"skills"})
+	if err != nil {
+		t.Fatalf("ScanDiskUsage: %v", err)
+	}
+	if len(report.Tasks) != 1 {
+		t.Fatalf("Tasks len = %d, want 1", len(report.Tasks))
+	}
+
+	task := report.Tasks[0]
+	if task.ArtifactSizeBytes != 500 {
+		t.Fatalf("ArtifactSizeBytes = %d, want 500 from codex-home/skills", task.ArtifactSizeBytes)
+	}
+	if report.TotalArtifactSizeBytes != 500 {
+		t.Fatalf("TotalArtifactSizeBytes = %d, want 500", report.TotalArtifactSizeBytes)
+	}
+	if task.Kind != string(execenv.GCKindIssue) {
+		t.Fatalf("Kind = %q, want %q", task.Kind, execenv.GCKindIssue)
+	}
+}
+
 func mustWriteMeta(t *testing.T, taskDir string, meta execenv.GCMeta) {
 	t.Helper()
 	data, err := json.Marshal(meta)

--- a/server/internal/daemon/execenv/context.go
+++ b/server/internal/daemon/execenv/context.go
@@ -432,6 +432,13 @@ func ensureSkillFrontmatter(content, slug, description string) string {
 	return content[:fmStart] + "name: " + slug + "\n" + content[fmStart:]
 }
 
+// EnsureSkillFrontmatter exposes the SKILL.md normalization logic to other
+// daemon packages that need to materialize the same on-disk layout as the
+// provider prep path.
+func EnsureSkillFrontmatter(content, slug, description string) string {
+	return ensureSkillFrontmatter(content, slug, description)
+}
+
 // synthesizeFrontmatter produces a SKILL.md body with a YAML frontmatter block
 // carrying at least `name` and (when non-empty) `description`. The description
 // is always escaped as a double-quoted YAML string so values containing colons,

--- a/server/internal/daemon/execenv/execenv.go
+++ b/server/internal/daemon/execenv/execenv.go
@@ -544,8 +544,10 @@ func installCodexSkillBundle(skillsDir string, skill SkillContextForEnv) error {
 		return fmt.Errorf("allocate skill dir for %q: %w", skill.Name, err)
 	}
 	if skill.CacheDir != "" {
-		if err := createDirLink(skill.CacheDir, dst); err == nil {
-			return nil
+		if info, err := os.Stat(skill.CacheDir); err == nil && info.IsDir() {
+			if err := createDirLink(skill.CacheDir, dst); err == nil {
+				return nil
+			}
 		}
 	}
 	// Fall back to a materialized copy when the shared cache is unavailable or

--- a/server/internal/daemon/execenv/execenv.go
+++ b/server/internal/daemon/execenv/execenv.go
@@ -138,6 +138,10 @@ type SkillContextForEnv struct {
 	Description string
 	Content     string
 	Files       []SkillFileContextForEnv
+	// CacheDir points at the shared, materialized bundle directory when the
+	// daemon can expose the skill by reference instead of copying it into the
+	// task home. Providers that do not support shared delivery can ignore it.
+	CacheDir string
 }
 
 // SkillFileContextForEnv represents a supporting file within a skill.
@@ -493,7 +497,8 @@ func Reuse(params ReuseParams, logger *slog.Logger) *Environment {
 // hydrateCodexSkills populates the per-task CODEX_HOME/skills directory with
 // both user-installed skills (from the shared ~/.codex/skills/) and
 // workspace-assigned skills. Workspace skills win on name conflict — they are
-// written last and seedUserCodexSkills already pre-filters their names.
+// linked to their shared cache directories when possible, and
+// seedUserCodexSkills already pre-filters their names.
 //
 // The skills directory is wiped first so two stale-state classes that the
 // Reuse path would otherwise leak are gone:
@@ -521,11 +526,51 @@ func hydrateCodexSkills(codexHome string, workspaceSkills []SkillContextForEnv, 
 	if len(workspaceSkills) == 0 {
 		return nil
 	}
-	// Codex skills live under env.RootDir/codex-home, which the GC loop
-	// (cloud) or env teardown (local_directory) wipes wholesale — they
-	// don't sit inside the user's workdir and don't need sidecar manifest
-	// tracking.
-	return writeSkillFiles(skillsDir, workspaceSkills, nil)
+	if err := recordMkdirAll(skillsDir, 0o755, nil); err != nil {
+		return fmt.Errorf("create codex skills dir: %w", err)
+	}
+	for _, skill := range workspaceSkills {
+		if err := installCodexSkillBundle(skillsDir, skill); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func installCodexSkillBundle(skillsDir string, skill SkillContextForEnv) error {
+	baseSlug := sanitizeSkillName(skill.Name)
+	slug, dst, err := allocateCollisionFreeSkillDir(skillsDir, baseSlug)
+	if err != nil {
+		return fmt.Errorf("allocate skill dir for %q: %w", skill.Name, err)
+	}
+	if skill.CacheDir != "" {
+		if err := createDirLink(skill.CacheDir, dst); err == nil {
+			return nil
+		}
+	}
+	// Fall back to a materialized copy when the shared cache is unavailable or
+	// the host cannot create a directory link. This keeps the provider runnable
+	// while still taking the shared path on the common case.
+	if err := os.RemoveAll(dst); err != nil {
+		return fmt.Errorf("clear codex skill dir %q: %w", skill.Name, err)
+	}
+	if err := os.MkdirAll(dst, 0o755); err != nil {
+		return fmt.Errorf("create codex skill dir %q: %w", skill.Name, err)
+	}
+	body := ensureSkillFrontmatter(skill.Content, slug, skill.Description)
+	if err := os.WriteFile(filepath.Join(dst, "SKILL.md"), []byte(body), 0o644); err != nil {
+		return fmt.Errorf("write codex skill %q: %w", skill.Name, err)
+	}
+	for _, f := range skill.Files {
+		fpath := filepath.Join(dst, f.Path)
+		if err := os.MkdirAll(filepath.Dir(fpath), 0o755); err != nil {
+			return fmt.Errorf("create codex skill file dir %q: %w", skill.Name, err)
+		}
+		if err := os.WriteFile(fpath, []byte(f.Content), 0o644); err != nil {
+			return fmt.Errorf("write codex skill file %q: %w", skill.Name, err)
+		}
+	}
+	return nil
 }
 
 // GCMetaKind identifies which kind of parent record a task workdir belongs to.

--- a/server/internal/daemon/execenv/execenv_test.go
+++ b/server/internal/daemon/execenv/execenv_test.go
@@ -2967,6 +2967,68 @@ func TestPrepareCodexSeedsUserSkills(t *testing.T) {
 	}
 }
 
+// TestPrepareCodexLinksWorkspaceSkillCache proves the new shared-delivery path:
+// workspace-assigned skills should land in CODEX_HOME as links to the shared
+// bundle cache instead of full copies.
+func TestPrepareCodexLinksWorkspaceSkillCache(t *testing.T) {
+	// Cannot use t.Parallel() with t.Setenv.
+
+	sharedHome := t.TempDir()
+	t.Setenv("CODEX_HOME", sharedHome)
+
+	cacheDir := filepath.Join(t.TempDir(), "skill-cache", "ws-1", "workspace", "skill-1", "sha256-good")
+	if err := os.MkdirAll(filepath.Join(cacheDir, "docs"), 0o755); err != nil {
+		t.Fatalf("seed cache dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(cacheDir, "SKILL.md"), []byte("body"), 0o644); err != nil {
+		t.Fatalf("seed cache SKILL.md: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(cacheDir, "docs", "guide.md"), []byte("guide"), 0o644); err != nil {
+		t.Fatalf("seed cache support file: %v", err)
+	}
+
+	env, err := Prepare(PrepareParams{
+		WorkspacesRoot: t.TempDir(),
+		WorkspaceID:    "ws-codex-cache-link",
+		TaskID:         "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+		AgentName:      "Codex Agent",
+		Provider:       "codex",
+		Task: TaskContextForEnv{
+			IssueID: "codex-cache-link-test",
+			AgentSkills: []SkillContextForEnv{
+				{
+					Name:        "Writing",
+					Description: "Shared cache skill",
+					Content:     "body",
+					Files:       []SkillFileContextForEnv{{Path: "docs/guide.md", Content: "guide"}},
+					CacheDir:    cacheDir,
+				},
+			},
+		},
+	}, testLogger())
+	if err != nil {
+		t.Fatalf("Prepare failed: %v", err)
+	}
+	defer env.Cleanup(true)
+
+	dst := filepath.Join(env.CodexHome, "skills", "writing")
+	assertDirLinkTarget(t, dst, cacheDir)
+	data, err := os.ReadFile(filepath.Join(dst, "SKILL.md"))
+	if err != nil {
+		t.Fatalf("linked SKILL.md missing: %v", err)
+	}
+	if string(data) != "body" {
+		t.Fatalf("linked SKILL.md = %q, want %q", data, "body")
+	}
+	support, err := os.ReadFile(filepath.Join(dst, "docs", "guide.md"))
+	if err != nil {
+		t.Fatalf("linked support file missing: %v", err)
+	}
+	if string(support) != "guide" {
+		t.Fatalf("linked support file = %q, want %q", support, "guide")
+	}
+}
+
 // TestPrepareCodexWorkspaceSkillBeatsUserSkillOnConflict checks that when a
 // workspace-assigned skill shares a sanitized name with a user-installed
 // skill, the workspace version fully replaces the user version (rather than

--- a/server/internal/daemon/execenv/execenv_test.go
+++ b/server/internal/daemon/execenv/execenv_test.go
@@ -3076,8 +3076,9 @@ func TestPrepareCodexCopiesWorkspaceSkillWhenCacheMissing(t *testing.T) {
 	if err != nil {
 		t.Fatalf("copied SKILL.md missing: %v", err)
 	}
-	if string(data) != "body" {
-		t.Fatalf("copied SKILL.md = %q, want %q", data, "body")
+	wantBody := ensureSkillFrontmatter("body", "writing", "Missing shared cache")
+	if string(data) != wantBody {
+		t.Fatalf("copied SKILL.md = %q, want normalized frontmatter %q", data, wantBody)
 	}
 	support, err := os.ReadFile(filepath.Join(dst, "docs", "guide.md"))
 	if err != nil {

--- a/server/internal/daemon/execenv/execenv_test.go
+++ b/server/internal/daemon/execenv/execenv_test.go
@@ -3029,6 +3029,65 @@ func TestPrepareCodexLinksWorkspaceSkillCache(t *testing.T) {
 	}
 }
 
+// TestPrepareCodexCopiesWorkspaceSkillWhenCacheMissing proves the fallback
+// path still materializes a usable skill tree when the shared cache entry is
+// unavailable, which is the migration-failure safety net.
+func TestPrepareCodexCopiesWorkspaceSkillWhenCacheMissing(t *testing.T) {
+	// Cannot use t.Parallel() with t.Setenv.
+
+	sharedHome := t.TempDir()
+	t.Setenv("CODEX_HOME", sharedHome)
+
+	missingCacheDir := filepath.Join(t.TempDir(), "skill-cache", "ws-1", "workspace", "skill-1", "sha256-missing")
+
+	env, err := Prepare(PrepareParams{
+		WorkspacesRoot: t.TempDir(),
+		WorkspaceID:    "ws-codex-cache-copy",
+		TaskID:         "b1c2d3e4-f5a6-7890-abcd-ef1234567890",
+		AgentName:      "Codex Agent",
+		Provider:       "codex",
+		Task: TaskContextForEnv{
+			IssueID: "codex-cache-copy-test",
+			AgentSkills: []SkillContextForEnv{
+				{
+					Name:        "Writing",
+					Description: "Missing shared cache",
+					Content:     "body",
+					Files:       []SkillFileContextForEnv{{Path: "docs/guide.md", Content: "guide"}},
+					CacheDir:    missingCacheDir,
+				},
+			},
+		},
+	}, testLogger())
+	if err != nil {
+		t.Fatalf("Prepare failed: %v", err)
+	}
+	defer env.Cleanup(true)
+
+	dst := filepath.Join(env.CodexHome, "skills", "writing")
+	fi, err := os.Lstat(dst)
+	if err != nil {
+		t.Fatalf("materialized skill missing: %v", err)
+	}
+	if fi.Mode()&os.ModeSymlink != 0 {
+		t.Fatal("expected fallback to copy the skill, not symlink a missing cache dir")
+	}
+	data, err := os.ReadFile(filepath.Join(dst, "SKILL.md"))
+	if err != nil {
+		t.Fatalf("copied SKILL.md missing: %v", err)
+	}
+	if string(data) != "body" {
+		t.Fatalf("copied SKILL.md = %q, want %q", data, "body")
+	}
+	support, err := os.ReadFile(filepath.Join(dst, "docs", "guide.md"))
+	if err != nil {
+		t.Fatalf("copied support file missing: %v", err)
+	}
+	if string(support) != "guide" {
+		t.Fatalf("copied support file = %q, want %q", support, "guide")
+	}
+}
+
 // TestPrepareCodexWorkspaceSkillBeatsUserSkillOnConflict checks that when a
 // workspace-assigned skill shares a sanitized name with a user-installed
 // skill, the workspace version fully replaces the user version (rather than

--- a/server/internal/daemon/gc.go
+++ b/server/internal/daemon/gc.go
@@ -456,11 +456,13 @@ func (d *Daemon) cleanTaskDir(taskDir string) {
 	}
 }
 
-// cleanTaskArtifacts walks taskDir and deletes every directory whose basename
-// matches one of patterns. Returns (removedCount, bytesReclaimed, perPattern).
+// cleanTaskArtifacts walks taskDir and deletes every directory whose relative
+// path matches one of the supported artifact locations. Returns
+// (removedCount, bytesReclaimed, perPattern).
 //
 // Safety contract:
-//   - patterns are basename-only; entries with a path separator are dropped.
+//   - only supported provider cache paths are matched; entries with a path
+//     separator are dropped.
 //   - .git subtrees are never descended into, so the agent's git history stays
 //     intact even if a pattern would otherwise match.
 //   - symlinks are skipped entirely — neither the link nor its target is
@@ -514,13 +516,13 @@ func (d *Daemon) cleanTaskArtifacts(taskDir string, patterns []string) (removed 
 		if info.Mode()&os.ModeSymlink != 0 {
 			return filepath.SkipDir
 		}
-		if _, ok := patternSet[entry.Name()]; !ok {
-			return nil
-		}
-		// Containment check: target must remain inside taskDir.
 		rel, relErr := filepath.Rel(absRoot, path)
 		if relErr != nil || rel == "" || rel == "." || strings.HasPrefix(rel, "..") {
 			return filepath.SkipDir
+		}
+		pattern, ok := matchArtifactPattern(rel, entry.Name(), patternSet)
+		if !ok {
+			return nil
 		}
 		size := dirSize(path)
 		if rmErr := os.RemoveAll(path); rmErr != nil {
@@ -529,7 +531,7 @@ func (d *Daemon) cleanTaskArtifacts(taskDir string, patterns []string) (removed 
 		}
 		removed++
 		bytes += size
-		perPattern[entry.Name()]++
+		perPattern[pattern]++
 		d.logger.Info("gc: artifact removed", "path", path, "bytes", size)
 		// Don't descend into the now-deleted subtree.
 		return filepath.SkipDir
@@ -691,6 +693,20 @@ func runGitCommand(barePath string, timeout time.Duration, args ...string) (stri
 	cmd := exec.CommandContext(ctx, "git", cmdArgs...)
 	out, err := cmd.CombinedOutput()
 	return strings.TrimSpace(string(out)), err
+}
+
+func matchArtifactPattern(relPath, entryName string, patternSet map[string]struct{}) (string, bool) {
+	if _, ok := patternSet[entryName]; !ok {
+		return "", false
+	}
+	if entryName != "skills" {
+		return entryName, true
+	}
+	relPath = filepath.ToSlash(relPath)
+	if relPath == "codex-home/skills" || strings.HasPrefix(relPath, "codex-home/skills/") {
+		return entryName, true
+	}
+	return "", false
 }
 
 func agentWorktreeBranches(barePath string) (map[string]struct{}, error) {

--- a/server/internal/daemon/gc_test.go
+++ b/server/internal/daemon/gc_test.go
@@ -32,7 +32,7 @@ func newGCTestDaemon(t *testing.T, handler http.Handler) *Daemon {
 		GCTTL:              5 * 24 * time.Hour,
 		GCOrphanTTL:        30 * 24 * time.Hour,
 		GCArtifactTTL:      12 * time.Hour,
-		GCArtifactPatterns: []string{"node_modules", ".next", ".turbo"},
+		GCArtifactPatterns: []string{"node_modules", ".next", ".turbo", "skills"},
 	}
 	d := New(cfg, slog.Default())
 	d.client = NewClient(srv.URL)
@@ -552,6 +552,69 @@ func TestCleanTaskArtifacts_RemovesOnlyMatchedDirs(t *testing.T) {
 		"workdir/repo/node_modules",
 		"workdir/repo/.next",
 		"workdir/repo/.turbo",
+	} {
+		if _, err := os.Stat(filepath.Join(taskDir, rel)); !os.IsNotExist(err) {
+			t.Errorf("expected %s to be removed, stat err=%v", rel, err)
+		}
+	}
+}
+
+func TestCleanTaskArtifacts_RemovesSkillTrees(t *testing.T) {
+	t.Parallel()
+
+	d := newGCTestDaemon(t, http.NewServeMux())
+	taskDir := t.TempDir()
+
+	mustMkdir := func(rel string) string {
+		p := filepath.Join(taskDir, rel)
+		if err := os.MkdirAll(p, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		return p
+	}
+	mustWrite := func(rel string, content string) {
+		p := filepath.Join(taskDir, rel)
+		if err := os.MkdirAll(filepath.Dir(p), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(p, []byte(content), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	mustMkdir("workdir/src")
+	mustWrite("workdir/src/main.go", "package main")
+	mustMkdir("codex-home/skills/writing/docs")
+	mustWrite("codex-home/skills/writing/SKILL.md", "body")
+	mustWrite("codex-home/skills/writing/docs/guide.md", "guide")
+	mustWrite("codex-home/config.toml", "model = \"codex\"")
+	mustMkdir("output")
+	mustWrite("output/result.txt", "done")
+
+	removed, bytes, perPattern := d.cleanTaskArtifacts(taskDir, []string{"skills"})
+	if removed != 1 {
+		t.Fatalf("expected 1 skill tree removed, got %d", removed)
+	}
+	if bytes <= 0 {
+		t.Fatalf("expected non-zero bytes reclaimed, got %d", bytes)
+	}
+	if perPattern["skills"] != 1 {
+		t.Fatalf("expected skills pattern count 1, got %+v", perPattern)
+	}
+
+	for _, rel := range []string{
+		"workdir/src/main.go",
+		"codex-home/config.toml",
+		"output/result.txt",
+	} {
+		if _, err := os.Stat(filepath.Join(taskDir, rel)); err != nil {
+			t.Errorf("expected %s to be preserved, got %v", rel, err)
+		}
+	}
+	for _, rel := range []string{
+		"codex-home/skills",
+		"codex-home/skills/writing",
+		"codex-home/skills/writing/SKILL.md",
 	} {
 		if _, err := os.Stat(filepath.Join(taskDir, rel)); !os.IsNotExist(err) {
 			t.Errorf("expected %s to be removed, stat err=%v", rel, err)

--- a/server/internal/daemon/gc_test.go
+++ b/server/internal/daemon/gc_test.go
@@ -584,6 +584,8 @@ func TestCleanTaskArtifacts_RemovesSkillTrees(t *testing.T) {
 
 	mustMkdir("workdir/src")
 	mustWrite("workdir/src/main.go", "package main")
+	mustMkdir("workdir/src/skills")
+	mustWrite("workdir/src/skills/SKILL.md", "workdir skill")
 	mustMkdir("codex-home/skills/writing/docs")
 	mustWrite("codex-home/skills/writing/SKILL.md", "body")
 	mustWrite("codex-home/skills/writing/docs/guide.md", "guide")
@@ -604,6 +606,8 @@ func TestCleanTaskArtifacts_RemovesSkillTrees(t *testing.T) {
 
 	for _, rel := range []string{
 		"workdir/src/main.go",
+		"workdir/src/skills",
+		"workdir/src/skills/SKILL.md",
 		"codex-home/config.toml",
 		"output/result.txt",
 	} {

--- a/server/internal/daemon/helpers.go
+++ b/server/internal/daemon/helpers.go
@@ -67,6 +67,18 @@ func intFromEnv(key string, fallback int) (int, error) {
 	return n, nil
 }
 
+func int64FromEnv(key string, fallback int64) (int64, error) {
+	value := strings.TrimSpace(os.Getenv(key))
+	if value == "" {
+		return fallback, nil
+	}
+	n, err := strconv.ParseInt(value, 10, 64)
+	if err != nil {
+		return 0, fmt.Errorf("%s: invalid integer %q: %w", key, value, err)
+	}
+	return n, nil
+}
+
 func sleepWithContext(ctx context.Context, d time.Duration) error {
 	timer := time.NewTimer(d)
 	defer timer.Stop()

--- a/server/internal/daemon/skill_cache.go
+++ b/server/internal/daemon/skill_cache.go
@@ -38,7 +38,10 @@ func (c *SkillBundleCache) Load(workspaceID string, ref SkillRefData) (SkillData
 	}
 	if c.legacyRoot != "" {
 		if bundle, ok := c.loadFromRoot(c.legacyRoot, workspaceID, ref); ok {
-			_ = c.Store(workspaceID, bundle)
+			legacyDir := bundleDirForRoot(c.legacyRoot, workspaceID, ref)
+			if err := c.Store(workspaceID, bundle); err == nil {
+				_ = os.RemoveAll(legacyDir)
+			}
 			return bundle, true
 		}
 	}

--- a/server/internal/daemon/skill_cache.go
+++ b/server/internal/daemon/skill_cache.go
@@ -6,37 +6,43 @@ import (
 	"os"
 	"path"
 	"path/filepath"
+	"regexp"
 	"strings"
 	"sync"
 
+	"github.com/multica-ai/multica/server/internal/daemon/execenv"
 	"github.com/multica-ai/multica/server/pkg/skillbundle"
 )
 
 type SkillBundleCache struct {
-	root  string
-	mu    sync.Mutex
-	locks map[string]*sync.Mutex
+	root       string
+	legacyRoot  string
+	mu         sync.Mutex
+	locks      map[string]*sync.Mutex
 }
 
 func NewSkillBundleCache(root string) *SkillBundleCache {
-	return &SkillBundleCache{root: root, locks: make(map[string]*sync.Mutex)}
+	cache := &SkillBundleCache{root: root, locks: make(map[string]*sync.Mutex)}
+	if filepath.Base(root) == "v2" {
+		cache.legacyRoot = filepath.Join(filepath.Dir(root), "v1")
+	}
+	return cache
 }
 
 func (c *SkillBundleCache) Load(workspaceID string, ref SkillRefData) (SkillData, bool) {
 	if c == nil || c.root == "" {
 		return SkillData{}, false
 	}
-	keyPath := c.bundlePath(workspaceID, ref)
-	data, err := os.ReadFile(keyPath)
-	if err != nil {
-		return SkillData{}, false
+	if bundle, ok := c.loadFromRoot(c.root, workspaceID, ref); ok {
+		return bundle, true
 	}
-	var bundle SkillData
-	if err := json.Unmarshal(data, &bundle); err != nil || !validateSkillBundle(ref, bundle) {
-		_ = os.Remove(keyPath)
-		return SkillData{}, false
+	if c.legacyRoot != "" {
+		if bundle, ok := c.loadFromRoot(c.legacyRoot, workspaceID, ref); ok {
+			_ = c.Store(workspaceID, bundle)
+			return bundle, true
+		}
 	}
-	return bundle, true
+	return SkillData{}, false
 }
 
 func (c *SkillBundleCache) Store(workspaceID string, bundle SkillData) error {
@@ -44,7 +50,7 @@ func (c *SkillBundleCache) Store(workspaceID string, bundle SkillData) error {
 		return nil
 	}
 	ref := SkillRefData{ID: bundle.ID, Source: bundle.Source, Hash: bundle.Hash}
-	dir := filepath.Dir(c.bundlePath(workspaceID, ref))
+	dir := c.bundleDir(workspaceID, ref)
 	tmp, err := os.MkdirTemp(filepath.Dir(dir), ".bundle-*")
 	if err != nil {
 		if mkErr := os.MkdirAll(filepath.Dir(dir), 0o755); mkErr != nil {
@@ -61,8 +67,21 @@ func (c *SkillBundleCache) Store(workspaceID string, bundle SkillData) error {
 	if err != nil {
 		return err
 	}
-	if err := os.WriteFile(filepath.Join(tmp, "bundle.json"), data, 0o644); err != nil {
+	if err := os.WriteFile(filepath.Join(tmp, ".skill-bundle.json"), data, 0o644); err != nil {
 		return err
+	}
+	body := execenv.EnsureSkillFrontmatter(bundle.Content, sanitizeSkillName(bundle.Name), bundle.Description)
+	if err := os.WriteFile(filepath.Join(tmp, "SKILL.md"), []byte(body), 0o644); err != nil {
+		return err
+	}
+	for _, file := range bundle.Files {
+		target := filepath.Join(tmp, file.Path)
+		if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
+			return err
+		}
+		if err := os.WriteFile(target, []byte(file.Content), 0o644); err != nil {
+			return err
+		}
 	}
 	_ = os.RemoveAll(dir)
 	if err := os.Rename(tmp, dir); err != nil {
@@ -94,14 +113,45 @@ func (c *SkillBundleCache) lockForKey(key string) *sync.Mutex {
 }
 
 func (c *SkillBundleCache) bundlePath(workspaceID string, ref SkillRefData) string {
+	return filepath.Join(c.bundleDir(workspaceID, ref), ".skill-bundle.json")
+}
+
+func (c *SkillBundleCache) bundleDir(workspaceID string, ref SkillRefData) string {
+	return bundleDirForRoot(c.root, workspaceID, ref)
+}
+
+func bundleDirForRoot(root, workspaceID string, ref SkillRefData) string {
 	return filepath.Join(
-		c.root,
+		root,
 		safeCacheSegment(workspaceID),
 		safeCacheSegment(ref.Source),
 		safeCacheSegment(ref.ID),
 		safeCacheSegment(ref.Hash),
-		"bundle.json",
 	)
+}
+
+func (c *SkillBundleCache) loadFromRoot(root, workspaceID string, ref SkillRefData) (SkillData, bool) {
+	dir := bundleDirForRoot(root, workspaceID, ref)
+	data, err := os.ReadFile(filepath.Join(dir, ".skill-bundle.json"))
+	if err != nil {
+		return SkillData{}, false
+	}
+	var bundle SkillData
+	if err := json.Unmarshal(data, &bundle); err != nil || !validateSkillBundle(ref, bundle) {
+		_ = os.RemoveAll(dir)
+		return SkillData{}, false
+	}
+	if _, err := os.Stat(filepath.Join(dir, "SKILL.md")); err != nil {
+		_ = os.RemoveAll(dir)
+		return SkillData{}, false
+	}
+	for _, file := range bundle.Files {
+		if _, err := os.Stat(filepath.Join(dir, file.Path)); err != nil {
+			_ = os.RemoveAll(dir)
+			return SkillData{}, false
+		}
+	}
+	return bundle, true
 }
 
 func validateSkillBundle(ref SkillRefData, bundle SkillData) bool {
@@ -168,6 +218,18 @@ func safeCacheSegment(s string) string {
 	out := b.String()
 	if out == "." || out == ".." {
 		return fmt.Sprintf("_%s", out)
+	}
+	return out
+}
+
+var nonAlphaNum = regexp.MustCompile(`[^a-z0-9]+`)
+
+func sanitizeSkillName(name string) string {
+	s := strings.ToLower(strings.TrimSpace(name))
+	s = nonAlphaNum.ReplaceAllString(s, "-")
+	out := strings.Trim(s, "-")
+	if out == "" {
+		return "skill"
 	}
 	return out
 }

--- a/server/internal/daemon/skill_cache_test.go
+++ b/server/internal/daemon/skill_cache_test.go
@@ -87,6 +87,65 @@ func TestSkillBundleCacheMigratesLegacyLayout(t *testing.T) {
 	if _, err := os.Stat(filepath.Join(cache.bundleDir("ws-1", ref), "SKILL.md")); err != nil {
 		t.Fatalf("migrated bundle missing SKILL.md: %v", err)
 	}
+	if _, err := os.Stat(legacyDir); !os.IsNotExist(err) {
+		t.Fatalf("expected legacy bundle to be reclaimed after successful migration, stat err=%v", err)
+	}
+}
+
+func TestSkillBundleCacheKeepsLegacyLayoutWhenMigrationWriteFails(t *testing.T) {
+	base := t.TempDir()
+	v2Root := filepath.Join(base, "v2")
+	if err := os.WriteFile(v2Root, []byte("not a dir"), 0o644); err != nil {
+		t.Fatalf("seed blocking v2 root: %v", err)
+	}
+	cache := NewSkillBundleCache(v2Root)
+	bundle := testSkillBundle()
+	ref := skillRefFromBundle(bundle)
+
+	legacyDir := bundleDirForRoot(cache.legacyRoot, "ws-1", ref)
+	if err := os.MkdirAll(legacyDir, 0o755); err != nil {
+		t.Fatalf("seed legacy dir: %v", err)
+	}
+	raw, err := json.Marshal(bundle)
+	if err != nil {
+		t.Fatalf("marshal bundle: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(legacyDir, ".skill-bundle.json"), raw, 0o644); err != nil {
+		t.Fatalf("seed legacy meta: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(legacyDir, "SKILL.md"), []byte("main"), 0o644); err != nil {
+		t.Fatalf("seed legacy SKILL.md: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(legacyDir, "rules.md"), []byte("rules"), 0o644); err != nil {
+		t.Fatalf("seed legacy support file: %v", err)
+	}
+
+	got, ok := cache.Load("ws-1", ref)
+	if !ok {
+		t.Fatal("expected cache hit from legacy layout")
+	}
+	if got.Content != bundle.Content {
+		t.Fatalf("loaded legacy bundle = %+v, want %+v", got, bundle)
+	}
+	if _, err := os.Stat(filepath.Join(cache.bundleDir("ws-1", ref), "SKILL.md")); err == nil {
+		t.Fatal("expected v2 migration write to fail, but bundle dir exists")
+	}
+	if _, err := os.Stat(legacyDir); err != nil {
+		t.Fatalf("expected legacy bundle to remain after failed migration, stat err=%v", err)
+	}
+}
+
+func TestConvertSkillsForEnvSkipsMissingCacheDir(t *testing.T) {
+	cache := NewSkillBundleCache(filepath.Join(t.TempDir(), "v2"))
+	skills := []SkillData{testSkillBundle()}
+
+	got := convertSkillsForEnv("ws-1", skills, cache)
+	if len(got) != 1 {
+		t.Fatalf("convertSkillsForEnv returned %d skills, want 1", len(got))
+	}
+	if got[0].CacheDir != "" {
+		t.Fatalf("CacheDir = %q, want empty when bundle dir is missing", got[0].CacheDir)
+	}
 }
 
 func testSkillBundle() SkillData {

--- a/server/internal/daemon/skill_cache_test.go
+++ b/server/internal/daemon/skill_cache_test.go
@@ -1,7 +1,9 @@
 package daemon
 
 import (
+	"encoding/json"
 	"os"
+	"path/filepath"
 	"testing"
 )
 
@@ -12,6 +14,16 @@ func TestSkillBundleCacheLoadStore(t *testing.T) {
 
 	if err := cache.Store("ws-1", bundle); err != nil {
 		t.Fatalf("Store: %v", err)
+	}
+	if data, err := os.ReadFile(filepath.Join(cache.bundleDir("ws-1", ref), "SKILL.md")); err != nil {
+		t.Fatalf("bundle dir missing SKILL.md: %v", err)
+	} else if string(data) != "---\nname: deploy\n---\n\nmain" {
+		t.Fatalf("bundle dir SKILL.md = %q, want normalized frontmatter", data)
+	}
+	if data, err := os.ReadFile(filepath.Join(cache.bundleDir("ws-1", ref), "rules.md")); err != nil {
+		t.Fatalf("bundle dir missing supporting file: %v", err)
+	} else if string(data) != "rules" {
+		t.Fatalf("bundle dir rules.md = %q, want %q", data, "rules")
 	}
 	got, ok := cache.Load("ws-1", ref)
 	if !ok {
@@ -39,6 +51,41 @@ func TestSkillBundleCacheRejectsCorruptBundle(t *testing.T) {
 	}
 	if _, err := os.Stat(path); !os.IsNotExist(err) {
 		t.Fatalf("expected corrupt cache file to be removed, stat err=%v", err)
+	}
+}
+
+func TestSkillBundleCacheMigratesLegacyLayout(t *testing.T) {
+	cache := NewSkillBundleCache(filepath.Join(t.TempDir(), "v2"))
+	bundle := testSkillBundle()
+	ref := skillRefFromBundle(bundle)
+
+	legacyDir := bundleDirForRoot(cache.legacyRoot, "ws-1", ref)
+	if err := os.MkdirAll(filepath.Join(legacyDir, "nested"), 0o755); err != nil {
+		t.Fatalf("seed legacy dir: %v", err)
+	}
+	raw, err := json.Marshal(bundle)
+	if err != nil {
+		t.Fatalf("marshal bundle: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(legacyDir, ".skill-bundle.json"), raw, 0o644); err != nil {
+		t.Fatalf("seed legacy meta: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(legacyDir, "SKILL.md"), []byte("main"), 0o644); err != nil {
+		t.Fatalf("seed legacy SKILL.md: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(legacyDir, "rules.md"), []byte("rules"), 0o644); err != nil {
+		t.Fatalf("seed legacy support file: %v", err)
+	}
+
+	got, ok := cache.Load("ws-1", ref)
+	if !ok {
+		t.Fatal("expected cache hit from legacy layout")
+	}
+	if got.Content != bundle.Content {
+		t.Fatalf("loaded legacy bundle = %+v, want %+v", got, bundle)
+	}
+	if _, err := os.Stat(filepath.Join(cache.bundleDir("ws-1", ref), "SKILL.md")); err != nil {
+		t.Fatalf("migrated bundle missing SKILL.md: %v", err)
 	}
 }
 


### PR DESCRIPTION
Implements daemon-side shared skill delivery, disk-pressure GC guard, and disk usage accounting.

Changes:
- materialize shared skill bundles under .skill-cache/v2 and link them into task envs when possible
- preserve the existing copy path as a fallback
- add disk-pressure checks with a fail-closed task-start guard and a background ticker
- report shared skill cache bytes/count in daemon disk-usage output
- add regression tests for cache migration, shared link prep, disk usage accounting, and the pressure failure mode

Migration follow-up:
- preserve a usable source/fallback when v2 migration write fails
- reclaim the legacy cache only after a successful migration

Closes SNDBX-446
Ready for review on the current head.
