### PR TITLE
fix(agent): select an offered ACP permission option so Hermes writes aren't denied (MUL-4441)

### DIFF
--- a/server/pkg/agent/hermes.go
+++ b/server/pkg/agent/hermes.go
@@ -555,10 +555,12 @@ func (c *hermesClient) handleLine(line string) {
 	}
 
 	// Agent → client request: has id + method (no result / error yet).
-	// Kimi uses this for session/request_permission; if we don't answer,
-	// the agent blocks for 300s and the task hangs. Hermes doesn't send
-	// these when launched with HERMES_YOLO_MODE=1, but we still handle
-	// the case generically for any future ACP backend we bolt on.
+	// Kimi and Hermes both use session/request_permission; if we don't
+	// answer, the agent blocks for its internal timeout and the task
+	// hangs. HERMES_YOLO_MODE=1 only suppresses Hermes' dangerous-shell-
+	// command prompts (tools/approval.py); its ACP edit-approval guard
+	// (acp_adapter/edit_approval.py) still asks before every file write,
+	// so we must handle these requests for Hermes too.
 	if _, hasID := raw["id"]; hasID {
 		if _, hasResult := raw["result"]; hasResult {
 			c.handleResponse(raw)
@@ -583,10 +585,17 @@ func (c *hermesClient) handleLine(line string) {
 // handleAgentRequest replies to JSON-RPC requests the agent sends
 // us (agent → client direction). The only one we care about today is
 // `session/request_permission`: the daemon is headless and cannot
-// actually prompt a user, so we auto-approve every action. Using
-// `approve_for_session` rather than `approve` means subsequent
-// identical actions (every Shell invocation, every file write) don't
-// round-trip through us — the agent remembers them locally.
+// actually prompt a user, so we auto-approve every action.
+//
+// The reply MUST select one of the optionIds the agent actually
+// offered — the ACP permission contract is "pick from these options",
+// and an id the agent never offered is treated as a denial. Hermes'
+// edit-approval path offers only ["allow_once","deny"] and rejects
+// anything but exactly "allow_once" (acp_adapter/edit_approval.py), so
+// the previous hardcoded "approve_for_session" silently blocked every
+// file write on the Hermes ACP runtime (GitHub multica#5300).
+// selectACPApprovalOptionID echoes a granting option instead, so this
+// works across Hermes' edit and command paths and other ACP backends.
 func (c *hermesClient) handleAgentRequest(raw map[string]json.RawMessage) {
 	var method string
 	_ = json.Unmarshal(raw["method"], &method)
@@ -599,17 +608,18 @@ func (c *hermesClient) handleAgentRequest(raw map[string]json.RawMessage) {
 	var resp map[string]any
 	switch method {
 	case "session/request_permission":
+		optionID := selectACPApprovalOptionID(raw["params"])
 		resp = map[string]any{
 			"jsonrpc": "2.0",
 			"id":      json.RawMessage(rawID),
 			"result": map[string]any{
 				"outcome": map[string]any{
 					"outcome":  "selected",
-					"optionId": "approve_for_session",
+					"optionId": optionID,
 				},
 			},
 		}
-		c.cfg.Logger.Debug("auto-approved agent permission request", "method", method)
+		c.cfg.Logger.Debug("auto-approved agent permission request", "method", method, "optionId", optionID)
 	default:
 		// Unknown agent→client method — reply with standard "method
 		// not found" so the agent doesn't block waiting for us. Better
@@ -634,6 +644,91 @@ func (c *hermesClient) handleAgentRequest(raw map[string]json.RawMessage) {
 	if err := c.writeLine(data); err != nil {
 		c.cfg.Logger.Warn("write agent-request response", "method", method, "error", err)
 	}
+}
+
+// acpPermissionOption is one entry in a session/request_permission
+// request's `options` array. `kind` is the ACP-level classification
+// (allow_once / allow_always / reject_once / reject_always); `optionId`
+// is the agent-defined string we echo back to select that option.
+type acpPermissionOption struct {
+	OptionID string `json:"optionId"`
+	Kind     string `json:"kind"`
+}
+
+// legacyACPApprovalOptionID is returned only when a request_permission
+// carries no usable options at all (a non-conforming or older ACP
+// agent). It preserves the id ACP backends relied on before we began
+// echoing offered options.
+const legacyACPApprovalOptionID = "approve_for_session"
+
+// acpApprovalOptionPreference ranks known granting optionIds; lower
+// index = preferred. Session scope avoids a per-action round-trip
+// without the permanent on-disk allowlist write a permanent grant
+// ("allow_always") triggers on Hermes (tools/approval.py's
+// save_permanent_allowlist), which would outlive the task and change
+// the runtime owner's local Hermes config. Single-use is the safe
+// universal fallback.
+var acpApprovalOptionPreference = []string{
+	"allow_session",       // Hermes command approval: session-scoped, not persisted
+	"approve_for_session", // other ACP agents' session-scoped id
+	"allow_once",          // Hermes edit + command approval: single action
+	"approve",             // other ACP agents' single-action id
+}
+
+// selectACPApprovalOptionID picks which optionId to return for an
+// auto-approved session/request_permission. It only ever returns an id
+// the agent actually offered, restricted to granting options (never a
+// reject), and prefers session-scoped > single-use > any other grant so
+// a permanent "allow_always" is chosen only when it is the sole grant
+// offered. Falls back to legacyACPApprovalOptionID when the request
+// carries no options.
+func selectACPApprovalOptionID(params json.RawMessage) string {
+	var p struct {
+		Options []acpPermissionOption `json:"options"`
+	}
+	if len(params) > 0 {
+		_ = json.Unmarshal(params, &p)
+	}
+
+	grants := make([]acpPermissionOption, 0, len(p.Options))
+	for _, opt := range p.Options {
+		if opt.OptionID == "" || isACPRejectOption(opt) {
+			continue
+		}
+		grants = append(grants, opt)
+	}
+	if len(grants) == 0 {
+		return legacyACPApprovalOptionID
+	}
+
+	// 1. Preferred known ids, in order.
+	for _, want := range acpApprovalOptionPreference {
+		for _, opt := range grants {
+			if opt.OptionID == want {
+				return opt.OptionID
+			}
+		}
+	}
+	// 2. Any explicitly single-use grant, to avoid a permanent allowlist write.
+	for _, opt := range grants {
+		if strings.EqualFold(strings.TrimSpace(opt.Kind), "allow_once") {
+			return opt.OptionID
+		}
+	}
+	// 3. First remaining grant (last resort; may be a permanent grant).
+	return grants[0].OptionID
+}
+
+// isACPRejectOption reports whether an option denies rather than grants.
+// ACP reject options carry a reject_* kind; we also treat a deny/reject
+// optionId as a denial so an agent that omits kind can't trick us into
+// selecting a rejection.
+func isACPRejectOption(opt acpPermissionOption) bool {
+	if strings.HasPrefix(strings.ToLower(strings.TrimSpace(opt.Kind)), "reject") {
+		return true
+	}
+	lowerID := strings.ToLower(opt.OptionID)
+	return strings.Contains(lowerID, "deny") || strings.Contains(lowerID, "reject")
 }
 
 // acpRPCError is a JSON-RPC error frame returned by the agent process.

--- a/server/pkg/agent/hermes.go
+++ b/server/pkg/agent/hermes.go
@@ -594,11 +594,11 @@ func (c *hermesClient) handleLine(line string) {
 // anything but exactly "allow_once" (acp_adapter/edit_approval.py), so
 // the previous hardcoded "approve_for_session" silently blocked every
 // file write on the Hermes ACP runtime (GitHub multica#5300).
-// selectACPApprovalOptionID picks a *safe* granting option the agent
-// offered (a known session-scoped id or any single-use allow_once). When
-// none is offered it fails closed with a protocol-correct "cancelled"
-// outcome rather than fabricate a selection or auto-grant a permanent
-// "allow_always" that would persist past the task.
+// selectACPPermissionOption picks an option the agent offered — a safe
+// grant when one exists, otherwise an offered single-use reject to deny
+// just this action — and we fail closed with a protocol error when the
+// request offers nothing safely selectable, never a permanent grant or a
+// whole-turn "cancelled".
 func (c *hermesClient) handleAgentRequest(raw map[string]json.RawMessage) {
 	var method string
 	_ = json.Unmarshal(raw["method"], &method)
@@ -611,7 +611,14 @@ func (c *hermesClient) handleAgentRequest(raw map[string]json.RawMessage) {
 	var resp map[string]any
 	switch method {
 	case "session/request_permission":
-		if optionID, ok := selectACPApprovalOptionID(raw["params"]); ok {
+		optionID, grant, ok := selectACPPermissionOption(raw["params"])
+		if ok {
+			// Select an offered option — either a safe grant (approve) or,
+			// when no safe grant exists, an offered reject_once (deny THIS
+			// action). Both are ACP "selected" outcomes; we deliberately do
+			// NOT reply "cancelled" here, which means the whole prompt turn
+			// was cancelled — other ACP backends sharing this client (kimi,
+			// kiro, ...) would abort the entire task, not just this action.
 			resp = map[string]any{
 				"jsonrpc": "2.0",
 				"id":      json.RawMessage(rawID),
@@ -622,23 +629,25 @@ func (c *hermesClient) handleAgentRequest(raw map[string]json.RawMessage) {
 					},
 				},
 			}
-			c.cfg.Logger.Debug("auto-approved agent permission request", "method", method, "optionId", optionID)
+			if grant {
+				c.cfg.Logger.Debug("auto-approved agent permission request", "method", method, "optionId", optionID)
+			} else {
+				c.cfg.Logger.Warn("no safe grant offered; selecting offered reject option", "method", method, "optionId", optionID)
+			}
 		} else {
-			// No safe auto-approvable option was offered (empty, reject-only,
-			// unknown kinds, or only a permanent "allow_always" we refuse to
-			// auto-select because it persists past this task). Fail closed
-			// with ACP's "cancelled" outcome instead of fabricating an
-			// optionId the agent never offered.
+			// The request offered nothing we can safely select: no safe grant
+			// and no single-use reject_once (empty, malformed, permanent-only,
+			// or reject_always-only). Return a protocol error rather than
+			// fabricate an un-offered id or a whole-turn "cancelled".
 			resp = map[string]any{
 				"jsonrpc": "2.0",
 				"id":      json.RawMessage(rawID),
-				"result": map[string]any{
-					"outcome": map[string]any{
-						"outcome": "cancelled",
-					},
+				"error": map[string]any{
+					"code":    -32603,
+					"message": "no auto-selectable permission option offered",
 				},
 			}
-			c.cfg.Logger.Warn("no safe auto-approvable permission option offered; cancelling", "method", method)
+			c.cfg.Logger.Warn("no safely selectable permission option offered; returning error", "method", method)
 		}
 	default:
 		// Unknown agent→client method — reply with standard "method
@@ -675,13 +684,16 @@ type acpPermissionOption struct {
 	Kind     string `json:"kind"`
 }
 
-// ACP v1 PermissionOptionKind grant values. Only these two mean "allow";
+// ACP v1 PermissionOptionKind values. Only the two allow kinds grant;
 // any other or unknown kind is treated as non-granting so a future or
-// abnormal kind can never be auto-approved.
+// abnormal kind can never be auto-approved. reject_once denies a single
+// action (the only reject we auto-select — reject_always would persist a
+// denial the way allow_always persists a grant).
 // https://agentclientprotocol.com/protocol/v1/schema#permissionoptionkind
 const (
 	acpKindAllowOnce   = "allow_once"
 	acpKindAllowAlways = "allow_always"
+	acpKindRejectOnce  = "reject_once"
 )
 
 // acpSessionScopedOptionIDs are optionIds known to grant for the current
@@ -692,31 +704,39 @@ const (
 // equivalent id other ACP backends use.
 var acpSessionScopedOptionIDs = []string{"allow_session", "approve_for_session"}
 
-// selectACPApprovalOptionID picks an optionId to auto-approve a
-// session/request_permission with, returning ok=false when no *safe*
-// granting option was offered. It only ever returns an id the agent
-// actually offered and, per review of GitHub multica#5300, deliberately
-// refuses to auto-select a permanent "allow_always" grant: on Hermes that
-// persists to the runtime owner's on-disk allowlist and would outlive the
-// task (ACP v1 allow_always "remembers the choice"). Grant nature is
-// decided purely by the explicit ACP kind — never by the opaque optionId —
-// and unknown kinds fail closed. Preference: a known session-scoped id,
-// then any single-use (kind=allow_once) grant; anything else → ok=false.
-func selectACPApprovalOptionID(params json.RawMessage) (string, bool) {
+// selectACPPermissionOption decides how to auto-answer a
+// session/request_permission. It returns the offered optionId to select,
+// whether that selection grants (true) or denies (false) the action, and
+// ok=false when the request offers nothing safely selectable (the caller
+// then returns a protocol error rather than fabricate an outcome).
+//
+// It only ever returns an id the agent actually offered. Per review of
+// GitHub multica#5300 it refuses to auto-select a permanent "allow_always"
+// grant — on Hermes that persists to the runtime owner's on-disk allowlist
+// and would outlive the task (ACP v1 allow_always "remembers the choice").
+// Grant nature is decided purely by the explicit ACP kind, never by the
+// opaque optionId, so unknown kinds fail closed. Order of preference:
+//
+//  1. a known session-scoped grant id;
+//  2. any single-use (kind=allow_once) grant;
+//  3. an offered single-use reject_once — deny just this action rather than
+//     reply "cancelled", which other ACP backends read as cancelling the
+//     whole prompt turn.
+func selectACPPermissionOption(params json.RawMessage) (optionID string, grant bool, ok bool) {
 	var p struct {
 		Options []acpPermissionOption `json:"options"`
 	}
 	if len(params) > 0 {
 		if err := json.Unmarshal(params, &p); err != nil {
-			return "", false
+			return "", false, false
 		}
 	}
 
-	// 1. A known session-scoped id, if actually offered with a grant kind.
+	// 1. A known session-scoped grant id, if actually offered with a grant kind.
 	for _, want := range acpSessionScopedOptionIDs {
 		for _, opt := range p.Options {
 			if opt.OptionID == want && isACPGrantKind(opt.Kind) {
-				return opt.OptionID, true
+				return opt.OptionID, true, true
 			}
 		}
 	}
@@ -725,12 +745,18 @@ func selectACPApprovalOptionID(params json.RawMessage) (string, bool) {
 	//    also covers agents that use non-standard option ids.
 	for _, opt := range p.Options {
 		if opt.OptionID != "" && strings.EqualFold(strings.TrimSpace(opt.Kind), acpKindAllowOnce) {
-			return opt.OptionID, true
+			return opt.OptionID, true, true
 		}
 	}
-	// 3. No safe grant offered (empty, reject-only, unknown kinds, or only a
-	//    permanent allow_always). Fail closed.
-	return "", false
+	// 3. No safe grant: deny THIS action by selecting an offered reject_once.
+	for _, opt := range p.Options {
+		if opt.OptionID != "" && strings.EqualFold(strings.TrimSpace(opt.Kind), acpKindRejectOnce) {
+			return opt.OptionID, false, true
+		}
+	}
+	// 4. Nothing safely selectable (empty, malformed, permanent-only, or
+	//    reject_always-only). Signal the caller to return a protocol error.
+	return "", false, false
 }
 
 // isACPGrantKind reports whether an ACP PermissionOptionKind grants the

--- a/server/pkg/agent/hermes.go
+++ b/server/pkg/agent/hermes.go
@@ -594,8 +594,11 @@ func (c *hermesClient) handleLine(line string) {
 // anything but exactly "allow_once" (acp_adapter/edit_approval.py), so
 // the previous hardcoded "approve_for_session" silently blocked every
 // file write on the Hermes ACP runtime (GitHub multica#5300).
-// selectACPApprovalOptionID echoes a granting option instead, so this
-// works across Hermes' edit and command paths and other ACP backends.
+// selectACPApprovalOptionID picks a *safe* granting option the agent
+// offered (a known session-scoped id or any single-use allow_once). When
+// none is offered it fails closed with a protocol-correct "cancelled"
+// outcome rather than fabricate a selection or auto-grant a permanent
+// "allow_always" that would persist past the task.
 func (c *hermesClient) handleAgentRequest(raw map[string]json.RawMessage) {
 	var method string
 	_ = json.Unmarshal(raw["method"], &method)
@@ -608,18 +611,35 @@ func (c *hermesClient) handleAgentRequest(raw map[string]json.RawMessage) {
 	var resp map[string]any
 	switch method {
 	case "session/request_permission":
-		optionID := selectACPApprovalOptionID(raw["params"])
-		resp = map[string]any{
-			"jsonrpc": "2.0",
-			"id":      json.RawMessage(rawID),
-			"result": map[string]any{
-				"outcome": map[string]any{
-					"outcome":  "selected",
-					"optionId": optionID,
+		if optionID, ok := selectACPApprovalOptionID(raw["params"]); ok {
+			resp = map[string]any{
+				"jsonrpc": "2.0",
+				"id":      json.RawMessage(rawID),
+				"result": map[string]any{
+					"outcome": map[string]any{
+						"outcome":  "selected",
+						"optionId": optionID,
+					},
 				},
-			},
+			}
+			c.cfg.Logger.Debug("auto-approved agent permission request", "method", method, "optionId", optionID)
+		} else {
+			// No safe auto-approvable option was offered (empty, reject-only,
+			// unknown kinds, or only a permanent "allow_always" we refuse to
+			// auto-select because it persists past this task). Fail closed
+			// with ACP's "cancelled" outcome instead of fabricating an
+			// optionId the agent never offered.
+			resp = map[string]any{
+				"jsonrpc": "2.0",
+				"id":      json.RawMessage(rawID),
+				"result": map[string]any{
+					"outcome": map[string]any{
+						"outcome": "cancelled",
+					},
+				},
+			}
+			c.cfg.Logger.Warn("no safe auto-approvable permission option offered; cancelling", "method", method)
 		}
-		c.cfg.Logger.Debug("auto-approved agent permission request", "method", method, "optionId", optionID)
 	default:
 		// Unknown agent→client method — reply with standard "method
 		// not found" so the agent doesn't block waiting for us. Better
@@ -649,86 +669,80 @@ func (c *hermesClient) handleAgentRequest(raw map[string]json.RawMessage) {
 // acpPermissionOption is one entry in a session/request_permission
 // request's `options` array. `kind` is the ACP-level classification
 // (allow_once / allow_always / reject_once / reject_always); `optionId`
-// is the agent-defined string we echo back to select that option.
+// is the agent-defined opaque string we echo back to select that option.
 type acpPermissionOption struct {
 	OptionID string `json:"optionId"`
 	Kind     string `json:"kind"`
 }
 
-// legacyACPApprovalOptionID is returned only when a request_permission
-// carries no usable options at all (a non-conforming or older ACP
-// agent). It preserves the id ACP backends relied on before we began
-// echoing offered options.
-const legacyACPApprovalOptionID = "approve_for_session"
+// ACP v1 PermissionOptionKind grant values. Only these two mean "allow";
+// any other or unknown kind is treated as non-granting so a future or
+// abnormal kind can never be auto-approved.
+// https://agentclientprotocol.com/protocol/v1/schema#permissionoptionkind
+const (
+	acpKindAllowOnce   = "allow_once"
+	acpKindAllowAlways = "allow_always"
+)
 
-// acpApprovalOptionPreference ranks known granting optionIds; lower
-// index = preferred. Session scope avoids a per-action round-trip
-// without the permanent on-disk allowlist write a permanent grant
-// ("allow_always") triggers on Hermes (tools/approval.py's
-// save_permanent_allowlist), which would outlive the task and change
-// the runtime owner's local Hermes config. Single-use is the safe
-// universal fallback.
-var acpApprovalOptionPreference = []string{
-	"allow_session",       // Hermes command approval: session-scoped, not persisted
-	"approve_for_session", // other ACP agents' session-scoped id
-	"allow_once",          // Hermes edit + command approval: single action
-	"approve",             // other ACP agents' single-action id
-}
+// acpSessionScopedOptionIDs are optionIds known to grant for the current
+// session only, without persisting a decision. Both Hermes' "allow_session"
+// and its permanent "allow_always" option carry ACP kind "allow_always"
+// (ACP has no session-scoped kind), so kind alone cannot tell them apart —
+// we recognise the session-scoped ones by id. "approve_for_session" is the
+// equivalent id other ACP backends use.
+var acpSessionScopedOptionIDs = []string{"allow_session", "approve_for_session"}
 
-// selectACPApprovalOptionID picks which optionId to return for an
-// auto-approved session/request_permission. It only ever returns an id
-// the agent actually offered, restricted to granting options (never a
-// reject), and prefers session-scoped > single-use > any other grant so
-// a permanent "allow_always" is chosen only when it is the sole grant
-// offered. Falls back to legacyACPApprovalOptionID when the request
-// carries no options.
-func selectACPApprovalOptionID(params json.RawMessage) string {
+// selectACPApprovalOptionID picks an optionId to auto-approve a
+// session/request_permission with, returning ok=false when no *safe*
+// granting option was offered. It only ever returns an id the agent
+// actually offered and, per review of GitHub multica#5300, deliberately
+// refuses to auto-select a permanent "allow_always" grant: on Hermes that
+// persists to the runtime owner's on-disk allowlist and would outlive the
+// task (ACP v1 allow_always "remembers the choice"). Grant nature is
+// decided purely by the explicit ACP kind — never by the opaque optionId —
+// and unknown kinds fail closed. Preference: a known session-scoped id,
+// then any single-use (kind=allow_once) grant; anything else → ok=false.
+func selectACPApprovalOptionID(params json.RawMessage) (string, bool) {
 	var p struct {
 		Options []acpPermissionOption `json:"options"`
 	}
 	if len(params) > 0 {
-		_ = json.Unmarshal(params, &p)
-	}
-
-	grants := make([]acpPermissionOption, 0, len(p.Options))
-	for _, opt := range p.Options {
-		if opt.OptionID == "" || isACPRejectOption(opt) {
-			continue
+		if err := json.Unmarshal(params, &p); err != nil {
+			return "", false
 		}
-		grants = append(grants, opt)
-	}
-	if len(grants) == 0 {
-		return legacyACPApprovalOptionID
 	}
 
-	// 1. Preferred known ids, in order.
-	for _, want := range acpApprovalOptionPreference {
-		for _, opt := range grants {
-			if opt.OptionID == want {
-				return opt.OptionID
+	// 1. A known session-scoped id, if actually offered with a grant kind.
+	for _, want := range acpSessionScopedOptionIDs {
+		for _, opt := range p.Options {
+			if opt.OptionID == want && isACPGrantKind(opt.Kind) {
+				return opt.OptionID, true
 			}
 		}
 	}
-	// 2. Any explicitly single-use grant, to avoid a permanent allowlist write.
-	for _, opt := range grants {
-		if strings.EqualFold(strings.TrimSpace(opt.Kind), "allow_once") {
-			return opt.OptionID
+	// 2. Any single-use grant. kind=allow_once is inherently scoped to this
+	//    one action, so it is safe regardless of the (opaque) optionId — this
+	//    also covers agents that use non-standard option ids.
+	for _, opt := range p.Options {
+		if opt.OptionID != "" && strings.EqualFold(strings.TrimSpace(opt.Kind), acpKindAllowOnce) {
+			return opt.OptionID, true
 		}
 	}
-	// 3. First remaining grant (last resort; may be a permanent grant).
-	return grants[0].OptionID
+	// 3. No safe grant offered (empty, reject-only, unknown kinds, or only a
+	//    permanent allow_always). Fail closed.
+	return "", false
 }
 
-// isACPRejectOption reports whether an option denies rather than grants.
-// ACP reject options carry a reject_* kind; we also treat a deny/reject
-// optionId as a denial so an agent that omits kind can't trick us into
-// selecting a rejection.
-func isACPRejectOption(opt acpPermissionOption) bool {
-	if strings.HasPrefix(strings.ToLower(strings.TrimSpace(opt.Kind)), "reject") {
+// isACPGrantKind reports whether an ACP PermissionOptionKind grants the
+// action. Only the two current allow kinds qualify; every other or unknown
+// value is non-granting, so grant detection fails closed.
+func isACPGrantKind(kind string) bool {
+	switch strings.ToLower(strings.TrimSpace(kind)) {
+	case acpKindAllowOnce, acpKindAllowAlways:
 		return true
+	default:
+		return false
 	}
-	lowerID := strings.ToLower(opt.OptionID)
-	return strings.Contains(lowerID, "deny") || strings.Contains(lowerID, "reject")
 }
 
 // acpRPCError is a JSON-RPC error frame returned by the agent process.

--- a/server/pkg/agent/hermes.go
+++ b/server/pkg/agent/hermes.go
@@ -585,7 +585,9 @@ func (c *hermesClient) handleLine(line string) {
 // handleAgentRequest replies to JSON-RPC requests the agent sends
 // us (agent → client direction). The only one we care about today is
 // `session/request_permission`: the daemon is headless and cannot
-// actually prompt a user, so we auto-approve every action.
+// actually prompt a user, so we answer it ourselves — granting when a
+// safe option is offered, otherwise declining just this action or
+// failing closed (see below).
 //
 // The reply MUST select one of the optionIds the agent actually
 // offered — the ACP permission contract is "pick from these options",

--- a/server/pkg/agent/hermes_test.go
+++ b/server/pkg/agent/hermes_test.go
@@ -579,48 +579,97 @@ func (b *bufferWriter) String() string {
 }
 
 // TestHermesClientAutoApprovesPermissionRequest asserts that when an
-// ACP agent sends us `session/request_permission` (kimi does this on
-// every Shell / file-mutating tool call), the client replies with
-// `approve_for_session` — without this the agent blocks 300s and the
-// task hangs. The id in the reply must match the agent's request id
-// so its in-flight future resolves.
+// ACP agent sends us `session/request_permission`, the client replies by
+// selecting one of the optionIds the agent *actually offered* — an id the
+// agent never offered is treated as a denial and, on Hermes' edit path,
+// silently blocks every file write (GitHub multica#5300). The reply must
+// prefer session-scoped over single-use over a permanent grant, and echo
+// the agent's request id so its in-flight future resolves.
 func TestHermesClientAutoApprovesPermissionRequest(t *testing.T) {
 	t.Parallel()
 
-	w := &bufferWriter{}
-	c := &hermesClient{
-		cfg:     Config{Logger: slog.Default()},
-		stdin:   w,
-		pending: make(map[int]*pendingRPC),
+	cases := []struct {
+		name    string
+		options string
+		wantID  string
+	}{
+		{
+			// Hermes edit-approval offers only these two and requires
+			// exactly "allow_once"; this is the multica#5300 regression
+			// the old hardcoded "approve_for_session" reply broke.
+			name:    "hermes edit approval",
+			options: `[{"optionId":"allow_once","name":"Allow edit","kind":"allow_once"},{"optionId":"deny","name":"Deny","kind":"reject_once"}]`,
+			wantID:  "allow_once",
+		},
+		{
+			// Hermes command approval offers a session option; prefer it
+			// over the permanent "allow_always" (which persists an on-disk
+			// allowlist) and over single-use "allow_once".
+			name:    "command approval prefers session over permanent",
+			options: `[{"optionId":"allow_once","kind":"allow_once"},{"optionId":"allow_session","kind":"allow_always"},{"optionId":"allow_always","kind":"allow_always"},{"optionId":"deny","kind":"reject_once"},{"optionId":"deny_always","kind":"reject_always"}]`,
+			wantID:  "allow_session",
+		},
+		{
+			// A permanent grant is selected only when it is the sole grant.
+			name:    "permanent grant only as last resort",
+			options: `[{"optionId":"allow_always","kind":"allow_always"},{"optionId":"deny","kind":"reject_once"}]`,
+			wantID:  "allow_always",
+		},
+		{
+			// Other ACP agents' session-scoped id is honoured when offered.
+			name:    "session-scoped id honoured",
+			options: `[{"optionId":"approve","kind":"allow_once"},{"optionId":"approve_for_session","kind":"allow_always"},{"optionId":"reject","kind":"reject_once"}]`,
+			wantID:  "approve_for_session",
+		},
+		{
+			// No offered options: fall back to the legacy id rather than hang.
+			name:    "no options falls back to legacy id",
+			options: `[]`,
+			wantID:  "approve_for_session",
+		},
 	}
 
-	c.handleLine(`{"jsonrpc":"2.0","id":42,"method":"session/request_permission","params":{"sessionId":"ses_1","options":[{"optionId":"approve","name":"Approve once","kind":"allow_once"},{"optionId":"approve_for_session","name":"Approve for this session","kind":"allow_always"},{"optionId":"reject","name":"Reject","kind":"reject_once"}],"toolCall":{"toolCallId":"tc_1","title":"Shell","content":[]}}}`)
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
 
-	got := w.String()
-	var resp struct {
-		JSONRPC string `json:"jsonrpc"`
-		ID      int    `json:"id"`
-		Result  struct {
-			Outcome struct {
-				Outcome  string `json:"outcome"`
-				OptionID string `json:"optionId"`
-			} `json:"outcome"`
-		} `json:"result"`
-	}
-	if err := json.Unmarshal([]byte(strings.TrimSpace(got)), &resp); err != nil {
-		t.Fatalf("reply is not valid JSON: %q err=%v", got, err)
-	}
-	if resp.JSONRPC != "2.0" {
-		t.Errorf("jsonrpc: got %q, want 2.0", resp.JSONRPC)
-	}
-	if resp.ID != 42 {
-		t.Errorf("id: got %d, want 42 (must echo agent's request id)", resp.ID)
-	}
-	if resp.Result.Outcome.Outcome != "selected" {
-		t.Errorf("outcome.outcome: got %q, want %q", resp.Result.Outcome.Outcome, "selected")
-	}
-	if resp.Result.Outcome.OptionID != "approve_for_session" {
-		t.Errorf("outcome.optionId: got %q, want %q", resp.Result.Outcome.OptionID, "approve_for_session")
+			w := &bufferWriter{}
+			c := &hermesClient{
+				cfg:     Config{Logger: slog.Default()},
+				stdin:   w,
+				pending: make(map[int]*pendingRPC),
+			}
+
+			c.handleLine(`{"jsonrpc":"2.0","id":42,"method":"session/request_permission","params":{"sessionId":"ses_1","options":` + tc.options + `,"toolCall":{"toolCallId":"tc_1","title":"write: reply.md","content":[]}}}`)
+
+			got := w.String()
+			var resp struct {
+				JSONRPC string `json:"jsonrpc"`
+				ID      int    `json:"id"`
+				Result  struct {
+					Outcome struct {
+						Outcome  string `json:"outcome"`
+						OptionID string `json:"optionId"`
+					} `json:"outcome"`
+				} `json:"result"`
+			}
+			if err := json.Unmarshal([]byte(strings.TrimSpace(got)), &resp); err != nil {
+				t.Fatalf("reply is not valid JSON: %q err=%v", got, err)
+			}
+			if resp.JSONRPC != "2.0" {
+				t.Errorf("jsonrpc: got %q, want 2.0", resp.JSONRPC)
+			}
+			if resp.ID != 42 {
+				t.Errorf("id: got %d, want 42 (must echo agent's request id)", resp.ID)
+			}
+			if resp.Result.Outcome.Outcome != "selected" {
+				t.Errorf("outcome.outcome: got %q, want %q", resp.Result.Outcome.Outcome, "selected")
+			}
+			if resp.Result.Outcome.OptionID != tc.wantID {
+				t.Errorf("outcome.optionId: got %q, want %q", resp.Result.Outcome.OptionID, tc.wantID)
+			}
+		})
 	}
 }
 

--- a/server/pkg/agent/hermes_test.go
+++ b/server/pkg/agent/hermes_test.go
@@ -578,54 +578,85 @@ func (b *bufferWriter) String() string {
 	return b.buf.String()
 }
 
-// TestHermesClientAutoApprovesPermissionRequest asserts that when an
-// ACP agent sends us `session/request_permission`, the client replies by
-// selecting one of the optionIds the agent *actually offered* — an id the
-// agent never offered is treated as a denial and, on Hermes' edit path,
-// silently blocks every file write (GitHub multica#5300). The reply must
-// prefer session-scoped over single-use over a permanent grant, and echo
-// the agent's request id so its in-flight future resolves.
+// TestHermesClientAutoApprovesPermissionRequest asserts how the client
+// answers an ACP agent's `session/request_permission`. It must select an
+// optionId the agent *actually offered* — an id the agent never offered is
+// treated as a denial and, on Hermes' edit path, silently blocks every file
+// write (GitHub multica#5300). It prefers a session-scoped grant over a
+// single-use one, refuses to auto-select a permanent "allow_always" (which
+// persists to the runtime owner's on-disk allowlist), and fails closed with
+// a "cancelled" outcome when no safe grant is offered rather than fabricate
+// a selection. The reply always echoes the agent's request id.
 func TestHermesClientAutoApprovesPermissionRequest(t *testing.T) {
 	t.Parallel()
 
 	cases := []struct {
-		name    string
-		options string
-		wantID  string
+		name        string
+		options     string
+		wantOutcome string // "selected" or "cancelled"
+		wantID      string // expected optionId when wantOutcome == "selected"
 	}{
 		{
 			// Hermes edit-approval offers only these two and requires
 			// exactly "allow_once"; this is the multica#5300 regression
 			// the old hardcoded "approve_for_session" reply broke.
-			name:    "hermes edit approval",
-			options: `[{"optionId":"allow_once","name":"Allow edit","kind":"allow_once"},{"optionId":"deny","name":"Deny","kind":"reject_once"}]`,
-			wantID:  "allow_once",
+			name:        "hermes edit approval selects allow_once",
+			options:     `[{"optionId":"allow_once","name":"Allow edit","kind":"allow_once"},{"optionId":"deny","name":"Deny","kind":"reject_once"}]`,
+			wantOutcome: "selected",
+			wantID:      "allow_once",
 		},
 		{
-			// Hermes command approval offers a session option; prefer it
-			// over the permanent "allow_always" (which persists an on-disk
-			// allowlist) and over single-use "allow_once".
-			name:    "command approval prefers session over permanent",
-			options: `[{"optionId":"allow_once","kind":"allow_once"},{"optionId":"allow_session","kind":"allow_always"},{"optionId":"allow_always","kind":"allow_always"},{"optionId":"deny","kind":"reject_once"},{"optionId":"deny_always","kind":"reject_always"}]`,
-			wantID:  "allow_session",
-		},
-		{
-			// A permanent grant is selected only when it is the sole grant.
-			name:    "permanent grant only as last resort",
-			options: `[{"optionId":"allow_always","kind":"allow_always"},{"optionId":"deny","kind":"reject_once"}]`,
-			wantID:  "allow_always",
+			// Hermes command approval offers a session option; prefer it over
+			// both the permanent "allow_always" and single-use "allow_once".
+			name:        "command approval prefers session over permanent",
+			options:     `[{"optionId":"allow_once","kind":"allow_once"},{"optionId":"allow_session","kind":"allow_always"},{"optionId":"allow_always","kind":"allow_always"},{"optionId":"deny","kind":"reject_once"},{"optionId":"deny_always","kind":"reject_always"}]`,
+			wantOutcome: "selected",
+			wantID:      "allow_session",
 		},
 		{
 			// Other ACP agents' session-scoped id is honoured when offered.
-			name:    "session-scoped id honoured",
-			options: `[{"optionId":"approve","kind":"allow_once"},{"optionId":"approve_for_session","kind":"allow_always"},{"optionId":"reject","kind":"reject_once"}]`,
-			wantID:  "approve_for_session",
+			name:        "session-scoped id honoured",
+			options:     `[{"optionId":"approve","kind":"allow_once"},{"optionId":"approve_for_session","kind":"allow_always"},{"optionId":"reject","kind":"reject_once"}]`,
+			wantOutcome: "selected",
+			wantID:      "approve_for_session",
 		},
 		{
-			// No offered options: fall back to the legacy id rather than hang.
-			name:    "no options falls back to legacy id",
-			options: `[]`,
-			wantID:  "approve_for_session",
+			// Grant nature comes from the ACP kind, not the opaque optionId:
+			// a single-use option with a non-standard id is still selected.
+			name:        "non-standard single-use id selected by kind",
+			options:     `[{"optionId":"yolo-42","kind":"allow_once"},{"optionId":"nope","kind":"reject_once"}]`,
+			wantOutcome: "selected",
+			wantID:      "yolo-42",
+		},
+		{
+			// Only a permanent grant offered: fail closed, never auto-persist.
+			name:        "permanent-only grant fails closed",
+			options:     `[{"optionId":"allow_always","kind":"allow_always"},{"optionId":"deny","kind":"reject_once"}]`,
+			wantOutcome: "cancelled",
+		},
+		{
+			// Reject-only options: fail closed.
+			name:        "reject-only fails closed",
+			options:     `[{"optionId":"deny","kind":"reject_once"},{"optionId":"deny_always","kind":"reject_always"}]`,
+			wantOutcome: "cancelled",
+		},
+		{
+			// Unknown / future kind must not be auto-approved by name.
+			name:        "unknown kind fails closed",
+			options:     `[{"optionId":"allow_forever","kind":"allow_super"},{"optionId":"deny","kind":"reject_once"}]`,
+			wantOutcome: "cancelled",
+		},
+		{
+			// No options at all: fail closed rather than fabricate a selection.
+			name:        "empty options fails closed",
+			options:     `[]`,
+			wantOutcome: "cancelled",
+		},
+		{
+			// Malformed options payload (not an array): fail closed.
+			name:        "malformed options fails closed",
+			options:     `"not-an-array"`,
+			wantOutcome: "cancelled",
 		},
 	}
 
@@ -663,11 +694,18 @@ func TestHermesClientAutoApprovesPermissionRequest(t *testing.T) {
 			if resp.ID != 42 {
 				t.Errorf("id: got %d, want 42 (must echo agent's request id)", resp.ID)
 			}
-			if resp.Result.Outcome.Outcome != "selected" {
-				t.Errorf("outcome.outcome: got %q, want %q", resp.Result.Outcome.Outcome, "selected")
+			if resp.Result.Outcome.Outcome != tc.wantOutcome {
+				t.Errorf("outcome.outcome: got %q, want %q", resp.Result.Outcome.Outcome, tc.wantOutcome)
 			}
-			if resp.Result.Outcome.OptionID != tc.wantID {
-				t.Errorf("outcome.optionId: got %q, want %q", resp.Result.Outcome.OptionID, tc.wantID)
+			switch tc.wantOutcome {
+			case "selected":
+				if resp.Result.Outcome.OptionID != tc.wantID {
+					t.Errorf("outcome.optionId: got %q, want %q", resp.Result.Outcome.OptionID, tc.wantID)
+				}
+			case "cancelled":
+				if resp.Result.Outcome.OptionID != "" {
+					t.Errorf("cancelled outcome must not carry an optionId, got %q", resp.Result.Outcome.OptionID)
+				}
 			}
 		})
 	}

--- a/server/pkg/agent/hermes_test.go
+++ b/server/pkg/agent/hermes_test.go
@@ -584,79 +584,92 @@ func (b *bufferWriter) String() string {
 // treated as a denial and, on Hermes' edit path, silently blocks every file
 // write (GitHub multica#5300). It prefers a session-scoped grant over a
 // single-use one, refuses to auto-select a permanent "allow_always" (which
-// persists to the runtime owner's on-disk allowlist), and fails closed with
-// a "cancelled" outcome when no safe grant is offered rather than fabricate
-// a selection. The reply always echoes the agent's request id.
+// persists to the runtime owner's on-disk allowlist), denies a single action
+// by selecting an offered reject_once rather than replying "cancelled" (which
+// other ACP backends read as cancelling the whole turn), and returns a
+// protocol error when nothing is safely selectable. The reply always echoes
+// the agent's request id.
 func TestHermesClientAutoApprovesPermissionRequest(t *testing.T) {
 	t.Parallel()
 
 	cases := []struct {
-		name        string
-		options     string
-		wantOutcome string // "selected" or "cancelled"
-		wantID      string // expected optionId when wantOutcome == "selected"
+		name    string
+		options string
+		wantErr bool   // true → JSON-RPC error reply, no outcome
+		wantID  string // expected selected optionId when wantErr == false
 	}{
 		{
 			// Hermes edit-approval offers only these two and requires
 			// exactly "allow_once"; this is the multica#5300 regression
 			// the old hardcoded "approve_for_session" reply broke.
-			name:        "hermes edit approval selects allow_once",
-			options:     `[{"optionId":"allow_once","name":"Allow edit","kind":"allow_once"},{"optionId":"deny","name":"Deny","kind":"reject_once"}]`,
-			wantOutcome: "selected",
-			wantID:      "allow_once",
+			name:    "hermes edit approval selects allow_once",
+			options: `[{"optionId":"allow_once","name":"Allow edit","kind":"allow_once"},{"optionId":"deny","name":"Deny","kind":"reject_once"}]`,
+			wantID:  "allow_once",
 		},
 		{
 			// Hermes command approval offers a session option; prefer it over
 			// both the permanent "allow_always" and single-use "allow_once".
-			name:        "command approval prefers session over permanent",
-			options:     `[{"optionId":"allow_once","kind":"allow_once"},{"optionId":"allow_session","kind":"allow_always"},{"optionId":"allow_always","kind":"allow_always"},{"optionId":"deny","kind":"reject_once"},{"optionId":"deny_always","kind":"reject_always"}]`,
-			wantOutcome: "selected",
-			wantID:      "allow_session",
+			name:    "command approval prefers session over permanent",
+			options: `[{"optionId":"allow_once","kind":"allow_once"},{"optionId":"allow_session","kind":"allow_always"},{"optionId":"allow_always","kind":"allow_always"},{"optionId":"deny","kind":"reject_once"},{"optionId":"deny_always","kind":"reject_always"}]`,
+			wantID:  "allow_session",
 		},
 		{
 			// Other ACP agents' session-scoped id is honoured when offered.
-			name:        "session-scoped id honoured",
-			options:     `[{"optionId":"approve","kind":"allow_once"},{"optionId":"approve_for_session","kind":"allow_always"},{"optionId":"reject","kind":"reject_once"}]`,
-			wantOutcome: "selected",
-			wantID:      "approve_for_session",
+			name:    "session-scoped id honoured",
+			options: `[{"optionId":"approve","kind":"allow_once"},{"optionId":"approve_for_session","kind":"allow_always"},{"optionId":"reject","kind":"reject_once"}]`,
+			wantID:  "approve_for_session",
 		},
 		{
 			// Grant nature comes from the ACP kind, not the opaque optionId:
 			// a single-use option with a non-standard id is still selected.
-			name:        "non-standard single-use id selected by kind",
-			options:     `[{"optionId":"yolo-42","kind":"allow_once"},{"optionId":"nope","kind":"reject_once"}]`,
-			wantOutcome: "selected",
-			wantID:      "yolo-42",
+			name:    "non-standard single-use id selected by kind",
+			options: `[{"optionId":"yolo-42","kind":"allow_once"},{"optionId":"nope","kind":"reject_once"}]`,
+			wantID:  "yolo-42",
 		},
 		{
-			// Only a permanent grant offered: fail closed, never auto-persist.
-			name:        "permanent-only grant fails closed",
-			options:     `[{"optionId":"allow_always","kind":"allow_always"},{"optionId":"deny","kind":"reject_once"}]`,
-			wantOutcome: "cancelled",
+			// Only a permanent grant offered: never auto-persist it; deny this
+			// action by selecting the offered single-use reject instead.
+			name:    "permanent grant refused, offered reject_once selected",
+			options: `[{"optionId":"allow_always","kind":"allow_always"},{"optionId":"deny","kind":"reject_once"}]`,
+			wantID:  "deny",
 		},
 		{
-			// Reject-only options: fail closed.
-			name:        "reject-only fails closed",
-			options:     `[{"optionId":"deny","kind":"reject_once"},{"optionId":"deny_always","kind":"reject_always"}]`,
-			wantOutcome: "cancelled",
+			// No grant at all: deny this action via the offered reject_once.
+			name:    "reject-only selects reject_once",
+			options: `[{"optionId":"deny","kind":"reject_once"},{"optionId":"deny_always","kind":"reject_always"}]`,
+			wantID:  "deny",
 		},
 		{
-			// Unknown / future kind must not be auto-approved by name.
-			name:        "unknown kind fails closed",
-			options:     `[{"optionId":"allow_forever","kind":"allow_super"},{"optionId":"deny","kind":"reject_once"}]`,
-			wantOutcome: "cancelled",
+			// Unknown / future kind is not a grant; fall through to reject_once.
+			name:    "unknown kind selects offered reject_once",
+			options: `[{"optionId":"allow_forever","kind":"allow_super"},{"optionId":"deny","kind":"reject_once"}]`,
+			wantID:  "deny",
 		},
 		{
-			// No options at all: fail closed rather than fabricate a selection.
-			name:        "empty options fails closed",
-			options:     `[]`,
-			wantOutcome: "cancelled",
+			// Permanent grant with no single-use reject: nothing safely
+			// selectable → protocol error, not a fabricated outcome.
+			name:    "permanent-only without reject_once errors",
+			options: `[{"optionId":"allow_always","kind":"allow_always"}]`,
+			wantErr: true,
 		},
 		{
-			// Malformed options payload (not an array): fail closed.
-			name:        "malformed options fails closed",
-			options:     `"not-an-array"`,
-			wantOutcome: "cancelled",
+			// Only a permanent reject offered: we don't auto-persist a denial
+			// either → protocol error.
+			name:    "reject_always-only errors",
+			options: `[{"optionId":"deny_always","kind":"reject_always"}]`,
+			wantErr: true,
+		},
+		{
+			// No options at all: protocol error rather than fabricate a reply.
+			name:    "empty options errors",
+			options: `[]`,
+			wantErr: true,
+		},
+		{
+			// Malformed options payload (not an array): protocol error.
+			name:    "malformed options errors",
+			options: `"not-an-array"`,
+			wantErr: true,
 		},
 	}
 
@@ -678,12 +691,16 @@ func TestHermesClientAutoApprovesPermissionRequest(t *testing.T) {
 			var resp struct {
 				JSONRPC string `json:"jsonrpc"`
 				ID      int    `json:"id"`
-				Result  struct {
+				Result  *struct {
 					Outcome struct {
 						Outcome  string `json:"outcome"`
 						OptionID string `json:"optionId"`
 					} `json:"outcome"`
 				} `json:"result"`
+				Error *struct {
+					Code    int    `json:"code"`
+					Message string `json:"message"`
+				} `json:"error"`
 			}
 			if err := json.Unmarshal([]byte(strings.TrimSpace(got)), &resp); err != nil {
 				t.Fatalf("reply is not valid JSON: %q err=%v", got, err)
@@ -694,18 +711,26 @@ func TestHermesClientAutoApprovesPermissionRequest(t *testing.T) {
 			if resp.ID != 42 {
 				t.Errorf("id: got %d, want 42 (must echo agent's request id)", resp.ID)
 			}
-			if resp.Result.Outcome.Outcome != tc.wantOutcome {
-				t.Errorf("outcome.outcome: got %q, want %q", resp.Result.Outcome.Outcome, tc.wantOutcome)
+			if tc.wantErr {
+				if resp.Error == nil {
+					t.Errorf("want a JSON-RPC error reply, got result %+v", resp.Result)
+				}
+				if resp.Result != nil {
+					t.Errorf("error reply must not carry a result, got %+v", resp.Result)
+				}
+				return
 			}
-			switch tc.wantOutcome {
-			case "selected":
-				if resp.Result.Outcome.OptionID != tc.wantID {
-					t.Errorf("outcome.optionId: got %q, want %q", resp.Result.Outcome.OptionID, tc.wantID)
-				}
-			case "cancelled":
-				if resp.Result.Outcome.OptionID != "" {
-					t.Errorf("cancelled outcome must not carry an optionId, got %q", resp.Result.Outcome.OptionID)
-				}
+			if resp.Error != nil {
+				t.Fatalf("unexpected JSON-RPC error reply: %+v", resp.Error)
+			}
+			if resp.Result == nil {
+				t.Fatalf("want a selected outcome, got no result: %q", got)
+			}
+			if resp.Result.Outcome.Outcome != "selected" {
+				t.Errorf("outcome.outcome: got %q, want %q", resp.Result.Outcome.Outcome, "selected")
+			}
+			if resp.Result.Outcome.OptionID != tc.wantID {
+				t.Errorf("outcome.optionId: got %q, want %q", resp.Result.Outcome.OptionID, tc.wantID)
 			}
 		})
 	}

--- a/server/pkg/agent/kimi.go
+++ b/server/pkg/agent/kimi.go
@@ -53,8 +53,9 @@ func (b *kimiBackend) Execute(ctx context.Context, prompt string, opts ExecOptio
 
 	// `kimi acp` ignores --yolo / --auto-approve (they're flags on the
 	// root `kimi` command, not on the `acp` subcommand). Instead, the
-	// daemon auto-approves in hermesClient.handleAgentRequest by replying
-	// "approve_for_session" to every session/request_permission request.
+	// daemon auto-approves in hermesClient.handleAgentRequest by selecting
+	// a safe granting option the agent offered (see
+	// selectACPApprovalOptionID) for each session/request_permission request.
 	kimiArgs := append([]string{"acp"}, filterCustomArgs(opts.CustomArgs, kimiBlockedArgs, b.cfg.Logger)...)
 	cmd := exec.CommandContext(runCtx, execPath, kimiArgs...)
 	hideAgentWindow(cmd)


### PR DESCRIPTION
## Summary

Fixes #5300 — on the Hermes ACP runtime, an agent's file writes (including the final `reply.md` handoff) are silently denied, so a task that finished its actual work can end with no delivered output.

**Root cause.** When auto-approving Hermes' `session/request_permission`, the daemon hardcoded `optionId: "approve_for_session"` (`server/pkg/agent/hermes.go`). The ACP permission contract is "select one of the options the agent offered," and Hermes' edit-approval path (`acp_adapter/edit_approval.py`) offers only `["allow_once", "deny"]` and treats anything but exactly `allow_once` as a denial. Since `approve_for_session` was never offered, every `write_file` / `patch` was rejected with `Edit approval denied by ACP client; file was not modified.`

`HERMES_YOLO_MODE=1` did not help: it only suppresses Hermes' dangerous-shell-command prompts (`tools/approval.py`); it is not consulted by the ACP edit-approval guard. That is also why shell-based writes worked while `write_file` did not.

## Fix

`handleAgentRequest` now selects an option the agent **actually offered**, via `selectACPPermissionOption(params) (optionId, grant, ok)`. Grant nature is decided **purely by the explicit ACP `kind`** (never by the opaque `optionId`), and the decision order is:

1. a known **session-scoped** grant id (`allow_session` / `approve_for_session`) offered with a grant kind → `selected`;
2. otherwise any **single-use** grant (`kind=allow_once`, incl. non-standard ids) → `selected`;
3. otherwise, to deny **just this action**, an offered **`reject_once`** → `selected` (this is how ACP clients decline a single permission);
4. otherwise (empty, malformed, permanent-only, or `reject_always`-only) → a **JSON-RPC error**.

Design guarantees, per review:

- **Never auto-selects a permanent `allow_always`.** On Hermes that persists to the runtime owner's on-disk allowlist (`save_permanent_allowlist`) and would outlive the task (ACP v1 `allow_always` "remembers the choice"). `reject_always` is likewise never auto-selected.
- **Never fabricates an un-offered id**, and **never replies `"cancelled"`** for a per-action denial — `cancelled` means the whole prompt turn was cancelled, which other ACP backends sharing this client (kimi/kiro/qoder/trae) could read as aborting the entire task. A single denied action uses an offered `reject_once`; a genuinely unselectable request returns a protocol error.
- **Fails closed on unknown kinds** — only the two current ACP allow kinds grant.

This resolves the Hermes edit path (→ selects `allow_once`) and command path (→ selects `allow_session`), and behaves correctly for other ACP backends.

The stale `kimi.go` comment describing the old hardcoded reply is updated.

## Verification

- **Live reproduction with the real `hermes acp` (v0.18.2):** a minimal ACP client mimicking the daemon confirmed the request offers `["allow_once","deny"]` even under `HERMES_YOLO_MODE=1`; replying `approve_for_session` → `reply.md` not created (denied); replying with the offered `allow_once` → `reply.md` written. This is exactly the pre/post-fix behavior; the fix selects `allow_once` on this path.
- **Unit tests** (`hermes_test.go`) — the previous test asserted `approve_for_session` against a fabricated option list Hermes never offers (green test, broken prod). Replaced with a table-driven test pinning the real option sets and all branches: edit path → `allow_once` (the #5300 regression), command path → `allow_session` (not the permanent `allow_always`), non-standard single-use id selected by kind, permanent/unknown-kind/reject-only → offered `reject_once`, and permanent-only / `reject_always`-only / empty / malformed params → JSON-RPC error.
- `gofmt`, `go vet`, and `go test ./server/pkg/agent/` pass; CI green.

## Note / possible follow-up

Under the default `ask` policy each write still round-trips a permission request (now correctly approved). A `session/set_mode` → `dont_ask` after `session/new` would auto-approve non-sensitive edits and cut the round-trips, but sensitive paths still prompt, so this reply-selection fix is required regardless. Left out to keep this PR focused on the bug.
