### PR TITLE
MUL-4490: KAP-769: recover queued-expired create_issue tasks

### DIFF
--- a/server/cmd/server/queued_expired_recovery_test.go
+++ b/server/cmd/server/queued_expired_recovery_test.go
@@ -1,0 +1,477 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/multica-ai/multica/server/internal/events"
+	"github.com/multica-ai/multica/server/internal/service"
+	db "github.com/multica-ai/multica/server/pkg/db/generated"
+)
+
+type queuedExpiredCreateIssueFixture struct {
+	agentID     string
+	runtimeID   string
+	autopilotID string
+	runID       string
+	issueID     string
+	taskID      string
+}
+
+func setupQueuedExpiredCreateIssueFixture(t *testing.T) queuedExpiredCreateIssueFixture {
+	t.Helper()
+	if testPool == nil {
+		t.Skip("database not available")
+	}
+	ctx := context.Background()
+	var f queuedExpiredCreateIssueFixture
+	if err := testPool.QueryRow(ctx, `
+		SELECT a.id, a.runtime_id
+		FROM agent a
+		WHERE a.workspace_id = $1 AND a.runtime_id IS NOT NULL AND a.archived_at IS NULL
+		LIMIT 1
+	`, testWorkspaceID).Scan(&f.agentID, &f.runtimeID); err != nil {
+		t.Fatalf("setup: get agent/runtime: %v", err)
+	}
+	if err := testPool.QueryRow(ctx, `
+		INSERT INTO autopilot (
+			workspace_id, title, assignee_type, assignee_id, execution_mode,
+			created_by_type, created_by_id
+		)
+		VALUES ($1, 'queued-expired recovery fixture', 'agent', $2, 'create_issue', 'member', $3)
+		RETURNING id
+	`, testWorkspaceID, f.agentID, testUserID).Scan(&f.autopilotID); err != nil {
+		t.Fatalf("setup: create autopilot: %v", err)
+	}
+	if err := testPool.QueryRow(ctx, `
+		INSERT INTO issue (
+			workspace_id, title, status, priority, creator_type, creator_id,
+			assignee_type, assignee_id, origin_type, origin_id
+		)
+		VALUES ($1, 'queued-expired created issue', 'todo', 'none', 'agent', $2,
+			'agent', $2, 'autopilot', $3)
+		RETURNING id
+	`, testWorkspaceID, f.agentID, f.autopilotID).Scan(&f.issueID); err != nil {
+		t.Fatalf("setup: create issue: %v", err)
+	}
+	if err := testPool.QueryRow(ctx, `
+		INSERT INTO autopilot_run (autopilot_id, source, status, issue_id)
+		VALUES ($1, 'schedule', 'issue_created', $2)
+		RETURNING id
+	`, f.autopilotID, f.issueID).Scan(&f.runID); err != nil {
+		t.Fatalf("setup: create autopilot run: %v", err)
+	}
+	if err := testPool.QueryRow(ctx, `
+		INSERT INTO agent_task_queue (
+			agent_id, runtime_id, issue_id, status, priority, created_at,
+			attempt, max_attempts
+		)
+		VALUES ($1, $2, $3, 'queued', 0, now() - interval '3 hours', 1, 2)
+		RETURNING id
+	`, f.agentID, f.runtimeID, f.issueID).Scan(&f.taskID); err != nil {
+		t.Fatalf("setup: create failed task: %v", err)
+	}
+	t.Cleanup(func() {
+		testPool.Exec(context.Background(), `DELETE FROM issue WHERE id = $1`, f.issueID)
+		testPool.Exec(context.Background(), `DELETE FROM autopilot WHERE id = $1`, f.autopilotID)
+	})
+	return f
+}
+
+func expireQueuedFixture(t *testing.T, taskSvc *service.TaskService, queries *db.Queries, taskID string) db.AgentTaskQueue {
+	t.Helper()
+	sweepExpiredQueuedTasks(context.Background(), queries, taskSvc)
+	task, err := queries.GetAgentTask(context.Background(), parseUUID(taskID))
+	if err != nil {
+		t.Fatalf("load expired task: %v", err)
+	}
+	if task.Status != "failed" || !task.FailureReason.Valid || task.FailureReason.String != "queued_expired" {
+		t.Fatalf("expired task = status %q reason %#v", task.Status, task.FailureReason)
+	}
+	return task
+}
+
+func TestHandleFailedTasksSurfacesQueuedExpiredCreateIssue(t *testing.T) {
+	f := setupQueuedExpiredCreateIssueFixture(t)
+	ctx := context.Background()
+	queries := db.New(testPool)
+	bus := events.New()
+	taskSvc := service.NewTaskService(queries, testPool, nil, bus)
+	autopilotSvc := service.NewAutopilotService(queries, testPool, bus, taskSvc)
+	registerAutopilotListeners(bus, autopilotSvc)
+	expireQueuedFixture(t, taskSvc, queries, f.taskID)
+
+	var status string
+	var metadataJSON []byte
+	if err := testPool.QueryRow(ctx, `SELECT status, metadata FROM issue WHERE id = $1`, f.issueID).Scan(&status, &metadataJSON); err != nil {
+		t.Fatalf("read surfaced issue: %v", err)
+	}
+	if status != "blocked" {
+		t.Fatalf("issue status = %q, want blocked", status)
+	}
+	var metadata map[string]any
+	if err := json.Unmarshal(metadataJSON, &metadata); err != nil {
+		t.Fatalf("decode metadata: %v", err)
+	}
+	if metadata["pipeline_status"] != "queued_expired" {
+		t.Fatalf("pipeline_status = %#v, want queued_expired", metadata["pipeline_status"])
+	}
+	if metadata["waiting_on"] != "runtime_reconnect" {
+		t.Fatalf("waiting_on = %#v, want runtime_reconnect", metadata["waiting_on"])
+	}
+
+	var comments int
+	if err := testPool.QueryRow(ctx, `
+		SELECT count(*) FROM comment
+		WHERE issue_id = $1 AND type = 'system' AND source_task_id = $2
+	`, f.issueID, f.taskID).Scan(&comments); err != nil {
+		t.Fatalf("count expiry comments: %v", err)
+	}
+	if comments != 1 {
+		t.Fatalf("expiry system comments = %d, want 1", comments)
+	}
+}
+
+func TestRecoverQueuedExpiredCreateIssueOnRuntimeReconnect(t *testing.T) {
+	f := setupQueuedExpiredCreateIssueFixture(t)
+	ctx := context.Background()
+	queries := db.New(testPool)
+	bus := events.New()
+	taskSvc := service.NewTaskService(queries, testPool, nil, bus)
+	autopilotSvc := service.NewAutopilotService(queries, testPool, bus, taskSvc)
+	registerAutopilotListeners(bus, autopilotSvc)
+	expireQueuedFixture(t, taskSvc, queries, f.taskID)
+
+	recovered, err := taskSvc.RecoverQueuedExpiredCreateIssueTasksForRuntime(ctx, parseUUID(f.runtimeID))
+	if err != nil {
+		t.Fatalf("recover on reconnect: %v", err)
+	}
+	if recovered != 1 {
+		t.Fatalf("recovered = %d, want 1", recovered)
+	}
+
+	var status string
+	var metadataJSON []byte
+	if err := testPool.QueryRow(ctx, `SELECT status, metadata FROM issue WHERE id = $1`, f.issueID).Scan(&status, &metadataJSON); err != nil {
+		t.Fatalf("read recovered issue: %v", err)
+	}
+	if status != "todo" {
+		t.Fatalf("issue status = %q, want todo", status)
+	}
+	var metadata map[string]any
+	if err := json.Unmarshal(metadataJSON, &metadata); err != nil {
+		t.Fatalf("decode metadata: %v", err)
+	}
+	if metadata["pipeline_status"] != "recovery_queued" {
+		t.Fatalf("pipeline_status = %#v, want recovery_queued", metadata["pipeline_status"])
+	}
+	if metadata["waiting_on"] != "runtime_execution" {
+		t.Fatalf("waiting_on = %#v, want runtime_execution", metadata["waiting_on"])
+	}
+
+	var parentID *string
+	var attempt, maxAttempts int
+	if err := testPool.QueryRow(ctx, `
+		SELECT parent_task_id::text, attempt, max_attempts
+		FROM agent_task_queue
+		WHERE issue_id = $1 AND id <> $2
+	`, f.issueID, f.taskID).Scan(&parentID, &attempt, &maxAttempts); err != nil {
+		t.Fatalf("read recovery task: %v", err)
+	}
+	if parentID == nil || *parentID != f.taskID {
+		t.Fatalf("recovery parent = %#v, want %s", parentID, f.taskID)
+	}
+	if attempt != 2 || maxAttempts != 2 {
+		t.Fatalf("recovery budget = %d/%d, want 2/2", attempt, maxAttempts)
+	}
+}
+
+func TestRecoverQueuedExpiredCreateIssueDeduplicatesReconnects(t *testing.T) {
+	f := setupQueuedExpiredCreateIssueFixture(t)
+	ctx := context.Background()
+	queries := db.New(testPool)
+	bus := events.New()
+	taskSvc := service.NewTaskService(queries, testPool, nil, bus)
+	autopilotSvc := service.NewAutopilotService(queries, testPool, bus, taskSvc)
+	registerAutopilotListeners(bus, autopilotSvc)
+	expireQueuedFixture(t, taskSvc, queries, f.taskID)
+
+	first, err := taskSvc.RecoverQueuedExpiredCreateIssueTasksForRuntime(ctx, parseUUID(f.runtimeID))
+	if err != nil {
+		t.Fatalf("first reconnect: %v", err)
+	}
+	second, err := taskSvc.RecoverQueuedExpiredCreateIssueTasksForRuntime(ctx, parseUUID(f.runtimeID))
+	if err != nil {
+		t.Fatalf("second reconnect: %v", err)
+	}
+	if first != 1 || second != 0 {
+		t.Fatalf("recovered counts = %d then %d, want 1 then 0", first, second)
+	}
+	var children int
+	if err := testPool.QueryRow(ctx, `SELECT count(*) FROM agent_task_queue WHERE parent_task_id = $1`, f.taskID).Scan(&children); err != nil {
+		t.Fatalf("count recovery children: %v", err)
+	}
+	if children != 1 {
+		t.Fatalf("recovery children = %d, want 1", children)
+	}
+}
+
+func TestRecoverQueuedExpiredCreateIssueWaitsForDurableSurface(t *testing.T) {
+	f := setupQueuedExpiredCreateIssueFixture(t)
+	ctx := context.Background()
+	queries := db.New(testPool)
+	taskSvc := service.NewTaskService(queries, testPool, nil, events.New())
+
+	failed, err := queries.ExpireStaleQueuedTasks(ctx, db.ExpireStaleQueuedTasksParams{
+		TtlSecs: 3600, MaxPerTick: 100,
+	})
+	if err != nil {
+		t.Fatalf("expire queued task: %v", err)
+	}
+	if len(failed) != 1 || failed[0].ID != parseUUID(f.taskID) {
+		t.Fatalf("expired tasks = %#v, want fixture task", failed)
+	}
+
+	// A heartbeat can land after the task failure commits but before failure
+	// side effects run. Recovery must wait instead of racing the durable block.
+	if recovered, err := taskSvc.RecoverQueuedExpiredCreateIssueTasksForRuntime(ctx, parseUUID(f.runtimeID)); err != nil || recovered != 0 {
+		t.Fatalf("pre-surface recovery = %d, %v; want 0, nil", recovered, err)
+	}
+	taskSvc.HandleFailedTasks(ctx, failed)
+	if recovered, err := taskSvc.RecoverQueuedExpiredCreateIssueTasksForRuntime(ctx, parseUUID(f.runtimeID)); err != nil || recovered != 1 {
+		t.Fatalf("post-surface recovery = %d, %v; want 1, nil", recovered, err)
+	}
+
+	var status, pipelineStatus string
+	if err := testPool.QueryRow(ctx, `
+		SELECT status, metadata ->> 'pipeline_status' FROM issue WHERE id = $1
+	`, f.issueID).Scan(&status, &pipelineStatus); err != nil {
+		t.Fatalf("read final issue state: %v", err)
+	}
+	if status != "todo" || pipelineStatus != "recovery_queued" {
+		t.Fatalf("final issue state = %s/%s, want todo/recovery_queued", status, pipelineStatus)
+	}
+}
+
+func TestQueuedExpiredSurfaceRechecksAfterConcurrentEnqueue(t *testing.T) {
+	f := setupQueuedExpiredCreateIssueFixture(t)
+	ctx := context.Background()
+	queries := db.New(testPool)
+	taskSvc := service.NewTaskService(queries, testPool, nil, events.New())
+	failed, err := queries.ExpireStaleQueuedTasks(ctx, db.ExpireStaleQueuedTasksParams{
+		TtlSecs: 3600, MaxPerTick: 100,
+	})
+	if err != nil || len(failed) != 1 {
+		t.Fatalf("expire fixture = %d tasks, %v; want 1, nil", len(failed), err)
+	}
+
+	// Model an ordinary enqueue transaction that owns the shared issue lock and
+	// commits a later task while surface is waiting. Surface must take a fresh
+	// snapshot after acquiring the lock and observe the insert.
+	tx, err := testPool.Begin(ctx)
+	if err != nil {
+		t.Fatalf("begin enqueue transaction: %v", err)
+	}
+	if _, err := tx.Exec(ctx, `SELECT id FROM issue WHERE id = $1 FOR UPDATE`, f.issueID); err != nil {
+		t.Fatalf("lock issue: %v", err)
+	}
+	if _, err := tx.Exec(ctx, `
+		INSERT INTO agent_task_queue (agent_id, runtime_id, issue_id, status, priority)
+		VALUES ($1, $2, $3, 'queued', 0)
+	`, f.agentID, f.runtimeID, f.issueID); err != nil {
+		t.Fatalf("insert concurrent task: %v", err)
+	}
+
+	done := make(chan struct{})
+	go func() {
+		taskSvc.HandleFailedTasks(ctx, failed)
+		close(done)
+	}()
+	if err := tx.Commit(ctx); err != nil {
+		t.Fatalf("commit concurrent enqueue: %v", err)
+	}
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("surface remained blocked after enqueue commit")
+	}
+
+	var status string
+	var metadataJSON []byte
+	if err := testPool.QueryRow(ctx, `SELECT status, metadata FROM issue WHERE id = $1`, f.issueID).Scan(&status, &metadataJSON); err != nil {
+		t.Fatalf("read issue: %v", err)
+	}
+	if status != "todo" || string(metadataJSON) != "{}" {
+		t.Fatalf("surface overwrote concurrent enqueue: status=%q metadata=%s", status, metadataJSON)
+	}
+}
+
+func TestRecoverQueuedExpiredCreateIssueSkipsAlreadyWorkedIssue(t *testing.T) {
+	f := setupQueuedExpiredCreateIssueFixture(t)
+	ctx := context.Background()
+	queries := db.New(testPool)
+	bus := events.New()
+	taskSvc := service.NewTaskService(queries, testPool, nil, bus)
+	autopilotSvc := service.NewAutopilotService(queries, testPool, bus, taskSvc)
+	registerAutopilotListeners(bus, autopilotSvc)
+	expireQueuedFixture(t, taskSvc, queries, f.taskID)
+	if _, err := testPool.Exec(ctx, `
+		INSERT INTO agent_task_queue (
+			agent_id, runtime_id, issue_id, status, priority, started_at, completed_at
+		)
+		VALUES ($1, $2, $3, 'completed', 0, now(), now())
+	`, f.agentID, f.runtimeID, f.issueID); err != nil {
+		t.Fatalf("seed later completed work: %v", err)
+	}
+
+	recovered, err := taskSvc.RecoverQueuedExpiredCreateIssueTasksForRuntime(ctx, parseUUID(f.runtimeID))
+	if err != nil {
+		t.Fatalf("recover already-worked issue: %v", err)
+	}
+	if recovered != 0 {
+		t.Fatalf("recovered = %d, want 0", recovered)
+	}
+}
+
+func TestRecoverQueuedExpiredCreateIssueHonorsMaxAttempts(t *testing.T) {
+	f := setupQueuedExpiredCreateIssueFixture(t)
+	ctx := context.Background()
+	if _, err := testPool.Exec(ctx, `UPDATE agent_task_queue SET max_attempts = 1 WHERE id = $1`, f.taskID); err != nil {
+		t.Fatalf("exhaust retry budget: %v", err)
+	}
+	queries := db.New(testPool)
+	bus := events.New()
+	taskSvc := service.NewTaskService(queries, testPool, nil, bus)
+	autopilotSvc := service.NewAutopilotService(queries, testPool, bus, taskSvc)
+	registerAutopilotListeners(bus, autopilotSvc)
+	expireQueuedFixture(t, taskSvc, queries, f.taskID)
+
+	recovered, err := taskSvc.RecoverQueuedExpiredCreateIssueTasksForRuntime(ctx, parseUUID(f.runtimeID))
+	if err != nil {
+		t.Fatalf("recover exhausted task: %v", err)
+	}
+	if recovered != 0 {
+		t.Fatalf("recovered = %d, want 0", recovered)
+	}
+}
+
+func TestManualRerunSupersedesQueuedExpiredRecovery(t *testing.T) {
+	f := setupQueuedExpiredCreateIssueFixture(t)
+	ctx := context.Background()
+	queries := db.New(testPool)
+	taskSvc := service.NewTaskService(queries, testPool, nil, events.New())
+	expireQueuedFixture(t, taskSvc, queries, f.taskID)
+
+	manual, err := taskSvc.RerunIssue(ctx, parseUUID(f.issueID), parseUUID(f.taskID), optionalUUID(""), parseUUID(testUserID), nil)
+	if err != nil {
+		t.Fatalf("manual rerun: %v", err)
+	}
+	if !manual.ForceFreshSession {
+		t.Fatal("manual rerun force_fresh_session = false, want true")
+	}
+	if recovered, err := taskSvc.RecoverQueuedExpiredCreateIssueTasksForRuntime(ctx, parseUUID(f.runtimeID)); err != nil || recovered != 0 {
+		t.Fatalf("recovery after manual rerun = %d, %v; want 0, nil", recovered, err)
+	}
+
+	var taskCount int
+	var status, pipelineStatus, waitingOn string
+	if err := testPool.QueryRow(ctx, `SELECT count(*) FROM agent_task_queue WHERE issue_id = $1`, f.issueID).Scan(&taskCount); err != nil {
+		t.Fatalf("count issue tasks: %v", err)
+	}
+	if err := testPool.QueryRow(ctx, `
+		SELECT status, metadata ->> 'pipeline_status', metadata ->> 'waiting_on'
+		FROM issue WHERE id = $1
+	`, f.issueID).Scan(&status, &pipelineStatus, &waitingOn); err != nil {
+		t.Fatalf("read pipeline status: %v", err)
+	}
+	if taskCount != 2 || status != "todo" || pipelineStatus != "manual_rerun" || waitingOn != "runtime_execution" {
+		t.Fatalf("manual state = tasks:%d %s/%s/%s, want 2 todo/manual_rerun/runtime_execution", taskCount, status, pipelineStatus, waitingOn)
+	}
+}
+
+func TestNewIssueWorkSupersedesQueuedExpiredRecovery(t *testing.T) {
+	f := setupQueuedExpiredCreateIssueFixture(t)
+	ctx := context.Background()
+	queries := db.New(testPool)
+	taskSvc := service.NewTaskService(queries, testPool, nil, events.New())
+	expireQueuedFixture(t, taskSvc, queries, f.taskID)
+
+	issue, err := queries.GetIssue(ctx, parseUUID(f.issueID))
+	if err != nil {
+		t.Fatalf("load issue: %v", err)
+	}
+	if _, err := taskSvc.EnqueueTaskForMention(ctx, issue, parseUUID(f.agentID), optionalUUID("")); err != nil {
+		t.Fatalf("enqueue new issue work: %v", err)
+	}
+	if recovered, err := taskSvc.RecoverQueuedExpiredCreateIssueTasksForRuntime(ctx, parseUUID(f.runtimeID)); err != nil || recovered != 0 {
+		t.Fatalf("recovery after new work = %d, %v; want 0, nil", recovered, err)
+	}
+
+	var status, pipelineStatus, waitingOn string
+	if err := testPool.QueryRow(ctx, `
+		SELECT status, metadata ->> 'pipeline_status', metadata ->> 'waiting_on'
+		FROM issue WHERE id = $1
+	`, f.issueID).Scan(&status, &pipelineStatus, &waitingOn); err != nil {
+		t.Fatalf("read issue state: %v", err)
+	}
+	if status != "todo" || pipelineStatus != "new_work_queued" || waitingOn != "runtime_execution" {
+		t.Fatalf("new-work state = %s/%s/%s, want todo/new_work_queued/runtime_execution", status, pipelineStatus, waitingOn)
+	}
+}
+
+func TestQueuedExpiredNonCreateIssueKeepsExistingBehavior(t *testing.T) {
+	f := setupQueuedExpiredCreateIssueFixture(t)
+	ctx := context.Background()
+	if _, err := testPool.Exec(ctx, `DELETE FROM autopilot_run WHERE id = $1`, f.runID); err != nil {
+		t.Fatalf("remove create_issue run: %v", err)
+	}
+	if _, err := testPool.Exec(ctx, `UPDATE issue SET origin_type = NULL, origin_id = NULL WHERE id = $1`, f.issueID); err != nil {
+		t.Fatalf("convert to ordinary issue: %v", err)
+	}
+	queries := db.New(testPool)
+	taskSvc := service.NewTaskService(queries, testPool, nil, events.New())
+	expireQueuedFixture(t, taskSvc, queries, f.taskID)
+
+	var status string
+	var metadataJSON []byte
+	if err := testPool.QueryRow(ctx, `SELECT status, metadata FROM issue WHERE id = $1`, f.issueID).Scan(&status, &metadataJSON); err != nil {
+		t.Fatalf("read ordinary issue: %v", err)
+	}
+	if status != "todo" || string(metadataJSON) != "{}" {
+		t.Fatalf("ordinary issue changed: status=%q metadata=%s", status, metadataJSON)
+	}
+	recovered, err := taskSvc.RecoverQueuedExpiredCreateIssueTasksForRuntime(ctx, parseUUID(f.runtimeID))
+	if err != nil {
+		t.Fatalf("recover ordinary issue: %v", err)
+	}
+	if recovered != 0 {
+		t.Fatalf("ordinary issue recovered = %d, want 0", recovered)
+	}
+}
+
+func TestQueuedExpiredCreateIssueIgnoresTerminalAutopilotRun(t *testing.T) {
+	f := setupQueuedExpiredCreateIssueFixture(t)
+	ctx := context.Background()
+	if _, err := testPool.Exec(ctx, `
+		UPDATE autopilot_run SET status = 'completed', completed_at = now() WHERE id = $1
+	`, f.runID); err != nil {
+		t.Fatalf("complete autopilot run: %v", err)
+	}
+	queries := db.New(testPool)
+	taskSvc := service.NewTaskService(queries, testPool, nil, events.New())
+	expireQueuedFixture(t, taskSvc, queries, f.taskID)
+
+	var status string
+	var metadataJSON []byte
+	if err := testPool.QueryRow(ctx, `SELECT status, metadata FROM issue WHERE id = $1`, f.issueID).Scan(&status, &metadataJSON); err != nil {
+		t.Fatalf("read terminal-run issue: %v", err)
+	}
+	if status != "todo" || string(metadataJSON) != "{}" {
+		t.Fatalf("terminal-run issue changed: status=%q metadata=%s", status, metadataJSON)
+	}
+	if recovered, err := taskSvc.RecoverQueuedExpiredCreateIssueTasksForRuntime(ctx, parseUUID(f.runtimeID)); err != nil || recovered != 0 {
+		t.Fatalf("terminal-run recovery = %d, %v; want 0, nil", recovered, err)
+	}
+}

--- a/server/internal/handler/daemon.go
+++ b/server/internal/handler/daemon.go
@@ -1097,6 +1097,24 @@ func (h *Handler) processHeartbeat(ctx context.Context, rt db.AgentRuntime, supp
 		m.UpdateMs = time.Since(updateStart).Milliseconds()
 		return nil, m, err
 	}
+	// Recovery is deliberately checked on every online heartbeat. The query is
+	// idempotent and bounded, so this both drains backlogs larger than one batch
+	// and retries a transient database failure without requiring another
+	// offline -> online transition.
+	if h.TaskService != nil {
+		recovered, err := h.TaskService.RecoverQueuedExpiredCreateIssueTasksForRuntime(ctx, rt.ID)
+		if err != nil {
+			slog.Warn("runtime reconnect: queued-expired recovery failed",
+				"runtime_id", runtimeID,
+				"error", err,
+			)
+		} else if recovered > 0 {
+			slog.Info("runtime reconnect: queued-expired create_issue tasks recovered",
+				"runtime_id", runtimeID,
+				"count", recovered,
+			)
+		}
+	}
 	m.UpdateMs = time.Since(updateStart).Milliseconds()
 
 	slog.Debug("daemon heartbeat", "runtime_id", runtimeID)

--- a/server/internal/metrics/business_sampler.go
+++ b/server/internal/metrics/business_sampler.go
@@ -110,14 +110,16 @@ type BusinessSamplerCollector struct {
 	// the values are computed once per scrape from a fresh DB read; we
 	// never want stale series sticking around because a label has stopped
 	// appearing in the result set.
-	descActiveUsers      *prometheus.Desc
-	descActiveWorkspaces *prometheus.Desc
-	descTaskQueued       *prometheus.Desc
-	descTaskRunning      *prometheus.Desc
-	descTaskStuck        *prometheus.Desc
-	descRuntimeOnline    *prometheus.Desc
-	descHeartbeatAgeHist *prometheus.Desc
-	descWorkspaceTotal   *prometheus.Desc
+	descActiveUsers                       *prometheus.Desc
+	descActiveWorkspaces                  *prometheus.Desc
+	descTaskQueued                        *prometheus.Desc
+	descTaskRunning                       *prometheus.Desc
+	descTaskStuck                         *prometheus.Desc
+	descQueuedExpiredCreateIssueCount     *prometheus.Desc
+	descQueuedExpiredCreateIssueOldestAge *prometheus.Desc
+	descRuntimeOnline                     *prometheus.Desc
+	descHeartbeatAgeHist                  *prometheus.Desc
+	descWorkspaceTotal                    *prometheus.Desc
 
 	mu       sync.Mutex
 	snapshot *samplerSnapshot
@@ -179,6 +181,14 @@ func NewBusinessSamplerCollector(opts *BusinessSamplerOptions) *BusinessSamplerC
 			"multica_agent_task_stuck_total",
 			"Current `running` agent_task_queue rows whose started_at is older than the stuck threshold. Sampled from the database.",
 			[]string{"source"}, nil),
+		descQueuedExpiredCreateIssueCount: prometheus.NewDesc(
+			"multica_create_issue_queued_expired",
+			"Current autopilot-created issues whose sole direct task expired in queue and has not been recovered.",
+			nil, nil),
+		descQueuedExpiredCreateIssueOldestAge: prometheus.NewDesc(
+			"multica_create_issue_queued_expired_oldest_age_seconds",
+			"Age of the oldest unrecovered autopilot create_issue queued expiry. Zero when none are affected.",
+			nil, nil),
 		descRuntimeOnline: prometheus.NewDesc(
 			"multica_runtime_online",
 			"Count of agent_runtime rows with last_seen_at within the online heartbeat window. Sampled from the database.",
@@ -217,6 +227,8 @@ func (c *BusinessSamplerCollector) Describe(ch chan<- *prometheus.Desc) {
 		c.descTaskQueued,
 		c.descTaskRunning,
 		c.descTaskStuck,
+		c.descQueuedExpiredCreateIssueCount,
+		c.descQueuedExpiredCreateIssueOldestAge,
 		c.descRuntimeOnline,
 		c.descHeartbeatAgeHist,
 		c.descWorkspaceTotal,
@@ -283,6 +295,10 @@ func (c *BusinessSamplerCollector) emit(ch chan<- prometheus.Metric, snap *sampl
 		ch <- prometheus.MustNewConstMetric(
 			c.descTaskStuck, prometheus.GaugeValue, snap.taskStuck[source], source)
 	}
+	ch <- prometheus.MustNewConstMetric(
+		c.descQueuedExpiredCreateIssueCount, prometheus.GaugeValue, snap.queuedExpiredCreateIssueCount)
+	ch <- prometheus.MustNewConstMetric(
+		c.descQueuedExpiredCreateIssueOldestAge, prometheus.GaugeValue, snap.queuedExpiredCreateIssueOldestAgeSeconds)
 	for _, source := range knownSourceLabels() {
 		for _, mode := range knownRuntimeModeLabels() {
 			key := taskRunningKey{source: source, runtimeMode: mode}
@@ -361,6 +377,9 @@ type samplerSnapshot struct {
 	taskRunning map[taskRunningKey]float64
 	taskStuck   map[string]float64
 
+	queuedExpiredCreateIssueCount            float64
+	queuedExpiredCreateIssueOldestAgeSeconds float64
+
 	runtimeOnline map[runtimeOnlineKey]float64
 	heartbeatAge  map[string]samplerHistogram
 
@@ -412,6 +431,9 @@ func (c *BusinessSamplerCollector) refreshFromDB(ctx context.Context, now time.T
 	})
 	c.runQuery(ctx, conn, "task_stuck", func(ctx context.Context, tx pgx.Tx) error {
 		return c.queryTaskStuck(ctx, tx, snap)
+	})
+	c.runQuery(ctx, conn, "queued_expired_create_issue", func(ctx context.Context, tx pgx.Tx) error {
+		return c.queryQueuedExpiredCreateIssue(ctx, tx, snap)
 	})
 	c.runQuery(ctx, conn, "runtime_online", func(ctx context.Context, tx pgx.Tx) error {
 		return c.queryRuntimeOnline(ctx, tx, snap)

--- a/server/internal/metrics/business_sampler_queries.go
+++ b/server/internal/metrics/business_sampler_queries.go
@@ -3,6 +3,7 @@ package metrics
 import (
 	"context"
 	"fmt"
+	"log/slog"
 
 	"github.com/jackc/pgx/v5"
 )
@@ -223,6 +224,64 @@ LIMIT 100
 		snap.taskStuck[NormalizeTaskSource(rawSource)] += float64(n)
 	}
 	return rows.Err()
+}
+
+// queryQueuedExpiredCreateIssue exposes the durable backlog that needs an
+// operator alert when runtime reconnect recovery has not produced a child
+// task. No issue/runtime labels are emitted, keeping metric cardinality fixed.
+func (c *BusinessSamplerCollector) queryQueuedExpiredCreateIssue(
+	ctx context.Context, tx pgx.Tx, snap *samplerSnapshot,
+) error {
+	const stmt = `
+WITH affected AS (
+  SELECT
+    t.completed_at,
+    i.id::text AS issue_id,
+    i.workspace_id::text AS workspace_id,
+    COALESCE(t.runtime_id::text, '') AS runtime_id
+  FROM agent_task_queue t
+  JOIN issue i ON i.id = t.issue_id
+  JOIN autopilot a ON a.id = i.origin_id
+  WHERE t.status = 'failed'
+    AND t.failure_reason = 'queued_expired'
+    AND t.parent_task_id IS NULL
+    AND t.trigger_comment_id IS NULL
+    AND t.autopilot_run_id IS NULL
+    AND i.origin_type = 'autopilot'
+    AND i.status = 'blocked'
+    AND i.metadata ->> 'pipeline_status' = 'queued_expired'
+    AND a.execution_mode = 'create_issue'
+    AND NOT EXISTS (
+      SELECT 1 FROM agent_task_queue other
+      WHERE other.issue_id = t.issue_id AND other.id <> t.id
+    )
+)
+SELECT
+  count(*) AS affected,
+  COALESCE(max(EXTRACT(EPOCH FROM (now() - completed_at))), 0) AS oldest_age_seconds,
+  COALESCE((SELECT issue_id FROM affected ORDER BY completed_at ASC LIMIT 1), '') AS oldest_issue_id,
+  COALESCE((SELECT workspace_id FROM affected ORDER BY completed_at ASC LIMIT 1), '') AS oldest_workspace_id,
+  COALESCE((SELECT runtime_id FROM affected ORDER BY completed_at ASC LIMIT 1), '') AS oldest_runtime_id
+FROM affected
+`
+	var count int64
+	var oldestAge float64
+	var oldestIssueID, oldestWorkspaceID, oldestRuntimeID string
+	if err := tx.QueryRow(ctx, stmt).Scan(&count, &oldestAge, &oldestIssueID, &oldestWorkspaceID, &oldestRuntimeID); err != nil {
+		return fmt.Errorf("queued_expired_create_issue: %w", err)
+	}
+	snap.queuedExpiredCreateIssueCount = float64(count)
+	snap.queuedExpiredCreateIssueOldestAgeSeconds = oldestAge
+	if count > 0 {
+		slog.Debug("queued-expired create_issue backlog identity",
+			"count", count,
+			"oldest_age_seconds", oldestAge,
+			"oldest_issue_id", oldestIssueID,
+			"oldest_workspace_id", oldestWorkspaceID,
+			"oldest_runtime_id", oldestRuntimeID,
+		)
+	}
+	return nil
 }
 
 // queryRuntimeOnline counts agent_runtime rows whose last_seen_at is within

--- a/server/internal/metrics/business_sampler_test.go
+++ b/server/internal/metrics/business_sampler_test.go
@@ -51,6 +51,8 @@ func filledSnapshot(now time.Time) *samplerSnapshot {
 	snap.taskRunning[taskRunningKey{source: "issue", runtimeMode: "local"}] = 1
 
 	snap.taskStuck["issue"] = 1
+	snap.queuedExpiredCreateIssueCount = 4
+	snap.queuedExpiredCreateIssueOldestAgeSeconds = 7200
 
 	snap.runtimeOnline[runtimeOnlineKey{runtimeMode: "local", provider: "claude"}] = 4
 	snap.runtimeOnline[runtimeOnlineKey{runtimeMode: "cloud", provider: "kiro"}] = 2
@@ -115,6 +117,8 @@ func TestBusinessSamplerCollectorEmitsExpectedMetrics(t *testing.T) {
 		`multica_agent_task_running{runtime_mode="cloud",source="chat"} 3`,
 		`multica_agent_task_running{runtime_mode="local",source="issue"} 1`,
 		`multica_agent_task_stuck_total{source="issue"} 1`,
+		`multica_create_issue_queued_expired 4`,
+		`multica_create_issue_queued_expired_oldest_age_seconds 7200`,
 		`multica_runtime_online{provider="claude",runtime_mode="local"} 4`,
 		`multica_runtime_online{provider="kiro",runtime_mode="cloud"} 2`,
 		`multica_runtime_heartbeat_age_seconds_count{runtime_mode="local"} 3`,

--- a/server/internal/service/builtin_skills/multica-autopilots/SKILL.md
+++ b/server/internal/service/builtin_skills/multica-autopilots/SKILL.md
@@ -62,6 +62,14 @@ For "why didn't it run":
 5. For webhooks, inspect delivery status: `queued` means the worker has not completed dispatch; `failed` carries the worker error. A provider retry with the same `X-GitHub-Delivery` / `Idempotency-Key` reuses the original delivery.
 6. For `create_issue`, inspect the created issue if the run records one.
 
+If a scheduled `create_issue` task stays queued past its server TTL, the issue
+is moved to `blocked`, receives a system comment, and records
+`pipeline_status=queued_expired` plus `waiting_on=runtime_reconnect`. When that
+same runtime reconnects, the server may enqueue one recovery attempt only if no
+other task has worked the issue and the retry budget remains. Repeated
+heartbeats do not create duplicate attempts. `run_only` and ordinary issue
+tasks keep their existing failure behavior.
+
 ## Side effects
 
 These mutate durable state or start work: `create`, `update`, `delete`, trigger add/update/delete/rotate, `trigger`, and webhook calls to `/api/webhooks/autopilots/{token}`.

--- a/server/internal/service/builtin_skills/multica-autopilots/references/autopilots-source-map.md
+++ b/server/internal/service/builtin_skills/multica-autopilots/references/autopilots-source-map.md
@@ -6,6 +6,14 @@
 - `create_issue` calls `dispatchCreateIssue`; `run_only` calls `dispatchRunOnly`.
 - `resolveAutopilotLeader` resolves squad-assigned autopilots to the squad leader.
 - `AgentReadiness` blocks archived/runtime-unready agents before enqueue.
+- `server/internal/service/task.go` surfaces `queued_expired` create_issue tasks
+  on their issue and provides bounded reconnect recovery;
+  `server/pkg/db/queries/agent.sql` locks eligible parent rows and excludes
+  dedupe/already-worked cases; `server/internal/handler/daemon.go` invokes the
+  bounded idempotent check on each heartbeat so large batches and transient
+  database failures drain without another reconnect cycle.
+- `server/internal/metrics/business_sampler_queries.go` exposes current affected
+  count and oldest age without issue/runtime labels.
 - `server/cmd/server/router.go` exposes authenticated `/api/autopilots` routes and unauthenticated webhook ingress `/api/webhooks/autopilots/{token}`.
 - `server/internal/handler/autopilot_webhook.go` durably stores public webhook deliveries, synchronously admits an idempotent run for the compatible `200 accepted|skipped` + `run_id` response, and wakes the worker.
 - `server/internal/handler/webhook_delivery_worker.go` claims queued deliveries with expiring database leases, applies per-trigger dispatch pacing, and resumes admitted runs using `autopilot_run.webhook_delivery_id` so recovery cannot duplicate a run/task.

--- a/server/internal/service/task.go
+++ b/server/internal/service/task.go
@@ -1043,7 +1043,7 @@ func (s *TaskService) enqueueIssueTaskWithCommentPlan(ctx context.Context, issue
 	originatorUserID := attr.UserID
 	runtimeMCPOverlay := s.buildRuntimeMCPOverlay(ctx, originatorUserID, agent)
 	attrSource, attrDelegatedFrom, attrEvidenceKind, attrEvidenceRef := attributionCreateParams(attr)
-	task, err := s.Queries.CreateAgentTask(ctx, db.CreateAgentTaskParams{
+	task, err := s.createIssueAgentTaskLocked(ctx, issue.ID, db.CreateAgentTaskParams{
 		AgentID:              issue.AssigneeID,
 		RuntimeID:            agent.RuntimeID,
 		IssueID:              issue.ID,
@@ -1087,6 +1087,38 @@ func (s *TaskService) enqueueIssueTaskWithCommentPlan(ctx context.Context, issue
 	s.broadcastTaskEvent(ctx, protocol.EventTaskQueued, task)
 	s.NotifyTaskEnqueued(ctx, task)
 	return task, nil
+}
+
+// createIssueAgentTaskLocked serializes every ordinary issue-linked enqueue
+// with queued-expired recovery's issue-row lock. Preparation (including any
+// external overlay lookup) stays outside the short transaction; only the final
+// enqueue decision and insert hold the row lock.
+func (s *TaskService) createIssueAgentTaskLocked(ctx context.Context, issueID pgtype.UUID, params db.CreateAgentTaskParams) (db.AgentTaskQueue, error) {
+	var task db.AgentTaskQueue
+	var oldIssue, updatedIssue db.Issue
+	err := s.runInTx(ctx, func(qtx *db.Queries) error {
+		if _, err := qtx.LockIssueForTaskEnqueue(ctx, issueID); err != nil {
+			return fmt.Errorf("lock issue task queue: %w", err)
+		}
+		var err error
+		oldIssue, err = qtx.GetIssue(ctx, issueID)
+		if err != nil {
+			return fmt.Errorf("load locked issue: %w", err)
+		}
+		if err := qtx.SupersedeQueuedExpiredIssueWithNewWork(ctx, issueID); err != nil {
+			return fmt.Errorf("supersede queued-expired recovery: %w", err)
+		}
+		updatedIssue, err = qtx.GetIssue(ctx, issueID)
+		if err != nil {
+			return fmt.Errorf("load updated issue: %w", err)
+		}
+		task, err = qtx.CreateAgentTask(ctx, params)
+		return err
+	})
+	if err == nil && oldIssue.Status != updatedIssue.Status {
+		s.broadcastIssueUpdated(updatedIssue, oldIssue.Status)
+	}
+	return task, err
 }
 
 // EnqueueTaskForMention creates a queued task for a mentioned agent on an issue.
@@ -1160,7 +1192,7 @@ func (s *TaskService) enqueueMentionTaskWithCommentPlan(ctx context.Context, iss
 	originatorUserID := attr.UserID
 	runtimeMCPOverlay := s.buildRuntimeMCPOverlay(ctx, originatorUserID, agent)
 	attrSource, attrDelegatedFrom, attrEvidenceKind, attrEvidenceRef := attributionCreateParams(attr)
-	task, err := s.Queries.CreateAgentTask(ctx, db.CreateAgentTaskParams{
+	task, err := s.createIssueAgentTaskLocked(ctx, issue.ID, db.CreateAgentTaskParams{
 		AgentID:              agentID,
 		RuntimeID:            agent.RuntimeID,
 		IssueID:              issue.ID,
@@ -3725,6 +3757,94 @@ func (s *TaskService) MaybeRetryFailedTask(ctx context.Context, parent db.AgentT
 	return &child, nil
 }
 
+const queuedExpiredReconnectBatchSize = 100
+
+type queuedExpiredRecovery struct {
+	parent   db.AgentTaskQueue
+	child    db.AgentTaskQueue
+	issue    db.Issue
+	oldState string
+}
+
+// RecoverQueuedExpiredCreateIssueTasksForRuntime queues one bounded recovery
+// attempt when a runtime reconnects. The parent-task row lock plus the
+// sole-task predicate make concurrent heartbeats idempotent; attempt/max_attempts
+// provide the hard retry ceiling.
+func (s *TaskService) RecoverQueuedExpiredCreateIssueTasksForRuntime(ctx context.Context, runtimeID pgtype.UUID) (int, error) {
+	var recoveries []queuedExpiredRecovery
+	err := s.runInTx(ctx, func(qtx *db.Queries) error {
+		parents, err := qtx.LockRecoverableQueuedExpiredCreateIssueTasks(ctx, db.LockRecoverableQueuedExpiredCreateIssueTasksParams{
+			RuntimeID:       runtimeID,
+			MaxPerReconnect: queuedExpiredReconnectBatchSize,
+		})
+		if err != nil {
+			return fmt.Errorf("lock recoverable queued-expired tasks: %w", err)
+		}
+		for _, parent := range parents {
+			issue, err := qtx.GetIssue(ctx, parent.IssueID)
+			if err != nil {
+				return fmt.Errorf("load queued-expired issue: %w", err)
+			}
+			child, err := qtx.CreateRetryTask(ctx, db.CreateRetryTaskParams{ID: parent.ID})
+			if err != nil {
+				return fmt.Errorf("create queued-expired recovery task: %w", err)
+			}
+			if _, err := qtx.SetIssueMetadataKey(ctx, db.SetIssueMetadataKeyParams{
+				Key:         "pipeline_status",
+				Value:       []byte(`"recovery_queued"`),
+				ID:          issue.ID,
+				WorkspaceID: issue.WorkspaceID,
+			}); err != nil {
+				return fmt.Errorf("set queued-expired recovery pipeline status: %w", err)
+			}
+			if _, err := qtx.SetIssueMetadataKey(ctx, db.SetIssueMetadataKeyParams{
+				Key:         "waiting_on",
+				Value:       []byte(`"runtime_execution"`),
+				ID:          issue.ID,
+				WorkspaceID: issue.WorkspaceID,
+			}); err != nil {
+				return fmt.Errorf("set queued-expired recovery waiting_on: %w", err)
+			}
+			updated, err := qtx.UpdateIssueStatus(ctx, db.UpdateIssueStatusParams{
+				ID:          issue.ID,
+				Status:      "todo",
+				WorkspaceID: issue.WorkspaceID,
+			})
+			if err != nil {
+				return fmt.Errorf("reopen queued-expired issue: %w", err)
+			}
+			recoveries = append(recoveries, queuedExpiredRecovery{
+				parent:   parent,
+				child:    child,
+				issue:    updated,
+				oldState: issue.Status,
+			})
+		}
+		return nil
+	})
+	if err != nil {
+		return 0, err
+	}
+
+	for _, recovery := range recoveries {
+		s.broadcastIssueUpdated(recovery.issue, recovery.oldState)
+		s.broadcastTaskEvent(ctx, protocol.EventTaskQueued, recovery.child)
+		s.NotifyTaskEnqueued(ctx, recovery.child)
+		s.createAgentComment(ctx, recovery.issue.ID, recovery.child.AgentID,
+			"Runtime reconnected. One automatic recovery attempt was queued.",
+			"system", pgtype.UUID{}, recovery.child.ID)
+		slog.Info("queued create_issue task recovered on runtime reconnect",
+			"issue_id", util.UUIDToString(recovery.issue.ID),
+			"parent_task_id", util.UUIDToString(recovery.parent.ID),
+			"recovery_task_id", util.UUIDToString(recovery.child.ID),
+			"runtime_id", util.UUIDToString(runtimeID),
+			"attempt", recovery.child.Attempt,
+			"max_attempts", recovery.child.MaxAttempts,
+		)
+	}
+	return len(recoveries), nil
+}
+
 // RerunIssue creates a fresh queued task for an agent on the issue. Used by
 // the manual rerun endpoint.
 //
@@ -3781,7 +3901,6 @@ func (s *TaskService) RerunIssue(ctx context.Context, issueID pgtype.UUID, sourc
 	if err != nil {
 		return nil, fmt.Errorf("load issue: %w", err)
 	}
-
 	// Determine the target agent for the rerun.
 	var (
 		agentID             pgtype.UUID
@@ -3842,27 +3961,99 @@ func (s *TaskService) RerunIssue(ctx context.Context, issueID pgtype.UUID, sourc
 	// so a since-reassigned issue can't be used to re-fire a private agent the
 	// operator may only view. A block fails closed: no prior task is cancelled,
 	// no new task is created.
+	agent, err := s.Queries.GetAgent(ctx, agentID)
+	if err != nil {
+		return nil, fmt.Errorf("load target agent: %w", err)
+	}
 	if canInvoke != nil {
-		targetAgent, err := s.Queries.GetAgent(ctx, agentID)
-		if err != nil {
-			return nil, fmt.Errorf("load target agent: %w", err)
-		}
-		if !canInvoke(targetAgent) {
+		if !canInvoke(agent) {
 			return nil, ErrRerunInvokeNotAllowed
 		}
 	}
+	if agent.ArchivedAt.Valid {
+		return nil, fmt.Errorf("agent is archived")
+	}
+	if !agent.RuntimeID.Valid {
+		return nil, fmt.Errorf("agent has no runtime")
+	}
 
-	// Cancel only the target agent's active/queued tasks on this issue.
-	cancelled, err := s.Queries.CancelAgentTasksByIssueAndAgent(ctx, db.CancelAgentTasksByIssueAndAgentParams{
-		IssueID: issueID,
-		AgentID: agentID,
+	attrSourceKind := attribution.SourceDelegation
+	if issue.AssigneeType.String == "agent" && issue.AssigneeID.Valid &&
+		util.UUIDToString(issue.AssigneeID) == util.UUIDToString(agentID) {
+		attrSourceKind = attribution.SourceCommentSource
+	}
+	attr := s.attributionForIssueTask(ctx, issue, triggerCommentID, attrSourceKind, actorUserID)
+	attr, err = s.applyAttributionFallback(ctx, attr, agent)
+	if err != nil {
+		return nil, err
+	}
+	originatorUserID := attr.UserID
+	runtimeMCPOverlay := s.buildRuntimeMCPOverlay(ctx, originatorUserID, agent)
+	attrSource, attrDelegatedFrom, attrEvidenceKind, attrEvidenceRef := attributionCreateParams(attr)
+	params := db.CreateAgentTaskParams{
+		AgentID:              agentID,
+		RuntimeID:            agent.RuntimeID,
+		IssueID:              issue.ID,
+		Priority:             priorityToInt(issue.Priority),
+		TriggerCommentID:     triggerCommentID,
+		CoalescedCommentIds:  coalescedCommentIDs,
+		TriggerSummary:       s.buildCommentTriggerSummary(ctx, issue.WorkspaceID, triggerCommentID),
+		IsLeaderTask:         pgtype.Bool{Bool: isLeader, Valid: isLeader},
+		ForceFreshSession:    pgtype.Bool{Bool: true, Valid: true},
+		SquadID:              squadID,
+		OriginatorUserID:     originatorUserID,
+		AccountableUserID:    attr.AccountableUserID,
+		RuleVersionID:        attr.RuleVersionID,
+		RerunOfTaskID:        sourceTaskID,
+		RuntimeMcpOverlay:    runtimeMCPOverlay.Overlay,
+		RuntimeConnectedApps: runtimeMCPOverlay.ConnectedApps,
+		OriginatorSource:     attrSource,
+		DelegatedFromTaskID:  attrDelegatedFrom,
+		TriggerEvidenceKind:  attrEvidenceKind,
+		TriggerEvidenceRefID: attrEvidenceRef,
+		HeadSha:              headShaText(s.ResolveIssueReviewSHA(ctx, issue.ID)),
+	}
+
+	var cancelled []db.AgentTaskQueue
+	var task db.AgentTaskQueue
+	var lockedIssue, updatedIssue db.Issue
+	err = s.runInTx(ctx, func(qtx *db.Queries) error {
+		// One transaction owns the issue-row decision, recovery suppression,
+		// cancellation, and replacement insert. Any validation/insert failure
+		// rolls everything back, leaving reconnect recovery eligible.
+		if _, err := qtx.LockIssueForTaskEnqueue(ctx, issueID); err != nil {
+			return fmt.Errorf("lock rerun issue: %w", err)
+		}
+		var err error
+		lockedIssue, err = qtx.GetIssue(ctx, issueID)
+		if err != nil {
+			return fmt.Errorf("load locked rerun issue: %w", err)
+		}
+		if err := qtx.MarkQueuedExpiredIssueManualRerun(ctx, issueID); err != nil {
+			return fmt.Errorf("claim queued-expired manual rerun: %w", err)
+		}
+		updatedIssue, err = qtx.GetIssue(ctx, issueID)
+		if err != nil {
+			return fmt.Errorf("load updated rerun issue: %w", err)
+		}
+		cancelled, err = qtx.CancelAgentTasksByIssueAndAgent(ctx, db.CancelAgentTasksByIssueAndAgentParams{
+			IssueID: issueID,
+			AgentID: agentID,
+		})
+		if err != nil {
+			return fmt.Errorf("cancel prior tasks: %w", err)
+		}
+		task, err = qtx.CreateAgentTask(ctx, params)
+		if err != nil {
+			return fmt.Errorf("create rerun task: %w", err)
+		}
+		return nil
 	})
 	if err != nil {
-		slog.Warn("rerun: cancel prior tasks failed",
-			"issue_id", util.UUIDToString(issueID),
-			"agent_id", util.UUIDToString(agentID),
-			"error", err,
-		)
+		return nil, err
+	}
+	if lockedIssue.Status != updatedIssue.Status {
+		s.broadcastIssueUpdated(updatedIssue, lockedIssue.Status)
 	}
 	for _, t := range cancelled {
 		s.captureTaskCancelled(ctx, t)
@@ -3870,15 +4061,8 @@ func (s *TaskService) RerunIssue(ctx context.Context, issueID pgtype.UUID, sourc
 		s.broadcastTaskEvent(ctx, protocol.EventTaskCancelled, t)
 	}
 
-	// A manual rerun is a NEW direct_human trigger attributed to the rerunning
-	// member, not the original run's human (MUL-4302 §5); actorUserID carries them.
-	// sourceTaskID is the rerun lineage: it rides the CreateAgentTask insert
-	// (rerun_of_task_id) so the queued event / daemon claim never sees a NULL
-	// lineage, and it stays distinct from system-retry's retry_of_task_id (§5).
-	task, err := s.enqueueRerunTask(ctx, issue, agentID, triggerCommentID, coalescedCommentIDs, isLeader, squadID, actorUserID, sourceTaskID)
-	if err != nil {
-		return nil, err
-	}
+	s.broadcastTaskEvent(ctx, protocol.EventTaskQueued, task)
+	s.NotifyTaskEnqueued(ctx, task)
 	slog.Info("issue rerun enqueued",
 		"task_id", util.UUIDToString(task.ID),
 		"issue_id", util.UUIDToString(issueID),
@@ -3940,26 +4124,51 @@ func (s *TaskService) promoteNewestSurvivingComment(ctx context.Context, ids []p
 	return survivors[newest].id, remaining, nil
 }
 
-// enqueueRerunTask enqueues a fresh task for the given agent on the issue.
-// When the target agent is the issue's single-agent assignee we use the
-// assignee-driven path (enqueueIssueTask) so the issue-assignee bookkeeping
-// stays in sync; otherwise (squad member, prior assignee that has since been
-// reassigned, mention agent) we use the mention path.
-//
-// force_fresh_session is pinned to true on every rerun row on purpose. It is
-// the rollback-safe legacy signal: an OLD claim handler (mid rolling deploy)
-// gates the whole resume lookup on !force_fresh_session, so it starts clean
-// instead of resuming via the (agent, issue) most-recent query — which could
-// pick a different execution than the one the user clicked. The NEW claim
-// handler ignores this flag for reruns and instead reads the exact source task
-// (rerun_of_task_id) to reuse its workdir and, when the failure did not poison
-// the conversation, resume its session (MUL-4869).
-func (s *TaskService) enqueueRerunTask(ctx context.Context, issue db.Issue, agentID pgtype.UUID, triggerCommentID pgtype.UUID, coalescedCommentIDs []pgtype.UUID, isLeader bool, squadID pgtype.UUID, actorUserID pgtype.UUID, rerunOfTaskID pgtype.UUID) (db.AgentTaskQueue, error) {
-	if issue.AssigneeType.String == "agent" && issue.AssigneeID.Valid &&
-		util.UUIDToString(issue.AssigneeID) == util.UUIDToString(agentID) {
-		return s.enqueueIssueTaskWithCommentPlan(ctx, issue, triggerCommentID, coalescedCommentIDs, true, "", actorUserID, rerunOfTaskID)
+const queuedExpiredCreateIssueComment = "Scheduled agent run expired before its runtime claimed it. The issue is blocked and will receive at most one automatic recovery attempt when that runtime reconnects. An operator can also use issue rerun."
+
+// surfaceQueuedExpiredCreateIssue makes a create_issue queue expiry durable on
+// the issue itself. Ordinary issue tasks and run_only autopilots are excluded:
+// only an active create_issue run has an autopilot_run linked through issue_id.
+func (s *TaskService) surfaceQueuedExpiredCreateIssue(ctx context.Context, task db.AgentTaskQueue) {
+	if !task.IssueID.Valid || task.AutopilotRunID.Valid ||
+		!task.FailureReason.Valid || task.FailureReason.String != string(taskfailure.ReasonQueuedExpired) {
+		return
 	}
-	return s.enqueueMentionTaskWithCommentPlan(ctx, issue, agentID, triggerCommentID, coalescedCommentIDs, isLeader, squadID, true, "", actorUserID, rerunOfTaskID)
+	var issue, updated db.Issue
+	err := s.runInTx(ctx, func(qtx *db.Queries) error {
+		var err error
+		if _, err = qtx.LockIssueForTaskEnqueue(ctx, task.IssueID); err != nil {
+			return fmt.Errorf("lock issue task queue: %w", err)
+		}
+		issue, err = qtx.GetQueuedExpiredCreateIssueForSurface(ctx, task.ID)
+		if err != nil {
+			return err
+		}
+		if _, err = qtx.SetIssueMetadataKey(ctx, db.SetIssueMetadataKeyParams{
+			Key: "pipeline_status", Value: []byte(`"queued_expired"`), ID: issue.ID, WorkspaceID: issue.WorkspaceID,
+		}); err != nil {
+			return fmt.Errorf("persist pipeline status: %w", err)
+		}
+		if _, err = qtx.SetIssueMetadataKey(ctx, db.SetIssueMetadataKeyParams{
+			Key: "waiting_on", Value: []byte(`"runtime_reconnect"`), ID: issue.ID, WorkspaceID: issue.WorkspaceID,
+		}); err != nil {
+			return fmt.Errorf("persist waiting_on: %w", err)
+		}
+		updated, err = qtx.UpdateIssueStatus(ctx, db.UpdateIssueStatusParams{
+			ID: issue.ID, Status: "blocked", WorkspaceID: issue.WorkspaceID,
+		})
+		return err
+	})
+	if errors.Is(err, pgx.ErrNoRows) {
+		return
+	}
+	if err != nil {
+		slog.Warn("queued expiry: durable issue transition failed", "issue_id", util.UUIDToString(task.IssueID), "task_id", util.UUIDToString(task.ID), "error", err)
+		return
+	}
+	s.broadcastIssueUpdated(updated, issue.Status)
+	s.createAgentComment(ctx, issue.ID, task.AgentID, queuedExpiredCreateIssueComment, "system", pgtype.UUID{}, task.ID)
+	slog.Warn("queued create_issue task surfaced", "issue_id", util.UUIDToString(issue.ID), "task_id", util.UUIDToString(task.ID), "runtime_id", util.UUIDToString(task.RuntimeID))
 }
 
 // HandleFailedTasks runs the post-failure side effects for a batch of
@@ -3982,6 +4191,8 @@ func (s *TaskService) HandleFailedTasks(ctx context.Context, tasks []db.AgentTas
 	retried := 0
 
 	for _, t := range tasks {
+		s.surfaceQueuedExpiredCreateIssue(ctx, t)
+
 		// Auto-retry first so the issue stays in_progress rather than
 		// flapping todo → in_progress within a tick.
 		if child, _ := s.MaybeRetryFailedTask(ctx, t); child != nil {

--- a/server/pkg/db/generated/agent.sql.go
+++ b/server/pkg/db/generated/agent.sql.go
@@ -3088,6 +3088,68 @@ func (q *Queries) GetLatestTaskRolloutMissing(ctx context.Context, arg GetLatest
 	return session_rollout_missing, err
 }
 
+const getQueuedExpiredCreateIssueForSurface = `-- name: GetQueuedExpiredCreateIssueForSurface :one
+SELECT i.id, i.workspace_id, i.title, i.description, i.status, i.priority, i.assignee_type, i.assignee_id, i.creator_type, i.creator_id, i.parent_issue_id, i.acceptance_criteria, i.context_refs, i.position, i.due_date, i.created_at, i.updated_at, i.number, i.project_id, i.origin_type, i.origin_id, i.first_executed_at, i.start_date, i.metadata, i.stage, i.properties
+FROM issue i
+JOIN autopilot a ON a.id = i.origin_id
+JOIN agent_task_queue t ON t.issue_id = i.id
+WHERE t.id = $1
+  AND t.status = 'failed'
+  AND t.failure_reason = 'queued_expired'
+  AND t.parent_task_id IS NULL
+  AND t.trigger_comment_id IS NULL
+  AND t.autopilot_run_id IS NULL
+  AND i.origin_type = 'autopilot'
+  AND i.status IN ('todo', 'in_progress')
+  AND a.execution_mode = 'create_issue'
+  AND EXISTS (
+    SELECT 1 FROM autopilot_run ar
+    WHERE ar.issue_id = i.id AND ar.status IN ('issue_created', 'running')
+  )
+  AND NOT EXISTS (
+    SELECT 1 FROM agent_task_queue other
+    WHERE other.issue_id = i.id AND other.id <> t.id
+  )
+`
+
+// Called only after LockIssueForTaskEnqueue in the same READ COMMITTED
+// transaction. Keeping the lock and eligibility read as separate statements
+// gives this predicate a fresh snapshot after any prior enqueue lock-holder
+// commits its task.
+func (q *Queries) GetQueuedExpiredCreateIssueForSurface(ctx context.Context, taskID pgtype.UUID) (Issue, error) {
+	row := q.db.QueryRow(ctx, getQueuedExpiredCreateIssueForSurface, taskID)
+	var i Issue
+	err := row.Scan(
+		&i.ID,
+		&i.WorkspaceID,
+		&i.Title,
+		&i.Description,
+		&i.Status,
+		&i.Priority,
+		&i.AssigneeType,
+		&i.AssigneeID,
+		&i.CreatorType,
+		&i.CreatorID,
+		&i.ParentIssueID,
+		&i.AcceptanceCriteria,
+		&i.ContextRefs,
+		&i.Position,
+		&i.DueDate,
+		&i.CreatedAt,
+		&i.UpdatedAt,
+		&i.Number,
+		&i.ProjectID,
+		&i.OriginType,
+		&i.OriginID,
+		&i.FirstExecutedAt,
+		&i.StartDate,
+		&i.Metadata,
+		&i.Stage,
+		&i.Properties,
+	)
+	return i, err
+}
+
 const getWorkspaceAgentActivity30d = `-- name: GetWorkspaceAgentActivity30d :many
 SELECT
     atq.agent_id,
@@ -4495,6 +4557,119 @@ func (q *Queries) ListWorkspaceWorkingAgents(ctx context.Context, arg ListWorksp
 			&i.AvatarUrl,
 			&i.RunningTaskCount,
 			&i.IssueIds,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+const lockRecoverableQueuedExpiredCreateIssueTasks = `-- name: LockRecoverableQueuedExpiredCreateIssueTasks :many
+SELECT t.id, t.agent_id, t.issue_id, t.status, t.priority, t.dispatched_at, t.started_at, t.completed_at, t.result, t.error, t.created_at, t.context, t.runtime_id, t.session_id, t.work_dir, t.trigger_comment_id, t.chat_session_id, t.autopilot_run_id, t.attempt, t.max_attempts, t.parent_task_id, t.failure_reason, t.trigger_summary, t.force_fresh_session, t.is_leader_task, t.wait_reason, t.initiator_user_id, t.handoff_note, t.prepare_lease_expires_at, t.squad_id, t.runtime_mcp_overlay, t.escalation_for_task_id, t.fire_at, t.originator_user_id, t.runtime_connected_apps, t.coalesced_comment_ids, t.delivered_comment_ids, t.chat_input_task_id, t.chat_finalize_deferred_at, t.originator_source, t.delegated_from_task_id, t.retry_of_task_id, t.rerun_of_task_id, t.rule_version_id, t.trigger_evidence_kind, t.trigger_evidence_ref_id, t.accountable_user_id, t.session_rollout_missing, t.retired_session_id, t.quick_actions_disabled, t.regenerate_quick_actions_for
+FROM agent_task_queue t
+JOIN issue i ON i.id = t.issue_id
+JOIN autopilot a ON a.id = i.origin_id
+WHERE t.runtime_id = $1
+  AND t.status = 'failed'
+  AND t.failure_reason = 'queued_expired'
+  AND t.parent_task_id IS NULL
+  AND t.trigger_comment_id IS NULL
+  AND t.autopilot_run_id IS NULL
+  AND t.attempt < t.max_attempts
+  AND i.origin_type = 'autopilot'
+  AND i.status = 'blocked'
+  AND i.metadata ->> 'pipeline_status' = 'queued_expired'
+  AND a.execution_mode = 'create_issue'
+  AND EXISTS (
+    SELECT 1 FROM autopilot_run ar
+    -- HandleFailedTasks emits task:failed after surfacing the issue, and the
+    -- autopilot status listener then changes issue_created -> failed. The
+    -- durable queued_expired marker proves this is that same recovery flow.
+    WHERE ar.issue_id = i.id AND ar.status IN ('issue_created', 'running', 'failed')
+  )
+  AND NOT EXISTS (
+    SELECT 1 FROM agent_task_queue other
+    WHERE other.issue_id = t.issue_id AND other.id <> t.id
+  )
+ORDER BY t.created_at ASC
+LIMIT $2::int
+FOR UPDATE OF i, t SKIP LOCKED
+`
+
+type LockRecoverableQueuedExpiredCreateIssueTasksParams struct {
+	RuntimeID       pgtype.UUID `json:"runtime_id"`
+	MaxPerReconnect int32       `json:"max_per_reconnect"`
+}
+
+// Locks at most one bounded batch of original create_issue tasks for a runtime
+// heartbeat. Holding both issue and parent rows through CreateRetryTask makes the
+// parent_task_id existence check an idempotency gate across concurrent HTTP and
+// WebSocket heartbeats. Any later work on the issue suppresses recovery.
+func (q *Queries) LockRecoverableQueuedExpiredCreateIssueTasks(ctx context.Context, arg LockRecoverableQueuedExpiredCreateIssueTasksParams) ([]AgentTaskQueue, error) {
+	rows, err := q.db.Query(ctx, lockRecoverableQueuedExpiredCreateIssueTasks, arg.RuntimeID, arg.MaxPerReconnect)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []AgentTaskQueue{}
+	for rows.Next() {
+		var i AgentTaskQueue
+		if err := rows.Scan(
+			&i.ID,
+			&i.AgentID,
+			&i.IssueID,
+			&i.Status,
+			&i.Priority,
+			&i.DispatchedAt,
+			&i.StartedAt,
+			&i.CompletedAt,
+			&i.Result,
+			&i.Error,
+			&i.CreatedAt,
+			&i.Context,
+			&i.RuntimeID,
+			&i.SessionID,
+			&i.WorkDir,
+			&i.TriggerCommentID,
+			&i.ChatSessionID,
+			&i.AutopilotRunID,
+			&i.Attempt,
+			&i.MaxAttempts,
+			&i.ParentTaskID,
+			&i.FailureReason,
+			&i.TriggerSummary,
+			&i.ForceFreshSession,
+			&i.IsLeaderTask,
+			&i.WaitReason,
+			&i.InitiatorUserID,
+			&i.HandoffNote,
+			&i.PrepareLeaseExpiresAt,
+			&i.SquadID,
+			&i.RuntimeMcpOverlay,
+			&i.EscalationForTaskID,
+			&i.FireAt,
+			&i.OriginatorUserID,
+			&i.RuntimeConnectedApps,
+			&i.CoalescedCommentIds,
+			&i.DeliveredCommentIds,
+			&i.ChatInputTaskID,
+			&i.ChatFinalizeDeferredAt,
+			&i.OriginatorSource,
+			&i.DelegatedFromTaskID,
+			&i.RetryOfTaskID,
+			&i.RerunOfTaskID,
+			&i.RuleVersionID,
+			&i.TriggerEvidenceKind,
+			&i.TriggerEvidenceRefID,
+			&i.AccountableUserID,
+			&i.SessionRolloutMissing,
+			&i.RetiredSessionID,
+			&i.QuickActionsDisabled,
+			&i.RegenerateQuickActionsFor,
 		); err != nil {
 			return nil, err
 		}

--- a/server/pkg/db/generated/issue.sql.go
+++ b/server/pkg/db/generated/issue.sql.go
@@ -1233,6 +1233,20 @@ func (q *Queries) LockIssueDuplicateKey(ctx context.Context, dollar_1 string) er
 	return err
 }
 
+const lockIssueForTaskEnqueue = `-- name: LockIssueForTaskEnqueue :one
+SELECT id FROM issue WHERE id = $1 FOR UPDATE
+`
+
+// All issue-linked enqueue decisions take this row lock. Recovery takes the
+// same lock in LockRecoverableQueuedExpiredCreateIssueTasks, eliminating the
+// NOT EXISTS snapshot race with ordinary/manual/mention task creation.
+func (q *Queries) LockIssueForTaskEnqueue(ctx context.Context, id pgtype.UUID) (pgtype.UUID, error) {
+	row := q.db.QueryRow(ctx, lockIssueForTaskEnqueue, id)
+	var id_2 pgtype.UUID
+	err := row.Scan(&id_2)
+	return id_2, err
+}
+
 const markIssueFirstExecuted = `-- name: MarkIssueFirstExecuted :one
 UPDATE issue
 SET first_executed_at = now()
@@ -1263,6 +1277,26 @@ func (q *Queries) MarkIssueFirstExecuted(ctx context.Context, id pgtype.UUID) (M
 		&i.FirstExecutedAt,
 	)
 	return i, err
+}
+
+const markQueuedExpiredIssueManualRerun = `-- name: MarkQueuedExpiredIssueManualRerun :exec
+UPDATE issue
+SET status = 'todo',
+    metadata = jsonb_set(
+        jsonb_set(metadata, '{pipeline_status}', '"manual_rerun"'::jsonb, true),
+        '{waiting_on}', '"runtime_execution"'::jsonb, true
+    ),
+    updated_at = now()
+WHERE id = $1
+  AND metadata ->> 'pipeline_status' = 'queued_expired'
+`
+
+// Claims the recovery decision before a manual rerun starts cancelling tasks.
+// A concurrent reconnect locks the same issue row; whichever transition wins
+// makes the other path observe a non-queued_expired pipeline state.
+func (q *Queries) MarkQueuedExpiredIssueManualRerun(ctx context.Context, id pgtype.UUID) error {
+	_, err := q.db.Exec(ctx, markQueuedExpiredIssueManualRerun, id)
+	return err
 }
 
 const setIssueMetadataKey = `-- name: SetIssueMetadataKey :one
@@ -1322,6 +1356,26 @@ func (q *Queries) SetIssueMetadataKey(ctx context.Context, arg SetIssueMetadataK
 		&i.Properties,
 	)
 	return i, err
+}
+
+const supersedeQueuedExpiredIssueWithNewWork = `-- name: SupersedeQueuedExpiredIssueWithNewWork :exec
+UPDATE issue
+SET status = 'todo',
+    metadata = jsonb_set(
+        jsonb_set(metadata, '{pipeline_status}', '"new_work_queued"'::jsonb, true),
+        '{waiting_on}', '"runtime_execution"'::jsonb, true
+    ),
+    updated_at = now()
+WHERE id = $1
+  AND metadata ->> 'pipeline_status' = 'queued_expired'
+`
+
+// Ordinary/mention work queued after durable expiry supersedes reconnect
+// recovery. This runs under LockIssueForTaskEnqueue and shares the task insert
+// transaction, so insert failure rolls the issue state back too.
+func (q *Queries) SupersedeQueuedExpiredIssueWithNewWork(ctx context.Context, id pgtype.UUID) error {
+	_, err := q.db.Exec(ctx, supersedeQueuedExpiredIssueWithNewWork, id)
+	return err
 }
 
 const updateIssue = `-- name: UpdateIssue :one

--- a/server/pkg/db/queries/agent.sql
+++ b/server/pkg/db/queries/agent.sql
@@ -1011,6 +1011,68 @@ WHERE t.id = v.id
   AND t.created_at < now() - make_interval(secs => @ttl_secs::double precision)
 RETURNING t.*;
 
+-- name: LockRecoverableQueuedExpiredCreateIssueTasks :many
+-- Locks at most one bounded batch of original create_issue tasks for a runtime
+-- heartbeat. Holding both issue and parent rows through CreateRetryTask makes the
+-- parent_task_id existence check an idempotency gate across concurrent HTTP and
+-- WebSocket heartbeats. Any later work on the issue suppresses recovery.
+SELECT t.*
+FROM agent_task_queue t
+JOIN issue i ON i.id = t.issue_id
+JOIN autopilot a ON a.id = i.origin_id
+WHERE t.runtime_id = sqlc.arg('runtime_id')
+  AND t.status = 'failed'
+  AND t.failure_reason = 'queued_expired'
+  AND t.parent_task_id IS NULL
+  AND t.trigger_comment_id IS NULL
+  AND t.autopilot_run_id IS NULL
+  AND t.attempt < t.max_attempts
+  AND i.origin_type = 'autopilot'
+  AND i.status = 'blocked'
+  AND i.metadata ->> 'pipeline_status' = 'queued_expired'
+  AND a.execution_mode = 'create_issue'
+  AND EXISTS (
+    SELECT 1 FROM autopilot_run ar
+    -- HandleFailedTasks emits task:failed after surfacing the issue, and the
+    -- autopilot status listener then changes issue_created -> failed. The
+    -- durable queued_expired marker proves this is that same recovery flow.
+    WHERE ar.issue_id = i.id AND ar.status IN ('issue_created', 'running', 'failed')
+  )
+  AND NOT EXISTS (
+    SELECT 1 FROM agent_task_queue other
+    WHERE other.issue_id = t.issue_id AND other.id <> t.id
+  )
+ORDER BY t.created_at ASC
+LIMIT sqlc.arg('max_per_reconnect')::int
+FOR UPDATE OF i, t SKIP LOCKED;
+
+-- name: GetQueuedExpiredCreateIssueForSurface :one
+-- Called only after LockIssueForTaskEnqueue in the same READ COMMITTED
+-- transaction. Keeping the lock and eligibility read as separate statements
+-- gives this predicate a fresh snapshot after any prior enqueue lock-holder
+-- commits its task.
+SELECT i.*
+FROM issue i
+JOIN autopilot a ON a.id = i.origin_id
+JOIN agent_task_queue t ON t.issue_id = i.id
+WHERE t.id = sqlc.arg('task_id')
+  AND t.status = 'failed'
+  AND t.failure_reason = 'queued_expired'
+  AND t.parent_task_id IS NULL
+  AND t.trigger_comment_id IS NULL
+  AND t.autopilot_run_id IS NULL
+  AND i.origin_type = 'autopilot'
+  AND i.status IN ('todo', 'in_progress')
+  AND a.execution_mode = 'create_issue'
+  AND EXISTS (
+    SELECT 1 FROM autopilot_run ar
+    WHERE ar.issue_id = i.id AND ar.status IN ('issue_created', 'running')
+  )
+  AND NOT EXISTS (
+    SELECT 1 FROM agent_task_queue other
+    WHERE other.issue_id = i.id AND other.id <> t.id
+  );
+
 -- name: CancelAgentTask :one
 UPDATE agent_task_queue
 SET status = 'cancelled', completed_at = now(), prepare_lease_expires_at = NULL

--- a/server/pkg/db/queries/issue.sql
+++ b/server/pkg/db/queries/issue.sql
@@ -121,6 +121,40 @@ UPDATE issue SET
 WHERE id = $1 AND workspace_id = $3
 RETURNING *;
 
+-- name: MarkQueuedExpiredIssueManualRerun :exec
+-- Claims the recovery decision before a manual rerun starts cancelling tasks.
+-- A concurrent reconnect locks the same issue row; whichever transition wins
+-- makes the other path observe a non-queued_expired pipeline state.
+UPDATE issue
+SET status = 'todo',
+    metadata = jsonb_set(
+        jsonb_set(metadata, '{pipeline_status}', '"manual_rerun"'::jsonb, true),
+        '{waiting_on}', '"runtime_execution"'::jsonb, true
+    ),
+    updated_at = now()
+WHERE id = $1
+  AND metadata ->> 'pipeline_status' = 'queued_expired';
+
+-- name: LockIssueForTaskEnqueue :one
+-- All issue-linked enqueue decisions take this row lock. Recovery takes the
+-- same lock in LockRecoverableQueuedExpiredCreateIssueTasks, eliminating the
+-- NOT EXISTS snapshot race with ordinary/manual/mention task creation.
+SELECT id FROM issue WHERE id = $1 FOR UPDATE;
+
+-- name: SupersedeQueuedExpiredIssueWithNewWork :exec
+-- Ordinary/mention work queued after durable expiry supersedes reconnect
+-- recovery. This runs under LockIssueForTaskEnqueue and shares the task insert
+-- transaction, so insert failure rolls the issue state back too.
+UPDATE issue
+SET status = 'todo',
+    metadata = jsonb_set(
+        jsonb_set(metadata, '{pipeline_status}', '"new_work_queued"'::jsonb, true),
+        '{waiting_on}', '"runtime_execution"'::jsonb, true
+    ),
+    updated_at = now()
+WHERE id = $1
+  AND metadata ->> 'pipeline_status' = 'queued_expired';
+
 -- name: CreateIssueWithOrigin :one
 INSERT INTO issue (
     workspace_id, title, description, status, priority,


### PR DESCRIPTION
## Summary

- surface scheduled `create_issue` tasks that expire unclaimed as a durable blocked issue with recovery metadata and a system comment
- enqueue one bounded retry when the owning runtime heartbeats again, with row-lock serialization, attempt limits, and already-worked/manual-rerun suppression
- expose fixed-cardinality backlog count and oldest-expiry-age metrics plus structured oldest-issue identity logging

## Verification

- `DATABASE_URL=postgres://multica:***@localhost:5432/multica?sslmode=disable go test ./internal/service ./internal/handler ./internal/metrics ./cmd/server -skip TestBusinessSamplerStatementTimeoutCutsHungQuery -count=1`
- `go vet ./internal/service ./internal/handler ./internal/metrics ./cmd/server`
- `git diff --cached --check`

Integration coverage includes offline queue TTL, durable surfacing, reconnect recovery, repeated-heartbeat dedupe, expiry/reconnect ordering, manual-rerun precedence, max attempts, already-worked issues, terminal autopilot runs, and non-create issues.

No schema migration. Rollout is server-only and upstream-owned.

Known unrelated local-suite issue: `TestBusinessSamplerStatementTimeoutCutsHungQuery` expects `*pgconn.PgError`, while the local PostgreSQL/driver combination returns a context deadline timeout. The affected metrics package passes with that pre-existing test skipped.

Closes KAP-769
