### PR TITLE
MUL-4486: self-heal pinned agent executable path after in-place upgrade

### DIFF
--- a/server/internal/daemon/agent_path_selfheal_test.go
+++ b/server/internal/daemon/agent_path_selfheal_test.go
@@ -1,12 +1,38 @@
 package daemon
 
 import (
+	"context"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"runtime"
 	"strings"
 	"testing"
 )
+
+// newSelfHealTestDaemon builds a Daemon with just the state resolveAgentEntry
+// touches (logger + the two maps it reads/writes), so these tests don't need a
+// fake HTTP server. healGroup / the mutexes are usable at their zero value.
+func newSelfHealTestDaemon() *Daemon {
+	return &Daemon{
+		logger:        slog.Default(),
+		resolvedPaths: make(map[string]string),
+		agentVersions: make(map[string]string),
+	}
+}
+
+// stubDetectVersionFromPath makes detectAgentVersion report the version encoded
+// in an installVersionedCodex path (…/codex/<ver>/bin/codex), so a heal to a
+// v2 directory "detects" v2. checkAgentMinVersion is intentionally left as the
+// real agent.CheckMinVersion so the min-version gate is exercised for real.
+func stubDetectVersionFromPath(t *testing.T) {
+	t.Helper()
+	orig := detectAgentVersion
+	detectAgentVersion = func(_ context.Context, path string) (string, error) {
+		return filepath.Base(filepath.Dir(filepath.Dir(path))), nil
+	}
+	t.Cleanup(func() { detectAgentVersion = orig })
+}
 
 // writeExecStub writes a runnable no-op executable at path, creating parents.
 func writeExecStub(t *testing.T, path string) {
@@ -42,12 +68,14 @@ func installVersionedCodex(t *testing.T, root, version, stableBin string) string
 // TestResolveAgentEntry_SelfHealsAfterInPlaceUpgrade reproduces MUL-4486: a
 // version manager upgrades codex in place, deleting the versioned directory the
 // daemon pinned at startup and repointing the stable command name at the new
-// version. resolveAgentEntry must re-resolve the pinned path instead of leaving
-// the daemon stuck on a path that no longer exists.
+// version. resolveAgentEntry must re-resolve the pinned path AND move the
+// cached detected version in lockstep, so downstream policy sees the binary
+// that will actually run.
 func TestResolveAgentEntry_SelfHealsAfterInPlaceUpgrade(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("symlink/exec-bit layout is POSIX-specific")
 	}
+	stubDetectVersionFromPath(t)
 
 	root := t.TempDir()
 	stableBin := filepath.Join(root, "bin") // the stable "/opt/homebrew/bin" analogue
@@ -62,12 +90,14 @@ func TestResolveAgentEntry_SelfHealsAfterInPlaceUpgrade(t *testing.T) {
 		t.Fatalf("pinned path %q does not point into the v1 versioned dir", v1)
 	}
 
-	d := newTestDaemon(t)
+	d := newSelfHealTestDaemon()
+	d.setAgentVersion("codex", "0.144.1") // the version detected for v1 at startup
 	entry := AgentEntry{Path: v1, Command: "codex"}
+	ctx := context.Background()
 
 	// While the pinned binary is present it must be returned unchanged — the
 	// anti-PATH-redirect guarantee for the normal case.
-	if got := d.resolveAgentEntry("codex", entry); got.Path != v1 {
+	if got := d.resolveAgentEntry(ctx, "codex", entry); got.Path != v1 {
 		t.Fatalf("live pinned path was rewritten: got %q, want %q", got.Path, v1)
 	}
 
@@ -80,20 +110,67 @@ func TestResolveAgentEntry_SelfHealsAfterInPlaceUpgrade(t *testing.T) {
 	}
 	v2 := installVersionedCodex(t, root, "0.144.3", stableBin)
 
-	got := d.resolveAgentEntry("codex", entry)
+	got := d.resolveAgentEntry(ctx, "codex", entry)
 	if got.Path != v2 {
 		t.Fatalf("self-heal resolved %q, want re-resolved v2 %q", got.Path, v2)
 	}
 	if !agentExecutablePresent(got.Path) {
 		t.Fatalf("self-healed path is not runnable: %q", got.Path)
 	}
+	// Must-fix (MUL-4486 review): the detected-version cache moved with the path.
+	if v := d.agentVersion("codex"); v != "0.144.3" {
+		t.Fatalf("agent version not updated in lockstep: got %q, want %q", v, "0.144.3")
+	}
 
 	// A subsequent call with the same stale entry must reuse the remembered
 	// heal without re-resolving from scratch. Prove it by breaking PATH: if it
 	// re-resolved now it would miss, but the cached healed path still resolves.
 	t.Setenv("PATH", filepath.Join(root, "empty"))
-	if got := d.resolveAgentEntry("codex", entry); got.Path != v2 {
+	if got := d.resolveAgentEntry(ctx, "codex", entry); got.Path != v2 {
 		t.Fatalf("cached self-heal not reused: got %q, want %q", got.Path, v2)
+	}
+}
+
+// TestResolveAgentEntry_RejectsBelowMinVersionAfterUpgrade covers the review's
+// second concern: if re-resolution lands on a build below the minimum supported
+// version, it must NOT be adopted or launched, and the cached version must not
+// be corrupted downward.
+func TestResolveAgentEntry_RejectsBelowMinVersionAfterUpgrade(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlink/exec-bit layout is POSIX-specific")
+	}
+	stubDetectVersionFromPath(t) // checkAgentMinVersion stays real: codex min is 0.100.0
+
+	root := t.TempDir()
+	stableBin := filepath.Join(root, "bin")
+	t.Setenv("PATH", stableBin)
+	t.Setenv("SHELL", filepath.Join(t.TempDir(), "fish"))
+
+	v1 := installVersionedCodex(t, root, "0.144.1", stableBin)
+
+	d := newSelfHealTestDaemon()
+	d.setAgentVersion("codex", "0.144.1")
+	entry := AgentEntry{Path: v1, Command: "codex"}
+	ctx := context.Background()
+
+	// "Upgrade" actually repoints at a below-minimum build (< 0.100.0).
+	if err := os.RemoveAll(filepath.Join(root, "Caskroom", "codex", "0.144.1")); err != nil {
+		t.Fatalf("remove v1 tree: %v", err)
+	}
+	installVersionedCodex(t, root, "0.9.0", stableBin)
+
+	got := d.resolveAgentEntry(ctx, "codex", entry)
+	if got.Path != v1 {
+		t.Fatalf("below-min build was adopted: got %q, want stale pinned %q", got.Path, v1)
+	}
+	d.resolvedPathsMu.RLock()
+	_, cached := d.resolvedPaths["codex"]
+	d.resolvedPathsMu.RUnlock()
+	if cached {
+		t.Fatalf("below-min build was cached as a healed path")
+	}
+	if v := d.agentVersion("codex"); v != "0.144.1" {
+		t.Fatalf("cached version was corrupted to a below-min value: got %q, want %q", v, "0.144.1")
 	}
 }
 
@@ -119,9 +196,9 @@ func TestResolveAgentEntry_UninstalledLeavesEntryUnchanged(t *testing.T) {
 		t.Fatalf("remove install root: %v", err)
 	}
 
-	d := newTestDaemon(t)
+	d := newSelfHealTestDaemon()
 	entry := AgentEntry{Path: pinned, Command: "codex"}
-	got := d.resolveAgentEntry("codex", entry)
+	got := d.resolveAgentEntry(context.Background(), "codex", entry)
 	if got.Path != pinned {
 		t.Fatalf("expected entry unchanged when binary is gone, got %q want %q", got.Path, pinned)
 	}
@@ -131,9 +208,9 @@ func TestResolveAgentEntry_UninstalledLeavesEntryUnchanged(t *testing.T) {
 // no recorded Command (e.g. a custom runtime profile carrying an absolute path)
 // is never re-resolved: the entry is returned as-is even when its path is gone.
 func TestResolveAgentEntry_NoCommandNoHeal(t *testing.T) {
-	d := newTestDaemon(t)
+	d := newSelfHealTestDaemon()
 	entry := AgentEntry{Path: filepath.Join(t.TempDir(), "does-not-exist"), Command: ""}
-	if got := d.resolveAgentEntry("codex", entry); got.Path != entry.Path {
+	if got := d.resolveAgentEntry(context.Background(), "codex", entry); got.Path != entry.Path {
 		t.Fatalf("entry with empty Command was rewritten: got %q, want %q", got.Path, entry.Path)
 	}
 }

--- a/server/internal/daemon/agent_path_selfheal_test.go
+++ b/server/internal/daemon/agent_path_selfheal_test.go
@@ -1,0 +1,139 @@
+package daemon
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+// writeExecStub writes a runnable no-op executable at path, creating parents.
+func writeExecStub(t *testing.T, path string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("mkdir for stub %s: %v", path, err)
+	}
+	if err := os.WriteFile(path, []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
+		t.Fatalf("write stub %s: %v", path, err)
+	}
+}
+
+// installVersionedCodex lays out a version-manager style install under root:
+// a concrete versioned binary plus a stable-name symlink pointing at it (the
+// shape Homebrew Cask / nvm / fnm produce). It returns the canonical path the
+// daemon would pin for the stable name, and repoints the symlink atomically on
+// later calls to simulate an in-place upgrade.
+func installVersionedCodex(t *testing.T, root, version, stableBin string) string {
+	t.Helper()
+	versioned := filepath.Join(root, "Caskroom", "codex", version, "bin", "codex")
+	writeExecStub(t, versioned)
+	link := filepath.Join(stableBin, "codex")
+	_ = os.Remove(link) // repoint on upgrade
+	if err := os.MkdirAll(stableBin, 0o755); err != nil {
+		t.Fatalf("mkdir stable bin: %v", err)
+	}
+	if err := os.Symlink(versioned, link); err != nil {
+		t.Fatalf("symlink %s -> %s: %v", link, versioned, err)
+	}
+	return canonicalExecutablePath(link)
+}
+
+// TestResolveAgentEntry_SelfHealsAfterInPlaceUpgrade reproduces MUL-4486: a
+// version manager upgrades codex in place, deleting the versioned directory the
+// daemon pinned at startup and repointing the stable command name at the new
+// version. resolveAgentEntry must re-resolve the pinned path instead of leaving
+// the daemon stuck on a path that no longer exists.
+func TestResolveAgentEntry_SelfHealsAfterInPlaceUpgrade(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlink/exec-bit layout is POSIX-specific")
+	}
+
+	root := t.TempDir()
+	stableBin := filepath.Join(root, "bin") // the stable "/opt/homebrew/bin" analogue
+	t.Setenv("PATH", stableBin)
+	// Pin resolution to the daemon's own PATH: an unsupported shell disables the
+	// login-shell fallback so the test can't accidentally resolve a real codex
+	// installed on the host running it.
+	t.Setenv("SHELL", filepath.Join(t.TempDir(), "fish"))
+
+	v1 := installVersionedCodex(t, root, "0.144.1", stableBin)
+	if !strings.Contains(v1, "0.144.1") {
+		t.Fatalf("pinned path %q does not point into the v1 versioned dir", v1)
+	}
+
+	d := newTestDaemon(t)
+	entry := AgentEntry{Path: v1, Command: "codex"}
+
+	// While the pinned binary is present it must be returned unchanged — the
+	// anti-PATH-redirect guarantee for the normal case.
+	if got := d.resolveAgentEntry("codex", entry); got.Path != v1 {
+		t.Fatalf("live pinned path was rewritten: got %q, want %q", got.Path, v1)
+	}
+
+	// In-place upgrade: drop the v1 tree and repoint the stable symlink at v2.
+	if err := os.RemoveAll(filepath.Join(root, "Caskroom", "codex", "0.144.1")); err != nil {
+		t.Fatalf("remove v1 tree: %v", err)
+	}
+	if agentExecutablePresent(v1) {
+		t.Fatalf("v1 path still present after removing its tree: %q", v1)
+	}
+	v2 := installVersionedCodex(t, root, "0.144.3", stableBin)
+
+	got := d.resolveAgentEntry("codex", entry)
+	if got.Path != v2 {
+		t.Fatalf("self-heal resolved %q, want re-resolved v2 %q", got.Path, v2)
+	}
+	if !agentExecutablePresent(got.Path) {
+		t.Fatalf("self-healed path is not runnable: %q", got.Path)
+	}
+
+	// A subsequent call with the same stale entry must reuse the remembered
+	// heal without re-resolving from scratch. Prove it by breaking PATH: if it
+	// re-resolved now it would miss, but the cached healed path still resolves.
+	t.Setenv("PATH", filepath.Join(root, "empty"))
+	if got := d.resolveAgentEntry("codex", entry); got.Path != v2 {
+		t.Fatalf("cached self-heal not reused: got %q, want %q", got.Path, v2)
+	}
+}
+
+// TestResolveAgentEntry_UninstalledLeavesEntryUnchanged verifies that when the
+// binary is genuinely gone (not just moved by an upgrade), resolveAgentEntry
+// returns the entry untouched so the downstream "executable not found" error
+// still surfaces rather than being silently swallowed.
+func TestResolveAgentEntry_UninstalledLeavesEntryUnchanged(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("POSIX-specific layout")
+	}
+
+	root := t.TempDir()
+	stableBin := filepath.Join(root, "bin")
+	t.Setenv("PATH", stableBin)
+	// Disable the login-shell fallback so an actual codex on the host running
+	// this test can't stand in for the "uninstalled" binary.
+	t.Setenv("SHELL", filepath.Join(t.TempDir(), "fish"))
+	pinned := installVersionedCodex(t, root, "0.144.1", stableBin)
+
+	// Uninstall entirely: remove the versioned tree and the stable symlink.
+	if err := os.RemoveAll(root); err != nil {
+		t.Fatalf("remove install root: %v", err)
+	}
+
+	d := newTestDaemon(t)
+	entry := AgentEntry{Path: pinned, Command: "codex"}
+	got := d.resolveAgentEntry("codex", entry)
+	if got.Path != pinned {
+		t.Fatalf("expected entry unchanged when binary is gone, got %q want %q", got.Path, pinned)
+	}
+}
+
+// TestResolveAgentEntry_NoCommandNoHeal verifies that a synthesized entry with
+// no recorded Command (e.g. a custom runtime profile carrying an absolute path)
+// is never re-resolved: the entry is returned as-is even when its path is gone.
+func TestResolveAgentEntry_NoCommandNoHeal(t *testing.T) {
+	d := newTestDaemon(t)
+	entry := AgentEntry{Path: filepath.Join(t.TempDir(), "does-not-exist"), Command: ""}
+	if got := d.resolveAgentEntry("codex", entry); got.Path != entry.Path {
+		t.Fatalf("entry with empty Command was rewritten: got %q, want %q", got.Path, entry.Path)
+	}
+}

--- a/server/internal/daemon/agent_path_selfheal_test.go
+++ b/server/internal/daemon/agent_path_selfheal_test.go
@@ -229,6 +229,56 @@ func TestResolveAgentEntry_ReturnsVersionPairedWithCachedPath(t *testing.T) {
 	}
 }
 
+// TestResolveAgentEntry_HealedPathWinsOverReappearingPinnedPath covers the
+// follow-up edge from the third-round review: after a self-heal to v2, if the
+// originally pinned v1 path reappears on disk (a downgrade / reinstall that
+// recreates the old versioned directory) while the healed v2 binary is still
+// present, resolveAgentEntry must keep returning the healed {v2, its version}
+// pair. Returning the reappeared v1 path here would pair the old binary with
+// the healed v2 version — the mismatched {old path, new version} the review
+// flagged.
+func TestResolveAgentEntry_HealedPathWinsOverReappearingPinnedPath(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlink/exec-bit layout is POSIX-specific")
+	}
+	stubDetectVersionFromPath(t)
+
+	root := t.TempDir()
+	stableBin := filepath.Join(root, "bin")
+	t.Setenv("PATH", stableBin)
+	t.Setenv("SHELL", filepath.Join(t.TempDir(), "fish"))
+
+	v1 := installVersionedCodex(t, root, "0.144.1", stableBin)
+	d := newSelfHealTestDaemon()
+	d.setAgentVersion("codex", "0.144.1")
+	entry := AgentEntry{Path: v1, Command: "codex"}
+	ctx := context.Background()
+
+	// In-place upgrade: drop v1, repoint the stable symlink at v2, and heal.
+	if err := os.RemoveAll(filepath.Join(root, "Caskroom", "codex", "0.144.1")); err != nil {
+		t.Fatalf("remove v1 tree: %v", err)
+	}
+	v2 := installVersionedCodex(t, root, "0.144.3", stableBin)
+	if got, ver := d.resolveAgentEntry(ctx, "codex", entry); got.Path != v2 || ver != "0.144.3" {
+		t.Fatalf("initial heal wrong: got (%q, %q), want (%q, %q)", got.Path, ver, v2, "0.144.3")
+	}
+
+	// The originally pinned v1 path reappears (a reinstall recreating the old
+	// versioned dir) while the healed v2 binary is still present on disk.
+	writeExecStub(t, v1)
+	if !agentExecutablePresent(v1) {
+		t.Fatalf("v1 path should be runnable again after reinstall: %q", v1)
+	}
+
+	got, ver := d.resolveAgentEntry(ctx, "codex", entry)
+	if got.Path != v2 {
+		t.Fatalf("reappearing pinned path hijacked the launch: got %q, want healed %q", got.Path, v2)
+	}
+	if ver != "0.144.3" {
+		t.Fatalf("returned version not paired with healed path: got %q, want %q", ver, "0.144.3")
+	}
+}
+
 // TestResolveAgentEntry_UninstalledLeavesEntryUnchanged verifies that when the
 // binary is genuinely gone (not just moved by an upgrade), resolveAgentEntry
 // returns the entry untouched so the downstream "executable not found" error

--- a/server/internal/daemon/agent_path_selfheal_test.go
+++ b/server/internal/daemon/agent_path_selfheal_test.go
@@ -16,7 +16,7 @@ import (
 func newSelfHealTestDaemon() *Daemon {
 	return &Daemon{
 		logger:        slog.Default(),
-		resolvedPaths: make(map[string]string),
+		resolvedPaths: make(map[string]healedAgent),
 		agentVersions: make(map[string]string),
 	}
 }
@@ -68,9 +68,9 @@ func installVersionedCodex(t *testing.T, root, version, stableBin string) string
 // TestResolveAgentEntry_SelfHealsAfterInPlaceUpgrade reproduces MUL-4486: a
 // version manager upgrades codex in place, deleting the versioned directory the
 // daemon pinned at startup and repointing the stable command name at the new
-// version. resolveAgentEntry must re-resolve the pinned path AND move the
-// cached detected version in lockstep, so downstream policy sees the binary
-// that will actually run.
+// version. resolveAgentEntry must re-resolve the pinned path AND return the
+// matching version, so the caller keys downstream policy off the binary that
+// will actually run.
 func TestResolveAgentEntry_SelfHealsAfterInPlaceUpgrade(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("symlink/exec-bit layout is POSIX-specific")
@@ -95,10 +95,10 @@ func TestResolveAgentEntry_SelfHealsAfterInPlaceUpgrade(t *testing.T) {
 	entry := AgentEntry{Path: v1, Command: "codex"}
 	ctx := context.Background()
 
-	// While the pinned binary is present it must be returned unchanged — the
-	// anti-PATH-redirect guarantee for the normal case.
-	if got := d.resolveAgentEntry(ctx, "codex", entry); got.Path != v1 {
-		t.Fatalf("live pinned path was rewritten: got %q, want %q", got.Path, v1)
+	// While the pinned binary is present it must be returned unchanged, paired
+	// with its registration-detected version — the anti-PATH-redirect case.
+	if got, ver := d.resolveAgentEntry(ctx, "codex", entry); got.Path != v1 || ver != "0.144.1" {
+		t.Fatalf("live pinned path/version rewritten: got (%q, %q), want (%q, %q)", got.Path, ver, v1, "0.144.1")
 	}
 
 	// In-place upgrade: drop the v1 tree and repoint the stable symlink at v2.
@@ -110,29 +110,33 @@ func TestResolveAgentEntry_SelfHealsAfterInPlaceUpgrade(t *testing.T) {
 	}
 	v2 := installVersionedCodex(t, root, "0.144.3", stableBin)
 
-	got := d.resolveAgentEntry(ctx, "codex", entry)
+	got, ver := d.resolveAgentEntry(ctx, "codex", entry)
 	if got.Path != v2 {
 		t.Fatalf("self-heal resolved %q, want re-resolved v2 %q", got.Path, v2)
 	}
 	if !agentExecutablePresent(got.Path) {
 		t.Fatalf("self-healed path is not runnable: %q", got.Path)
 	}
-	// Must-fix (MUL-4486 review): the detected-version cache moved with the path.
+	// Must-fix (MUL-4486 review): the version returned is paired with the healed
+	// path, and the shared version cache moved with it too.
+	if ver != "0.144.3" {
+		t.Fatalf("returned version not paired with healed path: got %q, want %q", ver, "0.144.3")
+	}
 	if v := d.agentVersion("codex"); v != "0.144.3" {
-		t.Fatalf("agent version not updated in lockstep: got %q, want %q", v, "0.144.3")
+		t.Fatalf("version cache not updated in lockstep: got %q, want %q", v, "0.144.3")
 	}
 
 	// A subsequent call with the same stale entry must reuse the remembered
-	// heal without re-resolving from scratch. Prove it by breaking PATH: if it
-	// re-resolved now it would miss, but the cached healed path still resolves.
+	// {path, version} without re-resolving. Prove it by breaking PATH: if it
+	// re-resolved now it would miss, but the cached heal still resolves.
 	t.Setenv("PATH", filepath.Join(root, "empty"))
-	if got := d.resolveAgentEntry(ctx, "codex", entry); got.Path != v2 {
-		t.Fatalf("cached self-heal not reused: got %q, want %q", got.Path, v2)
+	if got, ver := d.resolveAgentEntry(ctx, "codex", entry); got.Path != v2 || ver != "0.144.3" {
+		t.Fatalf("cached self-heal not reused: got (%q, %q), want (%q, %q)", got.Path, ver, v2, "0.144.3")
 	}
 }
 
 // TestResolveAgentEntry_RejectsBelowMinVersionAfterUpgrade covers the review's
-// second concern: if re-resolution lands on a build below the minimum supported
+// concern: if re-resolution lands on a build below the minimum supported
 // version, it must NOT be adopted or launched, and the cached version must not
 // be corrupted downward.
 func TestResolveAgentEntry_RejectsBelowMinVersionAfterUpgrade(t *testing.T) {
@@ -159,9 +163,13 @@ func TestResolveAgentEntry_RejectsBelowMinVersionAfterUpgrade(t *testing.T) {
 	}
 	installVersionedCodex(t, root, "0.9.0", stableBin)
 
-	got := d.resolveAgentEntry(ctx, "codex", entry)
+	got, ver := d.resolveAgentEntry(ctx, "codex", entry)
 	if got.Path != v1 {
 		t.Fatalf("below-min build was adopted: got %q, want stale pinned %q", got.Path, v1)
+	}
+	// The returned version stays the (stale) base — never the below-min value.
+	if ver != "0.144.1" {
+		t.Fatalf("returned version corrupted to below-min: got %q, want %q", ver, "0.144.1")
 	}
 	d.resolvedPathsMu.RLock()
 	_, cached := d.resolvedPaths["codex"]
@@ -171,6 +179,53 @@ func TestResolveAgentEntry_RejectsBelowMinVersionAfterUpgrade(t *testing.T) {
 	}
 	if v := d.agentVersion("codex"); v != "0.144.1" {
 		t.Fatalf("cached version was corrupted to a below-min value: got %q, want %q", v, "0.144.1")
+	}
+}
+
+// TestResolveAgentEntry_ReturnsVersionPairedWithCachedPath is the regression
+// for the second-round review race: a task that hits the already-healed path
+// (via the resolvedPaths fast path, without entering singleflight) must read
+// the version that goes WITH that path, not whatever the separately-mutable
+// agentVersions cache happens to hold. We heal to v2, then deliberately skew
+// agentVersions to a bogus value to stand in for the window where the two
+// caches disagree, and assert the reused resolution still returns v2's version.
+func TestResolveAgentEntry_ReturnsVersionPairedWithCachedPath(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlink/exec-bit layout is POSIX-specific")
+	}
+	stubDetectVersionFromPath(t)
+
+	root := t.TempDir()
+	stableBin := filepath.Join(root, "bin")
+	t.Setenv("PATH", stableBin)
+	t.Setenv("SHELL", filepath.Join(t.TempDir(), "fish"))
+
+	v1 := installVersionedCodex(t, root, "0.144.1", stableBin)
+	d := newSelfHealTestDaemon()
+	d.setAgentVersion("codex", "0.144.1")
+	entry := AgentEntry{Path: v1, Command: "codex"}
+	ctx := context.Background()
+
+	if err := os.RemoveAll(filepath.Join(root, "Caskroom", "codex", "0.144.1")); err != nil {
+		t.Fatalf("remove v1 tree: %v", err)
+	}
+	v2 := installVersionedCodex(t, root, "0.144.3", stableBin)
+
+	// First call heals and caches {v2, 0.144.3}.
+	if got, ver := d.resolveAgentEntry(ctx, "codex", entry); got.Path != v2 || ver != "0.144.3" {
+		t.Fatalf("initial heal wrong: got (%q, %q)", got.Path, ver)
+	}
+	// Simulate the two caches transiently disagreeing (the exact window the race
+	// was about): the shared version cache holds a value that does NOT match the
+	// cached path. The paired return must still win.
+	d.setAgentVersion("codex", "0.0.1-stale")
+
+	got, ver := d.resolveAgentEntry(ctx, "codex", entry)
+	if got.Path != v2 {
+		t.Fatalf("cached path not reused: got %q, want %q", got.Path, v2)
+	}
+	if ver != "0.144.3" {
+		t.Fatalf("returned version came from the skewed shared cache, not the cached path pairing: got %q, want %q", ver, "0.144.3")
 	}
 }
 
@@ -198,7 +253,7 @@ func TestResolveAgentEntry_UninstalledLeavesEntryUnchanged(t *testing.T) {
 
 	d := newSelfHealTestDaemon()
 	entry := AgentEntry{Path: pinned, Command: "codex"}
-	got := d.resolveAgentEntry(context.Background(), "codex", entry)
+	got, _ := d.resolveAgentEntry(context.Background(), "codex", entry)
 	if got.Path != pinned {
 		t.Fatalf("expected entry unchanged when binary is gone, got %q want %q", got.Path, pinned)
 	}
@@ -210,7 +265,7 @@ func TestResolveAgentEntry_UninstalledLeavesEntryUnchanged(t *testing.T) {
 func TestResolveAgentEntry_NoCommandNoHeal(t *testing.T) {
 	d := newSelfHealTestDaemon()
 	entry := AgentEntry{Path: filepath.Join(t.TempDir(), "does-not-exist"), Command: ""}
-	if got := d.resolveAgentEntry(context.Background(), "codex", entry); got.Path != entry.Path {
+	if got, _ := d.resolveAgentEntry(context.Background(), "codex", entry); got.Path != entry.Path {
 		t.Fatalf("entry with empty Command was rewritten: got %q, want %q", got.Path, entry.Path)
 	}
 }

--- a/server/internal/daemon/config.go
+++ b/server/internal/daemon/config.go
@@ -227,8 +227,9 @@ func LoadConfig(overrides Overrides) (Config, error) {
 		cmd := envOrDefault(envVar, defaultCmd)
 		if path, err := resolveAgentExecutablePath(cmd); err == nil {
 			return AgentEntry{
-				Path:  path,
-				Model: strings.TrimSpace(os.Getenv(modelEnv)),
+				Path:    path,
+				Command: cmd,
+				Model:   strings.TrimSpace(os.Getenv(modelEnv)),
 			}, true
 		}
 		// The shell fallback only rescues bare command names. An operator
@@ -240,8 +241,9 @@ func LoadConfig(overrides Overrides) (Config, error) {
 		}
 		if path, ok := getShellResolved()[cmd]; ok {
 			return AgentEntry{
-				Path:  path,
-				Model: strings.TrimSpace(os.Getenv(modelEnv)),
+				Path:    path,
+				Command: cmd,
+				Model:   strings.TrimSpace(os.Getenv(modelEnv)),
 			}, true
 		}
 		if defaultCmd == "codex" && cmd == defaultCmd {
@@ -250,8 +252,9 @@ func LoadConfig(overrides Overrides) (Config, error) {
 			for _, p := range codexDesktopAppBundlePaths() {
 				if _, err := os.Stat(p); err == nil {
 					return AgentEntry{
-						Path:  p,
-						Model: strings.TrimSpace(os.Getenv(modelEnv)),
+						Path:    p,
+						Command: cmd,
+						Model:   strings.TrimSpace(os.Getenv(modelEnv)),
 					}, true
 				}
 			}
@@ -303,8 +306,9 @@ func LoadConfig(overrides Overrides) (Config, error) {
 	qoderPath := envOrDefault("MULTICA_QODER_PATH", "qodercli")
 	if path, err := resolveAgentExecutablePath(qoderPath); err == nil {
 		agents["qoder"] = AgentEntry{
-			Path:  path,
-			Model: strings.TrimSpace(os.Getenv("MULTICA_QODER_MODEL")),
+			Path:    path,
+			Command: qoderPath,
+			Model:   strings.TrimSpace(os.Getenv("MULTICA_QODER_MODEL")),
 		}
 	}
 	// ByteDance official TRAE CLI (the `traecli` binary from https://docs.trae.cn/cli),
@@ -689,6 +693,47 @@ func resolveAgentExecutablePath(cmd string) (string, error) {
 		}
 	}
 	return canonicalExecutablePath(resolved), nil
+}
+
+// agentExecutablePresent reports whether path currently resolves to a runnable
+// executable, using the exact check the agent backends apply at launch
+// (exec.LookPath). A pinned AgentEntry.Path that fails this has vanished from
+// disk — typically because a version manager did an in-place upgrade and
+// deleted the old versioned directory the path pointed into (MUL-4486).
+func agentExecutablePresent(path string) bool {
+	if path == "" {
+		return false
+	}
+	_, err := exec.LookPath(path)
+	return err == nil
+}
+
+// reresolveAgentCommand re-runs the startup resolution for a single agent
+// command name, returning the freshly resolved absolute path. It mirrors the
+// probe() order in LoadConfig: exec.LookPath (with the ~/.multica/hooks
+// exclusion preserved via resolveAgentExecutablePath) first, then the login
+// shell fallback for a bare command name a GUI-launched daemon can't see on
+// its own PATH. It is only called on the miss path — when a previously pinned
+// path has disappeared — so the login-shell cost is paid rarely, never on a
+// normal launch.
+func reresolveAgentCommand(cmd string) (string, bool) {
+	if cmd == "" {
+		return "", false
+	}
+	if path, err := resolveAgentExecutablePath(cmd); err == nil {
+		return path, true
+	}
+	// A bare command name the daemon's own PATH can't see: retry via the
+	// user's login shell, exactly as the startup probe does for
+	// fnm/nvm/native-installer prefixes. Absolute/relative overrides skip
+	// this — an operator-pinned MULTICA_*_PATH that no longer exists should
+	// stay a hard miss rather than silently resolve a different binary.
+	if !strings.ContainsAny(cmd, "/\\") {
+		if path, ok := resolveAgentsViaLoginShell([]string{cmd})[cmd]; ok {
+			return path, true
+		}
+	}
+	return "", false
 }
 
 func lookPathExcludingMulticaHooks(cmd string) (string, error) {

--- a/server/internal/daemon/daemon.go
+++ b/server/internal/daemon/daemon.go
@@ -18,6 +18,8 @@ import (
 	"sync/atomic"
 	"time"
 
+	"golang.org/x/sync/singleflight"
+
 	"github.com/multica-ai/multica/server/internal/cli"
 	"github.com/multica-ai/multica/server/internal/daemon/execenv"
 	"github.com/multica-ai/multica/server/internal/daemon/repocache"
@@ -181,6 +183,10 @@ type Daemon struct {
 	// it without re-resolving. Keyed by provider. See MUL-4486.
 	resolvedPathsMu sync.RWMutex
 	resolvedPaths   map[string]string
+	// healGroup coalesces concurrent self-heal re-resolutions per provider so a
+	// just-upgraded agent seen by many queued tasks at once pays for a single
+	// login-shell probe + version detection instead of one per task (MUL-4486).
+	healGroup singleflight.Group
 
 	wsHBMu      sync.RWMutex         // guards wsHBLastAck
 	wsHBLastAck map[string]time.Time // runtime_id -> last successful WS heartbeat ack timestamp
@@ -319,16 +325,21 @@ func (d *Daemon) agentVersion(provider string) string {
 // Behaviour:
 //   - Pinned Path still present -> returned unchanged. The anti-redirect
 //     guarantee holds for the normal case: a live pinned binary is never
-//     second-guessed even if PATH now points elsewhere.
+//     second-guessed even if PATH now points elsewhere, and its cached detected
+//     version already corresponds to it.
 //   - Pinned Path gone -> reuse a previously self-healed path if it is still
 //     present, otherwise re-resolve entry.Command once (preserving the
-//     ~/.multica/hooks exclusion and the login-shell fallback) and remember the
-//     result for later calls. This reproduces exactly what a daemon restart
-//     would resolve, so it is no less safe than the documented restart
-//     workaround — only automatic.
-//   - Re-resolution fails (binary genuinely uninstalled) -> entry is returned
-//     unchanged so the downstream "executable not found" error still surfaces.
-func (d *Daemon) resolveAgentEntry(provider string, entry AgentEntry) AgentEntry {
+//     ~/.multica/hooks exclusion and the login-shell fallback). Before adopting
+//     the re-resolved binary it is version-detected and run through the same
+//     minimum-version gate registration applies, and on success the detected
+//     version cache is updated in lockstep so downstream policy (e.g. the Codex
+//     sandbox version) matches the binary that will actually run. This
+//     reproduces exactly what a daemon restart would resolve, so it is no less
+//     safe than the documented restart workaround — only automatic.
+//   - Re-resolution fails, the candidate can't be version-detected, or it is
+//     below the minimum supported version -> entry is returned unchanged so the
+//     candidate is never launched and the downstream error still surfaces.
+func (d *Daemon) resolveAgentEntry(ctx context.Context, provider string, entry AgentEntry) AgentEntry {
 	if agentExecutablePresent(entry.Path) {
 		return entry
 	}
@@ -341,9 +352,64 @@ func (d *Daemon) resolveAgentEntry(provider string, entry AgentEntry) AgentEntry
 		return entry
 	}
 
-	newPath, found := reresolveAgentCommand(entry.Command)
-	if !found {
+	if entry.Command == "" {
 		return entry
+	}
+
+	// Coalesce concurrent heals for the same provider: the first task through
+	// pays for the re-resolve + version detection, the rest share its result
+	// instead of each spawning their own login shell and `--version` probe.
+	command := entry.Command
+	v, _, _ := d.healGroup.Do(provider, func() (any, error) {
+		return d.healAgentPath(ctx, provider, command), nil
+	})
+	newPath, _ := v.(string)
+	if newPath == "" {
+		return entry
+	}
+	entry.Path = newPath
+	return entry
+}
+
+// healAgentPath re-resolves command for provider and, if a usable binary is
+// found, records it and returns its path. "Usable" means: it resolves, its
+// version can be detected, and that version meets the same minimum-version gate
+// registration enforces. Adopting the path also refreshes the detected-version
+// cache so callers that read d.agentVersion(provider) — notably the Codex
+// sandbox policy — see the version of the binary that will actually run. It
+// returns "" when nothing usable was found, so the caller keeps the (stale)
+// pinned entry and the candidate is never launched. Runs under healGroup, one
+// invocation at a time per provider.
+func (d *Daemon) healAgentPath(ctx context.Context, provider, command string) string {
+	// Re-check the cache: a predecessor under the same singleflight key may have
+	// already populated it, or a prior heal completed between the read above and
+	// entering here.
+	d.resolvedPathsMu.RLock()
+	cached, ok := d.resolvedPaths[provider]
+	d.resolvedPathsMu.RUnlock()
+	if ok && agentExecutablePresent(cached) {
+		return cached
+	}
+
+	newPath, found := reresolveAgentCommand(command)
+	if !found {
+		return ""
+	}
+
+	// Verify before adopting. An in-place "upgrade" that actually repoints at an
+	// older or broken install must not be launched under the daemon's stale
+	// version policy, and must not slip past the minimum-version gate that the
+	// registration path applies (MUL-4486 review).
+	version, err := detectAgentVersion(ctx, newPath)
+	if err != nil {
+		d.logger.Warn("re-resolved agent executable failed version detection; keeping pinned path",
+			"provider", provider, "command", command, "new_path", newPath, "error", err)
+		return ""
+	}
+	if err := checkAgentMinVersion(provider, version); err != nil {
+		d.logger.Warn("re-resolved agent executable is below the minimum supported version; not adopting it",
+			"provider", provider, "command", command, "new_path", newPath, "version", version, "error", err)
+		return ""
 	}
 
 	d.resolvedPathsMu.Lock()
@@ -352,11 +418,12 @@ func (d *Daemon) resolveAgentEntry(provider string, entry AgentEntry) AgentEntry
 	}
 	d.resolvedPaths[provider] = newPath
 	d.resolvedPathsMu.Unlock()
+	// Keep the detected-version cache in lockstep with the path.
+	d.setAgentVersion(provider, version)
 
 	d.logger.Info("re-resolved agent executable after pinned path vanished (in-place upgrade)",
-		"provider", provider, "command", entry.Command, "old_path", entry.Path, "new_path", newPath)
-	entry.Path = newPath
-	return entry
+		"provider", provider, "command", command, "new_path", newPath, "version", version)
+	return newPath
 }
 
 func (d *Daemon) notifyRuntimeSetChanged() {
@@ -997,8 +1064,10 @@ func (d *Daemon) registerRuntimesForWorkspace(ctx context.Context, workspaceID s
 	for name, entry := range d.cfg.Agents {
 		// Self-heal a pinned executable path an in-place upgrade deleted
 		// (MUL-4486) so version detection — and thus staying registered/online
-		// — recovers without a daemon restart.
-		entry = d.resolveAgentEntry(name, entry)
+		// — recovers without a daemon restart. resolveAgentEntry already
+		// version-gates the healed binary; the detect + min-version check below
+		// still runs to produce the version string this registration reports.
+		entry = d.resolveAgentEntry(ctx, name, entry)
 		version, err := detectAgentVersion(ctx, entry.Path)
 		if err != nil {
 			d.logger.Warn("skip registering runtime", "name", name, "error", err)
@@ -2123,7 +2192,7 @@ func (d *Daemon) handleModelList(ctx context.Context, rt Runtime, requestID stri
 		return
 	}
 	// Self-heal a pinned executable path an in-place upgrade deleted (MUL-4486).
-	entry = d.resolveAgentEntry(rt.Provider, entry)
+	entry = d.resolveAgentEntry(ctx, rt.Provider, entry)
 
 	models, err := agent.ListModels(ctx, rt.Provider, entry.Path)
 	if err != nil {
@@ -3544,12 +3613,6 @@ func (d *Daemon) runTask(ctx context.Context, task Task, provider string, slot i
 	defer d.clearTaskRepoRefs(task.WorkspaceID, task.ID)
 
 	entry, ok := d.cfg.Agents[provider]
-	if ok {
-		// Self-heal a pinned executable path that an in-place upgrade deleted
-		// (MUL-4486). Done before the custom-profile override below so a
-		// custom runtime's own path is never second-guessed.
-		entry = d.resolveAgentEntry(provider, entry)
-	}
 	// A custom runtime profile (MUL-3284) overrides the executable path: the
 	// runtime's protocol_family is the provider (so agent.New still selects
 	// the right backend), but the actual binary on PATH is the profile's
@@ -3566,6 +3629,12 @@ func (d *Daemon) runTask(ctx context.Context, task Task, provider string, slot i
 			"task_id", task.ID, "runtime_id", task.RuntimeID,
 			"provider", provider, "command_path", customSpec.path,
 			"fixed_args", len(profileFixedArgs))
+	} else if ok {
+		// Built-in provider: self-heal a pinned executable path that an in-place
+		// upgrade deleted (MUL-4486). Only reached when no custom profile owns
+		// the launch, so a custom runtime's path is never second-guessed and a
+		// custom-only host pays no wasted re-resolution.
+		entry = d.resolveAgentEntry(ctx, provider, entry)
 	}
 	if !ok {
 		return TaskResult{}, fmt.Errorf("no agent configured for provider %q", provider)

--- a/server/internal/daemon/daemon.go
+++ b/server/internal/daemon/daemon.go
@@ -343,31 +343,38 @@ type healedAgent struct {
 // updating.
 //
 // Behaviour:
-//   - Pinned Path still present -> returned unchanged, paired with its
-//     registration-detected version. The anti-redirect guarantee holds for the
-//     normal case: a live pinned binary is never second-guessed even if PATH
-//     now points elsewhere.
-//   - Pinned Path gone -> reuse a previously self-healed {path, version} if the
-//     path is still present, otherwise re-resolve entry.Command once (preserving
-//     the ~/.multica/hooks exclusion and the login-shell fallback). Before
-//     adopting the re-resolved binary it is version-detected and run through the
-//     same minimum-version gate registration applies. This reproduces exactly
-//     what a daemon restart would resolve, so it is no less safe than the
-//     documented restart workaround — only automatic.
+//   - A previous self-heal that is still live -> returned with its paired
+//     version. This is checked first so that once we've re-resolved to a new
+//     binary, a reappearing stale path (a downgrade / reinstall recreating the
+//     old versioned directory) cannot re-pair that old binary with the healed
+//     version — a mismatched {old path, new version} (MUL-4486 review).
+//   - Otherwise, pinned Path still present -> returned unchanged, paired with
+//     its registration-detected version. The anti-redirect guarantee holds for
+//     the normal (never-healed) case: a live pinned binary is never
+//     second-guessed even if PATH now points elsewhere.
+//   - Pinned Path gone and no live heal -> re-resolve entry.Command once
+//     (preserving the ~/.multica/hooks exclusion and the login-shell fallback).
+//     Before adopting the re-resolved binary it is version-detected and run
+//     through the same minimum-version gate registration applies. This
+//     reproduces exactly what a daemon restart would resolve, so it is no less
+//     safe than the documented restart workaround — only automatic.
 //   - Re-resolution fails, the candidate can't be version-detected, or it is
 //     below the minimum supported version -> entry is returned unchanged so the
 //     candidate is never launched and the downstream error still surfaces.
 func (d *Daemon) resolveAgentEntry(ctx context.Context, provider string, entry AgentEntry) (AgentEntry, string) {
-	if agentExecutablePresent(entry.Path) {
-		return entry, d.agentVersion(provider)
-	}
-
+	// A prior self-heal wins over the original pinned path: it carries a
+	// {path, version} pair we already verified together, so it can never regress
+	// to the mismatched pairing a reappearing stale path would produce.
 	d.resolvedPathsMu.RLock()
 	healed, ok := d.resolvedPaths[provider]
 	d.resolvedPathsMu.RUnlock()
 	if ok && agentExecutablePresent(healed.path) {
 		entry.Path = healed.path
 		return entry, healed.version
+	}
+
+	if agentExecutablePresent(entry.Path) {
+		return entry, d.agentVersion(provider)
 	}
 
 	if entry.Command == "" {
@@ -3745,8 +3752,10 @@ func (d *Daemon) runTask(ctx context.Context, task Task, provider string, slot i
 	var env *execenv.Environment
 	// For a built-in codex task, use the version paired with the resolved path
 	// so an in-place upgrade can't leave the sandbox policy on the old version
-	// (MUL-4486). Other providers / custom profiles fall back to the cached
-	// codex version, which they don't consume anyway.
+	// (MUL-4486). A custom codex runtime skips the self-heal, so resolvedVersion
+	// is empty and it keeps the existing cached-version fallback — its binary is
+	// the profile's own command, which the daemon never pins or version-detects.
+	// Non-codex providers carry the value through without consuming it.
 	codexVersion := d.agentVersion("codex")
 	if provider == "codex" && resolvedVersion != "" {
 		codexVersion = resolvedVersion

--- a/server/internal/daemon/daemon.go
+++ b/server/internal/daemon/daemon.go
@@ -172,6 +172,16 @@ type Daemon struct {
 	versionsMu    sync.RWMutex      // guards agentVersions
 	agentVersions map[string]string // provider -> detected CLI version (set during registration)
 
+	// resolvedPathsMu guards resolvedPaths, the self-healed executable paths.
+	// The daemon pins each agent's absolute path at startup so a later PATH
+	// change can't redirect a task launch. When that pinned path later vanishes
+	// (a version manager did an in-place upgrade — Homebrew Cask, nvm/fnm),
+	// resolveAgentEntry re-resolves the original command once and records the
+	// result here so subsequent launches, model lists, and registrations reuse
+	// it without re-resolving. Keyed by provider. See MUL-4486.
+	resolvedPathsMu sync.RWMutex
+	resolvedPaths   map[string]string
+
 	wsHBMu      sync.RWMutex         // guards wsHBLastAck
 	wsHBLastAck map[string]time.Time // runtime_id -> last successful WS heartbeat ack timestamp
 
@@ -263,6 +273,7 @@ func New(cfg Config, logger *slog.Logger) *Daemon {
 		profileLaunchSpecs:        make(map[string]profileLaunchSpec),
 		runtimeSet:                newRuntimeSetWatcher(),
 		agentVersions:             make(map[string]string),
+		resolvedPaths:             make(map[string]string),
 		wsHBLastAck:               make(map[string]time.Time),
 		activeEnvRoots:            make(map[string]int),
 		localPathLocks:            NewLocalPathLocker(),
@@ -291,6 +302,61 @@ func (d *Daemon) agentVersion(provider string) string {
 	d.versionsMu.RLock()
 	defer d.versionsMu.RUnlock()
 	return d.agentVersions[provider]
+}
+
+// resolveAgentEntry returns entry with a usable executable path, self-healing
+// the pinned Path when it has vanished from disk (MUL-4486).
+//
+// The daemon pins each agent's absolute, symlink-resolved path at startup so a
+// later PATH change cannot redirect a task launch. But a version manager
+// (Homebrew Cask, nvm/fnm) upgrading in place deletes the old versioned
+// directory that pinned path points into and repoints the stable command name
+// at the new version — leaving the daemon holding a path that no longer exists
+// until it restarts. Every consumer of entry.Path (task launch, model listing,
+// version detection at registration) then hard-fails with "executable not
+// found".
+//
+// Behaviour:
+//   - Pinned Path still present -> returned unchanged. The anti-redirect
+//     guarantee holds for the normal case: a live pinned binary is never
+//     second-guessed even if PATH now points elsewhere.
+//   - Pinned Path gone -> reuse a previously self-healed path if it is still
+//     present, otherwise re-resolve entry.Command once (preserving the
+//     ~/.multica/hooks exclusion and the login-shell fallback) and remember the
+//     result for later calls. This reproduces exactly what a daemon restart
+//     would resolve, so it is no less safe than the documented restart
+//     workaround — only automatic.
+//   - Re-resolution fails (binary genuinely uninstalled) -> entry is returned
+//     unchanged so the downstream "executable not found" error still surfaces.
+func (d *Daemon) resolveAgentEntry(provider string, entry AgentEntry) AgentEntry {
+	if agentExecutablePresent(entry.Path) {
+		return entry
+	}
+
+	d.resolvedPathsMu.RLock()
+	healed, ok := d.resolvedPaths[provider]
+	d.resolvedPathsMu.RUnlock()
+	if ok && agentExecutablePresent(healed) {
+		entry.Path = healed
+		return entry
+	}
+
+	newPath, found := reresolveAgentCommand(entry.Command)
+	if !found {
+		return entry
+	}
+
+	d.resolvedPathsMu.Lock()
+	if d.resolvedPaths == nil {
+		d.resolvedPaths = make(map[string]string)
+	}
+	d.resolvedPaths[provider] = newPath
+	d.resolvedPathsMu.Unlock()
+
+	d.logger.Info("re-resolved agent executable after pinned path vanished (in-place upgrade)",
+		"provider", provider, "command", entry.Command, "old_path", entry.Path, "new_path", newPath)
+	entry.Path = newPath
+	return entry
 }
 
 func (d *Daemon) notifyRuntimeSetChanged() {
@@ -929,6 +995,10 @@ func (d *Daemon) registerRuntimesForWorkspace(ctx context.Context, workspaceID s
 	var runtimes []map[string]string
 	var failedProfiles []map[string]string
 	for name, entry := range d.cfg.Agents {
+		// Self-heal a pinned executable path an in-place upgrade deleted
+		// (MUL-4486) so version detection — and thus staying registered/online
+		// — recovers without a daemon restart.
+		entry = d.resolveAgentEntry(name, entry)
 		version, err := detectAgentVersion(ctx, entry.Path)
 		if err != nil {
 			d.logger.Warn("skip registering runtime", "name", name, "error", err)
@@ -2052,6 +2122,8 @@ func (d *Daemon) handleModelList(ctx context.Context, rt Runtime, requestID stri
 		})
 		return
 	}
+	// Self-heal a pinned executable path an in-place upgrade deleted (MUL-4486).
+	entry = d.resolveAgentEntry(rt.Provider, entry)
 
 	models, err := agent.ListModels(ctx, rt.Provider, entry.Path)
 	if err != nil {
@@ -3472,6 +3544,12 @@ func (d *Daemon) runTask(ctx context.Context, task Task, provider string, slot i
 	defer d.clearTaskRepoRefs(task.WorkspaceID, task.ID)
 
 	entry, ok := d.cfg.Agents[provider]
+	if ok {
+		// Self-heal a pinned executable path that an in-place upgrade deleted
+		// (MUL-4486). Done before the custom-profile override below so a
+		// custom runtime's own path is never second-guessed.
+		entry = d.resolveAgentEntry(provider, entry)
+	}
 	// A custom runtime profile (MUL-3284) overrides the executable path: the
 	// runtime's protocol_family is the provider (so agent.New still selects
 	// the right backend), but the actual binary on PATH is the profile's

--- a/server/internal/daemon/daemon.go
+++ b/server/internal/daemon/daemon.go
@@ -180,9 +180,12 @@ type Daemon struct {
 	// (a version manager did an in-place upgrade — Homebrew Cask, nvm/fnm),
 	// resolveAgentEntry re-resolves the original command once and records the
 	// result here so subsequent launches, model lists, and registrations reuse
-	// it without re-resolving. Keyed by provider. See MUL-4486.
+	// it without re-resolving. Path and detected version are stored together so
+	// any reader that observes the new path also observes the matching version
+	// (no "new binary under stale version policy" window). Keyed by provider.
+	// See MUL-4486.
 	resolvedPathsMu sync.RWMutex
-	resolvedPaths   map[string]string
+	resolvedPaths   map[string]healedAgent
 	// healGroup coalesces concurrent self-heal re-resolutions per provider so a
 	// just-upgraded agent seen by many queued tasks at once pays for a single
 	// login-shell probe + version detection instead of one per task (MUL-4486).
@@ -279,7 +282,7 @@ func New(cfg Config, logger *slog.Logger) *Daemon {
 		profileLaunchSpecs:        make(map[string]profileLaunchSpec),
 		runtimeSet:                newRuntimeSetWatcher(),
 		agentVersions:             make(map[string]string),
-		resolvedPaths:             make(map[string]string),
+		resolvedPaths:             make(map[string]healedAgent),
 		wsHBLastAck:               make(map[string]time.Time),
 		activeEnvRoots:            make(map[string]int),
 		localPathLocks:            NewLocalPathLocker(),
@@ -310,8 +313,20 @@ func (d *Daemon) agentVersion(provider string) string {
 	return d.agentVersions[provider]
 }
 
-// resolveAgentEntry returns entry with a usable executable path, self-healing
-// the pinned Path when it has vanished from disk (MUL-4486).
+// healedAgent bundles a self-healed executable path with the CLI version
+// detected for it. The two are published together under resolvedPathsMu and
+// returned together from resolveAgentEntry, so a caller that observes the new
+// path necessarily observes the matching version — closing the window where a
+// just-upgraded binary would run under the daemon's previous version policy
+// (MUL-4486 review).
+type healedAgent struct {
+	path    string
+	version string
+}
+
+// resolveAgentEntry returns entry with a usable executable path plus the CLI
+// version that corresponds to that path, self-healing the pinned Path when it
+// has vanished from disk (MUL-4486).
 //
 // The daemon pins each agent's absolute, symlink-resolved path at startup so a
 // later PATH change cannot redirect a task launch. But a version manager
@@ -322,38 +337,41 @@ func (d *Daemon) agentVersion(provider string) string {
 // version detection at registration) then hard-fails with "executable not
 // found".
 //
+// The returned version always matches the returned path, so callers key
+// version-sensitive policy (e.g. the Codex sandbox) off it directly rather than
+// re-reading the shared version cache, which a concurrent heal could still be
+// updating.
+//
 // Behaviour:
-//   - Pinned Path still present -> returned unchanged. The anti-redirect
-//     guarantee holds for the normal case: a live pinned binary is never
-//     second-guessed even if PATH now points elsewhere, and its cached detected
-//     version already corresponds to it.
-//   - Pinned Path gone -> reuse a previously self-healed path if it is still
-//     present, otherwise re-resolve entry.Command once (preserving the
-//     ~/.multica/hooks exclusion and the login-shell fallback). Before adopting
-//     the re-resolved binary it is version-detected and run through the same
-//     minimum-version gate registration applies, and on success the detected
-//     version cache is updated in lockstep so downstream policy (e.g. the Codex
-//     sandbox version) matches the binary that will actually run. This
-//     reproduces exactly what a daemon restart would resolve, so it is no less
-//     safe than the documented restart workaround — only automatic.
+//   - Pinned Path still present -> returned unchanged, paired with its
+//     registration-detected version. The anti-redirect guarantee holds for the
+//     normal case: a live pinned binary is never second-guessed even if PATH
+//     now points elsewhere.
+//   - Pinned Path gone -> reuse a previously self-healed {path, version} if the
+//     path is still present, otherwise re-resolve entry.Command once (preserving
+//     the ~/.multica/hooks exclusion and the login-shell fallback). Before
+//     adopting the re-resolved binary it is version-detected and run through the
+//     same minimum-version gate registration applies. This reproduces exactly
+//     what a daemon restart would resolve, so it is no less safe than the
+//     documented restart workaround — only automatic.
 //   - Re-resolution fails, the candidate can't be version-detected, or it is
 //     below the minimum supported version -> entry is returned unchanged so the
 //     candidate is never launched and the downstream error still surfaces.
-func (d *Daemon) resolveAgentEntry(ctx context.Context, provider string, entry AgentEntry) AgentEntry {
+func (d *Daemon) resolveAgentEntry(ctx context.Context, provider string, entry AgentEntry) (AgentEntry, string) {
 	if agentExecutablePresent(entry.Path) {
-		return entry
+		return entry, d.agentVersion(provider)
 	}
 
 	d.resolvedPathsMu.RLock()
 	healed, ok := d.resolvedPaths[provider]
 	d.resolvedPathsMu.RUnlock()
-	if ok && agentExecutablePresent(healed) {
-		entry.Path = healed
-		return entry
+	if ok && agentExecutablePresent(healed.path) {
+		entry.Path = healed.path
+		return entry, healed.version
 	}
 
 	if entry.Command == "" {
-		return entry
+		return entry, d.agentVersion(provider)
 	}
 
 	// Coalesce concurrent heals for the same provider: the first task through
@@ -363,37 +381,37 @@ func (d *Daemon) resolveAgentEntry(ctx context.Context, provider string, entry A
 	v, _, _ := d.healGroup.Do(provider, func() (any, error) {
 		return d.healAgentPath(ctx, provider, command), nil
 	})
-	newPath, _ := v.(string)
-	if newPath == "" {
-		return entry
+	healed, _ = v.(healedAgent)
+	if healed.path == "" {
+		return entry, d.agentVersion(provider)
 	}
-	entry.Path = newPath
-	return entry
+	entry.Path = healed.path
+	return entry, healed.version
 }
 
 // healAgentPath re-resolves command for provider and, if a usable binary is
-// found, records it and returns its path. "Usable" means: it resolves, its
-// version can be detected, and that version meets the same minimum-version gate
-// registration enforces. Adopting the path also refreshes the detected-version
-// cache so callers that read d.agentVersion(provider) — notably the Codex
-// sandbox policy — see the version of the binary that will actually run. It
-// returns "" when nothing usable was found, so the caller keeps the (stale)
-// pinned entry and the candidate is never launched. Runs under healGroup, one
-// invocation at a time per provider.
-func (d *Daemon) healAgentPath(ctx context.Context, provider, command string) string {
+// found, records it and returns it. "Usable" means: it resolves, its version
+// can be detected, and that version meets the same minimum-version gate
+// registration enforces. Path and version are published together under
+// resolvedPathsMu so any observer of the path also sees the matching version;
+// the shared d.agentVersion cache is refreshed too, for registration hygiene.
+// It returns a zero healedAgent when nothing usable was found, so the caller
+// keeps the (stale) pinned entry and the candidate is never launched. Runs
+// under healGroup, one invocation at a time per provider.
+func (d *Daemon) healAgentPath(ctx context.Context, provider, command string) healedAgent {
 	// Re-check the cache: a predecessor under the same singleflight key may have
 	// already populated it, or a prior heal completed between the read above and
 	// entering here.
 	d.resolvedPathsMu.RLock()
 	cached, ok := d.resolvedPaths[provider]
 	d.resolvedPathsMu.RUnlock()
-	if ok && agentExecutablePresent(cached) {
+	if ok && agentExecutablePresent(cached.path) {
 		return cached
 	}
 
 	newPath, found := reresolveAgentCommand(command)
 	if !found {
-		return ""
+		return healedAgent{}
 	}
 
 	// Verify before adopting. An in-place "upgrade" that actually repoints at an
@@ -404,26 +422,32 @@ func (d *Daemon) healAgentPath(ctx context.Context, provider, command string) st
 	if err != nil {
 		d.logger.Warn("re-resolved agent executable failed version detection; keeping pinned path",
 			"provider", provider, "command", command, "new_path", newPath, "error", err)
-		return ""
+		return healedAgent{}
 	}
 	if err := checkAgentMinVersion(provider, version); err != nil {
 		d.logger.Warn("re-resolved agent executable is below the minimum supported version; not adopting it",
 			"provider", provider, "command", command, "new_path", newPath, "version", version, "error", err)
-		return ""
+		return healedAgent{}
 	}
 
+	adopted := healedAgent{path: newPath, version: version}
+	// Publish path + version atomically: any reader that sees the new path in
+	// resolveAgentEntry gets the matching version out of the same struct value.
 	d.resolvedPathsMu.Lock()
 	if d.resolvedPaths == nil {
-		d.resolvedPaths = make(map[string]string)
+		d.resolvedPaths = make(map[string]healedAgent)
 	}
-	d.resolvedPaths[provider] = newPath
+	d.resolvedPaths[provider] = adopted
 	d.resolvedPathsMu.Unlock()
-	// Keep the detected-version cache in lockstep with the path.
+	// Keep the registration version cache fresh too. The task path reads the
+	// version returned alongside the resolved path (above), not this map, so its
+	// staleness can never gate a launch — this is hygiene for the registration
+	// report and any future d.agentVersion reader.
 	d.setAgentVersion(provider, version)
 
 	d.logger.Info("re-resolved agent executable after pinned path vanished (in-place upgrade)",
 		"provider", provider, "command", command, "new_path", newPath, "version", version)
-	return newPath
+	return adopted
 }
 
 func (d *Daemon) notifyRuntimeSetChanged() {
@@ -1067,7 +1091,7 @@ func (d *Daemon) registerRuntimesForWorkspace(ctx context.Context, workspaceID s
 		// — recovers without a daemon restart. resolveAgentEntry already
 		// version-gates the healed binary; the detect + min-version check below
 		// still runs to produce the version string this registration reports.
-		entry = d.resolveAgentEntry(ctx, name, entry)
+		entry, _ = d.resolveAgentEntry(ctx, name, entry)
 		version, err := detectAgentVersion(ctx, entry.Path)
 		if err != nil {
 			d.logger.Warn("skip registering runtime", "name", name, "error", err)
@@ -2192,7 +2216,7 @@ func (d *Daemon) handleModelList(ctx context.Context, rt Runtime, requestID stri
 		return
 	}
 	// Self-heal a pinned executable path an in-place upgrade deleted (MUL-4486).
-	entry = d.resolveAgentEntry(ctx, rt.Provider, entry)
+	entry, _ = d.resolveAgentEntry(ctx, rt.Provider, entry)
 
 	models, err := agent.ListModels(ctx, rt.Provider, entry.Path)
 	if err != nil {
@@ -3621,6 +3645,10 @@ func (d *Daemon) runTask(ctx context.Context, task Task, provider string, slot i
 	// agent of the same provider installed, so when the runtime is custom we
 	// synthesize an AgentEntry instead of hard-failing on the !ok lookup.
 	var profileFixedArgs []string
+	// resolvedVersion is the CLI version of the built-in binary entry.Path
+	// resolves to, paired with the path by resolveAgentEntry so a just-upgraded
+	// codex is never launched under the previous version's policy (MUL-4486).
+	var resolvedVersion string
 	if customSpec, isCustom := d.customProfileLaunchForRuntime(task.RuntimeID); isCustom {
 		entry.Path = customSpec.path
 		profileFixedArgs = customSpec.fixedArgs
@@ -3634,7 +3662,7 @@ func (d *Daemon) runTask(ctx context.Context, task Task, provider string, slot i
 		// upgrade deleted (MUL-4486). Only reached when no custom profile owns
 		// the launch, so a custom runtime's path is never second-guessed and a
 		// custom-only host pays no wasted re-resolution.
-		entry = d.resolveAgentEntry(ctx, provider, entry)
+		entry, resolvedVersion = d.resolveAgentEntry(ctx, provider, entry)
 	}
 	if !ok {
 		return TaskResult{}, fmt.Errorf("no agent configured for provider %q", provider)
@@ -3715,7 +3743,14 @@ func (d *Daemon) runTask(ctx context.Context, task Task, provider string, slot i
 
 	// Try to reuse the workdir from a previous task on the same (agent, issue) pair.
 	var env *execenv.Environment
+	// For a built-in codex task, use the version paired with the resolved path
+	// so an in-place upgrade can't leave the sandbox policy on the old version
+	// (MUL-4486). Other providers / custom profiles fall back to the cached
+	// codex version, which they don't consume anyway.
 	codexVersion := d.agentVersion("codex")
+	if provider == "codex" && resolvedVersion != "" {
+		codexVersion = resolvedVersion
+	}
 	openclawBin := ""
 	if provider == "openclaw" {
 		openclawBin = entry.Path

--- a/server/internal/daemon/types.go
+++ b/server/internal/daemon/types.go
@@ -8,8 +8,16 @@ import (
 
 // AgentEntry describes a single available agent CLI.
 type AgentEntry struct {
-	Path  string // path to CLI binary
-	Model string // model override (optional)
+	Path string // path to CLI binary (pinned at startup; symlink-resolved to a concrete, possibly versioned, path)
+	// Command is the bare command name or MULTICA_*_PATH value that Path was
+	// resolved from at startup. It is kept so the daemon can re-resolve Path
+	// if the pinned executable later vanishes — e.g. a version manager
+	// (Homebrew Cask, nvm/fnm) does an in-place upgrade that deletes the old
+	// versioned directory Path points into. Empty for synthesized entries
+	// (custom runtime profiles) that carry an absolute path directly. See
+	// Daemon.resolveAgentEntry and MUL-4486.
+	Command string
+	Model   string // model override (optional)
 }
 
 // Runtime represents a registered daemon runtime.


### PR DESCRIPTION
## Summary

Fixes `codex executable not found at "…/codex/<oldver>/bin/codex"` (and the same failure for any agent CLI installed under a version manager) after an **in-place upgrade**.

The daemon pins each agent CLI's absolute, symlink-resolved path at startup so that a later `PATH` change can't redirect a task launch (`resolveAgentExecutablePath` → `EvalSymlinks`). Under Homebrew Cask / nvm / fnm, a stable command name (`/opt/homebrew/bin/codex`) is a symlink into a **versioned** directory (`…/Caskroom/codex/0.144.1/bin/codex`). `brew upgrade` deletes that versioned directory, installs the new one, and repoints the symlink — but the daemon is still holding the old, now-deleted path. Every subsequent task fails with `executable not found` (the binary never even starts) until the daemon is restarted. The same trap hits version detection at registration and model listing.

## What changed

- `AgentEntry` now records the **command name** each path was resolved from (bare name or `MULTICA_*_PATH`), so a vanished pin can be re-resolved.
- New `Daemon.resolveAgentEntry(provider, entry)` returns a usable executable path **paired with the CLI version detected for that exact path**:
  - **A previous self-heal that is still live** → returned with its paired version. Checked first so that once we've re-resolved to a new binary, a reappearing stale path (a downgrade / reinstall recreating the old versioned dir) can't re-pair the old binary with the healed version.
  - **Pinned path still present** → returned unchanged, paired with its registration-detected version. The anti-`PATH`-redirect guarantee holds for the normal (never-healed) case: a live pinned binary is never second-guessed.
  - **Pinned path gone, no live heal** → re-resolve the command once (preserving the `~/.multica/hooks` exclusion and the login-shell fallback). Before adopting the candidate it is **version-detected and run through the same minimum-version gate registration enforces**; path and version are then **published together atomically** under one mutex so any reader that sees the new path also sees the matching version. Concurrent misses for the same provider are coalesced with `singleflight`, so an upgrade only pays for one `--version` probe / login shell.
  - **Re-resolution fails, the candidate can't be version-detected, or it is below the minimum supported version** → entry returned unchanged, so the candidate is never launched and the existing `executable not found` / below-min error still surfaces. `cfg.Agents` is never mutated.
- Applied at all three consumers of the pinned path:
  - **Task launch** (`runTask`) — only for built-in providers, i.e. **after** the custom-runtime-profile check, so a custom runtime's path is never second-guessed and a custom-only host pays no wasted re-resolution. The Codex sandbox policy keys off the version paired with the resolved path, so a just-upgraded binary can't run under the previous version's policy.
  - **Model listing** (`handleModelList`).
  - **Version detection at registration** (`registerRuntimesForWorkspace`), so the runtime also stays online after an upgrade.

Re-resolution reproduces exactly what a daemon restart would resolve, so it is no less safe than the documented restart workaround — just automatic. This covers Homebrew Cask, nvm/fnm, and any install whose stable name symlinks into a versioned directory.

### Scope note

Local execution policy is corrected immediately (sandbox version + minimum-version gate — the two signals that decide execution safety). The version the **server** reports for a runtime (`metadata.version`, UI-visible) stays at its last-registered value until the next real re-registration or a daemon restart; `syncWorkspacesFromAPI` intentionally skips re-registering a workspace that already has a live runtime. Wiring an immediate provider-level heal into the workspace-level re-registration path was deliberately left out to avoid coupling the two — the local policy that gates launches is already correct.

## Testing

New `agent_path_selfheal_test.go` reproduces the in-place upgrade (versioned binary + stable symlink, then delete v1 / repoint to v2) and asserts:

- live path returned unchanged with its version;
- stale path re-resolves to the new version, and the returned version + shared cache move with it in lockstep;
- a below-minimum re-resolution target is **rejected** and the cached version is never corrupted downward;
- a cache hit returns the version **paired with the cached path** even when the shared version cache is deliberately skewed (the second-round race);
- a live healed path **wins over a reappearing pinned path** (downgrade/reinstall edge), so no `{old path, new version}` mismatch;
- the heal is cached (survives a broken `PATH`); a genuinely-uninstalled binary leaves the entry untouched; an entry with no recorded command is never re-resolved.

`go build ./...`, `go vet ./internal/daemon/`, and the full `go test -race ./internal/daemon/` suite pass.

MUL-4486
