### PR TITLE
fix(migrations): rebuild legacy label index CONCURRENTLY on rollback (MUL-4479)

### DIFF
--- a/server/migrations/162_resource_labels.down.sql
+++ b/server/migrations/162_resource_labels.down.sql
@@ -1,16 +1,21 @@
+-- Revert issue_label to its pre-162 issue-only shape and drop the resource
+-- label junction tables. The two rollback steps that each need their own
+-- transaction live in earlier down migrations, because a single migration
+-- file cannot mix DML/DDL with CREATE INDEX CONCURRENTLY:
+--   * 174.down removes the agent/skill rows, and
+--   * 171.down rebuilds the legacy workspace-wide unique name index
+--     CONCURRENTLY.
+-- Both run before this file (down migrations apply high->low), so the
+-- non-issue rows are already gone by the time we drop resource_type here.
 DROP TABLE IF EXISTS skill_to_label;
 DROP TABLE IF EXISTS agent_to_label;
 
+-- Defensive: a short-lived pre-release deploy may have applied the original
+-- 162 that created these indexes inline. On the normal down chain 167/168
+-- already dropped them CONCURRENTLY, so these are no-ops.
 DROP INDEX IF EXISTS issue_label_workspace_type_idx;
 DROP INDEX IF EXISTS issue_label_workspace_type_name_lower_idx;
-
--- The pre-162 schema can only represent issue labels. Resource-scoped rows
--- must be removed before restoring its workspace-wide unique name index.
-DELETE FROM issue_label WHERE resource_type <> 'issue';
 
 ALTER TABLE issue_label
     DROP COLUMN IF EXISTS description,
     DROP COLUMN IF EXISTS resource_type;
-
-CREATE UNIQUE INDEX issue_label_workspace_name_lower_idx
-    ON issue_label (workspace_id, LOWER(name));

--- a/server/migrations/171_drop_legacy_label_namespace_index.down.sql
+++ b/server/migrations/171_drop_legacy_label_namespace_index.down.sql
@@ -1,3 +1,10 @@
--- Migration 162 restores the legacy index after it removes non-issue labels.
--- Recreating it here could fail while those rows still exist during rollback.
-SELECT 1;
+-- Inverse of 171.up, which drops the pre-162 workspace-wide unique name
+-- index. Recreated as a single CREATE INDEX CONCURRENTLY statement so the
+-- rollback stays online-safe (it cannot be combined with other statements
+-- or run inside a transaction block).
+--
+-- The agent/skill rows that would violate this workspace-wide uniqueness are
+-- removed earlier in the down chain by 174.down (down migrations apply
+-- high->low), so only issue rows remain when this index is rebuilt.
+CREATE UNIQUE INDEX CONCURRENTLY IF NOT EXISTS issue_label_workspace_name_lower_idx
+    ON issue_label (workspace_id, LOWER(name));

--- a/server/migrations/174_legacy_label_index_rollback_prep.down.sql
+++ b/server/migrations/174_legacy_label_index_rollback_prep.down.sql
@@ -1,0 +1,6 @@
+-- Remove the resource-scoped (agent/skill) labels before 171.down rebuilds
+-- the pre-162 workspace-wide unique name index, which cannot coexist with
+-- rows that share (workspace_id, LOWER(name)) across resource types. This
+-- runs first in the down chain (high->low), and resource_type still exists
+-- here because 162.down (which drops it) runs later.
+DELETE FROM issue_label WHERE resource_type <> 'issue';

--- a/server/migrations/174_legacy_label_index_rollback_prep.up.sql
+++ b/server/migrations/174_legacy_label_index_rollback_prep.up.sql
@@ -1,0 +1,8 @@
+-- Forward no-op. This migration exists only to sequence a rollback step:
+-- its down removes the agent/skill rows from issue_label before 171.down
+-- rebuilds the workspace-wide unique name index. Because down migrations
+-- apply high->low, keeping this delete in the highest-numbered resource
+-- label migration guarantees the non-issue rows are gone before both
+-- 171.down (index rebuild) and 162.down (drops resource_type). There is
+-- nothing to do on the way up.
+SELECT 1;


### PR DESCRIPTION
## What

Preflight's re-check flagged one remaining release blocker for v0.3.44: the rollback (`down`) migration for resource labels still recreated an index without `CONCURRENTLY`.

`server/migrations/162_resource_labels.down.sql:15` did:

```sql
CREATE UNIQUE INDEX issue_label_workspace_name_lower_idx
    ON issue_label (workspace_id, LOWER(name));
```

On a rollback to v0.3.43 this takes a lock that blocks writes on the existing `issue_label` table — the exact online-migration hazard the "every `CREATE INDEX` must be `CONCURRENTLY`" rule exists to prevent.

## Why it had to be split

`CREATE INDEX CONCURRENTLY` cannot run inside a transaction block or a multi-command migration. `162.down` is multi-statement, so the index rebuild can't just gain a `CONCURRENTLY` keyword in place. It also can't move any lower than 162, and it must run **after** the non-issue rows are deleted (an agent/skill label sharing `(workspace_id, LOWER(name))` with an issue label would violate the workspace-wide unique index).

Down migrations apply high→low, so the fix sequences three files:

- **171.down** — now rebuilds the legacy index as a single `CREATE UNIQUE INDEX CONCURRENTLY` (the natural inverse of `171.up`, which drops it).
- **174** (new) — a no-op `up`; its `down` deletes the agent/skill label rows. As the highest-numbered resource-label migration it runs first on the way down, guaranteeing the non-issue rows are gone before `171.down` rebuilds the index and before `162.down` drops `resource_type`.
- **162.down** — keeps only the transaction-safe structural teardown (drop junction tables, drop columns).

Net down order: `174.down` (delete) → `171.down` (rebuild CONCURRENTLY) → `162.down` (drop). No behavior change on the `up` path — `174.up` is `SELECT 1`, so the forward schema and generated sqlc are unchanged.

## Validation

On an isolated Postgres, seeded with a colliding `Urgent` (issue) / `urgent` (agent) label pair in one workspace plus junction rows:

- **Real runner, full `up` → `down` → `up`** with the data present: the concurrent rebuild in `171.down` succeeds because `174.down` deleted the colliding row first.
- **Checkpoint after rollback past 162**: `issue_label_workspace_name_lower_idx` is restored and **valid**, `resource_type`/`description` columns dropped, junction tables gone, only the issue row remains.
- **Negative control**: running `171.down` *before* `174.down` fails with `could not create unique index ... Key (workspace_id, lower(name))=(…, urgent) is duplicated` — confirming the ordering is load-bearing and correct.
- `go test ./internal/migrations` (prefix/direction lint) and `sqlc generate` (no diff) both pass.

MUL-4479. Follows up #5345 (merged) and #5348. Once merged, the release migrations are fully online-safe on both the forward and rollback paths.
