### PR TITLE
Fix public multica.ai root redirect for logged-in users

### DIFF
--- a/apps/web/features/landing/components/redirect-if-authenticated.tsx
+++ b/apps/web/features/landing/components/redirect-if-authenticated.tsx
@@ -6,17 +6,20 @@ import { useQuery } from "@tanstack/react-query";
 import { useAuthStore } from "@multica/core/auth";
 import { workspaceListOptions } from "@multica/core/workspace";
 import { resolvePostAuthDestination, useHasOnboarded } from "@multica/core/paths";
+import { isOfficialMarketingHost } from "@/lib/public-host";
 
 /**
  * Client-side fallback redirect for authenticated visitors on the landing page.
  *
- * The primary path for logged-in users hitting `/` is a server-side redirect
- * in the Next.js proxy/middleware, driven by the `last_workspace_slug` cookie.
- * That cookie is set by the workspace layout on every visit. But on *first
- * login* — before the user has ever visited a workspace — the cookie is
- * absent, so the proxy falls through to the landing page. This component
- * covers that gap: once auth is resolved and the workspace list has loaded,
- * push the user into their workspace (or /onboarding if they have none).
+ * The primary path for logged-in users hitting an app host's `/` is a
+ * server-side redirect in the Next.js proxy/middleware, driven by the
+ * `last_workspace_slug` cookie. That cookie is set by the workspace layout on
+ * every visit. But on *first login* — before the user has ever visited a
+ * workspace — the cookie is absent, so the proxy falls through to the landing
+ * page. This component covers that gap on app/self-host origins.
+ *
+ * On the official marketing origins, `/` must remain public even for logged-in
+ * users. Explicit workspace routes still open the app.
  *
  * Renders nothing. Uses `router.replace` so the landing page never enters
  * browser history for authenticated users.
@@ -34,6 +37,7 @@ export function RedirectIfAuthenticated() {
 
   useEffect(() => {
     if (isLoading || !user || !isFetched) return;
+    if (isOfficialMarketingHost(window.location.hostname)) return;
     router.replace(resolvePostAuthDestination(list, hasOnboarded));
   }, [isLoading, user, isFetched, list, hasOnboarded, router]);
 

--- a/apps/web/lib/public-host.test.ts
+++ b/apps/web/lib/public-host.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "vitest";
+
+import { isOfficialMarketingHost } from "./public-host";
+
+describe("isOfficialMarketingHost", () => {
+  it.each(["multica.ai", "www.multica.ai", "MULTICA.AI", "multica.ai."])(
+    "recognizes %s as an official marketing host",
+    (host) => {
+      expect(isOfficialMarketingHost(host)).toBe(true);
+    },
+  );
+
+  it.each(["app.multica.ai", "api.multica.ai", "localhost", "multica.test"])(
+    "does not treat %s as the public marketing host",
+    (host) => {
+      expect(isOfficialMarketingHost(host)).toBe(false);
+    },
+  );
+});

--- a/apps/web/lib/public-host.ts
+++ b/apps/web/lib/public-host.ts
@@ -1,0 +1,6 @@
+const OFFICIAL_MARKETING_HOSTS = new Set(["multica.ai", "www.multica.ai"]);
+
+export function isOfficialMarketingHost(hostname: string): boolean {
+  const normalized = hostname.trim().toLowerCase().replace(/\.$/, "");
+  return OFFICIAL_MARKETING_HOSTS.has(normalized);
+}

--- a/apps/web/proxy.test.ts
+++ b/apps/web/proxy.test.ts
@@ -2,18 +2,26 @@ import { describe, expect, it } from "vitest";
 import { NextRequest } from "next/server";
 import { proxy } from "./proxy";
 
-function makeRequest(path: string, cookies: Record<string, string> = {}) {
+function makeRequest(
+  path: string,
+  cookies: Record<string, string> = {},
+  host = "app.multica.test",
+) {
   const cookieHeader = Object.entries(cookies)
     .map(([key, value]) => `${key}=${value}`)
     .join("; ");
 
-  return new NextRequest(`https://app.multica.test${path}`, {
+  return new NextRequest(`https://${host}${path}`, {
     headers: cookieHeader ? { cookie: cookieHeader } : undefined,
   });
 }
 
-function redirectLocation(path: string, cookies: Record<string, string> = {}) {
-  return proxy(makeRequest(path, cookies)).headers.get("location");
+function redirectLocation(
+  path: string,
+  cookies: Record<string, string> = {},
+  host?: string,
+) {
+  return proxy(makeRequest(path, cookies, host)).headers.get("location");
 }
 
 describe("proxy legacy workspace route redirects", () => {
@@ -60,5 +68,24 @@ describe("proxy legacy workspace route redirects", () => {
 
   it("does not redirect workspace-scoped URLs whose first segment is already a slug", () => {
     expect(redirectLocation("/acme/squads", sessionCookies)).toBeNull();
+  });
+
+  it("redirects app-host root URLs to the last workspace", () => {
+    expect(redirectLocation("/", sessionCookies)).toBe(
+      "https://app.multica.test/acme/issues",
+    );
+  });
+
+  it.each(["multica.ai", "www.multica.ai"])(
+    "does not redirect public marketing root on %s",
+    (host) => {
+      expect(redirectLocation("/", sessionCookies, host)).toBeNull();
+    },
+  );
+
+  it("still redirects explicit legacy app routes on the public marketing host", () => {
+    expect(redirectLocation("/issues/ABC-123", sessionCookies, "multica.ai")).toBe(
+      "https://multica.ai/acme/issues/ABC-123",
+    );
   });
 });

--- a/apps/web/proxy.ts
+++ b/apps/web/proxy.ts
@@ -4,6 +4,7 @@ import {
   MULTICA_LOCALE_HEADER,
   resolveLocaleFromSignals,
 } from "./lib/locale-routing";
+import { isOfficialMarketingHost } from "./lib/public-host";
 
 // Old workspace-scoped route segments that existed before the URL refactor
 // (pre-#1131). Any URL with these as the FIRST segment is a legacy URL that
@@ -75,7 +76,16 @@ export function proxy(req: NextRequest) {
   }
 
   // --- Root path: redirect logged-in users to their last workspace ---
-  if (pathname === "/" && hasSession && lastSlug) {
+  // The official cloud host also serves the public marketing site. Visiting
+  // https://multica.ai/ must remain a public-site navigation even when a local
+  // desktop/runtime session has fresh auth cookies; explicit app routes such
+  // as /acme/issues and legacy /issues still route to the workspace app.
+  if (
+    pathname === "/" &&
+    hasSession &&
+    lastSlug &&
+    !isOfficialMarketingHost(req.nextUrl.hostname)
+  ) {
     const url = req.nextUrl.clone();
     url.pathname = `/${lastSlug}/issues`;
     return NextResponse.redirect(url);


### PR DESCRIPTION
## What does this PR do?

Fixes GitHub #5326 by keeping the official public marketing root (`https://multica.ai/` and `https://www.multica.ai/`) public for logged-in users instead of automatically sending it to `/<workspace>/issues`.

The redirect was not caused by Windows URL interception in the desktop shell. The running desktop/runtime session keeps normal web auth cookies fresh; the web proxy and landing-page client fallback then treated `/` on `multica.ai` as an app entry point whenever `multica_logged_in` and `last_workspace_slug` were present.

This adds a small official-marketing-host guard used by both redirect paths. Explicit app routes still work: workspace-scoped URLs continue to load normally, and legacy URLs such as `/issues/...` still redirect through the last workspace slug.

<!-- multica-auto-bugfix -->

## Related Issue

Closes #5326

Multica issue: ZIC-74

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Refactor / code improvement (no behavior change)
- [x] Tests (adding or improving test coverage)
- [ ] CI / infrastructure

## Changes Made

- Added `apps/web/lib/public-host.ts` to identify the official marketing hosts.
- Updated `apps/web/proxy.ts` so logged-in root redirects are skipped on `multica.ai` and `www.multica.ai`.
- Updated `apps/web/features/landing/components/redirect-if-authenticated.tsx` so the client fallback also leaves the official marketing root alone.
- Added proxy and helper tests covering public-root, app-root, and explicit legacy-route behavior.

## How to Test

1. `pnpm --filter @multica/web test -- proxy.test.ts public-host.test.ts`
2. `pnpm --filter @multica/web lint`
3. `pnpm --filter @multica/web typecheck`
4. `make check-worktree`

Note: `make check-worktree` returned exit code 0, but Docker/PostgreSQL was unavailable locally (`Cannot connect to the Docker daemon at unix:///Users/icezero/.docker/run/docker.sock`), so the focused web checks above are the meaningful validation for this change.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [ ] I have updated relevant documentation to reflect my changes
- [ ] If I added a new runtime / coding tool / UI tab, I synced the change to **landing copy** (`apps/web/features/landing/i18n/`) and **relevant docs** (`apps/docs/content/docs/`)
- [ ] If this PR touches Chinese product copy, I checked it against `apps/docs/content/docs/developers/conventions.zh.mdx` (terminology, mixed-rule for `task` / `issue` / `skill`)
- [x] I have considered and documented any risks above
- [x] I will address all reviewer comments before requesting merge

## AI Disclosure

**AI tool used:** Multica Agent (Codex)

**Prompt / approach:**
Traced the reported redirect from the desktop/runtime symptom back to the web root redirect paths, implemented a host-aware guard for the official marketing origins, and verified the behavior with focused web tests.

## Screenshots (optional)

N/A
