### PR TITLE
Fix desktop daemon reauth reconnect target

### DIFF
--- a/apps/desktop/src/main/daemon-auth-probe.test.ts
+++ b/apps/desktop/src/main/daemon-auth-probe.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from "vitest";
 
-import { classifyAuthProbe, isAuthStatusError } from "./daemon-auth-probe";
+import {
+  classifyAuthProbe,
+  isAuthStatusError,
+  reauthTransientMessage,
+} from "./daemon-auth-probe";
 
 describe("classifyAuthProbe", () => {
   it("treats a 401 as expired login", () => {
@@ -52,5 +56,24 @@ describe("isAuthStatusError", () => {
     expect(isAuthStatusError(undefined)).toBe(false);
     expect(isAuthStatusError(null)).toBe(false);
     expect(isAuthStatusError("401")).toBe(false);
+  });
+});
+
+describe("reauthTransientMessage", () => {
+  it("turns low-level fetch failures into an actionable API reachability message", () => {
+    expect(
+      reauthTransientMessage(new Error("fetch failed"), "https://api.multica.ai"),
+    ).toBe(
+      "Couldn't reach https://api.multica.ai to refresh daemon credentials. Check your internet connection or VPN, then try Sign in again.",
+    );
+  });
+
+  it("preserves non-network failure details", () => {
+    expect(
+      reauthTransientMessage(
+        new Error("mint PAT failed: 503 Service Unavailable"),
+        "https://api.multica.ai",
+      ),
+    ).toBe("mint PAT failed: 503 Service Unavailable");
   });
 });

--- a/apps/desktop/src/main/daemon-auth-probe.ts
+++ b/apps/desktop/src/main/daemon-auth-probe.ts
@@ -40,6 +40,23 @@ export function isAuthStatusError(err: unknown): boolean {
   );
 }
 
+function isFetchFailure(err: unknown): boolean {
+  return err instanceof Error && err.message === "fetch failed";
+}
+
+export function reauthTransientMessage(
+  err: unknown,
+  apiBaseUrl: string | null,
+): string {
+  if (isFetchFailure(err) && apiBaseUrl) {
+    return `Couldn't reach ${apiBaseUrl} to refresh daemon credentials. Check your internet connection or VPN, then try Sign in again.`;
+  }
+  if (isFetchFailure(err)) {
+    return "Couldn't reach the Multica API to refresh daemon credentials. Check your internet connection or VPN, then try Sign in again.";
+  }
+  return err instanceof Error ? err.message : String(err);
+}
+
 export function classifyAuthProbe(outcome: AuthProbeOutcome): AuthProbeResult {
   // No credential to validate → the user must sign in.
   if (outcome.noToken) return "auth_expired";

--- a/apps/desktop/src/main/daemon-manager.ts
+++ b/apps/desktop/src/main/daemon-manager.ts
@@ -28,6 +28,7 @@ import {
 import {
   classifyAuthProbe,
   isAuthStatusError,
+  reauthTransientMessage,
   type AuthProbeResult,
 } from "./daemon-auth-probe";
 
@@ -299,6 +300,18 @@ async function ensureActiveProfile(): Promise<ActiveProfile> {
 
 function invalidateActiveProfile(): void {
   activeProfile = null;
+}
+
+async function setTargetApiUrl(
+  url: string | null,
+  options: { poll: boolean } = { poll: true },
+): Promise<void> {
+  const normalized = url || null;
+  if (targetApiBaseUrl === normalized) return;
+  console.log(`[daemon] target API URL set to ${normalized ?? "(none)"}`);
+  targetApiBaseUrl = normalized;
+  invalidateActiveProfile();
+  if (options.poll) await pollOnce();
 }
 
 async function fetchHealth(): Promise<DaemonStatus> {
@@ -756,10 +769,6 @@ export type ReauthResult =
   | { ok: false; reason: "session_invalid" }
   | { ok: false; reason: "transient"; message: string };
 
-function errorMessage(err: unknown): string {
-  return err instanceof Error ? err.message : String(err);
-}
-
 /**
  * Recover the local daemon from the "auth_expired" state. Drops the stale
  * cached PAT, mints a fresh one from the current session token, and restarts
@@ -774,14 +783,22 @@ function errorMessage(err: unknown): string {
 async function reauthenticate(
   token: string,
   userId: string,
+  apiBaseUrl?: string,
 ): Promise<ReauthResult> {
+  if (apiBaseUrl) {
+    await setTargetApiUrl(apiBaseUrl, { poll: false });
+  }
   try {
     await clearToken();
     // syncToken mints a fresh PAT because clearToken just removed any cache.
     await syncToken(token, userId);
   } catch (err) {
     if (isAuthStatusError(err)) return { ok: false, reason: "session_invalid" };
-    return { ok: false, reason: "transient", message: errorMessage(err) };
+    return {
+      ok: false,
+      reason: "transient",
+      message: reauthTransientMessage(err, targetApiBaseUrl),
+    };
   }
   const restart = await restartDaemon();
   if (!restart.success) {
@@ -1066,13 +1083,7 @@ export function setupDaemonManager(
   getMainWindow = windowGetter;
 
   ipcMain.handle("daemon:set-target-api-url", async (_e, url: string) => {
-    const normalized = url || null;
-    if (targetApiBaseUrl !== normalized) {
-      console.log(`[daemon] target API URL set to ${normalized ?? "(none)"}`);
-      targetApiBaseUrl = normalized;
-      invalidateActiveProfile();
-      await pollOnce();
-    }
+    await setTargetApiUrl(url);
   });
   ipcMain.handle("daemon:start", () => withGuard(() => startDaemon()));
   ipcMain.handle("daemon:stop", () => withGuard(() => stopDaemon()));
@@ -1090,7 +1101,8 @@ export function setupDaemonManager(
   ipcMain.handle("daemon:clear-token", () => clearToken());
   ipcMain.handle(
     "daemon:reauthenticate",
-    (_event, token: string, userId: string) => reauthenticate(token, userId),
+    (_event, token: string, userId: string, apiBaseUrl?: string) =>
+      reauthenticate(token, userId, apiBaseUrl),
   );
   ipcMain.handle("daemon:is-cli-installed", async () => {
     const bin = await resolveCliBinary();

--- a/apps/desktop/src/preload/index.d.ts
+++ b/apps/desktop/src/preload/index.d.ts
@@ -143,6 +143,7 @@ interface DaemonAPI {
   reauthenticate: (
     token: string,
     userId: string,
+    apiBaseUrl?: string,
   ) => Promise<DaemonReauthResult>;
   isCliInstalled: () => Promise<boolean>;
   getPrefs: () => Promise<DaemonPrefs>;

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -266,8 +266,9 @@ const daemonAPI = {
   reauthenticate: (
     token: string,
     userId: string,
+    apiBaseUrl?: string,
   ): Promise<DaemonReauthResult> =>
-    ipcRenderer.invoke("daemon:reauthenticate", token, userId),
+    ipcRenderer.invoke("daemon:reauthenticate", token, userId, apiBaseUrl),
   isCliInstalled: (): Promise<boolean> =>
     ipcRenderer.invoke("daemon:is-cli-installed"),
   getPrefs: (): Promise<{ autoStart: boolean; autoStop: boolean }> =>

--- a/apps/desktop/src/renderer/src/platform/daemon-reauth.test.ts
+++ b/apps/desktop/src/renderer/src/platform/daemon-reauth.test.ts
@@ -25,6 +25,17 @@ beforeEach(() => {
   vi.clearAllMocks();
   localStorage.clear();
   (window as unknown as { daemonAPI: typeof daemonAPI }).daemonAPI = daemonAPI;
+  (window as unknown as { desktopAPI: { runtimeConfig: unknown } }).desktopAPI = {
+    runtimeConfig: {
+      ok: true,
+      config: {
+        schemaVersion: 1,
+        apiUrl: "https://api.multica.ai",
+        wsUrl: "wss://api.multica.ai/ws",
+        appUrl: "https://multica.ai",
+      },
+    },
+  };
   mockGetState.mockReturnValue({ user: { id: "user-1" }, logout });
 });
 
@@ -35,9 +46,29 @@ describe("reauthenticateDaemon", () => {
 
     await reauthenticateDaemon();
 
-    expect(daemonAPI.reauthenticate).toHaveBeenCalledWith("jwt-abc", "user-1");
+    expect(daemonAPI.reauthenticate).toHaveBeenCalledWith(
+      "jwt-abc",
+      "user-1",
+      "https://api.multica.ai",
+    );
     expect(logout).not.toHaveBeenCalled();
     expect(toastError).not.toHaveBeenCalled();
+  });
+
+  it("falls back to the main-process target URL when runtime config is unavailable", async () => {
+    (window as unknown as { desktopAPI: { runtimeConfig: unknown } }).desktopAPI = {
+      runtimeConfig: { ok: false, error: { message: "bad config" } },
+    };
+    localStorage.setItem("multica_token", "jwt-abc");
+    daemonAPI.reauthenticate.mockResolvedValue({ ok: true });
+
+    await reauthenticateDaemon();
+
+    expect(daemonAPI.reauthenticate).toHaveBeenCalledWith(
+      "jwt-abc",
+      "user-1",
+      undefined,
+    );
   });
 
   it("logs out only when the session token itself is rejected (401)", async () => {

--- a/apps/desktop/src/renderer/src/platform/daemon-reauth.ts
+++ b/apps/desktop/src/renderer/src/platform/daemon-reauth.ts
@@ -28,7 +28,14 @@ export async function reauthenticateDaemon(): Promise<void> {
   }
 
   try {
-    const result = await window.daemonAPI.reauthenticate(token, user.id);
+    const apiBaseUrl = window.desktopAPI.runtimeConfig.ok
+      ? window.desktopAPI.runtimeConfig.config.apiUrl
+      : undefined;
+    const result = await window.daemonAPI.reauthenticate(
+      token,
+      user.id,
+      apiBaseUrl,
+    );
     if (result.ok) return; // daemon restarting; status flips via onStatusChange
     if (result.reason === "session_invalid") {
       // The session token itself is rejected (401) — full re-login.


### PR DESCRIPTION
<!-- multica-auto-bugfix -->

## What does this PR do?

Fixes the desktop daemon re-authentication path used when the local daemon reports `auth_expired`. The renderer now passes the active desktop API URL into the re-auth IPC call, so the main process refreshes credentials against the intended desktop-owned profile before clearing and re-minting the daemon PAT.

It also replaces the raw low-level `fetch failed` message with an actionable API reachability message when PAT minting cannot contact the backend.

## Related Issue

Closes #5337

Multica issue: ZIC-73

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Refactor / code improvement (no behavior change)
- [x] Tests (adding or improving test coverage)
- [ ] Documentation update
- [ ] CI / infrastructure

## Changes Made

- `apps/desktop/src/renderer/src/platform/daemon-reauth.ts`: pass the renderer runtime API URL to `daemonAPI.reauthenticate`.
- `apps/desktop/src/main/daemon-manager.ts`: apply an explicit target API URL before clearing/re-minting daemon credentials.
- `apps/desktop/src/main/daemon-auth-probe.ts`: format daemon reauth network failures as actionable reconnect guidance instead of surfacing raw `fetch failed`.
- Updated preload typings and focused tests.

## How to Test

1. `pnpm -C apps/desktop exec vitest run src/main/daemon-auth-probe.test.ts src/renderer/src/platform/daemon-reauth.test.ts`
2. `pnpm -C apps/desktop run typecheck`
3. `pnpm -C apps/desktop run lint`
4. `git diff --check`
5. `make check-worktree`

Note: `make check-worktree` exited 0 and printed "All checks passed", but the local Docker daemon was unavailable while it attempted to check/start the shared pgvector Postgres container.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [ ] I have updated relevant documentation to reflect my changes
- [ ] If I added a new runtime / coding tool / UI tab, I synced the change to **landing copy** (`apps/web/features/landing/i18n/`) and **relevant docs** (`apps/docs/content/docs/`)
- [ ] If this PR touches Chinese product copy, I checked it against `apps/docs/content/docs/developers/conventions.zh.mdx` (terminology, mixed-rule for `task` / `issue` / `skill`)
- [x] I have considered and documented any risks above
- [x] I will address all reviewer comments before requesting merge

## AI Disclosure

**AI tool used:** Multica Agent

**Prompt / approach:**
Traced GitHub #5337 from the desktop runtime card through renderer reauth IPC and the main-process daemon manager. Implemented the smallest fix to bind reauth to the current runtime API URL and to provide actionable messaging for backend reachability failures.

## Screenshots (optional)

Not applicable.
