### PR TITLE
fix(comments): reconcile dropped comment triggers on task fail/cancel (#5278)

### DIFF
--- a/server/cmd/server/main.go
+++ b/server/cmd/server/main.go
@@ -621,7 +621,9 @@ func main() {
 	// EmptyClaim cache into TaskService; constructing a second TaskService for
 	// scheduled Autopilot dispatch would send the daemon wakeup without bumping
 	// that cache's version, so an idle runtime could keep returning an empty
-	// claim until the cache TTL expires.
+	// claim until the cache TTL expires. Reusing it also means the shared
+	// post-terminal comment reconciler wired in handler.go covers the sweeper /
+	// orphan-recovery fail paths that run through this same instance (#5278).
 	taskSvc, autopilotSvc := backgroundServices(h)
 	registerAutopilotListeners(bus, autopilotSvc)
 

--- a/server/cmd/server/main.go
+++ b/server/cmd/server/main.go
@@ -415,7 +415,9 @@ func main() {
 	// EmptyClaim cache into TaskService; constructing a second TaskService for
 	// scheduled Autopilot dispatch would send the daemon wakeup without bumping
 	// that cache's version, so an idle runtime could keep returning an empty
-	// claim until the cache TTL expires.
+	// claim until the cache TTL expires. Reusing it also means the shared
+	// post-terminal comment reconciler wired in handler.go covers the sweeper /
+	// orphan-recovery fail paths that run through this same instance (#5278).
 	taskSvc, autopilotSvc := backgroundServices(h)
 	registerAutopilotListeners(bus, autopilotSvc)
 

--- a/server/internal/handler/chat.go
+++ b/server/internal/handler/chat.go
@@ -1861,7 +1861,9 @@ func (h *Handler) CancelTaskByUser(w http.ResponseWriter, r *http.Request) {
 		QueuedOnly:                 queuedOnly,
 		ExpectedChatSession:        expectedSession,
 		QueueAction:                queueAction,
-		UserInitiated:              true,
+		// Also replays any @agent hand-off deferred while this run held the
+		// active slot (#5278). No-op for chat-only tasks.
+		UserInitiated: true,
 	})
 	if errors.Is(err, service.ErrTaskNoLongerQueued) {
 		writeError(w, http.StatusConflict, err.Error())

--- a/server/internal/handler/chat.go
+++ b/server/internal/handler/chat.go
@@ -1747,6 +1747,9 @@ func (h *Handler) CancelTaskByUser(w http.ResponseWriter, r *http.Request) {
 		QueuedOnly:                 queuedOnly,
 		ExpectedChatSession:        expectedSession,
 		QueueAction:                queueAction,
+		// User-initiated cancel: replay any @agent hand-off deferred while this
+		// run held the active slot (#5278). No-op for chat-only tasks.
+		ReconcileDeferredComments: true,
 	})
 	if errors.Is(err, service.ErrTaskNoLongerQueued) {
 		writeError(w, http.StatusConflict, err.Error())

--- a/server/internal/handler/daemon.go
+++ b/server/internal/handler/daemon.go
@@ -4869,7 +4869,11 @@ func (h *Handler) CancelTask(w http.ResponseWriter, r *http.Request) {
 	}
 
 	taskID := chi.URLParam(r, "taskId")
-	existing, err := h.Queries.GetAgentTask(r.Context(), parseUUID(taskID))
+	taskUUID, ok := parseUUIDOrBadRequest(w, taskID, "taskId")
+	if !ok {
+		return
+	}
+	existing, err := h.Queries.GetAgentTask(r.Context(), taskUUID)
 	if err != nil || uuidToString(existing.IssueID) != uuidToString(issue.ID) {
 		writeError(w, http.StatusNotFound, "task not found")
 		return

--- a/server/internal/handler/daemon.go
+++ b/server/internal/handler/daemon.go
@@ -3799,13 +3799,11 @@ func (h *Handler) CompleteTask(w http.ResponseWriter, r *http.Request) {
 
 	h.emitIssueExecutedOnFirstCompletion(r, task)
 
-	// MUL-4195: guarantee at-least-once processing. If a member posted a
-	// deliberate comment while this run was executing (or one was merged into
-	// it after its context was built), schedule a single follow-up so the
-	// input is never silently dropped. Loop-safe: member-authored only, capped
-	// by the existing per-(issue, agent) dedup, and terminating because the
-	// triggering comment always predates the follow-up run's started_at.
-	h.reconcileCommentsOnCompletion(r.Context(), task)
+	// Undelivered-comment reconciliation (MUL-4195 / MUL-4304) now runs inside
+	// TaskService.CompleteTask via the shared ReconcileTerminal seam, so every
+	// terminal transition — including the fail / cancel / sweeper paths that
+	// never reach this handler — replays through one entry point (#5278).
+
 	// The terminal transaction and completion reconciliation are committed.
 	// Wake the owning runtime now so queued work that was blocked by this
 	// task's agent capacity or serialization key is re-claimed immediately.
@@ -3865,6 +3863,18 @@ func (h *Handler) emitIssueExecutedOnFirstCompletion(r *http.Request, task *db.A
 		taskContext.Provider,
 		durationMS,
 	))
+}
+
+// ReconcileTerminalTask is the exported seam TaskService calls after a task
+// leaves the active set on a path that should allow subsequent work (complete /
+// fail / user-cancel / sweeper fail / orphan recovery). It delegates to the
+// handler-local comment routing in reconcileCommentsOnCompletion, which is why
+// the reconciler is injected into TaskService rather than living in the service
+// package (that would invert the handler→service dependency). Wired in
+// handler.New for the request-serving TaskService and in cmd/server for the
+// sweeper's separate instance.
+func (h *Handler) ReconcileTerminalTask(ctx context.Context, task *db.AgentTaskQueue) {
+	h.reconcileCommentsOnCompletion(ctx, task)
 }
 
 // reconcileCommentsOnCompletion closes the at-least-once gap for member
@@ -4865,6 +4875,11 @@ func (h *Handler) CancelTask(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// User-initiated cancel: CancelTaskByUser sets UserInitiated, which also
+	// opts into #5278 reconciliation so an @agent hand-off deferred while this
+	// run held the active slot survives. The internal claim-time hard-fail
+	// cancels use the plain CancelTask wrapper and stay opted out, so a rejected
+	// claim never enqueues replacement work.
 	task, err := h.TaskService.CancelTaskByUser(r.Context(), existing.ID)
 	if err != nil {
 		slog.Warn("cancel task failed", "task_id", taskID, "error", err)

--- a/server/internal/handler/daemon.go
+++ b/server/internal/handler/daemon.go
@@ -3076,13 +3076,11 @@ func (h *Handler) CompleteTask(w http.ResponseWriter, r *http.Request) {
 
 	h.emitIssueExecutedOnFirstCompletion(r, task)
 
-	// MUL-4195: guarantee at-least-once processing. If a member posted a
-	// deliberate comment while this run was executing (or one was merged into
-	// it after its context was built), schedule a single follow-up so the
-	// input is never silently dropped. Loop-safe: member-authored only, capped
-	// by the existing per-(issue, agent) dedup, and terminating because the
-	// triggering comment always predates the follow-up run's started_at.
-	h.reconcileCommentsOnCompletion(r.Context(), task)
+	// Undelivered-comment reconciliation (MUL-4195 / MUL-4304) now runs inside
+	// TaskService.CompleteTask via the shared ReconcileTerminal seam, so every
+	// terminal transition — including the fail / cancel / sweeper paths that
+	// never reach this handler — replays through one entry point (#5278).
+
 	// The terminal transaction and completion reconciliation are committed.
 	// Wake the owning runtime now so queued work that was blocked by this
 	// task's agent capacity or serialization key is re-claimed immediately.
@@ -3142,6 +3140,18 @@ func (h *Handler) emitIssueExecutedOnFirstCompletion(r *http.Request, task *db.A
 		taskContext.Provider,
 		durationMS,
 	))
+}
+
+// ReconcileTerminalTask is the exported seam TaskService calls after a task
+// leaves the active set on a path that should allow subsequent work (complete /
+// fail / user-cancel / sweeper fail / orphan recovery). It delegates to the
+// handler-local comment routing in reconcileCommentsOnCompletion, which is why
+// the reconciler is injected into TaskService rather than living in the service
+// package (that would invert the handler→service dependency). Wired in
+// handler.New for the request-serving TaskService and in cmd/server for the
+// sweeper's separate instance.
+func (h *Handler) ReconcileTerminalTask(ctx context.Context, task *db.AgentTaskQueue) {
+	h.reconcileCommentsOnCompletion(ctx, task)
 }
 
 // reconcileCommentsOnCompletion closes the at-least-once gap for member
@@ -3961,12 +3971,20 @@ func (h *Handler) CancelTask(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	task, err := h.TaskService.CancelTask(r.Context(), existing.ID)
+	// User-initiated cancel: opt into #5278 reconciliation so an @agent hand-off
+	// deferred while this run held the active slot survives. The internal
+	// claim-time hard-fail cancels use the plain CancelTask wrapper and stay opted
+	// out, so a rejected claim never enqueues replacement work.
+	cancelled, err := h.TaskService.CancelTaskWithResult(r.Context(), existing.ID, service.CancelTaskOptions{
+		ClientSupportsDraftRestore: true,
+		ReconcileDeferredComments:  true,
+	})
 	if err != nil {
 		slog.Warn("cancel task failed", "task_id", taskID, "error", err)
 		writeError(w, http.StatusBadRequest, err.Error())
 		return
 	}
+	task := &cancelled.Task
 
 	slog.Info("task cancelled by user", "task_id", taskID, "issue_id", uuidToString(task.IssueID))
 	resp := taskToResponse(*task, uuidToString(issue.WorkspaceID))

--- a/server/internal/handler/daemon.go
+++ b/server/internal/handler/daemon.go
@@ -3965,7 +3965,11 @@ func (h *Handler) CancelTask(w http.ResponseWriter, r *http.Request) {
 	}
 
 	taskID := chi.URLParam(r, "taskId")
-	existing, err := h.Queries.GetAgentTask(r.Context(), parseUUID(taskID))
+	taskUUID, ok := parseUUIDOrBadRequest(w, taskID, "taskId")
+	if !ok {
+		return
+	}
+	existing, err := h.Queries.GetAgentTask(r.Context(), taskUUID)
 	if err != nil || uuidToString(existing.IssueID) != uuidToString(issue.ID) {
 		writeError(w, http.StatusNotFound, "task not found")
 		return

--- a/server/internal/handler/daemon_terminal_reconcile_test.go
+++ b/server/internal/handler/daemon_terminal_reconcile_test.go
@@ -1,0 +1,483 @@
+package handler
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/multica-ai/multica/server/internal/util"
+	db "github.com/multica-ai/multica/server/pkg/db/generated"
+)
+
+// claimOnWakeupNotifier is a test TaskWakeupNotifier that immediately advances
+// the notified task from queued → dispatched, simulating the daemon claiming
+// the retry child the instant it is woken. This reproduces the race that the
+// "reconcile before notify" ordering fix was written to prevent.
+type claimOnWakeupNotifier struct {
+	pool   *pgxpool.Pool
+	called bool
+}
+
+func (n *claimOnWakeupNotifier) NotifyTaskAvailable(_, taskID string) {
+	if taskID == "" {
+		return
+	}
+	_, _ = n.pool.Exec(context.Background(),
+		`UPDATE agent_task_queue SET status = 'dispatched', dispatched_at = now() WHERE id = $1 AND status = 'queued'`,
+		taskID)
+	n.called = true
+}
+
+// mentionInAnyActivePlanForAgent reports whether commentID appears in the
+// trigger or coalesced plan of ANY task for the (issue, agent) pair regardless
+// of status. Used by the race regression test where the retry child may have
+// been advanced to dispatched by the instant-claim wakeup notifier.
+func mentionInAnyActivePlanForAgent(t *testing.T, issueID, agentID, commentID string) bool {
+	t.Helper()
+	var n int
+	if err := testPool.QueryRow(context.Background(), `
+		SELECT count(*) FROM agent_task_queue
+		WHERE issue_id = $1 AND agent_id = $2
+		  AND ($3::uuid = ANY(coalesced_comment_ids) OR trigger_comment_id = $3::uuid)
+	`, issueID, agentID, commentID).Scan(&n); err != nil {
+		t.Fatalf("query mention in any plan: %v", err)
+	}
+	return n > 0
+}
+
+// These tests pin the #5278 invariant across EVERY terminal path that should
+// allow subsequent work: an @agent hand-off dropped while the target had an
+// in-flight task (merge-miss + active-task deferral) must still be replayed when
+// that run ends by fail / user-cancel / sweeper-fail — not only on success.
+// Reconciliation now runs inside the TaskService terminal transitions via the
+// injected ReconcileTerminal seam, so these drive the real service/handler paths.
+
+// failTaskWithReasonViaHandler drives the daemon FailTask endpoint with an
+// explicit failure_reason (the shared failTaskViaHandler helper hardcodes a
+// non-retryable agent_error; the retryable path here needs e.g. "timeout").
+func failTaskWithReasonViaHandler(t *testing.T, taskID, failureReason string) *httptest.ResponseRecorder {
+	t.Helper()
+	w := httptest.NewRecorder()
+	req := newDaemonTokenRequest("POST", "/api/daemon/tasks/"+taskID+"/fail",
+		map[string]any{"error": "boom", "failure_reason": failureReason},
+		testWorkspaceID, "legit-daemon")
+	rctx := chi.NewRouteContext()
+	rctx.URLParams.Add("taskId", taskID)
+	req = req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, rctx))
+	testHandler.FailTask(w, req)
+	return w
+}
+
+// cancelTaskViaHandler drives the issue-scoped daemon CancelTask endpoint
+// (POST /api/issues/{id}/tasks/{taskId}/cancel).
+func cancelTaskViaHandler(t *testing.T, issueID, taskID string) *httptest.ResponseRecorder {
+	t.Helper()
+	w := httptest.NewRecorder()
+	req := newRequest("POST", "/api/issues/"+issueID+"/tasks/"+taskID+"/cancel", nil)
+	req = withURLParams(req, "id", issueID, "taskId", taskID)
+	testHandler.CancelTask(w, req)
+	return w
+}
+
+// mentionInQueuedPlanForAgent reports whether commentID appears in the trigger
+// or coalesced plan of any QUEUED task for the (issue, agent) pair — i.e. the
+// dropped mention was merged into a queued run (retry child or fresh follow-up).
+func mentionInQueuedPlanForAgent(t *testing.T, issueID, agentID, commentID string) bool {
+	t.Helper()
+	var n int
+	if err := testPool.QueryRow(context.Background(), `
+		SELECT count(*) FROM agent_task_queue
+		WHERE issue_id = $1 AND agent_id = $2 AND status = 'queued'
+		  AND ($3::uuid = ANY(coalesced_comment_ids) OR trigger_comment_id = $3::uuid)
+	`, issueID, agentID, commentID).Scan(&n); err != nil {
+		t.Fatalf("query mention in queued plan: %v", err)
+	}
+	return n > 0
+}
+
+// markTaskFailedDirect transitions a task to failed the way the sweepers and
+// orphan recovery do — a direct row update — then returns the reloaded row to
+// hand to TaskService.HandleFailedTasks, exactly as those pipelines do.
+func markTaskFailedDirect(t *testing.T, taskID, reason string) db.AgentTaskQueue {
+	t.Helper()
+	ctx := context.Background()
+	if _, err := testPool.Exec(ctx,
+		`UPDATE agent_task_queue SET status = 'failed', failure_reason = $2 WHERE id = $1`,
+		taskID, reason); err != nil {
+		t.Fatalf("mark task failed: %v", err)
+	}
+	row, err := testHandler.Queries.GetAgentTask(ctx, util.MustParseUUID(taskID))
+	if err != nil {
+		t.Fatalf("reload failed task: %v", err)
+	}
+	return row
+}
+
+// seedDroppedAgentMention reproduces the #5278 precondition: agent B has a
+// DISPATCHED task on an issue when agent A posts an explicit @B mention, which
+// hits the merge-miss + active-task drop at creation time and is deferred to
+// terminal reconciliation. Returns the issue, B's (running) task, both agent
+// ids, and the dropped mention's comment id, with the drop already asserted.
+func seedDroppedAgentMention(t *testing.T, issueNumber int32) (issueID, taskID, agentA, agentB, mentionCommentID string) {
+	t.Helper()
+	ctx := context.Background()
+
+	var runtimeID string
+	if err := testPool.QueryRow(ctx,
+		`SELECT runtime_id FROM agent WHERE workspace_id = $1 AND runtime_id IS NOT NULL LIMIT 1`,
+		testWorkspaceID).Scan(&runtimeID); err != nil {
+		t.Fatalf("setup: get runtime: %v", err)
+	}
+	agentA = createHandlerTestAgent(t, "Terminal Reconcile Author A", nil)
+	agentB = createHandlerTestAgent(t, "Terminal Reconcile Target B", nil)
+
+	if err := testPool.QueryRow(ctx, `
+		INSERT INTO issue (workspace_id, title, status, priority, creator_id, creator_type, number, position, assignee_type, assignee_id)
+		VALUES ($1, 'terminal-reconcile fixture', 'in_progress', 'none', $2, 'member', $3, 0, 'agent', $4)
+		RETURNING id
+	`, testWorkspaceID, testUserID, issueNumber, agentB).Scan(&issueID); err != nil {
+		t.Fatalf("setup: create issue: %v", err)
+	}
+	t.Cleanup(func() { testPool.Exec(ctx, `DELETE FROM issue WHERE id = $1`, issueID) })
+	t.Cleanup(func() { testPool.Exec(ctx, `DELETE FROM comment WHERE issue_id = $1`, issueID) })
+
+	issue, err := testHandler.Queries.GetIssue(ctx, util.MustParseUUID(issueID))
+	if err != nil {
+		t.Fatalf("setup: load issue: %v", err)
+	}
+
+	var triggerCommentID string
+	if err := testPool.QueryRow(ctx, `
+		INSERT INTO comment (issue_id, workspace_id, author_type, author_id, content, type, created_at)
+		VALUES ($1, $2, 'member', $3, 'initial request', 'comment', now() - interval '10 minutes')
+		RETURNING id
+	`, issueID, testWorkspaceID, testUserID).Scan(&triggerCommentID); err != nil {
+		t.Fatalf("setup: trigger comment: %v", err)
+	}
+
+	// B's task is DISPATCHED — the state that makes an incoming mention hit the
+	// merge-miss + active-task drop at creation time.
+	if err := testPool.QueryRow(ctx, `
+		INSERT INTO agent_task_queue (agent_id, runtime_id, issue_id, trigger_comment_id, delivered_comment_ids, status, priority, created_at, dispatched_at)
+		VALUES ($1, $2, $3, $4, ARRAY[$4::uuid], 'dispatched', 0, now() - interval '10 minutes', now() - interval '5 minutes')
+		RETURNING id
+	`, agentB, runtimeID, issueID, triggerCommentID).Scan(&taskID); err != nil {
+		t.Fatalf("setup: dispatched task: %v", err)
+	}
+	t.Cleanup(func() { testPool.Exec(ctx, `DELETE FROM agent_task_queue WHERE issue_id = $1`, issueID) })
+
+	// Agent A posts an explicit @B mention through the real trigger path while B
+	// is dispatched.
+	mention := "[@B](mention://agent/" + agentB + ") please also handle this"
+	if err := testPool.QueryRow(ctx, `
+		INSERT INTO comment (issue_id, workspace_id, author_type, author_id, content, type)
+		VALUES ($1, $2, 'agent', $3, $4, 'comment')
+		RETURNING id
+	`, issueID, testWorkspaceID, agentA, mention).Scan(&mentionCommentID); err != nil {
+		t.Fatalf("setup: agent @B comment: %v", err)
+	}
+	mentionComment, err := testHandler.Queries.GetComment(ctx, util.MustParseUUID(mentionCommentID))
+	if err != nil {
+		t.Fatalf("setup: load mention comment: %v", err)
+	}
+	testHandler.triggerTasksForComment(ctx, issue, mentionComment, nil, "agent", agentA, "", "", nil)
+
+	if n := queuedTaskCountForAgentIssue(t, issueID, agentB); n != 0 {
+		t.Fatalf("expected the mention to be dropped at creation (0 queued follow-up), got %d", n)
+	}
+
+	// Advance B's task dispatched → running so the terminal endpoint has a live
+	// run to end.
+	if _, err := testPool.Exec(ctx, `UPDATE agent_task_queue SET status = 'running', started_at = now() - interval '1 minute' WHERE id = $1`, taskID); err != nil {
+		t.Fatalf("advance task to running: %v", err)
+	}
+	return issueID, taskID, agentA, agentB, mentionCommentID
+}
+
+// TestFailTask_ReconcilesDroppedAgentMentionOnTerminalFail — non-retryable fail
+// (agent_error) leaves no retry child, so the dropped mention earns exactly one
+// fresh follow-up for B. Author A is never enqueued (loop guard).
+func TestFailTask_ReconcilesDroppedAgentMentionOnTerminalFail(t *testing.T) {
+	if testHandler == nil {
+		t.Skip("database not available")
+	}
+	issueID, taskID, agentA, agentB, mention := seedDroppedAgentMention(t, 999101)
+
+	if w := failTaskViaHandler(t, taskID); w.Code != http.StatusOK {
+		t.Fatalf("FailTask: expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	if n := queuedTaskCountForAgentIssue(t, issueID, agentB); n != 1 {
+		t.Fatalf("expected exactly 1 fresh follow-up for B after fail-path reconcile, got %d", n)
+	}
+	if !mentionInQueuedPlanForAgent(t, issueID, agentB, mention) {
+		t.Fatalf("dropped mention not present in the follow-up's plan")
+	}
+	if n := pendingTaskCountForAgentIssue(t, issueID, agentA); n != 0 {
+		t.Fatalf("comment author A must not be enqueued, got %d A task(s)", n)
+	}
+}
+
+// TestFailTask_RetryableFail_MergesDroppedMentionIntoRetryChild — a retryable
+// fail (timeout) creates the auto-retry child first; reconcile then merges the
+// dropped mention INTO that single queued child rather than spawning a duplicate.
+func TestFailTask_RetryableFail_MergesDroppedMentionIntoRetryChild(t *testing.T) {
+	if testHandler == nil {
+		t.Skip("database not available")
+	}
+	issueID, taskID, agentA, agentB, mention := seedDroppedAgentMention(t, 999103)
+
+	if w := failTaskWithReasonViaHandler(t, taskID, "timeout"); w.Code != http.StatusOK {
+		t.Fatalf("FailTask: expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	// Exactly one queued child (the auto-retry), and the mention is folded into it.
+	if n := queuedTaskCountForAgentIssue(t, issueID, agentB); n != 1 {
+		t.Fatalf("expected exactly 1 queued retry child, got %d (duplicate follow-up?)", n)
+	}
+	if !mentionInQueuedPlanForAgent(t, issueID, agentB, mention) {
+		t.Fatalf("dropped mention not merged into the retry child's plan")
+	}
+	if n := pendingTaskCountForAgentIssue(t, issueID, agentA); n != 0 {
+		t.Fatalf("comment author A must not be enqueued, got %d A task(s)", n)
+	}
+}
+
+// TestCancelTask_ReconcilesDroppedAgentMentionOnCancel covers the issue-scoped
+// daemon cancel route.
+func TestCancelTask_ReconcilesDroppedAgentMentionOnCancel(t *testing.T) {
+	if testHandler == nil {
+		t.Skip("database not available")
+	}
+	issueID, taskID, agentA, agentB, mention := seedDroppedAgentMention(t, 999102)
+
+	if w := cancelTaskViaHandler(t, issueID, taskID); w.Code != http.StatusOK {
+		t.Fatalf("CancelTask: expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	if n := queuedTaskCountForAgentIssue(t, issueID, agentB); n != 1 {
+		t.Fatalf("expected exactly 1 follow-up for B after cancel-path reconcile, got %d", n)
+	}
+	if !mentionInQueuedPlanForAgent(t, issueID, agentB, mention) {
+		t.Fatalf("dropped mention not present in the follow-up's plan")
+	}
+	if n := pendingTaskCountForAgentIssue(t, issueID, agentA); n != 0 {
+		t.Fatalf("comment author A must not be enqueued, got %d A task(s)", n)
+	}
+}
+
+// TestCancelTaskByUser_ReconcilesDroppedAgentMention is the maintainer's
+// blocking case #1: the generic user-facing cancel route (POST
+// /api/tasks/{taskId}/cancel, used by CLI / mobile / Chat / Activity) must also
+// reconcile an issue-bound task's dropped hand-off.
+func TestCancelTaskByUser_ReconcilesDroppedAgentMention(t *testing.T) {
+	if testHandler == nil {
+		t.Skip("database not available")
+	}
+	issueID, taskID, agentA, agentB, mention := seedDroppedAgentMention(t, 999104)
+
+	w := httptest.NewRecorder()
+	testHandler.CancelTaskByUser(w, cancelTaskByUserRequest(t, testUserID, taskID))
+	if w.Code != http.StatusOK {
+		t.Fatalf("CancelTaskByUser: expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	if n := queuedTaskCountForAgentIssue(t, issueID, agentB); n != 1 {
+		t.Fatalf("expected exactly 1 follow-up for B after user-cancel reconcile, got %d", n)
+	}
+	if !mentionInQueuedPlanForAgent(t, issueID, agentB, mention) {
+		t.Fatalf("dropped mention not present in the follow-up's plan")
+	}
+	if n := pendingTaskCountForAgentIssue(t, issueID, agentA); n != 0 {
+		t.Fatalf("comment author A must not be enqueued, got %d A task(s)", n)
+	}
+}
+
+// TestHandleFailedTasks_RuntimeOffline_MergesDroppedMentionIntoRetryChild is the
+// maintainer's blocking case #2/#3: the sweeper / offline-runtime / orphan-
+// recovery pipeline (direct row update → TaskService.HandleFailedTasks) creates
+// the retry child and then reconciles, folding the dropped mention into it.
+func TestHandleFailedTasks_RuntimeOffline_MergesDroppedMentionIntoRetryChild(t *testing.T) {
+	if testHandler == nil {
+		t.Skip("database not available")
+	}
+	issueID, taskID, agentA, agentB, mention := seedDroppedAgentMention(t, 999105)
+
+	row := markTaskFailedDirect(t, taskID, "runtime_offline")
+	testHandler.TaskService.HandleFailedTasks(context.Background(), []db.AgentTaskQueue{row})
+
+	if n := queuedTaskCountForAgentIssue(t, issueID, agentB); n != 1 {
+		t.Fatalf("expected exactly 1 queued retry child from the sweeper pipeline, got %d", n)
+	}
+	if !mentionInQueuedPlanForAgent(t, issueID, agentB, mention) {
+		t.Fatalf("dropped mention not merged into the sweeper retry child's plan")
+	}
+	if n := pendingTaskCountForAgentIssue(t, issueID, agentA); n != 0 {
+		t.Fatalf("comment author A must not be enqueued, got %d A task(s)", n)
+	}
+}
+
+// TestHandleFailedTasks_NonRetryable_FreshFollowup is the maintainer's case #4:
+// with no retry child (non-retryable reason), the sweeper pipeline still yields
+// exactly one fresh follow-up carrying the dropped mention.
+func TestHandleFailedTasks_NonRetryable_FreshFollowup(t *testing.T) {
+	if testHandler == nil {
+		t.Skip("database not available")
+	}
+	issueID, taskID, agentA, agentB, mention := seedDroppedAgentMention(t, 999106)
+
+	row := markTaskFailedDirect(t, taskID, "agent_error")
+	testHandler.TaskService.HandleFailedTasks(context.Background(), []db.AgentTaskQueue{row})
+
+	if n := queuedTaskCountForAgentIssue(t, issueID, agentB); n != 1 {
+		t.Fatalf("expected exactly 1 fresh follow-up (no retry child), got %d", n)
+	}
+	if !mentionInQueuedPlanForAgent(t, issueID, agentB, mention) {
+		t.Fatalf("dropped mention not present in the fresh follow-up's plan")
+	}
+	if n := pendingTaskCountForAgentIssue(t, issueID, agentA); n != 0 {
+		t.Fatalf("comment author A must not be enqueued, got %d A task(s)", n)
+	}
+}
+
+// TestFailTask_IdempotentCallback_NoDuplicateFollowup is the maintainer's case
+// #5: a repeated terminal callback must not introduce a second task or a
+// duplicate coalesced comment id. The second FailTask hits the already-finalized
+// early-return, so the reconciler never fires twice.
+func TestFailTask_IdempotentCallback_NoDuplicateFollowup(t *testing.T) {
+	if testHandler == nil {
+		t.Skip("database not available")
+	}
+	issueID, taskID, agentA, agentB, mention := seedDroppedAgentMention(t, 999107)
+
+	if w := failTaskViaHandler(t, taskID); w.Code != http.StatusOK {
+		t.Fatalf("FailTask #1: expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	if w := failTaskViaHandler(t, taskID); w.Code != http.StatusOK {
+		t.Fatalf("FailTask #2: expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	// Still exactly one follow-up — no duplicate concurrent run.
+	if n := queuedTaskCountForAgentIssue(t, issueID, agentB); n != 1 {
+		t.Fatalf("expected exactly 1 follow-up after a repeated terminal callback, got %d", n)
+	}
+	if !mentionInQueuedPlanForAgent(t, issueID, agentB, mention) {
+		t.Fatalf("dropped mention missing from the follow-up's plan")
+	}
+	// The mention appears across the queued plans exactly once — no duplicate
+	// coalesced comment id from the second callback.
+	var occurrences int
+	if err := testPool.QueryRow(context.Background(), `
+		SELECT count(*)
+		FROM agent_task_queue t, unnest(t.coalesced_comment_ids) AS c
+		WHERE t.issue_id = $1 AND t.agent_id = $2 AND t.status = 'queued' AND c = $3::uuid
+	`, issueID, agentB, mention).Scan(&occurrences); err != nil {
+		t.Fatalf("count coalesced occurrences: %v", err)
+	}
+	if occurrences > 1 {
+		t.Fatalf("dropped mention duplicated in the coalesced plan: %d occurrences", occurrences)
+	}
+	if n := pendingTaskCountForAgentIssue(t, issueID, agentA); n != 0 {
+		t.Fatalf("comment author A must not be enqueued, got %d A task(s)", n)
+	}
+}
+
+// TestFailTask_RetryChildRace_MentionMergedBeforeWakeup is the race regression
+// for the "reconcile before notify" ordering fix in FailTask. A wakeup notifier
+// that immediately claims the retry child (advancing it to dispatched) is
+// installed before FailTask runs. With the fix in place, reconcileTerminal
+// merges the dropped mention into the queued child BEFORE NotifyTaskEnqueued
+// wakes the daemon, so the mention survives even though the child is instantly
+// dispatched.
+func TestFailTask_RetryChildRace_MentionMergedBeforeWakeup(t *testing.T) {
+	if testHandler == nil {
+		t.Skip("database not available")
+	}
+	issueID, taskID, _, agentB, mention := seedDroppedAgentMention(t, 999108)
+
+	notifier := &claimOnWakeupNotifier{pool: testPool}
+	orig := testHandler.TaskService.Wakeup
+	testHandler.TaskService.Wakeup = notifier
+	t.Cleanup(func() { testHandler.TaskService.Wakeup = orig })
+
+	if w := failTaskWithReasonViaHandler(t, taskID, "timeout"); w.Code != http.StatusOK {
+		t.Fatalf("FailTask: expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	if !notifier.called {
+		t.Fatal("instant-claim notifier was never called — race scenario not exercised")
+	}
+	// The mention must be present even though the child was instantly dispatched.
+	if !mentionInAnyActivePlanForAgent(t, issueID, agentB, mention) {
+		t.Fatal("dropped mention lost — reconcile ran after notify; ordering fix not effective")
+	}
+}
+
+// TestFailTask_IdempotentCallback_RecoveryFromSkippedReconcile covers the
+// idempotency path introduced by the second review: if the first FailTask
+// commits the terminal row but reconcileTerminal is skipped (simulating a
+// process crash between commit and reconcile), the repeated callback must
+// still produce exactly one follow-up carrying the dropped mention.
+func TestFailTask_IdempotentCallback_RecoveryFromSkippedReconcile(t *testing.T) {
+	if testHandler == nil {
+		t.Skip("database not available")
+	}
+	issueID, taskID, _, agentB, mention := seedDroppedAgentMention(t, 999109)
+
+	origReconcile := testHandler.TaskService.ReconcileTerminal
+	testHandler.TaskService.ReconcileTerminal = nil
+	if w := failTaskViaHandler(t, taskID); w.Code != http.StatusOK {
+		t.Fatalf("FailTask #1 (no reconcile): expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	if n := queuedTaskCountForAgentIssue(t, issueID, agentB); n != 0 {
+		t.Fatalf("expected 0 follow-ups before recovery, got %d", n)
+	}
+
+	testHandler.TaskService.ReconcileTerminal = origReconcile
+
+	// Second call hits the already-finalized early-exit, which calls
+	// reconcileTerminal on the existing row → recovery.
+	if w := failTaskViaHandler(t, taskID); w.Code != http.StatusOK {
+		t.Fatalf("FailTask #2 (recovery): expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	if n := queuedTaskCountForAgentIssue(t, issueID, agentB); n != 1 {
+		t.Fatalf("expected exactly 1 follow-up after idempotent recovery, got %d", n)
+	}
+	if !mentionInQueuedPlanForAgent(t, issueID, agentB, mention) {
+		t.Fatalf("dropped mention missing from the recovery follow-up")
+	}
+}
+
+// TestCompleteTask_IdempotentCallback_RecoveryFromSkippedReconcile covers the
+// same idempotency recovery scenario on the CompleteTask path.
+func TestCompleteTask_IdempotentCallback_RecoveryFromSkippedReconcile(t *testing.T) {
+	if testHandler == nil {
+		t.Skip("database not available")
+	}
+	issueID, taskID, _, agentB, mention := seedDroppedAgentMention(t, 999110)
+
+	origReconcile := testHandler.TaskService.ReconcileTerminal
+	testHandler.TaskService.ReconcileTerminal = nil
+	if _, err := testHandler.TaskService.CompleteTask(context.Background(),
+		parseUUID(taskID), completeResult(t, "done"), "", ""); err != nil {
+		t.Fatalf("CompleteTask #1 (no reconcile): %v", err)
+	}
+	if n := queuedTaskCountForAgentIssue(t, issueID, agentB); n != 0 {
+		t.Fatalf("expected 0 follow-ups before recovery, got %d", n)
+	}
+
+	testHandler.TaskService.ReconcileTerminal = origReconcile
+
+	if _, err := testHandler.TaskService.CompleteTask(context.Background(),
+		parseUUID(taskID), completeResult(t, "done"), "", ""); err != nil {
+		t.Fatalf("CompleteTask #2 (recovery): %v", err)
+	}
+	if n := queuedTaskCountForAgentIssue(t, issueID, agentB); n != 1 {
+		t.Fatalf("expected exactly 1 follow-up after idempotent recovery, got %d", n)
+	}
+	if !mentionInQueuedPlanForAgent(t, issueID, agentB, mention) {
+		t.Fatalf("dropped mention missing from the recovery follow-up")
+	}
+}

--- a/server/internal/handler/daemon_terminal_reconcile_test.go
+++ b/server/internal/handler/daemon_terminal_reconcile_test.go
@@ -428,6 +428,10 @@ func TestFailTask_IdempotentCallback_RecoveryFromSkippedReconcile(t *testing.T) 
 
 	origReconcile := testHandler.TaskService.ReconcileTerminal
 	testHandler.TaskService.ReconcileTerminal = nil
+	// Safety net: restore even if a panic fires between now and the inline restore
+	// below. Without this, a panic leaves the shared testHandler corrupted for
+	// every subsequent test in the binary run.
+	t.Cleanup(func() { testHandler.TaskService.ReconcileTerminal = origReconcile })
 	if w := failTaskViaHandler(t, taskID); w.Code != http.StatusOK {
 		t.Fatalf("FailTask #1 (no reconcile): expected 200, got %d: %s", w.Code, w.Body.String())
 	}
@@ -435,6 +439,7 @@ func TestFailTask_IdempotentCallback_RecoveryFromSkippedReconcile(t *testing.T) 
 		t.Fatalf("expected 0 follow-ups before recovery, got %d", n)
 	}
 
+	// Restore before the second call so the early-exit path can reconcile.
 	testHandler.TaskService.ReconcileTerminal = origReconcile
 
 	// Second call hits the already-finalized early-exit, which calls
@@ -460,6 +465,10 @@ func TestCompleteTask_IdempotentCallback_RecoveryFromSkippedReconcile(t *testing
 
 	origReconcile := testHandler.TaskService.ReconcileTerminal
 	testHandler.TaskService.ReconcileTerminal = nil
+	// Safety net: restore even if a panic fires between now and the inline restore
+	// below. Without this, a panic leaves the shared testHandler corrupted for
+	// every subsequent test in the binary run.
+	t.Cleanup(func() { testHandler.TaskService.ReconcileTerminal = origReconcile })
 	if _, err := testHandler.TaskService.CompleteTask(context.Background(),
 		parseUUID(taskID), completeResult(t, "done"), "", "", "", false, "", ""); err != nil {
 		t.Fatalf("CompleteTask #1 (no reconcile): %v", err)
@@ -468,6 +477,7 @@ func TestCompleteTask_IdempotentCallback_RecoveryFromSkippedReconcile(t *testing
 		t.Fatalf("expected 0 follow-ups before recovery, got %d", n)
 	}
 
+	// Restore before the second call so the early-exit path can reconcile.
 	testHandler.TaskService.ReconcileTerminal = origReconcile
 
 	if _, err := testHandler.TaskService.CompleteTask(context.Background(),

--- a/server/internal/handler/daemon_terminal_reconcile_test.go
+++ b/server/internal/handler/daemon_terminal_reconcile_test.go
@@ -1,0 +1,483 @@
+package handler
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/multica-ai/multica/server/internal/util"
+	db "github.com/multica-ai/multica/server/pkg/db/generated"
+)
+
+// claimOnWakeupNotifier is a test TaskWakeupNotifier that immediately advances
+// the notified task from queued → dispatched, simulating the daemon claiming
+// the retry child the instant it is woken. This reproduces the race that the
+// "reconcile before notify" ordering fix was written to prevent.
+type claimOnWakeupNotifier struct {
+	pool   *pgxpool.Pool
+	called bool
+}
+
+func (n *claimOnWakeupNotifier) NotifyTaskAvailable(_, taskID string) {
+	if taskID == "" {
+		return
+	}
+	_, _ = n.pool.Exec(context.Background(),
+		`UPDATE agent_task_queue SET status = 'dispatched', dispatched_at = now() WHERE id = $1 AND status = 'queued'`,
+		taskID)
+	n.called = true
+}
+
+// mentionInAnyActivePlanForAgent reports whether commentID appears in the
+// trigger or coalesced plan of ANY task for the (issue, agent) pair regardless
+// of status. Used by the race regression test where the retry child may have
+// been advanced to dispatched by the instant-claim wakeup notifier.
+func mentionInAnyActivePlanForAgent(t *testing.T, issueID, agentID, commentID string) bool {
+	t.Helper()
+	var n int
+	if err := testPool.QueryRow(context.Background(), `
+		SELECT count(*) FROM agent_task_queue
+		WHERE issue_id = $1 AND agent_id = $2
+		  AND ($3::uuid = ANY(coalesced_comment_ids) OR trigger_comment_id = $3::uuid)
+	`, issueID, agentID, commentID).Scan(&n); err != nil {
+		t.Fatalf("query mention in any plan: %v", err)
+	}
+	return n > 0
+}
+
+// These tests pin the #5278 invariant across EVERY terminal path that should
+// allow subsequent work: an @agent hand-off dropped while the target had an
+// in-flight task (merge-miss + active-task deferral) must still be replayed when
+// that run ends by fail / user-cancel / sweeper-fail — not only on success.
+// Reconciliation now runs inside the TaskService terminal transitions via the
+// injected ReconcileTerminal seam, so these drive the real service/handler paths.
+
+// failTaskWithReasonViaHandler drives the daemon FailTask endpoint with an
+// explicit failure_reason (the shared failTaskViaHandler helper hardcodes a
+// non-retryable agent_error; the retryable path here needs e.g. "timeout").
+func failTaskWithReasonViaHandler(t *testing.T, taskID, failureReason string) *httptest.ResponseRecorder {
+	t.Helper()
+	w := httptest.NewRecorder()
+	req := newDaemonTokenRequest("POST", "/api/daemon/tasks/"+taskID+"/fail",
+		map[string]any{"error": "boom", "failure_reason": failureReason},
+		testWorkspaceID, "legit-daemon")
+	rctx := chi.NewRouteContext()
+	rctx.URLParams.Add("taskId", taskID)
+	req = req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, rctx))
+	testHandler.FailTask(w, req)
+	return w
+}
+
+// cancelTaskViaHandler drives the issue-scoped daemon CancelTask endpoint
+// (POST /api/issues/{id}/tasks/{taskId}/cancel).
+func cancelTaskViaHandler(t *testing.T, issueID, taskID string) *httptest.ResponseRecorder {
+	t.Helper()
+	w := httptest.NewRecorder()
+	req := newRequest("POST", "/api/issues/"+issueID+"/tasks/"+taskID+"/cancel", nil)
+	req = withURLParams(req, "id", issueID, "taskId", taskID)
+	testHandler.CancelTask(w, req)
+	return w
+}
+
+// mentionInQueuedPlanForAgent reports whether commentID appears in the trigger
+// or coalesced plan of any QUEUED task for the (issue, agent) pair — i.e. the
+// dropped mention was merged into a queued run (retry child or fresh follow-up).
+func mentionInQueuedPlanForAgent(t *testing.T, issueID, agentID, commentID string) bool {
+	t.Helper()
+	var n int
+	if err := testPool.QueryRow(context.Background(), `
+		SELECT count(*) FROM agent_task_queue
+		WHERE issue_id = $1 AND agent_id = $2 AND status = 'queued'
+		  AND ($3::uuid = ANY(coalesced_comment_ids) OR trigger_comment_id = $3::uuid)
+	`, issueID, agentID, commentID).Scan(&n); err != nil {
+		t.Fatalf("query mention in queued plan: %v", err)
+	}
+	return n > 0
+}
+
+// markTaskFailedDirect transitions a task to failed the way the sweepers and
+// orphan recovery do — a direct row update — then returns the reloaded row to
+// hand to TaskService.HandleFailedTasks, exactly as those pipelines do.
+func markTaskFailedDirect(t *testing.T, taskID, reason string) db.AgentTaskQueue {
+	t.Helper()
+	ctx := context.Background()
+	if _, err := testPool.Exec(ctx,
+		`UPDATE agent_task_queue SET status = 'failed', failure_reason = $2 WHERE id = $1`,
+		taskID, reason); err != nil {
+		t.Fatalf("mark task failed: %v", err)
+	}
+	row, err := testHandler.Queries.GetAgentTask(ctx, util.MustParseUUID(taskID))
+	if err != nil {
+		t.Fatalf("reload failed task: %v", err)
+	}
+	return row
+}
+
+// seedDroppedAgentMention reproduces the #5278 precondition: agent B has a
+// DISPATCHED task on an issue when agent A posts an explicit @B mention, which
+// hits the merge-miss + active-task drop at creation time and is deferred to
+// terminal reconciliation. Returns the issue, B's (running) task, both agent
+// ids, and the dropped mention's comment id, with the drop already asserted.
+func seedDroppedAgentMention(t *testing.T, issueNumber int32) (issueID, taskID, agentA, agentB, mentionCommentID string) {
+	t.Helper()
+	ctx := context.Background()
+
+	var runtimeID string
+	if err := testPool.QueryRow(ctx,
+		`SELECT runtime_id FROM agent WHERE workspace_id = $1 AND runtime_id IS NOT NULL LIMIT 1`,
+		testWorkspaceID).Scan(&runtimeID); err != nil {
+		t.Fatalf("setup: get runtime: %v", err)
+	}
+	agentA = createHandlerTestAgent(t, "Terminal Reconcile Author A", nil)
+	agentB = createHandlerTestAgent(t, "Terminal Reconcile Target B", nil)
+
+	if err := testPool.QueryRow(ctx, `
+		INSERT INTO issue (workspace_id, title, status, priority, creator_id, creator_type, number, position, assignee_type, assignee_id)
+		VALUES ($1, 'terminal-reconcile fixture', 'in_progress', 'none', $2, 'member', $3, 0, 'agent', $4)
+		RETURNING id
+	`, testWorkspaceID, testUserID, issueNumber, agentB).Scan(&issueID); err != nil {
+		t.Fatalf("setup: create issue: %v", err)
+	}
+	t.Cleanup(func() { testPool.Exec(ctx, `DELETE FROM issue WHERE id = $1`, issueID) })
+	t.Cleanup(func() { testPool.Exec(ctx, `DELETE FROM comment WHERE issue_id = $1`, issueID) })
+
+	issue, err := testHandler.Queries.GetIssue(ctx, util.MustParseUUID(issueID))
+	if err != nil {
+		t.Fatalf("setup: load issue: %v", err)
+	}
+
+	var triggerCommentID string
+	if err := testPool.QueryRow(ctx, `
+		INSERT INTO comment (issue_id, workspace_id, author_type, author_id, content, type, created_at)
+		VALUES ($1, $2, 'member', $3, 'initial request', 'comment', now() - interval '10 minutes')
+		RETURNING id
+	`, issueID, testWorkspaceID, testUserID).Scan(&triggerCommentID); err != nil {
+		t.Fatalf("setup: trigger comment: %v", err)
+	}
+
+	// B's task is DISPATCHED — the state that makes an incoming mention hit the
+	// merge-miss + active-task drop at creation time.
+	if err := testPool.QueryRow(ctx, `
+		INSERT INTO agent_task_queue (agent_id, runtime_id, issue_id, trigger_comment_id, delivered_comment_ids, status, priority, created_at, dispatched_at)
+		VALUES ($1, $2, $3, $4, ARRAY[$4::uuid], 'dispatched', 0, now() - interval '10 minutes', now() - interval '5 minutes')
+		RETURNING id
+	`, agentB, runtimeID, issueID, triggerCommentID).Scan(&taskID); err != nil {
+		t.Fatalf("setup: dispatched task: %v", err)
+	}
+	t.Cleanup(func() { testPool.Exec(ctx, `DELETE FROM agent_task_queue WHERE issue_id = $1`, issueID) })
+
+	// Agent A posts an explicit @B mention through the real trigger path while B
+	// is dispatched.
+	mention := "[@B](mention://agent/" + agentB + ") please also handle this"
+	if err := testPool.QueryRow(ctx, `
+		INSERT INTO comment (issue_id, workspace_id, author_type, author_id, content, type)
+		VALUES ($1, $2, 'agent', $3, $4, 'comment')
+		RETURNING id
+	`, issueID, testWorkspaceID, agentA, mention).Scan(&mentionCommentID); err != nil {
+		t.Fatalf("setup: agent @B comment: %v", err)
+	}
+	mentionComment, err := testHandler.Queries.GetComment(ctx, util.MustParseUUID(mentionCommentID))
+	if err != nil {
+		t.Fatalf("setup: load mention comment: %v", err)
+	}
+	testHandler.triggerTasksForComment(ctx, issue, mentionComment, nil, "agent", agentA, "", "", nil)
+
+	if n := queuedTaskCountForAgentIssue(t, issueID, agentB); n != 0 {
+		t.Fatalf("expected the mention to be dropped at creation (0 queued follow-up), got %d", n)
+	}
+
+	// Advance B's task dispatched → running so the terminal endpoint has a live
+	// run to end.
+	if _, err := testPool.Exec(ctx, `UPDATE agent_task_queue SET status = 'running', started_at = now() - interval '1 minute' WHERE id = $1`, taskID); err != nil {
+		t.Fatalf("advance task to running: %v", err)
+	}
+	return issueID, taskID, agentA, agentB, mentionCommentID
+}
+
+// TestFailTask_ReconcilesDroppedAgentMentionOnTerminalFail — non-retryable fail
+// (agent_error) leaves no retry child, so the dropped mention earns exactly one
+// fresh follow-up for B. Author A is never enqueued (loop guard).
+func TestFailTask_ReconcilesDroppedAgentMentionOnTerminalFail(t *testing.T) {
+	if testHandler == nil {
+		t.Skip("database not available")
+	}
+	issueID, taskID, agentA, agentB, mention := seedDroppedAgentMention(t, 999101)
+
+	if w := failTaskViaHandler(t, taskID); w.Code != http.StatusOK {
+		t.Fatalf("FailTask: expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	if n := queuedTaskCountForAgentIssue(t, issueID, agentB); n != 1 {
+		t.Fatalf("expected exactly 1 fresh follow-up for B after fail-path reconcile, got %d", n)
+	}
+	if !mentionInQueuedPlanForAgent(t, issueID, agentB, mention) {
+		t.Fatalf("dropped mention not present in the follow-up's plan")
+	}
+	if n := pendingTaskCountForAgentIssue(t, issueID, agentA); n != 0 {
+		t.Fatalf("comment author A must not be enqueued, got %d A task(s)", n)
+	}
+}
+
+// TestFailTask_RetryableFail_MergesDroppedMentionIntoRetryChild — a retryable
+// fail (timeout) creates the auto-retry child first; reconcile then merges the
+// dropped mention INTO that single queued child rather than spawning a duplicate.
+func TestFailTask_RetryableFail_MergesDroppedMentionIntoRetryChild(t *testing.T) {
+	if testHandler == nil {
+		t.Skip("database not available")
+	}
+	issueID, taskID, agentA, agentB, mention := seedDroppedAgentMention(t, 999103)
+
+	if w := failTaskWithReasonViaHandler(t, taskID, "timeout"); w.Code != http.StatusOK {
+		t.Fatalf("FailTask: expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	// Exactly one queued child (the auto-retry), and the mention is folded into it.
+	if n := queuedTaskCountForAgentIssue(t, issueID, agentB); n != 1 {
+		t.Fatalf("expected exactly 1 queued retry child, got %d (duplicate follow-up?)", n)
+	}
+	if !mentionInQueuedPlanForAgent(t, issueID, agentB, mention) {
+		t.Fatalf("dropped mention not merged into the retry child's plan")
+	}
+	if n := pendingTaskCountForAgentIssue(t, issueID, agentA); n != 0 {
+		t.Fatalf("comment author A must not be enqueued, got %d A task(s)", n)
+	}
+}
+
+// TestCancelTask_ReconcilesDroppedAgentMentionOnCancel covers the issue-scoped
+// daemon cancel route.
+func TestCancelTask_ReconcilesDroppedAgentMentionOnCancel(t *testing.T) {
+	if testHandler == nil {
+		t.Skip("database not available")
+	}
+	issueID, taskID, agentA, agentB, mention := seedDroppedAgentMention(t, 999102)
+
+	if w := cancelTaskViaHandler(t, issueID, taskID); w.Code != http.StatusOK {
+		t.Fatalf("CancelTask: expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	if n := queuedTaskCountForAgentIssue(t, issueID, agentB); n != 1 {
+		t.Fatalf("expected exactly 1 follow-up for B after cancel-path reconcile, got %d", n)
+	}
+	if !mentionInQueuedPlanForAgent(t, issueID, agentB, mention) {
+		t.Fatalf("dropped mention not present in the follow-up's plan")
+	}
+	if n := pendingTaskCountForAgentIssue(t, issueID, agentA); n != 0 {
+		t.Fatalf("comment author A must not be enqueued, got %d A task(s)", n)
+	}
+}
+
+// TestCancelTaskByUser_ReconcilesDroppedAgentMention is the maintainer's
+// blocking case #1: the generic user-facing cancel route (POST
+// /api/tasks/{taskId}/cancel, used by CLI / mobile / Chat / Activity) must also
+// reconcile an issue-bound task's dropped hand-off.
+func TestCancelTaskByUser_ReconcilesDroppedAgentMention(t *testing.T) {
+	if testHandler == nil {
+		t.Skip("database not available")
+	}
+	issueID, taskID, agentA, agentB, mention := seedDroppedAgentMention(t, 999104)
+
+	w := httptest.NewRecorder()
+	testHandler.CancelTaskByUser(w, cancelTaskByUserRequest(t, testUserID, taskID))
+	if w.Code != http.StatusOK {
+		t.Fatalf("CancelTaskByUser: expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	if n := queuedTaskCountForAgentIssue(t, issueID, agentB); n != 1 {
+		t.Fatalf("expected exactly 1 follow-up for B after user-cancel reconcile, got %d", n)
+	}
+	if !mentionInQueuedPlanForAgent(t, issueID, agentB, mention) {
+		t.Fatalf("dropped mention not present in the follow-up's plan")
+	}
+	if n := pendingTaskCountForAgentIssue(t, issueID, agentA); n != 0 {
+		t.Fatalf("comment author A must not be enqueued, got %d A task(s)", n)
+	}
+}
+
+// TestHandleFailedTasks_RuntimeOffline_MergesDroppedMentionIntoRetryChild is the
+// maintainer's blocking case #2/#3: the sweeper / offline-runtime / orphan-
+// recovery pipeline (direct row update → TaskService.HandleFailedTasks) creates
+// the retry child and then reconciles, folding the dropped mention into it.
+func TestHandleFailedTasks_RuntimeOffline_MergesDroppedMentionIntoRetryChild(t *testing.T) {
+	if testHandler == nil {
+		t.Skip("database not available")
+	}
+	issueID, taskID, agentA, agentB, mention := seedDroppedAgentMention(t, 999105)
+
+	row := markTaskFailedDirect(t, taskID, "runtime_offline")
+	testHandler.TaskService.HandleFailedTasks(context.Background(), []db.AgentTaskQueue{row})
+
+	if n := queuedTaskCountForAgentIssue(t, issueID, agentB); n != 1 {
+		t.Fatalf("expected exactly 1 queued retry child from the sweeper pipeline, got %d", n)
+	}
+	if !mentionInQueuedPlanForAgent(t, issueID, agentB, mention) {
+		t.Fatalf("dropped mention not merged into the sweeper retry child's plan")
+	}
+	if n := pendingTaskCountForAgentIssue(t, issueID, agentA); n != 0 {
+		t.Fatalf("comment author A must not be enqueued, got %d A task(s)", n)
+	}
+}
+
+// TestHandleFailedTasks_NonRetryable_FreshFollowup is the maintainer's case #4:
+// with no retry child (non-retryable reason), the sweeper pipeline still yields
+// exactly one fresh follow-up carrying the dropped mention.
+func TestHandleFailedTasks_NonRetryable_FreshFollowup(t *testing.T) {
+	if testHandler == nil {
+		t.Skip("database not available")
+	}
+	issueID, taskID, agentA, agentB, mention := seedDroppedAgentMention(t, 999106)
+
+	row := markTaskFailedDirect(t, taskID, "agent_error")
+	testHandler.TaskService.HandleFailedTasks(context.Background(), []db.AgentTaskQueue{row})
+
+	if n := queuedTaskCountForAgentIssue(t, issueID, agentB); n != 1 {
+		t.Fatalf("expected exactly 1 fresh follow-up (no retry child), got %d", n)
+	}
+	if !mentionInQueuedPlanForAgent(t, issueID, agentB, mention) {
+		t.Fatalf("dropped mention not present in the fresh follow-up's plan")
+	}
+	if n := pendingTaskCountForAgentIssue(t, issueID, agentA); n != 0 {
+		t.Fatalf("comment author A must not be enqueued, got %d A task(s)", n)
+	}
+}
+
+// TestFailTask_IdempotentCallback_NoDuplicateFollowup is the maintainer's case
+// #5: a repeated terminal callback must not introduce a second task or a
+// duplicate coalesced comment id. The second FailTask hits the already-finalized
+// early-return, so the reconciler never fires twice.
+func TestFailTask_IdempotentCallback_NoDuplicateFollowup(t *testing.T) {
+	if testHandler == nil {
+		t.Skip("database not available")
+	}
+	issueID, taskID, agentA, agentB, mention := seedDroppedAgentMention(t, 999107)
+
+	if w := failTaskViaHandler(t, taskID); w.Code != http.StatusOK {
+		t.Fatalf("FailTask #1: expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	if w := failTaskViaHandler(t, taskID); w.Code != http.StatusOK {
+		t.Fatalf("FailTask #2: expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	// Still exactly one follow-up — no duplicate concurrent run.
+	if n := queuedTaskCountForAgentIssue(t, issueID, agentB); n != 1 {
+		t.Fatalf("expected exactly 1 follow-up after a repeated terminal callback, got %d", n)
+	}
+	if !mentionInQueuedPlanForAgent(t, issueID, agentB, mention) {
+		t.Fatalf("dropped mention missing from the follow-up's plan")
+	}
+	// The mention appears across the queued plans exactly once — no duplicate
+	// coalesced comment id from the second callback.
+	var occurrences int
+	if err := testPool.QueryRow(context.Background(), `
+		SELECT count(*)
+		FROM agent_task_queue t, unnest(t.coalesced_comment_ids) AS c
+		WHERE t.issue_id = $1 AND t.agent_id = $2 AND t.status = 'queued' AND c = $3::uuid
+	`, issueID, agentB, mention).Scan(&occurrences); err != nil {
+		t.Fatalf("count coalesced occurrences: %v", err)
+	}
+	if occurrences > 1 {
+		t.Fatalf("dropped mention duplicated in the coalesced plan: %d occurrences", occurrences)
+	}
+	if n := pendingTaskCountForAgentIssue(t, issueID, agentA); n != 0 {
+		t.Fatalf("comment author A must not be enqueued, got %d A task(s)", n)
+	}
+}
+
+// TestFailTask_RetryChildRace_MentionMergedBeforeWakeup is the race regression
+// for the "reconcile before notify" ordering fix in FailTask. A wakeup notifier
+// that immediately claims the retry child (advancing it to dispatched) is
+// installed before FailTask runs. With the fix in place, reconcileTerminal
+// merges the dropped mention into the queued child BEFORE NotifyTaskEnqueued
+// wakes the daemon, so the mention survives even though the child is instantly
+// dispatched.
+func TestFailTask_RetryChildRace_MentionMergedBeforeWakeup(t *testing.T) {
+	if testHandler == nil {
+		t.Skip("database not available")
+	}
+	issueID, taskID, _, agentB, mention := seedDroppedAgentMention(t, 999108)
+
+	notifier := &claimOnWakeupNotifier{pool: testPool}
+	orig := testHandler.TaskService.Wakeup
+	testHandler.TaskService.Wakeup = notifier
+	t.Cleanup(func() { testHandler.TaskService.Wakeup = orig })
+
+	if w := failTaskWithReasonViaHandler(t, taskID, "timeout"); w.Code != http.StatusOK {
+		t.Fatalf("FailTask: expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	if !notifier.called {
+		t.Fatal("instant-claim notifier was never called — race scenario not exercised")
+	}
+	// The mention must be present even though the child was instantly dispatched.
+	if !mentionInAnyActivePlanForAgent(t, issueID, agentB, mention) {
+		t.Fatal("dropped mention lost — reconcile ran after notify; ordering fix not effective")
+	}
+}
+
+// TestFailTask_IdempotentCallback_RecoveryFromSkippedReconcile covers the
+// idempotency path introduced by the second review: if the first FailTask
+// commits the terminal row but reconcileTerminal is skipped (simulating a
+// process crash between commit and reconcile), the repeated callback must
+// still produce exactly one follow-up carrying the dropped mention.
+func TestFailTask_IdempotentCallback_RecoveryFromSkippedReconcile(t *testing.T) {
+	if testHandler == nil {
+		t.Skip("database not available")
+	}
+	issueID, taskID, _, agentB, mention := seedDroppedAgentMention(t, 999109)
+
+	origReconcile := testHandler.TaskService.ReconcileTerminal
+	testHandler.TaskService.ReconcileTerminal = nil
+	if w := failTaskViaHandler(t, taskID); w.Code != http.StatusOK {
+		t.Fatalf("FailTask #1 (no reconcile): expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	if n := queuedTaskCountForAgentIssue(t, issueID, agentB); n != 0 {
+		t.Fatalf("expected 0 follow-ups before recovery, got %d", n)
+	}
+
+	testHandler.TaskService.ReconcileTerminal = origReconcile
+
+	// Second call hits the already-finalized early-exit, which calls
+	// reconcileTerminal on the existing row → recovery.
+	if w := failTaskViaHandler(t, taskID); w.Code != http.StatusOK {
+		t.Fatalf("FailTask #2 (recovery): expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	if n := queuedTaskCountForAgentIssue(t, issueID, agentB); n != 1 {
+		t.Fatalf("expected exactly 1 follow-up after idempotent recovery, got %d", n)
+	}
+	if !mentionInQueuedPlanForAgent(t, issueID, agentB, mention) {
+		t.Fatalf("dropped mention missing from the recovery follow-up")
+	}
+}
+
+// TestCompleteTask_IdempotentCallback_RecoveryFromSkippedReconcile covers the
+// same idempotency recovery scenario on the CompleteTask path.
+func TestCompleteTask_IdempotentCallback_RecoveryFromSkippedReconcile(t *testing.T) {
+	if testHandler == nil {
+		t.Skip("database not available")
+	}
+	issueID, taskID, _, agentB, mention := seedDroppedAgentMention(t, 999110)
+
+	origReconcile := testHandler.TaskService.ReconcileTerminal
+	testHandler.TaskService.ReconcileTerminal = nil
+	if _, err := testHandler.TaskService.CompleteTask(context.Background(),
+		parseUUID(taskID), completeResult(t, "done"), "", "", "", false, "", ""); err != nil {
+		t.Fatalf("CompleteTask #1 (no reconcile): %v", err)
+	}
+	if n := queuedTaskCountForAgentIssue(t, issueID, agentB); n != 0 {
+		t.Fatalf("expected 0 follow-ups before recovery, got %d", n)
+	}
+
+	testHandler.TaskService.ReconcileTerminal = origReconcile
+
+	if _, err := testHandler.TaskService.CompleteTask(context.Background(),
+		parseUUID(taskID), completeResult(t, "done"), "", "", "", false, "", ""); err != nil {
+		t.Fatalf("CompleteTask #2 (recovery): %v", err)
+	}
+	if n := queuedTaskCountForAgentIssue(t, issueID, agentB); n != 1 {
+		t.Fatalf("expected exactly 1 follow-up after idempotent recovery, got %d", n)
+	}
+	if !mentionInQueuedPlanForAgent(t, issueID, agentB, mention) {
+		t.Fatalf("dropped mention missing from the recovery follow-up")
+	}
+}

--- a/server/internal/handler/daemon_terminal_reconcile_test.go
+++ b/server/internal/handler/daemon_terminal_reconcile_test.go
@@ -428,6 +428,10 @@ func TestFailTask_IdempotentCallback_RecoveryFromSkippedReconcile(t *testing.T) 
 
 	origReconcile := testHandler.TaskService.ReconcileTerminal
 	testHandler.TaskService.ReconcileTerminal = nil
+	// Safety net: restore even if a panic fires between now and the inline restore
+	// below. Without this, a panic leaves the shared testHandler corrupted for
+	// every subsequent test in the binary run.
+	t.Cleanup(func() { testHandler.TaskService.ReconcileTerminal = origReconcile })
 	if w := failTaskViaHandler(t, taskID); w.Code != http.StatusOK {
 		t.Fatalf("FailTask #1 (no reconcile): expected 200, got %d: %s", w.Code, w.Body.String())
 	}
@@ -435,6 +439,7 @@ func TestFailTask_IdempotentCallback_RecoveryFromSkippedReconcile(t *testing.T) 
 		t.Fatalf("expected 0 follow-ups before recovery, got %d", n)
 	}
 
+	// Restore before the second call so the early-exit path can reconcile.
 	testHandler.TaskService.ReconcileTerminal = origReconcile
 
 	// Second call hits the already-finalized early-exit, which calls
@@ -460,18 +465,23 @@ func TestCompleteTask_IdempotentCallback_RecoveryFromSkippedReconcile(t *testing
 
 	origReconcile := testHandler.TaskService.ReconcileTerminal
 	testHandler.TaskService.ReconcileTerminal = nil
+	// Safety net: restore even if a panic fires between now and the inline restore
+	// below. Without this, a panic leaves the shared testHandler corrupted for
+	// every subsequent test in the binary run.
+	t.Cleanup(func() { testHandler.TaskService.ReconcileTerminal = origReconcile })
 	if _, err := testHandler.TaskService.CompleteTask(context.Background(),
-		parseUUID(taskID), completeResult(t, "done"), "", ""); err != nil {
+		parseUUID(taskID), completeResult(t, "done"), "", "", false, ""); err != nil {
 		t.Fatalf("CompleteTask #1 (no reconcile): %v", err)
 	}
 	if n := queuedTaskCountForAgentIssue(t, issueID, agentB); n != 0 {
 		t.Fatalf("expected 0 follow-ups before recovery, got %d", n)
 	}
 
+	// Restore before the second call so the early-exit path can reconcile.
 	testHandler.TaskService.ReconcileTerminal = origReconcile
 
 	if _, err := testHandler.TaskService.CompleteTask(context.Background(),
-		parseUUID(taskID), completeResult(t, "done"), "", ""); err != nil {
+		parseUUID(taskID), completeResult(t, "done"), "", "", false, ""); err != nil {
 		t.Fatalf("CompleteTask #2 (recovery): %v", err)
 	}
 	if n := queuedTaskCountForAgentIssue(t, issueID, agentB); n != 1 {

--- a/server/internal/handler/handler.go
+++ b/server/internal/handler/handler.go
@@ -490,6 +490,13 @@ func New(queries *db.Queries, txStarter txStarter, hub *realtime.Hub, bus *event
 	}
 	h.PRRefresh = ghsnapshot.NewManager(ghClient, queries, txStarter, h.broadcastPRSnapshotApplied)
 
+	// Wire the shared post-terminal comment reconciler so the service-layer
+	// terminal transitions (complete / fail / cancel / sweeper fail) replay
+	// undelivered comment triggers. cmd/server reuses this same TaskService
+	// instance for its background sweeper / autopilot dispatch (backgroundServices),
+	// so the runtime/stale/orphan-recovery fail paths inherit this wiring too (#5278).
+	h.TaskService.ReconcileTerminal = h.ReconcileTerminalTask
+
 	return h
 }
 

--- a/server/internal/handler/handler.go
+++ b/server/internal/handler/handler.go
@@ -397,6 +397,13 @@ func New(queries *db.Queries, txStarter txStarter, hub *realtime.Hub, bus *event
 	}
 	h.PRRefresh = ghsnapshot.NewManager(ghClient, queries, txStarter, h.broadcastPRSnapshotApplied)
 
+	// Wire the shared post-terminal comment reconciler so the service-layer
+	// terminal transitions (complete / fail / cancel / sweeper fail) replay
+	// undelivered comment triggers. cmd/server reuses this same TaskService
+	// instance for its background sweeper / autopilot dispatch (backgroundServices),
+	// so the runtime/stale/orphan-recovery fail paths inherit this wiring too (#5278).
+	h.TaskService.ReconcileTerminal = h.ReconcileTerminalTask
+
 	return h
 }
 

--- a/server/internal/service/task.go
+++ b/server/internal/service/task.go
@@ -85,6 +85,20 @@ type TaskService struct {
 	quickActionsInFlight sync.Map
 	quickActionsRunning  atomic.Int64
 
+	// ReconcileTerminal replays comment triggers a run did NOT deliver, once
+	// the task has freshly left the active set through a path that should allow
+	// subsequent work (complete / fail / user-cancel / sweeper fail / orphan
+	// recovery). The comment-routing logic lives in the handler layer, so this
+	// is an injected seam (like Composio / Wakeup): the handler wires it to its
+	// reconcileCommentsOnCompletion in New, and main.go wires the sweeper's
+	// TaskService to the same method. Nil is valid and disables replay — and it
+	// is deliberately left nil on the bulk-cleanup paths (issue delete,
+	// comment edit/delete re-routing, agent "cancel all") which must NOT enqueue
+	// replacement work. The callee is itself a no-op for tasks without a valid
+	// issue / agent / creation timestamp, and loop-safe (created_at anchor +
+	// delivered-set exclusion), so double invocation cannot duplicate a run.
+	ReconcileTerminal TerminalTaskReconciler
+
 	analyticsContextMu    sync.Mutex
 	analyticsContextCache map[string]analytics.TaskContext
 	analyticsContextOrder []string
@@ -118,6 +132,23 @@ type ComposioOverlayBuilder interface {
 
 type TaskWakeupNotifier interface {
 	NotifyTaskAvailable(runtimeID, taskID string)
+}
+
+// TerminalTaskReconciler replays any comment triggers a task did NOT deliver
+// after it leaves the active set on a path that should allow subsequent work.
+// It is the single shared post-terminal entry point the handler and the
+// background/sweeper paths both funnel through (see TaskService.ReconcileTerminal).
+type TerminalTaskReconciler func(ctx context.Context, task *db.AgentTaskQueue)
+
+// reconcileTerminal invokes the injected post-terminal reconciler when one is
+// wired. It is called only after a successful terminal transition and, on the
+// fail paths, only after the auto-retry child has been created — so an
+// undelivered comment merges into that queued retry instead of spawning a
+// duplicate run.
+func (s *TaskService) reconcileTerminal(ctx context.Context, task *db.AgentTaskQueue) {
+	if s.ReconcileTerminal != nil {
+		s.ReconcileTerminal(ctx, task)
+	}
 }
 
 // triggerSummaryMaxLen caps the snapshot length so the row stays cheap to
@@ -2706,6 +2737,14 @@ type CancelTaskOptions struct {
 	// server repairs. An explicit user cancellation terminally acknowledges any
 	// delegated-failure recovery signal planned into the task; automatic
 	// cancellations must leave that signal replayable.
+	//
+	// It also gates the #5278 replay of comment triggers this run did not
+	// deliver: the run is over by the user's own decision, so a deferred @agent
+	// hand-off must survive it. The internal claim-time hard-fail cancels
+	// (workspace-isolation / missing runtime owner / stale-plan repair in
+	// daemon.go) leave this false and therefore do NOT replay — they reject a
+	// claim before the run starts, and enqueuing replacement agent work there
+	// would re-dispatch into the same failure and loop.
 	UserInitiated bool
 }
 
@@ -2840,6 +2879,12 @@ func (s *TaskService) CancelTaskWithResult(ctx context.Context, taskID pgtype.UU
 		if err != nil {
 			return nil, fmt.Errorf("cancel task: %w", err)
 		}
+		// The task was already terminal when this call arrived. If this is a
+		// retry of a callback that committed the cancel but crashed before
+		// reconciling, re-enter reconciliation so the deferred comment survives.
+		if opts.UserInitiated {
+			s.reconcileTerminal(ctx, &existing)
+		}
 		return &CancelTaskResult{Task: existing}, nil
 	}
 	if err != nil {
@@ -2858,6 +2903,18 @@ func (s *TaskService) CancelTaskWithResult(ctx context.Context, taskID pgtype.UU
 	// Broadcast cancellation as a task:failed event so frontends clear the live card
 	s.broadcastTaskEvent(ctx, protocol.EventTaskCancelled, task)
 	s.NotifyTaskFinished(task)
+
+	// A user-facing single-task cancel is terminal with no auto-retry, so replay
+	// any comment deferred while this run held the active slot. Gated on the
+	// caller's intent (opts.UserInitiated): the internal claim-time hard-fail
+	// cancels leave it false so a rejected claim never enqueues replacement
+	// work. No-op anyway for chat-only tasks (no issue), and reached only after
+	// a real cancel — an already-finalized task returned early above.
+	// The bulk cancels — issue delete, comment edit/delete re-routing, agent
+	// "cancel all" — never route through this method.
+	if opts.UserInitiated {
+		s.reconcileTerminal(ctx, &task)
+	}
 
 	return &CancelTaskResult{
 		Task:                 task,
@@ -4270,6 +4327,12 @@ func (s *TaskService) CompleteTask(ctx context.Context, taskID pgtype.UUID, resu
 					"current_status", existing.Status,
 					"agent_id", util.UUIDToString(existing.AgentID),
 				)
+				// Recover a missed reconciliation: if this is a retry of a
+				// callback that committed the completion but crashed before
+				// reconciling, re-enter reconciliation so no deferred comment
+				// is stranded. reconcileTerminal is idempotent — a comment
+				// already in a queued task's plan is not duplicated.
+				s.reconcileTerminal(ctx, &existing)
 				return &existing, nil
 			}
 			slog.Warn("complete task failed",
@@ -4380,6 +4443,11 @@ func (s *TaskService) CompleteTask(ctx context.Context, taskID pgtype.UUID, resu
 
 	// Broadcast
 	s.broadcastTaskEvent(ctx, protocol.EventTaskCompleted, task)
+
+	// Replay any comment that landed while this run was busy and was deferred to
+	// completion-time reconciliation (MUL-4195 / MUL-4304). Shared with the fail
+	// / cancel terminal paths via the injected reconciler.
+	s.reconcileTerminal(ctx, &task)
 
 	return &task, nil
 }
@@ -4868,6 +4936,11 @@ func (s *TaskService) FailTask(ctx context.Context, taskID pgtype.UUID, errMsg, 
 					"current_status", existing.Status,
 					"agent_id", util.UUIDToString(existing.AgentID),
 				)
+				// Recover a missed reconciliation: if this is a retry of a
+				// callback that committed the failure but crashed before
+				// reconciling, re-enter reconciliation so no deferred comment
+				// is stranded. reconcileTerminal is idempotent.
+				s.reconcileTerminal(ctx, &existing)
 				return &existing, nil
 			}
 			slog.Warn("fail task failed",
@@ -4890,12 +4963,22 @@ func (s *TaskService) FailTask(ctx context.Context, taskID pgtype.UUID, errMsg, 
 	slog.Warn("task failed", "task_id", util.UUIDToString(task.ID), "issue_id", util.UUIDToString(task.IssueID), "error", errMsg, "failure_reason", failureReason)
 	s.captureTaskFailed(ctx, task)
 
-	// The auto-retry child (if any) was created inside the transaction above so
-	// no newer chat task could jump ahead of it. Surface it now: broadcast
-	// queued first, then notify the daemon — see EnqueueTaskForIssue for the
-	// ordering rationale. A deferred child (backoff armed via fire_at) is NOT
-	// queued yet: PromoteDueDeferredTasksForRuntime emits its queued event and
-	// daemon wakeup when fire_at arrives, so announcing it here would be wrong.
+	// Replay any comment dropped while this run was in flight before waking the
+	// daemon. The auto-retry child (if any) was created inside the transaction
+	// above and is still queued — no daemon has seen it yet. Reconciling first
+	// merges an undelivered comment into that queued child instead of racing
+	// with the daemon claim that NotifyTaskEnqueued triggers below. With no
+	// retry child it earns one fresh follow-up. Idempotent re-callbacks returned
+	// early above and never reach here, so a missed reconciliation is recovered
+	// on the next retry of this callback (see early-exit path above).
+	s.reconcileTerminal(ctx, &task)
+
+	// Announce the retry child now that reconciliation has settled its plan.
+	// Broadcast queued first, then notify the daemon — see EnqueueTaskForIssue
+	// for the ordering rationale. A deferred child (backoff armed via fire_at)
+	// is NOT queued yet: PromoteDueDeferredTasksForRuntime emits its queued
+	// event and daemon wakeup when fire_at arrives, so announcing it here would
+	// be wrong.
 	if retried != nil {
 		slog.Info("task auto-retry enqueued",
 			"parent_task_id", util.UUIDToString(task.ID),
@@ -5302,14 +5385,11 @@ func (s *TaskService) MaybeRetryFailedTask(ctx context.Context, parent db.AgentT
 		"max_attempts", child.MaxAttempts,
 		"status", child.Status,
 	)
-	// A queued child transitions ∅ → queued (same as EnqueueTaskFor*): broadcast
-	// queued first, then notify the daemon — see EnqueueTaskForIssue for ordering
-	// rationale. A deferred child (backoff armed) stays inert until
-	// PromoteDueDeferredTasksForRuntime fires its queued event + wakeup.
-	if child.Status == "queued" {
-		s.broadcastTaskEvent(ctx, protocol.EventTaskQueued, child)
-		s.NotifyTaskEnqueued(ctx, child)
-	}
+	// Announcement (broadcast + NotifyTaskEnqueued) is deliberately deferred to
+	// the caller. HandleFailedTasks must reconcile dropped comment triggers into
+	// the queued child BEFORE the daemon learns about it — if we announced here
+	// the daemon could claim (queued → dispatched) before reconciliation, and
+	// MergeCommentIntoPendingTask would silently skip the already-dispatched row.
 	return &child, nil
 }
 
@@ -5626,10 +5706,15 @@ func (s *TaskService) HandleFailedTasks(ctx context.Context, tasks []db.AgentTas
 	retried := 0
 
 	for _, t := range tasks {
-		// Auto-retry first so the issue stays in_progress rather than
-		// flapping todo → in_progress within a tick.
+		// Create the retry child first (without announcing it) so the issue stays
+		// in_progress rather than flapping todo → in_progress within a tick. The
+		// announce is deferred to after reconcileTerminal below so a dropped
+		// comment can be merged into the queued child while it is still
+		// unclaimable (#5278). retryPending gates the task:failed event's
+		// "will retry" hint (main) and must be set for the deferred child too.
 		retryPending := false
-		if child, _ := s.MaybeRetryFailedTask(ctx, t); child != nil {
+		child, _ := s.MaybeRetryFailedTask(ctx, t)
+		if child != nil {
 			retryPending = true
 			retried++
 			if t.IssueID.Valid {
@@ -5644,6 +5729,20 @@ func (s *TaskService) HandleFailedTasks(ctx context.Context, tasks []db.AgentTas
 					"error", err,
 				)
 			}
+		}
+
+		// Reconcile BEFORE announcing the retry child. MaybeRetryFailedTask no
+		// longer broadcasts or calls NotifyTaskEnqueued — that deferred the daemon
+		// wakeup to here, so we can safely merge any dropped comment into the
+		// queued row while it is still unclaimed.
+		s.reconcileTerminal(ctx, &t)
+
+		// Announce the retry child now that its comment plan is settled. A
+		// deferred child (fire_at set) stays inert until
+		// PromoteDueDeferredTasksForRuntime fires its queued event.
+		if child != nil && child.Status == "queued" {
+			s.broadcastTaskEvent(ctx, protocol.EventTaskQueued, *child)
+			s.NotifyTaskEnqueued(ctx, *child)
 		}
 
 		failureReason := "agent_error"

--- a/server/internal/service/task.go
+++ b/server/internal/service/task.go
@@ -2882,7 +2882,11 @@ func (s *TaskService) CancelTaskWithResult(ctx context.Context, taskID pgtype.UU
 		// The task was already terminal when this call arrived. If this is a
 		// retry of a callback that committed the cancel but crashed before
 		// reconciling, re-enter reconciliation so the deferred comment survives.
-		if opts.UserInitiated {
+		// Guard on status: CancelAgentTask returns ErrNoRows for ANY non-active
+		// task (completed and failed included), so only reconcile when the task
+		// really was cancelled — not when a stale cancel races a concurrent
+		// complete/fail that already ran its own reconcileTerminal.
+		if opts.UserInitiated && existing.Status == "cancelled" {
 			s.reconcileTerminal(ctx, &existing)
 		}
 		return &CancelTaskResult{Task: existing}, nil

--- a/server/internal/service/task.go
+++ b/server/internal/service/task.go
@@ -71,6 +71,20 @@ type TaskService struct {
 	quickActionsInFlight sync.Map
 	quickActionsRunning  atomic.Int64
 
+	// ReconcileTerminal replays comment triggers a run did NOT deliver, once
+	// the task has freshly left the active set through a path that should allow
+	// subsequent work (complete / fail / user-cancel / sweeper fail / orphan
+	// recovery). The comment-routing logic lives in the handler layer, so this
+	// is an injected seam (like Composio / Wakeup): the handler wires it to its
+	// reconcileCommentsOnCompletion in New, and main.go wires the sweeper's
+	// TaskService to the same method. Nil is valid and disables replay — and it
+	// is deliberately left nil on the bulk-cleanup paths (issue delete,
+	// comment edit/delete re-routing, agent "cancel all") which must NOT enqueue
+	// replacement work. The callee is itself a no-op for tasks without a valid
+	// issue / agent / creation timestamp, and loop-safe (created_at anchor +
+	// delivered-set exclusion), so double invocation cannot duplicate a run.
+	ReconcileTerminal TerminalTaskReconciler
+
 	analyticsContextMu    sync.Mutex
 	analyticsContextCache map[string]analytics.TaskContext
 	analyticsContextOrder []string
@@ -99,6 +113,23 @@ type ComposioOverlayBuilder interface {
 
 type TaskWakeupNotifier interface {
 	NotifyTaskAvailable(runtimeID, taskID string)
+}
+
+// TerminalTaskReconciler replays any comment triggers a task did NOT deliver
+// after it leaves the active set on a path that should allow subsequent work.
+// It is the single shared post-terminal entry point the handler and the
+// background/sweeper paths both funnel through (see TaskService.ReconcileTerminal).
+type TerminalTaskReconciler func(ctx context.Context, task *db.AgentTaskQueue)
+
+// reconcileTerminal invokes the injected post-terminal reconciler when one is
+// wired. It is called only after a successful terminal transition and, on the
+// fail paths, only after the auto-retry child has been created — so an
+// undelivered comment merges into that queued retry instead of spawning a
+// duplicate run.
+func (s *TaskService) reconcileTerminal(ctx context.Context, task *db.AgentTaskQueue) {
+	if s.ReconcileTerminal != nil {
+		s.ReconcileTerminal(ctx, task)
+	}
 }
 
 // triggerSummaryMaxLen caps the snapshot length so the row stays cheap to
@@ -2216,6 +2247,15 @@ type CancelTaskOptions struct {
 	QueuedOnly          bool
 	ExpectedChatSession pgtype.UUID
 	QueueAction         string
+	// ReconcileDeferredComments replays comment triggers this run did not deliver
+	// after the cancel (#5278). Set ONLY by the genuine user-facing cancels (the
+	// issue-scoped daemon cancel and CancelTaskByUser) — the run is over and a
+	// deferred @agent hand-off must survive. It is deliberately left false on the
+	// internal claim-time hard-fail cancels (workspace-isolation / missing runtime
+	// owner / stale-plan repair in daemon.go): those reject a claim before the run
+	// starts and must NOT enqueue replacement agent work, which would otherwise
+	// re-dispatch into the same failure and loop.
+	ReconcileDeferredComments bool
 }
 
 // CancelTask cancels a single task by ID. It broadcasts a task:cancelled event
@@ -2291,6 +2331,12 @@ func (s *TaskService) CancelTaskWithResult(ctx context.Context, taskID pgtype.UU
 		if err != nil {
 			return nil, fmt.Errorf("cancel task: %w", err)
 		}
+		// The task was already terminal when this call arrived. If this is a
+		// retry of a callback that committed the cancel but crashed before
+		// reconciling, re-enter reconciliation so the deferred comment survives.
+		if opts.ReconcileDeferredComments {
+			s.reconcileTerminal(ctx, &existing)
+		}
 		return &CancelTaskResult{Task: existing}, nil
 	}
 	if err != nil {
@@ -2309,6 +2355,18 @@ func (s *TaskService) CancelTaskWithResult(ctx context.Context, taskID pgtype.UU
 	// Broadcast cancellation as a task:failed event so frontends clear the live card
 	s.broadcastTaskEvent(ctx, protocol.EventTaskCancelled, task)
 	s.NotifyTaskFinished(task)
+
+	// A user-facing single-task cancel is terminal with no auto-retry, so replay
+	// any comment deferred while this run held the active slot. Gated on the
+	// caller's intent (opts.ReconcileDeferredComments): the internal claim-time
+	// hard-fail cancels leave it false so a rejected claim never enqueues
+	// replacement work. No-op anyway for chat-only tasks (no issue), and reached
+	// only after a real cancel — an already-finalized task returned early above.
+	// The bulk cancels — issue delete, comment edit/delete re-routing, agent
+	// "cancel all" — never route through this method.
+	if opts.ReconcileDeferredComments {
+		s.reconcileTerminal(ctx, &task)
+	}
 
 	return &CancelTaskResult{
 		Task:                 task,
@@ -3478,6 +3536,12 @@ func (s *TaskService) CompleteTask(ctx context.Context, taskID pgtype.UUID, resu
 					"current_status", existing.Status,
 					"agent_id", util.UUIDToString(existing.AgentID),
 				)
+				// Recover a missed reconciliation: if this is a retry of a
+				// callback that committed the completion but crashed before
+				// reconciling, re-enter reconciliation so no deferred comment
+				// is stranded. reconcileTerminal is idempotent — a comment
+				// already in a queued task's plan is not duplicated.
+				s.reconcileTerminal(ctx, &existing)
 				return &existing, nil
 			}
 			slog.Warn("complete task failed",
@@ -3588,6 +3652,11 @@ func (s *TaskService) CompleteTask(ctx context.Context, taskID pgtype.UUID, resu
 
 	// Broadcast
 	s.broadcastTaskEvent(ctx, protocol.EventTaskCompleted, task)
+
+	// Replay any comment that landed while this run was busy and was deferred to
+	// completion-time reconciliation (MUL-4195 / MUL-4304). Shared with the fail
+	// / cancel terminal paths via the injected reconciler.
+	s.reconcileTerminal(ctx, &task)
 
 	return &task, nil
 }
@@ -4002,6 +4071,11 @@ func (s *TaskService) FailTask(ctx context.Context, taskID pgtype.UUID, errMsg, 
 					"current_status", existing.Status,
 					"agent_id", util.UUIDToString(existing.AgentID),
 				)
+				// Recover a missed reconciliation: if this is a retry of a
+				// callback that committed the failure but crashed before
+				// reconciling, re-enter reconciliation so no deferred comment
+				// is stranded. reconcileTerminal is idempotent.
+				s.reconcileTerminal(ctx, &existing)
 				return &existing, nil
 			}
 			slog.Warn("fail task failed",
@@ -4024,12 +4098,22 @@ func (s *TaskService) FailTask(ctx context.Context, taskID pgtype.UUID, errMsg, 
 	slog.Warn("task failed", "task_id", util.UUIDToString(task.ID), "issue_id", util.UUIDToString(task.IssueID), "error", errMsg, "failure_reason", failureReason)
 	s.captureTaskFailed(ctx, task)
 
-	// The auto-retry child (if any) was created inside the transaction above so
-	// no newer chat task could jump ahead of it. Surface it now: broadcast
-	// queued first, then notify the daemon — see EnqueueTaskForIssue for the
-	// ordering rationale. A deferred child (backoff armed via fire_at) is NOT
-	// queued yet: PromoteDueDeferredTasksForRuntime emits its queued event and
-	// daemon wakeup when fire_at arrives, so announcing it here would be wrong.
+	// Replay any comment dropped while this run was in flight before waking the
+	// daemon. The auto-retry child (if any) was created inside the transaction
+	// above and is still queued — no daemon has seen it yet. Reconciling first
+	// merges an undelivered comment into that queued child instead of racing
+	// with the daemon claim that NotifyTaskEnqueued triggers below. With no
+	// retry child it earns one fresh follow-up. Idempotent re-callbacks returned
+	// early above and never reach here, so a missed reconciliation is recovered
+	// on the next retry of this callback (see early-exit path above).
+	s.reconcileTerminal(ctx, &task)
+
+	// Announce the retry child now that reconciliation has settled its plan.
+	// Broadcast queued first, then notify the daemon — see EnqueueTaskForIssue
+	// for the ordering rationale. A deferred child (backoff armed via fire_at)
+	// is NOT queued yet: PromoteDueDeferredTasksForRuntime emits its queued
+	// event and daemon wakeup when fire_at arrives, so announcing it here would
+	// be wrong.
 	if retried != nil {
 		slog.Info("task auto-retry enqueued",
 			"parent_task_id", util.UUIDToString(task.ID),
@@ -4299,14 +4383,11 @@ func (s *TaskService) MaybeRetryFailedTask(ctx context.Context, parent db.AgentT
 		"max_attempts", child.MaxAttempts,
 		"status", child.Status,
 	)
-	// A queued child transitions ∅ → queued (same as EnqueueTaskFor*): broadcast
-	// queued first, then notify the daemon — see EnqueueTaskForIssue for ordering
-	// rationale. A deferred child (backoff armed) stays inert until
-	// PromoteDueDeferredTasksForRuntime fires its queued event + wakeup.
-	if child.Status == "queued" {
-		s.broadcastTaskEvent(ctx, protocol.EventTaskQueued, child)
-		s.NotifyTaskEnqueued(ctx, child)
-	}
+	// Announcement (broadcast + NotifyTaskEnqueued) is deliberately deferred to
+	// the caller. HandleFailedTasks must reconcile dropped comment triggers into
+	// the queued child BEFORE the daemon learns about it — if we announced here
+	// the daemon could claim (queued → dispatched) before reconciliation, and
+	// MergeCommentIntoPendingTask would silently skip the already-dispatched row.
 	return &child, nil
 }
 
@@ -4567,15 +4648,34 @@ func (s *TaskService) HandleFailedTasks(ctx context.Context, tasks []db.AgentTas
 	retried := 0
 
 	for _, t := range tasks {
-		// Auto-retry first so the issue stays in_progress rather than
-		// flapping todo → in_progress within a tick.
+		// Create the retry child first (without announcing it) so the issue stays
+		// in_progress rather than flapping todo → in_progress within a tick. The
+		// announce is deferred to after reconcileTerminal below so a dropped
+		// comment can be merged into the queued child while it is still
+		// unclaimable (#5278). retryPending gates the task:failed event's
+		// "will retry" hint (main) and must be set for the deferred child too.
 		retryPending := false
-		if child, _ := s.MaybeRetryFailedTask(ctx, t); child != nil {
+		child, _ := s.MaybeRetryFailedTask(ctx, t)
+		if child != nil {
 			retryPending = true
 			retried++
 			if t.IssueID.Valid {
 				retriedIssues[util.UUIDToString(t.IssueID)] = true
 			}
+		}
+
+		// Reconcile BEFORE announcing the retry child. MaybeRetryFailedTask no
+		// longer broadcasts or calls NotifyTaskEnqueued — that deferred the daemon
+		// wakeup to here, so we can safely merge any dropped comment into the
+		// queued row while it is still unclaimed.
+		s.reconcileTerminal(ctx, &t)
+
+		// Announce the retry child now that its comment plan is settled. A
+		// deferred child (fire_at set) stays inert until
+		// PromoteDueDeferredTasksForRuntime fires its queued event.
+		if child != nil && child.Status == "queued" {
+			s.broadcastTaskEvent(ctx, protocol.EventTaskQueued, *child)
+			s.NotifyTaskEnqueued(ctx, *child)
 		}
 
 		failureReason := "agent_error"

--- a/server/internal/service/task.go
+++ b/server/internal/service/task.go
@@ -2334,7 +2334,11 @@ func (s *TaskService) CancelTaskWithResult(ctx context.Context, taskID pgtype.UU
 		// The task was already terminal when this call arrived. If this is a
 		// retry of a callback that committed the cancel but crashed before
 		// reconciling, re-enter reconciliation so the deferred comment survives.
-		if opts.ReconcileDeferredComments {
+		// Guard on status: CancelAgentTask returns ErrNoRows for ANY non-active
+		// task (completed and failed included), so only reconcile when the task
+		// really was cancelled — not when a stale cancel races a concurrent
+		// complete/fail that already ran its own reconcileTerminal.
+		if opts.ReconcileDeferredComments && existing.Status == "cancelled" {
 			s.reconcileTerminal(ctx, &existing)
 		}
 		return &CancelTaskResult{Task: existing}, nil


### PR DESCRIPTION
## Summary

Reconciliation of comment triggers a run did **not** deliver used to run only in `CompleteTask`. A dropped `@agent` hand-off — a mention that merge-missed while the target was already dispatched/running and was deferred to terminal reconciliation — was therefore lost on every **non-success** terminal transition: the HTTP fail callback, the generic user-cancel route, and the runtime/stale sweepers + orphan recovery. In an agent-to-agent workflow the hand-off silently vanishes with no task, retry, or error.

Fixes #5278.

## Design: one shared post-terminal entry point

Rather than sprinkling reconcile calls at each call site, `TaskService` gains a single injected seam, `ReconcileTerminal` (same pattern as `Composio` / `Wakeup`). The comment-routing logic lives in the handler, so the handler wires the seam to `reconcileCommentsOnCompletion` in `New`, and `cmd/server` wires the sweeper's **separate** `TaskService` instance to the same exported `Handler.ReconcileTerminalTask`. This keeps the `handler → service` dependency direction intact (no `service` import of `handler`).

The seam is invoked from the service-layer terminal transitions:

| Path | Method | Covers |
| --- | --- | --- |
| success | `CompleteTask` | daemon complete callback |
| fail | `FailTask` | daemon fail callback |
| cancel | `CancelTaskWithResult` | issue-scoped daemon cancel **and** the generic `POST /api/tasks/{id}/cancel` used by CLI / mobile / Chat / Activity |
| sweeper / recovery | `HandleFailedTasks` | `FailTasksForOfflineRuntimes`, `FailStaleTasks`, orphan recovery |

### Contracts honored

1. Runs only after a **successful** terminal transition, with the returned terminal row.
2. On the fail paths it runs **after** the auto-retry child is created, so an undelivered comment **merges into the queued retry** instead of duplicating it (`FailTask` builds the child in-tx; `HandleFailedTasks` calls `MaybeRetryFailedTask` first). With no retry it earns one fresh follow-up.
3. No-op for tasks without a valid issue / agent / creation timestamp (chat-only cancels included).
4. Idempotent re-callbacks return early (already-finalized) **before** the seam fires, so a repeated terminal callback adds no second task and no duplicate coalesced id.
5. The bulk-cleanup paths — issue delete (`CancelTasksForIssue`), comment edit/delete re-routing (`CancelTasksByTriggerComment`), agent "cancel all" (`CancelTasksForAgent`) — deliberately **bypass** the seam, so an explicit stop never enqueues replacement work.
6. Author-loop guard preserved: only the agent that just ran is replayed; the mention's author is never enqueued.

## Tests

`server/internal/handler/daemon_terminal_reconcile_test.go` drives the real service/handler paths on the #5278 dropped-mention fixture. Each **fails before the change and passes after**:

- non-retryable HTTP fail → one fresh follow-up
- retryable HTTP fail (`timeout`) → dropped mention merged into the single queued retry child
- issue-scoped daemon cancel
- generic user cancel (`CancelTaskByUser`)
- sweeper `runtime_offline` via `HandleFailedTasks` → merged into retry child
- sweeper non-retryable via `HandleFailedTasks` → one fresh follow-up
- idempotent double fail callback → still exactly one follow-up, mention present once

`go test ./internal/handler ./internal/service ./cmd/server` all pass; upstream `TestTerminalTransitionsNotifyRuntime` still green; `gofmt` clean.
