### PR TITLE
fix(autopilot): coalesce overlapping schedule runs

### DIFF
--- a/packages/core/api/client.test.ts
+++ b/packages/core/api/client.test.ts
@@ -168,8 +168,9 @@ describe("ApiClient", () => {
       kind: "schedule",
       cron_expression: "0 9 * * *",
       timezone: "UTC",
+      overlapPolicy: "coalesce",
     });
-    await client.updateAutopilotTrigger("ap-1", "tr-1", { enabled: false });
+    await client.updateAutopilotTrigger("ap-1", "tr-1", { enabled: false, overlapPolicy: "allow" });
     await client.deleteAutopilotTrigger("ap-1", "tr-1");
     await client.rotateAutopilotTriggerWebhookToken("ap-1", "tr-1");
 
@@ -207,12 +208,13 @@ describe("ApiClient", () => {
           kind: "schedule",
           cron_expression: "0 9 * * *",
           timezone: "UTC",
+          overlap_policy: "coalesce",
         }),
       },
       {
         url: "https://api.example.test/api/autopilots/ap-1/triggers/tr-1",
         method: "PATCH",
-        body: JSON.stringify({ enabled: false }),
+        body: JSON.stringify({ enabled: false, overlap_policy: "allow" }),
       },
       { url: "https://api.example.test/api/autopilots/ap-1/triggers/tr-1", method: "DELETE" },
       {

--- a/packages/core/api/client.ts
+++ b/packages/core/api/client.ts
@@ -186,10 +186,14 @@ import {
   EMPTY_USER,
   EMPTY_LIST_WEBHOOK_DELIVERIES_RESPONSE,
   EMPTY_WEBHOOK_DELIVERY,
+  EMPTY_AUTOPILOT_TRIGGER,
+  EMPTY_GET_AUTOPILOT_RESPONSE,
   AppConfigSchema,
   type AppConfigResponse,
   GroupedIssuesResponseSchema,
   ListAutopilotsResponseSchema,
+  AutopilotTriggerResponseSchema,
+  GetAutopilotResponseSchema,
   EMPTY_LIST_AUTOPILOTS_RESPONSE,
   ListIssuesResponseSchema,
   ListWebhookDeliveriesResponseSchema,
@@ -296,6 +300,16 @@ export class PreviewUnsupportedError extends Error {
     super("attachment type not supported for inline preview");
     this.name = "PreviewUnsupportedError";
   }
+}
+
+function toAutopilotTriggerWireRequest(
+  data: CreateAutopilotTriggerRequest | UpdateAutopilotTriggerRequest,
+): Record<string, unknown> {
+  const { overlapPolicy, ...wire } = data;
+  if (overlapPolicy !== undefined) {
+    return { ...wire, overlap_policy: overlapPolicy };
+  }
+  return wire;
 }
 
 export class ApiClient {
@@ -2250,7 +2264,10 @@ export class ApiClient {
   }
 
   async getAutopilot(id: string): Promise<GetAutopilotResponse> {
-    return this.fetch(`/api/autopilots/${id}`);
+    const raw = await this.fetch<unknown>(`/api/autopilots/${id}`);
+    return parseWithFallback(raw, GetAutopilotResponseSchema, EMPTY_GET_AUTOPILOT_RESPONSE, {
+      endpoint: "GET /api/autopilots/:id",
+    }) as GetAutopilotResponse;
   }
 
   async createAutopilot(data: CreateAutopilotRequest): Promise<Autopilot> {
@@ -2306,16 +2323,22 @@ export class ApiClient {
   }
 
   async createAutopilotTrigger(autopilotId: string, data: CreateAutopilotTriggerRequest): Promise<AutopilotTrigger> {
-    return this.fetch(`/api/autopilots/${autopilotId}/triggers`, {
+    const raw = await this.fetch<unknown>(`/api/autopilots/${autopilotId}/triggers`, {
       method: "POST",
-      body: JSON.stringify(data),
+      body: JSON.stringify(toAutopilotTriggerWireRequest(data)),
+    });
+    return parseWithFallback(raw, AutopilotTriggerResponseSchema, EMPTY_AUTOPILOT_TRIGGER, {
+      endpoint: "POST /api/autopilots/:id/triggers",
     });
   }
 
   async updateAutopilotTrigger(autopilotId: string, triggerId: string, data: UpdateAutopilotTriggerRequest): Promise<AutopilotTrigger> {
-    return this.fetch(`/api/autopilots/${autopilotId}/triggers/${triggerId}`, {
+    const raw = await this.fetch<unknown>(`/api/autopilots/${autopilotId}/triggers/${triggerId}`, {
       method: "PATCH",
-      body: JSON.stringify(data),
+      body: JSON.stringify(toAutopilotTriggerWireRequest(data)),
+    });
+    return parseWithFallback(raw, AutopilotTriggerResponseSchema, EMPTY_AUTOPILOT_TRIGGER, {
+      endpoint: "PATCH /api/autopilots/:id/triggers/:triggerId",
     });
   }
 
@@ -2327,10 +2350,13 @@ export class ApiClient {
     autopilotId: string,
     triggerId: string,
   ): Promise<AutopilotTrigger> {
-    return this.fetch(
+    const raw = await this.fetch<unknown>(
       `/api/autopilots/${autopilotId}/triggers/${triggerId}/rotate-webhook-token`,
       { method: "POST" },
     );
+    return parseWithFallback(raw, AutopilotTriggerResponseSchema, EMPTY_AUTOPILOT_TRIGGER, {
+      endpoint: "POST /api/autopilots/:id/triggers/:triggerId/rotate-webhook-token",
+    });
   }
 
   // Webhook deliveries — list is slim (no raw_body / selected_headers /

--- a/packages/core/api/schemas.test.ts
+++ b/packages/core/api/schemas.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
   AppConfigSchema,
+  AutopilotTriggerResponseSchema,
   AgentTaskListSchema,
   DashboardAgentRunTimeListSchema,
   DashboardUsageByAgentListSchema,
@@ -8,10 +9,13 @@ import {
   CreateFeedbackResponseSchema,
   DuplicateIssueErrorBodySchema,
   EMPTY_CREATE_FEEDBACK_RESPONSE,
+  EMPTY_AUTOPILOT_TRIGGER,
+  EMPTY_GET_AUTOPILOT_RESPONSE,
   EMPTY_INBOX_UNREAD_SUMMARY,
   EMPTY_SEARCH_PROJECTS_RESPONSE,
   EMPTY_USER,
   InboxUnreadSummarySchema,
+  GetAutopilotResponseSchema,
   IssueTriggerPreviewSchema,
   ListIssuesResponseSchema,
   SearchProjectsResponseSchema,
@@ -627,5 +631,95 @@ describe("SearchProjectsResponseSchema date drift", () => {
     expect(parsed.projects).toHaveLength(1);
     expect(parsed.projects[0]?.start_date).toBeNull();
     expect(parsed.projects[0]?.due_date).toBeNull();
+  });
+});
+
+describe("AutopilotTriggerResponseSchema", () => {
+  const ENDPOINT = { endpoint: "POST /api/autopilots/:id/triggers" };
+  const baseTrigger = {
+    id: "trigger-1",
+    autopilot_id: "autopilot-1",
+    kind: "schedule",
+    enabled: true,
+    cron_expression: "*/5 * * * *",
+    timezone: "UTC",
+    next_run_at: "2026-07-13T17:05:00Z",
+    webhook_token: null,
+    label: null,
+    last_fired_at: null,
+    created_at: "2026-07-13T17:00:00Z",
+    updated_at: "2026-07-13T17:00:00Z",
+  };
+
+  it("converts overlap_policy to camelCase", () => {
+    const parsed = parseWithFallback(
+      { ...baseTrigger, overlap_policy: "coalesce" },
+      AutopilotTriggerResponseSchema,
+      EMPTY_AUTOPILOT_TRIGGER,
+      ENDPOINT,
+    );
+    expect(parsed.overlapPolicy).toBe("coalesce");
+    expect(parsed).not.toHaveProperty("overlap_policy");
+  });
+
+  it("defaults an older server response to allow", () => {
+    const parsed = parseWithFallback(
+      baseTrigger,
+      AutopilotTriggerResponseSchema,
+      EMPTY_AUTOPILOT_TRIGGER,
+      ENDPOINT,
+    );
+    expect(parsed.overlapPolicy).toBe("allow");
+  });
+
+  it("falls back for a malformed overlap policy shape", () => {
+    const parsed = parseWithFallback(
+      { ...baseTrigger, overlap_policy: 42 },
+      AutopilotTriggerResponseSchema,
+      EMPTY_AUTOPILOT_TRIGGER,
+      ENDPOINT,
+    );
+    expect(parsed).toBe(EMPTY_AUTOPILOT_TRIGGER);
+  });
+});
+
+describe("GetAutopilotResponseSchema", () => {
+  it("normalizes nested trigger overlap policies", () => {
+    const trigger = {
+      id: "trigger-1",
+      autopilot_id: "autopilot-1",
+      kind: "schedule",
+      enabled: true,
+      cron_expression: "*/5 * * * *",
+      timezone: "UTC",
+      overlap_policy: "coalesce",
+      next_run_at: null,
+      webhook_token: null,
+      label: null,
+      last_fired_at: null,
+      created_at: "2026-07-13T17:00:00Z",
+      updated_at: "2026-07-13T17:00:00Z",
+    };
+    const autopilot = {
+      ...EMPTY_GET_AUTOPILOT_RESPONSE.autopilot,
+      id: "autopilot-1",
+      workspace_id: "workspace-1",
+      title: "Scheduled delivery",
+      assignee_id: "agent-1",
+      created_by_type: "member",
+      created_by_id: "user-1",
+      created_at: "2026-07-13T17:00:00Z",
+      updated_at: "2026-07-13T17:00:00Z",
+    };
+
+    const parsed = parseWithFallback(
+      { autopilot, triggers: [trigger] },
+      GetAutopilotResponseSchema,
+      EMPTY_GET_AUTOPILOT_RESPONSE,
+      { endpoint: "GET /api/autopilots/:id" },
+    );
+
+    expect(parsed.triggers[0]?.overlapPolicy).toBe("coalesce");
+    expect(parsed.triggers[0]).not.toHaveProperty("overlap_policy");
   });
 });

--- a/packages/core/api/schemas.ts
+++ b/packages/core/api/schemas.ts
@@ -5,6 +5,7 @@ import type {
   AgentTemplateSummary,
   AgentBuilderSession,
   Attachment,
+  AutopilotTrigger,
   BillingBalance,
   BillingBatchesPage,
   BillingCheckoutSessionStatus,
@@ -15,6 +16,7 @@ import type {
   CreateAgentFromTemplateResponse,
   CreateBillingCheckoutSessionResponse,
   CreateBillingPortalSessionResponse,
+  GetAutopilotResponse,
   GroupedIssuesResponse,
   InboxWorkspaceUnread,
   Label,
@@ -988,6 +990,80 @@ export const ListAutopilotsResponseSchema = z.object({
 export const EMPTY_LIST_AUTOPILOTS_RESPONSE = {
   autopilots: [],
   total: 0,
+};
+
+// Trigger responses keep their established wire fields while converting the
+// new overlap policy to camelCase at the TypeScript boundary. Older servers
+// omit overlap_policy; their behavior is the backward-compatible `allow`.
+export const AutopilotTriggerResponseSchema = z.object({
+  id: z.string(),
+  autopilot_id: z.string(),
+  kind: z.string(),
+  enabled: z.boolean(),
+  cron_expression: z.string().nullable(),
+  timezone: z.string().nullable(),
+  overlap_policy: z.string().default("allow"),
+  next_run_at: z.string().nullable(),
+  webhook_token: z.string().nullable(),
+  webhook_path: z.string().nullable().optional(),
+  webhook_url: z.string().nullable().optional(),
+  label: z.string().nullable(),
+  event_filters: z.array(z.unknown()).nullable().optional(),
+  last_fired_at: z.string().nullable(),
+  created_at: z.string(),
+  updated_at: z.string(),
+}).loose().transform(({ overlap_policy, ...trigger }) => ({
+  ...trigger,
+  overlapPolicy: overlap_policy,
+}));
+
+export const EMPTY_AUTOPILOT_TRIGGER: AutopilotTrigger = {
+  id: "",
+  autopilot_id: "",
+  kind: "schedule",
+  enabled: false,
+  cron_expression: null,
+  timezone: null,
+  overlapPolicy: "allow",
+  next_run_at: null,
+  webhook_token: null,
+  label: null,
+  last_fired_at: null,
+  created_at: "",
+  updated_at: "",
+};
+
+const AutopilotCollaboratorSchema = z.object({
+  user_type: z.literal("member"),
+  user_id: z.string(),
+  granted_by: z.string(),
+  created_at: z.string(),
+}).loose();
+
+export const GetAutopilotResponseSchema = z.object({
+  autopilot: AutopilotListItemSchema,
+  triggers: z.array(AutopilotTriggerResponseSchema).default([]),
+  collaborators: z.array(AutopilotCollaboratorSchema).optional(),
+}).loose();
+
+export const EMPTY_GET_AUTOPILOT_RESPONSE: GetAutopilotResponse = {
+  autopilot: {
+    id: "",
+    workspace_id: "",
+    title: "",
+    description: null,
+    assignee_type: "agent",
+    assignee_id: "",
+    status: "active",
+    execution_mode: "run_only",
+    issue_title_template: null,
+    created_by_type: "",
+    created_by_id: "",
+    last_run_at: null,
+    created_at: "",
+    updated_at: "",
+  },
+  triggers: [],
 };
 
 export const EMPTY_WEBHOOK_DELIVERY: WebhookDelivery = {

--- a/packages/core/autopilots/webhook.test.ts
+++ b/packages/core/autopilots/webhook.test.ts
@@ -9,6 +9,7 @@ const baseTrigger: AutopilotTrigger = {
   enabled: true,
   cron_expression: null,
   timezone: null,
+  overlapPolicy: "allow",
   next_run_at: null,
   webhook_token: "awt_abc",
   webhook_path: "/api/webhooks/autopilots/awt_abc",

--- a/packages/core/types/autopilot.ts
+++ b/packages/core/types/autopilot.ts
@@ -9,6 +9,7 @@ export type AutopilotExecutionMode = "create_issue" | "run_only";
 export type AutopilotAssigneeType = "agent" | "squad";
 
 export type AutopilotTriggerKind = "schedule" | "webhook" | "api";
+export type AutopilotOverlapPolicy = "allow" | "coalesce";
 
 // `skipped` is emitted by the backend pre-flight admission check
 // (assignee runtime offline at dispatch time, MUL-1899). The frontend MUST
@@ -92,6 +93,7 @@ export interface AutopilotTrigger {
   enabled: boolean;
   cron_expression: string | null;
   timezone: string | null;
+  overlapPolicy: AutopilotOverlapPolicy;
   next_run_at: string | null;
   webhook_token: string | null;
   // webhook_path is computed server-side from webhook_token (always
@@ -165,6 +167,7 @@ export interface CreateAutopilotTriggerRequest {
   kind: AutopilotTriggerKind;
   cron_expression?: string;
   timezone?: string;
+  overlapPolicy?: AutopilotOverlapPolicy;
   label?: string;
   // event_filters is only meaningful for webhook triggers.
   event_filters?: WebhookEventFilter[];
@@ -174,6 +177,7 @@ export interface UpdateAutopilotTriggerRequest {
   enabled?: boolean;
   cron_expression?: string;
   timezone?: string;
+  overlapPolicy?: AutopilotOverlapPolicy;
   label?: string;
   // event_filters is only meaningful for webhook triggers.
   event_filters?: WebhookEventFilter[] | null;

--- a/packages/core/types/index.ts
+++ b/packages/core/types/index.ts
@@ -149,6 +149,7 @@ export type {
   AutopilotCollaboratorsResponse,
   AutopilotTrigger,
   AutopilotTriggerKind,
+  AutopilotOverlapPolicy,
   AutopilotRun,
   AutopilotRunStatus,
   AutopilotRunSource,

--- a/server/cmd/multica/cmd_autopilot.go
+++ b/server/cmd/multica/cmd_autopilot.go
@@ -155,6 +155,7 @@ func init() {
 	autopilotTriggerAddCmd.Flags().String("kind", "schedule", "Trigger kind: schedule or webhook")
 	autopilotTriggerAddCmd.Flags().String("cron", "", "Cron expression (required for --kind schedule)")
 	autopilotTriggerAddCmd.Flags().String("timezone", "", "IANA timezone (default UTC; schedule only)")
+	autopilotTriggerAddCmd.Flags().String("overlap-policy", "allow", "Schedule overlap policy: allow or coalesce")
 	autopilotTriggerAddCmd.Flags().String("label", "", "Optional human-readable label")
 	autopilotTriggerAddCmd.Flags().String("output", "json", "Output format: table or json")
 
@@ -166,6 +167,7 @@ func init() {
 	autopilotTriggerUpdateCmd.Flags().Bool("enabled", true, "Enable or disable the trigger")
 	autopilotTriggerUpdateCmd.Flags().String("cron", "", "New cron expression")
 	autopilotTriggerUpdateCmd.Flags().String("timezone", "", "New IANA timezone")
+	autopilotTriggerUpdateCmd.Flags().String("overlap-policy", "", "New schedule overlap policy: allow or coalesce")
 	autopilotTriggerUpdateCmd.Flags().String("label", "", "New label")
 	autopilotTriggerUpdateCmd.Flags().String("output", "json", "Output format: table or json")
 }
@@ -558,6 +560,9 @@ func runAutopilotTriggerAdd(cmd *cobra.Command, args []string) error {
 		if cron != "" {
 			return fmt.Errorf("--cron is only valid with --kind schedule")
 		}
+		if cmd.Flags().Changed("overlap-policy") {
+			return fmt.Errorf("--overlap-policy is only valid with --kind schedule")
+		}
 	}
 
 	body := map[string]any{"kind": kind}
@@ -566,6 +571,11 @@ func runAutopilotTriggerAdd(cmd *cobra.Command, args []string) error {
 		if v, _ := cmd.Flags().GetString("timezone"); v != "" {
 			body["timezone"] = v
 		}
+		overlapPolicy, _ := cmd.Flags().GetString("overlap-policy")
+		if overlapPolicy != "allow" && overlapPolicy != "coalesce" {
+			return fmt.Errorf("--overlap-policy must be allow or coalesce")
+		}
+		body["overlap_policy"] = overlapPolicy
 	}
 	if v, _ := cmd.Flags().GetString("label"); v != "" {
 		body["label"] = v
@@ -677,12 +687,19 @@ func runAutopilotTriggerUpdate(cmd *cobra.Command, args []string) error {
 		v, _ := cmd.Flags().GetString("timezone")
 		body["timezone"] = v
 	}
+	if cmd.Flags().Changed("overlap-policy") {
+		v, _ := cmd.Flags().GetString("overlap-policy")
+		if v != "allow" && v != "coalesce" {
+			return fmt.Errorf("--overlap-policy must be allow or coalesce")
+		}
+		body["overlap_policy"] = v
+	}
 	if cmd.Flags().Changed("label") {
 		v, _ := cmd.Flags().GetString("label")
 		body["label"] = v
 	}
 	if len(body) == 0 {
-		return fmt.Errorf("no fields to update; use --enabled, --cron, --timezone, or --label")
+		return fmt.Errorf("no fields to update; use --enabled, --cron, --timezone, --overlap-policy, or --label")
 	}
 
 	ctx, cancel := cli.APIContext(context.Background())

--- a/server/cmd/server/autopilot_dispatch_for_plan_test.go
+++ b/server/cmd/server/autopilot_dispatch_for_plan_test.go
@@ -12,6 +12,14 @@ import (
 	db "github.com/multica-ai/multica/server/pkg/db/generated"
 )
 
+type scheduleTestWakeup struct {
+	notifications chan string
+}
+
+func (w *scheduleTestWakeup) NotifyTaskAvailable(_, taskID string) {
+	w.notifications <- taskID
+}
+
 // TestDispatchAutopilotForPlanIsIdempotent locks in the
 // occurrence-level idempotency contract (MUL-3551):
 //
@@ -72,6 +80,9 @@ func TestDispatchAutopilotForPlanIsIdempotent(t *testing.T) {
 	})
 	if err != nil {
 		t.Fatalf("CreateAutopilotTrigger: %v", err)
+	}
+	if trigger.OverlapPolicy != "allow" {
+		t.Fatalf("schedule trigger must default overlap_policy=allow, got %q", trigger.OverlapPolicy)
 	}
 
 	// Use a fixed planned_at so the partial unique index has something
@@ -146,6 +157,231 @@ func TestDispatchAutopilotForPlanIsIdempotent(t *testing.T) {
 	}
 	if rowCount != 2 {
 		t.Fatalf("expected 2 autopilot_run rows after distinct planned_ats, got %d", rowCount)
+	}
+}
+
+func TestDispatchScheduledAutopilotForPlanCoalescesActiveRun(t *testing.T) {
+	ctx := context.Background()
+	queries := db.New(testPool)
+	bus := events.New()
+	taskSvc := service.NewTaskService(queries, testPool, nil, bus)
+	wakeups := &scheduleTestWakeup{notifications: make(chan string, 4)}
+	taskSvc.Wakeup = wakeups
+	autopilotSvc := service.NewAutopilotService(queries, testPool, bus, taskSvc)
+
+	var agentID string
+	if err := testPool.QueryRow(ctx,
+		`SELECT id::text FROM agent WHERE workspace_id = $1 ORDER BY created_at ASC LIMIT 1`,
+		testWorkspaceID,
+	).Scan(&agentID); err != nil {
+		t.Fatalf("load fixture agent: %v", err)
+	}
+
+	ap, err := queries.CreateAutopilot(ctx, db.CreateAutopilotParams{
+		WorkspaceID:        parseUUID(testWorkspaceID),
+		Title:              "Coalesce active scheduled run",
+		Description:        pgtype.Text{String: "single-flight schedule test", Valid: true},
+		AssigneeType:       "agent",
+		AssigneeID:         parseUUID(agentID),
+		Status:             "active",
+		ExecutionMode:      "run_only",
+		IssueTitleTemplate: pgtype.Text{},
+		CreatedByType:      "member",
+		CreatedByID:        parseUUID(testUserID),
+	})
+	if err != nil {
+		t.Fatalf("CreateAutopilot: %v", err)
+	}
+	t.Cleanup(func() {
+		if _, err := testPool.Exec(context.Background(),
+			`DELETE FROM autopilot WHERE id = $1`, ap.ID); err != nil {
+			t.Logf("cleanup autopilot: %v", err)
+		}
+	})
+
+	trigger, err := queries.CreateAutopilotTrigger(ctx, db.CreateAutopilotTriggerParams{
+		AutopilotID:    ap.ID,
+		Kind:           "schedule",
+		Enabled:        true,
+		CronExpression: pgtype.Text{String: "*/5 * * * *", Valid: true},
+		Timezone:       pgtype.Text{String: "UTC", Valid: true},
+		OverlapPolicy:  pgtype.Text{String: "coalesce", Valid: true},
+	})
+	if err != nil {
+		t.Fatalf("CreateAutopilotTrigger: %v", err)
+	}
+
+	firstPlan := time.Now().UTC().Truncate(time.Second).Add(-30 * time.Second)
+	first, err := autopilotSvc.DispatchScheduledAutopilotForPlan(
+		ctx, ap, trigger, "schedule", nil, firstPlan,
+	)
+	if err != nil {
+		t.Fatalf("first scheduled dispatch: %v", err)
+	}
+	if first.Coalesced {
+		t.Fatal("first scheduled dispatch must create work")
+	}
+	if first.Run == nil || !first.Run.TaskID.Valid {
+		t.Fatal("first scheduled dispatch must create a linked task")
+	}
+	select {
+	case <-wakeups.notifications:
+	default:
+		t.Fatal("first scheduled dispatch must wake the task runtime after commit")
+	}
+
+	// The caller can carry a stale pre-update snapshot. Live policy must be
+	// reloaded under the admission lock so allow -> coalesce cannot leak one
+	// extra run while the earlier task is active.
+	staleAllowTrigger := trigger
+	staleAllowTrigger.OverlapPolicy = "allow"
+	second, err := autopilotSvc.DispatchScheduledAutopilotForPlan(
+		ctx, ap, staleAllowTrigger, "schedule", nil, firstPlan.Add(5*time.Minute),
+	)
+	if err != nil {
+		t.Fatalf("second scheduled dispatch: %v", err)
+	}
+	if !second.Coalesced {
+		t.Fatal("second scheduled dispatch must coalesce while the first task is active")
+	}
+	if second.Run == nil || second.Run.ID != first.Run.ID {
+		t.Fatal("coalesced result must point at the active run")
+	}
+
+	var runCount, taskCount int
+	if err := testPool.QueryRow(ctx,
+		`SELECT COUNT(*) FROM autopilot_run WHERE autopilot_id = $1`, ap.ID,
+	).Scan(&runCount); err != nil {
+		t.Fatalf("count runs: %v", err)
+	}
+	if err := testPool.QueryRow(ctx, `
+		SELECT COUNT(*)
+		  FROM agent_task_queue task
+		  JOIN autopilot_run run ON run.id = task.autopilot_run_id
+		 WHERE run.autopilot_id = $1
+	`, ap.ID).Scan(&taskCount); err != nil {
+		t.Fatalf("count tasks: %v", err)
+	}
+	if runCount != 1 || taskCount != 1 {
+		t.Fatalf("active coalescing must leave exactly one run/task, got runs=%d tasks=%d", runCount, taskCount)
+	}
+	for i, status := range []string{"dispatched", "running", "waiting_local_directory"} {
+		if _, err := testPool.Exec(ctx, `
+			UPDATE agent_task_queue SET status = $2 WHERE id = $1
+		`, first.Run.TaskID, status); err != nil {
+			t.Fatalf("set first task status=%s: %v", status, err)
+		}
+		out, err := autopilotSvc.DispatchScheduledAutopilotForPlan(
+			ctx, ap, trigger, "schedule", nil, firstPlan.Add(time.Duration(i+2)*5*time.Minute),
+		)
+		if err != nil {
+			t.Fatalf("dispatch while task status=%s: %v", status, err)
+		}
+		if !out.Coalesced || out.Run == nil || out.Run.ID != first.Run.ID {
+			t.Fatalf("task status=%s must coalesce onto the active run", status)
+		}
+	}
+
+	// A terminal task releases the single-flight gate. Race two later plan
+	// times through separate goroutines to model two scheduler replicas: one
+	// may create the next run, while the other must observe it and coalesce.
+	if _, err := testPool.Exec(ctx, `
+		UPDATE agent_task_queue
+		   SET status = 'completed', completed_at = now()
+		 WHERE id = $1
+	`, first.Run.TaskID); err != nil {
+		t.Fatalf("complete first task: %v", err)
+	}
+	completedTask, err := queries.GetAgentTask(ctx, first.Run.TaskID)
+	if err != nil {
+		t.Fatalf("reload completed task: %v", err)
+	}
+	autopilotSvc.SyncRunFromTask(ctx, completedTask)
+
+	retried, err := autopilotSvc.DispatchScheduledAutopilotForPlan(
+		ctx, ap, trigger, "schedule", nil, firstPlan,
+	)
+	if err != nil {
+		t.Fatalf("exact-plan retry after completion: %v", err)
+	}
+	if retried.Coalesced || retried.Run == nil || retried.Run.ID != first.Run.ID {
+		t.Fatal("exact-plan retry must reuse the completed run without coalescing")
+	}
+	select {
+	case taskID := <-wakeups.notifications:
+		t.Fatalf("exact-plan retry must not re-wake the completed task %s", taskID)
+	default:
+	}
+
+	type concurrentResult struct {
+		result *service.ScheduledAutopilotDispatchResult
+		err    error
+	}
+	results := make(chan concurrentResult, 2)
+	for _, plan := range []time.Time{firstPlan.Add(25 * time.Minute), firstPlan.Add(30 * time.Minute)} {
+		plan := plan
+		go func() {
+			result, err := autopilotSvc.DispatchScheduledAutopilotForPlan(
+				ctx, ap, trigger, "schedule", nil, plan,
+			)
+			results <- concurrentResult{result: result, err: err}
+		}()
+	}
+	created, coalesced := 0, 0
+	for range 2 {
+		out := <-results
+		if out.err != nil {
+			t.Fatalf("concurrent scheduled dispatch: %v", out.err)
+		}
+		if out.result.Coalesced {
+			coalesced++
+		} else {
+			created++
+		}
+	}
+	if created != 1 || coalesced != 1 {
+		t.Fatalf("concurrent dispatches must create one and coalesce one, got created=%d coalesced=%d", created, coalesced)
+	}
+
+	if err := testPool.QueryRow(ctx,
+		`SELECT COUNT(*) FROM autopilot_run WHERE autopilot_id = $1`, ap.ID,
+	).Scan(&runCount); err != nil {
+		t.Fatalf("count runs after terminal release: %v", err)
+	}
+	if err := testPool.QueryRow(ctx, `
+		SELECT COUNT(*)
+		  FROM agent_task_queue task
+		  JOIN autopilot_run run ON run.id = task.autopilot_run_id
+		 WHERE run.autopilot_id = $1
+	`, ap.ID).Scan(&taskCount); err != nil {
+		t.Fatalf("count tasks after terminal release: %v", err)
+	}
+	if runCount != 2 || taskCount != 2 {
+		t.Fatalf("terminal release plus concurrent admission must leave two total run/tasks, got runs=%d tasks=%d", runCount, taskCount)
+	}
+
+	if _, err := queries.UpdateAutopilot(ctx, db.UpdateAutopilotParams{
+		ID:     ap.ID,
+		Status: pgtype.Text{String: "paused", Valid: true},
+	}); err != nil {
+		t.Fatalf("pause autopilot: %v", err)
+	}
+	paused, err := autopilotSvc.DispatchScheduledAutopilotForPlan(
+		ctx, ap, trigger, "schedule", nil, firstPlan.Add(35*time.Minute),
+	)
+	if err != nil {
+		t.Fatalf("dispatch with stale active snapshot: %v", err)
+	}
+	if paused.SkippedReason != "autopilot_inactive" || paused.Run != nil {
+		t.Fatalf("locked status recheck must fail closed, got %+v", paused)
+	}
+	if err := testPool.QueryRow(ctx,
+		`SELECT COUNT(*) FROM autopilot_run WHERE autopilot_id = $1`, ap.ID,
+	).Scan(&runCount); err != nil {
+		t.Fatalf("count runs after paused race: %v", err)
+	}
+	if runCount != 2 {
+		t.Fatalf("paused race must create zero runs, got total=%d", runCount)
 	}
 }
 

--- a/server/cmd/server/autopilot_schedule_job_test.go
+++ b/server/cmd/server/autopilot_schedule_job_test.go
@@ -531,6 +531,94 @@ func TestAutopilotScheduleJobPausedAutopilotSkipsAtHandler(t *testing.T) {
 	}
 }
 
+func TestAutopilotScheduleJobCoalescesActiveRunAsSuccessfulNoOp(t *testing.T) {
+	ctx := context.Background()
+	queries := db.New(testPool)
+	trigger, mgr, autopilotSvc := setupAutopilotScheduleJob(t, "*/1 * * * *")
+
+	if _, err := testPool.Exec(ctx, `
+		UPDATE autopilot_trigger
+		   SET overlap_policy = 'coalesce'
+		 WHERE id = $1
+	`, trigger.ID); err != nil {
+		t.Fatalf("enable coalescing overlap policy: %v", err)
+	}
+	trigger, err := queries.GetAutopilotTrigger(ctx, trigger.ID)
+	if err != nil {
+		t.Fatalf("reload trigger: %v", err)
+	}
+	autopilot, err := queries.GetAutopilot(ctx, trigger.AutopilotID)
+	if err != nil {
+		t.Fatalf("load autopilot: %v", err)
+	}
+
+	firstPlan := time.Now().UTC().Truncate(time.Minute).Add(-time.Minute)
+	first, err := autopilotSvc.DispatchScheduledAutopilotForPlan(
+		ctx, autopilot, trigger, "schedule", nil, firstPlan,
+	)
+	if err != nil {
+		t.Fatalf("seed active scheduled run: %v", err)
+	}
+	if first.Run == nil || first.Coalesced {
+		t.Fatal("seed dispatch must create the active run")
+	}
+
+	if err := mgr.RunOnce(ctx); err != nil {
+		t.Fatalf("scheduler tick: %v", err)
+	}
+
+	var status, skippedReason, activeRunID string
+	var rowsAffected int64
+	var auditedPlan time.Time
+	if err := testPool.QueryRow(ctx, `
+		SELECT status, rows_affected, result->>'skipped_reason',
+		       result->>'active_run_id', plan_time
+		  FROM sys_cron_executions
+		 WHERE job_name = $1 AND scope_kind = $2 AND scope_id = $3
+		 ORDER BY plan_time DESC
+		 LIMIT 1
+	`, scheduler.JobNameAutopilotScheduleDispatch, scheduler.ScopeKindAutopilotTrigger,
+		util.UUIDToString(trigger.ID)).Scan(
+		&status, &rowsAffected, &skippedReason, &activeRunID, &auditedPlan,
+	); err != nil {
+		t.Fatalf("load scheduler audit row: %v", err)
+	}
+	if status != "SUCCESS" || rowsAffected != 0 || skippedReason != "autopilot_active" {
+		t.Fatalf("coalesced audit mismatch: status=%s rows=%d skipped_reason=%q", status, rowsAffected, skippedReason)
+	}
+	if activeRunID != util.UUIDToString(first.Run.ID) {
+		t.Fatalf("active_run_id mismatch: got %q want %q", activeRunID, util.UUIDToString(first.Run.ID))
+	}
+	advanced, err := queries.GetAutopilotTrigger(ctx, trigger.ID)
+	if err != nil {
+		t.Fatalf("reload advanced trigger: %v", err)
+	}
+	if !advanced.LastFiredAt.Valid {
+		t.Fatal("coalesced occurrence must update last_fired_at")
+	}
+	if !advanced.NextRunAt.Valid || !advanced.NextRunAt.Time.After(auditedPlan) {
+		t.Fatalf("coalesced occurrence must advance next_run_at past %s, got %v", auditedPlan, advanced.NextRunAt)
+	}
+
+	var runCount, taskCount int
+	if err := testPool.QueryRow(ctx,
+		`SELECT COUNT(*) FROM autopilot_run WHERE trigger_id = $1`, trigger.ID,
+	).Scan(&runCount); err != nil {
+		t.Fatalf("count runs: %v", err)
+	}
+	if err := testPool.QueryRow(ctx, `
+		SELECT COUNT(*)
+		  FROM agent_task_queue task
+		  JOIN autopilot_run run ON run.id = task.autopilot_run_id
+		 WHERE run.trigger_id = $1
+	`, trigger.ID).Scan(&taskCount); err != nil {
+		t.Fatalf("count tasks: %v", err)
+	}
+	if runCount != 1 || taskCount != 1 {
+		t.Fatalf("coalesced handler must create zero additional work, got runs=%d tasks=%d", runCount, taskCount)
+	}
+}
+
 // TestAutopilotScheduleJobBadCronStaysSilent locks in the failure
 // surface for malformed cron expressions: the trigger create/update
 // handlers reject bad cron at HTTP time (so this is a defence in

--- a/server/internal/handler/autopilot.go
+++ b/server/internal/handler/autopilot.go
@@ -106,6 +106,7 @@ type AutopilotTriggerResponse struct {
 	Enabled        bool    `json:"enabled"`
 	CronExpression *string `json:"cron_expression"`
 	Timezone       *string `json:"timezone"`
+	OverlapPolicy  string  `json:"overlap_policy"`
 	NextRunAt      *string `json:"next_run_at"`
 	WebhookToken   *string `json:"webhook_token"`
 	// WebhookPath is computed from webhook_token. Always present for webhook
@@ -202,6 +203,7 @@ func (h *Handler) triggerToResponse(t db.AutopilotTrigger) AutopilotTriggerRespo
 		Enabled:        t.Enabled,
 		CronExpression: textToPtr(t.CronExpression),
 		Timezone:       textToPtr(t.Timezone),
+		OverlapPolicy:  t.OverlapPolicy,
 		NextRunAt:      timestampToPtr(t.NextRunAt),
 		WebhookToken:   textToPtr(t.WebhookToken),
 		Label:          textToPtr(t.Label),
@@ -332,6 +334,7 @@ type CreateAutopilotTriggerRequest struct {
 	Kind           string  `json:"kind"`
 	CronExpression *string `json:"cron_expression"`
 	Timezone       *string `json:"timezone"`
+	OverlapPolicy  *string `json:"overlap_policy"`
 	Label          *string `json:"label"`
 	// Provider is currently only meaningful for kind=webhook. Allowed
 	// values: "generic" (default) or "github". Unset → "generic".
@@ -358,6 +361,7 @@ type UpdateAutopilotTriggerRequest struct {
 	Enabled        *bool   `json:"enabled"`
 	CronExpression *string `json:"cron_expression"`
 	Timezone       *string `json:"timezone"`
+	OverlapPolicy  *string `json:"overlap_policy"`
 	Label          *string `json:"label"`
 	// EventFilters is the desired event-filter set with tri-state PATCH
 	// semantics:
@@ -880,6 +884,38 @@ func (h *Handler) UpdateAutopilot(w http.ResponseWriter, r *http.Request) {
 	}
 	defer tx.Rollback(r.Context())
 	qtx := h.Queries.WithTx(tx)
+	lockedAutopilot, err := qtx.LockAutopilotForSchedulePolicy(r.Context(), prev.ID)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to lock autopilot")
+		return
+	}
+	if req.ExecutionMode != nil && *req.ExecutionMode != "run_only" {
+		triggers, err := qtx.ListAutopilotTriggers(r.Context(), lockedAutopilot.ID)
+		if err != nil {
+			writeError(w, http.StatusInternalServerError, "failed to validate schedule overlap policy")
+			return
+		}
+		for _, trigger := range triggers {
+			if trigger.Kind == "schedule" && trigger.OverlapPolicy == "coalesce" {
+				writeError(w, http.StatusBadRequest, "execution_mode must remain run_only while a schedule trigger uses overlap_policy=coalesce")
+				return
+			}
+		}
+	}
+	// Fields whose PATCH contract uses explicit values rather than COALESCE
+	// must preserve the row we locked, not the earlier authorization snapshot.
+	if _, sent := rawFields["description"]; !sent {
+		params.Description = lockedAutopilot.Description
+	}
+	if _, sent := rawFields["issue_title_template"]; !sent {
+		params.IssueTitleTemplate = lockedAutopilot.IssueTitleTemplate
+	}
+	if _, sent := rawFields["project_id"]; !sent {
+		params.ProjectID = lockedAutopilot.ProjectID
+	}
+	if !idSent {
+		params.AssigneeID = lockedAutopilot.AssigneeID
+	}
 
 	autopilot, err := qtx.UpdateAutopilot(r.Context(), params)
 	if err != nil {
@@ -1143,6 +1179,22 @@ func (h *Handler) CreateAutopilotTrigger(w http.ResponseWriter, r *http.Request)
 		writeError(w, http.StatusBadRequest, "timezone is not valid for webhook triggers")
 		return
 	}
+	overlapPolicy := "allow"
+	if req.OverlapPolicy != nil && *req.OverlapPolicy != "" {
+		if req.Kind != "schedule" {
+			writeError(w, http.StatusBadRequest, "overlap_policy is only valid for schedule triggers")
+			return
+		}
+		if *req.OverlapPolicy != "allow" && *req.OverlapPolicy != "coalesce" {
+			writeError(w, http.StatusBadRequest, "overlap_policy must be allow or coalesce")
+			return
+		}
+		overlapPolicy = *req.OverlapPolicy
+	}
+	if overlapPolicy == "coalesce" && ap.ExecutionMode != "run_only" {
+		writeError(w, http.StatusBadRequest, "overlap_policy=coalesce requires execution_mode=run_only")
+		return
+	}
 	if req.Kind != "webhook" && len(req.EventFilters) > 0 {
 		// event_filters narrows webhook ingress — it has no meaning for a
 		// schedule trigger and would otherwise be silently dropped.
@@ -1226,7 +1278,23 @@ func (h *Handler) CreateAutopilotTrigger(w http.ResponseWriter, r *http.Request)
 		return
 	}
 
-	trigger, err := h.Queries.CreateAutopilotTrigger(r.Context(), db.CreateAutopilotTriggerParams{
+	tx, err := h.TxStarter.Begin(r.Context())
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to create trigger")
+		return
+	}
+	defer tx.Rollback(r.Context())
+	qtx := h.Queries.WithTx(tx)
+	lockedAutopilot, err := qtx.LockAutopilotForSchedulePolicy(r.Context(), ap.ID)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to lock autopilot")
+		return
+	}
+	if overlapPolicy == "coalesce" && lockedAutopilot.ExecutionMode != "run_only" {
+		writeError(w, http.StatusBadRequest, "overlap_policy=coalesce requires execution_mode=run_only")
+		return
+	}
+	trigger, err := qtx.CreateAutopilotTrigger(r.Context(), db.CreateAutopilotTriggerParams{
 		AutopilotID:    ap.ID,
 		Kind:           req.Kind,
 		Enabled:        true,
@@ -1235,8 +1303,13 @@ func (h *Handler) CreateAutopilotTrigger(w http.ResponseWriter, r *http.Request)
 		NextRunAt:      nextRunAt,
 		Label:          ptrToText(req.Label),
 		WebhookToken:   webhookToken,
+		OverlapPolicy:  pgtype.Text{String: overlapPolicy, Valid: true},
 	})
 	if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to create trigger")
+		return
+	}
+	if err := tx.Commit(r.Context()); err != nil {
 		writeError(w, http.StatusInternalServerError, "failed to create trigger")
 		return
 	}
@@ -1388,15 +1461,26 @@ func (h *Handler) UpdateAutopilotTrigger(w http.ResponseWriter, r *http.Request)
 		return
 	}
 
-	prev, err := h.Queries.GetAutopilotTrigger(r.Context(), triggerUUID)
-	if err != nil || uuidToString(prev.AutopilotID) != uuidToString(ap.ID) {
-		writeError(w, http.StatusNotFound, "trigger not found")
-		return
-	}
-
 	var req UpdateAutopilotTriggerRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 		writeError(w, http.StatusBadRequest, "invalid request body")
+		return
+	}
+	tx, err := h.TxStarter.Begin(r.Context())
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to update trigger")
+		return
+	}
+	defer tx.Rollback(r.Context())
+	qtx := h.Queries.WithTx(tx)
+	lockedAutopilot, err := qtx.LockAutopilotForSchedulePolicy(r.Context(), ap.ID)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to lock autopilot")
+		return
+	}
+	prev, err := qtx.LockAutopilotTriggerForSchedulePolicy(r.Context(), triggerUUID)
+	if err != nil || uuidToString(prev.AutopilotID) != uuidToString(lockedAutopilot.ID) {
+		writeError(w, http.StatusNotFound, "trigger not found")
 		return
 	}
 
@@ -1411,6 +1495,10 @@ func (h *Handler) UpdateAutopilotTrigger(w http.ResponseWriter, r *http.Request)
 		}
 		if req.Timezone != nil {
 			writeError(w, http.StatusBadRequest, "timezone is only valid for schedule triggers")
+			return
+		}
+		if req.OverlapPolicy != nil {
+			writeError(w, http.StatusBadRequest, "overlap_policy is only valid for schedule triggers")
 			return
 		}
 	}
@@ -1439,6 +1527,17 @@ func (h *Handler) UpdateAutopilotTrigger(w http.ResponseWriter, r *http.Request)
 	}
 	if req.Label != nil {
 		params.Label = pgtype.Text{String: *req.Label, Valid: true}
+	}
+	if req.OverlapPolicy != nil {
+		if *req.OverlapPolicy != "allow" && *req.OverlapPolicy != "coalesce" {
+			writeError(w, http.StatusBadRequest, "overlap_policy must be allow or coalesce")
+			return
+		}
+		if *req.OverlapPolicy == "coalesce" && lockedAutopilot.ExecutionMode != "run_only" {
+			writeError(w, http.StatusBadRequest, "overlap_policy=coalesce requires execution_mode=run_only")
+			return
+		}
+		params.OverlapPolicy = pgtype.Text{String: *req.OverlapPolicy, Valid: true}
 	}
 	// Tri-state PATCH for event_filters. A nil pointer (field omitted or
 	// JSON null) leaves the existing row untouched — params.EventFilters
@@ -1484,8 +1583,12 @@ func (h *Handler) UpdateAutopilotTrigger(w http.ResponseWriter, r *http.Request)
 		params.NextRunAt = pgtype.Timestamptz{Time: t, Valid: true}
 	}
 
-	trigger, err := h.Queries.UpdateAutopilotTrigger(r.Context(), params)
+	trigger, err := qtx.UpdateAutopilotTrigger(r.Context(), params)
 	if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to update trigger")
+		return
+	}
+	if err := tx.Commit(r.Context()); err != nil {
 		writeError(w, http.StatusInternalServerError, "failed to update trigger")
 		return
 	}
@@ -1493,7 +1596,7 @@ func (h *Handler) UpdateAutopilotTrigger(w http.ResponseWriter, r *http.Request)
 	resp := h.triggerToResponse(trigger)
 	userID, _ := requireUserID(w, r)
 	h.publish(protocol.EventAutopilotUpdated, workspaceID, "member", userID, map[string]any{
-		"autopilot_id": uuidToString(ap.ID),
+		"autopilot_id": uuidToString(lockedAutopilot.ID),
 		"trigger":      resp,
 	})
 	writeJSON(w, http.StatusOK, resp)

--- a/server/internal/handler/autopilot_test.go
+++ b/server/internal/handler/autopilot_test.go
@@ -1,0 +1,211 @@
+package handler
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+func TestCreateAutopilotTrigger_AcceptsCoalesceForRunOnlySchedule(t *testing.T) {
+	agentID := createWebhookTestAgent(t, "Coalesce Schedule Agent")
+	apID := createWebhookTestAutopilot(t, agentID, "active", "run_only")
+
+	w := httptest.NewRecorder()
+	req := newRequest("POST", "/api/autopilots/"+apID+"/triggers", map[string]any{
+		"kind":            "schedule",
+		"cron_expression": "*/5 * * * *",
+		"timezone":        "UTC",
+		"overlap_policy":  "coalesce",
+	})
+	req = withURLParam(req, "id", apID)
+	testHandler.CreateAutopilotTrigger(w, req)
+	if w.Code != http.StatusCreated {
+		t.Fatalf("expected 201, got %d body=%s", w.Code, w.Body.String())
+	}
+	var resp AutopilotTriggerResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if resp.OverlapPolicy != "coalesce" {
+		t.Fatalf("overlap_policy: got %q want coalesce", resp.OverlapPolicy)
+	}
+}
+
+func TestCreateAutopilotTrigger_RejectsCoalesceForCreateIssue(t *testing.T) {
+	agentID := createWebhookTestAgent(t, "Coalesce Create Issue Agent")
+	apID := createWebhookTestAutopilot(t, agentID, "active", "create_issue")
+
+	w := httptest.NewRecorder()
+	req := newRequest("POST", "/api/autopilots/"+apID+"/triggers", map[string]any{
+		"kind":            "schedule",
+		"cron_expression": "*/5 * * * *",
+		"overlap_policy":  "coalesce",
+	})
+	req = withURLParam(req, "id", apID)
+	testHandler.CreateAutopilotTrigger(w, req)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d body=%s", w.Code, w.Body.String())
+	}
+}
+
+func TestCreateAutopilotTrigger_RejectsOverlapPolicyForWebhook(t *testing.T) {
+	agentID := createWebhookTestAgent(t, "Webhook Overlap Agent")
+	apID := createWebhookTestAutopilot(t, agentID, "active", "run_only")
+
+	w := httptest.NewRecorder()
+	req := newRequest("POST", "/api/autopilots/"+apID+"/triggers", map[string]any{
+		"kind":           "webhook",
+		"overlap_policy": "coalesce",
+	})
+	req = withURLParam(req, "id", apID)
+	testHandler.CreateAutopilotTrigger(w, req)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d body=%s", w.Code, w.Body.String())
+	}
+}
+
+func TestUpdateAutopilot_RequiresClearingCoalesceBeforeCreateIssueMode(t *testing.T) {
+	agentID := createWebhookTestAgent(t, "Coalesce Mode Guard Agent")
+	apID := createWebhookTestAutopilot(t, agentID, "active", "run_only")
+
+	create := httptest.NewRecorder()
+	req := newRequest("POST", "/api/autopilots/"+apID+"/triggers", map[string]any{
+		"kind":            "schedule",
+		"cron_expression": "*/5 * * * *",
+		"overlap_policy":  "coalesce",
+	})
+	req = withURLParam(req, "id", apID)
+	testHandler.CreateAutopilotTrigger(create, req)
+	if create.Code != http.StatusCreated {
+		t.Fatalf("create coalescing trigger: got %d body=%s", create.Code, create.Body.String())
+	}
+	var trigger AutopilotTriggerResponse
+	if err := json.Unmarshal(create.Body.Bytes(), &trigger); err != nil {
+		t.Fatalf("decode trigger: %v", err)
+	}
+
+	blocked := httptest.NewRecorder()
+	req = newRequest("PATCH", "/api/autopilots/"+apID, map[string]any{
+		"execution_mode": "create_issue",
+	})
+	req = withURLParam(req, "id", apID)
+	testHandler.UpdateAutopilot(blocked, req)
+	if blocked.Code != http.StatusBadRequest {
+		t.Fatalf("mode change with coalescing trigger: got %d body=%s", blocked.Code, blocked.Body.String())
+	}
+
+	clear := httptest.NewRecorder()
+	req = newRequest("PATCH", "/api/autopilots/"+apID+"/triggers/"+trigger.ID, map[string]any{
+		"overlap_policy": "allow",
+	})
+	req = withURLParams(req, "id", apID, "triggerId", trigger.ID)
+	testHandler.UpdateAutopilotTrigger(clear, req)
+	if clear.Code != http.StatusOK {
+		t.Fatalf("clear coalescing policy: got %d body=%s", clear.Code, clear.Body.String())
+	}
+
+	allowed := httptest.NewRecorder()
+	req = newRequest("PATCH", "/api/autopilots/"+apID, map[string]any{
+		"execution_mode": "create_issue",
+	})
+	req = withURLParam(req, "id", apID)
+	testHandler.UpdateAutopilot(allowed, req)
+	if allowed.Code != http.StatusOK {
+		t.Fatalf("mode change after clearing policy: got %d body=%s", allowed.Code, allowed.Body.String())
+	}
+}
+
+func TestAutopilotSchedulePolicyMutationsPreserveCrossTableInvariant(t *testing.T) {
+	agentID := createWebhookTestAgent(t, "Coalesce Concurrent Guard Agent")
+	apID := createWebhookTestAutopilot(t, agentID, "active", "run_only")
+
+	create := httptest.NewRecorder()
+	req := newRequest("POST", "/api/autopilots/"+apID+"/triggers", map[string]any{
+		"kind":            "schedule",
+		"cron_expression": "*/5 * * * *",
+		"overlap_policy":  "allow",
+	})
+	req = withURLParam(req, "id", apID)
+	testHandler.CreateAutopilotTrigger(create, req)
+	if create.Code != http.StatusCreated {
+		t.Fatalf("create allow trigger: got %d body=%s", create.Code, create.Body.String())
+	}
+	var trigger AutopilotTriggerResponse
+	if err := json.Unmarshal(create.Body.Bytes(), &trigger); err != nil {
+		t.Fatalf("decode trigger: %v", err)
+	}
+
+	// Hold the common parent lock until both requests have started. Once
+	// released, the two handlers must serialize: either the mode change wins
+	// and coalesce is rejected, or coalesce wins and the mode change is
+	// rejected. They must never both commit.
+	guard, err := testPool.Begin(context.Background())
+	if err != nil {
+		t.Fatalf("begin guard transaction: %v", err)
+	}
+	defer guard.Rollback(context.Background())
+	if _, err := guard.Exec(context.Background(), `SELECT id FROM autopilot WHERE id = $1 FOR UPDATE`, apID); err != nil {
+		t.Fatalf("lock autopilot: %v", err)
+	}
+
+	started := make(chan struct{}, 2)
+	results := make(chan int, 2)
+	go func() {
+		started <- struct{}{}
+		w := httptest.NewRecorder()
+		r := newRequest("PATCH", "/api/autopilots/"+apID, map[string]any{
+			"execution_mode": "create_issue",
+		})
+		r = withURLParam(r, "id", apID)
+		testHandler.UpdateAutopilot(w, r)
+		results <- w.Code
+	}()
+	go func() {
+		started <- struct{}{}
+		w := httptest.NewRecorder()
+		r := newRequest("PATCH", "/api/autopilots/"+apID+"/triggers/"+trigger.ID, map[string]any{
+			"overlap_policy": "coalesce",
+		})
+		r = withURLParams(r, "id", apID, "triggerId", trigger.ID)
+		testHandler.UpdateAutopilotTrigger(w, r)
+		results <- w.Code
+	}()
+	<-started
+	<-started
+	time.Sleep(50 * time.Millisecond)
+	if err := guard.Commit(context.Background()); err != nil {
+		t.Fatalf("release guard lock: %v", err)
+	}
+
+	successes := 0
+	rejections := 0
+	for range 2 {
+		switch code := <-results; code {
+		case http.StatusOK:
+			successes++
+		case http.StatusBadRequest:
+			rejections++
+		default:
+			t.Fatalf("unexpected concurrent mutation status: %d", code)
+		}
+	}
+	if successes != 1 || rejections != 1 {
+		t.Fatalf("concurrent mutations: got %d success and %d rejection, want one each", successes, rejections)
+	}
+
+	var executionMode, overlapPolicy string
+	if err := testPool.QueryRow(context.Background(), `
+		SELECT a.execution_mode, t.overlap_policy
+		FROM autopilot a
+		JOIN autopilot_trigger t ON t.autopilot_id = a.id
+		WHERE a.id = $1 AND t.id = $2
+	`, apID, trigger.ID).Scan(&executionMode, &overlapPolicy); err != nil {
+		t.Fatalf("read final invariant: %v", err)
+	}
+	if executionMode != "run_only" && overlapPolicy == "coalesce" {
+		t.Fatalf("illegal final state: execution_mode=%s overlap_policy=%s", executionMode, overlapPolicy)
+	}
+}

--- a/server/internal/scheduler/jobs_autopilot.go
+++ b/server/internal/scheduler/jobs_autopilot.go
@@ -42,14 +42,14 @@ const maxAutopilotScheduleLateness = 5 * time.Minute
 // package (and the cmd/server integration tests) can stub it without
 // pulling in the rest of the service layer.
 type AutopilotScheduleDispatcher interface {
-	DispatchAutopilotForPlan(
+	DispatchScheduledAutopilotForPlan(
 		ctx context.Context,
 		autopilot db.Autopilot,
-		triggerID pgtype.UUID,
+		trigger db.AutopilotTrigger,
 		source string,
 		payload []byte,
 		plannedAt time.Time,
-	) (*db.AutopilotRun, error)
+	) (*service.ScheduledAutopilotDispatchResult, error)
 }
 
 // AutopilotScheduleDispatchJob returns the JobSpec that drives
@@ -370,35 +370,30 @@ func autopilotHandler(
 			}}, nil
 		}
 
-		run, err := dispatcher.DispatchAutopilotForPlan(
-			ctx, autopilot, trigger.ID, "schedule", nil, in.PlanTime,
+		dispatch, err := dispatcher.DispatchScheduledAutopilotForPlan(
+			ctx, autopilot, trigger, "schedule", nil, in.PlanTime,
 		)
 		if err != nil {
 			return HandlerResult{}, fmt.Errorf("dispatch for plan: %w", err)
 		}
-
-		// Advance the display-only next_run_at to the upcoming slot and
-		// bump last_fired_at in the same write, so the trigger UI stops
-		// showing a "next run" that has already fired (MUL-3749). The
-		// value stays on the app local clock — consistent with the trigger
-		// create/update display path — but is floored at the plan_time
-		// that just fired (see advancedNextRun), so a lagging app clock can
-		// never recompute the slot we just dispatched. Errors are not
-		// fatal: the canonical record is autopilot_run.created_at and the
-		// next dispatch refreshes the value regardless; on a cron/timezone
-		// parse failure we fall back to the last_fired_at-only bump so the
-		// fire is still recorded.
-		tz := DefaultAutopilotScheduleTimezone
-		if trigger.Timezone.Valid && trigger.Timezone.String != "" {
-			tz = trigger.Timezone.String
+		if dispatch.SkippedReason == "" {
+			advanceAutopilotTriggerAfterPlan(ctx, queries, trigger, in.PlanTime)
 		}
-		if next, ok := advancedNextRun(trigger.CronExpression.String, tz, in.PlanTime, time.Now()); ok {
-			_ = queries.AdvanceTriggerNextRun(ctx, db.AdvanceTriggerNextRunParams{
-				ID:        trigger.ID,
-				NextRunAt: pgtype.Timestamptz{Time: next, Valid: true},
-			})
-		} else {
-			_ = queries.TouchAutopilotTriggerFiredAt(ctx, trigger.ID)
+		if dispatch.SkippedReason != "" {
+			return HandlerResult{RowsAffected: 0, Result: map[string]any{
+				"skipped_reason": dispatch.SkippedReason,
+			}}, nil
+		}
+		if dispatch.Coalesced {
+			result := map[string]any{"skipped_reason": "autopilot_active"}
+			if dispatch.Run != nil {
+				result["active_run_id"] = util.UUIDToString(dispatch.Run.ID)
+			}
+			return HandlerResult{RowsAffected: 0, Result: result}, nil
+		}
+		run := dispatch.Run
+		if run == nil {
+			return HandlerResult{}, fmt.Errorf("dispatch for plan returned no run")
 		}
 
 		return HandlerResult{
@@ -409,6 +404,31 @@ func autopilotHandler(
 			},
 		}, nil
 	}
+}
+
+// advanceAutopilotTriggerAfterPlan advances the display-only next_run_at and
+// bumps last_fired_at after both dispatched and coalesced occurrences. A
+// coalesced occurrence is still a successfully evaluated cron slot; returning
+// before this write would leave the UI and cold-start planner anchored in the
+// past. Errors remain non-fatal because sys_cron_executions is canonical.
+func advanceAutopilotTriggerAfterPlan(
+	ctx context.Context,
+	queries *db.Queries,
+	trigger db.AutopilotTrigger,
+	planTime time.Time,
+) {
+	tz := DefaultAutopilotScheduleTimezone
+	if trigger.Timezone.Valid && trigger.Timezone.String != "" {
+		tz = trigger.Timezone.String
+	}
+	if next, ok := advancedNextRun(trigger.CronExpression.String, tz, planTime, time.Now()); ok {
+		_ = queries.AdvanceTriggerNextRun(ctx, db.AdvanceTriggerNextRunParams{
+			ID:        trigger.ID,
+			NextRunAt: pgtype.Timestamptz{Time: next, Valid: true},
+		})
+		return
+	}
+	_ = queries.TouchAutopilotTriggerFiredAt(ctx, trigger.ID)
 }
 
 // advancedNextRun computes the display-only next_run_at value to write

--- a/server/internal/service/autopilot.go
+++ b/server/internal/service/autopilot.go
@@ -32,6 +32,12 @@ type AutopilotService struct {
 	TxStarter TxStarter
 	Bus       *events.Bus
 	TaskSvc   *TaskService
+
+	// deferExternalEffects is set only on the transaction-bound service copy
+	// used by coalescing schedule dispatch. Durable writes still use the
+	// existing dispatch path, while analytics, events, and daemon wakeups wait
+	// until the caller has committed the transaction.
+	deferExternalEffects bool
 }
 
 // DefaultAutopilotTriggerTimezone is the timezone used to render Autopilot
@@ -72,6 +78,156 @@ func (s *AutopilotService) DispatchAutopilot(
 	payload []byte,
 ) (*db.AutopilotRun, error) {
 	return s.dispatchAutopilot(ctx, autopilot, triggerID, source, payload, pgtype.Timestamptz{})
+}
+
+// ScheduledAutopilotDispatchResult describes the outcome of one canonical
+// schedule occurrence. A coalesced occurrence is a successful no-op: Run is
+// the earlier active run that owns the durable task and no new run or task was
+// created for the current plan time.
+type ScheduledAutopilotDispatchResult struct {
+	Run           *db.AutopilotRun
+	Coalesced     bool
+	SkippedReason string
+}
+
+// DispatchScheduledAutopilotForPlan applies a schedule trigger's overlap
+// policy before delegating to the occurrence-idempotent dispatch path.
+//
+// overlap_policy=allow preserves the historic behavior. For coalesce, an
+// exclusive lock on the parent Autopilot serializes admission across scheduler
+// replicas. While that lock is held, an active run_only task makes the new
+// occurrence a successful no-op. Otherwise the run and task are created in the
+// same transaction, so a crash cannot leave a committed run without its task.
+func (s *AutopilotService) DispatchScheduledAutopilotForPlan(
+	ctx context.Context,
+	autopilot db.Autopilot,
+	trigger db.AutopilotTrigger,
+	source string,
+	payload []byte,
+	plannedAt time.Time,
+) (*ScheduledAutopilotDispatchResult, error) {
+	if plannedAt.IsZero() {
+		return nil, fmt.Errorf("dispatch for plan: planned_at is required")
+	}
+	tx, err := s.TxStarter.Begin(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("begin coalescing schedule dispatch: %w", err)
+	}
+	defer tx.Rollback(ctx)
+	qtx := s.Queries.WithTx(tx)
+
+	lockedAutopilot, err := qtx.LockAutopilotForSchedulePolicy(ctx, autopilot.ID)
+	if err != nil {
+		return nil, fmt.Errorf("lock autopilot for schedule dispatch: %w", err)
+	}
+	if lockedAutopilot.Status != "active" {
+		if err := tx.Commit(ctx); err != nil {
+			return nil, fmt.Errorf("commit inactive-autopilot schedule no-op: %w", err)
+		}
+		return &ScheduledAutopilotDispatchResult{SkippedReason: "autopilot_inactive"}, nil
+	}
+	lockedTrigger, err := qtx.LockAutopilotTriggerForSchedulePolicy(ctx, trigger.ID)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			if err := tx.Commit(ctx); err != nil {
+				return nil, fmt.Errorf("commit missing-trigger schedule no-op: %w", err)
+			}
+			return &ScheduledAutopilotDispatchResult{SkippedReason: "trigger_not_found"}, nil
+		}
+		return nil, fmt.Errorf("reload trigger for schedule dispatch: %w", err)
+	}
+	if !lockedTrigger.Enabled || lockedTrigger.Kind != "schedule" {
+		if err := tx.Commit(ctx); err != nil {
+			return nil, fmt.Errorf("commit disabled-trigger schedule no-op: %w", err)
+		}
+		return &ScheduledAutopilotDispatchResult{SkippedReason: "trigger_disabled"}, nil
+	}
+	if lockedTrigger.OverlapPolicy != "coalesce" {
+		if err := tx.Commit(ctx); err != nil {
+			return nil, fmt.Errorf("commit overlap-policy recheck: %w", err)
+		}
+		run, err := s.DispatchAutopilotForPlan(ctx, lockedAutopilot, lockedTrigger.ID, source, payload, plannedAt)
+		return &ScheduledAutopilotDispatchResult{Run: run}, err
+	}
+	if lockedAutopilot.ExecutionMode != "run_only" {
+		return nil, fmt.Errorf("coalescing schedule triggers require execution_mode=run_only")
+	}
+
+	// Exact-plan stale retries reuse the prior complete run without replaying
+	// analytics, events, or task wakeups. This check must precede the broader
+	// active-task coalescing query so same-occurrence idempotency remains
+	// distinguishable from a genuinely skipped later occurrence.
+	plannedTS := pgtype.Timestamptz{Time: plannedAt.UTC(), Valid: true}
+	existing, err := qtx.GetAutopilotRunByTriggerAndPlanned(ctx, db.GetAutopilotRunByTriggerAndPlannedParams{
+		TriggerID: lockedTrigger.ID,
+		PlannedAt: plannedTS,
+	})
+	switch {
+	case err == nil && isAutopilotRunComplete(existing):
+		if err := tx.Commit(ctx); err != nil {
+			return nil, fmt.Errorf("commit idempotent schedule dispatch: %w", err)
+		}
+		return &ScheduledAutopilotDispatchResult{Run: &existing}, nil
+	case err != nil && !errors.Is(err, pgx.ErrNoRows):
+		return nil, fmt.Errorf("check existing schedule run: %w", err)
+	}
+
+	active, err := qtx.GetActiveAutopilotRunOnlyRun(ctx, lockedAutopilot.ID)
+	switch {
+	case err == nil:
+		if err := tx.Commit(ctx); err != nil {
+			return nil, fmt.Errorf("commit coalesced schedule dispatch: %w", err)
+		}
+		return &ScheduledAutopilotDispatchResult{Run: &active, Coalesced: true}, nil
+	case !errors.Is(err, pgx.ErrNoRows):
+		return nil, fmt.Errorf("check active autopilot task: %w", err)
+	}
+
+	// Execute the existing dispatch logic against this transaction. Defer
+	// externally visible wakeups/events until the transaction commits; a
+	// daemon must never be woken for a row that could still roll back.
+	txService := *s
+	txService.Queries = qtx
+	txService.deferExternalEffects = true
+	run, err := txService.DispatchAutopilotForPlan(
+		ctx, lockedAutopilot, lockedTrigger.ID, source, payload, plannedAt,
+	)
+	if err != nil {
+		return nil, err
+	}
+	var enqueuedTask *db.AgentTaskQueue
+	if run.TaskID.Valid {
+		task, err := qtx.GetAgentTask(ctx, run.TaskID)
+		if err != nil {
+			return nil, fmt.Errorf("reload coalescing schedule task before commit: %w", err)
+		}
+		enqueuedTask = &task
+	}
+	if err := tx.Commit(ctx); err != nil {
+		return nil, fmt.Errorf("commit coalescing schedule dispatch: %w", err)
+	}
+
+	if run.Status == "skipped" {
+		s.publishRunDone(util.UUIDToString(lockedAutopilot.WorkspaceID), *run, "skipped")
+	} else {
+		s.captureAutopilotRunStarted(lockedAutopilot, *run, source)
+		s.Bus.Publish(events.Event{
+			Type:        protocol.EventAutopilotRunStart,
+			WorkspaceID: util.UUIDToString(lockedAutopilot.WorkspaceID),
+			ActorType:   "system",
+			Payload: map[string]any{
+				"run_id":       util.UUIDToString(run.ID),
+				"autopilot_id": util.UUIDToString(lockedAutopilot.ID),
+				"source":       source,
+				"status":       run.Status,
+			},
+		})
+	}
+	if enqueuedTask != nil && s.TaskSvc != nil {
+		s.TaskSvc.NotifyTaskEnqueued(ctx, *enqueuedTask)
+	}
+
+	return &ScheduledAutopilotDispatchResult{Run: run}, nil
 }
 
 // DispatchAutopilotForPlan is the entry point for scheduled triggers that
@@ -227,7 +383,9 @@ func (s *AutopilotService) dispatchAutopilot(
 	if err != nil {
 		return nil, fmt.Errorf("create run: %w", err)
 	}
-	s.captureAutopilotRunStarted(autopilot, run, source)
+	if !s.deferExternalEffects {
+		s.captureAutopilotRunStarted(autopilot, run, source)
+	}
 
 	switch autopilot.ExecutionMode {
 	case "create_issue":
@@ -259,17 +417,19 @@ func (s *AutopilotService) dispatchAutopilot(
 	s.Queries.UpdateAutopilotLastRunAt(ctx, autopilot.ID)
 
 	// Publish run start event.
-	s.Bus.Publish(events.Event{
-		Type:        protocol.EventAutopilotRunStart,
-		WorkspaceID: util.UUIDToString(autopilot.WorkspaceID),
-		ActorType:   "system",
-		Payload: map[string]any{
-			"run_id":       util.UUIDToString(run.ID),
-			"autopilot_id": util.UUIDToString(autopilot.ID),
-			"source":       source,
-			"status":       run.Status,
-		},
-	})
+	if !s.deferExternalEffects {
+		s.Bus.Publish(events.Event{
+			Type:        protocol.EventAutopilotRunStart,
+			WorkspaceID: util.UUIDToString(autopilot.WorkspaceID),
+			ActorType:   "system",
+			Payload: map[string]any{
+				"run_id":       util.UUIDToString(run.ID),
+				"autopilot_id": util.UUIDToString(autopilot.ID),
+				"source":       source,
+				"status":       run.Status,
+			},
+		})
+	}
 
 	return &run, nil
 }
@@ -602,7 +762,9 @@ func (s *AutopilotService) dispatchRunOnly(ctx context.Context, ap db.Autopilot,
 	// (bypassing TaskService.Enqueue*), so without this the runtime
 	// would not get a wakeup and any cached "empty" verdict would
 	// stall the task until the TTL expired.
-	s.TaskSvc.NotifyTaskEnqueued(ctx, task)
+	if !s.deferExternalEffects {
+		s.TaskSvc.NotifyTaskEnqueued(ctx, task)
+	}
 
 	slog.Info("autopilot dispatched (run_only)",
 		"autopilot_id", util.UUIDToString(ap.ID),
@@ -1047,6 +1209,9 @@ func (s *AutopilotService) recordSkippedRun(
 }
 
 func (s *AutopilotService) publishRunDone(workspaceID string, run db.AutopilotRun, status string) {
+	if s.deferExternalEffects {
+		return
+	}
 	s.Bus.Publish(events.Event{
 		Type:        protocol.EventAutopilotRunDone,
 		WorkspaceID: workspaceID,
@@ -1060,7 +1225,7 @@ func (s *AutopilotService) publishRunDone(workspaceID string, run db.AutopilotRu
 }
 
 func (s *AutopilotService) captureIssueCreatedFromAutopilot(ap db.Autopilot, run *db.AutopilotRun, issue db.Issue, leaderID pgtype.UUID) {
-	if s.TaskSvc == nil || s.TaskSvc.Analytics == nil {
+	if s.deferExternalEffects || s.TaskSvc == nil || s.TaskSvc.Analytics == nil {
 		return
 	}
 	// For PostHog the agent_id should be the agent that will actually run
@@ -1079,7 +1244,7 @@ func (s *AutopilotService) captureIssueCreatedFromAutopilot(ap db.Autopilot, run
 }
 
 func (s *AutopilotService) captureAutopilotRunStarted(ap db.Autopilot, run db.AutopilotRun, triggerSource string) {
-	if s.TaskSvc == nil || s.TaskSvc.Analytics == nil {
+	if s.deferExternalEffects || s.TaskSvc == nil || s.TaskSvc.Analytics == nil {
 		return
 	}
 	obsmetrics.RecordEvent(s.TaskSvc.Analytics, s.TaskSvc.Metrics, analytics.AutopilotRunStarted(
@@ -1094,7 +1259,7 @@ func (s *AutopilotService) captureAutopilotRunStarted(ap db.Autopilot, run db.Au
 }
 
 func (s *AutopilotService) captureAutopilotRunCompleted(ap db.Autopilot, run db.AutopilotRun) {
-	if s.TaskSvc == nil || s.TaskSvc.Analytics == nil {
+	if s.deferExternalEffects || s.TaskSvc == nil || s.TaskSvc.Analytics == nil {
 		return
 	}
 	obsmetrics.RecordEvent(s.TaskSvc.Analytics, s.TaskSvc.Metrics, analytics.AutopilotRunCompleted(
@@ -1110,7 +1275,7 @@ func (s *AutopilotService) captureAutopilotRunCompleted(ap db.Autopilot, run db.
 }
 
 func (s *AutopilotService) captureAutopilotRunFailed(ap db.Autopilot, run db.AutopilotRun, triggerSource, reason string) {
-	if s.TaskSvc == nil || s.TaskSvc.Analytics == nil {
+	if s.deferExternalEffects || s.TaskSvc == nil || s.TaskSvc.Analytics == nil {
 		return
 	}
 	if reason == "" {

--- a/server/internal/service/builtin_skills/multica-autopilots/SKILL.md
+++ b/server/internal/service/builtin_skills/multica-autopilots/SKILL.md
@@ -31,6 +31,14 @@ Execution modes:
 - `run_only` creates an agent task directly. No issue is created; any durable
   report location has to come from other task context or instructions.
 
+Schedule overlap policies:
+
+- `allow` (default) dispatches every planned occurrence.
+- `coalesce` is available for `run_only` autopilots. While an earlier task is
+  queued, dispatched, running, or waiting for a local directory, the next
+  schedule occurrence is recorded by the scheduler as a successful no-op and
+  creates no additional run or task.
+
 `issue-title-template` only supports `{{date}}`. Do not invent `{{trigger_id}}`, `{{branch}}`, or other variables.
 
 ## CLI
@@ -41,7 +49,8 @@ multica autopilot get <autopilot-id> --output json
 multica autopilot create --title "<title>" --description "<task prompt>" --agent <agent-name-or-id> --mode create_issue|run_only --output json
 multica autopilot update <autopilot-id> --status active|paused --output json
 multica autopilot runs <autopilot-id> --output json
-multica autopilot trigger-add <autopilot-id> --kind schedule --cron "0 9 * * *" --timezone Asia/Shanghai --output json
+multica autopilot trigger-add <autopilot-id> --kind schedule --cron "0 9 * * *" --timezone Asia/Shanghai --overlap-policy allow|coalesce --output json
+multica autopilot trigger-update <autopilot-id> <trigger-id> --overlap-policy allow|coalesce --output json
 multica autopilot trigger-add <autopilot-id> --kind webhook --label "ci" --output json
 multica autopilot trigger <autopilot-id> --output json
 multica autopilot trigger-rotate-url <autopilot-id> <trigger-id> --yes --output json

--- a/server/internal/service/builtin_skills/multica-autopilots/references/autopilots-source-map.md
+++ b/server/internal/service/builtin_skills/multica-autopilots/references/autopilots-source-map.md
@@ -2,7 +2,7 @@
 
 - `server/cmd/multica/cmd_autopilot.go` registers `list`, `get`, `create`, `update`, `delete`, `trigger`, `runs`, `trigger-add`, `trigger-update`, `trigger-delete`, and `trigger-rotate-url`.
 - The CLI maps reads/writes to `/api/autopilots`, `/api/autopilots/{id}`, `/api/autopilots/{id}/trigger`, `/api/autopilots/{id}/runs`, and trigger subroutes.
-- `server/internal/service/autopilot.go` has `DispatchAutopilot`, creates `autopilot_run`, and switches on `execution_mode`.
+- `server/internal/service/autopilot.go` has `DispatchAutopilot`, creates `autopilot_run`, and switches on `execution_mode`. `DispatchScheduledAutopilotForPlan` applies schedule `overlap_policy`; `coalesce` serializes admission and skips new run/task creation while earlier `run_only` work is active.
 - `create_issue` calls `dispatchCreateIssue`; `run_only` calls `dispatchRunOnly`.
 - `resolveAutopilotLeader` resolves squad-assigned autopilots to the squad leader.
 - `AgentReadiness` blocks archived/runtime-unready agents before enqueue.

--- a/server/migrations/175_autopilot_trigger_overlap_policy.down.sql
+++ b/server/migrations/175_autopilot_trigger_overlap_policy.down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE autopilot_trigger DROP COLUMN IF EXISTS overlap_policy;

--- a/server/migrations/175_autopilot_trigger_overlap_policy.up.sql
+++ b/server/migrations/175_autopilot_trigger_overlap_policy.up.sql
@@ -1,0 +1,6 @@
+ALTER TABLE autopilot_trigger
+    ADD COLUMN overlap_policy TEXT NOT NULL DEFAULT 'allow'
+        CHECK (overlap_policy IN ('allow', 'coalesce'));
+
+COMMENT ON COLUMN autopilot_trigger.overlap_policy IS
+    'Schedule overlap policy: allow creates every occurrence; coalesce skips new work while an earlier run_only task is active.';

--- a/server/pkg/db/generated/autopilot.sql.go
+++ b/server/pkg/db/generated/autopilot.sql.go
@@ -291,13 +291,14 @@ func (q *Queries) CreateAutopilotTask(ctx context.Context, arg CreateAutopilotTa
 const createAutopilotTrigger = `-- name: CreateAutopilotTrigger :one
 INSERT INTO autopilot_trigger (
     autopilot_id, kind, enabled, cron_expression, timezone,
-    next_run_at, webhook_token, label, provider, event_filters
+    next_run_at, webhook_token, label, provider, event_filters, overlap_policy
 ) VALUES (
     $1, $2, $3, $4, $5,
     $6, $7, $8,
     COALESCE($9::text, 'generic'),
-    $10
-) RETURNING id, autopilot_id, kind, enabled, cron_expression, timezone, next_run_at, webhook_token, label, last_fired_at, created_at, updated_at, provider, signing_secret, event_filters
+    $10,
+    COALESCE($11::text, 'allow')
+) RETURNING id, autopilot_id, kind, enabled, cron_expression, timezone, next_run_at, webhook_token, label, last_fired_at, created_at, updated_at, provider, signing_secret, event_filters, overlap_policy
 `
 
 type CreateAutopilotTriggerParams struct {
@@ -311,6 +312,7 @@ type CreateAutopilotTriggerParams struct {
 	Label          pgtype.Text        `json:"label"`
 	Provider       pgtype.Text        `json:"provider"`
 	EventFilters   []byte             `json:"event_filters"`
+	OverlapPolicy  pgtype.Text        `json:"overlap_policy"`
 }
 
 func (q *Queries) CreateAutopilotTrigger(ctx context.Context, arg CreateAutopilotTriggerParams) (AutopilotTrigger, error) {
@@ -325,6 +327,7 @@ func (q *Queries) CreateAutopilotTrigger(ctx context.Context, arg CreateAutopilo
 		arg.Label,
 		arg.Provider,
 		arg.EventFilters,
+		arg.OverlapPolicy,
 	)
 	var i AutopilotTrigger
 	err := row.Scan(
@@ -343,6 +346,7 @@ func (q *Queries) CreateAutopilotTrigger(ctx context.Context, arg CreateAutopilo
 		&i.Provider,
 		&i.SigningSecret,
 		&i.EventFilters,
+		&i.OverlapPolicy,
 	)
 	return i, err
 }
@@ -406,6 +410,42 @@ WHERE issue_id = $1
 func (q *Queries) FailAutopilotRunsByIssue(ctx context.Context, issueID pgtype.UUID) error {
 	_, err := q.db.Exec(ctx, failAutopilotRunsByIssue, issueID)
 	return err
+}
+
+const getActiveAutopilotRunOnlyRun = `-- name: GetActiveAutopilotRunOnlyRun :one
+SELECT run.id, run.autopilot_id, run.trigger_id, run.source, run.status, run.issue_id, run.task_id, run.triggered_at, run.completed_at, run.failure_reason, run.trigger_payload, run.result, run.created_at, run.squad_id, run.planned_at
+FROM autopilot_run run
+JOIN agent_task_queue task ON task.autopilot_run_id = run.id
+WHERE run.autopilot_id = $1
+  AND task.status IN ('queued', 'dispatched', 'running', 'waiting_local_directory')
+ORDER BY task.created_at ASC
+LIMIT 1
+`
+
+// Returns the durable active run_only work that makes a coalescing schedule
+// occurrence a successful no-op. The task status is authoritative: a run may
+// briefly lag its terminal task until SyncRunFromTask updates it.
+func (q *Queries) GetActiveAutopilotRunOnlyRun(ctx context.Context, autopilotID pgtype.UUID) (AutopilotRun, error) {
+	row := q.db.QueryRow(ctx, getActiveAutopilotRunOnlyRun, autopilotID)
+	var i AutopilotRun
+	err := row.Scan(
+		&i.ID,
+		&i.AutopilotID,
+		&i.TriggerID,
+		&i.Source,
+		&i.Status,
+		&i.IssueID,
+		&i.TaskID,
+		&i.TriggeredAt,
+		&i.CompletedAt,
+		&i.FailureReason,
+		&i.TriggerPayload,
+		&i.Result,
+		&i.CreatedAt,
+		&i.SquadID,
+		&i.PlannedAt,
+	)
+	return i, err
 }
 
 const getAutopilot = `-- name: GetAutopilot :one
@@ -574,7 +614,7 @@ func (q *Queries) GetAutopilotRunByTriggerAndPlanned(ctx context.Context, arg Ge
 }
 
 const getAutopilotTrigger = `-- name: GetAutopilotTrigger :one
-SELECT id, autopilot_id, kind, enabled, cron_expression, timezone, next_run_at, webhook_token, label, last_fired_at, created_at, updated_at, provider, signing_secret, event_filters FROM autopilot_trigger
+SELECT id, autopilot_id, kind, enabled, cron_expression, timezone, next_run_at, webhook_token, label, last_fired_at, created_at, updated_at, provider, signing_secret, event_filters, overlap_policy FROM autopilot_trigger
 WHERE id = $1
 `
 
@@ -597,12 +637,13 @@ func (q *Queries) GetAutopilotTrigger(ctx context.Context, id pgtype.UUID) (Auto
 		&i.Provider,
 		&i.SigningSecret,
 		&i.EventFilters,
+		&i.OverlapPolicy,
 	)
 	return i, err
 }
 
 const getWebhookTriggerByToken = `-- name: GetWebhookTriggerByToken :one
-SELECT t.id, t.autopilot_id, t.kind, t.enabled, t.cron_expression, t.timezone, t.next_run_at, t.webhook_token, t.label, t.last_fired_at, t.created_at, t.updated_at, t.provider, t.signing_secret, t.event_filters, a.workspace_id AS autopilot_workspace_id
+SELECT t.id, t.autopilot_id, t.kind, t.enabled, t.cron_expression, t.timezone, t.next_run_at, t.webhook_token, t.label, t.last_fired_at, t.created_at, t.updated_at, t.provider, t.signing_secret, t.event_filters, t.overlap_policy, a.workspace_id AS autopilot_workspace_id
 FROM autopilot_trigger t
 JOIN autopilot a ON a.id = t.autopilot_id
 WHERE t.kind = 'webhook'
@@ -625,6 +666,7 @@ type GetWebhookTriggerByTokenRow struct {
 	Provider             string             `json:"provider"`
 	SigningSecret        pgtype.Text        `json:"signing_secret"`
 	EventFilters         []byte             `json:"event_filters"`
+	OverlapPolicy        string             `json:"overlap_policy"`
 	AutopilotWorkspaceID pgtype.UUID        `json:"autopilot_workspace_id"`
 }
 
@@ -652,6 +694,7 @@ func (q *Queries) GetWebhookTriggerByToken(ctx context.Context, webhookToken pgt
 		&i.Provider,
 		&i.SigningSecret,
 		&i.EventFilters,
+		&i.OverlapPolicy,
 		&i.AutopilotWorkspaceID,
 	)
 	return i, err
@@ -826,7 +869,7 @@ func (q *Queries) ListAutopilotSubscribers(ctx context.Context, autopilotID pgty
 
 const listAutopilotTriggers = `-- name: ListAutopilotTriggers :many
 
-SELECT id, autopilot_id, kind, enabled, cron_expression, timezone, next_run_at, webhook_token, label, last_fired_at, created_at, updated_at, provider, signing_secret, event_filters FROM autopilot_trigger
+SELECT id, autopilot_id, kind, enabled, cron_expression, timezone, next_run_at, webhook_token, label, last_fired_at, created_at, updated_at, provider, signing_secret, event_filters, overlap_policy FROM autopilot_trigger
 WHERE autopilot_id = $1
 ORDER BY created_at ASC
 `
@@ -859,6 +902,7 @@ func (q *Queries) ListAutopilotTriggers(ctx context.Context, autopilotID pgtype.
 			&i.Provider,
 			&i.SigningSecret,
 			&i.EventFilters,
+			&i.OverlapPolicy,
 		); err != nil {
 			return nil, err
 		}
@@ -1032,6 +1076,69 @@ func (q *Queries) ListSchedulableAutopilotTriggers(ctx context.Context) ([]ListS
 	return items, nil
 }
 
+const lockAutopilotForSchedulePolicy = `-- name: LockAutopilotForSchedulePolicy :one
+SELECT id, workspace_id, title, description, assignee_id, status, execution_mode, issue_title_template, created_by_type, created_by_id, last_run_at, created_at, updated_at, assignee_type, project_id FROM autopilot
+WHERE id = $1
+FOR UPDATE
+`
+
+// Serializes schedule admission and overlap-policy mutations for one
+// Autopilot. Callers always acquire this parent lock before a trigger lock.
+func (q *Queries) LockAutopilotForSchedulePolicy(ctx context.Context, id pgtype.UUID) (Autopilot, error) {
+	row := q.db.QueryRow(ctx, lockAutopilotForSchedulePolicy, id)
+	var i Autopilot
+	err := row.Scan(
+		&i.ID,
+		&i.WorkspaceID,
+		&i.Title,
+		&i.Description,
+		&i.AssigneeID,
+		&i.Status,
+		&i.ExecutionMode,
+		&i.IssueTitleTemplate,
+		&i.CreatedByType,
+		&i.CreatedByID,
+		&i.LastRunAt,
+		&i.CreatedAt,
+		&i.UpdatedAt,
+		&i.AssigneeType,
+		&i.ProjectID,
+	)
+	return i, err
+}
+
+const lockAutopilotTriggerForSchedulePolicy = `-- name: LockAutopilotTriggerForSchedulePolicy :one
+SELECT id, autopilot_id, kind, enabled, cron_expression, timezone, next_run_at, webhook_token, label, last_fired_at, created_at, updated_at, provider, signing_secret, event_filters, overlap_policy FROM autopilot_trigger
+WHERE id = $1
+FOR UPDATE
+`
+
+// Freezes one trigger while schedule admission or a policy mutation is
+// decided. The parent Autopilot lock must already be held.
+func (q *Queries) LockAutopilotTriggerForSchedulePolicy(ctx context.Context, id pgtype.UUID) (AutopilotTrigger, error) {
+	row := q.db.QueryRow(ctx, lockAutopilotTriggerForSchedulePolicy, id)
+	var i AutopilotTrigger
+	err := row.Scan(
+		&i.ID,
+		&i.AutopilotID,
+		&i.Kind,
+		&i.Enabled,
+		&i.CronExpression,
+		&i.Timezone,
+		&i.NextRunAt,
+		&i.WebhookToken,
+		&i.Label,
+		&i.LastFiredAt,
+		&i.CreatedAt,
+		&i.UpdatedAt,
+		&i.Provider,
+		&i.SigningSecret,
+		&i.EventFilters,
+		&i.OverlapPolicy,
+	)
+	return i, err
+}
+
 const recoverPartialAutopilotRun = `-- name: RecoverPartialAutopilotRun :exec
 UPDATE autopilot_run
 SET status = 'failed',
@@ -1062,7 +1169,7 @@ SET webhook_token = $2,
     updated_at = now()
 WHERE id = $1
   AND kind = 'webhook'
-RETURNING id, autopilot_id, kind, enabled, cron_expression, timezone, next_run_at, webhook_token, label, last_fired_at, created_at, updated_at, provider, signing_secret, event_filters
+RETURNING id, autopilot_id, kind, enabled, cron_expression, timezone, next_run_at, webhook_token, label, last_fired_at, created_at, updated_at, provider, signing_secret, event_filters, overlap_policy
 `
 
 type RotateAutopilotTriggerWebhookTokenParams struct {
@@ -1092,6 +1199,7 @@ func (q *Queries) RotateAutopilotTriggerWebhookToken(ctx context.Context, arg Ro
 		&i.Provider,
 		&i.SigningSecret,
 		&i.EventFilters,
+		&i.OverlapPolicy,
 	)
 	return i, err
 }
@@ -1184,7 +1292,7 @@ SET signing_secret = $2,
     updated_at = now()
 WHERE id = $1
   AND kind = 'webhook'
-RETURNING id, autopilot_id, kind, enabled, cron_expression, timezone, next_run_at, webhook_token, label, last_fired_at, created_at, updated_at, provider, signing_secret, event_filters
+RETURNING id, autopilot_id, kind, enabled, cron_expression, timezone, next_run_at, webhook_token, label, last_fired_at, created_at, updated_at, provider, signing_secret, event_filters, overlap_policy
 `
 
 type SetAutopilotTriggerSigningSecretParams struct {
@@ -1216,6 +1324,7 @@ func (q *Queries) SetAutopilotTriggerSigningSecret(ctx context.Context, arg SetA
 		&i.Provider,
 		&i.SigningSecret,
 		&i.EventFilters,
+		&i.OverlapPolicy,
 	)
 	return i, err
 }
@@ -1225,7 +1334,7 @@ UPDATE autopilot_trigger
 SET webhook_token = $2,
     updated_at = now()
 WHERE id = $1
-RETURNING id, autopilot_id, kind, enabled, cron_expression, timezone, next_run_at, webhook_token, label, last_fired_at, created_at, updated_at, provider, signing_secret, event_filters
+RETURNING id, autopilot_id, kind, enabled, cron_expression, timezone, next_run_at, webhook_token, label, last_fired_at, created_at, updated_at, provider, signing_secret, event_filters, overlap_policy
 `
 
 type SetAutopilotTriggerWebhookTokenParams struct {
@@ -1257,6 +1366,7 @@ func (q *Queries) SetAutopilotTriggerWebhookToken(ctx context.Context, arg SetAu
 		&i.Provider,
 		&i.SigningSecret,
 		&i.EventFilters,
+		&i.OverlapPolicy,
 	)
 	return i, err
 }
@@ -1609,9 +1719,10 @@ UPDATE autopilot_trigger SET
     next_run_at = $5,
     label = COALESCE($6, label),
     event_filters = COALESCE($7, event_filters),
+    overlap_policy = COALESCE($8::text, overlap_policy),
     updated_at = now()
 WHERE id = $1
-RETURNING id, autopilot_id, kind, enabled, cron_expression, timezone, next_run_at, webhook_token, label, last_fired_at, created_at, updated_at, provider, signing_secret, event_filters
+RETURNING id, autopilot_id, kind, enabled, cron_expression, timezone, next_run_at, webhook_token, label, last_fired_at, created_at, updated_at, provider, signing_secret, event_filters, overlap_policy
 `
 
 type UpdateAutopilotTriggerParams struct {
@@ -1622,6 +1733,7 @@ type UpdateAutopilotTriggerParams struct {
 	NextRunAt      pgtype.Timestamptz `json:"next_run_at"`
 	Label          pgtype.Text        `json:"label"`
 	EventFilters   []byte             `json:"event_filters"`
+	OverlapPolicy  pgtype.Text        `json:"overlap_policy"`
 }
 
 func (q *Queries) UpdateAutopilotTrigger(ctx context.Context, arg UpdateAutopilotTriggerParams) (AutopilotTrigger, error) {
@@ -1633,6 +1745,7 @@ func (q *Queries) UpdateAutopilotTrigger(ctx context.Context, arg UpdateAutopilo
 		arg.NextRunAt,
 		arg.Label,
 		arg.EventFilters,
+		arg.OverlapPolicy,
 	)
 	var i AutopilotTrigger
 	err := row.Scan(
@@ -1651,6 +1764,7 @@ func (q *Queries) UpdateAutopilotTrigger(ctx context.Context, arg UpdateAutopilo
 		&i.Provider,
 		&i.SigningSecret,
 		&i.EventFilters,
+		&i.OverlapPolicy,
 	)
 	return i, err
 }

--- a/server/pkg/db/generated/models.go
+++ b/server/pkg/db/generated/models.go
@@ -223,6 +223,8 @@ type AutopilotTrigger struct {
 	Provider       string             `json:"provider"`
 	SigningSecret  pgtype.Text        `json:"signing_secret"`
 	EventFilters   []byte             `json:"event_filters"`
+	// Schedule overlap policy: allow creates every occurrence; coalesce skips new work while an earlier run_only task is active.
+	OverlapPolicy string `json:"overlap_policy"`
 }
 
 type ChannelBindingToken struct {

--- a/server/pkg/db/queries/autopilot.sql
+++ b/server/pkg/db/queries/autopilot.sql
@@ -94,12 +94,13 @@ WHERE id = $1;
 -- name: CreateAutopilotTrigger :one
 INSERT INTO autopilot_trigger (
     autopilot_id, kind, enabled, cron_expression, timezone,
-    next_run_at, webhook_token, label, provider, event_filters
+    next_run_at, webhook_token, label, provider, event_filters, overlap_policy
 ) VALUES (
     $1, $2, $3, sqlc.narg('cron_expression'), sqlc.narg('timezone'),
     sqlc.narg('next_run_at'), sqlc.narg('webhook_token'), sqlc.narg('label'),
     COALESCE(sqlc.narg('provider')::text, 'generic'),
-    sqlc.narg('event_filters')
+    sqlc.narg('event_filters'),
+    COALESCE(sqlc.narg('overlap_policy')::text, 'allow')
 ) RETURNING *;
 
 -- name: UpdateAutopilotTrigger :one
@@ -110,9 +111,36 @@ UPDATE autopilot_trigger SET
     next_run_at = sqlc.narg('next_run_at'),
     label = COALESCE(sqlc.narg('label'), label),
     event_filters = COALESCE(sqlc.narg('event_filters'), event_filters),
+    overlap_policy = COALESCE(sqlc.narg('overlap_policy')::text, overlap_policy),
     updated_at = now()
 WHERE id = $1
 RETURNING *;
+
+-- name: LockAutopilotForSchedulePolicy :one
+-- Serializes schedule admission and overlap-policy mutations for one
+-- Autopilot. Callers always acquire this parent lock before a trigger lock.
+SELECT * FROM autopilot
+WHERE id = $1
+FOR UPDATE;
+
+-- name: LockAutopilotTriggerForSchedulePolicy :one
+-- Freezes one trigger while schedule admission or a policy mutation is
+-- decided. The parent Autopilot lock must already be held.
+SELECT * FROM autopilot_trigger
+WHERE id = $1
+FOR UPDATE;
+
+-- name: GetActiveAutopilotRunOnlyRun :one
+-- Returns the durable active run_only work that makes a coalescing schedule
+-- occurrence a successful no-op. The task status is authoritative: a run may
+-- briefly lag its terminal task until SyncRunFromTask updates it.
+SELECT run.*
+FROM autopilot_run run
+JOIN agent_task_queue task ON task.autopilot_run_id = run.id
+WHERE run.autopilot_id = $1
+  AND task.status IN ('queued', 'dispatched', 'running', 'waiting_local_directory')
+ORDER BY task.created_at ASC
+LIMIT 1;
 
 -- name: DeleteAutopilotTrigger :exec
 DELETE FROM autopilot_trigger WHERE id = $1;


### PR DESCRIPTION
## Summary

- add an opt-in schedule overlap policy (`allow` by default, `coalesce` for `run_only`)
- serialize schedule admission and policy mutations with a consistent Autopilot → trigger lock order
- create the initial run and task atomically, and defer events, analytics, and daemon wakeups until commit
- record overlapping occurrences as successful scheduler no-ops without creating another run or task
- expose the policy through the API, TypeScript client, CLI, migration, and built-in Autopilot skill

## Verification

- `go test ./cmd/server ./cmd/multica ./internal/handler ./internal/scheduler ./internal/service ./pkg/db/generated -count=1`
- `go test -race ./cmd/server ./internal/handler -run "Test(DispatchScheduledAutopilotForPlanCoalescesActiveRun|AutopilotSchedulePolicyMutationsPreserveCrossTableInvariant)" -count=1`
- `go vet ./cmd/server ./cmd/multica ./internal/handler ./internal/scheduler ./internal/service`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm --filter @multica/core test -- api/schemas.test.ts api/client.test.ts autopilots/webhook.test.ts` (80 files, 839 tests)
- applied all migrations through 175 against a fresh PostgreSQL 17 database and verified the default and CHECK constraint

## Notes

The policy is opt-in, so existing schedule behavior remains unchanged. No production rollout is included.