### PR TITLE
fix(agent): prefer active Codex model catalog

### DIFF
--- a/server/internal/service/builtin_skills/multica-creating-agents/SKILL.md
+++ b/server/internal/service/builtin_skills/multica-creating-agents/SKILL.md
@@ -100,10 +100,12 @@ update`, mirroring `--model`: the flag is a thin pass-through to the top-level
 clears it back to the runtime default. The CLI deliberately does not enumerate
 the valid levels — they are runtime/model-specific (Claude currently uses
 `low|medium|high|xhigh|max`; Codex values are discovered from the runtime's
-model catalog). It forwards the token, the server applies the provider's
-fixed-enum or safe-token gate, and the daemon performs the exact model/level
-check. A runtime whose provider has no thinking concept rejects any non-empty
-value with a 400.
+model catalog). Codex discovery prefers the CLI's active cached/account catalog,
+then falls back to its bundled catalog and finally Multica's static snapshot,
+so account-visible models stay selectable without sacrificing offline behavior.
+It forwards the token, the server applies the provider's fixed-enum or safe-token
+gate, and the daemon performs the exact model/level check. A runtime whose
+provider has no thinking concept rejects any non-empty value with a 400.
 
 ### model vs custom_args
 

--- a/server/internal/service/builtin_skills/multica-creating-agents/references/creating-agents-source-map.md
+++ b/server/internal/service/builtin_skills/multica-creating-agents/references/creating-agents-source-map.md
@@ -72,10 +72,10 @@ only.
 |---|---|---|
 | Codex model-list entry point | `models.go` 94–103 | `ListModels("codex")` uses cached daemon-local discovery instead of returning the fallback catalog unconditionally |
 | Codex fallback catalog | `models.go` 301–354 | Used for Codex <0.122.0 and failed/malformed discovery; includes current verified visible models plus legacy `gpt-5.3-codex`, with a separate `Thinking` catalog on every model |
-| Codex discovery version gate | `thinking.go` 280, 306–337 | `codex debug models --bundled` is used only for parseable versions ≥0.122.0; unsupported versions and command/parse/empty failures return the static model + thinking fallback |
-| Codex catalog projection | `thinking.go` 355–409 | Hidden models are excluded; visible `slug`/`display_name` rows and each row's `supported_reasoning_levels`/`default_reasoning_level` are preserved |
-| Per-model thinking validation | `thinking.go` 547–640 | `ValidateThinkingLevel` accepts only values in the explicit model's `Thinking.SupportedLevels`; an empty Codex model fails closed because its effective `config.toml` model is unknown |
-| Dynamic Codex token gate | `thinking.go` 642–710 | Server persistence accepts syntactically safe Codex tokens so new catalog values do not require a Multica release; exact support remains a daemon-local per-model check |
+| Codex discovery version gate | `thinking.go` 285, 312–363 | Parseable versions ≥0.122.0 try `codex debug models` against the active cached/account catalog, then `--bundled`, then the static model + thinking fallback; one 15s context bounds both catalog commands |
+| Codex catalog projection | `thinking.go` 372–426 | Hidden models are excluded; visible `slug`/`display_name` rows and each row's `supported_reasoning_levels`/`default_reasoning_level` are preserved |
+| Per-model thinking validation | `thinking.go` 594–657 | `ValidateThinkingLevel` accepts only values in the explicit model's `Thinking.SupportedLevels`; an empty Codex model fails closed because its effective `config.toml` model is unknown |
+| Dynamic Codex token gate | `thinking.go` 688–728 | Server persistence accepts syntactically safe Codex tokens so new catalog values do not require a Multica release; exact support remains a daemon-local per-model check |
 | Daemon invalid-combination handling | `internal/daemon/daemon.go` 3860–3892 | Before execution, invalid `(provider, model, thinking_level)` combinations log a warning and omit the override rather than failing the task |
 
 ## Env endpoint — `server/internal/handler/agent_env.go`

--- a/server/pkg/agent/thinking.go
+++ b/server/pkg/agent/thinking.go
@@ -240,9 +240,9 @@ func projectClaudeLevels(superset []string, allow map[string]bool) []ThinkingLev
 
 // ── Codex ────────────────────────────────────────────────────────────
 //
-// `codex debug models --bundled` is the structured discovery hook for both
-// the visible model catalog and each model's reasoning catalog. OpenAI added
-// the command and `--bundled` flag together in Codex 0.122.0 (openai/codex
+// `codex debug models` is the structured discovery hook for both the visible
+// model catalog and each model's reasoning catalog. OpenAI added the command
+// and `--bundled` fallback flag together in Codex 0.122.0 (openai/codex
 // #18625). Older versions, failed invocations, and malformed/empty payloads
 // use codexStaticModels so the picker remains usable.
 //
@@ -251,14 +251,13 @@ func projectClaudeLevels(superset []string, allow map[string]bool) []ThinkingLev
 //   2. The schema is structured and has been stable since its 0.122.0 debut.
 //   3. It doesn't pollute stderr with an intentional misconfiguration.
 //
-// The subcommand emits JSON on stdout by default — there is no
-// `--output json` flag (a prior version of this code passed one and
-// silently failed on 0.131.0). We add `--bundled` to skip the network
-// refresh: discovery runs on every daemon poll and a network hop here
-// would block the picker behind whatever the user's connection allows.
-// The bundled catalog is what determines which `model_reasoning_effort`
-// tokens the local binary actually accepts, which is the only thing we
-// need for validation.
+// The subcommand emits JSON on stdout by default — there is no `--output json`
+// flag (a prior version of this code passed one and silently failed on
+// 0.131.0). The unflagged command reads Codex's active cached/account catalog
+// and refreshes online only when uncached. If that attempt fails, is malformed,
+// or is empty, `--bundled` supplies the binary's offline catalog before we fall
+// back to Multica's static snapshot. A single timeout bounds both CLI calls so
+// an unavailable network cannot hold the picker open indefinitely.
 //
 // The static fallback deliberately mirrors a recently verified bundled
 // catalog, including thinking metadata, rather than guessing model IDs.
@@ -278,10 +277,11 @@ var codexEffortLabel = map[string]string{
 }
 
 const minCodexDebugModelsVersion = "0.122.0"
+const codexModelDiscoveryTimeout = 15 * time.Second
 
 // codexDebugModelsResponse mirrors the JSON shape emitted by
-// `codex debug models --bundled` (Codex 0.122.0+). Only the fields we
-// consume are typed; unknown keys are ignored.
+// `codex debug models` and its `--bundled` fallback (Codex 0.122.0+). Only the
+// fields we consume are typed; unknown keys are ignored.
 type codexDebugModelsResponse struct {
 	Models []codexDebugModel `json:"models"`
 }
@@ -312,15 +312,9 @@ func discoverCodexModels(ctx context.Context, executablePath string) []Model {
 		return codexStaticModels()
 	}
 
-	raw, err := runCodexDebugModels(ctx, executablePath)
-	if err != nil {
-		return codexStaticModels()
-	}
-	models, err := parseCodexModelCatalog(raw)
-	if err != nil || len(models) == 0 {
-		return codexStaticModels()
-	}
-	return models
+	discoveryCtx, cancel := context.WithTimeout(ctx, codexModelDiscoveryTimeout)
+	defer cancel()
+	return discoverCodexCatalog(discoveryCtx, executablePath, runCodexDebugModels)
 }
 
 func codexSupportsDebugModels(version string) bool {
@@ -335,23 +329,40 @@ func codexSupportsDebugModels(version string) bool {
 	return !parsed.lessThan(minimum)
 }
 
-// codexDebugModelsArgs is the argv we pass to discover the local Codex
-// catalog. Kept as a package-level var (not a literal at the call site)
-// so tests can assert the exact form a real `codex` invocation receives,
-// not just the parser behavior on a fixture string. The argv shape is
-// the contract that broke under PR1 review; the test that pins it sits
-// in thinking_test.go.
-var codexDebugModelsArgs = []string{"debug", "models", "--bundled"}
+type codexModelCatalogRunner func(context.Context, string, []string) ([]byte, error)
 
-func runCodexDebugModels(ctx context.Context, executablePath string) ([]byte, error) {
-	cmd := exec.CommandContext(ctx, executablePath, codexDebugModelsArgs...)
+// These argv values are package variables so tests can pin what a real Codex
+// process receives. The live command must remain unflagged: `--bundled` skips
+// the active cache/account catalog and caused multica#5362.
+var (
+	codexDebugModelsLiveArgs    = []string{"debug", "models"}
+	codexDebugModelsBundledArgs = []string{"debug", "models", "--bundled"}
+)
+
+func discoverCodexCatalog(ctx context.Context, executablePath string, run codexModelCatalogRunner) []Model {
+	for _, args := range [][]string{codexDebugModelsLiveArgs, codexDebugModelsBundledArgs} {
+		raw, err := run(ctx, executablePath, args)
+		if err != nil {
+			continue
+		}
+		models, err := parseCodexModelCatalog(raw)
+		if err == nil && len(models) > 0 {
+			return models
+		}
+	}
+	return codexStaticModels()
+}
+
+func runCodexDebugModels(ctx context.Context, executablePath string, args []string) ([]byte, error) {
+	cmd := exec.CommandContext(ctx, executablePath, args...)
 	hideAgentWindow(cmd)
+	cmd.WaitDelay = 2 * time.Second
 	return cmd.Output()
 }
 
 // parseCodexModelCatalog projects the CLI's raw catalog into the daemon wire
 // model. Hidden entries are intentionally excluded to match Codex's own model
-// picker; the first visible entry is the bundled catalog's preferred default.
+// picker; the first visible entry is the selected catalog's preferred default.
 func parseCodexModelCatalog(raw []byte) ([]Model, error) {
 	var resp codexDebugModelsResponse
 	if err := json.Unmarshal(raw, &resp); err != nil {

--- a/server/pkg/agent/thinking_test.go
+++ b/server/pkg/agent/thinking_test.go
@@ -119,8 +119,8 @@ func TestProjectClaudeLevels_PerModelSubset(t *testing.T) {
 //
 // Elon's PR1 review found that `codex debug models --output json` is
 // rejected by codex-cli 0.131.0 — there is no `--output` flag on the
-// subcommand. The fix was to drop the flag and add `--bundled` (which
-// just skips network refresh). These two tests pin the contract:
+// subcommand. The active catalog command stays unflagged; its bundled fallback
+// adds only `--bundled`. These two tests pin the contract:
 //
 //   - TestCodexDebugModelsArgs_Pinned asserts the literal argv we pass
 //     so a future "let's add a flag" refactor breaks loudly instead of
@@ -131,13 +131,22 @@ func TestProjectClaudeLevels_PerModelSubset(t *testing.T) {
 
 func TestCodexDebugModelsArgs_Pinned(t *testing.T) {
 	t.Parallel()
-	want := []string{"debug", "models", "--bundled"}
-	if !reflect.DeepEqual(codexDebugModelsArgs, want) {
-		t.Fatalf("codexDebugModelsArgs drifted: got %v, want %v", codexDebugModelsArgs, want)
+	cases := []struct {
+		name string
+		got  []string
+		want []string
+	}{
+		{name: "live", got: codexDebugModelsLiveArgs, want: []string{"debug", "models"}},
+		{name: "bundled", got: codexDebugModelsBundledArgs, want: []string{"debug", "models", "--bundled"}},
 	}
-	for _, arg := range codexDebugModelsArgs {
-		if arg == "--output" || arg == "-o" {
-			t.Errorf("--output / -o leaked back into argv (codex CLI does not accept it): %v", codexDebugModelsArgs)
+	for _, tc := range cases {
+		if !reflect.DeepEqual(tc.got, tc.want) {
+			t.Errorf("%s Codex argv drifted: got %v, want %v", tc.name, tc.got, tc.want)
+		}
+		for _, arg := range tc.got {
+			if arg == "--output" || arg == "-o" {
+				t.Errorf("--output / -o leaked back into %s argv: %v", tc.name, tc.got)
+			}
 		}
 	}
 }
@@ -166,19 +175,26 @@ func TestRunCodexDebugModels_ArgvSeenByBinary(t *testing.T) {
 	// Linux ETXTBSY when we exec the file (Go #22315).
 	writeTestExecutable(t, fake, []byte(script))
 
-	raw, err := runCodexDebugModels(context.Background(), fake)
-	if err != nil {
-		t.Fatalf("runCodexDebugModels: %v (output=%q)", err, raw)
-	}
+	for _, tc := range []struct {
+		name string
+		args []string
+	}{
+		{name: "live", args: codexDebugModelsLiveArgs},
+		{name: "bundled", args: codexDebugModelsBundledArgs},
+	} {
+		raw, err := runCodexDebugModels(context.Background(), fake, tc.args)
+		if err != nil {
+			t.Fatalf("runCodexDebugModels(%s): %v (output=%q)", tc.name, err, raw)
+		}
 
-	data, err := os.ReadFile(argvFile)
-	if err != nil {
-		t.Fatalf("read argv file: %v", err)
-	}
-	got := splitNonEmptyLines(string(data))
-	want := []string{"debug", "models", "--bundled"}
-	if !reflect.DeepEqual(got, want) {
-		t.Fatalf("fake codex received argv %v, want %v", got, want)
+		data, err := os.ReadFile(argvFile)
+		if err != nil {
+			t.Fatalf("read argv file: %v", err)
+		}
+		got := splitNonEmptyLines(string(data))
+		if !reflect.DeepEqual(got, tc.args) {
+			t.Fatalf("fake codex received %s argv %v, want %v", tc.name, got, tc.args)
+		}
 	}
 }
 
@@ -273,12 +289,79 @@ func TestParseCodexModelCatalogMalformed(t *testing.T) {
 	}
 }
 
+func TestDiscoverCodexCatalogPrefersActiveCatalog(t *testing.T) {
+	t.Parallel()
+	var calls [][]string
+	run := func(_ context.Context, _ string, args []string) ([]byte, error) {
+		calls = append(calls, append([]string(nil), args...))
+		if reflect.DeepEqual(args, codexDebugModelsLiveArgs) {
+			return []byte(`{"models":[{"slug":"gpt-5.6-terra","display_name":"GPT-5.6-Terra","visibility":"list"}]}`), nil
+		}
+		return []byte(`{"models":[{"slug":"gpt-5.5","display_name":"GPT-5.5","visibility":"list"}]}`), nil
+	}
+
+	got := discoverCodexCatalog(context.Background(), "codex", run)
+	if len(got) != 1 || got[0].ID != "gpt-5.6-terra" {
+		t.Fatalf("expected active Terra catalog, got %+v", got)
+	}
+	if len(calls) != 1 || !reflect.DeepEqual(calls[0], codexDebugModelsLiveArgs) {
+		t.Fatalf("expected only the active catalog command, got calls=%v", calls)
+	}
+}
+
+func TestDiscoverCodexCatalogFallsBackInOrder(t *testing.T) {
+	t.Parallel()
+
+	t.Run("active failure uses bundled catalog", func(t *testing.T) {
+		var calls [][]string
+		run := func(_ context.Context, _ string, args []string) ([]byte, error) {
+			calls = append(calls, append([]string(nil), args...))
+			if reflect.DeepEqual(args, codexDebugModelsLiveArgs) {
+				return nil, context.DeadlineExceeded
+			}
+			return []byte(`{"models":[{"slug":"gpt-5.5","display_name":"GPT-5.5","visibility":"list"}]}`), nil
+		}
+
+		got := discoverCodexCatalog(context.Background(), "codex", run)
+		if len(got) != 1 || got[0].ID != "gpt-5.5" {
+			t.Fatalf("expected bundled catalog, got %+v", got)
+		}
+		wantCalls := [][]string{codexDebugModelsLiveArgs, codexDebugModelsBundledArgs}
+		if !reflect.DeepEqual(calls, wantCalls) {
+			t.Fatalf("catalog calls = %v, want %v", calls, wantCalls)
+		}
+	})
+
+	t.Run("invalid active and bundled catalogs use static fallback", func(t *testing.T) {
+		run := func(_ context.Context, _ string, _ []string) ([]byte, error) {
+			return []byte(`{"models":[]}`), nil
+		}
+
+		got := discoverCodexCatalog(context.Background(), "codex", run)
+		if len(got) == 0 || got[0].ID != "gpt-5.6-sol" {
+			t.Fatalf("expected static fallback, got %+v", got)
+		}
+		if !containsModel(got, "gpt-5.6-terra") {
+			t.Fatalf("static fallback must retain Terra, got %+v", got)
+		}
+	})
+}
+
+func containsModel(models []Model, id string) bool {
+	for _, model := range models {
+		if model.ID == id {
+			return true
+		}
+	}
+	return false
+}
+
 func TestDiscoverCodexModelsVersionGateAndFallback(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("shell-script fake binary requires a POSIX shell")
 	}
 
-	t.Run("supported version uses bundled catalog", func(t *testing.T) {
+	t.Run("supported version uses active catalog", func(t *testing.T) {
 		dir := t.TempDir()
 		fake := filepath.Join(dir, "codex")
 		script := `#!/bin/sh


### PR DESCRIPTION
  ## What does this PR do?

  Prefer the active Codex cached/account model catalog before falling back to bundled and
  static catalogs.

  Codex CLI 0.142.0 ships a non-empty bundled catalog that does not contain `gpt-5.6-
  terra`. Because Multica treated that successful bundled result as authoritative, it
  suppressed the newer static fallback entry already present in Multica v0.4.0.

  ## Related Issue

  Closes #5362

  ## Type of Change

  - [x] Bug fix (non-breaking change that fixes an issue)
  - [x] New feature (non-breaking change that adds functionality)
  - [ ] Refactor / code improvement (no behavior change)
  - [x] Documentation update
  - [x] Tests (adding or improving test coverage)
  - [ ] CI / infrastructure

  ## Changes Made

  - Query `codex debug models` first for the active cached/account catalog.
  - Fall back to `codex debug models --bundled`.
  - Fall back to Multica's static catalog when both CLI discovery paths fail.
  - Bound catalog discovery with a shared 15-second timeout.
  - Add regression tests for active, bundled, and static fallback ordering.
  - Update the agent-creation skill documentation and source map.

  ## How to Test

  1. Connect a Codex runtime configured with `gpt-5.6-terra`.
  2. Open an agent's model selector.
  3. Verify that `gpt-5.6-terra` appears in the catalog.

  Focused automated tests:

  ```shell
  cd server
  go test ./pkg/agent -run 'Test(CodexDebugModelsArgs_Pinned|
  RunCodexDebugModels_ArgvSeenByBinary|ParseCodexModelCatalog|DiscoverCodexCatalog|
  DiscoverCodexModelsVersionGateAndFallback|
  ValidateThinkingLevelCodexPerModelFallbackCatalog)$' -count=1
  ```

  The focused regression suite passes locally with Go 1.26.1.

  The full `pkg/agent` suite was also attempted on Windows. Unrelated existing tests
  failed because several executable fixtures and path assertions assume Unix behavior.

  ## Checklist

  - [x] I have included a thinking path that traces from project context to this change
  - [x] I have run the relevant tests locally and they pass
  - [x] I have added or updated tests where applicable
  - [ ] If this change affects the UI, I have included before/after screenshots
  - [x] I have updated relevant documentation to reflect my changes
  - [x] New runtime / coding tool / UI tab synchronization is not applicable
  - [x] Chinese product copy validation is not applicable
  - [x] I have considered and documented risks above
  - [x] I will address reviewer comments before requesting merge

  ## AI Disclosure

  AI tool used: OpenAI Codex

  Prompt / approach: Traced the model selector through the frontend runtime query, daemon
  model discovery, Codex CLI invocation, and fallback catalog. Compared Multica v0.4.0
  with Codex CLI 0.142.0, implemented layered discovery, and added focused regression
  tests.

  ## Screenshots (optional)

  Not included. This change affects catalog contents but does not change component layout.