### PR TITLE
fix(editor): open mention/slash popup upward and clamp height to viewport

### DIFF
--- a/packages/views/editor/extensions/mention-suggestion.tsx
+++ b/packages/views/editor/extensions/mention-suggestion.tsx
@@ -352,9 +352,15 @@ export const MentionList = forwardRef<MentionListRef, MentionListProps>(
       <div
         className={cn(
           "flex flex-col overflow-y-auto overscroll-contain border bg-popover py-1",
+          // Height budget: clamp to whichever is smaller — the design max or the
+          // viewport-aware `--suggestion-available-height` published by the
+          // floating-ui `size` middleware (suggestion-popup.tsx). The var falls
+          // back to the design max when the popup renders outside that
+          // controller. This is the single height authority; do not add a second
+          // fixed max-height above it or the list can overflow the viewport.
           contextLayout
-            ? "max-h-[420px] w-96 rounded-lg shadow-xl"
-            : "max-h-[300px] w-72 rounded-md shadow-md",
+            ? "max-h-[min(420px,var(--suggestion-available-height,420px))] w-96 rounded-lg shadow-xl"
+            : "max-h-[min(300px,var(--suggestion-available-height,300px))] w-72 rounded-md shadow-md",
         )}
       >
         {groups.map((group) => (

--- a/packages/views/editor/extensions/slash-command-suggestion.tsx
+++ b/packages/views/editor/extensions/slash-command-suggestion.tsx
@@ -127,7 +127,11 @@ export const SlashCommandList = forwardRef<
       : item.description;
 
   return (
-    <div className="rounded-md border bg-popover py-1 shadow-md w-72 max-h-[300px] overflow-y-auto">
+    // Height budget clamps to min(design max, viewport-aware
+    // `--suggestion-available-height` from suggestion-popup.tsx's size
+    // middleware), falling back to the design max when rendered standalone.
+    // Single height authority — mirrors MentionList.
+    <div className="rounded-md border bg-popover py-1 shadow-md w-72 max-h-[min(300px,var(--suggestion-available-height,300px))] overflow-y-auto">
       {items.map((item, index) => {
         const description = describe(item);
         return (

--- a/packages/views/editor/extensions/suggestion-popup.tsx
+++ b/packages/views/editor/extensions/suggestion-popup.tsx
@@ -126,7 +126,17 @@ export function createSuggestionPopupRender<
         getBoundingClientRect: () => clientRect() ?? new DOMRect(),
       };
       computePosition(virtualEl, el, {
-        placement: "bottom-start",
+        // Open upward by default. The dominant hosts are bottom-anchored
+        // composers (chat input, issue comment/reply) whose roomy side is above
+        // the caret; preferring that side means `size` clamps to a large budget
+        // with no visible compression, and `flip` only sends it down in the rare
+        // case the caret sits near the viewport top. A `bottom-start` default
+        // instead stayed down whenever *any* space existed below — even when far
+        // more room was above — which read as "mostly opens down and gets
+        // squashed". Document-body editors (issue/project description, agent
+        // instructions) also host this popup; there the caret usually has room
+        // both ways, so `flip` keeps them on-screen regardless of the default.
+        placement: "top-start",
         strategy: "fixed",
         middleware: [
           offset(6),
@@ -135,7 +145,20 @@ export function createSuggestionPopupRender<
           size({
             padding: 8,
             apply({ availableHeight }) {
-              el.style.maxHeight = `${Math.max(120, availableHeight)}px`;
+              // Publish the viewport-aware height budget as a CSS variable so
+              // the list component (the real scroll container) can clamp its own
+              // max-height to `min(designMax, availableHeight)`. Writing
+              // maxHeight on this wrapper is inert — the wrapper does not clip,
+              // the inner list scrolls — so it would let a fixed-height list
+              // overflow past the viewport edge. No floor here: when space is
+              // tight a short scrollable list beats one clipped off-screen.
+              el.style.setProperty(
+                "--suggestion-available-height",
+                // Guard against a negative budget (caret scrolled just out of
+                // the boundary): a negative max-height is invalid CSS and would
+                // drop the clamp entirely, letting the list overflow.
+                `${Math.max(0, Math.round(availableHeight))}px`,
+              );
             },
           }),
         ],


### PR DESCRIPTION
Closes MUL-4513

## Problem

The `@`-mention and `/`-command suggestion popups (shared by chat input, issue comment/reply, and document-body editors — all built on `ContentEditor` → `createSuggestionPopupRender`) could open **downward past the bottom of the screen and get clipped/squashed**, most visibly in the issue comment composer.

<img width="500" alt="mention popup clipped at viewport bottom" src="clipped screenshot in issue" />

## Root cause

Two compounding issues in the shared positioning code (`suggestion-popup.tsx`):

1. **Wrong preferred side.** `placement: "bottom-start"` kept the popup below the caret whenever *any* space existed below — even when far more room was above. Composers are bottom-anchored, so their roomy side is *up*; opening down covered the send controls and fell toward the viewport edge.
2. **Split height authority.** The floating-ui `size` middleware wrote `maxHeight` on the outer wrapper `<div>`, which doesn't clip. The real scroll container is the **inner** list, which carried its own viewport-unaware `max-h-[300px]/[420px]`. That fixed cap won and could overflow. The old `Math.max(120, availableHeight)` floor made it worse — forcing ≥120px even when less was available.

## Fix

- Default to `placement: "top-start"` (prefer the composer's roomy side). `flip` still sends it down when the caret is near the viewport top; document-body editors have room both ways so `flip` keeps them on-screen either way.
- `size` middleware now publishes `availableHeight` as a `--suggestion-available-height` CSS var (guarded ≥ 0); the mention and slash list components clamp to `max-h-[min(designMax, var(...))]` — a **single, viewport-aware** height authority. Fallback equals the old design max, so behavior outside this controller is unchanged.
- Drop the `Math.max(120, ...)` floor.

Result: chat and issue comment now behave identically — default upward, only flipping down when genuinely near the top; the list never overflows the viewport (scrolls within the available budget in tight cases).

## Scope / consistency

Web mention + slash popups are a single shared implementation, so this covers every host at once. Mobile has a separate, unaffected implementation.

## Known tradeoff

Document-body editors (issue/project description, agent instructions) now also prefer opening upward. `flip` keeps them on-screen, but if we later want those to prefer downward we'd make `placement` per-surface — deferred to keep this change to one clean rule.

## Testing

Not run (pure positioning + className/style change). Suggest a manual pass: trigger `@` in chat, issue comment, and a description field at various scroll positions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
