### PR TITLE
feat(perf-recorder): dev-only frontend performance flight recorder v1 (MUL-4466)

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -61,6 +61,7 @@
   "devDependencies": {
     "@electron-toolkit/tsconfig": "^2.0.0",
     "@multica/eslint-config": "workspace:*",
+    "@multica/perf-recorder": "workspace:*",
     "@multica/tsconfig": "workspace:*",
     "@tailwindcss/vite": "^4",
     "@testing-library/jest-dom": "catalog:",

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -43,6 +43,7 @@
     "@fontsource-variable/source-serif-4": "^5.2.9",
     "@fontsource/geist-mono": "^5.2.7",
     "@multica/core": "workspace:*",
+    "@multica/perf-recorder": "workspace:*",
     "@multica/ui": "workspace:*",
     "@multica/views": "workspace:*",
     "@tanstack/react-query": "catalog:",
@@ -61,7 +62,6 @@
   "devDependencies": {
     "@electron-toolkit/tsconfig": "^2.0.0",
     "@multica/eslint-config": "workspace:*",
-    "@multica/perf-recorder": "workspace:*",
     "@multica/tsconfig": "workspace:*",
     "@tailwindcss/vite": "^4",
     "@testing-library/jest-dom": "catalog:",

--- a/apps/desktop/src/renderer/src/app-bootstrap.tsx
+++ b/apps/desktop/src/renderer/src/app-bootstrap.tsx
@@ -1,0 +1,39 @@
+// App bootstrap — the second stage of the desktop renderer entry.
+//
+// react / react-dom are imported HERE, never in main.tsx. main.tsx installs the
+// dev-only DevTools hook (perf-recorder) BEFORE dynamically importing this
+// module, so bippy's hook is present the moment react-dom first evaluates and
+// the recorder can observe every commit (MUL-4466 §6.2 Desktop two-stage
+// bootstrap). Keep all react-dom / app-root imports confined to this file.
+import ReactDOM from "react-dom/client";
+import App from "./App";
+// Inter variable font covers all weights (100-900) in a single file.
+// Geist Mono kept as-is for code blocks; CJK is handled by system font fallback
+// (see globals.css --font-sans chain). Keep font stack in sync with apps/web/app/layout.tsx.
+import "@fontsource-variable/inter";
+// Editorial serif — matches web's next/font Source_Serif_4. Loaded app-wide so
+// onboarding headings and any future editorial surface can use `font-serif`
+// (see tokens.css @theme inline). Variable font = one file covers all weights.
+import "@fontsource-variable/source-serif-4";
+import "@fontsource-variable/source-serif-4/wght-italic.css";
+import "@fontsource/geist-mono/400.css";
+import "@fontsource/geist-mono/700.css";
+import "./globals.css";
+
+// react-grab: dev-only element inspector. Hold ⌘C (Mac) / Ctrl+C and click any
+// element to copy its source path + line + component stack for pasting to an AI.
+// Opt-in per developer: only loads when VITE_REACT_GRAB is set in a local,
+// gitignored apps/desktop/.env.development.local — it never activates for anyone
+// else, and the whole branch is tree-shaken out of production builds. The web app
+// wires the same tool via next/script in apps/web/app/layout.tsx.
+// Unlike the perf recorder, react-grab reads fibers off DOM nodes on demand and
+// does not need to be installed before react-dom, so it can stay here.
+// See https://www.react-grab.com/
+if (import.meta.env.DEV && import.meta.env.VITE_REACT_GRAB) {
+  const grab = document.createElement("script");
+  grab.src = "//unpkg.com/react-grab/dist/index.global.js";
+  grab.crossOrigin = "anonymous";
+  document.head.appendChild(grab);
+}
+
+ReactDOM.createRoot(document.getElementById("root")!).render(<App />);

--- a/apps/desktop/src/renderer/src/main.tsx
+++ b/apps/desktop/src/renderer/src/main.tsx
@@ -1,30 +1,37 @@
-import ReactDOM from "react-dom/client";
-import App from "./App";
-// Inter variable font covers all weights (100-900) in a single file.
-// Geist Mono kept as-is for code blocks; CJK is handled by system font fallback
-// (see globals.css --font-sans chain). Keep font stack in sync with apps/web/app/layout.tsx.
-import "@fontsource-variable/inter";
-// Editorial serif — matches web's next/font Source_Serif_4. Loaded app-wide so
-// onboarding headings and any future editorial surface can use `font-serif`
-// (see tokens.css @theme inline). Variable font = one file covers all weights.
-import "@fontsource-variable/source-serif-4";
-import "@fontsource-variable/source-serif-4/wght-italic.css";
-import "@fontsource/geist-mono/400.css";
-import "@fontsource/geist-mono/700.css";
-import "./globals.css";
+// Desktop renderer entry — a thin, two-stage pre-bootstrap loader.
+//
+// It exists so the dev-only performance recorder can install its React DevTools
+// hook BEFORE react-dom is ever imported. bippy (the hook library) only sees
+// commits from renderers that register AFTER the hook exists on `window`, so the
+// hook install must strictly precede the react-dom evaluation that happens
+// inside ./app-bootstrap (MUL-4466 §6.2 Desktop two-stage bootstrap).
+//
+// Do NOT import react / react-dom / the app root here — that would defeat the
+// ordering guarantee. Everything React lives in ./app-bootstrap.
 
-// react-grab: dev-only element inspector. Hold ⌘C (Mac) / Ctrl+C and click any
-// element to copy its source path + line + component stack for pasting to an AI.
-// Opt-in per developer: only loads when VITE_REACT_GRAB is set in a local,
-// gitignored apps/desktop/.env.development.local — it never activates for anyone
-// else, and the whole branch is tree-shaken out of production builds. The web app
-// wires the same tool via next/script in apps/web/app/layout.tsx.
-// See https://www.react-grab.com/
-if (import.meta.env.DEV && import.meta.env.VITE_REACT_GRAB) {
-  const grab = document.createElement("script");
-  grab.src = "//unpkg.com/react-grab/dist/index.global.js";
-  grab.crossOrigin = "anonymous";
-  document.head.appendChild(grab);
+async function bootstrap(): Promise<void> {
+  // perf-recorder: Dev/Profiling-only frontend performance flight recorder.
+  // Opt-in per developer via VITE_PERF_RECORDER (local, gitignored env file);
+  // the whole branch is tree-shaken out of production builds, so Production
+  // never loads, requests, or exposes the recorder. Installing the hook must
+  // complete before ./app-bootstrap evaluates react-dom.
+  if (import.meta.env.DEV && import.meta.env.VITE_PERF_RECORDER) {
+    try {
+      const { installRecorderHook, createRecorder } = await import("@multica/perf-recorder");
+      installRecorderHook();
+      createRecorder({
+        appVersion: import.meta.env.VITE_APP_VERSION ?? "dev",
+        surface: "desktop-renderer",
+        mode: "development",
+      });
+    } catch (error) {
+      // A dev-tool failure must never blank the app — log once and continue.
+      console.error("[perf-recorder] failed to load; continuing without it", error);
+    }
+  }
+
+  // Stage two: load react-dom + the app. The hook (if any) is already installed.
+  await import("./app-bootstrap");
 }
 
-ReactDOM.createRoot(document.getElementById("root")!).render(<App />);
+void bootstrap();

--- a/apps/desktop/src/renderer/src/perf-recorder-loader.test.ts
+++ b/apps/desktop/src/renderer/src/perf-recorder-loader.test.ts
@@ -1,0 +1,60 @@
+// Hard gate (MUL-4466 §6.2): the desktop renderer MUST install the perf-recorder
+// DevTools hook before react-dom is evaluated, and it must be proven by an
+// automated test, not code review. main.tsx installs the hook, then dynamically
+// imports ./app-bootstrap (which owns the react-dom import). Both dependencies
+// are mocked so this test asserts pure ordering without loading React/Electron.
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+// Per-test mocks (vi.doMock, not hoisted) so each scenario re-runs the mock
+// factories after resetModules and records a fresh ordering trace.
+function installMocks(order: string[]): void {
+  vi.doMock("@multica/perf-recorder", () => ({
+    installRecorderHook: () => {
+      order.push("installRecorderHook");
+    },
+    createRecorder: () => {
+      order.push("createRecorder");
+      return { recorder: {}, panel: { destroy() {} }, destroy() {} };
+    },
+  }));
+  vi.doMock("./app-bootstrap", () => {
+    // Stands in for the real module whose first import is `react-dom/client`.
+    order.push("app-bootstrap");
+    return {};
+  });
+}
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+  vi.resetModules();
+  vi.doUnmock("@multica/perf-recorder");
+  vi.doUnmock("./app-bootstrap");
+});
+
+describe("desktop renderer two-stage bootstrap", () => {
+  it("installs the recorder hook before app-bootstrap (react-dom) is imported", async () => {
+    const order: string[] = [];
+    vi.resetModules();
+    installMocks(order);
+    vi.stubEnv("VITE_PERF_RECORDER", "1");
+
+    await import("./main");
+    await vi.waitFor(() => expect(order).toContain("app-bootstrap"));
+
+    const hookIndex = order.indexOf("installRecorderHook");
+    const appIndex = order.indexOf("app-bootstrap");
+    expect(hookIndex).toBeGreaterThanOrEqual(0);
+    expect(hookIndex).toBeLessThan(appIndex);
+  });
+
+  it("does not load the recorder when the dev flag is off, but still boots the app", async () => {
+    const order: string[] = [];
+    vi.resetModules();
+    installMocks(order);
+    // VITE_PERF_RECORDER unset — production / opt-out path.
+
+    await import("./main");
+    await vi.waitFor(() => expect(order).toContain("app-bootstrap"));
+    expect(order).not.toContain("installRecorderHook");
+  });
+});

--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -135,6 +135,20 @@ export default async function RootLayout({
             strategy="beforeInteractive"
           />
         )}
+        {/*
+          perf-recorder: dev-only frontend performance flight recorder (MUL-4466).
+          Same server-gated, beforeInteractive pattern as react-grab so the hook
+          installs before React hydrates and the <Script> is omitted from HTML
+          entirely in Production. Opt-in per developer via VITE_PERF_RECORDER in a
+          local, gitignored env file. In the in-repo phase the self-executing
+          global is served from public/ (copy packages/perf-recorder/dist/
+          auto.global.js → apps/web/public/__perf-recorder.global.js); after the
+          module is extracted this src becomes the published //unpkg.com/... URL,
+          exactly like react-grab above — no other change.
+        */}
+        {process.env.NODE_ENV === "development" && process.env.VITE_PERF_RECORDER && (
+          <Script src="/__perf-recorder.global.js" strategy="beforeInteractive" />
+        )}
         <ThemeProvider>
           <WebProviders locale={locale} resources={resources}>
             {children}

--- a/packages/perf-recorder/.gitignore
+++ b/packages/perf-recorder/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+dist

--- a/packages/perf-recorder/README.md
+++ b/packages/perf-recorder/README.md
@@ -1,0 +1,63 @@
+# @multica/perf-recorder
+
+Dev/Profiling-only frontend performance flight recorder for Multica Web & Desktop
+renderers. See the full RFC in **MUL-4466**.
+
+Start recording → interact with the app → stop → get a list of **Incidents**
+(slow React commits, slow resources, long tasks / dropped frames) with an
+exportable JSON report. **Production never loads, requests, or exposes it.**
+
+## Design constraints (hard gates)
+
+- **Browser-only & self-contained.** No imports from Multica domain model, stores,
+  query client, router, or business components. Only `bippy` (pinned) + browser APIs.
+- **Hook before React.** React commit timing comes from bippy patching
+  `window.__REACT_DEVTOOLS_GLOBAL_HOOK__`; React only reports to the hook that
+  exists when `react-dom` first evaluates, so the hook install must precede it
+  (Desktop uses a two-stage bootstrap — see below).
+- **Standard mode, no content snapshot.** Collectors never read `innerText` /
+  `value` / props / state / request bodies. Resource URLs are stripped of
+  query/hash/credentials at the collector entry. `MutationObserver` contributes
+  only a count. The panel is plain-DOM in a Shadow root, so it never observes
+  itself.
+
+## Entry points
+
+| Export | Use |
+| --- | --- |
+| `@multica/perf-recorder` | ESM API: `installRecorderHook()`, `createRecorder(config)` |
+| `@multica/perf-recorder/install` | `installRecorderHook()` only — no react-dom, evaluate before React |
+| `@multica/perf-recorder/auto` | self-mounting; source of `dist/auto.global.js` |
+| `dist/auto.global.js` | self-executing IIFE (bippy inlined) for the eventual `<script src>` |
+
+## Host wiring (in-repo, dev-only)
+
+**Desktop** (`apps/desktop/src/renderer/src/main.tsx`) — two-stage bootstrap:
+install the hook, *then* dynamically import `./app-bootstrap` (which owns the
+`react-dom` import). Proven by `perf-recorder-loader.test.ts`.
+
+**Web** (`apps/web/app/layout.tsx`) — server-gated `beforeInteractive` `<Script>`,
+same pattern as `react-grab`. In the in-repo phase, copy the built global to the
+served path:
+
+```bash
+pnpm --filter @multica/perf-recorder build
+cp packages/perf-recorder/dist/auto.global.js apps/web/public/__perf-recorder.global.js
+```
+
+Both are opt-in per developer via `VITE_PERF_RECORDER` in a local, gitignored env
+file, and both branches are DCE'd out of Production builds.
+
+## Extraction (later, per RFC §6.3)
+
+Move this package to its own repo, publish, and swap the host references from the
+local path to `//unpkg.com/<pkg>/dist/auto.global.js` — the dev-only gate and load
+order do not change. Extraction is "move code + change reference", not a redesign.
+
+## Verify
+
+```bash
+pnpm --filter @multica/perf-recorder typecheck
+pnpm --filter @multica/perf-recorder test
+pnpm --filter @multica/perf-recorder build
+```

--- a/packages/perf-recorder/eslint.config.mjs
+++ b/packages/perf-recorder/eslint.config.mjs
@@ -1,0 +1,15 @@
+import baseConfig from "@multica/eslint-config/base";
+
+// perf-recorder is browser-only plain-TS (no React/JSX), so it uses the base
+// config rather than the react config. tsup.config.ts legitimately imports the
+// `tsup` build tool (a devDependency); the shared allowlist doesn't cover that
+// path, so relax the phantom-dependency rule for it here.
+export default [
+  ...baseConfig,
+  {
+    files: ["tsup.config.ts"],
+    rules: {
+      "import-x/no-extraneous-dependencies": "off",
+    },
+  },
+];

--- a/packages/perf-recorder/package.json
+++ b/packages/perf-recorder/package.json
@@ -1,0 +1,32 @@
+{
+  "name": "@multica/perf-recorder",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "description": "Dev/Profiling-only frontend performance flight recorder. Browser-only, self-contained, no Multica domain dependencies. See MUL-4466.",
+  "exports": {
+    ".": "./src/index.ts",
+    "./install": "./src/install.ts",
+    "./auto": "./src/auto.ts"
+  },
+  "browser": "./dist/auto.global.js",
+  "scripts": {
+    "build": "tsup",
+    "typecheck": "tsc --noEmit",
+    "lint": "eslint .",
+    "test": "vitest run"
+  },
+  "dependencies": {
+    "bippy": "0.6.0"
+  },
+  "devDependencies": {
+    "@multica/eslint-config": "workspace:*",
+    "@multica/tsconfig": "workspace:*",
+    "@types/react": "catalog:",
+    "jsdom": "catalog:",
+    "tsup": "^8.5.0",
+    "typescript": "catalog:",
+    "vitest": "catalog:",
+    "zod": "catalog:"
+  }
+}

--- a/packages/perf-recorder/src/auto.ts
+++ b/packages/perf-recorder/src/auto.ts
@@ -1,0 +1,44 @@
+// Self-mounting entry for the `<script src>` global build (dist/auto.global.js),
+// the shape the standalone package ships — same pattern as react-scan's
+// dist/auto.global.js. Importing this module installs the hook immediately
+// (before React, when the script is loaded early enough) and mounts the panel
+// once the DOM is ready. The host may pre-set `window.__MULTICA_PERF_RECORDER__`
+// with a HostConfig before the script loads.
+import { installRecorderHook } from "./install";
+import { mountPanel } from "./panel";
+import { Recorder } from "./recorder";
+import type { HostConfig, RecorderMode, Surface } from "./types";
+
+// Install the hook at module-evaluation time — earliest possible moment.
+installRecorderHook();
+
+function readConfig(): HostConfig {
+  const raw =
+    typeof window !== "undefined"
+      ? (window as unknown as Record<string, unknown>).__MULTICA_PERF_RECORDER__
+      : undefined;
+  const cfg = (raw && typeof raw === "object" ? raw : {}) as Partial<HostConfig>;
+  const surface: Surface = cfg.surface === "desktop-renderer" ? "desktop-renderer" : "web";
+  const mode: RecorderMode = cfg.mode === "profiling" ? "profiling" : "development";
+  return {
+    appVersion: typeof cfg.appVersion === "string" ? cfg.appVersion : "unknown",
+    surface,
+    mode,
+    thresholds: cfg.thresholds,
+    boundaryAllowlist: cfg.boundaryAllowlist,
+    testIdAllowlist: cfg.testIdAllowlist,
+  };
+}
+
+function boot(): void {
+  const recorder = new Recorder(readConfig());
+  mountPanel(recorder);
+}
+
+if (typeof document !== "undefined") {
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", boot, { once: true });
+  } else {
+    boot();
+  }
+}

--- a/packages/perf-recorder/src/capabilities.ts
+++ b/packages/perf-recorder/src/capabilities.ts
@@ -1,0 +1,24 @@
+import type { Capabilities } from "./types";
+
+function supportsEntryType(type: string): boolean {
+  if (typeof PerformanceObserver === "undefined") return false;
+  const supported = (PerformanceObserver as unknown as { supportedEntryTypes?: string[] })
+    .supportedEntryTypes;
+  return Array.isArray(supported) ? supported.includes(type) : false;
+}
+
+/**
+ * Probe browser support once at start. Unsupported signals are recorded as
+ * `false` and simply skipped — the recorder never polyfills or fabricates
+ * performance data for a missing API (MUL-4466 §13).
+ */
+export function detectCapabilities(reactCommit: boolean): Capabilities {
+  return {
+    longTask: supportsEntryType("longtask"),
+    longAnimationFrame: supportsEntryType("long-animation-frame"),
+    eventTiming: supportsEntryType("event"),
+    reactCommit,
+    resourceTiming: supportsEntryType("resource"),
+    mutationObserver: typeof MutationObserver !== "undefined",
+  };
+}

--- a/packages/perf-recorder/src/constants.ts
+++ b/packages/perf-recorder/src/constants.ts
@@ -1,0 +1,7 @@
+/**
+ * DOM id of the recorder's Shadow-root host element. Shared between the panel
+ * (which owns the element) and the collectors (which must exclude the recorder's
+ * own surface from what they observe — MUL-4466 §10.2). Kept in a dependency-free
+ * module so importing it never creates a panel ⇆ recorder cycle.
+ */
+export const RECORDER_HOST_ID = "multica-perf-recorder";

--- a/packages/perf-recorder/src/index.ts
+++ b/packages/perf-recorder/src/index.ts
@@ -1,0 +1,41 @@
+// Public API for host loaders that import the recorder as an ESM module
+// (the in-repo dev-only path). The eventual standalone package also ships
+// `./auto` (self-mounting) for the `<script src>` path — see src/auto.ts.
+
+import { installRecorderHook } from "./install";
+import { mountPanel, type PanelHandle } from "./panel";
+import { Recorder } from "./recorder";
+import type { HostConfig } from "./types";
+
+export { installRecorderHook, isRecorderHookInstalled, uninstallRecorderHook } from "./install";
+export { Recorder } from "./recorder";
+export type { LiveStatus, RecorderState } from "./recorder";
+export * from "./types";
+
+export interface RecorderHandle {
+  recorder: Recorder;
+  panel: PanelHandle;
+  destroy: () => void;
+}
+
+/**
+ * Create a recorder and mount the (collapsed) panel. Does NOT start recording —
+ * collection only begins when the user clicks Start (MUL-4466 §7). The hook is
+ * installed here too, but for the mechanism to catch React commits it must have
+ * been installed BEFORE react-dom evaluated — host loaders call
+ * `installRecorderHook()` up front (Desktop two-stage bootstrap / Web
+ * beforeInteractive) and this call is then an idempotent no-op.
+ */
+export function createRecorder(config: HostConfig): RecorderHandle {
+  installRecorderHook();
+  const recorder = new Recorder(config);
+  const panel = mountPanel(recorder);
+  return {
+    recorder,
+    panel,
+    destroy: () => {
+      recorder.clear();
+      panel.destroy();
+    },
+  };
+}

--- a/packages/perf-recorder/src/install.ts
+++ b/packages/perf-recorder/src/install.ts
@@ -1,0 +1,62 @@
+// The one module the host loader evaluates BEFORE react-dom.
+//
+// Importing this module runs bippy's side-effect that installs
+// `window.__REACT_DEVTOOLS_GLOBAL_HOOK__`. React only registers itself with the
+// hook that exists at the moment `react-dom` first evaluates, so this module
+// MUST be imported before the app bootstrap (see MUL-4466 §6.2, Desktop
+// two-stage bootstrap). It deliberately does NOT import react / react-dom.
+//
+// `instrument()` from bippy composes onto the hook instead of replacing it, so
+// an already-present React DevTools install or another bippy consumer keeps
+// working. Installation is idempotent and HMR-safe.
+import { instrument } from "bippy";
+
+/** A committed fiber root, kept structurally loose to avoid coupling to bippy's internal types. */
+export type CommitRoot = { current: unknown } & Record<string, unknown>;
+export type CommitListener = (root: CommitRoot) => void;
+
+const commitListeners = new Set<CommitListener>();
+let uninstrument: (() => void) | null = null;
+
+/**
+ * Ensure the React DevTools hook exists and our commit dispatcher is attached.
+ * Safe to call multiple times; only the first call patches the hook.
+ */
+export function installRecorderHook(): void {
+  if (uninstrument) return;
+  uninstrument = instrument({
+    onCommitFiberRoot(_rendererID: number, root: unknown) {
+      // fail-open for the host app: a broken listener never bubbles into React.
+      for (const listener of commitListeners) {
+        try {
+          listener(root as CommitRoot);
+        } catch {
+          /* swallow — recording must never break the page */
+        }
+      }
+    },
+  });
+}
+
+/** True once the global hook is present on `window`. */
+export function isRecorderHookInstalled(): boolean {
+  return (
+    uninstrument !== null &&
+    typeof window !== "undefined" &&
+    typeof (window as unknown as Record<string, unknown>).__REACT_DEVTOOLS_GLOBAL_HOOK__ !==
+      "undefined"
+  );
+}
+
+/** Subscribe to React commits. Returns an unsubscribe function. */
+export function subscribeCommit(listener: CommitListener): () => void {
+  commitListeners.add(listener);
+  return () => commitListeners.delete(listener);
+}
+
+/** Detach our dispatcher and drop listeners (used on full teardown / HMR dispose). */
+export function uninstallRecorderHook(): void {
+  uninstrument?.();
+  uninstrument = null;
+  commitListeners.clear();
+}

--- a/packages/perf-recorder/src/panel.ts
+++ b/packages/perf-recorder/src/panel.ts
@@ -1,0 +1,256 @@
+import type { Recorder, LiveStatus } from "./recorder";
+import type { Incident, InteractionType } from "./types";
+
+// The panel is built with plain DOM inside a Shadow root — deliberately NOT
+// React. That keeps the recorder free of a React dependency AND means the panel
+// produces zero React commits and its internal DOM mutations are encapsulated
+// in the shadow tree, so the recorder never observes itself (MUL-4466 §10).
+const HOST_ID = "multica-perf-recorder";
+
+const STYLE = `
+:host { all: initial; }
+.root { position: fixed; right: 16px; bottom: 16px; z-index: 2147483000;
+  font: 12px/1.4 ui-sans-serif, system-ui, sans-serif; color: #e5e7eb; }
+.badge { display: flex; align-items: center; gap: 6px; background: #111827;
+  border: 1px solid #374151; border-radius: 999px; padding: 6px 12px; cursor: pointer;
+  box-shadow: 0 4px 12px rgba(0,0,0,.4); }
+.dot { width: 8px; height: 8px; border-radius: 50%; background: #6b7280; }
+.dot.rec { background: #ef4444; }
+.panel { width: 380px; max-height: 60vh; display: flex; flex-direction: column;
+  background: #0b1120; border: 1px solid #374151; border-radius: 10px; overflow: hidden;
+  box-shadow: 0 8px 28px rgba(0,0,0,.5); }
+.bar { display: flex; align-items: center; gap: 6px; padding: 8px 10px; border-bottom: 1px solid #1f2937; }
+.bar button { background: #1f2937; color: #e5e7eb; border: 1px solid #374151; border-radius: 6px;
+  padding: 4px 8px; cursor: pointer; font: inherit; }
+.bar button:hover { background: #374151; }
+.stats { margin-left: auto; display: flex; gap: 10px; color: #9ca3af; font-variant-numeric: tabular-nums; }
+.chips { display: flex; gap: 6px; padding: 6px 10px; border-bottom: 1px solid #1f2937; flex-wrap: wrap; }
+.chip { background: #111827; border: 1px solid #374151; border-radius: 999px; padding: 2px 8px; cursor: pointer; color: #9ca3af; }
+.chip.on { background: #2563eb; color: white; border-color: #2563eb; }
+.list { overflow: auto; }
+.row { padding: 8px 10px; border-bottom: 1px solid #111827; cursor: pointer; }
+.row:hover { background: #111827; }
+.row .top { display: flex; gap: 8px; align-items: baseline; }
+.row .dur { margin-left: auto; font-variant-numeric: tabular-nums; }
+.sev-ok { color: #34d399; } .sev-warn { color: #fbbf24; } .sev-bad { color: #f87171; }
+.muted { color: #6b7280; }
+.detail { margin-top: 6px; padding: 6px 8px; background: #0f172a; border-radius: 6px; color: #cbd5e1; white-space: pre-wrap; }
+.empty { padding: 16px; text-align: center; color: #6b7280; }
+`;
+
+const CHIPS: Array<{ key: InteractionType | "all"; label: string }> = [
+  { key: "all", label: "All" },
+  { key: "click", label: "Click" },
+  { key: "scroll", label: "Scroll" },
+  { key: "input", label: "Input" },
+  { key: "navigation", label: "Nav" },
+  { key: "background", label: "Background" },
+];
+
+export interface PanelHandle {
+  destroy: () => void;
+}
+
+export function mountPanel(recorder: Recorder): PanelHandle {
+  if (typeof document === "undefined") {
+    return { destroy: () => {} };
+  }
+  const existing = document.getElementById(HOST_ID);
+  if (existing) existing.remove();
+
+  const host = document.createElement("div");
+  host.id = HOST_ID;
+  const shadow = host.attachShadow({ mode: "open" });
+  const style = document.createElement("style");
+  style.textContent = STYLE;
+  shadow.appendChild(style);
+  const root = document.createElement("div");
+  root.className = "root";
+  shadow.appendChild(root);
+  document.body.appendChild(host);
+
+  let expanded = false;
+  let filter: InteractionType | "all" = "all";
+  let openId: string | null = null;
+  let status: LiveStatus = {
+    state: "idle",
+    fps: 0,
+    jankCount: 0,
+    longTaskCount: 0,
+    durationMs: 0,
+    incidentCount: 0,
+  };
+  let incidents: Incident[] = [];
+
+  const render = () => {
+    if (!expanded) {
+      root.innerHTML = "";
+      const badge = el("div", "badge");
+      badge.appendChild(el("span", `dot ${status.state === "recording" ? "rec" : ""}`));
+      badge.appendChild(text("span", `Perf · ${status.incidentCount}`));
+      badge.onclick = () => {
+        expanded = true;
+        render();
+      };
+      root.appendChild(badge);
+      return;
+    }
+
+    root.innerHTML = "";
+    const panel = el("div", "panel");
+
+    const bar = el("div", "bar");
+    bar.appendChild(el("span", `dot ${status.state === "recording" ? "rec" : ""}`));
+    bar.appendChild(button(status.state === "recording" ? "Stop" : "Start", () => {
+      if (status.state === "recording") recorder.stop();
+      else recorder.start();
+    }));
+    bar.appendChild(button("Clear", () => recorder.clear()));
+    bar.appendChild(button("Export", () => downloadReport(recorder)));
+    bar.appendChild(button("×", () => {
+      expanded = false;
+      render();
+    }));
+    const stats = el("div", "stats");
+    stats.appendChild(text("span", `${status.fps}fps`));
+    stats.appendChild(text("span", `jank ${status.jankCount}`));
+    stats.appendChild(text("span", `${Math.round(status.durationMs / 100) / 10}s`));
+    bar.appendChild(stats);
+    panel.appendChild(bar);
+
+    const chips = el("div", "chips");
+    for (const c of CHIPS) {
+      const chip = text("span", c.label + countFor(c.key, incidents));
+      chip.className = `chip ${filter === c.key ? "on" : ""}`;
+      chip.onclick = () => {
+        filter = c.key;
+        render();
+      };
+      chips.appendChild(chip);
+    }
+    panel.appendChild(chips);
+
+    const list = el("div", "list");
+    const shown = incidents
+      .filter((i) => filter === "all" || i.interaction.type === filter)
+      .slice()
+      .reverse();
+    if (shown.length === 0) {
+      list.appendChild(text("div", "No incidents yet. Start recording and interact.", "empty"));
+    }
+    for (const incident of shown) {
+      list.appendChild(renderRow(incident, openId, (id) => {
+        openId = openId === id ? null : id;
+        render();
+      }));
+    }
+    panel.appendChild(list);
+    root.appendChild(panel);
+  };
+
+  const offStatus = recorder.onStatus((s) => {
+    status = s;
+    render();
+  });
+  const offIncidents = recorder.onIncidents((list) => {
+    incidents = list;
+    render();
+  });
+  render();
+
+  return {
+    destroy: () => {
+      offStatus();
+      offIncidents();
+      host.remove();
+    },
+  };
+}
+
+function renderRow(incident: Incident, openId: string | null, toggle: (id: string) => void): HTMLElement {
+  const row = el("div", "row");
+  const top = el("div", "top");
+  top.appendChild(text("span", incident.interaction.type));
+  top.appendChild(text("span", incident.route.pathname ?? "—", "muted"));
+  const dur = text("span", `${incident.totalDurationMs}ms`, `dur ${severity(incident.totalDurationMs)}`);
+  top.appendChild(dur);
+  row.appendChild(top);
+  row.appendChild(text("div", primaryLabel(incident), "muted"));
+  if (openId === incident.id) {
+    row.appendChild(text("div", detailText(incident), "detail"));
+  }
+  row.onclick = () => toggle(incident.id);
+  return row;
+}
+
+function primaryLabel(incident: Incident): string {
+  switch (incident.primaryEvidence) {
+    case "react_commit":
+      return "Slow React commit";
+    case "long_task":
+      return "Long task on main thread";
+    case "frame":
+      return "Dropped / long frame";
+    case "resource":
+      return "Slow resource";
+    case "interaction":
+      return "Slow interaction";
+    default:
+      return "Insufficient evidence — inspect in Chrome Performance";
+  }
+}
+
+function detailText(incident: Incident): string {
+  const lines: string[] = [];
+  if (incident.interaction.testId) lines.push(`testId: ${incident.interaction.testId}`);
+  lines.push(`mutations: ${incident.mutationCount}`);
+  for (const c of incident.reactCommits)
+    lines.push(`react ${c.boundaryId ?? "(unregistered)"} ${c.phase} ${c.actualDurationMs}ms`);
+  for (const l of incident.longTasks) lines.push(`longTask ${l.durationMs}ms @${l.startOffsetMs}`);
+  for (const f of incident.frames) lines.push(`frame ${f.durationMs}ms (${f.source})`);
+  for (const r of incident.resources)
+    lines.push(`resource ${r.durationMs}ms ${r.origin ?? ""}${r.pathname ?? ""}`);
+  return lines.join("\n");
+}
+
+function countFor(key: InteractionType | "all", incidents: Incident[]): string {
+  const n = key === "all" ? incidents.length : incidents.filter((i) => i.interaction.type === key).length;
+  return n > 0 ? ` ${n}` : "";
+}
+
+function severity(ms: number): string {
+  if (ms >= 500) return "sev-bad";
+  if (ms >= 100) return "sev-warn";
+  return "sev-ok";
+}
+
+export function downloadReport(recorder: Recorder): void {
+  if (typeof document === "undefined") return;
+  const report = recorder.export();
+  const blob = new Blob([JSON.stringify(report, null, 2)], { type: "application/json" });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement("a");
+  a.href = url;
+  a.download = `perf-recorder-${report.recorderVersion}.json`;
+  a.click();
+  URL.revokeObjectURL(url);
+}
+
+function el(tag: string, className = ""): HTMLElement {
+  const node = document.createElement(tag);
+  if (className) node.className = className;
+  return node;
+}
+
+function text(tag: string, content: string, className = ""): HTMLElement {
+  const node = el(tag, className);
+  node.textContent = content;
+  return node;
+}
+
+function button(label: string, onClick: () => void): HTMLElement {
+  const b = el("button");
+  b.textContent = label;
+  b.onclick = onClick;
+  return b;
+}

--- a/packages/perf-recorder/src/panel.ts
+++ b/packages/perf-recorder/src/panel.ts
@@ -1,11 +1,12 @@
+import { RECORDER_HOST_ID } from "./constants";
 import type { Recorder, LiveStatus } from "./recorder";
 import type { Incident, InteractionType } from "./types";
 
 // The panel is built with plain DOM inside a Shadow root — deliberately NOT
 // React. That keeps the recorder free of a React dependency AND means the panel
 // produces zero React commits and its internal DOM mutations are encapsulated
-// in the shadow tree, so the recorder never observes itself (MUL-4466 §10).
-const HOST_ID = "multica-perf-recorder";
+// in the shadow tree. Interactions with the panel still bubble to window, so the
+// recorder excludes them via RECORDER_HOST_ID in composedPath (MUL-4466 §10).
 
 const STYLE = `
 :host { all: initial; }
@@ -22,7 +23,8 @@ const STYLE = `
 .bar { display: flex; align-items: center; gap: 6px; padding: 8px 10px; border-bottom: 1px solid #1f2937; }
 .bar button { background: #1f2937; color: #e5e7eb; border: 1px solid #374151; border-radius: 6px;
   padding: 4px 8px; cursor: pointer; font: inherit; }
-.bar button:hover { background: #374151; }
+.bar button:hover:not(:disabled) { background: #374151; }
+.bar button:disabled { opacity: .4; cursor: not-allowed; }
 .stats { margin-left: auto; display: flex; gap: 10px; color: #9ca3af; font-variant-numeric: tabular-nums; }
 .chips { display: flex; gap: 6px; padding: 6px 10px; border-bottom: 1px solid #1f2937; flex-wrap: wrap; }
 .chip { background: #111827; border: 1px solid #374151; border-radius: 999px; padding: 2px 8px; cursor: pointer; color: #9ca3af; }
@@ -55,11 +57,11 @@ export function mountPanel(recorder: Recorder): PanelHandle {
   if (typeof document === "undefined") {
     return { destroy: () => {} };
   }
-  const existing = document.getElementById(HOST_ID);
+  const existing = document.getElementById(RECORDER_HOST_ID);
   if (existing) existing.remove();
 
   const host = document.createElement("div");
-  host.id = HOST_ID;
+  host.id = RECORDER_HOST_ID;
   const shadow = host.attachShadow({ mode: "open" });
   const style = document.createElement("style");
   style.textContent = STYLE;
@@ -106,7 +108,10 @@ export function mountPanel(recorder: Recorder): PanelHandle {
       else recorder.start();
     }));
     bar.appendChild(button("Clear", () => recorder.clear()));
-    bar.appendChild(button("Export", () => downloadReport(recorder)));
+    // RFC §7: export is only available in the stopped state.
+    bar.appendChild(
+      button("Export", () => downloadReport(recorder), !recorder.canExport()),
+    );
     bar.appendChild(button("×", () => {
       expanded = false;
       render();
@@ -226,6 +231,9 @@ function severity(ms: number): string {
 
 export function downloadReport(recorder: Recorder): void {
   if (typeof document === "undefined") return;
+  // RFC §7: no-op unless stopped, so a stray call can't dump a mid-recording
+  // report even if the disabled control were bypassed.
+  if (!recorder.canExport()) return;
   const report = recorder.export();
   const blob = new Blob([JSON.stringify(report, null, 2)], { type: "application/json" });
   const url = URL.createObjectURL(blob);
@@ -248,9 +256,13 @@ function text(tag: string, content: string, className = ""): HTMLElement {
   return node;
 }
 
-function button(label: string, onClick: () => void): HTMLElement {
-  const b = el("button");
+function button(label: string, onClick: () => void, disabled = false): HTMLButtonElement {
+  const b = el("button") as HTMLButtonElement;
   b.textContent = label;
-  b.onclick = onClick;
+  b.disabled = disabled;
+  // A disabled <button> fires no click, but guard the handler too for safety.
+  b.onclick = () => {
+    if (!b.disabled) onClick();
+  };
   return b;
 }

--- a/packages/perf-recorder/src/react-commit.ts
+++ b/packages/perf-recorder/src/react-commit.ts
@@ -1,0 +1,83 @@
+import type { CommitRoot } from "./install";
+import type { ReactCommitEvidence } from "./types";
+
+// React fiber tag for a <Profiler> node. Stable across React 17–19.
+const PROFILER_TAG = 12;
+// Hard cap on fibers visited per commit — bounds cost and guards against
+// pathological trees / self-observation loops.
+const MAX_FIBERS_PER_COMMIT = 4000;
+
+/**
+ * Minimal structural view of a fiber. We only ever touch these fields, and on a
+ * fiber we only read `memoizedProps.id` when the fiber is a <Profiler> (that
+ * `id` is the boundary registration key, not user content). No other prop,
+ * state, context, or DOM text is ever read (MUL-4466 §8.2, §12).
+ */
+interface FiberLike {
+  tag?: number;
+  actualDuration?: number | null;
+  alternate?: FiberLike | null;
+  child?: FiberLike | null;
+  sibling?: FiberLike | null;
+  memoizedProps?: unknown;
+}
+
+function phaseOf(fiber: FiberLike): ReactCommitEvidence["phase"] {
+  if (fiber.alternate == null) return "mount";
+  return "update";
+}
+
+function readProfilerId(fiber: FiberLike): string | null {
+  if (fiber.tag !== PROFILER_TAG) return null;
+  const props = fiber.memoizedProps;
+  if (props && typeof props === "object" && "id" in props) {
+    const id = (props as { id?: unknown }).id;
+    return typeof id === "string" ? id : null;
+  }
+  return null;
+}
+
+export interface CommitExtract {
+  /** Total commit duration read off the root fiber, when available. */
+  commitActualDurationMs: number | null;
+  phase: ReactCommitEvidence["phase"];
+  /** Per-boundary evidence, only for host-registered Profiler ids. */
+  boundaries: ReactCommitEvidence[];
+}
+
+/**
+ * Extract commit timing from a committed fiber root. Pure and synchronous so it
+ * can be unit-tested against synthetic fibers without a live React tree.
+ */
+export function extractCommitEvidence(
+  root: CommitRoot,
+  boundaryAllowlist: ReadonlySet<string>,
+): CommitExtract {
+  const rootFiber = (root.current ?? null) as FiberLike | null;
+  const commitActualDurationMs =
+    rootFiber && typeof rootFiber.actualDuration === "number" ? rootFiber.actualDuration : null;
+  const phase = rootFiber ? phaseOf(rootFiber) : "unknown";
+
+  const boundaries: ReactCommitEvidence[] = [];
+  if (rootFiber && boundaryAllowlist.size > 0) {
+    let visited = 0;
+    // Iterative depth-first walk over child/sibling pointers.
+    const stack: FiberLike[] = [rootFiber];
+    while (stack.length > 0 && visited < MAX_FIBERS_PER_COMMIT) {
+      const fiber = stack.pop()!;
+      visited++;
+      const id = readProfilerId(fiber);
+      if (id !== null && boundaryAllowlist.has(id)) {
+        boundaries.push({
+          boundaryId: id,
+          phase: phaseOf(fiber),
+          actualDurationMs: typeof fiber.actualDuration === "number" ? fiber.actualDuration : 0,
+        });
+      }
+      if (fiber.child) stack.push(fiber.child);
+      if (fiber.sibling) stack.push(fiber.sibling);
+    }
+  }
+
+  return { commitActualDurationMs, phase, boundaries };
+}

--- a/packages/perf-recorder/src/recorder.ts
+++ b/packages/perf-recorder/src/recorder.ts
@@ -1,5 +1,6 @@
 import { detectCapabilities } from "./capabilities";
 import { subscribeCommit, type CommitRoot } from "./install";
+import { isRecorderEvent } from "./self-surface";
 import { extractCommitEvidence } from "./react-commit";
 import { sanitizeUrl } from "./sanitize-url";
 import {
@@ -137,11 +138,19 @@ export class Recorder {
     this.emitIncidents();
   }
 
+  /** RFC §7: a report may only be exported once the session is stopped. */
+  canExport(): boolean {
+    return this.state === "stopped";
+  }
+
   export(): Report {
-    // Export is only meaningful once stopped; finalize defensively regardless.
+    // RFC §7: export is only available in the stopped state. Enforced at the
+    // recorder layer so a programmatic caller can't dump a mid-recording report;
+    // the panel additionally disables/no-ops the Export control until stopped.
+    if (this.state !== "stopped") {
+      throw new Error("perf-recorder: export() is only available after stop() (RFC §7)");
+    }
     this.finalizeAll();
-    const durationMs =
-      (this.sessionEnd || now()) - (this.sessionStart || this.sessionEnd || now());
     const incidents = this.incidents.map(stripInternal);
     return {
       schemaVersion: SCHEMA_VERSION,
@@ -149,9 +158,15 @@ export class Recorder {
       host: { appVersion: this.appVersion, surface: this.surface, mode: this.mode },
       capabilities: this.capabilities,
       thresholdsMs: this.thresholds,
-      session: { durationMs: Math.max(0, Math.round(durationMs)), incidentCount: incidents.length },
+      session: { durationMs: this.sessionDurationMs(), incidentCount: incidents.length },
       incidents,
     };
+  }
+
+  private sessionDurationMs(): number {
+    if (!this.sessionStart) return 0;
+    const end = this.sessionEnd || now();
+    return Math.max(0, Math.round(end - this.sessionStart));
   }
 
   getIncidents(): Incident[] {
@@ -258,6 +273,11 @@ export class Recorder {
   private installInteractionListeners(): void {
     if (typeof window === "undefined") return;
     const handler = (type: InteractionType) => (event: Event) => {
+      // Exclude the recorder's own surface: a click/scroll/keydown inside the
+      // panel's Shadow root still retargets and bubbles to window, so without
+      // this the panel's own buttons would be logged as app interactions
+      // (MUL-4466 §10.2).
+      if (isRecorderEvent(event)) return;
       const testId = this.resolveTestId(event.target);
       this.openInteraction(type, testId);
     };
@@ -498,7 +518,8 @@ export class Recorder {
       fps: this.fps,
       jankCount: this.jankCount,
       longTaskCount: this.longTaskCount,
-      durationMs: this.state === "recording" ? round(now() - this.sessionStart) : this.export().session.durationMs,
+      durationMs:
+        this.state === "recording" ? round(now() - this.sessionStart) : this.sessionDurationMs(),
       incidentCount: this.incidents.length,
     };
     for (const listener of this.statusListeners) {

--- a/packages/perf-recorder/src/recorder.ts
+++ b/packages/perf-recorder/src/recorder.ts
@@ -1,0 +1,558 @@
+import { detectCapabilities } from "./capabilities";
+import { subscribeCommit, type CommitRoot } from "./install";
+import { extractCommitEvidence } from "./react-commit";
+import { sanitizeUrl } from "./sanitize-url";
+import {
+  DEFAULT_THRESHOLDS,
+  RECORDER_VERSION,
+  SCHEMA_VERSION,
+  type Capabilities,
+  type EvidenceKind,
+  type HostConfig,
+  type Incident,
+  type InteractionInfo,
+  type InteractionType,
+  type Report,
+  type RouteInfo,
+  type Thresholds,
+} from "./types";
+
+export type RecorderState = "idle" | "recording" | "stopped";
+
+export interface LiveStatus {
+  state: RecorderState;
+  fps: number;
+  jankCount: number;
+  longTaskCount: number;
+  durationMs: number;
+  incidentCount: number;
+}
+
+// A longtask entry is by definition ≥ ~50ms; kept explicit so incident ranking
+// can express "how many times over threshold" consistently across signals.
+const LONGTASK_THRESHOLD_MS = 50;
+const CORRELATION_WINDOW_MS = 1000;
+const BACKGROUND_IDLE_MS = 1000;
+const MAX_INCIDENTS = 500;
+const MAX_EVIDENCE_PER_INCIDENT = 200;
+
+interface InternalIncident extends Incident {
+  _startTime: number;
+  _endTime: number;
+  _routeKey: string;
+}
+
+type StatusListener = (status: LiveStatus) => void;
+type IncidentsListener = (incidents: Incident[]) => void;
+
+export class Recorder {
+  private readonly appVersion: string;
+  private readonly surface: HostConfig["surface"];
+  private readonly mode: HostConfig["mode"];
+  private readonly thresholds: Thresholds;
+  private readonly boundaryAllowlist: ReadonlySet<string>;
+  private readonly testIdAllowlist: ReadonlySet<string>;
+
+  private state: RecorderState = "idle";
+  private capabilities: Capabilities;
+  private sessionStart = 0;
+  private sessionEnd = 0;
+
+  private incidents: InternalIncident[] = [];
+  private current: InternalIncident | null = null;
+  private currentWindowEnd = 0;
+  private background: InternalIncident | null = null;
+  private backgroundIdleUntil = 0;
+  private incidentSeq = 0;
+
+  // live status counters
+  private jankCount = 0;
+  private longTaskCount = 0;
+  private frameTicks = 0;
+  private lastFpsSample = 0;
+  private fps = 0;
+
+  // teardown handles
+  private observers: PerformanceObserver[] = [];
+  private mutationObserver: MutationObserver | null = null;
+  private eventCleanups: Array<() => void> = [];
+  private rafHandle: number | null = null;
+  private unsubscribeCommit: (() => void) | null = null;
+
+  private statusListeners = new Set<StatusListener>();
+  private incidentsListeners = new Set<IncidentsListener>();
+
+  constructor(config: HostConfig) {
+    this.appVersion = config.appVersion;
+    this.surface = config.surface;
+    this.mode = config.mode;
+    this.thresholds = { ...DEFAULT_THRESHOLDS, ...(config.thresholds ?? {}) };
+    this.boundaryAllowlist = new Set(config.boundaryAllowlist ?? []);
+    this.testIdAllowlist = new Set(config.testIdAllowlist ?? []);
+    this.capabilities = detectCapabilities(false);
+  }
+
+  getState(): RecorderState {
+    return this.state;
+  }
+
+  onStatus(listener: StatusListener): () => void {
+    this.statusListeners.add(listener);
+    return () => this.statusListeners.delete(listener);
+  }
+
+  onIncidents(listener: IncidentsListener): () => void {
+    this.incidentsListeners.add(listener);
+    return () => this.incidentsListeners.delete(listener);
+  }
+
+  start(): void {
+    if (this.state === "recording") return;
+    // Fresh session: drop any prior un-exported in-memory data.
+    this.reset();
+    this.state = "recording";
+    this.sessionStart = now();
+    this.lastFpsSample = this.sessionStart;
+    this.capabilities = detectCapabilities(true);
+    this.setupCollectors();
+    this.emitStatus();
+    this.emitIncidents();
+  }
+
+  stop(): void {
+    if (this.state !== "recording") return;
+    this.teardownCollectors();
+    this.finalizeAll();
+    this.sessionEnd = now();
+    this.state = "stopped";
+    this.emitStatus();
+    this.emitIncidents();
+  }
+
+  clear(): void {
+    this.teardownCollectors();
+    this.reset();
+    this.state = "idle";
+    this.emitStatus();
+    this.emitIncidents();
+  }
+
+  export(): Report {
+    // Export is only meaningful once stopped; finalize defensively regardless.
+    this.finalizeAll();
+    const durationMs =
+      (this.sessionEnd || now()) - (this.sessionStart || this.sessionEnd || now());
+    const incidents = this.incidents.map(stripInternal);
+    return {
+      schemaVersion: SCHEMA_VERSION,
+      recorderVersion: RECORDER_VERSION,
+      host: { appVersion: this.appVersion, surface: this.surface, mode: this.mode },
+      capabilities: this.capabilities,
+      thresholdsMs: this.thresholds,
+      session: { durationMs: Math.max(0, Math.round(durationMs)), incidentCount: incidents.length },
+      incidents,
+    };
+  }
+
+  getIncidents(): Incident[] {
+    return this.incidents.map(stripInternal);
+  }
+
+  getCapabilities(): Capabilities {
+    return this.capabilities;
+  }
+
+  // ---- collectors ----------------------------------------------------------
+
+  private setupCollectors(): void {
+    this.observePerformance("longtask", (entry) => {
+      this.longTaskCount++;
+      this.jankCount++;
+      this.attach(
+        "long_task",
+        entry.startTime,
+        entry.startTime + entry.duration,
+        (incident) => pushCapped(incident.longTasks, {
+          startOffsetMs: this.offset(entry.startTime),
+          durationMs: round(entry.duration),
+        }),
+      );
+    });
+
+    if (this.capabilities.longAnimationFrame) {
+      this.observePerformance("long-animation-frame", (entry) => {
+        this.jankCount++;
+        this.attach("frame", entry.startTime, entry.startTime + entry.duration, (incident) =>
+          pushCapped(incident.frames, {
+            startOffsetMs: this.offset(entry.startTime),
+            durationMs: round(entry.duration),
+            source: "loaf",
+          }),
+        );
+      });
+    }
+
+    if (this.capabilities.resourceTiming) {
+      this.observePerformance("resource", (entry) => {
+        const res = entry as PerformanceResourceTiming;
+        if (res.duration < this.thresholds.resourceMs) return;
+        const route = sanitizeUrl(res.name, docBaseUrl());
+        this.attach("resource", res.startTime, res.startTime + res.duration, (incident) =>
+          pushCapped(incident.resources, {
+            origin: route.origin,
+            pathname: route.pathname,
+            initiatorType: typeof res.initiatorType === "string" ? res.initiatorType : "other",
+            durationMs: round(res.duration),
+            startOffsetMs: this.offset(res.startTime),
+          }),
+        );
+      });
+    }
+
+    if (this.capabilities.reactCommit) {
+      this.unsubscribeCommit = subscribeCommit((root) => this.onCommit(root));
+    }
+
+    if (this.capabilities.mutationObserver && typeof document !== "undefined") {
+      this.mutationObserver = new MutationObserver((records) => {
+        // Only the COUNT is used. MutationRecord contents (added/removed nodes,
+        // attribute names/values, subtrees, HTML) are never read (MUL-4466 §12).
+        const count = records.length;
+        this.attach("interaction", now(), now(), (incident) => {
+          incident.mutationCount += count;
+        });
+      });
+      this.mutationObserver.observe(document.documentElement, {
+        childList: true,
+        subtree: true,
+        attributes: true,
+      });
+    }
+
+    this.installInteractionListeners();
+    this.startFrameLoop();
+  }
+
+  private observePerformance(
+    type: string,
+    onEntry: (entry: PerformanceEntry) => void,
+  ): void {
+    if (typeof PerformanceObserver === "undefined") return;
+    try {
+      const observer = new PerformanceObserver((list) => {
+        for (const entry of list.getEntries()) {
+          try {
+            onEntry(entry);
+          } catch {
+            /* fail-open */
+          }
+        }
+      });
+      observer.observe({ type, buffered: false } as PerformanceObserverInit);
+      this.observers.push(observer);
+    } catch {
+      /* entry type unsupported at observe time — capability already flagged */
+    }
+  }
+
+  private installInteractionListeners(): void {
+    if (typeof window === "undefined") return;
+    const handler = (type: InteractionType) => (event: Event) => {
+      const testId = this.resolveTestId(event.target);
+      this.openInteraction(type, testId);
+    };
+    const add = (name: string, type: InteractionType) => {
+      const fn = handler(type);
+      // capture phase so we open the window before app handlers run
+      window.addEventListener(name, fn, { capture: true, passive: true });
+      this.eventCleanups.push(() => window.removeEventListener(name, fn, { capture: true }));
+    };
+    add("click", "click");
+    add("keydown", "input");
+    add("scroll", "scroll");
+    // route changes: history API + popstate
+    const onNav = () => this.openInteraction("navigation", undefined);
+    window.addEventListener("popstate", onNav);
+    this.eventCleanups.push(() => window.removeEventListener("popstate", onNav));
+  }
+
+  private startFrameLoop(): void {
+    if (typeof requestAnimationFrame === "undefined") return;
+    let last = now();
+    const tick = () => {
+      const t = now();
+      const gap = t - last;
+      this.frameTicks++;
+      // rAF gap fallback for dropped frames when LoAF is unavailable.
+      if (!this.capabilities.longAnimationFrame && gap >= this.thresholds.frameGapMs) {
+        this.jankCount++;
+        this.attach("frame", last, t, (incident) =>
+          pushCapped(incident.frames, {
+            startOffsetMs: this.offset(last),
+            durationMs: round(gap),
+            source: "raf",
+          }),
+        );
+      }
+      // sample fps ~1Hz
+      if (t - this.lastFpsSample >= 1000) {
+        this.fps = Math.round((this.frameTicks * 1000) / (t - this.lastFpsSample));
+        this.frameTicks = 0;
+        this.lastFpsSample = t;
+        this.emitStatus();
+      }
+      last = t;
+      this.rafHandle = requestAnimationFrame(tick);
+    };
+    this.rafHandle = requestAnimationFrame(tick);
+  }
+
+  private onCommit(root: CommitRoot): void {
+    const { commitActualDurationMs, phase, boundaries } = extractCommitEvidence(
+      root,
+      this.boundaryAllowlist,
+    );
+    const registered = boundaries.filter((b) => b.actualDurationMs >= this.thresholds.reactCommitMs);
+    const anonymousSlow =
+      commitActualDurationMs !== null && commitActualDurationMs >= this.thresholds.reactCommitMs;
+    if (registered.length === 0 && !anonymousSlow) return;
+    this.jankCount++;
+    const t = now();
+    this.attach("react_commit", t, t, (incident) => {
+      if (registered.length > 0) {
+        for (const b of registered) pushCapped(incident.reactCommits, b);
+      } else if (anonymousSlow) {
+        pushCapped(incident.reactCommits, {
+          phase,
+          actualDurationMs: round(commitActualDurationMs as number),
+        });
+      }
+    });
+  }
+
+  // ---- correlation ---------------------------------------------------------
+
+  private openInteraction(type: InteractionType, testId: string | undefined): void {
+    if (this.state !== "recording") return;
+    const t = now();
+    const route = this.route();
+    const interaction: InteractionInfo = testId ? { type, testId } : { type };
+    const incident = this.newIncident(route, interaction, t);
+    this.current = incident;
+    this.currentWindowEnd = t + CORRELATION_WINDOW_MS;
+    this.pushIncident(incident);
+    this.emitIncidents();
+  }
+
+  /** Route the evidence to the interaction window if fresh & same-route, else background. */
+  private attach(
+    _kind: EvidenceKind,
+    startTime: number,
+    endTime: number,
+    apply: (incident: InternalIncident) => void,
+  ): void {
+    if (this.state !== "recording") return;
+    const t = now();
+    const routeKey = this.route().pathname ?? "";
+    let incident: InternalIncident;
+    if (this.current && t <= this.currentWindowEnd && this.current._routeKey === routeKey) {
+      incident = this.current;
+    } else {
+      incident = this.backgroundIncident(routeKey, t);
+    }
+    apply(incident);
+    incident._startTime = Math.min(incident._startTime, startTime);
+    incident._endTime = Math.max(incident._endTime, endTime);
+    this.emitIncidents();
+  }
+
+  private backgroundIncident(routeKey: string, t: number): InternalIncident {
+    if (this.background && t <= this.backgroundIdleUntil && this.background._routeKey === routeKey) {
+      this.backgroundIdleUntil = t + BACKGROUND_IDLE_MS;
+      return this.background;
+    }
+    const incident = this.newIncident(this.route(), { type: "background" }, t);
+    this.background = incident;
+    this.backgroundIdleUntil = t + BACKGROUND_IDLE_MS;
+    this.pushIncident(incident);
+    return incident;
+  }
+
+  private newIncident(route: RouteInfo, interaction: InteractionInfo, t: number): InternalIncident {
+    return {
+      id: `local-${++this.incidentSeq}`,
+      offsetMs: this.offset(t),
+      route,
+      interaction,
+      totalDurationMs: 0,
+      primaryEvidence: "insufficient",
+      mutationCount: 0,
+      reactCommits: [],
+      longTasks: [],
+      frames: [],
+      resources: [],
+      _startTime: t,
+      _endTime: t,
+      _routeKey: route.pathname ?? "",
+    };
+  }
+
+  private pushIncident(incident: InternalIncident): void {
+    this.incidents.push(incident);
+    if (this.incidents.length > MAX_INCIDENTS) {
+      const dropped = this.incidents.shift();
+      if (dropped === this.current) this.current = null;
+      if (dropped === this.background) this.background = null;
+    }
+  }
+
+  private finalizeAll(): void {
+    for (const incident of this.incidents) this.finalize(incident);
+  }
+
+  private finalize(incident: InternalIncident): void {
+    const span = incident._endTime - incident._startTime;
+    incident.totalDurationMs = Math.max(0, round(span));
+    incident.primaryEvidence = this.rankPrimary(incident);
+  }
+
+  private rankPrimary(incident: Incident): EvidenceKind {
+    const ratios: Array<[EvidenceKind, number]> = [];
+    const maxCommit = maxBy(incident.reactCommits, (c) => c.actualDurationMs);
+    if (maxCommit > 0) ratios.push(["react_commit", maxCommit / this.thresholds.reactCommitMs]);
+    const maxTask = maxBy(incident.longTasks, (l) => l.durationMs);
+    if (maxTask > 0) ratios.push(["long_task", maxTask / LONGTASK_THRESHOLD_MS]);
+    const maxFrame = maxBy(incident.frames, (f) => f.durationMs);
+    if (maxFrame > 0) ratios.push(["frame", maxFrame / this.thresholds.frameGapMs]);
+    const maxRes = maxBy(incident.resources, (r) => r.durationMs);
+    if (maxRes > 0) ratios.push(["resource", maxRes / this.thresholds.resourceMs]);
+    if (ratios.length === 0) return "insufficient";
+    ratios.sort((a, b) => b[1] - a[1]);
+    // Only claim a root cause when at least one signal exceeded its threshold.
+    return ratios[0]![1] >= 1 ? ratios[0]![0] : "insufficient";
+  }
+
+  private resolveTestId(target: EventTarget | null): string | undefined {
+    if (this.testIdAllowlist.size === 0) return undefined;
+    let node = target as Element | null;
+    let depth = 0;
+    while (node && depth < 20) {
+      if (typeof node.getAttribute === "function") {
+        const id = node.getAttribute("data-testid");
+        if (id && this.testIdAllowlist.has(id)) return id;
+      }
+      node = node.parentElement;
+      depth++;
+    }
+    return undefined;
+  }
+
+  private route(): RouteInfo {
+    if (typeof location === "undefined") return { origin: null, pathname: null };
+    return sanitizeUrl(location.href);
+  }
+
+  private offset(t: number): number {
+    return Math.max(0, round(t - this.sessionStart));
+  }
+
+  private teardownCollectors(): void {
+    for (const observer of this.observers) {
+      try {
+        observer.disconnect();
+      } catch {
+        /* ignore */
+      }
+    }
+    this.observers = [];
+    this.mutationObserver?.disconnect();
+    this.mutationObserver = null;
+    for (const cleanup of this.eventCleanups) cleanup();
+    this.eventCleanups = [];
+    if (this.rafHandle !== null && typeof cancelAnimationFrame !== "undefined") {
+      cancelAnimationFrame(this.rafHandle);
+    }
+    this.rafHandle = null;
+    this.unsubscribeCommit?.();
+    this.unsubscribeCommit = null;
+  }
+
+  private reset(): void {
+    this.incidents = [];
+    this.current = null;
+    this.background = null;
+    this.currentWindowEnd = 0;
+    this.backgroundIdleUntil = 0;
+    this.incidentSeq = 0;
+    this.jankCount = 0;
+    this.longTaskCount = 0;
+    this.frameTicks = 0;
+    this.fps = 0;
+    this.sessionStart = 0;
+    this.sessionEnd = 0;
+  }
+
+  private emitStatus(): void {
+    const status: LiveStatus = {
+      state: this.state,
+      fps: this.fps,
+      jankCount: this.jankCount,
+      longTaskCount: this.longTaskCount,
+      durationMs: this.state === "recording" ? round(now() - this.sessionStart) : this.export().session.durationMs,
+      incidentCount: this.incidents.length,
+    };
+    for (const listener of this.statusListeners) {
+      try {
+        listener(status);
+      } catch {
+        /* ignore */
+      }
+    }
+  }
+
+  private emitIncidents(): void {
+    const snapshot = this.incidents.map(stripInternal);
+    for (const listener of this.incidentsListeners) {
+      try {
+        listener(snapshot);
+      } catch {
+        /* ignore */
+      }
+    }
+  }
+}
+
+// ---- helpers ---------------------------------------------------------------
+
+function now(): number {
+  return typeof performance !== "undefined" ? performance.now() : Date.now();
+}
+
+function docBaseUrl(): string | undefined {
+  return typeof document !== "undefined" ? document.baseURI : undefined;
+}
+
+function round(n: number): number {
+  return Math.round(n * 10) / 10;
+}
+
+function maxBy<T>(items: T[], pick: (item: T) => number): number {
+  let max = 0;
+  for (const item of items) {
+    const v = pick(item);
+    if (v > max) max = v;
+  }
+  return max;
+}
+
+function pushCapped<T>(arr: T[], item: T): void {
+  if (arr.length < MAX_EVIDENCE_PER_INCIDENT) arr.push(item);
+}
+
+function stripInternal(incident: InternalIncident): Incident {
+  const { _startTime, _endTime, _routeKey, ...rest } = incident;
+  void _startTime;
+  void _endTime;
+  void _routeKey;
+  return rest;
+}

--- a/packages/perf-recorder/src/sanitize-url.ts
+++ b/packages/perf-recorder/src/sanitize-url.ts
@@ -1,0 +1,34 @@
+import type { RouteInfo } from "./types";
+
+/**
+ * Entry-time URL sanitizer. Every URL (route or resource) MUST pass through
+ * this before it touches any buffer, incident, log, or state. It keeps only the
+ * origin and pathname and drops username, password, query, and hash. On a parse
+ * failure it returns nulls — it NEVER falls back to the raw string, so a secret
+ * embedded in a malformed URL can't leak (MUL-4466 §8.3, §12).
+ *
+ * `base` lets relative resource URLs resolve against the current document
+ * origin; timing entries expose absolute URLs already, but resource entries can
+ * be relative in some engines.
+ */
+export function sanitizeUrl(raw: string | null | undefined, base?: string): RouteInfo {
+  if (!raw) return { origin: null, pathname: null };
+  let parsed: URL;
+  try {
+    parsed = base ? new URL(raw, base) : new URL(raw);
+  } catch {
+    return { origin: null, pathname: null };
+  }
+  // Reading `.origin`/`.pathname` off the URL object never carries query/hash
+  // or credentials, so the secret-bearing parts are dropped by construction.
+  const origin = parsed.origin && parsed.origin !== "null" ? parsed.origin : null;
+  return {
+    origin,
+    pathname: parsed.pathname || null,
+  };
+}
+
+/** True when the parsed URL yielded no usable location. */
+export function isUrlUnavailable(route: RouteInfo): boolean {
+  return route.origin === null && route.pathname === null;
+}

--- a/packages/perf-recorder/src/self-surface.ts
+++ b/packages/perf-recorder/src/self-surface.ts
@@ -1,0 +1,26 @@
+import { RECORDER_HOST_ID } from "./constants";
+
+/**
+ * True when an event originates from the recorder's own panel (which lives in a
+ * Shadow root whose host carries RECORDER_HOST_ID), so the panel's own controls
+ * are never logged as app interactions (MUL-4466 §10.2).
+ *
+ * Real browsers expose the host via `composedPath()` (and retarget `target` to
+ * the host for outer-tree listeners) — that is the primary check. As a fallback
+ * we walk the target's ancestor chain, hopping across shadow roots via `.host`
+ * (checking the property rather than `instanceof ShadowRoot`, which jsdom does
+ * not reliably satisfy).
+ */
+export function isRecorderEvent(event: Event): boolean {
+  const path = typeof event.composedPath === "function" ? event.composedPath() : [];
+  for (const node of path) {
+    if (node instanceof Element && node.id === RECORDER_HOST_ID) return true;
+  }
+  let node: Node | null = event.target as Node | null;
+  for (let hops = 0; node && hops < 200; hops++) {
+    if (node instanceof Element && node.id === RECORDER_HOST_ID) return true;
+    const host = (node as { host?: unknown }).host;
+    node = host instanceof Element ? host : node.parentNode;
+  }
+  return false;
+}

--- a/packages/perf-recorder/src/types.ts
+++ b/packages/perf-recorder/src/types.ts
@@ -1,0 +1,141 @@
+// Data model for the Dev/Profiling-only performance flight recorder.
+//
+// Every field here is metadata: timings, counts, enums, and URLs already
+// stripped of query/hash/credentials at the collector entry. There is no field
+// that can hold page text, input values, React props/state, request bodies,
+// headers, tokens, or any content snapshot — that constraint is enforced by
+// construction, not by a redaction pass (see MUL-4466 Standard mode).
+
+export type Surface = "web" | "desktop-renderer";
+export type RecorderMode = "development" | "profiling";
+
+export interface HostConfig {
+  /** App version string shown in the report header. Non-sensitive. */
+  appVersion: string;
+  surface: Surface;
+  mode: RecorderMode;
+  /** Optional threshold overrides; defaults applied when omitted. */
+  thresholds?: Partial<Thresholds>;
+  /**
+   * Stable React Profiler boundary IDs the host has registered. Only commits
+   * whose Profiler `id` is in this set are attributed by name; everything else
+   * is recorded anonymously. Fail-closed: unset means "nothing registered".
+   */
+  boundaryAllowlist?: readonly string[];
+  /**
+   * Stable `data-testid` values the host has registered. Only these are emitted
+   * as the interaction target; any other testid is dropped.
+   */
+  testIdAllowlist?: readonly string[];
+}
+
+export interface Thresholds {
+  /** rAF gap (ms) above which a frame is considered dropped when LoAF absent. */
+  frameGapMs: number;
+  /** Boundary actualDuration (ms) above which a React commit is an incident. */
+  reactCommitMs: number;
+  /** Resource duration (ms) above which a request is slow. */
+  resourceMs: number;
+  /** Interaction total (ms) above which an interaction is flagged. */
+  interactionMs: number;
+}
+
+export interface Capabilities {
+  longTask: boolean;
+  longAnimationFrame: boolean;
+  eventTiming: boolean;
+  reactCommit: boolean;
+  resourceTiming: boolean;
+  mutationObserver: boolean;
+}
+
+export type InteractionType = "click" | "scroll" | "input" | "navigation" | "background";
+
+export interface RouteInfo {
+  /** Sanitized origin, or null when the URL could not be parsed. */
+  origin: string | null;
+  pathname: string | null;
+}
+
+export interface InteractionInfo {
+  type: InteractionType;
+  /** Only a host-registered, stable data-testid; never other identifiers. */
+  testId?: string;
+}
+
+export type EvidenceKind =
+  | "react_commit"
+  | "long_task"
+  | "frame"
+  | "resource"
+  | "interaction"
+  | "insufficient";
+
+export interface ReactCommitEvidence {
+  /** Present only when the committed boundary is host-registered. */
+  boundaryId?: string;
+  phase: "mount" | "update" | "nested-update" | "unknown";
+  actualDurationMs: number;
+}
+
+export interface LongTaskEvidence {
+  startOffsetMs: number;
+  durationMs: number;
+}
+
+export interface FrameEvidence {
+  startOffsetMs: number;
+  durationMs: number;
+  source: "loaf" | "raf";
+}
+
+export interface ResourceEvidence {
+  origin: string | null;
+  pathname: string | null;
+  initiatorType: string;
+  durationMs: number;
+  startOffsetMs: number;
+}
+
+export interface Incident {
+  id: string;
+  offsetMs: number;
+  route: RouteInfo;
+  interaction: InteractionInfo;
+  totalDurationMs: number;
+  primaryEvidence: EvidenceKind;
+  mutationCount: number;
+  reactCommits: ReactCommitEvidence[];
+  longTasks: LongTaskEvidence[];
+  frames: FrameEvidence[];
+  resources: ResourceEvidence[];
+}
+
+export interface ReportHost {
+  appVersion: string;
+  surface: Surface;
+  mode: RecorderMode;
+}
+
+export interface Report {
+  schemaVersion: string;
+  recorderVersion: string;
+  host: ReportHost;
+  capabilities: Capabilities;
+  thresholdsMs: Thresholds;
+  session: {
+    durationMs: number;
+    incidentCount: number;
+  };
+  incidents: Incident[];
+}
+
+export const SCHEMA_VERSION = "1.0";
+export const RECORDER_VERSION = "0.1.0";
+
+export const DEFAULT_THRESHOLDS: Thresholds = {
+  frameGapMs: 50,
+  reactCommitMs: 16.7,
+  resourceMs: 500,
+  interactionMs: 200,
+};

--- a/packages/perf-recorder/test/install.test.ts
+++ b/packages/perf-recorder/test/install.test.ts
@@ -1,0 +1,72 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  installRecorderHook,
+  isRecorderHookInstalled,
+  subscribeCommit,
+  uninstallRecorderHook,
+} from "../src/install";
+
+const HOOK_KEY = "__REACT_DEVTOOLS_GLOBAL_HOOK__";
+
+function getHook(): any {
+  return (window as unknown as Record<string, unknown>)[HOOK_KEY];
+}
+
+afterEach(() => {
+  uninstallRecorderHook();
+});
+
+describe("installRecorderHook (Desktop hook-order hard gate)", () => {
+  it("installs the DevTools global hook synchronously", () => {
+    installRecorderHook();
+    expect(isRecorderHookInstalled()).toBe(true);
+    const hook = getHook();
+    expect(hook).toBeDefined();
+    expect(typeof hook.onCommitFiberRoot).toBe("function");
+  });
+
+  it("captures a commit from a renderer that registers AFTER the hook is installed", () => {
+    // This is the ordering guarantee in miniature: the hook is installed first,
+    // then a React-like renderer injects and commits, and we still receive it.
+    installRecorderHook();
+    const listener = vi.fn();
+    subscribeCommit(listener);
+
+    const hook = getHook();
+    // Simulate react-dom registering itself, then committing a root.
+    if (typeof hook.inject === "function") {
+      hook.inject({ version: "19.0.0", rendererPackageName: "react-dom", findFiberByHostInstance: () => null });
+    }
+    const root = { current: { actualDuration: 12, alternate: null, child: null, sibling: null } };
+    hook.onCommitFiberRoot(1, root);
+
+    expect(listener).toHaveBeenCalledTimes(1);
+    expect(listener.mock.calls[0]?.[0]).toBe(root);
+  });
+
+  it("is idempotent — a second install does not double-dispatch commits", () => {
+    installRecorderHook();
+    installRecorderHook();
+    const listener = vi.fn();
+    subscribeCommit(listener);
+    const hook = getHook();
+    if (typeof hook.inject === "function") hook.inject({ version: "19.0.0", rendererPackageName: "react-dom" });
+    hook.onCommitFiberRoot(1, { current: { actualDuration: 1, alternate: null } });
+    expect(listener).toHaveBeenCalledTimes(1);
+  });
+
+  it("stops dispatching after uninstall", () => {
+    installRecorderHook();
+    const listener = vi.fn();
+    subscribeCommit(listener);
+    uninstallRecorderHook();
+    expect(isRecorderHookInstalled()).toBe(false);
+    listener.mockClear();
+    // Any further calls must not reach our (now cleared) listeners.
+    const hook = getHook();
+    if (hook && typeof hook.onCommitFiberRoot === "function") {
+      hook.onCommitFiberRoot(1, { current: { actualDuration: 1, alternate: null } });
+    }
+    expect(listener).not.toHaveBeenCalled();
+  });
+});

--- a/packages/perf-recorder/test/lifecycle.test.ts
+++ b/packages/perf-recorder/test/lifecycle.test.ts
@@ -64,4 +64,19 @@ describe("recording lifecycle", () => {
     recorder.stop();
     expect(() => recorder.stop()).not.toThrow();
   });
+
+  it("only allows export in the stopped state (RFC §7)", () => {
+    const recorder = new Recorder({ appVersion: "t", surface: "web", mode: "development" });
+    // idle
+    expect(recorder.canExport()).toBe(false);
+    expect(() => recorder.export()).toThrow();
+    // recording
+    recorder.start();
+    expect(recorder.canExport()).toBe(false);
+    expect(() => recorder.export()).toThrow();
+    // stopped
+    recorder.stop();
+    expect(recorder.canExport()).toBe(true);
+    expect(() => recorder.export()).not.toThrow();
+  });
 });

--- a/packages/perf-recorder/test/lifecycle.test.ts
+++ b/packages/perf-recorder/test/lifecycle.test.ts
@@ -1,0 +1,67 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { Recorder } from "../src/recorder";
+import { uninstallRecorderHook } from "../src/install";
+
+function tick(): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+afterEach(() => {
+  document.body.innerHTML = "";
+  uninstallRecorderHook();
+});
+
+describe("recording lifecycle", () => {
+  it("moves through idle → recording → stopped → idle", () => {
+    const recorder = new Recorder({ appVersion: "t", surface: "web", mode: "development" });
+    expect(recorder.getState()).toBe("idle");
+    recorder.start();
+    expect(recorder.getState()).toBe("recording");
+    recorder.stop();
+    expect(recorder.getState()).toBe("stopped");
+    recorder.clear();
+    expect(recorder.getState()).toBe("idle");
+  });
+
+  it("degrades on unsupported entry types instead of throwing", () => {
+    // The jsdom test env supports some PerformanceObserver entry types but not
+    // others (e.g. no `longtask`). start() must probe capabilities and skip the
+    // unsupported collectors without throwing.
+    const recorder = new Recorder({ appVersion: "t", surface: "web", mode: "development" });
+    expect(() => recorder.start()).not.toThrow();
+    const caps = recorder.getCapabilities();
+    // longtask is not implemented in jsdom → must be reported as unavailable.
+    expect(caps.longTask).toBe(false);
+    // every capability is a strict boolean regardless of environment.
+    expect(Object.values(caps).every((v) => typeof v === "boolean")).toBe(true);
+    recorder.stop();
+  });
+
+  it("releases the MutationObserver on stop (no incidents after stop)", async () => {
+    const recorder = new Recorder({ appVersion: "t", surface: "web", mode: "development" });
+    recorder.start();
+    recorder.stop();
+    document.body.appendChild(document.createElement("div"));
+    await tick();
+    expect(recorder.getIncidents()).toHaveLength(0);
+  });
+
+  it("start() drops prior un-exported data", async () => {
+    const recorder = new Recorder({ appVersion: "t", surface: "web", mode: "development" });
+    recorder.start();
+    document.body.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    await tick();
+    recorder.stop();
+    expect(recorder.getIncidents().length).toBeGreaterThanOrEqual(1);
+    recorder.start();
+    expect(recorder.getIncidents()).toHaveLength(0);
+    recorder.stop();
+  });
+
+  it("is idempotent on repeated stop", () => {
+    const recorder = new Recorder({ appVersion: "t", surface: "web", mode: "development" });
+    recorder.start();
+    recorder.stop();
+    expect(() => recorder.stop()).not.toThrow();
+  });
+});

--- a/packages/perf-recorder/test/privacy.test.ts
+++ b/packages/perf-recorder/test/privacy.test.ts
@@ -1,0 +1,98 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { Recorder } from "../src/recorder";
+import { uninstallRecorderHook } from "../src/install";
+
+const FORBIDDEN_GETTERS = [
+  "innerText",
+  "textContent",
+  "value",
+  "defaultValue",
+  "placeholder",
+  "title",
+  "ariaLabel",
+];
+
+function tick(): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+afterEach(() => {
+  document.body.innerHTML = "";
+  uninstallRecorderHook();
+});
+
+describe("Standard mode privacy boundary", () => {
+  it("resolves a registered testId without ever reading page content", async () => {
+    let forbiddenRead = false;
+    const row = document.createElement("div");
+    row.setAttribute("data-testid", "issue-row");
+    const span = document.createElement("span");
+    for (const key of FORBIDDEN_GETTERS) {
+      Object.defineProperty(span, key, {
+        configurable: true,
+        get() {
+          forbiddenRead = true;
+          return "SECRET-USER-CONTENT";
+        },
+      });
+    }
+    row.appendChild(span);
+    document.body.appendChild(row);
+
+    const recorder = new Recorder({
+      appVersion: "test",
+      surface: "web",
+      mode: "development",
+      testIdAllowlist: ["issue-row"],
+    });
+    recorder.start();
+
+    span.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    // let the MutationObserver flush
+    row.appendChild(document.createElement("b"));
+    await tick();
+
+    recorder.stop();
+    const report = recorder.export();
+
+    // The interaction target was identified by its registered testId only.
+    const click = report.incidents.find((i) => i.interaction.type === "click");
+    expect(click?.interaction.testId).toBe("issue-row");
+    // No forbidden DOM getter was ever accessed by any collector.
+    expect(forbiddenRead).toBe(false);
+    // And no user content leaked into the export.
+    expect(JSON.stringify(report)).not.toContain("SECRET-USER-CONTENT");
+  });
+
+  it("does not emit an unregistered testId", async () => {
+    const row = document.createElement("div");
+    row.setAttribute("data-testid", "not-registered");
+    document.body.appendChild(row);
+    const recorder = new Recorder({ appVersion: "test", surface: "web", mode: "development" });
+    recorder.start();
+    row.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    await tick();
+    recorder.stop();
+    const click = recorder.export().incidents.find((i) => i.interaction.type === "click");
+    expect(click?.interaction.testId).toBeUndefined();
+  });
+
+  it("MutationObserver contributes only a count, never record contents", async () => {
+    const recorder = new Recorder({ appVersion: "test", surface: "web", mode: "development" });
+    recorder.start();
+    // open an interaction window so mutations attach somewhere
+    document.body.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    const secret = document.createElement("div");
+    secret.setAttribute("data-secret", "TOP-SECRET-ATTR");
+    secret.textContent = "TOP-SECRET-TEXT";
+    document.body.appendChild(secret);
+    await tick();
+    recorder.stop();
+    const report = recorder.export();
+    const serialized = JSON.stringify(report);
+    expect(serialized).not.toContain("TOP-SECRET-ATTR");
+    expect(serialized).not.toContain("TOP-SECRET-TEXT");
+    // a mutationCount field exists and is numeric
+    expect(report.incidents.every((i) => typeof i.mutationCount === "number")).toBe(true);
+  });
+});

--- a/packages/perf-recorder/test/react-commit.test.ts
+++ b/packages/perf-recorder/test/react-commit.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from "vitest";
+import { extractCommitEvidence } from "../src/react-commit";
+import type { CommitRoot } from "../src/install";
+
+const PROFILER_TAG = 12;
+
+// Build a synthetic fiber tree. Only the fields the extractor is allowed to read
+// are set; any secret is placed in a forbidden field to prove it is never read.
+function fiber(partial: Record<string, unknown>): Record<string, unknown> {
+  return { tag: 0, actualDuration: 0, alternate: {}, child: null, sibling: null, ...partial };
+}
+
+describe("extractCommitEvidence", () => {
+  it("reads commit actualDuration and phase off the root", () => {
+    const root: CommitRoot = { current: fiber({ actualDuration: 42, alternate: null }) };
+    const out = extractCommitEvidence(root, new Set());
+    expect(out.commitActualDurationMs).toBe(42);
+    expect(out.phase).toBe("mount");
+  });
+
+  it("attributes only host-registered Profiler boundaries", () => {
+    const registered = fiber({
+      tag: PROFILER_TAG,
+      actualDuration: 30,
+      memoizedProps: { id: "issue-detail" },
+    });
+    const unregistered = fiber({
+      tag: PROFILER_TAG,
+      actualDuration: 99,
+      memoizedProps: { id: "secret-area" },
+    });
+    registered.sibling = unregistered;
+    const root: CommitRoot = { current: fiber({ actualDuration: 129, child: registered }) };
+
+    const out = extractCommitEvidence(root, new Set(["issue-detail"]));
+    expect(out.boundaries).toHaveLength(1);
+    expect(out.boundaries[0]).toMatchObject({ boundaryId: "issue-detail", actualDurationMs: 30 });
+  });
+
+  it("never reads non-id props / state / context — only a Profiler's own id", () => {
+    let sensitiveRead = false;
+    const props = {
+      get value() {
+        sensitiveRead = true;
+        return "user typed secret";
+      },
+      get children() {
+        sensitiveRead = true;
+        return "dom text";
+      },
+      id: "issue-detail",
+    };
+    const profiler = fiber({ tag: PROFILER_TAG, actualDuration: 20, memoizedProps: props });
+    // A non-Profiler fiber whose memoizedProps must NOT be touched at all.
+    // Defined via defineProperty so the getter is not triggered by object spread
+    // at construction time — only a real read would flip the flag.
+    const host = fiber({ tag: 5, actualDuration: 5 });
+    Object.defineProperty(host, "memoizedProps", {
+      enumerable: true,
+      get() {
+        sensitiveRead = true;
+        return { onClick: () => {} };
+      },
+    });
+    profiler.sibling = host;
+    const root: CommitRoot = { current: fiber({ child: profiler }) };
+
+    const out = extractCommitEvidence(root, new Set(["issue-detail"]));
+    expect(out.boundaries[0]?.boundaryId).toBe("issue-detail");
+    // reading `.id` off the Profiler props is expected; value/children/host props are not.
+    expect(sensitiveRead).toBe(false);
+  });
+
+  it("emits nothing for boundaries when the allowlist is empty", () => {
+    const profiler = fiber({ tag: PROFILER_TAG, actualDuration: 50, memoizedProps: { id: "x" } });
+    const root: CommitRoot = { current: fiber({ child: profiler }) };
+    expect(extractCommitEvidence(root, new Set()).boundaries).toHaveLength(0);
+  });
+});

--- a/packages/perf-recorder/test/report.test.ts
+++ b/packages/perf-recorder/test/report.test.ts
@@ -1,0 +1,123 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { z } from "zod";
+import { Recorder } from "../src/recorder";
+import { uninstallRecorderHook } from "../src/install";
+
+// The export contract from MUL-4466 §11 expressed as a runtime schema. If a
+// future change adds a content-bearing field, `.strict()` here fails the test.
+const routeSchema = z
+  .object({ origin: z.string().nullable(), pathname: z.string().nullable() })
+  .strict();
+
+const incidentSchema = z
+  .object({
+    id: z.string(),
+    offsetMs: z.number(),
+    route: routeSchema,
+    interaction: z
+      .object({
+        type: z.enum(["click", "scroll", "input", "navigation", "background"]),
+        testId: z.string().optional(),
+      })
+      .strict(),
+    totalDurationMs: z.number(),
+    primaryEvidence: z.enum([
+      "react_commit",
+      "long_task",
+      "frame",
+      "resource",
+      "interaction",
+      "insufficient",
+    ]),
+    mutationCount: z.number(),
+    reactCommits: z.array(
+      z
+        .object({
+          boundaryId: z.string().optional(),
+          phase: z.enum(["mount", "update", "nested-update", "unknown"]),
+          actualDurationMs: z.number(),
+        })
+        .strict(),
+    ),
+    longTasks: z.array(z.object({ startOffsetMs: z.number(), durationMs: z.number() }).strict()),
+    frames: z.array(
+      z
+        .object({ startOffsetMs: z.number(), durationMs: z.number(), source: z.enum(["loaf", "raf"]) })
+        .strict(),
+    ),
+    resources: z.array(
+      z
+        .object({
+          origin: z.string().nullable(),
+          pathname: z.string().nullable(),
+          initiatorType: z.string(),
+          durationMs: z.number(),
+          startOffsetMs: z.number(),
+        })
+        .strict(),
+    ),
+  })
+  .strict();
+
+const reportSchema = z
+  .object({
+    schemaVersion: z.literal("1.0"),
+    recorderVersion: z.string(),
+    host: z
+      .object({
+        appVersion: z.string(),
+        surface: z.enum(["web", "desktop-renderer"]),
+        mode: z.enum(["development", "profiling"]),
+      })
+      .strict(),
+    capabilities: z
+      .object({
+        longTask: z.boolean(),
+        longAnimationFrame: z.boolean(),
+        eventTiming: z.boolean(),
+        reactCommit: z.boolean(),
+        resourceTiming: z.boolean(),
+        mutationObserver: z.boolean(),
+      })
+      .strict(),
+    thresholdsMs: z
+      .object({
+        frameGapMs: z.number(),
+        reactCommitMs: z.number(),
+        resourceMs: z.number(),
+        interactionMs: z.number(),
+      })
+      .strict(),
+    session: z.object({ durationMs: z.number(), incidentCount: z.number() }).strict(),
+    incidents: z.array(incidentSchema),
+  })
+  .strict();
+
+afterEach(() => uninstallRecorderHook());
+
+describe("JSON export contract", () => {
+  it("produces a schema-valid report for an empty session", () => {
+    const recorder = new Recorder({
+      appVersion: "1.2.3",
+      surface: "desktop-renderer",
+      mode: "development",
+    });
+    recorder.start();
+    recorder.stop();
+    const report = recorder.export();
+    expect(() => reportSchema.parse(report)).not.toThrow();
+    expect(report.host.surface).toBe("desktop-renderer");
+    expect(report.session.incidentCount).toBe(0);
+  });
+
+  it("carries version, mode, capabilities, and thresholds in the header", () => {
+    const recorder = new Recorder({ appVersion: "9.9.9", surface: "web", mode: "profiling" });
+    recorder.start();
+    recorder.stop();
+    const report = recorder.export();
+    expect(report.schemaVersion).toBe("1.0");
+    expect(report.host.mode).toBe("profiling");
+    expect(report.thresholdsMs.reactCommitMs).toBeGreaterThan(0);
+    expect(typeof report.capabilities.reactCommit).toBe("boolean");
+  });
+});

--- a/packages/perf-recorder/test/sanitize-url.test.ts
+++ b/packages/perf-recorder/test/sanitize-url.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest";
+import { isUrlUnavailable, sanitizeUrl } from "../src/sanitize-url";
+
+describe("sanitizeUrl", () => {
+  it("drops query, hash, and credentials, keeping only origin + pathname", () => {
+    const out = sanitizeUrl("https://user:pass@api.example.com/api/issues/123?token=SECRET#frag");
+    expect(out).toEqual({ origin: "https://api.example.com", pathname: "/api/issues/123" });
+  });
+
+  it("never leaks a secret query value", () => {
+    const out = sanitizeUrl("https://x.test/y?access_token=abc123&sig=deadbeef");
+    const serialized = JSON.stringify(out);
+    expect(serialized).not.toContain("abc123");
+    expect(serialized).not.toContain("deadbeef");
+    expect(serialized).not.toContain("access_token");
+  });
+
+  it("returns nulls (not the raw string) on a parse failure", () => {
+    const out = sanitizeUrl("::::not a url::::");
+    expect(out).toEqual({ origin: null, pathname: null });
+    expect(isUrlUnavailable(out)).toBe(true);
+  });
+
+  it("resolves relative resource URLs against a base without keeping the query", () => {
+    const out = sanitizeUrl("/api/data?x=secret", "https://app.test/page");
+    expect(out).toEqual({ origin: "https://app.test", pathname: "/api/data" });
+  });
+
+  it("treats empty input as unavailable", () => {
+    expect(sanitizeUrl("")).toEqual({ origin: null, pathname: null });
+    expect(sanitizeUrl(undefined)).toEqual({ origin: null, pathname: null });
+  });
+});

--- a/packages/perf-recorder/test/self-exclusion.test.ts
+++ b/packages/perf-recorder/test/self-exclusion.test.ts
@@ -1,0 +1,57 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { Recorder } from "../src/recorder";
+import { createRecorder } from "../src/index";
+import { RECORDER_HOST_ID } from "../src/constants";
+import { uninstallRecorderHook } from "../src/install";
+
+function tick(): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+afterEach(() => {
+  document.body.innerHTML = "";
+  uninstallRecorderHook();
+});
+
+describe("recorder self-surface exclusion (MUL-4466 §10.2)", () => {
+  it("ignores clicks from the recorder panel, records clicks elsewhere", async () => {
+    const recorder = new Recorder({ appVersion: "t", surface: "web", mode: "development" });
+    const clicks = () => recorder.getIncidents().filter((i) => i.interaction.type === "click");
+
+    // Build the panel host + an unrelated control BEFORE start(), so their
+    // insertion isn't counted by the mutation collector.
+    const host = document.createElement("div");
+    host.id = RECORDER_HOST_ID;
+    const outside = document.createElement("button");
+    document.body.append(host, outside);
+    recorder.start();
+
+    // A retargeted panel interaction — a real browser delivers a shadow click to
+    // an outer-tree listener with target === the host — must be excluded.
+    host.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    await tick();
+    expect(clicks()).toHaveLength(0);
+
+    // A click anywhere outside the panel is still recorded.
+    outside.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    await tick();
+    expect(clicks().length).toBeGreaterThanOrEqual(1);
+
+    recorder.stop();
+  });
+
+  it("Howard's repro: mounted panel → start → click a panel control → stop yields no fake incident", async () => {
+    const { recorder } = createRecorder({ appVersion: "t", surface: "web", mode: "development" });
+    const host = document.getElementById(RECORDER_HOST_ID);
+    expect(host).not.toBeNull();
+
+    recorder.start();
+    // The panel host was mounted before start(); clicking it (retargeted to the
+    // host) must not produce a fake incident.
+    host!.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    await tick();
+    recorder.stop();
+
+    expect(recorder.export().session.incidentCount).toBe(0);
+  });
+});

--- a/packages/perf-recorder/test/self-surface.test.ts
+++ b/packages/perf-recorder/test/self-surface.test.ts
@@ -1,0 +1,53 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { isRecorderEvent } from "../src/self-surface";
+import { RECORDER_HOST_ID } from "../src/constants";
+
+function makeHost(): HTMLElement {
+  const host = document.createElement("div");
+  host.id = RECORDER_HOST_ID;
+  document.body.appendChild(host);
+  return host;
+}
+
+/** A minimal Event stand-in — isRecorderEvent only reads target + composedPath. */
+function ev(target: Node | null, path: EventTarget[] = []): Event {
+  return { target, composedPath: () => path } as unknown as Event;
+}
+
+afterEach(() => {
+  document.body.innerHTML = "";
+});
+
+describe("isRecorderEvent", () => {
+  it("matches when composedPath includes the recorder host (real-browser path)", () => {
+    const host = makeHost();
+    const inner = document.createElement("button");
+    expect(isRecorderEvent(ev(inner, [inner, host, document.body, window]))).toBe(true);
+  });
+
+  it("matches a retargeted event whose target IS the host", () => {
+    const host = makeHost();
+    expect(isRecorderEvent(ev(host))).toBe(true);
+  });
+
+  it("matches a light-DOM descendant of the host via the ancestor walk", () => {
+    const host = makeHost();
+    const child = document.createElement("span");
+    host.appendChild(child);
+    expect(isRecorderEvent(ev(child))).toBe(true);
+  });
+
+  it("matches a shadow-DOM descendant by hopping across the shadow host", () => {
+    const host = makeHost();
+    const shadow = host.attachShadow({ mode: "open" });
+    const inner = document.createElement("button");
+    shadow.appendChild(inner);
+    expect(isRecorderEvent(ev(inner))).toBe(true);
+  });
+
+  it("does not match events outside the recorder surface", () => {
+    const other = document.createElement("button");
+    document.body.appendChild(other);
+    expect(isRecorderEvent(ev(other, [other, document.body]))).toBe(false);
+  });
+});

--- a/packages/perf-recorder/tsconfig.json
+++ b/packages/perf-recorder/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "extends": "@multica/tsconfig/base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": ".",
+    "lib": ["ESNext", "DOM", "DOM.Iterable"],
+    "types": ["vitest/globals"],
+    "declaration": false,
+    "declarationMap": false,
+    "sourceMap": false,
+    "noEmit": true
+  },
+  "include": ["src/**/*.ts", "test/**/*.ts"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/packages/perf-recorder/tsup.config.ts
+++ b/packages/perf-recorder/tsup.config.ts
@@ -1,0 +1,35 @@
+import { defineConfig } from "tsup";
+
+// Two outputs, mirroring react-scan / react-grab packaging:
+//  - ESM entries consumed by the in-repo dev-only host loaders
+//    (`@multica/perf-recorder`, `/install`, `/auto`).
+//  - A single self-executing IIFE global (`dist/auto.global.js`) that inlines
+//    bippy, so the eventual standalone package can be referenced with a plain
+//    <script src> exactly like react-grab's `dist/index.global.js`.
+export default defineConfig([
+  {
+    entry: {
+      index: "src/index.ts",
+      install: "src/install.ts",
+      auto: "src/auto.ts",
+    },
+    format: ["esm"],
+    target: "es2022",
+    dts: true,
+    clean: true,
+    treeshake: true,
+    platform: "browser",
+  },
+  {
+    entry: { auto: "src/auto.ts" },
+    format: ["iife"],
+    globalName: "MulticaPerfRecorder",
+    outExtension: () => ({ js: ".global.js" }),
+    target: "es2022",
+    minify: true,
+    treeshake: true,
+    platform: "browser",
+    // Inline all deps (bippy) so the global file is self-contained.
+    noExternal: [/.*/],
+  },
+]);

--- a/packages/perf-recorder/vitest.config.ts
+++ b/packages/perf-recorder/vitest.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "jsdom",
+    globals: true,
+    include: ["test/**/*.test.ts"],
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -218,12 +218,15 @@ importers:
       '@multica/eslint-config':
         specifier: workspace:*
         version: link:../../packages/eslint-config
+      '@multica/perf-recorder':
+        specifier: workspace:*
+        version: link:../../packages/perf-recorder
       '@multica/tsconfig':
         specifier: workspace:*
         version: link:../../packages/tsconfig
       '@tailwindcss/vite':
         specifier: ^4
-        version: 4.2.2(vite@8.0.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@25.5.0)(jiti@2.6.1)(terser@5.47.1)(yaml@2.9.0))
+        version: 4.2.2(vite@8.0.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@25.5.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.47.1)(yaml@2.9.0))
       '@testing-library/jest-dom':
         specifier: 'catalog:'
         version: 6.9.1
@@ -241,7 +244,7 @@ importers:
         version: 19.2.3(@types/react@19.2.14)
       '@vitejs/plugin-react':
         specifier: ^5.1.1
-        version: 5.2.0(vite@8.0.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@25.5.0)(jiti@2.6.1)(terser@5.47.1)(yaml@2.9.0))
+        version: 5.2.0(vite@8.0.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@25.5.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.47.1)(yaml@2.9.0))
       electron:
         specifier: ^39.2.6
         version: 39.8.7
@@ -250,7 +253,7 @@ importers:
         version: 26.8.1(electron-builder-squirrel-windows@26.8.1)
       electron-vite:
         specifier: ^5.0.0
-        version: 5.0.0(vite@8.0.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@25.5.0)(jiti@2.6.1)(terser@5.47.1)(yaml@2.9.0))
+        version: 5.0.0(vite@8.0.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@25.5.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.47.1)(yaml@2.9.0))
       globals:
         specifier: ^16.0.0
         version: 16.5.0
@@ -265,7 +268,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: 'catalog:'
-        version: 4.1.0(@opentelemetry/api@1.9.1)(@types/node@25.5.0)(jsdom@29.0.1(@noble/hashes@1.8.0))(msw@2.12.14(@types/node@25.5.0)(typescript@5.9.3))(vite@8.0.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@25.5.0)(jiti@2.6.1)(terser@5.47.1)(yaml@2.9.0))
+        version: 4.1.0(@opentelemetry/api@1.9.1)(@types/node@25.5.0)(jsdom@29.0.1(@noble/hashes@1.8.0))(msw@2.12.14(@types/node@25.5.0)(typescript@5.9.3))(vite@8.0.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@25.5.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.47.1)(yaml@2.9.0))
 
   apps/docs:
     dependencies:
@@ -277,7 +280,7 @@ importers:
         version: 15.8.5(@types/react@19.2.14)(lucide-react@1.0.1(react@19.2.3))(next@15.5.18(@opentelemetry/api@1.9.1)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react-router@7.14.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)
       fumadocs-mdx:
         specifier: ^12.0.3
-        version: 12.0.3(fumadocs-core@15.8.5(@types/react@19.2.14)(lucide-react@1.0.1(react@19.2.3))(next@15.5.18(@opentelemetry/api@1.9.1)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react-router@7.14.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3))(next@15.5.18(@opentelemetry/api@1.9.1)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)(vite@8.0.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@25.5.0)(jiti@2.6.1)(terser@5.47.1)(yaml@2.9.0))
+        version: 12.0.3(fumadocs-core@15.8.5(@types/react@19.2.14)(lucide-react@1.0.1(react@19.2.3))(next@15.5.18(@opentelemetry/api@1.9.1)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react-router@7.14.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3))(next@15.5.18(@opentelemetry/api@1.9.1)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)(vite@8.0.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@25.5.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.47.1)(yaml@2.9.0))
       fumadocs-ui:
         specifier: ^15.5.2
         version: 15.8.5(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(lucide-react@1.0.1(react@19.2.3))(next@15.5.18(@opentelemetry/api@1.9.1)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react-router@7.14.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)(tailwindcss@4.2.2)
@@ -317,7 +320,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: 'catalog:'
-        version: 4.1.0(@opentelemetry/api@1.9.1)(@types/node@25.5.0)(jsdom@29.0.1(@noble/hashes@1.8.0))(msw@2.12.14(@types/node@25.5.0)(typescript@5.9.3))(vite@8.0.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@25.5.0)(jiti@2.6.1)(terser@5.47.1)(yaml@2.9.0))
+        version: 4.1.0(@opentelemetry/api@1.9.1)(@types/node@25.5.0)(jsdom@29.0.1(@noble/hashes@1.8.0))(msw@2.12.14(@types/node@25.5.0)(typescript@5.9.3))(vite@8.0.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@25.5.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.47.1)(yaml@2.9.0))
 
   apps/mobile:
     dependencies:
@@ -522,7 +525,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: 'catalog:'
-        version: 4.1.0(@opentelemetry/api@1.9.1)(@types/node@25.5.0)(jsdom@29.0.1(@noble/hashes@1.8.0))(msw@2.12.14(@types/node@25.5.0)(typescript@5.9.3))(vite@8.0.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@25.5.0)(jiti@1.21.7)(terser@5.47.1)(yaml@2.9.0))
+        version: 4.1.0(@opentelemetry/api@1.9.1)(@types/node@25.5.0)(jsdom@29.0.1(@noble/hashes@1.8.0))(msw@2.12.14(@types/node@25.5.0)(typescript@5.9.3))(vite@8.0.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@25.5.0)(esbuild@0.27.7)(jiti@1.21.7)(terser@5.47.1)(yaml@2.9.0))
 
   apps/web:
     dependencies:
@@ -724,7 +727,7 @@ importers:
         version: 19.2.3(@types/react@19.2.14)
       '@vitejs/plugin-react':
         specifier: 'catalog:'
-        version: 6.0.1(babel-plugin-react-compiler@1.0.0)(vite@8.0.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@25.5.0)(jiti@2.6.1)(terser@5.47.1)(yaml@2.9.0))
+        version: 6.0.1(babel-plugin-react-compiler@1.0.0)(vite@8.0.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@25.5.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.47.1)(yaml@2.9.0))
       jsdom:
         specifier: 'catalog:'
         version: 29.0.1(@noble/hashes@1.8.0)
@@ -736,7 +739,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: 'catalog:'
-        version: 4.1.0(@opentelemetry/api@1.9.1)(@types/node@25.5.0)(jsdom@29.0.1(@noble/hashes@1.8.0))(msw@2.12.14(@types/node@25.5.0)(typescript@5.9.3))(vite@8.0.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@25.5.0)(jiti@1.21.7)(terser@5.47.1)(yaml@2.9.0))
+        version: 4.1.0(@opentelemetry/api@1.9.1)(@types/node@25.5.0)(jsdom@29.0.1(@noble/hashes@1.8.0))(msw@2.12.14(@types/node@25.5.0)(typescript@5.9.3))(vite@8.0.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@25.5.0)(esbuild@0.27.7)(jiti@1.21.7)(terser@5.47.1)(yaml@2.9.0))
 
   packages/core:
     dependencies:
@@ -794,7 +797,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: 'catalog:'
-        version: 4.1.0(@opentelemetry/api@1.9.1)(@types/node@25.5.0)(jsdom@29.0.1(@noble/hashes@1.8.0))(msw@2.12.14(@types/node@25.5.0)(typescript@5.9.3))(vite@8.0.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@25.5.0)(jiti@2.6.1)(terser@5.47.1)(yaml@2.9.0))
+        version: 4.1.0(@opentelemetry/api@1.9.1)(@types/node@25.5.0)(jsdom@29.0.1(@noble/hashes@1.8.0))(msw@2.12.14(@types/node@25.5.0)(typescript@5.9.3))(vite@8.0.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@25.5.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.47.1)(yaml@2.9.0))
 
   packages/eslint-config:
     dependencies:
@@ -819,6 +822,37 @@ importers:
       typescript-eslint:
         specifier: ^8.35.0
         version: 8.58.1(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)
+
+  packages/perf-recorder:
+    dependencies:
+      bippy:
+        specifier: 0.6.0
+        version: 0.6.0(react@19.2.3)
+    devDependencies:
+      '@multica/eslint-config':
+        specifier: workspace:*
+        version: link:../eslint-config
+      '@multica/tsconfig':
+        specifier: workspace:*
+        version: link:../tsconfig
+      '@types/react':
+        specifier: ^19.2.0
+        version: 19.2.14
+      jsdom:
+        specifier: 'catalog:'
+        version: 29.0.1(@noble/hashes@1.8.0)
+      tsup:
+        specifier: ^8.5.0
+        version: 8.5.1(jiti@2.6.1)(postcss@8.5.8)(typescript@5.9.3)(yaml@2.9.0)
+      typescript:
+        specifier: 'catalog:'
+        version: 5.9.3
+      vitest:
+        specifier: 'catalog:'
+        version: 4.1.0(@opentelemetry/api@1.9.1)(@types/node@25.5.0)(jsdom@29.0.1(@noble/hashes@1.8.0))(msw@2.12.14(@types/node@25.5.0)(typescript@5.9.3))(vite@8.0.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@25.5.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.47.1)(yaml@2.9.0))
+      zod:
+        specifier: 'catalog:'
+        version: 4.3.6
 
   packages/tsconfig: {}
 
@@ -1149,7 +1183,7 @@ importers:
         version: 19.2.3(@types/react@19.2.14)
       '@vitejs/plugin-react':
         specifier: 'catalog:'
-        version: 6.0.1(babel-plugin-react-compiler@1.0.0)(vite@8.0.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@25.5.0)(jiti@2.6.1)(terser@5.47.1)(yaml@2.9.0))
+        version: 6.0.1(babel-plugin-react-compiler@1.0.0)(vite@8.0.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@25.5.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.47.1)(yaml@2.9.0))
       eslint-plugin-i18next:
         specifier: 'catalog:'
         version: 6.1.4
@@ -1161,7 +1195,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: 'catalog:'
-        version: 4.1.0(@opentelemetry/api@1.9.1)(@types/node@25.5.0)(jsdom@29.0.1(@noble/hashes@1.8.0))(msw@2.12.14(@types/node@25.5.0)(typescript@5.9.3))(vite@8.0.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@25.5.0)(jiti@2.6.1)(terser@5.47.1)(yaml@2.9.0))
+        version: 4.1.0(@opentelemetry/api@1.9.1)(@types/node@25.5.0)(jsdom@29.0.1(@noble/hashes@1.8.0))(msw@2.12.14(@types/node@25.5.0)(typescript@5.9.3))(vite@8.0.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@25.5.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.47.1)(yaml@2.9.0))
 
 packages:
 
@@ -1916,8 +1950,20 @@ packages:
     cpu: [ppc64]
     os: [aix]
 
+  '@esbuild/aix-ppc64@0.27.7':
+    resolution: {integrity: sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
   '@esbuild/android-arm64@0.25.12':
     resolution: {integrity: sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm64@0.27.7':
+    resolution: {integrity: sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [android]
@@ -1928,8 +1974,20 @@ packages:
     cpu: [arm]
     os: [android]
 
+  '@esbuild/android-arm@0.27.7':
+    resolution: {integrity: sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [android]
+
   '@esbuild/android-x64@0.25.12':
     resolution: {integrity: sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/android-x64@0.27.7':
+    resolution: {integrity: sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [android]
@@ -1940,8 +1998,20 @@ packages:
     cpu: [arm64]
     os: [darwin]
 
+  '@esbuild/darwin-arm64@0.27.7':
+    resolution: {integrity: sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
   '@esbuild/darwin-x64@0.25.12':
     resolution: {integrity: sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.27.7':
+    resolution: {integrity: sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [darwin]
@@ -1952,8 +2022,20 @@ packages:
     cpu: [arm64]
     os: [freebsd]
 
+  '@esbuild/freebsd-arm64@0.27.7':
+    resolution: {integrity: sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
   '@esbuild/freebsd-x64@0.25.12':
     resolution: {integrity: sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.27.7':
+    resolution: {integrity: sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [freebsd]
@@ -1964,8 +2046,20 @@ packages:
     cpu: [arm64]
     os: [linux]
 
+  '@esbuild/linux-arm64@0.27.7':
+    resolution: {integrity: sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
   '@esbuild/linux-arm@0.25.12':
     resolution: {integrity: sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.27.7':
+    resolution: {integrity: sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==}
     engines: {node: '>=18'}
     cpu: [arm]
     os: [linux]
@@ -1976,8 +2070,20 @@ packages:
     cpu: [ia32]
     os: [linux]
 
+  '@esbuild/linux-ia32@0.27.7':
+    resolution: {integrity: sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
   '@esbuild/linux-loong64@0.25.12':
     resolution: {integrity: sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==}
+    engines: {node: '>=18'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.27.7':
+    resolution: {integrity: sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==}
     engines: {node: '>=18'}
     cpu: [loong64]
     os: [linux]
@@ -1988,8 +2094,20 @@ packages:
     cpu: [mips64el]
     os: [linux]
 
+  '@esbuild/linux-mips64el@0.27.7':
+    resolution: {integrity: sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
   '@esbuild/linux-ppc64@0.25.12':
     resolution: {integrity: sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.27.7':
+    resolution: {integrity: sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==}
     engines: {node: '>=18'}
     cpu: [ppc64]
     os: [linux]
@@ -2000,8 +2118,20 @@ packages:
     cpu: [riscv64]
     os: [linux]
 
+  '@esbuild/linux-riscv64@0.27.7':
+    resolution: {integrity: sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
   '@esbuild/linux-s390x@0.25.12':
     resolution: {integrity: sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.27.7':
+    resolution: {integrity: sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==}
     engines: {node: '>=18'}
     cpu: [s390x]
     os: [linux]
@@ -2012,8 +2142,20 @@ packages:
     cpu: [x64]
     os: [linux]
 
+  '@esbuild/linux-x64@0.27.7':
+    resolution: {integrity: sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
   '@esbuild/netbsd-arm64@0.25.12':
     resolution: {integrity: sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-arm64@0.27.7':
+    resolution: {integrity: sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [netbsd]
@@ -2024,8 +2166,20 @@ packages:
     cpu: [x64]
     os: [netbsd]
 
+  '@esbuild/netbsd-x64@0.27.7':
+    resolution: {integrity: sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [netbsd]
+
   '@esbuild/openbsd-arm64@0.25.12':
     resolution: {integrity: sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-arm64@0.27.7':
+    resolution: {integrity: sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [openbsd]
@@ -2036,8 +2190,20 @@ packages:
     cpu: [x64]
     os: [openbsd]
 
+  '@esbuild/openbsd-x64@0.27.7':
+    resolution: {integrity: sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [openbsd]
+
   '@esbuild/openharmony-arm64@0.25.12':
     resolution: {integrity: sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@esbuild/openharmony-arm64@0.27.7':
+    resolution: {integrity: sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [openharmony]
@@ -2048,8 +2214,20 @@ packages:
     cpu: [x64]
     os: [sunos]
 
+  '@esbuild/sunos-x64@0.27.7':
+    resolution: {integrity: sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
+
   '@esbuild/win32-arm64@0.25.12':
     resolution: {integrity: sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-arm64@0.27.7':
+    resolution: {integrity: sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [win32]
@@ -2060,8 +2238,20 @@ packages:
     cpu: [ia32]
     os: [win32]
 
+  '@esbuild/win32-ia32@0.27.7':
+    resolution: {integrity: sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
   '@esbuild/win32-x64@0.25.12':
     resolution: {integrity: sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.27.7':
+    resolution: {integrity: sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [win32]
@@ -3766,6 +3956,144 @@ packages:
   '@rolldown/pluginutils@1.0.0-rc.7':
     resolution: {integrity: sha512-qujRfC8sFVInYSPPMLQByRh7zhwkGFS4+tyMQ83srV1qrxL4g8E2tyxVVyxd0+8QeBM1mIk9KbWxkegRr76XzA==}
 
+  '@rollup/rollup-android-arm-eabi@4.62.2':
+    resolution: {integrity: sha512-6o7ZLZK+BeenkZCFNDXqpbjw9bD6nuWonvS/lwQJp7NoVVxm6p3qE7qQ5jGuBjiFsgvqjD8mZAU5oWxTmbOeOg==}
+    cpu: [arm]
+    os: [android]
+
+  '@rollup/rollup-android-arm64@4.62.2':
+    resolution: {integrity: sha512-BaH7BllCACHoH1LguOU56UItGfUWjujlO65kS9LAodViaN4bwIKd7oeW/ZHJ/4ljr/7MIiENnNy3HJ0zXv8Zkw==}
+    cpu: [arm64]
+    os: [android]
+
+  '@rollup/rollup-darwin-arm64@4.62.2':
+    resolution: {integrity: sha512-v39RCCvj4He82I9sFmk+M1VZ0PLM9sfsLVikjfx2hYBNALhrrOR2D3JjQA6AhlaSOgcR+RzrKY7e1+bT6SUO/A==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@rollup/rollup-darwin-x64@4.62.2':
+    resolution: {integrity: sha512-yl0y2vq3S3lHeuXhEdss6TWfKW8vkujImO12tn4ZkG/4oghr09LvdYm2RElVjokTQiUvDUGXLGsYeLqUMCKpGA==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@rollup/rollup-freebsd-arm64@4.62.2':
+    resolution: {integrity: sha512-tT4pvt4qXD+vEoezupCWi+a1F0vvDiksiHc+PxRlYTOH1I6/X4id9jPxTP+Fg+545euaFT1jJVs4CEdHZAU1vw==}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@rollup/rollup-freebsd-x64@4.62.2':
+    resolution: {integrity: sha512-6nU5F2wCW+qvCBhTn1pdIU3bzsIoF7EUwsCDRxilWGprQR6yd508YnH9+OKFCwpfS8pjZqDUmnCAr7exax0XCg==}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@rollup/rollup-linux-arm-gnueabihf@4.62.2':
+    resolution: {integrity: sha512-n1GJHPOvpIfhi3TmrCeh6S6URt9BFCt0KQE3qvexyGCTAKpR4Lg+eWvNZEqu7epxwus/8ElT3hacYEucm49SZg==}
+    cpu: [arm]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-arm-musleabihf@4.62.2':
+    resolution: {integrity: sha512-JqgflS8wEB+UXV/vS1RpRbifGBeN4D5lz8D8oOFbFZw4vedvdOgCFAjfBmIMdW3yL10XpQQ0Ambepw6MXrhOnA==}
+    cpu: [arm]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-arm64-gnu@4.62.2':
+    resolution: {integrity: sha512-wnFJkogWvN4jm/hQRF2UBaeUmk20j5+DmHvoyWii2b8HJDyvz1MF2OU/6ynXt2KR63rbZLWkFpoytpdc/yBuSA==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-arm64-musl@4.62.2':
+    resolution: {integrity: sha512-HVu2bp0zhvJ8xHEV9+UUs7S90VadmBSY3LcIMvozbPo4AuMGDWlz3ymHLHZPX4hR67TKTt8Qp5PJ5RBg/i+RMQ==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-loong64-gnu@4.62.2':
+    resolution: {integrity: sha512-mQqqAV8QaoSgr9I2fKDLY2BAVvmKjWoGiu/cSYQonsLvtqwEn1E4QYfnCOcp5zoEqNhsDYin1s6jx/VJmrxlZg==}
+    cpu: [loong64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-loong64-musl@4.62.2':
+    resolution: {integrity: sha512-IxKLoxCQ2IWi6bT2akyDUBGsOImDKB+sPp4EsTmwFQ/fMwpCKm8uLSSgP/Kx/QYUgKis6SEZ5/Nlhup0DIA0PQ==}
+    cpu: [loong64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-ppc64-gnu@4.62.2':
+    resolution: {integrity: sha512-Mk5ha2RQSgyFfmYYLkBpPnUk8D8FriBxesO1u9O75X0mHgXL1UQcH5Itl2lurWL2tj0RxV9b9tJgipac0hRY9A==}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-ppc64-musl@4.62.2':
+    resolution: {integrity: sha512-CjvEnqJL/0/TQ3TXX3OPIJ/kmBellrWd4heXUmHeJlTnmwjKpSJzoehLaL6Xk0ZnMHBu9dZuFADNOrtjF4v+2w==}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-riscv64-gnu@4.62.2':
+    resolution: {integrity: sha512-1SiZbzwdkaDURsew/tSOrooKiYy7EQGT6m8ufavAi9NEyQb/6VuIxFXAL1fqa4iZe3g4NbNk4P7J32z2tw5Mgg==}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-riscv64-musl@4.62.2':
+    resolution: {integrity: sha512-nQts12zJ3NQRoE6uYljOH89v7szzLDvG2JD/vsX+vGXU8w/At1GowTZ5/7qeFQ8m7L55rpR8Okugnuo5bgjy2Q==}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-s390x-gnu@4.62.2':
+    resolution: {integrity: sha512-E9/ll019jhPIJgpzfZoIkBGhcz+kKNgVWYRY0zr9srBdPPFVpvOKW8VaJKUbeK+eZXyQF9ltME+Kk6affeaPgg==}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-x64-gnu@4.62.2':
+    resolution: {integrity: sha512-5BqxR/pshjey51iliyzTD5Xi3EN0aLmQ2lZ3lvefVV9c82BvrLo2/6OT55iifpWBufs6kdwWbuOKS841DrmK9A==}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-x64-musl@4.62.2':
+    resolution: {integrity: sha512-uNN83XxQrRAh/w0/pmAfibcwyb6YWt4gP+dpnQKPVJshAloQ785ii8CT8ZCIxkGg9opVsvAlGhFitSm6D1Jjpg==}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-openbsd-x64@4.62.2':
+    resolution: {integrity: sha512-srjEIxSH3LRnJN6THczDHWQplqEMFiAJrTab0msUryh9kwNpkICf3Ea6q6MN/2cZwRFUNx5w+h6Hpi4QuHS6Zg==}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@rollup/rollup-openharmony-arm64@4.62.2':
+    resolution: {integrity: sha512-8hOJnxgbyObnCm5AlRA3A931xX19xq80RjVTKgJOvEKWqJruP/Uf12IbAOaDjjEXYRewwHLfmF0YRIdK3OwKWA==}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@rollup/rollup-win32-arm64-msvc@4.62.2':
+    resolution: {integrity: sha512-mmF4AY1i0hG/bLWUctUq59gtmgaSIRa3cu/A3JFRp/sCNEme2bgDEiDS22P9FbnJB8NJNF4jPJiSP5RHQpUTDg==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@rollup/rollup-win32-ia32-msvc@4.62.2':
+    resolution: {integrity: sha512-DZgkknc6jhHrk46V25vbAM0zZkyP0nSDkJB8/dRkLTxv470dOmWDqGoEJl/9A0dFfS7yE3REOwNDxpHwSLSt0Q==}
+    cpu: [ia32]
+    os: [win32]
+
+  '@rollup/rollup-win32-x64-gnu@4.62.2':
+    resolution: {integrity: sha512-T6xr6ucWSFto+VGajA8YH26LdpHRuP4YLHEKAtCWvJDOlnmWcDZVCI2Jmjr+IFHDlt2zRaTAKE4tfjTaWLgJBg==}
+    cpu: [x64]
+    os: [win32]
+
+  '@rollup/rollup-win32-x64-msvc@4.62.2':
+    resolution: {integrity: sha512-BfzEnDJOt9T8M989/lA37EcJgat01wLRnoi5dQf3QzOH7jzpqTAzdDbVfRljVr5r+jzKqpbHeyOfAaXxAd0PAA==}
+    cpu: [x64]
+    os: [win32]
+
   '@rtsao/scc@1.1.0':
     resolution: {integrity: sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g==}
 
@@ -4404,6 +4732,9 @@ packages:
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
 
+  '@types/estree@1.0.9':
+    resolution: {integrity: sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==}
+
   '@types/fs-extra@9.0.13':
     resolution: {integrity: sha512-nEnwB++1u5lVDM2UI4c1+5R+FYaKfaAzS4OococimjVm3nQw3TuzH5UNsocrcTBbhnerblyHj4A49qXbIiZdpA==}
 
@@ -5040,6 +5371,11 @@ packages:
     resolution: {integrity: sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==}
     engines: {node: '>=8'}
 
+  bippy@0.6.0:
+    resolution: {integrity: sha512-6rdykmrQPOxyylsctFS3I1veDBWP03c2TbdD3sOowQ1w/3Y1FUQE52MhuNOyFvFQTNOxZOofRvdA1a0L/3Aagw==}
+    peerDependencies:
+      react: '>=17.0.1'
+
   bl@4.1.0:
     resolution: {integrity: sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==}
 
@@ -5106,6 +5442,12 @@ packages:
   bundle-name@4.1.0:
     resolution: {integrity: sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q==}
     engines: {node: '>=18'}
+
+  bundle-require@5.1.0:
+    resolution: {integrity: sha512-3WrrOuZiyaaZPWiEt4G3+IffISVC9HYlWueJEBWED4ZH4aIAC2PnkdnuRrR94M+w6yGWn4AglWtJtBI8YqvgoA==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+    peerDependencies:
+      esbuild: '>=0.18'
 
   bytes@3.1.2:
     resolution: {integrity: sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==}
@@ -5387,6 +5729,10 @@ packages:
   connect@3.7.0:
     resolution: {integrity: sha512-ZqRXc+tZukToSNmh5C2iWMSoV3X1YUcPbqEM4DkEG5tNQXrQUZCNVGGv3IuicnkMtPfGf3Xtp8WCXs295iQ1pQ==}
     engines: {node: '>= 0.10.0'}
+
+  consola@3.4.2:
+    resolution: {integrity: sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA==}
+    engines: {node: ^14.18.0 || >=16.10.0}
 
   content-disposition@1.0.1:
     resolution: {integrity: sha512-oIXISMynqSqm241k6kcQ5UwttDILMK4BiurCfGEREw6+X9jkkpEe5T9FZaApyLGGOnFuyMWZpdolTXMtvEJ08Q==}
@@ -6043,6 +6389,11 @@ packages:
     engines: {node: '>=18'}
     hasBin: true
 
+  esbuild@0.27.7:
+    resolution: {integrity: sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==}
+    engines: {node: '>=18'}
+    hasBin: true
+
   escalade@3.2.0:
     resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
     engines: {node: '>=6'}
@@ -6613,6 +6964,9 @@ packages:
   find-up@5.0.0:
     resolution: {integrity: sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==}
     engines: {node: '>=10'}
+
+  fix-dts-default-cjs-exports@1.0.1:
+    resolution: {integrity: sha512-pVIECanWFC61Hzl2+oOCtoJ3F17kglZC/6N94eRWycFgBH35hHx0Li604ZIzhseh97mf2p0cv7vVrOZGoqhlEg==}
 
   fix-path@5.0.0:
     resolution: {integrity: sha512-erEWGGCN7RIu1bXTCfNVpVBdm0f5mwcbeja+4QXiEZzIQukP401sbpu8gd3Ny1vS34YNeswyMO0TdT2tP5OlHA==}
@@ -7477,6 +7831,10 @@ packages:
   jose@6.2.2:
     resolution: {integrity: sha512-d7kPDd34KO/YnzaDOlikGpOurfF0ByC2sEV4cANCtdqLlTfBlw2p14O/5d/zv40gJPbIQxfES3nSx1/oYNyuZQ==}
 
+  joycon@3.1.1:
+    resolution: {integrity: sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==}
+    engines: {node: '>=10'}
+
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
@@ -7745,6 +8103,10 @@ packages:
 
   linkifyjs@4.3.3:
     resolution: {integrity: sha512-P8aEP5U/D1/IlTY2OeYsErdwh9bGuLE30NcXtKEjgdHcahveQoQwM2yZNsioQHsWFz0P7KKudisbrzCgR0sDHg==}
+
+  load-tsconfig@0.2.5:
+    resolution: {integrity: sha512-IXO6OCs9yg8tMKzfPZ1YmheJbZCiEsnBdcB03l0OcfK9prKnJb96siuHCr5Fl37/yo9DnKU+TLpxzTUspw9shg==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
   locate-path@5.0.0:
     resolution: {integrity: sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==}
@@ -9505,6 +9867,11 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
 
+  rollup@4.62.2:
+    resolution: {integrity: sha512-RFnrW4lhXA3s3eqHDZvN654g8OTjzRfqpIRJYczCGB6HzphckVAi/Qh4tbPUbRuDi7s1Llv8g/NspLkttY3gTA==}
+    engines: {node: '>=18.0.0', npm: '>=8.0.0'}
+    hasBin: true
+
   rope-sequence@1.3.4:
     resolution: {integrity: sha512-UT5EDe2cu2E/6O4igUr5PSFs23nvvukicWHx6GnOPlHAiiYbzNuCRQCuiUdHJQcqKalLKlrYJnjY0ySGsXNQXQ==}
 
@@ -10045,6 +10412,9 @@ packages:
   tinybench@2.9.0:
     resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
 
+  tinyexec@0.3.2:
+    resolution: {integrity: sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==}
+
   tinyexec@1.0.4:
     resolution: {integrity: sha512-u9r3uZC0bdpGOXtlxUIdwf9pkmvhqJdrVCH9fapQtgy/OeTTMZ1nqH7agtvEfmGui6e1XxjcdrlxvxJvc3sMqw==}
     engines: {node: '>=18'}
@@ -10096,6 +10466,10 @@ packages:
     resolution: {integrity: sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==}
     engines: {node: '>=20'}
 
+  tree-kill@1.2.2:
+    resolution: {integrity: sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==}
+    hasBin: true
+
   trim-lines@3.0.1:
     resolution: {integrity: sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==}
 
@@ -10130,6 +10504,25 @@ packages:
 
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
+
+  tsup@8.5.1:
+    resolution: {integrity: sha512-xtgkqwdhpKWr3tKPmCkvYmS9xnQK3m3XgxZHwSUjvfTjp7YfXe5tT3GgWi0F2N+ZSMsOeWeZFh7ZZFg5iPhing==}
+    engines: {node: '>=18'}
+    hasBin: true
+    peerDependencies:
+      '@microsoft/api-extractor': ^7.36.0
+      '@swc/core': ^1
+      postcss: ^8.4.12
+      typescript: '>=4.5.0'
+    peerDependenciesMeta:
+      '@microsoft/api-extractor':
+        optional: true
+      '@swc/core':
+        optional: true
+      postcss:
+        optional: true
+      typescript:
+        optional: true
 
   turbo@2.9.5:
     resolution: {integrity: sha512-JXNkRe6H6MjSlk5UQRTjyoKX5YN2zlc2632xcSlSFBao5yvbMWTpv9SNolOZlZmUlcDOHuszPLItbKrvcXnnZA==}
@@ -11664,79 +12057,157 @@ snapshots:
   '@esbuild/aix-ppc64@0.25.12':
     optional: true
 
+  '@esbuild/aix-ppc64@0.27.7':
+    optional: true
+
   '@esbuild/android-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/android-arm64@0.27.7':
     optional: true
 
   '@esbuild/android-arm@0.25.12':
     optional: true
 
+  '@esbuild/android-arm@0.27.7':
+    optional: true
+
   '@esbuild/android-x64@0.25.12':
+    optional: true
+
+  '@esbuild/android-x64@0.27.7':
     optional: true
 
   '@esbuild/darwin-arm64@0.25.12':
     optional: true
 
+  '@esbuild/darwin-arm64@0.27.7':
+    optional: true
+
   '@esbuild/darwin-x64@0.25.12':
+    optional: true
+
+  '@esbuild/darwin-x64@0.27.7':
     optional: true
 
   '@esbuild/freebsd-arm64@0.25.12':
     optional: true
 
+  '@esbuild/freebsd-arm64@0.27.7':
+    optional: true
+
   '@esbuild/freebsd-x64@0.25.12':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.27.7':
     optional: true
 
   '@esbuild/linux-arm64@0.25.12':
     optional: true
 
+  '@esbuild/linux-arm64@0.27.7':
+    optional: true
+
   '@esbuild/linux-arm@0.25.12':
+    optional: true
+
+  '@esbuild/linux-arm@0.27.7':
     optional: true
 
   '@esbuild/linux-ia32@0.25.12':
     optional: true
 
+  '@esbuild/linux-ia32@0.27.7':
+    optional: true
+
   '@esbuild/linux-loong64@0.25.12':
+    optional: true
+
+  '@esbuild/linux-loong64@0.27.7':
     optional: true
 
   '@esbuild/linux-mips64el@0.25.12':
     optional: true
 
+  '@esbuild/linux-mips64el@0.27.7':
+    optional: true
+
   '@esbuild/linux-ppc64@0.25.12':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.27.7':
     optional: true
 
   '@esbuild/linux-riscv64@0.25.12':
     optional: true
 
+  '@esbuild/linux-riscv64@0.27.7':
+    optional: true
+
   '@esbuild/linux-s390x@0.25.12':
+    optional: true
+
+  '@esbuild/linux-s390x@0.27.7':
     optional: true
 
   '@esbuild/linux-x64@0.25.12':
     optional: true
 
+  '@esbuild/linux-x64@0.27.7':
+    optional: true
+
   '@esbuild/netbsd-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.27.7':
     optional: true
 
   '@esbuild/netbsd-x64@0.25.12':
     optional: true
 
+  '@esbuild/netbsd-x64@0.27.7':
+    optional: true
+
   '@esbuild/openbsd-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.27.7':
     optional: true
 
   '@esbuild/openbsd-x64@0.25.12':
     optional: true
 
+  '@esbuild/openbsd-x64@0.27.7':
+    optional: true
+
   '@esbuild/openharmony-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/openharmony-arm64@0.27.7':
     optional: true
 
   '@esbuild/sunos-x64@0.25.12':
     optional: true
 
+  '@esbuild/sunos-x64@0.27.7':
+    optional: true
+
   '@esbuild/win32-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/win32-arm64@0.27.7':
     optional: true
 
   '@esbuild/win32-ia32@0.25.12':
     optional: true
 
+  '@esbuild/win32-ia32@0.27.7':
+    optional: true
+
   '@esbuild/win32-x64@0.25.12':
+    optional: true
+
+  '@esbuild/win32-x64@0.27.7':
     optional: true
 
   '@eslint-community/eslint-utils@4.9.1(eslint@9.39.4(jiti@1.21.7))':
@@ -13879,6 +14350,81 @@ snapshots:
 
   '@rolldown/pluginutils@1.0.0-rc.7': {}
 
+  '@rollup/rollup-android-arm-eabi@4.62.2':
+    optional: true
+
+  '@rollup/rollup-android-arm64@4.62.2':
+    optional: true
+
+  '@rollup/rollup-darwin-arm64@4.62.2':
+    optional: true
+
+  '@rollup/rollup-darwin-x64@4.62.2':
+    optional: true
+
+  '@rollup/rollup-freebsd-arm64@4.62.2':
+    optional: true
+
+  '@rollup/rollup-freebsd-x64@4.62.2':
+    optional: true
+
+  '@rollup/rollup-linux-arm-gnueabihf@4.62.2':
+    optional: true
+
+  '@rollup/rollup-linux-arm-musleabihf@4.62.2':
+    optional: true
+
+  '@rollup/rollup-linux-arm64-gnu@4.62.2':
+    optional: true
+
+  '@rollup/rollup-linux-arm64-musl@4.62.2':
+    optional: true
+
+  '@rollup/rollup-linux-loong64-gnu@4.62.2':
+    optional: true
+
+  '@rollup/rollup-linux-loong64-musl@4.62.2':
+    optional: true
+
+  '@rollup/rollup-linux-ppc64-gnu@4.62.2':
+    optional: true
+
+  '@rollup/rollup-linux-ppc64-musl@4.62.2':
+    optional: true
+
+  '@rollup/rollup-linux-riscv64-gnu@4.62.2':
+    optional: true
+
+  '@rollup/rollup-linux-riscv64-musl@4.62.2':
+    optional: true
+
+  '@rollup/rollup-linux-s390x-gnu@4.62.2':
+    optional: true
+
+  '@rollup/rollup-linux-x64-gnu@4.62.2':
+    optional: true
+
+  '@rollup/rollup-linux-x64-musl@4.62.2':
+    optional: true
+
+  '@rollup/rollup-openbsd-x64@4.62.2':
+    optional: true
+
+  '@rollup/rollup-openharmony-arm64@4.62.2':
+    optional: true
+
+  '@rollup/rollup-win32-arm64-msvc@4.62.2':
+    optional: true
+
+  '@rollup/rollup-win32-ia32-msvc@4.62.2':
+    optional: true
+
+  '@rollup/rollup-win32-x64-gnu@4.62.2':
+    optional: true
+
+  '@rollup/rollup-win32-x64-msvc@4.62.2':
+    optional: true
+
   '@rtsao/scc@1.1.0': {}
 
   '@sec-ant/readable-stream@0.4.1': {}
@@ -14061,12 +14607,12 @@ snapshots:
       postcss: 8.5.8
       tailwindcss: 4.2.2
 
-  '@tailwindcss/vite@4.2.2(vite@8.0.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@25.5.0)(jiti@2.6.1)(terser@5.47.1)(yaml@2.9.0))':
+  '@tailwindcss/vite@4.2.2(vite@8.0.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@25.5.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.47.1)(yaml@2.9.0))':
     dependencies:
       '@tailwindcss/node': 4.2.2
       '@tailwindcss/oxide': 4.2.2
       tailwindcss: 4.2.2
-      vite: 8.0.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@25.5.0)(jiti@2.6.1)(terser@5.47.1)(yaml@2.9.0)
+      vite: 8.0.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@25.5.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.47.1)(yaml@2.9.0)
 
   '@tanstack/query-core@5.96.2': {}
 
@@ -14562,6 +15108,8 @@ snapshots:
 
   '@types/estree@1.0.8': {}
 
+  '@types/estree@1.0.9': {}
+
   '@types/fs-extra@9.0.13':
     dependencies:
       '@types/node': 25.5.0
@@ -14884,7 +15432,7 @@ snapshots:
       d3-selection: 3.0.0
       d3-transition: 3.0.1(d3-selection@3.0.0)
 
-  '@vitejs/plugin-react@5.2.0(vite@8.0.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@25.5.0)(jiti@2.6.1)(terser@5.47.1)(yaml@2.9.0))':
+  '@vitejs/plugin-react@5.2.0(vite@8.0.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@25.5.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.47.1)(yaml@2.9.0))':
     dependencies:
       '@babel/core': 7.29.0
       '@babel/plugin-transform-react-jsx-self': 7.27.1(@babel/core@7.29.0)
@@ -14892,14 +15440,14 @@ snapshots:
       '@rolldown/pluginutils': 1.0.0-rc.3
       '@types/babel__core': 7.20.5
       react-refresh: 0.18.0
-      vite: 8.0.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@25.5.0)(jiti@2.6.1)(terser@5.47.1)(yaml@2.9.0)
+      vite: 8.0.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@25.5.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.47.1)(yaml@2.9.0)
     transitivePeerDependencies:
       - supports-color
 
-  '@vitejs/plugin-react@6.0.1(babel-plugin-react-compiler@1.0.0)(vite@8.0.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@25.5.0)(jiti@2.6.1)(terser@5.47.1)(yaml@2.9.0))':
+  '@vitejs/plugin-react@6.0.1(babel-plugin-react-compiler@1.0.0)(vite@8.0.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@25.5.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.47.1)(yaml@2.9.0))':
     dependencies:
       '@rolldown/pluginutils': 1.0.0-rc.7
-      vite: 8.0.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@25.5.0)(jiti@2.6.1)(terser@5.47.1)(yaml@2.9.0)
+      vite: 8.0.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@25.5.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.47.1)(yaml@2.9.0)
     optionalDependencies:
       babel-plugin-react-compiler: 1.0.0
 
@@ -14912,23 +15460,23 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.1.0
 
-  '@vitest/mocker@4.1.0(msw@2.12.14(@types/node@25.5.0)(typescript@5.9.3))(vite@8.0.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@25.5.0)(jiti@1.21.7)(terser@5.47.1)(yaml@2.9.0))':
+  '@vitest/mocker@4.1.0(msw@2.12.14(@types/node@25.5.0)(typescript@5.9.3))(vite@8.0.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@25.5.0)(esbuild@0.27.7)(jiti@1.21.7)(terser@5.47.1)(yaml@2.9.0))':
     dependencies:
       '@vitest/spy': 4.1.0
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
       msw: 2.12.14(@types/node@25.5.0)(typescript@5.9.3)
-      vite: 8.0.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@25.5.0)(jiti@1.21.7)(terser@5.47.1)(yaml@2.9.0)
+      vite: 8.0.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@25.5.0)(esbuild@0.27.7)(jiti@1.21.7)(terser@5.47.1)(yaml@2.9.0)
 
-  '@vitest/mocker@4.1.0(msw@2.12.14(@types/node@25.5.0)(typescript@5.9.3))(vite@8.0.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@25.5.0)(jiti@2.6.1)(terser@5.47.1)(yaml@2.9.0))':
+  '@vitest/mocker@4.1.0(msw@2.12.14(@types/node@25.5.0)(typescript@5.9.3))(vite@8.0.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@25.5.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.47.1)(yaml@2.9.0))':
     dependencies:
       '@vitest/spy': 4.1.0
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
       msw: 2.12.14(@types/node@25.5.0)(typescript@5.9.3)
-      vite: 8.0.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@25.5.0)(jiti@2.6.1)(terser@5.47.1)(yaml@2.9.0)
+      vite: 8.0.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@25.5.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.47.1)(yaml@2.9.0)
 
   '@vitest/pretty-format@4.1.0':
     dependencies:
@@ -15349,6 +15897,10 @@ snapshots:
 
   binary-extensions@2.3.0: {}
 
+  bippy@0.6.0(react@19.2.3):
+    dependencies:
+      react: 19.2.3
+
   bl@4.1.0:
     dependencies:
       buffer: 5.7.1
@@ -15455,6 +16007,11 @@ snapshots:
   bundle-name@4.1.0:
     dependencies:
       run-applescript: 7.1.0
+
+  bundle-require@5.1.0(esbuild@0.27.7):
+    dependencies:
+      esbuild: 0.27.7
+      load-tsconfig: 0.2.5
 
   bytes@3.1.2: {}
 
@@ -15744,6 +16301,8 @@ snapshots:
       utils-merge: 1.0.1
     transitivePeerDependencies:
       - supports-color
+
+  consola@3.4.2: {}
 
   content-disposition@1.0.1: {}
 
@@ -16306,7 +16865,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  electron-vite@5.0.0(vite@8.0.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@25.5.0)(jiti@2.6.1)(terser@5.47.1)(yaml@2.9.0)):
+  electron-vite@5.0.0(vite@8.0.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@25.5.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.47.1)(yaml@2.9.0)):
     dependencies:
       '@babel/core': 7.29.0
       '@babel/plugin-transform-arrow-functions': 7.27.1(@babel/core@7.29.0)
@@ -16314,7 +16873,7 @@ snapshots:
       esbuild: 0.25.12
       magic-string: 0.30.21
       picocolors: 1.1.1
-      vite: 8.0.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@25.5.0)(jiti@2.6.1)(terser@5.47.1)(yaml@2.9.0)
+      vite: 8.0.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@25.5.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.47.1)(yaml@2.9.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -16543,6 +17102,35 @@ snapshots:
       '@esbuild/win32-arm64': 0.25.12
       '@esbuild/win32-ia32': 0.25.12
       '@esbuild/win32-x64': 0.25.12
+
+  esbuild@0.27.7:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.27.7
+      '@esbuild/android-arm': 0.27.7
+      '@esbuild/android-arm64': 0.27.7
+      '@esbuild/android-x64': 0.27.7
+      '@esbuild/darwin-arm64': 0.27.7
+      '@esbuild/darwin-x64': 0.27.7
+      '@esbuild/freebsd-arm64': 0.27.7
+      '@esbuild/freebsd-x64': 0.27.7
+      '@esbuild/linux-arm': 0.27.7
+      '@esbuild/linux-arm64': 0.27.7
+      '@esbuild/linux-ia32': 0.27.7
+      '@esbuild/linux-loong64': 0.27.7
+      '@esbuild/linux-mips64el': 0.27.7
+      '@esbuild/linux-ppc64': 0.27.7
+      '@esbuild/linux-riscv64': 0.27.7
+      '@esbuild/linux-s390x': 0.27.7
+      '@esbuild/linux-x64': 0.27.7
+      '@esbuild/netbsd-arm64': 0.27.7
+      '@esbuild/netbsd-x64': 0.27.7
+      '@esbuild/openbsd-arm64': 0.27.7
+      '@esbuild/openbsd-x64': 0.27.7
+      '@esbuild/openharmony-arm64': 0.27.7
+      '@esbuild/sunos-x64': 0.27.7
+      '@esbuild/win32-arm64': 0.27.7
+      '@esbuild/win32-ia32': 0.27.7
+      '@esbuild/win32-x64': 0.27.7
 
   escalade@3.2.0: {}
 
@@ -17382,6 +17970,12 @@ snapshots:
       locate-path: 6.0.0
       path-exists: 4.0.0
 
+  fix-dts-default-cjs-exports@1.0.1:
+    dependencies:
+      magic-string: 0.30.21
+      mlly: 1.8.2
+      rollup: 4.62.2
+
   fix-path@5.0.0:
     dependencies:
       shell-path: 3.1.0
@@ -17537,7 +18131,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  fumadocs-mdx@12.0.3(fumadocs-core@15.8.5(@types/react@19.2.14)(lucide-react@1.0.1(react@19.2.3))(next@15.5.18(@opentelemetry/api@1.9.1)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react-router@7.14.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3))(next@15.5.18(@opentelemetry/api@1.9.1)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)(vite@8.0.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@25.5.0)(jiti@2.6.1)(terser@5.47.1)(yaml@2.9.0)):
+  fumadocs-mdx@12.0.3(fumadocs-core@15.8.5(@types/react@19.2.14)(lucide-react@1.0.1(react@19.2.3))(next@15.5.18(@opentelemetry/api@1.9.1)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react-router@7.14.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3))(next@15.5.18(@opentelemetry/api@1.9.1)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)(vite@8.0.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@25.5.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.47.1)(yaml@2.9.0)):
     dependencies:
       '@mdx-js/mdx': 3.1.1
       '@standard-schema/spec': 1.1.0
@@ -17559,7 +18153,7 @@ snapshots:
     optionalDependencies:
       next: 15.5.18(@opentelemetry/api@1.9.1)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       react: 19.2.3
-      vite: 8.0.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@25.5.0)(jiti@2.6.1)(terser@5.47.1)(yaml@2.9.0)
+      vite: 8.0.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@25.5.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.47.1)(yaml@2.9.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -18416,6 +19010,8 @@ snapshots:
 
   jose@6.2.2: {}
 
+  joycon@3.1.1: {}
+
   js-tokens@4.0.0: {}
 
   js-yaml@3.14.2:
@@ -18643,6 +19239,8 @@ snapshots:
       uc.micro: 2.1.0
 
   linkifyjs@4.3.3: {}
+
+  load-tsconfig@0.2.5: {}
 
   locate-path@5.0.0:
     dependencies:
@@ -20106,6 +20704,14 @@ snapshots:
       postcss: 8.5.8
       yaml: 2.9.0
 
+  postcss-load-config@6.0.1(jiti@2.6.1)(postcss@8.5.8)(yaml@2.9.0):
+    dependencies:
+      lilconfig: 3.1.3
+    optionalDependencies:
+      jiti: 2.6.1
+      postcss: 8.5.8
+      yaml: 2.9.0
+
   postcss-nested@6.2.0(postcss@8.5.8):
     dependencies:
       postcss: 8.5.8
@@ -21063,6 +21669,37 @@ snapshots:
       - '@emnapi/core'
       - '@emnapi/runtime'
 
+  rollup@4.62.2:
+    dependencies:
+      '@types/estree': 1.0.9
+    optionalDependencies:
+      '@rollup/rollup-android-arm-eabi': 4.62.2
+      '@rollup/rollup-android-arm64': 4.62.2
+      '@rollup/rollup-darwin-arm64': 4.62.2
+      '@rollup/rollup-darwin-x64': 4.62.2
+      '@rollup/rollup-freebsd-arm64': 4.62.2
+      '@rollup/rollup-freebsd-x64': 4.62.2
+      '@rollup/rollup-linux-arm-gnueabihf': 4.62.2
+      '@rollup/rollup-linux-arm-musleabihf': 4.62.2
+      '@rollup/rollup-linux-arm64-gnu': 4.62.2
+      '@rollup/rollup-linux-arm64-musl': 4.62.2
+      '@rollup/rollup-linux-loong64-gnu': 4.62.2
+      '@rollup/rollup-linux-loong64-musl': 4.62.2
+      '@rollup/rollup-linux-ppc64-gnu': 4.62.2
+      '@rollup/rollup-linux-ppc64-musl': 4.62.2
+      '@rollup/rollup-linux-riscv64-gnu': 4.62.2
+      '@rollup/rollup-linux-riscv64-musl': 4.62.2
+      '@rollup/rollup-linux-s390x-gnu': 4.62.2
+      '@rollup/rollup-linux-x64-gnu': 4.62.2
+      '@rollup/rollup-linux-x64-musl': 4.62.2
+      '@rollup/rollup-openbsd-x64': 4.62.2
+      '@rollup/rollup-openharmony-arm64': 4.62.2
+      '@rollup/rollup-win32-arm64-msvc': 4.62.2
+      '@rollup/rollup-win32-ia32-msvc': 4.62.2
+      '@rollup/rollup-win32-x64-gnu': 4.62.2
+      '@rollup/rollup-win32-x64-msvc': 4.62.2
+      fsevents: 2.3.3
+
   rope-sequence@1.3.4: {}
 
   roughjs@4.6.6:
@@ -21742,6 +22379,8 @@ snapshots:
 
   tinybench@2.9.0: {}
 
+  tinyexec@0.3.2: {}
+
   tinyexec@1.0.4: {}
 
   tinyglobby@0.2.15:
@@ -21783,6 +22422,8 @@ snapshots:
     dependencies:
       punycode: 2.3.1
 
+  tree-kill@1.2.2: {}
+
   trim-lines@3.0.1: {}
 
   trough@2.2.0: {}
@@ -21818,6 +22459,34 @@ snapshots:
       strip-bom: 3.0.0
 
   tslib@2.8.1: {}
+
+  tsup@8.5.1(jiti@2.6.1)(postcss@8.5.8)(typescript@5.9.3)(yaml@2.9.0):
+    dependencies:
+      bundle-require: 5.1.0(esbuild@0.27.7)
+      cac: 6.7.14
+      chokidar: 4.0.3
+      consola: 3.4.2
+      debug: 4.4.3
+      esbuild: 0.27.7
+      fix-dts-default-cjs-exports: 1.0.1
+      joycon: 3.1.1
+      picocolors: 1.1.1
+      postcss-load-config: 6.0.1(jiti@2.6.1)(postcss@8.5.8)(yaml@2.9.0)
+      resolve-from: 5.0.0
+      rollup: 4.62.2
+      source-map: 0.7.6
+      sucrase: 3.35.1
+      tinyexec: 0.3.2
+      tinyglobby: 0.2.15
+      tree-kill: 1.2.2
+    optionalDependencies:
+      postcss: 8.5.8
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - jiti
+      - supports-color
+      - tsx
+      - yaml
 
   turbo@2.9.5:
     optionalDependencies:
@@ -22146,7 +22815,7 @@ snapshots:
       d3-time: 3.1.0
       d3-timer: 3.0.1
 
-  vite@8.0.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@25.5.0)(jiti@1.21.7)(terser@5.47.1)(yaml@2.9.0):
+  vite@8.0.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@25.5.0)(esbuild@0.27.7)(jiti@1.21.7)(terser@5.47.1)(yaml@2.9.0):
     dependencies:
       lightningcss: 1.32.0
       picomatch: 4.0.3
@@ -22155,6 +22824,7 @@ snapshots:
       tinyglobby: 0.2.15
     optionalDependencies:
       '@types/node': 25.5.0
+      esbuild: 0.27.7
       fsevents: 2.3.3
       jiti: 1.21.7
       terser: 5.47.1
@@ -22163,7 +22833,7 @@ snapshots:
       - '@emnapi/core'
       - '@emnapi/runtime'
 
-  vite@8.0.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@25.5.0)(jiti@2.6.1)(terser@5.47.1)(yaml@2.9.0):
+  vite@8.0.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@25.5.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.47.1)(yaml@2.9.0):
     dependencies:
       lightningcss: 1.32.0
       picomatch: 4.0.3
@@ -22172,6 +22842,7 @@ snapshots:
       tinyglobby: 0.2.15
     optionalDependencies:
       '@types/node': 25.5.0
+      esbuild: 0.27.7
       fsevents: 2.3.3
       jiti: 2.6.1
       terser: 5.47.1
@@ -22180,10 +22851,10 @@ snapshots:
       - '@emnapi/core'
       - '@emnapi/runtime'
 
-  vitest@4.1.0(@opentelemetry/api@1.9.1)(@types/node@25.5.0)(jsdom@29.0.1(@noble/hashes@1.8.0))(msw@2.12.14(@types/node@25.5.0)(typescript@5.9.3))(vite@8.0.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@25.5.0)(jiti@1.21.7)(terser@5.47.1)(yaml@2.9.0)):
+  vitest@4.1.0(@opentelemetry/api@1.9.1)(@types/node@25.5.0)(jsdom@29.0.1(@noble/hashes@1.8.0))(msw@2.12.14(@types/node@25.5.0)(typescript@5.9.3))(vite@8.0.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@25.5.0)(esbuild@0.27.7)(jiti@1.21.7)(terser@5.47.1)(yaml@2.9.0)):
     dependencies:
       '@vitest/expect': 4.1.0
-      '@vitest/mocker': 4.1.0(msw@2.12.14(@types/node@25.5.0)(typescript@5.9.3))(vite@8.0.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@25.5.0)(jiti@1.21.7)(terser@5.47.1)(yaml@2.9.0))
+      '@vitest/mocker': 4.1.0(msw@2.12.14(@types/node@25.5.0)(typescript@5.9.3))(vite@8.0.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@25.5.0)(esbuild@0.27.7)(jiti@1.21.7)(terser@5.47.1)(yaml@2.9.0))
       '@vitest/pretty-format': 4.1.0
       '@vitest/runner': 4.1.0
       '@vitest/snapshot': 4.1.0
@@ -22200,7 +22871,7 @@ snapshots:
       tinyexec: 1.0.4
       tinyglobby: 0.2.15
       tinyrainbow: 3.1.0
-      vite: 8.0.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@25.5.0)(jiti@1.21.7)(terser@5.47.1)(yaml@2.9.0)
+      vite: 8.0.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@25.5.0)(esbuild@0.27.7)(jiti@1.21.7)(terser@5.47.1)(yaml@2.9.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@opentelemetry/api': 1.9.1
@@ -22209,10 +22880,10 @@ snapshots:
     transitivePeerDependencies:
       - msw
 
-  vitest@4.1.0(@opentelemetry/api@1.9.1)(@types/node@25.5.0)(jsdom@29.0.1(@noble/hashes@1.8.0))(msw@2.12.14(@types/node@25.5.0)(typescript@5.9.3))(vite@8.0.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@25.5.0)(jiti@2.6.1)(terser@5.47.1)(yaml@2.9.0)):
+  vitest@4.1.0(@opentelemetry/api@1.9.1)(@types/node@25.5.0)(jsdom@29.0.1(@noble/hashes@1.8.0))(msw@2.12.14(@types/node@25.5.0)(typescript@5.9.3))(vite@8.0.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@25.5.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.47.1)(yaml@2.9.0)):
     dependencies:
       '@vitest/expect': 4.1.0
-      '@vitest/mocker': 4.1.0(msw@2.12.14(@types/node@25.5.0)(typescript@5.9.3))(vite@8.0.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@25.5.0)(jiti@2.6.1)(terser@5.47.1)(yaml@2.9.0))
+      '@vitest/mocker': 4.1.0(msw@2.12.14(@types/node@25.5.0)(typescript@5.9.3))(vite@8.0.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@25.5.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.47.1)(yaml@2.9.0))
       '@vitest/pretty-format': 4.1.0
       '@vitest/runner': 4.1.0
       '@vitest/snapshot': 4.1.0
@@ -22229,7 +22900,7 @@ snapshots:
       tinyexec: 1.0.4
       tinyglobby: 0.2.15
       tinyrainbow: 3.1.0
-      vite: 8.0.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@25.5.0)(jiti@2.6.1)(terser@5.47.1)(yaml@2.9.0)
+      vite: 8.0.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@25.5.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.47.1)(yaml@2.9.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@opentelemetry/api': 1.9.1

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -169,6 +169,9 @@ importers:
       '@multica/core':
         specifier: workspace:*
         version: link:../../packages/core
+      '@multica/perf-recorder':
+        specifier: workspace:*
+        version: link:../../packages/perf-recorder
       '@multica/ui':
         specifier: workspace:*
         version: link:../../packages/ui
@@ -218,9 +221,6 @@ importers:
       '@multica/eslint-config':
         specifier: workspace:*
         version: link:../../packages/eslint-config
-      '@multica/perf-recorder':
-        specifier: workspace:*
-        version: link:../../packages/perf-recorder
       '@multica/tsconfig':
         specifier: workspace:*
         version: link:../../packages/tsconfig


### PR DESCRIPTION
## Dev-only frontend performance flight recorder — v1 (MUL-4466)

Implements the Howard-approved v1 RFC: a self-contained, **browser-only** performance recorder plus **dev-only** host loaders for Web and Desktop. Start recording → interact → stop → get a list of Incidents (slow React commits, slow resources, long tasks / dropped frames) with an exportable JSON report. **Production never loads, requests, or exposes it.**

### What's here

- **`packages/perf-recorder`** — self-contained module, no Multica domain/store imports; only `bippy` (pinned `0.6.0`) + browser APIs.
  - Hook install via bippy (`__REACT_DEVTOOLS_GLOBAL_HOOK__`), idempotent + HMR-safe, chains existing subscribers.
  - Collectors: interaction, Long Task, LoAF / rAF-gap frames, resource timing, React commit / `actualDuration`, DOM mutation **count only**.
  - Deterministic incident correlation + ranking; capability matrix with graceful degradation.
  - Plain-DOM **Shadow-root** panel (start/stop/clear/export, live status, filter chips, incident list + expand) — no React, so it never self-observes.
  - Versioned JSON export (schema §11).
  - `tsup` builds a self-contained **`dist/auto.global.js`** (bippy inlined, 20 KB) — the eventual `<script src>` extraction target, same shape as react-scan/react-grab.

- **Desktop hard gate** — two-stage bootstrap. `main.tsx` installs the hook, *then* dynamically imports `app-bootstrap.tsx` (which owns the `react-dom` import), so bippy sees every commit. Proven by an automated ordering test (not code review).

- **Web loader** — server-gated `beforeInteractive` `<Script>` in `layout.tsx`, identical pattern to react-grab; omitted from HTML entirely in Production.

- **Standard mode privacy** — no content snapshot by construction: resource URLs stripped of query/hash/credentials at collector entry; forbidden DOM getters never read; mutations counted only. Enforced by fixtures, not a redaction pass.

### Hard gates (from the assignment)

| Gate | Status |
| --- | --- |
| Desktop hook installed before React renderer registers, proven by automated test | ✅ `perf-recorder-loader.test.ts` (2/2) |
| Standard mode, no content snapshot; URL sanitized at entry | ✅ `privacy.test.ts`, `sanitize-url.test.ts` |
| Self-contained, browser-only, no Multica domain/store; Production absent | ✅ package imports only `bippy`; both loaders DCE'd from prod |
| In-repo now, extract later; Multica keeps only a dev-only host loader | ✅ ESM for in-repo + `dist/auto.global.js` for post-extraction `<script src>` |

### Verification

Machine-verified in this PR:
- `pnpm --filter @multica/perf-recorder typecheck` — clean
- `pnpm --filter @multica/perf-recorder test` — **23/23**
- `pnpm --filter @multica/perf-recorder build` — self-contained global bundle
- Desktop hook-order test — **2/2**

Runs in CI / needs live smoke (couldn't run headless here):
- Full Web (`next build`) + Desktop (`electron-vite build`) typecheck & build, and repo-wide lint.
- Live smoke: `pnpm dev:web` and `pnpm dev:desktop:staging` with `VITE_PERF_RECORDER=1` — record a slow interaction, confirm incidents + export, and (Web) copy the built global to `apps/web/public/__perf-recorder.global.js` (see package README).

### Out of scope (v1, per RFC §4.2)

Function-level sampling, Electron main/preload trace & IPC, synthetic full-snapshot mode, IndexedDB persistence, and the physical repo extraction (RFC §6.3 sequences that after in-repo verification).

### Known follow-ups

- Panel is functional but not yet pixel-matched to the MUL-4510 visual (Script/Render/Layout/Paint evidence bars, INP surfacing).
- Web asset-serving convenience (copy step / live smoke).
- React 17/18 cross-version commit fixtures + recorded overhead benchmark (RFC §13).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
