### PR TITLE
MUL-4520: always enable agent skill toggles

### DIFF
--- a/docs/feature-flags.md
+++ b/docs/feature-flags.md
@@ -191,17 +191,22 @@ agents_agent_builder:
   default: true
 settings_resource_labels:
   default: true
-agents_skill_toggles:
-  default: true
 ```
 
-Keep all three off for v0.3.44: it is a schema-only deployment for these
+Keep both off for v0.3.44: it is a schema-only deployment for these
 features. A later rollout may enable them only after it ships and verifies a
-rollback normalizer for builder agents, resource-label rows, and disabled
-skill rows. Do not rely on turning the flags off to make a database safe for
-an older binary; it prevents new writes but cannot remove states that already
-exist. Until that normalizer exists, rollbacks must target a version that
-understands these states or happen before any of the flags is enabled.
+rollback normalizer for builder agents and resource-label rows. Do not rely on
+turning the flags off to make a database safe for an older binary; it prevents
+new writes but cannot remove states that already exist. Until that normalizer
+exists, rollbacks must target a version that understands these states or happen
+before either flag is enabled.
+
+Agent skill toggles have completed this rollout and are now always available.
+Current clients render the switch without a release flag, and the backend no
+longer gates the write endpoint. `/api/config` still reports
+`agents_skill_toggles: true` so installed v0.4.0 desktop clients also expose the
+switch; this is a client-compatibility decision, not an operator-controlled
+flag.
 
 ### Security note: never rely on the frontend alone
 

--- a/packages/core/feature-flags/index.ts
+++ b/packages/core/feature-flags/index.ts
@@ -19,7 +19,6 @@ export { StaticProvider } from "./static-provider";
 export { ChainProvider } from "./chain-provider";
 export {
   AGENT_BUILDER_FLAG,
-  AGENT_SKILL_TOGGLES_FLAG,
   COMPOSIO_MCP_APPS_FLAG,
   RESOURCE_LABELS_FLAG,
 } from "./keys";

--- a/packages/core/feature-flags/keys.ts
+++ b/packages/core/feature-flags/keys.ts
@@ -1,4 +1,3 @@
 export const COMPOSIO_MCP_APPS_FLAG = "composio_mcp_apps";
 export const AGENT_BUILDER_FLAG = "agents_agent_builder";
 export const RESOURCE_LABELS_FLAG = "settings_resource_labels";
-export const AGENT_SKILL_TOGGLES_FLAG = "agents_skill_toggles";

--- a/packages/views/agents/components/tabs/skills-tab.test.tsx
+++ b/packages/views/agents/components/tabs/skills-tab.test.tsx
@@ -6,8 +6,6 @@ import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import type { Agent, AgentRuntime } from "@multica/core/types";
 import { I18nProvider } from "@multica/core/i18n/react";
-import { configStore } from "@multica/core/config";
-import { AGENT_SKILL_TOGGLES_FLAG } from "@multica/core/feature-flags";
 import enCommon from "../../../locales/en/common.json";
 import enAgents from "../../../locales/en/agents.json";
 
@@ -134,8 +132,7 @@ function renderSkillsTab(
 
 describe("SkillsTab", () => {
   beforeEach(() => {
-	vi.clearAllMocks();
-	configStore.getState().setFeatureFlags({ [AGENT_SKILL_TOGGLES_FLAG]: true });
+    vi.clearAllMocks();
     mockListSkills.mockResolvedValue([]);
     mockSetAgentSkillEnabled.mockResolvedValue(undefined);
     mockRemoveAgentSkill.mockResolvedValue(undefined);

--- a/packages/views/agents/components/tabs/skills-tab.tsx
+++ b/packages/views/agents/components/tabs/skills-tab.tsx
@@ -17,8 +17,6 @@ import type {
   RuntimeLocalSkillSummary,
 } from "@multica/core/types";
 import { api, ApiError } from "@multica/core/api";
-import { useFeatureEnabled } from "@multica/core/config";
-import { AGENT_SKILL_TOGGLES_FLAG } from "@multica/core/feature-flags";
 import { useWorkspaceId } from "@multica/core/hooks";
 import { runtimeCapabilitiesOptions } from "@multica/core/runtimes";
 import {
@@ -57,7 +55,6 @@ export function SkillsTab({
   const { t } = useT("agents");
   const qc = useQueryClient();
   const wsId = useWorkspaceId();
-  const skillTogglesEnabled = useFeatureEnabled(AGENT_SKILL_TOGGLES_FLAG, false);
   const { data: workspaceSkills = [] } = useQuery(skillListOptions(wsId));
   const runtimeId =
     runtime?.runtime_mode === "local" && runtime.status === "online"
@@ -170,7 +167,7 @@ export function SkillsTab({
                     <>
                       {busy ? (
                         <Loader2 className="h-4 w-4 animate-spin text-muted-foreground motion-reduce:animate-none" />
-                      ) : skillTogglesEnabled ? (
+                      ) : (
                         <Switch
                           checked={enabled}
                           onCheckedChange={(checked) => handleToggle(skill.id, checked)}
@@ -178,7 +175,7 @@ export function SkillsTab({
                             name: skill.name,
                           })}
                         />
-                      ) : null}
+                      )}
                       <Button
                         variant="ghost"
                         size="icon-sm"

--- a/server/internal/featureflags/keys.go
+++ b/server/internal/featureflags/keys.go
@@ -19,16 +19,16 @@ const (
 	// ResourceLabels controls the agent- and skill-scoped label namespaces.
 	// Issue labels remain available while this release flag is off.
 	ResourceLabels = "settings_resource_labels"
-	// AgentSkillToggles controls writes of agent_skill.enabled=false. Older
-	// servers do not filter that state when preparing an agent task.
-	AgentSkillToggles = "agents_skill_toggles"
+	// agentSkillTogglesCompat is no longer a release flag. Keep publishing the
+	// key as enabled so installed v0.4.0 desktop clients, which still gate the
+	// switch on this config decision, receive the permanently enabled behavior.
+	agentSkillTogglesCompat = "agents_skill_toggles"
 )
 
 var frontendPublicFlags = []string{
 	ComposioMCPApps,
 	AgentBuilder,
 	ResourceLabels,
-	AgentSkillToggles,
 }
 
 func ComposioMCPAppsEnabled(ctx context.Context, flags *featureflag.Service) bool {
@@ -43,14 +43,11 @@ func ResourceLabelsEnabled(ctx context.Context, flags *featureflag.Service) bool
 	return flags.IsEnabled(ctx, ResourceLabels, false)
 }
 
-func AgentSkillTogglesEnabled(ctx context.Context, flags *featureflag.Service) bool {
-	return flags.IsEnabled(ctx, AgentSkillToggles, false)
-}
-
 func EvaluateFrontendPublicFlags(ctx context.Context, flags *featureflag.Service) map[string]bool {
-	out := make(map[string]bool, len(frontendPublicFlags))
+	out := make(map[string]bool, len(frontendPublicFlags)+1)
 	for _, key := range frontendPublicFlags {
 		out[key] = flags.IsEnabled(ctx, key, false)
 	}
+	out[agentSkillTogglesCompat] = true
 	return out
 }

--- a/server/internal/featureflags/keys_test.go
+++ b/server/internal/featureflags/keys_test.go
@@ -13,7 +13,11 @@ func TestReleaseFlagsDefaultToOff(t *testing.T) {
 	if ResourceLabelsEnabled(ctx, nil) {
 		t.Fatal("resource labels release flag must default to off")
 	}
-	if AgentSkillTogglesEnabled(ctx, nil) {
-		t.Fatal("agent skill toggles release flag must default to off")
+}
+
+func TestAgentSkillTogglesCompatDecisionStaysEnabled(t *testing.T) {
+	flags := EvaluateFrontendPublicFlags(context.Background(), nil)
+	if !flags[agentSkillTogglesCompat] {
+		t.Fatal("agent skill toggles must stay enabled for installed v0.4.0 clients")
 	}
 }

--- a/server/internal/handler/config_test.go
+++ b/server/internal/handler/config_test.go
@@ -302,6 +302,9 @@ func TestGetConfigExposesFrontendFeatureFlags(t *testing.T) {
 	if cfg.FeatureFlags["composio_mcp_apps"] {
 		t.Fatalf("composio_mcp_apps: want false by default, got true")
 	}
+	if !cfg.FeatureFlags["agents_skill_toggles"] {
+		t.Fatalf("agents_skill_toggles: want true for installed v0.4.0 clients, got false")
+	}
 
 	withComposioMCPAppsFlag(t, h, true)
 	w = httptest.NewRecorder()

--- a/server/internal/handler/featureflag_test.go
+++ b/server/internal/handler/featureflag_test.go
@@ -19,10 +19,6 @@ func withResourceLabelsFlag(t *testing.T, h *Handler, enabled bool) {
 	withFeatureFlag(t, h, featureflags.ResourceLabels, enabled)
 }
 
-func withAgentSkillTogglesFlag(t *testing.T, h *Handler, enabled bool) {
-	withFeatureFlag(t, h, featureflags.AgentSkillToggles, enabled)
-}
-
 func withFeatureFlag(t *testing.T, h *Handler, key string, enabled bool) {
 	t.Helper()
 	provider := featureflag.NewStaticProvider()

--- a/server/internal/handler/skill.go
+++ b/server/internal/handler/skill.go
@@ -17,7 +17,6 @@ import (
 	"github.com/go-chi/chi/v5"
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgtype"
-	"github.com/multica-ai/multica/server/internal/featureflags"
 	skillpkg "github.com/multica-ai/multica/server/internal/skill"
 	db "github.com/multica-ai/multica/server/pkg/db/generated"
 	"github.com/multica-ai/multica/server/pkg/protocol"
@@ -2292,11 +2291,6 @@ func (h *Handler) SetAgentSkillEnabled(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusBadRequest, "enabled is required")
 		return
 	}
-	if !featureflags.AgentSkillTogglesEnabled(r.Context(), h.FeatureFlags) {
-		writeError(w, http.StatusNotFound, "agent skill toggles are not enabled")
-		return
-	}
-
 	rows, err := h.Queries.SetAgentSkillEnabled(r.Context(), db.SetAgentSkillEnabledParams{
 		AgentID: agent.ID,
 		SkillID: skillID,

--- a/server/internal/handler/skill_list_test.go
+++ b/server/internal/handler/skill_list_test.go
@@ -114,7 +114,6 @@ func TestListAgentSkills_OmitsContent(t *testing.T) {
 }
 
 func TestSetAgentSkillEnabledControlsExecutionWithoutRemovingAssignment(t *testing.T) {
-	withAgentSkillTogglesFlag(t, testHandler, true)
 	agentID := createHandlerTestAgent(t, "Handler Skill Toggle Test", nil)
 	skillID := insertHandlerTestSkill(t, "agent-skill-toggle", "# Toggle me")
 	if _, err := testPool.Exec(context.Background(),
@@ -159,27 +158,6 @@ func TestSetAgentSkillEnabledControlsExecutionWithoutRemovingAssignment(t *testi
 	active, err = testHandler.Queries.ListAgentSkills(context.Background(), parseUUID(agentID))
 	if err != nil || len(active) != 1 || active[0].Name == "" {
 		t.Fatalf("re-enabled skill missing from execution: skills=%+v err=%v", active, err)
-	}
-}
-
-func TestSetAgentSkillEnabledRequiresReleaseFlag(t *testing.T) {
-	withAgentSkillTogglesFlag(t, testHandler, false)
-	agentID := createHandlerTestAgent(t, "Blocked Skill Toggle", nil)
-	skillID := insertHandlerTestSkill(t, "blocked-agent-skill-toggle", "# Toggle me")
-	if _, err := testPool.Exec(context.Background(),
-		`INSERT INTO agent_skill (agent_id, skill_id) VALUES ($1, $2)`,
-		agentID, skillID,
-	); err != nil {
-		t.Fatalf("attach skill to agent: %v", err)
-	}
-	w := httptest.NewRecorder()
-	req := newRequest("PUT", "/api/agents/"+agentID+"/skills/"+skillID+"/enabled", map[string]any{"enabled": false})
-	rctx := chi.NewRouteContext()
-	rctx.URLParams.Add("id", agentID)
-	rctx.URLParams.Add("skillId", skillID)
-	testHandler.SetAgentSkillEnabled(w, req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, rctx)))
-	if w.Code != 404 {
-		t.Fatalf("SetAgentSkillEnabled without flag: expected 404, got %d: %s", w.Code, w.Body.String())
 	}
 }
 


### PR DESCRIPTION
## Summary

- always render per-agent workspace skill toggles and allow the enable/disable endpoint without a release flag
- keep reporting `agents_skill_toggles: true` from `/api/config` so installed v0.4.0 desktop clients also expose the switch
- remove the retired Go/TypeScript flag gates and update rollout documentation and tests

## Compatibility

- authentication and agent-management authorization remain unchanged
- disabled assignments remain attached but are excluded from task preparation
- this promotes v0.4.0 to the rollback floor; v0.3.43 does not understand disabled skill assignments

## Validation

- `pnpm --filter @multica/views exec vitest run agents/components/tabs/skills-tab.test.tsx` (5/5)
- `pnpm typecheck`
- `pnpm --filter @multica/views run lint` (0 errors; 16 warnings in untouched files)
- `go test ./internal/featureflags ./internal/handler -count=1`
- `go vet ./internal/featureflags ./internal/handler`
- `go build ./...`
- `git diff --check`
