### PR TITLE
docs: Cline 3.x NDJSON probe guide

### DIFF
--- a/docs/cline-ndjson-multica-adapter-plan.md
+++ b/docs/cline-ndjson-multica-adapter-plan.md
@@ -1,0 +1,247 @@
+# Cline 3.x NDJSON → Multica Adapter Plan
+
+**Status:** Agreed design (not yet implemented)  
+**Scope:** Adapt a Cline-based internal coding CLI to Multica via **`--json` NDJSON (形态 B / Cline 3.x)**  
+**Out of scope:** ACP (`--acp`), Codex-style JSON-RPC app-server, upstream contribution process  
+
+Related:
+
+- Probe / capture cookbook: [`docs/cline-ndjson-probe.md`](./cline-ndjson-probe.md)
+- Multica control plane: `server/internal/daemon/daemon.go` (`runTask`)
+- Backend contract: `server/pkg/agent/agent.go` (`Backend.Execute` → `Message` / `Result`)
+- Custom profiles: [`docs/custom-runtimes.md`](./custom-runtimes.md)
+
+---
+
+## 1. Goal
+
+Let Multica’s local daemon **spawn an internal CLI** that speaks **Cline 3.x NDJSON**, stream tool/text events to the UI, and finish tasks with correct status / usage / optional session resume — without implementing ACP.
+
+Multica still does **not** call the LLM. Business reads/writes stay on `multica` CLI inside the agent process (`MULTICA_TOKEN`, etc.).
+
+---
+
+## 2. Confirmed inputs
+
+| Fact | Decision impact |
+| --- | --- |
+| Wire format is **形态 B** (Cline 3.x envelopes) | Parse `agent_event` / `hook_event` / `run_result`, not Overview `say`/`ask` only |
+| Flags present: `--json`, `--auto-approve`, `-c`, `--id`, `-m`, `-t` | Build argv from this set |
+| **`-s` / system prompt not usable** | Do **not** pass `-s`; inject brief by **prepending** to the user prompt |
+| Prefer **simplest** reliable path | One `cline` Backend; internal binary name via Custom Runtime Profile |
+
+---
+
+## 3. Chosen approach
+
+### 3.1 Provider key: `cline`
+
+Add a first-class Multica provider / `protocol_family` named **`cline`**.
+
+| Host setup | How it runs |
+| --- | --- |
+| Binary on PATH as `cline` (or `MULTICA_CLINE_PATH`) | Built-in daemon probe registers runtime |
+| Internal binary, different name/path | **Custom Runtime Profile**: `protocol_family=cline`, `command_name=/path/to/internal-cli` |
+
+One NDJSON parser serves both. No second Backend for branding.
+
+### 3.2 Why not the alternatives
+
+| Alternative | Why rejected |
+| --- | --- |
+| Reuse `cursor` / `opencode` / `claude` family | Different event schema and flags |
+| Custom profile only (no new Backend) | No existing family understands Cline 3.x NDJSON |
+| ACP / JSON-RPC | Internal CLI has no ACP SDK; Multica does not need it for this path |
+
+---
+
+## 4. Control-plane flow
+
+```text
+Server  enqueue task → claim
+Daemon  prepare workdir / skills / AGENTS.md (best-effort)
+        BuildPrompt(task) → userPrompt
+        runtimeBrief → ExecOptions.SystemPrompt  (inline path)
+        agent.New("cline").Execute(...)
+Backend argv:
+          <cli> --json --auto-approve true
+                -c <workdir>
+                [-m <model>]
+                [--id <prior_session>]
+                "<SystemPrompt>\n\n<userPrompt>"   # NO -s
+        parse stdout NDJSON → Message stream
+        last run_result → Result
+Daemon  CompleteTask / FailTask (+ session_id, work_dir, usage)
+```
+
+Timeout: **Multica `runContext` / daemon timeout owns the wall clock.**  
+First implementation **does not pass CLI `-t`**, to avoid dual-timeout semantics. May revisit later if needed.
+
+---
+
+## 5. Launch contract
+
+### 5.1 Required / used flags
+
+```bash
+cli --json --auto-approve true \
+  -c <workdir> \
+  [-m <model>] \
+  [--id <session_id>] \
+  "<combined_prompt>"
+```
+
+| Flag | Source | Notes |
+| --- | --- | --- |
+| `--json` | Fixed | NDJSON on stdout |
+| `--auto-approve true` | Fixed | Unattended tool runs |
+| `-c` | `opts.Cwd` | Also set `cmd.Dir` |
+| `-m` | `opts.Model` | Agent model or daemon default |
+| `--id` | `opts.ResumeSessionID` | Only when non-empty |
+| prompt arg | `SystemPrompt + "\n\n" + prompt` when brief non-empty; else `prompt` | Replaces unusable `-s` |
+| `-t` | **Not used (v1)** | Daemon timeout only |
+| `-s` | **Never** | Confirmed unsupported / unusable |
+
+Also filter `CustomArgs` / `ExtraArgs` so users cannot override `--json`, `--auto-approve`, `-c`, `--id` in ways that break the protocol.
+
+### 5.2 Environment (Daemon already injects)
+
+Backend must use `buildEnv(cfg.Env)` so the child keeps:
+
+- `MULTICA_TOKEN`, `MULTICA_SERVER_URL`, `MULTICA_WORKSPACE_ID`
+- `MULTICA_AGENT_ID` / `MULTICA_TASK_ID` / …
+- `PATH` with `multica` binary first
+
+Do **not** call Multica HTTP from the Backend.
+
+---
+
+## 6. NDJSON → Multica mapping (形态 B)
+
+Authoritative shapes follow open-source Cline 3.x + [`docs/cline-ndjson-probe.md`](./cline-ndjson-probe.md).
+
+### 6.1 Top-level stdout types
+
+| Line `type` | Multica handling |
+| --- | --- |
+| `agent_event` | Nested `.event.type` drives text / usage / done |
+| `hook_event` | Lifecycle; `tool_call` / `tool_result` → tool messages |
+| `run_result` | **Authoritative final line** for `Result` |
+| other / invalid JSON | Skip + log; do not abort the scan |
+
+### 6.2 Event → `Message` / `Result`
+
+| Source | Multica |
+| --- | --- |
+| `agent_event` with text (`event.text` / content blocks) | `Message{Type: text, Content}` |
+| `hook_event` + `tool_call` | `Message{Type: tool-use, Tool, CallID, Input}` — if name missing, `Tool="tool"` |
+| `hook_event` + `tool_result` | `Message{Type: tool-result, CallID, Output}` |
+| `agent_event.event.type == "usage"` | Accumulate `TokenUsage` |
+| Session id if present on any event / `run_result` | Pin early via `Message{Type: status, SessionID}`; return on `Result` |
+| **Last** `run_result` with `finishReason == "completed"` | `Result{Status: "completed", Output: text, Usage, SessionID}` |
+| Last `run_result` with other `finishReason` (`aborted`, `error`, …) | `failed` (or `timeout` if stderr indicates timeout) |
+| No `run_result` | Fallback: last `done` + process exit code |
+| stderr JSON / text matching timeout | Prefer `Result.Status = "timeout"` |
+
+### 6.3 Parse policy (v1)
+
+1. Line-scan stdout; large scanner buffer (same order as other backends).  
+2. Prefer **last** `run_result` over mid-stream `done` for status and final `Output`.  
+3. Empty `Output` with `completed` is valid (work may be only `multica` side effects).  
+4. Tool name/path often **absent** in Cline 3.x hooks — do not fail; generic tool label is enough.  
+5. No fancy partial-dedup in v1; streaming text + correct terminal state is enough.  
+6. Resume: pass `--id` when `ResumeSessionID` set; if resume fails with empty SessionID, Daemon’s existing fresh-session retry applies.
+
+### 6.4 Illustrative stream (reference only)
+
+```jsonl
+{"type":"hook_event","event":{"type":"agent_start"}}
+{"type":"agent_event","event":{"type":"iteration_start","iteration":1}}
+{"type":"agent_event","event":{"type":"content_end","contentType":"text","text":"Working..."}}
+{"type":"hook_event","event":{"type":"tool_call"}}
+{"type":"hook_event","event":{"type":"tool_result"}}
+{"type":"agent_event","event":{"type":"usage","inputTokens":100,"outputTokens":20}}
+{"type":"agent_event","event":{"type":"done","reason":"completed","text":"Summary","iterations":1}}
+{"type":"run_result","finishReason":"completed","text":"Summary","durationMs":1234,"usage":{"inputTokens":100,"outputTokens":20}}
+```
+
+---
+
+## 7. Context injection without `-s`
+
+| Mechanism | Role |
+| --- | --- |
+| `providerNeedsInlineSystemPrompt("cline") == true` | Daemon sets `ExecOptions.SystemPrompt = runtimeBrief` |
+| Backend prepends brief to prompt arg | **Required** — primary path |
+| Write `AGENTS.md` via `InjectRuntimeConfig` | Best-effort secondary; not relied on |
+| Skills dir | v1: default `.agent_context/skills/` until a native Cline project skill path is confirmed |
+
+---
+
+## 8. Implementation checklist (when coding starts)
+
+### 8.1 Required for a working path
+
+| Area | Change |
+| --- | --- |
+| Backend | `server/pkg/agent/cline.go` + unit tests with NDJSON fixtures |
+| Factory | `SupportedTypes`, `New("cline")`, `launchHeaders` |
+| Lockstep test | `agent_supported_types_test.go` whitelist |
+| Daemon probe | `MULTICA_CLINE_PATH` / default binary `cline` in `config.go` |
+| Inline brief | `providerNeedsInlineSystemPrompt` includes `cline` |
+| Brief file | `runtimeConfigPath` → `AGENTS.md` for `cline` |
+| DB | migration widen `runtime_profile.protocol_family` CHECK with `cline` |
+| Display name | optional override e.g. `Cline` in `runtimeDisplayNameOverrides` |
+
+### 8.2 Deferred (do not block v1)
+
+- Fancy provider logo / onboarding marketing copy  
+- Dynamic `ListModels` discovery (empty catalog + manual `-m` is OK)  
+- CLI `-t` passthrough  
+- Native Cline skill directory layout (if later confirmed)  
+- Docs row in `CLI_AND_DAEMON.md` (nice-to-have)
+
+### 8.3 Explicit non-goals (v1)
+
+- ACP host  
+- File-level timeline from stream (use git outside if needed)  
+- Falling back to daemon PAT as agent token  
+- Opening PRs to upstream unless explicitly requested  
+
+---
+
+## 9. Verification plan
+
+1. **Unit:** fixture NDJSON (success, tool hooks, aborted, missing `run_result`, bad lines) → assert `Message` sequence and `Result`.  
+2. **Local daemon:** `MULTICA_CLINE_PATH=... multica daemon start --foreground` with a disposable workspace.  
+3. **Happy path:** assign a read-only / low-risk issue → claim → stream → complete.  
+4. **Resume (if session id appears):** second task with `--id` / `prior_session_id`.  
+5. **Custom profile:** same Backend with non-default `command_name`.  
+6. **Regression:** `go test ./server/pkg/agent/ …` and existing SupportedTypes lockstep tests.
+
+---
+
+## 10. Working branch policy (this effort)
+
+- Develop and push only on the **fork** remote (`origin` = personal fork).  
+- Do **not** open a PR against upstream unless the owner explicitly asks.  
+- Design docs for this adapter live under `docs/` on the feature branch.
+
+---
+
+## 11. Decision log
+
+| Date | Decision |
+| --- | --- |
+| 2026-07-14 | Use NDJSON, not ACP/JSON-RPC |
+| 2026-07-14 | Confirmed wire format = Cline 3.x 形态 B |
+| 2026-07-14 | Provider key `cline`; internal binary via Custom Runtime Profile |
+| 2026-07-14 | No `-s`; prepend system/brief into prompt |
+| 2026-07-14 | v1: no CLI `-t`; Multica daemon timeout only |
+| 2026-07-14 | Simplest implementation preferred over feature-complete UI |
+
+---
+
+## 12. Next step after this doc
+
+Implement §8.1 on the fork branch, using §6 mapping and §5 launch contract as the source of truth. Update this file’s **Status** line when implementation lands or decisions change.

--- a/docs/cline-ndjson-probe.md
+++ b/docs/cline-ndjson-probe.md
@@ -2,6 +2,8 @@
 
 Probe and capture notes for adapting a **Cline-based internal coding CLI** to Multica via **`--json` NDJSON** (not ACP / JSON-RPC).
 
+**Agreed adapter design (source of truth for implementation):** [`docs/cline-ndjson-multica-adapter-plan.md`](./cline-ndjson-multica-adapter-plan.md)
+
 **Confirmed shape:** Format **B** (Cline 3.x envelope), not the older Overview `say`/`ask` message form.
 
 Related Multica control plane:

--- a/docs/cline-ndjson-probe.md
+++ b/docs/cline-ndjson-probe.md
@@ -1,0 +1,367 @@
+# Cline 3.x NDJSON Probe Guide (形态 B)
+
+Probe and capture notes for adapting a **Cline-based internal coding CLI** to Multica via **`--json` NDJSON** (not ACP / JSON-RPC).
+
+**Confirmed shape:** Format **B** (Cline 3.x envelope), not the older Overview `say`/`ask` message form.
+
+Related Multica control plane:
+
+- Daemon spawns agent CLI: `server/internal/daemon/daemon.go` (`runTask`)
+- Unified backend contract: `server/pkg/agent/agent.go` (`Backend.Execute` → `Message` / `Result`)
+- NDJSON-style references in-tree: `server/pkg/agent/cursor.go`, `opencode.go`, `pi.go`
+
+Upstream references:
+
+- [Cline CLI Reference](https://docs.cline.bot/cli/cli-reference)
+- [Cline CLI Overview](https://docs.cline.bot/usage/cli-overview)
+- [SDK Events](https://docs.cline.bot/sdk/reference/events)
+- Official sample filter: `select(.type == "agent_event" and .event.type == "done")`
+
+---
+
+## 1. Why NDJSON (形态 B)
+
+| Path | Use for Multica? |
+| --- | --- |
+| `cline --json` → NDJSON on stdout | **Yes** — headless one-shot, matches Daemon spawn/drain model |
+| `cline --acp` → ACP JSON-RPC | No — requires bidirectional host; internal CLI has no ACP SDK |
+
+Multica does not call the LLM. The daemon:
+
+1. Prepares workdir / env (`MULTICA_TOKEN`, …)
+2. Spawns `your-cli --json … "<prompt>"`
+3. Parses stdout lines into `Message`
+4. Maps final `run_result` (or fallback) into `Result`
+
+---
+
+## 2. Launch recipe (open-source Cline 3.x)
+
+Replace `your-cli` with the internal binary name.
+
+```bash
+# Minimal headless NDJSON
+your-cli --json --auto-approve true \
+  -c /path/to/workdir \
+  -t 120 \
+  "Your prompt here"
+
+# Optional Multica-aligned knobs (if supported by the fork)
+your-cli --json --auto-approve true \
+  -c "$WORKDIR" \
+  -t 600 \
+  -s "$SYSTEM_OR_BRIEF" \
+  --data-dir "$PER_TASK_STATE_DIR" \
+  --id "$PRIOR_SESSION_ID" \
+  -m "$MODEL" \
+  -P "$PROVIDER" \
+  "$PROMPT"
+```
+
+Useful flags (open-source `cline --help`):
+
+| Flag | Role |
+| --- | --- |
+| `--json` | NDJSON instead of TUI |
+| `--auto-approve true\|false` | Tool auto-approval (often default `true`) |
+| `-c, --cwd` | Working directory (= Multica task workdir) |
+| `-t, --timeout` | Seconds (`0` = no timeout) |
+| `-s, --system` | System prompt override |
+| `--id` | Resume session |
+| `--data-dir` | Isolated local state (avoid global `~/.cline` crosstalk) |
+| `-m` / `-P` / `-k` | Model / provider / API key |
+| `--thinking` | Reasoning effort |
+| `--acp` | **Do not use** for Multica NDJSON path |
+
+---
+
+## 3. 形态 B schema (Cline 3.x)
+
+Each **stdout** line is one JSON object with a top-level `type`.
+
+### 3.1 Top-level types
+
+| `type` | Meaning | Multica use |
+| --- | --- | --- |
+| `hook_event` | Lifecycle: `agent_start`, `agent_end`, `tool_call`, `tool_result` | Tool timeline (name/path often **missing**) |
+| `agent_event` | Streaming content via nested `.event` | Text / usage / mid-run done |
+| `run_result` | **Authoritative final line** | `Result.Status`, `Output`, `Usage` |
+
+### 3.2 `agent_event.event.type` (SDK)
+
+| `event.type` | Meaning |
+| --- | --- |
+| `content_start` / `content_update` / `content_end` | Text / reasoning / tool content block |
+| `iteration_start` / `iteration_end` | Agent loop turn |
+| `usage` | Token / cost update |
+| `notice` | Status / recovery notice |
+| `done` | Agent finished this run |
+| `error` | Error |
+
+`done.reason` (SDK): `completed | max_iterations | aborted | mistake_limit | error`
+
+### 3.3 Illustrative stream (synthetic; verify on your binary)
+
+```jsonl
+{"type":"hook_event","event":{"type":"agent_start"},"ts":1710000000000}
+{"type":"agent_event","event":{"type":"iteration_start","iteration":1}}
+{"type":"agent_event","event":{"type":"content_start","contentType":"text"}}
+{"type":"agent_event","event":{"type":"content_end","contentType":"text","text":"I'll inspect the repo first."}}
+{"type":"hook_event","event":{"type":"tool_call"}}
+{"type":"hook_event","event":{"type":"tool_result"}}
+{"type":"agent_event","event":{"type":"usage","inputTokens":1200,"outputTokens":340,"totalCost":0.012}}
+{"type":"agent_event","event":{"type":"iteration_end","iteration":1}}
+{"type":"agent_event","event":{"type":"done","reason":"completed","text":"Done. Summary...","iterations":1}}
+{"type":"hook_event","event":{"type":"agent_end"}}
+{"type":"run_result","finishReason":"completed","text":"Done. Summary...","durationMs":12345,"iterations":2,"model":{"id":"xxx","provider":"yyy"},"usage":{"inputTokens":1200,"outputTokens":340,"totalCost":0.012}}
+```
+
+### 3.4 `run_result` fields to capture
+
+| Field | Notes |
+| --- | --- |
+| `finishReason` | `"completed"` = success; timeout often ends as `"aborted"` |
+| `text` | Final summary → Multica `Result.Output` |
+| `durationMs` | Wall time |
+| `iterations` | Loop count |
+| `model.id` / `model.provider` | Model identity |
+| `usage` / `aggregateUsage` | `inputTokens`, `outputTokens`, `totalCost`, cache fields if present |
+
+### 3.5 Timeout shape (observed on open-source ~3.0.37)
+
+- **stderr** (often one JSON line):
+
+  ```json
+  {"ts":"...","type":"error","message":"run timed out after 600s"}
+  ```
+
+- **stdout** last `run_result`: `finishReason` frequently `"aborted"` (not `"timeout"`); usage may be zeros.
+- Multica mapping: classify as `timeout` / `blocked` using stderr + `finishReason`, not stdout text alone.
+
+### 3.6 Known gaps
+
+- `hook_event` tool markers may **omit tool name and file paths** — do not rely on the stream for file-level diffs; use git if needed.
+- Exit code and `finishReason` can disagree. Prefer **last `run_result`** as truth; use exit code as fallback.
+- Tolerate malformed lines (skip + log).
+
+---
+
+## 4. Prompt examples for probing
+
+Use these as the CLI prompt argument. Prefer a clean temp directory and short timeouts.
+
+### 4.1 Minimal (schema only, no tools / no writes)
+
+```text
+Reply with exactly one line: pong.
+Do not create, edit, or delete any files.
+Do not run shell commands.
+```
+
+```bash
+your-cli --json --auto-approve true -c "$(pwd)" -t 60 \
+  "Reply with exactly one line: pong. Do not create, edit, or delete any files. Do not run shell commands." \
+  > /tmp/cli-probe/stdout.ndjson 2> /tmp/cli-probe/stderr.txt
+```
+
+**Expect:** `agent_event` text/done + final `run_result` with `finishReason=completed` and text containing `pong`.
+
+### 4.2 Single tool call
+
+```text
+Run exactly one shell command: echo hello-from-tool
+Then reply with the command output only.
+Do not modify any files.
+```
+
+**Expect:** `hook_event` `tool_call` / `tool_result` (possibly without tool name) + assistant text with `hello-from-tool`.
+
+### 4.3 Read-only listing
+
+```text
+List the files in the current directory using your tools if available.
+Summarize filenames in at most 5 bullet points.
+Do not modify any files.
+```
+
+### 4.4 Multica CLI smoke (only when `multica` is on PATH)
+
+```text
+You are a Multica coding agent.
+1) Run: multica --help
+2) Summarize available top-level commands in 5 bullets.
+3) Do not create issues or comments.
+4) Do not modify repository files.
+```
+
+### 4.5 Forced timeout (failure path)
+
+```text
+Work continuously without finishing. Keep exploring until stopped.
+Do not modify any files.
+```
+
+```bash
+your-cli --json --auto-approve true -c "$(pwd)" -t 3 \
+  "Work continuously without finishing. Keep exploring until stopped. Do not modify any files." \
+  > /tmp/cli-probe/timeout.out 2> /tmp/cli-probe/timeout.err
+```
+
+**Expect:** non-zero or aborted finish; stderr may carry `timed out`; stdout `run_result.finishReason` may be `aborted`.
+
+### 4.6 Multica-shaped assignment (integration later)
+
+```text
+You are running as a local coding agent for a Multica workspace.
+
+Your assigned issue ID is: ISSUE_UUID_HERE
+
+Start by running `multica issue get ISSUE_UUID_HERE --output json` to understand your task, then complete it.
+For comments, use `multica issue comment list ISSUE_UUID_HERE --recent 10 --output json`.
+When replying, write UTF-8 content to ./reply.md and post with:
+`multica issue comment add ISSUE_UUID_HERE --content-file ./reply.md`
+```
+
+(Replace `ISSUE_UUID_HERE`. Real Multica prompts are built in `server/internal/daemon/prompt.go`.)
+
+---
+
+## 5. Capture & analyze commands
+
+```bash
+INTERNAL_CLI=your-cli   # change me
+mkdir -p /tmp/cli-probe && cd /tmp/cli-probe
+
+$INTERNAL_CLI --help 2>&1 | tee /tmp/cli-probe/help.txt
+
+$INTERNAL_CLI --json --auto-approve true \
+  -c "$(pwd)" -t 120 \
+  "Reply with exactly one line: pong. Do not create, edit, or delete any files. Do not run shell commands." \
+  > /tmp/cli-probe/stdout.ndjson \
+  2> /tmp/cli-probe/stderr.txt
+echo "exit=$?"
+```
+
+### 5.1 Top-level `type` histogram
+
+```bash
+jq -r 'if type=="object" then (.type // "<no-type>") else "<non-object>" end' \
+  /tmp/cli-probe/stdout.ndjson | sort | uniq -c | sort -rn
+```
+
+Expected (形态 B):
+
+```text
+  N agent_event
+  M hook_event
+  1 run_result
+```
+
+### 5.2 Nested event types
+
+```bash
+jq -r 'select(.type=="agent_event") | .event.type // "<missing>"' \
+  /tmp/cli-probe/stdout.ndjson | sort | uniq -c | sort -rn
+
+jq -c 'select(.type=="agent_event" and .event.type=="done")' \
+  /tmp/cli-probe/stdout.ndjson
+
+jq -c 'select(.type=="run_result")' /tmp/cli-probe/stdout.ndjson | tail -n 1
+```
+
+### 5.3 Keys per type (for Backend field map)
+
+```bash
+jq -s '
+  group_by(.type)
+  | map({type: (.[0].type // "null"),
+         n: length,
+         keys: (map(keys) | add | unique)})
+' /tmp/cli-probe/stdout.ndjson
+```
+
+### 5.4 Extract final answer (official-sample style)
+
+```bash
+jq -r 'select(.type == "agent_event" and .event.type == "done") | .event.text' \
+  /tmp/cli-probe/stdout.ndjson | sed 's/\\n/\n/g'
+
+# Prefer authoritative run_result when present
+jq -r 'select(.type=="run_result") | .text' /tmp/cli-probe/stdout.ndjson | tail -n 1
+```
+
+---
+
+## 6. Field map checklist → Multica
+
+Fill after probing the internal binary.
+
+| Multica need | Internal NDJSON source (fill in) | Open-source default guess |
+| --- | --- | --- |
+| Streaming assistant text | | `agent_event.event.text` / content_* |
+| Tool start | | `hook_event` + `tool_call` |
+| Tool end | | `hook_event` + `tool_result` |
+| Tool name | | often **absent** → use `"tool"` |
+| Session id | | `run_result.sessionId` / CLI `--id` |
+| Success | | last `run_result.finishReason == "completed"` |
+| Failure / abort | | `aborted` / `error` / non-zero exit |
+| Final output | | `run_result.text` or `done.text` |
+| Usage | | `run_result.usage` / mid-stream `usage` events |
+| Model | | `run_result.model.id` |
+| Timeout | | stderr `timed out` + `finishReason=aborted` |
+
+### Suggested parse policy
+
+1. Line-scan stdout; skip invalid JSON with a log line.
+2. `agent_event` with text → `MessageText` (dedupe partials if needed).
+3. `hook_event` tool_* → `MessageToolUse` / `MessageToolResult`.
+4. First session id → `MessageStatus` + pin for resume.
+5. **Last** `run_result` decides `Result`.
+6. If no `run_result`: fall back to last `done` + process exit code.
+7. Never call Multica HTTP from the Backend; business I/O stays `multica` CLI inside the agent env.
+
+---
+
+## 7. Multica Backend mapping sketch
+
+| Internal event | `server/pkg/agent` |
+| --- | --- |
+| Text chunk | `Message{Type: text, Content}` |
+| tool_call | `Message{Type: tool-use, Tool, CallID, Input}` |
+| tool_result | `Message{Type: tool-result, CallID, Output}` |
+| session id | `Message{Type: status, SessionID}` |
+| `finishReason=completed` | `Result{Status: "completed", Output, Usage, SessionID}` |
+| aborted / error / timeout | `Result{Status: "failed"\|"timeout", Error, SessionID}` |
+
+Template files to copy when implementing:
+
+- Thin stream parser: `server/pkg/agent/cursor.go` or `opencode.go`
+- Factory whitelist: `server/pkg/agent/agent.go` (`SupportedTypes`, `New`)
+- PATH probe: `server/internal/daemon/config.go`
+- Skills / brief: `server/internal/daemon/execenv/`
+
+---
+
+## 8. Recommended probe order
+
+1. §4.1 minimal → confirm 形态 B histogram  
+2. §4.2 tool → confirm hook events  
+3. §4.5 timeout → confirm failure classification  
+4. §4.4 / §4.6 only with Multica credentials and a disposable workspace  
+
+After capture, attach (redacted):
+
+1. `type` histogram  
+2. One sample each of `agent_event`, `hook_event`, `run_result`  
+3. Relevant `--help` lines for json/cwd/timeout/id/system/data-dir  
+
+That is enough to implement a Multica `Backend` without guessing schema.
+
+---
+
+## 9. What not to do
+
+- Do not implement ACP solely for Multica if `--json` already works.  
+- Do not assume Overview docs `say`/`ask` shape on 3.x forks.  
+- Do not treat missing tool names as a hard failure.  
+- Do not fall back to the daemon PAT as `MULTICA_TOKEN` (task-scoped token only).  


### PR DESCRIPTION
## Summary
- Add `docs/cline-ndjson-probe.md` for adapting Cline-based internal CLIs to Multica via `--json` NDJSON (形态 B / Cline 3.x).
- Includes launch flags, sample event streams, probe prompts, jq capture recipes, and Multica `Message`/`Result` mapping notes.

## Test plan
- [ ] Open `docs/cline-ndjson-probe.md` and confirm links/sections render.
- [ ] Optional: run §4.1 prompt against an internal/open-source Cline binary and verify histogram matches 形态 B.