### PR TITLE
perf(issues): mount issue editors lazily, readonly-first

### DIFF
--- a/e2e/comments.spec.ts
+++ b/e2e/comments.spec.ts
@@ -29,6 +29,12 @@ test.describe("Comments", () => {
     // Wait for issue detail to load
     await expect(page.locator("text=Properties")).toBeVisible();
 
+    // The composer renders as a static shell until clicked (readonly-first);
+    // clicking it mounts and focuses the real ProseMirror editor.
+    const shell = page.getByTestId("comment-composer-shell");
+    await expect(shell).toBeVisible();
+    await shell.click();
+
     // Type a comment
     const commentText = "E2E comment " + Date.now();
     const editor = page
@@ -52,12 +58,12 @@ test.describe("Comments", () => {
 
     await expect(page.locator("text=Properties")).toBeVisible();
 
-    // Submit button should be disabled when input is empty
-    const editor = page
-      .locator('.ProseMirror[data-placeholder="Leave a comment..."], .ProseMirror:has([data-placeholder="Leave a comment..."])')
-      .first();
-    await expect(editor).toBeVisible();
-    const composer = editor.locator("xpath=ancestor::div[contains(@class, 'rounded-lg')][1]");
+    // Submit button should be disabled when input is empty. The composer is a
+    // static shell until clicked (readonly-first) — the disabled state must
+    // hold in shell form too, no activation needed.
+    const shell = page.getByTestId("comment-composer-shell");
+    await expect(shell).toBeVisible();
+    const composer = shell.locator("xpath=ancestor::div[contains(@class, 'rounded-lg')][1]");
     const submitBtn = composer.locator("button:has(svg.lucide-arrow-up)").last();
     await expect(submitBtn).toBeDisabled();
   });

--- a/packages/views/editor/content-editor.tsx
+++ b/packages/views/editor/content-editor.tsx
@@ -165,12 +165,28 @@ interface ContentEditorProps {
    * before the modal closes.
    */
   flushPendingOnUnmount?: boolean;
+  /**
+   * Called once when the Tiptap instance exists and its initial content is
+   * set (creation is deferred past first paint by `immediatelyRender: false`).
+   * Readonly-first hosts (issue description) use this as the signal to swap
+   * their static render for the live editor.
+   */
+  onReady?: () => void;
 }
 
 interface ContentEditorRef {
   getMarkdown: () => string;
   clearContent: () => void;
   focus: () => void;
+  /**
+   * Focus and place the caret at the document position under the given
+   * viewport coordinates. Used by readonly-first hosts so the click that
+   * summoned the editor lands the caret where the user clicked, matching
+   * the always-mounted editor's behavior. Falls back to focusing the end
+   * when no position resolves (click below the last line). Must be called
+   * while the editor element is laid out (not display: none).
+   */
+  focusAtCoords: (coords: { x: number; y: number }) => void;
   /** Drop focus from the editor — used by chat after send so the caret
    *  stops competing with the StatusPill / streaming reply for the user's
    *  attention. */
@@ -204,6 +220,7 @@ const ContentEditor = forwardRef<ContentEditorRef, ContentEditorProps>(
       slashCommandMode = "skill",
       attachments,
       flushPendingOnUnmount = false,
+      onReady,
     },
     ref,
   ) {
@@ -216,6 +233,7 @@ const ContentEditor = forwardRef<ContentEditorRef, ContentEditorProps>(
     const onUpdateRef = useRef(onUpdate);
     const onSubmitRef = useRef(onSubmit);
     const onBlurRef = useRef(onBlur);
+    const onReadyRef = useRef(onReady);
     const onUploadFileRef = useRef<
       ((file: File) => Promise<UploadResult | null>) | undefined
     >(undefined);
@@ -299,6 +317,7 @@ const ContentEditor = forwardRef<ContentEditorRef, ContentEditorProps>(
     onUpdateRef.current = onUpdate;
     onSubmitRef.current = onSubmit;
     onBlurRef.current = onBlur;
+    onReadyRef.current = onReady;
     onUploadFileRef.current = wrappedOnUploadFile;
     mentionContextItemsRef.current = mentionContextItems ?? [];
     flushPendingOnUnmountRef.current = flushPendingOnUnmount;
@@ -435,6 +454,16 @@ const ContentEditor = forwardRef<ContentEditorRef, ContentEditorProps>(
       },
     });
 
+    // Signal hosts that the deferred editor instance now exists. Fired from a
+    // passive effect (not `onCreate`) so it runs after the commit in which
+    // <EditorContent> attached the editor DOM — callers can measure/focus it.
+    const readyFiredRef = useRef(false);
+    useEffect(() => {
+      if (!editor || readyFiredRef.current) return;
+      readyFiredRef.current = true;
+      onReadyRef.current?.();
+    }, [editor]);
+
     // Cleanup on unmount. A pending debounced update is DROPPED by default,
     // not flushed — see the `flushPendingOnUnmount` prop doc for why. When the
     // owner opted in, emit the markdown cached at `onUpdate` time so a long
@@ -561,6 +590,16 @@ const ContentEditor = forwardRef<ContentEditorRef, ContentEditorProps>(
         if (editor) editor.commands.focus();
         // Editor not mounted yet — defer the focus to `onCreate`.
         else focusOnReadyRef.current = true;
+      },
+      focusAtCoords: (coords: { x: number; y: number }) => {
+        if (!editor) {
+          // Editor not mounted yet — degrade to the latched plain focus.
+          focusOnReadyRef.current = true;
+          return;
+        }
+        const pos = editor.view.posAtCoords({ left: coords.x, top: coords.y });
+        if (pos) editor.commands.focus(pos.pos);
+        else editor.commands.focus("end");
       },
       blur: () => {
         editor?.commands.blur();

--- a/packages/views/editor/content-editor.tsx
+++ b/packages/views/editor/content-editor.tsx
@@ -61,6 +61,7 @@ import { preprocessMarkdown } from "./utils/preprocess";
 import { repairEmptyListItems } from "./utils/repair-list-items";
 import { openLink, isMentionHref } from "./utils/link-handler";
 import { EditorBubbleMenu } from "./bubble-menu";
+import { posFromAnchor, type TextAnchor } from "./text-anchor";
 import { useLinkHover, LinkHoverCard } from "./link-hover-card";
 import { AttachmentDownloadProvider } from "./attachment-download-context";
 import "katex/dist/katex.min.css";
@@ -187,6 +188,15 @@ interface ContentEditorRef {
    * while the editor element is laid out (not display: none).
    */
   focusAtCoords: (coords: { x: number; y: number }) => void;
+  /**
+   * Focus and place the caret at the document position a text anchor
+   * resolves to. Preferred over `focusAtCoords` for readonly-first hosts:
+   * the anchor is a logical position ("block N, character M"), so it is
+   * immune to layout differences between the readonly render and the
+   * editor render — which is exactly where pixel coordinates drift on
+   * long documents.
+   */
+  focusAtAnchor: (anchor: TextAnchor) => void;
   /** Drop focus from the editor — used by chat after send so the caret
    *  stops competing with the StatusPill / streaming reply for the user's
    *  attention. */
@@ -600,6 +610,14 @@ const ContentEditor = forwardRef<ContentEditorRef, ContentEditorProps>(
         const pos = editor.view.posAtCoords({ left: coords.x, top: coords.y });
         if (pos) editor.commands.focus(pos.pos);
         else editor.commands.focus("end");
+      },
+      focusAtAnchor: (anchor: TextAnchor) => {
+        if (!editor) {
+          // Editor not mounted yet — degrade to the latched plain focus.
+          focusOnReadyRef.current = true;
+          return;
+        }
+        editor.commands.focus(posFromAnchor(editor.state.doc, anchor));
       },
       blur: () => {
         editor?.commands.blur();

--- a/packages/views/editor/extensions/code-block-view.tsx
+++ b/packages/views/editor/extensions/code-block-view.tsx
@@ -65,7 +65,7 @@ function CodeBlockView({ node }: NodeViewProps) {
     setView((v) => (v === "preview" ? "source" : "preview"));
 
   return (
-    <NodeViewWrapper className="code-block-wrapper group/code relative my-2">
+    <NodeViewWrapper className="code-block-wrapper group/code relative my-3">
       {isMermaid && debouncedChart.trim() && (
         <div
           contentEditable={false}
@@ -88,7 +88,7 @@ function CodeBlockView({ node }: NodeViewProps) {
       )}
       <div
         contentEditable={false}
-        className="code-block-header absolute top-0 right-0 z-10 flex items-center gap-1.5 px-2 py-1.5 opacity-0 transition-opacity group-hover/code:opacity-100"
+        className="code-block-header absolute top-0 right-0 z-10 flex items-center gap-1.5 px-2 py-1.5 opacity-0 transition-opacity group-hover/code:opacity-100 focus-within:opacity-100"
       >
         {language && (
           <span className="text-xs text-muted-foreground select-none">
@@ -123,6 +123,7 @@ function CodeBlockView({ node }: NodeViewProps) {
           onClick={handleCopy}
           className="flex h-6 w-6 items-center justify-center rounded text-muted-foreground hover:bg-muted hover:text-foreground transition-colors"
           title={t(($) => $.code_block.copy_code)}
+          aria-label={t(($) => $.code_block.copy_code)}
         >
           {copied ? (
             <Check className="h-3.5 w-3.5" />

--- a/packages/views/editor/html-block-preview.tsx
+++ b/packages/views/editor/html-block-preview.tsx
@@ -63,9 +63,9 @@ export function HtmlBlockPreview({ html, className }: HtmlBlockPreviewProps) {
     setView((v) => (v === "preview" ? "source" : "preview"));
 
   return (
-    <div className={cn("code-block-wrapper group/code relative my-2", className)}>
+    <div className={cn("code-block-wrapper group/code relative my-3", className)}>
       <div
-        className="absolute top-0 right-0 z-10 flex items-center gap-1.5 px-2 py-1.5 opacity-0 transition-opacity group-hover/code:opacity-100"
+        className="absolute top-0 right-0 z-10 flex items-center gap-1.5 px-2 py-1.5 opacity-0 transition-opacity group-hover/code:opacity-100 focus-within:opacity-100"
       >
         <span className="text-xs text-muted-foreground select-none">{HTML_LANGUAGE_LABEL}</span>
         <button

--- a/packages/views/editor/index.ts
+++ b/packages/views/editor/index.ts
@@ -11,6 +11,7 @@ export {
 export { ReadonlyContent } from "./readonly-content";
 export { useFileDropZone } from "./use-file-drop-zone";
 export { FileDropOverlay } from "./file-drop-overlay";
+export { useLazyEditor, type LazyEditorHandle } from "./use-lazy-editor";
 export { useDownloadAttachment } from "./use-download-attachment";
 export { AttachmentDownloadProvider } from "./attachment-download-context";
 export {

--- a/packages/views/editor/index.ts
+++ b/packages/views/editor/index.ts
@@ -11,7 +11,8 @@ export {
 export { ReadonlyContent } from "./readonly-content";
 export { useFileDropZone } from "./use-file-drop-zone";
 export { FileDropOverlay } from "./file-drop-overlay";
-export { useLazyEditor, type LazyEditorHandle } from "./use-lazy-editor";
+export { useLazyEditor, type LazyEditorHandle, type LazyFocusTarget } from "./use-lazy-editor";
+export { anchorFromPoint, type TextAnchor } from "./text-anchor";
 export { useDownloadAttachment } from "./use-download-attachment";
 export { AttachmentDownloadProvider } from "./attachment-download-context";
 export {

--- a/packages/views/editor/readonly-content.tsx
+++ b/packages/views/editor/readonly-content.tsx
@@ -202,7 +202,13 @@ function getTextContent(node: ReactNode): string {
   return "";
 }
 
-function ReadonlyCodeBlock({ children }: { children: ReactNode }) {
+function ReadonlyCodeBlock({
+  children,
+  language,
+}: {
+  children: ReactNode;
+  language?: string;
+}) {
   const { t } = useT("editor");
   const [copied, setCopied] = useState(false);
   const code = useMemo(
@@ -222,6 +228,13 @@ function ReadonlyCodeBlock({ children }: { children: ReactNode }) {
   return (
     <div className="code-block-wrapper group/code relative my-3">
       <div className="absolute top-0 right-0 z-10 flex items-center gap-1.5 px-2 py-1.5 opacity-0 transition-opacity group-hover/code:opacity-100 focus-within:opacity-100">
+        {/* Same hover chrome as the editable code block's header
+            (code-block-view.tsx): language label + copy. */}
+        {language && (
+          <span className="text-xs text-muted-foreground select-none">
+            {language}
+          </span>
+        )}
         <button
           type="button"
           onClick={handleCopy}
@@ -236,7 +249,10 @@ function ReadonlyCodeBlock({ children }: { children: ReactNode }) {
           )}
         </button>
       </div>
-      <pre className="!m-0 pr-12">{children}</pre>
+      {/* No extra right padding: `.rich-text-editor pre` outranks utility
+          padding classes anyway, and the editable NodeView uses the same
+          1rem — keeping them identical keeps line wrapping identical. */}
+      <pre className="!m-0">{children}</pre>
     </div>
   );
 }
@@ -409,13 +425,15 @@ function buildComponents(): Partial<Components> {
       // Match by exact class token: a substring `includes("language-html")`
       // would also fire on neighboring languages like `language-htmlbars`
       // and silently strip their <pre> wrapper.
+      let language: string | undefined;
       if (isValidElement(children)) {
         const childProps = children.props as { className?: string };
         if (PRE_UNWRAP_RE.test(childProps.className ?? "")) {
           return <>{children}</>;
         }
+        language = /language-(\w+)/.exec(childProps.className ?? "")?.[1];
       }
-      return <ReadonlyCodeBlock>{children}</ReadonlyCodeBlock>;
+      return <ReadonlyCodeBlock language={language}>{children}</ReadonlyCodeBlock>;
     },
   };
 }

--- a/packages/views/editor/styles/code.css
+++ b/packages/views/editor/styles/code.css
@@ -32,6 +32,11 @@ pre.rich-text-editor {
   border-radius: var(--radius);
   padding: 0.75rem 1rem;
   margin: 0.75rem 0;
+  /* Long lines wrap, matching the editable code block (its NodeViewContent
+     sets an inline pre-wrap). Without this, readonly blocks scroll while
+     editable blocks wrap and the same document changes shape between the
+     two renderers. overflow-x stays as a fallback for unbreakable tokens. */
+  white-space: pre-wrap;
   overflow-x: auto;
 }
 

--- a/packages/views/editor/styles/prose.css
+++ b/packages/views/editor/styles/prose.css
@@ -26,6 +26,16 @@
  *   box-decoration-break: clone on inline code.
  */
 
+/* Long unbreakable tokens (paths, URLs, identifiers) wrap mid-word instead
+   of overflowing. Tiptap injects the legacy alias `word-wrap: break-word`
+   on .ProseMirror, so the editable render already behaves this way; without
+   this rule the readonly render keeps such tokens on one line and the two
+   renders wrap the same text differently (machine-diffed: inline code and
+   code blocks gained 1-2 lines in the editor only). */
+.rich-text-editor {
+  overflow-wrap: break-word;
+}
+
 /* Headings — compact but with clear visual hierarchy */
 .rich-text-editor h1 {
   font-size: 1.375rem;
@@ -261,6 +271,11 @@
 }
 
 .rich-text-editor table {
+  /* `width`, not just `min-width`: Tiptap stamps an inline
+     `style="min-width: NNpx"` on its tables, which would override a
+     class-level min-width and let editor tables shrink to content while
+     readonly tables stretch full width. */
+  width: 100%;
   min-width: 100%;
   border-collapse: collapse;
 }
@@ -269,12 +284,22 @@
   display: none;
 }
 
-.rich-text-editor thead {
+/* Header-row background. Two structures produce header rows: readonly
+   (react-markdown) emits a real <thead>; Tiptap keeps the <th> row inside
+   <tbody>, so the tr:has(> th) arm covers the editable table. */
+.rich-text-editor thead,
+.rich-text-editor tr:has(> th) {
   background: color-mix(in srgb, var(--muted) 50%, transparent);
 }
 
 .rich-text-editor tbody tr {
   border-top: 1px solid var(--border);
+}
+
+/* Tiptap tables have no <thead>, so their header row is tbody's first row —
+   without this it draws a border-top right against the wrapper's own border. */
+.rich-text-editor table > tbody:first-child > tr:first-child {
+  border-top: 0;
 }
 
 .rich-text-editor tr:hover td {
@@ -287,6 +312,11 @@
   text-align: left;
   padding: 0.625rem 1rem;
   font-size: 0.875rem;
+  /* Match body-paragraph line-height. Tiptap wraps cell content in <p>
+     (which carries 1.625); the readonly render keeps bare text in the cell,
+     which otherwise inherits the host's text-sm line-height (~1.43) and
+     makes every readonly cell 2.5px shorter per line. */
+  line-height: 1.625;
 }
 
 .rich-text-editor th {

--- a/packages/views/editor/text-anchor.test.ts
+++ b/packages/views/editor/text-anchor.test.ts
@@ -1,0 +1,159 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it } from "vitest";
+import { Schema } from "@tiptap/pm/model";
+import { anchorFromPoint, posFromAnchor } from "./text-anchor";
+
+// Minimal schema — enough shape to exercise block walking, inline atoms
+// (mention-like zero-text nodes), leaf text blocks (code), and nested lists.
+const schema = new Schema({
+  nodes: {
+    doc: { content: "block+" },
+    paragraph: { group: "block", content: "inline*" },
+    codeBlock: { group: "block", content: "text*", marks: "" },
+    bulletList: { group: "block", content: "listItem+" },
+    listItem: { content: "paragraph+" },
+    mention: { group: "inline", inline: true, atom: true },
+    text: { group: "inline" },
+  },
+});
+
+const text = (s: string) => schema.text(s);
+const p = (...content: ReturnType<typeof text>[]) =>
+  schema.node("paragraph", null, content);
+
+describe("posFromAnchor", () => {
+  it("lands before the next word or after the previous one, per bias", () => {
+    const doc = schema.node("doc", null, [p(text("hello world"))]);
+    // 5 non-whitespace chars before the caret; the space is ambiguous.
+    expect(posFromAnchor(doc, { block: 0, offset: 5, bias: 1 })).toBe(7); // ▮world
+    expect(posFromAnchor(doc, { block: 0, offset: 5, bias: -1 })).toBe(6); // hello▮
+  });
+
+  it("maps offsets in later blocks past preceding node sizes", () => {
+    const doc = schema.node("doc", null, [p(text("abc")), p(text("defgh"))]);
+    // Mid-word there is no whitespace ambiguity: both biases agree.
+    expect(posFromAnchor(doc, { block: 1, offset: 2, bias: 1 })).toBe(8);
+    expect(posFromAnchor(doc, { block: 1, offset: 2, bias: -1 })).toBe(8);
+  });
+
+  it("skips zero-text inline atoms without counting them", () => {
+    const doc = schema.node("doc", null, [
+      p(text("hi "), schema.node("mention"), text(" yo")),
+    ]);
+    // Doc non-whitespace chars: h i y o. Offset 3 = caret before the "o".
+    expect(posFromAnchor(doc, { block: 0, offset: 3, bias: 1 })).toBe(7);
+    // Offset 4 = past the last one — lands right after it.
+    expect(posFromAnchor(doc, { block: 0, offset: 4, bias: 1 })).toBe(8);
+  });
+
+  it("clamps an overshooting offset to the block's content end", () => {
+    const doc = schema.node("doc", null, [p(text("abc")), p(text("xyz"))]);
+    expect(posFromAnchor(doc, { block: 0, offset: 99, bias: 1 })).toBe(4);
+  });
+
+  it("clamps an out-of-range block index to the document end", () => {
+    const doc = schema.node("doc", null, [p(text("abc"))]);
+    expect(posFromAnchor(doc, { block: 7, offset: 0, bias: 1 })).toBe(
+      doc.content.size,
+    );
+  });
+
+  it("distinguishes line end from next line start in code blocks", () => {
+    const doc = schema.node("doc", null, [
+      p(text("intro")),
+      schema.node("codeBlock", null, [text("line1\nline2")]),
+    ]);
+    // 5 non-whitespace chars ("line1") precede both carets; the \n between
+    // them is whitespace, so only the bias separates the two intents.
+    expect(posFromAnchor(doc, { block: 1, offset: 5, bias: -1 })).toBe(13); // line1▮
+    expect(posFromAnchor(doc, { block: 1, offset: 5, bias: 1 })).toBe(14); // ▮line2
+  });
+});
+
+describe("anchorFromPoint", () => {
+  // `as unknown` sidesteps lib.dom's full CaretPosition shape — the code
+  // under test only reads offsetNode/offset.
+  const docAny = document as unknown as {
+    caretPositionFromPoint?: (x: number, y: number) => {
+      offsetNode: Node;
+      offset: number;
+    } | null;
+  };
+  const originalCaret = docAny.caretPositionFromPoint;
+
+  afterEach(() => {
+    docAny.caretPositionFromPoint = originalCaret;
+    document.body.innerHTML = "";
+  });
+
+  function mount(html: string): HTMLElement {
+    const root = document.createElement("div");
+    root.innerHTML = html;
+    document.body.appendChild(root);
+    return root;
+  }
+
+  it("counts non-whitespace chars before the caret and biases toward text", () => {
+    const root = mount("<p>abc</p><p><strong>de</strong>fgh</p>");
+    const second = root.children[1] as HTMLElement;
+    // Caret one char into "fgh" — mid-word, next char is 'g'.
+    docAny.caretPositionFromPoint = () => ({
+      offsetNode: second.childNodes[1] as Node,
+      offset: 1,
+    });
+    expect(anchorFromPoint(0, 0, root)).toEqual({ block: 1, offset: 3, bias: 1 });
+  });
+
+  it("biases backward when the caret sits at the end of the text", () => {
+    const root = mount("<p>abc</p>");
+    const para = root.children[0] as HTMLElement;
+    docAny.caretPositionFromPoint = () => ({
+      offsetNode: para.firstChild as Node,
+      offset: 3,
+    });
+    expect(anchorFromPoint(0, 0, root)).toEqual({ block: 0, offset: 3, bias: -1 });
+  });
+
+  it("ignores inter-element whitespace artifacts (the list drift bug)", () => {
+    // react-markdown keeps the source newline between <li> elements as a
+    // text node; ProseMirror's doc has no such separator. Non-whitespace
+    // counting must make both sides agree.
+    const root = mount("<ul><li>URL: x</li>\n<li>Title: feat</li></ul>");
+    const li2 = root.querySelector("li:nth-child(2)") as HTMLElement;
+    docAny.caretPositionFromPoint = () => ({
+      offsetNode: li2.firstChild as Node,
+      offset: 7, // "Title: ▮feat"
+    });
+    const anchor = anchorFromPoint(0, 0, root);
+    // "URL:x" (5) + "Title:" (6) — the artifact \n and real spaces excluded.
+    expect(anchor).toEqual({ block: 0, offset: 11, bias: 1 });
+
+    // The same anchor resolves to right before "feat" in the PM doc.
+    const doc = schema.node("doc", null, [
+      schema.node("bulletList", null, [
+        schema.node("listItem", null, [p(text("URL: x"))]),
+        schema.node("listItem", null, [p(text("Title: feat"))]),
+      ]),
+    ]);
+    const pos = posFromAnchor(doc, anchor!);
+    expect(doc.textBetween(pos, pos + 4)).toBe("feat");
+  });
+
+  it("returns null when the caret lands outside the root", () => {
+    const root = mount("<p>abc</p>");
+    const stranger = document.createElement("p");
+    stranger.textContent = "elsewhere";
+    document.body.appendChild(stranger);
+    docAny.caretPositionFromPoint = () => ({
+      offsetNode: stranger.firstChild as Node,
+      offset: 0,
+    });
+    expect(anchorFromPoint(0, 0, root)).toBeNull();
+  });
+
+  it("returns null when no caret API is available", () => {
+    const root = mount("<p>abc</p>");
+    docAny.caretPositionFromPoint = undefined;
+    expect(anchorFromPoint(0, 0, root)).toBeNull();
+  });
+});

--- a/packages/views/editor/text-anchor.ts
+++ b/packages/views/editor/text-anchor.ts
@@ -1,0 +1,158 @@
+/**
+ * Text-anchor caret mapping between the readonly stand-in and the editor.
+ *
+ * The lazy-editor swap used to land the caret with raw pixel coordinates
+ * (`posAtCoords`), which assumes the readonly render and the Tiptap render
+ * are pixel-identical. They never are on long documents: per-block height
+ * differences (tables, code headers, mention cards) accumulate top-to-bottom,
+ * and NodeViews/images keep reflowing after `onReady` — so clicks landed
+ * lines away from the target. A text anchor sidesteps layout entirely:
+ * record WHICH character of WHICH top-level block was clicked, then resolve
+ * that logical position in the ProseMirror document.
+ *
+ * Offsets count NON-WHITESPACE characters only. The two renderers disagree
+ * about whitespace inside container blocks — react-markdown keeps the HTML
+ * source's inter-element newlines as text nodes ("URL: x\nTitle: y"), while
+ * ProseMirror's textContent concatenates with no separator ("URL: xTitle: y")
+ * — so raw character offsets drift one per list item / nested block. The
+ * non-whitespace character sequence, however, is identical on both sides.
+ * The whitespace ambiguity this creates at word boundaries ("end of this
+ * word" vs "start of the next") is resolved by `bias`, captured from what
+ * the user actually clicked next to.
+ *
+ * Known drift: content the two renderers textify differently (a mention's
+ * display name is text in the readonly render but an atom — zero text — in
+ * the doc) shifts offsets within that one block; resolution clamps to the
+ * block end, so worst case the caret lands earlier in the same block, never
+ * in another block.
+ */
+
+import type { Node as PMNode } from "@tiptap/pm/model";
+
+export interface TextAnchor {
+  /** Index of the top-level block (readonly root child ↔ doc child). */
+  block: number;
+  /** Count of non-whitespace characters before the caret within the block. */
+  offset: number;
+  /**
+   * Which neighbor the caret attaches to when whitespace separates the
+   * offset-th non-whitespace character from the next one: 1 = just before
+   * the next non-whitespace character (user clicked a line/word start),
+   * -1 = just after the previous one (user clicked a line/word end).
+   */
+  bias: 1 | -1;
+}
+
+const NON_WS = /\S/;
+
+function countNonWs(s: string): number {
+  let n = 0;
+  for (let i = 0; i < s.length; i++) if (NON_WS.test(s.charAt(i))) n++;
+  return n;
+}
+
+/**
+ * Resolve a click point inside the readonly render to a text anchor.
+ * `root` is the markdown container whose element children correspond 1:1 to
+ * the document's top-level blocks. Returns null when the point yields no
+ * caret position (unsupported API, click on empty margin below content) —
+ * callers fall back to coordinate focus.
+ */
+export function anchorFromPoint(
+  x: number,
+  y: number,
+  root: HTMLElement,
+): TextAnchor | null {
+  const doc = root.ownerDocument;
+  let node: Node | null = null;
+  let nodeOffset = 0;
+  // Standard API (Chromium/Firefox), then the WebKit legacy one.
+  if (typeof doc.caretPositionFromPoint === "function") {
+    const p = doc.caretPositionFromPoint(x, y);
+    if (p) {
+      node = p.offsetNode;
+      nodeOffset = p.offset;
+    }
+  } else if (typeof doc.caretRangeFromPoint === "function") {
+    const r = doc.caretRangeFromPoint(x, y);
+    if (r) {
+      node = r.startContainer;
+      nodeOffset = r.startOffset;
+    }
+  }
+  if (!node || !root.contains(node) || node === root) return null;
+
+  // Climb to the top-level block (the direct child of `root`).
+  let blockEl: Node = node;
+  while (blockEl.parentNode && blockEl.parentNode !== root) {
+    blockEl = blockEl.parentNode;
+  }
+  if (blockEl.parentNode !== root || blockEl.nodeType !== Node.ELEMENT_NODE) {
+    return null;
+  }
+  const block = Array.prototype.indexOf.call(root.children, blockEl);
+  if (block < 0) return null;
+
+  // Text before the caret within the block. Range.toString() handles both
+  // text-node carets and element carets (offset = child index), and yields
+  // a prefix of the block's textContent — which lets us peek at the char
+  // right after the caret for the bias.
+  const range = doc.createRange();
+  try {
+    range.setStart(blockEl, 0);
+    range.setEnd(node, nodeOffset);
+  } catch {
+    return { block, offset: 0, bias: 1 };
+  }
+  const before = range.toString();
+  const nextChar = (blockEl.textContent ?? "").charAt(before.length);
+  return {
+    block,
+    offset: countNonWs(before),
+    bias: NON_WS.test(nextChar) ? 1 : -1,
+  };
+}
+
+/**
+ * Resolve a text anchor to a ProseMirror position. Out-of-range values clamp
+ * (block → last block, offset → block end) so a stale or drifted anchor still
+ * lands inside the intended block instead of throwing.
+ */
+export function posFromAnchor(doc: PMNode, anchor: TextAnchor): number {
+  if (doc.childCount === 0) return 0;
+  if (anchor.block >= doc.childCount) return doc.content.size;
+  const blockIndex = Math.max(0, anchor.block);
+
+  let blockStart = 0;
+  for (let i = 0; i < blockIndex; i++) blockStart += doc.child(i).nodeSize;
+  const block = doc.child(blockIndex);
+  const contentStart = blockStart + 1;
+
+  const wanted = Math.max(0, anchor.offset);
+  let seen = 0;
+  // Caret position right after the `wanted`-th non-whitespace character
+  // (block content start while none have been passed yet).
+  let afterPrev = contentStart;
+  let resolved: number | null = null;
+  block.descendants((child, pos) => {
+    if (resolved !== null) return false;
+    if (!child.isText) return true;
+    const text = child.text ?? "";
+    for (let i = 0; i < text.length; i++) {
+      if (!NON_WS.test(text.charAt(i))) continue;
+      if (seen === wanted) {
+        // This is the first non-whitespace character AFTER the caret.
+        resolved = anchor.bias === 1 ? contentStart + pos + i : afterPrev;
+        return false;
+      }
+      seen++;
+      afterPrev = contentStart + pos + i + 1;
+    }
+    return true;
+  });
+  if (resolved !== null) return resolved;
+  // Caret past the last non-whitespace character: exact end lands after it;
+  // an overshoot (renderer textified something the doc doesn't, e.g. a
+  // mention label) clamps to the block's content end.
+  return seen === wanted ? afterPrev : blockStart + block.nodeSize - 1;
+}

--- a/packages/views/editor/title-editor.tsx
+++ b/packages/views/editor/title-editor.tsx
@@ -23,11 +23,24 @@ interface TitleEditorProps {
   onSubmit?: () => void;
   onBlur?: (value: string) => void;
   onChange?: (value: string) => void;
+  /**
+   * Called once when the Tiptap instance exists and its DOM is attached
+   * (creation is deferred past first paint by `immediatelyRender: false`).
+   * Same contract as ContentEditorProps.onReady.
+   */
+  onReady?: () => void;
 }
 
 interface TitleEditorRef {
   getText: () => string;
   focus: () => void;
+  /**
+   * Focus and place the caret at the document position under the given
+   * viewport coordinates — same contract as ContentEditorRef.focusAtCoords,
+   * so readonly-first hosts (useLazyEditor) can treat both editors alike.
+   * Must be called while the editor element is laid out (not display: none).
+   */
+  focusAtCoords: (coords: { x: number; y: number }) => void;
 }
 
 // ---------------------------------------------------------------------------
@@ -78,6 +91,7 @@ const TitleEditor = forwardRef<TitleEditorRef, TitleEditorProps>(
       onSubmit,
       onBlur,
       onChange,
+      onReady,
     },
     ref,
   ) {
@@ -85,10 +99,12 @@ const TitleEditor = forwardRef<TitleEditorRef, TitleEditorProps>(
     const onSubmitRef = useRef(onSubmit);
     const onBlurRef = useRef(onBlur);
     const onChangeRef = useRef(onChange);
+    const onReadyRef = useRef(onReady);
 
     onSubmitRef.current = onSubmit;
     onBlurRef.current = onBlur;
     onChangeRef.current = onChange;
+    onReadyRef.current = onReady;
 
     const editor = useEditor({
       immediatelyRender: false,
@@ -120,6 +136,16 @@ const TitleEditor = forwardRef<TitleEditorRef, TitleEditorProps>(
         onBlurRef.current?.(ed.getText());
       },
     });
+
+    // Signal readonly-first hosts that the deferred editor now exists. Fired
+    // from a passive effect so it runs after the commit that attached the
+    // editor DOM — same pattern as ContentEditor.
+    const readyFiredRef = useRef(false);
+    useEffect(() => {
+      if (!editor || readyFiredRef.current) return;
+      readyFiredRef.current = true;
+      onReadyRef.current?.();
+    }, [editor]);
 
     // Auto-focus after mount — delay to wait for Dialog open animation
     useEffect(() => {
@@ -174,6 +200,12 @@ const TitleEditor = forwardRef<TitleEditorRef, TitleEditorProps>(
       getText: () => editor?.getText() ?? "",
       focus: () => {
         editor?.commands.focus("end");
+      },
+      focusAtCoords: (coords: { x: number; y: number }) => {
+        if (!editor) return;
+        const pos = editor.view.posAtCoords({ left: coords.x, top: coords.y });
+        if (pos) editor.commands.focus(pos.pos);
+        else editor.commands.focus("end");
       },
     }));
 

--- a/packages/views/editor/use-lazy-editor.test.ts
+++ b/packages/views/editor/use-lazy-editor.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect, vi } from "vitest";
+import { act, renderHook } from "@testing-library/react";
+import { useLazyEditor, type LazyEditorHandle } from "./use-lazy-editor";
+
+function makeHandle() {
+  return { focus: vi.fn(), focusAtCoords: vi.fn(), uploadFile: vi.fn() };
+}
+
+describe("useLazyEditor", () => {
+  it("starts static, activates on intent, focuses at the click coords once ready", () => {
+    const handle = makeHandle();
+    const editorRef = { current: handle as LazyEditorHandle };
+    const { result } = renderHook(() => useLazyEditor({ editorRef }));
+
+    expect(result.current.active).toBe(false);
+    expect(result.current.ready).toBe(false);
+
+    act(() => result.current.activate({ x: 10, y: 20 }));
+    expect(result.current.active).toBe(true);
+    expect(result.current.ready).toBe(false);
+
+    act(() => result.current.onReady());
+    expect(result.current.ready).toBe(true);
+    expect(handle.focusAtCoords).toHaveBeenCalledWith({ x: 10, y: 20 });
+  });
+
+  it("mounts immediately when initialActive is set (unsent draft)", () => {
+    const editorRef = { current: makeHandle() as LazyEditorHandle };
+    const { result } = renderHook(() => useLazyEditor({ editorRef, initialActive: true }));
+
+    expect(result.current.active).toBe(true);
+  });
+
+  it("queues uploads against the stand-in and flushes them on ready", () => {
+    const handle = makeHandle();
+    const editorRef = { current: handle as LazyEditorHandle };
+    const { result } = renderHook(() => useLazyEditor({ editorRef }));
+
+    const file = new File(["x"], "x.txt", { type: "text/plain" });
+    act(() => result.current.uploadOrQueue([file]));
+    // Queuing summons the editor but must not upload into a dead handle.
+    expect(result.current.active).toBe(true);
+    expect(handle.uploadFile).not.toHaveBeenCalled();
+
+    act(() => result.current.onReady());
+    expect(handle.uploadFile).toHaveBeenCalledWith(file);
+  });
+
+  it("resets to the stand-in during the render that changes resetKey", () => {
+    const editorRef = { current: makeHandle() as LazyEditorHandle };
+    const { result, rerender } = renderHook(
+      ({ key }: { key: string }) => useLazyEditor({ editorRef, resetKey: key }),
+      { initialProps: { key: "issue-1" } },
+    );
+
+    act(() => result.current.activate());
+    act(() => result.current.onReady());
+    expect(result.current.ready).toBe(true);
+
+    // Same-render reset: after the rerender that carries the new key, the
+    // hook must already report the stand-in state — an effect-based reset
+    // would let a keyed editor mount once for the new subject first.
+    rerender({ key: "issue-2" });
+    expect(result.current.active).toBe(false);
+    expect(result.current.ready).toBe(false);
+  });
+});

--- a/packages/views/editor/use-lazy-editor.ts
+++ b/packages/views/editor/use-lazy-editor.ts
@@ -1,0 +1,117 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState, type RefObject } from "react";
+
+/**
+ * Minimal imperative surface useLazyEditor needs from the wrapped editor.
+ * ContentEditorRef and TitleEditorRef both satisfy it structurally.
+ */
+export interface LazyEditorHandle {
+  focus: () => void;
+  focusAtCoords?: (coords: { x: number; y: number }) => void;
+  uploadFile?: (file: File) => void;
+}
+
+export interface UseLazyEditorOptions {
+  /**
+   * Mount the real editor immediately instead of the static stand-in.
+   * The one legitimate case is an unsent draft: its existence proves edit
+   * intent, and hydrating it into a visible editor matches the pre-lazy
+   * behavior exactly.
+   */
+  initialActive?: boolean;
+  /** The host's own editor ref — used for post-swap focus and queued uploads. */
+  editorRef: RefObject<LazyEditorHandle | null>;
+}
+
+/**
+ * Shared controller for readonly-first editors (issue title / description /
+ * comment / reply). Tiptap instantiation costs ~70-460ms per editor on the
+ * main thread, so every always-mounted editor makes opening an issue jankier
+ * (measured: 2-4 editors per open froze the click for 0.4-1.3s). The pattern:
+ *
+ *   1. Render a cheap static stand-in while `!active`.
+ *   2. A click (or queued upload, or Enter on the stand-in) calls `activate`,
+ *      which mounts the real editor HIDDEN — the stand-in stays visible so
+ *      the content never blanks while Tiptap assembles.
+ *   3. The editor's `onReady` flips `ready`; the host swaps visibility in
+ *      that commit, and the effect below (running after that commit, so the
+ *      editor is laid out) lands the caret at the activating click's
+ *      coordinates and flushes any uploads queued against the stand-in.
+ *
+ * Host render contract:
+ *   {lazy.active && <div className={lazy.ready ? undefined : "hidden"}>
+ *     <Editor ref={editorRef} onReady={lazy.onReady} ... /></div>}
+ *   {!lazy.ready && <StaticStandIn onClick={e => lazy.activate({x: e.clientX, y: e.clientY})} />}
+ *
+ * Hosts that outlive an issue switch without remounting (the web issue route)
+ * must call `reset()` when their subject changes; keyed hosts get this for
+ * free by remounting.
+ */
+export function useLazyEditor({ initialActive = false, editorRef }: UseLazyEditorOptions) {
+  const [active, setActive] = useState(initialActive);
+  const [ready, setReady] = useState(false);
+  const focusCoordsRef = useRef<{ x: number; y: number } | null>(null);
+  const focusPendingRef = useRef(false);
+  const pendingFilesRef = useRef<File[]>([]);
+
+  const activate = useCallback(
+    (coords?: { x: number; y: number }) => {
+      focusCoordsRef.current = coords ?? null;
+      focusPendingRef.current = true;
+      setActive(true);
+      // Already swapped in (e.g. keyboard re-activation after a blur):
+      // focus straight away, there is no ready-effect coming.
+      if (ready) {
+        focusPendingRef.current = false;
+        const target = focusCoordsRef.current;
+        focusCoordsRef.current = null;
+        if (target && editorRef.current?.focusAtCoords) editorRef.current.focusAtCoords(target);
+        else editorRef.current?.focus();
+      }
+    },
+    [ready, editorRef],
+  );
+
+  const onReady = useCallback(() => setReady(true), []);
+
+  // Post-swap work — runs after the commit that revealed the ready editor,
+  // so focusAtCoords can resolve layout and uploads insert into a live doc.
+  useEffect(() => {
+    if (!ready) return;
+    if (focusPendingRef.current) {
+      focusPendingRef.current = false;
+      const coords = focusCoordsRef.current;
+      focusCoordsRef.current = null;
+      if (coords && editorRef.current?.focusAtCoords) editorRef.current.focusAtCoords(coords);
+      else editorRef.current?.focus();
+    }
+    const pending = pendingFilesRef.current;
+    pendingFilesRef.current = [];
+    for (const file of pending) editorRef.current?.uploadFile?.(file);
+  }, [ready, editorRef]);
+
+  /** Upload now when the editor is live; otherwise queue and summon it. */
+  const uploadOrQueue = useCallback(
+    (files: File[]) => {
+      if (ready) {
+        for (const file of files) editorRef.current?.uploadFile?.(file);
+        return;
+      }
+      pendingFilesRef.current.push(...files);
+      setActive(true);
+    },
+    [ready, editorRef],
+  );
+
+  /** Back to the static stand-in. For non-keyed hosts on subject switch. */
+  const reset = useCallback(() => {
+    setActive(false);
+    setReady(false);
+    focusCoordsRef.current = null;
+    focusPendingRef.current = false;
+    pendingFilesRef.current = [];
+  }, []);
+
+  return { active, ready, activate, onReady, uploadOrQueue, reset };
+}

--- a/packages/views/editor/use-lazy-editor.ts
+++ b/packages/views/editor/use-lazy-editor.ts
@@ -22,6 +22,17 @@ export interface UseLazyEditorOptions {
   initialActive?: boolean;
   /** The host's own editor ref — used for post-swap focus and queued uploads. */
   editorRef: RefObject<LazyEditorHandle | null>;
+  /**
+   * When this value changes, the hook returns to the static stand-in DURING
+   * that same render (setState-during-render, React's derived-state pattern)
+   * — not in an effect. An effect-based reset is one commit too late: the
+   * render that carries the new key would still see `active/ready === true`,
+   * visibly mount a keyed editor for the NEW subject, assemble a full Tiptap
+   * instance, and only then throw it away — re-paying the exact main-thread
+   * cost this hook exists to avoid, and blanking the region for a beat.
+   * Hosts that remount per subject (via `key`) don't need this.
+   */
+  resetKey?: unknown;
 }
 
 /**
@@ -44,16 +55,31 @@ export interface UseLazyEditorOptions {
  *     <Editor ref={editorRef} onReady={lazy.onReady} ... /></div>}
  *   {!lazy.ready && <StaticStandIn onClick={e => lazy.activate({x: e.clientX, y: e.clientY})} />}
  *
- * Hosts that outlive an issue switch without remounting (the web issue route)
- * must call `reset()` when their subject changes; keyed hosts get this for
- * free by remounting.
+ * Hosts that outlive a subject switch without remounting (the web issue
+ * route) must pass `resetKey`; keyed hosts get the reset for free by
+ * remounting.
  */
-export function useLazyEditor({ initialActive = false, editorRef }: UseLazyEditorOptions) {
+export function useLazyEditor({
+  initialActive = false,
+  editorRef,
+  resetKey,
+}: UseLazyEditorOptions) {
   const [active, setActive] = useState(initialActive);
   const [ready, setReady] = useState(false);
   const focusCoordsRef = useRef<{ x: number; y: number } | null>(null);
   const focusPendingRef = useRef(false);
   const pendingFilesRef = useRef<File[]>([]);
+
+  // Render-phase reset on subject change — see the `resetKey` option doc.
+  const [prevResetKey, setPrevResetKey] = useState(resetKey);
+  if (resetKey !== prevResetKey) {
+    setPrevResetKey(resetKey);
+    setActive(initialActive);
+    setReady(false);
+    focusCoordsRef.current = null;
+    focusPendingRef.current = false;
+    pendingFilesRef.current = [];
+  }
 
   const activate = useCallback(
     (coords?: { x: number; y: number }) => {
@@ -104,14 +130,5 @@ export function useLazyEditor({ initialActive = false, editorRef }: UseLazyEdito
     [ready, editorRef],
   );
 
-  /** Back to the static stand-in. For non-keyed hosts on subject switch. */
-  const reset = useCallback(() => {
-    setActive(false);
-    setReady(false);
-    focusCoordsRef.current = null;
-    focusPendingRef.current = false;
-    pendingFilesRef.current = [];
-  }, []);
-
-  return { active, ready, activate, onReady, uploadOrQueue, reset };
+  return { active, ready, activate, onReady, uploadOrQueue };
 }

--- a/packages/views/editor/use-lazy-editor.ts
+++ b/packages/views/editor/use-lazy-editor.ts
@@ -1,6 +1,7 @@
 "use client";
 
 import { useCallback, useEffect, useRef, useState, type RefObject } from "react";
+import type { TextAnchor } from "./text-anchor";
 
 /**
  * Minimal imperative surface useLazyEditor needs from the wrapped editor.
@@ -9,7 +10,20 @@ import { useCallback, useEffect, useRef, useState, type RefObject } from "react"
 export interface LazyEditorHandle {
   focus: () => void;
   focusAtCoords?: (coords: { x: number; y: number }) => void;
+  focusAtAnchor?: (anchor: TextAnchor) => void;
   uploadFile?: (file: File) => void;
+}
+
+/**
+ * Where the caret should land after the swap. `anchor` (logical "block N,
+ * character M", layout-independent) wins over the raw click coordinates;
+ * coordinates remain as the fallback for clicks that yield no text anchor
+ * (image, table chrome, margin) and for single-line hosts like the title.
+ */
+export interface LazyFocusTarget {
+  x: number;
+  y: number;
+  anchor?: TextAnchor;
 }
 
 export interface UseLazyEditorOptions {
@@ -47,8 +61,9 @@ export interface UseLazyEditorOptions {
  *      the content never blanks while Tiptap assembles.
  *   3. The editor's `onReady` flips `ready`; the host swaps visibility in
  *      that commit, and the effect below (running after that commit, so the
- *      editor is laid out) lands the caret at the activating click's
- *      coordinates and flushes any uploads queued against the stand-in.
+ *      editor is laid out) lands the caret at the activating click's focus
+ *      target — text anchor first, raw coordinates as fallback — and
+ *      flushes any uploads queued against the stand-in.
  *
  * Host render contract:
  *   {lazy.active && <div className={lazy.ready ? undefined : "hidden"}>
@@ -66,7 +81,7 @@ export function useLazyEditor({
 }: UseLazyEditorOptions) {
   const [active, setActive] = useState(initialActive);
   const [ready, setReady] = useState(false);
-  const focusCoordsRef = useRef<{ x: number; y: number } | null>(null);
+  const focusTargetRef = useRef<LazyFocusTarget | null>(null);
   const focusPendingRef = useRef(false);
   const pendingFilesRef = useRef<File[]>([]);
 
@@ -76,46 +91,56 @@ export function useLazyEditor({
     setPrevResetKey(resetKey);
     setActive(initialActive);
     setReady(false);
-    focusCoordsRef.current = null;
+    focusTargetRef.current = null;
     focusPendingRef.current = false;
     pendingFilesRef.current = [];
   }
 
+  const focusAtTarget = useCallback(
+    (target: LazyFocusTarget | null) => {
+      const handle = editorRef.current;
+      if (!handle) return;
+      if (target?.anchor && handle.focusAtAnchor) handle.focusAtAnchor(target.anchor);
+      else if (target && handle.focusAtCoords) handle.focusAtCoords(target);
+      else handle.focus();
+    },
+    [editorRef],
+  );
+
   const activate = useCallback(
-    (coords?: { x: number; y: number }) => {
-      focusCoordsRef.current = coords ?? null;
+    (target?: LazyFocusTarget) => {
+      focusTargetRef.current = target ?? null;
       focusPendingRef.current = true;
       setActive(true);
       // Already swapped in (e.g. keyboard re-activation after a blur):
       // focus straight away, there is no ready-effect coming.
       if (ready) {
         focusPendingRef.current = false;
-        const target = focusCoordsRef.current;
-        focusCoordsRef.current = null;
-        if (target && editorRef.current?.focusAtCoords) editorRef.current.focusAtCoords(target);
-        else editorRef.current?.focus();
+        const latched = focusTargetRef.current;
+        focusTargetRef.current = null;
+        focusAtTarget(latched);
       }
     },
-    [ready, editorRef],
+    [ready, focusAtTarget],
   );
 
   const onReady = useCallback(() => setReady(true), []);
 
   // Post-swap work — runs after the commit that revealed the ready editor,
-  // so focusAtCoords can resolve layout and uploads insert into a live doc.
+  // so focus targets can resolve against a laid-out, live doc and uploads
+  // insert into it.
   useEffect(() => {
     if (!ready) return;
     if (focusPendingRef.current) {
       focusPendingRef.current = false;
-      const coords = focusCoordsRef.current;
-      focusCoordsRef.current = null;
-      if (coords && editorRef.current?.focusAtCoords) editorRef.current.focusAtCoords(coords);
-      else editorRef.current?.focus();
+      const target = focusTargetRef.current;
+      focusTargetRef.current = null;
+      focusAtTarget(target);
     }
     const pending = pendingFilesRef.current;
     pendingFilesRef.current = [];
     for (const file of pending) editorRef.current?.uploadFile?.(file);
-  }, [ready, editorRef]);
+  }, [ready, editorRef, focusAtTarget]);
 
   /** Upload now when the editor is live; otherwise queue and summon it. */
   const uploadOrQueue = useCallback(

--- a/packages/views/issues/components/comment-composers.test.tsx
+++ b/packages/views/issues/components/comment-composers.test.tsx
@@ -1,9 +1,9 @@
-import { forwardRef, useImperativeHandle, useRef, type ReactNode, type Ref } from "react";
+import { forwardRef, useEffect, useImperativeHandle, useRef, type ReactNode, type Ref } from "react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { fireEvent, screen, waitFor } from "@testing-library/react";
 import type { UploadResult } from "@multica/core/hooks/use-file-upload";
-import { useCommentComposerStore } from "@multica/core/issues/stores";
+import { useCommentComposerStore, useCommentDraftStore } from "@multica/core/issues/stores";
 import { renderWithI18n } from "../../test/i18n";
 import { CommentInput } from "./comment-input";
 import { ReplyInput } from "./reply-input";
@@ -26,7 +26,12 @@ vi.mock("../../common/actor-avatar", () => ({
   ),
 }));
 
-vi.mock("../../editor", () => ({
+vi.mock("../../editor", async () => ({
+  // The lazy-mount controller is pure React (no Tiptap) — use the real one so
+  // shell → activate → ready flows behave exactly as in production.
+  ...(await vi.importActual<typeof import("../../editor/use-lazy-editor")>(
+    "../../editor/use-lazy-editor",
+  )),
   useFileDropZone: () => ({
     isDragOver: false,
     dropZoneProps: { "data-testid": "drop-zone" },
@@ -38,15 +43,22 @@ vi.mock("../../editor", () => ({
       onUpdate,
       placeholder,
       onUploadFile,
+      onReady,
     }: {
       defaultValue?: string;
       onUpdate?: (markdown: string) => void;
       placeholder?: string;
       onUploadFile?: (file: File) => Promise<UploadResult | null>;
+      onReady?: () => void;
     },
     ref: Ref<unknown>,
   ) {
     const valueRef = useRef(defaultValue ?? "");
+
+    useEffect(() => {
+      onReady?.();
+      // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, []);
 
     useImperativeHandle(ref, () => ({
       getMarkdown: () => valueRef.current,
@@ -54,6 +66,7 @@ vi.mock("../../editor", () => ({
         valueRef.current = "";
       },
       focus: () => {},
+      focusAtCoords: () => {},
       blur: () => {},
       uploadFile: async (file: File) => {
         const result = await onUploadFile?.(file);
@@ -114,6 +127,13 @@ function renderReplyInput({
   return { ...view, onSubmit };
 }
 
+// Composers render readonly-first: a static shell until clicked (unless an
+// unsent draft exists). Tests that interact with the editor activate it the
+// same way a user does.
+function activateComposer(shellTestId: "comment-composer-shell" | "reply-composer-shell") {
+  fireEvent.click(screen.getByTestId(shellTestId));
+}
+
 function getSubmitButton(container: HTMLElement): HTMLButtonElement {
   // Submit is always the last button in a composer's action cluster.
   const buttons = container.querySelectorAll("button");
@@ -126,12 +146,20 @@ beforeEach(() => {
   uploadWithToast.mockReset();
   localStorage.clear();
   useCommentComposerStore.setState({ sticky: true });
+  // The draft store is a module singleton — a draft left by a previous test
+  // (e.g. the failed-send case) would trip the composers' draft-direct-mount
+  // path and hide the shell the next test expects.
+  useCommentDraftStore.setState({ drafts: {} });
 });
 
 describe("comment composers", () => {
   it("renders the main comment composer without a manual expand control", () => {
     const { container } = renderCommentInput();
 
+    // Readonly-first: shell shows the placeholder text; clicking mounts the
+    // real editor in place.
+    expect(screen.getByTestId("comment-composer-shell")).toHaveTextContent("Leave a comment...");
+    activateComposer("comment-composer-shell");
     expect(screen.getByPlaceholderText("Leave a comment...")).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Attach file" })).toBeInTheDocument();
     expect(container.querySelectorAll("button")).toHaveLength(2);
@@ -144,6 +172,8 @@ describe("comment composers", () => {
   it("renders reply composer without a manual expand control", () => {
     const { container } = renderReplyInput();
 
+    expect(screen.getByTestId("reply-composer-shell")).toHaveTextContent("Leave a reply...");
+    activateComposer("reply-composer-shell");
     expect(screen.getByPlaceholderText("Leave a reply...")).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Attach file" })).toBeInTheDocument();
     expect(container.querySelectorAll("button")).toHaveLength(2);
@@ -156,6 +186,7 @@ describe("comment composers", () => {
   it("lets default-size replies grow without a height cap", () => {
     const { container } = renderReplyInput({ size: "default" });
 
+    activateComposer("reply-composer-shell");
     expect(screen.getByPlaceholderText("Leave a reply...")).toBeInTheDocument();
     expect(container.querySelectorAll("button")).toHaveLength(2);
 
@@ -166,6 +197,7 @@ describe("comment composers", () => {
   it("keeps main comment submission wired after removing expand", async () => {
     const { container, onSubmit } = renderCommentInput();
 
+    activateComposer("comment-composer-shell");
     fireEvent.change(screen.getByTestId("editor"), {
       target: { value: "hello from composer" },
     });
@@ -179,6 +211,7 @@ describe("comment composers", () => {
   it("keeps reply submission wired after removing expand", async () => {
     const { container, onSubmit } = renderReplyInput();
 
+    activateComposer("reply-composer-shell");
     fireEvent.change(screen.getByTestId("editor"), {
       target: { value: "thread reply" },
     });
@@ -196,6 +229,7 @@ describe("comment composers", () => {
     );
     const { container } = renderCommentInput(onSubmit);
 
+    activateComposer("comment-composer-shell");
     fireEvent.change(screen.getByTestId("editor"), { target: { value: "sending" } });
     fireEvent.click(getSubmitButton(container));
 
@@ -219,6 +253,7 @@ describe("comment composers", () => {
     const onSubmit = vi.fn().mockResolvedValue(false);
     const { container } = renderCommentInput(onSubmit);
 
+    activateComposer("comment-composer-shell");
     fireEvent.change(screen.getByTestId("editor"), { target: { value: "will fail" } });
     fireEvent.click(getSubmitButton(container));
 
@@ -232,6 +267,7 @@ describe("sticky composer preference", () => {
   it("caps the editor height while the sticky preference is on (default)", () => {
     renderCommentInput();
 
+    activateComposer("comment-composer-shell");
     // The height cap lives on the editor wrapper, not the card shell.
     expect(screen.getByTestId("editor").parentElement?.className).toContain("max-h-[40vh]");
   });
@@ -240,6 +276,7 @@ describe("sticky composer preference", () => {
     useCommentComposerStore.setState({ sticky: false });
     renderCommentInput();
 
+    activateComposer("comment-composer-shell");
     expect(screen.getByTestId("editor").parentElement?.className).not.toContain("max-h-[40vh]");
   });
 });

--- a/packages/views/issues/components/comment-input.tsx
+++ b/packages/views/issues/components/comment-input.tsx
@@ -2,7 +2,7 @@
 
 import { useRef, useState, useCallback, useEffect } from "react";
 import { cn } from "@multica/ui/lib/utils";
-import { ContentEditor, type ContentEditorRef, useFileDropZone, FileDropOverlay } from "../../editor";
+import { ContentEditor, type ContentEditorRef, useFileDropZone, FileDropOverlay, useLazyEditor } from "../../editor";
 import { FileUploadButton } from "@multica/ui/components/common/file-upload-button";
 import { SubmitButton } from "@multica/ui/components/common/submit-button";
 import { useFileUpload } from "@multica/core/hooks/use-file-upload";
@@ -44,8 +44,16 @@ function CommentInput({ issueId, onSubmit }: CommentInputProps) {
   //    resolve text/code/markdown previews that require the attachment id.
   const [pendingAttachments, setPendingAttachments] = useState<Attachment[]>([]);
   const { uploadWithToast } = useFileUpload(api);
+  // Readonly-first: the composer renders as a same-looking static shell until
+  // the user shows intent (click / keyboard / file drop). An unsent draft is
+  // standing intent — mount the real editor immediately so the draft is
+  // visible and editable, exactly like the pre-lazy behavior.
+  const lazy = useLazyEditor({
+    initialActive: !!initialDraft?.trim(),
+    editorRef,
+  });
   const { isDragOver, dropZoneProps } = useFileDropZone({
-    onDrop: (files) => files.forEach((f) => editorRef.current?.uploadFile(f)),
+    onDrop: lazy.uploadOrQueue,
   });
   // Sticky preference (Settings → Preferences): issue-detail pins this
   // composer to the bottom of the scroll viewport when enabled.
@@ -147,6 +155,7 @@ function CommentInput({ issueId, onSubmit }: CommentInputProps) {
           toggle Tiptap's `editable` post-mount (see its docstring), so the
           documented way to make it non-interactive is a pointer-events-none +
           dimmed wrapper. */}
+      {lazy.active && (
       <div
         className={cn(
           "flex-1 min-h-0 overflow-y-auto px-3 py-2",
@@ -155,12 +164,14 @@ function CommentInput({ issueId, onSubmit }: CommentInputProps) {
           // area scrolls internally instead).
           sticky && "max-h-[40vh]",
           submitting && "pointer-events-none opacity-60",
+          !lazy.ready && "hidden",
         )}
         aria-busy={submitting || undefined}
       >
         <ContentEditor
           ref={editorRef}
           defaultValue={initialDraft}
+          onReady={lazy.onReady}
           placeholder={t(($) => $.comment.leave_comment_placeholder)}
           onUpdate={(md) => {
             setContent(md);
@@ -179,6 +190,33 @@ function CommentInput({ issueId, onSubmit }: CommentInputProps) {
           slashCommandMode="command"
         />
       </div>
+      )}
+      {/* Static shell — visually clones the empty single-line composer.
+          Real editor mounts (hidden) on first intent; shell stays visible
+          until it's ready so the card never blanks or shifts. */}
+      {!lazy.ready && (
+        <div
+          data-testid="comment-composer-shell"
+          role="button"
+          tabIndex={0}
+          aria-label={t(($) => $.comment.leave_comment_placeholder)}
+          className="flex-1 min-h-0 cursor-text px-3 py-2"
+          onClick={() => lazy.activate()}
+          onKeyDown={(e) => {
+            if (e.key === "Enter" || e.key === " ") {
+              e.preventDefault();
+              lazy.activate();
+            }
+          }}
+        >
+          {/* rich-text-editor + <p>: the shell line inherits the editor's
+              exact type metrics (line-height 1.625 from prose.css), so the
+              shell→editor swap doesn't shift layout. */}
+          <div className="rich-text-editor text-sm">
+            <p className="text-muted-foreground">{t(($) => $.comment.leave_comment_placeholder)}</p>
+          </div>
+        </div>
+      )}
       <div className="absolute bottom-1 left-2 right-28 min-w-0">
         <CommentTriggerChips
           agents={triggerPreview.agents}
@@ -190,7 +228,7 @@ function CommentInput({ issueId, onSubmit }: CommentInputProps) {
         <FileUploadButton
           size="sm"
           multiple
-          onSelect={(file) => editorRef.current?.uploadFile(file)}
+          onSelect={(file) => lazy.uploadOrQueue([file])}
         />
         <SubmitButton
           onClick={handleSubmit}

--- a/packages/views/issues/components/issue-detail.test.tsx
+++ b/packages/views/issues/components/issue-detail.test.tsx
@@ -11,6 +11,11 @@ const TEST_RESOURCES = { en: { common: enCommon, issues: enIssues } };
 
 const mockViewport = vi.hoisted(() => ({ isMobile: false }));
 
+// Counts MockContentEditor mounts. Lets tests assert an editor was never
+// instantiated for a path (e.g. issue switch) even when a buggy mount would
+// already be unmounted again by the time the DOM is inspected.
+const contentEditorMounts = vi.hoisted(() => ({ count: 0 }));
+
 vi.mock("@multica/ui/hooks/use-mobile", () => ({
   useIsMobile: () => mockViewport.isMobile,
 }));
@@ -140,6 +145,7 @@ vi.mock("../../editor", async () => ({
     const valueRef = useRef(defaultValue || "");
     const [value, setValue] = useState(defaultValue || "");
     useEffect(() => {
+      contentEditorMounts.count += 1;
       onReady?.();
       // eslint-disable-next-line react-hooks/exhaustive-deps
     }, []);
@@ -597,6 +603,64 @@ describe("IssueDetail (shared)", () => {
 
     const description = await screen.findByDisplayValue("Add JWT auth to the backend");
     expect(description).toHaveAttribute("data-flush-on-unmount", "true");
+  });
+
+  it("activates the description stand-in from the keyboard (Enter)", async () => {
+    renderIssueDetail();
+
+    const readonly = await screen.findByText("Add JWT auth to the backend");
+    const standIn = readonly.closest("[role='button']");
+    expect(standIn).not.toBeNull();
+
+    fireEvent.keyDown(standIn!, { key: "Enter" });
+
+    expect(await screen.findByDisplayValue("Add JWT auth to the backend")).toBeInTheDocument();
+  });
+
+  it("folds an activated description back to the stand-in on issue switch without mounting an editor", async () => {
+    // The web issue route reuses IssueDetail across issues (no remount), so
+    // the reset must happen during the id-change render. An effect-based
+    // reset is one commit late: the new issue's keyed editor would mount,
+    // assemble, and be discarded — invisible in the final DOM, so this test
+    // counts editor MOUNTS instead of inspecting what remains.
+    const queryClient = createTestQueryClient();
+    const issue2 = {
+      ...mockIssue,
+      id: "issue-2",
+      title: "Second issue",
+      description: "Second description",
+    };
+    // The cache seed marks the data stale, so the query refetches in the
+    // background — getIssue must answer per-id or the refetch would clobber
+    // issue-2 with issue-1's payload.
+    mockApiObj.getIssue.mockImplementation((issueId: string) =>
+      Promise.resolve(issueId === "issue-2" ? issue2 : mockIssue),
+    );
+    // Pre-seed issue-2 so its first render skips the loading skeleton — the
+    // path where a stale active/ready would visibly mount a wasted editor.
+    queryClient.setQueryData(["issues", "ws-1", "detail", "issue-2"], issue2);
+    const ui = (issueId: string) => (
+      <I18nProvider locale="en" resources={TEST_RESOURCES}>
+        <QueryClientProvider client={queryClient}>
+          <IssueDetail issueId={issueId} />
+        </QueryClientProvider>
+      </I18nProvider>
+    );
+    const { rerender } = render(ui("issue-1"));
+
+    // Activate the description editor on issue-1.
+    fireEvent.click(await screen.findByText("Add JWT auth to the backend"));
+    await screen.findByDisplayValue("Add JWT auth to the backend");
+    const mountsAfterActivation = contentEditorMounts.count;
+
+    rerender(ui("issue-2"));
+
+    // issue-2 renders its static stand-in; no editor was ever instantiated.
+    await waitFor(() => {
+      expect(screen.getByText("Second description")).toBeInTheDocument();
+    });
+    expect(screen.queryByPlaceholderText("Add description...")).not.toBeInTheDocument();
+    expect(contentEditorMounts.count).toBe(mountsAfterActivation);
   });
 
   it("renders the issue title leaf as a link to the issue detail page", async () => {

--- a/packages/views/issues/components/issue-detail.test.tsx
+++ b/packages/views/issues/components/issue-detail.test.tsx
@@ -1,4 +1,4 @@
-import { forwardRef, useRef, useState, useImperativeHandle } from "react";
+import { forwardRef, useEffect, useRef, useState, useImperativeHandle } from "react";
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
@@ -110,7 +110,12 @@ vi.mock("../../navigation", () => ({
 }));
 
 // Mock editor components (Tiptap requires real DOM)
-vi.mock("../../editor", () => ({
+vi.mock("../../editor", async () => ({
+  // Real lazy-mount controller (pure React, no Tiptap) so readonly-first
+  // shell → activate → ready flows behave exactly as in production.
+  ...(await vi.importActual<typeof import("../../editor/use-lazy-editor")>(
+    "../../editor/use-lazy-editor",
+  )),
   useFileDropZone: () => ({ isDragOver: false, dropZoneProps: {} }),
   FileDropOverlay: () => null,
   // No-op so comment-card's AttachmentList can render without hitting the
@@ -129,15 +134,20 @@ vi.mock("../../editor", () => ({
     <div data-testid="readonly-content">{content}</div>
   ),
   ContentEditor: forwardRef(function MockContentEditor(
-    { defaultValue, onUpdate, placeholder, flushPendingOnUnmount }: any,
+    { defaultValue, onUpdate, placeholder, flushPendingOnUnmount, onReady }: any,
     ref: any,
   ) {
     const valueRef = useRef(defaultValue || "");
     const [value, setValue] = useState(defaultValue || "");
+    useEffect(() => {
+      onReady?.();
+      // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, []);
     useImperativeHandle(ref, () => ({
       getMarkdown: () => valueRef.current,
       clearContent: () => { valueRef.current = ""; setValue(""); },
       focus: () => {},
+      focusAtCoords: () => {},
       uploadFile: () => {},
     }));
     return (
@@ -155,14 +165,19 @@ vi.mock("../../editor", () => ({
     );
   }),
   TitleEditor: forwardRef(function MockTitleEditor(
-    { defaultValue, placeholder, onBlur, onChange }: any,
+    { defaultValue, placeholder, onBlur, onChange, onReady }: any,
     ref: any,
   ) {
     const valueRef = useRef(defaultValue || "");
     const [value, setValue] = useState(defaultValue || "");
+    useEffect(() => {
+      onReady?.();
+      // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, []);
     useImperativeHandle(ref, () => ({
       getText: () => valueRef.current,
       focus: () => {},
+      focusAtCoords: () => {},
     }));
     return (
       <input
@@ -556,11 +571,15 @@ describe("IssueDetail (shared)", () => {
   it("renders issue title and description after loading", async () => {
     renderIssueDetail();
 
+    // Readonly-first: title and description render as static views (no
+    // editors mounted) until the user clicks into them.
     await waitFor(() => {
-      expect(screen.getByDisplayValue("Implement authentication")).toBeInTheDocument();
+      expect(screen.getByText("Implement authentication")).toBeInTheDocument();
     });
 
-    expect(screen.getByDisplayValue("Add JWT auth to the backend")).toBeInTheDocument();
+    expect(screen.getByText("Add JWT auth to the backend")).toBeInTheDocument();
+    expect(screen.queryByTestId("title-editor")).not.toBeInTheDocument();
+    expect(screen.queryByPlaceholderText("Add description...")).not.toBeInTheDocument();
   });
 
   it("opts the description editor into the unmount flush", async () => {
@@ -571,6 +590,10 @@ describe("IssueDetail (shared)", () => {
     // markdown and its attachment_ids bind (MUL-3254). The flush behavior
     // itself is covered in content-editor.test.tsx; this pins the wiring.
     renderIssueDetail();
+
+    // Readonly-first: click the static description to summon the editor.
+    const readonly = await screen.findByText("Add JWT auth to the backend");
+    fireEvent.click(readonly);
 
     const description = await screen.findByDisplayValue("Add JWT auth to the backend");
     expect(description).toHaveAttribute("data-flush-on-unmount", "true");
@@ -682,7 +705,7 @@ describe("IssueDetail (shared)", () => {
     renderIssueDetail();
 
     await waitFor(() => {
-      expect(screen.getByDisplayValue("Implement authentication")).toBeInTheDocument();
+      expect(screen.getByText("Implement authentication")).toBeInTheDocument();
     });
 
     expect(screen.queryByTestId("panel-group")).not.toBeInTheDocument();
@@ -1282,6 +1305,10 @@ describe("IssueDetail (shared)", () => {
 
   it("sends empty description when editor is cleared", async () => {
     renderIssueDetail();
+
+    // Readonly-first: click the static description to summon the editor.
+    const readonly = await screen.findByText("Add JWT auth to the backend");
+    fireEvent.click(readonly);
 
     await waitFor(() => {
       expect(screen.getByDisplayValue("Add JWT auth to the backend")).toBeInTheDocument();

--- a/packages/views/issues/components/issue-detail.tsx
+++ b/packages/views/issues/components/issue-detail.tsx
@@ -30,7 +30,7 @@ import { Button } from "@multica/ui/components/ui/button";
 import { ResizablePanelGroup, ResizablePanel, ResizableHandle } from "@multica/ui/components/ui/resizable";
 import { Sheet, SheetContent } from "@multica/ui/components/ui/sheet";
 import { useIsMobile } from "@multica/ui/hooks/use-mobile";
-import { ContentEditor, type ContentEditorRef, ReadonlyContent, TitleEditor, type TitleEditorRef, useFileDropZone, FileDropOverlay, useLazyEditor } from "../../editor";
+import { ContentEditor, type ContentEditorRef, ReadonlyContent, TitleEditor, type TitleEditorRef, useFileDropZone, FileDropOverlay, useLazyEditor, anchorFromPoint } from "../../editor";
 import { FileUploadButton } from "@multica/ui/components/common/file-upload-button";
 import {
   Tooltip,
@@ -1299,7 +1299,8 @@ export function IssueDetail({ issueId, onDelete, onDone, defaultSidebarOpen = tr
   // ReadonlyContent shares the editor's `rich-text-editor` stylesheet, so
   // the swap is visually seamless. The click that used to place a caret now
   // calls `activate`; useLazyEditor mounts the editor hidden, swaps it in on
-  // `onReady`, and lands the caret at the clicked coordinates.
+  // `onReady`, and lands the caret at the clicked text anchor (coordinates
+  // only as fallback — see text-anchor.ts for why pixels drift).
   // resetKey: the web issue route reuses this component across issues, so a
   // subject switch must fold both regions back to their stand-ins during the
   // id-change render itself — an effect would let the new issue's keyed
@@ -1321,7 +1322,17 @@ export function IssueDetail({ issueId, onDelete, onDone, defaultSidebarOpen = tr
     // A drag-selection (copying text) must not summon the editor.
     const sel = window.getSelection();
     if (sel && !sel.isCollapsed) return;
-    descLazy.activate({ x: e.clientX, y: e.clientY });
+    // Prefer a text anchor ("block N, character M") over raw coordinates:
+    // the readonly render and the editor render are never pixel-identical
+    // on long documents, so posAtCoords drifts; a logical anchor doesn't.
+    // The `.readonly` qualifier skips nested `pre.rich-text-editor` blocks;
+    // the empty-placeholder stand-in has no readonly root and falls back to
+    // coordinates, which is fine for an empty document.
+    const readonlyRoot = e.currentTarget.querySelector<HTMLElement>(".rich-text-editor.readonly");
+    const anchor = readonlyRoot
+      ? anchorFromPoint(e.clientX, e.clientY, readonlyRoot)
+      : null;
+    descLazy.activate({ x: e.clientX, y: e.clientY, anchor: anchor ?? undefined });
   };
   const handleDescReadonlyKeyDown = (e: React.KeyboardEvent<HTMLDivElement>) => {
     if (e.key !== "Enter" && e.key !== " ") return;

--- a/packages/views/issues/components/issue-detail.tsx
+++ b/packages/views/issues/components/issue-detail.tsx
@@ -1300,9 +1300,13 @@ export function IssueDetail({ issueId, onDelete, onDone, defaultSidebarOpen = tr
   // the swap is visually seamless. The click that used to place a caret now
   // calls `activate`; useLazyEditor mounts the editor hidden, swaps it in on
   // `onReady`, and lands the caret at the clicked coordinates.
-  const descLazy = useLazyEditor({ editorRef: descEditorRef });
+  // resetKey: the web issue route reuses this component across issues, so a
+  // subject switch must fold both regions back to their stand-ins during the
+  // id-change render itself — an effect would let the new issue's keyed
+  // editor mount visibly once before being discarded.
+  const descLazy = useLazyEditor({ editorRef: descEditorRef, resetKey: id });
   const titleEditorRef = useRef<TitleEditorRef>(null);
-  const titleLazy = useLazyEditor({ editorRef: titleEditorRef });
+  const titleLazy = useLazyEditor({ editorRef: titleEditorRef, resetKey: id });
   const { isDragOver: descDragOver, dropZoneProps: descDropZoneProps } = useFileDropZone({
     onDrop: descLazy.uploadOrQueue,
   });
@@ -1310,11 +1314,23 @@ export function IssueDetail({ issueId, onDelete, onDone, defaultSidebarOpen = tr
     const target = e.target as HTMLElement;
     // Links, copy buttons, attachment cards etc. inside the readonly render
     // keep their own behavior — only a click on plain content enters editing.
-    if (target.closest("a, button, input, textarea, [role='button']")) return;
+    // The wrapper itself carries role="button" (keyboard path below), so the
+    // closest() hit must be an INNER element to count as interactive.
+    const interactive = target.closest("a, button, input, textarea, [role='button']");
+    if (interactive && interactive !== e.currentTarget) return;
     // A drag-selection (copying text) must not summon the editor.
     const sel = window.getSelection();
     if (sel && !sel.isCollapsed) return;
     descLazy.activate({ x: e.clientX, y: e.clientY });
+  };
+  const handleDescReadonlyKeyDown = (e: React.KeyboardEvent<HTMLDivElement>) => {
+    if (e.key !== "Enter" && e.key !== " ") return;
+    // Enter/Space on a focusable element INSIDE the readonly render (link,
+    // copy button, checkbox) keeps its own behavior — only activate when the
+    // wrapper itself holds focus.
+    if (e.target !== e.currentTarget) return;
+    e.preventDefault();
+    descLazy.activate();
   };
   // Pending uploads in the description editor. We don't pass `issueId` on
   // upload (to avoid orphaning attachments when the user deletes the file
@@ -1341,16 +1357,10 @@ export function IssueDetail({ issueId, onDelete, onDone, defaultSidebarOpen = tr
     [uploadWithToast],
   );
 
-  const resetDescLazy = descLazy.reset;
-  const resetTitleLazy = titleLazy.reset;
   useEffect(() => {
     descPendingAttachmentsRef.current = [];
     setDescPendingAttachments([]);
-    // Back to readonly-first on issue switch (the web route reuses this
-    // component instead of remounting it).
-    resetDescLazy();
-    resetTitleLazy();
-  }, [id, resetDescLazy, resetTitleLazy]);
+  }, [id]);
 
   // Shared issue actions (mutations, pin, copy-link, modal dispatch, etc.).
   // Called before the `if (!issue)` early return so hook order stays stable.
@@ -2112,13 +2122,22 @@ export function IssueDetail({ issueId, onDelete, onDone, defaultSidebarOpen = tr
                 the editor, so the swap is visually seamless. */}
             {!descLazy.ready &&
               (issue.description?.trim() ? (
-                <div className="cursor-text text-sm" onClick={handleDescReadonlyClick}>
+                <div
+                  role="button"
+                  tabIndex={0}
+                  className="cursor-text text-sm"
+                  onClick={handleDescReadonlyClick}
+                  onKeyDown={handleDescReadonlyKeyDown}
+                >
                   <ReadonlyContent content={issue.description} attachments={issueAttachments} />
                 </div>
               ) : (
                 <div
+                  role="button"
+                  tabIndex={0}
                   className="cursor-text rich-text-editor text-sm"
                   onClick={handleDescReadonlyClick}
+                  onKeyDown={handleDescReadonlyKeyDown}
                 >
                   {/* <p> under rich-text-editor: same type metrics as the
                       editor's empty paragraph — no height jump on swap. */}

--- a/packages/views/issues/components/issue-detail.tsx
+++ b/packages/views/issues/components/issue-detail.tsx
@@ -30,7 +30,7 @@ import { Button } from "@multica/ui/components/ui/button";
 import { ResizablePanelGroup, ResizablePanel, ResizableHandle } from "@multica/ui/components/ui/resizable";
 import { Sheet, SheetContent } from "@multica/ui/components/ui/sheet";
 import { useIsMobile } from "@multica/ui/hooks/use-mobile";
-import { ContentEditor, type ContentEditorRef, TitleEditor, useFileDropZone, FileDropOverlay } from "../../editor";
+import { ContentEditor, type ContentEditorRef, ReadonlyContent, TitleEditor, type TitleEditorRef, useFileDropZone, FileDropOverlay, useLazyEditor } from "../../editor";
 import { FileUploadButton } from "@multica/ui/components/common/file-upload-button";
 import {
   Tooltip,
@@ -1292,9 +1292,30 @@ export function IssueDetail({ issueId, onDelete, onDone, defaultSidebarOpen = tr
   }, [highlightCommentId, items, targetIdx, scrollContainerEl, replyToRoot, expandedResolved, timelineView, toggleResolvedExpand]);
 
   const descEditorRef = useRef<ContentEditorRef>(null);
+  // Readonly-first description + title. Always-mounted Tiptap editors made
+  // every issue open pay full editor-assembly cost on the first commit
+  // (measured 1.5s main-thread freeze on a 22k-char description; ~70-460ms
+  // even for the single-line title). Default render is a static stand-in —
+  // ReadonlyContent shares the editor's `rich-text-editor` stylesheet, so
+  // the swap is visually seamless. The click that used to place a caret now
+  // calls `activate`; useLazyEditor mounts the editor hidden, swaps it in on
+  // `onReady`, and lands the caret at the clicked coordinates.
+  const descLazy = useLazyEditor({ editorRef: descEditorRef });
+  const titleEditorRef = useRef<TitleEditorRef>(null);
+  const titleLazy = useLazyEditor({ editorRef: titleEditorRef });
   const { isDragOver: descDragOver, dropZoneProps: descDropZoneProps } = useFileDropZone({
-    onDrop: (files) => files.forEach((f) => descEditorRef.current?.uploadFile(f)),
+    onDrop: descLazy.uploadOrQueue,
   });
+  const handleDescReadonlyClick = (e: React.MouseEvent<HTMLDivElement>) => {
+    const target = e.target as HTMLElement;
+    // Links, copy buttons, attachment cards etc. inside the readonly render
+    // keep their own behavior — only a click on plain content enters editing.
+    if (target.closest("a, button, input, textarea, [role='button']")) return;
+    // A drag-selection (copying text) must not summon the editor.
+    const sel = window.getSelection();
+    if (sel && !sel.isCollapsed) return;
+    descLazy.activate({ x: e.clientX, y: e.clientY });
+  };
   // Pending uploads in the description editor. We don't pass `issueId` on
   // upload (to avoid orphaning attachments when the user deletes the file
   // from the markdown), so they start unattached and we re-bind them via
@@ -1320,10 +1341,16 @@ export function IssueDetail({ issueId, onDelete, onDone, defaultSidebarOpen = tr
     [uploadWithToast],
   );
 
+  const resetDescLazy = descLazy.reset;
+  const resetTitleLazy = titleLazy.reset;
   useEffect(() => {
     descPendingAttachmentsRef.current = [];
     setDescPendingAttachments([]);
-  }, [id]);
+    // Back to readonly-first on issue switch (the web route reuses this
+    // component instead of remounting it).
+    resetDescLazy();
+    resetTitleLazy();
+  }, [id, resetDescLazy, resetTitleLazy]);
 
   // Shared issue actions (mutations, pin, copy-link, modal dispatch, etc.).
   // Called before the `if (!issue)` early return so hook order stays stable.
@@ -1972,16 +1999,43 @@ export function IssueDetail({ issueId, onDelete, onDone, defaultSidebarOpen = tr
           className="relative flex-1 overflow-y-auto [scrollbar-gutter:stable_both-edges]"
         >
         <div className="mx-auto w-full max-w-4xl px-8 py-8">
-          <TitleEditor
-            key={`title-${id}`}
-            defaultValue={issue.title}
-            placeholder={t(($) => $.detail.title_placeholder)}
-            className="w-full text-2xl font-bold leading-snug tracking-tight"
-            onBlur={(value) => {
-              const trimmed = value.trim();
-              if (trimmed && trimmed !== issue.title) handleUpdateField({ title: trimmed });
-            }}
-          />
+          {titleLazy.active && (
+            <div className={titleLazy.ready ? undefined : "hidden"}>
+              <TitleEditor
+                key={`title-${id}`}
+                ref={titleEditorRef}
+                defaultValue={issue.title}
+                placeholder={t(($) => $.detail.title_placeholder)}
+                className="w-full text-2xl font-bold leading-snug tracking-tight"
+                onReady={titleLazy.onReady}
+                onBlur={(value) => {
+                  const trimmed = value.trim();
+                  if (trimmed && trimmed !== issue.title) handleUpdateField({ title: trimmed });
+                }}
+              />
+            </div>
+          )}
+          {!titleLazy.ready && (
+            <div
+              role="button"
+              tabIndex={0}
+              className="w-full cursor-text text-2xl font-bold leading-snug tracking-tight"
+              onClick={(e) => {
+                // A drag-selection (copying the title) must not summon the editor.
+                const sel = window.getSelection();
+                if (sel && !sel.isCollapsed) return;
+                titleLazy.activate({ x: e.clientX, y: e.clientY });
+              }}
+              onKeyDown={(e) => {
+                if (e.key === "Enter" || e.key === " ") {
+                  e.preventDefault();
+                  titleLazy.activate();
+                }
+              }}
+            >
+              {issue.title}
+            </div>
+          )}
 
           {parentIssue && (
             <AppLink
@@ -2009,11 +2063,14 @@ export function IssueDetail({ issueId, onDelete, onDone, defaultSidebarOpen = tr
           )}
 
           <div {...descDropZoneProps} className="relative mt-5 rounded-lg">
+            {descLazy.active && (
+            <div className={descLazy.ready ? undefined : "hidden"}>
             <ContentEditor
               ref={descEditorRef}
               key={id}
               defaultValue={issue.description || ""}
               placeholder={t(($) => $.detail.desc_placeholder)}
+              onReady={descLazy.onReady}
               onUpdate={(md) => {
                 // Bind any pending uploads still referenced in the markdown
                 // so they appear in `issueAttachments` after refresh and the
@@ -2046,6 +2103,28 @@ export function IssueDetail({ issueId, onDelete, onDone, defaultSidebarOpen = tr
               currentIssueId={id}
               attachments={descEditorAttachments}
             />
+            </div>
+            )}
+
+            {/* Static description — shown until the live editor is ready
+                (also covers the window between click and editor creation,
+                so the content never blanks). Same rich-text stylesheet as
+                the editor, so the swap is visually seamless. */}
+            {!descLazy.ready &&
+              (issue.description?.trim() ? (
+                <div className="cursor-text text-sm" onClick={handleDescReadonlyClick}>
+                  <ReadonlyContent content={issue.description} attachments={issueAttachments} />
+                </div>
+              ) : (
+                <div
+                  className="cursor-text rich-text-editor text-sm"
+                  onClick={handleDescReadonlyClick}
+                >
+                  {/* <p> under rich-text-editor: same type metrics as the
+                      editor's empty paragraph — no height jump on swap. */}
+                  <p className="text-muted-foreground">{t(($) => $.detail.desc_placeholder)}</p>
+                </div>
+              ))}
 
             <div className="flex items-center gap-1 mt-3">
               <ReactionBar
@@ -2057,7 +2136,7 @@ export function IssueDetail({ issueId, onDelete, onDone, defaultSidebarOpen = tr
               <FileUploadButton
                 size="sm"
                 multiple
-                onSelect={(file) => descEditorRef.current?.uploadFile(file)}
+                onSelect={(file) => descLazy.uploadOrQueue([file])}
               />
             </div>
             {descDragOver && <FileDropOverlay />}

--- a/packages/views/issues/components/reply-input.tsx
+++ b/packages/views/issues/components/reply-input.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useRef, useState, useCallback, useEffect } from "react";
-import { ContentEditor, type ContentEditorRef, useFileDropZone, FileDropOverlay } from "../../editor";
+import { ContentEditor, type ContentEditorRef, useFileDropZone, FileDropOverlay, useLazyEditor } from "../../editor";
 import { FileUploadButton } from "@multica/ui/components/common/file-upload-button";
 import { SubmitButton } from "@multica/ui/components/common/submit-button";
 import { ActorAvatar } from "../../common/actor-avatar";
@@ -71,8 +71,17 @@ function ReplyInput({
   // rationale (drives both submit-time attachment_ids and editor previews).
   const [pendingAttachments, setPendingAttachments] = useState<Attachment[]>([]);
   const { uploadWithToast } = useFileUpload(api);
+  // Readonly-first: static shell until intent; an unsent draft mounts the
+  // real editor immediately (see CommentInput). This is also what keeps the
+  // reply box working across Virtuoso scroll-out — a typed draft rehydrates
+  // into a live editor when the card remounts, an untouched box folds back
+  // to the shell.
+  const lazy = useLazyEditor({
+    initialActive: !!initialDraft?.trim(),
+    editorRef,
+  });
   const { isDragOver, dropZoneProps } = useFileDropZone({
-    onDrop: (files) => files.forEach((f) => editorRef.current?.uploadFile(f)),
+    onDrop: lazy.uploadOrQueue,
   });
 
   // Flush on tab close / mobile background — same rationale as CommentInput.
@@ -172,16 +181,19 @@ function ReplyInput({
         )}
       >
         {/* Lock the editor while the reply is in flight — see CommentInput. */}
+        {lazy.active && (
         <div
           className={cn(
             "flex-1 min-h-0 overflow-y-auto",
             submitting && "pointer-events-none opacity-60",
+            !lazy.ready && "hidden",
           )}
           aria-busy={submitting || undefined}
         >
           <ContentEditor
             ref={editorRef}
             defaultValue={initialDraft}
+            onReady={lazy.onReady}
             placeholder={placeholderText}
             onUpdate={(md) => {
               setContent(md);
@@ -200,6 +212,29 @@ function ReplyInput({
             slashCommandMode="command"
           />
         </div>
+        )}
+        {/* Static shell — clones the empty single-line reply box (see
+            CommentInput for the pattern). */}
+        {!lazy.ready && (
+          <div
+            data-testid="reply-composer-shell"
+            role="button"
+            tabIndex={0}
+            aria-label={placeholderText}
+            className="flex-1 min-h-0 cursor-text rich-text-editor text-sm"
+            onClick={() => lazy.activate()}
+            onKeyDown={(e) => {
+              if (e.key === "Enter" || e.key === " ") {
+                e.preventDefault();
+                lazy.activate();
+              }
+            }}
+          >
+            {/* <p> under rich-text-editor: same type metrics as the real
+                editor's empty paragraph — no height jump on swap. */}
+            <p className="text-muted-foreground">{placeholderText}</p>
+          </div>
+        )}
         <div className="absolute bottom-0 left-0 right-24 min-w-0">
           <CommentTriggerChips
             agents={triggerPreview.agents}
@@ -211,7 +246,7 @@ function ReplyInput({
           <FileUploadButton
             size="sm"
             multiple
-            onSelect={(file) => editorRef.current?.uploadFile(file)}
+            onSelect={(file) => lazy.uploadOrQueue([file])}
           />
           <SubmitButton
             onClick={handleSubmit}


### PR DESCRIPTION
## Problem

Opening an issue synchronously instantiated 2–4 Tiptap editors — title, description, bottom comment composer, and one reply box per open thread — at **70–460ms each**, freezing the click for 0.4–1.5s. Worst measured case: a 22k-char description froze the main thread for **1518ms** on every open, even for read-only visits.

Diagnosed with long-task observation + React Profiler bucketing on the desktop app: React render phase accounted for only 150–250ms; the bulk was Tiptap instantiation in the effect phase, scaling linearly with editor count.

## Fix

Editors render as static stand-ins until the user shows edit intent (readonly-first):

- **`useLazyEditor`** (new): shared controller for the pattern — activate on click/keyboard/file-drop, mount the editor hidden, swap on `onReady`, land the caret at the clicked coordinates via `focusAtCoords`, flush uploads queued against the stand-in.
- **Description**: renders `ReadonlyContent` (same `rich-text-editor` stylesheet → visually seamless swap). Clicking the text mounts the editor and places the caret where you clicked.
- **Title**: static line; click to edit, caret at click point (`TitleEditor` gains `onReady` + `focusAtCoords` to match `ContentEditorRef`).
- **Comment / reply composers**: same-looking shells sharing the editor's type metrics (line-height 1.625 from prose.css), so the swap never shifts layout. Keyboard-accessible (Enter/Space).
- **Draft gate**: an unsent draft mounts the real editor immediately — a draft is standing edit intent. This also keeps reply boxes rehydrating across Virtuoso scroll-out exactly as before.

## Measured result (desktop, test env)

| Metric | Before | After |
| --- | --- | --- |
| Click long task | 1518ms (heavy issue) / 0.4–1.3s (typical) | **150–350ms** |
| Editors created per open | 2–4 | **0** |
| Fastest first frame | ~2.2s | **144ms** |

## Tests

- `pnpm typecheck` ✅
- `packages/views` full vitest suite: 186 files / 1929 tests ✅
- Updated e2e (`comments.spec.ts`) to activate the composer shell before locating ProseMirror; added zero-editor-on-open assertions in `issue-detail.test.tsx`; composer tests activate shells the way a user does, with draft-store isolation in `beforeEach`.

## Follow-ups (tracked, not in this PR)

- Restore Virtuoso for inbox deep-links (flat timeline render is now the largest remaining item, 130–286ms).
- Batch/cache `MUL-XXXX` identifier searches; skip `highlightAuto` for unfenced code blocks.
- `project-detail` title editor has the same always-mounted pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)