### PR TITLE
fix(autopilot): retry scheduled dispatch when runtime offline

### DIFF
--- a/server/cmd/server/autopilot_offline_retry_test.go
+++ b/server/cmd/server/autopilot_offline_retry_test.go
@@ -1,0 +1,125 @@
+package main
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/multica-ai/multica/server/internal/events"
+	"github.com/multica-ai/multica/server/internal/service"
+	db "github.com/multica-ai/multica/server/pkg/db/generated"
+)
+
+func TestScheduledAutopilotOfflineRuntimeRetryContract(t *testing.T) {
+	ctx := context.Background()
+	queries := db.New(testPool)
+	bus := events.New()
+	taskSvc := service.NewTaskService(queries, testPool, nil, bus)
+	svc := service.NewAutopilotService(queries, testPool, bus, taskSvc)
+
+	var agentID, runtimeID string
+	if err := testPool.QueryRow(ctx, `
+		SELECT a.id::text, a.runtime_id::text
+		  FROM agent a
+		 WHERE a.workspace_id = $1 AND a.runtime_id IS NOT NULL
+		 ORDER BY a.created_at ASC LIMIT 1`, testWorkspaceID).Scan(&agentID, &runtimeID); err != nil {
+		t.Fatalf("load fixture agent/runtime: %v", err)
+	}
+	var originalStatus string
+	if err := testPool.QueryRow(ctx, `SELECT status FROM agent_runtime WHERE id = $1`, runtimeID).Scan(&originalStatus); err != nil {
+		t.Fatalf("load runtime status: %v", err)
+	}
+	setStatus := func(status string) {
+		t.Helper()
+		if _, err := testPool.Exec(ctx, `UPDATE agent_runtime SET status = $1 WHERE id = $2`, status, runtimeID); err != nil {
+			t.Fatalf("set runtime %s: %v", status, err)
+		}
+	}
+	t.Cleanup(func() {
+		_, _ = testPool.Exec(context.Background(), `UPDATE agent_runtime SET status = $1 WHERE id = $2`, originalStatus, runtimeID)
+	})
+
+	createAP := func(assigneeType string, assigneeID pgtype.UUID) (db.Autopilot, db.AutopilotTrigger) {
+		t.Helper()
+		ap, err := queries.CreateAutopilot(ctx, db.CreateAutopilotParams{
+			WorkspaceID: parseUUID(testWorkspaceID), Title: "offline retry contract",
+			AssigneeType: assigneeType, AssigneeID: assigneeID, Status: "active",
+			ExecutionMode: "run_only", CreatedByType: "member", CreatedByID: parseUUID(testUserID),
+		})
+		if err != nil {
+			t.Fatalf("CreateAutopilot: %v", err)
+		}
+		trigger, err := queries.CreateAutopilotTrigger(ctx, db.CreateAutopilotTriggerParams{
+			AutopilotID: ap.ID, Kind: "schedule", Enabled: true,
+			CronExpression: pgtype.Text{String: "*/5 * * * *", Valid: true},
+			Timezone:       pgtype.Text{String: "UTC", Valid: true},
+		})
+		if err != nil {
+			t.Fatalf("CreateAutopilotTrigger: %v", err)
+		}
+		t.Cleanup(func() { _, _ = testPool.Exec(context.Background(), `DELETE FROM autopilot WHERE id = $1`, ap.ID) })
+		return ap, trigger
+	}
+
+	agentAP, agentTrigger := createAP("agent", parseUUID(agentID))
+	plan := time.Now().UTC().Truncate(time.Second).Add(-time.Minute)
+	setStatus("offline")
+	if run, err := svc.DispatchAutopilotForPlanAttempt(ctx, agentAP, agentTrigger.ID, "schedule", nil, plan, true); err == nil || run != nil {
+		t.Fatalf("temporary offline must return retryable error without run: run=%v err=%v", run, err)
+	}
+	var count int
+	_ = testPool.QueryRow(ctx, `SELECT count(*) FROM autopilot_run WHERE trigger_id=$1`, agentTrigger.ID).Scan(&count)
+	if count != 0 {
+		t.Fatalf("offline retry attempt created %d runs, want 0", count)
+	}
+
+	setStatus("online")
+	run, err := svc.DispatchAutopilotForPlanAttempt(ctx, agentAP, agentTrigger.ID, "schedule", nil, plan, true)
+	if err != nil || run == nil || !run.TaskID.Valid {
+		t.Fatalf("online retry did not dispatch: run=%v err=%v", run, err)
+	}
+
+	persistentPlan := plan.Add(5 * time.Minute)
+	setStatus("offline")
+	for attempt := 1; attempt < 3; attempt++ {
+		if run, err = svc.DispatchAutopilotForPlanAttempt(ctx, agentAP, agentTrigger.ID, "schedule", nil, persistentPlan, true); err == nil || run != nil {
+			t.Fatalf("offline attempt %d must retry: run=%v err=%v", attempt, run, err)
+		}
+	}
+	run, err = svc.DispatchAutopilotForPlanAttempt(ctx, agentAP, agentTrigger.ID, "schedule", nil, persistentPlan, false)
+	if err != nil || run == nil || run.Status != "skipped" || !strings.Contains(run.FailureReason.String, "offline at dispatch time") {
+		t.Fatalf("final offline attempt must persist terminal reason: run=%v err=%v", run, err)
+	}
+	duplicate, err := svc.DispatchAutopilotForPlanAttempt(ctx, agentAP, agentTrigger.ID, "schedule", nil, persistentPlan, false)
+	if err != nil || duplicate.ID != run.ID {
+		t.Fatalf("duplicate plan did not reuse run: duplicate=%v err=%v", duplicate, err)
+	}
+	_ = testPool.QueryRow(ctx, `SELECT count(*) FROM autopilot_run WHERE trigger_id=$1 AND planned_at=$2`, agentTrigger.ID, persistentPlan).Scan(&count)
+	if count != 1 {
+		t.Fatalf("duplicate plan created %d runs, want 1", count)
+	}
+
+	squad, err := queries.CreateSquad(ctx, db.CreateSquadParams{
+		WorkspaceID: parseUUID(testWorkspaceID), Name: "offline retry squad", LeaderID: parseUUID(agentID), CreatorID: parseUUID(testUserID),
+	})
+	if err != nil {
+		t.Fatalf("CreateSquad: %v", err)
+	}
+	t.Cleanup(func() { _, _ = testPool.Exec(context.Background(), `DELETE FROM squad WHERE id=$1`, squad.ID) })
+	squadAP, squadTrigger := createAP("squad", squad.ID)
+	squadPlan := persistentPlan.Add(5 * time.Minute)
+	if run, err = svc.DispatchAutopilotForPlanAttempt(ctx, squadAP, squadTrigger.ID, "schedule", nil, squadPlan, true); err == nil || run != nil || !strings.Contains(err.Error(), "offline") {
+		t.Fatalf("offline squad leader must retry: run=%v err=%v", run, err)
+	}
+	setStatus("online")
+	run, err = svc.DispatchAutopilotForPlanAttempt(ctx, squadAP, squadTrigger.ID, "schedule", nil, squadPlan, true)
+	if err != nil || run == nil || !run.TaskID.Valid || !run.SquadID.Valid || run.SquadID != squad.ID {
+		t.Fatalf("squad retry did not dispatch to attributed leader: run=%v err=%v", run, err)
+	}
+	var taskAgent pgtype.UUID
+	if err := testPool.QueryRow(ctx, `SELECT agent_id FROM agent_task_queue WHERE id=$1`, run.TaskID).Scan(&taskAgent); err != nil || taskAgent != parseUUID(agentID) {
+		t.Fatalf("squad task agent mismatch: got=%v err=%v", taskAgent, err)
+	}
+}

--- a/server/cmd/server/autopilot_offline_retry_test.go
+++ b/server/cmd/server/autopilot_offline_retry_test.go
@@ -83,10 +83,8 @@ func TestScheduledAutopilotOfflineRuntimeRetryContract(t *testing.T) {
 
 	persistentPlan := plan.Add(5 * time.Minute)
 	setStatus("offline")
-	for attempt := 1; attempt < 3; attempt++ {
-		if run, err = svc.DispatchAutopilotForPlanAttempt(ctx, agentAP, agentTrigger.ID, "schedule", nil, persistentPlan, true); err == nil || run != nil {
-			t.Fatalf("offline attempt %d must retry: run=%v err=%v", attempt, run, err)
-		}
+	if run, err = svc.DispatchAutopilotForPlanAttempt(ctx, agentAP, agentTrigger.ID, "schedule", nil, persistentPlan, true); err == nil || run != nil {
+		t.Fatalf("first offline attempt must retry: run=%v err=%v", run, err)
 	}
 	run, err = svc.DispatchAutopilotForPlanAttempt(ctx, agentAP, agentTrigger.ID, "schedule", nil, persistentPlan, false)
 	if err != nil || run == nil || run.Status != "skipped" || !strings.Contains(run.FailureReason.String, "offline at dispatch time") {

--- a/server/internal/scheduler/jobs_autopilot.go
+++ b/server/internal/scheduler/jobs_autopilot.go
@@ -52,6 +52,18 @@ type AutopilotScheduleDispatcher interface {
 	) (*db.AutopilotRun, error)
 }
 
+type autopilotAttemptDispatcher interface {
+	DispatchAutopilotForPlanAttempt(
+		ctx context.Context,
+		autopilot db.Autopilot,
+		triggerID pgtype.UUID,
+		source string,
+		payload []byte,
+		plannedAt time.Time,
+		retryBudgetRemaining bool,
+	) (*db.AutopilotRun, error)
+}
+
 // AutopilotScheduleDispatchJob returns the JobSpec that drives
 // scheduled Autopilot dispatch through the existing scheduler +
 // sys_cron_executions lease infrastructure. Replaces the legacy
@@ -370,9 +382,17 @@ func autopilotHandler(
 			}}, nil
 		}
 
-		run, err := dispatcher.DispatchAutopilotForPlan(
-			ctx, autopilot, trigger.ID, "schedule", nil, in.PlanTime,
-		)
+		var run *db.AutopilotRun
+		if attemptDispatcher, ok := dispatcher.(autopilotAttemptDispatcher); ok {
+			run, err = attemptDispatcher.DispatchAutopilotForPlanAttempt(
+				ctx, autopilot, trigger.ID, "schedule", nil, in.PlanTime,
+				in.Attempt < in.Job.MaxAttempts,
+			)
+		} else {
+			run, err = dispatcher.DispatchAutopilotForPlan(
+				ctx, autopilot, trigger.ID, "schedule", nil, in.PlanTime,
+			)
+		}
 		if err != nil {
 			return HandlerResult{}, fmt.Errorf("dispatch for plan: %w", err)
 		}

--- a/server/internal/scheduler/jobs_autopilot.go
+++ b/server/internal/scheduler/jobs_autopilot.go
@@ -37,6 +37,12 @@ const DefaultAutopilotScheduleTimezone = "UTC"
 // time.
 const maxAutopilotScheduleLateness = 5 * time.Minute
 
+// autopilotScheduleOfflineRetryDelay is the only retry delay for scheduled
+// Autopilots. MaxAttempts=2 below means one initial attempt plus this one
+// retry; keeping the delay separate makes the high-frequency cron impact
+// explicit and prevents a later generic backoff from silently widening it.
+const autopilotScheduleOfflineRetryDelay = time.Minute
+
 // AutopilotScheduleDispatcher is the narrow contract this job needs
 // from service.AutopilotService. Defined here so unit tests in this
 // package (and the cmd/server integration tests) can stub it without
@@ -115,11 +121,9 @@ func AutopilotScheduleDispatchJob(
 		StaleTimeout:      5 * time.Minute,
 		HeartbeatInterval: 30 * time.Second,
 		AllowStaleReentry: true,
-		MaxAttempts:       3,
+		MaxAttempts:       2,
 		RetryBackoff: []time.Duration{
-			1 * time.Minute,
-			5 * time.Minute,
-			15 * time.Minute,
+			autopilotScheduleOfflineRetryDelay,
 		},
 		// Belt-and-suspenders: 5 plan_times is more than CatchUpLatestOnly
 		// ever needs; the cap matters only if a future caller flips the
@@ -266,6 +270,16 @@ func autopilotPlansForScope(cache *autopilotScheduleCache) func(
 		// MUST surface it here — moving forward to a newer occurrence
 		// would strand the FAILED row at attempt < max_attempts
 		// forever and leak the missed dispatch.
+		//
+		// This check intentionally precedes the five-minute lateness
+		// gate below. The gate admits new occurrences; once admitted, a
+		// failed occurrence keeps its single one-minute retry even when
+		// that makes plan_time older than five minutes. At the edge of
+		// the admission window the retry becomes eligible about six
+		// minutes after plan_time. Its claim can be later after scheduler
+		// downtime because retry eligibility is deliberately durable.
+		// After attempt 2 is exhausted, minute-frequency crons resume at
+		// the latest due occurrence instead of pinning this cursor.
 		if latest.RetryEligible(now) {
 			return []time.Time{latest.PlanTime}, nil
 		}

--- a/server/internal/scheduler/jobs_autopilot_test.go
+++ b/server/internal/scheduler/jobs_autopilot_test.go
@@ -1,9 +1,79 @@
 package scheduler
 
 import (
+	"context"
 	"testing"
 	"time"
 )
+
+func TestAutopilotScheduleOfflineRetryWindow(t *testing.T) {
+	job := AutopilotScheduleDispatchJob(nil, nil, nil)
+
+	if job.MaxAttempts != 2 {
+		t.Fatalf("scheduled autopilot must have one initial attempt plus one retry; got MaxAttempts=%d", job.MaxAttempts)
+	}
+	if len(job.RetryBackoff) != 1 || job.RetryBackoff[0] != time.Minute {
+		t.Fatalf("scheduled autopilot retry backoff must be exactly [1m]; got %v", job.RetryBackoff)
+	}
+
+	// A new occurrence may be admitted up to five minutes late. If that
+	// edge attempt fails immediately, the single retry becomes eligible one
+	// minute later. This six-minute value is the configured effective
+	// lateness under the full chain; planner/tick downtime can delay the
+	// durable retry further, as covered by the exemption test below.
+	if got, want := maxAutopilotScheduleLateness+job.RetryBackoff[0], 6*time.Minute; got != want {
+		t.Fatalf("maximum configured retry lateness=%s want %s", got, want)
+	}
+}
+
+func TestAutopilotScheduleMinuteCronRetryExemptionAndRecovery(t *testing.T) {
+	planTime := time.Date(2026, 8, 12, 12, 0, 0, 0, time.UTC)
+	retryAt := planTime.Add(6 * time.Minute)
+	scope := Scope{Kind: ScopeKindAutopilotTrigger, ID: "minute-trigger"}
+	cache := newAutopilotScheduleCache()
+	cache.replace(map[string]autopilotTriggerConfig{
+		scope.ID: {
+			TriggerID:      scope.ID,
+			CronExpression: "* * * * *",
+			Timezone:       "UTC",
+			CreatedAt:      planTime.Add(-time.Minute),
+		},
+	})
+	plansForScope := autopilotPlansForScope(cache)
+	latest := LatestPlanInfo{
+		Found:       true,
+		PlanTime:    planTime,
+		Status:      "FAILED",
+		Attempt:     1,
+		MaxAttempts: 2,
+		NextRetryAt: retryAt,
+	}
+
+	// RetryEligible intentionally wins before the five-minute lateness
+	// gate, preserving the one admitted occurrence through its final try.
+	plans, err := plansForScope(context.Background(), scope, retryAt, latest)
+	if err != nil {
+		t.Fatalf("plan retry: %v", err)
+	}
+	if len(plans) != 1 || !plans[0].Equal(planTime) {
+		t.Fatalf("retry must keep original plan_time %s; got %v", planTime, plans)
+	}
+	if !isAutopilotSchedulePlanStale(retryAt, plans[0]) {
+		t.Fatal("test setup must exercise the retry exemption beyond the normal lateness gate")
+	}
+
+	// Once the second (final) attempt is exhausted, the old plan no longer
+	// pins a high-frequency cursor. Latest-only catch-up collapses all minute
+	// occurrences missed during the retry window to the current one.
+	latest.Attempt = latest.MaxAttempts
+	plans, err = plansForScope(context.Background(), scope, retryAt, latest)
+	if err != nil {
+		t.Fatalf("plan after retry exhaustion: %v", err)
+	}
+	if len(plans) != 1 || !plans[0].Equal(retryAt) {
+		t.Fatalf("exhausted retry must advance minute cron to latest occurrence %s; got %v", retryAt, plans)
+	}
+}
 
 // TestAdvancedNextRunStrictlyAfterPlanTime is the regression guard for
 // MUL-3749's boundary case: the post-dispatch next_run_at write-back must

--- a/server/internal/service/autopilot.go
+++ b/server/internal/service/autopilot.go
@@ -361,6 +361,24 @@ func (s *AutopilotService) DispatchAutopilotForPlan(
 	payload []byte,
 	plannedAt time.Time,
 ) (*db.AutopilotRun, error) {
+	return s.DispatchAutopilotForPlanAttempt(ctx, autopilot, triggerID, source, payload, plannedAt, false)
+}
+
+// DispatchAutopilotForPlanAttempt adds scheduler-attempt awareness to
+// DispatchAutopilotForPlan. A scheduled run_only dispatch whose runtime is
+// temporarily offline returns a retryable error before creating a run while
+// retryBudgetRemaining is true. The scheduler's bounded retry/backoff then
+// re-enters with the same (trigger_id, planned_at). On the final attempt the
+// normal admission path persists an explicit terminal skipped run/reason.
+func (s *AutopilotService) DispatchAutopilotForPlanAttempt(
+	ctx context.Context,
+	autopilot db.Autopilot,
+	triggerID pgtype.UUID,
+	source string,
+	payload []byte,
+	plannedAt time.Time,
+	retryBudgetRemaining bool,
+) (*db.AutopilotRun, error) {
 	if !triggerID.Valid {
 		return nil, fmt.Errorf("dispatch for plan: trigger_id is required")
 	}
@@ -406,11 +424,26 @@ func (s *AutopilotService) DispatchAutopilotForPlan(
 		return nil, fmt.Errorf("dispatch for plan: lookup existing run: %w", err)
 	}
 
+	if retryBudgetRemaining && autopilot.ExecutionMode == "run_only" {
+		if reason, _, skip := s.shouldSkipDispatch(ctx, autopilot, pgtype.UUID{}); skip && isRetryableRuntimeAdmission(reason) {
+			return nil, &errAutopilotRuntimeUnavailable{reason: reason}
+		}
+	}
+
 	// Scheduled dispatch has no member actor → rule_owner attribution, and no
 	// human surface for a per-run reason code, so it is dropped. No webhook
 	// delivery on the scheduled-plan path.
 	run, _, err := s.dispatchAutopilot(ctx, autopilot, triggerID, source, payload, plannedTS, pgtype.UUID{}, pgtype.UUID{})
 	return run, err
+}
+
+type errAutopilotRuntimeUnavailable struct{ reason string }
+
+func (e *errAutopilotRuntimeUnavailable) Error() string { return e.reason }
+
+func isRetryableRuntimeAdmission(reason string) bool {
+	return strings.Contains(reason, "runtime is offline at dispatch time") ||
+		strings.Contains(reason, "runtime is stale at dispatch time")
 }
 
 // isAutopilotRunComplete decides whether an existing autopilot_run row

--- a/server/internal/service/autopilot.go
+++ b/server/internal/service/autopilot.go
@@ -367,9 +367,10 @@ func (s *AutopilotService) DispatchAutopilotForPlan(
 // DispatchAutopilotForPlanAttempt adds scheduler-attempt awareness to
 // DispatchAutopilotForPlan. A scheduled run_only dispatch whose runtime is
 // temporarily offline returns a retryable error before creating a run while
-// retryBudgetRemaining is true. The scheduler's bounded retry/backoff then
-// re-enters with the same (trigger_id, planned_at). On the final attempt the
-// normal admission path persists an explicit terminal skipped run/reason.
+// retryBudgetRemaining is true. The scheduled job permits exactly one retry,
+// one minute later, and re-enters with the same (trigger_id, planned_at). On
+// the final attempt the normal admission path persists an explicit terminal
+// skipped run/reason.
 func (s *AutopilotService) DispatchAutopilotForPlanAttempt(
 	ctx context.Context,
 	autopilot db.Autopilot,

--- a/server/internal/service/autopilot_squad_test.go
+++ b/server/internal/service/autopilot_squad_test.go
@@ -59,6 +59,24 @@ func TestFormatAdmissionReason(t *testing.T) {
 	}
 }
 
+func TestIsRetryableRuntimeAdmission(t *testing.T) {
+	tests := []struct {
+		reason string
+		want   bool
+	}{
+		{"agent runtime is offline at dispatch time", true},
+		{"agent runtime is stale at dispatch time", true},
+		{"squad leader runtime is offline at dispatch time", true},
+		{"assignee agent has no runtime bound", false},
+		{"assignee agent is archived", false},
+	}
+	for _, tc := range tests {
+		if got := isRetryableRuntimeAdmission(tc.reason); got != tc.want {
+			t.Errorf("isRetryableRuntimeAdmission(%q)=%v want %v", tc.reason, got, tc.want)
+		}
+	}
+}
+
 // errDispatchSkipped must be distinguishable via errors.As from a wrapped
 // fmt.Errorf, otherwise DispatchAutopilot's failure-vs-skip switch will treat
 // it as a generic failure and the manual-trigger handler will 500. Locks in


### PR DESCRIPTION
## Summary

- retry scheduled `run_only` dispatch once after 1 minute when runtime is offline/stale
- persist explicit terminal `skipped` run/reason when that retry is exhausted
- preserve occurrence idempotency, squad-to-leader routing, and manual/API/`create_issue`/webhook behavior

## Bounded coverage

This is short-blip recovery, not arbitrary catch-up. Each occurrence gets one initial attempt plus one retry after 1 minute (`MaxAttempts=2`, `RetryBackoff=[1m]`). A runtime offline beyond that retry still produces a terminal `skipped` run with the admission reason. The retry is durable and intentionally exempt from the 5-minute new-occurrence lateness gate; an occurrence first admitted at the edge of that gate can retry about 6 minutes after `plan_time`.

The single retry bounds cursor pinning for high-frequency schedules. For `* * * * *`, exhaustion releases the failed occurrence on attempt 2 and latest-only catch-up advances to the newest due minute instead of pinning the cursor for the previous ~6-minute backoff chain.

## Root cause

`shouldSkipDispatch` returned a successful terminal `skipped` result for offline runtime admission. Scheduler therefore marked `sys_cron_executions` successful and never used its retry machinery.

## Tests

- temporary offline → retry without run → online dispatch
- permanently offline → terminal skipped reason on final attempt
- exact `[1m]` retry window and explicit lateness exemption
- minute-level cron releases cursor after retry exhaustion
- duplicate `(trigger_id, planned_at)` prevention
- squad → leader retry and task attribution
- manual, `create_issue`, and webhook preservation regressions
- focused scheduler/service/cmd/server/handler suites and `git diff --check`

## Rollout / rollback

Normal server rollout; no migration or config change. Observe `sys_cron_executions` failed attempt with `next_retry_at`, then final `autopilot_run.status=skipped` plus `failure_reason` if runtime remains unavailable. Rollback by reverting this PR; legacy immediate-skip behavior returns.

Multica issue: KAP-833
