### PR TITLE
fix(comment): strip PG-unstorable bytes from comment content (MUL-4529, GH #5388)

### DIFF
--- a/server/internal/handler/comment.go
+++ b/server/internal/handler/comment.go
@@ -1139,7 +1139,13 @@ func (h *Handler) PreviewCommentTriggers(w http.ResponseWriter, r *http.Request)
 		parentComment = &parent
 	}
 
-	content := req.Content
+	// Normalize with the SAME entry point CreateComment/UpdateComment apply
+	// before persisting (sanitizeNullBytes), so the preview computes triggers on
+	// the exact content that will be stored and enqueued on submit. Otherwise a
+	// mention hidden behind a byte the DB strips (e.g. a NUL inside
+	// mention://agent/<uuid>) reads as inert in preview but enqueues the agent on
+	// submit — a preview/side-effect divergence (GH #5388 review).
+	content := sanitizeNullBytes(req.Content)
 	if content == "" {
 		writeJSON(w, http.StatusOK, CommentTriggerPreviewResponse{Agents: []CommentTriggerAgentResponse{}})
 		return
@@ -1200,6 +1206,15 @@ func (h *Handler) CreateComment(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Strip bytes PostgreSQL's TEXT column rejects before the empty check. The
+	// case reachable over the JSON API is an embedded NUL (0x00, SQLSTATE
+	// 22021) that survives a JSON round trip; sanitizeNullBytes also drops
+	// invalid UTF-8 as defense-in-depth. A stray such byte in agent-written
+	// content (notably via --content-file) otherwise fails the INSERT with an
+	// opaque 500 the CLI renders as "server unavailable" and retries forever —
+	// the plausible cause of GH #5388. Mirrors the skill-import sanitization;
+	// normalizing first means all-NUL content is correctly treated as empty.
+	req.Content = sanitizeNullBytes(req.Content)
 	if req.Content == "" {
 		writeError(w, http.StatusBadRequest, "content is required")
 		return
@@ -2054,6 +2069,10 @@ func (h *Handler) UpdateComment(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusBadRequest, "invalid request body")
 		return
 	}
+	// See CreateComment: strip NUL / invalid-UTF-8 bytes PostgreSQL's TEXT column
+	// rejects before the empty check, so an edit that introduces such a byte
+	// can't 500 (GH #5388).
+	req.Content = sanitizeNullBytes(req.Content)
 	if req.Content == "" {
 		writeError(w, http.StatusBadRequest, "content is required")
 		return

--- a/server/internal/handler/comment_content_sanitize_test.go
+++ b/server/internal/handler/comment_content_sanitize_test.go
@@ -1,0 +1,116 @@
+package handler
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/multica-ai/multica/server/internal/util"
+)
+
+// TestCreateComment_StripsNullBytesInsteadOf500 pins the fix for GH #5388.
+//
+// A comment whose content carries a byte PostgreSQL's TEXT type cannot store —
+// most commonly an embedded NUL (SQLSTATE 22021) that survives a JSON round
+// trip from `--content-file` — must post successfully with the offending byte
+// stripped, not fail the INSERT with an opaque 500 the CLI renders as a
+// generic "server unavailable" (and then retries forever).
+func TestCreateComment_StripsNullBytesInsteadOf500(t *testing.T) {
+	if testHandler == nil || testPool == nil {
+		t.Skip("database not available")
+	}
+
+	issueID := createTestIssue(t, "null-byte comment fixture (GH #5388)", "todo", "medium")
+	t.Cleanup(func() { deleteTestIssue(t, issueID) })
+
+	w := httptest.NewRecorder()
+	r := newRequest("POST", "/api/issues/"+issueID+"/comments", map[string]any{
+		"content": "diagnosis body\x00 with a stray NUL byte",
+	})
+	r = withURLParam(r, "id", issueID)
+
+	testHandler.CreateComment(w, r)
+	if w.Code != http.StatusCreated {
+		t.Fatalf("CreateComment with NUL byte: expected 201, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var body map[string]any
+	if err := json.NewDecoder(w.Body).Decode(&body); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	got, _ := body["content"].(string)
+	if strings.ContainsRune(got, '\x00') {
+		t.Fatalf("stored content still contains a NUL byte: %q", got)
+	}
+	if want := "diagnosis body with a stray NUL byte"; got != want {
+		t.Fatalf("stored content: expected %q (NUL stripped), got %q", want, got)
+	}
+}
+
+// TestCommentTriggers_NullByteHiddenMention_PreviewMatchesEnqueue guards the
+// preview/side-effect divergence raised in review of the #5388 fix.
+//
+// CreateComment/UpdateComment sanitize content (strip NUL) before storing and
+// triggering, so a mention hidden behind a NUL — valid only AFTER the byte is
+// stripped — would enqueue an agent. PreviewCommentTriggers must sanitize with
+// the same entry point, or it would report an empty target set while submit
+// silently enqueues the agent. This pins parity for both the create and edit
+// paths (the fix touches both).
+func TestCommentTriggers_NullByteHiddenMention_PreviewMatchesEnqueue(t *testing.T) {
+	if testHandler == nil || testPool == nil {
+		t.Skip("database not available")
+	}
+
+	issueID := createCommentTriggerPreviewIssue(t, "NUL-hidden mention parity (GH #5388 review)", "", "")
+	// Distinct agents for create vs edit: a single (issue, agent) pair allows
+	// only one pending task (idx_one_pending_task_per_issue_agent), which would
+	// mask the second enqueue.
+	createTarget := createHandlerTestAgent(t, "Preview NUL Parity Create", nil)
+	editTarget := createHandlerTestAgent(t, "Preview NUL Parity Edit", nil)
+
+	// mentionWithHiddenNull places the NUL between the agent UUID and the
+	// closing ')', so MentionRe does not match the raw text but does match once
+	// the byte is stripped.
+	mentionWithHiddenNull := func(agentID string) string {
+		return fmt.Sprintf("please take a look [@Target](mention://agent/%s\x00)", agentID)
+	}
+	previewAgentIDs := func(resp CommentTriggerPreviewResponse) map[string]bool {
+		ids := make(map[string]bool, len(resp.Agents))
+		for _, a := range resp.Agents {
+			ids[a.ID] = true
+		}
+		return ids
+	}
+
+	// --- create path ---
+	createContent := mentionWithHiddenNull(createTarget)
+	if n := len(util.ParseMentions(createContent)); n != 0 {
+		t.Fatalf("precondition: raw NUL content should not parse as a mention, got %d", n)
+	}
+	preview := previewCommentTriggersForTest(t, issueID, map[string]any{"content": createContent})
+	if ids := previewAgentIDs(preview); len(ids) != 1 || !ids[createTarget] {
+		t.Fatalf("create preview targets = %v, want exactly {%s}", ids, createTarget)
+	}
+	postCommentForTriggerPreviewTest(t, issueID, map[string]any{"content": createContent})
+	if got := countQueuedCommentTriggerTasks(t, issueID, createTarget); got != 1 {
+		t.Fatalf("create enqueued %d tasks for the mentioned agent, want 1 (parity with preview)", got)
+	}
+
+	// --- edit path ---
+	editContent := mentionWithHiddenNull(editTarget)
+	plainID := postCommentForTriggerPreviewTest(t, issueID, map[string]any{"content": "no mentions here yet"})
+	editPreview := previewCommentTriggersForTest(t, issueID, map[string]any{
+		"content":            editContent,
+		"editing_comment_id": plainID,
+	})
+	if ids := previewAgentIDs(editPreview); len(ids) != 1 || !ids[editTarget] {
+		t.Fatalf("edit preview targets = %v, want exactly {%s}", ids, editTarget)
+	}
+	updateCommentForTriggerPreviewTest(t, plainID, map[string]any{"content": editContent})
+	if got := countQueuedCommentTriggerTasks(t, issueID, editTarget); got != 1 {
+		t.Fatalf("edit enqueued %d tasks for the mentioned agent, want 1 (parity with preview)", got)
+	}
+}


### PR DESCRIPTION
## Summary

`multica issue comment add --content-file` on a large, agent-written body failed with a repeated server error (reported in #5388), while a heredoc body via `--content-stdin` worked. This PR hardens comment creation against the most likely cause and keeps the trigger preview consistent with the real side effect.

Note: this is a **defensive fix for a plausible cause**, not a confirmed fix for the reporter's exact bytes. The report varies size and input source at the same time, so #5388 stays open pending `--debug`/log confirmation.

## Root cause (most likely)

`--content-file` and `--content-stdin` build a byte-identical request, so size or the input branch alone can't explain the difference. The reachable culprit over the JSON API is a byte PostgreSQL's `TEXT` column can't store — an embedded NUL (`\x00`, SQLSTATE `22021`) — that survives a JSON round trip via `--content-file` but is dropped by the shell on the heredoc path (which would explain why `--content-stdin` succeeded). The failing `INSERT` returns a generic 500 the CLI renders as "server unavailable" and retries.

(Invalid UTF-8 is *not* a live path here: JSON must be UTF-8 and Go's encoder replaces invalid sequences with U+FFFD before they reach the server. `sanitizeNullBytes` still drops them as defense-in-depth.)

The codebase already ships `sanitizeNullBytes()` in `server/internal/handler/skill.go`, whose doc comment documents this exact PG failure — it is applied on the skill-import path but not on comments.

## Changes

- Apply `sanitizeNullBytes()` to comment content before the empty check in `CreateComment` and `UpdateComment`.
- Apply the **same** normalization in `PreviewCommentTriggers`, so the trigger preview and the real create/update side effect agree. Without it, a mention hidden behind a NUL (invalid until the byte is stripped) reads as inert in preview but enqueues the agent on submit — a preview/side-effect divergence.

## Testing

- `TestCreateComment_StripsNullBytesInsteadOf500`: NUL content posts (201, byte stripped) instead of 500.
- `TestCommentTriggers_NullByteHiddenMention_PreviewMatchesEnqueue`: the preview target set equals the enqueue set for a NUL-hidden mention, on both the create and edit paths.
- Full `internal/handler` package green on a freshly-migrated database; `go build ./...`, `go vet`, and `gofmt` clean.

## Follow-up (not in this PR)

The CLI collapses every `>= 500` into a "retry later" message, which is what masked this deterministic content error. Surfacing the raw server body on 5xx is worth a separate change.

Refs #5388

