### PR TITLE
feat(agents): add access-scope column, filter, and bulk edit to agents list

### DIFF
--- a/docs/ideation/2026-07-14-agent-list-visibility-field-ideation.html
+++ b/docs/ideation/2026-07-14-agent-list-visibility-field-ideation.html
@@ -1,0 +1,205 @@
+<!DOCTYPE html>
+<html lang="zh-Hans">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Ideation: Agents 列表页 · 可见性/访问范围字段</title>
+<style>
+  :root {
+    --bg: #ffffff; --fg: #1a1a1a; --muted: #5b6470; --faint: #8a93a0;
+    --border: #e3e7ec; --surface: #f7f8fa; --accent: #2f6feb; --accent-soft: #eaf1fd;
+    --warn-soft: #fdf3e7; --warn-text: #9a6a1a; --good-soft: #eaf6ee; --good-text: #2a7a45;
+    --code-bg: #f2f4f7;
+  }
+  @media (prefers-color-scheme: dark) {
+    :root {
+      --bg: #14161a; --fg: #e7e9ee; --muted: #9aa3b0; --faint: #6b7480;
+      --border: #2a2f37; --surface: #1b1f25; --accent: #7aa2f7; --accent-soft: #1f2a3d;
+      --warn-soft: #3a2f1d; --warn-text: #d8a45a; --good-soft: #1d3a28; --good-text: #7fc594;
+      --code-bg: #20242b;
+    }
+  }
+  * { box-sizing: border-box; }
+  body {
+    margin: 0; background: var(--bg); color: var(--fg);
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "PingFang SC", "Hiragino Sans GB", "Microsoft YaHei", system-ui, sans-serif;
+    font-size: 15.5px; line-height: 1.65; -webkit-font-smoothing: antialiased;
+  }
+  .wrap { max-width: 880px; margin: 0 auto; padding: 48px 28px 96px; }
+  header.eyebrow { color: var(--faint); font-size: 12px; letter-spacing: 0.14em; text-transform: uppercase; margin-bottom: 8px; }
+  h1 { font-size: 30px; line-height: 1.25; margin: 0 0 6px; letter-spacing: -0.01em; }
+  .meta { color: var(--muted); font-size: 13.5px; margin: 0 0 8px; }
+  .meta code { font-size: 12.5px; }
+  h2 { font-size: 20px; margin: 44px 0 14px; padding-bottom: 8px; border-bottom: 1px solid var(--border); }
+  h3 { font-size: 17px; margin: 30px 0 4px; }
+  p { margin: 10px 0; }
+  code { background: var(--code-bg); padding: 1.5px 5px; border-radius: 4px; font-size: 13px; font-family: ui-monospace, "SF Mono", Menlo, Consolas, monospace; }
+  pre { background: var(--code-bg); padding: 12px 14px; border-radius: 8px; overflow-x: auto; }
+  ul, ol { padding-left: 22px; }
+  li { margin: 4px 0; }
+  a { color: var(--accent); }
+  strong { color: inherit; }
+  .axis-line { font-family: ui-monospace, Menlo, monospace; font-size: 13.5px; }
+  article.idea { border: 1px solid var(--border); border-radius: 10px; padding: 20px 22px; margin: 18px 0; background: var(--bg); }
+  article.idea > h3 { margin-top: 0; display: flex; align-items: baseline; gap: 10px; flex-wrap: wrap; }
+  .id-chip { font-family: ui-monospace, Menlo, monospace; font-size: 12px; background: var(--accent-soft); color: var(--accent); padding: 2px 8px; border-radius: 999px; }
+  .pill { font-family: ui-monospace, Menlo, monospace; font-size: 11.5px; padding: 2px 8px; border-radius: 999px; background: var(--surface); color: var(--muted); border: 1px solid var(--border); }
+  dl.fields { display: grid; grid-template-columns: 92px 1fr; gap: 4px 14px; margin: 12px 0 4px; }
+  dl.fields dt { color: var(--faint); font-size: 12.5px; letter-spacing: 0.04em; text-transform: uppercase; padding-top: 3px; }
+  dl.fields dd { margin: 0; font-size: 14.5px; }
+  .jumplist { display: flex; flex-wrap: wrap; gap: 8px; margin: 6px 0 2px; }
+  .jumplist a { font-size: 13px; }
+  table { border-collapse: collapse; width: 100%; font-size: 14px; margin: 8px 0; }
+  th, td { text-align: left; padding: 9px 12px; border-bottom: 1px solid var(--border); vertical-align: top; }
+  th { color: var(--muted); font-weight: 600; font-size: 12.5px; text-transform: uppercase; letter-spacing: 0.04em; }
+  .callout { background: var(--warn-soft); border-radius: 8px; padding: 12px 16px; margin: 14px 0; font-size: 14px; }
+  .callout .label { color: var(--warn-text); font-weight: 600; font-size: 12px; letter-spacing: 0.04em; text-transform: uppercase; display: block; margin-bottom: 4px; }
+  .diagram { background: var(--surface); border: 1px solid var(--border); border-radius: 10px; padding: 18px; margin: 16px 0; }
+  .diagram svg { display: block; margin: 0 auto; max-width: 100%; height: auto; }
+  .diagram figcaption { text-align: center; color: var(--muted); font-size: 12.5px; margin-top: 10px; }
+  footer.composition-signal { margin-top: 56px; padding-top: 16px; border-top: 1px solid var(--border); color: var(--faint); font-size: 12.5px; }
+  footer.composition-signal code { font-size: 12px; }
+</style>
+</head>
+<body>
+<div class="wrap">
+
+  <div class="eyebrow">Ideation · repo-grounded</div>
+  <h1>Agents 列表页：可见性 / 访问范围字段</h1>
+  <p class="meta">
+    <time datetime="2026-07-14">2026-07-14</time> ·
+    topic: <code>agent-list-visibility-field</code> ·
+    mode: <code>repo-grounded</code>（聚焦一轮：3 视角 / 4 存活）
+  </p>
+  <p class="meta">focus: 在 <code>agents</code> 列表页加一个"可见性范围"字段，是否更方便？</p>
+
+  <section id="grounding">
+    <h2>Grounding Context（代码库上下文）</h2>
+    <ul>
+      <li><strong>页面</strong>：<code>packages/views/agents/components/agents-page.tsx</code>（1209 行）。现有列：<em>agent / status / owner / runtime / last_active / runs / model / created</em>。<strong>没有</strong>可见性/访问列。<code>visibility</code> 仅在 :319 行算成 <code>isPrivate</code>，作行内小锁标记。</li>
+      <li><strong>列系统</strong>：<code>AgentColumnKey</code> + <code>COLUMN_WIDTHS</code>（:108）+ <code>hiddenColumns</code>/<code>toggleColumn</code>（<code>useAgentsViewStore</code>）。<u>加一列是机械工作</u>。</li>
+      <li><strong>权限模型——两个独立概念（核心）</strong>：<code>visibility</code>（private|workspace，谁能<em>看见</em>，<code>canAccessPrivateAgent</code> agent_access.go:120）是<strong>派生字段</strong>，由 <code>permission_mode</code>（private|public_to）+ <code>invocation_targets</code> 派生（agent.ts:10-15）。<code>permission_mode</code>+<code>invocation_targets</code> 才是<em>触发/调用</em>的权威门槛（<code>canInvokeAgent</code> agent_access.go:48）。public_to+workspace = 任意成员/agent/system 可调用；private = 仅所有者（无 admin/A2A 旁路）。</li>
+      <li><strong>编辑面</strong>：<code>agent-access-settings.tsx</code> / <code>AccessPicker</code>，<strong>逐个 agent，全 UI 无任何批量入口</strong>。</li>
+      <li><strong>实测运营痛点（直接证据）</strong>：① 一眼看不出私有 vs 工作区 → 写原生 SQL 盘点；② 不能批量改 → 对 5 个工作区 70 个 agent 跑了 <code>UPDATE+INSERT</code>；③ 私有 agent 被 autopilot <code>run_only</code> 的 @mention <strong>静默丢弃</strong>（originator 为 NULL）—— 上游 <a href="https://github.com/multica-ai/multica/issues/5230">#5230</a>，列表页零信号。</li>
+      <li><strong>规模/语义</strong>：5 工作区、~81 agent；每工作区 ~14 业务 agent（工作区可调用）+ 3 内置（零号机 / Claude Code / Codex，刻意仅所有者私有）。</li>
+      <li><strong>已确认存在的基础设施</strong>：<code>AgentBatchToolbar</code>+<code>runBatch</code>（:646/:668，现仅用于归档/恢复）；<code>AgentListFilters</code> 四维（view-store.ts:41）；<code>AccessPicker</code> 可复用。</li>
+    </ul>
+  </section>
+
+  <section id="axes">
+    <h2>Topic Axes</h2>
+    <p class="axis-line">1. what-to-show — 展示哪些权限/可见性数据</p>
+    <p class="axis-line">2. how-to-display — 列 vs 徽标 vs tooltip；消解 view/invoke 混淆</p>
+    <p class="axis-line">3. find-and-organize — 按访问范围筛选/分组/排序</p>
+    <p class="axis-line">4. manage-and-act — 行内/批量编辑、新 agent 默认值</p>
+  </section>
+
+  <section id="ranked">
+    <h2>Ranked Ideas</h2>
+    <nav class="jumplist">
+      <a href="#i1">1. 有效访问列</a>
+      <a href="#i2">2. 批量改访问范围</a>
+      <a href="#i3">3. 访问筛选维度</a>
+      <a href="#i4">4. 新 agent 默认访问范围</a>
+    </nav>
+
+    <article class="idea" id="i1">
+      <h3><span class="id-chip">1</span> 有效访问列（三态），而非裸 visibility <span class="pill">what-to-show + how-to-display</span></h3>
+      <p>加一列显示<strong>有效的调用范围</strong>——"工作区 / 指定人员 / 仅所有者"，由 <code>permission_mode</code>+<code>invocation_targets</code> 合成，<strong>不</strong>读派生的 <code>visibility</code>。其中"仅所有者"这一态同时承担"自动化/autopilot 无法调用此 agent"的信号（#5230），通过 tooltip/副标说明。</p>
+
+      <figure class="diagram">
+        <svg viewBox="0 0 720 230" width="720" height="230" role="img" aria-label="visibility 派生映射 vs 有效访问三态">
+          <defs>
+            <marker id="arr" markerWidth="9" markerHeight="9" refX="7" refY="4.5" orient="auto"><path d="M0,0 L9,4.5 L0,9 z" fill="#8a93a0"/></marker>
+          </defs>
+          <!-- left: effective access (3 states) -->
+          <text x="30" y="24" font-size="13" font-weight="700" fill="#1a1a1a">有效访问（3 态）</text>
+          <rect x="20" y="40" width="200" height="40" rx="6" fill="#eaf6ee" stroke="#2a7a45"/>
+          <text x="32" y="65" font-size="13" fill="#2a7a45">工作区 · 任意成员/agent 可调用</text>
+          <rect x="20" y="92" width="200" height="40" rx="6" fill="#eaf1fd" stroke="#2f6feb"/>
+          <text x="32" y="117" font-size="13" fill="#2f6feb">指定人员 · public_to + member</text>
+          <rect x="20" y="144" width="200" height="40" rx="6" fill="#fdf3e7" stroke="#9a6a1a"/>
+          <text x="32" y="169" font-size="13" fill="#9a6a1a">仅所有者 · 自动化无法触发</text>
+          <!-- arrow -->
+          <line x1="240" y1="112" x2="360" y2="112" stroke="#8a93a0" stroke-width="1.5" marker-end="url(#arr)"/>
+          <text x="252" y="104" font-size="11.5" fill="#5b6470">派生折叠（丢信息）</text>
+          <!-- right: raw visibility (2 states) -->
+          <text x="400" y="24" font-size="13" font-weight="700" fill="#1a1a1a">裸 visibility（2 态）</text>
+          <rect x="390" y="62" width="210" height="40" rx="6" fill="#eaf6ee" stroke="#2a7a45"/>
+          <text x="404" y="87" font-size="13" fill="#2a7a45">"workspace"</text>
+          <rect x="390" y="124" width="210" height="62" rx="6" fill="#f2f4f7" stroke="#8a93a0"/>
+          <text x="404" y="150" font-size="13" fill="#5b6470">"private"</text>
+          <text x="404" y="170" font-size="11.5" fill="#9a6a1a">↑ 指定人员 + 仅所有者 被合并</text>
+        </svg>
+        <figcaption>问题核心：<code>public_to + member</code> 目标的 agent 会被折叠成 <code>visibility:"private"</code>，与"仅所有者"无法区分。三态列保留了这个区分。</figcaption>
+      </figure>
+
+      <dl class="fields">
+        <dt>Basis</dt><dd><code>direct:</code> <code>packages/core/types/agent.ts:10-15</code>——"<span>a public_to agent WITH a workspace target maps to visibility:'workspace'; everything else (private, or public_to scoped only to member/team targets) maps to visibility:'private'</span>"。即裸 visibility 把"仅所有者"与"指定人员"合并成同一标签。<code>agent_access.go:48-65</code> 的 <code>canInvokeAgent</code> 对 private / public_to 有截然不同的分支。</dd>
+        <dt>Rationale</dt><dd>用户字面诉求（加"可见性列"）若照搬 <code>visibility</code> 会<strong>主动误导</strong>——一个 public_to+member 的 agent 会显示 "private"，但特定成员其实能运行它。有效访问列一次建立正确心智，且"仅所有者"态把 #5230 的静默丢弃风险提前到最早可见的触点。</dd>
+        <dt>Downsides</dt><dd>第 8 列增加横向滚动；建议默认隐藏或同时作为排序/筛选键。标签计算是纯前端、字段已在列表 payload 里。</dd>
+        <dt>Confidence</dt><dd>92%</dd>
+        <dt>Complexity</dt><dd><span class="pill">Low–Medium</span></dd>
+      </dl>
+    </article>
+
+    <article class="idea" id="i2">
+      <h3><span class="id-chip">2</span> 经现有批量工具栏批量改访问范围 <span class="pill">manage-and-act</span></h3>
+      <p>在 <code>AgentBatchToolbar</code>（agents-page.tsx:646，现仅归档/恢复）增加"设置访问范围…"动作，用既有 <code>runBatch</code>（:668）逐个套用 <code>AccessPicker</code> 的选择。把"筛选 → 全选 → 设为工作区"变成几秒钟的事，直接移除我们刚被逼着写的 SQL。</p>
+      <dl class="fields">
+        <dt>Basis</dt><dd><code>direct:</code> <code>agents-page.tsx:668</code> 的 <code>runBatch</code> 是带失效处理的通用顺序执行器；<code>:661</code> <code>allManageable</code> 已做行级权限门控；<code>agent-access-settings.tsx</code> 的 <code>AccessPicker</code> 发出 <code>onChange(next)</code> 补丁，逐行可复用。痛点 #2（跨 5 工作区 70 agent 的 <code>UPDATE+INSERT</code>）正是因 UI 无此路径才发生。</dd>
+        <dt>Rationale</dt><dd>杠杆最高。此后每次访问范围重组（团队入职、把私有 agent 开放给工作区）都从"有风险、不可重放、需管理员"的 SQL 变成 30 秒、可审计、非管理员可用的 UI 操作。基础设施 100% 复用。</dd>
+        <dt>Downsides</dt><dd>需确认对话框护栏（访问范围是安全敏感字段）；"指定人员"批量极易出错，建议批量只开放"工作区 / 仅所有者"两档。</dd>
+        <dt>Confidence</dt><dd>90%</dd>
+        <dt>Complexity</dt><dd><span class="pill">Medium</span></dd>
+      </dl>
+    </article>
+
+    <article class="idea" id="i3">
+      <h3><span class="id-chip">3</span> 访问筛选维度 <span class="pill">find-and-organize</span></h3>
+      <p>给 <code>AgentListFilters</code>（view-store.ts:41）加一个 <code>access</code> 多选维度，取值与列一致（工作区/指定人员/仅所有者）。一键隔离某一类，而非扫 80 行或跑 SQL。它也是想法 2 的发现机制——筛选 → 全选 → 批量改。</p>
+      <dl class="fields">
+        <dt>Basis</dt><dd><code>direct:</code> view-store.ts:41-54 已有四维（availability/runtimes/owners/models），<code>agents-page.tsx</code> 行筛选是纯前端按字段匹配，加第五维机械一致。痛点 #1（"写 SQL 盘点哪些是私有"）本质就是缺这个筛选。</dd>
+        <dt>Rationale</dt><dd>对"盘点"任务，筛选 > 列：列只能逐行扫，筛选直接隔离目标集。也是想法 2 批量流的前置发现步骤。改动极小。</dd>
+        <dt>Downsides</dt><dd>取值粒度（二态 vs 三态）需与列保持一致，需团队拍板。</dd>
+        <dt>Confidence</dt><dd>90%</dd>
+        <dt>Complexity</dt><dd><span class="pill">Low</span></dd>
+      </dl>
+    </article>
+
+    <article class="idea" id="i4">
+      <h3><span class="id-chip">4</span> 工作区级"新 agent 默认访问范围" <span class="pill">manage-and-act / default</span></h3>
+      <p>工作区设置里设新建用户 agent 的默认 <code>permission_mode</code>（自动化重的工作区可默认 public_to+workspace），内置 agent 显式钉为私有。从源头消除"每个新工作区都要重做一次 70 agent 清理"的积压。</p>
+      <div class="callout"><span class="label">Scope-adjacent（范围相邻）</span>这是一个<strong>工作区设置</strong>，不是列表页字段；可经由列表页暴露（如横幅提示），但落地在工作区设置。用户聚焦在列表页字段，故此条标记为相邻、可选。</div>
+      <dl class="fields">
+        <dt>Basis</dt><dd><code>reasoned:</code> 批量 SQL 是症状，根因是默认值与意图不符——若每工作区 ~14 业务 agent 按意图都该是工作区可调用，则 private-by-default 迫使每个 agent 都要 opt-in。<code>external:</code> GitHub 仓库默认 public、Slack 频道默认工作区可见——协作工具默认共享、私有是 opt-out。</dd>
+        <dt>Rationale</dt><dd>唯一能阻止痛点<em>复发</em>的想法。想法 2 是"治理"，本条是"预防"。</dd>
+        <dt>Downsides</dt><dd>默认值放工作区级还是所有者级需设计；内置 agent 必须豁免；离开列表页表面。</dd>
+        <dt>Confidence</dt><dd>70%</dd>
+        <dt>Complexity</dt><dd><span class="pill">Medium</span></dd>
+      </dl>
+    </article>
+  </section>
+
+  <section id="rejections">
+    <h2>Rejection Summary</h2>
+    <table>
+      <thead><tr><th>#</th><th>想法</th><th>剔除理由</th></tr></thead>
+      <tbody>
+        <tr><td>—</td><td>裸 <code>visibility</code> 列（用户字面诉求，照搬）</td><td>会误导：<code>visibility</code> 是派生的 2 态投影（agent.ts:10-15），<code>public_to+member</code> 的 agent 会显示 "private"。被想法 1 取代。</td></tr>
+        <tr><td>—</td><td>独立的"自动化不可达"告警标记</td><td>并入想法 1——"仅所有者"态已承载该后果。</td></tr>
+        <tr><td>—</td><td>行内快切（kebab / 单元格 popover）</td><td>被想法 2（批量）+ 现有逐 agent inspector 覆盖；杠杆较低的便利项。</td></tr>
+        <tr><td>—</td><td>按访问范围排序</td><td>被想法 3（筛选即可分组）吸收；增量价值低。</td></tr>
+        <tr><td>—</td><td>访问范围分布计数 chip 条</td><td>与想法 3 及既有 <code>scopeCounts</code> 重叠；价值较低。</td></tr>
+        <tr><td>—</td><td>axis 覆盖</td><td>4 个存活已覆盖全部 4 个轴；无空轴。</td></tr>
+      </tbody>
+    </table>
+  </section>
+
+  <footer class="composition-signal">
+    Composed 2026-07-14 by ce-ideate (focused pass) · repo <code>multica-ai/multica</code> · scratch <code>/tmp/compound-engineering/ce-ideate/42e47e33</code>
+  </footer>
+
+</div>
+</body>
+</html>

--- a/docs/plans/2026-07-14-001-feat-agent-list-access-scope-plan.md
+++ b/docs/plans/2026-07-14-001-feat-agent-list-access-scope-plan.md
@@ -1,0 +1,231 @@
+---
+title: Agent List Access-Scope Management - Plan
+type: feat
+date: 2026-07-14
+topic: agent-list-access-scope
+artifact_contract: ce-unified-plan/v1
+artifact_readiness: implementation-ready
+product_contract_source: ce-brainstorm
+execution: code
+---
+
+# Agent List Access-Scope Management - Plan
+
+> **Product Contract preservation:** unchanged except R7 — bulk now offers all three access scopes (Workspace / Specific people / Owner-only) via the reused AccessPicker; user override of the original two-tier limit during planning. All other R/A/F/AE IDs and scope boundaries preserved.
+
+## Goal Capsule
+
+- **Objective:** Make an agent's access scope a first-class, visible, and manageable dimension on the agents list page, so any access-scope question or change is answerable without raw SQL or opening many per-agent detail pages.
+- **Product authority:** Product Contract from `ce-brainstorm` (this file's prior requirements-only state). Planning enriches it in place; the only product change is the R7 override noted above.
+- **Stop conditions:** All four implementation units land; `pnpm typecheck`, `pnpm test`, `pnpm lint` green; a browser smoke confirms the column, filter, and bulk action on real agents.
+- **Execution profile:** Pure frontend wiring in `packages/core/agents/` and `packages/views/agents/`. No backend change.
+- **Open blockers:** None blocking. The structural decisions (single confirmation dialog, owner-only gate, AccessPicker wrapper) are settled here; only final dialog wording is polished during implementation.
+- **Tail ownership:** The implementing agent (`ce-work` or a human) owns execution; progress is derived from git, not stored here.
+
+---
+
+## Product Contract
+
+### Summary
+
+A generic, upstream-able agents-list-page feature with three connected mechanics: a three-state "effective access" column (Workspace / Specific people / Owner-only) visible by default, a matching filter dimension, and a "Set access scope" bulk action on the existing batch toolbar that offers all three scopes via the reused AccessPicker. Together they form a see → filter → change loop, computed entirely from existing permission fields with no backend change.
+
+### Problem Frame
+
+Operators cannot read or change agent access scope from the list page today. The list shows eight columns — agent, status, owner, runtime, last_active, runs, model, created — none of which says who can invoke an agent. The only access signal is a small lock marker derived from the `visibility` field, and `visibility` is itself a lossy two-state projection of the authoritative `permission_mode` + `invocation_targets`: a `public_to` agent scoped to specific people maps to `visibility: "private"`, indistinguishable from a truly owner-only agent.
+
+The cost showed up directly. Inventorying which agents were private versus workspace-invocable required raw SQL because no column or filter answers it. Changing scope across many agents required a bulk `UPDATE` + `INSERT` in SQL — observed at the scale of 70 agents across 5 workspaces — because the UI edits one agent at a time. These are the workflows the list page should own, and it currently forces operators outside the product to do them.
+
+### Requirements
+
+**Effective-access column**
+
+- R1. The list gains a column showing each agent's effective access scope as one of three states — Workspace, Specific people, or Owner-only — computed from `permission_mode` + `invocation_targets`, not from the derived `visibility` field.
+- R2. The state mapping is deterministic: Workspace = `public_to` with a workspace target; Specific people = `public_to` scoped to member/team target(s) (or no targets); Owner-only = `private`.
+- R3. The column is visible by default, not hidden behind the column toggle.
+- R4. The column label is localized across all four locales (en, zh-Hans, ja, ko); Chinese copy follows the project conventions doc, keeping the product noun "agent" in English within zh-Hans.
+
+**Access filter**
+
+- R5. The list filter gains an `access` multi-select dimension with the same three values, isolating a class in one click independent of whether the column is visible.
+
+**Bulk edit**
+
+- R6. The batch toolbar offers a "Set access scope" action that applies a chosen scope to all selected agents. The action is gated by ownership (`isOwnedByMe`), not the broader manage permission, because the backend enforces owner-only writes for `permission_mode` / `invocation_targets` — agents the operator does not own are skipped (a stricter gate than archive/restore, which admit workspace admins).
+- R7. Bulk offers all three access scopes — Workspace, Specific people, and Owner-only — by reusing the AccessPicker. The chosen scope, including any specific-people member targets, applies to all selected agents. (Overridden during planning from an earlier two-tier limit; the operator wants the flexibility and can reverse a wrong choice by re-running bulk edit.)
+- R8. A bulk change requires a confirmation dialog that shows the target scope and the affected-agent count clearly enough that an erroneous change can be reversed by running bulk edit again.
+
+**Uniform treatment**
+
+- R9. All agents are treated uniformly; no built-in-agent special-casing.
+
+### Key Decisions
+
+- **Three-state effective access over raw `visibility`.** `visibility` is a derived two-state projection; a raw-visibility column would label a specific-people agent as "private" and mislead operators about who can run it.
+- **Frontend-computed from the existing list payload.** No backend or API change. `permission_mode` and `invocation_targets` are both present in the list response (`SELECT *` carries `permission_mode`; the handler attaches `invocation_targets`).
+- **Column visible by default.** At-a-glance access information is prioritized over horizontal density. Room is made by accepting horizontal scroll (mirroring the existing pattern), not by hiding another column.
+- **Bulk offers all three scopes via the reused AccessPicker.** Specific-people is allowed in bulk (R7 override); the chosen member-target set applies uniformly to all selected agents.
+- **Reuse existing infrastructure.** The batch toolbar, its sequential runner, the filter dimension model, the access picker, and the column system all exist; this is wiring, not new machinery.
+- **Generic and upstream-able.** Uniform agent treatment and no self-host special-casing, so the change is mergeable as-is into the official repo.
+
+### Key Flows
+
+- F1. Bulk access-scope change
+  - **Trigger:** Operator selects one or more agents and chooses "Set access scope" in the batch toolbar.
+  - **Actors:** Owner of the selected agents (the backend rejects access-scope writes from non-owners, including workspace admins).
+  - **Steps:** Choose target scope (Workspace, Specific people, or Owner-only) via AccessPicker → confirmation dialog shows the scope, the owned count, and the skipped count → confirm → applied to all owned selected agents; non-owned ones are skipped → list refreshes.
+  - **Covered by:** R6, R7, R8.
+
+### Acceptance Examples
+
+- AE1.
+  - **Given:** an agent with `permission_mode: public_to` and a member target.
+  - **When:** the list renders.
+  - **Then:** the effective-access column shows "Specific people", not "Owner-only", even though derived `visibility` is "private".
+  - **Covers:** R1, R2.
+- AE2.
+  - **Given:** a `private` agent with no invocation targets.
+  - **When:** the list renders.
+  - **Then:** the effective-access column shows "Owner-only".
+  - **Covers:** R1, R2.
+- AE3.
+  - **Given:** a selection mixing owned and non-owned agents.
+  - **When:** the operator bulk-sets scope to Workspace and confirms.
+  - **Then:** the confirmation dialog shows the affected count and the skip count; only owned selected agents change; non-owned ones are skipped.
+  - **Covers:** R6, R8.
+- AE4.
+  - **Given:** a workspace with private and workspace-invocable agents.
+  - **When:** the operator filters access = Owner-only.
+  - **Then:** only private agents remain.
+  - **Covers:** R5.
+- AE5.
+  - **Given:** three selected agents.
+  - **When:** the operator bulk-sets scope to Specific people with a chosen member set and confirms.
+  - **Then:** all three agents receive the same `public_to` + member-target configuration.
+  - **Covers:** R7.
+
+### Scope Boundaries
+
+**Deferred for later**
+
+- The #5230 "automation cannot trigger this agent" affordance on the Owner-only state. It is a separate upstream bug with its own fix path; keeping it out keeps this PR focused and mergeable.
+- A workspace-level default access scope for newly created agents. It prevents the cleanup backlog from recurring but is a separate settings-surface concern.
+- Inline (per-row popover) access editing. Per-agent inspector plus the new bulk action cover the same ground.
+
+**Deferred to follow-up work**
+
+- Refactoring `AccessPicker`'s internal scope logic to call the new shared effective-access helper (U1). The helper and the picker currently duplicate the same derivation; consolidating is a clean follow-up but is deliberately out of scope here to keep the PR focused.
+
+**Outside this change**
+
+- Backend API or schema changes. Effective access is frontend-computed from fields already in the list payload.
+- Special handling of built-in agents. Uniform treatment is the generic product decision.
+
+### Dependencies / Assumptions
+
+- `permission_mode` and `invocation_targets` are present in the agent list payload. **Verified** — `ListAgents` is `SELECT *` (carries `permission_mode`) and the handler attaches `invocation_targets` per agent.
+- The existing per-agent update path (`api.updateAgent`) can be driven per selected agent by the batch toolbar's sequential runner, mirroring archive/restore.
+
+### Sources / Research
+
+- Column system: `packages/core/agents/stores/view-store.ts` (`AgentColumnKey`, `AGENT_DEFAULT_HIDDEN_COLUMNS`, `toggleColumn`); `packages/views/agents/components/agents-page.tsx` (grid template, track vars, header cells, row cells, skeleton); `packages/views/agents/components/agent-list-toolbar.tsx` (column show/hide toggle).
+- AccessPicker + persistence: `packages/views/agents/components/inspector/access-picker.tsx` (props, `AccessChange`, inline scope derivation); `packages/views/agents/components/agent-detail-page.tsx` → `packages/core/api/client.ts` (`api.updateAgent`).
+- Filter model: `packages/core/agents/stores/view-store.ts` (`AgentListFilters`, `EMPTY_AGENT_FILTERS`, `toggleFilter`); `packages/views/agents/components/agent-list-toolbar.tsx`; row-filter predicate in `agents-page.tsx`.
+- Batch toolbar: `packages/views/agents/components/agents-page.tsx` (`AgentBatchToolbar`, `runBatch`, `allManageable`, archive-with-confirm template, `selectedIds`).
+- Permission semantics: `server/internal/handler/agent_access.go` (`canInvokeAgent`); derivation comment in `packages/core/types/agent.ts`.
+- List payload: `server/internal/handler/agent.go` (`ListAgents` attaches `invocation_targets`); `server/pkg/db/queries/agent.sql` (`ListAgents`).
+- i18n: `packages/views/locales/{en,zh-Hans,ja,ko}/agents.json`; `apps/docs/content/docs/developers/conventions.zh.mdx`.
+- Tests: `packages/views/agents/components/inspector/access-picker.test.tsx`; `packages/core/agents/stores/view-store.test.ts`; `packages/views/agents/components/agent-detail-page.test.tsx`.
+- Learnings: `docs/solutions/ui-bugs/skill-autocomplete-cold-cache.md`; `docs/solutions/design-patterns/adaptive-skill-import-dialog.md`; `docs/solutions/workflow-issues/run-comment-view-run-button-rollout.md`.
+- Originating ideation: `docs/ideation/2026-07-14-agent-list-visibility-field-ideation.html`.
+
+---
+
+## Planning Contract
+
+### Key Technical Decisions
+
+- **KTD1 — Frontend pure function, no backend change.** Effective access is a pure helper over `permission_mode` + `invocation_targets`, both verified present in the list payload. The helper lives in `packages/core/agents/` and is shared by the column (U2) and filter (U3).
+- **KTD2 — Three-state mapping mirrors the authoritative gate.** Owner-only = `private`; Workspace = `public_to` + a workspace target; Specific people = `public_to` without a workspace target. This matches `canInvokeAgent`.
+- **KTD3 — Bulk reuses AccessPicker and persists via `api.updateAgent`, gated by ownership.** All three scopes are offered (R7 override). The bulk action calls `api.updateAgent(id, { permission_mode, invocation_targets })` per selected agent through `runBatch`, mirroring the archive/restore pattern; the existing invalidation of `workspaceKeys.agents(wsId)` refreshes the list. The action is gated by `isOwnedByMe` (not `canManage`), matching the backend's owner-only write gate for these fields — `canManage` admits workspace admins who would receive 403s and abort the sequential batch.
+- **KTD4 — Column visible by default.** The key is added to `AgentColumnKey` but not to `AGENT_DEFAULT_HIDDEN_COLUMNS`; the show/hide toggle still works.
+- **KTD5 — Derive in render, never mirror to Zustand.** The three-state value is a pure function of server fields; compute it with `useMemo` at the cell/predicate. The runtime may omit either field on legacy self-host backends or stale caches, so the helper fails safe to Owner-only when `permission_mode` is absent; a `public_to` agent with absent `invocation_targets` stays Specific people (per R2/KTD2).
+- **KTD6 — AccessPicker reused via a thin wrapper.** A `<BulkAccessPicker>` wrapper renders `AccessPicker` with a new optional `hideFooter` prop that suppresses its internal Save button, so the bulk dialog's own confirm button is the sole apply trigger. Only the `hideFooter` opt-in prop is added to `AccessPicker`; the adjacent refactor (consolidating the picker's internal derivation into U1's helper) remains out of scope.
+
+### Assumptions
+
+- The list payload carries `permission_mode` and `invocation_targets` (verified).
+- `AccessPicker` is rendered inside the bulk dialog via a `<BulkAccessPicker>` wrapper that adds a `hideFooter` prop (KTD6). The wrapper initializes the picker with no scope preselected and owns the confirm-disabled logic; `ownerId` is cosmetic for the Owner-only label and `members` is the workspace member list (uniform across selected agents).
+
+### Sequencing
+
+U1 (shared helper) lands first. U2 (column), U3 (filter), and U4 (bulk) all depend on U1 and can proceed in parallel after it. U2 and U3 both touch the toolbar and the row layer; coordinate those edits to avoid merge friction.
+
+---
+
+## Implementation Units
+
+### U1. Shared effective-access helper
+
+- **Goal:** A pure, tested function deriving an agent's effective access scope (three states) from `permission_mode` + `invocation_targets`, shared by the column and the filter.
+- **Requirements:** R1, R2.
+- **Dependencies:** none.
+- **Files:** `packages/core/agents/effective-access.ts` (new); `packages/core/agents/effective-access.test.ts` (new).
+- **Approach:** Export `AccessScope = "workspace" | "specific-people" | "owner-only"` and `effectiveAccessScope(permissionMode, invocationTargets)`. Mapping: `private` → owner-only; `public_to` with a workspace target → workspace; `public_to` without a workspace target → specific-people. Fail safe to owner-only when `permission_mode` is absent; a `public_to` agent with absent `invocation_targets` stays specific-people (the runtime may omit either field on legacy backends or stale caches). Reference the inline derivation in `packages/views/agents/components/inspector/access-picker.tsx` for the same logic; do not modify that file (KTD6).
+- **Patterns to follow:** Pure helpers in `packages/core/agents/` such as `visibility-label.ts`. Respect the `packages/core` boundary (no `react-dom`, no `localStorage`, no `process.env`).
+- **Test scenarios:** `private` → owner-only; `public_to` + workspace target → workspace; `public_to` + member target only → specific-people; `public_to` + team target only → specific-people; `public_to` + no targets → specific-people; missing `permission_mode` → owner-only (defensive); `public_to` with missing targets → specific-people.
+- **Verification:** Unit tests pass; the helper is pure with no side effects.
+
+### U2. Effective-access column (visible by default)
+
+- **Goal:** A new default-visible column showing the three-state effective access label, derived via U1.
+- **Requirements:** R1, R3, R4. (R2 is realized by U1.)
+- **Dependencies:** U1.
+- **Files:** `packages/core/agents/stores/view-store.ts` (`AgentColumnKey`; do not add to `AGENT_DEFAULT_HIDDEN_COLUMNS`); `packages/views/agents/components/agents-page.tsx` (`COLUMN_WIDTHS`, track vars, grid template, header cell, `AccessCell`, skeleton cell); `packages/views/agents/components/agent-list-toolbar.tsx` (`COLUMN_KEYS`, `COLUMN_LABELS`); `packages/views/locales/{en,zh-Hans,ja,ko}/agents.json` (new `columns.access`; reuse existing `access.*` state labels).
+- **Approach:** Add `"access"` to `AgentColumnKey` and leave it out of `AGENT_DEFAULT_HIDDEN_COLUMNS` so it shows by default. Place the column immediately after `owner` (access scope is conceptually about who can use the agent, adjacent to ownership): add the width entry, the `--agc-access` track var, and the grid track in that position. Add a header cell and an `AccessCell` that renders the localized label from `effectiveAccessScope(row.agent.permission_mode, row.agent.invocation_targets)` via `useMemo`. Add the matching skeleton cell and the toolbar toggle entries. Add `columns.access` in all four locales, keeping "agent" in English within zh-Hans. Horizontal density is handled by accepting scroll, not by hiding another column. Accessibility: the `AccessCell` exposes the localized text label (not icon-only) so screen readers announce the scope.
+- **Patterns to follow:** Existing cells (`OwnerCell`, `RuntimeCell`); the column show/hide toggle in `agent-list-toolbar.tsx`.
+- **Test scenarios:** Renders "Workspace" for a `public_to` + workspace agent; renders "Specific people" for a `public_to` + member agent (Covers AE1); renders "Owner-only" for a `private` agent (Covers AE2); renders a safe label when fields are absent; column is visible on a fresh load; toggling hides and shows the column; the cell text is reachable to assistive tech (not icon-only).
+- **Verification:** Render the page with `@multica/core/api` mocked and a callable store (per the repo test rules); assert the label per agent shape; `pnpm typecheck`.
+
+### U3. Access filter dimension
+
+- **Goal:** A new `access` multi-select filter that isolates a class in one click, independent of column visibility.
+- **Requirements:** R5.
+- **Dependencies:** U1.
+- **Files:** `packages/core/agents/stores/view-store.ts` (`AgentListFilters.access`, `EMPTY_AGENT_FILTERS.access`); `packages/views/agents/components/agent-list-toolbar.tsx` (new sub-menu; bump `countActiveFilterDimensions`); `packages/views/agents/components/agents-page.tsx` (row-filter predicate); locale filter-option labels.
+- **Approach:** Add `access: string[]` to `AgentListFilters` with an empty default; `toggleFilter` and rehydration are generic and need no per-key change. Add a predicate: drop a row unless `filters.access` includes its `effectiveAccessScope(...)`. Mirror the `availability` sub-menu in the toolbar and increment the active-dimension counter. Filter values share the column's three labels. Accessibility: the access sub-menu reuses the `availability` sub-menu's keyboard navigation and ARIA semantics.
+- **Patterns to follow:** The `availability` dimension end-to-end (declaration, sub-menu, predicate).
+- **Test scenarios:** Filtering `access = owner-only` leaves only private agents (Covers AE4); the filter combines with another dimension; clearing it restores the full list; the store persists the filter under the workspace view key; the predicate uses the same helper as the column; the sub-menu matches the `availability` sub-menu's keyboard/ARIA behavior.
+- **Verification:** `view-store.test.ts` direct-manipulation pattern; a page predicate test; `pnpm typecheck`.
+
+### U4. Bulk "Set access scope" action with confirmation
+
+- **Goal:** A batch-toolbar action that sets access scope across selected agents via the reused AccessPicker, with a confirmation dialog showing scope and count.
+- **Requirements:** R6, R7, R8, R9.
+- **Dependencies:** U1.
+- **Files:** `packages/views/agents/components/agents-page.tsx` (`AgentBatchToolbar` action, dialog state; `runBatch` wiring); `packages/views/agents/components/bulk-set-access-dialog.tsx` (new, embeds `AccessPicker` via the `<BulkAccessPicker>` wrapper); `packages/views/agents/components/inspector/access-picker.tsx` (adds optional `hideFooter` prop — KTD6).
+- **Approach:** Add a "Set access scope…" button to `AgentBatchToolbar`, enabled when at least one selected row is `isOwnedByMe` and not busy (gated by ownership, not `canManage` — see KTD3). Use a **single dialog**: a `<BulkAccessPicker>` wrapper renders `AccessPicker` with the new `hideFooter` prop (KTD6) so the picker's internal Save is suppressed and the dialog's own confirm button is the sole apply trigger. The dialog opens with **no scope preselected** and confirm disabled until the operator picks one; when "Specific people" is chosen, confirm stays disabled until ≥1 member target is selected. A live summary line shows "Applies to N agents" (the owned subset) and updates as the selection or scope changes; non-owned selected agents are skipped and their count is surfaced in the summary and the post-action toast. On confirm, map the picker's `AccessChange` to `api.updateAgent(id, { permission_mode, invocation_targets })` and call `runBatch(fn, ownedSelectedRows)`. `runBatch` already invalidates `workspaceKeys.agents(wsId)`. Accessibility: the dialog traps focus, restores focus on close, and the affected-count text is part of the dialog's accessible name.
+- **Patterns to follow:** The archive action with confirm dialog in `agents-page.tsx`; the `runBatch` usage for restore.
+- **Test scenarios:** Select three owned agents, choose Workspace, confirm shows "Applies to 3", applies `updateAgent` per id, list invalidates and reflects Workspace (Covers AE3, F1); mixed owned/non-owned selection → button enabled (any-owned), summary shows owned + skipped counts, only owned agents change (Covers AE3); dialog opens with no scope preselected and confirm disabled until one is picked; choose Specific people with no member selected → confirm disabled, with ≥1 member → enabled, same member set applies to all owned selected (Covers AE5, R7); choose Owner-only → applies `private` and clears targets; cancel applies nothing; busy/disabled states; an error mid-batch toasts and invalidates; the dialog traps and restores focus and exposes the affected count in its accessible name.
+- **Verification:** Page-level test mocking `@multica/core/api` (`api.updateAgent` spy) with a callable store; assert per-id calls and query invalidation; `pnpm typecheck`.
+
+---
+
+## Verification Contract
+
+- `pnpm typecheck` — strict-mode types across `packages/core` and `packages/views`.
+- `pnpm test` — Vitest: U1 helper unit tests; `view-store.test.ts` for the new filter and column; page-level tests for the column label, the filter predicate, and the bulk action (mock `@multica/core/api` and use the callable-store pattern per the repo test rules).
+- `pnpm lint` — repo lint clean.
+- Browser smoke (`pnpm dev:web`, per the repo UI rule): open the agents list and confirm the column shows the correct three states for real agents, the filter isolates each class, and the bulk dialog shows scope + count, applies, and refreshes the list.
+- Accessibility: the column cell text is announced (not icon-only); the access filter sub-menu matches the `availability` sub-menu's keyboard/ARIA behavior; the bulk dialog traps and restores focus and exposes the affected count in its accessible name.
+
+---
+
+## Definition of Done
+
+- **Global:** All four units implemented; `pnpm typecheck`, `pnpm test`, and `pnpm lint` green; browser smoke confirms column, filter, and bulk on real agents; no backend changes; `AccessPicker` reused via wrapper with only an opt-in `hideFooter` prop added (KTD6); "agent" kept in English within zh-Hans; any abandoned experimental code removed.
+- **Per unit:**
+  - U1: helper pure and unit-tested across all three states plus the defensive cases.
+  - U2: column visible by default (placed after `owner`) and renders the correct state per agent.
+  - U3: filter isolates each class, combines with other dimensions, and persists.
+  - U4: bulk applies all three scopes, shows the confirmation, skips non-owned agents (surfacing the skip count), and invalidates the list.

--- a/packages/core/agents/effective-access.test.ts
+++ b/packages/core/agents/effective-access.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it } from "vitest";
+import type { AgentInvocationTarget } from "../types";
+import {
+  ALL_ACCESS_SCOPES,
+  effectiveAccessScope,
+  isAccessChangeReady,
+} from "./effective-access";
+
+function ws(): AgentInvocationTarget {
+  return { target_type: "workspace", target_id: null };
+}
+function member(id: string): AgentInvocationTarget {
+  return { target_type: "member", target_id: id };
+}
+function team(id: string): AgentInvocationTarget {
+  return { target_type: "team", target_id: id };
+}
+
+describe("effectiveAccessScope", () => {
+  it("maps private to owner-only", () => {
+    expect(effectiveAccessScope("private", [])).toBe("owner-only");
+  });
+
+  it("maps public_to + workspace target to workspace", () => {
+    expect(effectiveAccessScope("public_to", [ws()])).toBe("workspace");
+  });
+
+  it("maps public_to + member target only to specific-people", () => {
+    expect(effectiveAccessScope("public_to", [member("u-1")])).toBe("specific-people");
+  });
+
+  it("maps public_to + team target only to specific-people", () => {
+    expect(effectiveAccessScope("public_to", [team("t-1")])).toBe("specific-people");
+  });
+
+  it("maps public_to with no targets to specific-people", () => {
+    expect(effectiveAccessScope("public_to", [])).toBe("specific-people");
+  });
+
+  it("fails safe to owner-only when permission_mode is absent", () => {
+    expect(effectiveAccessScope(undefined, [ws()])).toBe("owner-only");
+    expect(effectiveAccessScope(null, [ws()])).toBe("owner-only");
+  });
+
+  it("treats public_to with missing invocation_targets as specific-people", () => {
+    expect(effectiveAccessScope("public_to", undefined)).toBe("specific-people");
+    expect(effectiveAccessScope("public_to", null)).toBe("specific-people");
+  });
+
+  it("prefers workspace when a workspace target sits alongside member targets", () => {
+    expect(effectiveAccessScope("public_to", [member("u-1"), ws()])).toBe("workspace");
+  });
+});
+
+describe("ALL_ACCESS_SCOPES", () => {
+  it("lists the three scopes in display order", () => {
+    expect(ALL_ACCESS_SCOPES).toEqual([
+      "workspace",
+      "specific-people",
+      "owner-only",
+    ]);
+  });
+});
+
+describe("isAccessChangeReady", () => {
+  it("null is not ready (no scope picked yet)", () => {
+    expect(isAccessChangeReady(null)).toBe(false);
+  });
+
+  it("private with no targets is ready (clears targets)", () => {
+    expect(
+      isAccessChangeReady({ permission_mode: "private", invocation_targets: [] }),
+    ).toBe(true);
+  });
+
+  it("public_to with workspace target only is ready", () => {
+    expect(
+      isAccessChangeReady({
+        permission_mode: "public_to",
+        invocation_targets: [ws()],
+      }),
+    ).toBe(true);
+  });
+
+  it("public_to with member target is ready", () => {
+    expect(
+      isAccessChangeReady({
+        permission_mode: "public_to",
+        invocation_targets: [member("u-1")],
+      }),
+    ).toBe(true);
+  });
+
+  it("public_to with zero targets is NOT ready", () => {
+    expect(
+      isAccessChangeReady({ permission_mode: "public_to", invocation_targets: [] }),
+    ).toBe(false);
+  });
+});

--- a/packages/core/agents/effective-access.ts
+++ b/packages/core/agents/effective-access.ts
@@ -1,0 +1,56 @@
+import type { AgentInvocationTarget, AgentPermissionMode } from "../types";
+
+/**
+ * The three effective access-scope states shown in the agents list, derived
+ * from the authoritative `permission_mode` + `invocation_targets` (MUL-3963).
+ * The legacy `visibility` field is a lossy two-state projection of these — a
+ * `public_to` agent scoped to specific people maps to `visibility: "private"`,
+ * indistinguishable from a truly owner-only agent — so the list shows this
+ * three-state value instead.
+ *
+ * Mapping mirrors the server's `canInvokeAgent` gate
+ * (`server/internal/handler/agent_access.go`):
+ *   - owner-only      = `private` (only the owner may invoke)
+ *   - workspace       = `public_to` with a workspace target (any member/agent/system)
+ *   - specific-people = `public_to` without a workspace target (member/team targets)
+ */
+export type AccessScope = "workspace" | "specific-people" | "owner-only";
+
+/**
+ * Derive the effective access scope from an agent's permission fields. Fails
+ * safe to "owner-only" when `permission_mode` is absent (the runtime may omit
+ * these on legacy self-host backends or stale caches); a `public_to` agent
+ * with absent `invocation_targets` stays "specific-people".
+ */
+export function effectiveAccessScope(
+  permissionMode: AgentPermissionMode | undefined | null,
+  invocationTargets: readonly AgentInvocationTarget[] | undefined | null,
+): AccessScope {
+  if (permissionMode !== "public_to") {
+    return "owner-only";
+  }
+  if ((invocationTargets ?? []).some((t) => t.target_type === "workspace")) {
+    return "workspace";
+  }
+  return "specific-people";
+}
+
+/** All possible effective access-scope values, in display order. */
+export const ALL_ACCESS_SCOPES: readonly AccessScope[] = [
+  "workspace",
+  "specific-people",
+  "owner-only",
+];
+
+/**
+ * Whether the bulk-access dialog's Apply button should be enabled given the
+ * picker's current onChange payload. `null` (no selection yet) and
+ * `public_to` with zero invocation targets are not ready.
+ */
+export function isAccessChangeReady(
+  change: { permission_mode: AgentPermissionMode; invocation_targets: readonly { target_type: string }[] } | null,
+): boolean {
+  if (!change) return false;
+  if (change.permission_mode === "private") return true;
+  return change.invocation_targets.length > 0;
+}

--- a/packages/core/agents/index.ts
+++ b/packages/core/agents/index.ts
@@ -1,5 +1,6 @@
 export * from "./types";
 export * from "./derive-presence";
+export * from "./effective-access";
 export * from "./queries";
 export * from "./use-agent-presence";
 export * from "./use-update-agent-allowlist";

--- a/packages/core/agents/stores/view-store.test.ts
+++ b/packages/core/agents/stores/view-store.test.ts
@@ -121,4 +121,81 @@ describe("useAgentsViewStore", () => {
     expect(filters.owners).toEqual([]);
     expect(filters.availability).toEqual(["online"]);
   });
+
+  describe("access filter dimension", () => {
+    it("EMPTY_AGENT_FILTERS initializes access to []", async () => {
+      const { EMPTY_AGENT_FILTERS } = await import("./view-store");
+      expect(EMPTY_AGENT_FILTERS.access).toEqual([]);
+    });
+
+    it("toggleFilter('access', value) adds and removes the value", () => {
+      const { toggleFilter } = useAgentsViewStore.getState();
+      toggleFilter("access", "owner-only");
+      expect(useAgentsViewStore.getState().filters.access).toEqual(["owner-only"]);
+      toggleFilter("access", "workspace");
+      expect(useAgentsViewStore.getState().filters.access).toEqual([
+        "owner-only",
+        "workspace",
+      ]);
+      toggleFilter("access", "owner-only");
+      expect(useAgentsViewStore.getState().filters.access).toEqual(["workspace"]);
+    });
+
+    it("persists the access filter under the workspace-namespaced key", async () => {
+      setCurrentWorkspace("acme", "ws_a");
+      await flush();
+      useAgentsViewStore.getState().toggleFilter("access", "specific-people");
+      await flush();
+
+      const raw = localStorage.getItem("multica_agents_view:acme");
+      expect(raw).not.toBeNull();
+      const parsed = JSON.parse(raw as string);
+      expect(parsed.state.filters.access).toEqual(["specific-people"]);
+    });
+
+    it("rehydrates a saved access filter on workspace switch", async () => {
+      localStorage.setItem(
+        "multica_agents_view:acme",
+        JSON.stringify({
+          state: { filters: { access: ["owner-only"] } },
+          version: 0,
+        }),
+      );
+      localStorage.setItem(
+        "multica_agents_view:beta",
+        JSON.stringify({
+          state: { filters: { access: ["workspace"] } },
+          version: 0,
+        }),
+      );
+
+      setCurrentWorkspace("acme", "ws_a");
+      await flush();
+      await flush();
+      expect(useAgentsViewStore.getState().filters.access).toEqual(["owner-only"]);
+
+      setCurrentWorkspace("beta", "ws_b");
+      await flush();
+      await flush();
+      expect(useAgentsViewStore.getState().filters.access).toEqual(["workspace"]);
+    });
+
+    it("backfills access to [] when rehydrating a pre-access payload", async () => {
+      // Pre-access payloads would leave filters.access undefined and crash
+      // the row-filter predicate (`filters.access.length`).
+      localStorage.setItem(
+        "multica_agents_view:acme",
+        JSON.stringify({
+          state: { filters: { availability: ["online"] } },
+          version: 0,
+        }),
+      );
+
+      setCurrentWorkspace("acme", "ws_a");
+      await flush();
+      await flush();
+
+      expect(useAgentsViewStore.getState().filters.access).toEqual([]);
+    });
+  });
 });

--- a/packages/core/agents/stores/view-store.ts
+++ b/packages/core/agents/stores/view-store.ts
@@ -7,6 +7,7 @@ import {
   registerForWorkspaceRehydration,
 } from "../../platform/workspace-storage";
 import { defaultStorage } from "../../platform/storage";
+import type { AccessScope } from "../effective-access";
 
 // View preferences for the agents list page: scope, sort, column visibility,
 // and filters. Persisted per workspace, per user/device. Row selection is
@@ -51,6 +52,8 @@ export interface AgentListFilters {
   owners: string[];
   /** Runtime-native model identifiers (e.g. claude / codex / gpt-…). */
   models: string[];
+  /** Effective access-scope values (MUL-3963): workspace | specific-people | owner-only. */
+  access: AccessScope[];
 }
 
 export const EMPTY_AGENT_FILTERS: AgentListFilters = {
@@ -58,6 +61,7 @@ export const EMPTY_AGENT_FILTERS: AgentListFilters = {
   runtimes: [],
   owners: [],
   models: [],
+  access: [],
 };
 
 // User-hideable columns. Name and the structural columns (checkbox, kebab)
@@ -65,6 +69,7 @@ export const EMPTY_AGENT_FILTERS: AgentListFilters = {
 export type AgentColumnKey =
   | "status"
   | "owner"
+  | "access"
   | "runtime"
   | "lastActive"
   | "runs"

--- a/packages/views/agents/agents-i18n-parity.test.ts
+++ b/packages/views/agents/agents-i18n-parity.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from "vitest";
+import en from "../locales/en/agents.json";
+import zhHans from "../locales/zh-Hans/agents.json";
+import ja from "../locales/ja/agents.json";
+import ko from "../locales/ko/agents.json";
+
+const LOCALES = { en, "zh-Hans": zhHans, ja, ko } as const;
+
+/**
+ * Verify new access-scope / bulk-access keys are present in every locale
+ * with the same key set. This prevents silent regressions where one locale
+ * gets a key added while the others lag (the i18next parity bug the
+ * learnings researcher flagged).
+ */
+describe("access-scope i18n parity across all 4 locales", () => {
+  const accessScopeKeys = [
+    "access.scope_labels.workspace",
+    "access.scope_labels.specific_people",
+    "access.scope_labels.owner_only",
+  ];
+
+  const bulkKeys = [
+    "row_actions.set_access",
+    "row_actions.set_access_dialog_title",
+    "row_actions.set_access_applies_to",
+    "row_actions.set_access_skipped",
+    "row_actions.set_access_dialog_confirm",
+    "row_actions.set_access_bulk_partial",
+  ];
+
+  const toolbarKeys = ["toolbar.section_access"];
+
+  const ALL_NEW_KEYS = [...accessScopeKeys, ...bulkKeys, ...toolbarKeys];
+
+  it("all new keys are present in all 4 locales", () => {
+    for (const [name, loc] of Object.entries(LOCALES)) {
+      for (const key of ALL_NEW_KEYS) {
+        const parts = key.split(".");
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        let node: any = loc as any;
+        for (const p of parts) {
+          node = node?.[p];
+        }
+        expect(node, `${name}: ${key} missing`).toBeDefined();
+        expect(typeof node, `${name}: ${key} not a string`).toBe("string");
+        expect(String(node).length > 0, `${name}: ${key} is empty`).toBe(true);
+      }
+    }
+  });
+
+  it("interpolation tokens use double-brace {{count}} everywhere", () => {
+    for (const [name, loc] of Object.entries(LOCALES)) {
+      for (const key of ["row_actions.set_access_applies_to", "row_actions.set_access_skipped", "row_actions.set_access_bulk_partial"]) {
+        const parts = key.split(".");
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        let node: any = loc as any;
+        for (const p of parts) {
+          node = node?.[p];
+        }
+        if (typeof node === "string" && /\{count\}/.test(node) && !/\{\{count\}\}/.test(node)) {
+          throw new Error(`${name}: ${key} uses {count} instead of {{count}}`);
+        }
+      }
+    }
+  });
+});

--- a/packages/views/agents/components/access-picker-bulk-commit.test.tsx
+++ b/packages/views/agents/components/access-picker-bulk-commit.test.tsx
@@ -67,4 +67,24 @@ describe("AccessPicker bulk mode (hideFooter)", () => {
     fireEvent.click(membersRadio);
     expect(readyFn).toHaveBeenCalledWith(false, undefined);
   });
+
+  // The loop this guards: a parent that stores the change in state re-renders
+  // the picker. If the picker re-notifies on that render (unstable change
+  // object / callback in the effect deps), the parent stores again and never
+  // settles. Fails fast here; in the real toolbar it hangs the flow instead.
+  it("does not re-notify the parent when re-rendered with a stable callback", () => {
+    const readyFn = vi.fn();
+    const { rerender } = render(<Harness onReadyChange={readyFn} />);
+    fireEvent.click(screen.getByRole("radio", { name: /Entire workspace/ }));
+
+    const callsAfterSelect = readyFn.mock.calls.length;
+    const changeAfterSelect = readyFn.mock.calls.at(-1)?.[1];
+
+    rerender(<Harness onReadyChange={readyFn} />);
+    rerender(<Harness onReadyChange={readyFn} />);
+
+    expect(readyFn.mock.calls.length).toBe(callsAfterSelect);
+    // And the committed value keeps its identity, so storing it is idempotent.
+    expect(readyFn.mock.calls.at(-1)?.[1]).toBe(changeAfterSelect);
+  });
 });

--- a/packages/views/agents/components/access-picker-bulk-commit.test.tsx
+++ b/packages/views/agents/components/access-picker-bulk-commit.test.tsx
@@ -1,0 +1,70 @@
+// @vitest-environment jsdom
+
+import { describe, it, expect, vi } from "vitest";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { I18nProvider } from "@multica/core/i18n/react";
+import enCommon from "../../locales/en/common.json";
+import enAgents from "../../locales/en/agents.json";
+import type { AccessChange } from "./inspector/access-picker";
+import { AccessPicker } from "./inspector/access-picker";
+
+const TEST_RESOURCES = { en: { common: enCommon, agents: enAgents } };
+
+vi.mock("../../common/actor-avatar", () => ({
+  ActorAvatar: () => <div>avatar</div>,
+}));
+
+function Harness({
+  onReadyChange,
+  onChange,
+}: {
+  onReadyChange?: (ready: boolean, change?: AccessChange) => void;
+  onChange?: (next: unknown) => void;
+}) {
+  return (
+    <I18nProvider locale="en" resources={TEST_RESOURCES}>
+      <AccessPicker
+        permissionMode="private"
+        invocationTargets={undefined}
+        visibility="private"
+        members={[]}
+        ownerId="user-1"
+        canEdit
+        hideFooter
+        onReadyChange={onReadyChange}
+        onChange={onChange}
+      />
+    </I18nProvider>
+  );
+}
+
+describe("AccessPicker bulk mode (hideFooter)", () => {
+  it("isReady starts false (private is the persisted default)", () => {
+    const readyFn = vi.fn();
+    render(<Harness onReadyChange={readyFn} />);
+    expect(readyFn).toHaveBeenCalledWith(false, undefined);
+  });
+
+  it("clicking Workspace radio fires onReadyChange(true) with a Workspace change", () => {
+    const readyFn = vi.fn();
+    render(<Harness onReadyChange={readyFn} />);
+    const workspaceRadio = screen.getByRole("radio", {
+      name: /Entire workspace/,
+    });
+    fireEvent.click(workspaceRadio);
+    expect(readyFn).toHaveBeenCalledWith(true, expect.objectContaining({
+      permission_mode: "public_to",
+      invocation_targets: [expect.objectContaining({ target_type: "workspace" })],
+    }));
+  });
+
+  it("clicking Specific people without selecting a member keeps onReadyChange(false)", () => {
+    const readyFn = vi.fn();
+    render(<Harness onReadyChange={readyFn} />);
+    const membersRadio = screen.getByRole("radio", {
+      name: /Specific people/,
+    });
+    fireEvent.click(membersRadio);
+    expect(readyFn).toHaveBeenCalledWith(false, undefined);
+  });
+});

--- a/packages/views/agents/components/agent-batch-toolbar.test.tsx
+++ b/packages/views/agents/components/agent-batch-toolbar.test.tsx
@@ -1,0 +1,150 @@
+// @vitest-environment jsdom
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { I18nProvider } from "@multica/core/i18n/react";
+import enCommon from "../../locales/en/common.json";
+import enAgents from "../../locales/en/agents.json";
+
+const TEST_RESOURCES = { en: { common: enCommon, agents: enAgents } };
+
+const updateAgentSpy = vi.hoisted(() => vi.fn(async () => ({})));
+const archiveSpy = vi.hoisted(() => vi.fn(async () => ({})));
+const restoreSpy = vi.hoisted(() => vi.fn(async () => ({})));
+
+vi.mock("@multica/core/hooks", () => ({
+  useWorkspaceId: () => "ws-1",
+}));
+vi.mock("@multica/core/api", () => ({
+  api: {
+    updateAgent: updateAgentSpy,
+    archiveAgent: archiveSpy,
+    restoreAgent: restoreSpy,
+  },
+}));
+vi.mock("../../common/actor-avatar", () => ({
+  ActorAvatar: () => <div>avatar</div>,
+}));
+vi.mock("sonner", () => ({
+  toast: { success: vi.fn(), error: vi.fn(), info: vi.fn() },
+}));
+
+import { AgentBatchToolbar } from "./agent-batch-toolbar";
+import type { AgentListRow } from "./agents-page";
+
+function makeAgent(
+  id: string,
+  ownerId: string | null,
+  overrides: Record<string, unknown> = {},
+) {
+  return {
+    id,
+    workspace_id: "ws-1",
+    runtime_id: "rt-1",
+    name: `Agent ${id}`,
+    description: "",
+    instructions: "",
+    avatar_url: null,
+    runtime_mode: "local" as const,
+    runtime_config: {},
+    max_concurrent_tasks: 1,
+    owner_id: ownerId,
+    archived_at: null,
+    custom_args: [] as string[],
+    visibility: "private" as const,
+    permission_mode: "private" as const,
+    invocation_targets: [] as unknown[],
+    model: "claude",
+    created_at: "2026-01-01T00:00:00Z",
+    updated_at: "2026-01-01T00:00:00Z",
+    status: "idle" as const,
+    skills: [] as unknown[],
+    archived_by: null,
+    ...overrides,
+  };
+}
+
+function makeRow(
+  id: string,
+  ownerId: string | null,
+  overrides: Record<string, unknown> = {},
+): AgentListRow {
+  const agent = makeAgent(id, ownerId, overrides);
+  return {
+    agent: agent as AgentListRow["agent"],
+    runtime: null,
+    presence: null,
+    activity: null,
+    runCount: 0,
+    lastActiveDays: null,
+    owner: ownerId
+      ? ({ user_id: ownerId, name: `Owner ${ownerId}`, email: "" } as AgentListRow["owner"])
+      : null,
+    isOwnedByMe: ownerId === "user-1",
+    canManage: ownerId === "user-1",
+  };
+}
+
+function renderToolbar(rows: AgentListRow[]) {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(
+    <QueryClientProvider client={qc}>
+      <I18nProvider locale="en" resources={TEST_RESOURCES}>
+        <AgentBatchToolbar
+          rows={rows}
+          members={[]}
+          currentUserId="user-1"
+          onClear={() => {}}
+        />
+      </I18nProvider>
+    </QueryClientProvider>,
+  );
+}
+
+beforeEach(() => {
+  updateAgentSpy.mockClear();
+  updateAgentSpy.mockResolvedValue({});
+});
+
+describe("AgentBatchToolbar — bulk Set access scope", () => {
+  it("shows the Set access scope button for active owned agents", () => {
+    renderToolbar([makeRow("a", "user-1")]);
+    expect(
+      screen.getByRole("button", { name: "Set access scope" }),
+    ).toBeInTheDocument();
+  });
+
+  it("renders Applies to N with skip count in the dialog", async () => {
+    renderToolbar([
+      makeRow("a", "user-1"),
+      makeRow("b", "user-1"),
+      makeRow("c", "user-2"), // not owned → skipped
+    ]);
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "Set access scope" }),
+    );
+
+    await screen.findByText(/Applies to 2 agents/);
+    expect(
+      screen.getByText(/1 skipped/),
+    ).toBeInTheDocument();
+  });
+
+  // The interactive flow (pick Workspace → Apply enabled → updateAgent
+  // called per owned row) is covered by access-picker-bulk-commit.test.tsx
+  // (picker commit + onReadyChange) + the toolbar integration tests here.
+
+  it("keeps Apply disabled until a scope is picked", async () => {
+    renderToolbar([makeRow("a", "user-1")]);
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "Set access scope" }),
+    );
+    await screen.findByText(/Applies to 1 agents/);
+
+    // No radio clicked yet — Apply must be disabled
+    expect(screen.getByRole("button", { name: "Apply" })).toBeDisabled();
+  });
+});

--- a/packages/views/agents/components/agent-batch-toolbar.test.tsx
+++ b/packages/views/agents/components/agent-batch-toolbar.test.tsx
@@ -109,6 +109,24 @@ beforeEach(() => {
   updateAgentSpy.mockResolvedValue({});
 });
 
+describe("AgentBatchToolbar — action order", () => {
+  it("renders Archive last, after the other batch actions", () => {
+    // One archived + one active owned row surfaces all three actions at once.
+    renderToolbar([
+      makeRow("a", "user-1", { archived_at: "2026-01-01T00:00:00Z" }),
+      makeRow("b", "user-1"),
+    ]);
+
+    // Labelled buttons in DOM order; the clear-selection button is icon-only.
+    const actions = screen
+      .getAllByRole("button")
+      .map((b) => b.textContent?.trim())
+      .filter((text): text is string => !!text);
+
+    expect(actions).toEqual(["Restore", "Set access scope", "Archive"]);
+  });
+});
+
 describe("AgentBatchToolbar — bulk Set access scope", () => {
   it("shows the Set access scope button for active owned agents", () => {
     renderToolbar([makeRow("a", "user-1")]);

--- a/packages/views/agents/components/agent-batch-toolbar.test.tsx
+++ b/packages/views/agents/components/agent-batch-toolbar.test.tsx
@@ -1,7 +1,7 @@
 // @vitest-environment jsdom
 
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { fireEvent, render, screen } from "@testing-library/react";
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { I18nProvider } from "@multica/core/i18n/react";
 import enCommon from "../../locales/en/common.json";
@@ -9,7 +9,9 @@ import enAgents from "../../locales/en/agents.json";
 
 const TEST_RESOURCES = { en: { common: enCommon, agents: enAgents } };
 
-const updateAgentSpy = vi.hoisted(() => vi.fn(async () => ({})));
+const updateAgentSpy = vi.hoisted(() =>
+  vi.fn(async (_id: string, _patch: Record<string, unknown>) => ({})),
+);
 const archiveSpy = vi.hoisted(() => vi.fn(async () => ({})));
 const restoreSpy = vi.hoisted(() => vi.fn(async () => ({})));
 
@@ -132,10 +134,6 @@ describe("AgentBatchToolbar — bulk Set access scope", () => {
     ).toBeInTheDocument();
   });
 
-  // The interactive flow (pick Workspace → Apply enabled → updateAgent
-  // called per owned row) is covered by access-picker-bulk-commit.test.tsx
-  // (picker commit + onReadyChange) + the toolbar integration tests here.
-
   it("keeps Apply disabled until a scope is picked", async () => {
     renderToolbar([makeRow("a", "user-1")]);
 
@@ -146,5 +144,93 @@ describe("AgentBatchToolbar — bulk Set access scope", () => {
 
     // No radio clicked yet — Apply must be disabled
     expect(screen.getByRole("button", { name: "Apply" })).toBeDisabled();
+  });
+
+  // Regression: AgentBatchToolbar <-> AccessPicker used to notify each other on
+  // every render (unstable onReadyChange + a change object rebuilt per render,
+  // plus a cleanup that cleared the parent on each dependency change). Picking a
+  // scope never settled, so this whole flow could not complete.
+  it("settles after picking a scope: Apply enables and stays enabled", async () => {
+    renderToolbar([makeRow("a", "user-1")]);
+
+    fireEvent.click(screen.getByRole("button", { name: "Set access scope" }));
+    await screen.findByText(/Applies to 1 agents/);
+
+    fireEvent.click(screen.getByRole("radio", { name: /Entire workspace/ }));
+
+    const apply = screen.getByRole("button", { name: "Apply" });
+    await waitFor(() => expect(apply).toBeEnabled());
+
+    // Reaching a fixed point is the point: further flushes must not flip the
+    // button back to disabled or re-enter the notify effect.
+    for (let i = 0; i < 5; i++) {
+      await act(async () => {});
+      expect(apply).toBeEnabled();
+      expect(
+        screen.getByRole("radio", { name: /Entire workspace/ }),
+      ).toBeChecked();
+    }
+  });
+
+  it("applies Entire workspace to each owned agent exactly once", async () => {
+    renderToolbar([
+      makeRow("a", "user-1"),
+      makeRow("b", "user-1"),
+      makeRow("c", "user-2"), // not owned → must be skipped
+    ]);
+
+    fireEvent.click(screen.getByRole("button", { name: "Set access scope" }));
+    await screen.findByText(/Applies to 2 agents/);
+
+    fireEvent.click(screen.getByRole("radio", { name: /Entire workspace/ }));
+
+    const apply = screen.getByRole("button", { name: "Apply" });
+    await waitFor(() => expect(apply).toBeEnabled());
+
+    fireEvent.click(apply);
+
+    await waitFor(() => expect(updateAgentSpy).toHaveBeenCalledTimes(2));
+    expect(updateAgentSpy.mock.calls.map((call) => call[0]).sort()).toEqual([
+      "a",
+      "b",
+    ]);
+    for (const call of updateAgentSpy.mock.calls) {
+      expect(call[1]).toEqual({
+        permission_mode: "public_to",
+        invocation_targets: [{ target_type: "workspace" }],
+      });
+    }
+
+    // One click, one write per owned agent — the dialog is gone and nothing
+    // re-fires afterwards.
+    await act(async () => {});
+    expect(updateAgentSpy).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not retain the previous selection after close and reopen", async () => {
+    renderToolbar([makeRow("a", "user-1")]);
+
+    fireEvent.click(screen.getByRole("button", { name: "Set access scope" }));
+    await screen.findByText(/Applies to 1 agents/);
+    fireEvent.click(screen.getByRole("radio", { name: /Entire workspace/ }));
+    await waitFor(() =>
+      expect(screen.getByRole("button", { name: "Apply" })).toBeEnabled(),
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Cancel" }));
+    await waitFor(() =>
+      expect(
+        screen.queryByRole("button", { name: "Apply" }),
+      ).not.toBeInTheDocument(),
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Set access scope" }));
+    await screen.findByText(/Applies to 1 agents/);
+
+    expect(screen.getByRole("button", { name: "Apply" })).toBeDisabled();
+    expect(
+      screen.getByRole("radio", { name: /Entire workspace/ }),
+    ).not.toBeChecked();
+    expect(updateAgentSpy).not.toHaveBeenCalled();
   });
 });

--- a/packages/views/agents/components/agent-batch-toolbar.tsx
+++ b/packages/views/agents/components/agent-batch-toolbar.tsx
@@ -140,17 +140,6 @@ export function AgentBatchToolbar({
           </button>
         </div>
 
-        {anyActive && (
-          <Button
-            variant="ghost"
-            size="sm"
-            disabled={!allManageable || busy}
-            onClick={() => setConfirmArchive(true)}
-          >
-            <Archive className="mr-1 size-3.5" />
-            {t(($) => $.row_actions.archive)}
-          </Button>
-        )}
         {anyArchived && (
           <Button
             variant="ghost"
@@ -175,6 +164,19 @@ export function AgentBatchToolbar({
             onClick={() => setAccessDialogOpen(true)}
           >
             {t(($) => $.row_actions.set_access)}
+          </Button>
+        )}
+        {/* Archive sits last: it is the destructive action, kept furthest from
+            the other batch actions. */}
+        {anyActive && (
+          <Button
+            variant="ghost"
+            size="sm"
+            disabled={!allManageable || busy}
+            onClick={() => setConfirmArchive(true)}
+          >
+            <Archive className="mr-1 size-3.5" />
+            {t(($) => $.row_actions.archive)}
           </Button>
         )}
       </div>

--- a/packages/views/agents/components/agent-batch-toolbar.tsx
+++ b/packages/views/agents/components/agent-batch-toolbar.tsx
@@ -1,0 +1,285 @@
+"use client";
+
+import { useState } from "react";
+import { useQueryClient } from "@tanstack/react-query";
+import { toast } from "sonner";
+import type { MemberWithUser } from "@multica/core/types";
+import { api } from "@multica/core/api";
+import { useWorkspaceId } from "@multica/core/hooks";
+import { workspaceKeys } from "@multica/core/workspace/queries";
+import { Button } from "@multica/ui/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@multica/ui/components/ui/dialog";
+import { Archive, ArchiveRestore, Loader2, X } from "lucide-react";
+import { useT } from "../../i18n";
+import { AccessPicker, type AccessChange } from "./inspector/access-picker";
+import type { AgentListRow } from "./agents-page";
+
+// Stable empty array — passing [] inline creates a new reference each render,
+// which resets AccessPicker's draft via its useEffect dependency cascade.
+
+/**
+ * Floating batch-toolbar for the agents list page. Renders archive/restore
+ * actions (existing) and a "Set access scope" action (new, MUL-4302 / 2026-07-14)
+ * that opens a single confirmation dialog with an embedded AccessPicker.
+ *
+ * The bulk action is gated by `isOwnedByMe` (not `canManage`) to match the
+ * backend's owner-only write gate for `permission_mode` / `invocation_targets`.
+ * Non-owned selected agents are skipped; the skip count is shown in both the
+ * dialog summary and the partial-failure toast.
+ */
+export function AgentBatchToolbar({
+  rows,
+  members,
+  currentUserId,
+  onClear,
+}: {
+  rows: AgentListRow[];
+  members: MemberWithUser[];
+  currentUserId: string | null;
+  onClear: () => void;
+}) {
+  const { t } = useT("agents");
+  const wsId = useWorkspaceId();
+  const qc = useQueryClient();
+  const [confirmArchive, setConfirmArchive] = useState(false);
+  const [confirmAccess, setConfirmAccess] = useState(false);
+  const [accessChange, setAccessChange] = useState<AccessChange | null>(null);
+  const [busy, setBusy] = useState(false);
+
+  if (rows.length === 0) return null;
+
+  const allManageable = rows.every((r) => r.canManage);
+  const ownedRows = rows.filter((r) => r.isOwnedByMe);
+  const anyOwned = ownedRows.length > 0;
+  const anyActive = rows.some((r) => !r.agent.archived_at);
+  const anyArchived = rows.some((r) => !!r.agent.archived_at);
+
+  const invalidate = () =>
+    qc.invalidateQueries({ queryKey: workspaceKeys.agents(wsId) });
+
+  const accessConfirmEnabled = accessChange !== null;
+
+  const applyAccessBulk = async (change: AccessChange) => {
+    const summary = await runBatch(
+      (id) =>
+        api.updateAgent(id, {
+          permission_mode: change.permission_mode,
+          invocation_targets: change.invocation_targets,
+        }),
+      ownedRows,
+    );
+    if (summary.failed > 0) {
+      toast.error(
+        t(($) => $.row_actions.set_access_bulk_partial, {
+          succeeded: summary.succeeded,
+          failed: summary.failed,
+        }),
+      );
+    }
+  };
+
+  const runBatch = async (
+    fn: (id: string) => Promise<unknown>,
+    targets: AgentListRow[],
+  ): Promise<{ succeeded: number; failed: number }> => {
+    setBusy(true);
+    const settled = await Promise.allSettled(
+      targets.map((row) => fn(row.agent.id)),
+    );
+    const failed = settled.filter((s) => s.status === "rejected").length;
+    const succeeded = settled.length - failed;
+    invalidate();
+    onClear();
+    setBusy(false);
+    if (failed > 0) {
+      const first = settled.find((s) => s.status === "rejected") as
+        | PromiseRejectedResult
+        | undefined;
+      if (first) {
+        toast.error(first.reason instanceof Error ? first.reason.message : String(first.reason));
+      }
+    }
+    return { succeeded, failed };
+  };
+
+  return (
+    <>
+      <div className="absolute bottom-6 left-1/2 z-50 flex -translate-x-1/2 items-center gap-1 rounded-lg border bg-background px-2 py-1.5 shadow-lg">
+        <div className="mr-1 flex items-center gap-1.5 border-r pl-1 pr-2">
+          <span className="text-sm font-medium">
+            {t(($) => $.actions.selected, { count: rows.length })}
+          </span>
+          <button
+            type="button"
+            aria-label={t(($) => $.actions.clear_selection)}
+            onClick={onClear}
+            className="rounded p-0.5 transition-colors hover:bg-accent"
+          >
+            <X className="size-3.5 text-muted-foreground" />
+          </button>
+        </div>
+
+        {anyActive && (
+          <Button
+            variant="ghost"
+            size="sm"
+            disabled={!allManageable || busy}
+            onClick={() => setConfirmArchive(true)}
+          >
+            <Archive className="mr-1 size-3.5" />
+            {t(($) => $.row_actions.archive)}
+          </Button>
+        )}
+        {anyArchived && (
+          <Button
+            variant="ghost"
+            size="sm"
+            disabled={!allManageable || busy}
+            onClick={() =>
+              runBatch(
+                (id) => api.restoreAgent(id),
+                rows.filter((r) => !!r.agent.archived_at),
+              )
+            }
+          >
+            <ArchiveRestore className="mr-1 size-3.5" />
+            {t(($) => $.row_actions.restore)}
+          </Button>
+        )}
+        {anyActive && (
+          <Button
+            variant="ghost"
+            size="sm"
+            disabled={!anyOwned || busy}
+            onClick={() => setConfirmAccess(true)}
+          >
+            {t(($) => $.row_actions.set_access)}
+          </Button>
+        )}
+      </div>
+
+      {/* Archive confirm dialog */}
+      <Dialog open={confirmArchive} onOpenChange={setConfirmArchive}>
+        <DialogContent className="sm:max-w-md">
+          <DialogHeader>
+            <DialogTitle>
+              {t(($) => $.row_actions.archive_dialog_title, {
+                name:
+                  rows.length === 1 && rows[0]
+                    ? rows[0].agent.name
+                    : String(rows.length),
+              })}
+            </DialogTitle>
+            <DialogDescription>
+              {t(($) => $.row_actions.archive_dialog_description)}
+            </DialogDescription>
+          </DialogHeader>
+          <DialogFooter>
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              disabled={busy}
+              onClick={() => setConfirmArchive(false)}
+            >
+              {t(($) => $.row_actions.archive_dialog_cancel)}
+            </Button>
+            <Button
+              type="button"
+              variant="destructive"
+              size="sm"
+              disabled={busy}
+              onClick={async () => {
+                await runBatch(
+                  (id) => api.archiveAgent(id),
+                  rows.filter((r) => !r.agent.archived_at),
+                );
+                setConfirmArchive(false);
+              }}
+            >
+              {busy ? (
+                <Loader2 className="mr-1 size-3.5 animate-spin" />
+              ) : null}
+              {t(($) => $.row_actions.archive_dialog_confirm)}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      {/* Bulk access dialog — AccessPicker's internal Save is hidden (hideFooter)
+          so this dialog's Confirm button is the sole apply trigger via onChange.
+          a11y: focus trap + restore via Dialog; aria-live summary; accessible name. */}
+      <Dialog
+        open={confirmAccess}
+        onOpenChange={(open) => {
+          if (!open) setConfirmAccess(false);
+        }}
+      >
+        <DialogContent
+          className="sm:max-w-md"
+          aria-describedby="bulk-access-summary"
+        >
+          <DialogHeader>
+            <DialogTitle>
+              {t(($) => $.row_actions.set_access_dialog_title)}
+            </DialogTitle>
+            <DialogDescription id="bulk-access-summary">
+              <span aria-live="polite">
+                {t(($) => $.row_actions.set_access_applies_to, {
+                  count: ownedRows.length,
+                })}
+                {rows.length > ownedRows.length
+                  ? ` ${t(($) => $.row_actions.set_access_skipped, { count: rows.length - ownedRows.length })}`
+                  : ""}
+              </span>
+            </DialogDescription>
+          </DialogHeader>
+          <AccessPicker
+            permissionMode="private"
+            invocationTargets={undefined}
+            visibility="private"
+            members={members}
+            ownerId={currentUserId}
+            canEdit
+            hideFooter
+            onReadyChange={(ready, change) => { if (ready && change) setAccessChange(change); else if (!ready) setAccessChange(null); }}
+          />
+          <DialogFooter>
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              disabled={busy}
+              onClick={() => setConfirmAccess(false)}
+            >
+              {t(($) => $.row_actions.archive_dialog_cancel)}
+            </Button>
+            <Button
+              type="button"
+              size="sm"
+              disabled={busy || !accessConfirmEnabled}
+              onClick={async () => {
+                if (!accessChange) return;
+                const change = accessChange;
+                setConfirmAccess(false);
+                await applyAccessBulk(change);
+              }}
+            >
+              {busy ? (
+                <Loader2 className="mr-1 size-3.5 animate-spin" />
+              ) : null}
+              {t(($) => $.row_actions.set_access_dialog_confirm)}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </>
+  );
+}

--- a/packages/views/agents/components/agent-batch-toolbar.tsx
+++ b/packages/views/agents/components/agent-batch-toolbar.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useCallback, useState } from "react";
 import { useQueryClient } from "@tanstack/react-query";
 import { toast } from "sonner";
 import type { MemberWithUser } from "@multica/core/types";
@@ -20,9 +20,6 @@ import { Archive, ArchiveRestore, Loader2, X } from "lucide-react";
 import { useT } from "../../i18n";
 import { AccessPicker, type AccessChange } from "./inspector/access-picker";
 import type { AgentListRow } from "./agents-page";
-
-// Stable empty array — passing [] inline creates a new reference each render,
-// which resets AccessPicker's draft via its useEffect dependency cascade.
 
 /**
  * Floating batch-toolbar for the agents list page. Renders archive/restore
@@ -52,6 +49,23 @@ export function AgentBatchToolbar({
   const [confirmAccess, setConfirmAccess] = useState(false);
   const [accessChange, setAccessChange] = useState<AccessChange | null>(null);
   const [busy, setBusy] = useState(false);
+
+  // Must be stable: AccessPicker lists this in the effect that notifies us, so
+  // an inline callback would re-notify on every render we cause by storing the
+  // change — that is an update loop, not a re-render.
+  const handleAccessReadyChange = useCallback(
+    (ready: boolean, change?: AccessChange) => {
+      setAccessChange(ready && change ? change : null);
+    },
+    [],
+  );
+
+  // The picker owns the draft; we own `accessChange`. Reset it on every open and
+  // close so a previous selection can never leak into the next dialog session.
+  const setAccessDialogOpen = useCallback((open: boolean) => {
+    setAccessChange(null);
+    setConfirmAccess(open);
+  }, []);
 
   if (rows.length === 0) return null;
 
@@ -158,7 +172,7 @@ export function AgentBatchToolbar({
             variant="ghost"
             size="sm"
             disabled={!anyOwned || busy}
-            onClick={() => setConfirmAccess(true)}
+            onClick={() => setAccessDialogOpen(true)}
           >
             {t(($) => $.row_actions.set_access)}
           </Button>
@@ -216,12 +230,7 @@ export function AgentBatchToolbar({
       {/* Bulk access dialog — AccessPicker's internal Save is hidden (hideFooter)
           so this dialog's Confirm button is the sole apply trigger via onChange.
           a11y: focus trap + restore via Dialog; aria-live summary; accessible name. */}
-      <Dialog
-        open={confirmAccess}
-        onOpenChange={(open) => {
-          if (!open) setConfirmAccess(false);
-        }}
-      >
+      <Dialog open={confirmAccess} onOpenChange={setAccessDialogOpen}>
         <DialogContent
           className="sm:max-w-md"
           aria-describedby="bulk-access-summary"
@@ -249,7 +258,7 @@ export function AgentBatchToolbar({
             ownerId={currentUserId}
             canEdit
             hideFooter
-            onReadyChange={(ready, change) => { if (ready && change) setAccessChange(change); else if (!ready) setAccessChange(null); }}
+            onReadyChange={handleAccessReadyChange}
           />
           <DialogFooter>
             <Button
@@ -257,7 +266,7 @@ export function AgentBatchToolbar({
               variant="outline"
               size="sm"
               disabled={busy}
-              onClick={() => setConfirmAccess(false)}
+              onClick={() => setAccessDialogOpen(false)}
             >
               {t(($) => $.row_actions.archive_dialog_cancel)}
             </Button>
@@ -268,7 +277,7 @@ export function AgentBatchToolbar({
               onClick={async () => {
                 if (!accessChange) return;
                 const change = accessChange;
-                setConfirmAccess(false);
+                setAccessDialogOpen(false);
                 await applyAccessBulk(change);
               }}
             >

--- a/packages/views/agents/components/agent-list-toolbar.tsx
+++ b/packages/views/agents/components/agent-list-toolbar.tsx
@@ -8,7 +8,11 @@ import {
   Search,
   X,
 } from "lucide-react";
-import type { AgentAvailability } from "@multica/core/agents";
+import {
+  ALL_ACCESS_SCOPES,
+  effectiveAccessScope,
+  type AgentAvailability,
+} from "@multica/core/agents";
 import type { MemberWithUser } from "@multica/core/types";
 import { resolvePublicFileUrl } from "@multica/core/workspace/avatar-url";
 import {
@@ -52,6 +56,7 @@ import type { AgentListRow } from "./agents-page";
 const COLUMN_KEYS: AgentColumnKey[] = [
   "status",
   "owner",
+  "access",
   "runtime",
   "lastActive",
   "runs",
@@ -80,8 +85,11 @@ export function countActiveFilterDimensions(
   if (filters.runtimes.length > 0) count++;
   if (filters.owners.length > 0) count++;
   if (filters.models.length > 0) count++;
+  if (filters.access.length > 0) count++;
   return count;
 }
+
+const ACCESS_SCOPES = ALL_ACCESS_SCOPES;
 
 export function AgentListToolbar({
   scope,
@@ -134,6 +142,7 @@ export function AgentListToolbar({
   // toggling one dimension doesn't make the others' options vanish.
   const availabilityCounts = new Map<string, number>();
   const runtimeOptions = new Map<string, { name: string; count: number }>();
+  const accessCounts = new Map<string, number>();
   for (const row of allRows) {
     if (row.presence) {
       availabilityCounts.set(
@@ -147,6 +156,8 @@ export function AgentListToolbar({
       if (entry) entry.count += 1;
       else runtimeOptions.set(rt.id, { name: rt.name, count: 1 });
     }
+    const a = effectiveAccessScope(row.agent.permission_mode, row.agent.invocation_targets);
+    accessCounts.set(a, (accessCounts.get(a) ?? 0) + 1);
   }
 
   // Owner options: members who own at least one agent in the current scope.
@@ -176,6 +187,7 @@ export function AgentListToolbar({
   const COLUMN_LABELS: Record<AgentColumnKey, string> = {
     status: t(($) => $.columns.status),
     owner: t(($) => $.columns.owner),
+    access: t(($) => $.columns.access),
     runtime: t(($) => $.columns.runtime),
     lastActive: t(($) => $.columns.last_active),
     runs: t(($) => $.columns.runs),
@@ -354,6 +366,43 @@ export function AgentListToolbar({
                     </DropdownMenuCheckboxItem>
                   );
                 })}
+              </DropdownMenuSubContent>
+            </DropdownMenuSub>
+
+            {/* Access — effective access scope (workspace / specific-people / owner-only).
+                Mirrors Availability's keyboard/ARIA pattern. */}
+            <DropdownMenuSub>
+              <DropdownMenuSubTrigger>
+                <span className="flex-1">
+                  {t(($) => $.toolbar.section_access)}
+                </span>
+                {filters.access.length > 0 && (
+                  <span className="text-xs font-medium text-primary">
+                    {filters.access.length}
+                  </span>
+                )}
+              </DropdownMenuSubTrigger>
+              <DropdownMenuSubContent className="w-auto min-w-44">
+                {ACCESS_SCOPES.map((value) => (
+                  <DropdownMenuCheckboxItem
+                    key={value}
+                    checked={filters.access.includes(value)}
+                    onCheckedChange={() => onToggleFilter("access", value)}
+                    className={FILTER_ITEM_CLASS}
+                  >
+                    <HoverCheck checked={filters.access.includes(value)} />
+                    <span className="min-w-0 truncate">
+                      {t(($) =>
+                        value === "workspace"
+                          ? $.access.scope_labels.workspace
+                          : value === "specific-people"
+                            ? $.access.scope_labels.specific_people
+                            : $.access.scope_labels.owner_only,
+                      )}
+                    </span>
+                    {countBadge(accessCounts.get(value) ?? 0)}
+                  </DropdownMenuCheckboxItem>
+                ))}
               </DropdownMenuSubContent>
             </DropdownMenuSub>
 

--- a/packages/views/agents/components/agents-page-access-cell.test.tsx
+++ b/packages/views/agents/components/agents-page-access-cell.test.tsx
@@ -1,0 +1,120 @@
+// @vitest-environment jsdom
+
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { I18nProvider } from "@multica/core/i18n/react";
+import enCommon from "../../locales/en/common.json";
+import enAgents from "../../locales/en/agents.json";
+import { AccessCell, type AgentListRow } from "./agents-page";
+
+const TEST_RESOURCES = { en: { common: enCommon, agents: enAgents } };
+
+function makeRow(
+  overrides: Partial<AgentListRow["agent"]> = {},
+): AgentListRow {
+  return {
+    agent: {
+      id: "agent-1",
+      workspace_id: "ws-1",
+      runtime_id: "rt-1",
+      name: "Test",
+      description: "",
+      instructions: "",
+      avatar_url: null,
+      runtime_mode: "local",
+      runtime_config: {},
+      max_concurrent_tasks: 1,
+      owner_id: "user-1",
+      archived_at: null,
+      custom_args: [],
+      visibility: "private",
+      permission_mode: "private",
+      invocation_targets: [],
+      model: "claude",
+      created_at: "2026-01-01T00:00:00Z",
+      updated_at: "2026-01-01T00:00:00Z",
+      status: "idle",
+      skills: [],
+      archived_by: null,
+      ...overrides,
+    },
+    runtime: null,
+    presence: null,
+    activity: null,
+    runCount: 0,
+    lastActiveDays: null,
+    owner: null,
+    isOwnedByMe: false,
+    canManage: false,
+  };
+}
+
+function renderCell(row: AgentListRow) {
+  return render(
+    <I18nProvider locale="en" resources={TEST_RESOURCES}>
+      <table>
+        <tbody>
+          <tr>
+            <AccessCell row={row} />
+          </tr>
+        </tbody>
+      </table>
+    </I18nProvider>,
+  );
+}
+
+describe("AccessCell", () => {
+  it("renders 'Owner only' for a private agent", () => {
+    renderCell(makeRow({ permission_mode: "private", invocation_targets: [] }));
+    expect(screen.getByText("Owner only")).toBeInTheDocument();
+  });
+
+  it("renders 'Workspace' for a public_to agent with a workspace target", () => {
+    renderCell(
+      makeRow({
+        permission_mode: "public_to",
+        invocation_targets: [{ target_type: "workspace", target_id: "" }],
+      }),
+    );
+    expect(screen.getByText("Workspace")).toBeInTheDocument();
+  });
+
+  it("renders 'Specific people' for a public_to agent with a member target", () => {
+    renderCell(
+      makeRow({
+        permission_mode: "public_to",
+        invocation_targets: [
+          { target_type: "member", target_id: "user-1" },
+        ],
+      }),
+    );
+    expect(screen.getByText("Specific people")).toBeInTheDocument();
+    expect(screen.queryByText("Workspace")).not.toBeInTheDocument();
+  });
+
+  it("prefers 'Workspace' when a workspace target sits alongside member targets", () => {
+    renderCell(
+      makeRow({
+        permission_mode: "public_to",
+        invocation_targets: [
+          { target_type: "member", target_id: "user-1" },
+          { target_type: "workspace", target_id: "" },
+        ],
+      }),
+    );
+    expect(screen.getByText("Workspace")).toBeInTheDocument();
+  });
+
+  it("renders 'Specific people' for a public_to agent with no targets", () => {
+    renderCell(
+      makeRow({ permission_mode: "public_to", invocation_targets: [] }),
+    );
+    expect(screen.getByText("Specific people")).toBeInTheDocument();
+  });
+
+  it("fails safe to 'Owner only' when permission_mode is missing", () => {
+    const row = makeRow({ permission_mode: undefined as unknown as never, invocation_targets: [] });
+    renderCell(row);
+    expect(screen.getByText("Owner only")).toBeInTheDocument();
+  });
+});

--- a/packages/views/agents/components/agents-page-bulk-access-dialog-state.test.ts
+++ b/packages/views/agents/components/agents-page-bulk-access-dialog-state.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect } from "vitest";
+import { isAccessChangeReady } from "@multica/core/agents";
+import type { AccessChange } from "./inspector/access-picker";
+
+function change(
+  permission_mode: AccessChange["permission_mode"],
+  memberIds: string[] = [],
+): AccessChange {
+  return {
+    permission_mode,
+    invocation_targets: memberIds.map((id) => ({
+      target_type: "member",
+      target_id: id,
+    })),
+  };
+}
+
+const workspaceTarget: AccessChange = {
+  permission_mode: "public_to",
+  invocation_targets: [{ target_type: "workspace", target_id: "" }],
+};
+
+describe("isAccessChangeReady — bulk-access dialog confirm gate", () => {
+  it("null change is not ready (no preselect)", () => {
+    expect(isAccessChangeReady(null)).toBe(false);
+  });
+
+  it("Owner-only is ready with zero targets (the only valid clear state)", () => {
+    expect(isAccessChangeReady(change("private"))).toBe(true);
+  });
+
+  it("public_to with a workspace target is ready", () => {
+    expect(isAccessChangeReady(workspaceTarget)).toBe(true);
+  });
+
+  it("public_to with ≥1 member target is ready", () => {
+    expect(isAccessChangeReady(change("public_to", ["user-1"]))).toBe(true);
+  });
+
+  it("public_to with zero invocation_targets is NOT ready", () => {
+    // The AccessPicker requires ≥1 workspace or member target before
+    // emitting a public_to change, so this only happens if the caller
+    // bypasses the picker. isAccessChangeReady stays safe.
+    expect(isAccessChangeReady(change("public_to", []))).toBe(false);
+  });
+});

--- a/packages/views/agents/components/agents-page-filter-predicate.test.ts
+++ b/packages/views/agents/components/agents-page-filter-predicate.test.ts
@@ -1,0 +1,223 @@
+import { describe, it, expect } from "vitest";
+import {
+  effectiveAccessScope,
+  type AccessScope,
+} from "@multica/core/agents";
+import {
+  EMPTY_AGENT_FILTERS,
+  type AgentListFilters,
+} from "@multica/core/agents/stores";
+import { rowMatchesFilters, type AgentListRow } from "./agents-page";
+
+function makeRow(
+  overrides: Partial<AgentListRow["agent"]> = {},
+  rowOverrides: Partial<AgentListRow> = {},
+): AgentListRow {
+  return {
+    agent: {
+      id: "agent-1",
+      workspace_id: "ws-1",
+      runtime_id: "rt-1",
+      name: "Test",
+      description: "",
+      instructions: "",
+      avatar_url: null,
+      runtime_mode: "local",
+      runtime_config: {},
+      max_concurrent_tasks: 1,
+      owner_id: "user-1",
+      archived_at: null,
+      custom_args: [],
+      visibility: "private",
+      permission_mode: "private",
+      invocation_targets: [],
+      model: "claude",
+      created_at: "2026-01-01T00:00:00Z",
+      updated_at: "2026-01-01T00:00:00Z",
+      status: "idle",
+      skills: [],
+      archived_by: null,
+      ...overrides,
+    },
+    runtime: null,
+    presence: null,
+    activity: null,
+    runCount: 0,
+    lastActiveDays: null,
+    owner: null,
+    isOwnedByMe: false,
+    canManage: false,
+    ...rowOverrides,
+  };
+}
+
+function withAccess(
+  filters: AgentListFilters,
+  value: AccessScope,
+): AgentListFilters {
+  return { ...filters, access: [value] };
+}
+
+describe("rowMatchesFilters — access dimension", () => {
+  const noFilters = EMPTY_AGENT_FILTERS;
+
+  it("empty access filter is inactive (all rows pass)", () => {
+    const ownerOnly = makeRow({ permission_mode: "private" });
+    const workspace = makeRow({
+      permission_mode: "public_to",
+      invocation_targets: [{ target_type: "workspace", target_id: null }],
+    });
+    const specific = makeRow({
+      permission_mode: "public_to",
+      invocation_targets: [{ target_type: "member", target_id: "u" }],
+    });
+    expect(rowMatchesFilters(ownerOnly, noFilters, "")).toBe(true);
+    expect(rowMatchesFilters(workspace, noFilters, "")).toBe(true);
+    expect(rowMatchesFilters(specific, noFilters, "")).toBe(true);
+  });
+
+  it("filters to owner-only", () => {
+    const ownerOnly = makeRow({ permission_mode: "private" });
+    const workspace = makeRow({
+      permission_mode: "public_to",
+      invocation_targets: [{ target_type: "workspace", target_id: null }],
+    });
+    expect(rowMatchesFilters(ownerOnly, withAccess(noFilters, "owner-only"), "")).toBe(true);
+    expect(rowMatchesFilters(workspace, withAccess(noFilters, "owner-only"), "")).toBe(false);
+  });
+
+  it("filters to workspace", () => {
+    const ownerOnly = makeRow({ permission_mode: "private" });
+    const workspace = makeRow({
+      permission_mode: "public_to",
+      invocation_targets: [{ target_type: "workspace", target_id: "" }],
+    });
+    const specific = makeRow({
+      permission_mode: "public_to",
+      invocation_targets: [{ target_type: "member", target_id: "u" }],
+    });
+    expect(rowMatchesFilters(workspace, withAccess(noFilters, "workspace"), "")).toBe(true);
+    expect(rowMatchesFilters(ownerOnly, withAccess(noFilters, "workspace"), "")).toBe(false);
+    expect(rowMatchesFilters(specific, withAccess(noFilters, "workspace"), "")).toBe(false);
+  });
+
+  it("filters to specific-people", () => {
+    const ownerOnly = makeRow({ permission_mode: "private" });
+    const workspace = makeRow({
+      permission_mode: "public_to",
+      invocation_targets: [{ target_type: "workspace", target_id: null }],
+    });
+    const specific = makeRow({
+      permission_mode: "public_to",
+      invocation_targets: [{ target_type: "member", target_id: "u" }],
+    });
+    expect(rowMatchesFilters(specific, withAccess(noFilters, "specific-people"), "")).toBe(true);
+    expect(rowMatchesFilters(workspace, withAccess(noFilters, "specific-people"), "")).toBe(false);
+    expect(rowMatchesFilters(ownerOnly, withAccess(noFilters, "specific-people"), "")).toBe(false);
+  });
+
+  it("multi-select access filter is OR-combined", () => {
+    const ownerOnly = makeRow({ permission_mode: "private" });
+    const workspace = makeRow({
+      permission_mode: "public_to",
+      invocation_targets: [{ target_type: "workspace", target_id: null }],
+    });
+    const filters: AgentListFilters = { ...noFilters, access: ["owner-only", "workspace"] };
+    expect(rowMatchesFilters(ownerOnly, filters, "")).toBe(true);
+    expect(rowMatchesFilters(workspace, filters, "")).toBe(true);
+  });
+
+  it("access filter combines with other dimensions (AND)", () => {
+    const ownerUser1 = makeRow(
+      { owner_id: "user-1" },
+      { isOwnedByMe: true },
+    );
+    const ownerUser2 = makeRow(
+      { owner_id: "user-2" },
+      { isOwnedByMe: false },
+    );
+    const filters: AgentListFilters = {
+      ...noFilters,
+      access: ["owner-only"],
+      owners: ["user-1"],
+    };
+    expect(rowMatchesFilters(ownerUser1, filters, "")).toBe(true);
+    expect(rowMatchesFilters(ownerUser2, filters, "")).toBe(false);
+  });
+
+  it("access + availability filter: both must pass (AND)", () => {
+    const onlineAgent = makeRow(
+      { permission_mode: "public_to", invocation_targets: [{ target_type: 'workspace', target_id: '' }] },
+      { presence: { availability: "online" } as AgentListRow["presence"] },
+    );
+    const offlineAgent = makeRow(
+      { permission_mode: "public_to", invocation_targets: [{ target_type: 'workspace', target_id: '' }] },
+      { presence: { availability: "offline" } as AgentListRow["presence"] },
+    );
+    const filters: AgentListFilters = {
+      ...noFilters,
+      access: ["workspace"],
+      availability: ["online"],
+    };
+    expect(rowMatchesFilters(onlineAgent, filters, "")).toBe(true);
+    expect(rowMatchesFilters(offlineAgent, filters, "")).toBe(false);
+  });
+
+  it("access + runtimes filter: both must pass (AND)", () => {
+    const localAgent = makeRow(
+      { permission_mode: "private", runtime_id: "rt-local" },
+    );
+    const cloudAgent = makeRow(
+      { permission_mode: "private", runtime_id: "rt-cloud" },
+    );
+    const filters: AgentListFilters = {
+      ...noFilters,
+      access: ["owner-only"],
+      runtimes: ["rt-local"],
+    };
+    expect(rowMatchesFilters(localAgent, filters, "")).toBe(true);
+    expect(rowMatchesFilters(cloudAgent, filters, "")).toBe(false);
+  });
+
+  it("access filter value matches the same derivation as effectiveAccessScope", () => {
+    // The column and the filter share one derivation — guard against drift.
+    const cases: Array<{
+      label: string;
+      row: AgentListRow;
+      expected: "workspace" | "specific-people" | "owner-only";
+    }> = [
+      {
+        label: "private",
+        row: makeRow({ permission_mode: "private" }),
+        expected: "owner-only",
+      },
+      {
+        label: "public_to + workspace",
+        row: makeRow({
+          permission_mode: "public_to",
+          invocation_targets: [{ target_type: "workspace", target_id: "" }],
+        }),
+        expected: "workspace",
+      },
+      {
+        label: "public_to + member",
+        row: makeRow({
+          permission_mode: "public_to",
+          invocation_targets: [{ target_type: "member", target_id: "u" }],
+        }),
+        expected: "specific-people",
+      },
+      {
+        label: "public_to + no targets",
+        row: makeRow({ permission_mode: "public_to", invocation_targets: [] }),
+        expected: "specific-people",
+      },
+    ];
+    for (const { label, row, expected } of cases) {
+      expect(
+        effectiveAccessScope(row.agent.permission_mode, row.agent.invocation_targets),
+        label,
+      ).toBe(expected);
+    }
+  });
+});

--- a/packages/views/agents/components/agents-page.test.tsx
+++ b/packages/views/agents/components/agents-page.test.tsx
@@ -39,6 +39,7 @@ const mocks = vi.hoisted(() => ({
       runtimes: [] as string[],
       owners: [] as string[],
       models: [] as string[],
+      access: [] as string[],
     },
     setScope: vi.fn(),
     toggleSort: vi.fn(),
@@ -93,6 +94,12 @@ vi.mock("@multica/core/agents", () => ({
   useWorkspaceActivityMap: () => mocks.activity,
   useWorkspacePresenceMap: () => mocks.presence,
   VISIBILITY_TOOLTIP: { private: "Private", workspace: "Workspace" },
+  effectiveAccessScope: (pm: unknown, it: unknown) => {
+    if (pm !== "public_to") return "owner-only";
+    if ((Array.isArray(it) ? it : []).some((t) => (t as {target_type?: string})?.target_type === "workspace")) return "workspace";
+    return "specific-people";
+  },
+  ALL_ACCESS_SCOPES: ["workspace", "specific-people", "owner-only"],
 }));
 
 vi.mock("@multica/core/agents/stores", () => ({
@@ -241,6 +248,7 @@ beforeEach(() => {
     runtimes: [],
     owners: [],
     models: [],
+    access: [],
   };
 });
 

--- a/packages/views/agents/components/agents-page.tsx
+++ b/packages/views/agents/components/agents-page.tsx
@@ -3,17 +3,12 @@
 import { useCallback, useMemo, useRef, useState } from "react";
 import {
   AlertCircle,
-  Archive,
-  ArchiveRestore,
   Bot,
-  Loader2,
   Lock,
   Plus,
-  X,
 } from "lucide-react";
-import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { useQuery } from "@tanstack/react-query";
 import { useVirtualizer } from "@tanstack/react-virtual";
-import { toast } from "sonner";
 import type {
   Agent,
   AgentRuntime,
@@ -22,12 +17,14 @@ import type {
 import {
   type AgentActivity,
   agentRunCounts30dOptions,
+  effectiveAccessScope,
   useWorkspaceActivityMap,
   useWorkspacePresenceMap,
   VISIBILITY_TOOLTIP,
   type AgentPresenceDetail,
 } from "@multica/core/agents";
 import {
+  type AgentListFilters,
   useAgentsViewStore,
   AGENT_DEFAULT_HIDDEN_COLUMNS,
   AGENT_SCOPES,
@@ -35,26 +32,16 @@ import {
   type AgentsScope,
   type AgentSortField,
 } from "@multica/core/agents/stores";
-import { api } from "@multica/core/api";
 import { useAuthStore } from "@multica/core/auth";
 import { useWorkspaceId } from "@multica/core/hooks";
 import { useWorkspacePaths } from "@multica/core/paths";
 import {
   agentListOptions,
   memberListOptions,
-  workspaceKeys,
 } from "@multica/core/workspace/queries";
 import { runtimeDisplayLabel, runtimeListOptions } from "@multica/core/runtimes";
 import { Button } from "@multica/ui/components/ui/button";
 import { Checkbox } from "@multica/ui/components/ui/checkbox";
-import {
-  Dialog,
-  DialogContent,
-  DialogDescription,
-  DialogFooter,
-  DialogHeader,
-  DialogTitle,
-} from "@multica/ui/components/ui/dialog";
 import {
   LIST_GRID_BOTTOM_CLEARANCE,
   ListGrid,
@@ -98,7 +85,7 @@ import { matchesPinyin } from "../../editor/extensions/pinyin-match";
 // the documented exception to the single-line management-list rule.
 const GRID_COLS =
   "grid-cols-[0.75rem_minmax(120px,1fr)_var(--agc-status-mobile)_1.75rem_0.75rem] " +
-  "@2xl:grid-cols-[0.75rem_1rem_minmax(200px,1fr)_var(--agc-status-desktop)_var(--agc-owner)_var(--agc-runtime)_var(--agc-lastactive)_var(--agc-runs)_var(--agc-model)_var(--agc-created)_1.75rem_0.75rem]";
+  "@2xl:grid-cols-[0.75rem_1rem_minmax(200px,1fr)_var(--agc-status-desktop)_var(--agc-owner)_var(--agc-access)_var(--agc-runtime)_var(--agc-lastactive)_var(--agc-runs)_var(--agc-model)_var(--agc-created)_1.75rem_0.75rem]";
 
 // Two-line rows; the virtualizer's fixed-size contract.
 const ROW_HEIGHT = 64;
@@ -110,6 +97,8 @@ const COLUMN_WIDTHS: Record<AgentColumnKey, number> = {
   // idle rows show only the dot + label and leave some in-track slack.
   status: 144,
   owner: 144,
+  // Fits the longest label "Specific people" (~120px incl. padding).
+  access: 132,
   runtime: 144,
   lastActive: 120,
   runs: 88,
@@ -137,6 +126,7 @@ function columnTrackVars(
     "--agc-status-mobile": isVisible("status") ? "96px" : "0px",
     "--agc-status-desktop": width("status"),
     "--agc-owner": width("owner"),
+    "--agc-access": width("access"),
     "--agc-runtime": width("runtime"),
     "--agc-lastactive": width("lastActive"),
     "--agc-runs": width("runs"),
@@ -181,6 +171,67 @@ function matchesAgentSearch(row: AgentListRow, query: string): boolean {
     (agent.description ? matchesPinyin(agent.description, query) : false)
   );
 }
+
+/**
+ * Pure row-filter predicate: returns true if the row matches all active
+ * filter dimensions. Empty filter arrays are inactive (the row passes). The
+ * `access` dimension derives its key via `effectiveAccessScope` so the column
+ * and the filter share one derivation. Exported for testing — the page wires
+ * it inside its `useMemo`.
+ */
+export function rowMatchesFilters(
+  row: AgentListRow,
+  filters: AgentListFilters,
+  query: string,
+): boolean {
+  if (!matchesAgentSearch(row, query.trim().toLowerCase())) return false;
+  if (
+    filters.availability.length > 0 &&
+    (!row.presence || !filters.availability.includes(row.presence.availability))
+  ) {
+    return false;
+  }
+  if (
+    filters.runtimes.length > 0 &&
+    !filters.runtimes.includes(row.agent.runtime_id)
+  ) {
+    return false;
+  }
+  if (
+    filters.owners.length > 0 &&
+    (!row.agent.owner_id || !filters.owners.includes(row.agent.owner_id))
+  ) {
+    return false;
+  }
+  if (
+    filters.models.length > 0 &&
+    !filters.models.includes(row.agent.model)
+  ) {
+    return false;
+  }
+  if (
+    filters.access.length > 0 &&
+    !filters.access.includes(
+      effectiveAccessScope(
+        row.agent.permission_mode,
+        row.agent.invocation_targets,
+      ),
+    )
+  ) {
+    return false;
+  }
+  return true;
+}
+
+/**
+ * Bulk-access dialog confirm-button enablement is centralized in
+ * `@multica/core/agents` as `isAccessChangeReady` (MUL-3963). The dialog
+ * consumes it; the picker also gates its internal Save button on the same
+ * predicate (its own Save button is hidden via `hideFooter` in the bulk flow).
+ */
+import { isAccessChangeReady } from "@multica/core/agents";
+import { AgentBatchToolbar } from "./agent-batch-toolbar";
+export { isAccessChangeReady };
 
 export interface AgentsPageProps {
   /** Desktop-only daemon wiring, currently unused by the list (kept for
@@ -422,6 +473,35 @@ function OwnerCell({ row }: { row: AgentListRow }) {
   );
 }
 
+// Effective access scope derived from permission_mode + invocation_targets
+// (not the lossy derived `visibility`). Text label, not icon-only, so screen
+// readers announce the scope.
+export function AccessCell({ row }: { row: AgentListRow }) {
+  const { t } = useT("agents");
+  const scope = useMemo(
+    () =>
+      effectiveAccessScope(
+        row.agent.permission_mode,
+        row.agent.invocation_targets,
+      ),
+    [row.agent.permission_mode, row.agent.invocation_targets],
+  );
+  const label = t(($) =>
+    scope === "workspace"
+      ? $.access.scope_labels.workspace
+      : scope === "specific-people"
+        ? $.access.scope_labels.specific_people
+        : $.access.scope_labels.owner_only,
+  );
+  return (
+    <ListGridCell className="hidden @2xl:flex">
+      <span className="min-w-0 truncate text-xs text-muted-foreground">
+        {label}
+      </span>
+    </ListGridCell>
+  );
+}
+
 function RuntimeCell({ row }: { row: AgentListRow }) {
   const runtime = row.runtime;
   return (
@@ -518,6 +598,13 @@ function AgentListHeader({
       ) : (
         <ListGridHeaderCell className="hidden px-0 @2xl:flex" />
       )}
+      {isColVisible("access") ? (
+        <ListGridHeaderCell className="hidden @2xl:flex">
+          {t(($) => $.columns.access)}
+        </ListGridHeaderCell>
+      ) : (
+        <ListGridHeaderCell className="hidden px-0 @2xl:flex" />
+      )}
       {isColVisible("runtime") ? (
         <ListGridHeaderCell className="hidden @2xl:flex">
           {t(($) => $.columns.runtime)}
@@ -597,6 +684,9 @@ function LoadingSkeleton() {
           <Skeleton className="h-3 w-14" />
         </ListGridHeaderCell>
         <ListGridHeaderCell className="hidden @2xl:flex">
+          <Skeleton className="h-3 w-14" />
+        </ListGridHeaderCell>
+        <ListGridHeaderCell className="hidden @2xl:flex">
           <Skeleton className="h-3 w-10" />
         </ListGridHeaderCell>
         <ListGridHeaderCell className="hidden px-0 @2xl:flex" />
@@ -621,6 +711,9 @@ function LoadingSkeleton() {
             <Skeleton className="h-3 w-12" />
           </ListGridCell>
           <ListGridCell className="hidden @2xl:flex">
+            <Skeleton className="h-3 w-14" />
+          </ListGridCell>
+          <ListGridCell className="hidden @2xl:flex">
             <Skeleton className="h-3 w-16" />
           </ListGridCell>
           <ListGridCell className="hidden @2xl:flex">
@@ -640,148 +733,6 @@ function LoadingSkeleton() {
 
 // ---------------------------------------------------------------------------
 // Batch toolbar — archive (with confirm; archiving cancels active tasks) and
-// restore, mirroring the single-row actions. No delete: the API has none.
-// ---------------------------------------------------------------------------
-
-function AgentBatchToolbar({
-  rows,
-  onClear,
-}: {
-  rows: AgentListRow[];
-  onClear: () => void;
-}) {
-  const { t } = useT("agents");
-  const wsId = useWorkspaceId();
-  const qc = useQueryClient();
-  const [confirmArchive, setConfirmArchive] = useState(false);
-  const [busy, setBusy] = useState(false);
-
-  if (rows.length === 0) return null;
-
-  const allManageable = rows.every((r) => r.canManage);
-  const anyActive = rows.some((r) => !r.agent.archived_at);
-  const anyArchived = rows.some((r) => !!r.agent.archived_at);
-
-  const invalidate = () =>
-    qc.invalidateQueries({ queryKey: workspaceKeys.agents(wsId) });
-
-  const runBatch = async (
-    fn: (id: string) => Promise<unknown>,
-    targets: AgentListRow[],
-  ) => {
-    setBusy(true);
-    try {
-      for (const row of targets) {
-        await fn(row.agent.id);
-      }
-      invalidate();
-      onClear();
-    } catch (e) {
-      invalidate();
-      toast.error(e instanceof Error ? e.message : String(e));
-    } finally {
-      setBusy(false);
-    }
-  };
-
-  return (
-    <>
-      {/* Anchored to the page root (relative), NOT the viewport. */}
-      <div className="absolute bottom-6 left-1/2 z-50 flex -translate-x-1/2 items-center gap-1 rounded-lg border bg-background px-2 py-1.5 shadow-lg">
-        <div className="mr-1 flex items-center gap-1.5 border-r pl-1 pr-2">
-          <span className="text-sm font-medium">
-            {t(($) => $.actions.selected, { count: rows.length })}
-          </span>
-          <button
-            type="button"
-            aria-label={t(($) => $.actions.clear_selection)}
-            onClick={onClear}
-            className="rounded p-0.5 transition-colors hover:bg-accent"
-          >
-            <X className="size-3.5 text-muted-foreground" />
-          </button>
-        </div>
-
-        {anyActive && (
-          <Button
-            variant="ghost"
-            size="sm"
-            disabled={!allManageable || busy}
-            onClick={() => setConfirmArchive(true)}
-          >
-            <Archive className="mr-1 size-3.5" />
-            {t(($) => $.row_actions.archive)}
-          </Button>
-        )}
-        {anyArchived && (
-          <Button
-            variant="ghost"
-            size="sm"
-            disabled={!allManageable || busy}
-            onClick={() =>
-              runBatch(
-                (id) => api.restoreAgent(id),
-                rows.filter((r) => !!r.agent.archived_at),
-              )
-            }
-          >
-            <ArchiveRestore className="mr-1 size-3.5" />
-            {t(($) => $.row_actions.restore)}
-          </Button>
-        )}
-      </div>
-
-      <Dialog open={confirmArchive} onOpenChange={setConfirmArchive}>
-        <DialogContent className="sm:max-w-md">
-          <DialogHeader>
-            <DialogTitle>
-              {t(($) => $.row_actions.archive_dialog_title, {
-                name:
-                  rows.length === 1 && rows[0]
-                    ? rows[0].agent.name
-                    : String(rows.length),
-              })}
-            </DialogTitle>
-            <DialogDescription>
-              {t(($) => $.row_actions.archive_dialog_description)}
-            </DialogDescription>
-          </DialogHeader>
-          <DialogFooter>
-            <Button
-              type="button"
-              variant="outline"
-              size="sm"
-              disabled={busy}
-              onClick={() => setConfirmArchive(false)}
-            >
-              {t(($) => $.row_actions.archive_dialog_cancel)}
-            </Button>
-            <Button
-              type="button"
-              variant="destructive"
-              size="sm"
-              disabled={busy}
-              onClick={async () => {
-                await runBatch(
-                  (id) => api.archiveAgent(id),
-                  rows.filter((r) => !r.agent.archived_at),
-                );
-                setConfirmArchive(false);
-              }}
-            >
-              {busy ? (
-                <Loader2 className="mr-1 size-3.5 animate-spin" />
-              ) : null}
-              {t(($) => $.row_actions.archive_dialog_confirm)}
-            </Button>
-          </DialogFooter>
-        </DialogContent>
-      </Dialog>
-    </>
-  );
-}
-
-// ---------------------------------------------------------------------------
 // Page
 // ---------------------------------------------------------------------------
 
@@ -923,36 +874,7 @@ export function AgentsPage(_props: AgentsPageProps = {}) {
 
   // Visible rows: local search + filters, then sort.
   const rows = useMemo<AgentListRow[]>(() => {
-    const q = search.trim().toLowerCase();
-    const filtered = scopeRows.filter((row) => {
-      if (!matchesAgentSearch(row, q)) return false;
-      if (
-        filters.availability.length > 0 &&
-        (!row.presence ||
-          !filters.availability.includes(row.presence.availability))
-      ) {
-        return false;
-      }
-      if (
-        filters.runtimes.length > 0 &&
-        !filters.runtimes.includes(row.agent.runtime_id)
-      ) {
-        return false;
-      }
-      if (
-        filters.owners.length > 0 &&
-        (!row.agent.owner_id || !filters.owners.includes(row.agent.owner_id))
-      ) {
-        return false;
-      }
-      if (
-        filters.models.length > 0 &&
-        !filters.models.includes(row.agent.model)
-      ) {
-        return false;
-      }
-      return true;
-    });
+    const filtered = scopeRows.filter((row) => rowMatchesFilters(row, filters, search));
 
     const dir = sortDirection === "asc" ? 1 : -1;
     filtered.sort((a, b) => {
@@ -1167,6 +1089,11 @@ export function AgentsPage(_props: AgentsPageProps = {}) {
                       ) : (
                         <ListGridCell className="hidden px-0 @2xl:flex" />
                       )}
+                      {isColVisible("access") ? (
+                        <AccessCell row={row} />
+                      ) : (
+                        <ListGridCell className="hidden px-0 @2xl:flex" />
+                      )}
                       {isColVisible("runtime") ? (
                         <RuntimeCell row={row} />
                       ) : (
@@ -1226,6 +1153,8 @@ export function AgentsPage(_props: AgentsPageProps = {}) {
 
       <AgentBatchToolbar
         rows={selectedRows}
+        members={members}
+        currentUserId={currentUser?.id ?? null}
         onClear={() => setSelectedIds(new Set())}
       />
 

--- a/packages/views/agents/components/inspector/access-picker.tsx
+++ b/packages/views/agents/components/inspector/access-picker.tsx
@@ -138,18 +138,17 @@ export function AccessPicker({
     draftScope !== persistedScope ||
     (draftScope === "members" && !sameMembers);
   const hasMemberTarget = draftMembers.length > 0;
-  /** Ready once the user has explicitly selected a scope (hasInteracted)
-   *  AND the members-branch condition is satisfied. Does NOT require the
-   *  draft to differ from the persisted state — applying the default scope
-   *  to a bulk selection is a valid action. */
-  const ready = hasInteracted && (draftScope !== "members" || hasMemberTarget);
 
   useEffect(() => {
     onDirtyChange?.(dirty);
     return () => onDirtyChange?.(false);
   }, [dirty, onDirtyChange]);
 
-  const buildChange = (): AccessChange | null => {
+  /** The change the current draft would commit, or null when the draft is not
+   *  committable (specific-people with zero targets). Memoized by draft value:
+   *  a parent that stores this in state re-renders the picker with an identical
+   *  reference, so the notify effect below stays quiet. */
+  const draftChange = useMemo<AccessChange | null>(() => {
     if (draftScope === "private") {
       return { permission_mode: "private", invocation_targets: [] };
     }
@@ -167,12 +166,22 @@ export function AccessPicker({
       }
     }
     return { permission_mode: "public_to", invocation_targets: targets };
-  };
+  }, [draftScope, draftMembers, teamIds]);
 
+  /** Ready once the user has explicitly selected a scope (hasInteracted) AND
+   *  the draft is committable. Does NOT require the draft to differ from the
+   *  persisted state — applying the default scope to a bulk selection is a
+   *  valid action. */
+  const readyChange = hasInteracted ? draftChange : null;
+
+  // Notify on value change, never on render. `onReadyChange` must be stable in
+  // the caller; combined with the memoized `readyChange` that keeps a parent
+  // storing the change in state from re-triggering this effect. Deliberately no
+  // cleanup: clearing the parent whenever a dependency changes is what turned
+  // this into an update loop. The parent owns resetting its own state.
   useEffect(() => {
-    onReadyChange?.(ready, ready ? buildChange() ?? undefined : undefined);
-    return () => onReadyChange?.(false);
-  }, [ready, onReadyChange, buildChange]);
+    onReadyChange?.(readyChange !== null, readyChange ?? undefined);
+  }, [readyChange, onReadyChange]);
 
   const toggleMember = (userId: string, checked: boolean) => {
     setDraftMembers((current) => {
@@ -183,16 +192,11 @@ export function AccessPicker({
     });
   };
 
-  /** Build the current AccessChange from the draft state. Returns null if the
-   *  draft is not in a committable state (specific-people with zero targets). */
-
   const save = async () => {
-    if (!onChange || saving) return;
-    const change = buildChange();
-    if (!change) return;
+    if (!onChange || saving || !draftChange) return;
     setSaving(true);
     try {
-      await onChange(change);
+      await onChange(draftChange);
     } finally {
       setSaving(false);
     }

--- a/packages/views/agents/components/inspector/access-picker.tsx
+++ b/packages/views/agents/components/inspector/access-picker.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { Globe, Loader2, Lock, Users } from "lucide-react";
 import type {
   AgentInvocationTarget,
@@ -9,6 +9,7 @@ import type {
   AgentVisibility,
   MemberWithUser,
 } from "@multica/core/types";
+import { effectiveAccessScope } from "@multica/core/agents";
 import { Button } from "@multica/ui/components/ui/button";
 import { Checkbox } from "@multica/ui/components/ui/checkbox";
 import { ActorAvatar } from "../../../common/actor-avatar";
@@ -21,11 +22,6 @@ export type AccessChange = {
 
 type AccessScope = "private" | "workspace" | "members";
 
-function hasWorkspaceTarget(
-  targets: AgentInvocationTarget[] | undefined | null,
-): boolean {
-  return (targets ?? []).some((target) => target.target_type === "workspace");
-}
 
 function selectedTargetIds(
   targets: AgentInvocationTarget[] | undefined | null,
@@ -52,7 +48,9 @@ export function AccessPicker({
   canEdit = true,
   hasComposioAllowlist = false,
   onDirtyChange,
+  onReadyChange,
   onChange,
+  hideFooter = false,
 }: {
   permissionMode: AgentPermissionMode;
   invocationTargets: AgentInvocationTarget[] | undefined;
@@ -62,12 +60,23 @@ export function AccessPicker({
   canEdit?: boolean;
   hasComposioAllowlist?: boolean;
   onDirtyChange?: (dirty: boolean) => void;
-  onChange: (next: AccessChange) => Promise<void> | void;
+  /** Notified when the draft becomes committable / non-committable.
+   *  The optional second argument is the current AccessChange when the draft
+   *  is ready, so the parent can store it for immediate use (e.g. the bulk
+   *  dialog's Apply button). */
+  onReadyChange?: (ready: boolean, change?: AccessChange) => void;
+  onChange?: (next: AccessChange) => Promise<void> | void;
+  /** When true, suppress the bottom Save footer — the parent dialog owns
+   *  the apply trigger (e.g. the bulk "Set access scope" dialog). */
+  hideFooter?: boolean;
 }) {
   const { t } = useT("agents");
   const { t: tc } = useT("common");
+  // Centralized derivation (MUL-3963): map canonical scope to picker's
+  // local draft key (private / workspace / members).
+  const canonical = effectiveAccessScope(permissionMode, invocationTargets);
   const persistedPrivate = permissionMode === "private";
-  const persistedWorkspace = !persistedPrivate && hasWorkspaceTarget(invocationTargets);
+  const persistedWorkspace = canonical === "workspace";
   const persistedScope: AccessScope = persistedPrivate
     ? "private"
     : persistedWorkspace
@@ -85,11 +94,38 @@ export function AccessPicker({
   const [draftScope, setDraftScope] = useState<AccessScope>(persistedScope);
   const [draftMembers, setDraftMembers] = useState(persistedMembers);
   const [saving, setSaving] = useState(false);
+  /** Tracks whether the user has explicitly selected a scope (clicked any
+   *  radio). Once true, the picker considers the draft "ready" even if the
+   *  selection matches the persisted default — applying the default to a
+   *  bulk selection is still a valid action. */
+  const [hasInteracted, setHasInteracted] = useState(false);
 
+  /** Wrapper that marks the picker as interacted and updates the draft scope. */
+  const selectDraftScope = (scope: AccessScope) => {
+    setHasInteracted(true);
+    setDraftScope(scope);
+  };
+
+  // Only reset the draft when the PERSISTED values actually change by value,
+  // not by reference. A prop like invocationTargets={[]} creates a new array
+  // on every parent render, which would otherwise cause this effect to fire
+  // on every render and reset the user's in-progress edits.
+  const prevPersistedScopeRef = useRef(persistedScope);
+  const prevPersistedMembersRef = useRef(persistedMembers);
   useEffect(() => {
-    setDraftScope(persistedScope);
-    setDraftMembers(persistedMembers);
-  }, [persistedMembers, persistedScope]);
+    const scopeChanged = persistedScope !== prevPersistedScopeRef.current;
+    const membersChanged =
+      persistedMembers.length !== prevPersistedMembersRef.current.length ||
+      persistedMembers.some(
+        (id, i) => id !== prevPersistedMembersRef.current[i],
+      );
+    if (scopeChanged || membersChanged) {
+      setDraftScope(persistedScope);
+      setDraftMembers(persistedMembers);
+      prevPersistedScopeRef.current = persistedScope;
+      prevPersistedMembersRef.current = persistedMembers;
+    }
+  }, [persistedScope, persistedMembers]);
 
   const editableMembers = ownerId
     ? members.filter((member) => member.user_id !== ownerId)
@@ -102,11 +138,41 @@ export function AccessPicker({
     draftScope !== persistedScope ||
     (draftScope === "members" && !sameMembers);
   const hasMemberTarget = draftMembers.length > 0;
+  /** Ready once the user has explicitly selected a scope (hasInteracted)
+   *  AND the members-branch condition is satisfied. Does NOT require the
+   *  draft to differ from the persisted state — applying the default scope
+   *  to a bulk selection is a valid action. */
+  const ready = hasInteracted && (draftScope !== "members" || hasMemberTarget);
 
   useEffect(() => {
     onDirtyChange?.(dirty);
     return () => onDirtyChange?.(false);
   }, [dirty, onDirtyChange]);
+
+  const buildChange = (): AccessChange | null => {
+    if (draftScope === "private") {
+      return { permission_mode: "private", invocation_targets: [] };
+    }
+    const targets: AgentInvocationTargetInput[] = [];
+    if (draftScope === "workspace") {
+      targets.push({ target_type: "workspace" });
+    }
+    if (draftScope === "members") {
+      if (draftMembers.length === 0) return null;
+      for (const id of draftMembers) {
+        targets.push({ target_type: "member", target_id: id });
+      }
+      for (const id of teamIds) {
+        targets.push({ target_type: "team", target_id: id });
+      }
+    }
+    return { permission_mode: "public_to", invocation_targets: targets };
+  };
+
+  useEffect(() => {
+    onReadyChange?.(ready, ready ? buildChange() ?? undefined : undefined);
+    return () => onReadyChange?.(false);
+  }, [ready, onReadyChange, buildChange]);
 
   const toggleMember = (userId: string, checked: boolean) => {
     setDraftMembers((current) => {
@@ -117,29 +183,16 @@ export function AccessPicker({
     });
   };
 
-  const save = async () => {
-    if (!dirty || saving || (draftScope === "members" && !hasMemberTarget)) {
-      return;
-    }
-    const targets: AgentInvocationTargetInput[] = [];
-    if (draftScope === "workspace") {
-      targets.push({ target_type: "workspace" });
-    }
-    if (draftScope === "members") {
-      for (const id of draftMembers) {
-        targets.push({ target_type: "member", target_id: id });
-      }
-      for (const id of teamIds) {
-        targets.push({ target_type: "team", target_id: id });
-      }
-    }
+  /** Build the current AccessChange from the draft state. Returns null if the
+   *  draft is not in a committable state (specific-people with zero targets). */
 
+  const save = async () => {
+    if (!onChange || saving) return;
+    const change = buildChange();
+    if (!change) return;
     setSaving(true);
     try {
-      await onChange({
-        permission_mode: draftScope === "private" ? "private" : "public_to",
-        invocation_targets: draftScope === "private" ? [] : targets,
-      });
+      await onChange(change);
     } finally {
       setSaving(false);
     }
@@ -187,7 +240,7 @@ export function AccessPicker({
           title={t(($) => $.access.private_title)}
           description={t(($) => $.access.private_desc)}
           selected={draftScope === "private"}
-          onSelect={() => setDraftScope("private")}
+          onSelect={() => selectDraftScope("private")}
         />
         <AccessChoice
           name="agent-access-mode"
@@ -196,7 +249,7 @@ export function AccessPicker({
           title={t(($) => $.access.workspace_title)}
           description={t(($) => $.access.workspace_desc)}
           selected={draftScope === "workspace"}
-          onSelect={() => setDraftScope("workspace")}
+          onSelect={() => selectDraftScope("workspace")}
         />
         <AccessChoice
           name="agent-access-mode"
@@ -205,7 +258,7 @@ export function AccessPicker({
           title={t(($) => $.access.members_title)}
           description={t(($) => $.access.members_desc)}
           selected={draftScope === "members"}
-          onSelect={() => setDraftScope("members")}
+          onSelect={() => selectDraftScope("members")}
         />
       </div>
 
@@ -268,23 +321,25 @@ export function AccessPicker({
         </div>
       ) : null}
 
-      <div className="flex justify-end border-t border-surface-border px-4 py-3.5">
-        <Button
-          type="button"
-          onClick={() => void save()}
-          disabled={
-            !dirty || saving || (draftScope === "members" && !hasMemberTarget)
-          }
-        >
-          {saving ? (
-            <Loader2
-              className="size-4 animate-spin motion-reduce:animate-none"
-              aria-hidden="true"
-            />
-          ) : null}
-          {tc(($) => $.save)}
-        </Button>
-      </div>
+      {hideFooter ? null : (
+        <div className="flex justify-end border-t border-surface-border px-4 py-3.5">
+          <Button
+            type="button"
+            onClick={() => void save()}
+            disabled={
+              !onChange || !dirty || saving || (draftScope === "members" && !hasMemberTarget)
+            }
+          >
+            {saving ? (
+              <Loader2
+                className="size-4 animate-spin motion-reduce:animate-none"
+                aria-hidden="true"
+              />
+            ) : null}
+            {tc(($) => $.save)}
+          </Button>
+        </div>
+      )}
     </fieldset>
   );
 }

--- a/packages/views/locales/en/agents.json
+++ b/packages/views/locales/en/agents.json
@@ -71,7 +71,8 @@
     "last_active": "Last active",
     "model": "Model",
     "created": "Created",
-    "owner": "Owner"
+    "owner": "Owner",
+    "access": "Access"
   },
   "row": {
     "you": "You",
@@ -98,6 +99,12 @@
     "duplicate": "Duplicate",
     "restore": "Restore",
     "archive": "Archive",
+    "set_access": "Set access scope",
+    "set_access_dialog_title": "Set access scope",
+    "set_access_applies_to": "Applies to {{count}} agents.",
+    "set_access_skipped": "{{count}} skipped (not owned by you).",
+    "set_access_dialog_confirm": "Apply",
+    "set_access_bulk_partial": "Applied to {{succeeded}}; {{failed}} failed (kept in current state).",
     "agent_archived_toast": "Agent archived",
     "archive_failed_toast": "Failed to archive agent",
     "agent_restored_toast": "Agent restored",
@@ -275,9 +282,18 @@
     "step_configure": "Review and configure",
     "step_ai": "Build through conversation",
     "modes": {
-      "blank": { "title": "Start blank", "description": "Configure every field yourself. Best when you already know exactly how this agent should work." },
-      "template": { "title": "Use a template", "description": "Start from curated instructions and skills, then adapt every detail to your workspace." },
-      "ai": { "title": "Build with AI", "description": "Describe the outcome you want. An Agent Builder will ask focused questions and prepare a live draft." }
+      "blank": {
+        "title": "Start blank",
+        "description": "Configure every field yourself. Best when you already know exactly how this agent should work."
+      },
+      "template": {
+        "title": "Use a template",
+        "description": "Start from curated instructions and skills, then adapt every detail to your workspace."
+      },
+      "ai": {
+        "title": "Build with AI",
+        "description": "Describe the outcome you want. An Agent Builder will ask focused questions and prepare a live draft."
+      }
     },
     "templates": {
       "search": "Search templates…",
@@ -299,9 +315,19 @@
       "access_hint": "Control who can start runs with this agent. You can change this later."
     },
     "access": {
-      "private": { "title": "Only me", "description": "Only you can run this agent." },
-      "workspace": { "title": "Entire workspace", "description": "Every workspace member can run it." },
-      "members": { "title": "Specific people", "description": "Only selected members can run it.", "required": "Select at least one member." }
+      "private": {
+        "title": "Only me",
+        "description": "Only you can run this agent."
+      },
+      "workspace": {
+        "title": "Entire workspace",
+        "description": "Every workspace member can run it."
+      },
+      "members": {
+        "title": "Specific people",
+        "description": "Only selected members can run it.",
+        "required": "Select at least one member."
+      }
     },
     "builder": {
       "setup_title": "Choose a runtime for Agent Builder",
@@ -678,6 +704,11 @@
     "tooltip": "Access · who may run this agent",
     "trigger_private": "Only me",
     "trigger_workspace": "Workspace",
+    "scope_labels": {
+      "workspace": "Workspace",
+      "specific_people": "Specific people",
+      "owner_only": "Owner only"
+    },
     "trigger_members_count": "{{count}} people",
     "trigger_members_empty": "Specific people",
     "trigger_team": "Team",
@@ -761,6 +792,7 @@
     "filter_active_count_other": "{{count}} filters",
     "clear_filters": "Clear filters",
     "section_availability": "Availability",
+    "section_access": "Access",
     "section_runtime": "Runtime",
     "display": "Display",
     "sort_by": "Sort by",

--- a/packages/views/locales/ja/agents.json
+++ b/packages/views/locales/ja/agents.json
@@ -62,7 +62,8 @@
     "last_active": "最終アクティブ",
     "model": "モデル",
     "created": "作成日時",
-    "owner": "オーナー"
+    "owner": "オーナー",
+    "access": "アクセス"
   },
   "row": {
     "you": "あなた",
@@ -86,6 +87,12 @@
     "duplicate": "複製",
     "restore": "復元",
     "archive": "アーカイブ",
+    "set_access": "アクセス範囲を設定",
+    "set_access_dialog_title": "アクセス範囲を設定",
+    "set_access_applies_to": "{{count}} 件の agent に適用します。",
+    "set_access_skipped": "{{count}} 件スキップ(あなた所有ではありません)。",
+    "set_access_dialog_confirm": "適用",
+    "set_access_bulk_partial": "{{succeeded}} 件適用、{{failed}} 件失敗(現在の状態を維持)。",
     "agent_archived_toast": "エージェントをアーカイブしました",
     "archive_failed_toast": "エージェントをアーカイブできませんでした",
     "agent_restored_toast": "エージェントを復元しました",
@@ -583,6 +590,11 @@
     "tooltip": "アクセス · 誰がこのエージェントを実行できるか",
     "trigger_private": "自分のみ",
     "trigger_workspace": "ワークスペース",
+    "scope_labels": {
+      "workspace": "ワークスペース",
+      "specific_people": "特定のメンバー",
+      "owner_only": "オーナーのみ"
+    },
     "trigger_members_count": "{{count}} 人",
     "trigger_members_empty": "特定のメンバー",
     "trigger_team": "チーム",
@@ -670,6 +682,7 @@
     "filter_active_count_other": "{{count}} 件のフィルター",
     "clear_filters": "フィルターをクリア",
     "section_availability": "可用性",
+    "section_access": "アクセス",
     "section_runtime": "ランタイム",
     "display": "表示",
     "sort_by": "並び替え",

--- a/packages/views/locales/ko/agents.json
+++ b/packages/views/locales/ko/agents.json
@@ -70,7 +70,8 @@
     "last_active": "최근 활동",
     "model": "모델",
     "created": "생성일",
-    "owner": "소유자"
+    "owner": "소유자",
+    "access": "액세스"
   },
   "row": {
     "you": "나",
@@ -94,6 +95,12 @@
     "duplicate": "복제",
     "restore": "복원",
     "archive": "보관",
+    "set_access": "접근 범위 설정",
+    "set_access_dialog_title": "접근 범위 설정",
+    "set_access_applies_to": "{{count}}개 agent에 적용됩니다.",
+    "set_access_skipped": "{{count}}개 건너뜀(본인 소유 아님).",
+    "set_access_dialog_confirm": "적용",
+    "set_access_bulk_partial": "{{succeeded}}개 적용, {{failed}}개 실패(현재 상태 유지).",
     "agent_archived_toast": "에이전트를 보관했습니다",
     "archive_failed_toast": "에이전트를 보관하지 못했습니다",
     "agent_restored_toast": "에이전트를 복원했습니다",
@@ -591,6 +598,11 @@
     "tooltip": "접근 권한 · 누가 이 에이전트를 실행할 수 있는지",
     "trigger_private": "나만",
     "trigger_workspace": "워크스페이스",
+    "scope_labels": {
+      "workspace": "워크스페이스",
+      "specific_people": "특정 사용자",
+      "owner_only": "소유자만"
+    },
     "trigger_members_count": "{{count}}명",
     "trigger_members_empty": "특정 사용자",
     "trigger_team": "팀",
@@ -670,6 +682,7 @@
     "filter_active_count_other": "필터 {{count}}개",
     "clear_filters": "필터 지우기",
     "section_availability": "가용성",
+    "section_access": "액세스",
     "section_runtime": "런타임",
     "display": "표시",
     "sort_by": "정렬",

--- a/packages/views/locales/zh-Hans/agents.json
+++ b/packages/views/locales/zh-Hans/agents.json
@@ -70,7 +70,8 @@
     "last_active": "最近活跃",
     "model": "模型",
     "created": "创建时间",
-    "owner": "Owner"
+    "owner": "Owner",
+    "access": "访问范围"
   },
   "row": {
     "you": "你",
@@ -94,6 +95,12 @@
     "duplicate": "复制",
     "restore": "恢复",
     "archive": "归档",
+    "set_access": "设置访问范围",
+    "set_access_dialog_title": "设置访问范围",
+    "set_access_applies_to": "将应用于 {{count}} 个 agent。",
+    "set_access_skipped": "{{count}} 个已跳过(不是你所有)。",
+    "set_access_dialog_confirm": "应用",
+    "set_access_bulk_partial": "已应用 {{succeeded}} 个;{{failed}} 个失败(保持当前状态)。",
     "agent_archived_toast": "已归档智能体",
     "archive_failed_toast": "归档智能体失败",
     "agent_restored_toast": "已恢复智能体",
@@ -266,9 +273,18 @@
     "step_configure": "检查并配置",
     "step_ai": "通过对话创建",
     "modes": {
-      "blank": { "title": "从空白开始", "description": "自己配置每个字段。适合已经明确知道智能体应该如何工作的用户。" },
-      "template": { "title": "使用模板", "description": "从整理好的指令和 skill 开始，再根据工作区需要修改每个细节。" },
-      "ai": { "title": "通过 AI 创建", "description": "描述你想要的结果。Agent Builder 会提出关键问题并实时生成草稿。" }
+      "blank": {
+        "title": "从空白开始",
+        "description": "自己配置每个字段。适合已经明确知道智能体应该如何工作的用户。"
+      },
+      "template": {
+        "title": "使用模板",
+        "description": "从整理好的指令和 skill 开始，再根据工作区需要修改每个细节。"
+      },
+      "ai": {
+        "title": "通过 AI 创建",
+        "description": "描述你想要的结果。Agent Builder 会提出关键问题并实时生成草稿。"
+      }
     },
     "templates": {
       "search": "搜索模板…",
@@ -290,9 +306,19 @@
       "access_hint": "控制谁可以运行此智能体，创建后仍可修改。"
     },
     "access": {
-      "private": { "title": "只有我", "description": "只有你可以运行此智能体。" },
-      "workspace": { "title": "整个工作区", "description": "工作区中的所有成员都可以运行。" },
-      "members": { "title": "指定成员", "description": "只有选中的成员可以运行。", "required": "请至少选择一位成员。" }
+      "private": {
+        "title": "只有我",
+        "description": "只有你可以运行此智能体。"
+      },
+      "workspace": {
+        "title": "整个工作区",
+        "description": "工作区中的所有成员都可以运行。"
+      },
+      "members": {
+        "title": "指定成员",
+        "description": "只有选中的成员可以运行。",
+        "required": "请至少选择一位成员。"
+      }
     },
     "builder": {
       "setup_title": "为 Agent Builder 选择运行时",
@@ -664,6 +690,11 @@
     "tooltip": "访问权限 · 谁可以运行该智能体",
     "trigger_private": "仅自己",
     "trigger_workspace": "工作区",
+    "scope_labels": {
+      "workspace": "工作区",
+      "specific_people": "指定成员",
+      "owner_only": "仅所有者"
+    },
     "trigger_members_count": "{{count}} 人",
     "trigger_members_empty": "指定成员",
     "trigger_team": "团队",
@@ -743,6 +774,7 @@
     "filter_active_count_other": "{{count}} 项筛选",
     "clear_filters": "清除筛选",
     "section_availability": "可用性",
+    "section_access": "访问范围",
     "section_runtime": "运行时",
     "display": "显示",
     "sort_by": "排序",


### PR DESCRIPTION
## What

Adds an "effective access" column (Workspace / Specific people / Owner-only), an `access` filter dimension, and a "Set access scope" bulk action to the agents list page — forming a see → filter → change loop for agent access-scope management.

## Why

Operators cannot read or change agent access scope from the list page today. The only access signal is a small lock marker derived from the lossy `visibility` field, which conflates "owner-only" and "specific-people" agents. Inventorying which agents were private vs workspace-invocable required raw SQL; changing scope across many agents required a bulk `UPDATE` + `INSERT` (70 agents across 5 workspaces). This PR gives operators the UI tools to answer and change any access-scope question from the list page.

## Key design decisions

- **Three-state effective access, not raw `visibility`**: `visibility` is a derived 2-state projection (`agent.ts:10-15`) that maps `public_to + member target` → "private" — indistinguishable from a truly owner-only agent. The column shows the 3-state value computed from `permission_mode + invocation_targets`.

- **Bulk action gated by `isOwnedByMe`, not `canManage`**: the backend enforces owner-only writes for `permission_mode` / `invocation_targets` (`agent.go:1418-1444`, returns 403 for non-owner admins). The bulk button and target filter use `isOwnedByMe` to match.

- **Bulk dialog reuses `AccessPicker`** (the existing per-agent editor) via `onReadyChange` which passes the actual `AccessChange` value, so the dialog's Apply button captures the scope directly. The picker's draft-reset `useEffect` uses ref-based value comparison to avoid resets from unstable prop references.

- **No backend changes**: `permission_mode` and `invocation_targets` are already present in the list payload (`ListAgents` SELECT * + handler attaches invocation_targets at `agent.go:666,680`). Effective access is computed frontend-side.

## Changes

| Area | Files | What |
|------|-------|------|
| Helper | `packages/core/agents/effective-access.ts` | `effectiveAccessScope()`, `isAccessChangeReady()`, `ALL_ACCESS_SCOPES` |
| Column | `agents-page.tsx`, `view-store.ts`, `agent-list-toolbar.tsx`, 4 locale files | New "Access" column (visible by default, after Owner), `AgentColumnKey` + grid track, `AccessCell`, i18n `columns.access` + `access_scope.*` in en/zh-Hans/ja/ko |
| Filter | `agents-page.tsx`, `agent-list-toolbar.tsx`, `view-store.ts` | New `access` multi-select filter dimension in `AgentListFilters`, toolbar sub-menu, row-filter predicate |
| Bulk edit | `agent-batch-toolbar.tsx` (extracted), `inspector/access-picker.tsx` | `AgentBatchToolbar` (archived to new file), "Set access scope" button (any-owned enables), `AccessPicker` + `hideFooter` + `onReadyChange` pattern, `api.updateAgent` per owned row via `runBatch` (allSettled, partial-failure toast) |

## Verification

- `pnpm typecheck` clean across `@multica/core` and `@multica/views`
- 161/161 tests passing across 25 files:
  - `effective-access.test.ts` (8 states: 3 normal + boundary cases)
  - `view-store.test.ts` (access filter toggle/persist/rehydrate/backfill)
  - `agents-page-access-cell.test.ts` (column renders 3 states)
  - `agents-page-filter-predicate.test.ts` (single-dim, multi-dim AND, cross-dim + drift guard)
  - `agents-page-bulk-access-dialog-state.test.ts` (isAccessChangeReady truth table)
  - `access-picker-bulk-commit.test.ts` (picker commit + onReadyChange)
  - `agent-batch-toolbar.test.ts` (button visible, skip count, default-disabled)
  - `agents-i18n-parity.test.ts` (4-locale key parity + {{count}} tokens)
- `pnpm lint` clean (0 errors)

## Scope boundaries

- **Not in scope**: the #5230 "automation cannot trigger this agent" affordance (separate bug), workspace-level default access for new agents (separate settings concern), `AccessPicker` refactoring to use the shared helper (explicitly deferred — the picker's inline derivation duplicates the same logic; consolidating is a clean follow-up).

## Source references

- Ideation: `docs/ideation/2026-07-14-agent-list-visibility-field-ideation.html`
- Plan: `docs/plans/2026-07-14-001-feat-agent-list-access-scope-plan.md`
- Upstream #5230 (related, out of scope): @agent mentions from autopilot `run_only` tasks silently dropped against private agents