### PR TITLE
fix(issues): stabilize scroll restoration

### DIFF
--- a/packages/views/issues/hooks/use-issue-detail-scroll-restore.test.tsx
+++ b/packages/views/issues/hooks/use-issue-detail-scroll-restore.test.tsx
@@ -97,6 +97,22 @@ describe("useIssueDetailScrollRestore", () => {
     expect(scroller.scrollTop).toBe(500);
   });
 
+  it("keeps positions when navigating through a page that unmounts issue detail", () => {
+    const issueA = nextKey("issue-a");
+    const issueB = nextKey("issue-b");
+
+    const firstPage = render(<Harness restoreKey={issueA} />);
+    setScroll(firstPage.getByTestId("scroller"), 610);
+    firstPage.unmount();
+
+    const secondPage = render(<Harness restoreKey={issueB} />);
+    expect(secondPage.getByTestId("scroller").scrollTop).toBe(0);
+    secondPage.unmount();
+
+    const returnedPage = render(<Harness restoreKey={issueA} />);
+    expect(returnedPage.getByTestId("scroller").scrollTop).toBe(610);
+  });
+
   it("waits until the page is ready before restoring a saved scrollTop", () => {
     const issueA = nextKey("issue-a");
     const issueB = nextKey("issue-b");
@@ -189,6 +205,29 @@ describe("useIssueDetailScrollRestore", () => {
     canScroll = true;
     flushNextAnimationFrame();
     expect(scroller.scrollTop).toBe(480);
+  });
+
+  it("restores again when a virtualized timeline resets scroll after the initial write", () => {
+    const issueA = nextKey("issue-a");
+    const issueB = nextKey("issue-b");
+
+    const { getByTestId, rerender } = render(<Harness restoreKey={issueA} />);
+    const scroller = getByTestId("scroller") as HTMLElement;
+
+    setScroll(scroller, 520);
+
+    rerender(<Harness restoreKey={issueB} />);
+    expect(scroller.scrollTop).toBe(0);
+
+    rerender(<Harness restoreKey={issueA} />);
+    expect(scroller.scrollTop).toBe(520);
+
+    // Virtuoso initializes after the parent's layout effect and can reset a
+    // successful synchronous restore before the next animation frame.
+    scroller.scrollTop = 0;
+    flushNextAnimationFrame();
+
+    expect(scroller.scrollTop).toBe(520);
   });
 
   it("cancels a pending restore retry when the issue key changes", () => {

--- a/packages/views/issues/hooks/use-issue-detail-scroll-restore.ts
+++ b/packages/views/issues/hooks/use-issue-detail-scroll-restore.ts
@@ -48,6 +48,11 @@ export function useIssueDetailScrollRestore({
     restoredKeyRef.current = restoreKey;
 
     const target = scrollPositions.get(restoreKey) ?? 0;
+    if (target <= 1) {
+      scrollContainerEl.scrollTop = target;
+      return;
+    }
+
     return restoreScrollTopWithRetry(scrollContainerEl, target);
   }, [scrollContainerEl, restoreKey, ready, disabled]);
 }
@@ -66,20 +71,30 @@ function saveScrollPosition(restoreKey: string, scrollTop: number) {
 function restoreScrollTopWithRetry(el: HTMLElement, target: number) {
   let cancelled = false;
   let attempts = 0;
+  let stableFrames = 0;
   const maxAttempts = 30;
+  const requiredStableFrames = 2;
 
   el.scrollTop = target;
-  if (Math.abs(el.scrollTop - target) <= 1) return () => {};
 
   let frameId: number;
 
   const tick = () => {
     if (cancelled || !el.isConnected) return;
 
-    el.scrollTop = target;
     attempts += 1;
 
-    if (Math.abs(el.scrollTop - target) <= 1 || attempts >= maxAttempts) {
+    if (Math.abs(el.scrollTop - target) <= 1) {
+      stableFrames += 1;
+    } else {
+      stableFrames = 0;
+      el.scrollTop = target;
+    }
+
+    // A virtualized timeline initializes after the parent's layout effect and
+    // may reset a synchronous scroll write. Requiring stability across frames
+    // keeps the restore alive long enough to outlast that initialization.
+    if (stableFrames >= requiredStableFrames || attempts >= maxAttempts) {
       return;
     }
 


### PR DESCRIPTION
## Summary

- keep per-issue scroll restoration active until the restored offset is stable across animation frames
- preserve the fast synchronous path for new or top-positioned issues
- add coverage for route unmount/remount and virtualized timeline initialization resets

## Why

Issue detail already cached scroll offsets locally, but the restore helper stopped as soon as the first synchronous `scrollTop` assignment succeeded. The virtualized timeline initializes after the parent layout effect and can reset that successful assignment to the top, so revisiting an issue appeared to lose the saved position.

The restore now waits for two stable frames, retrying for up to the existing 30-frame limit. This lets it outlast virtualizer initialization without changing comment deep-link behavior or persisting scroll data beyond the local app session.

## Validation

- `pnpm --filter @multica/views exec vitest run issues/components/issue-detail.test.tsx issues/hooks/use-issue-detail-scroll-restore.test.tsx` (44 tests)
- `pnpm --filter @multica/views exec tsc --noEmit`
- `pnpm --filter @multica/views exec eslint issues/hooks/use-issue-detail-scroll-restore.ts issues/hooks/use-issue-detail-scroll-restore.test.tsx`
- `git diff --check`
