### PR TITLE
SNDBX-418: prevent owner thread auto-subscriptions

### DIFF
--- a/server/cmd/server/notification_listeners_test.go
+++ b/server/cmd/server/notification_listeners_test.go
@@ -388,6 +388,73 @@ func TestNotification_CommentCreated(t *testing.T) {
 	}
 }
 
+func TestNotification_CommentMentionNotifiesOwnerWithoutSubscribing(t *testing.T) {
+	queries := db.New(testPool)
+	bus := newNotificationBus(t, queries)
+
+	commenterEmail := "notif-owner-mention-commenter@multica.ai"
+	commenterID := createTestUser(t, commenterEmail)
+	t.Cleanup(func() { cleanupTestUser(t, commenterEmail) })
+	addTestMember(t, testWorkspaceID, commenterID, "member")
+
+	issueID := createTestIssue(t, testWorkspaceID, testUserID)
+	t.Cleanup(func() {
+		cleanupInboxForIssue(t, issueID)
+		cleanupTestIssue(t, issueID)
+	})
+
+	mention := "[@Owner](mention://member/" + testUserID + ")"
+	bus.Publish(events.Event{
+		Type:        protocol.EventCommentCreated,
+		WorkspaceID: testWorkspaceID,
+		ActorType:   "member",
+		ActorID:     commenterID,
+		Payload: map[string]any{
+			"comment": handler.CommentResponse{
+				ID:         "00000000-0000-0000-0000-000000000000",
+				IssueID:    issueID,
+				AuthorType: "member",
+				AuthorID:   commenterID,
+				Content:    "Decision needed from " + mention,
+				Type:       "comment",
+			},
+			"issue_title":  "owner mention test issue",
+			"issue_status": "todo",
+		},
+	})
+
+	ownerItems := inboxItemsForRecipient(t, queries, testUserID)
+	if len(ownerItems) != 1 || ownerItems[0].Type != "mentioned" {
+		t.Fatalf("expected one direct mention inbox item for owner, got %+v", ownerItems)
+	}
+	if isSubscribed(t, queries, issueID, "member", testUserID) {
+		t.Fatal("direct owner mention must not subscribe the owner to the thread")
+	}
+
+	bus.Publish(events.Event{
+		Type:        protocol.EventCommentCreated,
+		WorkspaceID: testWorkspaceID,
+		ActorType:   "member",
+		ActorID:     commenterID,
+		Payload: map[string]any{
+			"comment": handler.CommentResponse{
+				ID:         "00000000-0000-0000-0000-000000000001",
+				IssueID:    issueID,
+				AuthorType: "member",
+				AuthorID:   commenterID,
+				Content:    "follow-up without another mention",
+				Type:       "comment",
+			},
+			"issue_title":  "owner mention test issue",
+			"issue_status": "todo",
+		},
+	})
+
+	if ownerItems = inboxItemsForRecipient(t, queries, testUserID); len(ownerItems) != 1 {
+		t.Fatalf("expected no follow-up inbox item after a direct mention, got %+v", ownerItems)
+	}
+}
+
 // TestNotification_SystemCommentSkipsInboxAndMentions guards the MUL-2538
 // must-fix: a comment with author_type='system' (the platform-generated
 // child-done parent notify) must NOT create any inbox rows for parent

--- a/server/cmd/server/subscriber_listeners.go
+++ b/server/cmd/server/subscriber_listeners.go
@@ -11,8 +11,9 @@ import (
 )
 
 // registerSubscriberListeners wires up event bus listeners that auto-subscribe
-// relevant users to issues. This ensures creators, assignees, and commenters
-// are automatically tracked as issue subscribers.
+// relevant users to issues. Creators and assignees are automatically tracked;
+// workspace owners receive mentions directly without being added to a thread's
+// later-comment firehose.
 func registerSubscriberListeners(bus *events.Bus, queries *db.Queries) {
 	// issue:created — subscribe creator + assignee (if different)
 	bus.Subscribe(protocol.EventIssueCreated, func(e events.Event) {
@@ -145,8 +146,15 @@ func extractIssueFields(v any) (handler.IssueResponse, bool) {
 }
 
 // addSubscriber adds a user as an issue subscriber and publishes a
-// subscriber:added event for real-time frontend sync.
+// subscriber:added event for real-time frontend sync. A workspace owner is not
+// auto-subscribed merely by a comment or mention: both are direct signals, not
+// a request to follow the entire thread. Creator, assignee, and manual
+// subscriptions remain intentional thread participation.
 func addSubscriber(bus *events.Bus, queries *db.Queries, workspaceID, issueID, userType, userID, reason string) {
+	if !shouldAutoSubscribe(queries, workspaceID, userType, userID, reason) {
+		return
+	}
+
 	err := queries.AddIssueSubscriber(context.Background(), db.AddIssueSubscriberParams{
 		IssueID:  parseUUID(issueID),
 		UserType: userType,
@@ -174,4 +182,29 @@ func addSubscriber(bus *events.Bus, queries *db.Queries, workspaceID, issueID, u
 			"reason":    reason,
 		},
 	})
+}
+
+func shouldAutoSubscribe(queries *db.Queries, workspaceID, userType, userID, reason string) bool {
+	if userType != "member" || (reason != "commenter" && reason != "mentioned") {
+		return true
+	}
+
+	member, err := queries.GetMemberByUserAndWorkspace(context.Background(), db.GetMemberByUserAndWorkspaceParams{
+		UserID:      parseUUID(userID),
+		WorkspaceID: parseUUID(workspaceID),
+	})
+	if err != nil {
+		// Keep existing subscription behavior if membership cannot be read;
+		// silently dropping a collaborator's requested signal is worse than a
+		// transient extra notification.
+		slog.Error("failed to load member role for issue subscription",
+			"workspace_id", workspaceID,
+			"user_id", userID,
+			"reason", reason,
+			"error", err,
+		)
+		return true
+	}
+
+	return member.Role != "owner"
 }

--- a/server/cmd/server/subscriber_listeners_test.go
+++ b/server/cmd/server/subscriber_listeners_test.go
@@ -60,6 +60,21 @@ func cleanupTestUser(t *testing.T, email string) {
 	testPool.Exec(context.Background(), `DELETE FROM "user" WHERE email = $1`, email)
 }
 
+func addTestMember(t *testing.T, workspaceID, userID, role string) {
+	t.Helper()
+	if _, err := testPool.Exec(context.Background(), `
+		INSERT INTO member (workspace_id, user_id, role)
+		VALUES ($1, $2, $3)
+	`, workspaceID, userID, role); err != nil {
+		t.Fatalf("add test member: %v", err)
+	}
+	t.Cleanup(func() {
+		testPool.Exec(context.Background(), `
+			DELETE FROM member WHERE workspace_id = $1 AND user_id = $2
+		`, workspaceID, userID)
+	})
+}
+
 func isSubscribed(t *testing.T, queries *db.Queries, issueID, userType, userID string) bool {
 	t.Helper()
 	subscribed, err := queries.IsIssueSubscriber(context.Background(), db.IsIssueSubscriberParams{
@@ -283,6 +298,7 @@ func TestSubscriberCommentCreated_CommenterSubscribed(t *testing.T) {
 	commenterEmail := "subscriber-commenter-test@multica.ai"
 	commenterID := createTestUser(t, commenterEmail)
 	t.Cleanup(func() { cleanupTestUser(t, commenterEmail) })
+	addTestMember(t, testWorkspaceID, commenterID, "member")
 
 	issueID := createTestIssue(t, testWorkspaceID, testUserID)
 	t.Cleanup(func() { cleanupTestIssue(t, issueID) })
@@ -306,6 +322,77 @@ func TestSubscriberCommentCreated_CommenterSubscribed(t *testing.T) {
 
 	if !isSubscribed(t, queries, issueID, "member", commenterID) {
 		t.Fatal("expected commenter to be subscribed after comment:created")
+	}
+}
+
+func TestSubscriberCommentCreated_WorkspaceOwnerNotSubscribed(t *testing.T) {
+	queries := db.New(testPool)
+	bus := events.New()
+	registerSubscriberListeners(bus, queries)
+
+	issueID := createTestIssue(t, testWorkspaceID, testUserID)
+	t.Cleanup(func() { cleanupTestIssue(t, issueID) })
+
+	bus.Publish(events.Event{
+		Type:        protocol.EventCommentCreated,
+		WorkspaceID: testWorkspaceID,
+		ActorType:   "member",
+		ActorID:     testUserID,
+		Payload: map[string]any{
+			"comment": handler.CommentResponse{
+				ID:         "00000000-0000-0000-0000-000000000000",
+				IssueID:    issueID,
+				AuthorType: "member",
+				AuthorID:   testUserID,
+				Content:    "owner asks a question",
+				Type:       "comment",
+			},
+		},
+	})
+
+	if isSubscribed(t, queries, issueID, "member", testUserID) {
+		t.Fatal("workspace owner must not be subscribed merely by commenting")
+	}
+}
+
+func TestSubscriberIssueCreated_WorkspaceOwnerMentionNotSubscribed(t *testing.T) {
+	queries := db.New(testPool)
+	bus := events.New()
+	registerSubscriberListeners(bus, queries)
+
+	creatorEmail := "subscriber-nonowner-creator-test@multica.ai"
+	creatorID := createTestUser(t, creatorEmail)
+	t.Cleanup(func() { cleanupTestUser(t, creatorEmail) })
+	addTestMember(t, testWorkspaceID, creatorID, "member")
+
+	issueID := createTestIssue(t, testWorkspaceID, testUserID)
+	t.Cleanup(func() { cleanupTestIssue(t, issueID) })
+	description := "Needs [@Owner](mention://member/" + testUserID + ")."
+
+	bus.Publish(events.Event{
+		Type:        protocol.EventIssueCreated,
+		WorkspaceID: testWorkspaceID,
+		ActorType:   "member",
+		ActorID:     creatorID,
+		Payload: map[string]any{
+			"issue": handler.IssueResponse{
+				ID:          issueID,
+				WorkspaceID: testWorkspaceID,
+				Title:       "owner mention test issue",
+				Status:      "todo",
+				Priority:    "medium",
+				CreatorType: "member",
+				CreatorID:   creatorID,
+				Description: &description,
+			},
+		},
+	})
+
+	if !isSubscribed(t, queries, issueID, "member", creatorID) {
+		t.Fatal("expected non-owner creator to be subscribed")
+	}
+	if isSubscribed(t, queries, issueID, "member", testUserID) {
+		t.Fatal("workspace owner must not be subscribed merely by a mention")
 	}
 }
 


### PR DESCRIPTION
## Summary

- Prevent workspace owners from becoming issue subscribers merely by commenting or being mentioned.
- Preserve intentional creator, assignee, and manual subscriptions.
- Keep direct mention notifications intact without later follow-up comments entering the owner inbox.

## Verification

- `go test ./cmd/server -count=1`
- `go test ./cmd/server -run 'Test(Subscriber|Notification)_ ' -count=1`\n- `go vet ./cmd/server`\n\n## Revert\n\nRevert commit `d9b28211f`.