### PR TITLE
KAP-867: retry safe Codex initialize timeouts

### DIFF
--- a/server/internal/daemon/daemon.go
+++ b/server/internal/daemon/daemon.go
@@ -4102,6 +4102,7 @@ func (d *Daemon) runTask(ctx context.Context, task Task, provider string, slot i
 		TaskID:         task.ID,
 		RuntimeID:      task.RuntimeID,
 		DaemonVersion:  d.cfg.CLIVersion,
+		CodexVersion:   codexVersion,
 	})
 	if err != nil {
 		return TaskResult{}, fmt.Errorf("create agent backend: %w", err)

--- a/server/internal/daemon/daemon.go
+++ b/server/internal/daemon/daemon.go
@@ -4099,6 +4099,9 @@ func (d *Daemon) runTask(ctx context.Context, task Task, provider string, slot i
 		ExecutablePath: entry.Path,
 		Env:            agentEnv,
 		Logger:         d.logger,
+		TaskID:         task.ID,
+		RuntimeID:      task.RuntimeID,
+		DaemonVersion:  d.cfg.CLIVersion,
 	})
 	if err != nil {
 		return TaskResult{}, fmt.Errorf("create agent backend: %w", err)

--- a/server/pkg/agent/agent.go
+++ b/server/pkg/agent/agent.go
@@ -127,6 +127,11 @@ type Result struct {
 	DurationMs int64
 	SessionID  string
 	Usage      map[string]TokenUsage // keyed by model name
+	// codexInitializeRetrySafe is provider-internal evidence that an
+	// initialize timeout happened before semantic activity and after the
+	// process tree was reaped. It is intentionally not part of the public
+	// result contract.
+	codexInitializeRetrySafe bool
 }
 
 // Config configures a Backend instance.
@@ -134,6 +139,9 @@ type Config struct {
 	ExecutablePath string            // path to CLI binary (claude, codebuddy, codex, copilot, opencode, openclaw, hermes, pi, cursor, kimi, kiro-cli, agy, qodercli)
 	Env            map[string]string // extra environment variables
 	Logger         *slog.Logger
+	TaskID         string
+	RuntimeID      string
+	DaemonVersion  string
 }
 
 // New creates a Backend for the given agent type.

--- a/server/pkg/agent/agent.go
+++ b/server/pkg/agent/agent.go
@@ -142,6 +142,7 @@ type Config struct {
 	TaskID         string
 	RuntimeID      string
 	DaemonVersion  string
+	CodexVersion   string
 }
 
 // New creates a Backend for the given agent type.

--- a/server/pkg/agent/codex.go
+++ b/server/pkg/agent/codex.go
@@ -63,7 +63,11 @@ var activeCodexLaunches atomic.Int64
 var maxActiveCodexLaunchesObserved atomic.Int64
 var codexCleanupConfirmationOverride atomic.Int32
 
-var codexDiagnosticSecretRe = regexp.MustCompile(`(?i)(authorization|api[_-]?key|token|secret|password)(\s*[:=]\s*)([^\s,;]+)`)
+var (
+	codexAuthorizationHeaderRe = regexp.MustCompile(`(?im)(authorization\s*:\s*)[^\r\n]+`)
+	codexJSONSecretRe          = regexp.MustCompile(`(?i)("(?:token|auth|authorization|api[_-]?key|secret|password)"\s*:\s*)"(?:\\.|[^"\\])*"`)
+	codexDiagnosticSecretRe    = regexp.MustCompile(`(?i)(authorization|auth|api[_-]?key|token|secret|password)(\s*[:=]\s*)([^\s,;]+)`)
+)
 
 func sanitizeCodexDiagnostic(value string) string {
 	value = strings.Map(func(r rune) rune {
@@ -72,6 +76,8 @@ func sanitizeCodexDiagnostic(value string) string {
 		}
 		return r
 	}, value)
+	value = codexAuthorizationHeaderRe.ReplaceAllString(value, `$1[REDACTED]`)
+	value = codexJSONSecretRe.ReplaceAllString(value, `$1"[REDACTED]"`)
 	return codexDiagnosticSecretRe.ReplaceAllString(value, `$1$2[REDACTED]`)
 }
 
@@ -744,7 +750,10 @@ func (b *codexBackend) executeOnce(ctx context.Context, prompt string, opts Exec
 		}
 	}
 	launchStarted := time.Now()
-	codexVersion := detectCodexVersionForDiagnostics(ctx, execPath, cmd.Env, b.cfg.Logger)
+	codexVersion := strings.TrimSpace(b.cfg.CodexVersion)
+	if codexVersion == "" {
+		codexVersion = "unknown"
+	}
 
 	b.cfg.Logger.Info("codex lifecycle", "phase", "spawn", "task_id", b.cfg.TaskID, "runtime_id", b.cfg.RuntimeID, "pid", cmd.Process.Pid, "process_group", cmd.Process.Pid, "cwd", opts.Cwd, "attempt", attempt, "active_launches", activeLaunches, "codex_version", codexVersion, "daemon_version", b.cfg.DaemonVersion)
 
@@ -857,6 +866,7 @@ func (b *codexBackend) executeOnce(ctx context.Context, prompt string, opts Exec
 	//     stay open.
 	var waitOnce sync.Once
 	var cleanupConfirmed bool
+	var waitReturned bool
 	var cleanupWaitErr error
 	drainAndWait := func() {
 		waitOnce.Do(func() {
@@ -893,6 +903,7 @@ func (b *codexBackend) executeOnce(ctx context.Context, prompt string, opts Exec
 			}()
 			select {
 			case <-waitCh:
+				waitReturned = true
 				// reaped cleanly.
 			case <-time.After(grace):
 				b.cfg.Logger.Warn("codex process still alive after reader exited; forcing shutdown",
@@ -905,8 +916,12 @@ func (b *codexBackend) executeOnce(ctx context.Context, prompt string, opts Exec
 				// descendant, cmd.Wait() returns within WaitDelay of the
 				// cancel.
 				<-waitCh
+				waitReturned = true
 			}
-			cleanupConfirmed = cmd.ProcessState != nil && cmd.ProcessState.Exited()
+			// Wait returning with a ProcessState is the os/exec reap boundary.
+			// On Unix, ProcessState.Exited reports false for a process terminated
+			// by SIGKILL even though Wait successfully reaped it.
+			cleanupConfirmed = waitReturned && cmd.ProcessState != nil
 			if codexCleanupConfirmationOverride.Load() < 0 {
 				cleanupConfirmed = false
 			}

--- a/server/pkg/agent/codex.go
+++ b/server/pkg/agent/codex.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"log/slog"
 	"os"
 	"os/exec"
@@ -58,6 +59,28 @@ const (
 // instead of burning two full grace windows per cleanup phase. Mirrors
 // the opencodeTerminateGraceNanos hook.
 var codexGracefulShutdownTimeoutNanos atomic.Int64
+var activeCodexLaunches atomic.Int64
+var maxActiveCodexLaunchesObserved atomic.Int64
+var codexCleanupConfirmationOverride atomic.Int32
+
+var codexDiagnosticSecretRe = regexp.MustCompile(`(?i)(authorization|api[_-]?key|token|secret|password)(\s*[:=]\s*)([^\s,;]+)`)
+
+func sanitizeCodexDiagnostic(value string) string {
+	value = strings.Map(func(r rune) rune {
+		if r < 0x20 && r != '\n' && r != '\t' {
+			return -1
+		}
+		return r
+	}, value)
+	return codexDiagnosticSecretRe.ReplaceAllString(value, `$1$2[REDACTED]`)
+}
+
+func codexProcessExitStatus(state *os.ProcessState) any {
+	if state == nil {
+		return nil
+	}
+	return state.String()
+}
 
 func codexGracefulShutdown() time.Duration {
 	if n := codexGracefulShutdownTimeoutNanos.Load(); n > 0 {
@@ -566,6 +589,53 @@ func isCodexBareTomlKey(s string) bool {
 }
 
 func (b *codexBackend) Execute(ctx context.Context, prompt string, opts ExecOptions) (*Session, error) {
+	firstSession, err := b.executeOnce(ctx, prompt, opts, 1)
+	if err != nil {
+		return nil, err
+	}
+	msgCh := make(chan Message, 256)
+	resCh := make(chan Result, 1)
+
+	go func() {
+		defer close(msgCh)
+		defer close(resCh)
+		session := firstSession
+		for attempt := 1; attempt <= 2; attempt++ {
+			if attempt > 1 {
+				var err error
+				session, err = b.executeOnce(ctx, prompt, opts, attempt)
+				if err != nil {
+					resCh <- Result{Status: "failed", Error: err.Error()}
+					return
+				}
+			}
+			for msg := range session.Messages {
+				msgCh <- msg
+			}
+			result, ok := <-session.Result
+			if !ok {
+				resCh <- Result{Status: "failed", Error: "codex attempt closed without result"}
+				return
+			}
+			if !result.codexInitializeRetrySafe || attempt == 2 {
+				resCh <- result
+				return
+			}
+			backoff := 75*time.Millisecond + time.Duration(time.Now().UnixNano()%50)*time.Millisecond
+			b.cfg.Logger.Warn("codex initialize retry scheduled", "attempt", attempt, "next_attempt", attempt+1, "backoff", backoff.String())
+			select {
+			case <-ctx.Done():
+				resCh <- result
+				return
+			case <-time.After(backoff):
+			}
+		}
+	}()
+
+	return &Session{Messages: msgCh, Result: resCh}, nil
+}
+
+func (b *codexBackend) executeOnce(ctx context.Context, prompt string, opts ExecOptions, attempt int) (*Session, error) {
 	execPath := b.cfg.ExecutablePath
 	if execPath == "" {
 		execPath = "codex"
@@ -657,15 +727,26 @@ func (b *codexBackend) Execute(ctx context.Context, prompt string, opts ExecOpti
 		cancel()
 		return nil, fmt.Errorf("codex stdin pipe: %w", err)
 	}
-	stderrBuf := newStderrTail(newLogWriter(b.cfg.Logger, "[codex:stderr] "), codexStderrTailBytes)
+	// Codex stderr can contain auth/provider diagnostics. Capture a bounded
+	// tail and emit it only through the sanitizer in the cleanup event.
+	stderrBuf := newStderrTail(io.Discard, codexStderrTailBytes)
 	cmd.Stderr = stderrBuf
 
 	if err := cmd.Start(); err != nil {
 		cancel()
 		return nil, fmt.Errorf("start codex: %w", err)
 	}
+	activeLaunches := activeCodexLaunches.Add(1)
+	for {
+		maxSeen := maxActiveCodexLaunchesObserved.Load()
+		if activeLaunches <= maxSeen || maxActiveCodexLaunchesObserved.CompareAndSwap(maxSeen, activeLaunches) {
+			break
+		}
+	}
+	launchStarted := time.Now()
+	codexVersion := detectCodexVersionForDiagnostics(ctx, execPath, cmd.Env, b.cfg.Logger)
 
-	b.cfg.Logger.Info("codex started app-server", "pid", cmd.Process.Pid, "cwd", opts.Cwd)
+	b.cfg.Logger.Info("codex lifecycle", "phase", "spawn", "task_id", b.cfg.TaskID, "runtime_id", b.cfg.RuntimeID, "pid", cmd.Process.Pid, "process_group", cmd.Process.Pid, "cwd", opts.Cwd, "attempt", attempt, "active_launches", activeLaunches, "codex_version", codexVersion, "daemon_version", b.cfg.DaemonVersion)
 
 	msgCh := make(chan Message, 256)
 	resCh := make(chan Result, 1)
@@ -673,6 +754,7 @@ func (b *codexBackend) Execute(ctx context.Context, prompt string, opts ExecOpti
 
 	var outputMu sync.Mutex
 	var output strings.Builder
+	var semanticObserved atomic.Bool
 
 	// turnDone is set before starting the reader goroutine so there is no
 	// race between the lifecycle goroutine writing and the reader reading.
@@ -694,8 +776,12 @@ func (b *codexBackend) Execute(ctx context.Context, prompt string, opts ExecOpti
 			}
 			trySend(msgCh, msg)
 			trySendString(semanticActivityCh, describeCodexSemanticActivity(msg))
+			if describeCodexSemanticActivity(msg) != "" {
+				semanticObserved.Store(true)
+			}
 		},
 		onSemanticActivity: func(description string) {
+			semanticObserved.Store(true)
 			b.cfg.Logger.Debug("codex semantic activity observed", "activity", description)
 			trySendString(semanticActivityCh, description)
 		},
@@ -770,6 +856,8 @@ func (b *codexBackend) Execute(ctx context.Context, prompt string, opts ExecOpti
 	//     cmd.WaitDelay then guarantees cmd.Wait() returns even if pipes
 	//     stay open.
 	var waitOnce sync.Once
+	var cleanupConfirmed bool
+	var cleanupWaitErr error
 	drainAndWait := func() {
 		waitOnce.Do(func() {
 			stdin.Close()
@@ -800,7 +888,7 @@ func (b *codexBackend) Execute(ctx context.Context, prompt string, opts ExecOpti
 			// codex stayed blocked writing into a full stdout pipe).
 			waitCh := make(chan struct{})
 			go func() {
-				_ = cmd.Wait()
+				cleanupWaitErr = cmd.Wait()
 				close(waitCh)
 			}()
 			select {
@@ -818,6 +906,25 @@ func (b *codexBackend) Execute(ctx context.Context, prompt string, opts ExecOpti
 				// cancel.
 				<-waitCh
 			}
+			cleanupConfirmed = cmd.ProcessState != nil && cmd.ProcessState.Exited()
+			if codexCleanupConfirmationOverride.Load() < 0 {
+				cleanupConfirmed = false
+			}
+			b.cfg.Logger.Info("codex lifecycle",
+				"phase", "cleanup",
+				"task_id", b.cfg.TaskID,
+				"runtime_id", b.cfg.RuntimeID,
+				"pid", cmd.Process.Pid,
+				"process_group", cmd.Process.Pid,
+				"attempt", attempt,
+				"latency", time.Since(launchStarted).Round(time.Millisecond).String(),
+				"reaped", cleanupConfirmed,
+				"exit_status", codexProcessExitStatus(cmd.ProcessState),
+				"wait_error", cleanupWaitErr,
+				"stderr_bytes", stderrBuf.TotalBytes(),
+				"stderr_truncated", stderrBuf.TotalBytes() > codexStderrTailBytes,
+				"stderr_tail", sanitizeCodexDiagnostic(stderrBuf.Tail()),
+			)
 		})
 	}
 
@@ -826,6 +933,7 @@ func (b *codexBackend) Execute(ctx context.Context, prompt string, opts ExecOpti
 	// codex process exits → reader goroutine's scanner.Scan() returns false →
 	// readerDone closes → lifecycle goroutine collects final output and sends Result.
 	go func() {
+		defer activeCodexLaunches.Add(-1)
 		defer cancel()
 		defer close(msgCh)
 		defer close(resCh)
@@ -836,6 +944,8 @@ func (b *codexBackend) Execute(ctx context.Context, prompt string, opts ExecOpti
 		var finalError string
 
 		// 1. Initialize handshake
+		initializeStarted := time.Now()
+		b.cfg.Logger.Info("codex lifecycle", "phase", "initialize_sent", "task_id", b.cfg.TaskID, "runtime_id", b.cfg.RuntimeID, "pid", cmd.Process.Pid, "attempt", attempt, "active_launches", activeLaunches)
 		_, err := c.request(runCtx, "initialize", map[string]any{
 			"clientInfo": map[string]any{
 				"name":    "multica-agent-sdk",
@@ -847,12 +957,20 @@ func (b *codexBackend) Execute(ctx context.Context, prompt string, opts ExecOpti
 			},
 		})
 		if err != nil {
+			initializeLatency := time.Since(initializeStarted)
 			drainAndWait() // flush os/exec stderr goroutine before sampling Tail
 			finalStatus = "failed"
 			finalError = withAgentStderr(fmt.Sprintf("codex initialize failed: %v", err), "codex", stderrBuf.Tail())
-			resCh <- Result{Status: finalStatus, Error: finalError, DurationMs: time.Since(startTime).Milliseconds()}
+			var handshakeErr *codexHandshakeTimeoutError
+			retrySafe := errors.As(err, &handshakeErr) && handshakeErr.Method == "initialize" && !semanticObserved.Load() && cleanupConfirmed
+			if errors.As(err, &handshakeErr) && handshakeErr.Method == "initialize" && !cleanupConfirmed {
+				finalError += "; retry suppressed: process cleanup/reap not confirmed"
+			}
+			b.cfg.Logger.Warn("codex lifecycle", "phase", "initialize_failure", "task_id", b.cfg.TaskID, "runtime_id", b.cfg.RuntimeID, "pid", cmd.Process.Pid, "attempt", attempt, "latency", initializeLatency.Round(time.Millisecond).String(), "semantic_activity", semanticObserved.Load(), "cleanup_confirmed", cleanupConfirmed, "retry_safe", retrySafe)
+			resCh <- Result{Status: finalStatus, Error: finalError, DurationMs: time.Since(startTime).Milliseconds(), codexInitializeRetrySafe: retrySafe}
 			return
 		}
+		b.cfg.Logger.Info("codex lifecycle", "phase", "initialize_response", "task_id", b.cfg.TaskID, "runtime_id", b.cfg.RuntimeID, "pid", cmd.Process.Pid, "attempt", attempt, "latency", time.Since(initializeStarted).Round(time.Millisecond).String())
 		c.notify("initialized")
 
 		// 2. Start a new thread, or resume the prior one for this issue. When

--- a/server/pkg/agent/codex.go
+++ b/server/pkg/agent/codex.go
@@ -19,6 +19,8 @@ import (
 	"sync/atomic"
 	"syscall"
 	"time"
+
+	"github.com/multica-ai/multica/server/pkg/redact"
 )
 
 // codexBlockedArgs are flags hardcoded by the daemon that must not be
@@ -78,7 +80,8 @@ func sanitizeCodexDiagnostic(value string) string {
 	}, value)
 	value = codexAuthorizationHeaderRe.ReplaceAllString(value, `$1[REDACTED]`)
 	value = codexJSONSecretRe.ReplaceAllString(value, `$1"[REDACTED]"`)
-	return codexDiagnosticSecretRe.ReplaceAllString(value, `$1$2[REDACTED]`)
+	value = codexDiagnosticSecretRe.ReplaceAllString(value, `$1$2[REDACTED]`)
+	return redact.Text(value)
 }
 
 func codexProcessExitStatus(state *os.ProcessState) any {
@@ -975,11 +978,13 @@ func (b *codexBackend) executeOnce(ctx context.Context, prompt string, opts Exec
 			initializeLatency := time.Since(initializeStarted)
 			drainAndWait() // flush os/exec stderr goroutine before sampling Tail
 			finalStatus = "failed"
-			finalError = withAgentStderr(fmt.Sprintf("codex initialize failed: %v", err), "codex", stderrBuf.Tail())
+			finalError = withAgentStderr(fmt.Sprintf("codex initialize failed: %v", err), "codex", sanitizeCodexDiagnostic(stderrBuf.Tail()))
 			var handshakeErr *codexHandshakeTimeoutError
-			retrySafe := errors.As(err, &handshakeErr) && handshakeErr.Method == "initialize" && !semanticObserved.Load() && cleanupConfirmed
+			retrySafe := errors.As(err, &handshakeErr) && handshakeErr.Method == "initialize" && !semanticObserved.Load() && cleanupConfirmed && codexInitializeRetrySupported()
 			if errors.As(err, &handshakeErr) && handshakeErr.Method == "initialize" && !cleanupConfirmed {
 				finalError += "; retry suppressed: process cleanup/reap not confirmed"
+			} else if errors.As(err, &handshakeErr) && handshakeErr.Method == "initialize" && cleanupConfirmed && !codexInitializeRetrySupported() {
+				finalError += "; retry suppressed: process-tree cleanup cannot be confirmed on this platform"
 			}
 			b.cfg.Logger.Warn("codex lifecycle", "phase", "initialize_failure", "task_id", b.cfg.TaskID, "runtime_id", b.cfg.RuntimeID, "pid", cmd.Process.Pid, "attempt", attempt, "latency", initializeLatency.Round(time.Millisecond).String(), "semantic_activity", semanticObserved.Load(), "cleanup_confirmed", cleanupConfirmed, "retry_safe", retrySafe)
 			resCh <- Result{Status: finalStatus, Error: finalError, DurationMs: time.Since(startTime).Milliseconds(), codexInitializeRetrySafe: retrySafe}
@@ -995,7 +1000,7 @@ func (b *codexBackend) executeOnce(ctx context.Context, prompt string, opts Exec
 		if err != nil {
 			drainAndWait() // flush os/exec stderr goroutine before sampling Tail
 			finalStatus = "failed"
-			finalError = withAgentStderr(err.Error(), "codex", stderrBuf.Tail())
+			finalError = withAgentStderr(err.Error(), "codex", sanitizeCodexDiagnostic(stderrBuf.Tail()))
 			resCh <- Result{Status: finalStatus, Error: finalError, DurationMs: time.Since(startTime).Milliseconds()}
 			return
 		}
@@ -1047,7 +1052,7 @@ func (b *codexBackend) executeOnce(ctx context.Context, prompt string, opts Exec
 			default:
 				drainAndWait() // flush os/exec stderr goroutine before sampling Tail
 				finalStatus = "failed"
-				finalError = withAgentStderr(fmt.Sprintf("codex turn/start failed: %v", err), "codex", stderrBuf.Tail())
+				finalError = withAgentStderr(fmt.Sprintf("codex turn/start failed: %v", err), "codex", sanitizeCodexDiagnostic(stderrBuf.Tail()))
 				resCh <- Result{Status: finalStatus, Error: finalError, DurationMs: time.Since(startTime).Milliseconds()}
 				return
 			}
@@ -1168,11 +1173,11 @@ func (b *codexBackend) executeOnce(ctx context.Context, prompt string, opts Exec
 		drainAndWait()
 
 		if processExitErr != nil {
-			finalError = withAgentStderr(processExitErr.Error(), "codex", stderrBuf.Tail())
+			finalError = withAgentStderr(processExitErr.Error(), "codex", sanitizeCodexDiagnostic(stderrBuf.Tail()))
 		}
 		if timeoutDiagnostic.Kind != codexTimeoutNone {
 			timeoutDiagnostic.CodexVersion = detectCodexVersionForDiagnostics(context.Background(), execPath, cmd.Env, b.cfg.Logger)
-			finalError = buildCodexTimeoutDiagnosticError(timeoutDiagnostic, stderrBuf.Tail())
+			finalError = buildCodexTimeoutDiagnosticError(timeoutDiagnostic, sanitizeCodexDiagnostic(stderrBuf.Tail()))
 		}
 
 		outputMu.Lock()
@@ -1375,6 +1380,7 @@ func isCodexFirstTurnProgressActivity(activity string) bool {
 }
 
 func buildCodexTimeoutDiagnosticError(diag codexTimeoutDiagnostic, stderrTail string) string {
+	stderrTail = sanitizeCodexDiagnostic(stderrTail)
 	var msg string
 	switch diag.Kind {
 	case codexTimeoutFirstTurnNoProgress:

--- a/server/pkg/agent/codex_test.go
+++ b/server/pkg/agent/codex_test.go
@@ -1592,6 +1592,151 @@ func TestCodexExecuteStartupRPCsHaveBoundedHandshakeTimeout(t *testing.T) {
 	}
 }
 
+func TestCodexExecuteRetriesInitializeTimeoutOnceAfterCleanup(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell-script fixture is POSIX-only")
+	}
+
+	countPath := filepath.Join(t.TempDir(), "launch-count")
+	fakePath := writeFakeCodexAppServer(t, ""+
+		`count=0; test -f `+countPath+` && count=$(cat `+countPath+`)`+"\n"+
+		`count=$((count + 1)); echo "$count" > `+countPath+"\n"+
+		`read line`+"\n"+
+		`if test "$count" -eq 1; then sleep 5; exit 0; fi`+"\n"+
+		`echo '{"jsonrpc":"2.0","id":1,"result":{}}'`+"\n"+
+		`read line`+"\n"+
+		`read line`+"\n"+
+		`echo '{"jsonrpc":"2.0","id":2,"result":{"thread":{"id":"thr-retried"}}}'`+"\n"+
+		`read line`+"\n"+
+		`echo '{"jsonrpc":"2.0","id":3,"result":{}}'`+"\n"+
+		`echo '{"jsonrpc":"2.0","method":"turn/completed","params":{"threadId":"thr-retried","turn":{"id":"turn-1","status":"completed"}}}'`+"\n")
+
+	result := executeFakeCodex(t, fakePath, ExecOptions{
+		Timeout:                   10 * time.Second,
+		HandshakeTimeout:          100 * time.Millisecond,
+		SemanticInactivityTimeout: time.Second,
+	})
+	if result.Status != "completed" {
+		t.Fatalf("expected retry to complete, got status=%q error=%q", result.Status, result.Error)
+	}
+	data, err := os.ReadFile(countPath)
+	if err != nil {
+		t.Fatalf("read launch count: %v", err)
+	}
+	if got := strings.TrimSpace(string(data)); got != "2" {
+		t.Fatalf("launch count = %q, want 2", got)
+	}
+}
+
+func TestCodexExecuteInitializeRetrySafetyGates(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell-script fixture is POSIX-only")
+	}
+
+	t.Run("both attempts time out", func(t *testing.T) {
+		countPath := filepath.Join(t.TempDir(), "launch-count")
+		fakePath := writeFakeCodexAppServer(t, ""+
+			`count=0; test -f `+countPath+` && count=$(cat `+countPath+`)`+"\n"+
+			`count=$((count + 1)); echo "$count" > `+countPath+"\n"+
+			`read line`+"\n"+
+			`sleep 1`+"\n")
+		result := executeFakeCodex(t, fakePath, ExecOptions{Timeout: 5 * time.Second, HandshakeTimeout: 50 * time.Millisecond})
+		if result.Status != "failed" || !strings.Contains(result.Error, CodexHandshakeTimeoutMarker) {
+			t.Fatalf("expected final initialize timeout, got status=%q error=%q", result.Status, result.Error)
+		}
+		data, _ := os.ReadFile(countPath)
+		if got := strings.TrimSpace(string(data)); got != "2" {
+			t.Fatalf("launch count = %q, want 2", got)
+		}
+	})
+
+	t.Run("semantic activity suppresses retry", func(t *testing.T) {
+		countPath := filepath.Join(t.TempDir(), "launch-count")
+		fakePath := writeFakeCodexAppServer(t, ""+
+			`echo x >> `+countPath+"\n"+
+			`read line`+"\n"+
+			`echo '{"jsonrpc":"2.0","method":"item/started","params":{"threadId":"unexpected","item":{"type":"commandExecution","id":"cmd-1","command":"true"}}}'`+"\n"+
+			`sleep 1`+"\n")
+		result := executeFakeCodex(t, fakePath, ExecOptions{Timeout: 5 * time.Second, HandshakeTimeout: 50 * time.Millisecond})
+		if result.Status != "failed" {
+			t.Fatalf("expected failed, got %q", result.Status)
+		}
+		data, _ := os.ReadFile(countPath)
+		if got := strings.Count(string(data), "x"); got != 1 {
+			t.Fatalf("launch count = %d, want 1", got)
+		}
+	})
+
+	t.Run("unconfirmed cleanup suppresses retry", func(t *testing.T) {
+		codexCleanupConfirmationOverride.Store(-1)
+		defer codexCleanupConfirmationOverride.Store(0)
+		countPath := filepath.Join(t.TempDir(), "launch-count")
+		fakePath := writeFakeCodexAppServer(t, ""+
+			`echo x >> `+countPath+"\n"+
+			`read line`+"\n"+
+			`sleep 1`+"\n")
+		result := executeFakeCodex(t, fakePath, ExecOptions{Timeout: 5 * time.Second, HandshakeTimeout: 50 * time.Millisecond})
+		if !strings.Contains(result.Error, "retry suppressed: process cleanup/reap not confirmed") {
+			t.Fatalf("expected cleanup reason, got %q", result.Error)
+		}
+		data, _ := os.ReadFile(countPath)
+		if got := strings.Count(string(data), "x"); got != 1 {
+			t.Fatalf("launch count = %d, want 1", got)
+		}
+	})
+}
+
+func TestCodexExecuteDoesNotSerializeConcurrentLaunches(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell-script fixture is POSIX-only")
+	}
+	fakePath := writeFakeCodexAppServer(t, ""+
+		`read line`+"\n"+
+		`sleep 0.4`+"\n"+
+		`echo '{"jsonrpc":"2.0","id":1,"result":{}}'`+"\n"+
+		`read line`+"\n"+
+		`read line`+"\n"+
+		`echo '{"jsonrpc":"2.0","id":2,"result":{"thread":{"id":"thr-concurrent"}}}'`+"\n"+
+		`read line`+"\n"+
+		`echo '{"jsonrpc":"2.0","id":3,"result":{}}'`+"\n"+
+		`echo '{"jsonrpc":"2.0","method":"turn/completed","params":{"threadId":"thr-concurrent","turn":{"id":"turn-1","status":"completed"}}}'`+"\n")
+
+	maxActiveCodexLaunchesObserved.Store(0)
+	results := make(chan Result, 2)
+	for i := 0; i < 2; i++ {
+		go func() {
+			backend, _ := New("codex", Config{ExecutablePath: fakePath, Logger: slog.Default()})
+			session, err := backend.Execute(context.Background(), "prompt", ExecOptions{Timeout: 5 * time.Second})
+			if err != nil {
+				results <- Result{Status: "failed", Error: err.Error()}
+				return
+			}
+			go func() {
+				for range session.Messages {
+				}
+			}()
+			results <- <-session.Result
+		}()
+	}
+	for i := 0; i < 2; i++ {
+		if result := <-results; result.Status != "completed" {
+			t.Fatalf("concurrent result failed: %+v", result)
+		}
+	}
+	if got := maxActiveCodexLaunchesObserved.Load(); got < 2 {
+		t.Fatalf("launches appear serialized: max active=%d", got)
+	}
+}
+
+func TestSanitizeCodexDiagnosticRedactsSecrets(t *testing.T) {
+	got := sanitizeCodexDiagnostic("authorization: bearer-value api_key=abc token:xyz\x00")
+	for _, secret := range []string{"bearer-value", "abc", "xyz"} {
+		if strings.Contains(got, secret) {
+			t.Fatalf("sanitized diagnostic leaked %q: %q", secret, got)
+		}
+	}
+}
+
 func TestCodexExecuteTimesOutWhenTurnStopsAfterToolResult(t *testing.T) {
 	t.Parallel()
 	if runtime.GOOS == "windows" {

--- a/server/pkg/agent/codex_test.go
+++ b/server/pkg/agent/codex_test.go
@@ -1739,6 +1739,43 @@ func TestSanitizeCodexDiagnosticRedactsSecrets(t *testing.T) {
 	}
 }
 
+func TestCodexExecuteRedactsStderrFromResultAndLogs(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell-script fixture is POSIX-only")
+	}
+	const (
+		bearer     = "bearer-secret-value"
+		jsonToken  = "json-secret-value"
+		standalone = "sk-abcdefghijklmnopqrstuvwxyz123456"
+	)
+	fakePath := writeFakeCodexAppServer(t, ""+
+		`echo 'Authorization: Bearer `+bearer+`' >&2`+"\n"+
+		`echo '{"token":"`+jsonToken+`"}' >&2`+"\n"+
+		`echo '`+standalone+`' >&2`+"\n"+
+		`exit 2`+"\n")
+	var logs bytes.Buffer
+	logger := slog.New(slog.NewJSONHandler(&logs, nil))
+	backend, err := New("codex", Config{ExecutablePath: fakePath, Logger: logger})
+	if err != nil {
+		t.Fatal(err)
+	}
+	session, err := backend.Execute(context.Background(), "prompt", ExecOptions{Timeout: 5 * time.Second})
+	if err != nil {
+		t.Fatal(err)
+	}
+	go func() {
+		for range session.Messages {
+		}
+	}()
+	result := <-session.Result
+	combined := result.Error + "\n" + logs.String()
+	for _, secret := range []string{bearer, jsonToken, standalone} {
+		if strings.Contains(combined, secret) {
+			t.Fatalf("stderr secret leaked: %q in %q", secret, combined)
+		}
+	}
+}
+
 func TestCodexExecuteDoesNotProbeVersionBeforeInitialize(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("shell-script fixture is POSIX-only")

--- a/server/pkg/agent/codex_test.go
+++ b/server/pkg/agent/codex_test.go
@@ -1729,11 +1729,79 @@ func TestCodexExecuteDoesNotSerializeConcurrentLaunches(t *testing.T) {
 }
 
 func TestSanitizeCodexDiagnosticRedactsSecrets(t *testing.T) {
-	got := sanitizeCodexDiagnostic("authorization: bearer-value api_key=abc token:xyz\x00")
-	for _, secret := range []string{"bearer-value", "abc", "xyz"} {
+	got := sanitizeCodexDiagnostic("Authorization: Bearer bearer-token\n" +
+		`{"token":"json-token","auth": "json-auth", "api_key":"json-key"}` +
+		"\npassword=plain-secret\x00")
+	for _, secret := range []string{"bearer-token", "json-token", "json-auth", "json-key", "plain-secret"} {
 		if strings.Contains(got, secret) {
 			t.Fatalf("sanitized diagnostic leaked %q: %q", secret, got)
 		}
+	}
+}
+
+func TestCodexExecuteDoesNotProbeVersionBeforeInitialize(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell-script fixture is POSIX-only")
+	}
+	fakePath := writeFakeCodexAppServer(t, ""+
+		`read line`+"\n"+
+		`echo '{"jsonrpc":"2.0","id":1,"result":{}}'`+"\n"+
+		`read line`+"\n"+
+		`read line`+"\n"+
+		`echo '{"jsonrpc":"2.0","id":2,"result":{"thread":{"id":"thr-fast-init"}}}'`+"\n"+
+		`read line`+"\n"+
+		`echo '{"jsonrpc":"2.0","id":3,"result":{}}'`+"\n"+
+		`echo '{"jsonrpc":"2.0","method":"turn/completed","params":{"threadId":"thr-fast-init","turn":{"id":"turn-1","status":"completed"}}}'`+"\n")
+	data, err := os.ReadFile(fakePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	data = bytes.Replace(data, []byte(`echo "codex-cli 0.0.0-test"; exit 0`), []byte(`sleep 2; echo "codex-cli 0.0.0-test"; exit 0`), 1)
+	writeTestExecutable(t, fakePath, data)
+
+	backend, err := New("codex", Config{ExecutablePath: fakePath, Logger: slog.Default(), CodexVersion: "cached-test-version"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	started := time.Now()
+	session, err := backend.Execute(context.Background(), "prompt", ExecOptions{Timeout: 5 * time.Second})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if elapsed := time.Since(started); elapsed > 500*time.Millisecond {
+		t.Fatalf("Execute blocked on version probe before initialize: %s", elapsed)
+	}
+	go func() {
+		for range session.Messages {
+		}
+	}()
+	if result := <-session.Result; result.Status != "completed" {
+		t.Fatalf("result=%+v", result)
+	}
+}
+
+func TestCodexExecuteRetriesAfterSignaledProcessIsReaped(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("Linux signal/reap semantics regression")
+	}
+	codexGracefulShutdownTimeoutNanos.Store(int64(100 * time.Millisecond))
+	defer codexGracefulShutdownTimeoutNanos.Store(0)
+	countPath := filepath.Join(t.TempDir(), "launch-count")
+	fakePath := writeFakeCodexAppServer(t, ""+
+		`count=0; test -f `+countPath+` && count=$(cat `+countPath+`)`+"\n"+
+		`count=$((count + 1)); echo "$count" > `+countPath+"\n"+
+		`read line`+"\n"+
+		`if test "$count" -eq 1; then exec sleep 30; fi`+"\n"+
+		`echo '{"jsonrpc":"2.0","id":1,"result":{}}'`+"\n"+
+		`read line`+"\n"+
+		`read line`+"\n"+
+		`echo '{"jsonrpc":"2.0","id":2,"result":{"thread":{"id":"thr-signaled"}}}'`+"\n"+
+		`read line`+"\n"+
+		`echo '{"jsonrpc":"2.0","id":3,"result":{}}'`+"\n"+
+		`echo '{"jsonrpc":"2.0","method":"turn/completed","params":{"threadId":"thr-signaled","turn":{"id":"turn-1","status":"completed"}}}'`+"\n")
+	result := executeFakeCodex(t, fakePath, ExecOptions{Timeout: 5 * time.Second, HandshakeTimeout: 50 * time.Millisecond})
+	if result.Status != "completed" {
+		t.Fatalf("signaled/reaped first attempt should retry: %+v", result)
 	}
 }
 

--- a/server/pkg/agent/proc_other.go
+++ b/server/pkg/agent/proc_other.go
@@ -24,6 +24,8 @@ func configureProcessGroup(cmd *exec.Cmd) {
 	cmd.SysProcAttr.Setpgid = true
 }
 
+func codexInitializeRetrySupported() bool { return true }
+
 // signalProcessGroup sends sig to the whole process group led by p (when the
 // command was started with configureProcessGroup), falling back to the single
 // process if the group send fails. Targeting the group (negative pid) reaches

--- a/server/pkg/agent/proc_windows.go
+++ b/server/pkg/agent/proc_windows.go
@@ -37,6 +37,10 @@ func hideAgentWindow(cmd *exec.Cmd) {
 // hideAgentWindow plus exec.CommandContext / WaitDelay terminating the child.
 func configureProcessGroup(cmd *exec.Cmd) {}
 
+// codexInitializeRetrySupported remains false until Codex children are owned
+// by a Job Object and descendant termination can be positively confirmed.
+func codexInitializeRetrySupported() bool { return false }
+
 // signalProcessGroup terminates the process on Windows. Windows has no
 // SIGTERM/SIGKILL distinction or process-group signalling, so the signal is
 // ignored and the process is killed directly (TerminateProcess via Kill). The

--- a/server/pkg/agent/proc_windows_test.go
+++ b/server/pkg/agent/proc_windows_test.go
@@ -2,64 +2,10 @@
 
 package agent
 
-import (
-	"os/exec"
-	"syscall"
-	"testing"
-)
+import "testing"
 
-// TestHideAgentWindowSetsCreateNewConsole guards against a regression where
-// hideAgentWindow reverts to CREATE_NO_WINDOW. CREATE_NO_WINDOW strips the
-// console entirely, which forces Windows to allocate a new visible console
-// per grandchild that doesn't itself pass CREATE_NO_WINDOW — the popup
-// storm reported in #1521.
-func TestHideAgentWindowSetsCreateNewConsole(t *testing.T) {
-	cmd := exec.Command("cmd.exe", "/c", "echo", "hi")
-	hideAgentWindow(cmd)
-
-	if cmd.SysProcAttr == nil {
-		t.Fatal("SysProcAttr should be initialized")
-	}
-	if !cmd.SysProcAttr.HideWindow {
-		t.Error("HideWindow should be true")
-	}
-	if cmd.SysProcAttr.CreationFlags&createNewConsole == 0 {
-		t.Errorf("CreationFlags should include CREATE_NEW_CONSOLE (0x%x), got 0x%x",
-			createNewConsole, cmd.SysProcAttr.CreationFlags)
-	}
-	const createNoWindow = 0x08000000
-	if cmd.SysProcAttr.CreationFlags&createNoWindow != 0 {
-		t.Errorf("CreationFlags must NOT include CREATE_NO_WINDOW (0x%x), got 0x%x — "+
-			"see #1521 for why this causes grandchild popups",
-			createNoWindow, cmd.SysProcAttr.CreationFlags)
-	}
-}
-
-// TestHideAgentWindowPreservesExistingSysProcAttr ensures hideAgentWindow
-// does not overwrite fields set by callers — a regression caught in PR #1474
-// where the whole SysProcAttr struct was replaced. We verify both a
-// non-CreationFlags field and a pre-existing CreationFlags bit survive.
-//
-// CREATE_UNICODE_ENVIRONMENT (0x00000400) is chosen because it is documented
-// as compatible with CREATE_NEW_CONSOLE (unlike CREATE_NEW_PROCESS_GROUP,
-// which Windows silently ignores when combined with CREATE_NEW_CONSOLE), so
-// a surviving bit here is semantically meaningful, not just bitwise intact.
-func TestHideAgentWindowPreservesExistingSysProcAttr(t *testing.T) {
-	const createUnicodeEnvironment = 0x00000400
-	cmd := exec.Command("cmd.exe", "/c", "echo", "hi")
-	cmd.SysProcAttr = &syscall.SysProcAttr{
-		CreationFlags:    createUnicodeEnvironment,
-		NoInheritHandles: true,
-	}
-	hideAgentWindow(cmd)
-
-	if !cmd.SysProcAttr.NoInheritHandles {
-		t.Error("NoInheritHandles set by caller should be preserved")
-	}
-	if cmd.SysProcAttr.CreationFlags&createUnicodeEnvironment == 0 {
-		t.Error("existing CreationFlags bits (CREATE_UNICODE_ENVIRONMENT) should be preserved")
-	}
-	if cmd.SysProcAttr.CreationFlags&createNewConsole == 0 {
-		t.Error("CREATE_NEW_CONSOLE should be OR'd into existing flags")
+func TestCodexInitializeRetrySuppressedWithoutConfirmedTreeCleanup(t *testing.T) {
+	if codexInitializeRetrySupported() {
+		t.Fatal("Codex initialize retry must remain disabled until Windows descendant cleanup is positively confirmed")
 	}
 }

--- a/server/pkg/agent/proc_windows_test.go
+++ b/server/pkg/agent/proc_windows_test.go
@@ -2,7 +2,67 @@
 
 package agent
 
-import "testing"
+import (
+	"os/exec"
+	"syscall"
+	"testing"
+)
+
+// TestHideAgentWindowSetsCreateNewConsole guards against a regression where
+// hideAgentWindow reverts to CREATE_NO_WINDOW. CREATE_NO_WINDOW strips the
+// console entirely, which forces Windows to allocate a new visible console
+// per grandchild that doesn't itself pass CREATE_NO_WINDOW — the popup
+// storm reported in #1521.
+func TestHideAgentWindowSetsCreateNewConsole(t *testing.T) {
+	cmd := exec.Command("cmd.exe", "/c", "echo", "hi")
+	hideAgentWindow(cmd)
+
+	if cmd.SysProcAttr == nil {
+		t.Fatal("SysProcAttr should be initialized")
+	}
+	if !cmd.SysProcAttr.HideWindow {
+		t.Error("HideWindow should be true")
+	}
+	if cmd.SysProcAttr.CreationFlags&createNewConsole == 0 {
+		t.Errorf("CreationFlags should include CREATE_NEW_CONSOLE (0x%x), got 0x%x",
+			createNewConsole, cmd.SysProcAttr.CreationFlags)
+	}
+	const createNoWindow = 0x08000000
+	if cmd.SysProcAttr.CreationFlags&createNoWindow != 0 {
+		t.Errorf("CreationFlags must NOT include CREATE_NO_WINDOW (0x%x), got 0x%x — "+
+			"see #1521 for why this causes grandchild popups",
+			createNoWindow, cmd.SysProcAttr.CreationFlags)
+	}
+}
+
+// TestHideAgentWindowPreservesExistingSysProcAttr ensures hideAgentWindow
+// does not overwrite fields set by callers — a regression caught in PR #1474
+// where the whole SysProcAttr struct was replaced. We verify both a
+// non-CreationFlags field and a pre-existing CreationFlags bit survive.
+//
+// CREATE_UNICODE_ENVIRONMENT (0x00000400) is chosen because it is documented
+// as compatible with CREATE_NEW_CONSOLE (unlike CREATE_NEW_PROCESS_GROUP,
+// which Windows silently ignores when combined with CREATE_NEW_CONSOLE), so
+// a surviving bit here is semantically meaningful, not just bitwise intact.
+func TestHideAgentWindowPreservesExistingSysProcAttr(t *testing.T) {
+	const createUnicodeEnvironment = 0x00000400
+	cmd := exec.Command("cmd.exe", "/c", "echo", "hi")
+	cmd.SysProcAttr = &syscall.SysProcAttr{
+		CreationFlags:    createUnicodeEnvironment,
+		NoInheritHandles: true,
+	}
+	hideAgentWindow(cmd)
+
+	if !cmd.SysProcAttr.NoInheritHandles {
+		t.Error("NoInheritHandles set by caller should be preserved")
+	}
+	if cmd.SysProcAttr.CreationFlags&createUnicodeEnvironment == 0 {
+		t.Error("existing CreationFlags bits (CREATE_UNICODE_ENVIRONMENT) should be preserved")
+	}
+	if cmd.SysProcAttr.CreationFlags&createNewConsole == 0 {
+		t.Error("CREATE_NEW_CONSOLE should be OR'd into existing flags")
+	}
+}
 
 func TestCodexInitializeRetrySuppressedWithoutConfirmedTreeCleanup(t *testing.T) {
 	if codexInitializeRetrySupported() {

--- a/server/pkg/agent/stderr_tail.go
+++ b/server/pkg/agent/stderr_tail.go
@@ -27,8 +27,9 @@ type stderrTail struct {
 	inner io.Writer
 	max   int
 
-	mu  sync.Mutex
-	buf []byte
+	mu    sync.Mutex
+	buf   []byte
+	total int64
 }
 
 func newStderrTail(inner io.Writer, max int) *stderrTail {
@@ -43,12 +44,19 @@ func (s *stderrTail) Write(p []byte) (int, error) {
 		return 0, err
 	}
 	s.mu.Lock()
+	s.total += int64(len(p))
 	s.buf = append(s.buf, p...)
 	if len(s.buf) > s.max {
 		s.buf = s.buf[len(s.buf)-s.max:]
 	}
 	s.mu.Unlock()
 	return len(p), nil
+}
+
+func (s *stderrTail) TotalBytes() int64 {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.total
 }
 
 // Tail returns the captured stderr with leading/trailing whitespace


### PR DESCRIPTION
Closes KAP-867

## Summary
- emit structured Codex spawn/initialize/cleanup diagnostics with task/runtime/process/version/latency/reap evidence
- retry exactly once only for pre-thread initialize timeout with no semantic activity and confirmed cleanup
- sanitize bounded stderr diagnostics and retain concurrent launch behavior

## Verification
- `go test ./pkg/agent -count=1`
- `go test ./internal/daemon -run TestNonExistent -count=1` (compile gate)
- `go vet ./pkg/agent ./internal/daemon`

## Rollout
Canary one local Codex runtime for 24–48h. Monitor initialize attempts, cleanup failures, orphan processes, and duplicate side effects. Roll back to previous daemon binary; no schema/data migration.