### PR TITLE
fix(daemon): allow larger WebSocket claim responses

### DIFF
--- a/server/internal/daemon/wakeup.go
+++ b/server/internal/daemon/wakeup.go
@@ -19,7 +19,10 @@ import (
 
 var errRuntimeSetChanged = errors.New("runtime set changed")
 
-const taskWakeupMaxBackoff = 30 * time.Second
+const (
+	taskWakeupMaxBackoff = 30 * time.Second
+	taskWakeupReadLimit  = 4 * 1024 * 1024
+)
 
 var (
 	taskWakeupPongWait          = 60 * time.Second
@@ -395,7 +398,7 @@ func (d *Daemon) readTaskWakeupMessages(conn *websocket.Conn, taskWakeups chan<-
 }
 
 func (d *Daemon) configureTaskWakeupReadLiveness(conn *websocket.Conn) {
-	conn.SetReadLimit(64 * 1024)
+	conn.SetReadLimit(taskWakeupReadLimit)
 	if err := d.extendTaskWakeupReadDeadline(conn); err != nil {
 		d.logger.Debug("task wakeup websocket read deadline failed", "error", err)
 	}

--- a/server/internal/daemon/wakeup_test.go
+++ b/server/internal/daemon/wakeup_test.go
@@ -93,6 +93,68 @@ func TestWSHeartbeatFreshnessSuppressesHTTP(t *testing.T) {
 	}
 }
 
+func TestReadTaskWakeupMessagesAcceptsClaimResponseLargerThan64KiB(t *testing.T) {
+	claimResponseFrame := mustProtocolFrame(t, protocol.Message{
+		Type: protocol.EventDaemonRPCResponse,
+		Payload: marshalRaw(protocol.RPCResponsePayload{
+			RequestID: "request-1",
+			Status:    http.StatusOK,
+			Body: json.RawMessage(
+				`{"tasks":[{"description":"` + strings.Repeat("x", 128*1024) + `"}]}`,
+			),
+		}),
+	})
+	if len(claimResponseFrame) <= 64*1024 {
+		t.Fatalf("claim response frame size = %d, want larger than 64 KiB", len(claimResponseFrame))
+	}
+	taskFrame := mustProtocolFrame(t, protocol.Message{
+		Type: protocol.EventDaemonTaskAvailable,
+		Payload: marshalRaw(protocol.TaskAvailablePayload{
+			RuntimeID: "runtime-1",
+			TaskID:    "task-1",
+		}),
+	})
+
+	upgrader := websocket.Upgrader{}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, err := upgrader.Upgrade(w, r, nil)
+		if err != nil {
+			return
+		}
+		defer conn.Close()
+
+		if !writeWSMessage(t, conn, websocket.TextMessage, claimResponseFrame) {
+			return
+		}
+		writeWSMessage(t, conn, websocket.TextMessage, taskFrame)
+	}))
+	defer srv.Close()
+
+	conn, _, err := websocket.DefaultDialer.Dial(taskWakeupTestWSURL(srv.URL), nil)
+	if err != nil {
+		t.Fatalf("dial websocket: %v", err)
+	}
+	defer conn.Close()
+
+	d := New(Config{}, slog.Default())
+	taskWakeups := make(chan taskWakeup, 1)
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- d.readTaskWakeupMessages(conn, taskWakeups)
+	}()
+
+	select {
+	case wakeup := <-taskWakeups:
+		if wakeup.runtimeID != "runtime-1" {
+			t.Fatalf("wakeup runtimeID = %q, want runtime-1", wakeup.runtimeID)
+		}
+	case err := <-errCh:
+		t.Fatalf("readTaskWakeupMessages returned before consuming large claim response: %v", err)
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for task wakeup after large claim response")
+	}
+}
+
 func TestReadTaskWakeupMessagesTimesOutWithoutPeerTraffic(t *testing.T) {
 	overrideTaskWakeupTimings(t, 60*time.Millisecond, 20*time.Millisecond, taskWakeupBackoffResetAfter)
 


### PR DESCRIPTION
## Summary

- raise the daemon client's inbound WebSocket control-frame limit from 64 KiB to a named, bounded 4 MiB value
- add a regression test that consumes a 128 KiB+ claim response before processing the following task wakeup
- leave the server-side daemon WebSocket inbound limit unchanged

## Verification

- Regression red: go test ./internal/daemon -run '^TestReadTaskWakeupMessagesAcceptsClaimResponseLargerThan64KiB$' -count=1 failed under the original limit with websocket: read limit exceeded
- Regression green: the same command passed after the production change
- go test ./internal/daemon -run 'Wakeup' -count=1 passed
- go vet ./internal/daemon passed
- make check-worktree could not start in this environment:
  `
  make : The term 'make' is not recognized as the name of a cmdlet, function, script file, or operable program.
  FullyQualifiedErrorId : CommandNotFoundException
  `
- go test ./internal/daemon -count=1 was also attempted and failed in unrelated environment-dependent tests (provider-home skill discovery, missing agent CLI, and Windows path-length failures)

Closes #5411