### PR TITLE
Fix OpenClaw unparseable output diagnostics (ZIC-81)

### DIFF
--- a/server/pkg/agent/openclaw.go
+++ b/server/pkg/agent/openclaw.go
@@ -92,7 +92,8 @@ func (b *openclawBackend) Execute(ctx context.Context, prompt string, opts ExecO
 		cancel()
 		return nil, fmt.Errorf("openclaw stdout pipe: %w", err)
 	}
-	cmd.Stderr = newLogWriter(b.cfg.Logger, "[openclaw:stderr] ")
+	stderrBuf := newStderrTail(newLogWriter(b.cfg.Logger, "[openclaw:stderr] "), agentStderrTailBytes)
+	cmd.Stderr = stderrBuf
 
 	if err := cmd.Start(); err != nil {
 		cancel()
@@ -128,9 +129,16 @@ func (b *openclawBackend) Execute(ctx context.Context, prompt string, opts ExecO
 		} else if runCtx.Err() == context.Canceled {
 			scanResult.status = "aborted"
 			scanResult.errMsg = "execution cancelled"
-		} else if exitErr != nil && scanResult.status == "completed" {
-			scanResult.status = "failed"
-			scanResult.errMsg = fmt.Sprintf("openclaw exited with error: %v", exitErr)
+		} else if exitErr != nil {
+			if scanResult.status == "completed" {
+				scanResult.status = "failed"
+				scanResult.errMsg = fmt.Sprintf("openclaw exited with error: %v", exitErr)
+			} else if scanResult.errMsg == openclawNoParseableOutput {
+				scanResult.errMsg = fmt.Sprintf("%s (process exited with %v)", scanResult.errMsg, exitErr)
+			}
+		}
+		if scanResult.status == "failed" && scanResult.errMsg != "" {
+			scanResult.errMsg = withAgentStderr(scanResult.errMsg, "openclaw", stderrBuf.Tail())
 		}
 
 		b.cfg.Logger.Info("openclaw finished", "pid", cmd.Process.Pid, "status", scanResult.status, "duration", duration.Round(time.Millisecond).String())

--- a/server/pkg/agent/openclaw_test.go
+++ b/server/pkg/agent/openclaw_test.go
@@ -1567,3 +1567,53 @@ func TestOpenclawExecuteAllowsCurrentVersion(t *testing.T) {
 		t.Fatal("timeout waiting for result")
 	}
 }
+
+func TestOpenclawExecuteIncludesStderrWhenOutputIsUnparseable(t *testing.T) {
+	t.Parallel()
+	if runtime.GOOS == "windows" {
+		t.Skip("shell-script fixture is POSIX-only")
+	}
+
+	fakePath := filepath.Join(t.TempDir(), "openclaw")
+	script := "#!/bin/sh\n" +
+		"if [ \"$1\" = \"--version\" ]; then\n" +
+		"  echo 'openclaw 2026.5.5 c37871e'\n" +
+		"  exit 0\n" +
+		"fi\n" +
+		"echo 'openclaw config validation failed: missing gateway.auth.token' >&2\n" +
+		"exit 7\n"
+	writeTestExecutable(t, fakePath, []byte(script))
+
+	backend, err := New("openclaw", Config{ExecutablePath: fakePath, Logger: slog.Default()})
+	if err != nil {
+		t.Fatalf("new openclaw backend: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	session, err := backend.Execute(ctx, "prompt-ignored", ExecOptions{Timeout: 5 * time.Second})
+	if err != nil {
+		t.Fatalf("Execute returned synchronous error: %v", err)
+	}
+	go func() {
+		for range session.Messages {
+		}
+	}()
+	select {
+	case result := <-session.Result:
+		if result.Status != "failed" {
+			t.Fatalf("status = %q, want failed", result.Status)
+		}
+		for _, want := range []string{
+			openclawNoParseableOutput,
+			"process exited with exit status 7",
+			"openclaw stderr: openclaw config validation failed: missing gateway.auth.token",
+		} {
+			if !strings.Contains(result.Error, want) {
+				t.Errorf("result error missing %q: %s", want, result.Error)
+			}
+		}
+	case <-time.After(10 * time.Second):
+		t.Fatal("timeout waiting for result")
+	}
+}


### PR DESCRIPTION
## What does this PR do?

Improves OpenClaw task failure diagnostics when the CLI exits before emitting parseable JSON on stdout. The backend now preserves the canonical `openclaw returned no parseable output` prefix while appending the subprocess exit status and captured stderr tail, so startup/config failures explain why no gateway request was emitted.

<!-- multica-auto-bugfix -->

## Related Issue

Closes #3822

Multica: ZIC-81

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Refactor / code improvement (no behavior change)
- [x] Tests (adding or improving test coverage)
- [ ] CI / infrastructure

## Changes Made

- `server/pkg/agent/openclaw.go`: route OpenClaw stderr through the shared bounded tail buffer and append it to failed unparseable-output results.
- `server/pkg/agent/openclaw_test.go`: add an execution-level regression test for a CLI startup/config failure that writes only stderr.

## How to Test

1. `cd server && go test ./pkg/agent -run 'TestOpenclaw'`
2. `cd server && go test ./pkg/agent`
3. `make check-worktree` was attempted; it returned exit 0 but printed `Cannot connect to the Docker daemon at unix:///Users/icezero/.docker/run/docker.sock` during the PostgreSQL check, so the backend package tests above are the reliable local verification.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [ ] I have updated relevant documentation to reflect my changes
- [ ] If I added a new runtime / coding tool / UI tab, I synced the change to **landing copy** (`apps/web/features/landing/i18n/`) and **relevant docs** (`apps/docs/content/docs/`)
- [ ] If this PR touches Chinese product copy, I checked it against `apps/docs/content/docs/developers/conventions.zh.mdx` (terminology, mixed-rule for `task` / `issue` / `skill`)
- [x] I have considered and documented any risks above
- [x] I will address all reviewer comments before requesting merge

## AI Disclosure

**AI tool used:** Multica Agent

**Prompt / approach:**
Traced the OpenClaw execution path from daemon runtime config through `server/pkg/agent/openclaw.go`, verified gateway mode already controls `--local`, then fixed the user-facing diagnostic path where stderr was logged but not included in failed results.

## Screenshots (optional)

N/A
