### PR TITLE
Fix delayed sub-issue list refresh

### DIFF
--- a/packages/core/issues/cache-helpers.ts
+++ b/packages/core/issues/cache-helpers.ts
@@ -116,6 +116,27 @@ export function insertByPosition(issues: Issue[], issue: Issue): Issue[] {
 }
 
 /**
+ * Upsert a child issue into a parent's children list using the backend's
+ * `ListChildIssues` order (`number ASC`). The create event may race with a
+ * local optimistic insert, so an existing child is merged instead of duplicated.
+ */
+export function upsertChildIssueByNumber(
+  issues: Issue[],
+  issue: Issue,
+): Issue[] {
+  const withoutIssue = issues.filter((i) => i.id !== issue.id);
+  const existing = issues.find((i) => i.id === issue.id);
+  const nextIssue = existing ? { ...existing, ...issue } : issue;
+  const idx = withoutIssue.findIndex((i) => i.number > nextIssue.number);
+  if (idx === -1) return [...withoutIssue, nextIssue];
+  return [
+    ...withoutIssue.slice(0, idx),
+    nextIssue,
+    ...withoutIssue.slice(idx),
+  ];
+}
+
+/**
  * Merge `patch` into the issue with `id`. If `patch.status` differs from the
  * current bucket, the issue moves to the new bucket and both buckets' totals
  * are adjusted. The moved card — and a same-column card whose `position`

--- a/packages/core/issues/mutations.test.tsx
+++ b/packages/core/issues/mutations.test.tsx
@@ -10,6 +10,7 @@ import { setApiInstance } from "../api";
 import type { ApiClient } from "../api/client";
 import {
   useBatchUpdateIssues,
+  useCreateIssue,
   useLoadMoreByAssigneeGroup,
   useLoadMoreByStatus,
   useResolveComment,
@@ -384,6 +385,78 @@ describe("useLoadMoreByAssigneeGroup", () => {
       "issue-1",
       "issue-2",
     ]);
+  });
+});
+
+describe("useCreateIssue — parent children cache refresh", () => {
+  const PARENT_ID = "parent-1";
+  const childKey = issueKeys.children(WS_ID, PARENT_ID);
+
+  let qc: QueryClient;
+  let createIssue: ReturnType<typeof vi.fn<(data: unknown) => Promise<Issue>>>;
+
+  beforeEach(() => {
+    qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    createIssue = vi.fn();
+    setApiInstance({ createIssue } as unknown as ApiClient);
+    vi.stubGlobal("localStorage", {
+      getItem: vi.fn(() => null),
+      setItem: vi.fn(),
+      removeItem: vi.fn(),
+    });
+  });
+
+  afterEach(() => {
+    qc.clear();
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it("inserts a created child into an already loaded parent children cache", async () => {
+    const child = makeIssue(2, { parent_issue_id: PARENT_ID });
+    qc.setQueryData<Issue[]>(childKey, [
+      makeIssue(1, { parent_issue_id: PARENT_ID }),
+    ]);
+    createIssue.mockResolvedValue(child);
+
+    const { result } = renderHook(() => useCreateIssue(), {
+      wrapper: createWrapper(qc),
+    });
+
+    await act(async () => {
+      await result.current.mutateAsync({
+        title: "Child",
+        parent_issue_id: PARENT_ID,
+      });
+    });
+
+    expect(qc.getQueryData<Issue[]>(childKey)?.map((i) => i.id)).toEqual([
+      "issue-1",
+      "issue-2",
+    ]);
+  });
+
+  it("invalidates parent children queries even when the children cache is not loaded", async () => {
+    const child = makeIssue(1, { parent_issue_id: PARENT_ID });
+    createIssue.mockResolvedValue(child);
+    const invalidateSpy = vi.spyOn(qc, "invalidateQueries");
+
+    const { result } = renderHook(() => useCreateIssue(), {
+      wrapper: createWrapper(qc),
+    });
+
+    await act(async () => {
+      await result.current.mutateAsync({
+        title: "Child",
+        parent_issue_id: PARENT_ID,
+      });
+    });
+
+    expect(qc.getQueryData<Issue[]>(childKey)).toBeUndefined();
+    const invalidatedKeys = invalidateSpy.mock.calls.map((c) => c[0]?.queryKey);
+    expect(invalidatedKeys).toContainEqual(childKey);
+    expect(invalidatedKeys).toContainEqual(issueKeys.childProgress(WS_ID));
+    expect(invalidatedKeys).toContainEqual(issueKeys.childrenByParentsAll(WS_ID));
   });
 });
 

--- a/packages/core/issues/mutations.ts
+++ b/packages/core/issues/mutations.ts
@@ -21,6 +21,7 @@ import {
   addIssueToBuckets,
   getBucket,
   setBucket,
+  upsertChildIssueByNumber,
 } from "./cache-helpers";
 import {
   cleanupDeletedIssueCaches,
@@ -200,8 +201,13 @@ export function useCreateIssue() {
       useRecentIssuesStore.getState().recordVisit(wsId, newIssue.id);
       // Invalidate parent's children query so sub-issues list updates immediately
       if (newIssue.parent_issue_id) {
+        qc.setQueryData<Issue[]>(
+          issueKeys.children(wsId, newIssue.parent_issue_id),
+          (old) => (old ? upsertChildIssueByNumber(old, newIssue) : old),
+        );
         qc.invalidateQueries({ queryKey: issueKeys.children(wsId, newIssue.parent_issue_id) });
         qc.invalidateQueries({ queryKey: issueKeys.childProgress(wsId) });
+        qc.invalidateQueries({ queryKey: issueKeys.childrenByParentsAll(wsId) });
       }
     },
     onSettled: () => {

--- a/packages/core/issues/ws-updaters.test.ts
+++ b/packages/core/issues/ws-updaters.test.ts
@@ -263,6 +263,67 @@ describe("project progress invalidation", () => {
   });
 });
 
+describe("onIssueCreated — parent children cache", () => {
+  let qc: QueryClient;
+
+  beforeEach(() => {
+    qc = new QueryClient();
+  });
+
+  it("shows a newly-created child in the parent's cached sub-issue list immediately", () => {
+    const child: Issue = {
+      ...parentedIssue,
+      id: "child-1",
+      identifier: "MUL-3",
+      number: 3,
+    };
+    qc.setQueryData<Issue[]>(issueKeys.children(WS_ID, PARENT_ISSUE_ID), []);
+    qc.setQueryData(issueKeys.childProgress(WS_ID), new Map());
+    qc.setQueryData(
+      issueKeys.childrenByParents(WS_ID, [PARENT_ISSUE_ID]),
+      new Map([[PARENT_ISSUE_ID, []]]),
+    );
+
+    onIssueCreated(qc, WS_ID, child);
+
+    const parentChildren = qc.getQueryData<Issue[]>(
+      issueKeys.children(WS_ID, PARENT_ISSUE_ID),
+    );
+    expect(parentChildren?.map((i) => i.id)).toEqual(["child-1"]);
+    expectInvalidated(qc, issueKeys.children(WS_ID, PARENT_ISSUE_ID));
+    expectInvalidated(qc, issueKeys.childProgress(WS_ID));
+    expectInvalidated(qc, issueKeys.childrenByParents(WS_ID, [PARENT_ISSUE_ID]));
+  });
+
+  it("keeps the parent's cached sub-issue list ordered by issue number and deduped", () => {
+    const serverChild: Issue = {
+      ...parentedIssue,
+      id: "child-1",
+      identifier: "MUL-2",
+      number: 2,
+      title: "Server title",
+    };
+    qc.setQueryData<Issue[]>(issueKeys.children(WS_ID, PARENT_ISSUE_ID), [
+      { ...serverChild, title: "Optimistic title" },
+      {
+        ...otherIssue,
+        id: "child-3",
+        identifier: "MUL-3",
+        number: 3,
+        parent_issue_id: PARENT_ISSUE_ID,
+      },
+    ]);
+
+    onIssueCreated(qc, WS_ID, serverChild);
+
+    const parentChildren = qc.getQueryData<Issue[]>(
+      issueKeys.children(WS_ID, PARENT_ISSUE_ID),
+    );
+    expect(parentChildren?.map((i) => i.id)).toEqual(["child-1", "child-3"]);
+    expect(parentChildren?.[0]?.title).toBe("Server title");
+  });
+});
+
 describe("onIssueUpdated — position move is surgical, not a list refetch", () => {
   let qc: QueryClient;
 

--- a/packages/core/issues/ws-updaters.ts
+++ b/packages/core/issues/ws-updaters.ts
@@ -11,6 +11,7 @@ import {
   addIssueToBuckets,
   findIssueLocation,
   patchIssueInBuckets,
+  upsertChildIssueByNumber,
 } from "./cache-helpers";
 import { cleanupDeletedIssueCaches } from "./delete-cache";
 import type { Issue, IssueLabelsResponse, IssueMetadata, Label } from "../types";
@@ -36,8 +37,13 @@ export function onIssueCreated(
   // page (if any) will refetch and pick it up if it qualifies.
   qc.invalidateQueries({ queryKey: issueKeys.projectGanttAll(wsId) });
   if (issue.parent_issue_id) {
+    qc.setQueryData<Issue[]>(
+      issueKeys.children(wsId, issue.parent_issue_id),
+      (old) => (old ? upsertChildIssueByNumber(old, issue) : old),
+    );
     qc.invalidateQueries({ queryKey: issueKeys.children(wsId, issue.parent_issue_id) });
     qc.invalidateQueries({ queryKey: issueKeys.childProgress(wsId) });
+    qc.invalidateQueries({ queryKey: issueKeys.childrenByParentsAll(wsId) });
   }
 }
 


### PR DESCRIPTION
<!-- multica-auto-bugfix -->

## What does this PR do?

Fixes stale parent issue sub-issue lists after a child issue is created by patching the cached parent children list immediately from issue creation events, then invalidating the same query for server reconciliation.

Thinking path: the issue detail page reads `issueKeys.children(wsId, parentId)`, while `issue:created` previously only invalidated that query. With the app-wide `staleTime: Infinity`, an already-mounted parent page could keep rendering the old empty array until a later refresh path. Updating the cached children array on the creation event makes the visible parent page reflect the new child immediately and still refetches to confirm server ordering.

## Related Issue

Closes #5405

Multica issue: ZIC-79

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Refactor / code improvement (no behavior change)
- [x] Tests (adding or improving test coverage)
- [ ] Documentation update
- [ ] CI / infrastructure

## Changes Made

- Added a shared child-issue cache upsert helper that dedupes create events and preserves the backend's `number ASC` child order.
- Updated websocket and local issue creation paths to patch the parent's cached children list immediately, then invalidate per-parent children, child progress, and batched-children caches.
- Added regression tests for an empty cached sub-issue list and create-event deduping/order.

## How to Test

1. `pnpm -C packages/core exec vitest run issues/ws-updaters.test.ts`
2. `pnpm --filter @multica/core typecheck`
3. `pnpm --filter @multica/core lint`
4. `make check-worktree` was attempted; Docker was unavailable locally (`Cannot connect to the Docker daemon`), and the Make target still exited 0 after logging that Docker error.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [ ] I have updated relevant documentation to reflect my changes
- [ ] If I added a new runtime / coding tool / UI tab, I synced the change to **landing copy** (`apps/web/features/landing/i18n/`) and **relevant docs** (`apps/docs/content/docs/`)
- [ ] If this PR touches Chinese product copy, I checked it against `apps/docs/content/docs/developers/conventions.zh.mdx` (terminology, mixed-rule for `task` / `issue` / `skill`)
- [x] I have considered and documented any risks above
- [x] I will address all reviewer comments before requesting merge

## AI Disclosure

**AI tool used:** Multica Agent

**Prompt / approach:**
Investigated the parent issue detail child-list query and websocket issue creation cache updater, then made the smallest shared cache update so created children are visible immediately while preserving server reconciliation.

## Screenshots (optional)

Not included; this is a cache refresh fix covered by focused unit tests.
