### PR TITLE
Fix desktop HTML attachment downloads

### DIFF
--- a/apps/desktop/src/main/download-authorization.test.ts
+++ b/apps/desktop/src/main/download-authorization.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "vitest";
+import {
+  PendingDownloadAuthorizations,
+  sanitizeBearerAuthorization,
+} from "./download-authorization";
+
+const ATTACHMENT_URL =
+  "https://api.example.test/api/attachments/11111111-2222-3333-4444-555555555555/download?workspace_slug=acme";
+
+describe("sanitizeBearerAuthorization", () => {
+  it("accepts non-empty bearer headers and trims whitespace", () => {
+    expect(sanitizeBearerAuthorization(" Bearer jwt-token ")).toBe(
+      "Bearer jwt-token",
+    );
+  });
+
+  it("rejects missing, empty, and newline-bearing values", () => {
+    expect(sanitizeBearerAuthorization(undefined)).toBeNull();
+    expect(sanitizeBearerAuthorization("Bearer ")).toBeNull();
+    expect(sanitizeBearerAuthorization("Token jwt-token")).toBeNull();
+    expect(sanitizeBearerAuthorization("Bearer jwt\r\nX-Evil: 1")).toBeNull();
+  });
+});
+
+describe("PendingDownloadAuthorizations", () => {
+  it("consumes auth once for the exact stable attachment download URL", () => {
+    const pending = new PendingDownloadAuthorizations();
+
+    expect(pending.register(ATTACHMENT_URL, "Bearer jwt-token")).toBe(true);
+    expect(pending.consume(ATTACHMENT_URL)).toBe("Bearer jwt-token");
+    expect(pending.consume(ATTACHMENT_URL)).toBeNull();
+  });
+
+  it("ignores non-attachment and non-http URLs", () => {
+    const pending = new PendingDownloadAuthorizations();
+
+    expect(
+      pending.register("https://api.example.test/api/me", "Bearer jwt-token"),
+    ).toBe(false);
+    expect(
+      pending.register(
+        "file:///api/attachments/11111111-2222-3333-4444-555555555555/download",
+        "Bearer jwt-token",
+      ),
+    ).toBe(false);
+  });
+
+  it("ignores malformed attachment ids", () => {
+    const pending = new PendingDownloadAuthorizations();
+
+    expect(
+      pending.register(
+        "https://api.example.test/api/attachments/not-a-uuid/download",
+        "Bearer jwt-token",
+      ),
+    ).toBe(false);
+  });
+});

--- a/apps/desktop/src/main/download-authorization.ts
+++ b/apps/desktop/src/main/download-authorization.ts
@@ -1,0 +1,57 @@
+const ATTACHMENT_DOWNLOAD_PATH_RE =
+  /^\/api\/attachments\/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\/download$/i;
+
+interface PendingDownloadAuthorization {
+  value: string;
+  timeout: NodeJS.Timeout;
+}
+
+export function sanitizeBearerAuthorization(value: unknown): string | null {
+  if (typeof value !== "string") return null;
+  const trimmed = value.trim();
+  if (!trimmed.startsWith("Bearer ")) return null;
+  if (/[\r\n]/.test(trimmed)) return null;
+  if (trimmed.length <= "Bearer ".length) return null;
+  return trimmed;
+}
+
+function normalizeAttachmentDownloadURLForAuth(rawURL: string): string | null {
+  try {
+    const parsed = new URL(rawURL);
+    if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+      return null;
+    }
+    if (!ATTACHMENT_DOWNLOAD_PATH_RE.test(parsed.pathname)) return null;
+    parsed.hash = "";
+    return parsed.toString();
+  } catch {
+    return null;
+  }
+}
+
+export class PendingDownloadAuthorizations {
+  private readonly entries = new Map<string, PendingDownloadAuthorization>();
+
+  register(rawURL: string, authorization: string): boolean {
+    const key = normalizeAttachmentDownloadURLForAuth(rawURL);
+    if (!key) return false;
+    const existing = this.entries.get(key);
+    if (existing) clearTimeout(existing.timeout);
+    const timeout = setTimeout(() => {
+      this.entries.delete(key);
+    }, 30_000);
+    timeout.unref?.();
+    this.entries.set(key, { value: authorization, timeout });
+    return true;
+  }
+
+  consume(rawURL: string): string | null {
+    const key = normalizeAttachmentDownloadURLForAuth(rawURL);
+    if (!key) return null;
+    const pending = this.entries.get(key);
+    if (!pending) return null;
+    clearTimeout(pending.timeout);
+    this.entries.delete(key);
+    return pending.value;
+  }
+}

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -8,6 +8,10 @@ import { setupDaemonManager } from "./daemon-manager";
 import { setupLocalDirectory } from "./local-directory";
 import { openExternalSafely, downloadURLSafely } from "./external-url";
 import { installContextMenu } from "./context-menu";
+import {
+  PendingDownloadAuthorizations,
+  sanitizeBearerAuthorization,
+} from "./download-authorization";
 import { handleAppShortcut } from "./keyboard-shortcuts";
 import { installNavigationGestures } from "./navigation-gestures";
 import { getAppVersion } from "./app-version";
@@ -86,6 +90,7 @@ if (process.platform !== "win32") {
 }
 
 const PROTOCOL = "multica";
+const pendingDownloadAuthorizations = new PendingDownloadAuthorizations();
 
 // Where the main process parks a freeze/crash breadcrumb until the next
 // renderer boot flushes it to telemetry. Lives in userData so it survives a
@@ -212,9 +217,15 @@ function createWindow(): void {
   // Strip Origin header from WebSocket upgrade requests so the server's
   // origin whitelist doesn't reject connections from localhost dev origins.
   window.webContents.session.webRequest.onBeforeSendHeaders(
-    { urls: ["wss://*/*", "ws://*/*"] },
+    { urls: ["http://*/*", "https://*/*", "ws://*/*", "wss://*/*"] },
     (details, callback) => {
-      delete details.requestHeaders["Origin"];
+      if (details.url.startsWith("ws://") || details.url.startsWith("wss://")) {
+        delete details.requestHeaders["Origin"];
+      }
+      const authorization = pendingDownloadAuthorizations.consume(details.url);
+      if (authorization) {
+        details.requestHeaders["Authorization"] = authorization;
+      }
       callback({ requestHeaders: details.requestHeaders });
     },
   );
@@ -440,13 +451,24 @@ if (!gotTheLock) {
       mainWindow?.close();
     });
 
-    ipcMain.handle("file:download-url", (_event, url: string) => {
-      if (!mainWindow) {
-        console.warn("[download] ignored file:download-url — mainWindow torn down");
-        return;
-      }
-      downloadURLSafely(mainWindow, url);
-    });
+    ipcMain.handle(
+      "file:download-url",
+      (_event, url: string, options?: { authorization?: string }) => {
+        if (!mainWindow) {
+          console.warn(
+            "[download] ignored file:download-url — mainWindow torn down",
+          );
+          return;
+        }
+        const authorization = sanitizeBearerAuthorization(
+          options?.authorization,
+        );
+        if (authorization) {
+          pendingDownloadAuthorizations.register(url, authorization);
+        }
+        downloadURLSafely(mainWindow, url);
+      },
+    );
 
     // Sync IPC: app version + normalized OS for preload. Sync (not invoke) so
     // preload can attach the values to `desktopAPI.appInfo` before any renderer

--- a/apps/desktop/src/preload/index.d.ts
+++ b/apps/desktop/src/preload/index.d.ts
@@ -31,7 +31,10 @@ interface DesktopAPI {
   openExternal: (url: string) => Promise<void>;
   /** Download a file by URL through Electron's native download system.
    *  Shows a native save dialog. On non-desktop platforms this is undefined. */
-  downloadURL: (url: string) => Promise<void>;
+  downloadURL: (
+    url: string,
+    options?: { authorization?: string },
+  ) => Promise<void>;
   /** Hide macOS traffic lights for full-screen modals; restore when false. */
   setImmersiveMode: (immersive: boolean) => Promise<void>;
   /** Show a native OS notification for a new inbox item. */

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -117,7 +117,8 @@ const desktopAPI = {
    *  Shows a save dialog and saves to disk. Unlike openExternal, this
    *  avoids browser rendering of HTML files on Linux.
    *  On non-desktop platforms this property is undefined. */
-  downloadURL: (url: string) => ipcRenderer.invoke("file:download-url", url),
+  downloadURL: (url: string, options?: { authorization?: string }) =>
+    ipcRenderer.invoke("file:download-url", url, options),
   /** Toggle immersive mode — hide macOS traffic lights for full-screen modals */
   setImmersiveMode: (immersive: boolean) =>
     ipcRenderer.invoke("window:setImmersive", immersive),

--- a/packages/views/editor/use-download-attachment.test.tsx
+++ b/packages/views/editor/use-download-attachment.test.tsx
@@ -44,6 +44,7 @@ afterEach(() => {
   vi.restoreAllMocks();
   // Scrub the desktop bridge between tests so suites don't leak state.
   delete (window as unknown as { desktopAPI?: unknown }).desktopAPI;
+  window.localStorage.removeItem("multica_token");
 });
 
 describe("useDownloadAttachment (web)", () => {
@@ -264,6 +265,33 @@ describe("useDownloadAttachment (desktop)", () => {
 
     expect(downloadURL).toHaveBeenCalledWith(
       "https://api.example.test/api/attachments/att-1/download",
+    );
+  });
+
+  it("passes bearer auth for stable API attachment downloads on desktop", async () => {
+    const downloadURL = vi.fn();
+    (window as unknown as { desktopAPI: { downloadURL: typeof downloadURL } }).desktopAPI = {
+      downloadURL,
+    };
+    window.localStorage.setItem("multica_token", "jwt-desktop");
+    getBaseUrlMock.mockReturnValue("https://api.example.test");
+    getAttachmentMock.mockResolvedValueOnce({
+      id: "11111111-2222-3333-4444-555555555555",
+      url: "/uploads/report.html",
+      download_url:
+        "/api/attachments/11111111-2222-3333-4444-555555555555/download",
+      filename: "report.html",
+    });
+
+    const { result } = renderHook(() => useDownloadAttachment());
+
+    await act(async () => {
+      await result.current("11111111-2222-3333-4444-555555555555");
+    });
+
+    expect(downloadURL).toHaveBeenCalledWith(
+      "https://api.example.test/api/attachments/11111111-2222-3333-4444-555555555555/download",
+      { authorization: "Bearer jwt-desktop" },
     );
   });
 

--- a/packages/views/editor/use-download-attachment.ts
+++ b/packages/views/editor/use-download-attachment.ts
@@ -4,11 +4,15 @@ import { useCallback } from "react";
 import { toast } from "sonner";
 import { api } from "@multica/core/api";
 import { useWorkspaceSlug } from "@multica/core/paths";
+import { attachmentIdFromDownloadURL } from "@multica/core/types";
 import { resolvePublicFileUrl } from "@multica/core/workspace/avatar-url";
 import { useT } from "../i18n";
 
 interface DesktopBridge {
-  downloadURL?: (u: string) => Promise<void> | void;
+  downloadURL?: (
+    u: string,
+    options?: { authorization?: string },
+  ) => Promise<void> | void;
 }
 
 function attachmentDownloadEndpoint(
@@ -45,6 +49,13 @@ function hasDesktopDownloadBridge(): boolean {
   if (typeof window === "undefined") return false;
   const bridge = (window as unknown as { desktopAPI?: DesktopBridge }).desktopAPI;
   return Boolean(bridge?.downloadURL);
+}
+
+function desktopAttachmentAuthorization(downloadUrl: string): string | undefined {
+  if (typeof window === "undefined") return undefined;
+  if (!attachmentIdFromDownloadURL(downloadUrl)) return undefined;
+  const token = window.localStorage?.getItem("multica_token");
+  return token ? `Bearer ${token}` : undefined;
 }
 
 /**
@@ -93,7 +104,12 @@ export function useDownloadAttachment(): (attachmentId: string) => Promise<void>
           const bridge = (
             window as unknown as { desktopAPI?: DesktopBridge }
           ).desktopAPI;
-          await bridge!.downloadURL!(downloadUrl);
+          const authorization = desktopAttachmentAuthorization(downloadUrl);
+          if (authorization) {
+            await bridge!.downloadURL!(downloadUrl, { authorization });
+          } else {
+            await bridge!.downloadURL!(downloadUrl);
+          }
         } catch {
           failed();
         }


### PR DESCRIPTION
## What does this PR do?

<!-- multica-auto-bugfix -->

Fixes desktop attachment downloads for stable `/api/attachments/{id}/download` URLs. In desktop token-mode/self-hosted setups, HTML previews load through the authenticated API client, but the Download button uses Electron's native `webContents.downloadURL()` request; that native request did not carry the renderer bearer token, so the authenticated attachment endpoint could reject it and the click appeared to do nothing.

Thinking path: the preview path proved the attachment was readable through the renderer API client; the failing path crossed into Electron main via the desktop download bridge. The fix keeps native streaming/download behavior, passes bearer auth only for exact stable attachment download endpoints, and consumes that pending auth after one request so signed CDN/external URLs are unchanged.

## Related Issue

Closes #3079

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Refactor / code improvement (no behavior change)
- [x] Tests (adding or improving test coverage)
- [ ] Documentation update
- [ ] CI / infrastructure

## Changes Made

- Added optional scoped authorization to the desktop download bridge for stable attachment API download URLs.
- Added a main-process pending-download authorization registry that only accepts HTTP(S) `/api/attachments/{uuid}/download` URLs and consumes auth once.
- Added renderer and desktop unit coverage for the self-hosted desktop download path.

## How to Test

1. `pnpm --filter @multica/views exec vitest run editor/use-download-attachment.test.tsx`
2. `pnpm -C apps/desktop exec vitest run src/main/download-authorization.test.ts`
3. `pnpm -C apps/desktop run typecheck`
4. `pnpm -C apps/desktop exec eslint src/main/download-authorization.ts src/main/download-authorization.test.ts src/main/index.ts src/preload/index.ts src/preload/index.d.ts`
5. `pnpm --filter @multica/views exec eslint editor/use-download-attachment.ts editor/use-download-attachment.test.tsx`
6. `make check-worktree` exited 0, but Docker was not running while it checked PostgreSQL (`Cannot connect to the Docker daemon...`).

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [ ] I have updated relevant documentation to reflect my changes
- [ ] If I added a new runtime / coding tool / UI tab, I synced the change to **landing copy** (`apps/web/features/landing/i18n/`) and **relevant docs** (`apps/docs/content/docs/`)
- [ ] If this PR touches Chinese product copy, I checked it against `apps/docs/content/docs/developers/conventions.zh.mdx` (terminology, mixed-rule for `task` / `issue` / `skill`)
- [x] I have considered and documented any risks above
- [x] I will address all reviewer comments before requesting merge

## AI Disclosure

**AI tool used:** Multica Agent

**Prompt / approach:** Traced the desktop HTML attachment preview/download path, identified the Electron native download request as missing renderer auth for stable API attachment endpoints, implemented a scoped one-shot auth handoff, and verified with focused tests plus desktop typecheck/lint.

## Screenshots (optional)

N/A: no visual UI changes.
