### PR TITLE
refactor(attribution): drop on-behalf badge from execution log rows (MUL-4766)

### DIFF
--- a/packages/views/issues/components/execution-log-section.tsx
+++ b/packages/views/issues/components/execution-log-section.tsx
@@ -18,7 +18,6 @@ import { formatDuration } from "../../agents/components/agent-activity-hover-con
 import { TranscriptButton } from "../../common/task-transcript";
 import { failureReasonLabel } from "../../agents/components/tabs/task-failure";
 import { useT } from "../../i18n";
-import { AttributionBadge } from "./attribution-badge";
 import { TerminateTaskConfirmDialog } from "./terminate-task-confirm-dialog";
 
 // Right-panel section that lists every agent run for this issue. Active
@@ -306,7 +305,6 @@ export function ActiveTaskRow({
   return (
     <RowShell task={task}>
       <TriggerText text={trigger} />
-      <AttributionBadge attribution={task.attribution} className="shrink-0" />
       <TaskCommentCoverage task={task} />
       <RowStatus title={label}>
         {task.status === "running" ? (
@@ -410,7 +408,6 @@ function PastRow({ task, issueId }: { task: AgentTask; issueId: string }) {
   return (
     <RowShell task={task}>
       <TriggerText text={trigger} />
-      <AttributionBadge attribution={task.attribution} className="shrink-0" />
       <TaskCommentCoverage task={task} />
       <RowStatus title={failureLabel ?? label}>
         <TaskStatusIcon status={task.status} />


### PR DESCRIPTION
## What

Remove the `on behalf of <member>` attribution chip from the **Execution log** run rows (both the active and past-run rows), restoring the original, denser layout.

Before this change, every run row rendered an `AttributionBadge` between the trigger text and the comment-coverage indicator, which added visual noise to what is meant to be a compact run list.

## Why

Per MUL-4766: the on-behalf attribution doesn't need to live on the execution-log row. It stays discoverable where it makes sense:

- The **task transcript** header (`agent-transcript-dialog.tsx`) still shows it.
- The **agent detail page → recent work** list (`activity-tab.tsx`) still shows it.

## Scope

Minimal, UI-only. Only three lines removed from `execution-log-section.tsx`:

- the `AttributionBadge` import
- the badge usage in the active-run row
- the badge usage in the past-run row

The `AttributionBadge` component and the underlying attribution data model are untouched.

## Verification

- `pnpm --filter @multica/views typecheck` — clean
- `vitest run execution-log-section.test.tsx attribution-badge.test.tsx` — 22 passed
- `eslint execution-log-section.tsx` — clean
