### PR TITLE
fix(attribution): align run avatar spacing in Activity rows (MUL-4767)

### DIFF
--- a/packages/views/agents/components/tabs/activity-tab.tsx
+++ b/packages/views/agents/components/tabs/activity-tab.tsx
@@ -641,13 +641,20 @@ function TaskRow({
             </>
           )}
           {/* Accountable member (MUL-4302 §9): whose behalf this run is on.
-              Avatar-only keeps the meta line tight; renders nothing when the
-              run has no resolved responsible member. */}
-          <AttributionBadge
-            attribution={task.attribution}
-            variant="avatar"
-            className="ml-0.5"
-          />
+              A leading separator keeps the avatar on the same middot rhythm as
+              the rest of the meta line instead of glued to the duration. The
+              guard mirrors the badge's own render condition (avatar-only needs
+              an initiator) so no dangling separator is left for an
+              unattributed run. */}
+          {task.attribution?.initiator && (
+            <>
+              <Sep />
+              <AttributionBadge
+                attribution={task.attribution}
+                variant="avatar"
+              />
+            </>
+          )}
         </div>
       </div>
 


### PR DESCRIPTION
## Summary

Fixes the odd spacing of the accountable-member ("负责人") avatar in the agent **Activity → Recent work** rows.

The meta line under each run (`Succeeded · 1m ago · 4m 27s`) is a middot-delimited list, but the on-behalf avatar was appended with only a 2px nudge (`ml-0.5`) and **no separator** — so it read as glued to the duration text while every other item is spaced by a `·` separator, making the spacing look inconsistent.

## Change

- Prepend the same `<Sep />` separator (already used for duration / failure) before the avatar, so it shares the exact middot rhythm of the rest of the meta line.
- Gate both the separator and the avatar on `task.attribution?.initiator` — the same condition the avatar badge renders on — so an unattributed run leaves no dangling trailing separator.
- Drop the now-redundant `ml-0.5`; spacing comes from the shared separator + flex gap.

One file: `packages/views/agents/components/tabs/activity-tab.tsx`. Purely visual — *what* renders is unchanged; only the avatar's spacing is now consistent.

## Verification

- `pnpm --filter @multica/views typecheck` ✅
- `eslint` on the changed file ✅
- `pnpm --filter @multica/views vitest run activity-tab` ✅ (8 passed)

MUL-4767
