### PR TITLE
fix(views): stop showing backfilled attribution as a warning (MUL-4768)

### DIFF
--- a/packages/views/issues/components/attribution-badge.test.tsx
+++ b/packages/views/issues/components/attribution-badge.test.tsx
@@ -52,9 +52,9 @@ describe("AttributionBadge", () => {
   });
 
   it("shows a backfilled attribution in the normal tone, not a warning (MUL-4768)", () => {
-    // Backfill is non-precise for the coverage metric, but it names a human the
-    // same waterfall resolved — just after the fact — so it must read like any
-    // other confident attribution rather than a yellow warning.
+    // Backfill is non-precise for the coverage metric — a historical, after-the-
+    // fact record — but that does not make the displayed name wrong, so it must
+    // read like any other resolved attribution rather than a yellow warning.
     const attribution: TaskAttribution = {
       source: "backfill",
       precise: false,

--- a/packages/views/issues/components/attribution-badge.test.tsx
+++ b/packages/views/issues/components/attribution-badge.test.tsx
@@ -35,7 +35,7 @@ describe("AttributionBadge", () => {
     expect(screen.getByTitle("Direct member action")).toBeInTheDocument();
   });
 
-  it("marks degraded (non-precise) attribution with a warning tone", () => {
+  it("marks a fallback guess (owner_fallback) with a warning tone", () => {
     const attribution: TaskAttribution = {
       source: "owner_fallback",
       precise: false,
@@ -49,6 +49,40 @@ describe("AttributionBadge", () => {
     expect(container.querySelector(".text-warning")).not.toBeNull();
     expect(screen.getByTitle("No precise owner — attributed to the agent owner"))
       .toBeInTheDocument();
+  });
+
+  it("shows a backfilled attribution in the normal tone, not a warning (MUL-4768)", () => {
+    // Backfill is non-precise for the coverage metric, but it names a human the
+    // same waterfall resolved — just after the fact — so it must read like any
+    // other confident attribution rather than a yellow warning.
+    const attribution: TaskAttribution = {
+      source: "backfill",
+      precise: false,
+      initiator: { id: "u5", name: "Bohan" },
+    };
+    const { container } = renderWithI18n(
+      <AttributionBadge attribution={attribution} />,
+    );
+
+    expect(screen.getByText("on behalf of Bohan")).toBeInTheDocument();
+    // No warning tone — the confusing yellow that flagged backfilled runs is gone.
+    expect(container.querySelector(".text-warning")).toBeNull();
+    expect(container.querySelector(".text-muted-foreground")).not.toBeNull();
+    // The "backfilled" nuance still lives in the tooltip for anyone who looks.
+    expect(screen.getByTitle("Backfilled attribution")).toBeInTheDocument();
+  });
+
+  it("avatar variant shows no warning ring for a backfilled attribution (MUL-4768)", () => {
+    const attribution: TaskAttribution = {
+      source: "backfill",
+      precise: false,
+      initiator: { id: "u5", name: "Bohan" },
+    };
+    const { container } = renderWithI18n(
+      <AttributionBadge attribution={attribution} variant="avatar" />,
+    );
+
+    expect(container.querySelector(".ring-warning\\/60")).toBeNull();
   });
 
   it("falls back to a generic name when the initiator has no display name", () => {

--- a/packages/views/issues/components/attribution-badge.tsx
+++ b/packages/views/issues/components/attribution-badge.tsx
@@ -23,8 +23,11 @@ function initialsOf(name: string): string {
 
 /**
  * AttributionBadge renders who an agent run is accountable to (MUL-4302 §9):
- * the "on behalf of <member>" provenance, with the resolution source and a
- * distinct warning tone for degraded (non-precise) attribution.
+ * the "on behalf of <member>" provenance, with the resolution source in a
+ * tooltip and a cautionary tone ONLY when the named human is a fallback guess
+ * (owner_fallback) rather than a confidently resolved one. A backfilled
+ * attribution is confident (resolved after the fact by the same waterfall), so
+ * it reads like any other attribution instead of a warning (MUL-4768).
  *
  * Two shapes, both silent when no responsible member resolved (MUL-4765):
  *  - `variant="badge"` (default): the full "on behalf of <name>" chip. Renders
@@ -82,9 +85,20 @@ export function AttributionBadge({
       sourceLabel = attribution.source;
   }
 
-  // Degraded attribution (owner_fallback / backfill / unattributed) is marked
-  // distinctly so it never reads as a compliance-grade "who is responsible".
-  const degraded = attribution.precise === false;
+  // The backend's `precise` flag is an attribution-*coverage* health bit:
+  // owner_fallback, backfill, and unattributed all fail it. But coverage is an
+  // ops metric, not a reader-facing signal. The only thing a viewer of "on
+  // behalf of <name>" cares about is whether that named human might NOT actually
+  // be who's responsible — true only for a fallback guess (owner_fallback:
+  // nothing resolved, so we defaulted to the agent owner). A backfilled
+  // attribution names a human the same waterfall resolved, just after the fact,
+  // so it is confident and must read like any other attribution, never as a
+  // warning (MUL-4768). The cautionary tone therefore fires for any non-precise
+  // source EXCEPT backfill; keeping the `precise === false` base means a future
+  // unknown degraded source still warns (fail-safe) instead of silently reading
+  // as confident.
+  const uncertain =
+    attribution.precise === false && attribution.source !== "backfill";
   const initiator = attribution.initiator;
 
   // Avatar-only shape: just the accountable member's face, with the name +
@@ -99,9 +113,9 @@ export function AttributionBadge({
             <span
               className={cn(
                 "inline-flex shrink-0",
-                // A subtle ring flags degraded attribution so an owner-fallback
-                // face never silently reads as a precise responsible member.
-                degraded && "rounded-full ring-1 ring-warning/60",
+                // A subtle ring flags a fallback guess so an owner-fallback face
+                // never silently reads as a confidently resolved responsible member.
+                uncertain && "rounded-full ring-1 ring-warning/60",
                 className
               )}
             >
@@ -122,7 +136,7 @@ export function AttributionBadge({
             <span
               className={cn(
                 "text-[11px]",
-                degraded ? "text-warning" : "text-muted-foreground"
+                uncertain ? "text-warning" : "text-muted-foreground"
               )}
             >
               {sourceLabel}
@@ -145,7 +159,7 @@ export function AttributionBadge({
       variant="outline"
       className={cn(
         "max-w-40 min-w-0 gap-1 font-normal",
-        degraded ? "text-warning" : "text-muted-foreground",
+        uncertain ? "text-warning" : "text-muted-foreground",
         className
       )}
       title={sourceLabel}

--- a/packages/views/issues/components/attribution-badge.tsx
+++ b/packages/views/issues/components/attribution-badge.tsx
@@ -24,10 +24,12 @@ function initialsOf(name: string): string {
 /**
  * AttributionBadge renders who an agent run is accountable to (MUL-4302 §9):
  * the "on behalf of <member>" provenance, with the resolution source in a
- * tooltip and a cautionary tone ONLY when the named human is a fallback guess
- * (owner_fallback) rather than a confidently resolved one. A backfilled
- * attribution is confident (resolved after the fact by the same waterfall), so
- * it reads like any other attribution instead of a warning (MUL-4768).
+ * tooltip and a cautionary tone ONLY when the named human may not be the real
+ * responsible person — a fallback guess (owner_fallback). A backfilled
+ * attribution is a historical, after-the-fact record (non-realtime, not
+ * compliance-grade), but that does not make the displayed name wrong, so it
+ * earns no warning tone; its historical origin still shows in the tooltip and
+ * the raw `source` field (MUL-4768).
  *
  * Two shapes, both silent when no responsible member resolved (MUL-4765):
  *  - `variant="badge"` (default): the full "on behalf of <name>" chip. Renders
@@ -90,13 +92,14 @@ export function AttributionBadge({
   // ops metric, not a reader-facing signal. The only thing a viewer of "on
   // behalf of <name>" cares about is whether that named human might NOT actually
   // be who's responsible — true only for a fallback guess (owner_fallback:
-  // nothing resolved, so we defaulted to the agent owner). A backfilled
-  // attribution names a human the same waterfall resolved, just after the fact,
-  // so it is confident and must read like any other attribution, never as a
-  // warning (MUL-4768). The cautionary tone therefore fires for any non-precise
-  // source EXCEPT backfill; keeping the `precise === false` base means a future
-  // unknown degraded source still warns (fail-safe) instead of silently reading
-  // as confident.
+  // nothing resolved, so we defaulted to the agent owner). Backfill is a
+  // historical, after-the-fact record (non-realtime, not compliance-grade), but
+  // that does not make the displayed name wrong — so it warrants no warning tone;
+  // its historical origin stays visible in the tooltip and the raw `source` field
+  // (MUL-4768). The cautionary tone therefore fires for any non-precise source
+  // EXCEPT backfill; keeping the `precise === false` base means a future unknown
+  // degraded source still warns (fail-safe) instead of silently reading as
+  // confident.
   const uncertain =
     attribution.precise === false && attribution.source !== "backfill";
   const initiator = attribution.initiator;


### PR DESCRIPTION
## Summary

Fixes MUL-4768: on the transcript (and agent activity) pages, the "on behalf of `<name>`" attribution chip was inconsistently colored — some rendered in the normal muted tone, others in a yellow warning tone — with no explanation, which read like an error to users.

### Root cause

`AttributionBadge` colored the chip yellow (`text-warning`) whenever `attribution.precise === false`. That `precise` bit is the backend's attribution-**coverage** health metric (`Source.Precise()` returns `false` for `owner_fallback`, `backfill`, and `unattributed`). Reusing an internal ops/coverage metric as a user-facing warning tone is the flaw:

- `owner_fallback` — nothing resolved a human, so we defaulted to the agent owner. The named human genuinely *might not* be who's responsible. A cautionary tone here is meaningful.
- `backfill` — a historical run attributed after the fact (non-realtime, not compliance-grade). Failing the coverage metric does **not** mean the displayed name is wrong, so coloring it yellow wrongly signals "this person may not be responsible" and made a correct "on behalf of Bohan" look like a problem. Its historical origin is a detail for the tooltip, not an alarm color.
- `unattributed` — has no `initiator`, so the badge already renders nothing.

So the two sources that produced a visible yellow name (`owner_fallback` and `backfill`) mean very different things, and the confusing case is `backfill`.

### Fix

The cautionary tone now fires only when the named human might genuinely not be responsible — a fallback guess — i.e. any non-precise source **except** `backfill`:

```ts
const uncertain = attribution.precise === false && attribution.source !== "backfill";
```

- Backfilled attributions now render in the normal tone. No information is lost: the historical origin still surfaces in the hover tooltip and the raw `source` field.
- `owner_fallback` keeps its warning tone, where it's actually informative.
- Keeping the `precise === false` base means any *future* unknown degraded source still warns (fail-safe) rather than silently reading as confident.

This is a single UI-layer change in `AttributionBadge`; both call sites (transcript header badge and activity-tab avatar ring) share it, so both are fixed. No backend or wire-format change.

## Testing

- `pnpm --filter @multica/views exec vitest run issues/components/attribution-badge.test.tsx` — 10 passed (added 2: backfill → normal tone on the badge, no warning ring on the avatar variant; kept the existing owner_fallback → warning assertion).
- `pnpm --filter @multica/views typecheck` — passes.
- `eslint` on both changed files — clean.
