### PR TITLE
MUL-4775: fix(daemon): negotiate websocket RPC support

### DIFF
--- a/server/internal/daemon/daemon.go
+++ b/server/internal/daemon/daemon.go
@@ -213,11 +213,6 @@ type Daemon struct {
 	// detached, callers fall back to HTTP.
 	wsRPC *wsRPCClient
 
-	// wsRPCSupported is set after a heartbeat acknowledgement explicitly
-	// advertises rpc-v1. Older servers ignore unknown WS request types, so WS
-	// claims must stay opt-in; HTTP negotiates batch-vs-legacy compatibility.
-	wsRPCSupported atomic.Bool
-
 	// batchClaimUnsupported is set once a batch claim gets a 404 from the
 	// server (no /api/daemon/tasks/claim route — an un-upgraded server), so
 	// subsequent polls skip WS+batch and use the legacy per-runtime claim

--- a/server/internal/daemon/daemon.go
+++ b/server/internal/daemon/daemon.go
@@ -213,6 +213,11 @@ type Daemon struct {
 	// detached, callers fall back to HTTP.
 	wsRPC *wsRPCClient
 
+	// wsRPCSupported is set after a heartbeat acknowledgement explicitly
+	// advertises rpc-v1. Older servers ignore unknown WS request types, so WS
+	// claims must stay opt-in; HTTP negotiates batch-vs-legacy compatibility.
+	wsRPCSupported atomic.Bool
+
 	// batchClaimUnsupported is set once a batch claim gets a 404 from the
 	// server (no /api/daemon/tasks/claim route — an un-upgraded server), so
 	// subsequent polls skip WS+batch and use the legacy per-runtime claim

--- a/server/internal/daemon/daemon_legacy_fallback_test.go
+++ b/server/internal/daemon/daemon_legacy_fallback_test.go
@@ -90,18 +90,18 @@ func TestClaimTasksWSFirst_NoDoubleClaimOnDetach(t *testing.T) {
 	defer srv.Close()
 
 	d := New(Config{ServerBaseURL: srv.URL, MaxConcurrentTasks: 4}, slog.New(slog.NewTextHandler(noopWriter{}, nil)))
-	d.wsRPCSupported.Store(true)
 	// Sender enqueues the frame and hands back its cancelable handle; we then
 	// mark it written to simulate the writer having put it on the wire, so the
 	// disconnect leaves a genuinely uncertain outcome (the server may commit).
 	var mu sync.Mutex
 	var item *wsOutbound
-	d.wsRPC.attach(func(frame []byte) (*wsOutbound, error) {
+	generation := d.wsRPC.attach(func(frame []byte) (*wsOutbound, error) {
 		mu.Lock()
 		defer mu.Unlock()
 		item = &wsOutbound{data: frame}
 		return item, nil
 	})
+	d.wsRPC.markRPCV1Supported(generation)
 
 	done := make(chan struct{})
 	var tasks []*Task
@@ -133,10 +133,12 @@ func TestClaimTasksWSFirst_NoDoubleClaimOnDetach(t *testing.T) {
 	}
 }
 
-// TestClaimTasksWSFirst_OldServerSkipsWSRPC pins compatibility with servers
-// predating rpc-v1. They ignore unknown WS frames, so the daemon must not send
-// tasks.claim until a heartbeat ack explicitly advertises server support.
-func TestClaimTasksWSFirst_OldServerSkipsWSRPC(t *testing.T) {
+// TestClaimTasksWSFirst_ReconnectToOldServerSkipsWSRPC pins compatibility when
+// a daemon moves from an rpc-v1 server to an older server. The replacement
+// connection must not inherit the first connection's negotiated capability;
+// old servers ignore unknown WS frames, so claims must use HTTP until a fresh
+// heartbeat ack explicitly advertises server support.
+func TestClaimTasksWSFirst_ReconnectToOldServerSkipsWSRPC(t *testing.T) {
 	var httpClaims, wsClaims atomic.Int64
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if strings.Contains(r.URL.Path, "/claim") {
@@ -148,6 +150,10 @@ func TestClaimTasksWSFirst_OldServerSkipsWSRPC(t *testing.T) {
 	defer srv.Close()
 
 	d := New(Config{ServerBaseURL: srv.URL, MaxConcurrentTasks: 4}, slog.New(slog.NewTextHandler(noopWriter{}, nil)))
+	previousGeneration := d.wsRPC.attach(func(frame []byte) (*wsOutbound, error) {
+		return &wsOutbound{data: frame}, nil
+	})
+	d.wsRPC.markRPCV1Supported(previousGeneration)
 	d.wsRPC.attach(func(frame []byte) (*wsOutbound, error) {
 		wsClaims.Add(1)
 		return &wsOutbound{data: frame}, nil

--- a/server/internal/daemon/daemon_legacy_fallback_test.go
+++ b/server/internal/daemon/daemon_legacy_fallback_test.go
@@ -90,6 +90,7 @@ func TestClaimTasksWSFirst_NoDoubleClaimOnDetach(t *testing.T) {
 	defer srv.Close()
 
 	d := New(Config{ServerBaseURL: srv.URL, MaxConcurrentTasks: 4}, slog.New(slog.NewTextHandler(noopWriter{}, nil)))
+	d.wsRPCSupported.Store(true)
 	// Sender enqueues the frame and hands back its cancelable handle; we then
 	// mark it written to simulate the writer having put it on the wire, so the
 	// disconnect leaves a genuinely uncertain outcome (the server may commit).
@@ -129,5 +130,40 @@ func TestClaimTasksWSFirst_NoDoubleClaimOnDetach(t *testing.T) {
 	}
 	if httpClaims.Load() != 0 {
 		t.Fatalf("HTTP fallback claimed %d times after an uncertain WS claim; must be 0 to avoid double-claim", httpClaims.Load())
+	}
+}
+
+// TestClaimTasksWSFirst_OldServerSkipsWSRPC pins compatibility with servers
+// predating rpc-v1. They ignore unknown WS frames, so the daemon must not send
+// tasks.claim until a heartbeat ack explicitly advertises server support.
+func TestClaimTasksWSFirst_OldServerSkipsWSRPC(t *testing.T) {
+	var httpClaims, wsClaims atomic.Int64
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.Contains(r.URL.Path, "/claim") {
+			httpClaims.Add(1)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(`{"tasks":[{"id":"http-t","runtime_id":"rt1","agent":{"name":"a"}}]}`))
+	}))
+	defer srv.Close()
+
+	d := New(Config{ServerBaseURL: srv.URL, MaxConcurrentTasks: 4}, slog.New(slog.NewTextHandler(noopWriter{}, nil)))
+	d.wsRPC.attach(func(frame []byte) (*wsOutbound, error) {
+		wsClaims.Add(1)
+		return &wsOutbound{data: frame}, nil
+	})
+
+	tasks, err := d.ClaimTasksWSFirst(context.Background(), "daemon-x", []string{"rt1"}, 1)
+	if err != nil {
+		t.Fatalf("ClaimTasksWSFirst: %v", err)
+	}
+	if len(tasks) != 1 || tasks[0].ID != "http-t" {
+		t.Fatalf("tasks = %#v, want HTTP task", tasks)
+	}
+	if wsClaims.Load() != 0 {
+		t.Fatalf("WS claims = %d without rpc-v1 advertisement, want 0", wsClaims.Load())
+	}
+	if httpClaims.Load() != 1 {
+		t.Fatalf("HTTP claims = %d, want 1", httpClaims.Load())
 	}
 }

--- a/server/internal/daemon/runtime_gone_test.go
+++ b/server/internal/daemon/runtime_gone_test.go
@@ -313,11 +313,15 @@ func TestHandleWSHeartbeatAck_NormalAckRecordsFreshness(t *testing.T) {
 
 	d := freshDaemon("")
 	d.handleWSHeartbeatAck(context.Background(), &HeartbeatResponse{
-		RuntimeID: "rt-1",
-		Status:    "ok",
+		RuntimeID:          "rt-1",
+		Status:             "ok",
+		ServerCapabilities: []string{"rpc-v1"},
 	})
 	if !d.wsHeartbeatRecentlyAcked("rt-1") {
 		t.Fatalf("normal ack should record WS freshness for rt-1")
+	}
+	if !d.wsRPCSupported.Load() {
+		t.Fatal("rpc-v1 heartbeat acknowledgement should enable WS RPC")
 	}
 }
 

--- a/server/internal/daemon/runtime_gone_test.go
+++ b/server/internal/daemon/runtime_gone_test.go
@@ -312,15 +312,19 @@ func TestHandleWSHeartbeatAck_NormalAckRecordsFreshness(t *testing.T) {
 	t.Parallel()
 
 	d := freshDaemon("")
-	d.handleWSHeartbeatAck(context.Background(), &HeartbeatResponse{
+	d.wsRPC = newWSRPCClient(wsRPCResponseGrace)
+	generation := d.wsRPC.attach(func(frame []byte) (*wsOutbound, error) {
+		return &wsOutbound{data: frame}, nil
+	})
+	d.handleWSHeartbeatAckForConnection(context.Background(), &HeartbeatResponse{
 		RuntimeID:          "rt-1",
 		Status:             "ok",
 		ServerCapabilities: []string{"rpc-v1"},
-	})
+	}, generation)
 	if !d.wsHeartbeatRecentlyAcked("rt-1") {
 		t.Fatalf("normal ack should record WS freshness for rt-1")
 	}
-	if !d.wsRPCSupported.Load() {
+	if !d.wsRPC.supportsRPCV1() {
 		t.Fatal("rpc-v1 heartbeat acknowledgement should enable WS RPC")
 	}
 }

--- a/server/internal/daemon/wakeup.go
+++ b/server/internal/daemon/wakeup.go
@@ -154,7 +154,7 @@ func (d *Daemon) runTaskWakeupConnection(ctx context.Context, runtimeIDs []strin
 	// close(writes), and the sender holds sendMu across its non-blocking send.
 	var sendMu sync.Mutex
 	sendClosed := false
-	d.wsRPC.attach(func(frame []byte) (*wsOutbound, error) {
+	wsRPCGeneration := d.wsRPC.attach(func(frame []byte) (*wsOutbound, error) {
 		sendMu.Lock()
 		defer sendMu.Unlock()
 		if sendClosed {
@@ -171,9 +171,6 @@ func (d *Daemon) runTaskWakeupConnection(ctx context.Context, runtimeIDs []strin
 	// A (re)connect may be a freshly-upgraded server: re-probe the batch claim
 	// route rather than staying on the legacy fallback forever (MUL-4257).
 	d.batchClaimUnsupported.Store(false)
-	// Capabilities belong to this specific connection. Require a fresh
-	// heartbeat acknowledgement before sending RPCs after every reconnect.
-	d.wsRPCSupported.Store(false)
 
 	heartbeatCtx, cancelHeartbeat := context.WithCancel(ctx)
 	hbDone := make(chan struct{})
@@ -184,7 +181,7 @@ func (d *Daemon) runTaskWakeupConnection(ctx context.Context, runtimeIDs []strin
 
 	errCh := make(chan error, 1)
 	go func() {
-		errCh <- d.readTaskWakeupMessages(conn, taskWakeups)
+		errCh <- d.readTaskWakeupMessagesForConnection(conn, taskWakeups, wsRPCGeneration)
 	}()
 
 	// Defer cleanup must shut goroutines down in this order:
@@ -325,6 +322,10 @@ func marshalRaw(v any) json.RawMessage {
 // handleRuntimeGone uses the daemon root context for its register call, so
 // this function can safely pass any caller context here.
 func (d *Daemon) handleWSHeartbeatAck(ctx context.Context, ack *HeartbeatResponse) {
+	d.handleWSHeartbeatAckForConnection(ctx, ack, d.wsRPC.currentGeneration())
+}
+
+func (d *Daemon) handleWSHeartbeatAckForConnection(ctx context.Context, ack *HeartbeatResponse, wsRPCGeneration uint64) {
 	if ack == nil || ack.RuntimeID == "" {
 		return
 	}
@@ -334,7 +335,7 @@ func (d *Daemon) handleWSHeartbeatAck(ctx context.Context, ack *HeartbeatRespons
 	}
 	for _, capability := range ack.ServerCapabilities {
 		if capability == protocol.DaemonCapabilityRPCV1 {
-			d.wsRPCSupported.Store(true)
+			d.wsRPC.markRPCV1Supported(wsRPCGeneration)
 			break
 		}
 	}
@@ -343,6 +344,10 @@ func (d *Daemon) handleWSHeartbeatAck(ctx context.Context, ack *HeartbeatRespons
 }
 
 func (d *Daemon) readTaskWakeupMessages(conn *websocket.Conn, taskWakeups chan<- taskWakeup) error {
+	return d.readTaskWakeupMessagesForConnection(conn, taskWakeups, d.wsRPC.currentGeneration())
+}
+
+func (d *Daemon) readTaskWakeupMessagesForConnection(conn *websocket.Conn, taskWakeups chan<- taskWakeup, wsRPCGeneration uint64) error {
 	d.configureTaskWakeupReadLiveness(conn)
 	for {
 		_, raw, err := conn.ReadMessage()
@@ -391,7 +396,7 @@ func (d *Daemon) readTaskWakeupMessages(conn *websocket.Conn, taskWakeups chan<-
 				d.logger.Debug("ws heartbeat ack invalid payload", "error", err)
 				continue
 			}
-			d.handleWSHeartbeatAck(context.Background(), &ack)
+			d.handleWSHeartbeatAckForConnection(context.Background(), &ack, wsRPCGeneration)
 		case protocol.EventDaemonRPCResponse:
 			var resp protocol.RPCResponsePayload
 			if err := json.Unmarshal(msg.Payload, &resp); err != nil {

--- a/server/internal/daemon/wakeup.go
+++ b/server/internal/daemon/wakeup.go
@@ -171,6 +171,9 @@ func (d *Daemon) runTaskWakeupConnection(ctx context.Context, runtimeIDs []strin
 	// A (re)connect may be a freshly-upgraded server: re-probe the batch claim
 	// route rather than staying on the legacy fallback forever (MUL-4257).
 	d.batchClaimUnsupported.Store(false)
+	// Capabilities belong to this specific connection. Require a fresh
+	// heartbeat acknowledgement before sending RPCs after every reconnect.
+	d.wsRPCSupported.Store(false)
 
 	heartbeatCtx, cancelHeartbeat := context.WithCancel(ctx)
 	hbDone := make(chan struct{})
@@ -328,6 +331,12 @@ func (d *Daemon) handleWSHeartbeatAck(ctx context.Context, ack *HeartbeatRespons
 	if ack.RuntimeGone {
 		go d.handleRuntimeGone(ack.RuntimeID)
 		return
+	}
+	for _, capability := range ack.ServerCapabilities {
+		if capability == protocol.DaemonCapabilityRPCV1 {
+			d.wsRPCSupported.Store(true)
+			break
+		}
 	}
 	d.recordWSHeartbeatAck(ack.RuntimeID)
 	d.handleHeartbeatActions(ctx, ack.RuntimeID, ack)

--- a/server/internal/daemon/wsrpc.go
+++ b/server/internal/daemon/wsrpc.go
@@ -83,6 +83,11 @@ type wsRPCClient struct {
 	mu        sync.Mutex
 	pending   map[string]chan protocol.RPCResponsePayload
 	sendFrame func([]byte) (*wsOutbound, error)
+	// rpcV1Supported belongs to the currently attached connection. attach
+	// clears it before exposing a replacement sender so a claim that races a
+	// reconnect can never carry negotiation state across connections.
+	rpcV1Supported bool
+	generation     uint64
 	// grace is added to a call's server-side timeout budget to get how long the
 	// daemon waits for the response, so a claim that committed just before the
 	// server deadline still reports back before the daemon gives up (MUL-4257).
@@ -96,29 +101,59 @@ func newWSRPCClient(grace time.Duration) *wsRPCClient {
 	}
 }
 
-// attach binds a live connection's frame writer. Passing nil detaches (on
-// disconnect), after which Call fails fast until the next attach. Any pending
-// requests are failed so their callers fall back to HTTP immediately.
-func (c *wsRPCClient) attach(sendFrame func([]byte) (*wsOutbound, error)) {
+// attach binds a live connection's frame writer and clears the previous
+// connection's negotiated capability. Passing nil detaches (on disconnect),
+// after which Call fails fast until the next attach and rpc-v1 heartbeat ack.
+// Any pending requests are failed so their callers fall back to HTTP
+// immediately.
+func (c *wsRPCClient) attach(sendFrame func([]byte) (*wsOutbound, error)) uint64 {
 	c.mu.Lock()
+	c.generation++
+	c.rpcV1Supported = false
 	c.sendFrame = sendFrame
-	if sendFrame == nil {
-		for id, ch := range c.pending {
-			close(ch)
-			delete(c.pending, id)
-		}
+	for id, ch := range c.pending {
+		close(ch)
+		delete(c.pending, id)
+	}
+	generation := c.generation
+	c.mu.Unlock()
+	return generation
+}
+
+// markRPCV1Supported records explicit server support for the currently
+// attached connection. Heartbeat acks received without a live sender cannot
+// enable a future connection.
+func (c *wsRPCClient) markRPCV1Supported(generation uint64) {
+	if c == nil {
+		return
+	}
+	c.mu.Lock()
+	if c.sendFrame != nil && c.generation == generation {
+		c.rpcV1Supported = true
 	}
 	c.mu.Unlock()
 }
 
-// connected reports whether a live connection is attached.
-func (c *wsRPCClient) connected() bool {
+func (c *wsRPCClient) currentGeneration() uint64 {
+	if c == nil {
+		return 0
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.generation
+}
+
+// supportsRPCV1 reports whether the live connection explicitly negotiated
+// rpc-v1. Call repeats this check while capturing the sender under the same
+// mutex, so this method is only a fast-path hint and cannot authorize a send by
+// itself.
+func (c *wsRPCClient) supportsRPCV1() bool {
 	if c == nil {
 		return false
 	}
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	return c.sendFrame != nil
+	return c.sendFrame != nil && c.rpcV1Supported
 }
 
 // Call issues an RPC and blocks until the response, the per-request timeout, or
@@ -155,7 +190,7 @@ func (c *wsRPCClient) Call(ctx context.Context, method string, serverTimeout tim
 
 	ch := make(chan protocol.RPCResponsePayload, 1)
 	c.mu.Lock()
-	if c.sendFrame == nil {
+	if c.sendFrame == nil || !c.rpcV1Supported {
 		c.mu.Unlock()
 		return 0, errWSRPCUnavailable
 	}
@@ -266,7 +301,7 @@ func (d *Daemon) ClaimTasksWSFirst(ctx context.Context, daemonID string, runtime
 	if d.batchClaimUnsupported.Load() {
 		return d.client.claimTasksLegacy(ctx, runtimeIDs, maxTasks)
 	}
-	if d.wsRPCSupported.Load() && d.wsRPC.connected() {
+	if d.wsRPC.supportsRPCV1() {
 		var resp struct {
 			Tasks []*Task `json:"tasks"`
 		}

--- a/server/internal/daemon/wsrpc.go
+++ b/server/internal/daemon/wsrpc.go
@@ -266,7 +266,7 @@ func (d *Daemon) ClaimTasksWSFirst(ctx context.Context, daemonID string, runtime
 	if d.batchClaimUnsupported.Load() {
 		return d.client.claimTasksLegacy(ctx, runtimeIDs, maxTasks)
 	}
-	if d.wsRPC.connected() {
+	if d.wsRPCSupported.Load() && d.wsRPC.connected() {
 		var resp struct {
 			Tasks []*Task `json:"tasks"`
 		}

--- a/server/internal/daemon/wsrpc.go
+++ b/server/internal/daemon/wsrpc.go
@@ -156,13 +156,27 @@ func (c *wsRPCClient) supportsRPCV1() bool {
 	return c.sendFrame != nil && c.rpcV1Supported
 }
 
-// Call issues an RPC and blocks until the response, the per-request timeout, or
-// ctx cancellation. reqBody is marshaled into the request envelope; on a 2xx
+// Call issues an RPC on any attached connection. Transport-level tests and
+// callers that have their own negotiation contract use this directly.
+func (c *wsRPCClient) Call(ctx context.Context, method string, serverTimeout time.Duration, reqBody, respBody any) (int, error) {
+	return c.call(ctx, method, serverTimeout, reqBody, respBody, false)
+}
+
+// CallIfRPCV1Supported issues an RPC only when the currently attached
+// connection explicitly negotiated rpc-v1. The capability check and sender
+// capture happen under the same mutex, so a reconnect cannot redirect a call
+// authorized by the previous connection onto its replacement.
+func (c *wsRPCClient) CallIfRPCV1Supported(ctx context.Context, method string, serverTimeout time.Duration, reqBody, respBody any) (int, error) {
+	return c.call(ctx, method, serverTimeout, reqBody, respBody, true)
+}
+
+// call blocks until the response, the per-request timeout, or ctx
+// cancellation. reqBody is marshaled into the request envelope; on a 2xx
 // response respBody (if non-nil) is unmarshaled from the response body. It
 // returns the response status (0 when the call never reached the server) so the
-// caller can distinguish transport failure (→ HTTP fallback) from a server-side
-// error.
-func (c *wsRPCClient) Call(ctx context.Context, method string, serverTimeout time.Duration, reqBody, respBody any) (int, error) {
+// caller can distinguish transport failure (→ HTTP fallback) from a
+// server-side error.
+func (c *wsRPCClient) call(ctx context.Context, method string, serverTimeout time.Duration, reqBody, respBody any, requireRPCV1 bool) (int, error) {
 	if c == nil {
 		return 0, errWSRPCUnavailable
 	}
@@ -190,7 +204,7 @@ func (c *wsRPCClient) Call(ctx context.Context, method string, serverTimeout tim
 
 	ch := make(chan protocol.RPCResponsePayload, 1)
 	c.mu.Lock()
-	if c.sendFrame == nil || !c.rpcV1Supported {
+	if c.sendFrame == nil || (requireRPCV1 && !c.rpcV1Supported) {
 		c.mu.Unlock()
 		return 0, errWSRPCUnavailable
 	}
@@ -307,7 +321,7 @@ func (d *Daemon) ClaimTasksWSFirst(ctx context.Context, daemonID string, runtime
 		}
 		// batchClaimRequestTimeout is the server-side execution budget; the
 		// daemon waits that plus the client's grace margin for the response.
-		_, err := d.wsRPC.Call(ctx, "tasks.claim", batchClaimRequestTimeout, map[string]any{
+		_, err := d.wsRPC.CallIfRPCV1Supported(ctx, "tasks.claim", batchClaimRequestTimeout, map[string]any{
 			"daemon_id":   daemonID,
 			"runtime_ids": runtimeIDs,
 			"max_tasks":   maxTasks,

--- a/server/internal/daemon/wsrpc_test.go
+++ b/server/internal/daemon/wsrpc_test.go
@@ -17,7 +17,7 @@ func TestWSRPCClient_CallRoundTrip(t *testing.T) {
 	c := newWSRPCClient(time.Second)
 
 	// Fake transport: capture the frame, and reply asynchronously with a 200.
-	c.attach(func(frame []byte) (*wsOutbound, error) {
+	generation := c.attach(func(frame []byte) (*wsOutbound, error) {
 		var msg protocol.Message
 		if err := json.Unmarshal(frame, &msg); err != nil {
 			return nil, err
@@ -36,6 +36,7 @@ func TestWSRPCClient_CallRoundTrip(t *testing.T) {
 		})
 		return &wsOutbound{data: frame}, nil
 	})
+	c.markRPCV1Supported(generation)
 
 	var resp struct {
 		Tasks []struct {
@@ -60,10 +61,45 @@ func TestWSRPCClient_Unavailable(t *testing.T) {
 	}
 }
 
+// TestWSRPCClient_ReattachRequiresFreshNegotiation pins capability state to a
+// specific connection. A replacement sender must remain unavailable until a
+// heartbeat ack from that connection explicitly advertises rpc-v1.
+func TestWSRPCClient_ReattachRequiresFreshNegotiation(t *testing.T) {
+	c := newWSRPCClient(time.Second)
+	firstGeneration := c.attach(func(frame []byte) (*wsOutbound, error) {
+		return &wsOutbound{data: frame}, nil
+	})
+	c.markRPCV1Supported(firstGeneration)
+	if !c.supportsRPCV1() {
+		t.Fatal("first connection should support rpc-v1 after negotiation")
+	}
+
+	newConnectionCalls := 0
+	secondGeneration := c.attach(func(frame []byte) (*wsOutbound, error) {
+		newConnectionCalls++
+		return &wsOutbound{data: frame}, nil
+	})
+	c.markRPCV1Supported(firstGeneration) // delayed ack from the replaced connection
+	if c.supportsRPCV1() {
+		t.Fatal("replacement connection inherited rpc-v1 support from a stale ack")
+	}
+	if _, err := c.Call(context.Background(), "tasks.claim", 0, nil, nil); !errors.Is(err, errWSRPCUnavailable) {
+		t.Fatalf("Call error = %v, want errWSRPCUnavailable before fresh negotiation", err)
+	}
+	if newConnectionCalls != 0 {
+		t.Fatalf("replacement connection received %d RPC calls before negotiation, want 0", newConnectionCalls)
+	}
+	c.markRPCV1Supported(secondGeneration)
+	if !c.supportsRPCV1() {
+		t.Fatal("replacement connection did not accept its own rpc-v1 acknowledgement")
+	}
+}
+
 // TestWSRPCClient_Timeout: no response arrives within the per-request timeout.
 func TestWSRPCClient_Timeout(t *testing.T) {
 	c := newWSRPCClient(50 * time.Millisecond)
-	c.attach(func(frame []byte) (*wsOutbound, error) { return &wsOutbound{data: frame}, nil }) // send succeeds, never replies
+	generation := c.attach(func(frame []byte) (*wsOutbound, error) { return &wsOutbound{data: frame}, nil }) // send succeeds, never replies
+	c.markRPCV1Supported(generation)
 	status, err := c.Call(context.Background(), "tasks.claim", 0, nil, nil)
 	if err == nil || status != 0 {
 		t.Fatalf("status=%d err=%v, want timeout (status 0, err)", status, err)
@@ -74,7 +110,7 @@ func TestWSRPCClient_Timeout(t *testing.T) {
 // server-provided message, and a non-zero status so the caller can classify.
 func TestWSRPCClient_ServerError(t *testing.T) {
 	c := newWSRPCClient(time.Second)
-	c.attach(func(frame []byte) (*wsOutbound, error) {
+	generation := c.attach(func(frame []byte) (*wsOutbound, error) {
 		var msg protocol.Message
 		json.Unmarshal(frame, &msg)
 		var req protocol.RPCRequestPayload
@@ -82,6 +118,7 @@ func TestWSRPCClient_ServerError(t *testing.T) {
 		go c.deliver(protocol.RPCResponsePayload{RequestID: req.RequestID, Status: 400, Error: "bad daemon_id"})
 		return &wsOutbound{data: frame}, nil
 	})
+	c.markRPCV1Supported(generation)
 	status, err := c.Call(context.Background(), "tasks.claim", 0, nil, nil)
 	if status != 400 || err == nil {
 		t.Fatalf("status=%d err=%v, want 400 + error", status, err)
@@ -95,12 +132,13 @@ func TestWSRPCClient_DetachFailsPending(t *testing.T) {
 	c := newWSRPCClient(2 * time.Second)
 	var mu sync.Mutex
 	var item *wsOutbound
-	c.attach(func(frame []byte) (*wsOutbound, error) {
+	generation := c.attach(func(frame []byte) (*wsOutbound, error) {
 		mu.Lock()
 		defer mu.Unlock()
 		item = &wsOutbound{data: frame}
 		return item, nil
 	})
+	c.markRPCV1Supported(generation)
 	done := make(chan error, 1)
 	go func() {
 		_, err := c.Call(context.Background(), "tasks.claim", 0, nil, nil)
@@ -187,12 +225,13 @@ func TestWSRPCClient_TimeoutCancelsUnsentFrame(t *testing.T) {
 	c := newWSRPCClient(20 * time.Millisecond)
 	var mu sync.Mutex
 	var item *wsOutbound
-	c.attach(func(frame []byte) (*wsOutbound, error) {
+	generation := c.attach(func(frame []byte) (*wsOutbound, error) {
 		mu.Lock()
 		defer mu.Unlock()
 		item = &wsOutbound{data: frame}
 		return item, nil // enqueued; no writer ever drains it
 	})
+	c.markRPCV1Supported(generation)
 	status, err := c.Call(context.Background(), "tasks.claim", 30*time.Millisecond, nil, nil)
 	if status != 0 {
 		t.Fatalf("status = %d, want 0", status)
@@ -220,12 +259,13 @@ func TestWSRPCClient_TimeoutUncertainWhenAlreadySent(t *testing.T) {
 	c := newWSRPCClient(30 * time.Millisecond)
 	var mu sync.Mutex
 	var item *wsOutbound
-	c.attach(func(frame []byte) (*wsOutbound, error) {
+	generation := c.attach(func(frame []byte) (*wsOutbound, error) {
 		mu.Lock()
 		defer mu.Unlock()
 		item = &wsOutbound{data: frame}
 		return item, nil
 	})
+	c.markRPCV1Supported(generation)
 	done := make(chan error, 1)
 	go func() {
 		_, err := c.Call(context.Background(), "tasks.claim", 40*time.Millisecond, nil, nil)

--- a/server/internal/daemon/wsrpc_test.go
+++ b/server/internal/daemon/wsrpc_test.go
@@ -17,7 +17,7 @@ func TestWSRPCClient_CallRoundTrip(t *testing.T) {
 	c := newWSRPCClient(time.Second)
 
 	// Fake transport: capture the frame, and reply asynchronously with a 200.
-	generation := c.attach(func(frame []byte) (*wsOutbound, error) {
+	c.attach(func(frame []byte) (*wsOutbound, error) {
 		var msg protocol.Message
 		if err := json.Unmarshal(frame, &msg); err != nil {
 			return nil, err
@@ -36,8 +36,6 @@ func TestWSRPCClient_CallRoundTrip(t *testing.T) {
 		})
 		return &wsOutbound{data: frame}, nil
 	})
-	c.markRPCV1Supported(generation)
-
 	var resp struct {
 		Tasks []struct {
 			ID string `json:"id"`
@@ -83,8 +81,8 @@ func TestWSRPCClient_ReattachRequiresFreshNegotiation(t *testing.T) {
 	if c.supportsRPCV1() {
 		t.Fatal("replacement connection inherited rpc-v1 support from a stale ack")
 	}
-	if _, err := c.Call(context.Background(), "tasks.claim", 0, nil, nil); !errors.Is(err, errWSRPCUnavailable) {
-		t.Fatalf("Call error = %v, want errWSRPCUnavailable before fresh negotiation", err)
+	if _, err := c.CallIfRPCV1Supported(context.Background(), "tasks.claim", 0, nil, nil); !errors.Is(err, errWSRPCUnavailable) {
+		t.Fatalf("CallIfRPCV1Supported error = %v, want errWSRPCUnavailable before fresh negotiation", err)
 	}
 	if newConnectionCalls != 0 {
 		t.Fatalf("replacement connection received %d RPC calls before negotiation, want 0", newConnectionCalls)
@@ -98,8 +96,7 @@ func TestWSRPCClient_ReattachRequiresFreshNegotiation(t *testing.T) {
 // TestWSRPCClient_Timeout: no response arrives within the per-request timeout.
 func TestWSRPCClient_Timeout(t *testing.T) {
 	c := newWSRPCClient(50 * time.Millisecond)
-	generation := c.attach(func(frame []byte) (*wsOutbound, error) { return &wsOutbound{data: frame}, nil }) // send succeeds, never replies
-	c.markRPCV1Supported(generation)
+	c.attach(func(frame []byte) (*wsOutbound, error) { return &wsOutbound{data: frame}, nil }) // send succeeds, never replies
 	status, err := c.Call(context.Background(), "tasks.claim", 0, nil, nil)
 	if err == nil || status != 0 {
 		t.Fatalf("status=%d err=%v, want timeout (status 0, err)", status, err)
@@ -110,7 +107,7 @@ func TestWSRPCClient_Timeout(t *testing.T) {
 // server-provided message, and a non-zero status so the caller can classify.
 func TestWSRPCClient_ServerError(t *testing.T) {
 	c := newWSRPCClient(time.Second)
-	generation := c.attach(func(frame []byte) (*wsOutbound, error) {
+	c.attach(func(frame []byte) (*wsOutbound, error) {
 		var msg protocol.Message
 		json.Unmarshal(frame, &msg)
 		var req protocol.RPCRequestPayload
@@ -118,7 +115,6 @@ func TestWSRPCClient_ServerError(t *testing.T) {
 		go c.deliver(protocol.RPCResponsePayload{RequestID: req.RequestID, Status: 400, Error: "bad daemon_id"})
 		return &wsOutbound{data: frame}, nil
 	})
-	c.markRPCV1Supported(generation)
 	status, err := c.Call(context.Background(), "tasks.claim", 0, nil, nil)
 	if status != 400 || err == nil {
 		t.Fatalf("status=%d err=%v, want 400 + error", status, err)
@@ -132,13 +128,12 @@ func TestWSRPCClient_DetachFailsPending(t *testing.T) {
 	c := newWSRPCClient(2 * time.Second)
 	var mu sync.Mutex
 	var item *wsOutbound
-	generation := c.attach(func(frame []byte) (*wsOutbound, error) {
+	c.attach(func(frame []byte) (*wsOutbound, error) {
 		mu.Lock()
 		defer mu.Unlock()
 		item = &wsOutbound{data: frame}
 		return item, nil
 	})
-	c.markRPCV1Supported(generation)
 	done := make(chan error, 1)
 	go func() {
 		_, err := c.Call(context.Background(), "tasks.claim", 0, nil, nil)
@@ -225,13 +220,12 @@ func TestWSRPCClient_TimeoutCancelsUnsentFrame(t *testing.T) {
 	c := newWSRPCClient(20 * time.Millisecond)
 	var mu sync.Mutex
 	var item *wsOutbound
-	generation := c.attach(func(frame []byte) (*wsOutbound, error) {
+	c.attach(func(frame []byte) (*wsOutbound, error) {
 		mu.Lock()
 		defer mu.Unlock()
 		item = &wsOutbound{data: frame}
 		return item, nil // enqueued; no writer ever drains it
 	})
-	c.markRPCV1Supported(generation)
 	status, err := c.Call(context.Background(), "tasks.claim", 30*time.Millisecond, nil, nil)
 	if status != 0 {
 		t.Fatalf("status = %d, want 0", status)
@@ -259,13 +253,12 @@ func TestWSRPCClient_TimeoutUncertainWhenAlreadySent(t *testing.T) {
 	c := newWSRPCClient(30 * time.Millisecond)
 	var mu sync.Mutex
 	var item *wsOutbound
-	generation := c.attach(func(frame []byte) (*wsOutbound, error) {
+	c.attach(func(frame []byte) (*wsOutbound, error) {
 		mu.Lock()
 		defer mu.Unlock()
 		item = &wsOutbound{data: frame}
 		return item, nil
 	})
-	c.markRPCV1Supported(generation)
 	done := make(chan error, 1)
 	go func() {
 		_, err := c.Call(context.Background(), "tasks.claim", 40*time.Millisecond, nil, nil)

--- a/server/internal/handler/daemon.go
+++ b/server/internal/handler/daemon.go
@@ -1016,9 +1016,10 @@ func (h *Handler) HandleDaemonWSHeartbeat(ctx context.Context, identity daemonws
 	if err != nil {
 		if isNotFound(err) {
 			return &protocol.DaemonHeartbeatAckPayload{
-				RuntimeID:   runtimeID,
-				Status:      protocol.HeartbeatStatusRuntimeGone,
-				RuntimeGone: true,
+				RuntimeID:          runtimeID,
+				Status:             protocol.HeartbeatStatusRuntimeGone,
+				ServerCapabilities: []string{protocol.DaemonCapabilityRPCV1},
+				RuntimeGone:        true,
 			}, nil
 		}
 		return nil, fmt.Errorf("get agent runtime: %w", err)
@@ -1101,8 +1102,9 @@ func (h *Handler) processHeartbeat(ctx context.Context, rt db.AgentRuntime, supp
 	slog.Debug("daemon heartbeat", "runtime_id", runtimeID)
 
 	ack := &protocol.DaemonHeartbeatAckPayload{
-		RuntimeID: runtimeID,
-		Status:    "ok",
+		RuntimeID:          runtimeID,
+		Status:             "ok",
+		ServerCapabilities: []string{protocol.DaemonCapabilityRPCV1},
 	}
 
 	probeUpdateCtx, cancelProbeUpdate := context.WithTimeout(ctx, heartbeatHasPendingTimeout)

--- a/server/internal/handler/daemon.go
+++ b/server/internal/handler/daemon.go
@@ -1016,10 +1016,9 @@ func (h *Handler) HandleDaemonWSHeartbeat(ctx context.Context, identity daemonws
 	if err != nil {
 		if isNotFound(err) {
 			return &protocol.DaemonHeartbeatAckPayload{
-				RuntimeID:          runtimeID,
-				Status:             protocol.HeartbeatStatusRuntimeGone,
-				ServerCapabilities: []string{protocol.DaemonCapabilityRPCV1},
-				RuntimeGone:        true,
+				RuntimeID:   runtimeID,
+				Status:      protocol.HeartbeatStatusRuntimeGone,
+				RuntimeGone: true,
 			}, nil
 		}
 		return nil, fmt.Errorf("get agent runtime: %w", err)

--- a/server/pkg/protocol/messages.go
+++ b/server/pkg/protocol/messages.go
@@ -249,6 +249,8 @@ type DaemonHeartbeatRequestPayload struct {
 
 // DaemonHeartbeatAckPayload is the server's reply to DaemonHeartbeatRequestPayload.
 // JSON shape mirrors the HTTP heartbeat response so daemon code can decode either.
+// ServerCapabilities is explicit server-to-daemon protocol negotiation. A
+// daemon must not infer support from its own advertised client capabilities.
 //
 // RuntimeGone is the WebSocket replacement for the HTTP 404 "runtime not found"
 // response. When the server discovers the runtime row was deleted (UI delete,
@@ -260,6 +262,7 @@ type DaemonHeartbeatRequestPayload struct {
 type DaemonHeartbeatAckPayload struct {
 	RuntimeID               string                                  `json:"runtime_id"`
 	Status                  string                                  `json:"status"`
+	ServerCapabilities      []string                                `json:"server_capabilities,omitempty"`
 	RuntimeGone             bool                                    `json:"runtime_gone,omitempty"`
 	PendingUpdate           *DaemonHeartbeatPendingUpdate           `json:"pending_update,omitempty"`
 	PendingModelList        *DaemonHeartbeatPendingModelList        `json:"pending_model_list,omitempty"`


### PR DESCRIPTION
## Problem

A v0.4.1 daemon unconditionally attempts `tasks.claim` over WebSocket whenever connected. Servers predating rpc-v1 intentionally ignore unknown WebSocket frames. The daemon then times out with an uncertain outcome, skips HTTP fallback to avoid a double claim, and repeats forever. This prevents new daemons from claiming tasks from older self-hosted backends.

## Root cause

Client capability advertisement is one-way. The daemon advertises rpc-v1, but never receives or requires an explicit server capability before using the new transport.

## Fix

- Add `server_capabilities` to heartbeat acknowledgements.
- Advertise rpc-v1 from servers that implement the RPC handler.
- Enable WS claims only after a heartbeat acknowledgement explicitly advertises rpc-v1.
- Bind negotiated support and heartbeat acknowledgements to the exact WS connection generation, so reconnects and delayed acknowledgements cannot leak capability state to a replacement connection.
- Preserve the existing HTTP batch-to-legacy 404 fallback for older servers.

This avoids both the infinite uncertain-outcome loop and unsafe immediate fallback after an ambiguous WS claim.

## Rollout

Deploy the server change before publishing the daemon update. Reversing the order remains safe—the daemon falls back to HTTP—but silently disables WS claims until the server starts advertising rpc-v1.

## Verification

- `go test ./internal/daemon ./internal/handler ./internal/daemonws ./pkg/protocol -count=1`
- Focused race coverage for reconnect negotiation, detach/no-double-claim, and legacy-server HTTP fallback.
- Regression coverage proves a daemon moving from an rpc-v1 server to a pre-rpc-v1 server sends zero WS claim attempts before fresh negotiation and claims successfully over HTTP.

Closes MUL-4775
