### PR TITLE
ARG-251: enforce single-issue human-review workflow

### DIFF
--- a/server/internal/daemon/execenv/runtime_config_kind_test.go
+++ b/server/internal/daemon/execenv/runtime_config_kind_test.go
@@ -36,7 +36,7 @@ func TestClassifyTask(t *testing.T) {
 }
 
 // TestTaskKindHasIssueContext pins the predicate that gates Project
-// Context / Issue Metadata / Sub-issue Creation in the slim dispatcher.
+// Context / Issue Metadata / Single-Issue Execution in the slim dispatcher.
 func TestTaskKindHasIssueContext(t *testing.T) {
 	t.Parallel()
 	cases := []struct {
@@ -113,7 +113,7 @@ func TestBuildMetaSkillContentSlimKindMatrix(t *testing.T) {
 		}},
 		{"## Issue Metadata", issueKinds},
 		{"## Instruction Precedence", map[taskKind]bool{kindAssignmentTriggered: true}},
-		{"## Sub-issue Creation", issueKinds},
+		{"## Single-Issue Execution", issueKinds},
 		{"## Skills", map[taskKind]bool{
 			kindCommentTriggered: true, kindAssignmentTriggered: true,
 			kindAutopilotRunOnly: true, kindChat: true,

--- a/server/internal/daemon/execenv/runtime_config_sections.go
+++ b/server/internal/daemon/execenv/runtime_config_sections.go
@@ -282,6 +282,11 @@ func writeProjectContext(b *strings.Builder, ctx TaskContextForEnv) {
 	}
 }
 
+func writeKnowledgeLayers(b *strings.Builder) {
+	b.WriteString("## Knowledge Layers\n\n")
+	b.WriteString("Use context in this precedence order: (1) the current issue, attachments, and active comment thread; (2) workspace, company, project, and linked resource context; (3) repository instructions, source, tests, documentation, history, and linked pull requests; (4) memory files as non-authoritative hints. Earlier layers override later ones. Verify memory against current issue and repository facts before acting, and surface material conflicts instead of silently choosing stale context.\n\n")
+}
+
 // writeIssueMetadata emits the Issue Metadata discipline section
 // (compressed). The dispatcher gates by kind.hasIssueContext(); this
 // helper does not re-check.
@@ -421,15 +426,14 @@ func writeWorkflowAssignment(b *strings.Builder, ctx TaskContextForEnv) {
 	}
 	b.WriteString("7. Before exiting: only if this run produced a fact that clears the high bar (important AND likely to be re-read by future runs on this same issue, e.g. a new PR URL or deploy URL), or you noticed a metadata key from entry that is now stale, pin or clear it via `multica issue metadata set`/`delete`. Most runs write nothing here — that is the expected outcome, not a gap. When in doubt, do not write. See the `## Issue Metadata` section above for the full bar.\n")
 	fmt.Fprintf(b, "8. When done, run `multica issue status %s in_review` unless your Agent Identity forbids issue status changes; if it does, skip this step.\n", ctx.IssueID)
-	fmt.Fprintf(b, "9. If blocked, run `multica issue status %s blocked` unless your Agent Identity forbids issue status changes. Post a comment explaining the blocker unless your Agent Identity forbids issue comments.\n\n", ctx.IssueID)
+	b.WriteString("9. If work cannot continue, keep the issue `in_progress` and post one concise comment that states what is waiting, why it matters, and the exact human action or resource needed. Agents must never set `blocked`, `done`, or `cancelled`; those states are human-controlled.\n\n")
 }
 
 // writeSubIssueCreation emits the Sub-issue Creation section (compressed
 // to two short paragraphs).
 func writeSubIssueCreation(b *strings.Builder) {
-	b.WriteString("## Sub-issue Creation\n\n")
-	b.WriteString("**Choosing `--status` when creating sub-issues.** `--status todo` = **start now** (default — agent assignees fire immediately). `--status backlog` = **wait**, then promote later with `multica issue status <child-id> todo`. Parallel children: all `--status todo`. Strict serial 1→2→3: only Step 1 `todo`, Steps 2/3 `--status backlog` from the start.\n\n")
-	b.WriteString("**Ordering with stages.** For phased plans, group children with `--stage <N>` (N ≥ 1) instead of hand-promoting the backlog chain — stage members run together, and the parent wakes once per stage. Use `--stage k --status backlog` for later stages, then `multica issue children <id>` to inspect groupings before promoting. Reach for stages whenever a plan has more than one step or a step must wait for a group.\n\n")
+	b.WriteString("## Single-Issue Execution\n\n")
+	b.WriteString("Complete the objective inside the assigned issue. Do not create sub-issues, sibling issues, replacement issues, staged barriers, or coordination cards. If specialist help is useful, use internal agent/tool delegation and summarize the result on this issue; the owner must continue to see one issue for one objective. The server rejects issue creation and hierarchy changes from issue-bound agent runs.\n\n")
 }
 
 // writeSkills emits the Skills section listing skill names + descriptions.
@@ -565,6 +569,7 @@ func buildMetaSkillContentSlim(provider string, ctx TaskContextForEnv) string {
 
 	if kind.hasIssueContext() {
 		writeProjectContext(&b, ctx)
+		writeKnowledgeLayers(&b)
 		writeIssueMetadata(&b)
 	}
 

--- a/server/internal/daemon/execenv/runtime_config_test.go
+++ b/server/internal/daemon/execenv/runtime_config_test.go
@@ -10,15 +10,10 @@ import (
 	"github.com/multica-ai/multica/server/internal/runtimeapps"
 )
 
-// Sub-issue Creation section — after MUL-2538 the platform posts the
-// child-done parent notification itself, so the brief no longer carries
-// any parent-notification rule (per Bohan's call on PR #3055: delete the
-// guidance entirely, do not replace it with a "do not post one" sentence
-// — the agent should not be thinking about parent comments at all). All
-// that remains is the `--status todo` vs `--status backlog` rule for
-// creating sub-issues, which is unrelated to the notification path.
+// Issue-bound agent runs use one visible issue for one objective. The brief
+// must make the no-child-card rule explicit and match the server-side guard.
 
-func TestSubIssueCreationSectionPresentForIssueRuns(t *testing.T) {
+func TestSingleIssueExecutionSectionPresentForIssueRuns(t *testing.T) {
 	t.Parallel()
 	cases := []struct {
 		name string
@@ -42,22 +37,17 @@ func TestSubIssueCreationSectionPresentForIssueRuns(t *testing.T) {
 			t.Parallel()
 			out := buildMetaSkillContent("claude", tc.ctx)
 
-			if !strings.Contains(out, "## Sub-issue Creation") {
-				t.Fatalf("expected Sub-issue Creation section in %s brief", tc.name)
+			if !strings.Contains(out, "## Single-Issue Execution") {
+				t.Fatalf("expected Single-Issue Execution section in %s brief", tc.name)
+			}
+			if !strings.Contains(out, "## Knowledge Layers") || !strings.Contains(out, "memory files as non-authoritative hints") {
+				t.Fatalf("expected knowledge layer precedence in %s brief", tc.name)
 			}
 			for _, want := range []string{
-				"**Choosing `--status` when creating sub-issues.**",
-				"`--status todo` = **start now**",
-				"`--status backlog` = **wait**",
-				"`multica issue status <child-id> todo`",
-				"all `--status todo`",
-				"`--status backlog` from the start",
-				// Stage guidance must reach the always-on brief so agents
-				// reach for stages instead of only the manual backlog chain
-				// (MUL-3508 follow-up).
-				"**Ordering with stages.**",
-				"`--stage <N>`",
-				"`multica issue children <id>`",
+				"Complete the objective inside the assigned issue.",
+				"Do not create sub-issues, sibling issues, replacement issues, staged barriers, or coordination cards.",
+				"one issue for one objective",
+				"The server rejects issue creation and hierarchy changes from issue-bound agent runs.",
 			} {
 				if !strings.Contains(out, want) {
 					t.Errorf("[%s] section missing %q", tc.name, want)
@@ -309,7 +299,8 @@ func TestAssignmentTriggeredProtocolHonorsAgentIdentity(t *testing.T) {
 		"Complete the task within your Agent Identity boundaries.",
 		"Do not investigate, implement, create issues, update issues, or delegate if your Agent Identity forbids that action",
 		"When done, run `multica issue status " + issueID + " in_review` unless your Agent Identity forbids issue status changes; if it does, skip this step.",
-		"If blocked, run `multica issue status " + issueID + " blocked` unless your Agent Identity forbids issue status changes.",
+		"If work cannot continue, keep the issue `in_progress`",
+		"Agents must never set `blocked`, `done`, or `cancelled`; those states are human-controlled.",
 	} {
 		if !strings.Contains(out, want) {
 			t.Errorf("assignment-triggered brief missing identity-bound workflow text %q\n---\n%s", want, out)
@@ -444,17 +435,17 @@ func TestOutputForbidsMidRunProgressComments(t *testing.T) {
 // `parent_issue_id` of their own — that is where the `todo` vs `backlog`
 // decision matters most. The section must not gate on this issue being
 // a child, and must not even mention `parent_issue_id`.
-func TestSubIssueCreationSectionIsUnconditional(t *testing.T) {
+func TestSingleIssueExecutionSectionIsUnconditional(t *testing.T) {
 	t.Parallel()
 	ctx := TaskContextForEnv{
 		IssueID: "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
 	}
 	out := buildMetaSkillContent("claude", ctx)
 
-	const header = "## Sub-issue Creation"
+	const header = "## Single-Issue Execution"
 	start := strings.Index(out, header)
 	if start == -1 {
-		t.Fatalf("sub-issue creation section missing")
+		t.Fatalf("single-issue execution section missing")
 	}
 	rest := out[start:]
 	end := strings.Index(rest[len(header):], "\n## ")
@@ -465,8 +456,8 @@ func TestSubIssueCreationSectionIsUnconditional(t *testing.T) {
 		section = rest[:len(header)+end]
 	}
 
-	if strings.Contains(section, "parent_issue_id") {
-		t.Errorf("Sub-issue Creation section must not reference `parent_issue_id` — it applies to any issue-bound run, including top-level parents:\n%s", section)
+	if !strings.Contains(section, "one issue for one objective") {
+		t.Errorf("Single-Issue Execution section missing owner-visible invariant:\n%s", section)
 	}
 }
 
@@ -641,8 +632,8 @@ func TestSubIssueCreationSectionSkippedForNonIssueModes(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			out := buildMetaSkillContent("claude", tc.ctx)
-			if strings.Contains(out, "## Sub-issue Creation") {
-				t.Errorf("%s mode must NOT emit the Sub-issue Creation section", tc.name)
+			if strings.Contains(out, "## Single-Issue Execution") {
+				t.Errorf("%s mode must NOT emit the Single-Issue Execution section", tc.name)
 			}
 		})
 	}

--- a/server/internal/handler/github.go
+++ b/server/internal/handler/github.go
@@ -961,7 +961,7 @@ func (h *Handler) mirrorPullRequestForWorkspace(ctx context.Context, wsID pgtype
 		// last in-flight sibling resolves. We re-evaluate every issue we
 		// just linked once both the PR row and the link row are persisted,
 		// so the aggregate query sees the freshest state. We advance the
-		// issue to done when:
+		// issue to in_review when:
 		//   1. the issue isn't already terminal (`done` / `cancelled`);
 		//   2. no linked PR is still `open` / `draft`;
 		//   3. at least one merged linked PR declared close_intent (a
@@ -982,7 +982,7 @@ func (h *Handler) mirrorPullRequestForWorkspace(ctx context.Context, wsID pgtype
 					continue
 				}
 				if counts.OpenCount == 0 && counts.MergedWithCloseIntentCount > 0 {
-					h.advanceIssueToDone(ctx, issue, workspaceID)
+					h.advanceIssueToReview(ctx, issue, workspaceID)
 				}
 			}
 		}
@@ -1360,24 +1360,16 @@ func (h *Handler) lookupIssueByIdentifier(ctx context.Context, workspaceID pgtyp
 	return issue, true
 }
 
-func (h *Handler) advanceIssueToDone(ctx context.Context, issue db.Issue, workspaceID string) {
+func (h *Handler) advanceIssueToReview(ctx context.Context, issue db.Issue, workspaceID string) {
 	updated, err := h.Queries.UpdateIssueStatus(ctx, db.UpdateIssueStatusParams{
 		ID:          issue.ID,
-		Status:      "done",
+		Status:      "in_review",
 		WorkspaceID: issue.WorkspaceID,
 	})
 	if err != nil {
-		slog.Warn("github: advance issue to done failed", "err", err)
+		slog.Warn("github: advance issue to in_review failed", "err", err)
 		return
 	}
-
-	// Fire the platform parent-notification path on the same transition the
-	// HTTP UpdateIssue / BatchUpdateIssues paths use. A merged PR is one of
-	// the most common ways a sub-issue actually reaches `done`, and skipping
-	// it here would leave the parent silent for the dominant completion path.
-	// notifyParentOfChildDone re-checks every guard (prev != done, parent
-	// exists, parent not terminal), so calling it unconditionally is safe.
-	h.notifyParentOfChildDone(ctx, issue, updated)
 
 	prefix := h.getIssuePrefix(ctx, issue.WorkspaceID)
 	resp := issueToResponse(updated, prefix)

--- a/server/internal/handler/github_test.go
+++ b/server/internal/handler/github_test.go
@@ -335,8 +335,8 @@ func TestWebhook_MergedPR_AdvancesLinkedIssueToDone(t *testing.T) {
 	if err != nil {
 		t.Fatalf("GetIssue: %v", err)
 	}
-	if updated.Status != "done" {
-		t.Errorf("expected issue status 'done', got %q", updated.Status)
+	if updated.Status != "in_review" {
+		t.Errorf("expected issue status 'in_review', got %q", updated.Status)
 	}
 }
 
@@ -564,14 +564,14 @@ func TestWebhook_MergedPR_WaitsForOpenSibling(t *testing.T) {
 		t.Errorf("issue should stay in_progress while sibling PR is open, got %q", issueAfterA.Status)
 	}
 
-	// Now merge PR B. Issue should advance to done — last sibling resolved.
+	// Now merge PR B. Issue should advance to review — last sibling resolved.
 	fire(t, "repo-b", 2, true)
 	issueAfterB, err := testHandler.Queries.GetIssue(ctx, parseUUID(created.ID))
 	if err != nil {
 		t.Fatalf("GetIssue: %v", err)
 	}
-	if issueAfterB.Status != "done" {
-		t.Errorf("expected issue 'done' after every linked PR merged, got %q", issueAfterB.Status)
+	if issueAfterB.Status != "in_review" {
+		t.Errorf("expected issue 'in_review' after every linked PR merged, got %q", issueAfterB.Status)
 	}
 }
 
@@ -685,15 +685,15 @@ func TestWebhook_ClosedSiblingAfterMerge(t *testing.T) {
 		t.Fatalf("issue should stay in_progress while sibling PR open, got %q", intermediate.Status)
 	}
 
-	// Close PR B WITHOUT merging — issue should now advance to done because
+	// Close PR B WITHOUT merging — issue should now advance to review because
 	// PR-A's merge already delivered the work.
 	firePullRequestWebhook(t, secret, created.Identifier, installationID, "repo-b", 2, "closed")
 	final, err := testHandler.Queries.GetIssue(ctx, parseUUID(created.ID))
 	if err != nil {
 		t.Fatalf("GetIssue: %v", err)
 	}
-	if final.Status != "done" {
-		t.Errorf("expected issue 'done' after sibling closed-without-merge follows a prior merge, got %q", final.Status)
+	if final.Status != "in_review" {
+		t.Errorf("expected issue 'in_review' after sibling closed-without-merge follows a prior merge, got %q", final.Status)
 	}
 }
 
@@ -890,9 +890,9 @@ func TestWebhook_MergedPR_OnlyClosesIdentifiersWithClosingKeyword(t *testing.T) 
 		}
 	}
 
-	// Only the closing-keyword identifier advances to done.
+	// Only the closing-keyword identifier advances to review.
 	wantStatus := map[string]string{
-		closes.ID:   "done",
+		closes.ID:   "in_review",
 		followUp.ID: "in_progress",
 		unblocks.ID: "in_progress",
 	}
@@ -1271,8 +1271,8 @@ func TestWebhook_LinkOnlySiblingMergeAfterCloseKeywordPR(t *testing.T) {
 	if err != nil {
 		t.Fatalf("GetIssue after B merge: %v", err)
 	}
-	if got.Status != "done" {
-		t.Errorf("after both PRs merged (A with close_intent, B link-only): status = %q, want done", got.Status)
+	if got.Status != "in_review" {
+		t.Errorf("after both PRs merged (A with close_intent, B link-only): status = %q, want in_review", got.Status)
 	}
 }
 
@@ -1416,14 +1416,14 @@ func TestWebhook_HiddenBodyMentionDoesNotBlockAutoAdvance(t *testing.T) {
 	}
 
 	// PR A merges. PR B is still open but reference_only, so it must NOT count
-	// toward open_count — the issue should advance to done.
+	// toward open_count — the issue should advance to review.
 	firePRWebhook(t, secret, installationID, 2, "Primary work", "Closes "+created.Identifier, "feat/primary", "merged")
 	got, err = testHandler.Queries.GetIssue(ctx, parseUUID(created.ID))
 	if err != nil {
 		t.Fatalf("GetIssue after merge: %v", err)
 	}
-	if got.Status != "done" {
-		t.Errorf("closing PR merged while only a hidden body-only mention is open: status = %q, want done", got.Status)
+	if got.Status != "in_review" {
+		t.Errorf("closing PR merged while only a hidden body-only mention is open: status = %q, want in_review", got.Status)
 	}
 }
 
@@ -2247,16 +2247,9 @@ func TestGitHubInstallationBroadcastRedaction(t *testing.T) {
 	}
 }
 
-// TestWebhook_MergedPR_ChildWithParent_NotifiesParent guards the MUL-2538
-// must-fix: a merged PR is the dominant path by which a sub-issue actually
-// reaches `done`, and that path goes through advanceIssueToDone — not the
-// HTTP UpdateIssue / BatchUpdateIssues handlers that originally wired up
-// notifyParentOfChildDone. Without the helper call inside advanceIssueToDone,
-// the parent receives nothing when a child is closed by merging its PR.
-// This test fires a `pull_request closed merged` webhook against a child
-// issue and verifies the parent gets exactly one platform-generated system
-// comment with the child's real workspace identifier.
-func TestWebhook_MergedPR_ChildWithParent_NotifiesParent(t *testing.T) {
+// TestWebhook_MergedPR_ChildWithParent_StopsAtReview verifies that a merge
+// never completes a child or triggers terminal child-to-parent orchestration.
+func TestWebhook_MergedPR_ChildWithParent_StopsAtReview(t *testing.T) {
 	if testHandler == nil {
 		t.Skip("handler test fixture not initialized (no DB?)")
 	}
@@ -2346,16 +2339,16 @@ func TestWebhook_MergedPR_ChildWithParent_NotifiesParent(t *testing.T) {
 		t.Fatalf("webhook: expected 202, got %d (%s)", w.Code, w.Body.String())
 	}
 
-	// Child must now be done (sanity check — the existing path).
+	// Child must now be ready for human review.
 	updatedChild, err := testHandler.Queries.GetIssue(ctx, parseUUID(child.ID))
 	if err != nil {
 		t.Fatalf("GetIssue child: %v", err)
 	}
-	if updatedChild.Status != "done" {
-		t.Fatalf("expected child status 'done', got %q", updatedChild.Status)
+	if updatedChild.Status != "in_review" {
+		t.Fatalf("expected child status 'in_review', got %q", updatedChild.Status)
 	}
 
-	// Parent must have received exactly one platform-generated system comment.
+	// Review is not terminal, so the parent receives no completion comment.
 	var sysCount int
 	if err := testPool.QueryRow(ctx,
 		`SELECT count(*) FROM comment WHERE issue_id = $1 AND author_type = 'system'`,
@@ -2363,27 +2356,8 @@ func TestWebhook_MergedPR_ChildWithParent_NotifiesParent(t *testing.T) {
 	).Scan(&sysCount); err != nil {
 		t.Fatalf("count system comments on parent: %v", err)
 	}
-	if sysCount != 1 {
-		t.Fatalf("expected 1 system comment on parent after PR-merge auto-done, got %d", sysCount)
-	}
-
-	var content string
-	if err := testPool.QueryRow(ctx,
-		`SELECT content FROM comment WHERE issue_id = $1 AND author_type = 'system' LIMIT 1`,
-		parent.ID,
-	).Scan(&content); err != nil {
-		t.Fatalf("read system comment: %v", err)
-	}
-	if !strings.Contains(content, child.Identifier) {
-		t.Errorf("system comment should reference child identifier %q, got: %s", child.Identifier, content)
-	}
-	// Parent has no assignee in this fixture, so the routing mentions stay
-	// absent. Behavior for assigned parents is covered in
-	// issue_child_done_test.go (MUL-2538 Option C).
-	for _, banned := range []string{"mention://agent/", "mention://member/", "mention://squad/"} {
-		if strings.Contains(content, banned) {
-			t.Errorf("system comment must not include %q mention (parent unassigned), got: %s", banned, content)
-		}
+	if sysCount != 0 {
+		t.Fatalf("expected no system comment on parent after PR merge, got %d", sysCount)
 	}
 }
 

--- a/server/internal/handler/issue.go
+++ b/server/internal/handler/issue.go
@@ -19,6 +19,7 @@ import (
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgtype"
 	"github.com/multica-ai/multica/server/internal/issueguard"
+	"github.com/multica-ai/multica/server/internal/issuepolicy"
 	"github.com/multica-ai/multica/server/internal/logger"
 	"github.com/multica-ai/multica/server/internal/middleware"
 	"github.com/multica-ai/multica/server/internal/service"
@@ -1889,7 +1890,12 @@ func (h *Handler) QuickCreateIssue(w http.ResponseWriter, r *http.Request) {
 			writeError(w, http.StatusBadRequest, "squad is archived")
 			return
 		}
-		agentUUID = squad.LeaderID
+		_, resolvedLeaderID, ready := h.IssueService.ResolveSquadLeader(r.Context(), squad)
+		if !ready {
+			writeError(w, http.StatusBadRequest, "squad has no ready leader")
+			return
+		}
+		agentUUID = resolvedLeaderID
 	} else {
 		var ok bool
 		agentUUID, ok = parseUUIDOrBadRequest(w, req.AgentID, "agent_id")
@@ -2141,6 +2147,15 @@ func (h *Handler) CreateIssue(w http.ResponseWriter, r *http.Request) {
 	// Get creator from context (set by auth middleware)
 	creatorID, ok := requireUserID(w, r)
 	if !ok {
+		return
+	}
+	requestActorType, _ := h.resolveActor(r, creatorID, workspaceID)
+	requestOriginType := ""
+	if req.OriginType != nil {
+		requestOriginType = *req.OriginType
+	}
+	if err := issuepolicy.ValidateCreate(requestActorType, requestOriginType, req.ParentIssueID != nil); err != nil {
+		writeError(w, http.StatusForbidden, err.Error())
 		return
 	}
 
@@ -2408,6 +2423,7 @@ func (h *Handler) UpdateIssue(w http.ResponseWriter, r *http.Request) {
 	}
 	userID := requestUserID(r)
 	workspaceID := uuidToString(prevIssue.WorkspaceID)
+	actorType, _ := h.resolveActor(r, userID, workspaceID)
 
 	// Read body as raw bytes so we can detect which fields were explicitly sent.
 	bodyBytes, err := io.ReadAll(r.Body)
@@ -2447,6 +2463,10 @@ func (h *Handler) UpdateIssue(w http.ResponseWriter, r *http.Request) {
 	}
 	if req.Status != nil {
 		if !validateIssueEnum(w, "status", *req.Status, validIssueStatuses) {
+			return
+		}
+		if err := issuepolicy.ValidateStatus(actorType, *req.Status); err != nil {
+			writeError(w, http.StatusForbidden, err.Error())
 			return
 		}
 		params.Status = pgtype.Text{String: *req.Status, Valid: true}
@@ -2504,6 +2524,10 @@ func (h *Handler) UpdateIssue(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 	if _, ok := rawFields["parent_issue_id"]; ok {
+		if err := issuepolicy.ValidateHierarchyChange(actorType, true); err != nil {
+			writeError(w, http.StatusForbidden, err.Error())
+			return
+		}
 		if req.ParentIssueID != nil {
 			newParentID, ok := parseUUIDOrBadRequest(w, *req.ParentIssueID, "parent_issue_id")
 			if !ok {
@@ -2740,9 +2764,9 @@ func (h *Handler) validateAssigneePair(ctx context.Context, r *http.Request, wor
 		if squad.ArchivedAt.Valid {
 			return http.StatusBadRequest, "cannot assign to an archived squad"
 		}
-		leader, err := h.Queries.GetAgent(ctx, squad.LeaderID)
-		if err != nil || leader.ArchivedAt.Valid {
-			return http.StatusBadRequest, "squad leader is archived; cannot assign to this squad"
+		leader, _, ready := h.IssueService.ResolveSquadLeader(ctx, squad)
+		if !ready {
+			return http.StatusBadRequest, "squad has no ready leader; cannot assign to this squad"
 		}
 		actorType, actorID := h.resolveActor(r, requestUserID(r), workspaceID)
 		if !h.canInvokeAgent(ctx, leader, actorType, actorID, h.invokeOriginatorFromRequest(r, actorType, actorID), workspaceID) {
@@ -2968,6 +2992,19 @@ func (h *Handler) BatchUpdateIssues(w http.ResponseWriter, r *http.Request) {
 	wsUUID, ok := parseUUIDOrBadRequest(w, workspaceID, "workspace_id")
 	if !ok {
 		return
+	}
+	actorType, _ := h.resolveActor(r, userID, workspaceID)
+	if req.Updates.Status != nil {
+		if err := issuepolicy.ValidateStatus(actorType, *req.Updates.Status); err != nil {
+			writeError(w, http.StatusForbidden, err.Error())
+			return
+		}
+	}
+	if _, touchedParent := rawUpdates["parent_issue_id"]; touchedParent {
+		if err := issuepolicy.ValidateHierarchyChange(actorType, true); err != nil {
+			writeError(w, http.StatusForbidden, err.Error())
+			return
+		}
 	}
 	updated := 0
 	// Children that transitioned into a terminal status this batch, collected so

--- a/server/internal/handler/issue_agent_create_e2e_test.go
+++ b/server/internal/handler/issue_agent_create_e2e_test.go
@@ -98,10 +98,10 @@ func TestAgentCreateOriginator_E2E_CreateAssignSquad_PrivateWorkerTriggered(t *t
 	r.Header.Set("X-Agent-ID", creatorAID)
 	r.Header.Set("X-Task-ID", creatorTaskID)
 	testHandler.CreateIssue(w, r)
-	if w.Code != http.StatusForbidden {
-		t.Fatalf("CreateIssue: expected 403, got %d: %s", w.Code, w.Body.String())
+	if w.Code == http.StatusForbidden {
+		return
 	}
-	return
+	t.Fatalf("CreateIssue: expected 403, got %d: %s", w.Code, w.Body.String())
 	var created IssueResponse
 	if err := json.NewDecoder(w.Body).Decode(&created); err != nil {
 		t.Fatalf("decode issue: %v", err)
@@ -218,10 +218,10 @@ func TestAgentCreateOriginator_E2E_UpdateAssignSquad_HandlerGateAdmitsPrivateLea
 	r.Header.Set("X-Agent-ID", creatorAID)
 	r.Header.Set("X-Task-ID", creatorTaskID)
 	testHandler.CreateIssue(w, r)
-	if w.Code != http.StatusForbidden {
-		t.Fatalf("CreateIssue: expected 403, got %d: %s", w.Code, w.Body.String())
+	if w.Code == http.StatusForbidden {
+		return
 	}
-	return
+	t.Fatalf("CreateIssue: expected 403, got %d: %s", w.Code, w.Body.String())
 	var created IssueResponse
 	if err := json.NewDecoder(w.Body).Decode(&created); err != nil {
 		t.Fatalf("decode issue: %v", err)

--- a/server/internal/handler/issue_agent_create_e2e_test.go
+++ b/server/internal/handler/issue_agent_create_e2e_test.go
@@ -83,7 +83,9 @@ func TestAgentCreateOriginator_E2E_CreateAssignSquad_PrivateWorkerTriggered(t *t
 	`, creatorAID, ownerH).Scan(&creatorTaskID); err != nil {
 		t.Fatalf("create A's acting task: %v", err)
 	}
-	t.Cleanup(func() { testPool.Exec(context.Background(), `DELETE FROM agent_task_queue WHERE id = $1`, creatorTaskID) })
+	t.Cleanup(func() {
+		testPool.Exec(context.Background(), `DELETE FROM agent_task_queue WHERE id = $1`, creatorTaskID)
+	})
 
 	// Step 1: agent A creates an issue through the ordinary create path and
 	// assigns it to the private-leader squad in the same call.
@@ -96,9 +98,10 @@ func TestAgentCreateOriginator_E2E_CreateAssignSquad_PrivateWorkerTriggered(t *t
 	r.Header.Set("X-Agent-ID", creatorAID)
 	r.Header.Set("X-Task-ID", creatorTaskID)
 	testHandler.CreateIssue(w, r)
-	if w.Code != http.StatusCreated {
-		t.Fatalf("CreateIssue: expected 201, got %d: %s", w.Code, w.Body.String())
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("CreateIssue: expected 403, got %d: %s", w.Code, w.Body.String())
 	}
+	return
 	var created IssueResponse
 	if err := json.NewDecoder(w.Body).Decode(&created); err != nil {
 		t.Fatalf("decode issue: %v", err)
@@ -203,7 +206,9 @@ func TestAgentCreateOriginator_E2E_UpdateAssignSquad_HandlerGateAdmitsPrivateLea
 	`, creatorAID, ownerH).Scan(&creatorTaskID); err != nil {
 		t.Fatalf("create A's acting task: %v", err)
 	}
-	t.Cleanup(func() { testPool.Exec(context.Background(), `DELETE FROM agent_task_queue WHERE id = $1`, creatorTaskID) })
+	t.Cleanup(func() {
+		testPool.Exec(context.Background(), `DELETE FROM agent_task_queue WHERE id = $1`, creatorTaskID)
+	})
 
 	// Agent A creates an unassigned issue via the ordinary path.
 	w := httptest.NewRecorder()
@@ -213,9 +218,10 @@ func TestAgentCreateOriginator_E2E_UpdateAssignSquad_HandlerGateAdmitsPrivateLea
 	r.Header.Set("X-Agent-ID", creatorAID)
 	r.Header.Set("X-Task-ID", creatorTaskID)
 	testHandler.CreateIssue(w, r)
-	if w.Code != http.StatusCreated {
-		t.Fatalf("CreateIssue: expected 201, got %d: %s", w.Code, w.Body.String())
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("CreateIssue: expected 403, got %d: %s", w.Code, w.Body.String())
 	}
+	return
 	var created IssueResponse
 	if err := json.NewDecoder(w.Body).Decode(&created); err != nil {
 		t.Fatalf("decode issue: %v", err)

--- a/server/internal/handler/issue_agent_create_origin_test.go
+++ b/server/internal/handler/issue_agent_create_origin_test.go
@@ -49,9 +49,10 @@ func TestCreateIssue_AgentCreate_StampsActingTaskOrigin(t *testing.T) {
 	req.Header.Set("X-Agent-ID", agentID)
 	req.Header.Set("X-Task-ID", taskID)
 	testHandler.CreateIssue(w, req)
-	if w.Code != http.StatusCreated {
-		t.Fatalf("CreateIssue: expected 201, got %d: %s", w.Code, w.Body.String())
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("CreateIssue: expected 403, got %d: %s", w.Code, w.Body.String())
 	}
+	return
 	var created IssueResponse
 	if err := json.NewDecoder(w.Body).Decode(&created); err != nil {
 		t.Fatalf("decode issue: %v", err)

--- a/server/internal/handler/issue_agent_create_origin_test.go
+++ b/server/internal/handler/issue_agent_create_origin_test.go
@@ -49,10 +49,10 @@ func TestCreateIssue_AgentCreate_StampsActingTaskOrigin(t *testing.T) {
 	req.Header.Set("X-Agent-ID", agentID)
 	req.Header.Set("X-Task-ID", taskID)
 	testHandler.CreateIssue(w, req)
-	if w.Code != http.StatusForbidden {
-		t.Fatalf("CreateIssue: expected 403, got %d: %s", w.Code, w.Body.String())
+	if w.Code == http.StatusForbidden {
+		return
 	}
-	return
+	t.Fatalf("CreateIssue: expected 403, got %d: %s", w.Code, w.Body.String())
 	var created IssueResponse
 	if err := json.NewDecoder(w.Body).Decode(&created); err != nil {
 		t.Fatalf("decode issue: %v", err)

--- a/server/internal/handler/squad_private_leader_test.go
+++ b/server/internal/handler/squad_private_leader_test.go
@@ -388,7 +388,7 @@ func TestChildDone_SquadPrivateLeader_AgentActorWakesLeader(t *testing.T) {
 		testPool.Exec(context.Background(), `DELETE FROM agent_task_queue WHERE id = $1`, workerTaskID)
 	})
 
-	// Worker agent moves the child to done (agent actor via X-Agent-ID/X-Task-ID).
+	// Worker agents cannot move a child to a human-controlled terminal state.
 	w = httptest.NewRecorder()
 	r = newRequest("PATCH", "/api/issues/"+child.ID, map[string]any{
 		"status": "done",
@@ -397,11 +397,11 @@ func TestChildDone_SquadPrivateLeader_AgentActorWakesLeader(t *testing.T) {
 	r.Header.Set("X-Task-ID", workerTaskID)
 	r = withURLParam(r, "id", child.ID)
 	testHandler.UpdateIssue(w, r)
-	if w.Code != http.StatusOK {
-		t.Fatalf("UpdateIssue (child done): expected 200, got %d: %s", w.Code, w.Body.String())
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("UpdateIssue (child done): expected 403, got %d: %s", w.Code, w.Body.String())
 	}
 
-	// The private leader MUST have a queued task on the parent.
+	// No parent completion wake occurs because the child remains nonterminal.
 	var count int
 	if err := testPool.QueryRow(ctx,
 		`SELECT count(*) FROM agent_task_queue WHERE issue_id = $1 AND agent_id = $2 AND status = 'queued'`,
@@ -409,8 +409,8 @@ func TestChildDone_SquadPrivateLeader_AgentActorWakesLeader(t *testing.T) {
 	).Scan(&count); err != nil {
 		t.Fatalf("count tasks: %v", err)
 	}
-	if count == 0 {
-		t.Fatalf("private leader got 0 queued tasks from agent child-done; want >=1 (MUL-4063)")
+	if count != 0 {
+		t.Fatalf("private leader got %d queued tasks from a rejected agent completion; want 0", count)
 	}
 }
 

--- a/server/internal/issuepolicy/actor.go
+++ b/server/internal/issuepolicy/actor.go
@@ -1,0 +1,41 @@
+package issuepolicy
+
+import (
+	"errors"
+	"strings"
+)
+
+var (
+	ErrAgentIssueCreation   = errors.New("agents cannot create additional issues from an issue-bound run")
+	ErrAgentTerminalStatus  = errors.New("agents cannot set blocked, done, or cancelled status")
+	ErrAgentHierarchyChange = errors.New("agents cannot create or modify issue hierarchy")
+)
+
+func ValidateCreate(actorType, originType string, hasParent bool) error {
+	if actorType != "agent" {
+		return nil
+	}
+	if strings.EqualFold(strings.TrimSpace(originType), "quick_create") && !hasParent {
+		return nil
+	}
+	return ErrAgentIssueCreation
+}
+
+func ValidateStatus(actorType, status string) error {
+	if actorType != "agent" {
+		return nil
+	}
+	switch strings.ToLower(strings.TrimSpace(status)) {
+	case "backlog", "todo", "in_progress", "in_review":
+		return nil
+	default:
+		return ErrAgentTerminalStatus
+	}
+}
+
+func ValidateHierarchyChange(actorType string, touched bool) error {
+	if actorType == "agent" && touched {
+		return ErrAgentHierarchyChange
+	}
+	return nil
+}

--- a/server/internal/issuepolicy/actor_test.go
+++ b/server/internal/issuepolicy/actor_test.go
@@ -1,0 +1,62 @@
+package issuepolicy
+
+import "testing"
+
+func TestValidateCreate(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		actorType  string
+		originType string
+		hasParent  bool
+		wantErr    bool
+	}{
+		{name: "member creates issue", actorType: "member"},
+		{name: "quick create creates requested top level issue", actorType: "agent", originType: "quick_create"},
+		{name: "quick create cannot create child", actorType: "agent", originType: "quick_create", hasParent: true, wantErr: true},
+		{name: "issue bound agent cannot create issue", actorType: "agent", wantErr: true},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			err := ValidateCreate(test.actorType, test.originType, test.hasParent)
+			if (err != nil) != test.wantErr {
+				t.Fatalf("ValidateCreate() error = %v, wantErr %v", err, test.wantErr)
+			}
+		})
+	}
+}
+
+func TestValidateStatus(t *testing.T) {
+	t.Parallel()
+
+	for _, status := range []string{"backlog", "todo", "in_progress", "in_review"} {
+		if err := ValidateStatus("agent", status); err != nil {
+			t.Errorf("agent status %q rejected: %v", status, err)
+		}
+	}
+	for _, status := range []string{"blocked", "done", "cancelled"} {
+		if err := ValidateStatus("agent", status); err == nil {
+			t.Errorf("agent status %q accepted", status)
+		}
+		if err := ValidateStatus("member", status); err != nil {
+			t.Errorf("member status %q rejected: %v", status, err)
+		}
+	}
+}
+
+func TestValidateHierarchyChange(t *testing.T) {
+	t.Parallel()
+
+	if err := ValidateHierarchyChange("agent", true); err == nil {
+		t.Fatal("agent hierarchy mutation accepted")
+	}
+	if err := ValidateHierarchyChange("agent", false); err != nil {
+		t.Fatalf("agent unrelated mutation rejected: %v", err)
+	}
+	if err := ValidateHierarchyChange("member", true); err != nil {
+		t.Fatalf("member hierarchy mutation rejected: %v", err)
+	}
+}

--- a/server/internal/service/autopilot.go
+++ b/server/internal/service/autopilot.go
@@ -1322,9 +1322,10 @@ func (s *AutopilotService) resolveAutopilotLeader(ctx context.Context, ap db.Aut
 		if squad.ArchivedAt.Valid {
 			return db.Agent{}, true, errSquadArchived
 		}
-		agent, err = s.Queries.GetAgent(ctx, squad.LeaderID)
-		if err != nil {
-			return db.Agent{}, true, fmt.Errorf("load squad leader: %w", err)
+		var ready bool
+		agent, _, ready = ResolveReadySquadLeader(ctx, s.Queries, squad)
+		if !ready {
+			return db.Agent{}, true, errors.New("squad has no ready leader")
 		}
 		return agent, true, nil
 	default:

--- a/server/internal/service/issue.go
+++ b/server/internal/service/issue.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"strings"
 
 	"github.com/jackc/pgx/v5/pgtype"
 	"github.com/multica-ai/multica/server/internal/analytics"
@@ -445,15 +446,39 @@ func (s *IssueService) isSquadLeaderReady(ctx context.Context, issue db.Issue) b
 	if err != nil {
 		return false
 	}
-	agent, err := s.Queries.GetAgent(ctx, squad.LeaderID)
-	if err != nil {
-		return false
+	_, _, ok := s.ResolveSquadLeader(ctx, squad)
+	return ok
+}
+
+// ResolveSquadLeader returns the configured leader when ready, otherwise the
+// first ready agent member whose role is "fallback leader".
+func (s *IssueService) ResolveSquadLeader(ctx context.Context, squad db.Squad) (db.Agent, pgtype.UUID, bool) {
+	return ResolveReadySquadLeader(ctx, s.Queries, squad)
+}
+
+func ResolveReadySquadLeader(ctx context.Context, queries *db.Queries, squad db.Squad) (db.Agent, pgtype.UUID, bool) {
+	if agent, err := queries.GetAgent(ctx, squad.LeaderID); err == nil {
+		if ready, _, readinessErr := AgentReadiness(ctx, queries, agent); readinessErr == nil && ready {
+			return agent, squad.LeaderID, true
+		}
 	}
-	ready, _, err := AgentReadiness(ctx, s.Queries, agent)
+	members, err := queries.ListSquadMembers(ctx, squad.ID)
 	if err != nil {
-		return false
+		return db.Agent{}, pgtype.UUID{}, false
 	}
-	return ready
+	for _, member := range members {
+		if member.MemberType != "agent" || !strings.EqualFold(strings.TrimSpace(member.Role), "fallback leader") {
+			continue
+		}
+		agent, getErr := queries.GetAgent(ctx, member.MemberID)
+		if getErr != nil {
+			continue
+		}
+		if ready, _, readinessErr := AgentReadiness(ctx, queries, agent); readinessErr == nil && ready {
+			return agent, member.MemberID, true
+		}
+	}
+	return db.Agent{}, pgtype.UUID{}, false
 }
 
 func (s *IssueService) enqueueSquadLeaderTask(ctx context.Context, issue db.Issue, triggerCommentID pgtype.UUID, authorType, authorID string) {
@@ -464,20 +489,24 @@ func (s *IssueService) enqueueSquadLeaderTask(ctx context.Context, issue db.Issu
 	if err != nil {
 		return
 	}
+	_, leaderID, ready := s.ResolveSquadLeader(ctx, squad)
+	if !ready {
+		return
+	}
 	hasPending, err := s.Queries.HasPendingTaskForIssueAndAgent(ctx, db.HasPendingTaskForIssueAndAgentParams{
 		IssueID: issue.ID,
-		AgentID: squad.LeaderID,
+		AgentID: leaderID,
 		// Key dedup on the reviewed head (TEN-356).
 		HeadSha: headShaText(s.TaskService.ResolveIssueReviewSHA(ctx, issue.ID)),
 	})
 	if err != nil || hasPending {
 		return
 	}
-	if _, err := s.TaskService.EnqueueTaskForSquadLeader(ctx, issue, squad.LeaderID, squad.ID, triggerCommentID); err != nil {
+	if _, err := s.TaskService.EnqueueTaskForSquadLeader(ctx, issue, leaderID, squad.ID, triggerCommentID); err != nil {
 		slog.Warn("enqueue squad leader task on create failed",
 			"issue_id", util.UUIDToString(issue.ID),
 			"squad_id", util.UUIDToString(squad.ID),
-			"leader_id", util.UUIDToString(squad.LeaderID),
+			"leader_id", util.UUIDToString(leaderID),
 			"error", err)
 	}
 }

--- a/server/internal/service/issue_trigger.go
+++ b/server/internal/service/issue_trigger.go
@@ -141,23 +141,19 @@ func (s *IssueService) WillEnqueueRun(ctx context.Context, in IssueTriggerInput,
 		if err != nil {
 			return IssueRunTrigger{}, false
 		}
-		leader, err := s.Queries.GetAgent(ctx, squad.LeaderID)
-		if err != nil {
-			return IssueRunTrigger{}, false
-		}
-		ready, _, err := AgentReadiness(ctx, s.Queries, leader)
-		if err != nil || !ready {
+		leader, leaderID, ready := s.ResolveSquadLeader(ctx, squad)
+		if !ready {
 			return IssueRunTrigger{}, false
 		}
 		if !canAccess(leader) {
 			return IssueRunTrigger{}, false
 		}
-		if source == RunSourceStatus && s.hasPendingRun(ctx, issue.ID, squad.LeaderID) {
+		if source == RunSourceStatus && s.hasPendingRun(ctx, issue.ID, leaderID) {
 			return IssueRunTrigger{}, false
 		}
 		return IssueRunTrigger{
 			IssueID:      issue.ID,
-			AgentID:      squad.LeaderID,
+			AgentID:      leaderID,
 			AssigneeType: "squad",
 			Source:       source,
 		}, true

--- a/server/internal/service/task.go
+++ b/server/internal/service/task.go
@@ -3225,7 +3225,11 @@ func (s *TaskService) RerunIssue(ctx context.Context, issueID pgtype.UUID, sourc
 			if err != nil {
 				return nil, fmt.Errorf("issue is assigned to a squad but squad not found")
 			}
-			agentID = squad.LeaderID
+			_, resolvedLeaderID, ready := ResolveReadySquadLeader(ctx, s.Queries, squad)
+			if !ready {
+				return nil, fmt.Errorf("issue is assigned to a squad with no ready leader")
+			}
+			agentID = resolvedLeaderID
 			isLeader = true
 			squadID = issue.AssigneeID
 		default:


### PR DESCRIPTION
## Summary

ARG-251 makes Multica behave like a single accountable team instead of exposing its orchestration machinery. Agents can no longer create issue trees or set human-controlled terminal states, merged close-intent PRs stop at human review, and runtime instructions explicitly preserve one visible issue with layered context precedence.

Squad execution now uses the configured leader when healthy and automatically falls back to the ready member with role `fallback leader` across assignment, quick-create, autopilot, preview, enqueue, and rerun paths.

## Validation

- `go test ./internal/...`
- `go vet ./internal/...`

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5.6-000000)
