### PR TITLE
fix(desktop): match canvas left margin to right when sidebar is collapsed

### DIFF
--- a/apps/desktop/src/renderer/src/components/desktop-layout.tsx
+++ b/apps/desktop/src/renderer/src/components/desktop-layout.tsx
@@ -129,6 +129,25 @@ function MainTopBar() {
   );
 }
 
+// The canvas hugs the expanded sidebar with a hairline gap. When the sidebar
+// leaves the main flow, the left margin must grow to mirror the fixed mr-2 so
+// the floating canvas sits symmetrically inside the window frame.
+function MainCanvas({ children }: { children: React.ReactNode }) {
+  const { state, isMobile } = useSidebar();
+  const sidebarHidden = state === "collapsed" || isMobile;
+
+  return (
+    <motion.div
+      animate={{ marginLeft: sidebarHidden ? 8 : 2 }}
+      className="relative flex flex-1 min-h-0 flex-col overflow-hidden mr-2 mb-2 rounded-xl bg-page-canvas ring-1 ring-surface-border shadow-[var(--surface-shadow)]"
+      initial={false}
+      transition={toolbarMotion}
+    >
+      {children}
+    </motion.div>
+  );
+}
+
 function useInternalLinkHandler() {
   useEffect(() => {
     const handler = (e: Event) => {
@@ -219,10 +238,10 @@ export function DesktopShell() {
             {/* Right side: header + content container */}
             <motion.div layout transition={toolbarMotion} className="flex flex-1 min-w-0 flex-col">
               <MainTopBar />
-              <div className="relative flex flex-1 min-h-0 flex-col overflow-hidden mr-2 mb-2 ml-0.5 rounded-xl bg-page-canvas ring-1 ring-surface-border shadow-[var(--surface-shadow)]">
+              <MainCanvas>
                 <TabContent />
                 {slug && <FloatingChat />}
-              </div>
+              </MainCanvas>
             </motion.div>
           </SidebarProvider>
         </div>


### PR DESCRIPTION
## Problem

MUL-4780: after collapsing the left sidebar in the desktop app, the canvas kept its static 2px left margin while the right edge uses an 8px margin, so the floating canvas sat visibly off-center in the window frame.

## Fix

Extract the shell canvas into a `MainCanvas` component that reads the sidebar state (same pattern as `MainTopBar`) and animates `marginLeft` 2px → 8px with the shared `toolbarMotion` spring whenever the sidebar leaves the main flow (collapsed or mobile). This mirrors what the web app already does in `SidebarInset` via `peer-data-[state=collapsed]:ml-2`.

## Measured (CDP, 1280px window)

| State | Left gap | Right gap |
| --- | --- | --- |
| Expanded (before & after) | sidebar + 2px | 8px |
| Collapsed before | **2px** | 8px |
| Collapsed after | **8px** | 8px |

## Verification

- `turbo typecheck lint --filter=@multica/desktop` ✅
- `pnpm -C apps/desktop test` — 267 tests pass ✅
- Verified live in the dev Electron app via CDP: margins measured before/after, screenshots on MUL-4780
