### PR TITLE
fix(ui): render select labels instead of raw values

### DIFF
--- a/packages/ui/components/ui/select.tsx
+++ b/packages/ui/components/ui/select.tsx
@@ -6,7 +6,22 @@ import { Select as SelectPrimitive } from "@base-ui/react/select"
 import { cn } from "@multica/ui/lib/utils"
 import { ChevronDownIcon, CheckIcon, ChevronUpIcon } from "lucide-react"
 
-const Select = SelectPrimitive.Root
+type SelectProps<
+  Value,
+  Multiple extends boolean | undefined = false,
+> = SelectPrimitive.Root.Props<Value, Multiple> & {
+  items: NonNullable<SelectPrimitive.Root.Props<Value, Multiple>["items"]>
+}
+
+/**
+ * Base UI renders the raw value unless Root receives an items label map.
+ * Keep items required so every select has a single source for value labels.
+ */
+function Select<Value, Multiple extends boolean | undefined = false>(
+  props: SelectProps<Value, Multiple>
+) {
+  return <SelectPrimitive.Root {...props} />
+}
 
 function SelectGroup({ className, ...props }: SelectPrimitive.Group.Props) {
   return (

--- a/packages/views/autopilots/components/autopilot-dialog.tsx
+++ b/packages/views/autopilots/components/autopilot-dialog.tsx
@@ -963,6 +963,14 @@ function ScheduleSection({
   const formatCountdown = useFormatCountdown();
   const now = useNowTicker();
   const next = useMemo(() => computeNextRun(config, now), [config, now]);
+  const frequencyItems = FREQUENCY_KEYS.map((value) => ({
+    value,
+    label: t(($) => $.dialog.frequency_long[value]),
+  }));
+  const dayItems = DAY_KEYS.map((dayKey, value) => ({
+    value: String(value),
+    label: t(($) => $.dialog.days[dayKey]),
+  }));
   const timezones = useMemo(() => {
     const local = getLocalTimezone();
     if (TIMEZONE_OPTIONS.includes(local)) return TIMEZONE_OPTIONS;
@@ -983,6 +991,7 @@ function ScheduleSection({
         {/* Row 1: Frequency + (Day when weekly) */}
         <div className="grid grid-cols-2 gap-2">
           <Select
+            items={frequencyItems}
             value={config.frequency}
             onValueChange={(v) =>
               v && onChange({ ...config, frequency: v as TriggerFrequency })
@@ -992,15 +1001,16 @@ function ScheduleSection({
               <SelectValue />
             </SelectTrigger>
             <SelectContent>
-              {FREQUENCY_KEYS.map((freq) => (
-                <SelectItem key={freq} value={freq}>
-                  {t(($) => $.dialog.frequency_long[freq])}
+              {frequencyItems.map((item) => (
+                <SelectItem key={item.value} value={item.value}>
+                  {item.label}
                 </SelectItem>
               ))}
             </SelectContent>
           </Select>
           {config.frequency === "weekly" ? (
             <Select
+              items={dayItems}
               value={String(selectedDay)}
               onValueChange={(v) =>
                 v && onChange({ ...config, daysOfWeek: [parseInt(v, 10)] })
@@ -1010,9 +1020,9 @@ function ScheduleSection({
                 <SelectValue />
               </SelectTrigger>
               <SelectContent>
-                {DAY_KEYS.map((dayKey, i) => (
-                  <SelectItem key={dayKey} value={String(i)}>
-                    {t(($) => $.dialog.days[dayKey])}
+                {dayItems.map((item) => (
+                  <SelectItem key={item.value} value={item.value}>
+                    {item.label}
                   </SelectItem>
                 ))}
               </SelectContent>

--- a/packages/views/autopilots/components/trigger-config.tsx
+++ b/packages/views/autopilots/components/trigger-config.tsx
@@ -350,6 +350,10 @@ export function TriggerConfigSection({
                     {t(($) => $.trigger_config.timezone_label)}
                   </label>
                   <Select
+                    items={timezones.map((value) => ({
+                      value,
+                      label: getTimezoneLabel(value),
+                    }))}
                     value={config.timezone}
                     onValueChange={(v) => v && onChange({ ...config, timezone: v })}
                   >

--- a/packages/views/common/select.test.tsx
+++ b/packages/views/common/select.test.tsx
@@ -1,0 +1,29 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import {
+  Select,
+  SelectTrigger,
+  SelectValue,
+} from "@multica/ui/components/ui/select";
+
+describe("Select", () => {
+  it("renders the selected item label instead of its raw value", () => {
+    render(
+      <Select
+        items={[
+          { value: "select", label: "Single select" },
+          { value: "multi_select", label: "Multi-select" },
+        ]}
+        value="multi_select"
+      >
+        <SelectTrigger aria-label="Property type">
+          <SelectValue />
+        </SelectTrigger>
+      </Select>,
+    );
+
+    const trigger = screen.getByRole("combobox", { name: "Property type" });
+    expect(trigger).toHaveTextContent("Multi-select");
+    expect(trigger).not.toHaveTextContent("multi_select");
+  });
+});

--- a/packages/views/common/timezone-select.tsx
+++ b/packages/views/common/timezone-select.tsx
@@ -93,9 +93,11 @@ export function TimezoneSelect({
   const options = timezoneOptions(value);
   const render = (tz: string) =>
     tz === browser ? `${tz}${browserSuffix}` : tz;
+  const items = options.map((value) => ({ value, label: render(value) }));
 
   return (
     <Select
+      items={items}
       value={value}
       disabled={disabled}
       onValueChange={(next) => {
@@ -109,9 +111,9 @@ export function TimezoneSelect({
         <SelectValue>{render(value)}</SelectValue>
       </SelectTrigger>
       <SelectContent align="start" className="max-h-72">
-        {options.map((tz) => (
-          <SelectItem key={tz} value={tz} className="font-mono text-xs">
-            {render(tz)}
+        {items.map((item) => (
+          <SelectItem key={item.value} value={item.value} className="font-mono text-xs">
+            {item.label}
           </SelectItem>
         ))}
       </SelectContent>

--- a/packages/views/dashboard/components/dashboard-page.tsx
+++ b/packages/views/dashboard/components/dashboard-page.tsx
@@ -528,9 +528,14 @@ function ProjectFilter({
   const selected = projects.find((p) => p.id === value);
   const selectedTitle =
     value === ALL_PROJECTS ? allLabel : selected?.title ?? allLabel;
+  const projectItems = [
+    { value: ALL_PROJECTS, label: allLabel },
+    ...projects.map((project) => ({ value: project.id, label: project.title })),
+  ];
 
   return (
     <Select
+      items={projectItems}
       value={value}
       onValueChange={(v) => onChange(v ?? ALL_PROJECTS)}
     >

--- a/packages/views/runtimes/components/cloud-runtime-dialog.tsx
+++ b/packages/views/runtimes/components/cloud-runtime-dialog.tsx
@@ -254,7 +254,11 @@ function LabeledInput({
         <Label htmlFor={id} className="text-xs text-muted-foreground">
           {label}
         </Label>
-        <Select value={value} onValueChange={(next) => onChange(next ?? value)}>
+        <Select
+          items={options.map((option) => ({ value: option, label: option }))}
+          value={value}
+          onValueChange={(next) => onChange(next ?? value)}
+        >
           <SelectTrigger id={id} className="h-9 w-full rounded-md text-sm">
             <SelectValue>
               {() => <span className="truncate">{value}</span>}

--- a/packages/views/settings/components/members-tab.tsx
+++ b/packages/views/settings/components/members-tab.tsx
@@ -356,7 +356,14 @@ export function MembersTab() {
                     if (e.key === "Enter" && inviteEmail.trim()) handleInviteMember();
                   }}
                 />
-                <Select value={inviteRole} onValueChange={(value) => setInviteRole(value as MemberRole)}>
+                <Select
+                  items={(["member", "admin"] as const).map((value) => ({
+                    value,
+                    label: roleConfig[value].label,
+                  }))}
+                  value={inviteRole}
+                  onValueChange={(value) => setInviteRole(value as MemberRole)}
+                >
                   <SelectTrigger size="sm">
                     <SelectValue>{() => roleConfig[inviteRole].label}</SelectValue>
                   </SelectTrigger>

--- a/packages/views/settings/components/preferences-tab.tsx
+++ b/packages/views/settings/components/preferences-tab.tsx
@@ -101,6 +101,7 @@ export function PreferencesTab() {
             size="select"
           >
             <Select
+              items={themeOptions}
               value={theme}
               onValueChange={(next) => {
                 if (!next || next === theme) return;
@@ -134,6 +135,7 @@ export function PreferencesTab() {
             size="select"
           >
             <Select
+              items={languageOptions}
               value={currentLocale}
               onValueChange={(next) => {
                 if (next) void handleLanguageChange(next as SupportedLocale);
@@ -243,6 +245,13 @@ function TimezoneRow() {
       size="select-wide"
     >
       <Select
+        items={[
+          { value: BROWSER_TZ_VALUE, label: formatTZLabel(BROWSER_TZ_VALUE) },
+          ...options.map((timezone) => ({
+            value: timezone,
+            label: formatTZLabel(timezone),
+          })),
+        ]}
         value={value}
         onValueChange={(next) => {
           if (next) void handleChange(next);

--- a/packages/views/settings/components/properties-tab.tsx
+++ b/packages/views/settings/components/properties-tab.tsx
@@ -384,6 +384,10 @@ function PropertyEditorDialog({
 
   const showOptions = typeHasOptions(draft.type);
   const validOptions = draft.options.filter((option) => option.name.trim());
+  const propertyTypeItems = ISSUE_PROPERTY_TYPES.map((type) => ({
+    value: type,
+    label: <PropertyTypeLabel type={type} />,
+  }));
   const canSubmit =
     draft.name.trim().length > 0 && (!showOptions || validOptions.length > 0);
 
@@ -475,6 +479,7 @@ function PropertyEditorDialog({
                 </div>
               ) : (
                 <Select
+                  items={propertyTypeItems}
                   value={draft.type}
                   onValueChange={(value) =>
                     value &&
@@ -492,9 +497,9 @@ function PropertyEditorDialog({
                     <SelectValue />
                   </SelectTrigger>
                   <SelectContent>
-                    {ISSUE_PROPERTY_TYPES.map((type) => (
-                      <SelectItem key={type} value={type}>
-                        <PropertyTypeLabel type={type} />
+                    {propertyTypeItems.map((item) => (
+                      <SelectItem key={item.value} value={item.value}>
+                        {item.label}
                       </SelectItem>
                     ))}
                   </SelectContent>

--- a/packages/views/settings/components/tokens-tab.tsx
+++ b/packages/views/settings/components/tokens-tab.tsx
@@ -44,6 +44,10 @@ const EXPIRY_KEYS = ["30", "90", "365", "never"] as const;
 
 export function TokensTab() {
   const { t } = useT("settings");
+  const expiryItems = EXPIRY_KEYS.map((value) => ({
+    value,
+    label: t(($) => $.tokens.expiry[value]),
+  }));
   const [tokens, setTokens] = useState<PersonalAccessToken[]>([]);
   const [tokenName, setTokenName] = useState("");
   const [tokenExpiry, setTokenExpiry] = useState("90");
@@ -147,14 +151,18 @@ export function TokensTab() {
                 onChange={(e) => setTokenName(e.target.value)}
                 placeholder={t(($) => $.tokens.name_placeholder)}
               />
-              <Select value={tokenExpiry} onValueChange={(v) => { if (v) setTokenExpiry(v); }}>
+              <Select
+                items={expiryItems}
+                value={tokenExpiry}
+                onValueChange={(v) => { if (v) setTokenExpiry(v); }}
+              >
                 <SelectTrigger
                   size="sm"
                   aria-label={t(($) => $.tokens.title)}
                 ><SelectValue /></SelectTrigger>
                 <SelectContent>
-                  {EXPIRY_KEYS.map((key) => (
-                    <SelectItem key={key} value={key}>{t(($) => $.tokens.expiry[key])}</SelectItem>
+                  {expiryItems.map((item) => (
+                    <SelectItem key={item.value} value={item.value}>{item.label}</SelectItem>
                   ))}
                 </SelectContent>
               </Select>

--- a/packages/views/skills/components/runtime-local-skill-import-panel.tsx
+++ b/packages/views/skills/components/runtime-local-skill-import-panel.tsx
@@ -1162,6 +1162,10 @@ export function RuntimeLocalSkillImportPanel({
             {t(($) => $.runtime_import.runtime_label)}
           </label>
           <Select
+            items={localRuntimes.map((runtime) => ({
+              value: runtime.id,
+              label: runtimeLabel(runtime),
+            }))}
             value={selectedRuntimeId}
             onValueChange={(v) => v && setSelectedRuntimeId(v)}
           >


### PR DESCRIPTION
## Summary

- require every shared Select to provide a Base UI `items` value-to-label mapping
- migrate all 13 Select call sites, including property types, autopilot schedules, token expiry, timezones, roles, preferences, projects, and runtimes
- add a regression test proving `multi_select` renders as `Multi-select`

## Root cause

Base UI renders the raw selected value unless `Select.Root` receives an `items` mapping or `Select.Value` formats the value explicitly. Our shared wrapper did not enforce that requirement. Four call sites used an empty `SelectValue` and exposed internal values directly, while the remaining call sites manually formatted labels and masked the same missing contract.

## Impact

Selected options now consistently show their user-facing, localized labels. The shared TypeScript wrapper requires `items`, so future unmapped Select usage fails type checking instead of silently rendering raw values.

## Validation

- `pnpm typecheck`
- `pnpm --filter @multica/views test` — 192 files, 1996 tests
- `pnpm --filter @multica/ui lint`
- `pnpm --filter @multica/views lint` — 0 errors; existing unrelated warnings only
- `git diff --check`
