### PR TITLE
fix(landing): point dashboard CTAs at the real workspace route (MUL-4794)

### DIFF
--- a/apps/web/features/landing/components/how-it-works-section.tsx
+++ b/apps/web/features/landing/components/how-it-works-section.tsx
@@ -3,11 +3,13 @@
 import Link from "next/link";
 import { useAuthStore } from "@multica/core/auth";
 import { docsHrefForLocale, useLocale } from "../i18n";
+import { useDashboardCtaHref } from "../utils/use-dashboard-cta";
 import { GitHubMark, githubUrl, heroButtonClassName } from "./shared";
 
 export function HowItWorksSection() {
   const { t, locale } = useLocale();
   const user = useAuthStore((s) => s.user);
+  const ctaHref = useDashboardCtaHref();
 
   return (
     <section id="how-it-works" className="bg-[#05070b] text-white">
@@ -41,7 +43,7 @@ export function HowItWorksSection() {
         </div>
 
         <div className="mt-14 flex flex-wrap items-center gap-4">
-          <Link href={user ? "/" : "/login"} className={heroButtonClassName("solid")}>
+          <Link href={ctaHref} className={heroButtonClassName("solid")}>
             {user ? t.header.dashboard : t.howItWorks.cta}
           </Link>
           <Link

--- a/apps/web/features/landing/components/landing-footer.tsx
+++ b/apps/web/features/landing/components/landing-footer.tsx
@@ -13,10 +13,12 @@ import {
   discordUrl,
 } from "./shared";
 import { useLocale, locales, localeLabels } from "../i18n";
+import { useDashboardCtaHref } from "../utils/use-dashboard-cta";
 
 export function LandingFooter() {
   const { t, locale, setLocale } = useLocale();
   const user = useAuthStore((s) => s.user);
+  const ctaHref = useDashboardCtaHref();
   const groups = Object.values(t.footer.groups);
 
   return (
@@ -64,7 +66,7 @@ export function LandingFooter() {
             </div>
             <div className="mt-6">
               <Link
-                href={user ? "/" : "/login"}
+                href={ctaHref}
                 className="inline-flex items-center justify-center rounded-[11px] bg-white px-5 py-2.5 text-[13px] font-semibold text-[#0a0d12] transition-colors hover:bg-white/88"
               >
                 {user ? t.header.dashboard : t.footer.cta}

--- a/apps/web/features/landing/components/landing-header.tsx
+++ b/apps/web/features/landing/components/landing-header.tsx
@@ -7,6 +7,7 @@ import { MulticaIcon } from "@multica/ui/components/common/multica-icon";
 import { cn } from "@multica/ui/lib/utils";
 import { useAuthStore } from "@multica/core/auth";
 import { docsHrefForLocale, useLocale } from "../i18n";
+import { useDashboardCtaHref } from "../utils/use-dashboard-cta";
 import { formatStarCount, useGithubStars } from "../utils/use-github-stars";
 import { GitHubMark, githubUrl, headerButtonClassName } from "./shared";
 
@@ -26,7 +27,7 @@ export function LandingHeader({
     { href: docsHref, label: t.header.docs },
     { href: "/changelog", label: t.header.changelog },
   ];
-  const ctaHref = user ? "/" : "/login";
+  const ctaHref = useDashboardCtaHref();
   const ctaLabel = user ? t.header.dashboard : t.header.cta;
 
   return (

--- a/apps/web/features/landing/components/landing-hero.tsx
+++ b/apps/web/features/landing/components/landing-hero.tsx
@@ -5,6 +5,7 @@ import Link from "next/link";
 import { ArrowRight, Download } from "lucide-react";
 import { useAuthStore } from "@multica/core/auth";
 import { useLocale } from "../i18n";
+import { useDashboardCtaHref } from "../utils/use-dashboard-cta";
 import {
   ClaudeCodeLogo,
   CodexLogo,
@@ -17,6 +18,7 @@ import {
 export function LandingHero() {
   const { t } = useLocale();
   const user = useAuthStore((s) => s.user);
+  const ctaHref = useDashboardCtaHref();
 
   return (
     <div className="relative min-h-full overflow-hidden bg-[#05070b] text-white">
@@ -39,7 +41,7 @@ export function LandingHero() {
             </p>
 
             <div className="mt-8 flex flex-wrap items-center justify-center gap-3">
-              <Link href={user ? "/" : "/login"} className={heroButtonClassName("solid")}>
+              <Link href={ctaHref} className={heroButtonClassName("solid")}>
                 {user ? t.header.dashboard : t.hero.cta}
               </Link>
               <Link

--- a/apps/web/features/landing/utils/use-dashboard-cta.test.ts
+++ b/apps/web/features/landing/utils/use-dashboard-cta.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from "vitest";
+import { paths } from "@multica/core/paths";
+import type { Workspace } from "@multica/core/types";
+import { resolveDashboardCtaHref } from "./use-dashboard-cta";
+
+function makeWs(slug: string): Workspace {
+  return {
+    id: `id-${slug}`,
+    name: slug,
+    slug,
+    description: null,
+    context: null,
+    settings: {},
+    repos: [],
+    issue_prefix: slug.toUpperCase(),
+    avatar_url: null,
+    created_at: "",
+    updated_at: "",
+  };
+}
+
+const fetched = (workspaces: Workspace[], hasOnboarded = true) => ({
+  isAuthenticated: true,
+  isWorkspaceListFetched: true,
+  workspaces,
+  hasOnboarded,
+});
+
+describe("resolveDashboardCtaHref", () => {
+  it("sends logged-out visitors to /login", () => {
+    expect(
+      resolveDashboardCtaHref({
+        isAuthenticated: false,
+        isWorkspaceListFetched: false,
+        workspaces: undefined,
+        hasOnboarded: false,
+      }),
+    ).toBe(paths.login());
+  });
+
+  // The bug this hook exists to fix: the CTA used to be `/`, which on the
+  // public marketing host resolves to the page the visitor is already on, so
+  // the click did nothing. It must resolve to a real workspace route.
+  it("sends an onboarded visitor to their workspace, never back to the landing page", () => {
+    const href = resolveDashboardCtaHref(fetched([makeWs("acme")]));
+    expect(href).toBe(paths.workspace("acme").issues());
+    expect(href).not.toBe("/");
+  });
+
+  it("sends an un-onboarded visitor to /onboarding", () => {
+    expect(resolveDashboardCtaHref(fetched([makeWs("acme")], false))).toBe(
+      paths.onboarding(),
+    );
+  });
+
+  it("sends an onboarded visitor with no workspace to /workspaces/new", () => {
+    expect(resolveDashboardCtaHref(fetched([]))).toBe(paths.newWorkspace());
+  });
+
+  it.each([
+    ["the list has not resolved yet", false, undefined],
+    ["the list resolved as undefined", true, undefined],
+  ])("falls back to /issues while %s", (_label, isWorkspaceListFetched, workspaces) => {
+    // /issues is a legacy route the proxy rewrites to the last workspace, so
+    // the button still works during hydration. It must not fall back to `/`,
+    // which is what made the CTA dead in the first place.
+    const href = resolveDashboardCtaHref({
+      isAuthenticated: true,
+      isWorkspaceListFetched,
+      workspaces,
+      hasOnboarded: true,
+    });
+    expect(href).toBe("/issues");
+    expect(href).not.toBe("/");
+  });
+});

--- a/apps/web/features/landing/utils/use-dashboard-cta.ts
+++ b/apps/web/features/landing/utils/use-dashboard-cta.ts
@@ -1,0 +1,68 @@
+"use client";
+
+import { useQuery } from "@tanstack/react-query";
+import { useAuthStore } from "@multica/core/auth";
+import { workspaceListOptions } from "@multica/core/workspace";
+import {
+  paths,
+  resolvePostAuthDestination,
+  useHasOnboarded,
+} from "@multica/core/paths";
+import type { Workspace } from "@multica/core/types";
+
+/**
+ * While the workspace list is in flight the CTA points at `/issues`, which the
+ * proxy rewrites to the last workspace. That keeps the button working during
+ * hydration without hiding or disabling it (which would flicker). A visitor
+ * with no workspace history lands back on the landing page in that window and
+ * can click again once the list resolves.
+ */
+const LOADING_FALLBACK_HREF = "/issues";
+
+export function resolveDashboardCtaHref({
+  isAuthenticated,
+  isWorkspaceListFetched,
+  workspaces,
+  hasOnboarded,
+}: {
+  isAuthenticated: boolean;
+  isWorkspaceListFetched: boolean;
+  workspaces: Workspace[] | undefined;
+  hasOnboarded: boolean;
+}): string {
+  if (!isAuthenticated) return paths.login();
+  if (!isWorkspaceListFetched || !workspaces) return LOADING_FALLBACK_HREF;
+  return resolvePostAuthDestination(workspaces, hasOnboarded);
+}
+
+/**
+ * Destination for the landing "Dashboard" CTA.
+ *
+ * These CTAs used to point at `/` and lean on the proxy bouncing logged-in
+ * visitors from the root path to their workspace. Once `/` stayed public on the
+ * official marketing host, that bounce stopped and the CTA resolved to the page
+ * the visitor was already on — a click with no visible effect. Resolve the real
+ * destination here instead, through the same resolver
+ * `RedirectIfAuthenticated` uses, so "where the dashboard lives" has one source
+ * of truth.
+ *
+ * Shares `workspaceListOptions()`' query key with `RedirectIfAuthenticated`, so
+ * on the landing page the list is typically already in flight or cached and this
+ * adds no request.
+ */
+export function useDashboardCtaHref(): string {
+  const user = useAuthStore((s) => s.user);
+  const hasOnboarded = useHasOnboarded();
+
+  const { data, isFetched } = useQuery({
+    ...workspaceListOptions(),
+    enabled: !!user,
+  });
+
+  return resolveDashboardCtaHref({
+    isAuthenticated: !!user,
+    isWorkspaceListFetched: isFetched,
+    workspaces: data,
+    hasOnboarded,
+  });
+}


### PR DESCRIPTION
## Problem

On `multica.ai`, a logged-in visitor clicking **进入工作台 / Dashboard** gets nothing — no navigation, no error, no console output. Reported in MUL-4779.

The button is not broken. It successfully navigates the visitor to the page they are already on.

All four landing CTAs hard-coded `href="/"`:

| File | Line |
| --- | --- |
| `landing-header.tsx` | 29 |
| `landing-hero.tsx` | 42 |
| `how-it-works-section.tsx` | 44 |
| `landing-footer.tsx` | 67 |

Same `user ? "/" : "/login"` line, copy-pasted four times. None of them knew where the dashboard actually lives — they relied on `proxy.ts` redirecting the root path to `/{lastSlug}/issues`, i.e. the navigation *semantics* were parasitic on another module's *side effect*.

## Why it surfaced now

#5363 (thanks @vicksiyi) fixed #5326 — logged-in users could not browse the public site because the root path bounced them into their workspace. It made `multica.ai/` stay public, which is correct.

Before that, logged-in users with a `last_workspace_slug` cookie were 302'd away server-side and **never reached the landing page at all**, so these four CTAs were unreachable and their brokenness was invisible. (They did work from `/changelog`, `/usecases`, etc., since the proxy only guards `pathname === "/"`.)

**#5363 introduced no bug. It turned a long-standing bad design from unreachable into reachable.**

## Fix

`useDashboardCtaHref()` resolves the real destination via `resolvePostAuthDestination()` — the same resolver `RedirectIfAuthenticated` already uses — so "where the dashboard lives" has one source of truth. All four CTAs now use it, collapsing the duplicated line.

While the workspace list is in flight the CTA falls back to `/issues` (which the proxy rewrites to the last workspace), keeping the button useful during hydration without flicker from hiding/disabling it.

`proxy.ts` and `redirect-if-authenticated.tsx` are **untouched** — #5363's behavior is correct and stays.

## Not reverting #5363

Reverting would restore #5326 for **every** logged-in user (the marketing site becomes unreachable without logging out) — a wider blast radius than the current bug, whose workarounds are plentiful (bookmarks, `/issues`, direct URL, Desktop all work today). It would also not fix the root cause, leaving the same four CTAs to break again the next time root-path routing changes. And since both are `apps/web` frontend changes on the same build/deploy path, a revert saves no time.

## Verification

- `pnpm --filter @multica/web exec vitest run features/landing/utils/use-dashboard-cta.test.ts proxy.test.ts lib/public-host.test.ts` — 33 passed
- `pnpm --filter @multica/web typecheck` — clean
- `eslint` on all changed files — clean
- `proxy.test.ts` passes **unchanged**, proving #5363's behavior did not regress

New tests cover: logged-out → `/login`; onboarded → `/{slug}/issues`; un-onboarded → `/onboarding`; no workspace → `/workspaces/new`; loading → `/issues`. Two assert the href is never `/`, which is the actual defect.

Closes MUL-4794

🤖 Generated with [Claude Code](https://claude.com/claude-code)
