### PR TITLE
MUL-4810: fix issue property migration blockers

### DIFF
--- a/server/internal/handler/workspace_test.go
+++ b/server/internal/handler/workspace_test.go
@@ -209,6 +209,17 @@ VALUES ($1, 123456789, 'multica-ai', 'multica', 3366, 987654321, 'abc123', 15368
 `, wsID); err != nil {
 		t.Fatalf("create pending check suite: %v", err)
 	}
+	var propertyID string
+	if err := testPool.QueryRow(ctx, `
+INSERT INTO issue_property (workspace_id, name, type)
+VALUES ($1, 'Delete cleanup property', 'text')
+RETURNING id
+`, wsID).Scan(&propertyID); err != nil {
+		t.Fatalf("create issue property: %v", err)
+	}
+	t.Cleanup(func() {
+		_, _ = testPool.Exec(context.Background(), `DELETE FROM issue_property WHERE id = $1`, propertyID)
+	})
 
 	w := httptest.NewRecorder()
 	req := newRequest("DELETE", "/api/workspaces/"+wsID, nil)
@@ -233,6 +244,14 @@ VALUES ($1, 123456789, 'multica-ai', 'multica', 3366, 987654321, 'abc123', 15368
 	}
 	if pendingCount != 0 {
 		t.Fatalf("pending check suites were not cleaned up for deleted workspace: %d", pendingCount)
+	}
+
+	var propertyCount int
+	if err := testPool.QueryRow(ctx, `SELECT COUNT(*) FROM issue_property WHERE id = $1`, propertyID).Scan(&propertyCount); err != nil {
+		t.Fatalf("verify issue property cleanup: %v", err)
+	}
+	if propertyCount != 0 {
+		t.Fatalf("issue properties were not cleaned up for deleted workspace: %d", propertyCount)
 	}
 }
 

--- a/server/migrations/191_issue_properties.up.sql
+++ b/server/migrations/191_issue_properties.up.sql
@@ -14,7 +14,7 @@
 
 CREATE TABLE issue_property (
     id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
-    workspace_id UUID NOT NULL REFERENCES workspace(id) ON DELETE CASCADE,
+    workspace_id UUID NOT NULL,
     name TEXT NOT NULL,
     type TEXT NOT NULL CHECK (type IN ('text', 'number', 'select', 'multi_select', 'date', 'checkbox', 'url')),
     description TEXT NOT NULL DEFAULT '',
@@ -25,9 +25,6 @@ CREATE TABLE issue_property (
     created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
     updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
 );
-
-CREATE UNIQUE INDEX idx_issue_property_ws_name ON issue_property (workspace_id, LOWER(name));
-CREATE INDEX idx_issue_property_workspace ON issue_property (workspace_id);
 
 ALTER TABLE issue ADD COLUMN properties JSONB NOT NULL DEFAULT '{}'::jsonb;
 -- NOT VALID + VALIDATE keeps the ACCESS EXCLUSIVE lock instantaneous; the
@@ -41,7 +38,6 @@ ALTER TABLE issue VALIDATE CONSTRAINT issue_properties_is_object;
 ALTER TABLE issue ADD CONSTRAINT issue_properties_size_limit
     CHECK (pg_column_size(properties) <= 16384) NOT VALID;
 ALTER TABLE issue VALIDATE CONSTRAINT issue_properties_size_limit;
--- The GIN index on issue.properties lives in the follow-up migration
--- (192_issue_properties_gin_index): CREATE INDEX CONCURRENTLY cannot share a
--- migration with other statements, and a plain CREATE INDEX would lock writes
--- on the hot issue table for the duration of the build.
+-- All indexes live in follow-up, single-statement migrations because CREATE
+-- INDEX CONCURRENTLY cannot share a migration with other statements. The GIN
+-- index is in 192; the issue_property indexes are in 194 and 195.

--- a/server/migrations/193_issue_property_drop_workspace_fk.down.sql
+++ b/server/migrations/193_issue_property_drop_workspace_fk.down.sql
@@ -1,0 +1,2 @@
+-- Deliberately do not restore the pre-release foreign key. Workspace deletion
+-- remains application-owned across both migration directions.

--- a/server/migrations/193_issue_property_drop_workspace_fk.up.sql
+++ b/server/migrations/193_issue_property_drop_workspace_fk.up.sql
@@ -1,0 +1,5 @@
+-- A short-lived pre-release build created this foreign key in migration 191.
+-- Fresh databases no longer create it; this idempotent cleanup brings databases
+-- that applied the earlier migration back to the application-owned lifecycle.
+ALTER TABLE issue_property
+    DROP CONSTRAINT IF EXISTS issue_property_workspace_id_fkey;

--- a/server/migrations/194_issue_property_workspace_name_index.down.sql
+++ b/server/migrations/194_issue_property_workspace_name_index.down.sql
@@ -1,0 +1,1 @@
+DROP INDEX CONCURRENTLY IF EXISTS idx_issue_property_ws_name;

--- a/server/migrations/194_issue_property_workspace_name_index.up.sql
+++ b/server/migrations/194_issue_property_workspace_name_index.up.sql
@@ -1,0 +1,5 @@
+-- Enforce case-insensitive property-name uniqueness without blocking writes.
+-- Keep this as the migration's only statement: PostgreSQL rejects CREATE INDEX
+-- CONCURRENTLY inside a transaction or multi-command string.
+CREATE UNIQUE INDEX CONCURRENTLY IF NOT EXISTS idx_issue_property_ws_name
+    ON issue_property (workspace_id, LOWER(name));

--- a/server/migrations/195_issue_property_workspace_index.down.sql
+++ b/server/migrations/195_issue_property_workspace_index.down.sql
@@ -1,0 +1,1 @@
+DROP INDEX CONCURRENTLY IF EXISTS idx_issue_property_workspace;

--- a/server/migrations/195_issue_property_workspace_index.up.sql
+++ b/server/migrations/195_issue_property_workspace_index.up.sql
@@ -1,0 +1,5 @@
+-- Support workspace-scoped property listing and counts without blocking writes.
+-- Keep this as the migration's only statement: PostgreSQL rejects CREATE INDEX
+-- CONCURRENTLY inside a transaction or multi-command string.
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_issue_property_workspace
+    ON issue_property (workspace_id);

--- a/server/pkg/db/generated/workspace.sql.go
+++ b/server/pkg/db/generated/workspace.sql.go
@@ -110,16 +110,20 @@ cleared_binding_tokens AS (
 cleared_installations AS (
     DELETE FROM channel_installation WHERE workspace_id = $1
 ),
+cleared_issue_properties AS (
+    DELETE FROM issue_property WHERE workspace_id = $1
+),
 deleted_pending_check_suites AS (
     DELETE FROM github_pending_check_suite WHERE workspace_id = $1
 )
 DELETE FROM workspace WHERE workspace.id = $1
 `
 
-// The channel_* tables (MUL-3515 §4) and resource-label junctions carry NO FK to
-// workspace, so — unlike the CASCADE-backed tables the DELETE below sweeps —
-// they are not cleaned up implicitly. Remove their workspace-owned rows here so
-// they commit or roll back atomically with the workspace row.
+// The channel_* tables (MUL-3515 §4), resource-label junctions, and custom issue
+// property definitions carry NO FK to workspace, so — unlike the CASCADE-backed
+// tables the DELETE below sweeps — they are not cleaned up implicitly. Remove
+// their workspace-owned rows here so they commit or roll back atomically with
+// the workspace row.
 func (q *Queries) DeleteWorkspace(ctx context.Context, id pgtype.UUID) error {
 	_, err := q.db.Exec(ctx, deleteWorkspace, id)
 	return err

--- a/server/pkg/db/queries/workspace.sql
+++ b/server/pkg/db/queries/workspace.sql
@@ -91,10 +91,11 @@ SELECT id FROM workspace WHERE id = $1 FOR UPDATE;
 SELECT id FROM workspace WHERE id = $1 FOR KEY SHARE;
 
 -- name: DeleteWorkspace :exec
--- The channel_* tables (MUL-3515 §4) and resource-label junctions carry NO FK to
--- workspace, so — unlike the CASCADE-backed tables the DELETE below sweeps —
--- they are not cleaned up implicitly. Remove their workspace-owned rows here so
--- they commit or roll back atomically with the workspace row.
+-- The channel_* tables (MUL-3515 §4), resource-label junctions, and custom issue
+-- property definitions carry NO FK to workspace, so — unlike the CASCADE-backed
+-- tables the DELETE below sweeps — they are not cleaned up implicitly. Remove
+-- their workspace-owned rows here so they commit or roll back atomically with
+-- the workspace row.
 WITH ws_installations AS (
     SELECT id FROM channel_installation WHERE workspace_id = $1
 ),
@@ -151,6 +152,9 @@ cleared_binding_tokens AS (
 ),
 cleared_installations AS (
     DELETE FROM channel_installation WHERE workspace_id = $1
+),
+cleared_issue_properties AS (
+    DELETE FROM issue_property WHERE workspace_id = $1
 ),
 deleted_pending_check_suites AS (
     DELETE FROM github_pending_check_suite WHERE workspace_id = $1


### PR DESCRIPTION
## Summary

- remove the workspace foreign key and cascade from the unreleased issue-property table migration
- repair databases that applied the short-lived pre-release migration, then create both table indexes in separate `CREATE INDEX CONCURRENTLY` migrations
- delete issue-property definitions explicitly in the existing workspace teardown transaction and cover the behavior with a regression test

## Validation

- `make migrate-up` on a fresh isolated database (001 through 195)
- simulated an existing database with the old 191 foreign key and indexes; 193 removed the foreign key and 194/195 completed idempotently with both indexes valid/ready
- `go test -race ./internal/handler -run '^(TestDeleteWorkspace_|TestProperty)' -count=1`
- `go test -race ./internal/migrations ./cmd/migrate`
- `go build ./cmd/server ./cmd/migrate`
- `git diff --check`

191 has not shipped in a formal release, so production takes the clean no-foreign-key path. Migration 193 is only the compatibility repair for databases that already applied its pre-release form; its down migration deliberately does not restore the unsafe foreign key.

Related to MUL-4810
