### PR TITLE
MUL-4819 fix(help): stop Help menu crash and hide server-version row from managed users

### DIFF
--- a/packages/views/layout/help-launcher.test.tsx
+++ b/packages/views/layout/help-launcher.test.tsx
@@ -24,14 +24,36 @@ vi.mock("../i18n", () => ({
 // Follows the app-sidebar.test.tsx convention of flattening the Base UI
 // dropdown primitives to plain children so the menu content is always in
 // the DOM, instead of exercising the real portal/open-state interaction.
-vi.mock("@multica/ui/components/ui/dropdown-menu", () => ({
-  DropdownMenu: ({ children }: { children: ReactNode }) => <>{children}</>,
-  DropdownMenuContent: ({ children }: { children: ReactNode }) => <>{children}</>,
-  DropdownMenuItem: ({ children }: { children: ReactNode }) => <>{children}</>,
-  DropdownMenuLabel: ({ children }: { children: ReactNode }) => <div>{children}</div>,
-  DropdownMenuSeparator: () => null,
-  DropdownMenuTrigger: ({ children }: { children: ReactNode }) => <>{children}</>,
-}));
+//
+// The mock deliberately preserves ONE real invariant: DropdownMenuLabel wraps
+// Base UI's Menu.GroupLabel, whose useMenuGroupRootContext() throws when it has
+// no Menu.Group ancestor. A plain-<div> mock silently swallowed that contract,
+// which is exactly how MUL-4819 shipped — a version row rendered outside a
+// DropdownMenuGroup crashed the whole app (no error boundary above the sidebar)
+// the moment the Help menu opened. Mirroring the throw here keeps the guard.
+// The group context lives inside the factory so it survives vi.mock hoisting.
+vi.mock("@multica/ui/components/ui/dropdown-menu", async () => {
+  const { createContext, useContext } = await import("react");
+  const GroupContext = createContext(false);
+  return {
+    DropdownMenu: ({ children }: { children: ReactNode }) => <>{children}</>,
+    DropdownMenuContent: ({ children }: { children: ReactNode }) => <>{children}</>,
+    DropdownMenuItem: ({ children }: { children: ReactNode }) => <>{children}</>,
+    DropdownMenuGroup: ({ children }: { children: ReactNode }) => (
+      <GroupContext.Provider value={true}>{children}</GroupContext.Provider>
+    ),
+    DropdownMenuLabel: ({ children }: { children: ReactNode }) => {
+      if (!useContext(GroupContext)) {
+        throw new Error(
+          "Base UI: MenuGroupRootContext is missing. Menu group parts must be used within <Menu.Group>.",
+        );
+      }
+      return <div>{children}</div>;
+    },
+    DropdownMenuSeparator: () => null,
+    DropdownMenuTrigger: ({ children }: { children: ReactNode }) => <>{children}</>,
+  };
+});
 
 afterEach(() => {
   configStore.getState().setServerVersion("");
@@ -47,5 +69,15 @@ describe("HelpLauncher", () => {
     configStore.getState().setServerVersion("1.2.3");
     render(<HelpLauncher />);
     expect(screen.getByText("Server version 1.2.3")).toBeInTheDocument();
+  });
+
+  // MUL-4819: the version row's DropdownMenuLabel must sit inside a
+  // DropdownMenuGroup. Rendering it bare made Base UI's Menu.GroupLabel throw
+  // on open, unmounting the whole app (black screen, no error) because no error
+  // boundary sits above the sidebar. Rendering here must not throw.
+  it("renders the version row without a missing-group crash", () => {
+    configStore.getState().setServerVersion("9.9.9");
+    expect(() => render(<HelpLauncher />)).not.toThrow();
+    expect(screen.getByText("Server version 9.9.9")).toBeInTheDocument();
   });
 });

--- a/packages/views/layout/help-launcher.tsx
+++ b/packages/views/layout/help-launcher.tsx
@@ -4,6 +4,7 @@ import { ArrowUpRight, BookOpen, CircleHelp, History, MessageCircle } from "luci
 import {
   DropdownMenu,
   DropdownMenuContent,
+  DropdownMenuGroup,
   DropdownMenuItem,
   DropdownMenuLabel,
   DropdownMenuSeparator,
@@ -75,9 +76,16 @@ export function HelpLauncher() {
         {serverVersion && (
           <>
             <DropdownMenuSeparator />
-            <DropdownMenuLabel className="font-normal">
-              {t(($) => $.help.server_version, { version: serverVersion })}
-            </DropdownMenuLabel>
+            {/* DropdownMenuLabel renders Base UI's Menu.GroupLabel, which reads
+                a Menu.Group context and throws if it has no Group ancestor. It
+                must always be wrapped in a DropdownMenuGroup — without it the
+                Help menu crashes the whole app on open (no error boundary sits
+                above the sidebar). */}
+            <DropdownMenuGroup>
+              <DropdownMenuLabel className="font-normal">
+                {t(($) => $.help.server_version, { version: serverVersion })}
+              </DropdownMenuLabel>
+            </DropdownMenuGroup>
           </>
         )}
       </DropdownMenuContent>


### PR DESCRIPTION
Two related fixes for the Help popover's server-version row (MUL-4819).

## 1. Crash: opening Help black-screened the whole app

Clicking **Help** (bottom-left sidebar) crashed the desktop app to a black screen with no error.

**Root cause:** `HelpLauncher` rendered the version row's `DropdownMenuLabel` directly under the popup, with no `DropdownMenuGroup`. `DropdownMenuLabel` is Base UI's `Menu.GroupLabel`, whose `useMenuGroupRootContext()` **throws** when it has no `Menu.Group` ancestor:

```
Base UI: MenuGroupRootContext is missing. Menu group parts must be used within <Menu.Group>.
```

The throw happens during render when the menu opens. The app sidebar sits **outside** the router's `errorElement`, so nothing catches it — React unmounts the whole tree → black screen (dark mode), no error. Every other `DropdownMenuLabel` in the codebase is already wrapped in a `DropdownMenuGroup`; Help was the lone exception.

**Fix:** wrap the row in `DropdownMenuGroup`, and harden `help-launcher.test.tsx` (its mock had flattened the dropdown to plain `<div>`s, dropping the Group/GroupLabel contract — which is how this shipped; the mock now mirrors Base UI's real throw).

## 2. Gating: the version row leaked to managed/online users

The row is meant for **self-hosted operators only**, but managed/online users were seeing it (screenshot in the issue is from `multica-app.copilothub.ai`) — annoying, useless noise for users who can't act on the build.

**Root cause:** `isOfficialCloudDeployment()` matched only the exact host `multica.ai`, so managed deployments on `staging.multica.ai` / `multica-app.copilothub.ai` fell through to the self-hosted path.

**Fix:** gate the row on a new `isManagedCloudDeployment()` that matches Multica-operated domains (`multica.ai`, `copilothub.ai`) **and their subdomains**. Kept deliberately separate from the daemon-setup check (`isOfficialCloudDaemonConfig`), which must stay an exact prod-`multica.ai` match so non-prod managed hosts still emit per-deployment daemon URLs. Gating reads the backend's `MULTICA_APP_URL`/`FRONTEND_ORIGIN`, so previews inherit their backend's managed origin too.

Net result: managed users (any environment) never see the row; self-hosters still do — and even if they do, it no longer crashes.

## Verification

- **Frontend:** reproduced the crash by reverting the wrapper → the hardened test throws the exact Base UI error. With the fix, `help-launcher.test.tsx` (3) + full `packages/views/layout` suite (37) pass; `tsc --noEmit` + `eslint` clean.
- **Backend:** `go test ./internal/handler -run TestGetConfig` passes, including new table cases for `multica.ai`, `app.multica.ai`, `staging.multica.ai`, `multica-app.copilothub.ai`, `copilothub.ai` (all suppressed) and a self-hosted domain (still reported). `go build ./...` clean, `gofmt` clean.

Fixes MUL-4819.
