### PR TITLE
test(desktop): de-flake UpdatesSettingsTab preference-load test

### DIFF
--- a/apps/desktop/src/renderer/src/components/updates-settings-tab.test.tsx
+++ b/apps/desktop/src/renderer/src/components/updates-settings-tab.test.tsx
@@ -85,8 +85,11 @@ describe("UpdatesSettingsTab", () => {
     const toggle = screen.getByRole("switch", {
       name: "Automatic background updates",
     });
-    await waitFor(() => expect(toggle).toBeEnabled());
-    expect(toggle).not.toBeChecked();
+    // The switch renders as <span role="switch">, so jest-dom's toBeEnabled()
+    // treats it as always enabled and does not actually wait for getPreferences
+    // to resolve. Wait on the persisted value being reflected instead, which
+    // deterministically holds until the loaded preference (false) is applied.
+    await waitFor(() => expect(toggle).not.toBeChecked());
 
     fireEvent.click(toggle);
 


### PR DESCRIPTION
## Background

The `frontend` CI job intermittently fails on `apps/desktop` with:

```
FAIL src/renderer/src/components/updates-settings-tab.test.tsx > UpdatesSettingsTab > loads the persisted preference and saves changes from the switch
Error: expect(element).not.toBeChecked()
Received element is checked
```

It surfaced today on an unrelated changelog PR (#5453), but the test has been flaky since it landed in `v0.4.1` (#5380) — it passes locally in isolation and only trips under CI load.

## Root cause

The Switch renders as `<span role="switch">`, not a native form control. jest-dom's `toBeEnabled()` only treats native form elements as disable-able, so:

```ts
await waitFor(() => expect(toggle).toBeEnabled()); // passes immediately — no real wait
expect(toggle).not.toBeChecked();                   // races getPreferences() resolving
```

The `waitFor` is effectively a no-op, so the `not.toBeChecked()` assertion runs against the component's initial `checked=true` state whenever `getPreferences()` hasn't resolved yet. Under CI load that window is hit and the test fails.

## Fix

Wait on the actual observable the test cares about — the persisted preference (`false`) being reflected — so the wait deterministically holds until the loaded value is applied:

```ts
await waitFor(() => expect(toggle).not.toBeChecked());
```

Since `setAutomaticUpdates(false)` and `setPreferencesReady(true)` share one promise chain (`.then` then `.finally`), by the time the switch reads unchecked it is also enabled, so the subsequent click path is unchanged.

## Testing

- `pnpm --filter @multica/desktop exec vitest run src/renderer/src/components/updates-settings-tab.test.tsx` — passed 8/8 consecutive runs.
