### PR TITLE
MUL-4810: codify database migration safety rules

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,6 +36,11 @@ Go backend + monorepo frontend (pnpm workspaces + Turborepo) with shared package
 - `packages/views/` - zero `next/*`, zero `react-router-dom`, use `NavigationAdapter` for routing
 - `apps/web/platform/` - only place for Next.js APIs
 
+### Database Migrations (hard rules)
+
+- Never add database foreign keys or cascading actions. Enforce relationships and perform dependent cleanup explicitly in the application layer, using transactions when the operation must be atomic.
+- Every index created by a migration, including unique indexes and indexes on new tables, must use `CREATE [UNIQUE] INDEX CONCURRENTLY`. Keep each concurrent index build in its own single-statement migration file.
+
 ### Commands
 
 ```bash

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -96,6 +96,13 @@ Worktrees share one PostgreSQL container and get isolated DB names/ports via `.e
 
 CI runs Node 22, Go 1.26.1, and a `pgvector/pgvector:pg17` PostgreSQL service.
 
+## Database and Migration Rules
+
+These are hard requirements for every new or modified database design and production migration:
+
+- Do not add database foreign keys (`FOREIGN KEY` / `REFERENCES`), cascading deletes, or cascading updates. Resolve relationships, validation, and dependent cleanup explicitly in application code. Use an application transaction when cleanup and the parent operation must commit or roll back atomically.
+- Every index created by a migration must use `CREATE INDEX CONCURRENTLY` or `CREATE UNIQUE INDEX CONCURRENTLY`, including indexes on newly created tables. PostgreSQL rejects concurrent index creation inside a transaction or a multi-command string, so keep each concurrent index build in its own single-statement migration file. The repository migration runner executes migration files outside an explicit transaction to support this.
+
 ## Coding Rules
 
 - TypeScript strict mode is enabled; keep types explicit.


### PR DESCRIPTION
## Summary

- add the database hard rules to the concise `AGENTS.md` quick reference
- add the authoritative guidance to `CLAUDE.md`
- require application-owned relationships and cleanup instead of foreign keys/cascades
- require every migration index build, including unique indexes and indexes on new tables, to use a dedicated `CREATE INDEX CONCURRENTLY` migration

## Validation

- `git diff --check`
- manually verified both documents express the same requirements and match the repository migration runner's non-transactional execution model

Docs-only change; no runtime tests were needed.

Related to MUL-4810
