### PR TITLE
MUL-4819 fix(help): hide server-version row from all managed-cloud hosts

### DIFF
--- a/server/internal/handler/config.go
+++ b/server/internal/handler/config.go
@@ -74,10 +74,11 @@ func (h *Handler) GetConfig(w http.ResponseWriter, r *http.Request) {
 	config.CdnSigned = h.CFSigner != nil
 	config.DaemonServerURL, config.DaemonAppURL = daemonSetupURLsFromEnv()
 	config.FeatureFlags = featureflags.EvaluateFrontendPublicFlags(r.Context(), h.FeatureFlags)
-	// Only surface the build version on self-hosted deployments. The managed
-	// cloud is continuously deployed and its users can't choose the build, so
-	// the Help popover's version row would just be noise there (MUL-4108).
-	if !isOfficialCloudDeployment() {
+	// Only surface the build version on self-hosted deployments. Multica's
+	// managed cloud is continuously deployed and its users can't choose the
+	// build, so the Help popover's version row is just noise there — on EVERY
+	// managed host, not only prod multica.ai (MUL-4108, MUL-4819).
+	if !isManagedCloudDeployment() {
 		config.ServerVersion = h.cfg.ServerVersion
 	}
 
@@ -140,13 +141,35 @@ func isOfficialCloudDaemonConfig(appURL string) bool {
 	return urlHostEquals(appURL, "multica.ai")
 }
 
-// isOfficialCloudDeployment reports whether this server is the official Multica
-// Cloud, reusing the same frontend-host signal as the daemon setup (multica.ai).
-// Managed-cloud-only behavior — such as suppressing the Help popover's
+// multicaOperatedDomains are the registrable domains Multica runs its managed
+// cloud on. A frontend host on any of them — or a subdomain such as
+// staging.multica.ai or multica-app.copilothub.ai — is a Multica-operated
+// managed deployment, not a self-hosted one. Third parties cannot host under
+// these domains, so matching them never misfires on a real self-hosted install.
+var multicaOperatedDomains = []string{"multica.ai", "copilothub.ai"}
+
+// isManagedCloudDeployment reports whether this server is a Multica-operated
+// managed deployment (prod, staging, or preview), identified by its frontend
+// host. Managed-cloud-only behavior — such as suppressing the Help popover's
 // server-version row, which only matters to self-hosted operators — is gated on
 // this.
-func isOfficialCloudDeployment() bool {
-	return isOfficialCloudDaemonConfig(resolveFrontendAppURL())
+//
+// Deliberately BROADER than isOfficialCloudDaemonConfig, which matches only the
+// exact prod host multica.ai: the daemon-setup URLs must stay per-deployment on
+// non-prod managed hosts (the hardcoded `multica setup` reaches only
+// api.multica.ai), whereas the version row is noise on EVERY managed host
+// regardless of domain or environment (MUL-4819).
+func isManagedCloudDeployment() bool {
+	host := canonicalURLHost(resolveFrontendAppURL())
+	if host == "" {
+		return false
+	}
+	for _, domain := range multicaOperatedDomains {
+		if host == domain || strings.HasSuffix(host, "."+domain) {
+			return true
+		}
+	}
+	return false
 }
 
 func urlHostEquals(raw, want string) bool {

--- a/server/internal/handler/config_test.go
+++ b/server/internal/handler/config_test.go
@@ -325,39 +325,47 @@ func TestGetConfigExposesServerVersion(t *testing.T) {
 	}
 }
 
-// TestGetConfigOmitsServerVersionOnOfficialCloud verifies the build version is
-// suppressed on the managed cloud (frontend host multica.ai) even when the
-// binary is stamped, while a self-hosted frontend origin still reports it. The
-// managed cloud is continuously deployed, so its users don't need the row.
-func TestGetConfigOmitsServerVersionOnOfficialCloud(t *testing.T) {
+// TestGetConfigOmitsServerVersionOnManagedCloud verifies the build version is
+// suppressed on Multica's managed cloud even when the binary is stamped, while a
+// self-hosted frontend origin still reports it. The managed cloud is
+// continuously deployed, so its users can't act on the row.
+//
+// MUL-4819: suppression must cover EVERY managed host, not just prod
+// multica.ai — the row was leaking to managed users on staging /
+// multica-app.copilothub.ai, which is exactly what this guards.
+func TestGetConfigOmitsServerVersionOnManagedCloud(t *testing.T) {
 	origCfg := testHandler.cfg
 	defer func() { testHandler.cfg = origCfg }()
 	testHandler.cfg.ServerVersion = "1.2.3"
 
 	req := httptest.NewRequest(http.MethodGet, "/api/config", nil)
 
-	// Official cloud: frontend host multica.ai -> version omitted.
-	t.Setenv("MULTICA_APP_URL", "https://multica.ai")
-	t.Setenv("FRONTEND_ORIGIN", "")
-	w := httptest.NewRecorder()
-	testHandler.GetConfig(w, req)
-	var cfg AppConfig
-	if err := json.Unmarshal(w.Body.Bytes(), &cfg); err != nil {
-		t.Fatalf("decode config: %v", err)
+	tests := []struct {
+		name    string
+		appURL  string
+		wantVer string
+	}{
+		{"prod apex", "https://multica.ai", ""},
+		{"prod app subdomain", "https://app.multica.ai", ""},
+		{"staging subdomain", "https://staging.multica.ai", ""},
+		{"managed copilothub app host", "https://multica-app.copilothub.ai", ""},
+		{"copilothub apex", "https://copilothub.ai", ""},
+		{"self-hosted own domain", "https://multica.self-hosted.example", "1.2.3"},
 	}
-	if cfg.ServerVersion != "" {
-		t.Fatalf("server_version: want omitted on official cloud, got %q", cfg.ServerVersion)
-	}
-
-	// Self-hosted: operator's own frontend origin -> version reported.
-	t.Setenv("MULTICA_APP_URL", "https://multica.self-hosted.example")
-	w = httptest.NewRecorder()
-	testHandler.GetConfig(w, req)
-	if err := json.Unmarshal(w.Body.Bytes(), &cfg); err != nil {
-		t.Fatalf("decode config: %v", err)
-	}
-	if cfg.ServerVersion != "1.2.3" {
-		t.Fatalf("server_version: want 1.2.3 on self-hosted, got %q", cfg.ServerVersion)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv("MULTICA_APP_URL", tt.appURL)
+			t.Setenv("FRONTEND_ORIGIN", "")
+			w := httptest.NewRecorder()
+			testHandler.GetConfig(w, req)
+			var cfg AppConfig
+			if err := json.Unmarshal(w.Body.Bytes(), &cfg); err != nil {
+				t.Fatalf("decode config: %v", err)
+			}
+			if cfg.ServerVersion != tt.wantVer {
+				t.Fatalf("server_version for %s: want %q, got %q", tt.appURL, tt.wantVer, cfg.ServerVersion)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
Follow-up to #5458 (merged). That PR shipped the crash fix but landed before this gating change, so the server-version gating never made it into `main` — this PR carries it in.

## Problem

The Help popover's server-version row is meant for **self-hosted operators only**, but managed/online users were seeing it (the report screenshot is from `multica-app.copilothub.ai`) — useless noise for users who can't act on the build.

**Root cause:** `isOfficialCloudDeployment()` matched only the exact host `multica.ai`, so managed deployments on `staging.multica.ai` / `multica-app.copilothub.ai` fell through to the self-hosted path and rendered the row.

## Fix

Gate the row on a new `isManagedCloudDeployment()` that matches Multica-operated domains (`multica.ai`, `copilothub.ai`) **and their subdomains**. Third parties can't host under these domains, so it never misfires on a real self-hosted install.

Kept deliberately separate from the daemon-setup check (`isOfficialCloudDaemonConfig`), which must stay an exact prod-`multica.ai` match so non-prod managed hosts still emit per-deployment daemon URLs (the hardcoded `multica setup` reaches only `api.multica.ai`). The gate reads the backend's `MULTICA_APP_URL`/`FRONTEND_ORIGIN`, so previews inherit their backend's managed origin too.

Net result: managed users (any environment/domain) never see the row; self-hosters still do.

## Verification

`go test ./internal/handler -run TestGetConfig` passes, with new table cases for `multica.ai`, `app.multica.ai`, `staging.multica.ai`, `multica-app.copilothub.ai`, `copilothub.ai` (all suppressed) and a self-hosted domain (still reported). `go build ./...` and `gofmt` clean.

MUL-4819
