### PR TITLE
fix(editor): drop underline mark so pasted rich text stops emitting ++

### DIFF
--- a/packages/views/editor/extensions/index.ts
+++ b/packages/views/editor/extensions/index.ts
@@ -172,6 +172,13 @@ export function createEditorExtensions(
       heading: { levels: [1, 2, 3] },
       link: false,
       codeBlock: false,
+      // Underline has no Markdown representation. Tiptap's extension serializes
+      // the mark as `++text++`, which is not CommonMark or GFM, so ReadonlyContent
+      // (react-markdown + remark-gfm) renders the delimiters literally. Disabling
+      // the extension drops the mark at parse time instead: pasted `<u>` /
+      // `text-decoration: underline` keep their text, and Cmd+U becomes a no-op
+      // rather than a way to produce content the display layer cannot render.
+      underline: false,
       // Disable StarterKit's stock ListItem — its Enter keybind binds only
       // `splitListItem`, which leaves the user stuck inside an empty top-level
       // list item (see list-item.ts). PatchedListItem below restores the

--- a/packages/views/editor/extensions/underline.test.ts
+++ b/packages/views/editor/extensions/underline.test.ts
@@ -1,0 +1,132 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { Editor } from "@tiptap/core";
+import { createEditorExtensions } from ".";
+
+/**
+ * Underline has no Markdown representation. Tiptap's Underline extension
+ * serializes the mark as `++text++`, which neither CommonMark nor GFM defines,
+ * so ReadonlyContent (react-markdown + remark-gfm) renders the delimiters
+ * literally and the user sees `++text++` in a saved comment.
+ *
+ * StarterKit registers Underline by default, and it maps BOTH `<u>` and
+ * `text-decoration: underline` to the mark, so rich-text paste was enough to
+ * produce unrenderable Markdown. These tests pin the mark out of the schema.
+ */
+
+let editor: Editor | null = null;
+
+afterEach(() => {
+  editor?.destroy();
+  editor = null;
+  document.body.innerHTML = "";
+});
+
+function makeProductionEditor(): Editor {
+  const element = document.createElement("div");
+  document.body.appendChild(element);
+
+  return new Editor({
+    element,
+    extensions: createEditorExtensions({
+      placeholder: "",
+      disableMentions: true,
+      enableSlashCommands: false,
+      onUploadFileRef: { current: undefined },
+    }),
+  });
+}
+
+/**
+ * Dispatches a real `paste` event at the editor DOM, which is where
+ * ProseMirror binds its own paste handler. That runs the genuine production
+ * chain — clipboard parse against the editor schema, then the handlePaste
+ * props — rather than a reimplementation of it.
+ *
+ * The path exercised here is the native one: markdownPaste classifies semantic
+ * rich HTML (`<u>`, styled spans) as "native" and declines it, so ProseMirror
+ * parses the HTML against the schema, which is exactly where a mark that no
+ * registered extension claims gets dropped.
+ *
+ * `bubbles: false` keeps ProseMirror's eventBelongsToView check trivially
+ * satisfied; it does not affect its own listener on view.dom.
+ */
+function paste(ed: Editor, text: string, html: string): void {
+  const event = new Event("paste", { bubbles: false, cancelable: true });
+  Object.defineProperty(event, "clipboardData", {
+    value: {
+      files: [],
+      getData: (type: string) =>
+        type === "text/plain" ? text : type === "text/html" ? html : "",
+    },
+  });
+  ed.view.dom.dispatchEvent(event);
+}
+
+describe("underline is not in the editor schema", () => {
+  it("registers no underline mark, so Cmd+U cannot produce one", () => {
+    editor = makeProductionEditor();
+
+    // The mark type backs both the Mod-u shortcut and HTML parsing. Absent
+    // from the schema, neither entry point can create `++text++`.
+    expect(editor.schema.marks.underline).toBeUndefined();
+  });
+});
+
+describe("pasting underlined rich text", () => {
+  it("keeps the text of a pasted <u> tag and writes no ++ delimiters", () => {
+    editor = makeProductionEditor();
+
+    paste(
+      editor,
+      "before underlined after",
+      '<meta charset="utf-8"><p>before <u>underlined</u> after</p>',
+    );
+
+    expect(editor.getText()).toContain("underlined");
+    expect(editor.getMarkdown()).toContain("underlined");
+    expect(editor.getMarkdown()).not.toContain("++");
+  });
+
+  it("keeps the text of a pasted text-decoration: underline span and writes no ++ delimiters", () => {
+    editor = makeProductionEditor();
+
+    paste(
+      editor,
+      "before underlined after",
+      '<meta charset="utf-8"><p>before <span style="text-decoration: underline">underlined</span> after</p>',
+    );
+
+    expect(editor.getText()).toContain("underlined");
+    expect(editor.getMarkdown()).toContain("underlined");
+    expect(editor.getMarkdown()).not.toContain("++");
+  });
+
+  it("preserves sibling formatting when dropping the underline mark", () => {
+    editor = makeProductionEditor();
+
+    paste(
+      editor,
+      "bold underlined",
+      '<meta charset="utf-8"><p><strong>bold</strong> <u>underlined</u></p>',
+    );
+
+    const markdown = editor.getMarkdown();
+    expect(markdown).toContain("**bold**");
+    expect(markdown).toContain("underlined");
+    expect(markdown).not.toContain("++");
+  });
+});
+
+describe("existing content containing ++", () => {
+  it("round-trips literal ++ text unchanged", () => {
+    // Historical comments already contain `++` (both from this bug and from
+    // legitimate text like `g++`). Disabling Underline also removes its
+    // markdown tokenizer, so `++x++` is now plain text — editing and re-saving
+    // such a comment must not rewrite or re-escape it.
+    editor = makeProductionEditor();
+    editor.commands.setContent(editor.markdown!.parse("a ++b++ c"));
+
+    expect(editor.getText()).toBe("a ++b++ c");
+    expect(editor.getMarkdown().trim()).toBe("a ++b++ c");
+  });
+});


### PR DESCRIPTION
## Problem

Pasting rich text into a comment saved Markdown with literal `++` around the pasted text.

StarterKit registers Tiptap's `Underline` extension by default. Its `parseHTML` maps **both** `<u>` and `text-decoration: underline` to an underline mark, and its `renderMarkdown` serializes that mark as `` `++text++` `` — a syntax neither CommonMark nor GFM defines. `ReadonlyContent` renders comments with react-markdown + remark-gfm, which has no rule for `++`, so the delimiters survive to the screen.

Verified at source: `@tiptap/extension-underline@3.27.1` `renderMarkdown` returns `` `++${children}++` ``; `readonly-content.tsx` passes only `remarkGfm` / `remarkMath` / `remarkBreaks`.

## Fix

Set `underline: false` in the shared `StarterKit.configure({...})`.

Disabling the extension is deliberate over filtering `u` out of the rich-HTML paste selector: the mark is also reachable through the extension's own `Mod-u` shortcut, so a paste-only fix would leave Cmd+U producing the same unrenderable Markdown. With the mark absent from the schema, both entry points are closed — ProseMirror drops the unclaimed mark at parse time and keeps the text.

## Scope

This is **shared editor config**. It applies to every `ContentEditor` surface — issue comments, issue descriptions, chat, agent prompts — not just the comment box. Underline had no toolbar control, no `toggleUnderline` caller, and no stylesheet rule; it was reachable only via Cmd+U and paste. Net effect is the removal of a formatting option that could not be represented in the storage format.

One deliberate side effect: removing the extension also removes its `++text++` markdown tokenizer, so existing text containing `++` (this bug's output, or legitimate text like `g++`) now round-trips as literal text instead of being silently reinterpreted as an underline mark. That matches what the display layer already shows. Pinned by a test.

Historical `++` in existing comments is intentionally **not** batch-cleaned — legitimate text can contain `++`, so the mis-clean risk outweighs the benefit.

## Tests

New `packages/views/editor/extensions/underline.test.ts` — 5 tests against the real production extension set:

- `<u>text</u>` paste keeps its text, emits no `++`
- `text-decoration: underline` paste keeps its text, emits no `++`
- sibling formatting (`**bold**`) survives the mark drop
- no `underline` mark in the schema (the guard that makes Cmd+U a no-op)
- literal `++` text round-trips unchanged

Paste tests dispatch a real `paste` event at the editor DOM, so ProseMirror's own handler runs the genuine chain (clipboard parse against the schema, then the `handlePaste` props) instead of a reimplementation of it. All 5 were confirmed to **fail without the fix**, reproducing the reported symptom exactly (`before ++underlined++ after`).

## Verification

- `packages/views` suite: 211 files / 2101 tests pass
- `tsc --noEmit` clean
- `eslint` clean on both changed files
