### PR TITLE
fix(views): stop server version from stretching the help menu (MUL-4828)

### DIFF
--- a/packages/views/layout/help-launcher.tsx
+++ b/packages/views/layout/help-launcher.tsx
@@ -34,7 +34,7 @@ export function HelpLauncher() {
         align="end"
         side="top"
         sideOffset={8}
-        className="min-w-40"
+        className="min-w-40 max-w-56"
       >
         <DropdownMenuItem
           render={
@@ -82,7 +82,7 @@ export function HelpLauncher() {
                 Help menu crashes the whole app on open (no error boundary sits
                 above the sidebar). */}
             <DropdownMenuGroup>
-              <DropdownMenuLabel className="font-normal">
+              <DropdownMenuLabel className="font-normal break-words">
                 {t(($) => $.help.server_version, { version: serverVersion })}
               </DropdownMenuLabel>
             </DropdownMenuGroup>


### PR DESCRIPTION
## Summary

The Help menu (the `?` launcher in the sidebar) showed the server version on a single unbreakable line, e.g. `Server version 2026-07-15_13-37-14-main-66316c261`. Since the popup width is shrink-to-fit with only a `min-w-40`, that long string stretched the entire menu much wider than its short items (Docs / Change log / Discord / Feedback).

This caps the menu width and lets the version wrap instead of widening the popup:

- `packages/views/layout/help-launcher.tsx`
  - `DropdownMenuContent`: `min-w-40` → `min-w-40 max-w-56`. The menu keeps its natural floor when no version is shown and can no longer grow past ~224px.
  - Version `DropdownMenuLabel`: added `break-words` so the long version token wraps within the capped width (and can't overflow for future/longer version formats).

No copy or i18n changes — the `Server version {{version}}` string is untouched.

## Testing

- `pnpm --filter @multica/views exec vitest run layout/help-launcher.test.tsx` — 3/3 pass.
- `eslint packages/views/layout/help-launcher.tsx` — clean.

Layout/wrapping is presentational CSS and isn't asserted in jsdom, so no unit test was added; the existing tests still cover the render + missing-group-crash guard.

MUL-4828
