### PR TITLE
MUL-4812: anchor Inbox deep-links inside the virtualized issue timeline

### DIFF
--- a/e2e/fixtures.ts
+++ b/e2e/fixtures.ts
@@ -171,6 +171,56 @@ export class TestApiClient {
     await this.authedFetch(`/api/issues/${id}`, { method: "DELETE" });
   }
 
+  /**
+   * Seed an inbox notification pointing at `commentId`.
+   *
+   * Inserted directly: the server only creates one when *another* actor
+   * comments on something you subscribe to, which would mean standing up a
+   * second member and an invite flow just to reach the deep-link. The row
+   * shape is what matters to the client, and that is what this writes.
+   */
+  async createInboxComment(issueId: string, commentId: string, title = "E2E inbox") {
+    if (!this.email) throw new Error("Cannot seed inbox before login");
+    const workspaceId = this.workspaceId;
+    if (!workspaceId) throw new Error("Cannot seed inbox before ensureWorkspace");
+
+    const client = new pg.Client(DATABASE_URL);
+    await client.connect();
+    try {
+      const user = await client.query('SELECT id FROM "user" WHERE email = $1', [this.email]);
+      const recipientId = user.rows[0]?.id;
+      if (!recipientId) throw new Error(`No user row for ${this.email}`);
+      await client.query(
+        `
+          INSERT INTO inbox_item
+            (workspace_id, recipient_type, recipient_id, actor_type, actor_id,
+             type, severity, issue_id, title, read, archived, details)
+          VALUES ($1, 'member', $2, 'member', $2, 'new_comment', 'info', $3, $4,
+                  FALSE, FALSE, $5::jsonb)
+        `,
+        [workspaceId, recipientId, issueId, title, JSON.stringify({ comment_id: commentId })],
+      );
+    } finally {
+      await client.end();
+    }
+  }
+
+  async createComment(issueId: string, content: string, opts?: Record<string, unknown>) {
+    const res = await this.authedFetch(`/api/issues/${issueId}/comments`, {
+      body: JSON.stringify({ content, ...opts }),
+      method: "POST",
+    });
+    return res.json();
+  }
+
+  async updateIssue(id: string, patch: Record<string, unknown>) {
+    const res = await this.authedFetch(`/api/issues/${id}`, {
+      body: JSON.stringify(patch),
+      method: "PATCH",
+    });
+    return res.json();
+  }
+
   /** Clean up all issues created during this test. */
   async cleanup() {
     for (const id of this.createdIssueIds) {

--- a/e2e/inbox-deep-link.spec.ts
+++ b/e2e/inbox-deep-link.spec.ts
@@ -1,0 +1,155 @@
+import { expect, test } from "@playwright/test";
+import { createTestApi, loginAsDefault } from "./helpers";
+import type { TestApiClient } from "./fixtures";
+
+// ---------------------------------------------------------------------------
+// MUL-4812 — Inbox deep-link lands on its comment, and STAYS there.
+//
+// These cases cannot live in the jsdom suite: every one of them is a question
+// about real layout (where is the row, did a decoded image push it, how many
+// rows are actually mounted). jsdom reports zero for all of it.
+//
+// The image responses are deliberately delayed. Late-decoding images with no
+// intrinsic size are the whole reason the calibration hook exists — an image
+// that resolves instantly proves nothing, because the anchor would have been
+// right without any calibration at all.
+// ---------------------------------------------------------------------------
+
+/** 1x1 transparent PNG, rendered large via markdown-adjacent CSS width. */
+const PNG_BYTES = Buffer.from(
+  "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNkYPhfDwAChwGA60e6kgAAAABJRU5ErkJggg==",
+  "base64",
+);
+
+const SLOW_IMAGE_URL = "https://e2e.invalid/slow-image.png";
+const IMAGE_DELAY_MS = 1500;
+
+test.describe("Inbox deep-link anchoring", () => {
+  let api: TestApiClient;
+  let workspaceSlug: string;
+
+  test.beforeEach(async ({ page }) => {
+    api = await createTestApi();
+    workspaceSlug = await loginAsDefault(page);
+
+    // Serve the image only after the timeline has certainly rendered, so the
+    // height it adds always lands *after* the anchor.
+    await page.route(SLOW_IMAGE_URL, async (route) => {
+      await new Promise((resolve) => setTimeout(resolve, IMAGE_DELAY_MS));
+      await route.fulfill({ body: PNG_BYTES, contentType: "image/png" });
+    });
+  });
+
+  test.afterEach(async () => {
+    if (api) await api.cleanup();
+  });
+
+  /** True when the element's box sits inside the scroll viewport's box. */
+  async function targetIsInViewport(page: import("@playwright/test").Page, commentId: string) {
+    return page.evaluate((id) => {
+      const el = document.getElementById(`comment-${id}`);
+      const container = document.querySelector("[data-tab-scroll-root]");
+      if (!el || !container) return false;
+      const e = el.getBoundingClientRect();
+      const c = container.getBoundingClientRect();
+      return e.top >= c.top - 4 && e.top < c.bottom;
+    }, commentId);
+  }
+
+  async function seedIssueWithComments(count: number, opts: { imageBeforeTarget?: boolean } = {}) {
+    const issue = await api.createIssue(`Deep link ${Date.now()}`);
+    const ids: string[] = [];
+    for (let i = 0; i < count; i++) {
+      const body =
+        opts.imageBeforeTarget && i === count - 2
+          ? `Comment ${i}\n\n![late](${SLOW_IMAGE_URL})`
+          : `Comment ${i}`;
+      const comment = await api.createComment(issue.id, body);
+      ids.push(comment.id);
+    }
+    return { commentIds: ids, issueId: issue.id };
+  }
+
+  test("lands on the deep-linked comment and highlights it", async ({ page }) => {
+    const { commentIds, issueId } = await seedIssueWithComments(30);
+    const target = commentIds[15]!;
+    await api.createInboxComment(issueId, target);
+
+    await page.goto(`/${workspaceSlug}/inbox`, { waitUntil: "domcontentloaded" });
+
+    await expect(page.locator(`#comment-${target}`)).toBeVisible();
+    expect(await targetIsInViewport(page, target)).toBe(true);
+  });
+
+  // 8a — the case Howard called out: growth ABOVE the target that is not the
+  // target's own row and not inside the timeline at all.
+  test("holds the anchor when a description image above the target loads late", async ({ page }) => {
+    const { commentIds, issueId } = await seedIssueWithComments(30);
+    const target = commentIds[15]!;
+    await api.updateIssue(issueId, {
+      description: `Big picture\n\n![late](${SLOW_IMAGE_URL})`,
+    });
+    await api.createInboxComment(issueId, target);
+
+    await page.goto(`/${workspaceSlug}/inbox`, { waitUntil: "domcontentloaded" });
+    await expect(page.locator(`#comment-${target}`)).toBeVisible();
+
+    // Let the image resolve and the calibration settle.
+    await page.waitForTimeout(IMAGE_DELAY_MS + 1500);
+
+    expect(await targetIsInViewport(page, target)).toBe(true);
+  });
+
+  // 8b — growth in a sibling row above the target inside the virtualized list.
+  test("holds the anchor when the row before the target loads an image late", async ({ page }) => {
+    const { commentIds, issueId } = await seedIssueWithComments(30, { imageBeforeTarget: true });
+    const target = commentIds[29]!;
+    await api.createInboxComment(issueId, target);
+
+    await page.goto(`/${workspaceSlug}/inbox`, { waitUntil: "domcontentloaded" });
+    await expect(page.locator(`#comment-${target}`)).toBeVisible();
+
+    await page.waitForTimeout(IMAGE_DELAY_MS + 1500);
+
+    expect(await targetIsInViewport(page, target)).toBe(true);
+  });
+
+  test("keeps mounted rows proportional to the viewport, not the timeline", async ({ page }) => {
+    // The regression this whole change exists to prevent: a deep-link used to
+    // mount every comment. 60 rows must not produce 60 mounted cards.
+    const { commentIds, issueId } = await seedIssueWithComments(60);
+    const target = commentIds[30]!;
+    await api.createInboxComment(issueId, target);
+
+    await page.goto(`/${workspaceSlug}/inbox`, { waitUntil: "domcontentloaded" });
+    await expect(page.locator(`#comment-${target}`)).toBeVisible();
+
+    const mounted = await page.locator('[id^="comment-"]').count();
+    expect(mounted).toBeLessThan(60);
+  });
+
+  test("does not steal the viewport when a newer notification arrives after the user scrolls", async ({
+    page,
+  }) => {
+    const { commentIds, issueId } = await seedIssueWithComments(30);
+    const target = commentIds[10]!;
+    await api.createInboxComment(issueId, target);
+
+    await page.goto(`/${workspaceSlug}/inbox`, { waitUntil: "domcontentloaded" });
+    await expect(page.locator(`#comment-${target}`)).toBeVisible();
+
+    const container = page.locator("[data-tab-scroll-root]");
+    await container.hover();
+    await page.mouse.wheel(0, 600);
+    await page.waitForTimeout(200);
+    const afterScroll = await container.evaluate((el) => el.scrollTop);
+
+    // A newer notification lands passively for the issue already on screen.
+    const newer = await api.createComment(issueId, "Newer comment");
+    await api.createInboxComment(issueId, newer.id, "Newer");
+    await page.waitForTimeout(2000);
+
+    // The user is reading. Their position is theirs.
+    expect(await container.evaluate((el) => el.scrollTop)).toBe(afterScroll);
+  });
+});

--- a/packages/core/inbox/queries.test.ts
+++ b/packages/core/inbox/queries.test.ts
@@ -25,6 +25,28 @@ function item(overrides: Partial<InboxItem>): InboxItem {
 }
 
 describe("deduplicateInboxItems", () => {
+  // Load-bearing for the issue-detail deep-link anchor (MUL-4812): because the
+  // inbox shows exactly ONE row per issue, the user cannot hand-pick a second
+  // comment for an issue they are already viewing. That is what lets
+  // useCommentAnchorCalibration treat every highlightCommentId change on a
+  // mounted IssueDetail as a passive update and defer to the user's scroll,
+  // with no provenance flag threaded through the props.
+  //
+  // If this ever stops holding — an ungrouped inbox, a per-notification row —
+  // that inference is void and the anchor will start stealing the viewport on
+  // an explicit click. Fail here first.
+  it("collapses every notification for one issue into a single row", () => {
+    const merged = deduplicateInboxItems([
+      item({ created_at: "2026-06-15T08:00:00Z", id: "inbox-a", issue_id: "issue-1" }),
+      item({ created_at: "2026-06-15T09:00:00Z", id: "inbox-b", issue_id: "issue-1" }),
+      item({ created_at: "2026-06-15T10:00:00Z", id: "inbox-c", issue_id: "issue-1" }),
+      item({ created_at: "2026-06-15T08:30:00Z", id: "inbox-d", issue_id: "issue-2" }),
+    ]);
+
+    expect(merged.map((i) => i.issue_id)).toEqual(["issue-1", "issue-2"]);
+    expect(merged.find((i) => i.issue_id === "issue-1")?.id).toBe("inbox-c");
+  });
+
   it("keeps the newest issue row while preserving an older comment anchor", () => {
     const merged = deduplicateInboxItems([
       item({

--- a/packages/views/issues/components/issue-detail.test.tsx
+++ b/packages/views/issues/components/issue-detail.test.tsx
@@ -5,6 +5,7 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import type { Issue, TimelineEntry } from "@multica/core/types";
 import { I18nProvider } from "@multica/core/i18n/react";
 import { useResolvedExpandStore } from "@multica/core/issues/stores/resolved-expand-store";
+import { ScrollRestorationProvider } from "../../platform";
 import enCommon from "../../locales/en/common.json";
 import enIssues from "../../locales/en/issues.json";
 
@@ -351,17 +352,39 @@ vi.mock("@multica/core/issues/stores", async () => ({
 // layout.
 const scrollIntoViewSpy = vi.hoisted(() => vi.fn());
 
+// Observability for the deep-link path. The real Virtuoso needs layout to do
+// anything, so jsdom can only assert the contract we hand it: which index it
+// was told to start at, whether scroll restoration was suppressed, whether a
+// later target change went through the imperative scrollToIndex (rather than a
+// remount), and the props it saw on its FIRST render — `initialTopMostItemIndex`
+// is mount-only, so "was it right on the first frame" is the whole question.
+const virtuoso = vi.hoisted(() => ({
+  firstProps: null as Record<string, unknown> | null,
+  mounts: 0,
+  props: null as Record<string, unknown> | null,
+  scrollToIndex: vi.fn(),
+  reset() {
+    this.firstProps = null;
+    this.props = null;
+    this.mounts = 0;
+    this.scrollToIndex.mockClear();
+  },
+}));
+
 vi.mock("react-virtuoso", () => ({
   Virtuoso: forwardRef(function MockVirtuoso(
-    { data, itemContent }: { data: unknown[]; itemContent: (i: number, item: unknown) => unknown },
+    props: { data: unknown[]; itemContent: (i: number, item: unknown) => unknown },
     ref: any,
   ) {
+    const { data, itemContent } = props;
+    virtuoso.props = props as unknown as Record<string, unknown>;
+    if (!virtuoso.firstProps) virtuoso.firstProps = { ...props };
+    useEffect(() => {
+      virtuoso.mounts += 1;
+    }, []);
     useImperativeHandle(ref, () => ({
-      // Real Virtuoso ref methods are not exercised by tests in this file
-      // since the deep-link cold-path drives the container's scrollTop on the
-      // real DOM node, not Virtuoso's imperative API.
       scrollIntoView: vi.fn(),
-      scrollToIndex: vi.fn(),
+      scrollToIndex: virtuoso.scrollToIndex,
     }));
     return (
       <div data-testid="virtuoso-mock">
@@ -377,6 +400,7 @@ vi.mock("react-virtuoso", () => ({
 // with a spy so the deep-link effect's call can be observed.
 beforeEach(() => {
   scrollIntoViewSpy.mockClear();
+  virtuoso.reset();
   Object.defineProperty(HTMLElement.prototype, "scrollIntoView", {
     configurable: true,
     writable: true,
@@ -1207,10 +1231,9 @@ describe("IssueDetail (shared)", () => {
     it("scrolls to the highlighted comment after both issue and timeline finish loading", async () => {
       renderIssueDetailWithHighlight("comment-2");
 
-      // Wait for the comment row to mount. With initialItemCount in
-      // production, items[0..targetIdx] are force-mounted on first commit;
-      // the mock unconditionally inline-renders every item, so this just
-      // waits for the regular render pass.
+      // Wait for the comment row to mount. In production Virtuoso mounts the
+      // window around initialTopMostItemIndex; the mock inline-renders every
+      // item, so this just waits for the regular render pass.
       await waitFor(() => {
         expect(
           document.getElementById("comment-comment-2"),
@@ -1361,6 +1384,237 @@ describe("IssueDetail (shared)", () => {
           document.getElementById("comment-reply-1")?.className,
         ).toContain("bg-[color-mix(in_srgb,var(--card)_95%,var(--brand)_5%)]");
       });
+    });
+  });
+
+  // MUL-4812: a deep-link no longer force-renders the timeline flat. These
+  // tests pin the contract handed to Virtuoso, because jsdom has no layout and
+  // the landing itself is only observable in the E2E suite.
+  describe("deep-link virtualized anchoring", () => {
+    // comment-1 (head) / comment-2 / comment-3 (tail) as top-level rows.
+    const threeComments: TimelineEntry[] = [
+      ...mockTimeline,
+      {
+        type: "comment",
+        id: "comment-3",
+        actor_type: "member",
+        actor_id: "user-1",
+        content: "Third",
+        parent_id: null,
+        created_at: "2026-01-18T00:00:00Z",
+        updated_at: "2026-01-18T00:00:00Z",
+        comment_type: "comment",
+      } as TimelineEntry,
+    ];
+
+    function renderWithTarget(target: string | undefined, ui = { restoredTop: 0 }) {
+      const queryClient = createTestQueryClient();
+      const adapter = {
+        get: () => (ui.restoredTop ? { height: 0, top: ui.restoredTop } : undefined),
+      };
+      const view = render(
+        <I18nProvider locale="en" resources={TEST_RESOURCES}>
+          <QueryClientProvider client={queryClient}>
+            <ScrollRestorationProvider adapter={adapter}>
+              <IssueDetail issueId="issue-1" highlightCommentId={target} />
+            </ScrollRestorationProvider>
+          </QueryClientProvider>
+        </I18nProvider>,
+      );
+      const rerenderWithTarget = (next: string | undefined) =>
+        view.rerender(
+          <I18nProvider locale="en" resources={TEST_RESOURCES}>
+            <QueryClientProvider client={queryClient}>
+              <ScrollRestorationProvider adapter={adapter}>
+                <IssueDetail issueId="issue-1" highlightCommentId={next} />
+              </ScrollRestorationProvider>
+            </QueryClientProvider>
+          </I18nProvider>,
+        );
+      return { ...view, rerenderWithTarget };
+    }
+
+    // index 0 matters on its own: upstream treats a default-positioned
+    // {index: 0} as "no initial scroll", which is only correct because our
+    // offset makes it non-default. A target at the head must still anchor.
+    it.each([
+      ["comment-1", 0],
+      ["comment-2", 1],
+      ["comment-3", 2],
+    ])("anchors the first frame on %s (index %i)", async (target, index) => {
+      mockApiObj.listTimeline.mockResolvedValue(threeComments);
+      renderWithTarget(target);
+
+      await waitFor(() => expect(virtuoso.firstProps).not.toBeNull());
+      // First frame, not a later correction: initialTopMostItemIndex is
+      // mount-only, so anything landed afterwards would be too late.
+      expect(virtuoso.firstProps?.initialTopMostItemIndex).toEqual({
+        align: "start",
+        index,
+        offset: -16,
+      });
+      // The whole point of the change: still virtualized, never the flat path.
+      expect(screen.getByTestId("virtuoso-mock")).toBeInTheDocument();
+    });
+
+    it("does not anchor when there is no deep-link target", async () => {
+      mockApiObj.listTimeline.mockResolvedValue(threeComments);
+      renderWithTarget(undefined);
+
+      await waitFor(() => expect(virtuoso.firstProps).not.toBeNull());
+      expect(virtuoso.firstProps?.initialTopMostItemIndex).toBeUndefined();
+    });
+
+    it("expands a resolved thread on the first frame so the anchor index is already correct", async () => {
+      // comment-3 is a resolved root; the target is a reply folded inside it.
+      // Pre-expansion has to be derived during render — if it were an effect,
+      // Virtuoso would have mounted against the folded index and stayed there.
+      mockApiObj.listTimeline.mockResolvedValue([
+        ...mockTimeline,
+        {
+          type: "comment",
+          id: "comment-3",
+          actor_type: "member",
+          actor_id: "user-1",
+          content: "Resolved root",
+          parent_id: null,
+          created_at: "2026-01-18T00:00:00Z",
+          updated_at: "2026-01-18T00:00:00Z",
+          comment_type: "comment",
+          resolved_at: "2026-01-19T00:00:00Z",
+        } as TimelineEntry,
+        {
+          type: "comment",
+          id: "reply-1",
+          actor_type: "member",
+          actor_id: "user-1",
+          content: "Reply inside resolved thread",
+          parent_id: "comment-3",
+          created_at: "2026-01-18T01:00:00Z",
+          updated_at: "2026-01-18T01:00:00Z",
+          comment_type: "comment",
+        } as TimelineEntry,
+      ]);
+      renderWithTarget("reply-1");
+
+      await waitFor(() => expect(virtuoso.firstProps).not.toBeNull());
+      expect(virtuoso.firstProps?.initialTopMostItemIndex).toEqual({
+        align: "start",
+        index: 2,
+        offset: -16,
+      });
+      // Derived, not folded-then-expanded: the row is a real comment card on
+      // the very first frame Virtuoso saw, never a resolved bar.
+      const firstData = virtuoso.firstProps?.data as Array<{ kind: string; id: string }>;
+      expect(firstData[2]).toMatchObject({ id: "comment-3", kind: "comment" });
+    });
+
+    it("re-anchors through scrollToIndex without remounting when a passive inbox update swaps the target", async () => {
+      mockApiObj.listTimeline.mockResolvedValue(threeComments);
+      const { rerenderWithTarget } = renderWithTarget("comment-1");
+      await waitFor(() => expect(virtuoso.mounts).toBe(1));
+
+      rerenderWithTarget("comment-3");
+
+      await waitFor(() =>
+        expect(virtuoso.scrollToIndex).toHaveBeenCalledWith({
+          align: "start",
+          index: 2,
+          offset: -16,
+        }),
+      );
+      // The detail pane must survive the swap: a remount would flash a
+      // skeleton and re-pay the mount cost this work exists to remove.
+      expect(virtuoso.mounts).toBe(1);
+    });
+
+    it("leaves the reading position alone when the target is swapped after the user scrolled", async () => {
+      mockApiObj.listTimeline.mockResolvedValue(threeComments);
+      const { rerenderWithTarget } = renderWithTarget("comment-1");
+      await waitFor(() => expect(virtuoso.mounts).toBe(1));
+
+      const container = document.querySelector("[data-tab-scroll-root]")!;
+      fireEvent.wheel(container);
+
+      rerenderWithTarget("comment-3");
+
+      // Passive swap + a user who is already reading: the newer notification
+      // does not get to take the viewport.
+      await waitFor(() => expect(virtuoso.props?.data).toBeDefined());
+      expect(virtuoso.scrollToIndex).not.toHaveBeenCalled();
+    });
+
+    it("still renders flat while in-page find is open, deep-link or not", async () => {
+      // find needs every comment in the DOM to walk and match, so it keeps the
+      // flat path. That boundary is the one thing this change must not move.
+      // The hook gates on getClientRects(), which jsdom always reports empty.
+      const rects = vi
+        .spyOn(HTMLElement.prototype, "getClientRects")
+        .mockReturnValue({ length: 1 } as unknown as DOMRectList);
+      mockApiObj.listTimeline.mockResolvedValue(threeComments);
+      renderWithTarget("comment-1");
+      await waitFor(() => expect(virtuoso.mounts).toBe(1));
+
+      // The find chord is primary+F; primary is Meta on macOS and Control
+      // elsewhere. Fire both — exactly one matches on any given platform.
+      fireEvent.keyDown(document, { ctrlKey: true, key: "f" });
+      fireEvent.keyDown(document, { key: "f", metaKey: true });
+
+      await waitFor(() =>
+        expect(screen.queryByTestId("virtuoso-mock")).not.toBeInTheDocument(),
+      );
+      rects.mockRestore();
+    });
+  });
+
+  describe("deep-link vs scroll restoration", () => {
+    let scrollTopWrites: number[] = [];
+
+    beforeEach(() => {
+      scrollTopWrites = [];
+      Object.defineProperty(HTMLElement.prototype, "scrollTop", {
+        configurable: true,
+        get(this: HTMLElement & { __top?: number }) {
+          return this.__top ?? 0;
+        },
+        set(this: HTMLElement & { __top?: number }, value: number) {
+          this.__top = value;
+          scrollTopWrites.push(value);
+        },
+      });
+    });
+
+    function renderWithRestore(target: string | undefined) {
+      const queryClient = createTestQueryClient();
+      const adapter = { get: () => ({ height: 0, top: 500 }) };
+      return render(
+        <I18nProvider locale="en" resources={TEST_RESOURCES}>
+          <QueryClientProvider client={queryClient}>
+            <ScrollRestorationProvider adapter={adapter}>
+              <IssueDetail issueId="issue-1" highlightCommentId={target} />
+            </ScrollRestorationProvider>
+          </QueryClientProvider>
+        </I18nProvider>,
+      );
+    }
+
+    it("restores the saved offset through both write paths when browsing", async () => {
+      renderWithRestore(undefined);
+      await waitFor(() => expect(virtuoso.firstProps).not.toBeNull());
+
+      expect(virtuoso.firstProps?.initialScrollTop).toBe(500);
+      expect(scrollTopWrites).toContain(500);
+    });
+
+    it("suppresses both restoration write paths for a deep-link", async () => {
+      renderWithRestore("comment-2");
+      await waitFor(() => expect(virtuoso.firstProps).not.toBeNull());
+
+      // Write path 1: Virtuoso's own initial position.
+      expect(virtuoso.firstProps?.initialScrollTop).toBeUndefined();
+      // Write path 2: the ref-attach write. Both have to stand down, or the
+      // restored offset races the anchor and the user lands in the wrong place.
+      expect(scrollTopWrites).not.toContain(500);
     });
   });
 

--- a/packages/views/issues/components/issue-detail.tsx
+++ b/packages/views/issues/components/issue-detail.tsx
@@ -1,7 +1,11 @@
 "use client";
 
 import { useState, useEffect, useCallback, useMemo, useRef, Fragment } from "react";
-import { Virtuoso, type VirtuosoHandle } from "react-virtuoso";
+import {
+  Virtuoso,
+  type FlatIndexLocationWithAlign,
+  type VirtuosoHandle,
+} from "react-virtuoso";
 import { useDefaultLayout, usePanelRef } from "react-resizable-panels";
 import { AppLink } from "../../navigation";
 import { useNavigation } from "../../navigation";
@@ -101,6 +105,7 @@ import { matchesPinyin } from "../../editor/extensions/pinyin-match";
 import { useT } from "../../i18n";
 import { useIssueDetailScrollRestore } from "../hooks/use-issue-detail-scroll-restore";
 import { useInPageFind } from "../hooks/use-in-page-find";
+import { useCommentAnchorCalibration } from "../hooks/use-comment-anchor-calibration";
 import { FindBar } from "./find-bar";
 import {
   AnimatedRightSidebar,
@@ -300,6 +305,12 @@ function formatTokenCount(n: number): string {
 // Stable reference for threads with no replies. Inline `[]` would create a
 // new array on every render and bust React.memo on CommentCard / ResolvedThreadBar.
 const EMPTY_REPLIES: TimelineEntry[] = [];
+
+/**
+ * Gap left above a deep-linked comment's header, so it reads as "in the page"
+ * rather than jammed against the viewport edge.
+ */
+const DEEP_LINK_TOP_GAP_PX = 16;
 
 // ---------------------------------------------------------------------------
 // Sidebar progressive disclosure
@@ -787,17 +798,30 @@ export function IssueDetail({ issueId, onDelete, onDone, defaultSidebarOpen = tr
   // Virtuoso prop would never receive the element. Callback ref + state fixes
   // that: setState triggers the re-render that hands Virtuoso the element.
   const [scrollContainerEl, setScrollContainerEl] = useState<HTMLDivElement | null>(null);
+  const [contentWrapperEl, setContentWrapperEl] = useState<HTMLDivElement | null>(null);
   // Pull-based scroll restoration (MUL-4741): the platform serves the offset
   // captured when this route was last left. The ref-attach assignment covers
-  // the flat render modes (real heights at commit); the virtualized browsing
-  // mode feeds the offset into Virtuoso's initialScrollTop below so the
-  // list's first render already materializes the rows around it.
+  // the flat find mode (real heights at commit); the virtualized mode feeds the
+  // offset into Virtuoso's initialScrollTop below so the list's first render
+  // already materializes the rows around it.
   const restoredScrollTop = useRestoredScrollOffset("main");
   const restoreScrollRef = useRestoredScrollRef("main");
+  // An inbox deep-link outranks scroll restoration: the user asked for a
+  // specific comment, not for wherever this tab was left. Restoration has three
+  // write paths and all three must stand down, or they race the anchor:
+  //   1. `initialScrollTop` on Virtuoso (suppressed where the prop is passed);
+  //   2. this ref-attach write;
+  //   3. `useIssueDetailScrollRestore` below (already gated on the same signal).
+  // Read through a ref rather than closing over `highlightCommentId`: a ref
+  // callback whose identity changes makes React detach (null) and re-attach it,
+  // which would null out `scrollContainerEl`, flash the skeleton, and remount
+  // Virtuoso on every inbox target change — the exact remount this work removes.
+  const suppressScrollRestoreRef = useRef(false);
+  suppressScrollRestoreRef.current = !!highlightCommentId;
   const attachScrollContainer = useCallback(
     (el: HTMLDivElement | null) => {
       setScrollContainerEl(el);
-      restoreScrollRef(el);
+      if (!suppressScrollRestoreRef.current) restoreScrollRef(el);
     },
     [restoreScrollRef],
   );
@@ -811,7 +835,20 @@ export function IssueDetail({ issueId, onDelete, onDone, defaultSidebarOpen = tr
   // all-comments commands can drive it from outside this page.
   const expandedResolved = useResolvedExpandStore(selectExpandedResolved(id));
   const setResolvedExpanded = useResolvedExpandStore((s) => s.setExpanded);
+  // Thread roots the user folded back by hand. The deep-link auto-expansion
+  // below is derived every render, so without this the user could never
+  // collapse the target's thread — the derivation would re-open it on the next
+  // render. An explicit collapse is the user overriding us; it wins.
+  const [userCollapsedRoots, setUserCollapsedRoots] = useState<Set<string>>(() => new Set());
   const toggleResolvedExpand = useCallback((commentId: string, expand: boolean) => {
+    if (!expand) {
+      setUserCollapsedRoots((prev) => {
+        if (prev.has(commentId)) return prev;
+        const next = new Set(prev);
+        next.add(commentId);
+        return next;
+      });
+    }
     setResolvedExpanded(id, commentId, expand);
     // On collapse the thread shrinks and the viewport would jump to whatever was
     // below; pull the just-folded thread back into view with the smallest
@@ -876,7 +913,6 @@ export function IssueDetail({ issueId, onDelete, onDone, defaultSidebarOpen = tr
       return next;
     });
   }, []);
-  const didHighlightRef = useRef<string | null>(null);
 
   // Issue data from TQ — uses detail query, seeded from list cache if available.
   // Only seed when description is present; list API omits it, and ContentEditor
@@ -1043,13 +1079,80 @@ export function IssueDetail({ issueId, onDelete, onDone, defaultSidebarOpen = tr
     return { threadReplies, groups };
   }, [timeline]);
 
+  // Map of reply-comment id → root-comment id, so a deep-link to a reply
+  // (which lives inside a CommentCard, not in the flat items array) can fall
+  // back to scrolling the root thread into view. Without this, an inbox
+  // notification on a reply would land at items[-1] and short-circuit.
+  const replyToRoot = useMemo(() => {
+    const map = new Map<string, string>();
+    for (const [rootId, replies] of timelineView.threadReplies) {
+      for (const reply of replies) {
+        map.set(reply.id, rootId);
+      }
+    }
+    return map;
+  }, [timelineView.threadReplies]);
+
+  const rootEntryById = useMemo(() => {
+    const map = new Map<string, TimelineEntry>();
+    for (const group of timelineView.groups) {
+      if (group.type === "comment") map.set(group.entries[0]!.id, group.entries[0]!);
+    }
+    return map;
+  }, [timelineView.groups]);
+
+  // The thread root that has to be expanded for the deep-link target to exist
+  // in `items` at all.
+  //
+  // Derived during render, deliberately NOT an effect writing the store: the
+  // flat index feeds Virtuoso's `initialTopMostItemIndex`, which is read once
+  // at mount. Expanding from an effect lands a render too late — Virtuoso has
+  // already anchored on the pre-expansion index and will not re-read the prop.
+  const autoExpandRootId = useMemo(() => {
+    if (!highlightCommentId) return null;
+    const rootId = replyToRoot.get(highlightCommentId);
+    // Only a reply can be hidden inside a thread; a root comment always has a
+    // row of its own (a folded resolved root renders as its bar, which carries
+    // the same anchor id).
+    if (!rootId || rootId === highlightCommentId) return null;
+    if (expandedResolved.has(rootId) || userCollapsedRoots.has(rootId)) return null;
+    const rootEntry = rootEntryById.get(rootId);
+    if (!rootEntry) return null;
+    // Root resolved → the whole thread is folded behind a bar.
+    if (rootEntry.resolved_at) return rootId;
+    // A reply is the resolution → the other replies fold around it; expand only
+    // when the target is one of those folded ones.
+    const resolution = deriveThreadResolution(
+      rootEntry,
+      timelineView.threadReplies.get(rootId) ?? EMPTY_REPLIES,
+    );
+    if (resolution.kind === "reply" && resolution.resolutionId !== highlightCommentId) {
+      return rootId;
+    }
+    return null;
+  }, [
+    highlightCommentId,
+    replyToRoot,
+    expandedResolved,
+    userCollapsedRoots,
+    rootEntryById,
+    timelineView.threadReplies,
+  ]);
+
+  const effectiveExpandedResolved = useMemo(() => {
+    if (!autoExpandRootId) return expandedResolved;
+    const next = new Set(expandedResolved);
+    next.add(autoExpandRootId);
+    return next;
+  }, [expandedResolved, autoExpandRootId]);
+
   // Flat array consumed by <Virtuoso>. Recomputed when timelineView.groups
-  // changes (timeline events) or expandedResolved flips (user toggles a
-  // resolved thread). Kept in a useMemo so Virtuoso's data identity is stable
-  // across unrelated re-renders.
+  // changes (timeline events) or the effective expansion flips (user toggles a
+  // resolved thread, or a deep-link target forces its thread open). Kept in a
+  // useMemo so Virtuoso's data identity is stable across unrelated re-renders.
   const items = useMemo<TimelineItem[]>(
-    () => flattenGroups(timelineView.groups, expandedResolved),
-    [timelineView.groups, expandedResolved],
+    () => flattenGroups(timelineView.groups, effectiveExpandedResolved),
+    [timelineView.groups, effectiveExpandedResolved],
   );
 
   // In-page find (Cmd/Ctrl+F). `items.length` is the content signal that
@@ -1077,20 +1180,6 @@ export function IssueDetail({ issueId, onDelete, onDone, defaultSidebarOpen = tr
     return null;
   }, [timelineView.groups]);
 
-  // Map of reply-comment id → root-comment id, so a deep-link to a reply
-  // (which lives inside a CommentCard, not in the flat items array) can fall
-  // back to scrolling the root thread into view. Without this, an inbox
-  // notification on a reply would land at items[-1] and short-circuit.
-  const replyToRoot = useMemo(() => {
-    const map = new Map<string, string>();
-    for (const [rootId, replies] of timelineView.threadReplies) {
-      for (const reply of replies) {
-        map.set(reply.id, rootId);
-      }
-    }
-    return map;
-  }, [timelineView.threadReplies]);
-
   // Deep-link target index in the flat items array. For root comments this is
   // a direct findIndex hit; for reply ids we look up the enclosing root.
   const targetIdx = useMemo(() => {
@@ -1101,6 +1190,22 @@ export function IssueDetail({ issueId, onDelete, onDone, defaultSidebarOpen = tr
     if (!rootId) return -1;
     return items.findIndex((it) => it.id === rootId);
   }, [items, highlightCommentId, replyToRoot]);
+
+  // First-frame anchor for an inbox deep-link. `align: "start"` plus a small
+  // negative offset is what puts the target's header just below the top edge
+  // with breathing room, rather than centring it — a long comment centred by
+  // its own box pushes its opening lines off-screen, which is the one thing a
+  // reader arriving from a notification needs to see.
+  //
+  // Virtuoso reads this once, at mount. Every later target change goes through
+  // scrollToIndex inside useCommentAnchorCalibration.
+  const deepLinkAnchor = useMemo<FlatIndexLocationWithAlign | undefined>(
+    () =>
+      targetIdx >= 0
+        ? { align: "start", index: targetIdx, offset: -DEEP_LINK_TOP_GAP_PX }
+        : undefined,
+    [targetIdx],
+  );
 
   // Quick-jump minimap rail: one tick per comment thread (folded resolved
   // bars included), activity groups skipped. Derived from the same flat
@@ -1115,9 +1220,9 @@ export function IssueDetail({ issueId, onDelete, onDone, defaultSidebarOpen = tr
     [items],
   );
 
-  // When the timeline renders flat (deep-link or in-page find), there is no
-  // Virtuoso instance — minimap jumps drive the scroll container directly.
-  const isFlatTimeline = !!highlightCommentId || find.open;
+  // When the timeline renders flat (in-page find only), there is no Virtuoso
+  // instance — minimap jumps drive the scroll container directly.
+  const isFlatTimeline = find.open;
   const virtuosoRef = useRef<VirtuosoHandle>(null);
   const jumpFlashTimerRef = useRef<number | null>(null);
   useEffect(
@@ -1226,90 +1331,23 @@ export function IssueDetail({ issueId, onDelete, onDone, defaultSidebarOpen = tr
 
   const loading = issueLoading;
 
-  // Deep-link landing. Semantically equivalent to navigating to
-  // `#comment-${id}`: find the element with that id, scrollIntoView it.
-  // When `highlightCommentId` is set the timeline below renders flat (no
-  // virtualization), so every comment id is in the DOM by the time this
-  // effect runs after commit.
+  // Deep-link tint. Landing the target is no longer this effect's job: the
+  // first frame is anchored by Virtuoso's `initialTopMostItemIndex` below, and
+  // `useCommentAnchorCalibration` holds it there while late content (images
+  // above the target, mermaid, streamed replies) settles. The thread expansion
+  // a reply target may need is derived during render — see `autoExpandRootId`.
   //
-  // For a reply inside a folded resolved thread, the reply is not in items
-  // (only the resolved-bar root is). Auto-expand the thread first; the
-  // effect re-runs once items re-flatten.
-  //
-  // `scrollContainerEl` is in deps because the component early-returns a
-  // loading skeleton while the issue query is pending. The scroll-container
-  // ref populates only on the post-loading render, so it's the signal that
-  // the timeline (and the deep-link target id) has actually rendered.
+  // The old implementation force-rendered the whole timeline flat and re-centred
+  // across ~30 frames; both are gone. Never reintroduce native scrollIntoView
+  // here: it is spec'd to scroll EVERY scrollable ancestor, which shoved the
+  // desktop shell's `overflow:hidden` wrapper off the top with no scrollbar to
+  // recover (#3929). Corrections stay scoped to the scroll container.
   useEffect(() => {
-    if (!highlightCommentId || items.length === 0) return;
-    if (didHighlightRef.current === highlightCommentId) return;
-
-    const rootId = replyToRoot.get(highlightCommentId);
-    if (rootId && rootId !== highlightCommentId) {
-      // Root resolved → the whole thread is a folded bar.
-      if (items[targetIdx]?.kind === "resolved-bar") {
-        toggleResolvedExpand(rootId, true);
-        return;
-      }
-      // A reply is the resolution → the other replies fold behind the
-      // "N comments" bar; expand if the target is one of those folded replies.
-      const rootItem = items[targetIdx];
-      if (rootItem?.kind === "comment" && !expandedResolved.has(rootId)) {
-        const resolution = deriveThreadResolution(
-          rootItem.entry,
-          timelineView.threadReplies.get(rootId) ?? EMPTY_REPLIES,
-        );
-        if (resolution.kind === "reply" && resolution.resolutionId !== highlightCommentId) {
-          toggleResolvedExpand(rootId, true);
-          return;
-        }
-      }
-    }
-
-    const el = document.getElementById(`comment-${highlightCommentId}`);
-    const container = scrollContainerEl;
-    if (!el || !container) return;
-
-    didHighlightRef.current = highlightCommentId;
-
-    // Center the target comment WITHIN its own scroll container by driving the
-    // container's scrollTop directly — never native scrollIntoView. Native
-    // scrollIntoView is spec'd to scroll EVERY scrollable ancestor: on a cold
-    // mount where the timeline is still growing (streaming agent), the inner
-    // scroller can't satisfy centering on its own, so the scroll propagates up
-    // and moves the desktop shell's `overflow:hidden` wrapper — shoving the
-    // whole page, header included, off the top with no scrollbar to recover,
-    // until a resize reflows it (#3929). Scoping the scroll to `container`
-    // keeps it contained; re-centering across frames lands the comment
-    // precisely once async heights (markdown, code highlight, streamed replies)
-    // settle, instead of leaning on the ancestor scroll the way native did.
-    let rafId = 0;
-    let frames = 0;
-    let last = -1;
-    const center = () => {
-      const c = container.getBoundingClientRect();
-      const e = el.getBoundingClientRect();
-      const target = Math.max(
-        0,
-        container.scrollTop + (e.top - c.top) - (container.clientHeight - e.height) / 2,
-      );
-      container.scrollTop = target;
-      // Content is still laying out → the centered offset keeps shifting; keep
-      // re-centering until it stabilizes (within 1px) or we hit ~0.5s of frames.
-      if (Math.abs(target - last) > 1 && ++frames < 30) {
-        last = target;
-        rafId = requestAnimationFrame(center);
-      }
-    };
-    rafId = requestAnimationFrame(center);
-
+    if (!highlightCommentId) return;
     setHighlightedId(highlightCommentId);
     const fade = window.setTimeout(() => setHighlightedId(null), 2500);
-    return () => {
-      cancelAnimationFrame(rafId);
-      clearTimeout(fade);
-    };
-  }, [highlightCommentId, items, targetIdx, scrollContainerEl, replyToRoot, expandedResolved, timelineView, toggleResolvedExpand]);
+    return () => clearTimeout(fade);
+  }, [highlightCommentId]);
 
   const descEditorRef = useRef<ContentEditorRef>(null);
   // Keep the description editor mounted from the start. Unlike the empty
@@ -1471,6 +1509,20 @@ export function IssueDetail({ issueId, onDelete, onDone, defaultSidebarOpen = tr
     scrollContainerEl,
     ready: !!issue && !loading && !timelineLoading,
     disabled: !!highlightCommentId,
+  });
+
+  // Holds the deep-linked comment at the top of the viewport while late
+  // content settles, and re-anchors when a passive inbox update swaps the
+  // target — unless the user has already scrolled, in which case their
+  // reading position wins. Disabled in flat find mode, which owns the scroll.
+  useCommentAnchorCalibration({
+    targetCommentId: highlightCommentId ?? null,
+    targetIndex: targetIdx,
+    scrollContainerEl,
+    contentWrapperEl,
+    virtuosoRef,
+    topGap: DEEP_LINK_TOP_GAP_PX,
+    enabled: !isFlatTimeline,
   });
 
   if (loading) {
@@ -1903,7 +1955,7 @@ export function IssueDetail({ issueId, onDelete, onDone, defaultSidebarOpen = tr
             onToggleReaction={handleToggleReaction}
             onResolveToggle={handleResolveToggle}
             onCollapseResolved={isResolved ? () => toggleResolvedExpand(item.id, false) : undefined}
-            expandedResolvedIds={expandedResolved}
+            expandedResolvedIds={effectiveExpandedResolved}
             onResolvedExpandChange={toggleResolvedExpand}
             highlightedCommentId={highlightedId}
           />
@@ -2077,7 +2129,13 @@ export function IssueDetail({ issueId, onDelete, onDone, defaultSidebarOpen = tr
           data-tab-scroll-root
           className="relative flex-1 overflow-y-auto [scrollbar-gutter:stable_both-edges]"
         >
-        <div className="mx-auto w-full max-w-4xl px-8 py-8">
+        {/* Auto-height content column. The scroll container above is a
+            fixed-height viewport whose border-box never changes, so it is
+            useless to a ResizeObserver; this element is the one that actually
+            grows when a description image, the sub-issues block, or a comment
+            lands late. useCommentAnchorCalibration observes it to know the
+            deep-link target may have been pushed. */}
+        <div ref={setContentWrapperEl} className="mx-auto w-full max-w-4xl px-8 py-8">
           {titleLazy.active && (
             <div className={titleLazy.ready ? undefined : "hidden"}>
               <TitleEditor
@@ -2369,25 +2427,21 @@ export function IssueDetail({ issueId, onDelete, onDone, defaultSidebarOpen = tr
               <TimelineSkeleton />
             ) : (
               // Two render modes:
-              //   - `highlightCommentId` set (came from inbox deep-link) →
-              //     render flat. Every comment mounts, every height is real,
-              //     the target id is in the DOM the instant the useEffect
-              //     above runs `scrollIntoView`. No virtualization estimate
-              //     errors, no spacer reflow drift. Pays cold-mount cost
-              //     proportional to items.length (markdown + lowlight per
-              //     comment), which is acceptable in the deep-link case —
-              //     the user has explicit intent to land on a specific item.
-              //   - `find.open` (in-page Cmd/Ctrl+F) → also render flat, so
-              //     every comment is in the DOM for the find walk to match
-              //     and highlight. Same explicit-intent cold-mount trade-off.
-              //   - otherwise → Virtuoso. Browsing mode, virtualization
-              //     wins on first-paint perf for long timelines.
-              //
-              // The split is deliberate: virtualization and "land precisely
-              // on a target" have fundamentally opposed contracts (estimated
-              // heights vs real heights). Trying to satisfy both in one
-              // path is what produced the bug history this PR closes.
-              !highlightCommentId && !find.open ? (
+              //   - `find.open` (in-page Cmd/Ctrl+F) → render flat, so every
+              //     comment is in the DOM for the find walk to match and
+              //     highlight. Pays a cold-mount cost proportional to
+              //     items.length, which is the trade-off for an explicit
+              //     "search the whole page" intent.
+              //   - otherwise → Virtuoso, including inbox deep-links. A
+              //     deep-link used to force the flat path too, on the theory
+              //     that only real heights can land precisely on a target;
+              //     what it actually bought was an O(N) markdown + lowlight
+              //     mount on every notification click, and it still drifted,
+              //     because a 30-frame re-centre window cannot outlast an
+              //     image that decodes later. Anchoring by index and holding
+              //     the anchor while heights settle is both cheaper and more
+              //     accurate — see useCommentAnchorCalibration.
+              !find.open ? (
                 !scrollContainerEl ? (
                   // Skeleton while the callback ref populates so the gap
                   // between IssueDetail mount and Virtuoso mount doesn't
@@ -2400,7 +2454,13 @@ export function IssueDetail({ issueId, onDelete, onDone, defaultSidebarOpen = tr
                       ref={virtuosoRef}
                       customScrollParent={scrollContainerEl}
                       data={items}
-                      initialScrollTop={restoredScrollTop}
+                      // Mutually exclusive with initialTopMostItemIndex: they
+                      // are two answers to "where does this list start", and
+                      // upstream's own guidance is to prefer the index form.
+                      // A deep-link wins over restoration — the user asked for
+                      // a comment, not for wherever the tab was left.
+                      initialScrollTop={deepLinkAnchor ? undefined : restoredScrollTop}
+                      initialTopMostItemIndex={deepLinkAnchor}
                       increaseViewportBy={{ top: 800, bottom: 800 }}
                       computeItemKey={(_i, item) => `${item.kind}:${item.id}`}
                       skipAnimationFrameInResizeObserver

--- a/packages/views/issues/hooks/use-comment-anchor-calibration.test.ts
+++ b/packages/views/issues/hooks/use-comment-anchor-calibration.test.ts
@@ -1,0 +1,323 @@
+import { act, renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { VirtuosoHandle } from "react-virtuoso";
+import { useCommentAnchorCalibration } from "./use-comment-anchor-calibration";
+
+// ---------------------------------------------------------------------------
+// jsdom has no layout, so the geometry is stubbed: the scroll container sits at
+// viewport top with a 600px height, and the target row's top is whatever the
+// test says it is. That is enough to drive every branch, because the hook only
+// ever reads two rects and compares them.
+// ---------------------------------------------------------------------------
+
+const TOP_GAP = 16;
+const CONTAINER_HEIGHT = 600;
+
+let observers: Array<{ callback: () => void; targets: Element[] }>;
+let rafQueue: FrameRequestCallback[];
+
+function flushFrame() {
+  const queued = rafQueue;
+  rafQueue = [];
+  for (const cb of queued) cb(0);
+}
+
+/** Fire the ResizeObserver that is watching `el`, and nothing else. */
+function fireResizeFor(el: Element) {
+  for (const observer of observers) {
+    if (observer.targets.includes(el)) observer.callback();
+  }
+}
+
+describe("useCommentAnchorCalibration", () => {
+  let container: HTMLElement;
+  let wrapper: HTMLElement;
+  let row: HTMLElement;
+  let virtuosoRef: { current: VirtuosoHandle | null };
+  let scrollToIndex: ReturnType<typeof vi.fn>;
+  let targetTop: number;
+
+  function setup(overrides: Partial<Parameters<typeof useCommentAnchorCalibration>[0]> = {}) {
+    return renderHook(() =>
+      useCommentAnchorCalibration({
+        contentWrapperEl: wrapper,
+        enabled: true,
+        scrollContainerEl: container,
+        targetCommentId: "c1",
+        targetIndex: 3,
+        topGap: TOP_GAP,
+        virtuosoRef: virtuosoRef as never,
+        ...overrides,
+      }),
+    );
+  }
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    observers = [];
+    rafQueue = [];
+
+    vi.stubGlobal(
+      "ResizeObserver",
+      class {
+        targets: Element[] = [];
+        constructor(private cb: () => void) {
+          observers.push({ callback: () => this.cb(), targets: this.targets });
+        }
+        observe(el: Element) {
+          this.targets.push(el);
+        }
+        unobserve(el: Element) {
+          const i = this.targets.indexOf(el);
+          if (i >= 0) this.targets.splice(i, 1);
+        }
+        disconnect() {
+          this.targets.length = 0;
+        }
+      },
+    );
+    vi.stubGlobal("requestAnimationFrame", (cb: FrameRequestCallback) => {
+      rafQueue.push(cb);
+      return rafQueue.length;
+    });
+    vi.stubGlobal("cancelAnimationFrame", () => {});
+
+    container = document.createElement("div");
+    container.getBoundingClientRect = () => ({ height: CONTAINER_HEIGHT, top: 0 }) as DOMRect;
+    Object.defineProperty(container, "clientHeight", { value: CONTAINER_HEIGHT });
+    let scrollTop = 0;
+    Object.defineProperty(container, "scrollTop", {
+      get: () => scrollTop,
+      set: (v: number) => {
+        scrollTop = v;
+      },
+    });
+    document.body.appendChild(container);
+
+    wrapper = document.createElement("div");
+    container.appendChild(wrapper);
+
+    row = document.createElement("div");
+    row.id = "comment-c1";
+    targetTop = TOP_GAP;
+    row.getBoundingClientRect = () => ({ height: 100, top: targetTop }) as DOMRect;
+    wrapper.appendChild(row);
+
+    scrollToIndex = vi.fn();
+    virtuosoRef = { current: { scrollToIndex } as unknown as VirtuosoHandle };
+  });
+
+  afterEach(() => {
+    document.body.innerHTML = "";
+    vi.unstubAllGlobals();
+    vi.useRealTimers();
+  });
+
+  // The blocker this hook exists for: content ABOVE the target growing. The
+  // target row's own box does not change and the scroll container is a
+  // fixed-height viewport whose border-box never changes, so neither of those
+  // observers fires. Only the auto-height content wrapper does.
+  it("corrects when only the content wrapper resizes", () => {
+    setup();
+    act(() => flushFrame()); // initial check: already anchored, no-op
+    expect(container.scrollTop).toBe(0);
+
+    targetTop = TOP_GAP + 120; // a description image above the target decoded
+    act(() => {
+      fireResizeFor(wrapper);
+      flushFrame();
+    });
+
+    expect(container.scrollTop).toBe(120);
+  });
+
+  it("corrects when only the target row resizes", () => {
+    setup();
+    act(() => flushFrame());
+
+    targetTop = TOP_GAP + 40;
+    act(() => {
+      fireResizeFor(row);
+      flushFrame();
+    });
+
+    expect(container.scrollTop).toBe(40);
+  });
+
+  it("still corrects when nothing resizes, via the bounded re-check", () => {
+    // Net-zero case: content above grows while content below shrinks by the
+    // same amount, so no observed box changes size but the target still moved.
+    setup();
+    act(() => flushFrame());
+
+    targetTop = TOP_GAP + 30;
+    act(() => {
+      vi.advanceTimersByTime(250);
+      flushFrame();
+    });
+
+    expect(container.scrollTop).toBe(30);
+  });
+
+  it("collapses multiple wake-ups in the same frame into one correction", () => {
+    setup();
+    act(() => flushFrame());
+
+    targetTop = TOP_GAP + 50;
+    act(() => {
+      fireResizeFor(wrapper);
+      fireResizeFor(row);
+      vi.advanceTimersByTime(250);
+      flushFrame();
+    });
+
+    // One correction, not three: three sources, one throttled dispatch. If each
+    // source got its own write they would stack and overshoot.
+    expect(container.scrollTop).toBe(50);
+  });
+
+  it("ignores deviation inside the dead zone", () => {
+    setup();
+    act(() => flushFrame());
+
+    targetTop = TOP_GAP + 3;
+    act(() => {
+      fireResizeFor(wrapper);
+      flushFrame();
+    });
+
+    expect(container.scrollTop).toBe(0);
+    expect(scrollToIndex).not.toHaveBeenCalled();
+  });
+
+  it("hands a more-than-one-viewport deviation back to Virtuoso", () => {
+    setup();
+    act(() => flushFrame());
+
+    targetTop = TOP_GAP + CONTAINER_HEIGHT + 10;
+    act(() => {
+      fireResizeFor(wrapper);
+      flushFrame();
+    });
+
+    // Beyond a screen the row is likely unmounted; nudging scrollTop would be
+    // guesswork against estimated heights, so Virtuoso re-anchors by index.
+    expect(scrollToIndex).toHaveBeenCalledWith({ align: "start", index: 3, offset: -TOP_GAP });
+    expect(container.scrollTop).toBe(0);
+  });
+
+  it("re-anchors by index when the target row is not mounted", () => {
+    setup();
+    act(() => flushFrame());
+    row.remove();
+
+    act(() => {
+      fireResizeFor(wrapper);
+      flushFrame();
+    });
+
+    expect(scrollToIndex).toHaveBeenCalledWith({ align: "start", index: 3, offset: -TOP_GAP });
+  });
+
+  it("stops for good once the user scrolls", () => {
+    setup();
+    act(() => flushFrame());
+
+    act(() => container.dispatchEvent(new Event("wheel")));
+
+    targetTop = TOP_GAP + 200;
+    act(() => {
+      fireResizeFor(wrapper);
+      vi.advanceTimersByTime(1000);
+      flushFrame();
+    });
+
+    // The user is reading. Never move the page under them, however wrong the
+    // anchor now is.
+    expect(container.scrollTop).toBe(0);
+    expect(scrollToIndex).not.toHaveBeenCalled();
+  });
+
+  it("stops at the deadline", () => {
+    setup();
+    act(() => flushFrame());
+
+    act(() => vi.advanceTimersByTime(5000));
+
+    targetTop = TOP_GAP + 200;
+    act(() => {
+      fireResizeFor(wrapper);
+      flushFrame();
+    });
+
+    expect(container.scrollTop).toBe(0);
+  });
+
+  it("does nothing when disabled", () => {
+    setup({ enabled: false });
+
+    targetTop = TOP_GAP + 200;
+    act(() => {
+      fireResizeFor(wrapper);
+      flushFrame();
+    });
+
+    expect(container.scrollTop).toBe(0);
+    expect(scrollToIndex).not.toHaveBeenCalled();
+  });
+
+  it("does not anchor the mount-time target, which Virtuoso already placed", () => {
+    setup();
+    act(() => flushFrame());
+
+    // initialTopMostItemIndex owns the first landing; issuing scrollToIndex on
+    // top of it would be a second writer for the same position.
+    expect(scrollToIndex).not.toHaveBeenCalled();
+  });
+
+  it("re-anchors when the target changes while mounted", () => {
+    const { rerender } = renderHook(
+      ({ target }: { target: string }) =>
+        useCommentAnchorCalibration({
+          contentWrapperEl: wrapper,
+          enabled: true,
+          scrollContainerEl: container,
+          targetCommentId: target,
+          targetIndex: 7,
+          topGap: TOP_GAP,
+          virtuosoRef: virtuosoRef as never,
+        }),
+      { initialProps: { target: "c1" } },
+    );
+    act(() => flushFrame());
+    expect(scrollToIndex).not.toHaveBeenCalled();
+
+    act(() => rerender({ target: "c2" }));
+
+    // Mount-only prop cannot move an already-mounted list — this is the only
+    // way a passive inbox update lands on the newer comment.
+    expect(scrollToIndex).toHaveBeenCalledWith({ align: "start", index: 7, offset: -TOP_GAP });
+  });
+
+  it("does not re-anchor a swapped target once the user has scrolled", () => {
+    const { rerender } = renderHook(
+      ({ target }: { target: string }) =>
+        useCommentAnchorCalibration({
+          contentWrapperEl: wrapper,
+          enabled: true,
+          scrollContainerEl: container,
+          targetCommentId: target,
+          targetIndex: 7,
+          topGap: TOP_GAP,
+          virtuosoRef: virtuosoRef as never,
+        }),
+      { initialProps: { target: "c1" } },
+    );
+    act(() => flushFrame());
+    act(() => container.dispatchEvent(new Event("wheel")));
+
+    act(() => rerender({ target: "c2" }));
+
+    expect(scrollToIndex).not.toHaveBeenCalled();
+  });
+});

--- a/packages/views/issues/hooks/use-comment-anchor-calibration.ts
+++ b/packages/views/issues/hooks/use-comment-anchor-calibration.ts
@@ -1,0 +1,242 @@
+"use client";
+
+import { useEffect, useRef, type RefObject } from "react";
+import type { VirtuosoHandle } from "react-virtuoso";
+
+// ---------------------------------------------------------------------------
+// Deep-link anchor calibration for the virtualized issue timeline (MUL-4812).
+//
+// Virtuoso puts the target row at the top of the viewport on the first frame
+// (`initialTopMostItemIndex`), but that position is only as good as the
+// heights known at that moment. Comment images carry no intrinsic size
+// (`renderImage` in packages/views/common/markdown.tsx passes src/alt only),
+// so anything above the target — the description, the sub-issues block, an
+// earlier comment's image, a mermaid diagram — can grow *after* the anchor
+// lands and push the target out of view.
+//
+// This hook holds the target in place until the user takes over.
+//
+// Wake-up sources (why three, and why the obvious two are not enough):
+//
+//   1. ResizeObserver on the scroll CONTENT WRAPPER. This is the load-bearing
+//      one. `ResizeObserver` reports SIZE changes of the observed element, not
+//      POSITION changes — so observing the target row alone never fires when
+//      content *above* it grows and shoves it down. Observing the scroll
+//      container is equally useless: it is a fixed-height `overflow-y-auto`
+//      viewport, so late content grows its scrollHeight while its border-box
+//      stays exactly the same and the observer never fires. The content
+//      wrapper is the auto-height element that encloses title, description,
+//      sub-issues, the timeline and the composer, so *any* growth above the
+//      target changes its height and wakes us. One observer, no enumeration
+//      of "things that might grow" that the next feature would silently miss.
+//   2. ResizeObserver on the target row itself. Redundant with (1) for
+//      correctness, but faster: when the target's own image lands, the wrapper
+//      only changes after Virtuoso re-measures the row and updates its total
+//      height — two hops. Observing the row reacts on the first.
+//   3. A bounded low-frequency re-check. Covers the one case ResizeObserver
+//      cannot see: content above growing while content below shrinks by the
+//      same amount in the same frame — net wrapper height unchanged, target
+//      still moved.
+//
+// All three funnel into the same throttled correction, so there is exactly one
+// place that decides what to do and the backstop cannot introduce a second
+// correction path.
+//
+// Corrections are deliberately split by magnitude:
+//   - more than a viewport off  -> hand it back to Virtuoso via scrollToIndex.
+//     The row is likely unmounted; only Virtuoso can materialize and land on it.
+//   - within a viewport         -> nudge scrollTop directly. Cheap, exact, and
+//     the resulting `scroll` event makes Virtuoso recompute the `offsetTop` it
+//     caches for customScrollParent (see useWindowViewportRect upstream),
+//     which is itself stale for exactly the same reason we are here.
+//   - under the dead zone       -> do nothing. Sub-pixel churn is invisible and
+//     re-entering the correction path is how oscillation starts.
+// ---------------------------------------------------------------------------
+
+/** Deviation we treat as "landed". Below this, correcting is pure churn. */
+const DEAD_ZONE_PX = 4;
+/** Hard stop, whichever comes first with the user's own scroll input. */
+const MAX_DURATION_MS = 5000;
+/** Backstop poll interval — see wake-up source (3). */
+const RECHECK_INTERVAL_MS = 250;
+
+type UseCommentAnchorCalibrationArgs = {
+  /** Deep-link target comment id (root or reply), or null when not deep-linked. */
+  targetCommentId: string | null;
+  /** Flat index of the target's top-level row in the Virtuoso data, or -1. */
+  targetIndex: number;
+  /** The `overflow-y-auto` viewport. */
+  scrollContainerEl: HTMLElement | null;
+  /** Auto-height wrapper inside the viewport — wake-up source (1). */
+  contentWrapperEl: HTMLElement | null;
+  virtuosoRef: RefObject<VirtuosoHandle | null>;
+  /** Breathing room to leave above the target's header. */
+  topGap: number;
+  enabled: boolean;
+};
+
+export function useCommentAnchorCalibration({
+  targetCommentId,
+  targetIndex,
+  scrollContainerEl,
+  contentWrapperEl,
+  virtuosoRef,
+  topGap,
+  enabled,
+}: UseCommentAnchorCalibrationArgs) {
+  // Set once the user takes control of the scroll, and never cleared for the
+  // life of the mount. Two callers depend on it:
+  //   - calibration stops immediately (never fight the user's scroll);
+  //   - a passively-changed target does not re-anchor (see the effect below).
+  const userScrolledRef = useRef(false);
+  // `undefined` = the effect has not run yet. Distinguishes "mounted with a
+  // target" (Virtuoso's initialTopMostItemIndex owns that first landing) from
+  // "target changed while mounted" (only scrollToIndex can move it, because
+  // initialTopMostItemIndex is mount-only).
+  const previousTargetRef = useRef<string | null | undefined>(undefined);
+  // Absolute per-target deadline, so a timeline that keeps changing height
+  // re-runs the effect without ever extending the session.
+  const deadlineRef = useRef<{ at: number; id: string } | null>(null);
+  const targetIndexRef = useRef(targetIndex);
+  targetIndexRef.current = targetIndex;
+
+  useEffect(() => {
+    if (!scrollContainerEl) return;
+    // Only genuine user input counts. `scroll` events are excluded on purpose:
+    // our own corrections emit them, and treating those as "the user scrolled"
+    // would make the hook cancel itself on its first correction.
+    //
+    // Any keydown counts, not just the scroll keys: if the user is typing in
+    // the composer, moving the timeline under them is exactly as unwelcome as
+    // moving it while they page down.
+    const takeOver = () => {
+      userScrolledRef.current = true;
+    };
+    const opts = { passive: true } as const;
+    scrollContainerEl.addEventListener("wheel", takeOver, opts);
+    scrollContainerEl.addEventListener("touchstart", takeOver, opts);
+    window.addEventListener("keydown", takeOver, opts);
+    return () => {
+      scrollContainerEl.removeEventListener("wheel", takeOver);
+      scrollContainerEl.removeEventListener("touchstart", takeOver);
+      window.removeEventListener("keydown", takeOver);
+    };
+  }, [scrollContainerEl]);
+
+  useEffect(() => {
+    const previousTarget = previousTargetRef.current;
+    const isFirstRun = previousTarget === undefined;
+    previousTargetRef.current = targetCommentId;
+
+    if (!enabled || !targetCommentId || !scrollContainerEl) return;
+
+    // Once the user has taken over there is nothing to do: no re-anchor (that
+    // would yank the viewport away from what they are reading) and no
+    // calibration (same reason). This is the whole latch — see the ruling in
+    // MUL-4812: a target that changes while mounted is, inside the inbox,
+    // necessarily a passive update. IssueDetail is keyed by issue_id and
+    // deduplicateInboxItems keeps exactly one row per issue, so hand-picking a
+    // different comment for the same issue is not reachable; the change came
+    // from a refreshed inbox query swapping in a newer notification.
+    if (userScrolledRef.current) return;
+
+    // Mount-time targets are landed by Virtuoso's initialTopMostItemIndex.
+    // Anything later needs scrollToIndex — that prop is read only at mount.
+    const isRetarget = !isFirstRun && previousTarget !== targetCommentId;
+
+    if (deadlineRef.current?.id !== targetCommentId) {
+      deadlineRef.current = { at: Date.now() + MAX_DURATION_MS, id: targetCommentId };
+    }
+    const deadline = deadlineRef.current;
+    if (Date.now() >= deadline.at) return;
+
+    if (isRetarget && targetIndexRef.current >= 0) {
+      virtuosoRef.current?.scrollToIndex({
+        align: "start",
+        index: targetIndexRef.current,
+        offset: -topGap,
+      });
+    }
+
+    let frame = 0;
+    let poll: ReturnType<typeof setInterval> | undefined;
+    let stopped = false;
+
+    const stop = () => {
+      stopped = true;
+      if (frame) cancelAnimationFrame(frame);
+      frame = 0;
+      if (poll) clearInterval(poll);
+      poll = undefined;
+    };
+
+    const correct = () => {
+      frame = 0;
+      if (stopped || userScrolledRef.current) return stop();
+      if (Date.now() >= deadline.at) return stop();
+
+      const index = targetIndexRef.current;
+      const target = document.getElementById(`comment-${targetCommentId}`);
+      if (!target) {
+        // Virtualized away: it can only be far outside the viewport, and only
+        // Virtuoso can bring it back.
+        if (index >= 0) {
+          virtuosoRef.current?.scrollToIndex({ align: "start", index, offset: -topGap });
+        }
+        return;
+      }
+
+      const containerRect = scrollContainerEl.getBoundingClientRect();
+      const targetRect = target.getBoundingClientRect();
+      const deviation = targetRect.top - (containerRect.top + topGap);
+      if (Math.abs(deviation) < DEAD_ZONE_PX) return;
+
+      if (Math.abs(deviation) > scrollContainerEl.clientHeight && index >= 0) {
+        virtuosoRef.current?.scrollToIndex({ align: "start", index, offset: -topGap });
+        return;
+      }
+      scrollContainerEl.scrollTop += deviation;
+    };
+
+    // One correction per frame at most, no matter how many sources fired.
+    // Virtuoso settles estimated heights into real ones across frames; landing
+    // a second write inside the same frame is what makes the two loops ring.
+    const schedule = () => {
+      if (stopped || frame) return;
+      frame = requestAnimationFrame(correct);
+    };
+
+    const wrapperObserver = new ResizeObserver(schedule);
+    if (contentWrapperEl) wrapperObserver.observe(contentWrapperEl);
+
+    // The row is re-created as Virtuoso mounts/unmounts it, so re-resolve the
+    // node on every poll rather than observing once and holding a dead ref.
+    const rowObserver = new ResizeObserver(schedule);
+    let observedRow: HTMLElement | null = null;
+    const rebindRow = () => {
+      const row = document.getElementById(`comment-${targetCommentId}`);
+      if (row === observedRow) return;
+      if (observedRow) rowObserver.unobserve(observedRow);
+      if (row) rowObserver.observe(row);
+      observedRow = row;
+    };
+    rebindRow();
+
+    poll = setInterval(() => {
+      if (stopped || userScrolledRef.current || Date.now() >= deadline.at) return stop();
+      rebindRow();
+      schedule();
+    }, RECHECK_INTERVAL_MS);
+
+    const deadlineTimer = setTimeout(stop, Math.max(0, deadline.at - Date.now()));
+
+    schedule();
+
+    return () => {
+      stop();
+      clearTimeout(deadlineTimer);
+      wrapperObserver.disconnect();
+      rowObserver.disconnect();
+    };
+  }, [targetCommentId, targetIndex, enabled, scrollContainerEl, contentWrapperEl, virtuosoRef, topGap]);
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -77,7 +77,7 @@ catalogs:
       version: 2.0.21
     react-virtuoso:
       specifier: ^4.14.0
-      version: 4.18.7
+      version: 4.18.10
     rehype-katex:
       specifier: ^7.0.1
       version: 7.0.1
@@ -1097,7 +1097,7 @@ importers:
         version: 4.7.5(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       react-virtuoso:
         specifier: 'catalog:'
-        version: 4.18.7(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+        version: 4.18.10(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       recharts:
         specifier: 3.8.0
         version: 3.8.0(@types/react@19.2.14)(react-dom@19.2.3(react@19.2.3))(react-is@19.2.6)(react@19.2.3)(redux@5.0.1)
@@ -9259,8 +9259,8 @@ packages:
       '@types/react':
         optional: true
 
-  react-virtuoso@4.18.7:
-    resolution: {integrity: sha512-xNF5zDGEEIMB7cKwcen/pLig0YDf6OnfFrVgKFa7sHPf9fRem0CaLshyObbBcP88jzn0enavL39EgplgdyT21g==}
+  react-virtuoso@4.18.10:
+    resolution: {integrity: sha512-P6GIZ7kWAPOYB2H16yRQNgy+VF9pJOuTFw1EUc1EAtCj5WxVSAF1Sql3x3fbLwaLeBFsiPnu+3U9o6sIOyTdFw==}
     peerDependencies:
       react: '>=16 || >=17 || >= 18 || >= 19'
       react-dom: '>=16 || >=17 || >= 18 || >=19'
@@ -20705,7 +20705,7 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.14
 
-  react-virtuoso@4.18.7(react-dom@19.2.3(react@19.2.3))(react@19.2.3):
+  react-virtuoso@4.18.10(react-dom@19.2.3(react@19.2.3))(react@19.2.3):
     dependencies:
       react: 19.2.3
       react-dom: 19.2.3(react@19.2.3)


### PR DESCRIPTION
Closes MUL-4812.

Clicking an Inbox notification used to drop the issue timeline out of virtualization and mount every comment, so first paint cost O(N) markdown parses and lowlight passes — seconds of long tasks on a large issue. It did not even buy accuracy: the 30-frame re-centre window it relied on expires long before a slow image decodes, so the target drifted anyway.

Deep-links now stay virtualized: Virtuoso anchors the first frame by index, and a calibration hook holds that anchor while late content settles — until the user scrolls, at which point their reading position wins.

Plan and review history live on MUL-4812 (reviewed by Lalo → Howard, approved by Naiyuan).

## Scope

| # | Item | Where it landed |
|---|---|---|
| 1 | `isFlatTimeline` narrowed to `find.open` only; `initialTopMostItemIndex` first-frame anchor; 30-frame centring loop removed | `issue-detail.tsx` — `isFlatTimeline = find.open`, `deepLinkAnchor` memo, old rAF loop deleted |
| 2 | Resolved thread expanded on the first frame via render-time derivation (not an effect writing the store) | `autoExpandRootId` + `effectiveExpandedResolved` memos feeding `flattenGroups` |
| 3 | Three-source calibration wake-up funnelled into one throttle / dead zone / dispatch | new `use-comment-anchor-calibration.ts` |
| 4 | Desktop scroll-restoration mutual exclusion, decided through a render-phase ref (never in the `useCallback` deps) | `suppressScrollRestoreRef` |
| 5 | Passive target swap: re-anchor via `scrollToIndex` when untouched, skip once the user has scrolled; never remount | latch inside the same hook |
| 6 | react-virtuoso 4.18.7 → 4.18.10 as an isolated first commit | `3e9577fe` (lockfile only; catalog `^4.14.0` already covered it) |
| 7 | Unit + component + e2e coverage | see Testing |

`align: 'start'` + a top gap replaces centring: a long comment centred by its own box pushes its opening lines off-screen, which is the one thing a reader arriving from a notification needs to see.

### Why the wake-up source is what it is

`ResizeObserver` reports **size, not position**. Watching the target row never fires when content *above* it grows, and watching the scroll container never fires at all — it is a fixed-height `overflow-y-auto` viewport whose border-box does not change when its content grows. Those two are exactly what pushes a deep-linked comment off screen, because comment images carry no intrinsic size (`renderImage` passes `src`/`alt` only).

So the observer watches the **auto-height content wrapper**, which encloses title, description, sub-issues, timeline and composer — one observer, no enumeration of "things that might grow" for a future feature to silently miss. Plus the target row (a faster path for its own images) and a bounded re-check for the net-zero case `ResizeObserver` cannot see (content above grows while content below shrinks by the same amount).

Corrections are split by magnitude: more than a viewport off → hand back to Virtuoso via `scrollToIndex` (the row is likely unmounted); within a viewport → nudge `scrollTop`; under 4px → do nothing, because re-entering the correction path is how oscillation starts.

## Three things found while implementing

**1. Scroll restoration has three write paths, not two.** Besides `initialScrollTop` and the `restoreScrollRef` ref-attach write, `useIssueDetailScrollRestore`'s `restoreScrollTopWithRetry` rewrites `scrollTop` for up to 30 frames until stable — its own comment says this is to "outlast" a virtualized list's initialization, i.e. it is built to override exactly the scroll we are trying to apply. It is also module-level state, so unlike the other two it is live on web, not just Desktop. It was already gated by `disabled: !!highlightCommentId`; all three are now documented together so the next reader does not plug only two.

**2. The obvious fix for the ref-attach write destroys requirement 5.** Putting `highlightCommentId` in `attachScrollContainer`'s `useCallback` deps changes the callback identity, so React detaches it with `null` → `setScrollContainerEl(null)` → skeleton branch → **Virtuoso remounts** on every target change, flashing a skeleton and re-paying the mount cost this PR removes. The suppression is read through a render-phase ref instead, and a regression test pins the mount count at 1 across a target change.

**3. Render-time derivation needs a user-collapse latch.** The derivation runs every render, so a user folding the target's thread back would have it immediately re-expanded — unable to collapse it at all. `userCollapsedRoots` makes an explicit collapse win.

## Provenance: no new prop

A `highlightCommentId` change on a *mounted* `IssueDetail` can only be a passive Inbox query/cache update: the detail is keyed by `issue_id`, and `deduplicateInboxItems` keeps exactly one row per issue, so hand-picking a second comment for an issue already on screen is not reachable. The user-scroll latch alone therefore implements the ruling, with no provenance flag threaded through props.

That inference is load-bearing, so it is pinned at the source: `packages/core/inbox/queries.test.ts` now asserts "collapses every notification for one issue into a single row", with a comment explaining what depends on it. If the Inbox ever stops de-duplicating, that test fails first — instead of the anchor quietly starting to steal the viewport on an explicit click.

(Related: `deduplicateInboxItems` can borrow an older comment's anchor when the newest notification has none, so even a pure status change can retarget the deep-link. Another reason the latch matters.)

## Testing

`pnpm typecheck` (6/6), `pnpm lint` (0 errors, 0 warnings in changed files), `pnpm test` (2116 tests / 210 files, green).

**`use-comment-anchor-calibration.test.ts`** (13 new) — controllable `ResizeObserver`, fake timers, stubbed geometry; covers each wake-up source in isolation, same-frame collapsing, dead zone, the two dispatch branches, unmounted target, permanent stop on wheel, deadline, disabled, mount-time target not re-anchored, retarget, and retarget-after-scroll.

These were **mutation-checked**: reverting the hook to the previously-rejected design (target row + scroll container only, no backstop) fails 4 of them — the first being `corrects when only the content wrapper resizes`, the exact scenario that blocked the plan. The tests have teeth.

**`issue-detail.test.tsx`** (+10) — the Virtuoso mock was upgraded first: its `scrollToIndex` was constructed inside `useImperativeHandle` and unreachable from tests (its own comment admitted the ref methods were never exercised). It now exposes a hoisted spy and captures **first-render** props, which is the only frame that matters for a mount-only prop. Covers head/middle/tail anchors (index 0 included — it maps to the 4.18.9 `{index: 0}` patch), no target → no anchor, resolved-reply target already expanded in the **first** frame's data, passive retarget → `scrollToIndex` with `mounts === 1`, retarget-after-scroll → no anchor, find still flat, and both restoration write paths suppressed/active as appropriate.

### Known gap: e2e is written but unexecuted

`e2e/inbox-deep-link.spec.ts` adds 5 specs, including the two real layout-drift cases (**description image above the target loading late**, and **the row before the target loading late**), both driven by a Playwright route interception with a fixed delay so the drift reproduces deterministically rather than by timing luck. `--list` registers all 5.

They have **not been run**: the server requires Go 1.26.1 (local toolchain is 1.24.5) and `playwright.config.ts` has no `webServer`, so they assume an already-running stack.

Worth flagging for reviewers: **e2e is not wired into CI at all** — `ci.yml` runs only `turbo build typecheck lint test`, and no workflow references playwright. So these specs will not run on merge. Until they are executed, the "target does not drift when images load late" criterion is supported by hook-level unit tests (mutation-checked) and source-level reasoning, **not** by real browser layout. That decision is being routed separately on MUL-4812; it is not resolved here.

Desktop production-build manual perf acceptance is scheduled separately and is not part of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
