### PR TITLE
SNDBX-491 carry intake fields through create paths

### DIFF
--- a/apps/mobile/app/(app)/[workspace]/new-issue.tsx
+++ b/apps/mobile/app/(app)/[workspace]/new-issue.tsx
@@ -30,6 +30,7 @@ import { DescriptionField } from "@/components/issue/description-field";
 import { MOBILE_PLACEHOLDER_COLOR } from "@/components/ui/input-tokens";
 import { useCreateIssue } from "@/data/mutations/issues";
 import { useNewIssueDraftStore } from "@/data/stores/new-issue-draft-store";
+import { extractAcceptanceCriteria } from "@multica/core/issues";
 import { useMentionInput } from "@/lib/use-mention-input";
 
 export default function NewIssueModal() {
@@ -63,17 +64,20 @@ export default function NewIssueModal() {
     const trimmedTitle = title.trim();
     if (trimmedTitle.length === 0) return;
     const finalDescription = description.serialize().trim();
+    const acceptanceCriteria = extractAcceptanceCriteria(finalDescription);
     try {
       await createIssue.mutateAsync({
         title: trimmedTitle,
         description: finalDescription || undefined,
         status,
         priority,
+        label_ids: [],
         ...(assignee
           ? { assignee_type: assignee.type, assignee_id: assignee.id }
           : {}),
         ...(dueDate ? { due_date: dueDate } : {}),
         ...(project ? { project_id: project.id } : {}),
+        ...(acceptanceCriteria ? { acceptance_criteria: acceptanceCriteria } : {}),
       });
       router.back();
     } catch (err) {

--- a/packages/core/issues/acceptance-criteria.ts
+++ b/packages/core/issues/acceptance-criteria.ts
@@ -1,0 +1,19 @@
+const CLOSING_LINE_RE = /^Closes when:\s*(.+)$/i;
+
+/**
+ * Pull explicit exit criteria lines out of an issue description. The create
+ * surfaces can keep treating the description as free-form markdown while still
+ * forwarding any `Closes when:` checks the user included.
+ */
+export function extractAcceptanceCriteria(
+  description?: string | null,
+): string[] | undefined {
+  if (!description) return undefined;
+
+  const criteria = description
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter((line) => CLOSING_LINE_RE.test(line));
+
+  return criteria.length > 0 ? criteria : undefined;
+}

--- a/packages/core/issues/index.ts
+++ b/packages/core/issues/index.ts
@@ -4,3 +4,4 @@ export * from "./mutations";
 export * from "./ws-updaters";
 export * from "./config";
 export * from "./stores";
+export * from "./acceptance-criteria";

--- a/packages/core/types/api.ts
+++ b/packages/core/types/api.ts
@@ -12,6 +12,8 @@ export interface CreateIssueRequest {
   assignee_id?: string;
   parent_issue_id?: string;
   project_id?: string;
+  label_ids?: string[];
+  acceptance_criteria?: string[];
   /** Ordered stage (>= 1) grouping this sub-issue under its parent. */
   stage?: number;
   start_date?: string;
@@ -31,6 +33,8 @@ export interface UpdateIssueRequest {
   due_date?: string | null;
   parent_issue_id?: string | null;
   project_id?: string | null;
+  label_ids?: string[];
+  acceptance_criteria?: string[];
   /** Ordered stage (>= 1); null clears it (unstaged). */
   stage?: number | null;
   /** Attachment IDs to bind to this issue alongside the description update.

--- a/packages/views/modals/create-issue.test.tsx
+++ b/packages/views/modals/create-issue.test.tsx
@@ -449,6 +449,7 @@ describe("CreateIssueModal", () => {
         start_date: undefined,
         due_date: undefined,
         attachment_ids: undefined,
+        label_ids: [],
         parent_issue_id: undefined,
         project_id: undefined,
       });
@@ -496,6 +497,7 @@ describe("CreateIssueModal", () => {
         start_date: undefined,
         due_date: undefined,
         attachment_ids: undefined,
+        label_ids: [],
         parent_issue_id: undefined,
         project_id: undefined,
       });
@@ -516,6 +518,32 @@ describe("CreateIssueModal", () => {
       labelIds: [],
       attachments: [],
     });
+  });
+
+  it("forwards selected labels and extracted exit criteria through create payload", async () => {
+    const user = userEvent.setup();
+    const onClose = vi.fn();
+    mockDraftStore.draft.labelIds = ["label-1", "label-2"];
+
+    renderModal(<CreateIssueModal onClose={onClose} />);
+
+    await user.type(screen.getByPlaceholderText("Issue title"), "Carry intake fields");
+    await user.type(
+      screen.getByPlaceholderText("Add description..."),
+      "Build the compatibility slice.\nCloses when: the intake fields reach create callers.",
+    );
+    await user.click(screen.getByRole("button", { name: "Create Issue" }));
+
+    await waitFor(() => {
+        expect(mockCreateIssue).toHaveBeenCalledWith(
+          expect.objectContaining({
+            label_ids: ["label-1", "label-2"],
+            acceptance_criteria: [
+              "Closes when: the intake fields reach create callers.",
+            ],
+          }),
+        );
+      });
   });
 
   it("persists manual-mode uploads in the issue draft", async () => {

--- a/packages/views/modals/create-issue.tsx
+++ b/packages/views/modals/create-issue.tsx
@@ -43,12 +43,12 @@ import { useIssueTriggerPreview } from "../issues/hooks/use-issue-trigger-previe
 import { useActorName } from "@multica/core/workspace/hooks";
 import { useCurrentWorkspace, useWorkspacePaths } from "@multica/core/paths";
 import { useWorkspaceId } from "@multica/core/hooks";
+import { extractAcceptanceCriteria } from "@multica/core/issues";
 import { useIssueDraftStore } from "@multica/core/issues/stores/draft-store";
 import { useCreateModeStore } from "@multica/core/issues/stores/create-mode-store";
 import { useQuickCreateStore } from "@multica/core/issues/stores/quick-create-store";
 import { issueDetailOptions, childIssuesOptions } from "@multica/core/issues/queries";
 import { useCreateIssue, useUpdateIssue } from "@multica/core/issues/mutations";
-import { useAttachLabelToIssue } from "@multica/core/labels";
 import { useFileUpload } from "@multica/core/hooks/use-file-upload";
 import {
   api,
@@ -311,7 +311,6 @@ export function ManualCreatePanel({
 
   const createIssueMutation = useCreateIssue();
   const updateIssueMutation = useUpdateIssue();
-  const attachLabelMutation = useAttachLabelToIssue();
   const resetForNextIssue = () => {
     setTitle("");
     setStatus("todo");
@@ -344,6 +343,7 @@ export function ManualCreatePanel({
     setSubmitting(true);
     try {
       const description = descEditorRef.current?.getMarkdown()?.trim() || undefined;
+      const acceptanceCriteria = extractAcceptanceCriteria(description);
       const activeAttachmentIds = draftAttachments
         .filter((a) => contentReferencesAttachment(description ?? "", a))
         .map((a) => a.id);
@@ -357,6 +357,8 @@ export function ManualCreatePanel({
         start_date: startDate || undefined,
         due_date: dueDate || undefined,
         attachment_ids: activeAttachmentIds.length > 0 ? activeAttachmentIds : undefined,
+        label_ids: labelIds,
+        ...(acceptanceCriteria ? { acceptance_criteria: acceptanceCriteria } : {}),
         parent_issue_id: parentIssueId,
         // Stage is only meaningful for a sub-issue (relative to its siblings).
         stage: parentIssueId && stage != null ? stage : undefined,
@@ -394,28 +396,6 @@ export function ManualCreatePanel({
                   total: childIssues.length,
                 }),
           );
-        }
-      }
-
-      // Attach the labels chosen in the dialog. Like the sub-issue links
-      // above, this is deferred to after create because the new issue's ID
-      // doesn't exist yet, and the create endpoint takes no labels. Partial
-      // failures don't roll back the committed issue.
-      if (labelIds.length > 0) {
-        const results = await Promise.allSettled(
-          labelIds.map((labelId) =>
-            attachLabelMutation.mutateAsync({ issueId: issue.id, labelId }),
-          ),
-        );
-        let labelsFailed = 0;
-        for (const result of results) {
-          if (result.status === "rejected") {
-            labelsFailed += 1;
-            console.error("[create-issue] label attach failed", result.reason);
-          }
-        }
-        if (labelsFailed > 0) {
-          toast.error(t(($) => $.create_issue.toast_link_labels_failed));
         }
       }
 

--- a/packages/views/workspace/welcome-after-onboarding.tsx
+++ b/packages/views/workspace/welcome-after-onboarding.tsx
@@ -9,6 +9,7 @@ import { useWelcomeStore } from "@multica/core/onboarding";
 import { paths, useCurrentWorkspace } from "@multica/core/paths";
 import { resolvePublicFileUrl } from "@multica/core/workspace/avatar-url";
 import { issueKeys } from "@multica/core/issues/queries";
+import { extractAcceptanceCriteria } from "@multica/core/issues";
 import { workspaceKeys } from "@multica/core/workspace/queries";
 import type { Agent, CreateIssueRequest, Issue } from "@multica/core/types";
 import {
@@ -448,13 +449,19 @@ function RuntimeWelcome({
       const issues = await Promise.all(
         orderedIds.map((id) => {
           const card = HELPER_STARTER_PROMPTS[id];
+          const description = card.prompt[lang] + userContext;
+          const acceptanceCriteria = extractAcceptanceCriteria(description);
           return api.createIssue({
             title: card.title[lang],
-            description: card.prompt[lang] + userContext,
+            description,
             status: "todo",
             priority: "high",
             assignee_type: "agent",
             assignee_id: agent.id,
+            label_ids: [],
+            ...(acceptanceCriteria
+              ? { acceptance_criteria: acceptanceCriteria }
+              : {}),
           });
         }),
       );

--- a/server/internal/handler/issue.go
+++ b/server/internal/handler/issue.go
@@ -173,6 +173,103 @@ func (h *Handler) labelsByIssue(ctx context.Context, wsUUID pgtype.UUID, issueID
 	return out
 }
 
+func marshalAcceptanceCriteria(criteria []string) []byte {
+	if len(criteria) == 0 {
+		return []byte("[]")
+	}
+	data, err := json.Marshal(criteria)
+	if err != nil {
+		return []byte("[]")
+	}
+	return data
+}
+
+var errIssueLabelNotFound = errors.New("issue label not found")
+
+func (h *Handler) syncIssueLabels(ctx context.Context, issue db.Issue, desiredLabelIDs []pgtype.UUID) ([]db.IssueLabel, bool, error) {
+	current, err := h.Queries.ListLabelsByIssue(ctx, db.ListLabelsByIssueParams{
+		IssueID:     issue.ID,
+		WorkspaceID: issue.WorkspaceID,
+	})
+	if err != nil {
+		return nil, false, fmt.Errorf("list labels for issue: %w", err)
+	}
+
+	desiredByID := make(map[string]pgtype.UUID, len(desiredLabelIDs))
+	for _, labelID := range desiredLabelIDs {
+		if !labelID.Valid {
+			continue
+		}
+		desiredByID[uuidToString(labelID)] = labelID
+	}
+
+	currentByID := make(map[string]struct{}, len(current))
+	for _, label := range current {
+		currentByID[uuidToString(label.ID)] = struct{}{}
+	}
+
+	validatedDesired := make(map[string]pgtype.UUID, len(desiredByID))
+	for key, labelID := range desiredByID {
+		if _, alreadyAttached := currentByID[key]; alreadyAttached {
+			continue
+		}
+		label, err := h.Queries.GetLabel(ctx, db.GetLabelParams{
+			ID:          labelID,
+			WorkspaceID: issue.WorkspaceID,
+		})
+		if err != nil {
+			if errors.Is(err, pgx.ErrNoRows) {
+				return nil, false, errIssueLabelNotFound
+			}
+			return nil, false, fmt.Errorf("get label for issue: %w", err)
+		}
+		if label.ResourceType != "issue" {
+			return nil, false, errIssueLabelNotFound
+		}
+		validatedDesired[key] = labelID
+	}
+
+	changed := false
+	for _, labelID := range validatedDesired {
+		if err := h.Queries.AttachLabelToIssue(ctx, db.AttachLabelToIssueParams{
+			IssueID:     issue.ID,
+			LabelID:     labelID,
+			WorkspaceID: issue.WorkspaceID,
+		}); err != nil {
+			return nil, false, fmt.Errorf("attach label to issue: %w", err)
+		}
+		changed = true
+	}
+
+	for _, label := range current {
+		key := uuidToString(label.ID)
+		if _, keep := desiredByID[key]; keep {
+			continue
+		}
+		if err := h.Queries.DetachLabelFromIssue(ctx, db.DetachLabelFromIssueParams{
+			IssueID:     issue.ID,
+			LabelID:     label.ID,
+			WorkspaceID: issue.WorkspaceID,
+		}); err != nil {
+			return nil, false, fmt.Errorf("detach label from issue: %w", err)
+		}
+		changed = true
+	}
+
+	if !changed {
+		return current, false, nil
+	}
+
+	updated, err := h.Queries.ListLabelsByIssue(ctx, db.ListLabelsByIssueParams{
+		IssueID:     issue.ID,
+		WorkspaceID: issue.WorkspaceID,
+	})
+	if err != nil {
+		return nil, false, fmt.Errorf("refresh labels for issue: %w", err)
+	}
+	return updated, true, nil
+}
+
 func openIssueRowToResponse(i db.ListOpenIssuesRow, issuePrefix string) IssueResponse {
 	identifier := issuePrefix + "-" + strconv.Itoa(int(i.Number))
 	return IssueResponse{
@@ -2093,18 +2190,20 @@ func readRuntimeCLIVersion(metadata []byte) string {
 }
 
 type CreateIssueRequest struct {
-	Title         string   `json:"title"`
-	Description   *string  `json:"description"`
-	Status        string   `json:"status"`
-	Priority      string   `json:"priority"`
-	AssigneeType  *string  `json:"assignee_type"`
-	AssigneeID    *string  `json:"assignee_id"`
-	ParentIssueID *string  `json:"parent_issue_id"`
-	ProjectID     *string  `json:"project_id"`
-	Stage         *int32   `json:"stage,omitempty"`
-	StartDate     *string  `json:"start_date"`
-	DueDate       *string  `json:"due_date"`
-	AttachmentIDs []string `json:"attachment_ids,omitempty"`
+	Title              string   `json:"title"`
+	Description        *string  `json:"description"`
+	Status             string   `json:"status"`
+	Priority           string   `json:"priority"`
+	AssigneeType       *string  `json:"assignee_type"`
+	AssigneeID         *string  `json:"assignee_id"`
+	ParentIssueID      *string  `json:"parent_issue_id"`
+	ProjectID          *string  `json:"project_id"`
+	LabelIDs           []string `json:"label_ids"`
+	AcceptanceCriteria []string `json:"acceptance_criteria"`
+	Stage              *int32   `json:"stage,omitempty"`
+	StartDate          *string  `json:"start_date"`
+	DueDate            *string  `json:"due_date"`
+	AttachmentIDs      []string `json:"attachment_ids,omitempty"`
 	// OriginType / OriginID stamp the new issue with its provenance so
 	// platform-internal flows can deterministically locate it later. Only
 	// trusted callers should set these — currently the daemon CLI passes
@@ -2203,6 +2302,10 @@ func (h *Handler) CreateIssue(w http.ResponseWriter, r *http.Request) {
 	// without duplicating the lookup here.
 
 	attachmentIDs, ok := parseUUIDSliceOrBadRequest(w, req.AttachmentIDs, "attachment_ids")
+	if !ok {
+		return
+	}
+	labelIDs, ok := parseUUIDSliceOrBadRequest(w, req.LabelIDs, "label_ids")
 	if !ok {
 		return
 	}
@@ -2308,24 +2411,26 @@ func (h *Handler) CreateIssue(w http.ResponseWriter, r *http.Request) {
 	}
 
 	res, err := h.IssueService.Create(r.Context(), service.IssueCreateParams{
-		WorkspaceID:    wsUUID,
-		Title:          req.Title,
-		Description:    ptrToText(req.Description),
-		Status:         status,
-		Priority:       priority,
-		AssigneeType:   assigneeType,
-		AssigneeID:     assigneeID,
-		CreatorType:    creatorType,
-		CreatorID:      parseUUID(actualCreatorID),
-		ParentIssueID:  parentIssueID,
-		ProjectID:      projectID,
-		StartDate:      startDate,
-		DueDate:        dueDate,
-		OriginType:     originType,
-		OriginID:       originID,
-		Stage:          ptrToInt4(req.Stage),
-		AttachmentIDs:  attachmentIDs,
-		AllowDuplicate: req.AllowDuplicate,
+		WorkspaceID:        wsUUID,
+		Title:              req.Title,
+		Description:        ptrToText(req.Description),
+		Status:             status,
+		Priority:           priority,
+		AssigneeType:       assigneeType,
+		AssigneeID:         assigneeID,
+		CreatorType:        creatorType,
+		CreatorID:          parseUUID(actualCreatorID),
+		ParentIssueID:      parentIssueID,
+		ProjectID:          projectID,
+		StartDate:          startDate,
+		DueDate:            dueDate,
+		OriginType:         originType,
+		OriginID:           originID,
+		Stage:              ptrToInt4(req.Stage),
+		AttachmentIDs:      attachmentIDs,
+		LabelIDs:           labelIDs,
+		AcceptanceCriteria: marshalAcceptanceCriteria(req.AcceptanceCriteria),
+		AllowDuplicate:     req.AllowDuplicate,
 	}, service.IssueCreateOpts{
 		ActorID:          actualCreatorID,
 		AnalyticsAgentID: analyticsAgentID,
@@ -2333,6 +2438,9 @@ func (h *Handler) CreateIssue(w http.ResponseWriter, r *http.Request) {
 		BroadcastPayload: func(issue db.Issue, atts []db.Attachment) map[string]any {
 			payload := issueToResponse(issue, prefix)
 			payload.Attachments = buildAttachmentResponses(atts)
+			if labels := h.labelsByIssue(r.Context(), issue.WorkspaceID, []pgtype.UUID{issue.ID})[uuidToString(issue.ID)]; len(labels) > 0 {
+				payload.Labels = &labels
+			}
 			return map[string]any{"issue": payload}
 		},
 	})
@@ -2366,22 +2474,27 @@ func (h *Handler) CreateIssue(w http.ResponseWriter, r *http.Request) {
 
 	resp := issueToResponse(issue, prefix)
 	resp.Attachments = buildAttachmentResponses(res.Attachments)
+	if labels := h.labelsByIssue(r.Context(), issue.WorkspaceID, []pgtype.UUID{issue.ID})[uuidToString(issue.ID)]; len(labels) > 0 {
+		resp.Labels = &labels
+	}
 	writeJSON(w, http.StatusCreated, resp)
 }
 
 type UpdateIssueRequest struct {
-	Title         *string  `json:"title"`
-	Description   *string  `json:"description"`
-	Status        *string  `json:"status"`
-	Priority      *string  `json:"priority"`
-	AssigneeType  *string  `json:"assignee_type"`
-	AssigneeID    *string  `json:"assignee_id"`
-	Position      *float64 `json:"position"`
-	StartDate     *string  `json:"start_date"`
-	DueDate       *string  `json:"due_date"`
-	ParentIssueID *string  `json:"parent_issue_id"`
-	ProjectID     *string  `json:"project_id"`
-	Stage         *int32   `json:"stage"`
+	Title              *string  `json:"title"`
+	Description        *string  `json:"description"`
+	Status             *string  `json:"status"`
+	Priority           *string  `json:"priority"`
+	AssigneeType       *string  `json:"assignee_type"`
+	AssigneeID         *string  `json:"assignee_id"`
+	Position           *float64 `json:"position"`
+	StartDate          *string  `json:"start_date"`
+	DueDate            *string  `json:"due_date"`
+	ParentIssueID      *string  `json:"parent_issue_id"`
+	ProjectID          *string  `json:"project_id"`
+	LabelIDs           []string `json:"label_ids"`
+	AcceptanceCriteria []string `json:"acceptance_criteria"`
+	Stage              *int32   `json:"stage"`
 	// AttachmentIDs lets the description editor bind newly uploaded files to
 	// this issue so they surface in `GET /api/issues/:id/attachments` and the
 	// editor's preview Eye keeps working past a refresh. Existing bindings
@@ -2564,6 +2677,19 @@ func (h *Handler) UpdateIssue(w http.ResponseWriter, r *http.Request) {
 			params.Stage = pgtype.Int4{Valid: false} // explicit null = unstage
 		}
 	}
+	if _, ok := rawFields["acceptance_criteria"]; ok {
+		params.AcceptanceCriteria = marshalAcceptanceCriteria(req.AcceptanceCriteria)
+	}
+
+	labelIDsTouched := false
+	var labelIDs []pgtype.UUID
+	if _, ok := rawFields["label_ids"]; ok {
+		labelIDsTouched = true
+		labelIDs, ok = parseUUIDSliceOrBadRequest(w, req.LabelIDs, "label_ids")
+		if !ok {
+			return
+		}
+	}
 
 	// Validate the resulting (assignee_type, assignee_id) pair when the caller
 	// touches either field. Existing data on the issue is left alone if the
@@ -2589,12 +2715,49 @@ func (h *Handler) UpdateIssue(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	var syncedLabelResponses *[]LabelResponse
+	syncedLabelsChanged := false
+	if labelIDsTouched {
+		syncedLabels, changed, err := h.syncIssueLabels(r.Context(), issue, labelIDs)
+		if err != nil {
+			if errors.Is(err, errIssueLabelNotFound) {
+				writeError(w, http.StatusNotFound, "issue label not found")
+				return
+			}
+			slog.Warn("sync issue labels failed", append(logger.RequestAttrs(r), "error", err, "issue_id", id, "workspace_id", workspaceID)...)
+			writeError(w, http.StatusInternalServerError, "failed to update issue labels")
+			return
+		}
+		syncedLabelsChanged = changed
+		responses := make([]LabelResponse, len(syncedLabels))
+		for i, label := range syncedLabels {
+			responses[i] = LabelResponse{
+				ID:           uuidToString(label.ID),
+				WorkspaceID:  uuidToString(label.WorkspaceID),
+				ResourceType: label.ResourceType,
+				Name:         label.Name,
+				Description:  label.Description,
+				Color:        label.Color,
+				CreatedAt:    timestampToString(label.CreatedAt),
+				UpdatedAt:    timestampToString(label.UpdatedAt),
+			}
+		}
+		syncedLabelResponses = &responses
+	}
+
 	if len(attachmentIDs) > 0 {
 		h.linkAttachmentsByIssueIDs(r.Context(), issue.ID, issue.WorkspaceID, attachmentIDs)
 	}
 
 	prefix := h.getIssuePrefix(r.Context(), issue.WorkspaceID)
 	resp := issueToResponse(issue, prefix)
+	if syncedLabelResponses != nil {
+		resp.Labels = syncedLabelResponses
+	} else {
+		if labels := h.labelsByIssue(r.Context(), issue.WorkspaceID, []pgtype.UUID{issue.ID})[uuidToString(issue.ID)]; len(labels) > 0 {
+			resp.Labels = &labels
+		}
+	}
 	slog.Info("issue updated", append(logger.RequestAttrs(r), "issue_id", id, "workspace_id", workspaceID)...)
 
 	assigneeChanged := (req.AssigneeType != nil || req.AssigneeID != nil) &&
@@ -2639,6 +2802,12 @@ func (h *Handler) UpdateIssue(w http.ResponseWriter, r *http.Request) {
 		"creator_type":        prevIssue.CreatorType,
 		"creator_id":          uuidToString(prevIssue.CreatorID),
 	})
+	if syncedLabelsChanged && syncedLabelResponses != nil {
+		h.publish(protocol.EventIssueLabelsChanged, workspaceID, actorType, actorID, map[string]any{
+			"issue_id": uuidToString(issue.ID),
+			"labels":   *syncedLabelResponses,
+		})
+	}
 
 	// Reconcile the task queue. Whether this write starts an agent run — and
 	// for whom (agent assignee or squad leader) — is decided by the single

--- a/server/internal/handler/issue.go
+++ b/server/internal/handler/issue.go
@@ -184,10 +184,35 @@ func marshalAcceptanceCriteria(criteria []string) []byte {
 	return data
 }
 
-var errIssueLabelNotFound = errors.New("issue label not found")
+func (h *Handler) validateIssueLabelIDs(ctx context.Context, q *db.Queries, workspaceID pgtype.UUID, labelIDs []pgtype.UUID) error {
+	desiredByID := make(map[string]pgtype.UUID, len(labelIDs))
+	for _, labelID := range labelIDs {
+		if !labelID.Valid {
+			continue
+		}
+		desiredByID[uuidToString(labelID)] = labelID
+	}
 
-func (h *Handler) syncIssueLabels(ctx context.Context, issue db.Issue, desiredLabelIDs []pgtype.UUID) ([]db.IssueLabel, bool, error) {
-	current, err := h.Queries.ListLabelsByIssue(ctx, db.ListLabelsByIssueParams{
+	for _, labelID := range desiredByID {
+		label, err := q.GetLabel(ctx, db.GetLabelParams{
+			ID:          labelID,
+			WorkspaceID: workspaceID,
+		})
+		if err != nil {
+			if errors.Is(err, pgx.ErrNoRows) {
+				return service.ErrIssueLabelNotFound
+			}
+			return fmt.Errorf("get label for issue: %w", err)
+		}
+		if label.ResourceType != "issue" {
+			return service.ErrIssueLabelNotFound
+		}
+	}
+	return nil
+}
+
+func (h *Handler) syncIssueLabels(ctx context.Context, q *db.Queries, issue db.Issue, desiredLabelIDs []pgtype.UUID) ([]db.IssueLabel, bool, error) {
+	current, err := q.ListLabelsByIssue(ctx, db.ListLabelsByIssueParams{
 		IssueID:     issue.ID,
 		WorkspaceID: issue.WorkspaceID,
 	})
@@ -208,30 +233,12 @@ func (h *Handler) syncIssueLabels(ctx context.Context, issue db.Issue, desiredLa
 		currentByID[uuidToString(label.ID)] = struct{}{}
 	}
 
-	validatedDesired := make(map[string]pgtype.UUID, len(desiredByID))
-	for key, labelID := range desiredByID {
-		if _, alreadyAttached := currentByID[key]; alreadyAttached {
+	changed := false
+	for _, labelID := range desiredByID {
+		if _, alreadyAttached := currentByID[uuidToString(labelID)]; alreadyAttached {
 			continue
 		}
-		label, err := h.Queries.GetLabel(ctx, db.GetLabelParams{
-			ID:          labelID,
-			WorkspaceID: issue.WorkspaceID,
-		})
-		if err != nil {
-			if errors.Is(err, pgx.ErrNoRows) {
-				return nil, false, errIssueLabelNotFound
-			}
-			return nil, false, fmt.Errorf("get label for issue: %w", err)
-		}
-		if label.ResourceType != "issue" {
-			return nil, false, errIssueLabelNotFound
-		}
-		validatedDesired[key] = labelID
-	}
-
-	changed := false
-	for _, labelID := range validatedDesired {
-		if err := h.Queries.AttachLabelToIssue(ctx, db.AttachLabelToIssueParams{
+		if err := q.AttachLabelToIssue(ctx, db.AttachLabelToIssueParams{
 			IssueID:     issue.ID,
 			LabelID:     labelID,
 			WorkspaceID: issue.WorkspaceID,
@@ -246,7 +253,7 @@ func (h *Handler) syncIssueLabels(ctx context.Context, issue db.Issue, desiredLa
 		if _, keep := desiredByID[key]; keep {
 			continue
 		}
-		if err := h.Queries.DetachLabelFromIssue(ctx, db.DetachLabelFromIssueParams{
+		if err := q.DetachLabelFromIssue(ctx, db.DetachLabelFromIssueParams{
 			IssueID:     issue.ID,
 			LabelID:     label.ID,
 			WorkspaceID: issue.WorkspaceID,
@@ -260,7 +267,7 @@ func (h *Handler) syncIssueLabels(ctx context.Context, issue db.Issue, desiredLa
 		return current, false, nil
 	}
 
-	updated, err := h.Queries.ListLabelsByIssue(ctx, db.ListLabelsByIssueParams{
+	updated, err := q.ListLabelsByIssue(ctx, db.ListLabelsByIssueParams{
 		IssueID:     issue.ID,
 		WorkspaceID: issue.WorkspaceID,
 	})
@@ -2463,6 +2470,10 @@ func (h *Handler) CreateIssue(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusBadRequest, "project not found in this workspace")
 		return
 	}
+	if errors.Is(err, service.ErrIssueLabelNotFound) {
+		writeError(w, http.StatusNotFound, "issue label not found")
+		return
+	}
 	if err != nil {
 		slog.Warn("create issue failed", append(logger.RequestAttrs(r), "error", err, "workspace_id", workspaceID)...)
 		writeError(w, http.StatusInternalServerError, "failed to create issue: "+err.Error())
@@ -2708,7 +2719,27 @@ func (h *Handler) UpdateIssue(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	issue, err := h.Queries.UpdateIssue(r.Context(), params)
+	tx, err := h.TxStarter.Begin(r.Context())
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to start transaction")
+		return
+	}
+	defer tx.Rollback(r.Context())
+	qtx := h.Queries.WithTx(tx)
+
+	if labelIDsTouched {
+		if err := h.validateIssueLabelIDs(r.Context(), qtx, prevIssue.WorkspaceID, labelIDs); err != nil {
+			if errors.Is(err, service.ErrIssueLabelNotFound) {
+				writeError(w, http.StatusNotFound, "issue label not found")
+				return
+			}
+			slog.Warn("validate issue labels failed", append(logger.RequestAttrs(r), "error", err, "issue_id", id, "workspace_id", workspaceID)...)
+			writeError(w, http.StatusInternalServerError, "failed to update issue labels")
+			return
+		}
+	}
+
+	issue, err := qtx.UpdateIssue(r.Context(), params)
 	if err != nil {
 		slog.Warn("update issue failed", append(logger.RequestAttrs(r), "error", err, "issue_id", id, "workspace_id", workspaceID)...)
 		writeError(w, http.StatusInternalServerError, "failed to update issue: "+err.Error())
@@ -2718,9 +2749,9 @@ func (h *Handler) UpdateIssue(w http.ResponseWriter, r *http.Request) {
 	var syncedLabelResponses *[]LabelResponse
 	syncedLabelsChanged := false
 	if labelIDsTouched {
-		syncedLabels, changed, err := h.syncIssueLabels(r.Context(), issue, labelIDs)
+		syncedLabels, changed, err := h.syncIssueLabels(r.Context(), qtx, issue, labelIDs)
 		if err != nil {
-			if errors.Is(err, errIssueLabelNotFound) {
+			if errors.Is(err, service.ErrIssueLabelNotFound) {
 				writeError(w, http.StatusNotFound, "issue label not found")
 				return
 			}
@@ -2743,6 +2774,12 @@ func (h *Handler) UpdateIssue(w http.ResponseWriter, r *http.Request) {
 			}
 		}
 		syncedLabelResponses = &responses
+	}
+
+	if err := tx.Commit(r.Context()); err != nil {
+		slog.Warn("commit update issue tx failed", append(logger.RequestAttrs(r), "error", err, "issue_id", id, "workspace_id", workspaceID)...)
+		writeError(w, http.StatusInternalServerError, "failed to update issue")
+		return
 	}
 
 	if len(attachmentIDs) > 0 {

--- a/server/internal/handler/issue_validation_test.go
+++ b/server/internal/handler/issue_validation_test.go
@@ -1,6 +1,8 @@
 package handler
 
 import (
+	"context"
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -60,6 +62,56 @@ func TestUpdateIssueInvalidPriorityReturns400(t *testing.T) {
 	testHandler.UpdateIssue(w, req)
 	if w.Code != http.StatusBadRequest {
 		t.Fatalf("expected 400 for invalid priority, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestUpdateIssueRejectsStaleLabelIDsWithoutMutation(t *testing.T) {
+	issueID := createTestIssue(t, "update stale label issue", "todo", "none")
+	t.Cleanup(func() { deleteTestIssue(t, issueID) })
+
+	w := httptest.NewRecorder()
+	req := newRequest("POST", "/api/labels", map[string]any{
+		"name":  "stale-update-label",
+		"color": "#3b82f6",
+	})
+	testHandler.CreateLabel(w, req)
+	if w.Code != http.StatusCreated {
+		t.Fatalf("CreateLabel: expected 201, got %d: %s", w.Code, w.Body.String())
+	}
+	var label LabelResponse
+	if err := json.NewDecoder(w.Body).Decode(&label); err != nil {
+		t.Fatalf("decode label: %v", err)
+	}
+
+	w = httptest.NewRecorder()
+	req = newRequest("DELETE", "/api/labels/"+label.ID, nil)
+	req = withURLParam(req, "id", label.ID)
+	testHandler.DeleteLabel(w, req)
+	if w.Code != http.StatusNoContent {
+		t.Fatalf("DeleteLabel: expected 204, got %d: %s", w.Code, w.Body.String())
+	}
+
+	w = httptest.NewRecorder()
+	req = newRequest("PUT", "/api/issues/"+issueID, map[string]any{
+		"title":     "mutated title",
+		"status":    "in_progress",
+		"label_ids": []string{label.ID},
+	})
+	req = withURLParam(req, "id", issueID)
+	testHandler.UpdateIssue(w, req)
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("expected 404 for stale label, got %d: %s", w.Code, w.Body.String())
+	}
+
+	issue, err := testHandler.Queries.GetIssue(context.Background(), parseUUID(issueID))
+	if err != nil {
+		t.Fatalf("GetIssue after failed update: %v", err)
+	}
+	if issue.Title != "update stale label issue" {
+		t.Fatalf("expected title to remain unchanged, got %q", issue.Title)
+	}
+	if issue.Status != "todo" {
+		t.Fatalf("expected status to remain todo, got %q", issue.Status)
 	}
 }
 

--- a/server/internal/handler/label_test.go
+++ b/server/internal/handler/label_test.go
@@ -276,6 +276,55 @@ func TestCreateIssueCarriesLabelIdsAndAcceptanceCriteria(t *testing.T) {
 	})
 }
 
+func TestCreateIssueRejectsStaleLabelIDsWithoutMutation(t *testing.T) {
+	w := httptest.NewRecorder()
+	req := newRequest("POST", "/api/labels", map[string]any{
+		"name":  "stale-issue-label-" + uuid.NewString()[:8],
+		"color": "#3b82f6",
+	})
+	testHandler.CreateLabel(w, req)
+	if w.Code != http.StatusCreated {
+		t.Fatalf("CreateLabel: expected 201, got %d: %s", w.Code, w.Body.String())
+	}
+	var label LabelResponse
+	if err := json.NewDecoder(w.Body).Decode(&label); err != nil {
+		t.Fatalf("decode label: %v", err)
+	}
+
+	w = httptest.NewRecorder()
+	req = newRequest("DELETE", "/api/labels/"+label.ID, nil)
+	req = withURLParam(req, "id", label.ID)
+	testHandler.DeleteLabel(w, req)
+	if w.Code != http.StatusNoContent {
+		t.Fatalf("DeleteLabel: expected 204, got %d: %s", w.Code, w.Body.String())
+	}
+
+	title := "Issue rejects stale label " + uuid.NewString()[:8]
+	w = httptest.NewRecorder()
+	req = newRequest("POST", "/api/issues?workspace_id="+testWorkspaceID, map[string]any{
+		"title":     title,
+		"status":    "todo",
+		"priority":  "medium",
+		"label_ids": []string{label.ID},
+	})
+	testHandler.CreateIssue(w, req)
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("CreateIssue: expected 404 for stale label, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var count int64
+	if err := testPool.QueryRow(context.Background(), `
+		SELECT COUNT(*)
+		FROM issue
+		WHERE workspace_id = $1 AND title = $2
+	`, testWorkspaceID, title).Scan(&count); err != nil {
+		t.Fatalf("count issue rows: %v", err)
+	}
+	if count != 0 {
+		t.Fatalf("expected no issue row to be created, found %d", count)
+	}
+}
+
 func TestIssueLabelRejectsNonIssueScope(t *testing.T) {
 	w := httptest.NewRecorder()
 	req := newRequest("POST", "/api/issues?workspace_id="+testWorkspaceID, map[string]any{

--- a/server/internal/handler/label_test.go
+++ b/server/internal/handler/label_test.go
@@ -198,6 +198,84 @@ func TestIssueLabelAttachDetach(t *testing.T) {
 	}
 }
 
+func TestCreateIssueCarriesLabelIdsAndAcceptanceCriteria(t *testing.T) {
+	w := httptest.NewRecorder()
+	req := newRequest("POST", "/api/labels", map[string]any{
+		"name":  "intake-slice-" + uuid.NewString()[:8],
+		"color": "#3b82f6",
+	})
+	testHandler.CreateLabel(w, req)
+	if w.Code != http.StatusCreated {
+		t.Fatalf("CreateLabel: expected 201, got %d: %s", w.Code, w.Body.String())
+	}
+	var label LabelResponse
+	if err := json.NewDecoder(w.Body).Decode(&label); err != nil {
+		t.Fatalf("decode label: %v", err)
+	}
+	t.Cleanup(func() {
+		w := httptest.NewRecorder()
+		req := newRequest("DELETE", "/api/labels/"+label.ID, nil)
+		req = withURLParam(req, "id", label.ID)
+		testHandler.DeleteLabel(w, req)
+	})
+
+	w = httptest.NewRecorder()
+	req = newRequest("POST", "/api/issues?workspace_id="+testWorkspaceID, map[string]any{
+		"title":               "Issue carries intake fields",
+		"status":              "todo",
+		"priority":            "medium",
+		"label_ids":           []string{label.ID},
+		"acceptance_criteria": []string{"the intake fields are stored"},
+	})
+	testHandler.CreateIssue(w, req)
+	if w.Code != http.StatusCreated {
+		t.Fatalf("CreateIssue: expected 201, got %d: %s", w.Code, w.Body.String())
+	}
+	var created IssueResponse
+	if err := json.NewDecoder(w.Body).Decode(&created); err != nil {
+		t.Fatalf("decode issue: %v", err)
+	}
+	if created.Labels == nil || len(*created.Labels) != 1 || (*created.Labels)[0].ID != label.ID {
+		t.Fatalf("expected created issue to return the attached label, got %+v", created.Labels)
+	}
+
+	issue, err := testHandler.Queries.GetIssue(context.Background(), parseUUID(created.ID))
+	if err != nil {
+		t.Fatalf("GetIssue: %v", err)
+	}
+	var criteria []string
+	if err := json.Unmarshal(issue.AcceptanceCriteria, &criteria); err != nil {
+		t.Fatalf("unmarshal acceptance_criteria: %v", err)
+	}
+	if len(criteria) != 1 || criteria[0] != "the intake fields are stored" {
+		t.Fatalf("unexpected acceptance_criteria: %#v", criteria)
+	}
+
+	w = httptest.NewRecorder()
+	req = newRequest("GET", "/api/issues/"+created.ID+"/labels", nil)
+	req = withURLParam(req, "id", created.ID)
+	testHandler.ListLabelsForIssue(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("ListLabelsForIssue: expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	var issueLabels struct {
+		Labels []LabelResponse `json:"labels"`
+	}
+	if err := json.NewDecoder(w.Body).Decode(&issueLabels); err != nil {
+		t.Fatalf("decode issue labels: %v", err)
+	}
+	if len(issueLabels.Labels) != 1 || issueLabels.Labels[0].ID != label.ID {
+		t.Fatalf("unexpected issue labels: %+v", issueLabels.Labels)
+	}
+
+	t.Cleanup(func() {
+		w := httptest.NewRecorder()
+		req := newRequest("DELETE", "/api/issues/"+created.ID, nil)
+		req = withURLParam(req, "id", created.ID)
+		testHandler.DeleteIssue(w, req)
+	})
+}
+
 func TestIssueLabelRejectsNonIssueScope(t *testing.T) {
 	w := httptest.NewRecorder()
 	req := newRequest("POST", "/api/issues?workspace_id="+testWorkspaceID, map[string]any{

--- a/server/internal/integrations/channel/engine/router.go
+++ b/server/internal/integrations/channel/engine/router.go
@@ -2,9 +2,12 @@ package engine
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"log/slog"
+	"regexp"
+	"strings"
 	"sync"
 	"time"
 
@@ -13,6 +16,8 @@ import (
 	"github.com/multica-ai/multica/server/internal/integrations/channel"
 	"github.com/multica-ai/multica/server/internal/service"
 )
+
+var closingLineRE = regexp.MustCompile(`(?im)^Closes when:\s*(.+)$`)
 
 // Router is the channel-agnostic inbound pipeline — the generalization of the
 // Feishu-only lark.Dispatcher (+ the Hub's handleEvent outbound seam). It is
@@ -453,20 +458,43 @@ func (r *Router) createIssue(ctx context.Context, inst ResolvedInstallation, ori
 	if cmd.Title == "" {
 		return service.IssueCreateResult{}, ErrEmptyIssueTitle
 	}
+	criteria := extractAcceptanceCriteriaJSON(cmd.Description)
 	params := service.IssueCreateParams{
-		WorkspaceID:  inst.WorkspaceID,
-		Title:        cmd.Title,
-		Description:  pgtype.Text{String: cmd.Description, Valid: cmd.Description != ""},
-		Status:       "todo",
-		Priority:     "none",
-		AssigneeType: pgtype.Text{String: "agent", Valid: true},
-		AssigneeID:   inst.AgentID,
-		CreatorType:  "member",
-		CreatorID:    creatorUserID,
-		OriginType:   pgtype.Text{String: originType, Valid: originType != ""},
-		OriginID:     sessionID,
+		WorkspaceID:        inst.WorkspaceID,
+		Title:              cmd.Title,
+		Description:        pgtype.Text{String: cmd.Description, Valid: cmd.Description != ""},
+		Status:             "todo",
+		Priority:           "none",
+		AssigneeType:       pgtype.Text{String: "agent", Valid: true},
+		AssigneeID:         inst.AgentID,
+		CreatorType:        "member",
+		CreatorID:          creatorUserID,
+		OriginType:         pgtype.Text{String: originType, Valid: originType != ""},
+		OriginID:           sessionID,
+		AcceptanceCriteria: criteria,
+		LabelIDs:           []pgtype.UUID{},
 	}
 	return r.issues.Create(ctx, params, service.IssueCreateOpts{})
+}
+
+func extractAcceptanceCriteriaJSON(description string) []byte {
+	lines := strings.Split(description, "\n")
+	criteria := make([]string, 0, len(lines))
+	for _, line := range lines {
+		line = strings.TrimSpace(line)
+		if !closingLineRE.MatchString(line) {
+			continue
+		}
+		criteria = append(criteria, line)
+	}
+	if len(criteria) == 0 {
+		return []byte("[]")
+	}
+	data, err := json.Marshal(criteria)
+	if err != nil {
+		return []byte("[]")
+	}
+	return data
 }
 
 // ErrEmptyIssueTitle is returned by createIssue when /issue has no title and

--- a/server/internal/service/issue.go
+++ b/server/internal/service/issue.go
@@ -50,23 +50,25 @@ func NewIssueService(q *db.Queries, tx TxStarter, bus *events.Bus, ac analytics.
 // to IssueService.Create. The handler owns the parsing step that turns its
 // request payload into this struct; the service stays transport-agnostic.
 type IssueCreateParams struct {
-	WorkspaceID    pgtype.UUID
-	Title          string
-	Description    pgtype.Text
-	Status         string
-	Priority       string
-	AssigneeType   pgtype.Text
-	AssigneeID     pgtype.UUID
-	CreatorType    string // "agent" or "member"
-	CreatorID      pgtype.UUID
-	ParentIssueID  pgtype.UUID
-	ProjectID      pgtype.UUID
-	StartDate      pgtype.Date
-	DueDate        pgtype.Date
-	OriginType     pgtype.Text
-	OriginID       pgtype.UUID
-	AttachmentIDs  []pgtype.UUID
-	AllowDuplicate bool
+	WorkspaceID        pgtype.UUID
+	Title              string
+	Description        pgtype.Text
+	Status             string
+	Priority           string
+	AssigneeType       pgtype.Text
+	AssigneeID         pgtype.UUID
+	CreatorType        string // "agent" or "member"
+	CreatorID          pgtype.UUID
+	ParentIssueID      pgtype.UUID
+	AcceptanceCriteria []byte
+	ProjectID          pgtype.UUID
+	StartDate          pgtype.Date
+	DueDate            pgtype.Date
+	OriginType         pgtype.Text
+	OriginID           pgtype.UUID
+	AttachmentIDs      []pgtype.UUID
+	LabelIDs           []pgtype.UUID
+	AllowDuplicate     bool
 	// Stage groups this issue into an ordered barrier group under its parent
 	// (NULL = unstaged). See issue_child_done.go for the staged-barrier wake.
 	Stage pgtype.Int4
@@ -225,47 +227,62 @@ func (s *IssueService) Create(ctx context.Context, p IssueCreateParams, opts Iss
 	var issue db.Issue
 	if p.OriginType.Valid {
 		issue, err = qtx.CreateIssueWithOrigin(ctx, db.CreateIssueWithOriginParams{
-			WorkspaceID:   p.WorkspaceID,
-			Title:         p.Title,
-			Description:   p.Description,
-			Status:        p.Status,
-			Priority:      p.Priority,
-			AssigneeType:  p.AssigneeType,
-			AssigneeID:    p.AssigneeID,
-			CreatorType:   p.CreatorType,
-			CreatorID:     p.CreatorID,
-			ParentIssueID: p.ParentIssueID,
-			Position:      newPosition,
-			StartDate:     p.StartDate,
-			DueDate:       p.DueDate,
-			Number:        issueNumber,
-			ProjectID:     projectID,
-			OriginType:    p.OriginType,
-			OriginID:      p.OriginID,
-			Stage:         p.Stage,
+			WorkspaceID:        p.WorkspaceID,
+			Title:              p.Title,
+			Description:        p.Description,
+			Status:             p.Status,
+			Priority:           p.Priority,
+			AssigneeType:       p.AssigneeType,
+			AssigneeID:         p.AssigneeID,
+			CreatorType:        p.CreatorType,
+			CreatorID:          p.CreatorID,
+			ParentIssueID:      p.ParentIssueID,
+			AcceptanceCriteria: p.AcceptanceCriteria,
+			Position:           newPosition,
+			StartDate:          p.StartDate,
+			DueDate:            p.DueDate,
+			Number:             issueNumber,
+			ProjectID:          projectID,
+			OriginType:         p.OriginType,
+			OriginID:           p.OriginID,
+			Stage:              p.Stage,
 		})
 	} else {
 		issue, err = qtx.CreateIssue(ctx, db.CreateIssueParams{
-			WorkspaceID:   p.WorkspaceID,
-			Title:         p.Title,
-			Description:   p.Description,
-			Status:        p.Status,
-			Priority:      p.Priority,
-			AssigneeType:  p.AssigneeType,
-			AssigneeID:    p.AssigneeID,
-			CreatorType:   p.CreatorType,
-			CreatorID:     p.CreatorID,
-			ParentIssueID: p.ParentIssueID,
-			Position:      newPosition,
-			StartDate:     p.StartDate,
-			DueDate:       p.DueDate,
-			Number:        issueNumber,
-			ProjectID:     projectID,
-			Stage:         p.Stage,
+			WorkspaceID:        p.WorkspaceID,
+			Title:              p.Title,
+			Description:        p.Description,
+			Status:             p.Status,
+			Priority:           p.Priority,
+			AssigneeType:       p.AssigneeType,
+			AssigneeID:         p.AssigneeID,
+			CreatorType:        p.CreatorType,
+			CreatorID:          p.CreatorID,
+			ParentIssueID:      p.ParentIssueID,
+			AcceptanceCriteria: p.AcceptanceCriteria,
+			Position:           newPosition,
+			StartDate:          p.StartDate,
+			DueDate:            p.DueDate,
+			Number:             issueNumber,
+			ProjectID:          projectID,
+			Stage:              p.Stage,
 		})
 	}
 	if err != nil {
 		return IssueCreateResult{}, fmt.Errorf("create issue: %w", err)
+	}
+
+	for _, labelID := range p.LabelIDs {
+		if !labelID.Valid {
+			continue
+		}
+		if err := qtx.AttachLabelToIssue(ctx, db.AttachLabelToIssueParams{
+			IssueID:     issue.ID,
+			LabelID:     labelID,
+			WorkspaceID: p.WorkspaceID,
+		}); err != nil {
+			return IssueCreateResult{}, fmt.Errorf("attach label: %w", err)
+		}
 	}
 
 	if err := tx.Commit(ctx); err != nil {

--- a/server/internal/service/issue.go
+++ b/server/internal/service/issue.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"log/slog"
 
+	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgtype"
 	"github.com/multica-ai/multica/server/internal/analytics"
 	"github.com/multica-ai/multica/server/internal/events"
@@ -126,6 +127,10 @@ var ErrParentIssueNotFound = errors.New("parent issue not found in this workspac
 // having to remember it. Callers translate this into 400.
 var ErrProjectNotFound = errors.New("project not found in this workspace")
 
+// ErrIssueLabelNotFound signals that one of the requested issue labels does
+// not exist in the workspace or is not scoped for issues.
+var ErrIssueLabelNotFound = errors.New("issue label not found")
+
 // IssueCreateResult is the typed return from IssueService.Create.
 //
 //   - On the happy path: Issue is the new row, Attachments lists the
@@ -194,6 +199,10 @@ func (s *IssueService) Create(ctx context.Context, p IssueCreateParams, opts Iss
 		}); err != nil {
 			return IssueCreateResult{}, ErrProjectNotFound
 		}
+	}
+
+	if err := s.validateIssueLabels(ctx, qtx, p.WorkspaceID, p.LabelIDs); err != nil {
+		return IssueCreateResult{}, err
 	}
 
 	duplicate, found, err := issueguard.LockAndFindActiveDuplicate(ctx, qtx, p.WorkspaceID, projectID, p.ParentIssueID, p.Title, p.AllowDuplicate)
@@ -301,6 +310,33 @@ func (s *IssueService) Create(ctx context.Context, p IssueCreateParams, opts Iss
 	s.maybeEnqueueOnAssign(ctx, issue, p.CreatorType, actorID)
 
 	return IssueCreateResult{Issue: issue, Attachments: attachments}, nil
+}
+
+func (s *IssueService) validateIssueLabels(ctx context.Context, qtx *db.Queries, workspaceID pgtype.UUID, labelIDs []pgtype.UUID) error {
+	desiredByID := make(map[string]pgtype.UUID, len(labelIDs))
+	for _, labelID := range labelIDs {
+		if !labelID.Valid {
+			continue
+		}
+		desiredByID[util.UUIDToString(labelID)] = labelID
+	}
+
+	for _, labelID := range desiredByID {
+		label, err := qtx.GetLabel(ctx, db.GetLabelParams{
+			ID:          labelID,
+			WorkspaceID: workspaceID,
+		})
+		if err != nil {
+			if errors.Is(err, pgx.ErrNoRows) {
+				return ErrIssueLabelNotFound
+			}
+			return fmt.Errorf("get label for issue: %w", err)
+		}
+		if label.ResourceType != "issue" {
+			return ErrIssueLabelNotFound
+		}
+	}
+	return nil
 }
 
 // linkAttachments links the given attachment IDs to the newly created

--- a/server/pkg/db/generated/issue.sql.go
+++ b/server/pkg/db/generated/issue.sql.go
@@ -174,31 +174,32 @@ const createIssue = `-- name: CreateIssue :one
 INSERT INTO issue (
     workspace_id, title, description, status, priority,
     assignee_type, assignee_id, creator_type, creator_id,
-    parent_issue_id, position, start_date, due_date, number, project_id,
+    parent_issue_id, acceptance_criteria, position, start_date, due_date, number, project_id,
     stage
 ) VALUES (
-    $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15,
-    $16
+    $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16,
+    $17
 ) RETURNING id, workspace_id, title, description, status, priority, assignee_type, assignee_id, creator_type, creator_id, parent_issue_id, acceptance_criteria, context_refs, position, due_date, created_at, updated_at, number, project_id, origin_type, origin_id, first_executed_at, start_date, metadata, stage
 `
 
 type CreateIssueParams struct {
-	WorkspaceID   pgtype.UUID `json:"workspace_id"`
-	Title         string      `json:"title"`
-	Description   pgtype.Text `json:"description"`
-	Status        string      `json:"status"`
-	Priority      string      `json:"priority"`
-	AssigneeType  pgtype.Text `json:"assignee_type"`
-	AssigneeID    pgtype.UUID `json:"assignee_id"`
-	CreatorType   string      `json:"creator_type"`
-	CreatorID     pgtype.UUID `json:"creator_id"`
-	ParentIssueID pgtype.UUID `json:"parent_issue_id"`
-	Position      float64     `json:"position"`
-	StartDate     pgtype.Date `json:"start_date"`
-	DueDate       pgtype.Date `json:"due_date"`
-	Number        int32       `json:"number"`
-	ProjectID     pgtype.UUID `json:"project_id"`
-	Stage         pgtype.Int4 `json:"stage"`
+	WorkspaceID        pgtype.UUID `json:"workspace_id"`
+	Title              string      `json:"title"`
+	Description        pgtype.Text `json:"description"`
+	Status             string      `json:"status"`
+	Priority           string      `json:"priority"`
+	AssigneeType       pgtype.Text `json:"assignee_type"`
+	AssigneeID         pgtype.UUID `json:"assignee_id"`
+	CreatorType        string      `json:"creator_type"`
+	CreatorID          pgtype.UUID `json:"creator_id"`
+	ParentIssueID      pgtype.UUID `json:"parent_issue_id"`
+	AcceptanceCriteria []byte      `json:"acceptance_criteria"`
+	Position           float64     `json:"position"`
+	StartDate          pgtype.Date `json:"start_date"`
+	DueDate            pgtype.Date `json:"due_date"`
+	Number             int32       `json:"number"`
+	ProjectID          pgtype.UUID `json:"project_id"`
+	Stage              pgtype.Int4 `json:"stage"`
 }
 
 func (q *Queries) CreateIssue(ctx context.Context, arg CreateIssueParams) (Issue, error) {
@@ -213,6 +214,7 @@ func (q *Queries) CreateIssue(ctx context.Context, arg CreateIssueParams) (Issue
 		arg.CreatorType,
 		arg.CreatorID,
 		arg.ParentIssueID,
+		arg.AcceptanceCriteria,
 		arg.Position,
 		arg.StartDate,
 		arg.DueDate,
@@ -255,33 +257,34 @@ const createIssueWithOrigin = `-- name: CreateIssueWithOrigin :one
 INSERT INTO issue (
     workspace_id, title, description, status, priority,
     assignee_type, assignee_id, creator_type, creator_id,
-    parent_issue_id, position, start_date, due_date, number, project_id,
+    parent_issue_id, acceptance_criteria, position, start_date, due_date, number, project_id,
     origin_type, origin_id, stage
 ) VALUES (
-    $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15,
-    $16, $17, $18
+    $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16,
+    $17, $18, $19
 ) RETURNING id, workspace_id, title, description, status, priority, assignee_type, assignee_id, creator_type, creator_id, parent_issue_id, acceptance_criteria, context_refs, position, due_date, created_at, updated_at, number, project_id, origin_type, origin_id, first_executed_at, start_date, metadata, stage
 `
 
 type CreateIssueWithOriginParams struct {
-	WorkspaceID   pgtype.UUID `json:"workspace_id"`
-	Title         string      `json:"title"`
-	Description   pgtype.Text `json:"description"`
-	Status        string      `json:"status"`
-	Priority      string      `json:"priority"`
-	AssigneeType  pgtype.Text `json:"assignee_type"`
-	AssigneeID    pgtype.UUID `json:"assignee_id"`
-	CreatorType   string      `json:"creator_type"`
-	CreatorID     pgtype.UUID `json:"creator_id"`
-	ParentIssueID pgtype.UUID `json:"parent_issue_id"`
-	Position      float64     `json:"position"`
-	StartDate     pgtype.Date `json:"start_date"`
-	DueDate       pgtype.Date `json:"due_date"`
-	Number        int32       `json:"number"`
-	ProjectID     pgtype.UUID `json:"project_id"`
-	OriginType    pgtype.Text `json:"origin_type"`
-	OriginID      pgtype.UUID `json:"origin_id"`
-	Stage         pgtype.Int4 `json:"stage"`
+	WorkspaceID        pgtype.UUID `json:"workspace_id"`
+	Title              string      `json:"title"`
+	Description        pgtype.Text `json:"description"`
+	Status             string      `json:"status"`
+	Priority           string      `json:"priority"`
+	AssigneeType       pgtype.Text `json:"assignee_type"`
+	AssigneeID         pgtype.UUID `json:"assignee_id"`
+	CreatorType        string      `json:"creator_type"`
+	CreatorID          pgtype.UUID `json:"creator_id"`
+	ParentIssueID      pgtype.UUID `json:"parent_issue_id"`
+	AcceptanceCriteria []byte      `json:"acceptance_criteria"`
+	Position           float64     `json:"position"`
+	StartDate          pgtype.Date `json:"start_date"`
+	DueDate            pgtype.Date `json:"due_date"`
+	Number             int32       `json:"number"`
+	ProjectID          pgtype.UUID `json:"project_id"`
+	OriginType         pgtype.Text `json:"origin_type"`
+	OriginID           pgtype.UUID `json:"origin_id"`
+	Stage              pgtype.Int4 `json:"stage"`
 }
 
 func (q *Queries) CreateIssueWithOrigin(ctx context.Context, arg CreateIssueWithOriginParams) (Issue, error) {
@@ -296,6 +299,7 @@ func (q *Queries) CreateIssueWithOrigin(ctx context.Context, arg CreateIssueWith
 		arg.CreatorType,
 		arg.CreatorID,
 		arg.ParentIssueID,
+		arg.AcceptanceCriteria,
 		arg.Position,
 		arg.StartDate,
 		arg.DueDate,
@@ -1223,31 +1227,33 @@ UPDATE issue SET
     priority = COALESCE($5, priority),
     assignee_type = $6,
     assignee_id = $7,
-    position = COALESCE($8, position),
-    start_date = $9,
-    due_date = $10,
-    parent_issue_id = $11,
-    project_id = $12,
-    stage = $13,
+    acceptance_criteria = COALESCE($8::jsonb, acceptance_criteria),
+    position = COALESCE($9, position),
+    start_date = $10,
+    due_date = $11,
+    parent_issue_id = $12,
+    project_id = $13,
+    stage = $14,
     updated_at = now()
 WHERE id = $1
 RETURNING id, workspace_id, title, description, status, priority, assignee_type, assignee_id, creator_type, creator_id, parent_issue_id, acceptance_criteria, context_refs, position, due_date, created_at, updated_at, number, project_id, origin_type, origin_id, first_executed_at, start_date, metadata, stage
 `
 
 type UpdateIssueParams struct {
-	ID            pgtype.UUID   `json:"id"`
-	Title         pgtype.Text   `json:"title"`
-	Description   pgtype.Text   `json:"description"`
-	Status        pgtype.Text   `json:"status"`
-	Priority      pgtype.Text   `json:"priority"`
-	AssigneeType  pgtype.Text   `json:"assignee_type"`
-	AssigneeID    pgtype.UUID   `json:"assignee_id"`
-	Position      pgtype.Float8 `json:"position"`
-	StartDate     pgtype.Date   `json:"start_date"`
-	DueDate       pgtype.Date   `json:"due_date"`
-	ParentIssueID pgtype.UUID   `json:"parent_issue_id"`
-	ProjectID     pgtype.UUID   `json:"project_id"`
-	Stage         pgtype.Int4   `json:"stage"`
+	ID                 pgtype.UUID   `json:"id"`
+	Title              pgtype.Text   `json:"title"`
+	Description        pgtype.Text   `json:"description"`
+	Status             pgtype.Text   `json:"status"`
+	Priority           pgtype.Text   `json:"priority"`
+	AssigneeType       pgtype.Text   `json:"assignee_type"`
+	AssigneeID         pgtype.UUID   `json:"assignee_id"`
+	AcceptanceCriteria []byte        `json:"acceptance_criteria"`
+	Position           pgtype.Float8 `json:"position"`
+	StartDate          pgtype.Date   `json:"start_date"`
+	DueDate            pgtype.Date   `json:"due_date"`
+	ParentIssueID      pgtype.UUID   `json:"parent_issue_id"`
+	ProjectID          pgtype.UUID   `json:"project_id"`
+	Stage              pgtype.Int4   `json:"stage"`
 }
 
 func (q *Queries) UpdateIssue(ctx context.Context, arg UpdateIssueParams) (Issue, error) {
@@ -1259,6 +1265,7 @@ func (q *Queries) UpdateIssue(ctx context.Context, arg UpdateIssueParams) (Issue
 		arg.Priority,
 		arg.AssigneeType,
 		arg.AssigneeID,
+		arg.AcceptanceCriteria,
 		arg.Position,
 		arg.StartDate,
 		arg.DueDate,

--- a/server/pkg/db/queries/issue.sql
+++ b/server/pkg/db/queries/issue.sql
@@ -73,10 +73,10 @@ WHERE id = $1 AND workspace_id = $2;
 INSERT INTO issue (
     workspace_id, title, description, status, priority,
     assignee_type, assignee_id, creator_type, creator_id,
-    parent_issue_id, position, start_date, due_date, number, project_id,
+    parent_issue_id, acceptance_criteria, position, start_date, due_date, number, project_id,
     stage
 ) VALUES (
-    $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15,
+    $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16,
     sqlc.narg('stage')
 ) RETURNING *;
 
@@ -92,6 +92,7 @@ UPDATE issue SET
     priority = COALESCE(sqlc.narg('priority'), priority),
     assignee_type = sqlc.narg('assignee_type'),
     assignee_id = sqlc.narg('assignee_id'),
+    acceptance_criteria = COALESCE(sqlc.narg('acceptance_criteria')::jsonb, acceptance_criteria),
     position = COALESCE(sqlc.narg('position'), position),
     start_date = sqlc.narg('start_date'),
     due_date = sqlc.narg('due_date'),
@@ -114,10 +115,10 @@ RETURNING *;
 INSERT INTO issue (
     workspace_id, title, description, status, priority,
     assignee_type, assignee_id, creator_type, creator_id,
-    parent_issue_id, position, start_date, due_date, number, project_id,
+    parent_issue_id, acceptance_criteria, position, start_date, due_date, number, project_id,
     origin_type, origin_id, stage
 ) VALUES (
-    $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15,
+    $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16,
     sqlc.narg('origin_type'), sqlc.narg('origin_id'), sqlc.narg('stage')
 ) RETURNING *;
 


### PR DESCRIPTION
Carries `label_ids` and `acceptance_criteria` through the request models and all known create callers, while preserving legacy records.

Tests:
- `go test ./internal/handler -run 'Test(CreateIssueCarriesLabelIdsAndAcceptanceCriteria|IssueLabelAttachDetach|CreateIssueInvalidStatusReturns400|UpdateIssueInvalidStatusReturns400|CreateIssueRejectsStaleLabelIDsWithoutMutation|UpdateIssueRejectsStaleLabelIDsWithoutMutation)$'`
- `go test ./internal/integrations/channel/engine -run 'Test.*'`
- `pnpm test -- modals/create-issue.test.tsx workspace/welcome-after-onboarding.test.tsx`
- `pnpm exec tsc --noEmit` in `apps/mobile`

Closes SNDBX-491
