### PR TITLE
Ingest Feishu image attachments

### DIFF
--- a/server/cmd/server/router.go
+++ b/server/cmd/server/router.go
@@ -353,6 +353,7 @@ func NewRouterWithOptions(pool *pgxpool.Pool, hub *realtime.Hub, bus *events.Bus
 					APIClient:   larkClient,
 					Credentials: installSvc,
 					Logger:      slog.Default(),
+					Storage:     store,
 				})
 				channelRouter.Register(channel.TypeFeishu, lark.NewFeishuResolverSet(
 					cs, feishuSession, auditLogger, resolverReplier, typingIndicator,

--- a/server/cmd/server/router.go
+++ b/server/cmd/server/router.go
@@ -348,15 +348,16 @@ func NewRouterWithOptions(pool *pgxpool.Pool, hub *realtime.Hub, bus *events.Bus
 				// (inbound pipeline seams) is all it takes to add the platform
 				// to the engine — no engine edit.
 				connector, connectorLabel := buildLarkConnector(installSvc, larkClient)
+				mediaDownloader, _ := larkClient.(lark.MessageResourceDownloader)
 				lark.RegisterFeishu(channelRegistry, lark.FeishuChannelDeps{
 					Connector:   connector,
 					APIClient:   larkClient,
 					Credentials: installSvc,
 					Logger:      slog.Default(),
-					Storage:     store,
 				})
 				channelRouter.Register(channel.TypeFeishu, lark.NewFeishuResolverSet(
 					cs, feishuSession, auditLogger, resolverReplier, typingIndicator,
+					mediaDownloader, installSvc, store,
 				))
 				slog.Info("lark inbound pipeline wired", "connector", connectorLabel)
 

--- a/server/internal/integrations/channel/engine/resolvers.go
+++ b/server/internal/integrations/channel/engine/resolvers.go
@@ -92,6 +92,7 @@ type EnsureSessionParams struct {
 type AppendParams struct {
 	SessionID      pgtype.UUID
 	Sender         pgtype.UUID
+	WorkspaceID    pgtype.UUID
 	InstallationID pgtype.UUID
 	Message        channel.InboundMessage
 	ClaimToken     pgtype.UUID

--- a/server/internal/integrations/channel/engine/resolvers.go
+++ b/server/internal/integrations/channel/engine/resolvers.go
@@ -147,6 +147,14 @@ type IdentityResolver interface {
 	ResolveSender(ctx context.Context, inst ResolvedInstallation, msg channel.InboundMessage) (ResolvedIdentity, error)
 }
 
+// MediaResolver persists platform media after the Router's drop gates have
+// accepted the message. Cleanup removes any objects created by Resolve and is
+// called when a later pre-commit step fails. A nil resolver means the platform
+// has no inbound media work.
+type MediaResolver interface {
+	Resolve(ctx context.Context, inst ResolvedInstallation, msg channel.InboundMessage) (resolved channel.InboundMessage, cleanup func(context.Context), err error)
+}
+
 // Deduper is the two-phase idempotency seam. Claim mints an owner-fence token
 // (ErrDuplicate when already processed / in flight); Mark/Release are fenced on
 // the token (a no-op on token mismatch is not an error).
@@ -200,6 +208,7 @@ type ResolverSet struct {
 	Installation InstallationResolver
 	Identity     IdentityResolver
 	Dedup        Deduper
+	Media        MediaResolver
 	Session      SessionBinder
 	Audit        Auditor
 	Replier      OutboundReplier

--- a/server/internal/integrations/channel/engine/router.go
+++ b/server/internal/integrations/channel/engine/router.go
@@ -38,9 +38,10 @@ type Router struct {
 
 	batcher *pendingBatcher
 
-	replyTimeout time.Duration
-	mediaTimeout time.Duration
-	replyWg      sync.WaitGroup
+	replyTimeout   time.Duration
+	mediaTimeout   time.Duration
+	cleanupTimeout time.Duration
+	replyWg        sync.WaitGroup
 
 	logger *slog.Logger
 
@@ -55,9 +56,13 @@ type RouterConfig struct {
 	// under the platform ACK deadline (Lark: 3s). Defaults to 2.5s.
 	ReplyTimeout time.Duration
 	// MediaTimeout bounds platform download + object-storage upload while the
-	// connector is waiting to ACK. Defaults to 2s (below Lark's 3s budget).
+	// connector is waiting to ACK. Defaults to 750ms, reserving most of
+	// Lark's 3s budget for enrichment, DB work, and the ACK write.
 	MediaTimeout time.Duration
-	Logger       *slog.Logger
+	// CleanupTimeout independently bounds best-effort deletion of media that
+	// was uploaded but could not be linked. Defaults to 500ms.
+	CleanupTimeout time.Duration
+	Logger         *slog.Logger
 }
 
 // NewRouter builds a Router around the shared (platform-agnostic) services:
@@ -69,20 +74,24 @@ func NewRouter(issues IssueCreator, tasks TaskEnqueuer, reader SessionReader, cf
 		cfg.ReplyTimeout = 2500 * time.Millisecond
 	}
 	if cfg.MediaTimeout == 0 {
-		cfg.MediaTimeout = 2 * time.Second
+		cfg.MediaTimeout = 750 * time.Millisecond
+	}
+	if cfg.CleanupTimeout == 0 {
+		cfg.CleanupTimeout = 500 * time.Millisecond
 	}
 	if cfg.Logger == nil {
 		cfg.Logger = slog.Default()
 	}
 	return &Router{
-		sets:         make(map[channel.Type]ResolverSet),
-		issues:       issues,
-		tasks:        tasks,
-		reader:       reader,
-		replyTimeout: cfg.ReplyTimeout,
-		mediaTimeout: cfg.MediaTimeout,
-		logger:       cfg.Logger,
-		pendingFresh: make(map[string]bool),
+		sets:           make(map[channel.Type]ResolverSet),
+		issues:         issues,
+		tasks:          tasks,
+		reader:         reader,
+		replyTimeout:   cfg.ReplyTimeout,
+		mediaTimeout:   cfg.MediaTimeout,
+		cleanupTimeout: cfg.CleanupTimeout,
+		logger:         cfg.Logger,
+		pendingFresh:   make(map[string]bool),
 	}
 }
 
@@ -256,19 +265,28 @@ func (r *Router) processClaimed(ctx context.Context, set ResolverSet, msg channe
 	cleanupMedia := func(context.Context) {}
 	if set.Media != nil {
 		mediaCtx, cancelMedia := context.WithTimeout(ctx, r.mediaTimeout)
-		msg, cleanupMedia, err = set.Media.Resolve(mediaCtx, inst, msg)
+		resolved, cleanup, mediaErr := set.Media.Resolve(mediaCtx, inst, msg)
 		cancelMedia()
-		if err != nil {
-			return Result{}, finalizeRelease, fmt.Errorf("resolve media: %w", err)
+		if cleanup != nil {
+			cleanupMedia = cleanup
 		}
-		if cleanupMedia == nil {
+		if mediaErr != nil {
+			r.logger.Warn("channel router: media resolution failed; ingesting placeholder",
+				"channel_type", string(msg.Source.ChannelType),
+				"event_id", msg.EventID,
+				"message_id", msg.MessageID,
+				"error", mediaErr,
+			)
+			r.cleanupMedia(cleanupMedia)
 			cleanupMedia = func(context.Context) {}
+		} else {
+			msg = resolved
 		}
 	}
 	mediaCommitted := false
 	defer func() {
 		if !mediaCommitted {
-			cleanupMedia(context.WithoutCancel(ctx))
+			r.cleanupMedia(cleanupMedia)
 		}
 	}()
 
@@ -345,6 +363,15 @@ func (r *Router) processClaimed(ctx context.Context, set ResolverSet, msg channe
 	//    in a window wins (MUL-2645).
 	r.scheduleRun(set, inst, msg, sessionID, identity.UserID)
 	return res, postAppendFinalize, nil
+}
+
+func (r *Router) cleanupMedia(cleanup func(context.Context)) {
+	if cleanup == nil {
+		return
+	}
+	cleanupCtx, cancel := context.WithTimeout(context.Background(), r.cleanupTimeout)
+	defer cancel()
+	cleanup(cleanupCtx)
 }
 
 // scheduleRun hands the per-session run trigger to the debouncer (or fires it

--- a/server/internal/integrations/channel/engine/router.go
+++ b/server/internal/integrations/channel/engine/router.go
@@ -242,7 +242,27 @@ func (r *Router) processClaimed(ctx context.Context, set ResolverSet, msg channe
 		}
 	}
 
-	// 5. Resolve the chat_session. Group sessions are created by the INSTALLER
+	// 5. Resolve platform media only after dedup, group filtering, and sender
+	//    authorization have accepted the event. If any later pre-commit step
+	//    fails, remove objects created here so no unlinked media remains.
+	cleanupMedia := func(context.Context) {}
+	if set.Media != nil {
+		msg, cleanupMedia, err = set.Media.Resolve(ctx, inst, msg)
+		if err != nil {
+			return Result{}, finalizeRelease, fmt.Errorf("resolve media: %w", err)
+		}
+		if cleanupMedia == nil {
+			cleanupMedia = func(context.Context) {}
+		}
+	}
+	mediaCommitted := false
+	defer func() {
+		if !mediaCommitted {
+			cleanupMedia(context.WithoutCancel(ctx))
+		}
+	}()
+
+	// 6. Resolve the chat_session. Group sessions are created by the INSTALLER
 	//    (stable workspace identity that won't churn with group membership);
 	//    p2p sessions by the sole human sender.
 	sessionCreator := identity.UserID
@@ -259,7 +279,7 @@ func (r *Router) processClaimed(ctx context.Context, set ResolverSet, msg channe
 		return Result{}, finalizeRelease, fmt.Errorf("ensure chat session: %w", err)
 	}
 
-	// 6. Append message + in-tx dedup Mark — the durable transition point.
+	// 7. Append message + in-tx dedup Mark — the durable transition point.
 	appendRes, err := set.Session.AppendMessage(ctx, AppendParams{
 		SessionID:      sessionID,
 		Sender:         identity.UserID,
@@ -274,6 +294,7 @@ func (r *Router) processClaimed(ctx context.Context, set ResolverSet, msg channe
 		}
 		return Result{}, finalizeRelease, fmt.Errorf("append user message: %w", err)
 	}
+	mediaCommitted = true
 
 	// Post-append paths must NOT Release (chat_message + Mark already
 	// committed). Mark-again is a no-op, so finalizeNone — unless the binder
@@ -290,7 +311,7 @@ func (r *Router) processClaimed(ctx context.Context, set ResolverSet, msg channe
 		Sender:         msg.Source.SenderID,
 	}
 
-	// 7. /issue command, if present. chat_message is already durable; all
+	// 8. /issue command, if present. chat_message is already durable; all
 	//    error returns from here signal finalizeNone (or the defensive Mark).
 	if appendRes.IssueCommand != nil {
 		issueRes, err := r.createIssue(ctx, inst, set.OriginType, identity.UserID, sessionID, *appendRes.IssueCommand)
@@ -307,7 +328,7 @@ func (r *Router) processClaimed(ctx context.Context, set ResolverSet, msg channe
 		}
 	}
 
-	// 8. Debounce the run trigger. The synchronous outcome is OutcomeIngested
+	// 9. Debounce the run trigger. The synchronous outcome is OutcomeIngested
 	//    with no TaskID — the task row is created at flush. identity.UserID is
 	//    THIS message's sender (the task initiator), deliberately not the
 	//    session creator (group sessions are creator=installer). Latest sender

--- a/server/internal/integrations/channel/engine/router.go
+++ b/server/internal/integrations/channel/engine/router.go
@@ -264,6 +264,7 @@ func (r *Router) processClaimed(ctx context.Context, set ResolverSet, msg channe
 		SessionID:      sessionID,
 		Sender:         identity.UserID,
 		InstallationID: inst.ID,
+		WorkspaceID:    inst.WorkspaceID,
 		Message:        msg,
 		ClaimToken:     claimToken,
 	})

--- a/server/internal/integrations/channel/engine/router.go
+++ b/server/internal/integrations/channel/engine/router.go
@@ -39,6 +39,7 @@ type Router struct {
 	batcher *pendingBatcher
 
 	replyTimeout time.Duration
+	mediaTimeout time.Duration
 	replyWg      sync.WaitGroup
 
 	logger *slog.Logger
@@ -53,6 +54,9 @@ type RouterConfig struct {
 	// call. It runs off the connector ACK path, so it must stay strictly
 	// under the platform ACK deadline (Lark: 3s). Defaults to 2.5s.
 	ReplyTimeout time.Duration
+	// MediaTimeout bounds platform download + object-storage upload while the
+	// connector is waiting to ACK. Defaults to 2s (below Lark's 3s budget).
+	MediaTimeout time.Duration
 	Logger       *slog.Logger
 }
 
@@ -64,6 +68,9 @@ func NewRouter(issues IssueCreator, tasks TaskEnqueuer, reader SessionReader, cf
 	if cfg.ReplyTimeout == 0 {
 		cfg.ReplyTimeout = 2500 * time.Millisecond
 	}
+	if cfg.MediaTimeout == 0 {
+		cfg.MediaTimeout = 2 * time.Second
+	}
 	if cfg.Logger == nil {
 		cfg.Logger = slog.Default()
 	}
@@ -73,6 +80,7 @@ func NewRouter(issues IssueCreator, tasks TaskEnqueuer, reader SessionReader, cf
 		tasks:        tasks,
 		reader:       reader,
 		replyTimeout: cfg.ReplyTimeout,
+		mediaTimeout: cfg.MediaTimeout,
 		logger:       cfg.Logger,
 		pendingFresh: make(map[string]bool),
 	}
@@ -247,7 +255,9 @@ func (r *Router) processClaimed(ctx context.Context, set ResolverSet, msg channe
 	//    fails, remove objects created here so no unlinked media remains.
 	cleanupMedia := func(context.Context) {}
 	if set.Media != nil {
-		msg, cleanupMedia, err = set.Media.Resolve(ctx, inst, msg)
+		mediaCtx, cancelMedia := context.WithTimeout(ctx, r.mediaTimeout)
+		msg, cleanupMedia, err = set.Media.Resolve(mediaCtx, inst, msg)
+		cancelMedia()
 		if err != nil {
 			return Result{}, finalizeRelease, fmt.Errorf("resolve media: %w", err)
 		}

--- a/server/internal/integrations/channel/engine/router_test.go
+++ b/server/internal/integrations/channel/engine/router_test.go
@@ -35,34 +35,58 @@ type fakeMedia struct {
 	cleanupCalls int
 	err          error
 	block        bool
+	cleanupOnErr bool
 }
 
 func (f *fakeMedia) Resolve(ctx context.Context, _ ResolvedInstallation, msg channel.InboundMessage) (channel.InboundMessage, func(context.Context), error) {
 	f.resolveCalls++
 	if f.err != nil {
-		return msg, nil, f.err
+		var cleanup func(context.Context)
+		if f.cleanupOnErr {
+			cleanup = func(context.Context) { f.cleanupCalls++ }
+		}
+		return msg, cleanup, f.err
 	}
 	if f.block {
 		<-ctx.Done()
-		return msg, nil, ctx.Err()
+		return msg, func(context.Context) { f.cleanupCalls++ }, ctx.Err()
 	}
 	msg.MediaRefs = []channel.MediaRef{{Type: channel.MsgTypeImage, StorageKey: "channel-inbound/image.png"}}
 	return msg, func(context.Context) { f.cleanupCalls++ }, nil
 }
 
-func TestRouter_MediaTimeoutReleasesClaim(t *testing.T) {
+func TestRouter_MediaTimeoutIngestsPlaceholder(t *testing.T) {
 	h := newHarness(t)
 	h.router.mediaTimeout = 10 * time.Millisecond
 	h.media.block = true
-	err := h.router.Handle(context.Background(), p2pMessage(t))
-	if !errors.Is(err, context.DeadlineExceeded) {
-		t.Fatalf("expected media deadline error, got %v", err)
+	msg := p2pMessage(t)
+	msg.Text = "[Image]"
+	if err := h.router.Handle(context.Background(), msg); err != nil {
+		t.Fatalf("media timeout must fail open, got %v", err)
 	}
-	if h.dedup.releases() != 1 {
-		t.Fatalf("media timeout must release claim, got %d", h.dedup.releases())
+	if h.dedup.releases() != 0 || h.dedup.marks() != 0 {
+		t.Fatalf("in-tx Mark must stand without Release; marks=%d releases=%d", h.dedup.marks(), h.dedup.releases())
 	}
-	if h.binder.lastAppend.Message.MessageID != "" {
-		t.Fatal("timed-out media must not append the message")
+	if h.binder.lastAppend.Message.Text != "[Image]" || len(h.binder.lastAppend.Message.MediaRefs) != 0 {
+		t.Fatalf("placeholder append = %+v", h.binder.lastAppend.Message)
+	}
+	if h.media.cleanupCalls != 1 {
+		t.Fatalf("partial media must be cleaned once, got %d", h.media.cleanupCalls)
+	}
+}
+
+func TestRouter_MediaErrorCleansPartialUploadAndIngests(t *testing.T) {
+	h := newHarness(t)
+	h.media.err = errors.New("upload interrupted")
+	h.media.cleanupOnErr = true
+	if err := h.router.Handle(context.Background(), p2pMessage(t)); err != nil {
+		t.Fatalf("media failure must fail open, got %v", err)
+	}
+	if h.media.cleanupCalls != 1 {
+		t.Fatalf("partial upload cleanup calls = %d, want 1", h.media.cleanupCalls)
+	}
+	if h.binder.lastAppend.Message.MessageID == "" || len(h.binder.lastAppend.Message.MediaRefs) != 0 {
+		t.Fatalf("original message was not appended without media: %+v", h.binder.lastAppend.Message)
 	}
 }
 

--- a/server/internal/integrations/channel/engine/router_test.go
+++ b/server/internal/integrations/channel/engine/router_test.go
@@ -34,15 +34,36 @@ type fakeMedia struct {
 	resolveCalls int
 	cleanupCalls int
 	err          error
+	block        bool
 }
 
-func (f *fakeMedia) Resolve(_ context.Context, _ ResolvedInstallation, msg channel.InboundMessage) (channel.InboundMessage, func(context.Context), error) {
+func (f *fakeMedia) Resolve(ctx context.Context, _ ResolvedInstallation, msg channel.InboundMessage) (channel.InboundMessage, func(context.Context), error) {
 	f.resolveCalls++
 	if f.err != nil {
 		return msg, nil, f.err
 	}
+	if f.block {
+		<-ctx.Done()
+		return msg, nil, ctx.Err()
+	}
 	msg.MediaRefs = []channel.MediaRef{{Type: channel.MsgTypeImage, StorageKey: "channel-inbound/image.png"}}
 	return msg, func(context.Context) { f.cleanupCalls++ }, nil
+}
+
+func TestRouter_MediaTimeoutReleasesClaim(t *testing.T) {
+	h := newHarness(t)
+	h.router.mediaTimeout = 10 * time.Millisecond
+	h.media.block = true
+	err := h.router.Handle(context.Background(), p2pMessage(t))
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("expected media deadline error, got %v", err)
+	}
+	if h.dedup.releases() != 1 {
+		t.Fatalf("media timeout must release claim, got %d", h.dedup.releases())
+	}
+	if h.binder.lastAppend.Message.MessageID != "" {
+		t.Fatal("timed-out media must not append the message")
+	}
 }
 
 func (f *fakeIdentity) ResolveSender(_ context.Context, _ ResolvedInstallation, _ channel.InboundMessage) (ResolvedIdentity, error) {

--- a/server/internal/integrations/channel/engine/router_test.go
+++ b/server/internal/integrations/channel/engine/router_test.go
@@ -30,6 +30,21 @@ type fakeIdentity struct {
 	err error
 }
 
+type fakeMedia struct {
+	resolveCalls int
+	cleanupCalls int
+	err          error
+}
+
+func (f *fakeMedia) Resolve(_ context.Context, _ ResolvedInstallation, msg channel.InboundMessage) (channel.InboundMessage, func(context.Context), error) {
+	f.resolveCalls++
+	if f.err != nil {
+		return msg, nil, f.err
+	}
+	msg.MediaRefs = []channel.MediaRef{{Type: channel.MsgTypeImage, StorageKey: "channel-inbound/image.png"}}
+	return msg, func(context.Context) { f.cleanupCalls++ }, nil
+}
+
 func (f *fakeIdentity) ResolveSender(_ context.Context, _ ResolvedInstallation, _ channel.InboundMessage) (ResolvedIdentity, error) {
 	return f.id, f.err
 }
@@ -217,6 +232,7 @@ type harness struct {
 	inst    *fakeInstaller
 	ident   *fakeIdentity
 	dedup   *fakeDedup
+	media   *fakeMedia
 	binder  *fakeBinder
 	audit   *fakeAuditor
 	replier *fakeReplier
@@ -232,6 +248,7 @@ func newHarness(t *testing.T) *harness {
 		inst:    &fakeInstaller{inst: activeResolved(t)},
 		ident:   &fakeIdentity{id: ResolvedIdentity{UserID: uuidFromString(t, "44444444-4444-4444-4444-444444444444")}},
 		dedup:   &fakeDedup{token: uuidFromString(t, "55555555-5555-5555-5555-555555555555")},
+		media:   &fakeMedia{},
 		binder:  &fakeBinder{ensureID: uuidFromString(t, "66666666-6666-6666-6666-666666666666"), appendResult: AppendResult{DedupMarked: true}},
 		audit:   &fakeAuditor{},
 		replier: &fakeReplier{},
@@ -245,6 +262,7 @@ func newHarness(t *testing.T) *harness {
 		Installation: h.inst,
 		Identity:     h.ident,
 		Dedup:        h.dedup,
+		Media:        h.media,
 		Session:      h.binder,
 		Audit:        h.audit,
 		Replier:      h.replier,
@@ -297,6 +315,9 @@ func TestRouter_Duplicate_Drops(t *testing.T) {
 	if r, _ := h.audit.last(); r != DropReasonDuplicate {
 		t.Fatalf("expected duplicate, got %q", r)
 	}
+	if h.media.resolveCalls != 0 {
+		t.Fatalf("duplicate must not resolve media")
+	}
 }
 
 func TestRouter_GroupNotAddressed_Drops(t *testing.T) {
@@ -313,6 +334,9 @@ func TestRouter_GroupNotAddressed_Drops(t *testing.T) {
 	if h.dedup.marks() != 1 {
 		t.Fatalf("group-filter drop must finalize Mark (1), got %d", h.dedup.marks())
 	}
+	if h.media.resolveCalls != 0 {
+		t.Fatalf("unaddressed group message must not resolve media")
+	}
 }
 
 func TestRouter_UnboundSender_NeedsBinding(t *testing.T) {
@@ -326,6 +350,9 @@ func TestRouter_UnboundSender_NeedsBinding(t *testing.T) {
 	}
 	if h.dedup.marks() != 1 {
 		t.Fatalf("unbound drop must finalize Mark, got %d", h.dedup.marks())
+	}
+	if h.media.resolveCalls != 0 {
+		t.Fatalf("unbound sender must not resolve media")
 	}
 	if !waitFor(time.Second, func() bool {
 		for _, r := range h.replier.calls() {
@@ -348,6 +375,9 @@ func TestRouter_NonMember_Drops(t *testing.T) {
 	if r, _ := h.audit.last(); r != DropReasonNonWorkspaceMember {
 		t.Fatalf("expected non_workspace_member, got %q", r)
 	}
+	if h.media.resolveCalls != 0 {
+		t.Fatalf("non-member must not resolve media")
+	}
 }
 
 func TestRouter_EnsureSessionError_Releases(t *testing.T) {
@@ -359,6 +389,20 @@ func TestRouter_EnsureSessionError_Releases(t *testing.T) {
 	}
 	if h.dedup.releases() != 1 {
 		t.Fatalf("ensure-session error must Release the claim (1), got %d", h.dedup.releases())
+	}
+	if h.media.resolveCalls != 1 || h.media.cleanupCalls != 1 {
+		t.Fatalf("ensure failure must clean resolved media; resolve=%d cleanup=%d", h.media.resolveCalls, h.media.cleanupCalls)
+	}
+}
+
+func TestRouter_AppendErrorCleansResolvedMedia(t *testing.T) {
+	h := newHarness(t)
+	h.binder.appendErr = errors.New("link attachment failed")
+	if err := h.router.Handle(context.Background(), p2pMessage(t)); err == nil {
+		t.Fatal("append error must surface")
+	}
+	if h.media.resolveCalls != 1 || h.media.cleanupCalls != 1 {
+		t.Fatalf("append failure must clean resolved media; resolve=%d cleanup=%d", h.media.resolveCalls, h.media.cleanupCalls)
 	}
 }
 
@@ -374,6 +418,9 @@ func TestRouter_Ingested_InTxMark_FinalizeNone(t *testing.T) {
 	}
 	if h.dedup.releases() != 0 {
 		t.Fatalf("a durable ingest must not Release, got %d", h.dedup.releases())
+	}
+	if h.media.resolveCalls != 1 || h.media.cleanupCalls != 0 {
+		t.Fatalf("successful ingest must retain resolved media; resolve=%d cleanup=%d", h.media.resolveCalls, h.media.cleanupCalls)
 	}
 	if !h.tasks.wasCalled() {
 		t.Fatalf("ingest must trigger a chat run (inline, no batcher)")

--- a/server/internal/integrations/channel/engine/session.go
+++ b/server/internal/integrations/channel/engine/session.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/jackc/pgx/v5/pgtype"
@@ -41,6 +42,8 @@ type SessionQueries interface {
 	CreateChatSession(ctx context.Context, arg db.CreateChatSessionParams) (db.ChatSession, error)
 	CreateChannelChatSessionBinding(ctx context.Context, arg db.CreateChannelChatSessionBindingParams) (db.ChannelChatSessionBinding, error)
 	CreateChatMessage(ctx context.Context, arg db.CreateChatMessageParams) (db.ChatMessage, error)
+	CreateAttachment(ctx context.Context, arg db.CreateAttachmentParams) (db.Attachment, error)
+	LinkAttachmentsToChatMessage(ctx context.Context, arg db.LinkAttachmentsToChatMessageParams) ([]pgtype.UUID, error)
 	TouchChatSession(ctx context.Context, id pgtype.UUID) error
 	GetMostRecentUserChatMessage(ctx context.Context, chatSessionID pgtype.UUID) (db.ChatMessage, error)
 	UpdateChannelChatSessionBindingReplyTarget(ctx context.Context, arg db.UpdateChannelChatSessionBindingReplyTargetParams) error
@@ -66,6 +69,12 @@ func (a dbSessionQueries) CreateChannelChatSessionBinding(ctx context.Context, a
 }
 func (a dbSessionQueries) CreateChatMessage(ctx context.Context, arg db.CreateChatMessageParams) (db.ChatMessage, error) {
 	return a.q.CreateChatMessage(ctx, arg)
+}
+func (a dbSessionQueries) CreateAttachment(ctx context.Context, arg db.CreateAttachmentParams) (db.Attachment, error) {
+	return a.q.CreateAttachment(ctx, arg)
+}
+func (a dbSessionQueries) LinkAttachmentsToChatMessage(ctx context.Context, arg db.LinkAttachmentsToChatMessageParams) ([]pgtype.UUID, error) {
+	return a.q.LinkAttachmentsToChatMessage(ctx, arg)
 }
 func (a dbSessionQueries) TouchChatSession(ctx context.Context, id pgtype.UUID) error {
 	return a.q.TouchChatSession(ctx, id)
@@ -232,12 +241,14 @@ func (s *ChatSession) createSessionAndBinding(ctx context.Context, in EnsureSess
 type AppendInput struct {
 	SessionID      pgtype.UUID
 	Sender         pgtype.UUID
+	WorkspaceID    pgtype.UUID
 	InstallationID pgtype.UUID
 	Body           string
 	CommandText    string
 	MessageID      string
 	ThreadID       string
 	ClaimToken     pgtype.UUID
+	MediaRefs      []channel.MediaRef
 }
 
 // AppendUserMessage writes the user message into the chat_session (touching it
@@ -269,12 +280,39 @@ func (s *ChatSession) AppendUserMessage(ctx context.Context, in AppendInput) (Ap
 		}
 	}
 
-	if _, err := qtx.CreateChatMessage(ctx, db.CreateChatMessageParams{
+	message, err := qtx.CreateChatMessage(ctx, db.CreateChatMessageParams{
 		ChatSessionID: in.SessionID,
 		Role:          "user",
 		Content:       in.Body,
-	}); err != nil {
+	})
+	if err != nil {
 		return AppendResult{}, fmt.Errorf("create chat message: %w", err)
+	}
+	for _, media := range in.MediaRefs {
+		id, err := uuid.NewV7()
+		if err != nil {
+			return AppendResult{}, fmt.Errorf("generate attachment id: %w", err)
+		}
+		if _, err := qtx.CreateAttachment(ctx, db.CreateAttachmentParams{
+			ID:            pgtype.UUID{Bytes: id, Valid: true},
+			WorkspaceID:   in.WorkspaceID,
+			UploaderType:  "member",
+			UploaderID:    in.Sender,
+			Filename:      media.Filename,
+			Url:           media.URL,
+			ContentType:   media.MimeType,
+			SizeBytes:     media.SizeBytes,
+			ChatSessionID: in.SessionID,
+		}); err != nil {
+			return AppendResult{}, fmt.Errorf("create chat attachment: %w", err)
+		}
+		if _, err := qtx.LinkAttachmentsToChatMessage(ctx, db.LinkAttachmentsToChatMessageParams{
+			ChatMessageID: message.ID, ChatSessionID: in.SessionID, WorkspaceID: in.WorkspaceID,
+			UploaderType: "member", UploaderID: in.Sender,
+			AttachmentIds: []pgtype.UUID{{Bytes: id, Valid: true}},
+		}); err != nil {
+			return AppendResult{}, fmt.Errorf("link chat attachment: %w", err)
+		}
 	}
 	if err := qtx.TouchChatSession(ctx, in.SessionID); err != nil {
 		return AppendResult{}, fmt.Errorf("touch chat session: %w", err)

--- a/server/internal/integrations/channel/engine/session_test.go
+++ b/server/internal/integrations/channel/engine/session_test.go
@@ -47,6 +47,8 @@ type fakeSessionQueries struct {
 	markRows         int64   // MarkChannelInboundDedupProcessed result
 	createBindingErr error   // simulate a unique violation on create
 	raceWinner       pgtype.UUID
+	attachments      []db.CreateAttachmentParams
+	attachmentLinks  []db.LinkAttachmentsToChatMessageParams
 }
 
 func newFake() *fakeSessionQueries {
@@ -83,7 +85,17 @@ func (f *fakeSessionQueries) CreateChannelChatSessionBinding(_ context.Context, 
 
 func (f *fakeSessionQueries) CreateChatMessage(_ context.Context, arg db.CreateChatMessageParams) (db.ChatMessage, error) {
 	f.messages = append(f.messages, arg.Content)
-	return db.ChatMessage{}, nil
+	return db.ChatMessage{ID: uid(88)}, nil
+}
+
+func (f *fakeSessionQueries) CreateAttachment(_ context.Context, arg db.CreateAttachmentParams) (db.Attachment, error) {
+	f.attachments = append(f.attachments, arg)
+	return db.Attachment{}, nil
+}
+
+func (f *fakeSessionQueries) LinkAttachmentsToChatMessage(_ context.Context, arg db.LinkAttachmentsToChatMessageParams) ([]pgtype.UUID, error) {
+	f.attachmentLinks = append(f.attachmentLinks, arg)
+	return nil, nil
 }
 
 func (f *fakeSessionQueries) TouchChatSession(context.Context, pgtype.UUID) error {
@@ -229,6 +241,28 @@ func TestAppendUserMessage_PlainText(t *testing.T) {
 	}
 	if f.touched != 1 || f.replyTargets != 1 {
 		t.Errorf("touched=%d replyTargets=%d, want 1/1", f.touched, f.replyTargets)
+	}
+}
+
+func TestAppendUserMessage_BindsMediaAttachment(t *testing.T) {
+	f := newFake()
+	s := newTestSession(f)
+	_, err := s.AppendUserMessage(context.Background(), AppendInput{
+		SessionID: uid(1), WorkspaceID: uid(2), Sender: uid(7), Body: "[Image]",
+		MediaRefs: []channel.MediaRef{{
+			Type: channel.MsgTypeImage, URL: "/uploads/image.png", Filename: "image.png",
+			MimeType: "image/png", SizeBytes: 3,
+		}},
+	})
+	if err != nil {
+		t.Fatalf("AppendUserMessage: %v", err)
+	}
+	if len(f.attachments) != 1 || f.attachments[0].Url != "/uploads/image.png" ||
+		f.attachments[0].UploaderID != uid(7) || f.attachments[0].WorkspaceID != uid(2) {
+		t.Fatalf("attachments = %+v", f.attachments)
+	}
+	if len(f.attachmentLinks) != 1 || f.attachmentLinks[0].ChatMessageID != uid(88) {
+		t.Fatalf("attachment links = %+v", f.attachmentLinks)
 	}
 }
 

--- a/server/internal/integrations/channel/message.go
+++ b/server/internal/integrations/channel/message.go
@@ -86,6 +86,9 @@ type MediaRef struct {
 	Type MsgType
 	// StorageKey locates the persisted object in Multica object storage.
 	StorageKey string
+	// URL is the durable storage URL returned when the adapter persisted the
+	// object. The session binder records it on the attachment row.
+	URL string
 	// Filename is the original display name, when the platform supplies
 	// one.
 	Filename string

--- a/server/internal/integrations/lark/client.go
+++ b/server/internal/integrations/lark/client.go
@@ -118,6 +118,16 @@ type APIClient interface {
 	DeleteMessageReaction(ctx context.Context, p DeleteReactionParams) error
 }
 
+type MessageResource struct {
+	Data        []byte
+	Filename    string
+	ContentType string
+}
+
+type MessageResourceDownloader interface {
+	DownloadMessageResource(ctx context.Context, creds InstallationCredentials, messageID, fileKey, resourceType string) (MessageResource, error)
+}
+
 // ListMessagesParams selects a bounded, recent window of messages in a
 // single Lark chat for the group-context prefetch. Only the fields the
 // enricher needs today are exposed (ChatID, PageSize, EndTime);

--- a/server/internal/integrations/lark/feishu_channel.go
+++ b/server/internal/integrations/lark/feishu_channel.go
@@ -8,15 +8,12 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
-	"path/filepath"
 
-	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgtype"
 
 	"github.com/multica-ai/multica/server/internal/integrations/channel"
 	"github.com/multica-ai/multica/server/internal/integrations/channel/engine"
-	"github.com/multica-ai/multica/server/internal/storage"
 	db "github.com/multica-ai/multica/server/pkg/db/generated"
 )
 
@@ -38,10 +35,8 @@ type feishuChannel struct {
 	conn    EventConnector
 	handler channel.InboundHandler
 	sender  APIClient
-	media   MessageResourceDownloader
 	creds   CredentialsResolver
 	logger  *slog.Logger
-	storage storage.Storage
 }
 
 var _ channel.Channel = (*feishuChannel)(nil)
@@ -59,59 +54,8 @@ func (c *feishuChannel) Connect(ctx context.Context) error {
 		if c.handler == nil {
 			return DispatchResult{}, errors.New("lark: inbound handler not configured")
 		}
-		msg := channelMessageFromLark(lm)
-		if lm.MessageType == "image" {
-			if err := c.attachImage(emitCtx, lm, &msg); err != nil {
-				return DispatchResult{}, err
-			}
-		}
-		return DispatchResult{}, c.handler(emitCtx, msg)
+		return DispatchResult{}, c.handler(emitCtx, channelMessageFromLark(lm))
 	})
-}
-
-func (c *feishuChannel) attachImage(ctx context.Context, lm InboundMessage, msg *channel.InboundMessage) error {
-	if c.storage == nil {
-		return errors.New("lark: attachment storage not configured")
-	}
-	var body struct {
-		ImageKey string `json:"image_key"`
-	}
-	if err := json.Unmarshal([]byte(lm.RawContent), &body); err != nil || body.ImageKey == "" {
-		return errors.New("lark: image message missing image_key")
-	}
-	creds, err := c.installationCredentials()
-	if err != nil {
-		return err
-	}
-	if c.media == nil {
-		return errors.New("lark: message resource downloader not configured")
-	}
-	resource, err := c.media.DownloadMessageResource(ctx, creds, lm.MessageID, body.ImageKey, "image")
-	if err != nil {
-		return fmt.Errorf("download image resource: %w", err)
-	}
-	id, err := uuid.NewV7()
-	if err != nil {
-		return fmt.Errorf("generate image attachment id: %w", err)
-	}
-	ext := filepath.Ext(resource.Filename)
-	if ext == "" {
-		ext = ".png"
-	}
-	filename := resource.Filename
-	if filename == "" {
-		filename = "feishu-image" + ext
-	}
-	key := "channel-inbound/" + id.String() + ext
-	link, err := c.storage.Upload(ctx, key, resource.Data, resource.ContentType, filename)
-	if err != nil {
-		return fmt.Errorf("persist image resource: %w", err)
-	}
-	msg.MediaRefs = []channel.MediaRef{{
-		Type: channel.MsgTypeImage, StorageKey: key, URL: link, Filename: filename,
-		MimeType: resource.ContentType, SizeBytes: int64(len(resource.Data)),
-	}}
-	return nil
 }
 
 // Disconnect is a no-op: the connector's receive loop is torn down by ctx
@@ -240,8 +184,6 @@ type FeishuChannelDeps struct {
 	APIClient   APIClient
 	Credentials CredentialsResolver
 	Logger      *slog.Logger
-	Storage     storage.Storage
-	Media       MessageResourceDownloader
 }
 
 // RegisterFeishu registers the Feishu Factory on reg under channel.TypeFeishu
@@ -271,19 +213,13 @@ func newFeishuFactory(deps FeishuChannelDeps) channel.Factory {
 		if err != nil {
 			return nil, fmt.Errorf("decode feishu installation config: %w", err)
 		}
-		media := deps.Media
-		if media == nil {
-			media, _ = deps.APIClient.(MessageResourceDownloader)
-		}
 		return &feishuChannel{
 			inst:    inst,
 			conn:    deps.Connector,
 			handler: cfg.Handler,
 			sender:  deps.APIClient,
-			media:   media,
 			creds:   deps.Credentials,
 			logger:  logger,
-			storage: deps.Storage,
 		}, nil
 	}
 }

--- a/server/internal/integrations/lark/feishu_channel.go
+++ b/server/internal/integrations/lark/feishu_channel.go
@@ -8,12 +8,15 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"path/filepath"
 
+	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgtype"
 
 	"github.com/multica-ai/multica/server/internal/integrations/channel"
 	"github.com/multica-ai/multica/server/internal/integrations/channel/engine"
+	"github.com/multica-ai/multica/server/internal/storage"
 	db "github.com/multica-ai/multica/server/pkg/db/generated"
 )
 
@@ -35,8 +38,10 @@ type feishuChannel struct {
 	conn    EventConnector
 	handler channel.InboundHandler
 	sender  APIClient
+	media   MessageResourceDownloader
 	creds   CredentialsResolver
 	logger  *slog.Logger
+	storage storage.Storage
 }
 
 var _ channel.Channel = (*feishuChannel)(nil)
@@ -54,8 +59,59 @@ func (c *feishuChannel) Connect(ctx context.Context) error {
 		if c.handler == nil {
 			return DispatchResult{}, errors.New("lark: inbound handler not configured")
 		}
-		return DispatchResult{}, c.handler(emitCtx, channelMessageFromLark(lm))
+		msg := channelMessageFromLark(lm)
+		if lm.MessageType == "image" {
+			if err := c.attachImage(emitCtx, lm, &msg); err != nil {
+				return DispatchResult{}, err
+			}
+		}
+		return DispatchResult{}, c.handler(emitCtx, msg)
 	})
+}
+
+func (c *feishuChannel) attachImage(ctx context.Context, lm InboundMessage, msg *channel.InboundMessage) error {
+	if c.storage == nil {
+		return errors.New("lark: attachment storage not configured")
+	}
+	var body struct {
+		ImageKey string `json:"image_key"`
+	}
+	if err := json.Unmarshal([]byte(lm.RawContent), &body); err != nil || body.ImageKey == "" {
+		return errors.New("lark: image message missing image_key")
+	}
+	creds, err := c.installationCredentials()
+	if err != nil {
+		return err
+	}
+	if c.media == nil {
+		return errors.New("lark: message resource downloader not configured")
+	}
+	resource, err := c.media.DownloadMessageResource(ctx, creds, lm.MessageID, body.ImageKey, "image")
+	if err != nil {
+		return fmt.Errorf("download image resource: %w", err)
+	}
+	id, err := uuid.NewV7()
+	if err != nil {
+		return fmt.Errorf("generate image attachment id: %w", err)
+	}
+	ext := filepath.Ext(resource.Filename)
+	if ext == "" {
+		ext = ".png"
+	}
+	filename := resource.Filename
+	if filename == "" {
+		filename = "feishu-image" + ext
+	}
+	key := "channel-inbound/" + id.String() + ext
+	link, err := c.storage.Upload(ctx, key, resource.Data, resource.ContentType, filename)
+	if err != nil {
+		return fmt.Errorf("persist image resource: %w", err)
+	}
+	msg.MediaRefs = []channel.MediaRef{{
+		Type: channel.MsgTypeImage, StorageKey: key, URL: link, Filename: filename,
+		MimeType: resource.ContentType, SizeBytes: int64(len(resource.Data)),
+	}}
+	return nil
 }
 
 // Disconnect is a no-op: the connector's receive loop is torn down by ctx
@@ -184,6 +240,8 @@ type FeishuChannelDeps struct {
 	APIClient   APIClient
 	Credentials CredentialsResolver
 	Logger      *slog.Logger
+	Storage     storage.Storage
+	Media       MessageResourceDownloader
 }
 
 // RegisterFeishu registers the Feishu Factory on reg under channel.TypeFeishu
@@ -213,13 +271,19 @@ func newFeishuFactory(deps FeishuChannelDeps) channel.Factory {
 		if err != nil {
 			return nil, fmt.Errorf("decode feishu installation config: %w", err)
 		}
+		media := deps.Media
+		if media == nil {
+			media, _ = deps.APIClient.(MessageResourceDownloader)
+		}
 		return &feishuChannel{
 			inst:    inst,
 			conn:    deps.Connector,
 			handler: cfg.Handler,
 			sender:  deps.APIClient,
+			media:   media,
 			creds:   deps.Credentials,
 			logger:  logger,
+			storage: deps.Storage,
 		}, nil
 	}
 }

--- a/server/internal/integrations/lark/feishu_channel_test.go
+++ b/server/internal/integrations/lark/feishu_channel_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"io"
 	"testing"
 
@@ -33,11 +34,35 @@ type fakeMediaStorage struct {
 	key, contentType, filename string
 	data                       []byte
 	deleted                    []string
+	uploadErr                  error
 }
 
 func (s *fakeMediaStorage) Upload(_ context.Context, key string, data []byte, contentType, filename string) (string, error) {
 	s.key, s.data, s.contentType, s.filename = key, data, contentType, filename
+	if s.uploadErr != nil {
+		return "", s.uploadErr
+	}
 	return "/uploads/" + key, nil
+}
+
+func TestFeishuMediaResolverUploadErrorReturnsCleanup(t *testing.T) {
+	api := &fakeSender{resource: MessageResource{
+		Data: []byte("png"), Filename: "screen.png", ContentType: "image/png",
+	}}
+	store := &fakeMediaStorage{uploadErr: errors.New("upload interrupted")}
+	lm := InboundMessage{MessageID: "om_image", RawContent: `{"image_key":"img_key"}`}
+	raw, _ := json.Marshal(lm)
+	resolver := &feishuMediaResolver{media: api, creds: fakeCreds{secret: "secret"}, storage: store}
+	_, cleanup, err := resolver.Resolve(context.Background(), engine.ResolvedInstallation{
+		Platform: Installation{AppID: "cli", Region: "feishu"},
+	}, channel.InboundMessage{Type: channel.MsgTypeImage, Raw: raw})
+	if err == nil || cleanup == nil {
+		t.Fatalf("Resolve error=%v cleanup=%v, want both", err, cleanup != nil)
+	}
+	cleanup(context.Background())
+	if len(store.deleted) != 1 || store.deleted[0] != store.key {
+		t.Fatalf("cleanup deleted = %v, uploaded key = %q", store.deleted, store.key)
+	}
 }
 func (s *fakeMediaStorage) Delete(_ context.Context, key string)                   { s.deleted = append(s.deleted, key) }
 func (*fakeMediaStorage) DeleteKeys(context.Context, []string)                     {}

--- a/server/internal/integrations/lark/feishu_channel_test.go
+++ b/server/internal/integrations/lark/feishu_channel_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/base64"
 	"encoding/json"
+	"io"
 	"testing"
 
 	"github.com/multica-ai/multica/server/internal/integrations/channel"
@@ -14,14 +15,34 @@ import (
 // SendTextMessage — the single method feishuChannel.Send calls.
 type fakeSender struct {
 	APIClient
-	last  SendTextParams
-	msgID string
+	last     SendTextParams
+	msgID    string
+	resource MessageResource
 }
 
 func (f *fakeSender) SendTextMessage(_ context.Context, p SendTextParams) (string, error) {
 	f.last = p
 	return f.msgID, nil
 }
+
+func (f *fakeSender) DownloadMessageResource(context.Context, InstallationCredentials, string, string, string) (MessageResource, error) {
+	return f.resource, nil
+}
+
+type fakeMediaStorage struct {
+	key, contentType, filename string
+	data                       []byte
+}
+
+func (s *fakeMediaStorage) Upload(_ context.Context, key string, data []byte, contentType, filename string) (string, error) {
+	s.key, s.data, s.contentType, s.filename = key, data, contentType, filename
+	return "/uploads/" + key, nil
+}
+func (*fakeMediaStorage) Delete(context.Context, string)                           {}
+func (*fakeMediaStorage) DeleteKeys(context.Context, []string)                     {}
+func (*fakeMediaStorage) KeyFromURL(raw string) string                             { return raw }
+func (*fakeMediaStorage) CdnDomain() string                                        { return "" }
+func (*fakeMediaStorage) GetReader(context.Context, string) (io.ReadCloser, error) { return nil, nil }
 
 type fakeCreds struct{ secret string }
 
@@ -99,6 +120,31 @@ func TestFeishuChannel_Capabilities(t *testing.T) {
 	}
 	if caps.Has(channel.CapVoice) {
 		t.Fatalf("Feishu adapter does not declare voice")
+	}
+}
+
+func TestFeishuChannel_AttachImagePersistsMediaRef(t *testing.T) {
+	api := &fakeSender{resource: MessageResource{
+		Data: []byte("png"), Filename: "screen.png", ContentType: "image/png",
+	}}
+	store := &fakeMediaStorage{}
+	fc := &feishuChannel{
+		inst:   Installation{AppID: "cli", Region: "feishu"},
+		sender: api, media: api, creds: fakeCreds{secret: "secret"}, storage: store,
+	}
+	msg := channel.InboundMessage{}
+	err := fc.attachImage(context.Background(), InboundMessage{
+		MessageID: "om_image", RawContent: `{"image_key":"img_key"}`,
+	}, &msg)
+	if err != nil {
+		t.Fatalf("attachImage: %v", err)
+	}
+	if len(msg.MediaRefs) != 1 || msg.MediaRefs[0].URL == "" ||
+		msg.MediaRefs[0].Filename != "screen.png" || msg.MediaRefs[0].MimeType != "image/png" {
+		t.Fatalf("MediaRefs = %+v", msg.MediaRefs)
+	}
+	if string(store.data) != "png" || store.contentType != "image/png" {
+		t.Fatalf("stored data=%q contentType=%q", store.data, store.contentType)
 	}
 }
 

--- a/server/internal/integrations/lark/feishu_channel_test.go
+++ b/server/internal/integrations/lark/feishu_channel_test.go
@@ -32,13 +32,14 @@ func (f *fakeSender) DownloadMessageResource(context.Context, InstallationCreden
 type fakeMediaStorage struct {
 	key, contentType, filename string
 	data                       []byte
+	deleted                    []string
 }
 
 func (s *fakeMediaStorage) Upload(_ context.Context, key string, data []byte, contentType, filename string) (string, error) {
 	s.key, s.data, s.contentType, s.filename = key, data, contentType, filename
 	return "/uploads/" + key, nil
 }
-func (*fakeMediaStorage) Delete(context.Context, string)                           {}
+func (s *fakeMediaStorage) Delete(_ context.Context, key string)                   { s.deleted = append(s.deleted, key) }
 func (*fakeMediaStorage) DeleteKeys(context.Context, []string)                     {}
 func (*fakeMediaStorage) KeyFromURL(raw string) string                             { return raw }
 func (*fakeMediaStorage) CdnDomain() string                                        { return "" }
@@ -128,16 +129,14 @@ func TestFeishuChannel_AttachImagePersistsMediaRef(t *testing.T) {
 		Data: []byte("png"), Filename: "screen.png", ContentType: "image/png",
 	}}
 	store := &fakeMediaStorage{}
-	fc := &feishuChannel{
-		inst:   Installation{AppID: "cli", Region: "feishu"},
-		sender: api, media: api, creds: fakeCreds{secret: "secret"}, storage: store,
-	}
-	msg := channel.InboundMessage{}
-	err := fc.attachImage(context.Background(), InboundMessage{
-		MessageID: "om_image", RawContent: `{"image_key":"img_key"}`,
-	}, &msg)
+	lm := InboundMessage{MessageID: "om_image", RawContent: `{"image_key":"img_key"}`}
+	raw, _ := json.Marshal(lm)
+	resolver := &feishuMediaResolver{media: api, creds: fakeCreds{secret: "secret"}, storage: store}
+	msg, cleanup, err := resolver.Resolve(context.Background(), engine.ResolvedInstallation{
+		Platform: Installation{AppID: "cli", Region: "feishu"},
+	}, channel.InboundMessage{Type: channel.MsgTypeImage, Raw: raw})
 	if err != nil {
-		t.Fatalf("attachImage: %v", err)
+		t.Fatalf("Resolve: %v", err)
 	}
 	if len(msg.MediaRefs) != 1 || msg.MediaRefs[0].URL == "" ||
 		msg.MediaRefs[0].Filename != "screen.png" || msg.MediaRefs[0].MimeType != "image/png" {
@@ -145,6 +144,10 @@ func TestFeishuChannel_AttachImagePersistsMediaRef(t *testing.T) {
 	}
 	if string(store.data) != "png" || store.contentType != "image/png" {
 		t.Fatalf("stored data=%q contentType=%q", store.data, store.contentType)
+	}
+	cleanup(context.Background())
+	if len(store.deleted) != 1 || store.deleted[0] != msg.MediaRefs[0].StorageKey {
+		t.Fatalf("cleanup deleted = %v", store.deleted)
 	}
 }
 

--- a/server/internal/integrations/lark/feishu_channel_test.go
+++ b/server/internal/integrations/lark/feishu_channel_test.go
@@ -189,6 +189,23 @@ func TestChannelMessageFromLark_NormalizesAndStashesRaw(t *testing.T) {
 	}
 }
 
+func TestChannelMessageFromLark_ImageKeepsPlaceholder(t *testing.T) {
+	cm := channelMessageFromLark(InboundMessage{
+		MessageID:   "om_image",
+		ChatID:      "oc",
+		ChatType:    ChatTypeP2P,
+		Body:        "[Image]",
+		MessageType: "image",
+	})
+
+	if cm.Type != channel.MsgTypeImage {
+		t.Fatalf("image must normalize to image, got %q", cm.Type)
+	}
+	if cm.Text != "[Image]" {
+		t.Fatalf("image placeholder lost during normalization: %q", cm.Text)
+	}
+}
+
 func TestChannelMsgType(t *testing.T) {
 	cases := map[string]channel.MsgType{
 		"":              channel.MsgTypeText,

--- a/server/internal/integrations/lark/feishu_resolvers.go
+++ b/server/internal/integrations/lark/feishu_resolvers.go
@@ -119,7 +119,8 @@ func (r *feishuMediaResolver) Resolve(ctx context.Context, inst engine.ResolvedI
 	key := "channel-inbound/" + id.String() + ext
 	link, err := r.storage.Upload(ctx, key, resource.Data, resource.ContentType, filename)
 	if err != nil {
-		return msg, nil, fmt.Errorf("persist image resource: %w", err)
+		return msg, func(cleanupCtx context.Context) { r.storage.Delete(cleanupCtx, key) },
+			fmt.Errorf("persist image resource: %w", err)
 	}
 	msg.MediaRefs = []channel.MediaRef{{
 		Type: channel.MsgTypeImage, StorageKey: key, URL: link, Filename: filename,

--- a/server/internal/integrations/lark/feishu_resolvers.go
+++ b/server/internal/integrations/lark/feishu_resolvers.go
@@ -5,12 +5,15 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"path/filepath"
 
+	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgtype"
 
 	"github.com/multica-ai/multica/server/internal/integrations/channel"
 	"github.com/multica-ai/multica/server/internal/integrations/channel/engine"
+	"github.com/multica-ai/multica/server/internal/storage"
 )
 
 // This file is the Feishu ResolverSet: the platform-specific implementations
@@ -44,11 +47,12 @@ func larkMsgFromRaw(msg channel.InboundMessage) (InboundMessage, error) {
 // shared session service, audit logger, and (optional) outbound replier +
 // typing indicator. Feishu is just another consumer of the channel-agnostic
 // engine.ChatSession — there is no Feishu-specific session implementation.
-func NewFeishuResolverSet(store *ChannelStore, session *engine.ChatSession, audit AuditLogger, replier OutcomeReplier, typing *TypingIndicatorManager) engine.ResolverSet {
+func NewFeishuResolverSet(store *ChannelStore, session *engine.ChatSession, audit AuditLogger, replier OutcomeReplier, typing *TypingIndicatorManager, media MessageResourceDownloader, creds CredentialsResolver, objectStore storage.Storage) engine.ResolverSet {
 	set := engine.ResolverSet{
 		Installation: &feishuInstallationResolver{store: store},
 		Identity:     &feishuIdentityResolver{store: store},
 		Dedup:        &feishuDeduper{store: store},
+		Media:        &feishuMediaResolver{media: media, creds: creds, storage: objectStore},
 		Session:      &feishuSessionBinder{session: session},
 		Audit:        &feishuAuditor{audit: audit},
 		OriginType:   originFeishuChat,
@@ -60,6 +64,68 @@ func NewFeishuResolverSet(store *ChannelStore, session *engine.ChatSession, audi
 		set.Typing = &feishuTypingNotifier{mgr: typing}
 	}
 	return set
+}
+
+type feishuMediaResolver struct {
+	media   MessageResourceDownloader
+	creds   CredentialsResolver
+	storage storage.Storage
+}
+
+func (r *feishuMediaResolver) Resolve(ctx context.Context, inst engine.ResolvedInstallation, msg channel.InboundMessage) (channel.InboundMessage, func(context.Context), error) {
+	if msg.Type != channel.MsgTypeImage {
+		return msg, nil, nil
+	}
+	lm, err := larkMsgFromRaw(msg)
+	if err != nil {
+		return msg, nil, err
+	}
+	var body struct {
+		ImageKey string `json:"image_key"`
+	}
+	if err := json.Unmarshal([]byte(lm.RawContent), &body); err != nil || body.ImageKey == "" {
+		return msg, nil, errors.New("lark: image message missing image_key")
+	}
+	larkInst, ok := inst.Platform.(Installation)
+	if !ok {
+		return msg, nil, errors.New("lark: resolved installation has invalid platform data")
+	}
+	if r.creds == nil || r.media == nil || r.storage == nil {
+		return msg, nil, errors.New("lark: image media dependencies not configured")
+	}
+	secret, err := r.creds.DecryptAppSecret(larkInst)
+	if err != nil {
+		return msg, nil, fmt.Errorf("decrypt app_secret: %w", err)
+	}
+	resource, err := r.media.DownloadMessageResource(ctx, InstallationCredentials{
+		AppID: larkInst.AppID, AppSecret: secret, TenantKey: larkInst.TenantKey.String,
+		Region: RegionOrDefault(larkInst.Region),
+	}, lm.MessageID, body.ImageKey, "image")
+	if err != nil {
+		return msg, nil, fmt.Errorf("download image resource: %w", err)
+	}
+	id, err := uuid.NewV7()
+	if err != nil {
+		return msg, nil, fmt.Errorf("generate image attachment id: %w", err)
+	}
+	ext := filepath.Ext(resource.Filename)
+	if ext == "" {
+		ext = ".png"
+	}
+	filename := resource.Filename
+	if filename == "" {
+		filename = "feishu-image" + ext
+	}
+	key := "channel-inbound/" + id.String() + ext
+	link, err := r.storage.Upload(ctx, key, resource.Data, resource.ContentType, filename)
+	if err != nil {
+		return msg, nil, fmt.Errorf("persist image resource: %w", err)
+	}
+	msg.MediaRefs = []channel.MediaRef{{
+		Type: channel.MsgTypeImage, StorageKey: key, URL: link, Filename: filename,
+		MimeType: resource.ContentType, SizeBytes: int64(len(resource.Data)),
+	}}
+	return msg, func(cleanupCtx context.Context) { r.storage.Delete(cleanupCtx, key) }, nil
 }
 
 // ---- installation routing ----

--- a/server/internal/integrations/lark/feishu_resolvers.go
+++ b/server/internal/integrations/lark/feishu_resolvers.go
@@ -209,12 +209,14 @@ func (r *feishuSessionBinder) AppendMessage(ctx context.Context, p engine.Append
 	return r.session.AppendUserMessage(ctx, engine.AppendInput{
 		SessionID:      p.SessionID,
 		Sender:         p.Sender,
+		WorkspaceID:    p.WorkspaceID,
 		InstallationID: p.InstallationID,
 		Body:           p.Message.Text,
 		CommandText:    lm.CommandBody,
 		MessageID:      p.Message.MessageID,
 		ThreadID:       p.Message.Source.ThreadID,
 		ClaimToken:     p.ClaimToken,
+		MediaRefs:      p.Message.MediaRefs,
 	})
 }
 

--- a/server/internal/integrations/lark/feishu_types.go
+++ b/server/internal/integrations/lark/feishu_types.go
@@ -33,6 +33,8 @@ type InboundMessage struct {
 	// enricher can decide whether a message needs an HTTP round-trip to
 	// expand while the core stays msg_type-agnostic and only reads Body.
 	MessageType string
+	// RawContent is the JSON-encoded body.content used to resolve media keys.
+	RawContent string
 
 	// CreateTime is the trigger message's creation time (epoch milliseconds).
 	// The enricher anchors the group recent-context window to it; the typing

--- a/server/internal/integrations/lark/http_client.go
+++ b/server/internal/integrations/lark/http_client.go
@@ -726,6 +726,43 @@ func (c *httpAPIClient) DeleteMessageReaction(ctx context.Context, p DeleteReact
 	return nil
 }
 
+func (c *httpAPIClient) DownloadMessageResource(ctx context.Context, creds InstallationCredentials, messageID, fileKey, resourceType string) (MessageResource, error) {
+	if messageID == "" || fileKey == "" {
+		return MessageResource{}, errors.New("lark http client: missing message_id or file_key")
+	}
+	if resourceType != "image" && resourceType != "file" {
+		return MessageResource{}, fmt.Errorf("lark http client: unsupported resource type %q", resourceType)
+	}
+	token, err := c.tenantAccessToken(ctx, creds)
+	if err != nil {
+		return MessageResource{}, err
+	}
+	q := url.Values{}
+	q.Set("file_key", fileKey)
+	q.Set("type", resourceType)
+	path := "/open-apis/im/v1/messages/" + url.PathEscape(messageID) + "/resources?" + q.Encode()
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.resolveBaseURL(creds)+path, nil)
+	if err != nil {
+		return MessageResource{}, fmt.Errorf("lark http client: download resource: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+token)
+	resp, err := c.cfg.HTTPClient.Do(req)
+	if err != nil {
+		return MessageResource{}, fmt.Errorf("lark http client: download resource: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		raw, _ := io.ReadAll(io.LimitReader(resp.Body, 513))
+		return MessageResource{}, fmt.Errorf("lark http client: download resource: http %d: %s", resp.StatusCode, truncate(string(raw), 512))
+	}
+	data, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return MessageResource{}, fmt.Errorf("lark http client: download resource: read body: %w", err)
+	}
+	filename := strings.Trim(strings.TrimPrefix(resp.Header.Get("Content-Disposition"), "attachment; filename="), `"`)
+	return MessageResource{Data: data, Filename: filename, ContentType: resp.Header.Get("Content-Type")}, nil
+}
+
 // BatchGetUsers resolves user open_ids to display names via
 // GET /open-apis/contact/v3/users/batch?user_ids=…&user_id_type=open_id.
 // It mirrors fetchBotUnionID's single-user contact lookup, batched. Only

--- a/server/internal/integrations/lark/http_client.go
+++ b/server/internal/integrations/lark/http_client.go
@@ -51,7 +51,8 @@ const (
 	// defaultRequestTimeout is the per-call HTTP timeout. Lark's API
 	// is normally well under 1s; we leave headroom for cross-region
 	// latency from a self-hosted Multica deployment to feishu.cn.
-	defaultRequestTimeout = 10 * time.Second
+	defaultRequestTimeout         = 10 * time.Second
+	defaultMaxResourceBytes int64 = 100 << 20
 
 	// Lark's "invalid tenant_access_token" / "tenant_access_token
 	// expired" error codes. When we see either, drop the cached token
@@ -86,6 +87,10 @@ type HTTPClientConfig struct {
 	// Logger receives warnings about Lark error codes. Nil uses
 	// slog.Default().
 	Logger *slog.Logger
+
+	// MaxResourceBytes caps message-resource downloads before they enter
+	// object storage. Zero defaults to the same 100 MB ceiling as uploads.
+	MaxResourceBytes int64
 }
 
 func (c HTTPClientConfig) withDefaults() HTTPClientConfig {
@@ -104,6 +109,9 @@ func (c HTTPClientConfig) withDefaults() HTTPClientConfig {
 	}
 	if c.Logger == nil {
 		c.Logger = slog.Default()
+	}
+	if c.MaxResourceBytes <= 0 {
+		c.MaxResourceBytes = defaultMaxResourceBytes
 	}
 	return c
 }
@@ -755,12 +763,32 @@ func (c *httpAPIClient) DownloadMessageResource(ctx context.Context, creds Insta
 		raw, _ := io.ReadAll(io.LimitReader(resp.Body, 513))
 		return MessageResource{}, fmt.Errorf("lark http client: download resource: http %d: %s", resp.StatusCode, truncate(string(raw), 512))
 	}
-	data, err := io.ReadAll(resp.Body)
+	data, err := io.ReadAll(io.LimitReader(resp.Body, c.cfg.MaxResourceBytes+1))
 	if err != nil {
 		return MessageResource{}, fmt.Errorf("lark http client: download resource: read body: %w", err)
 	}
+	if int64(len(data)) > c.cfg.MaxResourceBytes {
+		return MessageResource{}, fmt.Errorf("lark http client: download resource exceeds %d bytes", c.cfg.MaxResourceBytes)
+	}
+	contentType := resp.Header.Get("Content-Type")
+	if strings.HasPrefix(strings.ToLower(contentType), "application/json") {
+		var businessErr struct {
+			Code int    `json:"code"`
+			Msg  string `json:"msg"`
+		}
+		if err := json.Unmarshal(data, &businessErr); err != nil {
+			return MessageResource{}, fmt.Errorf("lark http client: download resource: decode JSON response: %w", err)
+		}
+		if businessErr.Code != 0 {
+			if isTokenError(businessErr.Code) {
+				c.invalidateToken(creds.AppID)
+			}
+			return MessageResource{}, &APIError{Op: "download resource", Code: businessErr.Code, Msg: businessErr.Msg}
+		}
+		return MessageResource{}, errors.New("lark http client: download resource returned JSON instead of media")
+	}
 	filename := strings.Trim(strings.TrimPrefix(resp.Header.Get("Content-Disposition"), "attachment; filename="), `"`)
-	return MessageResource{Data: data, Filename: filename, ContentType: resp.Header.Get("Content-Type")}, nil
+	return MessageResource{Data: data, Filename: filename, ContentType: contentType}, nil
 }
 
 // BatchGetUsers resolves user open_ids to display names via

--- a/server/internal/integrations/lark/http_client.go
+++ b/server/internal/integrations/lark/http_client.go
@@ -747,9 +747,9 @@ func (c *httpAPIClient) DownloadMessageResource(ctx context.Context, creds Insta
 		return MessageResource{}, err
 	}
 	q := url.Values{}
-	q.Set("file_key", fileKey)
 	q.Set("type", resourceType)
-	path := "/open-apis/im/v1/messages/" + url.PathEscape(messageID) + "/resources?" + q.Encode()
+	path := "/open-apis/im/v1/messages/" + url.PathEscape(messageID) +
+		"/resources/" + url.PathEscape(fileKey) + "?" + q.Encode()
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.resolveBaseURL(creds)+path, nil)
 	if err != nil {
 		return MessageResource{}, fmt.Errorf("lark http client: download resource: %w", err)

--- a/server/internal/integrations/lark/http_client.go
+++ b/server/internal/integrations/lark/http_client.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
+	"mime"
 	"net/http"
 	"net/url"
 	"strconv"
@@ -52,7 +53,7 @@ const (
 	// is normally well under 1s; we leave headroom for cross-region
 	// latency from a self-hosted Multica deployment to feishu.cn.
 	defaultRequestTimeout         = 10 * time.Second
-	defaultMaxResourceBytes int64 = 100 << 20
+	defaultMaxResourceBytes int64 = 10 << 20
 
 	// Lark's "invalid tenant_access_token" / "tenant_access_token
 	// expired" error codes. When we see either, drop the cached token
@@ -787,7 +788,10 @@ func (c *httpAPIClient) DownloadMessageResource(ctx context.Context, creds Insta
 		}
 		return MessageResource{}, errors.New("lark http client: download resource returned JSON instead of media")
 	}
-	filename := strings.Trim(strings.TrimPrefix(resp.Header.Get("Content-Disposition"), "attachment; filename="), `"`)
+	filename := ""
+	if _, params, err := mime.ParseMediaType(resp.Header.Get("Content-Disposition")); err == nil {
+		filename = params["filename"]
+	}
 	return MessageResource{Data: data, Filename: filename, ContentType: contentType}, nil
 }
 

--- a/server/internal/integrations/lark/http_client_resource_test.go
+++ b/server/internal/integrations/lark/http_client_resource_test.go
@@ -43,6 +43,34 @@ func TestHTTPClientDownloadMessageResource(t *testing.T) {
 	}
 }
 
+func TestHTTPClientDownloadMessageResourceParsesContentDisposition(t *testing.T) {
+	tests := []struct {
+		header string
+		want   string
+	}{
+		{`Attachment ; filename = "screen shot.png"`, "screen shot.png"},
+		{`attachment; filename="fallback.png"; filename*=UTF-8''screen%20shot.png`, "screen shot.png"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.header, func(t *testing.T) {
+			srv := resourceTestServer(t, func(w http.ResponseWriter, _ *http.Request) {
+				w.Header().Set("Content-Type", "image/png")
+				w.Header().Set("Content-Disposition", tc.header)
+				_, _ = io.WriteString(w, "png")
+			})
+			defer srv.Close()
+			client := NewHTTPAPIClient(HTTPClientConfig{BaseURL: srv.URL}).(*httpAPIClient)
+			got, err := client.DownloadMessageResource(context.Background(), testCreds(), "om_1", "img_key", "image")
+			if err != nil {
+				t.Fatalf("DownloadMessageResource: %v", err)
+			}
+			if got.Filename != tc.want {
+				t.Fatalf("Filename = %q, want %q", got.Filename, tc.want)
+			}
+		})
+	}
+}
+
 func TestHTTPClientDownloadMessageResourceRejectsOversize(t *testing.T) {
 	srv := resourceTestServer(t, func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "image/png")

--- a/server/internal/integrations/lark/http_client_resource_test.go
+++ b/server/internal/integrations/lark/http_client_resource_test.go
@@ -13,12 +13,12 @@ import (
 func TestHTTPClientDownloadMessageResource(t *testing.T) {
 	var gotPath, gotQuery string
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		switch r.URL.Path {
-		case "/open-apis/auth/v3/tenant_access_token/internal":
+		switch {
+		case r.URL.Path == "/open-apis/auth/v3/tenant_access_token/internal":
 			w.Header().Set("Content-Type", "application/json")
 			_, _ = w.Write([]byte(`{"code":0,"tenant_access_token":"token","expire":7200}`))
-		case "/open-apis/im/v1/messages/om_1/resources":
-			gotPath, gotQuery = r.URL.Path, r.URL.RawQuery
+		case r.URL.EscapedPath() == "/open-apis/im/v1/messages/om_1/resources/img%2Fkey":
+			gotPath, gotQuery = r.URL.EscapedPath(), r.URL.RawQuery
 			w.Header().Set("Content-Type", "image/png")
 			w.Header().Set("Content-Disposition", `attachment; filename="screen.png"`)
 			_, _ = w.Write([]byte("png"))
@@ -31,11 +31,11 @@ func TestHTTPClientDownloadMessageResource(t *testing.T) {
 	client := NewHTTPAPIClient(HTTPClientConfig{BaseURL: srv.URL}).(*httpAPIClient)
 	got, err := client.DownloadMessageResource(context.Background(), InstallationCredentials{
 		AppID: "cli", AppSecret: "secret",
-	}, "om_1", "img_key", "image")
+	}, "om_1", "img/key", "image")
 	if err != nil {
 		t.Fatalf("DownloadMessageResource: %v", err)
 	}
-	if gotPath == "" || gotQuery != "file_key=img_key&type=image" {
+	if gotPath != "/open-apis/im/v1/messages/om_1/resources/img%2Fkey" || gotQuery != "type=image" {
 		t.Fatalf("request = %s?%s", gotPath, gotQuery)
 	}
 	if string(got.Data) != "png" || got.Filename != "screen.png" || got.ContentType != "image/png" {
@@ -118,7 +118,7 @@ func resourceTestServer(t *testing.T, resource http.HandlerFunc) *httptest.Serve
 		case "/open-apis/auth/v3/tenant_access_token/internal":
 			w.Header().Set("Content-Type", "application/json")
 			_, _ = io.WriteString(w, `{"code":0,"tenant_access_token":"token","expire":7200}`)
-		case "/open-apis/im/v1/messages/om_1/resources":
+		case "/open-apis/im/v1/messages/om_1/resources/img_key":
 			resource(w, r)
 		default:
 			http.NotFound(w, r)

--- a/server/internal/integrations/lark/http_client_resource_test.go
+++ b/server/internal/integrations/lark/http_client_resource_test.go
@@ -2,8 +2,11 @@ package lark
 
 import (
 	"context"
+	"errors"
+	"io"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 )
 
@@ -38,4 +41,59 @@ func TestHTTPClientDownloadMessageResource(t *testing.T) {
 	if string(got.Data) != "png" || got.Filename != "screen.png" || got.ContentType != "image/png" {
 		t.Fatalf("resource = %+v", got)
 	}
+}
+
+func TestHTTPClientDownloadMessageResourceRejectsOversize(t *testing.T) {
+	srv := resourceTestServer(t, func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "image/png")
+		_, _ = io.WriteString(w, "12345")
+	})
+	defer srv.Close()
+
+	client := NewHTTPAPIClient(HTTPClientConfig{BaseURL: srv.URL, MaxResourceBytes: 4}).(*httpAPIClient)
+	_, err := client.DownloadMessageResource(context.Background(), testCreds(), "om_1", "img_key", "image")
+	if err == nil || !strings.Contains(err.Error(), "exceeds 4 bytes") {
+		t.Fatalf("expected size-limit error, got %v", err)
+	}
+}
+
+func TestHTTPClientDownloadMessageResourceBusinessErrorInvalidatesToken(t *testing.T) {
+	tokenCalls := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/open-apis/auth/v3/tenant_access_token/internal" {
+			tokenCalls++
+			_, _ = io.WriteString(w, `{"code":0,"tenant_access_token":"token","expire":7200}`)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+		_, _ = io.WriteString(w, `{"code":99991663,"msg":"token expired"}`)
+	}))
+	defer srv.Close()
+
+	client := NewHTTPAPIClient(HTTPClientConfig{BaseURL: srv.URL}).(*httpAPIClient)
+	for i := 0; i < 2; i++ {
+		_, err := client.DownloadMessageResource(context.Background(), testCreds(), "om_1", "img_key", "image")
+		var apiErr *APIError
+		if !errors.As(err, &apiErr) || apiErr.Code != codeTokenExpired {
+			t.Fatalf("call %d: expected token APIError, got %v", i, err)
+		}
+	}
+	if tokenCalls != 2 {
+		t.Fatalf("invalid token must be evicted; token endpoint calls=%d want 2", tokenCalls)
+	}
+}
+
+func resourceTestServer(t *testing.T, resource http.HandlerFunc) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/open-apis/auth/v3/tenant_access_token/internal":
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = io.WriteString(w, `{"code":0,"tenant_access_token":"token","expire":7200}`)
+		case "/open-apis/im/v1/messages/om_1/resources":
+			resource(w, r)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
 }

--- a/server/internal/integrations/lark/http_client_resource_test.go
+++ b/server/internal/integrations/lark/http_client_resource_test.go
@@ -1,0 +1,41 @@
+package lark
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestHTTPClientDownloadMessageResource(t *testing.T) {
+	var gotPath, gotQuery string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/open-apis/auth/v3/tenant_access_token/internal":
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"code":0,"tenant_access_token":"token","expire":7200}`))
+		case "/open-apis/im/v1/messages/om_1/resources":
+			gotPath, gotQuery = r.URL.Path, r.URL.RawQuery
+			w.Header().Set("Content-Type", "image/png")
+			w.Header().Set("Content-Disposition", `attachment; filename="screen.png"`)
+			_, _ = w.Write([]byte("png"))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	client := NewHTTPAPIClient(HTTPClientConfig{BaseURL: srv.URL}).(*httpAPIClient)
+	got, err := client.DownloadMessageResource(context.Background(), InstallationCredentials{
+		AppID: "cli", AppSecret: "secret",
+	}, "om_1", "img_key", "image")
+	if err != nil {
+		t.Fatalf("DownloadMessageResource: %v", err)
+	}
+	if gotPath == "" || gotQuery != "file_key=img_key&type=image" {
+		t.Fatalf("request = %s?%s", gotPath, gotQuery)
+	}
+	if string(got.Data) != "png" || got.Filename != "screen.png" || got.ContentType != "image/png" {
+		t.Fatalf("resource = %+v", got)
+	}
+}

--- a/server/internal/integrations/lark/ws_connector.go
+++ b/server/internal/integrations/lark/ws_connector.go
@@ -98,10 +98,20 @@ type WSConnectorConfig struct {
 	Enricher Enricher
 
 	// EnrichTimeout caps a single message's enrichment (at most two
-	// GetMessage calls). It MUST stay well under Lark's ~3s long-conn
-	// ACK window, since enrichment runs before the frame is ACKed.
-	// Zero defaults to 2 seconds.
+	// GetMessage calls). It is also bounded by the shared AckTimeout.
+	// Zero defaults to 500 milliseconds.
 	EnrichTimeout time.Duration
+
+	// AckTimeout is the shared budget for enrichment, dispatch (including
+	// media resolution and DB writes), and the ACK write. It MUST stay below
+	// Lark's ~3s long-conn ACK deadline. Zero defaults to 2.5 seconds.
+	AckTimeout time.Duration
+
+	// AckWriteReserve is held back from AckTimeout for serializing and
+	// writing the ACK. Enrichment and dispatch receive a context whose
+	// deadline is AckTimeout-AckWriteReserve after frame handling starts.
+	// Zero defaults to 250 milliseconds.
+	AckWriteReserve time.Duration
 
 	// CredentialsProvider returns the InstallationCredentials the
 	// EndpointFetcher needs. Typically wraps
@@ -154,7 +164,13 @@ func (c WSConnectorConfig) withDefaults() WSConnectorConfig {
 		c.ChunkTTL = 5 * time.Second
 	}
 	if c.EnrichTimeout == 0 {
-		c.EnrichTimeout = 2 * time.Second
+		c.EnrichTimeout = 500 * time.Millisecond
+	}
+	if c.AckTimeout == 0 {
+		c.AckTimeout = 2500 * time.Millisecond
+	}
+	if c.AckWriteReserve == 0 {
+		c.AckWriteReserve = 250 * time.Millisecond
 	}
 	if c.Now == nil {
 		c.Now = time.Now
@@ -180,7 +196,11 @@ func NewWSLongConnConnector(cfg WSConnectorConfig) (*WSLongConnConnector, error)
 	if cfg.CredentialsProvider == nil {
 		return nil, errors.New("lark ws connector: CredentialsProvider is required")
 	}
-	return &WSLongConnConnector{cfg: cfg.withDefaults()}, nil
+	cfg = cfg.withDefaults()
+	if cfg.AckWriteReserve >= cfg.AckTimeout {
+		return nil, errors.New("lark ws connector: AckWriteReserve must be less than AckTimeout")
+	}
+	return &WSLongConnConnector{cfg: cfg}, nil
 }
 
 // Run satisfies EventConnector. Opens one WebSocket session, reads
@@ -381,6 +401,14 @@ func (c *WSLongConnConnector) Run(ctx context.Context, inst Installation, emit E
 			continue
 		}
 
+		// Enrichment and dispatch share one pre-ACK budget. Holding back a
+		// fixed write reserve prevents independently bounded network work
+		// (enrichment, then media resolution) from consuming Lark's entire
+		// ~3s ACK window before the DB path and ACK write run.
+		ackDeadline := c.cfg.Now().Add(c.cfg.AckTimeout)
+		processDeadline := ackDeadline.Add(-c.cfg.AckWriteReserve)
+		processCtx, cancelProcess := context.WithDeadline(ctx, processDeadline)
+
 		// Enrich the decoded body with explicitly-attached context
 		// (quoted reply / forwarded bundle) before emitting. This runs
 		// before the frame ACK, so it is bounded by EnrichTimeout and
@@ -388,17 +416,18 @@ func (c *WSLongConnConnector) Run(ctx context.Context, inst Installation, emit E
 		// pipeline. Most messages need no enrichment and return
 		// immediately without any network call.
 		if c.cfg.Enricher != nil {
-			enrichCtx, cancelEnrich := context.WithTimeout(ctx, c.cfg.EnrichTimeout)
+			enrichCtx, cancelEnrich := context.WithTimeout(processCtx, c.cfg.EnrichTimeout)
 			msg = c.cfg.Enricher.Enrich(enrichCtx, msg, creds)
 			cancelEnrich()
 		}
 
-		_, emitErr := emit(ctx, msg)
+		_, emitErr := emit(processCtx, msg)
+		cancelProcess()
 		if emitErr != nil {
 			// Infra failure from Dispatcher (DB down, etc.). NACK so
 			// Lark retries this event on a healthy replica; then
 			// return so the Hub backs off and reconnects.
-			if werr := c.writeFrame(&writeMu, conn, NewAckFrame(frame, false)); werr != nil {
+			if werr := c.writeFrameBefore(&writeMu, conn, NewAckFrame(frame, false), ackDeadline); werr != nil {
 				log.Warn("lark ws connector: nack write failed", "err", werr.Error())
 			}
 			log.Error("lark ws connector: emit infra error",
@@ -407,7 +436,7 @@ func (c *WSLongConnConnector) Run(ctx context.Context, inst Installation, emit E
 			)
 			return fmt.Errorf("dispatch: %w", emitErr)
 		}
-		if werr := c.writeFrame(&writeMu, conn, NewAckFrame(frame, true)); werr != nil {
+		if werr := c.writeFrameBefore(&writeMu, conn, NewAckFrame(frame, true), ackDeadline); werr != nil {
 			log.Warn("lark ws connector: ack write failed", "err", werr.Error())
 			return fmt.Errorf("write ack: %w", werr)
 		}
@@ -418,10 +447,17 @@ func (c *WSLongConnConnector) Run(ctx context.Context, inst Installation, emit E
 // message under the connector's write mutex. Caller MUST NOT hold
 // writeMu when calling.
 func (c *WSLongConnConnector) writeFrame(mu *sync.Mutex, conn WSConn, f *Frame) error {
+	return c.writeFrameBefore(mu, conn, f, time.Time{})
+}
+
+func (c *WSLongConnConnector) writeFrameBefore(mu *sync.Mutex, conn WSConn, f *Frame, before time.Time) error {
 	payload := f.Marshal()
 	mu.Lock()
 	defer mu.Unlock()
 	deadline := c.cfg.Now().Add(c.cfg.WriteTimeout)
+	if !before.IsZero() && before.Before(deadline) {
+		deadline = before
+	}
 	if err := conn.SetWriteDeadline(deadline); err != nil {
 		return err
 	}

--- a/server/internal/integrations/lark/ws_connector_enrich_test.go
+++ b/server/internal/integrations/lark/ws_connector_enrich_test.go
@@ -17,6 +17,18 @@ type recordingEnricher struct {
 	creds []InstallationCredentials
 }
 
+type deadlineEnricher struct {
+	deadline chan time.Time
+}
+
+func (e *deadlineEnricher) Enrich(ctx context.Context, msg InboundMessage, _ InstallationCredentials) InboundMessage {
+	if deadline, ok := ctx.Deadline(); ok {
+		e.deadline <- deadline
+	}
+	<-ctx.Done()
+	return msg
+}
+
 func (e *recordingEnricher) Enrich(ctx context.Context, msg InboundMessage, creds InstallationCredentials) InboundMessage {
 	e.mu.Lock()
 	defer e.mu.Unlock()
@@ -112,5 +124,111 @@ func TestWSConnectorEnrichesBeforeEmit(t *testing.T) {
 	}
 	if len(enr.creds) != 1 || enr.creds[0].AppID != "test_app" || enr.creds[0].AppSecret != "secret" {
 		t.Errorf("enricher got wrong creds: %+v", enr.creds)
+	}
+}
+
+func TestWSConnectorSharesAckBudgetAcrossEnrichmentAndDispatch(t *testing.T) {
+	t.Parallel()
+	conn := newFakeWSConn()
+	decoder := FrameDecoderFunc(func(payload []byte, _ Installation) (InboundMessage, bool, error) {
+		return InboundMessage{EventID: string(payload), MessageID: "msg-" + string(payload)}, true, nil
+	})
+	enr := &deadlineEnricher{deadline: make(chan time.Time, 1)}
+
+	const (
+		ackTimeout      = 180 * time.Millisecond
+		ackWriteReserve = 40 * time.Millisecond
+		enrichTimeout   = 60 * time.Millisecond
+	)
+	c, err := NewWSLongConnConnector(WSConnectorConfig{
+		Dialer: &fakeWSDialer{conn: conn},
+		EndpointFetcher: EndpointFetcherFunc(func(context.Context, InstallationCredentials) (WSEndpoint, error) {
+			return WSEndpoint{URL: "wss://test/ignored", ServiceID: 7, PingInterval: time.Hour}, nil
+		}),
+		FrameDecoder: decoder,
+		Enricher:     enr,
+		CredentialsProvider: CredentialsProviderFunc(func(context.Context, Installation) (InstallationCredentials, error) {
+			return InstallationCredentials{AppID: "test_app", AppSecret: "secret"}, nil
+		}),
+		PingInterval:    time.Hour,
+		ReadDeadline:    time.Second,
+		WriteTimeout:    time.Second,
+		EnrichTimeout:   enrichTimeout,
+		AckTimeout:      ackTimeout,
+		AckWriteReserve: ackWriteReserve,
+		Logger:          slog.New(slog.NewTextHandler(io.Discard, nil)),
+	})
+	if err != nil {
+		t.Fatalf("NewWSLongConnConnector: %v", err)
+	}
+
+	emitDeadline := make(chan time.Time, 1)
+	emit := func(ctx context.Context, _ InboundMessage) (DispatchResult, error) {
+		deadline, ok := ctx.Deadline()
+		if !ok {
+			t.Error("dispatch context has no shared ACK deadline")
+		} else {
+			emitDeadline <- deadline
+		}
+		// Model media consuming the rest of the shared processing budget and
+		// failing open. The connector must still ACK 200 and keep the socket.
+		<-ctx.Done()
+		return DispatchResult{Outcome: OutcomeIngested}, nil
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() { done <- c.Run(ctx, Installation{AppID: "test_app"}, emit) }()
+
+	started := time.Now()
+	pushDataFrame(conn, []byte("evt-budget"), "m-budget")
+
+	enrichDeadline := <-enr.deadline
+	dispatchDeadline := <-emitDeadline
+	if !dispatchDeadline.After(enrichDeadline) {
+		t.Fatalf("dispatch deadline %v must outlive enrichment deadline %v", dispatchDeadline, enrichDeadline)
+	}
+	if got := dispatchDeadline.Sub(enrichDeadline); got < 50*time.Millisecond || got > 100*time.Millisecond {
+		t.Fatalf("deadline gap = %v; want enrichment's shorter cap within the shared budget", got)
+	}
+
+	deadline := time.After(time.Second)
+	for {
+		writes := conn.snapshot()
+		if len(writes) > 0 {
+			frame, unmarshalErr := UnmarshalFrame(writes[0])
+			if unmarshalErr != nil {
+				t.Fatalf("unmarshal ACK: %v", unmarshalErr)
+			}
+			if !contains(string(frame.Payload), `"code":200`) {
+				t.Fatalf("ACK payload = %s; want code=200", frame.Payload)
+			}
+			break
+		}
+		select {
+		case runErr := <-done:
+			t.Fatalf("connector exited instead of ACKing and keeping the connection: %v", runErr)
+		case <-deadline:
+			t.Fatal("connector did not ACK within 1s")
+		case <-time.After(5 * time.Millisecond):
+		}
+	}
+	if elapsed := time.Since(started); elapsed > ackTimeout+100*time.Millisecond {
+		t.Fatalf("ACK took %v; shared budget is %v", elapsed, ackTimeout)
+	}
+	select {
+	case runErr := <-done:
+		t.Fatalf("connector exited after fail-open dispatch: %v", runErr)
+	default:
+	}
+
+	cancel()
+	select {
+	case runErr := <-done:
+		if runErr != nil {
+			t.Fatalf("Run returned error on cancellation: %v", runErr)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("Run did not return after cancellation")
 	}
 }

--- a/server/internal/integrations/lark/ws_frame_decoder.go
+++ b/server/internal/integrations/lark/ws_frame_decoder.go
@@ -91,16 +91,20 @@ func (d *LarkJSONFrameDecoder) Decode(payload []byte, inst Installation) (Inboun
 		botUnionID = inst.BotUnionID.String
 	}
 
-	// text + post are flattened synchronously here (no external calls —
-	// the decoder must stay fast and dependency-free). merge_forward
-	// leaves Body empty: it needs an HTTP round-trip to expand and is
-	// handled downstream by the enricher, which keys off MessageType.
-	// Other types (image, file, …) also leave Body empty in this MVP;
-	// attachment ingestion is a separate issue.
+	// All directly renderable types are flattened synchronously here (no
+	// external calls — the decoder must stay fast and dependency-free).
+	// Media messages become stable placeholders such as [Image], so an
+	// image-only event never lands in chat history as an empty message.
+	// merge_forward alone leaves Body empty: it needs an HTTP round-trip to
+	// expand and is handled downstream by the enricher.
 	switch evt.Message.MessageType {
 	case "text", "post":
 		msg.Body = resolveMentions(flattenContent(evt.Message.MessageType, evt.Message.Content),
 			evt.Message.Mentions, inst.BotOpenID, botUnionID)
+	case "merge_forward":
+		// Expanded by InboundEnricher.
+	default:
+		msg.Body = flattenContent(evt.Message.MessageType, evt.Message.Content)
 	}
 
 	// Snapshot the user's own text as the command source BEFORE any

--- a/server/internal/integrations/lark/ws_frame_decoder.go
+++ b/server/internal/integrations/lark/ws_frame_decoder.go
@@ -73,6 +73,7 @@ func (d *LarkJSONFrameDecoder) Decode(payload []byte, inst Installation) (Inboun
 		MessageID:    evt.Message.MessageID,
 		SenderOpenID: OpenID(evt.Sender.SenderID.OpenID),
 		MessageType:  evt.Message.MessageType,
+		RawContent:   evt.Message.Content,
 		CreateTime:   evt.Message.CreateTime,
 		// parent_id / root_id are populated by Lark only in reply
 		// scenarios. The enricher keys quoted-reply expansion off

--- a/server/internal/integrations/lark/ws_frame_decoder_test.go
+++ b/server/internal/integrations/lark/ws_frame_decoder_test.go
@@ -429,7 +429,7 @@ func TestLarkJSONFrameDecoderMessageContentEmptyOnInvalidContentJSON(t *testing.
 	}
 }
 
-func TestLarkJSONFrameDecoderNonTextMessageHasEmptyBody(t *testing.T) {
+func TestLarkJSONFrameDecoderImageMessageHasPlaceholderBody(t *testing.T) {
 	t.Parallel()
 	raw := []byte(`{
 		"type":"event_callback",
@@ -443,8 +443,8 @@ func TestLarkJSONFrameDecoderNonTextMessageHasEmptyBody(t *testing.T) {
 	if err != nil || !ok {
 		t.Fatalf("ok=%v err=%v", ok, err)
 	}
-	if msg.Body != "" {
-		t.Errorf("Body = %q; non-text messages should have empty body in MVP", msg.Body)
+	if msg.Body != "[Image]" {
+		t.Errorf("Body = %q; want [Image]", msg.Body)
 	}
 	if msg.MessageID == "" {
 		t.Error("MessageID should still be populated for non-text events")


### PR DESCRIPTION
## Summary
- download inbound Feishu image resources and persist them to Multica object storage
- bind each image as an attachment on the corresponding user chat message so agent tasks can read it
- keep the `[Image]` text fallback and preserve existing text/post/merge-forward handling
- cover resource download, storage normalization, and chat attachment binding with focused tests

## Tests
- `go test ./internal/integrations/lark ./internal/integrations/channel/... ./cmd/server`
- `go vet ./internal/integrations/lark ./internal/integrations/channel/... ./cmd/server`
- `git diff --check`