### PR TITLE
fix(desktop): rename Linux executable to multica-desktop

### DIFF
--- a/apps/desktop/electron-builder.yml
+++ b/apps/desktop/electron-builder.yml
@@ -43,9 +43,21 @@ linux:
   # violates the freedesktop desktop-entry naming guidance, so GNOME /
   # Ubuntu fail to associate the running window with the `.desktop` entry
   # and fall back to the theme's default app icon (the Settings gear on
-  # Yaru). Forcing `multica` makes every Linux identity slot agree and
-  # matches `StartupWMClass=Multica` (productName-derived).
-  executableName: multica
+  # Yaru).
+  #
+  # `multica-desktop` (not `multica`) so the deb/rpm/AppImage package never
+  # installs this Electron binary as `/usr/bin/multica`. The Go CLI is a
+  # separate artifact (see CLI_INSTALL.md) that agents and scripts expect
+  # to find at `multica` on PATH; when both packages are installed on the
+  # same box, a plain electron-builder default collides the two under one
+  # name. Whichever installs later — or wins the PATH lookup order — silently
+  # shadows the other. Hitting the Electron binary from a CLI call is the
+  # worst failure mode: it exits 0 with empty stdout (its own Chromium flags
+  # eat CLI args like `--output json`), which looks like a healthy CLI that
+  # returned nothing rather than "wrong binary" (github.com/multica-ai/multica/issues/5481).
+  # `StartupWMClass=Multica` (productName-derived) is unaffected by this
+  # rename — it comes from `app.getName()`, not `executableName`.
+  executableName: multica-desktop
   # Pin StartupWMClass to the WM_CLASS Electron emits on X11. Electron
   # derives WM_CLASS from `app.getName()`, which reads the *packaged*
   # ASAR's `package.json` — `productName` if present, otherwise `name`.


### PR DESCRIPTION
Fixes #5481.

## What

Renames the Electron desktop app's Linux packaged executable from `multica` to `multica-desktop` (`apps/desktop/electron-builder.yml`, `linux.executableName`).

## Why

The deb/rpm/AppImage packages installed the Electron launcher as `multica`, the same name the Go CLI binary uses. When both are installed on the same machine, PATH resolution order decides which one wins — and hitting the Electron binary from a CLI call is a nasty failure mode: it exits `0` with empty stdout (its own Chromium flags eat args like `--output json`), which looks like a healthy CLI returning nothing rather than "wrong binary entirely." See #5481 for the full diagnosis.

## Scope

Config-only change, one file. `StartupWMClass: Multica` is untouched — it's derived from `app.getName()` (productName), not `executableName`, so window/taskbar association on Linux is unaffected. `artifactName` already used the `multica-desktop-*` naming scheme, so release filenames don't change.

## Test plan

- [x] `apps/desktop/electron-builder.yml` parses as valid YAML
- [x] Grepped the repo for other references to the packaged Linux binary name — none found outside this file
- [ ] Full `pnpm package` / installed `.deb` verification on a Linux box (not run in this environment — no Linux packaging toolchain available here)
