### PR TITLE
KAP-892: stabilize Codex auth provisioning

### DIFF
--- a/server/internal/daemon/execenv/codex_auth_provision_test.go
+++ b/server/internal/daemon/execenv/codex_auth_provision_test.go
@@ -40,6 +40,42 @@ func TestPrepareCodexHomeFallsBackFromDeletedManagedHome(t *testing.T) {
 	}
 }
 
+func TestPrepareCodexHomeNeverAnchorsToLiveManagedHome(t *testing.T) {
+	root := t.TempDir()
+	if err := EnsureWorkspacesRootMarker(root); err != nil {
+		t.Fatal(err)
+	}
+	managed := filepath.Join(root, "ws", "task-a", "codex-home")
+	if err := os.MkdirAll(managed, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(managed, "auth.json"), []byte("managed"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	home := t.TempDir()
+	stable := filepath.Join(home, ".codex")
+	if err := os.MkdirAll(stable, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(stable, "auth.json"), []byte("stable"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("HOME", home)
+	t.Setenv("CODEX_HOME", managed)
+	t.Setenv("OPENAI_API_KEY", "")
+	dst := filepath.Join(root, "ws", "task-b", "codex-home")
+	if err := prepareCodexHome(dst, testLogger()); err != nil {
+		t.Fatalf("prepare: %v", err)
+	}
+	if err := os.RemoveAll(filepath.Dir(managed)); err != nil {
+		t.Fatal(err)
+	}
+	data, err := os.ReadFile(filepath.Join(dst, "auth.json"))
+	if err != nil || string(data) != "stable" {
+		t.Fatalf("destination after cleanup: data=%q err=%v", data, err)
+	}
+}
+
 func TestPrepareCodexHomeFailsClosedWithoutFileAuth(t *testing.T) {
 	root := t.TempDir()
 	if err := EnsureWorkspacesRootMarker(root); err != nil {
@@ -49,8 +85,64 @@ func TestPrepareCodexHomeFailsClosedWithoutFileAuth(t *testing.T) {
 	t.Setenv("CODEX_HOME", filepath.Join(root, "ws", "task", "codex-home"))
 	t.Setenv("OPENAI_API_KEY", "")
 	err := prepareCodexHome(filepath.Join(t.TempDir(), "codex-home"), testLogger())
-	if err == nil || !strings.Contains(err.Error(), "readable auth.json") {
+	if err == nil || !strings.Contains(err.Error(), "readable provisioned auth.json") {
 		t.Fatalf("error = %v", err)
+	}
+}
+
+func TestPrepareCodexHomeFailsClosedForDefaultAndCustomHomes(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		custom bool
+	}{{"default", false}, {"custom", true}} {
+		t.Run(tc.name, func(t *testing.T) {
+			home := t.TempDir()
+			t.Setenv("HOME", home)
+			t.Setenv("OPENAI_API_KEY", "")
+			if tc.custom {
+				t.Setenv("CODEX_HOME", filepath.Join(home, "stable-custom"))
+			} else {
+				t.Setenv("CODEX_HOME", "")
+			}
+			err := prepareCodexHome(filepath.Join(t.TempDir(), "codex-home"), testLogger())
+			if err == nil || !strings.Contains(err.Error(), "readable provisioned auth.json") {
+				t.Fatalf("error = %v", err)
+			}
+		})
+	}
+}
+
+func TestPrepareCodexHomeFailsWhenDestinationCannotBeProvisioned(t *testing.T) {
+	shared := t.TempDir()
+	if err := os.WriteFile(filepath.Join(shared, "auth.json"), []byte("auth"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("CODEX_HOME", shared)
+	t.Setenv("OPENAI_API_KEY", "")
+	dst := filepath.Join(t.TempDir(), "codex-home")
+	if err := os.MkdirAll(filepath.Join(dst, "auth.json"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dst, "auth.json", "blocker"), []byte("x"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	err := prepareCodexHome(dst, testLogger())
+	if err == nil || !strings.Contains(err.Error(), "provision codex auth file") {
+		t.Fatalf("error = %v", err)
+	}
+}
+
+func TestReuseReturnsNilWhenCodexAuthPreparationFails(t *testing.T) {
+	shared := t.TempDir()
+	t.Setenv("CODEX_HOME", shared)
+	t.Setenv("OPENAI_API_KEY", "")
+	root := t.TempDir()
+	workDir := filepath.Join(root, "workdir")
+	if err := os.MkdirAll(workDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if got := Reuse(ReuseParams{WorkDir: workDir, Provider: "codex"}, testLogger()); got != nil {
+		t.Fatalf("Reuse = %#v, want nil", got)
 	}
 }
 
@@ -95,5 +187,30 @@ func TestResolveSharedCodexHomeKeepsStableCustomHome(t *testing.T) {
 	t.Setenv("CODEX_HOME", custom)
 	if got := resolveSharedCodexHome(); got != custom {
 		t.Fatalf("got %q want %q", got, custom)
+	}
+}
+
+func TestManagedCodexHomeDetectionUsesDaemonMarker(t *testing.T) {
+	root := t.TempDir()
+	if err := EnsureWorkspacesRootMarker(root); err != nil {
+		t.Fatal(err)
+	}
+	if !isManagedCodexHome(filepath.Join(root, "ws", "task", "codex-home")) {
+		t.Fatal("marked task home not detected")
+	}
+	if isManagedCodexHome(filepath.Join(t.TempDir(), "codex-home")) {
+		t.Fatal("unmarked custom home detected as managed")
+	}
+}
+
+func TestValidateCodexAuthDestinationAcceptsWindowsCopyFallback(t *testing.T) {
+	shared := t.TempDir()
+	dst := filepath.Join(t.TempDir(), "auth.json")
+	if err := os.WriteFile(dst, []byte("copied-auth"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("OPENAI_API_KEY", "")
+	if err := validateCodexAuthDestination(shared, dst); err != nil {
+		t.Fatalf("regular-file fallback rejected: %v", err)
 	}
 }

--- a/server/internal/daemon/execenv/codex_auth_provision_test.go
+++ b/server/internal/daemon/execenv/codex_auth_provision_test.go
@@ -85,7 +85,7 @@ func TestPrepareCodexHomeFailsClosedWithoutFileAuth(t *testing.T) {
 	t.Setenv("CODEX_HOME", filepath.Join(root, "ws", "task", "codex-home"))
 	t.Setenv("OPENAI_API_KEY", "")
 	err := prepareCodexHome(filepath.Join(t.TempDir(), "codex-home"), testLogger())
-	if err == nil || !strings.Contains(err.Error(), "readable provisioned auth.json") {
+	if err == nil || !strings.Contains(err.Error(), "readable durable source auth.json") {
 		t.Fatalf("error = %v", err)
 	}
 }
@@ -105,7 +105,7 @@ func TestPrepareCodexHomeFailsClosedForDefaultAndCustomHomes(t *testing.T) {
 				t.Setenv("CODEX_HOME", "")
 			}
 			err := prepareCodexHome(filepath.Join(t.TempDir(), "codex-home"), testLogger())
-			if err == nil || !strings.Contains(err.Error(), "readable provisioned auth.json") {
+			if err == nil || !strings.Contains(err.Error(), "readable durable source auth.json") {
 				t.Fatalf("error = %v", err)
 			}
 		})
@@ -205,6 +205,9 @@ func TestManagedCodexHomeDetectionUsesDaemonMarker(t *testing.T) {
 
 func TestValidateCodexAuthDestinationAcceptsWindowsCopyFallback(t *testing.T) {
 	shared := t.TempDir()
+	if err := os.WriteFile(filepath.Join(shared, "auth.json"), []byte("source-auth"), 0o600); err != nil {
+		t.Fatal(err)
+	}
 	dst := filepath.Join(t.TempDir(), "auth.json")
 	if err := os.WriteFile(dst, []byte("copied-auth"), 0o600); err != nil {
 		t.Fatal(err)
@@ -212,5 +215,40 @@ func TestValidateCodexAuthDestinationAcceptsWindowsCopyFallback(t *testing.T) {
 	t.Setenv("OPENAI_API_KEY", "")
 	if err := validateCodexAuthDestination(shared, dst); err != nil {
 		t.Fatalf("regular-file fallback rejected: %v", err)
+	}
+}
+
+func TestWindowsCopyFallbackFailsClosedAfterSourceRemoval(t *testing.T) {
+	shared := t.TempDir()
+	source := filepath.Join(shared, "auth.json")
+	if err := os.WriteFile(source, []byte("source-auth"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("CODEX_HOME", shared)
+	t.Setenv("OPENAI_API_KEY", "")
+	root := t.TempDir()
+	workDir := filepath.Join(root, "workdir")
+	destination := filepath.Join(root, "codex-home", "auth.json")
+	if err := os.MkdirAll(filepath.Dir(destination), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// Models createFileLink's Windows fallback: a regular file, not a symlink.
+	if err := os.WriteFile(destination, []byte("copied-auth"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := validateCodexAuthDestination(shared, destination); err != nil {
+		t.Fatalf("initial copy invalid: %v", err)
+	}
+	if err := os.Remove(source); err != nil {
+		t.Fatal(err)
+	}
+	if err := prepareCodexHome(filepath.Join(t.TempDir(), "codex-home"), testLogger()); err == nil || !strings.Contains(err.Error(), "readable durable source auth.json") {
+		t.Fatalf("prepare error = %v", err)
+	}
+	if err := os.MkdirAll(workDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if got := Reuse(ReuseParams{WorkDir: workDir, Provider: "codex"}, testLogger()); got != nil {
+		t.Fatalf("Reuse = %#v, want nil", got)
 	}
 }

--- a/server/internal/daemon/execenv/codex_auth_provision_test.go
+++ b/server/internal/daemon/execenv/codex_auth_provision_test.go
@@ -1,0 +1,99 @@
+package execenv
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestPrepareCodexHomeFallsBackFromDeletedManagedHome(t *testing.T) {
+	root := t.TempDir()
+	if err := EnsureWorkspacesRootMarker(root); err != nil {
+		t.Fatal(err)
+	}
+	managed := filepath.Join(root, "ws", "task", "codex-home")
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("CODEX_HOME", managed)
+	t.Setenv("OPENAI_API_KEY", "")
+	stable := filepath.Join(home, ".codex")
+	if err := os.MkdirAll(stable, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(stable, "auth.json"), []byte(`{"tokens":{}}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	dst := filepath.Join(t.TempDir(), "codex-home")
+	if err := prepareCodexHome(dst, testLogger()); err != nil {
+		t.Fatalf("prepare: %v", err)
+	}
+	data, err := os.ReadFile(filepath.Join(dst, "auth.json"))
+	if err != nil || string(data) != `{"tokens":{}}` {
+		t.Fatalf("fallback auth: data=%q err=%v", data, err)
+	}
+	if err := os.RemoveAll(dst); err != nil {
+		t.Fatal(err)
+	}
+	if err := prepareCodexHome(dst, testLogger()); err != nil {
+		t.Fatalf("prepare after cleanup: %v", err)
+	}
+}
+
+func TestPrepareCodexHomeFailsClosedWithoutFileAuth(t *testing.T) {
+	root := t.TempDir()
+	if err := EnsureWorkspacesRootMarker(root); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("CODEX_HOME", filepath.Join(root, "ws", "task", "codex-home"))
+	t.Setenv("OPENAI_API_KEY", "")
+	err := prepareCodexHome(filepath.Join(t.TempDir(), "codex-home"), testLogger())
+	if err == nil || !strings.Contains(err.Error(), "readable auth.json") {
+		t.Fatalf("error = %v", err)
+	}
+}
+
+func TestPrepareCodexHomeAllowsAPIKeyWithoutFileAuth(t *testing.T) {
+	root := t.TempDir()
+	if err := EnsureWorkspacesRootMarker(root); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("CODEX_HOME", filepath.Join(root, "ws", "task", "codex-home"))
+	t.Setenv("OPENAI_API_KEY", "set")
+	if err := prepareCodexHome(filepath.Join(t.TempDir(), "codex-home"), testLogger()); err != nil {
+		t.Fatalf("prepare: %v", err)
+	}
+}
+
+func TestPrepareCodexHomeAllowsCustomProviderEnvKeyWithoutFileAuth(t *testing.T) {
+	root := t.TempDir()
+	if err := EnsureWorkspacesRootMarker(root); err != nil {
+		t.Fatal(err)
+	}
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("CODEX_HOME", filepath.Join(root, "ws", "task", "codex-home"))
+	t.Setenv("OPENAI_API_KEY", "")
+	t.Setenv("CUSTOM_API_KEY", "set")
+	stable := filepath.Join(home, ".codex")
+	if err := os.MkdirAll(stable, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	config := "model_provider = \"custom\"\n[model_providers.custom]\nenv_key = \"CUSTOM_API_KEY\"\n"
+	if err := os.WriteFile(filepath.Join(stable, "config.toml"), []byte(config), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := prepareCodexHome(filepath.Join(t.TempDir(), "codex-home"), testLogger()); err != nil {
+		t.Fatalf("prepare: %v", err)
+	}
+}
+
+func TestResolveSharedCodexHomeKeepsStableCustomHome(t *testing.T) {
+	custom := filepath.Join(t.TempDir(), "custom-codex")
+	t.Setenv("CODEX_HOME", custom)
+	if got := resolveSharedCodexHome(); got != custom {
+		t.Fatalf("got %q want %q", got, custom)
+	}
+}

--- a/server/internal/daemon/execenv/codex_home.go
+++ b/server/internal/daemon/execenv/codex_home.go
@@ -238,7 +238,13 @@ func codexFileAuthRequired(sharedHome string) bool {
 }
 
 func validateCodexAuthDestination(sharedHome, destination string) error {
-	if codexFileAuthRequired(sharedHome) && !isReadableRegularFile(destination) {
+	if !codexFileAuthRequired(sharedHome) {
+		return nil
+	}
+	if !isReadableRegularFile(filepath.Join(sharedHome, "auth.json")) {
+		return errors.New("codex file authentication requires readable durable source auth.json")
+	}
+	if !isReadableRegularFile(destination) {
 		return errors.New("codex file authentication requires readable provisioned auth.json")
 	}
 	return nil

--- a/server/internal/daemon/execenv/codex_home.go
+++ b/server/internal/daemon/execenv/codex_home.go
@@ -80,9 +80,6 @@ func prepareCodexHome(codexHome string, logger *slog.Logger) error {
 // daemon-managed sandbox block picked by codexSandboxPolicyFor.
 func prepareCodexHomeWithOpts(codexHome string, opts CodexHomeOptions, logger *slog.Logger) error {
 	sharedHome := resolveSharedCodexHome()
-	if inherited := inheritedManagedCodexHomeWithoutAuth(); inherited && !isReadableRegularFile(filepath.Join(sharedHome, "auth.json")) && codexFileAuthRequired(sharedHome) {
-		return errors.New("codex file authentication requires readable auth.json")
-	}
 
 	if err := os.MkdirAll(codexHome, 0o755); err != nil {
 		return fmt.Errorf("create codex-home dir: %w", err)
@@ -100,7 +97,7 @@ func prepareCodexHomeWithOpts(codexHome string, opts CodexHomeOptions, logger *s
 		src := filepath.Join(sharedHome, name)
 		dst := filepath.Join(codexHome, name)
 		if err := ensureSymlink(src, dst); err != nil {
-			logger.Warn("execenv: codex-home symlink failed", "file", name, "error", err)
+			return errors.New("provision codex auth file failed")
 		}
 	}
 
@@ -109,6 +106,9 @@ func prepareCodexHomeWithOpts(codexHome string, opts CodexHomeOptions, logger *s
 	// per-task home is tracking the shared ~/.codex/auth.json or has drifted
 	// into a stale local copy.
 	logCodexAuthState(filepath.Join(codexHome, "auth.json"), logger)
+	if err := validateCodexAuthDestination(sharedHome, filepath.Join(codexHome, "auth.json")); err != nil {
+		return err
+	}
 
 	// Sync config files from the shared source (isolated per task).
 	for _, name := range codexCopiedFiles {
@@ -170,7 +170,7 @@ func resolveSharedCodexHome() string {
 	if v := os.Getenv("CODEX_HOME"); v != "" {
 		abs, err := filepath.Abs(v)
 		if err == nil {
-			if isManagedCodexHome(abs) && !isReadableRegularFile(filepath.Join(abs, "auth.json")) {
+			if isManagedCodexHome(abs) {
 				return defaultCodexHome()
 			}
 			return abs
@@ -216,15 +216,6 @@ func isReadableRegularFile(path string) bool {
 	return f.Close() == nil
 }
 
-func inheritedManagedCodexHomeWithoutAuth() bool {
-	v := os.Getenv("CODEX_HOME")
-	if v == "" {
-		return false
-	}
-	abs, err := filepath.Abs(v)
-	return err == nil && isManagedCodexHome(abs) && !isReadableRegularFile(filepath.Join(abs, "auth.json"))
-}
-
 func codexFileAuthRequired(sharedHome string) bool {
 	if strings.TrimSpace(os.Getenv("OPENAI_API_KEY")) != "" {
 		return false
@@ -244,6 +235,13 @@ func codexFileAuthRequired(sharedHome string) bool {
 	}
 	provider, ok := cfg.ModelProviders[cfg.ModelProvider]
 	return !ok || provider.EnvKey == "" || strings.TrimSpace(os.Getenv(provider.EnvKey)) == ""
+}
+
+func validateCodexAuthDestination(sharedHome, destination string) error {
+	if codexFileAuthRequired(sharedHome) && !isReadableRegularFile(destination) {
+		return errors.New("codex file authentication requires readable provisioned auth.json")
+	}
+	return nil
 }
 
 // codexSessionStateGlobs are the session-derived SQLite state Codex builds

--- a/server/internal/daemon/execenv/codex_home.go
+++ b/server/internal/daemon/execenv/codex_home.go
@@ -3,6 +3,8 @@ package execenv
 import (
 	"crypto/sha256"
 	"encoding/hex"
+	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"log/slog"
@@ -78,6 +80,9 @@ func prepareCodexHome(codexHome string, logger *slog.Logger) error {
 // daemon-managed sandbox block picked by codexSandboxPolicyFor.
 func prepareCodexHomeWithOpts(codexHome string, opts CodexHomeOptions, logger *slog.Logger) error {
 	sharedHome := resolveSharedCodexHome()
+	if inherited := inheritedManagedCodexHomeWithoutAuth(); inherited && !isReadableRegularFile(filepath.Join(sharedHome, "auth.json")) && codexFileAuthRequired(sharedHome) {
+		return errors.New("codex file authentication requires readable auth.json")
+	}
 
 	if err := os.MkdirAll(codexHome, 0o755); err != nil {
 		return fmt.Errorf("create codex-home dir: %w", err)
@@ -165,14 +170,80 @@ func resolveSharedCodexHome() string {
 	if v := os.Getenv("CODEX_HOME"); v != "" {
 		abs, err := filepath.Abs(v)
 		if err == nil {
+			if isManagedCodexHome(abs) && !isReadableRegularFile(filepath.Join(abs, "auth.json")) {
+				return defaultCodexHome()
+			}
 			return abs
 		}
 	}
+	return defaultCodexHome()
+}
+
+func defaultCodexHome() string {
 	home, err := os.UserHomeDir()
 	if err != nil {
 		return filepath.Join(os.TempDir(), ".codex") // last resort fallback
 	}
 	return filepath.Join(home, ".codex")
+}
+
+func isManagedCodexHome(path string) bool {
+	if filepath.Base(path) != "codex-home" {
+		return false
+	}
+	for dir := filepath.Dir(path); ; dir = filepath.Dir(dir) {
+		data, err := os.ReadFile(filepath.Join(dir, TaskContextMarkerRelPath))
+		if err == nil {
+			var marker taskContextMarkerFile
+			return json.Unmarshal(data, &marker) == nil && marker.ManagedBy == TaskContextMarkerManagedBy
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			return false
+		}
+	}
+}
+
+func isReadableRegularFile(path string) bool {
+	fi, err := os.Stat(path)
+	if err != nil || !fi.Mode().IsRegular() {
+		return false
+	}
+	f, err := os.Open(path)
+	if err != nil {
+		return false
+	}
+	return f.Close() == nil
+}
+
+func inheritedManagedCodexHomeWithoutAuth() bool {
+	v := os.Getenv("CODEX_HOME")
+	if v == "" {
+		return false
+	}
+	abs, err := filepath.Abs(v)
+	return err == nil && isManagedCodexHome(abs) && !isReadableRegularFile(filepath.Join(abs, "auth.json"))
+}
+
+func codexFileAuthRequired(sharedHome string) bool {
+	if strings.TrimSpace(os.Getenv("OPENAI_API_KEY")) != "" {
+		return false
+	}
+	data, err := os.ReadFile(filepath.Join(sharedHome, "config.toml"))
+	if err != nil {
+		return true
+	}
+	var cfg struct {
+		ModelProvider  string `toml:"model_provider"`
+		ModelProviders map[string]struct {
+			EnvKey string `toml:"env_key"`
+		} `toml:"model_providers"`
+	}
+	if toml.Unmarshal(data, &cfg) != nil || cfg.ModelProvider == "" {
+		return true
+	}
+	provider, ok := cfg.ModelProviders[cfg.ModelProvider]
+	return !ok || provider.EnvKey == "" || strings.TrimSpace(os.Getenv(provider.EnvKey)) == ""
 }
 
 // codexSessionStateGlobs are the session-derived SQLite state Codex builds

--- a/server/internal/daemon/execenv/execenv.go
+++ b/server/internal/daemon/execenv/execenv.go
@@ -506,6 +506,7 @@ func Reuse(params ReuseParams, logger *slog.Logger) *Environment {
 		codexHome := filepath.Join(env.RootDir, "codex-home")
 		if err := prepareCodexHomeWithOpts(codexHome, CodexHomeOptions{CodexVersion: params.CodexVersion, ResumeSessionID: params.ResumeSessionID, IsLocalDirectory: params.LocalDirectory, SessionStoreKey: codexSessionStoreKey(params.Profile, params.Task.AgentID, params.Task.IssueID)}, logger); err != nil {
 			logger.Warn("execenv: refresh codex-home failed", "error", err)
+			return nil
 		} else {
 			env.CodexHome = codexHome
 			if err := hydrateCodexSkills(codexHome, params.Task.AgentSkills, logger); err != nil {

--- a/server/internal/daemon/execenv/execenv_test.go
+++ b/server/internal/daemon/execenv/execenv_test.go
@@ -2083,6 +2083,7 @@ func TestPrepareCodexHomeCopiesRelativeModelCatalog(t *testing.T) {
 	// Cannot use t.Parallel() with t.Setenv.
 
 	sharedHome := t.TempDir()
+	t.Setenv("OPENAI_API_KEY", "test-key")
 	if err := os.WriteFile(filepath.Join(sharedHome, "config.toml"), []byte(`model_catalog_json = "cc-switch-model-catalog.json"`), 0o644); err != nil {
 		t.Fatalf("write shared config.toml: %v", err)
 	}
@@ -2109,6 +2110,7 @@ func TestPrepareCodexHomeReportsMissingModelCatalogPath(t *testing.T) {
 	// Cannot use t.Parallel() with t.Setenv.
 
 	sharedHome := t.TempDir()
+	t.Setenv("OPENAI_API_KEY", "test-key")
 	if err := os.WriteFile(filepath.Join(sharedHome, "config.toml"), []byte(`model_catalog_json = "missing-catalog.json"`), 0o644); err != nil {
 		t.Fatalf("write shared config.toml: %v", err)
 	}
@@ -2135,6 +2137,7 @@ func TestPrepareCodexHomeStripsSkillsConfigEntries(t *testing.T) {
 	// Cannot use t.Parallel() with t.Setenv.
 
 	sharedHome := t.TempDir()
+	t.Setenv("OPENAI_API_KEY", "test-key")
 	sharedConfig := `model = "o3"
 
 [[skills.config]]
@@ -2182,6 +2185,7 @@ func TestPrepareCodexHomeSkipsMissingFiles(t *testing.T) {
 
 	// Empty shared home — no files to seed.
 	sharedHome := t.TempDir()
+	t.Setenv("OPENAI_API_KEY", "test-key")
 	t.Setenv("CODEX_HOME", sharedHome)
 
 	codexHome := filepath.Join(t.TempDir(), "codex-home")
@@ -2287,6 +2291,7 @@ func TestPrepareCodexHome_RefreshesStaleCopiedConfigOnReuse(t *testing.T) {
 	// Cannot use t.Parallel() with t.Setenv.
 
 	sharedHome := t.TempDir()
+	t.Setenv("OPENAI_API_KEY", "test-key")
 	oldConfig := `model_provider = "old-provider"
 
 [model_providers.old-provider]
@@ -2394,6 +2399,7 @@ func TestPrepareCodexHome_DropsCopiedConfigWhenSharedSourceRemoved(t *testing.T)
 	// Cannot use t.Parallel() with t.Setenv.
 
 	sharedHome := t.TempDir()
+	t.Setenv("OPENAI_API_KEY", "test-key")
 	oldConfig := `model_provider = "old-provider"
 
 [model_providers.old-provider]
@@ -2745,6 +2751,7 @@ func TestPrepareCodexHomeEnsuresNetworkAccess(t *testing.T) {
 
 	// Empty shared home — no config.toml to copy.
 	sharedHome := t.TempDir()
+	t.Setenv("OPENAI_API_KEY", "test-key")
 	t.Setenv("CODEX_HOME", sharedHome)
 
 	codexHome := filepath.Join(t.TempDir(), "codex-home")
@@ -2771,6 +2778,7 @@ func TestReuseRestoresCodexHome(t *testing.T) {
 	// Cannot use t.Parallel() with t.Setenv.
 
 	sharedHome := t.TempDir()
+	t.Setenv("OPENAI_API_KEY", "test-key")
 	t.Setenv("CODEX_HOME", sharedHome)
 
 	workspacesRoot := t.TempDir()
@@ -2814,6 +2822,7 @@ func TestReuseRestoresCodexHome(t *testing.T) {
 }
 
 func TestReuseRestoresCodexPluginCache(t *testing.T) {
+	t.Setenv("OPENAI_API_KEY", "test-key")
 	// Cannot use t.Parallel() with t.Setenv.
 
 	sharedHome := t.TempDir()
@@ -2859,6 +2868,7 @@ func TestReuseRestoresCodexPluginCache(t *testing.T) {
 }
 
 func TestReuseWritesMissingCodexWorkspaceSkills(t *testing.T) {
+	t.Setenv("OPENAI_API_KEY", "test-key")
 	// Cannot use t.Parallel() with t.Setenv.
 
 	sharedHome := t.TempDir()
@@ -2913,6 +2923,7 @@ func TestReuseWritesMissingCodexWorkspaceSkills(t *testing.T) {
 }
 
 func TestReuseUpdatesCodexWorkspaceSkills(t *testing.T) {
+	t.Setenv("OPENAI_API_KEY", "test-key")
 	// Cannot use t.Parallel() with t.Setenv.
 
 	sharedHome := t.TempDir()
@@ -2976,6 +2987,7 @@ func TestReuseUpdatesCodexWorkspaceSkills(t *testing.T) {
 // inside a Multica task, despite the daemon redirecting CODEX_HOME to a
 // per-task directory.
 func TestPrepareCodexSeedsUserSkills(t *testing.T) {
+	t.Setenv("OPENAI_API_KEY", "test-key")
 	// Cannot use t.Parallel() with t.Setenv.
 
 	sharedHome := t.TempDir()
@@ -3041,6 +3053,7 @@ func TestPrepareCodexSeedsUserSkills(t *testing.T) {
 // skill, the workspace version fully replaces the user version (rather than
 // leaving stale user files lingering).
 func TestPrepareCodexWorkspaceSkillBeatsUserSkillOnConflict(t *testing.T) {
+	t.Setenv("OPENAI_API_KEY", "test-key")
 	// Cannot use t.Parallel() with t.Setenv.
 
 	sharedHome := t.TempDir()
@@ -3093,6 +3106,7 @@ func TestPrepareCodexWorkspaceSkillBeatsUserSkillOnConflict(t *testing.T) {
 // when ~/.codex/skills doesn't exist, the seed step is a no-op and Prepare
 // still succeeds.
 func TestPrepareCodexNoUserSkillsDir(t *testing.T) {
+	t.Setenv("OPENAI_API_KEY", "test-key")
 	// Cannot use t.Parallel() with t.Setenv.
 
 	sharedHome := t.TempDir()
@@ -3120,6 +3134,7 @@ func TestPrepareCodexNoUserSkillsDir(t *testing.T) {
 // installer directory. The per-task home must end up with a real copy, not
 // a dangling symlink that points outside the task root.
 func TestPrepareCodexResolvesUserSkillSymlinks(t *testing.T) {
+	t.Setenv("OPENAI_API_KEY", "test-key")
 	if runtime.GOOS == "windows" {
 		t.Skip("symlink semantics differ on Windows; covered by Unix path")
 	}
@@ -3177,6 +3192,7 @@ func TestPrepareCodexResolvesUserSkillSymlinks(t *testing.T) {
 // TestReuseSeedsUserSkillUpdates ensures that user-skill edits between two
 // runs of the same task (the Reuse path) propagate into the per-task home.
 func TestReuseSeedsUserSkillUpdates(t *testing.T) {
+	t.Setenv("OPENAI_API_KEY", "test-key")
 	// Cannot use t.Parallel() with t.Setenv.
 
 	sharedHome := t.TempDir()
@@ -3229,6 +3245,7 @@ func TestReuseSeedsUserSkillUpdates(t *testing.T) {
 // with a workspace skill `Writing`, the user-version support files must not
 // linger under the workspace skill's directory.
 func TestReuseClearsUserSkillResidueOnWorkspaceConflict(t *testing.T) {
+	t.Setenv("OPENAI_API_KEY", "test-key")
 	// Cannot use t.Parallel() with t.Setenv.
 
 	sharedHome := t.TempDir()
@@ -3290,6 +3307,7 @@ func TestReuseClearsUserSkillResidueOnWorkspaceConflict(t *testing.T) {
 // per-task home on Reuse — otherwise users would still see deleted skills
 // surface to the codex CLI.
 func TestReuseClearsRemovedUserSkill(t *testing.T) {
+	t.Setenv("OPENAI_API_KEY", "test-key")
 	// Cannot use t.Parallel() with t.Setenv.
 
 	sharedHome := t.TempDir()


### PR DESCRIPTION
Closes KAP-892

## Summary
- treat CODEX_HOME under a daemon-marked workspaces root as managed, not a durable shared anchor
- self-heal deleted/dangling managed homes to stable ~/.codex
- fail preparation when managed file-auth drift has no readable auth source
- preserve stable custom CODEX_HOME, OPENAI_API_KEY, and configured provider env_key modes

## Tests
- go test ./internal/daemon/execenv -count=1
- go test ./internal/daemon -count=1
- GOOS=windows GOARCH=amd64 go test -c ./internal/daemon/execenv -o /tmp/execenv-windows.test.exe