### PR TITLE
KAP-672: close active env root GC race

### DIFF
--- a/server/internal/daemon/daemon.go
+++ b/server/internal/daemon/daemon.go
@@ -4200,8 +4200,10 @@ func (d *Daemon) runTask(ctx context.Context, task Task, provider string, slot i
 		return TaskResult{}, ctx.Err()
 	}
 	defer releasePredicted()
+	var priorRootIdentity os.FileInfo
 	if task.PriorWorkDir != "" {
 		priorRoot := filepath.Dir(task.PriorWorkDir)
+		priorRootIdentity, _ = os.Stat(priorRoot)
 		if priorRoot != predictedRoot {
 			releasePrior, ok := d.markActiveEnvRoot(ctx, priorRoot)
 			if !ok {
@@ -4213,6 +4215,7 @@ func (d *Daemon) runTask(ctx context.Context, task Task, provider string, slot i
 
 	// Try to reuse the workdir from a previous task on the same (agent, issue) pair.
 	var env *execenv.Environment
+	envWasReused := false
 	// For a built-in codex task, use the version paired with the resolved path
 	// so an in-place upgrade can't leave the sandbox policy on the old version
 	// (MUL-4486). A custom codex runtime skips the self-heal, so resolvedVersion
@@ -4326,12 +4329,36 @@ func (d *Daemon) runTask(ctx context.Context, task Task, provider string, slot i
 	if task.PriorWorkDir != "" && d.envRootPreOpenHook != nil {
 		d.envRootPreOpenHook(filepath.Dir(task.PriorWorkDir))
 	}
-	// Prior-workdir reuse is fail-closed until execenv.Reuse accepts a pinned
-	// object/handle. A pathname check followed by pathname-based mutation cannot
-	// atomically prove that it is still operating on the leased filesystem
-	// object, so always Prepare a fresh environment.
-	if task.PriorWorkDir != "" {
-		taskLog.Info("prior workdir reuse disabled: object-bound reuse unavailable")
+	priorIdentityMatches := false
+	if priorRootIdentity != nil {
+		currentPrior, statErr := os.Stat(filepath.Dir(task.PriorWorkDir))
+		priorIdentityMatches = statErr == nil && os.SameFile(priorRootIdentity, currentPrior)
+	}
+	if priorIdentityMatches &&
+		canonicalPathIdentity(d.cfg.WorkspacesRoot) == d.workspacesRootIdentity &&
+		shouldReusePriorWorkdir(task, localAssignment, d.cfg.WorkspacesRoot) {
+		var err error
+		env, err = d.reuseExecutionEnvironment(prepareCtx, execenv.ReuseParams{
+			WorkspacesRoot:        d.cfg.WorkspacesRoot,
+			Profile:               d.cfg.Profile,
+			WorkDir:               task.PriorWorkDir,
+			Provider:              provider,
+			CodexVersion:          codexVersion,
+			ResumeSessionID:       task.PriorSessionID,
+			OpenclawBin:           openclawBin,
+			McpConfig:             effectiveMcpConfig,
+			CursorMcpAuthSource:   cursorMcpAuthSource,
+			OpenclawGateway:       openclawGateway,
+			HermesSourceHome:      hermesSourceHome,
+			HermesSourceMustExist: hermesSourceMustExist,
+			HermesEnv:             hermesEnv,
+			CodexCustomArgs:       codexSandboxArgs,
+			Task:                  taskCtx,
+		})
+		if err != nil {
+			return TaskResult{}, fmt.Errorf("reuse execution environment: %w", err)
+		}
+		envWasReused = env != nil
 	}
 	if env == nil {
 		var err error
@@ -4400,9 +4427,7 @@ func (d *Daemon) runTask(ctx context.Context, task Task, provider string, slot i
 	cancelPrepare()
 	_ = d.client.ReportProgress(ctx, task.ID, fmt.Sprintf("Launching %s", provider), 1, 2)
 
-	// Pathname-based reuse is disabled above, so a matching workdir string is
-	// not proof of reuse (fresh Prepare may return the same stable path).
-	reused := gateResumeToReusedWorkdir(&task, &taskCtx, env.WorkDir, false, taskLog)
+	reused := gateResumeToReusedWorkdir(&task, &taskCtx, env.WorkDir, envWasReused, taskLog)
 	// A reused workdir is necessary but not sufficient for a Codex resume: the
 	// prior thread's rollout must actually be present in this task's CODEX_HOME
 	// sessions (MUL-4424 isolates them). Drop the resume before the brief is
@@ -5494,7 +5519,7 @@ func (d *Daemon) markActiveEnvRoot(ctx context.Context, envRoot string) (release
 	if envRoot == "" {
 		return func() {}, true
 	}
-	key := envRootGuardKey(envRoot, nil)
+	key := canonicalPathIdentity(envRoot)
 	d.activeEnvRootsMu.Lock()
 	d.ensureActiveEnvRootStateLocked()
 	if d.workspacesRootIdentity == "" && len(d.activeEnvRoots) == 0 && len(d.deletingEnvRoots) == 0 {
@@ -5530,7 +5555,7 @@ func (d *Daemon) markActiveEnvRoot(ctx context.Context, envRoot string) (release
 }
 
 func (d *Daemon) isActiveEnvRoot(envRoot string) bool {
-	key := envRootGuardKey(envRoot, nil)
+	key := canonicalPathIdentity(envRoot)
 	d.activeEnvRootsMu.Lock()
 	defer d.activeEnvRootsMu.Unlock()
 	d.ensureActiveEnvRootStateLocked()
@@ -5585,17 +5610,6 @@ type envRootGCLease struct {
 	expected os.FileInfo
 }
 
-func envRootGuardKey(path string, known os.FileInfo) string {
-	info := known
-	if info == nil {
-		info, _ = os.Stat(path)
-	}
-	if info != nil {
-		return fmt.Sprintf("file:%T:%v", info.Sys(), info.Sys())
-	}
-	return "path:" + canonicalPathIdentity(path)
-}
-
 // reserveEnvRootForGC atomically confirms that no live task is using envRoot
 // and prevents a new task from entering until release runs. This closes the
 // check-then-remove race between the GC loop and task startup: either GC sees
@@ -5630,7 +5644,11 @@ func (d *Daemon) reserveEnvRootForGCIdentity(envRoot string) (envRootGCLease, bo
 	if d.gcAfterExpectedHook != nil {
 		d.gcAfterExpectedHook(envRoot)
 	}
-	key := envRootGuardKey(envRoot, expected)
+	// Lease identity is the canonical logical task-root path, not mutable stat
+	// data. It is therefore identical before/after mkdir and content changes.
+	// The pinned os.Root + expected SameFile checks bind mutations to the
+	// discovered filesystem object.
+	key := canonicalPathIdentity(envRoot)
 	d.activeEnvRootsMu.Lock()
 	defer d.activeEnvRootsMu.Unlock()
 	d.ensureActiveEnvRootStateLocked()

--- a/server/internal/daemon/daemon.go
+++ b/server/internal/daemon/daemon.go
@@ -4388,14 +4388,25 @@ func (d *Daemon) runTask(ctx context.Context, task Task, provider string, slot i
 			return TaskResult{}, fmt.Errorf("prepare execution environment: %w", err)
 		}
 	}
-	// Belt-and-suspenders: also mark whatever root we ended up with, in case
-	// future changes diverge from PredictRootDir.
-	if env.RootDir != predictedRoot && env.RootDir != "" {
+	// Acquire a second lease after Prepare/Reuse even when the pathname equals
+	// predictedRoot. The pre-Prepare lease protects the immutable logical name;
+	// this post-Prepare lease adds the created object's canonical alias key.
+	// Together they close a symlink-ancestor retarget between prediction and
+	// mkdir, while still covering future divergence from PredictRootDir.
+	if env.RootDir != "" {
+		preparedIdentity, identityErr := d.statEnvRootThroughPinnedWorkspace(env.RootDir)
+		if identityErr != nil {
+			return TaskResult{}, fmt.Errorf("prove prepared env root identity: %w", identityErr)
+		}
 		releaseActual, ok := d.markActiveEnvRoot(ctx, env.RootDir)
 		if !ok {
 			return TaskResult{}, ctx.Err()
 		}
 		defer releaseActual()
+		currentIdentity, identityErr := d.statEnvRootThroughPinnedWorkspace(env.RootDir)
+		if identityErr != nil || !os.SameFile(preparedIdentity, currentIdentity) {
+			return TaskResult{}, fmt.Errorf("prepared env root identity changed while acquiring lease")
+		}
 	}
 	taskTempDir, err := ensureTaskTempDir(env.RootDir, task.WorkspaceID, task.ID)
 	if err != nil {
@@ -5519,13 +5530,13 @@ func (d *Daemon) markActiveEnvRoot(ctx context.Context, envRoot string) (release
 	if envRoot == "" {
 		return func() {}, true
 	}
-	key := canonicalPathIdentity(envRoot)
+	keys := envRootLeaseKeys(envRoot)
 	d.activeEnvRootsMu.Lock()
 	d.ensureActiveEnvRootStateLocked()
 	if d.workspacesRootIdentity == "" && len(d.activeEnvRoots) == 0 && len(d.deletingEnvRoots) == 0 {
 		d.workspacesRootIdentity = canonicalPathIdentity(d.cfg.WorkspacesRoot)
 	}
-	for d.deletingEnvRoots[key] {
+	for anyEnvRootKeySet(d.deletingEnvRoots, keys) {
 		if d.activeEnvRootWaitHook != nil {
 			d.activeEnvRootWaitHook(envRoot)
 		}
@@ -5538,28 +5549,32 @@ func (d *Daemon) markActiveEnvRoot(ctx context.Context, envRoot string) (release
 		}
 		d.activeEnvRootsMu.Lock()
 	}
-	d.activeEnvRoots[key]++
+	for _, key := range keys {
+		d.activeEnvRoots[key]++
+	}
 	d.activeEnvRootsMu.Unlock()
 	var once sync.Once
 	return func() {
 		once.Do(func() {
 			d.activeEnvRootsMu.Lock()
 			defer d.activeEnvRootsMu.Unlock()
-			if d.activeEnvRoots[key] <= 1 {
-				delete(d.activeEnvRoots, key)
-				return
+			for _, key := range keys {
+				if d.activeEnvRoots[key] <= 1 {
+					delete(d.activeEnvRoots, key)
+					continue
+				}
+				d.activeEnvRoots[key]--
 			}
-			d.activeEnvRoots[key]--
 		})
 	}, true
 }
 
 func (d *Daemon) isActiveEnvRoot(envRoot string) bool {
-	key := canonicalPathIdentity(envRoot)
+	keys := envRootLeaseKeys(envRoot)
 	d.activeEnvRootsMu.Lock()
 	defer d.activeEnvRootsMu.Unlock()
 	d.ensureActiveEnvRootStateLocked()
-	return d.activeEnvRoots[key] > 0
+	return anyEnvRootKeyCounted(d.activeEnvRoots, keys)
 }
 
 func (d *Daemon) ensureActiveEnvRootStateLocked() {
@@ -5605,6 +5620,70 @@ func canonicalPathIdentity(path string) string {
 	}
 }
 
+// envRootLeaseKeys binds both names that must contend:
+//   - logical: the immutable configured pathname, stable across mkdir and
+//     symlink-ancestor retargeting;
+//   - object: the current canonical target, so a real path and symlink alias
+//     to the same object cannot bypass each other.
+//
+// Neither key contains mutable stat fields. Holding both closes the gap where
+// choosing only a logical key misses aliases, while choosing only a resolved
+// key changes after retarget.
+func envRootLeaseKeys(path string) []string {
+	logical := filepath.Clean(path)
+	if abs, err := filepath.Abs(path); err == nil {
+		logical = filepath.Clean(abs)
+	}
+	if runtime.GOOS == "darwin" || runtime.GOOS == "windows" {
+		logical = strings.ToLower(logical)
+	}
+	logical = "logical:" + logical
+	object := "object:" + canonicalPathIdentity(path)
+	return []string{logical, object}
+}
+
+func anyEnvRootKeySet(values map[string]bool, keys []string) bool {
+	for _, key := range keys {
+		if values[key] {
+			return true
+		}
+	}
+	return false
+}
+
+func anyEnvRootKeyCounted(values map[string]int, keys []string) bool {
+	for _, key := range keys {
+		if values[key] > 0 {
+			return true
+		}
+	}
+	return false
+}
+
+func (d *Daemon) statEnvRootThroughPinnedWorkspace(envRoot string) (os.FileInfo, error) {
+	rel, err := filepath.Rel(d.cfg.WorkspacesRoot, envRoot)
+	if err != nil || !isContainedRelativePath(rel) {
+		return nil, fmt.Errorf("env root is outside workspaces root")
+	}
+	root, err := os.OpenRoot(d.cfg.WorkspacesRoot)
+	if err != nil {
+		return nil, err
+	}
+	defer root.Close()
+	info, err := root.Stat(rel)
+	if err != nil {
+		return nil, err
+	}
+	if !info.IsDir() {
+		return nil, fmt.Errorf("env root is not a directory")
+	}
+	pathInfo, err := os.Stat(envRoot)
+	if err != nil || !os.SameFile(info, pathInfo) {
+		return nil, fmt.Errorf("env root pathname does not match pinned object")
+	}
+	return info, nil
+}
+
 type envRootGCLease struct {
 	release  func()
 	expected os.FileInfo
@@ -5644,24 +5723,24 @@ func (d *Daemon) reserveEnvRootForGCIdentity(envRoot string) (envRootGCLease, bo
 	if d.gcAfterExpectedHook != nil {
 		d.gcAfterExpectedHook(envRoot)
 	}
-	// Lease identity is the canonical logical task-root path, not mutable stat
-	// data. It is therefore identical before/after mkdir and content changes.
-	// The pinned os.Root + expected SameFile checks bind mutations to the
-	// discovered filesystem object.
-	key := canonicalPathIdentity(envRoot)
+	keys := envRootLeaseKeys(envRoot)
 	d.activeEnvRootsMu.Lock()
 	defer d.activeEnvRootsMu.Unlock()
 	d.ensureActiveEnvRootStateLocked()
-	if d.activeEnvRoots[key] > 0 || d.deletingEnvRoots[key] {
+	if anyEnvRootKeyCounted(d.activeEnvRoots, keys) || anyEnvRootKeySet(d.deletingEnvRoots, keys) {
 		return envRootGCLease{}, false
 	}
-	d.deletingEnvRoots[key] = true
+	for _, key := range keys {
+		d.deletingEnvRoots[key] = true
+	}
 	if d.gcAfterReserveHook != nil {
 		d.gcAfterReserveHook(envRoot)
 	}
 	release := func() {
 		d.activeEnvRootsMu.Lock()
-		delete(d.deletingEnvRoots, key)
+		for _, key := range keys {
+			delete(d.deletingEnvRoots, key)
+		}
 		close(d.activeEnvRootsChanged)
 		d.activeEnvRootsChanged = make(chan struct{})
 		d.activeEnvRootsMu.Unlock()

--- a/server/internal/daemon/daemon.go
+++ b/server/internal/daemon/daemon.go
@@ -324,6 +324,10 @@ type Daemon struct {
 	activeEnvRootsCond *sync.Cond      // signalled when an in-flight env-root GC mutation finishes
 	activeEnvRoots     map[string]int  // env root path -> reference count (handles reuse paths marked twice)
 	deletingEnvRoots   map[string]bool // env roots reserved by GC; new tasks wait until the mutation finishes
+	// Test hooks for deterministic GC failure/race coverage. Nil in production.
+	activeEnvRootWaitHook func(string)
+	renameEnvRootHook     func(string, string) error
+	removeEnvRootHook     func(string) error
 
 	activeCodexStoresMu   sync.Mutex
 	activeCodexStoresCond *sync.Cond      // signalled when an in-flight store deletion finishes, so a blocked markActive can proceed
@@ -5468,6 +5472,9 @@ func (d *Daemon) markActiveEnvRoot(envRoot string) {
 	defer d.activeEnvRootsMu.Unlock()
 	d.ensureActiveEnvRootStateLocked()
 	for d.deletingEnvRoots[envRoot] {
+		if d.activeEnvRootWaitHook != nil {
+			d.activeEnvRootWaitHook(envRoot)
+		}
 		d.activeEnvRootsCond.Wait()
 	}
 	d.activeEnvRoots[envRoot]++

--- a/server/internal/daemon/daemon.go
+++ b/server/internal/daemon/daemon.go
@@ -320,15 +320,17 @@ type Daemon struct {
 	pauseClaims    bool // when true, the batch poller skips claiming
 	claimsInFlight int  // pollers that have decided to claim but haven't yet handed the task off to handleTask
 
-	activeEnvRootsMu      sync.Mutex
-	activeEnvRootsChanged chan struct{}   // closed and replaced when an in-flight env-root GC mutation finishes
-	activeEnvRoots        map[string]int  // env root path -> reference count (handles reuse paths marked twice)
-	deletingEnvRoots      map[string]bool // env roots reserved by GC; new tasks wait until the mutation finishes
+	activeEnvRootsMu       sync.Mutex
+	workspacesRootIdentity string
+	activeEnvRootsChanged  chan struct{}   // closed and replaced when an in-flight env-root GC mutation finishes
+	activeEnvRoots         map[string]int  // env root path -> reference count (handles reuse paths marked twice)
+	deletingEnvRoots       map[string]bool // env roots reserved by GC; new tasks wait until the mutation finishes
 	// Test hooks for deterministic GC failure/race coverage. Nil in production.
 	activeEnvRootWaitHook func(string)
 	renameEnvRootHook     func(string, string) error
 	removeEnvRootHook     func(string) error
 	envRootQuarantineHook func(string) // test-only: runs after WorkspacesRoot is opened, before rename
+	envRootPreOpenHook    func(string) // test-only: runs after reservation, before a filesystem root is opened
 	artifactCleanupHook   func(string) // test-only: runs while the artifact-cleanup reservation is held
 	artifactRemoveHook    func(string) // test-only: runs after artifact inspection, before fd-relative removal
 
@@ -3254,43 +3256,11 @@ func (d *Daemon) handleTask(ctx context.Context, task Task, slot int) {
 		defer localRelease()
 	}
 
-	// Hold a process-wide active-root guard for the rest of this task so
-	// the GC loop never sees a window where the env root has neither the
-	// in-process guard nor .gc_meta.json (issue #3999 race B). runTask
-	// installs its own ref-counted mark/unmark internally; without this
-	// outer guard the inner unmark fires when runTask returns, leaving
-	// the directory protected only by the 72h orphan TTL through
-	// reportTaskResult and execenv.WriteGCMeta below. markActiveEnvRoot
-	// is reference-counted, so the duplicate marks runTask installs are
-	// correctly nested within these.
-	predictedEnvRoot := execenv.PredictRootDir(d.cfg.WorkspacesRoot, task.WorkspaceID, task.ID)
-	if predictedEnvRoot != "" {
-		release, ok := d.markActiveEnvRoot(ctx, predictedEnvRoot)
-		if !ok {
-			return
-		}
-		defer release()
-	}
-	if task.PriorWorkDir != "" {
-		if priorRoot := filepath.Dir(task.PriorWorkDir); priorRoot != "" && priorRoot != predictedEnvRoot {
-			release, ok := d.markActiveEnvRoot(ctx, priorRoot)
-			if !ok {
-				return
-			}
-			defer release()
-		}
-	}
-
-	// Create a cancellable context so we can interrupt the running agent
-	// when the server signals the task should stop — either the task reached
-	// a terminal state (completed/failed/cancelled) or the task row is
-	// deleted (404).
+	// Start server-side cancellation polling before any potentially blocking
+	// env-root claim so a cancelled/deleted task can release its slot even when
+	// GC is stalled in a same-root filesystem mutation.
 	runCtx, runCancel := context.WithCancel(ctx)
 	defer runCancel()
-
-	// Poll interval is d.cancelPollInterval (5s in production, reduced in tests
-	// via direct field override). Guard against zero so a misconfigured daemon
-	// doesn't panic time.NewTicker.
 	pollInterval := d.cancelPollInterval
 	if pollInterval == 0 {
 		pollInterval = 5 * time.Second
@@ -3303,6 +3273,33 @@ func (d *Daemon) handleTask(ctx context.Context, task Task, slot int) {
 		case <-runCtx.Done():
 		}
 	}()
+
+	// Hold a process-wide active-root guard for the rest of this task so
+	// the GC loop never sees a window where the env root has neither the
+	// in-process guard nor .gc_meta.json (issue #3999 race B). runTask
+	// installs its own ref-counted mark/unmark internally; without this
+	// outer guard the inner unmark fires when runTask returns, leaving
+	// the directory protected only by the 72h orphan TTL through
+	// reportTaskResult and execenv.WriteGCMeta below. markActiveEnvRoot
+	// is reference-counted, so the duplicate marks runTask installs are
+	// correctly nested within these.
+	predictedEnvRoot := execenv.PredictRootDir(d.cfg.WorkspacesRoot, task.WorkspaceID, task.ID)
+	if predictedEnvRoot != "" {
+		release, ok := d.markActiveEnvRoot(runCtx, predictedEnvRoot)
+		if !ok {
+			return
+		}
+		defer release()
+	}
+	if task.PriorWorkDir != "" {
+		if priorRoot := filepath.Dir(task.PriorWorkDir); priorRoot != "" && priorRoot != predictedEnvRoot {
+			release, ok := d.markActiveEnvRoot(runCtx, priorRoot)
+			if !ok {
+				return
+			}
+			defer release()
+		}
+	}
 
 	result, err := d.runner.run(runCtx, task, provider, slot, taskLog)
 
@@ -3761,16 +3758,28 @@ func shouldReusePriorWorkdir(task Task, localAssignment *localDirectoryAssignmen
 	if task.PriorWorkDir == "" || localAssignment != nil {
 		return false
 	}
+	rawRoot, rootAbsErr := filepath.Abs(workspacesRoot)
+	rawWorkdir, workdirAbsErr := filepath.Abs(task.PriorWorkDir)
+	if rootAbsErr != nil || workdirAbsErr != nil {
+		return false
+	}
+	rawRel, err := filepath.Rel(rawRoot, rawWorkdir)
+	if err != nil || !filepath.IsLocal(rawRel) {
+		return false
+	}
 	if !task.IsLeaderTask {
 		return true
 	}
-
 	root, err := filepath.EvalSymlinks(workspacesRoot)
 	if err != nil {
 		return false
 	}
 	workdir, err := filepath.EvalSymlinks(task.PriorWorkDir)
 	if err != nil {
+		return false
+	}
+	resolvedRel, err := filepath.Rel(root, workdir)
+	if err != nil || !filepath.IsLocal(resolvedRel) || filepath.Clean(rawRel) != filepath.Clean(resolvedRel) {
 		return false
 	}
 	info, err := os.Stat(workdir)
@@ -4309,7 +4318,11 @@ func (d *Daemon) runTask(ctx context.Context, task Task, provider string, slot i
 			defer d.unmarkActiveCodexStore(store)
 		}
 	}
-	if shouldReusePriorWorkdir(task, localAssignment, d.cfg.WorkspacesRoot) {
+	if task.PriorWorkDir != "" && d.envRootPreOpenHook != nil {
+		d.envRootPreOpenHook(filepath.Dir(task.PriorWorkDir))
+	}
+	if canonicalPathIdentity(d.cfg.WorkspacesRoot) == d.workspacesRootIdentity &&
+		shouldReusePriorWorkdir(task, localAssignment, d.cfg.WorkspacesRoot) {
 		var err error
 		env, err = d.reuseExecutionEnvironment(prepareCtx, execenv.ReuseParams{
 			WorkspacesRoot:        d.cfg.WorkspacesRoot,
@@ -5494,6 +5507,9 @@ func (d *Daemon) markActiveEnvRoot(ctx context.Context, envRoot string) (release
 	key := canonicalPathIdentity(envRoot)
 	d.activeEnvRootsMu.Lock()
 	d.ensureActiveEnvRootStateLocked()
+	if d.workspacesRootIdentity == "" && len(d.activeEnvRoots) == 0 && len(d.deletingEnvRoots) == 0 {
+		d.workspacesRootIdentity = canonicalPathIdentity(d.cfg.WorkspacesRoot)
+	}
 	for d.deletingEnvRoots[key] {
 		if d.activeEnvRootWaitHook != nil {
 			d.activeEnvRootWaitHook(envRoot)
@@ -5559,7 +5575,11 @@ func canonicalPathIdentity(path string) string {
 			for i := len(suffix) - 1; i >= 0; i-- {
 				resolved = filepath.Join(resolved, suffix[i])
 			}
-			return filepath.Clean(resolved)
+			resolved = filepath.Clean(resolved)
+			if runtime.GOOS == "darwin" || runtime.GOOS == "windows" {
+				resolved = strings.ToLower(resolved)
+			}
+			return resolved
 		}
 		parent := filepath.Dir(current)
 		if parent == current {
@@ -5570,30 +5590,48 @@ func canonicalPathIdentity(path string) string {
 	}
 }
 
+type envRootGCLease struct {
+	release  func()
+	expected os.FileInfo
+}
+
 // reserveEnvRootForGC atomically confirms that no live task is using envRoot
 // and prevents a new task from entering until release runs. This closes the
 // check-then-remove race between the GC loop and task startup: either GC sees
 // the active task and skips, or task startup waits for the mutation to finish
 // and recreates/uses the post-GC environment.
 func (d *Daemon) reserveEnvRootForGC(envRoot string) (release func(), ok bool) {
-	if envRoot == "" {
+	lease, ok := d.reserveEnvRootForGCIdentity(envRoot)
+	if !ok {
 		return nil, false
+	}
+	return lease.release, true
+}
+
+func (d *Daemon) reserveEnvRootForGCIdentity(envRoot string) (envRootGCLease, bool) {
+	if envRoot == "" {
+		return envRootGCLease{}, false
+	}
+	expected, err := os.Stat(envRoot)
+	if err != nil || !expected.IsDir() {
+		return envRootGCLease{}, false
 	}
 	key := canonicalPathIdentity(envRoot)
 	d.activeEnvRootsMu.Lock()
 	defer d.activeEnvRootsMu.Unlock()
 	d.ensureActiveEnvRootStateLocked()
 	if d.activeEnvRoots[key] > 0 || d.deletingEnvRoots[key] {
-		return nil, false
+		return envRootGCLease{}, false
 	}
 	d.deletingEnvRoots[key] = true
-	return func() {
+	release := func() {
 		d.activeEnvRootsMu.Lock()
 		delete(d.deletingEnvRoots, key)
 		close(d.activeEnvRootsChanged)
 		d.activeEnvRootsChanged = make(chan struct{})
 		d.activeEnvRootsMu.Unlock()
-	}, true
+	}
+	return envRootGCLease{release: release, expected: expected}, true
 }
 
 // markActiveCodexStore records that a task is about to use the given per-issue

--- a/server/internal/daemon/daemon.go
+++ b/server/internal/daemon/daemon.go
@@ -332,6 +332,8 @@ type Daemon struct {
 	envRootQuarantineHook func(string) // test-only: runs after WorkspacesRoot is opened, before rename
 	envRootPreOpenHook    func(string) // test-only: runs after reservation, before a filesystem root is opened
 	gcBeforeApplyHook     func(string) // test-only: runs after decision, before reservation
+	gcAfterExpectedHook   func(string) // test-only: runs after pinned identity read, before key creation
+	gcAfterReserveHook    func(string) // test-only: runs after reservation, before mutation
 	gcCycleRoot           *os.Root     // pinned for the synchronous runGC cycle
 	artifactCleanupHook   func(string) // test-only: runs while the artifact-cleanup reservation is held
 	artifactRemoveHook    func(string) // test-only: runs after artifact inspection, before fd-relative removal
@@ -4197,10 +4199,8 @@ func (d *Daemon) runTask(ctx context.Context, task Task, provider string, slot i
 		return TaskResult{}, ctx.Err()
 	}
 	defer releasePredicted()
-	var priorRootIdentity os.FileInfo
 	if task.PriorWorkDir != "" {
 		priorRoot := filepath.Dir(task.PriorWorkDir)
-		priorRootIdentity, _ = os.Stat(priorRoot)
 		if priorRoot != predictedRoot {
 			releasePrior, ok := d.markActiveEnvRoot(ctx, priorRoot)
 			if !ok {
@@ -4325,35 +4325,12 @@ func (d *Daemon) runTask(ctx context.Context, task Task, provider string, slot i
 	if task.PriorWorkDir != "" && d.envRootPreOpenHook != nil {
 		d.envRootPreOpenHook(filepath.Dir(task.PriorWorkDir))
 	}
-	priorIdentityMatches := false
-	if priorRootIdentity != nil {
-		currentPrior, statErr := os.Stat(filepath.Dir(task.PriorWorkDir))
-		priorIdentityMatches = statErr == nil && os.SameFile(priorRootIdentity, currentPrior)
-	}
-	if priorIdentityMatches &&
-		canonicalPathIdentity(d.cfg.WorkspacesRoot) == d.workspacesRootIdentity &&
-		shouldReusePriorWorkdir(task, localAssignment, d.cfg.WorkspacesRoot) {
-		var err error
-		env, err = d.reuseExecutionEnvironment(prepareCtx, execenv.ReuseParams{
-			WorkspacesRoot:        d.cfg.WorkspacesRoot,
-			Profile:               d.cfg.Profile,
-			WorkDir:               task.PriorWorkDir,
-			Provider:              provider,
-			CodexVersion:          codexVersion,
-			ResumeSessionID:       task.PriorSessionID,
-			OpenclawBin:           openclawBin,
-			McpConfig:             effectiveMcpConfig,
-			CursorMcpAuthSource:   cursorMcpAuthSource,
-			OpenclawGateway:       openclawGateway,
-			HermesSourceHome:      hermesSourceHome,
-			HermesSourceMustExist: hermesSourceMustExist,
-			HermesEnv:             hermesEnv,
-			CodexCustomArgs:       codexSandboxArgs,
-			Task:                  taskCtx,
-		})
-		if err != nil {
-			return TaskResult{}, fmt.Errorf("reuse execution environment: %w", err)
-		}
+	// Prior-workdir reuse is fail-closed until execenv.Reuse accepts a pinned
+	// object/handle. A pathname check followed by pathname-based mutation cannot
+	// atomically prove that it is still operating on the leased filesystem
+	// object, so always Prepare a fresh environment.
+	if task.PriorWorkDir != "" {
+		taskLog.Info("prior workdir reuse disabled: object-bound reuse unavailable")
 	}
 	if env == nil {
 		var err error
@@ -5514,7 +5491,7 @@ func (d *Daemon) markActiveEnvRoot(ctx context.Context, envRoot string) (release
 	if envRoot == "" {
 		return func() {}, true
 	}
-	key := canonicalPathIdentity(envRoot)
+	key := envRootGuardKey(envRoot, nil)
 	d.activeEnvRootsMu.Lock()
 	d.ensureActiveEnvRootStateLocked()
 	if d.workspacesRootIdentity == "" && len(d.activeEnvRoots) == 0 && len(d.deletingEnvRoots) == 0 {
@@ -5550,7 +5527,7 @@ func (d *Daemon) markActiveEnvRoot(ctx context.Context, envRoot string) (release
 }
 
 func (d *Daemon) isActiveEnvRoot(envRoot string) bool {
-	key := canonicalPathIdentity(envRoot)
+	key := envRootGuardKey(envRoot, nil)
 	d.activeEnvRootsMu.Lock()
 	defer d.activeEnvRootsMu.Unlock()
 	d.ensureActiveEnvRootStateLocked()
@@ -5605,6 +5582,17 @@ type envRootGCLease struct {
 	expected os.FileInfo
 }
 
+func envRootGuardKey(path string, known os.FileInfo) string {
+	info := known
+	if info == nil {
+		info, _ = os.Stat(path)
+	}
+	if info != nil {
+		return fmt.Sprintf("file:%T:%v", info.Sys(), info.Sys())
+	}
+	return "path:" + canonicalPathIdentity(path)
+}
+
 // reserveEnvRootForGC atomically confirms that no live task is using envRoot
 // and prevents a new task from entering until release runs. This closes the
 // check-then-remove race between the GC loop and task startup: either GC sees
@@ -5636,7 +5624,10 @@ func (d *Daemon) reserveEnvRootForGCIdentity(envRoot string) (envRootGCLease, bo
 	if err != nil || !expected.IsDir() {
 		return envRootGCLease{}, false
 	}
-	key := canonicalPathIdentity(envRoot)
+	if d.gcAfterExpectedHook != nil {
+		d.gcAfterExpectedHook(envRoot)
+	}
+	key := envRootGuardKey(envRoot, expected)
 	d.activeEnvRootsMu.Lock()
 	defer d.activeEnvRootsMu.Unlock()
 	d.ensureActiveEnvRootStateLocked()
@@ -5644,6 +5635,9 @@ func (d *Daemon) reserveEnvRootForGCIdentity(envRoot string) (envRootGCLease, bo
 		return envRootGCLease{}, false
 	}
 	d.deletingEnvRoots[key] = true
+	if d.gcAfterReserveHook != nil {
+		d.gcAfterReserveHook(envRoot)
+	}
 	release := func() {
 		d.activeEnvRootsMu.Lock()
 		delete(d.deletingEnvRoots, key)

--- a/server/internal/daemon/daemon.go
+++ b/server/internal/daemon/daemon.go
@@ -328,6 +328,7 @@ type Daemon struct {
 	activeEnvRootWaitHook func(string)
 	renameEnvRootHook     func(string, string) error
 	removeEnvRootHook     func(string) error
+	envRootQuarantineHook func(string) // test-only: runs after WorkspacesRoot is opened, before rename
 	artifactCleanupHook   func(string) // test-only: runs while the artifact-cleanup reservation is held
 	artifactRemoveHook    func(string) // test-only: runs after artifact inspection, before fd-relative removal
 
@@ -3264,17 +3265,19 @@ func (d *Daemon) handleTask(ctx context.Context, task Task, slot int) {
 	// correctly nested within these.
 	predictedEnvRoot := execenv.PredictRootDir(d.cfg.WorkspacesRoot, task.WorkspaceID, task.ID)
 	if predictedEnvRoot != "" {
-		if !d.markActiveEnvRootContext(ctx, predictedEnvRoot) {
+		release, ok := d.markActiveEnvRoot(ctx, predictedEnvRoot)
+		if !ok {
 			return
 		}
-		defer d.unmarkActiveEnvRoot(predictedEnvRoot)
+		defer release()
 	}
 	if task.PriorWorkDir != "" {
 		if priorRoot := filepath.Dir(task.PriorWorkDir); priorRoot != "" && priorRoot != predictedEnvRoot {
-			if !d.markActiveEnvRootContext(ctx, priorRoot) {
+			release, ok := d.markActiveEnvRoot(ctx, priorRoot)
+			if !ok {
 				return
 			}
-			defer d.unmarkActiveEnvRoot(priorRoot)
+			defer release()
 		}
 	}
 
@@ -4178,17 +4181,19 @@ func (d *Daemon) runTask(ctx context.Context, task Task, provider string, slot i
 	// predicted root for a fresh Prepare and the prior root for Reuse — they
 	// usually differ (Reuse keeps the original task's directory).
 	predictedRoot := execenv.PredictRootDir(d.cfg.WorkspacesRoot, task.WorkspaceID, task.ID)
-	if !d.markActiveEnvRootContext(ctx, predictedRoot) {
+	releasePredicted, ok := d.markActiveEnvRoot(ctx, predictedRoot)
+	if !ok {
 		return TaskResult{}, ctx.Err()
 	}
-	defer d.unmarkActiveEnvRoot(predictedRoot)
+	defer releasePredicted()
 	if task.PriorWorkDir != "" {
 		priorRoot := filepath.Dir(task.PriorWorkDir)
 		if priorRoot != predictedRoot {
-			if !d.markActiveEnvRootContext(ctx, priorRoot) {
+			releasePrior, ok := d.markActiveEnvRoot(ctx, priorRoot)
+			if !ok {
 				return TaskResult{}, ctx.Err()
 			}
-			defer d.unmarkActiveEnvRoot(priorRoot)
+			defer releasePrior()
 		}
 	}
 
@@ -4358,10 +4363,11 @@ func (d *Daemon) runTask(ctx context.Context, task Task, provider string, slot i
 	// Belt-and-suspenders: also mark whatever root we ended up with, in case
 	// future changes diverge from PredictRootDir.
 	if env.RootDir != predictedRoot && env.RootDir != "" {
-		if !d.markActiveEnvRootContext(ctx, env.RootDir) {
+		releaseActual, ok := d.markActiveEnvRoot(ctx, env.RootDir)
+		if !ok {
 			return TaskResult{}, ctx.Err()
 		}
-		defer d.unmarkActiveEnvRoot(env.RootDir)
+		defer releaseActual()
 	}
 	taskTempDir, err := ensureTaskTempDir(env.RootDir, task.WorkspaceID, task.ID)
 	if err != nil {
@@ -5475,17 +5481,15 @@ func convertProjectResourcesForEnv(resources []ProjectResourceData) []execenv.Pr
 // markActiveEnvRoot records that a task is currently using the given env root,
 // so the GC loop won't reclaim its artifacts mid-execution. Calls are
 // reference-counted so a reuse path marked twice (predicted + prior) only
-// becomes inactive after both unmark calls.
-func (d *Daemon) markActiveEnvRoot(envRoot string) {
-	d.markActiveEnvRootContext(context.Background(), envRoot)
-}
-
-// markActiveEnvRootContext waits for an in-flight mutation without making task
+// becomes inactive after both leases are released.
+// markActiveEnvRoot waits for an in-flight mutation without making task
 // cancellation depend on filesystem progress. It returns false when ctx is
-// cancelled before the root can be claimed.
-func (d *Daemon) markActiveEnvRootContext(ctx context.Context, envRoot string) bool {
+// cancelled before the root can be claimed. The returned lease closes over the
+// exact canonical key acquired here, so pathname retargeting cannot release a
+// different root.
+func (d *Daemon) markActiveEnvRoot(ctx context.Context, envRoot string) (release func(), ok bool) {
 	if envRoot == "" {
-		return true
+		return func() {}, true
 	}
 	key := canonicalPathIdentity(envRoot)
 	d.activeEnvRootsMu.Lock()
@@ -5498,29 +5502,25 @@ func (d *Daemon) markActiveEnvRootContext(ctx context.Context, envRoot string) b
 		d.activeEnvRootsMu.Unlock()
 		select {
 		case <-ctx.Done():
-			return false
+			return nil, false
 		case <-changed:
 		}
 		d.activeEnvRootsMu.Lock()
 	}
 	d.activeEnvRoots[key]++
 	d.activeEnvRootsMu.Unlock()
-	return true
-}
-
-func (d *Daemon) unmarkActiveEnvRoot(envRoot string) {
-	if envRoot == "" {
-		return
-	}
-	key := canonicalPathIdentity(envRoot)
-	d.activeEnvRootsMu.Lock()
-	defer d.activeEnvRootsMu.Unlock()
-	d.ensureActiveEnvRootStateLocked()
-	if d.activeEnvRoots[key] <= 1 {
-		delete(d.activeEnvRoots, key)
-		return
-	}
-	d.activeEnvRoots[key]--
+	var once sync.Once
+	return func() {
+		once.Do(func() {
+			d.activeEnvRootsMu.Lock()
+			defer d.activeEnvRootsMu.Unlock()
+			if d.activeEnvRoots[key] <= 1 {
+				delete(d.activeEnvRoots, key)
+				return
+			}
+			d.activeEnvRoots[key]--
+		})
+	}, true
 }
 
 func (d *Daemon) isActiveEnvRoot(envRoot string) bool {

--- a/server/internal/daemon/daemon.go
+++ b/server/internal/daemon/daemon.go
@@ -328,6 +328,7 @@ type Daemon struct {
 	activeEnvRootWaitHook func(string)
 	renameEnvRootHook     func(string, string) error
 	removeEnvRootHook     func(string) error
+	artifactCleanupHook   func(string) // test-only: runs while the artifact-cleanup reservation is held
 
 	activeCodexStoresMu   sync.Mutex
 	activeCodexStoresCond *sync.Cond      // signalled when an in-flight store deletion finishes, so a blocked markActive can proceed

--- a/server/internal/daemon/daemon.go
+++ b/server/internal/daemon/daemon.go
@@ -320,15 +320,16 @@ type Daemon struct {
 	pauseClaims    bool // when true, the batch poller skips claiming
 	claimsInFlight int  // pollers that have decided to claim but haven't yet handed the task off to handleTask
 
-	activeEnvRootsMu   sync.Mutex
-	activeEnvRootsCond *sync.Cond      // signalled when an in-flight env-root GC mutation finishes
-	activeEnvRoots     map[string]int  // env root path -> reference count (handles reuse paths marked twice)
-	deletingEnvRoots   map[string]bool // env roots reserved by GC; new tasks wait until the mutation finishes
+	activeEnvRootsMu      sync.Mutex
+	activeEnvRootsChanged chan struct{}   // closed and replaced when an in-flight env-root GC mutation finishes
+	activeEnvRoots        map[string]int  // env root path -> reference count (handles reuse paths marked twice)
+	deletingEnvRoots      map[string]bool // env roots reserved by GC; new tasks wait until the mutation finishes
 	// Test hooks for deterministic GC failure/race coverage. Nil in production.
 	activeEnvRootWaitHook func(string)
 	renameEnvRootHook     func(string, string) error
 	removeEnvRootHook     func(string) error
 	artifactCleanupHook   func(string) // test-only: runs while the artifact-cleanup reservation is held
+	artifactRemoveHook    func(string) // test-only: runs after artifact inspection, before fd-relative removal
 
 	activeCodexStoresMu   sync.Mutex
 	activeCodexStoresCond *sync.Cond      // signalled when an in-flight store deletion finishes, so a blocked markActive can proceed
@@ -405,7 +406,7 @@ func New(cfg Config, logger *slog.Logger) *Daemon {
 		workspaceChanges:          newWorkspaceChangeSignal(),
 		wsRPC:                     newWSRPCClient(wsRPCResponseGrace),
 	}
-	d.activeEnvRootsCond = sync.NewCond(&d.activeEnvRootsMu)
+	d.activeEnvRootsChanged = make(chan struct{})
 	d.activeCodexStoresCond = sync.NewCond(&d.activeCodexStoresMu)
 	d.executionEnvironmentCommand = defaultExecutionEnvironmentCommand
 	d.runner = taskRunnerFunc(d.runTask)
@@ -3263,12 +3264,16 @@ func (d *Daemon) handleTask(ctx context.Context, task Task, slot int) {
 	// correctly nested within these.
 	predictedEnvRoot := execenv.PredictRootDir(d.cfg.WorkspacesRoot, task.WorkspaceID, task.ID)
 	if predictedEnvRoot != "" {
-		d.markActiveEnvRoot(predictedEnvRoot)
+		if !d.markActiveEnvRootContext(ctx, predictedEnvRoot) {
+			return
+		}
 		defer d.unmarkActiveEnvRoot(predictedEnvRoot)
 	}
 	if task.PriorWorkDir != "" {
 		if priorRoot := filepath.Dir(task.PriorWorkDir); priorRoot != "" && priorRoot != predictedEnvRoot {
-			d.markActiveEnvRoot(priorRoot)
+			if !d.markActiveEnvRootContext(ctx, priorRoot) {
+				return
+			}
 			defer d.unmarkActiveEnvRoot(priorRoot)
 		}
 	}
@@ -4173,12 +4178,16 @@ func (d *Daemon) runTask(ctx context.Context, task Task, provider string, slot i
 	// predicted root for a fresh Prepare and the prior root for Reuse — they
 	// usually differ (Reuse keeps the original task's directory).
 	predictedRoot := execenv.PredictRootDir(d.cfg.WorkspacesRoot, task.WorkspaceID, task.ID)
-	d.markActiveEnvRoot(predictedRoot)
+	if !d.markActiveEnvRootContext(ctx, predictedRoot) {
+		return TaskResult{}, ctx.Err()
+	}
 	defer d.unmarkActiveEnvRoot(predictedRoot)
 	if task.PriorWorkDir != "" {
 		priorRoot := filepath.Dir(task.PriorWorkDir)
 		if priorRoot != predictedRoot {
-			d.markActiveEnvRoot(priorRoot)
+			if !d.markActiveEnvRootContext(ctx, priorRoot) {
+				return TaskResult{}, ctx.Err()
+			}
 			defer d.unmarkActiveEnvRoot(priorRoot)
 		}
 	}
@@ -4349,7 +4358,9 @@ func (d *Daemon) runTask(ctx context.Context, task Task, provider string, slot i
 	// Belt-and-suspenders: also mark whatever root we ended up with, in case
 	// future changes diverge from PredictRootDir.
 	if env.RootDir != predictedRoot && env.RootDir != "" {
-		d.markActiveEnvRoot(env.RootDir)
+		if !d.markActiveEnvRootContext(ctx, env.RootDir) {
+			return TaskResult{}, ctx.Err()
+		}
 		defer d.unmarkActiveEnvRoot(env.RootDir)
 	}
 	taskTempDir, err := ensureTaskTempDir(env.RootDir, task.WorkspaceID, task.ID)
@@ -5466,40 +5477,58 @@ func convertProjectResourcesForEnv(resources []ProjectResourceData) []execenv.Pr
 // reference-counted so a reuse path marked twice (predicted + prior) only
 // becomes inactive after both unmark calls.
 func (d *Daemon) markActiveEnvRoot(envRoot string) {
+	d.markActiveEnvRootContext(context.Background(), envRoot)
+}
+
+// markActiveEnvRootContext waits for an in-flight mutation without making task
+// cancellation depend on filesystem progress. It returns false when ctx is
+// cancelled before the root can be claimed.
+func (d *Daemon) markActiveEnvRootContext(ctx context.Context, envRoot string) bool {
 	if envRoot == "" {
-		return
+		return true
 	}
+	key := canonicalPathIdentity(envRoot)
 	d.activeEnvRootsMu.Lock()
-	defer d.activeEnvRootsMu.Unlock()
 	d.ensureActiveEnvRootStateLocked()
-	for d.deletingEnvRoots[envRoot] {
+	for d.deletingEnvRoots[key] {
 		if d.activeEnvRootWaitHook != nil {
 			d.activeEnvRootWaitHook(envRoot)
 		}
-		d.activeEnvRootsCond.Wait()
+		changed := d.activeEnvRootsChanged
+		d.activeEnvRootsMu.Unlock()
+		select {
+		case <-ctx.Done():
+			return false
+		case <-changed:
+		}
+		d.activeEnvRootsMu.Lock()
 	}
-	d.activeEnvRoots[envRoot]++
+	d.activeEnvRoots[key]++
+	d.activeEnvRootsMu.Unlock()
+	return true
 }
 
 func (d *Daemon) unmarkActiveEnvRoot(envRoot string) {
 	if envRoot == "" {
 		return
 	}
+	key := canonicalPathIdentity(envRoot)
 	d.activeEnvRootsMu.Lock()
 	defer d.activeEnvRootsMu.Unlock()
 	d.ensureActiveEnvRootStateLocked()
-	if d.activeEnvRoots[envRoot] <= 1 {
-		delete(d.activeEnvRoots, envRoot)
+	if d.activeEnvRoots[key] <= 1 {
+		delete(d.activeEnvRoots, key)
 		return
 	}
-	d.activeEnvRoots[envRoot]--
+	d.activeEnvRoots[key]--
 }
 
 func (d *Daemon) isActiveEnvRoot(envRoot string) bool {
+	key := canonicalPathIdentity(envRoot)
 	d.activeEnvRootsMu.Lock()
 	defer d.activeEnvRootsMu.Unlock()
 	d.ensureActiveEnvRootStateLocked()
-	return d.activeEnvRoots[envRoot] > 0
+	return d.activeEnvRoots[key] > 0
 }
 
 func (d *Daemon) ensureActiveEnvRootStateLocked() {
@@ -5509,8 +5538,35 @@ func (d *Daemon) ensureActiveEnvRootStateLocked() {
 	if d.deletingEnvRoots == nil {
 		d.deletingEnvRoots = make(map[string]bool)
 	}
-	if d.activeEnvRootsCond == nil {
-		d.activeEnvRootsCond = sync.NewCond(&d.activeEnvRootsMu)
+	if d.activeEnvRootsChanged == nil {
+		d.activeEnvRootsChanged = make(chan struct{})
+	}
+}
+
+// canonicalPathIdentity returns one guard key for lexical and symlink aliases.
+// For not-yet-created predicted roots it resolves the nearest existing
+// ancestor and appends the missing suffix.
+func canonicalPathIdentity(path string) string {
+	abs, err := filepath.Abs(path)
+	if err != nil {
+		return filepath.Clean(path)
+	}
+	current := filepath.Clean(abs)
+	var suffix []string
+	for {
+		resolved, resolveErr := filepath.EvalSymlinks(current)
+		if resolveErr == nil {
+			for i := len(suffix) - 1; i >= 0; i-- {
+				resolved = filepath.Join(resolved, suffix[i])
+			}
+			return filepath.Clean(resolved)
+		}
+		parent := filepath.Dir(current)
+		if parent == current {
+			return filepath.Clean(abs)
+		}
+		suffix = append(suffix, filepath.Base(current))
+		current = parent
 	}
 }
 
@@ -5523,17 +5579,19 @@ func (d *Daemon) reserveEnvRootForGC(envRoot string) (release func(), ok bool) {
 	if envRoot == "" {
 		return nil, false
 	}
+	key := canonicalPathIdentity(envRoot)
 	d.activeEnvRootsMu.Lock()
 	defer d.activeEnvRootsMu.Unlock()
 	d.ensureActiveEnvRootStateLocked()
-	if d.activeEnvRoots[envRoot] > 0 || d.deletingEnvRoots[envRoot] {
+	if d.activeEnvRoots[key] > 0 || d.deletingEnvRoots[key] {
 		return nil, false
 	}
-	d.deletingEnvRoots[envRoot] = true
+	d.deletingEnvRoots[key] = true
 	return func() {
 		d.activeEnvRootsMu.Lock()
-		delete(d.deletingEnvRoots, envRoot)
-		d.activeEnvRootsCond.Broadcast()
+		delete(d.deletingEnvRoots, key)
+		close(d.activeEnvRootsChanged)
+		d.activeEnvRootsChanged = make(chan struct{})
 		d.activeEnvRootsMu.Unlock()
 	}, true
 }

--- a/server/internal/daemon/daemon.go
+++ b/server/internal/daemon/daemon.go
@@ -3716,8 +3716,9 @@ func providerNeedsInlineSystemPrompt(provider string) bool {
 
 // gateResumeToReusedWorkdir clears the task's prior session unless the caller
 // has object-bound proof that the environment was reused and it runs in the
-// exact workdir the session was recorded against. CLI backends key their session stores to
-// the cwd (Claude Code looks sessions up under ~/.claude/projects/<encoded-cwd>/),
+// exact workdir the session was recorded against. CLI backends key their
+// session stores to the cwd (Claude Code looks sessions up under
+// ~/.claude/projects/<encoded-cwd>/),
 // so a session id from a different workdir can never resolve: the CLI exits
 // within a second and the run fails before doing any work — permanently,
 // because the failed run records no session and the next claim serves the

--- a/server/internal/daemon/daemon.go
+++ b/server/internal/daemon/daemon.go
@@ -331,6 +331,8 @@ type Daemon struct {
 	removeEnvRootHook     func(string) error
 	envRootQuarantineHook func(string) // test-only: runs after WorkspacesRoot is opened, before rename
 	envRootPreOpenHook    func(string) // test-only: runs after reservation, before a filesystem root is opened
+	gcBeforeApplyHook     func(string) // test-only: runs after decision, before reservation
+	gcCycleRoot           *os.Root     // pinned for the synchronous runGC cycle
 	artifactCleanupHook   func(string) // test-only: runs while the artifact-cleanup reservation is held
 	artifactRemoveHook    func(string) // test-only: runs after artifact inspection, before fd-relative removal
 
@@ -4195,8 +4197,10 @@ func (d *Daemon) runTask(ctx context.Context, task Task, provider string, slot i
 		return TaskResult{}, ctx.Err()
 	}
 	defer releasePredicted()
+	var priorRootIdentity os.FileInfo
 	if task.PriorWorkDir != "" {
 		priorRoot := filepath.Dir(task.PriorWorkDir)
+		priorRootIdentity, _ = os.Stat(priorRoot)
 		if priorRoot != predictedRoot {
 			releasePrior, ok := d.markActiveEnvRoot(ctx, priorRoot)
 			if !ok {
@@ -4321,7 +4325,13 @@ func (d *Daemon) runTask(ctx context.Context, task Task, provider string, slot i
 	if task.PriorWorkDir != "" && d.envRootPreOpenHook != nil {
 		d.envRootPreOpenHook(filepath.Dir(task.PriorWorkDir))
 	}
-	if canonicalPathIdentity(d.cfg.WorkspacesRoot) == d.workspacesRootIdentity &&
+	priorIdentityMatches := false
+	if priorRootIdentity != nil {
+		currentPrior, statErr := os.Stat(filepath.Dir(task.PriorWorkDir))
+		priorIdentityMatches = statErr == nil && os.SameFile(priorRootIdentity, currentPrior)
+	}
+	if priorIdentityMatches &&
+		canonicalPathIdentity(d.cfg.WorkspacesRoot) == d.workspacesRootIdentity &&
 		shouldReusePriorWorkdir(task, localAssignment, d.cfg.WorkspacesRoot) {
 		var err error
 		env, err = d.reuseExecutionEnvironment(prepareCtx, execenv.ReuseParams{
@@ -5612,7 +5622,17 @@ func (d *Daemon) reserveEnvRootForGCIdentity(envRoot string) (envRootGCLease, bo
 	if envRoot == "" {
 		return envRootGCLease{}, false
 	}
-	expected, err := os.Stat(envRoot)
+	var expected os.FileInfo
+	var err error
+	if d.gcCycleRoot != nil {
+		rel, relErr := filepath.Rel(d.cfg.WorkspacesRoot, envRoot)
+		if relErr != nil || !isContainedRelativePath(rel) {
+			return envRootGCLease{}, false
+		}
+		expected, err = d.gcCycleRoot.Stat(rel)
+	} else {
+		expected, err = os.Stat(envRoot)
+	}
 	if err != nil || !expected.IsDir() {
 		return envRootGCLease{}, false
 	}

--- a/server/internal/daemon/daemon.go
+++ b/server/internal/daemon/daemon.go
@@ -3714,9 +3714,9 @@ func providerNeedsInlineSystemPrompt(provider string) bool {
 	}
 }
 
-// gateResumeToReusedWorkdir clears the task's prior session unless the task
-// runs in the exact workdir the session was recorded against, and reports
-// whether that workdir was reused. CLI backends key their session stores to
+// gateResumeToReusedWorkdir clears the task's prior session unless the caller
+// has object-bound proof that the environment was reused and it runs in the
+// exact workdir the session was recorded against. CLI backends key their session stores to
 // the cwd (Claude Code looks sessions up under ~/.claude/projects/<encoded-cwd>/),
 // so a session id from a different workdir can never resolve: the CLI exits
 // within a second and the run fails before doing any work — permanently,
@@ -3724,8 +3724,8 @@ func providerNeedsInlineSystemPrompt(provider string) bool {
 // same stale pointer again. This fires whenever the prior workdir no longer
 // exists (GC'd after the issue went done, daemon reinstall, manual cleanup)
 // and execenv.Reuse fell back to a fresh Prepare (GitHub #3854).
-func gateResumeToReusedWorkdir(task *Task, taskCtx *execenv.TaskContextForEnv, envWorkDir string, taskLog *slog.Logger) bool {
-	reused := task.PriorWorkDir != "" && envWorkDir == task.PriorWorkDir
+func gateResumeToReusedWorkdir(task *Task, taskCtx *execenv.TaskContextForEnv, envWorkDir string, envWasReused bool, taskLog *slog.Logger) bool {
+	reused := envWasReused && task.PriorWorkDir != "" && envWorkDir == task.PriorWorkDir
 	if !reused && task.PriorSessionID != "" {
 		taskLog.Info("dropping prior session: workdir not reused, per-cwd session cannot resolve",
 			"session_id", task.PriorSessionID,
@@ -4399,7 +4399,9 @@ func (d *Daemon) runTask(ctx context.Context, task Task, provider string, slot i
 	cancelPrepare()
 	_ = d.client.ReportProgress(ctx, task.ID, fmt.Sprintf("Launching %s", provider), 1, 2)
 
-	reused := gateResumeToReusedWorkdir(&task, &taskCtx, env.WorkDir, taskLog)
+	// Pathname-based reuse is disabled above, so a matching workdir string is
+	// not proof of reuse (fresh Prepare may return the same stable path).
+	reused := gateResumeToReusedWorkdir(&task, &taskCtx, env.WorkDir, false, taskLog)
 	// A reused workdir is necessary but not sufficient for a Codex resume: the
 	// prior thread's rollout must actually be present in this task's CODEX_HOME
 	// sessions (MUL-4424 isolates them). Drop the resume before the brief is

--- a/server/internal/daemon/daemon_test.go
+++ b/server/internal/daemon/daemon_test.go
@@ -1275,20 +1275,30 @@ func TestGateResumeToReusedWorkdir(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name        string
-		sessionID   string
-		priorDir    string
-		envDir      string
-		wantSession string
-		wantReused  bool
+		name         string
+		sessionID    string
+		priorDir     string
+		envDir       string
+		envWasReused bool
+		wantSession  string
+		wantReused   bool
 	}{
 		{
-			name:        "same workdir keeps session",
+			name:        "same workdir from fresh prepare drops session",
 			sessionID:   "sess-1",
 			priorDir:    "/ws/task-a/workdir",
 			envDir:      "/ws/task-a/workdir",
-			wantSession: "sess-1",
-			wantReused:  true,
+			wantSession: "",
+			wantReused:  false,
+		},
+		{
+			name:         "object-bound reused workdir keeps session",
+			sessionID:    "sess-1",
+			priorDir:     "/ws/task-a/workdir",
+			envDir:       "/ws/task-a/workdir",
+			envWasReused: true,
+			wantSession:  "sess-1",
+			wantReused:   true,
 		},
 		{
 			name:        "fresh workdir drops session",
@@ -1321,7 +1331,7 @@ func TestGateResumeToReusedWorkdir(t *testing.T) {
 			task := Task{PriorSessionID: tt.sessionID, PriorWorkDir: tt.priorDir}
 			taskCtx := execenv.TaskContextForEnv{PriorSessionResumed: tt.sessionID != ""}
 
-			reused := gateResumeToReusedWorkdir(&task, &taskCtx, tt.envDir, slog.Default())
+			reused := gateResumeToReusedWorkdir(&task, &taskCtx, tt.envDir, tt.envWasReused, slog.Default())
 
 			if reused != tt.wantReused {
 				t.Fatalf("reused = %v, want %v", reused, tt.wantReused)

--- a/server/internal/daemon/gc.go
+++ b/server/internal/daemon/gc.go
@@ -5,6 +5,7 @@ import (
 	"crypto/sha256"
 	"errors"
 	"fmt"
+	"io/fs"
 	"net/http"
 	"os"
 	"os/exec"
@@ -735,12 +736,17 @@ func (d *Daemon) cleanTaskArtifactsMatching(taskDir string, matcher artifactMatc
 	if err != nil {
 		return
 	}
+	root, err := os.OpenRoot(absRoot)
+	if err != nil {
+		return
+	}
+	defer root.Close()
 
-	walkErr := filepath.WalkDir(absRoot, func(path string, entry os.DirEntry, err error) error {
+	walkErr := fs.WalkDir(root.FS(), ".", func(path string, entry fs.DirEntry, err error) error {
 		if err != nil {
 			return nil // best-effort — keep walking
 		}
-		if path == absRoot {
+		if path == "." {
 			return nil
 		}
 		if !entry.IsDir() {
@@ -753,19 +759,22 @@ func (d *Daemon) cleanTaskArtifactsMatching(taskDir string, matcher artifactMatc
 		}
 		// Refuse to follow symlinked directories. WalkDir reports them as type
 		// Dir on some platforms; lstat to be sure.
-		info, statErr := os.Lstat(path)
+		info, statErr := root.Lstat(path)
 		if statErr != nil {
 			return nil
 		}
 		if info.Mode()&os.ModeSymlink != 0 {
 			return filepath.SkipDir
 		}
-		pattern, ok := matcher.matchDirectory(absRoot, path, entry)
+		pattern, ok := matcher.matchDirectory(absRoot, filepath.Join(absRoot, filepath.FromSlash(path)), entry)
 		if !ok {
 			return nil
 		}
-		size := dirSize(path)
-		if rmErr := os.RemoveAll(path); rmErr != nil {
+		size := rootDirSize(root, path)
+		if d.artifactRemoveHook != nil {
+			d.artifactRemoveHook(path)
+		}
+		if rmErr := root.RemoveAll(path); rmErr != nil {
 			d.logger.Warn("gc: artifact remove failed", "path", path, "error", rmErr)
 			return filepath.SkipDir
 		}
@@ -780,6 +789,21 @@ func (d *Daemon) cleanTaskArtifactsMatching(taskDir string, matcher artifactMatc
 		d.logger.Warn("gc: artifact walk failed", "dir", taskDir, "error", walkErr)
 	}
 	return
+}
+
+func rootDirSize(root *os.Root, path string) int64 {
+	var total int64
+	_ = fs.WalkDir(root.FS(), path, func(_ string, entry fs.DirEntry, err error) error {
+		if err != nil || entry.IsDir() {
+			return nil
+		}
+		info, statErr := entry.Info()
+		if statErr == nil && info.Mode().IsRegular() {
+			total += info.Size()
+		}
+		return nil
+	})
+	return total
 }
 
 // dirSize returns the total size of all regular files under root, in bytes.

--- a/server/internal/daemon/gc.go
+++ b/server/internal/daemon/gc.go
@@ -223,7 +223,7 @@ func (d *Daemon) gcWorkspaceIssues(ctx context.Context, workspaceID string, cand
 // atomically reserves the env root because a task can start while the server
 // reconciliation request is in flight.
 func (d *Daemon) applyGCAction(taskDir string, action gcAction, stats *gcStats) int {
-	if action == gcActionCleanArtifacts {
+	if action == gcActionCleanArtifacts || action == gcActionCleanManagedArtifacts {
 		release, ok := d.reserveEnvRootForGC(taskDir)
 		if !ok {
 			stats.skipped++
@@ -256,6 +256,9 @@ func (d *Daemon) applyGCAction(taskDir string, action gcAction, stats *gcStats) 
 		recordArtifactCleanup(stats, removed, bytes, perPattern)
 		stats.skipped++ // task dir itself preserved
 	case gcActionCleanManagedArtifacts:
+		if d.artifactCleanupHook != nil {
+			d.artifactCleanupHook(taskDir)
+		}
 		removed, bytes, perPattern := d.cleanManagedTaskArtifacts(taskDir)
 		recordArtifactCleanup(stats, removed, bytes, perPattern)
 		stats.skipped++ // task dir itself preserved
@@ -635,12 +638,13 @@ func (d *Daemon) cleanTaskDir(taskDir string) bool {
 	}
 	defer release()
 
-	quarantineDir, err := d.quarantineTaskDir(taskDir)
+	root, quarantineDir, quarantineRel, err := d.quarantineTaskDir(taskDir)
 	if err != nil {
 		d.logger.Warn("gc: quarantine task dir failed", "dir", taskDir, "error", err)
 		return false
 	}
-	if err := d.removeEnvRoot(quarantineDir); err != nil {
+	defer root.Close()
+	if err := d.removeEnvRoot(root, quarantineDir, quarantineRel); err != nil {
 		d.logger.Warn("gc: remove quarantined task dir failed", "dir", quarantineDir, "error", err)
 		return false
 	}
@@ -648,29 +652,52 @@ func (d *Daemon) cleanTaskDir(taskDir string) bool {
 	return true
 }
 
-func (d *Daemon) quarantineTaskDir(taskDir string) (string, error) {
+func (d *Daemon) quarantineTaskDir(taskDir string) (*os.Root, string, string, error) {
 	quarantineDir, err := gcQuarantinePath(d.cfg.WorkspacesRoot, taskDir)
 	if err != nil {
-		return "", err
+		return nil, "", "", err
 	}
-	trashRoot := filepath.Join(d.cfg.WorkspacesRoot, gcTrashDirName)
-	if err := ensureGCTrashRoot(trashRoot); err != nil {
-		return "", err
+	taskRel, err := filepath.Rel(d.cfg.WorkspacesRoot, taskDir)
+	if err != nil || !isContainedRelativePath(taskRel) {
+		return nil, "", "", fmt.Errorf("task dir outside workspaces root")
 	}
-	if _, err := os.Lstat(quarantineDir); err == nil {
-		return "", fmt.Errorf("quarantine destination already exists")
+	quarantineRel, err := filepath.Rel(d.cfg.WorkspacesRoot, quarantineDir)
+	if err != nil || !isContainedRelativePath(quarantineRel) {
+		return nil, "", "", fmt.Errorf("quarantine dir outside workspaces root")
+	}
+	root, err := os.OpenRoot(d.cfg.WorkspacesRoot)
+	if err != nil {
+		return nil, "", "", err
+	}
+	fail := func(err error) (*os.Root, string, string, error) {
+		root.Close()
+		return nil, "", "", err
+	}
+	if err := ensureGCTrashRootAt(root); err != nil {
+		return fail(err)
+	}
+	if _, err := root.Lstat(quarantineRel); err == nil {
+		return fail(fmt.Errorf("quarantine destination already exists"))
 	} else if !os.IsNotExist(err) {
-		return "", err
+		return fail(err)
+	}
+	if d.envRootQuarantineHook != nil {
+		d.envRootQuarantineHook(taskDir)
 	}
 	if d.renameEnvRootHook != nil {
 		err = d.renameEnvRootHook(taskDir, quarantineDir)
 	} else {
-		err = os.Rename(taskDir, quarantineDir)
+		err = root.Rename(taskRel, quarantineRel)
 	}
 	if err != nil {
-		return "", err
+		return fail(err)
 	}
-	return quarantineDir, nil
+	return root, quarantineDir, quarantineRel, nil
+}
+
+func isContainedRelativePath(path string) bool {
+	return path != "" && path != "." && path != ".." && !filepath.IsAbs(path) &&
+		!strings.HasPrefix(path, ".."+string(filepath.Separator))
 }
 
 func gcQuarantinePath(workspacesRoot, taskDir string) (string, error) {
@@ -681,13 +708,13 @@ func gcQuarantinePath(workspacesRoot, taskDir string) (string, error) {
 	return filepath.Join(workspacesRoot, gcTrashDirName, fmt.Sprintf("%x", sha256.Sum256([]byte(rel)))), nil
 }
 
-func ensureGCTrashRoot(trashRoot string) error {
-	info, err := os.Lstat(trashRoot)
+func ensureGCTrashRootAt(root *os.Root) error {
+	info, err := root.Lstat(gcTrashDirName)
 	if os.IsNotExist(err) {
-		if err := os.Mkdir(trashRoot, 0o755); err != nil && !os.IsExist(err) {
+		if err := root.Mkdir(gcTrashDirName, 0o755); err != nil && !os.IsExist(err) {
 			return err
 		}
-		info, err = os.Lstat(trashRoot)
+		info, err = root.Lstat(gcTrashDirName)
 	}
 	if err != nil {
 		return err
@@ -698,11 +725,11 @@ func ensureGCTrashRoot(trashRoot string) error {
 	return nil
 }
 
-func (d *Daemon) removeEnvRoot(path string) error {
+func (d *Daemon) removeEnvRoot(root *os.Root, path, rel string) error {
 	if d.removeEnvRootHook != nil {
 		return d.removeEnvRootHook(path)
 	}
-	return os.RemoveAll(path)
+	return root.RemoveAll(rel)
 }
 
 // cleanTaskArtifacts walks taskDir and deletes every directory whose basename

--- a/server/internal/daemon/gc.go
+++ b/server/internal/daemon/gc.go
@@ -65,16 +65,56 @@ type gcStats struct {
 
 // runGC performs a single GC scan across all workspace directories.
 func (d *Daemon) runGC(ctx context.Context) {
-	// Fail closed until task leases and GC mutations share one portable,
-	// object-bound filesystem identity contract. In particular, do not even
-	// discover WorkspacesRoot here: pathname discovery followed by a later
-	// mutation can target a different object after a symlink/rename retarget.
-	//
-	// This intentionally disables task/workspace deletion, artifact cleanup,
-	// repository pruning, .gc-trash retry, and Codex-store pruning. Disk/cache
-	// growth is the accepted short-term operational cost (tracked separately)
-	// for guaranteeing that daemon GC cannot delete active or external data.
-	d.logger.Warn("gc: filesystem mutation disabled; object-bound root lease unavailable")
+	root := d.cfg.WorkspacesRoot
+	rootHandle, err := os.OpenRoot(root)
+	if err != nil {
+		if !os.IsNotExist(err) {
+			d.logger.Warn("gc: open workspaces root failed", "error", err)
+		}
+		return
+	}
+	defer rootHandle.Close()
+	d.gcCycleRoot = rootHandle
+	defer func() { d.gcCycleRoot = nil }()
+	entries, err := fs.ReadDir(rootHandle.FS(), ".")
+	if err != nil {
+		if os.IsNotExist(err) {
+			return
+		}
+		d.logger.Warn("gc: read workspaces root failed", "error", err)
+		return
+	}
+
+	stats := &gcStats{byPattern: map[string]int{}}
+	for _, wsEntry := range entries {
+		if !wsEntry.IsDir() || wsEntry.Name() == ".repos" || wsEntry.Name() == gcTrashDirName {
+			continue
+		}
+		d.gcWorkspace(ctx, filepath.Join(root, wsEntry.Name()), stats)
+	}
+	if err := rootHandle.RemoveAll(gcTrashDirName); err != nil && !os.IsNotExist(err) {
+		d.logger.Warn("gc: quarantine retry failed", "error", err)
+	}
+
+	// Repo pruning still takes pathname arguments. Keep it out of the pinned
+	// cycle until repocache accepts an fd-relative root.
+
+	if storesRemoved, storeBytes := execenv.PruneCodexSessionStores(d.cfg.Profile, d.cfg.GCCodexSessionTTL, time.Now(), d.reserveCodexStoreForDeletion, d.logger); storesRemoved > 0 {
+		stats.storesReclaimed += storesRemoved
+		stats.bytesReclaimed += storeBytes
+	}
+	if stats.cleaned > 0 || stats.orphaned > 0 || stats.artifactDirs > 0 || stats.storesReclaimed > 0 {
+		d.logger.Info("gc: cycle complete",
+			"cleaned", stats.cleaned,
+			"orphaned", stats.orphaned,
+			"skipped", stats.skipped,
+			"artifact_dirs", stats.artifactDirs,
+			"artifact_removed", stats.artifactRemoved,
+			"codex_session_stores_reclaimed", stats.storesReclaimed,
+			"bytes_reclaimed", stats.bytesReclaimed,
+			"by_pattern", stats.byPattern,
+		)
+	}
 }
 
 // gcWorkspace scans task directories inside a single workspace directory.

--- a/server/internal/daemon/gc.go
+++ b/server/internal/daemon/gc.go
@@ -248,6 +248,9 @@ func (d *Daemon) applyGCAction(taskDir string, action gcAction, stats *gcStats) 
 		}
 		stats.skipped++
 	case gcActionCleanArtifacts:
+		if d.artifactCleanupHook != nil {
+			d.artifactCleanupHook(taskDir)
+		}
 		removed, bytes, perPattern := d.cleanTaskArtifacts(taskDir, d.cfg.GCArtifactPatterns)
 		recordArtifactCleanup(stats, removed, bytes, perPattern)
 		stats.skipped++ // task dir itself preserved

--- a/server/internal/daemon/gc.go
+++ b/server/internal/daemon/gc.go
@@ -125,7 +125,6 @@ func (d *Daemon) gcWorkspace(ctx context.Context, wsDir string, stats *gcStats) 
 		return
 	}
 
-	cleanedHere := 0
 	issueCandidates := make([]issueGCCandidate, 0, len(taskEntries))
 	for _, entry := range taskEntries {
 		if ctx.Err() != nil {
@@ -145,17 +144,14 @@ func (d *Daemon) gcWorkspace(ctx context.Context, wsDir string, stats *gcStats) 
 			continue
 		}
 		action := d.shouldCleanTaskDir(ctx, taskDir)
-		cleanedHere += d.applyGCAction(taskDir, action, stats)
+		d.applyGCAction(taskDir, action, stats)
 	}
-	cleanedHere += d.gcWorkspaceIssues(ctx, filepath.Base(wsDir), issueCandidates, stats)
+	d.gcWorkspaceIssues(ctx, filepath.Base(wsDir), issueCandidates, stats)
 
-	// Remove the workspace directory itself if it's now empty.
-	if cleanedHere > 0 {
-		remaining, _ := os.ReadDir(wsDir)
-		if len(remaining) == 0 {
-			os.Remove(wsDir)
-		}
-	}
+	// Keep empty workspace directories. Reopening wsDir by pathname here would
+	// escape the cycle's pinned os.Root after an ancestor retarget. Empty dirs
+	// are harmless and bounded by workspace count; task/artifact cleanup above
+	// remains fd-relative and identity-checked.
 }
 
 const issueGCBatchSize = 500

--- a/server/internal/daemon/gc.go
+++ b/server/internal/daemon/gc.go
@@ -2,7 +2,9 @@ package daemon
 
 import (
 	"context"
+	"crypto/sha256"
 	"errors"
+	"fmt"
 	"net/http"
 	"os"
 	"os/exec"
@@ -74,12 +76,15 @@ func (d *Daemon) runGC(ctx context.Context) {
 
 	stats := &gcStats{byPattern: map[string]int{}}
 	for _, wsEntry := range entries {
-		if !wsEntry.IsDir() || wsEntry.Name() == ".repos" {
+		if !wsEntry.IsDir() || wsEntry.Name() == ".repos" || wsEntry.Name() == gcTrashDirName {
 			continue
 		}
 		wsDir := filepath.Join(root, wsEntry.Name())
 		d.gcWorkspace(ctx, wsDir, stats)
 	}
+	// Retry quarantines left by a prior partial/failed removal. They are never
+	// reusable task roots, so retrying cannot race with task startup.
+	_ = os.RemoveAll(filepath.Join(root, gcTrashDirName))
 
 	// Prune stale worktree references from all bare repo caches.
 	d.pruneRepoWorktrees(root)
@@ -217,7 +222,7 @@ func (d *Daemon) gcWorkspaceIssues(ctx context.Context, workspaceID string, cand
 // atomically reserves the env root because a task can start while the server
 // reconciliation request is in flight.
 func (d *Daemon) applyGCAction(taskDir string, action gcAction, stats *gcStats) int {
-	if action != gcActionSkip {
+	if action == gcActionCleanArtifacts {
 		release, ok := d.reserveEnvRootForGC(taskDir)
 		if !ok {
 			stats.skipped++
@@ -228,16 +233,20 @@ func (d *Daemon) applyGCAction(taskDir string, action gcAction, stats *gcStats) 
 	switch action {
 	case gcActionClean:
 		bytes := dirSize(taskDir)
-		d.cleanTaskDir(taskDir)
-		stats.cleaned++
-		stats.bytesReclaimed += bytes
-		return 1
+		if d.cleanTaskDir(taskDir) {
+			stats.cleaned++
+			stats.bytesReclaimed += bytes
+			return 1
+		}
+		stats.skipped++
 	case gcActionOrphan:
 		bytes := dirSize(taskDir)
-		d.cleanTaskDir(taskDir)
-		stats.orphaned++
-		stats.bytesReclaimed += bytes
-		return 1
+		if d.cleanTaskDir(taskDir) {
+			stats.orphaned++
+			stats.bytesReclaimed += bytes
+			return 1
+		}
+		stats.skipped++
 	case gcActionCleanArtifacts:
 		removed, bytes, perPattern := d.cleanTaskArtifacts(taskDir, d.cfg.GCArtifactPatterns)
 		recordArtifactCleanup(stats, removed, bytes, perPattern)
@@ -268,6 +277,8 @@ func recordArtifactCleanup(stats *gcStats, removed int, bytes int64, perPattern 
 }
 
 type gcAction int
+
+const gcTrashDirName = ".gc-trash"
 
 const (
 	gcActionSkip                  gcAction = iota
@@ -610,13 +621,84 @@ func isAgentTaskTerminal(status string) bool {
 	}
 }
 
-// cleanTaskDir removes a task directory and logs the result.
-func (d *Daemon) cleanTaskDir(taskDir string) {
-	if err := os.RemoveAll(taskDir); err != nil {
-		d.logger.Warn("gc: remove task dir failed", "dir", taskDir, "error", err)
-	} else {
-		d.logger.Info("gc: removed", "dir", taskDir)
+// cleanTaskDir reserves and atomically quarantines a task root before removal.
+// A partial removal can therefore never leave a damaged reusable PriorWorkDir.
+func (d *Daemon) cleanTaskDir(taskDir string) bool {
+	release, ok := d.reserveEnvRootForGC(taskDir)
+	if !ok {
+		d.logger.Info("gc: skip removal; env root became active", "dir", taskDir)
+		return false
 	}
+	defer release()
+
+	quarantineDir, err := d.quarantineTaskDir(taskDir)
+	if err != nil {
+		d.logger.Warn("gc: quarantine task dir failed", "dir", taskDir, "error", err)
+		return false
+	}
+	if err := d.removeEnvRoot(quarantineDir); err != nil {
+		d.logger.Warn("gc: remove quarantined task dir failed", "dir", quarantineDir, "error", err)
+		return false
+	}
+	d.logger.Info("gc: removed", "dir", taskDir)
+	return true
+}
+
+func (d *Daemon) quarantineTaskDir(taskDir string) (string, error) {
+	quarantineDir, err := gcQuarantinePath(d.cfg.WorkspacesRoot, taskDir)
+	if err != nil {
+		return "", err
+	}
+	trashRoot := filepath.Join(d.cfg.WorkspacesRoot, gcTrashDirName)
+	if err := ensureGCTrashRoot(trashRoot); err != nil {
+		return "", err
+	}
+	if _, err := os.Lstat(quarantineDir); err == nil {
+		return "", fmt.Errorf("quarantine destination already exists")
+	} else if !os.IsNotExist(err) {
+		return "", err
+	}
+	if d.renameEnvRootHook != nil {
+		err = d.renameEnvRootHook(taskDir, quarantineDir)
+	} else {
+		err = os.Rename(taskDir, quarantineDir)
+	}
+	if err != nil {
+		return "", err
+	}
+	return quarantineDir, nil
+}
+
+func gcQuarantinePath(workspacesRoot, taskDir string) (string, error) {
+	rel, err := filepath.Rel(workspacesRoot, taskDir)
+	if err != nil || rel == "." || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) || filepath.IsAbs(rel) {
+		return "", fmt.Errorf("task dir outside workspaces root")
+	}
+	return filepath.Join(workspacesRoot, gcTrashDirName, fmt.Sprintf("%x", sha256.Sum256([]byte(rel)))), nil
+}
+
+func ensureGCTrashRoot(trashRoot string) error {
+	info, err := os.Lstat(trashRoot)
+	if os.IsNotExist(err) {
+		if err := os.Mkdir(trashRoot, 0o755); err != nil && !os.IsExist(err) {
+			return err
+		}
+		info, err = os.Lstat(trashRoot)
+	}
+	if err != nil {
+		return err
+	}
+	if !info.IsDir() || info.Mode()&os.ModeSymlink != 0 {
+		return fmt.Errorf("gc trash root is not a real directory")
+	}
+	return nil
+}
+
+func (d *Daemon) removeEnvRoot(path string) error {
+	if d.removeEnvRootHook != nil {
+		return d.removeEnvRootHook(path)
+	}
+	return os.RemoveAll(path)
 }
 
 // cleanTaskArtifacts walks taskDir and deletes every directory whose basename

--- a/server/internal/daemon/gc.go
+++ b/server/internal/daemon/gc.go
@@ -74,6 +74,8 @@ func (d *Daemon) runGC(ctx context.Context) {
 		return
 	}
 	defer rootHandle.Close()
+	d.gcCycleRoot = rootHandle
+	defer func() { d.gcCycleRoot = nil }()
 	entries, err := fs.ReadDir(rootHandle.FS(), ".")
 	if err != nil {
 		if os.IsNotExist(err) {
@@ -97,8 +99,9 @@ func (d *Daemon) runGC(ctx context.Context) {
 		d.logger.Warn("gc: quarantine retry failed", "error", err)
 	}
 
-	// Prune stale worktree references from all bare repo caches.
-	d.pruneRepoWorktrees(root)
+	// Repo pruning invokes git with pathname arguments. Skip it while this
+	// cycle is identity-pinned; reopening the configured root would reintroduce
+	// the retarget window this handle closes.
 
 	// Reclaim per-issue Codex session stores idle past their TTL. These live
 	// under the shared ~/.codex home (outside WorkspacesRoot) so resume survives
@@ -233,6 +236,9 @@ func (d *Daemon) gcWorkspaceIssues(ctx context.Context, workspaceID string, cand
 // atomically reserves the env root because a task can start while the server
 // reconciliation request is in flight.
 func (d *Daemon) applyGCAction(taskDir string, action gcAction, stats *gcStats) int {
+	if d.gcBeforeApplyHook != nil {
+		d.gcBeforeApplyHook(taskDir)
+	}
 	var lease envRootGCLease
 	if action == gcActionCleanArtifacts || action == gcActionCleanManagedArtifacts {
 		var ok bool

--- a/server/internal/daemon/gc.go
+++ b/server/internal/daemon/gc.go
@@ -65,64 +65,16 @@ type gcStats struct {
 
 // runGC performs a single GC scan across all workspace directories.
 func (d *Daemon) runGC(ctx context.Context) {
-	root := d.cfg.WorkspacesRoot
-	rootHandle, err := os.OpenRoot(root)
-	if err != nil {
-		if !os.IsNotExist(err) {
-			d.logger.Warn("gc: open workspaces root failed", "error", err)
-		}
-		return
-	}
-	defer rootHandle.Close()
-	d.gcCycleRoot = rootHandle
-	defer func() { d.gcCycleRoot = nil }()
-	entries, err := fs.ReadDir(rootHandle.FS(), ".")
-	if err != nil {
-		if os.IsNotExist(err) {
-			return
-		}
-		d.logger.Warn("gc: read workspaces root failed", "error", err)
-		return
-	}
-
-	stats := &gcStats{byPattern: map[string]int{}}
-	for _, wsEntry := range entries {
-		if !wsEntry.IsDir() || wsEntry.Name() == ".repos" || wsEntry.Name() == gcTrashDirName {
-			continue
-		}
-		wsDir := filepath.Join(root, wsEntry.Name())
-		d.gcWorkspace(ctx, wsDir, stats)
-	}
-	// Retry quarantines left by a prior partial/failed removal. They are never
-	// reusable task roots, so retrying cannot race with task startup.
-	if err := rootHandle.RemoveAll(gcTrashDirName); err != nil && !os.IsNotExist(err) {
-		d.logger.Warn("gc: quarantine retry failed", "error", err)
-	}
-
-	// Repo pruning invokes git with pathname arguments. Skip it while this
-	// cycle is identity-pinned; reopening the configured root would reintroduce
-	// the retarget window this handle closes.
-
-	// Reclaim per-issue Codex session stores idle past their TTL. These live
-	// under the shared ~/.codex home (outside WorkspacesRoot) so resume survives
-	// the task GC, which means they need their own bounded lifecycle (MUL-4424).
-	if storesRemoved, storeBytes := execenv.PruneCodexSessionStores(d.cfg.Profile, d.cfg.GCCodexSessionTTL, time.Now(), d.reserveCodexStoreForDeletion, d.logger); storesRemoved > 0 {
-		stats.storesReclaimed += storesRemoved
-		stats.bytesReclaimed += storeBytes
-	}
-
-	if stats.cleaned > 0 || stats.orphaned > 0 || stats.artifactDirs > 0 || stats.storesReclaimed > 0 {
-		d.logger.Info("gc: cycle complete",
-			"cleaned", stats.cleaned,
-			"orphaned", stats.orphaned,
-			"skipped", stats.skipped,
-			"artifact_dirs", stats.artifactDirs,
-			"artifact_removed", stats.artifactRemoved,
-			"codex_session_stores_reclaimed", stats.storesReclaimed,
-			"bytes_reclaimed", stats.bytesReclaimed,
-			"by_pattern", stats.byPattern,
-		)
-	}
+	// Fail closed until task leases and GC mutations share one portable,
+	// object-bound filesystem identity contract. In particular, do not even
+	// discover WorkspacesRoot here: pathname discovery followed by a later
+	// mutation can target a different object after a symlink/rename retarget.
+	//
+	// This intentionally disables task/workspace deletion, artifact cleanup,
+	// repository pruning, .gc-trash retry, and Codex-store pruning. Disk/cache
+	// growth is the accepted short-term operational cost (tracked separately)
+	// for guaranteeing that daemon GC cannot delete active or external data.
+	d.logger.Warn("gc: filesystem mutation disabled; object-bound root lease unavailable")
 }
 
 // gcWorkspace scans task directories inside a single workspace directory.

--- a/server/internal/daemon/gc.go
+++ b/server/internal/daemon/gc.go
@@ -66,7 +66,15 @@ type gcStats struct {
 // runGC performs a single GC scan across all workspace directories.
 func (d *Daemon) runGC(ctx context.Context) {
 	root := d.cfg.WorkspacesRoot
-	entries, err := os.ReadDir(root)
+	rootHandle, err := os.OpenRoot(root)
+	if err != nil {
+		if !os.IsNotExist(err) {
+			d.logger.Warn("gc: open workspaces root failed", "error", err)
+		}
+		return
+	}
+	defer rootHandle.Close()
+	entries, err := fs.ReadDir(rootHandle.FS(), ".")
 	if err != nil {
 		if os.IsNotExist(err) {
 			return
@@ -85,7 +93,9 @@ func (d *Daemon) runGC(ctx context.Context) {
 	}
 	// Retry quarantines left by a prior partial/failed removal. They are never
 	// reusable task roots, so retrying cannot race with task startup.
-	_ = os.RemoveAll(filepath.Join(root, gcTrashDirName))
+	if err := rootHandle.RemoveAll(gcTrashDirName); err != nil && !os.IsNotExist(err) {
+		d.logger.Warn("gc: quarantine retry failed", "error", err)
+	}
 
 	// Prune stale worktree references from all bare repo caches.
 	d.pruneRepoWorktrees(root)
@@ -223,13 +233,15 @@ func (d *Daemon) gcWorkspaceIssues(ctx context.Context, workspaceID string, cand
 // atomically reserves the env root because a task can start while the server
 // reconciliation request is in flight.
 func (d *Daemon) applyGCAction(taskDir string, action gcAction, stats *gcStats) int {
+	var lease envRootGCLease
 	if action == gcActionCleanArtifacts || action == gcActionCleanManagedArtifacts {
-		release, ok := d.reserveEnvRootForGC(taskDir)
+		var ok bool
+		lease, ok = d.reserveEnvRootForGCIdentity(taskDir)
 		if !ok {
 			stats.skipped++
 			return 0
 		}
-		defer release()
+		defer lease.release()
 	}
 	switch action {
 	case gcActionClean:
@@ -252,14 +264,14 @@ func (d *Daemon) applyGCAction(taskDir string, action gcAction, stats *gcStats) 
 		if d.artifactCleanupHook != nil {
 			d.artifactCleanupHook(taskDir)
 		}
-		removed, bytes, perPattern := d.cleanTaskArtifacts(taskDir, d.cfg.GCArtifactPatterns)
+		removed, bytes, perPattern := d.cleanTaskArtifactsPinned(taskDir, d.cfg.GCArtifactPatterns, lease.expected)
 		recordArtifactCleanup(stats, removed, bytes, perPattern)
 		stats.skipped++ // task dir itself preserved
 	case gcActionCleanManagedArtifacts:
 		if d.artifactCleanupHook != nil {
 			d.artifactCleanupHook(taskDir)
 		}
-		removed, bytes, perPattern := d.cleanManagedTaskArtifacts(taskDir)
+		removed, bytes, perPattern := d.cleanManagedTaskArtifactsPinned(taskDir, lease.expected)
 		recordArtifactCleanup(stats, removed, bytes, perPattern)
 		stats.skipped++ // task dir itself preserved
 	default:
@@ -631,14 +643,17 @@ func isAgentTaskTerminal(status string) bool {
 // cleanTaskDir reserves and atomically quarantines a task root before removal.
 // A partial removal can therefore never leave a damaged reusable PriorWorkDir.
 func (d *Daemon) cleanTaskDir(taskDir string) bool {
-	release, ok := d.reserveEnvRootForGC(taskDir)
+	lease, ok := d.reserveEnvRootForGCIdentity(taskDir)
 	if !ok {
 		d.logger.Info("gc: skip removal; env root became active", "dir", taskDir)
 		return false
 	}
-	defer release()
+	defer lease.release()
+	if d.envRootPreOpenHook != nil {
+		d.envRootPreOpenHook(taskDir)
+	}
 
-	root, quarantineDir, quarantineRel, err := d.quarantineTaskDir(taskDir)
+	root, quarantineDir, quarantineRel, err := d.quarantineTaskDir(taskDir, lease.expected)
 	if err != nil {
 		d.logger.Warn("gc: quarantine task dir failed", "dir", taskDir, "error", err)
 		return false
@@ -652,7 +667,7 @@ func (d *Daemon) cleanTaskDir(taskDir string) bool {
 	return true
 }
 
-func (d *Daemon) quarantineTaskDir(taskDir string) (*os.Root, string, string, error) {
+func (d *Daemon) quarantineTaskDir(taskDir string, expected os.FileInfo) (*os.Root, string, string, error) {
 	quarantineDir, err := gcQuarantinePath(d.cfg.WorkspacesRoot, taskDir)
 	if err != nil {
 		return nil, "", "", err
@@ -675,6 +690,10 @@ func (d *Daemon) quarantineTaskDir(taskDir string) (*os.Root, string, string, er
 	}
 	if err := ensureGCTrashRootAt(root); err != nil {
 		return fail(err)
+	}
+	openedTask, err := root.Stat(taskRel)
+	if err != nil || !os.SameFile(expected, openedTask) {
+		return fail(fmt.Errorf("task dir identity changed before quarantine"))
 	}
 	if _, err := root.Lstat(quarantineRel); err == nil {
 		return fail(fmt.Errorf("quarantine destination already exists"))
@@ -749,11 +768,23 @@ func (d *Daemon) cleanTaskArtifacts(taskDir string, patterns []string) (removed 
 	return d.cleanTaskArtifactsMatching(taskDir, newArtifactMatcher(patterns, execenv.ManagedReclaimableArtifactSubpaths()))
 }
 
+func (d *Daemon) cleanTaskArtifactsPinned(taskDir string, patterns []string, expected os.FileInfo) (removed int, bytes int64, perPattern map[string]int) {
+	return d.cleanTaskArtifactsMatchingPinned(taskDir, newArtifactMatcher(patterns, execenv.ManagedReclaimableArtifactSubpaths()), expected)
+}
+
 func (d *Daemon) cleanManagedTaskArtifacts(taskDir string) (removed int, bytes int64, perPattern map[string]int) {
 	return d.cleanTaskArtifactsMatching(taskDir, newArtifactMatcher(nil, execenv.ManagedReclaimableArtifactSubpaths()))
 }
 
+func (d *Daemon) cleanManagedTaskArtifactsPinned(taskDir string, expected os.FileInfo) (removed int, bytes int64, perPattern map[string]int) {
+	return d.cleanTaskArtifactsMatchingPinned(taskDir, newArtifactMatcher(nil, execenv.ManagedReclaimableArtifactSubpaths()), expected)
+}
+
 func (d *Daemon) cleanTaskArtifactsMatching(taskDir string, matcher artifactMatcher) (removed int, bytes int64, perPattern map[string]int) {
+	return d.cleanTaskArtifactsMatchingPinned(taskDir, matcher, nil)
+}
+
+func (d *Daemon) cleanTaskArtifactsMatchingPinned(taskDir string, matcher artifactMatcher, expected os.FileInfo) (removed int, bytes int64, perPattern map[string]int) {
 	perPattern = map[string]int{}
 	if taskDir == "" || (len(matcher.basenames) == 0 && len(matcher.exactPaths) == 0) {
 		return
@@ -763,11 +794,21 @@ func (d *Daemon) cleanTaskArtifactsMatching(taskDir string, matcher artifactMatc
 	if err != nil {
 		return
 	}
+	if expected != nil && d.envRootPreOpenHook != nil {
+		d.envRootPreOpenHook(taskDir)
+	}
 	root, err := os.OpenRoot(absRoot)
 	if err != nil {
 		return
 	}
 	defer root.Close()
+	if expected != nil {
+		opened, statErr := root.Stat(".")
+		if statErr != nil || !os.SameFile(expected, opened) {
+			d.logger.Warn("gc: artifact root identity changed; skipping", "dir", taskDir)
+			return
+		}
+	}
 
 	walkErr := fs.WalkDir(root.FS(), ".", func(path string, entry fs.DirEntry, err error) error {
 		if err != nil {

--- a/server/internal/daemon/gc.go
+++ b/server/internal/daemon/gc.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"os"
 	"os/exec"
+	"path"
 	"path/filepath"
 	"strings"
 	"time"
@@ -87,7 +88,7 @@ func (d *Daemon) runGC(ctx context.Context) {
 
 	stats := &gcStats{byPattern: map[string]int{}}
 	for _, wsEntry := range entries {
-		if !wsEntry.IsDir() || wsEntry.Name() == ".repos" || wsEntry.Name() == gcTrashDirName {
+		if !wsEntry.IsDir() || wsEntry.Name() == repoCacheDirName || wsEntry.Name() == gcTrashDirName {
 			continue
 		}
 		d.gcWorkspace(ctx, filepath.Join(root, wsEntry.Name()), stats)
@@ -96,8 +97,7 @@ func (d *Daemon) runGC(ctx context.Context) {
 		d.logger.Warn("gc: quarantine retry failed", "error", err)
 	}
 
-	// Repo pruning still takes pathname arguments. Keep it out of the pinned
-	// cycle until repocache accepts an fd-relative root.
+	d.pruneRepoWorktrees(rootHandle, root)
 
 	if storesRemoved, storeBytes := execenv.PruneCodexSessionStores(d.cfg.Profile, d.cfg.GCCodexSessionTTL, time.Now(), d.reserveCodexStoreForDeletion, d.logger); storesRemoved > 0 {
 		stats.storesReclaimed += storesRemoved
@@ -292,6 +292,9 @@ func recordArtifactCleanup(stats *gcStats, removed int, bytes int64, perPattern 
 type gcAction int
 
 const gcTrashDirName = ".gc-trash"
+
+// repoCacheDirName is the bare-repo cache directory inside the workspaces root.
+const repoCacheDirName = ".repos"
 
 const (
 	gcActionSkip                  gcAction = iota
@@ -898,9 +901,29 @@ const (
 )
 
 // pruneRepoWorktrees runs `git worktree prune` on all bare repos in the cache.
-func (d *Daemon) pruneRepoWorktrees(workspacesRoot string) {
-	reposRoot := filepath.Join(workspacesRoot, ".repos")
-	wsEntries, err := os.ReadDir(reposRoot)
+//
+// Directory traversal stays inside the cycle's pinned root: `.repos` is opened
+// fd-relative from rootHandle, so a symlinked or retargeted `.repos` cannot
+// walk GC into a foreign tree. git itself only accepts pathnames, so every
+// pathname handed to it is first proven — via os.SameFile against the pinned
+// handle — to name the same object the pinned root resolves to. A retarget of
+// any ancestor loses that identity and the repo is skipped instead of pruned
+// somewhere else. The residual window between the identity proof and the git
+// exec cannot be closed while git is pathname-only; it is bounded to one repo
+// and requires an attacker to win a race against an fd-verified path, whereas
+// the unguarded version pruned whatever the retargeted pathname pointed at.
+func (d *Daemon) pruneRepoWorktrees(rootHandle *os.Root, workspacesRoot string) {
+	reposHandle, err := rootHandle.OpenRoot(repoCacheDirName)
+	if err != nil {
+		if !os.IsNotExist(err) {
+			d.logger.Warn("gc: open repo cache root failed", "error", err)
+		}
+		return
+	}
+	defer reposHandle.Close()
+	reposRoot := filepath.Join(workspacesRoot, repoCacheDirName)
+
+	wsEntries, err := fs.ReadDir(reposHandle.FS(), ".")
 	if err != nil {
 		return
 	}
@@ -910,7 +933,7 @@ func (d *Daemon) pruneRepoWorktrees(workspacesRoot string) {
 			continue
 		}
 		wsRepoDir := filepath.Join(reposRoot, wsEntry.Name())
-		repoEntries, err := os.ReadDir(wsRepoDir)
+		repoEntries, err := fs.ReadDir(reposHandle.FS(), wsEntry.Name())
 		if err != nil {
 			continue
 		}
@@ -919,12 +942,32 @@ func (d *Daemon) pruneRepoWorktrees(workspacesRoot string) {
 				continue
 			}
 			barePath := filepath.Join(wsRepoDir, repoEntry.Name())
+			if !pinnedDirMatchesPathname(reposHandle, path.Join(wsEntry.Name(), repoEntry.Name()), barePath) {
+				d.logger.Warn("gc: skipping repo outside pinned cache root", "repo", barePath)
+				continue
+			}
 			if !isBareRepo(barePath) {
 				continue
 			}
 			d.pruneWorktree(barePath)
 		}
 	}
+}
+
+// pinnedDirMatchesPathname reports whether pathname resolves to the very same
+// directory object that root reaches at rel. Both lookups must succeed and
+// refer to one inode, so an ancestor symlink swap between the pinned walk and
+// a pathname-only consumer is detected instead of silently followed.
+func pinnedDirMatchesPathname(root *os.Root, rel, pathname string) bool {
+	pinnedInfo, err := root.Stat(rel)
+	if err != nil || !pinnedInfo.IsDir() {
+		return false
+	}
+	pathInfo, err := os.Stat(pathname)
+	if err != nil || !pathInfo.IsDir() {
+		return false
+	}
+	return os.SameFile(pinnedInfo, pathInfo)
 }
 
 func (d *Daemon) pruneWorktree(barePath string) {

--- a/server/internal/daemon/gc_test.go
+++ b/server/internal/daemon/gc_test.go
@@ -3,6 +3,7 @@ package daemon
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log/slog"
 	"net/http"
@@ -274,6 +275,119 @@ func TestCleanTaskDir_RemovesDirectory(t *testing.T) {
 
 	if _, err := os.Stat(taskDir); !os.IsNotExist(err) {
 		t.Fatal("task dir should be removed after cleanup")
+	}
+}
+
+func TestCleanTaskDir_ActiveAfterDecisionPreservesDirectory(t *testing.T) {
+	t.Parallel()
+	issueID := "77777777-7777-7777-7777-777777777777"
+	mux := http.NewServeMux()
+	mux.HandleFunc(fmt.Sprintf("/api/daemon/issues/%s/gc-check", issueID), func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{"status": "done", "updated_at": time.Now().Add(-30 * 24 * time.Hour)})
+	})
+	d := newGCTestDaemon(t, mux)
+	taskDir := createTaskDir(t, d.cfg.WorkspacesRoot, "ws1", "reused-follow-up", &execenv.GCMeta{
+		IssueID: issueID, WorkspaceID: "ws1", CompletedAt: time.Now().Add(-30 * 24 * time.Hour),
+	})
+	if action := d.shouldCleanTaskDir(context.Background(), taskDir); action != gcActionClean {
+		t.Fatalf("expected initial gcActionClean, got %d", action)
+	}
+	d.markActiveEnvRoot(taskDir)
+	defer d.unmarkActiveEnvRoot(taskDir)
+	if d.cleanTaskDir(taskDir) {
+		t.Fatal("cleanup succeeded for active env root")
+	}
+	if _, err := os.Stat(taskDir); err != nil {
+		t.Fatalf("active env root removed after stale GC decision: %v", err)
+	}
+}
+
+func TestCleanTaskDir_TrashSymlinkFailsClosed(t *testing.T) {
+	t.Parallel()
+	d := newGCTestDaemon(t, http.NewServeMux())
+	taskDir := createTaskDir(t, d.cfg.WorkspacesRoot, "ws1", "symlink-trash", nil)
+	outside := t.TempDir()
+	marker := filepath.Join(outside, "keep")
+	if err := os.WriteFile(marker, []byte("keep"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(outside, filepath.Join(d.cfg.WorkspacesRoot, gcTrashDirName)); err != nil {
+		t.Skipf("symlink unsupported: %v", err)
+	}
+	if d.cleanTaskDir(taskDir) {
+		t.Fatal("cleanup succeeded through symlinked trash root")
+	}
+	if _, err := os.Stat(taskDir); err != nil {
+		t.Fatalf("task dir changed after fail-closed quarantine: %v", err)
+	}
+	if _, err := os.Stat(marker); err != nil {
+		t.Fatalf("symlink target changed: %v", err)
+	}
+}
+
+func TestGcWorkspace_ActiveAtFinalGateOnlyIncrementsSkipped(t *testing.T) {
+	t.Parallel()
+	issueID := "77777777-7777-7777-7777-777777777778"
+	mux := http.NewServeMux()
+	mux.HandleFunc(fmt.Sprintf("/api/daemon/issues/%s/gc-check", issueID), func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{"status": "done", "updated_at": time.Now().Add(-30 * 24 * time.Hour)})
+	})
+	d := newGCTestDaemon(t, mux)
+	wsDir := filepath.Join(d.cfg.WorkspacesRoot, "ws-active-final-gate")
+	taskDir := createTaskDir(t, d.cfg.WorkspacesRoot, "ws-active-final-gate", "task", &execenv.GCMeta{
+		IssueID: issueID, WorkspaceID: "ws-active-final-gate",
+	})
+	d.markActiveEnvRoot(taskDir)
+	defer d.unmarkActiveEnvRoot(taskDir)
+	stats := &gcStats{byPattern: map[string]int{}}
+	d.gcWorkspace(context.Background(), wsDir, stats)
+	if stats.skipped != 1 || stats.cleaned != 0 || stats.orphaned != 0 || stats.bytesReclaimed != 0 {
+		t.Fatalf("unexpected stats: %+v", stats)
+	}
+	if _, err := os.Stat(taskDir); err != nil {
+		t.Fatalf("active task dir removed: %v", err)
+	}
+}
+
+func TestGcWorkspace_PartialRemovalFailureQuarantinesAndOnlyIncrementsSkipped(t *testing.T) {
+	t.Parallel()
+	issueID := "77777777-7777-7777-7777-777777777779"
+	mux := http.NewServeMux()
+	mux.HandleFunc(fmt.Sprintf("/api/daemon/issues/%s/gc-check", issueID), func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{"status": "done", "updated_at": time.Now().Add(-30 * 24 * time.Hour)})
+	})
+	d := newGCTestDaemon(t, mux)
+	wsDir := filepath.Join(d.cfg.WorkspacesRoot, "ws-remove-error")
+	taskDir := createTaskDir(t, d.cfg.WorkspacesRoot, "ws-remove-error", "task", &execenv.GCMeta{
+		IssueID: issueID, WorkspaceID: "ws-remove-error",
+	})
+	priorWorkDir := filepath.Join(taskDir, "workdir")
+	if err := os.MkdirAll(priorWorkDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	d.removeEnvRootHook = func(path string) error {
+		if err := os.Remove(filepath.Join(path, ".gc_meta.json")); err != nil {
+			t.Fatalf("simulate partial removal: %v", err)
+		}
+		return errors.New("injected partial removal failure")
+	}
+	stats := &gcStats{byPattern: map[string]int{}}
+	d.gcWorkspace(context.Background(), wsDir, stats)
+	if stats.skipped != 1 || stats.cleaned != 0 || stats.orphaned != 0 || stats.bytesReclaimed != 0 {
+		t.Fatalf("unexpected stats: %+v", stats)
+	}
+	if _, err := os.Stat(priorWorkDir); !os.IsNotExist(err) {
+		t.Fatalf("prior workdir remains reusable after partial removal: %v", err)
+	}
+	if env := execenv.Reuse(execenv.ReuseParams{WorkDir: priorWorkDir}, slog.Default()); env != nil {
+		t.Fatal("Reuse accepted quarantined prior workdir after partial removal")
+	}
+	quarantineDir, err := gcQuarantinePath(d.cfg.WorkspacesRoot, taskDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(quarantineDir); err != nil {
+		t.Fatalf("failed quarantine missing: %v", err)
 	}
 }
 
@@ -1034,6 +1148,93 @@ func TestEnvRootGCReservationBlocksConcurrentClaim(t *testing.T) {
 		t.Fatal("concurrent claim did not resume after reservation release")
 	}
 	d.unmarkActiveEnvRoot(root)
+}
+
+func TestEnvRootGCReservationBlocksSymlinkAliasClaim(t *testing.T) {
+	t.Parallel()
+	d := newGCTestDaemon(t, http.NewServeMux())
+	realRoot := filepath.Join(t.TempDir(), "real")
+	taskDir := filepath.Join(realRoot, "ws", "task")
+	if err := os.MkdirAll(taskDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	aliasRoot := filepath.Join(t.TempDir(), "alias")
+	if err := os.Symlink(realRoot, aliasRoot); err != nil {
+		t.Skipf("symlink unsupported: %v", err)
+	}
+	aliasTaskDir := filepath.Join(aliasRoot, "ws", "task")
+
+	release, ok := d.reserveEnvRootForGC(taskDir)
+	if !ok {
+		t.Fatal("expected reservation through real path")
+	}
+	reachedGate := make(chan struct{})
+	var once sync.Once
+	d.activeEnvRootWaitHook = func(string) { once.Do(func() { close(reachedGate) }) }
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go func() {
+		<-reachedGate
+		cancel()
+	}()
+	if d.markActiveEnvRootContext(ctx, aliasTaskDir) {
+		t.Fatal("symlink alias bypassed reservation")
+	}
+	release()
+	if !d.markActiveEnvRootContext(context.Background(), aliasTaskDir) {
+		t.Fatal("claim did not succeed after reservation release")
+	}
+	d.unmarkActiveEnvRoot(taskDir)
+}
+
+func TestEnvRootGCReservationWaitIsCancellable(t *testing.T) {
+	t.Parallel()
+	d := newGCTestDaemon(t, http.NewServeMux())
+	root := filepath.Join(t.TempDir(), "task")
+	release, ok := d.reserveEnvRootForGC(root)
+	if !ok {
+		t.Fatal("expected reservation")
+	}
+	defer release()
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	if d.markActiveEnvRootContext(ctx, root) {
+		t.Fatal("cancelled claimant entered reserved root")
+	}
+}
+
+func TestCleanTaskArtifacts_AncestorSymlinkSwapCannotEscapeRoot(t *testing.T) {
+	t.Parallel()
+	d := newGCTestDaemon(t, http.NewServeMux())
+	taskDir := createTaskDir(t, d.cfg.WorkspacesRoot, "ws-artifact-swap", "task", nil)
+	parent := filepath.Join(taskDir, "nested")
+	artifact := filepath.Join(parent, "node_modules")
+	if err := os.MkdirAll(artifact, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	outside := t.TempDir()
+	outsideArtifact := filepath.Join(outside, "node_modules")
+	if err := os.MkdirAll(outsideArtifact, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	marker := filepath.Join(outsideArtifact, "keep")
+	if err := os.WriteFile(marker, []byte("keep"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	d.artifactRemoveHook = func(string) {
+		moved := parent + "-moved"
+		if err := os.Rename(parent, moved); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.Symlink(outside, parent); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	d.cleanTaskArtifacts(taskDir, []string{"node_modules"})
+	if _, err := os.Stat(marker); err != nil {
+		t.Fatalf("fd-relative cleanup escaped task root: %v", err)
+	}
 }
 
 func TestApplyGCAction_ArtifactCleanupActiveAfterDecisionOnlyIncrementsSkipped(t *testing.T) {

--- a/server/internal/daemon/gc_test.go
+++ b/server/internal/daemon/gc_test.go
@@ -398,7 +398,7 @@ func TestGcWorkspace_PartialRemovalFailureQuarantinesAndOnlyIncrementsSkipped(t 
 	}
 }
 
-func TestGcWorkspace_CleansEmptyWorkspaceDir(t *testing.T) {
+func TestGcWorkspace_PreservesEmptyWorkspaceDir(t *testing.T) {
 	t.Parallel()
 	issueID := "77777777-7777-7777-7777-777777777777"
 
@@ -421,8 +421,8 @@ func TestGcWorkspace_CleansEmptyWorkspaceDir(t *testing.T) {
 
 	d.gcWorkspace(context.Background(), wsDir, &gcStats{byPattern: map[string]int{}})
 
-	if _, err := os.Stat(wsDir); !os.IsNotExist(err) {
-		t.Fatal("empty workspace dir should be removed after all tasks cleaned")
+	if _, err := os.Stat(wsDir); err != nil {
+		t.Fatalf("empty workspace dir should remain after task cleanup: %v", err)
 	}
 }
 
@@ -1590,6 +1590,44 @@ func TestEnvRootLease_MarkAbsentThenMkdirRejectsGCReservation(t *testing.T) {
 	}
 }
 
+func TestEnvRootLease_SymlinkAncestorRetargetRejectsGCReservation(t *testing.T) {
+	t.Parallel()
+	d := newGCTestDaemon(t, http.NewServeMux())
+	rootA := t.TempDir()
+	rootB := t.TempDir()
+	alias := filepath.Join(t.TempDir(), "workspaces")
+	if err := os.Symlink(rootA, alias); err != nil {
+		t.Skipf("symlink unsupported: %v", err)
+	}
+	taskRoot := filepath.Join(alias, "ws", "task")
+	release, ok := d.markActiveEnvRoot(context.Background(), taskRoot)
+	if !ok {
+		t.Fatal("mark through symlink ancestor failed")
+	}
+	defer release()
+	if err := os.Remove(alias); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(rootB, alias); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(taskRoot, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if _, reserved := d.reserveEnvRootForGC(taskRoot); reserved {
+		t.Fatal("symlink ancestor retarget changed lease key and allowed GC reservation")
+	}
+	releasePrepared, ok := d.markActiveEnvRoot(context.Background(), taskRoot)
+	if !ok {
+		t.Fatal("failed to acquire prepared-object lease")
+	}
+	defer releasePrepared()
+	realPreparedRoot := filepath.Join(rootB, "ws", "task")
+	if _, reserved := d.reserveEnvRootForGC(realPreparedRoot); reserved {
+		t.Fatal("prepared object alias bypassed post-Prepare lease")
+	}
+}
+
 func TestEnvRootLease_MutateContentsRejectsGCReservation(t *testing.T) {
 	t.Parallel()
 	d := newGCTestDaemon(t, http.NewServeMux())
@@ -1607,6 +1645,36 @@ func TestEnvRootLease_MutateContentsRejectsGCReservation(t *testing.T) {
 	}
 	if _, reserved := d.reserveEnvRootForGC(root); reserved {
 		t.Fatal("content mutation changed lease identity and allowed GC reservation")
+	}
+}
+
+func TestGcWorkspace_WorkspacesRootRetargetAfterQuarantinePreservesExternalWorkspace(t *testing.T) {
+	t.Parallel()
+	d := newGCTestDaemon(t, http.NewServeMux())
+	d.cfg.GCOrphanTTL = 0
+	originalRoot := d.cfg.WorkspacesRoot
+	movedRoot := originalRoot + "-moved"
+	wsName := "ws-empty-retarget"
+	taskDir := createTaskDir(t, originalRoot, wsName, "task", nil)
+	externalRoot := t.TempDir()
+	externalWorkspace := filepath.Join(externalRoot, wsName)
+	if err := os.MkdirAll(externalWorkspace, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	d.removeEnvRootHook = func(quarantine string) error {
+		d.removeEnvRootHook = nil
+		if err := os.RemoveAll(quarantine); err != nil {
+			return err
+		}
+		if err := os.Rename(originalRoot, movedRoot); err != nil {
+			return err
+		}
+		return os.Symlink(externalRoot, originalRoot)
+	}
+	stats := &gcStats{byPattern: map[string]int{}}
+	d.gcWorkspace(context.Background(), filepath.Dir(taskDir), stats)
+	if _, err := os.Stat(externalWorkspace); err != nil {
+		t.Fatalf("pathname workspace cleanup removed external target: %v", err)
 	}
 }
 

--- a/server/internal/daemon/gc_test.go
+++ b/server/internal/daemon/gc_test.go
@@ -1553,6 +1553,39 @@ func TestRunGC_QuarantineRetryUsesPinnedRoot(t *testing.T) {
 	}
 }
 
+func TestRunGC_PreReservationRetargetUsesPinnedCycleIdentity(t *testing.T) {
+	d := newGCTestDaemon(t, http.NewServeMux())
+	d.cfg.GCOrphanTTL = 0
+	originalRoot := d.cfg.WorkspacesRoot
+	movedRoot := originalRoot + "-moved"
+	createTaskDir(t, originalRoot, "ws-cycle-pre-reservation", "task", nil)
+	externalRoot := t.TempDir()
+	externalTask := filepath.Join(externalRoot, "ws-cycle-pre-reservation", "task")
+	if err := os.MkdirAll(externalTask, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	marker := filepath.Join(externalTask, "keep")
+	if err := os.WriteFile(marker, []byte("keep"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	d.gcBeforeApplyHook = func(string) {
+		d.gcBeforeApplyHook = nil
+		if err := os.Rename(originalRoot, movedRoot); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.Symlink(externalRoot, originalRoot); err != nil {
+			t.Fatal(err)
+		}
+	}
+	d.runGC(context.Background())
+	if _, err := os.Stat(marker); err != nil {
+		t.Fatalf("pre-reservation full-cycle retarget mutated external root: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(movedRoot, "ws-cycle-pre-reservation", "task")); err != nil {
+		t.Fatalf("pinned cycle unexpectedly removed original task: %v", err)
+	}
+}
+
 func TestCleanTaskArtifacts_AncestorSymlinkSwapCannotEscapeRoot(t *testing.T) {
 	t.Parallel()
 	d := newGCTestDaemon(t, http.NewServeMux())

--- a/server/internal/daemon/gc_test.go
+++ b/server/internal/daemon/gc_test.go
@@ -1590,9 +1590,19 @@ func TestRunGC_FailClosedPreservesWorkspaceStorage(t *testing.T) {
 	if !os.SameFile(before, after) {
 		t.Fatal("inactive stale root identity changed")
 	}
-	for _, marker := range []string{staleMarker, predictedMarker, artifactMarker, repoRef, trashMarker} {
-		if _, err := os.Stat(marker); err != nil {
+	for marker, want := range map[string]string{
+		staleMarker:     "stale",
+		predictedMarker: "predicted",
+		artifactMarker:  "artifact",
+		repoRef:         "deadbeef",
+		trashMarker:     "trash",
+	} {
+		got, err := os.ReadFile(marker)
+		if err != nil {
 			t.Fatalf("runGC mutated %s: %v", marker, err)
+		}
+		if string(got) != want {
+			t.Fatalf("runGC changed %s: got %q, want %q", marker, got, want)
 		}
 	}
 	if downstreamCalled.Load() {

--- a/server/internal/daemon/gc_test.go
+++ b/server/internal/daemon/gc_test.go
@@ -11,6 +11,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -993,6 +994,46 @@ func TestReserveEnvRootForGCIsExclusive(t *testing.T) {
 		t.Fatal("expected GC reservation after release")
 	}
 	release()
+}
+
+func TestEnvRootGCReservationBlocksConcurrentClaim(t *testing.T) {
+	t.Parallel()
+	d := newGCTestDaemon(t, http.NewServeMux())
+	root := filepath.Join(t.TempDir(), "reserved-env")
+	release, ok := d.reserveEnvRootForGC(root)
+	if !ok {
+		t.Fatal("expected inactive env root GC reservation")
+	}
+	reachedGate := make(chan struct{})
+	var reachedOnce sync.Once
+	d.activeEnvRootWaitHook = func(got string) {
+		if got != root {
+			t.Errorf("wait hook root = %q, want %q", got, root)
+		}
+		reachedOnce.Do(func() { close(reachedGate) })
+	}
+	marked := make(chan struct{})
+	go func() {
+		d.markActiveEnvRoot(root)
+		close(marked)
+	}()
+	select {
+	case <-reachedGate:
+	case <-time.After(time.Second):
+		t.Fatal("concurrent claim did not reach GC reservation gate")
+	}
+	select {
+	case <-marked:
+		t.Fatal("concurrent claim passed reservation before release")
+	default:
+	}
+	release()
+	select {
+	case <-marked:
+	case <-time.After(time.Second):
+		t.Fatal("concurrent claim did not resume after reservation release")
+	}
+	d.unmarkActiveEnvRoot(root)
 }
 
 func TestIsBareRepo(t *testing.T) {

--- a/server/internal/daemon/gc_test.go
+++ b/server/internal/daemon/gc_test.go
@@ -1523,14 +1523,13 @@ func TestApplyGCAction_PreOpenRetargetFailsClosed(t *testing.T) {
 	}
 }
 
-func TestRunGC_FailClosedPreservesWorkspaceStorage(t *testing.T) {
+func TestRunGC_ReachesCleanupAndPreservesActiveRoot(t *testing.T) {
 	d := newGCTestDaemon(t, http.NewServeMux())
 	d.cfg.GCOrphanTTL = 0
 	root := d.cfg.WorkspacesRoot
 
 	staleRoot := createTaskDir(t, root, "ws-stale", "task", nil)
-	staleMarker := filepath.Join(staleRoot, "keep")
-	if err := os.WriteFile(staleMarker, []byte("stale"), 0o644); err != nil {
+	if err := os.WriteFile(filepath.Join(staleRoot, "keep"), []byte("stale"), 0o644); err != nil {
 		t.Fatal(err)
 	}
 
@@ -1548,15 +1547,6 @@ func TestRunGC_FailClosedPreservesWorkspaceStorage(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	managedArtifact := filepath.Join(staleRoot, "codex-home", ".sandbox-bin")
-	if err := os.MkdirAll(managedArtifact, 0o755); err != nil {
-		t.Fatal(err)
-	}
-	artifactMarker := filepath.Join(managedArtifact, "keep")
-	if err := os.WriteFile(artifactMarker, []byte("artifact"), 0o644); err != nil {
-		t.Fatal(err)
-	}
-
 	repoRef := filepath.Join(root, ".repos", "repo.git", "refs", "heads", "main")
 	if err := os.MkdirAll(filepath.Dir(repoRef), 0o755); err != nil {
 		t.Fatal(err)
@@ -1565,37 +1555,13 @@ func TestRunGC_FailClosedPreservesWorkspaceStorage(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	trashMarker := filepath.Join(root, gcTrashDirName, "quarantine", "keep")
-	if err := os.MkdirAll(filepath.Dir(trashMarker), 0o755); err != nil {
-		t.Fatal(err)
-	}
-	if err := os.WriteFile(trashMarker, []byte("trash"), 0o644); err != nil {
-		t.Fatal(err)
-	}
-
-	var downstreamCalled atomic.Bool
-	d.gcBeforeApplyHook = func(string) { downstreamCalled.Store(true) }
-	d.envRootPreOpenHook = func(string) { downstreamCalled.Store(true) }
-	d.artifactCleanupHook = func(string) { downstreamCalled.Store(true) }
-
-	before, err := os.Stat(staleRoot)
-	if err != nil {
-		t.Fatal(err)
-	}
 	d.runGC(context.Background())
-	after, err := os.Stat(staleRoot)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if !os.SameFile(before, after) {
-		t.Fatal("inactive stale root identity changed")
+	if _, err := os.Stat(staleRoot); !os.IsNotExist(err) {
+		t.Fatalf("scheduled/manual GC did not remove stale root: %v", err)
 	}
 	for marker, want := range map[string]string{
-		staleMarker:     "stale",
 		predictedMarker: "predicted",
-		artifactMarker:  "artifact",
 		repoRef:         "deadbeef",
-		trashMarker:     "trash",
 	} {
 		got, err := os.ReadFile(marker)
 		if err != nil {
@@ -1605,8 +1571,42 @@ func TestRunGC_FailClosedPreservesWorkspaceStorage(t *testing.T) {
 			t.Fatalf("runGC changed %s: got %q, want %q", marker, got, want)
 		}
 	}
-	if downstreamCalled.Load() {
-		t.Fatal("runGC invoked downstream discovery or mutation helper")
+}
+
+func TestEnvRootLease_MarkAbsentThenMkdirRejectsGCReservation(t *testing.T) {
+	t.Parallel()
+	d := newGCTestDaemon(t, http.NewServeMux())
+	root := filepath.Join(t.TempDir(), "predicted")
+	release, ok := d.markActiveEnvRoot(context.Background(), root)
+	if !ok {
+		t.Fatal("mark absent root failed")
+	}
+	defer release()
+	if err := os.MkdirAll(root, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if _, reserved := d.reserveEnvRootForGC(root); reserved {
+		t.Fatal("mkdir changed lease identity and allowed GC reservation")
+	}
+}
+
+func TestEnvRootLease_MutateContentsRejectsGCReservation(t *testing.T) {
+	t.Parallel()
+	d := newGCTestDaemon(t, http.NewServeMux())
+	root := filepath.Join(t.TempDir(), "existing")
+	if err := os.MkdirAll(root, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	release, ok := d.markActiveEnvRoot(context.Background(), root)
+	if !ok {
+		t.Fatal("mark existing root failed")
+	}
+	defer release()
+	if err := os.WriteFile(filepath.Join(root, "mutated"), []byte("new contents"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, reserved := d.reserveEnvRootForGC(root); reserved {
+		t.Fatal("content mutation changed lease identity and allowed GC reservation")
 	}
 }
 

--- a/server/internal/daemon/gc_test.go
+++ b/server/internal/daemon/gc_test.go
@@ -1586,6 +1586,47 @@ func TestRunGC_PreReservationRetargetUsesPinnedCycleIdentity(t *testing.T) {
 	}
 }
 
+func TestRunGC_CycleIdentityKeyBlocksABARetargetWithActiveClaimant(t *testing.T) {
+	d := newGCTestDaemon(t, http.NewServeMux())
+	d.cfg.GCOrphanTTL = 0
+	originalRoot := d.cfg.WorkspacesRoot
+	movedRoot := originalRoot + "-moved"
+	taskDir := createTaskDir(t, originalRoot, "ws-cycle-aba", "task", nil)
+	externalRoot := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(externalRoot, "ws-cycle-aba", "task"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	var releaseClaim func()
+	d.gcAfterExpectedHook = func(string) {
+		d.gcAfterExpectedHook = nil
+		if err := os.Rename(originalRoot, movedRoot); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.Symlink(externalRoot, originalRoot); err != nil {
+			t.Fatal(err)
+		}
+		var ok bool
+		releaseClaim, ok = d.markActiveEnvRoot(context.Background(), filepath.Join(movedRoot, "ws-cycle-aba", "task"))
+		if !ok {
+			t.Fatal("active claimant could not acquire pinned A task")
+		}
+		if err := os.Remove(originalRoot); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.Rename(movedRoot, originalRoot); err != nil {
+			t.Fatal(err)
+		}
+	}
+	d.runGC(context.Background())
+	if releaseClaim == nil {
+		t.Fatal("A→B→A hook did not run")
+	}
+	defer releaseClaim()
+	if _, err := os.Stat(taskDir); err != nil {
+		t.Fatalf("active claimant A was mutated after A→B→A retarget: %v", err)
+	}
+}
+
 func TestCleanTaskArtifacts_AncestorSymlinkSwapCannotEscapeRoot(t *testing.T) {
 	t.Parallel()
 	d := newGCTestDaemon(t, http.NewServeMux())

--- a/server/internal/daemon/gc_test.go
+++ b/server/internal/daemon/gc_test.go
@@ -1523,107 +1523,80 @@ func TestApplyGCAction_PreOpenRetargetFailsClosed(t *testing.T) {
 	}
 }
 
-func TestRunGC_QuarantineRetryUsesPinnedRoot(t *testing.T) {
+func TestRunGC_FailClosedPreservesWorkspaceStorage(t *testing.T) {
 	d := newGCTestDaemon(t, http.NewServeMux())
 	d.cfg.GCOrphanTTL = 0
-	originalRoot := d.cfg.WorkspacesRoot
-	movedRoot := originalRoot + "-moved"
-	createTaskDir(t, originalRoot, "ws-cycle-swap", "task", nil)
-	externalRoot := t.TempDir()
-	externalTrash := filepath.Join(externalRoot, gcTrashDirName)
-	if err := os.MkdirAll(externalTrash, 0o755); err != nil {
-		t.Fatal(err)
-	}
-	marker := filepath.Join(externalTrash, "keep")
-	if err := os.WriteFile(marker, []byte("keep"), 0o644); err != nil {
-		t.Fatal(err)
-	}
-	d.envRootPreOpenHook = func(string) {
-		d.envRootPreOpenHook = nil
-		if err := os.Rename(originalRoot, movedRoot); err != nil {
-			t.Fatal(err)
-		}
-		if err := os.Symlink(externalRoot, originalRoot); err != nil {
-			t.Fatal(err)
-		}
-	}
-	d.runGC(context.Background())
-	if _, err := os.Stat(marker); err != nil {
-		t.Fatalf("full-cycle quarantine retry escaped pinned root: %v", err)
-	}
-}
+	root := d.cfg.WorkspacesRoot
 
-func TestRunGC_PreReservationRetargetUsesPinnedCycleIdentity(t *testing.T) {
-	d := newGCTestDaemon(t, http.NewServeMux())
-	d.cfg.GCOrphanTTL = 0
-	originalRoot := d.cfg.WorkspacesRoot
-	movedRoot := originalRoot + "-moved"
-	createTaskDir(t, originalRoot, "ws-cycle-pre-reservation", "task", nil)
-	externalRoot := t.TempDir()
-	externalTask := filepath.Join(externalRoot, "ws-cycle-pre-reservation", "task")
-	if err := os.MkdirAll(externalTask, 0o755); err != nil {
+	staleRoot := createTaskDir(t, root, "ws-stale", "task", nil)
+	staleMarker := filepath.Join(staleRoot, "keep")
+	if err := os.WriteFile(staleMarker, []byte("stale"), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	marker := filepath.Join(externalTask, "keep")
-	if err := os.WriteFile(marker, []byte("keep"), 0o644); err != nil {
-		t.Fatal(err)
-	}
-	d.gcBeforeApplyHook = func(string) {
-		d.gcBeforeApplyHook = nil
-		if err := os.Rename(originalRoot, movedRoot); err != nil {
-			t.Fatal(err)
-		}
-		if err := os.Symlink(externalRoot, originalRoot); err != nil {
-			t.Fatal(err)
-		}
-	}
-	d.runGC(context.Background())
-	if _, err := os.Stat(marker); err != nil {
-		t.Fatalf("pre-reservation full-cycle retarget mutated external root: %v", err)
-	}
-	if _, err := os.Stat(filepath.Join(movedRoot, "ws-cycle-pre-reservation", "task")); err != nil {
-		t.Fatalf("pinned cycle unexpectedly removed original task: %v", err)
-	}
-}
 
-func TestRunGC_CycleIdentityKeyBlocksABARetargetWithActiveClaimant(t *testing.T) {
-	d := newGCTestDaemon(t, http.NewServeMux())
-	d.cfg.GCOrphanTTL = 0
-	originalRoot := d.cfg.WorkspacesRoot
-	movedRoot := originalRoot + "-moved"
-	taskDir := createTaskDir(t, originalRoot, "ws-cycle-aba", "task", nil)
-	externalRoot := t.TempDir()
-	if err := os.MkdirAll(filepath.Join(externalRoot, "ws-cycle-aba", "task"), 0o755); err != nil {
+	predictedRoot := execenv.PredictRootDir(root, "ws-predicted", "task-predicted")
+	releasePredicted, ok := d.markActiveEnvRoot(context.Background(), predictedRoot)
+	if !ok {
+		t.Fatal("failed to claim absent predicted root")
+	}
+	defer releasePredicted()
+	if err := os.MkdirAll(predictedRoot, 0o755); err != nil {
 		t.Fatal(err)
 	}
-	var releaseClaim func()
-	d.gcAfterExpectedHook = func(string) {
-		d.gcAfterExpectedHook = nil
-		if err := os.Rename(originalRoot, movedRoot); err != nil {
-			t.Fatal(err)
-		}
-		if err := os.Symlink(externalRoot, originalRoot); err != nil {
-			t.Fatal(err)
-		}
-		var ok bool
-		releaseClaim, ok = d.markActiveEnvRoot(context.Background(), filepath.Join(movedRoot, "ws-cycle-aba", "task"))
-		if !ok {
-			t.Fatal("active claimant could not acquire pinned A task")
-		}
-		if err := os.Remove(originalRoot); err != nil {
-			t.Fatal(err)
-		}
-		if err := os.Rename(movedRoot, originalRoot); err != nil {
-			t.Fatal(err)
-		}
+	predictedMarker := filepath.Join(predictedRoot, "keep")
+	if err := os.WriteFile(predictedMarker, []byte("predicted"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	managedArtifact := filepath.Join(staleRoot, "codex-home", ".sandbox-bin")
+	if err := os.MkdirAll(managedArtifact, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	artifactMarker := filepath.Join(managedArtifact, "keep")
+	if err := os.WriteFile(artifactMarker, []byte("artifact"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	repoRef := filepath.Join(root, ".repos", "repo.git", "refs", "heads", "main")
+	if err := os.MkdirAll(filepath.Dir(repoRef), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(repoRef, []byte("deadbeef"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	trashMarker := filepath.Join(root, gcTrashDirName, "quarantine", "keep")
+	if err := os.MkdirAll(filepath.Dir(trashMarker), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(trashMarker, []byte("trash"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	var downstreamCalled atomic.Bool
+	d.gcBeforeApplyHook = func(string) { downstreamCalled.Store(true) }
+	d.envRootPreOpenHook = func(string) { downstreamCalled.Store(true) }
+	d.artifactCleanupHook = func(string) { downstreamCalled.Store(true) }
+
+	before, err := os.Stat(staleRoot)
+	if err != nil {
+		t.Fatal(err)
 	}
 	d.runGC(context.Background())
-	if releaseClaim == nil {
-		t.Fatal("A→B→A hook did not run")
+	after, err := os.Stat(staleRoot)
+	if err != nil {
+		t.Fatal(err)
 	}
-	defer releaseClaim()
-	if _, err := os.Stat(taskDir); err != nil {
-		t.Fatalf("active claimant A was mutated after A→B→A retarget: %v", err)
+	if !os.SameFile(before, after) {
+		t.Fatal("inactive stale root identity changed")
+	}
+	for _, marker := range []string{staleMarker, predictedMarker, artifactMarker, repoRef, trashMarker} {
+		if _, err := os.Stat(marker); err != nil {
+			t.Fatalf("runGC mutated %s: %v", marker, err)
+		}
+	}
+	if downstreamCalled.Load() {
+		t.Fatal("runGC invoked downstream discovery or mutation helper")
 	}
 }
 

--- a/server/internal/daemon/gc_test.go
+++ b/server/internal/daemon/gc_test.go
@@ -292,8 +292,11 @@ func TestCleanTaskDir_ActiveAfterDecisionPreservesDirectory(t *testing.T) {
 	if action := d.shouldCleanTaskDir(context.Background(), taskDir); action != gcActionClean {
 		t.Fatalf("expected initial gcActionClean, got %d", action)
 	}
-	d.markActiveEnvRoot(taskDir)
-	defer d.unmarkActiveEnvRoot(taskDir)
+	releaseActive, ok := d.markActiveEnvRoot(context.Background(), taskDir)
+	if !ok {
+		t.Fatal("failed to mark active env root")
+	}
+	defer releaseActive()
 	if d.cleanTaskDir(taskDir) {
 		t.Fatal("cleanup succeeded for active env root")
 	}
@@ -337,8 +340,11 @@ func TestGcWorkspace_ActiveAtFinalGateOnlyIncrementsSkipped(t *testing.T) {
 	taskDir := createTaskDir(t, d.cfg.WorkspacesRoot, "ws-active-final-gate", "task", &execenv.GCMeta{
 		IssueID: issueID, WorkspaceID: "ws-active-final-gate",
 	})
-	d.markActiveEnvRoot(taskDir)
-	defer d.unmarkActiveEnvRoot(taskDir)
+	releaseActive, ok := d.markActiveEnvRoot(context.Background(), taskDir)
+	if !ok {
+		t.Fatal("failed to mark active env root")
+	}
+	defer releaseActive()
 	stats := &gcStats{byPattern: map[string]int{}}
 	d.gcWorkspace(context.Background(), wsDir, stats)
 	if stats.skipped != 1 || stats.cleaned != 0 || stats.orphaned != 0 || stats.bytesReclaimed != 0 {
@@ -730,8 +736,11 @@ func TestShouldCleanTaskDir_ActiveEnvRootSkipsArtifactCleanup(t *testing.T) {
 		CompletedAt: time.Now().Add(-24 * time.Hour),
 	})
 
-	d.markActiveEnvRoot(taskDir)
-	defer d.unmarkActiveEnvRoot(taskDir)
+	releaseActive, ok := d.markActiveEnvRoot(context.Background(), taskDir)
+	if !ok {
+		t.Fatal("failed to mark active env root")
+	}
+	defer releaseActive()
 
 	if action := d.shouldCleanTaskDir(context.Background(), taskDir); action != gcActionSkip {
 		t.Fatalf("expected gcActionSkip while task is active, got %d", action)
@@ -763,8 +772,11 @@ func TestShouldCleanTaskDir_ActiveEnvRootSkipsFullCleanup(t *testing.T) {
 		CompletedAt: time.Now().Add(-30 * 24 * time.Hour),
 	})
 
-	d.markActiveEnvRoot(taskDir)
-	defer d.unmarkActiveEnvRoot(taskDir)
+	releaseActive, ok := d.markActiveEnvRoot(context.Background(), taskDir)
+	if !ok {
+		t.Fatal("failed to mark active env root")
+	}
+	defer releaseActive()
 
 	if action := d.shouldCleanTaskDir(context.Background(), taskDir); action != gcActionSkip {
 		t.Fatalf("expected gcActionSkip on active env root with done+stale issue, got %d", action)
@@ -789,8 +801,11 @@ func TestShouldCleanTaskDir_ActiveEnvRootSkipsOrphan404(t *testing.T) {
 		CompletedAt: time.Now(),
 	})
 
-	d.markActiveEnvRoot(taskDir)
-	defer d.unmarkActiveEnvRoot(taskDir)
+	releaseActive, ok := d.markActiveEnvRoot(context.Background(), taskDir)
+	if !ok {
+		t.Fatal("failed to mark active env root")
+	}
+	defer releaseActive()
 
 	if action := d.shouldCleanTaskDir(context.Background(), taskDir); action != gcActionSkip {
 		t.Fatalf("expected gcActionSkip on active env root with 404 issue, got %d", action)
@@ -804,8 +819,11 @@ func TestShouldCleanTaskDir_ActiveEnvRootSkipsNoMetaOrphan(t *testing.T) {
 	d.cfg.GCOrphanTTL = 0
 	taskDir := createTaskDir(t, d.cfg.WorkspacesRoot, "ws1", "active-no-meta", nil)
 
-	d.markActiveEnvRoot(taskDir)
-	defer d.unmarkActiveEnvRoot(taskDir)
+	releaseActive, ok := d.markActiveEnvRoot(context.Background(), taskDir)
+	if !ok {
+		t.Fatal("failed to mark active env root")
+	}
+	defer releaseActive()
 
 	if action := d.shouldCleanTaskDir(context.Background(), taskDir); action != gcActionSkip {
 		t.Fatalf("expected gcActionSkip on active env root with no-meta orphan, got %d", action)
@@ -1067,16 +1085,22 @@ func TestActiveEnvRootRefcount(t *testing.T) {
 	if d.isActiveEnvRoot(root) {
 		t.Fatal("expected inactive before mark")
 	}
-	d.markActiveEnvRoot(root)
-	d.markActiveEnvRoot(root) // second mark from reuse path
+	releaseFirst, ok := d.markActiveEnvRoot(context.Background(), root)
+	if !ok {
+		t.Fatal("first mark failed")
+	}
+	releaseSecond, ok := d.markActiveEnvRoot(context.Background(), root)
+	if !ok {
+		t.Fatal("second mark failed")
+	}
 	if !d.isActiveEnvRoot(root) {
 		t.Fatal("expected active after mark")
 	}
-	d.unmarkActiveEnvRoot(root)
+	releaseFirst()
 	if !d.isActiveEnvRoot(root) {
 		t.Fatal("expected still active after one unmark")
 	}
-	d.unmarkActiveEnvRoot(root)
+	releaseSecond()
 	if d.isActiveEnvRoot(root) {
 		t.Fatal("expected inactive after both unmarks")
 	}
@@ -1088,11 +1112,14 @@ func TestReserveEnvRootForGCIsExclusive(t *testing.T) {
 	d := newGCTestDaemon(t, http.NewServeMux())
 	root := "/tmp/fake/gc-reservation"
 
-	d.markActiveEnvRoot(root)
+	releaseActive, ok := d.markActiveEnvRoot(context.Background(), root)
+	if !ok {
+		t.Fatal("mark failed")
+	}
 	if _, ok := d.reserveEnvRootForGC(root); ok {
 		t.Fatal("GC reservation must fail while a task is active")
 	}
-	d.unmarkActiveEnvRoot(root)
+	releaseActive()
 
 	release, ok := d.reserveEnvRootForGC(root)
 	if !ok {
@@ -1127,8 +1154,13 @@ func TestEnvRootGCReservationBlocksConcurrentClaim(t *testing.T) {
 		reachedOnce.Do(func() { close(reachedGate) })
 	}
 	marked := make(chan struct{})
+	releaseClaim := make(chan func(), 1)
 	go func() {
-		d.markActiveEnvRoot(root)
+		releaseActive, markedOK := d.markActiveEnvRoot(context.Background(), root)
+		if !markedOK {
+			return
+		}
+		releaseClaim <- releaseActive
 		close(marked)
 	}()
 	select {
@@ -1147,7 +1179,7 @@ func TestEnvRootGCReservationBlocksConcurrentClaim(t *testing.T) {
 	case <-time.After(time.Second):
 		t.Fatal("concurrent claim did not resume after reservation release")
 	}
-	d.unmarkActiveEnvRoot(root)
+	(<-releaseClaim)()
 }
 
 func TestEnvRootGCReservationBlocksSymlinkAliasClaim(t *testing.T) {
@@ -1177,14 +1209,15 @@ func TestEnvRootGCReservationBlocksSymlinkAliasClaim(t *testing.T) {
 		<-reachedGate
 		cancel()
 	}()
-	if d.markActiveEnvRootContext(ctx, aliasTaskDir) {
+	if _, marked := d.markActiveEnvRoot(ctx, aliasTaskDir); marked {
 		t.Fatal("symlink alias bypassed reservation")
 	}
 	release()
-	if !d.markActiveEnvRootContext(context.Background(), aliasTaskDir) {
+	releaseAlias, marked := d.markActiveEnvRoot(context.Background(), aliasTaskDir)
+	if !marked {
 		t.Fatal("claim did not succeed after reservation release")
 	}
-	d.unmarkActiveEnvRoot(taskDir)
+	releaseAlias()
 }
 
 func TestEnvRootGCReservationWaitIsCancellable(t *testing.T) {
@@ -1198,8 +1231,162 @@ func TestEnvRootGCReservationWaitIsCancellable(t *testing.T) {
 	defer release()
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
-	if d.markActiveEnvRootContext(ctx, root) {
+	if _, marked := d.markActiveEnvRoot(ctx, root); marked {
 		t.Fatal("cancelled claimant entered reserved root")
+	}
+}
+
+func TestActiveEnvRootLeaseSurvivesSymlinkRetarget(t *testing.T) {
+	t.Parallel()
+	d := newGCTestDaemon(t, http.NewServeMux())
+	realOne := filepath.Join(t.TempDir(), "one")
+	realTwo := filepath.Join(t.TempDir(), "two")
+	if err := os.MkdirAll(realOne, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(realTwo, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	alias := filepath.Join(t.TempDir(), "alias")
+	if err := os.Symlink(realOne, alias); err != nil {
+		t.Skipf("symlink unsupported: %v", err)
+	}
+	releaseTwo, ok := d.markActiveEnvRoot(context.Background(), realTwo)
+	if !ok {
+		t.Fatal("failed to mark second root")
+	}
+	defer releaseTwo()
+	releaseAlias, ok := d.markActiveEnvRoot(context.Background(), alias)
+	if !ok {
+		t.Fatal("failed to mark alias")
+	}
+	if err := os.Remove(alias); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(realTwo, alias); err != nil {
+		t.Fatal(err)
+	}
+	releaseAlias()
+	if d.isActiveEnvRoot(realOne) {
+		t.Fatal("lease left originally acquired canonical key active")
+	}
+	if !d.isActiveEnvRoot(realTwo) {
+		t.Fatal("lease released retargeted root instead of acquired key")
+	}
+}
+
+func TestApplyGCAction_ManagedArtifactCleanupActiveAfterDecisionOnlyIncrementsSkipped(t *testing.T) {
+	t.Parallel()
+	d := newGCTestDaemon(t, http.NewServeMux())
+	taskDir := createTaskDir(t, d.cfg.WorkspacesRoot, "ws-managed-active", "task", nil)
+	artifactDir := filepath.Join(taskDir, "codex-home", ".sandbox-bin")
+	if err := os.MkdirAll(artifactDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	releaseActive, ok := d.markActiveEnvRoot(context.Background(), taskDir)
+	if !ok {
+		t.Fatal("failed to mark task root")
+	}
+	defer releaseActive()
+	stats := &gcStats{byPattern: map[string]int{}}
+	d.applyGCAction(taskDir, gcActionCleanManagedArtifacts, stats)
+	if stats.skipped != 1 || stats.artifactDirs != 0 || stats.artifactRemoved != 0 || stats.bytesReclaimed != 0 {
+		t.Fatalf("unexpected stats: %+v", stats)
+	}
+	if _, err := os.Stat(artifactDir); err != nil {
+		t.Fatalf("managed artifact removed after active claim: %v", err)
+	}
+}
+
+func TestApplyGCAction_ManagedArtifactCleanupBlocksConcurrentClaim(t *testing.T) {
+	t.Parallel()
+	d := newGCTestDaemon(t, http.NewServeMux())
+	taskDir := createTaskDir(t, d.cfg.WorkspacesRoot, "ws-managed-wait", "task", nil)
+	artifactDir := filepath.Join(taskDir, "codex-home", ".sandbox-bin")
+	payload := filepath.Join(artifactDir, "tool")
+	if err := os.MkdirAll(artifactDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(payload, []byte("managed"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	inCleanup := make(chan struct{})
+	releaseCleanup := make(chan struct{})
+	d.artifactCleanupHook = func(string) {
+		close(inCleanup)
+		<-releaseCleanup
+	}
+	reachedGate := make(chan struct{})
+	var once sync.Once
+	d.activeEnvRootWaitHook = func(string) { once.Do(func() { close(reachedGate) }) }
+	stats := &gcStats{byPattern: map[string]int{}}
+	cleanupDone := make(chan struct{})
+	go func() {
+		d.applyGCAction(taskDir, gcActionCleanManagedArtifacts, stats)
+		close(cleanupDone)
+	}()
+	<-inCleanup
+	claimed := make(chan struct{})
+	releaseClaim := make(chan func(), 1)
+	go func() {
+		releaseActive, ok := d.markActiveEnvRoot(context.Background(), taskDir)
+		if !ok {
+			return
+		}
+		releaseClaim <- releaseActive
+		close(claimed)
+	}()
+	<-reachedGate
+	select {
+	case <-claimed:
+		t.Fatal("claim passed while managed cleanup held reservation")
+	default:
+	}
+	close(releaseCleanup)
+	<-cleanupDone
+	<-claimed
+	(<-releaseClaim)()
+	if stats.skipped != 1 || stats.artifactDirs != 1 || stats.artifactRemoved != 1 ||
+		stats.bytesReclaimed != int64(len("managed")) ||
+		stats.byPattern["managed:codex-home/.sandbox-bin"] != 1 {
+		t.Fatalf("unexpected stats: %+v", stats)
+	}
+	if _, err := os.Stat(artifactDir); !os.IsNotExist(err) {
+		t.Fatalf("managed artifact should be removed before claim resumes: %v", err)
+	}
+}
+
+func TestCleanTaskDir_WorkspacesRootAncestorSwapCannotEscape(t *testing.T) {
+	t.Parallel()
+	d := newGCTestDaemon(t, http.NewServeMux())
+	taskDir := createTaskDir(t, d.cfg.WorkspacesRoot, "ws-root-swap", "task", nil)
+	originalRoot := d.cfg.WorkspacesRoot
+	movedRoot := originalRoot + "-moved"
+	externalRoot := t.TempDir()
+	externalTask := filepath.Join(externalRoot, "ws-root-swap", "task")
+	if err := os.MkdirAll(externalTask, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	marker := filepath.Join(externalTask, "keep")
+	if err := os.WriteFile(marker, []byte("keep"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	d.envRootQuarantineHook = func(string) {
+		if err := os.Rename(originalRoot, movedRoot); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.Symlink(externalRoot, originalRoot); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if !d.cleanTaskDir(taskDir) {
+		t.Fatal("fd-relative cleanup failed after root pathname swap")
+	}
+	if _, err := os.Stat(marker); err != nil {
+		t.Fatalf("whole-root cleanup escaped stable WorkspacesRoot: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(movedRoot, "ws-root-swap", "task")); !os.IsNotExist(err) {
+		t.Fatalf("original task root was not quarantined: %v", err)
 	}
 }
 
@@ -1245,8 +1432,11 @@ func TestApplyGCAction_ArtifactCleanupActiveAfterDecisionOnlyIncrementsSkipped(t
 	if err := os.MkdirAll(artifactDir, 0o755); err != nil {
 		t.Fatal(err)
 	}
-	d.markActiveEnvRoot(taskDir)
-	defer d.unmarkActiveEnvRoot(taskDir)
+	releaseActive, ok := d.markActiveEnvRoot(context.Background(), taskDir)
+	if !ok {
+		t.Fatal("failed to mark active env root")
+	}
+	defer releaseActive()
 	stats := &gcStats{byPattern: map[string]int{}}
 	d.applyGCAction(taskDir, gcActionCleanArtifacts, stats)
 	if stats.skipped != 1 || stats.artifactDirs != 0 || stats.artifactRemoved != 0 || stats.bytesReclaimed != 0 {
@@ -1282,8 +1472,13 @@ func TestApplyGCAction_ArtifactCleanupBlocksConcurrentClaim(t *testing.T) {
 	}()
 	<-inCleanup
 	claimed := make(chan struct{})
+	releaseClaim := make(chan func(), 1)
 	go func() {
-		d.markActiveEnvRoot(taskDir)
+		releaseActive, marked := d.markActiveEnvRoot(context.Background(), taskDir)
+		if !marked {
+			return
+		}
+		releaseClaim <- releaseActive
 		close(claimed)
 	}()
 	select {
@@ -1307,7 +1502,7 @@ func TestApplyGCAction_ArtifactCleanupBlocksConcurrentClaim(t *testing.T) {
 	case <-time.After(time.Second):
 		t.Fatal("claim did not resume after cleanup")
 	}
-	d.unmarkActiveEnvRoot(taskDir)
+	(<-releaseClaim)()
 	if stats.artifactRemoved != 1 || stats.skipped != 1 {
 		t.Fatalf("unexpected stats: %+v", stats)
 	}

--- a/server/internal/daemon/gc_test.go
+++ b/server/internal/daemon/gc_test.go
@@ -13,6 +13,7 @@ import (
 	"path/filepath"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -1111,6 +1112,10 @@ func TestReserveEnvRootForGCIsExclusive(t *testing.T) {
 
 	d := newGCTestDaemon(t, http.NewServeMux())
 	root := "/tmp/fake/gc-reservation"
+	if err := os.MkdirAll(root, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(root) })
 
 	releaseActive, ok := d.markActiveEnvRoot(context.Background(), root)
 	if !ok {
@@ -1141,6 +1146,9 @@ func TestEnvRootGCReservationBlocksConcurrentClaim(t *testing.T) {
 	t.Parallel()
 	d := newGCTestDaemon(t, http.NewServeMux())
 	root := filepath.Join(t.TempDir(), "reserved-env")
+	if err := os.MkdirAll(root, 0o755); err != nil {
+		t.Fatal(err)
+	}
 	release, ok := d.reserveEnvRootForGC(root)
 	if !ok {
 		t.Fatal("expected inactive env root GC reservation")
@@ -1220,10 +1228,42 @@ func TestEnvRootGCReservationBlocksSymlinkAliasClaim(t *testing.T) {
 	releaseAlias()
 }
 
+func TestEnvRootGCReservationBlocksCaseAliasClaim(t *testing.T) {
+	t.Parallel()
+	d := newGCTestDaemon(t, http.NewServeMux())
+	parent := t.TempDir()
+	root := filepath.Join(parent, "CaseSensitiveProbe")
+	if err := os.MkdirAll(root, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	alias := filepath.Join(parent, "casesensitiveprobe")
+	rootInfo, err := os.Stat(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	aliasInfo, err := os.Stat(alias)
+	if err != nil || !os.SameFile(rootInfo, aliasInfo) {
+		t.Skip("filesystem is case-sensitive")
+	}
+	release, ok := d.reserveEnvRootForGC(root)
+	if !ok {
+		t.Fatal("expected reservation")
+	}
+	defer release()
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	if _, marked := d.markActiveEnvRoot(ctx, alias); marked {
+		t.Fatal("case alias bypassed reservation")
+	}
+}
+
 func TestEnvRootGCReservationWaitIsCancellable(t *testing.T) {
 	t.Parallel()
 	d := newGCTestDaemon(t, http.NewServeMux())
 	root := filepath.Join(t.TempDir(), "task")
+	if err := os.MkdirAll(root, 0o755); err != nil {
+		t.Fatal(err)
+	}
 	release, ok := d.reserveEnvRootForGC(root)
 	if !ok {
 		t.Fatal("expected reservation")
@@ -1233,6 +1273,48 @@ func TestEnvRootGCReservationWaitIsCancellable(t *testing.T) {
 	cancel()
 	if _, marked := d.markActiveEnvRoot(ctx, root); marked {
 		t.Fatal("cancelled claimant entered reserved root")
+	}
+}
+
+func TestHandleTaskCancellationAbortsReservedRootWait(t *testing.T) {
+	t.Parallel()
+	taskID := "task-cancelled-at-root-gate"
+	workspaceID := "ws-cancelled-at-root-gate"
+	mux := http.NewServeMux()
+	mux.HandleFunc(fmt.Sprintf("/api/daemon/tasks/%s/status", taskID), func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]string{"status": "cancelled"})
+	})
+	d := newGCTestDaemon(t, mux)
+	d.cancelPollInterval = time.Millisecond
+	d.runtimeIndex["rt-1"] = Runtime{Provider: "claude"}
+	predicted := execenv.PredictRootDir(d.cfg.WorkspacesRoot, workspaceID, taskID)
+	if err := os.MkdirAll(predicted, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	releaseGC, ok := d.reserveEnvRootForGC(predicted)
+	if !ok {
+		t.Fatal("expected GC reservation")
+	}
+	defer releaseGC()
+	var runnerEntered atomic.Bool
+	d.runner = taskRunnerFunc(func(context.Context, Task, string, int, *slog.Logger) (TaskResult, error) {
+		runnerEntered.Store(true)
+		return TaskResult{}, nil
+	})
+	done := make(chan struct{})
+	go func() {
+		d.handleTask(context.Background(), Task{
+			ID: taskID, WorkspaceID: workspaceID, RuntimeID: "rt-1",
+		}, 0)
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("handleTask did not exit after server-side cancellation")
+	}
+	if runnerEntered.Load() {
+		t.Fatal("runner entered reserved root after cancellation")
 	}
 }
 
@@ -1387,6 +1469,87 @@ func TestCleanTaskDir_WorkspacesRootAncestorSwapCannotEscape(t *testing.T) {
 	}
 	if _, err := os.Stat(filepath.Join(movedRoot, "ws-root-swap", "task")); !os.IsNotExist(err) {
 		t.Fatalf("original task root was not quarantined: %v", err)
+	}
+}
+
+func TestApplyGCAction_PreOpenRetargetFailsClosed(t *testing.T) {
+	for _, action := range []gcAction{gcActionCleanArtifacts, gcActionCleanManagedArtifacts} {
+		action := action
+		t.Run(fmt.Sprintf("action-%d", action), func(t *testing.T) {
+			d := newGCTestDaemon(t, http.NewServeMux())
+			originalRoot := d.cfg.WorkspacesRoot
+			movedRoot := originalRoot + "-moved"
+			taskDir := createTaskDir(t, originalRoot, "ws-preopen", "task", nil)
+			normal := filepath.Join(taskDir, "node_modules")
+			managed := filepath.Join(taskDir, "codex-home", ".sandbox-bin")
+			if err := os.MkdirAll(normal, 0o755); err != nil {
+				t.Fatal(err)
+			}
+			if err := os.MkdirAll(managed, 0o755); err != nil {
+				t.Fatal(err)
+			}
+			externalRoot := t.TempDir()
+			externalTask := filepath.Join(externalRoot, "ws-preopen", "task")
+			externalNormal := filepath.Join(externalTask, "node_modules")
+			externalManaged := filepath.Join(externalTask, "codex-home", ".sandbox-bin")
+			if err := os.MkdirAll(externalNormal, 0o755); err != nil {
+				t.Fatal(err)
+			}
+			if err := os.MkdirAll(externalManaged, 0o755); err != nil {
+				t.Fatal(err)
+			}
+			marker := filepath.Join(externalTask, "keep")
+			if err := os.WriteFile(marker, []byte("keep"), 0o644); err != nil {
+				t.Fatal(err)
+			}
+			d.envRootPreOpenHook = func(string) {
+				d.envRootPreOpenHook = nil
+				if err := os.Rename(originalRoot, movedRoot); err != nil {
+					t.Fatal(err)
+				}
+				if err := os.Symlink(externalRoot, originalRoot); err != nil {
+					t.Fatal(err)
+				}
+			}
+			stats := &gcStats{byPattern: map[string]int{}}
+			d.applyGCAction(taskDir, action, stats)
+			if stats.artifactRemoved != 0 || stats.bytesReclaimed != 0 || stats.skipped != 1 {
+				t.Fatalf("unexpected fail-closed stats: %+v", stats)
+			}
+			if _, err := os.Stat(marker); err != nil {
+				t.Fatalf("pre-open retarget escaped reservation identity: %v", err)
+			}
+		})
+	}
+}
+
+func TestRunGC_QuarantineRetryUsesPinnedRoot(t *testing.T) {
+	d := newGCTestDaemon(t, http.NewServeMux())
+	d.cfg.GCOrphanTTL = 0
+	originalRoot := d.cfg.WorkspacesRoot
+	movedRoot := originalRoot + "-moved"
+	createTaskDir(t, originalRoot, "ws-cycle-swap", "task", nil)
+	externalRoot := t.TempDir()
+	externalTrash := filepath.Join(externalRoot, gcTrashDirName)
+	if err := os.MkdirAll(externalTrash, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	marker := filepath.Join(externalTrash, "keep")
+	if err := os.WriteFile(marker, []byte("keep"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	d.envRootPreOpenHook = func(string) {
+		d.envRootPreOpenHook = nil
+		if err := os.Rename(originalRoot, movedRoot); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.Symlink(externalRoot, originalRoot); err != nil {
+			t.Fatal(err)
+		}
+	}
+	d.runGC(context.Background())
+	if _, err := os.Stat(marker); err != nil {
+		t.Fatalf("full-cycle quarantine retry escaped pinned root: %v", err)
 	}
 }
 

--- a/server/internal/daemon/gc_test.go
+++ b/server/internal/daemon/gc_test.go
@@ -1036,6 +1036,85 @@ func TestEnvRootGCReservationBlocksConcurrentClaim(t *testing.T) {
 	d.unmarkActiveEnvRoot(root)
 }
 
+func TestApplyGCAction_ArtifactCleanupActiveAfterDecisionOnlyIncrementsSkipped(t *testing.T) {
+	t.Parallel()
+	d := newGCTestDaemon(t, http.NewServeMux())
+	taskDir := createTaskDir(t, d.cfg.WorkspacesRoot, "ws-artifact-race", "task", nil)
+	artifactDir := filepath.Join(taskDir, "node_modules")
+	if err := os.MkdirAll(artifactDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	d.markActiveEnvRoot(taskDir)
+	defer d.unmarkActiveEnvRoot(taskDir)
+	stats := &gcStats{byPattern: map[string]int{}}
+	d.applyGCAction(taskDir, gcActionCleanArtifacts, stats)
+	if stats.skipped != 1 || stats.artifactDirs != 0 || stats.artifactRemoved != 0 || stats.bytesReclaimed != 0 {
+		t.Fatalf("unexpected stats: %+v", stats)
+	}
+	if _, err := os.Stat(artifactDir); err != nil {
+		t.Fatalf("artifact dir removed after concurrent claim: %v", err)
+	}
+}
+
+func TestApplyGCAction_ArtifactCleanupBlocksConcurrentClaim(t *testing.T) {
+	t.Parallel()
+	d := newGCTestDaemon(t, http.NewServeMux())
+	taskDir := createTaskDir(t, d.cfg.WorkspacesRoot, "ws-artifact-wait", "task", nil)
+	artifactDir := filepath.Join(taskDir, "node_modules")
+	if err := os.MkdirAll(artifactDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	inCleanup := make(chan struct{})
+	releaseCleanup := make(chan struct{})
+	d.artifactCleanupHook = func(string) {
+		close(inCleanup)
+		<-releaseCleanup
+	}
+	reachedGate := make(chan struct{})
+	var reachedOnce sync.Once
+	d.activeEnvRootWaitHook = func(string) { reachedOnce.Do(func() { close(reachedGate) }) }
+	cleanupDone := make(chan struct{})
+	stats := &gcStats{byPattern: map[string]int{}}
+	go func() {
+		d.applyGCAction(taskDir, gcActionCleanArtifacts, stats)
+		close(cleanupDone)
+	}()
+	<-inCleanup
+	claimed := make(chan struct{})
+	go func() {
+		d.markActiveEnvRoot(taskDir)
+		close(claimed)
+	}()
+	select {
+	case <-reachedGate:
+	case <-time.After(time.Second):
+		t.Fatal("claim did not reach GC reservation gate")
+	}
+	select {
+	case <-claimed:
+		t.Fatal("claim passed while artifact cleanup was in flight")
+	default:
+	}
+	close(releaseCleanup)
+	select {
+	case <-cleanupDone:
+	case <-time.After(time.Second):
+		t.Fatal("artifact cleanup did not finish")
+	}
+	select {
+	case <-claimed:
+	case <-time.After(time.Second):
+		t.Fatal("claim did not resume after cleanup")
+	}
+	d.unmarkActiveEnvRoot(taskDir)
+	if stats.artifactRemoved != 1 || stats.skipped != 1 {
+		t.Fatalf("unexpected stats: %+v", stats)
+	}
+	if _, err := os.Stat(artifactDir); !os.IsNotExist(err) {
+		t.Fatalf("artifact dir should be removed before claim resumes: %v", err)
+	}
+}
+
 func TestIsBareRepo(t *testing.T) {
 	t.Parallel()
 

--- a/server/internal/daemon/gc_test.go
+++ b/server/internal/daemon/gc_test.go
@@ -2589,3 +2589,57 @@ func TestShouldCleanTaskDir_LocalDirectoryFalsePreservesNormalClean(t *testing.T
 		t.Fatalf("expected gcActionClean for normal task, got %d", got)
 	}
 }
+
+// TestRunGC_PrunesRepoWorktreesFromProductionEntryPoint pins that repo
+// worktree pruning is reachable from runGC again. The pinned-root traversal
+// added for the GC race must not silently drop the pruning step: without the
+// call, stale `agent/` branches accumulate in the bare cache forever.
+func TestRunGC_PrunesRepoWorktreesFromProductionEntryPoint(t *testing.T) {
+	t.Parallel()
+
+	d := newGCTestDaemon(t, http.NewServeMux())
+	sourceRepo := createGCGitRepo(t)
+	barePath := filepath.Join(d.cfg.WorkspacesRoot, repoCacheDirName, "ws-1", "cache.git")
+	if err := os.MkdirAll(filepath.Dir(barePath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	runGitForGC(t, "", "clone", "--bare", sourceRepo, barePath)
+	staleBranch := "agent/stale/87654321"
+	runGitForGC(t, "", "-C", barePath, "branch", staleBranch, "HEAD")
+
+	d.runGC(context.Background())
+
+	if gitRefExists(t, barePath, "refs/heads/"+staleBranch) {
+		t.Fatalf("expected runGC to prune stale branch %q from the repo cache", staleBranch)
+	}
+}
+
+// TestRunGC_SkipsRepoCacheOutsidePinnedRoot is the regression for the pathname
+// escape: git only takes pathnames, so the repo cache must be reached
+// fd-relative from the cycle's pinned root. With `.repos` replaced by a
+// symlink to a foreign tree, GC must skip pruning entirely instead of deleting
+// branches in whatever the link points at.
+func TestRunGC_SkipsRepoCacheOutsidePinnedRoot(t *testing.T) {
+	t.Parallel()
+
+	d := newGCTestDaemon(t, http.NewServeMux())
+	sourceRepo := createGCGitRepo(t)
+	externalCache := t.TempDir()
+	barePath := filepath.Join(externalCache, "ws-1", "cache.git")
+	if err := os.MkdirAll(filepath.Dir(barePath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	runGitForGC(t, "", "clone", "--bare", sourceRepo, barePath)
+	staleBranch := "agent/stale/87654321"
+	runGitForGC(t, "", "-C", barePath, "branch", staleBranch, "HEAD")
+
+	if err := os.Symlink(externalCache, filepath.Join(d.cfg.WorkspacesRoot, repoCacheDirName)); err != nil {
+		t.Skipf("symlink unsupported: %v", err)
+	}
+
+	d.runGC(context.Background())
+
+	if !gitRefExists(t, barePath, "refs/heads/"+staleBranch) {
+		t.Fatalf("branch %q outside the pinned root was pruned through a symlinked repo cache", staleBranch)
+	}
+}

--- a/server/internal/daemon/leader_workdir_reuse_test.go
+++ b/server/internal/daemon/leader_workdir_reuse_test.go
@@ -84,6 +84,49 @@ func TestRunTaskSquadLeaderDoesNotReuseExternalPriorWorkdir(t *testing.T) {
 	}
 }
 
+func TestRunTaskPriorWorkdirRetargetAfterLeaseFailsClosed(t *testing.T) {
+	t.Parallel()
+	d, _, cleanup := newLeaderReuseTestDaemon(t)
+	defer cleanup()
+	first := leaderReuseTestTask("alpha-retarget-first")
+	first.IsLeaderTask = false
+	firstResult, err := d.runTask(context.Background(), first, "claude", 0, d.logger)
+	if err != nil {
+		t.Fatal(err)
+	}
+	priorRoot := firstResult.EnvRoot
+	movedRoot := priorRoot + "-moved"
+	externalRoot := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(externalRoot, "workdir"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	hookRan := false
+	d.envRootPreOpenHook = func(string) {
+		d.envRootPreOpenHook = nil
+		hookRan = true
+		if err := os.Rename(priorRoot, movedRoot); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.Symlink(externalRoot, priorRoot); err != nil {
+			t.Fatal(err)
+		}
+	}
+	second := leaderReuseTestTask("beta-retarget-second")
+	second.IsLeaderTask = false
+	second.PriorWorkDir = firstResult.WorkDir
+	second.PriorSessionID = firstResult.SessionID
+	secondResult, err := d.runTask(context.Background(), second, "claude", 0, d.logger)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !hookRan {
+		t.Fatal("retarget hook did not run")
+	}
+	if secondResult.WorkDir == firstResult.WorkDir || secondResult.EnvRoot == externalRoot {
+		t.Fatalf("retargeted prior workdir was reused: %+v", secondResult)
+	}
+}
+
 // TestShouldReusePriorWorkdirNonLeaderReusesUnchanged locks the refactor's
 // non-leader branch: the leader-only provenance/marker gate must not touch the
 // pre-existing behavior where any non-local prior workdir is reused.

--- a/server/internal/daemon/leader_workdir_reuse_test.go
+++ b/server/internal/daemon/leader_workdir_reuse_test.go
@@ -24,7 +24,7 @@ import (
 // hinge on the Prepare-time .managed_env.json provenance, not the terminal GC
 // file. runTask writes that provenance via execenv.Prepare; this test never
 // writes .gc_meta.json, so it fails against the pre-fix GC-meta-keyed gate.
-func TestRunTaskSquadLeaderReusesWorkdirBeforeGCMetaWritten(t *testing.T) {
+func TestRunTaskSquadLeaderReuseFailsClosedWithoutObjectBoundContract(t *testing.T) {
 	t.Parallel()
 
 	d, argsFile, cleanup := newLeaderReuseTestDaemon(t)
@@ -52,15 +52,15 @@ func TestRunTaskSquadLeaderReusesWorkdirBeforeGCMetaWritten(t *testing.T) {
 	if err != nil {
 		t.Fatalf("second runTask: %v", err)
 	}
-	if secondResult.WorkDir != firstResult.WorkDir {
-		t.Fatalf("second WorkDir = %q, want reused leader workdir %q", secondResult.WorkDir, firstResult.WorkDir)
+	if secondResult.WorkDir == firstResult.WorkDir {
+		t.Fatalf("second task reused pathname-only prior workdir %q", firstResult.WorkDir)
 	}
 	args, err := os.ReadFile(argsFile)
 	if err != nil {
 		t.Fatalf("read claude args: %v", err)
 	}
-	if !strings.Contains(string(args), "--resume\nsession-leader-reuse\n") {
-		t.Fatalf("second claude invocation did not resume prior session; args:\n%s", args)
+	if strings.Contains(string(args), "--resume\nsession-leader-reuse\n") {
+		t.Fatalf("second claude invocation resumed without object-bound reuse; args:\n%s", args)
 	}
 }
 

--- a/server/internal/daemon/leader_workdir_reuse_test.go
+++ b/server/internal/daemon/leader_workdir_reuse_test.go
@@ -24,7 +24,7 @@ import (
 // hinge on the Prepare-time .managed_env.json provenance, not the terminal GC
 // file. runTask writes that provenance via execenv.Prepare; this test never
 // writes .gc_meta.json, so it fails against the pre-fix GC-meta-keyed gate.
-func TestRunTaskSquadLeaderReuseFailsClosedWithoutObjectBoundContract(t *testing.T) {
+func TestRunTaskSquadLeaderReusesWorkdirBeforeGCMetaWritten(t *testing.T) {
 	t.Parallel()
 
 	d, argsFile, cleanup := newLeaderReuseTestDaemon(t)
@@ -52,15 +52,15 @@ func TestRunTaskSquadLeaderReuseFailsClosedWithoutObjectBoundContract(t *testing
 	if err != nil {
 		t.Fatalf("second runTask: %v", err)
 	}
-	if secondResult.WorkDir == firstResult.WorkDir {
-		t.Fatalf("second task reused pathname-only prior workdir %q", firstResult.WorkDir)
+	if secondResult.WorkDir != firstResult.WorkDir {
+		t.Fatalf("second WorkDir = %q, want reused leader workdir %q", secondResult.WorkDir, firstResult.WorkDir)
 	}
 	args, err := os.ReadFile(argsFile)
 	if err != nil {
 		t.Fatalf("read claude args: %v", err)
 	}
-	if strings.Contains(string(args), "--resume\nsession-leader-reuse\n") {
-		t.Fatalf("second claude invocation resumed without object-bound reuse; args:\n%s", args)
+	if !strings.Contains(string(args), "--resume\nsession-leader-reuse\n") {
+		t.Fatalf("second claude invocation did not resume prior session; args:\n%s", args)
 	}
 }
 

--- a/server/internal/daemon/leader_workdir_reuse_test.go
+++ b/server/internal/daemon/leader_workdir_reuse_test.go
@@ -84,6 +84,35 @@ func TestRunTaskSquadLeaderDoesNotReuseExternalPriorWorkdir(t *testing.T) {
 	}
 }
 
+func TestRunTaskFreshPrepareSamePriorPathDoesNotResumeSession(t *testing.T) {
+	t.Parallel()
+
+	d, argsFile, cleanup := newLeaderReuseTestDaemon(t)
+	defer cleanup()
+
+	task := leaderReuseTestTask("task-fresh-same-path")
+	task.PriorWorkDir = filepath.Join(
+		execenv.PredictRootDir(d.cfg.WorkspacesRoot, task.WorkspaceID, task.ID),
+		"workdir",
+	)
+	task.PriorSessionID = "session-must-not-resume"
+
+	result, err := d.runTask(context.Background(), task, "claude", 0, d.logger)
+	if err != nil {
+		t.Fatalf("runTask: %v", err)
+	}
+	if result.WorkDir != task.PriorWorkDir {
+		t.Fatalf("fresh Prepare workdir = %q, want same pathname %q", result.WorkDir, task.PriorWorkDir)
+	}
+	args, err := os.ReadFile(argsFile)
+	if err != nil {
+		t.Fatalf("read claude args: %v", err)
+	}
+	if strings.Contains(string(args), "--resume\nsession-must-not-resume\n") {
+		t.Fatalf("fresh Prepare resumed session from pathname equality; args:\n%s", args)
+	}
+}
+
 func TestRunTaskPriorWorkdirRetargetAfterLeaseFailsClosed(t *testing.T) {
 	t.Parallel()
 	d, _, cleanup := newLeaderReuseTestDaemon(t)

--- a/server/internal/daemon/workdir_race_test.go
+++ b/server/internal/daemon/workdir_race_test.go
@@ -489,8 +489,11 @@ func TestHandleTask_KeepsEnvRootActiveAcrossCompletion(t *testing.T) {
 	// isActiveEnvRoot back to false before reportTaskResult fires.
 	d.runner = taskRunnerFunc(func(_ context.Context, tk Task, _ string, _ int, _ *slog.Logger) (TaskResult, error) {
 		predicted := execenv.PredictRootDir(d.cfg.WorkspacesRoot, tk.WorkspaceID, tk.ID)
-		d.markActiveEnvRoot(predicted)
-		defer d.unmarkActiveEnvRoot(predicted)
+		releaseActive, ok := d.markActiveEnvRoot(context.Background(), predicted)
+		if !ok {
+			t.Fatal("failed to mark active env root")
+		}
+		defer releaseActive()
 		return TaskResult{
 			Status:  "completed",
 			EnvRoot: predicted,


### PR DESCRIPTION
## Summary

- close daemon GC TOCTOU between lifecycle decision and whole-root removal
- atomically quarantine inactive roots before delete so partial removal cannot be reused
- keep final-gate skip/error statistics accurate

## Root cause

`shouldCleanTaskDir` sampled `activeEnvRoots`, then released its mutex. `gcWorkspace` later ran whole-root deletion. A follow-up task reusing a stale terminal issue root could claim it after the decision snapshot but before removal.

Initial reservation fixed active-first ordering, but review found a second failure path: partial `RemoveAll` failure could release a waiting claimant onto a damaged `PriorWorkDir`.

## Fix

- per-root reservation linearizes claim vs deletion without holding global mutex during filesystem I/O
- delete-first path atomically renames root under verified non-symlink `.gc-trash` before removal
- after partial removal failure, original `PriorWorkDir` is absent and `execenv.Reuse` returns nil; caller falls back to fresh `Prepare`
- failed quarantines are retried by later GC cycles
- rename/quarantine failure is fail-closed

## Regression coverage

- decision → follow-up active mark → final removal skip
- deterministic waiter-at-reservation handshake; no negative timing assertion
- partial removal error leaves original path non-reusable and `Reuse == nil`
- `gcWorkspace` active/error paths increment `skipped` only; no cleaned/orphaned/bytes count
- symlinked trash root fails closed

## Verification

- focused GC/failure/race suite: `-race -count=10` PASS
- `go test ./internal/daemon -race -count=1` PASS
- `go vet ./internal/daemon` PASS
- `git diff --check` PASS

## Commit / rollback

- commit: `0351d4991`
- rollback: revert this single daemon commit

## Release gate

Fresh 3-point code/security re-review, separate merge approval, test-profile canary, controlled runtime rollout, fresh long-running task plus forced test-GC smoke, then monitoring. No merge/release/deploy without approval.

Tracking: KAP-672
