### PR TITLE
feat(helm): add per-component affinity and tolerations

### DIFF
--- a/deploy/helm/multica/templates/backend.yaml
+++ b/deploy/helm/multica/templates/backend.yaml
@@ -104,6 +104,14 @@ spec:
             periodSeconds: 30
           resources:
             {{- toYaml .Values.backend.resources | nindent 12 }}
+      {{- with .Values.backend.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.backend.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- if .Values.backend.uploads.persistence.enabled }}
       volumes:
         - name: uploads

--- a/deploy/helm/multica/templates/frontend.yaml
+++ b/deploy/helm/multica/templates/frontend.yaml
@@ -33,6 +33,14 @@ spec:
               value: "3000"
           resources:
             {{- toYaml .Values.frontend.resources | nindent 12 }}
+      {{- with .Values.frontend.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.frontend.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
 ---
 apiVersion: v1
 kind: Service

--- a/deploy/helm/multica/templates/postgres.yaml
+++ b/deploy/helm/multica/templates/postgres.yaml
@@ -77,6 +77,14 @@ spec:
             periodSeconds: 5
           resources:
             {{- toYaml .Values.postgres.resources | nindent 12 }}
+      {{- with .Values.postgres.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.postgres.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       volumes:
         - name: data
           persistentVolumeClaim:

--- a/deploy/helm/multica/values.yaml
+++ b/deploy/helm/multica/values.yaml
@@ -68,6 +68,9 @@ postgres:
     limits:
       cpu: 1000m
       memory: 1Gi
+  # Standard Kubernetes scheduling constraints for the postgres Deployment.
+  affinity: {}
+  tolerations: []
 
 # -----------------------------------------------------------------------------
 # Backend (Go API + WS server)
@@ -135,6 +138,9 @@ backend:
     limits:
       cpu: 1000m
       memory: 1Gi
+  # Standard Kubernetes scheduling constraints for the backend Deployment.
+  affinity: {}
+  tolerations: []
 
 # -----------------------------------------------------------------------------
 # Frontend (Next.js standalone)
@@ -162,6 +168,9 @@ frontend:
     limits:
       cpu: 1000m
       memory: 1Gi
+  # Standard Kubernetes scheduling constraints for the frontend Deployment.
+  affinity: {}
+  tolerations: []
 
 # -----------------------------------------------------------------------------
 # Ingress


### PR DESCRIPTION
## What does this PR do?

Allow scheduling backend, frontend, and postgres pods onto tainted or labeled nodes independently via values.yaml.


## Related Issue

Closes #5488

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Refactor / code improvement (no behavior change)
- [ ] Documentation update
- [ ] Tests (adding or improving test coverage)
- [x] CI / infrastructure

## Changes Made

- `deploy/helm/multica/templates/backend.yaml`
- `deploy/helm/multica/templates/frontend.yaml`
- `deploy/helm/multica/templates/postgres.yaml`
- `deploy/helm/multica/values.yaml`

## How to Test

1. **Test backend**:
```bash
helm template example deploy/helm/multica \
  --set 'backend.tolerations[0].key=dedicated' \
  --set 'backend.tolerations[0].operator=Equal' \
  --set 'backend.tolerations[0].value=backend' \
  --set 'backend.tolerations[0].effect=NoSchedule' \
  --set 'backend.affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms[0].matchExpressions[0].key=kubernetes.io/hostname' \
  --set 'backend.affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms[0].matchExpressions[0].operator=In' \
  --set 'backend.affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms[0].matchExpressions[0].values[0]=node-1' \
  --show-only templates/backend.yaml
```
2. **Test frontend**
```bash
helm template example deploy/helm/multica \
  --set 'frontend.tolerations[0].key=dedicated' \
  --set 'frontend.tolerations[0].operator=Equal' \
  --set 'frontend.tolerations[0].value=frontend' \
  --set 'frontend.tolerations[0].effect=NoSchedule' \
  --set 'frontend.affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms[0].matchExpressions[0].key=kubernetes.io/hostname' \
  --set 'frontend.affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms[0].matchExpressions[0].operator=In' \
  --set 'frontend.affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms[0].matchExpressions[0].values[0]=node-1' \
  --show-only templates/frontend.yaml
```

3. **Test postgres**
```bash
helm template example deploy/helm/multica \
  --set 'postgres.tolerations[0].key=dedicated' \
  --set 'postgres.tolerations[0].operator=Equal' \
  --set 'postgres.tolerations[0].value=psql' \
  --set 'postgres.tolerations[0].effect=NoSchedule' \
  --set 'postgres.affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms[0].matchExpressions[0].key=kubernetes.io/hostname' \
  --set 'postgres.affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms[0].matchExpressions[0].operator=In' \
  --set 'postgres.affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms[0].matchExpressions[0].values[0]=node-1' \
  --show-only templates/postgres.yaml
```

## Checklist

- [ ] I have included a thinking path that traces from project context to this change
- [ ] I have run tests locally and they pass
- [ ] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [ ] I have updated relevant documentation to reflect my changes
- [ ] If I added a new runtime / coding tool / UI tab, I synced the change to **landing copy** (`apps/web/features/landing/i18n/`) and **relevant docs** (`apps/docs/content/docs/`)
- [ ] If this PR touches Chinese product copy, I checked it against `apps/docs/content/docs/developers/conventions.zh.mdx` (terminology, mixed-rule for `task` / `issue` / `skill`)
- [x] I have considered and documented any risks above
- [x] I will address all reviewer comments before requesting merge

## AI Disclosure

<!-- Most PRs involve AI coding tools — that's totally fine! We're curious about your process. -->

**AI tool used:** N/A

**Prompt / approach:** N/A

## Screenshots (optional)

N/A
