### PR TITLE
fix(issues): render create picker trigger content

### DIFF
--- a/packages/views/issues/components/pickers/assignee-picker.tsx
+++ b/packages/views/issues/components/pickers/assignee-picker.tsx
@@ -66,10 +66,12 @@ interface AssigneePickerProps {
  * itself), so trigger-less callers stay eager.
  */
 export function AssigneePicker(props: AssigneePickerProps) {
+  const hasDeferredTriggerContent =
+    props.trigger !== undefined || props.triggerRender?.props.children != null;
   const canDefer =
     props.open === undefined &&
     props.onOpenChange === undefined &&
-    (props.trigger !== undefined || props.triggerRender !== undefined);
+    hasDeferredTriggerContent;
   if (!canDefer) {
     return <AssigneePickerImpl {...props} />;
   }

--- a/packages/views/issues/components/pickers/deferred-trigger.test.tsx
+++ b/packages/views/issues/components/pickers/deferred-trigger.test.tsx
@@ -1,0 +1,55 @@
+// @vitest-environment jsdom
+
+import { cleanup, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { renderWithI18n } from "../../../test/i18n";
+import { PillButton } from "../../../common/pill-button";
+import { AssigneePicker } from "./assignee-picker";
+import { PriorityPicker } from "./priority-picker";
+
+vi.mock("@tanstack/react-query", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@tanstack/react-query")>()),
+  useQuery: () => ({ data: [] }),
+}));
+
+vi.mock("@multica/core/auth", () => ({
+  useAuthStore: (selector: (state: { user: null }) => unknown) =>
+    selector({ user: null }),
+}));
+
+vi.mock("@multica/core/hooks", () => ({
+  useWorkspaceId: () => "workspace-1",
+}));
+
+vi.mock("@multica/core/workspace/hooks", () => ({
+  useActorName: () => ({ getActorName: () => "Unknown" }),
+}));
+
+afterEach(cleanup);
+
+describe("deferred picker triggers", () => {
+  it("renders generated content when triggerRender only supplies an empty shell", () => {
+    renderWithI18n(
+      <>
+        <PriorityPicker
+          priority="none"
+          onUpdate={() => {}}
+          triggerRender={<PillButton />}
+        />
+        <AssigneePicker
+          assigneeType={null}
+          assigneeId={null}
+          onUpdate={() => {}}
+          triggerRender={<PillButton />}
+        />
+      </>,
+    );
+
+    expect(
+      screen.getByRole("button", { name: "No priority" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Unassigned" }),
+    ).toBeInTheDocument();
+  });
+});

--- a/packages/views/issues/components/pickers/priority-picker.tsx
+++ b/packages/views/issues/components/pickers/priority-picker.tsx
@@ -33,11 +33,13 @@ interface PriorityPickerProps {
  * on first interaction. See `DeferredPopup` for why.
  */
 export function PriorityPicker(props: PriorityPickerProps) {
+  const hasDeferredTriggerContent =
+    props.trigger !== undefined || props.triggerRender?.props.children != null;
   const canDefer =
     props.open === undefined &&
     props.onOpenChange === undefined &&
     !props.defaultOpen &&
-    (props.trigger !== undefined || props.triggerRender !== undefined);
+    hasDeferredTriggerContent;
   if (!canDefer) {
     return <PriorityPickerImpl {...props} />;
   }


### PR DESCRIPTION
## Summary

- keep priority and assignee pickers eager when an empty `triggerRender` shell relies on picker-generated content
- preserve deferred popup mounting for callers that provide their own visible trigger content
- add regression coverage for the manual create-issue property pills

## Root cause

The popup deferral added in #5403 treated the presence of `triggerRender` as sufficient to render a cold trigger. The manual create-issue dialog passes an empty `PillButton` shell and relies on each picker to generate its children, so the deferred branch cloned an undefined `trigger` into the shell and rendered two empty pills.

## Impact

Restores the priority and assignee controls in the manual create-issue dialog without removing the board/list picker mounting optimization.

## Validation

- `pnpm --filter @multica/views exec vitest run issues/components/pickers/deferred-trigger.test.tsx`
- `pnpm --filter @multica/views typecheck`
- ESLint on the changed picker and test files
- `git diff --check`
