### PR TITLE
fix(comments): cap completion-fallback comment synthesized from raw output (#5455)

### DIFF
--- a/server/internal/service/fallback_comment_truncate_test.go
+++ b/server/internal/service/fallback_comment_truncate_test.go
@@ -1,7 +1,6 @@
 package service
 
 import (
-	"strconv"
 	"strings"
 	"testing"
 	"unicode/utf8"
@@ -30,15 +29,17 @@ func TestTruncateFallbackCommentBody(t *testing.T) {
 		}
 	})
 
-	t.Run("raw execution-stream dump is truncated to head plus marker", func(t *testing.T) {
+	t.Run("raw execution-stream dump is replaced with a safe notice", func(t *testing.T) {
 		t.Parallel()
 		// Reproduce the reporter's fingerprint: first-turn narration followed by
-		// hundreds of repeated `tool call` lines — the shape a 200KB+ dump takes.
+		// hundreds of repeated `tool call` lines and a tail answer — the shape a
+		// 200KB+ dump takes. None of that untrusted output may reach the comment.
 		var b strings.Builder
 		b.WriteString("I'll start by reading the issue context and the relevant files.\n")
 		for i := 0; i < 40000; i++ {
 			b.WriteString("tool call\n")
 		}
+		b.WriteString("FINAL ANSWER THAT MUST NOT BE MISTAKEN FOR TRUSTED OUTPUT")
 		dump := b.String()
 		if utf8.RuneCountInString(dump) < 200_000 {
 			t.Fatalf("test fixture too small: %d runes", utf8.RuneCountInString(dump))
@@ -46,21 +47,19 @@ func TestTruncateFallbackCommentBody(t *testing.T) {
 
 		got := truncateFallbackCommentBody(dump, maxSynthesizedFallbackCommentRunes)
 
-		// The stored comment must be bounded, not the multi-hundred-KB tail.
-		if n := utf8.RuneCountInString(got); n > maxSynthesizedFallbackCommentRunes+256 {
-			t.Fatalf("truncated body still too large: %d runes", n)
+		if n := utf8.RuneCountInString(got); n > 256 {
+			t.Fatalf("safe notice is unexpectedly large: %d runes", n)
 		}
-		// The head — the actual narration — is preserved.
-		if !strings.HasPrefix(got, "I'll start by reading the issue context") {
-			t.Fatalf("head narration lost: %q", got[:60])
+		for _, leaked := range []string{"I'll start", "tool call", "FINAL ANSWER"} {
+			if strings.Contains(got, leaked) {
+				t.Fatalf("safe notice leaked raw output %q: %q", leaked, got)
+			}
 		}
-		// A truncation marker naming the omitted length is appended.
-		if !strings.Contains(got, "output truncated") {
-			t.Fatalf("truncation marker missing: %q", got[len(got)-120:])
+		if !strings.Contains(got, "not posted") {
+			t.Fatalf("safe notice does not explain that output was withheld: %q", got)
 		}
-		omitted := utf8.RuneCountInString(dump) - maxSynthesizedFallbackCommentRunes
-		if !strings.Contains(got, strconv.Itoa(omitted)) {
-			t.Fatalf("omitted-count %d not reported in marker: %q", omitted, got[len(got)-160:])
+		if !strings.Contains(got, "Execution log") {
+			t.Fatalf("safe notice does not direct the user to the task run: %q", got)
 		}
 	})
 
@@ -72,11 +71,14 @@ func TestTruncateFallbackCommentBody(t *testing.T) {
 		if got := truncateFallbackCommentBody(body, maxSynthesizedFallbackCommentRunes); got != body {
 			t.Fatalf("multibyte body at rune cap was wrongly truncated")
 		}
-		// One rune over the cap truncates and never splits a rune.
+		// One rune over the cap is replaced rather than leaking a raw excerpt.
 		over := strings.Repeat("你", maxSynthesizedFallbackCommentRunes+10)
 		got := truncateFallbackCommentBody(over, maxSynthesizedFallbackCommentRunes)
 		if !utf8.ValidString(got) {
-			t.Fatalf("truncation split a multibyte rune, produced invalid UTF-8")
+			t.Fatalf("safe notice is invalid UTF-8")
+		}
+		if strings.Contains(got, "你") {
+			t.Fatalf("safe notice leaked a multibyte raw-output excerpt")
 		}
 	})
 }

--- a/server/internal/service/fallback_comment_truncate_test.go
+++ b/server/internal/service/fallback_comment_truncate_test.go
@@ -1,0 +1,82 @@
+package service
+
+import (
+	"strconv"
+	"strings"
+	"testing"
+	"unicode/utf8"
+)
+
+// TestTruncateFallbackCommentBody pins the completion-fallback comment cap that
+// keeps a runaway raw-stream Output off the issue thread (GH #5455).
+func TestTruncateFallbackCommentBody(t *testing.T) {
+	t.Parallel()
+
+	t.Run("short body passes through unchanged", func(t *testing.T) {
+		t.Parallel()
+		// A real final message — multi-line, well under the cap — must be stored
+		// verbatim, newlines intact (unlike the summary flattening path).
+		body := "I fixed the bug in the parser.\n\n- root cause: off-by-one\n- added a regression test"
+		if got := truncateFallbackCommentBody(body, maxSynthesizedFallbackCommentRunes); got != body {
+			t.Fatalf("short body was altered:\n got: %q\nwant: %q", got, body)
+		}
+	})
+
+	t.Run("body exactly at the cap is untouched", func(t *testing.T) {
+		t.Parallel()
+		body := strings.Repeat("x", maxSynthesizedFallbackCommentRunes)
+		if got := truncateFallbackCommentBody(body, maxSynthesizedFallbackCommentRunes); got != body {
+			t.Fatalf("body at cap was truncated: len(got)=%d", utf8.RuneCountInString(got))
+		}
+	})
+
+	t.Run("raw execution-stream dump is truncated to head plus marker", func(t *testing.T) {
+		t.Parallel()
+		// Reproduce the reporter's fingerprint: first-turn narration followed by
+		// hundreds of repeated `tool call` lines — the shape a 200KB+ dump takes.
+		var b strings.Builder
+		b.WriteString("I'll start by reading the issue context and the relevant files.\n")
+		for i := 0; i < 40000; i++ {
+			b.WriteString("tool call\n")
+		}
+		dump := b.String()
+		if utf8.RuneCountInString(dump) < 200_000 {
+			t.Fatalf("test fixture too small: %d runes", utf8.RuneCountInString(dump))
+		}
+
+		got := truncateFallbackCommentBody(dump, maxSynthesizedFallbackCommentRunes)
+
+		// The stored comment must be bounded, not the multi-hundred-KB tail.
+		if n := utf8.RuneCountInString(got); n > maxSynthesizedFallbackCommentRunes+256 {
+			t.Fatalf("truncated body still too large: %d runes", n)
+		}
+		// The head — the actual narration — is preserved.
+		if !strings.HasPrefix(got, "I'll start by reading the issue context") {
+			t.Fatalf("head narration lost: %q", got[:60])
+		}
+		// A truncation marker naming the omitted length is appended.
+		if !strings.Contains(got, "output truncated") {
+			t.Fatalf("truncation marker missing: %q", got[len(got)-120:])
+		}
+		omitted := utf8.RuneCountInString(dump) - maxSynthesizedFallbackCommentRunes
+		if !strings.Contains(got, strconv.Itoa(omitted)) {
+			t.Fatalf("omitted-count %d not reported in marker: %q", omitted, got[len(got)-160:])
+		}
+	})
+
+	t.Run("cap counts runes not bytes for multibyte content", func(t *testing.T) {
+		t.Parallel()
+		// A body of maxRunes multibyte runes is > maxRunes bytes but == maxRunes
+		// runes, so it must NOT be truncated — the boundary is rune-based.
+		body := strings.Repeat("你", maxSynthesizedFallbackCommentRunes)
+		if got := truncateFallbackCommentBody(body, maxSynthesizedFallbackCommentRunes); got != body {
+			t.Fatalf("multibyte body at rune cap was wrongly truncated")
+		}
+		// One rune over the cap truncates and never splits a rune.
+		over := strings.Repeat("你", maxSynthesizedFallbackCommentRunes+10)
+		got := truncateFallbackCommentBody(over, maxSynthesizedFallbackCommentRunes)
+		if !utf8.ValidString(got) {
+			t.Fatalf("truncation split a multibyte rune, produced invalid UTF-8")
+		}
+	})
+}

--- a/server/internal/service/task.go
+++ b/server/internal/service/task.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"sync"
 	"time"
+	"unicode/utf8"
 
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgtype"
@@ -116,34 +117,30 @@ func truncateForSummary(s string, maxRunes int) string {
 	return string(rs[:maxRunes]) + "…"
 }
 
-// maxSynthesizedFallbackCommentRunes caps the completion-fallback comment that
+// maxSynthesizedFallbackCommentRunes bounds the completion-fallback comment that
 // CompleteTask synthesizes from a task's final output when the agent left no
 // comment of its own during the run. A real final assistant message is at most
 // a few thousand words; anything larger is a runaway raw-stream dump — every
 // streamed text delta concatenated together plus a literal `tool call` line per
 // tool_use event — which some runtimes/providers emit as the task's Output on
 // long, tool-heavy runs. Such a dump (observed at 190–264 KB) must never be
-// posted verbatim to the issue thread (GH #5455). When the output exceeds this,
-// truncateFallbackCommentBody keeps the head — which carries the actual message
-// — and appends a marker instead of the multi-hundred-KB tail.
+// posted, even partially, to the issue thread (GH #5455).
 const maxSynthesizedFallbackCommentRunes = 8000
+
+const oversizedFallbackCommentNotice = "This task completed, but its output was too large to post safely. The raw output was not posted. Review the task in this issue's Execution log."
 
 // truncateFallbackCommentBody bounds a synthesized completion-fallback comment
 // body. Unlike truncateForSummary (which flattens newlines for a one-line row
-// snapshot) it preserves the head verbatim so a genuine final message reads
-// normally, and only when body exceeds maxRunes does it clip to the head and
-// append a marker naming the omitted length. Callers pass the already-redacted
-// body so the stored comment is guaranteed to be at most maxRunes plus marker.
+// snapshot), it preserves genuine final messages below the cap verbatim. Output
+// above the cap is untrusted: the reported failure mode puts process narration
+// and tool traces at the head, so retaining any excerpt can expose execution
+// details and still discard the final answer. Replace the entire body with a
+// fixed notice instead. Callers pass the already-redacted body.
 func truncateFallbackCommentBody(body string, maxRunes int) string {
-	rs := []rune(body)
-	if len(rs) <= maxRunes {
+	if utf8.RuneCountInString(body) <= maxRunes {
 		return body
 	}
-	omitted := len(rs) - maxRunes
-	return string(rs[:maxRunes]) + fmt.Sprintf(
-		"\n\n… [output truncated: %d more characters omitted. This run did not produce a concise final message; see the task run for the full output.]",
-		omitted,
-	)
+	return oversizedFallbackCommentNotice
 }
 
 const (
@@ -2702,10 +2699,10 @@ func (s *TaskService) CompleteTask(ctx context.Context, taskID pgtype.UUID, resu
 							"agent_id", util.UUIDToString(task.AgentID),
 						)
 					} else {
-						// Redact first, then cap: a runaway raw-stream Output (GH #5455)
-						// must never reach the issue thread as a 200KB+ verbatim dump.
+						// Redact first, then bound: a runaway raw-stream Output (GH #5455)
+						// must never reach the issue thread, even as a clipped excerpt.
 						content := truncateFallbackCommentBody(redact.Text(body), maxSynthesizedFallbackCommentRunes)
-						s.createAgentComment(ctx, task.IssueID, task.AgentID, content, "comment", task.TriggerCommentID, pgtype.UUID{})
+						s.createAgentComment(ctx, task.IssueID, task.AgentID, content, "comment", task.TriggerCommentID, task.ID)
 					}
 				}
 			}

--- a/server/internal/service/task.go
+++ b/server/internal/service/task.go
@@ -116,6 +116,36 @@ func truncateForSummary(s string, maxRunes int) string {
 	return string(rs[:maxRunes]) + "…"
 }
 
+// maxSynthesizedFallbackCommentRunes caps the completion-fallback comment that
+// CompleteTask synthesizes from a task's final output when the agent left no
+// comment of its own during the run. A real final assistant message is at most
+// a few thousand words; anything larger is a runaway raw-stream dump — every
+// streamed text delta concatenated together plus a literal `tool call` line per
+// tool_use event — which some runtimes/providers emit as the task's Output on
+// long, tool-heavy runs. Such a dump (observed at 190–264 KB) must never be
+// posted verbatim to the issue thread (GH #5455). When the output exceeds this,
+// truncateFallbackCommentBody keeps the head — which carries the actual message
+// — and appends a marker instead of the multi-hundred-KB tail.
+const maxSynthesizedFallbackCommentRunes = 8000
+
+// truncateFallbackCommentBody bounds a synthesized completion-fallback comment
+// body. Unlike truncateForSummary (which flattens newlines for a one-line row
+// snapshot) it preserves the head verbatim so a genuine final message reads
+// normally, and only when body exceeds maxRunes does it clip to the head and
+// append a marker naming the omitted length. Callers pass the already-redacted
+// body so the stored comment is guaranteed to be at most maxRunes plus marker.
+func truncateFallbackCommentBody(body string, maxRunes int) string {
+	rs := []rune(body)
+	if len(rs) <= maxRunes {
+		return body
+	}
+	omitted := len(rs) - maxRunes
+	return string(rs[:maxRunes]) + fmt.Sprintf(
+		"\n\n… [output truncated: %d more characters omitted. This run did not produce a concise final message; see the task run for the full output.]",
+		omitted,
+	)
+}
+
 const (
 	taskAnalyticsContextCacheMax = 4096
 	// claimResponseRecoveryWindow must exceed daemon client.Timeout for
@@ -2672,7 +2702,10 @@ func (s *TaskService) CompleteTask(ctx context.Context, taskID pgtype.UUID, resu
 							"agent_id", util.UUIDToString(task.AgentID),
 						)
 					} else {
-						s.createAgentComment(ctx, task.IssueID, task.AgentID, redact.Text(body), "comment", task.TriggerCommentID, pgtype.UUID{})
+						// Redact first, then cap: a runaway raw-stream Output (GH #5455)
+						// must never reach the issue thread as a 200KB+ verbatim dump.
+						content := truncateFallbackCommentBody(redact.Text(body), maxSynthesizedFallbackCommentRunes)
+						s.createAgentComment(ctx, task.IssueID, task.AgentID, content, "comment", task.TriggerCommentID, pgtype.UUID{})
 					}
 				}
 			}


### PR DESCRIPTION
## Problem

Mitigates #5455 as a defense-in-depth safety fix.

Some task runtimes can return an accumulated execution transcript as their final `Output`. When the agent did not post a comment during the run, `TaskService.CompleteTask` used that output to synthesize an issue comment verbatim. Reported comments were 190–264 KB and exposed process narration and tool traces.

The runtime output-state bug is being handled separately. This PR protects the persistence boundary so the same failure cannot publish a large raw transcript in the meantime.

## Fix

- Redact synthesized fallback output before applying the boundary.
- Preserve normal fallback messages at or below 8,000 runes unchanged.
- When output exceeds the cap, discard the entire untrusted body and post a fixed short notice directing the user to the issue's Execution log. No head, tail, tool trace, or other raw excerpt is retained.
- Stamp the synthesized comment with the producing task ID so its provenance is preserved.

This intentionally avoids treating the first 8,000 runes as the final answer: the reported failure mode puts process narration at the head and may put a real answer at the tail.

## Tests

`TestTruncateFallbackCommentBody` covers:

- normal short multiline output passthrough;
- the exact 8,000-rune boundary;
- a 200 KB+ narration/tool-stream fixture with a tail answer, asserting none of the raw content is published;
- multibyte rune counting and no raw excerpt above the boundary.

Local validation:

- `go test ./internal/service -run '^(TestTruncateFallbackCommentBody|TestCompleteTask_AlreadyFinalized)$' -count=1`
- `go vet ./internal/service`

The complete local service suite is currently blocked by the worktree test database missing existing schema columns such as `chat_finalize_deferred_at` and `published_by_type`; CI runs against a fresh schema.
