### PR TITLE
MUL-4853: SNDBX-491 refresh autopilot project binding at dispatch

### DIFF
--- a/server/internal/handler/handler_test.go
+++ b/server/internal/handler/handler_test.go
@@ -1362,6 +1362,101 @@ func TestAutopilotCreateIssueAssociatesConfiguredProject(t *testing.T) {
 	}
 }
 
+func TestAutopilotDispatchUsesCurrentProjectBinding(t *testing.T) {
+	ctx := context.Background()
+	title := fmt.Sprintf("Autopilot stale project issue %d", time.Now().UnixNano())
+	var autopilotID, issueID, projectAID, projectBID string
+	defer func() {
+		if issueID != "" {
+			testPool.Exec(ctx, `DELETE FROM issue WHERE id = $1`, issueID)
+		}
+		if autopilotID != "" {
+			testPool.Exec(ctx, `DELETE FROM autopilot WHERE id = $1`, autopilotID)
+		}
+		if projectAID != "" {
+			testPool.Exec(ctx, `DELETE FROM project WHERE id = $1`, projectAID)
+		}
+		if projectBID != "" {
+			testPool.Exec(ctx, `DELETE FROM project WHERE id = $1`, projectBID)
+		}
+	}()
+
+	if err := testPool.QueryRow(ctx, `
+		INSERT INTO project (workspace_id, title)
+		VALUES ($1, $2)
+		RETURNING id::text
+	`, testWorkspaceID, "Autopilot stale project A").Scan(&projectAID); err != nil {
+		t.Fatalf("create project A fixture: %v", err)
+	}
+	if err := testPool.QueryRow(ctx, `
+		INSERT INTO project (workspace_id, title)
+		VALUES ($1, $2)
+		RETURNING id::text
+	`, testWorkspaceID, "Autopilot stale project B").Scan(&projectBID); err != nil {
+		t.Fatalf("create project B fixture: %v", err)
+	}
+
+	var agentID string
+	if err := testPool.QueryRow(ctx, `SELECT id FROM agent WHERE workspace_id = $1 LIMIT 1`, testWorkspaceID).Scan(&agentID); err != nil {
+		t.Fatalf("load test agent: %v", err)
+	}
+
+	w := httptest.NewRecorder()
+	req := newRequest("POST", "/api/autopilots?workspace_id="+testWorkspaceID, map[string]any{
+		"title":                "Stale-project autopilot",
+		"assignee_id":          agentID,
+		"execution_mode":       "create_issue",
+		"issue_title_template": title,
+		"project_id":           projectAID,
+	})
+	testHandler.CreateAutopilot(w, req)
+	if w.Code != http.StatusCreated {
+		t.Fatalf("CreateAutopilot: expected 201, got %d: %s", w.Code, w.Body.String())
+	}
+	var created AutopilotResponse
+	if err := json.NewDecoder(w.Body).Decode(&created); err != nil {
+		t.Fatalf("decode autopilot: %v", err)
+	}
+	autopilotID = created.ID
+
+	queries := db.New(testPool)
+	ap, err := queries.GetAutopilot(ctx, parseUUID(autopilotID))
+	if err != nil {
+		t.Fatalf("GetAutopilot: %v", err)
+	}
+
+	w = httptest.NewRecorder()
+	req = newRequest("PATCH", "/api/autopilots/"+autopilotID+"?workspace_id="+testWorkspaceID, map[string]any{
+		"project_id": projectBID,
+	})
+	req = withURLParam(req, "id", autopilotID)
+	testHandler.UpdateAutopilot(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("UpdateAutopilot: expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	run, err := testHandler.AutopilotService.DispatchAutopilot(ctx, ap, pgtype.UUID{}, "manual", nil)
+	if err != nil {
+		t.Fatalf("DispatchAutopilot: %v", err)
+	}
+	if run == nil || !run.IssueID.Valid {
+		t.Fatalf("dispatch run = %+v, want linked issue", run)
+	}
+	issueID = uuidToString(run.IssueID)
+
+	var issueProjectID *string
+	if err := testPool.QueryRow(ctx, `
+		SELECT project_id::text
+		FROM issue
+		WHERE id = $1
+	`, issueID).Scan(&issueProjectID); err != nil {
+		t.Fatalf("load created issue project: %v", err)
+	}
+	if issueProjectID == nil || *issueProjectID != projectBID {
+		t.Fatalf("created issue project_id = %v, want refreshed %q", issueProjectID, projectBID)
+	}
+}
+
 func TestUpdateAutopilotCanSetAndClearProject(t *testing.T) {
 	ctx := context.Background()
 	var autopilotID, projectID string

--- a/server/internal/service/autopilot.go
+++ b/server/internal/service/autopilot.go
@@ -302,8 +302,19 @@ func (s *AutopilotService) dispatchCreateIssue(ctx context.Context, ap db.Autopi
 	title := s.interpolateTemplate(ap, *run, triggerTimezone)
 	description := s.buildIssueDescription(ap, *run, triggerTimezone)
 
+	// Refresh the autopilot row at dispatch time so we use the current project
+	// binding instead of any stale snapshot the caller may have cached.
+	currentAutopilot, err := qtx.GetAutopilotInWorkspace(ctx, db.GetAutopilotInWorkspaceParams{
+		ID:          ap.ID,
+		WorkspaceID: ap.WorkspaceID,
+	})
+	if err != nil {
+		return fmt.Errorf("refresh autopilot: %w", err)
+	}
+	projectID := currentAutopilot.ProjectID
+
 	if duplicate, found, err := issueguard.LockAndFindRecentAutopilotDuplicate(
-		ctx, qtx, ap.WorkspaceID, ap.ID, ap.ProjectID, title, autopilotRecentDuplicateWindow,
+		ctx, qtx, ap.WorkspaceID, ap.ID, projectID, title, autopilotRecentDuplicateWindow,
 	); err != nil {
 		return fmt.Errorf("recent duplicate guard: %w", err)
 	} else if found {
@@ -340,7 +351,7 @@ func (s *AutopilotService) dispatchCreateIssue(ctx context.Context, ap db.Autopi
 		StartDate:     pgtype.Date{},
 		DueDate:       pgtype.Date{},
 		Number:        issueNumber,
-		ProjectID:     ap.ProjectID,
+		ProjectID:     projectID,
 		OriginType:    pgtype.Text{String: "autopilot", Valid: true},
 		OriginID:      ap.ID,
 	})


### PR DESCRIPTION
Refreshes autopilot dispatch to use the current project binding instead of a stale in-memory snapshot, and adds a regression for project changes between load and dispatch.

Tests:
- `go test ./internal/handler -run 'Test(AutopilotCreateIssueAssociatesConfiguredProject|AutopilotDispatchUsesCurrentProjectBinding|UpdateAutopilotCanSetAndClearProject)$'`
