### PR TITLE
fix(desktop): fade tab separators on hover, correct their weight (MUL-4811)

### DIFF
--- a/apps/desktop/src/renderer/src/components/tab-bar.tsx
+++ b/apps/desktop/src/renderer/src/components/tab-bar.tsx
@@ -183,7 +183,10 @@ function SortableTabItem({
   canCloseOthers: boolean;
   isNew: boolean;
   shouldReduceMotion: boolean;
-  /** Hairline on the tab's left edge — hidden next to the active tab. */
+  /**
+   * Hairline on the tab's left edge — hidden next to the active tab, and
+   * faded out while either of the two tabs it divides is hovered.
+   */
   showSeparator: boolean;
 }) {
   const setActiveTab = useTabStore((s) => s.setActiveTab);
@@ -345,9 +348,12 @@ function SortableTabItem({
           />
         )}
         {showSeparator && (
+          // Fades in step with the neighbouring hover pill: both use a bare
+          // transition-opacity, so the hairline clears exactly as the pill
+          // arrives rather than lingering 2px off its rounded edge.
           <span
             aria-hidden
-            className="pointer-events-none absolute left-0 top-1/2 h-4 w-px -translate-y-1/2 bg-border"
+            className="pointer-events-none absolute left-0 top-1/2 h-4 w-px -translate-y-1/2 bg-surface-border transition-opacity group-hover/tab:opacity-0 prev-tab-hover:opacity-0"
           />
         )}
         <ContextMenu>
@@ -630,7 +636,7 @@ export function TabBar() {
                       unpinnedCount > 0 && (
                         <div
                           aria-hidden
-                          className="mx-1 mb-2.5 h-4 w-px shrink-0 self-end bg-border"
+                          className="mx-1 mb-2.5 h-4 w-px shrink-0 self-end bg-surface-border"
                         />
                       )}
                   </Fragment>

--- a/apps/desktop/src/renderer/src/globals.css
+++ b/apps/desktop/src/renderer/src/globals.css
@@ -6,6 +6,20 @@
 
 @custom-variant dark (&:is(.dark *));
 
+/* Tab strip hairlines sit on each tab's own left edge, so the hairline between
+   two tabs belongs to the tab on the right. Hovering the left tab has to fade
+   it out as well, which no ancestor-based variant can reach — hence the
+   adjacent-sibling selector. The (hover: hover) gate mirrors what Tailwind
+   already wraps group-hover in, so both halves of the fade stay in step on
+   devices without a pointer. */
+@custom-variant prev-tab-hover {
+  @media (hover: hover) {
+    [data-tab-frame]:hover + [data-tab-frame] & {
+      @slot;
+    }
+  }
+}
+
 /* Font stack: Inter for Latin UI text + system CJK fonts for localized content.
    Web app uses the same stack via next/font/google in apps/web/app/layout.tsx —
    keep the CJK fallback tail in sync across both files. The Inter primary family


### PR DESCRIPTION
Multica issue: **MUL-4811** — Tab bar 右键菜单按钮左侧分割线：hover 时应消失并带动画效果

The tab strip's separators were shipped in #5314. This fixes two things about them: they are nearly invisible, and they do not get out of the way on hover.

## 1. Weight: `--border` → `--surface-border`

`--border` is authored for near-white surfaces. Its other uses sit on `--surface-raised` (L=1.0), where it gives a reasonable ΔL 0.055. The tab strip draws it on `--app-shell` (L=0.964), where it collapses to **ΔL 0.019** — roughly a quarter of the 0.068–0.080 that the rest of this chrome's 1px keylines run at. That is why it read as "too light".

The token itself is fine; it was misapplied here. The surrounding chrome already has a keyline token — the active tab's border, the flare arcs, and the content card's ring all use `--surface-border` — and the design system's own answer for a separator on a surface of this lightness is the same value: `SidebarSeparator` draws `--sidebar-border` on `--sidebar`, whose OKLCH is bit-identical to `--app-shell`.

So this is not a colour tweak; it reconnects the hairline to the keyline language it already lives in.

| | before | after |
| --- | --- | --- |
| light | ΔL 0.0194 (26% of system band) | ΔL 0.0444 (60%) |
| dark | ΔL 0.0659 (67%) | ΔL 0.1071 (108%) |

The pinned-zone divider moves too — same token, same surface, same defect; leaving it behind would strand a lighter line next to a darker one.

Note the two modes are **not** symmetric: `--border` is an opaque grey in light but an alpha (`white / 6%`) in dark, so the same token is not perceptually equivalent across them. The complaint was effectively a light-mode problem.

## 2. Hover: fade the hairline out

A hairline sits on a tab's own left edge, so the line between two tabs belongs to the tab on the **right**. Hovering either neighbour must fade it, otherwise it lingers 2px off the hover pill's rounded edge.

- own side → `group-hover/tab:opacity-0` (the `group/tab` already exists)
- neighbour's side → belongs to a different component instance, which no ancestor-based variant can reach — hence the adjacent-sibling `@custom-variant prev-tab-hover` in `globals.css`

The variant is desktop-scoped (that file already declares `@custom-variant dark`), so `packages/ui` is untouched. It is anchored on `[data-tab-frame]`, which only the tab bar uses.

Animation is a bare `transition-opacity` — the same mechanism the hover pill uses, so the two are synchronised by construction (150ms): the hairline clears exactly as the pill arrives. No framer-motion node, no new React state, no re-render on hover.

## Verification

- `pnpm typecheck` — 6/6
- `pnpm lint` — 8/8, 0 errors (19 pre-existing warnings, none in the touched files)
- `pnpm test` (desktop) — 281/281
- `electron-vite build` — real bundle inspected, which is the check that matters for Tailwind (whether the class is actually scanned and emitted):

```css
@media (hover: hover) {
  [data-tab-frame]:hover + [data-tab-frame] .prev-tab-hover\:opacity-0 {
    opacity: 0;
  }
}
```

`--surface-border` resolves in the bundle to `oklch(92% .004 286.32)` (light) / `oklch(100% 0 0 / .1)` (dark).

The `+` selector depends on tab frames being **adjacent** DOM siblings. That was verified against a real render rather than assumed: the selector matches 2 pairs across 4 tabs (not 0), and the pinned-zone divider naturally breaks adjacency exactly where `showSeparator` is already false, so the two rules agree without extra conditions.

**Not verified:** `pnpm dev:desktop` by hand in light/dark. No GUI in the agent environment. Logic correctness is covered above; what remains for human eyes is purely whether the new weight reads right.

## Review notes

- The adjacent-sibling adjacency is a hidden invariant with no test guarding it — jsdom cannot exercise `:hover` cascade, so if someone later wraps `SortableTabItem` the hover fade breaks **silently**. Deliberately not adding a low-value assertion, but flagging the failure mode.
- Branch is 14 commits behind main; merges cleanly. The one upstream commit touching `tab-bar.tsx` (#5462) only adds a context-menu item and does not affect the frame structure this change relies on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
