### PR TITLE
fix(autopilots): show run results in history

### DIFF
--- a/packages/views/autopilots/components/autopilot-detail-page.test.tsx
+++ b/packages/views/autopilots/components/autopilot-detail-page.test.tsx
@@ -1,0 +1,21 @@
+import { describe, expect, it } from "vitest";
+import { formatRunResult } from "./autopilot-detail-page";
+
+describe("formatRunResult", () => {
+  it("extracts the final output captured from an agent task", () => {
+    expect(formatRunResult({ output: "  Weekly report complete.  " })).toBe(
+      "Weekly report complete.",
+    );
+  });
+
+  it("supports plain and structured results", () => {
+    expect(formatRunResult("  Done. ")).toBe("Done.");
+    expect(formatRunResult({ count: 3 })).toBe('{"count":3}');
+  });
+
+  it("keeps missing or empty output explicit", () => {
+    expect(formatRunResult(null)).toBeNull();
+    expect(formatRunResult({ output: "  " })).toBeNull();
+    expect(formatRunResult({})).toBeNull();
+  });
+});

--- a/packages/views/autopilots/components/autopilot-detail-page.tsx
+++ b/packages/views/autopilots/components/autopilot-detail-page.tsx
@@ -77,6 +77,27 @@ function formatDate(date: string): string {
   });
 }
 
+export function formatRunResult(result: unknown): string | null {
+  if (typeof result === "string") {
+    return result.trim() || null;
+  }
+  if (result && typeof result === "object" && !Array.isArray(result)) {
+    const output = (result as Record<string, unknown>).output;
+    if (typeof output === "string") {
+      return output.trim() || null;
+    }
+  }
+  if (result == null) {
+    return null;
+  }
+  try {
+    const serialized = JSON.stringify(result);
+    return serialized === "{}" || serialized === "[]" ? null : serialized;
+  } catch {
+    return null;
+  }
+}
+
 type RunStatus = "issue_created" | "running" | "skipped" | "completed" | "failed";
 
 const RUN_VISUAL: Record<RunStatus, { color: string; icon: typeof CheckCircle2; spin?: boolean }> = {
@@ -114,6 +135,7 @@ function RunRow({ run, agentId, agentName }: { run: AutopilotRun; agentId: strin
   const status = (RUN_VISUAL[run.status as RunStatus] ? (run.status as RunStatus) : "issue_created");
   const visual = RUN_VISUAL[status];
   const StatusIcon = visual.icon;
+  const result = formatRunResult(run.result);
 
   // For runs with a task_id (run_only mode), build a minimal AgentTask so
   // TranscriptButton can lazy-load the execution transcript.
@@ -147,11 +169,18 @@ function RunRow({ run, agentId, agentName }: { run: AutopilotRun; agentId: strin
       <span className="w-20 shrink-0 text-xs text-muted-foreground">
         {t(($) => $.run_source[run.source as "schedule" | "manual" | "webhook" | "api"]) ?? run.source}
       </span>
-      <span className="flex-1 min-w-0 text-xs text-muted-foreground truncate">
+      <span
+        className="flex-1 min-w-0 text-xs text-muted-foreground truncate"
+        title={result ?? undefined}
+      >
         {run.issue_id ? (
           t(($) => $.run.issue_linked)
         ) : run.failure_reason ? (
           <span className="text-destructive">{run.failure_reason}</span>
+        ) : result ? (
+          result
+        ) : run.status === "completed" ? (
+          <span className="italic">{t(($) => $.run.no_output)}</span>
         ) : null}
       </span>
       <span className="w-32 shrink-0 text-right text-xs text-muted-foreground tabular-nums">

--- a/packages/views/locales/en/autopilots.json
+++ b/packages/views/locales/en/autopilots.json
@@ -137,6 +137,7 @@
   "run": {
     "issue_linked": "Issue linked",
     "view_log": "View execution log",
+    "no_output": "No output",
     "skipped_group": {
       "label": "Skipped",
       "summary": "{{count}} skipped runs"

--- a/packages/views/locales/ja/autopilots.json
+++ b/packages/views/locales/ja/autopilots.json
@@ -137,6 +137,7 @@
   "run": {
     "issue_linked": "イシューをリンク済み",
     "view_log": "実行ログを表示",
+    "no_output": "出力なし",
     "skipped_group": {
       "label": "スキップ済み",
       "summary": "スキップされた実行 {{count}} 件"

--- a/packages/views/locales/ko/autopilots.json
+++ b/packages/views/locales/ko/autopilots.json
@@ -137,6 +137,7 @@
   "run": {
     "issue_linked": "이슈 연결됨",
     "view_log": "실행 로그 보기",
+    "no_output": "출력 없음",
     "skipped_group": {
       "label": "건너뜀",
       "summary": "건너뛴 실행 {{count}}개"

--- a/packages/views/locales/zh-Hans/autopilots.json
+++ b/packages/views/locales/zh-Hans/autopilots.json
@@ -137,6 +137,7 @@
   "run": {
     "issue_linked": "已关联 issue",
     "view_log": "查看执行日志",
+    "no_output": "无输出",
     "skipped_group": {
       "label": "已跳过",
       "summary": "{{count}} 条跳过的运行"


### PR DESCRIPTION
## Summary

- render stored automation run results in run history
- support output objects, plain strings, and structured results
- show a localized no-output fallback for completed runs
- add formatter and localization coverage

## Testing

- pnpm --filter @multica/views test
- pnpm typecheck
- pnpm lint
- git diff --check