### PR TITLE
fix(ui): drop native title that stacked on custom hover surfaces (MUL-4836)

### DIFF
--- a/packages/ui/components/common/actor-avatar.tsx
+++ b/packages/ui/components/common/actor-avatar.tsx
@@ -53,7 +53,6 @@ function ActorAvatar({
         "rounded-full"
       )}
       style={{ width: px, height: px, fontSize: px * 0.45 }}
-      title={name}
     >
       {avatarUrl && !imgError ? (
         <img

--- a/packages/views/common/actor-avatar.tsx
+++ b/packages/views/common/actor-avatar.tsx
@@ -208,7 +208,6 @@ export function AgentStatusDot({ agentId, size }: { agentId: string; size?: Avat
   return (
     <span
       aria-label={`Status: ${label}`}
-      title={label}
       className={`absolute bottom-0 right-0 rounded-full ring-1 ring-background ${dotClass} ${dotSize}`}
     />
   );

--- a/packages/views/modals/create-project.test.tsx
+++ b/packages/views/modals/create-project.test.tsx
@@ -177,8 +177,10 @@ describe("CreateProjectModal", () => {
   it("exposes full repository URLs in the repository picker", () => {
     render(<CreateProjectModal onClose={vi.fn()} />);
 
-    expect(screen.getByTitle(longRepoUrl)).toHaveTextContent(longRepoUrl);
+    // The Tooltip is the single reveal mechanism. A native `title` carrying the
+    // same URL would stack a browser tooltip on top of it (MUL-4836).
     expect(screen.getByRole("tooltip", { name: longRepoUrl })).toBeInTheDocument();
+    expect(screen.queryByTitle(longRepoUrl)).toBeNull();
   });
 
   it("reveals the start/due date pickers from the ⋯ overflow menu", async () => {

--- a/packages/views/modals/create-project.tsx
+++ b/packages/views/modals/create-project.tsx
@@ -78,10 +78,7 @@ function RepoUrlText({
     <Tooltip>
       <TooltipTrigger
         render={
-          <span
-            title={url}
-            className={cn("truncate flex-1 text-left", className)}
-          >
+          <span className={cn("truncate flex-1 text-left", className)}>
             {url}
           </span>
         }


### PR DESCRIPTION
Fixes MUL-4836.

## Problem

The screenshot on the issue shows a native browser tooltip ("Yushen") stacked on top of the member PreviewCard, on the same hover.

Root cause is a single shared component: `ActorAvatarBase` hardcoded `title={name}` on the avatar div, unconditionally. All 155 avatar renders emitted a browser tooltip; the 34 that also pass `enableHoverCard` therefore showed two surfaces at once.

They don't suppress each other because they aren't on the same element — `title` sits on the inner `<div data-slot="avatar">`, the PreviewCard trigger sits on an ancestor `<span>`. The card opens at 600ms, the OS title floats in around 1s.

Two more instances of the same mistake:
- `AgentStatusDot` added a third `title` inside the same trigger (the 16 sites that also pass `showStatusDot`).
- `RepoUrlText` rendered a `title` carrying the exact string its Tooltip already displays.

## Change

Phase 1 scope only — three duplicate `title` attributes removed:

1. `packages/ui/components/common/actor-avatar.tsx` — `title={name}`
2. `packages/views/common/actor-avatar.tsx` (`AgentStatusDot`) — `title={label}`
3. `packages/views/modals/create-project.tsx` (`RepoUrlText`) — `title={url}`

Deliberately **not** touched: PreviewCard trigger semantics, `profileLink`, runtime ancestor detection, the 159 `ActorAvatar` call sites, and the ~80 remaining native-title sites. Those are Phase 2/3 and are separately scoped.

## Accessible-name impact

Worth being explicit, since 121 avatars had no hover surface and `title` was their only hint:

- **Image avatars** keep `alt={name}` — accessible name unchanged.
- **Initials avatars** keep their text content — accessible name unchanged.
- **Icon-only avatars** (no-image agent/squad/system, rendering `<Bot>` / `<Users>` / `MulticaIcon`) lose their only name source. This is a known, accepted Phase 1 gap: `title` was never a reliable a11y mechanism (not exposed on touch, inconsistent across screen readers), so this removes an unreliable crutch rather than a working affordance. Giving these a real accessible name is Phase 2.
- `AgentStatusDot` keeps `aria-label={`Status: ${label}`}`, so the status stays exposed to assistive tech; only the browser tooltip is gone.

## Verification

- `pnpm typecheck` — 6/6 packages pass.
- `pnpm test` — 214 files, 2131 tests, all pass.
- `pnpm lint` — 0 errors; the 4 changed files produce no lint output (19 pre-existing warnings elsewhere in `packages/views` are untouched).
- `create-project.test.tsx` asserted the now-removed `title`; updated to assert the Tooltip is the single reveal mechanism and that no native `title` is rendered, which pins acceptance criterion 3.
- Grep-verified all three components no longer render a native `title`.

Not verified by me: manual hover in a running app, and VoiceOver/NVDA behavior. `packages/ui` has no test harness at all (no test script, no test files), so the `ActorAvatarBase` change has no unit-test guard — flagging rather than standing up vitest there, which would exceed this scope.

## Acceptance criteria

| Criterion | Status |
| --- | --- |
| Long hover shows only one custom surface | Met by construction — the only competing surface is deleted |
| Click / keyboard behavior unchanged | No trigger, handler, or tabIndex touched; full suite green |
| Three components no longer render native `title` | Grep-verified + test-pinned for `RepoUrlText` |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
