### PR TITLE
MUL-4861: align runtime CLI update permissions

### DIFF
--- a/packages/views/locales/en/runtimes.json
+++ b/packages/views/locales/en/runtimes.json
@@ -253,6 +253,8 @@
     "version_unknown": "unknown",
     "managed_by_desktop": "Managed by Desktop",
     "managed_by_desktop_title": "The CLI binary is managed by Multica Desktop — update Desktop to upgrade the CLI.",
+    "read_only": "Read-only",
+    "read_only_title": "Only runtime owners and workspace admins can update the CLI.",
     "latest": "Latest",
     "available": "available",
     "action": "Update",

--- a/packages/views/locales/ja/runtimes.json
+++ b/packages/views/locales/ja/runtimes.json
@@ -241,6 +241,8 @@
     "version_unknown": "不明",
     "managed_by_desktop": "デスクトップで管理",
     "managed_by_desktop_title": "CLI バイナリは Multica Desktop で管理されています。CLI をアップグレードするには Desktop を更新してください。",
+    "read_only": "読み取り専用",
+    "read_only_title": "CLI を更新できるのは、ランタイムの所有者とワークスペース管理者のみです。",
     "latest": "最新",
     "available": "利用可能",
     "action": "更新",

--- a/packages/views/locales/ko/runtimes.json
+++ b/packages/views/locales/ko/runtimes.json
@@ -241,6 +241,8 @@
     "version_unknown": "알 수 없음",
     "managed_by_desktop": "데스크톱에서 관리",
     "managed_by_desktop_title": "CLI 바이너리는 Multica Desktop에서 관리합니다. CLI를 업그레이드하려면 Desktop을 업데이트하세요.",
+    "read_only": "읽기 전용",
+    "read_only_title": "런타임 소유자와 워크스페이스 관리자만 CLI를 업데이트할 수 있습니다.",
     "latest": "최신",
     "available": "사용 가능",
     "action": "업데이트",

--- a/packages/views/locales/zh-Hans/runtimes.json
+++ b/packages/views/locales/zh-Hans/runtimes.json
@@ -241,6 +241,8 @@
     "version_unknown": "未知",
     "managed_by_desktop": "由桌面端管理",
     "managed_by_desktop_title": "CLI 二进制由 Multica 桌面端管理 —— 升级桌面端即可升级 CLI。",
+    "read_only": "只读",
+    "read_only_title": "只有运行时所有者和工作区管理员可以更新 CLI。",
     "latest": "最新",
     "available": "可用",
     "action": "更新",

--- a/packages/views/runtimes/components/machine-cli-section.test.tsx
+++ b/packages/views/runtimes/components/machine-cli-section.test.tsx
@@ -89,6 +89,7 @@ describe("MachineCliSection", () => {
       <MachineCliSection
         machine={machine([offlineOwned, onlineOwned, otherUsers])}
         currentUserId="user-1"
+        canManageAnyRuntime={false}
       />,
     );
 
@@ -99,6 +100,34 @@ describe("MachineCliSection", () => {
       currentVersion: "0.3.17",
       isOnline: true,
       launchedBy: "desktop",
+    });
+  });
+
+  it("lets a workspace admin update through an online teammate-owned runtime", () => {
+    const offline = runtime({
+      id: "offline-other-user",
+      owner_id: "user-2",
+      status: "offline",
+    });
+    const online = runtime({
+      id: "online-other-user",
+      owner_id: "user-2",
+    });
+
+    render(
+      <MachineCliSection
+        machine={machine([offline, online])}
+        currentUserId="user-1"
+        canManageAnyRuntime
+      />,
+    );
+
+    expect(screen.getAllByRole("button", { name: "Update" })).toHaveLength(1);
+    expect(mockUpdateSection).toHaveBeenCalledWith({
+      runtimeId: "online-other-user",
+      currentVersion: "0.3.17",
+      isOnline: true,
+      launchedBy: null,
     });
   });
 
@@ -115,6 +144,7 @@ describe("MachineCliSection", () => {
           }),
         ])}
         currentUserId="user-1"
+        canManageAnyRuntime={false}
       />,
     );
 

--- a/packages/views/runtimes/components/machine-cli-section.tsx
+++ b/packages/views/runtimes/components/machine-cli-section.tsx
@@ -3,31 +3,44 @@ import type { RuntimeMachine } from "./runtime-machines";
 import { UpdateSection } from "./update-section";
 
 /**
- * Pick one viewer-owned runtime as the command channel for a machine-wide
- * daemon update. An online runtime wins so the daemon can receive the request
- * immediately; an offline row still keeps version/managed-state display
- * available without enabling the update action.
+ * Pick one runtime the viewer may manage as the command channel for a
+ * machine-wide daemon update. Workspace admins may manage any runtime; other
+ * members must own the runtime. An online runtime wins so the daemon can
+ * receive the request immediately.
  */
 export function machineUpdateRuntime(
   machine: RuntimeMachine,
   currentUserId: string | undefined,
+  canManageAnyRuntime: boolean,
 ): AgentRuntime | null {
-  if (machine.mode !== "local" || !currentUserId) return null;
+  if (machine.mode !== "local") return null;
 
-  const owned = machine.runtimes.filter(
-    (runtime) => runtime.owner_id === currentUserId,
+  const manageable = canManageAnyRuntime
+    ? machine.runtimes
+    : currentUserId
+      ? machine.runtimes.filter((runtime) => runtime.owner_id === currentUserId)
+      : [];
+  return (
+    manageable.find((runtime) => runtime.status === "online") ??
+    manageable[0] ??
+    null
   );
-  return owned.find((runtime) => runtime.status === "online") ?? owned[0] ?? null;
 }
 
 export function MachineCliSection({
   machine,
   currentUserId,
+  canManageAnyRuntime,
 }: {
   machine: RuntimeMachine;
   currentUserId: string | undefined;
+  canManageAnyRuntime: boolean;
 }) {
-  const updateRuntime = machineUpdateRuntime(machine, currentUserId);
+  const updateRuntime = machineUpdateRuntime(
+    machine,
+    currentUserId,
+    canManageAnyRuntime,
+  );
 
   if (machine.mode !== "local") {
     return machine.cliVersion ? (

--- a/packages/views/runtimes/components/runtime-detail-page.tsx
+++ b/packages/views/runtimes/components/runtime-detail-page.tsx
@@ -261,6 +261,7 @@ export function RuntimeDetailPage({
                   <MachineCliSection
                     machine={machine}
                     currentUserId={currentUserId}
+                    canManageAnyRuntime={isAdmin}
                   />
                   {machine.lastSeenAt && (
                     <span>{timeAgo(machine.lastSeenAt)}</span>

--- a/packages/views/runtimes/components/update-section.test.tsx
+++ b/packages/views/runtimes/components/update-section.test.tsx
@@ -39,7 +39,7 @@ afterEach(() => {
 });
 
 describe("UpdateSection read-only status", () => {
-  it("shows Latest without exposing an update action", async () => {
+  it("shows Latest without a redundant read-only label or update action", async () => {
     vi.stubGlobal(
       "fetch",
       vi.fn().mockResolvedValue({
@@ -51,12 +51,7 @@ describe("UpdateSection read-only status", () => {
     renderSection({ runtimeId: null });
 
     expect(await screen.findByText("Latest")).toBeInTheDocument();
-    expect(screen.getByText("Read-only")).toBeInTheDocument();
-    expect(
-      screen.getByTitle(
-        "Only runtime owners and workspace admins can update the CLI.",
-      ),
-    ).toBeInTheDocument();
+    expect(screen.queryByText("Read-only")).not.toBeInTheDocument();
     expect(
       screen.queryByRole("button", { name: "Update" }),
     ).not.toBeInTheDocument();
@@ -93,6 +88,11 @@ describe("UpdateSection read-only status", () => {
 
     expect(await screen.findByText("available")).toBeInTheDocument();
     expect(screen.getByText("Read-only")).toBeInTheDocument();
+    expect(
+      screen.getByTitle(
+        "Only runtime owners and workspace admins can update the CLI.",
+      ),
+    ).toBeInTheDocument();
     expect(
       screen.queryByRole("button", { name: "Update" }),
     ).not.toBeInTheDocument();

--- a/packages/views/runtimes/components/update-section.test.tsx
+++ b/packages/views/runtimes/components/update-section.test.tsx
@@ -51,6 +51,12 @@ describe("UpdateSection read-only status", () => {
     renderSection({ runtimeId: null });
 
     expect(await screen.findByText("Latest")).toBeInTheDocument();
+    expect(screen.getByText("Read-only")).toBeInTheDocument();
+    expect(
+      screen.getByTitle(
+        "Only runtime owners and workspace admins can update the CLI.",
+      ),
+    ).toBeInTheDocument();
     expect(
       screen.queryByRole("button", { name: "Update" }),
     ).not.toBeInTheDocument();
@@ -68,6 +74,7 @@ describe("UpdateSection read-only status", () => {
     renderSection({ runtimeId: null, launchedBy: "desktop" });
 
     expect(screen.getByText("Managed by Desktop")).toBeInTheDocument();
+    expect(screen.queryByText("Read-only")).not.toBeInTheDocument();
     expect(
       screen.queryByRole("button", { name: "Update" }),
     ).not.toBeInTheDocument();
@@ -85,6 +92,7 @@ describe("UpdateSection read-only status", () => {
     renderSection({ runtimeId: null, currentVersion: "v0.3.17" });
 
     expect(await screen.findByText("available")).toBeInTheDocument();
+    expect(screen.getByText("Read-only")).toBeInTheDocument();
     expect(
       screen.queryByRole("button", { name: "Update" }),
     ).not.toBeInTheDocument();

--- a/packages/views/runtimes/components/update-section.tsx
+++ b/packages/views/runtimes/components/update-section.tsx
@@ -5,6 +5,7 @@ import {
   XCircle,
   ArrowUpCircle,
   Check,
+  Lock,
 } from "lucide-react";
 import { Button } from "@multica/ui/components/ui/button";
 import { api } from "@multica/core/api";
@@ -211,6 +212,16 @@ export function UpdateSection({
                 </span>
                 <span className="text-xs text-muted-foreground">{t(($) => $.update.available)}</span>
               </>
+            )}
+
+            {!runtimeId && (
+              <span
+                className="inline-flex items-center gap-1 text-xs text-muted-foreground"
+                title={t(($) => $.update.read_only_title)}
+              >
+                <Lock className="h-3 w-3" />
+                {t(($) => $.update.read_only)}
+              </span>
             )}
 
             {hasUpdate && runtimeId && isOnline && !status && (

--- a/packages/views/runtimes/components/update-section.tsx
+++ b/packages/views/runtimes/components/update-section.tsx
@@ -214,7 +214,7 @@ export function UpdateSection({
               </>
             )}
 
-            {!runtimeId && (
+            {hasUpdate && !runtimeId && (
               <span
                 className="inline-flex items-center gap-1 text-xs text-muted-foreground"
                 title={t(($) => $.update.read_only_title)}

--- a/server/internal/handler/runtime_update.go
+++ b/server/internal/handler/runtime_update.go
@@ -219,7 +219,12 @@ func (h *Handler) InitiateUpdate(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if _, ok := h.requireWorkspaceMember(w, r, uuidToString(rt.WorkspaceID), "runtime not found"); !ok {
+	member, ok := h.requireWorkspaceMember(w, r, uuidToString(rt.WorkspaceID), "runtime not found")
+	if !ok {
+		return
+	}
+	if !canEditRuntime(member, rt) {
+		writeError(w, http.StatusForbidden, "only runtime owners and workspace admins can update runtimes")
 		return
 	}
 
@@ -257,7 +262,12 @@ func (h *Handler) GetUpdate(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusNotFound, "runtime not found")
 		return
 	}
-	if _, ok := h.requireWorkspaceMember(w, r, uuidToString(rt.WorkspaceID), "runtime not found"); !ok {
+	member, ok := h.requireWorkspaceMember(w, r, uuidToString(rt.WorkspaceID), "runtime not found")
+	if !ok {
+		return
+	}
+	if !canEditRuntime(member, rt) {
+		writeError(w, http.StatusForbidden, "only runtime owners and workspace admins can update runtimes")
 		return
 	}
 

--- a/server/internal/handler/runtime_update.go
+++ b/server/internal/handler/runtime_update.go
@@ -27,15 +27,16 @@ const (
 
 // UpdateRequest represents a pending or completed CLI update request.
 type UpdateRequest struct {
-	ID            string       `json:"id"`
-	RuntimeID     string       `json:"runtime_id"`
-	Status        UpdateStatus `json:"status"`
-	TargetVersion string       `json:"target_version"`
-	Output        string       `json:"output,omitempty"`
-	Error         string       `json:"error,omitempty"`
-	CreatedAt     time.Time    `json:"created_at"`
-	UpdatedAt     time.Time    `json:"updated_at"`
-	RunStartedAt  *time.Time   `json:"-"`
+	ID              string       `json:"id"`
+	RuntimeID       string       `json:"runtime_id"`
+	InitiatorUserID string       `json:"-"`
+	Status          UpdateStatus `json:"status"`
+	TargetVersion   string       `json:"target_version"`
+	Output          string       `json:"output,omitempty"`
+	Error           string       `json:"error,omitempty"`
+	CreatedAt       time.Time    `json:"created_at"`
+	UpdatedAt       time.Time    `json:"updated_at"`
+	RunStartedAt    *time.Time   `json:"-"`
 }
 
 const (
@@ -45,7 +46,7 @@ const (
 )
 
 type UpdateStore interface {
-	Create(ctx context.Context, runtimeID, targetVersion string) (*UpdateRequest, error)
+	Create(ctx context.Context, runtimeID, targetVersion, initiatorUserID string) (*UpdateRequest, error)
 	Get(ctx context.Context, id string) (*UpdateRequest, error)
 	HasPending(ctx context.Context, runtimeID string) (bool, error)
 	PopPending(ctx context.Context, runtimeID string) (*UpdateRequest, error)
@@ -91,7 +92,7 @@ func NewInMemoryUpdateStore() *InMemoryUpdateStore {
 	}
 }
 
-func (s *InMemoryUpdateStore) Create(_ context.Context, runtimeID, targetVersion string) (*UpdateRequest, error) {
+func (s *InMemoryUpdateStore) Create(_ context.Context, runtimeID, targetVersion, initiatorUserID string) (*UpdateRequest, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
@@ -110,12 +111,13 @@ func (s *InMemoryUpdateStore) Create(_ context.Context, runtimeID, targetVersion
 	}
 
 	req := &UpdateRequest{
-		ID:            randomID(),
-		RuntimeID:     runtimeID,
-		Status:        UpdatePending,
-		TargetVersion: targetVersion,
-		CreatedAt:     time.Now(),
-		UpdatedAt:     time.Now(),
+		ID:              randomID(),
+		RuntimeID:       runtimeID,
+		InitiatorUserID: initiatorUserID,
+		Status:          UpdatePending,
+		TargetVersion:   targetVersion,
+		CreatedAt:       time.Now(),
+		UpdatedAt:       time.Now(),
 	}
 	s.requests[req.ID] = req
 	return req, nil
@@ -240,7 +242,12 @@ func (h *Handler) InitiateUpdate(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	update, err := h.UpdateStore.Create(r.Context(), uuidToString(rt.ID), req.TargetVersion)
+	update, err := h.UpdateStore.Create(
+		r.Context(),
+		uuidToString(rt.ID),
+		req.TargetVersion,
+		uuidToString(member.UserID),
+	)
 	if err != nil {
 		writeError(w, http.StatusConflict, err.Error())
 		return
@@ -266,11 +273,6 @@ func (h *Handler) GetUpdate(w http.ResponseWriter, r *http.Request) {
 	if !ok {
 		return
 	}
-	if !canEditRuntime(member, rt) {
-		writeError(w, http.StatusForbidden, "only runtime owners and workspace admins can update runtimes")
-		return
-	}
-
 	updateID := chi.URLParam(r, "updateId")
 
 	update, err := h.UpdateStore.Get(r.Context(), updateID)
@@ -280,6 +282,13 @@ func (h *Handler) GetUpdate(w http.ResponseWriter, r *http.Request) {
 	}
 	if update == nil || update.RuntimeID != uuidToString(rt.ID) {
 		writeError(w, http.StatusNotFound, "update not found")
+		return
+	}
+	// Keep an in-flight poll alive if an admin is downgraded after starting
+	// the update. This exception is scoped to the immutable request initiator;
+	// other plain members still cannot read another runtime's update status.
+	if !canEditRuntime(member, rt) && update.InitiatorUserID != uuidToString(member.UserID) {
+		writeError(w, http.StatusForbidden, "only runtime owners, workspace admins, and the update initiator can view this update")
 		return
 	}
 

--- a/server/internal/handler/runtime_update_authorization_test.go
+++ b/server/internal/handler/runtime_update_authorization_test.go
@@ -1,0 +1,119 @@
+package handler
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func promoteRuntimeTestMemberToAdmin(t *testing.T, userID string) {
+	t.Helper()
+	if _, err := testPool.Exec(context.Background(), `
+		UPDATE member
+		SET role = 'admin'
+		WHERE workspace_id = $1 AND user_id = $2
+	`, testWorkspaceID, userID); err != nil {
+		t.Fatalf("promote runtime test member to admin: %v", err)
+	}
+}
+
+func TestInitiateUpdateRequiresRuntimeManager(t *testing.T) {
+	if testHandler == nil {
+		t.Skip("database not available")
+	}
+
+	tests := []struct {
+		name       string
+		actor      string
+		wantStatus int
+	}{
+		{name: "runtime owner", actor: "runtime_owner", wantStatus: http.StatusOK},
+		{name: "workspace admin", actor: "workspace_admin", wantStatus: http.StatusOK},
+		{name: "plain member", actor: "plain_member", wantStatus: http.StatusForbidden},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			runtimeID, runtimeOwnerID, plainMemberID := runtimeVisibilityFixture(t)
+			actorID := runtimeOwnerID
+			switch tc.actor {
+			case "workspace_admin":
+				promoteRuntimeTestMemberToAdmin(t, plainMemberID)
+				actorID = plainMemberID
+			case "plain_member":
+				actorID = plainMemberID
+			}
+
+			w := httptest.NewRecorder()
+			req := withURLParam(
+				newRequestAs(actorID, http.MethodPost, "/api/runtimes/"+runtimeID+"/update", map[string]any{
+					"target_version": "v9.9.9",
+				}),
+				"runtimeId",
+				runtimeID,
+			)
+			testHandler.InitiateUpdate(w, req)
+
+			if w.Code != tc.wantStatus {
+				t.Fatalf("expected %d, got %d: %s", tc.wantStatus, w.Code, w.Body.String())
+			}
+
+			hasPending, err := testHandler.UpdateStore.HasPending(context.Background(), runtimeID)
+			if err != nil {
+				t.Fatalf("check pending update request: %v", err)
+			}
+			wantPending := tc.wantStatus == http.StatusOK
+			if hasPending != wantPending {
+				t.Fatalf("pending update request = %v; want %v", hasPending, wantPending)
+			}
+		})
+	}
+}
+
+func TestGetUpdateRequiresRuntimeManager(t *testing.T) {
+	if testHandler == nil {
+		t.Skip("database not available")
+	}
+
+	tests := []struct {
+		name       string
+		actor      string
+		wantStatus int
+	}{
+		{name: "runtime owner", actor: "runtime_owner", wantStatus: http.StatusOK},
+		{name: "workspace admin", actor: "workspace_admin", wantStatus: http.StatusOK},
+		{name: "plain member", actor: "plain_member", wantStatus: http.StatusForbidden},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			runtimeID, runtimeOwnerID, plainMemberID := runtimeVisibilityFixture(t)
+			actorID := runtimeOwnerID
+			switch tc.actor {
+			case "workspace_admin":
+				promoteRuntimeTestMemberToAdmin(t, plainMemberID)
+				actorID = plainMemberID
+			case "plain_member":
+				actorID = plainMemberID
+			}
+
+			update, err := testHandler.UpdateStore.Create(context.Background(), runtimeID, "v9.9.9")
+			if err != nil {
+				t.Fatalf("create update request: %v", err)
+			}
+
+			w := httptest.NewRecorder()
+			req := withURLParams(
+				newRequestAs(actorID, http.MethodGet, "/api/runtimes/"+runtimeID+"/update/"+update.ID, nil),
+				"runtimeId", runtimeID,
+				"updateId", update.ID,
+			)
+			testHandler.GetUpdate(w, req)
+
+			if w.Code != tc.wantStatus {
+				t.Fatalf("expected %d, got %d: %s", tc.wantStatus, w.Code, w.Body.String())
+			}
+		})
+	}
+}

--- a/server/internal/handler/runtime_update_authorization_test.go
+++ b/server/internal/handler/runtime_update_authorization_test.go
@@ -2,20 +2,29 @@ package handler
 
 import (
 	"context"
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"testing"
 )
 
-func promoteRuntimeTestMemberToAdmin(t *testing.T, userID string) {
+func setRuntimeTestMemberRole(t *testing.T, userID, role string) {
 	t.Helper()
 	if _, err := testPool.Exec(context.Background(), `
 		UPDATE member
-		SET role = 'admin'
+		SET role = $3
 		WHERE workspace_id = $1 AND user_id = $2
-	`, testWorkspaceID, userID); err != nil {
-		t.Fatalf("promote runtime test member to admin: %v", err)
+	`, testWorkspaceID, userID, role); err != nil {
+		t.Fatalf("set runtime test member role to %s: %v", role, err)
 	}
+	if testHandler.MembershipCache != nil {
+		testHandler.MembershipCache.Invalidate(context.Background(), userID, testWorkspaceID)
+	}
+}
+
+func promoteRuntimeTestMemberToAdmin(t *testing.T, userID string) {
+	t.Helper()
+	setRuntimeTestMemberRole(t, userID, "admin")
 }
 
 func TestInitiateUpdateRequiresRuntimeManager(t *testing.T) {
@@ -98,7 +107,7 @@ func TestGetUpdateRequiresRuntimeManager(t *testing.T) {
 				actorID = plainMemberID
 			}
 
-			update, err := testHandler.UpdateStore.Create(context.Background(), runtimeID, "v9.9.9")
+			update, err := testHandler.UpdateStore.Create(context.Background(), runtimeID, "v9.9.9", runtimeOwnerID)
 			if err != nil {
 				t.Fatalf("create update request: %v", err)
 			}
@@ -115,5 +124,47 @@ func TestGetUpdateRequiresRuntimeManager(t *testing.T) {
 				t.Fatalf("expected %d, got %d: %s", tc.wantStatus, w.Code, w.Body.String())
 			}
 		})
+	}
+}
+
+func TestGetUpdateAllowsInitiatorAfterAdminDemotion(t *testing.T) {
+	if testHandler == nil {
+		t.Skip("database not available")
+	}
+
+	runtimeID, _, adminID := runtimeVisibilityFixture(t)
+	promoteRuntimeTestMemberToAdmin(t, adminID)
+
+	initRecorder := httptest.NewRecorder()
+	initRequest := withURLParam(
+		newRequestAs(adminID, http.MethodPost, "/api/runtimes/"+runtimeID+"/update", map[string]any{
+			"target_version": "v9.9.9",
+		}),
+		"runtimeId",
+		runtimeID,
+	)
+	testHandler.InitiateUpdate(initRecorder, initRequest)
+	if initRecorder.Code != http.StatusOK {
+		t.Fatalf("initiate update: expected 200, got %d: %s", initRecorder.Code, initRecorder.Body.String())
+	}
+
+	var update UpdateRequest
+	if err := json.Unmarshal(initRecorder.Body.Bytes(), &update); err != nil {
+		t.Fatalf("decode initiated update: %v", err)
+	}
+	if update.InitiatorUserID != "" {
+		t.Fatalf("initiator user ID leaked in API response: %q", update.InitiatorUserID)
+	}
+	setRuntimeTestMemberRole(t, adminID, "member")
+
+	pollRecorder := httptest.NewRecorder()
+	pollRequest := withURLParams(
+		newRequestAs(adminID, http.MethodGet, "/api/runtimes/"+runtimeID+"/update/"+update.ID, nil),
+		"runtimeId", runtimeID,
+		"updateId", update.ID,
+	)
+	testHandler.GetUpdate(pollRecorder, pollRequest)
+	if pollRecorder.Code != http.StatusOK {
+		t.Fatalf("poll after admin demotion: expected 200, got %d: %s", pollRecorder.Code, pollRecorder.Body.String())
 	}
 }

--- a/server/internal/handler/runtime_update_redis_store.go
+++ b/server/internal/handler/runtime_update_redis_store.go
@@ -43,15 +43,16 @@ func NewRedisUpdateStore(rdb *redis.Client) *RedisUpdateStore {
 	return &RedisUpdateStore{rdb: rdb}
 }
 
-func (s *RedisUpdateStore) Create(ctx context.Context, runtimeID, targetVersion string) (*UpdateRequest, error) {
+func (s *RedisUpdateStore) Create(ctx context.Context, runtimeID, targetVersion, initiatorUserID string) (*UpdateRequest, error) {
 	now := time.Now()
 	req := &UpdateRequest{
-		ID:            randomID(),
-		RuntimeID:     runtimeID,
-		Status:        UpdatePending,
-		TargetVersion: targetVersion,
-		CreatedAt:     now,
-		UpdatedAt:     now,
+		ID:              randomID(),
+		RuntimeID:       runtimeID,
+		InitiatorUserID: initiatorUserID,
+		Status:          UpdatePending,
+		TargetVersion:   targetVersion,
+		CreatedAt:       now,
+		UpdatedAt:       now,
 	}
 	data, err := s.marshalRequest(req)
 	if err != nil {
@@ -123,12 +124,17 @@ func (s *RedisUpdateStore) persistRequest(ctx context.Context, req *UpdateReques
 }
 
 type redisUpdateEnvelope struct {
-	Public       *UpdateRequest `json:"r"`
-	RunStartedAt *time.Time     `json:"s,omitempty"`
+	Public          *UpdateRequest `json:"r"`
+	RunStartedAt    *time.Time     `json:"s,omitempty"`
+	InitiatorUserID string         `json:"u,omitempty"`
 }
 
 func (s *RedisUpdateStore) marshalRequest(req *UpdateRequest) ([]byte, error) {
-	env := redisUpdateEnvelope{Public: req, RunStartedAt: req.RunStartedAt}
+	env := redisUpdateEnvelope{
+		Public:          req,
+		RunStartedAt:    req.RunStartedAt,
+		InitiatorUserID: req.InitiatorUserID,
+	}
 	data, err := json.Marshal(env)
 	if err != nil {
 		return nil, fmt.Errorf("marshal update request: %w", err)
@@ -145,6 +151,7 @@ func (s *RedisUpdateStore) unmarshalRequest(raw []byte) (*UpdateRequest, error) 
 		return nil, fmt.Errorf("decode update request: missing payload")
 	}
 	env.Public.RunStartedAt = env.RunStartedAt
+	env.Public.InitiatorUserID = env.InitiatorUserID
 	return env.Public, nil
 }
 

--- a/server/internal/handler/runtime_update_redis_store_test.go
+++ b/server/internal/handler/runtime_update_redis_store_test.go
@@ -11,13 +11,14 @@ func TestRedisUpdateStore_EnvelopePersistsRunStartedAt(t *testing.T) {
 	store := &RedisUpdateStore{}
 	now := time.Now().UTC().Truncate(time.Microsecond)
 	req := &UpdateRequest{
-		ID:            "upd-1",
-		RuntimeID:     "rt-1",
-		Status:        UpdateRunning,
-		TargetVersion: "v1.2.3",
-		CreatedAt:     now.Add(-time.Second),
-		UpdatedAt:     now,
-		RunStartedAt:  &now,
+		ID:              "upd-1",
+		RuntimeID:       "rt-1",
+		InitiatorUserID: "user-1",
+		Status:          UpdateRunning,
+		TargetVersion:   "v1.2.3",
+		CreatedAt:       now.Add(-time.Second),
+		UpdatedAt:       now,
+		RunStartedAt:    &now,
 	}
 
 	data, err := store.marshalRequest(req)
@@ -37,6 +38,9 @@ func TestRedisUpdateStore_EnvelopePersistsRunStartedAt(t *testing.T) {
 	if got.TargetVersion != "v1.2.3" {
 		t.Fatalf("target version lost: %+v", got)
 	}
+	if got.InitiatorUserID != "user-1" {
+		t.Fatalf("initiator user ID lost: %+v", got)
+	}
 }
 
 func TestRedisUpdateStore_CreateGetComplete(t *testing.T) {
@@ -44,7 +48,7 @@ func TestRedisUpdateStore_CreateGetComplete(t *testing.T) {
 	ctx := context.Background()
 	store := NewRedisUpdateStore(rdb)
 
-	req, err := store.Create(ctx, "runtime-1", "v1.2.3")
+	req, err := store.Create(ctx, "runtime-1", "v1.2.3", "user-1")
 	if err != nil {
 		t.Fatalf("create: %v", err)
 	}
@@ -71,7 +75,7 @@ func TestRedisUpdateStore_CreateGetComplete(t *testing.T) {
 		t.Fatalf("completed request mismatch: %+v", got)
 	}
 
-	if _, err := store.Create(ctx, "runtime-1", "v1.2.4"); err != nil {
+	if _, err := store.Create(ctx, "runtime-1", "v1.2.4", "user-1"); err != nil {
 		t.Fatalf("create after complete should be allowed: %v", err)
 	}
 }
@@ -83,7 +87,7 @@ func TestRedisUpdateStore_PopPendingAcrossInstances(t *testing.T) {
 	nodeA := NewRedisUpdateStore(rdb)
 	nodeB := NewRedisUpdateStore(rdb)
 
-	req, err := nodeA.Create(ctx, "runtime-cross", "v1.2.3")
+	req, err := nodeA.Create(ctx, "runtime-cross", "v1.2.3", "user-1")
 	if err != nil {
 		t.Fatalf("node A create: %v", err)
 	}
@@ -120,7 +124,7 @@ func TestRedisUpdateStore_ReportAndPollAcrossInstances(t *testing.T) {
 	nodeC := NewRedisUpdateStore(rdb)
 	nodeD := NewRedisUpdateStore(rdb)
 
-	req, err := nodeA.Create(ctx, "runtime-report", "v1.2.3")
+	req, err := nodeA.Create(ctx, "runtime-report", "v1.2.3", "user-1")
 	if err != nil {
 		t.Fatalf("node A create: %v", err)
 	}
@@ -148,7 +152,7 @@ func TestRedisUpdateStore_FailAcrossInstances(t *testing.T) {
 	nodeB := NewRedisUpdateStore(rdb)
 	nodeC := NewRedisUpdateStore(rdb)
 
-	req, err := nodeA.Create(ctx, "runtime-fail", "v1.2.3")
+	req, err := nodeA.Create(ctx, "runtime-fail", "v1.2.3", "user-1")
 	if err != nil {
 		t.Fatalf("create: %v", err)
 	}
@@ -173,17 +177,17 @@ func TestRedisUpdateStore_RejectsConcurrentActive(t *testing.T) {
 	ctx := context.Background()
 	store := NewRedisUpdateStore(rdb)
 
-	req, err := store.Create(ctx, "runtime-active", "v1.2.3")
+	req, err := store.Create(ctx, "runtime-active", "v1.2.3", "user-1")
 	if err != nil {
 		t.Fatalf("create: %v", err)
 	}
-	if _, err := store.Create(ctx, "runtime-active", "v1.2.4"); err != errUpdateInProgress {
+	if _, err := store.Create(ctx, "runtime-active", "v1.2.4", "user-1"); err != errUpdateInProgress {
 		t.Fatalf("second create error = %v, want errUpdateInProgress", err)
 	}
 	if err := store.Complete(ctx, req.ID, "done"); err != nil {
 		t.Fatalf("complete: %v", err)
 	}
-	if _, err := store.Create(ctx, "runtime-active", "v1.2.4"); err != nil {
+	if _, err := store.Create(ctx, "runtime-active", "v1.2.4", "user-1"); err != nil {
 		t.Fatalf("create after terminal should succeed: %v", err)
 	}
 }
@@ -193,7 +197,7 @@ func TestRedisUpdateStore_RunningTimeoutClearsActive(t *testing.T) {
 	ctx := context.Background()
 	store := NewRedisUpdateStore(rdb)
 
-	req, err := store.Create(ctx, "runtime-timeout", "v1.2.3")
+	req, err := store.Create(ctx, "runtime-timeout", "v1.2.3", "user-1")
 	if err != nil {
 		t.Fatalf("create: %v", err)
 	}
@@ -218,7 +222,7 @@ func TestRedisUpdateStore_RunningTimeoutClearsActive(t *testing.T) {
 	if got.Status != UpdateTimeout {
 		t.Fatalf("status = %s, want timeout", got.Status)
 	}
-	if _, err := store.Create(ctx, "runtime-timeout", "v1.2.4"); err != nil {
+	if _, err := store.Create(ctx, "runtime-timeout", "v1.2.4", "user-1"); err != nil {
 		t.Fatalf("create after timeout should succeed: %v", err)
 	}
 }
@@ -228,7 +232,7 @@ func TestRedisUpdateStore_PopPendingConcurrent(t *testing.T) {
 	ctx := context.Background()
 	store := NewRedisUpdateStore(rdb)
 
-	req, err := store.Create(ctx, "runtime-race", "v1.2.3")
+	req, err := store.Create(ctx, "runtime-race", "v1.2.3", "user-1")
 	if err != nil {
 		t.Fatalf("create: %v", err)
 	}

--- a/server/internal/handler/runtime_update_test.go
+++ b/server/internal/handler/runtime_update_test.go
@@ -14,7 +14,7 @@ func TestInMemoryUpdateStore_HasPending(t *testing.T) {
 		t.Fatalf("empty store should not report pending: has=%v err=%v", has, err)
 	}
 
-	if _, err := store.Create(ctx, "rt-1", "v1.2.3"); err != nil {
+	if _, err := store.Create(ctx, "rt-1", "v1.2.3", "user-1"); err != nil {
 		t.Fatalf("create: %v", err)
 	}
 	if has, err := store.HasPending(ctx, "rt-1"); err != nil || !has {
@@ -36,7 +36,7 @@ func TestInMemoryUpdateStore_PopPendingIgnoresTerminalHistory(t *testing.T) {
 	ctx := context.Background()
 	store := NewInMemoryUpdateStore()
 
-	first, err := store.Create(ctx, "rt-1", "v1.2.3")
+	first, err := store.Create(ctx, "rt-1", "v1.2.3", "user-1")
 	if err != nil {
 		t.Fatalf("create first: %v", err)
 	}
@@ -44,7 +44,7 @@ func TestInMemoryUpdateStore_PopPendingIgnoresTerminalHistory(t *testing.T) {
 		t.Fatalf("fail first: %v", err)
 	}
 	time.Sleep(2 * time.Millisecond)
-	second, err := store.Create(ctx, "rt-1", "v1.2.4")
+	second, err := store.Create(ctx, "rt-1", "v1.2.4", "user-1")
 	if err != nil {
 		t.Fatalf("create second: %v", err)
 	}
@@ -62,7 +62,7 @@ func TestInMemoryUpdateStore_RunningRequestTimesOut(t *testing.T) {
 	ctx := context.Background()
 	store := NewInMemoryUpdateStore()
 
-	req, err := store.Create(ctx, "rt-timeout", "v1.2.3")
+	req, err := store.Create(ctx, "rt-timeout", "v1.2.3", "user-1")
 	if err != nil {
 		t.Fatalf("create: %v", err)
 	}
@@ -95,17 +95,17 @@ func TestInMemoryUpdateStore_RejectsConcurrentActiveUntilTerminal(t *testing.T) 
 	ctx := context.Background()
 	store := NewInMemoryUpdateStore()
 
-	req, err := store.Create(ctx, "rt-1", "v1.2.3")
+	req, err := store.Create(ctx, "rt-1", "v1.2.3", "user-1")
 	if err != nil {
 		t.Fatalf("create: %v", err)
 	}
-	if _, err := store.Create(ctx, "rt-1", "v1.2.4"); err != errUpdateInProgress {
+	if _, err := store.Create(ctx, "rt-1", "v1.2.4", "user-1"); err != errUpdateInProgress {
 		t.Fatalf("second create error = %v, want errUpdateInProgress", err)
 	}
 	if err := store.Complete(ctx, req.ID, "done"); err != nil {
 		t.Fatalf("complete: %v", err)
 	}
-	if _, err := store.Create(ctx, "rt-1", "v1.2.4"); err != nil {
+	if _, err := store.Create(ctx, "rt-1", "v1.2.4", "user-1"); err != nil {
 		t.Fatalf("create after terminal should succeed: %v", err)
 	}
 }

--- a/server/internal/service/builtin_skills/multica-runtimes-and-repos/SKILL.md
+++ b/server/internal/service/builtin_skills/multica-runtimes-and-repos/SKILL.md
@@ -45,7 +45,7 @@ multica repo checkout <url>
 multica repo checkout <url> --ref <branch-or-sha>
 ```
 
-`runtime update` and `runtime delete` are writes. Updating a runtime is limited to its owner or a workspace owner/admin. `runtime delete` removes a runtime registration; if active agents are still bound, it refuses unless the user explicitly passes `--cascade`, which archives those agents and cancels their queued/running tasks before deleting the runtime. `repo checkout` creates a git worktree in the task working directory.
+`runtime update` and `runtime delete` are writes. Starting a runtime update is limited to its owner or a workspace owner/admin; the original initiator may keep polling that specific in-flight request if their admin role changes. `runtime delete` removes a runtime registration; if active agents are still bound, it refuses unless the user explicitly passes `--cascade`, which archives those agents and cancels their queued/running tasks before deleting the runtime. `repo checkout` creates a git worktree in the task working directory.
 
 `repo checkout` requires `MULTICA_DAEMON_PORT`; it is intended to run inside a daemon task. If absent, you are not in the normal agent checkout path. When a project `github_repo` resource has `resource_ref.ref`, `repo checkout <url>` uses that ref by default for the current task; an explicit `repo checkout <url> --ref <branch-or-sha>` overrides it.
 

--- a/server/internal/service/builtin_skills/multica-runtimes-and-repos/SKILL.md
+++ b/server/internal/service/builtin_skills/multica-runtimes-and-repos/SKILL.md
@@ -45,7 +45,7 @@ multica repo checkout <url>
 multica repo checkout <url> --ref <branch-or-sha>
 ```
 
-`runtime update` and `runtime delete` are writes. `runtime delete` removes a runtime registration; if active agents are still bound, it refuses unless the user explicitly passes `--cascade`, which archives those agents and cancels their queued/running tasks before deleting the runtime. `repo checkout` creates a git worktree in the task working directory.
+`runtime update` and `runtime delete` are writes. Updating a runtime is limited to its owner or a workspace owner/admin. `runtime delete` removes a runtime registration; if active agents are still bound, it refuses unless the user explicitly passes `--cascade`, which archives those agents and cancels their queued/running tasks before deleting the runtime. `repo checkout` creates a git worktree in the task working directory.
 
 `repo checkout` requires `MULTICA_DAEMON_PORT`; it is intended to run inside a daemon task. If absent, you are not in the normal agent checkout path. When a project `github_repo` resource has `resource_ref.ref`, `repo checkout <url>` uses that ref by default for the current task; an explicit `repo checkout <url> --ref <branch-or-sha>` overrides it.
 

--- a/server/internal/service/builtin_skills/multica-runtimes-and-repos/references/runtimes-and-repos-source-map.md
+++ b/server/internal/service/builtin_skills/multica-runtimes-and-repos/references/runtimes-and-repos-source-map.md
@@ -2,7 +2,7 @@
 
 - `server/cmd/multica/cmd_runtime.go` registers `runtime list`, `usage`, `activity`, `update`, and `delete`.
 - `runtime list` reads `/api/runtimes` and prints `id`, `name`, `runtime_mode`, `provider`, `status`, and `last_seen_at`.
-- `runtime update` posts to `/api/runtimes/{runtime-id}/update`; with `--wait` it polls update status.
+- `runtime update` posts to `/api/runtimes/{runtime-id}/update`; with `--wait` it polls update status. Both handlers enforce runtime-owner or workspace-owner/admin access through `canEditRuntime` in `server/internal/handler/runtime_update.go` and `runtime.go`.
 - `runtime delete` deletes `/api/runtimes/{runtime-id}`; with `--cascade`, it first reads the `runtime_has_active_agents` conflict payload and posts those ids to `/api/runtimes/{runtime-id}/archive-agents-and-delete`.
 - `server/cmd/multica/cmd_repo.go` registers `repo checkout <url> [--ref]`.
 - `repo checkout` requires `MULTICA_DAEMON_PORT`, sends `workspace_id`, `workdir`, `ref`, `agent_name`, and `task_id` to local daemon `/repo/checkout`, then prints the checked-out path.

--- a/server/internal/service/builtin_skills/multica-runtimes-and-repos/references/runtimes-and-repos-source-map.md
+++ b/server/internal/service/builtin_skills/multica-runtimes-and-repos/references/runtimes-and-repos-source-map.md
@@ -2,7 +2,7 @@
 
 - `server/cmd/multica/cmd_runtime.go` registers `runtime list`, `usage`, `activity`, `update`, and `delete`.
 - `runtime list` reads `/api/runtimes` and prints `id`, `name`, `runtime_mode`, `provider`, `status`, and `last_seen_at`.
-- `runtime update` posts to `/api/runtimes/{runtime-id}/update`; with `--wait` it polls update status. Both handlers enforce runtime-owner or workspace-owner/admin access through `canEditRuntime` in `server/internal/handler/runtime_update.go` and `runtime.go`.
+- `runtime update` posts to `/api/runtimes/{runtime-id}/update`; with `--wait` it polls update status. Initiation enforces runtime-owner or workspace-owner/admin access through `canEditRuntime`; status polling additionally permits that request's immutable initiator so an in-flight poll survives an admin-role change (`server/internal/handler/runtime_update.go` and `runtime.go`).
 - `runtime delete` deletes `/api/runtimes/{runtime-id}`; with `--cascade`, it first reads the `runtime_has_active_agents` conflict payload and posts those ids to `/api/runtimes/{runtime-id}/archive-agents-and-delete`.
 - `server/cmd/multica/cmd_repo.go` registers `repo checkout <url> [--ref]`.
 - `repo checkout` requires `MULTICA_DAEMON_PORT`, sends `workspace_id`, `workdir`, `ref`, `agent_name`, and `task_id` to local daemon `/repo/checkout`, then prints the checked-out path.


### PR DESCRIPTION
## Summary

- let workspace owners/admins use an online machine runtime as the CLI update command channel
- enforce the same runtime-owner or workspace-owner/admin permission on update creation and polling APIs
- show a localized read-only reason to members who can inspect version status but cannot update
- document the authorization contract in the built-in runtime skill

## Safety

- unauthorized requests are rejected before an update is enqueued
- public runtime visibility does not grant machine-management permission
- Desktop-managed runtimes continue to hide the Web CLI update action
- no migration, persisted-format, daemon-protocol, or deployment changes

## Validation

- focused runtime UI and locale parity tests: 166 passed
- full monorepo TypeScript typecheck
- `@multica/views` lint: 0 errors (19 pre-existing warnings)
- full `server/internal/handler` test package
- built-in skill conformance tests
- `git diff --check`

Closes MUL-4861
