### PR TITLE
fix(ci): de-flake chat draft-restore reconciliation test (MUL-4856)

### DIFF
--- a/packages/views/chat/components/use-chat-draft-restore.test.tsx
+++ b/packages/views/chat/components/use-chat-draft-restore.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, vi } from "vitest";
-import { act, renderHook, waitFor } from "@testing-library/react";
+import { act, renderHook, waitFor, configure } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import type { ReactNode } from "react";
 
@@ -68,6 +68,18 @@ vi.mock("@multica/core/logger", () => ({
 
 import type { Attachment } from "@multica/core/types";
 import { useChatDraftRestore } from "./use-chat-draft-restore";
+
+// Every assertion here drives a real react-query fetch and mutation, so each
+// `waitFor` gates on a multi-hop async chain (fetch → effect → mutate → settle →
+// refetch). The reconciliation case chains the most hops — consume, settle, a
+// stale refetch on returning to the session, then a re-consume — and timed out
+// under the default 1s `waitFor` budget when the full Vitest suite saturated the
+// CI runner (the whole run took 405s, import alone 364s). Widen both the
+// async-utility and per-test budgets for this file so whole-suite contention
+// can't starve the chain; the defaults stay in force everywhere else (Vitest
+// isolates config per file).
+vi.setConfig({ testTimeout: 20000 });
+configure({ asyncUtilTimeout: 5000 });
 
 function wrapper({ children }: { children: ReactNode }) {
   const qc = new QueryClient({


### PR DESCRIPTION
## Summary

Fixes the `frontend` CI failure that appeared on `main` after PR #5508 merged (`MUL-4856`).

PR #5508 is **Go-only** (`server/internal/daemon/**`), so it cannot change any frontend logic. What it did was land a new commit on `main`, re-running CI on a badly saturated runner — the whole run took **405s** (import alone **364s**). Under that contention, one timing-sensitive frontend test timed out:

```
FAIL  chat/components/use-chat-draft-restore.test.tsx
  > useChatDraftRestore reconciliation (#5219)
  > re-consumes a row on the next fetch after the consume failed
AssertionError: expected "vi.fn()" to be called 2 times, but got 1 times
```

## Root cause

Every assertion in this suite drives a real react-query fetch + mutation, so each `waitFor` gates on a multi-hop async chain (fetch → effect → mutate → settle → refetch). The reconciliation case chains the **most** hops:

1. `consume#1` fires and rejects (offline),
2. its `onSettled` clears the in-flight ref,
3. returning to the session triggers a `staleTime: 0` **refetch**,
4. the refetch re-runs the reconcile effect,
5. `consume#2` fires.

That whole chain normally finishes in tens of ms, but under a starved event loop it can exceed the **default 1000ms `waitFor` budget**, and the assertion throws before `consume#2` lands. It is a pure timeout, not a logic regression — which is why the test passes on every normal run and only flaked on a contended one.

Proven locally: pinning just the retry `waitFor` to a tiny time budget reproduces the exact `expected 2 times, but got 1 times` error, and delaying the mocked refetch to ~1300ms fails under a 1000ms budget but passes once the budget is widened.

## Fix

Widen this file's async-utility and per-test timeouts so whole-suite CI contention can't starve the chain:

```ts
vi.setConfig({ testTimeout: 20000 });
configure({ asyncUtilTimeout: 5000 });
```

Test-only change, no product code touched. Vitest isolates config per file, so the defaults stay in force everywhere else.

## Verification

- `pnpm exec vitest run chat/components/use-chat-draft-restore.test.tsx` → 8/8 pass.
- With the fix, a ~1300ms-delayed refetch (past the old 1s budget) passes; pinning the retry `waitFor` back to 1000ms reproduces the original failure.
- `eslint` clean, `tsc --noEmit` clean (exit 0).
