### PR TITLE
feat(provenance): surface the official release baseline of the running frontend and backend

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help makehelp dev server daemon cli multica build test migrate-up migrate-down sqlc seed clean setup start stop check worktree-env setup-main start-main stop-main check-main setup-worktree start-worktree stop-worktree check-worktree db-up db-down db-reset selfhost selfhost-build selfhost-stop
+.PHONY: help makehelp dev server daemon cli multica build build-prod test migrate-up migrate-down sqlc seed clean setup start stop check worktree-env setup-main start-main stop-main check-main setup-worktree start-worktree stop-worktree check-worktree db-up db-down db-reset selfhost selfhost-build selfhost-stop
 
 MAIN_ENV_FILE ?= .env
 WORKTREE_ENV_FILE ?= .env.worktree
@@ -150,7 +150,20 @@ selfhost-build: ## Build backend/web from the current checkout and start the sel
 		fi; \
 		echo "==> Generated random JWT_SECRET and POSTGRES_PASSWORD"; \
 	fi
-	@echo "==> Building Multica from the current checkout..."
+	@set -e; \
+	echo "==> Resolving official release baseline..."; \
+	BASELINE=$$(bash scripts/resolve-official-baseline.sh) || { \
+		echo ""; \
+		echo "Could not resolve an official release baseline."; \
+		echo "Build from a checkout with reachable upstream tags, or set:"; \
+		echo "  MULTICA_TRUSTED_BASELINE=vX.Y.Z"; \
+		echo "before running make selfhost-build."; \
+		exit 1; \
+	}; \
+	echo "==> Official release baseline: $$BASELINE"; \
+	export VERSION="$$BASELINE"; \
+	export NEXT_PUBLIC_APP_VERSION="$$BASELINE"; \
+	echo "==> Building Multica from the current checkout..."; \
 	$(COMPOSE) -f docker-compose.selfhost.yml -f docker-compose.selfhost.build.yml up -d --build
 	@echo "==> Waiting for backend to be ready..."
 	@for i in $$(seq 1 30); do \
@@ -317,6 +330,17 @@ build: ## Build the server, CLI, and migrate binaries into server/bin
 	cd server && go build -ldflags "-X main.version=$(VERSION) -X main.commit=$(COMMIT)" -o bin/server ./cmd/server
 	cd server && go build -ldflags "-X main.version=$(VERSION) -X main.commit=$(COMMIT) -X main.date=$(DATE)" -o bin/multica ./cmd/multica
 	cd server && go build -o bin/migrate ./cmd/migrate
+
+build-prod: ## Build a production server binary and web bundle stamped with the resolved official baseline
+	@set -e; \
+	BASELINE=$$(bash scripts/resolve-official-baseline.sh) || { \
+		echo "Could not resolve an official release baseline."; \
+		echo "Build from a checkout with reachable upstream tags, or set MULTICA_TRUSTED_BASELINE=vX.Y.Z."; \
+		exit 1; \
+	}; \
+	echo "==> Official release baseline: $$BASELINE"; \
+	cd server && CGO_ENABLED=0 go build -ldflags "-s -w -X main.version=$$BASELINE" -o bin/server ./cmd/server; \
+	cd .. && NEXT_PUBLIC_APP_VERSION="$$BASELINE" pnpm --filter @multica/web build
 
 test: ## Run Go tests after ensuring the target DB exists and migrations are applied
 	$(REQUIRE_ENV)

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help makehelp dev server daemon cli multica build build-prod test migrate-up migrate-down sqlc seed clean setup start stop check worktree-env setup-main start-main stop-main check-main setup-worktree start-worktree stop-worktree check-worktree db-up db-down db-reset selfhost selfhost-build selfhost-stop
+.PHONY: help makehelp dev server daemon cli multica build build-prod upgrade test migrate-up migrate-down sqlc seed clean setup start stop check worktree-env setup-main start-main stop-main check-main setup-worktree start-worktree stop-worktree check-worktree db-up db-down db-reset selfhost selfhost-build selfhost-stop
 
 MAIN_ENV_FILE ?= .env
 WORKTREE_ENV_FILE ?= .env.worktree
@@ -382,3 +382,30 @@ clean: ## Remove build caches, generated binaries, and temp files
 	rm -rf .turbo apps/*/.turbo packages/*/.turbo
 	rm -rf apps/*/*.tsbuildinfo packages/*/*.tsbuildinfo
 	@echo "✓ Clean complete."
+
+# Resolves the upstream-verified baseline once, then rebuilds the backend
+# (with -X main.version=<baseline>) and the frontend prod bundle (with
+# NEXT_PUBLIC_APP_VERSION=<baseline> in .env) so a single `make upgrade`
+# brings both halves of runtime build provenance up to date.
+#
+# Assumes you're running the backend via nohup/PM2 and the frontend via
+# `next start` (or another supervisor). After the build, restart the
+# running processes — this target does not kill or restart them itself,
+# since the supervisor varies per deployment.
+upgrade: ## Rebuild backend + frontend prod bundle with the resolved official baseline
+	@if [ -z "$(BASELINE_OVERRIDE)" ]; then \
+		BASELINE=$$(bash scripts/resolve-official-baseline.sh) || exit 1; \
+	else \
+		BASELINE=$(BASELINE_OVERRIDE); \
+	fi
+	@echo "==> Official baseline: $$BASELINE"
+	@if [ ! -f .env ]; then \
+		echo "Missing .env. Copy from .env.example first." >&2; exit 1; \
+	fi
+	@sed -i.bak "s|^NEXT_PUBLIC_APP_VERSION=.*|NEXT_PUBLIC_APP_VERSION=$$BASELINE|" .env
+	@echo "==> .env: NEXT_PUBLIC_APP_VERSION set to $$BASELINE (backup at .env.bak)"
+	cd server && CGO_ENABLED=0 go build -ldflags "-s -w -X main.version=$$BASELINE" -o bin/server ./cmd/server
+	cd apps/web && pnpm build
+	@echo ""
+	@echo "Built with baseline $$BASELINE. Restart the running backend and frontend processes"
+	@echo "to pick up the new artifacts (e.g. \`pm2 restart all\` or your usual supervisor)."

--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ multica setup          # Connect to Multica Cloud, log in, start daemon
 > ```
 >
 > This pulls the official Multica images from GHCR (latest stable by default). Requires Docker. See the [Self-Hosting Guide](SELF_HOSTING.md) for details.
-> If the selected GHCR tag has not been published yet, fall back to `make selfhost-build` from a checkout.
+> If the selected GHCR tag has not been published yet, fall back to `make selfhost-build` from a checkout. The build override requires both `VERSION` (backend) and `NEXT_PUBLIC_APP_VERSION` (web) — `make selfhost-build` resolves them via the official upstream release tags; raw `docker compose` needs them passed explicitly. See `SELF_HOSTING.md → Manual Docker Compose Setup → Source build from checkout`.
 
 ---
 

--- a/SELF_HOSTING.md
+++ b/SELF_HOSTING.md
@@ -427,7 +427,7 @@ docker compose -f docker-compose.selfhost.yml up -d
 ```
 
 Pin `MULTICA_IMAGE_TAG` in `.env` to an exact version like `v0.2.4` if you want to stay on a specific release. Migrations run automatically on backend startup.
-If the selected GHCR tag has not been published yet, fall back to `make selfhost-build` or `docker compose -f docker-compose.selfhost.yml -f docker-compose.selfhost.build.yml up -d --build`.
+If the selected GHCR tag has not been published yet, fall back to `make selfhost-build` (resolves the official release baseline on the host and threads it into both backend and web Docker builds) or, if you prefer raw compose, see [Manual Docker Compose Setup → Source build from checkout](#source-build-from-checkout) for the required `VERSION` / `NEXT_PUBLIC_APP_VERSION` overrides.
 
 > **Upgrading from `v0.3.4` to `v0.3.5+` fails with `refusing to drop legacy daily rollups: ...`?** That's migration `103`'s fail-closed guard: it requires `task_usage_hourly` to be seeded before the legacy daily rollups are dropped. As of MUL-2957 `migrate up` runs that backfill automatically right before applying `103`, so the upgrade completes in a single invocation. If you are still on a pre-MUL-2957 binary or the auto-hook fails, run `backfill_task_usage_hourly` manually first, then re-run the upgrade. Full instructions in [Advanced Configuration → Usage Dashboard Rollup](SELF_HOSTING_ADVANCED.md#usage-dashboard-rollup).
 
@@ -455,6 +455,48 @@ Then start everything:
 docker compose -f docker-compose.selfhost.yml pull
 docker compose -f docker-compose.selfhost.yml up -d
 ```
+
+### Source build from checkout
+
+To build the backend and web images from your current checkout (instead of pulling official ones), use `make selfhost-build`. It resolves the official release baseline on the host via `scripts/resolve-official-baseline.sh` and threads it into both Docker builds in one step.
+
+If you prefer raw `docker compose`, you **must** pass the baseline explicitly — the build override now requires both `VERSION` (backend) and `NEXT_PUBLIC_APP_VERSION` (web) and rejects a `dev` default, so a bare invocation fails instead of silently stamping an unstamped build:
+
+```bash
+VERSION=vX.Y.Z \
+NEXT_PUBLIC_APP_VERSION=vX.Y.Z \
+docker compose -f docker-compose.selfhost.yml -f docker-compose.selfhost.build.yml up -d --build
+```
+
+Replace `vX.Y.Z` with the real upstream release tag you intend to ship. The sidebar Help menu shows both values after a hard refresh — if either reads `unavailable`, the rebuild did not take effect.
+
+### Direct production build (no Docker)
+
+For self-hosted production deployments that don't run the Docker Compose stack, `make build-prod` resolves the same official baseline and produces a server binary plus web bundle stamped with it:
+
+```bash
+make build-prod    # writes server/bin/server and apps/web/.next/...
+```
+
+`make build-prod` fails fast if the baseline cannot be resolved (shallow clone without tags, source archive, offline build, or a fork whose `v*` tags are not on the upstream remote) — see [Recovery when baseline can't be resolved](#recovery-when-baseline-cant-be-resolved).
+
+### Recovery when baseline can't be resolved
+
+`scripts/resolve-official-baseline.sh` derives the nearest reachable upstream tag via `git describe --tags --abbrev=0 --match 'v[0-9]*'` and verifies it against the canonical upstream release tags. The following contexts can't be auto-derived and require an explicit trusted override:
+
+- **Shallow clone** without tags (only the latest commit fetched).
+- **Source archive** (tarball / zip without a `.git` history).
+- **Fork** whose own `v*` tags are not present on the canonical upstream (`https://github.com/multica-ai/multica`).
+- **Offline / air-gapped** build that cannot reach the upstream remote.
+
+In any of these contexts, set `MULTICA_TRUSTED_BASELINE` to the upstream release tag the build is based on (e.g. `vX.Y.Z`) before invoking `make selfhost-build` or `make build-prod`:
+
+```bash
+export MULTICA_TRUSTED_BASELINE=vX.Y.Z
+make selfhost-build
+```
+
+The displayed value in the Help sidebar is the upstream-verified baseline — it does not prove the source is clean or that the artifact is an unmodified official image, only that the running build is associated with the upstream release you supplied.
 
 ## Manual CLI Configuration
 

--- a/SELF_HOSTING.md
+++ b/SELF_HOSTING.md
@@ -482,7 +482,7 @@ make build-prod    # writes server/bin/server and apps/web/.next/...
 
 ### Recovery when baseline can't be resolved
 
-`scripts/resolve-official-baseline.sh` derives the nearest reachable upstream tag via `git describe --tags --abbrev=0 --match 'v[0-9]*'` and verifies it against the canonical upstream release tags. The following contexts can't be auto-derived and require an explicit trusted override:
+`scripts/resolve-official-baseline.sh` derives the nearest reachable upstream tag via `git describe --tags --abbrev=0 --match 'v[0-9]*'` and verifies it against the canonical upstream release tags. All four of the contexts below share one prerequisite: **the resolver calls `git ls-remote https://github.com/multica-ai/multica`**, so the build host needs network access to that URL — unless an explicit trusted override is supplied, the resolver cannot proceed. The four failure modes that require the override:
 
 - **Shallow clone** without tags (only the latest commit fetched).
 - **Source archive** (tarball / zip without a `.git` history).

--- a/SELF_HOSTING.md
+++ b/SELF_HOSTING.md
@@ -431,6 +431,30 @@ If the selected GHCR tag has not been published yet, fall back to `make selfhost
 
 > **Upgrading from `v0.3.4` to `v0.3.5+` fails with `refusing to drop legacy daily rollups: ...`?** That's migration `103`'s fail-closed guard: it requires `task_usage_hourly` to be seeded before the legacy daily rollups are dropped. As of MUL-2957 `migrate up` runs that backfill automatically right before applying `103`, so the upgrade completes in a single invocation. If you are still on a pre-MUL-2957 binary or the auto-hook fails, run `backfill_task_usage_hourly` manually first, then re-run the upgrade. Full instructions in [Advanced Configuration → Usage Dashboard Rollup](SELF_HOSTING_ADVANCED.md#usage-dashboard-rollup).
 
+### Direct production upgrade (no Docker)
+
+For self-host deployments that run the backend and frontend directly from the checkout (no Docker Compose), `make upgrade` rebuilds both halves with the **single upstream-verified baseline** so the Help sidebar's two rows — Frontend and Backend — never drift out of sync:
+
+```bash
+git pull
+make upgrade
+# then restart your running processes, e.g.:
+#   pm2 restart all
+#   # or, if you launched them via nohup:
+kill -TERM $(pgrep -f 'server/bin/server|next start') && \
+  nohup ./server/bin/server > /tmp/multica-server.log 2>&1 & \
+  nohup bash -c 'cd apps/web && exec pnpm exec next start -p 3001' > /tmp/multica-web-prod.log 2>&1 &
+```
+
+What `make upgrade` does, in order:
+
+1. Calls `scripts/resolve-official-baseline.sh` once to pick the upstream-verified tag (`vX.Y.Z`); if the resolver can't reach the upstream or the checkout has no `v*` tag reachable, set `BASELINE_OVERRIDE=vX.Y.Z` to supply an explicit trusted baseline (see [Recovery when baseline can't be resolved](#recovery-when-baseline-cant-be-resolved)).
+2. Writes the resolved baseline to `NEXT_PUBLIC_APP_VERSION` in `.env` (preserves a backup at `.env.bak`) so the frontend prod bundle can bake it in at `pnpm build` time.
+3. Rebuilds the backend binary with `-X main.version=<baseline>` so `server_version` in `/api/config` reflects the new baseline.
+4. Runs `pnpm build` in `apps/web`, producing a fresh frontend prod bundle whose `Help` menu shows the same `<baseline>`.
+
+After `make upgrade` completes, restart the backend and frontend processes with your supervisor (PM2, systemd, nohup, etc.). The Help sidebar will then show `Frontend vX.Y.Z` and `Backend vX.Y.Z` for the new release. If `.env` is missing, `make upgrade` aborts early — copy from `.env.example` first.
+
 ---
 
 ## Manual Docker Compose Setup

--- a/apps/web/components/web-providers.tsx
+++ b/apps/web/components/web-providers.tsx
@@ -77,6 +77,12 @@ export function WebProviders({
         clearLoggedInCookie();
       }}
       identity={identity}
+      // Pass the raw build-time version (no package.json/dev fallback) to the
+      // platform boundary. The config store validates it via officialBaseline,
+      // so a dev bundle or un-stamped build becomes "unavailable" rather than
+      // a false baseline. Identity.version above still carries the analytics
+      // fallback for PostHog — intentionally separate from provenance.
+      frontendBaseline={process.env.NEXT_PUBLIC_APP_VERSION}
       locale={locale}
       resources={resources}
       localeAdapter={localeAdapter}

--- a/apps/web/components/web-providers.tsx
+++ b/apps/web/components/web-providers.tsx
@@ -5,6 +5,7 @@ import { CoreProvider } from "@multica/core/platform";
 import { createBrowserCookieLocaleAdapter } from "@multica/core/i18n/browser";
 import type { LocaleResources, SupportedLocale } from "@multica/core/i18n";
 import { useWelcomeStore } from "@multica/core/onboarding";
+import { officialBaseline } from "@multica/core/config";
 import packageJson from "../package.json";
 import { WebNavigationProvider } from "@/platform/navigation";
 import {
@@ -77,12 +78,14 @@ export function WebProviders({
         clearLoggedInCookie();
       }}
       identity={identity}
-      // Pass the raw build-time version (no package.json/dev fallback) to the
-      // platform boundary. The config store validates it via officialBaseline,
-      // so a dev bundle or un-stamped build becomes "unavailable" rather than
-      // a false baseline. Identity.version above still carries the analytics
-      // fallback for PostHog — intentionally separate from provenance.
-      frontendBaseline={process.env.NEXT_PUBLIC_APP_VERSION}
+      // Wrap the raw build-time version in officialBaseline at the platform
+      // boundary so the value reaching core/config is already canonical.
+      // The store also validates as defense-in-depth, but sanitizing here
+      // makes the contract visible at the seam: the API surface takes a
+      // clean v… tag (or ""), not "anything a build script happened to set".
+      // The analytics identity.version above still carries the package.json
+      // / dev fallback for PostHog — intentionally separate from provenance.
+      frontendBaseline={officialBaseline(process.env.NEXT_PUBLIC_APP_VERSION)}
       locale={locale}
       resources={resources}
       localeAdapter={localeAdapter}

--- a/docker-compose.selfhost.build.yml
+++ b/docker-compose.selfhost.build.yml
@@ -8,7 +8,11 @@ services:
       context: .
       dockerfile: Dockerfile
       args:
-        VERSION: ${VERSION:-dev}
+        # Required official release baseline, resolved on the host by
+        # `make selfhost-build` (scripts/resolve-official-baseline.sh) or
+        # supplied explicitly. Never defaults to `dev`: a raw `docker compose`
+        # invocation must fail rather than silently stamp a non-release.
+        VERSION: ${VERSION:?VERSION is required; run make selfhost-build or set VERSION / MULTICA_TRUSTED_BASELINE}
         COMMIT: ${COMMIT:-unknown}
         DATE: ${DATE:-unknown}
 
@@ -20,4 +24,6 @@ services:
       args:
         REMOTE_API_URL: http://backend:8080
         NEXT_PUBLIC_WS_URL: ${NEXT_PUBLIC_WS_URL:-}
-        NEXT_PUBLIC_APP_VERSION: dev
+        # Same official baseline as the backend, threaded into the web bundle
+        # by `make selfhost-build`. Required for the same reason as VERSION.
+        NEXT_PUBLIC_APP_VERSION: ${NEXT_PUBLIC_APP_VERSION:?NEXT_PUBLIC_APP_VERSION is required; run make selfhost-build or set NEXT_PUBLIC_APP_VERSION / MULTICA_TRUSTED_BASELINE}

--- a/packages/core/api/client.ts
+++ b/packages/core/api/client.ts
@@ -1649,8 +1649,8 @@ export class ApiClient {
   }
 
   // App Config
-  async getConfig(): Promise<AppConfigResponse> {
-    const raw = await this.fetch<unknown>("/api/config");
+  async getConfig(signal?: AbortSignal): Promise<AppConfigResponse> {
+    const raw = await this.fetch<unknown>("/api/config", signal ? { signal } : undefined);
     return parseWithFallback<AppConfigResponse>(raw, AppConfigSchema, EMPTY_APP_CONFIG, {
       endpoint: "GET /api/config",
     });

--- a/packages/core/config/index.test.ts
+++ b/packages/core/config/index.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { configStore, officialBaseline } from "./index";
+
+describe("officialBaseline", () => {
+  it("returns the tag only for a clean v… official release", () => {
+    expect(officialBaseline("v0.4.0")).toBe("v0.4.0");
+  });
+  it("rejects dev, empty, and undefined", () => {
+    expect(officialBaseline("dev")).toBe("");
+    expect(officialBaseline("")).toBe("");
+    expect(officialBaseline(undefined)).toBe("");
+  });
+  it("rejects git-describe commit-distance suffixes", () => {
+    expect(officialBaseline("v0.4.0-5-gabc1234")).toBe("");
+    expect(officialBaseline("v0.4.0-rc1-3-gabc1234")).toBe("");
+  });
+  it("rejects the dirty marker", () => {
+    expect(officialBaseline("v0.4.0-dirty")).toBe("");
+  });
+  it("rejects hashes and non-v values", () => {
+    expect(officialBaseline("abc1234")).toBe("");
+    expect(officialBaseline("garbage")).toBe("");
+    expect(officialBaseline("1.2.3")).toBe("");
+  });
+  it("accepts a prerelease tag with no describe suffix", () => {
+    expect(officialBaseline("v0.4.0-rc1")).toBe("v0.4.0-rc1");
+  });
+  it("trims surrounding whitespace", () => {
+    expect(officialBaseline(" v0.4.0 ")).toBe("v0.4.0");
+  });
+});
+
+describe("configStore build-provenance state", () => {
+  beforeEach(() => {
+    // Reset only the fields the provenance flow owns so unrelated store
+    // state (featureFlags, auth, …) doesn't leak between tests.
+    configStore.setState({
+      frontendBaseline: "",
+      backendBaseline: "",
+      backendBaselineStatus: "loading",
+      serverVersion: "",
+    });
+  });
+
+  it("starts with backend baseline loading and both values unavailable", () => {
+    expect(configStore.getState().frontendBaseline).toBe("");
+    expect(configStore.getState().backendBaseline).toBe("");
+    expect(configStore.getState().backendBaselineStatus).toBe("loading");
+  });
+
+  it("setFrontendBaseline stores a clean tag as the frontend baseline", () => {
+    configStore.getState().setFrontendBaseline("v0.4.2");
+    expect(configStore.getState().frontendBaseline).toBe("v0.4.2");
+  });
+
+  it("setFrontendBaseline rejects dev/non-tag values so a package.json or dev fallback never becomes a baseline", () => {
+    configStore.getState().setFrontendBaseline("dev");
+    expect(configStore.getState().frontendBaseline).toBe("");
+    configStore.getState().setFrontendBaseline("0.1.0");
+    expect(configStore.getState().frontendBaseline).toBe("");
+    configStore.getState().setFrontendBaseline("v0.4.0-5-gabc1234");
+    expect(configStore.getState().frontendBaseline).toBe("");
+  });
+
+  it("setBackendBaseline stores the normalized value and transitions loading -> settled", () => {
+    configStore.getState().setBackendBaseline("v0.4.2");
+    expect(configStore.getState().backendBaseline).toBe("v0.4.2");
+    expect(configStore.getState().backendBaselineStatus).toBe("settled");
+  });
+
+  it("setBackendBaseline called with no value marks settled and unavailable (fetch failure path)", () => {
+    configStore.setState({ backendBaselineStatus: "loading" });
+    configStore.getState().setBackendBaseline();
+    expect(configStore.getState().backendBaseline).toBe("");
+    expect(configStore.getState().backendBaselineStatus).toBe("settled");
+  });
+
+  it("setBackendBaseline rejects non-baseline values from a buggy server", () => {
+    configStore.getState().setBackendBaseline("v0.4.2-5-gabc1234");
+    expect(configStore.getState().backendBaseline).toBe("");
+    expect(configStore.getState().backendBaselineStatus).toBe("settled");
+  });
+
+  it("partial deployment: frontend and backend can differ", () => {
+    configStore.getState().setFrontendBaseline("v0.4.2");
+    configStore.getState().setBackendBaseline("v0.4.1");
+    expect(configStore.getState().frontendBaseline).toBe("v0.4.2");
+    expect(configStore.getState().backendBaseline).toBe("v0.4.1");
+    expect(configStore.getState().backendBaselineStatus).toBe("settled");
+  });
+});

--- a/packages/core/config/index.test.ts
+++ b/packages/core/config/index.test.ts
@@ -38,7 +38,7 @@ describe("configStore build-provenance state", () => {
       frontendBaseline: "",
       backendBaseline: "",
       backendBaselineStatus: "loading",
-      serverVersion: "",
+      // serverVersion removed in U4 (replaced by frontendBaseline/backendBaseline)
     });
   });
 

--- a/packages/core/config/index.ts
+++ b/packages/core/config/index.ts
@@ -1,6 +1,23 @@
 import { createStore } from "zustand/vanilla";
 import { useStore } from "zustand";
 
+// git-describe commit-distance suffix (-N-g<hash>) on a tag, e.g. v0.4.2-5-gabc1234.
+const DESCRIBE_SUFFIX_RE = /-\d+-g[0-9a-f]{4,}$/;
+
+/** officialBaseline returns the tag only when it is a trustworthy official
+ *  release baseline: a clean vX.Y.Z-style tag carrying no commit-distance
+ *  suffix (-N-g<hash>) or dirty marker. Dev builds, package-version
+ *  fallbacks, hashes, and any non-v value map to "" so the UI shows
+ *  "unavailable" instead of presenting a non-release as a baseline. Shared by
+ *  the frontend- and backend-baseline setters so both components use one rule. */
+export function officialBaseline(v?: string): string {
+  const tag = (v ?? "").trim();
+  if (!tag || tag === "dev") return "";
+  if (!/^v\d/.test(tag)) return "";
+  if (tag.includes("-dirty") || DESCRIBE_SUFFIX_RE.test(tag)) return "";
+  return tag;
+}
+
 interface ConfigState {
   cdnDomain: string;
   // True when cdnDomain serves private content via time-bounded signed URLs
@@ -20,6 +37,16 @@ interface ConfigState {
   // self-hosted operators can confirm what's deployed. Empty for dev builds
   // or servers older than this feature.
   serverVersion: string;
+  // Official release baseline of the loaded frontend bundle (clean vX.Y.Z tag
+  // compiled in at build time), or "" when the bundle was not stamped with a
+  // trustworthy tag (dev build). Known synchronously at boot — no loading state.
+  frontendBaseline: string;
+  // Official release baseline of the running backend (from /api/config), or ""
+  // when unavailable (dev/old server, fetch failure, or a non-baseline value).
+  backendBaseline: string;
+  // "loading" until the non-blocking /api/config request settles, so the UI
+  // shows a loading state instead of prematurely marking the backend unavailable.
+  backendBaselineStatus: "loading" | "settled";
   setCdnConfig: (config: { cdnDomain: string; cdnSigned?: boolean }) => void;
   setAuthConfig: (config: {
     allowSignup: boolean;
@@ -32,6 +59,8 @@ interface ConfigState {
   }) => void;
   setFeatureFlags: (flags?: Record<string, boolean>) => void;
   setServerVersion: (version?: string) => void;
+  setFrontendBaseline: (baseline?: string) => void;
+  setBackendBaseline: (baseline?: string) => void;
 }
 
 export const configStore = createStore<ConfigState>((set) => ({
@@ -44,6 +73,9 @@ export const configStore = createStore<ConfigState>((set) => ({
   workspaceCreationDisabled: false,
   featureFlags: {},
   serverVersion: "",
+  frontendBaseline: "",
+  backendBaseline: "",
+  backendBaselineStatus: "loading",
   setCdnConfig: ({ cdnDomain, cdnSigned = false }) => set({ cdnDomain, cdnSigned }),
   setAuthConfig: ({ allowSignup, googleClientId = "", workspaceCreationDisabled = false }) =>
     set({ allowSignup, googleClientId, workspaceCreationDisabled }),
@@ -51,6 +83,9 @@ export const configStore = createStore<ConfigState>((set) => ({
     set({ daemonServerUrl, daemonAppUrl }),
   setFeatureFlags: (flags = {}) => set({ featureFlags: { ...flags } }),
   setServerVersion: (version = "") => set({ serverVersion: version }),
+  setFrontendBaseline: (baseline) => set({ frontendBaseline: officialBaseline(baseline) }),
+  setBackendBaseline: (baseline) =>
+    set({ backendBaseline: officialBaseline(baseline), backendBaselineStatus: "settled" }),
 }));
 
 export function useConfigStore(): ConfigState;

--- a/packages/core/config/index.ts
+++ b/packages/core/config/index.ts
@@ -33,10 +33,6 @@ interface ConfigState {
   // the managed-cloud case.
   workspaceCreationDisabled: boolean;
   featureFlags: Record<string, boolean>;
-  // The running API build version, surfaced in the Help popover so
-  // self-hosted operators can confirm what's deployed. Empty for dev builds
-  // or servers older than this feature.
-  serverVersion: string;
   // Official release baseline of the loaded frontend bundle (clean vX.Y.Z tag
   // compiled in at build time), or "" when the bundle was not stamped with a
   // trustworthy tag (dev build). Known synchronously at boot — no loading state.
@@ -58,7 +54,6 @@ interface ConfigState {
     daemonAppUrl?: string;
   }) => void;
   setFeatureFlags: (flags?: Record<string, boolean>) => void;
-  setServerVersion: (version?: string) => void;
   setFrontendBaseline: (baseline?: string) => void;
   setBackendBaseline: (baseline?: string) => void;
 }
@@ -72,7 +67,6 @@ export const configStore = createStore<ConfigState>((set) => ({
   daemonAppUrl: "",
   workspaceCreationDisabled: false,
   featureFlags: {},
-  serverVersion: "",
   frontendBaseline: "",
   backendBaseline: "",
   backendBaselineStatus: "loading",
@@ -82,7 +76,6 @@ export const configStore = createStore<ConfigState>((set) => ({
   setDaemonConfig: ({ daemonServerUrl = "", daemonAppUrl = "" }) =>
     set({ daemonServerUrl, daemonAppUrl }),
   setFeatureFlags: (flags = {}) => set({ featureFlags: { ...flags } }),
-  setServerVersion: (version = "") => set({ serverVersion: version }),
   setFrontendBaseline: (baseline) => set({ frontendBaseline: officialBaseline(baseline) }),
   setBackendBaseline: (baseline) =>
     set({ backendBaseline: officialBaseline(baseline), backendBaselineStatus: "settled" }),

--- a/packages/core/platform/auth-initializer.tsx
+++ b/packages/core/platform/auth-initializer.tsx
@@ -28,6 +28,7 @@ export function AuthInitializer({
   storage = defaultStorage,
   cookieAuth,
   identity,
+  frontendBaseline,
 }: {
   children: ReactNode;
   onLogin?: () => void;
@@ -35,6 +36,7 @@ export function AuthInitializer({
   storage?: StorageAdapter;
   cookieAuth?: boolean;
   identity?: ClientIdentity;
+  frontendBaseline?: string;
 }) {
   const qc = useQueryClient();
 
@@ -44,6 +46,11 @@ export function AuthInitializer({
     // Stamp attribution before anything else — the signup event (server-side)
     // reads this cookie, so it has to be present before the user hits submit.
     captureSignupSource();
+
+    // The frontend official baseline is known synchronously at boot (it's
+    // compiled into the bundle). Set it before the config fetch so a quick
+    // Help-menu open before /api/config settles still shows the frontend row.
+    configStore.getState().setFrontendBaseline(frontendBaseline);
 
     // Fetch app config (CDN domain, PostHog key, …) in the background — non-blocking.
     api
@@ -69,6 +76,8 @@ export function AuthInitializer({
         });
         configStore.getState().setFeatureFlags(cfg.feature_flags);
         configStore.getState().setServerVersion(cfg.server_version);
+        // Backend official baseline (with loading -> settled transition).
+        configStore.getState().setBackendBaseline(cfg.server_version);
         if (cfg.posthog_key) {
           initAnalytics({
             key: cfg.posthog_key,
@@ -79,7 +88,10 @@ export function AuthInitializer({
         }
       })
       .catch(() => {
-        /* config is optional — legacy file card matching degrades gracefully */
+        // Config is optional — legacy file card matching degrades gracefully.
+        // Still mark the backend baseline settled (unavailable) so the UI
+        // doesn't show "loading" forever after a fetch failure.
+        configStore.getState().setBackendBaseline();
       });
 
     const onAuthSuccess = (user: User) => {

--- a/packages/core/platform/auth-initializer.tsx
+++ b/packages/core/platform/auth-initializer.tsx
@@ -52,9 +52,17 @@ export function AuthInitializer({
     // Help-menu open before /api/config settles still shows the frontend row.
     configStore.getState().setFrontendBaseline(frontendBaseline);
 
+    // Bound the non-blocking /api/config request with a wall-clock timeout so
+    // a silently dropped network or indefinitely-pending CORS preflight can't
+    // leave backendBaselineStatus stuck at "loading" (which would render as
+    // "Backend loading…" in the Help menu forever). 8s is well above a
+    // healthy same-origin response and well below any user-perceived wait.
+    const configController = new AbortController();
+    const configTimeout = setTimeout(() => configController.abort(), 8000);
+
     // Fetch app config (CDN domain, PostHog key, …) in the background — non-blocking.
     api
-      .getConfig()
+      .getConfig(configController.signal)
       .then((cfg) => {
         if (cfg.cdn_domain) {
           configStore.getState().setCdnConfig({
@@ -91,6 +99,9 @@ export function AuthInitializer({
         // Still mark the backend baseline settled (unavailable) so the UI
         // doesn't show "loading" forever after a fetch failure.
         configStore.getState().setBackendBaseline();
+      })
+      .finally(() => {
+        clearTimeout(configTimeout);
       });
 
     const onAuthSuccess = (user: User) => {

--- a/packages/core/platform/auth-initializer.tsx
+++ b/packages/core/platform/auth-initializer.tsx
@@ -75,7 +75,6 @@ export function AuthInitializer({
           daemonAppUrl: cfg.daemon_app_url,
         });
         configStore.getState().setFeatureFlags(cfg.feature_flags);
-        configStore.getState().setServerVersion(cfg.server_version);
         // Backend official baseline (with loading -> settled transition).
         configStore.getState().setBackendBaseline(cfg.server_version);
         if (cfg.posthog_key) {

--- a/packages/core/platform/core-provider.tsx
+++ b/packages/core/platform/core-provider.tsx
@@ -90,6 +90,7 @@ export function CoreProvider({
   onLogin,
   onLogout,
   identity,
+  frontendBaseline,
   locale,
   resources,
   localeAdapter,
@@ -116,6 +117,7 @@ export function CoreProvider({
         storage={storage}
         cookieAuth={cookieAuth}
         identity={identity}
+        frontendBaseline={frontendBaseline}
       >
         <WSProvider
           wsUrl={wsUrl}

--- a/packages/core/platform/types.ts
+++ b/packages/core/platform/types.ts
@@ -33,6 +33,11 @@ export interface CoreProviderProps {
   onLogout?: () => void;
   /** Identifies the calling client (web/desktop + version + os) to the server. */
   identity?: ClientIdentity;
+  /** Official release baseline of the loaded frontend bundle, as a raw
+   *  build-time tag (e.g. NEXT_PUBLIC_APP_VERSION). The config store validates
+   *  it via officialBaseline, so pass the raw value — dev/non-tag input
+   *  becomes "" (unavailable) rather than a false baseline. */
+  frontendBaseline?: string;
   /** Active locale, determined server-side (web) or at app boot (desktop). */
   locale: SupportedLocale;
   /** i18next resources, server-preloaded for the active locale. */

--- a/packages/views/layout/help-launcher.test.tsx
+++ b/packages/views/layout/help-launcher.test.tsx
@@ -22,8 +22,8 @@ vi.mock("../i18n", () => ({
 }));
 
 // Follows the app-sidebar.test.tsx convention of flattening the Base UI
-// dropdown primitives to plain children so the menu content is always in
-// the DOM, instead of exercising the real portal/open-state interaction.
+// dropdown primitives to plain children so the menu content is always in the
+// DOM, instead of exercising the real portal/open-state interaction.
 //
 // The mock deliberately preserves ONE real invariant: DropdownMenuLabel wraps
 // Base UI's Menu.GroupLabel, whose useMenuGroupRootContext() throws when it has
@@ -56,28 +56,81 @@ vi.mock("@multica/ui/components/ui/dropdown-menu", async () => {
 });
 
 afterEach(() => {
-  configStore.getState().setServerVersion("");
+  configStore.getState().setFrontendBaseline("");
+  configStore.getState().setBackendBaseline("");
+  // Force the loading -> settled transition back to loading so each test
+  // sees the initial loading state on the backend row.
+  configStore.setState({ backendBaselineStatus: "loading" });
 });
 
-describe("HelpLauncher", () => {
-  it("does not show a version row when the server omits it", () => {
+describe("HelpLauncher provenance rows", () => {
+  it("renders two rows (frontend + backend) even when both values are unavailable", () => {
     render(<HelpLauncher />);
-    expect(screen.queryByText(/Server version/)).not.toBeInTheDocument();
+    expect(screen.getByText(enLayout.help.frontend_label)).toBeInTheDocument();
+    expect(screen.getByText(enLayout.help.backend_label)).toBeInTheDocument();
+    expect(
+      screen.getAllByText(enLayout.help.frontend_unavailable).length,
+    ).toBeGreaterThan(0);
+    // Backend defaults to "loading" before the non-blocking /api/config resolves.
+    expect(
+      screen.getByText(enLayout.help.backend_loading),
+    ).toBeInTheDocument();
   });
 
-  it("shows the server version once /api/config resolves it", () => {
-    configStore.getState().setServerVersion("1.2.3");
+  it("shows the frontend and backend tags side by side when both are stamped", () => {
+    configStore.getState().setFrontendBaseline("v0.4.2");
+    configStore.getState().setBackendBaseline("v0.4.2");
     render(<HelpLauncher />);
-    expect(screen.getByText("Server version 1.2.3")).toBeInTheDocument();
+    const tags = screen.getAllByText("v0.4.2");
+    expect(tags.length).toBe(2);
   });
 
-  // MUL-4819: the version row's DropdownMenuLabel must sit inside a
-  // DropdownMenuGroup. Rendering it bare made Base UI's Menu.GroupLabel throw
-  // on open, unmounting the whole app (black screen, no error) because no error
-  // boundary sits above the sidebar. Rendering here must not throw.
-  it("renders the version row without a missing-group crash", () => {
-    configStore.getState().setServerVersion("9.9.9");
+  it("shows two different tags when frontend and backend are out of sync", () => {
+    configStore.getState().setFrontendBaseline("v0.4.2");
+    configStore.getState().setBackendBaseline("v0.4.1");
+    render(<HelpLauncher />);
+    expect(screen.getByText("v0.4.2")).toBeInTheDocument();
+    expect(screen.getByText("v0.4.1")).toBeInTheDocument();
+  });
+
+  it("shows the backend tag alongside an unavailable frontend", () => {
+    configStore.getState().setFrontendBaseline("");
+    configStore.getState().setBackendBaseline("v0.4.2");
+    render(<HelpLauncher />);
+    expect(
+      screen.getByText(enLayout.help.frontend_unavailable),
+    ).toBeInTheDocument();
+    expect(screen.getByText("v0.4.2")).toBeInTheDocument();
+  });
+
+  it("shows the frontend tag alongside a loading backend", () => {
+    configStore.getState().setFrontendBaseline("v0.4.2");
+    configStore.setState({ backendBaselineStatus: "loading" });
+    render(<HelpLauncher />);
+    expect(screen.getByText("v0.4.2")).toBeInTheDocument();
+    expect(
+      screen.getByText(enLayout.help.backend_loading),
+    ).toBeInTheDocument();
+  });
+
+  it("shows both rows as unavailable after a config failure settles", () => {
+    configStore.getState().setFrontendBaseline("");
+    configStore.getState().setBackendBaseline(); // settled, unavailable
+    render(<HelpLauncher />);
+    expect(
+      screen.getByText(enLayout.help.frontend_unavailable),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(enLayout.help.backend_unavailable),
+    ).toBeInTheDocument();
+  });
+
+  // MUL-4819 (kept as a guardrail): both DropdownMenuLabels must sit inside a
+  // DropdownMenuGroup. Rendering either outside a group would crash the app on
+  // open. The DropdownMenuLabel mock throws if it has no Group ancestor.
+  it("does not throw when rendering both rows under a DropdownMenuGroup", () => {
+    configStore.getState().setFrontendBaseline("v0.4.2");
+    configStore.getState().setBackendBaseline("v0.4.2");
     expect(() => render(<HelpLauncher />)).not.toThrow();
-    expect(screen.getByText("Server version 9.9.9")).toBeInTheDocument();
   });
 });

--- a/packages/views/layout/help-launcher.tsx
+++ b/packages/views/layout/help-launcher.tsx
@@ -20,7 +20,28 @@ const CHANGELOG_URL = "https://multica.ai/changelog";
 
 export function HelpLauncher() {
   const { t } = useT("layout");
-  const serverVersion = useConfigStore((state) => state.serverVersion);
+  // Read frontend and backend observations independently so a partial
+  // rollout or a missing backend metadata can render each row with its own
+  // state (tag / loading / unavailable) instead of inventing a value.
+  const frontendBaseline = useConfigStore((state) => state.frontendBaseline);
+  const backendBaseline = useConfigStore((state) => state.backendBaseline);
+  const backendBaselineStatus = useConfigStore(
+    (state) => state.backendBaselineStatus,
+  );
+
+  // The provenance rows are intentionally always present in the DOM (even
+  // when unavailable): self-host operators rely on them to confirm what is
+  // deployed. A hidden row would make a stale or rolled-back artifact look
+  // identical to a missing one, defeating the whole feature.
+  const frontendText = frontendBaseline
+    ? frontendBaseline
+    : t(($) => $.help.frontend_unavailable);
+  const backendText =
+    backendBaseline ||
+    (backendBaselineStatus === "loading"
+      ? t(($) => $.help.backend_loading)
+      : t(($) => $.help.backend_unavailable));
+
   return (
     <DropdownMenu>
       <DropdownMenuTrigger
@@ -73,21 +94,23 @@ export function HelpLauncher() {
           <MessageCircle className="h-3.5 w-3.5" />
           {t(($) => $.help.feedback)}
         </DropdownMenuItem>
-        {serverVersion && (
-          <>
-            <DropdownMenuSeparator />
-            {/* DropdownMenuLabel renders Base UI's Menu.GroupLabel, which reads
-                a Menu.Group context and throws if it has no Group ancestor. It
-                must always be wrapped in a DropdownMenuGroup — without it the
-                Help menu crashes the whole app on open (no error boundary sits
-                above the sidebar). */}
-            <DropdownMenuGroup>
-              <DropdownMenuLabel className="font-normal break-words">
-                {t(($) => $.help.server_version, { version: serverVersion })}
-              </DropdownMenuLabel>
-            </DropdownMenuGroup>
-          </>
-        )}
+        <DropdownMenuSeparator />
+        {/* DropdownMenuLabel renders Base UI's Menu.GroupLabel, which reads
+            a Menu.Group context and throws if it has no Group ancestor. It
+            must always be wrapped in a DropdownMenuGroup — without it the
+            Help menu crashes the whole app on open (no error boundary sits
+            above the sidebar). Two rows share one Group so a single
+            dropdown-label context surrounds both. */}
+        <DropdownMenuGroup>
+          <DropdownMenuLabel className="flex items-center gap-2 font-normal text-muted-foreground">
+            <span>{t(($) => $.help.frontend_label)}</span>
+            <span className="text-foreground">{frontendText}</span>
+          </DropdownMenuLabel>
+          <DropdownMenuLabel className="flex items-center gap-2 font-normal text-muted-foreground">
+            <span>{t(($) => $.help.backend_label)}</span>
+            <span className="text-foreground">{backendText}</span>
+          </DropdownMenuLabel>
+        </DropdownMenuGroup>
       </DropdownMenuContent>
     </DropdownMenu>
   );

--- a/packages/views/locales/en/layout.json
+++ b/packages/views/locales/en/layout.json
@@ -23,7 +23,7 @@
     "backend_label": "Backend",
     "frontend_unavailable": "Frontend unavailable",
     "backend_unavailable": "Backend unavailable",
-    "backend_loading": "Backend loading…"
+    "backend_loading": "Backend loading..."
   },
   "workspace_loader": {
     "loading_workspace": "Loading workspace…",

--- a/packages/views/locales/en/layout.json
+++ b/packages/views/locales/en/layout.json
@@ -19,7 +19,11 @@
     "changelog": "Change log",
     "discord": "Discord",
     "feedback": "Feedback",
-    "server_version": "Server version {{version}}"
+    "frontend_label": "Frontend",
+    "backend_label": "Backend",
+    "frontend_unavailable": "Frontend unavailable",
+    "backend_unavailable": "Backend unavailable",
+    "backend_loading": "Backend loading…"
   },
   "workspace_loader": {
     "loading_workspace": "Loading workspace…",

--- a/packages/views/locales/ja/layout.json
+++ b/packages/views/locales/ja/layout.json
@@ -23,7 +23,7 @@
     "backend_label": "バックエンド",
     "frontend_unavailable": "フロントエンドのバージョンを取得できません",
     "backend_unavailable": "バックエンドのバージョンを取得できません",
-    "backend_loading": "バックエンドのバージョン取得中…"
+    "backend_loading": "バックエンドのバージョン取得中..."
   },
   "workspace_loader": {
     "loading_workspace": "ワークスペースを読み込み中…",

--- a/packages/views/locales/ja/layout.json
+++ b/packages/views/locales/ja/layout.json
@@ -19,7 +19,11 @@
     "changelog": "変更ログ",
     "discord": "Discord",
     "feedback": "フィードバック",
-    "server_version": "サーバーバージョン {{version}}"
+    "frontend_label": "フロントエンド",
+    "backend_label": "バックエンド",
+    "frontend_unavailable": "フロントエンドのバージョンを取得できません",
+    "backend_unavailable": "バックエンドのバージョンを取得できません",
+    "backend_loading": "バックエンドのバージョン取得中…"
   },
   "workspace_loader": {
     "loading_workspace": "ワークスペースを読み込み中…",

--- a/packages/views/locales/ko/layout.json
+++ b/packages/views/locales/ko/layout.json
@@ -19,7 +19,11 @@
     "changelog": "변경 로그",
     "discord": "Discord",
     "feedback": "피드백",
-    "server_version": "서버 버전 {{version}}"
+    "frontend_label": "프런트엔드",
+    "backend_label": "백엔드",
+    "frontend_unavailable": "프런트엔드 버전 정보를 사용할 수 없음",
+    "backend_unavailable": "백엔드 버전 정보를 사용할 수 없음",
+    "backend_loading": "백엔드 버전 정보 로드 중…"
   },
   "workspace_loader": {
     "loading_workspace": "워크스페이스 로딩 중...",

--- a/packages/views/locales/ko/layout.json
+++ b/packages/views/locales/ko/layout.json
@@ -23,7 +23,7 @@
     "backend_label": "백엔드",
     "frontend_unavailable": "프런트엔드 버전 정보를 사용할 수 없음",
     "backend_unavailable": "백엔드 버전 정보를 사용할 수 없음",
-    "backend_loading": "백엔드 버전 정보 로드 중…"
+    "backend_loading": "백엔드 버전 정보 로드 중..."
   },
   "workspace_loader": {
     "loading_workspace": "워크스페이스 로딩 중...",

--- a/packages/views/locales/zh-Hans/layout.json
+++ b/packages/views/locales/zh-Hans/layout.json
@@ -19,7 +19,11 @@
     "changelog": "更新日志",
     "discord": "Discord",
     "feedback": "反馈",
-    "server_version": "服务器版本 {{version}}"
+    "frontend_label": "前端",
+    "backend_label": "后端",
+    "frontend_unavailable": "前端版本不可用",
+    "backend_unavailable": "后端版本不可用",
+    "backend_loading": "后端版本加载中…"
   },
   "workspace_loader": {
     "loading_workspace": "正在加载工作区...",

--- a/packages/views/locales/zh-Hans/layout.json
+++ b/packages/views/locales/zh-Hans/layout.json
@@ -23,7 +23,7 @@
     "backend_label": "后端",
     "frontend_unavailable": "前端版本不可用",
     "backend_unavailable": "后端版本不可用",
-    "backend_loading": "后端版本加载中…"
+    "backend_loading": "后端版本加载中..."
   },
   "workspace_loader": {
     "loading_workspace": "正在加载工作区...",

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -264,6 +264,7 @@ pull_official_selfhost_images() {
   echo "This can happen before the first GHCR release is available."
   echo "From $INSTALL_DIR, build from source instead:"
   echo "  docker compose -f docker-compose.selfhost.yml -f docker-compose.selfhost.build.yml up -d --build"
+    echo "  (requires VERSION and NEXT_PUBLIC_APP_VERSION — 'make selfhost-build' resolves them for you)"
   exit 1
 }
 

--- a/scripts/resolve-official-baseline.sh
+++ b/scripts/resolve-official-baseline.sh
@@ -52,8 +52,9 @@ verify_upstream() {
 		return 2
 	fi
 	# ls-remote --tags emits: <sha>\trefs/tags/<tag> and, for annotated tags,
-	# <sha>\trefs/tags/<tag>^{}. Strip down to one clean tag name per line.
-	names=$(printf '%s\n' "$refs" | sed 's#.*refs/tags/##; s#\^{}$##')
+	# <sha>\trefs/tags/<tag>^{}. Reduce to one clean tag name per line via awk so
+	# the pipeline is identical on macOS BSD sed and GNU sed (POSIX-portable).
+	names=$(printf '%s\n' "$refs" | awk -F'/tags/' '{p=$2; sub(/\^{}$/, "", p); print p}')
 	if printf '%s\n' "$names" | grep -Fxq "$candidate"; then
 		return 0
 	fi
@@ -64,6 +65,10 @@ candidate=""
 reason=""
 
 if candidate=$(git describe --tags --abbrev=0 --match 'v[0-9]*' 2>/dev/null) && [ -n "$candidate" ]; then
+	# Trim the candidate for parity with the TS/Go officialBaseline helpers and
+	# with the override path below; `git describe --abbrev=0` already trims, but
+	# defending here keeps the boundary consistent across the three layers.
+	candidate=$(printf '%s' "$candidate" | tr -d '\r' | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')
 	if verify_upstream "$candidate"; then
 		printf '%s\n' "$candidate"
 		exit 0
@@ -79,6 +84,11 @@ fi
 # Derivation unavailable — fall back to the explicit trusted baseline.
 if [ -n "$TRUSTED_BASELINE" ]; then
 	if is_official_tag "$TRUSTED_BASELINE"; then
+		# Re-read the trimmed value so the printed baseline matches the
+		# normalized form (no leading/trailing whitespace). is_official_tag
+		# already trims internally; capture that here for the output path.
+		TRUSTED_BASELINE="${TRUSTED_BASELINE#"${TRUSTED_BASELINE%%[![:space:]]*}"}"
+		TRUSTED_BASELINE="${TRUSTED_BASELINE%"${TRUSTED_BASELINE##*[![:space:]]}"}"
 		printf '%s\n' "$TRUSTED_BASELINE"
 		exit 0
 	fi

--- a/scripts/resolve-official-baseline.sh
+++ b/scripts/resolve-official-baseline.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+# Resolve the official release baseline tag for a self-hosted build.
+#
+# Authority order (runtime-build-provenance plan, KTD1):
+#   1. Derive the nearest reachable official tag with
+#      `git describe --tags --abbrev=0 --match 'v[0-9]*'`. The result is
+#      exactly the tag, never a commit-distance/hash suffix.
+#   2. Verify the candidate exists among the canonical upstream release
+#      tags (`git ls-remote --tags` against MULTICA_UPSTREAM_REMOTE). A tag
+#      that is only local/fork-created, or an upstream that cannot be
+#      reached, leaves derivation unavailable.
+#   3. Fall back to an explicit trusted operator baseline
+#      (MULTICA_TRUSTED_BASELINE) only when derivation is unavailable.
+#   4. Exit non-zero when neither is available. Never emit `dev`, a commit
+#      hash, or a dirty suffix as a valid baseline.
+#
+# Output: exactly the baseline tag on stdout (nothing else); diagnostics on
+# stderr. Operates on the current git repository, so run it from the
+# checkout root on the host before Docker context creation (`.dockerignore`
+# excludes `.git`, so this cannot run inside Docker). See
+# scripts/resolve-official-baseline.test.sh for the behavior contract.
+set -euo pipefail
+
+# Canonical upstream whose tags define an "official" release. Kept as a
+# single constant so a heavily-forked deployment that tracks a different
+# upstream can retarget verification in one place.
+UPSTREAM_REMOTE="${MULTICA_UPSTREAM_REMOTE:-https://github.com/multica-ai/multica}"
+TRUSTED_BASELINE="${MULTICA_TRUSTED_BASELINE:-}"
+
+fail() {
+	echo "resolve-official-baseline: $*" >&2
+	echo "  Derivation unavailable. Set MULTICA_TRUSTED_BASELINE=vX.Y.Z to supply an explicit trusted baseline." >&2
+	exit 1
+}
+
+# A valid official tag starts with 'v' + digit and carries no git-describe
+# commit-distance/hash suffix (-<n>-g<hash>).
+is_official_tag() {
+	local tag="$1"
+	[[ "$tag" =~ ^v[0-9] ]] || return 1
+	# Defensive: abbrev=0 already prevents describe suffixes.
+	[[ "$tag" =~ -[0-9]+-g[0-9a-f]{4,}$ ]] && return 1
+	return 0
+}
+
+# Return 0 if $1 is among the upstream's tags, 1 if absent, 2 if the
+# upstream cannot be reached.
+verify_upstream() {
+	local candidate="$1" refs names
+	if ! refs=$(git ls-remote --tags "$UPSTREAM_REMOTE" 2>/dev/null); then
+		return 2
+	fi
+	# ls-remote --tags emits: <sha>\trefs/tags/<tag> and, for annotated tags,
+	# <sha>\trefs/tags/<tag>^{}. Strip down to one clean tag name per line.
+	names=$(printf '%s\n' "$refs" | sed 's#.*refs/tags/##; s#\^{}$##')
+	if printf '%s\n' "$names" | grep -Fxq "$candidate"; then
+		return 0
+	fi
+	return 1
+}
+
+candidate=""
+reason=""
+
+if candidate=$(git describe --tags --abbrev=0 --match 'v[0-9]*' 2>/dev/null) && [ -n "$candidate" ]; then
+	if verify_upstream "$candidate"; then
+		printf '%s\n' "$candidate"
+		exit 0
+	elif [ "$?" = "2" ]; then
+		reason="could not reach upstream '$UPSTREAM_REMOTE' to verify nearest tag '$candidate'"
+	else
+		reason="nearest tag '$candidate' is not present on upstream '$UPSTREAM_REMOTE'"
+	fi
+else
+	reason="no reachable v* tag in this checkout"
+fi
+
+# Derivation unavailable — fall back to the explicit trusted baseline.
+if [ -n "$TRUSTED_BASELINE" ]; then
+	if is_official_tag "$TRUSTED_BASELINE"; then
+		printf '%s\n' "$TRUSTED_BASELINE"
+		exit 0
+	fi
+	fail "MULTICA_TRUSTED_BASELINE='$TRUSTED_BASELINE' is not a valid official tag (expected a v... tag). $reason"
+fi
+
+fail "cannot establish official baseline: $reason"

--- a/scripts/resolve-official-baseline.sh
+++ b/scripts/resolve-official-baseline.sh
@@ -37,6 +37,7 @@ fail() {
 # commit-distance/hash suffix (-<n>-g<hash>).
 is_official_tag() {
 	local tag="$1"
+	tag="${tag#"${tag%%[![:space:]]*}"}"; tag="${tag%"${tag##*[![:space:]]}"}"
 	[[ "$tag" =~ ^v[0-9] ]] || return 1
 	# Defensive: abbrev=0 already prevents describe suffixes.
 	[[ "$tag" =~ -[0-9]+-g[0-9a-f]{4,}$ ]] && return 1

--- a/scripts/resolve-official-baseline.test.sh
+++ b/scripts/resolve-official-baseline.test.sh
@@ -132,6 +132,12 @@ expect_fail "tagless checkout without override fails"
 run_resolver "$WORK/fork" "$WORK/upstream" "v8.8.8"
 expect_ok "trusted override used for fork-only tag" "v8.8.8"
 
+# Lock the parity contract surfaced by the resolver review: the trusted override
+# path trims surrounding whitespace, matching the TS and Go officialBaseline
+# helpers. Without this case the trim symmetry would have no test coverage.
+run_resolver "$WORK/exact" "$WORK/does-not-exist" " v8.8.8 "
+expect_ok "trusted override trims surrounding whitespace" "v8.8.8"
+
 echo
 echo "pass=$pass fail=$fails"
 [ "$fails" = "0" ] || exit 1

--- a/scripts/resolve-official-baseline.test.sh
+++ b/scripts/resolve-official-baseline.test.sh
@@ -1,0 +1,137 @@
+#!/usr/bin/env bash
+# Tests for scripts/resolve-official-baseline.sh.
+#
+# Builds throwaway local git fixtures (a "checkout" repo and an "upstream"
+# repo of canonical release tags) and asserts the official-baseline
+# resolution semantics from the runtime-build-provenance plan (KTD1):
+#   - nearest reachable tag via `git describe --abbrev=0` (no commit suffix)
+#   - candidate verified against the canonical upstream tags
+#   - explicit trusted override only when derivation is unavailable
+#   - failure (never `dev`/hash/dirty) when neither source exists
+#
+# The upstream is a *local* fixture path so the resolver's `git ls-remote`
+# verification can be exercised offline.
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+RESOLVER="$ROOT_DIR/scripts/resolve-official-baseline.sh"
+
+pass=0
+fails=0
+RC_OUT=""
+RC_STATUS=0
+
+# Run the resolver inside a fixture checkout with a given upstream and
+# (optional) trusted baseline. Captures stdout into RC_OUT and exit status
+# into RC_STATUS.
+run_resolver() {
+	local checkout="$1" upstream="$2" trusted="${3:-}"
+	local out rc=0
+	out="$(
+		cd "$checkout"
+		export MULTICA_UPSTREAM_REMOTE="$upstream"
+		export MULTICA_TRUSTED_BASELINE="$trusted"
+		"$RESOLVER" 2>/dev/null
+	)" || rc=$?
+	RC_OUT="$out"
+	RC_STATUS="$rc"
+}
+
+expect_ok() { # name expected-tag
+	local name="$1" want="$2"
+	if [ "$RC_STATUS" = "0" ] && [ "$RC_OUT" = "$want" ]; then
+		echo "ok   - $name"
+		pass=$((pass + 1))
+	else
+		echo "FAIL - $name: expected exit 0 out [$want], got exit $RC_STATUS out [$RC_OUT]"
+		fails=$((fails + 1))
+	fi
+}
+
+expect_fail() { # name
+	local name="$1"
+	if [ "$RC_STATUS" != "0" ]; then
+		echo "ok   - $name"
+		pass=$((pass + 1))
+	else
+		echo "FAIL - $name: expected non-zero exit, got exit 0 out [$RC_OUT]"
+		fails=$((fails + 1))
+	fi
+}
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+# Create a fixture repo at $1 with one commit, then tag it with the remaining args.
+make_repo() {
+	local path="$1"
+	shift
+	mkdir -p "$path"
+	git -C "$path" init -q
+	git -C "$path" config user.email t@t.t
+	git -C "$path" config user.name t
+	git -C "$path" commit -q --allow-empty -m init
+	for tag in "$@"; do git -C "$path" tag "$tag"; done
+}
+
+# Upstream canonical release tags.
+make_repo "$WORK/upstream" v9.9.9 v1.2.3
+
+# Checkout at exactly v9.9.9.
+make_repo "$WORK/exact" v9.9.9
+
+# Checkout with commits after v9.9.9.
+make_repo "$WORK/posttag" v9.9.9
+git -C "$WORK/posttag" commit -q --allow-empty -m c1
+git -C "$WORK/posttag" commit -q --allow-empty -m c2
+
+# Checkout at v9.9.9 with a dirty working tree.
+make_repo "$WORK/dirty" v9.9.9
+echo x >"$WORK/dirty/file"
+git -C "$WORK/dirty" add file
+
+# Checkout whose only tag is fork-only (not on the upstream).
+make_repo "$WORK/fork" v7.7.7-forkonly
+
+# Checkout with no tags at all.
+make_repo "$WORK/notags"
+
+# 1. exact official checkout, upstream carries the tag
+run_resolver "$WORK/exact" "$WORK/upstream" ""
+expect_ok "exact checkout resolves nearest upstream tag" "v9.9.9"
+
+# 2. commits after the tag resolve to exactly the tag (no -N-g<hash> suffix)
+run_resolver "$WORK/posttag" "$WORK/upstream" ""
+expect_ok "post-tag commits resolve to exactly the tag" "v9.9.9"
+
+# 3. dirty working tree does not add a dirty suffix
+run_resolver "$WORK/dirty" "$WORK/upstream" ""
+expect_ok "dirty working tree keeps the clean tag" "v9.9.9"
+
+# 4. fork-only tag not on upstream, no override -> fail
+run_resolver "$WORK/fork" "$WORK/upstream" ""
+expect_fail "fork-only tag without override fails"
+
+# 5. unreachable upstream, no override -> fail
+run_resolver "$WORK/exact" "$WORK/does-not-exist" ""
+expect_fail "unreachable upstream without override fails"
+
+# 6. unreachable upstream + trusted override -> override
+run_resolver "$WORK/exact" "$WORK/does-not-exist" "v8.8.8"
+expect_ok "trusted override used when derivation unavailable" "v8.8.8"
+
+# 7. unreachable upstream + invalid trusted baseline -> fail
+run_resolver "$WORK/exact" "$WORK/does-not-exist" "garbage"
+expect_fail "invalid trusted baseline fails"
+
+# 8. checkout without tags, no override -> fail
+run_resolver "$WORK/notags" "$WORK/upstream" ""
+expect_fail "tagless checkout without override fails"
+
+# 9. fork-only tag + trusted override -> override (derivation unavailable)
+run_resolver "$WORK/fork" "$WORK/upstream" "v8.8.8"
+expect_ok "trusted override used for fork-only tag" "v8.8.8"
+
+echo
+echo "pass=$pass fail=$fails"
+[ "$fails" = "0" ] || exit 1

--- a/scripts/selfhost-config.test.sh
+++ b/scripts/selfhost-config.test.sh
@@ -84,4 +84,34 @@ require_env "$local_env" 'MULTICA_SERVER_URL=ws://localhost:9100/ws'
 require_env "$local_env" 'LOCAL_UPLOAD_BASE_URL=http://localhost:9100'
 require_env "$local_env" 'PLAYWRIGHT_BASE_URL=http://localhost:3100'
 
+# Build override threads the resolved official baseline into both images and
+# never defaults provenance to `dev`. The no-dev constraint is verified against
+# the file directly so it does not depend on a Docker daemon being present.
+if grep -Fq '${VERSION:-dev}' docker-compose.selfhost.build.yml \
+	|| grep -Fq 'NEXT_PUBLIC_APP_VERSION: dev' docker-compose.selfhost.build.yml; then
+	echo "Build override must not default provenance to dev."
+	exit 1
+fi
+
+# With a baseline supplied, the resolved config carries it for both images.
+build_config_with_tag="$(
+  VERSION=v9.9.9-test \
+  NEXT_PUBLIC_APP_VERSION=v9.9.9-test \
+  docker compose \
+    -f docker-compose.selfhost.yml \
+    -f docker-compose.selfhost.build.yml \
+    config 2>/dev/null
+)"
+require_config "$build_config_with_tag" 'v9.9.9-test'
+
+# A raw invocation without a baseline must fail rather than stamp `dev`.
+if env -u VERSION -u NEXT_PUBLIC_APP_VERSION \
+  docker compose \
+    -f docker-compose.selfhost.yml \
+    -f docker-compose.selfhost.build.yml \
+    config >/dev/null 2>&1; then
+	echo "Build override must require VERSION / NEXT_PUBLIC_APP_VERSION (no dev default)."
+	exit 1
+fi
+
 echo "self-host env derivation ok"

--- a/server/cmd/server/main_test.go
+++ b/server/cmd/server/main_test.go
@@ -79,11 +79,12 @@ func TestNewNamedRedisClient_DisableClientName_InvalidValue(t *testing.T) {
 	}
 }
 
-// TestNormalizeServerVersion covers the router-config wiring path (not just
-// a hand-set handler.Config field): an unstamped "dev" build must not leak
-// into /api/config's server_version, or the Help popover would render
-// "Server version dev" instead of hiding the row.
-func TestNormalizeServerVersion(t *testing.T) {
+// TestOfficialBaseline covers the router-config wiring path (not just a
+// hand-set handler.Config field): only a clean official release tag is
+// reportable as /api/config's server_version. Dev builds, dirty checkouts,
+// commit-distance suffixes, hashes, and non-v values map to "" so the Help
+// popover hides the row instead of presenting a non-release as a baseline.
+func TestOfficialBaseline(t *testing.T) {
 	tests := []struct {
 		name string
 		in   string
@@ -92,11 +93,17 @@ func TestNormalizeServerVersion(t *testing.T) {
 		{"unstamped_dev_default_becomes_empty", "dev", ""},
 		{"already_empty_stays_empty", "", ""},
 		{"stamped_release_tag_passes_through", "v0.4.0", "v0.4.0"},
+		{"describe_commit_suffix_is_rejected", "v0.4.0-5-gabc1234", ""},
+		{"dirty_marker_is_rejected", "v0.4.0-dirty", ""},
+		{"bare_hash_is_rejected", "abc1234", ""},
+		{"non_v_value_is_rejected", "garbage", ""},
+		{"prerelease_tag_passes_through", "v0.4.0-rc1", "v0.4.0-rc1"},
+		{"surrounding_whitespace_is_trimmed", " v0.4.0 ", "v0.4.0"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := normalizeServerVersion(tt.in); got != tt.want {
-				t.Errorf("normalizeServerVersion(%q) = %q, want %q", tt.in, got, tt.want)
+			if got := officialBaseline(tt.in); got != tt.want {
+				t.Errorf("officialBaseline(%q) = %q, want %q", tt.in, got, tt.want)
 			}
 		})
 	}

--- a/server/cmd/server/router.go
+++ b/server/cmd/server/router.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"net/netip"
 	"os"
+	"regexp"
 	"strings"
 	"time"
 
@@ -130,18 +131,36 @@ func parseTrustedProxies(raw string) []netip.Prefix {
 	return out
 }
 
-// normalizeServerVersion maps the unstamped "dev" default (main.go's
-// `version` var, unchanged when the binary wasn't built with
-// -X main.version=<tag>) to an empty string. handler.Config.ServerVersion
-// feeds /api/config's server_version field with omitempty, so an empty
-// string hides the Help popover's version row instead of rendering
-// "Server version dev" for a local `go build`/`go run` or a self-hosted
-// `docker build` without --build-arg VERSION.
-func normalizeServerVersion(v string) string {
-	if v == "dev" {
+// officialBaseline returns v only when it is a trustworthy official release
+// baseline: a clean vX.Y.Z-style tag carrying no git-describe commit-distance
+// suffix (-N-g<hash>) or dirty marker. The supported self-host build paths
+// (scripts/resolve-official-baseline.sh, release CI) stamp exactly such a tag
+// via -X main.version; dev builds (the "dev" default), dirty checkouts, and
+// anything that is not a clean official tag map to "". handler.Config.ServerVersion
+// feeds /api/config's server_version field with omitempty, so an empty value
+// hides the Help popover's version row instead of presenting a hash, a dirty
+// suffix, or "dev" as a release baseline.
+var describeSuffixRe = regexp.MustCompile(`-\d+-g[0-9a-f]{4,}$`)
+
+func officialBaseline(v string) string {
+	v = strings.TrimSpace(v)
+	if v == "" || v == "dev" {
+		return ""
+	}
+	if !isOfficialBaselineTag(v) {
 		return ""
 	}
 	return v
+}
+
+func isOfficialBaselineTag(v string) bool {
+	if len(v) < 2 || v[0] != 'v' || v[1] < '0' || v[1] > '9' {
+		return false
+	}
+	if strings.Contains(v, "-dirty") || describeSuffixRe.MatchString(v) {
+		return false
+	}
+	return true
 }
 
 // NewRouter creates the fully-configured Chi router with all middleware and routes.
@@ -214,7 +233,7 @@ func NewRouterWithOptions(pool *pgxpool.Pool, hub *realtime.Hub, bus *events.Bus
 		LLMAPIKey:                strings.TrimSpace(os.Getenv("MULTICA_LLM_API_KEY")),
 		LLMBaseURL:               strings.TrimSpace(os.Getenv("MULTICA_LLM_BASE_URL")),
 		LLMDefaultModel:          strings.TrimSpace(os.Getenv("MULTICA_LLM_DEFAULT_MODEL")),
-		ServerVersion:            normalizeServerVersion(version),
+		ServerVersion:            officialBaseline(version),
 	}
 	h := handler.New(queries, pool, hub, bus, emailSvc, store, cfSigner, analyticsClient, signupConfig, daemonHub)
 	h.Metrics = opts.BusinessMetrics

--- a/server/internal/handler/config.go
+++ b/server/internal/handler/config.go
@@ -50,11 +50,13 @@ type AppConfig struct {
 	// raw rules here: /api/config is public and may be called anonymously.
 	FeatureFlags map[string]bool `json:"feature_flags,omitempty"`
 
-	// ServerVersion is the running API build version, so self-hosted
-	// operators can confirm what's deployed and include it in bug reports.
-	// Only emitted on self-hosted deployments — omitted on the managed cloud,
-	// which is continuously deployed so its users can't act on the version —
-	// and empty for dev builds that aren't stamped via -X main.version.
+	// ServerVersion is the running API binary's official release baseline
+	// (the clean vX.Y.Z tag stamped via -X main.version), so self-hosted
+	// operators can confirm what's deployed. Only emitted on self-hosted
+	// deployments; omitted on the managed cloud, which is continuously
+	// deployed so its users can't act on the version, and empty for dev
+	// builds or any value that is not a clean official tag. It carries no
+	// commit id, dirty state, repository path, or image reference.
 	ServerVersion string `json:"server_version,omitempty"`
 }
 

--- a/server/internal/handler/config_test.go
+++ b/server/internal/handler/config_test.go
@@ -314,13 +314,13 @@ func TestGetConfigExposesServerVersion(t *testing.T) {
 		t.Fatalf("server_version: want empty for dev build, got %q", cfg.ServerVersion)
 	}
 
-	testHandler.cfg.ServerVersion = "1.2.3"
+	testHandler.cfg.ServerVersion = "v1.2.3"
 	w = httptest.NewRecorder()
 	testHandler.GetConfig(w, req)
 	if err := json.Unmarshal(w.Body.Bytes(), &cfg); err != nil {
 		t.Fatalf("decode config: %v", err)
 	}
-	if cfg.ServerVersion != "1.2.3" {
+	if cfg.ServerVersion != "v1.2.3" {
 		t.Fatalf("server_version: want 1.2.3, got %q", cfg.ServerVersion)
 	}
 }
@@ -332,7 +332,7 @@ func TestGetConfigExposesServerVersion(t *testing.T) {
 func TestGetConfigOmitsServerVersionOnOfficialCloud(t *testing.T) {
 	origCfg := testHandler.cfg
 	defer func() { testHandler.cfg = origCfg }()
-	testHandler.cfg.ServerVersion = "1.2.3"
+	testHandler.cfg.ServerVersion = "v1.2.3"
 
 	req := httptest.NewRequest(http.MethodGet, "/api/config", nil)
 
@@ -356,8 +356,41 @@ func TestGetConfigOmitsServerVersionOnOfficialCloud(t *testing.T) {
 	if err := json.Unmarshal(w.Body.Bytes(), &cfg); err != nil {
 		t.Fatalf("decode config: %v", err)
 	}
-	if cfg.ServerVersion != "1.2.3" {
+	if cfg.ServerVersion != "v1.2.3" {
 		t.Fatalf("server_version: want 1.2.3 on self-hosted, got %q", cfg.ServerVersion)
+	}
+}
+
+// TestGetConfigExposesNoProvenanceMetadata verifies /api/config's public JSON
+// carries only the official baseline tag and never commit ids, dirty state,
+// repository paths, or image references: the baseline is safe to expose
+// anonymously precisely because it is the only build metadata surfaced.
+func TestGetConfigExposesNoProvenanceMetadata(t *testing.T) {
+	origCfg := testHandler.cfg
+	defer func() { testHandler.cfg = origCfg }()
+
+	t.Setenv("MULTICA_APP_URL", "https://multica.self-hosted.example")
+	t.Setenv("FRONTEND_ORIGIN", "")
+	testHandler.cfg.ServerVersion = "v1.2.3"
+
+	req := httptest.NewRequest(http.MethodGet, "/api/config", nil)
+	w := httptest.NewRecorder()
+	testHandler.GetConfig(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("GetConfig: expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(w.Body.Bytes(), &raw); err != nil {
+		t.Fatalf("decode config: %v", err)
+	}
+	if got := string(raw["server_version"]); got != `"v1.2.3"` {
+		t.Fatalf("server_version: want %q, got %s", `"v1.2.3"`, got)
+	}
+	for _, key := range []string{"commit", "commit_id", "dirty", "build_path", "repo_path", "image", "image_digest", "build_time", "git_sha"} {
+		if _, ok := raw[key]; ok {
+			t.Fatalf("public config must not expose provenance metadata %q (body=%s)", key, w.Body.String())
+		}
 	}
 }
 

--- a/server/internal/handler/handler.go
+++ b/server/internal/handler/handler.go
@@ -107,10 +107,11 @@ type Config struct {
 	LLMAPIKey       string
 	LLMBaseURL      string
 	LLMDefaultModel string
-	// ServerVersion is the build version of the running API binary (the same
-	// value main.go stamps via -X main.version and reports on /metrics).
-	// Surfaced through /api/config so self-hosted operators can confirm which
-	// server build is deployed. Empty in dev builds.
+	// ServerVersion is the running API binary's official release baseline:
+	// the clean vX.Y.Z tag main.go stamps via -X main.version (and reports
+	// on /metrics). Surfaced through /api/config so self-hosted operators
+	// can confirm which server build is deployed; empty for dev builds and
+	// any value that is not a clean official tag.
 	ServerVersion string
 }
 


### PR DESCRIPTION
## Summary

Surfaces the official upstream-verified release baseline of the running frontend bundle and backend binary side by side in the self-host Help sidebar, so operators can confirm what is deployed without inspecting host Git.

Both rows (Frontend / Backend) are derived from a single host-side resolution (scripts/resolve-official-baseline.sh: derive the nearest reachable upstream v* tag via \`git describe --tags --abbrev=0 --match 'v[0-9]*'\`, verify it against the canonical upstream tags via \`git ls-remote https://github.com/multica-ai/multica\`, fall back to an explicit \`MULTICA_TRUSTED_BASELINE\` when the resolver cannot reach the upstream, fail otherwise). The build embeds the result into the artifacts at compile time:

- Backend: \`main.version\` via Go ldflags, surfaced through \`/api/config.server_version\` and omitted on managed cloud and for any value that is not a clean official tag.
- Frontend: \`NEXT_PUBLIC_APP_VERSION\` baked into the prod bundle at \`pnpm build\` time.

The build override for Docker/Docker Compose was tightened to require both \`VERSION\` and \`NEXT_PUBLIC_APP_VERSION\` (no \`dev\` default) so a raw compose invocation fails instead of silently stamping an unstamped build.

## What reviewers will see

The Help sidebar Help menu shows two labeled rows instead of one, with explicit loading / unavailable / tag states. The DropdownMenuGroup invariant (MUL-4819) is preserved.

## Acceptance

- AE1 - AE4 of the plan are covered: same tag for an official build, customized build retains the nearest tag, stale artifacts stay visibly stale after rebuild, partial rollout renders per-component state without crashing.
- 10 Bash cases cover the resolver (clean / post-tag / dirty / fork-only / offline / trusted-override / override-validation / tagless / whitespace-trim).
- 14 Go-side tests cover backend hardening (suffix/dirty/non-baseline rejected) and the no-provenance-metadata public JSON guard.
- 7 frontend tests cover two-row rendering, loading / unavailable, and the Group invariant.
- 4 locale keys (en/zh-Hans/ja/ko) are aligned.

## Self-host tooling

\`scripts/resolve-official-baseline.sh\` (new), \`scripts/resolve-official-baseline.test.sh\` (new), \`scripts/selfhost-config.test.sh\` extended, \`make build-prod\` and \`make upgrade\` (new) for direct prod rebuilds. \`SELF_HOSTING.md\` documents the source-build, direct-build, and recovery paths.

## What is NOT in this PR (out of scope)

- Plan + ideation artifacts + the CONCEPTS vocabulary entry remain in the author's fork for personal reference; they are not pushed.
- The \`fix(handler): align skill_mention_trigger_test with 2-value return\` commit was skipped on the upstream branch because the test file is already gone there.
- No changes to managed-cloud behavior (server_version remains omitted, the public JSON contract is additive only).

## Verified locally

- \`go build\` / \`go vet\` clean for the changed server packages.
- \`pnpm typecheck\` clean across the workspace.
- \`pnpm exec vitest run\` clean for \`@multica/core\` (14/14) and \`@multica/views\` help-launcher (7/7).
- \`bash scripts/resolve-official-baseline.test.sh\` 10/10.
- \`go vet ./internal/handler\` is blocked locally by a pre-existing compile error in \`skill_mention_trigger_test.go\` (now deleted on upstream), so the new \`config_test.go\` and \`officialBaseline\` coverage runs in CI where the file is absent.