### PR TITLE
WS-2062: preserve daemon config across restart

### DIFF
--- a/docs/plans/2026-07-16-daemon-restart-env-preservation-design.md
+++ b/docs/plans/2026-07-16-daemon-restart-env-preservation-design.md
@@ -1,0 +1,54 @@
+# Daemon Restart Environment Preservation Design
+
+## Problem
+
+A plain `multica daemon restart` stops the running daemon and launches a new
+daemon from the caller process. That changes ownership of restart configuration:
+the new process inherits the caller's executable, flags, and environment instead
+of the daemon's. In WS-2062 this removed `MULTICA_SKILL_TRACE_ENABLED`,
+`MULTICA_SKILL_TRACE_PATH`, and `MULTICA_DAEMON_AUTO_UPDATE=false`, which stopped
+skill telemetry while leaving the daemon otherwise healthy.
+
+The Loop-1 assertion runner also writes its issue description under the machine
+temporary directory. Multica now rejects `--description-file` paths outside the
+task workdir, so automatic triage creation fails even when the assertion is
+correct.
+
+## Options
+
+1. Copy a fixed list of environment variables in the CLI caller. This is brittle:
+   each new daemon setting can regress independently, and the caller still may
+   use a different executable or start flags.
+2. Add launchd-specific restart logic. This preserves the configured environment
+   on macOS but does not solve the same ownership bug on Linux or Windows.
+3. Let the running daemon hand off to its successor for plain restarts. This
+   reuses the existing self-update restart path, preserving the daemon's own
+   executable, start flags, profile, and complete environment. This is the
+   selected approach.
+
+## Design
+
+The daemon exposes a localhost-only `POST /restart` endpoint beside `/shutdown`.
+The handler schedules the existing graceful restart path and responds before
+cancelling the daemon context. A plain background `multica daemon restart` calls
+this endpoint and waits until the health endpoint reports a different ready PID.
+
+If the user supplies restart flags or requests foreground mode, the CLI retains
+the existing stop-then-start behavior because those overrides intentionally come
+from the caller. This keeps explicit flag semantics while making the common
+restart path environment-safe.
+
+The assertion runner creates its temporary description directory beneath the
+configured blackboard repository, passes that in-workdir path to Multica, and
+removes the directory after the command finishes.
+
+## Verification
+
+- Go handler tests prove `POST /restart` schedules a restart and non-POST methods
+  are rejected.
+- CLI tests prove plain restart selects self-handoff while explicit overrides do
+  not.
+- Bun tests prove triage descriptions are inside the runner workdir and cleaned
+  up.
+- Focused Go and Bun suites must pass before operational verification.
+

--- a/docs/superpowers/plans/2026-07-16-daemon-restart-env-preservation.md
+++ b/docs/superpowers/plans/2026-07-16-daemon-restart-env-preservation.md
@@ -1,0 +1,128 @@
+# Daemon Restart Environment Preservation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Preserve the running daemon's executable, flags, and environment across a plain restart, and make Loop-1 triage description files pass Multica's workdir safety check.
+
+**Architecture:** Route plain background restarts through a new localhost daemon endpoint that reuses the existing self-handoff path. Keep caller-owned stop/start behavior for explicit flag overrides. Store assertion-runner temp files below its configured repository workdir.
+
+**Tech Stack:** Go, Cobra, `net/http`, Bun, TypeScript, Vitest-compatible Bun tests.
+
+---
+
+### Task 1: Daemon self-restart endpoint
+
+**Files:**
+- Modify: `server/internal/daemon/health.go`
+- Test: `server/internal/daemon/health_test.go`
+
+- [ ] **Step 1: Write failing handler tests**
+
+Add tests that POST `/restart`, assert the response is `restarting`, and verify
+the daemon restart binary and cancellation signal are set. Add a GET test that
+expects `405 Method Not Allowed`.
+
+- [ ] **Step 2: Run the focused tests and confirm red**
+
+Run: `go test ./internal/daemon -run 'TestRestartHandler'`
+
+Expected: compilation or assertion failure because `restartHandler` does not
+exist.
+
+- [ ] **Step 3: Implement the handler**
+
+Add `restartHandler`, respond before asynchronously invoking the existing
+`triggerRestart`, and register `/restart` in `serveHealth`.
+
+- [ ] **Step 4: Run the focused tests and confirm green**
+
+Run: `go test ./internal/daemon -run 'TestRestartHandler'`
+
+Expected: PASS.
+
+### Task 2: Plain CLI restart uses daemon-owned handoff
+
+**Files:**
+- Modify: `server/cmd/multica/cmd_daemon.go`
+- Test: `server/cmd/multica/cmd_daemon_test.go`
+
+- [ ] **Step 1: Write failing restart-selection tests**
+
+Add a helper test proving a plain background restart has no caller overrides,
+while `--foreground`, `--no-auto-update`, timing, identity, capacity, and server
+flags count as overrides. `--profile` remains a target selector and still uses
+self-handoff.
+
+- [ ] **Step 2: Run the focused tests and confirm red**
+
+Run: `go test ./cmd/multica -run 'TestDaemonRestartUsesSelfHandoff'`
+
+Expected: compilation failure because the selection helper does not exist.
+
+- [ ] **Step 3: Implement request and readiness wait**
+
+For the no-override case, POST `/restart`, then wait for the old PID to disappear
+and a different PID to report `status=running`. Preserve the existing stop/start
+path when overrides are present.
+
+- [ ] **Step 4: Run the focused tests and confirm green**
+
+Run: `go test ./cmd/multica -run 'TestDaemonRestartUsesSelfHandoff'`
+
+Expected: PASS.
+
+### Task 3: Loop-1 triage file stays in the task workdir
+
+**Files:**
+- Modify: `/Users/tangyuanjc/blackboard-v3/scripts/consumer-assertions.ts`
+- Test: `/Users/tangyuanjc/blackboard-v3/scripts/consumer-assertions.test.ts`
+
+- [ ] **Step 1: Write a failing triage-path test**
+
+Capture the `multica issue create` arguments, assert `--description-file` is
+inside `blackboardRepo`, and assert the path no longer exists after collection.
+
+- [ ] **Step 2: Run the focused test and confirm red**
+
+Run: `/Users/tangyuanjc/.bun/bin/bun test scripts/consumer-assertions.test.ts`
+
+Expected: FAIL because the current path is under the system temp directory.
+
+- [ ] **Step 3: Implement in-workdir temporary storage**
+
+Create the temporary directory with `mkdtempSync(join(config.blackboardRepo,
+'.consumer-assertion-triage-'))` and remove the entire directory in `finally`.
+
+- [ ] **Step 4: Run the focused test and confirm green**
+
+Run: `/Users/tangyuanjc/.bun/bin/bun test scripts/consumer-assertions.test.ts`
+
+Expected: PASS.
+
+### Task 4: Verification and delivery
+
+**Files:**
+- Verify all modified files above.
+
+- [ ] **Step 1: Run focused Go tests**
+
+Run: `go test ./internal/daemon ./cmd/multica`
+
+Expected: PASS.
+
+- [ ] **Step 2: Run the runner test suite**
+
+Run: `/Users/tangyuanjc/.bun/bin/bun test scripts/consumer-assertions.test.ts`
+
+Expected: PASS.
+
+- [ ] **Step 3: Review diffs and commit only scoped files**
+
+Commit the Multica change with a `fix(daemon)` conventional commit and the
+blackboard change separately, without staging unrelated dirty-worktree files.
+
+- [ ] **Step 4: Push/open a PR and perform safe operational handoff**
+
+Use `WS-2062` in the PR title or body. Do not restart the daemon while unrelated
+tasks are active; once only the current task remains, hand off to the configured
+daemon and verify the live process environment plus new trace growth.

--- a/server/cmd/multica/cmd_daemon.go
+++ b/server/cmd/multica/cmd_daemon.go
@@ -17,6 +17,7 @@ import (
 	"time"
 
 	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
 	lumberjack "gopkg.in/natefinch/lumberjack.v2"
 
 	"github.com/multica-ai/multica/server/internal/cli"
@@ -598,6 +599,14 @@ func runDaemonRestart(cmd *cobra.Command, args []string) error {
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 	defer cancel()
 	health := checkDaemonHealthOnPort(ctx, healthPort)
+	if daemonAlive(health) && daemonRestartUsesSelfHandoff(cmd) {
+		oldPID, _ := health["pid"].(float64)
+		fmt.Fprintf(os.Stderr, "Restarting daemon (pid %d) with its current configuration...\n", int(oldPID))
+		if err := requestDaemonRestart(healthPort); err != nil {
+			return fmt.Errorf("request daemon self-restart: %w", err)
+		}
+		return waitForDaemonRestart(healthPort, int(oldPID), profile)
+	}
 	if daemonAlive(health) {
 		pid, _ := health["pid"].(float64)
 		if pid > 0 {
@@ -623,6 +632,64 @@ func runDaemonRestart(cmd *cobra.Command, args []string) error {
 
 	// Start fresh.
 	return runDaemonStart(cmd, args)
+}
+
+func daemonRestartUsesSelfHandoff(cmd *cobra.Command) bool {
+	foreground, _ := cmd.Flags().GetBool("foreground")
+	if foreground {
+		return false
+	}
+
+	for _, name := range []string{
+		"daemon-id",
+		"device-name",
+		"runtime-name",
+		"poll-interval",
+		"heartbeat-interval",
+		"agent-timeout",
+		"codex-semantic-inactivity-timeout",
+		"codex-handshake-timeout",
+		"max-concurrent-tasks",
+		"no-auto-update",
+		"auto-update-interval",
+		"server-url",
+	} {
+		if commandFlagChanged(cmd, name) {
+			return false
+		}
+	}
+	return true
+}
+
+func commandFlagChanged(cmd *cobra.Command, name string) bool {
+	for _, flags := range []*pflag.FlagSet{cmd.Flags(), cmd.InheritedFlags(), cmd.PersistentFlags()} {
+		if flag := flags.Lookup(name); flag != nil && flag.Changed {
+			return true
+		}
+	}
+	return false
+}
+
+func waitForDaemonRestart(healthPort, oldPID int, profile string) error {
+	const restartTimeout = 90 * time.Second
+	deadline := time.Now().Add(restartTimeout)
+	for time.Now().Before(deadline) {
+		time.Sleep(500 * time.Millisecond)
+		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		health := checkDaemonHealthOnPort(ctx, healthPort)
+		cancel()
+		pid, _ := health["pid"].(float64)
+		status, _ := health["status"].(string)
+		if status == "running" && int(pid) > 0 && int(pid) != oldPID {
+			label := "Daemon"
+			if profile != "" {
+				label = fmt.Sprintf("Daemon [%s]", profile)
+			}
+			fmt.Fprintf(os.Stderr, "%s restarted (pid %d, version %v)\n", label, int(pid), health["cli_version"])
+			return nil
+		}
+	}
+	return fmt.Errorf("daemon did not return with a new ready process within %s", restartTimeout)
 }
 
 // --- daemon stop ---
@@ -691,6 +758,24 @@ func runDaemonStop(cmd *cobra.Command, _ []string) error {
 // (network error, non-2xx status, or the endpoint predates this change).
 func requestDaemonShutdown(healthPort int) error {
 	url := fmt.Sprintf("http://127.0.0.1:%d/shutdown", healthPort)
+	req, err := http.NewRequest(http.MethodPost, url, nil)
+	if err != nil {
+		return err
+	}
+	client := &http.Client{Timeout: 2 * time.Second}
+	resp, err := client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return fmt.Errorf("unexpected status %d", resp.StatusCode)
+	}
+	return nil
+}
+
+func requestDaemonRestart(healthPort int) error {
+	url := fmt.Sprintf("http://127.0.0.1:%d/restart", healthPort)
 	req, err := http.NewRequest(http.MethodPost, url, nil)
 	if err != nil {
 		return err

--- a/server/cmd/multica/cmd_daemon_test.go
+++ b/server/cmd/multica/cmd_daemon_test.go
@@ -76,6 +76,57 @@ func TestBuildDaemonStartArgsForwardsCodexHandshakeTimeout(t *testing.T) {
 	}
 }
 
+func TestDaemonRestartUsesSelfHandoff(t *testing.T) {
+	newCommand := func() *cobra.Command {
+		cmd := &cobra.Command{}
+		cmd.Flags().Bool("foreground", false, "")
+		cmd.Flags().String("daemon-id", "", "")
+		cmd.Flags().String("device-name", "", "")
+		cmd.Flags().String("runtime-name", "", "")
+		cmd.Flags().Duration("poll-interval", 0, "")
+		cmd.Flags().Duration("heartbeat-interval", 0, "")
+		cmd.Flags().Duration("agent-timeout", 0, "")
+		cmd.Flags().Duration("codex-semantic-inactivity-timeout", 0, "")
+		cmd.Flags().Duration("codex-handshake-timeout", 0, "")
+		cmd.Flags().Int("max-concurrent-tasks", 0, "")
+		cmd.Flags().Bool("no-auto-update", false, "")
+		cmd.Flags().Duration("auto-update-interval", 0, "")
+		cmd.Flags().String("server-url", "", "")
+		cmd.Flags().String("profile", "", "")
+		return cmd
+	}
+
+	tests := []struct {
+		name  string
+		flag  string
+		value string
+		want  bool
+	}{
+		{name: "plain restart", want: true},
+		{name: "target profile keeps daemon-owned config", flag: "profile", value: "desktop", want: true},
+		{name: "foreground override", flag: "foreground", value: "true", want: false},
+		{name: "identity override", flag: "daemon-id", value: "replacement", want: false},
+		{name: "timing override", flag: "poll-interval", value: "5s", want: false},
+		{name: "capacity override", flag: "max-concurrent-tasks", value: "4", want: false},
+		{name: "auto update override", flag: "no-auto-update", value: "true", want: false},
+		{name: "server override", flag: "server-url", value: "https://example.test", want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cmd := newCommand()
+			if tt.flag != "" {
+				if err := cmd.Flags().Set(tt.flag, tt.value); err != nil {
+					t.Fatalf("set %s: %v", tt.flag, err)
+				}
+			}
+			if got := daemonRestartUsesSelfHandoff(cmd); got != tt.want {
+				t.Fatalf("daemonRestartUsesSelfHandoff() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
 // TestPrintDaemonStatusOmitsVersionWhenMissing pins the back-compat contract:
 // when the daemon doesn't report cli_version (older daemon paired with a newer
 // CLI) or reports an empty string, the CLI must skip the line entirely instead

--- a/server/internal/daemon/health.go
+++ b/server/internal/daemon/health.go
@@ -133,12 +133,29 @@ func (d *Daemon) shutdownHandler() http.HandlerFunc {
 	}
 }
 
+// restartHandler asks the running daemon to hand off to a successor using its
+// own executable, start flags, and environment. Keeping restart ownership in
+// the daemon prevents a CLI caller with a different environment from silently
+// dropping daemon-only configuration.
+func (d *Daemon) restartHandler() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]string{"status": "restarting"})
+		go d.triggerRestart()
+	}
+}
+
 // serveHealth runs the health HTTP server on the given listener.
 // Blocks until ctx is cancelled.
 func (d *Daemon) serveHealth(ctx context.Context, ln net.Listener, startedAt time.Time) {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/health", d.healthHandler(startedAt))
 	mux.HandleFunc("/shutdown", d.shutdownHandler())
+	mux.HandleFunc("/restart", d.restartHandler())
 	mux.HandleFunc("/repo/checkout", d.repoCheckoutHandler())
 
 	srv := &http.Server{Handler: mux}

--- a/server/internal/daemon/health_test.go
+++ b/server/internal/daemon/health_test.go
@@ -178,6 +178,62 @@ func TestShutdownHandlerRejectsNonPost(t *testing.T) {
 	}
 }
 
+func TestRestartHandlerPostSchedulesDaemonSelfHandoff(t *testing.T) {
+	originalResolveSelfExecutable := resolveSelfExecutable
+	originalIsBrewInstall := isBrewInstall
+	t.Cleanup(func() {
+		resolveSelfExecutable = originalResolveSelfExecutable
+		isBrewInstall = originalIsBrewInstall
+	})
+
+	wantBinary := t.TempDir() + "/multica"
+	resolveSelfExecutable = func() (string, error) { return wantBinary, nil }
+	isBrewInstall = func() bool { return false }
+
+	cancelled := make(chan struct{})
+	d := &Daemon{
+		cancelFunc: func() { close(cancelled) },
+		logger:     slog.Default(),
+	}
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/restart", nil)
+	d.restartHandler().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rec.Code)
+	}
+	if got := strings.TrimSpace(rec.Body.String()); got != `{"status":"restarting"}` {
+		t.Fatalf("response body = %q, want restarting status", got)
+	}
+
+	select {
+	case <-cancelled:
+	case <-time.After(time.Second):
+		t.Fatal("daemon context was not cancelled after POST /restart")
+	}
+	if got := d.RestartBinary(); got != wantBinary {
+		t.Fatalf("restart binary = %q, want %q", got, wantBinary)
+	}
+}
+
+func TestRestartHandlerRejectsNonPost(t *testing.T) {
+	cancelled := false
+	d := &Daemon{cancelFunc: func() { cancelled = true }}
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/restart", nil)
+	d.restartHandler().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusMethodNotAllowed {
+		t.Fatalf("expected 405, got %d", rec.Code)
+	}
+	time.Sleep(10 * time.Millisecond)
+	if cancelled {
+		t.Fatal("GET request should not schedule a restart")
+	}
+}
+
 func TestHealthHandlerRespondsWhileTaskRepoLookupWaits(t *testing.T) {
 	const workspaceID = "ws-health"
 	const repoURL = "https://github.com/org/repo.git"

--- a/server/internal/service/builtin_skills/multica-runtimes-and-repos/SKILL.md
+++ b/server/internal/service/builtin_skills/multica-runtimes-and-repos/SKILL.md
@@ -19,6 +19,13 @@ multica repo checkout <repo-url>
 
 Runtime and repo commands affect active agent execution. Do not restart daemons, update runtimes, or check out arbitrary repos just to test.
 
+A plain background `multica daemon restart` is owned by the running daemon: it
+hands off using its current executable, flags, profile, and environment. Restart
+flags such as `--foreground`, `--no-auto-update`, identity/timing overrides, or
+`--server-url` deliberately select the older caller-owned stop/start path. A
+`--profile` flag only selects which daemon to restart and does not replace that
+daemon's configuration.
+
 ## Core model
 
 A runtime is the execution target behind an agent. A daemon owns local runtime processes and claims queued tasks from the server.
@@ -41,11 +48,17 @@ multica runtime usage <runtime-id> --output json
 multica runtime activity <runtime-id> --output json
 multica runtime update <runtime-id> --target-version <version> --output json
 multica runtime delete <runtime-id>
+multica daemon restart
 multica repo checkout <url>
 multica repo checkout <url> --ref <branch-or-sha>
 ```
 
 `runtime update` and `runtime delete` are writes. Starting a runtime update is limited to its owner or a workspace owner/admin; the original initiator may keep polling that specific in-flight request if their admin role changes. `runtime delete` removes a runtime registration; if active agents are still bound, it refuses unless the user explicitly passes `--cascade`, which archives those agents and cancels their queued/running tasks before deleting the runtime. `repo checkout` creates a git worktree in the task working directory.
+
+`daemon restart` interrupts daemon availability and can affect in-flight tasks;
+use it only when the task explicitly requires a restart. The plain form asks the
+daemon to self-handoff so daemon-only environment does not get replaced by the
+caller's environment.
 
 `repo checkout` requires `MULTICA_DAEMON_PORT`; it is intended to run inside a daemon task. If absent, you are not in the normal agent checkout path. When a project `github_repo` resource has `resource_ref.ref`, `repo checkout <url>` uses that ref by default for the current task; an explicit `repo checkout <url> --ref <branch-or-sha>` overrides it.
 

--- a/server/internal/service/builtin_skills/multica-runtimes-and-repos/references/runtimes-and-repos-source-map.md
+++ b/server/internal/service/builtin_skills/multica-runtimes-and-repos/references/runtimes-and-repos-source-map.md
@@ -5,6 +5,13 @@
 - `runtime update` posts to `/api/runtimes/{runtime-id}/update`; with `--wait` it polls update status. Initiation enforces runtime-owner or workspace-owner/admin access through `canEditRuntime`; status polling additionally permits that request's immutable initiator so an in-flight poll survives an admin-role change (`server/internal/handler/runtime_update.go` and `runtime.go`).
 - `runtime delete` deletes `/api/runtimes/{runtime-id}`; with `--cascade`, it first reads the `runtime_has_active_agents` conflict payload and posts those ids to `/api/runtimes/{runtime-id}/archive-agents-and-delete`.
 - `server/cmd/multica/cmd_repo.go` registers `repo checkout <url> [--ref]`.
+- `server/cmd/multica/cmd_daemon.go` routes a plain background `daemon restart`
+  through the running daemon's local `/restart` endpoint, then waits for a new
+  ready PID. Explicit restart configuration flags retain caller-owned stop/start
+  semantics; `--profile` only selects the target daemon.
+- `server/internal/daemon/health.go` registers localhost-only `POST /restart`;
+  the handler reuses `triggerRestart`, so the successor inherits the running
+  daemon's executable, flags, profile, and full environment.
 - `repo checkout` requires `MULTICA_DAEMON_PORT`, sends `workspace_id`, `workdir`, `ref`, `agent_name`, and `task_id` to local daemon `/repo/checkout`, then prints the checked-out path.
 - `server/internal/daemon/health.go` resolves the checkout ref: request `ref` wins; otherwise it asks `server/internal/daemon/daemon.go` for the current task's project repo default ref.
 - `server/cmd/server/router.go` registers daemon APIs under `/api/daemon`, including workspace repos and task claim.


### PR DESCRIPTION
## Summary

- make plain background daemon restarts self-handoff from the running daemon
- preserve the daemon-owned executable, start flags, profile, and environment
- retain caller-owned stop/start semantics for explicit restart overrides
- document the restart contract in the built-in runtime skill

## Root cause

`multica daemon restart` previously stopped the running daemon and spawned the
replacement from the CLI caller. A caller inside an agent task did not carry the
daemon-only trace and auto-update environment, so the replacement stayed healthy
while silently stopping skill telemetry.

## Tests

- `go test ./internal/daemon`
- full `cmd/multica` test binary executed outside the daemon task marker: PASS

Closes WS-2062
