### PR TITLE
fix(desktop): suppress Chromium F3 accelerator on Windows

### DIFF
--- a/apps/desktop/src/main/keyboard-shortcuts.test.ts
+++ b/apps/desktop/src/main/keyboard-shortcuts.test.ts
@@ -144,6 +144,28 @@ describe("handleAppShortcut — reset zoom", () => {
   });
 });
 
+describe("handleAppShortcut — Windows F3 passthrough for global hotkeys", () => {
+  it("swallows bare F3 on Windows", () => {
+    const wc = makeWc();
+    expect(handleAppShortcut(key("F3"), wc, "win32")).toBe(true);
+  });
+
+  it("does not swallow F3 on macOS", () => {
+    const wc = makeWc();
+    expect(handleAppShortcut(key("F3"), wc, "darwin")).toBe(false);
+  });
+
+  it("does not swallow F3 on Linux", () => {
+    const wc = makeWc();
+    expect(handleAppShortcut(key("F3"), wc, "linux")).toBe(false);
+  });
+
+  it("does not swallow Ctrl+F3 on Windows", () => {
+    const wc = makeWc();
+    expect(handleAppShortcut(key("F3", { control: true }), wc, "win32")).toBe(false);
+  });
+});
+
 describe("handleAppShortcut — unrelated keys pass through", () => {
   it("does not capture plain letters", () => {
     const wc = makeWc();

--- a/apps/desktop/src/main/keyboard-shortcuts.ts
+++ b/apps/desktop/src/main/keyboard-shortcuts.ts
@@ -57,6 +57,15 @@ export function handleAppShortcut(
     return true;
   }
 
+  // Windows: Chromium internally maps bare F3 to its "Find Next" accelerator.
+  // Even with no active find bar, Chromium consumes F3 before the renderer JS
+  // sees it, which can prevent third-party global-hotkey apps (e.g. voice
+  // recognition) from receiving the key. Multica uses Ctrl+F for its own find
+  // bar and has no other F3 binding, so suppress Chromium's default handling.
+  if (platform === "win32" && input.key === "F3" && !input.control && !input.meta) {
+    return true;
+  }
+
   if (!cmdOrCtrl) return false;
 
   // Cmd/Ctrl + "=" (unshifted) or "+" (Shift+=) → zoom in.


### PR DESCRIPTION
## Summary

- Chromium internally maps bare F3 to its \"Find Next\" accelerator, consuming the key before renderer JS sees it
- On Windows, this prevents third-party global-hotkey apps (e.g. voice-recognition tools like Handy) from receiving F3 when Multica has focus
- Fix: call `event.preventDefault()` for bare F3 on Windows in `before-input-event` handler
- Multica uses Ctrl+F for its own find bar and has no other F3 binding, so suppressing Chromium's default is safe
- Ctrl+F3 and Meta+F3 modifier combos are not affected

## Test plan

- [ ] Build desktop app on Windows and verify Handy (or similar global hotkey app) receives F3 when Multica is focused
- [ ] Verify Ctrl+F still opens the find bar normally
- [ ] Verify F3 in renderer JS (if any future binding added) would need to be handled at the main-process level
- [ ] 249 unit tests pass (1 pre-existing failure in runtime-config-loader unrelated to this change)

Fixes: A-210