### PR TITLE
fix(inbox): 归档视图不再显示未读状态 (MUL-4893)

### DIFF
--- a/packages/views/inbox/components/inbox-list-item.test.tsx
+++ b/packages/views/inbox/components/inbox-list-item.test.tsx
@@ -1,0 +1,74 @@
+import { render } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import type { InboxItem } from "@multica/core/types";
+import { InboxListItem } from "./inbox-list-item";
+
+vi.mock("../../issues/components", () => ({ StatusIcon: () => null }));
+vi.mock("../../common/actor-avatar", () => ({ ActorAvatar: () => null }));
+vi.mock("./inbox-detail-label", () => ({ InboxDetailLabel: () => null }));
+vi.mock("../../i18n", () => ({ useT: () => ({ t: () => "label" }) }));
+
+function item(overrides: Partial<InboxItem> = {}): InboxItem {
+  return {
+    id: "inbox-1",
+    workspace_id: "workspace-1",
+    recipient_type: "member",
+    recipient_id: "member-1",
+    actor_type: "agent",
+    actor_id: "agent-1",
+    type: "new_comment",
+    severity: "info",
+    issue_id: "issue-1",
+    title: "Issue title",
+    body: null,
+    issue_status: null,
+    read: false,
+    archived: false,
+    created_at: "2026-06-15T08:00:00Z",
+    details: null,
+    ...overrides,
+  };
+}
+
+function renderRow(props: { item: InboxItem; view: "inbox" | "archived" }) {
+  return render(
+    <InboxListItem
+      item={props.item}
+      view={props.view}
+      isSelected={false}
+      onClick={vi.fn()}
+      onAction={vi.fn()}
+    />,
+  );
+}
+
+const unreadDot = (container: HTMLElement) => container.querySelector(".bg-brand");
+const title = (container: HTMLElement) => container.querySelector(".truncate");
+
+describe("InboxListItem unread affordance", () => {
+  it("marks an unread row in the main inbox", () => {
+    const { container } = renderRow({ item: item({ read: false }), view: "inbox" });
+
+    expect(unreadDot(container)).not.toBeNull();
+    expect(title(container)?.className).toContain("font-medium");
+  });
+
+  it("leaves a read row unmarked in the main inbox", () => {
+    const { container } = renderRow({ item: item({ read: true }), view: "inbox" });
+
+    expect(unreadDot(container)).toBeNull();
+    expect(title(container)?.className).not.toContain("font-medium");
+  });
+
+  it("renders an unread row as read in the archived view", () => {
+    // Archiving preserves `read` so unarchiving can restore real unread state,
+    // which left archived rows showing a dot no action in this view can clear.
+    const { container } = renderRow({
+      item: item({ read: false, archived: true }),
+      view: "archived",
+    });
+
+    expect(unreadDot(container)).toBeNull();
+    expect(title(container)?.className).not.toContain("font-medium");
+  });
+});

--- a/packages/views/inbox/components/inbox-list-item.tsx
+++ b/packages/views/inbox/components/inbox-list-item.tsx
@@ -45,6 +45,10 @@ export function InboxListItem({
   const timeAgo = useTimeAgo();
   const displayTitle = getInboxDisplayTitle(item);
   const isArchivedView = view === "archived";
+  // Archiving deliberately leaves `read` untouched so unarchiving restores the
+  // real unread state, so archived rows would otherwise keep an unread marker
+  // the user cannot clear from this view. Suppress the affordance here only.
+  const showUnread = item.read !== true && !isArchivedView;
   const ActionIcon = isArchivedView ? ArchiveRestore : Archive;
   const actionLabel = isArchivedView
     ? t(($) => $.list.unarchive_tooltip)
@@ -67,11 +71,11 @@ export function InboxListItem({
       <div className="min-w-0 flex-1">
         <div className="flex items-center justify-between gap-2">
           <div className="flex min-w-0 items-center gap-1.5">
-            {!item.read && (
+            {showUnread && (
               <span className="h-1.5 w-1.5 shrink-0 rounded-full bg-brand" />
             )}
             <span
-              className={`truncate text-sm ${!item.read ? "font-medium" : "text-muted-foreground"}`}
+              className={`truncate text-sm ${showUnread ? "font-medium" : "text-muted-foreground"}`}
             >
               {displayTitle}
             </span>
@@ -102,10 +106,10 @@ export function InboxListItem({
           </div>
         </div>
         <div className="mt-0.5 flex items-center justify-between gap-2">
-          <p className={`min-w-0 overflow-hidden text-ellipsis whitespace-nowrap text-xs ${item.read ? "text-muted-foreground/60" : "text-muted-foreground"}`}>
+          <p className={`min-w-0 overflow-hidden text-ellipsis whitespace-nowrap text-xs ${showUnread ? "text-muted-foreground" : "text-muted-foreground/60"}`}>
             <InboxDetailLabel item={item} />
           </p>
-          <span className={`shrink-0 text-xs ${item.read ? "text-muted-foreground/60" : "text-muted-foreground"}`}>
+          <span className={`shrink-0 text-xs ${showUnread ? "text-muted-foreground" : "text-muted-foreground/60"}`}>
             {timeAgo(item.created_at)}
           </span>
         </div>


### PR DESCRIPTION
## MUL-4893 — 已归档的 inbox 仍显示未读状态

归档列表里的条目一直挂着清不掉的未读蓝点和加粗标题——归档视图里没有任何操作能清除它，只能逐条点开。

## 根因

归档操作（`ArchiveInboxItem` / `ArchiveAllInbox`，`server/pkg/db/queries/inbox.sql:63-70`）刻意不改 `read` 字段，这是 MUL-3736 归档子视图的既定设计，目的是 unarchive 时还原真实未读状态。而 `InboxListItem` 渲染时不区分视图，只要 `!item.read` 就画未读点。两者叠加 = 归档列表里永远清不掉的未读点。

## 改动

展示层修复，对齐 chat 的既定先例（MUL-4360：保留底层状态、只挡展示）：

- `packages/views/inbox/components/inbox-list-item.tsx`：新增 `showUnread = item.read !== true && !isArchivedView`，归档视图强制按已读渲染。
- 把四处 `read` 驱动的样式（未读点、标题字重、detail label、时间戳）统一走这一个 flag。诊断只点到了未读点/加粗，但 detail label 和时间戳同样按 `read` 分明暗两档——只改前两处会让归档行渲染成「点没了但文字还是亮的」的半吊子状态。
- 新增 `inbox-list-item.test.tsx` 覆盖三种组合。

**不改 DB 写入语义，不动 `read` 字段**，unarchive 还原未读的语义完全保留。Web / Desktop 共用该组件，一次覆盖。

## 排查范围

Lalo 已全面排查其他未读面（服务端计数、侧边栏/dock 角标、移动端、chat、issue 删除级联、退出 workspace），均已正确排除归档项，本 PR 是唯一泄漏点。移动端 `apps/mobile/lib/inbox-display.ts:70` 直接把归档行过滤掉、根本没有归档子视图，无需改动。

## 验证

- `pnpm typecheck` — 6/6 通过
- `pnpm lint` — 8/8 通过
- `packages/views` 全量测试 — 216 文件 / 2170 用例通过
- 红绿验证：把组件改动 stash 回 origin/main 后，归档用例确实失败（渲染出 `bg-brand` 未读点），另两条主收件箱用例仍通过——确认测试精准锁定该 bug 且没有过度约束

## 已知技术债（与本次修复无关，现状即如此）

归档视图里点开条目仍会把 `read` 写成 true，该条 unarchive 后不再还原未读。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
