### PR TITLE
fix(search): prevent stale results in dialogs

### DIFF
--- a/packages/views/modals/issue-picker-modal.test.tsx
+++ b/packages/views/modals/issue-picker-modal.test.tsx
@@ -1,0 +1,120 @@
+import { act } from "react";
+import { screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { IssuePickerModal } from "./issue-picker-modal";
+import { renderWithI18n } from "../test/i18n";
+
+const { mockSearchIssues } = vi.hoisted(() => ({
+  mockSearchIssues: vi.fn(),
+}));
+
+vi.mock("@multica/core/api", () => ({
+  api: { searchIssues: mockSearchIssues },
+}));
+
+function deferred<T>() {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+  return { promise, resolve, reject };
+}
+
+describe("IssuePickerModal search lifecycle", () => {
+  beforeEach(() => {
+    mockSearchIssues.mockReset().mockResolvedValue({ issues: [] });
+    Element.prototype.scrollIntoView = vi.fn();
+  });
+
+  it("cancels an in-flight search and discards its results when the modal closes", async () => {
+    const user = userEvent.setup();
+    const pendingSearch = deferred<{
+      issues: Array<{
+        id: string;
+        identifier: string;
+        title: string;
+        status: "todo";
+      }>;
+    }>();
+    mockSearchIssues.mockReturnValueOnce(pendingSearch.promise);
+    const props = {
+      onOpenChange: vi.fn(),
+      title: "Select issue",
+      description: "Choose an issue",
+      excludeIds: [],
+      onSelect: vi.fn(),
+    };
+    const { rerender } = renderWithI18n(<IssuePickerModal {...props} open />);
+
+    const input = screen.getByPlaceholderText("Search issues...");
+    await user.type(input, "stale");
+    await waitFor(() => expect(mockSearchIssues).toHaveBeenCalledTimes(1), {
+      timeout: 2000,
+    });
+    const signal = mockSearchIssues.mock.calls[0]?.[0]?.signal as AbortSignal;
+
+    rerender(<IssuePickerModal {...props} open={false} />);
+    await act(async () => {
+      pendingSearch.resolve({
+        issues: [
+          {
+            id: "stale-issue",
+            identifier: "MUL-404",
+            title: "Stale picker result",
+            status: "todo",
+          },
+        ],
+      });
+      await pendingSearch.promise;
+    });
+
+    rerender(<IssuePickerModal {...props} open />);
+    await screen.findByPlaceholderText("Search issues...");
+
+    expect(signal.aborted).toBe(true);
+    expect(screen.queryByText("Stale picker result")).not.toBeInTheDocument();
+  });
+
+  it("clears previous results immediately and keeps them cleared when the next search fails", async () => {
+    const user = userEvent.setup();
+    mockSearchIssues
+      .mockResolvedValueOnce({
+        issues: [
+          {
+            id: "first-issue",
+            identifier: "MUL-1",
+            title: "First picker result",
+            status: "todo",
+          },
+        ],
+      })
+      .mockRejectedValueOnce(new Error("search failed"));
+    renderWithI18n(
+      <IssuePickerModal
+        open
+        onOpenChange={vi.fn()}
+        title="Select issue"
+        description="Choose an issue"
+        excludeIds={[]}
+        onSelect={vi.fn()}
+      />,
+    );
+
+    const input = screen.getByPlaceholderText("Search issues...");
+    await user.type(input, "first");
+    await screen.findByText("First picker result", undefined, { timeout: 2000 });
+
+    await user.type(input, "x");
+    expect(screen.queryByText("First picker result")).not.toBeInTheDocument();
+    await waitFor(() => expect(mockSearchIssues).toHaveBeenCalledTimes(2), {
+      timeout: 2000,
+    });
+
+    await waitFor(() => {
+      expect(screen.queryByText("First picker result")).not.toBeInTheDocument();
+    });
+  });
+});

--- a/packages/views/modals/issue-picker-modal.tsx
+++ b/packages/views/modals/issue-picker-modal.tsx
@@ -39,18 +39,32 @@ export function IssuePickerModal({
   const debounceRef = useRef<ReturnType<typeof setTimeout>>(undefined);
   const abortRef = useRef<AbortController>(undefined);
 
+  const cancelPendingSearch = useCallback(() => {
+    if (debounceRef.current !== undefined) {
+      clearTimeout(debounceRef.current);
+      debounceRef.current = undefined;
+    }
+
+    if (abortRef.current !== undefined) {
+      abortRef.current.abort();
+      abortRef.current = undefined;
+    }
+  }, []);
+
+  useEffect(() => cancelPendingSearch, [cancelPendingSearch]);
+
   useEffect(() => {
     if (!open) {
+      cancelPendingSearch();
       setQuery("");
       setResults([]);
       setIsLoading(false);
     }
-  }, [open]);
+  }, [cancelPendingSearch, open]);
 
   const search = useCallback(
     (q: string) => {
-      if (debounceRef.current) clearTimeout(debounceRef.current);
-      if (abortRef.current) abortRef.current.abort();
+      cancelPendingSearch();
 
       if (!q.trim()) {
         setResults([]);
@@ -58,8 +72,10 @@ export function IssuePickerModal({
         return;
       }
 
+      setResults([]);
       setIsLoading(true);
       debounceRef.current = setTimeout(async () => {
+        debounceRef.current = undefined;
         const controller = new AbortController();
         abortRef.current = controller;
         try {
@@ -75,12 +91,17 @@ export function IssuePickerModal({
           }
         } catch {
           if (!controller.signal.aborted) {
+            setResults([]);
             setIsLoading(false);
+          }
+        } finally {
+          if (abortRef.current === controller) {
+            abortRef.current = undefined;
           }
         }
       }, 300);
     },
-    [excludeIds],
+    [cancelPendingSearch, excludeIds],
   );
 
   return (

--- a/packages/views/search/search-command.test.tsx
+++ b/packages/views/search/search-command.test.tsx
@@ -22,6 +22,16 @@ function I18nWrapper({ children }: { children: ReactNode }) {
   );
 }
 
+function deferred<T>() {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+  return { promise, resolve, reject };
+}
+
 const renderSearch = () => render(<SearchCommand />, { wrapper: I18nWrapper });
 
 const {
@@ -296,6 +306,81 @@ describe("SearchCommand", () => {
       expect(useSearchStore.getState().open).toBe(false);
     });
     expect(screen.queryByPlaceholderText("Type a command or search...")).not.toBeInTheDocument();
+  });
+
+  it("cancels an in-flight search and discards its results when the palette closes", async () => {
+    const user = userEvent.setup();
+    const pendingIssues = deferred<{
+      issues: Array<{
+        id: string;
+        identifier: string;
+        title: string;
+        status: "todo";
+      }>;
+    }>();
+    mockSearchIssues.mockReturnValueOnce(pendingIssues.promise);
+    renderSearch();
+
+    const input = screen.getByPlaceholderText("Type a command or search...");
+    await user.type(input, "stale");
+    await waitFor(() => expect(mockSearchIssues).toHaveBeenCalledTimes(1), {
+      timeout: 2000,
+    });
+    const signal = mockSearchIssues.mock.calls[0]?.[0]?.signal as AbortSignal;
+
+    act(() => useSearchStore.setState({ open: false }));
+    await act(async () => {
+      pendingIssues.resolve({
+        issues: [
+          {
+            id: "stale-issue",
+            identifier: "MUL-404",
+            title: "Stale search result",
+            status: "todo",
+          },
+        ],
+      });
+      await pendingIssues.promise;
+    });
+
+    act(() => useSearchStore.setState({ open: true }));
+    await screen.findByPlaceholderText("Type a command or search...");
+
+    expect(signal.aborted).toBe(true);
+    expect(screen.queryByText("Stale search result")).not.toBeInTheDocument();
+  });
+
+  it("clears previous results immediately and keeps them cleared when the next search fails", async () => {
+    const user = userEvent.setup();
+    const firstResultTitle = (_: string, element: Element | null) =>
+      element?.textContent === "First query result" && element.tagName === "SPAN";
+    mockSearchIssues
+      .mockResolvedValueOnce({
+        issues: [
+          {
+            id: "first-issue",
+            identifier: "MUL-1",
+            title: "First query result",
+            status: "todo",
+          },
+        ],
+      })
+      .mockRejectedValueOnce(new Error("search failed"));
+    renderSearch();
+
+    const input = screen.getByPlaceholderText("Type a command or search...");
+    await user.type(input, "first");
+    await screen.findByText(firstResultTitle, undefined, { timeout: 2000 });
+
+    await user.type(input, "x");
+    expect(screen.queryByText(firstResultTitle)).not.toBeInTheDocument();
+    await waitFor(() => expect(mockSearchIssues).toHaveBeenCalledTimes(2), {
+      timeout: 2000,
+    });
+
+    await waitFor(() => {
+      expect(screen.queryByText(firstResultTitle)).not.toBeInTheDocument();
+    });
   });
 
   it("shows only New Issue by default and hides Pages / low-frequency commands until query", () => {

--- a/packages/views/search/search-command.tsx
+++ b/packages/views/search/search-command.tsx
@@ -185,6 +185,18 @@ export function SearchCommand() {
   const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const abortRef = useRef<AbortController | null>(null);
 
+  const cancelPendingSearch = useCallback(() => {
+    if (debounceRef.current !== null) {
+      clearTimeout(debounceRef.current);
+      debounceRef.current = null;
+    }
+
+    if (abortRef.current !== null) {
+      abortRef.current.abort();
+      abortRef.current = null;
+    }
+  }, []);
+
   const filteredPages = useMemo(() => {
     const q = query.trim().toLowerCase();
     if (!q) return [];
@@ -396,25 +408,20 @@ export function SearchCommand() {
   }, [open, setOpen]);
 
   // Cleanup debounce/abort on unmount
-  useEffect(() => {
-    return () => {
-      if (debounceRef.current) clearTimeout(debounceRef.current);
-      if (abortRef.current) abortRef.current.abort();
-    };
-  }, []);
+  useEffect(() => cancelPendingSearch, [cancelPendingSearch]);
 
   // Reset state when dialog closes
   useEffect(() => {
     if (!open) {
+      cancelPendingSearch();
       setQuery("");
       setResults({ issues: [], projects: [] });
       setIsLoading(false);
     }
-  }, [open]);
+  }, [cancelPendingSearch, open]);
 
   const search = useCallback((q: string) => {
-    if (debounceRef.current) clearTimeout(debounceRef.current);
-    if (abortRef.current) abortRef.current.abort();
+    cancelPendingSearch();
 
     if (!q.trim()) {
       setResults({ issues: [], projects: [] });
@@ -422,8 +429,10 @@ export function SearchCommand() {
       return;
     }
 
+    setResults({ issues: [], projects: [] });
     setIsLoading(true);
     debounceRef.current = setTimeout(async () => {
+      debounceRef.current = null;
       const controller = new AbortController();
       abortRef.current = controller;
       try {
@@ -450,11 +459,16 @@ export function SearchCommand() {
         }
       } catch {
         if (!controller.signal.aborted) {
+          setResults({ issues: [], projects: [] });
           setIsLoading(false);
+        }
+      } finally {
+        if (abortRef.current === controller) {
+          abortRef.current = null;
         }
       }
     }, 300);
-  }, []);
+  }, [cancelPendingSearch]);
 
   const handleValueChange = useCallback(
     (value: string) => {


### PR DESCRIPTION
## Summary

- cancel pending debounced and in-flight searches when the query changes, a dialog closes, or the component unmounts
- clear results immediately for a new query and keep them empty when the new search fails
- cover the global search command and issue picker with async lifecycle regression tests

## Root cause

The dialogs reset their visible state on close but did not cancel the pending debounce or active request. They also kept results from the previous query while the next request was pending or after it failed. A late response could therefore repopulate state and surface stale results when the dialog reopened.

## User impact

Search dialogs no longer display results from an earlier query or a previous open session.

## Validation

- `pnpm --filter @multica/views exec vitest run search/search-command.test.tsx modals/issue-picker-modal.test.tsx` — 23 tests passed
- `pnpm --filter @multica/views test` — 2,171 tests passed
- `pnpm --filter @multica/views typecheck`
- `pnpm --filter @multica/views lint` — 0 errors (existing warnings remain)
- `git diff --check`
