### PR TITLE
test(agent): serialize thinking cache tests

### DIFF
--- a/server/pkg/agent/thinking_test.go
+++ b/server/pkg/agent/thinking_test.go
@@ -496,7 +496,7 @@ func TestValidateThinkingLevel_EmptyModelResolvesToDefault(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("shell-script fake binary requires a POSIX shell")
 	}
-	t.Parallel()
+	// This test resets the package-global thinking cache, so it must remain serial.
 
 	// We need a `claude` whose --help advertises the full superset
 	// (low/medium/high/xhigh/max) so per-model projection actually has
@@ -551,7 +551,7 @@ func TestValidateThinkingLevel_ExplicitModel(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("shell-script fake binary requires a POSIX shell")
 	}
-	t.Parallel()
+	// This test resets the package-global thinking cache, so it must remain serial.
 	fakeClaude := writeFakeClaudeHelpBinary(t)
 	resetThinkingCacheForTests()
 	defer resetThinkingCacheForTests()
@@ -637,7 +637,7 @@ func TestValidateThinkingLevel_PreEffortCLIRejectsAllLevels(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("shell-script fake binary requires a POSIX shell")
 	}
-	t.Parallel()
+	// This test resets the package-global thinking cache, so it must remain serial.
 
 	// End-to-end guard for the daemon's pre-execution check against a CLI
 	// that predates --effort: the catalog must offer no levels, so any
@@ -791,7 +791,7 @@ func writeFakeCodexModelsBinary(t *testing.T) string {
 // ── Cache key invalidation ───────────────────────────────────────────
 
 func TestThinkingCacheKeyDistinct(t *testing.T) {
-	t.Parallel()
+	// This test resets the package-global thinking cache, so it must remain serial.
 	resetThinkingCacheForTests()
 	defer resetThinkingCacheForTests()
 
@@ -803,15 +803,24 @@ func TestThinkingCacheKeyDistinct(t *testing.T) {
 	thinkingCachePut(b, map[string]*ModelThinking{"x": {DefaultLevel: "b"}})
 	thinkingCachePut(c, map[string]*ModelThinking{"x": {DefaultLevel: "c"}})
 
-	if got, _ := thinkingCacheGet(a); got["x"].DefaultLevel != "a" {
-		t.Errorf("cache key A: got %q, want a", got["x"].DefaultLevel)
+	assertLevel := func(name string, key thinkingCacheKey, want string) {
+		t.Helper()
+		models, ok := thinkingCacheGet(key)
+		if !ok {
+			t.Fatalf("cache key %s: entry missing", name)
+		}
+		model, ok := models["x"]
+		if !ok || model == nil {
+			t.Fatalf("cache key %s: model x missing", name)
+		}
+		if model.DefaultLevel != want {
+			t.Errorf("cache key %s: got %q, want %q", name, model.DefaultLevel, want)
+		}
 	}
-	if got, _ := thinkingCacheGet(b); got["x"].DefaultLevel != "b" {
-		t.Errorf("cache key B: got %q, want b", got["x"].DefaultLevel)
-	}
-	if got, _ := thinkingCacheGet(c); got["x"].DefaultLevel != "c" {
-		t.Errorf("cache key C: got %q, want c", got["x"].DefaultLevel)
-	}
+
+	assertLevel("A", a, "a")
+	assertLevel("B", b, "b")
+	assertLevel("C", c, "c")
 }
 
 // ── Shared injection fixture (Trump's MUL-2339 constraint) ───────────


### PR DESCRIPTION
## Summary

- run every test that resets the package-global thinking cache serially
- make the cache-key test report missing entries explicitly instead of panicking on a nil lookup

## Root cause

`TestThinkingCacheKeyDistinct` and three validation tests called `t.Parallel()` while also resetting the same package-global `thinkingCache`. The cache mutex prevents a data race on individual operations, but it does not make a test's reset/put/get sequence atomic. A sibling test could therefore reset the cache after another test populated it, causing the cache-key test to dereference a missing model.

This caused the nondeterministic backend failure observed in [PR #5550](https://github.com/multica-ai/multica/pull/5550) at `thinking_test.go:806`.

## Impact

Backend CI no longer depends on scheduling between tests that mutate the shared thinking cache, and any future missing cache entry produces a focused assertion instead of a nil-pointer panic.

## Validation

- `go test -race ./pkg/agent -run '^TestThinkingCacheKeyDistinct$' -count=1000 -shuffle=on`
- `go test -race ./pkg/agent -run '^(TestThinkingCacheKeyDistinct|TestValidateThinkingLevel_EmptyModelResolvesToDefault|TestValidateThinkingLevel_ExplicitModel|TestValidateThinkingLevel_PreEffortCLIRejectsAllLevels)$' -count=10 -shuffle=on -parallel=64`
- `go test -race -p 2 -parallel 2 ./pkg/agent/...`
- `git diff --check`
