### PR TITLE
feat(issues): show unread updates on cards

### DIFF
--- a/packages/core/api/schemas.test.ts
+++ b/packages/core/api/schemas.test.ts
@@ -53,6 +53,7 @@ const baseIssue = {
   stage: null,
   start_date: null,
   due_date: null,
+  has_unread: false,
   metadata: {},
   created_at: "2026-01-01T00:00:00Z",
   updated_at: "2026-01-01T00:00:00Z",
@@ -103,6 +104,18 @@ describe("IssueSchema (via ListIssuesResponseSchema)", () => {
     const payload = { issues: [issueWithoutStage], total: 1 };
     const parsed = ListIssuesResponseSchema.parse(payload);
     expect(parsed.issues[0]?.stage).toBeNull();
+  });
+
+  it("accepts issue unread state and defaults it to false for older backends", () => {
+    const unread = ListIssuesResponseSchema.parse({
+      issues: [{ ...baseIssue, has_unread: true }],
+      total: 1,
+    });
+    expect(unread.issues[0]?.has_unread).toBe(true);
+
+    const { has_unread: _omit, ...issueWithoutUnread } = baseIssue;
+    const older = ListIssuesResponseSchema.parse({ issues: [issueWithoutUnread], total: 1 });
+    expect(older.issues[0]?.has_unread).toBe(false);
   });
 
   it("accepts custom property values including multi_select arrays", () => {

--- a/packages/core/api/schemas.ts
+++ b/packages/core/api/schemas.ts
@@ -455,6 +455,8 @@ export const IssueSchema = z.object({
   stage: z.number().nullable().default(null),
   start_date: z.string().nullable(),
   due_date: z.string().nullable(),
+  // Older backends predate issue-level unread state.
+  has_unread: z.boolean().default(false),
   metadata: IssueMetadataSchema,
   // Older backends predate custom properties; default {} so consumers never
   // nil-guard issue.properties.

--- a/packages/core/inbox/mutations.test.tsx
+++ b/packages/core/inbox/mutations.test.tsx
@@ -11,6 +11,7 @@ import type { ApiClient } from "../api/client";
 import type { InboxItem } from "../types";
 import { useUnarchiveInbox } from "./mutations";
 import { inboxKeys } from "./queries";
+import { issueKeys } from "../issues/queries";
 
 vi.mock("../hooks", () => ({
   useWorkspaceId: () => "workspace-1",
@@ -111,6 +112,9 @@ describe("useUnarchiveInbox", () => {
     });
     expect(invalidate).toHaveBeenCalledWith({
       queryKey: inboxKeys.unreadSummary(),
+    });
+    expect(invalidate).toHaveBeenCalledWith({
+      queryKey: issueKeys.all(WORKSPACE_ID),
     });
   });
 

--- a/packages/core/inbox/mutations.ts
+++ b/packages/core/inbox/mutations.ts
@@ -1,6 +1,7 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { api } from "../api";
 import { inboxKeys } from "./queries";
+import { issueKeys } from "../issues/queries";
 import { useWorkspaceId } from "../hooks";
 import type { InboxItem } from "../types";
 
@@ -28,6 +29,7 @@ export function useMarkInboxRead() {
     },
     onSettled: () => {
       qc.invalidateQueries({ queryKey: inboxKeys.all(wsId) });
+      qc.invalidateQueries({ queryKey: issueKeys.all(wsId) });
     },
   });
 }
@@ -58,6 +60,7 @@ export function useArchiveInbox() {
     onSettled: () => {
       // Both lists: the item just moved from the main inbox into the archive.
       qc.invalidateQueries({ queryKey: inboxKeys.all(wsId) });
+      qc.invalidateQueries({ queryKey: issueKeys.all(wsId) });
     },
   });
 }
@@ -102,6 +105,7 @@ export function useUnarchiveInbox() {
       // rises again when it was archived unread.
       qc.invalidateQueries({ queryKey: inboxKeys.all(wsId) });
       qc.invalidateQueries({ queryKey: inboxKeys.unreadSummary() });
+      qc.invalidateQueries({ queryKey: issueKeys.all(wsId) });
     },
   });
 }
@@ -126,6 +130,7 @@ export function useMarkAllInboxRead() {
     },
     onSettled: () => {
       qc.invalidateQueries({ queryKey: inboxKeys.list(wsId) });
+      qc.invalidateQueries({ queryKey: issueKeys.all(wsId) });
     },
   });
 }
@@ -139,6 +144,7 @@ export function useArchiveAllInbox() {
     mutationFn: () => api.archiveAllInbox(),
     onSettled: () => {
       qc.invalidateQueries({ queryKey: inboxKeys.all(wsId) });
+      qc.invalidateQueries({ queryKey: issueKeys.all(wsId) });
     },
   });
 }
@@ -150,6 +156,7 @@ export function useArchiveAllReadInbox() {
     mutationFn: () => api.archiveAllReadInbox(),
     onSettled: () => {
       qc.invalidateQueries({ queryKey: inboxKeys.all(wsId) });
+      qc.invalidateQueries({ queryKey: issueKeys.all(wsId) });
     },
   });
 }
@@ -161,6 +168,7 @@ export function useArchiveCompletedInbox() {
     mutationFn: () => api.archiveCompletedInbox(),
     onSettled: () => {
       qc.invalidateQueries({ queryKey: inboxKeys.all(wsId) });
+      qc.invalidateQueries({ queryKey: issueKeys.all(wsId) });
     },
   });
 }

--- a/packages/core/inbox/queries.test.ts
+++ b/packages/core/inbox/queries.test.ts
@@ -78,6 +78,27 @@ describe("deduplicateInboxItems", () => {
     expect(merged[0]?.details?.comment_id).toBe("comment-2");
   });
 
+  it("uses id as the stable newest tie-breaker when timestamps match", () => {
+    const merged = deduplicateInboxItems([
+      item({
+        id: "00000000-0000-0000-0000-000000000001",
+        read: false,
+        created_at: "2026-06-15T08:00:00Z",
+      }),
+      item({
+        id: "00000000-0000-0000-0000-000000000002",
+        read: true,
+        created_at: "2026-06-15T08:00:00Z",
+      }),
+    ]);
+
+    expect(merged).toHaveLength(1);
+    expect(merged[0]).toMatchObject({
+      id: "00000000-0000-0000-0000-000000000002",
+      read: true,
+    });
+  });
+
   it("drops archived rows so an optimistic archive leaves the list at once", () => {
     const merged = deduplicateInboxItems([
       item({ id: "active", issue_id: "issue-1" }),

--- a/packages/core/inbox/queries.ts
+++ b/packages/core/inbox/queries.ts
@@ -112,10 +112,7 @@ function groupInboxItemsByIssue(items: InboxItem[]): InboxItem[] {
   }
   const merged: InboxItem[] = [];
   for (const group of groups.values()) {
-    group.sort(
-      (a, b) =>
-        new Date(b.created_at).getTime() - new Date(a.created_at).getTime(),
-    );
+    group.sort(compareNewestInboxItem);
     const newest = group[0];
     if (!newest) continue;
 
@@ -133,8 +130,12 @@ function groupInboxItemsByIssue(items: InboxItem[]): InboxItem[] {
 
     merged.push(newest);
   }
-  return merged.sort(
-    (a, b) =>
-      new Date(b.created_at).getTime() - new Date(a.created_at).getTime(),
-  );
+  return merged.sort(compareNewestInboxItem);
+}
+
+function compareNewestInboxItem(a: InboxItem, b: InboxItem): number {
+  const byCreatedAt =
+    new Date(b.created_at).getTime() - new Date(a.created_at).getTime();
+  if (byCreatedAt !== 0) return byCreatedAt;
+  return b.id.localeCompare(a.id);
 }

--- a/packages/core/realtime/use-realtime-sync.test.ts
+++ b/packages/core/realtime/use-realtime-sync.test.ts
@@ -22,6 +22,7 @@ import {
   applyChatSessionUpdatedToCache,
   applyWorkspaceUpdatedToCache,
   handleInboxNew,
+  invalidateAllWorkspaceIssueQueries,
   invalidateChatMessageQueries,
   refetchPendingChatAggregate,
   resolveInboxSourceSlug,
@@ -606,6 +607,26 @@ describe("resolveInboxSourceSlug", () => {
   });
 });
 
+describe("invalidateAllWorkspaceIssueQueries", () => {
+  it("invalidates every cached workspace-scoped issue query without touching global per-issue caches", () => {
+    const qc = createQueryClient();
+    qc.setQueryData(issueKeys.list("ws-a"), []);
+    qc.setQueryData(issueKeys.detail("ws-b", "issue-1"), { id: "issue-1" });
+    qc.setQueryData(issueKeys.timeline("issue-1"), []);
+    const invalidate = vi.spyOn(qc, "invalidateQueries");
+
+    invalidateAllWorkspaceIssueQueries(qc);
+
+    expect(invalidate).toHaveBeenCalledWith({ predicate: expect.any(Function) });
+    const predicate = invalidate.mock.calls[0]?.[0]?.predicate;
+    expect(predicate).toBeTypeOf("function");
+    expect(predicate?.({ queryKey: issueKeys.list("ws-a") } as any)).toBe(true);
+    expect(predicate?.({ queryKey: issueKeys.detail("ws-b", "issue-1") } as any)).toBe(true);
+    expect(predicate?.({ queryKey: issueKeys.timeline("issue-1") } as any)).toBe(false);
+  });
+});
+
+
 describe("handleInboxNew", () => {
   function workspace(overrides: Partial<Workspace> = {}): Workspace {
     return {
@@ -678,7 +699,7 @@ describe("handleInboxNew", () => {
     });
   });
 
-  it("invalidates the ITEM's workspace inbox cache and resolves its slug, not the active workspace's", async () => {
+  it("invalidates the ITEM's workspace inbox and issue caches, not the active workspace's", async () => {
     const qc = createQueryClient();
     qc.setQueryData<Workspace[]>(workspaceKeys.list(), [
       workspace({ id: "ws-b", slug: "workspace-b" }),
@@ -697,6 +718,9 @@ describe("handleInboxNew", () => {
     // inbox, so the archived list has to drop it in the same pass (MUL-3736).
     expect(invalidate).toHaveBeenCalledWith({
       queryKey: inboxKeys.all("ws-a"),
+    });
+    expect(invalidate).toHaveBeenCalledWith({
+      queryKey: issueKeys.all("ws-a"),
     });
     expect(showNotification).toHaveBeenCalledWith(
       expect.objectContaining({ slug: "workspace-a" }),

--- a/packages/core/realtime/use-realtime-sync.ts
+++ b/packages/core/realtime/use-realtime-sync.ts
@@ -404,7 +404,10 @@ export async function handleInboxNew(
   item: InboxItem,
 ): Promise<void> {
   const sourceWsId = item.workspace_id;
-  if (sourceWsId) onInboxNew(qc, sourceWsId, item);
+  if (sourceWsId) {
+    onInboxNew(qc, sourceWsId, item);
+    qc.invalidateQueries({ queryKey: issueKeys.all(sourceWsId) });
+  }
   // A new item in ANY workspace can light the workspace-switcher dot, so
   // refresh the cross-workspace summary regardless of the active workspace.
   onInboxSummaryInvalidate(qc);
@@ -530,6 +533,30 @@ function invalidateWorkspaceScopedQueries(qc: QueryClient): void {
   qc.invalidateQueries({ queryKey: workspaceKeys.list() });
 }
 
+const nonWorkspaceIssueKeySegments = new Set([
+  "timeline",
+  "comment-trigger-preview",
+  "issue-trigger-preview",
+  "reactions",
+  "subscribers",
+  "usage",
+  "attachments",
+  "tasks",
+]);
+
+export function invalidateAllWorkspaceIssueQueries(qc: QueryClient): void {
+  qc.invalidateQueries({
+    predicate: (query) => {
+      const key = query.queryKey;
+      return (
+        key[0] === "issues" &&
+        typeof key[1] === "string" &&
+        !nonWorkspaceIssueKeySegments.has(key[1])
+      );
+    },
+  });
+}
+
 function invalidateSquadMemberStatusQueries(qc: QueryClient, wsId: string): void {
   qc.invalidateQueries({
     predicate: (query) => {
@@ -590,10 +617,13 @@ export function useRealtimeSync(
         if (wsId) onInboxInvalidate(qc, wsId);
         // inbox:read / inbox:archived / inbox:unarchived / batch events arrive
         // here. They can originate from a workspace other than the active one
-        // (personal events fan out to all the user's connections), so always
-        // refresh the cross-workspace summary — its dot must clear when another
-        // workspace's items are read/archived, and light again when an unread
-        // item is restored from the archive.
+        // (personal events fan out to all the user's connections), and these
+        // payloads do not carry source workspace_id. Refresh every cached
+        // workspace-scoped issue query so stale has_unread flags self-heal.
+        invalidateAllWorkspaceIssueQueries(qc);
+        // The cross-workspace summary dot must clear when another workspace's
+        // items are read/archived, and light again when an unread item is
+        // restored from the archive.
         onInboxSummaryInvalidate(qc);
       },
       agent: () => {

--- a/packages/core/types/issue.ts
+++ b/packages/core/types/issue.ts
@@ -58,6 +58,9 @@ export interface Issue {
   // + local formatting, which shifts the day by the viewer's offset.
   start_date: string | null;
   due_date: string | null;
+  // Whether the current member's newest active inbox item for this issue is
+  // unread. This is viewer-specific and optional for older backend payloads.
+  has_unread?: boolean;
   metadata: IssueMetadata;
   // Custom property values keyed by property definition id. Always present
   // in responses (empty object when unset), mirroring `metadata`.

--- a/packages/views/issues/components/board-card.test.tsx
+++ b/packages/views/issues/components/board-card.test.tsx
@@ -1,0 +1,106 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { describe, expect, it, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import type { Issue } from "@multica/core/types";
+import { BoardCardContent } from "./board-card";
+
+vi.mock("@multica/core/hooks", () => ({
+  useWorkspaceId: () => "ws-1",
+}));
+
+vi.mock("@multica/core/properties", () => ({
+  propertyListOptions: () => ({
+    queryKey: ["properties", "ws-1"],
+    queryFn: async () => [],
+  }),
+}));
+
+vi.mock("@multica/core/issues/stores/view-store-context", () => ({
+  useViewStore: (selector: (state: unknown) => unknown) =>
+    selector({
+      cardProperties: {
+        priority: false,
+        description: false,
+        assignee: false,
+        startDate: false,
+        dueDate: false,
+        project: false,
+        childProgress: false,
+        labels: false,
+      },
+      cardPropertyIds: [],
+    }),
+}));
+
+vi.mock("@multica/core/workspace/hooks", () => ({
+  useActorName: () => ({ getActorName: () => null }),
+}));
+
+vi.mock("../../i18n", () => ({
+  useT: () => ({
+    t: (selector: (value: any) => string) =>
+      selector({
+        card: { unread_update: "Unread update" },
+        priority: { none: "No priority" },
+        pickers: { assignee: { trigger_unassigned: "Unassigned" } },
+      }),
+  }),
+  useTimeAgo: () => () => "now",
+}));
+
+vi.mock("./issue-agent-activity-indicator", () => ({
+  IssueAgentActivityIndicator: () => null,
+}));
+
+const issue: Issue = {
+  id: "issue-1",
+  workspace_id: "ws-1",
+  number: 1,
+  identifier: "TEST-1",
+  title: "Unread card",
+  description: null,
+  status: "todo",
+  priority: "none",
+  assignee_type: null,
+  assignee_id: null,
+  creator_type: "member",
+  creator_id: "member-1",
+  parent_issue_id: null,
+  project_id: null,
+  position: 0,
+  stage: null,
+  start_date: null,
+  due_date: null,
+  metadata: {},
+  properties: {},
+  created_at: "2026-07-16T00:00:00Z",
+  updated_at: "2026-07-16T00:00:00Z",
+};
+
+function renderCard(value: Issue) {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <BoardCardContent issue={value} />
+    </QueryClientProvider>,
+  );
+}
+
+describe("BoardCardContent unread indicator", () => {
+  it("shows an accessible dot only when the issue has unread updates", () => {
+    const { rerender } = renderCard({ ...issue, has_unread: true });
+    expect(screen.getByLabelText("Unread update")).toBeInTheDocument();
+
+    rerender(
+      <QueryClientProvider client={new QueryClient()}>
+        <BoardCardContent issue={{ ...issue, has_unread: false }} />
+      </QueryClientProvider>,
+    );
+    expect(screen.queryByLabelText("Unread update")).not.toBeInTheDocument();
+  });
+});

--- a/packages/views/issues/components/board-card.tsx
+++ b/packages/views/issues/components/board-card.tsx
@@ -183,6 +183,13 @@ export const BoardCardContent = memo(function BoardCardContent({
         <div className="flex items-center gap-1.5 min-w-0">
           {priorityIconNode}
           <p className="text-xs text-muted-foreground truncate">{issue.identifier}</p>
+          {issue.has_unread === true && (
+            <span
+              className="size-1.5 shrink-0 rounded-full bg-destructive"
+              aria-label={t(($) => $.card.unread_update)}
+              title={t(($) => $.card.unread_update)}
+            />
+          )}
         </div>
         <IssueAgentActivityIndicator issueId={issue.id} />
       </div>

--- a/packages/views/locales/en/issues.json
+++ b/packages/views/locales/en/issues.json
@@ -446,7 +446,8 @@
   },
   "card": {
     "update_failed": "Failed to update issue",
-    "updated_ago": "Updated {{time}}"
+    "updated_ago": "Updated {{time}}",
+    "unread_update": "Unread update"
   },
   "actions": {
     "status": "Status",

--- a/packages/views/locales/ja/issues.json
+++ b/packages/views/locales/ja/issues.json
@@ -424,7 +424,8 @@
   },
   "card": {
     "update_failed": "イシューを更新できませんでした",
-    "updated_ago": "{{time}} に更新"
+    "updated_ago": "{{time}} に更新",
+    "unread_update": "未読の更新"
   },
   "actions": {
     "status": "ステータス",

--- a/packages/views/locales/ko/issues.json
+++ b/packages/views/locales/ko/issues.json
@@ -424,7 +424,8 @@
   },
   "card": {
     "update_failed": "이슈를 업데이트하지 못했습니다",
-    "updated_ago": "{{time}} 수정됨"
+    "updated_ago": "{{time}} 수정됨",
+    "unread_update": "읽지 않은 업데이트"
   },
   "actions": {
     "status": "상태",

--- a/packages/views/locales/zh-Hans/issues.json
+++ b/packages/views/locales/zh-Hans/issues.json
@@ -424,7 +424,8 @@
   },
   "card": {
     "update_failed": "更新 issue 失败",
-    "updated_ago": "更新于 {{time}}"
+    "updated_ago": "更新于 {{time}}",
+    "unread_update": "有未读更新"
   },
   "actions": {
     "status": "状态",

--- a/server/internal/handler/issue.go
+++ b/server/internal/handler/issue.go
@@ -53,6 +53,10 @@ type IssueResponse struct {
 	DueDate   *string `json:"due_date"`
 	CreatedAt string  `json:"created_at"`
 	UpdatedAt string  `json:"updated_at"`
+	// Viewer-specific: list/detail endpoints set this for the requesting
+	// member. Write responses and workspace broadcasts omit it so they cannot
+	// clear another viewer's cached unread state.
+	HasUnread *bool `json:"has_unread,omitempty"`
 	// Metadata is the per-issue KV map (see issue_metadata.go). Always emitted
 	// (empty object when unset) so frontend code can `issue.metadata[key]`
 	// without nil-guarding the parent field.
@@ -176,6 +180,40 @@ func (h *Handler) labelsByIssue(ctx context.Context, wsUUID pgtype.UUID, issueID
 		})
 	}
 	return out
+}
+
+// unreadIssueIDs returns the requested issues whose newest active inbox item
+// is unread for the current member. Failure is non-critical: issue lists remain
+// usable and simply omit unread indicators until the next refetch.
+func (h *Handler) unreadIssueIDs(ctx context.Context, r *http.Request, wsUUID pgtype.UUID, issueIDs []pgtype.UUID) map[string]bool {
+	out := map[string]bool{}
+	if len(issueIDs) == 0 {
+		return out
+	}
+	userID := requestUserID(r)
+	if userID == "" {
+		return out
+	}
+	rows, err := h.Queries.ListUnreadIssueIDs(ctx, db.ListUnreadIssueIDsParams{
+		WorkspaceID: wsUUID,
+		RecipientID: parseUUID(userID),
+		IssueIds:    issueIDs,
+	})
+	if err != nil {
+		slog.Warn("ListUnreadIssueIDs failed", "error", err)
+		return out
+	}
+	for _, issueID := range rows {
+		out[uuidToString(issueID)] = true
+	}
+	return out
+}
+
+func applyIssueUnread(resp []IssueResponse, unread map[string]bool) {
+	for i := range resp {
+		hasUnread := unread[resp[i].ID]
+		resp[i].HasUnread = &hasUnread
+	}
 }
 
 func openIssueRowToResponse(i db.ListOpenIssuesRow, issuePrefix string) IssueResponse {
@@ -723,12 +761,19 @@ func (h *Handler) SearchIssues(w http.ResponseWriter, r *http.Request) {
 	}
 
 	prefix := h.getIssuePrefix(ctx, wsUUID)
+	ids := make([]pgtype.UUID, len(results))
+	for i, result := range results {
+		ids[i] = result.issue.ID
+	}
+	unreadMap := h.unreadIssueIDs(ctx, r, wsUUID, ids)
 	resp := make([]SearchIssueResponse, len(results))
 	for i, sr := range results {
 		sir := SearchIssueResponse{
 			IssueResponse: issueToResponse(sr.issue, prefix),
 			MatchSource:   sr.matchSource,
 		}
+		hasUnread := unreadMap[sir.ID]
+		sir.HasUnread = &hasUnread
 		// Always populate comment snippet when a matching comment exists
 		if sr.matchedCommentContent != "" {
 			snippet := extractSnippet(sr.matchedCommentContent, q)
@@ -869,6 +914,7 @@ func (h *Handler) ListIssues(w http.ResponseWriter, r *http.Request) {
 			ids[i] = issue.ID
 		}
 		labelsMap := h.labelsByIssue(ctx, wsUUID, ids)
+		unreadMap := h.unreadIssueIDs(ctx, r, wsUUID, ids)
 		resp := make([]IssueResponse, len(issues))
 		for i, issue := range issues {
 			resp[i] = openIssueRowToResponse(issue, prefix)
@@ -878,6 +924,7 @@ func (h *Handler) ListIssues(w http.ResponseWriter, r *http.Request) {
 			}
 			resp[i].Labels = &labels
 		}
+		applyIssueUnread(resp, unreadMap)
 
 		writeJSON(w, http.StatusOK, map[string]any{
 			"issues": resp,
@@ -1142,6 +1189,7 @@ LIMIT %s OFFSET %s`, whereSql, orderBy, limitRef, offsetRef)
 		ids[i] = issue.ID
 	}
 	labelsMap := h.labelsByIssue(ctx, wsUUID, ids)
+	unreadMap := h.unreadIssueIDs(ctx, r, wsUUID, ids)
 	resp := make([]IssueResponse, len(issues))
 	for i, issue := range issues {
 		resp[i] = issueListRowToResponse(issue, prefix)
@@ -1151,6 +1199,7 @@ LIMIT %s OFFSET %s`, whereSql, orderBy, limitRef, offsetRef)
 		}
 		resp[i].Labels = &labels
 	}
+	applyIssueUnread(resp, unreadMap)
 
 	writeJSON(w, http.StatusOK, map[string]any{
 		"issues": resp,
@@ -1681,6 +1730,7 @@ ORDER BY
 		ids[i] = row.ID
 	}
 	labelsMap := h.labelsByIssue(ctx, wsUUID, ids)
+	unreadMap := h.unreadIssueIDs(ctx, r, wsUUID, ids)
 	prefix := h.getIssuePrefix(ctx, wsUUID)
 
 	groups := []IssueAssigneeGroupResponse{}
@@ -1701,6 +1751,8 @@ ORDER BY
 		}
 
 		issue := issueListRowToResponse(row.ListIssuesRow, prefix)
+		hasUnread := unreadMap[issue.ID]
+		issue.HasUnread = &hasUnread
 		labels := labelsMap[issue.ID]
 		if labels == nil {
 			labels = []LabelResponse{}
@@ -1720,6 +1772,8 @@ func (h *Handler) GetIssue(w http.ResponseWriter, r *http.Request) {
 	}
 	prefix := h.getIssuePrefix(r.Context(), issue.WorkspaceID)
 	resp := issueToResponse(issue, prefix)
+	hasUnread := h.unreadIssueIDs(r.Context(), r, issue.WorkspaceID, []pgtype.UUID{issue.ID})[resp.ID]
+	resp.HasUnread = &hasUnread
 	detailLabels := h.labelsByIssue(r.Context(), issue.WorkspaceID, []pgtype.UUID{issue.ID})[uuidToString(issue.ID)]
 	if detailLabels == nil {
 		detailLabels = []LabelResponse{}
@@ -1763,9 +1817,12 @@ func (h *Handler) ListChildIssues(w http.ResponseWriter, r *http.Request) {
 	}
 	prefix := h.getIssuePrefix(r.Context(), issue.WorkspaceID)
 	resp := make([]IssueResponse, len(children))
+	ids := make([]pgtype.UUID, len(children))
 	for i, child := range children {
 		resp[i] = issueToResponse(child, prefix)
+		ids[i] = child.ID
 	}
+	applyIssueUnread(resp, h.unreadIssueIDs(r.Context(), r, issue.WorkspaceID, ids))
 	writeJSON(w, http.StatusOK, map[string]any{
 		"issues": resp,
 	})
@@ -1832,9 +1889,12 @@ func (h *Handler) ListChildrenByParents(w http.ResponseWriter, r *http.Request) 
 	}
 	prefix := h.getIssuePrefix(r.Context(), wsUUID)
 	resp := make([]IssueResponse, len(children))
+	ids := make([]pgtype.UUID, len(children))
 	for i, child := range children {
 		resp[i] = issueToResponse(child, prefix)
+		ids[i] = child.ID
 	}
+	applyIssueUnread(resp, h.unreadIssueIDs(r.Context(), r, wsUUID, ids))
 	writeJSON(w, http.StatusOK, map[string]any{
 		"issues": resp,
 	})

--- a/server/internal/handler/issue_unread_test.go
+++ b/server/internal/handler/issue_unread_test.go
@@ -1,0 +1,83 @@
+package handler
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestListIssuesHasUnreadUsesNewestActiveInboxItem(t *testing.T) {
+	ctx := context.Background()
+	var issueID string
+	if err := testPool.QueryRow(ctx, `
+		INSERT INTO issue (
+			workspace_id, title, status, priority, creator_type, creator_id, number
+		)
+		VALUES ($1, 'Unread indicator test', 'todo', 'none', 'member', $2,
+			(SELECT COALESCE(MAX(number), 0) + 1 FROM issue WHERE workspace_id = $1))
+		RETURNING id
+	`, testWorkspaceID, testUserID).Scan(&issueID); err != nil {
+		t.Fatalf("create issue: %v", err)
+	}
+	t.Cleanup(func() {
+		testPool.Exec(context.Background(), `DELETE FROM inbox_item WHERE issue_id = $1`, issueID)
+		testPool.Exec(context.Background(), `DELETE FROM issue WHERE id = $1`, issueID)
+	})
+
+	insertItem := func(id string, read, archived bool, createdAt string) {
+		t.Helper()
+		if _, err := testPool.Exec(ctx, `
+			INSERT INTO inbox_item (
+				id, workspace_id, recipient_type, recipient_id, type, issue_id,
+				title, read, archived, created_at
+			)
+			VALUES ($1, $2, 'member', $3, 'new_comment', $4, 'Update', $5, $6, $7)
+		`, id, testWorkspaceID, testUserID, issueID, read, archived, createdAt); err != nil {
+			t.Fatalf("create inbox item: %v", err)
+		}
+	}
+
+	// An older unread item must not keep the dot alive when the newest active
+	// item is read. A newer archived item is excluded from the decision.
+	insertItem("00000000-0000-0000-0000-000000000001", false, false, "2026-07-16T10:00:00Z")
+	insertItem("00000000-0000-0000-0000-000000000002", true, false, "2026-07-16T11:00:00Z")
+	insertItem("00000000-0000-0000-0000-000000000003", false, true, "2026-07-16T12:00:00Z")
+
+	list := func() IssueResponse {
+		t.Helper()
+		w := httptest.NewRecorder()
+		testHandler.ListIssues(w, newRequest(http.MethodGet, "/api/issues?limit=100", nil))
+		if w.Code != http.StatusOK {
+			t.Fatalf("ListIssues: expected 200, got %d: %s", w.Code, w.Body.String())
+		}
+		var payload struct {
+			Issues []IssueResponse `json:"issues"`
+		}
+		if err := json.NewDecoder(w.Body).Decode(&payload); err != nil {
+			t.Fatalf("decode list: %v", err)
+		}
+		for _, issue := range payload.Issues {
+			if issue.ID == issueID {
+				return issue
+			}
+		}
+		t.Fatalf("issue %s missing from response", issueID)
+		return IssueResponse{}
+	}
+
+	if got := list().HasUnread; got == nil || *got {
+		t.Fatal("has_unread = true with a newer active read item")
+	}
+
+	insertItem("00000000-0000-0000-0000-000000000004", false, false, "2026-07-16T13:00:00Z")
+	if got := list().HasUnread; got == nil || !*got {
+		t.Fatal("has_unread = false with a newest active unread item")
+	}
+
+	insertItem("00000000-0000-0000-0000-000000000005", true, false, "2026-07-16T13:00:00Z")
+	if got := list().HasUnread; got == nil || *got {
+		t.Fatal("has_unread = true when same-time higher-id active item is read")
+	}
+}

--- a/server/pkg/db/generated/inbox.sql.go
+++ b/server/pkg/db/generated/inbox.sql.go
@@ -185,7 +185,7 @@ FROM (
     WHERE i.recipient_type = 'member'
       AND i.recipient_id = $1
       AND i.archived = false
-    ORDER BY i.workspace_id, COALESCE(i.issue_id, i.id), i.created_at DESC
+    ORDER BY i.workspace_id, COALESCE(i.issue_id, i.id), i.created_at DESC, i.id DESC
 ) newest
 WHERE newest.read = false
 GROUP BY newest.workspace_id
@@ -505,6 +505,50 @@ func (q *Queries) ListInboxItems(ctx context.Context, arg ListInboxItemsParams) 
 			return nil, err
 		}
 		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+const listUnreadIssueIDs = `-- name: ListUnreadIssueIDs :many
+SELECT newest.issue_id
+FROM (
+    SELECT DISTINCT ON (i.issue_id)
+        i.issue_id, i.read
+    FROM inbox_item i
+    WHERE i.workspace_id = $1
+      AND i.recipient_type = 'member'
+      AND i.recipient_id = $2
+      AND i.issue_id = ANY($3::uuid[])
+      AND i.archived = false
+    ORDER BY i.issue_id, i.created_at DESC, i.id DESC
+) newest
+WHERE newest.read = false
+`
+
+type ListUnreadIssueIDsParams struct {
+	WorkspaceID pgtype.UUID   `json:"workspace_id"`
+	RecipientID pgtype.UUID   `json:"recipient_id"`
+	IssueIds    []pgtype.UUID `json:"issue_ids"`
+}
+
+// Match the inbox UI's issue-level deduplication: only the newest active item
+// for each requested issue decides whether that issue has an unread update.
+func (q *Queries) ListUnreadIssueIDs(ctx context.Context, arg ListUnreadIssueIDsParams) ([]pgtype.UUID, error) {
+	rows, err := q.db.Query(ctx, listUnreadIssueIDs, arg.WorkspaceID, arg.RecipientID, arg.IssueIds)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []pgtype.UUID{}
+	for rows.Next() {
+		var issue_id pgtype.UUID
+		if err := rows.Scan(&issue_id); err != nil {
+			return nil, err
+		}
+		items = append(items, issue_id)
 	}
 	if err := rows.Err(); err != nil {
 		return nil, err

--- a/server/pkg/db/queries/inbox.sql
+++ b/server/pkg/db/queries/inbox.sql
@@ -93,6 +93,23 @@ RETURNING recipient_type, recipient_id;
 SELECT count(*) FROM inbox_item
 WHERE workspace_id = $1 AND recipient_type = $2 AND recipient_id = $3 AND read = false AND archived = false;
 
+-- name: ListUnreadIssueIDs :many
+-- Match the inbox UI's issue-level deduplication: only the newest active item
+-- for each requested issue decides whether that issue has an unread update.
+SELECT newest.issue_id
+FROM (
+    SELECT DISTINCT ON (i.issue_id)
+        i.issue_id, i.read
+    FROM inbox_item i
+    WHERE i.workspace_id = $1
+      AND i.recipient_type = 'member'
+      AND i.recipient_id = $2
+      AND i.issue_id = ANY(sqlc.arg('issue_ids')::uuid[])
+      AND i.archived = false
+    ORDER BY i.issue_id, i.created_at DESC, i.id DESC
+) newest
+WHERE newest.read = false;
+
 -- name: CountUnreadInboxByWorkspace :many
 -- Per-workspace unread inbox counts for a recipient member, matching the
 -- inbox UI's deduplicated view: notifications are grouped per issue
@@ -113,7 +130,7 @@ FROM (
     WHERE i.recipient_type = 'member'
       AND i.recipient_id = $1
       AND i.archived = false
-    ORDER BY i.workspace_id, COALESCE(i.issue_id, i.id), i.created_at DESC
+    ORDER BY i.workspace_id, COALESCE(i.issue_id, i.id), i.created_at DESC, i.id DESC
 ) newest
 WHERE newest.read = false
 GROUP BY newest.workspace_id;


### PR DESCRIPTION
## Summary
- add current-viewer unread state to issue responses and render a red unread indicator on issue dashboard cards
- keep unread state fresh for inbox mutations and realtime inbox events across workspaces
- make inbox latest-item selection deterministic when timestamps tie

## Tests
- git diff --check
- corepack pnpm exec vitest run packages/core/realtime/use-realtime-sync.test.ts packages/core/inbox/queries.test.ts packages/core/inbox/mutations.test.tsx packages/core/api/schemas.test.ts
- corepack pnpm --dir packages/views exec vitest run issues/components/board-card.test.tsx
- corepack pnpm --filter @multica/core typecheck && corepack pnpm --filter @multica/views typecheck
- cd server && GOCACHE=/tmp/multica-go-cache go test ./internal/handler -run 'TestListIssuesHasUnreadUsesNewestActiveInboxItem|TestIssueCRUD' -count=1\n\n🤖 Generated with [Claude Code](https://claude.com/claude-code)