### PR TITLE
MUL-4873: move create-issue field settings into a Settings Issue tab

### DIFF
--- a/packages/core/issues/stores/issue-create-settings-store.test.ts
+++ b/packages/core/issues/stores/issue-create-settings-store.test.ts
@@ -1,0 +1,71 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import {
+  DEFAULT_MANUAL_CREATE_FIELDS,
+  DEFAULT_QUICK_CREATE_FIELDS,
+  useIssueCreateSettingsStore,
+} from "./issue-create-settings-store";
+
+describe("issue create settings store", () => {
+  beforeEach(() => {
+    useIssueCreateSettingsStore.setState({
+      quickCreateFields: DEFAULT_QUICK_CREATE_FIELDS,
+      manualCreateFields: DEFAULT_MANUAL_CREATE_FIELDS,
+    });
+  });
+
+  it("defaults to project-only quick create and the classic manual toolbar", () => {
+    expect(useIssueCreateSettingsStore.getState().quickCreateFields).toEqual(["project"]);
+    expect(useIssueCreateSettingsStore.getState().manualCreateFields).toEqual([
+      "status",
+      "priority",
+      "assignee",
+      "labels",
+      "project",
+    ]);
+  });
+
+  it("keeps quick create fields in canonical order regardless of toggle sequence", () => {
+    const { setQuickCreateFieldVisible } = useIssueCreateSettingsStore.getState();
+
+    setQuickCreateFieldVisible("due_date", true);
+    setQuickCreateFieldVisible("priority", true);
+
+    expect(useIssueCreateSettingsStore.getState().quickCreateFields).toEqual([
+      "project",
+      "priority",
+      "due_date",
+    ]);
+
+    setQuickCreateFieldVisible("project", false);
+    expect(useIssueCreateSettingsStore.getState().quickCreateFields).toEqual([
+      "priority",
+      "due_date",
+    ]);
+  });
+
+  it("toggles manual create fields independently of quick create", () => {
+    const { setManualCreateFieldVisible } = useIssueCreateSettingsStore.getState();
+
+    setManualCreateFieldVisible("labels", false);
+    setManualCreateFieldVisible("due_date", true);
+
+    expect(useIssueCreateSettingsStore.getState().manualCreateFields).toEqual([
+      "status",
+      "priority",
+      "assignee",
+      "project",
+      "due_date",
+    ]);
+    expect(useIssueCreateSettingsStore.getState().quickCreateFields).toEqual(["project"]);
+  });
+
+  it("is a no-op to re-enable an already visible field", () => {
+    const { setManualCreateFieldVisible } = useIssueCreateSettingsStore.getState();
+
+    setManualCreateFieldVisible("status", true);
+
+    expect(useIssueCreateSettingsStore.getState().manualCreateFields).toEqual(
+      DEFAULT_MANUAL_CREATE_FIELDS,
+    );
+  });
+});

--- a/packages/core/issues/stores/issue-create-settings-store.ts
+++ b/packages/core/issues/stores/issue-create-settings-store.ts
@@ -1,0 +1,91 @@
+"use client";
+
+import { create } from "zustand";
+import { createJSONStorage, persist } from "zustand/middleware";
+import { createWorkspaceAwareStorage, registerForWorkspaceRehydration } from "../../platform/workspace-storage";
+import { defaultStorage } from "../../platform/storage";
+
+export type QuickCreateField = "project" | "priority" | "due_date";
+export type ManualCreateField =
+  | "status"
+  | "priority"
+  | "assignee"
+  | "labels"
+  | "project"
+  | "due_date"
+  | "start_date";
+
+// Canonical field order — the settings tab renders rows in this order and
+// setters normalize persisted arrays against it, so a toggle sequence never
+// produces two different persisted encodings of the same selection.
+export const QUICK_CREATE_FIELDS: QuickCreateField[] = ["project", "priority", "due_date"];
+export const MANUAL_CREATE_FIELDS: ManualCreateField[] = [
+  "status",
+  "priority",
+  "assignee",
+  "labels",
+  "project",
+  "due_date",
+  "start_date",
+];
+
+export const DEFAULT_QUICK_CREATE_FIELDS: QuickCreateField[] = ["project"];
+// Mirrors the manual dialog's historical toolbar: these five always rendered,
+// while due/start date lived behind the ⋯ overflow.
+export const DEFAULT_MANUAL_CREATE_FIELDS: ManualCreateField[] = [
+  "status",
+  "priority",
+  "assignee",
+  "labels",
+  "project",
+];
+
+// Which optional fields each create-issue mode keeps on its toolbar. Owned by
+// Settings → Issue and read by both create dialogs; a field toggled off here
+// stays reachable from the dialog's ⋯ overflow and always re-surfaces while it
+// holds a value. Per-workspace via the workspace-aware storage (projects and
+// custom properties differ per workspace), per-user for free from
+// localStorage being browser-profile-local — same scoping as quick-create's
+// actor/project memory.
+interface IssueCreateSettingsState {
+  quickCreateFields: QuickCreateField[];
+  setQuickCreateFieldVisible: (field: QuickCreateField, visible: boolean) => void;
+  manualCreateFields: ManualCreateField[];
+  setManualCreateFieldVisible: (field: ManualCreateField, visible: boolean) => void;
+}
+
+function toggle<F extends string>(all: F[], current: F[], field: F, visible: boolean): F[] {
+  return all.filter((f) => (f === field ? visible : current.includes(f)));
+}
+
+export const useIssueCreateSettingsStore = create<IssueCreateSettingsState>()(
+  persist(
+    (set) => ({
+      quickCreateFields: DEFAULT_QUICK_CREATE_FIELDS,
+      setQuickCreateFieldVisible: (field, visible) =>
+        set((s) => ({
+          quickCreateFields: toggle(QUICK_CREATE_FIELDS, s.quickCreateFields, field, visible),
+        })),
+      manualCreateFields: DEFAULT_MANUAL_CREATE_FIELDS,
+      setManualCreateFieldVisible: (field, visible) =>
+        set((s) => ({
+          manualCreateFields: toggle(MANUAL_CREATE_FIELDS, s.manualCreateFields, field, visible),
+        })),
+    }),
+    {
+      name: "multica_issue_create_settings",
+      storage: createJSONStorage(() => createWorkspaceAwareStorage(defaultStorage)),
+      merge: (persistedState, currentState) => {
+        const persisted = (persistedState ?? {}) as Partial<IssueCreateSettingsState>;
+        return {
+          ...currentState,
+          ...persisted,
+          quickCreateFields: persisted.quickCreateFields ?? DEFAULT_QUICK_CREATE_FIELDS,
+          manualCreateFields: persisted.manualCreateFields ?? DEFAULT_MANUAL_CREATE_FIELDS,
+        };
+      },
+    },
+  ),
+);
+
+registerForWorkspaceRehydration(() => useIssueCreateSettingsStore.persist.rehydrate());

--- a/packages/core/issues/stores/quick-create-store.test.ts
+++ b/packages/core/issues/stores/quick-create-store.test.ts
@@ -1,14 +1,10 @@
 import { beforeEach, describe, expect, it } from "vitest";
-import {
-  DEFAULT_QUICK_CREATE_FIELDS,
-  useQuickCreateStore,
-} from "./quick-create-store";
+import { useQuickCreateStore } from "./quick-create-store";
 
 const RESET_STATE = {
   lastActorType: null,
   lastActorId: null,
   lastProjectId: null,
-  visibleFields: DEFAULT_QUICK_CREATE_FIELDS,
   prompt: "",
   keepOpen: false,
 };
@@ -54,17 +50,5 @@ describe("quick create store", () => {
     setLastActor(null, null);
     expect(useQuickCreateStore.getState().lastActorType).toBeNull();
     expect(useQuickCreateStore.getState().lastActorId).toBeNull();
-  });
-
-  it("persists the fields exposed in the quick create toolbar", () => {
-    const { setVisibleFields } = useQuickCreateStore.getState();
-
-    setVisibleFields(["project", "priority", "due_date"]);
-
-    expect(useQuickCreateStore.getState().visibleFields).toEqual([
-      "project",
-      "priority",
-      "due_date",
-    ]);
   });
 });

--- a/packages/core/issues/stores/quick-create-store.ts
+++ b/packages/core/issues/stores/quick-create-store.ts
@@ -6,9 +6,6 @@ import { createWorkspaceAwareStorage, registerForWorkspaceRehydration } from "..
 import { defaultStorage } from "../../platform/storage";
 
 export type QuickCreateActorType = "agent" | "squad";
-export type QuickCreateField = "project" | "priority" | "due_date";
-
-export const DEFAULT_QUICK_CREATE_FIELDS: QuickCreateField[] = ["project"];
 
 // Per-workspace memory of the last actor (agent or squad) and project the
 // user picked in the Quick Create modal. Defaulted to those values on next
@@ -30,8 +27,6 @@ interface QuickCreateState {
   setLastActor: (type: QuickCreateActorType | null, id: string | null) => void;
   lastProjectId: string | null;
   setLastProjectId: (id: string | null) => void;
-  visibleFields: QuickCreateField[];
-  setVisibleFields: (fields: QuickCreateField[]) => void;
   prompt: string;
   setPrompt: (prompt: string) => void;
   clearPrompt: () => void;
@@ -47,8 +42,6 @@ export const useQuickCreateStore = create<QuickCreateState>()(
       setLastActor: (type, id) => set({ lastActorType: type, lastActorId: id }),
       lastProjectId: null,
       setLastProjectId: (id) => set({ lastProjectId: id }),
-      visibleFields: DEFAULT_QUICK_CREATE_FIELDS,
-      setVisibleFields: (visibleFields) => set({ visibleFields }),
       prompt: "",
       setPrompt: (prompt) => set({ prompt }),
       clearPrompt: () => set({ prompt: "" }),
@@ -58,14 +51,6 @@ export const useQuickCreateStore = create<QuickCreateState>()(
     {
       name: "multica_quick_create",
       storage: createJSONStorage(() => createWorkspaceAwareStorage(defaultStorage)),
-      merge: (persistedState, currentState) => {
-        const persisted = (persistedState ?? {}) as Partial<QuickCreateState>;
-        return {
-          ...currentState,
-          ...persisted,
-          visibleFields: persisted.visibleFields ?? DEFAULT_QUICK_CREATE_FIELDS,
-        };
-      },
     },
   ),
 );

--- a/packages/views/locales/en/modals.json
+++ b/packages/views/locales/en/modals.json
@@ -179,6 +179,12 @@
     "set_start_date": "Set start date...",
     "set_parent": "Set parent issue...",
     "add_subissue": "Add sub-issue...",
+    "set_status": "Set status...",
+    "set_priority": "Set priority...",
+    "set_assignee": "Set assignee...",
+    "set_labels": "Set labels...",
+    "set_project": "Set project...",
+    "customize_fields": "Customize fields...",
     "custom_properties": "Custom properties",
     "remove_parent": "Remove parent",
     "set_parent_picker": {
@@ -205,14 +211,6 @@
       "set_priority": "Set priority...",
       "set_due_date": "Set due date...",
       "customize_fields": "Customize fields...",
-      "field_settings_title": "Quick create fields",
-      "field_settings_description": "Choose which fields stay visible in the quick create toolbar.",
-      "field_settings_done": "Done",
-      "fields": {
-        "project": "Project",
-        "priority": "Priority",
-        "due_date": "Due date"
-      },
       "submit": "Create",
       "sending": "Sending…",
       "uploading": "Uploading…",

--- a/packages/views/locales/en/settings.json
+++ b/packages/views/locales/en/settings.json
@@ -99,6 +99,22 @@
     "floating_label": "Floating chat window",
     "floating_hint": "Show the floating chat button in the corner of every page. Off by default — turn it on to summon chat anywhere; when off, Chat lives only in this tab."
   },
+  "issue": {
+    "description": "Choose which fields each create dialog keeps on its toolbar. Hidden fields stay available from the ⋯ menu and reappear while they hold a value.",
+    "quick_create_title": "Create with agent",
+    "quick_create_description": "Fields shown in the quick create toolbar.",
+    "manual_create_title": "Create manually",
+    "manual_create_description": "Fields shown in the manual create toolbar.",
+    "fields": {
+      "status": "Status",
+      "priority": "Priority",
+      "assignee": "Assignee",
+      "labels": "Labels",
+      "project": "Project",
+      "due_date": "Due date",
+      "start_date": "Start date"
+    }
+  },
   "page": {
     "title": "Settings",
     "my_account": "My Account",
@@ -107,6 +123,7 @@
       "profile": "Profile",
       "preferences": "Preferences",
       "shortcuts": "Shortcuts",
+      "issue": "Issue",
       "chat": "Chat",
       "notifications": "Notifications",
       "tokens": "API Tokens",

--- a/packages/views/locales/ja/modals.json
+++ b/packages/views/locales/ja/modals.json
@@ -177,6 +177,12 @@
     "set_start_date": "開始日を設定...",
     "set_parent": "親イシューを設定...",
     "add_subissue": "サブイシューを追加...",
+    "set_status": "ステータスを設定...",
+    "set_priority": "優先度を設定...",
+    "set_assignee": "担当者を設定...",
+    "set_labels": "ラベルを設定...",
+    "set_project": "プロジェクトを設定...",
+    "customize_fields": "フィールドをカスタマイズ...",
     "custom_properties": "カスタムプロパティ",
     "remove_parent": "親を削除",
     "set_parent_picker": {
@@ -203,14 +209,6 @@
       "set_priority": "優先度を設定...",
       "set_due_date": "期限を設定...",
       "customize_fields": "フィールドをカスタマイズ...",
-      "field_settings_title": "クイック作成フィールド",
-      "field_settings_description": "クイック作成ツールバーに常に表示するフィールドを選択します。",
-      "field_settings_done": "完了",
-      "fields": {
-        "project": "プロジェクト",
-        "priority": "優先度",
-        "due_date": "期限"
-      },
       "submit": "作成",
       "sending": "送信中…",
       "uploading": "アップロード中…",

--- a/packages/views/locales/ja/settings.json
+++ b/packages/views/locales/ja/settings.json
@@ -96,6 +96,22 @@
     "floating_label": "フローティングチャット",
     "floating_hint": "すべてのページの隅にフローティングチャットボタンを表示します。デフォルトはオフ——オンにするとどこからでもチャットを呼び出せます。オフのときは専用タブでのみ利用できます。"
   },
+  "issue": {
+    "description": "各作成ダイアログのツールバーに常時表示するフィールドを選択します。非表示のフィールドは ⋯ メニューから引き続き使用でき、値がある間は自動的に表示されます。",
+    "quick_create_title": "エージェントで作成",
+    "quick_create_description": "クイック作成ツールバーに表示するフィールド。",
+    "manual_create_title": "手動で作成",
+    "manual_create_description": "手動作成ツールバーに表示するフィールド。",
+    "fields": {
+      "status": "ステータス",
+      "priority": "優先度",
+      "assignee": "担当者",
+      "labels": "ラベル",
+      "project": "プロジェクト",
+      "due_date": "期限",
+      "start_date": "開始日"
+    }
+  },
   "page": {
     "title": "設定",
     "my_account": "マイアカウント",
@@ -104,6 +120,7 @@
       "profile": "プロフィール",
       "preferences": "環境設定",
       "shortcuts": "ショートカット",
+      "issue": "イシュー",
       "chat": "チャット",
       "notifications": "通知",
       "tokens": "API トークン",

--- a/packages/views/locales/ko/modals.json
+++ b/packages/views/locales/ko/modals.json
@@ -177,6 +177,12 @@
     "set_start_date": "시작일 설정...",
     "set_parent": "상위 이슈 설정...",
     "add_subissue": "하위 이슈 추가...",
+    "set_status": "상태 설정...",
+    "set_priority": "우선순위 설정...",
+    "set_assignee": "담당자 설정...",
+    "set_labels": "레이블 설정...",
+    "set_project": "프로젝트 설정...",
+    "customize_fields": "필드 사용자 지정...",
     "custom_properties": "사용자 지정 속성",
     "remove_parent": "상위 이슈 제거",
     "set_parent_picker": {
@@ -203,14 +209,6 @@
       "set_priority": "우선순위 설정...",
       "set_due_date": "마감일 설정...",
       "customize_fields": "필드 사용자 지정...",
-      "field_settings_title": "빠른 만들기 필드",
-      "field_settings_description": "빠른 만들기 도구 모음에 항상 표시할 필드를 선택하세요.",
-      "field_settings_done": "완료",
-      "fields": {
-        "project": "프로젝트",
-        "priority": "우선순위",
-        "due_date": "마감일"
-      },
       "submit": "만들기",
       "sending": "보내는 중...",
       "uploading": "업로드 중...",

--- a/packages/views/locales/ko/settings.json
+++ b/packages/views/locales/ko/settings.json
@@ -96,6 +96,22 @@
     "floating_label": "플로팅 채팅 창",
     "floating_hint": "모든 페이지 모서리에 플로팅 채팅 버튼을 표시합니다. 기본값은 꺼짐 — 켜면 어디서나 채팅을 불러올 수 있고, 꺼면 채팅은 이 탭에서만 사용할 수 있습니다."
   },
+  "issue": {
+    "description": "각 생성 방식의 툴바에 항상 표시할 필드를 선택합니다. 숨긴 필드는 ⋯ 메뉴에서 계속 사용할 수 있으며, 값이 있는 동안에는 자동으로 표시됩니다.",
+    "quick_create_title": "에이전트로 만들기",
+    "quick_create_description": "빠른 생성 툴바에 표시할 필드입니다.",
+    "manual_create_title": "직접 만들기",
+    "manual_create_description": "직접 만들기 툴바에 표시할 필드입니다.",
+    "fields": {
+      "status": "상태",
+      "priority": "우선순위",
+      "assignee": "담당자",
+      "labels": "레이블",
+      "project": "프로젝트",
+      "due_date": "마감일",
+      "start_date": "시작일"
+    }
+  },
   "page": {
     "title": "설정",
     "my_account": "내 계정",
@@ -104,6 +120,7 @@
       "profile": "프로필",
       "preferences": "환경설정",
       "shortcuts": "단축키",
+      "issue": "이슈",
       "chat": "채팅",
       "notifications": "알림",
       "tokens": "API 토큰",

--- a/packages/views/locales/zh-Hans/modals.json
+++ b/packages/views/locales/zh-Hans/modals.json
@@ -177,6 +177,12 @@
     "set_start_date": "设置开始日期...",
     "set_parent": "设置父 issue...",
     "add_subissue": "添加子 issue...",
+    "set_status": "设置状态...",
+    "set_priority": "设置优先级...",
+    "set_assignee": "设置负责人...",
+    "set_labels": "设置标签...",
+    "set_project": "设置项目...",
+    "customize_fields": "自定义字段...",
     "custom_properties": "自定义属性",
     "remove_parent": "移除父级",
     "set_parent_picker": {
@@ -203,14 +209,6 @@
       "set_priority": "设置优先级...",
       "set_due_date": "设置截止日期...",
       "customize_fields": "自定义字段...",
-      "field_settings_title": "快速创建字段",
-      "field_settings_description": "选择快速创建工具栏中常驻显示的字段。",
-      "field_settings_done": "完成",
-      "fields": {
-        "project": "项目",
-        "priority": "优先级",
-        "due_date": "截止日期"
-      },
       "submit": "创建",
       "sending": "发送中...",
       "uploading": "上传中...",

--- a/packages/views/locales/zh-Hans/settings.json
+++ b/packages/views/locales/zh-Hans/settings.json
@@ -99,6 +99,22 @@
     "floating_label": "悬浮聊天窗",
     "floating_hint": "在每个页面右下角显示悬浮聊天按钮。默认关闭——打开后可随处召唤聊天；关闭时，聊天只在此标签页中可用。"
   },
+  "issue": {
+    "description": "选择各创建方式的工具栏中常驻显示的字段。隐藏的字段仍可从 ⋯ 菜单使用，有值时会自动显示。",
+    "quick_create_title": "通过智能体创建",
+    "quick_create_description": "快速创建工具栏中显示的字段。",
+    "manual_create_title": "手动创建",
+    "manual_create_description": "手动创建工具栏中显示的字段。",
+    "fields": {
+      "status": "状态",
+      "priority": "优先级",
+      "assignee": "负责人",
+      "labels": "标签",
+      "project": "项目",
+      "due_date": "截止日期",
+      "start_date": "开始日期"
+    }
+  },
   "page": {
     "title": "设置",
     "my_account": "我的账号",
@@ -107,6 +123,7 @@
       "profile": "个人资料",
       "preferences": "偏好设置",
       "shortcuts": "快捷键",
+      "issue": "Issue",
       "chat": "聊天",
       "notifications": "通知",
       "tokens": "API Token",

--- a/packages/views/modals/create-issue.test.tsx
+++ b/packages/views/modals/create-issue.test.tsx
@@ -77,6 +77,27 @@ const mockQuickCreateStore = {
   setKeepOpen: mockSetKeepOpen,
 };
 
+type ManualCreateField =
+  | "status"
+  | "priority"
+  | "assignee"
+  | "labels"
+  | "project"
+  | "due_date"
+  | "start_date";
+
+const DEFAULT_MANUAL_FIELDS: ManualCreateField[] = [
+  "status",
+  "priority",
+  "assignee",
+  "labels",
+  "project",
+];
+
+const mockCreateSettingsStore = {
+  manualCreateFields: DEFAULT_MANUAL_FIELDS as ManualCreateField[],
+};
+
 vi.mock("../navigation", () => ({
   useNavigation: () => ({ push: mockPush }),
 }));
@@ -85,6 +106,7 @@ vi.mock("@multica/core/paths", () => ({
   useCurrentWorkspace: () => ({ name: "Test Workspace" }),
   useWorkspacePaths: () => ({
     issueDetail: (id: string) => `/ws-test/issues/${id}`,
+    settings: () => "/ws-test/settings",
   }),
 }));
 
@@ -137,6 +159,12 @@ vi.mock("@multica/core/issues/stores/draft-store", () => ({
 vi.mock("@multica/core/issues/stores/quick-create-store", () => ({
   useQuickCreateStore: (selector?: (state: typeof mockQuickCreateStore) => unknown) =>
     (selector ? selector(mockQuickCreateStore) : mockQuickCreateStore),
+}));
+
+vi.mock("@multica/core/issues/stores/issue-create-settings-store", () => ({
+  useIssueCreateSettingsStore: (
+    selector?: (state: typeof mockCreateSettingsStore) => unknown,
+  ) => (selector ? selector(mockCreateSettingsStore) : mockCreateSettingsStore),
 }));
 
 vi.mock("@multica/core/issues/mutations", () => ({
@@ -310,7 +338,15 @@ vi.mock("../issues/components", () => ({
       onClick={() => onOpenChange?.(false)}
     />
   ),
-  LabelPicker: () => <div data-testid="label-picker" />,
+  // Labels can now be hidden via Settings → Issue and revealed from the
+  // overflow, so surface open/onOpenChange like the date pickers.
+  LabelPicker: ({ open, onOpenChange }: { open?: boolean; onOpenChange?: (v: boolean) => void }) => (
+    <div
+      data-testid="label-picker"
+      data-open={open ? "true" : "false"}
+      onClick={() => onOpenChange?.(false)}
+    />
+  ),
 }));
 
 vi.mock("../issues/components/pickers/custom-property-picker", () => ({
@@ -440,6 +476,7 @@ describe("CreateIssueModal", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockQuickCreateStore.keepOpen = false;
+    mockCreateSettingsStore.manualCreateFields = DEFAULT_MANUAL_FIELDS;
     mockSetKeepOpen.mockImplementation((v: boolean) => {
       mockQuickCreateStore.keepOpen = v;
     });
@@ -1048,6 +1085,55 @@ describe("CreateIssueModal", () => {
     await user.click(picker);
 
     expect(screen.queryByTestId("due-date-picker")).not.toBeInTheDocument();
+  });
+
+  it("hides toolbar fields turned off in Settings → Issue and re-reveals them from the overflow", async () => {
+    const user = userEvent.setup();
+    mockCreateSettingsStore.manualCreateFields = ["status", "priority", "assignee", "project"];
+
+    renderModal(<CreateIssueModal onClose={vi.fn()} />);
+
+    expect(screen.queryByTestId("label-picker")).not.toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: /Set labels/i }));
+
+    const picker = await screen.findByTestId("label-picker");
+    expect(picker).toHaveAttribute("data-open", "true");
+
+    await user.click(picker);
+
+    expect(screen.queryByTestId("label-picker")).not.toBeInTheDocument();
+  });
+
+  it("keeps a hidden field on the toolbar while it holds a value", () => {
+    mockCreateSettingsStore.manualCreateFields = ["status", "priority", "assignee", "project"];
+    mockDraftStore.draft.labelIds = ["label-1"];
+
+    renderModal(<CreateIssueModal onClose={vi.fn()} />);
+
+    expect(screen.getByTestId("label-picker")).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /Set labels/i })).not.toBeInTheDocument();
+  });
+
+  it("renders due date inline when enabled in Settings → Issue", () => {
+    mockCreateSettingsStore.manualCreateFields = [...DEFAULT_MANUAL_FIELDS, "due_date"];
+
+    renderModal(<CreateIssueModal onClose={vi.fn()} />);
+
+    expect(screen.getByTestId("due-date-picker")).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /Set due date/i })).not.toBeInTheDocument();
+  });
+
+  it("routes Customize fields to Settings → Issue and closes the dialog", async () => {
+    const user = userEvent.setup();
+    const onClose = vi.fn();
+
+    renderModal(<CreateIssueModal onClose={onClose} />);
+
+    await user.click(screen.getByRole("button", { name: /Customize fields/i }));
+
+    expect(onClose).toHaveBeenCalled();
+    expect(mockPush).toHaveBeenCalledWith("/ws-test/settings?tab=issue");
   });
 
   // Title + description are packed into the agent prompt on switch; if we

--- a/packages/views/modals/create-issue.tsx
+++ b/packages/views/modals/create-issue.tsx
@@ -12,10 +12,14 @@ import {
   CalendarDays,
   Check,
   ChevronRight,
+  CircleUser,
+  FolderKanban,
   Maximize2,
   Minimize2,
   MoreHorizontal,
+  Settings2,
   Shapes,
+  Tag,
   X as XIcon,
 } from "lucide-react";
 import { cn } from "@multica/ui/lib/utils";
@@ -47,7 +51,7 @@ import { Tooltip, TooltipTrigger, TooltipContent, TooltipProvider } from "@multi
 import { Button } from "@multica/ui/components/ui/button";
 import { Switch } from "@multica/ui/components/ui/switch";
 import { ContentEditor, type ContentEditorRef, TitleEditor, useFileDropZone, FileDropOverlay, useUploadGate, useEditorUpload } from "../editor";
-import { StatusIcon, StatusPicker, PriorityPicker, StagePicker, AssigneePicker, StartDatePicker, DueDatePicker, LabelPicker } from "../issues/components";
+import { StatusIcon, StatusPicker, PriorityIcon, PriorityPicker, StagePicker, AssigneePicker, StartDatePicker, DueDatePicker, LabelPicker } from "../issues/components";
 import { maxSiblingStage } from "../issues/components/pickers/stage-picker";
 import { ProjectPicker } from "../projects/components/project-picker";
 import { useIssueTriggerPreview } from "../issues/hooks/use-issue-trigger-preview";
@@ -57,6 +61,10 @@ import { useWorkspaceId } from "@multica/core/hooks";
 import { useIssueDraftStore } from "@multica/core/issues/stores/draft-store";
 import { useCreateModeStore } from "@multica/core/issues/stores/create-mode-store";
 import { useQuickCreateStore } from "@multica/core/issues/stores/quick-create-store";
+import {
+  useIssueCreateSettingsStore,
+  type ManualCreateField,
+} from "@multica/core/issues/stores/issue-create-settings-store";
 import { issueDetailOptions, childIssuesOptions } from "@multica/core/issues/queries";
 import { useCreateIssue, useUpdateIssue } from "@multica/core/issues/mutations";
 import { useAttachLabelToIssue } from "@multica/core/labels";
@@ -220,6 +228,7 @@ export function ManualCreatePanel({
   const setLastMode = useCreateModeStore((s) => s.setLastMode);
   const keepOpen = useQuickCreateStore((s) => s.keepOpen);
   const setKeepOpen = useQuickCreateStore((s) => s.setKeepOpen);
+  const manualFields = useIssueCreateSettingsStore((s) => s.manualCreateFields);
 
   const [title, setTitle] = useState(draft.title);
   const [formResetKey, setFormResetKey] = useState(0);
@@ -263,6 +272,15 @@ export function ManualCreatePanel({
     typeof data?.stage === "number" ? (data.stage as number) : null,
   );
   const [parentPickerOpen, setParentPickerOpen] = useState(false);
+  // Toolbar fields hidden via Settings → Issue reuse the overflow reveal
+  // pattern: the ⋯ menu item flips this open, which mounts the inline pill
+  // (the popover's anchor) AND opens the picker. Closing without a value
+  // unmounts the pill again; a field holding a non-default value always
+  // renders regardless of the setting so nothing applied is ever invisible.
+  const [fieldPickerOpen, setFieldPickerOpen] = useState<Exclude<
+    ManualCreateField,
+    "due_date" | "start_date"
+  > | null>(null);
   // Start date is a low-frequency field — by default it lives in the
   // overflow ⋯ menu. Clicking the menu item flips this open, which both
   // mounts the inline pill (the popover's anchor) AND opens the calendar.
@@ -344,6 +362,28 @@ export function ManualCreatePanel({
     else next[propertyId] = value;
     setPropertyValues(next);
     setDraft({ propertyValues: next });
+  };
+
+  // Inline pill reveal per toolbar field: kept by Settings → Issue, holding a
+  // non-default value (a hidden field with a value must stay visible — the
+  // draft or a mode-switch carry may have set it), or just opened from the ⋯
+  // overflow (the picker popover needs the inline pill as its anchor).
+  const showField = {
+    status: manualFields.includes("status") || status !== "todo" || fieldPickerOpen === "status",
+    priority: manualFields.includes("priority") || priority !== "none" || fieldPickerOpen === "priority",
+    assignee: manualFields.includes("assignee") || assigneeId != null || fieldPickerOpen === "assignee",
+    labels: manualFields.includes("labels") || labelIds.length > 0 || fieldPickerOpen === "labels",
+    project: manualFields.includes("project") || projectId != null || fieldPickerOpen === "project",
+    due_date: manualFields.includes("due_date") || dueDate !== null || dueDatePickerOpen,
+    start_date: manualFields.includes("start_date") || startDate !== null || startDatePickerOpen,
+  };
+
+  // Field visibility lives in Settings → Issue; the modal closes first so the
+  // dialog doesn't linger over the settings page. The draft store already
+  // holds everything typed, so nothing is lost across the round-trip.
+  const openFieldSettings = () => {
+    onClose();
+    router.push(`${p.settings()}?tab=issue`);
   };
 
   const createIssueMutation = useCreateIssue();
@@ -720,54 +760,75 @@ export function ManualCreatePanel({
                 when an agent assignee will pick the issue up. */}
             <CreateRunHint assigneeType={assigneeType} assigneeId={assigneeId} status={status} />
 
-            {/* Property toolbar */}
+            {/* Property toolbar — each field renders per the Settings → Issue
+                selection (see showField above). */}
             <div className="flex items-center gap-1.5 px-4 py-2 shrink-0 flex-wrap">
               {/* Status */}
-              <StatusPicker
-                status={status}
-                onUpdate={(u) => { if (u.status) updateStatus(u.status); }}
-                triggerRender={<PillButton />}
-                align="start"
-              />
+              {showField.status && (
+                <StatusPicker
+                  status={status}
+                  onUpdate={(u) => { if (u.status) updateStatus(u.status); }}
+                  triggerRender={<PillButton />}
+                  align="start"
+                  open={fieldPickerOpen === "status" ? true : undefined}
+                  onOpenChange={(open) => setFieldPickerOpen(open ? "status" : null)}
+                />
+              )}
 
               {/* Priority */}
-              <PriorityPicker
-                priority={priority}
-                onUpdate={(u) => { if (u.priority) updatePriority(u.priority); }}
-                triggerRender={<PillButton />}
-                align="start"
-              />
+              {showField.priority && (
+                <PriorityPicker
+                  priority={priority}
+                  onUpdate={(u) => { if (u.priority) updatePriority(u.priority); }}
+                  triggerRender={<PillButton />}
+                  align="start"
+                  open={fieldPickerOpen === "priority" ? true : undefined}
+                  onOpenChange={(open) => setFieldPickerOpen(open ? "priority" : null)}
+                />
+              )}
 
               {/* Assignee */}
-              <AssigneePicker
-                assigneeType={assigneeType ?? null}
-                assigneeId={assigneeId ?? null}
-                onUpdate={(u) => updateAssignee(
-                  u.assignee_type ?? undefined,
-                  u.assignee_id ?? undefined,
-                )}
-                triggerRender={<PillButton />}
-                align="start"
-              />
+              {showField.assignee && (
+                <AssigneePicker
+                  assigneeType={assigneeType ?? null}
+                  assigneeId={assigneeId ?? null}
+                  onUpdate={(u) => updateAssignee(
+                    u.assignee_type ?? undefined,
+                    u.assignee_id ?? undefined,
+                  )}
+                  triggerRender={<PillButton />}
+                  align="start"
+                  open={fieldPickerOpen === "assignee" ? true : undefined}
+                  onOpenChange={(open) => setFieldPickerOpen(open ? "assignee" : null)}
+                />
+              )}
 
               {/* Labels — occupies the slot that used to hold Due date so the
                   add-label entry is exposed directly on the dialog. Draft mode:
                   selection is local until the issue is created (handleSubmit
                   attaches the labels afterward). */}
-              <LabelPicker
-                selectedIds={labelIds}
-                onSelectedIdsChange={updateLabelIds}
-                triggerRender={<PillButton />}
-                align="start"
-              />
+              {showField.labels && (
+                <LabelPicker
+                  selectedIds={labelIds}
+                  onSelectedIdsChange={updateLabelIds}
+                  triggerRender={<PillButton />}
+                  align="start"
+                  open={fieldPickerOpen === "labels" ? true : undefined}
+                  onOpenChange={(open) => setFieldPickerOpen(open ? "labels" : null)}
+                />
+              )}
 
               {/* Project */}
-              <ProjectPicker
-                projectId={projectId ?? null}
-                onUpdate={(u) => setProjectId(u.project_id ?? undefined)}
-                triggerRender={<PillButton />}
-                align="start"
-              />
+              {showField.project && (
+                <ProjectPicker
+                  projectId={projectId ?? null}
+                  onUpdate={(u) => setProjectId(u.project_id ?? undefined)}
+                  triggerRender={<PillButton />}
+                  align="start"
+                  open={fieldPickerOpen === "project" ? true : undefined}
+                  onOpenChange={(open) => setFieldPickerOpen(open ? "project" : null)}
+                />
+              )}
 
               {/* Stage — only relevant when creating a sub-issue under a parent */}
               {parentIssueId && (
@@ -781,11 +842,12 @@ export function ManualCreatePanel({
               )}
 
               {/* Start date — collapsed into the ⋯ menu by default since it's
-                  a low-frequency field. Renders inline only when the field
-                  has a value OR the user just opened it from the overflow
+                  a low-frequency field (exposable via Settings → Issue).
+                  Renders inline when configured visible, when the field has a
+                  value, OR when the user just opened it from the overflow
                   menu (the picker's calendar popover needs the inline pill
                   as its anchor). */}
-              {(startDate || startDatePickerOpen) && (
+              {showField.start_date && (
                 <StartDatePicker
                   startDate={startDate}
                   onUpdate={(u) => updateStartDate(u.start_date ?? null)}
@@ -798,9 +860,8 @@ export function ManualCreatePanel({
 
               {/* Due date — collapsed into the ⋯ menu by default (moved off
                   the toolbar to make room for Labels). Same reveal rule as
-                  start date: inline only when it has a value or the user just
-                  opened it from the overflow menu. */}
-              {(dueDate || dueDatePickerOpen) && (
+                  start date. */}
+              {showField.due_date && (
                 <DueDatePicker
                   dueDate={dueDate}
                   onUpdate={(u) => updateDueDate(u.due_date ?? null)}
@@ -908,13 +969,46 @@ export function ManualCreatePanel({
                   }
                 />
                 <DropdownMenuContent align="start" className="w-auto">
-                  {!dueDate && (
+                  {/* Re-entry points for toolbar fields hidden via
+                      Settings → Issue. Listed in toolbar order; each opens
+                      the picker inline (mounting the pill as its anchor). */}
+                  {!showField.status && (
+                    <DropdownMenuItem onClick={() => setFieldPickerOpen("status")}>
+                      <StatusIcon status={status} className="h-3.5 w-3.5" />
+                      {t(($) => $.create_issue.set_status)}
+                    </DropdownMenuItem>
+                  )}
+                  {!showField.priority && (
+                    <DropdownMenuItem onClick={() => setFieldPickerOpen("priority")}>
+                      <PriorityIcon priority="none" className="h-3.5 w-3.5" />
+                      {t(($) => $.create_issue.set_priority)}
+                    </DropdownMenuItem>
+                  )}
+                  {!showField.assignee && (
+                    <DropdownMenuItem onClick={() => setFieldPickerOpen("assignee")}>
+                      <CircleUser className="h-3.5 w-3.5" />
+                      {t(($) => $.create_issue.set_assignee)}
+                    </DropdownMenuItem>
+                  )}
+                  {!showField.labels && (
+                    <DropdownMenuItem onClick={() => setFieldPickerOpen("labels")}>
+                      <Tag className="h-3.5 w-3.5" />
+                      {t(($) => $.create_issue.set_labels)}
+                    </DropdownMenuItem>
+                  )}
+                  {!showField.project && (
+                    <DropdownMenuItem onClick={() => setFieldPickerOpen("project")}>
+                      <FolderKanban className="h-3.5 w-3.5" />
+                      {t(($) => $.create_issue.set_project)}
+                    </DropdownMenuItem>
+                  )}
+                  {!showField.due_date && (
                     <DropdownMenuItem onClick={() => setDueDatePickerOpen(true)}>
                       <CalendarDays className="h-3.5 w-3.5" />
                       {t(($) => $.create_issue.set_due_date)}
                     </DropdownMenuItem>
                   )}
-                  {!startDate && (
+                  {!showField.start_date && (
                     <DropdownMenuItem onClick={() => setStartDatePickerOpen(true)}>
                       <CalendarClock className="h-3.5 w-3.5" />
                       {t(($) => $.create_issue.set_start_date)}
@@ -962,6 +1056,11 @@ export function ManualCreatePanel({
                       </DropdownMenuSubContent>
                     </DropdownMenuSub>
                   )}
+                  <DropdownMenuSeparator />
+                  <DropdownMenuItem onClick={openFieldSettings}>
+                    <Settings2 className="h-3.5 w-3.5" />
+                    {t(($) => $.create_issue.customize_fields)}
+                  </DropdownMenuItem>
                   {parentIssueId && parentIssue && (
                     <>
                       <DropdownMenuSeparator />

--- a/packages/views/modals/quick-create-issue.test.tsx
+++ b/packages/views/modals/quick-create-issue.test.tsx
@@ -6,13 +6,14 @@ import userEvent from "@testing-library/user-event";
 const mockQuickCreateIssue = vi.hoisted(() => vi.fn());
 const mockSetLastActor = vi.hoisted(() => vi.fn());
 const mockSetLastProjectId = vi.hoisted(() => vi.fn());
-const mockSetVisibleFields = vi.hoisted(() => vi.fn());
+const mockSetQuickCreateFieldVisible = vi.hoisted(() => vi.fn());
 const mockSetPrompt = vi.hoisted(() => vi.fn());
 const mockClearPrompt = vi.hoisted(() => vi.fn());
 const mockSetKeepOpen = vi.hoisted(() => vi.fn());
 const mockSetLastMode = vi.hoisted(() => vi.fn());
 const mockToastSuccess = vi.hoisted(() => vi.fn());
 const mockUploadWithToast = vi.hoisted(() => vi.fn());
+const mockNavigationPush = vi.hoisted(() => vi.fn());
 
 const mockQuickCreateStore = {
   lastActorType: null as "agent" | "squad" | null,
@@ -20,13 +21,16 @@ const mockQuickCreateStore = {
   setLastActor: mockSetLastActor,
   lastProjectId: null as string | null,
   setLastProjectId: mockSetLastProjectId,
-  visibleFields: ["project"] as Array<"project" | "priority" | "due_date">,
-  setVisibleFields: mockSetVisibleFields,
   prompt: "Persisted draft prompt",
   setPrompt: mockSetPrompt,
   clearPrompt: mockClearPrompt,
   keepOpen: false,
   setKeepOpen: mockSetKeepOpen,
+};
+
+const mockCreateSettingsStore = {
+  quickCreateFields: ["project"] as Array<"project" | "priority" | "due_date">,
+  setQuickCreateFieldVisible: mockSetQuickCreateFieldVisible,
 };
 
 // Per-test override for the projects query, so tests can swap between
@@ -83,6 +87,13 @@ vi.mock("@multica/core/hooks", () => ({
 
 vi.mock("@multica/core/paths", () => ({
   useCurrentWorkspace: () => ({ name: "Test Workspace" }),
+  useWorkspacePaths: () => ({
+    settings: () => "/ws-test/settings",
+  }),
+}));
+
+vi.mock("../navigation", () => ({
+  useNavigation: () => ({ push: mockNavigationPush }),
 }));
 
 vi.mock("@multica/core/workspace/queries", () => ({
@@ -100,6 +111,12 @@ vi.mock("@multica/core/projects/queries", () => ({
 vi.mock("@multica/core/issues/stores/quick-create-store", () => ({
   useQuickCreateStore: (selector?: (state: typeof mockQuickCreateStore) => unknown) =>
     (selector ? selector(mockQuickCreateStore) : mockQuickCreateStore),
+}));
+
+vi.mock("@multica/core/issues/stores/issue-create-settings-store", () => ({
+  useIssueCreateSettingsStore: (
+    selector?: (state: typeof mockCreateSettingsStore) => unknown,
+  ) => (selector ? selector(mockCreateSettingsStore) : mockCreateSettingsStore),
 }));
 
 vi.mock("@multica/core/issues/stores/create-mode-store", () => ({
@@ -350,7 +367,7 @@ describe("AgentCreatePanel", () => {
     mockQuickCreateStore.lastActorType = null;
     mockQuickCreateStore.lastActorId = null;
     mockQuickCreateStore.lastProjectId = null;
-    mockQuickCreateStore.visibleFields = ["project"];
+    mockCreateSettingsStore.quickCreateFields = ["project"];
     mockQuickCreateStore.prompt = "Persisted draft prompt";
     mockQuickCreateStore.keepOpen = false;
     mockProjectsQuery.data = [];
@@ -377,11 +394,6 @@ describe("AgentCreatePanel", () => {
     mockSetKeepOpen.mockImplementation((value: boolean) => {
       mockQuickCreateStore.keepOpen = value;
     });
-    mockSetVisibleFields.mockImplementation(
-      (fields: Array<"project" | "priority" | "due_date">) => {
-        mockQuickCreateStore.visibleFields = fields;
-      },
-    );
   });
 
   it("loads the persisted prompt draft when no transient prompt is provided", () => {
@@ -447,16 +459,31 @@ describe("AgentCreatePanel", () => {
     });
   });
 
-  it("lets users choose which quick-create fields stay exposed", async () => {
+  it("routes Customize fields to Settings → Issue, keeping the typed prompt", async () => {
     const user = userEvent.setup();
+    const onClose = vi.fn();
+
+    renderPanel({ onClose, isExpanded: false, setIsExpanded: vi.fn() });
+
+    const editor = screen.getByPlaceholderText(
+      'Tell the agent what to do, e.g. "let Bohan fix the inbox loading slowness in the Web project"',
+    );
+    fireEvent.change(editor, { target: { value: "Half-typed request" } });
+    await user.click(screen.getByRole("button", { name: "Customize fields..." }));
+
+    expect(mockSetPrompt).toHaveBeenLastCalledWith("Half-typed request");
+    expect(onClose).toHaveBeenCalled();
+    expect(mockNavigationPush).toHaveBeenCalledWith("/ws-test/settings?tab=issue");
+  });
+
+  it("respects fields enabled in Settings → Issue by rendering them inline", () => {
+    mockCreateSettingsStore.quickCreateFields = ["project", "priority", "due_date"];
 
     renderPanel({ onClose: vi.fn(), isExpanded: false, setIsExpanded: vi.fn() });
 
-    await user.click(screen.getByRole("button", { name: "Customize fields..." }));
-    expect(screen.getByText("Quick create fields")).toBeInTheDocument();
-    await user.click(screen.getAllByRole("checkbox")[1]!);
-
-    expect(mockSetVisibleFields).toHaveBeenCalledWith(["project", "priority"]);
+    expect(screen.getByTestId("project-picker")).toBeInTheDocument();
+    expect(screen.getByTestId("priority-picker")).toBeInTheDocument();
+    expect(screen.getByTestId("due-date-picker")).toBeInTheDocument();
   });
 
   it("submits seeded priority and due date as authoritative quick-create fields", async () => {

--- a/packages/views/modals/quick-create-issue.tsx
+++ b/packages/views/modals/quick-create-issue.tsx
@@ -2,7 +2,6 @@
 
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
-  ArrowLeft,
   ArrowLeftRight,
   CalendarDays,
   Check,
@@ -16,7 +15,6 @@ import {
 } from "lucide-react";
 import { useQuery } from "@tanstack/react-query";
 import { toast } from "sonner";
-import { cn } from "@multica/ui/lib/utils";
 import { DialogTitle } from "@multica/ui/components/ui/dialog";
 import {
   DropdownMenu,
@@ -29,14 +27,18 @@ import { Button } from "@multica/ui/components/ui/button";
 import { Switch } from "@multica/ui/components/ui/switch";
 import { api, ApiError } from "@multica/core/api";
 import { useWorkspaceId } from "@multica/core/hooks";
-import { useCurrentWorkspace } from "@multica/core/paths";
+import { useCurrentWorkspace, useWorkspacePaths } from "@multica/core/paths";
+import { useNavigation } from "../navigation";
 import { agentListOptions, squadListOptions } from "@multica/core/workspace/queries";
 import { projectListOptions } from "@multica/core/projects/queries";
 import {
   useQuickCreateStore,
   type QuickCreateActorType,
-  type QuickCreateField,
 } from "@multica/core/issues/stores/quick-create-store";
+import {
+  useIssueCreateSettingsStore,
+  type QuickCreateField,
+} from "@multica/core/issues/stores/issue-create-settings-store";
 import { useIssueDraftStore } from "@multica/core/issues/stores/draft-store";
 import { useCreateModeStore } from "@multica/core/issues/stores/create-mode-store";
 import {
@@ -114,6 +116,8 @@ export function AgentCreatePanel({
   const { t } = useT("modals");
   const sendShortcut = useShortcut("send");
   const workspaceName = useCurrentWorkspace()?.name;
+  const workspacePaths = useWorkspacePaths();
+  const navigation = useNavigation();
   const wsId = useWorkspaceId();
   const userId = useAuthStore((s) => s.user?.id);
   const { data: members = [] } = useQuery(memberListOptions(wsId));
@@ -159,8 +163,7 @@ export function AgentCreatePanel({
   const setLastActor = useQuickCreateStore((s) => s.setLastActor);
   const lastProjectId = useQuickCreateStore((s) => s.lastProjectId);
   const setLastProjectId = useQuickCreateStore((s) => s.setLastProjectId);
-  const visibleFields = useQuickCreateStore((s) => s.visibleFields);
-  const setVisibleFields = useQuickCreateStore((s) => s.setVisibleFields);
+  const visibleFields = useIssueCreateSettingsStore((s) => s.quickCreateFields);
   const promptDraft = useQuickCreateStore((s) => s.prompt);
   const setPrompt = useQuickCreateStore((s) => s.setPrompt);
   const clearPrompt = useQuickCreateStore((s) => s.clearPrompt);
@@ -240,7 +243,6 @@ export function AgentCreatePanel({
     (data?.due_date as string | undefined) ?? null,
   );
   const [fieldPickerOpen, setFieldPickerOpen] = useState<QuickCreateField | null>(null);
-  const [settingsOpen, setSettingsOpen] = useState(false);
 
   // Parent-issue context — seeded by `openCreateSubIssue` when the modal is
   // opened from the "Add sub issue" entry on an existing issue. We carry it
@@ -459,18 +461,13 @@ export function AgentCreatePanel({
     onSwitchMode?.(Object.keys(carry).length > 0 ? carry : null);
   };
 
-  const toggleVisibleField = (field: QuickCreateField, visible: boolean) => {
-    setVisibleFields(
-      visible
-        ? [...visibleFields.filter((item) => item !== field), field]
-        : visibleFields.filter((item) => item !== field),
-    );
-  };
-
+  // Field visibility lives in Settings → Issue. Persist the prompt draft
+  // before leaving so what the user typed survives the round-trip, then
+  // close — the dialog would otherwise linger over the settings page.
   const openFieldSettings = () => {
     setPrompt(editorRef.current?.getMarkdown() ?? "");
-    setFieldPickerOpen(null);
-    setSettingsOpen(true);
+    onClose();
+    navigation.push(`${workspacePaths.settings()}?tab=issue`);
   };
 
   return (
@@ -479,22 +476,11 @@ export function AgentCreatePanel({
 
         {/* Header */}
         <div className="flex items-center justify-between px-5 pt-3 pb-2 shrink-0">
-          {settingsOpen ? (
-            <button
-              type="button"
-              onClick={() => setSettingsOpen(false)}
-              className="flex items-center gap-1.5 rounded-sm px-1 py-0.5 text-xs font-medium hover:bg-accent/60"
-            >
-              <ArrowLeft className="size-3.5" />
-              {t(($) => $.create_issue.agent.field_settings_title)}
-            </button>
-          ) : (
-            <div className="flex items-center gap-1.5 text-xs">
-              <span className="text-muted-foreground">{workspaceName}</span>
-              <ChevronRight className="size-3 text-muted-foreground/50" />
-              <span className="font-medium">{t(($) => $.create_issue.agent_breadcrumb)}</span>
-            </div>
-          )}
+          <div className="flex items-center gap-1.5 text-xs">
+            <span className="text-muted-foreground">{workspaceName}</span>
+            <ChevronRight className="size-3 text-muted-foreground/50" />
+            <span className="font-medium">{t(($) => $.create_issue.agent_breadcrumb)}</span>
+          </div>
           {/* Native `title` instead of Base UI Tooltip — Tooltip opens on
               keyboard focus, and the dialog's focus trap briefly lands focus
               on the first focusable element on mount, causing the tooltip to
@@ -520,47 +506,6 @@ export function AgentCreatePanel({
             </button>
           </div>
         </div>
-
-        {settingsOpen ? (
-          <div className="flex min-h-0 flex-1 flex-col">
-            <div className="flex-1 overflow-y-auto px-5 py-3">
-              <p className="mb-3 text-xs text-muted-foreground">
-                {t(($) => $.create_issue.agent.field_settings_description)}
-              </p>
-              <div className="overflow-hidden rounded-lg border">
-                {([
-                  ["project", <FolderKanban key="project" className="size-4 text-muted-foreground" />],
-                  ["priority", <PriorityIcon key="priority" priority="none" className="size-4" />],
-                  ["due_date", <CalendarDays key="due-date" className="size-4 text-muted-foreground" />],
-                ] as const).map(([field, icon], index) => (
-                  <label
-                    key={field}
-                    className={cn(
-                      "flex cursor-pointer items-center gap-3 px-3 py-2.5 text-sm",
-                      index > 0 && "border-t",
-                    )}
-                  >
-                    {icon}
-                    <span className="flex-1">
-                      {t(($) => $.create_issue.agent.fields[field])}
-                    </span>
-                    <Switch
-                      size="sm"
-                      checked={visibleFields.includes(field)}
-                      onCheckedChange={(checked) => toggleVisibleField(field, checked)}
-                    />
-                  </label>
-                ))}
-              </div>
-            </div>
-            <div className="flex justify-end border-t px-4 py-3">
-              <Button size="sm" onClick={() => setSettingsOpen(false)}>
-                {t(($) => $.create_issue.agent.field_settings_done)}
-              </Button>
-            </div>
-          </div>
-        ) : (
-          <>
 
         {/* Actor picker — agents and squads in one searchable list. Squads
             route to their leader agent on the backend; the leader runs the
@@ -794,8 +739,6 @@ export function AgentCreatePanel({
             </Button>
           </div>
         </div>
-          </>
-        )}
     </>
   );
 }

--- a/packages/views/settings/components/issue-tab.test.tsx
+++ b/packages/views/settings/components/issue-tab.test.tsx
@@ -1,0 +1,76 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { cleanup, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import {
+  DEFAULT_MANUAL_CREATE_FIELDS,
+  DEFAULT_QUICK_CREATE_FIELDS,
+  useIssueCreateSettingsStore,
+} from "@multica/core/issues/stores/issue-create-settings-store";
+import { renderWithI18n } from "../../test/i18n";
+import { IssueTab } from "./issue-tab";
+
+function resetStore() {
+  useIssueCreateSettingsStore.setState({
+    quickCreateFields: DEFAULT_QUICK_CREATE_FIELDS,
+    manualCreateFields: DEFAULT_MANUAL_CREATE_FIELDS,
+  });
+}
+
+describe("IssueTab", () => {
+  beforeEach(resetStore);
+
+  afterEach(() => {
+    cleanup();
+    resetStore();
+  });
+
+  it("renders a switch per field with the persisted selection", () => {
+    renderWithI18n(<IssueTab />);
+
+    // 3 quick create fields + 7 manual create fields.
+    const switches = screen.getAllByRole("switch");
+    expect(switches).toHaveLength(10);
+
+    // Quick create defaults to project only.
+    const [quickProject, quickPriority, quickDueDate] = switches;
+    expect(quickProject).toBeChecked();
+    expect(quickPriority).not.toBeChecked();
+    expect(quickDueDate).not.toBeChecked();
+
+    // Manual create defaults to the classic toolbar; dates start hidden.
+    const manual = switches.slice(3);
+    for (const s of manual.slice(0, 5)) expect(s).toBeChecked();
+    expect(manual[5]).not.toBeChecked();
+    expect(manual[6]).not.toBeChecked();
+  });
+
+  it("persists enabling a quick create field", async () => {
+    const user = userEvent.setup();
+    renderWithI18n(<IssueTab />);
+
+    const [, quickPriority] = screen.getAllByRole("switch");
+    await user.click(quickPriority!);
+
+    expect(useIssueCreateSettingsStore.getState().quickCreateFields).toEqual([
+      "project",
+      "priority",
+    ]);
+  });
+
+  it("persists hiding a manual create field without touching quick create", async () => {
+    const user = userEvent.setup();
+    renderWithI18n(<IssueTab />);
+
+    // Manual section starts at index 3; labels is its 4th row (index 6 overall).
+    const manualLabels = screen.getAllByRole("switch")[6];
+    await user.click(manualLabels!);
+
+    expect(useIssueCreateSettingsStore.getState().manualCreateFields).toEqual([
+      "status",
+      "priority",
+      "assignee",
+      "project",
+    ]);
+    expect(useIssueCreateSettingsStore.getState().quickCreateFields).toEqual(["project"]);
+  });
+});

--- a/packages/views/settings/components/issue-tab.tsx
+++ b/packages/views/settings/components/issue-tab.tsx
@@ -1,0 +1,82 @@
+"use client";
+
+import { Switch } from "@multica/ui/components/ui/switch";
+import {
+  MANUAL_CREATE_FIELDS,
+  QUICK_CREATE_FIELDS,
+  useIssueCreateSettingsStore,
+} from "@multica/core/issues/stores/issue-create-settings-store";
+import { toast } from "sonner";
+import { useT } from "../../i18n";
+import {
+  SettingsCard,
+  SettingsRow,
+  SettingsSection,
+  SettingsTab,
+} from "./settings-layout";
+
+/**
+ * Issue settings — its own tab under "My Account". One group per create-issue
+ * mode (agent quick create / manual create), each a switch list of the fields
+ * that mode keeps on its dialog toolbar. Persisted client-side per workspace;
+ * a field toggled off stays reachable from the dialog's ⋯ overflow and
+ * re-surfaces automatically while it holds a value, so hiding is never
+ * destructive.
+ */
+export function IssueTab() {
+  const { t } = useT("settings");
+  const quickFields = useIssueCreateSettingsStore((s) => s.quickCreateFields);
+  const setQuickVisible = useIssueCreateSettingsStore((s) => s.setQuickCreateFieldVisible);
+  const manualFields = useIssueCreateSettingsStore((s) => s.manualCreateFields);
+  const setManualVisible = useIssueCreateSettingsStore((s) => s.setManualCreateFieldVisible);
+
+  const savedToast = () =>
+    toast.success(t(($) => $.auto_save.toast_saved), { id: "settings-auto-save" });
+
+  return (
+    <SettingsTab
+      title={t(($) => $.page.tabs.issue)}
+      description={t(($) => $.issue.description)}
+    >
+      <SettingsSection
+        title={t(($) => $.issue.quick_create_title)}
+        description={t(($) => $.issue.quick_create_description)}
+      >
+        <SettingsCard>
+          {QUICK_CREATE_FIELDS.map((field) => (
+            <SettingsRow key={field} label={t(($) => $.issue.fields[field])}>
+              <Switch
+                checked={quickFields.includes(field)}
+                onCheckedChange={(checked) => {
+                  setQuickVisible(field, checked);
+                  savedToast();
+                }}
+                aria-label={t(($) => $.issue.fields[field])}
+              />
+            </SettingsRow>
+          ))}
+        </SettingsCard>
+      </SettingsSection>
+
+      <SettingsSection
+        title={t(($) => $.issue.manual_create_title)}
+        description={t(($) => $.issue.manual_create_description)}
+      >
+        <SettingsCard>
+          {MANUAL_CREATE_FIELDS.map((field) => (
+            <SettingsRow key={field} label={t(($) => $.issue.fields[field])}>
+              <Switch
+                checked={manualFields.includes(field)}
+                onCheckedChange={(checked) => {
+                  setManualVisible(field, checked);
+                  savedToast();
+                }}
+                aria-label={t(($) => $.issue.fields[field])}
+              />
+            </SettingsRow>
+          ))}
+        </SettingsCard>
+      </SettingsSection>
+    </SettingsTab>
+  );
+}

--- a/packages/views/settings/components/settings-page.tsx
+++ b/packages/views/settings/components/settings-page.tsx
@@ -14,6 +14,7 @@ import {
   MessageCircle,
   Tags,
   Keyboard,
+  ListTodo,
 } from "lucide-react";
 import { GitHubMark } from "./github-mark";
 import { Tabs, TabsList, TabsTrigger, TabsContent } from "@multica/ui/components/ui/tabs";
@@ -23,6 +24,7 @@ import { useNavigation } from "../../navigation";
 import { AccountTab } from "./account-tab";
 import { PreferencesTab } from "./preferences-tab";
 import { ChatTab } from "./chat-tab";
+import { IssueTab } from "./issue-tab";
 import { TokensTab } from "./tokens-tab";
 import { WorkspaceTab } from "./workspace-tab";
 import { MembersTab } from "./members-tab";
@@ -36,11 +38,12 @@ import { PropertiesTab } from "./properties-tab";
 import { KeyboardShortcutsTab } from "./keyboard-shortcuts-tab";
 import { useT } from "../../i18n";
 
-const ACCOUNT_TAB_KEYS = ["profile", "preferences", "shortcuts", "chat", "notifications", "tokens"] as const;
+const ACCOUNT_TAB_KEYS = ["profile", "preferences", "shortcuts", "issue", "chat", "notifications", "tokens"] as const;
 const ACCOUNT_TAB_ICONS = {
   profile: User,
   preferences: SlidersHorizontal,
   shortcuts: Keyboard,
+  issue: ListTodo,
   chat: MessageCircle,
   notifications: Bell,
   tokens: Key,
@@ -208,6 +211,7 @@ export function SettingsPage({ extraAccountTabs }: SettingsPageProps = {}) {
           <TabsContent value="profile"><AccountTab /></TabsContent>
           <TabsContent value="preferences"><PreferencesTab /></TabsContent>
           <TabsContent value="shortcuts"><KeyboardShortcutsTab /></TabsContent>
+          <TabsContent value="issue"><IssueTab /></TabsContent>
           <TabsContent value="chat"><ChatTab /></TabsContent>
           <TabsContent value="notifications"><NotificationsTab /></TabsContent>
           <TabsContent value="tokens"><TokensTab /></TabsContent>


### PR DESCRIPTION
Follow-up to #5532 / MUL-4873: the quick-create field configuration was implemented as a settings sub-view inside the quick create popover; the requested behavior is a dedicated **Issue** tab on the Settings page holding the create-dialog configuration, including manual create.

## Changes

**Settings → Issue tab (new, My Account group)**
- Two groups: **Create with agent** (Project / Priority / Due date) and **Create manually** (Status / Priority / Assignee / Labels / Project / Due date / Start date), each a switch list controlling which fields that dialog keeps on its toolbar.
- Backed by a new per-workspace persisted `issue-create-settings-store` in `@multica/core`; quick-create's `visibleFields` moved there from `quick-create-store` (feature shipped hours ago, no migration concerns).

**Quick create dialog**
- The in-popover field-settings view is removed; **Customize fields…** in the ⋯ menu now persists the typed prompt, closes the dialog, and routes to `settings?tab=issue`.

**Manual create dialog**
- Toolbar fields render per the Settings selection. A hidden field stays reachable from the ⋯ menu (`Set status/priority/assignee/labels/project/due date/start date…`) and always re-surfaces while it holds a non-default value, so a draft or mode-switch carry is never invisible.
- ⋯ menu gains **Customize fields…** routing to the same tab.

i18n: en / zh-Hans / ja / ko, following the conventions doc (issue stays English; existing field-name glossary reused). Dead `field_settings_*` modal strings removed.

## Verification
- `packages/core` + `packages/views` typecheck, lint (0 errors; only pre-existing warnings in untouched files).
- Focused suites: 4 store tests, 3 issue-tab tests, 15 quick-create tests, 26 create-issue tests — all passing. Full core/views suites: only pre-existing localStorage-environment failures also present on clean main (`projects/mutations`, `realtime`, `sidebar-resize`).
- Real before/after screenshots from the local web app attached on MUL-4873.
