### PR TITLE
MUL-4903 fix(agent): harden Cursor terminal failures

### DIFF
--- a/server/pkg/agent/codex.go
+++ b/server/pkg/agent/codex.go
@@ -19,8 +19,6 @@ import (
 	"sync/atomic"
 	"syscall"
 	"time"
-
-	"github.com/multica-ai/multica/server/pkg/redact"
 )
 
 // codexBlockedArgs are flags hardcoded by the daemon that must not be
@@ -65,23 +63,8 @@ var activeCodexLaunches atomic.Int64
 var maxActiveCodexLaunchesObserved atomic.Int64
 var codexCleanupConfirmationOverride atomic.Int32
 
-var (
-	codexAuthorizationHeaderRe = regexp.MustCompile(`(?im)(authorization\s*:\s*)[^\r\n]+`)
-	codexJSONSecretRe          = regexp.MustCompile(`(?i)("(?:token|auth|authorization|api[_-]?key|secret|password)"\s*:\s*)"(?:\\.|[^"\\])*"`)
-	codexDiagnosticSecretRe    = regexp.MustCompile(`(?i)(authorization|auth|api[_-]?key|token|secret|password)(\s*[:=]\s*)([^\s,;]+)`)
-)
-
 func sanitizeCodexDiagnostic(value string) string {
-	value = strings.Map(func(r rune) rune {
-		if r < 0x20 && r != '\n' && r != '\t' {
-			return -1
-		}
-		return r
-	}, value)
-	value = codexAuthorizationHeaderRe.ReplaceAllString(value, `$1[REDACTED]`)
-	value = codexJSONSecretRe.ReplaceAllString(value, `$1"[REDACTED]"`)
-	value = codexDiagnosticSecretRe.ReplaceAllString(value, `$1$2[REDACTED]`)
-	return redact.Text(value)
+	return sanitizeAgentDiagnostic(value)
 }
 
 func codexProcessExitStatus(state *os.ProcessState) any {

--- a/server/pkg/agent/codex_test.go
+++ b/server/pkg/agent/codex_test.go
@@ -15,6 +15,7 @@ import (
 	"sync"
 	"testing"
 	"time"
+	"unicode/utf8"
 )
 
 func newTestCodexClient(t *testing.T) (*codexClient, *fakeStdin, []Message) {
@@ -1538,6 +1539,56 @@ func TestStderrTailEmptyWhenNothingWritten(t *testing.T) {
 	s := newStderrTail(&sink, 16)
 	if tail := s.Tail(); tail != "" {
 		t.Errorf("expected empty tail, got %q", tail)
+	}
+}
+
+func TestStderrTailReturnsValidUTF8(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		input []byte
+		max   int
+		want  string
+	}{
+		{
+			name:  "leading rune split by tail bound",
+			input: []byte("aa界bc"),
+			max:   4,
+			want:  "bc",
+		},
+		{
+			name:  "trailing incomplete rune",
+			input: append([]byte("ok"), []byte("界")[:2]...),
+			max:   16,
+			want:  "ok",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			var sink bytes.Buffer
+			s := newStderrTail(&sink, tt.max)
+			if _, err := s.Write(tt.input); err != nil {
+				t.Fatalf("write: %v", err)
+			}
+
+			if !bytes.Equal(sink.Bytes(), tt.input) {
+				t.Errorf("inner sink: got %q, want raw bytes %q", sink.Bytes(), tt.input)
+			}
+			got := s.Tail()
+			if !utf8.ValidString(got) {
+				t.Errorf("tail is not valid UTF-8: %q", got)
+			}
+			if len(got) > tt.max {
+				t.Errorf("tail exceeds bound: got %d bytes (%q), max %d", len(got), got, tt.max)
+			}
+			if got != tt.want {
+				t.Errorf("tail: got %q, want %q", got, tt.want)
+			}
+		})
 	}
 }
 

--- a/server/pkg/agent/cursor.go
+++ b/server/pkg/agent/cursor.go
@@ -50,7 +50,8 @@ func (b *cursorBackend) Execute(ctx context.Context, prompt string, opts ExecOpt
 		cancel()
 		return nil, fmt.Errorf("cursor stdout pipe: %w", err)
 	}
-	cmd.Stderr = newLogWriter(b.cfg.Logger, "[cursor:stderr] ")
+	stderrBuf := newStderrTail(newLogWriter(b.cfg.Logger, "[cursor:stderr] "), agentStderrTailBytes)
+	cmd.Stderr = stderrBuf
 
 	if err := cmd.Start(); err != nil {
 		cancel()
@@ -79,7 +80,15 @@ func (b *cursorBackend) Execute(ctx context.Context, prompt string, opts ExecOpt
 		var sessionID string
 		finalStatus := "completed"
 		var finalError string
+		var protocolError string
 		resultSeen := false
+		resultIsError := false
+		resultBytes := 0
+		eventCount := 0
+		invalidEventCount := 0
+		assistantEventCount := 0
+		toolUseCount := 0
+		lastEventType := "none"
 		// stepUsage accumulates per-step token counts from "step_finish" events.
 		// resultUsage holds authoritative session totals from "result" events.
 		// If the result event includes usage, we use resultUsage exclusively;
@@ -100,8 +109,11 @@ func (b *cursorBackend) Execute(ctx context.Context, prompt string, opts ExecOpt
 
 			var evt cursorStreamEvent
 			if err := json.Unmarshal([]byte(line), &evt); err != nil {
+				invalidEventCount++
 				continue
 			}
+			eventCount++
+			lastEventType = observedCursorEventType(evt.Type)
 
 			if sid := evt.readSessionID(); sid != "" {
 				sessionID = sid
@@ -115,14 +127,17 @@ func (b *cursorBackend) Execute(ctx context.Context, prompt string, opts ExecOpt
 				if evt.Subtype == "error" {
 					errMsg := cursorErrorText(&evt)
 					if errMsg != "" {
+						protocolError = errMsg
 						trySend(msgCh, Message{Type: MessageError, Content: errMsg})
 					}
 				}
 
 			case "assistant":
+				assistantEventCount++
 				b.handleCursorAssistant(&evt, msgCh, &output)
 
 			case "tool_use":
+				toolUseCount++
 				var params map[string]any
 				if evt.Parameters != nil {
 					_ = json.Unmarshal(evt.Parameters, &params)
@@ -146,7 +161,9 @@ func (b *cursorBackend) Execute(ctx context.Context, prompt string, opts ExecOpt
 				if evt.IsError || evt.Subtype == "error" {
 					finalStatus = "failed"
 					finalError = cursorErrorText(&evt)
+					resultIsError = true
 				}
+				resultBytes = len(evt.ResultText)
 				if evt.ResultText != "" && output.Len() == 0 {
 					output.WriteString(evt.ResultText)
 					trySend(msgCh, Message{Type: MessageText, Content: evt.ResultText})
@@ -163,7 +180,7 @@ func (b *cursorBackend) Execute(ctx context.Context, prompt string, opts ExecOpt
 			case "error":
 				errMsg := cursorErrorText(&evt)
 				if errMsg != "" {
-					finalError = errMsg
+					protocolError = errMsg
 				}
 				trySend(msgCh, Message{Type: MessageError, Content: errMsg})
 
@@ -190,6 +207,13 @@ func (b *cursorBackend) Execute(ctx context.Context, prompt string, opts ExecOpt
 				}
 			}
 		}
+		scanErr := scanner.Err()
+		if scanErr != nil {
+			// Scanner stopped consuming stdout. Close the pipe before Wait so a
+			// child writing a malformed or oversized event cannot deadlock on a
+			// full OS pipe; the scanner error remains the primary failure.
+			_ = stdout.Close()
+		}
 
 		// Use result usage if available (session totals); otherwise fall back
 		// to accumulated step_finish usage.
@@ -200,22 +224,79 @@ func (b *cursorBackend) Execute(ctx context.Context, prompt string, opts ExecOpt
 		exitErr := cmd.Wait()
 		duration := time.Since(startTime)
 
-		if runCtx.Err() == context.DeadlineExceeded {
-			finalStatus = "timeout"
-			finalError = fmt.Sprintf("cursor-agent timed out after %s", timeout)
-		} else if runCtx.Err() == context.Canceled && !resultSeen {
-			finalStatus = "aborted"
-			finalError = "execution cancelled"
-		} else if exitErr != nil && finalStatus == "completed" && !resultSeen {
-			finalStatus = "failed"
-			finalError = fmt.Sprintf("cursor-agent exited with error: %v", exitErr)
+		if resultSeen {
+			// A parsed result is the protocol boundary. Ignore the cancellation and
+			// exit error caused by stopping a Cursor worker that lingers afterward.
+			if finalStatus == "failed" && finalError == "" {
+				finalError = "cursor-agent returned an error result without details"
+			}
+		} else {
+			switch {
+			case runCtx.Err() == context.DeadlineExceeded:
+				finalStatus = "timeout"
+				finalError = fmt.Sprintf("cursor-agent timed out after %s", timeout)
+			case runCtx.Err() == context.Canceled:
+				finalStatus = "aborted"
+				finalError = "execution cancelled"
+			case scanErr != nil:
+				finalStatus = "failed"
+				finalError = fmt.Sprintf("cursor-agent stdout read error: %v", scanErr)
+			case protocolError != "":
+				finalStatus = "failed"
+				finalError = protocolError
+			case exitErr != nil:
+				finalStatus = "failed"
+				finalError = fmt.Sprintf("cursor-agent exited with error: %v", exitErr)
+			default:
+				finalStatus = "failed"
+				finalError = "cursor-agent stream ended without terminal result"
+			}
 		}
+
+		if finalError != "" {
+			finalError = sanitizeAgentDiagnostic(finalError)
+		}
+		if finalStatus == "failed" && !resultSeen {
+			finalError = cursorFailureDiagnostic(
+				finalError,
+				exitErr,
+				scanErr,
+				eventCount,
+				invalidEventCount,
+				lastEventType,
+			)
+			finalError = withAgentStderr(finalError, "cursor", sanitizeAgentDiagnostic(stderrBuf.Tail()))
+		}
+
+		logStreamProtocolObservation(b.cfg.Logger, streamProtocolObservation{
+			provider:            "cursor-agent",
+			cliVersion:          b.cfg.CLIVersion,
+			model:               opts.Model,
+			exitCode:            streamProcessExitCode(exitErr),
+			eventCount:          eventCount,
+			invalidEventCount:   invalidEventCount,
+			assistantEventCount: assistantEventCount,
+			toolUseCount:        toolUseCount,
+			sawResult:           resultSeen,
+			resultIsError:       resultIsError,
+			resultBytes:         resultBytes,
+			lastAssistantBytes:  output.Len(),
+			scannerError:        scanErr != nil && !resultSeen,
+			lastEventType:       lastEventType,
+		})
 
 		b.cfg.Logger.Info("cursor-agent finished", "pid", cmd.Process.Pid, "status", finalStatus, "duration", duration.Round(time.Millisecond).String())
 
+		finalOutput := output.String()
+		if finalStatus != "completed" {
+			// A partial transcript is not a final answer. Keep it in Messages for
+			// observability, but never expose it as Result.Output on failure.
+			finalOutput = ""
+		}
+
 		resCh <- Result{
 			Status:     finalStatus,
-			Output:     output.String(),
+			Output:     finalOutput,
 			Error:      finalError,
 			DurationMs: duration.Milliseconds(),
 			SessionID:  sessionID,
@@ -224,6 +305,41 @@ func (b *cursorBackend) Execute(ctx context.Context, prompt string, opts ExecOpt
 	}()
 
 	return &Session{Messages: msgCh, Result: resCh}, nil
+}
+
+const cursorIncompleteFinalizationWarning = "actions completed before finalization may already have taken effect"
+
+func cursorFailureDiagnostic(message string, exitErr, scanErr error, eventCount, invalidEventCount int, lastEventType string) string {
+	return fmt.Sprintf(
+		"%s (result_seen=false, exit_code=%d, scanner_error=%t, event_count=%d, invalid_event_count=%d, last_event_type=%s); %s",
+		message,
+		streamProcessExitCode(exitErr),
+		scanErr != nil,
+		eventCount,
+		invalidEventCount,
+		lastEventType,
+		cursorIncompleteFinalizationWarning,
+	)
+}
+
+// observedCursorEventType keeps protocol diagnostics bounded and content-free.
+// Event types are identifiers; arbitrary values are collapsed instead of being
+// copied into daemon logs or task errors.
+func observedCursorEventType(value string) string {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return "unknown"
+	}
+	if len(value) > 64 {
+		return "invalid"
+	}
+	for _, r := range value {
+		if (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || (r >= '0' && r <= '9') || r == '_' || r == '-' {
+			continue
+		}
+		return "invalid"
+	}
+	return value
 }
 
 func (b *cursorBackend) handleCursorAssistant(evt *cursorStreamEvent, ch chan<- Message, output *strings.Builder) {

--- a/server/pkg/agent/cursor_execute_unix_test.go
+++ b/server/pkg/agent/cursor_execute_unix_test.go
@@ -4,7 +4,9 @@ package agent
 
 import (
 	"log/slog"
+	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 )
@@ -91,11 +93,155 @@ sleep 10
 	if result.Error != "failed hard" {
 		t.Fatalf("error = %q, want failed hard", result.Error)
 	}
-	if result.Output != "failed hard" {
-		t.Fatalf("output = %q, want failed hard", result.Output)
+	if result.Output != "" {
+		t.Fatalf("output = %q, want empty failed output", result.Output)
 	}
 	if result.SessionID != "sess-terminal-error" {
 		t.Fatalf("session id = %q, want sess-terminal-error", result.SessionID)
+	}
+}
+
+func TestCursorExecuteReportsSanitizedStderrOnProcessFailure(t *testing.T) {
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		t.Fatalf("UserHomeDir: %v", err)
+	}
+
+	script := `#!/bin/sh
+dd if=/dev/zero bs=4096 count=1 2>/dev/null | tr '\000' x >&2
+printf '\nAuthorization: Bearer cursor-secret-token-value\npath=%s/private\n' "$HOME" >&2
+exit 1
+`
+	result := executeFakeCursor(t, script)
+
+	if result.Status != "failed" {
+		t.Fatalf("status = %q, want failed; error=%q", result.Status, result.Error)
+	}
+	for _, want := range []string{
+		"cursor-agent exited with error: exit status 1",
+		"result_seen=false",
+		"exit_code=1",
+		"cursor stderr:",
+		"Authorization: [REDACTED]",
+		"actions completed before finalization may already have taken effect",
+	} {
+		if !strings.Contains(result.Error, want) {
+			t.Errorf("error = %q, want substring %q", result.Error, want)
+		}
+	}
+	for _, secret := range []string{"cursor-secret-token-value", homeDir} {
+		if strings.Contains(result.Error, secret) {
+			t.Errorf("error leaked %q: %q", secret, result.Error)
+		}
+	}
+	if result.Output != "" {
+		t.Fatalf("output = %q, want empty failed output", result.Output)
+	}
+	if len(result.Error) > agentStderrTailBytes+1024 {
+		t.Fatalf("error length = %d, want bounded stderr diagnostic", len(result.Error))
+	}
+}
+
+func TestCursorExecuteReportsMalformedTerminalEvent(t *testing.T) {
+	script := `#!/bin/sh
+printf '%s\n' '{"type":"system","subtype":"init","session_id":"sess-malformed"}'
+printf '%s\n' '{"type":"result","subtype":"success","result":"truncated"'
+exit 1
+`
+	result := executeFakeCursor(t, script)
+
+	if result.Status != "failed" {
+		t.Fatalf("status = %q, want failed; error=%q", result.Status, result.Error)
+	}
+	for _, want := range []string{
+		"result_seen=false",
+		"invalid_event_count=1",
+		"last_event_type=system",
+	} {
+		if !strings.Contains(result.Error, want) {
+			t.Errorf("error = %q, want substring %q", result.Error, want)
+		}
+	}
+	if result.Output != "" {
+		t.Fatalf("output = %q, want empty failed output", result.Output)
+	}
+}
+
+func TestCursorExecuteReportsScannerOverflow(t *testing.T) {
+	script := `#!/bin/sh
+printf '%s\n' '{"type":"system","subtype":"init","session_id":"sess-overflow"}'
+dd if=/dev/zero bs=1048576 count=11 2>/dev/null | tr '\000' x
+printf '\n'
+`
+	result := executeFakeCursor(t, script)
+
+	if result.Status != "failed" {
+		t.Fatalf("status = %q, want failed; error=%q", result.Status, result.Error)
+	}
+	for _, want := range []string{
+		"cursor-agent stdout read error",
+		"token too long",
+		"result_seen=false",
+		"scanner_error=true",
+		"last_event_type=system",
+	} {
+		if !strings.Contains(result.Error, want) {
+			t.Errorf("error = %q, want substring %q", result.Error, want)
+		}
+	}
+	if result.Output != "" {
+		t.Fatalf("output = %q, want empty failed output", result.Output)
+	}
+}
+
+func TestCursorExecuteFailsOnCleanEOFWithoutResult(t *testing.T) {
+	script := `#!/bin/sh
+printf '%s\n' '{"type":"system","subtype":"init","session_id":"sess-no-result"}'
+printf '%s\n' '{"type":"assistant","message":{"content":[{"type":"text","text":"partial answer"}]}}'
+`
+	result := executeFakeCursor(t, script)
+
+	if result.Status != "failed" {
+		t.Fatalf("status = %q, want failed; error=%q", result.Status, result.Error)
+	}
+	for _, want := range []string{
+		"cursor-agent stream ended without terminal result",
+		"result_seen=false",
+		"exit_code=0",
+		"last_event_type=assistant",
+	} {
+		if !strings.Contains(result.Error, want) {
+			t.Errorf("error = %q, want substring %q", result.Error, want)
+		}
+	}
+	if result.Output != "" {
+		t.Fatalf("output = %q, want partial transcript suppressed", result.Output)
+	}
+}
+
+func TestCursorExecutePreservesStructuredStreamError(t *testing.T) {
+	script := `#!/bin/sh
+printf '%s\n' '{"type":"system","subtype":"init","session_id":"sess-stream-error"}'
+printf '%s\n' '{"type":"error","error":"provider rejected request"}'
+exit 1
+`
+	result := executeFakeCursor(t, script)
+
+	if result.Status != "failed" {
+		t.Fatalf("status = %q, want failed; error=%q", result.Status, result.Error)
+	}
+	for _, want := range []string{
+		"provider rejected request",
+		"result_seen=false",
+		"exit_code=1",
+		"last_event_type=error",
+	} {
+		if !strings.Contains(result.Error, want) {
+			t.Errorf("error = %q, want substring %q", result.Error, want)
+		}
+	}
+	if result.Output != "" {
+		t.Fatalf("output = %q, want empty failed output", result.Output)
 	}
 }
 

--- a/server/pkg/agent/cursor_test.go
+++ b/server/pkg/agent/cursor_test.go
@@ -157,6 +157,30 @@ func TestNormalizeCursorStreamLine(t *testing.T) {
 	}
 }
 
+func TestObservedCursorEventTypeIsBoundedAndContentFree(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		value string
+		want  string
+	}{
+		{name: "known type", value: "tool_result", want: "tool_result"},
+		{name: "trimmed", value: "  step-finish  ", want: "step-finish"},
+		{name: "empty", value: " ", want: "unknown"},
+		{name: "content-like", value: "result secret-value", want: "invalid"},
+		{name: "oversized", value: strings.Repeat("x", 65), want: "invalid"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := observedCursorEventType(tc.value); got != tc.want {
+				t.Fatalf("observedCursorEventType(%q) = %q, want %q", tc.value, got, tc.want)
+			}
+		})
+	}
+}
+
 func TestCursorHandleAssistantText(t *testing.T) {
 	t.Parallel()
 
@@ -255,10 +279,10 @@ func TestCursorUsageModelFallback(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name             string
-		evtModel         string
-		configuredModel  string
-		want             string
+		name            string
+		evtModel        string
+		configuredModel string
+		want            string
 	}{
 		{"event model wins", "gpt-5.3-codex", "composer-2.5", "gpt-5.3-codex"},
 		{"configured model fallback", "", "composer-2.5", "composer-2.5"},

--- a/server/pkg/agent/stderr_tail.go
+++ b/server/pkg/agent/stderr_tail.go
@@ -2,8 +2,11 @@ package agent
 
 import (
 	"io"
+	"regexp"
 	"strings"
 	"sync"
+
+	"github.com/multica-ai/multica/server/pkg/redact"
 )
 
 // agentStderrTailBytes bounds the stderr tail captured for inclusion in
@@ -12,6 +15,29 @@ import (
 // contain typical CLI error lines, small enough to stay sensible inside
 // a task-level Result.Error string.
 const agentStderrTailBytes = 2048
+
+var (
+	agentAuthorizationHeaderRe = regexp.MustCompile(`(?im)(authorization\s*:\s*)[^\r\n]+`)
+	agentJSONSecretRe          = regexp.MustCompile(`(?i)("(?:token|auth|authorization|api[_-]?key|secret|password)"\s*:\s*)"(?:\\.|[^"\\])*"`)
+	agentDiagnosticSecretRe    = regexp.MustCompile(`(?i)(authorization|auth|api[_-]?key|token|secret|password)(\s*[:=]\s*)([^\s,;]+)`)
+)
+
+// sanitizeAgentDiagnostic removes terminal control characters, common secret
+// shapes, and local home-directory details before a child-process diagnostic is
+// persisted in Result.Error. stderr is still forwarded to the local daemon log;
+// this helper protects the task row and user-visible failure comment.
+func sanitizeAgentDiagnostic(value string) string {
+	value = strings.Map(func(r rune) rune {
+		if r < 0x20 && r != '\n' && r != '\t' {
+			return -1
+		}
+		return r
+	}, value)
+	value = agentAuthorizationHeaderRe.ReplaceAllString(value, `$1[REDACTED]`)
+	value = agentJSONSecretRe.ReplaceAllString(value, `$1"[REDACTED]"`)
+	value = agentDiagnosticSecretRe.ReplaceAllString(value, `$1$2[REDACTED]`)
+	return redact.Text(value)
+}
 
 // stderrTail forwards writes to an inner writer (typically the daemon's
 // log) while also retaining a bounded tail of the bytes written. Consumers

--- a/server/pkg/agent/stderr_tail.go
+++ b/server/pkg/agent/stderr_tail.go
@@ -85,13 +85,16 @@ func (s *stderrTail) TotalBytes() int64 {
 	return s.total
 }
 
-// Tail returns the captured stderr with leading/trailing whitespace
-// trimmed; empty string means nothing was written or everything was
-// whitespace.
+// Tail returns the captured stderr as valid UTF-8 with leading/trailing
+// whitespace trimmed. A byte-bounded tail can start or end partway through a
+// multi-byte rune, so invalid fragments are discarded before the diagnostic is
+// persisted. The inner writer still receives every original byte verbatim.
+// Empty string means nothing was written or no valid non-whitespace text was
+// captured.
 func (s *stderrTail) Tail() string {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	return strings.TrimSpace(string(s.buf))
+	return strings.TrimSpace(strings.ToValidUTF8(string(s.buf), ""))
 }
 
 // withAgentStderr appends a stderr tail hint to an error message when

--- a/server/pkg/agent/stream_json_final_output_test.go
+++ b/server/pkg/agent/stream_json_final_output_test.go
@@ -75,6 +75,7 @@ func TestStreamProtocolObservationDoesNotLogContent(t *testing.T) {
 		sawResult:                  true,
 		resultBytes:                len(resultSecret),
 		lastAssistantBytes:         len(assistantSecret),
+		lastEventType:              "result",
 		anthropicBaseURLConfigured: true,
 	})
 
@@ -87,6 +88,7 @@ func TestStreamProtocolObservationDoesNotLogContent(t *testing.T) {
 		"event_count=7",
 		"saw_result=true",
 		"result_bytes=20",
+		"last_event_type=result",
 		"anthropic_base_url_configured=true",
 	} {
 		if !strings.Contains(got, required) {

--- a/server/pkg/agent/stream_json_result.go
+++ b/server/pkg/agent/stream_json_result.go
@@ -100,6 +100,7 @@ type streamProtocolObservation struct {
 	resultBytes                int
 	lastAssistantBytes         int
 	scannerError               bool
+	lastEventType              string
 	anthropicBaseURLConfigured bool
 }
 
@@ -122,6 +123,7 @@ func logStreamProtocolObservation(logger *slog.Logger, obs streamProtocolObserva
 		"result_bytes", obs.resultBytes,
 		"last_assistant_bytes", obs.lastAssistantBytes,
 		"scanner_error", obs.scannerError,
+		"last_event_type", obs.lastEventType,
 		"anthropic_base_url_configured", obs.anthropicBaseURLConfigured,
 	)
 }


### PR DESCRIPTION
## What does this PR do?

Makes Cursor Agent task finalization fail closed unless Multica parses a terminal `result` event, while preserving the existing rule that a valid terminal result wins over the cancellation/exit error used to stop a lingering Cursor worker.

The reported task had already produced an external side effect, but the adapter never observed a terminal result and collapsed every possible cause into `exit status 1`. This change keeps external side effects separate from protocol success and adds bounded diagnostics that distinguish process exit, invalid JSON, scanner failure, and clean EOF without a result.

## Related Issue

Closes MUL-4903
Fixes #5552

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [x] Refactor / code improvement (no behavior change)
- [ ] Documentation update
- [x] Tests (adding or improving test coverage)
- [ ] CI / infrastructure

## Changes Made

- Capture Cursor stderr in the existing 2 KiB tail while continuing to forward it to daemon logs.
- Sanitize secrets, terminal controls, and home-directory paths before diagnostics enter `Result.Error`.
- Record content-free stream metadata including event counts, parse failures, scanner state, and a bounded event type.
- Treat scanner errors and clean EOF without a terminal result as failures and suppress partial transcripts from failed `Result.Output` values.
- Preserve structured Cursor errors and the terminal-result boundary introduced by PR #3165.
- Extract the existing Codex diagnostic sanitizer into a shared helper without changing its behavior.

Risk is limited to Cursor finalization and error text. There are no API, database, persisted-format, or deployment changes. Failure diagnostics remain bounded, and raw stdout/tool content is never copied into the protocol summary.

## How to Test

1. Run `go test ./pkg/agent -count=1` from `server/`.
2. Run `go test -race ./pkg/agent -run 'TestCursorExecute' -count=1`.
3. Run `go vet ./pkg/agent`.

Regression coverage includes stderr-only exit 1, malformed terminal JSON, scanner token overflow without deadlock, clean EOF without result, structured stream errors, stderr redaction/bounds, and valid success/error results followed by a lingering worker.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [ ] I have updated relevant documentation to reflect my changes
- [ ] If I added a new runtime / coding tool / UI tab, I synced the change to **landing copy** (`apps/web/features/landing/i18n/`) and **relevant docs** (`apps/docs/content/docs/`)
- [ ] If this PR touches Chinese product copy, I checked it against `apps/docs/content/docs/developers/conventions.zh.mdx` (terminology, mixed-rule for `task` / `issue` / `skill`)
- [x] I have considered and documented any risks above
- [x] I will address all reviewer comments before requesting merge

## AI Disclosure

**AI tool used:** Codex (Multica agent Sol-Boy)

**Prompt / approach:** Reviewed the Cursor stream adapter, the shared stderr-tail and stream finalization helpers, PR #3165's terminal-result boundary, and the task failure persistence path. Added failing fake-CLI regressions first, then implemented the narrow adapter fix and ran focused, race, vet, and full package validation.

## Screenshots (optional)

Not applicable; backend/daemon behavior only.
