### PR TITLE
fix(desktop): block duplicate legacy daemon startup

### DIFF
--- a/apps/desktop/src/main/daemon-manager.ts
+++ b/apps/desktop/src/main/daemon-manager.ts
@@ -30,6 +30,7 @@ import {
   isAuthStatusError,
   type AuthProbeResult,
 } from "./daemon-auth-probe";
+import { legacyDaemonConflict } from "./daemon-start-conflict";
 
 const DEFAULT_HEALTH_PORT = 19514;
 const POLL_INTERVAL_MS = 5_000;
@@ -114,6 +115,19 @@ function profileLogPath(profile: string): string {
 // fresh PAT instead of reusing a token that belongs to a previous user.
 function profileUserIdPath(profile: string): string {
   return join(profileDir(profile), ".desktop-user-id");
+}
+
+function machineDaemonIdPath(): string {
+  return join(homedir(), ".multica", "daemon.id");
+}
+
+async function readMachineDaemonId(): Promise<string | null> {
+  try {
+    const value = (await readFile(machineDaemonIdPath(), "utf-8")).trim();
+    return value || null;
+  } catch {
+    return null;
+  }
 }
 
 async function readProfileUserId(profile: string): Promise<string | null> {
@@ -831,6 +845,34 @@ async function startDaemon(): Promise<{ success: boolean; error?: string }> {
     // Let polling track it through to "running".
     pollOnce();
     return { success: true };
+  }
+
+  // Migration guard: Desktop moved from the default CLI profile to a named
+  // Desktop-owned profile, which changed the health port and PID file but not
+  // the machine-wide daemon.id. An old default-profile process can therefore
+  // survive an app update and claim the same runtime tasks in parallel. Before
+  // spawning on the new port, confirm whether the default port belongs to this
+  // machine and backend. Refuse startup instead of killing it: the legacy
+  // process may still own active agent work, and automatic termination would
+  // violate the drain guarantee.
+  if (active.name) {
+    const legacyHealth = await fetchHealthAtPort(DEFAULT_HEALTH_PORT);
+    const conflict = legacyDaemonConflict(
+      await readMachineDaemonId(),
+      targetApiBaseUrl,
+      legacyHealth,
+    );
+    if (conflict) {
+      const pid = conflict.pid ? ` (pid ${conflict.pid})` : "";
+      const tasks = conflict.activeTaskCount;
+      return {
+        success: false,
+        error:
+          `Legacy Multica daemon${pid} is still running on port ${DEFAULT_HEALTH_PORT} ` +
+          `for this machine and server (${tasks} active task(s)). ` +
+          "Wait for active tasks to finish, then stop the legacy daemon before retrying.",
+      };
+    }
   }
 
   currentState = "starting";

--- a/apps/desktop/src/main/daemon-start-conflict.test.ts
+++ b/apps/desktop/src/main/daemon-start-conflict.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest";
+import { legacyDaemonConflict } from "./daemon-start-conflict";
+
+describe("legacyDaemonConflict", () => {
+  it("blocks profiled Desktop startup beside a legacy daemon with the same identity", () => {
+    expect(
+      legacyDaemonConflict("machine-1", "https://api.multica.ai", {
+        status: "running",
+        daemon_id: "machine-1",
+        server_url: "https://api.multica.ai/",
+        pid: 14683,
+        active_task_count: 1,
+      }),
+    ).toEqual({ pid: 14683, activeTaskCount: 1 });
+  });
+
+  it("also blocks a matching daemon that is still starting", () => {
+    expect(
+      legacyDaemonConflict("machine-1", "https://api.multica.ai", {
+        status: "starting",
+        daemon_id: "machine-1",
+        server_url: "https://api.multica.ai",
+      }),
+    ).toEqual({ pid: undefined, activeTaskCount: 0 });
+  });
+
+  it.each([
+    ["reused port with another daemon", "machine-2", "https://api.multica.ai"],
+    ["same machine on another backend", "machine-1", "https://staging.multica.ai"],
+  ])("ignores %s", (_name, daemonId, serverUrl) => {
+    expect(
+      legacyDaemonConflict("machine-1", "https://api.multica.ai", {
+        status: "running",
+        daemon_id: daemonId,
+        server_url: serverUrl,
+        pid: 42,
+      }),
+    ).toBeNull();
+  });
+
+  it("fails open when identity cannot be confirmed", () => {
+    expect(
+      legacyDaemonConflict(null, "https://api.multica.ai", {
+        status: "running",
+        daemon_id: "machine-1",
+        server_url: "https://api.multica.ai",
+      }),
+    ).toBeNull();
+  });
+});

--- a/apps/desktop/src/main/daemon-start-conflict.ts
+++ b/apps/desktop/src/main/daemon-start-conflict.ts
@@ -1,0 +1,55 @@
+export interface DaemonIdentityHealth {
+  status?: string;
+  daemon_id?: string;
+  server_url?: string;
+  pid?: number;
+  active_task_count?: number;
+}
+
+export interface LegacyDaemonConflict {
+  pid?: number;
+  activeTaskCount: number;
+}
+
+function normalizeUrl(value: string): string {
+  try {
+    const parsed = new URL(value);
+    return `${parsed.protocol}//${parsed.host}`.toLowerCase();
+  } catch {
+    return value.replace(/\/+$/, "").toLowerCase();
+  }
+}
+
+/**
+ * Detects the migration hazard where an old default-profile daemon survived a
+ * Desktop update and a new Desktop-owned profile is about to start alongside
+ * it. Both processes use the machine-wide daemon.id and would therefore claim
+ * tasks for the same runtime registrations.
+ *
+ * Be deliberately narrow: only a live default-port daemon with the confirmed
+ * local machine identity and the same backend conflicts. A reused port, a
+ * different machine identity, or an intentionally separate backend is not
+ * affected.
+ */
+export function legacyDaemonConflict(
+  localDaemonId: string | null,
+  targetServerUrl: string | null,
+  health: DaemonIdentityHealth | null,
+): LegacyDaemonConflict | null {
+  if (
+    !localDaemonId ||
+    !targetServerUrl ||
+    !health ||
+    (health.status !== "running" && health.status !== "starting") ||
+    health.daemon_id !== localDaemonId ||
+    !health.server_url ||
+    normalizeUrl(health.server_url) !== normalizeUrl(targetServerUrl)
+  ) {
+    return null;
+  }
+
+  return {
+    pid: health.pid,
+    activeTaskCount: health.active_task_count ?? 0,
+  };
+}


### PR DESCRIPTION
## Summary

- block Desktop profiled daemon startup when a live legacy default-profile daemon has the same machine `daemon.id` and backend
- preserve active work by refusing startup instead of terminating the legacy process
- ignore reused default ports, different daemon identities, and separate backends

## Root cause

Daemon lifecycle checks were scoped to each profile's health port and PID file, while `daemon.id` and runtime registrations are machine-wide. After the Desktop migration to a named profile, a legacy default-profile daemon could survive an update and pass both profile-local singleton checks.

## Tests

- `pnpm --filter @multica/desktop test` (35 files, 317 tests)
- `pnpm --filter @multica/desktop typecheck:node`
- `git diff --check`

Closes KAP-953
