### PR TITLE
fix(agents): cut activity sparkline days in the viewer's timezone

### DIFF
--- a/packages/core/agents/queries.ts
+++ b/packages/core/agents/queries.ts
@@ -8,7 +8,13 @@ export const agentTaskSnapshotKeys = {
 
 export const agentActivityKeys = {
   all: (wsId: string) => ["workspaces", wsId, "agent-activity"] as const,
-  last30d: (wsId: string) => [...agentActivityKeys.all(wsId), "30d"] as const,
+  // Prefix without tz — invalidation targets every tz variant at once.
+  last30dAll: (wsId: string) =>
+    [...agentActivityKeys.all(wsId), "30d"] as const,
+  // tz is part of the fetch key: the backend cuts the daily buckets in the
+  // viewer's timezone, so a tz change is a different dataset.
+  last30d: (wsId: string, tz: string) =>
+    [...agentActivityKeys.last30dAll(wsId), tz] as const,
 };
 
 export const agentRunCountsKeys = {
@@ -41,10 +47,10 @@ export function agentTaskSnapshotOptions(wsId: string) {
 // the agent detail "Last 30 days" panel. WS task lifecycle events
 // invalidate this query in useRealtimeSync; the staleTime is a
 // tab-focus safety net.
-export function agentActivity30dOptions(wsId: string) {
+export function agentActivity30dOptions(wsId: string, tz: string) {
   return queryOptions({
-    queryKey: agentActivityKeys.last30d(wsId),
-    queryFn: () => api.getWorkspaceAgentActivity30d(),
+    queryKey: agentActivityKeys.last30d(wsId, tz),
+    queryFn: () => api.getWorkspaceAgentActivity30d({ tz }),
     staleTime: 60 * 1000,
     gcTime: 5 * 60 * 1000,
     refetchOnWindowFocus: true,

--- a/packages/core/agents/use-agent-activity.test.ts
+++ b/packages/core/agents/use-agent-activity.test.ts
@@ -8,9 +8,18 @@ import {
 
 const DAY = 24 * 60 * 60 * 1000;
 
-// Fixed anchor — derivation uses local-time start of "today", a real
-// clock would drift. 12:00 also keeps "today" stable across odd timezones.
-const NOW = new Date("2026-04-28T12:00:00").getTime();
+// Fixed anchors. Buckets are calendar-day strings pre-cut in the viewer's
+// timezone by the backend; the derivation only does whole-day arithmetic
+// between them and TODAY, so tests are timezone-independent by design.
+const TODAY = "2026-04-28";
+const NOW = new Date(`${TODAY}T12:00:00`).getTime();
+
+function isoDaysAgo(daysAgo: number): string {
+  const [y, m, d] = TODAY.split("-").map(Number);
+  return new Date(Date.UTC(y!, m! - 1, d!) - daysAgo * DAY)
+    .toISOString()
+    .slice(0, 10);
+}
 
 function bucket(
   agentId: string,
@@ -18,11 +27,9 @@ function bucket(
   taskCount: number,
   failedCount = 0,
 ): AgentActivityBucket {
-  const t = new Date(NOW);
-  t.setHours(0, 0, 0, 0);
   return {
     agent_id: agentId,
-    bucket_at: new Date(t.getTime() - daysAgo * DAY).toISOString(),
+    date: isoDaysAgo(daysAgo),
     task_count: taskCount,
     failed_count: failedCount,
   };
@@ -64,6 +71,7 @@ describe("deriveAgentActivity", () => {
       buckets,
       fullHistoryAgent.created_at,
       NOW,
+      TODAY,
     );
     expect(result.buckets).toHaveLength(30);
     expect(result.buckets[0]).toEqual({ total: 1, failed: 0 });
@@ -73,13 +81,13 @@ describe("deriveAgentActivity", () => {
 
   it("clamps daysSinceCreated for young agents", () => {
     const created = new Date(NOW - 3 * DAY - 60 * 1000).toISOString();
-    const result = deriveAgentActivity([bucket("fresh", 1, 4)], created, NOW);
+    const result = deriveAgentActivity([bucket("fresh", 1, 4)], created, NOW, TODAY);
     expect(result.daysSinceCreated).toBe(3);
   });
 
   it("treats sub-day-old agents as daysSinceCreated = 0", () => {
     const created = new Date(NOW - 2 * 60 * 60 * 1000).toISOString();
-    const result = deriveAgentActivity([bucket("fresh", 0, 1)], created, NOW);
+    const result = deriveAgentActivity([bucket("fresh", 0, 1)], created, NOW, TODAY);
     expect(result.daysSinceCreated).toBe(0);
     // Today's bucket still records — pre-life days simply look like zero
     // days, which is on purpose.
@@ -91,6 +99,7 @@ describe("deriveAgentActivity", () => {
       [bucket("a1", 60, 99)],
       fullHistoryAgent.created_at,
       NOW,
+      TODAY,
     );
     expect(
       result.buckets.reduce((s, b) => s + b.total, 0),
@@ -102,6 +111,7 @@ describe("deriveAgentActivity", () => {
       [],
       fullHistoryAgent.created_at,
       NOW,
+      TODAY,
     );
     expect(result.buckets).toHaveLength(30);
     expect(result.buckets.every((b) => b.total === 0 && b.failed === 0)).toBe(
@@ -121,6 +131,7 @@ describe("summarizeActivityWindow", () => {
       ],
       fullHistoryAgent.created_at,
       NOW,
+      TODAY,
     );
     const last7 = summarizeActivityWindow(result, 7);
     expect(last7.totalRuns).toBe(4);
@@ -146,6 +157,7 @@ describe("summarizeActivityWindow", () => {
       [bucket("a1", 0, 2)],
       fullHistoryAgent.created_at,
       NOW,
+      TODAY,
     );
     const summary = summarizeActivityWindow(result, 1000);
     expect(summary.buckets).toHaveLength(30);
@@ -157,6 +169,7 @@ describe("summarizeActivityWindow", () => {
       [bucket("a1", 0, 5)],
       fullHistoryAgent.created_at,
       NOW,
+      TODAY,
     );
     const summary = summarizeActivityWindow(result, 0);
     expect(summary.buckets).toEqual([]);
@@ -175,7 +188,7 @@ describe("buildActivityMap", () => {
       bucket("a2", 1, 2, 1),
       bucket("a1", 2, 4),
     ];
-    const map = buildActivityMap(agents, buckets, NOW);
+    const map = buildActivityMap(agents, buckets, NOW, TODAY);
     expect(map.size).toBe(2);
     expect(summarizeActivityWindow(map.get("a1"), 30).totalRuns).toBe(7);
     expect(summarizeActivityWindow(map.get("a2"), 30).totalRuns).toBe(2);
@@ -184,7 +197,7 @@ describe("buildActivityMap", () => {
 
   it("emits a zero-filled entry for an agent with no buckets", () => {
     const agents: Agent[] = [fullHistoryAgent];
-    const map = buildActivityMap(agents, [], NOW);
+    const map = buildActivityMap(agents, [], NOW, TODAY);
     const a = map.get("a1");
     expect(a?.buckets).toHaveLength(30);
     expect(summarizeActivityWindow(a, 30).totalRuns).toBe(0);

--- a/packages/core/agents/use-agent-activity.ts
+++ b/packages/core/agents/use-agent-activity.ts
@@ -68,7 +68,10 @@ const EMPTY_SUMMARY: ActivityWindowSummary = {
  * list AND the detail panel — adding rows costs O(1) HTTP and O(N)
  * compute (not O(N) HTTP).
  */
-export function useWorkspaceActivityMap(wsId: string | undefined): {
+export function useWorkspaceActivityMap(
+  wsId: string | undefined,
+  tz: string,
+): {
   byAgent: Map<string, AgentActivity>;
   loading: boolean;
 } {
@@ -77,14 +80,14 @@ export function useWorkspaceActivityMap(wsId: string | undefined): {
     enabled: !!wsId,
   });
   const { data: buckets, isPending: bucketsPending } = useQuery({
-    ...agentActivity30dOptions(wsId ?? ""),
+    ...agentActivity30dOptions(wsId ?? "", tz),
     enabled: !!wsId,
   });
 
   const byAgent = useMemo(() => {
     if (!agents || !buckets) return new Map<string, AgentActivity>();
-    return buildActivityMap(agents, buckets, Date.now());
-  }, [agents, buckets]);
+    return buildActivityMap(agents, buckets, Date.now(), todayIsoInTz(tz));
+  }, [agents, buckets, tz]);
 
   return { byAgent, loading: agentsPending || bucketsPending };
 }
@@ -93,6 +96,7 @@ export function buildActivityMap(
   agents: readonly Agent[],
   buckets: readonly AgentActivityBucket[],
   now: number,
+  todayIso: string,
 ): Map<string, AgentActivity> {
   // Group buckets by agent once so per-agent derivation is O(buckets) not
   // O(agents × buckets).
@@ -111,6 +115,7 @@ export function buildActivityMap(
         bucketsByAgent.get(agent.id) ?? [],
         agent.created_at,
         now,
+        todayIso,
       ),
     );
   }
@@ -127,20 +132,24 @@ export function deriveAgentActivity(
   buckets: readonly AgentActivityBucket[],
   agentCreatedAt: string,
   now: number,
+  todayIso: string,
 ): AgentActivity {
   const series: ActivityBucket[] = Array.from({ length: DAYS }, () => ({
     total: 0,
     failed: 0,
   }));
 
-  // Newest slot is the start of "today" in local time; we walk back DAYS
-  // slots so index 0 = oldest, index DAYS-1 = today.
-  const today = startOfDay(now);
+  // Buckets arrive as calendar days (YYYY-MM-DD) already cut in the
+  // viewer's timezone by the backend; `todayIso` is today in that same
+  // timezone. Slotting is pure date arithmetic — parsing both sides as
+  // UTC midnights keeps the diff exact and independent of the browser tz.
+  // Index 0 = oldest, index DAYS-1 = today.
+  const today = isoDateToUtcMs(todayIso);
 
   for (const b of buckets) {
-    const ts = new Date(b.bucket_at).getTime();
+    const ts = isoDateToUtcMs(b.date);
     if (Number.isNaN(ts)) continue;
-    const daysAgo = Math.floor((today - startOfDay(ts)) / DAY_MS);
+    const daysAgo = Math.round((today - ts) / DAY_MS);
     if (daysAgo < 0 || daysAgo >= DAYS) continue;
     const slot = DAYS - 1 - daysAgo;
     series[slot]!.total += b.task_count;
@@ -191,14 +200,27 @@ export function summarizeActivityWindow(
   return { buckets: slice, totalRuns, totalFailed, windowDays };
 }
 
-function startOfDay(ts: number): number {
-  // Local-time day boundary. The back-end truncates to UTC midnight, but
-  // the user's mental model is "today/yesterday in the timezone they're
-  // looking at"; using local matches that and keeps "today" stable across
-  // a working session even when buckets cross UTC midnight.
-  const d = new Date(ts);
-  d.setHours(0, 0, 0, 0);
-  return d.getTime();
+// UTC-midnight epoch ms for a YYYY-MM-DD string. Used only for exact
+// whole-day arithmetic between two such strings — never for display.
+function isoDateToUtcMs(iso: string): number {
+  const [y, m, d] = iso.split("-").map(Number);
+  if (!y || !m || !d) return NaN;
+  return Date.UTC(y, m - 1, d);
+}
+
+// Today's calendar date (YYYY-MM-DD) in the given IANA timezone. `en-CA`
+// formats as ISO. Falls back to the browser tz on an invalid zone.
+export function todayIsoInTz(tz: string): string {
+  try {
+    return new Intl.DateTimeFormat("en-CA", {
+      timeZone: tz,
+      year: "numeric",
+      month: "2-digit",
+      day: "2-digit",
+    }).format(new Date());
+  } catch {
+    return new Intl.DateTimeFormat("en-CA").format(new Date());
+  }
 }
 
 export const __EMPTY_ACTIVITY = EMPTY;

--- a/packages/core/api/client.ts
+++ b/packages/core/api/client.ts
@@ -205,6 +205,7 @@ import {
   ListIssuesResponseSchema,
   CreateIssueResponseSchema,
   ListWebhookDeliveriesResponseSchema,
+  AgentActivityBucketListSchema,
   RuntimeHourlyActivityListSchema,
   RuntimeUsageByAgentListSchema,
   RuntimeUsageByHourListSchema,
@@ -1547,8 +1548,24 @@ export class ApiClient {
   // completed_at. One workspace-wide fetch backs both the Agents-list
   // sparkline (uses trailing 7 buckets) and the agent detail "Last 30
   // days" panel (uses all 30).
-  async getWorkspaceAgentActivity30d(): Promise<AgentActivityBucket[]> {
-    return this.fetch(`/api/agent-activity-30d`);
+  async getWorkspaceAgentActivity30d(params?: {
+    tz?: string;
+  }): Promise<AgentActivityBucket[]> {
+    const search = new URLSearchParams();
+    // `tz` drives the calendar-day boundary, like the usage reports.
+    // Caller-supplied; the backend falls back to user.timezone / UTC if
+    // omitted.
+    if (params?.tz) search.set("tz", params.tz);
+    const qs = search.toString();
+    const raw = await this.fetch<unknown>(
+      `/api/agent-activity-30d${qs ? `?${qs}` : ""}`,
+    );
+    return parseWithFallback<AgentActivityBucket[]>(
+      raw,
+      AgentActivityBucketListSchema,
+      [],
+      { endpoint: "GET /api/agent-activity-30d" },
+    );
   }
 
   // Per-agent 30-day total run count for the Agents-list RUNS column.

--- a/packages/core/api/schema.test.ts
+++ b/packages/core/api/schema.test.ts
@@ -78,6 +78,35 @@ describe("ApiClient schema fallback", () => {
     });
   });
 
+  describe("getWorkspaceAgentActivity30d", () => {
+    it("falls back to an empty list when the response is malformed", async () => {
+      stubFetchJson({ buckets: "not-an-array" });
+      const client = new ApiClient("https://api.example.test");
+      const res = await client.getWorkspaceAgentActivity30d({ tz: "UTC" });
+      expect(res).toEqual([]);
+    });
+
+    it("passes the viewer tz through as a query param", async () => {
+      stubFetchJson([
+        {
+          agent_id: "a-1",
+          date: "2026-07-16",
+          task_count: 2,
+          failed_count: 1,
+        },
+      ]);
+      const client = new ApiClient("https://api.example.test");
+      const res = await client.getWorkspaceAgentActivity30d({
+        tz: "Asia/Shanghai",
+      });
+      expect(res).toEqual([
+        { agent_id: "a-1", date: "2026-07-16", task_count: 2, failed_count: 1 },
+      ]);
+      const url = String(vi.mocked(globalThis.fetch).mock.calls[0]?.[0] ?? "");
+      expect(url).toContain("/api/agent-activity-30d?tz=Asia%2FShanghai");
+    });
+  });
+
   describe("listIssues", () => {
     it("falls back to an empty list when the response is malformed", async () => {
       // `issues` having the wrong type triggers the fallback. An object

--- a/packages/core/api/schemas.ts
+++ b/packages/core/api/schemas.ts
@@ -696,6 +696,15 @@ const RuntimeHourlyActivitySchema = z.object({
 
 export const RuntimeHourlyActivityListSchema = z.array(RuntimeHourlyActivitySchema);
 
+const AgentActivityBucketSchema = z.object({
+  agent_id: z.string().default(""),
+  date: z.string().default(""),
+  task_count: z.number().default(0),
+  failed_count: z.number().default(0),
+}).loose();
+
+export const AgentActivityBucketListSchema = z.array(AgentActivityBucketSchema);
+
 const RuntimeUsageByAgentSchema = z.object({
   agent_id: z.string().default(""),
   provider: z.string().default(""),

--- a/packages/core/issues/delete-cache.ts
+++ b/packages/core/issues/delete-cache.ts
@@ -125,7 +125,7 @@ export function invalidateDeletedIssueDependentCaches(
   wsId: string,
 ) {
   qc.invalidateQueries({ queryKey: agentTaskSnapshotKeys.list(wsId) });
-  qc.invalidateQueries({ queryKey: agentActivityKeys.last30d(wsId) });
+  qc.invalidateQueries({ queryKey: agentActivityKeys.last30dAll(wsId) });
   qc.invalidateQueries({ queryKey: agentRunCountsKeys.last30d(wsId) });
   qc.invalidateQueries({ queryKey: agentTasksKeys.all(wsId) });
 }

--- a/packages/core/issues/ws-updaters.test.ts
+++ b/packages/core/issues/ws-updaters.test.ts
@@ -759,11 +759,11 @@ describe("onIssueDeleted", () => {
       [makeTask()],
     );
     qc.setQueryData<AgentActivityBucket[]>(
-      agentActivityKeys.last30d(WS_ID),
+      agentActivityKeys.last30d(WS_ID, "UTC"),
       [
         {
           agent_id: AGENT_ID,
-          bucket_at: "2025-01-01T00:00:00Z",
+          date: "2025-01-01",
           task_count: 1,
           failed_count: 0,
         },
@@ -780,7 +780,9 @@ describe("onIssueDeleted", () => {
     onIssueDeleted(qc, WS_ID, ISSUE_ID);
 
     expectInvalidated(qc, agentTaskSnapshotKeys.list(WS_ID));
-    expectInvalidated(qc, agentActivityKeys.last30d(WS_ID));
+    // The invalidation targets the tz-less prefix; the concrete cached
+    // query (keyed with a tz) must be caught by it.
+    expectInvalidated(qc, agentActivityKeys.last30d(WS_ID, "UTC"));
     expectInvalidated(qc, agentRunCountsKeys.last30d(WS_ID));
     expectInvalidated(qc, agentTasksKeys.detail(WS_ID, AGENT_ID));
     expect(qc.getQueryData(issueKeys.tasks(ISSUE_ID))).toBeUndefined();

--- a/packages/core/realtime/use-realtime-sync.ts
+++ b/packages/core/realtime/use-realtime-sync.ts
@@ -700,7 +700,7 @@ export function useRealtimeSync(
         // here keeps the WS-handler shape uniform; the resulting refetch
         // is cheap.) Both the list (trailing 7d slice) and the detail
         // panel read off this single cache.
-        qc.invalidateQueries({ queryKey: agentActivityKeys.last30d(wsId) });
+        qc.invalidateQueries({ queryKey: agentActivityKeys.last30dAll(wsId) });
         // 30-day run count likewise increments per task lifecycle event.
         qc.invalidateQueries({ queryKey: agentRunCountsKeys.last30d(wsId) });
         // Per-agent task list (Activity tab "Recent work"). Prefix match

--- a/packages/core/types/agent.ts
+++ b/packages/core/types/agent.ts
@@ -185,8 +185,8 @@ export type TaskFailureReason =
 // is anchored on completed_at (a task in flight contributes nothing).
 export interface AgentActivityBucket {
   agent_id: string;
-  // ISO timestamp at midnight UTC of the day.
-  bucket_at: string;
+  // Calendar day (YYYY-MM-DD) in the viewer's timezone.
+  date: string;
   task_count: number;
   failed_count: number;
 }

--- a/packages/views/agents/components/agents-page.tsx
+++ b/packages/views/agents/components/agents-page.tsx
@@ -60,6 +60,7 @@ import {
 } from "@multica/ui/components/ui/tooltip";
 import { useNavigation, useRowLink } from "../../navigation";
 import { ActorAvatar } from "../../common/actor-avatar";
+import { useViewingTimezone } from "../../common/use-viewing-timezone";
 import {
   CollectionPageHeader,
   CollectionPageHeaderAction,
@@ -759,8 +760,9 @@ export function AgentsPage(_props: AgentsPageProps = {}) {
   );
   const { byAgent: presenceMap, loading: presenceLoading } =
     useWorkspacePresenceMap(wsId);
+  const viewTZ = useViewingTimezone();
   const { byAgent: activityMap, loading: activityLoading } =
-    useWorkspaceActivityMap(wsId);
+    useWorkspaceActivityMap(wsId, viewTZ);
 
   const [selectedIds, setSelectedIds] = useState<ReadonlySet<string>>(
     new Set(),

--- a/packages/views/agents/components/tabs/activity-tab.render.test.tsx
+++ b/packages/views/agents/components/tabs/activity-tab.render.test.tsx
@@ -18,6 +18,18 @@ vi.mock("@multica/core/hooks", () => ({
   useWorkspaceId: () => "ws-1",
 }));
 
+// The auth store is a module-level singleton wired at app boot via
+// registerAuthStore(); tests stand in a minimal callable-store so the
+// component's useViewingTimezone() resolves without a real provider.
+vi.mock("@multica/core/auth", () => {
+  const state = { user: { timezone: "UTC" } };
+  const useAuthStore = (selector?: (s: typeof state) => unknown) =>
+    selector ? selector(state) : state;
+  (useAuthStore as unknown as { getState: () => typeof state }).getState =
+    () => state;
+  return { useAuthStore };
+});
+
 // api / paths are only reached from a rendered TaskRow, which never mounts in
 // the loading and empty states under test — stub them so the module graph
 // resolves without dragging in platform wiring.

--- a/packages/views/agents/components/tabs/activity-tab.tsx
+++ b/packages/views/agents/components/tabs/activity-tab.tsx
@@ -38,6 +38,7 @@ import { useWorkspacePaths } from "@multica/core/paths";
 import { issueDetailOptions } from "@multica/core/issues/queries";
 import { AppLink } from "../../../navigation";
 import { TranscriptButton } from "../../../common/task-transcript";
+import { useViewingTimezone } from "../../../common/use-viewing-timezone";
 import { AttributionBadge } from "../../../issues/components/attribution-badge";
 import { taskStatusConfig } from "../../config";
 import { failureReasonLabel } from "./task-failure";
@@ -84,7 +85,8 @@ export function ActivityTab({ agent, showPerformance = true }: ActivityTabProps)
   const { data: agentTasks = [], isLoading: isLoadingRecent } = useQuery(
     agentTasksOptions(wsId, agent.id),
   );
-  const { byAgent: activityMap } = useWorkspaceActivityMap(wsId);
+  const viewTZ = useViewingTimezone();
+  const { byAgent: activityMap } = useWorkspaceActivityMap(wsId, viewTZ);
   const activity = activityMap.get(agent.id);
 
   const [recentDisplayLimit, setRecentDisplayLimit] = useState(RECENT_INITIAL);
@@ -205,7 +207,8 @@ export function AgentPerformanceSummary({ agent }: { agent: Agent }) {
   const { data: agentTasks = [] } = useQuery(
     agentTasksOptions(wsId, agent.id),
   );
-  const { byAgent: activityMap } = useWorkspaceActivityMap(wsId);
+  const viewTZ = useViewingTimezone();
+  const { byAgent: activityMap } = useWorkspaceActivityMap(wsId, viewTZ);
   const activity = activityMap.get(agent.id);
   const summary = summarizeActivityWindow(activity, 30);
   const avgDurationMs = useMemo(

--- a/server/internal/handler/agent.go
+++ b/server/internal/handler/agent.go
@@ -2014,10 +2014,11 @@ func (h *Handler) ListAgentTasks(w http.ResponseWriter, r *http.Request) {
 }
 
 // AgentActivityBucket is one day-bucketed throughput sample for the
-// Agents-list ACTIVITY sparkline. bucket_at is midnight UTC of the day.
+// Agents-list ACTIVITY sparkline. date is the calendar day (YYYY-MM-DD)
+// in the viewer's timezone (see resolveViewingTZ).
 type AgentActivityBucket struct {
 	AgentID     string `json:"agent_id"`
-	BucketAt    string `json:"bucket_at"`
+	Date        string `json:"date"`
 	TaskCount   int32  `json:"task_count"`
 	FailedCount int32  `json:"failed_count"`
 }
@@ -2073,6 +2074,9 @@ func (h *Handler) GetWorkspaceAgentRunCounts(w http.ResponseWriter, r *http.Requ
 // agent detail "Last 30 days" panel (uses all 30) — one fetch is cheaper
 // than two. Front-end fills missing days with zero; the back-end omits
 // empty buckets to keep the response small.
+//
+// Days are cut in the viewer's tz so the sparkline agrees with the
+// dashboard/runtime usage reports on which day a task belongs to.
 func (h *Handler) GetWorkspaceAgentActivity30d(w http.ResponseWriter, r *http.Request) {
 	workspaceID := h.resolveWorkspaceID(r)
 	member, ok := h.workspaceMember(w, r, workspaceID)
@@ -2080,7 +2084,12 @@ func (h *Handler) GetWorkspaceAgentActivity30d(w http.ResponseWriter, r *http.Re
 		return
 	}
 
-	rows, err := h.Queries.GetWorkspaceAgentActivity30d(r.Context(), parseUUID(workspaceID))
+	viewTZ := h.resolveViewingTZ(r)
+	rows, err := h.Queries.GetWorkspaceAgentActivity30d(r.Context(), db.GetWorkspaceAgentActivity30dParams{
+		WorkspaceID: parseUUID(workspaceID),
+		Tz:          viewTZ,
+		Since:       parseSinceParamInTZ(r, 30, viewTZ),
+	})
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, "failed to get agent activity")
 		return
@@ -2101,7 +2110,7 @@ func (h *Handler) GetWorkspaceAgentActivity30d(w http.ResponseWriter, r *http.Re
 		}
 		resp = append(resp, AgentActivityBucket{
 			AgentID:     agentID,
-			BucketAt:    timestampToString(row.Bucket),
+			Date:        row.Date.Time.Format("2006-01-02"),
 			TaskCount:   row.TaskCount,
 			FailedCount: row.FailedCount,
 		})

--- a/server/pkg/db/generated/agent.sql.go
+++ b/server/pkg/db/generated/agent.sql.go
@@ -2728,23 +2728,29 @@ func (q *Queries) GetLatestTaskRoleForIssueAndAgent(ctx context.Context, arg Get
 const getWorkspaceAgentActivity30d = `-- name: GetWorkspaceAgentActivity30d :many
 SELECT
     atq.agent_id,
-    DATE_TRUNC('day', atq.completed_at)::timestamptz AS bucket,
+    DATE(atq.completed_at AT TIME ZONE $2::text) AS date,
     COUNT(*)::int AS task_count,
     COUNT(*) FILTER (WHERE atq.status = 'failed')::int AS failed_count
 FROM agent_task_queue atq
 JOIN agent a ON a.id = atq.agent_id
 WHERE a.workspace_id = $1
   AND atq.completed_at IS NOT NULL
-  AND atq.completed_at > now() - INTERVAL '30 days'
-GROUP BY atq.agent_id, bucket
-ORDER BY atq.agent_id, bucket
+  AND atq.completed_at >= $3
+GROUP BY atq.agent_id, date
+ORDER BY atq.agent_id, date
 `
 
+type GetWorkspaceAgentActivity30dParams struct {
+	WorkspaceID pgtype.UUID        `json:"workspace_id"`
+	Tz          string             `json:"tz"`
+	Since       pgtype.Timestamptz `json:"since"`
+}
+
 type GetWorkspaceAgentActivity30dRow struct {
-	AgentID     pgtype.UUID        `json:"agent_id"`
-	Bucket      pgtype.Timestamptz `json:"bucket"`
-	TaskCount   int32              `json:"task_count"`
-	FailedCount int32              `json:"failed_count"`
+	AgentID     pgtype.UUID `json:"agent_id"`
+	Date        pgtype.Date `json:"date"`
+	TaskCount   int32       `json:"task_count"`
+	FailedCount int32       `json:"failed_count"`
 }
 
 // Returns per-agent daily activity buckets for the last 30 days. Single
@@ -2761,8 +2767,16 @@ type GetWorkspaceAgentActivity30dRow struct {
 // still in flight has no completed_at and contributes nothing here — that's
 // correct: in-flight tasks are surfaced via the live presence indicator,
 // not the historical trend.
-func (q *Queries) GetWorkspaceAgentActivity30d(ctx context.Context, workspaceID pgtype.UUID) ([]GetWorkspaceAgentActivity30dRow, error) {
-	rows, err := q.db.Query(ctx, getWorkspaceAgentActivity30d, workspaceID)
+//
+// Days are cut in the caller-supplied @tz (the viewer's tz, like the
+// dashboard/runtime usage reports) so every viewer of a workspace sees the
+// same tasks attributed to the same calendar day. DATE_TRUNC without a zone
+// would bucket in the session tz and make the sparkline disagree with the
+// usage charts. @since is the viewer-local start-of-day cutoff computed by
+// parseSinceParamInTZ; see ListDashboardUsageDaily for why it must not be
+// re-truncated here.
+func (q *Queries) GetWorkspaceAgentActivity30d(ctx context.Context, arg GetWorkspaceAgentActivity30dParams) ([]GetWorkspaceAgentActivity30dRow, error) {
+	rows, err := q.db.Query(ctx, getWorkspaceAgentActivity30d, arg.WorkspaceID, arg.Tz, arg.Since)
 	if err != nil {
 		return nil, err
 	}
@@ -2772,7 +2786,7 @@ func (q *Queries) GetWorkspaceAgentActivity30d(ctx context.Context, workspaceID 
 		var i GetWorkspaceAgentActivity30dRow
 		if err := rows.Scan(
 			&i.AgentID,
-			&i.Bucket,
+			&i.Date,
 			&i.TaskCount,
 			&i.FailedCount,
 		); err != nil {

--- a/server/pkg/db/queries/agent.sql
+++ b/server/pkg/db/queries/agent.sql
@@ -1123,18 +1123,26 @@ GROUP BY atq.agent_id;
 -- still in flight has no completed_at and contributes nothing here — that's
 -- correct: in-flight tasks are surfaced via the live presence indicator,
 -- not the historical trend.
+--
+-- Days are cut in the caller-supplied @tz (the viewer's tz, like the
+-- dashboard/runtime usage reports) so every viewer of a workspace sees the
+-- same tasks attributed to the same calendar day. DATE_TRUNC without a zone
+-- would bucket in the session tz and make the sparkline disagree with the
+-- usage charts. @since is the viewer-local start-of-day cutoff computed by
+-- parseSinceParamInTZ; see ListDashboardUsageDaily for why it must not be
+-- re-truncated here.
 SELECT
     atq.agent_id,
-    DATE_TRUNC('day', atq.completed_at)::timestamptz AS bucket,
+    DATE(atq.completed_at AT TIME ZONE sqlc.arg('tz')::text) AS date,
     COUNT(*)::int AS task_count,
     COUNT(*) FILTER (WHERE atq.status = 'failed')::int AS failed_count
 FROM agent_task_queue atq
 JOIN agent a ON a.id = atq.agent_id
 WHERE a.workspace_id = $1
   AND atq.completed_at IS NOT NULL
-  AND atq.completed_at > now() - INTERVAL '30 days'
-GROUP BY atq.agent_id, bucket
-ORDER BY atq.agent_id, bucket;
+  AND atq.completed_at >= sqlc.arg('since')
+GROUP BY atq.agent_id, date
+ORDER BY atq.agent_id, date;
 
 -- name: ListWorkspaceAgentTaskSnapshot :many
 -- Returns the tasks needed to derive each agent's current presence:


### PR DESCRIPTION
## Problem

The 30-day agent activity endpoint (`/api/agent-activity-30d`, backing the Agents-list ACTIVITY sparkline and the agent detail "Last 30 days" panel) buckets tasks with a bare `DATE_TRUNC('day', completed_at)`, i.e. in the DB session timezone, and the frontend then maps each bucket into a day slot using the **browser-local** start of day (`use-agent-activity.ts`).

Consequences:

- Two teammates in different timezones see the same task attributed to **different calendar days** (e.g. a task completing at 2026-07-16 01:00 UTC lands on Jul 16 for a UTC+8 viewer but Jul 15 for a UTC-5 viewer).
- The sparkline disagrees with the dashboard / runtime usage reports, which already cut days in the viewer's timezone (`resolveViewingTZ` + `AT TIME ZONE` projection, e.g. `ListDashboardUsageDaily`, `ListRuntimeUsage`).

## Fix

Align the endpoint with the existing usage-report convention:

- **SQL**: `GetWorkspaceAgentActivity30d` projects `completed_at` through `AT TIME ZONE @tz` and windows on the viewer-local start of day (`parseSinceParamInTZ`), returning the calendar day as `date` (`YYYY-MM-DD`) instead of `bucket_at` (midnight-UTC timestamp).
- **Handler**: resolves the tz via the existing `resolveViewingTZ` (`?tz=` param → stored `user.timezone` → UTC).
- **Client**: passes `?tz=` (now part of the query key), parses the response through a new zod schema with `parseWithFallback`, and slots buckets by pure whole-day arithmetic between the server-cut date strings — the browser timezone no longer participates. Cache invalidation keeps working through a tz-less key prefix.
- **Views**: `useWorkspaceActivityMap` now takes the viewer tz from `useViewingTimezone()`.

## Compatibility note

The response field `bucket_at` is replaced by `date`. An older installed client talking to a newer backend will find `bucket_at` missing, skip every bucket (NaN guard), and render an empty sparkline — a cosmetic, self-healing degradation consistent with the API-compatibility guidance (the new client also parses through a schema with fallback).

## Testing

- `go build ./...`, `go vet`, `go test ./internal/handler/` — pass.
- `pnpm typecheck` (all packages) — pass.
- `pnpm test` — pass (core 306 targeted + full suite; views agents suite 175).
- Pre-existing, unrelated failures in `server/pkg/agent` backend tests (Grok/Kiro/Cursor timing-dependent tests) reproduce identically on a clean `main` checkout without this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
