### PR TITLE
fix(chat): always scroll to bottom when switching chat session (MUL-4912)

### DIFF
--- a/packages/views/chat/components/chat-message-list.tsx
+++ b/packages/views/chat/components/chat-message-list.tsx
@@ -194,6 +194,16 @@ export function ChatMessageList({
         customScrollParent={scrollContainerEl}
         data={messages}
         firstItemIndex={firstIndex}
+        // Open pinned to the newest message. The list is remounted per session
+        // (`key={activeSessionId}` upstream), so this initial position is
+        // re-applied on every session switch. Without it a fresh Virtuoso
+        // renders from the top and the only thing that can scroll it down is
+        // `followOutput`, which reacts to post-mount data growth — leaving the
+        // landing spot racy: cached sessions resolve synchronously and stick at
+        // the top, while fetched ones sometimes catch a growth tick and land at
+        // the bottom. `align: "end"` bottom-aligns even a last message taller
+        // than the viewport, so switching sessions always shows the latest reply.
+        initialTopMostItemIndex={{ index: "LAST", align: "end" }}
         increaseViewportBy={{ top: 400, bottom: 600 }}
         atBottomThreshold={120}
         atBottomStateChange={setIsNearBottom}


### PR DESCRIPTION
## Summary

Fixes inconsistent scroll behavior when switching chat sessions in the **Chat** tab (MUL-4912). Previously, switching sessions sometimes auto-scrolled to the bottom and sometimes stayed at the top, forcing a manual scroll down. Now switching a session always lands at the bottom (newest message).

## Root cause

The Chat tab (`ChatPage`) and the floating chat window (`ChatWindow`) both render the shared `ChatMessageList`, re-keyed by `activeSessionId` — so the `Virtuoso` list **fully remounts on every session switch**.

That `Virtuoso` had **no initial-position prop**. A fresh mount therefore renders from the top (item 0). The only thing that could scroll it down was `followOutput`, which reacts to *post-mount data growth* and is gated on `isNearBottom`. Whether it landed at the bottom depended on a race:

- **Cached sessions** (`staleTime: Infinity`) resolve synchronously — the list mounts with static data, `followOutput` has no growth to react to → sticks at the **top**.
- **Fetched sessions** mount after the skeleton, sometimes catching a growth tick → land at the **bottom**.

Async height measurement of variable-height Markdown rows made the outcome non-deterministic.

## Fix

One line in `packages/views/chat/components/chat-message-list.tsx`: pin the freshly-mounted list to the newest message.

```tsx
initialTopMostItemIndex={{ index: "LAST", align: "end" }}
```

Because the list is remounted per session, this initial position is re-applied on every switch. `align: "end"` bottom-aligns even a last message taller than the viewport, so the latest reply is always fully in view. This is additive to the existing `followOutput` streaming-stick behavior — no other logic changes. It fixes both the Chat tab and the floating chat window, since both route through the same component.

## Testing

- `pnpm --filter @multica/views typecheck` — passes
- `pnpm --filter @multica/views exec vitest run chat-message-list.test.tsx chat-page.test.tsx` — 10/10 pass

MUL-4912
