### PR TITLE
fix(shortcuts): ignore synthetic key events without a key

### DIFF
--- a/packages/core/shortcuts/definitions.test.ts
+++ b/packages/core/shortcuts/definitions.test.ts
@@ -98,6 +98,14 @@ describe("keyboard shortcut definitions", () => {
     expect(shortcutMatchesEvent(null, keyEvent(key, modifiers), "macos")).toBe(false);
   });
 
+  it("ignores synthetic events without a key, such as Chrome autofill", () => {
+    const event = keyEvent(undefined as unknown as string, { metaKey: true });
+    expect(shortcutFromEvent(event, "macos")).toBeNull();
+    expect(
+      shortcutMatchesEvent(createShortcutChord("K", { primary: true }), event, "macos"),
+    ).toBe(false);
+  });
+
   it("formats the same semantic binding for each platform", () => {
     const shortcut = createShortcutChord("Enter", { primary: true });
     expect(formatShortcut(shortcut, "macos")).toBe("⌘↵");

--- a/packages/core/shortcuts/definitions.ts
+++ b/packages/core/shortcuts/definitions.ts
@@ -114,6 +114,8 @@ const KEY_LABELS: Record<string, string> = {
 };
 
 function eventKey(event: KeyboardEvent): string | null {
+  // Synthetic events (e.g. Chrome autofill) may omit `key` entirely.
+  if (typeof event.key !== "string") return null;
   if (MODIFIER_KEYS.has(event.key) || NON_ACTIONABLE_KEYS.has(event.key)) return null;
   const key = KEY_LABELS[event.key] ?? event.key;
   if (key.length === 1 && /[a-z]/i.test(key)) return key.toUpperCase();


### PR DESCRIPTION
## What does this PR do?

Fixes a runtime crash in the global keyboard shortcut handler: `TypeError: Cannot read properties of undefined (reading 'length')` at `eventKey` (`packages/core/shortcuts/definitions.ts`).

The document-level `keydown` listener installed by `GlobalShortcuts` receives not only real key presses but also synthetic `KeyboardEvent`s dispatched by Chrome autofill and password-manager extensions. Those events can omit the `key` property entirely. `eventKey()` assumed `event.key` is always a string — `MODIFIER_KEYS.has(undefined)` and `NON_ACTIONABLE_KEYS.has(undefined)` both return `false`, so `undefined` fell through to `key.length` and crashed the page. We hit this on the create-workspace form, where the browser autofills credentials/profile fields.

The fix bails out of `eventKey()` early when `event.key` is not a string, so events without an actionable key are treated the same as modifier-only presses (no shortcut match, no crash).

## Related Issue

No existing issue — crash observed while running the app locally. Happy to file one if preferred.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Refactor / code improvement (no behavior change)
- [ ] Documentation update
- [ ] Tests (adding or improving test coverage)
- [ ] CI / infrastructure

## Changes Made

- `packages/core/shortcuts/definitions.ts`: guard `eventKey()` — return `null` when `typeof event.key !== "string"`.
- `packages/core/shortcuts/definitions.test.ts`: regression test simulating a synthetic keydown without `key` (Chrome autofill), asserting `shortcutFromEvent` returns `null` and `shortcutMatchesEvent` returns `false`.

## How to Test

1. `cd packages/core && pnpm exec vitest run shortcuts/` — all tests pass (the new test crashes with the exact reported `TypeError` without the fix).
2. Manual reproduction: open any page with the global shortcut listener mounted (e.g. workspace creation), trigger Chrome autofill on a form field, and observe no runtime error overlay.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots (N/A — no UI change)
- [ ] I have updated relevant documentation to reflect my changes (N/A)
- [ ] If I added a new runtime / coding tool / UI tab, I synced the change to **landing copy** (`apps/web/features/landing/i18n/`) and **relevant docs** (`apps/docs/content/docs/`) (N/A)
- [ ] If this PR touches Chinese product copy, I checked it against `apps/docs/content/docs/developers/conventions.zh.mdx` (terminology, mixed-rule for `task` / `issue` / `skill`) (N/A)
- [x] I have considered and documented any risks above
- [x] I will address all reviewer comments before requesting merge

## AI Disclosure

**AI tool used:** Claude Code

**Prompt / approach:** Pasted the Next.js runtime error into Claude Code and asked it to trace the origin. It confirmed the crash comes from `eventKey()` assuming `event.key` is a string, wrote a failing regression test reproducing the exact `TypeError`, then applied the minimal guard and verified tests and typecheck.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
