### PR TITLE
fix(autopilots): clarify Chinese schedule day-pattern labels (MUL-4927)

### DIFF
--- a/packages/views/locales/zh-Hans/autopilots.json
+++ b/packages/views/locales/zh-Hans/autopilots.json
@@ -321,10 +321,10 @@
     "every_prefix": "每",
     "unit_hours": "小时",
     "unit_minutes": "分钟",
-    "days_label": "日子",
+    "days_label": "重复",
     "days_every": "每天",
-    "days_weekly": "按星期",
-    "days_monthly": "按日期",
+    "days_weekly": "每周",
+    "days_monthly": "每月",
     "monthly_short_month_hint": "没有 {{day}} 日的月份将跳过。",
     "days_short": {
       "sun": "日",
@@ -386,7 +386,7 @@
       "window_start_minute": "时间窗口起始分钟",
       "window_end_hour": "时间窗口结束小时",
       "window_end_minute": "时间窗口结束分钟",
-      "day_pattern": "日期方式",
+      "day_pattern": "重复方式",
       "day_of_month": "每月几号",
       "timezone": "时区",
       "days_full": {

--- a/packages/views/locales/zh-Hans/autopilots.json
+++ b/packages/views/locales/zh-Hans/autopilots.json
@@ -323,7 +323,7 @@
     "unit_minutes": "分钟",
     "days_label": "重复",
     "days_every": "每天",
-    "days_weekly": "每周",
+    "days_weekly": "每周特定几天",
     "days_monthly": "每月",
     "monthly_short_month_hint": "没有 {{day}} 日的月份将跳过。",
     "days_short": {


### PR DESCRIPTION
## Summary

Improves the Chinese wording of the autopilot schedule editor's day-pattern selector (from #5457). The previous copy was semantically vague:

- Field label `日子` was colloquial and unclear.
- Option `按星期` ("by week") was hard to understand.

New wording aligns with how iOS/Google/飞书 calendars label recurrence in Chinese, and keeps the option set short and parallel:

| key | before | after | EN source |
| --- | --- | --- | --- |
| `schedule_editor.days_label` | 日子 | **重复** | Days |
| `schedule_editor.days_every` | 每天 | 每天 (unchanged) | Every day |
| `schedule_editor.days_weekly` | 按星期 | **每周** | Days of week |
| `schedule_editor.days_monthly` | 按日期 | **每月** | Day of month |
| `schedule_editor.a11y.day_pattern` | 日期方式 | **重复方式** | Day pattern |

`每周` reveals the weekday chips and `每月` reveals the day-of-month field, so the short labels stay unambiguous in context. Only `zh-Hans` values changed; keys are untouched.

## Testing

- `zh-Hans/autopilots.json` validated as well-formed JSON.
- Replicated the `parity.test.ts` key-parity check between `en` and `zh-Hans` autopilots bundles (348 keys each, no missing/extra) — value-only edits keep parity intact.
