### PR TITLE
Fix macOS Desktop launch with inherited NODE_OPTIONS

### DIFF
--- a/apps/desktop/electron-builder.yml
+++ b/apps/desktop/electron-builder.yml
@@ -14,6 +14,15 @@ protocols:
       - multica
 asarUnpack:
   - resources/**
+electronFuses:
+  # Packaged Electron apps read NODE_OPTIONS before our main process can run.
+  # Disable inherited Node runtime env so user shell/debugger options cannot
+  # abort launch before renderer startup (github.com/multica-ai/multica/issues/5520).
+  enableNodeOptionsEnvironmentVariable: false
+  # Keep ELECTRON_RUN_AS_NODE from turning the app binary into a Node runtime
+  # when inherited from a parent process. The desktop main process does not use
+  # child_process.fork, so this is safe for the packaged app bootstrap path.
+  runAsNode: false
 mac:
   entitlementsInherit: build/entitlements.mac.plist
   target:

--- a/apps/desktop/scripts/package.test.mjs
+++ b/apps/desktop/scripts/package.test.mjs
@@ -1,5 +1,5 @@
 import { execFileSync } from "node:child_process";
-import { mkdtempSync, rmSync } from "node:fs";
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { delimiter, join, resolve } from "node:path";
 import { afterEach, describe, it, expect } from "vitest";
@@ -397,6 +397,16 @@ describe("builderArgsForTarget", () => {
       "--publish",
       "never",
     ]);
+  });
+});
+
+describe("electron-builder fuses", () => {
+  it("ignores inherited Node runtime env in packaged desktop builds", () => {
+    const config = readFileSync(resolve("electron-builder.yml"), "utf-8");
+    expect(config).toMatch(
+      /electronFuses:\n(?:  .+\n)*  enableNodeOptionsEnvironmentVariable: false\n/,
+    );
+    expect(config).toMatch(/electronFuses:\n(?:  .+\n)*  runAsNode: false\n/);
   });
 });
 

--- a/apps/desktop/scripts/package.test.mjs
+++ b/apps/desktop/scripts/package.test.mjs
@@ -404,9 +404,9 @@ describe("electron-builder fuses", () => {
   it("ignores inherited Node runtime env in packaged desktop builds", () => {
     const config = readFileSync(resolve("electron-builder.yml"), "utf-8");
     expect(config).toMatch(
-      /electronFuses:\n(?:  .+\n)*  enableNodeOptionsEnvironmentVariable: false\n/,
+      /electronFuses:\n(?: {2}.+\n)* {2}enableNodeOptionsEnvironmentVariable: false\n/,
     );
-    expect(config).toMatch(/electronFuses:\n(?:  .+\n)*  runAsNode: false\n/);
+    expect(config).toMatch(/electronFuses:\n(?: {2}.+\n)* {2}runAsNode: false\n/);
   });
 });
 


### PR DESCRIPTION
<!-- multica-auto-bugfix -->

## What does this PR do?

Disables Electron's packaged-app Node runtime environment fuses for Desktop builds so inherited `NODE_OPTIONS` cannot abort launch before Multica's main process and renderer bootstrap run.

Electron reads `NODE_OPTIONS` before app code can sanitize `process.env`, so the fix belongs in `electron-builder.yml` rather than `src/main/index.ts`.

## Related Issue

Closes #5520

Multica issue: ZIC-91

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Refactor / code improvement (no behavior change)
- [ ] Documentation update
- [x] Tests (adding or improving test coverage)
- [x] CI / infrastructure

## Changes Made

- Added `electronFuses.enableNodeOptionsEnvironmentVariable: false` so packaged Desktop builds ignore inherited `NODE_OPTIONS` before Electron initializes.
- Added `electronFuses.runAsNode: false` so inherited `ELECTRON_RUN_AS_NODE` cannot turn the packaged app binary into a Node runtime.
- Added a package-script regression test that locks the Desktop builder fuse settings.

## How to Test

1. `pnpm install`
2. `pnpm --dir apps/desktop exec vitest run scripts/package.test.mjs`
3. `pnpm --dir apps/desktop run typecheck:node`
4. `pnpm --dir apps/desktop run test`

Additional checks:

- `make check-worktree` was attempted, but the local Docker daemon was unavailable, so the full pipeline stopped at the PostgreSQL prerequisite: `Cannot connect to the Docker daemon at unix:///Users/icezero/.docker/run/docker.sock`.
- An unsigned macOS x64 package smoke test was attempted with `env CSC_IDENTITY_AUTO_DISCOVERY=false pnpm --dir apps/desktop run package -- --mac dir --x64 --publish never`. The Electron main/preload/renderer production build completed, then the bundled Go CLI cross-compile failed because the host temp volume ran out of space (`no space left on device`) before electron-builder packaging could run.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [ ] I have updated relevant documentation to reflect my changes
- [ ] If I added a new runtime / coding tool / UI tab, I synced the change to **landing copy** (`apps/web/features/landing/i18n/`) and **relevant docs** (`apps/docs/content/docs/`)
- [ ] If this PR touches Chinese product copy, I checked it against `apps/docs/content/docs/developers/conventions.zh.mdx` (terminology, mixed-rule for `task` / `issue` / `skill`)
- [x] I have considered and documented any risks above
- [x] I will address all reviewer comments before requesting merge

## AI Disclosure

**AI tool used:** Multica Agent

**Prompt / approach:**
I traced the packaged Desktop launch path from GitHub issue #5520, verified Electron handles `NODE_OPTIONS` before application code can run, applied the smallest package-time fuse change, and added a regression test around the Desktop builder config.

## Screenshots (optional)

N/A
