### PR TITLE
Enable slash-selected task skills (ZIC-92)

### DIFF
--- a/server/internal/daemon/daemon.go
+++ b/server/internal/daemon/daemon.go
@@ -4163,6 +4163,26 @@ func (d *Daemon) runTask(ctx context.Context, task Task, provider string, slot i
 	}
 
 	prompt := BuildPrompt(task, provider)
+	if task.SkillSelectionError != "" {
+		return TaskResult{
+			Status:        "blocked",
+			Comment:       "Skill selection error: " + task.SkillSelectionError,
+			WorkDir:       env.WorkDir,
+			EnvRoot:       env.RootDir,
+			FailureReason: taskfailure.ReasonAgentUnknown.String(),
+		}, nil
+	}
+	var nativeActivation bool
+	prompt, nativeActivation, err = applyNativeSkillActivation(prompt, provider, task.SelectedSkills)
+	if err != nil {
+		return TaskResult{
+			Status:        "blocked",
+			Comment:       err.Error(),
+			WorkDir:       env.WorkDir,
+			EnvRoot:       env.RootDir,
+			FailureReason: taskfailure.ReasonAgentUnknown.String(),
+		}, nil
+	}
 
 	// Pass task-scoped auth credentials and context so the spawned agent CLI
 	// can call the Multica API and the local daemon (e.g. `multica repo checkout`).
@@ -4419,6 +4439,7 @@ func (d *Daemon) runTask(ctx context.Context, task Task, provider string, slot i
 		"provider", provider,
 		"model", model,
 		"prompt_bytes", len(prompt),
+		"native_skill_activation", nativeActivation,
 		"custom_args", len(customArgs),
 		"extra_args", len(extraArgs),
 		"mcp_config", len(mcpConfig) > 0,

--- a/server/internal/daemon/prompt.go
+++ b/server/internal/daemon/prompt.go
@@ -37,6 +37,7 @@ func BuildPrompt(task Task, provider string) string {
 		b.WriteString("You were handed this issue with a handoff note. Treat it as the assigner's scoping instruction for this run; follow it before doing anything broader, and do not reply to it as if it were a comment:\n\n")
 		fmt.Fprintf(&b, "> %s\n\n", task.HandoffNote)
 	}
+	writeSelectedSkillsBlock(&b, task)
 	fmt.Fprintf(&b, "Start by running `multica issue get %s --output json` to understand your task, then complete it.\n", task.IssueID)
 	fmt.Fprintf(&b, "For comment history, follow the rule in your runtime workflow file (assignment-triggered tasks treat the read as mandatory). Start with `multica issue comment list %s --recent 10 --output json` to read the 10 most recently active threads, then page older threads via the stderr `Next thread cursor: ...` line and the matching `--before` / `--before-id` until you have enough history. Resolved threads come back folded — `--full` to expand. `--since <RFC3339>` is still available for incremental polling and may combine with `--recent`.\n", task.IssueID)
 	return b.String()
@@ -212,6 +213,7 @@ func buildCommentPrompt(task Task, provider string) string {
 			fmt.Fprintf(&b, "⚠️ **Squad leader no_action rule:** If you decide no action is needed, call `multica squad activity %s no_action --reason \"...\"` and EXIT. DO NOT post any comment — not even one that says \"no action needed\" or \"exiting silently\". The squad activity call records your decision; a comment is redundant noise.\n\n", task.IssueID)
 		}
 	}
+	writeSelectedSkillsBlock(&b, task)
 	fmt.Fprintf(&b, "Start by running `multica issue get %s --output json` to understand your task, then decide how to proceed.\n\n", task.IssueID)
 	// Comment-reading pointer. Warm path with new comments: issue-wide
 	// since-delta count, but steer the agent to read the triggering thread
@@ -353,37 +355,7 @@ func buildChatPrompt(task Task) string {
 		}
 		b.WriteString("\n")
 	}
-	if task.Agent != nil && len(task.Agent.Skills) > 0 {
-		refs := ExtractSlashSkills(task.ChatMessage)
-		if len(refs) > 0 {
-			agentSkills := make(map[string]string, len(task.Agent.Skills))
-			for _, s := range task.Agent.Skills {
-				agentSkills[s.ID] = s.Name
-			}
-
-			selected := make([]string, 0, len(refs))
-			seen := make(map[string]struct{}, len(refs))
-			for _, ref := range refs {
-				name, ok := agentSkills[ref.ID]
-				if !ok {
-					continue
-				}
-				if _, ok := seen[ref.ID]; ok {
-					continue
-				}
-				seen[ref.ID] = struct{}{}
-				selected = append(selected, name)
-			}
-
-			if len(selected) > 0 {
-				b.WriteString("Explicitly selected skills:\n")
-				for _, name := range selected {
-					fmt.Fprintf(&b, "- %s\n", name)
-				}
-				b.WriteString("\n")
-			}
-		}
-	}
+	writeSelectedSkillsBlock(&b, task)
 	fmt.Fprintf(&b, "User message:\n%s\n", task.ChatMessage)
 	// List attachments by id + filename so the agent can fetch them via
 	// the CLI. We deliberately do NOT inline the URL: chat attachments
@@ -416,6 +388,17 @@ func buildChatPrompt(task Task) string {
 		fmt.Fprintf(&b, "\nThis reply is delivered to %s as text. You cannot attach a file to it: `multica attachment upload` binds to a Multica chat reply, which this is not. If you produce a file, describe it in words — never write its local path as a link, and never upload it and then write as though it arrived.\n", channelDisplayName(task.ChatChannelType))
 	}
 	return b.String()
+}
+
+func writeSelectedSkillsBlock(b *strings.Builder, task Task) {
+	if len(task.SelectedSkills) == 0 {
+		return
+	}
+	b.WriteString("Explicitly selected skills:\n")
+	for _, skill := range task.SelectedSkills {
+		fmt.Fprintf(b, "- %s\n", skill.Name)
+	}
+	b.WriteString("\n")
 }
 
 // channelDisplayName renders a chat_channel_type for prompt copy. The mapping

--- a/server/internal/daemon/prompt_test.go
+++ b/server/internal/daemon/prompt_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/multica-ai/multica/server/internal/daemon/execenv"
+	"github.com/multica-ai/multica/server/internal/taskskill"
 )
 
 // TestBuildQuickCreatePromptRules locks in the rules that govern how the
@@ -451,11 +452,9 @@ func TestBuildChatPromptAgentIntro(t *testing.T) {
 func TestBuildChatPromptSlashSkills(t *testing.T) {
 	t.Run("injects selected skills block", func(t *testing.T) {
 		task := Task{
-			ChatSessionID: "sess-1",
-			ChatMessage:   "please [/deploy](slash://skill/abc-123) this",
-			Agent: &AgentData{
-				Skills: []SkillData{{ID: "abc-123", Name: "deploy"}},
-			},
+			ChatSessionID:  "sess-1",
+			ChatMessage:    "please [/deploy](slash://skill/abc-123) this",
+			SelectedSkills: []taskskill.SelectedSkill{{ID: "abc-123", Name: "deploy", NativeName: "deploy"}},
 		}
 		out := buildChatPrompt(task)
 		if !strings.Contains(out, "Explicitly selected skills:\n- deploy\n") {
@@ -466,41 +465,11 @@ func TestBuildChatPromptSlashSkills(t *testing.T) {
 		}
 	})
 
-	t.Run("ignores skills not belonging to agent", func(t *testing.T) {
+	t.Run("uses validated canonical name not raw label", func(t *testing.T) {
 		task := Task{
-			ChatSessionID: "sess-1",
-			ChatMessage:   "[/hacker-skill](slash://skill/evil-id)",
-			Agent: &AgentData{
-				Skills: []SkillData{{ID: "good-id", Name: "deploy"}},
-			},
-		}
-		out := buildChatPrompt(task)
-		if strings.Contains(out, "Explicitly selected skills") {
-			t.Fatalf("should not inject block for unknown skill ID, got:\n%s", out)
-		}
-	})
-
-	t.Run("validates by ID not label", func(t *testing.T) {
-		task := Task{
-			ChatSessionID: "sess-1",
-			ChatMessage:   "[/deploy](slash://skill/wrong-id)",
-			Agent: &AgentData{
-				Skills: []SkillData{{ID: "real-id", Name: "deploy"}},
-			},
-		}
-		out := buildChatPrompt(task)
-		if strings.Contains(out, "Explicitly selected skills") {
-			t.Fatalf("matching label with wrong ID must not pass, got:\n%s", out)
-		}
-	})
-
-	t.Run("uses canonical name not label", func(t *testing.T) {
-		task := Task{
-			ChatSessionID: "sess-1",
-			ChatMessage:   "[/spoofed-name](slash://skill/real-id)",
-			Agent: &AgentData{
-				Skills: []SkillData{{ID: "real-id", Name: "deploy"}},
-			},
+			ChatSessionID:  "sess-1",
+			ChatMessage:    "[/spoofed-name](slash://skill/real-id)",
+			SelectedSkills: []taskskill.SelectedSkill{{ID: "real-id", Name: "deploy", NativeName: "deploy"}},
 		}
 		out := buildChatPrompt(task)
 		if !strings.Contains(out, "- deploy\n") {
@@ -516,11 +485,9 @@ func TestBuildChatPromptSlashSkills(t *testing.T) {
 
 	t.Run("deduplicates skills", func(t *testing.T) {
 		task := Task{
-			ChatSessionID: "sess-1",
-			ChatMessage:   "[/deploy](slash://skill/a) and [/deploy](slash://skill/a) again",
-			Agent: &AgentData{
-				Skills: []SkillData{{ID: "a", Name: "deploy"}},
-			},
+			ChatSessionID:  "sess-1",
+			ChatMessage:    "[/deploy](slash://skill/a) and [/deploy](slash://skill/a) again",
+			SelectedSkills: []taskskill.SelectedSkill{{ID: "a", Name: "deploy", NativeName: "deploy"}},
 		}
 		out := buildChatPrompt(task)
 		if strings.Count(out, "- deploy") != 1 {
@@ -532,7 +499,6 @@ func TestBuildChatPromptSlashSkills(t *testing.T) {
 		task := Task{
 			ChatSessionID: "sess-1",
 			ChatMessage:   "just a normal message",
-			Agent:         &AgentData{Skills: []SkillData{{ID: "a", Name: "deploy"}}},
 		}
 		out := buildChatPrompt(task)
 		if strings.Contains(out, "Explicitly selected skills") {
@@ -544,7 +510,6 @@ func TestBuildChatPromptSlashSkills(t *testing.T) {
 		task := Task{
 			ChatSessionID: "sess-1",
 			ChatMessage:   "[/deploy](slash://skill/abc-123)",
-			Agent:         &AgentData{},
 		}
 		out := buildChatPrompt(task)
 		if strings.Contains(out, "Explicitly selected skills") {

--- a/server/internal/daemon/skill_activation.go
+++ b/server/internal/daemon/skill_activation.go
@@ -1,0 +1,52 @@
+package daemon
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/multica-ai/multica/server/internal/taskskill"
+)
+
+func applyNativeSkillActivation(prompt, provider string, selected []taskskill.SelectedSkill) (string, bool, error) {
+	if len(selected) == 0 {
+		return prompt, false, nil
+	}
+	needsNative := false
+	for _, skill := range selected {
+		if skill.RequiresNativeActivation {
+			needsNative = true
+			break
+		}
+	}
+	if !needsNative {
+		return prompt, false, nil
+	}
+	if !providerSupportsNativeSkillActivation(provider) {
+		names := make([]string, 0, len(selected))
+		for _, skill := range selected {
+			if skill.RequiresNativeActivation {
+				names = append(names, skill.Name)
+			}
+		}
+		return "", false, fmt.Errorf("selected skill %s requires native runtime activation, but provider %q does not support Multica slash-skill activation yet", strings.Join(names, ", "), provider)
+	}
+
+	var b strings.Builder
+	for _, skill := range selected {
+		name := strings.TrimSpace(skill.NativeName)
+		if name == "" {
+			name = strings.TrimSpace(skill.Name)
+		}
+		if name == "" {
+			return "", false, fmt.Errorf("selected skill %q cannot be activated because it has no native command name", skill.ID)
+		}
+		fmt.Fprintf(&b, "/skill:%s\n", name)
+	}
+	b.WriteString("\n")
+	b.WriteString(prompt)
+	return b.String(), true, nil
+}
+
+func providerSupportsNativeSkillActivation(provider string) bool {
+	return provider == "pi"
+}

--- a/server/internal/daemon/skill_activation_test.go
+++ b/server/internal/daemon/skill_activation_test.go
@@ -1,0 +1,59 @@
+package daemon
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/multica-ai/multica/server/internal/taskskill"
+)
+
+func TestApplyNativeSkillActivationPrefixesPiPrompt(t *testing.T) {
+	prompt, activated, err := applyNativeSkillActivation("wrapped prompt", "pi", []taskskill.SelectedSkill{{
+		ID:                       "skill-1",
+		Name:                     "Deploy",
+		NativeName:               "deploy",
+		RequiresNativeActivation: true,
+	}})
+	if err != nil {
+		t.Fatalf("applyNativeSkillActivation returned error: %v", err)
+	}
+	if !activated {
+		t.Fatal("expected native activation")
+	}
+	if !strings.HasPrefix(prompt, "/skill:deploy\n\nwrapped prompt") {
+		t.Fatalf("prompt was not prefixed with native skill command:\n%s", prompt)
+	}
+}
+
+func TestApplyNativeSkillActivationRejectsUnsupportedProvider(t *testing.T) {
+	_, _, err := applyNativeSkillActivation("wrapped prompt", "codex", []taskskill.SelectedSkill{{
+		ID:                       "skill-1",
+		Name:                     "Deploy",
+		NativeName:               "deploy",
+		RequiresNativeActivation: true,
+	}})
+	if err == nil {
+		t.Fatal("expected unsupported provider error")
+	}
+	if !strings.Contains(err.Error(), "does not support Multica slash-skill activation") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestApplyNativeSkillActivationSkipsVisibleSkills(t *testing.T) {
+	prompt, activated, err := applyNativeSkillActivation("wrapped prompt", "codex", []taskskill.SelectedSkill{{
+		ID:                       "skill-1",
+		Name:                     "Deploy",
+		NativeName:               "deploy",
+		RequiresNativeActivation: false,
+	}})
+	if err != nil {
+		t.Fatalf("applyNativeSkillActivation returned error: %v", err)
+	}
+	if activated {
+		t.Fatal("did not expect native activation")
+	}
+	if prompt != "wrapped prompt" {
+		t.Fatalf("prompt changed: %q", prompt)
+	}
+}

--- a/server/internal/daemon/types.go
+++ b/server/internal/daemon/types.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 
 	"github.com/multica-ai/multica/server/internal/runtimeapps"
+	"github.com/multica-ai/multica/server/internal/taskskill"
 )
 
 // AgentEntry describes a single available agent CLI.
@@ -66,44 +67,46 @@ type Task struct {
 	// prompt set in Settings → General). Server populates this on every claim
 	// regardless of task kind so the daemon can inject `## Workspace Context`
 	// into the brief. Empty when the owner hasn't set one.
-	WorkspaceContext         string                 `json:"workspace_context,omitempty"`
-	ThreadName               string                 `json:"thread_name,omitempty"` // semantic title for provider-native session/thread history
-	Agent                    *AgentData             `json:"agent,omitempty"`
-	ConnectedApps            []ConnectedAppData     `json:"connected_apps,omitempty"` // per-run app capabilities mounted through runtime MCP overlays
-	Repos                    []RepoData             `json:"repos,omitempty"`
-	ProjectID                string                 `json:"project_id,omitempty"`                  // issue's project, when present
-	ProjectTitle             string                 `json:"project_title,omitempty"`               // human-readable project title for context injection
-	ProjectDescription       string                 `json:"project_description,omitempty"`         // durable project-level context injected into the brief
-	ProjectResources         []ProjectResourceData  `json:"project_resources,omitempty"`           // project-scoped resources to expose to the agent
-	IsLeaderTask             bool                   `json:"is_leader_task,omitempty"`              // true when executing in the squad-leader coordinator role
-	PriorSessionID           string                 `json:"prior_session_id,omitempty"`            // Claude session ID from a previous task on this issue
-	PriorWorkDir             string                 `json:"prior_work_dir,omitempty"`              // work_dir from a previous task on this issue
-	TriggerCommentID         string                 `json:"trigger_comment_id,omitempty"`          // comment that triggered this task
-	CoalescedCommentIDs      []string               `json:"coalesced_comment_ids,omitempty"`       // MUL-4195: earlier comments folded into this run while it was still queued; the agent must address these in addition to the (newest) triggering comment. Empty for old servers / non-merged runs
-	CoalescedComments        []CoalescedCommentData `json:"coalesced_comments,omitempty"`          // MUL-4195: full detail of the folded comments (thread_id/author/created_at/content) so the prompt can address each without assuming a shared thread. Empty for old servers / non-merged runs
-	TriggerThreadID          string                 `json:"trigger_thread_id,omitempty"`           // root comment ID for the triggering thread; falls back to trigger_comment_id on old servers
-	TriggerCommentContent    string                 `json:"trigger_comment_content,omitempty"`     // content of the triggering comment
-	TriggerAuthorType        string                 `json:"trigger_author_type,omitempty"`         // "agent" or "member" — author kind for the triggering comment
-	TriggerAuthorName        string                 `json:"trigger_author_name,omitempty"`         // display name of the triggering comment author
-	NewCommentCount          int                    `json:"new_comment_count,omitempty"`           // issue-wide comments since this agent's last run (excludes its own and the injected trigger); 0/omitted for old daemons or cold start
-	NewCommentsSince         string                 `json:"new_comments_since,omitempty"`          // RFC3339 anchor (last run's started_at) the count is measured from; empty on cold start
-	ChatSessionID            string                 `json:"chat_session_id,omitempty"`             // non-empty for chat tasks
-	ChatChannelType          string                 `json:"chat_channel_type,omitempty"`           // "slack" when the chat session is backed by an IM channel; empty for a web-only chat. Drives the channel-awareness block in the prompt
-	ChatInThread             bool                   `json:"chat_in_thread,omitempty"`              // true when the latest @mention was a thread reply; selects which read command the prompt tells the agent to start with
-	ChatMessage              string                 `json:"chat_message,omitempty"`                // user message content for chat tasks
-	ChatMessageAttachments   []ChatAttachmentMeta   `json:"chat_message_attachments,omitempty"`    // attachments linked to the chat message; agent uses these to `multica attachment download <id>`
-	ChatIntro                bool                   `json:"chat_intro,omitempty"`                  // true for the agent's proactive self-introduction chat (no user message); selects the self-introduction prompt in buildChatPrompt
-	AutopilotRunID           string                 `json:"autopilot_run_id,omitempty"`            // non-empty for autopilot run_only tasks
-	AutopilotID              string                 `json:"autopilot_id,omitempty"`                // autopilot that spawned this run
-	AutopilotTitle           string                 `json:"autopilot_title,omitempty"`             // autopilot title used as task context
-	AutopilotDescription     string                 `json:"autopilot_description,omitempty"`       // autopilot description used as task prompt
-	AutopilotSource          string                 `json:"autopilot_source,omitempty"`            // manual, schedule, webhook, or api
-	AutopilotTriggerPayload  json.RawMessage        `json:"autopilot_trigger_payload,omitempty"`   // optional trigger payload for webhook/api runs
-	QuickCreatePrompt        string                 `json:"quick_create_prompt,omitempty"`         // user's natural-language input for quick-create tasks
-	QuickCreatePriority      string                 `json:"quick_create_priority,omitempty"`       // explicit priority selected in quick-create
-	QuickCreateDueDate       string                 `json:"quick_create_due_date,omitempty"`       // explicit calendar due date selected in quick-create
-	QuickCreateAttachmentIDs []string               `json:"quick_create_attachment_ids,omitempty"` // attachments uploaded in the quick-create prompt and bound by issue create
-	HandoffNote              string                 `json:"handoff_note,omitempty"`                // assignment handoff instruction; rendered into the opening prompt + issue_context.md
+	WorkspaceContext         string                    `json:"workspace_context,omitempty"`
+	ThreadName               string                    `json:"thread_name,omitempty"` // semantic title for provider-native session/thread history
+	Agent                    *AgentData                `json:"agent,omitempty"`
+	ConnectedApps            []ConnectedAppData        `json:"connected_apps,omitempty"` // per-run app capabilities mounted through runtime MCP overlays
+	Repos                    []RepoData                `json:"repos,omitempty"`
+	ProjectID                string                    `json:"project_id,omitempty"`                  // issue's project, when present
+	ProjectTitle             string                    `json:"project_title,omitempty"`               // human-readable project title for context injection
+	ProjectDescription       string                    `json:"project_description,omitempty"`         // durable project-level context injected into the brief
+	ProjectResources         []ProjectResourceData     `json:"project_resources,omitempty"`           // project-scoped resources to expose to the agent
+	IsLeaderTask             bool                      `json:"is_leader_task,omitempty"`              // true when executing in the squad-leader coordinator role
+	PriorSessionID           string                    `json:"prior_session_id,omitempty"`            // Claude session ID from a previous task on this issue
+	PriorWorkDir             string                    `json:"prior_work_dir,omitempty"`              // work_dir from a previous task on this issue
+	TriggerCommentID         string                    `json:"trigger_comment_id,omitempty"`          // comment that triggered this task
+	CoalescedCommentIDs      []string                  `json:"coalesced_comment_ids,omitempty"`       // MUL-4195: earlier comments folded into this run while it was still queued; the agent must address these in addition to the (newest) triggering comment. Empty for old servers / non-merged runs
+	CoalescedComments        []CoalescedCommentData    `json:"coalesced_comments,omitempty"`          // MUL-4195: full detail of the folded comments (thread_id/author/created_at/content) so the prompt can address each without assuming a shared thread. Empty for old servers / non-merged runs
+	TriggerThreadID          string                    `json:"trigger_thread_id,omitempty"`           // root comment ID for the triggering thread; falls back to trigger_comment_id on old servers
+	TriggerCommentContent    string                    `json:"trigger_comment_content,omitempty"`     // content of the triggering comment
+	TriggerAuthorType        string                    `json:"trigger_author_type,omitempty"`         // "agent" or "member" — author kind for the triggering comment
+	TriggerAuthorName        string                    `json:"trigger_author_name,omitempty"`         // display name of the triggering comment author
+	NewCommentCount          int                       `json:"new_comment_count,omitempty"`           // issue-wide comments since this agent's last run (excludes its own and the injected trigger); 0/omitted for old daemons or cold start
+	NewCommentsSince         string                    `json:"new_comments_since,omitempty"`          // RFC3339 anchor (last run's started_at) the count is measured from; empty on cold start
+	ChatSessionID            string                    `json:"chat_session_id,omitempty"`             // non-empty for chat tasks
+	ChatChannelType          string                    `json:"chat_channel_type,omitempty"`           // "slack" when the chat session is backed by an IM channel; empty for a web-only chat. Drives the channel-awareness block in the prompt
+	ChatInThread             bool                      `json:"chat_in_thread,omitempty"`              // true when the latest @mention was a thread reply; selects which read command the prompt tells the agent to start with
+	ChatMessage              string                    `json:"chat_message,omitempty"`                // user message content for chat tasks
+	ChatMessageAttachments   []ChatAttachmentMeta      `json:"chat_message_attachments,omitempty"`    // attachments linked to the chat message; agent uses these to `multica attachment download <id>`
+	ChatIntro                bool                      `json:"chat_intro,omitempty"`                  // true for the agent's proactive self-introduction chat (no user message); selects the self-introduction prompt in buildChatPrompt
+	AutopilotRunID           string                    `json:"autopilot_run_id,omitempty"`            // non-empty for autopilot run_only tasks
+	AutopilotID              string                    `json:"autopilot_id,omitempty"`                // autopilot that spawned this run
+	AutopilotTitle           string                    `json:"autopilot_title,omitempty"`             // autopilot title used as task context
+	AutopilotDescription     string                    `json:"autopilot_description,omitempty"`       // autopilot description used as task prompt
+	AutopilotSource          string                    `json:"autopilot_source,omitempty"`            // manual, schedule, webhook, or api
+	AutopilotTriggerPayload  json.RawMessage           `json:"autopilot_trigger_payload,omitempty"`   // optional trigger payload for webhook/api runs
+	QuickCreatePrompt        string                    `json:"quick_create_prompt,omitempty"`         // user's natural-language input for quick-create tasks
+	QuickCreatePriority      string                    `json:"quick_create_priority,omitempty"`       // explicit priority selected in quick-create
+	QuickCreateDueDate       string                    `json:"quick_create_due_date,omitempty"`       // explicit calendar due date selected in quick-create
+	QuickCreateAttachmentIDs []string                  `json:"quick_create_attachment_ids,omitempty"` // attachments uploaded in the quick-create prompt and bound by issue create
+	HandoffNote              string                    `json:"handoff_note,omitempty"`                // assignment handoff instruction; rendered into the opening prompt + issue_context.md
+	SelectedSkills           []taskskill.SelectedSkill `json:"selected_skills,omitempty"`             // user-selected slash skill(s), validated by the server against materialized skills
+	SkillSelectionError      string                    `json:"skill_selection_error,omitempty"`       // server-side validation error for unavailable / ambiguous selected skills
 
 	SquadID               string `json:"squad_id,omitempty"`                // when the picker was a squad, the squad's UUID; Agent is still the resolved leader
 	SquadName             string `json:"squad_name,omitempty"`              // display name for the picker squad, used in prompt text

--- a/server/internal/handler/agent.go
+++ b/server/internal/handler/agent.go
@@ -22,6 +22,7 @@ import (
 	obsmetrics "github.com/multica-ai/multica/server/internal/metrics"
 	"github.com/multica-ai/multica/server/internal/runtimeapps"
 	"github.com/multica-ai/multica/server/internal/service"
+	"github.com/multica-ai/multica/server/internal/taskskill"
 	"github.com/multica-ai/multica/server/internal/util"
 	"github.com/multica-ai/multica/server/pkg/agent"
 	db "github.com/multica-ai/multica/server/pkg/db/generated"
@@ -310,39 +311,41 @@ type AgentTaskResponse struct {
 	// when WorkDir is empty, or when stripping leaves nothing. See
 	// relativeWorkDir() for the full rules. Older clients can still read
 	// WorkDir directly; newer UIs should prefer RelativeWorkDir.
-	RelativeWorkDir          string                 `json:"relative_work_dir,omitempty"`
-	TriggerCommentID         *string                `json:"trigger_comment_id,omitempty"`          // comment that triggered this task
-	CoalescedCommentIDs      []string               `json:"coalesced_comment_ids,omitempty"`       // MUL-4195: earlier comments folded into this run when it had not yet started, so a single run still covers every deliberate comment; trigger_comment_id is the newest. Surfaced so the UI can show which comments a run covered. omitempty so old clients ignore it
-	CoalescedComments        []CoalescedCommentData `json:"coalesced_comments,omitempty"`          // MUL-4195: full detail (thread_id/author/created_at/content) of the folded comments, so the daemon prompt can address each without assuming they share the triggering thread. omitempty so old clients ignore it
-	DeliveredCommentIDs      []string               `json:"delivered_comment_ids"`                 // always present: [] is an authoritative empty receipt, while field absence identifies responses from legacy servers
-	TriggerThreadID          string                 `json:"trigger_thread_id,omitempty"`           // root comment ID for the triggering thread
-	TriggerCommentContent    string                 `json:"trigger_comment_content,omitempty"`     // content of the triggering comment
-	TriggerSummary           *string                `json:"trigger_summary,omitempty"`             // canonical short description snapshot — comment text / autopilot title — taken at task creation; survives source edits/deletes
-	TriggerAuthorType        string                 `json:"trigger_author_type,omitempty"`         // "agent" or "member" — author kind of the triggering comment
-	TriggerAuthorName        string                 `json:"trigger_author_name,omitempty"`         // display name of the triggering comment author
-	NewCommentCount          int                    `json:"new_comment_count,omitempty"`           // trigger-thread comments since last run; excludes injected trigger + own comments; omitempty so old daemons ignore it
-	NewCommentsSince         string                 `json:"new_comments_since,omitempty"`          // RFC3339 anchor (last run's started_at) the count is measured from; omitempty so old daemons ignore it
-	ChatSessionID            string                 `json:"chat_session_id,omitempty"`             // non-empty for chat tasks
-	ChatChannelType          string                 `json:"chat_channel_type,omitempty"`           // "slack" when the chat session is backed by an IM channel; empty for a web-only chat. Makes the agent channel-aware (read history from the channel, not Multica)
-	ChatInThread             bool                   `json:"chat_in_thread,omitempty"`              // true when the latest @mention was a thread reply; tells the agent to start with `multica chat thread` vs `multica chat history`
-	ChatMessage              string                 `json:"chat_message,omitempty"`                // user message for chat tasks
-	ChatMessageAttachments   []ChatAttachmentMeta   `json:"chat_message_attachments,omitempty"`    // attachments on the user message — agent calls `multica attachment download <id>` per entry
-	ChatIntro                bool                   `json:"chat_intro,omitempty"`                  // true for the agent's proactive self-introduction chat (is_agent_intro session, no user message); the daemon builds an intro prompt instead of a reply prompt
-	AutopilotRunID           string                 `json:"autopilot_run_id,omitempty"`            // non-empty for autopilot-spawned tasks
-	AutopilotID              string                 `json:"autopilot_id,omitempty"`                // autopilot that spawned this task
-	AutopilotTitle           string                 `json:"autopilot_title,omitempty"`             // autopilot title used as task context
-	AutopilotDescription     string                 `json:"autopilot_description,omitempty"`       // autopilot description used as task prompt
-	AutopilotSource          string                 `json:"autopilot_source,omitempty"`            // manual, schedule, webhook, or api
-	AutopilotTriggerPayload  json.RawMessage        `json:"autopilot_trigger_payload,omitempty"`   // optional trigger payload for webhook/api runs
-	QuickCreatePrompt        string                 `json:"quick_create_prompt,omitempty"`         // user's natural-language input for quick-create tasks
-	QuickCreatePriority      string                 `json:"quick_create_priority,omitempty"`       // explicit priority selected in quick-create
-	QuickCreateDueDate       string                 `json:"quick_create_due_date,omitempty"`       // explicit calendar due date selected in quick-create
-	QuickCreateAttachmentIDs []string               `json:"quick_create_attachment_ids,omitempty"` // attachment ids uploaded in the quick-create prompt and bound on issue create
-	HandoffNote              string                 `json:"handoff_note,omitempty"`                // assignment handoff instruction; rendered into the run's opening prompt + issue_context.md (omitempty so old daemons ignore it)
-	SquadID                  string                 `json:"squad_id,omitempty"`                    // for quick-create tasks where the picker was a squad; Agent is still the resolved leader
-	SquadName                string                 `json:"squad_name,omitempty"`                  // display name for the picker squad
-	ParentIssueID            string                 `json:"parent_issue_id,omitempty"`             // for quick-create tasks opened from "Add sub issue" — UUID of the parent issue the new issue should be filed under
-	ParentIssueIdentifier    string                 `json:"parent_issue_identifier,omitempty"`     // human-readable identifier (e.g. MUL-123) of the quick-create parent issue, resolved on claim for prompt context
+	RelativeWorkDir          string                    `json:"relative_work_dir,omitempty"`
+	TriggerCommentID         *string                   `json:"trigger_comment_id,omitempty"`          // comment that triggered this task
+	CoalescedCommentIDs      []string                  `json:"coalesced_comment_ids,omitempty"`       // MUL-4195: earlier comments folded into this run when it had not yet started, so a single run still covers every deliberate comment; trigger_comment_id is the newest. Surfaced so the UI can show which comments a run covered. omitempty so old clients ignore it
+	CoalescedComments        []CoalescedCommentData    `json:"coalesced_comments,omitempty"`          // MUL-4195: full detail (thread_id/author/created_at/content) of the folded comments, so the daemon prompt can address each without assuming they share the triggering thread. omitempty so old clients ignore it
+	DeliveredCommentIDs      []string                  `json:"delivered_comment_ids"`                 // always present: [] is an authoritative empty receipt, while field absence identifies responses from legacy servers
+	TriggerThreadID          string                    `json:"trigger_thread_id,omitempty"`           // root comment ID for the triggering thread
+	TriggerCommentContent    string                    `json:"trigger_comment_content,omitempty"`     // content of the triggering comment
+	TriggerSummary           *string                   `json:"trigger_summary,omitempty"`             // canonical short description snapshot — comment text / autopilot title — taken at task creation; survives source edits/deletes
+	TriggerAuthorType        string                    `json:"trigger_author_type,omitempty"`         // "agent" or "member" — author kind of the triggering comment
+	TriggerAuthorName        string                    `json:"trigger_author_name,omitempty"`         // display name of the triggering comment author
+	NewCommentCount          int                       `json:"new_comment_count,omitempty"`           // trigger-thread comments since last run; excludes injected trigger + own comments; omitempty so old daemons ignore it
+	NewCommentsSince         string                    `json:"new_comments_since,omitempty"`          // RFC3339 anchor (last run's started_at) the count is measured from; omitempty so old daemons ignore it
+	ChatSessionID            string                    `json:"chat_session_id,omitempty"`             // non-empty for chat tasks
+	ChatChannelType          string                    `json:"chat_channel_type,omitempty"`           // "slack" when the chat session is backed by an IM channel; empty for a web-only chat. Makes the agent channel-aware (read history from the channel, not Multica)
+	ChatInThread             bool                      `json:"chat_in_thread,omitempty"`              // true when the latest @mention was a thread reply; tells the agent to start with `multica chat thread` vs `multica chat history`
+	ChatMessage              string                    `json:"chat_message,omitempty"`                // user message for chat tasks
+	ChatMessageAttachments   []ChatAttachmentMeta      `json:"chat_message_attachments,omitempty"`    // attachments on the user message — agent calls `multica attachment download <id>` per entry
+	ChatIntro                bool                      `json:"chat_intro,omitempty"`                  // true for the agent's proactive self-introduction chat (is_agent_intro session, no user message); the daemon builds an intro prompt instead of a reply prompt
+	AutopilotRunID           string                    `json:"autopilot_run_id,omitempty"`            // non-empty for autopilot-spawned tasks
+	AutopilotID              string                    `json:"autopilot_id,omitempty"`                // autopilot that spawned this task
+	AutopilotTitle           string                    `json:"autopilot_title,omitempty"`             // autopilot title used as task context
+	AutopilotDescription     string                    `json:"autopilot_description,omitempty"`       // autopilot description used as task prompt
+	AutopilotSource          string                    `json:"autopilot_source,omitempty"`            // manual, schedule, webhook, or api
+	AutopilotTriggerPayload  json.RawMessage           `json:"autopilot_trigger_payload,omitempty"`   // optional trigger payload for webhook/api runs
+	QuickCreatePrompt        string                    `json:"quick_create_prompt,omitempty"`         // user's natural-language input for quick-create tasks
+	QuickCreatePriority      string                    `json:"quick_create_priority,omitempty"`       // explicit priority selected in quick-create
+	QuickCreateDueDate       string                    `json:"quick_create_due_date,omitempty"`       // explicit calendar due date selected in quick-create
+	QuickCreateAttachmentIDs []string                  `json:"quick_create_attachment_ids,omitempty"` // attachment ids uploaded in the quick-create prompt and bound on issue create
+	HandoffNote              string                    `json:"handoff_note,omitempty"`                // assignment handoff instruction; rendered into the run's opening prompt + issue_context.md (omitempty so old daemons ignore it)
+	SelectedSkills           []taskskill.SelectedSkill `json:"selected_skills,omitempty"`             // user-selected slash skill(s), validated against this task's materialized agent skills
+	SkillSelectionError      string                    `json:"skill_selection_error,omitempty"`       // clear daemon-facing error when a selected skill is unavailable or ambiguous
+	SquadID                  string                    `json:"squad_id,omitempty"`                    // for quick-create tasks where the picker was a squad; Agent is still the resolved leader
+	SquadName                string                    `json:"squad_name,omitempty"`                  // display name for the picker squad
+	ParentIssueID            string                    `json:"parent_issue_id,omitempty"`             // for quick-create tasks opened from "Add sub issue" — UUID of the parent issue the new issue should be filed under
+	ParentIssueIdentifier    string                    `json:"parent_issue_identifier,omitempty"`     // human-readable identifier (e.g. MUL-123) of the quick-create parent issue, resolved on claim for prompt context
 	// RequestingUserName + RequestingUserProfileDescription mirror the user
 	// the agent is acting on behalf of (see daemon/types.go). v1 sources them
 	// from the runtime owner so they're populated for daemon runtimes and

--- a/server/internal/handler/daemon.go
+++ b/server/internal/handler/daemon.go
@@ -26,6 +26,7 @@ import (
 	"github.com/multica-ai/multica/server/internal/middleware"
 	"github.com/multica-ai/multica/server/internal/runtimeapps"
 	"github.com/multica-ai/multica/server/internal/service"
+	"github.com/multica-ai/multica/server/internal/taskskill"
 	"github.com/multica-ai/multica/server/internal/util"
 	db "github.com/multica-ai/multica/server/pkg/db/generated"
 	"github.com/multica-ai/multica/server/pkg/protocol"
@@ -1579,6 +1580,26 @@ type claimBuildFailure struct {
 	message string
 }
 
+func resolveSelectedSkillsForTask(input string, skills []service.AgentSkillData) ([]taskskill.SelectedSkill, string) {
+	selected, err := taskskill.Resolve(input, availableTaskSkills(skills))
+	if err != nil {
+		return nil, err.Error()
+	}
+	return selected, ""
+}
+
+func availableTaskSkills(skills []service.AgentSkillData) []taskskill.AvailableSkill {
+	out := make([]taskskill.AvailableSkill, 0, len(skills))
+	for _, skill := range skills {
+		out = append(out, taskskill.AvailableSkill{
+			ID:      skill.ID,
+			Name:    skill.Name,
+			Content: skill.Content,
+		})
+	}
+	return out
+}
+
 // buildClaimedTaskResponse assembles the full daemon claim payload for a
 // single already-claimed task and computes the exact comment ids embedded in
 // it (deliveredCommentIDs). Shared by the per-runtime handler
@@ -1599,6 +1620,7 @@ func (h *Handler) buildClaimedTaskResponse(r *http.Request, task *db.AgentTaskQu
 	if composioMCPEnabled {
 		resp.ConnectedApps = parseRuntimeConnectedAppsForClaim(task.RuntimeConnectedApps, task.ID)
 	}
+	var materializedSkills []service.AgentSkillData
 	if agent, err := h.Queries.GetAgent(r.Context(), task.AgentID); err == nil {
 		useSkillRefs := requestHasClientCapability(r, protocol.DaemonCapabilitySkillBundlesV1)
 		var customEnv map[string]string
@@ -1650,7 +1672,8 @@ func (h *Handler) buildClaimedTaskResponse(r *http.Request, task *db.AgentTaskQu
 			RuntimeConfig: runtimeConfig,
 		}
 		if useSkillRefs {
-			_, skillRefs := h.TaskService.LoadAgentSkillBundles(r.Context(), task.AgentID)
+			bundles, skillRefs := h.TaskService.LoadAgentSkillBundles(r.Context(), task.AgentID)
+			materializedSkills = bundles
 			agentSkillCount = len(skillRefs)
 			resp.Agent.SkillRefs = skillRefs
 		} else {
@@ -1659,6 +1682,7 @@ func (h *Handler) buildClaimedTaskResponse(r *http.Request, task *db.AgentTaskQu
 			builtinSkills := h.TaskService.BuiltinSkills()
 			builtinSkillCount = len(builtinSkills)
 			skills = append(skills, builtinSkills...)
+			materializedSkills = skills
 			resp.Agent.Skills = skills
 		}
 	}
@@ -1709,6 +1733,9 @@ func (h *Handler) buildClaimedTaskResponse(r *http.Request, task *db.AgentTaskQu
 		if issue, err := h.Queries.GetIssue(r.Context(), task.IssueID); err == nil {
 			resp.WorkspaceID = uuidToString(issue.WorkspaceID)
 			resp.ThreadName = issue.Title
+			if len(resp.SelectedSkills) == 0 && resp.SkillSelectionError == "" {
+				resp.SelectedSkills, resp.SkillSelectionError = resolveSelectedSkillsForTask(issue.Description.String, materializedSkills)
+			}
 
 			// Squad-leader briefing injection: keyed off the task being a
 			// leader-task (is_leader_task) carrying a squad_id — NOT off the
@@ -1947,6 +1974,9 @@ func (h *Handler) buildClaimedTaskResponse(r *http.Request, task *db.AgentTaskQu
 				}
 			}
 		}
+		if resp.TriggerCommentContent != "" {
+			resp.SelectedSkills, resp.SkillSelectionError = resolveSelectedSkillsForTask(resp.TriggerCommentContent, materializedSkills)
+		}
 
 		if !supportsCoalescedComments {
 			// Legacy daemons ignore the structured coalesced fields. Fold every
@@ -2160,6 +2190,7 @@ func (h *Handler) buildClaimedTaskResponse(r *http.Request, task *db.AgentTaskQu
 				}
 			}
 			resp.ChatMessage = strings.Join(parts, "\n\n")
+			resp.SelectedSkills, resp.SkillSelectionError = resolveSelectedSkillsForTask(resp.ChatMessage, materializedSkills)
 
 			// Fail closed: a task-owned direct task that resolves to no user text
 			// (and is not the agent's proactive intro) must never dispatch an

--- a/server/internal/handler/skill_selection_test.go
+++ b/server/internal/handler/skill_selection_test.go
@@ -1,0 +1,45 @@
+package handler
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/multica-ai/multica/server/internal/service"
+)
+
+func TestResolveSelectedSkillsForTaskValidatesMaterializedSkills(t *testing.T) {
+	skills := []service.AgentSkillData{{
+		ID:   "skill-1",
+		Name: "Deploy",
+		Content: `---
+name: deploy
+disable-model-invocation: true
+---
+
+body`,
+	}}
+
+	selected, errText := resolveSelectedSkillsForTask("[/deploy](slash://skill/skill-1)", skills)
+	if errText != "" {
+		t.Fatalf("unexpected selection error: %s", errText)
+	}
+	if len(selected) != 1 {
+		t.Fatalf("selected len = %d, want 1", len(selected))
+	}
+	if !selected[0].RequiresNativeActivation || selected[0].NativeName != "deploy" {
+		t.Fatalf("unexpected selected skill: %+v", selected[0])
+	}
+}
+
+func TestResolveSelectedSkillsForTaskUnavailableSkillReturnsClearError(t *testing.T) {
+	_, errText := resolveSelectedSkillsForTask("[/missing](slash://skill/missing)", []service.AgentSkillData{{
+		ID:   "skill-1",
+		Name: "Deploy",
+	}})
+	if errText == "" {
+		t.Fatal("expected selection error")
+	}
+	if !strings.Contains(errText, "not assigned") {
+		t.Fatalf("unexpected error: %s", errText)
+	}
+}

--- a/server/internal/taskskill/selection.go
+++ b/server/internal/taskskill/selection.go
@@ -1,0 +1,188 @@
+package taskskill
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+var (
+	slashSkillLinkRe = regexp.MustCompile(`\[/((?:[^\]\\]|\\.)+)\]\(slash://skill/([^)]+)\)`)
+	nativeSkillRe    = regexp.MustCompile(`^/skill:([^\s]+)`)
+)
+
+type AvailableSkill struct {
+	ID      string
+	Name    string
+	Content string
+}
+
+type SelectedSkill struct {
+	ID                       string `json:"id"`
+	Name                     string `json:"name"`
+	NativeName               string `json:"native_name"`
+	RequiresNativeActivation bool   `json:"requires_native_activation,omitempty"`
+}
+
+type slashSkillRef struct {
+	Label string
+	ID    string
+}
+
+func Resolve(input string, skills []AvailableSkill) ([]SelectedSkill, error) {
+	refs := extractSlashSkillLinks(input)
+	if len(refs) > 0 {
+		return resolveLinkRefs(refs, skills)
+	}
+	if name, ok := extractNativeSkillName(input); ok {
+		return resolveNativeName(name, skills)
+	}
+	return nil, nil
+}
+
+func extractSlashSkillLinks(md string) []slashSkillRef {
+	matches := slashSkillLinkRe.FindAllStringSubmatch(md, -1)
+	seen := make(map[string]struct{}, len(matches))
+	refs := make([]slashSkillRef, 0, len(matches))
+	for _, m := range matches {
+		id := m[2]
+		if _, ok := seen[id]; ok {
+			continue
+		}
+		seen[id] = struct{}{}
+		label := strings.ReplaceAll(m[1], `\[`, "[")
+		label = strings.ReplaceAll(label, `\]`, "]")
+		refs = append(refs, slashSkillRef{Label: label, ID: id})
+	}
+	return refs
+}
+
+func extractNativeSkillName(input string) (string, bool) {
+	trimmed := strings.TrimSpace(input)
+	m := nativeSkillRe.FindStringSubmatch(trimmed)
+	if len(m) != 2 {
+		return "", false
+	}
+	name := strings.TrimSpace(m[1])
+	return name, name != ""
+}
+
+func resolveLinkRefs(refs []slashSkillRef, skills []AvailableSkill) ([]SelectedSkill, error) {
+	byID := make(map[string]AvailableSkill, len(skills))
+	for _, skill := range skills {
+		if skill.ID != "" {
+			byID[skill.ID] = skill
+		}
+	}
+	selected := make([]SelectedSkill, 0, len(refs))
+	for _, ref := range refs {
+		skill, ok := byID[ref.ID]
+		if !ok {
+			label := ref.Label
+			if label == "" {
+				label = ref.ID
+			}
+			return nil, fmt.Errorf("selected skill %q is not assigned to this agent", label)
+		}
+		selected = append(selected, selectedSkill(skill))
+	}
+	return selected, nil
+}
+
+func resolveNativeName(name string, skills []AvailableSkill) ([]SelectedSkill, error) {
+	var matches []AvailableSkill
+	for _, skill := range skills {
+		if skillNameMatches(name, skill) {
+			matches = append(matches, skill)
+		}
+	}
+	switch len(matches) {
+	case 0:
+		return nil, fmt.Errorf("selected skill %q is not assigned to this agent", name)
+	case 1:
+		return []SelectedSkill{selectedSkill(matches[0])}, nil
+	default:
+		return nil, fmt.Errorf("selected skill %q is ambiguous; use the slash skill picker so Multica can send a skill ID", name)
+	}
+}
+
+func skillNameMatches(input string, skill AvailableSkill) bool {
+	input = strings.TrimSpace(input)
+	return strings.EqualFold(input, strings.TrimSpace(skill.Name)) ||
+		strings.EqualFold(input, nativeName(skill))
+}
+
+func selectedSkill(skill AvailableSkill) SelectedSkill {
+	native := nativeName(skill)
+	return SelectedSkill{
+		ID:                       skill.ID,
+		Name:                     skill.Name,
+		NativeName:               native,
+		RequiresNativeActivation: skillDisablesModelInvocation(skill.Content),
+	}
+}
+
+func nativeName(skill AvailableSkill) string {
+	if name := skillFrontmatterName(skill.Content); name != "" {
+		return name
+	}
+	return strings.TrimSpace(skill.Name)
+}
+
+func skillFrontmatterName(content string) string {
+	fm, _, ok := frontmatterParts(content)
+	if !ok {
+		return ""
+	}
+	var data map[string]any
+	if err := yaml.Unmarshal([]byte(fm), &data); err != nil {
+		return ""
+	}
+	if name, ok := data["name"].(string); ok {
+		return strings.TrimSpace(name)
+	}
+	return ""
+}
+
+func skillDisablesModelInvocation(content string) bool {
+	fm, _, ok := frontmatterParts(content)
+	if !ok {
+		return false
+	}
+	var data map[string]any
+	if err := yaml.Unmarshal([]byte(fm), &data); err != nil {
+		return false
+	}
+	value, ok := data["disable-model-invocation"]
+	if !ok {
+		return false
+	}
+	switch v := value.(type) {
+	case bool:
+		return v
+	case string:
+		return strings.EqualFold(strings.TrimSpace(v), "true")
+	default:
+		return false
+	}
+}
+
+func frontmatterParts(content string) (fmBody, body string, ok bool) {
+	if !strings.HasPrefix(content, "---\n") && !strings.HasPrefix(content, "---\r\n") {
+		return "", content, false
+	}
+	bodyStart := 4
+	if strings.HasPrefix(content, "---\r\n") {
+		bodyStart = 5
+	}
+	rest := content[bodyStart:]
+	for _, marker := range []string{"\n---\n", "\n---\r\n", "\r\n---\n", "\r\n---\r\n"} {
+		if idx := strings.Index(rest, marker); idx >= 0 {
+			endLineLen := len(marker)
+			return rest[:idx], rest[idx+endLineLen:], true
+		}
+	}
+	return "", content, false
+}

--- a/server/internal/taskskill/selection_test.go
+++ b/server/internal/taskskill/selection_test.go
@@ -1,0 +1,75 @@
+package taskskill
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestResolveSlashSkillLinkByID(t *testing.T) {
+	skills := []AvailableSkill{{
+		ID:   "skill-1",
+		Name: "Deploy",
+		Content: `---
+name: deploy
+disable-model-invocation: true
+---
+
+body`,
+	}}
+
+	selected, err := Resolve("please [/anything](slash://skill/skill-1)", skills)
+	if err != nil {
+		t.Fatalf("Resolve returned error: %v", err)
+	}
+	if len(selected) != 1 {
+		t.Fatalf("selected len = %d, want 1", len(selected))
+	}
+	got := selected[0]
+	if got.Name != "Deploy" || got.NativeName != "deploy" || !got.RequiresNativeActivation {
+		t.Fatalf("unexpected selected skill: %+v", got)
+	}
+}
+
+func TestResolveRejectsUnavailableSlashSkill(t *testing.T) {
+	_, err := Resolve("[/missing](slash://skill/missing)", []AvailableSkill{{ID: "skill-1", Name: "Deploy"}})
+	if err == nil {
+		t.Fatal("expected unavailable skill error")
+	}
+	if !strings.Contains(err.Error(), "not assigned") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestResolveNativeSkillCommand(t *testing.T) {
+	skills := []AvailableSkill{{
+		ID:   "skill-1",
+		Name: "Deploy Production",
+		Content: `---
+name: deploy-prod
+---
+
+body`,
+	}}
+
+	selected, err := Resolve("  /skill:deploy-prod\nship it", skills)
+	if err != nil {
+		t.Fatalf("Resolve returned error: %v", err)
+	}
+	if len(selected) != 1 || selected[0].ID != "skill-1" || selected[0].NativeName != "deploy-prod" {
+		t.Fatalf("unexpected selected skills: %+v", selected)
+	}
+}
+
+func TestResolveNativeSkillCommandAmbiguous(t *testing.T) {
+	skills := []AvailableSkill{
+		{ID: "a", Name: "Deploy"},
+		{ID: "b", Name: "deploy"},
+	}
+	_, err := Resolve("/skill:deploy", skills)
+	if err == nil {
+		t.Fatal("expected ambiguous skill error")
+	}
+	if !strings.Contains(err.Error(), "ambiguous") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}


### PR DESCRIPTION
## What does this PR do?

<!-- multica-auto-bugfix -->

Fixes user-invoked skill activation from Multica task surfaces by carrying a validated slash-skill selection from the daemon claim response into task prompt construction. The selected skill is validated against the materialized skills available to the assigned runtime, and hidden skills with `disable-model-invocation: true` are activated for Pi by prefixing the final prompt with the runtime-native `/skill:<name>` command before the Multica wrapper.

This also converts bad selections into clear task failures instead of silently ignoring unavailable skill IDs or ambiguous native names.

## Related Issue

Closes #5444

Multica issue: ZIC-92

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Refactor / code improvement (no behavior change)
- [x] Tests (adding or improving test coverage)
- [ ] CI / infrastructure

## Changes Made

- Added `server/internal/taskskill` to parse `[/name](slash://skill/<id>)` links and leading `/skill:name` commands, validate them against assigned skills, and detect hidden skills that require native activation.
- Added `selected_skills` and `skill_selection_error` to daemon task claims.
- Updated daemon prompt construction to render validated selected skills for issue, comment, and chat tasks.
- Added Pi-native activation by prefixing hidden selected skills as `/skill:<native-name>` before the Multica wrapper; unsupported providers return a clear blocked result.
- Added regression tests for selection parsing, handler validation, prompt rendering, and native activation support/failure.

## How to Test

1. `go test ./internal/taskskill ./internal/daemon`
2. `go test ./internal/handler -run TestResolveSelectedSkillsForTask -count=1`
3. `go test ./internal/taskskill ./internal/daemon ./internal/handler -run 'TestResolveSelectedSkillsForTask|TestResolve|TestApplyNativeSkillActivation|TestBuildChatPromptSlashSkills|TestBuildPromptDefaultMentionsRecent' -count=1`
4. `make check-worktree` was attempted, but local Docker/PostgreSQL was unavailable (`Cannot connect to the Docker daemon at unix:///Users/icezero/.docker/run/docker.sock`). The target returned exit 0 while printing that Docker error, so I am not treating it as full environment validation.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [ ] I have updated relevant documentation to reflect my changes
- [ ] If I added a new runtime / coding tool / UI tab, I synced the change to **landing copy** (`apps/web/features/landing/i18n/`) and **relevant docs** (`apps/docs/content/docs/`)
- [ ] If this PR touches Chinese product copy, I checked it against `apps/docs/content/docs/developers/conventions.zh.mdx` (terminology, mixed-rule for `task` / `issue` / `skill`)
- [x] I have considered and documented any risks above
- [x] I will address all reviewer comments before requesting merge

## AI Disclosure

**AI tool used:** Multica Agent (Codex)

**Prompt / approach:**
Investigated GitHub #5444 from Multica issue ZIC-92, traced skill materialization, daemon claim response construction, and runtime prompt invocation. Implemented the smallest backend/daemon path that preserves validated user selection through issue/comment/chat task claims and activates hidden selected skills outside the Multica wrapper for Pi.

## Screenshots (optional)

N/A
