### PR TITLE
Fix empty chat output on resumed daemon sessions

### DIFF
--- a/server/internal/daemon/daemon.go
+++ b/server/internal/daemon/daemon.go
@@ -4486,6 +4486,9 @@ func (d *Daemon) runTask(ctx context.Context, task Task, provider string, slot i
 	switch result.Status {
 	case "completed":
 		if result.Output == "" {
+			if taskResult, ok := completedEmptyOutputTaskResult(task, provider, result, env.WorkDir, env.RootDir, usageEntries); ok {
+				return taskResult, nil
+			}
 			// The agent completed successfully but produced no text output.
 			// This is valid — the agent may have done all its work via tool
 			// calls (e.g. posting comments via CLI, pushing code). Treat as
@@ -4632,6 +4635,22 @@ func (d *Daemon) runTask(ctx context.Context, task Task, provider string, slot i
 			FailureReason: failureReason,
 		}, nil
 	}
+}
+
+func completedEmptyOutputTaskResult(task Task, provider string, result agent.Result, workDir, envRoot string, usageEntries []TaskUsageEntry) (TaskResult, bool) {
+	if task.ChatSessionID == "" {
+		return TaskResult{}, false
+	}
+	comment := fmt.Sprintf("%s completed without returning a chat response", provider)
+	return TaskResult{
+		Status:        "failed",
+		Comment:       comment,
+		SessionID:     result.SessionID,
+		WorkDir:       workDir,
+		EnvRoot:       envRoot,
+		Usage:         usageEntries,
+		FailureReason: taskfailure.ReasonAgentEmptyOrUnparseableOutput.String(),
+	}, true
 }
 
 // executeAndDrain runs a backend, drains its message stream (forwarding to the

--- a/server/internal/daemon/daemon_test.go
+++ b/server/internal/daemon/daemon_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/multica-ai/multica/server/internal/daemon/execenv"
 	"github.com/multica-ai/multica/server/internal/daemon/repocache"
 	"github.com/multica-ai/multica/server/pkg/agent"
+	"github.com/multica-ai/multica/server/pkg/taskfailure"
 )
 
 func createDaemonTestRepo(t *testing.T) string {
@@ -1159,6 +1160,46 @@ func (b *fakeBackend) Execute(_ context.Context, _ string, opts agent.ExecOption
 	close(msgCh)
 	resCh <- b.results[i]
 	return &agent.Session{Messages: msgCh, Result: resCh}, nil
+}
+
+func TestCompletedEmptyOutputTaskResultFailsChatTasks(t *testing.T) {
+	t.Parallel()
+
+	usage := []TaskUsageEntry{{Provider: "codex", Model: "gpt-5", InputTokens: 12}}
+	got, ok := completedEmptyOutputTaskResult(
+		Task{ChatSessionID: "chat-1"},
+		"codex",
+		agent.Result{Status: "completed", SessionID: "runtime-session-1"},
+		"/tmp/work",
+		"/tmp/env",
+		usage,
+	)
+	if !ok {
+		t.Fatal("expected chat empty output to be converted to a task result")
+	}
+	if got.Status != "failed" {
+		t.Fatalf("status = %q, want failed", got.Status)
+	}
+	if got.Comment != "codex completed without returning a chat response" {
+		t.Fatalf("comment = %q", got.Comment)
+	}
+	if got.FailureReason != taskfailure.ReasonAgentEmptyOrUnparseableOutput.String() {
+		t.Fatalf("failure reason = %q, want %q", got.FailureReason, taskfailure.ReasonAgentEmptyOrUnparseableOutput.String())
+	}
+	if got.SessionID != "runtime-session-1" || got.WorkDir != "/tmp/work" || got.EnvRoot != "/tmp/env" {
+		t.Fatalf("resume fields not forwarded: %+v", got)
+	}
+	if len(got.Usage) != 1 || got.Usage[0].InputTokens != 12 {
+		t.Fatalf("usage not forwarded: %+v", got.Usage)
+	}
+}
+
+func TestCompletedEmptyOutputTaskResultLeavesNonChatTasksAlone(t *testing.T) {
+	t.Parallel()
+
+	if got, ok := completedEmptyOutputTaskResult(Task{IssueID: "issue-1"}, "codex", agent.Result{Status: "completed"}, "", "", nil); ok {
+		t.Fatalf("non-chat empty output should keep side-effect-only completion path, got %+v", got)
+	}
 }
 
 func newTestDaemon(t *testing.T) *Daemon {


### PR DESCRIPTION
## What does this PR do?

Fixes a chat-session failure mode where a daemon-backed runtime could report `completed` with an empty final output, causing the chat UI to show a successful turn with no response. Chat tasks now fail closed with a clear empty-output error, while non-chat issue tasks still allow side-effect-only completions such as posting comments or pushing code.

<!-- multica-auto-bugfix -->

## Related Issue

Closes #5581

Multica issue: ZIC-93

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Refactor / code improvement (no behavior change)
- [x] Tests (adding or improving test coverage)
- [ ] CI / infrastructure

## Changes Made

- `server/internal/daemon/daemon.go`: convert chat-task `completed` results with empty output into failed task results with `agent_error.empty_or_unparseable_output`.
- `server/internal/daemon/daemon_test.go`: add regression coverage for chat empty-output failure and non-chat side-effect-only preservation.

## How to Test

1. `cd server && go test ./internal/daemon -run 'TestCompletedEmptyOutputTaskResult|TestExecuteAndDrain_ResumeFailureFallback|TestExecuteAndDrain_SeqContinuesAcrossRetry'`
2. `cd server && go test ./internal/daemon`

`make check-worktree` was not run because this checkout has no `node_modules`, and the local volume had less than 1 GB free after checkout; the full script would require dependency-heavy pnpm and Playwright steps unrelated to this backend-only change.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] If this change affects the UI, I have included before/after screenshots
- [ ] I have updated relevant documentation to reflect my changes
- [ ] If I added a new runtime / coding tool / UI tab, I synced the change to **landing copy** (`apps/web/features/landing/i18n/`) and **relevant docs** (`apps/docs/content/docs/`)
- [ ] If this PR touches Chinese product copy, I checked it against `apps/docs/content/docs/developers/conventions.zh.mdx` (terminology, mixed-rule for `task` / `issue` / `skill`)
- [x] I have considered and documented any risks above
- [x] I will address all reviewer comments before requesting merge

## AI Disclosure

**AI tool used:** Multica Agent

**Prompt / approach:**
Traced GitHub issue #5581 from daemon chat-session completion semantics to the shared agent-result conversion path. Added a fail-closed guard for chat tasks only, preserving existing side-effect-only behavior for issue tasks, then validated with focused and package-level daemon tests.

## Screenshots (optional)

N/A
