### PR TITLE
fix(agent): surface kimi turns that silently fail as end_turn

### DIFF
--- a/server/pkg/agent/kimi.go
+++ b/server/pkg/agent/kimi.go
@@ -384,6 +384,16 @@ func (b *kimiBackend) Execute(ctx context.Context, prompt string, opts ExecOptio
 			usageMap = map[string]TokenUsage{model: u}
 		}
 
+		// The stderr sniffer above cannot see Kimi's failures: unlike
+		// hermes/grok, Kimi's ACP adapter writes upstream-LLM errors to
+		// its own session log, and resolves session/prompt with
+		// stopReason=end_turn even when the turn failed (e.g. a
+		// non-retryable HTTP 400). Such a turn reaches here as
+		// completed with no output and no token usage, which would be
+		// reported to the user as a misleading success. Promote that
+		// specific shape to failed so the task surfaces the problem.
+		finalStatus, finalError = promoteKimiSilentFailure(finalStatus, finalError, finalOutput, usageMap)
+
 		resCh <- Result{
 			Status:     finalStatus,
 			Output:     finalOutput,
@@ -395,6 +405,29 @@ func (b *kimiBackend) Execute(ctx context.Context, prompt string, opts ExecOptio
 	}()
 
 	return &Session{Messages: msgCh, Result: resCh}, nil
+}
+
+// promoteKimiSilentFailure flips a Kimi turn that "completed" with no
+// output and no token usage to failed.
+//
+// Kimi's ACP adapter resolves session/prompt with stopReason=end_turn
+// even when the underlying turn failed upstream, and writes the actual
+// error (expired token, rate limit, non-retryable HTTP 400, …) to its
+// own session log rather than stderr — so the stderr-based provider
+// sniffer used by promoteACPResultOnProviderError captures nothing for
+// Kimi. The one signal that survives to the daemon is the shape of the
+// result: a genuinely completed turn always emits assistant text or
+// tool output and consumes tokens, so completed + empty output + no
+// usage uniquely identifies a swallowed failure. Only that exact shape
+// is promoted; any output or any usage leaves the status untouched.
+func promoteKimiSilentFailure(finalStatus, finalError, finalOutput string, usageMap map[string]TokenUsage) (string, string) {
+	if finalStatus != "completed" {
+		return finalStatus, finalError
+	}
+	if finalOutput != "" || usageMap != nil {
+		return finalStatus, finalError
+	}
+	return "failed", "kimi returned no output and no token usage; the upstream turn likely failed (see the kimi session log for the provider error)"
 }
 
 // kimiToolNameFromTitle normalises tool names emitted by Kimi's ACP

--- a/server/pkg/agent/kimi_test.go
+++ b/server/pkg/agent/kimi_test.go
@@ -22,6 +22,67 @@ func TestNewReturnsKimiBackend(t *testing.T) {
 	}
 }
 
+func TestPromoteKimiSilentFailure(t *testing.T) {
+	t.Parallel()
+
+	usage := map[string]TokenUsage{"k3": {InputTokens: 10, OutputTokens: 5}}
+
+	tests := []struct {
+		name       string
+		status     string
+		errStr     string
+		output     string
+		usage      map[string]TokenUsage
+		wantStatus string
+		wantErrHas string
+	}{
+		{
+			name:       "swallowed failure: completed with no output and no usage",
+			status:     "completed",
+			output:     "",
+			usage:      nil,
+			wantStatus: "failed",
+			wantErrHas: "no output and no token usage",
+		},
+		{
+			name:       "real completion with output stays completed",
+			status:     "completed",
+			output:     "here is the answer",
+			usage:      nil,
+			wantStatus: "completed",
+		},
+		{
+			name:       "empty output but usage present stays completed",
+			status:     "completed",
+			output:     "",
+			usage:      usage,
+			wantStatus: "completed",
+		},
+		{
+			name:       "non-completed status is never touched",
+			status:     "aborted",
+			errStr:     "execution cancelled",
+			output:     "",
+			usage:      nil,
+			wantStatus: "aborted",
+			wantErrHas: "execution cancelled",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			gotStatus, gotErr := promoteKimiSilentFailure(tt.status, tt.errStr, tt.output, tt.usage)
+			if gotStatus != tt.wantStatus {
+				t.Errorf("status = %q, want %q", gotStatus, tt.wantStatus)
+			}
+			if tt.wantErrHas != "" && !strings.Contains(gotErr, tt.wantErrHas) {
+				t.Errorf("error = %q, want it to contain %q", gotErr, tt.wantErrHas)
+			}
+		})
+	}
+}
+
 func TestKimiToolNameFromTitle(t *testing.T) {
 	t.Parallel()
 	tests := []struct {
@@ -66,7 +127,7 @@ func fakeKimiACPScript() string {
 #
 # Writes the full argv (one arg per line) to $KIMI_ARGS_FILE if that env
 # var is set, so tests can assert that the daemon invokes us with the
-# right flags (`+"`--yolo acp`"+`, not bare `+"`acp`"+`).
+# right flags (` + "`--yolo acp`" + `, not bare ` + "`acp`" + `).
 #
 # Then reads one JSON-RPC request per line from stdin, matches on the
 # method name, and writes back a canned response. Exits after set_model


### PR DESCRIPTION
## What does this PR do?

Makes the daemon surface Kimi turns that fail upstream but are reported to the client as a clean `end_turn`.

Kimi's ACP adapter resolves `session/prompt` with `stopReason=end_turn` even when the underlying turn failed (e.g. a non-retryable HTTP 400, an expired token, or a rate limit), and — unlike hermes/grok — it writes the real error to its own session log rather than stderr. The existing `promoteACPResultOnProviderError` promotion relies on sniffing stderr, so for Kimi it captures nothing (`grep -c "kimi:stderr" daemon.log` = 0 while other providers = hundreds). The result: a genuinely failed turn reaches the daemon as `completed` with empty output and no token usage, and is reported to the user as a misleading success.

This adds a Kimi-scoped promotion for that exact shape.

## Related Issue

<!-- No upstream GitHub issue; the problem and full evidence are described here and tracked internally. -->

Closes #

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `server/pkg/agent/kimi.go`: new pure function `promoteKimiSilentFailure(finalStatus, finalError, finalOutput, usageMap)` — when a Kimi turn is `completed` with empty output **and** no token usage, promote it to `failed` with a diagnostic pointing at the Kimi session log. Called from the backend goroutine after usage is computed. Scoped to the Kimi backend only; hermes/grok promotion (`promoteACPResultOnProviderError`) is untouched. Any output or any usage leaves the status unchanged.
- `server/pkg/agent/kimi_test.go`: `TestPromoteKimiSilentFailure` (table-driven, 4 cases: swallowed failure promoted; real completion with output untouched; empty output but usage present untouched; non-completed status untouched).

## How to Test

1. `cd server && go vet ./pkg/agent/` — clean.
2. `cd server && go test ./pkg/agent/ -run 'TestPromoteKimiSilentFailure|TestKimi'` — passes, including the existing Kimi ACP integration tests.
3. `gofmt -l server/pkg/agent/kimi.go server/pkg/agent/kimi_test.go` — empty (formatted).

Real-world reproduction that motivated this: a poisoned Kimi session repeatedly returned HTTP 400 (`the message at position N with role 'assistant' must not be empty`); the daemon logged `status=completed output_bytes=0 agent_error=""` on every attempt, so the user saw silent no-ops instead of a surfaced failure.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [ ] I have updated relevant documentation to reflect my changes
- [ ] If I added a new runtime / coding tool / UI tab, I synced the change to landing copy and docs
- [ ] If this PR touches Chinese product copy, I checked it against conventions.zh.mdx
- [x] I have considered and documented any risks above
- [x] I will address all reviewer comments before requesting merge

Risk: the promotion is a heuristic on result shape (completed + empty output + zero usage). For an agent task prompt this shape is definitionally a swallowed failure — a real turn always emits output or consumes tokens — so false positives are low. It further tightens once Kimi reports usage over ACP (upstream MoonshotAI/kimi-code#1858), after which any real turn carries usage > 0.

## AI Disclosure

**AI tool used:** Claude Code (Multica Agent runtime)

**Prompt / approach:** Investigated a report that the Kimi runtime returned no values and no usage. Traced the daemon logs and Kimi session logs to two root causes (a poisoned session hitting HTTP 400, and the stderr-only error sniffer missing Kimi's log-file errors), confirmed the failed-turn/end_turn mapping in kimi-code's acp-adapter source, then wrote this Kimi-scoped promotion with a table-driven unit test and verified with go vet / go test / gofmt.
