### PR TITLE
fix(service): dedup quick-create tasks to stop duplicate issues

### DIFF
--- a/server/internal/service/task.go
+++ b/server/internal/service/task.go
@@ -1,6 +1,7 @@
 package service
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -1286,6 +1287,29 @@ const QuickCreateContextType = "quick_create"
 // parentIssueID is optional (zero-valued pgtype.UUID when the user didn't
 // open the modal from "Add sub issue"). The handler is responsible for
 // validating it belongs to the same workspace before passing it in.
+// pendingQuickCreateDuplicate returns a still-pending quick-create task from
+// `pending` that represents the same request as (agentID, requesterID,
+// contextJSON), or nil if none matches.
+//
+// Two identical quick-create submissions — a double-click or a client retry —
+// marshal to byte-identical context, so an exact context match against a task
+// from the same requester to the same agent that has not finished yet uniquely
+// identifies an accidental duplicate. `pending` is expected to be the
+// queued/dispatched set for the agent's runtime (ListPendingTasksByRuntime), so
+// a task that already completed and created its issue no longer appears here and
+// does not suppress a deliberate re-submission.
+func pendingQuickCreateDuplicate(pending []db.AgentTaskQueue, agentID, requesterID pgtype.UUID, contextJSON []byte) *db.AgentTaskQueue {
+	for i := range pending {
+		t := &pending[i]
+		if util.UUIDToString(t.AgentID) == util.UUIDToString(agentID) &&
+			util.UUIDToString(t.OriginatorUserID) == util.UUIDToString(requesterID) &&
+			bytes.Equal(t.Context, contextJSON) {
+			return t
+		}
+	}
+	return nil
+}
+
 func (s *TaskService) EnqueueQuickCreateTask(ctx context.Context, workspaceID, requesterID pgtype.UUID, agentID, squadID pgtype.UUID, prompt, priority, dueDate string, projectID, parentIssueID pgtype.UUID, attachmentIDs []pgtype.UUID) (db.AgentTaskQueue, error) {
 	agent, err := s.Queries.GetAgent(ctx, agentID)
 	if err != nil {
@@ -1326,6 +1350,27 @@ func (s *TaskService) EnqueueQuickCreateTask(ctx context.Context, workspaceID, r
 	contextJSON, err := json.Marshal(payload)
 	if err != nil {
 		return db.AgentTaskQueue{}, fmt.Errorf("marshal quick-create context: %w", err)
+	}
+
+	// Dedup an accidental double-submit: if the same requester already has a
+	// byte-identical quick-create for this agent still pending (queued or
+	// dispatched), return that task instead of enqueuing a second one — a single
+	// request must not fan out into two tasks that each create a duplicate issue.
+	// Best-effort: a lookup error falls through to create so a transient DB hiccup
+	// can never block a real submission. This mirrors the existing pending-task
+	// dedup (HasPendingTaskForIssueAndAgent) and, like it, is a check-then-insert:
+	// it closes the observed double-click / client-retry window but is not atomic
+	// against two truly simultaneous requests. A unique index would harden that.
+	if pending, listErr := s.Queries.ListPendingTasksByRuntime(ctx, agent.RuntimeID); listErr == nil {
+		if dup := pendingQuickCreateDuplicate(pending, agentID, requesterID, contextJSON); dup != nil {
+			slog.Info("quick-create dedup: returning existing pending task",
+				"task_id", util.UUIDToString(dup.ID),
+				"agent_id", util.UUIDToString(agentID),
+				"requester_id", util.UUIDToString(requesterID),
+				"workspace_id", util.UUIDToString(workspaceID),
+			)
+			return *dup, nil
+		}
 	}
 
 	// The requester who submitted the quick-create modal is the direct_human

--- a/server/internal/service/task_quickcreate_dedup_test.go
+++ b/server/internal/service/task_quickcreate_dedup_test.go
@@ -1,0 +1,91 @@
+package service
+
+import (
+	"testing"
+
+	"github.com/jackc/pgx/v5/pgtype"
+	db "github.com/multica-ai/multica/server/pkg/db/generated"
+)
+
+func uuidFromByte(b byte) pgtype.UUID {
+	var u pgtype.UUID
+	u.Valid = true
+	u.Bytes[15] = b
+	return u
+}
+
+func TestPendingQuickCreateDuplicate(t *testing.T) {
+	t.Parallel()
+
+	agentA := uuidFromByte(1)
+	agentB := uuidFromByte(2)
+	userA := uuidFromByte(10)
+	userB := uuidFromByte(11)
+	ctx := []byte(`{"type":"quick_create","prompt":"add archive button"}`)
+	ctxOther := []byte(`{"type":"quick_create","prompt":"something else"}`)
+
+	task := func(id byte, agent, user pgtype.UUID, context []byte) db.AgentTaskQueue {
+		return db.AgentTaskQueue{ID: uuidFromByte(id), AgentID: agent, OriginatorUserID: user, Context: context}
+	}
+
+	tests := []struct {
+		name    string
+		pending []db.AgentTaskQueue
+		wantDup bool
+		wantID  byte
+	}{
+		{
+			name:    "identical request from same requester to same agent is a duplicate",
+			pending: []db.AgentTaskQueue{task(100, agentA, userA, ctx)},
+			wantDup: true,
+			wantID:  100,
+		},
+		{
+			name:    "different prompt is not a duplicate",
+			pending: []db.AgentTaskQueue{task(100, agentA, userA, ctxOther)},
+			wantDup: false,
+		},
+		{
+			name:    "same request but different agent is not a duplicate",
+			pending: []db.AgentTaskQueue{task(100, agentB, userA, ctx)},
+			wantDup: false,
+		},
+		{
+			name:    "same request but different requester is not a duplicate",
+			pending: []db.AgentTaskQueue{task(100, agentA, userB, ctx)},
+			wantDup: false,
+		},
+		{
+			name:    "empty pending set is not a duplicate",
+			pending: nil,
+			wantDup: false,
+		},
+		{
+			name: "matches the duplicate among unrelated pending tasks",
+			pending: []db.AgentTaskQueue{
+				task(100, agentB, userA, ctx),
+				task(101, agentA, userB, ctx),
+				task(102, agentA, userA, ctx),
+			},
+			wantDup: true,
+			wantID:  102,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := pendingQuickCreateDuplicate(tt.pending, agentA, userA, ctx)
+			if tt.wantDup {
+				if got == nil {
+					t.Fatalf("expected a duplicate, got nil")
+				}
+				if got.ID != uuidFromByte(tt.wantID) {
+					t.Errorf("matched wrong task: got %v, want id byte %d", got.ID, tt.wantID)
+				}
+			} else if got != nil {
+				t.Errorf("expected no duplicate, got task %v", got.ID)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## What does this PR do?

Stops a single "create issue via agent" (quick-create) submission from producing **two duplicate issues**.

`EnqueueQuickCreateTask` (`server/internal/service/task.go`) inserted an `agent_task_queue` row unconditionally, with no dedup — unlike the @mention/review paths that coalesce via `HasPendingTaskForIssueAndAgent`. A double-click or a client retry therefore enqueued two tasks, and each independently created an issue.

Observed live: one request produced two near-identical issues; daemon logs showed two tasks with **identical `prompt_bytes=6508`**, wakeups **1.7s apart**, both with empty `trigger_comment_id` and `autopilot_run_id` (the direct quick-create path).

## Related Issue

Closes #2

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `server/internal/service/task.go`:
  - New pure helper `pendingQuickCreateDuplicate(pending, agentID, requesterID, contextJSON)` — returns a still-pending quick-create task from `pending` whose (agent, requester, byte-identical context) matches, else nil.
  - In `EnqueueQuickCreateTask`, before `CreateQuickCreateTask`: list the agent runtime's pending (queued/dispatched) tasks via the existing `ListPendingTasksByRuntime` and, if a duplicate is found, return that task instead of enqueuing a second one. Best-effort — a list error falls through to create so a transient DB hiccup can never block a real submission.
- `server/internal/service/task_quickcreate_dedup_test.go`: table-driven unit test for the matcher (identical → dup; different prompt/agent/requester → not; empty set; matches among unrelated pending tasks).

## How to Test

1. `cd server && go build ./internal/service/` — clean.
2. `cd server && go vet ./internal/service/` — clean.
3. `cd server && go test ./internal/service/ -run TestPendingQuickCreateDuplicate -v` — 6/6 pass.
4. `gofmt -l server/internal/service/task.go server/internal/service/task_quickcreate_dedup_test.go` — empty.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [ ] I have updated relevant documentation to reflect my changes
- [ ] If I added a new runtime / coding tool / UI tab, I synced the change to landing copy and docs
- [ ] If this PR touches Chinese product copy, I checked it against conventions.zh.mdx
- [x] I have considered and documented any risks above
- [x] I will address all reviewer comments before requesting merge

### Design notes / risks

- **Reused `ListPendingTasksByRuntime` + a Go-side filter** rather than a dedicated dedup query. A dedicated `sqlc` query (e.g. `HasRecentPendingQuickCreateTask`) would be cleaner, but adding one needs a `sqlc` regen I could not run in my environment; this reuse keeps the change compiling and minimal. Happy to switch to a dedicated query if you prefer.
- **check-then-insert, not atomic.** Mirrors the existing `HasPendingTaskForIssueAndAgent` pattern; it closes the double-click / client-retry window but two *truly simultaneous* requests could still both miss. A unique partial index on (agent_id, originator_user_id, context-hash) for pending rows would harden it — omitted here to avoid a migration and keep scope tight; can add if wanted.
- **DB-backed verification is CI-only.** The repo's service dedup tests self-skip without Postgres (`t.Skipf("database unavailable")`), and I don't have a Postgres here. I verified build/vet/gofmt and the pure matcher unit test locally; the full `go test` (with the pgvector service) runs in CI.

## AI Disclosure

**AI tool used:** Claude Code (Multica Agent runtime)

**Prompt / approach:** A user noticed one request created two duplicate issues (PRTS-93/PRTS-94). I traced daemon logs (identical prompt bytes, 1.7s apart, no comment/autopilot trigger) to the quick-create dispatch path, found `EnqueueQuickCreateTask` had no dedup while sibling paths use `HasPendingTaskForIssueAndAgent`, and added a best-effort pending-duplicate guard with a pure-function unit test, verified with go build/vet/gofmt and the unit test.
