### PR TITLE
fix(daemon): keep explicit custom_env secrets in Codex shell allowlist

### DIFF
--- a/server/internal/daemon/execenv/codex_shell_env.go
+++ b/server/internal/daemon/execenv/codex_shell_env.go
@@ -45,11 +45,11 @@ type tomlByteRange struct {
 // Inherited process variables keep Codex's documented default filtering for
 // names containing KEY, SECRET, or TOKEN. Inherited MULTICA_* variables are
 // always dropped because they belong to the daemon process, not necessarily to
-// this task. Explicit MULTICA_* values are safe to include because daemon.go
-// blocklists that namespace from agent custom_env and constructs those values
-// from the current task. Non-secret explicit custom_env values keep their
-// existing shell visibility; secret-looking custom_env remains filtered just
-// as it was under Codex's default policy.
+// this task. Every explicitly configured variable is included, because it is
+// either a daemon-constructed task value or a key the agent owner deliberately
+// set in custom_env; this covers credential-looking names (KEY/SECRET/TOKEN)
+// the owner authorized for this task. Only names enter the allowlist — values
+// are never written to config.toml or logs.
 func CodexShellEnvAllowlist(inherited []string, explicit map[string]string) []string {
 	// Codex's glob matching is case-insensitive. De-duplicate on the same basis
 	// so Windows Path/PATH aliases cannot create ambiguous policy entries.
@@ -59,12 +59,12 @@ func CodexShellEnvAllowlist(inherited []string, explicit map[string]string) []st
 			return
 		}
 		upper := strings.ToUpper(key)
-		if strings.HasPrefix(upper, "MULTICA_") {
-			if !isExplicit {
+		// Explicit keys are always authorized for this task, so they bypass the
+		// inherited-secret guard even when named like a credential.
+		if !isExplicit {
+			if strings.HasPrefix(upper, "MULTICA_") || codexDefaultExcludesEnvKey(upper) {
 				return
 			}
-		} else if codexDefaultExcludesEnvKey(upper) {
-			return
 		}
 		allowed[upper] = key
 	}

--- a/server/internal/daemon/execenv/codex_shell_env_test.go
+++ b/server/internal/daemon/execenv/codex_shell_env_test.go
@@ -53,11 +53,14 @@ func TestCodexShellEnvAllowlistUsesExactTaskAndSafeInheritedNames(t *testing.T) 
 		"MULTICA_TOKEN":      "mat_task",
 		"MULTICA_SERVER_URL": "https://task.example",
 		"CUSTOM_FLAG":        "enabled",
-		"ANTHROPIC_API_KEY":  "agent-secret",
+		// Explicit custom_env, credential-named: authorized for this task, so it
+		// must be allowlisted even though inherited OPENAI_API_KEY/GH_TOKEN are not.
+		"ANTHROPIC_API_KEY": "agent-secret",
 	}
 
 	got := CodexShellEnvAllowlist(inherited, explicit)
 	want := []string{
+		"ANTHROPIC_API_KEY",
 		"APPDATA",
 		"COMSPEC",
 		"CUSTOM_FLAG",
@@ -75,6 +78,79 @@ func TestCodexShellEnvAllowlistUsesExactTaskAndSafeInheritedNames(t *testing.T) 
 	}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("CodexShellEnvAllowlist() = %#v, want %#v", got, want)
+	}
+}
+
+// Regression for #5601: an agent's explicitly configured custom_env credential
+// (a KEY/SECRET/TOKEN-named value) was dropped from the Codex shell allowlist,
+// so the task shell saw CUSTOM_ENDPOINT but not CUSTOM_ACCESS_TOKEN. Explicit
+// keys must be included regardless of their name; only inherited daemon-process
+// secrets keep Codex's default KEY/SECRET/TOKEN filtering.
+func TestCodexShellEnvAllowlistIncludesExplicitCredentialNames(t *testing.T) {
+	t.Parallel()
+
+	inherited := []string{
+		"PATH=/usr/bin",
+		// Same-shaped names but inherited from the daemon process: stay filtered.
+		"HOST_API_KEY=daemon-secret",
+		"HOST_SECRET=daemon-secret",
+		"HOST_ACCESS_TOKEN=daemon-secret",
+	}
+	explicit := map[string]string{
+		"CUSTOM_ENDPOINT":     "https://example.com",
+		"CUSTOM_ACCESS_TOKEN": "agent-secret",
+		"CUSTOM_API_KEY":      "agent-secret",
+		"CUSTOM_SECRET":       "agent-secret",
+	}
+
+	got := CodexShellEnvAllowlist(inherited, explicit)
+	want := []string{
+		"CUSTOM_ACCESS_TOKEN",
+		"CUSTOM_API_KEY",
+		"CUSTOM_ENDPOINT",
+		"CUSTOM_SECRET",
+		"PATH",
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("CodexShellEnvAllowlist() = %#v, want %#v", got, want)
+	}
+}
+
+// Regression for #5601 at the config layer: the credential-named explicit key
+// must land in the managed include_only that nested shell/worker subprocesses
+// read, while its value never touches config.toml.
+func TestEnsureCodexShellEnvPolicyConfigAllowsExplicitCredentialNameWithoutValue(t *testing.T) {
+	t.Parallel()
+
+	includeOnly := CodexShellEnvAllowlist(
+		[]string{"PATH=/usr/bin"},
+		map[string]string{"CUSTOM_ACCESS_TOKEN": "super-secret-value"},
+	)
+
+	configPath := filepath.Join(t.TempDir(), "config.toml")
+	if err := EnsureCodexShellEnvPolicyConfig(configPath, includeOnly, testLogger()); err != nil {
+		t.Fatalf("EnsureCodexShellEnvPolicyConfig: %v", err)
+	}
+	data, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatalf("read config.toml: %v", err)
+	}
+	s := string(data)
+	assertValidToml(t, s)
+
+	policy := parsedShellEnvPolicy(t, s)
+	found := false
+	for _, k := range policy.IncludeOnly {
+		if k == "CUSTOM_ACCESS_TOKEN" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("include_only missing CUSTOM_ACCESS_TOKEN: %#v", policy.IncludeOnly)
+	}
+	if strings.Contains(s, "super-secret-value") {
+		t.Fatalf("secret value leaked into config.toml:\n%s", s)
 	}
 }
 

--- a/server/internal/daemon/execenv/codex_shell_env_test.go
+++ b/server/internal/daemon/execenv/codex_shell_env_test.go
@@ -116,6 +116,38 @@ func TestCodexShellEnvAllowlistIncludesExplicitCredentialNames(t *testing.T) {
 	}
 }
 
+// Regression for the #5601 follow-up at the config layer: when an explicit
+// custom_env key is a case-variant of an inherited daemon secret, the allowlist
+// must emit only the explicit name — not the inherited secret. include_only
+// matches case-insensitively, so the daemon (buildCodexEnv) drops the inherited
+// case-variant from the process env; here we assert the config side never
+// re-adds it and folds to a single entry.
+func TestCodexShellEnvAllowlistCaseVariantExplicitDropsInheritedSecret(t *testing.T) {
+	t.Parallel()
+
+	got := CodexShellEnvAllowlist(
+		[]string{"PATH=/usr/bin", "HOST_API_KEY=daemon-secret"},
+		map[string]string{"host_api_key": "agent-value"},
+	)
+	want := []string{"host_api_key", "PATH"} // case-insensitive sort: HOST_API_KEY < PATH
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("CodexShellEnvAllowlist() = %#v, want %#v", got, want)
+	}
+	// Exactly one entry folds to HOST_API_KEY, and it is the explicit casing.
+	folded := 0
+	for _, k := range got {
+		if strings.EqualFold(k, "HOST_API_KEY") {
+			folded++
+			if k != "host_api_key" {
+				t.Fatalf("allowlist emitted inherited casing %q, want explicit host_api_key", k)
+			}
+		}
+	}
+	if folded != 1 {
+		t.Fatalf("expected exactly one HOST_API_KEY-folded entry, got %d in %#v", folded, got)
+	}
+}
+
 // Regression for #5601 at the config layer: the credential-named explicit key
 // must land in the managed include_only that nested shell/worker subprocesses
 // read, while its value never touches config.toml.

--- a/server/pkg/agent/codex.go
+++ b/server/pkg/agent/codex.go
@@ -735,7 +735,7 @@ func (b *codexBackend) executeOnce(ctx context.Context, prompt string, opts Exec
 	if opts.Cwd != "" {
 		cmd.Dir = opts.Cwd
 	}
-	cmd.Env = buildEnv(b.cfg.Env)
+	cmd.Env = buildCodexEnv(b.cfg.Env)
 
 	stdout, err := cmd.StdoutPipe()
 	if err != nil {
@@ -1470,6 +1470,36 @@ func appendCodexKnownStderrHint(msg, stderrTail string) string {
 		return msg + "; diagnosis: Codex stderr shows the model catalog refresh timed out. Try setting an explicit model, switching Codex CLI versions, or using another runtime while Codex app-server recovers"
 	}
 	return msg
+}
+
+// buildCodexEnv assembles the Codex child-process environment. Beyond
+// buildEnv's inherited-namespace filtering, it drops any inherited variable
+// whose name case-insensitively collides with an explicitly configured key.
+//
+// Codex matches shell_environment_policy.include_only case-insensitively, and
+// the daemon allowlists explicit custom_env keys by their exact name. On a
+// case-sensitive OS (macOS/Linux) an inherited daemon secret like
+// HOST_API_KEY and an explicit custom_env host_api_key would both survive the
+// case-sensitive parent environment, so the case-insensitive include_only entry
+// for host_api_key would pull the daemon secret HOST_API_KEY into the task
+// shell. Removing the inherited case-variant here keeps the explicit value the
+// only survivor; the folding mirrors the allowlist's (see
+// execenv.CodexShellEnvAllowlist), so the two never disagree.
+func buildCodexEnv(extra map[string]string) []string {
+	explicitFolded := make(map[string]struct{}, len(extra))
+	for k := range extra {
+		explicitFolded[strings.ToUpper(k)] = struct{}{}
+	}
+	inherited := os.Environ()
+	base := make([]string, 0, len(inherited))
+	for _, entry := range inherited {
+		key, _, _ := strings.Cut(entry, "=")
+		if _, collides := explicitFolded[strings.ToUpper(key)]; collides {
+			continue
+		}
+		base = append(base, entry)
+	}
+	return mergeEnv(base, extra)
 }
 
 func detectCodexVersionForDiagnostics(ctx context.Context, execPath string, env []string, logger *slog.Logger) string {

--- a/server/pkg/agent/codex_test.go
+++ b/server/pkg/agent/codex_test.go
@@ -3221,3 +3221,48 @@ func TestHasManagedCodexMcpConfig(t *testing.T) {
 		})
 	}
 }
+
+// TestBuildCodexEnvDropsInheritedCaseCollisionWithExplicitKey is a regression
+// for the #5601 follow-up: on case-sensitive OSes (macOS/Linux) an inherited
+// daemon secret must not ride Codex's case-insensitive
+// shell_environment_policy.include_only into the task shell when an explicit
+// custom_env key shares its case-folded name. buildCodexEnv must drop the
+// inherited case-variant and keep only the explicit value.
+func TestBuildCodexEnvDropsInheritedCaseCollisionWithExplicitKey(t *testing.T) {
+	// buildCodexEnv reads os.Environ(); t.Setenv forbids t.Parallel.
+	t.Setenv("HOST_API_KEY", "daemon-secret")
+	t.Setenv("UNRELATED_INHERITED", "keep-me")
+
+	env := buildCodexEnv(map[string]string{
+		"host_api_key":    "agent-value", // case-variant of the inherited secret
+		"CUSTOM_ENDPOINT": "https://example.com",
+	})
+
+	var hostFolded []string
+	sawExplicit, sawUnrelated := false, false
+	for _, entry := range env {
+		key, val, _ := strings.Cut(entry, "=")
+		if strings.EqualFold(key, "HOST_API_KEY") {
+			hostFolded = append(hostFolded, entry)
+			if val == "daemon-secret" {
+				t.Fatalf("inherited daemon secret leaked into Codex env: %q", entry)
+			}
+		}
+		if key == "host_api_key" && val == "agent-value" {
+			sawExplicit = true
+		}
+		if key == "UNRELATED_INHERITED" && val == "keep-me" {
+			sawUnrelated = true
+		}
+	}
+	if !sawExplicit {
+		t.Fatalf("explicit host_api_key=agent-value missing:\n%s", strings.Join(env, "\n"))
+	}
+	// Exactly one entry folds to HOST_API_KEY — the explicit one.
+	if len(hostFolded) != 1 {
+		t.Fatalf("expected exactly one HOST_API_KEY-folded entry, got %v", hostFolded)
+	}
+	if !sawUnrelated {
+		t.Fatalf("unrelated inherited var was wrongly dropped:\n%s", strings.Join(env, "\n"))
+	}
+}


### PR DESCRIPTION
## What & why

`CodexShellEnvAllowlist` (added in #5415 / v0.4.4) filters every non-`MULTICA_` variable whose name contains `KEY`, `SECRET`, or `TOKEN` — **even when the agent explicitly configured it in `custom_env`**. So a task's Codex shell saw `CUSTOM_ENDPOINT` but lost `CUSTOM_ACCESS_TOKEN`, breaking any task that reads it (`Missing required env: CUSTOM_ACCESS_TOKEN`).

Root cause: the secret guard was applied to explicit keys too. It should only guard variables **inherited from the daemon process** (`os.Environ()`), not keys the agent owner deliberately set.

## Change

`server/internal/daemon/execenv/codex_shell_env.go` — apply the `MULTICA_*` / `KEY`·`SECRET`·`TOKEN` guard only to inherited (non-explicit) variables. Every explicitly configured key (daemon-constructed task value or agent `custom_env`) is now allowlisted regardless of its name.

- Only the **name** enters `include_only`; the value is never written to `config.toml` or logs (logging records `include_count` only).
- Inherited daemon-process secrets keep Codex's default filtering — no leak of daemon credentials.

## Tests

- `TestCodexShellEnvAllowlistIncludesExplicitCredentialNames` — explicit `KEY`/`SECRET`/`TOKEN`-named custom_env keys are included; same-shaped **inherited** daemon secrets stay filtered.
- `TestEnsureCodexShellEnvPolicyConfigAllowsExplicitCredentialNameWithoutValue` — the credential name reaches the managed `include_only` that nested shell/worker subprocesses read, while its value never touches `config.toml`.
- Updated `TestCodexShellEnvAllowlistUsesExactTaskAndSafeInheritedNames` (it encoded the buggy behavior: explicit `ANTHROPIC_API_KEY` was asserted dropped — now included).

Local verification: `go build ./internal/daemon/...`, `go vet`, `gofmt`, full `execenv` package tests, and daemon-package `CustomEnv|ShellEnv|Codex` tests all pass.

Closes #5601
