### PR TITLE
fix(kiro): stop duplicating runtime brief on every ACP turn

### DIFF
--- a/server/internal/daemon/daemon.go
+++ b/server/internal/daemon/daemon.go
@@ -3500,7 +3500,7 @@ func providerDisplayName(name string) string {
 
 func providerNeedsInlineSystemPrompt(provider string) bool {
 	switch provider {
-	case "openclaw", "kiro", "kimi", "traecli":
+	case "openclaw", "kimi", "traecli":
 		return true
 	default:
 		return false
@@ -4398,8 +4398,8 @@ func (d *Daemon) runTask(ctx context.Context, task Task, provider string, slot i
 	//     as a belt-and-suspenders for older openclaw releases until that load
 	//     path stabilises in production; remove this once a release tracks the
 	//     workdir bootstrap reliably end-to-end.
-	//   - kiro and kimi are wrapped through their own CLIs whose cwd handling
-	//     is opaque enough that we can't trust the file-based path either.
+	//   - kimi is wrapped through its own CLI whose cwd handling is opaque
+	//     enough that we can't trust the file-based path either.
 	// Pass the full runtime brief inline (CLI catalog + workflow steps + agent
 	// identity/persona + skills + project context) so the backend prepends the
 	// same payload that file-based runtimes pick up from disk. Without this,
@@ -4407,10 +4407,11 @@ func (d *Daemon) runTask(ctx context.Context, task Task, provider string, slot i
 	// `multica issue status` / `multica issue comment add`, leaving issues
 	// stuck in `todo`.
 	//
-	// Hermes is intentionally excluded: ACP sessions start in the task cwd and
-	// Hermes loads AGENTS.md / .agent_context itself. Prepending the full runtime
-	// brief into the ACP user prompt duplicates that context, bloats every turn,
-	// and has triggered upstream safety filters on harmless tasks.
+	// Hermes and Kiro are intentionally excluded: their ACP sessions start in
+	// the task cwd and load AGENTS.md themselves. Kiro documents root AGENTS.md
+	// as always included, and a real kiro-cli 2.13.0 ACP smoke confirms it.
+	// Prepending the full runtime brief into the ACP user prompt duplicates that
+	// context and bloats every turn.
 	if providerNeedsInlineSystemPrompt(provider) {
 		execOpts.SystemPrompt = runtimeBrief
 	}

--- a/server/internal/daemon/daemon_test.go
+++ b/server/internal/daemon/daemon_test.go
@@ -484,7 +484,9 @@ func TestProviderNeedsInlineSystemPrompt(t *testing.T) {
 		// directly. Inlining the full runtime brief duplicates that context and
 		// can trip upstream provider safety filters on otherwise harmless tasks.
 		{provider: "hermes", want: false},
-		{provider: "kiro", want: true},
+		// Kiro CLI loads a root AGENTS.md in ACP sessions. Inlining the same
+		// runtime brief duplicates it at the start of every user turn.
+		{provider: "kiro", want: false},
 		{provider: "kimi", want: true},
 		{provider: "traecli", want: true},
 		{provider: "codex", want: false},


### PR DESCRIPTION
## Summary

- Remove Kiro from `providerNeedsInlineSystemPrompt`.
- Keep Kiro's existing managed root `AGENTS.md` materialization unchanged.
- Add a regression expectation that Kiro does not inline the same brief into every user turn.

Closes #5604.

## Why

Kiro currently receives the complete runtime brief twice: once through the workdir's `AGENTS.md`, and again because the daemon passes it as `ExecOptions.SystemPrompt`, which the ACP backend prepends to every `session/prompt` user message.

Kiro's current documentation states that a workspace-root `AGENTS.md` is always included. I also verified this with `kiro-cli 2.13.0` through Multica's real ACP backend: with `ExecOptions.Cwd` set, no inline `SystemPrompt`, and a nonce only in root `AGENTS.md`, Kiro returned the nonce correctly.

The original inline opt-in in #2328 was precautionary ("ahead of any field report") and its real Kiro deployment verification was left unchecked. On the current native ACP path, the fallback now creates deterministic prompt duplication and recurring token cost.

Official reference: https://kiro.dev/docs/cli/steering/#agentsmd

## Scope

This is intentionally Kiro-only. OpenClaw, Kimi, and Trae CLI retain their existing inline behavior. No Kiro session, model, tool, or skill behavior changes.

## Test plan

- [x] `go test ./internal/daemon -run TestProviderNeedsInlineSystemPrompt -count=1`
- [x] `go test ./internal/daemon/execenv -run 'TestInjectRuntimeConfigByProvider|TestCleanupRuntimeConfigByProvider' -count=1`
- [x] `go test ./pkg/agent -run 'TestKiro' -count=1`
- [x] Real `kiro-cli 2.13.0` ACP smoke confirms root `AGENTS.md` is loaded with no inline system prompt.
