### PR TITLE
fix(settings): restore mounted flag on remount so auto-save can settle (MUL-4962)

### DIFF
--- a/packages/views/settings/components/use-auto-save.test.tsx
+++ b/packages/views/settings/components/use-auto-save.test.tsx
@@ -1,3 +1,4 @@
+import { StrictMode } from "react";
 import { act, render, waitFor } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { useAutoSave } from "./use-auto-save";
@@ -51,6 +52,23 @@ describe("useAutoSave success feedback", () => {
       expect(onSave).toHaveBeenCalledWith("saved");
       expect(onSuccess).toHaveBeenCalledWith("saved");
     });
+  });
+
+  it("still reports success under StrictMode's double-invoked mount", async () => {
+    // StrictMode runs setup/cleanup/setup on mount. A mount effect that only
+    // clears the mounted flag in cleanup leaves it false for the component's
+    // life, so a successful save is silently dropped: neither the "saved"
+    // status nor onSuccess ever fires and the indicator spins forever.
+    const onSave = vi.fn(async () => undefined);
+    const onSuccess = vi.fn();
+    render(
+      <StrictMode>
+        <AutoSaveHarness value="saved" onSave={onSave} onSuccess={onSuccess} />
+      </StrictMode>,
+    );
+
+    await waitFor(() => expect(onSave).toHaveBeenCalledWith("saved"));
+    await waitFor(() => expect(onSuccess).toHaveBeenCalledWith("saved"));
   });
 
   it("waits for the latest queued value before reporting success", async () => {

--- a/packages/views/settings/components/use-auto-save.ts
+++ b/packages/views/settings/components/use-auto-save.ts
@@ -131,13 +131,16 @@ export function useAutoSave<T>({
     };
   }, [delay, enabled, isEqual, runSave, value]);
 
-  useEffect(
-    () => () => {
+  useEffect(() => {
+    // Restore the invariant on every mount. Under React StrictMode the initial
+    // setup/cleanup/setup cycle would otherwise leave mountedRef pinned to false
+    // for the component's whole life, stranding status at "saving".
+    mountedRef.current = true;
+    return () => {
       mountedRef.current = false;
       if (timerRef.current) clearTimeout(timerRef.current);
-    },
-    [],
-  );
+    };
+  }, []);
 
   return { status, flush, saveNow };
 }


### PR DESCRIPTION
## What does this PR do?

Fixes the shared settings auto-save indicator getting stranded on "Saving…" forever, even though the save succeeded.

The `useAutoSave` mount effect (`packages/views/settings/components/use-auto-save.ts`) only cleared `mountedRef` in its cleanup and never re-set it to `true` on setup. Under React StrictMode (the Next.js dev default), the initial **setup → cleanup → setup** cycle leaves `mountedRef.current` pinned to `false` for the component's whole life. A successful save then never reaches its terminal branch (`succeeded && mountedRef.current`), so `setStatus("saved")` and `onSuccess` never fire — the indicator spins forever and no success toast appears, even though `PATCH /api/workspaces/{id}` returned 200.

The fix restores the invariant by setting `mountedRef.current = true` on every mount. This is the standard mounted-ref pattern and keeps the flag reflecting the live component across StrictMode's simulated remount (and any genuine remount).

Shared by all auto-saved settings surfaces (Repositories, GitHub, etc.), so this fixes the whole set.

## Related Issue

Closes #5612

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Refactor / code improvement (no behavior change)
- [ ] Documentation update
- [ ] Tests (adding or improving test coverage)
- [ ] CI / infrastructure

## Changes Made

- `packages/views/settings/components/use-auto-save.ts`: set `mountedRef.current = true` in the mount effect's setup so StrictMode's setup/cleanup/setup cycle no longer strands the flag at `false`.
- `packages/views/settings/components/use-auto-save.test.tsx`: add a StrictMode regression test asserting a successful save still transitions to success (`onSuccess` fires).

## How to Test

1. Before the fix: run the web app in dev, go to **Settings → Code repositories**, add a repo URL and blur. The `PATCH /api/workspaces/{id}` returns 200 but the indicator stays on "Saving…" indefinitely.
2. After the fix: the indicator transitions to "Saved" and the success toast fires.
3. Automated: `pnpm --filter @multica/views test -- use-auto-save`. The added StrictMode test fails on the old code and passes with the fix.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [x] I have updated relevant documentation to reflect my changes
- [x] If I added a new runtime / coding tool / UI tab, I synced the change to landing copy and relevant docs
- [ ] If this PR touches Chinese product copy, I checked it against conventions.zh.mdx
- [x] I have considered and documented any risks above
- [x] I will address all reviewer comments before requesting merge

## AI Disclosure

**AI tool used:** Claude Code

**Prompt / approach:** Started from a user-reported "Saving… spins forever" bug with a screenshot. Traced the auto-save state machine end to end, confirmed via DevTools that the PATCH returned 200 (ruling out a hung request), then pinpointed the broken mounted-ref pattern that only misfires under StrictMode's double-invoked mount. Wrote a failing StrictMode regression test first, verified it fails on the old code and passes with the one-line invariant fix.
