### PR TITLE
fix(agents): reset model and thinking level on runtime change (MUL-4963)

### DIFF
--- a/packages/views/agents/components/agent-creation-studio.tsx
+++ b/packages/views/agents/components/agent-creation-studio.tsx
@@ -1098,7 +1098,11 @@ function ConfigurationPanel({
               members={members}
               currentUserId={currentUserId}
               selectedRuntimeId={draft.runtimeId}
-              onSelect={(id) => set("runtimeId", id)}
+              onSelect={(id) => {
+                // Model is per-runtime; clear it on runtime change so the new
+                // runtime resolves its own default instead of a stale value.
+                if (id !== draft.runtimeId) onChange({ ...draft, runtimeId: id, model: "" });
+              }}
             />
             <ModelDropdown
               runtimeId={selectedRuntime?.id ?? null}
@@ -1248,7 +1252,7 @@ function DraftFieldRow({
 function BuilderSetup({ draft, onChange, runtimes, runtimesLoading, members, currentUserId, selectedRuntime, starting, error, onStart, onConnectRuntime }: { draft: AgentDraft; onChange: (draft: AgentDraft) => void; runtimes: RuntimeDevice[]; runtimesLoading: boolean; members: MemberWithUser[]; currentUserId: string | null; selectedRuntime: RuntimeDevice | null; starting: boolean; error: string | null; onStart: () => void; onConnectRuntime: () => void; }) {
   const { t } = useT("agents");
   const hasOnline = runtimes.some((runtime) => runtime.status === "online" && isRuntimeUsableForUser(runtime, currentUserId));
-  return <main className="flex min-h-0 flex-1 items-center justify-center overflow-y-auto px-5 py-10"><div className="w-full max-w-xl rounded-xl border bg-card p-6 shadow-sm"><span className="flex size-11 items-center justify-center rounded-lg bg-primary/10 text-primary"><MessageSquare className="size-5" /></span><h2 className="mt-5 text-xl font-semibold">{t(($) => $.creation_studio.builder.setup_title)}</h2><p className="mt-2 text-sm leading-6 text-muted-foreground">{t(($) => $.creation_studio.builder.setup_description)}</p><div className="mt-6 space-y-4"><RuntimePicker runtimes={runtimes} runtimesLoading={runtimesLoading} members={members} currentUserId={currentUserId} selectedRuntimeId={draft.runtimeId} onSelect={(runtimeId) => onChange({ ...draft, runtimeId })} /><ModelDropdown runtimeId={selectedRuntime?.id ?? null} runtimeOnline={selectedRuntime?.status === "online"} value={draft.model} onChange={(model) => onChange({ ...draft, model })} disabled={!selectedRuntime} /></div>{error && <div role="alert" className="mt-4 text-sm text-destructive">{error}</div>}<div className="mt-6 flex justify-end">{hasOnline ? <Button onClick={onStart} disabled={starting || selectedRuntime?.status !== "online"}>{starting && <Loader2 className="size-4 animate-spin" />}{t(($) => $.creation_studio.builder.start)}</Button> : <Button onClick={onConnectRuntime}>{t(($) => $.creation_studio.builder.connect_runtime)}</Button>}</div></div></main>;
+  return <main className="flex min-h-0 flex-1 items-center justify-center overflow-y-auto px-5 py-10"><div className="w-full max-w-xl rounded-xl border bg-card p-6 shadow-sm"><span className="flex size-11 items-center justify-center rounded-lg bg-primary/10 text-primary"><MessageSquare className="size-5" /></span><h2 className="mt-5 text-xl font-semibold">{t(($) => $.creation_studio.builder.setup_title)}</h2><p className="mt-2 text-sm leading-6 text-muted-foreground">{t(($) => $.creation_studio.builder.setup_description)}</p><div className="mt-6 space-y-4"><RuntimePicker runtimes={runtimes} runtimesLoading={runtimesLoading} members={members} currentUserId={currentUserId} selectedRuntimeId={draft.runtimeId} onSelect={(runtimeId) => { if (runtimeId !== draft.runtimeId) onChange({ ...draft, runtimeId, model: "" }); }} /><ModelDropdown runtimeId={selectedRuntime?.id ?? null} runtimeOnline={selectedRuntime?.status === "online"} value={draft.model} onChange={(model) => onChange({ ...draft, model })} disabled={!selectedRuntime} /></div>{error && <div role="alert" className="mt-4 text-sm text-destructive">{error}</div>}<div className="mt-6 flex justify-end">{hasOnline ? <Button onClick={onStart} disabled={starting || selectedRuntime?.status !== "online"}>{starting && <Loader2 className="size-4 animate-spin" />}{t(($) => $.creation_studio.builder.start)}</Button> : <Button onClick={onConnectRuntime}>{t(($) => $.creation_studio.builder.connect_runtime)}</Button>}</div></div></main>;
 }
 
 function BuilderConversation({

--- a/packages/views/agents/components/agent-detail-inspector.tsx
+++ b/packages/views/agents/components/agent-detail-inspector.tsx
@@ -220,7 +220,13 @@ export function AgentDetailInspector({
               members={members}
               currentUserId={currentUserId}
               canEdit={canEdit}
-              onChange={(id) => update({ runtime_id: id })}
+              // Model and thinking level are per-runtime/per-model; clear both
+              // so the new runtime resolves its own defaults instead of keeping
+              // values it may not support (a stale thinking level would linger
+              // as an orphan token otherwise).
+              onChange={(id) =>
+                update({ runtime_id: id, model: "", thinking_level: "" })
+              }
             />
           </SettingsRow>
           <SettingsRow

--- a/packages/views/agents/components/create-agent-dialog.tsx
+++ b/packages/views/agents/components/create-agent-dialog.tsx
@@ -422,7 +422,12 @@ export function CreateAgentDialog({
               members={members}
               currentUserId={currentUserId}
               selectedRuntimeId={selectedRuntimeId}
-              onSelect={setSelectedRuntimeId}
+              onSelect={(id) => {
+                // Models are per-runtime; a value picked for the old runtime
+                // may not exist on the new one, so drop it on runtime change.
+                if (id !== selectedRuntimeId) setModel("");
+                setSelectedRuntimeId(id);
+              }}
             />
 
             <ModelDropdown


### PR DESCRIPTION
## What does this PR do?

Models are advertised **per-runtime** (each runtime exposes its own catalog through `runtimeModelsOptions`). The runtime pickers' `onSelect`/`onChange` handlers updated only the runtime and left the previously selected model in place, so switching runtime could leave an agent configured with a model the new runtime does not serve. In the detail inspector the same applies to the model-dependent **thinking level**, which lingers as an orphan token after a runtime switch.

This PR clears the dependent fields when the runtime actually changes, so the new runtime resolves its own default.

## Related Issue

Closes #5614

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `packages/views/agents/components/create-agent-dialog.tsx` — reset `model` on runtime change.
- `packages/views/agents/components/agent-creation-studio.tsx` — reset `model` on runtime change in both the main config panel and the AI-builder setup step.
- `packages/views/agents/components/agent-detail-inspector.tsx` — clear `model` **and** `thinking_level` in the same update when the runtime changes.

Each handler guards on an actual runtime change (`id !== current`), so unrelated re-renders and the duplicate/prefill flows keep their values. The inspector's runtime picker already fires `onChange` only on a real change and persists via one optimistic `update({...})`, so both fields flip together.

Note: switching the **model** directly (without changing runtime) intentionally keeps the persisted thinking level so an unsupported value is surfaced as an orphan token for the user to clear, matching the existing `ThinkingPropRow` behavior. This PR only resets on **runtime** change.

## How to Test

1. Open **Create agent** (dialog or studio). Select runtime A, pick a specific model, then switch to runtime B — the model field resets instead of keeping A's model.
2. Edit an existing agent in the inspector: with a model and a thinking level set, switch the runtime — both the model and the thinking level reset.
3. Duplicate an agent whose runtime is still usable — the prefilled runtime/model are preserved (no spurious reset).

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [ ] I have run tests locally and they pass
- [ ] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [ ] I have updated relevant documentation to reflect my changes
- [ ] If I added a new runtime / coding tool / UI tab, I synced the change to **landing copy** and **relevant docs**
- [ ] If this PR touches Chinese product copy, I checked it against `conventions.zh.mdx`
- [x] I have considered and documented any risks above
- [x] I will address all reviewer comments before requesting merge

Notes on the unchecked items: no new tests were added (behavioral change in inline handlers, no existing unit coverage for these pickers); `pnpm --filter @multica/views typecheck` passes. No docs or product copy are affected. Screenshots omitted as the change has no visual surface — it only resets field values on runtime change.

## AI Disclosure

**AI tool used:** Claude Code

**Prompt / approach:** Located the three runtime/model picker surfaces, confirmed models are fetched per-runtime, then reset the dependent model (and inspector thinking level) in each `onSelect`/`onChange` guarded on an actual runtime change. Verified with a package typecheck.
