### PR TITLE
feat(agents): default runtime picker to the scope with a usable runtime

### DIFF
--- a/packages/views/agents/components/agent-creation-studio.tsx
+++ b/packages/views/agents/components/agent-creation-studio.tsx
@@ -154,6 +154,7 @@ export function AgentCreationStudio() {
     content: string;
   } | null>(null);
   const duplicateAppliedRef = useRef(false);
+  const runtimeSeededRef = useRef(false);
   const appliedAssistantMessageRef = useRef<string | null>(null);
   const builderSessionIdRef = useRef("");
 
@@ -283,8 +284,15 @@ export function AgentCreationStudio() {
     [builderModelCatalog],
   );
 
+  // Seed a default runtime once, when usable runtimes first become available.
+  // This is a one-shot: after the initial seed, selection is owned by the
+  // RuntimePicker (scope-aware). Re-seeding on every empty draft.runtimeId
+  // would fight the picker — clearing the selection on a Mine/All switch to an
+  // empty scope would be immediately overridden, leaving a stale trigger.
   useEffect(() => {
-    if (draft.runtimeId || usableRuntimes.length === 0) return;
+    if (runtimeSeededRef.current || usableRuntimes.length === 0) return;
+    runtimeSeededRef.current = true;
+    if (draft.runtimeId) return;
     setDraft((current) => ({ ...current, runtimeId: usableRuntimes[0]?.id ?? "" }));
   }, [draft.runtimeId, usableRuntimes]);
 

--- a/packages/views/agents/components/inspector/runtime-picker.test.tsx
+++ b/packages/views/agents/components/inspector/runtime-picker.test.tsx
@@ -153,13 +153,16 @@ describe("RuntimePicker (agent settings)", () => {
     openPicker();
     fireEvent.click(screen.getByRole("button", { name: "Back to machines" }));
 
-    // Mine scope: only my machine, with its online count.
+    // The picker defaults to Mine when "mine" has a runtime
+    // (here rt-claude), so only my machine lists up front; the All fallback
+    // only kicks in when Mine would be empty.
     expect(
       screen.getByRole("button", { name: /^Jiayuan's MacBook Pro/ }),
     ).toBeTruthy();
     expect(screen.getByText("2/2 online")).toBeTruthy();
     expect(screen.queryByRole("button", { name: /^other\.local/ })).toBeNull();
 
+    // All scope: every machine lists, including other members'.
     fireEvent.click(screen.getByRole("button", { name: "All" }));
     expect(
       screen.getByRole("button", { name: /^other\.local/ }),
@@ -242,4 +245,106 @@ describe("RuntimePicker (agent settings)", () => {
     expect(screen.getByRole("button", { name: /^Claude/ })).toBeTruthy();
     expect(screen.getByRole("button", { name: /^Codex/ })).toBeTruthy();
   });
+});
+
+// The default scope is a pure function of three independent inputs: do I own a
+// runtime, does another member expose a *pickable* (public) one, and is another
+// member's runtime present but locked (private). "Usable" == pickable: a locked
+// private runtime never counts toward All. This covers the full 2×2×2 product.
+describe("RuntimePicker default scope (mine/all derivation)", () => {
+  // Open the picker and normalise to the machine list — the picker auto-drills
+  // into a lone machine, so step back out when it does — then report the active
+  // scope. "none" means the scope toggle isn't rendered (no other member's
+  // runtime exists to scope against).
+  function openToMachineList(): "mine" | "all" | "none" {
+    fireEvent.click(screen.getByRole("button", { name: /^Runtime · / }));
+    const back = screen.queryByRole("button", { name: "Back to machines" });
+    if (back) fireEvent.click(back);
+    const mine = screen.queryByRole("button", { name: "Mine" });
+    const all = screen.queryByRole("button", { name: "All" });
+    if (!mine || !all) return "none";
+    return mine.className.includes("bg-background") ? "mine" : "all";
+  }
+
+  const MINE_MACHINE = /^Jiayuan's MacBook Pro/;
+  const PUBLIC_MACHINE = /^other\.local/;
+  const PRIVATE_MACHINE = /^secret\.local/;
+
+  const cases: {
+    name: string;
+    runtimes: RuntimeDevice[];
+    scope: "mine" | "all" | "none";
+    visible: RegExp[];
+    hidden: RegExp[];
+  }[] = [
+    {
+      name: "no runtimes → mine, no toggle, empty list",
+      runtimes: [],
+      scope: "none",
+      visible: [],
+      hidden: [MINE_MACHINE, PUBLIC_MACHINE, PRIVATE_MACHINE],
+    },
+    {
+      name: "mine only → mine, no toggle, my machine lists",
+      runtimes: [RT_CLAUDE],
+      scope: "none",
+      visible: [MINE_MACHINE],
+      hidden: [PUBLIC_MACHINE, PRIVATE_MACHINE],
+    },
+    {
+      name: "others' public only → all, their pickable machine lists",
+      runtimes: [RT_OTHER_PUBLIC],
+      scope: "all",
+      visible: [PUBLIC_MACHINE],
+      hidden: [MINE_MACHINE, PRIVATE_MACHINE],
+    },
+    {
+      name: "others' private only → mine, empty (locked machine hidden)",
+      runtimes: [RT_OTHER_PRIVATE],
+      scope: "mine",
+      visible: [],
+      hidden: [MINE_MACHINE, PUBLIC_MACHINE, PRIVATE_MACHINE],
+    },
+    {
+      name: "others' public + private → all, both machines list",
+      runtimes: [RT_OTHER_PUBLIC, RT_OTHER_PRIVATE],
+      scope: "all",
+      visible: [PUBLIC_MACHINE, PRIVATE_MACHINE],
+      hidden: [MINE_MACHINE],
+    },
+    {
+      name: "mine + others' public → mine, others hidden in mine scope",
+      runtimes: [RT_CLAUDE, RT_OTHER_PUBLIC],
+      scope: "mine",
+      visible: [MINE_MACHINE],
+      hidden: [PUBLIC_MACHINE, PRIVATE_MACHINE],
+    },
+    {
+      name: "mine + others' private → mine, locked machine hidden",
+      runtimes: [RT_CLAUDE, RT_OTHER_PRIVATE],
+      scope: "mine",
+      visible: [MINE_MACHINE],
+      hidden: [PUBLIC_MACHINE, PRIVATE_MACHINE],
+    },
+    {
+      name: "mine + others' public + private → mine, others hidden",
+      runtimes: [RT_CLAUDE, RT_OTHER_PUBLIC, RT_OTHER_PRIVATE],
+      scope: "mine",
+      visible: [MINE_MACHINE],
+      hidden: [PUBLIC_MACHINE, PRIVATE_MACHINE],
+    },
+  ];
+
+  for (const c of cases) {
+    it(c.name, () => {
+      renderPicker({ value: "", runtimes: c.runtimes });
+      expect(openToMachineList()).toBe(c.scope);
+      for (const re of c.visible) {
+        expect(screen.getByRole("button", { name: re })).toBeTruthy();
+      }
+      for (const re of c.hidden) {
+        expect(screen.queryByRole("button", { name: re })).toBeNull();
+      }
+    });
+  }
 });

--- a/packages/views/agents/components/inspector/runtime-picker.tsx
+++ b/packages/views/agents/components/inspector/runtime-picker.tsx
@@ -61,7 +61,9 @@ export function RuntimePicker({
 }) {
   const { t } = useT("agents");
   const [open, setOpen] = useState(false);
-  const [filter, setFilter] = useState<Filter>("mine");
+  // null = the user hasn't toggled the scope yet; the default is derived below
+  // from what's actually usable.
+  const [userFilter, setUserFilter] = useState<Filter | null>(null);
   // Level 2 target. `null` shows the machine list; a machine id shows that
   // machine's runtimes. Falls back to the machine list at render time when
   // the id no longer resolves (e.g. the daemon was GC'd over WS).
@@ -74,6 +76,15 @@ export function RuntimePicker({
     if (r.owner_id === currentUserId) return false;
     return r.visibility !== "public";
   };
+
+  // Default to "mine"; fall back to "all" only when "mine" has
+  // no usable runtime but "all" does — so the tab never opens on an empty or
+  // all-locked list.
+  const mineHasUsable =
+    !!currentUserId && runtimes.some((r) => r.owner_id === currentUserId);
+  const allHasUsable = runtimes.some((r) => !isDisabled(r));
+  const filter: Filter =
+    userFilter ?? (!mineHasUsable && allHasUsable ? "all" : "mine");
 
   // Machine grouping over the unfiltered list — resolves the selected
   // runtime's machine for the trigger label regardless of the Mine/All
@@ -201,7 +212,7 @@ export function RuntimePicker({
         selected && currentUserId && selected.owner_id !== currentUserId
           ? "all"
           : filter;
-      setFilter(nextFilter);
+      setUserFilter(nextFilter);
       const visible =
         nextFilter === "mine" && currentUserId
           ? buildRuntimeMachines(
@@ -334,13 +345,13 @@ export function RuntimePicker({
             <div className="flex items-center gap-0.5 rounded-md bg-muted p-0.5">
               <FilterButton
                 active={filter === "mine"}
-                onClick={() => setFilter("mine")}
+                onClick={() => setUserFilter("mine")}
               >
                 {t(($) => $.scope.mine)}
               </FilterButton>
               <FilterButton
                 active={filter === "all"}
-                onClick={() => setFilter("all")}
+                onClick={() => setUserFilter("all")}
               >
                 {t(($) => $.scope.all)}
               </FilterButton>

--- a/packages/views/agents/components/runtime-picker.tsx
+++ b/packages/views/agents/components/runtime-picker.tsx
@@ -43,7 +43,9 @@ export function RuntimePicker({
 }) {
   const { t } = useT("agents");
   const [open, setOpen] = useState(false);
-  const [filter, setFilter] = useState<RuntimeFilter>("mine");
+  // null = the user hasn't toggled the scope yet; the default is derived below
+  // from what's actually usable.
+  const [userFilter, setUserFilter] = useState<RuntimeFilter | null>(null);
   const [search, setSearch] = useState("");
 
   const getOwnerMember = (ownerId: string | null) => {
@@ -52,6 +54,16 @@ export function RuntimePicker({
   };
 
   const hasOtherRuntimes = runtimes.some((r) => r.owner_id !== currentUserId);
+  // Default to "mine"; fall back to "all" only when "mine" has
+  // no usable runtime but "all" does — so the tab never opens on an empty or
+  // all-locked list.
+  const mineHasUsable =
+    !!currentUserId && runtimes.some((r) => r.owner_id === currentUserId);
+  const allHasUsable = runtimes.some((r) =>
+    isRuntimeUsableForUser(r, currentUserId),
+  );
+  const filter: RuntimeFilter =
+    userFilter ?? (!mineHasUsable && allHasUsable ? "all" : "mine");
 
   // Base list honours the mine/all toggle and drives auto-selection; it is
   // intentionally independent of the search box so typing never changes the
@@ -94,7 +106,7 @@ export function RuntimePicker({
   // effect above is a no-op in that case (correct: no usable item to pick).
   const handleFilterChange = (next: RuntimeFilter) => {
     if (next === filter) return;
-    setFilter(next);
+    setUserFilter(next);
     const nextList = computeFilteredRuntimes(runtimes, next, currentUserId);
     const firstUsable = nextList.find((r) =>
       isRuntimeUsableForUser(r, currentUserId),


### PR DESCRIPTION
## What

The runtime picker's `Mine` / `All` scope tab always defaulted to **Mine**. In a multi-member workspace, a user who has no runtime of their own opens the picker on an empty Mine tab — even when a teammate exposes a **public, pickable** runtime under All.

## Change

Derive the initial scope from what's actually usable instead of hard-coding `"mine"`:

- Default to **Mine**.
- Fall back to **All** only when Mine has no usable runtime **and** All has one.
- A locked (private) runtime owned by another member is **not pickable**, so it never triggers the fallback — the tab never opens on an empty or all-locked list.
- Once the user toggles the scope, their explicit choice takes over (`userFilter` overrides the derived default).

Applies to both surfaces that render the scope tab:
- `agents/components/inspector/runtime-picker.tsx` (agent-settings inspector)
- `agents/components/runtime-picker.tsx` (create-agent dialog)

## Tests

Adds a table-driven test covering the full `mine × others-public × others-private` (2×2×2) matrix of the default-scope derivation, asserting both the active scope and which machines list up front.

## Verification

- `pnpm --filter @multica/views typecheck` — clean
- `pnpm --filter @multica/views exec vitest run agents/components/inspector/runtime-picker.test.tsx` — 16 passed
