### PR TITLE
Fix daemon HTTP recovery on macOS

### DIFF
--- a/server/internal/daemon/client.go
+++ b/server/internal/daemon/client.go
@@ -119,11 +119,31 @@ type Client struct {
 func NewClient(baseURL string) *Client {
 	return &Client{
 		baseURL:      baseURL,
-		client:       &http.Client{Timeout: 30 * time.Second, Transport: cloneDefaultTransport()},
+		client:       newControlPlaneHTTPClient(runtime.GOOS),
 		bundleClient: &http.Client{},
 		platform:     "daemon",
 		os:           normalizeGOOS(runtime.GOOS),
 	}
+}
+
+func newControlPlaneHTTPClient(goos string) *http.Client {
+	return &http.Client{
+		Timeout:   30 * time.Second,
+		Transport: newControlPlaneTransport(goos),
+	}
+}
+
+func newControlPlaneTransport(goos string) http.RoundTripper {
+	transport := cloneDefaultTransport()
+	if transport, ok := transport.(*http.Transport); ok && goos == "darwin" {
+		// macOS self-hosted LAN setups have shown poisoned keep-alive pools
+		// after the daemon's initial registration burst. Avoid reusing
+		// control-plane sockets there; bundle downloads keep their separate
+		// long-lived client.
+		transport.DisableKeepAlives = true
+		return transport
+	}
+	return transport
 }
 
 func cloneDefaultTransport() http.RoundTripper {
@@ -140,7 +160,13 @@ func (c *Client) CloseIdleConnections() {
 	if c == nil || c.client == nil {
 		return
 	}
-	c.client.CloseIdleConnections()
+	closeIdleConnections(c.client)
+}
+
+func closeIdleConnections(client *http.Client) {
+	if client != nil {
+		client.CloseIdleConnections()
+	}
 }
 
 // normalizeGOOS maps Go's runtime.GOOS values to the protocol vocabulary
@@ -539,6 +565,7 @@ func (c *Client) ListWorkspaces(ctx context.Context) ([]WorkspaceInfo, error) {
 
 	resp, err := c.client.Do(req)
 	if err != nil {
+		closeIdleConnections(c.client)
 		return nil, err
 	}
 	defer resp.Body.Close()
@@ -954,6 +981,7 @@ func (c *Client) postJSONVia(ctx context.Context, httpClient *http.Client, path 
 
 	resp, err := httpClient.Do(req)
 	if err != nil {
+		closeIdleConnections(httpClient)
 		return err
 	}
 	defer resp.Body.Close()
@@ -981,6 +1009,7 @@ func (c *Client) getJSON(ctx context.Context, path string, respBody any) error {
 
 	resp, err := c.client.Do(req)
 	if err != nil {
+		closeIdleConnections(c.client)
 		return err
 	}
 	defer resp.Body.Close()

--- a/server/internal/daemon/client_test.go
+++ b/server/internal/daemon/client_test.go
@@ -100,6 +100,60 @@ func TestClient_VersionOmittedWhenUnset(t *testing.T) {
 	}
 }
 
+func TestControlPlaneTransportDisablesKeepAlivesOnDarwin(t *testing.T) {
+	transport, ok := newControlPlaneTransport("darwin").(*http.Transport)
+	if !ok {
+		t.Fatalf("control-plane transport = %T, want *http.Transport", transport)
+	}
+	if !transport.DisableKeepAlives {
+		t.Fatal("darwin control-plane transport must disable keep-alives")
+	}
+}
+
+func TestControlPlaneTransportKeepsDefaultReuseOffDarwin(t *testing.T) {
+	transport, ok := newControlPlaneTransport("linux").(*http.Transport)
+	if !ok {
+		t.Fatalf("control-plane transport = %T, want *http.Transport", transport)
+	}
+	if transport.DisableKeepAlives {
+		t.Fatal("non-darwin control-plane transport should preserve default keep-alive reuse")
+	}
+}
+
+func TestPostJSONClosesIdleConnectionsOnTransportError(t *testing.T) {
+	transport := &closeCountingTransport{}
+	c := NewClient("http://daemon.test")
+	c.client = &http.Client{
+		Timeout:   time.Second,
+		Transport: transport,
+	}
+
+	err := c.postJSON(context.Background(), "/api/daemon/test", map[string]any{}, nil)
+	if err == nil {
+		t.Fatal("expected transport error, got nil")
+	}
+	if got := transport.closeCount.Load(); got != 1 {
+		t.Fatalf("CloseIdleConnections calls = %d, want 1", got)
+	}
+}
+
+func TestGetJSONClosesIdleConnectionsOnTransportError(t *testing.T) {
+	transport := &closeCountingTransport{}
+	c := NewClient("http://daemon.test")
+	c.client = &http.Client{
+		Timeout:   time.Second,
+		Transport: transport,
+	}
+
+	err := c.getJSON(context.Background(), "/api/daemon/test", nil)
+	if err == nil {
+		t.Fatal("expected transport error, got nil")
+	}
+	if got := transport.closeCount.Load(); got != 1 {
+		t.Fatalf("CloseIdleConnections calls = %d, want 1", got)
+	}
+}
+
 func TestClient_ListWorkspacesUsesDaemonEndpointAndETag(t *testing.T) {
 	var calls atomic.Int32
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/server/internal/daemon/wakeup_test.go
+++ b/server/internal/daemon/wakeup_test.go
@@ -492,7 +492,7 @@ func TestShouldResetTaskWakeupBackoffRequiresStableConnection(t *testing.T) {
 	}
 }
 
-func TestRuntimeHeartbeatClosesIdleConnectionsAfterRepeatedTransientFailures(t *testing.T) {
+func TestRuntimeHeartbeatClosesIdleConnectionsAfterTransientFailure(t *testing.T) {
 	transport := &closeCountingTransport{}
 	client := NewClient("http://daemon.test")
 	client.client = &http.Client{
@@ -526,8 +526,8 @@ func TestRuntimeHeartbeatClosesIdleConnectionsAfterRepeatedTransientFailures(t *
 	case <-time.After(time.Second):
 		t.Fatal("runRuntimeHeartbeat did not stop after context cancellation")
 	}
-	if got := transport.roundTrips.Load(); got < 2 {
-		t.Fatalf("RoundTrip count = %d, want at least 2", got)
+	if got := transport.roundTrips.Load(); got < 1 {
+		t.Fatalf("RoundTrip count = %d, want at least 1", got)
 	}
 }
 


### PR DESCRIPTION
<!-- multica-auto-bugfix -->

## What does this PR do?

Fixes daemon control-plane HTTP recovery for GitHub #1100 / ZIC-98. The daemon now avoids keep-alive reuse for macOS control-plane requests, and it clears idle connections whenever a transport-level request failure occurs so subsequent claim, heartbeat, and related daemon API calls do not keep using a stale or poisoned connection pool.

## Related Issue

Closes #1100

Multica issue: ZIC-98

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Refactor / code improvement (no behavior change)
- [x] Tests (adding or improving test coverage)
- [ ] CI / infrastructure

## Changes Made

- Updated `server/internal/daemon/client.go` to build a dedicated control-plane HTTP client and disable keep-alive reuse on Darwin.
- Added shared idle-connection cleanup on transport-level failures from daemon POST/GET/workspace-list calls.
- Added focused tests for Darwin transport policy and request-error cleanup, and updated the heartbeat cleanup test to match the new shared recovery point.

## How to Test

1. `git diff --check`
2. `cd server && go test ./internal/daemon`
3. `make check-worktree`

Note: `make check-worktree` exited 0 and printed "✓ All checks passed.", but also emitted `Cannot connect to the Docker daemon at unix:///Users/icezero/.docker/run/docker.sock` while checking PostgreSQL.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] If this change affects the UI, I have included before/after screenshots (N/A, no UI)
- [x] I have updated relevant documentation to reflect my changes (N/A, code/test-only)
- [x] If I added a new runtime / coding tool / UI tab, I synced the change to **landing copy** (`apps/web/features/landing/i18n/`) and **relevant docs** (`apps/docs/content/docs/`) (N/A)
- [x] If this PR touches Chinese product copy, I checked it against `apps/docs/content/docs/developers/conventions.zh.mdx` (terminology, mixed-rule for `task` / `issue` / `skill`) (N/A)
- [x] I have considered and documented any risks above
- [x] I will address all reviewer comments before requesting merge

## AI Disclosure

**AI tool used:** Multica Agent

**Prompt / approach:**
Traced the daemon HTTP client, heartbeat, and claim paths from GitHub #1100. The fix keeps non-Darwin default pooling behavior, avoids macOS control-plane keep-alive reuse, and clears idle connections after transport-level request failures without retrying non-idempotent daemon calls immediately.

## Screenshots (optional)

N/A
