### PR TITLE
Fix project detail mobile panel layout crash

### DIFF
--- a/packages/views/projects/components/project-detail.test.tsx
+++ b/packages/views/projects/components/project-detail.test.tsx
@@ -1,0 +1,272 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { Project } from "@multica/core/types";
+
+import { ProjectDetail } from "./project-detail";
+
+const mocks = vi.hoisted(() => ({
+  isMobile: true,
+  project: {
+    id: "project-1",
+    workspace_id: "workspace-1",
+    title: "Launch Plan",
+    description: null,
+    icon: null,
+    status: "in_progress",
+    priority: "high",
+    lead_type: null,
+    lead_id: null,
+    start_date: null,
+    due_date: null,
+    created_at: "2026-06-01T00:00:00Z",
+    updated_at: "2026-06-01T00:00:00Z",
+    issue_count: 0,
+    done_count: 0,
+    resource_count: 0,
+  } as Project,
+  onLayoutChanged: vi.fn(),
+  panelGroupProps: [] as any[],
+  updateProject: vi.fn(),
+  deleteProject: vi.fn(),
+  createPin: vi.fn(),
+  deletePin: vi.fn(),
+  recordVisit: vi.fn(),
+}));
+
+vi.mock("react-resizable-panels", () => ({
+  Group: ({ children, ...props }: any) => {
+    mocks.panelGroupProps.push(props);
+    return <div data-testid="panel-group">{children}</div>;
+  },
+  Panel: ({ children, ...props }: any) => (
+    <div data-testid="panel" {...props}>
+      {children}
+    </div>
+  ),
+  Separator: ({ children, ...props }: any) => (
+    <div data-testid="panel-handle" {...props}>
+      {children}
+    </div>
+  ),
+  useDefaultLayout: () => ({
+    defaultLayout: { content: 70, sidebar: 30 },
+    onLayoutChanged: mocks.onLayoutChanged,
+  }),
+  usePanelRef: () => ({
+    current: { isCollapsed: () => false, expand: vi.fn(), collapse: vi.fn() },
+  }),
+}));
+
+vi.mock("@tanstack/react-query", () => ({
+  useQuery: (options: { queryKey?: readonly unknown[] }) => {
+    if (options.queryKey?.[0] === "project") {
+      return { data: mocks.project, isLoading: false };
+    }
+    return { data: [], isLoading: false };
+  },
+}));
+
+vi.mock("@multica/core/projects/queries", () => ({
+  projectDetailOptions: () => ({ queryKey: ["project"] }),
+}));
+
+vi.mock("@multica/core/projects/mutations", () => ({
+  useUpdateProject: () => ({ mutate: mocks.updateProject }),
+  useDeleteProject: () => ({ mutate: mocks.deleteProject }),
+}));
+
+vi.mock("@multica/core/pins", () => ({
+  pinListOptions: () => ({ queryKey: ["pins"] }),
+  useCreatePin: () => ({ mutate: mocks.createPin }),
+  useDeletePin: () => ({ mutate: mocks.deletePin }),
+}));
+
+vi.mock("@multica/core/auth", () => ({
+  useAuthStore: (selector: (state: unknown) => unknown) =>
+    selector({ user: { id: "user-1" } }),
+}));
+
+vi.mock("@multica/core/hooks", () => ({
+  useWorkspaceId: () => "workspace-1",
+}));
+
+vi.mock("@multica/core/paths", () => ({
+  useWorkspacePaths: () => ({
+    projects: () => "/test-workspace/projects",
+  }),
+}));
+
+vi.mock("@multica/core/workspace/queries", () => ({
+  memberListOptions: () => ({ queryKey: ["members"] }),
+  agentListOptions: () => ({ queryKey: ["agents"] }),
+}));
+
+vi.mock("@multica/core/workspace/hooks", () => ({
+  useActorName: () => ({ getActorName: () => "Test Lead" }),
+}));
+
+vi.mock("@multica/core/chat", () => ({
+  useRecentContextStore: (selector: (state: unknown) => unknown) =>
+    selector({ recordVisit: mocks.recordVisit }),
+}));
+
+vi.mock("@multica/ui/hooks/use-mobile", () => ({
+  useIsMobile: () => mocks.isMobile,
+}));
+
+vi.mock("../../navigation", () => ({
+  useNavigation: () => ({ push: vi.fn() }),
+}));
+
+vi.mock("../../i18n", () => ({
+  useT: () => ({ t: () => "label" }),
+}));
+
+vi.mock("../../layout/breadcrumb-header", () => ({
+  BreadcrumbHeader: ({
+    leaf,
+    actions,
+  }: {
+    leaf: React.ReactNode;
+    actions?: React.ReactNode;
+  }) => (
+    <header>
+      {leaf}
+      {actions}
+    </header>
+  ),
+}));
+
+vi.mock("../../layout/animated-right-sidebar", () => ({
+  AnimatedRightSidebar: ({ children }: { children: React.ReactNode }) => (
+    <aside>{children}</aside>
+  ),
+  getAnimatedRightSidebarInitialOpen: () => true,
+  rightSidebarPanelMotionProps: {},
+  useAnimatedRightSidebarState: () => ({
+    open: true,
+    visualOpen: true,
+    motionEnabled: false,
+    beginToggle: vi.fn(),
+    handleResize: vi.fn(),
+  }),
+}));
+
+vi.mock("../../editor", () => ({
+  ContentEditor: () => <div data-testid="content-editor" />,
+  TitleEditor: ({ defaultValue }: { defaultValue: string }) => (
+    <span>{defaultValue}</span>
+  ),
+}));
+
+vi.mock("../../issues/surface/issue-surface", () => ({
+  IssueSurface: () => <div data-testid="issue-surface" />,
+}));
+
+vi.mock("../../common/actor-avatar", () => ({
+  ActorAvatar: () => <span data-testid="actor-avatar" />,
+}));
+
+vi.mock("./project-resources-section", () => ({
+  ProjectResourcesSection: () => <div data-testid="project-resources" />,
+}));
+
+vi.mock("./project-start-date-picker", () => ({
+  ProjectStartDatePicker: () => <button type="button">start date</button>,
+}));
+
+vi.mock("./project-due-date-picker", () => ({
+  ProjectDueDatePicker: () => <button type="button">due date</button>,
+}));
+
+vi.mock("./priority-icon", () => ({
+  PriorityIcon: () => <span data-testid="priority-icon" />,
+}));
+
+vi.mock("./labels", () => ({
+  useProjectStatusLabels: () => ({ in_progress: "In Progress" }),
+  useProjectPriorityLabels: () => ({ high: "High" }),
+}));
+
+vi.mock("@multica/ui/components/ui/dropdown-menu", () => ({
+  DropdownMenu: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  DropdownMenuTrigger: ({ render }: { render: React.ReactNode }) => <>{render}</>,
+  DropdownMenuContent: ({ children }: { children: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
+  DropdownMenuItem: ({
+    children,
+    onClick,
+  }: {
+    children: React.ReactNode;
+    onClick?: () => void;
+  }) => (
+    <button type="button" onClick={onClick}>
+      {children}
+    </button>
+  ),
+  DropdownMenuSeparator: () => <hr />,
+}));
+
+vi.mock("@multica/ui/components/ui/popover", () => ({
+  Popover: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  PopoverTrigger: ({ render }: { render: React.ReactNode }) => <>{render}</>,
+  PopoverContent: ({ children }: { children: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
+}));
+
+vi.mock("@multica/ui/components/ui/tooltip", () => ({
+  Tooltip: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  TooltipTrigger: ({ render }: { render: React.ReactNode }) => <>{render}</>,
+  TooltipContent: ({ children }: { children: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
+}));
+
+vi.mock("@multica/ui/components/ui/sheet", () => ({
+  Sheet: ({
+    open,
+    children,
+  }: {
+    open: boolean;
+    children: React.ReactNode;
+  }) => (open ? <div data-testid="sheet">{children}</div> : null),
+  SheetContent: ({ children }: { children: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
+}));
+
+vi.mock("@multica/ui/components/common/emoji-picker", () => ({
+  EmojiPicker: () => <div data-testid="emoji-picker" />,
+}));
+
+beforeEach(() => {
+  mocks.isMobile = true;
+  mocks.onLayoutChanged.mockClear();
+  mocks.panelGroupProps = [];
+});
+
+describe("ProjectDetail responsive layout", () => {
+  it("does not mount a resizable panel group on mobile when a desktop layout was restored", () => {
+    render(<ProjectDetail projectId="project-1" />);
+
+    expect(screen.getByText("Launch Plan")).toBeInTheDocument();
+    expect(screen.getByTestId("issue-surface")).toBeInTheDocument();
+    expect(screen.queryByTestId("panel-group")).not.toBeInTheDocument();
+    expect(mocks.onLayoutChanged).not.toHaveBeenCalled();
+  });
+
+  it("keeps the persisted split-panel group on desktop", () => {
+    mocks.isMobile = false;
+
+    render(<ProjectDetail projectId="project-1" />);
+
+    expect(mocks.panelGroupProps[0]?.defaultLayout).toEqual({
+      content: 70,
+      sidebar: 30,
+    });
+    expect(screen.getAllByTestId("panel")).toHaveLength(2);
+  });
+});

--- a/packages/views/projects/components/project-detail.tsx
+++ b/packages/views/projects/components/project-detail.tsx
@@ -467,114 +467,138 @@ export function ProjectDetail({ projectId }: { projectId: string }) {
     </div>
   );
 
-  return (
-    <>
-    <ResizablePanelGroup orientation="horizontal" className="flex-1 min-h-0" defaultLayout={defaultLayout} onLayoutChanged={onLayoutChanged}>
-      <ResizablePanel id="content" minSize="50%">
-        <div className="flex h-full flex-col">
-          <BreadcrumbHeader
-            segments={[{ href: wsPaths.projects(), label: t(($) => $.detail.breadcrumb_fallback) }]}
-            leaf={<span className="truncate font-medium text-foreground">{project.title}</span>}
-            actions={
-              <>
-              <Button
-                variant="ghost"
-                size="icon-sm"
-                className={cn("text-muted-foreground", isPinned && "text-foreground")}
-                title={isPinned ? t(($) => $.detail.unpin_tooltip) : t(($) => $.detail.pin_tooltip)}
-                onClick={() => {
-                  if (isPinned) {
-                    deletePinMut.mutate({ itemType: "project", itemId: projectId });
-                  } else {
-                    createPin.mutate({ item_type: "project", item_id: projectId });
-                  }
-                }}
-              >
-                {isPinned ? <PinOff /> : <Pin />}
-              </Button>
-              <DropdownMenu>
-                <DropdownMenuTrigger
-                  render={
-                    <Button variant="ghost" size="icon-sm" className="text-muted-foreground">
-                      <MoreHorizontal />
-                    </Button>
-                  }
-                />
-                <DropdownMenuContent align="end" className="w-auto">
-                  <DropdownMenuItem onClick={() => {
+  const mainContent = (
+    <div className="flex h-full flex-col">
+      <BreadcrumbHeader
+        segments={[
+          { href: wsPaths.projects(), label: t(($) => $.detail.breadcrumb_fallback) },
+        ]}
+        leaf={
+          <span className="truncate font-medium text-foreground">
+            {project.title}
+          </span>
+        }
+        actions={
+          <>
+            <Button
+              variant="ghost"
+              size="icon-sm"
+              className={cn("text-muted-foreground", isPinned && "text-foreground")}
+              title={isPinned ? t(($) => $.detail.unpin_tooltip) : t(($) => $.detail.pin_tooltip)}
+              onClick={() => {
+                if (isPinned) {
+                  deletePinMut.mutate({ itemType: "project", itemId: projectId });
+                } else {
+                  createPin.mutate({ item_type: "project", item_id: projectId });
+                }
+              }}
+            >
+              {isPinned ? <PinOff /> : <Pin />}
+            </Button>
+            <DropdownMenu>
+              <DropdownMenuTrigger
+                render={
+                  <Button variant="ghost" size="icon-sm" className="text-muted-foreground">
+                    <MoreHorizontal />
+                  </Button>
+                }
+              />
+              <DropdownMenuContent align="end" className="w-auto">
+                <DropdownMenuItem
+                  onClick={() => {
                     void copyText(window.location.href).then((ok) => {
                       if (ok) toast.success(t(($) => $.detail.toast_link_copied));
                     });
-                  }}>
-                    <Link2 className="h-3.5 w-3.5" />
-                    {t(($) => $.detail.copy_link)}
-                  </DropdownMenuItem>
-                  {isWorkspaceAdmin && (
-                    <>
-                      <DropdownMenuSeparator />
-                      <DropdownMenuItem
-                        variant="destructive"
-                        onClick={() => setDeleteDialogOpen(true)}
-                      >
-                        <Trash2 className="h-3.5 w-3.5" />
-                        {t(($) => $.detail.delete_action)}
-                      </DropdownMenuItem>
-                    </>
-                  )}
-                </DropdownMenuContent>
-              </DropdownMenu>
-              <Tooltip>
-                <TooltipTrigger
-                  render={
-                    <Button
-                      variant={sidebarOpen ? "secondary" : "ghost"}
-                      size="icon-sm"
-                      className={sidebarOpen ? "" : "text-muted-foreground"}
-                      onClick={handleToggleSidebar}
+                  }}
+                >
+                  <Link2 className="h-3.5 w-3.5" />
+                  {t(($) => $.detail.copy_link)}
+                </DropdownMenuItem>
+                {isWorkspaceAdmin && (
+                  <>
+                    <DropdownMenuSeparator />
+                    <DropdownMenuItem
+                      variant="destructive"
+                      onClick={() => setDeleteDialogOpen(true)}
                     >
-                      <PanelRight />
-                    </Button>
-                  }
-                />
-                <TooltipContent side="bottom">{t(($) => $.detail.sidebar_tooltip)}</TooltipContent>
-              </Tooltip>
-              </>
-            }
-          />
+                      <Trash2 className="h-3.5 w-3.5" />
+                      {t(($) => $.detail.delete_action)}
+                    </DropdownMenuItem>
+                  </>
+                )}
+              </DropdownMenuContent>
+            </DropdownMenu>
+            <Tooltip>
+              <TooltipTrigger
+                render={
+                  <Button
+                    variant={sidebarOpen ? "secondary" : "ghost"}
+                    size="icon-sm"
+                    className={sidebarOpen ? "" : "text-muted-foreground"}
+                    onClick={handleToggleSidebar}
+                  >
+                    <PanelRight />
+                  </Button>
+                }
+              />
+              <TooltipContent side="bottom">
+                {t(($) => $.detail.sidebar_tooltip)}
+              </TooltipContent>
+            </Tooltip>
+          </>
+        }
+      />
 
-          <IssueSurface
-            scope={issueScope}
-            modes={["board", "list", "table", "swimlane", "gantt"]}
-          />
-          </div>
-        </ResizablePanel>
-        {!isMobile && <ResizableHandle />}
-        {!isMobile && (
-        <ResizablePanel
-          id="sidebar"
-          {...rightSidebarPanelMotionProps}
-          data-right-sidebar-motion={desktopSidebarMotionEnabled ? "enabled" : undefined}
-          defaultSize={desktopSidebarOpen ? 320 : 0}
-          minSize={260}
-          maxSize={420}
-          collapsible
-          groupResizeBehavior="preserve-pixel-size"
-          panelRef={sidebarRef}
-          onResize={handleDesktopSidebarResize}
+      <IssueSurface
+        scope={issueScope}
+        modes={["board", "list", "table", "swimlane", "gantt"]}
+      />
+    </div>
+  );
+
+  return (
+    <>
+      {isMobile ? (
+        <div className="flex flex-1 min-h-0">
+          {mainContent}
+        </div>
+      ) : (
+        <ResizablePanelGroup
+          orientation="horizontal"
+          className="flex-1 min-h-0"
+          defaultLayout={defaultLayout}
+          onLayoutChanged={onLayoutChanged}
         >
-          <AnimatedRightSidebar open={desktopSidebarVisualOpen} motionEnabled={desktopSidebarMotionEnabled}>
-            {sidebarContent}
-          </AnimatedRightSidebar>
-        </ResizablePanel>
-        )}
-        {isMobile && (
-          <Sheet open={mobileSidebarOpen} onOpenChange={setMobileSidebarOpen}>
-            <SheetContent side="right" showCloseButton={false} className="w-[320px] overflow-y-auto p-4">
+          <ResizablePanel id="content" minSize="50%">
+            {mainContent}
+          </ResizablePanel>
+          <ResizableHandle />
+          <ResizablePanel
+            id="sidebar"
+            {...rightSidebarPanelMotionProps}
+            data-right-sidebar-motion={desktopSidebarMotionEnabled ? "enabled" : undefined}
+            defaultSize={desktopSidebarOpen ? 320 : 0}
+            minSize={260}
+            maxSize={420}
+            collapsible
+            groupResizeBehavior="preserve-pixel-size"
+            panelRef={sidebarRef}
+            onResize={handleDesktopSidebarResize}
+          >
+            <AnimatedRightSidebar open={desktopSidebarVisualOpen} motionEnabled={desktopSidebarMotionEnabled}>
               {sidebarContent}
-            </SheetContent>
-          </Sheet>
-        )}
-      </ResizablePanelGroup>
+            </AnimatedRightSidebar>
+          </ResizablePanel>
+        </ResizablePanelGroup>
+      )}
+
+      {isMobile && (
+        <Sheet open={mobileSidebarOpen} onOpenChange={setMobileSidebarOpen}>
+          <SheetContent side="right" showCloseButton={false} className="w-[320px] overflow-y-auto p-4">
+            {sidebarContent}
+          </SheetContent>
+        </Sheet>
+      )}
 
       {/* Delete confirmation */}
       {isWorkspaceAdmin && (


### PR DESCRIPTION
## What does this PR do?

Fixes a responsive crash in the project detail page where the mobile path kept `ResizablePanelGroup` mounted while only the content panel was rendered. If `react-resizable-panels` restored a saved desktop two-panel layout during a resize, the group could validate it against one mounted panel and throw `Invalid 1 panel layout`.

The mobile project detail path now renders the main content directly and keeps the sidebar in the mobile sheet, matching the issue detail pattern. Desktop still renders the two-panel resizable group with the restored layout.

<!-- multica-auto-bugfix -->

## Related Issue

Closes #3626

Multica issue: ZIC-96

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Refactor / code improvement (no behavior change)
- [x] Tests (adding or improving test coverage)
- [ ] Documentation update
- [ ] CI / infrastructure

## Changes Made

- Updated `packages/views/projects/components/project-detail.tsx` so mobile renders without `ResizablePanelGroup`, avoiding one-panel group validation against restored two-panel state.
- Added `packages/views/projects/components/project-detail.test.tsx` coverage for the mobile no-panel-group path and the desktop persisted split-panel path.

## How to Test

1. `pnpm --filter @multica/views exec vitest run projects/components/project-detail.test.tsx`
2. `pnpm --filter @multica/views typecheck`
3. `pnpm --filter @multica/views lint`

Notes:
- `pnpm --filter @multica/views lint` exits 0 with existing warnings.
- `make check-worktree` was attempted, but local Docker is not running, so the PostgreSQL preflight printed `Cannot connect to the Docker daemon` before the full pipeline could run.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [ ] I have updated relevant documentation to reflect my changes
- [ ] If I added a new runtime / coding tool / UI tab, I synced the change to **landing copy** (`apps/web/features/landing/i18n/`) and **relevant docs** (`apps/docs/content/docs/`)
- [ ] If this PR touches Chinese product copy, I checked it against `apps/docs/content/docs/developers/conventions.zh.mdx` (terminology, mixed-rule for `task` / `issue` / `skill`)
- [x] I have considered and documented any risks above
- [x] I will address all reviewer comments before requesting merge

## AI Disclosure

**AI tool used:** Multica Agent

**Prompt / approach:**
Traced `react-resizable-panels` usage around responsive detail layouts, identified `ProjectDetail` as the path that could render a one-panel group with restored two-panel state, applied the existing mobile sheet pattern from issue detail, and added focused regression coverage.

## Screenshots (optional)

Not applicable; this is a responsive crash guard with no visual behavior change intended.
