### PR TITLE
Fix intentional top-level comment threads from triggered tasks

### DIFF
--- a/CLI_AND_DAEMON.md
+++ b/CLI_AND_DAEMON.md
@@ -458,6 +458,9 @@ multica issue comment add <issue-id> --content "Looks good, merging now"
 # Reply to a specific comment
 multica issue comment add <issue-id> --parent <comment-id> --content "Thanks!"
 
+# Intentionally start a new top-level thread from a comment-triggered task
+multica issue comment add <issue-id> --new-thread --content "Decision for the issue timeline"
+
 # Delete a comment
 multica issue comment delete <comment-id>
 ```

--- a/server/cmd/multica/cmd_issue.go
+++ b/server/cmd/multica/cmd_issue.go
@@ -540,7 +540,8 @@ func init() {
 	issueCommentAddCmd.Flags().Bool("content-stdin", false, "Read comment content from stdin (preserves multi-line content verbatim)")
 	issueCommentAddCmd.Flags().String("content-file", "", "Read comment content from a UTF-8 file (preserves multi-line content verbatim; use this on Windows when stdin piping mangles non-ASCII bytes). The path must be inside the current working directory unless --allow-external-file is set.")
 	issueCommentAddCmd.Flags().Bool("allow-external-file", false, "Allow --content-file / --attachment to read a path outside the current working directory. Off by default so a stale file from another run/environment can't be picked up (MUL-4252).")
-	issueCommentAddCmd.Flags().String("parent", "", "Parent comment ID to reply under. A comment-triggered agent task must reply under its trigger comment; omitting --parent to post a top-level comment is rejected")
+	issueCommentAddCmd.Flags().String("parent", "", "Parent comment ID to reply under. A comment-triggered agent task must reply under its trigger comment unless --new-thread is set")
+	issueCommentAddCmd.Flags().Bool("new-thread", false, "Explicitly create a new top-level thread from a comment-triggered task. Cannot be combined with --parent")
 	issueCommentAddCmd.Flags().StringSlice("attachment", nil, "File path(s) to attach (can be specified multiple times)")
 	issueCommentAddCmd.Flags().String("output", "json", "Output format: table or json")
 
@@ -1929,6 +1930,11 @@ func runIssueCommentAdd(cmd *cobra.Command, args []string) error {
 		"Deliver the file itself with `multica issue comment add <issue-id> --attachment <path>` (repeatable) and drop the link."); err != nil {
 		return err
 	}
+	parentID, _ := cmd.Flags().GetString("parent")
+	newThread, _ := cmd.Flags().GetBool("new-thread")
+	if parentID != "" && newThread {
+		return fmt.Errorf("--new-thread cannot be combined with --parent")
+	}
 
 	client, err := newAPIClient(cmd)
 	if err != nil {
@@ -1971,8 +1977,11 @@ func runIssueCommentAdd(cmd *cobra.Command, args []string) error {
 	}
 
 	body := map[string]any{"content": content}
-	if parentID, _ := cmd.Flags().GetString("parent"); parentID != "" {
+	if parentID != "" {
 		body["parent_id"] = parentID
+	}
+	if newThread {
+		body["new_thread"] = true
 	}
 	if len(attachmentIDs) > 0 {
 		body["attachment_ids"] = attachmentIDs

--- a/server/cmd/multica/cmd_issue_test.go
+++ b/server/cmd/multica/cmd_issue_test.go
@@ -359,8 +359,60 @@ func newIssueCommentAddTestCmd() *cobra.Command {
 	cmd.Flags().Bool("allow-external-file", false, "")
 	cmd.Flags().StringSlice("attachment", nil, "")
 	cmd.Flags().String("parent", "", "")
+	cmd.Flags().Bool("new-thread", false, "")
 	cmd.Flags().String("output", "json", "")
 	return cmd
+}
+
+func TestRunIssueCommentAddSendsNewThreadIntent(t *testing.T) {
+	const issueID = "11111111-1111-4111-8111-111111111111"
+	var body map[string]any
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/api/issues/"+issueID:
+			_ = json.NewEncoder(w).Encode(map[string]any{"id": issueID, "identifier": "TST-1"})
+		case r.Method == http.MethodPost && r.URL.Path == "/api/issues/"+issueID+"/comments":
+			if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+				t.Errorf("decode comment body: %v", err)
+			}
+			_ = json.NewEncoder(w).Encode(map[string]any{"id": "comment-1"})
+		default:
+			t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer srv.Close()
+	setCLITestServerEnv(t, srv.URL)
+	t.Setenv("MULTICA_TOKEN", "mat_test-token")
+
+	cmd := newIssueCommentAddTestCmd()
+	_ = cmd.Flags().Set("content", "decision for humans")
+	_ = cmd.Flags().Set("new-thread", "true")
+
+	if err := runIssueCommentAdd(cmd, []string{issueID}); err != nil {
+		t.Fatalf("runIssueCommentAdd: %v", err)
+	}
+	if got := body["new_thread"]; got != true {
+		t.Fatalf("new_thread = %#v, want true in request body", got)
+	}
+	if _, ok := body["parent_id"]; ok {
+		t.Fatalf("parent_id should be omitted for --new-thread, body = %#v", body)
+	}
+}
+
+func TestRunIssueCommentAddRejectsNewThreadWithParent(t *testing.T) {
+	cmd := newIssueCommentAddTestCmd()
+	_ = cmd.Flags().Set("content", "ambiguous")
+	_ = cmd.Flags().Set("parent", "22222222-2222-4222-8222-222222222222")
+	_ = cmd.Flags().Set("new-thread", "true")
+
+	err := runIssueCommentAdd(cmd, []string{"11111111-1111-4111-8111-111111111111"})
+	if err == nil {
+		t.Fatalf("expected --new-thread with --parent to be rejected")
+	}
+	if !strings.Contains(err.Error(), "--new-thread cannot be combined with --parent") {
+		t.Fatalf("unexpected error: %v", err)
+	}
 }
 
 // TestRunIssueCommentAddRejectsExternalAttachmentWithZeroUploads is the MUL-4252

--- a/server/internal/handler/comment.go
+++ b/server/internal/handler/comment.go
@@ -994,6 +994,7 @@ type CreateCommentRequest struct {
 	Content          string   `json:"content"`
 	Type             string   `json:"type"`
 	ParentID         *string  `json:"parent_id"`
+	NewThread        bool     `json:"new_thread"`
 	AttachmentIDs    []string `json:"attachment_ids"`
 	SuppressAgentIDs []string `json:"suppress_agent_ids"`
 }
@@ -1280,6 +1281,10 @@ func (h *Handler) CreateComment(w http.ResponseWriter, r *http.Request) {
 	var parentID pgtype.UUID
 	var parentComment *db.Comment
 	if req.ParentID != nil {
+		if req.NewThread {
+			writeError(w, http.StatusBadRequest, "new_thread cannot be combined with parent_id")
+			return
+		}
 		var parsed pgtype.UUID
 		parsed, ok = parseUUIDOrBadRequest(w, *req.ParentID, "parent_id")
 		if !ok {
@@ -1308,9 +1313,10 @@ func (h *Handler) CreateComment(w http.ResponseWriter, r *http.Request) {
 
 	// Defense against resumed-session drift: when an agent posts from inside a
 	// comment-triggered task AND the comment is being posted on that same
-	// issue, the parent_id must exactly match the task's trigger comment.
-	// Resumed Claude sessions otherwise carry forward a previous turn's
-	// --parent UUID and silently misplace the reply.
+	// issue, the parent_id must be covered by that task unless the request
+	// explicitly asks to start a new thread. Resumed sessions otherwise carry
+	// forward a previous turn's --parent UUID or omit it by accident and
+	// silently misplace the reply.
 	//
 	// The task.IssueID scope is important: the CLI stamps X-Task-ID on every
 	// request, so an agent legitimately commenting on a different issue must
@@ -1333,10 +1339,11 @@ func (h *Handler) CreateComment(w http.ResponseWriter, r *http.Request) {
 				task, err := h.Queries.GetAgentTask(r.Context(), taskUUID)
 				if err == nil && task.IssueID.Valid && uuidToString(task.IssueID) == uuidToString(issue.ID) {
 					if task.TriggerCommentID.Valid {
-						if !taskCoversReplyParent(task, parentID) {
+						allowsExplicitNewThread := req.NewThread && !parentID.Valid
+						if !taskCoversReplyParent(task, parentID) && !allowsExplicitNewThread {
 							// Keep this error actionable for agents (MUL-4417 / GH #5266).
 							writeError(w, http.StatusConflict,
-								"comment-triggered tasks cannot create top-level comments; set parent_id (--parent) to "+uuidToString(task.TriggerCommentID)+" or a coalesced comment id")
+								"comment-triggered tasks cannot create top-level comments by default; set parent_id (--parent) to "+uuidToString(task.TriggerCommentID)+" or a coalesced comment id, or pass new_thread (--new-thread) to intentionally start a top-level thread")
 							return
 						}
 					}

--- a/server/internal/handler/comment_reply_authz_handler_test.go
+++ b/server/internal/handler/comment_reply_authz_handler_test.go
@@ -50,10 +50,70 @@ func TestCreateComment_TriggeredTaskRejectsTopLevelComment(t *testing.T) {
 		"top-level comments",   // reason
 		fx.TriggerCommentID,    // the comment to reply under
 		"parent_id (--parent)", // actionable fix
+		"new_thread",           // explicit opt-in for a new top-level thread
 	} {
 		if !strings.Contains(msg, want) {
 			t.Fatalf("409 message should contain %q, got %q", want, msg)
 		}
+	}
+}
+
+func TestCreateComment_TriggeredTaskAllowsExplicitNewThread(t *testing.T) {
+	if testHandler == nil || testPool == nil {
+		t.Skip("database not available")
+	}
+
+	fx := newRunningSquadLeaderTaskFixture(t)
+
+	w := httptest.NewRecorder()
+	r := newRequest("POST", "/api/issues/"+fx.IssueID+"/comments", map[string]any{
+		"content":    "starting a human-facing decision thread",
+		"new_thread": true,
+	})
+	r = withURLParam(r, "id", fx.IssueID)
+	r.Header.Set("X-Agent-ID", fx.LeaderID)
+	r.Header.Set("X-Task-ID", fx.TaskID)
+
+	testHandler.CreateComment(w, r)
+	if w.Code != http.StatusCreated {
+		t.Fatalf("CreateComment explicit new thread: expected 201, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var got struct {
+		ParentID     *string `json:"parent_id"`
+		SourceTaskID *string `json:"source_task_id"`
+	}
+	if err := json.NewDecoder(w.Body).Decode(&got); err != nil {
+		t.Fatalf("decode comment response: %v", err)
+	}
+	if got.ParentID != nil {
+		t.Fatalf("explicit new thread should be top-level, got parent_id %q", *got.ParentID)
+	}
+	if got.SourceTaskID == nil || *got.SourceTaskID != fx.TaskID {
+		t.Fatalf("explicit new thread should be stamped with source_task_id %q, got %#v", fx.TaskID, got.SourceTaskID)
+	}
+}
+
+func TestCreateComment_NewThreadRejectsParentID(t *testing.T) {
+	if testHandler == nil || testPool == nil {
+		t.Skip("database not available")
+	}
+
+	fx := newRunningSquadLeaderTaskFixture(t)
+
+	w := httptest.NewRecorder()
+	r := newRequest("POST", "/api/issues/"+fx.IssueID+"/comments", map[string]any{
+		"content":    "ambiguous reply",
+		"parent_id":  fx.TriggerCommentID,
+		"new_thread": true,
+	})
+	r = withURLParam(r, "id", fx.IssueID)
+	r.Header.Set("X-Agent-ID", fx.LeaderID)
+	r.Header.Set("X-Task-ID", fx.TaskID)
+
+	testHandler.CreateComment(w, r)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("CreateComment new_thread + parent_id: expected 400, got %d: %s", w.Code, w.Body.String())
 	}
 }
 


### PR DESCRIPTION
## What does this PR do?

Allows comment-triggered agent tasks to intentionally start a new top-level issue comment thread without weakening the default stale-session guard.

The default remains fail-closed: a comment-triggered task posting on its own issue must reply under its trigger/coalesced comment unless the request explicitly carries `new_thread: true`. The CLI exposes that intent as `multica issue comment add --new-thread`.

<!-- multica-auto-bugfix -->

## Related Issue

Closes #5383

Multica issue: ZIC-100

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Refactor / code improvement (no behavior change)
- [ ] Documentation update
- [x] Tests (adding or improving test coverage)
- [ ] CI / infrastructure

## Changes Made

- Added `new_thread` to `CreateCommentRequest` and allowed it only for parentless top-level comments from same-issue comment-triggered tasks.
- Added `multica issue comment add --new-thread` and request-body coverage.
- Documented the CLI usage in `CLI_AND_DAEMON.md`.
- Added handler regression tests for default rejection, explicit top-level success, and ambiguous `new_thread` plus `parent_id`.

## How to Test

1. `go test ./cmd/multica ./internal/handler` from `server`
2. `make check-worktree` from repo root

Note: `make check-worktree` exited 0 locally, but printed a Docker daemon warning while checking PostgreSQL: `Cannot connect to the Docker daemon at unix:///Users/icezero/.docker/run/docker.sock`.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [x] I have updated relevant documentation to reflect my changes
- [ ] If I added a new runtime / coding tool / UI tab, I synced the change to **landing copy** (`apps/web/features/landing/i18n/`) and **relevant docs** (`apps/docs/content/docs/`)
- [ ] If this PR touches Chinese product copy, I checked it against `apps/docs/content/docs/developers/conventions.zh.mdx` (terminology, mixed-rule for `task` / `issue` / `skill`)
- [x] I have considered and documented any risks above
- [x] I will address all reviewer comments before requesting merge

## AI Disclosure

**AI tool used:** Multica Agent

**Prompt / approach:**
Implemented from Multica issue ZIC-100 / GitHub #5383 by tracing the existing `CreateComment` task coverage guard, adding the smallest explicit API/CLI intent path, and pinning behavior with focused handler and CLI tests.

## Screenshots (optional)

N/A