### PR TITLE
feat(editor): support collapsible `<details>`/`<summary>` blocks in issue & comment rendering

### DIFF
--- a/packages/views/editor/extensions/details-view.test.tsx
+++ b/packages/views/editor/extensions/details-view.test.tsx
@@ -1,5 +1,11 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import {
+  cleanup,
+  createEvent,
+  fireEvent,
+  render,
+  screen,
+} from "@testing-library/react";
 
 // Tiptap's NodeView primitives need a full editor to instantiate. Stub the
 // wrapper so <DetailsBlockView /> can render as a plain React component and we
@@ -42,6 +48,64 @@ afterEach(() => {
 });
 
 describe("DetailsBlockView — editable mode", () => {
+  it("renders collapsed by default, keeping the editable fields", () => {
+    const { props } = makeProps({ summary: "Click to expand", body: "Body." });
+    render(<DetailsBlockView {...props} />);
+
+    // The regression: editable mode used to render always-expanded form
+    // controls, so the block never collapsed on issues. It must stay a
+    // (collapsed) native <details> even while editable.
+    const details = document.querySelector("details");
+    expect(details).toBeTruthy();
+    expect(details!.hasAttribute("open")).toBe(false);
+    expect(screen.getByLabelText("Summary")).toBeTruthy();
+  });
+
+  it("respects the open attribute in editable mode", () => {
+    const { props } = makeProps({ summary: "s", body: "b", open: true });
+    render(<DetailsBlockView {...props} />);
+
+    const details = document.querySelector("details");
+    expect(details).toBeTruthy();
+    expect(details!.hasAttribute("open")).toBe(true);
+  });
+
+  it("treats folding/unfolding as local UI state that does not dirty the doc", () => {
+    const { props, updateAttributes } = makeProps({
+      summary: "s",
+      body: "b",
+    });
+    render(<DetailsBlockView {...props} />);
+
+    const details = document.querySelector("details") as HTMLDetailsElement;
+    expect(details.open).toBe(false);
+
+    // Simulate the user unfolding the block: the browser flips the DOM `open`
+    // property and fires `toggle`; the view must mirror that locally without
+    // writing the `open` attribute back into the document.
+    details.open = true;
+    fireEvent(details, new Event("toggle"));
+    expect(details.open).toBe(true);
+
+    details.open = false;
+    fireEvent(details, new Event("toggle"));
+    expect(details.open).toBe(false);
+
+    expect(updateAttributes).not.toHaveBeenCalled();
+  });
+
+  it("does not toggle the block when clicking into the summary field", () => {
+    const { props } = makeProps({ summary: "s", body: "b" });
+    render(<DetailsBlockView {...props} />);
+
+    // Clicking a <summary> toggles the parent <details> by default; the click
+    // on the input must be prevented so the user can focus/edit the field.
+    const input = screen.getByLabelText("Summary");
+    const click = createEvent.click(input);
+    fireEvent(input, click);
+    expect(click.defaultPrevented).toBe(true);
+  });
+
   it("renders the summary in an editable text field", () => {
     const { props } = makeProps({ summary: "Click to expand", body: "Body." });
     render(<DetailsBlockView {...props} />);

--- a/packages/views/editor/extensions/details-view.test.tsx
+++ b/packages/views/editor/extensions/details-view.test.tsx
@@ -1,0 +1,104 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+
+// Tiptap's NodeView primitives need a full editor to instantiate. Stub the
+// wrapper so <DetailsBlockView /> can render as a plain React component and we
+// can inspect the DOM shape and interactions directly.
+vi.mock("@tiptap/react", () => {
+  const NodeViewWrapper = ({ children, ...rest }: any) => (
+    <div data-testid="nvw" {...rest}>
+      {children}
+    </div>
+  );
+  return { NodeViewWrapper };
+});
+
+// The body preview goes through the heavy react-markdown renderer; a sentinel
+// is enough to assert the readonly branch renders it (and the edit branch does
+// not).
+vi.mock("../readonly-content", () => ({
+  ReadonlyContent: ({ content }: { content: string }) => (
+    <div data-testid="readonly">{content}</div>
+  ),
+}));
+
+import { DetailsBlockView } from "./details";
+
+function makeProps(
+  attrs: { summary?: string; body?: string; open?: boolean },
+  { editable = true }: { editable?: boolean } = {},
+) {
+  const updateAttributes = vi.fn();
+  const props = {
+    node: { attrs: { summary: "", body: "", open: false, ...attrs } },
+    updateAttributes,
+    editor: { isEditable: editable },
+  } as unknown as Parameters<typeof DetailsBlockView>[0];
+  return { props, updateAttributes };
+}
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("DetailsBlockView — editable mode", () => {
+  it("renders the summary in an editable text field", () => {
+    const { props } = makeProps({ summary: "Click to expand", body: "Body." });
+    render(<DetailsBlockView {...props} />);
+
+    const input = screen.getByLabelText("Summary") as HTMLInputElement;
+    expect(input.value).toBe("Click to expand");
+    // A plain read-only <summary> text node is NOT editable — the bug.
+    expect(input.tagName).toBe("INPUT");
+  });
+
+  it("renders the body in an editable (source) field holding the verbatim markdown", () => {
+    const { props } = makeProps({
+      summary: "s",
+      body: "Hidden **markdown** body.\n\n- one\n- two",
+    });
+    render(<DetailsBlockView {...props} />);
+
+    const body = screen.getByLabelText(/body/i) as HTMLTextAreaElement;
+    expect(body.value).toBe("Hidden **markdown** body.\n\n- one\n- two");
+    expect(body.tagName).toBe("TEXTAREA");
+    // In edit mode the body is a source field, not the readonly preview.
+    expect(screen.queryByTestId("readonly")).toBeNull();
+  });
+
+  it("writes summary edits back through updateAttributes", () => {
+    const { props, updateAttributes } = makeProps({ summary: "Old" });
+    render(<DetailsBlockView {...props} />);
+
+    fireEvent.change(screen.getByLabelText("Summary"), {
+      target: { value: "New summary" },
+    });
+    expect(updateAttributes).toHaveBeenCalledWith({ summary: "New summary" });
+  });
+
+  it("writes body edits back through updateAttributes", () => {
+    const { props, updateAttributes } = makeProps({ body: "old body" });
+    render(<DetailsBlockView {...props} />);
+
+    fireEvent.change(screen.getByLabelText(/body/i), {
+      target: { value: "new body" },
+    });
+    expect(updateAttributes).toHaveBeenCalledWith({ body: "new body" });
+  });
+});
+
+describe("DetailsBlockView — readonly mode", () => {
+  it("renders a collapsed <details> with the body through ReadonlyContent", () => {
+    const { props } = makeProps(
+      { summary: "Click to expand", body: "Body." },
+      { editable: false },
+    );
+    render(<DetailsBlockView {...props} />);
+
+    expect(document.querySelector("details")).toBeTruthy();
+    expect(screen.getByTestId("readonly").textContent).toBe("Body.");
+    // No editable fields when the editor is not editable.
+    expect(screen.queryByLabelText("Summary")).toBeNull();
+    expect(screen.queryByLabelText(/body/i)).toBeNull();
+  });
+});

--- a/packages/views/editor/extensions/details.test.tsx
+++ b/packages/views/editor/extensions/details.test.tsx
@@ -29,6 +29,26 @@ function findAll(node: JsonNode, type: string, acc: JsonNode[] = []): JsonNode[]
   return acc;
 }
 
+// Mimics what the NodeView's editable controls do: patch the detailsBlock
+// node's attributes in place (the same effect as `updateAttributes`).
+function editDetailsAttrs(ed: Editor, attrs: Record<string, unknown>): void {
+  const { state } = ed;
+  let pos = -1;
+  let current: Record<string, unknown> = {};
+  state.doc.descendants((n, p) => {
+    if (n.type.name === "detailsBlock") {
+      pos = p;
+      current = n.attrs;
+      return false;
+    }
+    return true;
+  });
+  if (pos < 0) throw new Error("no detailsBlock node found");
+  ed.view.dispatch(
+    state.tr.setNodeMarkup(pos, undefined, { ...current, ...attrs }),
+  );
+}
+
 let editor: Editor | null = null;
 
 afterEach(() => {
@@ -218,5 +238,43 @@ Another body.
     expect(blocks).toHaveLength(0);
     // No content is destroyed by the fallback.
     expect(editor.getMarkdown()).toContain("Has a fenced sample");
+  });
+
+  it("re-serializes summary and body edits back to <details> markdown", () => {
+    editor = makeEditor();
+    editor.commands.setContent(SIMPLE, { contentType: "markdown" });
+
+    editDetailsAttrs(editor, {
+      summary: "Edited summary",
+      body: "Edited **body** text.",
+    });
+
+    const out = editor.getMarkdown().trim();
+    expect(out).toContain("<summary>Edited summary</summary>");
+    expect(out).toContain("Edited **body** text.");
+
+    // Full round-trip: reloading the edited markdown yields the edited attrs,
+    // so an in-editor edit survives a save/reload cycle.
+    editor.commands.setContent(out, { contentType: "markdown" });
+    const block = findAll(editor.getJSON() as JsonNode, "detailsBlock")[0];
+    expect(block?.attrs?.summary).toBe("Edited summary");
+    expect(block?.attrs?.body).toBe("Edited **body** text.");
+  });
+
+  it("keeps surrounding content intact when the block is edited", () => {
+    const doc = `Intro paragraph.
+
+${SIMPLE}
+
+Outro paragraph.`;
+    editor = makeEditor();
+    editor.commands.setContent(doc, { contentType: "markdown" });
+
+    editDetailsAttrs(editor, { summary: "Changed" });
+
+    const out = editor.getMarkdown();
+    expect(out).toContain("Intro paragraph.");
+    expect(out).toContain("<summary>Changed</summary>");
+    expect(out).toContain("Outro paragraph.");
   });
 });

--- a/packages/views/editor/extensions/details.test.tsx
+++ b/packages/views/editor/extensions/details.test.tsx
@@ -137,4 +137,86 @@ nested
     expect(out).toContain("Inner");
     expect(out).toContain("nested");
   });
+
+  it("tolerates blank lines between the opening tag and <summary>", () => {
+    const md = `<details>
+
+<summary>Spaced out</summary>
+
+Body.
+</details>`;
+    editor = makeEditor();
+    editor.commands.setContent(md, { contentType: "markdown" });
+
+    const blocks = findAll(editor.getJSON() as JsonNode, "detailsBlock");
+    expect(blocks).toHaveLength(1);
+    expect(blocks[0]?.attrs?.summary).toBe("Spaced out");
+    expect(blocks[0]?.attrs?.body).toBe("Body.");
+  });
+
+  it("does not treat `open` inside another attribute value as the open flag", () => {
+    const md = `<details class="is open">
+<summary>Not actually open</summary>
+
+Body.
+</details>`;
+    editor = makeEditor();
+    editor.commands.setContent(md, { contentType: "markdown" });
+
+    const blocks = findAll(editor.getJSON() as JsonNode, "detailsBlock");
+    expect(blocks).toHaveLength(1);
+    expect(blocks[0]?.attrs?.open).toBe(false);
+  });
+
+  it("round-trips an empty body", () => {
+    const md = `<details>
+<summary>Empty</summary>
+
+
+</details>`;
+    editor = makeEditor();
+    editor.commands.setContent(md, { contentType: "markdown" });
+
+    const blocks = findAll(editor.getJSON() as JsonNode, "detailsBlock");
+    expect(blocks).toHaveLength(1);
+    expect(blocks[0]?.attrs?.summary).toBe("Empty");
+    expect(blocks[0]?.attrs?.body).toBe("");
+  });
+
+  it("parses two consecutive <details> blocks independently", () => {
+    const md = `${SIMPLE}
+
+<details>
+<summary>Second</summary>
+
+Another body.
+</details>`;
+    editor = makeEditor();
+    editor.commands.setContent(md, { contentType: "markdown" });
+
+    const blocks = findAll(editor.getJSON() as JsonNode, "detailsBlock");
+    expect(blocks).toHaveLength(2);
+    expect(blocks[0]?.attrs?.summary).toBe("Click to expand");
+    expect(blocks[1]?.attrs?.summary).toBe("Second");
+  });
+
+  it("declines a body truncated inside a code fence (stray </details>)", () => {
+    // The lazy </details> match would stop inside the fenced sample; the odd
+    // fence count signals the truncation, so the block declines and falls back
+    // to flat rendering rather than leaking an unterminated fence.
+    const md = `<details>
+<summary>Has a fenced sample</summary>
+
+\`\`\`html
+</details>
+\`\`\`
+</details>`;
+    editor = makeEditor();
+    editor.commands.setContent(md, { contentType: "markdown" });
+
+    const blocks = findAll(editor.getJSON() as JsonNode, "detailsBlock");
+    expect(blocks).toHaveLength(0);
+    // No content is destroyed by the fallback.
+    expect(editor.getMarkdown()).toContain("Has a fenced sample");
+  });
 });

--- a/packages/views/editor/extensions/details.test.tsx
+++ b/packages/views/editor/extensions/details.test.tsx
@@ -1,0 +1,140 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { Editor } from "@tiptap/core";
+import StarterKit from "@tiptap/starter-kit";
+import { Markdown } from "@tiptap/markdown";
+import { DetailsBlockExtension } from "./details";
+
+interface JsonNode {
+  type?: string;
+  attrs?: Record<string, unknown>;
+  content?: JsonNode[];
+}
+
+function makeEditor() {
+  const element = document.createElement("div");
+  document.body.appendChild(element);
+  return new Editor({
+    element,
+    extensions: [
+      StarterKit,
+      DetailsBlockExtension,
+      Markdown.configure({ indentation: { style: "space", size: 3 } }),
+    ],
+  });
+}
+
+function findAll(node: JsonNode, type: string, acc: JsonNode[] = []): JsonNode[] {
+  if (node.type === type) acc.push(node);
+  for (const child of node.content ?? []) findAll(child, type, acc);
+  return acc;
+}
+
+let editor: Editor | null = null;
+
+afterEach(() => {
+  editor?.destroy();
+  editor = null;
+  document.body.innerHTML = "";
+});
+
+const SIMPLE = `<details>
+<summary>Click to expand</summary>
+
+Hidden **markdown** body.
+
+- one
+- two
+</details>`;
+
+describe("details editor extension", () => {
+  it("parses a <details> block into a detailsBlock node", () => {
+    editor = makeEditor();
+    editor.commands.setContent(SIMPLE, { contentType: "markdown" });
+
+    const blocks = findAll(editor.getJSON() as JsonNode, "detailsBlock");
+    expect(blocks).toHaveLength(1);
+    expect(blocks[0]?.attrs?.summary).toBe("Click to expand");
+    expect(blocks[0]?.attrs?.body).toBe(
+      "Hidden **markdown** body.\n\n- one\n- two",
+    );
+    expect(blocks[0]?.attrs?.open).toBe(false);
+  });
+
+  it("round-trips a <details> block on save (verbatim inner markdown)", () => {
+    editor = makeEditor();
+    editor.commands.setContent(SIMPLE, { contentType: "markdown" });
+
+    expect(editor.getMarkdown().trim()).toBe(SIMPLE);
+  });
+
+  it("is idempotent: reloading the saved markdown yields the same output", () => {
+    editor = makeEditor();
+    editor.commands.setContent(SIMPLE, { contentType: "markdown" });
+    const once = editor.getMarkdown().trim();
+
+    editor.commands.setContent(once, { contentType: "markdown" });
+    const twice = editor.getMarkdown().trim();
+
+    expect(twice).toBe(once);
+    expect(findAll(editor.getJSON() as JsonNode, "detailsBlock")).toHaveLength(1);
+  });
+
+  it("survives an edit to surrounding content instead of being dropped", () => {
+    const doc = `Intro paragraph.
+
+${SIMPLE}
+
+Outro paragraph.`;
+    editor = makeEditor();
+    editor.commands.setContent(doc, { contentType: "markdown" });
+
+    // The block is preserved as a node, so editing elsewhere cannot silently
+    // destroy it (the original bug flattened/lost it on the next save).
+    const blocks = findAll(editor.getJSON() as JsonNode, "detailsBlock");
+    expect(blocks).toHaveLength(1);
+
+    const out = editor.getMarkdown();
+    expect(out).toContain("<details>");
+    expect(out).toContain("<summary>Click to expand</summary>");
+    expect(out).toContain("Intro paragraph.");
+    expect(out).toContain("Outro paragraph.");
+  });
+
+  it("preserves the open attribute", () => {
+    const md = `<details open>
+<summary>Expanded by default</summary>
+
+Body.
+</details>`;
+    editor = makeEditor();
+    editor.commands.setContent(md, { contentType: "markdown" });
+
+    const blocks = findAll(editor.getJSON() as JsonNode, "detailsBlock");
+    expect(blocks).toHaveLength(1);
+    expect(blocks[0]?.attrs?.open).toBe(true);
+    expect(editor.getMarkdown().trim()).toBe(md);
+  });
+
+  it("declines nested <details> (falls back rather than breaking round-trip)", () => {
+    const md = `<details>
+<summary>Outer</summary>
+
+<details>
+<summary>Inner</summary>
+
+nested
+</details>
+</details>`;
+    editor = makeEditor();
+    editor.commands.setContent(md, { contentType: "markdown" });
+
+    // The outer block declines tokenization (its body still holds an opener),
+    // so it is NOT collapsed into a single detailsBlock covering both levels —
+    // that is the documented fallback. The key guarantee is that no content is
+    // silently destroyed: every piece of text still round-trips.
+    const out = editor.getMarkdown();
+    expect(out).toContain("Outer");
+    expect(out).toContain("Inner");
+    expect(out).toContain("nested");
+  });
+});

--- a/packages/views/editor/extensions/details.tsx
+++ b/packages/views/editor/extensions/details.tsx
@@ -45,7 +45,7 @@ import { ReadonlyContent } from "../readonly-content";
 // only to detect the `open` flag); group 2 = summary inner text; group 3 = the
 // body between </summary> and </details>.
 const DETAILS_BLOCK_RE =
-  /^<details((?:\s[^>]*)?)>[ \t]*\n?[ \t]*<summary>([\s\S]*?)<\/summary>([\s\S]*?)<\/details>[ \t]*(?:\n|$)/;
+  /^<details((?:\s[^>]*)?)>\s*<summary>([\s\S]*?)<\/summary>([\s\S]*?)<\/details>[ \t]*(?:\n|$)/;
 
 // ---------------------------------------------------------------------------
 // React NodeView — a native <details> so the browser handles the collapse,
@@ -141,13 +141,18 @@ export const DetailsBlockExtension = Node.create({
       // leaving a dangling opener in the body. Decline so it falls back to
       // the flattened rendering instead of producing a broken round-trip.
       if (/<details[\s>]/.test(body)) return undefined;
+      // A body ending mid-code-fence means the lazy </details> match truncated
+      // inside a fenced sample that itself contained a </details>. An odd fence
+      // count is the tell-tale of that truncation — decline so the block falls
+      // back to flat rendering instead of leaking an unterminated fence.
+      if (((body.match(/```/g) ?? []).length) % 2 !== 0) return undefined;
       return {
         type: "detailsBlock",
         raw: match[0],
         attributes: {
           summary: (match[2] ?? "").trim(),
           body,
-          open: /\bopen\b/.test(match[1] ?? ""),
+          open: /(^|\s)open(\s|=|$)/.test(match[1] ?? ""),
         },
       };
     },

--- a/packages/views/editor/extensions/details.tsx
+++ b/packages/views/editor/extensions/details.tsx
@@ -24,10 +24,15 @@
  * the SAME `ReadonlyContent` renderer the autopilot view uses, so a collapsed
  * block on an issue looks identical to the autopilot view.
  *
- * Trade-off (consistent with the other atom nodes): the body is edited as a unit
- * (via markdown source) rather than inline. That fits real usage — these blocks
- * are authored by autopilots and mostly *viewed* on generated issues; the
- * priority is safe round-trip over in-place authoring.
+ * Editing: the node stays an `atom`, but in an editable editor the NodeView
+ * swaps its read-only preview for form controls — an inline `<input>` for the
+ * summary and a source-edit `<textarea>` for the body — that write straight
+ * back to the `summary`/`body` attributes via `updateAttributes`. Because the
+ * attributes remain the verbatim source of truth, an edit still round-trips to
+ * `<details>` markdown unchanged. Keeping the body as a markdown source field
+ * (rather than promoting it to real ProseMirror content) is deliberate: it
+ * preserves that verbatim round-trip for arbitrary bodies (code fences, lists),
+ * which real ProseMirror content could not guarantee.
  *
  * Known limitation: a `<details>` nested inside another `<details>` is not parsed
  * as collapsible — the tokenizer declines it (the inner block's `</details>`
@@ -48,14 +53,40 @@ const DETAILS_BLOCK_RE =
   /^<details((?:\s[^>]*)?)>\s*<summary>([\s\S]*?)<\/summary>([\s\S]*?)<\/details>[ \t]*(?:\n|$)/;
 
 // ---------------------------------------------------------------------------
-// React NodeView — a native <details> so the browser handles the collapse,
-// with the body rendered through the shared ReadonlyContent markdown renderer.
+// React NodeView. When the editor is read-only it renders a native <details>
+// so the browser handles the collapse, with the body rendered through the
+// shared ReadonlyContent markdown renderer. When the editor is editable it
+// swaps in form controls that write edits back to the node attributes.
 // ---------------------------------------------------------------------------
 
-export function DetailsBlockView({ node }: NodeViewProps) {
+export function DetailsBlockView({ node, updateAttributes, editor }: NodeViewProps) {
   const summary = String(node.attrs.summary ?? "");
   const body = String(node.attrs.body ?? "");
   const open = Boolean(node.attrs.open);
+  const editable = editor?.isEditable ?? false;
+
+  if (!editable) {
+    return (
+      <NodeViewWrapper
+        as="div"
+        className="details-block-node"
+        data-type="detailsBlock"
+      >
+        <details className="details-block" open={open} contentEditable={false}>
+          <summary className="details-block-summary">{summary || "Details"}</summary>
+          <div className="details-block-body">
+            <ReadonlyContent content={body} />
+          </div>
+        </details>
+      </NodeViewWrapper>
+    );
+  }
+
+  // Keep keystrokes and pointer gestures inside the form controls so ProseMirror
+  // keymaps (Backspace deleting the node, Enter splitting, etc.) don't fire while
+  // the user is typing in a field. The controls live in a contentEditable=false
+  // shell, matching the other atom node views.
+  const stop = (e: { stopPropagation: () => void }) => e.stopPropagation();
 
   return (
     <NodeViewWrapper
@@ -63,12 +94,28 @@ export function DetailsBlockView({ node }: NodeViewProps) {
       className="details-block-node"
       data-type="detailsBlock"
     >
-      <details className="details-block" open={open} contentEditable={false}>
-        <summary className="details-block-summary">{summary || "Details"}</summary>
-        <div className="details-block-body">
-          <ReadonlyContent content={body} />
-        </div>
-      </details>
+      <div className="details-block details-block--editing" contentEditable={false}>
+        <input
+          className="details-block-summary-input"
+          type="text"
+          value={summary}
+          placeholder="Details"
+          aria-label="Summary"
+          onChange={(e) => updateAttributes({ summary: e.target.value })}
+          onKeyDown={stop}
+          onMouseDown={stop}
+        />
+        <textarea
+          className="details-block-body-input"
+          value={body}
+          placeholder="Body (Markdown)"
+          aria-label="Details body (Markdown)"
+          rows={Math.max(3, body.split("\n").length)}
+          onChange={(e) => updateAttributes({ body: e.target.value })}
+          onKeyDown={stop}
+          onMouseDown={stop}
+        />
+      </div>
     </NodeViewWrapper>
   );
 }

--- a/packages/views/editor/extensions/details.tsx
+++ b/packages/views/editor/extensions/details.tsx
@@ -1,0 +1,170 @@
+"use client";
+
+/**
+ * DetailsBlock — Tiptap node extension for collapsible `<details>`/`<summary>`
+ * blocks (the GitHub-flavored disclosure widget autopilots emit).
+ *
+ * Why this exists
+ * ---------------
+ * Autopilot descriptions and issue *comments* render through `ReadonlyContent`
+ * (react-markdown + rehype-raw + rehype-sanitize), whose sanitize schema already
+ * allows `<details>`/`<summary>`, so those collapse correctly. The issue
+ * *description*, however, renders through the Tiptap `ContentEditor`. ProseMirror
+ * had no node for `<details>`, so `@tiptap/markdown` dropped the tags — both on
+ * load (the block flattened into its raw text) AND on save (the block was
+ * silently destroyed the moment anyone edited the description).
+ *
+ * Approach (modeled on the math / file-card atom nodes)
+ * -----------------------------------------------------
+ * A block-level `markdownTokenizer` captures a whole
+ * `<details><summary>…</summary>…</details>` block and stores the summary and
+ * the inner body markdown **verbatim** as attributes. `renderMarkdown` re-emits
+ * the exact same block, so an edit elsewhere in the description round-trips this
+ * block instead of losing it. The NodeView renders the body collapsibly through
+ * the SAME `ReadonlyContent` renderer the autopilot view uses, so a collapsed
+ * block on an issue looks identical to the autopilot view.
+ *
+ * Trade-off (consistent with the other atom nodes): the body is edited as a unit
+ * (via markdown source) rather than inline. That fits real usage — these blocks
+ * are authored by autopilots and mostly *viewed* on generated issues; the
+ * priority is safe round-trip over in-place authoring.
+ *
+ * Known limitation: a `<details>` nested inside another `<details>` is not parsed
+ * as collapsible — the tokenizer declines it (the inner block's `</details>`
+ * would close the outer one), so it falls back to the previous flattened
+ * rendering rather than breaking the round-trip.
+ */
+
+import { Node, mergeAttributes } from "@tiptap/core";
+import { ReactNodeViewRenderer, NodeViewWrapper } from "@tiptap/react";
+import type { NodeViewProps } from "@tiptap/react";
+import { ReadonlyContent } from "../readonly-content";
+
+// Matches a complete <details><summary>…</summary>…</details> block at the
+// start of the remaining source. Group 1 = the raw `<details>` attributes (used
+// only to detect the `open` flag); group 2 = summary inner text; group 3 = the
+// body between </summary> and </details>.
+const DETAILS_BLOCK_RE =
+  /^<details((?:\s[^>]*)?)>[ \t]*\n?[ \t]*<summary>([\s\S]*?)<\/summary>([\s\S]*?)<\/details>[ \t]*(?:\n|$)/;
+
+// ---------------------------------------------------------------------------
+// React NodeView — a native <details> so the browser handles the collapse,
+// with the body rendered through the shared ReadonlyContent markdown renderer.
+// ---------------------------------------------------------------------------
+
+export function DetailsBlockView({ node }: NodeViewProps) {
+  const summary = String(node.attrs.summary ?? "");
+  const body = String(node.attrs.body ?? "");
+  const open = Boolean(node.attrs.open);
+
+  return (
+    <NodeViewWrapper
+      as="div"
+      className="details-block-node"
+      data-type="detailsBlock"
+    >
+      <details className="details-block" open={open} contentEditable={false}>
+        <summary className="details-block-summary">{summary || "Details"}</summary>
+        <div className="details-block-body">
+          <ReadonlyContent content={body} />
+        </div>
+      </details>
+    </NodeViewWrapper>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Tiptap Node Extension
+// ---------------------------------------------------------------------------
+
+export const DetailsBlockExtension = Node.create({
+  name: "detailsBlock",
+  group: "block",
+  atom: true,
+  defining: true,
+  isolating: true,
+  selectable: true,
+
+  addAttributes() {
+    return {
+      // The three attributes are the source of truth for both rendering and
+      // markdown serialization; none are reflected onto the DOM by ProseMirror
+      // (the NodeView owns the DOM), so `rendered: false`.
+      summary: { default: "", rendered: false },
+      body: { default: "", rendered: false },
+      open: { default: false, rendered: false },
+    };
+  },
+
+  parseHTML() {
+    return [
+      {
+        tag: 'div[data-type="detailsBlock"]',
+        getAttrs: (el) => {
+          const node = el as HTMLElement;
+          return {
+            summary: node.getAttribute("data-summary") ?? "",
+            body: node.getAttribute("data-body") ?? "",
+            open: node.hasAttribute("data-open"),
+          };
+        },
+      },
+    ];
+  },
+
+  renderHTML({ node, HTMLAttributes }) {
+    return [
+      "div",
+      mergeAttributes(HTMLAttributes, {
+        "data-type": "detailsBlock",
+        "data-summary": node.attrs.summary,
+        "data-body": node.attrs.body,
+        ...(node.attrs.open ? { "data-open": "" } : {}),
+      }),
+    ];
+  },
+
+  // Capture the whole <details> block before @tiptap/markdown's default HTML
+  // handling flattens it. Declining (returning undefined) leaves the raw HTML
+  // to the previous fallback path.
+  markdownTokenizer: {
+    name: "detailsBlock",
+    level: "block" as const,
+    start(src: string) {
+      return src.search(/^<details[\s>]/m);
+    },
+    tokenize(src: string) {
+      const match = src.match(DETAILS_BLOCK_RE);
+      if (!match) return undefined;
+      const body = (match[3] ?? "").trim();
+      // Nested <details> would have matched the inner block's </details>,
+      // leaving a dangling opener in the body. Decline so it falls back to
+      // the flattened rendering instead of producing a broken round-trip.
+      if (/<details[\s>]/.test(body)) return undefined;
+      return {
+        type: "detailsBlock",
+        raw: match[0],
+        attributes: {
+          summary: (match[2] ?? "").trim(),
+          body,
+          open: /\bopen\b/.test(match[1] ?? ""),
+        },
+      };
+    },
+  },
+
+  parseMarkdown: (token: any, helpers: any) => {
+    return helpers.createNode("detailsBlock", token.attributes);
+  },
+
+  renderMarkdown: (node: any) => {
+    const summary = String(node.attrs?.summary ?? "").trim();
+    const body = String(node.attrs?.body ?? "").trim();
+    const open = node.attrs?.open ? " open" : "";
+    return `<details${open}>\n<summary>${summary}</summary>\n\n${body}\n</details>`;
+  },
+
+  addNodeView() {
+    return ReactNodeViewRenderer(DetailsBlockView);
+  },
+});

--- a/packages/views/editor/extensions/details.tsx
+++ b/packages/views/editor/extensions/details.tsx
@@ -25,14 +25,20 @@
  * block on an issue looks identical to the autopilot view.
  *
  * Editing: the node stays an `atom`, but in an editable editor the NodeView
- * swaps its read-only preview for form controls — an inline `<input>` for the
- * summary and a source-edit `<textarea>` for the body — that write straight
- * back to the `summary`/`body` attributes via `updateAttributes`. Because the
- * attributes remain the verbatim source of truth, an edit still round-trips to
- * `<details>` markdown unchanged. Keeping the body as a markdown source field
- * (rather than promoting it to real ProseMirror content) is deliberate: it
- * preserves that verbatim round-trip for arbitrary bodies (code fences, lists),
- * which real ProseMirror content could not guarantee.
+ * keeps the native `<details>` chrome and puts form controls inside it — an
+ * inline `<input>` in the `<summary>` and a source-edit `<textarea>` in the
+ * expanded region — that write straight back to the `summary`/`body`
+ * attributes via `updateAttributes`. Because the attributes remain the
+ * verbatim source of truth, an edit still round-trips to `<details>` markdown
+ * unchanged. Keeping the body as a markdown source field (rather than
+ * promoting it to real ProseMirror content) is deliberate: it preserves that
+ * verbatim round-trip for arbitrary bodies (code fences, lists), which real
+ * ProseMirror content could not guarantee.
+ *
+ * The collapse state is local UI state initialized from the `open` attribute:
+ * the block renders collapsed by default (expanded only when authored as
+ * `<details open>`), and folding/unfolding never writes back to the document,
+ * so merely peeking inside a block does not dirty the description.
  *
  * Known limitation: a `<details>` nested inside another `<details>` is not parsed
  * as collapsible — the tokenizer declines it (the inner block's `</details>`
@@ -40,6 +46,7 @@
  * rendering rather than breaking the round-trip.
  */
 
+import { useState } from "react";
 import { Node, mergeAttributes } from "@tiptap/core";
 import { ReactNodeViewRenderer, NodeViewWrapper } from "@tiptap/react";
 import type { NodeViewProps } from "@tiptap/react";
@@ -53,10 +60,12 @@ const DETAILS_BLOCK_RE =
   /^<details((?:\s[^>]*)?)>\s*<summary>([\s\S]*?)<\/summary>([\s\S]*?)<\/details>[ \t]*(?:\n|$)/;
 
 // ---------------------------------------------------------------------------
-// React NodeView. When the editor is read-only it renders a native <details>
-// so the browser handles the collapse, with the body rendered through the
-// shared ReadonlyContent markdown renderer. When the editor is editable it
-// swaps in form controls that write edits back to the node attributes.
+// React NodeView. Both modes render a native <details> so the block stays
+// collapsible. When the editor is read-only the summary is plain text and the
+// body renders through the shared ReadonlyContent markdown renderer. When the
+// editor is editable the summary becomes an inline <input> and the body a
+// source <textarea> that write edits back to the node attributes; the fold
+// itself is local UI state so toggling it never dirties the doc.
 // ---------------------------------------------------------------------------
 
 export function DetailsBlockView({ node, updateAttributes, editor }: NodeViewProps) {
@@ -64,6 +73,12 @@ export function DetailsBlockView({ node, updateAttributes, editor }: NodeViewPro
   const body = String(node.attrs.body ?? "");
   const open = Boolean(node.attrs.open);
   const editable = editor?.isEditable ?? false;
+
+  // Fold state is local UI state, initialized from the stored `open` attr so
+  // a block authored as `<details open>` starts expanded. Toggling must NOT
+  // write `open` back through updateAttributes — merely folding/unfolding the
+  // block would otherwise mark the description as modified.
+  const [expanded, setExpanded] = useState(open);
 
   if (!editable) {
     return (
@@ -94,17 +109,28 @@ export function DetailsBlockView({ node, updateAttributes, editor }: NodeViewPro
       className="details-block-node"
       data-type="detailsBlock"
     >
-      <div className="details-block details-block--editing" contentEditable={false}>
-        <input
-          className="details-block-summary-input"
-          type="text"
-          value={summary}
-          placeholder="Details"
-          aria-label="Summary"
-          onChange={(e) => updateAttributes({ summary: e.target.value })}
-          onKeyDown={stop}
-          onMouseDown={stop}
-        />
+      <details
+        className="details-block details-block--editing"
+        open={expanded}
+        onToggle={(e) => setExpanded(e.currentTarget.open)}
+        contentEditable={false}
+      >
+        <summary className="details-block-summary">
+          <input
+            className="details-block-summary-input"
+            type="text"
+            value={summary}
+            placeholder="Details"
+            aria-label="Summary"
+            onChange={(e) => updateAttributes({ summary: e.target.value })}
+            onKeyDown={stop}
+            onMouseDown={stop}
+            // Clicking anywhere in a <summary> toggles the <details>; swallow
+            // the click's default action so focusing the field doesn't fold
+            // the block. (Focus itself happens on mousedown, unaffected.)
+            onClick={(e) => e.preventDefault()}
+          />
+        </summary>
         <textarea
           className="details-block-body-input"
           value={body}
@@ -115,7 +141,7 @@ export function DetailsBlockView({ node, updateAttributes, editor }: NodeViewPro
           onKeyDown={stop}
           onMouseDown={stop}
         />
-      </div>
+      </details>
     </NodeViewWrapper>
   );
 }

--- a/packages/views/editor/extensions/index.ts
+++ b/packages/views/editor/extensions/index.ts
@@ -55,6 +55,7 @@ import { createFileUploadExtension } from "./file-upload";
 import { FileCardExtension } from "./file-card";
 import { ImageView } from "./image-view";
 import { BlockMathExtension, InlineMathExtension } from "./math";
+import { DetailsBlockExtension } from "./details";
 import { HighlightExtension } from "./highlight";
 import { codeLowlight } from "../syntax-highlight";
 
@@ -215,6 +216,7 @@ export function createEditorExtensions(
     TableCell,
     BlockMathExtension,
     InlineMathExtension,
+    DetailsBlockExtension,
     HighlightExtension,
     // 3-space indent so nested ordered lists survive CommonMark in ReadonlyContent.
     Markdown.configure({ indentation: { style: "space", size: 3 } }),

--- a/packages/views/editor/styles/details.css
+++ b/packages/views/editor/styles/details.css
@@ -42,3 +42,36 @@
 .rich-text-editor .details-block-body > .rich-text-editor {
   margin: 0;
 }
+
+/* Editing mode: the read-only preview is replaced by form controls that write
+   back to the node attributes. The container stays a bordered panel so the
+   block is still visually recognizable while both fields are exposed. */
+.rich-text-editor .details-block--editing {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.rich-text-editor .details-block-summary-input,
+.rich-text-editor .details-block-body-input {
+  width: 100%;
+  background: var(--background);
+  border: 1px solid var(--border);
+  border-radius: calc(var(--radius) - 2px);
+  color: inherit;
+  font: inherit;
+  padding: 0.35rem 0.5rem;
+}
+
+.rich-text-editor .details-block-summary-input {
+  font-weight: 500;
+}
+
+.rich-text-editor .details-block-body-input {
+  resize: vertical;
+  min-height: 4.5rem;
+  font-family: var(--font-mono, ui-monospace, monospace);
+  font-size: 0.9em;
+  line-height: 1.5;
+  white-space: pre;
+}

--- a/packages/views/editor/styles/details.css
+++ b/packages/views/editor/styles/details.css
@@ -1,0 +1,44 @@
+/* Collapsible <details>/<summary> blocks (DetailsBlock node view) */
+.rich-text-editor .details-block {
+  background: var(--muted);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  margin: 0.75rem 0;
+  padding: 0.5rem 0.75rem;
+}
+
+.rich-text-editor .details-block-summary {
+  cursor: pointer;
+  font-weight: 500;
+  list-style: none;
+  outline: none;
+  user-select: none;
+}
+
+/* Hide the native disclosure triangle and draw our own so it matches the
+   caret used elsewhere in the editor chrome. */
+.rich-text-editor .details-block-summary::-webkit-details-marker {
+  display: none;
+}
+
+.rich-text-editor .details-block-summary::before {
+  content: "▸";
+  display: inline-block;
+  margin-right: 0.4rem;
+  color: var(--muted-foreground);
+  transition: transform 0.15s;
+}
+
+.rich-text-editor .details-block[open] > .details-block-summary::before {
+  transform: rotate(90deg);
+}
+
+.rich-text-editor .details-block-body {
+  margin-top: 0.5rem;
+}
+
+/* The body renders through ReadonlyContent, which wraps in its own
+   .rich-text-editor; strip its outer margins so it sits flush in the panel. */
+.rich-text-editor .details-block-body > .rich-text-editor {
+  margin: 0;
+}

--- a/packages/views/editor/styles/details.css
+++ b/packages/views/editor/styles/details.css
@@ -43,13 +43,13 @@
   margin: 0;
 }
 
-/* Editing mode: the read-only preview is replaced by form controls that write
-   back to the node attributes. The container stays a bordered panel so the
-   block is still visually recognizable while both fields are exposed. */
-.rich-text-editor .details-block--editing {
+/* Editing mode: the block keeps the native <details> chrome (collapsed by
+   default, caret toggle) but the summary text is replaced by an inline <input>
+   and the expanded region holds a body source <textarea>; both write back to
+   the node attributes. */
+.rich-text-editor .details-block--editing > .details-block-summary {
   display: flex;
-  flex-direction: column;
-  gap: 0.5rem;
+  align-items: center;
 }
 
 .rich-text-editor .details-block-summary-input,
@@ -64,10 +64,18 @@
 }
 
 .rich-text-editor .details-block-summary-input {
+  flex: 1;
+  min-width: 0;
+  width: auto;
   font-weight: 500;
+  /* The summary disables text selection for the caret toggle; re-enable it in
+     the field so the summary text stays selectable while editing. */
+  user-select: text;
 }
 
 .rich-text-editor .details-block-body-input {
+  display: block;
+  margin-top: 0.5rem;
   resize: vertical;
   min-height: 4.5rem;
   font-family: var(--font-mono, ui-monospace, monospace);

--- a/packages/views/editor/styles/index.css
+++ b/packages/views/editor/styles/index.css
@@ -11,3 +11,4 @@
 @import "./code.css";
 @import "./mermaid.css";
 @import "./media.css";
+@import "./details.css";


### PR DESCRIPTION
## Summary

Adds full support for `<details>`/`<summary>` collapsible HTML blocks in the issue description and comment editor. Previously these blocks rendered flat/expanded on issues (while working correctly in the autopilot view). This PR adds tokenization, rendering, and inline editing for the block.

## Changes

### 1. `feat(editor): support collapsible <details>/<summary> blocks in issue and comment rendering`
- New `details` ProseMirror node type with HTML tokenization from `<details>`/`<summary>` markdown
- `DetailsBlockView` NodeView: collapsed preview in read-only mode (via `ReadonlyContent`), full markdown rendering with headings, lists, code blocks
- Dedicated `details.css` styles for the collapsible block

### 2. `refactor(editor): harden details/summary tokenizer per review`
- Hardened the HTML tokenizer against edge cases (malformed HTML, nested blocks, missing summary)

### 3. `fix(editor): make details/summary block editable in the editor`
- Editable mode renders an inline `<input>` for the summary and a source-edit `<textarea>` (raw Markdown) for the body
- Both write back to node attributes via `updateAttributes`, preserving the `open` flag
- Read-only path unchanged — collapsed preview via `ReadonlyContent`
- Node stays an `atom` with Markdown source as the verbatim source of truth, guaranteeing parse → edit → serialize round-trip fidelity

## Files changed

| File | Description |
|------|-------------|
| `packages/views/editor/extensions/details.tsx` | Node spec, tokenizer, and `DetailsBlockView` NodeView |
| `packages/views/editor/extensions/index.ts` | Register the `details` extension |
| `packages/views/editor/extensions/details.test.tsx` | Model-level parse/serialize round-trip tests |
| `packages/views/editor/extensions/details-view.test.tsx` | NodeView rendering tests (editable + read-only) |
| `packages/views/editor/styles/details.css` | Block styles |
| `packages/views/editor/styles/index.css` | Import details styles |

## Verification

- `pnpm typecheck` — pass (all 6 packages)
- Editor suite (`packages/views/editor`) — 582 tests passed, including 8 new/updated details tests
- `pnpm lint` (views) — 0 errors in changed files

## Before / After

**Before:** 
<img width="1280" height="1400" alt="image" src="https://github.com/user-attachments/assets/c6ea8676-beb2-45e4-89fd-a7bb7ec06ad0" />

**After:** 
<img width="1280" height="1400" alt="image" src="https://github.com/user-attachments/assets/ccfa3010-ffc0-41fe-b045-8762bac1a67c" />
<img width="1280" height="1400" alt="image" src="https://github.com/user-attachments/assets/2bd668bb-c9c2-4aa0-9bdc-def45b010fef" />
