### PR TITLE
fix(comments): preserve suppression through reconciliation

### DIFF
--- a/server/internal/handler/comment.go
+++ b/server/internal/handler/comment.go
@@ -1302,6 +1302,7 @@ func (h *Handler) CreateComment(w http.ResponseWriter, r *http.Request) {
 	if !ok {
 		return
 	}
+	suppressAgentIDs = deduplicateUUIDs(suppressAgentIDs)
 
 	// Determine author identity: agent (via X-Agent-ID header) or member.
 	authorType, authorID := h.resolveActor(r, userID, uuidToString(issue.WorkspaceID))
@@ -1383,14 +1384,15 @@ func (h *Handler) CreateComment(w http.ResponseWriter, r *http.Request) {
 	}
 
 	comment, err := h.Queries.CreateComment(r.Context(), db.CreateCommentParams{
-		IssueID:      issue.ID,
-		WorkspaceID:  issue.WorkspaceID,
-		AuthorType:   authorType,
-		AuthorID:     parseUUID(authorID),
-		Content:      req.Content,
-		Type:         req.Type,
-		ParentID:     parentID,
-		SourceTaskID: sourceTaskID,
+		IssueID:            issue.ID,
+		WorkspaceID:        issue.WorkspaceID,
+		AuthorType:         authorType,
+		AuthorID:           parseUUID(authorID),
+		Content:            req.Content,
+		Type:               req.Type,
+		ParentID:           parentID,
+		SourceTaskID:       sourceTaskID,
+		SuppressedAgentIds: suppressAgentIDs,
 	})
 	if err != nil {
 		slog.Warn("create comment failed", append(logger.RequestAttrs(r), "error", err, "issue_id", issueID)...)
@@ -1496,6 +1498,25 @@ func filterSuppressedCommentAgentTriggers(triggers []commentAgentTrigger, suppre
 		filtered = append(filtered, trigger)
 	}
 	return filtered
+}
+
+func deduplicateUUIDs(ids []pgtype.UUID) []pgtype.UUID {
+	if len(ids) < 2 {
+		return ids
+	}
+	unique := make([]pgtype.UUID, 0, len(ids))
+	seen := make(map[[16]byte]struct{}, len(ids))
+	for _, id := range ids {
+		if !id.Valid {
+			continue
+		}
+		if _, ok := seen[id.Bytes]; ok {
+			continue
+		}
+		seen[id.Bytes] = struct{}{}
+		unique = append(unique, id)
+	}
+	return unique
 }
 
 // commentEnqueueResult is the domain outcome of enqueuing ONE executing agent.
@@ -2456,10 +2477,20 @@ func (h *Handler) UpdateComment(w http.ResponseWriter, r *http.Request) {
 	if !ok {
 		return
 	}
+	suppressAgentIDs = deduplicateUUIDs(suppressAgentIDs)
 
 	// NOTE: See CreateComment — Markdown is sanitized at render/edit time, not here.
 
 	oldContent := existing.Content
+	// Suppression belongs to the routing action, not to attachment-only or other
+	// content-preserving updates. A content edit is a new routing action and
+	// replaces the prior suppression set (omission deliberately means empty);
+	// an unchanged edit retains the original contract so a later completion
+	// reconcile cannot resurrect a target that was suppressed on creation.
+	suppressedAgentIDsForWrite := existing.SuppressedAgentIds
+	if oldContent != req.Content {
+		suppressedAgentIDsForWrite = suppressAgentIDs
+	}
 	// Preserve the existing authority lineage by default — this path is taken only
 	// for an UNCHANGED edit (no re-trigger). When the content changes below, the
 	// lineage is re-derived from the EDIT action itself (MUL-4857), never carried
@@ -2499,9 +2530,10 @@ func (h *Handler) UpdateComment(w http.ResponseWriter, r *http.Request) {
 	}
 
 	comment, err := h.Queries.UpdateComment(r.Context(), db.UpdateCommentParams{
-		ID:           commentUUID,
-		Content:      req.Content,
-		SourceTaskID: sourceTaskID,
+		ID:                 commentUUID,
+		Content:            req.Content,
+		SourceTaskID:       sourceTaskID,
+		SuppressedAgentIds: suppressedAgentIDsForWrite,
 	})
 	if err != nil {
 		slog.Warn("update comment failed", append(logger.RequestAttrs(r), "error", err, "comment_id", commentId)...)

--- a/server/internal/handler/comment_reconcile_test.go
+++ b/server/internal/handler/comment_reconcile_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/go-chi/chi/v5"
+	"github.com/jackc/pgx/v5/pgtype"
 	"github.com/multica-ai/multica/server/internal/util"
 	db "github.com/multica-ai/multica/server/pkg/db/generated"
 )
@@ -118,6 +119,100 @@ func TestCompleteTask_ReconcilesMemberCommentPostedDuringRun(t *testing.T) {
 	// A follow-up run must now be queued for the agent.
 	if n := pendingTaskCountForAgentIssue(t, issueID, agentID); n != 1 {
 		t.Fatalf("expected exactly 1 follow-up task after reconciliation, got %d", n)
+	}
+}
+
+// TestCompleteTask_PreservesSuppressionDuringReconcile covers the delayed
+// routing race: a member comment posted while its assignee is already active
+// cannot be enqueued immediately and is revisited at task completion. The
+// persisted suppression contract must still prevent a follow-up wake.
+func TestCompleteTask_PreservesSuppressionDuringReconcile(t *testing.T) {
+	if testHandler == nil {
+		t.Skip("database not available")
+	}
+	ctx := context.Background()
+
+	var agentID, runtimeID string
+	if err := testPool.QueryRow(ctx,
+		`SELECT id, runtime_id FROM agent WHERE workspace_id = $1 AND runtime_id IS NOT NULL LIMIT 1`,
+		testWorkspaceID).Scan(&agentID, &runtimeID); err != nil {
+		t.Fatalf("setup: get agent: %v", err)
+	}
+
+	var issueID string
+	if err := testPool.QueryRow(ctx, `
+		INSERT INTO issue (workspace_id, title, status, priority, creator_id, creator_type, number, position, assignee_type, assignee_id)
+		VALUES ($1, 'reconcile suppression fixture', 'in_progress', 'none', $2, 'member', 999011, 0, 'agent', $3)
+		RETURNING id
+	`, testWorkspaceID, testUserID, agentID).Scan(&issueID); err != nil {
+		t.Fatalf("setup: create issue: %v", err)
+	}
+	t.Cleanup(func() { testPool.Exec(ctx, `DELETE FROM issue WHERE id = $1`, issueID) })
+
+	var triggerCommentID string
+	if err := testPool.QueryRow(ctx, `
+		INSERT INTO comment (issue_id, workspace_id, author_type, author_id, content, type, created_at)
+		VALUES ($1, $2, 'member', $3, 'initial request', 'comment', now() - interval '10 minutes')
+		RETURNING id
+	`, issueID, testWorkspaceID, testUserID).Scan(&triggerCommentID); err != nil {
+		t.Fatalf("setup: trigger comment: %v", err)
+	}
+
+	var taskID string
+	if err := testPool.QueryRow(ctx, `
+		INSERT INTO agent_task_queue (agent_id, runtime_id, issue_id, trigger_comment_id, delivered_comment_ids, status, priority, created_at, started_at)
+		VALUES ($1, $2, $3, $4, ARRAY[$4::uuid], 'running', 0, now() - interval '10 minutes', now() - interval '5 minutes')
+		RETURNING id
+	`, agentID, runtimeID, issueID, triggerCommentID).Scan(&taskID); err != nil {
+		t.Fatalf("setup: running task: %v", err)
+	}
+	t.Cleanup(func() { testPool.Exec(ctx, `DELETE FROM agent_task_queue WHERE issue_id = $1`, issueID) })
+
+	commentID := postCommentForTriggerPreviewTest(t, issueID, map[string]any{
+		"content":            "suppressed mid-run follow-up",
+		"suppress_agent_ids": []string{agentID, agentID},
+	})
+	var persisted []pgtype.UUID
+	if err := testPool.QueryRow(ctx,
+		`SELECT suppressed_agent_ids FROM comment WHERE id = $1`, commentID,
+	).Scan(&persisted); err != nil {
+		t.Fatalf("load persisted suppression: %v", err)
+	}
+	if len(persisted) != 1 || !persisted[0].Valid || uuidToString(persisted[0]) != agentID {
+		t.Fatalf("persisted suppression = %v, want [%s]", persisted, agentID)
+	}
+
+	if w := completeTaskViaHandler(t, taskID, "done"); w.Code != http.StatusOK {
+		t.Fatalf("CompleteTask: expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	if n := pendingTaskCountForAgentIssue(t, issueID, agentID); n != 0 {
+		t.Fatalf("suppressed assignee must not receive a reconciled follow-up, got %d", n)
+	}
+}
+
+func TestCommentSuppressesAgent(t *testing.T) {
+	agent := util.MustParseUUID("11111111-1111-1111-1111-111111111111")
+	other := util.MustParseUUID("22222222-2222-2222-2222-222222222222")
+	tests := []struct {
+		name       string
+		suppressed []pgtype.UUID
+		agent      pgtype.UUID
+		want       bool
+	}{
+		{name: "empty metadata", agent: agent},
+		{name: "invalid target", suppressed: []pgtype.UUID{agent}},
+		{name: "different agent", suppressed: []pgtype.UUID{other}, agent: agent},
+		{name: "exact agent", suppressed: []pgtype.UUID{agent}, agent: agent, want: true},
+		{name: "duplicate exact agent", suppressed: []pgtype.UUID{agent, agent}, agent: agent, want: true},
+		{name: "invalid entries ignored", suppressed: []pgtype.UUID{{}, agent}, agent: agent, want: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			comment := db.Comment{SuppressedAgentIds: tt.suppressed}
+			if got := commentSuppressesAgent(comment, tt.agent); got != tt.want {
+				t.Fatalf("commentSuppressesAgent() = %v, want %v", got, tt.want)
+			}
+		})
 	}
 }
 

--- a/server/internal/handler/comment_trigger_preview_test.go
+++ b/server/internal/handler/comment_trigger_preview_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/jackc/pgx/v5/pgtype"
 	"github.com/multica-ai/multica/server/internal/util"
 )
 
@@ -966,6 +967,43 @@ func TestUpdateComment_SuppressAgentIDsFiltersEditRetrigger(t *testing.T) {
 	}
 	if got := countQueuedCommentTriggerTasks(t, issueID, agentB); got != 0 {
 		t.Fatalf("suppressed agent queued tasks = %d, want 0", got)
+	}
+}
+
+func TestUpdateComment_SuppressionEditSemantics(t *testing.T) {
+	if testHandler == nil || testPool == nil {
+		t.Skip("database not available")
+	}
+
+	agentID := createHandlerTestAgent(t, "Edit Suppression Semantics", nil)
+	issueID := createCommentTriggerPreviewIssue(t, "edit suppression semantics", "", "")
+	commentID := postCommentForTriggerPreviewTest(t, issueID, map[string]any{
+		"content":            "original content",
+		"suppress_agent_ids": []string{agentID},
+	})
+
+	readSuppressed := func() []pgtype.UUID {
+		t.Helper()
+		var ids []pgtype.UUID
+		if err := testPool.QueryRow(context.Background(),
+			`SELECT suppressed_agent_ids FROM comment WHERE id = $1`, commentID,
+		).Scan(&ids); err != nil {
+			t.Fatalf("read suppressed_agent_ids: %v", err)
+		}
+		return ids
+	}
+
+	// An attachment-only/content-preserving update is not a new routing action.
+	updateCommentForTriggerPreviewTest(t, commentID, map[string]any{"content": "original content"})
+	if ids := readSuppressed(); len(ids) != 1 || uuidToString(ids[0]) != agentID {
+		t.Fatalf("unchanged edit suppression = %v, want [%s]", ids, agentID)
+	}
+
+	// A content edit is a new routing action; omitting suppression replaces the
+	// old set with empty rather than silently inheriting stale transport policy.
+	updateCommentForTriggerPreviewTest(t, commentID, map[string]any{"content": "revised content"})
+	if ids := readSuppressed(); len(ids) != 0 {
+		t.Fatalf("changed edit suppression = %v, want empty", ids)
 	}
 }
 

--- a/server/internal/handler/daemon.go
+++ b/server/internal/handler/daemon.go
@@ -3008,6 +3008,15 @@ func (h *Handler) reconcileCommentsOnCompletion(ctx context.Context, task *db.Ag
 		if isNoteComment(c.Content) {
 			continue
 		}
+		// A comment can arrive while this agent already has a dispatched/running
+		// task. The creation-time trigger path then deliberately defers it to
+		// completion reconciliation. Preserve the original transport contract:
+		// an explicitly suppressed agent must stay suppressed here as well,
+		// otherwise the delayed path silently turns a no-wake protocol marker
+		// into a redundant follow-up run.
+		if commentSuppressesAgent(c, task.AgentID) {
+			continue
+		}
 		var parentComment *db.Comment
 		if c.ParentID.Valid {
 			// Scope to the issue's workspace; a comment's parent is always in the
@@ -3082,6 +3091,19 @@ func (h *Handler) reconcileCommentsOnCompletion(ctx context.Context, task *db.Ag
 			"agent_id", agentID,
 			"undelivered_comments", scheduled)
 	}
+}
+
+func commentSuppressesAgent(comment db.Comment, agentID pgtype.UUID) bool {
+	if !agentID.Valid {
+		return false
+	}
+	want := uuidToString(agentID)
+	for _, suppressedID := range comment.SuppressedAgentIds {
+		if suppressedID.Valid && uuidToString(suppressedID) == want {
+			return true
+		}
+	}
+	return false
 }
 
 // keepExplicitMentionTriggers filters a computed trigger set down to the ones

--- a/server/internal/service/builtin_skills/multica-mentioning/SKILL.md
+++ b/server/internal/service/builtin_skills/multica-mentioning/SKILL.md
@@ -88,7 +88,14 @@ When creating or editing a comment, clients may send an optional
 `suppress_agent_ids` array. The server still computes the full trigger set
 first, then removes those agent IDs as a post-filter. A missing or empty field
 preserves the old behavior. A valid UUID that is not in the computed trigger set
-is a no-op; a malformed UUID is rejected at the request boundary.
+is a no-op; duplicate UUIDs are collapsed before storage, and a malformed UUID
+is rejected at the request boundary.
+
+Suppression is durable per comment routing action. If a target is busy and the
+comment is reconsidered when that target's current task completes, the same
+exact agent IDs remain suppressed. A content edit is a new routing action and
+replaces the stored suppression set; an update that leaves content unchanged
+retains it.
 
 ## @all is the broadcast type
 

--- a/server/internal/service/builtin_skills/multica-mentioning/references/mentioning-source-map.md
+++ b/server/internal/service/builtin_skills/multica-mentioning/references/mentioning-source-map.md
@@ -56,6 +56,8 @@ a pointer.
 | Create-comment `suppress_agent_ids` is parsed as request-boundary UUID input | `server/internal/handler/comment.go:957-964` |
 | Update-comment `suppress_agent_ids` is parsed as request-boundary UUID input | `server/internal/handler/comment.go:1523-1535` |
 | Create and edit trigger paths compute the full trigger set, then apply `filterSuppressedCommentAgentTriggers` before enqueueing | `server/internal/handler/comment.go:1092-1122,1594` |
+| Comment suppression is stored with the comment and reapplied to the exact completing agent during deferred reconciliation | `server/pkg/db/queries/comment.sql` (`CreateComment`, `UpdateComment`); `server/internal/handler/daemon.go` (search `commentSuppressesAgent`) |
+| A content edit replaces stored suppression; a content-preserving update retains it | `server/internal/handler/comment.go` (search `suppressedAgentIDsForWrite`) |
 | Frontend API sends `editing_comment_id` for preview and `suppress_agent_ids` for update when present | `packages/core/api/client.ts:664-700` |
 | Edit UI calls preview with `editingCommentId`, renders trigger chips, tracks suppressed agents, and submits suppressions on save | `packages/views/issues/components/comment-card.tsx:269-274,300-315,359-367,578-582,858-862` |
 | Preview hook includes `editingCommentId` in its query key and sends it to the API | `packages/views/issues/hooks/use-comment-trigger-preview.ts:58-80` |

--- a/server/migrations/202_comment_suppressed_agent_ids.down.sql
+++ b/server/migrations/202_comment_suppressed_agent_ids.down.sql
@@ -1,0 +1,2 @@
+ALTER TABLE comment
+DROP COLUMN IF EXISTS suppressed_agent_ids;

--- a/server/migrations/202_comment_suppressed_agent_ids.up.sql
+++ b/server/migrations/202_comment_suppressed_agent_ids.up.sql
@@ -1,0 +1,6 @@
+-- Persist transport-level trigger suppression so a comment deferred while an
+-- agent task is active keeps the same routing contract during completion
+-- reconciliation. This metadata is intentionally not exposed in comment API
+-- responses; it only constrains agent wake delivery.
+ALTER TABLE comment
+ADD COLUMN suppressed_agent_ids UUID[] NOT NULL DEFAULT '{}';

--- a/server/pkg/db/generated/comment.sql.go
+++ b/server/pkg/db/generated/comment.sql.go
@@ -45,7 +45,7 @@ UPDATE comment SET
 WHERE comment.id IN (SELECT id FROM descendants)
   AND comment.id <> $1
   AND comment.resolved_at IS NOT NULL
-RETURNING id, issue_id, author_type, author_id, content, type, created_at, updated_at, parent_id, workspace_id, resolved_at, resolved_by_type, resolved_by_id, source_task_id
+RETURNING id, issue_id, author_type, author_id, content, type, created_at, updated_at, parent_id, workspace_id, resolved_at, resolved_by_type, resolved_by_id, source_task_id, suppressed_agent_ids
 `
 
 type ClearOtherThreadResolutionsParams struct {
@@ -88,6 +88,7 @@ func (q *Queries) ClearOtherThreadResolutions(ctx context.Context, arg ClearOthe
 			&i.ResolvedByType,
 			&i.ResolvedByID,
 			&i.SourceTaskID,
+			&i.SuppressedAgentIds,
 		); err != nil {
 			return nil, err
 		}
@@ -155,20 +156,21 @@ func (q *Queries) CountNewCommentsSince(ctx context.Context, arg CountNewComment
 }
 
 const createComment = `-- name: CreateComment :one
-INSERT INTO comment (issue_id, workspace_id, author_type, author_id, content, type, parent_id, source_task_id)
-VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
-RETURNING id, issue_id, author_type, author_id, content, type, created_at, updated_at, parent_id, workspace_id, resolved_at, resolved_by_type, resolved_by_id, source_task_id
+INSERT INTO comment (issue_id, workspace_id, author_type, author_id, content, type, parent_id, source_task_id, suppressed_agent_ids)
+VALUES ($1, $2, $3, $4, $5, $6, $7, $8, COALESCE($9::uuid[], '{}'::uuid[]))
+RETURNING id, issue_id, author_type, author_id, content, type, created_at, updated_at, parent_id, workspace_id, resolved_at, resolved_by_type, resolved_by_id, source_task_id, suppressed_agent_ids
 `
 
 type CreateCommentParams struct {
-	IssueID      pgtype.UUID `json:"issue_id"`
-	WorkspaceID  pgtype.UUID `json:"workspace_id"`
-	AuthorType   string      `json:"author_type"`
-	AuthorID     pgtype.UUID `json:"author_id"`
-	Content      string      `json:"content"`
-	Type         string      `json:"type"`
-	ParentID     pgtype.UUID `json:"parent_id"`
-	SourceTaskID pgtype.UUID `json:"source_task_id"`
+	IssueID            pgtype.UUID   `json:"issue_id"`
+	WorkspaceID        pgtype.UUID   `json:"workspace_id"`
+	AuthorType         string        `json:"author_type"`
+	AuthorID           pgtype.UUID   `json:"author_id"`
+	Content            string        `json:"content"`
+	Type               string        `json:"type"`
+	ParentID           pgtype.UUID   `json:"parent_id"`
+	SourceTaskID       pgtype.UUID   `json:"source_task_id"`
+	SuppressedAgentIds []pgtype.UUID `json:"suppressed_agent_ids"`
 }
 
 func (q *Queries) CreateComment(ctx context.Context, arg CreateCommentParams) (Comment, error) {
@@ -181,6 +183,7 @@ func (q *Queries) CreateComment(ctx context.Context, arg CreateCommentParams) (C
 		arg.Type,
 		arg.ParentID,
 		arg.SourceTaskID,
+		arg.SuppressedAgentIds,
 	)
 	var i Comment
 	err := row.Scan(
@@ -198,6 +201,7 @@ func (q *Queries) CreateComment(ctx context.Context, arg CreateCommentParams) (C
 		&i.ResolvedByType,
 		&i.ResolvedByID,
 		&i.SourceTaskID,
+		&i.SuppressedAgentIds,
 	)
 	return i, err
 }
@@ -218,7 +222,7 @@ func (q *Queries) DeleteComment(ctx context.Context, arg DeleteCommentParams) er
 }
 
 const getComment = `-- name: GetComment :one
-SELECT id, issue_id, author_type, author_id, content, type, created_at, updated_at, parent_id, workspace_id, resolved_at, resolved_by_type, resolved_by_id, source_task_id FROM comment
+SELECT id, issue_id, author_type, author_id, content, type, created_at, updated_at, parent_id, workspace_id, resolved_at, resolved_by_type, resolved_by_id, source_task_id, suppressed_agent_ids FROM comment
 WHERE id = $1
 `
 
@@ -240,12 +244,13 @@ func (q *Queries) GetComment(ctx context.Context, id pgtype.UUID) (Comment, erro
 		&i.ResolvedByType,
 		&i.ResolvedByID,
 		&i.SourceTaskID,
+		&i.SuppressedAgentIds,
 	)
 	return i, err
 }
 
 const getCommentInWorkspace = `-- name: GetCommentInWorkspace :one
-SELECT id, issue_id, author_type, author_id, content, type, created_at, updated_at, parent_id, workspace_id, resolved_at, resolved_by_type, resolved_by_id, source_task_id FROM comment
+SELECT id, issue_id, author_type, author_id, content, type, created_at, updated_at, parent_id, workspace_id, resolved_at, resolved_by_type, resolved_by_id, source_task_id, suppressed_agent_ids FROM comment
 WHERE id = $1 AND workspace_id = $2
 `
 
@@ -272,12 +277,13 @@ func (q *Queries) GetCommentInWorkspace(ctx context.Context, arg GetCommentInWor
 		&i.ResolvedByType,
 		&i.ResolvedByID,
 		&i.SourceTaskID,
+		&i.SuppressedAgentIds,
 	)
 	return i, err
 }
 
 const getLatestMemberCommentForIssueSince = `-- name: GetLatestMemberCommentForIssueSince :one
-SELECT id, issue_id, author_type, author_id, content, type, created_at, updated_at, parent_id, workspace_id, resolved_at, resolved_by_type, resolved_by_id, source_task_id FROM comment
+SELECT id, issue_id, author_type, author_id, content, type, created_at, updated_at, parent_id, workspace_id, resolved_at, resolved_by_type, resolved_by_id, source_task_id, suppressed_agent_ids FROM comment
 WHERE issue_id = $1
   AND author_type = 'member'
   AND created_at > $2
@@ -317,6 +323,7 @@ func (q *Queries) GetLatestMemberCommentForIssueSince(ctx context.Context, arg G
 		&i.ResolvedByType,
 		&i.ResolvedByID,
 		&i.SourceTaskID,
+		&i.SuppressedAgentIds,
 	)
 	return i, err
 }
@@ -331,7 +338,7 @@ WITH RECURSIVE root_of AS (
     FROM comment p
     JOIN root_of r ON p.id = r.parent_id
 )
-SELECT c.id, c.issue_id, c.author_type, c.author_id, c.content, c.type, c.created_at, c.updated_at, c.parent_id, c.workspace_id, c.resolved_at, c.resolved_by_type, c.resolved_by_id, c.source_task_id FROM comment c
+SELECT c.id, c.issue_id, c.author_type, c.author_id, c.content, c.type, c.created_at, c.updated_at, c.parent_id, c.workspace_id, c.resolved_at, c.resolved_by_type, c.resolved_by_id, c.source_task_id, c.suppressed_agent_ids FROM comment c
 WHERE c.id = (SELECT id FROM root_of WHERE parent_id IS NULL LIMIT 1)
 `
 
@@ -363,6 +370,7 @@ func (q *Queries) GetThreadRoot(ctx context.Context, arg GetThreadRootParams) (C
 		&i.ResolvedByType,
 		&i.ResolvedByID,
 		&i.SourceTaskID,
+		&i.SuppressedAgentIds,
 	)
 	return i, err
 }
@@ -411,7 +419,7 @@ func (q *Queries) HasAgentRepliedInThread(ctx context.Context, arg HasAgentRepli
 }
 
 const listCommentsForIssue = `-- name: ListCommentsForIssue :many
-SELECT id, issue_id, author_type, author_id, content, type, created_at, updated_at, parent_id, workspace_id, resolved_at, resolved_by_type, resolved_by_id, source_task_id FROM comment
+SELECT id, issue_id, author_type, author_id, content, type, created_at, updated_at, parent_id, workspace_id, resolved_at, resolved_by_type, resolved_by_id, source_task_id, suppressed_agent_ids FROM comment
 WHERE issue_id = $1 AND workspace_id = $2
 ORDER BY created_at ASC, id ASC
 LIMIT $3
@@ -450,6 +458,7 @@ func (q *Queries) ListCommentsForIssue(ctx context.Context, arg ListCommentsForI
 			&i.ResolvedByType,
 			&i.ResolvedByID,
 			&i.SourceTaskID,
+			&i.SuppressedAgentIds,
 		); err != nil {
 			return nil, err
 		}
@@ -462,7 +471,7 @@ func (q *Queries) ListCommentsForIssue(ctx context.Context, arg ListCommentsForI
 }
 
 const listCommentsSinceForIssue = `-- name: ListCommentsSinceForIssue :many
-SELECT id, issue_id, author_type, author_id, content, type, created_at, updated_at, parent_id, workspace_id, resolved_at, resolved_by_type, resolved_by_id, source_task_id FROM comment
+SELECT id, issue_id, author_type, author_id, content, type, created_at, updated_at, parent_id, workspace_id, resolved_at, resolved_by_type, resolved_by_id, source_task_id, suppressed_agent_ids FROM comment
 WHERE issue_id = $1 AND workspace_id = $2 AND created_at > $3
 ORDER BY created_at ASC, id ASC
 LIMIT $4
@@ -506,6 +515,7 @@ func (q *Queries) ListCommentsSinceForIssue(ctx context.Context, arg ListComment
 			&i.ResolvedByType,
 			&i.ResolvedByID,
 			&i.SourceTaskID,
+			&i.SuppressedAgentIds,
 		); err != nil {
 			return nil, err
 		}
@@ -658,7 +668,7 @@ func (q *Queries) ListRecentThreadCommentsForIssue(ctx context.Context, arg List
 }
 
 const listReconcilableCommentsForIssueSince = `-- name: ListReconcilableCommentsForIssueSince :many
-SELECT id, issue_id, author_type, author_id, content, type, created_at, updated_at, parent_id, workspace_id, resolved_at, resolved_by_type, resolved_by_id, source_task_id FROM comment
+SELECT id, issue_id, author_type, author_id, content, type, created_at, updated_at, parent_id, workspace_id, resolved_at, resolved_by_type, resolved_by_id, source_task_id, suppressed_agent_ids FROM comment
 WHERE issue_id = $1
   AND author_type IN ('member', 'agent')
   AND (
@@ -725,6 +735,7 @@ func (q *Queries) ListReconcilableCommentsForIssueSince(ctx context.Context, arg
 			&i.ResolvedByType,
 			&i.ResolvedByID,
 			&i.SourceTaskID,
+			&i.SuppressedAgentIds,
 		); err != nil {
 			return nil, err
 		}
@@ -1213,7 +1224,7 @@ UPDATE comment SET
     resolved_by_id = COALESCE(resolved_by_id, $3),
     updated_at = CASE WHEN resolved_at IS NULL THEN now() ELSE updated_at END
 WHERE id = $1
-RETURNING id, issue_id, author_type, author_id, content, type, created_at, updated_at, parent_id, workspace_id, resolved_at, resolved_by_type, resolved_by_id, source_task_id
+RETURNING id, issue_id, author_type, author_id, content, type, created_at, updated_at, parent_id, workspace_id, resolved_at, resolved_by_type, resolved_by_id, source_task_id, suppressed_agent_ids
 `
 
 type ResolveCommentParams struct {
@@ -1242,6 +1253,7 @@ func (q *Queries) ResolveComment(ctx context.Context, arg ResolveCommentParams) 
 		&i.ResolvedByType,
 		&i.ResolvedByID,
 		&i.SourceTaskID,
+		&i.SuppressedAgentIds,
 	)
 	return i, err
 }
@@ -1253,7 +1265,7 @@ UPDATE comment SET
     resolved_by_id = NULL,
     updated_at = CASE WHEN resolved_at IS NOT NULL THEN now() ELSE updated_at END
 WHERE id = $1
-RETURNING id, issue_id, author_type, author_id, content, type, created_at, updated_at, parent_id, workspace_id, resolved_at, resolved_by_type, resolved_by_id, source_task_id
+RETURNING id, issue_id, author_type, author_id, content, type, created_at, updated_at, parent_id, workspace_id, resolved_at, resolved_by_type, resolved_by_id, source_task_id, suppressed_agent_ids
 `
 
 // Idempotent: a no-op clear (already unresolved) just returns the row.
@@ -1275,6 +1287,7 @@ func (q *Queries) UnresolveComment(ctx context.Context, id pgtype.UUID) (Comment
 		&i.ResolvedByType,
 		&i.ResolvedByID,
 		&i.SourceTaskID,
+		&i.SuppressedAgentIds,
 	)
 	return i, err
 }
@@ -1283,19 +1296,26 @@ const updateComment = `-- name: UpdateComment :one
 UPDATE comment SET
     content = $2,
     source_task_id = $3,
+    suppressed_agent_ids = COALESCE($4::uuid[], '{}'::uuid[]),
     updated_at = now()
 WHERE id = $1
-RETURNING id, issue_id, author_type, author_id, content, type, created_at, updated_at, parent_id, workspace_id, resolved_at, resolved_by_type, resolved_by_id, source_task_id
+RETURNING id, issue_id, author_type, author_id, content, type, created_at, updated_at, parent_id, workspace_id, resolved_at, resolved_by_type, resolved_by_id, source_task_id, suppressed_agent_ids
 `
 
 type UpdateCommentParams struct {
-	ID           pgtype.UUID `json:"id"`
-	Content      string      `json:"content"`
-	SourceTaskID pgtype.UUID `json:"source_task_id"`
+	ID                 pgtype.UUID   `json:"id"`
+	Content            string        `json:"content"`
+	SourceTaskID       pgtype.UUID   `json:"source_task_id"`
+	SuppressedAgentIds []pgtype.UUID `json:"suppressed_agent_ids"`
 }
 
 func (q *Queries) UpdateComment(ctx context.Context, arg UpdateCommentParams) (Comment, error) {
-	row := q.db.QueryRow(ctx, updateComment, arg.ID, arg.Content, arg.SourceTaskID)
+	row := q.db.QueryRow(ctx, updateComment,
+		arg.ID,
+		arg.Content,
+		arg.SourceTaskID,
+		arg.SuppressedAgentIds,
+	)
 	var i Comment
 	err := row.Scan(
 		&i.ID,
@@ -1312,6 +1332,7 @@ func (q *Queries) UpdateComment(ctx context.Context, arg UpdateCommentParams) (C
 		&i.ResolvedByType,
 		&i.ResolvedByID,
 		&i.SourceTaskID,
+		&i.SuppressedAgentIds,
 	)
 	return i, err
 }

--- a/server/pkg/db/generated/models.go
+++ b/server/pkg/db/generated/models.go
@@ -389,20 +389,21 @@ type ChatSession struct {
 }
 
 type Comment struct {
-	ID             pgtype.UUID        `json:"id"`
-	IssueID        pgtype.UUID        `json:"issue_id"`
-	AuthorType     string             `json:"author_type"`
-	AuthorID       pgtype.UUID        `json:"author_id"`
-	Content        string             `json:"content"`
-	Type           string             `json:"type"`
-	CreatedAt      pgtype.Timestamptz `json:"created_at"`
-	UpdatedAt      pgtype.Timestamptz `json:"updated_at"`
-	ParentID       pgtype.UUID        `json:"parent_id"`
-	WorkspaceID    pgtype.UUID        `json:"workspace_id"`
-	ResolvedAt     pgtype.Timestamptz `json:"resolved_at"`
-	ResolvedByType pgtype.Text        `json:"resolved_by_type"`
-	ResolvedByID   pgtype.UUID        `json:"resolved_by_id"`
-	SourceTaskID   pgtype.UUID        `json:"source_task_id"`
+	ID                 pgtype.UUID        `json:"id"`
+	IssueID            pgtype.UUID        `json:"issue_id"`
+	AuthorType         string             `json:"author_type"`
+	AuthorID           pgtype.UUID        `json:"author_id"`
+	Content            string             `json:"content"`
+	Type               string             `json:"type"`
+	CreatedAt          pgtype.Timestamptz `json:"created_at"`
+	UpdatedAt          pgtype.Timestamptz `json:"updated_at"`
+	ParentID           pgtype.UUID        `json:"parent_id"`
+	WorkspaceID        pgtype.UUID        `json:"workspace_id"`
+	ResolvedAt         pgtype.Timestamptz `json:"resolved_at"`
+	ResolvedByType     pgtype.Text        `json:"resolved_by_type"`
+	ResolvedByID       pgtype.UUID        `json:"resolved_by_id"`
+	SourceTaskID       pgtype.UUID        `json:"source_task_id"`
+	SuppressedAgentIds []pgtype.UUID      `json:"suppressed_agent_ids"`
 }
 
 type CommentReaction struct {

--- a/server/pkg/db/queries/comment.sql
+++ b/server/pkg/db/queries/comment.sql
@@ -393,14 +393,15 @@ SELECT c.* FROM comment c
 WHERE c.id = (SELECT id FROM root_of WHERE parent_id IS NULL LIMIT 1);
 
 -- name: CreateComment :one
-INSERT INTO comment (issue_id, workspace_id, author_type, author_id, content, type, parent_id, source_task_id)
-VALUES ($1, $2, $3, $4, $5, $6, sqlc.narg(parent_id), sqlc.narg(source_task_id))
+INSERT INTO comment (issue_id, workspace_id, author_type, author_id, content, type, parent_id, source_task_id, suppressed_agent_ids)
+VALUES ($1, $2, $3, $4, $5, $6, sqlc.narg(parent_id), sqlc.narg(source_task_id), COALESCE(@suppressed_agent_ids::uuid[], '{}'::uuid[]))
 RETURNING *;
 
 -- name: UpdateComment :one
 UPDATE comment SET
     content = $2,
     source_task_id = sqlc.narg(source_task_id),
+    suppressed_agent_ids = COALESCE(@suppressed_agent_ids::uuid[], '{}'::uuid[]),
     updated_at = now()
 WHERE id = $1
 RETURNING *;


### PR DESCRIPTION
## What changed

- persist `suppress_agent_ids` as internal comment routing metadata
- reapply exact-agent suppression when completion reconciliation revisits an undelivered comment
- deduplicate suppression IDs before storage while continuing to reject malformed UUIDs at the request boundary
- define edit semantics: content edits replace suppression; content-preserving updates retain it
- update the built-in mentioning skill and source map for the durable contract
- add production-path DB regressions and regenerate sqlc projections

## Why

A comment can be posted while its target already has an active task. Immediate routing honors `suppress_agent_ids`, but completion reconciliation may revisit the same undelivered comment after that task becomes terminal. Suppression previously existed only on the request, so the delayed path could turn an explicit no-wake decision into a redundant follow-up run.

Suppression is now part of the comment's durable routing action. Immediate routing and delayed reconciliation therefore make the same exact-agent decision across retries and process restarts. Unrelated agents, explicit mentions not present in the suppression set, and ordinary comments with no suppression metadata keep their existing behavior.

The field remains internal: comment API responses are built through `CommentResponse` and do not expose `suppressed_agent_ids`.

## Design

The metadata lives on `comment` because reconciliation already replays saved comments as its durable unit. A separate delivery relation would add lifecycle and cleanup complexity without improving the only lookup required here, while repository rules intentionally avoid database foreign keys. A UUID array matches the bounded set-valued routing contract and requires no index because it is read only with the reconciled comment row.

A content edit is a new routing action and replaces the stored suppression set; omitting the field on such an edit intentionally clears it. Attachment-only or otherwise content-preserving updates retain the original suppression contract.

## Validation

- clean schema migration from 001 through 202
- full migration down/up round trip on a disposable database
- focused handler regressions with `-race`, including real create-handler persistence and delayed reconciliation
- `go test -race` across the full Go suite, with `pkg/agent` run under the repository's bounded parallelism
- final `go test ./...`
- deterministic `make sqlc` with no generated diff
- `git diff --check`
