### PR TITLE
WEN-31: preserve IME input while issue editor loads

### DIFF
--- a/packages/views/editor/content-editor.test.tsx
+++ b/packages/views/editor/content-editor.test.tsx
@@ -192,6 +192,29 @@ describe("ContentEditor", () => {
     expect(mockFocus).not.toHaveBeenCalled();
   });
 
+  it("focuses at the end through the lazy-handoff ref", () => {
+    const ref = createRef<ContentEditorRef>();
+    render(<ContentEditor ref={ref} />);
+
+    act(() => ref.current?.focusAtEnd());
+
+    expect(mockFocus).toHaveBeenCalledWith("end");
+  });
+
+  it("adopts pending handoff text without emitting an update", () => {
+    const onUpdate = vi.fn();
+    const ref = createRef<ContentEditorRef>();
+    render(<ContentEditor ref={ref} onUpdate={onUpdate} />);
+
+    act(() => ref.current?.adoptContent("我"));
+
+    expect(mockSetContent).toHaveBeenCalledWith(
+      "我",
+      expect.objectContaining({ emitUpdate: false, contentType: "markdown" }),
+    );
+    expect(onUpdate).not.toHaveBeenCalled();
+  });
+
   it("syncs editor content when defaultValue changes externally and editor is unfocused", () => {
     editorState.markdown = "old content";
     const { rerender } = render(<ContentEditor defaultValue="old content" />);

--- a/packages/views/editor/content-editor.tsx
+++ b/packages/views/editor/content-editor.tsx
@@ -196,6 +196,8 @@ interface ContentEditorRef {
   getMarkdown: () => string;
   clearContent: () => void;
   focus: () => void;
+  /** Focus the editor with the caret after its current content. */
+  focusAtEnd: () => void;
   /**
    * Focus and place the caret at the document position under the given
    * viewport coordinates. Used by readonly-first hosts so the click that
@@ -722,6 +724,10 @@ const ContentEditor = forwardRef<ContentEditorRef, ContentEditorProps>(
       focus: () => {
         if (editor) editor.commands.focus();
         // Editor not mounted yet — defer the focus to `onCreate`.
+        else focusOnReadyRef.current = true;
+      },
+      focusAtEnd: () => {
+        if (editor) editor.commands.focus("end");
         else focusOnReadyRef.current = true;
       },
       focusAtCoords: (coords: { x: number; y: number }) => {

--- a/packages/views/editor/use-lazy-editor.test.ts
+++ b/packages/views/editor/use-lazy-editor.test.ts
@@ -46,6 +46,36 @@ describe("useLazyEditor", () => {
     expect(handle.uploadFile).toHaveBeenCalledWith(file);
   });
 
+  it("keeps an editable stand-in alive until IME composition ends", () => {
+    let pendingContent = "w";
+    const handle = {
+      ...makeHandle(),
+      focusAtEnd: vi.fn(),
+      adoptContent: vi.fn(),
+    };
+    const editorRef = { current: handle as LazyEditorHandle };
+    const { result } = renderHook(() =>
+      useLazyEditor({
+        editorRef,
+        getPendingContent: () => pendingContent,
+      }),
+    );
+
+    act(() => result.current.activate());
+    act(() => result.current.onCompositionStart());
+    act(() => result.current.onReady());
+
+    expect(result.current.ready).toBe(false);
+    expect(handle.adoptContent).not.toHaveBeenCalled();
+
+    pendingContent = "我";
+    act(() => result.current.onCompositionEnd());
+
+    expect(result.current.ready).toBe(true);
+    expect(handle.adoptContent).toHaveBeenCalledWith("我");
+    expect(handle.focusAtEnd).toHaveBeenCalled();
+  });
+
   it("resets to the stand-in during the render that changes resetKey", () => {
     const editorRef = { current: makeHandle() as LazyEditorHandle };
     const { result, rerender } = renderHook(

--- a/packages/views/editor/use-lazy-editor.test.ts
+++ b/packages/views/editor/use-lazy-editor.test.ts
@@ -76,6 +76,41 @@ describe("useLazyEditor", () => {
     expect(handle.focusAtEnd).toHaveBeenCalled();
   });
 
+  it("cancels a queued ready swap when composition starts before its commit", () => {
+    let pendingContent = "";
+    const handle = {
+      ...makeHandle(),
+      focusAtEnd: vi.fn(),
+      adoptContent: vi.fn(),
+    };
+    const editorRef = { current: handle as LazyEditorHandle };
+    const { result } = renderHook(() =>
+      useLazyEditor({
+        editorRef,
+        getPendingContent: () => pendingContent,
+      }),
+    );
+
+    act(() => result.current.activate());
+    act(() => {
+      result.current.onReady();
+      result.current.onCompositionStart();
+    });
+
+    // React may batch the ready update with the next native input event. The
+    // composition-start update must win that batch so the focused shell stays.
+    expect(result.current.ready).toBe(false);
+    expect(handle.adoptContent).toHaveBeenCalledWith("");
+    expect(handle.focusAtEnd).not.toHaveBeenCalled();
+
+    pendingContent = "我";
+    act(() => result.current.onCompositionEnd());
+
+    expect(result.current.ready).toBe(true);
+    expect(handle.adoptContent).toHaveBeenLastCalledWith("我");
+    expect(handle.focusAtEnd).toHaveBeenCalled();
+  });
+
   it("resets to the stand-in during the render that changes resetKey", () => {
     const editorRef = { current: makeHandle() as LazyEditorHandle };
     const { result, rerender } = renderHook(

--- a/packages/views/editor/use-lazy-editor.ts
+++ b/packages/views/editor/use-lazy-editor.ts
@@ -9,9 +9,12 @@ import type { TextAnchor } from "./text-anchor";
  */
 export interface LazyEditorHandle {
   focus: () => void;
+  focusAtEnd?: () => void;
   focusAtCoords?: (coords: { x: number; y: number }) => void;
   focusAtAnchor?: (anchor: TextAnchor) => void;
   uploadFile?: (file: File) => void;
+  /** Replace the live document with text collected by an editable stand-in. */
+  adoptContent?: (markdown: string) => void;
 }
 
 /**
@@ -47,6 +50,12 @@ export interface UseLazyEditorOptions {
    * Hosts that remount per subject (via `key`) don't need this.
    */
   resetKey?: unknown;
+  /**
+   * Read text accepted by an editable stand-in while Tiptap initializes.
+   * When present, readiness is held across an active IME composition, then
+   * the collected text is adopted before the stand-in is replaced.
+   */
+  getPendingContent?: () => string | undefined;
 }
 
 /**
@@ -70,6 +79,10 @@ export interface UseLazyEditorOptions {
  *     <Editor ref={editorRef} onReady={lazy.onReady} ... /></div>}
  *   {!lazy.ready && <StaticStandIn onClick={e => lazy.activate({x: e.clientX, y: e.clientY})} />}
  *
+ * A stand-in that accepts text should pass `getPendingContent` and wire the
+ * returned composition handlers. The hook then delays the swap until IME
+ * composition ends and adopts the stand-in's complete text first.
+ *
  * Hosts that outlive a subject switch without remounting (the web issue
  * route) must pass `resetKey`; keyed hosts get the reset for free by
  * remounting.
@@ -78,12 +91,15 @@ export function useLazyEditor({
   initialActive = false,
   editorRef,
   resetKey,
+  getPendingContent,
 }: UseLazyEditorOptions) {
   const [active, setActive] = useState(initialActive);
   const [ready, setReady] = useState(false);
   const focusTargetRef = useRef<LazyFocusTarget | null>(null);
   const focusPendingRef = useRef(false);
   const pendingFilesRef = useRef<File[]>([]);
+  const editorReadyRef = useRef(false);
+  const composingRef = useRef(false);
 
   // Render-phase reset on subject change — see the `resetKey` option doc.
   const [prevResetKey, setPrevResetKey] = useState(resetKey);
@@ -94,6 +110,8 @@ export function useLazyEditor({
     focusTargetRef.current = null;
     focusPendingRef.current = false;
     pendingFilesRef.current = [];
+    editorReadyRef.current = false;
+    composingRef.current = false;
   }
 
   const focusAtTarget = useCallback(
@@ -102,6 +120,7 @@ export function useLazyEditor({
       if (!handle) return;
       if (target?.anchor && handle.focusAtAnchor) handle.focusAtAnchor(target.anchor);
       else if (target && handle.focusAtCoords) handle.focusAtCoords(target);
+      else if (handle.focusAtEnd) handle.focusAtEnd();
       else handle.focus();
     },
     [editorRef],
@@ -124,7 +143,27 @@ export function useLazyEditor({
     [ready, focusAtTarget],
   );
 
-  const onReady = useCallback(() => setReady(true), []);
+  const completeReady = useCallback(() => {
+    const pendingContent = getPendingContent?.();
+    if (pendingContent !== undefined) {
+      editorRef.current?.adoptContent?.(pendingContent);
+    }
+    setReady(true);
+  }, [editorRef, getPendingContent]);
+
+  const onReady = useCallback(() => {
+    editorReadyRef.current = true;
+    if (!composingRef.current) completeReady();
+  }, [completeReady]);
+
+  const onCompositionStart = useCallback(() => {
+    composingRef.current = true;
+  }, []);
+
+  const onCompositionEnd = useCallback(() => {
+    composingRef.current = false;
+    if (editorReadyRef.current) completeReady();
+  }, [completeReady]);
 
   // Post-swap work — runs after the commit that revealed the ready editor,
   // so focus targets can resolve against a laid-out, live doc and uploads
@@ -155,5 +194,13 @@ export function useLazyEditor({
     [ready, editorRef],
   );
 
-  return { active, ready, activate, onReady, uploadOrQueue };
+  return {
+    active,
+    ready,
+    activate,
+    onReady,
+    onCompositionStart,
+    onCompositionEnd,
+    uploadOrQueue,
+  };
 }

--- a/packages/views/editor/use-lazy-editor.ts
+++ b/packages/views/editor/use-lazy-editor.ts
@@ -158,6 +158,10 @@ export function useLazyEditor({
 
   const onCompositionStart = useCallback(() => {
     composingRef.current = true;
+    // `onReady` and the next native input event can land in one React batch.
+    // If readiness already queued the stand-in swap but has not committed it,
+    // make this later update win so the browser keeps its composing node.
+    if (editorReadyRef.current) setReady(false);
   }, []);
 
   const onCompositionEnd = useCallback(() => {

--- a/packages/views/issues/components/comment-composers.test.tsx
+++ b/packages/views/issues/components/comment-composers.test.tsx
@@ -9,6 +9,10 @@ import { CommentInput } from "./comment-input";
 import { ReplyInput } from "./reply-input";
 
 const uploadWithToast = vi.hoisted(() => vi.fn());
+const editorLifecycle = vi.hoisted(() => ({
+  deferReady: false,
+  pendingReady: [] as Array<() => void>,
+}));
 
 vi.mock("@multica/core/api", () => ({
   api: {},
@@ -64,13 +68,18 @@ vi.mock("../../editor", async () => ({
     ref: Ref<unknown>,
   ) {
     const valueRef = useRef(defaultValue ?? "");
+    const textareaRef = useRef<HTMLTextAreaElement>(null);
     // Mirrors the real editor's `uploading` node attrs: the placeholder exists
     // from before the await until the upload settles, `hasActiveUploads` reads
     // it synchronously, and the host is told through onUploadingChange.
     const inFlightRef = useRef(0);
 
     useEffect(() => {
-      onReady?.();
+      if (editorLifecycle.deferReady && onReady) {
+        editorLifecycle.pendingReady.push(onReady);
+      } else {
+        onReady?.();
+      }
       // eslint-disable-next-line react-hooks/exhaustive-deps
     }, []);
 
@@ -79,8 +88,18 @@ vi.mock("../../editor", async () => ({
       clearContent: () => {
         valueRef.current = "";
       },
-      focus: () => {},
-      focusAtCoords: () => {},
+      focus: () => textareaRef.current?.focus(),
+      focusAtEnd: () => {
+        const textarea = textareaRef.current;
+        if (!textarea) return;
+        textarea.focus();
+        textarea.setSelectionRange(textarea.value.length, textarea.value.length);
+      },
+      focusAtCoords: () => textareaRef.current?.focus(),
+      adoptContent: (markdown: string) => {
+        valueRef.current = markdown;
+        if (textareaRef.current) textareaRef.current.value = markdown;
+      },
       blur: () => {},
       uploadFile: async (file: File) => {
         inFlightRef.current += 1;
@@ -100,6 +119,7 @@ vi.mock("../../editor", async () => ({
 
     return (
       <textarea
+        ref={textareaRef}
         data-testid="editor"
         defaultValue={defaultValue}
         placeholder={placeholder}
@@ -157,7 +177,7 @@ function renderReplyInput({
 // unsent draft exists). Tests that interact with the editor activate it the
 // same way a user does.
 function activateComposer(shellTestId: "comment-composer-shell" | "reply-composer-shell") {
-  fireEvent.click(screen.getByTestId(shellTestId));
+  fireEvent.focus(screen.getByTestId(shellTestId));
 }
 
 function getSubmitButton(container: HTMLElement): HTMLButtonElement {
@@ -170,6 +190,8 @@ function getSubmitButton(container: HTMLElement): HTMLButtonElement {
 
 beforeEach(() => {
   uploadWithToast.mockReset();
+  editorLifecycle.deferReady = false;
+  editorLifecycle.pendingReady = [];
   localStorage.clear();
   useCommentComposerStore.setState({ sticky: true });
   // The draft store is a module singleton — a draft left by a previous test
@@ -179,14 +201,58 @@ beforeEach(() => {
 });
 
 describe("comment composers", () => {
+  it.each([
+    {
+      name: "main comment",
+      shellTestId: "comment-composer-shell" as const,
+      renderComposer: () => renderCommentInput(),
+    },
+    {
+      name: "reply",
+      shellTestId: "reply-composer-shell" as const,
+      renderComposer: () => renderReplyInput(),
+    },
+  ])("keeps $name IME composition intact while the editor becomes ready", async ({
+    shellTestId,
+    renderComposer,
+  }) => {
+    editorLifecycle.deferReady = true;
+    renderComposer();
+
+    const shell = screen.getByTestId(shellTestId);
+    expect(shell).toHaveAttribute("role", "textbox");
+    act(() => shell.focus());
+    await waitFor(() => expect(editorLifecycle.pendingReady).toHaveLength(1));
+
+    fireEvent.compositionStart(shell);
+    fireEvent.input(shell, { target: { value: "w" } });
+    act(() => editorLifecycle.pendingReady.shift()?.());
+
+    // The hidden Tiptap instance may finish mounting, but replacing the
+    // composing native control here would cancel the browser's IME session.
+    expect(screen.getByTestId(shellTestId)).toBe(shell);
+    expect(shell).toHaveFocus();
+
+    fireEvent.input(shell, { target: { value: "我" } });
+    fireEvent.compositionEnd(shell);
+
+    await waitFor(() => expect(screen.queryByTestId(shellTestId)).not.toBeInTheDocument());
+    expect(screen.getByTestId("editor")).toHaveValue("我");
+    expect(screen.getByTestId("editor")).toHaveFocus();
+    expect(screen.getByTestId("editor")).toHaveProperty("selectionStart", 1);
+  });
+
   it("renders the main comment composer without a manual expand control", () => {
     const { container } = renderCommentInput();
 
     // Readonly-first: shell shows the placeholder text; clicking mounts the
     // real editor in place.
-    expect(screen.getByTestId("comment-composer-shell")).toHaveTextContent("Leave a comment...");
+    expect(screen.getByTestId("comment-composer-shell")).toHaveAttribute(
+      "placeholder",
+      "Leave a comment...",
+    );
     activateComposer("comment-composer-shell");
-    expect(screen.getByPlaceholderText("Leave a comment...")).toBeInTheDocument();
+    expect(screen.getByTestId("editor")).toHaveAttribute("placeholder", "Leave a comment...");
     expect(screen.getByRole("button", { name: "Attach file" })).toBeInTheDocument();
     expect(container.querySelectorAll("button")).toHaveLength(2);
 
@@ -198,9 +264,12 @@ describe("comment composers", () => {
   it("renders reply composer without a manual expand control", () => {
     const { container } = renderReplyInput();
 
-    expect(screen.getByTestId("reply-composer-shell")).toHaveTextContent("Leave a reply...");
+    expect(screen.getByTestId("reply-composer-shell")).toHaveAttribute(
+      "placeholder",
+      "Leave a reply...",
+    );
     activateComposer("reply-composer-shell");
-    expect(screen.getByPlaceholderText("Leave a reply...")).toBeInTheDocument();
+    expect(screen.getByTestId("editor")).toHaveAttribute("placeholder", "Leave a reply...");
     expect(screen.getByRole("button", { name: "Attach file" })).toBeInTheDocument();
     expect(container.querySelectorAll("button")).toHaveLength(2);
 

--- a/packages/views/issues/components/comment-composers.test.tsx
+++ b/packages/views/issues/components/comment-composers.test.tsx
@@ -242,6 +242,40 @@ describe("comment composers", () => {
     expect(screen.getByTestId("editor")).toHaveProperty("selectionStart", 1);
   });
 
+  it.each([
+    {
+      name: "main comment",
+      shellTestId: "comment-composer-shell" as const,
+      renderComposer: () => renderCommentInput(),
+    },
+    {
+      name: "reply",
+      shellTestId: "reply-composer-shell" as const,
+      renderComposer: () => renderReplyInput(),
+    },
+  ])("preserves $name text typed before the editor is ready", async ({
+    shellTestId,
+    renderComposer,
+  }) => {
+    editorLifecycle.deferReady = true;
+    renderComposer();
+
+    const shell = screen.getByTestId(shellTestId);
+    act(() => shell.focus());
+    await waitFor(() => expect(editorLifecycle.pendingReady).toHaveLength(1));
+
+    fireEvent.input(shell, { target: { value: "typed during startup" } });
+    act(() => editorLifecycle.pendingReady.shift()?.());
+
+    await waitFor(() => expect(screen.queryByTestId(shellTestId)).not.toBeInTheDocument());
+    expect(screen.getByTestId("editor")).toHaveValue("typed during startup");
+    expect(screen.getByTestId("editor")).toHaveFocus();
+    expect(screen.getByTestId("editor")).toHaveProperty(
+      "selectionStart",
+      "typed during startup".length,
+    );
+  });
+
   it("renders the main comment composer without a manual expand control", () => {
     const { container } = renderCommentInput();
 

--- a/packages/views/issues/components/comment-input.tsx
+++ b/packages/views/issues/components/comment-input.tsx
@@ -26,6 +26,7 @@ function CommentInput({ issueId, onSubmit }: CommentInputProps) {
   const { t: tEditor } = useT("editor");
   const sendShortcut = useShortcut("send");
   const editorRef = useRef<ContentEditorRef>(null);
+  const shellRef = useRef<HTMLTextAreaElement>(null);
   // Sending mid-upload would strip the pending image's blob URL out of the
   // markdown and bind no attachment id — the comment posts without the file.
   const uploadGate = useUploadGate(editorRef);
@@ -46,6 +47,12 @@ function CommentInput({ issueId, onSubmit }: CommentInputProps) {
   //    resolve text/code/markdown previews that require the attachment id.
   const [pendingAttachments, setPendingAttachments] = useState<Attachment[]>([]);
   const { uploadWithToast } = useEditorUpload();
+  const setDraft = useCommentDraftStore((s) => s.setDraft);
+  const clearDraft = useCommentDraftStore((s) => s.clearDraft);
+  const getPendingContent = useCallback(
+    () => shellRef.current?.value,
+    [],
+  );
   // Readonly-first: the composer renders as a same-looking static shell until
   // the user shows intent (click / keyboard / file drop). An unsent draft is
   // standing intent — mount the real editor immediately so the draft is
@@ -53,6 +60,7 @@ function CommentInput({ issueId, onSubmit }: CommentInputProps) {
   const lazy = useLazyEditor({
     initialActive: !!initialDraft?.trim(),
     editorRef,
+    getPendingContent,
   });
   const { isDragOver, dropZoneProps } = useFileDropZone({
     onDrop: lazy.uploadOrQueue,
@@ -61,12 +69,9 @@ function CommentInput({ issueId, onSubmit }: CommentInputProps) {
   // composer to the bottom of the scroll viewport when enabled.
   const sticky = useCommentComposerStore((s) => s.sticky);
 
-  // Draft persistence. Hydrate from store on mount via `defaultValue` above
-  // (ContentEditorRef has no setContent, so this is the only injection point).
-  // Flush on every onUpdate (debounced upstream) + visibilitychange/pagehide
+  // Draft persistence. Hydrate from store on mount via `defaultValue` above;
+  // flush on every onUpdate (debounced upstream) + visibilitychange/pagehide
   // so tab close / mobile background doesn't lose work. Cleared on submit.
-  const setDraft = useCommentDraftStore((s) => s.setDraft);
-  const clearDraft = useCommentDraftStore((s) => s.clearDraft);
   useEffect(() => {
     const flush = () => {
       const md = editorRef.current?.getMarkdown();
@@ -198,31 +203,30 @@ function CommentInput({ issueId, onSubmit }: CommentInputProps) {
         />
       </div>
       )}
-      {/* Static shell — visually clones the empty single-line composer.
-          Real editor mounts (hidden) on first intent; shell stays visible
-          until it's ready so the card never blanks or shifts. */}
+      {/* Native handoff shell. It can accept text while Tiptap initializes,
+          and useLazyEditor keeps it mounted through an active IME composition
+          before adopting its text and moving focus to the real editor. */}
       {!lazy.ready && (
-        <div
+        <textarea
+          ref={shellRef}
           data-testid="comment-composer-shell"
-          role="button"
-          tabIndex={0}
+          role="textbox"
+          rows={1}
           aria-label={t(($) => $.comment.leave_comment_placeholder)}
-          className="flex-1 min-h-0 cursor-text px-3 py-2"
-          onClick={() => lazy.activate()}
-          onKeyDown={(e) => {
-            if (e.key === "Enter" || e.key === " ") {
-              e.preventDefault();
-              lazy.activate();
-            }
+          defaultValue={initialDraft}
+          placeholder={t(($) => $.comment.leave_comment_placeholder)}
+          className="flex-1 min-h-0 w-full resize-none overflow-hidden bg-transparent px-3 py-2 text-sm leading-[1.625] outline-none placeholder:text-muted-foreground"
+          onFocus={() => lazy.activate()}
+          onInput={(event) => {
+            const md = event.currentTarget.value;
+            setContent(md);
+            setIsEmpty(!md.trim());
+            if (md.trim().length > 0) setDraft(draftKey, md);
+            else clearDraft(draftKey);
           }}
-        >
-          {/* rich-text-editor + <p>: the shell line inherits the editor's
-              exact type metrics (line-height 1.625 from prose.css), so the
-              shell→editor swap doesn't shift layout. */}
-          <div className="rich-text-editor text-sm">
-            <p className="text-muted-foreground">{t(($) => $.comment.leave_comment_placeholder)}</p>
-          </div>
-        </div>
+          onCompositionStart={lazy.onCompositionStart}
+          onCompositionEnd={lazy.onCompositionEnd}
+        />
       )}
       <div className="absolute bottom-1 left-2 right-28 min-w-0">
         <CommentTriggerChips

--- a/packages/views/issues/components/reply-input.tsx
+++ b/packages/views/issues/components/reply-input.tsx
@@ -54,10 +54,11 @@ function ReplyInput({
   const sendShortcut = useShortcut("send");
   const placeholderText = placeholder ?? t(($) => $.reply.placeholder);
   const editorRef = useRef<ContentEditorRef>(null);
+  const shellRef = useRef<HTMLTextAreaElement>(null);
   // See CommentInput — replying mid-upload posts without the file.
   const uploadGate = useUploadGate(editorRef);
-  // If a draft key is provided, hydrate from store on mount (defaultValue is
-  // the only injection point on ContentEditorRef) and flush on every onUpdate.
+  // If a draft key is provided, hydrate from store on mount and flush on every
+  // onUpdate.
   const initialDraft = draftKey
     ? useCommentDraftStore.getState().getDraft(draftKey)
     : undefined;
@@ -72,6 +73,10 @@ function ReplyInput({
   // rationale (drives both submit-time attachment_ids and editor previews).
   const [pendingAttachments, setPendingAttachments] = useState<Attachment[]>([]);
   const { uploadWithToast } = useEditorUpload();
+  const getPendingContent = useCallback(
+    () => shellRef.current?.value,
+    [],
+  );
   // Readonly-first: static shell until intent; an unsent draft mounts the
   // real editor immediately (see CommentInput). This is also what keeps the
   // reply box working across Virtuoso scroll-out — a typed draft rehydrates
@@ -80,6 +85,7 @@ function ReplyInput({
   const lazy = useLazyEditor({
     initialActive: !!initialDraft?.trim(),
     editorRef,
+    getPendingContent,
   });
   const { isDragOver, dropZoneProps } = useFileDropZone({
     onDrop: lazy.uploadOrQueue,
@@ -217,27 +223,30 @@ function ReplyInput({
           />
         </div>
         )}
-        {/* Static shell — clones the empty single-line reply box (see
-            CommentInput for the pattern). */}
+        {/* Native handoff shell — see CommentInput for the IME-safe swap. */}
         {!lazy.ready && (
-          <div
+          <textarea
+            ref={shellRef}
             data-testid="reply-composer-shell"
-            role="button"
-            tabIndex={0}
+            role="textbox"
+            rows={1}
             aria-label={placeholderText}
-            className="flex-1 min-h-0 cursor-text rich-text-editor text-sm"
-            onClick={() => lazy.activate()}
-            onKeyDown={(e) => {
-              if (e.key === "Enter" || e.key === " ") {
-                e.preventDefault();
-                lazy.activate();
+            defaultValue={initialDraft}
+            placeholder={placeholderText}
+            className="flex-1 min-h-0 w-full resize-none overflow-hidden bg-transparent text-sm leading-[1.625] outline-none placeholder:text-muted-foreground"
+            onFocus={() => lazy.activate()}
+            onInput={(event) => {
+              const md = event.currentTarget.value;
+              setContent(md);
+              setIsEmpty(!md.trim());
+              if (draftKey) {
+                if (md.trim().length > 0) setDraft(draftKey, md);
+                else clearDraft(draftKey);
               }
             }}
-          >
-            {/* <p> under rich-text-editor: same type metrics as the real
-                editor's empty paragraph — no height jump on swap. */}
-            <p className="text-muted-foreground">{placeholderText}</p>
-          </div>
+            onCompositionStart={lazy.onCompositionStart}
+            onCompositionEnd={lazy.onCompositionEnd}
+          />
         )}
         <div className="absolute bottom-0 left-0 right-24 min-w-0">
           <CommentTriggerChips


### PR DESCRIPTION
## What does this PR do?

Fixes #5617.

This is a real product bug: empty issue comment and reply composers rendered a focusable static shell, mounted Tiptap asynchronously after intent, then replaced the focused shell when Tiptap reported ready. Replacing that node during a Chinese/Japanese/Korean IME composition cancels the native composition and splits input such as `wo` instead of `我`. Agent-query rerenders preserve the editor node; the shell-to-editor handoff is the failing boundary.

The fix keeps lazy editor initialization, but makes the handoff shell a native textarea that can receive input. Tiptap mounts hidden in the background. If IME composition overlaps readiness in either order, the swap waits for `compositionend`; completed shell text is adopted into Tiptap and focus lands at the end. Main comments and thread replies share the behavior.

Multica work item: WEN-31

## Related Issue

Fixes #5617

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Refactor / code improvement (no behavior change)
- [ ] Documentation update
- [x] Tests (adding or improving test coverage)
- [ ] CI / infrastructure

## Changes Made

- `packages/views/editor/use-lazy-editor.ts`: preserve an editable stand-in across IME composition, including the boundary where readiness and composition start are batched in the reverse order; adopt pending text before the swap and focus the live editor at the end.
- `packages/views/editor/content-editor.tsx`: expose an explicit end-focus operation for handoff callers.
- `packages/views/issues/components/comment-input.tsx`: use an editable, draft-aware native handoff shell for the main composer.
- `packages/views/issues/components/reply-input.tsx`: apply the same handoff to thread replies.
- Hook, real-editor, and component regression tests cover both readiness/composition orderings, ordinary startup input, both composer entry points, content adoption, focus, and existing upload behavior.

## How to Test

1. Open an issue with an empty comment composer and switch to a Chinese IME.
2. Focus the composer and start typing `wo` immediately while the rich editor initializes.
3. Verify composition is not interrupted, `我` is preserved, and subsequent input is appended after it. Repeat in a thread reply.
4. Repeat with ordinary non-IME text typed immediately after focus; verify no startup characters are lost.

Automated verification run after review fixes:

- `pnpm -C packages/views exec vitest run issues/components/comment-composers.test.tsx editor/use-lazy-editor.test.ts editor/content-editor.test.tsx` — 59/59 passed.
- `pnpm --filter @multica/views typecheck` — passed.
- `pnpm --filter @multica/views lint` — 0 errors; 19 pre-existing warnings in untouched files.
- `pnpm --filter @multica/views test` — 234 files, 2687/2687 tests passed.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [x] I have updated relevant documentation to reflect my changes (inline lifecycle contract; no user documentation is affected)
- [x] If I added a new runtime / coding tool / UI tab, I synced the change to **landing copy** and **relevant docs** (N/A)
- [x] If this PR touches Chinese product copy, I checked it against the Chinese conventions (N/A; no copy changed)
- [x] I have considered and documented any risks above
- [x] I will address all reviewer comments before requesting merge

## Risks considered

- The performance optimization remains intact: untouched composers avoid Tiptap mount cost until focus, and the real editor initializes hidden after intent.
- Plain input received during the short startup window is adopted through the editor's existing Markdown pipeline.
- File-only activation still queues uploads and does not steal focus.
- The native textarea preserves keyboard and screen-reader text-entry semantics during initialization.
- Review specifically tested both event orderings: composition already active when ready arrives, and ready queued before composition starts in the same React batch.

## AI Disclosure

**AI tool used:** OpenAI Codex (Multica Agent)

**Prompt / approach:** Investigated GitHub #5617 on current `main`, isolated the shell-to-editor focus transfer, wrote delayed-readiness IME regressions, implemented a composition-aware handoff, then reviewed the PR as an external change. That review found the reverse-order batched ready/composition-start gap, demonstrated it with a failing test on the original PR commit, patched it, added ordinary-input and real-editor contract tests, and reran targeted plus package-wide verification.

## Screenshots (optional)

Not included: the visible layout is unchanged; the regression is an IME/focus timing boundary covered by deterministic component and hook tests.
