### PR TITLE
docs(demo): scope statement + serial-flow wording in squad demo (WS-592)

### DIFF
--- a/docs/demo/seed-squad-demo.sh
+++ b/docs/demo/seed-squad-demo.sh
@@ -1,0 +1,178 @@
+#!/usr/bin/env bash
+#
+# seed-squad-demo.sh - 一键导入「跨员工 Agent 协作」演示数据。
+#
+# 做三件事（幂等，可重复执行）：
+#   1. 创建（或复用同名）squad「代码交付小队」，leader = 资深工程师；
+#   2. 加入 4 个专项成员（架构 / 编码 / 测试 / 文档），leader 本身也作为成员登记；
+#   3. 写入 squad 指令（leader 编排手册，会在 leader 接管任务时注入其 prompt）。
+#
+# 只创建数据，不触发任何 agent 运行（无 issue 被分派）。
+# 导入完成后，按 docs/demo/squad-collaboration.md §6 创建并分派一个 issue 即可启动演示。
+#
+# 依赖：multica CLI（已 auth login）、python3（解析 JSON）。
+# 兼容 macOS 自带 bash 3.x（不使用关联数组）。
+set -euo pipefail
+
+SQUAD_NAME="代码交付小队"
+SQUAD_DESC="代码交付演示小队：leader 编排，架构/编码/测试/文档协作交付一个需求。见 docs/demo/squad-collaboration.md"
+
+# name|member-type|role  --  第一个必须是 leader agent
+MEMBERS=(
+  "资深工程师|agent|leader"
+  "量化架构师agent|agent|架构"
+  "高级工程师|agent|编码"
+  "测试agent|agent|测试"
+  "paper agent|agent|文档"
+)
+
+read -r -d '' INSTRUCTIONS <<'INSTRUCTIONS_EOF' || true
+# 代码交付小队 · 编排手册
+
+本小队按以下流水线协作交付需求：
+
+1. 架构（量化架构师agent）：先出技术方案 / 接口设计 / 影响面评估，以 issue 评论回传。
+2. 编码（高级工程师）：拿到架构方案后实现，改动 / PR 以评论回传。
+3. 测试（测试agent）：拿到实现后端到端验证，结论以评论回传。
+4. 文档（paper agent）：交付后写变更说明 / changelog。
+
+leader（资深工程师）职责：
+- 读需求后按上面顺序逐个 @mention 派活，不要一次性全派。
+- 每一轮派活后调 `multica squad activity <issue-id> action --reason "<简述>"` 记录评估。
+- 成员回传后再次被触发时，评估是否进入下一阶段。
+- 全部完成后推进 issue 状态并 @mention 提交者汇报。
+- 需求不清时 @mention 提交者澄清，不要自行假设。
+INSTRUCTIONS_EOF
+
+# ---------- helpers ----------
+
+die() { echo "ERROR: $*" >&2; exit 1; }
+
+require_cmd() { command -v "$1" >/dev/null 2>&1 || die "missing dependency: $1"; }
+require_cmd multica
+require_cmd python3
+
+# 缓存 agent 列表，避免多次调用 CLI
+AGENT_LIST_FILE="$(mktemp)"
+trap 'rm -f "$AGENT_LIST_FILE"' EXIT
+multica agent list --output json > "$AGENT_LIST_FILE" || die "multica agent list 失败"
+
+# resolve_agent_id <name> -> prints agent id (exit 1 if not found, 2 if archived)
+resolve_agent_id() {
+  local name="$1"
+  NAME="$name" AGENT_LIST_FILE="$AGENT_LIST_FILE" python3 -c '
+import json, os, sys
+name = os.environ["NAME"]
+with open(os.environ["AGENT_LIST_FILE"]) as f:
+    agents = json.load(f)
+matches = [a for a in agents if a.get("name") == name]
+if not matches:
+    sys.exit(1)
+if matches[0].get("archived_at"):
+    sys.stderr.write("agent %r is archived\n" % name); sys.exit(2)
+print(matches[0]["id"])
+'
+}
+
+# find_squad_id <name> -> prints squad id or empty
+find_squad_id() {
+  local name="$1"
+  multica squad list --output json 2>/dev/null | NAME="$name" python3 -c '
+import json, os, sys
+name = os.environ["NAME"]
+try:
+    squads = json.load(sys.stdin)
+except Exception:
+    sys.exit(0)
+for s in squads:
+    if s.get("name") == name and not s.get("archived_at"):
+        print(s["id"]); break
+' || true
+}
+
+# member_exists <squad-id> <member-type> <member-id> -> 0/1
+member_exists() {
+  local squad_id="$1" mtype="$2" mid="$3"
+  multica squad member list "$squad_id" --output json 2>/dev/null | \
+    MTYPE="$mtype" MID="$mid" python3 -c '
+import json, os, sys
+mtype, mid = os.environ["MTYPE"], os.environ["MID"]
+try:
+    members = json.load(sys.stdin)
+except Exception:
+    sys.exit(1)
+for m in members:
+    if m.get("member_type") == mtype and m.get("member_id") == mid:
+        sys.exit(0)
+sys.exit(1)
+'
+}
+
+# ---------- main ----------
+
+echo "==> 解析成员 agent id（按名字）"
+leader_name="${MEMBERS[0]%%|*}"
+leader_id=""
+member_count=0
+MEMBER_NAMES=()
+MEMBER_IDS=()
+MEMBER_TYPES=()
+MEMBER_ROLES=()
+for entry in "${MEMBERS[@]}"; do
+  name="${entry%%|*}"
+  rest="${entry#*|}"
+  mtype="${rest%%|*}"
+  role="${rest##*|}"
+  id="$(resolve_agent_id "$name")" || die "agent 不存在: $name（请在 Agents 页创建或改名后重跑）"
+  MEMBER_NAMES+=("$name"); MEMBER_IDS+=("$id"); MEMBER_TYPES+=("$mtype"); MEMBER_ROLES+=("$role")
+  echo "    $name ($mtype, $role) -> ${id:0:8}…"
+done
+leader_id="${MEMBER_IDS[0]}"
+echo "==> leader = $leader_name ($leader_id)"
+
+echo "==> 查找或创建 squad「$SQUAD_NAME」"
+squad_id="$(find_squad_id "$SQUAD_NAME")"
+if [ -n "$squad_id" ]; then
+  echo "    已存在，复用 $squad_id"
+  cur_leader="$(multica squad get "$squad_id" --output json 2>/dev/null | python3 -c 'import json,sys;print(json.load(sys.stdin).get("leader_id",""))' 2>/dev/null || true)"
+  if [ -n "$cur_leader" ] && [ "$cur_leader" != "$leader_id" ]; then
+    echo "    校正 leader -> $leader_name"
+    multica squad update "$squad_id" --leader "$leader_id" >/dev/null
+  fi
+else
+  echo "    创建中…"
+  squad_id="$(multica squad create --name "$SQUAD_NAME" --leader "$leader_id" --description "$SQUAD_DESC" --output json | python3 -c 'import json,sys;print(json.load(sys.stdin)["id"])')"
+  echo "    创建完成 $squad_id"
+fi
+
+echo "==> 写入 squad 指令"
+multica squad update "$squad_id" --instructions "$INSTRUCTIONS" >/dev/null
+echo "    OK"
+
+echo "==> 加入成员（幂等，已存在则跳过）"
+i=0
+for entry in "${MEMBERS[@]}"; do
+  name="${MEMBER_NAMES[$i]}"; mid="${MEMBER_IDS[$i]}"; mtype="${MEMBER_TYPES[$i]}"; role="${MEMBER_ROLES[$i]}"
+  if member_exists "$squad_id" "$mtype" "$mid"; then
+    echo "    $name 已在 squad，跳过"
+  else
+    multica squad member add "$squad_id" --type "$mtype" --member-id "$mid" --role "$role" >/dev/null
+    echo "    + $name ($role)"
+  fi
+  i=$((i+1))
+done
+
+echo
+echo "==> 完成。demo squad id：$squad_id"
+echo
+echo "下一步（启动 5 分钟演示）："
+echo "  multica issue create \\"
+echo "    --title \"Demo: 给用户菜单增加深色模式开关\" \\"
+echo "    --description \"演示用，由代码交付小队协作完成。\" \\"
+echo "    --assignee \"$SQUAD_NAME\""
+echo
+echo "查看成员状态："
+echo "  multica squad get $squad_id"
+echo "  multica squad member list $squad_id --output json"
+echo
+echo "完整步骤见 docs/demo/squad-collaboration.md"

--- a/docs/demo/squad-collaboration.md
+++ b/docs/demo/squad-collaboration.md
@@ -1,0 +1,189 @@
+# 跨员工 Agent 协作演示 · Squad Collaboration Demo
+
+> 场景级演示：一个需求进入 squad，由 leader agent 编排，分派给架构师 / 工程师 / 测试 / 文档等专项 agent 协作完成。5 分钟内从「创建 squad」看到「协作结果」。
+>
+> 本文档面向产品演示 / 客户 demo / 新同学上手。每一条命令均可直接复制执行。
+
+---
+
+## 1. 这是什么
+
+> **本 demo 的范围**：演示「单 workspace 内多 agent 协作」（leader 编排 + 成员专项分工 + 可观测交接）。WS-567 中更进一步的「跨员工 remote agent endpoint + 消息协议」是独立的 2 周 P0 MVP，目前 blocked 未实装，不在本 demo 范围（详见 §10 局限）。
+
+Multica 的 **Squad（小队）** 是一类特殊的 issue assignee。把 issue 分派给 squad，系统不会让 squad 自己跑，而是**唤醒 squad 的 leader agent**。leader 拿到任务后只做一件事：**编排**——读需求、按成员技能挑人、在 issue 评论里用 `@mention` 把活派下去，然后记录自己的评估。
+
+这就构成了一条**多 agent 协作链**：
+
+```
+issue 指派给 squad
+   └─> leader agent 被唤醒（注入「Squad Operating Protocol + 成员花名册 + squad 指令」）
+         └─> leader 在评论里 @mention 架构师  ──> 架构师出方案（评论回传）
+               └─> leader @mention 工程师     ──> 工程师编码（评论回传）
+                     └─> leader @mention 测试 ──> 测试验证（评论回传）
+                           └─> leader 调 `multica squad activity` 记录评估
+```
+
+相比单个全能 agent 串行做完所有事，squad 的增益是：**专业化分工 + 可观测的编排过程 + 并行能力**。
+
+---
+
+## 2. 演示价值（对照 WS-567）
+
+| 价值点 | 单 agent | Squad |
+|---|---|---|
+| **分工** | 一个 agent 干所有事，无专业边界 | 架构师出方案、工程师编码、测试验证、文档沉淀，各司其职 |
+| **协作** | 无交接，全程黑盒 | leader 在 issue 评论里 `@mention` 派活，交接可追溯 |
+| **价值** | 串行、无编排视角 | 专项化工作 + leader 编排，每一步在时间线上可见 |
+
+> **关于「跨员工」**：本演示覆盖 WS-567 中「单 workspace 内多 agent（分属不同职能）协作」这一已通电部分。WS-567 里更进一步的「跨员工 remote agent endpoint + agent 间消息协议」是独立的 2 周 P0 MVP，目前 blocked、未实装，不在本演示范围（见 §10 局限）。
+
+---
+
+## 3. 演示场景：代码交付小队
+
+**用户故事**：
+
+> 作为 workspace owner，我提交一个产品需求（如「给用户菜单加一个深色模式开关」），不指定具体执行者，而是分派给「代码交付小队」。小队的 leader（资深工程师）评估后，把方案设计派给架构师、把编码派给工程师、把验证派给测试、把变更说明派给文档 agent。我在 issue 时间线和 squad 成员页上实时看到谁在干什么。
+
+**角色配置**（demo squad「代码交付小队」）：
+
+| 成员 | 角色 | 职责 |
+|---|---|---|
+| 资深工程师 | leader | 编排：评估需求、按技能派活、记录评估 |
+| 量化架构师agent | 架构 | 出技术方案 / 接口设计 |
+| 高级工程师 | 编码 | 实现 |
+| 测试agent | 测试 | 端到端验证 |
+| paper agent | 文档 | 变更说明 / changelog |
+
+---
+
+## 4. 前置条件
+
+1. **workspace 内存在上述 5 个 agent**（名字匹配即可，见 §5 一键导入）。本工作区已自带这套阵容。
+2. **相关 agent 的 runtime 已绑定且在线**。成员状态来自 runtime 心跳 + 活跃任务（`server/internal/handler/squad.go::deriveSquadMemberStatus`）：runtime 未绑定的成员会显示 `offline`，演示效果差。在 **Agents** 页确认 leader 与至少 2 个成员状态不是 offline。
+3. **已安装 `multica` CLI** 并 `multica auth login` 到目标 workspace。
+
+---
+
+## 5. 一键导入 demo 数据
+
+```bash
+bash docs/demo/seed-squad-demo.sh
+```
+
+脚本幂等：已存在同名 squad 则复用并补齐成员与指令，不会重复创建。它做三件事：
+
+1. 创建（或复用）squad **代码交付小队**，leader = 资深工程师；
+2. 按 §3 表格加入 4 个成员（带角色）；
+3. 写入 squad 指令（leader 编排手册，会被注入到 leader 的 prompt，见 `server/internal/handler/squad_briefing.go`）。
+
+脚本只创建数据，**不会触发任何 agent 运行**（没有 issue 被分派）。导入完成后拿到的 squad id 用于后续步骤。
+
+校验导入结果：
+
+```bash
+multica squad list --output json | python3 -c "import json,sys;[print(s['name'],s['id']) for s in json.load(sys.stdin)]"
+multica squad member list <squad-id> --output json
+```
+
+---
+
+## 6. 5 分钟演示步骤
+
+> 计时从「创建并分派 issue」开始算（demo 数据已在 §5 导入）。实际 leader / 成员 agent 真正跑完各自的活可能超过 5 分钟，但**协作链的启动与可观测信号**在 5 分钟内必定出现。
+
+### Step 1 ｜ 创建并分派 issue（~30 秒）
+
+```bash
+multica issue create \
+  --title "Demo: 给用户菜单增加深色模式开关" \
+  --description "演示用：由「代码交付小队」协作完成。需要架构方案、编码实现、测试验证、变更文档。" \
+  --assignee "代码交付小队"
+```
+
+`--assignee` 接受 squad 名（模糊匹配，等价于 `--assignee-id <squad-id>`）。这一刻系统把 issue 的 `assignee_type` 设为 `squad`，并向 squad 的 leader 排一个 `is_leader_task=true` 的任务（`server/internal/service/issue.go::maybeEnqueueOnAssign`）。
+
+### Step 2 ｜ 观察 leader 接管（~30–60 秒）
+
+打开 issue 页（Web/Desktop）或 `multica issue comment list <issue-id> --recent 5`：
+
+- leader（资深工程师）被唤醒，拿到注入的 **Squad Operating Protocol + 成员花名册**（每行带可粘贴的 `[@Name](mention://agent/<UUID>)` 链接 + 该 agent 的技能）。
+- leader 发一条**简短的派活评论**，`@mention` 架构师并交代要做什么。
+- leader 调 `multica squad activity <issue-id> action --reason "派给架构师出方案"`，在 issue 时间线记一条 `squad_leader_evaluated`。
+
+> Operating Protocol 要求 leader「只编排、不亲自干活」「派完就停、被再次触发再评估」（`server/internal/handler/squad_briefing.go::squadOperatingProtocol`）。演示时讲清这条，能让观众理解为什么 leader 不直接写代码。
+
+### Step 3 ｜ 观察成员协作（~2–3 分钟）
+
+随着 leader 派活，被 `@mention` 的成员依次被唤醒：
+
+- 架构师发方案评论 → leader 再次被触发 → `@mention` 工程师编码；
+- 工程师编码回传 → leader `@mention` 测试验证；
+- 测试验证回传 → leader `@mention` 文档沉淀。
+
+每一轮 leader 都会调一次 `multica squad activity`。所有交接都在**同一 issue 的评论线程**里，可线性回放。
+
+### Step 4 ｜ 看协作全貌
+
+| 看哪里 | 看到什么 |
+|---|---|
+| **Squad 详情页** `/squads/<id>` | 成员行右侧的状态 pill 翻成 `working`（绿点），下方出现 active issue chip（`WS-xxx`）。空闲成员是 `idle`，离线是 `offline`。 |
+| **Issue 活动** `multica issue comment list <issue-id>` | leader 的派活评论、成员的结果评论、带 `@mention` 的交接。 |
+| **Issue 活动时间线**（Web issue 页） | 每轮 `squad_leader_evaluated` 条目（`action`/`no_action`/`failed`）。 |
+| **CLI** | `multica agent tasks <leader-id>` 可看 leader 当前编排任务。 |
+
+---
+
+## 7. 预期输出（30 秒可感知信号）
+
+观众 30 秒内应能说出这三件事，否则演示没到位：
+
+1. **「leader 在派活，不是自己干」**——issue 评论里能看到 leader 的 `@mention` 派活评论。
+2. **「不同 agent 在各自干活」**——squad 成员页上 ≥2 个成员状态 pill 是 `working` 且各挂一条 active issue。
+3. **「过程可追溯」**——issue 时间线里有 `squad_leader_evaluated` 条目，评论线程能线性回放交接。
+
+---
+
+## 8. 单 agent vs Squad 价值对照（可现场对比）
+
+```bash
+# 对照组：同样需求分派给单个 agent（资深工程师）
+multica issue create --title "对照: 深色模式开关（单 agent）" --assignee "资深工程师"
+```
+
+对照观察：单 agent 串行做所有事，无交接评论、无成员状态联动、无 leader 评估记录；squad 则有明确分工与可观测编排。
+
+---
+
+## 9. 清理
+
+```bash
+# 归档 demo squad（成员的 issue assignee 会自动转给 leader，不会丢失）
+multica squad delete <squad-id>
+
+# 归档 demo issue
+multica issue status <issue-id> cancelled
+```
+
+---
+
+## 10. 局限与后续
+
+- **无专门的「Flow 可视化」图**。当前协作可视化形式是：squad 成员状态 pill + active issue chip + issue 活动时间线 + 评论线程。没有一张汇总的「squad 协作流程图」。`stageBarrierClosed`（`server/internal/handler/issue_child_done.go`）是父子 issue 的 stage 闭环，不是 squad 可视化。
+- **无 agent 间消息协议**。agent 之间通过 issue 评论 + `@mention` 通信（`server/internal/util/mention.go`、`computeCommentAgentTriggers`），没有独立 inbox / 消息表。
+- **跨员工 remote agent**（WS-567 MVP）：让员工 A 的 agent 与员工 B 的 agent 在同一 squad 协作、远程 endpoint 注册、跨员工消息审计——目前 blocked、未实装，是下一步重点。
+
+---
+
+## 11. 技术参考（源码位置）
+
+| 能力 | 位置 |
+|---|---|
+| issue 分派给 squad → 唤醒 leader | `server/internal/service/issue.go`（`maybeEnqueueOnAssign` / `shouldEnqueueSquadLeaderOnAssign` / `enqueueSquadLeaderTask`） |
+| leader 任务打标 | `server/internal/service/task.go`（`EnqueueTaskForSquadLeader`，`IsLeaderTask`/`SquadID`） |
+| leader 拿任务时注入 briefing | `server/internal/handler/daemon.go` + `server/internal/handler/squad_briefing.go`（`buildSquadLeaderBriefing` = Protocol + Roster + Instructions） |
+| `multica squad activity` 落库 | `server/internal/handler/squad.go`（`RecordSquadLeaderEvaluation`，写统一 `activity_log`） |
+| 成员状态推导 | `server/internal/handler/squad.go`（`deriveSquadMemberStatus`） |
+| 前端 squad 页 | `packages/views/squads/components/squad-detail-page.tsx` |
+| 前端活动渲染 | `packages/views/issues/components/issue-detail.tsx`（`squad_leader_evaluated`） |
+| demo 数据导入脚本 | `docs/demo/seed-squad-demo.sh` |


### PR DESCRIPTION
## Summary

Lands the WS-584 squad demo doc + script (`docs/demo/squad-collaboration.md`, `docs/demo/seed-squad-demo.sh`) and applies the 2 wording fixes from the WS-589 product walkthrough follow-up (WS-592).

The demo files were previously only workspace artifacts (never committed to the repo); this PR commits them with the WS-592 fixes already applied.

## Changes

- **§1** (优化点 1, 方案 A): add a scope statement clarifying this demo covers single-workspace multi-agent collaboration (leader orchestration + member specialization + observable handoff). The WS-567 cross-employee remote-agent endpoint + messaging protocol is a separate blocked 2-week P0 MVP, out of scope (详见 §10 局限).
- **§2 value table** (优化点 2): `并行的专项工作 + leader 级编排` → `专项化工作 + leader 编排`, matching the actual serial pipeline (架构 → 编码 → 测试 → 文档) rather than claiming parallelism the demo does not exhibit.
- **§2 note** (adjacent, disclosed): fix wrong cross-reference `见 §8 局限` → `见 §10 局限` (局限 is §10; §8 is the single-agent vs squad comparison).

## Verification

- `seed-squad-demo.sh` is unchanged; idempotency was already re-verified in the WS-589 walkthrough.
- No demo-data / script-logic changes (per WS-592 acceptance: no re-run needed).

## Refs

- Walkthrough (passed): WS-589
- Follow-up issue: WS-592
- Parent: WS-584 (squad demo path)
