### PR TITLE
feat(views): add theme switcher to user menu

### DIFF
--- a/packages/views/layout/app-sidebar.test.tsx
+++ b/packages/views/layout/app-sidebar.test.tsx
@@ -1,9 +1,9 @@
-import { render, screen, waitFor } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { ApiError } from "@multica/core/api";
 import { AppSidebar } from "./app-sidebar";
 
-const { appForeground, chatSessions, chatStore, detail, deletePin, inboxItems, navigation, pins, summary, workspaces } = vi.hoisted(() => ({
+const { appForeground, chatSessions, chatStore, detail, deletePin, inboxItems, navigation, pins, summary, themeMock, workspaces } = vi.hoisted(() => ({
   appForeground: { current: true },
   chatSessions: { current: [] as { id?: string; unread_count?: number }[] },
   chatStore: { current: { activeSessionId: null as string | null, isOpen: false } },
@@ -12,6 +12,9 @@ const { appForeground, chatSessions, chatStore, detail, deletePin, inboxItems, n
   inboxItems: { current: [] as { id: string; read: boolean }[] },
   navigation: { current: { pathname: "/acme/issues" } },
   summary: { current: [] as { workspace_id: string; count: number }[] },
+  themeMock: {
+    current: { theme: "light" as string | undefined, setTheme: vi.fn() },
+  },
   workspaces: {
     current: [] as { id: string; name: string; slug: string; avatar_url: string | null }[],
   },
@@ -68,15 +71,61 @@ vi.mock("@multica/ui/components/ui/sidebar", () => ({
   SidebarMenuItem: ({ children }: { children: React.ReactNode }) => <>{children}</>,
   SidebarRail: () => null,
 }));
-vi.mock("@multica/ui/components/ui/dropdown-menu", () => ({
-  DropdownMenu: ({ children }: { children: React.ReactNode }) => <>{children}</>,
-  DropdownMenuContent: ({ children }: { children: React.ReactNode }) => <>{children}</>,
-  DropdownMenuGroup: ({ children }: { children: React.ReactNode }) => <>{children}</>,
-  DropdownMenuItem: ({ children }: { children: React.ReactNode }) => <>{children}</>,
-  DropdownMenuLabel: ({ children }: { children: React.ReactNode }) => <>{children}</>,
-  DropdownMenuSeparator: () => null,
-  DropdownMenuTrigger: ({ render }: { render: React.ReactNode }) => <>{render}</>,
-}));
+vi.mock("@multica/ui/components/ui/dropdown-menu", async () => {
+  const { createContext, useContext } = await import("react");
+  // Faithful-enough radio semantics so the appearance submenu's "current
+  // theme has a Check" and "click calls setTheme" behavior is testable:
+  // RadioGroup feeds its value + onValueChange via context, and RadioItem
+  // renders data-checked when its value matches and forwards clicks.
+  const RadioCtx = createContext<{ value?: string; onValueChange?: (v: string) => void }>({});
+  return {
+    DropdownMenu: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+    DropdownMenuContent: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+    DropdownMenuGroup: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+    DropdownMenuItem: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+    DropdownMenuLabel: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+    DropdownMenuSeparator: () => null,
+    DropdownMenuTrigger: ({ render }: { render: React.ReactNode }) => <>{render}</>,
+    DropdownMenuSub: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+    DropdownMenuSubTrigger: ({ children }: { children: React.ReactNode }) => (
+      <button type="button">{children}</button>
+    ),
+    DropdownMenuSubContent: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+    DropdownMenuRadioGroup: ({
+      value,
+      onValueChange,
+      children,
+    }: {
+      value?: string;
+      onValueChange?: (v: string) => void;
+      children: React.ReactNode;
+    }) => (
+      <RadioCtx.Provider value={{ value, onValueChange }}>{children}</RadioCtx.Provider>
+    ),
+    DropdownMenuRadioItem: ({
+      value,
+      children,
+    }: {
+      value?: string;
+      children: React.ReactNode;
+    }) => {
+      const ctx = useContext(RadioCtx);
+      const checked = value !== undefined && value === ctx.value;
+      return (
+        <button
+          type="button"
+          role="menuitemradio"
+          data-value={value}
+          data-checked={checked ? "true" : undefined}
+          aria-checked={checked}
+          onClick={() => ctx.onValueChange?.(value as string)}
+        >
+          {children}
+        </button>
+      );
+    },
+  };
+});
 vi.mock("@multica/ui/components/ui/collapsible", () => ({
   Collapsible: ({ children }: { children: React.ReactNode }) => <>{children}</>,
   CollapsibleContent: ({ children }: { children: React.ReactNode }) => <>{children}</>,
@@ -100,6 +149,9 @@ vi.mock("../navigation", () => ({
 vi.mock("../projects/components/project-icon", () => ({ ProjectIcon: () => <span /> }));
 vi.mock("../workspace/workspace-avatar", () => ({ WorkspaceAvatar: () => <span /> }));
 vi.mock("@multica/ui/components/common/actor-avatar", () => ({ ActorAvatar: () => <span /> }));
+vi.mock("@multica/ui/components/common/theme-provider", () => ({
+  useTheme: () => themeMock.current,
+}));
 
 vi.mock("@multica/core/auth", () => ({
   useAuthStore: (selector: (state: { user: { id: string } }) => unknown) => selector({ user: { id: "user-1" } }),
@@ -391,5 +443,42 @@ describe("personal nav — Chat", () => {
     appForeground.current = false;
     const { container } = render(<AppSidebar />);
     expect(chatBadge(container)).toHaveAttribute("aria-label", "5");
+  });
+});
+
+describe("appearance submenu", () => {
+  beforeEach(() => {
+    themeMock.current = { theme: "light", setTheme: vi.fn() };
+    summary.current = [];
+    workspaces.current = [];
+  });
+
+  it("renders the three theme options inside the appearance submenu", () => {
+    const { container } = render(<AppSidebar />);
+    expect(container.querySelector('[data-value="light"]')).not.toBeNull();
+    expect(container.querySelector('[data-value="dark"]')).not.toBeNull();
+    expect(container.querySelector('[data-value="system"]')).not.toBeNull();
+  });
+
+  it("calls setTheme when a theme option is clicked", () => {
+    const { container } = render(<AppSidebar />);
+    fireEvent.click(container.querySelector('[data-value="dark"]')!);
+    expect(themeMock.current.setTheme).toHaveBeenCalledWith("dark");
+  });
+
+  it("does not call setTheme when the already-active theme is clicked", () => {
+    // theme defaults to "light"; clicking light is a no-op so the radio
+    // group's onValueChange guard skips the redundant write.
+    const { container } = render(<AppSidebar />);
+    fireEvent.click(container.querySelector('[data-value="light"]')!);
+    expect(themeMock.current.setTheme).not.toHaveBeenCalled();
+  });
+
+  it("marks the current theme option as checked", () => {
+    themeMock.current = { theme: "dark", setTheme: vi.fn() };
+    const { container } = render(<AppSidebar />);
+    expect(container.querySelector('[data-value="dark"]')).toHaveAttribute("data-checked", "true");
+    expect(container.querySelector('[data-value="light"]')).not.toHaveAttribute("data-checked");
+    expect(container.querySelector('[data-value="system"]')).not.toHaveAttribute("data-checked");
   });
 });

--- a/packages/views/layout/app-sidebar.tsx
+++ b/packages/views/layout/app-sidebar.tsx
@@ -25,6 +25,7 @@ import {
   ChevronDown,
   ChevronRight,
   Settings,
+  SunMoon,
   LogOut,
   Plus,
   Check,
@@ -39,6 +40,7 @@ import {
 } from "lucide-react";
 import { WorkspaceAvatar } from "../workspace/workspace-avatar";
 import { ActorAvatar } from "@multica/ui/components/common/actor-avatar";
+import { useTheme } from "@multica/ui/components/common/theme-provider";
 import { Tooltip, TooltipTrigger, TooltipContent } from "@multica/ui/components/ui/tooltip";
 import { Collapsible, CollapsibleTrigger, CollapsibleContent } from "@multica/ui/components/ui/collapsible";
 import { CappedNumberFlow } from "@multica/ui/components/ui/number-flow";
@@ -64,7 +66,12 @@ import {
   DropdownMenuGroup,
   DropdownMenuItem,
   DropdownMenuLabel,
+  DropdownMenuRadioGroup,
+  DropdownMenuRadioItem,
   DropdownMenuSeparator,
+  DropdownMenuSub,
+  DropdownMenuSubContent,
+  DropdownMenuSubTrigger,
   DropdownMenuTrigger,
 } from "@multica/ui/components/ui/dropdown-menu";
 import { useAuthStore } from "@multica/core/auth";
@@ -341,6 +348,48 @@ function PinSkeleton() {
         <div className="h-3 w-24 rounded bg-sidebar-accent/40" />
       </div>
     </SidebarMenuItem>
+  );
+}
+
+// Quick theme switcher surfaced in the workspace-switcher user menu. Reuses
+// the same next-themes `useTheme` as the Settings > Preferences tab, so the
+// two surfaces stay in sync without a shared store. Theme options borrow the
+// Settings namespace labels (preferences.theme.*) instead of duplicating
+// them here; only the group trigger label is local to layout.
+function AppearanceSubmenu() {
+  const { t } = useT("layout");
+  const { t: tSettings } = useT("settings");
+  const { theme, setTheme } = useTheme();
+
+  const themeOptions = [
+    { value: "light" as const, label: tSettings(($) => $.preferences.theme.light) },
+    { value: "dark" as const, label: tSettings(($) => $.preferences.theme.dark) },
+    { value: "system" as const, label: tSettings(($) => $.preferences.theme.system) },
+  ];
+
+  return (
+    <DropdownMenuGroup>
+      <DropdownMenuSub>
+        <DropdownMenuSubTrigger>
+          <SunMoon className="h-3.5 w-3.5" />
+          <span>{t(($) => $.sidebar.appearance)}</span>
+        </DropdownMenuSubTrigger>
+        <DropdownMenuSubContent>
+          <DropdownMenuRadioGroup
+            value={theme}
+            onValueChange={(next) => {
+              if (next && next !== theme) setTheme(next);
+            }}
+          >
+            {themeOptions.map((option) => (
+              <DropdownMenuRadioItem key={option.value} value={option.value}>
+                {option.label}
+              </DropdownMenuRadioItem>
+            ))}
+          </DropdownMenuRadioGroup>
+        </DropdownMenuSubContent>
+      </DropdownMenuSub>
+    </DropdownMenuGroup>
   );
 }
 
@@ -628,6 +677,8 @@ export function AppSidebar({ topSlot, searchSlot, headerClassName, headerStyle }
                       </DropdownMenuGroup>
                     </>
                   )}
+                  <DropdownMenuSeparator />
+                  <AppearanceSubmenu />
                   <DropdownMenuSeparator />
                   <DropdownMenuGroup>
                     <DropdownMenuItem variant="destructive" onClick={logout}>

--- a/packages/views/locales/en/layout.json
+++ b/packages/views/locales/en/layout.json
@@ -33,6 +33,7 @@
     "invitation_workspace_fallback": "Workspace",
     "invitation_join": "Join",
     "invitation_decline": "Decline",
+    "appearance": "Appearance",
     "log_out": "Log out",
     "new_issue": "New Issue",
     "new_issue_shortcut": "C",

--- a/packages/views/locales/ja/layout.json
+++ b/packages/views/locales/ja/layout.json
@@ -33,6 +33,7 @@
     "invitation_workspace_fallback": "ワークスペース",
     "invitation_join": "参加",
     "invitation_decline": "辞退",
+    "appearance": "外観",
     "log_out": "ログアウト",
     "new_issue": "新規イシュー",
     "new_issue_shortcut": "C",

--- a/packages/views/locales/ko/layout.json
+++ b/packages/views/locales/ko/layout.json
@@ -33,6 +33,7 @@
     "invitation_workspace_fallback": "워크스페이스",
     "invitation_join": "참가",
     "invitation_decline": "거절",
+    "appearance": "모양",
     "log_out": "로그아웃",
     "new_issue": "새 이슈",
     "new_issue_shortcut": "C",

--- a/packages/views/locales/zh-Hans/layout.json
+++ b/packages/views/locales/zh-Hans/layout.json
@@ -33,6 +33,7 @@
     "invitation_workspace_fallback": "工作区",
     "invitation_join": "加入",
     "invitation_decline": "拒绝",
+    "appearance": "外观",
     "log_out": "退出登录",
     "new_issue": "新建 issue",
     "new_issue_shortcut": "C",


### PR DESCRIPTION
## Summary
- Add an **Appearance** submenu to the workspace-switcher user menu (`packages/views/layout/app-sidebar.tsx`) with Light / Dark / System options, rendered as a `DropdownMenuSub` + `DropdownMenuRadioGroup` (current option auto-checked), inserted above the "Log out" group.
- Reuses `useTheme()` from `@multica/ui/components/common/theme-provider` (next-themes) — the same source as **Settings > Preferences** — so the two surfaces stay bidirectionally in sync with no new store, matching the client-view-state split in CLAUDE.md.
- Theme option labels borrow `settings.preferences.theme.{light,dark,system}` (no key duplication); only `sidebar.appearance` is new, added to en / zh-Hans / ja / ko per the conventions glossary (Appearance → 外观 / 外観 / 모양).
- SSR-safe: passes `theme` (may be `undefined` on first frame) straight to the radio group — no item is checked until resolved, same fallback as the preferences tab.

## Files
- `packages/views/layout/app-sidebar.tsx` — `AppearanceSubmenu` component + insertion before logout group.
- `packages/views/layout/app-sidebar.test.tsx` — `useTheme` mock, extended dropdown-menu mock with Sub/Radio primitives, 4 new cases.
- `packages/views/locales/{en,zh-Hans,ja,ko}/layout.json` — `sidebar.appearance`.

## Test plan
- [x] `pnpm typecheck` (full monorepo: ui/core/docs/views/web/desktop) — pass
- [x] `pnpm test` (views) — 2683 tests pass, incl. 4 new appearance-submenu cases and 162 locale-parity checks
- [ ] Manual: open user menu → Appearance submenu shows 3 options, current has check; switching flips theme immediately and matches Settings > Preferences.

Closes the coding phase of WS-591. Test agent to run end-to-end verification.
