### PR TITLE
feat(squads): clarify squad member management (WS-656)

### DIFF
--- a/packages/views/locales/en/squads.json
+++ b/packages/views/locales/en/squads.json
@@ -67,7 +67,15 @@
     "status_archived": "Archived",
     "issue_status_blocked": "blocked",
     "active_issue_more": "and {{count}} more",
-    "last_active_label": "last active {{time}}"
+    "last_active_label": "last active {{time}}",
+    "status_summary_label": "Status",
+    "filter_all": "All",
+    "agents_section": "Agents",
+    "humans_section": "People",
+    "archived_section": "Archived",
+    "no_role": "No role",
+    "no_match_filter": "No agents match this filter",
+    "empty_roster": "No members yet. Add an agent or member to get started."
   },
   "profile_card": {
     "unavailable": "Squad unavailable",

--- a/packages/views/locales/ja/squads.json
+++ b/packages/views/locales/ja/squads.json
@@ -66,7 +66,15 @@
     "issue_status_blocked": "ブロック中",
     "active_issue_more": "他 {{count}}件",
     "last_active_label": "最終アクティブ {{time}}",
-    "status_archived": "アーカイブ済み"
+    "status_archived": "アーカイブ済み",
+    "status_summary_label": "ステータス",
+    "filter_all": "すべて",
+    "agents_section": "エージェント",
+    "humans_section": "メンバー",
+    "archived_section": "アーカイブ",
+    "no_role": "役割なし",
+    "no_match_filter": "この絞り込みに一致するエージェントはありません",
+    "empty_roster": "まだメンバーがいません。エージェントまたはメンバーを追加してください。"
   },
   "profile_card": {
     "unavailable": "スクワッドを利用できません",

--- a/packages/views/locales/ko/squads.json
+++ b/packages/views/locales/ko/squads.json
@@ -66,7 +66,15 @@
     "status_archived": "보관됨",
     "issue_status_blocked": "막힘",
     "active_issue_more": "외 {{count}}개",
-    "last_active_label": "마지막 활동 {{time}}"
+    "last_active_label": "마지막 활동 {{time}}",
+    "status_summary_label": "상태",
+    "filter_all": "전체",
+    "agents_section": "에이전트",
+    "humans_section": "멤버",
+    "archived_section": "보관됨",
+    "no_role": "역할 없음",
+    "no_match_filter": "이 필터와 일치하는 에이전트가 없습니다",
+    "empty_roster": "아직 멤버가 없습니다. 에이전트 또는 멤버를 추가하세요."
   },
   "profile_card": {
     "unavailable": "스쿼드를 사용할 수 없습니다",

--- a/packages/views/locales/zh-Hans/squads.json
+++ b/packages/views/locales/zh-Hans/squads.json
@@ -66,7 +66,15 @@
     "status_archived": "已归档",
     "issue_status_blocked": "已阻塞",
     "active_issue_more": "还有 {{count}} 个",
-    "last_active_label": "最近活动 {{time}}"
+    "last_active_label": "最近活动 {{time}}",
+    "status_summary_label": "状态",
+    "filter_all": "全部",
+    "agents_section": "智能体",
+    "humans_section": "人员",
+    "archived_section": "已归档",
+    "no_role": "未设置角色",
+    "no_match_filter": "没有匹配该筛选的智能体",
+    "empty_roster": "还没有成员。添加智能体或成员以开始。"
   },
   "profile_card": {
     "unavailable": "小队不可用",

--- a/packages/views/squads/components/squad-detail-page.test.tsx
+++ b/packages/views/squads/components/squad-detail-page.test.tsx
@@ -1,0 +1,243 @@
+// @vitest-environment jsdom
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { fireEvent, render, screen, within } from "@testing-library/react";
+import { I18nProvider } from "@multica/core/i18n/react";
+import type {
+  SquadMember,
+  SquadMemberStatus,
+  SquadMemberStatusValue,
+} from "@multica/core/types";
+import enCommon from "../../locales/en/common.json";
+import enSquads from "../../locales/en/squads.json";
+
+const TEST_RESOURCES = { en: { common: enCommon, squads: enSquads } };
+
+// SquadMembersTab pulls nothing from React Query (it receives its data as
+// props), but the host module imports a handful of platform hooks at the
+// top level - stub them inert so the module loads without workspace infra.
+vi.mock("@multica/core/paths", () => ({
+  useCurrentWorkspace: () => ({ id: "ws-1", name: "Acme" }),
+  useWorkspacePaths: () => ({
+    agentDetail: (id: string) => `/ws-1/agents/${id}`,
+    issueDetail: (id: string) => `/ws-1/issues/${id}`,
+  }),
+}));
+vi.mock("@multica/core/hooks", () => ({ useWorkspaceId: () => "ws-1" }));
+vi.mock("@multica/core/auth", () => ({
+  useAuthStore: Object.assign(vi.fn(), {
+    getState: () => ({ user: { id: "user-1" } }),
+  }),
+}));
+vi.mock("@multica/core/workspace/queries", () => ({
+  agentListOptions: () => ({ queryKey: ["agents"], queryFn: () => Promise.resolve([]) }),
+  memberListOptions: () => ({ queryKey: ["members"], queryFn: () => Promise.resolve([]) }),
+  squadMemberStatusOptions: () => ({ queryKey: ["squad-status"], queryFn: () => Promise.resolve({ members: [] }) }),
+  workspaceKeys: { squads: () => ["squads"] },
+}));
+vi.mock("@multica/core/workspace/avatar-url", () => ({ resolvePublicFileUrl: (u: string) => u }));
+vi.mock("@multica/core/utils", () => ({ isImeComposing: () => false }));
+vi.mock("@multica/core/shortcuts", () => ({
+  getShortcut: () => ({ key: "Enter", ctrl: false, meta: false, shift: false, alt: false }),
+  shortcutMatchesEvent: () => false,
+}));
+vi.mock("../../common/actor-avatar", () => ({
+  ActorAvatar: ({ actorId }: { actorId: string }) => (
+    <div data-testid={`avatar-${actorId}`} />
+  ),
+}));
+vi.mock("../../navigation", () => ({
+  AppLink: ({ href, children }: { href: string; children: React.ReactNode }) => (
+    <a href={href}>{children}</a>
+  ),
+  useNavigation: () => ({ push: vi.fn(), replace: vi.fn(), back: vi.fn() }),
+}));
+vi.mock("sonner", () => ({ toast: { success: vi.fn(), error: vi.fn() } }));
+
+import { SquadMembersTab } from "./squad-detail-page";
+
+const LEADER_ID = "agent-leader";
+const WORKING_ID = "agent-working";
+const IDLE_ID = "agent-idle";
+const ARCHIVED_ID = "agent-archived";
+const HUMAN_WITH_ROLE_ID = "user-1";
+const HUMAN_NO_ROLE_ID = "user-2";
+
+function makeMember(
+  id: string,
+  memberType: "agent" | "member",
+  memberId: string,
+  role = "",
+): SquadMember {
+  return {
+    id,
+    squad_id: "squad-1",
+    member_type: memberType,
+    member_id: memberId,
+    role,
+    created_at: "2026-01-01T00:00:00Z",
+  };
+}
+
+function makeStatus(
+  memberId: string,
+  status: SquadMemberStatusValue,
+): SquadMemberStatus {
+  return {
+    member_type: "agent",
+    member_id: memberId,
+    status,
+    active_issues: [],
+    last_active_at: "2026-07-19T12:00:00Z",
+  };
+}
+
+const archivedIds = new Set<string>([ARCHIVED_ID]);
+
+interface Fixture {
+  members: SquadMember[];
+  memberStatusById: Map<string, SquadMemberStatus>;
+}
+
+function fullFixture(): Fixture {
+  const members: SquadMember[] = [
+    makeMember("m-leader", "agent", LEADER_ID, "Lead"),
+    makeMember("m-working", "agent", WORKING_ID, "Reviewer"),
+    makeMember("m-idle", "agent", IDLE_ID, ""),
+    makeMember("m-archived", "agent", ARCHIVED_ID, "Old role"),
+    makeMember("m-human1", "member", HUMAN_WITH_ROLE_ID, "PM"),
+    makeMember("m-human2", "member", HUMAN_NO_ROLE_ID, ""),
+  ];
+  const memberStatusById = new Map<string, SquadMemberStatus>([
+    [LEADER_ID, makeStatus(LEADER_ID, "working")],
+    [WORKING_ID, makeStatus(WORKING_ID, "working")],
+    [IDLE_ID, makeStatus(IDLE_ID, "idle")],
+    [ARCHIVED_ID, makeStatus(ARCHIVED_ID, "archived")],
+  ]);
+  return { members, memberStatusById };
+}
+
+function isLeader(m: SquadMember) {
+  return m.member_type === "agent" && m.member_id === LEADER_ID;
+}
+function isArchived(m: SquadMember) {
+  return m.member_type === "agent" && archivedIds.has(m.member_id);
+}
+
+// MemberSubsection wraps its rows in <div><div header><span label>...
+// so label -> header div -> outer section div. Returns the outer section
+// container so a test can scope queries to one group.
+function sectionByText(label: string) {
+  return screen.getByText(label).parentElement!.parentElement!;
+}
+
+function renderTab(overrides: Partial<Parameters<typeof SquadMembersTab>[0]> = {}) {
+  const { members, memberStatusById } = fullFixture();
+  const props = {
+    members,
+    memberStatusById,
+    canManage: false,
+    isLeader,
+    isArchived,
+    getEntityName: (_type: string, id: string) => id,
+    onAddMemberClick: vi.fn(),
+    onSetLeader: vi.fn(),
+    onRemoveMember: vi.fn(),
+    onUpdateRole: vi.fn(),
+    setLeaderPending: false,
+    ...overrides,
+  };
+  render(
+    <I18nProvider locale="en" resources={TEST_RESOURCES}>
+      <SquadMembersTab {...props} />
+    </I18nProvider>,
+  );
+  return props;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("SquadMembersTab grouping", () => {
+  it("pulls the leader into its own prominent card and out of the Agents group", () => {
+    renderTab();
+    // Leader renders exactly once (in the amber Leader card), never duplicated
+    // inside the Agents group.
+    expect(screen.getAllByText(LEADER_ID)).toHaveLength(1);
+    const agentsSection = sectionByText("Agents");
+    expect(within(agentsSection).queryByText(LEADER_ID)).toBeNull();
+    // The leader-card label ("Leader") is present once.
+    expect(screen.getAllByText(/Leader/).length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("splits the working roster into Agents and People groups with counts", () => {
+    renderTab();
+    const agentsSection = sectionByText("Agents");
+    const peopleSection = sectionByText("People");
+    // Agents group: working + idle (leader pulled out, archived collapsed).
+    expect(agentsSection).toHaveTextContent(/·\s*2/);
+    // People group: two humans.
+    expect(peopleSection).toHaveTextContent(/·\s*2/);
+    expect(within(peopleSection).getByText(HUMAN_WITH_ROLE_ID)).toBeInTheDocument();
+    expect(within(agentsSection).queryByText(HUMAN_WITH_ROLE_ID)).toBeNull();
+  });
+
+  it("renders the status summary with presence counts over non-archived agents", () => {
+    renderTab();
+    // 2 working (leader + working agent), 1 idle, 1 offline, 0 unstable.
+    const working = screen.getByRole("button", { name: /Working/ });
+    const idle = screen.getByRole("button", { name: /Idle/ });
+    const offline = screen.getByRole("button", { name: /Offline/ });
+    expect(working).toHaveTextContent(/2/);
+    expect(idle).toHaveTextContent(/1/);
+    expect(offline).toHaveTextContent(/0/);
+  });
+
+  it("filters the Agents group by status when a chip is clicked", () => {
+    renderTab();
+    // Both working and idle agents are visible before filtering.
+    expect(screen.getByText(WORKING_ID)).toBeInTheDocument();
+    expect(screen.getByText(IDLE_ID)).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: /Idle/ }));
+
+    // Idle agent stays; working agent is filtered out.
+    expect(screen.getByText(IDLE_ID)).toBeInTheDocument();
+    expect(screen.queryByText(WORKING_ID)).toBeNull();
+  });
+
+  it("collapses archived members by default and reveals them on toggle", () => {
+    renderTab();
+    // Archived agent is not in the active roster initially.
+    expect(screen.queryByText(ARCHIVED_ID)).toBeNull();
+
+    fireEvent.click(screen.getByRole("button", { name: /Archived/ }));
+    expect(screen.getByText(ARCHIVED_ID)).toBeInTheDocument();
+  });
+
+  it("always shows the role, even in read-only mode, falling back to a placeholder", () => {
+    renderTab({ canManage: false });
+    // A set role renders as text.
+    expect(screen.getByText("PM")).toBeInTheDocument();
+    // Empty roles (one agent, one human) render the placeholder, not nothing.
+    expect(screen.getAllByText("No role")).toHaveLength(2);
+  });
+
+  it("hides every mutating control when canManage is false", () => {
+    renderTab({ canManage: false });
+    expect(screen.queryByRole("button", { name: /Add Member/i })).toBeNull();
+    expect(screen.queryByRole("button", { name: /Create Agent/i })).toBeNull();
+    expect(screen.queryByRole("button", { name: /Remove from squad/i })).toBeNull();
+    expect(screen.queryByRole("button", { name: /Make squad leader/i })).toBeNull();
+  });
+
+  it("exposes add / create / remove / make-leader controls when canManage is true", () => {
+    renderTab({ canManage: true, onCreateAgentClick: vi.fn() });
+    expect(screen.getByRole("button", { name: /Add Member/i })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /Create Agent/i })).toBeInTheDocument();
+    // Remove + make-leader are hover-revealed (opacity-0) but still in the DOM.
+    expect(screen.getAllByRole("button", { name: /Remove from squad/i }).length).toBeGreaterThan(0);
+    expect(screen.getAllByRole("button", { name: /Make squad leader/i }).length).toBeGreaterThan(0);
+  });
+});

--- a/packages/views/squads/components/squad-detail-page.tsx
+++ b/packages/views/squads/components/squad-detail-page.tsx
@@ -48,6 +48,11 @@ import {
   AlertDialogHeader,
   AlertDialogTitle,
 } from "@multica/ui/components/ui/alert-dialog";
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from "@multica/ui/components/ui/collapsible";
 import { ActorAvatar as ActorAvatarBase } from "@multica/ui/components/common/actor-avatar";
 import { ActorAvatar } from "../../common/actor-avatar";
 import { AvatarUploadControl } from "../../common/avatar-upload-control";
@@ -59,7 +64,8 @@ import {
 } from "../../issues/components/pickers/property-picker";
 import { ChevronDown, UserPlus } from "lucide-react";
 import { toast } from "sonner";
-import type { Squad, SquadMember, SquadMemberStatus, SquadMemberStatusValue, Agent, MemberWithUser } from "@multica/core/types";
+import type { Squad, SquadMember, SquadMemberStatus, SquadMemberStatusValue, SquadActiveIssueBrief, Agent, MemberWithUser } from "@multica/core/types";
+import type { TFunction } from "i18next";
 import { useT } from "../../i18n";
 import { matchesPinyin } from "../../editor/extensions/pinyin-match";
 
@@ -1081,8 +1087,32 @@ const SQUAD_STATUS_DOT_CLASS: Record<SquadMemberStatusValue, string> = {
   archived: "bg-muted-foreground/40",
 };
 
-// Members tab body — re-uses the existing list/role editing patterns.
-function SquadMembersTab({
+// Status buckets surfaced as filter chips above the roster. Archived is
+// excluded - it has its own collapsed section below - and humans (status
+// === null) never match a chip, so they stay listed under their own
+// People group regardless of the active filter.
+const SQUAD_FILTERABLE_STATUSES: SquadMemberStatusValue[] = [
+  "working",
+  "idle",
+  "offline",
+  "unstable",
+];
+
+// Members tab body. The roster is split into four regions, top to bottom:
+//   1. Leader card - the squad leader pulled out of the flat list and
+//      rendered with an amber accent so it reads as "in charge", not just
+//      "first in the list".
+//   2. Status summary - clickable chips (working / idle / offline /
+//      unstable) that filter the Agents group by presence. People have no
+//      presence signal and are never filtered out.
+//   3. Agents group + People group - members split by type, each with a
+//      count. The leader and archived agents live elsewhere, so these are
+//      the regular working roster.
+//   4. Archived - collapsed by default; archived agents don't pollute the
+//      active roster but are still reachable.
+// `canManage` gates every mutating control (add / create / make-leader /
+// remove / role edit); read-only viewers see the same layout, inert.
+export function SquadMembersTab({
   members,
   memberStatusById,
   canManage,
@@ -1105,7 +1135,7 @@ function SquadMembersTab({
   isArchived: (m: SquadMember) => boolean;
   getEntityName: (type: string, id: string) => string;
   onAddMemberClick: () => void;
-  // Hidden for viewers who can't manage — see SquadOverviewPane.
+  // Hidden for viewers who can't manage - see SquadOverviewPane.
   onCreateAgentClick?: () => void;
   onSetLeader: (agentId: string) => void;
   onRemoveMember: (m: SquadMember) => void;
@@ -1113,8 +1143,46 @@ function SquadMembersTab({
   setLeaderPending: boolean;
 }) {
   const { t } = useT("squads");
-  const timeAgo = useTimeAgo();
-  const p = useWorkspacePaths();
+  const [statusFilter, setStatusFilter] = useState<SquadMemberStatusValue | null>(null);
+  const [archivedExpanded, setArchivedExpanded] = useState(false);
+
+  // Partition the roster. `members` is the server-ordered list; we slice it
+  // rather than re-fetch so the leader / archived / working regions stay in
+  // sync with the same query.
+  const leaderMember = members.find(isLeader) ?? null;
+  const archivedMembers = members.filter(isArchived);
+  const activeMembers = members.filter((m) => !isLeader(m) && !isArchived(m));
+  const agentMembers = activeMembers.filter((m) => m.member_type === "agent");
+  const humanMembers = activeMembers.filter((m) => m.member_type === "member");
+
+  // Presence distribution across every non-archived agent in the squad
+  // (leader + working roster). Humans are excluded - they carry status ===
+  // null and don't belong in a presence summary.
+  const statusCounts = useMemo(() => {
+    const counts: Record<SquadMemberStatusValue, number> = {
+      working: 0,
+      idle: 0,
+      offline: 0,
+      unstable: 0,
+      archived: 0,
+    };
+    for (const m of members) {
+      if (m.member_type !== "agent" || isArchived(m)) continue;
+      const s = memberStatusById.get(m.member_id)?.status;
+      if (s && s in counts) counts[s] += 1;
+    }
+    return counts;
+  }, [members, memberStatusById, isArchived]);
+
+  const visibleAgentMembers = statusFilter
+    ? agentMembers.filter((m) => memberStatusById.get(m.member_id)?.status === statusFilter)
+    : agentMembers;
+
+  // Hide the summary bar entirely when the squad has no presence-bearing
+  // agents (e.g. a humans-only squad) - chips that all read 0 are noise.
+  const showStatusSummary = agentMembers.length > 0 || !!leaderMember;
+  const hasRoster = agentMembers.length > 0 || humanMembers.length > 0;
+
   return (
     <div className="flex flex-col gap-4">
       <div className="flex items-center justify-between">
@@ -1140,160 +1208,544 @@ function SquadMembersTab({
         )}
       </div>
 
-      <div className="space-y-2">
-        {members.map((m) => {
-          const status = memberStatusById.get(m.member_id);
-          const statusValue = status?.status ?? null;
-          const dotClass =
-            statusValue && statusValue in SQUAD_STATUS_DOT_CLASS
-              ? SQUAD_STATUS_DOT_CLASS[statusValue as keyof typeof SQUAD_STATUS_DOT_CLASS]
-              : null;
-          const statusLabel =
-            statusValue === "working" ? t(($) => $.members_tab.status_working)
-              : statusValue === "idle" ? t(($) => $.members_tab.status_idle)
-              : statusValue === "offline" ? t(($) => $.members_tab.status_offline)
-              : statusValue === "unstable" ? t(($) => $.members_tab.status_unstable)
-              : statusValue === "archived" ? t(($) => $.members_tab.status_archived)
-              : null;
-          const activeIssues = status?.active_issues ?? [];
-          const primaryIssue = activeIssues[0];
-          const extraIssueCount = Math.max(0, activeIssues.length - 1);
-          // Show last_active only when the agent isn't currently working —
-          // a "working" pill already implies the agent is live, and a
-          // "last active 2s ago" line next to it is just noise.
-          const showLastActive =
-            m.member_type === "agent" && statusValue && statusValue !== "working" && status?.last_active_at;
-          return (
-            <div key={m.id} className="group flex items-start gap-3 rounded-lg border p-3">
-              <ActorAvatar
-                actorType={m.member_type}
-                actorId={m.member_id}
-                size="lg"
-                showStatusDot
-                enableHoverCard={m.member_type === "agent"}
-                hoverCardVariant="live"
-              />
-              <div className="flex-1 min-w-0">
-                <div className="flex items-center gap-2">
-                  <span className="text-sm font-medium">{getEntityName(m.member_type, m.member_id)}</span>
-                  <span className="text-xs text-muted-foreground capitalize">{m.member_type}</span>
-                  {isLeader(m) && (
-                    <span className="inline-flex items-center gap-0.5 text-xs bg-amber-100 dark:bg-amber-900/30 text-amber-700 dark:text-amber-400 px-1.5 py-0.5 rounded">
-                      <Crown className="size-3" />
-                      {t(($) => $.members_tab.leader_chip)}
-                    </span>
-                  )}
-                  {m.member_type === "agent" && statusLabel && (
-                    <span className="inline-flex items-center gap-1 text-xs text-muted-foreground">
-                      <span className={`h-1.5 w-1.5 rounded-full ${dotClass ?? "bg-muted-foreground/40"}`} />
-                      {statusLabel}
-                    </span>
-                  )}
-                </div>
-                {canManage ? (
-                  <RoleEditor
-                    value={m.role ?? ""}
-                    onSave={async (next) => { await onUpdateRole(m, next); }}
+      {leaderMember && (
+        <LeaderCard
+          member={leaderMember}
+          status={memberStatusById.get(leaderMember.member_id)}
+          canManage={canManage}
+          getEntityName={getEntityName}
+          onUpdateRole={onUpdateRole}
+        />
+      )}
+
+      {showStatusSummary && (
+        <StatusSummaryBar
+          counts={statusCounts}
+          activeFilter={statusFilter}
+          onChange={setStatusFilter}
+        />
+      )}
+
+      <div className="flex flex-col gap-4">
+        {(agentMembers.length > 0 || statusFilter) && (
+          <MemberSubsection
+            label={t(($) => $.members_tab.agents_section)}
+            count={agentMembers.length}
+          >
+            {visibleAgentMembers.length > 0 ? (
+              <div className="space-y-2">
+                {visibleAgentMembers.map((m) => (
+                  <SquadMemberRow
+                    key={m.id}
+                    member={m}
+                    status={memberStatusById.get(m.member_id)}
+                    canManage={canManage}
+                    isLeader={false}
+                    isArchived={false}
+                    getEntityName={getEntityName}
+                    onSetLeader={onSetLeader}
+                    onRemoveMember={onRemoveMember}
+                    onUpdateRole={onUpdateRole}
+                    setLeaderPending={setLeaderPending}
                   />
-                ) : m.role ? (
-                  <div className="mt-0.5 text-xs text-muted-foreground">{m.role}</div>
-                ) : null}
-                {primaryIssue && (
-                  <div className="mt-1 flex items-center gap-1 text-xs text-muted-foreground min-w-0">
-                    <AppLink
-                      href={p.issueDetail(primaryIssue.issue_id)}
-                      className="inline-flex items-center gap-1 min-w-0 hover:text-foreground transition-colors"
-                    >
-                      <span className="font-mono text-[10px] uppercase shrink-0">{primaryIssue.identifier}</span>
-                      <span className="truncate">{primaryIssue.title}</span>
-                      {primaryIssue.issue_status === "blocked" && (
-                        <span className="shrink-0 inline-flex items-center text-[10px] uppercase tracking-wide text-warning">
-                          {t(($) => $.members_tab.issue_status_blocked)}
-                        </span>
-                      )}
-                    </AppLink>
-                    {extraIssueCount > 0 && (
-                      <span className="shrink-0">
-                        · {t(($) => $.members_tab.active_issue_more, { count: extraIssueCount })}
-                      </span>
-                    )}
-                  </div>
-                )}
-                {showLastActive && (
-                  <div className="mt-0.5 text-xs text-muted-foreground">
-                    {t(($) => $.members_tab.last_active_label, {
-                      time: timeAgo(status!.last_active_at!),
-                    })}
-                  </div>
-                )}
+                ))}
               </div>
-            <div className="flex items-center gap-1 opacity-0 group-hover:opacity-100 group-focus-within:opacity-100 transition-opacity">
-              {m.member_type === "agent" && (
-                <Tooltip>
-                  <TooltipTrigger
-                    render={
-                      <AppLink
-                        href={p.agentDetail(m.member_id)}
-                        className="inline-flex items-center justify-center h-8 w-8 rounded-md text-muted-foreground hover:text-foreground hover:bg-accent transition-colors"
-                        aria-label={t(($) => $.members_tab.view_agent_tooltip)}
-                      >
-                        <ArrowUpRight className="size-3.5" />
-                      </AppLink>
-                    }
-                  />
-                  <TooltipContent>
-                    {t(($) => $.members_tab.view_agent_tooltip)}
-                  </TooltipContent>
-                </Tooltip>
-              )}
-              {canManage && m.member_type === "agent" && !isLeader(m) && !isArchived(m) && (
-                <Tooltip>
-                  <TooltipTrigger
-                    render={
-                      <Button
-                        size="sm"
-                        variant="ghost"
-                        className="text-muted-foreground hover:text-amber-600 h-8 w-8 p-0"
-                        onClick={() => onSetLeader(m.member_id)}
-                        disabled={setLeaderPending}
-                        aria-label={t(($) => $.members_tab.make_leader_tooltip)}
-                      >
-                        <Crown className="size-3.5" />
-                      </Button>
-                    }
-                  />
-                  <TooltipContent>
-                    {t(($) => $.members_tab.make_leader_tooltip)}
-                  </TooltipContent>
-                </Tooltip>
-              )}
-              {canManage && !isLeader(m) && (
-                <Tooltip>
-                  <TooltipTrigger
-                    render={
-                      <Button
-                        size="sm"
-                        variant="ghost"
-                        className="text-muted-foreground hover:text-destructive h-8 w-8 p-0"
-                        onClick={() => onRemoveMember(m)}
-                        aria-label={t(($) => $.members_tab.remove_member_tooltip)}
-                      >
-                        <Trash2 className="size-3.5" />
-                      </Button>
-                    }
-                  />
-                  <TooltipContent>
-                    {t(($) => $.members_tab.remove_member_tooltip)}
-                  </TooltipContent>
-                </Tooltip>
-              )}
+            ) : (
+              <p className="rounded-lg border border-dashed px-3 py-4 text-xs text-muted-foreground">
+                {t(($) => $.members_tab.no_match_filter)}
+              </p>
+            )}
+          </MemberSubsection>
+        )}
+
+        {humanMembers.length > 0 && (
+          <MemberSubsection
+            label={t(($) => $.members_tab.humans_section)}
+            count={humanMembers.length}
+          >
+            <div className="space-y-2">
+              {humanMembers.map((m) => (
+                <SquadMemberRow
+                  key={m.id}
+                  member={m}
+                  status={memberStatusById.get(m.member_id)}
+                  canManage={canManage}
+                  isLeader={false}
+                  isArchived={false}
+                  getEntityName={getEntityName}
+                  onSetLeader={onSetLeader}
+                  onRemoveMember={onRemoveMember}
+                  onUpdateRole={onUpdateRole}
+                  setLeaderPending={setLeaderPending}
+                />
+              ))}
             </div>
+          </MemberSubsection>
+        )}
+
+        {!hasRoster && !leaderMember && (
+          <p className="rounded-lg border border-dashed px-3 py-6 text-center text-xs text-muted-foreground">
+            {t(($) => $.members_tab.empty_roster)}
+          </p>
+        )}
+      </div>
+
+      {archivedMembers.length > 0 && (
+        <Collapsible open={archivedExpanded} onOpenChange={setArchivedExpanded}>
+          <CollapsibleTrigger className="flex w-full items-center gap-1.5 rounded-md px-1 py-1 text-xs font-medium text-muted-foreground hover:text-foreground transition-colors">
+            <ChevronDown
+              className={`size-3.5 transition-transform ${archivedExpanded ? "" : "-rotate-90"}`}
+            />
+            {t(($) => $.members_tab.archived_section)}
+            <span className="tabular-nums">· {archivedMembers.length}</span>
+          </CollapsibleTrigger>
+          <CollapsibleContent>
+            <div className="mt-2 space-y-2">
+              {archivedMembers.map((m) => (
+                <SquadMemberRow
+                  key={m.id}
+                  member={m}
+                  status={memberStatusById.get(m.member_id)}
+                  canManage={canManage}
+                  isLeader={false}
+                  isArchived
+                  getEntityName={getEntityName}
+                  onSetLeader={onSetLeader}
+                  onRemoveMember={onRemoveMember}
+                  onUpdateRole={onUpdateRole}
+                  setLeaderPending={setLeaderPending}
+                />
+              ))}
+            </div>
+          </CollapsibleContent>
+        </Collapsible>
+      )}
+    </div>
+  );
+}
+
+// Section label + count, mirroring the muted "Members · 3" style used in
+// SquadProfileCard so group headers read the same on the detail page and the
+// list card.
+function MemberSubsection({ label, count, children }: { label: string; count: number; children: ReactNode }) {
+  return (
+    <div className="flex flex-col gap-2">
+      <div className="flex items-center gap-1.5 px-1">
+        <span className="text-xs font-medium text-foreground">{label}</span>
+        <span className="text-xs text-muted-foreground tabular-nums">· {count}</span>
+      </div>
+      {children}
+    </div>
+  );
+}
+
+// Amber-accented leader card. Pulled out of the flat roster so the leader
+// reads as "in charge" at a glance instead of just being the row with the
+// Crown chip. The amber matches the existing leader chip palette so the
+// accent is consistent across the page. The leader exposes no make-leader /
+// remove controls - it can only be visited or (when manageable) re-roled
+// in place.
+function LeaderCard({
+  member,
+  status,
+  canManage,
+  getEntityName,
+  onUpdateRole,
+}: {
+  member: SquadMember;
+  status: SquadMemberStatus | undefined;
+  canManage: boolean;
+  getEntityName: (type: string, id: string) => string;
+  onUpdateRole: (m: SquadMember, role: string) => Promise<void>;
+}) {
+  const { t } = useT("squads");
+  const p = useWorkspacePaths();
+  const timeAgo = useTimeAgo();
+  const statusValue = status?.status ?? null;
+  const dotClass = squadStatusDotClass(statusValue);
+  const statusLabel = squadStatusLabel(t, statusValue);
+  const activeIssues = status?.active_issues ?? [];
+  const primaryIssue = activeIssues[0];
+  const extraIssueCount = Math.max(0, activeIssues.length - 1);
+  const showLastActive =
+    !!statusValue && statusValue !== "working" && !!status?.last_active_at;
+
+  return (
+    <section className="rounded-lg border border-amber-200 bg-amber-50/70 p-4 dark:border-amber-900/40 dark:bg-amber-950/15">
+      <div className="mb-2 flex items-center gap-1.5">
+        <Crown className="size-3.5 text-amber-600 dark:text-amber-400" />
+        <span className="text-[10px] font-medium uppercase tracking-wider text-amber-700 dark:text-amber-400">
+          {t(($) => $.members_tab.leader_chip)}
+        </span>
+      </div>
+      <div className="flex items-start gap-3">
+        <ActorAvatar
+          actorType="agent"
+          actorId={member.member_id}
+          size="lg"
+          showStatusDot
+          enableHoverCard
+          hoverCardVariant="live"
+        />
+        <div className="flex-1 min-w-0">
+          <div className="flex items-center gap-2">
+            <span className="text-sm font-semibold">{getEntityName("agent", member.member_id)}</span>
+            {statusLabel && (
+              <span className="inline-flex items-center gap-1 text-xs text-muted-foreground">
+                <span className={`h-1.5 w-1.5 rounded-full ${dotClass}`} />
+                {statusLabel}
+              </span>
+            )}
+            <Tooltip>
+              <TooltipTrigger
+                render={
+                  <AppLink
+                    href={p.agentDetail(member.member_id)}
+                    className="ml-auto inline-flex items-center justify-center h-7 w-7 rounded-md text-muted-foreground hover:text-foreground hover:bg-accent transition-colors"
+                    aria-label={t(($) => $.members_tab.view_agent_tooltip)}
+                  >
+                    <ArrowUpRight className="size-3.5" />
+                  </AppLink>
+                }
+              />
+              <TooltipContent>
+                {t(($) => $.members_tab.view_agent_tooltip)}
+              </TooltipContent>
+            </Tooltip>
           </div>
-          );
-        })}
+          <RoleLine
+            role={member.role ?? ""}
+            canManage={canManage}
+            onSave={async (next) => { await onUpdateRole(member, next); }}
+          />
+          {primaryIssue && (
+            <ActiveIssueLine primaryIssue={primaryIssue} extraIssueCount={extraIssueCount} />
+          )}
+          {showLastActive && (
+            <div className="mt-0.5 text-xs text-muted-foreground">
+              {t(($) => $.members_tab.last_active_label, {
+                time: timeAgo(status!.last_active_at!),
+              })}
+            </div>
+          )}
+        </div>
+      </div>
+    </section>
+  );
+}
+
+// A single member row. Shared across the Agents group, the People group,
+// and the Archived group so the layout, status dot, role line, active
+// issue, and hover actions stay consistent. `isLeader` / `isArchived`
+// resolve the action set: the leader exposes neither make-leader nor remove
+// (handled in LeaderCard instead), archived members expose remove only.
+function SquadMemberRow({
+  member,
+  status,
+  canManage,
+  isLeader: leaderFlag,
+  isArchived: archivedFlag,
+  getEntityName,
+  onSetLeader,
+  onRemoveMember,
+  onUpdateRole,
+  setLeaderPending,
+}: {
+  member: SquadMember;
+  status: SquadMemberStatus | undefined;
+  canManage: boolean;
+  isLeader: boolean;
+  isArchived: boolean;
+  getEntityName: (type: string, id: string) => string;
+  onSetLeader: (agentId: string) => void;
+  onRemoveMember: (m: SquadMember) => void;
+  onUpdateRole: (m: SquadMember, role: string) => Promise<void>;
+  setLeaderPending: boolean;
+}) {
+  const { t } = useT("squads");
+  const p = useWorkspacePaths();
+  const timeAgo = useTimeAgo();
+  const statusValue = status?.status ?? null;
+  const dotClass = squadStatusDotClass(statusValue);
+  const statusLabel = squadStatusLabel(t, statusValue);
+  const activeIssues = status?.active_issues ?? [];
+  const primaryIssue = activeIssues[0];
+  const extraIssueCount = Math.max(0, activeIssues.length - 1);
+  const showLastActive =
+    member.member_type === "agent" &&
+    !!statusValue &&
+    statusValue !== "working" &&
+    !!status?.last_active_at;
+
+  return (
+    <div className="group flex items-start gap-3 rounded-lg border p-3">
+      <ActorAvatar
+        actorType={member.member_type}
+        actorId={member.member_id}
+        size="lg"
+        showStatusDot
+        enableHoverCard={member.member_type === "agent"}
+        hoverCardVariant="live"
+      />
+      <div className="flex-1 min-w-0">
+        <div className="flex items-center gap-2">
+          <span className="text-sm font-medium">{getEntityName(member.member_type, member.member_id)}</span>
+          <span className="text-xs text-muted-foreground capitalize">{member.member_type}</span>
+          {statusLabel && member.member_type === "agent" && (
+            <span className="inline-flex items-center gap-1 text-xs text-muted-foreground">
+              <span className={`h-1.5 w-1.5 rounded-full ${dotClass}`} />
+              {statusLabel}
+            </span>
+          )}
+        </div>
+        <RoleLine
+          role={member.role ?? ""}
+          canManage={canManage}
+          onSave={async (next) => { await onUpdateRole(member, next); }}
+        />
+        {primaryIssue && (
+          <ActiveIssueLine primaryIssue={primaryIssue} extraIssueCount={extraIssueCount} />
+        )}
+        {showLastActive && (
+          <div className="mt-0.5 text-xs text-muted-foreground">
+            {t(($) => $.members_tab.last_active_label, {
+              time: timeAgo(status!.last_active_at!),
+            })}
+          </div>
+        )}
+      </div>
+      <div className="flex items-center gap-1 opacity-0 group-hover:opacity-100 group-focus-within:opacity-100 transition-opacity">
+        {member.member_type === "agent" && (
+          <Tooltip>
+            <TooltipTrigger
+              render={
+                <AppLink
+                  href={p.agentDetail(member.member_id)}
+                  className="inline-flex items-center justify-center h-8 w-8 rounded-md text-muted-foreground hover:text-foreground hover:bg-accent transition-colors"
+                  aria-label={t(($) => $.members_tab.view_agent_tooltip)}
+                >
+                  <ArrowUpRight className="size-3.5" />
+                </AppLink>
+              }
+            />
+            <TooltipContent>
+              {t(($) => $.members_tab.view_agent_tooltip)}
+            </TooltipContent>
+          </Tooltip>
+        )}
+        {canManage && member.member_type === "agent" && !leaderFlag && !archivedFlag && (
+          <Tooltip>
+            <TooltipTrigger
+              render={
+                <Button
+                  size="sm"
+                  variant="ghost"
+                  className="text-muted-foreground hover:text-amber-600 h-8 w-8 p-0"
+                  onClick={() => onSetLeader(member.member_id)}
+                  disabled={setLeaderPending}
+                  aria-label={t(($) => $.members_tab.make_leader_tooltip)}
+                >
+                  <Crown className="size-3.5" />
+                </Button>
+              }
+            />
+            <TooltipContent>
+              {t(($) => $.members_tab.make_leader_tooltip)}
+            </TooltipContent>
+          </Tooltip>
+        )}
+        {canManage && !leaderFlag && (
+          <Tooltip>
+            <TooltipTrigger
+              render={
+                <Button
+                  size="sm"
+                  variant="ghost"
+                  className="text-muted-foreground hover:text-destructive h-8 w-8 p-0"
+                  onClick={() => onRemoveMember(member)}
+                  aria-label={t(($) => $.members_tab.remove_member_tooltip)}
+                >
+                  <Trash2 className="size-3.5" />
+                </Button>
+              }
+            />
+            <TooltipContent>
+              {t(($) => $.members_tab.remove_member_tooltip)}
+            </TooltipContent>
+          </Tooltip>
+        )}
       </div>
     </div>
   );
+}
+
+// Role line shared by LeaderCard and SquadMemberRow. Always renders a row so
+// the layout doesn't shift between members with and without a role. In
+// manage mode it's an inline editor (placeholder when empty); read-only
+// viewers see the role text, or a muted "no role" hint when empty, so role
+// stays visible even outside manage mode.
+function RoleLine({
+  role,
+  canManage,
+  onSave,
+}: {
+  role: string;
+  canManage: boolean;
+  onSave: (next: string) => Promise<void>;
+}) {
+  const { t } = useT("squads");
+  if (canManage) {
+    return <RoleEditor value={role} onSave={onSave} />;
+  }
+  if (role) {
+    return <div className="mt-0.5 text-xs text-muted-foreground">{role}</div>;
+  }
+  return (
+    <div className="mt-0.5 text-xs italic text-muted-foreground/60">
+      {t(($) => $.members_tab.no_role)}
+    </div>
+  );
+}
+
+// Active-issue link line shared by LeaderCard and SquadMemberRow.
+function ActiveIssueLine({
+  primaryIssue,
+  extraIssueCount,
+}: {
+  primaryIssue: SquadActiveIssueBrief;
+  extraIssueCount: number;
+}) {
+  const { t } = useT("squads");
+  const p = useWorkspacePaths();
+  return (
+    <div className="mt-1 flex items-center gap-1 text-xs text-muted-foreground min-w-0">
+      <AppLink
+        href={p.issueDetail(primaryIssue.issue_id)}
+        className="inline-flex items-center gap-1 min-w-0 hover:text-foreground transition-colors"
+      >
+        <span className="font-mono text-[10px] uppercase shrink-0">{primaryIssue.identifier}</span>
+        <span className="truncate">{primaryIssue.title}</span>
+        {primaryIssue.issue_status === "blocked" && (
+          <span className="shrink-0 inline-flex items-center text-[10px] uppercase tracking-wide text-warning">
+            {t(($) => $.members_tab.issue_status_blocked)}
+          </span>
+        )}
+      </AppLink>
+      {extraIssueCount > 0 && (
+        <span className="shrink-0">
+          · {t(($) => $.members_tab.active_issue_more, { count: extraIssueCount })}
+        </span>
+      )}
+    </div>
+  );
+}
+
+// Presence distribution chips above the roster. Clicking a status toggles a
+// filter that narrows the Agents group to that status; clicking the active
+// status again (or "All") clears it. Counts cover every non-archived agent
+// (leader + working roster), so the summary reflects the whole squad.
+function StatusSummaryBar({
+  counts,
+  activeFilter,
+  onChange,
+}: {
+  counts: Record<SquadMemberStatusValue, number>;
+  activeFilter: SquadMemberStatusValue | null;
+  onChange: (next: SquadMemberStatusValue | null) => void;
+}) {
+  const { t } = useT("squads");
+  return (
+    <div className="flex flex-wrap items-center gap-1.5">
+      <span className="mr-1 text-xs text-muted-foreground">
+        {t(($) => $.members_tab.status_summary_label)}
+      </span>
+      <FilterChip
+        active={activeFilter === null}
+        onClick={() => onChange(null)}
+        label={t(($) => $.members_tab.filter_all)}
+      />
+      {SQUAD_FILTERABLE_STATUSES.map((s) => {
+        const count = counts[s] ?? 0;
+        return (
+          <FilterChip
+            key={s}
+            active={activeFilter === s}
+            disabled={count === 0 && activeFilter !== s}
+            onClick={() => onChange(activeFilter === s ? null : s)}
+            label={squadStatusLabel(t, s) ?? s}
+            count={count}
+          />
+        );
+      })}
+    </div>
+  );
+}
+
+function FilterChip({
+  active,
+  disabled,
+  onClick,
+  label,
+  count,
+}: {
+  active: boolean;
+  disabled?: boolean;
+  onClick: () => void;
+  label: string;
+  count?: number;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      disabled={disabled}
+      aria-pressed={active}
+      className={`inline-flex items-center gap-1 rounded-full border px-2 py-0.5 text-xs transition-colors disabled:cursor-not-allowed disabled:opacity-40 ${
+        active
+          ? "border-foreground/30 bg-foreground/5 text-foreground"
+          : "border-border text-muted-foreground hover:bg-accent/50 hover:text-foreground"
+      }`}
+    >
+      <span>{label}</span>
+      {typeof count === "number" && <span className="tabular-nums">{count}</span>}
+    </button>
+  );
+}
+
+// Resolves a squad member status value to its dot class. Returns the neutral
+// muted dot for unknown / null statuses (humans, server-side enum drift) -
+// the "downgrade, don't crash" defense from CLAUDE.md > API Response
+// Compatibility.
+function squadStatusDotClass(statusValue: SquadMemberStatusValue | null): string {
+  if (statusValue && statusValue in SQUAD_STATUS_DOT_CLASS) {
+    return SQUAD_STATUS_DOT_CLASS[statusValue];
+  }
+  return "bg-muted-foreground/40";
+}
+
+// Resolves a squad member status value to its localized label. Shared by the
+// row status pill, the leader card, and the status-summary chips. Returns
+// null for unknown / null statuses (humans, server-side enum drift) so
+// callers can render the neutral fallback instead of a stale label.
+function squadStatusLabel(
+  t: TFunction<"squads">,
+  statusValue: SquadMemberStatusValue | null,
+): string | null {
+  if (!statusValue) return null;
+  switch (statusValue) {
+    case "working":
+      return t(($) => $.members_tab.status_working);
+    case "idle":
+      return t(($) => $.members_tab.status_idle);
+    case "offline":
+      return t(($) => $.members_tab.status_offline);
+    case "unstable":
+      return t(($) => $.members_tab.status_unstable);
+    case "archived":
+      return t(($) => $.members_tab.status_archived);
+    default:
+      return null;
+  }
 }
 
 // Instructions tab body — mirrors agent's InstructionsTab. ContentEditor +

--- a/packages/views/squads/components/squad-profile-card.tsx
+++ b/packages/views/squads/components/squad-profile-card.tsx
@@ -126,7 +126,23 @@ function MembersList({
 }) {
   const { t } = useT("squads");
   const p = useWorkspacePaths();
-  const visible = members.slice(0, 3);
+  // Pin the leader to the front so the squad's owner is always the first
+  // face in the compact preview (matches the leader-prominent detail page).
+  // Stable: only lifts the leader, leaves every other member in server order.
+  // Uses slice (not indexed access) so the element type stays defined under
+  // noUncheckedIndexedAccess.
+  const leaderIdx = members.findIndex(
+    (m) => m.member_type === "agent" && m.member_id === leaderId,
+  );
+  const ordered =
+    leaderIdx > 0
+      ? [
+          ...members.slice(leaderIdx, leaderIdx + 1),
+          ...members.slice(0, leaderIdx),
+          ...members.slice(leaderIdx + 1),
+        ]
+      : members;
+  const visible = ordered.slice(0, 3);
   const overflow = Math.max(0, memberCount - visible.length);
 
   return (


### PR DESCRIPTION
## Summary

Overhauls `SquadMembersTab` and the squad profile card so squad membership reads at a glance (WS-656, subtask of WS-653 Squad UX).

- **Leader prominence**: the squad leader is pulled out of the roster into a dedicated amber-accented card at the top, and pinned to the front of the squad profile card member preview.
- **Status summary bar**: a clickable distribution bar (Working / Idle / Offline / Unstable) over non-archived agents that filters the roster; chips with a zero count are disabled.
- **Type grouping**: the active roster splits into **Agents** and **People** subsections, each with a live count.
- **Archived collapsible**: archived agents are collapsed by default behind a toggle instead of cluttering the active roster.
- **Role always visible**: roles render as text in read-only mode and fall back to a "No role" placeholder when empty, so empty roles never look like a rendering bug.
- **canManage preserved**: every mutating control (add / create agent / remove / make leader / role edit) stays gated behind `canManage` exactly as before.

## Test plan

- [x] `pnpm typecheck`
- [x] `pnpm test --filter @multica/views` (incl. new `squad-detail-page.test.tsx`, 8 tests covering leader extraction, type grouping + counts, status summary counts, filter behavior, archived collapse, role visibility, and canManage gating)
- [x] Locale parity across en / zh-Hans / ja / ko

Co-authored-by: multica-agent <github@multica.ai>