### PR TITLE
fix(daemon): protect unmanaged workspace directories from GC (MUL-484)

### DIFF
--- a/server/internal/daemon/gc.go
+++ b/server/internal/daemon/gc.go
@@ -128,6 +128,11 @@ func (d *Daemon) gcWorkspace(ctx context.Context, wsDir string, stats *gcStats) 
 			continue
 		}
 		meta, metaErr := execenv.ReadGCMeta(taskDir)
+		if !isManagedGCEnvRoot(filepath.Base(wsDir), taskDir, meta, metaErr) {
+			d.logger.Warn("gc: skipping unmanaged workspace directory", "dir", taskDir)
+			stats.skipped++
+			continue
+		}
 		if metaErr == nil && meta.Kind == execenv.GCKindIssue && strings.TrimSpace(meta.IssueID) != "" {
 			issueCandidates = append(issueCandidates, issueGCCandidate{taskDir: taskDir, meta: meta})
 			continue
@@ -337,11 +342,22 @@ func isManagedGCEnvRoot(workspaceID, taskDir string, meta *execenv.GCMeta, metaE
 		return false
 	}
 
-	if metaErr == nil && meta != nil && strings.TrimSpace(meta.WorkspaceID) == workspaceID {
+	metaMatches := metaErr == nil && meta != nil && strings.TrimSpace(meta.WorkspaceID) == workspaceID
+	// A readable ownership record that names a different workspace is an
+	// explicit contradiction, not a reason to fall through to a weaker proof.
+	if metaErr == nil && meta != nil && !metaMatches {
+		return false
+	}
+
+	prov, provErr := execenv.ReadManagedEnvProvenance(taskDir)
+	if provErr == nil && prov != nil {
+		if strings.TrimSpace(prov.WorkspaceID) != workspaceID {
+			return false
+		}
 		return true
 	}
 
-	if prov, err := execenv.ReadManagedEnvProvenance(taskDir); err == nil && prov != nil && strings.TrimSpace(prov.WorkspaceID) == workspaceID {
+	if metaMatches {
 		return true
 	}
 

--- a/server/internal/daemon/gc.go
+++ b/server/internal/daemon/gc.go
@@ -267,6 +267,13 @@ const (
 // Dispatches on meta.Kind so chat / autopilot / quick-create tasks each
 // follow the parent record that actually governs their lifecycle.
 func (d *Daemon) shouldCleanTaskDir(ctx context.Context, taskDir string) gcAction {
+	workspaceID := filepath.Base(filepath.Dir(taskDir))
+	meta, err := execenv.ReadGCMeta(taskDir)
+	if !isManagedGCEnvRoot(workspaceID, taskDir, meta, err) {
+		d.logger.Warn("gc: skipping unmanaged workspace directory", "dir", taskDir)
+		return gcActionSkip
+	}
+
 	// A task currently running on this env root must never be reclaimed —
 	// not even on the done/cancelled or orphan-404 paths. A new comment on
 	// an already-done issue can dispatch a follow-up task that reuses the
@@ -276,7 +283,6 @@ func (d *Daemon) shouldCleanTaskDir(ctx context.Context, taskDir string) gcActio
 		return gcActionSkip
 	}
 
-	meta, err := execenv.ReadGCMeta(taskDir)
 	if err != nil {
 		return d.orphanByMTime(taskDir, "no meta")
 	}
@@ -313,6 +319,56 @@ func applyLocalDirectoryGCOverride(meta *execenv.GCMeta, action gcAction) gcActi
 	default:
 		return action
 	}
+}
+
+// isManagedGCEnvRoot is the ownership boundary for destructive workspace GC.
+// A directory is eligible only when the daemon can prove it owns the env root:
+//
+//   - completion-time GC metadata matches the containing workspace;
+//   - Prepare-time managed-env provenance matches the workspace; or
+//   - a pre-provenance env uses the historical 8-hex task name and contains
+//     the standard workdir/output/logs directory layout.
+//
+// The explicit Output reservation is defense in depth for the shared durable
+// output path. Unknown directories fail closed and are left for an operator to
+// inspect instead of falling through to the mtime-based orphan deletion path.
+func isManagedGCEnvRoot(workspaceID, taskDir string, meta *execenv.GCMeta, metaErr error) bool {
+	if filepath.Base(taskDir) == "Output" {
+		return false
+	}
+
+	if metaErr == nil && meta != nil && strings.TrimSpace(meta.WorkspaceID) == workspaceID {
+		return true
+	}
+
+	if prov, err := execenv.ReadManagedEnvProvenance(taskDir); err == nil && prov != nil && strings.TrimSpace(prov.WorkspaceID) == workspaceID {
+		return true
+	}
+
+	if !isLegacyTaskDirName(filepath.Base(taskDir)) {
+		return false
+	}
+
+	for _, sub := range []string{"workdir", "output", "logs"} {
+		info, err := os.Stat(filepath.Join(taskDir, sub))
+		if err != nil || !info.IsDir() {
+			return false
+		}
+	}
+	return true
+}
+
+func isLegacyTaskDirName(name string) bool {
+	if len(name) != 8 {
+		return false
+	}
+	for i := 0; i < len(name); i++ {
+		b := name[i]
+		if !((b >= '0' && b <= '9') || (b >= 'a' && b <= 'f') || (b >= 'A' && b <= 'F')) {
+			return false
+		}
+	}
+	return true
 }
 
 // shouldCleanTaskDirForKind runs the per-Kind dispatch without applying the

--- a/server/internal/daemon/gc_test.go
+++ b/server/internal/daemon/gc_test.go
@@ -1583,3 +1583,148 @@ func TestShouldCleanTaskDir_LocalDirectoryFalsePreservesNormalClean(t *testing.T
 		t.Fatalf("expected gcActionClean for normal task, got %d", got)
 	}
 }
+
+func TestGCWorkspace_ProtectsUnmanagedDirectories(t *testing.T) {
+	d := newGCTestDaemon(t, http.NewServeMux())
+	d.cfg.GCOrphanTTL = 72 * time.Hour
+	wsDir := filepath.Join(d.cfg.WorkspacesRoot, "ws-unmanaged")
+
+	paths := []string{
+		filepath.Join(wsDir, "Output"),
+		filepath.Join(wsDir, "Output", "AgentOutput", "MUL-100"),
+		filepath.Join(wsDir, "custom-tools"),
+		filepath.Join(wsDir, "12345678"), // 8 hex chars but missing workdir/output/logs subdirs
+	}
+	for _, path := range paths {
+		if err := os.MkdirAll(path, 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	old := time.Now().Add(-73 * time.Hour)
+	for _, path := range paths {
+		if err := os.Chtimes(path, old, old); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	stats := &gcStats{byPattern: map[string]int{}}
+	d.gcWorkspace(context.Background(), wsDir, stats)
+
+	for _, path := range paths {
+		if _, err := os.Stat(path); err != nil {
+			t.Fatalf("unmanaged directory %s must survive GC: %v", path, err)
+		}
+	}
+	if stats.orphaned != 0 {
+		t.Fatalf("stats.orphaned = %d, want 0", stats.orphaned)
+	}
+}
+
+func TestGCWorkspace_DoesNotFollowSymlink(t *testing.T) {
+	d := newGCTestDaemon(t, http.NewServeMux())
+	d.cfg.GCOrphanTTL = 0
+	wsDir := filepath.Join(d.cfg.WorkspacesRoot, "ws-symlink")
+	if err := os.MkdirAll(wsDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	target := t.TempDir()
+	keep := filepath.Join(target, "keep.txt")
+	if err := os.WriteFile(keep, []byte("keep"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(target, filepath.Join(wsDir, "deadbeef")); err != nil {
+		t.Fatal(err)
+	}
+
+	stats := &gcStats{byPattern: map[string]int{}}
+	d.gcWorkspace(context.Background(), wsDir, stats)
+
+	if _, err := os.Stat(keep); err != nil {
+		t.Fatalf("GC must not follow workspace symlinks: %v", err)
+	}
+}
+
+func TestGCWorkspace_RemovesOwnedNoMetaEnv(t *testing.T) {
+	tests := []struct {
+		name  string
+		setup func(t *testing.T, taskDir, workspaceID string)
+	}{
+		{
+			name: "prepare-time provenance",
+			setup: func(t *testing.T, taskDir, workspaceID string) {
+				t.Helper()
+				if err := execenv.WriteManagedEnvProvenance(taskDir, execenv.ManagedEnvProvenance{
+					WorkspaceID: workspaceID,
+					IssueID:     "issue-1",
+					AgentID:     "agent-1",
+				}); err != nil {
+					t.Fatal(err)
+				}
+			},
+		},
+		{
+			name: "legacy task layout",
+			setup: func(t *testing.T, taskDir, _ string) {
+				t.Helper()
+				for _, name := range []string{"workdir", "output", "logs"} {
+					if err := os.Mkdir(filepath.Join(taskDir, name), 0o755); err != nil {
+						t.Fatal(err)
+					}
+				}
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			workspaceID := "ws-owned"
+			d := newGCTestDaemon(t, http.NewServeMux())
+			d.cfg.GCOrphanTTL = 72 * time.Hour
+			taskDir := createTaskDir(t, d.cfg.WorkspacesRoot, workspaceID, "deadbeef", nil)
+			tt.setup(t, taskDir, workspaceID)
+			old := time.Now().Add(-73 * time.Hour)
+			if err := os.Chtimes(taskDir, old, old); err != nil {
+				t.Fatal(err)
+			}
+
+			stats := &gcStats{byPattern: map[string]int{}}
+			d.gcWorkspace(context.Background(), filepath.Dir(taskDir), stats)
+
+			if _, err := os.Stat(taskDir); !os.IsNotExist(err) {
+				t.Fatalf("owned orphan env must be removed; stat err = %v", err)
+			}
+			if stats.orphaned != 1 {
+				t.Fatalf("orphaned = %d, want 1", stats.orphaned)
+			}
+		})
+	}
+}
+
+func TestGCWorkspace_RejectsMismatchedOwnershipProofs(t *testing.T) {
+	d := newGCTestDaemon(t, http.NewServeMux())
+	d.cfg.GCOrphanTTL = 0
+	wsDir := filepath.Join(d.cfg.WorkspacesRoot, "ws-owner")
+
+	badMeta := createTaskDir(t, d.cfg.WorkspacesRoot, "ws-owner", "meta-owner", &execenv.GCMeta{
+		Kind: execenv.GCKindIssue, IssueID: "issue-1", WorkspaceID: "different-workspace",
+	})
+	badProvenance := createTaskDir(t, d.cfg.WorkspacesRoot, "ws-owner", "cafebabe", nil)
+	if err := execenv.WriteManagedEnvProvenance(badProvenance, execenv.ManagedEnvProvenance{
+		WorkspaceID: "different-workspace", IssueID: "issue-1", AgentID: "agent-1",
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	stats := &gcStats{byPattern: map[string]int{}}
+	d.gcWorkspace(context.Background(), wsDir, stats)
+
+	for _, path := range []string{badMeta, badProvenance} {
+		if _, err := os.Stat(path); err != nil {
+			t.Fatalf("mismatched ownership proof %s must survive GC: %v", path, err)
+		}
+	}
+	if stats.orphaned != 0 {
+		t.Fatalf("stats.orphaned = %d, want 0", stats.orphaned)
+	}
+}

--- a/server/internal/daemon/gc_test.go
+++ b/server/internal/daemon/gc_test.go
@@ -177,12 +177,12 @@ func TestShouldCleanTaskDir_NoMetaOldOrphan(t *testing.T) {
 	t.Parallel()
 
 	d := newGCTestDaemon(t, http.NewServeMux())
-	d.cfg.GCOrphanTTL = 0 // treat all orphans as expired
+	d.cfg.GCOrphanTTL = 0
 	taskDir := createTaskDir(t, d.cfg.WorkspacesRoot, "ws1", "task6", nil)
 
 	action := d.shouldCleanTaskDir(context.Background(), taskDir)
-	if action != gcActionOrphan {
-		t.Fatalf("expected gcActionOrphan, got %d", action)
+	if action != gcActionSkip {
+		t.Fatalf("expected gcActionSkip for an unproven directory, got %d", action)
 	}
 }
 


### PR DESCRIPTION
## What does this PR do?

<!-- Describe the change clearly. What problem does it solve? Why is this approach the right one? -->



## Related Issue

<!-- Link the issue this PR addresses. If no issue exists, consider creating one first. -->

Closes #

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Refactor / code improvement (no behavior change)
- [ ] Documentation update
- [ ] Tests (adding or improving test coverage)
- [ ] CI / infrastructure

## Changes Made

<!-- List the specific changes. Include file paths for code changes. -->

-

## How to Test

<!-- Steps to verify this change works. For bugs: reproduction steps + proof that the fix works. -->

1.
2.
3.

## Checklist

- [ ] I have included a thinking path that traces from project context to this change
- [ ] I have run tests locally and they pass
- [ ] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [ ] I have updated relevant documentation to reflect my changes
- [ ] If I added a new runtime / coding tool / UI tab, I synced the change to **landing copy** (`apps/web/features/landing/i18n/`) and **relevant docs** (`apps/docs/content/docs/`)
- [ ] If this PR touches Chinese product copy, I checked it against `apps/docs/content/docs/developers/conventions.zh.mdx` (terminology, mixed-rule for `task` / `issue` / `skill`)
- [ ] I have considered and documented any risks above
- [ ] I will address all reviewer comments before requesting merge

## AI Disclosure

<!-- Most PRs involve AI coding tools — that's totally fine! We're curious about your process. -->

**AI tool used:** <!-- e.g. Claude Code, Cursor, GitHub Copilot, Multica Agent, N/A -->

**Prompt / approach:**
<!-- How did you use AI to produce this code? Share your prompt, conversation link, or describe your approach. This helps the team learn from each other's AI workflows. -->


## Screenshots (optional)

<!-- If applicable, add screenshots showing the change in action. -->
