### PR TITLE
MUL-4952: pass agent custom env secrets to Codex shells

### DIFF
--- a/server/internal/daemon/daemon.go
+++ b/server/internal/daemon/daemon.go
@@ -4278,7 +4278,7 @@ func (d *Daemon) runTask(ctx context.Context, task Task, provider string, slot i
 		agentCustomEnv = task.Agent.CustomEnv
 	}
 	layerCustomEnvAndHermesHome(agentEnv, agentCustomEnv, env.HermesHome, d.logger)
-	if err := configureCodexTaskShellEnvironment(provider, env.CodexHome, os.Environ(), agentEnv, d.logger); err != nil {
+	if err := configureCodexTaskShellEnvironment(provider, env.CodexHome, os.Environ(), agentEnv, agentCustomEnv, d.logger); err != nil {
 		return TaskResult{}, err
 	}
 	backend, err := agent.New(provider, agent.Config{
@@ -5408,20 +5408,37 @@ func layerCustomEnvAndHermesHome(agentEnv, customEnv map[string]string, overlayH
 	}
 }
 
+// codexShellAuthorizedCustomEnvNames returns names from the current agent's
+// custom_env that pass the same daemon blocklist used when assembling the child
+// environment. Returning names only keeps credential values out of the managed
+// Codex config path.
+func codexShellAuthorizedCustomEnvNames(customEnv map[string]string) []string {
+	names := make([]string, 0, len(customEnv))
+	for key := range customEnv {
+		if key == "" || isBlockedEnvKey(key) {
+			continue
+		}
+		names = append(names, key)
+	}
+	return names
+}
+
 // configureCodexTaskShellEnvironment writes the managed shell policy only
 // after the task and agent custom environment are fully assembled. This makes
 // the allowlist reflect the child environment that will actually be launched,
-// including platform-specific essentials and non-secret custom_env values.
+// including platform-specific essentials and blocklist-checked custom_env
+// credentials.
 // Failure is fatal: launching with an unowned or malformed policy could either
 // drop the task-scoped token again or expose inherited daemon credentials.
-func configureCodexTaskShellEnvironment(provider, codexHome string, inherited []string, agentEnv map[string]string, logger *slog.Logger) error {
+func configureCodexTaskShellEnvironment(provider, codexHome string, inherited []string, agentEnv, agentCustomEnv map[string]string, logger *slog.Logger) error {
 	if provider != "codex" {
 		return nil
 	}
 	if strings.TrimSpace(codexHome) == "" {
 		return errors.New("configure Codex shell environment: task CODEX_HOME is missing")
 	}
-	includeOnly := execenv.CodexShellEnvAllowlist(inherited, agentEnv)
+	authorizedExplicit := codexShellAuthorizedCustomEnvNames(agentCustomEnv)
+	includeOnly := execenv.CodexShellEnvAllowlist(inherited, agentEnv, authorizedExplicit)
 	configPath := filepath.Join(codexHome, "config.toml")
 	if err := execenv.EnsureCodexShellEnvPolicyConfig(configPath, includeOnly, logger); err != nil {
 		return fmt.Errorf("configure Codex shell environment: %w", err)

--- a/server/internal/daemon/daemon_test.go
+++ b/server/internal/daemon/daemon_test.go
@@ -266,7 +266,7 @@ func TestConfigureCodexTaskShellEnvironment(t *testing.T) {
 	t.Run("non-Codex runtime is unchanged", func(t *testing.T) {
 		t.Parallel()
 		codexHome := t.TempDir()
-		if err := configureCodexTaskShellEnvironment("claude", codexHome, nil, nil, slog.Default()); err != nil {
+		if err := configureCodexTaskShellEnvironment("claude", codexHome, nil, nil, nil, slog.Default()); err != nil {
 			t.Fatalf("configureCodexTaskShellEnvironment: %v", err)
 		}
 		if _, err := os.Stat(filepath.Join(codexHome, "config.toml")); !os.IsNotExist(err) {
@@ -284,11 +284,17 @@ func TestConfigureCodexTaskShellEnvironment(t *testing.T) {
 			"MULTICA_LLM_API_KEY=daemon-secret",
 		}
 		agentEnv := map[string]string{
-			"CUSTOM_FLAG":        "enabled",
-			"MULTICA_SERVER_URL": "https://task.example",
-			"MULTICA_TOKEN":      "mat_task",
+			"CUSTOM_ACCESS_TOKEN": "agent-secret",
+			"CUSTOM_FLAG":         "enabled",
+			"UNAUTHORIZED_TOKEN":  "daemon-secret",
+			"MULTICA_SERVER_URL":  "https://task.example",
+			"MULTICA_TOKEN":       "mat_task",
 		}
-		if err := configureCodexTaskShellEnvironment("codex", codexHome, inherited, agentEnv, slog.Default()); err != nil {
+		agentCustomEnv := map[string]string{
+			"CUSTOM_ACCESS_TOKEN": "agent-secret",
+			"CUSTOM_FLAG":         "enabled",
+		}
+		if err := configureCodexTaskShellEnvironment("codex", codexHome, inherited, agentEnv, agentCustomEnv, slog.Default()); err != nil {
 			t.Fatalf("configureCodexTaskShellEnvironment: %v", err)
 		}
 		data, err := os.ReadFile(filepath.Join(codexHome, "config.toml"))
@@ -296,12 +302,12 @@ func TestConfigureCodexTaskShellEnvironment(t *testing.T) {
 			t.Fatalf("read config.toml: %v", err)
 		}
 		config := string(data)
-		for _, want := range []string{"SystemRoot", "USERPROFILE", "CUSTOM_FLAG", "MULTICA_SERVER_URL", "MULTICA_TOKEN"} {
+		for _, want := range []string{"SystemRoot", "USERPROFILE", "CUSTOM_ACCESS_TOKEN", "CUSTOM_FLAG", "MULTICA_SERVER_URL", "MULTICA_TOKEN"} {
 			if !strings.Contains(config, want) {
 				t.Errorf("config.toml missing %q:\n%s", want, config)
 			}
 		}
-		for _, unwanted := range []string{"OPENAI_API_KEY", "MULTICA_LLM_API_KEY", "MULTICA_*"} {
+		for _, unwanted := range []string{"OPENAI_API_KEY", "MULTICA_LLM_API_KEY", "UNAUTHORIZED_TOKEN", "MULTICA_*", "agent-secret", "daemon-secret", "mat_task"} {
 			if strings.Contains(config, unwanted) {
 				t.Errorf("config.toml unexpectedly contains %q:\n%s", unwanted, config)
 			}
@@ -310,11 +316,30 @@ func TestConfigureCodexTaskShellEnvironment(t *testing.T) {
 
 	t.Run("Codex without task home fails closed", func(t *testing.T) {
 		t.Parallel()
-		err := configureCodexTaskShellEnvironment("codex", "", nil, map[string]string{"MULTICA_TOKEN": "mat_task"}, slog.Default())
+		err := configureCodexTaskShellEnvironment("codex", "", nil, map[string]string{"MULTICA_TOKEN": "mat_task"}, nil, slog.Default())
 		if err == nil || !strings.Contains(err.Error(), "CODEX_HOME is missing") {
 			t.Fatalf("error = %v, want missing CODEX_HOME", err)
 		}
 	})
+}
+
+func TestCodexShellAuthorizedCustomEnvNamesUsesDaemonBlocklist(t *testing.T) {
+	t.Parallel()
+
+	got := codexShellAuthorizedCustomEnvNames(map[string]string{
+		"CUSTOM_ACCESS_TOKEN": "agent-secret",
+		"custom_secret":       "agent-secret",
+		"MULTICA_TOKEN":       "must-not-authorize",
+		"PATH":                "/must/not/override",
+		"HOME":                "/must/not/override",
+		"CODEX_HOME":          "/must/not/override",
+		"":                    "must-not-authorize",
+	})
+	slices.Sort(got)
+	want := []string{"CUSTOM_ACCESS_TOKEN", "custom_secret"}
+	if !slices.Equal(got, want) {
+		t.Fatalf("codexShellAuthorizedCustomEnvNames() = %#v, want %#v", got, want)
+	}
 }
 
 func TestTaskScopedAuthToken(t *testing.T) {

--- a/server/internal/daemon/execenv/codex_shell_env.go
+++ b/server/internal/daemon/execenv/codex_shell_env.go
@@ -43,14 +43,22 @@ type tomlByteRange struct {
 // managed shell policy.
 //
 // Inherited process variables keep Codex's documented default filtering for
-// names containing KEY, SECRET, or TOKEN. Inherited MULTICA_* variables are
-// always dropped because they belong to the daemon process, not necessarily to
-// this task. Explicit MULTICA_* values are safe to include because daemon.go
-// blocklists that namespace from agent custom_env and constructs those values
-// from the current task. Non-secret explicit custom_env values keep their
-// existing shell visibility; secret-looking custom_env remains filtered just
-// as it was under Codex's default policy.
-func CodexShellEnvAllowlist(inherited []string, explicit map[string]string) []string {
+// names containing KEY, SECRET, or TOKEN. Credential-looking explicit values
+// are included only when their names also appear in authorizedExplicit, which
+// daemon.go derives solely from the current agent's blocklist-checked
+// custom_env. Inherited MULTICA_* variables are always dropped because they
+// belong to the daemon process, not necessarily to this task. Explicit
+// MULTICA_* values are safe to include because daemon.go blocklists that
+// namespace from agent custom_env and constructs those values from the current
+// task.
+func CodexShellEnvAllowlist(inherited []string, explicit map[string]string, authorizedExplicit []string) []string {
+	authorized := make(map[string]struct{}, len(authorizedExplicit))
+	for _, key := range authorizedExplicit {
+		if key != "" {
+			authorized[strings.ToUpper(key)] = struct{}{}
+		}
+	}
+
 	// Codex's glob matching is case-insensitive. De-duplicate on the same basis
 	// so Windows Path/PATH aliases cannot create ambiguous policy entries.
 	allowed := make(map[string]string, len(inherited)+len(explicit))
@@ -64,7 +72,12 @@ func CodexShellEnvAllowlist(inherited []string, explicit map[string]string) []st
 				return
 			}
 		} else if codexDefaultExcludesEnvKey(upper) {
-			return
+			if !isExplicit {
+				return
+			}
+			if _, ok := authorized[upper]; !ok {
+				return
+			}
 		}
 		allowed[upper] = key
 	}

--- a/server/internal/daemon/execenv/codex_shell_env_test.go
+++ b/server/internal/daemon/execenv/codex_shell_env_test.go
@@ -55,9 +55,11 @@ func TestCodexShellEnvAllowlistUsesExactTaskAndSafeInheritedNames(t *testing.T) 
 		"CUSTOM_FLAG":        "enabled",
 		"ANTHROPIC_API_KEY":  "agent-secret",
 	}
+	authorizedExplicit := []string{"ANTHROPIC_API_KEY"}
 
-	got := CodexShellEnvAllowlist(inherited, explicit)
+	got := CodexShellEnvAllowlist(inherited, explicit, authorizedExplicit)
 	want := []string{
+		"ANTHROPIC_API_KEY",
 		"APPDATA",
 		"COMSPEC",
 		"CUSTOM_FLAG",
@@ -72,6 +74,42 @@ func TestCodexShellEnvAllowlistUsesExactTaskAndSafeInheritedNames(t *testing.T) 
 		"SSL_CERT_FILE",
 		"SystemRoot",
 		"USERPROFILE",
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("CodexShellEnvAllowlist() = %#v, want %#v", got, want)
+	}
+}
+
+func TestCodexShellEnvAllowlistOnlyAuthorizesExplicitCustomSecrets(t *testing.T) {
+	t.Parallel()
+
+	inherited := []string{
+		"PATH=/usr/bin",
+		"CUSTOM_ACCESS_TOKEN=host-secret",
+		"HOST_SECRET=host-secret",
+		"MULTICA_TOKEN=daemon-secret",
+	}
+	explicit := map[string]string{
+		"CUSTOM_ACCESS_TOKEN": "agent-secret",
+		"x_secret":            "agent-secret",
+		"Y_KEY":               "agent-secret",
+		"UNAUTHORIZED_TOKEN":  "daemon-secret",
+		"MULTICA_TOKEN":       "mat_task",
+	}
+	authorizedExplicit := []string{
+		"custom_access_token", // Authorization matching is case-insensitive.
+		"X_SECRET",
+		"Y_KEY",
+		"HOST_SECRET", // Authorization alone cannot expose an inherited value.
+	}
+
+	got := CodexShellEnvAllowlist(inherited, explicit, authorizedExplicit)
+	want := []string{
+		"CUSTOM_ACCESS_TOKEN",
+		"MULTICA_TOKEN",
+		"PATH",
+		"x_secret",
+		"Y_KEY",
 	}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("CodexShellEnvAllowlist() = %#v, want %#v", got, want)


### PR DESCRIPTION
## What does this PR do?

Fixes Codex task shells dropping credential-like environment variables that a user explicitly configured on the current agent through `custom_env`.

The daemon still builds one exact `shell_environment_policy.include_only` list. The fix keeps the merged task environment separate from a names-only authorization list derived from the current agent's `custom_env` after applying the existing daemon blocklist. A `KEY`, `SECRET`, or `TOKEN` name is allowed only when it is both present in the explicit task environment and present in that authorization list.

This preserves the security boundary: host/daemon inherited credentials remain filtered, blocked agent overrides remain blocked, `MULTICA_*` task values keep their existing handling, and no environment value is written to Codex config or logs.

## Related Issue

Closes MUL-4952

Fixes #5601

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Refactor / code improvement (no behavior change)
- [ ] Documentation update
- [x] Tests (adding or improving test coverage)
- [ ] CI / infrastructure

## Changes Made

- Update `server/internal/daemon/execenv/codex_shell_env.go` to require source-aware authorization before allowing credential-like explicit names.
- Update `server/internal/daemon/daemon.go` to derive the authorization list only from blocklist-checked current-agent `custom_env` keys.
- Add regressions for `KEY` / `SECRET` / `TOKEN`, case-insensitive authorization, inherited and untrusted merged-env filtering, blocked namespaces, and names-only generated TOML.

## How to Test

1. `cd server && go test ./internal/daemon/... -count=1`
2. `cd server && go vet ./internal/daemon/...`
3. Configure a Codex agent with `CUSTOM_ENDPOINT` and `CUSTOM_ACCESS_TOKEN`; confirm both are visible to shell tools without printing their values.

Local verification: the daemon test suite and daemon vet pass. A broader `go test ./...` was also attempted; unrelated CLI tests reject the Multica task marker in this runtime, and integration tests find a stale shared database missing current migration columns.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have run the relevant tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] If this change affects the UI, I have included before/after screenshots (not applicable)
- [x] I have updated relevant documentation to reflect my changes (not applicable; no documented contract changed)
- [x] If I added a new runtime / coding tool / UI tab, I synced the change to **landing copy** (`apps/web/features/landing/i18n/`) and **relevant docs** (`apps/docs/content/docs/`) (not applicable)
- [x] If this PR touches Chinese product copy, I checked it against `apps/docs/content/docs/developers/conventions.zh.mdx` (not applicable)
- [x] I have considered and documented any risks above
- [x] I will address all reviewer comments before requesting merge

## AI Disclosure

**AI tool used:** Multica Agent (Codex)

**Prompt / approach:** Traced `task.Agent.CustomEnv` through daemon child-environment assembly and managed Codex policy generation, reproduced the omission in the existing allowlist test, then introduced a separate names-only authorization input and regression-tested both the intended passthrough and the inherited-secret isolation boundary.

## Screenshots (optional)

N/A
