### PR TITLE
MUL-4998: always enable AI agent creation

### DIFF
--- a/docs/feature-flags.md
+++ b/docs/feature-flags.md
@@ -181,25 +181,29 @@ Outside a `FeatureFlagsProvider` (Storybook, unit tests, error pages) `useFlag` 
 
 ### v0.3.44 compatibility rollout
 
-The following release flags default to `false` so the schema can ship before
-the new persisted states are visible to older server pods or a rollback:
+The following release flag defaults to `false` so the schema can ship before
+the new persisted state is visible to older server pods or a rollback:
 
 ```yaml
 # Enable only after every v0.3.43 server pod has drained and rollback reads
 # have been validated against the migrated database.
-agents_agent_builder:
-  default: true
 settings_resource_labels:
   default: true
 ```
 
-Keep both off for v0.3.44: it is a schema-only deployment for these
-features. A later rollout may enable them only after it ships and verifies a
-rollback normalizer for builder agents and resource-label rows. Do not rely on
-turning the flags off to make a database safe for an older binary; it prevents
-new writes but cannot remove states that already exist. Until that normalizer
-exists, rollbacks must target a version that understands these states or happen
-before either flag is enabled.
+Keep it off for v0.3.44: it is a schema-only deployment for resource labels. A
+later rollout may enable it only after it ships and verifies a rollback
+normalizer for resource-label rows. Do not rely on turning the flag off to make
+a database safe for an older binary; it prevents new writes but cannot remove
+states that already exist. Until that normalizer exists, rollbacks must target
+a version that understands these states or happen before the flag is enabled.
+
+Agent Builder has completed this rollout and is now always available. Current
+clients always render the AI creation entry, and the backend no longer gates the
+session endpoint. `/api/config` still reports `agents_agent_builder: true` so
+installed desktop clients that still gate the entry on this config decision
+also receive the permanently enabled behavior; this is a client-compatibility
+decision, not an operator-controlled flag.
 
 Agent skill toggles have completed this rollout and are now always available.
 Current clients render the switch without a release flag, and the backend no

--- a/packages/core/feature-flags/index.ts
+++ b/packages/core/feature-flags/index.ts
@@ -18,7 +18,6 @@ export { FeatureFlagService } from "./service";
 export { StaticProvider } from "./static-provider";
 export { ChainProvider } from "./chain-provider";
 export {
-  AGENT_BUILDER_FLAG,
   COMPOSIO_MCP_APPS_FLAG,
   RESOURCE_LABELS_FLAG,
 } from "./keys";

--- a/packages/core/feature-flags/keys.ts
+++ b/packages/core/feature-flags/keys.ts
@@ -1,3 +1,2 @@
 export const COMPOSIO_MCP_APPS_FLAG = "composio_mcp_apps";
-export const AGENT_BUILDER_FLAG = "agents_agent_builder";
 export const RESOURCE_LABELS_FLAG = "settings_resource_labels";

--- a/packages/views/agents/components/agent-creation-studio.test.ts
+++ b/packages/views/agents/components/agent-creation-studio.test.ts
@@ -1,5 +1,8 @@
-import { describe, expect, it } from "vitest";
+import { createElement } from "react";
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
 import {
+  ModeChooser,
   buildInvocationTargets,
   decodeBuilderInput,
   deriveDuplicateAccess,
@@ -10,6 +13,45 @@ import {
   stripBuilderDraft,
   type AgentDraft,
 } from "./agent-creation-studio";
+
+vi.mock("../../i18n", () => ({
+  useT: () => ({
+    t: (
+      selector: (translations: {
+        creation_studio: {
+          eyebrow: string;
+          choose_title: string;
+          choose_description: string;
+          recommended: string;
+          continue: string;
+          modes: {
+            blank: { title: string; description: string };
+            ai: { title: string; description: string };
+          };
+        };
+      }) => string,
+    ) =>
+      selector({
+        creation_studio: {
+          eyebrow: "Agent creation",
+          choose_title: "How would you like to start?",
+          choose_description: "Choose a creation mode.",
+          recommended: "Recommended",
+          continue: "Continue",
+          modes: {
+            blank: {
+              title: "Start blank",
+              description: "Configure every field yourself.",
+            },
+            ai: {
+              title: "Build with AI",
+              description: "Describe the outcome you want.",
+            },
+          },
+        },
+      }),
+  }),
+}));
 
 const draft = (): AgentDraft => ({
   name: "Old name",
@@ -22,6 +64,20 @@ const draft = (): AgentDraft => ({
   permissionScope: "private",
   memberIds: new Set(),
   teamIds: new Set(),
+});
+
+describe("Agent creation studio mode chooser", () => {
+  it("always offers AI-assisted creation", () => {
+    render(
+      createElement(ModeChooser, {
+        onBlank: vi.fn(),
+        onAI: vi.fn(),
+      }),
+    );
+
+    expect(screen.getByText("Start blank")).toBeInTheDocument();
+    expect(screen.getByText("Build with AI")).toBeInTheDocument();
+  });
 });
 
 describe("Agent creation studio builder protocol", () => {

--- a/packages/views/agents/components/agent-creation-studio.tsx
+++ b/packages/views/agents/components/agent-creation-studio.tsx
@@ -15,8 +15,6 @@ import {
 import { toast } from "sonner";
 import { api } from "@multica/core/api";
 import { useAuthStore } from "@multica/core/auth";
-import { useFeatureEnabled } from "@multica/core/config";
-import { AGENT_BUILDER_FLAG } from "@multica/core/feature-flags";
 import {
   agentTemplateDetailOptions,
   agentTemplateListOptions,
@@ -121,7 +119,6 @@ export function AgentCreationStudio() {
   const navigation = useNavigation();
   const qc = useQueryClient();
   const currentUser = useAuthStore((state) => state.user);
-  const agentBuilderEnabled = useFeatureEnabled(AGENT_BUILDER_FLAG, false);
   const duplicateId = navigation.searchParams.get("duplicate");
   const squadId = navigation.searchParams.get("squad");
 
@@ -687,7 +684,6 @@ export function AgentCreationStudio() {
         <ModeChooser
           onBlank={chooseBlank}
           onAI={() => setMode("ai")}
-          agentBuilderEnabled={agentBuilderEnabled}
         />
       )}
 
@@ -802,14 +798,12 @@ export function AgentCreationStudio() {
   );
 }
 
-function ModeChooser({
+export function ModeChooser({
   onBlank,
   onAI,
-  agentBuilderEnabled,
 }: {
   onBlank: () => void;
   onAI: () => void;
-  agentBuilderEnabled: boolean;
 }) {
   const { t } = useT("agents");
   const modes = [
@@ -819,15 +813,13 @@ function ModeChooser({
       description: t(($) => $.creation_studio.modes.blank.description),
       action: onBlank,
     },
-    ...(agentBuilderEnabled
-      ? [{
-          icon: MessageSquare,
-          title: t(($) => $.creation_studio.modes.ai.title),
-          description: t(($) => $.creation_studio.modes.ai.description),
-          action: onAI,
-          recommended: true,
-        }]
-      : []),
+    {
+      icon: MessageSquare,
+      title: t(($) => $.creation_studio.modes.ai.title),
+      description: t(($) => $.creation_studio.modes.ai.description),
+      action: onAI,
+      recommended: true,
+    },
   ];
   return (
     <main className="flex min-h-0 flex-1 items-center justify-center overflow-y-auto px-5 py-10">

--- a/server/internal/featureflags/keys.go
+++ b/server/internal/featureflags/keys.go
@@ -13,12 +13,13 @@ const (
 	// The access model exists to gate Composio sharing, so the two ship on the
 	// same switch.
 	ComposioMCPApps = "composio_mcp_apps"
-	// AgentBuilder controls writes of system builder agents. It stays disabled
-	// through the schema-only rollout so an older server cannot expose them.
-	AgentBuilder = "agents_agent_builder"
 	// ResourceLabels controls the agent- and skill-scoped label namespaces.
 	// Issue labels remain available while this release flag is off.
 	ResourceLabels = "settings_resource_labels"
+	// agentBuilderCompat is no longer a release flag. Keep publishing the key
+	// as enabled so installed desktop clients that still gate the AI creation
+	// entry on this config decision receive the permanently enabled behavior.
+	agentBuilderCompat = "agents_agent_builder"
 	// agentSkillTogglesCompat is no longer a release flag. Keep publishing the
 	// key as enabled so installed v0.4.0 desktop clients, which still gate the
 	// switch on this config decision, receive the permanently enabled behavior.
@@ -27,7 +28,6 @@ const (
 
 var frontendPublicFlags = []string{
 	ComposioMCPApps,
-	AgentBuilder,
 	ResourceLabels,
 }
 
@@ -35,19 +35,16 @@ func ComposioMCPAppsEnabled(ctx context.Context, flags *featureflag.Service) boo
 	return flags.IsEnabled(ctx, ComposioMCPApps, false)
 }
 
-func AgentBuilderEnabled(ctx context.Context, flags *featureflag.Service) bool {
-	return flags.IsEnabled(ctx, AgentBuilder, false)
-}
-
 func ResourceLabelsEnabled(ctx context.Context, flags *featureflag.Service) bool {
 	return flags.IsEnabled(ctx, ResourceLabels, false)
 }
 
 func EvaluateFrontendPublicFlags(ctx context.Context, flags *featureflag.Service) map[string]bool {
-	out := make(map[string]bool, len(frontendPublicFlags)+1)
+	out := make(map[string]bool, len(frontendPublicFlags)+2)
 	for _, key := range frontendPublicFlags {
 		out[key] = flags.IsEnabled(ctx, key, false)
 	}
+	out[agentBuilderCompat] = true
 	out[agentSkillTogglesCompat] = true
 	return out
 }

--- a/server/internal/featureflags/keys_test.go
+++ b/server/internal/featureflags/keys_test.go
@@ -5,13 +5,17 @@ import (
 	"testing"
 )
 
-func TestReleaseFlagsDefaultToOff(t *testing.T) {
+func TestResourceLabelsReleaseFlagDefaultsToOff(t *testing.T) {
 	ctx := context.Background()
-	if AgentBuilderEnabled(ctx, nil) {
-		t.Fatal("agent builder release flag must default to off")
-	}
 	if ResourceLabelsEnabled(ctx, nil) {
 		t.Fatal("resource labels release flag must default to off")
+	}
+}
+
+func TestAgentBuilderCompatDecisionStaysEnabled(t *testing.T) {
+	flags := EvaluateFrontendPublicFlags(context.Background(), nil)
+	if !flags[agentBuilderCompat] {
+		t.Fatal("agent builder must stay enabled for installed clients")
 	}
 }
 

--- a/server/internal/handler/agent_builder.go
+++ b/server/internal/handler/agent_builder.go
@@ -11,7 +11,6 @@ import (
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgtype"
 
-	"github.com/multica-ai/multica/server/internal/featureflags"
 	db "github.com/multica-ai/multica/server/pkg/db/generated"
 )
 
@@ -53,10 +52,6 @@ type CreateAgentBuilderSessionResponse struct {
 // chat/task pipeline is intentionally agent-backed; it never appears in normal
 // agent lists and cannot be selected as an assignee.
 func (h *Handler) CreateAgentBuilderSession(w http.ResponseWriter, r *http.Request) {
-	if !featureflags.AgentBuilderEnabled(r.Context(), h.FeatureFlags) {
-		writeError(w, http.StatusNotFound, "agent builder is not enabled")
-		return
-	}
 	workspaceID := h.resolveWorkspaceID(r)
 	userID, ok := requireUserID(w, r)
 	if !ok {

--- a/server/internal/handler/agent_builder_test.go
+++ b/server/internal/handler/agent_builder_test.go
@@ -25,7 +25,6 @@ func TestCreateAgentBuilderSessionCreatesIsolatedHiddenBuilder(t *testing.T) {
 	if testHandler == nil {
 		t.Skip("database not available")
 	}
-	withAgentBuilderFlag(t, testHandler, true)
 	t.Cleanup(func() {
 		_, _ = testPool.Exec(context.Background(), `
 			DELETE FROM agent
@@ -113,17 +112,6 @@ func TestCreateAgentBuilderSessionCreatesIsolatedHiddenBuilder(t *testing.T) {
 	}
 	if remaining != 0 {
 		t.Fatalf("builder agent survived chat deletion")
-	}
-}
-
-func TestCreateAgentBuilderSessionRequiresReleaseFlag(t *testing.T) {
-	withAgentBuilderFlag(t, testHandler, false)
-	w := httptest.NewRecorder()
-	testHandler.CreateAgentBuilderSession(w, newRequest(http.MethodPost, "/api/agent-builder/sessions", map[string]any{
-		"runtime_id": testRuntimeID,
-	}))
-	if w.Code != http.StatusNotFound {
-		t.Fatalf("CreateAgentBuilderSession without flag: expected 404, got %d: %s", w.Code, w.Body.String())
 	}
 }
 

--- a/server/internal/handler/featureflag_test.go
+++ b/server/internal/handler/featureflag_test.go
@@ -11,10 +11,6 @@ func withComposioMCPAppsFlag(t *testing.T, h *Handler, enabled bool) {
 	withFeatureFlag(t, h, featureflags.ComposioMCPApps, enabled)
 }
 
-func withAgentBuilderFlag(t *testing.T, h *Handler, enabled bool) {
-	withFeatureFlag(t, h, featureflags.AgentBuilder, enabled)
-}
-
 func withResourceLabelsFlag(t *testing.T, h *Handler, enabled bool) {
 	withFeatureFlag(t, h, featureflags.ResourceLabels, enabled)
 }


### PR DESCRIPTION
## Summary

- always show the **Build with AI** option in the shared Web/Desktop Agent creation studio
- remove the backend release-flag gate from Agent Builder session creation
- keep `/api/config` reporting `agents_agent_builder: true` for installed Desktop clients that still read the retired flag
- retire the frontend/backend flag symbols and document the completed rollout

## Why

Agent Builder shipped as a public v0.4.0 feature, but its temporary rollout flag still defaulted to off. Deployments without explicit feature-flag configuration therefore hid the AI creation path and returned 404 from the session endpoint.

Closes MUL-4998

## Risk

- Agent Builder can now create hidden system-agent state on every deployment; rollbacks must target a version that understands that state or normalize it first.
- `FF_AGENTS_AGENT_BUILDER` and the equivalent YAML rule no longer control behavior. Older Desktop clients remain compatible because the public config decision is pinned to `true`.
- No schema or data migration is included.

## Test plan

- [x] `go test ./internal/featureflags -count=1`
- [x] `go test ./internal/handler -run 'TestAgentBuilderInstructionsConstrainModelsToRuntimeCatalog|TestCreateAgentBuilderSessionCreatesIsolatedHiddenBuilder' -count=1`
- [x] `pnpm --filter @multica/views exec vitest run agents/components/agent-creation-studio.test.ts`
- [x] `pnpm --filter @multica/views exec eslint agents/components/agent-creation-studio.tsx agents/components/agent-creation-studio.test.ts`
- [x] `pnpm --filter @multica/web run typecheck`
- [ ] Full `go test ./internal/handler` is blocked by a stale local test database missing current columns such as `issue.properties` and `autopilot_trigger.published_by_type`; the focused Agent Builder tests pass.
