### PR TITLE
fix(views): close project picker dropdown after selecting a project

### DIFF
--- a/packages/views/projects/components/project-picker.open-state.test.tsx
+++ b/packages/views/projects/components/project-picker.open-state.test.tsx
@@ -1,0 +1,95 @@
+// Regression test: selecting a project in the create-issue
+// dialog left the dropdown stuck open. The dialog wires the picker with
+// `open={cond ? true : undefined}`; Base UI's Menu latches a controlled
+// `open={true}` and does NOT treat a later `undefined` as "close", so the
+// picker must normalize to an always-boolean controlled value. This test
+// uses the REAL dropdown-menu (Base UI) — do not mock it here.
+import { useState } from "react";
+import { describe, expect, it, vi } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { I18nProvider } from "@multica/core/i18n/react";
+import enProjects from "../../locales/en/projects.json";
+import { ProjectPicker } from "./project-picker";
+import { PillButton } from "../../common/pill-button";
+
+vi.mock("@tanstack/react-query", () => ({
+  useQuery: () => ({
+    data: [
+      { id: "project-1", title: "Launch Command Center", icon: null },
+      { id: "project-2", title: "Mobile Web", icon: null },
+    ],
+  }),
+}));
+
+vi.mock("@multica/core/hooks", () => ({
+  useWorkspaceId: () => "workspace-1",
+}));
+
+vi.mock("@multica/core/projects/queries", () => ({
+  projectListOptions: () => ({ queryKey: ["projects"] }),
+}));
+
+vi.mock("./project-icon", () => ({
+  ProjectIcon: () => <span data-testid="project-icon" />,
+}));
+
+/** Mirrors the create-issue dialog wiring from packages/views/modals/create-issue.tsx. */
+function CreateDialogHarness({ onUpdate }: { onUpdate: (u: object) => void }) {
+  const [fieldPickerOpen, setFieldPickerOpen] = useState<"project" | null>(null);
+  const [projectId, setProjectId] = useState<string | null>(null);
+  return (
+    <I18nProvider locale="en" resources={{ en: { projects: enProjects } }}>
+      <ProjectPicker
+        projectId={projectId}
+        onUpdate={(u) => {
+          onUpdate(u);
+          setProjectId(u.project_id ?? null);
+        }}
+        triggerRender={<PillButton />}
+        align="start"
+        open={fieldPickerOpen === "project" ? true : undefined}
+        onOpenChange={(open) => setFieldPickerOpen(open ? "project" : null)}
+      />
+    </I18nProvider>
+  );
+}
+
+describe("ProjectPicker open state under create-dialog wiring", () => {
+  it("closes the dropdown after selecting a project", async () => {
+    const user = userEvent.setup();
+    const onUpdate = vi.fn();
+
+    render(<CreateDialogHarness onUpdate={onUpdate} />);
+
+    // Open the picker via its trigger.
+    await user.click(screen.getByRole("button", { name: /no project/i }));
+    const item = await screen.findByRole("menuitem", { name: /mobile web/i });
+
+    // Select a project — the selection must register AND the popup must close.
+    await user.click(item);
+    expect(onUpdate).toHaveBeenCalledWith({ project_id: "project-2" });
+    await waitFor(() => {
+      expect(screen.queryByRole("menuitem", { name: /mobile web/i })).not.toBeInTheDocument();
+    });
+  });
+
+  it("can be reopened and closed again after a selection", async () => {
+    const user = userEvent.setup();
+
+    render(<CreateDialogHarness onUpdate={vi.fn()} />);
+
+    await user.click(screen.getByRole("button", { name: /no project/i }));
+    await user.click(await screen.findByRole("menuitem", { name: /launch command center/i }));
+    await waitFor(() => {
+      expect(screen.queryByRole("menuitem", { name: /launch command center/i })).not.toBeInTheDocument();
+    });
+
+    // Reopen from the (now selected) trigger and close by selecting again.
+    await user.click(screen.getByRole("button", { name: /launch command center/i }));
+    await user.click(await screen.findByRole("menuitem", { name: /mobile web/i }));
+    await waitFor(() => {
+      expect(screen.queryByRole("menuitem", { name: /mobile web/i })).not.toBeInTheDocument();
+    });
+  });
+});

--- a/packages/views/projects/components/project-picker.tsx
+++ b/packages/views/projects/components/project-picker.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useState } from "react";
 import { Check, FolderKanban, X } from "lucide-react";
 import { useQuery } from "@tanstack/react-query";
 import { projectListOptions } from "@multica/core/projects/queries";
@@ -21,7 +22,7 @@ export function ProjectPicker({
   triggerRender,
   align = "start",
   defaultOpen = false,
-  open,
+  open: controlledOpen,
   onOpenChange,
 }: {
   projectId: string | null;
@@ -38,9 +39,17 @@ export function ProjectPicker({
   const wsId = useWorkspaceId();
   const { data: projects = [] } = useQuery(projectListOptions(wsId));
   const current = projects.find((p) => p.id === projectId);
+  // Normalize to an always-boolean controlled `open`, matching the other
+  // pickers (status/priority/assignee/labels). Base UI's Menu latches a
+  // controlled `open={true}` — a later `undefined` does NOT close it — so
+  // callers wiring `open={cond ? true : undefined}` (create-issue dialog)
+  // would leave the popup stuck open after selecting a project.
+  const [internalOpen, setInternalOpen] = useState(defaultOpen);
+  const open = controlledOpen ?? internalOpen;
+  const setOpen = onOpenChange ?? setInternalOpen;
 
   return (
-    <DropdownMenu defaultOpen={defaultOpen} open={open} onOpenChange={onOpenChange}>
+    <DropdownMenu open={open} onOpenChange={setOpen}>
       <div className="group/project relative inline-flex min-w-0">
         <DropdownMenuTrigger
           className={triggerRender ? undefined : "flex items-center gap-1.5 cursor-pointer rounded px-1 -mx-1 hover:bg-accent/30 transition-colors overflow-hidden"}


### PR DESCRIPTION
## What does this PR do?

Closes the project dropdown after selecting a project in the manual and quick create-issue dialogs.

The create dialogs pass `true` while the project picker is active and `undefined` after Base UI requests a close. `ProjectPicker` forwarded that transition directly, which switched the menu from controlled to uncontrolled and left Base UI holding the previous open state. This change normalizes the picker to an always-boolean `open` value, matching the status, priority, assignee, and label picker pattern.

Uncontrolled callers still use an internal state initialized from `defaultOpen`, so issue details, autopilot configuration, and progressive-disclosure fields keep their existing behavior.

## Related Issue

Closes #5662

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Refactor / code improvement (no behavior change)
- [ ] Documentation update
- [x] Tests (adding or improving test coverage)
- [ ] CI / infrastructure

## Changes Made

- `packages/views/projects/components/project-picker.tsx`
  - Normalize controlled and uncontrolled menu state to an explicit boolean.
  - Preserve `defaultOpen` for uncontrolled callers.
- `packages/views/projects/components/project-picker.open-state.test.tsx`
  - Exercise the real Base UI dropdown with the create-dialog wiring.
  - Cover closing after selection and closing again after reopening.

## How to Test

1. Open either the manual or quick create-issue dialog.
2. Open the project picker and select a project.
3. Verify the selection is applied and the dropdown closes.
4. Reopen the picker, select another project, and verify it closes again.

Local validation:

- `pnpm --filter @multica/views exec vitest run projects/components/project-picker.open-state.test.tsx` — 2 tests passed.
- `pnpm --filter @multica/views typecheck` — passed.
- Full TypeScript typecheck and unit suites passed (386 files, 4,147 tests).
- Full Go tests passed on rerun; one unrelated 100 ms Codex handshake timing test was flaky on the first run and passed when isolated.
- `make check` reached E2E with 19 passed and 6 unrelated failures in existing Agent MCP, navigation, and settings scenarios. The create-issue E2E path passed.

## Risk

Low. The change is isolated to shared project-picker open-state plumbing. The regression tests cover both the reported close transition and a subsequent reopen/close cycle.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [x] I have updated relevant documentation to reflect my changes — no documentation change is needed for this behavior fix
- [x] If I added a new runtime / coding tool / UI tab, I synced the change to **landing copy** (`apps/web/features/landing/i18n/`) and **relevant docs** (`apps/docs/content/docs/`) — not applicable
- [x] If this PR touches Chinese product copy, I checked it against `apps/docs/content/docs/developers/conventions.zh.mdx` (terminology, mixed-rule for `task` / `issue` / `skill`) — no copy change
- [x] I have considered and documented any risks above
- [x] I will address all reviewer comments before requesting merge

## AI Disclosure

**AI tool used:** OpenAI Codex

**Prompt / approach:**

Started from a screenshot of the create-issue project menu remaining visible after selection. Traced the shared picker and every call site, compared its state handling with the other field pickers, reproduced the controlled `true` to uncontrolled `undefined` transition using the real Base UI menu, then added focused regression coverage for closing and reopening behavior.

## Screenshots (optional)

The linked issue describes the before state. The user-visible change is limited to the dropdown closing immediately after selection.
