### PR TITLE
fix(issues): rename board display button to Display (MUL-5011)

### DIFF
--- a/packages/views/issues/components/issues-header.tsx
+++ b/packages/views/issues/components/issues-header.tsx
@@ -1332,14 +1332,8 @@ export function IssueDisplayControls({
                 <TooltipTrigger
                   render={
                     <Button variant="outline" size="sm" className={controlButtonClass}>
-                      {sortBy === "position" ? (
-                        <SlidersHorizontal className="size-3.5" />
-                      ) : sortDirection === "asc" ? (
-                        <ArrowUp className="size-3.5" />
-                      ) : (
-                        <ArrowDown className="size-3.5" />
-                      )}
-                      <span className="hidden md:inline">{sortLabel}</span>
+                      <SlidersHorizontal className="size-3.5" />
+                      <span className="hidden md:inline">{t(($) => $.display.button)}</span>
                     </Button>
                   }
                 />

--- a/packages/views/locales/en/issues.json
+++ b/packages/views/locales/en/issues.json
@@ -68,6 +68,7 @@
   },
   "display": {
     "tooltip": "Display settings",
+    "button": "Display",
     "grouping_section": "Grouping",
     "ordering_section": "Ordering",
     "card_properties_section": "Card properties",

--- a/packages/views/locales/ja/issues.json
+++ b/packages/views/locales/ja/issues.json
@@ -66,6 +66,7 @@
   },
   "display": {
     "tooltip": "表示設定",
+    "button": "表示",
     "grouping_section": "グループ化",
     "ordering_section": "並び替え",
     "card_properties_section": "カードのプロパティ",

--- a/packages/views/locales/ko/issues.json
+++ b/packages/views/locales/ko/issues.json
@@ -66,6 +66,7 @@
   },
   "display": {
     "tooltip": "보기 설정",
+    "button": "보기",
     "grouping_section": "그룹화",
     "ordering_section": "정렬",
     "card_properties_section": "카드 속성",

--- a/packages/views/locales/zh-Hans/issues.json
+++ b/packages/views/locales/zh-Hans/issues.json
@@ -66,6 +66,7 @@
   },
   "display": {
     "tooltip": "显示设置",
+    "button": "显示",
     "grouping_section": "分组",
     "ordering_section": "排序",
     "card_properties_section": "卡片属性",


### PR DESCRIPTION
## Summary

The Issue Board's display-settings button showed the **current sort mode** as its label — so with the default "manual" (position) ordering it read **"Manual"**, which is confusing as a button name.

This changes the trigger to a stable **"Display"** label with the sliders icon, matching the button's existing `Display settings` tooltip and the standard pattern for this control. The current sort mode is still visible inside the popover's **Ordering** section, so no information is lost.

### Before / After
- Before: button label = current sort (`Manual` / `Priority` / `Created date` …), icon toggled between sliders and asc/desc arrows.
- After: button label = `Display` (localized), fixed sliders icon.

## Changes
- `packages/views/issues/components/issues-header.tsx` — trigger button now renders a fixed `SlidersHorizontal` icon + `display.button` label instead of the dynamic sort icon/label.
- `packages/views/locales/{en,zh-Hans,ja,ko}/issues.json` — added `display.button` (`Display` / `显示` / `表示` / `보기`).

## Verification
- `pnpm exec tsc --noEmit` (packages/views) — pass
- `pnpm exec vitest run locales/parity.test.ts issues/components/issues-page.test.tsx` — 170 passed (locale parity confirms the new key exists in all locales)
- `pnpm exec eslint issues/components/issues-header.tsx` — clean

MUL-5011
