### PR TITLE
fix(i18n): capitalize on-behalf-of attribution label (MUL-5026)

### DIFF
--- a/packages/views/issues/components/attribution-badge.test.tsx
+++ b/packages/views/issues/components/attribution-badge.test.tsx
@@ -31,7 +31,7 @@ describe("AttributionBadge", () => {
     };
     renderWithI18n(<AttributionBadge attribution={attribution} />);
 
-    expect(screen.getByText("on behalf of Ada Lovelace")).toBeInTheDocument();
+    expect(screen.getByText("On behalf of Ada Lovelace")).toBeInTheDocument();
     expect(screen.getByTitle("Direct member action")).toBeInTheDocument();
   });
 
@@ -45,7 +45,7 @@ describe("AttributionBadge", () => {
       <AttributionBadge attribution={attribution} />,
     );
 
-    expect(screen.getByText("on behalf of Grace")).toBeInTheDocument();
+    expect(screen.getByText("On behalf of Grace")).toBeInTheDocument();
     expect(container.querySelector(".text-warning")).not.toBeNull();
     expect(screen.getByTitle("No precise owner — attributed to the agent owner"))
       .toBeInTheDocument();
@@ -64,7 +64,7 @@ describe("AttributionBadge", () => {
       <AttributionBadge attribution={attribution} />,
     );
 
-    expect(screen.getByText("on behalf of Bohan")).toBeInTheDocument();
+    expect(screen.getByText("On behalf of Bohan")).toBeInTheDocument();
     // No warning tone — the confusing yellow that flagged backfilled runs is gone.
     expect(container.querySelector(".text-warning")).toBeNull();
     expect(container.querySelector(".text-muted-foreground")).not.toBeNull();
@@ -93,7 +93,7 @@ describe("AttributionBadge", () => {
     };
     renderWithI18n(<AttributionBadge attribution={attribution} />);
 
-    expect(screen.getByText("on behalf of someone")).toBeInTheDocument();
+    expect(screen.getByText("On behalf of someone")).toBeInTheDocument();
   });
 
   it("renders nothing when no responsible member resolved (MUL-4765)", () => {
@@ -134,7 +134,7 @@ describe("AttributionBadge", () => {
 
     // Only the avatar (name plumbs through the stub) — no "on behalf of" chip.
     expect(screen.getByTestId("actor-avatar")).toHaveTextContent("Ada Lovelace");
-    expect(screen.queryByText("on behalf of Ada Lovelace")).toBeNull();
+    expect(screen.queryByText("On behalf of Ada Lovelace")).toBeNull();
   });
 
   it("avatar variant renders nothing without an accountable member", () => {

--- a/packages/views/locales/en/issues.json
+++ b/packages/views/locales/en/issues.json
@@ -478,7 +478,7 @@
     "status_failed": "Failed",
     "status_cancelled": "Cancelled",
     "attribution": {
-      "on_behalf_of": "on behalf of {{name}}",
+      "on_behalf_of": "On behalf of {{name}}",
       "someone": "someone",
       "source_direct_human": "Direct member action",
       "source_delegation": "Delegated from another run",


### PR DESCRIPTION
## What does this PR do?

The English attribution chip (`AttributionBadge`) rendered its label as
lowercase `on behalf of {{name}}`. Because the chip is shown standalone —
not embedded mid-sentence — the leading lowercase word reads like a
truncated fragment. This capitalizes the leading word so the label reads
as a proper standalone phrase: `On behalf of {{name}}`.

## Related Issue

<!-- No tracking issue; trivial copy fix. -->

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Refactor / code improvement (no behavior change)
- [ ] Documentation update
- [ ] Tests (adding or improving test coverage)
- [ ] CI / infrastructure

## Changes Made

- `packages/views/locales/en/issues.json`: capitalize `attribution.on_behalf_of` to `On behalf of {{name}}`.
- `packages/views/issues/components/attribution-badge.test.tsx`: update the rendered-text assertions to the capitalized label.

## How to Test

1. `cd packages/views && pnpm exec vitest run issues/components/attribution-badge.test.tsx`
2. All 10 tests pass.
3. In the app, the attribution chip now reads `On behalf of <name>`.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [ ] I have updated relevant documentation to reflect my changes
- [ ] If I added a new runtime / coding tool / UI tab, I synced the change to **landing copy** and **relevant docs**
- [ ] If this PR touches Chinese product copy, I checked it against conventions.zh.mdx
- [x] I have considered and documented any risks above
- [x] I will address all reviewer comments before requesting merge

## AI Disclosure

**AI tool used:** Claude Code

**Prompt / approach:** Asked Claude Code to capitalize the first letter of the `on_behalf_of` English label and update the corresponding test assertions.
