### PR TITLE
fix(daemon): run Codex unsandboxed on Windows to stop reject-by-policy (MUL-4957)

### DIFF
--- a/server/internal/daemon/daemon.go
+++ b/server/internal/daemon/daemon.go
@@ -4093,17 +4093,18 @@ func (d *Daemon) runTask(ctx context.Context, task Task, provider string, slot i
 		agentEnvOverrides = task.Agent.CustomEnv
 		agentCustomArgs = task.Agent.CustomArgs
 	}
-	// Effective Codex CLI args the task will launch with (profile-fixed +
-	// daemon defaults + per-agent custom_args), mirroring buildCodexArgs'
-	// ordering. Threaded into execenv so the Windows sandbox decision can honor
-	// a `-c windows.sandbox=...` override that never lands in config.toml —
-	// otherwise the daemon would silently downgrade a user's isolation opt-in
-	// (MUL-4957).
+	// Effective Codex CLI args the task will launch with, normalized through the
+	// same agent.NormalizeCodexLaunchArgs pipeline buildCodexArgs uses (shell
+	// unquoting + blocked-flag filtering), preserving its ExtraArgs
+	// (profile-fixed + daemon defaults) vs CustomArgs (per-agent custom_args)
+	// split so the filtering matches launch exactly. Threaded into execenv so
+	// the Windows sandbox decision can honor a `-c windows.sandbox=...` override
+	// that never lands in config.toml — even when it arrives shell-quoted —
+	// instead of silently downgrading a user's isolation opt-in (MUL-4957).
 	var codexSandboxArgs []string
 	if provider == "codex" {
-		codexSandboxArgs = append(codexSandboxArgs, profileFixedArgs...)
-		codexSandboxArgs = append(codexSandboxArgs, defaultArgsForProvider(d.cfg, provider)...)
-		codexSandboxArgs = append(codexSandboxArgs, agentCustomArgs...)
+		extraArgs := append(append([]string{}, profileFixedArgs...), defaultArgsForProvider(d.cfg, provider)...)
+		codexSandboxArgs = agent.NormalizeCodexLaunchArgs(extraArgs, agentCustomArgs, effectiveMcpConfig, d.logger)
 	}
 	// Hermes: resolve the overlay source home through one resolver contract —
 	// the selection parsed from custom_args (agent.ParseHermesProfileArgs) plus

--- a/server/internal/daemon/daemon.go
+++ b/server/internal/daemon/daemon.go
@@ -4093,6 +4093,18 @@ func (d *Daemon) runTask(ctx context.Context, task Task, provider string, slot i
 		agentEnvOverrides = task.Agent.CustomEnv
 		agentCustomArgs = task.Agent.CustomArgs
 	}
+	// Effective Codex CLI args the task will launch with (profile-fixed +
+	// daemon defaults + per-agent custom_args), mirroring buildCodexArgs'
+	// ordering. Threaded into execenv so the Windows sandbox decision can honor
+	// a `-c windows.sandbox=...` override that never lands in config.toml —
+	// otherwise the daemon would silently downgrade a user's isolation opt-in
+	// (MUL-4957).
+	var codexSandboxArgs []string
+	if provider == "codex" {
+		codexSandboxArgs = append(codexSandboxArgs, profileFixedArgs...)
+		codexSandboxArgs = append(codexSandboxArgs, defaultArgsForProvider(d.cfg, provider)...)
+		codexSandboxArgs = append(codexSandboxArgs, agentCustomArgs...)
+	}
 	// Hermes: resolve the overlay source home through one resolver contract —
 	// the selection parsed from custom_args (agent.ParseHermesProfileArgs) plus
 	// the agent's custom_env HERMES_HOME feed execenv.ResolveHermesProfile, which
@@ -4146,6 +4158,7 @@ func (d *Daemon) runTask(ctx context.Context, task Task, provider string, slot i
 			HermesSourceHome:      hermesSourceHome,
 			HermesSourceMustExist: hermesSourceMustExist,
 			HermesEnv:             hermesEnv,
+			CodexCustomArgs:       codexSandboxArgs,
 			Task:                  taskCtx,
 		}, d.logger)
 	}
@@ -4166,6 +4179,7 @@ func (d *Daemon) runTask(ctx context.Context, task Task, provider string, slot i
 			HermesSourceHome:      hermesSourceHome,
 			HermesSourceMustExist: hermesSourceMustExist,
 			HermesEnv:             hermesEnv,
+			CodexCustomArgs:       codexSandboxArgs,
 			Task:                  taskCtx,
 		}
 		if localAssignment != nil {

--- a/server/internal/daemon/execenv/codex_home.go
+++ b/server/internal/daemon/execenv/codex_home.go
@@ -286,7 +286,15 @@ func prepareCodexHomeWithOpts(codexHome string, opts CodexHomeOptions, logger *s
 	policy := codexSandboxPolicyForConfig(opts.GOOS, opts.CodexVersion, winState)
 	policy.WritableRoots = opts.WritableRoots
 	if err := ensureCodexSandboxConfig(configFile, policy, opts.CodexVersion, logger); err != nil {
-		logger.Warn("execenv: codex-home ensure sandbox config failed", "error", err)
+		// The managed block is the authoritative on-disk sandbox policy. If it
+		// can't be written, config.toml keeps whatever it already had — on a
+		// reused home that may be a stale danger-full-access from a prior run —
+		// so the fail-closed policy just computed above would only exist in
+		// memory while the effective config silently stays loose. Abort rather
+		// than launch Codex with an unenforced sandbox: on fresh Prepare this
+		// fails the task; on Reuse the caller leaves env.CodexHome unset, which
+		// configureCodexTaskShellEnvironment then refuses to start (MUL-4957).
+		return fmt.Errorf("ensure codex sandbox config: %w", err)
 	}
 
 	// Disable Codex native multi-agent inside daemon-managed task sessions

--- a/server/internal/daemon/execenv/codex_home.go
+++ b/server/internal/daemon/execenv/codex_home.go
@@ -169,11 +169,16 @@ func prepareCodexHomeWithOpts(codexHome string, opts CodexHomeOptions, logger *s
 	}
 
 	// Write a daemon-managed sandbox block into config.toml. On macOS we may
-	// need to fall back to danger-full-access because of openai/codex#10390;
-	// see codex_sandbox.go for the full rationale.
-	policy := codexSandboxPolicyFor(opts.GOOS, opts.CodexVersion)
+	// need to fall back to danger-full-access because of openai/codex#10390,
+	// and on Windows the daemon defaults to danger-full-access unless the user
+	// opted into a native windows.sandbox; see codex_sandbox.go for the full
+	// rationale. Read the copied+sanitized config first so the policy can honor
+	// an explicit user windows.sandbox instead of overriding it.
+	configFile := filepath.Join(codexHome, "config.toml")
+	existingConfig, _ := os.ReadFile(configFile)
+	policy := codexSandboxPolicyForConfig(opts.GOOS, opts.CodexVersion, string(existingConfig))
 	policy.WritableRoots = opts.WritableRoots
-	if err := ensureCodexSandboxConfig(filepath.Join(codexHome, "config.toml"), policy, opts.CodexVersion, logger); err != nil {
+	if err := ensureCodexSandboxConfig(configFile, policy, opts.CodexVersion, logger); err != nil {
 		logger.Warn("execenv: codex-home ensure sandbox config failed", "error", err)
 	}
 

--- a/server/internal/daemon/execenv/codex_home.go
+++ b/server/internal/daemon/execenv/codex_home.go
@@ -99,32 +99,60 @@ func prepareCodexHome(codexHome string, logger *slog.Logger) error {
 	return prepareCodexHomeWithOpts(codexHome, CodexHomeOptions{GOOS: "linux"}, logger)
 }
 
+// sharedConfigPresence is the tri-state existence of the shared
+// ~/.codex/config.toml copy source. It is three-valued so a stat that fails for
+// a reason other than "not found" (permission/IO) never masquerades as a
+// confident "the user has no config" — which would let the daemon loosen to
+// danger-full-access on doubt. See resolveWindowsSandboxState (MUL-4957).
+type sharedConfigPresence int
+
+const (
+	// sharedConfigAbsent: the shared config.toml is confidently not present
+	// (os.IsNotExist), so an absent per-task copy is a genuine "unconfigured".
+	sharedConfigAbsent sharedConfigPresence = iota
+	// sharedConfigPresent: the shared config.toml exists.
+	sharedConfigPresent
+	// sharedConfigUndecidable: the stat failed for a reason other than
+	// not-found; the daemon cannot tell whether the user has a config.
+	sharedConfigUndecidable
+)
+
+// statSharedCodexConfig classifies the shared ~/.codex/config.toml (the copy
+// source) into the tri-state above, distinguishing a genuine absence from a
+// stat that could not complete.
+func statSharedCodexConfig(sharedHome string) sharedConfigPresence {
+	if sharedHome == "" {
+		return sharedConfigAbsent
+	}
+	_, err := os.Stat(filepath.Join(sharedHome, "config.toml"))
+	switch {
+	case err == nil:
+		return sharedConfigPresent
+	case os.IsNotExist(err):
+		return sharedConfigAbsent
+	default:
+		return sharedConfigUndecidable
+	}
+}
+
 // resolveWindowsSandboxState determines, for a Windows task, whether a native
 // Codex sandbox is configured — across the per-task config.toml and the
 // effective custom args — failing closed (Undecidable) when it cannot tell.
 //
-// The distinction that matters for MUL-4957's first must-fix: an absent
-// per-task config is a genuine "no sandbox configured" only when the user also
-// has no shared ~/.codex/config.toml. If a shared config exists but the
-// per-task copy/read failed, the daemon cannot read the user's intent and must
-// NOT loosen to danger-full-access — it fails closed and logs the condition.
-func resolveWindowsSandboxState(configFile, sharedHome string, customArgs []string, logger *slog.Logger) windowsSandboxConfig {
-	configState := windowsSandboxAbsent
-	data, err := os.ReadFile(configFile)
-	switch {
-	case err == nil:
-		configState = windowsSandboxFromConfig(string(data))
-	case os.IsNotExist(err):
-		// No per-task config. Genuinely unconfigured only if there is no shared
-		// source config either; otherwise the copy failed → undecidable.
-		if sharedCodexConfigExists(sharedHome) {
-			configState = windowsSandboxUndecidable
-		}
-	default:
-		// A read error (permission/IO) on a file the daemon just wrote.
-		configState = windowsSandboxUndecidable
-	}
-
+// Two signals it does NOT gather itself (the caller does) keep the fail-closed
+// logic unit-testable without faulting the filesystem, and close MUL-4957's
+// round-3 must-fix where a failed sync could be misread as "unconfigured":
+//
+//   - configSyncErr: the error (if any) from syncing the shared config.toml
+//     into this per-task home. Non-nil means the per-task config.toml is
+//     unreliable — stale from a prior run, or never (re)written — so neither its
+//     contents nor its absence reflect the user's intent. Fail closed.
+//   - sharedPresence: whether the shared config.toml source exists. Only a
+//     confident absence lets an absent per-task copy count as genuinely
+//     unconfigured; a present-or-undecidable source whose per-task copy is
+//     missing means the copy silently did not land, so fail closed.
+func resolveWindowsSandboxState(configFile string, configSyncErr error, sharedPresence sharedConfigPresence, customArgs []string, logger *slog.Logger) windowsSandboxConfig {
+	configState := classifyPerTaskWindowsSandbox(configFile, configSyncErr, sharedPresence)
 	state := resolveWindowsSandbox(configState, windowsSandboxFromCustomArgs(customArgs))
 	if state == windowsSandboxUndecidable && logger != nil {
 		logger.Error("codex sandbox: cannot determine Windows native sandbox config; keeping workspace-write and refusing to loosen to danger-full-access",
@@ -133,14 +161,32 @@ func resolveWindowsSandboxState(configFile, sharedHome string, customArgs []stri
 	return state
 }
 
-// sharedCodexConfigExists reports whether the shared ~/.codex/config.toml (the
-// copy source) exists — used to tell "user has no config" from "copy failed".
-func sharedCodexConfigExists(sharedHome string) bool {
-	if sharedHome == "" {
-		return false
+// classifyPerTaskWindowsSandbox inspects the per-task config.toml given the
+// outcome of syncing it from the shared source, failing closed whenever the
+// file cannot be trusted or read.
+func classifyPerTaskWindowsSandbox(configFile string, configSyncErr error, sharedPresence sharedConfigPresence) windowsSandboxConfig {
+	// A failed shared→per-task sync leaves config.toml stale or missing; neither
+	// its contents nor its absence reflect the user's intent. Fail closed.
+	if configSyncErr != nil {
+		return windowsSandboxUndecidable
 	}
-	_, err := os.Stat(filepath.Join(sharedHome, "config.toml"))
-	return err == nil
+	data, err := os.ReadFile(configFile)
+	switch {
+	case err == nil:
+		return windowsSandboxFromConfig(string(data))
+	case os.IsNotExist(err):
+		// Sync succeeded and the per-task config is absent. That is a genuine
+		// "no config" only when the shared source is confidently absent too; a
+		// present or undecidable source whose copy is missing means the copy
+		// did not land → fail closed rather than loosen.
+		if sharedPresence == sharedConfigAbsent {
+			return windowsSandboxAbsent
+		}
+		return windowsSandboxUndecidable
+	default:
+		// A read error (permission/IO) on a file the daemon just wrote.
+		return windowsSandboxUndecidable
+	}
 }
 
 // prepareCodexHomeWithOpts creates a per-task CODEX_HOME directory and seeds
@@ -180,12 +226,19 @@ func prepareCodexHomeWithOpts(codexHome string, opts CodexHomeOptions, logger *s
 	// into a stale local copy.
 	logCodexAuthState(filepath.Join(codexHome, "auth.json"), logger)
 
-	// Sync isolated files from the shared source.
+	// Sync isolated files from the shared source. Track the config.toml sync
+	// outcome specifically: on Windows a failed sync makes the per-task config
+	// untrustworthy, so the sandbox decision must fail closed rather than read a
+	// stale or absent copy as "unconfigured" and loosen (MUL-4957).
+	var configSyncErr error
 	for _, name := range codexCopiedFiles {
 		src := filepath.Join(sharedHome, name)
 		dst := filepath.Join(codexHome, name)
 		if err := syncCopiedFile(src, dst); err != nil {
 			logger.Warn("execenv: codex-home sync failed", "file", name, "error", err)
+			if name == "config.toml" {
+				configSyncErr = err
+			}
 		}
 	}
 	// Drop `[[skills.config]]` entries inherited from the user's
@@ -228,7 +281,7 @@ func prepareCodexHomeWithOpts(codexHome string, opts CodexHomeOptions, logger *s
 	configFile := filepath.Join(codexHome, "config.toml")
 	winState := windowsSandboxAbsent
 	if resolveGOOS(opts.GOOS) == "windows" {
-		winState = resolveWindowsSandboxState(configFile, sharedHome, opts.CodexCustomArgs, logger)
+		winState = resolveWindowsSandboxState(configFile, configSyncErr, statSharedCodexConfig(sharedHome), opts.CodexCustomArgs, logger)
 	}
 	policy := codexSandboxPolicyForConfig(opts.GOOS, opts.CodexVersion, winState)
 	policy.WritableRoots = opts.WritableRoots

--- a/server/internal/daemon/execenv/codex_home.go
+++ b/server/internal/daemon/execenv/codex_home.go
@@ -83,6 +83,12 @@ type CodexHomeOptions struct {
 	// Only meaningful when the policy resolves to workspace-write; ignored on
 	// darwin danger-full-access. See task_home.go and MUL-4856.
 	WritableRoots []string
+	// CodexCustomArgs are the effective Codex CLI args this task will launch
+	// with (daemon defaults + profile-fixed + per-agent custom_args). Only the
+	// Windows sandbox decision reads them, to honor a `-c windows.sandbox=...`
+	// override that never lands in config.toml. See resolveWindowsSandboxState
+	// and MUL-4957.
+	CodexCustomArgs []string
 }
 
 // prepareCodexHome is a thin wrapper around prepareCodexHomeWithOpts kept for
@@ -91,6 +97,50 @@ type CodexHomeOptions struct {
 // works correctly.
 func prepareCodexHome(codexHome string, logger *slog.Logger) error {
 	return prepareCodexHomeWithOpts(codexHome, CodexHomeOptions{GOOS: "linux"}, logger)
+}
+
+// resolveWindowsSandboxState determines, for a Windows task, whether a native
+// Codex sandbox is configured — across the per-task config.toml and the
+// effective custom args — failing closed (Undecidable) when it cannot tell.
+//
+// The distinction that matters for MUL-4957's first must-fix: an absent
+// per-task config is a genuine "no sandbox configured" only when the user also
+// has no shared ~/.codex/config.toml. If a shared config exists but the
+// per-task copy/read failed, the daemon cannot read the user's intent and must
+// NOT loosen to danger-full-access — it fails closed and logs the condition.
+func resolveWindowsSandboxState(configFile, sharedHome string, customArgs []string, logger *slog.Logger) windowsSandboxConfig {
+	configState := windowsSandboxAbsent
+	data, err := os.ReadFile(configFile)
+	switch {
+	case err == nil:
+		configState = windowsSandboxFromConfig(string(data))
+	case os.IsNotExist(err):
+		// No per-task config. Genuinely unconfigured only if there is no shared
+		// source config either; otherwise the copy failed → undecidable.
+		if sharedCodexConfigExists(sharedHome) {
+			configState = windowsSandboxUndecidable
+		}
+	default:
+		// A read error (permission/IO) on a file the daemon just wrote.
+		configState = windowsSandboxUndecidable
+	}
+
+	state := resolveWindowsSandbox(configState, windowsSandboxFromCustomArgs(customArgs))
+	if state == windowsSandboxUndecidable && logger != nil {
+		logger.Error("codex sandbox: cannot determine Windows native sandbox config; keeping workspace-write and refusing to loosen to danger-full-access",
+			"config_file", configFile)
+	}
+	return state
+}
+
+// sharedCodexConfigExists reports whether the shared ~/.codex/config.toml (the
+// copy source) exists — used to tell "user has no config" from "copy failed".
+func sharedCodexConfigExists(sharedHome string) bool {
+	if sharedHome == "" {
+		return false
+	}
+	_, err := os.Stat(filepath.Join(sharedHome, "config.toml"))
+	return err == nil
 }
 
 // prepareCodexHomeWithOpts creates a per-task CODEX_HOME directory and seeds
@@ -172,11 +222,15 @@ func prepareCodexHomeWithOpts(codexHome string, opts CodexHomeOptions, logger *s
 	// need to fall back to danger-full-access because of openai/codex#10390,
 	// and on Windows the daemon defaults to danger-full-access unless the user
 	// opted into a native windows.sandbox; see codex_sandbox.go for the full
-	// rationale. Read the copied+sanitized config first so the policy can honor
-	// an explicit user windows.sandbox instead of overriding it.
+	// rationale. On Windows, resolve the native-sandbox state across the copied
+	// config and the effective custom args so an explicit user opt-in is honored
+	// and an undecidable config fails closed instead of loosening.
 	configFile := filepath.Join(codexHome, "config.toml")
-	existingConfig, _ := os.ReadFile(configFile)
-	policy := codexSandboxPolicyForConfig(opts.GOOS, opts.CodexVersion, string(existingConfig))
+	winState := windowsSandboxAbsent
+	if resolveGOOS(opts.GOOS) == "windows" {
+		winState = resolveWindowsSandboxState(configFile, sharedHome, opts.CodexCustomArgs, logger)
+	}
+	policy := codexSandboxPolicyForConfig(opts.GOOS, opts.CodexVersion, winState)
 	policy.WritableRoots = opts.WritableRoots
 	if err := ensureCodexSandboxConfig(configFile, policy, opts.CodexVersion, logger); err != nil {
 		logger.Warn("execenv: codex-home ensure sandbox config failed", "error", err)

--- a/server/internal/daemon/execenv/codex_sandbox.go
+++ b/server/internal/daemon/execenv/codex_sandbox.go
@@ -49,13 +49,24 @@ type codexSandboxPolicy struct {
 	WritableRoots []string
 	// Reason is a short human-readable label used in warn-level logs.
 	Reason string
+	// Hint is an optional, actionable remediation surfaced in warn-level logs
+	// when Mode is danger-full-access. It is empty when no operator action can
+	// restore a real sandbox (e.g. Windows has no filesystem sandbox backend at
+	// all), so the log omits the hint instead of showing an irrelevant one.
+	Hint string
 }
 
 // codexSandboxPolicyFor picks the right policy for the given platform and
 // detected Codex CLI version.
 //
-//   - Non-darwin: always workspace-write with network access (Landlock is not
-//     affected by the macOS Seatbelt bug).
+//   - Linux: workspace-write with network access. Landlock enforces the
+//     filesystem sandbox and is not affected by the macOS Seatbelt bug.
+//   - Windows: danger-full-access. Windows has no filesystem sandbox backend
+//     the daemon configures (see task_home.go), so a workspace-write policy is
+//     unenforceable. Worse than no sandbox, it pushes Codex into rejecting
+//     non-safe mutation commands "by policy" (e.g. `multica issue create`)
+//     instead of running them. Mirror the macOS fallback and run unsandboxed.
+//     See MUL-4957.
 //   - darwin with a version at or above CodexDarwinNetworkAccessFixedVersion:
 //     workspace-write with network access (upstream bug fixed).
 //   - darwin otherwise (including when the version is unknown): fall back to
@@ -63,6 +74,19 @@ type codexSandboxPolicy struct {
 func codexSandboxPolicyFor(goos, detectedVersion string) codexSandboxPolicy {
 	if goos == "" {
 		goos = runtime.GOOS
+	}
+	if goos == "windows" {
+		// Windows has no Landlock/Seatbelt-equivalent sandbox the daemon can
+		// configure (see task_home.go), so workspace-write cannot be enforced.
+		// An unenforceable sandbox is worse than none: Codex can neither run a
+		// non-safe command inside a sandbox nor, under approval_policy = "never",
+		// escalate it to the daemon's auto-approver, so it rejects the command
+		// "by policy" and `multica issue create` fails. Run unsandboxed, matching
+		// the macOS fallback. See MUL-4957.
+		return codexSandboxPolicy{
+			Mode:   "danger-full-access",
+			Reason: "codex on windows: no filesystem sandbox backend; workspace-write is unenforceable and forces reject-by-policy (MUL-4957)",
+		}
 	}
 	if goos != "darwin" {
 		return codexSandboxPolicy{
@@ -86,6 +110,7 @@ func codexSandboxPolicyFor(goos, detectedVersion string) codexSandboxPolicy {
 		Mode:          "danger-full-access",
 		NetworkAccess: false,
 		Reason:        reason,
+		Hint:          codexUpgradeHint(),
 	}
 }
 
@@ -262,12 +287,15 @@ func ensureCodexSandboxConfig(configPath string, policy codexSandboxPolicy, dete
 		if version == "" {
 			version = "unknown"
 		}
-		logger.Warn("codex sandbox: falling back to danger-full-access on macOS",
+		attrs := []any{
 			"reason", policy.Reason,
 			"codex_version", version,
-			"hint", codexUpgradeHint(),
 			"config_path", configPath,
-		)
+		}
+		if policy.Hint != "" {
+			attrs = append(attrs, "hint", policy.Hint)
+		}
+		logger.Warn("codex sandbox: running unsandboxed with danger-full-access", attrs...)
 	}
 
 	if err := os.WriteFile(configPath, []byte(updated), 0o644); err != nil {

--- a/server/internal/daemon/execenv/codex_sandbox.go
+++ b/server/internal/daemon/execenv/codex_sandbox.go
@@ -8,6 +8,8 @@ import (
 	"runtime"
 	"strconv"
 	"strings"
+
+	"github.com/pelletier/go-toml/v2"
 )
 
 // Background
@@ -50,23 +52,34 @@ type codexSandboxPolicy struct {
 	// Reason is a short human-readable label used in warn-level logs.
 	Reason string
 	// Hint is an optional, actionable remediation surfaced in warn-level logs
-	// when Mode is danger-full-access. It is empty when no operator action can
-	// restore a real sandbox (e.g. Windows has no filesystem sandbox backend at
-	// all), so the log omits the hint instead of showing an irrelevant one.
+	// when Mode is danger-full-access. It is empty when there is no generic
+	// action to surface (e.g. the Windows compatibility fallback, where
+	// enabling Codex's native sandbox is deferred follow-up work rather than a
+	// version bump), so the log omits the hint instead of showing an irrelevant
+	// one.
 	Hint string
 }
 
-// codexSandboxPolicyFor picks the right policy for the given platform and
-// detected Codex CLI version.
+// codexSandboxPolicyFor picks the default policy for the given platform and
+// detected Codex CLI version. It is the platform baseline; per-task user config
+// can refine it (see codexSandboxPolicyForConfig).
 //
 //   - Linux: workspace-write with network access. Landlock enforces the
 //     filesystem sandbox and is not affected by the macOS Seatbelt bug.
-//   - Windows: danger-full-access. Windows has no filesystem sandbox backend
-//     the daemon configures (see task_home.go), so a workspace-write policy is
-//     unenforceable. Worse than no sandbox, it pushes Codex into rejecting
-//     non-safe mutation commands "by policy" (e.g. `multica issue create`)
-//     instead of running them. Mirror the macOS fallback and run unsandboxed.
-//     See MUL-4957.
+//   - Windows: danger-full-access, as a deliberate compatibility choice.
+//     Codex 0.144.5 does ship a native Windows sandbox (windows.sandbox =
+//     "unelevated" via a Restricted Token, or "elevated"), but it is still
+//     experimental with open upstream reliability bugs (e.g. openai/codex
+//     #18451, #32314, #24098), so the daemon does not enable it by default.
+//     When no native windows.sandbox is configured, Codex cannot enforce
+//     workspace-write on Windows (it downgrades to read-only) and then rejects
+//     non-safe mutation commands "by policy" — e.g. `multica issue create`
+//     fails — because under approval_policy = "never" the request never reaches
+//     the daemon's auto-approver. danger-full-access sidesteps that. Enabling
+//     the native sandbox is tracked as separate follow-up work. See MUL-4957.
+//     A user who has explicitly opted into windows.sandbox keeps workspace-write
+//     instead of this fallback; that refinement lives in
+//     codexSandboxPolicyForConfig.
 //   - darwin with a version at or above CodexDarwinNetworkAccessFixedVersion:
 //     workspace-write with network access (upstream bug fixed).
 //   - darwin otherwise (including when the version is unknown): fall back to
@@ -76,16 +89,9 @@ func codexSandboxPolicyFor(goos, detectedVersion string) codexSandboxPolicy {
 		goos = runtime.GOOS
 	}
 	if goos == "windows" {
-		// Windows has no Landlock/Seatbelt-equivalent sandbox the daemon can
-		// configure (see task_home.go), so workspace-write cannot be enforced.
-		// An unenforceable sandbox is worse than none: Codex can neither run a
-		// non-safe command inside a sandbox nor, under approval_policy = "never",
-		// escalate it to the daemon's auto-approver, so it rejects the command
-		// "by policy" and `multica issue create` fails. Run unsandboxed, matching
-		// the macOS fallback. See MUL-4957.
 		return codexSandboxPolicy{
 			Mode:   "danger-full-access",
-			Reason: "codex on windows: no filesystem sandbox backend; workspace-write is unenforceable and forces reject-by-policy (MUL-4957)",
+			Reason: "codex on windows: compatibility fallback; no native windows.sandbox configured, so workspace-write cannot be enforced (MUL-4957)",
 		}
 	}
 	if goos != "darwin" {
@@ -111,6 +117,56 @@ func codexSandboxPolicyFor(goos, detectedVersion string) codexSandboxPolicy {
 		NetworkAccess: false,
 		Reason:        reason,
 		Hint:          codexUpgradeHint(),
+	}
+}
+
+// codexSandboxPolicyForConfig returns the platform default from
+// codexSandboxPolicyFor, refined by the user's existing per-task config.toml.
+//
+// It only differs from the default on Windows: when the user has explicitly
+// opted into a native Codex sandbox (windows.sandbox = "unelevated" |
+// "elevated"), the daemon keeps workspace-write so Codex enforces task
+// isolation with the user's chosen backend, instead of overriding their choice
+// with the danger-full-access compatibility fallback. A user who asked for
+// isolation must not have it silently disabled. See MUL-4957.
+//
+// This is intentionally the branch point for the eventual native-sandbox
+// rollout: flipping the Windows default later means writing windows.sandbox
+// ourselves and defaulting this predicate to true, not restructuring callers.
+func codexSandboxPolicyForConfig(goos, detectedVersion, existingConfig string) codexSandboxPolicy {
+	if goos == "" {
+		goos = runtime.GOOS
+	}
+	if goos == "windows" && userConfiguredWindowsSandbox(existingConfig) {
+		return codexSandboxPolicy{
+			Mode:          "workspace-write",
+			NetworkAccess: true,
+			Reason:        "codex on windows: user explicitly configured windows.sandbox; keeping workspace-write so Codex enforces task isolation",
+		}
+	}
+	return codexSandboxPolicyFor(goos, detectedVersion)
+}
+
+// userConfiguredWindowsSandbox reports whether the given config.toml content
+// explicitly selects a native Codex Windows sandbox backend
+// (windows.sandbox = "unelevated" | "elevated"). Any other value, an absent
+// key, or unparseable TOML counts as "not configured", so the caller falls back
+// to the safe danger-full-access compatibility default rather than assuming an
+// enforceable sandbox exists.
+func userConfiguredWindowsSandbox(config string) bool {
+	var probe struct {
+		Windows struct {
+			Sandbox string `toml:"sandbox"`
+		} `toml:"windows"`
+	}
+	if err := toml.Unmarshal([]byte(config), &probe); err != nil {
+		return false
+	}
+	switch strings.ToLower(strings.TrimSpace(probe.Windows.Sandbox)) {
+	case "unelevated", "elevated":
+		return true
+	default:
+		return false
 	}
 }
 

--- a/server/internal/daemon/execenv/codex_sandbox.go
+++ b/server/internal/daemon/execenv/codex_sandbox.go
@@ -60,6 +60,15 @@ type codexSandboxPolicy struct {
 	Hint string
 }
 
+// resolveGOOS returns goos, or runtime.GOOS when goos is empty. Callers pass an
+// explicit goos in tests; production leaves it empty to use the host platform.
+func resolveGOOS(goos string) string {
+	if goos == "" {
+		return runtime.GOOS
+	}
+	return goos
+}
+
 // codexSandboxPolicyFor picks the default policy for the given platform and
 // detected Codex CLI version. It is the platform baseline; per-task user config
 // can refine it (see codexSandboxPolicyForConfig).
@@ -67,19 +76,19 @@ type codexSandboxPolicy struct {
 //   - Linux: workspace-write with network access. Landlock enforces the
 //     filesystem sandbox and is not affected by the macOS Seatbelt bug.
 //   - Windows: danger-full-access, as a deliberate compatibility choice.
-//     Codex 0.144.5 does ship a native Windows sandbox (windows.sandbox =
-//     "unelevated" via a Restricted Token, or "elevated"), but it is still
-//     experimental with open upstream reliability bugs (e.g. openai/codex
-//     #18451, #32314, #24098), so the daemon does not enable it by default.
-//     When no native windows.sandbox is configured, Codex cannot enforce
-//     workspace-write on Windows (it downgrades to read-only) and then rejects
-//     non-safe mutation commands "by policy" — e.g. `multica issue create`
-//     fails — because under approval_policy = "never" the request never reaches
-//     the daemon's auto-approver. danger-full-access sidesteps that. Enabling
-//     the native sandbox is tracked as separate follow-up work. See MUL-4957.
-//     A user who has explicitly opted into windows.sandbox keeps workspace-write
-//     instead of this fallback; that refinement lives in
-//     codexSandboxPolicyForConfig.
+//     Codex ships a native Windows sandbox (windows.sandbox = "unelevated" via
+//     a Restricted Token, or "elevated"), but it is still experimental with
+//     known reliability limitations, so the daemon does not enable it by
+//     default. When no native windows.sandbox is configured, Codex cannot
+//     enforce workspace-write on Windows (it downgrades to read-only) and then
+//     rejects non-safe mutation commands "by policy" — e.g. `multica issue
+//     create` fails — because under approval_policy = "never" the request never
+//     reaches the daemon's auto-approver. danger-full-access sidesteps that.
+//     Enabling the native sandbox is tracked as separate follow-up work. See
+//     MUL-4957. A user who has opted into windows.sandbox (via config.toml or a
+//     `-c` custom arg) keeps workspace-write instead of this fallback, and an
+//     undecidable config fails closed; that logic lives in
+//     codexSandboxPolicyForConfig / resolveWindowsSandboxState.
 //   - darwin with a version at or above CodexDarwinNetworkAccessFixedVersion:
 //     workspace-write with network access (upstream bug fixed).
 //   - darwin otherwise (including when the version is unknown): fall back to
@@ -120,54 +129,168 @@ func codexSandboxPolicyFor(goos, detectedVersion string) codexSandboxPolicy {
 	}
 }
 
+// windowsSandboxConfig is the tri-state of a native Codex Windows sandbox
+// selection. It is three-valued (not a bool) so an undecidable config fails
+// closed — the daemon never loosens to danger-full-access when it cannot
+// confirm the user's intent. See MUL-4957.
+type windowsSandboxConfig int
+
+const (
+	// windowsSandboxAbsent: confidently no native sandbox is selected anywhere,
+	// so the danger-full-access compatibility fallback is safe to apply.
+	windowsSandboxAbsent windowsSandboxConfig = iota
+	// windowsSandboxNative: a valid windows.sandbox = "unelevated"|"elevated"
+	// is selected, so keep workspace-write and let Codex enforce isolation.
+	windowsSandboxNative
+	// windowsSandboxUndecidable: the config could not be read/parsed, or holds
+	// a windows.sandbox value Codex does not accept. The daemon cannot tell
+	// whether the user asked for isolation, so it must NOT loosen — fail closed.
+	windowsSandboxUndecidable
+)
+
 // codexSandboxPolicyForConfig returns the platform default from
-// codexSandboxPolicyFor, refined by the user's existing per-task config.toml.
-//
-// It only differs from the default on Windows: when the user has explicitly
-// opted into a native Codex sandbox (windows.sandbox = "unelevated" |
-// "elevated"), the daemon keeps workspace-write so Codex enforces task
-// isolation with the user's chosen backend, instead of overriding their choice
-// with the danger-full-access compatibility fallback. A user who asked for
-// isolation must not have it silently disabled. See MUL-4957.
+// codexSandboxPolicyFor for linux/darwin. On Windows it applies the resolved
+// native-sandbox state (see resolveWindowsSandboxState): a user who opted into
+// windows.sandbox keeps workspace-write, an undecidable config fails closed to
+// workspace-write, and only a confidently absent sandbox gets the
+// danger-full-access compatibility fallback. See MUL-4957.
 //
 // This is intentionally the branch point for the eventual native-sandbox
 // rollout: flipping the Windows default later means writing windows.sandbox
-// ourselves and defaulting this predicate to true, not restructuring callers.
-func codexSandboxPolicyForConfig(goos, detectedVersion, existingConfig string) codexSandboxPolicy {
+// ourselves and defaulting winState to native, not restructuring callers.
+func codexSandboxPolicyForConfig(goos, detectedVersion string, winState windowsSandboxConfig) codexSandboxPolicy {
 	if goos == "" {
 		goos = runtime.GOOS
 	}
-	if goos == "windows" && userConfiguredWindowsSandbox(existingConfig) {
-		return codexSandboxPolicy{
-			Mode:          "workspace-write",
-			NetworkAccess: true,
-			Reason:        "codex on windows: user explicitly configured windows.sandbox; keeping workspace-write so Codex enforces task isolation",
-		}
+	if goos == "windows" {
+		return codexSandboxPolicyForWindows(winState)
 	}
 	return codexSandboxPolicyFor(goos, detectedVersion)
 }
 
-// userConfiguredWindowsSandbox reports whether the given config.toml content
-// explicitly selects a native Codex Windows sandbox backend
-// (windows.sandbox = "unelevated" | "elevated"). Any other value, an absent
-// key, or unparseable TOML counts as "not configured", so the caller falls back
-// to the safe danger-full-access compatibility default rather than assuming an
-// enforceable sandbox exists.
-func userConfiguredWindowsSandbox(config string) bool {
+// codexSandboxPolicyForWindows maps a resolved native-sandbox state to a
+// policy. Native and Undecidable both keep workspace-write (Undecidable is the
+// fail-closed case — it never loosens on doubt); only a confidently absent
+// native sandbox gets the danger-full-access compatibility fallback.
+func codexSandboxPolicyForWindows(state windowsSandboxConfig) codexSandboxPolicy {
+	switch state {
+	case windowsSandboxNative:
+		return codexSandboxPolicy{
+			Mode:          "workspace-write",
+			NetworkAccess: true,
+			Reason:        "codex on windows: native windows.sandbox configured; keeping workspace-write so Codex enforces task isolation",
+		}
+	case windowsSandboxUndecidable:
+		return codexSandboxPolicy{
+			Mode:          "workspace-write",
+			NetworkAccess: true,
+			Reason:        "codex on windows: windows.sandbox config undecidable (unreadable/unparseable/invalid); failing closed to workspace-write rather than loosening (MUL-4957)",
+		}
+	default: // windowsSandboxAbsent
+		return codexSandboxPolicy{
+			Mode:   "danger-full-access",
+			Reason: "codex on windows: compatibility fallback; no native windows.sandbox configured (MUL-4957)",
+		}
+	}
+}
+
+// windowsSandboxFromConfig classifies the windows.sandbox selection in a
+// config.toml body. Codex accepts only the exact-lowercase variants
+// "unelevated"/"elevated" and refuses to load a config with any other value, so
+// anything else present is treated as undecidable (fail closed) rather than a
+// safe "absent". Unparseable TOML is likewise undecidable — Codex would reject
+// the same file. An absent windows.sandbox key is a genuine "absent".
+func windowsSandboxFromConfig(config string) windowsSandboxConfig {
 	var probe struct {
 		Windows struct {
 			Sandbox string `toml:"sandbox"`
 		} `toml:"windows"`
 	}
 	if err := toml.Unmarshal([]byte(config), &probe); err != nil {
-		return false
+		return windowsSandboxUndecidable
 	}
-	switch strings.ToLower(strings.TrimSpace(probe.Windows.Sandbox)) {
+	return classifyWindowsSandboxValue(probe.Windows.Sandbox)
+}
+
+// codexConfigOverrideValueRe matches the value token of a Codex `-c` /
+// `--config` windows.sandbox override, e.g. `windows.sandbox = "unelevated"`.
+// It tolerates whitespace around the dotted key and the `=`, matching Codex's
+// own lenient `-c` parsing.
+var codexWindowsSandboxOverrideRe = regexp.MustCompile(`^\s*windows\s*\.\s*sandbox\s*=`)
+
+// windowsSandboxFromCustomArgs classifies a native Windows sandbox selection
+// passed via Codex `-c windows.sandbox=...` / `--config windows.sandbox=...`
+// args. These never land in config.toml (they stay in argv and are applied on
+// top of it), so config-only detection would miss them — the MUL-4957 review's
+// second must-fix. Mirrors the override-parsing shape in server/pkg/agent's
+// buildCodexArgs: inline (`-c=windows.sandbox=x`) and two-token
+// (`-c windows.sandbox=x`) forms, last occurrence winning (Codex is last-wins).
+func windowsSandboxFromCustomArgs(args []string) windowsSandboxConfig {
+	state := windowsSandboxAbsent
+	for i := 0; i < len(args); i++ {
+		arg := args[i]
+		flag := arg
+		value := ""
+		hasInlineValue := false
+		if idx := strings.Index(arg, "="); idx > 0 {
+			flag = arg[:idx]
+			value = arg[idx+1:]
+			hasInlineValue = true
+		}
+		if flag != "-c" && flag != "--config" {
+			continue
+		}
+		if !hasInlineValue {
+			if i+1 >= len(args) {
+				continue
+			}
+			i++
+			value = args[i]
+		}
+		if !codexWindowsSandboxOverrideRe.MatchString(value) {
+			continue
+		}
+		// A windows.sandbox override token: take the part after its first `=`.
+		if eq := strings.Index(value, "="); eq >= 0 {
+			state = classifyWindowsSandboxValue(value[eq+1:])
+		}
+	}
+	return state
+}
+
+// classifyWindowsSandboxValue maps a raw windows.sandbox value (from config.toml
+// or a `-c` arg, possibly surrounded by whitespace/quotes) to a tri-state. Only
+// the exact-lowercase variants Codex accepts count as native; a present but
+// unaccepted value is undecidable (Codex would refuse the config); an empty
+// value is absent.
+func classifyWindowsSandboxValue(raw string) windowsSandboxConfig {
+	v := strings.TrimSpace(raw)
+	v = strings.Trim(v, `"'`)
+	v = strings.TrimSpace(v)
+	switch v {
+	case "":
+		return windowsSandboxAbsent
 	case "unelevated", "elevated":
-		return true
+		return windowsSandboxNative
 	default:
-		return false
+		return windowsSandboxUndecidable
 	}
+}
+
+// resolveWindowsSandbox folds per-layer states into one. Undecidable wins over
+// everything (any broken/ambiguous layer means fail closed), then Native over
+// Absent (an opt-in in any layer keeps isolation).
+func resolveWindowsSandbox(states ...windowsSandboxConfig) windowsSandboxConfig {
+	result := windowsSandboxAbsent
+	for _, s := range states {
+		if s == windowsSandboxUndecidable {
+			return windowsSandboxUndecidable
+		}
+		if s == windowsSandboxNative {
+			result = windowsSandboxNative
+		}
+	}
+	return result
 }
 
 // codexDarwinNetworkAccessFixed returns true if the given detected version is

--- a/server/internal/daemon/execenv/codex_windows_sandbox_integration_test.go
+++ b/server/internal/daemon/execenv/codex_windows_sandbox_integration_test.go
@@ -1,0 +1,49 @@
+package execenv
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/multica-ai/multica/server/pkg/agent"
+)
+
+// TestWindowsSandboxHonorsShellQuotedCustomArg is the MUL-4957 round-3 must-fix
+// 2 integration test. A `-c windows.sandbox=...` opt-in supplied shell-quoted
+// (as users commonly type custom_args) reaches Codex normalized by
+// agent.NormalizeCodexLaunchArgs; the Windows sandbox decision must consume the
+// SAME normalized args, not the raw tokens, or the two drift and the user's
+// isolation opt-in is silently downgraded. This locks the raw-args →
+// normalized → policy chain end to end across the two packages so they cannot
+// diverge again.
+func TestWindowsSandboxHonorsShellQuotedCustomArg(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name string
+		raw  []string
+	}{
+		{"both tokens single-quoted", []string{"'-c'", "'windows.sandbox=unelevated'"}},
+		{"value double-quoted", []string{"-c", `"windows.sandbox=elevated"`}},
+		{"inline flag single-quoted", []string{"'-c=windows.sandbox=unelevated'"}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			// The raw tokens still carry shell quotes, so scanning them directly
+			// must NOT recognize the opt-in — this is the drift the bug was.
+			if got := windowsSandboxFromCustomArgs(tc.raw); got == windowsSandboxNative {
+				t.Fatalf("raw shell-quoted args unexpectedly recognized without normalization: %v", tc.raw)
+			}
+			// After the daemon's normalization the same args resolve to native,
+			// so the policy keeps workspace-write instead of loosening.
+			norm := agent.NormalizeCodexLaunchArgs(nil, tc.raw, nil, testLogger())
+			missing := filepath.Join(t.TempDir(), "config.toml")
+			state := resolveWindowsSandboxState(missing, nil, sharedConfigAbsent, norm, testLogger())
+			if state != windowsSandboxNative {
+				t.Fatalf("normalized %v -> state %v, want native", norm, state)
+			}
+			if p := codexSandboxPolicyForWindows(state); p.Mode != "workspace-write" {
+				t.Fatalf("policy mode = %q, want workspace-write (isolation preserved)", p.Mode)
+			}
+		})
+	}
+}

--- a/server/internal/daemon/execenv/execenv.go
+++ b/server/internal/daemon/execenv/execenv.go
@@ -81,7 +81,12 @@ type PrepareParams struct {
 	// blocklisted keys) used to expand ${VAR} in Hermes external_dirs so it
 	// matches what the Hermes child process actually sees. Only used for hermes.
 	HermesEnv map[string]string
-	Task      TaskContextForEnv // context data for writing files
+	// CodexCustomArgs are the effective Codex CLI args this task launches with
+	// (daemon defaults + profile-fixed + per-agent custom_args). Only the
+	// Windows sandbox decision reads them, to honor a `-c windows.sandbox=...`
+	// override that never lands in config.toml (MUL-4957).
+	CodexCustomArgs []string
+	Task            TaskContextForEnv // context data for writing files
 }
 
 // TaskContextForEnv is the subset of task context used for writing context files.
@@ -343,7 +348,7 @@ func Prepare(params PrepareParams, logger *slog.Logger) (*Environment, error) {
 			return nil, fmt.Errorf("execenv: prepare task home: %w", err)
 		}
 		env.TaskHome = taskHome
-		if err := prepareCodexHomeWithOpts(codexHome, CodexHomeOptions{CodexVersion: params.CodexVersion, IsLocalDirectory: params.LocalWorkDir != "", SessionStoreKey: codexSessionStoreKey(params.Profile, params.Task.AgentID, params.Task.IssueID), WritableRoots: writableRoots}, logger); err != nil {
+		if err := prepareCodexHomeWithOpts(codexHome, CodexHomeOptions{CodexVersion: params.CodexVersion, IsLocalDirectory: params.LocalWorkDir != "", SessionStoreKey: codexSessionStoreKey(params.Profile, params.Task.AgentID, params.Task.IssueID), WritableRoots: writableRoots, CodexCustomArgs: params.CodexCustomArgs}, logger); err != nil {
 			return nil, fmt.Errorf("execenv: prepare codex-home: %w", err)
 		}
 		if err := hydrateCodexSkills(codexHome, params.Task.AgentSkills, logger); err != nil {
@@ -452,7 +457,11 @@ type ReuseParams struct {
 	HermesSourceHome      string
 	HermesSourceMustExist bool
 	HermesEnv             map[string]string
-	Task                  TaskContextForEnv // refreshed context files / skills
+	// CodexCustomArgs mirrors PrepareParams.CodexCustomArgs on reuse so the
+	// Windows sandbox decision honors a `-c windows.sandbox=...` override here
+	// too (MUL-4957).
+	CodexCustomArgs []string
+	Task            TaskContextForEnv // refreshed context files / skills
 }
 
 // Reuse wraps an existing workdir into an Environment and refreshes context files.
@@ -555,7 +564,7 @@ func Reuse(params ReuseParams, logger *slog.Logger) *Environment {
 			logger.Warn("execenv: refresh task home failed", "error", err)
 		}
 		env.TaskHome = taskHome
-		if err := prepareCodexHomeWithOpts(codexHome, CodexHomeOptions{CodexVersion: params.CodexVersion, ResumeSessionID: params.ResumeSessionID, IsLocalDirectory: params.LocalDirectory, SessionStoreKey: codexSessionStoreKey(params.Profile, params.Task.AgentID, params.Task.IssueID), WritableRoots: writableRoots}, logger); err != nil {
+		if err := prepareCodexHomeWithOpts(codexHome, CodexHomeOptions{CodexVersion: params.CodexVersion, ResumeSessionID: params.ResumeSessionID, IsLocalDirectory: params.LocalDirectory, SessionStoreKey: codexSessionStoreKey(params.Profile, params.Task.AgentID, params.Task.IssueID), WritableRoots: writableRoots, CodexCustomArgs: params.CodexCustomArgs}, logger); err != nil {
 			logger.Warn("execenv: refresh codex-home failed", "error", err)
 		} else {
 			env.CodexHome = codexHome

--- a/server/internal/daemon/execenv/execenv_test.go
+++ b/server/internal/daemon/execenv/execenv_test.go
@@ -2555,6 +2555,30 @@ func TestEnsureCodexSandboxConfigDarwinFallsBack(t *testing.T) {
 	}
 }
 
+// TestEnsureCodexSandboxConfigWindowsFallsBack pins MUL-4957: Windows has no
+// enforceable filesystem sandbox, so an unenforceable workspace-write policy
+// makes Codex reject mutation commands (e.g. `multica issue create`) "by
+// policy". Windows must therefore get danger-full-access, mirroring macOS, and
+// must not emit any workspace-write keys.
+func TestEnsureCodexSandboxConfigWindowsFallsBack(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "config.toml")
+
+	policy := codexSandboxPolicyFor("windows", "0.144.5")
+	if err := ensureCodexSandboxConfig(configPath, policy, "0.144.5", testLogger()); err != nil {
+		t.Fatalf("ensureCodexSandboxConfig failed: %v", err)
+	}
+
+	s, _ := os.ReadFile(configPath)
+	if !strings.Contains(string(s), `sandbox_mode = "danger-full-access"`) {
+		t.Errorf("expected danger-full-access fallback on windows, got:\n%s", s)
+	}
+	if strings.Contains(string(s), "sandbox_workspace_write") {
+		t.Errorf("should not emit any workspace-write keys on windows fallback, got:\n%s", s)
+	}
+}
+
 func TestEnsureCodexSandboxConfigIsIdempotent(t *testing.T) {
 	t.Parallel()
 	dir := t.TempDir()
@@ -2752,11 +2776,17 @@ func TestCodexSandboxPolicyFor(t *testing.T) {
 		version  string
 		wantMode string
 		wantNet  bool
+		// wantHint is whether the policy carries an actionable upgrade hint.
+		// Only the macOS seatbelt fallback has one; Windows has no filesystem
+		// sandbox to restore, so it must not surface a misleading macOS hint.
+		wantHint bool
 	}{
-		{"linux any version", "linux", "0.100.0", "workspace-write", true},
-		{"linux unknown version", "linux", "", "workspace-write", true},
-		{"darwin old version", "darwin", "0.121.0", "danger-full-access", false},
-		{"darwin unknown version", "darwin", "", "danger-full-access", false},
+		{"linux any version", "linux", "0.100.0", "workspace-write", true, false},
+		{"linux unknown version", "linux", "", "workspace-write", true, false},
+		{"windows any version", "windows", "0.144.5", "danger-full-access", false, false},
+		{"windows unknown version", "windows", "", "danger-full-access", false, false},
+		{"darwin old version", "darwin", "0.121.0", "danger-full-access", false, true},
+		{"darwin unknown version", "darwin", "", "danger-full-access", false, true},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -2769,6 +2799,9 @@ func TestCodexSandboxPolicyFor(t *testing.T) {
 			}
 			if p.Reason == "" {
 				t.Error("expected non-empty Reason")
+			}
+			if (p.Hint != "") != tc.wantHint {
+				t.Errorf("hint present = %v, want %v (hint=%q)", p.Hint != "", tc.wantHint, p.Hint)
 			}
 		})
 	}

--- a/server/internal/daemon/execenv/execenv_test.go
+++ b/server/internal/daemon/execenv/execenv_test.go
@@ -2,6 +2,7 @@ package execenv
 
 import (
 	"encoding/json"
+	"errors"
 	"io"
 	"log/slog"
 	"os"
@@ -2599,7 +2600,7 @@ func TestEnsureCodexSandboxConfigWindowsRespectsUserSandbox(t *testing.T) {
 				t.Fatalf("write config: %v", err)
 			}
 
-			winState := resolveWindowsSandboxState(configPath, dir, nil, testLogger())
+			winState := resolveWindowsSandboxState(configPath, nil, sharedConfigPresent, nil, testLogger())
 			if winState != windowsSandboxNative {
 				t.Fatalf("resolveWindowsSandboxState = %v, want native", winState)
 			}
@@ -2971,42 +2972,94 @@ func TestResolveWindowsSandbox(t *testing.T) {
 	}
 }
 
-// TestResolveWindowsSandboxStateFailsClosed pins the first MUL-4957 must-fix:
-// when a shared ~/.codex/config.toml exists but the per-task copy is missing,
-// the daemon cannot read the user's intent and must fail closed (undecidable),
-// NOT treat it as unconfigured and loosen. A genuinely configlesss user stays
-// absent.
+// TestStatSharedCodexConfig verifies the shared-config tri-state used to tell a
+// genuinely config-less user from one whose config could not be stat'd.
+func TestStatSharedCodexConfig(t *testing.T) {
+	t.Parallel()
+
+	t.Run("present", func(t *testing.T) {
+		t.Parallel()
+		dir := t.TempDir()
+		if err := os.WriteFile(filepath.Join(dir, "config.toml"), []byte(`model = "o3"`), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		if got := statSharedCodexConfig(dir); got != sharedConfigPresent {
+			t.Errorf("got %v, want present", got)
+		}
+	})
+
+	t.Run("absent", func(t *testing.T) {
+		t.Parallel()
+		if got := statSharedCodexConfig(t.TempDir()); got != sharedConfigAbsent {
+			t.Errorf("got %v, want absent", got)
+		}
+	})
+
+	t.Run("empty home is absent", func(t *testing.T) {
+		t.Parallel()
+		if got := statSharedCodexConfig(""); got != sharedConfigAbsent {
+			t.Errorf("got %v, want absent", got)
+		}
+	})
+}
+
+// TestResolveWindowsSandboxStateFailsClosed pins the MUL-4957 fail-closed
+// invariant across every path where the daemon cannot confidently confirm the
+// user configured no native sandbox: a missing per-task copy of an existing (or
+// un-stat'able) shared config, and a failed config sync that leaves a stale
+// copy behind, all keep the restrictive workspace-write policy. Only a
+// genuinely config-less user with no custom-arg opt-in resolves to absent (the
+// one state that earns the danger-full-access compatibility fallback).
 func TestResolveWindowsSandboxStateFailsClosed(t *testing.T) {
 	t.Parallel()
 
-	t.Run("copy failed with shared config present -> undecidable", func(t *testing.T) {
+	t.Run("shared config present but per-task copy missing -> undecidable", func(t *testing.T) {
 		t.Parallel()
-		sharedHome := t.TempDir()
-		if err := os.WriteFile(filepath.Join(sharedHome, "config.toml"), []byte(`windows.sandbox = "unelevated"`), 0o644); err != nil {
-			t.Fatal(err)
-		}
-		// Per-task config file is absent (copy failed).
 		missing := filepath.Join(t.TempDir(), "config.toml")
-		if got := resolveWindowsSandboxState(missing, sharedHome, nil, testLogger()); got != windowsSandboxUndecidable {
+		if got := resolveWindowsSandboxState(missing, nil, sharedConfigPresent, nil, testLogger()); got != windowsSandboxUndecidable {
 			t.Errorf("got %v, want undecidable (fail closed)", got)
 		}
 	})
 
-	t.Run("no shared config -> absent", func(t *testing.T) {
+	t.Run("shared config stat undecidable -> undecidable", func(t *testing.T) {
 		t.Parallel()
-		sharedHome := t.TempDir() // no config.toml inside
+		// The shared source could not be stat'd (permission/IO), so an absent
+		// per-task copy cannot be trusted as "the user has no config".
 		missing := filepath.Join(t.TempDir(), "config.toml")
-		if got := resolveWindowsSandboxState(missing, sharedHome, nil, testLogger()); got != windowsSandboxAbsent {
+		if got := resolveWindowsSandboxState(missing, nil, sharedConfigUndecidable, nil, testLogger()); got != windowsSandboxUndecidable {
+			t.Errorf("got %v, want undecidable (fail closed)", got)
+		}
+	})
+
+	t.Run("config sync error with stale absent-looking copy -> undecidable", func(t *testing.T) {
+		t.Parallel()
+		// A leftover per-task config that reads as "no sandbox" must NOT be
+		// trusted when the sync that should have refreshed it failed — the
+		// reuse-path fail-open Elon's round-3 must-fix 1 called out.
+		dir := t.TempDir()
+		stale := filepath.Join(dir, "config.toml")
+		if err := os.WriteFile(stale, []byte(`model = "o3"`), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		syncErr := errors.New("copy failed")
+		if got := resolveWindowsSandboxState(stale, syncErr, sharedConfigPresent, nil, testLogger()); got != windowsSandboxUndecidable {
+			t.Errorf("got %v, want undecidable (fail closed on sync error)", got)
+		}
+	})
+
+	t.Run("no shared config and successful sync -> absent", func(t *testing.T) {
+		t.Parallel()
+		missing := filepath.Join(t.TempDir(), "config.toml")
+		if got := resolveWindowsSandboxState(missing, nil, sharedConfigAbsent, nil, testLogger()); got != windowsSandboxAbsent {
 			t.Errorf("got %v, want absent", got)
 		}
 	})
 
 	t.Run("custom-arg opt-in detected even with no config file", func(t *testing.T) {
 		t.Parallel()
-		sharedHome := t.TempDir()
 		missing := filepath.Join(t.TempDir(), "config.toml")
 		args := []string{"-c", "windows.sandbox=unelevated"}
-		if got := resolveWindowsSandboxState(missing, sharedHome, args, testLogger()); got != windowsSandboxNative {
+		if got := resolveWindowsSandboxState(missing, nil, sharedConfigAbsent, args, testLogger()); got != windowsSandboxNative {
 			t.Errorf("got %v, want native", got)
 		}
 	})

--- a/server/internal/daemon/execenv/execenv_test.go
+++ b/server/internal/daemon/execenv/execenv_test.go
@@ -2565,8 +2565,8 @@ func TestEnsureCodexSandboxConfigWindowsFallsBack(t *testing.T) {
 	dir := t.TempDir()
 	configPath := filepath.Join(dir, "config.toml")
 
-	// No user config → unconfigured Windows → danger-full-access.
-	policy := codexSandboxPolicyForConfig("windows", "0.144.5", "")
+	// No native sandbox configured → danger-full-access.
+	policy := codexSandboxPolicyForConfig("windows", "0.144.5", windowsSandboxAbsent)
 	if err := ensureCodexSandboxConfig(configPath, policy, "0.144.5", testLogger()); err != nil {
 		t.Fatalf("ensureCodexSandboxConfig failed: %v", err)
 	}
@@ -2599,7 +2599,11 @@ func TestEnsureCodexSandboxConfigWindowsRespectsUserSandbox(t *testing.T) {
 				t.Fatalf("write config: %v", err)
 			}
 
-			policy := codexSandboxPolicyForConfig("windows", "0.144.5", userConfig)
+			winState := resolveWindowsSandboxState(configPath, dir, nil, testLogger())
+			if winState != windowsSandboxNative {
+				t.Fatalf("resolveWindowsSandboxState = %v, want native", winState)
+			}
+			policy := codexSandboxPolicyForConfig("windows", "0.144.5", winState)
 			if err := ensureCodexSandboxConfig(configPath, policy, "0.144.5", testLogger()); err != nil {
 				t.Fatalf("ensureCodexSandboxConfig failed: %v", err)
 			}
@@ -2852,32 +2856,28 @@ func TestCodexSandboxPolicyFor(t *testing.T) {
 	}
 }
 
-// TestCodexSandboxPolicyForConfig pins the MUL-4957 must-fix: on Windows the
-// policy honors a user's explicit native windows.sandbox opt-in (keeping
-// workspace-write) and only falls back to danger-full-access when it is absent,
-// disabled, or unparseable. Linux and darwin ignore windows.sandbox entirely.
+// TestCodexSandboxPolicyForConfig maps resolved Windows sandbox states to
+// policies: native and undecidable both keep workspace-write (undecidable fails
+// closed), only absent gets danger-full-access. Linux/darwin ignore winState.
 func TestCodexSandboxPolicyForConfig(t *testing.T) {
 	t.Parallel()
 	cases := []struct {
 		name     string
 		goos     string
-		config   string
+		winState windowsSandboxConfig
 		wantMode string
 		wantNet  bool
 	}{
-		{"windows unelevated dotted", "windows", `windows.sandbox = "unelevated"`, "workspace-write", true},
-		{"windows elevated table", "windows", "[windows]\nsandbox = \"elevated\"\n", "workspace-write", true},
-		{"windows mixed case respected", "windows", `windows.sandbox = "Unelevated"`, "workspace-write", true},
-		{"windows disabled falls back", "windows", `windows.sandbox = "disabled"`, "danger-full-access", false},
-		{"windows unconfigured falls back", "windows", "", "danger-full-access", false},
-		{"windows unparseable falls back", "windows", "this is not = valid toml [[", "danger-full-access", false},
-		// Non-Windows platforms must not be swayed by a stray windows.sandbox key.
-		{"linux ignores windows.sandbox", "linux", `windows.sandbox = "unelevated"`, "workspace-write", true},
-		{"darwin ignores windows.sandbox", "darwin", `windows.sandbox = "unelevated"`, "danger-full-access", false},
+		{"windows native keeps workspace-write", "windows", windowsSandboxNative, "workspace-write", true},
+		{"windows undecidable fails closed", "windows", windowsSandboxUndecidable, "workspace-write", true},
+		{"windows absent falls back", "windows", windowsSandboxAbsent, "danger-full-access", false},
+		// Non-Windows platforms ignore winState entirely.
+		{"linux ignores winState", "linux", windowsSandboxNative, "workspace-write", true},
+		{"darwin ignores winState", "darwin", windowsSandboxNative, "danger-full-access", false},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			p := codexSandboxPolicyForConfig(tc.goos, "0.144.5", tc.config)
+			p := codexSandboxPolicyForConfig(tc.goos, "0.144.5", tc.winState)
 			if p.Mode != tc.wantMode {
 				t.Errorf("mode = %q, want %q", p.Mode, tc.wantMode)
 			}
@@ -2889,6 +2889,127 @@ func TestCodexSandboxPolicyForConfig(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestWindowsSandboxFromConfig verifies config.toml classification: only the
+// exact-lowercase variants Codex accepts are native; any other present value or
+// unparseable TOML is undecidable (fail closed); an absent key is absent.
+func TestWindowsSandboxFromConfig(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name   string
+		config string
+		want   windowsSandboxConfig
+	}{
+		{"unelevated dotted", `windows.sandbox = "unelevated"`, windowsSandboxNative},
+		{"elevated table", "[windows]\nsandbox = \"elevated\"\n", windowsSandboxNative},
+		{"absent key", `model = "o3"`, windowsSandboxAbsent},
+		{"empty config", "", windowsSandboxAbsent},
+		{"mixed case is invalid to codex", `windows.sandbox = "Unelevated"`, windowsSandboxUndecidable},
+		{"disabled is invalid to codex", `windows.sandbox = "disabled"`, windowsSandboxUndecidable},
+		{"unparseable toml", "this is not = valid toml [[", windowsSandboxUndecidable},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := windowsSandboxFromConfig(tc.config); got != tc.want {
+				t.Errorf("windowsSandboxFromConfig(%q) = %v, want %v", tc.config, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestWindowsSandboxFromCustomArgs verifies detection of a native sandbox opted
+// into via `-c windows.sandbox=...` args — the second MUL-4957 must-fix, since
+// such args never land in config.toml.
+func TestWindowsSandboxFromCustomArgs(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name string
+		args []string
+		want windowsSandboxConfig
+	}{
+		{"two-token bare", []string{"-c", "windows.sandbox=unelevated"}, windowsSandboxNative},
+		{"two-token quoted", []string{"-c", `windows.sandbox="unelevated"`}, windowsSandboxNative},
+		{"two-token spaced", []string{"-c", `windows.sandbox = "elevated"`}, windowsSandboxNative},
+		{"inline -c=", []string{"-c=windows.sandbox=unelevated"}, windowsSandboxNative},
+		{"--config long form", []string{"--config", "windows.sandbox=elevated"}, windowsSandboxNative},
+		{"last occurrence wins", []string{"-c", "windows.sandbox=unelevated", "-c", "windows.sandbox=elevated"}, windowsSandboxNative},
+		{"invalid value undecidable", []string{"-c", "windows.sandbox=disabled"}, windowsSandboxUndecidable},
+		{"unrelated override ignored", []string{"-c", "model=o3"}, windowsSandboxAbsent},
+		{"no args", nil, windowsSandboxAbsent},
+		{"dangling -c ignored", []string{"-c"}, windowsSandboxAbsent},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := windowsSandboxFromCustomArgs(tc.args); got != tc.want {
+				t.Errorf("windowsSandboxFromCustomArgs(%v) = %v, want %v", tc.args, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestResolveWindowsSandbox verifies the fold precedence: undecidable > native
+// > absent.
+func TestResolveWindowsSandbox(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name   string
+		states []windowsSandboxConfig
+		want   windowsSandboxConfig
+	}{
+		{"all absent", []windowsSandboxConfig{windowsSandboxAbsent, windowsSandboxAbsent}, windowsSandboxAbsent},
+		{"native in args", []windowsSandboxConfig{windowsSandboxAbsent, windowsSandboxNative}, windowsSandboxNative},
+		{"undecidable beats native", []windowsSandboxConfig{windowsSandboxNative, windowsSandboxUndecidable}, windowsSandboxUndecidable},
+		{"undecidable beats absent", []windowsSandboxConfig{windowsSandboxUndecidable, windowsSandboxAbsent}, windowsSandboxUndecidable},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := resolveWindowsSandbox(tc.states...); got != tc.want {
+				t.Errorf("resolveWindowsSandbox(%v) = %v, want %v", tc.states, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestResolveWindowsSandboxStateFailsClosed pins the first MUL-4957 must-fix:
+// when a shared ~/.codex/config.toml exists but the per-task copy is missing,
+// the daemon cannot read the user's intent and must fail closed (undecidable),
+// NOT treat it as unconfigured and loosen. A genuinely configlesss user stays
+// absent.
+func TestResolveWindowsSandboxStateFailsClosed(t *testing.T) {
+	t.Parallel()
+
+	t.Run("copy failed with shared config present -> undecidable", func(t *testing.T) {
+		t.Parallel()
+		sharedHome := t.TempDir()
+		if err := os.WriteFile(filepath.Join(sharedHome, "config.toml"), []byte(`windows.sandbox = "unelevated"`), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		// Per-task config file is absent (copy failed).
+		missing := filepath.Join(t.TempDir(), "config.toml")
+		if got := resolveWindowsSandboxState(missing, sharedHome, nil, testLogger()); got != windowsSandboxUndecidable {
+			t.Errorf("got %v, want undecidable (fail closed)", got)
+		}
+	})
+
+	t.Run("no shared config -> absent", func(t *testing.T) {
+		t.Parallel()
+		sharedHome := t.TempDir() // no config.toml inside
+		missing := filepath.Join(t.TempDir(), "config.toml")
+		if got := resolveWindowsSandboxState(missing, sharedHome, nil, testLogger()); got != windowsSandboxAbsent {
+			t.Errorf("got %v, want absent", got)
+		}
+	})
+
+	t.Run("custom-arg opt-in detected even with no config file", func(t *testing.T) {
+		t.Parallel()
+		sharedHome := t.TempDir()
+		missing := filepath.Join(t.TempDir(), "config.toml")
+		args := []string{"-c", "windows.sandbox=unelevated"}
+		if got := resolveWindowsSandboxState(missing, sharedHome, args, testLogger()); got != windowsSandboxNative {
+			t.Errorf("got %v, want native", got)
+		}
+	})
 }
 
 func TestPrepareCodexHomeEnsuresNetworkAccess(t *testing.T) {

--- a/server/internal/daemon/execenv/execenv_test.go
+++ b/server/internal/daemon/execenv/execenv_test.go
@@ -2555,17 +2555,18 @@ func TestEnsureCodexSandboxConfigDarwinFallsBack(t *testing.T) {
 	}
 }
 
-// TestEnsureCodexSandboxConfigWindowsFallsBack pins MUL-4957: Windows has no
-// enforceable filesystem sandbox, so an unenforceable workspace-write policy
-// makes Codex reject mutation commands (e.g. `multica issue create`) "by
-// policy". Windows must therefore get danger-full-access, mirroring macOS, and
-// must not emit any workspace-write keys.
+// TestEnsureCodexSandboxConfigWindowsFallsBack pins MUL-4957: when a Windows
+// user has not opted into a native Codex sandbox, Codex cannot enforce
+// workspace-write and rejects mutation commands (e.g. `multica issue create`)
+// "by policy". The daemon therefore defaults Windows to danger-full-access and
+// emits no workspace-write keys.
 func TestEnsureCodexSandboxConfigWindowsFallsBack(t *testing.T) {
 	t.Parallel()
 	dir := t.TempDir()
 	configPath := filepath.Join(dir, "config.toml")
 
-	policy := codexSandboxPolicyFor("windows", "0.144.5")
+	// No user config → unconfigured Windows → danger-full-access.
+	policy := codexSandboxPolicyForConfig("windows", "0.144.5", "")
 	if err := ensureCodexSandboxConfig(configPath, policy, "0.144.5", testLogger()); err != nil {
 		t.Fatalf("ensureCodexSandboxConfig failed: %v", err)
 	}
@@ -2576,6 +2577,49 @@ func TestEnsureCodexSandboxConfigWindowsFallsBack(t *testing.T) {
 	}
 	if strings.Contains(string(s), "sandbox_workspace_write") {
 		t.Errorf("should not emit any workspace-write keys on windows fallback, got:\n%s", s)
+	}
+}
+
+// TestEnsureCodexSandboxConfigWindowsRespectsUserSandbox pins the MUL-4957
+// must-fix: a Windows user who explicitly opted into a native Codex sandbox
+// (windows.sandbox = "unelevated"|"elevated") must NOT be silently downgraded
+// to danger-full-access. The daemon keeps workspace-write so Codex enforces
+// task isolation with the user's chosen backend, and preserves their
+// windows.sandbox line verbatim.
+func TestEnsureCodexSandboxConfigWindowsRespectsUserSandbox(t *testing.T) {
+	t.Parallel()
+	for _, mode := range []string{"unelevated", "elevated"} {
+		t.Run(mode, func(t *testing.T) {
+			t.Parallel()
+			dir := t.TempDir()
+			configPath := filepath.Join(dir, "config.toml")
+
+			userConfig := "model = \"o3\"\n\n[windows]\nsandbox = \"" + mode + "\"\n"
+			if err := os.WriteFile(configPath, []byte(userConfig), 0o644); err != nil {
+				t.Fatalf("write config: %v", err)
+			}
+
+			policy := codexSandboxPolicyForConfig("windows", "0.144.5", userConfig)
+			if err := ensureCodexSandboxConfig(configPath, policy, "0.144.5", testLogger()); err != nil {
+				t.Fatalf("ensureCodexSandboxConfig failed: %v", err)
+			}
+
+			data, _ := os.ReadFile(configPath)
+			s := string(data)
+			if !strings.Contains(s, `sandbox_mode = "workspace-write"`) {
+				t.Errorf("expected workspace-write kept for user-configured windows.sandbox, got:\n%s", s)
+			}
+			if strings.Contains(s, "danger-full-access") {
+				t.Errorf("must not downgrade a user-configured windows.sandbox to danger-full-access, got:\n%s", s)
+			}
+			if !strings.Contains(s, "network_access = true") {
+				t.Errorf("expected network_access = true under workspace-write, got:\n%s", s)
+			}
+			// The user's explicit opt-in must survive verbatim.
+			if !strings.Contains(s, `sandbox = "`+mode+`"`) {
+				t.Errorf("user windows.sandbox = %q must be preserved, got:\n%s", mode, s)
+			}
+		})
 	}
 }
 
@@ -2777,8 +2821,9 @@ func TestCodexSandboxPolicyFor(t *testing.T) {
 		wantMode string
 		wantNet  bool
 		// wantHint is whether the policy carries an actionable upgrade hint.
-		// Only the macOS seatbelt fallback has one; Windows has no filesystem
-		// sandbox to restore, so it must not surface a misleading macOS hint.
+		// Only the macOS seatbelt fallback has one; the Windows compatibility
+		// fallback has no generic upgrade action, so it must not surface a
+		// misleading macOS hint.
 		wantHint bool
 	}{
 		{"linux any version", "linux", "0.100.0", "workspace-write", true, false},
@@ -2802,6 +2847,45 @@ func TestCodexSandboxPolicyFor(t *testing.T) {
 			}
 			if (p.Hint != "") != tc.wantHint {
 				t.Errorf("hint present = %v, want %v (hint=%q)", p.Hint != "", tc.wantHint, p.Hint)
+			}
+		})
+	}
+}
+
+// TestCodexSandboxPolicyForConfig pins the MUL-4957 must-fix: on Windows the
+// policy honors a user's explicit native windows.sandbox opt-in (keeping
+// workspace-write) and only falls back to danger-full-access when it is absent,
+// disabled, or unparseable. Linux and darwin ignore windows.sandbox entirely.
+func TestCodexSandboxPolicyForConfig(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name     string
+		goos     string
+		config   string
+		wantMode string
+		wantNet  bool
+	}{
+		{"windows unelevated dotted", "windows", `windows.sandbox = "unelevated"`, "workspace-write", true},
+		{"windows elevated table", "windows", "[windows]\nsandbox = \"elevated\"\n", "workspace-write", true},
+		{"windows mixed case respected", "windows", `windows.sandbox = "Unelevated"`, "workspace-write", true},
+		{"windows disabled falls back", "windows", `windows.sandbox = "disabled"`, "danger-full-access", false},
+		{"windows unconfigured falls back", "windows", "", "danger-full-access", false},
+		{"windows unparseable falls back", "windows", "this is not = valid toml [[", "danger-full-access", false},
+		// Non-Windows platforms must not be swayed by a stray windows.sandbox key.
+		{"linux ignores windows.sandbox", "linux", `windows.sandbox = "unelevated"`, "workspace-write", true},
+		{"darwin ignores windows.sandbox", "darwin", `windows.sandbox = "unelevated"`, "danger-full-access", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			p := codexSandboxPolicyForConfig(tc.goos, "0.144.5", tc.config)
+			if p.Mode != tc.wantMode {
+				t.Errorf("mode = %q, want %q", p.Mode, tc.wantMode)
+			}
+			if p.NetworkAccess != tc.wantNet {
+				t.Errorf("network_access = %v, want %v", p.NetworkAccess, tc.wantNet)
+			}
+			if p.Reason == "" {
+				t.Error("expected non-empty Reason")
 			}
 		})
 	}

--- a/server/internal/daemon/execenv/execenv_test.go
+++ b/server/internal/daemon/execenv/execenv_test.go
@@ -3065,6 +3065,69 @@ func TestResolveWindowsSandboxStateFailsClosed(t *testing.T) {
 	})
 }
 
+// TestPrepareCodexHomeFailsClosedWhenSandboxWriteFails pins the MUL-4957
+// round-4 must-fix: the computed fail-closed policy must not stay only in
+// memory. It reproduces the reuse scenario where (1) the per-task config.toml
+// still holds last run's managed danger-full-access, (2) the shared config has
+// since opted into a native windows.sandbox but the sync cannot refresh the
+// copy, and (3) the managed block cannot be rewritten. Previously prepare
+// warned and returned success, so the task launched with the stale
+// danger-full-access — the decision failed closed while the effective config
+// failed open. prepareCodexHomeWithOpts must now return an error, which blocks
+// startup on both paths (fresh Prepare fails the task; Reuse leaves
+// env.CodexHome unset, which configureCodexTaskShellEnvironment refuses).
+func TestPrepareCodexHomeFailsClosedWhenSandboxWriteFails(t *testing.T) {
+	if os.Geteuid() == 0 {
+		t.Skip("running as root bypasses the read-only permissions this test relies on")
+	}
+	// Cannot use t.Parallel() with t.Setenv.
+
+	// Shared home the user has since pointed at a native Windows sandbox.
+	sharedHome := t.TempDir()
+	if err := os.WriteFile(filepath.Join(sharedHome, "config.toml"), []byte("windows.sandbox = \"unelevated\"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("CODEX_HOME", sharedHome)
+
+	// Reused per-task home still holding the prior run's danger-full-access.
+	codexHome := t.TempDir()
+	configPath := filepath.Join(codexHome, "config.toml")
+	stale := multicaManagedBeginMarker + "\nsandbox_mode = \"danger-full-access\"\n" + multicaManagedEndMarker + "\n"
+	if err := os.WriteFile(configPath, []byte(stale), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	// Read-only file + directory: the sync cannot replace the stale copy and
+	// the managed block cannot be rewritten.
+	if err := os.Chmod(configPath, 0o444); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chmod(codexHome, 0o500); err != nil {
+		t.Fatal(err)
+	}
+	// Restore before t.TempDir's own cleanup so removal succeeds (LIFO).
+	t.Cleanup(func() {
+		_ = os.Chmod(codexHome, 0o755)
+		_ = os.Chmod(configPath, 0o644)
+	})
+
+	err := prepareCodexHomeWithOpts(codexHome, CodexHomeOptions{GOOS: "windows", CodexVersion: "0.144.5"}, testLogger())
+	if err == nil {
+		t.Fatal("expected prepareCodexHomeWithOpts to fail closed when the sandbox block cannot be written, got nil")
+	}
+	if !strings.Contains(err.Error(), "sandbox config") {
+		t.Errorf("expected a sandbox-config error, got: %v", err)
+	}
+	// The stale danger-full-access is still on disk — proving the task would
+	// have launched unsandboxed had prepare reported success.
+	data, readErr := os.ReadFile(configPath)
+	if readErr != nil {
+		t.Fatalf("read config: %v", readErr)
+	}
+	if !strings.Contains(string(data), `sandbox_mode = "danger-full-access"`) {
+		t.Fatalf("expected the stale danger-full-access to remain (write failed), got:\n%s", data)
+	}
+}
+
 func TestPrepareCodexHomeEnsuresNetworkAccess(t *testing.T) {
 	// Cannot use t.Parallel() with t.Setenv.
 

--- a/server/pkg/agent/codex.go
+++ b/server/pkg/agent/codex.go
@@ -123,22 +123,41 @@ type codexBackend struct {
 
 func buildCodexArgs(opts ExecOptions, logger *slog.Logger) []string {
 	args := []string{"app-server", "--listen", "stdio://"}
-	extra := filterCustomArgs(opts.ExtraArgs, codexBlockedArgs, logger)
-	custom := filterCustomArgs(opts.CustomArgs, codexBlockedArgs, logger)
+	return append(args, NormalizeCodexLaunchArgs(opts.ExtraArgs, opts.CustomArgs, opts.McpConfig, logger)...)
+}
+
+// NormalizeCodexLaunchArgs returns the user-supplied Codex args (extra then
+// custom) exactly as buildCodexArgs hands them to the launched process: shell
+// quoting stripped, protocol-critical flags removed, and — when a managed
+// mcp_config owns the mcp_servers namespace — stray `-c mcp_servers.*`
+// overrides dropped. buildCodexArgs only prepends the fixed
+// `app-server --listen stdio://` transport flags to this result.
+//
+// It is exported so the daemon can reconstruct the *effective* launch args when
+// deciding the Windows sandbox mode. A `-c windows.sandbox=…` opt-in may arrive
+// shell-quoted (users commonly type custom_args with shell syntax, e.g.
+// `'-c' 'windows.sandbox=unelevated'`), and only after this same normalization
+// does it match the `-c windows.sandbox=…` shape the sandbox detector looks
+// for. Reconstructing the args any other way lets the two drift, silently
+// downgrading a user's isolation opt-in (MUL-4957).
+func NormalizeCodexLaunchArgs(extraArgs, customArgs []string, mcpConfig json.RawMessage, logger *slog.Logger) []string {
+	extra := filterCustomArgs(extraArgs, codexBlockedArgs, logger)
+	custom := filterCustomArgs(customArgs, codexBlockedArgs, logger)
 	// Only claim ownership of the `mcp_servers` namespace when the agent
 	// actually has a managed mcp_config in the MCP Tab. Otherwise existing
 	// users who configure MCP via `custom_args: ["-c", "mcp_servers.…"]`
-	// would silently lose those entries after this PR ships. With managed
-	// mcp_config present, daemon-written `$CODEX_HOME/config.toml` is the
-	// authoritative source and stray `-c mcp_servers.*` overrides are
-	// dropped to keep last-wins from re-shadowing it.
-	if hasManagedCodexMcpConfig(opts.McpConfig) {
+	// would silently lose those entries. With managed mcp_config present,
+	// daemon-written `$CODEX_HOME/config.toml` is the authoritative source and
+	// stray `-c mcp_servers.*` overrides are dropped to keep last-wins from
+	// re-shadowing it.
+	if hasManagedCodexMcpConfig(mcpConfig) {
 		extra = filterCodexCustomConfigOverrides(extra, logger)
 		custom = filterCodexCustomConfigOverrides(custom, logger)
 	}
-	args = append(args, extra...)
-	args = append(args, custom...)
-	return args
+	out := make([]string, 0, len(extra)+len(custom))
+	out = append(out, extra...)
+	out = append(out, custom...)
+	return out
 }
 
 // hasManagedCodexMcpConfig reports whether the agent's mcp_config field is

--- a/server/pkg/agent/codex_test.go
+++ b/server/pkg/agent/codex_test.go
@@ -2543,6 +2543,27 @@ func TestBuildCodexArgsDoesNotLeakMcpToArgv(t *testing.T) {
 	}
 }
 
+// TestNormalizeCodexLaunchArgsStripsShellQuotes locks the normalization the
+// daemon reuses for the Windows sandbox decision (MUL-4957): a shell-quoted
+// `-c windows.sandbox=...` opt-in must come out as clean tokens, and
+// buildCodexArgs must be exactly the transport prefix followed by this result,
+// so the sandbox decision and the launch argv can never diverge.
+func TestNormalizeCodexLaunchArgsStripsShellQuotes(t *testing.T) {
+	t.Parallel()
+
+	got := NormalizeCodexLaunchArgs(nil, []string{"'-c'", "'windows.sandbox=unelevated'"}, nil, slog.Default())
+	want := []string{"-c", "windows.sandbox=unelevated"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("NormalizeCodexLaunchArgs = %v, want %v", got, want)
+	}
+
+	launch := buildCodexArgs(ExecOptions{CustomArgs: []string{"'-c'", "'windows.sandbox=unelevated'"}}, slog.Default())
+	wantLaunch := append([]string{"app-server", "--listen", "stdio://"}, want...)
+	if !reflect.DeepEqual(launch, wantLaunch) {
+		t.Fatalf("buildCodexArgs = %v, want %v", launch, wantLaunch)
+	}
+}
+
 func TestCodexExecuteFailsClosedWhenMcpConfigInvalid(t *testing.T) {
 	t.Parallel()
 	if runtime.GOOS == "windows" {


### PR DESCRIPTION
## Summary

Fixes the Windows Codex bug reported in #5606 (MUL-4957): running `multica issue create` fails with `Script error: multica issue create was rejected by policy.`

**Root cause.** `rejected by policy` is a Codex-CLI-native verdict, not a Multica message. The daemon writes `sandbox_mode = "workspace-write"` into every task's `config.toml` on all non-darwin platforms. On Windows, when no native Codex sandbox is configured, Codex **cannot enforce `workspace-write`** (it downgrades to read-only). A non-safe mutation like `multica issue create`:

- is a network write, not on Codex's known-safe read-only list;
- can't be run inside a sandbox (none is active);
- under `approval_policy = "never"` (commonly inherited from the user's global `~/.codex/config.toml`, which the daemon copies into the task home) isn't allowed to ask, so Codex **rejects it by policy without ever sending an approval request** — the daemon's auto-approver never gets a chance to accept it.

The transcript's "restricted / read-only filesystem" is just Codex describing that same downgraded mode.

> **Note (corrected from the first revision):** Codex 0.144.5 *does* ship a native Windows sandbox (`windows.sandbox = "unelevated"` via a Restricted Token, or `"elevated"`). The bug is not that Windows has no sandbox — it's that Multica doesn't enable one and the default is `Disabled`. That native sandbox is still experimental with open upstream reliability issues (openai/codex #18451, #32314), so this PR does **not** turn it on by default; it uses `danger-full-access` as a deliberate compatibility choice and leaves native-sandbox rollout as follow-up.

## Fix

`resolveWindowsSandboxState` decides the Windows policy from a tri-state folded across the per-task `config.toml` **and** the effective Codex launch args:

- **User explicitly set a native sandbox** — `windows.sandbox = "unelevated"|"elevated"` in `config.toml`, or a `-c windows.sandbox=…` arg (even shell-quoted) — → keep `workspace-write` + network, so Codex enforces task isolation with the user's chosen backend. A user who asked for isolation is never silently downgraded.
- **Confidently no native sandbox anywhere** → `danger-full-access`, matching the existing macOS fallback, so `multica issue create` runs instead of being rejected.
- **Undecidable** — unparseable TOML, an invalid `windows.sandbox` value, a read error, a failed per-task config sync, or an un-stat-able shared config → **fail closed to `workspace-write`** (never loosens on doubt), logged at error level.

And, so the decision is not merely advisory: **if the managed sandbox block cannot be written, `prepareCodexHomeWithOpts` returns an error instead of warning and continuing.** Otherwise a computed fail-closed policy would exist only in memory while `config.toml` kept whatever it had — on a reused home, possibly a stale `danger-full-access`. The abort blocks startup on both paths (fresh Prepare fails the task; Reuse leaves `env.CodexHome` unset, which `configureCodexTaskShellEnvironment` already refuses).

This is intentionally the branch point for a future native-sandbox rollout: enabling it later means writing `windows.sandbox` ourselves and defaulting the state to native, with callers unchanged.

Secondary cleanup: the `danger-full-access` warn log no longer hardcodes `"on macOS"`, and the macOS-specific upgrade hint moved to a `codexSandboxPolicy.Hint` field only populated on macOS.

## Scope of behavior change

| Platform | `sandbox_mode` | |
| --- | --- | --- |
| Linux | `workspace-write` + network | Landlock enforces it (unchanged) |
| macOS | `danger-full-access` | Seatbelt network bug, unenforceable (unchanged) |
| Windows, native `windows.sandbox` set | `workspace-write` + network | **New** — user's native sandbox respected |
| Windows, config undecidable | `workspace-write` | **New** — fail closed, never loosens on doubt |
| Windows, confidently unconfigured | `danger-full-access` | **New** — was forcing reject-by-policy |

For the common unconfigured Windows user this widens the agent's default filesystem access to whatever that Windows account can already reach (still not root) — the same posture macOS already has today. Restoring true task isolation for unconfigured users via Codex's native Windows sandbox is larger, separate work, intentionally out of scope here.

## Windows decision (final)

| Resolved native-sandbox state | `sandbox_mode` |
| --- | --- |
| **Native** — valid `windows.sandbox = "unelevated"\|"elevated"` in config.toml **or** a `-c windows.sandbox=…` arg (shell-quoted forms normalized) | `workspace-write` + network (isolation preserved) |
| **Absent** — confidently no native sandbox anywhere | `danger-full-access` (compat fallback; fixes the bug) |
| **Undecidable** — unparseable TOML, invalid value, read error, failed per-task config sync, or un-stat-able shared config | `workspace-write` (**fail closed — never loosens**), logged at error level |

Only exact-lowercase `unelevated`/`elevated` count — verified against Codex 0.144.1, any other value makes Codex refuse to load the config.

### How the decision is read, and made to actually take effect

- **config.toml**: the decision receives the config-sync outcome and a tri-state shared-config presence (`statSharedCodexConfig`) instead of re-stat-ing inside. A failed `config.toml` sync (stale/absent per-task copy) or a shared source that can't be stat'd is undecidable → fail closed, rather than being mistaken for "the user has no config". IO is split from the decision so both are unit-testable without faulting the filesystem.
- **custom args**: a `-c windows.sandbox=…` opt-in never lands in config.toml, and users commonly type custom_args shell-quoted (`'-c' 'windows.sandbox=unelevated'`). The daemon normalizes the effective launch args through the **same** `agent.NormalizeCodexLaunchArgs` helper `buildCodexArgs` uses, so the sandbox scan sees exactly what Codex will.
- **enforcement**: a failed managed-block write aborts prepare, so the resolved policy can never be silently replaced on disk by a stale one.

## Testing

- `TestWindowsSandboxFromConfig` / `TestWindowsSandboxFromCustomArgs` / `TestResolveWindowsSandbox`: value classification, `-c`/`--config` forms, fold precedence (undecidable > native > absent).
- `TestStatSharedCodexConfig`: shared-config presence tri-state.
- `TestResolveWindowsSandboxStateFailsClosed`: shared present but per-task copy missing → undecidable; shared stat undecidable → undecidable; config sync error with a stale absent-looking copy → undecidable; confidently unconfigured → absent; custom-arg opt-in → native.
- `TestNormalizeCodexLaunchArgsStripsShellQuotes` (agent): shell-quoted `-c windows.sandbox=…` normalizes to clean tokens, and `buildCodexArgs` == transport prefix + this result.
- `TestWindowsSandboxHonorsShellQuotedCustomArg` (execenv↔agent integration): raw shell-quoted args → normalized → native / `workspace-write`, end to end.
- **`TestPrepareCodexHomeFailsClosedWhenSandboxWriteFails`**: the full reuse scenario — stale managed `danger-full-access` + failed config sync + failed managed-block write → `prepareCodexHomeWithOpts` returns an error and the stale config is provably still on disk. Verified it fails with "got nil" when the abort is reverted.
- `TestCodexSandboxPolicyForConfig` + `…WindowsRespectsUserSandbox` / `…WindowsFallsBack`: state→policy mapping and end-to-end config write.
- `go test ./server/internal/daemon/execenv/...` and `./server/pkg/agent/...` pass; `gofmt`/`go vet` clean; GitHub CI green including `windows-execenv`.

## Review history

- v1: mirrored the macOS fallback unconditionally for Windows.
- v2: corrected the false "Windows has no sandbox" rationale; `danger-full-access` only when the user hasn't opted into a native `windows.sandbox` (config.toml only).
- v3: undecidable config fails closed to `workspace-write`; exact-lowercase value matching; `-c windows.sandbox=…` custom args honored.
- v4: config.toml sync errors / un-stat-able shared config fail closed instead of being read as "unconfigured"; the custom-arg scan consumes the same `agent.NormalizeCodexLaunchArgs` normalization as `buildCodexArgs`, so shell-quoted opt-ins are no longer missed.
- v5 (current): **a failed managed-block write now aborts `prepareCodexHomeWithOpts`** instead of warn-and-continue, so the fail-closed decision can't stay in memory while a stale `danger-full-access` remains the effective on-disk config; regression covers stale danger + sync error + write error.

**Known follow-ups (non-blocking, from review):** a Windows Codex smoke test reproducing the real `multica issue create` fail→success; surfacing the sandbox level to the user (currently daemon-log only); and de-duplicating the blocked-flag warning now that `NormalizeCodexLaunchArgs` is called once for the sandbox decision and once at launch.

MUL-4957
