### PR TITLE
test(execenv): fix flaky Windows prepare-helper deadlock (MUL-4923)

### DIFF
--- a/server/internal/daemon/execenv/isolation_windows_test.go
+++ b/server/internal/daemon/execenv/isolation_windows_test.go
@@ -53,7 +53,18 @@ func TestWindowsPreparationJobHelperProcess(t *testing.T) {
 	if err := os.WriteFile(ready, []byte("ready"), 0o600); err != nil {
 		os.Exit(4)
 	}
-	select {}
+	// Block until the parent tears this whole process tree down via the Job
+	// Object. A bare select{} is unsafe here: once the helper reaches it, the Go
+	// runtime can find every goroutine parked with no possible wakeup and reap
+	// the process itself with "all goroutines are asleep - deadlock!" (exit
+	// status 2). That races the parent's kill and surfaces as a spurious
+	// "helper failed" instead of the context.Canceled the parent test asserts,
+	// which is the flake this job hit on main. Sleeping keeps a pending timer —
+	// a wakeable source — so the runtime never declares a deadlock; the process
+	// still dies the instant the Job Object kills the tree.
+	for {
+		time.Sleep(time.Hour)
+	}
 }
 
 func TestWindowsPreparationDelayedWriter(t *testing.T) {


### PR DESCRIPTION
## Summary

Fixes a flaky failure in the `windows-execenv` CI job's `TestPrepareIsolated_WindowsKillsDescendantBeforeRetry` (added in MUL-4923 / #5584). The job passes on PR branches but intermittently fails on `main`:

```
--- FAIL: TestPrepareIsolated_WindowsKillsDescendantBeforeRetry (0.02s)
    isolation_windows_test.go:111: PrepareIsolated error = execenv: preparation
    helper failed: exit status 2: fatal error: all goroutines are asleep - deadlock!
```

## Root cause

The test launches a helper subprocess (`TestWindowsPreparationJobHelperProcess`) that is meant to **block forever** so the parent can prove the Windows Job Object kills the whole process tree on cancellation. It blocked with a bare `select{}`.

Once the helper reaches `select{}`, every goroutine in that process can be parked with no possible wakeup source, so the Go runtime's deadlock detector reaps the process itself — `fatal error: all goroutines are asleep - deadlock!`, exit status 2. Whether this fires is a scheduling race, which is why it's flaky. When it fires, it races the parent's Job-Object kill: `PrepareIsolated` observes the exit-2 helper and returns a "helper failed" error instead of the `context.Canceled` the test asserts, failing at `isolation_windows_test.go:111`.

## Fix

Block on a timer-backed sleep loop instead of `select{}`:

```go
for {
    time.Sleep(time.Hour)
}
```

A pending timer is a wakeable source, so the runtime never declares a deadlock and the helper stays alive until the Job Object tears the tree down — exactly the "block until killed" behavior the test needs. No production code changes; test-only.

## Testing

- `gofmt` clean; `GOOS=windows go vet ./internal/daemon/execenv/` passes; `GOOS=windows go test -c ./internal/daemon/execenv/` compiles cleanly.
- I can't run Windows binaries locally (darwin dev host), so the behavioral confirmation is this PR's **`windows-execenv`** CI job.
