### PR TITLE
feat(projects): project list view control as a dropdown menu (MUL-5030)

### DIFF
--- a/packages/views/projects/components/projects-page.test.tsx
+++ b/packages/views/projects/components/projects-page.test.tsx
@@ -112,6 +112,12 @@ vi.mock("@multica/ui/components/ui/dropdown-menu", () => ({
   DropdownMenuContent: ({ children }: { children: React.ReactNode }) => (
     <div>{children}</div>
   ),
+  DropdownMenuGroup: ({ children }: { children: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
+  DropdownMenuLabel: ({ children }: { children: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
   DropdownMenuItem: ({
     children,
     onClick,

--- a/packages/views/projects/components/projects-page.tsx
+++ b/packages/views/projects/components/projects-page.tsx
@@ -27,6 +27,7 @@ import {
   type ProjectColumnKey,
   type ProjectListFilters,
   type ProjectSortField,
+  type ProjectViewMode,
 } from "@multica/core/projects";
 import {
   pinListOptions,
@@ -58,7 +59,9 @@ import {
   DropdownMenu,
   DropdownMenuCheckboxItem,
   DropdownMenuContent,
+  DropdownMenuGroup,
   DropdownMenuItem,
+  DropdownMenuLabel,
   DropdownMenuRadioGroup,
   DropdownMenuRadioItem,
   DropdownMenuSeparator,
@@ -1150,32 +1153,55 @@ export function ProjectsPage() {
                   </PopoverContent>
                 </Popover>
 
-              {/* View toggle — a single button that flips table ⇄ cards.
-                  Pure presentation; coupled to nothing else. */}
-              <Tooltip>
-                <TooltipTrigger
-                  render={
-                    <Button
-                      variant="outline"
-                      size="sm"
-                      className="h-8 w-8 gap-1 px-0 text-muted-foreground md:w-auto md:px-2.5"
-                      onClick={() => setViewMode(isCompact ? "comfortable" : "compact")}
-                    >
-                      {isCompact ? (
-                        <Rows3 className="size-3.5" />
-                      ) : (
-                        <LayoutGrid className="size-3.5" />
-                      )}
-                      <span className="hidden md:inline">
-                        {isCompact ? t(($) => $.page.view_table) : t(($) => $.page.view_cards)}
-                      </span>
-                    </Button>
-                  }
-                />
-                <TooltipContent side="bottom">
-                  {isCompact ? t(($) => $.page.view_cards) : t(($) => $.page.view_table)}
-                </TooltipContent>
-              </Tooltip>
+              {/* View selector — a dropdown menu to pick the list view,
+                  aligned with the issue list's view menu. The trigger shows
+                  the active view; the menu carries every mode so new views
+                  can be added as menu items. Pure presentation. */}
+              <DropdownMenu>
+                <Tooltip>
+                  <DropdownMenuTrigger
+                    render={
+                      <TooltipTrigger
+                        render={
+                          <Button
+                            variant="outline"
+                            size="sm"
+                            className="h-8 w-8 gap-1 px-0 text-muted-foreground md:w-auto md:px-2.5"
+                          >
+                            {isCompact ? (
+                              <Rows3 className="size-3.5" />
+                            ) : (
+                              <LayoutGrid className="size-3.5" />
+                            )}
+                            <span className="hidden md:inline">
+                              {isCompact ? t(($) => $.page.view_table) : t(($) => $.page.view_cards)}
+                            </span>
+                          </Button>
+                        }
+                      />
+                    }
+                  />
+                  <TooltipContent side="bottom">{t(($) => $.toolbar.view)}</TooltipContent>
+                </Tooltip>
+                <DropdownMenuContent align="end" className="w-auto">
+                  <DropdownMenuGroup>
+                    <DropdownMenuLabel>{t(($) => $.toolbar.view)}</DropdownMenuLabel>
+                  </DropdownMenuGroup>
+                  <DropdownMenuRadioGroup
+                    value={viewMode}
+                    onValueChange={(v) => setViewMode(v as ProjectViewMode)}
+                  >
+                    <DropdownMenuRadioItem value="compact">
+                      <Rows3 />
+                      {t(($) => $.page.view_table)}
+                    </DropdownMenuRadioItem>
+                    <DropdownMenuRadioItem value="comfortable">
+                      <LayoutGrid />
+                      {t(($) => $.page.view_cards)}
+                    </DropdownMenuRadioItem>
+                  </DropdownMenuRadioGroup>
+                </DropdownMenuContent>
+              </DropdownMenu>
             </div>
           </div>
 


### PR DESCRIPTION
## Summary

Aligns the **Project list** view control with the **Issue list** view selector.

Previously the control was a single button that toggled directly between the Table and Cards views on each click. Now the trigger opens a dropdown menu — a `View` header followed by a radio group of view modes (**Table** / **Cards**), with a check mark on the active view — mirroring the issue list's view menu.

The dropdown is built with `DropdownMenuRadioGroup` / `DropdownMenuRadioItem`, so adding future view modes is just another menu item (the request notes more project views are coming).

MUL-5030

## Changes

- `packages/views/projects/components/projects-page.tsx`: replace the toggle `Button` with a `DropdownMenu` view selector that mirrors `issues-header.tsx`. Reuses the existing `useProjectViewStore` `viewMode` / `setViewMode` (`compact` = Table, `comfortable` = Cards) and the existing `page.view_table` / `page.view_cards` / `toolbar.view` i18n keys — no new strings needed.
- `packages/views/projects/components/projects-page.test.tsx`: add mocks for the newly used `DropdownMenuGroup` / `DropdownMenuLabel`.

## Verification

- `pnpm --filter @multica/views typecheck` — passes
- `pnpm --filter @multica/views test` — 2720 tests pass
- `eslint` on both changed files — clean
