### PR TITLE
fix(desktop): commit staging env with explicit VITE_APP_URL (MUL-5025)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,11 @@ dist-electron
 # Desktop production config is public (backend URL, etc.) — track it so
 # `pnpm package` produces a release-ready build without extra setup.
 !apps/desktop/.env.production
+# Desktop staging config is public (staging API/web URLs) — track it so
+# `pnpm dev:desktop:staging` works from a fresh checkout instead of relying
+# on a hand-written local env file (MUL-5025: a misnamed VITE_ var there
+# silently broke copy-link URLs).
+!apps/desktop/.env.staging
 # Mobile staging config is public (staging API URL) — track it so a fresh
 # checkout can run `pnpm dev:mobile:staging` / `ios:mobile*:staging` without
 # the user having to copy `.env.example` first.

--- a/apps/desktop/.env.staging
+++ b/apps/desktop/.env.staging
@@ -1,0 +1,9 @@
+# Used by `pnpm dev:desktop:staging` (`electron-vite dev --mode staging`).
+# Personal overrides go in .env.staging.local, not here.
+VITE_API_URL=https://multica-api.copilothub.ai
+
+# Web app origin (what "copy link" URLs point at) — NOT the API host. Must be
+# explicit here: the automatic derivation in shared/runtime-config.ts only
+# rewrites `api.<host>` hostnames, so this deployment's `multica-api.<domain>`
+# naming would silently fall back to the API origin (MUL-5025).
+VITE_APP_URL=https://multica-app.copilothub.ai

--- a/apps/desktop/.env.staging
+++ b/apps/desktop/.env.staging
@@ -1,9 +1,11 @@
+# Internal staging environment; not a public support environment.
 # Used by `pnpm dev:desktop:staging` (`electron-vite dev --mode staging`).
-# Personal overrides go in .env.staging.local, not here.
+# Personal overrides go in .env.staging.local.
 VITE_API_URL=https://multica-api.copilothub.ai
 
-# Web app origin (what "copy link" URLs point at) — NOT the API host. Must be
-# explicit here: the automatic derivation in shared/runtime-config.ts only
-# rewrites `api.<host>` hostnames, so this deployment's `multica-api.<domain>`
-# naming would silently fall back to the API origin (MUL-5025).
+# VITE_APP_URL is the web app origin used for copy-link/open-in-browser URLs.
+# Do not point it at the API host. It must be explicit here: the `api.<host>`
+# derivation in shared/runtime-config.ts doesn't match this deployment's
+# `multica-api.<domain>` naming and would fall back to the API origin
+# (MUL-5025).
 VITE_APP_URL=https://multica-app.copilothub.ai

--- a/apps/mobile/.env.staging
+++ b/apps/mobile/.env.staging
@@ -1,3 +1,4 @@
+# Internal staging environment; not a public support environment.
 # Used by `pnpm dev:mobile:staging` and the `ios:device:staging[:release]`
 # scripts. Loaded via `dotenv-cli` (see package.json), NOT by Expo's auto-
 # loader — Expo only auto-loads .env.<NODE_ENV>.local files.

--- a/apps/mobile/.env.staging
+++ b/apps/mobile/.env.staging
@@ -4,7 +4,5 @@
 EXPO_PUBLIC_API_URL=https://multica-api.copilothub.ai
 
 # Optional. Enables "Copy link" / "Open on web" actions in issue / project /
-# comment menus. Without it those menu items just don't appear. Fill in the
-# staging web host when you have it (canonical value lives in
-# apps/desktop/.env.staging on a teammate's machine).
-# EXPO_PUBLIC_WEB_URL=https://<staging-web-host>
+# comment menus. Without it those menu items just don't appear.
+EXPO_PUBLIC_WEB_URL=https://multica-app.copilothub.ai


### PR DESCRIPTION
Fixes MUL-5025 (staging desktop "copy link" pointing at the API host, 404).

**Root cause.** Staging desktop dev depended on a hand-maintained local `apps/desktop/.env.staging`, where the web-origin var was misnamed `VITE_WEB_URL`. Desktop only reads `VITE_APP_URL` (`apps/desktop/src/main/index.ts`), so the unknown var was silently ignored and `appUrl` fell back to derivation — which only rewrites `api.<host>` hostnames, not `multica-api.<domain>` — leaving every `getShareableUrl` link (issue copy link, search copy, attachment previews) built on the API origin.

**Change.** This repository already tracks public staging pointers for mobile (`apps/mobile/.env.staging`). This PR makes Desktop staging consistent and documents that the environment is internal, not a public support target.

- Track `apps/desktop/.env.staging` with the correct var names. Header comments state the environment is internal and that `VITE_APP_URL` is the web app origin for copy-link/open-in-browser URLs — never the API host. Personal overrides go in `.env.staging.local`.
- Add the matching `.gitignore` exception.
- Fill in mobile's `EXPO_PUBLIC_WEB_URL` (its comment previously deferred to "apps/desktop/.env.staging on a teammate's machine"; the value now lives here), enabling the staging mobile copy-link/open-on-web menus. Same internal-environment note added.

Config-only change; no code paths touched. Verified `git check-ignore` resolves the new file to the negation rule so it stays tracked.

Note for anyone with a hand-written local `apps/desktop/.env.staging`: delete it before pulling this branch (git refuses to overwrite the untracked file); move personal values to `.env.staging.local`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
