### PR TITLE
fix(dropdown): keep picker open prop controlled

### DIFF
--- a/packages/views/modals/create-issue.tsx
+++ b/packages/views/modals/create-issue.tsx
@@ -770,7 +770,7 @@ export function ManualCreatePanel({
                   onUpdate={(u) => { if (u.status) updateStatus(u.status); }}
                   triggerRender={<PillButton />}
                   align="start"
-                  open={fieldPickerOpen === "status" ? true : undefined}
+                  open={fieldPickerOpen === "status"}
                   onOpenChange={(open) => setFieldPickerOpen(open ? "status" : null)}
                 />
               )}
@@ -782,7 +782,7 @@ export function ManualCreatePanel({
                   onUpdate={(u) => { if (u.priority) updatePriority(u.priority); }}
                   triggerRender={<PillButton />}
                   align="start"
-                  open={fieldPickerOpen === "priority" ? true : undefined}
+                  open={fieldPickerOpen === "priority"}
                   onOpenChange={(open) => setFieldPickerOpen(open ? "priority" : null)}
                 />
               )}
@@ -798,7 +798,7 @@ export function ManualCreatePanel({
                   )}
                   triggerRender={<PillButton />}
                   align="start"
-                  open={fieldPickerOpen === "assignee" ? true : undefined}
+                  open={fieldPickerOpen === "assignee"}
                   onOpenChange={(open) => setFieldPickerOpen(open ? "assignee" : null)}
                 />
               )}
@@ -813,7 +813,7 @@ export function ManualCreatePanel({
                   onSelectedIdsChange={updateLabelIds}
                   triggerRender={<PillButton />}
                   align="start"
-                  open={fieldPickerOpen === "labels" ? true : undefined}
+                  open={fieldPickerOpen === "labels"}
                   onOpenChange={(open) => setFieldPickerOpen(open ? "labels" : null)}
                 />
               )}
@@ -825,7 +825,7 @@ export function ManualCreatePanel({
                   onUpdate={(u) => setProjectId(u.project_id ?? undefined)}
                   triggerRender={<PillButton />}
                   align="start"
-                  open={fieldPickerOpen === "project" ? true : undefined}
+                  open={fieldPickerOpen === "project"}
                   onOpenChange={(open) => setFieldPickerOpen(open ? "project" : null)}
                 />
               )}

--- a/packages/views/modals/quick-create-issue.tsx
+++ b/packages/views/modals/quick-create-issue.tsx
@@ -588,7 +588,7 @@ export function AgentCreatePanel({
               onUpdate={(u) => setProjectId(u.project_id ?? null)}
               triggerRender={<PillButton />}
               align="start"
-              open={fieldPickerOpen === "project" ? true : undefined}
+              open={fieldPickerOpen === "project"}
               onOpenChange={(open) => setFieldPickerOpen(open ? "project" : null)}
             />
           )}
@@ -602,7 +602,7 @@ export function AgentCreatePanel({
               }}
               triggerRender={<PillButton />}
               align="start"
-              open={fieldPickerOpen === "priority" ? true : undefined}
+              open={fieldPickerOpen === "priority"}
               onOpenChange={(open) => setFieldPickerOpen(open ? "priority" : null)}
             />
           )}
@@ -614,7 +614,7 @@ export function AgentCreatePanel({
               onUpdate={(updates) => setDueDate(updates.due_date ?? null)}
               triggerRender={<PillButton />}
               align="start"
-              open={fieldPickerOpen === "due_date" ? true : undefined}
+              open={fieldPickerOpen === "due_date"}
               onOpenChange={(open) => setFieldPickerOpen(open ? "due_date" : null)}
             />
           )}


### PR DESCRIPTION
Replace `open={fieldPickerOpen === 'x' ? true : undefined}` with `open={fieldPickerOpen === 'x'}` in create-issue and quick-create-issue. Passing undefined made DropdownMenu switch between controlled and uncontrolled, triggering the React/Base UI warning.