### PR TITLE
MUL-5038: fix project resource preparation decoding

### DIFF
--- a/server/internal/daemon/execenv/execenv.go
+++ b/server/internal/daemon/execenv/execenv.go
@@ -27,10 +27,10 @@ type RepoContextForEnv struct {
 // fields the meta-skill template needs to render a human-readable summary
 // (URL for github_repo, generic label otherwise).
 type ProjectResourceForEnv struct {
-	ID           string          // server-assigned UUID
-	ResourceType string          // e.g. "github_repo"
-	ResourceRef  json.RawMessage // raw JSONB payload from the API
-	Label        string          // optional user-supplied label
+	ID           string          `json:"id"`              // server-assigned UUID
+	ResourceType string          `json:"resource_type"`   // e.g. "github_repo"
+	ResourceRef  json.RawMessage `json:"resource_ref"`    // raw JSONB payload from the API
+	Label        string          `json:"label,omitempty"` // optional user-supplied label
 }
 
 // PrepareParams holds all inputs needed to set up an execution environment.

--- a/server/internal/daemon/execenv/isolation.go
+++ b/server/internal/daemon/execenv/isolation.go
@@ -31,6 +31,28 @@ type preparationRequest struct {
 	Reuse   *ReuseParams   `json:"reuse,omitempty"`
 }
 
+// preparationOpenclawGatewayPin is the private helper-protocol view of an
+// OpenclawGatewayPin. Defining a new type intentionally drops MarshalJSON,
+// whose public/logging contract masks Token. The helper needs the real token
+// over its stdin pipe so it can materialize a working per-task wrapper.
+type preparationOpenclawGatewayPin OpenclawGatewayPin
+
+type preparationPrepareParams struct {
+	*PrepareParams
+	OpenclawGateway preparationOpenclawGatewayPin `json:"OpenclawGateway"`
+}
+
+type preparationReuseParams struct {
+	*ReuseParams
+	OpenclawGateway preparationOpenclawGatewayPin `json:"OpenclawGateway"`
+}
+
+type preparationRequestPayload struct {
+	Action  string                    `json:"action"`
+	Prepare *preparationPrepareParams `json:"prepare,omitempty"`
+	Reuse   *preparationReuseParams   `json:"reuse,omitempty"`
+}
+
 type preparationResponse struct {
 	Environment *Environment `json:"environment,omitempty"`
 	Error       string       `json:"error,omitempty"`
@@ -63,7 +85,7 @@ func runPreparationProcess(ctx context.Context, command []string, request prepar
 	if ctx.Err() != nil {
 		return nil, context.Cause(ctx)
 	}
-	payload, err := json.Marshal(request)
+	payload, err := marshalPreparationRequest(request)
 	if err != nil {
 		return nil, fmt.Errorf("execenv: encode preparation request: %w", err)
 	}
@@ -149,15 +171,44 @@ func runPreparationProcess(ctx context.Context, command []string, request prepar
 	return response.Environment, nil
 }
 
+// marshalPreparationRequest builds the private parent-to-helper payload. A
+// methodless view is required for OpenclawGateway so its bearer token survives
+// this trusted local process boundary; ordinary json.Marshal calls on the
+// public type remain redacted.
+func marshalPreparationRequest(request preparationRequest) ([]byte, error) {
+	payload := preparationRequestPayload{Action: request.Action}
+	if request.Prepare != nil {
+		payload.Prepare = &preparationPrepareParams{
+			PrepareParams:   request.Prepare,
+			OpenclawGateway: preparationOpenclawGatewayPin(request.Prepare.OpenclawGateway),
+		}
+	}
+	if request.Reuse != nil {
+		payload.Reuse = &preparationReuseParams{
+			ReuseParams:     request.Reuse,
+			OpenclawGateway: preparationOpenclawGatewayPin(request.Reuse.OpenclawGateway),
+		}
+	}
+	return json.Marshal(payload)
+}
+
+func decodePreparationRequest(in io.Reader) (preparationRequest, error) {
+	var request preparationRequest
+	decoder := json.NewDecoder(in)
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(&request); err != nil {
+		return preparationRequest{}, err
+	}
+	return request, nil
+}
+
 // RunPreparationHelper serves the private helper protocol on stdin/stdout.
 // Operational errors from Prepare are encoded in the response so the parent
 // can preserve them; malformed protocol input/output is returned as a process
 // error because the parent cannot safely interpret the result.
 func RunPreparationHelper(in io.Reader, out io.Writer, logger *slog.Logger) error {
-	var request preparationRequest
-	decoder := json.NewDecoder(in)
-	decoder.DisallowUnknownFields()
-	if err := decoder.Decode(&request); err != nil {
+	request, err := decodePreparationRequest(in)
+	if err != nil {
 		return fmt.Errorf("decode preparation request: %w", err)
 	}
 

--- a/server/internal/daemon/execenv/isolation_test.go
+++ b/server/internal/daemon/execenv/isolation_test.go
@@ -2,9 +2,11 @@ package execenv
 
 import (
 	"context"
+	"encoding/json"
 	"io"
 	"log/slog"
 	"os"
+	"path/filepath"
 	"testing"
 	"time"
 )
@@ -53,12 +55,78 @@ func TestPreparationHelperRoundTripsReuse(t *testing.T) {
 		WorkspacesRoot: params.WorkspacesRoot,
 		WorkDir:        env.WorkDir,
 		Provider:       params.Provider,
-		Task:           TaskContextForEnv{IssueID: "issue-helper-reuse", NewCommentCount: 1},
+		Task: TaskContextForEnv{
+			IssueID:         "issue-helper-reuse",
+			NewCommentCount: 1,
+			ProjectID:       "project-helper-reuse",
+			ProjectResources: []ProjectResourceForEnv{
+				{
+					ID:           "resource-helper-reuse",
+					ResourceType: "github_repo",
+					ResourceRef:  json.RawMessage(`{"url":"https://github.com/multica-ai/multica"}`),
+				},
+			},
+		},
 	}, logger)
 	if err != nil {
 		t.Fatalf("ReuseIsolated: %v", err)
 	}
 	if reused == nil || reused.RootDir != env.RootDir || reused.WorkDir != env.WorkDir {
 		t.Fatalf("reused environment = %#v, want root %q workdir %q", reused, env.RootDir, env.WorkDir)
+	}
+}
+
+func TestPreparationHelperRoundTripsProjectResources(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	params := PrepareParams{
+		WorkspacesRoot: t.TempDir(),
+		WorkspaceID:    "ws-helper-project-resource",
+		TaskID:         "88888888-7777-6666-5555-444444444444",
+		Provider:       "claude",
+		Task: TaskContextForEnv{
+			IssueID:   "issue-helper-project-resource",
+			ProjectID: "project-helper-project-resource",
+			ProjectResources: []ProjectResourceForEnv{
+				{
+					ID:           "resource-helper-project-resource",
+					ResourceType: "github_repo",
+					ResourceRef:  json.RawMessage(`{"url":"https://github.com/multica-ai/multica"}`),
+					Label:        "Multica",
+				},
+			},
+		},
+	}
+
+	env, err := PrepareIsolated(ctx, preparationHelperTestCommand(), params, logger)
+	if err != nil {
+		t.Fatalf("PrepareIsolated: %v", err)
+	}
+	defer env.Cleanup(true)
+
+	data, err := os.ReadFile(filepath.Join(env.WorkDir, ".multica", "project", "resources.json"))
+	if err != nil {
+		t.Fatalf("read project resources: %v", err)
+	}
+	var got projectResourceFile
+	if err := json.Unmarshal(data, &got); err != nil {
+		t.Fatalf("decode project resources: %v", err)
+	}
+	if len(got.Resources) != 1 {
+		t.Fatalf("project resources = %#v, want one resource", got.Resources)
+	}
+	resource := got.Resources[0]
+	var ref struct {
+		URL string `json:"url"`
+	}
+	if err := json.Unmarshal(resource.ResourceRef, &ref); err != nil {
+		t.Fatalf("decode resource ref: %v", err)
+	}
+	if resource.ID != "resource-helper-project-resource" ||
+		resource.ResourceType != "github_repo" ||
+		ref.URL != "https://github.com/multica-ai/multica" ||
+		resource.Label != "Multica" {
+		t.Fatalf("project resource = %#v, want all fields preserved", resource)
 	}
 }

--- a/server/internal/daemon/execenv/isolation_test.go
+++ b/server/internal/daemon/execenv/isolation_test.go
@@ -1,6 +1,7 @@
 package execenv
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"io"
@@ -128,5 +129,65 @@ func TestPreparationHelperRoundTripsProjectResources(t *testing.T) {
 		ref.URL != "https://github.com/multica-ai/multica" ||
 		resource.Label != "Multica" {
 		t.Fatalf("project resource = %#v, want all fields preserved", resource)
+	}
+}
+
+func TestPreparationRequestPreservesOpenclawGatewayForHelper(t *testing.T) {
+	t.Parallel()
+	want := OpenclawGatewayPin{
+		Host:  "gw.internal",
+		Port:  18789,
+		Token: "real-secret",
+		TLS:   true,
+	}
+	tests := []struct {
+		name    string
+		request preparationRequest
+		pin     func(preparationRequest) OpenclawGatewayPin
+	}{
+		{
+			name: "prepare",
+			request: preparationRequest{
+				Action:  preparationActionPrepare,
+				Prepare: &PrepareParams{OpenclawGateway: want},
+			},
+			pin: func(request preparationRequest) OpenclawGatewayPin {
+				return request.Prepare.OpenclawGateway
+			},
+		},
+		{
+			name: "reuse",
+			request: preparationRequest{
+				Action: preparationActionReuse,
+				Reuse:  &ReuseParams{OpenclawGateway: want},
+			},
+			pin: func(request preparationRequest) OpenclawGatewayPin {
+				return request.Reuse.OpenclawGateway
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			redacted, err := json.Marshal(tt.request)
+			if err != nil {
+				t.Fatalf("marshal redacted request: %v", err)
+			}
+			if bytes.Contains(redacted, []byte(want.Token)) {
+				t.Fatalf("ordinary JSON leaked gateway token: %s", redacted)
+			}
+
+			payload, err := marshalPreparationRequest(tt.request)
+			if err != nil {
+				t.Fatalf("marshal preparation request: %v", err)
+			}
+			got, err := decodePreparationRequest(bytes.NewReader(payload))
+			if err != nil {
+				t.Fatalf("decode preparation request: %v", err)
+			}
+			if got := tt.pin(got); got != want {
+				t.Fatal("gateway pin fields did not survive the helper protocol")
+			}
+		})
 	}
 }

--- a/server/internal/daemon/execenv/openclaw_config.go
+++ b/server/internal/daemon/execenv/openclaw_config.go
@@ -65,10 +65,10 @@ type OpenclawConfigPrep struct {
 // only, token left to inherit from the user's config) does the right
 // thing under OpenClaw's deep-merge $include semantics.
 type OpenclawGatewayPin struct {
-	Host  string
-	Port  int
-	Token string
-	TLS   bool
+	Host  string `json:"host,omitempty"`
+	Port  int    `json:"port,omitempty"`
+	Token string `json:"token,omitempty"`
+	TLS   bool   `json:"tls,omitempty"`
 }
 
 // IsZero reports whether every field is zero, i.e. there is nothing to pin.
@@ -91,8 +91,8 @@ func (p OpenclawGatewayPin) String() string {
 
 // MarshalJSON masks the bearer token in any default JSON dump (debug
 // endpoints, error envelopes, structured-log encoders). The wrapper config
-// writer goes through buildGatewayOverride which assembles a map directly,
-// so it is unaffected by this masking.
+// writer goes through buildGatewayOverride, and the private preparation-helper
+// transport uses its own methodless wire view, so both retain the real token.
 func (p OpenclawGatewayPin) MarshalJSON() ([]byte, error) {
 	type alias struct {
 		Host  string `json:"host,omitempty"`


### PR DESCRIPTION
## Summary

- declare the existing snake_case JSON contract on `ProjectResourceForEnv` so the strict preparation helper can decode project-bound tasks
- preserve OpenClaw gateway fields and the real bearer token across the trusted helper process boundary while keeping ordinary JSON/log output redacted
- cover both fresh Prepare and existing-workdir Reuse helper paths for project resources and OpenClaw gateway pins

## Tests

- `go test ./internal/daemon/execenv -count=1`
- `go test ./internal/daemon/... -count=1`
- `go vet ./internal/daemon/execenv`

Fixes MUL-5038
