### PR TITLE
fix: retry incomplete Claude result streams

### DIFF
--- a/server/internal/service/task_complete_race_test.go
+++ b/server/internal/service/task_complete_race_test.go
@@ -259,8 +259,7 @@ func TestTaskFailureClassifiers(t *testing.T) {
 		{reason: "api_invalid_request", wantType: "agent_error", wantResumeOK: false, wantRetry: false},
 		{reason: "agent_error.context_overflow", wantType: "agent_error", wantResumeOK: false, wantRetry: false},
 		{reason: "agent_error", wantType: "agent_error", wantResumeOK: true, wantRetry: false},
-		// Missing terminal result errors classify to agent_error.unknown. Keep
-		// that deterministic upstream failure outside the auto-retry allowlist.
+		// Unknown agent errors remain outside the auto-retry allowlist.
 		{reason: "agent_error.unknown", wantType: "agent_error", wantResumeOK: true, wantRetry: false},
 	}
 

--- a/server/pkg/taskfailure/classify.go
+++ b/server/pkg/taskfailure/classify.go
@@ -167,9 +167,12 @@ func Classify(rawError string) Reason {
 	//    instead of falling through to agent_error.unknown / process_failure
 	//    and terminating the task (MUL-4910). Checked before rule 13 so the
 	//    "... exited with error: exit status N ..." variant still routes here.
+	//    A Claude-style stream that exits cleanly without its terminal result
+	//    is also an incomplete provider stream and is safe to resume.
 	//    Mirror these substrings into the MUL-1949 offline backfill SQL.
 	case containsAny(lower,
 		"stream disconnected",
+		"stream ended without terminal result",
 		"connection closed",
 		"mid-response",
 		"error sending request",

--- a/server/pkg/taskfailure/classify_test.go
+++ b/server/pkg/taskfailure/classify_test.go
@@ -93,6 +93,7 @@ func TestClassifyRules(t *testing.T) {
 
 		// 7. Provider network.
 		{"stream disconnected", "stream disconnected before completion", ReasonAgentProviderNetwork},
+		{"stream ended without terminal result", "claude stream ended without terminal result", ReasonAgentProviderNetwork},
 		{"connection closed mid-response", "API Error: Connection closed mid-response. The response above may be incomplete.", ReasonAgentProviderNetwork},
 		{"connection closed with exit status wins over process failure", "claude exited with error: exit status 1\nAPI Error: Connection closed mid-response.", ReasonAgentProviderNetwork},
 		{"error sending request", "error sending request for url (https://api.example.com/v1)", ReasonAgentProviderNetwork},


### PR DESCRIPTION
## Summary

Classify `claude stream ended without terminal result` as `agent_error.provider_network` so the existing session-resume retry policy can recover incomplete Claude streams.

## Why

The v0.4.3 fail-closed change correctly turns a missing terminal `result` event into a task failure. However, the exact error currently falls through to `agent_error.unknown`, which is resume-safe but excluded from automatic retry.

In a production incident, two independent delegated Claude sessions ended in the same second with an empty final assistant event, `stop_reason: null`, and no terminal result. Treating the incomplete stream as transient is safer than stopping the workflow; the existing retry path resumes the same session and remains capped by the current retry tiers.

## Tests

- `go test ./pkg/taskfailure ./internal/service -count=1`
- `go vet ./pkg/taskfailure ./internal/service`

The classifier test was added first and failed with `got unknown, want provider_network` before the implementation change.