### PR TITLE
Fix OpenClaw native agent flag filtering (ZIC-106)

### DIFF
--- a/server/pkg/agent/openclaw.go
+++ b/server/pkg/agent/openclaw.go
@@ -43,11 +43,26 @@ var openclawBlockedArgs = map[string]blockedArgMode{
 	"--message":       blockedWithValue,  // prompt is set by daemon
 	"--model":         blockedWithValue,  // openclaw agent does not accept --model; model is bound at registration via `openclaw agents add/update --model`
 	"--system-prompt": blockedWithValue,  // openclaw agent does not accept --system-prompt; instructions are injected into --message
+
+	// Claude Code / Cursor protocol flags are invalid for `openclaw agent`.
+	// Keep them out of custom_args so a copied config cannot push OpenClaw back
+	// into help/usage output and the canonical no-parseable-output failure.
+	"-p":                  blockedWithValue,
+	"--output-format":     blockedWithValue,
+	"--input-format":      blockedWithValue,
+	"--json-input":        blockedWithValue,
+	"--workdir":           blockedWithValue,
+	"--add-dir":           blockedWithValue,
+	"--mcp-config":        blockedWithValue,
+	"--strict-mcp-config": blockedStandalone,
+	"--no-tui":            blockedStandalone,
+	"--dangerously-bypass-approvals-and-sandbox": blockedStandalone,
+	"--dangerously-skip-permissions":             blockedStandalone,
+	"--permission-mode":                          blockedWithValue,
 }
 
 // openclawBackend implements Backend by spawning `openclaw agent --message <prompt>
-// --output-format stream-json --yes` and reading streaming NDJSON events from
-// stdout — similar to the opencode backend.
+// --json` and reading JSON output from stdout.
 type openclawBackend struct {
 	cfg Config
 }

--- a/server/pkg/agent/openclaw_test.go
+++ b/server/pkg/agent/openclaw_test.go
@@ -1061,14 +1061,46 @@ func TestBuildOpenclawArgsFiltersBlockedCustomArgs(t *testing.T) {
 			"--system-prompt", "You are helpful",
 			"--session-id", "hijacked",
 			"--message", "hijacked",
+			"-p", "bad prompt",
+			"--output-format", "stream-json",
+			"--json-input", "/tmp/openclaw-input.json",
+			"--workdir", "/tmp/work",
+			"--add-dir", "/tmp/repo",
+			"--mcp-config", "/tmp/mcp.json",
+			"--strict-mcp-config",
+			"--no-tui",
+			"--dangerously-bypass-approvals-and-sandbox",
 		},
 	}, slog.Default())
 
-	if idx := indexOf(args, "--model"); idx != -1 {
-		t.Errorf("--model should be filtered from custom_args: %v", args)
+	for _, blocked := range []string{
+		"--model",
+		"--system-prompt",
+		"-p",
+		"--output-format",
+		"--json-input",
+		"--workdir",
+		"--add-dir",
+		"--mcp-config",
+		"--strict-mcp-config",
+		"--no-tui",
+		"--dangerously-bypass-approvals-and-sandbox",
+	} {
+		if idx := indexOf(args, blocked); idx != -1 {
+			t.Errorf("%s should be filtered from custom_args: %v", blocked, args)
+		}
 	}
-	if idx := indexOf(args, "--system-prompt"); idx != -1 {
-		t.Errorf("--system-prompt should be filtered from custom_args: %v", args)
+	for _, consumedValue := range []string{
+		"bad prompt",
+		"stream-json",
+		"/tmp/openclaw-input.json",
+		"/tmp/work",
+		"/tmp/repo",
+		"/tmp/mcp.json",
+	} {
+		if idx := indexOf(args, consumedValue); idx != -1 {
+			t.Errorf("value for blocked flag %q should be consumed: %v", consumedValue, args)
+		}
 	}
 	// Whitelisted pass-through flag must survive filtering.
 	if idx := indexOf(args, "--agent"); idx == -1 || idx+1 >= len(args) || args[idx+1] != "research-bot" {
@@ -1080,6 +1112,94 @@ func TestBuildOpenclawArgsFiltersBlockedCustomArgs(t *testing.T) {
 	}
 	if count := countOccurrences(args, "--message"); count != 1 {
 		t.Errorf("expected 1 --message (daemon-managed), got %d: %v", count, args)
+	}
+}
+
+func TestOpenclawExecuteUsesNativeAgentFlags(t *testing.T) {
+	t.Parallel()
+	if runtime.GOOS == "windows" {
+		t.Skip("shell-script fixture is POSIX-only")
+	}
+
+	tempDir := t.TempDir()
+	fakePath := filepath.Join(tempDir, "openclaw")
+	capturePath := filepath.Join(tempDir, "argv.txt")
+	script := "#!/bin/sh\n" +
+		"if [ \"$1\" = \"--version\" ]; then\n" +
+		"  echo 'openclaw 2026.7.1 c37871e'\n" +
+		"  exit 0\n" +
+		"fi\n" +
+		"printf '%s\\n' \"$@\" > \"$OPENCLAW_ARGV_CAPTURE\"\n" +
+		"printf '%s\\n' '{\"payloads\":[{\"text\":\"ok\"}],\"meta\":{\"durationMs\":1,\"agentMeta\":{\"sessionId\":\"sess-native\",\"model\":\"anthropic/claude-opus-4.7\"}}}'\n"
+	writeTestExecutable(t, fakePath, []byte(script))
+
+	backend, err := New("openclaw", Config{
+		ExecutablePath: fakePath,
+		Env:            map[string]string{"OPENCLAW_ARGV_CAPTURE": capturePath},
+		Logger:         slog.Default(),
+	})
+	if err != nil {
+		t.Fatalf("new openclaw backend: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	session, err := backend.Execute(ctx, "hello", ExecOptions{
+		Model:           "main",
+		ResumeSessionID: "resume-123",
+		Timeout:         5 * time.Second,
+		CustomArgs: []string{
+			"-p", "bad prompt",
+			"--output-format", "stream-json",
+			"--json-input", "/tmp/openclaw-input.json",
+			"--workdir", "/tmp/work",
+			"--add-dir", "/tmp/repo",
+			"--mcp-config", "/tmp/mcp.json",
+			"--strict-mcp-config",
+			"--no-tui",
+			"--dangerously-bypass-approvals-and-sandbox",
+			"--channel", "ops",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Execute returned synchronous error: %v", err)
+	}
+
+	for range session.Messages {
+	}
+	select {
+	case result := <-session.Result:
+		if result.Status != "completed" || result.Output != "ok" {
+			t.Fatalf("result = %#v, want completed output", result)
+		}
+	case <-time.After(10 * time.Second):
+		t.Fatal("timeout waiting for result")
+	}
+
+	data, err := os.ReadFile(capturePath)
+	if err != nil {
+		t.Fatalf("read captured argv: %v", err)
+	}
+	args := strings.Fields(string(data))
+	for _, want := range []string{"agent", "--local", "--json", "--session-id", "resume-123", "--timeout", "5", "--agent", "main", "--channel", "ops", "--message", "hello"} {
+		if idx := indexOf(args, want); idx == -1 {
+			t.Fatalf("captured argv missing %q: %v", want, args)
+		}
+	}
+	for _, blocked := range []string{
+		"-p",
+		"--output-format",
+		"--json-input",
+		"--workdir",
+		"--add-dir",
+		"--mcp-config",
+		"--strict-mcp-config",
+		"--no-tui",
+		"--dangerously-bypass-approvals-and-sandbox",
+	} {
+		if idx := indexOf(args, blocked); idx != -1 {
+			t.Fatalf("captured argv must not include Claude-style flag %q: %v", blocked, args)
+		}
 	}
 }
 


### PR DESCRIPTION
<!-- multica-auto-bugfix -->

## What does this PR do?

Hardens the OpenClaw backend so Claude Code / Cursor protocol flags cannot be forwarded to `openclaw agent` through copied `custom_args`. The backend continues to launch OpenClaw with native `agent --local --json --session-id --timeout --agent --message` flags, while preserving native pass-through flags such as `--channel`.

## Related Issue

Closes #5648

Multica issue: ZIC-106

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Refactor / code improvement (no behavior change)
- [x] Tests (adding or improving test coverage)
- [ ] CI / infrastructure

## Changes Made

- Expanded OpenClaw's blocked `custom_args` list to strip Claude/Cursor-only protocol flags including `-p`, `--output-format`, `--json-input`, `--workdir`, `--add-dir`, `--mcp-config`, `--no-tui`, and bypass/permission flags.
- Added a fake OpenClaw executable regression test that captures the actual argv from `Execute` and asserts the native OpenClaw protocol is used.
- Corrected the stale OpenClaw backend comment that still described the old `--output-format stream-json` launch shape.

## How to Test

1. `cd server && go test ./pkg/agent -run Openclaw -count=1`
2. `cd server && go test ./pkg/agent -count=1`
3. `make check-worktree` (exited 0 locally; Docker was unavailable while checking PostgreSQL: `Cannot connect to the Docker daemon at unix:///Users/icezero/.docker/run/docker.sock`)

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [ ] I have updated relevant documentation to reflect my changes
- [ ] If I added a new runtime / coding tool / UI tab, I synced the change to **landing copy** (`apps/web/features/landing/i18n/`) and **relevant docs** (`apps/docs/content/docs/`)
- [ ] If this PR touches Chinese product copy, I checked it against `apps/docs/content/docs/developers/conventions.zh.mdx` (terminology, mixed-rule for `task` / `issue` / `skill`)
- [x] I have considered and documented any risks above
- [x] I will address all reviewer comments before requesting merge

## AI Disclosure

**AI tool used:** Multica Agent

**Prompt / approach:**
Traced the OpenClaw provider path from the reported argv, confirmed the backend's native launch shape, then added defensive filtering and a process-boundary regression test using a fake OpenClaw command.

## Screenshots (optional)

N/A
