### PR TITLE
test: cover Claude stale symlink self-heal

### DIFF
--- a/server/internal/daemon/agent_path_selfheal_test.go
+++ b/server/internal/daemon/agent_path_selfheal_test.go
@@ -65,6 +65,24 @@ func installVersionedCodex(t *testing.T, root, version, stableBin string) string
 	return canonicalExecutablePath(link)
 }
 
+// installVersionedClaude lays out the native Claude Code installer shape seen
+// in issue #5683: a stable claude command symlink pointing into
+// ~/.local/share/claude/versions/<version>.
+func installVersionedClaude(t *testing.T, root, version, stableBin string) string {
+	t.Helper()
+	versioned := filepath.Join(root, ".local", "share", "claude", "versions", version, "bin", "claude")
+	writeExecStub(t, versioned)
+	link := filepath.Join(stableBin, "claude")
+	_ = os.Remove(link) // repoint on upgrade
+	if err := os.MkdirAll(stableBin, 0o755); err != nil {
+		t.Fatalf("mkdir stable bin: %v", err)
+	}
+	if err := os.Symlink(versioned, link); err != nil {
+		t.Fatalf("symlink %s -> %s: %v", link, versioned, err)
+	}
+	return canonicalExecutablePath(link)
+}
+
 // TestResolveAgentEntry_SelfHealsAfterInPlaceUpgrade reproduces MUL-4486: a
 // version manager upgrades codex in place, deleting the versioned directory the
 // daemon pinned at startup and repointing the stable command name at the new
@@ -132,6 +150,59 @@ func TestResolveAgentEntry_SelfHealsAfterInPlaceUpgrade(t *testing.T) {
 	t.Setenv("PATH", filepath.Join(root, "empty"))
 	if got, ver := d.resolveAgentEntry(ctx, "codex", entry); got.Path != v2 || ver != "0.144.3" {
 		t.Fatalf("cached self-heal not reused: got (%q, %q), want (%q, %q)", got.Path, ver, v2, "0.144.3")
+	}
+}
+
+// TestResolveAgentEntry_SelfHealsClaudeAfterNativeInstallerUpgrade reproduces
+// GitHub #5683: Claude Code's stable command symlink is resolved to a
+// versioned executable at daemon startup, then an auto-update repoints the
+// symlink and garbage-collects the old version directory before the daemon
+// restarts. A built-in Claude task must re-resolve the bare "claude" command
+// instead of failing permanently on the stale pinned target.
+func TestResolveAgentEntry_SelfHealsClaudeAfterNativeInstallerUpgrade(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlink/exec-bit layout is POSIX-specific")
+	}
+	stubDetectVersionFromPath(t)
+
+	root := t.TempDir()
+	stableBin := filepath.Join(root, "bin")
+	t.Setenv("PATH", stableBin)
+	// Disable the login-shell fallback so the test only sees the fake Claude
+	// install rooted under stableBin.
+	t.Setenv("SHELL", filepath.Join(t.TempDir(), "fish"))
+
+	v1 := installVersionedClaude(t, root, "2.1.210", stableBin)
+	if !strings.Contains(v1, "2.1.210") {
+		t.Fatalf("pinned path %q does not point into the v1 versioned dir", v1)
+	}
+
+	d := newSelfHealTestDaemon()
+	d.setAgentVersion("claude", "2.1.210")
+	entry := AgentEntry{Path: v1, Command: "claude"}
+	ctx := context.Background()
+
+	if got, ver := d.resolveAgentEntry(ctx, "claude", entry); got.Path != v1 || ver != "2.1.210" {
+		t.Fatalf("live pinned path/version rewritten: got (%q, %q), want (%q, %q)", got.Path, ver, v1, "2.1.210")
+	}
+
+	if err := os.RemoveAll(filepath.Join(root, ".local", "share", "claude", "versions", "2.1.210")); err != nil {
+		t.Fatalf("remove v1 tree: %v", err)
+	}
+	if agentExecutablePresent(v1) {
+		t.Fatalf("v1 path still present after removing its tree: %q", v1)
+	}
+	v2 := installVersionedClaude(t, root, "2.1.215", stableBin)
+
+	got, ver := d.resolveAgentEntry(ctx, "claude", entry)
+	if got.Path != v2 {
+		t.Fatalf("self-heal resolved %q, want re-resolved v2 %q", got.Path, v2)
+	}
+	if ver != "2.1.215" {
+		t.Fatalf("returned version not paired with healed path: got %q, want %q", ver, "2.1.215")
+	}
+	if v := d.agentVersion("claude"); v != "2.1.215" {
+		t.Fatalf("version cache not updated in lockstep: got %q, want %q", v, "2.1.215")
 	}
 }
 

--- a/server/internal/daemon/agent_path_selfheal_test.go
+++ b/server/internal/daemon/agent_path_selfheal_test.go
@@ -22,13 +22,16 @@ func newSelfHealTestDaemon() *Daemon {
 }
 
 // stubDetectVersionFromPath makes detectAgentVersion report the version encoded
-// in an installVersionedCodex path (…/codex/<ver>/bin/codex), so a heal to a
-// v2 directory "detects" v2. checkAgentMinVersion is intentionally left as the
-// real agent.CheckMinVersion so the min-version gate is exercised for real.
+// in a versioned test path, so a heal to a v2 executable "detects" v2.
+// checkAgentMinVersion is intentionally left as the real agent.CheckMinVersion
+// so the min-version gate is exercised for real.
 func stubDetectVersionFromPath(t *testing.T) {
 	t.Helper()
 	orig := detectAgentVersion
 	detectAgentVersion = func(_ context.Context, path string) (string, error) {
+		if base := filepath.Base(path); strings.Count(base, ".") >= 2 {
+			return base, nil
+		}
 		return filepath.Base(filepath.Dir(filepath.Dir(path))), nil
 	}
 	t.Cleanup(func() { detectAgentVersion = orig })
@@ -70,7 +73,7 @@ func installVersionedCodex(t *testing.T, root, version, stableBin string) string
 // ~/.local/share/claude/versions/<version>.
 func installVersionedClaude(t *testing.T, root, version, stableBin string) string {
 	t.Helper()
-	versioned := filepath.Join(root, ".local", "share", "claude", "versions", version, "bin", "claude")
+	versioned := filepath.Join(root, ".local", "share", "claude", "versions", version)
 	writeExecStub(t, versioned)
 	link := filepath.Join(stableBin, "claude")
 	_ = os.Remove(link) // repoint on upgrade
@@ -197,6 +200,9 @@ func TestResolveAgentEntry_SelfHealsClaudeAfterNativeInstallerUpgrade(t *testing
 	got, ver := d.resolveAgentEntry(ctx, "claude", entry)
 	if got.Path != v2 {
 		t.Fatalf("self-heal resolved %q, want re-resolved v2 %q", got.Path, v2)
+	}
+	if !agentExecutablePresent(got.Path) {
+		t.Fatalf("self-healed path is not runnable: %q", got.Path)
 	}
 	if ver != "2.1.215" {
 		t.Fatalf("returned version not paired with healed path: got %q, want %q", ver, "2.1.215")


### PR DESCRIPTION
## What does this PR do?

Adds regression coverage for GitHub #5683, where Claude Code's stable command symlink can be pinned to a versioned executable path at daemon startup and later disappear after Claude auto-updates and garbage-collects the old version directory.

The daemon's built-in `resolveAgentEntry` path already re-resolves vanished pinned executables for built-in providers. This PR makes the Claude native-installer shape explicit so future changes cannot accidentally leave this coverage Codex-only.

<!-- multica-auto-bugfix -->

## Related Issue

Closes #5683

Multica: ZIC-107

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Refactor / code improvement (no behavior change)
- [ ] Documentation update
- [x] Tests (adding or improving test coverage)
- [ ] CI / infrastructure

## Changes Made

- Added a Claude native-installer stale-symlink regression test in `server/internal/daemon/agent_path_selfheal_test.go`.
- Verified the healed executable path and detected version move together after the old Claude version directory disappears.

## How to Test

1. `cd server`
2. `go test ./internal/daemon -run 'TestResolveAgentEntry'`
3. `go test ./internal/daemon`

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] If this change affects the UI, I have included before/after screenshots (N/A - no UI change)
- [x] I have updated relevant documentation to reflect my changes (N/A - regression test only)
- [x] If I added a new runtime / coding tool / UI tab, I synced the change to **landing copy** (`apps/web/features/landing/i18n/`) and **relevant docs** (`apps/docs/content/docs/`) (N/A)
- [x] If this PR touches Chinese product copy, I checked it against `apps/docs/content/docs/developers/conventions.zh.mdx` (terminology, mixed-rule for `task` / `issue` / `skill`) (N/A)
- [x] I have considered and documented any risks above
- [x] I will address all reviewer comments before requesting merge

## AI Disclosure

**AI tool used:** Multica Agent

**Prompt / approach:**
Traced daemon executable resolution and self-heal behavior, then added focused regression coverage for the Claude native-installer symlink/update layout described in GitHub #5683.

## Screenshots (optional)

N/A
