### PR TITLE
Fix Home and End in search input

### DIFF
--- a/packages/views/search/search-command.test.tsx
+++ b/packages/views/search/search-command.test.tsx
@@ -1,5 +1,5 @@
 import { act, type ReactNode } from "react";
-import { render, screen, waitFor } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { I18nProvider } from "@multica/core/i18n/react";
@@ -260,6 +260,26 @@ describe("SearchCommand", () => {
       expect(useSearchStore.getState().open).toBe(false);
     });
     expect(screen.queryByPlaceholderText("Type a command or search...")).not.toBeInTheDocument();
+  });
+
+  it("moves the search input caret with Home and End", async () => {
+    const user = userEvent.setup();
+
+    renderSearch();
+
+    const input = screen.getByPlaceholderText("Type a command or search...") as HTMLInputElement;
+    await user.type(input, "abcdef");
+    input.setSelectionRange(3, 3);
+
+    fireEvent.keyDown(input, { key: "Home" });
+    expect(input.selectionStart).toBe(0);
+    expect(input.selectionEnd).toBe(0);
+    expect(useSearchStore.getState().open).toBe(true);
+
+    fireEvent.keyDown(input, { key: "End" });
+    expect(input.selectionStart).toBe(6);
+    expect(input.selectionEnd).toBe(6);
+    expect(useSearchStore.getState().open).toBe(true);
   });
 
   it("shows only New Issue by default and hides Pages / low-frequency commands until query", () => {

--- a/packages/views/search/search-command.tsx
+++ b/packages/views/search/search-command.tsx
@@ -138,6 +138,35 @@ interface SearchResults {
   projects: SearchProjectResult[];
 }
 
+function handleSearchInputKeyDown(event: React.KeyboardEvent<HTMLInputElement>) {
+  if (event.key !== "Home" && event.key !== "End") return;
+
+  event.stopPropagation();
+
+  if (event.altKey || event.ctrlKey || event.metaKey) return;
+
+  const input = event.currentTarget;
+  const target = event.key === "Home" ? 0 : input.value.length;
+
+  event.preventDefault();
+
+  if (event.shiftKey) {
+    const selectionStart = input.selectionStart ?? target;
+    const selectionEnd = input.selectionEnd ?? target;
+    const anchor =
+      input.selectionDirection === "backward" ? selectionEnd : selectionStart;
+
+    if (event.key === "Home") {
+      input.setSelectionRange(0, anchor, "backward");
+    } else {
+      input.setSelectionRange(anchor, input.value.length, "forward");
+    }
+    return;
+  }
+
+  input.setSelectionRange(target, target);
+}
+
 export function SearchCommand() {
   const { t } = useT("search");
   const navPages: NavPage[] = [
@@ -481,6 +510,7 @@ export function SearchCommand() {
               placeholder={t(($) => $.placeholder)}
               value={query}
               onValueChange={handleValueChange}
+              onKeyDownCapture={handleSearchInputKeyDown}
               className="flex-1 bg-transparent text-sm outline-none placeholder:text-muted-foreground"
             />
             <kbd className="hidden shrink-0 rounded bg-muted px-1.5 py-0.5 text-[10px] font-medium text-muted-foreground sm:inline">


### PR DESCRIPTION
## What does this PR do?

Fixes Ctrl+K search input Home/End behavior by handling those keys on the focused input before cmdk's root list-navigation handler consumes them. Bare Home/End now move the caret to the beginning/end of the input, Shift+Home/End extends selection, and modified Home/End are kept from changing command-list selection while preserving browser/native default behavior.

<!-- multica-auto-bugfix -->

## Related Issue

Closes #5655

Multica issue: ZIC-109

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Refactor / code improvement (no behavior change)
- [x] Tests (adding or improving test coverage)
- [ ] CI / infrastructure

## Changes Made

- Added focused Home/End key handling to `packages/views/search/search-command.tsx`.
- Added a regression test for moving the Ctrl+K search input caret with Home/End.

## How to Test

1. Open the app, press Ctrl+K, type text in the search input, place the caret in the middle, then press Home and End.
2. Confirm Home moves the caret to the beginning and End moves it to the end without closing the palette or selecting first/last results.
3. Run the automated checks listed below.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [ ] I have updated relevant documentation to reflect my changes
- [ ] If I added a new runtime / coding tool / UI tab, I synced the change to **landing copy** (`apps/web/features/landing/i18n/`) and **relevant docs** (`apps/docs/content/docs/`)
- [ ] If this PR touches Chinese product copy, I checked it against `apps/docs/content/docs/developers/conventions.zh.mdx` (terminology, mixed-rule for `task` / `issue` / `skill`)
- [x] I have considered and documented any risks above
- [x] I will address all reviewer comments before requesting merge

## Validation

- PASS: `pnpm --filter @multica/views exec vitest run search/search-command.test.tsx`
- PASS: `pnpm --filter @multica/views typecheck` on the upstream-main based branch before rebasing to the fork push base.
- PASS: `pnpm --filter @multica/views lint` (exits 0 with existing warnings).
- LIMITED: `make check-worktree` reported Docker unavailable while checking PostgreSQL: `Cannot connect to the Docker daemon at unix:///Users/icezero/.docker/run/docker.sock`.
- LIMITED: after rebasing onto `fork/main` to avoid workflow-scope push rejection, `pnpm --filter @multica/views typecheck` fails in unrelated mention/slash suggestion tests missing the newer `signal` argument.
- LIMITED: full `pnpm --filter @multica/views test` reached 236 passing files / 2720 passing tests, with one unrelated failure in `layout/sidebar-resize.test.tsx` expecting `localStorage.setItem` to be called once.

## AI Disclosure

**AI tool used:** Multica Agent

**Prompt / approach:**
Traced Ctrl+K search palette keyboard handling, confirmed cmdk's root handler consumes Home/End for first/last item navigation, added input-level capture handling for native text editing, and added a focused regression test.

## Screenshots (optional)

Not included; this is keyboard caret behavior covered by a focused test.
