### PR TITLE
[ZIC-108] Fix comment-triggered agent working status refresh

### DIFF
--- a/packages/core/issues/mutations.test.tsx
+++ b/packages/core/issues/mutations.test.tsx
@@ -10,6 +10,7 @@ import { setApiInstance } from "../api";
 import type { ApiClient } from "../api/client";
 import {
   useBatchUpdateIssues,
+  useCreateComment,
   useLoadMoreByAssigneeGroup,
   useLoadMoreByStatus,
   useResolveComment,
@@ -19,7 +20,9 @@ import {
   issueKeys,
   type IssueSortParam,
 } from "./queries";
+import { agentTaskSnapshotKeys } from "../agents/queries";
 import type {
+  Comment,
   GroupedIssuesResponse,
   Issue,
   ListIssuesCache,
@@ -63,11 +66,64 @@ function makeIssue(idx: number, overrides: Partial<Issue> = {}): Issue {
   };
 }
 
+function makeComment(overrides: Partial<Comment> = {}): Comment {
+  return {
+    id: "comment-1",
+    issue_id: "issue-1",
+    author_type: "member",
+    author_id: "user-1",
+    content: "please continue",
+    type: "comment",
+    parent_id: null,
+    reactions: [],
+    attachments: [],
+    created_at: "2025-01-01T00:00:00Z",
+    updated_at: "2025-01-01T00:00:00Z",
+    resolved_at: null,
+    resolved_by_type: null,
+    resolved_by_id: null,
+    ...overrides,
+  };
+}
 function createWrapper(qc: QueryClient) {
   return function Wrapper({ children }: { children: ReactNode }) {
     return <QueryClientProvider client={qc}>{children}</QueryClientProvider>;
   };
 }
+
+describe("useCreateComment", () => {
+  let qc: QueryClient;
+  let createComment: ReturnType<typeof vi.fn<() => Promise<Comment>>>;
+
+  beforeEach(() => {
+    qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    createComment = vi.fn().mockResolvedValue(makeComment({ issue_id: "issue-1" }));
+    setApiInstance({ createComment } as unknown as ApiClient);
+  });
+
+  afterEach(() => {
+    qc.clear();
+    vi.restoreAllMocks();
+  });
+
+  it("refreshes active-task caches after a saved comment can trigger agent work", async () => {
+    qc.setQueryData(issueKeys.tasks("issue-1"), []);
+    qc.setQueryData(agentTaskSnapshotKeys.list(WS_ID), []);
+
+    const { result } = renderHook(() => useCreateComment("issue-1"), {
+      wrapper: createWrapper(qc),
+    });
+
+    await act(async () => {
+      await result.current.mutateAsync({ content: "please continue" });
+    });
+
+    expect(qc.getQueryState(issueKeys.tasks("issue-1"))?.isInvalidated).toBe(true);
+    expect(
+      qc.getQueryState(agentTaskSnapshotKeys.list(WS_ID))?.isInvalidated,
+    ).toBe(true);
+  });
+});
 
 describe("useLoadMoreByStatus", () => {
   let qc: QueryClient;

--- a/packages/core/issues/mutations.ts
+++ b/packages/core/issues/mutations.ts
@@ -9,6 +9,7 @@ import {
   type MyIssuesFilter,
 } from "./queries";
 import { projectKeys } from "../projects/queries";
+import { agentTaskSnapshotKeys } from "../agents/queries";
 import {
   addIssueToBuckets,
   findIssueLocation,
@@ -679,6 +680,7 @@ type TimelineCache = TimelineEntry[];
 
 export function useCreateComment(issueId: string) {
   const qc = useQueryClient();
+  const wsId = useWorkspaceId();
   return useMutation({
     mutationFn: ({
       content,
@@ -719,6 +721,14 @@ export function useCreateComment(issueId: string) {
       // task now dedupes follow-up triggers), so cached previews for this
       // issue are stale the moment the create lands.
       qc.invalidateQueries({ queryKey: issueKeys.commentTriggerPreview(issueId) });
+      // A saved comment can immediately enqueue an issue task (assignee
+      // follow-up, @agent, @squad). Refresh the active-task caches that drive
+      // the issue-header and workspace "agents working" indicators without
+      // waiting for a separate task lifecycle event.
+      qc.invalidateQueries({ queryKey: issueKeys.tasks(issueId) });
+      if (wsId) {
+        qc.invalidateQueries({ queryKey: agentTaskSnapshotKeys.list(wsId) });
+      }
     },
     // No onSettled invalidate. The `comment:created` WS broadcast keeps
     // the timeline cache fresh after a successful create, and reconnect

--- a/packages/core/realtime/use-realtime-sync.ts
+++ b/packages/core/realtime/use-realtime-sync.ts
@@ -684,7 +684,16 @@ export function useRealtimeSync(
 
     const unsubCommentCreated = ws.on("comment:created", (p) => {
       const { comment } = p as CommentCreatedPayload;
-      if (comment?.issue_id) invalidateTimeline(comment.issue_id);
+      if (!comment?.issue_id) return;
+      invalidateTimeline(comment.issue_id);
+      const wsId = getCurrentWsId();
+      if (wsId) {
+        // Comments can enqueue issue tasks before or without an immediate
+        // task:* fanout reaching this tab. Refresh the live work indicators
+        // that read task caches instead of waiting for focus/manual reload.
+        qc.invalidateQueries({ queryKey: issueKeys.tasks(comment.issue_id) });
+        qc.invalidateQueries({ queryKey: agentTaskSnapshotKeys.list(wsId) });
+      }
     });
 
     const unsubCommentUpdated = ws.on("comment:updated", (p) => {


### PR DESCRIPTION
## What does this PR do?

Restores immediate refresh of the live agent-working indicators after an issue comment is saved or received over realtime.

Root cause: the comment create path updated the timeline and trigger preview caches, but did not refresh the issue task list or workspace task snapshot caches that power the header and workspace working chips. If the task lifecycle event lagged or was missed, those indicators stayed stale until a focus/manual refresh.

<!-- multica-auto-bugfix -->

## Related Issue

Closes #5596

Multica issue: ZIC-108

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Refactor / code improvement (no behavior change)
- [x] Tests (adding or improving test coverage)
- [ ] CI / infrastructure

## Changes Made

- `packages/core/issues/mutations.ts`: invalidate the per-issue task cache and workspace agent task snapshot after successful comment creation.
- `packages/core/realtime/use-realtime-sync.ts`: refresh those same active-task caches when a `comment:created` event arrives in another tab.
- `packages/core/issues/mutations.test.tsx`: cover comment-created invalidation of active-task caches.

## How to Test

1. `pnpm -C packages/core exec vitest run issues/mutations.test.tsx`
2. `pnpm -C packages/core typecheck`
3. `pnpm -C packages/core lint`

`make check-worktree` was attempted and exited 0, but the local Docker daemon was unavailable during its PostgreSQL preflight, so the focused package checks above are the meaningful validation from this environment.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [ ] I have updated relevant documentation to reflect my changes
- [ ] If I added a new runtime / coding tool / UI tab, I synced the change to **landing copy** (`apps/web/features/landing/i18n/`) and **relevant docs** (`apps/docs/content/docs/`)
- [ ] If this PR touches Chinese product copy, I checked it against `apps/docs/content/docs/developers/conventions.zh.mdx` (terminology, mixed-rule for `task` / `issue` / `skill`)
- [x] I have considered and documented any risks above
- [x] I will address all reviewer comments before requesting merge

## AI Disclosure

**AI tool used:** Multica Agent

**Prompt / approach:**
Traced the comment submission, realtime comment event, issue header active-task query, and workspace agent task snapshot paths; then added cache invalidations at the comment mutation and realtime broadcast boundaries.

## Screenshots (optional)

Not applicable; this is a realtime cache refresh fix with unit coverage.
