### PR TITLE
INF-1200: add audited parent trigger suppression

### DIFF
--- a/server/cmd/multica/cmd_issue.go
+++ b/server/cmd/multica/cmd_issue.go
@@ -495,7 +495,7 @@ func init() {
 	issueUpdateCmd.Flags().String("output", "json", "Output format: table or json")
 
 	// issue status
-	issueStatusCmd.Flags().String("output", "table", "Output format: table or json")
+	registerIssueStatusFlags(issueStatusCmd)
 
 	// issue reorder
 	registerIssueReorderFlags(issueReorderCmd)
@@ -1427,6 +1427,10 @@ func runIssueStatus(cmd *cobra.Command, args []string) error {
 	if err := validateIssueStatus(status); err != nil {
 		return err
 	}
+	suppressParentAssigneeTrigger, _ := cmd.Flags().GetBool("suppress-parent-assignee-trigger")
+	if suppressParentAssigneeTrigger && status != "done" {
+		return fmt.Errorf("--suppress-parent-assignee-trigger is only valid when setting a child issue to done")
+	}
 
 	client, err := newAPIClient(cmd)
 	if err != nil {
@@ -1442,6 +1446,9 @@ func runIssueStatus(cmd *cobra.Command, args []string) error {
 	}
 
 	body := map[string]any{"status": status}
+	if suppressParentAssigneeTrigger {
+		body["suppress_parent_assignee_trigger"] = true
+	}
 	var result map[string]any
 	if err := client.PutJSON(ctx, "/api/issues/"+issueRef.ID, body, &result); err != nil {
 		return fmt.Errorf("update status: %w", err)
@@ -1454,6 +1461,16 @@ func runIssueStatus(cmd *cobra.Command, args []string) error {
 		return cli.PrintJSON(os.Stdout, result)
 	}
 	return nil
+}
+
+// registerIssueStatusFlags keeps the narrowly scoped parent-trigger suppression
+// opt-in attached only to `issue status`. It deliberately does not appear on
+// generic issue update/assign commands: callers must make an explicit child ->
+// done transition, and the server preserves the parent system comment while
+// auditing and skipping only that transition's parent-assignee dispatch.
+func registerIssueStatusFlags(cmd *cobra.Command) {
+	cmd.Flags().String("output", "table", "Output format: table or json")
+	cmd.Flags().Bool("suppress-parent-assignee-trigger", false, "When setting a child to done, preserve the parent system comment but audit and skip the parent assignee task dispatch")
 }
 
 // ---------------------------------------------------------------------------

--- a/server/cmd/multica/cmd_issue_test.go
+++ b/server/cmd/multica/cmd_issue_test.go
@@ -2820,6 +2820,78 @@ func newIssueUpdateTestCmd() *cobra.Command {
 	return cmd
 }
 
+func newIssueStatusTestCmd() *cobra.Command {
+	cmd := &cobra.Command{Use: "status"}
+	registerIssueStatusFlags(cmd)
+	return cmd
+}
+
+func TestRunIssueStatusParentTriggerSuppressionWireContract(t *testing.T) {
+	tests := []struct {
+		name      string
+		suppress  bool
+		wantField bool
+	}{
+		{name: "default omitted", suppress: false, wantField: false},
+		{name: "explicit opt-in", suppress: true, wantField: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var body map[string]any
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				switch {
+				case r.Method == http.MethodGet && r.URL.Path == "/api/issues/INF-1200":
+					json.NewEncoder(w).Encode(map[string]any{
+						"id": "issue-1", "identifier": "INF-1200", "status": "in_progress",
+					})
+				case r.Method == http.MethodPut && r.URL.Path == "/api/issues/issue-1":
+					if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+						t.Errorf("decode body: %v", err)
+					}
+					json.NewEncoder(w).Encode(map[string]any{
+						"id": "issue-1", "identifier": "INF-1200", "status": "done",
+					})
+				default:
+					http.NotFound(w, r)
+				}
+			}))
+			defer srv.Close()
+
+			t.Setenv("MULTICA_SERVER_URL", srv.URL)
+			t.Setenv("MULTICA_WORKSPACE_ID", "ws-1")
+			t.Setenv("MULTICA_TOKEN", "mat_test-token")
+
+			cmd := newIssueStatusTestCmd()
+			if tt.suppress {
+				_ = cmd.Flags().Set("suppress-parent-assignee-trigger", "true")
+			}
+			if err := runIssueStatus(cmd, []string{"INF-1200", "done"}); err != nil {
+				t.Fatalf("runIssueStatus: %v", err)
+			}
+			if body["status"] != "done" {
+				t.Fatalf("status = %#v, want done", body["status"])
+			}
+			got, present := body["suppress_parent_assignee_trigger"]
+			if present != tt.wantField {
+				t.Fatalf("suppression field presence = %v, want %v (body=%#v)", present, tt.wantField, body)
+			}
+			if present && got != true {
+				t.Fatalf("suppress_parent_assignee_trigger = %#v, want true", got)
+			}
+		})
+	}
+}
+
+func TestRunIssueStatusRejectsSuppressionOutsideDone(t *testing.T) {
+	cmd := newIssueStatusTestCmd()
+	_ = cmd.Flags().Set("suppress-parent-assignee-trigger", "true")
+	err := runIssueStatus(cmd, []string{"INF-1200", "in_review"})
+	if err == nil || !strings.Contains(err.Error(), "only valid when setting a child issue to done") {
+		t.Fatalf("expected narrow done-only validation error, got %v", err)
+	}
+}
+
 func newIssueListTestCmd() *cobra.Command {
 	cmd := &cobra.Command{Use: "list"}
 	cmd.Flags().String("output", "table", "")

--- a/server/internal/handler/github.go
+++ b/server/internal/handler/github.go
@@ -1377,7 +1377,7 @@ func (h *Handler) advanceIssueToDone(ctx context.Context, issue db.Issue, worksp
 	// it here would leave the parent silent for the dominant completion path.
 	// notifyParentOfChildDone re-checks every guard (prev != done, parent
 	// exists, parent not terminal), so calling it unconditionally is safe.
-	h.notifyParentOfChildDone(ctx, issue, updated)
+	h.notifyParentOfChildDone(ctx, issue, updated, childDoneNotificationOptions{})
 
 	prefix := h.getIssuePrefix(ctx, issue.WorkspaceID)
 	resp := issueToResponse(updated, prefix)

--- a/server/internal/handler/issue.go
+++ b/server/internal/handler/issue.go
@@ -2675,6 +2675,11 @@ type UpdateIssueRequest struct {
 	// the issue can be run later via manual run/rerun. Optional; omitted or
 	// false keeps today's behavior. Mirrors comment suppress_agent_ids.
 	SuppressRun bool `json:"suppress_run,omitempty"`
+	// SuppressParentAssigneeTrigger applies only to an explicit child -> done
+	// status transition. The normal parent system comment is preserved, but the
+	// parent-assignee task dispatch is skipped after a durable audit row is
+	// written. Optional; omitted or false preserves the default wake behavior.
+	SuppressParentAssigneeTrigger bool `json:"suppress_parent_assignee_trigger,omitempty"`
 	// HandoffNote is an optional free-text instruction injected into the run's
 	// opening context when this write starts an agent/squad run ("交接说明" —
 	// MUL-3375). Only consumed when a run actually starts: SuppressRun=true or
@@ -2738,6 +2743,10 @@ func (h *Handler) UpdateIssue(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		params.Priority = pgtype.Text{String: *req.Priority, Valid: true}
+	}
+	if req.SuppressParentAssigneeTrigger && (req.Status == nil || *req.Status != "done") {
+		writeError(w, http.StatusBadRequest, "suppress_parent_assignee_trigger is only valid when setting a child issue to done")
+		return
 	}
 	if req.Position != nil {
 		params.Position = pgtype.Float8{Float64: *req.Position, Valid: true}
@@ -2957,7 +2966,11 @@ func (h *Handler) UpdateIssue(w http.ResponseWriter, r *http.Request) {
 	// loops in PR #2918). The helper guards on transition + parent state and
 	// fails best-effort.
 	if statusChanged {
-		h.notifyParentOfChildDone(r.Context(), prevIssue, issue)
+		h.notifyParentOfChildDone(r.Context(), prevIssue, issue, childDoneNotificationOptions{
+			SuppressParentAssigneeTrigger: req.SuppressParentAssigneeTrigger,
+			ActorType:                     actorType,
+			ActorID:                       actorID,
+		})
 	}
 
 	writeJSON(w, http.StatusOK, resp)
@@ -3244,6 +3257,10 @@ func (h *Handler) BatchUpdateIssues(w http.ResponseWriter, r *http.Request) {
 		if !validateIssueEnum(w, "priority", *req.Updates.Priority, validIssuePriorities) {
 			return
 		}
+	}
+	if req.Updates.SuppressParentAssigneeTrigger {
+		writeError(w, http.StatusBadRequest, "suppress_parent_assignee_trigger is only supported for single-issue status updates")
+		return
 	}
 
 	workspaceID := h.resolveWorkspaceID(r)

--- a/server/internal/handler/issue_child_done.go
+++ b/server/internal/handler/issue_child_done.go
@@ -2,6 +2,7 @@ package handler
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"log/slog"
 	"sort"
@@ -9,9 +10,22 @@ import (
 	"strings"
 
 	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/multica-ai/multica/server/internal/util"
 	db "github.com/multica-ai/multica/server/pkg/db/generated"
 	"github.com/multica-ai/multica/server/pkg/protocol"
 )
+
+const childDoneParentTriggerSuppressedActivity = "child_done_parent_assignee_trigger_suppressed"
+
+// childDoneNotificationOptions is request-scoped control for the one optional
+// side effect of a child completion. A zero value is the historical behavior.
+// Actor identity is captured only so an applied suppression can leave a
+// durable, queryable audit row before the dispatcher is skipped.
+type childDoneNotificationOptions struct {
+	SuppressParentAssigneeTrigger bool
+	ActorType                     string
+	ActorID                       string
+}
 
 // notifyParentOfChildDone posts a top-level system comment on the parent
 // issue when a child issue transitions from non-done into done. This replaces
@@ -65,7 +79,7 @@ import (
 // Errors are logged at warn level and swallowed: this is a best-effort
 // notification on the side of a successful status update; failing it must
 // not roll back the user's status change.
-func (h *Handler) notifyParentOfChildDone(ctx context.Context, prev, issue db.Issue) {
+func (h *Handler) notifyParentOfChildDone(ctx context.Context, prev, issue db.Issue, opts childDoneNotificationOptions) {
 	if !issue.ParentIssueID.Valid {
 		return
 	}
@@ -132,7 +146,7 @@ func (h *Handler) notifyParentOfChildDone(ctx context.Context, prev, issue db.Is
 	if staged {
 		closedStage = issue.Stage.Int32
 	}
-	h.postChildDoneComment(ctx, parent, issue, children, staged, closedStage, false)
+	h.postChildDoneComment(ctx, parent, issue, children, staged, closedStage, false, opts)
 }
 
 // notifyParentsOfBatchChildDone emits child-done parent notifications for a
@@ -210,7 +224,7 @@ func (h *Handler) notifyParentsOfBatchChildDone(ctx context.Context, completed [
 			if !stageBarrierClosed(children, g.children[0]) {
 				continue
 			}
-			h.postChildDoneComment(ctx, parent, g.children[0], children, false, 0, batch)
+			h.postChildDoneComment(ctx, parent, g.children[0], children, false, 0, batch, childDoneNotificationOptions{})
 			continue
 		}
 
@@ -241,7 +255,7 @@ func (h *Handler) notifyParentsOfBatchChildDone(ctx context.Context, completed [
 		if !found {
 			continue
 		}
-		h.postChildDoneComment(ctx, parent, rep, children, true, bestStage, batch)
+		h.postChildDoneComment(ctx, parent, rep, children, true, bestStage, batch, childDoneNotificationOptions{})
 	}
 }
 
@@ -256,7 +270,7 @@ func (h *Handler) notifyParentsOfBatchChildDone(ctx context.Context, completed [
 // an unstaged set). `batch` selects batch-aware wording: a single update keeps
 // its historical byte-identical copy, while a batch that finished several
 // children at once must not claim "the last sub-issue just finished".
-func (h *Handler) postChildDoneComment(ctx context.Context, parent, completed db.Issue, children []db.Issue, staged bool, closedStage int32, batch bool) {
+func (h *Handler) postChildDoneComment(ctx context.Context, parent, completed db.Issue, children []db.Issue, staged bool, closedStage int32, batch bool, opts childDoneNotificationOptions) {
 	prefix := h.getIssuePrefix(ctx, completed.WorkspaceID)
 	identifier := prefix + "-" + strconv.Itoa(int(completed.Number))
 	childID := uuidToString(completed.ID)
@@ -331,7 +345,67 @@ func (h *Handler) postChildDoneComment(ctx context.Context, parent, completed db
 	// author_type='system'); this keeps smuggled mentions from the child
 	// title inert and gives the platform a single place to apply the loop
 	// and idempotency guards.
+	parentHasDispatchableAssignee := parent.AssigneeType.Valid && parent.AssigneeID.Valid &&
+		(parent.AssigneeType.String == "agent" || parent.AssigneeType.String == "squad")
+	if opts.SuppressParentAssigneeTrigger && parentHasDispatchableAssignee {
+		// Suppression is fail-closed with respect to auditability: if the durable
+		// audit row cannot be written, retain the historical dispatch. The status
+		// update and normal system comment already succeeded, so this best-effort
+		// side effect must not turn the whole request into a misleading retry.
+		if err := h.auditChildDoneParentTriggerSuppression(ctx, opts, parent, completed, comment); err == nil {
+			slog.Info("child done: parent assignee trigger suppressed",
+				"child_id", childID,
+				"parent_id", parentID,
+				"comment_id", uuidToString(comment.ID),
+				"actor_type", opts.ActorType,
+				"actor_id", opts.ActorID)
+			return
+		} else {
+			slog.Error("child done: suppression audit failed; dispatching parent assignee trigger",
+				"error", err,
+				"child_id", childID,
+				"parent_id", parentID,
+				"comment_id", uuidToString(comment.ID),
+				"actor_type", opts.ActorType,
+				"actor_id", opts.ActorID)
+		}
+	}
 	h.dispatchParentAssigneeTrigger(ctx, parent, comment)
+}
+
+// auditChildDoneParentTriggerSuppression records the exact actor and artifacts
+// involved in an applied suppression. The activity belongs to the child issue,
+// whose status mutation requested the opt-in; parent/comment ids make the
+// skipped dispatch independently traceable without mutating either artifact.
+func (h *Handler) auditChildDoneParentTriggerSuppression(ctx context.Context, opts childDoneNotificationOptions, parent, child db.Issue, comment db.Comment) error {
+	actorID, err := util.ParseUUID(opts.ActorID)
+	if err != nil {
+		return fmt.Errorf("parse suppression actor id: %w", err)
+	}
+	if opts.ActorType != "member" && opts.ActorType != "agent" {
+		return fmt.Errorf("invalid suppression actor type %q", opts.ActorType)
+	}
+	details, err := json.Marshal(map[string]any{
+		"child_issue_id":    uuidToString(child.ID),
+		"child_status":      child.Status,
+		"parent_issue_id":   uuidToString(parent.ID),
+		"system_comment_id": uuidToString(comment.ID),
+	})
+	if err != nil {
+		return fmt.Errorf("encode suppression audit details: %w", err)
+	}
+	_, err = h.Queries.CreateActivity(ctx, db.CreateActivityParams{
+		WorkspaceID: child.WorkspaceID,
+		IssueID:     child.ID,
+		ActorType:   pgtype.Text{String: opts.ActorType, Valid: true},
+		ActorID:     actorID,
+		Action:      childDoneParentTriggerSuppressedActivity,
+		Details:     details,
+	})
+	if err != nil {
+		return fmt.Errorf("create suppression audit activity: %w", err)
+	}
+	return nil
 }
 
 // isTerminalChildStatus reports whether a child issue status counts as

--- a/server/internal/handler/issue_child_done_test.go
+++ b/server/internal/handler/issue_child_done_test.go
@@ -73,6 +73,25 @@ func updateChildStatus(t *testing.T, childID, status string) {
 	}
 }
 
+// updateChildStatusSuppressingParentTrigger drives the explicit automation
+// opt-in. The request still performs a normal child -> done transition; only
+// the parent-assignee task dispatch is suppressed after the parent comment and
+// durable audit row are written.
+func updateChildStatusSuppressingParentTrigger(t *testing.T, childID string) {
+	t.Helper()
+
+	w := httptest.NewRecorder()
+	req := newRequest("PUT", "/api/issues/"+childID, map[string]any{
+		"status":                           "done",
+		"suppress_parent_assignee_trigger": true,
+	})
+	req = withURLParam(req, "id", childID)
+	testHandler.UpdateIssue(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("UpdateIssue suppressed child status: expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
 // countSystemCommentsOn returns the number of platform-generated comments on
 // the given issue. The schema CHECK was widened in migration 107 to allow
 // author_type='system'; this query is the canary that the migration applied
@@ -170,6 +189,32 @@ func TestChildDoneNotificationIsIdempotent(t *testing.T) {
 	updateChildStatus(t, fx.child.ID, "done")
 	if got := countSystemCommentsOn(t, fx.parent.ID); got != 1 {
 		t.Fatalf("after second done: expected still 1 comment (idempotent), got %d", got)
+	}
+}
+
+func TestSuppressParentAssigneeTriggerRequiresDoneStatus(t *testing.T) {
+	fx := newChildDoneFixture(t, "in_progress")
+
+	w := httptest.NewRecorder()
+	req := newRequest("PUT", "/api/issues/"+fx.child.ID, map[string]any{
+		"status":                           "in_review",
+		"suppress_parent_assignee_trigger": true,
+	})
+	req = withURLParam(req, "id", fx.child.ID)
+	testHandler.UpdateIssue(w, req)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("UpdateIssue invalid suppression scope: expected 400, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var status string
+	if err := testPool.QueryRow(context.Background(), `SELECT status FROM issue WHERE id = $1`, fx.child.ID).Scan(&status); err != nil {
+		t.Fatalf("read child after rejected update: %v", err)
+	}
+	if status != "in_progress" {
+		t.Errorf("rejected suppression request changed child status to %q", status)
+	}
+	if got := countSystemCommentsOn(t, fx.parent.ID); got != 0 {
+		t.Errorf("rejected suppression request created %d parent comments, want 0", got)
 	}
 }
 
@@ -339,6 +384,77 @@ func TestChildDoneMentionsParentAssignee_Agent(t *testing.T) {
 	}
 	if got := countPendingTasksForAgent(t, fx.parent.ID, agentID); got != 1 {
 		t.Errorf("expected 1 pending task for parent agent, got %d", got)
+	}
+}
+
+// TestChildDoneSuppressParentAssigneeTriggerKeepsCommentAndAudits proves the
+// opt-in stops exactly one side effect: the parent-assignee task. The ordinary
+// system comment (including its assignee mention) remains, the suppression is
+// durably attributable to the request actor, and a later member correction on
+// the same parent still follows the normal comment-trigger path.
+func TestChildDoneSuppressParentAssigneeTriggerKeepsCommentAndAudits(t *testing.T) {
+	fx := newChildDoneFixture(t, "in_progress")
+
+	var agentID string
+	if err := testPool.QueryRow(context.Background(),
+		`SELECT id FROM agent WHERE workspace_id = $1 AND name = $2`,
+		testWorkspaceID, "Handler Test Agent",
+	).Scan(&agentID); err != nil {
+		t.Fatalf("locate test agent: %v", err)
+	}
+	setIssueAssigneeDirect(t, fx.parent.ID, "agent", agentID)
+	t.Cleanup(func() {
+		testPool.Exec(context.Background(),
+			`DELETE FROM agent_task_queue WHERE issue_id = $1`, fx.parent.ID)
+		testPool.Exec(context.Background(),
+			`DELETE FROM activity_log WHERE issue_id = $1`, fx.child.ID)
+	})
+
+	updateChildStatusSuppressingParentTrigger(t, fx.child.ID)
+
+	content := parentSystemCommentContent(t, fx.parent.ID)
+	if !strings.Contains(content, "mention://agent/"+agentID) {
+		t.Errorf("suppression must preserve the normal parent-assignee mention, got: %s", content)
+	}
+	if got := countPendingTasksForAgent(t, fx.parent.ID, agentID); got != 0 {
+		t.Fatalf("suppressed child completion queued %d parent tasks, want 0", got)
+	}
+
+	var actorType, actorID, detailsJSON string
+	if err := testPool.QueryRow(context.Background(), `
+		SELECT actor_type, actor_id::text, details::text
+		FROM activity_log
+		WHERE issue_id = $1 AND action = $2
+	`, fx.child.ID, childDoneParentTriggerSuppressedActivity).Scan(&actorType, &actorID, &detailsJSON); err != nil {
+		t.Fatalf("read suppression audit activity: %v", err)
+	}
+	if actorType != "member" || actorID != testUserID {
+		t.Errorf("audit actor = %s/%s, want member/%s", actorType, actorID, testUserID)
+	}
+	var details map[string]any
+	if err := json.Unmarshal([]byte(detailsJSON), &details); err != nil {
+		t.Fatalf("decode suppression audit details: %v", err)
+	}
+	if details["child_issue_id"] != fx.child.ID || details["child_status"] != "done" || details["parent_issue_id"] != fx.parent.ID {
+		t.Errorf("unexpected suppression audit details: %#v", details)
+	}
+	if details["system_comment_id"] != systemCommentIDOn(t, fx.parent.ID) {
+		t.Errorf("audit system_comment_id = %#v, want current parent system comment", details["system_comment_id"])
+	}
+
+	// The suppression is not sticky and does not alter ordinary member comment
+	// routing. A later correction still wakes the parent assignee exactly once.
+	w := httptest.NewRecorder()
+	req := newRequest("POST", "/api/issues/"+fx.parent.ID+"/comments", map[string]any{
+		"content": "Member correction after the automated child completion.",
+	})
+	req = withURLParam(req, "id", fx.parent.ID)
+	testHandler.CreateComment(w, req)
+	if w.Code != http.StatusCreated {
+		t.Fatalf("CreateComment member correction: expected 201, got %d: %s", w.Code, w.Body.String())
+	}
+	if got := countPendingTasksForAgent(t, fx.parent.ID, agentID); got != 1 {
+		t.Errorf("ordinary member correction queued %d parent tasks, want 1", got)
 	}
 }
 

--- a/server/internal/service/builtin_skills/multica-working-on-issues/SKILL.md
+++ b/server/internal/service/builtin_skills/multica-working-on-issues/SKILL.md
@@ -185,6 +185,13 @@ on it. These are the contracts, not advice:
 - **`done`** on a child issue posts a system comment on its parent. If a PR
   carries close intent (`Closes MUL-XXXX`), it advances the issue to `done`
   itself on merge — you do not also need to flip it manually.
+- A specifically authorized automation may use
+  `multica issue status <child-id> done --suppress-parent-assignee-trigger` to
+  preserve that normal parent system comment while skipping only the
+  parent-assignee task dispatch for this one transition. The opt-in is
+  default-off, valid only for a single child → `done` status request, and leaves
+  a durable activity-log audit row. Do not use it for member comments,
+  corrections, assignments, ordinary status changes, or broad trigger control.
 - **`cancelled`** is a terminal, user-driven decision to close the issue. Like
   `done` it enqueues no new agent work, but it does **not** stop tasks already in
   flight — a run in progress keeps going (MUL-4465). To stop a running task,

--- a/server/internal/service/builtin_skills/multica-working-on-issues/references/working-on-issues-source-map.md
+++ b/server/internal/service/builtin_skills/multica-working-on-issues/references/working-on-issues-source-map.md
@@ -115,12 +115,12 @@ and is hidden from the PR list.
 
 | Behavior | File:line | Drifted from |
 |---|---|---|
-| Create-time: agent-assigned, non-backlog issue enqueues immediately | `server/internal/handler/issue.go:2263-2264` | new citation |
-| `shouldEnqueueAgentTask` returns false for `backlog` (parking lot) | `server/internal/handler/issue.go:2644-2648` | new citation |
-| Backlog → non-backlog (not done/cancelled) enqueues on update | `server/internal/handler/issue.go:2537-2540` | `:2523` |
-| Same contract in batch update | `server/internal/handler/issue.go:3021-3024` | new citation |
-| Child → `done` notifies + wakes the parent, gated by the stage barrier | `server/internal/handler/issue_child_done.go:66` (`notifyParentOfChildDone`; doc comment at `:15`; barrier gate at `:115`) | func def `:51` |
-| Status change (incl. → `cancelled`) does NOT cancel in-flight tasks; only issue deletion does (MUL-4465) | no-cancel note in `server/internal/handler/issue.go:2652-2658` (`UpdateIssue`) and `:3170-3171` (`BatchUpdateIssues`); deletion still cancels at `:2863` (`DeleteIssue`) / `:3239` (`BatchDeleteIssues`) via `CancelTasksForIssue` (`server/internal/service/task.go:1229`) | new citation |
+| Create-time: agent/squad-assigned, non-backlog issue enqueues immediately | `server/internal/service/issue.go:330-331,481-506,520-524` | refreshed citation |
+| Backlog → non-backlog (not done/cancelled) enqueues on update | shared predicate `server/internal/service/issue_trigger.go:99-115`; single write `server/internal/handler/issue.go:2951-2960` | refreshed citation |
+| Same contract in batch update | `server/internal/handler/issue.go:3457-3466` | refreshed citation |
+| Child → terminal notifies + wakes the parent by default, gated by the stage barrier | `server/internal/handler/issue_child_done.go:82-149`; comment/dispatch boundary `:273-373` | refreshed citation |
+| Explicit single-child → `done` suppression keeps the parent system comment, writes a durable audit activity, and skips only the parent-assignee dispatcher | request field/validation/call `server/internal/handler/issue.go:2678-2682,2747-2750,2969-2973`; comment/audit/dispatch boundary `server/internal/handler/issue_child_done.go:342-408`; CLI flag/wire field `server/cmd/multica/cmd_issue.go:1423-1474` | new citation |
+| Status change (incl. → `cancelled`) does NOT cancel in-flight tasks; only issue deletion does (MUL-4465) | no-cancel note in `server/internal/handler/issue.go:2939-2950` (`UpdateIssue`) and `:3469-3470` (`BatchUpdateIssues`); deletion calls at `:3151-3158` / `:3538`; implementation `server/internal/service/task.go:1604-1612` | refreshed citation |
 
 Creation with `--status todo` (or any non-backlog status) on an agent-assigned
 issue fires the agent immediately; `--status backlog` parks it with the assignee
@@ -139,10 +139,10 @@ away, so no task is left orphaned.
 | Behavior | File:line |
 |---|---|
 | `issue.stage` column (nullable, `>= 1`) | `server/migrations/123_issue_stage.up.sql` |
-| Stage barrier: notify+wake fire only when the lowest unfinished stage is all-terminal; unstaged set = one implicit stage | `server/internal/handler/issue_child_done.go:231` (`stageBarrierClosed`) |
-| Per-stage summary + next stage for the wake comment | `server/internal/handler/issue_child_done.go:254` (`stageProgressSummary`) |
-| `--stage` on `issue create` / `issue update` | `server/cmd/multica/cmd_issue.go:328,350` |
-| `multica issue children <id>` (sub-issues grouped by stage) | `server/cmd/multica/cmd_issue.go:114,678`; route `GET /api/issues/{id}/children` → `ListChildIssues` |
+| Stage barrier: notify+wake fire only when the lowest unfinished stage is all-terminal; unstaged set = one implicit stage | `server/internal/handler/issue_child_done.go:444` (`stageBarrierClosed`) |
+| Per-stage summary + next stage for the wake comment | `server/internal/handler/issue_child_done.go:476` (`stageProgressSummary`) |
+| `--stage` on `issue create` / `issue update` | `server/cmd/multica/cmd_issue.go:470,493` |
+| `multica issue children <id>` (sub-issues grouped by stage) | `server/cmd/multica/cmd_issue.go:191,862`; route `GET /api/issues/{id}/children` → `ListChildIssues` |
 
 Advancement is agent-driven: the server only detects the closed barrier and
 wakes the parent assignee. Promoting the next stage's `backlog` sub-issues to


### PR DESCRIPTION
## Summary

- add the default-off `suppress_parent_assignee_trigger` field to single-issue status updates
- expose it only as `multica issue status <child> done --suppress-parent-assignee-trigger`
- preserve the normal parent system comment while durably auditing and skipping only the parent-assignee task dispatch
- keep default, batch, PR-merge, member-comment, correction, assignment, and ordinary status paths unchanged
- document the narrowly authorized automation contract in the built-in issue-working skill

## Why

Child completion currently creates the correct parent system comment and immediately dispatches the parent assignee. Verified automation sometimes needs the durable comment without another agent run. The dispatcher had no request-scoped suppression boundary, so local automation could not prevent that redundant wake safely.

The new path is done-only, single-issue, default-off, and fail-closed: if its durable audit activity cannot be written, the server retains the historical dispatch behavior.

## Verification

- `go test ./internal/handler -run 'Test(BatchChildDone|ChildDone|ChildReopen|SuppressParentAssigneeTrigger)' -count=1`
- `go test ./cmd/multica -run 'TestRunIssueStatus(ParentTriggerSuppressionWireContract|RejectsSuppressionOutsideDone)$' -count=1`
- `go vet ./cmd/multica ./internal/handler`
- `git diff --check`

The handler integration tests ran against a fresh isolated PostgreSQL 17 database migrated through the repository's current migration set. No production deployment or live issue-status mutation was performed.
