### PR TITLE
fix(agent/cursor): send prompt on stdin so CLI-like flags cannot be re-tokenised (MUL-4992)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -194,6 +194,19 @@ jobs:
         # outside this PR; the normal backend job still runs the full package.
         run: go test ./internal/daemon/execenv -run '^TestPrepareIsolated_WindowsKillsDescendantBeforeRetry$' -count=1 -timeout=5m
 
+      - name: Test Windows agent launcher argv/stdin handling
+        working-directory: server
+        # Agent prompts must never reach a Windows launcher through argv: the
+        # official cursor-agent.ps1 ends in `& node.exe index.js $args`, and
+        # PowerShell re-serialises $args onto the child command line. Under
+        # Legacy native argument passing (powershell.exe 5.1, pwsh <= 7.2) a
+        # prompt holding embedded quotes is re-tokenised and fragments like
+        # `-X` become flags (#5649). Only a real PowerShell host proves this,
+        # so it cannot live in the ubuntu backend job. Scoped to the launcher
+        # tests, which are windows-tagged and therefore run nowhere else today;
+        # the backend job still runs the full package on Linux.
+        run: go test ./pkg/agent -run '^(TestCursorExecutePromptSurvivesPowerShellShim|TestPlatformCursorInvocation|TestPlatformCopilotInvocation|TestPlatformPiInvocation)' -count=1 -timeout=5m
+
       - name: Build Windows CLI helper entrypoint
         working-directory: server
         run: go build ./cmd/multica

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -205,7 +205,9 @@ jobs:
         # so it cannot live in the ubuntu backend job. Scoped to the launcher
         # tests, which are windows-tagged and therefore run nowhere else today;
         # the backend job still runs the full package on Linux.
-        run: go test ./pkg/agent -run '^(TestCursorExecutePromptSurvivesPowerShellShim|TestPlatformCursorInvocation|TestPlatformCopilotInvocation|TestPlatformPiInvocation)' -count=1 -timeout=5m
+        # -v so a silent skip (no PowerShell host resolved, or a -run pattern
+        # that stops matching) is visible in the log instead of passing as "ok".
+        run: go test ./pkg/agent -v -run '^(TestCursorExecutePromptSurvivesPowerShellShim|TestPlatformCursorInvocation|TestPlatformCopilotInvocation|TestPlatformPiInvocation)' -count=1 -timeout=5m
 
       - name: Build Windows CLI helper entrypoint
         working-directory: server

--- a/server/pkg/agent/cursor.go
+++ b/server/pkg/agent/cursor.go
@@ -5,10 +5,12 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"log/slog"
 	"os/exec"
 	"regexp"
 	"strings"
+	"sync"
 	"time"
 )
 
@@ -33,7 +35,7 @@ func (b *cursorBackend) Execute(ctx context.Context, prompt string, opts ExecOpt
 	timeout := opts.Timeout
 	runCtx, cancel := runContext(ctx, timeout)
 
-	args := buildCursorArgs(prompt, opts, b.cfg.Logger)
+	args := buildCursorArgs(opts, b.cfg.Logger)
 	argv0, cmdArgs := chooseCursorInvocation(execName, lookedUp, args, b.cfg.Logger)
 
 	cmd := exec.CommandContext(runCtx, argv0, cmdArgs...)
@@ -50,10 +52,18 @@ func (b *cursorBackend) Execute(ctx context.Context, prompt string, opts ExecOpt
 		cancel()
 		return nil, fmt.Errorf("cursor stdout pipe: %w", err)
 	}
+	stdin, err := cmd.StdinPipe()
+	if err != nil {
+		cancel()
+		return nil, fmt.Errorf("cursor stdin pipe: %w", err)
+	}
+	var closeStdinOnce sync.Once
+	closeStdin := func() { closeStdinOnce.Do(func() { _ = stdin.Close() }) }
 	stderrBuf := newStderrTail(newLogWriter(b.cfg.Logger, "[cursor:stderr] "), agentStderrTailBytes)
 	cmd.Stderr = stderrBuf
 
 	if err := cmd.Start(); err != nil {
+		closeStdin()
 		cancel()
 		return nil, fmt.Errorf("start cursor-agent: %w", err)
 	}
@@ -63,14 +73,30 @@ func (b *cursorBackend) Execute(ctx context.Context, prompt string, opts ExecOpt
 	msgCh := make(chan Message, 256)
 	resCh := make(chan Result, 1)
 
+	// The prompt is delivered on stdin (see buildCursorArgs). Write it from its
+	// own goroutine so it cannot deadlock against the stdout reader below: a
+	// prompt larger than the OS pipe buffer (~64 KiB) blocks mid-write until the
+	// child drains it, and the child cannot drain while we are not reading its
+	// stdout. Closing stdin is what signals end-of-prompt — cursor-agent reads
+	// to EOF — so we always close, on both the success and error paths.
+	writeErrCh := make(chan error, 1)
+	go func() {
+		_, err := io.WriteString(stdin, prompt)
+		closeStdin()
+		writeErrCh <- err
+	}()
+
 	go func() {
 		defer cancel()
 		defer close(msgCh)
 		defer close(resCh)
 
 		// Close stdout when the context is cancelled so scanner.Scan() unblocks.
+		// Closing stdin too releases a prompt write still blocked on a full pipe
+		// (e.g. the child died before draining it), so that goroutine cannot leak.
 		go func() {
 			<-runCtx.Done()
+			closeStdin()
 			_ = stdout.Close()
 		}()
 
@@ -224,6 +250,10 @@ func (b *cursorBackend) Execute(ctx context.Context, prompt string, opts ExecOpt
 		exitErr := cmd.Wait()
 		duration := time.Since(startTime)
 
+		// Wait has already closed the stdin pipe, so a prompt write still blocked
+		// on a full pipe has returned by now; the writer sends exactly once.
+		writeErr := <-writeErrCh
+
 		if resultSeen {
 			// A parsed result is the protocol boundary. Ignore the cancellation and
 			// exit error caused by stopping a Cursor worker that lingers afterward.
@@ -244,6 +274,14 @@ func (b *cursorBackend) Execute(ctx context.Context, prompt string, opts ExecOpt
 			case protocolError != "":
 				finalStatus = "failed"
 				finalError = protocolError
+			case writeErr != nil:
+				// Ranked below explicit agent errors because a child that exits
+				// early for its own reason (bad auth, bad flag) makes our write
+				// fail with EPIPE as a side effect. The stderr tail is appended
+				// to every !resultSeen failure below, so the real cause still
+				// surfaces either way.
+				finalStatus = "failed"
+				finalError = fmt.Sprintf("cursor-agent prompt write failed: %v", writeErr)
 			case exitErr != nil:
 				finalStatus = "failed"
 				finalError = fmt.Sprintf("cursor-agent exited with error: %v", exitErr)
@@ -587,12 +625,27 @@ var cursorBlockedArgs = map[string]blockedArgMode{
 
 // buildCursorArgs assembles the argv for a one-shot cursor-agent invocation.
 //
-// Usage: cursor-agent -p <prompt> --output-format stream-json
+// Usage: cursor-agent -p --output-format stream-json
 //
 //	--workspace <cwd> --yolo [--model <m>] [--resume <id>]
-func buildCursorArgs(prompt string, opts ExecOptions, logger *slog.Logger) []string {
+//
+// The prompt is deliberately NOT part of argv. cursor-agent's -p is a boolean
+// print-mode switch and the prompt is a positional argument; when no positional
+// prompt is present and stdin is not a TTY, the CLI reads stdin to EOF and uses
+// that as the prompt. We rely on that path because putting user-controlled text
+// on the command line is not safe on Windows: the official cursor-agent.cmd/.ps1
+// launcher ends in `& node.exe index.js $args`, and PowerShell re-serialises
+// $args onto node's command line. Under Windows PowerShell 5.1 (and pwsh
+// <= 7.2, which default to Legacy native argument passing) an argument holding
+// embedded double quotes is not re-escaped, so a prompt containing e.g.
+// `go build -ldflags "-X main.version=foo"` gets re-tokenised and `-X` reaches
+// commander.js as a standalone flag: "error: unknown option '-X'" (#5649).
+// Routing the prompt through stdin keeps it off every command line, so no shell
+// or launcher on any platform can re-tokenise it. Only fixed, content-free
+// flags remain in argv.
+func buildCursorArgs(opts ExecOptions, logger *slog.Logger) []string {
 	args := []string{
-		"-p", prompt,
+		"-p",
 		"--output-format", "stream-json",
 		"--yolo",
 	}

--- a/server/pkg/agent/cursor_stdin_unix_test.go
+++ b/server/pkg/agent/cursor_stdin_unix_test.go
@@ -1,0 +1,156 @@
+//go:build unix
+
+package agent
+
+import (
+	"fmt"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// cursorStdinProbe runs the cursor backend against a fake cursor-agent that
+// records the argv it was given and drains its stdin to EOF, then emits a
+// terminal stream-json result. It returns (argv, stdin, result).
+//
+// Draining stdin before answering mirrors the real CLI: with no positional
+// prompt and a non-TTY stdin, cursor-agent reads stdin to EOF and uses it as
+// the prompt.
+func cursorStdinProbe(t *testing.T, prompt string) ([]string, string, Result) {
+	t.Helper()
+
+	dir := t.TempDir()
+	argvPath := filepath.Join(dir, "argv.txt")
+	stdinPath := filepath.Join(dir, "stdin.txt")
+
+	// Record argv one element per line, then drain stdin to EOF before
+	// answering. Quoting "$@" keeps each argv element intact.
+	script := fmt.Sprintf(`#!/bin/sh
+: > %[1]q
+for a in "$@"; do printf '%%s\n' "$a" >> %[1]q; done
+cat > %[2]q
+printf '%%s\n' '{"type":"result","subtype":"success","is_error":false,"result":"ok"}'
+`, argvPath, stdinPath)
+
+	fakePath := filepath.Join(dir, "cursor-agent")
+	writeTestExecutable(t, fakePath, []byte(script))
+
+	backend, err := New("cursor", Config{ExecutablePath: fakePath, Logger: slog.Default()})
+	if err != nil {
+		t.Fatalf("New(cursor): %v", err)
+	}
+	session, err := backend.Execute(t.Context(), prompt, ExecOptions{Timeout: 30 * time.Second})
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	go func() {
+		for range session.Messages {
+		}
+	}()
+	result := <-session.Result
+
+	argvRaw, err := os.ReadFile(argvPath)
+	if err != nil {
+		t.Fatalf("read recorded argv: %v", err)
+	}
+	stdinRaw, err := os.ReadFile(stdinPath)
+	if err != nil {
+		t.Fatalf("read recorded stdin: %v", err)
+	}
+	argv := strings.Split(strings.TrimSuffix(string(argvRaw), "\n"), "\n")
+	return argv, string(stdinRaw), result
+}
+
+// TestCursorExecuteSendsPromptOnStdinNotArgv is the regression test for #5649.
+// A prompt carrying CLI-like flags inside embedded double quotes (the exact
+// shape from the report) must reach the child intact on stdin, and must not
+// appear in argv at all — argv is where Windows launchers re-tokenise it.
+func TestCursorExecuteSendsPromptOnStdinNotArgv(t *testing.T) {
+	t.Parallel()
+
+	prompt := "Please fix the build.\n" +
+		"Log follows:\n" +
+		`go build -ldflags "-X main.version=foo -X main.commit=bar" -o bin/server ./cmd/server` + "\n" +
+		"Thanks."
+
+	argv, stdinGot, result := cursorStdinProbe(t, prompt)
+
+	if stdinGot != prompt {
+		t.Errorf("prompt did not arrive on stdin intact:\n got  %q\n want %q", stdinGot, prompt)
+	}
+
+	// The whole point of the fix: no fragment of the prompt is in argv, so no
+	// shell or launcher on any platform can re-tokenise it into flags.
+	for _, a := range argv {
+		for _, needle := range []string{"-X", "ldflags", "main.version", "Please fix"} {
+			if strings.Contains(a, needle) {
+				t.Errorf("prompt fragment %q leaked into argv element %q; argv=%v", needle, a, argv)
+			}
+		}
+	}
+
+	// The fixed, content-free flags must still be present.
+	joined := strings.Join(argv, " ")
+	for _, want := range []string{"-p", "--output-format", "stream-json", "--yolo"} {
+		if !strings.Contains(joined, want) {
+			t.Errorf("expected %q in argv, got %v", want, argv)
+		}
+	}
+
+	if result.Status != "completed" {
+		t.Fatalf("status = %q, want completed; error=%q", result.Status, result.Error)
+	}
+}
+
+// TestCursorExecuteLargePromptDoesNotDeadlock guards the reason the prompt
+// write lives in its own goroutine. A prompt well past the OS pipe buffer
+// (~64 KiB) blocks mid-write until the child drains it; if we wrote it before
+// starting the stdout reader, neither side could make progress and the run
+// would fail only at the task timeout.
+func TestCursorExecuteLargePromptDoesNotDeadlock(t *testing.T) {
+	t.Parallel()
+
+	// 512 KiB — several times any plausible pipe buffer on Linux/macOS.
+	prompt := strings.Repeat("multica cursor stdin payload 0123456789\n", 13_108)
+	if len(prompt) < 512*1024 {
+		t.Fatalf("test prompt too small: %d bytes", len(prompt))
+	}
+
+	_, stdinGot, result := cursorStdinProbe(t, prompt)
+
+	if len(stdinGot) != len(prompt) {
+		t.Errorf("stdin truncated: got %d bytes, want %d", len(stdinGot), len(prompt))
+	}
+	if stdinGot != prompt {
+		t.Error("large prompt arrived corrupted on stdin")
+	}
+	if result.Status != "completed" {
+		t.Fatalf("status = %q, want completed; error=%q", result.Status, result.Error)
+	}
+}
+
+// TestCursorExecuteWritesPromptVerbatim pins our side of the whitespace
+// contract: we write the prompt bytes exactly as given, adding no wrapper,
+// framing or trailing newline (unlike Claude, which sends a JSON frame).
+//
+// Note the CLI itself trims the stdin prompt before use, so leading/trailing
+// whitespace is not preserved end-to-end. That is cursor-agent's behaviour, not
+// ours; task prompts carry no meaning in outer whitespace, so we do not
+// compensate for it here.
+func TestCursorExecuteWritesPromptVerbatim(t *testing.T) {
+	t.Parallel()
+
+	prompt := "\n  leading and trailing whitespace  \n\n"
+
+	_, stdinGot, result := cursorStdinProbe(t, prompt)
+
+	if stdinGot != prompt {
+		t.Errorf("prompt was mutated before write:\n got  %q\n want %q", stdinGot, prompt)
+	}
+	if result.Status != "completed" {
+		t.Fatalf("status = %q, want completed; error=%q", result.Status, result.Error)
+	}
+}

--- a/server/pkg/agent/cursor_stdin_unix_test.go
+++ b/server/pkg/agent/cursor_stdin_unix_test.go
@@ -3,6 +3,7 @@
 package agent
 
 import (
+	"context"
 	"fmt"
 	"log/slog"
 	"os"
@@ -105,30 +106,110 @@ func TestCursorExecuteSendsPromptOnStdinNotArgv(t *testing.T) {
 	}
 }
 
-// TestCursorExecuteLargePromptDoesNotDeadlock guards the reason the prompt
-// write lives in its own goroutine. A prompt well past the OS pipe buffer
-// (~64 KiB) blocks mid-write until the child drains it; if we wrote it before
-// starting the stdout reader, neither side could make progress and the run
-// would fail only at the task timeout.
+// TestCursorExecuteLargePromptDoesNotDeadlock is the interlock test: it forces
+// the exact mutual block the concurrent writer exists to avoid.
+//
+// The child floods stdout PAST the pipe capacity *before* reading a byte of
+// stdin. So the child is blocked writing stdout, and a parent that wrote the
+// prompt before starting its stdout reader would be blocked writing stdin —
+// neither side can advance and the run only ends at the task timeout. It passes
+// only because the writer and the scanner run concurrently.
+//
+// Ordering matters: a fake that drains stdin first would pass even against a
+// synchronous write, which is why this test flooded stdout first.
 func TestCursorExecuteLargePromptDoesNotDeadlock(t *testing.T) {
 	t.Parallel()
 
-	// 512 KiB — several times any plausible pipe buffer on Linux/macOS.
+	dir := t.TempDir()
+	stdinPath := filepath.Join(dir, "stdin.txt")
+
+	// ~520 KiB of stdout before any read of stdin, several times any plausible
+	// pipe buffer on Linux/macOS.
+	script := fmt.Sprintf(`#!/bin/sh
+yes '{"type":"noise","pad":"0123456789012345678901234567890123456789"}' | head -n 8000
+cat > %[1]q
+printf '%%s\n' '{"type":"result","subtype":"success","is_error":false,"result":"ok"}'
+`, stdinPath)
+
+	fakePath := filepath.Join(dir, "cursor-agent")
+	writeTestExecutable(t, fakePath, []byte(script))
+
 	prompt := strings.Repeat("multica cursor stdin payload 0123456789\n", 13_108)
 	if len(prompt) < 512*1024 {
 		t.Fatalf("test prompt too small: %d bytes", len(prompt))
 	}
 
-	_, stdinGot, result := cursorStdinProbe(t, prompt)
-
-	if len(stdinGot) != len(prompt) {
-		t.Errorf("stdin truncated: got %d bytes, want %d", len(stdinGot), len(prompt))
+	backend, err := New("cursor", Config{ExecutablePath: fakePath, Logger: slog.Default()})
+	if err != nil {
+		t.Fatalf("New(cursor): %v", err)
 	}
-	if stdinGot != prompt {
+	// A deadlock surfaces as this timeout firing instead of a completed run.
+	session, err := backend.Execute(t.Context(), prompt, ExecOptions{Timeout: 30 * time.Second})
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	go func() {
+		for range session.Messages {
+		}
+	}()
+	result := <-session.Result
+
+	stdinRaw, err := os.ReadFile(stdinPath)
+	if err != nil {
+		t.Fatalf("read recorded stdin: %v", err)
+	}
+	if len(stdinRaw) != len(prompt) {
+		t.Errorf("stdin truncated: got %d bytes, want %d", len(stdinRaw), len(prompt))
+	}
+	if string(stdinRaw) != prompt {
 		t.Error("large prompt arrived corrupted on stdin")
 	}
 	if result.Status != "completed" {
-		t.Fatalf("status = %q, want completed; error=%q", result.Status, result.Error)
+		t.Fatalf("status = %q, want completed (deadlock would show as timeout); error=%q", result.Status, result.Error)
+	}
+}
+
+// TestCursorExecuteCancelReleasesBlockedPromptWrite pins the other unlock
+// point. The child never reads stdin at all, so a prompt past the pipe buffer
+// leaves the writer blocked indefinitely; cancelling the parent context must
+// close stdin, release that writer, and settle the run rather than hang.
+func TestCursorExecuteCancelReleasesBlockedPromptWrite(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	// Never reads stdin, never exits on its own.
+	script := "#!/bin/sh\nsleep 120\n"
+	fakePath := filepath.Join(dir, "cursor-agent")
+	writeTestExecutable(t, fakePath, []byte(script))
+
+	prompt := strings.Repeat("blocked write payload 0123456789\n", 16_384) // ~512 KiB
+
+	backend, err := New("cursor", Config{ExecutablePath: fakePath, Logger: slog.Default()})
+	if err != nil {
+		t.Fatalf("New(cursor): %v", err)
+	}
+	ctx, cancel := context.WithCancel(t.Context())
+	session, err := backend.Execute(ctx, prompt, ExecOptions{Timeout: 120 * time.Second})
+	if err != nil {
+		cancel()
+		t.Fatalf("Execute: %v", err)
+	}
+	go func() {
+		for range session.Messages {
+		}
+	}()
+
+	// Give the writer time to fill the pipe and block, then cancel.
+	time.Sleep(200 * time.Millisecond)
+	cancel()
+
+	select {
+	case result := <-session.Result:
+		if result.Status != "aborted" {
+			t.Fatalf("status = %q, want aborted; error=%q", result.Status, result.Error)
+		}
+	case <-time.After(30 * time.Second):
+		t.Fatal("cancel did not release the blocked prompt write; Result never arrived")
 	}
 }
 

--- a/server/pkg/agent/cursor_stdin_windows_test.go
+++ b/server/pkg/agent/cursor_stdin_windows_test.go
@@ -1,0 +1,99 @@
+//go:build windows
+
+package agent
+
+import (
+	"fmt"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestCursorExecutePromptSurvivesPowerShellShim is the Windows half of the
+// #5649 regression. It drives a real PowerShell host through the same
+// .cmd → `powershell -File <ps1>` rewrite production uses, and asserts the two
+// properties the fix depends on:
+//
+//   - the prompt is absent from the argv PowerShell hands the shim, so the
+//     `& node.exe index.js $args` re-serialisation in the official shim has
+//     nothing user-controlled left to re-tokenise; and
+//   - the prompt still arrives byte-for-byte on stdin.
+//
+// Unlike the unix tests this one needs a real powershell.exe/pwsh.exe, so it
+// only runs on Windows. It deliberately does NOT stub powerShellLookup — the
+// point is to exercise the actual host.
+func TestCursorExecutePromptSurvivesPowerShellShim(t *testing.T) {
+	if _, ok := defaultPowerShellLookup(); !ok {
+		t.Skip("no PowerShell host available")
+	}
+
+	dir := t.TempDir()
+	argvPath := filepath.Join(dir, "argv.txt")
+	stdinPath := filepath.Join(dir, "stdin.txt")
+
+	// The .cmd only has to exist and carry the right extension; the rewrite
+	// routes around it to the sibling .ps1, which is what actually runs.
+	cmdPath := filepath.Join(dir, "cursor-agent.cmd")
+	writeFile(t, cmdPath, "@echo off\r\npowershell -NoProfile -ExecutionPolicy Bypass -File \"%~dp0cursor-agent.ps1\" %*\r\n")
+
+	// Record argv and stdin with .NET APIs so nothing adds a BOM or rewrites
+	// line endings, then emit the terminal stream-json event.
+	ps1 := fmt.Sprintf(""+
+		"[System.IO.File]::WriteAllLines('%s', [string[]]$args)\r\n"+
+		"$stdin = [Console]::In.ReadToEnd()\r\n"+
+		"[System.IO.File]::WriteAllText('%s', $stdin)\r\n"+
+		"Write-Output '{\"type\":\"result\",\"subtype\":\"success\",\"is_error\":false,\"result\":\"ok\"}'\r\n",
+		argvPath, stdinPath)
+	writeFile(t, filepath.Join(dir, "cursor-agent.ps1"), ps1)
+
+	prompt := "Please fix the build.\n" +
+		`go build -ldflags "-X main.version=foo -X main.commit=bar" -o bin/server ./cmd/server` + "\n" +
+		"Thanks."
+
+	backend, err := New("cursor", Config{ExecutablePath: cmdPath, Logger: slog.Default()})
+	if err != nil {
+		t.Fatalf("New(cursor): %v", err)
+	}
+	session, err := backend.Execute(t.Context(), prompt, ExecOptions{Timeout: 60 * time.Second})
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	go func() {
+		for range session.Messages {
+		}
+	}()
+	result := <-session.Result
+
+	argvRaw, err := os.ReadFile(argvPath)
+	if err != nil {
+		t.Fatalf("read recorded argv (shim did not run?): %v; result=%+v", err, result)
+	}
+	stdinRaw, err := os.ReadFile(stdinPath)
+	if err != nil {
+		t.Fatalf("read recorded stdin: %v; result=%+v", err, result)
+	}
+
+	// PowerShell hands the script one argv element per line here; no element
+	// may carry any part of the prompt.
+	for _, a := range strings.Split(strings.TrimSuffix(string(argvRaw), "\r\n"), "\r\n") {
+		for _, needle := range []string{"-X", "ldflags", "main.version", "Please fix"} {
+			if strings.Contains(a, needle) {
+				t.Errorf("prompt fragment %q leaked into argv element %q", needle, a)
+			}
+		}
+	}
+
+	// [Console]::In normalises the trailing newline of the stream, so compare
+	// on normalised line endings rather than raw bytes.
+	gotStdin := strings.ReplaceAll(string(stdinRaw), "\r\n", "\n")
+	if strings.TrimRight(gotStdin, "\r\n") != strings.TrimRight(prompt, "\n") {
+		t.Errorf("prompt did not survive the PowerShell hop:\n got  %q\n want %q", gotStdin, prompt)
+	}
+
+	if result.Status != "completed" {
+		t.Fatalf("status = %q, want completed; error=%q", result.Status, result.Error)
+	}
+}

--- a/server/pkg/agent/cursor_stdin_windows_test.go
+++ b/server/pkg/agent/cursor_stdin_windows_test.go
@@ -4,6 +4,7 @@ package agent
 
 import (
 	"fmt"
+	"io"
 	"log/slog"
 	"os"
 	"os/exec"
@@ -13,22 +14,70 @@ import (
 	"time"
 )
 
+// Env contract between the test and the helper process it re-executes as the
+// native child of the PowerShell shim.
+const (
+	shimHelperEnv      = "MULTICA_CURSOR_SHIM_HELPER"
+	shimHelperArgvFile = "MULTICA_CURSOR_SHIM_ARGV_FILE"
+	shimHelperInFile   = "MULTICA_CURSOR_SHIM_STDIN_FILE"
+)
+
+// TestCursorShimHelperProcess is not a test. Re-executed by the fake
+// cursor-agent.ps1 below, it stands in for `node.exe index.js` as a real native
+// child: it records the argv it was handed, drains stdin, and emits the
+// terminal stream-json event. Inert unless the shim env var is set.
+func TestCursorShimHelperProcess(t *testing.T) {
+	if os.Getenv(shimHelperEnv) != "1" {
+		t.Skip("helper process; only runs when re-executed by the shim")
+	}
+
+	// Everything after "--" is what the shim forwarded to us.
+	var forwarded []string
+	for i, a := range os.Args {
+		if a == "--" {
+			forwarded = os.Args[i+1:]
+			break
+		}
+	}
+	if err := os.WriteFile(os.Getenv(shimHelperArgvFile), []byte(strings.Join(forwarded, "\n")), 0o644); err != nil {
+		fmt.Fprintf(os.Stderr, "helper: write argv: %v\n", err)
+		os.Exit(1)
+	}
+	stdin, err := io.ReadAll(os.Stdin)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "helper: read stdin: %v\n", err)
+		os.Exit(1)
+	}
+	if err := os.WriteFile(os.Getenv(shimHelperInFile), stdin, 0o644); err != nil {
+		fmt.Fprintf(os.Stderr, "helper: write stdin: %v\n", err)
+		os.Exit(1)
+	}
+
+	fmt.Println(`{"type":"result","subtype":"success","is_error":false,"result":"ok"}`)
+	// Exit before the test framework can print PASS/ok into the JSON stream.
+	os.Exit(0)
+}
+
 // TestCursorExecutePromptSurvivesPowerShellShim is the Windows half of the
-// #5649 regression. It drives a real PowerShell host through the same
-// .cmd → `powershell -File <ps1>` rewrite production uses, and asserts the two
-// properties the fix depends on:
+// #5649 regression, and it exercises the full production launch chain:
 //
-//   - the prompt is absent from the argv PowerShell hands the shim, so the
-//     `& node.exe index.js $args` re-serialisation in the official shim has
-//     nothing user-controlled left to re-tokenise; and
-//   - the prompt still arrives byte-for-byte on stdin.
+//	Go → powershell -File cursor-agent.ps1 → native child
+//
+// The last hop is the one that matters and the one a shim-only test cannot
+// reach. The official cursor-agent.ps1 ends in `& node.exe index.js $args`, so
+// the fake ps1 here likewise invokes a *native* executable with $args and lets
+// that child record argv and read stdin. That proves both properties the fix
+// depends on end to end:
+//
+//   - the prompt is absent from the argv PowerShell re-serialises onto the
+//     child's command line, so there is nothing left to re-tokenise; and
+//   - stdin is still inherited by the native child, byte for byte.
 //
 // It runs against every PowerShell host present, not just the one
-// defaultPowerShellLookup would pick. That matters because the two hosts differ
-// on exactly the mechanism behind this bug: windows powershell.exe (5.1) and
-// pwsh <= 7.2 default to Legacy native argument passing, while pwsh >= 7.3
-// defaults to Standard. A fix that only held on the newer host would be no fix
-// at all for the reporter.
+// defaultPowerShellLookup would pick, because the hosts differ on exactly the
+// mechanism behind this bug: powershell.exe (5.1) and pwsh <= 7.2 default to
+// Legacy native argument passing, pwsh >= 7.3 to Standard. A fix that only held
+// on the newer host would be no fix at all for the reporter.
 func TestCursorExecutePromptSurvivesPowerShellShim(t *testing.T) {
 	hosts := availablePowerShellHosts()
 	if len(hosts) == 0 {
@@ -57,6 +106,11 @@ func availablePowerShellHosts() []string {
 func assertPromptSurvivesShim(t *testing.T) {
 	t.Helper()
 
+	self, err := os.Executable()
+	if err != nil {
+		t.Fatalf("locate test binary to use as native child: %v", err)
+	}
+
 	dir := t.TempDir()
 	argvPath := filepath.Join(dir, "argv.txt")
 	stdinPath := filepath.Join(dir, "stdin.txt")
@@ -66,14 +120,17 @@ func assertPromptSurvivesShim(t *testing.T) {
 	cmdPath := filepath.Join(dir, "cursor-agent.cmd")
 	writeFile(t, cmdPath, "@echo off\r\npowershell -NoProfile -ExecutionPolicy Bypass -File \"%~dp0cursor-agent.ps1\" %*\r\n")
 
-	// Record argv and stdin with .NET APIs so nothing adds a BOM or rewrites
-	// line endings, then emit the terminal stream-json event.
+	// Shaped like the official shim: set up, then hand $args to a native child.
 	ps1 := fmt.Sprintf(""+
-		"[System.IO.File]::WriteAllLines('%s', [string[]]$args)\r\n"+
-		"$stdin = [Console]::In.ReadToEnd()\r\n"+
-		"[System.IO.File]::WriteAllText('%s', $stdin)\r\n"+
-		"Write-Output '{\"type\":\"result\",\"subtype\":\"success\",\"is_error\":false,\"result\":\"ok\"}'\r\n",
-		argvPath, stdinPath)
+		"$env:%s = '1'\r\n"+
+		"$env:%s = '%s'\r\n"+
+		"$env:%s = '%s'\r\n"+
+		"& '%s' '-test.run=^TestCursorShimHelperProcess$' '--' $args\r\n"+
+		"exit $LASTEXITCODE\r\n",
+		shimHelperEnv,
+		shimHelperArgvFile, argvPath,
+		shimHelperInFile, stdinPath,
+		self)
 	writeFile(t, filepath.Join(dir, "cursor-agent.ps1"), ps1)
 
 	prompt := "Please fix the build.\n" +
@@ -96,28 +153,32 @@ func assertPromptSurvivesShim(t *testing.T) {
 
 	argvRaw, err := os.ReadFile(argvPath)
 	if err != nil {
-		t.Fatalf("read recorded argv (shim did not run?): %v; result=%+v", err, result)
+		t.Fatalf("native child never recorded argv (did the shim reach it?): %v; result=%+v", err, result)
 	}
 	stdinRaw, err := os.ReadFile(stdinPath)
 	if err != nil {
-		t.Fatalf("read recorded stdin: %v; result=%+v", err, result)
+		t.Fatalf("native child never recorded stdin: %v; result=%+v", err, result)
 	}
 
-	// PowerShell hands the script one argv element per line here; no element
-	// may carry any part of the prompt.
-	for _, a := range strings.Split(strings.TrimSuffix(string(argvRaw), "\r\n"), "\r\n") {
+	// argv as the *native child* received it — past PowerShell's $args
+	// re-serialisation, which is where #5649 was introduced.
+	for _, a := range strings.Split(strings.TrimSuffix(string(argvRaw), "\n"), "\n") {
 		for _, needle := range []string{"-X", "ldflags", "main.version", "Please fix"} {
 			if strings.Contains(a, needle) {
-				t.Errorf("prompt fragment %q leaked into argv element %q", needle, a)
+				t.Errorf("prompt fragment %q leaked into native child argv element %q", needle, a)
 			}
 		}
 	}
+	// The content-free flags must still survive the same hop.
+	gotArgv := string(argvRaw)
+	for _, want := range []string{"-p", "--output-format", "stream-json", "--yolo"} {
+		if !strings.Contains(gotArgv, want) {
+			t.Errorf("expected %q to reach the native child; argv was %q", want, gotArgv)
+		}
+	}
 
-	// [Console]::In normalises the trailing newline of the stream, so compare
-	// on normalised line endings rather than raw bytes.
-	gotStdin := strings.ReplaceAll(string(stdinRaw), "\r\n", "\n")
-	if strings.TrimRight(gotStdin, "\r\n") != strings.TrimRight(prompt, "\n") {
-		t.Errorf("prompt did not survive the PowerShell hop:\n got  %q\n want %q", gotStdin, prompt)
+	if string(stdinRaw) != prompt {
+		t.Errorf("prompt did not survive Go → PowerShell → native child:\n got  %q\n want %q", string(stdinRaw), prompt)
 	}
 
 	if result.Status != "completed" {

--- a/server/pkg/agent/cursor_stdin_windows_test.go
+++ b/server/pkg/agent/cursor_stdin_windows_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"log/slog"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -22,13 +23,39 @@ import (
 //     nothing user-controlled left to re-tokenise; and
 //   - the prompt still arrives byte-for-byte on stdin.
 //
-// Unlike the unix tests this one needs a real powershell.exe/pwsh.exe, so it
-// only runs on Windows. It deliberately does NOT stub powerShellLookup — the
-// point is to exercise the actual host.
+// It runs against every PowerShell host present, not just the one
+// defaultPowerShellLookup would pick. That matters because the two hosts differ
+// on exactly the mechanism behind this bug: windows powershell.exe (5.1) and
+// pwsh <= 7.2 default to Legacy native argument passing, while pwsh >= 7.3
+// defaults to Standard. A fix that only held on the newer host would be no fix
+// at all for the reporter.
 func TestCursorExecutePromptSurvivesPowerShellShim(t *testing.T) {
-	if _, ok := defaultPowerShellLookup(); !ok {
+	hosts := availablePowerShellHosts()
+	if len(hosts) == 0 {
 		t.Skip("no PowerShell host available")
 	}
+	for _, host := range hosts {
+		t.Run(filepath.Base(host), func(t *testing.T) {
+			stubPowerShell(t, host, true)
+			assertPromptSurvivesShim(t)
+		})
+	}
+}
+
+// availablePowerShellHosts resolves every PowerShell host on PATH so the
+// regression can be proven on each independently.
+func availablePowerShellHosts() []string {
+	var found []string
+	for _, name := range []string{"powershell.exe", "pwsh.exe"} {
+		if p, err := exec.LookPath(name); err == nil {
+			found = append(found, p)
+		}
+	}
+	return found
+}
+
+func assertPromptSurvivesShim(t *testing.T) {
+	t.Helper()
 
 	dir := t.TempDir()
 	argvPath := filepath.Join(dir, "argv.txt")

--- a/server/pkg/agent/cursor_test.go
+++ b/server/pkg/agent/cursor_test.go
@@ -21,13 +21,13 @@ func TestNewReturnsCursorBackend(t *testing.T) {
 func TestBuildCursorArgs(t *testing.T) {
 	t.Parallel()
 
-	args := buildCursorArgs("do something", ExecOptions{
+	args := buildCursorArgs(ExecOptions{
 		Cwd:   "/tmp/work",
 		Model: "composer-1.5",
 	}, slog.Default())
 
 	expected := []string{
-		"-p", "do something",
+		"-p",
 		"--output-format", "stream-json",
 		"--yolo",
 		"--workspace", "/tmp/work",
@@ -47,7 +47,7 @@ func TestBuildCursorArgs(t *testing.T) {
 func TestBuildCursorArgsWithResume(t *testing.T) {
 	t.Parallel()
 
-	args := buildCursorArgs("continue", ExecOptions{
+	args := buildCursorArgs(ExecOptions{
 		ResumeSessionID: "sess-123",
 	}, slog.Default())
 
@@ -65,8 +65,8 @@ func TestBuildCursorArgsWithResume(t *testing.T) {
 func TestBuildCursorArgsMinimal(t *testing.T) {
 	t.Parallel()
 
-	args := buildCursorArgs("hello", ExecOptions{}, slog.Default())
-	expected := []string{"-p", "hello", "--output-format", "stream-json", "--yolo"}
+	args := buildCursorArgs(ExecOptions{}, slog.Default())
+	expected := []string{"-p", "--output-format", "stream-json", "--yolo"}
 
 	if len(args) != len(expected) {
 		t.Fatalf("expected %d args, got %d: %v", len(expected), len(args), args)
@@ -78,7 +78,7 @@ func TestBuildCursorArgsIgnoresSystemPromptAndMaxTurns(t *testing.T) {
 
 	// cursor-agent CLI does not support --system-prompt or --max-turns;
 	// verify they are NOT emitted even when set in ExecOptions.
-	args := buildCursorArgs("task", ExecOptions{
+	args := buildCursorArgs(ExecOptions{
 		SystemPrompt: "You are helpful",
 		MaxTurns:     5,
 	}, slog.Default())
@@ -96,7 +96,7 @@ func TestBuildCursorArgsIgnoresSystemPromptAndMaxTurns(t *testing.T) {
 func TestBuildCursorArgsCustomArgs(t *testing.T) {
 	t.Parallel()
 
-	args := buildCursorArgs("task", ExecOptions{
+	args := buildCursorArgs(ExecOptions{
 		CustomArgs: []string{"--extra", "val", "--yolo", "--output-format", "text"},
 	}, slog.Default())
 


### PR DESCRIPTION
Fixes #5649. MUL-4992.

## Problem

On Windows, a Cursor task whose prompt contains CLI-like flags fails in ~2s with `error: unknown option '-X'` and no agent output. A pasted build log is enough to trigger it:

```
go build -ldflags "-X main.version=foo -X main.commit=bar" -o bin/server ./cmd/server
```

## Root cause

`buildCursorArgs` put the entire prompt in argv (the positional after `-p`). On Windows the official launcher chain ends in `& node.exe index.js $args` inside `cursor-agent.ps1`, where PowerShell re-serialises `$args` onto node's command line. Under Windows PowerShell 5.1 and pwsh <= 7.2 (Legacy native argument passing), an argument containing embedded double quotes is **not** re-escaped — the quoted region closes early, node's argv parser re-splits at the interior spaces, and `-X` arrives at commander.js as a standalone flag.

#1709 removed the `cmd.exe` `%*` re-tokenisation, but stopped at the Go → PowerShell boundary — one hop before this one. Its Windows tests only compare the argv slice Go builds and never execute a shim, which is why the gap stayed invisible.

## Fix

Keep the prompt off every command line. `cursor-agent`'s `-p` is a boolean print-mode switch and the prompt is positional; with no positional prompt and a non-TTY stdin, the CLI reads stdin to EOF and uses that as the prompt. So the prompt is dropped from argv **on all platforms** and written to stdin, leaving only fixed, content-free flags in argv:

```
before: -p <PROMPT> --output-format stream-json --yolo
after:  -p --output-format stream-json --yolo
```

Nothing can re-tokenise what is not on a command line. This also brings Cursor in line with `claude.go` / `codex.go`, which already deliver the prompt over stdin.

The write runs in its own goroutine — a prompt larger than the pipe buffer (~64 KiB) blocks mid-write until the child drains it, and the child cannot drain while nothing is reading its stdout. Closing stdin is what signals end-of-prompt, so it is closed on success, error, and cancellation paths. Write failures surface in the result diagnostic, ranked below explicit agent errors so an early child exit (bad auth, bad flag) is not masked by the resulting EPIPE.

## Verification

`go test -race ./pkg/agent/` passes (the one unrelated pre-existing failure, `TestGrokRealACPSmoke`, needs a locally authenticated grok CLI and fails identically on `main`).

New unix tests, all confirmed to **fail against the pre-fix code** and pass after:

- `TestCursorExecuteSendsPromptOnStdinNotArgv` — the exact `-ldflags "-X ..."` prompt arrives byte-for-byte on stdin and no fragment appears in argv. Pre-fix, argv contained `go build -ldflags "-X main.version=foo ..."` verbatim.
- `TestCursorExecuteLargePromptDoesNotDeadlock` — 512 KiB prompt, guards the concurrent write. Pre-fix: `stdin truncated: got 0 bytes, want 524320`.
- `TestCursorExecuteWritesPromptVerbatim` — pins that we write the prompt unmodified (no framing, no added newline). Note the CLI itself trims the stdin prompt, so outer whitespace is not preserved end-to-end; that is cursor-agent's behaviour and task prompts carry no meaning there.

## Windows verification: full chain, both hosts, in CI

`TestCursorExecutePromptSurvivesPowerShellShim` drives the complete production chain — **Go → `powershell -File cursor-agent.ps1` → native child** — not just the first two hops. The official shim ends in `& node.exe index.js $args`, so the fake ps1 likewise invokes a *native* executable with `$args`: it re-executes the test binary as a helper process, which records the argv it actually received and drains stdin. That is the hop where #5649 lives, and it is now asserted rather than assumed.

It runs against **every** PowerShell host on PATH, not just the one `defaultPowerShellLookup` picks. `powershell.exe` (5.1) and pwsh <= 7.2 default to Legacy native argument passing, pwsh >= 7.3 to Standard, so a fix verified only on the newer host would not be a fix for the reporter.

These launcher tests are `//go:build windows` while the backend job runs on ubuntu, so until now they ran **nowhere** — including the five #1709 added. They are wired into the existing `windows-execenv` job, with `-v` so a silent skip cannot masquerade as coverage.

Both hosts pass ([run](https://github.com/multica-ai/multica/actions/runs/29811254025/job/88572509947)):

```
--- PASS: TestCursorExecutePromptSurvivesPowerShellShim/powershell.exe (0.24s)
--- PASS: TestCursorExecutePromptSurvivesPowerShellShim/pwsh.exe (0.29s)
```

The native child receives `-p --output-format stream-json --yolo` and no fragment of the prompt, and its stdin matches the prompt byte for byte — so PowerShell does inherit stdin to the native child on both hosts.

## Concurrency tests actually create the conditions they guard

- `TestCursorExecuteLargePromptDoesNotDeadlock` — the fake floods stdout **past pipe capacity before reading stdin**, so the child is blocked writing while a parent that wrote the prompt before starting its reader would be blocked writing too. Confirmed to fail for the right reason: with the writer made synchronous it deadlocks to its 30s timeout, and passes only with the concurrent writer. (An earlier version drained stdin first and would have passed either way.)
- `TestCursorExecuteCancelReleasesBlockedPromptWrite` — the child never reads stdin, leaving the writer blocked on a full pipe; cancelling must close stdin, release the writer, and settle as `aborted` rather than hang.

## What this does and does not prove

Proven on real Windows, both hosts, through a native child: the prompt is absent from argv and arrives intact on stdin.

Not proven here: an end-to-end run against the real `cursor-agent` binary consuming that stdin as its prompt — that needs a Windows box with the CLI installed and a live #5649 repro. The supporting evidence is that `-p` is a boolean print-mode switch with a positional prompt, and the CLI's `build-prompt` path reads stdin to EOF when no positional prompt is present and stdin is not a TTY.
