### PR TITLE
MUL-5065: use the official Qwen Code logo

### DIFF
--- a/packages/views/runtimes/components/provider-logo.test.tsx
+++ b/packages/views/runtimes/components/provider-logo.test.tsx
@@ -6,7 +6,9 @@ describe("ProviderLogo", () => {
   it("renders the dedicated Qwen Code mark", () => {
     const { container } = render(<ProviderLogo provider="qwen" className="runtime-logo" />);
 
-    expect(container.querySelector("#qwen-logo-gradient")).not.toBeNull();
-    expect(container.querySelector("svg")?.classList.contains("runtime-logo")).toBe(true);
+    const logo = container.querySelector('svg[viewBox="0 0 141.38 140"]');
+
+    expect(logo?.querySelector('path[fill="#6D44E8"]')).not.toBeNull();
+    expect(logo?.classList.contains("runtime-logo")).toBe(true);
   });
 });

--- a/packages/views/runtimes/components/provider-logo.tsx
+++ b/packages/views/runtimes/components/provider-logo.tsx
@@ -283,20 +283,15 @@ function GrokLogo({ className }: { className: string }) {
   );
 }
 
-// Qwen Code — compact Q mark using Qwen's violet/blue brand palette. The
-// inline SVG keeps the runtime list crisp at small sizes without another asset.
+// Qwen Code — official mark from QwenLM/qwen-code's desktop brand assets
+// (packages/desktop/apps/electron/resources/brands/qwen-code/icon.svg).
 function QwenLogo({ className }: { className: string }) {
   return (
-    <svg viewBox="0 0 24 24" fill="none" className={className} aria-hidden>
-      <defs>
-        <linearGradient id="qwen-logo-gradient" x1="4" y1="3" x2="20" y2="21">
-          <stop stopColor="#7C4DFF" />
-          <stop offset="1" stopColor="#2F80ED" />
-        </linearGradient>
-      </defs>
-      <rect width="24" height="24" rx="5" fill="url(#qwen-logo-gradient)" />
-      <circle cx="11.5" cy="11.5" r="5.25" stroke="white" strokeWidth="2.25" />
-      <path d="m15.2 15.2 3.1 3.1" stroke="white" strokeWidth="2.25" strokeLinecap="round" />
+    <svg viewBox="0 0 141.38 140" className={className} aria-hidden>
+      <path
+        fill="#6D44E8"
+        d="m140.93 85-16.35-28.33-1.93-3.34 8.66-15a3.323 3.323 0 0 0 0-3.34l-9.62-16.67c-.3-.51-.72-.93-1.22-1.22s-1.07-.45-1.67-.45H82.23l-8.66-15a3.33 3.33 0 0 0-2.89-1.67H51.43c-.59 0-1.17.16-1.66.45-.5.29-.92.71-1.22 1.22L32.19 29.98l-1.92 3.33H12.96c-.59 0-1.17.16-1.66.45-.5.29-.93.71-1.22 1.22L.45 51.66a3.323 3.323 0 0 0 0 3.34l18.28 31.67-8.66 15a3.32 3.32 0 0 0 0 3.34l9.62 16.67c.3.51.72.93 1.22 1.22s1.07.45 1.67.45h36.56l8.66 15a3.35 3.35 0 0 0 2.89 1.67h19.25a3.34 3.34 0 0 0 2.89-1.67l18.28-31.67h17.32c.6 0 1.17-.16 1.67-.45s.92-.71 1.22-1.22l9.62-16.67a3.323 3.323 0 0 0 0-3.34ZM51.44 3.33 61.07 20l-9.63 16.66h76.98l-9.62 16.66H45.67l-11.54-20zM57.21 120H22.58l9.63-16.67h19.25l-38.5-66.67h19.25l9.62 16.67L68.78 100l-11.55 20Zm61.59-33.34-9.62-16.67-38.49 66.67-9.63-16.67 9.63-16.66 26.94-46.67h23.1l17.32 30z"
+      />
     </svg>
   );
 }


### PR DESCRIPTION
## Summary

- replace the hand-drawn Qwen Code placeholder with the official upstream SVG mark
- keep the logo inline so it stays crisp in the compact runtime list
- update the focused component test to assert the official viewBox and brand color

Source: https://github.com/QwenLM/qwen-code/blob/2abafe39da656ff40fadb82d2907a8078d7aa7c5/packages/desktop/apps/electron/resources/brands/qwen-code/icon.svg (Apache-2.0)

## Verification

- `pnpm --filter @multica/views exec vitest run runtimes/components/provider-logo.test.tsx`
- `pnpm --filter @multica/views typecheck`
- `pnpm --filter @multica/views exec eslint runtimes/components/provider-logo.tsx runtimes/components/provider-logo.test.tsx`

Closes MUL-5065
