### PR TITLE
fix(mobile): prevent hidden My Issues refresh spinner (MUL-5139)

### DIFF
--- a/apps/mobile/app/(app)/[workspace]/(tabs)/my-issues.tsx
+++ b/apps/mobile/app/(app)/[workspace]/(tabs)/my-issues.tsx
@@ -17,6 +17,7 @@
 import { useMemo } from "react";
 import { Pressable, SectionList, View } from "react-native";
 import { useQuery } from "@tanstack/react-query";
+import { useIsFocused } from "@react-navigation/native";
 import { router } from "expo-router";
 import { Ionicons } from "@expo/vector-icons";
 import type { Issue, IssuePriority, IssueStatus } from "@multica/core/types";
@@ -60,6 +61,7 @@ const SCOPES: { value: MyIssuesScope; label: string }[] = [
 type IssueSection = { status: IssueStatus; data: Issue[] };
 
 export default function MyIssues() {
+  const isFocused = useIsFocused();
   const userId = useAuthStore((s) => s.user?.id ?? null);
   const wsId = useWorkspaceStore((s) => s.currentWorkspaceId);
   const wsSlug = useWorkspaceStore((s) => s.currentWorkspaceSlug);
@@ -189,7 +191,7 @@ export default function MyIssues() {
               }}
             />
           )}
-          refreshing={isRefetching}
+          refreshing={isFocused && isRefetching}
           onRefresh={refetch}
         />
       )}
@@ -370,4 +372,3 @@ function emptyMessageForScope(scope: MyIssuesScope): string {
       return "No issues assigned to your agents or squads yet.";
   }
 }
-


### PR DESCRIPTION
# PR title

`fix(mobile): prevent hidden My Issues refresh spinner`

## What does this PR do?

Fixes an iOS-only `My Issues` refresh-control state leak that appears after updating an issue and navigating back from its detail screen.

The `My Issues` screen remains mounted behind the issue detail screen. Saving an issue invalidates the list query, so `isRefetching` can transition `false -> true -> false` while the list is not focused. Before this change, `SectionList.refreshing` forwarded those background transitions directly to the iOS Fabric `RefreshControl`.

### Root cause

The JavaScript query state completes correctly: `isRefetching` returns to `false`. The stale UI is in the native refresh-control lifecycle:

1. Fabric handles the programmatic `refreshing=true` transition by moving the underlying `UIScrollView` content offset by one refresh-control height and starting the spinner.
2. The matching `refreshing=false` transition happens while `My Issues` is inactive behind the detail screen.
3. The native spinner stops, but the programmatically introduced offset is not restored correctly in this inactive-screen timing.
4. When the user returns, the controlled value is already `false`, so React Native has no new `true -> false` transition to reconcile. The spinner and approximately 60 pt gap remain visible.

Diagnostic instrumentation confirmed that both React Query's `isRefetching` and the value passed to `SectionList.refreshing` were already `false` while the native spinner remained visible. The first section's accessibility frame moved from `y=171` normally to `y=231` in the stuck state, matching one refresh-control height.

The relevant React Native 0.83.6 implementation is asymmetric:

- [Fabric applies the controlled `refreshing` transition](https://github.com/facebook/react-native/blob/v0.83.6/packages/react-native/React/Fabric/Mounting/ComponentViews/ScrollView/RCTPullToRefreshViewComponentView.mm#L103-L109): the false branch only calls `endRefreshing`.
- [Fabric's programmatic begin changes `contentOffset`](https://github.com/facebook/react-native/blob/v0.83.6/packages/react-native/React/Fabric/Mounting/ComponentViews/ScrollView/RCTPullToRefreshViewComponentView.mm#L214-L228) by one refresh-control height.
- For comparison, the [legacy implementation explicitly restores the scroll offset](https://github.com/facebook/react-native/blob/v0.83.6/packages/react-native/React/Views/RefreshControl/RCTRefreshControl.m#L112-L137) when a programmatic refresh ends.

The fix gates only the native refresh indicator with screen focus:

```tsx
refreshing={isFocused && isRefetching}
```

Background query invalidation and refetching still run normally. An inactive `My Issues` screen simply no longer starts a native pull-to-refresh animation that the user cannot see.

## Related Issue

N/A — found during iOS smoke testing.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Refactor / code improvement (no behavior change)
- [ ] Documentation update
- [ ] Tests (adding or improving test coverage)
- [ ] CI / infrastructure

## Changes Made

- Read the current route focus state with `useIsFocused` in `apps/mobile/app/(app)/[workspace]/(tabs)/my-issues.tsx`.
- Expose `isRefetching` to `SectionList.refreshing` only while `My Issues` is focused.
- Keep background data refetching unchanged.

## How to Test

1. Launch the mobile app on an iOS Simulator and open **My Issues**.
2. Open an issue from the list.
3. Change its priority or status and wait for the update and list refetch to complete while the detail screen is still open.
4. Navigate back to **My Issues**.
5. Confirm the spinner is not exposed and the first section returns to its normal top position without the approximately 60 pt gap.
6. Pull to refresh while **My Issues** is visible and confirm the refresh indicator still behaves normally.

Verification completed locally:

- `vitest run`: 33 tests passed
- `tsc --noEmit`: passed
- `expo lint`: passed
- iPhone 16 Pro Simulator: update-and-return regression verified before and after the change

## Risk

Low. The change only affects presentation of the native refresh indicator. React Query still owns and performs the same background refetch. If the user returns while a refetch is still in progress, `isFocused && isRefetching` becomes `true` and the visible screen can still show the indicator.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable — no new unit test was added for this native navigation lifecycle edge; it was covered with an iOS Simulator regression and the existing mobile test suite
- [x] If this change affects the UI, I have included before/after recordings
- [x] I have updated relevant documentation to reflect my changes — N/A, no user-facing behavior or API documentation changed
- [x] If I added a new runtime / coding tool / UI tab, I synced the change to landing copy and relevant docs — N/A
- [x] If this PR touches Chinese product copy, I checked it against the terminology convention — N/A, no product copy changed
- [x] I have considered and documented any risks above
- [x] I will address all reviewer comments before requesting merge

## AI Disclosure

**AI tool used:** Codex

**Prompt / approach:** Reproduced the issue on an iOS Simulator, exposed the query/focus/list refreshing states on screen, compared the controlled JavaScript state with the native Fabric refresh-control behavior, then verified the smallest focus-gated change against the original update-and-return flow.

## Screenshots / recordings

### Before

https://github.com/user-attachments/assets/5f61d950-d39a-4067-8df8-d8b3962b3403

After the background refetch completes and the user returns to **My Issues**, the spinner remains exposed and the list content stays shifted down by approximately 60 pt.

### After

https://github.com/user-attachments/assets/a794d6c4-b908-48a0-b901-88ebee5e7638

The same issue-update-and-return flow finishes with no spinner and the list at its normal top offset.
