### PR TITLE
feat(issues): richer sub-issue rows in issue detail (MUL-5098)

### DIFF
--- a/packages/core/issues/queries.ts
+++ b/packages/core/issues/queries.ts
@@ -82,8 +82,11 @@ export const issueKeys = {
   /** Resolve a bare issue identifier (e.g. "MUL-123") to an issue. */
   identifier: (wsId: string, identifier: string) =>
     [...issueKeys.all(wsId), "identifier", identifier] as const,
+  /** Prefix for every per-parent children query in a workspace. */
+  childrenAll: (wsId: string) =>
+    [...issueKeys.all(wsId), "children"] as const,
   children: (wsId: string, id: string) =>
-    [...issueKeys.all(wsId), "children", id] as const,
+    [...issueKeys.childrenAll(wsId), id] as const,
   /** Prefix for invalidating all batched-children queries in a workspace. */
   childrenByParentsAll: (wsId: string) =>
     [...issueKeys.all(wsId), "children-by-parents"] as const,

--- a/packages/core/issues/stores/index.ts
+++ b/packages/core/issues/stores/index.ts
@@ -63,3 +63,10 @@ export {
   pruneIssueSurfaceViewStates,
   getIssueSurfaceViewStateRegistrySnapshot,
 } from "./surface-view-store";
+export {
+  useSubIssueDisplayStore,
+  SUB_ISSUE_ROW_PROPERTY_KEYS,
+  DEFAULT_SUB_ISSUE_ROW_PROPERTIES,
+  type SubIssueRowProperties,
+  type SubIssueRowPropertyKey,
+} from "./sub-issue-display-store";

--- a/packages/core/issues/stores/sub-issue-display-store.test.ts
+++ b/packages/core/issues/stores/sub-issue-display-store.test.ts
@@ -1,0 +1,71 @@
+// @vitest-environment jsdom
+import { beforeAll, beforeEach, describe, expect, it } from "vitest";
+import {
+  DEFAULT_SUB_ISSUE_ROW_PROPERTIES,
+  useSubIssueDisplayStore,
+} from "./sub-issue-display-store";
+
+// Node 25 ships a partial `localStorage` shim under jsdom that's missing
+// `clear`/`removeItem`; replace it with a real in-memory Storage so persist
+// can round-trip values.
+beforeAll(() => {
+  if (typeof globalThis.localStorage?.setItem !== "function") {
+    const values = new Map<string, string>();
+    const storage: Storage = {
+      get length() { return values.size; },
+      clear: () => values.clear(),
+      getItem: (k) => values.get(k) ?? null,
+      key: (i) => Array.from(values.keys())[i] ?? null,
+      removeItem: (k) => { values.delete(k); },
+      setItem: (k, v) => { values.set(k, v); },
+    };
+    Object.defineProperty(globalThis, "localStorage", { configurable: true, value: storage });
+    Object.defineProperty(window, "localStorage", { configurable: true, value: storage });
+  }
+});
+
+describe("sub-issue display store", () => {
+  beforeEach(() => {
+    useSubIssueDisplayStore.setState({
+      rowProperties: { ...DEFAULT_SUB_ISSUE_ROW_PROPERTIES },
+      rowPropertyIds: [],
+    });
+  });
+
+  it("defaults to showing every built-in field and no custom properties", () => {
+    const s = useSubIssueDisplayStore.getState();
+    expect(s.rowProperties).toEqual({
+      priority: true,
+      labels: true,
+      childProgress: true,
+      dueDate: true,
+      assignee: true,
+    });
+    expect(s.rowPropertyIds).toEqual([]);
+  });
+
+  it("toggleRowProperty flips a single field without touching the rest", () => {
+    useSubIssueDisplayStore.getState().toggleRowProperty("dueDate");
+    expect(useSubIssueDisplayStore.getState().rowProperties).toEqual({
+      ...DEFAULT_SUB_ISSUE_ROW_PROPERTIES,
+      dueDate: false,
+    });
+
+    useSubIssueDisplayStore.getState().toggleRowProperty("dueDate");
+    expect(useSubIssueDisplayStore.getState().rowProperties).toEqual(
+      DEFAULT_SUB_ISSUE_ROW_PROPERTIES,
+    );
+  });
+
+  it("toggleRowPropertyId adds then removes a custom property id", () => {
+    useSubIssueDisplayStore.getState().toggleRowPropertyId("prop-1");
+    useSubIssueDisplayStore.getState().toggleRowPropertyId("prop-2");
+    expect(useSubIssueDisplayStore.getState().rowPropertyIds).toEqual([
+      "prop-1",
+      "prop-2",
+    ]);
+
+    useSubIssueDisplayStore.getState().toggleRowPropertyId("prop-1");
+    expect(useSubIssueDisplayStore.getState().rowPropertyIds).toEqual(["prop-2"]);
+  });
+});

--- a/packages/core/issues/stores/sub-issue-display-store.ts
+++ b/packages/core/issues/stores/sub-issue-display-store.ts
@@ -1,0 +1,81 @@
+import { create } from "zustand";
+import { createJSONStorage, persist } from "zustand/middleware";
+import { defaultStorage } from "../../platform/storage";
+
+/**
+ * Which properties the issue-detail sub-issues rows display.
+ *
+ * This is a personal reading preference (like the comment composer's sticky
+ * toggle), not a per-view setting: every issue's sub-issues panel shares the
+ * one configuration, persisted globally via `defaultStorage`. Defaults match
+ * the panel's built-in row layout so the preference is invisible until the
+ * user changes it.
+ *
+ * `rowPropertyIds` holds workspace custom property definition ids. The list
+ * is global while property ids are workspace-scoped — renderers resolve ids
+ * against the current workspace's property list, so ids from another
+ * workspace are simply inert there (same tolerance as the view store's
+ * `cardPropertyIds`).
+ */
+export const SUB_ISSUE_ROW_PROPERTY_KEYS = [
+  "priority",
+  "labels",
+  "childProgress",
+  "dueDate",
+  "assignee",
+] as const;
+export type SubIssueRowPropertyKey =
+  (typeof SUB_ISSUE_ROW_PROPERTY_KEYS)[number];
+export type SubIssueRowProperties = Record<SubIssueRowPropertyKey, boolean>;
+
+export const DEFAULT_SUB_ISSUE_ROW_PROPERTIES: SubIssueRowProperties = {
+  priority: true,
+  labels: true,
+  childProgress: true,
+  dueDate: true,
+  assignee: true,
+};
+
+interface SubIssueDisplayStore {
+  rowProperties: SubIssueRowProperties;
+  rowPropertyIds: string[];
+  toggleRowProperty: (key: SubIssueRowPropertyKey) => void;
+  toggleRowPropertyId: (propertyId: string) => void;
+}
+
+export const useSubIssueDisplayStore = create<SubIssueDisplayStore>()(
+  persist(
+    (set) => ({
+      rowProperties: { ...DEFAULT_SUB_ISSUE_ROW_PROPERTIES },
+      rowPropertyIds: [],
+      toggleRowProperty: (key) =>
+        set((s) => ({
+          rowProperties: { ...s.rowProperties, [key]: !s.rowProperties[key] },
+        })),
+      toggleRowPropertyId: (propertyId) =>
+        set((s) => ({
+          rowPropertyIds: s.rowPropertyIds.includes(propertyId)
+            ? s.rowPropertyIds.filter((id) => id !== propertyId)
+            : [...s.rowPropertyIds, propertyId],
+        })),
+    }),
+    {
+      name: "multica_sub_issue_display",
+      storage: createJSONStorage(() => defaultStorage),
+      // Deep-merge rowProperties so a key added in a future release defaults
+      // to visible instead of undefined (persist's default shallow merge
+      // would replace the whole object with the stale persisted one).
+      merge: (persisted, current) => {
+        const p = (persisted ?? {}) as Partial<SubIssueDisplayStore>;
+        return {
+          ...current,
+          ...p,
+          rowProperties: {
+            ...current.rowProperties,
+            ...(p.rowProperties ?? {}),
+          },
+        };
+      },
+    },
+  ),
+);

--- a/packages/core/issues/ws-updaters.test.ts
+++ b/packages/core/issues/ws-updaters.test.ts
@@ -203,6 +203,40 @@ describe("onIssueLabelsChanged", () => {
     onIssueLabelsChanged(qc, WS_ID, ISSUE_ID, [labelB]);
     expectInvalidated(qc, flatKey);
   });
+
+  it("patches the parent's children cache so the sub-issues panel stays fresh", () => {
+    const child = { ...baseIssue, parent_issue_id: PARENT_ISSUE_ID };
+    qc.setQueryData<Issue[]>(issueKeys.children(WS_ID, PARENT_ISSUE_ID), [
+      child,
+      otherIssue,
+    ]);
+    // A children cache that does NOT hold the issue must keep its reference
+    // (no pointless rerender of unrelated sub-issue panels).
+    const unrelated = [otherIssue];
+    qc.setQueryData<Issue[]>(issueKeys.children(WS_ID, "parent-9"), unrelated);
+
+    onIssueLabelsChanged(qc, WS_ID, ISSUE_ID, [labelB]);
+
+    const children = qc.getQueryData<Issue[]>(
+      issueKeys.children(WS_ID, PARENT_ISSUE_ID),
+    );
+    expect(children?.find((i) => i.id === ISSUE_ID)?.labels).toEqual([labelB]);
+    expect(children?.find((i) => i.id === OTHER_ISSUE_ID)?.labels).toEqual([
+      labelA,
+    ]);
+    expect(qc.getQueryData<Issue[]>(issueKeys.children(WS_ID, "parent-9"))).toBe(
+      unrelated,
+    );
+  });
+
+  it("invalidates batched children caches (Map-shaped, not patchable)", () => {
+    const batchedKey = issueKeys.childrenByParents(WS_ID, [PARENT_ISSUE_ID]);
+    qc.setQueryData(batchedKey, new Map([[PARENT_ISSUE_ID, [baseIssue]]]));
+
+    onIssueLabelsChanged(qc, WS_ID, ISSUE_ID, [labelB]);
+
+    expectInvalidated(qc, batchedKey);
+  });
 });
 
 describe("onIssueMetadataChanged", () => {

--- a/packages/core/issues/ws-updaters.test.ts
+++ b/packages/core/issues/ws-updaters.test.ts
@@ -206,7 +206,8 @@ describe("onIssueLabelsChanged", () => {
 
   it("patches the parent's children cache so the sub-issues panel stays fresh", () => {
     const child = { ...baseIssue, parent_issue_id: PARENT_ISSUE_ID };
-    qc.setQueryData<Issue[]>(issueKeys.children(WS_ID, PARENT_ISSUE_ID), [
+    const childrenKey = issueKeys.children(WS_ID, PARENT_ISSUE_ID);
+    qc.setQueryData<Issue[]>(childrenKey, [
       child,
       otherIssue,
     ]);
@@ -227,6 +228,9 @@ describe("onIssueLabelsChanged", () => {
     expect(qc.getQueryData<Issue[]>(issueKeys.children(WS_ID, "parent-9"))).toBe(
       unrelated,
     );
+    // The committed WS/mutation snapshot also marks active children queries
+    // stale, preventing an older in-flight response from overwriting the patch.
+    expectInvalidated(qc, childrenKey);
   });
 
   it("invalidates batched children caches (Map-shaped, not patchable)", () => {
@@ -294,6 +298,50 @@ describe("onIssueMetadataChanged", () => {
 });
 
 describe("issue property snapshots", () => {
+  it("patches per-parent children and invalidates every children projection on commit", () => {
+    const qc = new QueryClient();
+    const childrenKey = issueKeys.children(WS_ID, PARENT_ISSUE_ID);
+    const unrelatedKey = issueKeys.children(WS_ID, "parent-9");
+    const batchedKey = issueKeys.childrenByParents(WS_ID, [PARENT_ISSUE_ID]);
+    const child = {
+      ...parentedIssue,
+      properties: { estimate: 1, environment: "staging" },
+    };
+    const unrelated = [otherIssue];
+    qc.setQueryData<Issue[]>(childrenKey, [child, otherIssue]);
+    qc.setQueryData<Issue[]>(unrelatedKey, unrelated);
+    qc.setQueryData(batchedKey, new Map([[PARENT_ISSUE_ID, [child]]]));
+
+    // The optimistic leg is deterministic: patch immediately without a
+    // premature refetch that could still return the pre-mutation value.
+    patchIssueProperties(qc, WS_ID, ISSUE_ID, {
+      estimate: 2,
+      environment: "staging",
+    });
+
+    expect(
+      qc.getQueryData<Issue[]>(childrenKey)?.find((candidate) => candidate.id === ISSUE_ID)
+        ?.properties,
+    ).toEqual({ estimate: 2, environment: "staging" });
+    expect(qc.getQueryState(childrenKey)?.isInvalidated).toBe(false);
+    expect(qc.getQueryData<Issue[]>(unrelatedKey)).toBe(unrelated);
+
+    // The committed response/event keeps the immediate patch, then marks both
+    // per-parent and batched projections stale for authoritative convergence.
+    onIssuePropertiesChanged(qc, WS_ID, ISSUE_ID, {
+      estimate: 3,
+      environment: "staging",
+    });
+
+    expect(
+      qc.getQueryData<Issue[]>(childrenKey)?.find((candidate) => candidate.id === ISSUE_ID)
+        ?.properties,
+    ).toEqual({ estimate: 3, environment: "staging" });
+    expectInvalidated(qc, childrenKey);
+    expectInvalidated(qc, batchedKey);
+    expect(qc.getQueryData<Issue[]>(unrelatedKey)).toBe(unrelated);
+  });
+
   it("keeps optimistic patches local, then invalidates property windows after commit", () => {
     const qc = new QueryClient();
     const flatKey = issueKeys.flat(

--- a/packages/core/issues/ws-updaters.ts
+++ b/packages/core/issues/ws-updaters.ts
@@ -216,6 +216,19 @@ export function patchIssueLabels(
   qc.setQueryData<IssueLabelsResponse>(labelKeys.byIssue(wsId, issueId), (old) =>
     old ? { ...old, labels } : old,
   );
+  // Patch every per-parent children cache holding this issue — the parent
+  // issue's sub-issues panel renders label chips from these arrays, so a
+  // label change made elsewhere (agent, other tab, the child's own detail
+  // page) must not leave the panel stale.
+  for (const [key, data] of qc.getQueriesData<Issue[]>({
+    queryKey: [...issueKeys.all(wsId), "children"],
+  })) {
+    if (!data || !data.some((c) => c.id === issueId)) continue;
+    qc.setQueryData<Issue[]>(
+      key,
+      data.map((c) => (c.id === issueId ? { ...c, labels } : c)),
+    );
+  }
   // Patch the Project Gantt caches in-place: the Gantt view applies
   // `labelFilters` to the row data, so a stale `labels` array would silently
   // hide or surface bars after another tab/agent attached or detached a
@@ -234,6 +247,10 @@ export function patchIssueLabels(
 
 /** Reconcile server-filtered label windows only after the write commits. */
 export function invalidateIssueLabelDerivatives(qc: QueryClient, wsId: string) {
+  // Batched children caches hold Map-shaped data (parentId → Issue[]) that
+  // patchIssueLabels can't surgically update — refetch instead so swimlane
+  // child lanes pick up the new label set.
+  qc.invalidateQueries({ queryKey: issueKeys.childrenByParentsAll(wsId) });
   qc.invalidateQueries({ queryKey: issueKeys.myAll(wsId) });
   qc.invalidateQueries({ queryKey: issueKeys.assigneeGroupsAll(wsId) });
   qc.invalidateQueries({ queryKey: issueKeys.myAssigneeGroupsAll(wsId) });

--- a/packages/core/issues/ws-updaters.ts
+++ b/packages/core/issues/ws-updaters.ts
@@ -40,6 +40,26 @@ function patchIssueInFlatCaches(
   }
 }
 
+/** Patch denormalized issue snapshots in every loaded per-parent cache. */
+function patchIssueInChildrenCaches(
+  qc: QueryClient,
+  wsId: string,
+  issueId: string,
+  patch: Partial<Issue>,
+) {
+  for (const [key, data] of qc.getQueriesData<Issue[]>({
+    queryKey: issueKeys.childrenAll(wsId),
+  })) {
+    if (!data || !data.some((child) => child.id === issueId)) continue;
+    qc.setQueryData<Issue[]>(
+      key,
+      data.map((child) =>
+        child.id === issueId ? { ...child, ...patch } : child,
+      ),
+    );
+  }
+}
+
 function findIssueInFlatCaches(
   qc: QueryClient,
   wsId: string,
@@ -216,19 +236,8 @@ export function patchIssueLabels(
   qc.setQueryData<IssueLabelsResponse>(labelKeys.byIssue(wsId, issueId), (old) =>
     old ? { ...old, labels } : old,
   );
-  // Patch every per-parent children cache holding this issue — the parent
-  // issue's sub-issues panel renders label chips from these arrays, so a
-  // label change made elsewhere (agent, other tab, the child's own detail
-  // page) must not leave the panel stale.
-  for (const [key, data] of qc.getQueriesData<Issue[]>({
-    queryKey: [...issueKeys.all(wsId), "children"],
-  })) {
-    if (!data || !data.some((c) => c.id === issueId)) continue;
-    qc.setQueryData<Issue[]>(
-      key,
-      data.map((c) => (c.id === issueId ? { ...c, labels } : c)),
-    );
-  }
+  // The sub-issues panel renders label chips from these denormalized rows.
+  patchIssueInChildrenCaches(qc, wsId, issueId, { labels });
   // Patch the Project Gantt caches in-place: the Gantt view applies
   // `labelFilters` to the row data, so a stale `labels` array would silently
   // hide or surface bars after another tab/agent attached or detached a
@@ -247,6 +256,9 @@ export function patchIssueLabels(
 
 /** Reconcile server-filtered label windows only after the write commits. */
 export function invalidateIssueLabelDerivatives(qc: QueryClient, wsId: string) {
+  // A committed response/event must cancel or supersede any per-parent fetch
+  // that started before the label write and could otherwise land afterward.
+  qc.invalidateQueries({ queryKey: issueKeys.childrenAll(wsId) });
   // Batched children caches hold Map-shaped data (parentId → Issue[]) that
   // patchIssueLabels can't surgically update — refetch instead so swimlane
   // child lanes pick up the new label set.
@@ -308,6 +320,10 @@ export function onIssuePropertiesChanged(
   properties: IssuePropertyValues,
 ) {
   patchIssueProperties(qc, wsId, issueId, properties);
+  // Per-parent rows are patched for immediate UI feedback, then all children
+  // projections are marked stale so older fetches cannot win after commit.
+  qc.invalidateQueries({ queryKey: issueKeys.childrenAll(wsId) });
+  qc.invalidateQueries({ queryKey: issueKeys.childrenByParentsAll(wsId) });
   qc.invalidateQueries({ queryKey: issueKeys.myAll(wsId) });
   // Plain assignee-group caches are never patched in place (their bucket
   // shape differs) and would otherwise hold stale chips forever under
@@ -340,6 +356,7 @@ export function patchIssueProperties(
   qc.setQueryData<Issue>(issueKeys.detail(wsId, issueId), (old) =>
     old ? { ...old, properties } : old,
   );
+  patchIssueInChildrenCaches(qc, wsId, issueId, { properties });
 }
 
 /**

--- a/packages/core/labels/mutations.test.tsx
+++ b/packages/core/labels/mutations.test.tsx
@@ -1,0 +1,182 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import type { ReactNode } from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { setApiInstance } from "../api";
+import type { ApiClient } from "../api/client";
+import { issueKeys } from "../issues/queries";
+import type {
+  Issue,
+  IssueLabelsResponse,
+  Label,
+  ListLabelsResponse,
+} from "../types";
+import { useAttachLabel, useDetachLabel } from "./mutations";
+import { labelKeys } from "./queries";
+
+vi.mock("../hooks", () => ({ useWorkspaceId: () => "ws-1" }));
+
+const labelA: Label = {
+  id: "label-a",
+  workspace_id: "ws-1",
+  name: "bug",
+  color: "#ef4444",
+  created_at: "2026-01-01T00:00:00Z",
+  updated_at: "2026-01-01T00:00:00Z",
+};
+
+const labelB: Label = {
+  id: "label-b",
+  workspace_id: "ws-1",
+  name: "feature",
+  color: "#22c55e",
+  created_at: "2026-01-01T00:00:00Z",
+  updated_at: "2026-01-01T00:00:00Z",
+};
+
+const issue: Issue = {
+  id: "issue-1",
+  workspace_id: "ws-1",
+  number: 1,
+  identifier: "MUL-1",
+  title: "Child",
+  description: null,
+  status: "todo",
+  priority: "none",
+  assignee_type: null,
+  assignee_id: null,
+  creator_type: "member",
+  creator_id: "member-1",
+  parent_issue_id: "parent-1",
+  project_id: null,
+  position: 1,
+  stage: null,
+  start_date: null,
+  due_date: null,
+  labels: [labelA],
+  metadata: {},
+  properties: {},
+  created_at: "2026-01-01T00:00:00Z",
+  updated_at: "2026-01-01T00:00:00Z",
+};
+
+function wrapper(qc: QueryClient) {
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return <QueryClientProvider client={qc}>{children}</QueryClientProvider>;
+  };
+}
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((done) => {
+    resolve = done;
+  });
+  return { promise, resolve };
+}
+
+function startStaleChildrenFetch(qc: QueryClient, labels: Label[]) {
+  const childKey = issueKeys.children("ws-1", "parent-1");
+  const response = deferred<Issue[]>();
+  const fetch = qc
+    .fetchQuery({
+      queryKey: childKey,
+      queryFn: () => response.promise,
+    })
+    .catch(() => undefined);
+  return { childKey, response, fetch, staleIssue: { ...issue, labels } };
+}
+
+describe("issue label mutations", () => {
+  afterEach(() => vi.restoreAllMocks());
+
+  it("prevents an older children fetch from overwriting an optimistic attach", async () => {
+    const qc = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+    const childKey = issueKeys.children("ws-1", "parent-1");
+    qc.setQueryData<Issue[]>(childKey, [issue]);
+    qc.setQueryData<IssueLabelsResponse>(labelKeys.byIssue("ws-1", issue.id), {
+      labels: [labelA],
+    });
+    qc.setQueryData<ListLabelsResponse>(labelKeys.list("ws-1"), {
+      labels: [labelA, labelB],
+      total: 2,
+    });
+    const stale = startStaleChildrenFetch(qc, [labelA]);
+    await waitFor(() =>
+      expect(qc.getQueryState(childKey)?.fetchStatus).toBe("fetching"),
+    );
+
+    const write = deferred<IssueLabelsResponse>();
+    setApiInstance({
+      attachLabel: vi.fn(() => write.promise),
+    } as unknown as ApiClient);
+    const { result } = renderHook(() => useAttachLabel(issue.id), {
+      wrapper: wrapper(qc),
+    });
+
+    act(() => result.current.mutate(labelB.id));
+    await waitFor(() =>
+      expect(qc.getQueryData<Issue[]>(childKey)?.[0]?.labels).toEqual([
+        labelA,
+        labelB,
+      ]),
+    );
+
+    stale.response.resolve([stale.staleIssue]);
+    await stale.fetch;
+    expect(qc.getQueryData<Issue[]>(childKey)?.[0]?.labels).toEqual([
+      labelA,
+      labelB,
+    ]);
+
+    await act(async () => {
+      write.resolve({ labels: [labelA, labelB] });
+    });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    qc.clear();
+  });
+
+  it("prevents an older children fetch from overwriting an optimistic detach", async () => {
+    const qc = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+    const childKey = issueKeys.children("ws-1", "parent-1");
+    const labeledIssue = { ...issue, labels: [labelA, labelB] };
+    qc.setQueryData<Issue[]>(childKey, [labeledIssue]);
+    qc.setQueryData<IssueLabelsResponse>(labelKeys.byIssue("ws-1", issue.id), {
+      labels: [labelA, labelB],
+    });
+    const stale = startStaleChildrenFetch(qc, [labelA, labelB]);
+    await waitFor(() =>
+      expect(qc.getQueryState(childKey)?.fetchStatus).toBe("fetching"),
+    );
+
+    const write = deferred<IssueLabelsResponse>();
+    setApiInstance({
+      detachLabel: vi.fn(() => write.promise),
+    } as unknown as ApiClient);
+    const { result } = renderHook(() => useDetachLabel(issue.id), {
+      wrapper: wrapper(qc),
+    });
+
+    act(() => result.current.mutate(labelB.id));
+    await waitFor(() =>
+      expect(qc.getQueryData<Issue[]>(childKey)?.[0]?.labels).toEqual([labelA]),
+    );
+
+    stale.response.resolve([stale.staleIssue]);
+    await stale.fetch;
+    expect(qc.getQueryData<Issue[]>(childKey)?.[0]?.labels).toEqual([labelA]);
+
+    await act(async () => {
+      write.resolve({ labels: [labelA] });
+    });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    qc.clear();
+  });
+});

--- a/packages/core/labels/mutations.ts
+++ b/packages/core/labels/mutations.ts
@@ -155,17 +155,27 @@ function workspaceKeysForLabels(resourceType: "agent" | "skill", wsId: string) {
   return ["workspaces", wsId, resourceType === "agent" ? "agents" : "skills"] as const;
 }
 
+async function cancelIssueLabelMutationQueries(
+  qc: ReturnType<typeof useQueryClient>,
+  wsId: string,
+  issueId: string,
+) {
+  await Promise.all([
+    qc.cancelQueries({ queryKey: labelKeys.byIssue(wsId, issueId) }),
+    qc.cancelQueries({ queryKey: issueKeys.list(wsId) }),
+    qc.cancelQueries({ queryKey: issueKeys.flatAll(wsId) }),
+    qc.cancelQueries({ queryKey: issueKeys.childrenAll(wsId) }),
+    qc.cancelQueries({ queryKey: issueKeys.childrenByParentsAll(wsId) }),
+  ]);
+}
+
 export function useAttachLabel(issueId: string) {
   const qc = useQueryClient();
   const wsId = useWorkspaceId();
   return useMutation({
     mutationFn: (labelId: string) => api.attachLabel(issueId, labelId),
     onMutate: async (labelId) => {
-      await Promise.all([
-        qc.cancelQueries({ queryKey: labelKeys.byIssue(wsId, issueId) }),
-        qc.cancelQueries({ queryKey: issueKeys.list(wsId) }),
-        qc.cancelQueries({ queryKey: issueKeys.flatAll(wsId) }),
-      ]);
+      await cancelIssueLabelMutationQueries(qc, wsId, issueId);
       const prev = qc.getQueryData<IssueLabelsResponse>(labelKeys.byIssue(wsId, issueId));
       // Only patch when we already know the current label set — otherwise
       // appending `[label]` to an empty array would wipe denormalized
@@ -235,11 +245,7 @@ export function useDetachLabel(issueId: string) {
   return useMutation({
     mutationFn: (labelId: string) => api.detachLabel(issueId, labelId),
     onMutate: async (labelId) => {
-      await Promise.all([
-        qc.cancelQueries({ queryKey: labelKeys.byIssue(wsId, issueId) }),
-        qc.cancelQueries({ queryKey: issueKeys.list(wsId) }),
-        qc.cancelQueries({ queryKey: issueKeys.flatAll(wsId) }),
-      ]);
+      await cancelIssueLabelMutationQueries(qc, wsId, issueId);
       const prev = qc.getQueryData<IssueLabelsResponse>(labelKeys.byIssue(wsId, issueId));
       const next = prev
         ? { ...prev, labels: prev.labels.filter((l: Label) => l.id !== labelId) }

--- a/packages/core/properties/mutations.test.tsx
+++ b/packages/core/properties/mutations.test.tsx
@@ -46,8 +46,81 @@ function wrapper(qc: QueryClient) {
   };
 }
 
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((done) => {
+    resolve = done;
+  });
+  return { promise, resolve };
+}
+
 describe("useSetIssueProperty", () => {
   afterEach(() => vi.restoreAllMocks());
+
+  it("keeps an optimistic children-cache patch when an older fetch resolves late", async () => {
+    const qc = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+    const parentId = "parent-1";
+    const childKey = issueKeys.children("ws-1", parentId);
+    const child = {
+      ...issue,
+      parent_issue_id: parentId,
+      properties: { estimate: 1, environment: "staging" },
+    };
+    qc.setQueryData<Issue[]>(childKey, [child]);
+
+    const staleChildren = deferred<Issue[]>();
+    const staleFetch = qc
+      .fetchQuery({
+        queryKey: childKey,
+        queryFn: () => staleChildren.promise,
+      })
+      .catch(() => undefined);
+    await waitFor(() =>
+      expect(qc.getQueryState(childKey)?.fetchStatus).toBe("fetching"),
+    );
+
+    const write = deferred<IssuePropertiesResponse>();
+    setApiInstance({
+      setIssueProperty: vi.fn(() => write.promise),
+    } as unknown as ApiClient);
+
+    const { result } = renderHook(() => useSetIssueProperty(), {
+      wrapper: wrapper(qc),
+    });
+    act(() => {
+      result.current.mutate({
+        issueId: issue.id,
+        propertyId: "estimate",
+        value: 2,
+      });
+    });
+
+    await waitFor(() =>
+      expect(qc.getQueryData<Issue[]>(childKey)?.[0]?.properties).toEqual({
+        estimate: 2,
+        environment: "staging",
+      }),
+    );
+
+    // Resolve the response captured before the mutation. cancelQueries must
+    // keep it from restoring estimate=1 while the write is still pending.
+    staleChildren.resolve([child]);
+    await staleFetch;
+    expect(qc.getQueryData<Issue[]>(childKey)?.[0]?.properties).toEqual({
+      estimate: 2,
+      environment: "staging",
+    });
+
+    await act(async () => {
+      write.resolve({
+        properties: { estimate: 2, environment: "staging" },
+      });
+    });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    qc.clear();
+  });
 
   it("does not refetch a property window before the mutation commits", async () => {
     const qc = new QueryClient({

--- a/packages/core/properties/mutations.ts
+++ b/packages/core/properties/mutations.ts
@@ -73,9 +73,28 @@ function readIssueProperties(qc: ReturnType<typeof useQueryClient>, wsId: string
       if (issue) return issue.properties ?? {};
     }
   }
+  for (const [, data] of qc.getQueriesData<Issue[]>({
+    queryKey: issueKeys.childrenAll(wsId),
+  })) {
+    const issue = data?.find((candidate) => candidate.id === issueId);
+    if (issue) return issue.properties ?? {};
+  }
   return undefined;
 }
 
+async function cancelIssuePropertyMutationQueries(
+  qc: ReturnType<typeof useQueryClient>,
+  wsId: string,
+  issueId: string,
+) {
+  await Promise.all([
+    qc.cancelQueries({ queryKey: issueKeys.detail(wsId, issueId) }),
+    qc.cancelQueries({ queryKey: issueKeys.list(wsId) }),
+    qc.cancelQueries({ queryKey: issueKeys.flatAll(wsId) }),
+    qc.cancelQueries({ queryKey: issueKeys.childrenAll(wsId) }),
+    qc.cancelQueries({ queryKey: issueKeys.childrenByParentsAll(wsId) }),
+  ]);
+}
 
 /**
  * Optimistic single-property write on an issue.
@@ -102,13 +121,9 @@ export function useSetIssueProperty() {
     scope: { id: `issue-properties:${wsId}` },
     mutationKey: ["issue-properties", wsId],
     onMutate: async ({ issueId, propertyId, value }) => {
-      // Cancel in-flight list refetches too: a response snapshotted before
-      // this write would land after the optimistic patch and revert it.
-      await Promise.all([
-        qc.cancelQueries({ queryKey: issueKeys.detail(wsId, issueId) }),
-        qc.cancelQueries({ queryKey: issueKeys.list(wsId) }),
-        qc.cancelQueries({ queryKey: issueKeys.flatAll(wsId) }),
-      ]);
+      // A response snapshotted before this write must not land after the
+      // optimistic patch and revert any denormalized issue projection.
+      await cancelIssuePropertyMutationQueries(qc, wsId, issueId);
       const prev = readIssueProperties(qc, wsId, issueId);
       patchIssueProperties(qc, wsId, issueId, { ...(prev ?? {}), [propertyId]: value });
       return { prevValue: prev?.[propertyId], hadBag: prev !== undefined, issueId, propertyId };
@@ -135,11 +150,7 @@ export function useUnsetIssueProperty() {
     scope: { id: `issue-properties:${wsId}` },
     mutationKey: ["issue-properties", wsId],
     onMutate: async ({ issueId, propertyId }) => {
-      await Promise.all([
-        qc.cancelQueries({ queryKey: issueKeys.detail(wsId, issueId) }),
-        qc.cancelQueries({ queryKey: issueKeys.list(wsId) }),
-        qc.cancelQueries({ queryKey: issueKeys.flatAll(wsId) }),
-      ]);
+      await cancelIssuePropertyMutationQueries(qc, wsId, issueId);
       const prev = readIssueProperties(qc, wsId, issueId);
       if (prev) {
         const next = { ...prev };

--- a/packages/views/issues/components/issue-detail.test.tsx
+++ b/packages/views/issues/components/issue-detail.test.tsx
@@ -5,6 +5,10 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import type { Issue, Label, TimelineEntry } from "@multica/core/types";
 import { I18nProvider } from "@multica/core/i18n/react";
 import { useResolvedExpandStore } from "@multica/core/issues/stores/resolved-expand-store";
+import {
+  DEFAULT_SUB_ISSUE_ROW_PROPERTIES,
+  useSubIssueDisplayStore,
+} from "@multica/core/issues/stores/sub-issue-display-store";
 import enCommon from "../../locales/en/common.json";
 import enIssues from "../../locales/en/issues.json";
 
@@ -256,6 +260,7 @@ const mockApiObj = vi.hoisted(() => ({
   listChildIssues: vi.fn().mockResolvedValue({ issues: [] }),
   getChildIssueProgress: vi.fn().mockResolvedValue({ progress: [] }),
   getAgentTaskSnapshot: vi.fn().mockResolvedValue([]),
+  listProperties: vi.fn().mockResolvedValue({ properties: [], total: 0 }),
   listIssues: vi.fn().mockResolvedValue({ issues: [], total: 0 }),
   uploadFile: vi.fn(),
   listIssueReactions: vi.fn().mockResolvedValue([]),
@@ -308,6 +313,11 @@ vi.mock("@multica/core/issues/stores", async () => ({
   ...(await vi.importActual<
     typeof import("@multica/core/issues/stores/resolved-expand-store")
   >("@multica/core/issues/stores/resolved-expand-store")),
+  // Real store: sub-issue display tests drive it with setState, and the
+  // component reads it through the barrel — both must hit the same instance.
+  ...(await vi.importActual<
+    typeof import("@multica/core/issues/stores/sub-issue-display-store")
+  >("@multica/core/issues/stores/sub-issue-display-store")),
   useRecentIssuesStore: Object.assign(
     (selector?: any) => {
       const state = { byWorkspace: {}, recordVisit: mockRecordVisit, pruneWorkspaces: vi.fn() };
@@ -588,6 +598,7 @@ describe("IssueDetail (shared)", () => {
     mockApiObj.listChildIssues.mockResolvedValue({ issues: [] });
     mockApiObj.getChildIssueProgress.mockResolvedValue({ progress: [] });
     mockApiObj.getAgentTaskSnapshot.mockResolvedValue([]);
+    mockApiObj.listProperties.mockResolvedValue({ properties: [], total: 0 });
     mockApiObj.listIssues.mockResolvedValue({ issues: [], total: 0 });
     mockApiObj.getActiveTasksForIssue.mockResolvedValue({ tasks: [] });
     mockApiObj.listTasksByIssue.mockResolvedValue([]);
@@ -1405,6 +1416,13 @@ describe("IssueDetail (shared)", () => {
   });
 
   describe("sub-issues list", () => {
+    beforeEach(() => {
+      useSubIssueDisplayStore.setState({
+        rowProperties: { ...DEFAULT_SUB_ISSUE_ROW_PROPERTIES },
+        rowPropertyIds: [],
+      });
+    });
+
     const label = (id: string, name: string): Label => ({
       id,
       workspace_id: "ws-1",
@@ -1464,6 +1482,77 @@ describe("IssueDetail (shared)", () => {
       // Bare row shows no due date / no progress chip of its own.
       const bareRow = screen.getByText("Ship dashboards").closest("a");
       expect(bareRow?.textContent).not.toContain("/");
+    });
+
+    it("hides fields the user toggled off in the display preference", async () => {
+      useSubIssueDisplayStore.setState({
+        rowProperties: {
+          ...DEFAULT_SUB_ISSUE_ROW_PROPERTIES,
+          labels: false,
+          dueDate: false,
+        },
+      });
+      mockApiObj.listChildIssues.mockResolvedValue({
+        issues: [
+          subIssue({
+            id: "child-1",
+            number: 11,
+            identifier: "TES-11",
+            title: "Fix login flow",
+            labels: [label("l1", "backend")],
+            due_date: "2020-01-01",
+          }),
+        ],
+      });
+
+      renderIssueDetail();
+
+      await screen.findByText("Fix login flow");
+      expect(screen.queryByText("backend")).not.toBeInTheDocument();
+      expect(screen.queryByText("Jan 1")).not.toBeInTheDocument();
+    });
+
+    it("renders opted-in custom property chips on rows that carry a value", async () => {
+      const estimate = {
+        id: "prop-1",
+        workspace_id: "ws-1",
+        name: "Estimate",
+        type: "text",
+        config: {},
+        position: 0,
+        archived: false,
+        created_at: "2026-01-01T00:00:00Z",
+        updated_at: "2026-01-01T00:00:00Z",
+      };
+      mockApiObj.listProperties.mockResolvedValue({
+        properties: [estimate],
+        total: 1,
+      });
+      useSubIssueDisplayStore.setState({ rowPropertyIds: ["prop-1"] });
+      mockApiObj.listChildIssues.mockResolvedValue({
+        issues: [
+          subIssue({
+            id: "child-1",
+            number: 11,
+            identifier: "TES-11",
+            title: "Fix login flow",
+            properties: { "prop-1": "Sprint 3" },
+          }),
+          subIssue({
+            id: "child-2",
+            number: 12,
+            identifier: "TES-12",
+            title: "Ship dashboards",
+          }),
+        ],
+      });
+
+      renderIssueDetail();
+
+      await screen.findByText("Fix login flow");
+      // Chip renders only on the row that has a value for the property.
+      expect(await screen.findByText("Sprint 3")).toBeInTheDocument();
+      expect(screen.getAllByText("Sprint 3")).toHaveLength(1);
     });
 
     it("mutes the due date on done sub-issues even when past", async () => {

--- a/packages/views/issues/components/issue-detail.test.tsx
+++ b/packages/views/issues/components/issue-detail.test.tsx
@@ -2,7 +2,7 @@ import { forwardRef, useEffect, useRef, useState, useImperativeHandle } from "re
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import type { Issue, TimelineEntry } from "@multica/core/types";
+import type { Issue, Label, TimelineEntry } from "@multica/core/types";
 import { I18nProvider } from "@multica/core/i18n/react";
 import { useResolvedExpandStore } from "@multica/core/issues/stores/resolved-expand-store";
 import enCommon from "../../locales/en/common.json";
@@ -254,6 +254,8 @@ const mockApiObj = vi.hoisted(() => ({
   rerunIssue: vi.fn(),
   listTaskMessages: vi.fn().mockResolvedValue([]),
   listChildIssues: vi.fn().mockResolvedValue({ issues: [] }),
+  getChildIssueProgress: vi.fn().mockResolvedValue({ progress: [] }),
+  getAgentTaskSnapshot: vi.fn().mockResolvedValue([]),
   listIssues: vi.fn().mockResolvedValue({ issues: [], total: 0 }),
   uploadFile: vi.fn(),
   listIssueReactions: vi.fn().mockResolvedValue([]),
@@ -584,6 +586,8 @@ describe("IssueDetail (shared)", () => {
     mockApiObj.listIssueReactions.mockResolvedValue([]);
     mockApiObj.listIssueSubscribers.mockResolvedValue([]);
     mockApiObj.listChildIssues.mockResolvedValue({ issues: [] });
+    mockApiObj.getChildIssueProgress.mockResolvedValue({ progress: [] });
+    mockApiObj.getAgentTaskSnapshot.mockResolvedValue([]);
     mockApiObj.listIssues.mockResolvedValue({ issues: [], total: 0 });
     mockApiObj.getActiveTasksForIssue.mockResolvedValue({ tasks: [] });
     mockApiObj.listTasksByIssue.mockResolvedValue([]);
@@ -1397,6 +1401,91 @@ describe("IssueDetail (shared)", () => {
         "issue-1",
         expect.objectContaining({ description: "" }),
       );
+    });
+  });
+
+  describe("sub-issues list", () => {
+    const label = (id: string, name: string): Label => ({
+      id,
+      workspace_id: "ws-1",
+      resource_type: "issue",
+      name,
+      color: "#3b82f6",
+      created_at: "2026-01-01T00:00:00Z",
+      updated_at: "2026-01-01T00:00:00Z",
+    });
+
+    const subIssue = (overrides: Partial<Issue>): Issue => ({
+      ...mockIssue,
+      parent_issue_id: "issue-1",
+      assignee_type: null,
+      assignee_id: null,
+      due_date: null,
+      priority: "none",
+      ...overrides,
+    });
+
+    it("renders priority, labels, due date and nested progress on rows", async () => {
+      mockApiObj.listChildIssues.mockResolvedValue({
+        issues: [
+          subIssue({
+            id: "child-1",
+            number: 11,
+            identifier: "TES-11",
+            title: "Fix login flow",
+            priority: "urgent",
+            labels: [label("l1", "backend"), label("l2", "auth")],
+            // Past date-only value → overdue styling on an open issue.
+            due_date: "2020-01-01",
+          }),
+          subIssue({
+            id: "child-2",
+            number: 12,
+            identifier: "TES-12",
+            title: "Ship dashboards",
+          }),
+        ],
+      });
+      mockApiObj.getChildIssueProgress.mockResolvedValue({
+        progress: [{ parent_issue_id: "child-1", done: 1, total: 3 }],
+      });
+
+      renderIssueDetail();
+
+      await screen.findByText("Fix login flow");
+      // Label chips ride inside the row link.
+      expect(screen.getByText("backend")).toBeInTheDocument();
+      expect(screen.getByText("auth")).toBeInTheDocument();
+      // Nested own-children progress for child-1 only (header shows 0/2).
+      expect(await screen.findByText("1/3")).toBeInTheDocument();
+      // Overdue open issue renders its due date in the destructive tone.
+      const due = screen.getByText("Jan 1");
+      expect(due.closest("span")?.className).toContain("text-destructive");
+      // Bare row shows no due date / no progress chip of its own.
+      const bareRow = screen.getByText("Ship dashboards").closest("a");
+      expect(bareRow?.textContent).not.toContain("/");
+    });
+
+    it("mutes the due date on done sub-issues even when past", async () => {
+      mockApiObj.listChildIssues.mockResolvedValue({
+        issues: [
+          subIssue({
+            id: "child-1",
+            number: 11,
+            identifier: "TES-11",
+            title: "Wrapped up",
+            status: "done",
+            due_date: "2020-01-01",
+          }),
+        ],
+      });
+
+      renderIssueDetail();
+
+      await screen.findByText("Wrapped up");
+      const due = screen.getByText("Jan 1");
+      expect(due.closest("span")?.className).not.toContain("text-destructive");
+      expect(due.closest("span")?.className).toContain("text-muted-foreground");
     });
   });
 });

--- a/packages/views/issues/components/issue-detail.tsx
+++ b/packages/views/issues/components/issue-detail.tsx
@@ -49,13 +49,15 @@ import { PropertyIcon } from "../../common/property-icon";
 import type { Attachment, Issue, IssueStatus, IssuePriority, TimelineEntry, UpdateIssueRequest } from "@multica/core/types";
 import { contentReferencesAttachment } from "@multica/core/types";
 import { STATUS_CONFIG, PRIORITY_CONFIG } from "@multica/core/issues/config";
-import { formatDateOnly } from "@multica/core/issues/date";
+import { formatDateOnly, isPastDateOnly } from "@multica/core/issues/date";
 import { useUpdateIssue } from "@multica/core/issues/mutations";
 import { toast } from "sonner";
 import { StatusIcon, PriorityIcon, StatusPicker, PriorityPicker, StagePicker, StartDatePicker, DueDatePicker, AssigneePicker, LabelPicker } from ".";
 import { maxSiblingStage } from "./pickers/stage-picker";
 import { CustomPropertyValueEditor } from "./pickers/custom-property-picker";
-import { IssueActionsDropdown, useIssueActions } from "../actions";
+import { IssueActionsDropdown, useIssueActions, IssueActionsContextMenu, IssueContextMenuProvider } from "../actions";
+import { LabelChip } from "../../labels/label-chip";
+import { IssueAgentActivityIndicator } from "./issue-agent-activity-indicator";
 import { ProjectPicker } from "../../projects/components/project-picker";
 import { LocalDirectoryHint } from "../../projects/components/local-directory-hint";
 import { CommentCard } from "./comment-card";
@@ -73,7 +75,7 @@ import { useWorkspacePaths } from "@multica/core/paths";
 import { useActorName } from "@multica/core/workspace/hooks";
 import { useWorkspaceId } from "@multica/core/hooks";
 import { useRecentContextStore } from "@multica/core/chat";
-import { issueListOptions, issueDetailOptions, childIssuesOptions, issueUsageOptions, issueAttachmentsOptions } from "@multica/core/issues/queries";
+import { issueListOptions, issueDetailOptions, childIssuesOptions, childIssueProgressOptions, issueUsageOptions, issueAttachmentsOptions } from "@multica/core/issues/queries";
 import { projectDetailOptions } from "@multica/core/projects/queries";
 import { ProjectIcon } from "../../projects/components/project-icon";
 import { issueLabelsOptions } from "@multica/core/labels";
@@ -582,13 +584,21 @@ function ActivityBlock({
 // SubIssueRow — sub-issue list item with inline status & assignee editing
 // ---------------------------------------------------------------------------
 
-function SubIssueRow({ child }: { child: Issue }) {
+function SubIssueRow({
+  child,
+  childProgress,
+}: {
+  child: Issue;
+  /** The sub-issue's OWN children progress (it can itself be a parent). */
+  childProgress?: { done: number; total: number };
+}) {
   const { t } = useT("issues");
   const paths = useWorkspacePaths();
   const updateIssue = useUpdateIssue();
   const selected = useIssueSelectionStore((s) => s.selectedIds.has(child.id));
   const toggleSelected = useIssueSelectionStore((s) => s.toggle);
   const isDone = child.status === "done" || child.status === "cancelled";
+  const labels = child.labels ?? [];
 
   const handleUpdate = useCallback(
     (updates: Partial<UpdateIssueRequest>) => {
@@ -610,80 +620,141 @@ function SubIssueRow({ child }: { child: Issue }) {
   // AppLink wraps only the title/identifier area. Pickers and checkbox are
   // siblings, so their clicks never navigate — no stopPropagation acrobatics
   // and no risk of the native checkbox / picker triggers being blocked.
+  // Right-click anywhere on the row opens the shared issue actions menu
+  // (priority, labels, dates, delete, …) — the same menu as list rows.
   return (
-    <div
-      className={cn(
-        "flex items-center gap-2.5 px-3 py-2 hover:bg-accent/50 transition-colors group/row",
-        selected && "bg-accent/30",
-      )}
-    >
+    <IssueActionsContextMenu issue={child}>
       <div
         className={cn(
-          "flex h-4 w-4 shrink-0 items-center justify-center transition-opacity",
-          selected
-            ? "opacity-100"
-            : "opacity-0 group-hover/row:opacity-100 focus-within:opacity-100",
+          "flex items-center gap-2.5 px-3 py-2 hover:bg-accent/50 transition-colors group/row",
+          selected && "bg-accent/30",
         )}
       >
-        <input
-          type="checkbox"
-          checked={selected}
-          onChange={() => toggleSelected(child.id)}
-          aria-label={`Select ${child.identifier}`}
-          className="cursor-pointer accent-primary"
+        {/* Priority ⇄ checkbox slot, mirroring the main list rows: the
+            priority icon yields to the selection checkbox on hover/focus.
+            Opacity (not display) swap keeps the checkbox keyboard-tabbable. */}
+        <div className="relative flex h-4 w-4 shrink-0 items-center justify-center">
+          <PriorityIcon
+            priority={child.priority}
+            className={cn(
+              "transition-opacity",
+              selected
+                ? "opacity-0"
+                : "group-hover/row:opacity-0 group-focus-within/row:opacity-0",
+            )}
+          />
+          <input
+            type="checkbox"
+            checked={selected}
+            onChange={() => toggleSelected(child.id)}
+            aria-label={`Select ${child.identifier}`}
+            className={cn(
+              "absolute inset-0 cursor-pointer accent-primary transition-opacity",
+              selected
+                ? "opacity-100"
+                : "opacity-0 group-hover/row:opacity-100 focus-visible:opacity-100",
+            )}
+          />
+        </div>
+        <StatusPicker
+          status={child.status}
+          onUpdate={handleUpdate}
+          align="start"
+          trigger={
+            <StatusIcon
+              status={child.status}
+              className="h-[15px] w-[15px] shrink-0"
+            />
+          }
+        />
+        <AppLink
+          href={paths.issueDetail(child.id)}
+          className="flex min-w-0 flex-1 items-center gap-2.5"
+        >
+          <span className="text-[11px] text-muted-foreground tabular-nums font-medium shrink-0">
+            {child.identifier}
+          </span>
+          <IssueAgentActivityIndicator issueId={child.id} />
+          <span className="flex min-w-0 flex-1 items-center gap-1.5">
+            <span
+              className={cn(
+                "text-sm truncate",
+                isDone
+                  ? "text-muted-foreground"
+                  : "group-hover/row:text-foreground",
+              )}
+            >
+              {child.title}
+            </span>
+            {labels.length > 0 && (
+              <span className="hidden max-w-[200px] shrink-0 items-center gap-1 overflow-hidden md:inline-flex">
+                {labels.slice(0, 2).map((label) => (
+                  <LabelChip key={label.id} label={label} />
+                ))}
+                {labels.length > 2 && (
+                  <span className="text-[11px] text-muted-foreground">
+                    +{labels.length - 2}
+                  </span>
+                )}
+              </span>
+            )}
+            {childProgress && childProgress.total > 0 && (
+              <span className="inline-flex shrink-0 items-center gap-1 rounded-full bg-muted/60 px-1.5 py-0.5">
+                <ProgressRing
+                  done={childProgress.done}
+                  total={childProgress.total}
+                  size={11}
+                />
+                <span className="text-[11px] text-muted-foreground tabular-nums font-medium">
+                  {childProgress.done}/{childProgress.total}
+                </span>
+              </span>
+            )}
+          </span>
+        </AppLink>
+        {child.due_date && (
+          <DueDatePicker
+            dueDate={child.due_date}
+            onUpdate={handleUpdate}
+            align="end"
+            trigger={
+              <span
+                className={cn(
+                  "flex shrink-0 items-center gap-1 text-xs tabular-nums",
+                  !isDone && isPastDateOnly(child.due_date)
+                    ? "text-destructive"
+                    : "text-muted-foreground",
+                )}
+              >
+                <CalendarDays className="size-3" />
+                {shortDate(child.due_date)}
+              </span>
+            }
+          />
+        )}
+        <AssigneePicker
+          assigneeType={child.assignee_type}
+          assigneeId={child.assignee_id}
+          onUpdate={handleUpdate}
+          align="end"
+          trigger={
+            child.assignee_type && child.assignee_id ? (
+              <ActorAvatar
+                actorType={child.assignee_type}
+                actorId={child.assignee_id}
+                size="sm"
+                className="shrink-0"
+              />
+            ) : (
+              <span
+                aria-hidden
+                className="h-5 w-5 rounded-full border border-dashed border-muted-foreground/30 shrink-0"
+              />
+            )
+          }
         />
       </div>
-      <StatusPicker
-        status={child.status}
-        onUpdate={handleUpdate}
-        align="start"
-        trigger={
-          <StatusIcon
-            status={child.status}
-            className="h-[15px] w-[15px] shrink-0"
-          />
-        }
-      />
-      <AppLink
-        href={paths.issueDetail(child.id)}
-        className="flex min-w-0 flex-1 items-center gap-2.5"
-      >
-        <span className="text-[11px] text-muted-foreground tabular-nums font-medium shrink-0">
-          {child.identifier}
-        </span>
-        <span
-          className={cn(
-            "text-sm truncate flex-1",
-            isDone
-              ? "text-muted-foreground"
-              : "group-hover/row:text-foreground",
-          )}
-        >
-          {child.title}
-        </span>
-      </AppLink>
-      <AssigneePicker
-        assigneeType={child.assignee_type}
-        assigneeId={child.assignee_id}
-        onUpdate={handleUpdate}
-        align="end"
-        trigger={
-          child.assignee_type && child.assignee_id ? (
-            <ActorAvatar
-              actorType={child.assignee_type}
-              actorId={child.assignee_id}
-              size="sm"
-              className="shrink-0"
-            />
-          ) : (
-            <span
-              aria-hidden
-              className="h-5 w-5 rounded-full border border-dashed border-muted-foreground/30 shrink-0"
-            />
-          )
-        }
-      />
-    </div>
+    </IssueActionsContextMenu>
   );
 }
 
@@ -1200,6 +1271,13 @@ export function IssueDetail({ issueId, onDelete, onDone, defaultSidebarOpen = tr
   const { data: parentChildIssues = [] } = useQuery({
     ...childIssuesOptions(wsId, parentIssueId ?? ""),
     enabled: !!parentIssueId,
+  });
+  // Workspace-wide parent→(done/total) map; lets each sub-issue row show its
+  // OWN nested progress ring without opening it. Same query the list
+  // surfaces use, so it's usually already cached.
+  const { data: subIssueProgress } = useQuery({
+    ...childIssueProgressOptions(wsId),
+    enabled: childIssues.length > 0,
   });
   const [subIssuesCollapsed, setSubIssuesCollapsed] = useState(false);
 
@@ -2227,6 +2305,9 @@ export function IssueDetail({ issueId, onDelete, onDone, defaultSidebarOpen = tr
           {childIssues.length > 0 && (() => {
             const doneCount = childIssues.filter((c) => c.status === "done").length;
             return (
+              // Provider hosts the shared right-click actions menu the rows
+              // delegate to (one singleton menu, not one per row).
+              <IssueContextMenuProvider>
               <div className="mt-10 group/sub-issues">
                 {/* Header */}
                 <div className="flex items-center gap-2 mb-2">
@@ -2301,7 +2382,11 @@ export function IssueDetail({ issueId, onDelete, onDone, defaultSidebarOpen = tr
                             </div>
                           )}
                           {items.map((child) => (
-                            <SubIssueRow key={child.id} child={child} />
+                            <SubIssueRow
+                              key={child.id}
+                              child={child}
+                              childProgress={subIssueProgress?.get(child.id)}
+                            />
                           ))}
                         </Fragment>
                       ))}
@@ -2309,6 +2394,7 @@ export function IssueDetail({ issueId, onDelete, onDone, defaultSidebarOpen = tr
                   );
                 })()}
               </div>
+              </IssueContextMenuProvider>
             );
           })()}
 

--- a/packages/views/issues/components/issue-detail.tsx
+++ b/packages/views/issues/components/issue-detail.tsx
@@ -46,7 +46,7 @@ import { AvatarGroup, AvatarGroupCount } from "@multica/ui/components/ui/avatar"
 import { ActorAvatar } from "../../common/actor-avatar";
 import { PropRow } from "../../common/prop-row";
 import { PropertyIcon } from "../../common/property-icon";
-import type { Attachment, Issue, IssueStatus, IssuePriority, TimelineEntry, UpdateIssueRequest } from "@multica/core/types";
+import type { Attachment, Issue, IssueProperty, IssueStatus, IssuePriority, TimelineEntry, UpdateIssueRequest } from "@multica/core/types";
 import { contentReferencesAttachment } from "@multica/core/types";
 import { STATUS_CONFIG, PRIORITY_CONFIG } from "@multica/core/issues/config";
 import { formatDateOnly, isPastDateOnly } from "@multica/core/issues/date";
@@ -54,7 +54,8 @@ import { useUpdateIssue } from "@multica/core/issues/mutations";
 import { toast } from "sonner";
 import { StatusIcon, PriorityIcon, StatusPicker, PriorityPicker, StagePicker, StartDatePicker, DueDatePicker, AssigneePicker, LabelPicker } from ".";
 import { maxSiblingStage } from "./pickers/stage-picker";
-import { CustomPropertyValueEditor } from "./pickers/custom-property-picker";
+import { CustomPropertyValueEditor, CustomPropertyValueDisplay } from "./pickers/custom-property-picker";
+import { Switch } from "@multica/ui/components/ui/switch";
 import { IssueActionsDropdown, useIssueActions, IssueActionsContextMenu, IssueContextMenuProvider } from "../actions";
 import { LabelChip } from "../../labels/label-chip";
 import { IssueAgentActivityIndicator } from "./issue-agent-activity-indicator";
@@ -86,6 +87,10 @@ import {
   useCommentComposerStore,
   useRecentIssuesStore,
   useResolvedExpandStore,
+  useSubIssueDisplayStore,
+  SUB_ISSUE_ROW_PROPERTY_KEYS,
+  type SubIssueRowProperties,
+  type SubIssueRowPropertyKey,
 } from "@multica/core/issues/stores";
 import { useIssueSelectionStore } from "@multica/core/issues/stores/selection-store";
 import { BatchActionToolbar } from "./batch-action-toolbar";
@@ -587,10 +592,16 @@ function ActivityBlock({
 function SubIssueRow({
   child,
   childProgress,
+  rowProps,
+  customProperties,
 }: {
   child: Issue;
   /** The sub-issue's OWN children progress (it can itself be a parent). */
   childProgress?: { done: number; total: number };
+  /** User-level display preference: which built-in fields the row shows. */
+  rowProps: SubIssueRowProperties;
+  /** Workspace custom properties the user opted into showing on rows. */
+  customProperties: IssueProperty[];
 }) {
   const { t } = useT("issues");
   const paths = useWorkspacePaths();
@@ -598,7 +609,10 @@ function SubIssueRow({
   const selected = useIssueSelectionStore((s) => s.selectedIds.has(child.id));
   const toggleSelected = useIssueSelectionStore((s) => s.toggle);
   const isDone = child.status === "done" || child.status === "cancelled";
-  const labels = child.labels ?? [];
+  const labels = rowProps.labels ? (child.labels ?? []) : [];
+  const customPropsWithValue = customProperties.filter(
+    (p) => child.properties?.[p.id] !== undefined,
+  );
 
   const handleUpdate = useCallback(
     (updates: Partial<UpdateIssueRequest>) => {
@@ -634,15 +648,17 @@ function SubIssueRow({
             priority icon yields to the selection checkbox on hover/focus.
             Opacity (not display) swap keeps the checkbox keyboard-tabbable. */}
         <div className="relative flex h-4 w-4 shrink-0 items-center justify-center">
-          <PriorityIcon
-            priority={child.priority}
-            className={cn(
-              "transition-opacity",
-              selected
-                ? "opacity-0"
-                : "group-hover/row:opacity-0 group-focus-within/row:opacity-0",
-            )}
-          />
+          {rowProps.priority && (
+            <PriorityIcon
+              priority={child.priority}
+              className={cn(
+                "transition-opacity",
+                selected
+                  ? "opacity-0"
+                  : "group-hover/row:opacity-0 group-focus-within/row:opacity-0",
+              )}
+            />
+          )}
           <input
             type="checkbox"
             checked={selected}
@@ -698,7 +714,23 @@ function SubIssueRow({
                 )}
               </span>
             )}
-            {childProgress && childProgress.total > 0 && (
+            {customPropsWithValue.length > 0 && (
+              <span className="hidden max-w-[260px] shrink-0 items-center gap-1 overflow-hidden md:inline-flex">
+                {customPropsWithValue.slice(0, 3).map((property) => (
+                  <span
+                    key={property.id}
+                    className="inline-flex max-w-[120px] items-center gap-1 rounded-full bg-muted/60 px-1.5 py-0.5 text-[11px] text-muted-foreground"
+                  >
+                    <PropertyIcon property={property} className="size-3 text-[11px]" />
+                    <CustomPropertyValueDisplay
+                      property={property}
+                      value={child.properties?.[property.id]}
+                    />
+                  </span>
+                ))}
+              </span>
+            )}
+            {rowProps.childProgress && childProgress && childProgress.total > 0 && (
               <span className="inline-flex shrink-0 items-center gap-1 rounded-full bg-muted/60 px-1.5 py-0.5">
                 <ProgressRing
                   done={childProgress.done}
@@ -712,7 +744,7 @@ function SubIssueRow({
             )}
           </span>
         </AppLink>
-        {child.due_date && (
+        {rowProps.dueDate && child.due_date && (
           <DueDatePicker
             dueDate={child.due_date}
             onUpdate={handleUpdate}
@@ -732,29 +764,120 @@ function SubIssueRow({
             }
           />
         )}
-        <AssigneePicker
-          assigneeType={child.assignee_type}
-          assigneeId={child.assignee_id}
-          onUpdate={handleUpdate}
-          align="end"
-          trigger={
-            child.assignee_type && child.assignee_id ? (
-              <ActorAvatar
-                actorType={child.assignee_type}
-                actorId={child.assignee_id}
-                size="sm"
-                className="shrink-0"
-              />
-            ) : (
-              <span
-                aria-hidden
-                className="h-5 w-5 rounded-full border border-dashed border-muted-foreground/30 shrink-0"
-              />
-            )
-          }
-        />
+        {rowProps.assignee && (
+          <AssigneePicker
+            assigneeType={child.assignee_type}
+            assigneeId={child.assignee_id}
+            onUpdate={handleUpdate}
+            align="end"
+            trigger={
+              child.assignee_type && child.assignee_id ? (
+                <ActorAvatar
+                  actorType={child.assignee_type}
+                  actorId={child.assignee_id}
+                  size="sm"
+                  className="shrink-0"
+                />
+              ) : (
+                <span
+                  aria-hidden
+                  className="h-5 w-5 rounded-full border border-dashed border-muted-foreground/30 shrink-0"
+                />
+              )
+            }
+          />
+        )}
       </div>
     </IssueActionsContextMenu>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// SubIssueDisplayPopover — per-user "which properties do rows show" control
+// ---------------------------------------------------------------------------
+
+// Reuses the main Display panel's `card_*` labels — the property names are
+// identical, so the sub-issues control needs no locale keys of its own.
+const SUB_ISSUE_ROW_PROPERTY_LABEL_KEY: Record<
+  SubIssueRowPropertyKey,
+  "card_priority" | "card_labels" | "card_child_progress" | "card_due_date" | "card_assignee"
+> = {
+  priority: "card_priority",
+  labels: "card_labels",
+  childProgress: "card_child_progress",
+  dueDate: "card_due_date",
+  assignee: "card_assignee",
+};
+
+function SubIssueDisplayPopover({
+  workspaceProperties,
+}: {
+  workspaceProperties: IssueProperty[];
+}) {
+  const { t } = useT("issues");
+  const rowProperties = useSubIssueDisplayStore((s) => s.rowProperties);
+  const rowPropertyIds = useSubIssueDisplayStore((s) => s.rowPropertyIds);
+  const toggleRowProperty = useSubIssueDisplayStore((s) => s.toggleRowProperty);
+  const toggleRowPropertyId = useSubIssueDisplayStore((s) => s.toggleRowPropertyId);
+
+  return (
+    <Popover>
+      <Tooltip>
+        <PopoverTrigger
+          render={
+            <TooltipTrigger
+              render={
+                <button
+                  type="button"
+                  className="inline-flex h-7 w-7 items-center justify-center rounded-md text-muted-foreground hover:bg-accent hover:text-foreground transition-colors"
+                  aria-label={t(($) => $.display.tooltip)}
+                >
+                  <SlidersHorizontal className="h-3.5 w-3.5" />
+                </button>
+              }
+            />
+          }
+        />
+        <TooltipContent side="bottom">{t(($) => $.display.tooltip)}</TooltipContent>
+      </Tooltip>
+      <PopoverContent align="end" className="w-56 p-0">
+        <div className="px-3 py-2.5">
+          <div className="space-y-2">
+            {SUB_ISSUE_ROW_PROPERTY_KEYS.map((key) => (
+              <label
+                key={key}
+                className="flex cursor-pointer items-center justify-between"
+              >
+                <span className="text-sm">
+                  {t(($) => $.display[SUB_ISSUE_ROW_PROPERTY_LABEL_KEY[key]])}
+                </span>
+                <Switch
+                  size="sm"
+                  checked={rowProperties[key]}
+                  onCheckedChange={() => toggleRowProperty(key)}
+                />
+              </label>
+            ))}
+            {workspaceProperties.map((property) => (
+              <label
+                key={property.id}
+                className="flex cursor-pointer items-center justify-between gap-3"
+              >
+                <span className="flex min-w-0 items-center gap-1.5 truncate text-sm">
+                  <PropertyIcon property={property} className="size-3.5 text-xs" />
+                  <span className="truncate">{property.name}</span>
+                </span>
+                <Switch
+                  size="sm"
+                  checked={rowPropertyIds.includes(property.id)}
+                  onCheckedChange={() => toggleRowPropertyId(property.id)}
+                />
+              </label>
+            ))}
+          </div>
+        </div>
+      </PopoverContent>
+    </Popover>
   );
 }
 
@@ -1279,6 +1402,12 @@ export function IssueDetail({ issueId, onDelete, onDone, defaultSidebarOpen = tr
     ...childIssueProgressOptions(wsId),
     enabled: childIssues.length > 0,
   });
+  // User-level display preference for sub-issue rows (built-in field toggles
+  // + opted-in workspace custom properties). `subIssueCustomProps` resolves
+  // the persisted ids against this workspace's live, non-archived property
+  // definitions — ids from other workspaces or archived properties drop out.
+  const subIssueRowProps = useSubIssueDisplayStore((s) => s.rowProperties);
+  const subIssueRowPropertyIds = useSubIssueDisplayStore((s) => s.rowPropertyIds);
   const [subIssuesCollapsed, setSubIssuesCollapsed] = useState(false);
 
   // Selection store is global (workspace-scoped); clear it whenever this
@@ -1448,6 +1577,20 @@ export function IssueDetail({ issueId, onDelete, onDone, defaultSidebarOpen = tr
   // still carry a value written before the archive, and that row must stay
   // renderable (read-only) until someone clears it.
   const { data: workspaceProperties = [] } = useQuery(propertyListOptions(wsId, true));
+
+  // Sub-issue rows only surface live definitions: the display picker offers
+  // non-archived properties, and chips render only ids that resolve here.
+  const activeWorkspaceProperties = useMemo(
+    () => workspaceProperties.filter((p) => p.archived !== true),
+    [workspaceProperties],
+  );
+  const subIssueCustomProps = useMemo(
+    () =>
+      subIssueRowPropertyIds
+        .map((pid) => activeWorkspaceProperties.find((p) => p.id === pid))
+        .filter((p): p is IssueProperty => !!p),
+    [subIssueRowPropertyIds, activeWorkspaceProperties],
+  );
 
   // Seed the visible-optional-props set:
   //   - on issue switch, reset to whichever fields are currently set
@@ -2345,21 +2488,24 @@ export function IssueDetail({ issueId, onDelete, onDone, defaultSidebarOpen = tr
                         : "opacity-0 group-hover/sub-issues:opacity-100 focus-visible:opacity-100",
                     )}
                   />
-                  <Tooltip>
-                    <TooltipTrigger
-                      render={
-                        <button
-                          type="button"
-                          className="ml-auto inline-flex h-7 w-7 items-center justify-center rounded-md text-muted-foreground hover:bg-accent hover:text-foreground transition-colors"
-                          onClick={() => actions.openCreateSubIssue()}
-                          aria-label={t(($) => $.detail.add_sub_issue_aria)}
-                        >
-                          <Plus className="h-4 w-4" />
-                        </button>
-                      }
-                    />
-                    <TooltipContent side="bottom">{t(($) => $.detail.add_sub_issue_tooltip)}</TooltipContent>
-                  </Tooltip>
+                  <div className="ml-auto flex items-center gap-0.5">
+                    <SubIssueDisplayPopover workspaceProperties={activeWorkspaceProperties} />
+                    <Tooltip>
+                      <TooltipTrigger
+                        render={
+                          <button
+                            type="button"
+                            className="inline-flex h-7 w-7 items-center justify-center rounded-md text-muted-foreground hover:bg-accent hover:text-foreground transition-colors"
+                            onClick={() => actions.openCreateSubIssue()}
+                            aria-label={t(($) => $.detail.add_sub_issue_aria)}
+                          >
+                            <Plus className="h-4 w-4" />
+                          </button>
+                        }
+                      />
+                      <TooltipContent side="bottom">{t(($) => $.detail.add_sub_issue_tooltip)}</TooltipContent>
+                    </Tooltip>
+                  </div>
                 </div>
 
                 {/* Inline batch toolbar — appears next to the rows when
@@ -2386,6 +2532,8 @@ export function IssueDetail({ issueId, onDelete, onDone, defaultSidebarOpen = tr
                               key={child.id}
                               child={child}
                               childProgress={subIssueProgress?.get(child.id)}
+                              rowProps={subIssueRowProps}
+                              customProperties={subIssueCustomProps}
                             />
                           ))}
                         </Fragment>

--- a/server/internal/handler/issue.go
+++ b/server/internal/handler/issue.go
@@ -1911,9 +1911,19 @@ func (h *Handler) ListChildIssues(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	prefix := h.getIssuePrefix(r.Context(), issue.WorkspaceID)
+	ids := make([]pgtype.UUID, len(children))
+	for i, child := range children {
+		ids[i] = child.ID
+	}
+	labelsMap := h.labelsByIssue(r.Context(), issue.WorkspaceID, ids)
 	resp := make([]IssueResponse, len(children))
 	for i, child := range children {
 		resp[i] = issueToResponse(child, prefix)
+		labels := labelsMap[resp[i].ID]
+		if labels == nil {
+			labels = []LabelResponse{}
+		}
+		resp[i].Labels = &labels
 	}
 	writeJSON(w, http.StatusOK, map[string]any{
 		"issues": resp,
@@ -1980,9 +1990,19 @@ func (h *Handler) ListChildrenByParents(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 	prefix := h.getIssuePrefix(r.Context(), wsUUID)
+	ids := make([]pgtype.UUID, len(children))
+	for i, child := range children {
+		ids[i] = child.ID
+	}
+	labelsMap := h.labelsByIssue(r.Context(), wsUUID, ids)
 	resp := make([]IssueResponse, len(children))
 	for i, child := range children {
 		resp[i] = issueToResponse(child, prefix)
+		labels := labelsMap[resp[i].ID]
+		if labels == nil {
+			labels = []LabelResponse{}
+		}
+		resp[i].Labels = &labels
 	}
 	writeJSON(w, http.StatusOK, map[string]any{
 		"issues": resp,

--- a/server/internal/handler/issue_children_for_parents_test.go
+++ b/server/internal/handler/issue_children_for_parents_test.go
@@ -336,3 +336,66 @@ func TestListChildrenByParents_OrdersByNumberAscWithinParent(t *testing.T) {
 
 	assertNumberAscending(t, decodeIssueBatch(t, w), children)
 }
+
+// TestListChildIssues_IncludesLabels verifies both child listings bulk-load
+// labels, so the sub-issues panel (and swimlane-hydrated caches) can render
+// label chips without per-child fetches. Every child carries an explicit
+// labels field — empty for unlabeled children, populated for labeled ones.
+func TestListChildIssues_IncludesLabels(t *testing.T) {
+	fx := newChildrenBatchFixture(t)
+	labelID := createTestIssueLabel(t, "children-labels-"+uuid.NewString()[:8])
+
+	labeled := fx.childrenA[0]
+	w := httptest.NewRecorder()
+	req := withURLParam(
+		newRequest("POST", "/api/issues/"+labeled.ID+"/labels", map[string]any{
+			"label_id": labelID,
+		}),
+		"id", labeled.ID,
+	)
+	testHandler.AttachLabel(w, req)
+	if w.Code != http.StatusOK && w.Code != http.StatusCreated && w.Code != http.StatusNoContent {
+		t.Fatalf("attach label: unexpected status %d: %s", w.Code, w.Body.String())
+	}
+
+	assertChildLabels := func(t *testing.T, got []IssueResponse) {
+		t.Helper()
+		for _, child := range got {
+			if child.Labels == nil {
+				t.Fatalf("child %s missing labels field", child.ID)
+			}
+			want := 0
+			if child.ID == labeled.ID {
+				want = 1
+			}
+			if len(*child.Labels) != want {
+				t.Errorf("child %s: want %d labels, got %d", child.ID, want, len(*child.Labels))
+			}
+			if child.ID == labeled.ID && len(*child.Labels) == 1 && (*child.Labels)[0].ID != labelID {
+				t.Errorf("child %s: want label %s, got %s", child.ID, labelID, (*child.Labels)[0].ID)
+			}
+		}
+	}
+
+	// Single-parent listing.
+	w = httptest.NewRecorder()
+	req = withURLParam(
+		newRequest("GET", "/api/issues/"+fx.parentA.ID+"/children", nil),
+		"id", fx.parentA.ID,
+	)
+	testHandler.ListChildIssues(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("ListChildIssues: expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	assertChildLabels(t, decodeIssueBatch(t, w))
+
+	// Batched listing.
+	w = httptest.NewRecorder()
+	req = newRequest("GET", "/api/issues/children?workspace_id="+testWorkspaceID+
+		"&parent_ids="+fx.parentA.ID, nil)
+	testHandler.ListChildrenByParents(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("ListChildrenByParents: expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	assertChildLabels(t, decodeIssueBatch(t, w))
+}


### PR DESCRIPTION
Closes MUL-5098.

## Problem

The sub-issues panel in issue detail showed only status, identifier, title and assignee. Priority, due dates, labels, live agent activity and nested breakdowns were invisible without opening every child issue one by one.

## Changes

**Sub-issue rows** (`packages/views/issues/components/issue-detail.tsx`)
- Priority icon in the checkbox slot, swapping to the selection checkbox on hover/focus — same muscle memory as the main list rows (opacity swap keeps the checkbox keyboard-tabbable).
- `IssueAgentActivityIndicator` after the identifier: see which sub-issue an agent is working on right now, from the parent.
- Label chips after the title (max 2 + `+n` overflow, hidden below `md`).
- The child's **own** done/total progress ring when it has children of its own, backed by the workspace-wide `childIssueProgressOptions` query the list surfaces already share.
- Inline-editable due date (`DueDatePicker`), red when overdue — muted when the child is done/cancelled so finished work doesn't scream.
- Right-click anywhere on a row opens the shared issue actions context menu (priority, labels, dates, delete, …) via a section-level `IssueContextMenuProvider` — parity with list/board surfaces, one singleton menu for the whole section.

**Backend** (`server/internal/handler/issue.go`)
- `ListChildIssues` and `ListChildrenByParents` now bulk-load labels with the same `labelsByIssue` pattern the other list endpoints use, so child rows can render chips without per-child fetches. Client schema already tolerated the optional field.

**Realtime consistency** (`packages/core/issues/ws-updaters.ts`)
- `patchIssueLabels` also patches per-parent children caches (reference-preserving for unrelated parents).
- `invalidateIssueLabelDerivatives` refetches the Map-shaped batched children caches (swimlane lanes) that can't be surgically patched.

## Tests

- views: 2 new SubIssueRow cases (rich row rendering; overdue-vs-done due-date tone) — full suite 2798 passed (1 pre-existing `sidebar-resize` failure, reproduced on clean tree).
- core: 2 new ws-updater cases (children cache patch, batched invalidation) — `issues/` 203 passed (8 pre-existing failures in workspace/projects/realtime, reproduced on clean tree).
- Go: new `TestListChildIssues_IncludesLabels` covering both endpoints — full `internal/handler` package passes.
- `pnpm typecheck` (desktop has 1 pre-existing unrelated error in `provider-logo.tsx`), `pnpm lint` clean for touched packages.

## Addendum: customizable property display (follow-up in this PR)

Per follow-up on MUL-5098, the row's field set is now user-configurable:

- **`useSubIssueDisplayStore`** (`packages/core/issues/stores/`) — persisted user-level preference: toggles for the five built-in fields plus opted-in workspace custom property ids. Defaults reproduce the fixed layout above, so the preference is invisible until changed. Deep-merged on rehydrate so future field additions default to visible.
- **`SubIssueDisplayPopover`** on the Sub-issues header — same switch-row interaction as the main views' Display panel, reusing its `card_*` locale keys (zero new translations).
- Rows render opted-in **custom property chips** (`PropertyIcon` + `CustomPropertyValueDisplay`, list-row parity) only where the child carries a value. Ids resolve against live, non-archived definitions — ids from other workspaces or archived properties are inert.

Tests: 3 store cases + 2 issue-detail cases (toggled-off fields hidden; custom chips render per-value). Full issue-detail suite (40) and core issues suite (206) pass.