### PR TITLE
fix(auth): remove OR divider from the sign-in card (MUL-5105)

### DIFF
--- a/packages/views/auth/login-page.tsx
+++ b/packages/views/auth/login-page.tsx
@@ -450,46 +450,34 @@ export function LoginPage({
               : t(($) => $.signin.continue)}
           </Button>
           {(google || onGoogleLogin) && (
-            <>
-              <div className="relative w-full">
-                <div className="absolute inset-0 flex items-center">
-                  <span className="w-full border-t" />
-                </div>
-                <div className="relative flex justify-center text-xs uppercase">
-                  <span className="bg-card px-2 text-muted-foreground">
-                    {t(($) => $.signin.divider)}
-                  </span>
-                </div>
-              </div>
-              <Button
-                type="button"
-                variant="outline"
-                className="w-full"
-                size="lg"
-                onClick={handleGoogleLogin}
-                disabled={loading}
-              >
-                <svg className="mr-2 h-4 w-4" viewBox="0 0 24 24">
-                  <path
-                    d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92a5.06 5.06 0 0 1-2.2 3.32v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.1z"
-                    fill="#4285F4"
-                  />
-                  <path
-                    d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z"
-                    fill="#34A853"
-                  />
-                  <path
-                    d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z"
-                    fill="#FBBC05"
-                  />
-                  <path
-                    d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z"
-                    fill="#EA4335"
-                  />
-                </svg>
-                {t(($) => $.signin.google)}
-              </Button>
-            </>
+            <Button
+              type="button"
+              variant="outline"
+              className="w-full"
+              size="lg"
+              onClick={handleGoogleLogin}
+              disabled={loading}
+            >
+              <svg className="mr-2 h-4 w-4" viewBox="0 0 24 24">
+                <path
+                  d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92a5.06 5.06 0 0 1-2.2 3.32v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.1z"
+                  fill="#4285F4"
+                />
+                <path
+                  d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z"
+                  fill="#34A853"
+                />
+                <path
+                  d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z"
+                  fill="#FBBC05"
+                />
+                <path
+                  d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z"
+                  fill="#EA4335"
+                />
+              </svg>
+              {t(($) => $.signin.google)}
+            </Button>
           )}
           {extra && <div className="w-full pt-1 text-center">{extra}</div>}
         </CardFooter>

--- a/packages/views/locales/en/auth.json
+++ b/packages/views/locales/en/auth.json
@@ -4,7 +4,6 @@
     "description": "Enter your email to get a login code",
     "continue": "Continue",
     "sending": "Sending code...",
-    "divider": "or",
     "google": "Continue with Google"
   },
   "verify": {

--- a/packages/views/locales/ja/auth.json
+++ b/packages/views/locales/ja/auth.json
@@ -4,7 +4,6 @@
     "description": "ログインコードを受け取るメールアドレスを入力してください",
     "continue": "続ける",
     "sending": "コードを送信中...",
-    "divider": "または",
     "google": "Googleで続ける"
   },
   "verify": {

--- a/packages/views/locales/ko/auth.json
+++ b/packages/views/locales/ko/auth.json
@@ -4,7 +4,6 @@
     "description": "로그인 코드를 받을 이메일을 입력하세요",
     "continue": "계속",
     "sending": "코드 전송 중...",
-    "divider": "또는",
     "google": "Google로 계속"
   },
   "verify": {

--- a/packages/views/locales/zh-Hans/auth.json
+++ b/packages/views/locales/zh-Hans/auth.json
@@ -4,7 +4,6 @@
     "description": "输入邮箱以获取登录验证码",
     "continue": "继续",
     "sending": "发送验证码...",
-    "divider": "或",
     "google": "使用 Google 登录"
   },
   "verify": {


### PR DESCRIPTION
Removes the "OR" divider between the email **Continue** button and **Continue with Google** on the sign-in card (MUL-5105).

## Why

- The divider label rendered as a floating white chip: it masks the line with `bg-card`, but the card footer background is muted, so the chip stood out as a misaligned white box (see issue screenshot).
- The two sign-in options read clearly as alternatives without a labelled separator; the buttons now stack with the footer's existing 12px gap.

## Changes

- `packages/views/auth/login-page.tsx`: drop the divider block, unwrap the now-single-child fragment.
- `packages/views/locales/{en,zh-Hans,ja,ko}/auth.json`: remove the now-unused `signin.divider` key (locale parity test enforces identical keys).

Shared `LoginPage` in `packages/views` — web and desktop both get the change. Mobile has its own login without this divider.

(An earlier commit here carried a fix for the `provider-logo.tsx` desktop typecheck breakage from #5716; main received the equivalent fix via #5728, so this branch was rebased onto it and that commit dropped.)

## Verification

- `packages/views` vitest: `auth/login-page.test.tsx` + `locales/parity.test.ts` — 194/194 pass after the rebase.
- `@multica/views` and `@multica/desktop` typecheck pass after the rebase.
- Before/after screenshots from the running web app are attached on MUL-5105.