### PR TITLE
docs(changelog): add 0.4.7 release entry (MUL-5111)

### DIFF
--- a/apps/web/features/landing/i18n/en.ts
+++ b/apps/web/features/landing/i18n/en.ts
@@ -294,6 +294,25 @@ export function createEnDict(allowSignup: boolean): LandingDict {
     },
     entries: [
       {
+        version: "0.4.7",
+        date: "2026-07-21",
+        title: "Qwen Code runtime, live chat diagrams, and Windows agent fixes",
+        changes: [],
+        features: [
+          "You can now build agents on the Qwen Code runtime.",
+          "Diagrams your agents draw in Chat now show as real diagrams.",
+        ],
+        improvements: [
+          "The assign-confirmation dialog now opens instantly, with no loading wait.",
+        ],
+        fixes: [
+          "On Windows, Cursor tasks no longer fail when your prompt contains command-line flags.",
+          "On Windows, Codex tasks no longer get rejected before they can start.",
+          "Self-hosted custom models no longer fail to sign in on the first turn.",
+          "The project dropdown now closes after you pick a project while creating an issue.",
+        ],
+      },
+      {
         version: "0.4.5",
         date: "2026-07-20",
         title: "Customizable issue tables, live-sorting boards, and steadier agent runs",

--- a/apps/web/features/landing/i18n/ja.ts
+++ b/apps/web/features/landing/i18n/ja.ts
@@ -270,6 +270,25 @@ export function createJaDict(allowSignup: boolean): LandingDict {
       },
       entries: [
         {
+          version: "0.4.7",
+          date: "2026-07-21",
+          title: "Qwen Code ランタイム、チャットの図表、Windows の修正",
+          changes: [],
+          features: [
+            "Qwen Code ランタイムでエージェントを構築できるようになりました。",
+            "エージェントがチャットで描いた図が、そのまま図として表示されます。",
+          ],
+          improvements: [
+            "割り当て確認ダイアログが、読み込み待ちなしですぐに開きます。",
+          ],
+          fixes: [
+            "Windows で、プロンプトにコマンドライン引数が含まれていても Cursor タスクが失敗しなくなりました。",
+            "Windows で、Codex タスクが開始前に拒否されなくなりました。",
+            "セルフホストのカスタムモデルが、最初のターンで認証に失敗しなくなりました。",
+            "Issue の作成時にプロジェクトを選ぶと、プロジェクトのドロップダウンが閉じます。",
+          ],
+        },
+        {
           version: "0.4.5",
           date: "2026-07-20",
           title: "カスタマイズできる Issue テーブル、リアルタイムに並ぶボード、より安定したエージェント実行",

--- a/apps/web/features/landing/i18n/ko.ts
+++ b/apps/web/features/landing/i18n/ko.ts
@@ -269,6 +269,25 @@ export function createKoDict(allowSignup: boolean): LandingDict {
       },
       entries: [
         {
+          version: "0.4.7",
+          date: "2026-07-21",
+          title: "Qwen Code 런타임, 채팅 다이어그램, Windows 수정",
+          changes: [],
+          features: [
+            "이제 Qwen Code 런타임으로 에이전트를 만들 수 있습니다.",
+            "에이전트가 채팅에서 그린 다이어그램이 이제 실제 도표로 표시됩니다.",
+          ],
+          improvements: [
+            "할당 확인 창이 로딩 대기 없이 바로 열립니다.",
+          ],
+          fixes: [
+            "Windows에서 프롬프트에 명령줄 옵션이 들어 있어도 Cursor 작업이 실패하지 않습니다.",
+            "Windows에서 Codex 작업이 시작되기도 전에 거부되지 않습니다.",
+            "셀프 호스팅 맞춤 모델이 첫 턴에서 인증에 실패하지 않습니다.",
+            "Issue를 만들 때 프로젝트를 고르면 프로젝트 드롭다운이 닫힙니다.",
+          ],
+        },
+        {
           version: "0.4.5",
           date: "2026-07-20",
           title: "맞춤 설정할 수 있는 Issue 테이블, 실시간으로 정렬되는 보드, 더 안정적인 에이전트 실행",

--- a/apps/web/features/landing/i18n/zh.ts
+++ b/apps/web/features/landing/i18n/zh.ts
@@ -294,6 +294,25 @@ export function createZhDict(allowSignup: boolean): LandingDict {
     },
     entries: [
       {
+        version: "0.4.7",
+        date: "2026-07-21",
+        title: "新增 Qwen Code 运行时，聊天图表与 Windows 修复",
+        changes: [],
+        features: [
+          "你现在可以基于 Qwen Code 运行时搭建智能体了。",
+          "智能体在聊天里画的图表，现在会真正显示为图表了。",
+        ],
+        improvements: [
+          "指派确认弹窗现在秒开，不再有加载等待。",
+        ],
+        fixes: [
+          "在 Windows 上，提示词里包含命令行参数时，Cursor 任务不再失败。",
+          "在 Windows 上，Codex 任务不再在开始前就被拒绝。",
+          "自托管的自定义模型，现在首轮不再登录失败了。",
+          "创建 Issue 时选好项目后，项目下拉菜单现在会自动关闭。",
+        ],
+      },
+      {
         version: "0.4.5",
         date: "2026-07-20",
         title: "可自定义的 Issue 表格、实时排序的看板，以及更稳的智能体任务",


### PR DESCRIPTION
## What

Adds the **0.4.7** changelog entry (dated 2026-07-21) to all four locale sites: `en`, `zh`, `ja`, `ko`.

## Why

Daily release for 2026-07-21. Covers everything on `main` from the latest release tag `v0.4.6` to HEAD (`e5e278a1`). Entries are written user-facing (result, not implementation) per the changelog language rules.

## Scope of this release

**Features**
- Qwen Code runtime — you can now build agents on it (community PR #5666 by Bowser, review & merge by Multica Eve; logo follow-ups #5713/#5716).
- Unified RichContent renderer — diagrams agents draw in Chat now render as real diagrams (#5578, Naiyuan Qing).

**Improvements**
- Assign-confirmation dialog opens instantly, no loading wait (#5678, Naiyuan Qing).

**Bug fixes**
- Windows Cursor tasks with command-line flags in the prompt no longer fail (#5711, Bohan Jiang).
- Windows Codex tasks no longer rejected before they start (#5672, Bohan Jiang).
- Self-hosted custom models no longer fail auth on the first turn (#5690, Bohan Jiang).
- Project dropdown closes after picking a project (community PR #5663 by beast, merge by Multica Eve).

Internal-only change excluded from the changelog: desktop staging env commit (#5680).

Version bump: **patch** `0.4.6 → 0.4.7` — this release is routine day-to-day work; no headline feature warrants a minor bump.

## Test

- `pnpm --filter @multica/web run typecheck` — pass
- `pnpm --filter @multica/web exec vitest run features/landing/components/changelog-page-client.test.ts` — 3/3 pass
