### PR TITLE
fix(chat): 恢复 chat 输入框的 bubble menu 以支持清除格式 (MUL-5106)

### DIFF
--- a/packages/views/chat/components/chat-input.tsx
+++ b/packages/views/chat/components/chat-input.tsx
@@ -537,9 +537,13 @@ export function ChatInput({
             mentionMode={contextItems ? "context" : "default"}
             mentionContextItems={contextItems}
             enableSlashCommands
-            // Chat is short-form — the floating formatting toolbar is
-            // more distraction than feature here.
-            showBubbleMenu={false}
+            // The bubble menu carries the only affordance that can strip
+            // formatting — "Normal text" (setParagraph) plus the mark/list
+            // toggles. Once a `# ` input rule or a Markdown/HTML paste turns a
+            // line into a heading, chat has no other way to remove it, so
+            // without the bubble menu formatting can be created but never
+            // undone (MUL-5106).
+            showBubbleMenu
           />
         </div>
         {(uploadEnabled || leftAdornment) && (


### PR DESCRIPTION
## 问题 (MUL-5106)

Chat 输入框是共用的 Tiptap 富文本编辑器,`# ` input rule 与 Markdown/HTML 粘贴都会把一行变成标题(heading)。但 chat 此前传了 `showBubbleMenu={false}`,关掉了唯一能把标题降回正文("Normal text" / `setParagraph`)以及切换其它格式的浮动工具栏 —— 结果格式一旦产生就没有任何入口去掉。

## 改动

`packages/views/chat/components/chat-input.tsx`:把 `showBubbleMenu={false}` 改为启用。组件在设计时就暴露了这个配置能力,启用即可,交互与 Linear 一致。选中文本即弹出气泡菜单,可将标题降回正文、切换/去掉各类格式。

attach、`@` 提及、`/` 命令、图片/文件等内联能力不受影响(均为独立扩展)。

## 验证

- `pnpm exec tsc --noEmit`(@multica/views)通过
- `eslint chat/components/chat-input.tsx` 通过
- `vitest run chat-input.test.tsx` — 26 passed
- `vitest run content-editor.test.tsx` — 34 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
