### PR TITLE
MUL-5111: fix Desktop Qwen logo typecheck

### DIFF
--- a/packages/views/runtimes/components/provider-logo.tsx
+++ b/packages/views/runtimes/components/provider-logo.tsx
@@ -286,7 +286,10 @@ function GrokLogo({ className }: { className: string }) {
 
 // Qwen Code — official SVG copied verbatim from QwenLM/qwen-code's desktop
 // brand assets (packages/desktop/apps/electron/resources/brands/qwen-code/icon.svg).
-const qwenLogoSrc = typeof qwenLogo === "string" ? qwenLogo : qwenLogo.src;
+const qwenLogoSrc: string = (() => {
+  const asset = qwenLogo as unknown;
+  return typeof asset === "string" ? asset : (asset as { src: string }).src;
+})();
 
 function QwenLogo({ className }: { className: string }) {
   return <img src={qwenLogoSrc} alt="" aria-hidden className={className} />;


### PR DESCRIPTION
## Summary

- normalize the Qwen SVG import across Vite and Next.js asset shapes
- unblock the Desktop renderer typecheck without changing logo rendering

## Testing

- `pnpm --filter @multica/desktop run typecheck`
- `pnpm --filter @multica/web run typecheck`
- `pnpm --filter @multica/views exec vitest run runtimes/components/provider-logo.test.tsx`
