### PR TITLE
fix(agent/codex): retry once when the model catalog refresh blocks the first turn (MUL-5110)

### DIFF
--- a/server/pkg/agent/agent.go
+++ b/server/pkg/agent/agent.go
@@ -147,6 +147,11 @@ type Result struct {
 	// process tree was reaped. It is intentionally not part of the public
 	// result contract.
 	codexInitializeRetrySafe bool
+	// codexStartupRefreshRetrySafe is provider-internal evidence that the
+	// first turn produced no semantic progress because Codex could not load
+	// its model catalog, and that the process tree was reaped afterwards.
+	// Like codexInitializeRetrySafe it is not part of the public contract.
+	codexStartupRefreshRetrySafe bool
 }
 
 // Config configures a Backend instance.

--- a/server/pkg/agent/codex.go
+++ b/server/pkg/agent/codex.go
@@ -93,7 +93,13 @@ const CodexFirstTurnNoProgressMarker = "codex app-server no progress timeout"
 // did not answer within the bounded handshake window.
 const CodexHandshakeTimeoutMarker = "codex app-server handshake timeout"
 
-const codexModelCatalogRefreshTimeoutSignal = "failed to refresh available models: timeout waiting for child process to exit"
+// codexModelCatalogRefreshFailureSignal matches the Codex models-manager error
+// emitted when the model catalog could not be refreshed. Codex reports several
+// distinct causes under this prefix ("timeout waiting for child process to
+// exit", "stream disconnected before completion", ...), so match the shared
+// prefix rather than one variant: they are all the same startup-blocking
+// failure from the daemon's point of view.
+const codexModelCatalogRefreshFailureSignal = "failed to refresh available models"
 
 var errCodexProcessExited = errors.New("codex process exited")
 
@@ -640,22 +646,61 @@ func (b *codexBackend) Execute(ctx context.Context, prompt string, opts ExecOpti
 					return
 				}
 			}
+			// Hold back the leading session-pin status messages until this
+			// attempt proves it made real progress. A retried attempt runs on a
+			// fresh Codex thread, so forwarding a discarded attempt's pin would
+			// leave the resume pointer aimed at a thread that never produced a
+			// turn (MUL-5110). The first non-pin message means the attempt is
+			// live: flush and stream normally from then on.
+			var heldPins []Message
+			holdingPins := true
+			flushHeldPins := func() {
+				for _, held := range heldPins {
+					msgCh <- held
+				}
+				heldPins = nil
+				holdingPins = false
+			}
 			for msg := range session.Messages {
+				if holdingPins && msg.Type == MessageStatus && msg.Status == "running" {
+					heldPins = append(heldPins, msg)
+					continue
+				}
+				if holdingPins {
+					flushHeldPins()
+				}
 				msgCh <- msg
 			}
 			result, ok := <-session.Result
 			if !ok {
+				flushHeldPins()
 				resCh <- Result{Status: "failed", Error: "codex attempt closed without result"}
 				return
 			}
-			if !result.codexInitializeRetrySafe || attempt == 2 {
+			retryReason := ""
+			switch {
+			case result.codexInitializeRetrySafe:
+				retryReason = "initialize"
+			case result.codexStartupRefreshRetrySafe:
+				retryReason = "model_catalog_refresh"
+			}
+			if retryReason == "" || attempt == 2 {
+				flushHeldPins()
 				resCh <- result
 				return
 			}
+			// The model catalog refresh reaches the network, so give the
+			// transient failure a little more room than the local initialize
+			// handshake gets. Both stay well inside the task timeout, and
+			// ctx.Done() below keeps the retry from extending it.
 			backoff := 75*time.Millisecond + time.Duration(time.Now().UnixNano()%50)*time.Millisecond
-			b.cfg.Logger.Warn("codex initialize retry scheduled", "attempt", attempt, "next_attempt", attempt+1, "backoff", backoff.String())
+			if retryReason == "model_catalog_refresh" {
+				backoff = 500*time.Millisecond + time.Duration(time.Now().UnixNano()%1000)*time.Millisecond
+			}
+			b.cfg.Logger.Warn("codex retry scheduled", "reason", retryReason, "attempt", attempt, "next_attempt", attempt+1, "backoff", backoff.String())
 			select {
 			case <-ctx.Done():
+				flushHeldPins()
 				resCh <- result
 				return
 			case <-time.After(backoff):
@@ -1218,9 +1263,27 @@ func (b *codexBackend) executeOnce(ctx context.Context, prompt string, opts Exec
 		if processExitErr != nil {
 			finalError = withAgentStderr(processExitErr.Error(), "codex", sanitizeCodexDiagnostic(stderrBuf.Tail()))
 		}
+		stderrTail := sanitizeCodexDiagnostic(stderrBuf.Tail())
 		if timeoutDiagnostic.Kind != codexTimeoutNone {
 			timeoutDiagnostic.CodexVersion = detectCodexVersionForDiagnostics(context.Background(), execPath, cmd.Env, b.cfg.Logger)
-			finalError = buildCodexTimeoutDiagnosticError(timeoutDiagnostic, sanitizeCodexDiagnostic(stderrBuf.Tail()))
+			finalError = buildCodexTimeoutDiagnosticError(timeoutDiagnostic, stderrTail)
+		}
+
+		// A first turn that produced no semantic progress because Codex could
+		// not load its model catalog is a startup-only failure: no tool ran and
+		// no content reached the user, so replaying the prompt cannot duplicate
+		// side effects. Require the reaped process tree for the same reason
+		// initialize retries do — a surviving app-server would race the retry.
+		startupRefreshRetrySafe := timeoutDiagnostic.Kind == codexTimeoutFirstTurnNoProgress &&
+			!firstTurnProgressObserved &&
+			strings.Contains(stderrTail, codexModelCatalogRefreshFailureSignal) &&
+			cmd.ProcessState != nil
+		if startupRefreshRetrySafe {
+			b.cfg.Logger.Warn("codex startup model catalog refresh failure is retry safe",
+				"pid", cmd.Process.Pid,
+				"thread_id", threadID,
+				"attempt", attempt,
+			)
 		}
 
 		outputMu.Lock()
@@ -1257,12 +1320,13 @@ func (b *codexBackend) executeOnce(ctx context.Context, prompt string, opts Exec
 		}
 
 		resCh <- Result{
-			Status:     finalStatus,
-			Output:     finalOutput,
-			Error:      finalError,
-			SessionID:  threadID,
-			DurationMs: duration.Milliseconds(),
-			Usage:      usageMap,
+			Status:                       finalStatus,
+			Output:                       finalOutput,
+			Error:                        finalError,
+			SessionID:                    threadID,
+			DurationMs:                   duration.Milliseconds(),
+			Usage:                        usageMap,
+			codexStartupRefreshRetrySafe: startupRefreshRetrySafe,
 		}
 	}()
 
@@ -1494,8 +1558,8 @@ func formatCodexDiagnosticModel(model string) string {
 }
 
 func appendCodexKnownStderrHint(msg, stderrTail string) string {
-	if strings.Contains(stderrTail, codexModelCatalogRefreshTimeoutSignal) {
-		return msg + "; diagnosis: Codex stderr shows the model catalog refresh timed out. Try setting an explicit model, switching Codex CLI versions, or using another runtime while Codex app-server recovers"
+	if strings.Contains(stderrTail, codexModelCatalogRefreshFailureSignal) {
+		return msg + "; diagnosis: Codex could not load its model catalog, which blocks the first turn. This is usually a transient network failure reaching the Codex service. Check network/proxy connectivity and retry the task, or switch to another runtime while the Codex service is unreachable"
 	}
 	return msg
 }

--- a/server/pkg/agent/codex.go
+++ b/server/pkg/agent/codex.go
@@ -637,21 +637,23 @@ func (b *codexBackend) Execute(ctx context.Context, prompt string, opts ExecOpti
 		defer close(msgCh)
 		defer close(resCh)
 		session := firstSession
+		attemptOpts := opts
 		for attempt := 1; attempt <= 2; attempt++ {
 			if attempt > 1 {
 				var err error
-				session, err = b.executeOnce(ctx, prompt, opts, attempt)
+				session, err = b.executeOnce(ctx, prompt, attemptOpts, attempt)
 				if err != nil {
 					resCh <- Result{Status: "failed", Error: err.Error()}
 					return
 				}
 			}
 			// Hold back the leading session-pin status messages until this
-			// attempt proves it made real progress. A retried attempt runs on a
-			// fresh Codex thread, so forwarding a discarded attempt's pin would
-			// leave the resume pointer aimed at a thread that never produced a
-			// turn (MUL-5110). The first non-pin message means the attempt is
-			// live: flush and stream normally from then on.
+			// attempt proves it made real progress. A retry never continues the
+			// discarded attempt's thread (initialize retries fail before any
+			// thread exists; catalog retries clear ResumeSessionID below), so
+			// forwarding its pin would leave the resume pointer aimed at a
+			// thread that never produced a turn (MUL-5110). The first non-pin
+			// message means the attempt is live: flush and stream from then on.
 			var heldPins []Message
 			holdingPins := true
 			flushHeldPins := func() {
@@ -696,6 +698,18 @@ func (b *codexBackend) Execute(ctx context.Context, prompt string, opts ExecOpti
 			backoff := 75*time.Millisecond + time.Duration(time.Now().UnixNano()%50)*time.Millisecond
 			if retryReason == "model_catalog_refresh" {
 				backoff = 500*time.Millisecond + time.Duration(time.Now().UnixNano()%1000)*time.Millisecond
+				// The stalled attempt already reached turn/started, so the prior
+				// thread may hold the submitted input or an unfinished turn.
+				// Resuming it again could duplicate that input; start a fresh
+				// thread instead and keep ResumeExpected so codexTurnInput
+				// prepends the continuity notice about the lost context.
+				if attemptOpts.ResumeSessionID != "" {
+					b.cfg.Logger.Warn("codex retry dropping resume pointer after model catalog refresh failure",
+						"prior_thread_id", attemptOpts.ResumeSessionID,
+					)
+					attemptOpts.ResumeSessionID = ""
+					attemptOpts.ResumeExpected = true
+				}
 			}
 			b.cfg.Logger.Warn("codex retry scheduled", "reason", retryReason, "attempt", attempt, "next_attempt", attempt+1, "backoff", backoff.String())
 			select {
@@ -1272,12 +1286,14 @@ func (b *codexBackend) executeOnce(ctx context.Context, prompt string, opts Exec
 		// A first turn that produced no semantic progress because Codex could
 		// not load its model catalog is a startup-only failure: no tool ran and
 		// no content reached the user, so replaying the prompt cannot duplicate
-		// side effects. Require the reaped process tree for the same reason
-		// initialize retries do — a surviving app-server would race the retry.
+		// side effects. Reuse the same process-tree evidence initialize retries
+		// require (cleanupConfirmed plus platform support) rather than a bare
+		// ProcessState check: on Windows the daemon cannot prove the whole tree
+		// is gone, and a surviving app-server would race the retry.
 		startupRefreshRetrySafe := timeoutDiagnostic.Kind == codexTimeoutFirstTurnNoProgress &&
 			!firstTurnProgressObserved &&
 			strings.Contains(stderrTail, codexModelCatalogRefreshFailureSignal) &&
-			cmd.ProcessState != nil
+			cleanupConfirmed && codexInitializeRetrySupported()
 		if startupRefreshRetrySafe {
 			b.cfg.Logger.Warn("codex startup model catalog refresh failure is retry safe",
 				"pid", cmd.Process.Pid,

--- a/server/pkg/agent/codex_test.go
+++ b/server/pkg/agent/codex_test.go
@@ -2880,6 +2880,174 @@ func TestCodexExecuteRetriesAfterModelCatalogRefreshFailure(t *testing.T) {
 	}
 }
 
+// TestCodexExecuteRetryAfterCatalogFailureStartsFreshThreadForResume covers the
+// resume case: the stalled attempt already reached turn/started on the prior
+// thread, so the retry must not resume it again. It starts a fresh thread and
+// keeps ResumeExpected so the lost context is disclosed to the agent.
+func TestCodexExecuteRetryAfterCatalogFailureStartsFreshThreadForResume(t *testing.T) {
+	// Not t.Parallel(): this test mutates codexGracefulShutdownTimeoutNanos.
+	if runtime.GOOS == "windows" {
+		t.Skip("shell-script fixture is POSIX-only")
+	}
+	codexGracefulShutdownTimeoutNanos.Store(int64(100 * time.Millisecond))
+	t.Cleanup(func() { codexGracefulShutdownTimeoutNanos.Store(0) })
+
+	// Each invocation records the JSON-RPC lines it received so the test can
+	// assert which thread RPC the retry used.
+	fakePath := writeFakeCodexAppServer(t, ""+
+		`DIR="$(dirname "$0")"`+"\n"+
+		`ATTEMPT=$(cat "$DIR/attempts" 2>/dev/null || echo 0)`+"\n"+
+		`ATTEMPT=$((ATTEMPT+1))`+"\n"+
+		`echo "$ATTEMPT" > "$DIR/attempts"`+"\n"+
+		`LOG="$DIR/rpc-$ATTEMPT.log"`+"\n"+
+		`read line; echo "$line" >> "$LOG"`+"\n"+
+		`echo '{"jsonrpc":"2.0","id":1,"result":{}}'`+"\n"+
+		`read line; echo "$line" >> "$LOG"`+"\n"+
+		`read line; echo "$line" >> "$LOG"`+"\n"+
+		`if [ "$ATTEMPT" = "1" ]; then`+"\n"+
+		`  echo '{"jsonrpc":"2.0","id":2,"result":{"thread":{"id":"thr-prior"}}}'`+"\n"+
+		`  read line; echo "$line" >> "$LOG"`+"\n"+
+		`  echo '{"jsonrpc":"2.0","id":3,"result":{}}'`+"\n"+
+		`  echo '{"jsonrpc":"2.0","method":"turn/started","params":{"threadId":"thr-prior","turn":{"id":"turn-prior"}}}'`+"\n"+
+		`  echo 'ERROR codex_models_manager::manager: failed to refresh available models: timeout waiting for child process to exit' >&2`+"\n"+
+		`  sleep 2`+"\n"+
+		`else`+"\n"+
+		`  echo '{"jsonrpc":"2.0","id":2,"result":{"thread":{"id":"thr-fresh"}}}'`+"\n"+
+		`  read line; echo "$line" >> "$LOG"`+"\n"+
+		`  echo '{"jsonrpc":"2.0","id":3,"result":{}}'`+"\n"+
+		`  echo '{"jsonrpc":"2.0","method":"turn/started","params":{"threadId":"thr-fresh","turn":{"id":"turn-fresh"}}}'`+"\n"+
+		`  echo '{"jsonrpc":"2.0","method":"item/completed","params":{"threadId":"thr-fresh","item":{"type":"agentMessage","id":"msg-1","text":"Fresh"}}}'`+"\n"+
+		`  echo '{"jsonrpc":"2.0","method":"turn/completed","params":{"threadId":"thr-fresh","turn":{"id":"turn-fresh","status":"completed"}}}'`+"\n"+
+		`fi`+"\n")
+
+	result, _ := executeFakeCodexCollectingMessages(t, fakePath, ExecOptions{
+		ResumeSessionID:           "thr-prior",
+		ResumeExpected:            true,
+		Timeout:                   20 * time.Second,
+		SemanticInactivityTimeout: 100 * time.Millisecond,
+	}, 20*time.Second)
+
+	if result.Status != "completed" {
+		t.Fatalf("expected the retry to complete, got status=%q error=%q", result.Status, result.Error)
+	}
+	if result.SessionID != "thr-fresh" {
+		t.Fatalf("expected the retry to land on a fresh thread, got %q", result.SessionID)
+	}
+	dir := filepath.Dir(fakePath)
+	first, err := os.ReadFile(filepath.Join(dir, "rpc-1.log"))
+	if err != nil {
+		t.Fatalf("read first attempt rpc log: %v", err)
+	}
+	if !strings.Contains(string(first), "thread/resume") {
+		t.Fatalf("expected the first attempt to resume the prior thread, got %s", first)
+	}
+	second, err := os.ReadFile(filepath.Join(dir, "rpc-2.log"))
+	if err != nil {
+		t.Fatalf("read second attempt rpc log: %v", err)
+	}
+	if strings.Contains(string(second), "thread/resume") {
+		t.Fatalf("retry must not resume the stalled thread, got %s", second)
+	}
+	if !strings.Contains(string(second), "thread/start") {
+		t.Fatalf("expected the retry to start a fresh thread, got %s", second)
+	}
+	// ResumeExpected survives the cleared pointer, so the agent is told the
+	// prior context could not be restored.
+	if !strings.Contains(string(second), "previous conversation context could not be restored") {
+		t.Fatalf("expected the retry input to carry the continuity notice, got %s", second)
+	}
+}
+
+// TestCodexExecuteDoesNotRetryCatalogFailureWhenCleanupUnconfirmed keeps the
+// retry gate tied to a reaped process tree: a surviving app-server would race
+// the second attempt, so an unconfirmed cleanup must not retry.
+func TestCodexExecuteDoesNotRetryCatalogFailureWhenCleanupUnconfirmed(t *testing.T) {
+	// Not t.Parallel(): this test mutates package-level Codex overrides.
+	if runtime.GOOS == "windows" {
+		t.Skip("shell-script fixture is POSIX-only")
+	}
+	codexGracefulShutdownTimeoutNanos.Store(int64(100 * time.Millisecond))
+	t.Cleanup(func() { codexGracefulShutdownTimeoutNanos.Store(0) })
+	codexCleanupConfirmationOverride.Store(-1)
+	t.Cleanup(func() { codexCleanupConfirmationOverride.Store(0) })
+
+	fakePath := writeFakeCodexAppServer(t, ""+
+		`DIR="$(dirname "$0")"`+"\n"+
+		`ATTEMPT=$(cat "$DIR/attempts" 2>/dev/null || echo 0)`+"\n"+
+		`ATTEMPT=$((ATTEMPT+1))`+"\n"+
+		`echo "$ATTEMPT" > "$DIR/attempts"`+"\n"+
+		`read line`+"\n"+
+		`echo '{"jsonrpc":"2.0","id":1,"result":{}}'`+"\n"+
+		`read line`+"\n"+
+		`read line`+"\n"+
+		`echo '{"jsonrpc":"2.0","id":2,"result":{"thread":{"id":"thr-unreaped"}}}'`+"\n"+
+		`read line`+"\n"+
+		`echo '{"jsonrpc":"2.0","id":3,"result":{}}'`+"\n"+
+		`echo '{"jsonrpc":"2.0","method":"turn/started","params":{"threadId":"thr-unreaped","turn":{"id":"turn-unreaped"}}}'`+"\n"+
+		`echo 'ERROR codex_models_manager::manager: failed to refresh available models: timeout waiting for child process to exit' >&2`+"\n"+
+		`sleep 2`+"\n")
+
+	result := executeFakeCodex(t, fakePath, ExecOptions{
+		Timeout:                   5 * time.Second,
+		SemanticInactivityTimeout: 100 * time.Millisecond,
+	})
+	if result.Status != "timeout" {
+		t.Fatalf("expected timeout, got status=%q error=%q", result.Status, result.Error)
+	}
+	assertCodexAttemptCount(t, fakePath, "1")
+}
+
+// TestCodexExecuteDoesNotRetryCatalogFailureAfterSemanticProgress is the core
+// no-duplicate-side-effects guard: once a turn has produced content or run a
+// tool, the catalog signal must not buy it a replay.
+func TestCodexExecuteDoesNotRetryCatalogFailureAfterSemanticProgress(t *testing.T) {
+	// Not t.Parallel(): this test mutates codexGracefulShutdownTimeoutNanos.
+	if runtime.GOOS == "windows" {
+		t.Skip("shell-script fixture is POSIX-only")
+	}
+	codexGracefulShutdownTimeoutNanos.Store(int64(100 * time.Millisecond))
+	t.Cleanup(func() { codexGracefulShutdownTimeoutNanos.Store(0) })
+
+	fakePath := writeFakeCodexAppServer(t, ""+
+		`DIR="$(dirname "$0")"`+"\n"+
+		`ATTEMPT=$(cat "$DIR/attempts" 2>/dev/null || echo 0)`+"\n"+
+		`ATTEMPT=$((ATTEMPT+1))`+"\n"+
+		`echo "$ATTEMPT" > "$DIR/attempts"`+"\n"+
+		`read line`+"\n"+
+		`echo '{"jsonrpc":"2.0","id":1,"result":{}}'`+"\n"+
+		`read line`+"\n"+
+		`read line`+"\n"+
+		`echo '{"jsonrpc":"2.0","id":2,"result":{"thread":{"id":"thr-worked"}}}'`+"\n"+
+		`read line`+"\n"+
+		`echo '{"jsonrpc":"2.0","id":3,"result":{}}'`+"\n"+
+		`echo '{"jsonrpc":"2.0","method":"turn/started","params":{"threadId":"thr-worked","turn":{"id":"turn-worked"}}}'`+"\n"+
+		// A tool ran: this turn has side effects and must never be replayed,
+		// even though the catalog signal is present in stderr.
+		`echo '{"jsonrpc":"2.0","method":"item/completed","params":{"threadId":"thr-worked","item":{"type":"commandExecution","id":"cmd-1","aggregatedOutput":"deployed"}}}'`+"\n"+
+		`echo 'ERROR codex_models_manager::manager: failed to refresh available models: timeout waiting for child process to exit' >&2`+"\n"+
+		`sleep 2`+"\n")
+
+	result := executeFakeCodex(t, fakePath, ExecOptions{
+		Timeout:                   5 * time.Second,
+		SemanticInactivityTimeout: 100 * time.Millisecond,
+	})
+	if result.Status != "timeout" {
+		t.Fatalf("expected timeout, got status=%q error=%q", result.Status, result.Error)
+	}
+	assertCodexAttemptCount(t, fakePath, "1")
+}
+
+func assertCodexAttemptCount(t *testing.T, fakePath, want string) {
+	t.Helper()
+	attempts, err := os.ReadFile(filepath.Join(filepath.Dir(fakePath), "attempts"))
+	if err != nil {
+		t.Fatalf("read attempt counter: %v", err)
+	}
+	if got := strings.TrimSpace(string(attempts)); got != want {
+		t.Fatalf("expected %s attempt(s), got %q", want, got)
+	}
+}
+
 // TestCodexExecuteDoesNotRetryFirstTurnNoProgressWithoutCatalogSignal keeps the
 // retry gate narrow: a stalled first turn with no model catalog evidence in
 // stderr is not known to be transient, so it must fail on the first attempt.
@@ -2914,13 +3082,7 @@ func TestCodexExecuteDoesNotRetryFirstTurnNoProgressWithoutCatalogSignal(t *test
 	if result.Status != "timeout" {
 		t.Fatalf("expected timeout, got status=%q error=%q", result.Status, result.Error)
 	}
-	attempts, err := os.ReadFile(filepath.Join(filepath.Dir(fakePath), "attempts"))
-	if err != nil {
-		t.Fatalf("read attempt counter: %v", err)
-	}
-	if got := strings.TrimSpace(string(attempts)); got != "1" {
-		t.Fatalf("expected exactly one attempt without the catalog signal, got %q", got)
-	}
+	assertCodexAttemptCount(t, fakePath, "1")
 }
 
 func TestCodexExecuteTurnCompletionCanPrecedeTurnStartResponse(t *testing.T) {

--- a/server/pkg/agent/codex_test.go
+++ b/server/pkg/agent/codex_test.go
@@ -2434,10 +2434,14 @@ func TestCodexExecuteTimesOutWhenTurnStopsAfterToolResult(t *testing.T) {
 }
 
 func TestCodexExecuteFirstTurnNoProgressSurfacesDiagnostics(t *testing.T) {
-	t.Parallel()
+	// Not t.Parallel(): this test mutates codexGracefulShutdownTimeoutNanos.
+	// The model catalog signal below makes both attempts retry safe, so this
+	// exercises the exhausted-retry path and pays two cleanup windows.
 	if runtime.GOOS == "windows" {
 		t.Skip("shell-script fixture is POSIX-only")
 	}
+	codexGracefulShutdownTimeoutNanos.Store(int64(100 * time.Millisecond))
+	t.Cleanup(func() { codexGracefulShutdownTimeoutNanos.Store(0) })
 
 	fakePath := writeFakeCodexAppServer(t, ""+
 		`read line`+"\n"+
@@ -2449,7 +2453,7 @@ func TestCodexExecuteFirstTurnNoProgressSurfacesDiagnostics(t *testing.T) {
 		`echo '{"jsonrpc":"2.0","id":3,"result":{}}'`+"\n"+
 		`echo '{"jsonrpc":"2.0","method":"turn/started","params":{"threadId":"thr-stuck","turn":{"id":"turn-stuck"}}}'`+"\n"+
 		`echo 'ERROR codex_models_manager::manager: failed to refresh available models: timeout waiting for child process to exit' >&2`+"\n"+
-		`sleep 5`+"\n")
+		`sleep 2`+"\n")
 
 	result := executeFakeCodex(t, fakePath, ExecOptions{
 		Timeout:                   5 * time.Second,
@@ -2464,9 +2468,9 @@ func TestCodexExecuteFirstTurnNoProgressSurfacesDiagnostics(t *testing.T) {
 		"turn-stuck",
 		`model="default(empty)"`,
 		`codex_version="codex-cli 0.0.0-test"`,
-		"model catalog refresh timed out",
+		"Codex could not load its model catalog",
 		"codex stderr:",
-		codexModelCatalogRefreshTimeoutSignal,
+		codexModelCatalogRefreshFailureSignal,
 	} {
 		if !strings.Contains(result.Error, want) {
 			t.Fatalf("expected error to contain %q, got %q", want, result.Error)
@@ -2815,6 +2819,110 @@ func TestCodexExecuteSemanticInactivityDoesNotAffectNormalTurnCompletion(t *test
 	}
 }
 
+// TestCodexExecuteRetriesAfterModelCatalogRefreshFailure covers the MUL-5110
+// hot path: Codex accepts the turn, fails to load its model catalog, and never
+// emits an item. The daemon must retry once and surface the second attempt.
+func TestCodexExecuteRetriesAfterModelCatalogRefreshFailure(t *testing.T) {
+	// Not t.Parallel(): this test mutates codexGracefulShutdownTimeoutNanos.
+	if runtime.GOOS == "windows" {
+		t.Skip("shell-script fixture is POSIX-only")
+	}
+	codexGracefulShutdownTimeoutNanos.Store(int64(100 * time.Millisecond))
+	t.Cleanup(func() { codexGracefulShutdownTimeoutNanos.Store(0) })
+
+	// The fixture counts invocations next to itself so attempt 1 can stall and
+	// attempt 2 can succeed on a different thread.
+	fakePath := writeFakeCodexAppServer(t, ""+
+		`STATE="$(dirname "$0")/attempts"`+"\n"+
+		`ATTEMPT=$(cat "$STATE" 2>/dev/null || echo 0)`+"\n"+
+		`ATTEMPT=$((ATTEMPT+1))`+"\n"+
+		`echo "$ATTEMPT" > "$STATE"`+"\n"+
+		`read line`+"\n"+
+		`echo '{"jsonrpc":"2.0","id":1,"result":{}}'`+"\n"+
+		`read line`+"\n"+
+		`read line`+"\n"+
+		`if [ "$ATTEMPT" = "1" ]; then`+"\n"+
+		`  echo '{"jsonrpc":"2.0","id":2,"result":{"thread":{"id":"thr-cold"}}}'`+"\n"+
+		`  read line`+"\n"+
+		`  echo '{"jsonrpc":"2.0","id":3,"result":{}}'`+"\n"+
+		`  echo '{"jsonrpc":"2.0","method":"turn/started","params":{"threadId":"thr-cold","turn":{"id":"turn-cold"}}}'`+"\n"+
+		`  echo 'ERROR codex_models_manager::manager: failed to refresh available models: stream disconnected before completion' >&2`+"\n"+
+		`  sleep 2`+"\n"+
+		`else`+"\n"+
+		`  echo '{"jsonrpc":"2.0","id":2,"result":{"thread":{"id":"thr-warm"}}}'`+"\n"+
+		`  read line`+"\n"+
+		`  echo '{"jsonrpc":"2.0","id":3,"result":{}}'`+"\n"+
+		`  echo '{"jsonrpc":"2.0","method":"turn/started","params":{"threadId":"thr-warm","turn":{"id":"turn-warm"}}}'`+"\n"+
+		`  echo '{"jsonrpc":"2.0","method":"item/completed","params":{"threadId":"thr-warm","item":{"type":"agentMessage","id":"msg-1","text":"Recovered"}}}'`+"\n"+
+		`  echo '{"jsonrpc":"2.0","method":"turn/completed","params":{"threadId":"thr-warm","turn":{"id":"turn-warm","status":"completed"}}}'`+"\n"+
+		`fi`+"\n")
+
+	result, messages := executeFakeCodexCollectingMessages(t, fakePath, ExecOptions{
+		Timeout:                   20 * time.Second,
+		SemanticInactivityTimeout: 100 * time.Millisecond,
+	}, 20*time.Second)
+
+	if result.Status != "completed" {
+		t.Fatalf("expected the retry to complete, got status=%q error=%q", result.Status, result.Error)
+	}
+	if result.Output != "Recovered" {
+		t.Fatalf("expected output from the second attempt, got %q", result.Output)
+	}
+	if result.SessionID != "thr-warm" {
+		t.Fatalf("expected the surviving thread id, got %q", result.SessionID)
+	}
+	// The discarded attempt must not pin the resume pointer to a thread that
+	// never produced a turn.
+	for _, msg := range messages {
+		if msg.SessionID == "thr-cold" {
+			t.Fatalf("discarded attempt leaked a session pin for thr-cold: %+v", msg)
+		}
+	}
+}
+
+// TestCodexExecuteDoesNotRetryFirstTurnNoProgressWithoutCatalogSignal keeps the
+// retry gate narrow: a stalled first turn with no model catalog evidence in
+// stderr is not known to be transient, so it must fail on the first attempt.
+func TestCodexExecuteDoesNotRetryFirstTurnNoProgressWithoutCatalogSignal(t *testing.T) {
+	// Not t.Parallel(): this test mutates codexGracefulShutdownTimeoutNanos.
+	if runtime.GOOS == "windows" {
+		t.Skip("shell-script fixture is POSIX-only")
+	}
+	codexGracefulShutdownTimeoutNanos.Store(int64(100 * time.Millisecond))
+	t.Cleanup(func() { codexGracefulShutdownTimeoutNanos.Store(0) })
+
+	fakePath := writeFakeCodexAppServer(t, ""+
+		`STATE="$(dirname "$0")/attempts"`+"\n"+
+		`ATTEMPT=$(cat "$STATE" 2>/dev/null || echo 0)`+"\n"+
+		`ATTEMPT=$((ATTEMPT+1))`+"\n"+
+		`echo "$ATTEMPT" > "$STATE"`+"\n"+
+		`read line`+"\n"+
+		`echo '{"jsonrpc":"2.0","id":1,"result":{}}'`+"\n"+
+		`read line`+"\n"+
+		`read line`+"\n"+
+		`echo '{"jsonrpc":"2.0","id":2,"result":{"thread":{"id":"thr-quiet"}}}'`+"\n"+
+		`read line`+"\n"+
+		`echo '{"jsonrpc":"2.0","id":3,"result":{}}'`+"\n"+
+		`echo '{"jsonrpc":"2.0","method":"turn/started","params":{"threadId":"thr-quiet","turn":{"id":"turn-quiet"}}}'`+"\n"+
+		`echo 'ERROR something else entirely went wrong' >&2`+"\n"+
+		`sleep 2`+"\n")
+
+	result := executeFakeCodex(t, fakePath, ExecOptions{
+		Timeout:                   5 * time.Second,
+		SemanticInactivityTimeout: 100 * time.Millisecond,
+	})
+	if result.Status != "timeout" {
+		t.Fatalf("expected timeout, got status=%q error=%q", result.Status, result.Error)
+	}
+	attempts, err := os.ReadFile(filepath.Join(filepath.Dir(fakePath), "attempts"))
+	if err != nil {
+		t.Fatalf("read attempt counter: %v", err)
+	}
+	if got := strings.TrimSpace(string(attempts)); got != "1" {
+		t.Fatalf("expected exactly one attempt without the catalog signal, got %q", got)
+	}
+}
+
 func TestCodexExecuteTurnCompletionCanPrecedeTurnStartResponse(t *testing.T) {
 	t.Parallel()
 	if runtime.GOOS == "windows" {
@@ -2888,18 +2996,34 @@ func writeFakeCodexAppServer(t *testing.T, body string) string {
 
 func executeFakeCodex(t *testing.T, fakePath string, opts ExecOptions) Result {
 	t.Helper()
+	result, _ := executeFakeCodexCollectingMessages(t, fakePath, opts, 10*time.Second)
+	return result
+}
+
+// executeFakeCodexCollectingMessages runs the fixture and returns the streamed
+// messages alongside the result. budget bounds both the execution context and
+// the wait, so retry-exercising tests can ask for more than the default.
+func executeFakeCodexCollectingMessages(t *testing.T, fakePath string, opts ExecOptions, budget time.Duration) (Result, []Message) {
+	t.Helper()
 	backend, err := New("codex", Config{ExecutablePath: fakePath, Logger: slog.Default()})
 	if err != nil {
 		t.Fatalf("new codex backend: %v", err)
 	}
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), budget)
 	defer cancel()
 	session, err := backend.Execute(ctx, "prompt", opts)
 	if err != nil {
 		t.Fatalf("execute: %v", err)
 	}
+	var (
+		mu       sync.Mutex
+		messages []Message
+	)
 	go func() {
-		for range session.Messages {
+		for msg := range session.Messages {
+			mu.Lock()
+			messages = append(messages, msg)
+			mu.Unlock()
 		}
 	}()
 	select {
@@ -2907,10 +3031,13 @@ func executeFakeCodex(t *testing.T, fakePath string, opts ExecOptions) Result {
 		if !ok {
 			t.Fatal("result channel closed without a value")
 		}
-		return result
-	case <-time.After(10 * time.Second):
+		mu.Lock()
+		collected := append([]Message(nil), messages...)
+		mu.Unlock()
+		return result, collected
+	case <-time.After(budget):
 		t.Fatal("timeout waiting for result")
-		return Result{}
+		return Result{}, nil
 	}
 }
 


### PR DESCRIPTION
## Summary

Implements **P0** from MUL-5110: a transient Codex model-catalog refresh failure should not become a user-visible task failure.

Codex loads its model catalog on the `thread/start` path. When the task-local cache misses (version change, schema change, or the 300s TTL) it falls back to an online refresh; if that refresh fails, the app-server accepts the turn and then emits no item, message, tool, `turn/completed`, or error event. Multica's first-turn no-progress watchdog fires after 30s and fails the task, leaving the user to press "retry" manually.

This adds one narrow automatic retry for exactly that shape.

## What changed

**Retry gate** (`server/pkg/agent/codex.go`). Retries once only when all hold:
- the first-turn no-progress timeout fired (`codexTimeoutFirstTurnNoProgress`),
- no semantic progress was observed in the turn,
- stderr shows a model catalog refresh failure,
- `cleanupConfirmed && codexInitializeRetrySupported()` — the same process-tree evidence initialize retries require. This is false on Windows, where the daemon cannot prove the whole tree is gone, and it honours `codexCleanupConfirmationOverride`.

Anything that already produced a tool call, tool result, or content is never retried, so a retry cannot duplicate side effects. It reuses the existing two-attempt loop, so the retry stays inside the task timeout and `ctx.Done()` still aborts it. Backoff is 500ms + up to 1s jitter (the catalog refresh crosses the network, unlike the local initialize handshake, which keeps its 75ms).

**Resume isolation.** The stalled attempt already reached `turn/started`, so the prior thread may hold the submitted input or an unfinished turn. A catalog retry therefore clears `ResumeSessionID` and keeps `ResumeExpected`, so it starts a fresh thread and `codexTurnInput` prepends the continuity notice telling the agent the earlier context could not be restored. (Initialize retries are untouched: they fail before any thread exists.)

**Session-pin buffering.** The first attempt emits a `status:running` message carrying its thread ID, which pins the resume pointer. Previously that was forwarded immediately, so a retry would leave the server resuming a thread that never produced a turn. Leading pin messages are now held until an attempt proves it made progress; the first non-pin message flushes them and streaming continues normally. A discarded attempt's pin is dropped. Content is never delayed — only the leading `status:running` pin is buffered, and only until the first non-pin message.

**Broader stderr signal.** `codexModelCatalogRefreshTimeoutSignal` matched only `failed to refresh available models: timeout waiting for child process to exit`. On the reporting machine's Codex logs, that variant is 71 of 127 occurrences; the other 56 are `stream disconnected before completion`. The constant is now the shared `failed to refresh available models` prefix, so both the diagnosis hint and the retry gate cover all causes.

**Diagnosis text.** Dropped the "set an explicit model, switch Codex CLI versions" advice — neither avoids the catalog load on `thread/start`, and a version switch actively causes a fresh cache miss. It now points at network/proxy connectivity or switching runtime.

## Testing

`go test ./pkg/agent/`, `go test -race ./pkg/agent/ -run Codex`, and `go test ./internal/daemon/...` pass. `gofmt` and `go vet` clean.

Tests, each verified to fail against the un-fixed code rather than just passing:
- `TestCodexExecuteRetriesAfterModelCatalogRefreshFailure` — stalls with the catalog error on attempt 1, completes on a different thread on attempt 2; asserts the run completes, output and `SessionID` come from the second attempt, and no message leaked the discarded thread's pin. Fails without the buffering fix (`discarded attempt leaked a session pin for thr-cold`).
- `TestCodexExecuteRetryAfterCatalogFailureStartsFreshThreadForResume` — fixture logs the JSON-RPC it receives; asserts attempt 1 used `thread/resume`, attempt 2 used `thread/start` on a fresh thread, and the retry input carries the continuity notice. Fails if `ResumeSessionID` is not cleared.
- `TestCodexExecuteDoesNotRetryCatalogFailureWhenCleanupUnconfirmed` — with `codexCleanupConfirmationOverride`, asserts exactly one attempt. Fails if the gate is reverted to `cmd.ProcessState != nil`.
- `TestCodexExecuteDoesNotRetryCatalogFailureAfterSemanticProgress` — a turn that ran a tool must not be replayed even with the catalog signal present.
- `TestCodexExecuteDoesNotRetryFirstTurnNoProgressWithoutCatalogSignal` — a stall without the catalog signal fails on attempt 1.
- `TestCodexExecuteFirstTurnNoProgressSurfacesDiagnostics` now exercises the exhausted-retry path and asserts the updated diagnosis text.

Pre-existing unrelated failure on this branch and on a clean tree: `TestGrokRealACPSmoke`.

## Deliberate deviations from the proposal

- **The invalid `models_cache.json` is not deleted before retrying.** The proposal called for discarding it. I could not establish whether Codex falls back to an expired-but-parseable cache when a refresh fails; if it does, deleting would remove a working fallback and make the retry *more* likely to need the network. The retry alone addresses the transient failure, so this stays out of a P0 hotfix.
- **No feature flag.** The gate is narrow enough that the flag would be dead config; the behavior change is one extra attempt on a shape that is currently a guaranteed failure.

## Scope

P0 only. It does not stop Codex from needing the network — the 300s TTL means any task home idle longer than 5 minutes still refreshes online, and the app-server also refreshes in the background. P1 (version/provider-aware daemon cache pool) is unaddressed and, per the thread, is an optimization rather than a correctness fix on a stable network.
