### PR TITLE
MUL-5127: show issue agent activity in Inbox

### DIFF
--- a/packages/views/inbox/components/inbox-list-item.test.tsx
+++ b/packages/views/inbox/components/inbox-list-item.test.tsx
@@ -4,7 +4,24 @@ import type { InboxItem } from "@multica/core/types";
 import { InboxListItem } from "./inbox-list-item";
 
 vi.mock("../../issues/components", () => ({ StatusIcon: () => null }));
-vi.mock("../../common/actor-avatar", () => ({ ActorAvatar: () => null }));
+vi.mock("../../common/actor-avatar", () => ({
+  ActorAvatar: ({
+    actorType,
+    actorId,
+    showStatusDot,
+  }: {
+    actorType: string;
+    actorId: string;
+    showStatusDot?: boolean;
+  }) => (
+    <span
+      data-testid="actor-avatar"
+      data-actor-type={actorType}
+      data-actor-id={actorId}
+      data-show-status-dot={showStatusDot === true ? "true" : "false"}
+    />
+  ),
+}));
 vi.mock("./inbox-detail-label", () => ({ InboxDetailLabel: () => null }));
 vi.mock("../../i18n", () => ({ useT: () => ({ t: () => "label" }) }));
 
@@ -70,5 +87,26 @@ describe("InboxListItem unread affordance", () => {
 
     expect(unreadDot(container)).toBeNull();
     expect(title(container)?.className).not.toContain("font-medium");
+  });
+});
+
+describe("InboxListItem agent presence", () => {
+  it("shows the agent status indicator on the row avatar", () => {
+    const { getByTestId } = renderRow({ item: item(), view: "inbox" });
+
+    expect(getByTestId("actor-avatar").getAttribute("data-show-status-dot")).toBe(
+      "true",
+    );
+  });
+
+  it("leaves member avatars without an agent status indicator", () => {
+    const { getByTestId } = renderRow({
+      item: item({ actor_type: "member", actor_id: "member-2" }),
+      view: "inbox",
+    });
+
+    expect(getByTestId("actor-avatar").getAttribute("data-show-status-dot")).toBe(
+      "false",
+    );
   });
 });

--- a/packages/views/inbox/components/inbox-list-item.test.tsx
+++ b/packages/views/inbox/components/inbox-list-item.test.tsx
@@ -4,6 +4,11 @@ import type { InboxItem } from "@multica/core/types";
 import { InboxListItem } from "./inbox-list-item";
 
 vi.mock("../../issues/components", () => ({ StatusIcon: () => null }));
+vi.mock("../../issues/components/issue-agent-activity-indicator", () => ({
+  IssueAgentActivityIndicator: ({ issueId }: { issueId: string }) => (
+    <span data-testid="issue-agent-activity" data-issue-id={issueId} />
+  ),
+}));
 vi.mock("../../common/actor-avatar", () => ({
   ActorAvatar: ({
     actorType,
@@ -90,23 +95,24 @@ describe("InboxListItem unread affordance", () => {
   });
 });
 
-describe("InboxListItem agent presence", () => {
-  it("shows the agent status indicator on the row avatar", () => {
+describe("InboxListItem issue activity", () => {
+  it("shows issue-specific agent activity without an availability dot", () => {
     const { getByTestId } = renderRow({ item: item(), view: "inbox" });
-
-    expect(getByTestId("actor-avatar").getAttribute("data-show-status-dot")).toBe(
-      "true",
-    );
-  });
-
-  it("leaves member avatars without an agent status indicator", () => {
-    const { getByTestId } = renderRow({
-      item: item({ actor_type: "member", actor_id: "member-2" }),
-      view: "inbox",
-    });
 
     expect(getByTestId("actor-avatar").getAttribute("data-show-status-dot")).toBe(
       "false",
     );
+    expect(
+      getByTestId("issue-agent-activity").getAttribute("data-issue-id"),
+    ).toBe("issue-1");
+  });
+
+  it("omits issue activity for a notification without an issue", () => {
+    const { queryByTestId } = renderRow({
+      item: item({ issue_id: null }),
+      view: "inbox",
+    });
+
+    expect(queryByTestId("issue-agent-activity")).toBeNull();
   });
 });

--- a/packages/views/inbox/components/inbox-list-item.tsx
+++ b/packages/views/inbox/components/inbox-list-item.tsx
@@ -53,6 +53,7 @@ export function InboxListItem({
   const actionLabel = isArchivedView
     ? t(($) => $.list.unarchive_tooltip)
     : t(($) => $.list.archive_tooltip);
+  const actorType = item.actor_type ?? item.recipient_type;
 
   return (
     <button
@@ -63,10 +64,11 @@ export function InboxListItem({
       }`}
     >
       <ActorAvatar
-        actorType={item.actor_type ?? item.recipient_type}
+        actorType={actorType}
         actorId={item.actor_id ?? item.recipient_id}
         size="lg"
         enableHoverCard
+        showStatusDot={actorType === "agent"}
       />
       <div className="min-w-0 flex-1">
         <div className="flex items-center justify-between gap-2">

--- a/packages/views/inbox/components/inbox-list-item.tsx
+++ b/packages/views/inbox/components/inbox-list-item.tsx
@@ -1,6 +1,9 @@
 "use client";
 
 import { StatusIcon } from "../../issues/components";
+import {
+  IssueAgentActivityIndicator,
+} from "../../issues/components/issue-agent-activity-indicator";
 import { ActorAvatar } from "../../common/actor-avatar";
 import { Archive, ArchiveRestore } from "lucide-react";
 import type { InboxItem } from "@multica/core/types";
@@ -68,7 +71,6 @@ export function InboxListItem({
         actorId={item.actor_id ?? item.recipient_id}
         size="lg"
         enableHoverCard
-        showStatusDot={actorType === "agent"}
       />
       <div className="min-w-0 flex-1">
         <div className="flex items-center justify-between gap-2">
@@ -111,9 +113,14 @@ export function InboxListItem({
           <p className={`min-w-0 overflow-hidden text-ellipsis whitespace-nowrap text-xs ${showUnread ? "text-muted-foreground" : "text-muted-foreground/60"}`}>
             <InboxDetailLabel item={item} />
           </p>
-          <span className={`shrink-0 text-xs ${showUnread ? "text-muted-foreground" : "text-muted-foreground/60"}`}>
-            {timeAgo(item.created_at)}
-          </span>
+          <div className="flex shrink-0 items-center gap-1.5">
+            {item.issue_id && (
+              <IssueAgentActivityIndicator issueId={item.issue_id} />
+            )}
+            <span className={`text-xs ${showUnread ? "text-muted-foreground" : "text-muted-foreground/60"}`}>
+              {timeAgo(item.created_at)}
+            </span>
+          </div>
         </div>
       </div>
     </button>


### PR DESCRIPTION
## Summary

- replace the Inbox avatar availability dot with the existing issue-scoped agent activity indicator
- show `Working` for running tasks, `Queued` for queued/dispatched tasks, and no indicator when the issue has no active agent task
- keep the issue title prominent by placing activity beside the notification timestamp
- add regression coverage for linked and non-issue Inbox items

## Why

The requested state is whether an agent is actively working on this specific issue, not whether that agent's runtime is online or offline. Reusing `IssueAgentActivityIndicator` keeps Inbox aligned with the Issues surfaces and their shared task snapshot.

## Validation

- `pnpm exec vitest run inbox/components/inbox-list-item.test.tsx --reporter=verbose` — 5 passed
- `pnpm --filter @multica/views typecheck` — passed
- `pnpm --filter @multica/views lint -- inbox/components/inbox-list-item.tsx inbox/components/inbox-list-item.test.tsx` — passed with 0 errors (19 existing package warnings)
- local Web visual check with one running issue and one idle issue — only the running issue shows `Working`; neither Inbox avatar shows an availability dot

Closes MUL-5127
