### PR TITLE
MUL-5215: fix(agents): keep creation errors visible

### DIFF
--- a/packages/views/agents/components/agent-creation-studio.test.ts
+++ b/packages/views/agents/components/agent-creation-studio.test.ts
@@ -1,9 +1,13 @@
 import { createElement } from "react";
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
+import { ApiError } from "@multica/core/api";
 import {
+  AgentNameField,
   ModeChooser,
+  StudioFooter,
   buildInvocationTargets,
+  classifyAgentCreateError,
   decodeBuilderInput,
   deriveDuplicateAccess,
   encodeBuilderInput,
@@ -29,6 +33,13 @@ vi.mock("../../i18n", () => ({
             blank: { title: string; description: string };
             ai: { title: string; description: string };
           };
+          create_and_open: string;
+          create_and_add: string;
+          creating: string;
+        };
+        create_dialog: {
+          name_label: string;
+          name_placeholder: string;
         };
       }) => string,
     ) =>
@@ -49,6 +60,13 @@ vi.mock("../../i18n", () => ({
               description: "Describe the outcome you want.",
             },
           },
+          create_and_open: "Create and open",
+          create_and_add: "Create and add",
+          creating: "Creating…",
+        },
+        create_dialog: {
+          name_label: "Name",
+          name_placeholder: "Agent name",
         },
       }),
   }),
@@ -60,6 +78,98 @@ describe("Agent creation studio screen keys", () => {
     expect(getAgentCreationScreenKey("template", "")).toBe("configure");
     expect(getAgentCreationScreenKey("ai", "")).toBe("ai-setup");
     expect(getAgentCreationScreenKey("ai", "session-1")).toBe("ai-builder");
+  });
+});
+
+describe("Agent creation errors", () => {
+  it("classifies a conflict as a name error", () => {
+    expect(
+      classifyAgentCreateError(
+        new ApiError("An agent with this name already exists", 409, "Conflict"),
+        "Could not create the agent.",
+      ),
+    ).toEqual({
+      nameError: "An agent with this name already exists",
+      formError: null,
+    });
+  });
+
+  it("classifies a network error as a form error", () => {
+    expect(
+      classifyAgentCreateError(
+        new Error("Network request failed"),
+        "Could not create the agent.",
+      ),
+    ).toEqual({
+      nameError: null,
+      formError: "Network request failed",
+    });
+  });
+
+  it("renders a name error directly below the name input", () => {
+    const onChange = vi.fn();
+    render(
+      createElement(AgentNameField, {
+        name: "Existing agent",
+        error: "An agent with this name already exists",
+        onChange,
+      }),
+    );
+
+    const input = screen.getByRole("textbox", { name: "Name" });
+    const error = screen.getByRole("alert");
+    expect(input).toHaveAttribute("aria-invalid", "true");
+    expect(input).toHaveAttribute("aria-describedby", error.id);
+    expect(
+      input.compareDocumentPosition(error) & Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
+
+    fireEvent.change(input, { target: { value: "New agent" } });
+    expect(onChange).toHaveBeenCalledWith("New agent");
+  });
+
+  it("focuses the name input when a name error appears", () => {
+    const onChange = vi.fn();
+    const view = render(
+      createElement(AgentNameField, {
+        name: "Existing agent",
+        error: null,
+        onChange,
+      }),
+    );
+
+    const input = screen.getByRole("textbox", { name: "Name" });
+    expect(input).not.toHaveFocus();
+
+    view.rerender(
+      createElement(AgentNameField, {
+        name: "Existing agent",
+        error: "An agent with this name already exists",
+        onChange,
+      }),
+    );
+
+    expect(input).toHaveFocus();
+  });
+
+  it("renders a generic error on the left side of the sticky footer", () => {
+    render(
+      createElement(StudioFooter, {
+        canCreate: true,
+        creating: false,
+        squad: false,
+        error: "Network request failed",
+        onCreate: vi.fn(),
+      }),
+    );
+
+    const error = screen.getByRole("alert");
+    const button = screen.getByRole("button", { name: "Create and open" });
+    expect(error.parentElement).toBe(button.parentElement);
+    expect(
+      error.compareDocumentPosition(button) & Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
+    expect(error.parentElement).toHaveClass("sticky", "justify-between");
   });
 });
 

--- a/packages/views/agents/components/agent-creation-studio.test.ts
+++ b/packages/views/agents/components/agent-creation-studio.test.ts
@@ -36,6 +36,7 @@ vi.mock("../../i18n", () => ({
           create_and_open: string;
           create_and_add: string;
           creating: string;
+          name_conflict: string;
         };
         create_dialog: {
           name_label: string;
@@ -63,6 +64,7 @@ vi.mock("../../i18n", () => ({
           create_and_open: "Create and open",
           create_and_add: "Create and add",
           creating: "Creating…",
+          name_conflict: "An agent with this name already exists.",
         },
         create_dialog: {
           name_label: "Name",
@@ -87,9 +89,10 @@ describe("Agent creation errors", () => {
       classifyAgentCreateError(
         new ApiError("An agent with this name already exists", 409, "Conflict"),
         "Could not create the agent.",
+        "This localized name is already in use.",
       ),
     ).toEqual({
-      nameError: "An agent with this name already exists",
+      nameError: "This localized name is already in use.",
       formError: null,
     });
   });
@@ -99,6 +102,7 @@ describe("Agent creation errors", () => {
       classifyAgentCreateError(
         new Error("Network request failed"),
         "Could not create the agent.",
+        "An agent with this name already exists.",
       ),
     ).toEqual({
       nameError: null,
@@ -117,9 +121,10 @@ describe("Agent creation errors", () => {
     );
 
     const input = screen.getByRole("textbox", { name: "Name" });
-    const error = screen.getByRole("alert");
+    const error = screen.getByText("An agent with this name already exists");
     expect(input).toHaveAttribute("aria-invalid", "true");
     expect(input).toHaveAttribute("aria-describedby", error.id);
+    expect(error).not.toHaveAttribute("role");
     expect(
       input.compareDocumentPosition(error) & Node.DOCUMENT_POSITION_FOLLOWING,
     ).toBeTruthy();
@@ -128,7 +133,7 @@ describe("Agent creation errors", () => {
     expect(onChange).toHaveBeenCalledWith("New agent");
   });
 
-  it("focuses the name input when a name error appears", () => {
+  it("focuses and selects the name input when a name error appears", () => {
     const onChange = vi.fn();
     const view = render(
       createElement(AgentNameField, {
@@ -150,6 +155,9 @@ describe("Agent creation errors", () => {
     );
 
     expect(input).toHaveFocus();
+    expect(input).toHaveValue("Existing agent");
+    expect(input).toHaveProperty("selectionStart", 0);
+    expect(input).toHaveProperty("selectionEnd", "Existing agent".length);
   });
 
   it("renders a generic error on the left side of the sticky footer", () => {
@@ -169,7 +177,6 @@ describe("Agent creation errors", () => {
     expect(
       error.compareDocumentPosition(button) & Node.DOCUMENT_POSITION_FOLLOWING,
     ).toBeTruthy();
-    expect(error.parentElement).toHaveClass("sticky", "justify-between");
   });
 });
 

--- a/packages/views/agents/components/agent-creation-studio.tsx
+++ b/packages/views/agents/components/agent-creation-studio.tsx
@@ -126,11 +126,12 @@ export interface AgentCreateErrors {
 export function classifyAgentCreateError(
   error: unknown,
   fallbackMessage: string,
+  conflictMessage: string,
 ): AgentCreateErrors {
   const message =
     error instanceof Error && error.message ? error.message : fallbackMessage;
   return error instanceof ApiError && error.status === 409
-    ? { nameError: message, formError: null }
+    ? { nameError: conflictMessage, formError: null }
     : { nameError: null, formError: message };
 }
 
@@ -741,6 +742,7 @@ export function AgentCreationStudio() {
       const nextErrors = classifyAgentCreateError(
         error,
         t(($) => $.creation_studio.create_failed),
+        t(($) => $.creation_studio.name_conflict),
       );
       setNameError(nextErrors.nameError);
       setFormError(nextErrors.formError);
@@ -780,6 +782,11 @@ export function AgentCreationStudio() {
         ease: UI_EASE_OUT,
       },
     }),
+  };
+
+  const updateAgentName = (name: string) => {
+    setNameError(null);
+    setDraft((current) => ({ ...current, name }));
   };
 
   return (
@@ -865,7 +872,7 @@ export function AgentCreationStudio() {
               members={members}
               currentUserId={currentUser?.id ?? null}
               nameError={nameError}
-              onNameEdited={() => setNameError(null)}
+              onNameChange={updateAgentName}
             />
           </div>
           <StudioFooter
@@ -933,7 +940,7 @@ export function AgentCreationStudio() {
                 members={members}
                 currentUserId={currentUser?.id ?? null}
                 nameError={nameError}
-                onNameEdited={() => setNameError(null)}
+                onNameChange={updateAgentName}
                 onRuntimeSelect={(runtimeId) => {
                   void switchBuilderRuntime(runtimeId);
                 }}
@@ -1132,7 +1139,7 @@ function ConfigurationPanel({
   members,
   currentUserId,
   nameError,
-  onNameEdited,
+  onNameChange,
   compact = false,
   onRuntimeSelect,
   runtimeSwitchPending = false,
@@ -1145,7 +1152,7 @@ function ConfigurationPanel({
   members: MemberWithUser[];
   currentUserId: string | null;
   nameError: string | null;
-  onNameEdited: () => void;
+  onNameChange: (name: string) => void;
   compact?: boolean;
   /** Builder sessions rebind the server-side carrier instead of only editing
    *  the draft. Absent for the plain create flows, where the draft is the only
@@ -1198,10 +1205,7 @@ function ConfigurationPanel({
             compact={compact}
             name={draft.name}
             error={nameError}
-            onChange={(name) => {
-              onNameEdited();
-              set("name", name);
-            }}
+            onChange={onNameChange}
           />
           <DraftFieldRow
             compact={compact}
@@ -1398,7 +1402,9 @@ export function AgentNameField({
   const inputRef = useRef<HTMLInputElement>(null);
 
   useEffect(() => {
-    if (error) inputRef.current?.focus();
+    if (!error) return;
+    inputRef.current?.focus();
+    inputRef.current?.select();
   }, [error]);
 
   return (
@@ -1421,7 +1427,7 @@ export function AgentNameField({
           placeholder={t(($) => $.create_dialog.name_placeholder)}
         />
         {error ? (
-          <p id={errorId} role="alert" className="text-xs text-destructive">
+          <p id={errorId} className="text-xs text-destructive">
             {error}
           </p>
         ) : null}

--- a/packages/views/agents/components/agent-creation-studio.tsx
+++ b/packages/views/agents/components/agent-creation-studio.tsx
@@ -14,7 +14,7 @@ import {
   Search,
 } from "lucide-react";
 import { toast } from "sonner";
-import { api } from "@multica/core/api";
+import { api, ApiError } from "@multica/core/api";
 import { useAuthStore } from "@multica/core/auth";
 import {
   agentTemplateDetailOptions,
@@ -118,6 +118,22 @@ export interface BuilderDraftPayload {
   member_ids?: unknown;
 }
 
+export interface AgentCreateErrors {
+  nameError: string | null;
+  formError: string | null;
+}
+
+export function classifyAgentCreateError(
+  error: unknown,
+  fallbackMessage: string,
+): AgentCreateErrors {
+  const message =
+    error instanceof Error && error.message ? error.message : fallbackMessage;
+  return error instanceof ApiError && error.status === 409
+    ? { nameError: message, formError: null }
+    : { nameError: null, formError: message };
+}
+
 const BUILDER_INPUT_PREFIX = "MULTICA_AGENT_BUILDER_INPUT\n";
 const EMPTY_CHAT_MESSAGES: ChatMessage[] = [];
 const EMPTY_DRAFT: AgentDraft = {
@@ -165,7 +181,8 @@ export function AgentCreationStudio() {
   const [selectedTemplate, setSelectedTemplate] = useState<AgentTemplateSummary | null>(null);
   const [templateSearch, setTemplateSearch] = useState("");
   const [creating, setCreating] = useState(false);
-  const [createError, setCreateError] = useState<string | null>(null);
+  const [nameError, setNameError] = useState<string | null>(null);
+  const [formError, setFormError] = useState<string | null>(null);
   const [builderSessionId, setBuilderSessionId] = useState("");
   const [builderStarting, setBuilderStarting] = useState(false);
   const [builderClosing, setBuilderClosing] = useState(false);
@@ -418,6 +435,8 @@ export function AgentCreationStudio() {
     setSelectedTemplate(null);
     setSourceTemplate(null);
     setBuilderSessionId("");
+    setNameError(null);
+    setFormError(null);
   };
 
   const deleteBuilderSession = async () => {
@@ -638,7 +657,8 @@ export function AgentCreationStudio() {
   const createAgent = async () => {
     if (!canCreate || !selectedRuntime) return;
     setCreating(true);
-    setCreateError(null);
+    setNameError(null);
+    setFormError(null);
     try {
       const invocationTargets = buildInvocationTargets(draft);
       let agent: Agent;
@@ -718,9 +738,12 @@ export function AgentCreationStudio() {
       toast.success(t(($) => $.creation_studio.created, { name: agent.name || draft.name.trim() }));
       navigation.push(squadId ? paths.squadDetail(squadId) : paths.agentDetail(agent.id));
     } catch (error) {
-      setCreateError(
-        error instanceof Error ? error.message : t(($) => $.creation_studio.create_failed),
+      const nextErrors = classifyAgentCreateError(
+        error,
+        t(($) => $.creation_studio.create_failed),
       );
+      setNameError(nextErrors.nameError);
+      setFormError(nextErrors.formError);
       setCreating(false);
     }
   };
@@ -841,13 +864,15 @@ export function AgentCreationStudio() {
               runtimesLoading={runtimesLoading}
               members={members}
               currentUserId={currentUser?.id ?? null}
-              createError={createError}
+              nameError={nameError}
+              onNameEdited={() => setNameError(null)}
             />
           </div>
           <StudioFooter
             canCreate={canCreate}
             creating={creating}
             squad={!!squadId}
+            error={formError}
             onCreate={createAgent}
           />
         </div>
@@ -907,7 +932,8 @@ export function AgentCreationStudio() {
                 runtimesLoading={runtimesLoading}
                 members={members}
                 currentUserId={currentUser?.id ?? null}
-                createError={createError}
+                nameError={nameError}
+                onNameEdited={() => setNameError(null)}
                 onRuntimeSelect={(runtimeId) => {
                   void switchBuilderRuntime(runtimeId);
                 }}
@@ -919,6 +945,7 @@ export function AgentCreationStudio() {
               canCreate={canCreate && !builderPending}
               creating={creating}
               squad={!!squadId}
+              error={formError}
               onCreate={createAgent}
             />
           </div>
@@ -1104,7 +1131,8 @@ function ConfigurationPanel({
   runtimesLoading,
   members,
   currentUserId,
-  createError,
+  nameError,
+  onNameEdited,
   compact = false,
   onRuntimeSelect,
   runtimeSwitchPending = false,
@@ -1116,7 +1144,8 @@ function ConfigurationPanel({
   runtimesLoading: boolean;
   members: MemberWithUser[];
   currentUserId: string | null;
-  createError: string | null;
+  nameError: string | null;
+  onNameEdited: () => void;
   compact?: boolean;
   /** Builder sessions rebind the server-side carrier instead of only editing
    *  the draft. Absent for the plain create flows, where the draft is the only
@@ -1165,21 +1194,15 @@ function ConfigurationPanel({
               />
             </div>
           </DraftFieldRow>
-          <DraftFieldRow
+          <AgentNameField
             compact={compact}
-            label={t(($) => $.create_dialog.name_label)}
-            htmlFor="agent-create-name"
-          >
-            <Input
-              id="agent-create-name"
-              name="agent-name"
-              autoComplete="off"
-              aria-label={t(($) => $.create_dialog.name_label)}
-              value={draft.name}
-              onChange={(event) => set("name", event.target.value)}
-              placeholder={t(($) => $.create_dialog.name_placeholder)}
-            />
-          </DraftFieldRow>
+            name={draft.name}
+            error={nameError}
+            onChange={(name) => {
+              onNameEdited();
+              set("name", name);
+            }}
+          />
           <DraftFieldRow
             compact={compact}
             align="start"
@@ -1355,17 +1378,55 @@ function ConfigurationPanel({
           ) : null}
         </SettingsCard>
       </SettingsSection>
-
-      {createError ? (
-        <div
-          role="alert"
-          aria-live="polite"
-          className="rounded-lg border border-destructive/30 bg-destructive/5 px-4 py-3 text-sm text-destructive"
-        >
-          {createError}
-        </div>
-      ) : null}
     </div>
+  );
+}
+
+export function AgentNameField({
+  name,
+  error,
+  onChange,
+  compact = false,
+}: {
+  name: string;
+  error: string | null;
+  onChange: (name: string) => void;
+  compact?: boolean;
+}) {
+  const { t } = useT("agents");
+  const errorId = "agent-create-name-error";
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    if (error) inputRef.current?.focus();
+  }, [error]);
+
+  return (
+    <DraftFieldRow
+      compact={compact}
+      label={t(($) => $.create_dialog.name_label)}
+      htmlFor="agent-create-name"
+    >
+      <div className="space-y-1.5">
+        <Input
+          ref={inputRef}
+          id="agent-create-name"
+          name="agent-name"
+          autoComplete="off"
+          aria-label={t(($) => $.create_dialog.name_label)}
+          aria-invalid={!!error}
+          aria-describedby={error ? errorId : undefined}
+          value={name}
+          onChange={(event) => onChange(event.target.value)}
+          placeholder={t(($) => $.create_dialog.name_placeholder)}
+        />
+        {error ? (
+          <p id={errorId} role="alert" className="text-xs text-destructive">
+            {error}
+          </p>
+        ) : null}
+      </div>
+    </DraftFieldRow>
   );
 }
 
@@ -1526,7 +1587,46 @@ function BuilderConversation({
   );
 }
 
-function StudioFooter({ canCreate, creating, squad, onCreate }: { canCreate: boolean; creating: boolean; squad: boolean; onCreate: () => void; }) { const { t } = useT("agents"); return <div className="sticky bottom-0 mt-8 flex items-center justify-end gap-3 border-t bg-background/95 px-5 py-3 backdrop-blur"><Button type="button" onClick={onCreate} disabled={!canCreate}>{creating && <Loader2 className="size-4 animate-spin" />}{creating ? t(($) => $.creation_studio.creating) : squad ? t(($) => $.creation_studio.create_and_add) : t(($) => $.creation_studio.create_and_open)}</Button></div>; }
+export function StudioFooter({
+  canCreate,
+  creating,
+  squad,
+  error,
+  onCreate,
+}: {
+  canCreate: boolean;
+  creating: boolean;
+  squad: boolean;
+  error: string | null;
+  onCreate: () => void;
+}) {
+  const { t } = useT("agents");
+  return (
+    <div className="sticky bottom-0 mt-8 flex items-center justify-between gap-3 border-t bg-background/95 px-5 py-3 backdrop-blur">
+      {error ? (
+        <p
+          role="alert"
+          className="min-w-0 flex-1 break-words text-sm text-destructive"
+        >
+          {error}
+        </p>
+      ) : null}
+      <Button
+        type="button"
+        className="ml-auto shrink-0"
+        onClick={onCreate}
+        disabled={!canCreate}
+      >
+        {creating && <Loader2 className="size-4 animate-spin" />}
+        {creating
+          ? t(($) => $.creation_studio.creating)
+          : squad
+            ? t(($) => $.creation_studio.create_and_add)
+            : t(($) => $.creation_studio.create_and_open)}
+      </Button>
+    </div>
+  );
+}
 export function buildInvocationTargets(
   draft: AgentDraft,
 ): AgentInvocationTargetInput[] {

--- a/packages/views/locales/en/agents.json
+++ b/packages/views/locales/en/agents.json
@@ -365,6 +365,7 @@
     "create_and_add": "Create & add to squad",
     "creating": "Creating agent…",
     "create_failed": "Could not create the agent.",
+    "name_conflict": "An agent with this name already exists.",
     "created": "{{name}} was created"
   },
   "create_dialog": {

--- a/packages/views/locales/ja/agents.json
+++ b/packages/views/locales/ja/agents.json
@@ -793,6 +793,7 @@
     "create_and_add": "作成してスクワッドに追加",
     "creating": "エージェントを作成中…",
     "create_failed": "エージェントを作成できませんでした。",
+    "name_conflict": "同じ名前のエージェントがすでに存在します。",
     "created": "{{name}} を作成しました"
   },
   "actions": {

--- a/packages/views/locales/ko/agents.json
+++ b/packages/views/locales/ko/agents.json
@@ -793,6 +793,7 @@
     "create_and_add": "만들고 스쿼드에 추가",
     "creating": "에이전트 만드는 중…",
     "create_failed": "에이전트를 만들지 못했습니다.",
+    "name_conflict": "같은 이름의 에이전트가 이미 있습니다.",
     "created": "{{name}}을(를) 만들었습니다"
   },
   "actions": {

--- a/packages/views/locales/zh-Hans/agents.json
+++ b/packages/views/locales/zh-Hans/agents.json
@@ -356,6 +356,7 @@
     "create_and_add": "创建并加入小队",
     "creating": "正在创建…",
     "create_failed": "无法创建智能体。",
+    "name_conflict": "工作区中已存在同名智能体。",
     "created": "已创建 {{name}}"
   },
   "create_dialog": {


### PR DESCRIPTION
## Problem

Agent creation failures need to remain visible and appear near the action the user can take. The previous page-bottom alert could be outside the viewport, while a toast is temporary and loses the form context.

## Changes

- Show HTTP 409 name conflicts directly below the Name input.
- Mark the Name input invalid, connect it to the error with `aria-describedby`, and focus it when the error appears so the field is brought into view.
- Show network, server, and unknown failures persistently on the left side of the sticky submit footer, with the submit button remaining on the right.
- Clear both errors when retrying, and clear the name error when the user edits the name.
- Apply the behavior to blank, template, and Build-with-AI agent creation flows.

## Verification

- `@multica/views` tests: 250 files / 2838 tests passed.
- `@multica/views` TypeScript check passed.
- ESLint passed for the changed source and test files.
