### PR TITLE
fix(skills): tree-first skill import to stop 504 on large repos (MUL-5136)

### DIFF
--- a/server/internal/daemon/local_skills.go
+++ b/server/internal/daemon/local_skills.go
@@ -14,7 +14,10 @@ import (
 const (
 	maxLocalSkillFileSize   int64 = 1 << 20
 	maxLocalSkillBundleSize int64 = 8 << 20
-	maxLocalSkillFileCount        = 128
+	// Kept in lockstep with the server-side importer's maxImportFileCount so a
+	// skill that imports from a URL/archive also imports from a runtime-local
+	// directory. The 8 MiB bundle cap is the real guard on skill size.
+	maxLocalSkillFileCount = 256
 	// Cap how deep skill discovery descends below a runtime root. opencode
 	// stores skills two levels deep (e.g. `release/reporter/SKILL.md`); a
 	// few extra levels covers any realistic future layout while bounding

--- a/server/internal/handler/agent_template.go
+++ b/server/internal/handler/agent_template.go
@@ -1,6 +1,7 @@
 package handler
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -283,11 +284,13 @@ func (h *Handler) CreateAgentFromTemplate(w http.ResponseWriter, r *http.Request
 	// Fetch only the skills that aren't already in the workspace. fetched[j]
 	// corresponds to toFetchRefs[j], whose original index is toFetchOrigIdx[j].
 	httpClient := &http.Client{Timeout: 30 * time.Second}
+	fetchCtx, cancelFetch := context.WithTimeout(r.Context(), importFetchTimeout)
+	defer cancelFetch()
 	fetchStart := time.Now()
 	var fetched []*importedSkill
 	var failedURLs []string
 	if len(toFetchRefs) > 0 {
-		fetched, failedURLs = fetchTemplateSkillsParallel(httpClient, toFetchRefs)
+		fetched, failedURLs = fetchTemplateSkillsParallel(fetchCtx, httpClient, toFetchRefs)
 	}
 	slog.Info("agent-template create: fetch phase done",
 		append(logger.RequestAttrs(r),
@@ -645,7 +648,7 @@ type templateFetchResult struct {
 // importedSkill, in parallel. Returns the imports in input order; failed_urls
 // is non-nil iff any fetch failed. Logs per-URL timing so we can spot which
 // upstream is the long pole in a slow request.
-func fetchTemplateSkillsParallel(client *http.Client, refs []agenttmpl.TemplateSkillRef) ([]*importedSkill, []string) {
+func fetchTemplateSkillsParallel(ctx context.Context, client *http.Client, refs []agenttmpl.TemplateSkillRef) ([]*importedSkill, []string) {
 	results := make(chan templateFetchResult, len(refs))
 	var wg sync.WaitGroup
 	for i, ref := range refs {
@@ -654,7 +657,7 @@ func fetchTemplateSkillsParallel(client *http.Client, refs []agenttmpl.TemplateS
 			defer wg.Done()
 			start := time.Now()
 			slog.Info("agent-template fetch: start", "index", i, "source_url", ref.SourceURL)
-			imp, err := fetchSkillFromURL(client, ref.SourceURL)
+			imp, err := fetchSkillFromURL(ctx, client, ref.SourceURL)
 			elapsedMs := time.Since(start).Milliseconds()
 			if err != nil {
 				slog.Warn("agent-template fetch: failed",
@@ -699,18 +702,18 @@ func fetchTemplateSkillsParallel(client *http.Client, refs []agenttmpl.TemplateS
 // fetchSkillFromURL dispatches to the right upstream fetcher based on URL.
 // Mirrors the switch inside ImportSkill (skill.go:1566) so both entry points
 // stay in sync.
-func fetchSkillFromURL(client *http.Client, rawURL string) (*importedSkill, error) {
+func fetchSkillFromURL(ctx context.Context, client *http.Client, rawURL string) (*importedSkill, error) {
 	source, normalized, err := detectImportSource(rawURL)
 	if err != nil {
 		return nil, err
 	}
 	switch source {
 	case sourceClawHub:
-		return fetchFromClawHub(client, normalized)
+		return fetchFromClawHub(ctx, client, normalized)
 	case sourceSkillsSh:
-		return fetchFromSkillsSh(client, normalized)
+		return fetchFromSkillsSh(ctx, client, normalized)
 	case sourceGitHub:
-		return fetchFromGitHub(client, normalized)
+		return fetchFromGitHub(ctx, client, normalized)
 	}
 	return nil, fmt.Errorf("unknown import source for %s", rawURL)
 }

--- a/server/internal/handler/skill.go
+++ b/server/internal/handler/skill.go
@@ -11,6 +11,7 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 	"time"
 
@@ -20,6 +21,7 @@ import (
 	skillpkg "github.com/multica-ai/multica/server/internal/skill"
 	db "github.com/multica-ai/multica/server/pkg/db/generated"
 	"github.com/multica-ai/multica/server/pkg/protocol"
+	"golang.org/x/sync/errgroup"
 )
 
 // sanitizeNullBytes makes a string safe for a PostgreSQL TEXT column.
@@ -598,7 +600,7 @@ func validImportOnConflict(strategy string) bool {
 const (
 	maxImportFileSize  = 1 << 20 // 1 MiB per file
 	maxImportTotalSize = 8 << 20 // 8 MiB per import bundle (sum of supporting files)
-	maxImportFileCount = 128     // max number of supporting files
+	maxImportFileCount = 256     // max number of supporting files
 )
 
 // importedSkill holds the data extracted from an external source.
@@ -753,14 +755,15 @@ type githubTreeResponse struct {
 type githubTreeEntry struct {
 	Path string `json:"path"`
 	Type string `json:"type"` // "blob" or "tree"
+	Size int64  `json:"size"` // blob byte size (absent/0 for tree entries)
 }
 
 // fetchGitHubDefaultBranch returns the default branch of a GitHub repository.
 // Falls back to "main" if the API call fails.
-func fetchGitHubDefaultBranch(httpClient *http.Client, owner, repo string) string {
+func fetchGitHubDefaultBranch(ctx context.Context, httpClient *http.Client, owner, repo string) string {
 	apiURL := fmt.Sprintf("https://api.github.com/repos/%s/%s",
 		url.PathEscape(owner), url.PathEscape(repo))
-	resp, err := doGitHubAPIGet(httpClient, apiURL)
+	resp, err := doGitHubAPIGet(ctx, httpClient, apiURL)
 	if err != nil || resp.StatusCode != http.StatusOK {
 		if resp != nil {
 			resp.Body.Close()
@@ -915,7 +918,7 @@ func fetchClawHubInstallCount(httpClient *http.Client, slug string) (int64, bool
 	return detail.Skill.Stats.InstallsCurrent, true
 }
 
-func fetchFromClawHub(httpClient *http.Client, rawURL string) (*importedSkill, error) {
+func fetchFromClawHub(ctx context.Context, httpClient *http.Client, rawURL string) (*importedSkill, error) {
 	slug, err := parseClawHubSlug(rawURL)
 	if err != nil {
 		return nil, err
@@ -924,7 +927,11 @@ func fetchFromClawHub(httpClient *http.Client, rawURL string) (*importedSkill, e
 	apiBase := clawHubAPIBase
 
 	// 1. Fetch skill metadata
-	skillResp, err := httpClient.Get(apiBase + "/skills/" + url.PathEscape(slug))
+	skillReq, err := http.NewRequestWithContext(ctx, http.MethodGet, apiBase+"/skills/"+url.PathEscape(slug), nil)
+	if err != nil {
+		return nil, err
+	}
+	skillResp, err := httpClient.Do(skillReq)
 	if err != nil {
 		return nil, fmt.Errorf("failed to reach ClawHub: %w", err)
 	}
@@ -954,7 +961,11 @@ func fetchFromClawHub(httpClient *http.Client, rawURL string) (*importedSkill, e
 	var filePaths []string
 	if latestVersion != "" {
 		vURL := fmt.Sprintf("%s/skills/%s/versions/%s", apiBase, url.PathEscape(slug), url.PathEscape(latestVersion))
-		vResp, err := httpClient.Get(vURL)
+		vReq, verr := http.NewRequestWithContext(ctx, http.MethodGet, vURL, nil)
+		if verr != nil {
+			return nil, verr
+		}
+		vResp, err := httpClient.Do(vReq)
 		if err == nil {
 			defer vResp.Body.Close()
 			if vResp.StatusCode == http.StatusOK {
@@ -987,7 +998,7 @@ func fetchFromClawHub(httpClient *http.Client, rawURL string) (*importedSkill, e
 		if latestVersion != "" {
 			fileURL += "&version=" + url.QueryEscape(latestVersion)
 		}
-		body, err := fetchRawFile(httpClient, fileURL)
+		body, err := fetchRawFile(ctx, httpClient, fileURL)
 		if err != nil {
 			// Cap violations must abort: silently dropping a file would
 			// produce an incomplete bundle that looks valid. SKILL.md is
@@ -1030,22 +1041,67 @@ func parseSkillsShParts(raw string) (owner, repo, skillName string, err error) {
 	return parts[0], parts[1], parts[2], nil
 }
 
-func fetchFromSkillsSh(httpClient *http.Client, rawURL string) (*importedSkill, error) {
+func fetchFromSkillsSh(ctx context.Context, httpClient *http.Client, rawURL string) (*importedSkill, error) {
 	owner, repo, skillName, err := parseSkillsShParts(rawURL)
 	if err != nil {
 		return nil, err
 	}
 
+	// A skills.sh URL maps onto a GitHub repository. Both skill-directory
+	// resolution and supporting-file enumeration are driven by a single
+	// recursive tree fetch. This collapses what used to be one contents-API
+	// call per directory — hundreds of sequential requests for a large mono-repo
+	// like api-gateway-skill, which pushed the request past the reverse-proxy
+	// gateway timeout (504) — into one call, and lets the import caps be checked
+	// from the tree metadata before any file is downloaded.
+	defaultBranch := fetchGitHubDefaultBranch(ctx, httpClient, owner, repo)
+	rawPrefix := fmt.Sprintf("https://raw.githubusercontent.com/%s/%s/%s",
+		url.PathEscape(owner), url.PathEscape(repo), url.PathEscape(defaultBranch))
+
+	tree, truncated, treeErr := fetchGitHubTree(ctx, httpClient, owner, repo, defaultBranch)
+	if treeErr != nil {
+		// The tree fetch itself failed (e.g. GitHub API rate limiting). Fall
+		// back to the legacy raw-probe resolution + per-directory crawl so a
+		// single bad tree probe doesn't fail an otherwise importable skill.
+		slog.Warn("skills.sh import: tree fetch failed, falling back to legacy crawl",
+			"owner", owner, "repo", repo, "error", treeErr)
+		return fetchFromSkillsShLegacy(ctx, httpClient, owner, repo, skillName, defaultBranch, rawPrefix, rawURL)
+	}
+
+	skillDir, skillMdBody, err := resolveSkillDirFromTree(ctx, httpClient, owner, repo, defaultBranch, rawPrefix, skillName, tree, truncated)
+	if err != nil {
+		return nil, err
+	}
+
+	result := newSkillsShImportedSkill(skillMdBody, skillName, rawURL, owner, repo)
+
+	if truncated {
+		// The tree is incomplete, so it can't drive enumeration; use the legacy
+		// per-directory crawl scoped to the resolved skill directory.
+		if err := addSupportingFilesViaCrawl(ctx, httpClient, result, owner, repo, defaultBranch, skillDir); err != nil {
+			return nil, err
+		}
+		return result, nil
+	}
+
+	if err := addSupportingFilesFromTree(ctx, httpClient, result, tree, rawPrefix, skillDir); err != nil {
+		return nil, err
+	}
+	return result, nil
+}
+
+// fetchFromSkillsShLegacy is the fallback used when the recursive tree cannot be
+// fetched (e.g. the GitHub API is rate limiting). It resolves the skill
+// directory with raw candidate probes (which hit raw.githubusercontent.com and
+// so survive api.github.com rate limiting) and enumerates supporting files with
+// the per-directory contents crawl.
+func fetchFromSkillsShLegacy(ctx context.Context, httpClient *http.Client, owner, repo, skillName, defaultBranch, rawPrefix, rawURL string) (*importedSkill, error) {
 	// Skills can be at different paths depending on the repo structure:
 	//   skills/{name}/SKILL.md          (most common)
 	//   .claude/skills/{name}/SKILL.md  (Claude Code native discovery)
 	//   plugin/skills/{name}/SKILL.md   (e.g. microsoft repos)
 	//   {name}/SKILL.md                 (e.g. anthropics/skills layout)
 	//   SKILL.md                        (single-skill repo: the repo is the skill)
-	defaultBranch := fetchGitHubDefaultBranch(httpClient, owner, repo)
-	rawPrefix := fmt.Sprintf("https://raw.githubusercontent.com/%s/%s/%s",
-		url.PathEscape(owner), url.PathEscape(repo), url.PathEscape(defaultBranch))
-
 	candidatePaths := []string{
 		"skills/" + skillName,
 		".claude/skills/" + skillName,
@@ -1056,20 +1112,18 @@ func fetchFromSkillsSh(httpClient *http.Client, rawURL string) (*importedSkill, 
 	var skillMdBody []byte
 	var skillDir string
 	for _, dir := range candidatePaths {
-		body, err := fetchRawFile(httpClient, buildRawGitHubURL(rawPrefix, dir+"/SKILL.md"))
+		body, err := fetchRawFile(ctx, httpClient, buildRawGitHubURL(rawPrefix, dir+"/SKILL.md"))
 		if err == nil {
 			skillMdBody = body
 			skillDir = dir
 			break
 		}
 	}
-	// Single-skill repos place SKILL.md at the repository root. Try it as a
-	// fast path before the tree-listing fallback to avoid a recursive tree
-	// API call for a common case. Verify the frontmatter name matches so a
-	// stray root SKILL.md in a multi-skill repo can't get picked up for an
-	// unrelated skill URL.
+	// Single-skill repos place SKILL.md at the repository root. Verify the
+	// frontmatter name matches so a stray root SKILL.md in a multi-skill repo
+	// can't get picked up for an unrelated skill URL.
 	if skillMdBody == nil {
-		body, err := fetchRawFile(httpClient, buildRawGitHubURL(rawPrefix, "SKILL.md"))
+		body, err := fetchRawFile(ctx, httpClient, buildRawGitHubURL(rawPrefix, "SKILL.md"))
 		if err == nil {
 			if name, _ := skillpkg.ParseSkillFrontmatter(string(body)); name == skillName {
 				skillMdBody = body
@@ -1078,19 +1132,28 @@ func fetchFromSkillsSh(httpClient *http.Client, rawURL string) (*importedSkill, 
 		}
 	}
 	if skillMdBody == nil {
-		skillDir, skillMdBody, err = resolveGitHubSkillDirByName(httpClient, owner, repo, defaultBranch, rawPrefix, skillName)
-		if err != nil {
-			return nil, err
+		dir, body, ok := findSkillDirFromConventionalPrefixes(ctx, httpClient, owner, repo, defaultBranch, rawPrefix, skillName)
+		if !ok {
+			return nil, skillMdNotFoundError(owner, repo, skillName)
 		}
+		skillDir, skillMdBody = dir, body
 	}
 
-	// Parse name and description from YAML frontmatter
+	result := newSkillsShImportedSkill(skillMdBody, skillName, rawURL, owner, repo)
+	if err := addSupportingFilesViaCrawl(ctx, httpClient, result, owner, repo, defaultBranch, skillDir); err != nil {
+		return nil, err
+	}
+	return result, nil
+}
+
+// newSkillsShImportedSkill builds the importedSkill shell (name, description,
+// SKILL.md content, provenance) from a fetched SKILL.md body.
+func newSkillsShImportedSkill(skillMdBody []byte, skillName, rawURL, owner, repo string) *importedSkill {
 	name, description := skillpkg.ParseSkillFrontmatter(string(skillMdBody))
 	if name == "" {
 		name = skillName
 	}
-
-	result := &importedSkill{
+	return &importedSkill{
 		name:        name,
 		description: description,
 		content:     string(skillMdBody),
@@ -1102,32 +1165,33 @@ func fetchFromSkillsSh(httpClient *http.Client, rawURL string) (*importedSkill, 
 			"skill":      skillName,
 		},
 	}
+}
 
-	// 2. List supporting files via GitHub API
-	apiURL := buildGitHubContentsURL(owner, repo, skillDir, defaultBranch)
-	dirResp, err := doGitHubAPIGet(httpClient, apiURL)
+// addSupportingFilesViaCrawl is the legacy per-directory enumeration path, used
+// only as a fallback when the recursive tree is unavailable or truncated. It
+// lists skillDir via the contents API, recurses subdirectories, and downloads
+// each file. It stays lenient on a listing failure (returns with only SKILL.md)
+// to match prior behavior under GitHub API rate limiting.
+func addSupportingFilesViaCrawl(ctx context.Context, httpClient *http.Client, result *importedSkill, owner, repo, ref, skillDir string) error {
+	apiURL := buildGitHubContentsURL(owner, repo, skillDir, ref)
+	dirResp, err := doGitHubAPIGet(ctx, httpClient, apiURL)
 	if err != nil || dirResp.StatusCode != http.StatusOK {
-		// Can't list files — return what we have (SKILL.md only)
 		if dirResp != nil {
 			dirResp.Body.Close()
 		}
-		return result, nil
+		return nil
 	}
 	defer dirResp.Body.Close()
 
 	var entries []githubContentEntry
 	if err := json.NewDecoder(dirResp.Body).Decode(&entries); err != nil {
 		slog.Warn("github import: failed to decode top-level directory listing", "url", apiURL, "error", err)
-		return result, nil
+		return nil
 	}
 
-	// 3. Recursively collect files (excluding SKILL.md and LICENSE)
 	var allFiles []githubContentEntry
-	slog.Info("github import: collecting supporting files", "skill", skillName, "top_level_entries", len(entries))
-	collectGitHubFiles(httpClient, entries, &allFiles, apiURL)
-	slog.Info("github import: collected supporting files", "skill", skillName, "files", len(allFiles))
+	collectGitHubFiles(ctx, httpClient, entries, &allFiles, apiURL)
 
-	// 4. Download each file
 	basePath := ""
 	if skillDir != "" {
 		basePath = skillDir + "/"
@@ -1136,62 +1200,191 @@ func fetchFromSkillsSh(httpClient *http.Client, rawURL string) (*importedSkill, 
 		if entry.DownloadURL == "" {
 			continue
 		}
-		body, err := fetchRawFile(httpClient, entry.DownloadURL)
+		body, err := fetchRawFile(ctx, httpClient, entry.DownloadURL)
 		if err != nil {
 			if isCapError(err) {
-				return nil, fmt.Errorf("github import: %s: %w", entry.Path, err)
+				return fmt.Errorf("github import: %s: %w", entry.Path, err)
 			}
 			slog.Warn("github import: file download failed", "path", entry.Path, "error", err)
 			continue
 		}
-		// Convert absolute GitHub path to relative path within skill
 		relPath := strings.TrimPrefix(entry.Path, basePath)
 		if err := result.addFile(relPath, string(body)); err != nil {
-			return nil, err
+			return err
 		}
 	}
-
-	return result, nil
+	return nil
 }
 
-func resolveGitHubSkillDirByName(httpClient *http.Client, owner, repo, defaultBranch, rawPrefix, skillName string) (string, []byte, error) {
+// fetchGitHubTree fetches the full recursive git tree for a ref in a single API
+// call. Each returned blob entry carries its path and byte size, which lets the
+// importer both resolve the skill directory and enforce the import caps without
+// the per-directory contents crawl that previously issued one API call per
+// directory — hundreds of sequential requests for a large mono-repo, which is
+// what pushed skills.sh imports past the reverse-proxy gateway timeout (504).
+func fetchGitHubTree(ctx context.Context, httpClient *http.Client, owner, repo, ref string) (entries []githubTreeEntry, truncated bool, err error) {
 	apiURL := fmt.Sprintf("https://api.github.com/repos/%s/%s/git/trees/%s?recursive=1",
-		url.PathEscape(owner), url.PathEscape(repo), url.PathEscape(defaultBranch))
-	resp, err := doGitHubAPIGet(httpClient, apiURL)
+		url.PathEscape(owner), url.PathEscape(repo), url.PathEscape(ref))
+	resp, err := doGitHubAPIGet(ctx, httpClient, apiURL)
 	if err != nil {
-		return "", nil, fmt.Errorf("failed to inspect repository %s/%s for skill %s: %w", owner, repo, skillName, err)
+		return nil, false, err
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusOK {
-		return "", nil, fmt.Errorf("failed to inspect repository %s/%s for skill %s: HTTP %d", owner, repo, skillName, resp.StatusCode)
+		return nil, false, fmt.Errorf("HTTP %d", resp.StatusCode)
 	}
-
 	var tree githubTreeResponse
 	if err := json.NewDecoder(resp.Body).Decode(&tree); err != nil {
-		return "", nil, fmt.Errorf("failed to inspect repository %s/%s for skill %s: %w", owner, repo, skillName, err)
+		return nil, false, err
 	}
+	return tree.Tree, tree.Truncated, nil
+}
 
-	skillPaths := extractSkillMdPaths(tree.Tree)
+// resolveSkillDirFromTree resolves the skill directory and its SKILL.md body
+// from an already-fetched repository tree. It prefers the most specific
+// frontmatter-verified match (a SKILL.md whose directory matches the skill
+// name), only considering the repository root when nothing deeper matches — so
+// a repo-root SKILL.md whose name happens to collide with the skill name no
+// longer captures the whole repository. When the tree is truncated it falls
+// back to a bounded per-prefix listing.
+func resolveSkillDirFromTree(ctx context.Context, httpClient *http.Client, owner, repo, defaultBranch, rawPrefix, skillName string, tree []githubTreeEntry, truncated bool) (string, []byte, error) {
+	skillPaths := extractSkillMdPaths(tree)
 	preferred, remaining := partitionSkillMdPaths(skillName, skillPaths)
-	if dir, body, ok := findMatchingSkillDirByFrontmatter(httpClient, rawPrefix, skillName, preferred); ok {
+	if dir, body, ok := findMatchingSkillDirByFrontmatter(ctx, httpClient, rawPrefix, skillName, preferred); ok {
 		return dir, body, nil
 	}
-	if !tree.Truncated {
-		if dir, body, ok := findMatchingSkillDirByFrontmatter(httpClient, rawPrefix, skillName, remaining); ok {
+	if !truncated {
+		if dir, body, ok := findMatchingSkillDirByFrontmatter(ctx, httpClient, rawPrefix, skillName, remaining); ok {
 			return dir, body, nil
 		}
 		return "", nil, skillMdNotFoundError(owner, repo, skillName)
 	}
 
 	slog.Warn("github import: repository tree listing truncated", "owner", owner, "repo", repo, "branch", defaultBranch)
-	if dir, body, ok := findSkillDirFromConventionalPrefixes(httpClient, owner, repo, defaultBranch, rawPrefix, skillName); ok {
+	if dir, body, ok := findSkillDirFromConventionalPrefixes(ctx, httpClient, owner, repo, defaultBranch, rawPrefix, skillName); ok {
 		return dir, body, nil
 	}
 	return "", nil, fmt.Errorf("repository %s/%s tree is too large to scan exhaustively for skill %s", owner, repo, skillName)
 }
 
+// treeDownloadConcurrency bounds how many supporting files are downloaded in
+// parallel during tree-based collection. Small enough that one import cannot
+// open hundreds of sockets to GitHub at once, large enough to keep the download
+// phase well under the overall import deadline for a full (256-file) bundle.
+const treeDownloadConcurrency = 8
+
+// addSupportingFilesFromTree enumerates the supporting files under skillDir from
+// a single recursive git tree, enforces the per-file / count / total-byte caps
+// arithmetically from the tree metadata BEFORE downloading anything (so an
+// over-limit skill fails fast with a clear error instead of timing out), then
+// downloads the surviving files concurrently and appends them in a stable path
+// order. It replaces the legacy per-directory contents crawl (collectGitHubFiles).
+func addSupportingFilesFromTree(ctx context.Context, httpClient *http.Client, result *importedSkill, tree []githubTreeEntry, rawPrefix, skillDir string) error {
+	basePath := ""
+	if skillDir != "" {
+		basePath = skillDir + "/"
+	}
+
+	// Select the eligible supporting-file blobs under skillDir, mirroring the
+	// filters the download loop / addFile would otherwise apply: skip the
+	// skill's own SKILL.md, LICENSE files, and binary assets (which addFile
+	// drops anyway). Keeping the filter here makes the arithmetic cap check
+	// below match what actually gets imported.
+	type treeFile struct {
+		repoPath string
+		relPath  string
+		size     int64
+	}
+	var eligible []treeFile
+	for _, entry := range tree {
+		if entry.Type != "blob" {
+			continue
+		}
+		if basePath != "" && !strings.HasPrefix(entry.Path, basePath) {
+			continue
+		}
+		relPath := strings.TrimPrefix(entry.Path, basePath)
+		if relPath == "" {
+			continue
+		}
+		lowerBase := strings.ToLower(filepath.Base(relPath))
+		if lowerBase == "skill.md" || lowerBase == "license" || lowerBase == "license.txt" || lowerBase == "license.md" {
+			continue
+		}
+		if isLikelyBinaryFilePath(relPath) {
+			continue
+		}
+		eligible = append(eligible, treeFile{repoPath: entry.Path, relPath: relPath, size: entry.size()})
+	}
+
+	// Stable order so imports are deterministic regardless of download timing.
+	sort.Slice(eligible, func(i, j int) bool { return eligible[i].relPath < eligible[j].relPath })
+
+	// Arithmetic cap pre-check on the tree metadata — no downloads required to
+	// reject an over-limit bundle.
+	if len(eligible) > maxImportFileCount {
+		return fmt.Errorf("%w: import bundle would contain %d files, exceeding the %d file limit", errImportCapExceeded, len(eligible), maxImportFileCount)
+	}
+	var totalSize int64
+	for _, f := range eligible {
+		if f.size > maxImportFileSize {
+			return fmt.Errorf("%w: %s is %d bytes, exceeding the %d byte per-file limit", errImportCapExceeded, f.relPath, f.size, maxImportFileSize)
+		}
+		totalSize += f.size
+	}
+	if totalSize > maxImportTotalSize {
+		return fmt.Errorf("%w: import bundle is %d bytes, exceeding the %d byte limit", errImportCapExceeded, totalSize, maxImportTotalSize)
+	}
+
+	// Download concurrently, then append in the pre-sorted order.
+	contents := make([]string, len(eligible))
+	fetched := make([]bool, len(eligible))
+	g, gctx := errgroup.WithContext(ctx)
+	g.SetLimit(treeDownloadConcurrency)
+	for i, f := range eligible {
+		i, f := i, f
+		g.Go(func() error {
+			body, err := fetchRawFile(gctx, httpClient, buildRawGitHubURL(rawPrefix, f.repoPath))
+			if err != nil {
+				if isCapError(err) {
+					return fmt.Errorf("github import: %s: %w", f.repoPath, err)
+				}
+				// Match the legacy loop's leniency: a single failed supporting
+				// file is logged and skipped, not fatal.
+				slog.Warn("github import: file download failed", "path", f.repoPath, "error", err)
+				return nil
+			}
+			contents[i] = string(body)
+			fetched[i] = true
+			return nil
+		})
+	}
+	if err := g.Wait(); err != nil {
+		return err
+	}
+
+	for i, f := range eligible {
+		if !fetched[i] {
+			continue
+		}
+		if err := result.addFile(f.relPath, contents[i]); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// size returns the blob byte size, guarding against a negative value from a
+// malformed tree response.
+func (e githubTreeEntry) size() int64 {
+	if e.Size < 0 {
+		return 0
+	}
+	return e.Size
+}
+
 // collectGitHubFiles recursively collects file entries from a GitHub directory listing.
-func collectGitHubFiles(httpClient *http.Client, entries []githubContentEntry, out *[]githubContentEntry, parentURL string) {
+func collectGitHubFiles(ctx context.Context, httpClient *http.Client, entries []githubContentEntry, out *[]githubContentEntry, parentURL string) {
 	for _, entry := range entries {
 		lower := strings.ToLower(entry.Name)
 		if lower == "skill.md" || lower == "license" || lower == "license.txt" || lower == "license.md" {
@@ -1211,7 +1404,7 @@ func collectGitHubFiles(httpClient *http.Client, entries []githubContentEntry, o
 				parsed.Path = strings.TrimSuffix(parsed.Path, "/") + "/" + entry.Name
 				subURL = parsed.String()
 			}
-			subResp, err := doGitHubAPIGet(httpClient, subURL)
+			subResp, err := doGitHubAPIGet(ctx, httpClient, subURL)
 			if err != nil || subResp.StatusCode != http.StatusOK {
 				attrs := []any{"url", subURL}
 				if subResp != nil {
@@ -1231,16 +1424,16 @@ func collectGitHubFiles(httpClient *http.Client, entries []githubContentEntry, o
 				continue
 			}
 			subResp.Body.Close()
-			collectGitHubFiles(httpClient, subEntries, out, subURL)
+			collectGitHubFiles(ctx, httpClient, subEntries, out, subURL)
 		}
 	}
 }
 
-func findSkillDirFromConventionalPrefixes(httpClient *http.Client, owner, repo, defaultBranch, rawPrefix, skillName string) (string, []byte, bool) {
+func findSkillDirFromConventionalPrefixes(ctx context.Context, httpClient *http.Client, owner, repo, defaultBranch, rawPrefix, skillName string) (string, []byte, bool) {
 	prefixes := []string{"skills", ".claude/skills", "plugin/skills"}
 	var skillPaths []string
 	for _, prefix := range prefixes {
-		paths, err := listGitHubSkillMdPaths(httpClient, owner, repo, prefix, defaultBranch)
+		paths, err := listGitHubSkillMdPaths(ctx, httpClient, owner, repo, prefix, defaultBranch)
 		if err != nil {
 			slog.Warn("github import: failed to list conventional skill prefix", "prefix", prefix, "error", err)
 			continue
@@ -1249,15 +1442,15 @@ func findSkillDirFromConventionalPrefixes(httpClient *http.Client, owner, repo, 
 	}
 
 	preferred, remaining := partitionSkillMdPaths(skillName, skillPaths)
-	if dir, body, ok := findMatchingSkillDirByFrontmatter(httpClient, rawPrefix, skillName, preferred); ok {
+	if dir, body, ok := findMatchingSkillDirByFrontmatter(ctx, httpClient, rawPrefix, skillName, preferred); ok {
 		return dir, body, true
 	}
-	return findMatchingSkillDirByFrontmatter(httpClient, rawPrefix, skillName, remaining)
+	return findMatchingSkillDirByFrontmatter(ctx, httpClient, rawPrefix, skillName, remaining)
 }
 
-func listGitHubSkillMdPaths(httpClient *http.Client, owner, repo, repoPath, ref string) ([]string, error) {
+func listGitHubSkillMdPaths(ctx context.Context, httpClient *http.Client, owner, repo, repoPath, ref string) ([]string, error) {
 	apiURL := buildGitHubContentsURL(owner, repo, repoPath, ref)
-	resp, err := doGitHubAPIGet(httpClient, apiURL)
+	resp, err := doGitHubAPIGet(ctx, httpClient, apiURL)
 	if err != nil {
 		return nil, err
 	}
@@ -1275,11 +1468,11 @@ func listGitHubSkillMdPaths(httpClient *http.Client, owner, repo, repoPath, ref 
 	}
 
 	var paths []string
-	collectGitHubSkillMdPaths(httpClient, entries, &paths, apiURL)
+	collectGitHubSkillMdPaths(ctx, httpClient, entries, &paths, apiURL)
 	return paths, nil
 }
 
-func collectGitHubSkillMdPaths(httpClient *http.Client, entries []githubContentEntry, out *[]string, parentURL string) {
+func collectGitHubSkillMdPaths(ctx context.Context, httpClient *http.Client, entries []githubContentEntry, out *[]string, parentURL string) {
 	for _, entry := range entries {
 		lower := strings.ToLower(entry.Name)
 		if entry.Type == "file" {
@@ -1303,7 +1496,7 @@ func collectGitHubSkillMdPaths(httpClient *http.Client, entries []githubContentE
 			subURL = parsed.String()
 		}
 
-		subResp, err := doGitHubAPIGet(httpClient, subURL)
+		subResp, err := doGitHubAPIGet(ctx, httpClient, subURL)
 		if err != nil || subResp.StatusCode != http.StatusOK {
 			attrs := []any{"url", subURL}
 			if subResp != nil {
@@ -1324,7 +1517,7 @@ func collectGitHubSkillMdPaths(httpClient *http.Client, entries []githubContentE
 			continue
 		}
 		subResp.Body.Close()
-		collectGitHubSkillMdPaths(httpClient, subEntries, out, subURL)
+		collectGitHubSkillMdPaths(ctx, httpClient, subEntries, out, subURL)
 	}
 }
 
@@ -1350,9 +1543,9 @@ func partitionSkillMdPaths(skillName string, skillPaths []string) (preferred []s
 	return preferred, remaining
 }
 
-func findMatchingSkillDirByFrontmatter(httpClient *http.Client, rawPrefix, skillName string, skillPaths []string) (string, []byte, bool) {
+func findMatchingSkillDirByFrontmatter(ctx context.Context, httpClient *http.Client, rawPrefix, skillName string, skillPaths []string) (string, []byte, bool) {
 	for _, skillPath := range skillPaths {
-		body, err := fetchRawFile(httpClient, buildRawGitHubURL(rawPrefix, skillPath))
+		body, err := fetchRawFile(ctx, httpClient, buildRawGitHubURL(rawPrefix, skillPath))
 		if err != nil {
 			slog.Warn("github import: fallback SKILL.md fetch failed", "path", skillPath, "error", err)
 			continue
@@ -1417,8 +1610,8 @@ var errGitHubAPIBlocked = errors.New("github API blocked (rate limit or auth)")
 // API requests are capped at 60/hour per IP, which is trivially exhausted on
 // shared self-hosted servers and surfaces to users as 403 errors during
 // skill imports. Setting GITHUB_TOKEN raises the limit to 5000/hour.
-func doGitHubAPIGet(httpClient *http.Client, apiURL string) (*http.Response, error) {
-	req, err := http.NewRequest(http.MethodGet, apiURL, nil)
+func doGitHubAPIGet(ctx context.Context, httpClient *http.Client, apiURL string) (*http.Response, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, apiURL, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -1532,7 +1725,7 @@ func parseGitHubURL(raw string) (githubSpec, error) {
 // On success spec.ref and spec.skillDir are overwritten with the resolved
 // pair. On failure (no candidate resolves) a single error is returned that
 // names every candidate that was tried.
-func resolveGitHubRefAndPath(httpClient *http.Client, spec *githubSpec) error {
+func resolveGitHubRefAndPath(ctx context.Context, httpClient *http.Client, spec *githubSpec) error {
 	if len(spec.refSegments) == 0 {
 		return nil
 	}
@@ -1542,7 +1735,7 @@ func resolveGitHubRefAndPath(httpClient *http.Client, spec *githubSpec) error {
 	for n := len(spec.refSegments); n >= 1; n-- {
 		candidate := strings.Join(spec.refSegments[:n], "/")
 		tried = append(tried, candidate)
-		ok, err := githubRefExists(httpClient, spec.owner, spec.repo, candidate)
+		ok, err := githubRefExists(ctx, httpClient, spec.owner, spec.repo, candidate)
 		if errors.Is(err, errGitHubAPIBlocked) {
 			// 401/403/429 means we can't tell whether the ref exists. Keep
 			// trying the remaining (shorter) candidates so we don't punish
@@ -1585,10 +1778,10 @@ func resolveGitHubRefAndPath(httpClient *http.Client, spec *githubSpec) error {
 // only match one). 404 means the ref does not exist; any other non-200
 // status is treated as an error so the caller can distinguish "missing"
 // from "API down".
-func githubRefExists(httpClient *http.Client, owner, repo, ref string) (bool, error) {
+func githubRefExists(ctx context.Context, httpClient *http.Client, owner, repo, ref string) (bool, error) {
 	apiURL := fmt.Sprintf("https://api.github.com/repos/%s/%s/commits/%s",
 		url.PathEscape(owner), url.PathEscape(repo), escapeRefPath(ref))
-	req, err := http.NewRequest(http.MethodGet, apiURL, nil)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, apiURL, nil)
 	if err != nil {
 		return false, err
 	}
@@ -1613,7 +1806,7 @@ func githubRefExists(httpClient *http.Client, owner, repo, ref string) (bool, er
 	}
 }
 
-func fetchFromGitHub(httpClient *http.Client, rawURL string) (*importedSkill, error) {
+func fetchFromGitHub(ctx context.Context, httpClient *http.Client, rawURL string) (*importedSkill, error) {
 	spec, err := parseGitHubURL(rawURL)
 	if err != nil {
 		return nil, err
@@ -1621,12 +1814,12 @@ func fetchFromGitHub(httpClient *http.Client, rawURL string) (*importedSkill, er
 	if len(spec.refSegments) > 0 {
 		// Disambiguate slash-bearing refs (release/v2 etc.) against the API
 		// before issuing any raw or contents requests.
-		if err := resolveGitHubRefAndPath(httpClient, &spec); err != nil {
+		if err := resolveGitHubRefAndPath(ctx, httpClient, &spec); err != nil {
 			return nil, err
 		}
 	}
 	if spec.ref == "" {
-		spec.ref = fetchGitHubDefaultBranch(httpClient, spec.owner, spec.repo)
+		spec.ref = fetchGitHubDefaultBranch(ctx, httpClient, spec.owner, spec.repo)
 	}
 	rawPrefix := fmt.Sprintf("https://raw.githubusercontent.com/%s/%s/%s",
 		url.PathEscape(spec.owner), url.PathEscape(spec.repo), escapeRefPath(spec.ref))
@@ -1635,7 +1828,7 @@ func fetchFromGitHub(httpClient *http.Client, rawURL string) (*importedSkill, er
 	if spec.skillDir != "" {
 		skillMdPath = spec.skillDir + "/SKILL.md"
 	}
-	skillMdBody, err := fetchRawFile(httpClient, buildRawGitHubURL(rawPrefix, skillMdPath))
+	skillMdBody, err := fetchRawFile(ctx, httpClient, buildRawGitHubURL(rawPrefix, skillMdPath))
 	if err != nil {
 		if spec.skillDir == "" {
 			return nil, fmt.Errorf("SKILL.md not found at the root of %s/%s@%s. For multi-skill repositories, point to a specific directory using github.com/%s/%s/tree/%s/<skill-dir>",
@@ -1668,50 +1861,21 @@ func fetchFromGitHub(httpClient *http.Client, rawURL string) (*importedSkill, er
 		},
 	}
 
-	apiURL := buildGitHubContentsURL(spec.owner, spec.repo, spec.skillDir, spec.ref)
-	dirResp, err := doGitHubAPIGet(httpClient, apiURL)
-	if err != nil || dirResp.StatusCode != http.StatusOK {
-		// Cannot list the directory — return what we have (SKILL.md only).
-		// Keep this lenient: a private rate-limited request shouldn't fail
-		// an import that has already produced a valid SKILL.md.
-		if dirResp != nil {
-			dirResp.Body.Close()
-		}
-		return result, nil
-	}
-	defer dirResp.Body.Close()
-
-	var entries []githubContentEntry
-	if err := json.NewDecoder(dirResp.Body).Decode(&entries); err != nil {
-		slog.Warn("github import: failed to decode top-level directory listing", "url", apiURL, "error", err)
-		return result, nil
-	}
-
-	var allFiles []githubContentEntry
-	collectGitHubFiles(httpClient, entries, &allFiles, apiURL)
-
-	basePath := ""
-	if spec.skillDir != "" {
-		basePath = spec.skillDir + "/"
-	}
-	for _, entry := range allFiles {
-		if entry.DownloadURL == "" {
-			continue
-		}
-		body, err := fetchRawFile(httpClient, entry.DownloadURL)
-		if err != nil {
-			if isCapError(err) {
-				return nil, fmt.Errorf("github import: %s: %w", entry.Path, err)
-			}
-			slog.Warn("github import: file download failed", "path", entry.Path, "error", err)
-			continue
-		}
-		relPath := strings.TrimPrefix(entry.Path, basePath)
-		if err := result.addFile(relPath, string(body)); err != nil {
+	// Enumerate supporting files from a single recursive tree, checking the
+	// import caps against the tree metadata before downloading anything. Fall
+	// back to the per-directory contents crawl when the tree is unavailable or
+	// truncated (kept lenient so a rate-limited listing doesn't fail an import
+	// that already produced a valid SKILL.md).
+	tree, truncated, treeErr := fetchGitHubTree(ctx, httpClient, spec.owner, spec.repo, spec.ref)
+	if treeErr == nil && !truncated {
+		if err := addSupportingFilesFromTree(ctx, httpClient, result, tree, rawPrefix, spec.skillDir); err != nil {
 			return nil, err
 		}
+		return result, nil
 	}
-
+	if err := addSupportingFilesViaCrawl(ctx, httpClient, result, spec.owner, spec.repo, spec.ref, spec.skillDir); err != nil {
+		return nil, err
+	}
 	return result, nil
 }
 
@@ -1726,8 +1890,8 @@ const rawGitHubContentHost = "raw.githubusercontent.com"
 // fetchRawFile downloads a URL and returns the body bytes. Returns an error
 // if the response exceeds maxImportFileSize so we never silently truncate a
 // half-downloaded skill file into the workspace.
-func fetchRawFile(httpClient *http.Client, fileURL string) ([]byte, error) {
-	req, err := newRawFileRequest(fileURL)
+func fetchRawFile(ctx context.Context, httpClient *http.Client, fileURL string) ([]byte, error) {
+	req, err := newRawFileRequest(ctx, fileURL)
 	if err != nil {
 		return nil, err
 	}
@@ -1754,8 +1918,8 @@ func fetchRawFile(httpClient *http.Client, fileURL string) ([]byte, error) {
 // host gate lives here, separate from the round-trip, so it can be unit tested
 // without a live network call — GITHUB_TOKEN must never reach a non-GitHub
 // skill host.
-func newRawFileRequest(fileURL string) (*http.Request, error) {
-	req, err := http.NewRequest(http.MethodGet, fileURL, nil)
+func newRawFileRequest(ctx context.Context, fileURL string) (*http.Request, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, fileURL, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -1968,21 +2132,49 @@ func (h *Handler) ImportSkill(w http.ResponseWriter, r *http.Request) {
 
 	httpClient := &http.Client{Timeout: 30 * time.Second}
 
+	// Bound the whole server-side fetch under an overall deadline that is
+	// shorter than the reverse-proxy / CDN gateway timeout in front of the API.
+	// If an upstream is slow, the import returns a clear error instead of the
+	// proxy severing the connection with a 504, and a client disconnect cancels
+	// the in-flight fetch instead of letting it run on orphaned.
+	ctx, cancel := context.WithTimeout(r.Context(), importFetchTimeout)
+	defer cancel()
+
 	var imported *importedSkill
 	switch source {
 	case sourceClawHub:
-		imported, err = fetchFromClawHub(httpClient, normalized)
+		imported, err = fetchFromClawHub(ctx, httpClient, normalized)
 	case sourceSkillsSh:
-		imported, err = fetchFromSkillsSh(httpClient, normalized)
+		imported, err = fetchFromSkillsSh(ctx, httpClient, normalized)
 	case sourceGitHub:
-		imported, err = fetchFromGitHub(httpClient, normalized)
+		imported, err = fetchFromGitHub(ctx, httpClient, normalized)
 	}
 	if err != nil {
-		writeError(w, http.StatusBadGateway, err.Error())
+		status, msg := importFetchErrorResponse(ctx, err)
+		writeError(w, status, msg)
 		return
 	}
 
 	h.finishSkillImport(w, r, workspaceID, workspaceUUID, creatorUUID, creatorID, strategy, structuredResult, imported)
+}
+
+// importFetchTimeout bounds the total time spent fetching a skill's files from
+// the upstream source. It is deliberately below the reverse-proxy gateway
+// timeout so a slow or oversized source surfaces as a readable API error rather
+// than a proxy 504.
+const importFetchTimeout = 45 * time.Second
+
+// importFetchErrorResponse maps a fetch failure onto an HTTP status and message.
+// Cap violations become 413 (the skill is too large to import), an exhausted
+// deadline becomes 504 with an actionable hint, and everything else stays 502.
+func importFetchErrorResponse(ctx context.Context, err error) (int, string) {
+	if isCapError(err) {
+		return http.StatusRequestEntityTooLarge, err.Error()
+	}
+	if errors.Is(err, context.DeadlineExceeded) || ctx.Err() == context.DeadlineExceeded {
+		return http.StatusGatewayTimeout, "skill import timed out fetching source files; the skill may be too large or the source too slow"
+	}
+	return http.StatusBadGateway, err.Error()
 }
 
 // finishSkillImport runs the shared tail of every skill import — whether the

--- a/server/internal/handler/skill.go
+++ b/server/internal/handler/skill.go
@@ -623,6 +623,12 @@ type importedFile struct {
 // produce an incomplete skill that looks valid to the user.
 var errImportCapExceeded = errors.New("import cap exceeded")
 
+// errImportSourceUnavailable marks a transient failure to read the upstream
+// source (e.g. the GitHub tree API rate limiting). The import can't proceed
+// safely but should be retried, so it maps to a retryable HTTP status rather
+// than a permanent error.
+var errImportSourceUnavailable = errors.New("import source temporarily unavailable")
+
 // isCapError reports whether err is (or wraps) errImportCapExceeded.
 func isCapError(err error) bool {
 	return errors.Is(err, errImportCapExceeded)
@@ -1006,6 +1012,12 @@ func fetchFromClawHub(ctx context.Context, httpClient *http.Client, rawURL strin
 			if isCapError(err) || fp == "SKILL.md" {
 				return nil, fmt.Errorf("clawhub import: %s: %w", fp, err)
 			}
+			// A cancelled context (overall deadline / client disconnect) is
+			// fatal for the same reason: skipping every remaining file would
+			// persist a half-populated bundle as a success.
+			if ctx.Err() != nil {
+				return nil, fmt.Errorf("clawhub import: fetch aborted at %s: %w", fp, ctx.Err())
+			}
 			slog.Warn("clawhub import: file download failed", "path", fp, "error", err)
 			continue
 		}
@@ -1060,12 +1072,18 @@ func fetchFromSkillsSh(ctx context.Context, httpClient *http.Client, rawURL stri
 
 	tree, truncated, treeErr := fetchGitHubTree(ctx, httpClient, owner, repo, defaultBranch)
 	if treeErr != nil {
-		// The tree fetch itself failed (e.g. GitHub API rate limiting). Fall
-		// back to the legacy raw-probe resolution + per-directory crawl so a
-		// single bad tree probe doesn't fail an otherwise importable skill.
-		slog.Warn("skills.sh import: tree fetch failed, falling back to legacy crawl",
+		// The tree fetch failed (typically GitHub API rate limiting, which also
+		// takes down the contents API). Without the tree we cannot safely
+		// resolve which directory is the skill: a raw-probe + root-SKILL.md
+		// fallback would re-select the repository root whenever its name
+		// collides with the slug (the api-gateway-skill case) and the same
+		// rate limiting would then leave the crawl empty — persisting the wrong
+		// SKILL.md with zero supporting files as a "successful" import. Fail
+		// with a retryable error instead so nothing incorrect is saved.
+		slog.Warn("skills.sh import: repository tree fetch failed",
 			"owner", owner, "repo", repo, "error", treeErr)
-		return fetchFromSkillsShLegacy(ctx, httpClient, owner, repo, skillName, defaultBranch, rawPrefix, rawURL)
+		return nil, fmt.Errorf("%w: could not read the %s/%s repository tree (usually GitHub API rate limiting — set GITHUB_TOKEN on the server or retry): %v",
+			errImportSourceUnavailable, owner, repo, treeErr)
 	}
 
 	skillDir, skillMdBody, err := resolveSkillDirFromTree(ctx, httpClient, owner, repo, defaultBranch, rawPrefix, skillName, tree, truncated)
@@ -1085,62 +1103,6 @@ func fetchFromSkillsSh(ctx context.Context, httpClient *http.Client, rawURL stri
 	}
 
 	if err := addSupportingFilesFromTree(ctx, httpClient, result, tree, rawPrefix, skillDir); err != nil {
-		return nil, err
-	}
-	return result, nil
-}
-
-// fetchFromSkillsShLegacy is the fallback used when the recursive tree cannot be
-// fetched (e.g. the GitHub API is rate limiting). It resolves the skill
-// directory with raw candidate probes (which hit raw.githubusercontent.com and
-// so survive api.github.com rate limiting) and enumerates supporting files with
-// the per-directory contents crawl.
-func fetchFromSkillsShLegacy(ctx context.Context, httpClient *http.Client, owner, repo, skillName, defaultBranch, rawPrefix, rawURL string) (*importedSkill, error) {
-	// Skills can be at different paths depending on the repo structure:
-	//   skills/{name}/SKILL.md          (most common)
-	//   .claude/skills/{name}/SKILL.md  (Claude Code native discovery)
-	//   plugin/skills/{name}/SKILL.md   (e.g. microsoft repos)
-	//   {name}/SKILL.md                 (e.g. anthropics/skills layout)
-	//   SKILL.md                        (single-skill repo: the repo is the skill)
-	candidatePaths := []string{
-		"skills/" + skillName,
-		".claude/skills/" + skillName,
-		"plugin/skills/" + skillName,
-		skillName,
-	}
-
-	var skillMdBody []byte
-	var skillDir string
-	for _, dir := range candidatePaths {
-		body, err := fetchRawFile(ctx, httpClient, buildRawGitHubURL(rawPrefix, dir+"/SKILL.md"))
-		if err == nil {
-			skillMdBody = body
-			skillDir = dir
-			break
-		}
-	}
-	// Single-skill repos place SKILL.md at the repository root. Verify the
-	// frontmatter name matches so a stray root SKILL.md in a multi-skill repo
-	// can't get picked up for an unrelated skill URL.
-	if skillMdBody == nil {
-		body, err := fetchRawFile(ctx, httpClient, buildRawGitHubURL(rawPrefix, "SKILL.md"))
-		if err == nil {
-			if name, _ := skillpkg.ParseSkillFrontmatter(string(body)); name == skillName {
-				skillMdBody = body
-				skillDir = ""
-			}
-		}
-	}
-	if skillMdBody == nil {
-		dir, body, ok := findSkillDirFromConventionalPrefixes(ctx, httpClient, owner, repo, defaultBranch, rawPrefix, skillName)
-		if !ok {
-			return nil, skillMdNotFoundError(owner, repo, skillName)
-		}
-		skillDir, skillMdBody = dir, body
-	}
-
-	result := newSkillsShImportedSkill(skillMdBody, skillName, rawURL, owner, repo)
-	if err := addSupportingFilesViaCrawl(ctx, httpClient, result, owner, repo, defaultBranch, skillDir); err != nil {
 		return nil, err
 	}
 	return result, nil
@@ -1179,6 +1141,12 @@ func addSupportingFilesViaCrawl(ctx context.Context, httpClient *http.Client, re
 		if dirResp != nil {
 			dirResp.Body.Close()
 		}
+		// A cancelled context (overall deadline / client disconnect) must abort
+		// rather than being swallowed as "no supporting files", which would
+		// persist an incomplete bundle as a success.
+		if ctx.Err() != nil {
+			return fmt.Errorf("github import: directory listing aborted: %w", ctx.Err())
+		}
 		return nil
 	}
 	defer dirResp.Body.Close()
@@ -1191,6 +1159,11 @@ func addSupportingFilesViaCrawl(ctx context.Context, httpClient *http.Client, re
 
 	var allFiles []githubContentEntry
 	collectGitHubFiles(ctx, httpClient, entries, &allFiles, apiURL)
+	// collectGitHubFiles is lenient on a failed subdirectory listing; if the
+	// context was cancelled mid-crawl the collected set is incomplete, so abort.
+	if ctx.Err() != nil {
+		return fmt.Errorf("github import: directory crawl aborted: %w", ctx.Err())
+	}
 
 	basePath := ""
 	if skillDir != "" {
@@ -1204,6 +1177,9 @@ func addSupportingFilesViaCrawl(ctx context.Context, httpClient *http.Client, re
 		if err != nil {
 			if isCapError(err) {
 				return fmt.Errorf("github import: %s: %w", entry.Path, err)
+			}
+			if ctx.Err() != nil {
+				return fmt.Errorf("github import: fetch aborted at %s: %w", entry.Path, ctx.Err())
 			}
 			slog.Warn("github import: file download failed", "path", entry.Path, "error", err)
 			continue
@@ -1268,7 +1244,7 @@ func resolveSkillDirFromTree(ctx context.Context, httpClient *http.Client, owner
 		// only the tree we already have (at most one extra raw fetch, never a
 		// directory crawl). Kept after the frontmatter pass so the bare repo
 		// root is never eligible here — the collision fix stays intact.
-		if dir, body, ok := acceptConventionalSkillDirFromTree(ctx, httpClient, rawPrefix, skillName, skillPaths); ok {
+		if dir, body, ok := acceptConventionalSkillDir(ctx, httpClient, rawPrefix, skillName, skillPaths, true); ok {
 			return dir, body, nil
 		}
 		return "", nil, skillMdNotFoundError(owner, repo, skillName)
@@ -1276,6 +1252,13 @@ func resolveSkillDirFromTree(ctx context.Context, httpClient *http.Client, owner
 
 	slog.Warn("github import: repository tree listing truncated", "owner", owner, "repo", repo, "branch", defaultBranch)
 	if dir, body, ok := findSkillDirFromConventionalPrefixes(ctx, httpClient, owner, repo, defaultBranch, rawPrefix, skillName); ok {
+		return dir, body, nil
+	}
+	// Same path-based acceptance as the untruncated branch, so a conventional
+	// skill with a display-name frontmatter imports identically regardless of
+	// whether GitHub truncated the tree. The tree can't prove absence here, so
+	// the helper probes each candidate directly.
+	if dir, body, ok := acceptConventionalSkillDir(ctx, httpClient, rawPrefix, skillName, skillPaths, false); ok {
 		return dir, body, nil
 	}
 	return "", nil, fmt.Errorf("repository %s/%s tree is too large to scan exhaustively for skill %s", owner, repo, skillName)
@@ -1293,23 +1276,36 @@ func conventionalSkillMdPaths(skillName string) []string {
 	}
 }
 
-// acceptConventionalSkillDirFromTree accepts a skill by its conventional path
-// when that path is present in the already-extracted tree SKILL.md set, without
-// requiring a frontmatter name match. It deliberately excludes the bare repo
-// root SKILL.md, which stays reachable only through the frontmatter pass, so a
-// root SKILL.md whose name collides with the slug can never be selected here.
-func acceptConventionalSkillDirFromTree(ctx context.Context, httpClient *http.Client, rawPrefix, skillName string, skillPaths []string) (string, []byte, bool) {
-	present := make(map[string]struct{}, len(skillPaths))
-	for _, p := range skillPaths {
+// acceptConventionalSkillDir accepts a skill by its conventional path
+// (skills/<name>/SKILL.md, etc.) without requiring a frontmatter name match,
+// restoring the pre-tree importer's lenient path-based acceptance. It never
+// accepts the bare repo root, so a root SKILL.md whose name collides with the
+// slug can only be selected through the frontmatter pass — the collision fix
+// stays intact.
+//
+// When treeComplete is true, the untruncated tree proves which conventional
+// paths exist, so absent candidates are skipped without a network call. When
+// the tree was truncated it can't prove absence, so each candidate is probed
+// directly (a missing candidate simply 404s and is skipped).
+func acceptConventionalSkillDir(ctx context.Context, httpClient *http.Client, rawPrefix, skillName string, treeSkillPaths []string, treeComplete bool) (string, []byte, bool) {
+	present := make(map[string]struct{}, len(treeSkillPaths))
+	for _, p := range treeSkillPaths {
 		present[p] = struct{}{}
 	}
 	for _, candidate := range conventionalSkillMdPaths(skillName) {
-		if _, ok := present[candidate]; !ok {
-			continue
+		if treeComplete {
+			if _, ok := present[candidate]; !ok {
+				continue // a complete tree proves this path is absent
+			}
 		}
 		body, err := fetchRawFile(ctx, httpClient, buildRawGitHubURL(rawPrefix, candidate))
 		if err != nil {
-			slog.Warn("skills.sh import: conventional SKILL.md fetch failed", "path", candidate, "error", err)
+			// With a complete tree the path was proven present, so a fetch
+			// error is unexpected and worth a breadcrumb; with a truncated tree
+			// this is just a probe miss.
+			if treeComplete {
+				slog.Warn("skills.sh import: conventional SKILL.md fetch failed", "path", candidate, "error", err)
+			}
 			continue
 		}
 		return skillDirFromSkillFilePath(candidate), body, true
@@ -1446,6 +1442,11 @@ func (e githubTreeEntry) size() int64 {
 // collectGitHubFiles recursively collects file entries from a GitHub directory listing.
 func collectGitHubFiles(ctx context.Context, httpClient *http.Client, entries []githubContentEntry, out *[]githubContentEntry, parentURL string) {
 	for _, entry := range entries {
+		// Stop descending once the context is cancelled; the caller checks
+		// ctx.Err() afterwards and aborts rather than importing a partial crawl.
+		if ctx.Err() != nil {
+			return
+		}
 		lower := strings.ToLower(entry.Name)
 		if lower == "skill.md" || lower == "license" || lower == "license.txt" || lower == "license.md" {
 			continue
@@ -2226,13 +2227,17 @@ const importFetchTimeout = 45 * time.Second
 
 // importFetchErrorResponse maps a fetch failure onto an HTTP status and message.
 // Cap violations become 413 (the skill is too large to import), an exhausted
-// deadline becomes 504 with an actionable hint, and everything else stays 502.
+// deadline becomes 504, a transiently unavailable source becomes a retryable
+// 503, and everything else stays 502.
 func importFetchErrorResponse(ctx context.Context, err error) (int, string) {
 	if isCapError(err) {
 		return http.StatusRequestEntityTooLarge, err.Error()
 	}
 	if errors.Is(err, context.DeadlineExceeded) || ctx.Err() == context.DeadlineExceeded {
 		return http.StatusGatewayTimeout, "skill import timed out fetching source files; the skill may be too large or the source too slow"
+	}
+	if errors.Is(err, errImportSourceUnavailable) {
+		return http.StatusServiceUnavailable, err.Error()
 	}
 	return http.StatusBadGateway, err.Error()
 }

--- a/server/internal/handler/skill.go
+++ b/server/internal/handler/skill.go
@@ -1245,8 +1245,10 @@ func fetchGitHubTree(ctx context.Context, httpClient *http.Client, owner, repo, 
 // frontmatter-verified match (a SKILL.md whose directory matches the skill
 // name), only considering the repository root when nothing deeper matches — so
 // a repo-root SKILL.md whose name happens to collide with the skill name no
-// longer captures the whole repository. When the tree is truncated it falls
-// back to a bounded per-prefix listing.
+// longer captures the whole repository. When frontmatter matching finds nothing
+// it falls back to accepting a conventional skill location by path (preserving
+// the pre-tree importer's lenient semantics). When the tree is truncated it
+// falls back to a bounded per-prefix listing.
 func resolveSkillDirFromTree(ctx context.Context, httpClient *http.Client, owner, repo, defaultBranch, rawPrefix, skillName string, tree []githubTreeEntry, truncated bool) (string, []byte, error) {
 	skillPaths := extractSkillMdPaths(tree)
 	preferred, remaining := partitionSkillMdPaths(skillName, skillPaths)
@@ -1257,6 +1259,18 @@ func resolveSkillDirFromTree(ctx context.Context, httpClient *http.Client, owner
 		if dir, body, ok := findMatchingSkillDirByFrontmatter(ctx, httpClient, rawPrefix, skillName, remaining); ok {
 			return dir, body, nil
 		}
+		// Frontmatter matching found nothing. Fall back to path-based
+		// acceptance so a skill living at a conventional location
+		// (skills/<name>/SKILL.md, etc.) still imports even when its
+		// frontmatter name doesn't byte-match the URL slug — e.g. `name: Foo`
+		// for slug `foo`. This restores the pre-tree importer's semantics and
+		// matches what the rate-limited legacy fallback already accepts, using
+		// only the tree we already have (at most one extra raw fetch, never a
+		// directory crawl). Kept after the frontmatter pass so the bare repo
+		// root is never eligible here — the collision fix stays intact.
+		if dir, body, ok := acceptConventionalSkillDirFromTree(ctx, httpClient, rawPrefix, skillName, skillPaths); ok {
+			return dir, body, nil
+		}
 		return "", nil, skillMdNotFoundError(owner, repo, skillName)
 	}
 
@@ -1265,6 +1279,42 @@ func resolveSkillDirFromTree(ctx context.Context, httpClient *http.Client, owner
 		return dir, body, nil
 	}
 	return "", nil, fmt.Errorf("repository %s/%s tree is too large to scan exhaustively for skill %s", owner, repo, skillName)
+}
+
+// conventionalSkillMdPaths returns the SKILL.md locations the importer accepts
+// by path (without a frontmatter name check) for a given skill slug. Order is
+// significant: it mirrors the pre-tree importer's probe order.
+func conventionalSkillMdPaths(skillName string) []string {
+	return []string{
+		"skills/" + skillName + "/SKILL.md",
+		".claude/skills/" + skillName + "/SKILL.md",
+		"plugin/skills/" + skillName + "/SKILL.md",
+		skillName + "/SKILL.md",
+	}
+}
+
+// acceptConventionalSkillDirFromTree accepts a skill by its conventional path
+// when that path is present in the already-extracted tree SKILL.md set, without
+// requiring a frontmatter name match. It deliberately excludes the bare repo
+// root SKILL.md, which stays reachable only through the frontmatter pass, so a
+// root SKILL.md whose name collides with the slug can never be selected here.
+func acceptConventionalSkillDirFromTree(ctx context.Context, httpClient *http.Client, rawPrefix, skillName string, skillPaths []string) (string, []byte, bool) {
+	present := make(map[string]struct{}, len(skillPaths))
+	for _, p := range skillPaths {
+		present[p] = struct{}{}
+	}
+	for _, candidate := range conventionalSkillMdPaths(skillName) {
+		if _, ok := present[candidate]; !ok {
+			continue
+		}
+		body, err := fetchRawFile(ctx, httpClient, buildRawGitHubURL(rawPrefix, candidate))
+		if err != nil {
+			slog.Warn("skills.sh import: conventional SKILL.md fetch failed", "path", candidate, "error", err)
+			continue
+		}
+		return skillDirFromSkillFilePath(candidate), body, true
+	}
+	return "", nil, false
 }
 
 // treeDownloadConcurrency bounds how many supporting files are downloaded in
@@ -1349,8 +1399,18 @@ func addSupportingFilesFromTree(ctx context.Context, httpClient *http.Client, re
 				if isCapError(err) {
 					return fmt.Errorf("github import: %s: %w", f.repoPath, err)
 				}
-				// Match the legacy loop's leniency: a single failed supporting
-				// file is logged and skipped, not fatal.
+				// A cancelled context (overall import deadline exceeded, or the
+				// client disconnecting) must abort, not be swallowed as a
+				// per-file skip: otherwise every remaining download fails the
+				// same way, g.Wait returns nil, and the user gets a bundle that
+				// looks complete but is silently missing files. Let it surface
+				// so importFetchErrorResponse maps the deadline to a readable
+				// 504.
+				if gctx.Err() != nil {
+					return fmt.Errorf("github import: fetch aborted at %s: %w", f.repoPath, gctx.Err())
+				}
+				// Otherwise match the legacy loop's leniency: a single failed
+				// supporting file is logged and skipped, not fatal.
 				slog.Warn("github import: file download failed", "path", f.repoPath, "error", err)
 				return nil
 			}

--- a/server/internal/handler/skill.go
+++ b/server/internal/handler/skill.go
@@ -1130,10 +1130,13 @@ func newSkillsShImportedSkill(skillMdBody []byte, skillName, rawURL, owner, repo
 }
 
 // addSupportingFilesViaCrawl is the legacy per-directory enumeration path, used
-// only as a fallback when the recursive tree is unavailable or truncated. It
-// lists skillDir via the contents API, recurses subdirectories, and downloads
-// each file. It stays lenient on a listing failure (returns with only SKILL.md)
-// to match prior behavior under GitHub API rate limiting.
+// as a fallback only for a truncated recursive tree (and by the github.com
+// importer). A tree-fetch failure no longer routes here — it returns a retryable
+// error instead. It lists skillDir via the contents API, recurses
+// subdirectories, and downloads each file. It stays lenient on a genuine listing
+// failure (returns with only SKILL.md, matching prior behavior under GitHub API
+// rate limiting) but treats a cancelled context as fatal so a mid-crawl deadline
+// or disconnect can't persist an incomplete bundle as a success.
 func addSupportingFilesViaCrawl(ctx context.Context, httpClient *http.Client, result *importedSkill, owner, repo, ref, skillDir string) error {
 	apiURL := buildGitHubContentsURL(owner, repo, skillDir, ref)
 	dirResp, err := doGitHubAPIGet(ctx, httpClient, apiURL)
@@ -1153,6 +1156,13 @@ func addSupportingFilesViaCrawl(ctx context.Context, httpClient *http.Client, re
 
 	var entries []githubContentEntry
 	if err := json.NewDecoder(dirResp.Body).Decode(&entries); err != nil {
+		// A cancelled context surfaces as a decode error when the deadline or a
+		// client disconnect lands while the response body is still being read.
+		// Treat it as fatal rather than swallowing it — otherwise the import is
+		// saved with a valid SKILL.md but zero supporting files.
+		if ctx.Err() != nil {
+			return fmt.Errorf("github import: directory listing read aborted: %w", ctx.Err())
+		}
 		slog.Warn("github import: failed to decode top-level directory listing", "url", apiURL, "error", err)
 		return nil
 	}

--- a/server/internal/handler/skill_test.go
+++ b/server/internal/handler/skill_test.go
@@ -887,6 +887,56 @@ func TestFetchFromClawHub_ContextCancelledMidDownloadAborts(t *testing.T) {
 	}
 }
 
+// A cancellation that lands while the top-level contents listing body is being
+// read (200 headers received, decode fails with "context canceled") must abort
+// the crawl, not be swallowed into a valid-SKILL.md/zero-files "success".
+func TestFetchFromSkillsSh_CrawlListingDecodeCancelledAborts(t *testing.T) {
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+	client, _ := newGitHubFixtureClient(t, func(w http.ResponseWriter, r *http.Request) {
+		switch r.Header.Get("X-Test-Original-Host") {
+		case "api.github.com":
+			switch r.URL.Path {
+			case "/repos/acme/skills":
+				writeJSON(w, http.StatusOK, map[string]any{"default_branch": "main"})
+			case "/repos/acme/skills/git/trees/main":
+				writeJSON(w, http.StatusOK, githubTreeResponse{
+					Tree:      []githubTreeEntry{{Path: "skills/foo/SKILL.md", Type: "blob"}},
+					Truncated: true,
+				})
+			case "/repos/acme/skills/contents/skills/foo":
+				// Flush 200 headers so the client sees a valid response, then
+				// cancel and block: the JSON decode of the body is torn down
+				// mid-stream and returns "context canceled".
+				w.WriteHeader(http.StatusOK)
+				if f, ok := w.(http.Flusher); ok {
+					f.Flush()
+				}
+				cancel()
+				<-r.Context().Done()
+			default:
+				http.NotFound(w, r)
+			}
+		case "raw.githubusercontent.com":
+			if r.URL.Path == "/acme/skills/main/skills/foo/SKILL.md" {
+				w.Write([]byte("---\nname: foo\n---\nbody"))
+				return
+			}
+			http.NotFound(w, r)
+		default:
+			http.NotFound(w, r)
+		}
+	})
+
+	_, err := fetchFromSkillsSh(ctx, client, "https://skills.sh/acme/skills/foo")
+	if err == nil {
+		t.Fatal("expected crawl listing decode to abort on cancellation")
+	}
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("error = %q, want context.Canceled", err.Error())
+	}
+}
+
 func TestImportFetchErrorResponse(t *testing.T) {
 	capErr := fmt.Errorf("%w: import bundle would contain 999 files", errImportCapExceeded)
 	if status, _ := importFetchErrorResponse(context.Background(), capErr); status != http.StatusRequestEntityTooLarge {

--- a/server/internal/handler/skill_test.go
+++ b/server/internal/handler/skill_test.go
@@ -24,6 +24,14 @@ func TestFetchFromSkillsSh_UsesEntryURLForNestedDirectories(t *testing.T) {
 			switch r.URL.Path {
 			case "/repos/acme/skills":
 				writeJSON(w, http.StatusOK, map[string]any{"default_branch": "main"})
+			case "/repos/acme/skills/git/trees/main":
+				// Truncated tree: resolution still succeeds by frontmatter, but
+				// enumeration falls through to the per-directory crawl exercised
+				// by this test.
+				writeJSON(w, http.StatusOK, githubTreeResponse{
+					Tree:      []githubTreeEntry{{Path: "skills/pptx/SKILL.md", Type: "blob"}},
+					Truncated: true,
+				})
 			case "/repos/acme/skills/contents/skills/pptx":
 				if got := r.URL.Query().Get("ref"); got != "main" {
 					t.Fatalf("top-level ref = %q, want main", got)
@@ -78,7 +86,7 @@ func TestFetchFromSkillsSh_UsesEntryURLForNestedDirectories(t *testing.T) {
 		case "raw.githubusercontent.com":
 			switch r.URL.Path {
 			case "/acme/skills/main/skills/pptx/SKILL.md":
-				w.Write([]byte("---\nname: PPTX\n---\ncontent"))
+				w.Write([]byte("---\nname: pptx\n---\ncontent"))
 			case "/acme/skills/main/skills/pptx/editing.md":
 				w.Write([]byte("editing"))
 			case "/acme/skills/main/skills/pptx/scripts/add_slide.py":
@@ -118,6 +126,11 @@ func TestFetchFromSkillsSh_FallbackDoesNotDoubleEscapeDirectoryNames(t *testing.
 			switch r.URL.Path {
 			case "/repos/acme/skills":
 				writeJSON(w, http.StatusOK, map[string]any{"default_branch": "main"})
+			case "/repos/acme/skills/git/trees/main":
+				writeJSON(w, http.StatusOK, githubTreeResponse{
+					Tree:      []githubTreeEntry{{Path: "skills/pptx/SKILL.md", Type: "blob"}},
+					Truncated: true,
+				})
 			case "/repos/acme/skills/contents/skills/pptx":
 				writeJSON(w, http.StatusOK, []githubContentEntry{
 					{
@@ -144,7 +157,7 @@ func TestFetchFromSkillsSh_FallbackDoesNotDoubleEscapeDirectoryNames(t *testing.
 		case "raw.githubusercontent.com":
 			switch r.URL.Path {
 			case "/acme/skills/main/skills/pptx/SKILL.md":
-				w.Write([]byte("---\nname: PPTX\n---\ncontent"))
+				w.Write([]byte("---\nname: pptx\n---\ncontent"))
 			case "/acme/skills/main/skills/pptx/my dir/note.md":
 				w.Write([]byte("note"))
 			default:
@@ -182,6 +195,11 @@ func TestFetchFromSkillsSh_LogsSubdirectoryFailures(t *testing.T) {
 			switch r.URL.Path {
 			case "/repos/acme/skills":
 				writeJSON(w, http.StatusOK, map[string]any{"default_branch": "main"})
+			case "/repos/acme/skills/git/trees/main":
+				writeJSON(w, http.StatusOK, githubTreeResponse{
+					Tree:      []githubTreeEntry{{Path: "skills/pptx/SKILL.md", Type: "blob"}},
+					Truncated: true,
+				})
 			case "/repos/acme/skills/contents/skills/pptx":
 				writeJSON(w, http.StatusOK, []githubContentEntry{
 					{
@@ -199,7 +217,7 @@ func TestFetchFromSkillsSh_LogsSubdirectoryFailures(t *testing.T) {
 		case "raw.githubusercontent.com":
 			switch r.URL.Path {
 			case "/acme/skills/main/skills/pptx/SKILL.md":
-				w.Write([]byte("---\nname: PPTX\n---\ncontent"))
+				w.Write([]byte("---\nname: pptx\n---\ncontent"))
 			default:
 				http.NotFound(w, r)
 			}
@@ -668,6 +686,207 @@ func TestFetchFromSkillsSh_ContextCancelledMidDownloadAborts(t *testing.T) {
 	}
 }
 
+// When the tree fetch fails (e.g. GitHub API rate limiting) for the real
+// api-gateway-skill shape — a same-named repo-root SKILL.md plus the actual
+// skill nested at a non-conventional path — the importer must NOT fall back to
+// resolving the repository root and "succeed" with the wrong SKILL.md and zero
+// files. It must return a retryable error.
+func TestFetchFromSkillsSh_TreeFetchFailureReturnsRetryableError(t *testing.T) {
+	var rootProbed bool
+	client, _ := newGitHubFixtureClient(t, func(w http.ResponseWriter, r *http.Request) {
+		switch r.Header.Get("X-Test-Original-Host") {
+		case "api.github.com":
+			switch r.URL.Path {
+			case "/repos/maton/api-gateway-skill":
+				writeJSON(w, http.StatusOK, map[string]any{"default_branch": "main"})
+			case "/repos/maton/api-gateway-skill/git/trees/main":
+				// Rate limited.
+				http.Error(w, "rate limited", http.StatusForbidden)
+			default:
+				http.NotFound(w, r)
+			}
+		case "raw.githubusercontent.com":
+			if r.URL.Path == "/maton/api-gateway-skill/main/SKILL.md" {
+				rootProbed = true
+				w.Write([]byte("---\nname: api-gateway\n---\nroot"))
+				return
+			}
+			http.NotFound(w, r)
+		default:
+			http.NotFound(w, r)
+		}
+	})
+
+	result, err := fetchFromSkillsSh(t.Context(), client, "https://skills.sh/maton/api-gateway-skill/api-gateway")
+	if err == nil {
+		t.Fatalf("expected a retryable error on tree fetch failure, got skill %+v", result)
+	}
+	if !errors.Is(err, errImportSourceUnavailable) {
+		t.Fatalf("error = %q, want errImportSourceUnavailable", err.Error())
+	}
+	if rootProbed {
+		t.Fatal("the colliding repo-root SKILL.md must not be probed/selected when the tree is unavailable")
+	}
+}
+
+// A skill at a conventional path with a display-name frontmatter must import
+// identically whether or not GitHub truncated the tree — the truncated branch
+// must also honor path-based acceptance (Elon review point 3).
+func TestFetchFromSkillsSh_TruncatedTreeAcceptsConventionalPathDespiteNameMismatch(t *testing.T) {
+	client, _ := newGitHubFixtureClient(t, func(w http.ResponseWriter, r *http.Request) {
+		switch r.Header.Get("X-Test-Original-Host") {
+		case "api.github.com":
+			switch r.URL.Path {
+			case "/repos/acme/skills":
+				writeJSON(w, http.StatusOK, map[string]any{"default_branch": "main"})
+			case "/repos/acme/skills/git/trees/main":
+				writeJSON(w, http.StatusOK, githubTreeResponse{
+					Tree:      []githubTreeEntry{{Path: "skills/foo/SKILL.md", Type: "blob"}},
+					Truncated: true,
+				})
+			case "/repos/acme/skills/contents/skills/foo":
+				writeJSON(w, http.StatusOK, []githubContentEntry{
+					{
+						Name:        "ref.md",
+						Path:        "skills/foo/ref.md",
+						Type:        "file",
+						DownloadURL: "https://raw.githubusercontent.com/acme/skills/main/skills/foo/ref.md",
+					},
+				})
+			default:
+				// skills/.claude/skills/plugin conventional-prefix listings 404.
+				http.NotFound(w, r)
+			}
+		case "raw.githubusercontent.com":
+			switch r.URL.Path {
+			case "/acme/skills/main/skills/foo/SKILL.md":
+				w.Write([]byte("---\nname: Foo\ndescription: display name\n---\nbody"))
+			case "/acme/skills/main/skills/foo/ref.md":
+				w.Write([]byte("ref"))
+			default:
+				http.NotFound(w, r)
+			}
+		default:
+			http.NotFound(w, r)
+		}
+	})
+
+	result, err := fetchFromSkillsSh(t.Context(), client, "https://skills.sh/acme/skills/foo")
+	if err != nil {
+		t.Fatalf("fetchFromSkillsSh (truncated): %v", err)
+	}
+	if result.name != "Foo" {
+		t.Fatalf("name = %q, want Foo", result.name)
+	}
+	if !equalStrings(importedFilePaths(result.files), []string{"ref.md"}) {
+		t.Fatalf("files = %v, want [ref.md]", importedFilePaths(result.files))
+	}
+}
+
+// The crawl fallback (used by the truncated-tree branch) must also treat a
+// mid-download cancellation as fatal, not silently drop the remaining files.
+func TestFetchFromSkillsSh_CrawlFallbackContextCancelledAborts(t *testing.T) {
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+	client, _ := newGitHubFixtureClient(t, func(w http.ResponseWriter, r *http.Request) {
+		switch r.Header.Get("X-Test-Original-Host") {
+		case "api.github.com":
+			switch r.URL.Path {
+			case "/repos/acme/skills":
+				writeJSON(w, http.StatusOK, map[string]any{"default_branch": "main"})
+			case "/repos/acme/skills/git/trees/main":
+				writeJSON(w, http.StatusOK, githubTreeResponse{
+					Tree:      []githubTreeEntry{{Path: "skills/foo/SKILL.md", Type: "blob"}},
+					Truncated: true,
+				})
+			case "/repos/acme/skills/contents/skills/foo":
+				writeJSON(w, http.StatusOK, []githubContentEntry{
+					{
+						Name:        "ref.md",
+						Path:        "skills/foo/ref.md",
+						Type:        "file",
+						DownloadURL: "https://raw.githubusercontent.com/acme/skills/main/skills/foo/ref.md",
+					},
+				})
+			default:
+				http.NotFound(w, r)
+			}
+		case "raw.githubusercontent.com":
+			switch r.URL.Path {
+			case "/acme/skills/main/skills/foo/SKILL.md":
+				w.Write([]byte("---\nname: foo\n---\nbody"))
+			case "/acme/skills/main/skills/foo/ref.md":
+				cancel()
+				<-r.Context().Done()
+			default:
+				http.NotFound(w, r)
+			}
+		default:
+			http.NotFound(w, r)
+		}
+	})
+
+	_, err := fetchFromSkillsSh(ctx, client, "https://skills.sh/acme/skills/foo")
+	if err == nil {
+		t.Fatal("expected crawl fallback to abort on cancellation")
+	}
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("error = %q, want context.Canceled", err.Error())
+	}
+}
+
+// ClawHub imports must likewise abort when the context is cancelled during a
+// supporting-file download rather than reporting a half-populated success.
+func TestFetchFromClawHub_ContextCancelledMidDownloadAborts(t *testing.T) {
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+	slug := "review-helper"
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/api/v1/skills/"+slug:
+			writeJSON(w, http.StatusOK, map[string]any{
+				"skill": map[string]any{
+					"slug": slug, "displayName": slug, "summary": "s",
+					"tags": map[string]string{"latest": "1.0.0"},
+				},
+			})
+		case r.URL.Path == "/api/v1/skills/"+slug+"/versions/1.0.0":
+			writeJSON(w, http.StatusOK, map[string]any{
+				"version": map[string]any{
+					"version": "1.0.0",
+					"files": []map[string]any{
+						{"path": "SKILL.md", "size": 16},
+						{"path": "ref.md", "size": 8},
+					},
+				},
+			})
+		case r.URL.Path == "/api/v1/skills/"+slug+"/file":
+			switch r.URL.Query().Get("path") {
+			case "SKILL.md":
+				w.Write([]byte("# Imported\n"))
+			case "ref.md":
+				cancel()
+				<-r.Context().Done()
+			default:
+				http.NotFound(w, r)
+			}
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	prev := clawHubAPIBase
+	clawHubAPIBase = srv.URL + "/api/v1"
+	t.Cleanup(func() { clawHubAPIBase = prev; srv.Close() })
+
+	_, err := fetchFromClawHub(ctx, &http.Client{}, "https://clawhub.ai/acme/"+slug)
+	if err == nil {
+		t.Fatal("expected ClawHub import to abort on cancellation")
+	}
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("error = %q, want context.Canceled", err.Error())
+	}
+}
+
 func TestImportFetchErrorResponse(t *testing.T) {
 	capErr := fmt.Errorf("%w: import bundle would contain 999 files", errImportCapExceeded)
 	if status, _ := importFetchErrorResponse(context.Background(), capErr); status != http.StatusRequestEntityTooLarge {
@@ -675,6 +894,10 @@ func TestImportFetchErrorResponse(t *testing.T) {
 	}
 	if status, _ := importFetchErrorResponse(context.Background(), context.DeadlineExceeded); status != http.StatusGatewayTimeout {
 		t.Fatalf("deadline error status = %d, want 504", status)
+	}
+	unavailErr := fmt.Errorf("%w: could not read tree", errImportSourceUnavailable)
+	if status, _ := importFetchErrorResponse(context.Background(), unavailErr); status != http.StatusServiceUnavailable {
+		t.Fatalf("source-unavailable status = %d, want 503", status)
 	}
 	if status, _ := importFetchErrorResponse(context.Background(), fmt.Errorf("boom")); status != http.StatusBadGateway {
 		t.Fatalf("generic error status = %d, want 502", status)
@@ -1183,6 +1406,13 @@ func TestFetchFromSkillsSh_OversizedSupportingFileFailsImport(t *testing.T) {
 			switch r.URL.Path {
 			case "/repos/acme/skills":
 				writeJSON(w, http.StatusOK, map[string]any{"default_branch": "main"})
+			case "/repos/acme/skills/git/trees/main":
+				// Truncated so enumeration goes through the crawl fallback,
+				// which enforces the per-file cap during download.
+				writeJSON(w, http.StatusOK, githubTreeResponse{
+					Tree:      []githubTreeEntry{{Path: "skills/foo/SKILL.md", Type: "blob"}},
+					Truncated: true,
+				})
 			case "/repos/acme/skills/contents/skills/foo":
 				writeJSON(w, http.StatusOK, []githubContentEntry{
 					{

--- a/server/internal/handler/skill_test.go
+++ b/server/internal/handler/skill_test.go
@@ -3,6 +3,7 @@ package handler
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"net/http"
@@ -362,9 +363,10 @@ func TestFetchFromSkillsSh_ResolvesRootLevelSkillMd(t *testing.T) {
 }
 
 func TestFetchFromSkillsSh_PrefersMostSpecificDirOverCollidingRoot(t *testing.T) {
-	// Multi-skill repo with an unrelated root SKILL.md (skill "other") plus a
-	// subdir skill "wanted". URL requests "wanted". Tree-first resolution must
-	// pick the most specific matching directory (extras/wanted) instead of
+	// Multi-skill repo whose root SKILL.md name collides with the URL slug
+	// ("wanted") — the real api-gateway-skill scenario — plus a deeper subdir
+	// skill also named "wanted". Tree-first resolution must pick the most
+	// specific matching directory (extras/wanted) instead of
 	// letting the repo-root SKILL.md hijack the request — this is the
 	// api-gateway-skill root-collision that used to make the importer crawl the
 	// whole repository.
@@ -388,7 +390,10 @@ func TestFetchFromSkillsSh_PrefersMostSpecificDirOverCollidingRoot(t *testing.T)
 		case "raw.githubusercontent.com":
 			switch r.URL.Path {
 			case "/acme/multi/main/SKILL.md":
-				w.Write([]byte("---\nname: other\n---\ncontent"))
+				// Root SKILL.md name collides byte-for-byte with the URL slug —
+				// the exact api-gateway-skill scenario. The most-specific
+				// (deeper) match must still win over this root.
+				w.Write([]byte("---\nname: wanted\n---\ncontent"))
 			case "/acme/multi/main/extras/wanted/SKILL.md":
 				w.Write([]byte("---\nname: wanted\ndescription: the right one\n---\ncontent"))
 			case "/acme/multi/main/extras/wanted/ref.md":
@@ -563,6 +568,103 @@ func TestFetchFromSkillsSh_TreeEnumerationImportsManyFiles(t *testing.T) {
 		if result.files[i-1].path >= result.files[i].path {
 			t.Fatalf("files not in stable sorted order: %q then %q", result.files[i-1].path, result.files[i].path)
 		}
+	}
+}
+
+// A skill sitting at a conventional path (skills/<name>/) must still import
+// even when its frontmatter name doesn't byte-match the URL slug (e.g.
+// `name: Foo` for slug `foo`). Tree-first resolution first tries frontmatter
+// matching, then falls back to accepting the conventional path — restoring the
+// pre-tree importer's lenient semantics without re-introducing the root
+// collision.
+func TestFetchFromSkillsSh_TreeAcceptsConventionalPathDespiteNameMismatch(t *testing.T) {
+	tree := []githubTreeEntry{
+		{Path: "skills/foo/SKILL.md", Type: "blob"},
+		{Path: "skills/foo/ref.md", Type: "blob", Size: 3},
+	}
+	client, _ := newGitHubFixtureClient(t, func(w http.ResponseWriter, r *http.Request) {
+		switch r.Header.Get("X-Test-Original-Host") {
+		case "api.github.com":
+			switch r.URL.Path {
+			case "/repos/acme/skills":
+				writeJSON(w, http.StatusOK, map[string]any{"default_branch": "main"})
+			case "/repos/acme/skills/git/trees/main":
+				writeJSON(w, http.StatusOK, githubTreeResponse{Tree: tree})
+			default:
+				http.NotFound(w, r)
+			}
+		case "raw.githubusercontent.com":
+			switch r.URL.Path {
+			case "/acme/skills/main/skills/foo/SKILL.md":
+				w.Write([]byte("---\nname: Foo\ndescription: display name\n---\nbody"))
+			case "/acme/skills/main/skills/foo/ref.md":
+				w.Write([]byte("ref"))
+			default:
+				http.NotFound(w, r)
+			}
+		default:
+			http.NotFound(w, r)
+		}
+	})
+
+	result, err := fetchFromSkillsSh(t.Context(), client, "https://skills.sh/acme/skills/foo")
+	if err != nil {
+		t.Fatalf("fetchFromSkillsSh: %v", err)
+	}
+	if result.name != "Foo" {
+		t.Fatalf("name = %q, want Foo (frontmatter display name)", result.name)
+	}
+	if !equalStrings(importedFilePaths(result.files), []string{"ref.md"}) {
+		t.Fatalf("files = %v, want [ref.md]", importedFilePaths(result.files))
+	}
+}
+
+// If the overall import context is cancelled mid-download, the import must
+// abort with an error rather than silently dropping the remaining files and
+// reporting success with a half-populated bundle.
+func TestFetchFromSkillsSh_ContextCancelledMidDownloadAborts(t *testing.T) {
+	tree := []githubTreeEntry{
+		{Path: "skills/foo/SKILL.md", Type: "blob"},
+		{Path: "skills/foo/ref.md", Type: "blob", Size: 3},
+	}
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+
+	client, _ := newGitHubFixtureClient(t, func(w http.ResponseWriter, r *http.Request) {
+		switch r.Header.Get("X-Test-Original-Host") {
+		case "api.github.com":
+			switch r.URL.Path {
+			case "/repos/acme/skills":
+				writeJSON(w, http.StatusOK, map[string]any{"default_branch": "main"})
+			case "/repos/acme/skills/git/trees/main":
+				writeJSON(w, http.StatusOK, githubTreeResponse{Tree: tree})
+			default:
+				http.NotFound(w, r)
+			}
+		case "raw.githubusercontent.com":
+			switch r.URL.Path {
+			case "/acme/skills/main/skills/foo/SKILL.md":
+				w.Write([]byte("---\nname: foo\n---\nbody"))
+			case "/acme/skills/main/skills/foo/ref.md":
+				// Simulate the overall deadline firing during the download
+				// phase: cancel the import context, then block until the
+				// request is torn down so fetchRawFile observes the cancel.
+				cancel()
+				<-r.Context().Done()
+			default:
+				http.NotFound(w, r)
+			}
+		default:
+			http.NotFound(w, r)
+		}
+	})
+
+	_, err := fetchFromSkillsSh(ctx, client, "https://skills.sh/acme/skills/foo")
+	if err == nil {
+		t.Fatal("expected import to abort on cancellation, not silently drop files")
+	}
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("error = %q, want a propagated context.Canceled", err.Error())
 	}
 }
 

--- a/server/internal/handler/skill_test.go
+++ b/server/internal/handler/skill_test.go
@@ -2,6 +2,8 @@ package handler
 
 import (
 	"bytes"
+	"context"
+	"fmt"
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
@@ -90,7 +92,7 @@ func TestFetchFromSkillsSh_UsesEntryURLForNestedDirectories(t *testing.T) {
 		}
 	})
 
-	result, err := fetchFromSkillsSh(client, "https://skills.sh/acme/skills/pptx")
+	result, err := fetchFromSkillsSh(t.Context(), client, "https://skills.sh/acme/skills/pptx")
 	if err != nil {
 		t.Fatalf("fetchFromSkillsSh: %v", err)
 	}
@@ -152,7 +154,7 @@ func TestFetchFromSkillsSh_FallbackDoesNotDoubleEscapeDirectoryNames(t *testing.
 		}
 	})
 
-	result, err := fetchFromSkillsSh(client, "https://skills.sh/acme/skills/pptx")
+	result, err := fetchFromSkillsSh(t.Context(), client, "https://skills.sh/acme/skills/pptx")
 	if err != nil {
 		t.Fatalf("fetchFromSkillsSh: %v", err)
 	}
@@ -212,7 +214,7 @@ func TestFetchFromSkillsSh_LogsSubdirectoryFailures(t *testing.T) {
 		slog.SetDefault(prev)
 	})
 
-	result, err := fetchFromSkillsSh(client, "https://skills.sh/acme/skills/pptx")
+	result, err := fetchFromSkillsSh(t.Context(), client, "https://skills.sh/acme/skills/pptx")
 	if err != nil {
 		t.Fatalf("fetchFromSkillsSh: %v", err)
 	}
@@ -246,19 +248,8 @@ func TestFetchFromSkillsSh_ResolvesAliasedSkillNamesViaFrontmatter(t *testing.T)
 				writeJSON(w, http.StatusOK, githubTreeResponse{
 					Tree: []githubTreeEntry{
 						{Path: "skills/composition-patterns/SKILL.md", Type: "blob"},
+						{Path: "skills/composition-patterns/rules.md", Type: "blob", Size: 5},
 						{Path: "skills/react-best-practices/SKILL.md", Type: "blob"},
-					},
-				})
-			case "/repos/vercel-labs/agent-skills/contents/skills/composition-patterns":
-				if got := r.URL.Query().Get("ref"); got != "main" {
-					t.Fatalf("resolved dir ref = %q, want main", got)
-				}
-				writeJSON(w, http.StatusOK, []githubContentEntry{
-					{
-						Name:        "rules.md",
-						Path:        "skills/composition-patterns/rules.md",
-						Type:        "file",
-						DownloadURL: "https://raw.githubusercontent.com/vercel-labs/agent-skills/main/skills/composition-patterns/rules.md",
 					},
 				})
 			default:
@@ -280,7 +271,7 @@ func TestFetchFromSkillsSh_ResolvesAliasedSkillNamesViaFrontmatter(t *testing.T)
 		}
 	})
 
-	result, err := fetchFromSkillsSh(client, "https://skills.sh/vercel-labs/agent-skills/vercel-composition-patterns")
+	result, err := fetchFromSkillsSh(t.Context(), client, "https://skills.sh/vercel-labs/agent-skills/vercel-composition-patterns")
 	if err != nil {
 		t.Fatalf("fetchFromSkillsSh: %v", err)
 	}
@@ -294,7 +285,7 @@ func TestFetchFromSkillsSh_ResolvesAliasedSkillNamesViaFrontmatter(t *testing.T)
 		t.Fatalf("files = %v, want %v", gotPaths, wantPaths)
 	}
 	if !containsString(*requests, "api.github.com /repos/vercel-labs/agent-skills/git/trees/main?recursive=1") {
-		t.Fatalf("expected fallback tree lookup, got requests %v", *requests)
+		t.Fatalf("expected primary tree lookup, got requests %v", *requests)
 	}
 	for _, request := range *requests {
 		if request == "raw.githubusercontent.com /vercel-labs/agent-skills/main/skills/react-best-practices/SKILL.md" {
@@ -316,43 +307,10 @@ func TestFetchFromSkillsSh_ResolvesRootLevelSkillMd(t *testing.T) {
 				}
 				writeJSON(w, http.StatusOK, githubTreeResponse{
 					Tree: []githubTreeEntry{
-						{Path: "README.md", Type: "blob"},
-						{Path: "SKILL.md", Type: "blob"},
+						{Path: "README.md", Type: "blob", Size: 8},
+						{Path: "SKILL.md", Type: "blob", Size: 40},
 						{Path: "assets", Type: "tree"},
-						{Path: "assets/logo.png", Type: "blob"},
-					},
-				})
-			case "/repos/alchaincyf/huashu-design/contents":
-				if got := r.URL.Query().Get("ref"); got != "master" {
-					t.Fatalf("root contents ref = %q, want master", got)
-				}
-				writeJSON(w, http.StatusOK, []githubContentEntry{
-					{
-						Name:        "README.md",
-						Path:        "README.md",
-						Type:        "file",
-						DownloadURL: "https://raw.githubusercontent.com/alchaincyf/huashu-design/master/README.md",
-					},
-					{
-						Name:        "SKILL.md",
-						Path:        "SKILL.md",
-						Type:        "file",
-						DownloadURL: "https://raw.githubusercontent.com/alchaincyf/huashu-design/master/SKILL.md",
-					},
-					{
-						Name: "assets",
-						Path: "assets",
-						Type: "dir",
-						URL:  "https://api.github.com/repos/alchaincyf/huashu-design/contents/assets?ref=master",
-					},
-				})
-			case "/repos/alchaincyf/huashu-design/contents/assets":
-				writeJSON(w, http.StatusOK, []githubContentEntry{
-					{
-						Name:        "logo.png",
-						Path:        "assets/logo.png",
-						Type:        "file",
-						DownloadURL: "https://raw.githubusercontent.com/alchaincyf/huashu-design/master/assets/logo.png",
+						{Path: "assets/logo.png", Type: "blob", Size: 8},
 					},
 				})
 			default:
@@ -374,7 +332,7 @@ func TestFetchFromSkillsSh_ResolvesRootLevelSkillMd(t *testing.T) {
 		}
 	})
 
-	result, err := fetchFromSkillsSh(client, "https://skills.sh/alchaincyf/huashu-design/huashu-design")
+	result, err := fetchFromSkillsSh(t.Context(), client, "https://skills.sh/alchaincyf/huashu-design/huashu-design")
 	if err != nil {
 		t.Fatalf("fetchFromSkillsSh: %v", err)
 	}
@@ -384,25 +342,32 @@ func TestFetchFromSkillsSh_ResolvesRootLevelSkillMd(t *testing.T) {
 	if !strings.HasPrefix(result.content, "---\nname: huashu-design") {
 		t.Fatalf("SKILL.md content not populated, got %q", result.content)
 	}
-	// assets/logo.png is intentionally dropped by addFile's binary-extension
-	// guard — PG TEXT columns can't store image bytes, and agents never read
-	// them as text. The directory is still walked (the listing request below
-	// confirms it), but the .png never reaches result.files.
+	// assets/logo.png is intentionally dropped by the binary-extension guard —
+	// PG TEXT columns can't store image bytes, and agents never read them as
+	// text. With tree-based enumeration the .png is filtered out from the tree
+	// metadata, so it is never even downloaded.
 	gotPaths := importedFilePaths(result.files)
 	wantPaths := []string{"README.md"}
 	if !equalStrings(gotPaths, wantPaths) {
 		t.Fatalf("files = %v, want %v", gotPaths, wantPaths)
 	}
-	if !containsString(*requests, "api.github.com /repos/alchaincyf/huashu-design/contents?ref=master") {
-		t.Fatalf("expected root contents listing, got %v", *requests)
+	if !containsString(*requests, "api.github.com /repos/alchaincyf/huashu-design/git/trees/master?recursive=1") {
+		t.Fatalf("expected recursive tree fetch, got %v", *requests)
+	}
+	for _, request := range *requests {
+		if request == "raw.githubusercontent.com /alchaincyf/huashu-design/master/assets/logo.png" {
+			t.Fatalf("binary asset must not be downloaded, got %v", *requests)
+		}
 	}
 }
 
-func TestFetchFromSkillsSh_RootSkillMdFastPathSkipsFrontmatterMismatch(t *testing.T) {
+func TestFetchFromSkillsSh_PrefersMostSpecificDirOverCollidingRoot(t *testing.T) {
 	// Multi-skill repo with an unrelated root SKILL.md (skill "other") plus a
-	// subdir skill "wanted". URL requests "wanted". The fast-path must reject
-	// the root SKILL.md on frontmatter mismatch and fall through to the tree
-	// fallback, which then resolves "wanted" correctly.
+	// subdir skill "wanted". URL requests "wanted". Tree-first resolution must
+	// pick the most specific matching directory (extras/wanted) instead of
+	// letting the repo-root SKILL.md hijack the request — this is the
+	// api-gateway-skill root-collision that used to make the importer crawl the
+	// whole repository.
 	client, requests := newGitHubFixtureClient(t, func(w http.ResponseWriter, r *http.Request) {
 		switch r.Header.Get("X-Test-Original-Host") {
 		case "api.github.com":
@@ -414,15 +379,7 @@ func TestFetchFromSkillsSh_RootSkillMdFastPathSkipsFrontmatterMismatch(t *testin
 					Tree: []githubTreeEntry{
 						{Path: "SKILL.md", Type: "blob"},
 						{Path: "extras/wanted/SKILL.md", Type: "blob"},
-					},
-				})
-			case "/repos/acme/multi/contents/extras/wanted":
-				writeJSON(w, http.StatusOK, []githubContentEntry{
-					{
-						Name:        "ref.md",
-						Path:        "extras/wanted/ref.md",
-						Type:        "file",
-						DownloadURL: "https://raw.githubusercontent.com/acme/multi/main/extras/wanted/ref.md",
+						{Path: "extras/wanted/ref.md", Type: "blob", Size: 3},
 					},
 				})
 			default:
@@ -444,7 +401,7 @@ func TestFetchFromSkillsSh_RootSkillMdFastPathSkipsFrontmatterMismatch(t *testin
 		}
 	})
 
-	result, err := fetchFromSkillsSh(client, "https://skills.sh/acme/multi/wanted")
+	result, err := fetchFromSkillsSh(t.Context(), client, "https://skills.sh/acme/multi/wanted")
 	if err != nil {
 		t.Fatalf("fetchFromSkillsSh: %v", err)
 	}
@@ -457,7 +414,7 @@ func TestFetchFromSkillsSh_RootSkillMdFastPathSkipsFrontmatterMismatch(t *testin
 		t.Fatalf("files = %v, want %v", gotPaths, wantPaths)
 	}
 	if !containsString(*requests, "api.github.com /repos/acme/multi/git/trees/main?recursive=1") {
-		t.Fatalf("expected tree fallback to run after fast-path frontmatter miss, got %v", *requests)
+		t.Fatalf("expected recursive tree lookup for skill resolution, got %v", *requests)
 	}
 }
 
@@ -509,7 +466,7 @@ func TestFetchFromSkillsSh_ReturnsActionableErrorForTruncatedTrees(t *testing.T)
 		}
 	})
 
-	_, err := fetchFromSkillsSh(client, "https://skills.sh/acme/skills/vercel-composition-patterns")
+	_, err := fetchFromSkillsSh(t.Context(), client, "https://skills.sh/acme/skills/vercel-composition-patterns")
 	if err == nil {
 		t.Fatal("expected error for truncated tree fallback miss")
 	}
@@ -521,12 +478,143 @@ func TestFetchFromSkillsSh_ReturnsActionableErrorForTruncatedTrees(t *testing.T)
 	}
 }
 
+// A skill whose tree exceeds the file-count cap must fail fast from the tree
+// metadata alone, before any supporting file is downloaded. This is the
+// api-gateway case: an over-limit skill returns a clear error in one tree call
+// instead of crawling hundreds of directories until the reverse proxy times
+// out (504).
+func TestFetchFromSkillsSh_TreeFileCountCapFailsFastWithoutDownloads(t *testing.T) {
+	tree := []githubTreeEntry{{Path: "skills/foo/SKILL.md", Type: "blob"}}
+	for i := 0; i < maxImportFileCount+1; i++ {
+		tree = append(tree, githubTreeEntry{
+			Path: fmt.Sprintf("skills/foo/ref-%d.md", i),
+			Type: "blob",
+			Size: 4,
+		})
+	}
+
+	client, requests := newGitHubFixtureClient(t, treeOnlySkillFixture(tree))
+
+	_, err := fetchFromSkillsSh(t.Context(), client, "https://skills.sh/acme/skills/foo")
+	if err == nil {
+		t.Fatal("expected file-count cap error")
+	}
+	if !isCapError(err) || !strings.Contains(err.Error(), "file limit") {
+		t.Fatalf("error = %q, want file-count cap error", err.Error())
+	}
+	for _, req := range *requests {
+		if strings.Contains(req, "ref-") {
+			t.Fatalf("no supporting file should be downloaded before the cap check, saw %q", req)
+		}
+	}
+}
+
+// The total-byte cap is likewise enforced from tree sizes before any download.
+func TestFetchFromSkillsSh_TreeTotalByteCapFailsFast(t *testing.T) {
+	tree := []githubTreeEntry{{Path: "skills/foo/SKILL.md", Type: "blob"}}
+	for i := 0; i < 9; i++ { // 9 MiB total > 8 MiB bundle cap, each at the per-file cap
+		tree = append(tree, githubTreeEntry{
+			Path: fmt.Sprintf("skills/foo/big-%d.md", i),
+			Type: "blob",
+			Size: maxImportFileSize,
+		})
+	}
+
+	client, requests := newGitHubFixtureClient(t, treeOnlySkillFixture(tree))
+
+	_, err := fetchFromSkillsSh(t.Context(), client, "https://skills.sh/acme/skills/foo")
+	if err == nil {
+		t.Fatal("expected total-byte cap error")
+	}
+	if !isCapError(err) || !strings.Contains(err.Error(), "byte limit") {
+		t.Fatalf("error = %q, want total-byte cap error", err.Error())
+	}
+	for _, req := range *requests {
+		if strings.Contains(req, "big-") {
+			t.Fatalf("no supporting file should be downloaded before the cap check, saw %q", req)
+		}
+	}
+}
+
+// A skill under the raised 256-file cap imports its full supporting-file set
+// from the tree via concurrent downloads, in a stable path order regardless of
+// completion timing.
+func TestFetchFromSkillsSh_TreeEnumerationImportsManyFiles(t *testing.T) {
+	const count = 40
+	tree := []githubTreeEntry{{Path: "skills/foo/SKILL.md", Type: "blob"}}
+	for i := 0; i < count; i++ {
+		tree = append(tree, githubTreeEntry{
+			Path: fmt.Sprintf("skills/foo/ref-%02d.md", i),
+			Type: "blob",
+			Size: 3,
+		})
+	}
+
+	client, _ := newGitHubFixtureClient(t, treeOnlySkillFixture(tree))
+
+	result, err := fetchFromSkillsSh(t.Context(), client, "https://skills.sh/acme/skills/foo")
+	if err != nil {
+		t.Fatalf("fetchFromSkillsSh: %v", err)
+	}
+	if len(result.files) != count {
+		t.Fatalf("imported %d files, want %d", len(result.files), count)
+	}
+	for i := 1; i < len(result.files); i++ {
+		if result.files[i-1].path >= result.files[i].path {
+			t.Fatalf("files not in stable sorted order: %q then %q", result.files[i-1].path, result.files[i].path)
+		}
+	}
+}
+
+func TestImportFetchErrorResponse(t *testing.T) {
+	capErr := fmt.Errorf("%w: import bundle would contain 999 files", errImportCapExceeded)
+	if status, _ := importFetchErrorResponse(context.Background(), capErr); status != http.StatusRequestEntityTooLarge {
+		t.Fatalf("cap error status = %d, want 413", status)
+	}
+	if status, _ := importFetchErrorResponse(context.Background(), context.DeadlineExceeded); status != http.StatusGatewayTimeout {
+		t.Fatalf("deadline error status = %d, want 504", status)
+	}
+	if status, _ := importFetchErrorResponse(context.Background(), fmt.Errorf("boom")); status != http.StatusBadGateway {
+		t.Fatalf("generic error status = %d, want 502", status)
+	}
+}
+
+// treeOnlySkillFixture serves the default branch, one recursive tree, the
+// skills/foo/SKILL.md body, and a stub body for every skills/foo/* supporting
+// file. It is the minimal fixture for exercising the tree-first primary path.
+func treeOnlySkillFixture(tree []githubTreeEntry) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		switch r.Header.Get("X-Test-Original-Host") {
+		case "api.github.com":
+			switch r.URL.Path {
+			case "/repos/acme/skills":
+				writeJSON(w, http.StatusOK, map[string]any{"default_branch": "main"})
+			case "/repos/acme/skills/git/trees/main":
+				writeJSON(w, http.StatusOK, githubTreeResponse{Tree: tree})
+			default:
+				http.NotFound(w, r)
+			}
+		case "raw.githubusercontent.com":
+			switch {
+			case r.URL.Path == "/acme/skills/main/skills/foo/SKILL.md":
+				w.Write([]byte("---\nname: foo\n---\nbody"))
+			case strings.HasPrefix(r.URL.Path, "/acme/skills/main/skills/foo/"):
+				w.Write([]byte("x"))
+			default:
+				http.NotFound(w, r)
+			}
+		default:
+			http.NotFound(w, r)
+		}
+	}
+}
+
 func TestFetchFromSkillsSh_AnthropicPptxIntegration(t *testing.T) {
 	if os.Getenv("MULTICA_RUN_SKILLS_SH_INTEGRATION") == "" {
 		t.Skip("set MULTICA_RUN_SKILLS_SH_INTEGRATION=1 to run live GitHub integration test")
 	}
 
-	result, err := fetchFromSkillsSh(&http.Client{Timeout: 30 * time.Second}, "https://skills.sh/anthropics/skills/pptx")
+	result, err := fetchFromSkillsSh(t.Context(), &http.Client{Timeout: 30 * time.Second}, "https://skills.sh/anthropics/skills/pptx")
 	if err != nil {
 		t.Fatalf("fetchFromSkillsSh: %v", err)
 	}
@@ -687,7 +775,7 @@ func TestFetchFromGitHub_TreeURLImportsSkillDirectory(t *testing.T) {
 		}
 	})
 
-	result, err := fetchFromGitHub(client, "https://github.com/anthropics/skills/tree/main/document-skills/pptx")
+	result, err := fetchFromGitHub(t.Context(), client, "https://github.com/anthropics/skills/tree/main/document-skills/pptx")
 	if err != nil {
 		t.Fatalf("fetchFromGitHub: %v", err)
 	}
@@ -757,7 +845,7 @@ func TestFetchFromGitHub_RepoRootResolvesDefaultBranch(t *testing.T) {
 		}
 	})
 
-	result, err := fetchFromGitHub(client, "https://github.com/alice/single-skill")
+	result, err := fetchFromGitHub(t.Context(), client, "https://github.com/alice/single-skill")
 	if err != nil {
 		t.Fatalf("fetchFromGitHub: %v", err)
 	}
@@ -789,7 +877,7 @@ func TestFetchFromGitHub_RepoRootMissingSKILLmdReturnsActionableError(t *testing
 		}
 	})
 
-	_, err := fetchFromGitHub(client, "https://github.com/alice/multi")
+	_, err := fetchFromGitHub(t.Context(), client, "https://github.com/alice/multi")
 	if err == nil {
 		t.Fatal("expected error for missing root SKILL.md")
 	}
@@ -821,7 +909,7 @@ func TestFetchFromGitHub_BlobURLImportsSpecificSkill(t *testing.T) {
 		}
 	})
 
-	result, err := fetchFromGitHub(client, "https://github.com/acme/skills/blob/main/skills/foo/SKILL.md")
+	result, err := fetchFromGitHub(t.Context(), client, "https://github.com/acme/skills/blob/main/skills/foo/SKILL.md")
 	if err != nil {
 		t.Fatalf("fetchFromGitHub: %v", err)
 	}
@@ -864,7 +952,7 @@ func TestNewRawFileRequest_AttachesGitHubTokenOnlyForRawGitHubHost(t *testing.T)
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			req, err := newRawFileRequest(tc.url)
+			req, err := newRawFileRequest(t.Context(), tc.url)
 			if err != nil {
 				t.Fatalf("newRawFileRequest(%q): %v", tc.url, err)
 			}
@@ -878,7 +966,7 @@ func TestNewRawFileRequest_AttachesGitHubTokenOnlyForRawGitHubHost(t *testing.T)
 func TestNewRawFileRequest_NoAuthHeaderWhenTokenUnset(t *testing.T) {
 	t.Setenv("GITHUB_TOKEN", "")
 
-	req, err := newRawFileRequest("https://raw.githubusercontent.com/acme/private/main/SKILL.md")
+	req, err := newRawFileRequest(t.Context(), "https://raw.githubusercontent.com/acme/private/main/SKILL.md")
 	if err != nil {
 		t.Fatalf("newRawFileRequest: %v", err)
 	}
@@ -895,7 +983,7 @@ func TestFetchRawFile_ReturnsErrorOnOversizedFile(t *testing.T) {
 	}))
 	t.Cleanup(server.Close)
 
-	_, err := fetchRawFile(&http.Client{}, server.URL+"/big.bin")
+	_, err := fetchRawFile(t.Context(), &http.Client{}, server.URL+"/big.bin")
 	if err == nil {
 		t.Fatal("expected error for oversized file, got nil")
 	}
@@ -975,7 +1063,7 @@ func TestFetchFromGitHub_OversizedSupportingFileFailsImport(t *testing.T) {
 			http.NotFound(w, r)
 		}
 	})
-	_, err := fetchFromGitHub(client, "https://github.com/acme/skills/tree/main/foo")
+	_, err := fetchFromGitHub(t.Context(), client, "https://github.com/acme/skills/tree/main/foo")
 	if err == nil {
 		t.Fatal("expected oversized supporting file to fail the whole import")
 	}
@@ -1018,7 +1106,7 @@ func TestFetchFromSkillsSh_OversizedSupportingFileFailsImport(t *testing.T) {
 			http.NotFound(w, r)
 		}
 	})
-	_, err := fetchFromSkillsSh(client, "https://skills.sh/acme/skills/foo")
+	_, err := fetchFromSkillsSh(t.Context(), client, "https://skills.sh/acme/skills/foo")
 	if err == nil {
 		t.Fatal("expected oversized supporting file to fail the whole import")
 	}
@@ -1060,7 +1148,7 @@ func TestFetchFromGitHub_ResolvesSlashRefAgainstAPI(t *testing.T) {
 			http.NotFound(w, r)
 		}
 	})
-	result, err := fetchFromGitHub(client, "https://github.com/acme/skills/tree/release/v2/skills/foo")
+	result, err := fetchFromGitHub(t.Context(), client, "https://github.com/acme/skills/tree/release/v2/skills/foo")
 	if err != nil {
 		t.Fatalf("fetchFromGitHub: %v", err)
 	}
@@ -1091,7 +1179,7 @@ func TestFetchFromGitHub_UnresolvableRefFailsLoudly(t *testing.T) {
 			http.NotFound(w, r)
 		}
 	})
-	_, err := fetchFromGitHub(client, "https://github.com/acme/skills/tree/nope/skills/foo")
+	_, err := fetchFromGitHub(t.Context(), client, "https://github.com/acme/skills/tree/nope/skills/foo")
 	if err == nil {
 		t.Fatal("expected error when no candidate ref resolves")
 	}
@@ -1131,7 +1219,7 @@ func TestFetchFromGitHub_FallsBackOnAPIBlocked(t *testing.T) {
 			http.NotFound(w, r)
 		}
 	})
-	result, err := fetchFromGitHub(client, "https://github.com/anthropics/skills/tree/main/skills/pptx")
+	result, err := fetchFromGitHub(t.Context(), client, "https://github.com/anthropics/skills/tree/main/skills/pptx")
 	if err != nil {
 		t.Fatalf("fetchFromGitHub: %v", err)
 	}
@@ -1185,7 +1273,7 @@ func TestFetchFromGitHub_SendsAuthHeaderWhenTokenSet(t *testing.T) {
 			http.NotFound(w, r)
 		}
 	})
-	if _, err := fetchFromGitHub(client, "https://github.com/acme/skills/tree/main/skills/foo"); err != nil {
+	if _, err := fetchFromGitHub(t.Context(), client, "https://github.com/acme/skills/tree/main/skills/foo"); err != nil {
 		t.Fatalf("fetchFromGitHub: %v", err)
 	}
 	mu.Lock()

--- a/server/internal/service/builtin_skills/multica-skill-importing/SKILL.md
+++ b/server/internal/service/builtin_skills/multica-skill-importing/SKILL.md
@@ -79,7 +79,7 @@ skill folder works too. The server:
   wrapper directory name and then the uploaded filename;
 - carries the supporting files — dropping any `SKILL.md`, dotfiles, `__MACOSX`,
   license files, and binary assets — under the same per-file (1 MiB),
-  per-bundle (8 MiB), and file-count (128) caps as URL imports, and rejects path
+  per-bundle (8 MiB), and file-count (256) caps as URL imports, and rejects path
   traversal (zip-slip);
 - returns the same structured result envelope and honors the same
   `--on-conflict` strategies as URL imports.


### PR DESCRIPTION
## Summary

Fixes the `504` users hit when importing large skills from skills.sh (e.g. `maton-ai/api-gateway-skill/api-gateway`) — MUL-5136.

**Root cause:** server-side import enumerated a skill's supporting files with a serial, per-directory GitHub *contents* crawl (one API call per directory) and no overall deadline. For a large mono-repo (`api-gateway-skill`: 819 dirs / 1164 files, with a `references/` tree of 200+ service subdirectories) that's hundreds of sequential requests, which exceeds the reverse-proxy gateway timeout and surfaces as `API error: 504`. Compounding it: the repo's root `SKILL.md` frontmatter `name` is also `api-gateway`, so the "single-skill repo root" fast-path treated the **entire repository root** as the skill directory and crawled everything.

## What changed

Both the skills.sh and github.com importers are reworked around a **single recursive git-tree fetch**:

1. **One tree call** replaces the per-directory crawl — the timeout root cause disappears.
2. **Arithmetic cap check on tree metadata before any download** — an over-limit skill fails fast with a clear `413` instead of timing out. (per-file 1 MiB / count / total 8 MiB)
3. **Most-specific skill-dir resolution** from the tree; the repository root is only used when nothing deeper matches — this dissolves the root `SKILL.md` name collision without a special case.
4. **Concurrent downloads** of the surviving files (`errgroup`, limit 8).

The legacy per-directory crawl is **kept as a fallback** for a **truncated tree** (GitHub truncates very large trees) and for the github.com importer. A skills.sh **tree-fetch failure** (typically GitHub API rate limiting, which also downs the contents API) does **not** fall back to the crawl — without the tree it can't resolve the skill directory safely (a same-named repo root would be re-selected) and the crawl would be empty anyway, so it returns a retryable **503** (`errImportSourceUnavailable`) instead. Cancellation/deadline is fatal on every supporting-file path (tree downloader, crawl listing/recursion/download, ClawHub) so a mid-download abort never persists a half-populated bundle.

Additional:
- **Overall fetch deadline** (`context.WithTimeout(r.Context(), 45s)`, below the gateway timeout) threaded through every import-path request via `NewRequestWithContext`, so a slow/oversized source returns a readable error (`504`/`413`) rather than the proxy severing the connection, and a client disconnect cancels the in-flight fetch.
- **`maxImportFileCount` 128 → 256** (and the aligned daemon `maxLocalSkillFileCount`) so reference-heavy skills like `api-gateway` (231 files / ~1 MB) import. The 8 MiB bundle cap remains the real guard; file count has no technical cliff (skills are progressively disclosed — only name+description enter the prompt; the 231 reference files sit on disk until an agent reads them).
- Built-in `multica-skill-importing` SKILL.md updated (file-count 128 → 256).

## Testing

- `gofmt` clean, `go build ./...` OK, `go vet` clean.
- Full `server/internal/handler` and `server/internal/daemon` packages pass on a freshly migrated DB.
- New/updated tests: tree-first resolution & enumeration fixtures; most-specific-over-colliding-root; **cap fast-fail** (file-count and total-byte, asserting no supporting file is downloaded); many-file concurrent import with stable ordering; `importFetchErrorResponse` status mapping.

## Notes

- Setting `GITHUB_TOKEN` in production (raises the anonymous 60/hr GitHub API limit to 5000/hr) is an ops follow-up, not part of this code change.
- Frontend needs no change: the import dialog already renders `err.message`, and the backend now returns a JSON error body before the proxy times out.

