### PR TITLE
feat(autopilot): add dry-run / test-trigger mode (WS-749)

### DIFF
--- a/server/cmd/multica/cmd_autopilot.go
+++ b/server/cmd/multica/cmd_autopilot.go
@@ -144,6 +144,7 @@ func init() {
 	// (no flags)
 
 	// trigger (manual run)
+	autopilotTriggerCmd.Flags().Bool("dry-run", false, "Preview the dispatch plan without persisting any state (no run/issue/task rows)")
 	autopilotTriggerCmd.Flags().String("output", "json", "Output format: table or json")
 
 	// runs
@@ -467,16 +468,45 @@ func runAutopilotTrigger(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("resolve autopilot: %w", err)
 	}
 
-	var run map[string]any
-	if err := client.PostJSON(ctx, "/api/autopilots/"+autopilotRef.ID+"/trigger", nil, &run); err != nil {
+	dryRun, _ := cmd.Flags().GetBool("dry-run")
+	path := "/api/autopilots/" + autopilotRef.ID + "/trigger"
+	if dryRun {
+		path += "?dry_run=true"
+	}
+
+	var result map[string]any
+	if err := client.PostJSON(ctx, path, nil, &result); err != nil {
 		return fmt.Errorf("trigger autopilot: %w", err)
 	}
 
 	output, _ := cmd.Flags().GetString("output")
 	if output == "json" {
-		return cli.PrintJSON(os.Stdout, run)
+		return cli.PrintJSON(os.Stdout, result)
 	}
-	fmt.Printf("Autopilot triggered: run %s (status: %s)\n", strVal(run, "id"), strVal(run, "status"))
+
+	if dryRun {
+		// Render the dispatch plan in a way that lets the user decide
+		// whether the autopilot would actually dispatch.
+		skipped, _ := result["skipped"].(bool)
+		ready, _ := result["ready"].(bool)
+		if skipped {
+			fmt.Printf("DRY RUN — would be SKIPPED: %s (%s)\n", strVal(result, "reason"), strVal(result, "reason_code"))
+		} else if !ready {
+			fmt.Printf("DRY RUN — agent NOT READY: %s\n", strVal(result, "readiness_reason"))
+		} else {
+			if t, ok := result["task_prompt"].(string); ok && t != "" {
+				fmt.Printf("DRY RUN — would run_only; prompt: %s\n", t)
+			} else {
+				fmt.Printf("DRY RUN — would create_issue: %s\n", strVal(result, "issue_title"))
+			}
+		}
+		if leader, ok := result["leader"].(map[string]any); ok {
+			fmt.Printf("Leader: %s (id=%s, runtime=%s, squad_resolved=%v)\n",
+				strVal(leader, "name"), strVal(leader, "id"), strVal(leader, "runtime_id"), strVal(leader, "squad_resolved"))
+		}
+		return nil
+	}
+	fmt.Printf("Autopilot triggered: run %s (status: %s)\n", strVal(result, "id"), strVal(result, "status"))
 	return nil
 }
 

--- a/server/cmd/multica/cmd_autopilot_dryrun_test.go
+++ b/server/cmd/multica/cmd_autopilot_dryrun_test.go
@@ -1,0 +1,103 @@
+package main
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+func newAutopilotTriggerTestCmd() *cobra.Command {
+	cmd := &cobra.Command{Use: "trigger"}
+	cmd.Flags().Bool("dry-run", false, "")
+	cmd.Flags().String("output", "json", "")
+	return cmd
+}
+
+// TestRunAutopilotTrigger_DryRunSendsQuery verifies the --dry-run flag appends
+// ?dry_run=true to the trigger POST and prints the returned dispatch plan as
+// JSON. The plan's DryRun marker must round-trip to stdout so a caller can
+// distinguish a preview from a real run.
+func TestRunAutopilotTrigger_DryRunSendsQuery(t *testing.T) {
+	const autopilotID = "11111111-1111-1111-1111-111111111111"
+
+	var capturedPath, capturedMethod string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/autopilots/"+autopilotID+"/trigger" {
+			http.NotFound(w, r)
+			return
+		}
+		capturedPath = r.URL.Path + "?" + r.URL.RawQuery
+		capturedMethod = r.Method
+		json.NewEncoder(w).Encode(map[string]any{
+			"autopilot_id":   autopilotID,
+			"execution_mode": "create_issue",
+			"dry_run":        true,
+			"skipped":        false,
+			"ready":          true,
+			"issue_title":    "nightly report 2026-07-22",
+			"leader": map[string]any{
+				"id":             "22222222-2222-2222-2222-222222222222",
+				"name":           "worker",
+				"squad_resolved": false,
+			},
+		})
+	}))
+	defer srv.Close()
+
+	t.Setenv("MULTICA_SERVER_URL", srv.URL)
+	t.Setenv("MULTICA_WORKSPACE_ID", "ws-1")
+	t.Setenv("MULTICA_TOKEN", "mat_test-token")
+
+	cmd := newAutopilotTriggerTestCmd()
+	_ = cmd.Flags().Set("dry-run", "true")
+
+	if err := runAutopilotTrigger(cmd, []string{autopilotID}); err != nil {
+		t.Fatalf("runAutopilotTrigger: %v", err)
+	}
+
+	if capturedMethod != http.MethodPost {
+		t.Fatalf("method = %q, want POST", capturedMethod)
+	}
+	if !strings.Contains(capturedPath, "dry_run=true") {
+		t.Fatalf("trigger path = %q, want query to contain dry_run=true", capturedPath)
+	}
+}
+
+// TestRunAutopilotTrigger_RealRunOmitsQuery is the regression guard: without
+// --dry-run the trigger POST must NOT carry the dry_run query, so the real
+// dispatch path runs unchanged.
+func TestRunAutopilotTrigger_RealRunOmitsQuery(t *testing.T) {
+	const autopilotID = "11111111-1111-1111-1111-111111111111"
+
+	var capturedQuery string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/autopilots/"+autopilotID+"/trigger" {
+			http.NotFound(w, r)
+			return
+		}
+		capturedQuery = r.URL.RawQuery
+		json.NewEncoder(w).Encode(map[string]any{
+			"id":     "run-1",
+			"status": "issue_created",
+		})
+	}))
+	defer srv.Close()
+
+	t.Setenv("MULTICA_SERVER_URL", srv.URL)
+	t.Setenv("MULTICA_WORKSPACE_ID", "ws-1")
+	t.Setenv("MULTICA_TOKEN", "mat_test-token")
+
+	cmd := newAutopilotTriggerTestCmd()
+	// dry-run flag left at its default (false).
+	if err := runAutopilotTrigger(cmd, []string{autopilotID}); err != nil {
+		t.Fatalf("runAutopilotTrigger: %v", err)
+	}
+	if strings.Contains(capturedQuery, "dry_run") {
+		t.Fatalf("real trigger query = %q, must not contain dry_run", capturedQuery)
+	}
+}
+

--- a/server/internal/handler/autopilot.go
+++ b/server/internal/handler/autopilot.go
@@ -2003,6 +2003,25 @@ func (h *Handler) TriggerAutopilot(w http.ResponseWriter, r *http.Request) {
 	if !h.requireAutopilotWrite(w, r, autopilot, workspaceID) {
 		return
 	}
+
+	// dry_run previews a dispatch without persisting state (WS-749). It reuses
+	// the same auth (requireAutopilotWrite) as a real trigger but performs NO
+	// writes - no autopilot_run, no issue, no task - so the active-status gate
+	// that protects real execution does not apply to a read-only preview. The
+	// plan reports what WOULD happen: resolved leader, readiness, and the
+	// rendered issue title/description (create_issue) or task prompt
+	// (run_only), plus the admission skip reason when the gate would reject.
+	dryRun, ok := parseBoolQueryDefault(w, r, "dry_run", false)
+	if !ok {
+		// Malformed value: parseBoolQueryDefault already wrote a 400. Return so
+		// we never fall through into a real dispatch on a typo.
+		return
+	}
+	if dryRun {
+		h.dryRunAutopilot(w, r, autopilot, workspaceID)
+		return
+	}
+
 	if autopilot.Status != "active" {
 		writeError(w, http.StatusBadRequest, "autopilot is not active")
 		return
@@ -2033,4 +2052,52 @@ func (h *Handler) TriggerAutopilot(w http.ResponseWriter, r *http.Request) {
 		resp.ReasonCode = &c
 	}
 	writeJSON(w, http.StatusOK, resp)
+}
+
+// dryRunAutopilot previews a manual trigger without persisting state
+// (WS-749). It resolves the same actor a real manual trigger would and
+// returns the PlanDispatch projection. The plan carries DryRun=true so a
+// caller can distinguish it from a real run response.
+//
+// Auth is identical to a real trigger (requireAutopilotWrite was already
+// enforced by TriggerAutopilot). The autopilot-active gate is skipped: a
+// read-only preview is safe on a paused/archived autopilot and the most
+// useful moment to preview is often right before activating a configuration.
+func (h *Handler) dryRunAutopilot(w http.ResponseWriter, r *http.Request, autopilot db.Autopilot, workspaceID string) {
+	userID, ok := requireUserID(w, r)
+	if !ok {
+		return
+	}
+	actorType, actorID := h.resolveActor(r, userID, workspaceID)
+	plan, err := h.AutopilotService.PlanDispatch(
+		r.Context(),
+		autopilot,
+		pgtype.UUID{},
+		"manual",
+		nil,
+		memberActorUserID(actorType, actorID),
+	)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to preview autopilot: "+err.Error())
+		return
+	}
+	writeJSON(w, http.StatusOK, plan)
+}
+
+// parseBoolQueryDefault parses a boolean query parameter. An absent or empty
+// value returns (def, true). A value strconv.ParseBool accepts
+// (true/1/t/yes, false/0/f/no) returns (parsed, true). Any other non-empty
+// value is a 400 (the error is written to w) and returns (def, false) so the
+// caller can return without falling through into a real dispatch on a typo.
+func parseBoolQueryDefault(w http.ResponseWriter, r *http.Request, key string, def bool) (bool, bool) {
+	raw := r.URL.Query().Get(key)
+	if raw == "" {
+		return def, true
+	}
+	v, err := strconv.ParseBool(raw)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, fmt.Sprintf("invalid boolean for %q: %s", key, raw))
+		return def, false
+	}
+	return v, true
 }

--- a/server/internal/handler/autopilot_dryrun_test.go
+++ b/server/internal/handler/autopilot_dryrun_test.go
@@ -1,0 +1,401 @@
+package handler
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/multica-ai/multica/server/internal/dispatch"
+)
+
+// dispatchPlanResponse mirrors the JSON the dry-run endpoint returns. Only the
+// fields the tests assert are typed; the rest ride along so a future additive
+// field does not break these tests.
+type dispatchPlanResponse struct {
+	AutopilotID      string         `json:"autopilot_id"`
+	ExecutionMode    string         `json:"execution_mode"`
+	AssigneeType     string         `json:"assignee_type"`
+	Source           string         `json:"source"`
+	DryRun           bool           `json:"dry_run"`
+	Skipped          bool           `json:"skipped"`
+	Reason           string         `json:"reason,omitempty"`
+	ReasonCode       string         `json:"reason_code,omitempty"`
+	Leader           *planAgentJSON `json:"leader,omitempty"`
+	Ready            bool           `json:"ready"`
+	ReadinessReason  string         `json:"readiness_reason,omitempty"`
+	IssueTitle       string         `json:"issue_title,omitempty"`
+	IssueDescription string         `json:"issue_description,omitempty"`
+	TaskPrompt       string         `json:"task_prompt,omitempty"`
+}
+
+type planAgentJSON struct {
+	ID            string `json:"id"`
+	Name          string `json:"name"`
+	RuntimeID     string `json:"runtime_id,omitempty"`
+	Archived      bool   `json:"archived"`
+	SquadResolved bool   `json:"squad_resolved"`
+}
+
+// createDryRunAutopilot creates an autopilot via the API as the workspace owner
+// (testUserID) with the requested mode/assignee and returns its id. Shared
+// setup for the dry-run handler tests.
+func createDryRunAutopilot(t *testing.T, body map[string]any) string {
+	t.Helper()
+	if body["title"] == nil {
+		body["title"] = "dryrun ap"
+	}
+	w := httptest.NewRecorder()
+	r := newRequest("POST", "/api/autopilots?workspace_id="+testWorkspaceID, body)
+	testHandler.CreateAutopilot(w, r)
+	if w.Code != http.StatusCreated {
+		t.Fatalf("CreateAutopilot: expected 201, got %d: %s", w.Code, w.Body.String())
+	}
+	var ap AutopilotResponse
+	if err := json.NewDecoder(w.Body).Decode(&ap); err != nil {
+		t.Fatalf("decode autopilot: %v", err)
+	}
+	t.Cleanup(func() {
+		ctx := context.Background()
+		testPool.Exec(ctx, `DELETE FROM autopilot_run WHERE autopilot_id = $1`, ap.ID)
+		testPool.Exec(ctx, `DELETE FROM autopilot_trigger WHERE autopilot_id = $1`, ap.ID)
+		testPool.Exec(ctx, `DELETE FROM autopilot_collaborator WHERE autopilot_id = $1`, ap.ID)
+		testPool.Exec(ctx, `DELETE FROM autopilot WHERE id = $1`, ap.ID)
+	})
+	return ap.ID
+}
+
+// callDryRunTrigger POSTs /trigger?dry_run=true as the given user (empty =
+// workspace owner) and decodes the dispatch plan. It asserts the endpoint
+// returned 200 and carried DryRun=true.
+func callDryRunTrigger(t *testing.T, userID, apID string) dispatchPlanResponse {
+	t.Helper()
+	w := httptest.NewRecorder()
+	path := "/api/autopilots/" + apID + "/trigger?workspace_id=" + testWorkspaceID + "&dry_run=true"
+	var r *http.Request
+	if userID == "" {
+		r = newRequest("POST", path, nil)
+	} else {
+		r = newRequestAs(userID, "POST", path, nil)
+	}
+	r = withURLParam(r, "id", apID)
+	testHandler.TriggerAutopilot(w, r)
+	if w.Code != http.StatusOK {
+		t.Fatalf("dry-run trigger: expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	var plan dispatchPlanResponse
+	if err := json.NewDecoder(w.Body).Decode(&plan); err != nil {
+		t.Fatalf("decode plan: %v", err)
+	}
+	if !plan.DryRun {
+		t.Fatalf("plan.DryRun = false, want true (must distinguish from a real run response)")
+	}
+	return plan
+}
+
+// assertNoDispatchSideEffects fails the test if a dry-run call left behind any
+// autopilot_run row for this autopilot. The dispatch flow's first write is
+// always the autopilot_run row (the unit of attribution/audit), so zero runs
+// implies zero downstream issue/task creation - this is the core WS-749
+// guarantee: zero persistent side effects.
+func assertNoDispatchSideEffects(t *testing.T, apID string) {
+	t.Helper()
+	ctx := context.Background()
+	var runs int
+	if err := testPool.QueryRow(ctx, `SELECT count(*) FROM autopilot_run WHERE autopilot_id = $1`, apID).Scan(&runs); err != nil {
+		t.Fatalf("count autopilot_run: %v", err)
+	}
+	if runs != 0 {
+		t.Fatalf("dry-run must not persist autopilot_run rows; got %d", runs)
+	}
+}
+
+// TestDryRunAutopilot_CreateIssue previews a create_issue dispatch and asserts
+// the plan reports a ready leader plus the rendered title/description, with no
+// run row written.
+func TestDryRunAutopilot_CreateIssue(t *testing.T) {
+	if testHandler == nil || testPool == nil {
+		t.Skip("database not available")
+	}
+	agentID := createHandlerTestAgent(t, "dryrun-createissue-agent", nil)
+	apID := createDryRunAutopilot(t, map[string]any{
+		"title":                "dryrun create_issue",
+		"assignee_id":          agentID,
+		"execution_mode":       "create_issue",
+		"description":          "watch the dashboard",
+		"issue_title_template": "nightly report {{date}}",
+	})
+
+	plan := callDryRunTrigger(t, "", apID)
+
+	if plan.ExecutionMode != "create_issue" {
+		t.Fatalf("execution_mode = %q, want create_issue", plan.ExecutionMode)
+	}
+	if plan.Skipped {
+		t.Fatalf("expected dispatch to proceed, got skipped: %s (%s)", plan.Reason, plan.ReasonCode)
+	}
+	if !plan.Ready {
+		t.Fatalf("expected ready leader, got not-ready: %s", plan.ReadinessReason)
+	}
+	if plan.Leader == nil || plan.Leader.ID != agentID {
+		t.Fatalf("leader not resolved to the assignee agent: %+v", plan.Leader)
+	}
+	if plan.Leader.SquadResolved {
+		t.Fatalf("direct agent assignee must not report squad_resolved")
+	}
+	if plan.TaskPrompt != "" {
+		t.Fatalf("create_issue must not populate task_prompt: %q", plan.TaskPrompt)
+	}
+	if !strings.Contains(plan.IssueTitle, "nightly report") {
+		t.Fatalf("issue title not rendered from template: %q", plan.IssueTitle)
+	}
+	if !strings.Contains(plan.IssueDescription, "watch the dashboard") {
+		t.Fatalf("issue description must preserve autopilot description: %q", plan.IssueDescription)
+	}
+	assertNoDispatchSideEffects(t, apID)
+}
+
+// TestDryRunAutopilot_RunOnly previews a run_only dispatch and asserts the plan
+// surfaces the autopilot description as the task prompt, with no issue fields
+// and no persistence.
+func TestDryRunAutopilot_RunOnly(t *testing.T) {
+	if testHandler == nil || testPool == nil {
+		t.Skip("database not available")
+	}
+	agentID := createHandlerTestAgent(t, "dryrun-runonly-agent", nil)
+	apID := createDryRunAutopilot(t, map[string]any{
+		"title":          "dryrun run_only",
+		"assignee_id":    agentID,
+		"execution_mode": "run_only",
+		"description":    "summarize today's PRs",
+	})
+
+	plan := callDryRunTrigger(t, "", apID)
+
+	if plan.ExecutionMode != "run_only" {
+		t.Fatalf("execution_mode = %q, want run_only", plan.ExecutionMode)
+	}
+	if plan.Skipped {
+		t.Fatalf("expected dispatch to proceed, got skipped: %s (%s)", plan.Reason, plan.ReasonCode)
+	}
+	if plan.TaskPrompt != "summarize today's PRs" {
+		t.Fatalf("task_prompt = %q, want the autopilot description", plan.TaskPrompt)
+	}
+	if plan.IssueTitle != "" || plan.IssueDescription != "" {
+		t.Fatalf("run_only must not populate issue fields: title=%q desc=%q", plan.IssueTitle, plan.IssueDescription)
+	}
+	assertNoDispatchSideEffects(t, apID)
+}
+
+// TestDryRunAutopilot_SquadAssigned previews a squad-assigned autopilot and
+// asserts the leader is resolved through the squad (SquadResolved=true) and
+// points at the squad's leader agent.
+func TestDryRunAutopilot_SquadAssigned(t *testing.T) {
+	if testHandler == nil || testPool == nil {
+		t.Skip("database not available")
+	}
+	ctx := context.Background()
+
+	leaderID := createHandlerTestAgent(t, "dryrun-squad-leader", nil)
+
+	var squadID string
+	if err := testPool.QueryRow(ctx, `
+		INSERT INTO squad (workspace_id, name, description, leader_id, creator_id)
+		VALUES ($1, 'dryrun squad', '', $2, $3)
+		RETURNING id
+	`, testWorkspaceID, leaderID, testUserID).Scan(&squadID); err != nil {
+		t.Fatalf("create squad: %v", err)
+	}
+	t.Cleanup(func() { testPool.Exec(context.Background(), `DELETE FROM squad WHERE id = $1`, squadID) })
+
+	apID := createDryRunAutopilot(t, map[string]any{
+		"title":          "dryrun squad ap",
+		"assignee_type":  "squad",
+		"assignee_id":    squadID,
+		"execution_mode": "create_issue",
+	})
+
+	plan := callDryRunTrigger(t, "", apID)
+
+	if plan.AssigneeType != "squad" {
+		t.Fatalf("assignee_type = %q, want squad", plan.AssigneeType)
+	}
+	if plan.Skipped {
+		t.Fatalf("expected squad dispatch to proceed, got skipped: %s (%s)", plan.Reason, plan.ReasonCode)
+	}
+	if plan.Leader == nil {
+		t.Fatalf("squad leader must be resolved")
+	}
+	if !plan.Leader.SquadResolved {
+		t.Fatalf("squad autopilot must report squad_resolved=true")
+	}
+	if plan.Leader.ID != leaderID {
+		t.Fatalf("leader id = %q, want squad leader %q", plan.Leader.ID, leaderID)
+	}
+	assertNoDispatchSideEffects(t, apID)
+}
+
+// TestDryRunAutopilot_NotReadyArchivedAgent pins the readiness-blocked path:
+// an archived agent is not ready, so the plan reports Skipped=true with a
+// target_unavailable reason code, and still writes nothing.
+func TestDryRunAutopilot_NotReadyArchivedAgent(t *testing.T) {
+	if testHandler == nil || testPool == nil {
+		t.Skip("database not available")
+	}
+	ctx := context.Background()
+
+	// Start from a ready, workspace-invocable agent (so the invocation gate
+	// would pass) and archive it, isolating the readiness failure. The autopilot
+	// is created first while the agent is still active (CreateAutopilot may
+	// reject an archived assignee), then the agent is archived for the preview.
+	agentID := createHandlerTestAgent(t, "dryrun-archived-agent", nil)
+	apID := createDryRunAutopilot(t, map[string]any{
+		"title":          "dryrun archived ap",
+		"assignee_id":    agentID,
+		"execution_mode": "create_issue",
+	})
+	if _, err := testPool.Exec(ctx, `UPDATE agent SET archived_at = now() WHERE id = $1`, agentID); err != nil {
+		t.Fatalf("archive agent: %v", err)
+	}
+
+	plan := callDryRunTrigger(t, "", apID)
+
+	if !plan.Skipped {
+		t.Fatalf("expected skip for archived agent, got proceed")
+	}
+	if plan.ReasonCode != string(dispatch.ReasonTargetUnavailable) {
+		t.Fatalf("reason_code = %q, want %q", plan.ReasonCode, dispatch.ReasonTargetUnavailable)
+	}
+	if plan.Ready {
+		t.Fatalf("expected Ready=false for archived agent")
+	}
+	if plan.Leader == nil {
+		t.Fatalf("leader should still be resolved so the plan names what is blocking")
+	}
+	if !plan.Leader.Archived {
+		t.Fatalf("leader must report archived=true")
+	}
+	assertNoDispatchSideEffects(t, apID)
+}
+
+// TestDryRunAutopilot_PausedAutopilotAllowed proves the dry-run path skips the
+// active-status gate a real trigger enforces: a paused autopilot still returns
+// a 200 plan rather than a 400 "autopilot is not active".
+func TestDryRunAutopilot_PausedAutopilotAllowed(t *testing.T) {
+	if testHandler == nil || testPool == nil {
+		t.Skip("database not available")
+	}
+	ctx := context.Background()
+	agentID := createHandlerTestAgent(t, "dryrun-paused-agent", nil)
+	apID := createDryRunAutopilot(t, map[string]any{
+		"title":          "dryrun paused ap",
+		"assignee_id":    agentID,
+		"execution_mode": "create_issue",
+	})
+	if _, err := testPool.Exec(ctx, `UPDATE autopilot SET status = 'paused' WHERE id = $1`, apID); err != nil {
+		t.Fatalf("pause autopilot: %v", err)
+	}
+
+	plan := callDryRunTrigger(t, "", apID)
+	if plan.Skipped {
+		t.Fatalf("paused-but-ready autopilot should still preview a proceed plan: %s", plan.Reason)
+	}
+	assertNoDispatchSideEffects(t, apID)
+}
+
+// TestDryRunAutopilot_StrangerForbidden enforces that dry-run reuses the real
+// trigger's auth: a workspace member who is neither creator nor collaborator
+// gets 403, not a free preview.
+func TestDryRunAutopilot_StrangerForbidden(t *testing.T) {
+	if testHandler == nil || testPool == nil {
+		t.Skip("database not available")
+	}
+	agentID := createHandlerTestAgent(t, "dryrun-stranger-agent", nil)
+	apID := createDryRunAutopilot(t, map[string]any{
+		"title":          "dryrun stranger ap",
+		"assignee_id":    agentID,
+		"execution_mode": "create_issue",
+	})
+	stranger := createPlainMember(t, "dryrun-stranger@example.com")
+
+	w := httptest.NewRecorder()
+	r := newRequestAs(stranger, "POST", "/api/autopilots/"+apID+"/trigger?workspace_id="+testWorkspaceID+"&dry_run=true", nil)
+	r = withURLParam(r, "id", apID)
+	testHandler.TriggerAutopilot(w, r)
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("stranger dry-run: expected 403, got %d: %s", w.Code, w.Body.String())
+	}
+	assertNoDispatchSideEffects(t, apID)
+}
+
+// TestDryRunAutopilot_InvalidBoolean rejects a malformed dry_run query value
+// with 400 rather than silently treating it as false (and dispatching for
+// real) - a typo must never trigger a real run.
+func TestDryRunAutopilot_InvalidBoolean(t *testing.T) {
+	if testHandler == nil || testPool == nil {
+		t.Skip("database not available")
+	}
+	agentID := createHandlerTestAgent(t, "dryrun-badbool-agent", nil)
+	apID := createDryRunAutopilot(t, map[string]any{
+		"title":          "dryrun badbool ap",
+		"assignee_id":    agentID,
+		"execution_mode": "create_issue",
+	})
+
+	w := httptest.NewRecorder()
+	r := newRequest("POST", "/api/autopilots/"+apID+"/trigger?workspace_id="+testWorkspaceID+"&dry_run=notabool", nil)
+	r = withURLParam(r, "id", apID)
+	testHandler.TriggerAutopilot(w, r)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("invalid dry_run boolean: expected 400, got %d: %s", w.Code, w.Body.String())
+	}
+	assertNoDispatchSideEffects(t, apID)
+}
+
+// TestDryRunAutopilot_NoPersistenceVsRealTrigger is the integration proof for
+// WS-749: a dry-run on a ready create_issue autopilot writes zero rows, while a
+// real trigger on the same autopilot writes exactly one autopilot_run. The
+// contrast is what proves the dry-run branch is genuinely side-effect-free
+// rather than merely returning early on a path that never persisted anyway.
+func TestDryRunAutopilot_NoPersistenceVsRealTrigger(t *testing.T) {
+	if testHandler == nil || testPool == nil {
+		t.Skip("database not available")
+	}
+	ctx := context.Background()
+	agentID := createHandlerTestAgent(t, "dryrun-contrast-agent", nil)
+	apID := createDryRunAutopilot(t, map[string]any{
+		"title":          "dryrun contrast ap",
+		"assignee_id":    agentID,
+		"execution_mode": "create_issue",
+	})
+
+	// Dry-run: zero persistence.
+	callDryRunTrigger(t, "", apID)
+	assertNoDispatchSideEffects(t, apID)
+
+	// Real trigger: exactly one run row, and an issue created.
+	w := httptest.NewRecorder()
+	r := newRequest("POST", "/api/autopilots/"+apID+"/trigger?workspace_id="+testWorkspaceID, nil)
+	r = withURLParam(r, "id", apID)
+	testHandler.TriggerAutopilot(w, r)
+	if w.Code != http.StatusOK {
+		t.Fatalf("real trigger: expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var runs int
+	if err := testPool.QueryRow(ctx, `SELECT count(*) FROM autopilot_run WHERE autopilot_id = $1`, apID).Scan(&runs); err != nil {
+		t.Fatalf("count runs after real trigger: %v", err)
+	}
+	if runs != 1 {
+		t.Fatalf("real trigger must persist exactly 1 autopilot_run; got %d", runs)
+	}
+	var issues int
+	if err := testPool.QueryRow(ctx, `SELECT count(*) FROM issue WHERE workspace_id = $1 AND title LIKE 'dryrun contrast ap%'`, testWorkspaceID).Scan(&issues); err != nil {
+		t.Fatalf("count issues after real trigger: %v", err)
+	}
+	if issues < 1 {
+		t.Fatalf("real trigger must create at least 1 issue; got %d", issues)
+	}
+}

--- a/server/internal/service/autopilot.go
+++ b/server/internal/service/autopilot.go
@@ -146,6 +146,198 @@ func (s *AutopilotService) DispatchAutopilotManual(
 	return s.dispatchAutopilot(ctx, autopilot, triggerID, "manual", payload, pgtype.Timestamptz{}, pgtype.UUID{}, actorUserID)
 }
 
+// DispatchPlan is the projected outcome of triggering an autopilot, computed
+// without any persistent side effect (WS-749: dry-run / test-trigger mode). It
+// answers "what would happen if I triggered this now": which agent/leader
+// would run, whether it is ready, whether the admission gate would skip it
+// (and why), and - for create_issue - the rendered issue title/description,
+// or - for run_only - the task prompt.
+//
+// PlanDispatch produces this. A real dispatch resolves the same leader, runs
+// the same admission gate, and renders the same title/description/prompt, so a
+// dry run is a faithful preview of a real run - without creating an
+// autopilot_run, issue, or task.
+type DispatchPlan struct {
+	AutopilotID   string `json:"autopilot_id"`
+	ExecutionMode string `json:"execution_mode"`
+	AssigneeType  string `json:"assignee_type"`
+	// Source is the dispatch source this plan previewed (manual / webhook /
+	// schedule). Mirrors autopilot_run.source.
+	Source string `json:"source"`
+	// DryRun is always true on a DispatchPlan; it lets a caller that round-trips
+	// the JSON distinguish a plan from a real run response of the same shape.
+	DryRun bool `json:"dry_run"`
+	// Skipped reports whether the admission gate would reject the dispatch
+	// (assignee gone, archived, runtime offline for run_only, or invocation not
+	// allowed). When true the dispatch would record a `skipped` run and create
+	// no issue/task; Reason/ReasonCode explain why. create_issue with a merely
+	// offline runtime is NOT skipped (the audit-trail exception), though Ready
+	// still reports false.
+	Skipped    bool                 `json:"skipped"`
+	Reason     string               `json:"reason,omitempty"`
+	ReasonCode dispatch.ReasonCode  `json:"reason_code,omitempty"`
+	Leader     *DispatchPlanAgent   `json:"leader,omitempty"`
+	Ready      bool                 `json:"ready"`
+	ReadinessReason string         `json:"readiness_reason,omitempty"`
+	// IssueTitle is the rendered title for create_issue mode (issue-title
+	// template interpolated against the would-be run time). Empty for run_only.
+	IssueTitle string `json:"issue_title,omitempty"`
+	// IssueDescription is the rendered description for create_issue mode
+	// (autopilot description + the autopilot run system note, plus the webhook
+	// payload block when source=webhook). Empty for run_only.
+	IssueDescription string `json:"issue_description,omitempty"`
+	// TaskPrompt is the prompt that would be sent to the agent in run_only
+	// mode - the autopilot's description, which the CLI surfaces as the task
+	// prompt. Empty for create_issue.
+	TaskPrompt string `json:"task_prompt,omitempty"`
+	Trigger    DispatchPlanTrigger `json:"trigger"`
+}
+
+// DispatchPlanAgent is the resolved executing agent a dispatch would run as:
+// the assignee for assignee_type=agent, or the squad leader for
+// assignee_type=squad. Nil on the plan when the leader could not be resolved.
+type DispatchPlanAgent struct {
+	ID   string `json:"id"`
+	Name string `json:"name"`
+	// RuntimeID is the bound runtime (empty when the agent has no runtime).
+	RuntimeID string `json:"runtime_id,omitempty"`
+	// Archived reports whether the agent is archived_at.
+	Archived bool `json:"archived"`
+	// SquadResolved is true when the leader was resolved through a squad
+	// (assignee_type=squad) rather than being the direct assignee.
+	SquadResolved bool `json:"squad_resolved"`
+}
+
+// DispatchPlanTrigger summarizes the trigger source and payload this plan
+// previewed. Payload is the raw webhook payload bytes (omitted when nil/empty),
+// mirrored from the would-be autopilot_run.trigger_payload.
+type DispatchPlanTrigger struct {
+	Source  string          `json:"source"`
+	Payload json.RawMessage `json:"payload,omitempty"`
+}
+
+// PlanDispatch projects what a real dispatch of autopilot would do, without
+// persisting any state. It is the shared core of the dry-run / test-trigger mode
+// (WS-749): the CLI `multica autopilot trigger <id> --dry-run` flag and
+// `POST /api/autopilots/{id}/trigger?dry_run=true` both return this plan.
+//
+// It performs NO writes - no autopilot_run, no issue, no task - and is safe to
+// call for previewing a configuration. It runs the same admission gate
+// (shouldSkipDispatch), resolves the same leader (resolveAutopilotLeader),
+// checks the same runtime readiness (AgentReadiness), and renders the same
+// issue title/description (create_issue) or task prompt (run_only) that a real
+// dispatch would, so the preview matches reality.
+//
+// actorUserID carries the triggering member for a manual preview so the
+// invocation gate runs against the clicker's access (same as a real manual
+// trigger); pass an invalid UUID to preview the automation path (schedule /
+// webhook), which gates against the autopilot creator.
+func (s *AutopilotService) PlanDispatch(
+	ctx context.Context,
+	autopilot db.Autopilot,
+	triggerID pgtype.UUID,
+	source string,
+	payload []byte,
+	actorUserID pgtype.UUID,
+) (*DispatchPlan, error) {
+	plan := &DispatchPlan{
+		AutopilotID:   util.UUIDToString(autopilot.ID),
+		ExecutionMode: autopilot.ExecutionMode,
+		AssigneeType:  autopilot.AssigneeType,
+		Source:        source,
+		DryRun:        true,
+		Trigger: DispatchPlanTrigger{
+			Source:  source,
+			Payload: payloadJSON(payload),
+		},
+	}
+
+	// Admission gate: the same pre-flight check a real dispatch runs. For a
+	// manual preview actorUserID is the clicker; for an automation preview it
+	// is invalid and the gate falls back to the autopilot creator.
+	reason, code, skip := s.shouldSkipDispatch(ctx, autopilot, actorUserID)
+	plan.Skipped = skip
+	plan.Reason = reason
+	plan.ReasonCode = code
+
+	// Resolve the leader and check readiness regardless of skip outcome, so the
+	// plan names who/what is blocking even when the gate rejects the dispatch.
+	leader, squadResolved, err := s.resolveAutopilotLeader(ctx, autopilot)
+	if err == nil {
+		plan.Leader = dispatchPlanAgent(leader, squadResolved)
+		ready, readyReason, readyErr := AgentReadiness(ctx, s.Queries, leader)
+		if readyErr != nil {
+			// Transient runtime lookup error. shouldSkipDispatch fails open
+			// for this case (does not skip), so mirror that: report readiness
+			// as unknown rather than fabricating a "not ready" verdict.
+			plan.Ready = false
+			plan.ReadinessReason = "failed to load runtime"
+		} else {
+			plan.Ready = ready
+			plan.ReadinessReason = readyReason
+		}
+	}
+	// else: leader resolution failed; shouldSkipDispatch already set the skip
+	// reason/code and Leader stays nil.
+
+	// Render the projected output only when the dispatch would actually
+	// proceed (create_issue's offline-runtime audit-trail exception is NOT
+	// skipped, so it still renders).
+	if !skip {
+		s.renderDispatchPlanOutput(ctx, autopilot, triggerID, source, payload, plan)
+	}
+	return plan, nil
+}
+
+// renderDispatchPlanOutput fills in the mode-specific preview fields: the
+// rendered issue title/description for create_issue, or the task prompt for
+// run_only. Rendering uses a synthetic autopilot_run anchored at "now" so the
+// {{date}} template and the "triggered at" timestamp reflect what a real run
+// would produce - the real dispatch path renders from a just-inserted run row
+// whose TriggeredAt is the same effective "now".
+func (s *AutopilotService) renderDispatchPlanOutput(ctx context.Context, ap db.Autopilot, triggerID pgtype.UUID, source string, payload []byte, plan *DispatchPlan) {
+	now := pgtype.Timestamptz{Time: time.Now().UTC(), Valid: true}
+	synthRun := db.AutopilotRun{
+		AutopilotID:    ap.ID,
+		Source:         source,
+		TriggerPayload: payload,
+		TriggeredAt:    now,
+		CreatedAt:      now,
+	}
+	triggerTimezone := s.resolveAutopilotTriggerTimezone(ctx, triggerID)
+	switch ap.ExecutionMode {
+	case "create_issue":
+		plan.IssueTitle = s.interpolateTemplate(ap, synthRun, triggerTimezone)
+		plan.IssueDescription = s.buildIssueDescription(ap, synthRun, triggerTimezone).String
+	case "run_only":
+		// The autopilot description IS the task prompt (CLI --description is
+		// documented as "used as task prompt"). The enqueued task row's
+		// TriggerSummary is the truncated autopilot title; we surface the full
+		// description here as the prompt the agent would receive.
+		plan.TaskPrompt = ap.Description.String
+	}
+}
+
+// dispatchPlanAgent maps a resolved agent row to its plan representation.
+func dispatchPlanAgent(agent db.Agent, squadResolved bool) *DispatchPlanAgent {
+	return &DispatchPlanAgent{
+		ID:            util.UUIDToString(agent.ID),
+		Name:          agent.Name,
+		RuntimeID:     util.UUIDToString(agent.RuntimeID),
+		Archived:      agent.ArchivedAt.Valid,
+		SquadResolved: squadResolved,
+	}
+}
+
+// payloadJSON returns payload as json.RawMessage for direct JSON marshaling,
+// or nil when the payload is empty so the field omits from the response.
+func payloadJSON(payload []byte) json.RawMessage {
+	if len(payload) == 0 {
+		return nil
+	}
+	return json.RawMessage(payload)
+}
+
 // AdmitAutopilotWebhookDelivery creates or reuses the idempotent run for a
 // durable webhook delivery without executing its downstream issue/task side
 // effect. The HTTP ingress calls this synchronously so the public webhook

--- a/server/internal/service/autopilot_dryrun_test.go
+++ b/server/internal/service/autopilot_dryrun_test.go
@@ -1,0 +1,171 @@
+package service
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/multica-ai/multica/server/internal/util"
+	db "github.com/multica-ai/multica/server/pkg/db/generated"
+)
+
+// TestPayloadJSON pins the omit-empty contract for DispatchPlanTrigger.Payload:
+// an empty payload must serialize to a nil (omitted) field so a manual preview
+// does not echo a spurious null, while a real webhook payload round-trips
+// verbatim as raw JSON.
+func TestPayloadJSON(t *testing.T) {
+	if got := payloadJSON(nil); got != nil {
+		t.Fatalf("payloadJSON(nil) = %v, want nil", got)
+	}
+	if got := payloadJSON([]byte{}); got != nil {
+		t.Fatalf("payloadJSON(empty) = %v, want nil", got)
+	}
+
+	raw := []byte(`{"event":"github.pull_request.opened"}`)
+	got := payloadJSON(raw)
+	if string(got) != string(raw) {
+		t.Fatalf("payloadJSON = %q, want %q", got, raw)
+	}
+	// Must marshal as raw JSON, not a base64 []byte.
+	out, err := json.Marshal(struct {
+		Payload json.RawMessage `json:"payload,omitempty"`
+	}{Payload: got})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if !strings.Contains(string(out), `"event":"github.pull_request.opened"`) {
+		t.Fatalf("payload did not marshal as raw JSON: %s", out)
+	}
+}
+
+// TestDispatchPlanAgent maps the resolved agent row to its plan representation,
+// including archived detection (ArchivedAt.Valid) and the squad-resolved flag.
+func TestDispatchPlanAgent(t *testing.T) {
+	id := pgtype.UUID{Bytes: [16]byte{1, 2, 3, 4}, Valid: true}
+	rt := pgtype.UUID{Bytes: [16]byte{5, 6, 7, 8}, Valid: true}
+
+	t.Run("active agent with runtime", func(t *testing.T) {
+		a := db.Agent{ID: id, Name: "worker", RuntimeID: rt}
+		got := dispatchPlanAgent(a, false)
+		if got.ID != util.UUIDToString(id) || got.Name != "worker" {
+			t.Fatalf("unexpected agent mapping: %+v", got)
+		}
+		if got.RuntimeID != util.UUIDToString(rt) {
+			t.Fatalf("runtime id = %q, want %q", got.RuntimeID, util.UUIDToString(rt))
+		}
+		if got.Archived {
+			t.Fatalf("active agent must not report archived")
+		}
+		if got.SquadResolved {
+			t.Fatalf("direct assignee must not report squad_resolved")
+		}
+	})
+
+	t.Run("archived agent", func(t *testing.T) {
+		a := db.Agent{ID: id, Name: "retired", ArchivedAt: pgtype.Timestamptz{Time: time.Now().UTC(), Valid: true}}
+		got := dispatchPlanAgent(a, false)
+		if !got.Archived {
+			t.Fatalf("archived agent must report archived=true")
+		}
+	})
+
+	t.Run("squad-resolved leader", func(t *testing.T) {
+		a := db.Agent{ID: id, Name: "leader"}
+		got := dispatchPlanAgent(a, true)
+		if !got.SquadResolved {
+			t.Fatalf("squad leader must report squad_resolved=true")
+		}
+	})
+
+	t.Run("no runtime bound", func(t *testing.T) {
+		a := db.Agent{ID: id, Name: "runtimeless"}
+		got := dispatchPlanAgent(a, false)
+		if got.RuntimeID != "" {
+			t.Fatalf("absent runtime must serialize empty, got %q", got.RuntimeID)
+		}
+	})
+}
+
+// TestRenderDispatchPlanOutput_CreateIssue verifies the create_issue preview
+// renders the interpolated title and full description from a synthetic run,
+// without any DB access (dry-run passes an invalid triggerID so the timezone
+// resolver short-circuits to UTC).
+func TestRenderDispatchPlanOutput_CreateIssue(t *testing.T) {
+	s := &AutopilotService{}
+	ap := db.Autopilot{
+		Description:        pgtype.Text{String: "watch the dashboard", Valid: true},
+		IssueTitleTemplate: pgtype.Text{String: "nightly report {{date}}", Valid: true},
+		ExecutionMode:      "create_issue",
+	}
+	plan := &DispatchPlan{}
+	s.renderDispatchPlanOutput(nil, ap, pgtype.UUID{}, "schedule", nil, plan)
+
+	if plan.TaskPrompt != "" {
+		t.Fatalf("create_issue must not populate task_prompt: %q", plan.TaskPrompt)
+	}
+	if !strings.HasPrefix(plan.IssueTitle, "nightly report ") {
+		t.Fatalf("issue title not rendered from template: %q", plan.IssueTitle)
+	}
+	if !strings.Contains(plan.IssueDescription, "watch the dashboard") {
+		t.Fatalf("description must preserve autopilot description: %q", plan.IssueDescription)
+	}
+	if !strings.Contains(plan.IssueDescription, "Autopilot run triggered at") {
+		t.Fatalf("description must include the run system note: %q", plan.IssueDescription)
+	}
+}
+
+// TestRenderDispatchPlanOutput_RunOnly verifies the run_only preview surfaces
+// the autopilot description as the task prompt the agent would receive.
+func TestRenderDispatchPlanOutput_RunOnly(t *testing.T) {
+	s := &AutopilotService{}
+	ap := db.Autopilot{
+		Description:   pgtype.Text{String: "summarize today's PRs", Valid: true},
+		ExecutionMode: "run_only",
+	}
+	plan := &DispatchPlan{}
+	s.renderDispatchPlanOutput(nil, ap, pgtype.UUID{}, "manual", nil, plan)
+
+	if plan.TaskPrompt != "summarize today's PRs" {
+		t.Fatalf("run_only task_prompt = %q, want the autopilot description", plan.TaskPrompt)
+	}
+	if plan.IssueTitle != "" || plan.IssueDescription != "" {
+		t.Fatalf("run_only must not populate issue fields: title=%q desc=%q", plan.IssueTitle, plan.IssueDescription)
+	}
+}
+
+// TestRenderDispatchPlanOutput_WebhookPayload verifies the webhook-source
+// preview renders the webhook event block in the issue description, matching
+// what a real webhook-triggered create_issue dispatch would produce.
+func TestRenderDispatchPlanOutput_WebhookPayload(t *testing.T) {
+	s := &AutopilotService{}
+	ap := db.Autopilot{
+		Description:   pgtype.Text{String: "triage PRs", Valid: true},
+		ExecutionMode: "create_issue",
+	}
+	payload := []byte(`{"event":"github.pull_request.opened","eventPayload":{"number":42}}`)
+	plan := &DispatchPlan{}
+	s.renderDispatchPlanOutput(nil, ap, pgtype.UUID{}, "webhook", payload, plan)
+
+	if !strings.Contains(plan.IssueDescription, "Webhook event: github.pull_request.opened") {
+		t.Fatalf("webhook preview must include the event line: %q", plan.IssueDescription)
+	}
+	if !strings.Contains(plan.IssueDescription, "42") {
+		t.Fatalf("webhook preview must include the payload: %q", plan.IssueDescription)
+	}
+}
+
+// TestRenderDispatchPlanOutput_UnknownModeLeavesFieldsEmpty is a defensive
+// guard: a future execution_mode that bypasses the CHECK constraint must not
+// crash the preview - it renders no output and the plan still serializes.
+func TestRenderDispatchPlanOutput_UnknownModeLeavesFieldsEmpty(t *testing.T) {
+	s := &AutopilotService{}
+	ap := db.Autopilot{ExecutionMode: "future_mode"}
+	plan := &DispatchPlan{}
+	s.renderDispatchPlanOutput(nil, ap, pgtype.UUID{}, "manual", nil, plan)
+
+	if plan.IssueTitle != "" || plan.IssueDescription != "" || plan.TaskPrompt != "" {
+		t.Fatalf("unknown mode must leave output fields empty: %+v", plan)
+	}
+}


### PR DESCRIPTION
## Summary

Implements WS-749: a side-effect-free **dry-run / test-trigger** mode for autopilots, so operators can preview what a trigger would do before committing to a real run. (Supersedes the prior WS-749 delivery, which was not actually present in the tree.)

- **`service.PlanDispatch`** — projects the dispatch outcome (resolved leader, runtime readiness, admission skip reason + code, and the rendered issue title/description for `create_issue` or task prompt for `run_only`) **without writing any `autopilot_run`/`issue`/`agent_task_queue` row**. It reuses the exact same admission gate (`shouldSkipDispatch`), leader resolver (`resolveAutopilotLeader`), readiness check (`AgentReadiness`), and template rendering (`interpolateTemplate` / `buildIssueDescription`) as a real dispatch, so the preview is faithful to reality.
- **API** — `POST /api/autopilots/{id}/trigger?dry_run=true` returns the `DispatchPlan`. Auth reuses `requireAutopilotWrite` (identical to a real trigger). The active-status gate is skipped for a read-only preview (a paused autopilot is safe to preview, and the most useful moment to preview is often right before activating). A malformed `dry_run` value is a `400` that **never falls through to a real dispatch**.
- **CLI** — `multica autopilot trigger <id> --dry-run` appends `?dry_run=true` and prints the plan. The real-trigger path is unchanged.

### Design notes
- `DispatchPlan.DryRun=true` lets a caller distinguish a plan from a real run response of similar shape.
- The plan reports leader + readiness even when the admission gate skips, so the preview names *what* is blocking (archived agent → `target_unavailable`; no/offline runtime → `runtime_offline`; invocation denied → `invocation_not_allowed`).
- The API dry-run uses `source=manual` with no payload (matching the existing trigger's no-body contract). Webhook-payload rendering is covered at the service layer (`PlanDispatch` with `source=webhook` + payload) and by pure-function tests.

## Test plan
- [x] `service` pure-function tests: `payloadJSON`, `dispatchPlanAgent`, `renderDispatchPlanOutput` (create_issue / run_only / webhook payload / unknown-mode).
- [x] `handler` DB-backed tests: create_issue, run_only, squad-assigned (leader resolved via squad), readiness-blocked (archived agent → skip + `target_unavailable`), paused-autopilot-allowed, stranger-forbidden (403), invalid-boolean (400), and a no-persistence-vs-real-trigger contrast (dry-run writes 0 runs; real trigger writes exactly 1 run + issue).
- [x] CLI tests: `--dry-run` appends `?dry_run=true`; regression that a real trigger omits the query.
- [x] Full `go test ./...` green (all packages).
