### PR TITLE
feat(autopilot): add dry-run dispatch preview (WS-749)

### DIFF
--- a/server/cmd/multica/cmd_autopilot.go
+++ b/server/cmd/multica/cmd_autopilot.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"context"
 	"fmt"
+	"io"
 	"net/url"
 	"os"
 	"regexp"
@@ -145,6 +146,7 @@ func init() {
 
 	// trigger (manual run)
 	autopilotTriggerCmd.Flags().String("output", "json", "Output format: table or json")
+	autopilotTriggerCmd.Flags().Bool("dry-run", false, "Preview the dispatch plan without creating a run, issue, or task")
 
 	// runs
 	autopilotRunsCmd.Flags().Int("limit", 20, "Max number of runs to return")
@@ -467,17 +469,78 @@ func runAutopilotTrigger(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("resolve autopilot: %w", err)
 	}
 
-	var run map[string]any
-	if err := client.PostJSON(ctx, "/api/autopilots/"+autopilotRef.ID+"/trigger", nil, &run); err != nil {
+	dryRun, _ := cmd.Flags().GetBool("dry-run")
+	path := "/api/autopilots/" + autopilotRef.ID + "/trigger"
+	if dryRun {
+		path += "?dry_run=true"
+	}
+
+	var result map[string]any
+	if err := client.PostJSON(ctx, path, nil, &result); err != nil {
 		return fmt.Errorf("trigger autopilot: %w", err)
 	}
 
 	output, _ := cmd.Flags().GetString("output")
 	if output == "json" {
-		return cli.PrintJSON(os.Stdout, run)
+		return cli.PrintJSON(os.Stdout, result)
 	}
-	fmt.Printf("Autopilot triggered: run %s (status: %s)\n", strVal(run, "id"), strVal(run, "status"))
+
+	if dryRun {
+		return printDispatchPlan(os.Stdout, autopilotRef.ID, result)
+	}
+
+	fmt.Printf("Autopilot triggered: run %s (status: %s)\n", strVal(result, "id"), strVal(result, "status"))
 	return nil
+}
+
+// printDispatchPlan renders a DispatchPlan response (from the dry-run API)
+// as a human-readable summary. Field presence follows the plan contract:
+// agent_* and squad_id are omitted when unresolved; rendered_title /
+// rendered_description / task_summary only appear when Allowed.
+func printDispatchPlan(w io.Writer, autopilotID string, plan map[string]any) error {
+	fmt.Fprintf(w, "Dispatch plan (dry-run) for autopilot %s\n", autopilotID)
+	fmt.Fprintf(w, "  Execution mode: %s\n", strVal(plan, "execution_mode"))
+	fmt.Fprintf(w, "  Source:         %s\n", strVal(plan, "source"))
+	fmt.Fprintf(w, "  Assignee type:  %s\n", strVal(plan, "assignee_type"))
+	if name := strVal(plan, "agent_name"); name != "" {
+		fmt.Fprintf(w, "  Agent:          %s (%s)\n", name, strVal(plan, "agent_id"))
+	}
+	if squad := strVal(plan, "squad_id"); squad != "" {
+		fmt.Fprintf(w, "  Squad:          %s\n", squad)
+	}
+	fmt.Fprintf(w, "  Agent ready:    %v", boolVal(plan, "agent_ready"))
+	if reason := strVal(plan, "readiness_reason"); reason != "" {
+		fmt.Fprintf(w, " (%s)", reason)
+	}
+	fmt.Fprintln(w)
+	fmt.Fprintf(w, "  Invoke allowed: %v\n", boolVal(plan, "invoke_allowed"))
+	if boolVal(plan, "allowed") {
+		fmt.Fprintln(w, "  Result:         ✅ would dispatch")
+		if title := strVal(plan, "rendered_title"); title != "" {
+			fmt.Fprintf(w, "  Title:          %s\n", title)
+		}
+		if summary := strVal(plan, "task_summary"); summary != "" {
+			fmt.Fprintf(w, "  Task summary:   %s\n", summary)
+		}
+	} else {
+		fmt.Fprintf(w, "  Result:         ❌ would skip: %s\n", strVal(plan, "skip_reason"))
+		if code := strVal(plan, "reason_code"); code != "" {
+			fmt.Fprintf(w, "  Reason code:    %s\n", code)
+		}
+	}
+	return nil
+}
+
+// boolVal coerces a JSON-decoded any to a bool. Missing keys or wrong types
+// come back as false, which matches the "field not populated" contract of the
+// dispatch plan response.
+func boolVal(m map[string]any, key string) bool {
+	v, ok := m[key]
+	if !ok {
+		return false
+	}
+	b, ok := v.(bool)
+	return ok && b
 }
 
 func runAutopilotRuns(cmd *cobra.Command, args []string) error {

--- a/server/cmd/multica/cmd_autopilot_test.go
+++ b/server/cmd/multica/cmd_autopilot_test.go
@@ -473,3 +473,127 @@ func TestUUIDRegexp(t *testing.T) {
 		}
 	}
 }
+
+func newAutopilotTriggerTestCmd(dryRun bool) *cobra.Command {
+	cmd := &cobra.Command{Use: "trigger"}
+	cmd.Flags().String("output", "table", "")
+	cmd.Flags().Bool("dry-run", dryRun, "")
+	return cmd
+}
+
+// TestRunAutopilotTrigger_DryRunAppendsQuery guards the request wiring:
+// --dry-run must POST to /trigger?dry_run=true (the query the handler branches
+// on), and a real trigger must NOT carry it.
+func TestRunAutopilotTrigger_DryRunAppendsQuery(t *testing.T) {
+	const apID = "11111111-1111-1111-1111-111111111111"
+
+	var capturedQuery string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodPost && r.URL.Path == "/api/autopilots/"+apID+"/trigger" {
+			capturedQuery = r.URL.RawQuery
+			json.NewEncoder(w).Encode(map[string]any{
+				"allowed":        true,
+				"execution_mode": "create_issue",
+				"source":         "manual",
+				"assignee_type":  "agent",
+				"agent_id":       "22222222-2222-2222-2222-222222222222",
+				"agent_name":     "Lambda",
+				"agent_ready":    true,
+				"invoke_allowed": true,
+				"rendered_title": "Daily Report 2026-07-22",
+			})
+			return
+		}
+		// resolveAutopilotID passes a full UUID through without a lookup, so no
+		// GET /api/autopilots should arrive; 404 anything unexpected.
+		http.NotFound(w, r)
+	}))
+	defer srv.Close()
+
+	t.Setenv("MULTICA_SERVER_URL", srv.URL)
+	t.Setenv("MULTICA_WORKSPACE_ID", "ws-1")
+	t.Setenv("MULTICA_TOKEN", "test-token")
+
+	t.Run("dry_run carries the query", func(t *testing.T) {
+		capturedQuery = ""
+		cmd := newAutopilotTriggerTestCmd(true)
+		_ = cmd.Flags().Set("output", "json")
+		if err := runAutopilotTrigger(cmd, []string{apID}); err != nil {
+			t.Fatalf("runAutopilotTrigger: %v", err)
+		}
+		if !strings.Contains(capturedQuery, "dry_run=true") {
+			t.Fatalf("expected dry_run=true in query, got %q", capturedQuery)
+		}
+	})
+
+	t.Run("real trigger omits the query", func(t *testing.T) {
+		capturedQuery = ""
+		cmd := newAutopilotTriggerTestCmd(false)
+		_ = cmd.Flags().Set("output", "json")
+		// The non-dry-run response is a run, not a plan; the test server above
+		// returns a plan-shaped body either way, which is fine - we only assert
+		// the query here. runAutopilotTrigger tolerates the extra fields.
+		if err := runAutopilotTrigger(cmd, []string{apID}); err != nil {
+			t.Fatalf("runAutopilotTrigger: %v", err)
+		}
+		if strings.Contains(capturedQuery, "dry_run") {
+			t.Fatalf("real trigger must not carry dry_run, got query %q", capturedQuery)
+		}
+	})
+}
+
+// TestPrintDispatchPlan verifies the table renderer covers both outcomes:
+// an allowed plan surfaces the rendered title, and a blocked plan surfaces
+// the skip reason + typed code. JSON output is the raw API response, so it
+// is not rendered here.
+func TestPrintDispatchPlan(t *testing.T) {
+	t.Run("allowed create_issue", func(t *testing.T) {
+		var b strings.Builder
+		plan := map[string]any{
+			"allowed":              true,
+			"execution_mode":       "create_issue",
+			"source":               "manual",
+			"assignee_type":        "agent",
+			"agent_id":             "22222222-2222-2222-2222-222222222222",
+			"agent_name":           "Lambda",
+			"agent_ready":          true,
+			"invoke_allowed":       true,
+			"rendered_title":       "Daily Report 2026-07-22",
+			"rendered_description": "body text",
+		}
+		if err := printDispatchPlan(&b, "11111111-1111-1111-1111-111111111111", plan); err != nil {
+			t.Fatal(err)
+		}
+		out := b.String()
+		for _, want := range []string{"would dispatch", "Daily Report 2026-07-22", "Lambda", "Execution mode"} {
+			if !strings.Contains(out, want) {
+				t.Errorf("output missing %q; got:\n%s", want, out)
+			}
+		}
+	})
+
+	t.Run("blocked run_only", func(t *testing.T) {
+		var b strings.Builder
+		plan := map[string]any{
+			"allowed":          false,
+			"execution_mode":   "run_only",
+			"source":           "manual",
+			"assignee_type":    "agent",
+			"agent_id":         "22222222-2222-2222-2222-222222222222",
+			"agent_name":       "Lambda",
+			"agent_ready":      false,
+			"readiness_reason": "agent has no runtime bound",
+			"skip_reason":      "assignee agent has no runtime bound",
+			"reason_code":      "runtime_offline",
+		}
+		if err := printDispatchPlan(&b, "11111111-1111-1111-1111-111111111111", plan); err != nil {
+			t.Fatal(err)
+		}
+		out := b.String()
+		for _, want := range []string{"would skip", "runtime_offline", "agent has no runtime bound"} {
+			if !strings.Contains(out, want) {
+				t.Errorf("output missing %q; got:\n%s", want, out)
+			}
+		}
+	})
+}

--- a/server/internal/handler/autopilot.go
+++ b/server/internal/handler/autopilot.go
@@ -2017,8 +2017,22 @@ func (h *Handler) TriggerAutopilot(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	actorType, actorID := h.resolveActor(r, userID, workspaceID)
+	actor := memberActorUserID(actorType, actorID)
 
-	run, reasonCode, err := h.AutopilotService.DispatchAutopilotManual(r.Context(), autopilot, pgtype.UUID{}, nil, memberActorUserID(actorType, actorID))
+	// Dry-run: preview the dispatch plan without committing a run/issue/task.
+	// Reuses the same authorization gate as the real trigger so the preview
+	// reflects exactly what the clicking member would be allowed to do.
+	if r.URL.Query().Get("dry_run") == "true" {
+		plan, err := h.AutopilotService.PlanDispatch(r.Context(), autopilot, pgtype.UUID{}, "manual", nil, actor)
+		if err != nil {
+			writeError(w, http.StatusInternalServerError, "failed to plan dispatch: "+err.Error())
+			return
+		}
+		writeJSON(w, http.StatusOK, plan)
+		return
+	}
+
+	run, reasonCode, err := h.AutopilotService.DispatchAutopilotManual(r.Context(), autopilot, pgtype.UUID{}, nil, actor)
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, "failed to trigger autopilot: "+err.Error())
 		return

--- a/server/internal/handler/autopilot_dryrun_test.go
+++ b/server/internal/handler/autopilot_dryrun_test.go
@@ -1,0 +1,321 @@
+package handler
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// insertDryRunTestAutopilot creates an autopilot row assigned to the given
+// agent with the requested execution mode and optional issue-title template,
+// then registers cascade cleanup. Used by the dry-run tests so they can vary
+// mode/template without going through the create endpoint.
+func insertDryRunTestAutopilot(t *testing.T, agentID, title, mode, titleTemplate string) string {
+	t.Helper()
+	var id string
+	if err := testPool.QueryRow(context.Background(), `
+		INSERT INTO autopilot (
+			workspace_id, title, description, assignee_type, assignee_id,
+			status, execution_mode, issue_title_template, created_by_type, created_by_id
+		)
+		VALUES ($1, $2, 'do the thing', 'agent', $3, 'active', $4, NULLIF($5, '')::text, 'member', $6)
+		RETURNING id
+	`, testWorkspaceID, title, agentID, mode, titleTemplate, testUserID).Scan(&id); err != nil {
+		t.Fatalf("failed to insert test autopilot: %v", err)
+	}
+	t.Cleanup(func() {
+		testPool.Exec(context.Background(), `DELETE FROM autopilot_run WHERE autopilot_id = $1`, id)
+		testPool.Exec(context.Background(), `DELETE FROM autopilot_trigger WHERE autopilot_id = $1`, id)
+		testPool.Exec(context.Background(), `DELETE FROM autopilot WHERE id = $1`, id)
+	})
+	return id
+}
+
+// insertAgentWithOfflineRuntime creates a workspace-visible agent bound to a
+// runtime whose status is 'offline', so AgentReadiness reports "agent runtime
+// is offline" and a run_only dispatch is blocked. agent.runtime_id is NOT NULL
+// with a FK to agent_runtime, so "not ready" must come from an offline bound
+// runtime, not a NULL one. Used to exercise the readiness-blocked branch of
+// the dry-run plan and the real-trigger skipped-run path.
+func insertAgentWithOfflineRuntime(t *testing.T, name string) string {
+	t.Helper()
+	var runtimeID string
+	if err := testPool.QueryRow(context.Background(), `
+		INSERT INTO agent_runtime (
+			workspace_id, daemon_id, name, runtime_mode, provider, status, device_info, metadata, owner_id, last_seen_at
+		)
+		VALUES ($1, NULL, $2, 'cloud', $3, 'offline', $4, '{}'::jsonb, $5, now())
+		RETURNING id
+	`, testWorkspaceID, name+" runtime", name+"-offline", name+" offline runtime", testUserID).Scan(&runtimeID); err != nil {
+		t.Fatalf("failed to create offline agent_runtime: %v", err)
+	}
+	var agentID string
+	if err := testPool.QueryRow(context.Background(), `
+		INSERT INTO agent (
+			workspace_id, name, description, runtime_mode, runtime_config,
+			runtime_id, visibility, permission_mode, max_concurrent_tasks, owner_id,
+			instructions, custom_env, custom_args, mcp_config
+		)
+		VALUES ($1, $2, '', 'cloud', '{}'::jsonb, $3, 'workspace', 'public_to', 1, $4, '', '{}'::jsonb, '[]'::jsonb, '[]'::jsonb)
+		RETURNING id
+	`, testWorkspaceID, name, runtimeID, testUserID).Scan(&agentID); err != nil {
+		t.Fatalf("failed to create offline-runtime agent: %v", err)
+	}
+	if _, err := testPool.Exec(context.Background(), `
+		INSERT INTO agent_invocation_target (agent_id, target_type, target_id)
+		VALUES ($1, 'workspace', $2)
+		ON CONFLICT (agent_id, target_type, target_id) DO NOTHING
+	`, agentID, testWorkspaceID); err != nil {
+		t.Fatalf("failed to seed workspace invocation target: %v", err)
+	}
+	t.Cleanup(func() {
+		testPool.Exec(context.Background(), `DELETE FROM agent WHERE id = $1`, agentID)
+		testPool.Exec(context.Background(), `DELETE FROM agent_runtime WHERE id = $1`, runtimeID)
+	})
+	return agentID
+}
+
+// countRows returns the row count for a table filtered by autopilot_id, used
+// to assert the dry-run left no run/issue/task behind.
+func countRows(t *testing.T, table, autopilotID string) int {
+	t.Helper()
+	var n int
+	if err := testPool.QueryRow(context.Background(),
+		`SELECT count(*) FROM `+table+` WHERE autopilot_id = $1`, autopilotID).Scan(&n); err != nil {
+		t.Fatalf("count %s: %v", table, err)
+	}
+	return n
+}
+
+// dispatchPlan is the test-side mirror of service.DispatchPlan. Decoding into
+// a local struct keeps the test independent of the service package's exact
+// field set while still asserting the contract the API exposes.
+type dispatchPlan struct {
+	Allowed             bool   `json:"allowed"`
+	ExecutionMode       string `json:"execution_mode"`
+	Source              string `json:"source"`
+	AssigneeType        string `json:"assignee_type"`
+	AgentID             string `json:"agent_id"`
+	AgentName           string `json:"agent_name"`
+	AgentReady          bool   `json:"agent_ready"`
+	ReadinessReason     string `json:"readiness_reason"`
+	InvokeAllowed       bool   `json:"invoke_allowed"`
+	SkipReason          string `json:"skip_reason"`
+	ReasonCode          string `json:"reason_code"`
+	RenderedTitle       string `json:"rendered_title"`
+	RenderedDescription string `json:"rendered_description"`
+	TaskSummary         string `json:"task_summary"`
+}
+
+func callDryRun(t *testing.T, apID string) dispatchPlan {
+	t.Helper()
+	w := httptest.NewRecorder()
+	r := newRequest("POST", "/api/autopilots/"+apID+"/trigger?dry_run=true&workspace_id="+testWorkspaceID, nil)
+	r = withURLParam(r, "id", apID)
+	testHandler.TriggerAutopilot(w, r)
+	if w.Code != http.StatusOK {
+		t.Fatalf("dry-run: expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	var plan dispatchPlan
+	if err := json.NewDecoder(w.Body).Decode(&plan); err != nil {
+		t.Fatalf("decode plan: %v", err)
+	}
+	return plan
+}
+
+// TestTriggerAutopilot_DryRun_CreateIssue exercises the happy path for a
+// create_issue autopilot assigned to a ready agent: the plan reports allowed,
+// a rendered title, and readiness - and crucially creates no run/issue/task.
+func TestTriggerAutopilot_DryRun_CreateIssue(t *testing.T) {
+	if testHandler == nil || testPool == nil {
+		t.Skip("database not available")
+	}
+	agentID := createHandlerTestAgent(t, "dryrun-createissue-agent", nil)
+	apID := insertDryRunTestAutopilot(t, agentID, "Daily Report {{date}}", "create_issue", "Daily Report {{date}}")
+
+	plan := callDryRun(t, apID)
+
+	if !plan.Allowed {
+		t.Fatalf("expected allowed=true, got skip_reason=%q reason_code=%q", plan.SkipReason, plan.ReasonCode)
+	}
+	if plan.ExecutionMode != "create_issue" {
+		t.Fatalf("execution_mode: got %q want create_issue", plan.ExecutionMode)
+	}
+	if plan.AgentID == "" || plan.AgentName == "" {
+		t.Fatalf("expected resolved agent, got id=%q name=%q", plan.AgentID, plan.AgentName)
+	}
+	if !plan.AgentReady {
+		t.Fatalf("expected agent_ready=true, reason=%q", plan.ReadinessReason)
+	}
+	if !plan.InvokeAllowed {
+		t.Fatalf("expected invoke_allowed=true")
+	}
+	if plan.RenderedTitle == "" || plan.RenderedTitle == "Daily Report {{date}}" {
+		t.Fatalf("expected {{date}} interpolated, got %q", plan.RenderedTitle)
+	}
+	if plan.RenderedDescription == "" {
+		t.Fatalf("expected rendered_description non-empty")
+	}
+	if plan.TaskSummary != "" {
+		t.Fatalf("run_only-only field task_summary should be empty for create_issue, got %q", plan.TaskSummary)
+	}
+
+	// Zero side effects: no run, no issue, no task.
+	if n := countRows(t, "autopilot_run", apID); n != 0 {
+		t.Fatalf("dry-run created %d autopilot_run rows", n)
+	}
+	if n := countAutopilotIssues(t, apID); n != 0 {
+		t.Fatalf("dry-run created %d issues", n)
+	}
+	if n := countAutopilotTasks(t, apID); n != 0 {
+		t.Fatalf("dry-run created %d agent_task_queue rows", n)
+	}
+}
+
+// TestTriggerAutopilot_DryRun_RunOnly verifies the run_only path renders a
+// task summary instead of a title/description, and still creates nothing.
+func TestTriggerAutopilot_DryRun_RunOnly(t *testing.T) {
+	if testHandler == nil || testPool == nil {
+		t.Skip("database not available")
+	}
+	agentID := createHandlerTestAgent(t, "dryrun-runonly-agent", nil)
+	apID := insertDryRunTestAutopilot(t, agentID, "Nightly Cleanup", "run_only", "")
+
+	plan := callDryRun(t, apID)
+
+	if !plan.Allowed {
+		t.Fatalf("expected allowed=true, got skip_reason=%q", plan.SkipReason)
+	}
+	if plan.ExecutionMode != "run_only" {
+		t.Fatalf("execution_mode: got %q want run_only", plan.ExecutionMode)
+	}
+	if plan.TaskSummary == "" {
+		t.Fatalf("expected task_summary non-empty")
+	}
+	if plan.RenderedTitle != "" || plan.RenderedDescription != "" {
+		t.Fatalf("create_issue-only fields should be empty for run_only, got title=%q desc=%q", plan.RenderedTitle, plan.RenderedDescription)
+	}
+	if n := countRows(t, "autopilot_run", apID); n != 0 {
+		t.Fatalf("dry-run created %d autopilot_run rows", n)
+	}
+	if n := countAutopilotTasks(t, apID); n != 0 {
+		t.Fatalf("dry-run created %d agent_task_queue rows", n)
+	}
+}
+
+// TestTriggerAutopilot_DryRun_ReadinessBlocked verifies a run_only autopilot
+// whose agent's runtime is offline reports allowed=false with a typed reason
+// and still creates nothing. This is the case users most need to catch before a
+// real trigger silently skips.
+func TestTriggerAutopilot_DryRun_ReadinessBlocked(t *testing.T) {
+	if testHandler == nil || testPool == nil {
+		t.Skip("database not available")
+	}
+	agentID := insertAgentWithOfflineRuntime(t, "dryrun-offline-agent")
+	apID := insertDryRunTestAutopilot(t, agentID, "Blocked Run", "run_only", "")
+
+	plan := callDryRun(t, apID)
+
+	if plan.Allowed {
+		t.Fatalf("expected allowed=false for no-runtime run_only agent")
+	}
+	if plan.AgentReady {
+		t.Fatalf("expected agent_ready=false")
+	}
+	if plan.ReadinessReason == "" {
+		t.Fatalf("expected readiness_reason non-empty")
+	}
+	if plan.SkipReason == "" {
+		t.Fatalf("expected skip_reason non-empty")
+	}
+	if plan.ReasonCode == "" {
+		t.Fatalf("expected typed reason_code non-empty")
+	}
+	if n := countRows(t, "autopilot_run", apID); n != 0 {
+		t.Fatalf("dry-run created %d autopilot_run rows for a blocked plan", n)
+	}
+}
+
+// TestTriggerAutopilot_DryRun_AuthorizationMatchesRealTrigger guards that the
+// dry-run path reuses requireAutopilotWrite: a plain member who cannot write
+// the autopilot gets 403 on dry-run just as they would on a real trigger.
+func TestTriggerAutopilot_DryRun_AuthorizationMatchesRealTrigger(t *testing.T) {
+	if testHandler == nil || testPool == nil {
+		t.Skip("database not available")
+	}
+	apID := createAutopilotAs(t, "", "dryrun-auth-owner")
+	stranger := createPlainMember(t, "dryrun-auth-stranger@multica.test")
+
+	w := httptest.NewRecorder()
+	r := newRequestAs(stranger, "POST", "/api/autopilots/"+apID+"/trigger?dry_run=true&workspace_id="+testWorkspaceID, nil)
+	r = withURLParam(r, "id", apID)
+	testHandler.TriggerAutopilot(w, r)
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("dry-run by stranger: expected 403, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+// TestTriggerAutopilot_RealTriggerUnaffectedByDryRunBranch is the regression
+// guard: POSTing /trigger WITHOUT dry_run must still dispatch (create a run)
+// rather than return a plan. Uses a run_only + offline-runtime autopilot so the
+// real dispatch records a skipped run without the heavier issue/task fan-out,
+// keeping the test focused on "the branch did not swallow the real path".
+func TestTriggerAutopilot_RealTriggerUnaffectedByDryRunBranch(t *testing.T) {
+	if testHandler == nil || testPool == nil {
+		t.Skip("database not available")
+	}
+	agentID := insertAgentWithOfflineRuntime(t, "realtrigger-offline-agent")
+	apID := insertDryRunTestAutopilot(t, agentID, "Real Trigger Regression", "run_only", "")
+
+	w := httptest.NewRecorder()
+	r := newRequest("POST", "/api/autopilots/"+apID+"/trigger?workspace_id="+testWorkspaceID, nil)
+	r = withURLParam(r, "id", apID)
+	testHandler.TriggerAutopilot(w, r)
+	if w.Code != http.StatusOK {
+		t.Fatalf("real trigger: expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	// Response must be a run (has id + status), not a dispatch plan (has allowed).
+	var resp map[string]any
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if _, ok := resp["allowed"]; ok {
+		t.Fatalf("real trigger returned a dispatch plan, not a run: %v", resp)
+	}
+	if resp["id"] == nil || resp["status"] == nil {
+		t.Fatalf("real trigger response missing run id/status: %v", resp)
+	}
+	if n := countRows(t, "autopilot_run", apID); n != 1 {
+		t.Fatalf("real trigger: expected 1 autopilot_run row, got %d", n)
+	}
+}
+
+// countAutopilotIssues counts issues whose origin_id is the autopilot - the
+// marker dispatchCreateIssue stamps via origin_type='autopilot'.
+func countAutopilotIssues(t *testing.T, autopilotID string) int {
+	t.Helper()
+	var n int
+	if err := testPool.QueryRow(context.Background(),
+		`SELECT count(*) FROM issue WHERE origin_type = 'autopilot' AND origin_id = $1`, autopilotID).Scan(&n); err != nil {
+		t.Fatalf("count autopilot issues: %v", err)
+	}
+	return n
+}
+
+// countAutopilotTasks counts agent_task_queue rows whose autopilot_run_id belongs
+// to a run of this autopilot - the link dispatchCreateIssue/dispatchRunOnly
+// stamps when it enqueues the assignee task. agent_task_queue has no
+// autopilot_id column (it links via autopilot_run_id), so this joins through
+// autopilot_run. A dry-run must leave zero.
+func countAutopilotTasks(t *testing.T, autopilotID string) int {
+	t.Helper()
+	var n int
+	if err := testPool.QueryRow(context.Background(),
+		`SELECT count(*) FROM agent_task_queue WHERE autopilot_run_id IN (SELECT id FROM autopilot_run WHERE autopilot_id = $1)`, autopilotID).Scan(&n); err != nil {
+		t.Fatalf("count autopilot tasks: %v", err)
+	}
+	return n
+}

--- a/server/internal/service/autopilot.go
+++ b/server/internal/service/autopilot.go
@@ -146,6 +146,141 @@ func (s *AutopilotService) DispatchAutopilotManual(
 	return s.dispatchAutopilot(ctx, autopilot, triggerID, "manual", payload, pgtype.Timestamptz{}, pgtype.UUID{}, actorUserID)
 }
 
+// DispatchPlan describes the resolved outcome of an autopilot dispatch without
+// persisting any run, issue, or task. Dry-run API and CLI callers consume it
+// to preview what would happen if a trigger fired, so they can validate
+// assignee/leader resolution, readiness, template rendering, and the invoke
+// gate before committing side effects.
+type DispatchPlan struct {
+	Allowed             bool   `json:"allowed"`
+	ExecutionMode       string `json:"execution_mode"`
+	Source              string `json:"source"`
+	AssigneeType        string `json:"assignee_type"`
+	AgentID             string `json:"agent_id,omitempty"`
+	AgentName           string `json:"agent_name,omitempty"`
+	SquadID             string `json:"squad_id,omitempty"`
+	AgentReady          bool   `json:"agent_ready"`
+	ReadinessReason     string `json:"readiness_reason,omitempty"`
+	InvokeAllowed       bool   `json:"invoke_allowed"`
+	SkipReason          string `json:"skip_reason,omitempty"`
+	ReasonCode          string `json:"reason_code,omitempty"`
+	RenderedTitle       string `json:"rendered_title,omitempty"`
+	RenderedDescription string `json:"rendered_description,omitempty"`
+	TaskSummary         string `json:"task_summary,omitempty"`
+	TriggerID           string `json:"trigger_id,omitempty"`
+}
+
+// PlanDispatch simulates a dispatch of the given autopilot with the given
+// trigger/source/payload/actor and returns the resolved plan without
+// persisting anything. It mirrors shouldSkipDispatch for admission and the
+// render logic from dispatchCreateIssue/dispatchRunOnly for output. Returns
+// (nil, error) only on transient lookup failures that prevented a decision;
+// a resolved skip (readiness/invoke/target) comes back as (plan, nil) with
+// plan.Allowed=false so the caller can render the reason.
+func (s *AutopilotService) PlanDispatch(
+	ctx context.Context,
+	autopilot db.Autopilot,
+	triggerID pgtype.UUID,
+	source string,
+	payload []byte,
+	actorUserID pgtype.UUID,
+) (*DispatchPlan, error) {
+	plan := &DispatchPlan{
+		ExecutionMode: autopilot.ExecutionMode,
+		Source:        source,
+		AssigneeType:  autopilot.AssigneeType,
+	}
+	if triggerID.Valid {
+		plan.TriggerID = util.UUIDToString(triggerID)
+	}
+
+	if !autopilot.AssigneeID.Valid {
+		plan.SkipReason = "autopilot has no assignee"
+		plan.ReasonCode = string(dispatch.ReasonTargetUnavailable)
+		return plan, nil
+	}
+
+	// Resolve leader (agent or squad leader). Mirrors shouldSkipDispatch's
+	// resolution so the dry-run reports exactly what real dispatch would see.
+	agent, _, err := s.resolveAutopilotLeader(ctx, autopilot)
+	if err != nil {
+		switch {
+		case errors.Is(err, pgx.ErrNoRows):
+			plan.SkipReason = "assignee agent no longer exists"
+		case errors.Is(err, errSquadArchived):
+			plan.SkipReason = "assignee squad is archived"
+		default:
+			// Transient DB error — surface as an error so the caller can
+			// distinguish "we couldn't tell" from "we told you no".
+			return nil, fmt.Errorf("resolve leader: %w", err)
+		}
+		plan.ReasonCode = string(dispatch.ReasonTargetUnavailable)
+		return plan, nil
+	}
+	plan.AgentID = util.UUIDToString(agent.ID)
+	plan.AgentName = agent.Name
+	if autopilot.AssigneeType == "squad" && autopilot.AssigneeID.Valid {
+		plan.SquadID = util.UUIDToString(autopilot.AssigneeID)
+	}
+
+	// Agent readiness. Same tolerance as shouldSkipDispatch: create_issue mode
+	// tolerates offline runtime (issue still created, task queued when runtime
+	// comes back); run_only requires online runtime.
+	ready, reason, err := AgentReadiness(ctx, s.Queries, agent)
+	if err != nil {
+		return nil, fmt.Errorf("readiness check: %w", err)
+	}
+	plan.AgentReady = ready
+	plan.ReadinessReason = reason
+
+	wouldBlock := !ready
+	if !ready && autopilot.ExecutionMode == "create_issue" && strings.HasPrefix(reason, "agent runtime is ") {
+		wouldBlock = false
+	}
+	if wouldBlock {
+		plan.SkipReason = formatAdmissionReason(autopilot, reason)
+		plan.ReasonCode = string(agentReadinessReasonCode(agent))
+		return plan, nil
+	}
+
+	// Invoke gate. The admission principal mirrors autopilotAdmitInvoke's
+	// callers: a MANUAL trigger (actorUserID valid) is gated by the clicking
+	// member; automation falls back to the creator.
+	if !s.autopilotAdmitInvoke(ctx, autopilot, agent, actorUserID) {
+		plan.InvokeAllowed = false
+		if actorUserID.Valid {
+			plan.SkipReason = "you are not allowed to trigger this autopilot's assignee agent"
+		} else {
+			plan.SkipReason = "autopilot creator lacks access to private assignee agent"
+		}
+		plan.ReasonCode = string(dispatch.ReasonInvocationNotAllowed)
+		return plan, nil
+	}
+	plan.InvokeAllowed = true
+
+	// Render the would-be output. Use a synthetic run carrying source/payload/now
+	// so interpolateTemplate / buildIssueDescription produce the same text the
+	// real dispatch would have, modulo the run's DB-assigned fields (id,
+	// triggered_at) which don't flow into the rendered strings.
+	fakeRun := db.AutopilotRun{
+		Source:         source,
+		TriggerPayload: payload,
+		TriggeredAt:    pgtype.Timestamptz{Time: time.Now().UTC(), Valid: true},
+	}
+	triggerTimezone := s.resolveAutopilotTriggerTimezone(ctx, triggerID)
+
+	if autopilot.ExecutionMode == "create_issue" {
+		plan.RenderedTitle = s.interpolateTemplate(autopilot, fakeRun, triggerTimezone)
+		desc := s.buildIssueDescription(autopilot, fakeRun, triggerTimezone)
+		plan.RenderedDescription = desc.String
+	} else {
+		plan.TaskSummary = truncateForSummary(autopilot.Title, triggerSummaryMaxLen)
+	}
+
+	plan.Allowed = true
+	return plan, nil
+}
+
 // AdmitAutopilotWebhookDelivery creates or reuses the idempotent run for a
 // durable webhook delivery without executing its downstream issue/task side
 // effect. The HTTP ingress calls this synchronously so the public webhook


### PR DESCRIPTION
## Summary

Adds a read-only **dry-run** mode to the autopilot trigger so users can preview what a trigger would do — resolved assignee/leader, agent readiness, rendered issue title/description (create_issue) or task summary (run_only), and the typed skip reason — **without creating a run, issue, or task**.

Closes the WS-749 gap: today the only way to find out why an autopilot would skip (offline runtime, archived assignee, blocked invoke) is to actually fire it and read the skipped run.

### Changes
- **service** (`internal/service/autopilot.go`): new `PlanDispatch` mirrors `shouldSkipDispatch` for admission (leader resolution, `AgentReadiness` with the create_issue offline-runtime tolerance, invoke gate) and the render logic for output, short-circuiting before any persistence. Returns `(plan, nil)` for resolved skips so the caller can render the reason; `(nil, err)` only on transient lookup failures. No change to the real dispatch path.
- **handler** (`internal/handler/autopilot.go`): `TriggerAutopilot` branches on `?dry_run=true` before `DispatchAutopilotManual`, reusing the same authorization gate (`requireAutopilotWrite`) so the preview reflects exactly what the clicking member is allowed to do.
- **cli** (`cmd/multica/cmd_autopilot.go`): `multica autopilot trigger <id> --dry-run` appends the query and prints a human-readable plan (table) or the raw plan (json).

### Example
```
$ multica autopilot trigger <id> --dry-run
Dispatch plan (dry-run) for autopilot <id>
  Execution mode: create_issue
  Source:         manual
  Assignee type:  agent
  Agent:          Lambda (22222222-...)
  Agent ready:    true
  Invoke allowed: true
  Result:         ✅ would dispatch
  Title:          Daily Report 2026-07-22
```

A blocked plan surfaces the typed reason instead:
```
  Agent ready:    false (agent runtime is offline)
  Result:         ❌ would skip: agent runtime is offline at dispatch time
  Reason code:    runtime_offline
```

## Test plan
- [x] `go build ./...`, `go vet`, `gofmt` clean
- [x] `internal/handler` dry-run tests (5): create_issue happy path, run_only, readiness-blocked, authorization-matches-real-trigger (stranger 403), real-trigger-unaffected-by-dry-run-branch (regression guard)
- [x] `internal/service` autopilot tests pass (no regression in real dispatch)
- [x] `cmd/multica` autopilot tests: dry-run appends `?dry_run=true`, real trigger omits it, `printDispatchPlan` covers allowed + blocked
- [x] Dry-run asserts zero side effects: no `autopilot_run`, `issue`, or `agent_task_queue` rows created