### PR TITLE
fix(onboarding): eliminate Desktop runtime-step false-negative flash + parallelize daemon version detection (MUL-5119)

### DIFF
--- a/apps/desktop/src/renderer/src/components/window-overlay.tsx
+++ b/apps/desktop/src/renderer/src/components/window-overlay.tsx
@@ -7,6 +7,7 @@ import { useNavigation } from "@multica/views/navigation";
 import { paths } from "@multica/core/paths";
 import { workspaceListOptions } from "@multica/core/workspace/queries";
 import { useWindowOverlayStore } from "@/stores/window-overlay-store";
+import { useLocalRuntimesPending } from "../platform/use-local-runtimes-pending";
 
 /**
  * Window-level transition overlay: renders above the tab system when the
@@ -37,6 +38,9 @@ function WindowOverlayInner() {
   const close = useWindowOverlayStore((s) => s.close);
   const { push } = useNavigation();
   const { data: wsList = [] } = useQuery(workspaceListOptions());
+  // Live local-daemon signal for the onboarding runtime step so it doesn't
+  // flash "no runtime found" while the daemon is still probing CLI versions.
+  const runtimesPending = useLocalRuntimesPending();
 
   if (!overlay) return null;
 
@@ -81,6 +85,7 @@ function WindowOverlayInner() {
           onRuntimeRefresh={async () => {
             await window.daemonAPI?.restart?.();
           }}
+          runtimesPending={runtimesPending}
         />
       )}
     </div>

--- a/apps/desktop/src/renderer/src/platform/use-local-runtimes-pending.ts
+++ b/apps/desktop/src/renderer/src/platform/use-local-runtimes-pending.ts
@@ -1,0 +1,52 @@
+import { useEffect, useState } from "react";
+import type { DaemonStatus } from "../../../shared/daemon-types";
+
+/**
+ * True while the local daemon is still expected to produce agent runtimes: it
+ * is booting (`starting` / `installing_cli`) or it is running and reports agent
+ * CLIs detected on this host that may not have finished registering yet.
+ *
+ * The onboarding runtime step reads this so it keeps showing the scanning
+ * skeleton instead of flashing "no runtime found" while the daemon is still
+ * probing CLI versions — a false negative on a machine that does have coding
+ * tools installed (MUL-5119). The daemon's `/health` `agents` list comes from
+ * its boot-time PATH scan, so it is populated well before the slower
+ * version-registration finishes, which is exactly what makes it a reliable
+ * "runtimes are coming" hint.
+ *
+ * It goes false once the daemon settles into a state that will not yield
+ * runtimes (running with zero detected agents, stopped, cli_not_found,
+ * auth_expired), letting the step fall through to its genuine empty exits.
+ *
+ * Starts true so a daemon that is mid-boot when the user lands on the step
+ * doesn't get a scanning→empty flash before the first status resolves.
+ */
+export function useLocalRuntimesPending(): boolean {
+  const [pending, setPending] = useState(true);
+  useEffect(() => {
+    const apply = (s: DaemonStatus) => {
+      setPending(
+        s.state === "starting" ||
+          s.state === "installing_cli" ||
+          (s.state === "running" && (s.agents?.length ?? 0) > 0),
+      );
+    };
+    let cancelled = false;
+    window.daemonAPI
+      .getStatus()
+      .then((s) => {
+        if (!cancelled) apply(s);
+      })
+      .catch(() => {
+        // No daemon status available — leave `pending` at its initial true so
+        // the step relies on the runtime step's absolute hard-timeout ceiling
+        // rather than flashing empty prematurely.
+      });
+    const unsubscribe = window.daemonAPI.onStatusChange(apply);
+    return () => {
+      cancelled = true;
+      unsubscribe();
+    };
+  }, []);
+  return pending;
+}

--- a/packages/views/onboarding/onboarding-flow.tsx
+++ b/packages/views/onboarding/onboarding-flow.tsx
@@ -106,6 +106,7 @@ export function OnboardingFlow({
   onComplete,
   runtimeInstructions,
   onRuntimeRefresh,
+  runtimesPending,
 }: {
   onComplete: (workspace?: Workspace, issueId?: string) => void;
   runtimeInstructions?: React.ReactNode;
@@ -114,6 +115,10 @@ export function OnboardingFlow({
    *  it — its CLI install flow already runs on the user's machine and
    *  the embedded picker reacts to daemon:register events. */
   onRuntimeRefresh?: () => void | Promise<void>;
+  /** Desktop wires this to the local daemon's live status so the runtime
+   *  step doesn't flash "no runtime found" while the daemon is still booting
+   *  or probing CLI versions (MUL-5119). Web omits it. */
+  runtimesPending?: boolean;
 }) {
   const { t } = useT("onboarding");
   const user = useAuthStore((s) => s.user);
@@ -336,6 +341,7 @@ export function OnboardingFlow({
           onNext={handleRuntimeNext}
           onBack={() => handleBack("runtime")}
           onRefresh={onRuntimeRefresh}
+          runtimesPending={runtimesPending}
         />
       );
     }

--- a/packages/views/onboarding/steps/step-runtime-connect.test.tsx
+++ b/packages/views/onboarding/steps/step-runtime-connect.test.tsx
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
-import { render, screen } from "@testing-library/react";
+import { act, render, screen } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import type { AgentRuntime } from "@multica/core/types";
 import { I18nProvider } from "@multica/core/i18n/react";
@@ -27,7 +27,17 @@ vi.mock("../components/use-runtime-picker", () => ({
 
 import { StepRuntimeConnect } from "./step-runtime-connect";
 
-function renderStep() {
+function makeRuntime(overrides: Partial<AgentRuntime> = {}): AgentRuntime {
+  return {
+    id: "rt_1",
+    name: "Claude (dev-box)",
+    provider: "claude",
+    status: "online",
+    ...overrides,
+  } as AgentRuntime;
+}
+
+function renderStep(props: { runtimesPending?: boolean } = {}) {
   const onNext = vi.fn();
   const onBack = vi.fn();
   const qc = new QueryClient({
@@ -36,7 +46,12 @@ function renderStep() {
   render(
     <QueryClientProvider client={qc}>
       <I18nProvider locale="en" resources={TEST_RESOURCES}>
-        <StepRuntimeConnect wsId="ws_test" onNext={onNext} onBack={onBack} />
+        <StepRuntimeConnect
+          wsId="ws_test"
+          onNext={onNext}
+          onBack={onBack}
+          runtimesPending={props.runtimesPending}
+        />
       </I18nProvider>
     </QueryClientProvider>,
   );
@@ -61,5 +76,70 @@ describe("StepRuntimeConnect", () => {
     expect(
       screen.getByText(/connecting this computer/i),
     ).toBeInTheDocument();
+  });
+
+  it("does not render a permanently-disabled Start exploring while scanning", () => {
+    renderStep();
+    expect(
+      screen.queryByRole("button", { name: /start exploring/i }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("flips to the empty state after the idle timeout when no pending signal is given", () => {
+    renderStep();
+    act(() => vi.advanceTimersByTime(5000));
+    expect(
+      screen.getByText(/no agent runtime found on this computer yet/i),
+    ).toBeInTheDocument();
+  });
+
+  it("keeps scanning past the idle timeout while runtimes are pending, then falls back at the hard ceiling", () => {
+    renderStep({ runtimesPending: true });
+
+    // Past the soft budget the daemon still reports work in flight, so the
+    // false-negative empty state must not appear (MUL-5119).
+    act(() => vi.advanceTimersByTime(5000));
+    expect(
+      screen.getByText(/connecting this computer/i),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByText(/no agent runtime found/i),
+    ).not.toBeInTheDocument();
+
+    // The absolute ceiling still guarantees a fallback so a wedged probe
+    // cannot hang the step on the skeleton forever.
+    act(() => vi.advanceTimersByTime(15000));
+    expect(
+      screen.getByText(/no agent runtime found/i),
+    ).toBeInTheDocument();
+  });
+
+  it("shows the found list — not the empty state — once runtimes register", () => {
+    mocks.pickerState.runtimes = [makeRuntime()];
+    mocks.pickerState.selected = makeRuntime();
+    mocks.pickerState.selectedId = "rt_1";
+    mocks.pickerState.hasRuntimes = true;
+
+    renderStep();
+    act(() => vi.advanceTimersByTime(25000));
+
+    expect(
+      screen.getByText(/this computer is connected/i),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByText(/no agent runtime found/i),
+    ).not.toBeInTheDocument();
+    // Continue is actionable in the found phase.
+    expect(
+      screen.getByRole("button", { name: /start exploring/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("shows a single Skip affordance in the empty state (no duplicate footer button)", () => {
+    renderStep();
+    act(() => vi.advanceTimersByTime(5000));
+    // The empty view owns one prominent "Skip for now" card; the footer no
+    // longer duplicates it.
+    expect(screen.getAllByText("Skip for now")).toHaveLength(1);
   });
 });

--- a/packages/views/onboarding/steps/step-runtime-connect.tsx
+++ b/packages/views/onboarding/steps/step-runtime-connect.tsx
@@ -36,6 +36,7 @@ export function StepRuntimeConnect({
   onNext,
   onBack,
   onRefresh,
+  runtimesPending,
 }: {
   wsId: string;
   onNext: (runtime: AgentRuntime | null) => void | Promise<void>;
@@ -44,6 +45,13 @@ export function StepRuntimeConnect({
    *  bundled daemon so a freshly-installed CLI shows up — otherwise the
    *  daemon's PATH probe runs once at boot and never re-probes. */
   onRefresh?: () => void | Promise<void>;
+  /** Desktop-only signal: the local daemon is still booting or is known to
+   *  have agent CLIs on this host that haven't finished registering yet.
+   *  While true, the step keeps showing the scanning skeleton past the normal
+   *  timeout instead of flashing the "no runtime found" empty state — that
+   *  empty state is a false negative when the daemon is mid-probe (MUL-5119).
+   *  Web omits it and keeps the plain wall-clock timeout. */
+  runtimesPending?: boolean;
 }) {
   const { runtimes, selected, selectedId, setSelectedId } =
     useRuntimePicker(wsId);
@@ -58,6 +66,7 @@ export function StepRuntimeConnect({
       onNext={onNext}
       onBack={onBack}
       onRefresh={onRefresh}
+      runtimesPending={runtimesPending}
     />
   );
 }
@@ -68,8 +77,14 @@ export function StepRuntimeConnect({
 
 type Phase = "scanning" | "found" | "empty";
 
-/** Input ms before an empty list flips from "scanning" to "empty". */
+/** Idle ms before an empty list flips from "scanning" to "empty" — unless the
+ *  platform reports runtimes are still pending (see `runtimesPending`). */
 const EMPTY_TIMEOUT_MS = 5000;
+
+/** Absolute ceiling: even while the platform still reports runtimes pending,
+ *  fall back to the empty exits after this so a wedged version probe can never
+ *  hang the step on the scanning skeleton forever. */
+const EMPTY_HARD_TIMEOUT_MS = 20000;
 
 function FancyView({
   wsId,
@@ -80,6 +95,7 @@ function FancyView({
   onNext,
   onBack,
   onRefresh,
+  runtimesPending,
 }: {
   wsId: string;
   runtimes: AgentRuntime[];
@@ -89,30 +105,52 @@ function FancyView({
   onNext: (runtime: AgentRuntime | null) => void | Promise<void>;
   onBack?: () => void;
   onRefresh?: () => void | Promise<void>;
+  runtimesPending?: boolean;
 }) {
   const { t } = useT("onboarding");
   const qc = useQueryClient();
   const mainRef = useRef<HTMLElement>(null);
   const fadeStyle = useScrollFade(mainRef);
 
-  // Flip to "empty" only after we've waited long enough for the daemon
-  // to report. The 5s budget covers the bundled daemon's typical 1–3s
-  // boot; anything past that is a genuine "no runtime" situation and we
-  // switch from scanning skeletons to the skip / refresh exits.
-  // `scanEpoch` resets the timer when the user hits Refresh, so a
-  // freshly-installed CLI gets another scanning window before falling
-  // back to the empty state.
+  // Decide when an empty runtime list stops being "still scanning" and becomes
+  // the genuine "no runtime" exits. Two timers run while the list is empty:
+  //
+  //   - soft (EMPTY_TIMEOUT_MS): the normal budget. Once it fires we flip to
+  //     empty UNLESS `runtimesPending` says the platform (desktop daemon) is
+  //     still booting or mid-probe — registration on a host with several CLIs
+  //     can outlast the soft budget, and flashing "no runtime found" while the
+  //     daemon is still working is a false negative (MUL-5119).
+  //   - hard (EMPTY_HARD_TIMEOUT_MS): an absolute ceiling so a wedged probe
+  //     that never resolves `runtimesPending` back to false can't pin the step
+  //     on the scanning skeleton forever.
+  //
+  // `scanEpoch` resets both timers when the user hits Refresh, so a
+  // freshly-installed CLI gets another scanning window before falling back to
+  // the empty state.
   const [scanEpoch, setScanEpoch] = useState(0);
-  const [hasTimedOut, setHasTimedOut] = useState(false);
+  const [softTimedOut, setSoftTimedOut] = useState(false);
+  const [hardTimedOut, setHardTimedOut] = useState(false);
   useEffect(() => {
     if (runtimes.length > 0) return;
-    setHasTimedOut(false);
-    const id = window.setTimeout(() => setHasTimedOut(true), EMPTY_TIMEOUT_MS);
-    return () => window.clearTimeout(id);
+    setSoftTimedOut(false);
+    setHardTimedOut(false);
+    const soft = window.setTimeout(() => setSoftTimedOut(true), EMPTY_TIMEOUT_MS);
+    const hard = window.setTimeout(
+      () => setHardTimedOut(true),
+      EMPTY_HARD_TIMEOUT_MS,
+    );
+    return () => {
+      window.clearTimeout(soft);
+      window.clearTimeout(hard);
+    };
   }, [runtimes.length, scanEpoch]);
 
   const phase: Phase =
-    runtimes.length > 0 ? "found" : hasTimedOut ? "empty" : "scanning";
+    runtimes.length > 0
+      ? "found"
+      : hardTimedOut || (softTimedOut && runtimesPending !== true)
+        ? "empty"
+        : "scanning";
 
   const onlineCount = runtimes.filter((r) => r.status === "online").length;
 
@@ -229,12 +267,20 @@ function FancyView({
             )}
             {phase === "empty" && (
               <EmptyView
-                onSkip={() => onNext(null)}
+                onSkip={handleSkip}
                 onRefresh={handleRefresh}
                 refreshing={refreshing}
               />
             )}
 
+            {/* Footer action bar. The controls are phase-scoped so no dead or
+                duplicated affordance ever shows:
+                  - Skip: shown while scanning / found. The empty phase owns its
+                    own prominent Skip card, so the footer Skip is dropped there
+                    to avoid two "Skip for now" buttons on one screen.
+                  - Start exploring: only actionable once a runtime is picked, so
+                    it renders only in the found phase instead of sitting
+                    permanently disabled through scanning / empty. */}
             <div className="mt-8 flex flex-wrap items-center justify-end gap-x-4 gap-y-2">
               <span
                 aria-live="polite"
@@ -242,25 +288,31 @@ function FancyView({
               >
                 {footerHint}
               </span>
-              <div className="flex items-center gap-2">
-                <Button
-                  size="lg"
-                  variant="secondary"
-                  disabled={submitting}
-                  onClick={handleSkip}
-                >
-                  {t(($) => $.step_runtime.skip)}
-                </Button>
-                <Button
-                  size="lg"
-                  disabled={!canContinue || submitting}
-                  onClick={handleContinue}
-                >
-                  {submitting && <Loader2 className="h-4 w-4 animate-spin" />}
-                  {t(($) => $.step_runtime.start_exploring)}
-                  <ArrowRight className="h-4 w-4" />
-                </Button>
-              </div>
+              {phase !== "empty" && (
+                <div className="flex items-center gap-2">
+                  <Button
+                    size="lg"
+                    variant="secondary"
+                    disabled={submitting}
+                    onClick={handleSkip}
+                  >
+                    {t(($) => $.step_runtime.skip)}
+                  </Button>
+                  {phase === "found" && (
+                    <Button
+                      size="lg"
+                      disabled={!canContinue || submitting}
+                      onClick={handleContinue}
+                    >
+                      {submitting && (
+                        <Loader2 className="h-4 w-4 animate-spin" />
+                      )}
+                      {t(($) => $.step_runtime.start_exploring)}
+                      <ArrowRight className="h-4 w-4" />
+                    </Button>
+                  )}
+                </div>
+              )}
             </div>
           </div>
         </main>

--- a/server/internal/daemon/daemon.go
+++ b/server/internal/daemon/daemon.go
@@ -19,6 +19,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	"golang.org/x/sync/errgroup"
 	"golang.org/x/sync/singleflight"
 
 	"github.com/multica-ai/multica/server/internal/cli"
@@ -1200,39 +1201,98 @@ func (d *Daemon) customProfileLaunchForRuntime(runtimeID string) (profileLaunchS
 	return spec, true
 }
 
-func (d *Daemon) registerRuntimesForWorkspace(ctx context.Context, workspaceID string) (*RegisterResponse, string, error) {
-	d.logger.Debug("registering runtimes for workspace", "workspace_id", workspaceID, "agent_count", len(d.cfg.Agents))
-	var runtimes []map[string]string
-	var failedProfiles []map[string]string
+// runtimeVersionProbeConcurrency bounds how many `<cli> --version` probes run
+// at once during registration. Version detection is process-spawn bound rather
+// than CPU bound, and each probe already carries its own timeout, so a modest
+// fan-out is safe even when a host has many agent CLIs installed.
+const runtimeVersionProbeConcurrency = 8
+
+// detectBuiltinRuntimes version-detects every configured built-in agent CLI and
+// returns a registration entry for each one that resolves and clears the
+// minimum-version gate. Probes run concurrently, bounded by
+// runtimeVersionProbeConcurrency.
+//
+// The previous implementation probed serially, so total latency was the SUM of
+// every CLI's `--version` call. On an onboarding host with several coding tools
+// installed that stacked into many seconds of dead time before the daemon could
+// register — long enough that the desktop runtime step timed out into its empty
+// "no runtime found" state while the probes were still running (MUL-5119).
+// Fanning the probes out makes total latency track the SLOWEST single probe
+// instead of their sum, so a freshly-created workspace lights up its runtimes
+// well inside the UI's scanning window.
+//
+// Each probe still self-heals a vanished pinned path (MUL-4486) and re-detects
+// the live version — no result is cached across registrations, so an in-place
+// CLI upgrade is still reported with its current version. A probe that fails to
+// detect a version or is below the minimum supported version is logged and
+// skipped, exactly as the serial loop did.
+func (d *Daemon) detectBuiltinRuntimes(ctx context.Context) []map[string]string {
+	type detected struct {
+		name    string
+		version string
+	}
+	var (
+		mu      sync.Mutex
+		results []detected
+		g       errgroup.Group
+	)
+	g.SetLimit(runtimeVersionProbeConcurrency)
 	for name, entry := range d.cfg.Agents {
-		// Self-heal a pinned executable path an in-place upgrade deleted
-		// (MUL-4486) so version detection — and thus staying registered/online
-		// — recovers without a daemon restart. resolveAgentEntry already
-		// version-gates the healed binary; the detect + min-version check below
-		// still runs to produce the version string this registration reports.
-		entry, _ = d.resolveAgentEntry(ctx, name, entry)
-		version, err := detectAgentVersion(ctx, entry.Path)
-		if err != nil {
-			d.logger.Warn("skip registering runtime", "name", name, "error", err)
-			continue
-		}
-		if err := checkAgentMinVersion(name, version); err != nil {
-			d.logger.Warn("skip registering runtime: version too old", "name", name, "version", version, "error", err)
-			continue
-		}
-		d.setAgentVersion(name, version)
-		d.logger.Debug("agent version detected", "name", name, "version", version, "path", entry.Path)
-		displayName := providerDisplayName(name)
+		name, entry := name, entry
+		g.Go(func() error {
+			// Self-heal a pinned executable path an in-place upgrade deleted
+			// (MUL-4486) so version detection — and thus staying
+			// registered/online — recovers without a daemon restart.
+			// resolveAgentEntry already version-gates the healed binary; the
+			// detect + min-version check below still runs to produce the
+			// version string this registration reports.
+			entry, _ = d.resolveAgentEntry(ctx, name, entry)
+			version, err := detectAgentVersion(ctx, entry.Path)
+			if err != nil {
+				d.logger.Warn("skip registering runtime", "name", name, "error", err)
+				return nil
+			}
+			if err := checkAgentMinVersion(name, version); err != nil {
+				d.logger.Warn("skip registering runtime: version too old", "name", name, "version", version, "error", err)
+				return nil
+			}
+			d.setAgentVersion(name, version)
+			d.logger.Debug("agent version detected", "name", name, "version", version, "path", entry.Path)
+			mu.Lock()
+			results = append(results, detected{name: name, version: version})
+			mu.Unlock()
+			return nil
+		})
+	}
+	// No probe returns a non-nil error — failures are logged and skipped above —
+	// so Wait only blocks for the in-flight probes to finish.
+	_ = g.Wait()
+
+	// Source iteration (a map) and parallel completion order are both
+	// nondeterministic; sort by provider so the registration payload is stable
+	// across runs and order-sensitive tests stay deterministic.
+	sort.Slice(results, func(i, j int) bool { return results[i].name < results[j].name })
+
+	runtimes := make([]map[string]string, 0, len(results))
+	for _, r := range results {
+		displayName := providerDisplayName(r.name)
 		if d.cfg.DeviceName != "" {
 			displayName = fmt.Sprintf("%s (%s)", displayName, d.cfg.DeviceName)
 		}
 		runtimes = append(runtimes, map[string]string{
 			"name":    displayName,
-			"type":    name,
-			"version": version,
+			"type":    r.name,
+			"version": r.version,
 			"status":  "online",
 		})
 	}
+	return runtimes
+}
+
+func (d *Daemon) registerRuntimesForWorkspace(ctx context.Context, workspaceID string) (*RegisterResponse, string, error) {
+	d.logger.Debug("registering runtimes for workspace", "workspace_id", workspaceID, "agent_count", len(d.cfg.Agents))
+	runtimes := d.detectBuiltinRuntimes(ctx)
+	var failedProfiles []map[string]string
 
 	// Append any workspace custom runtime profiles whose command resolves on
 	// this host (MUL-3284). This is best-effort: a fetch error (e.g. an older

--- a/server/internal/daemon/runtime_probe_concurrency_test.go
+++ b/server/internal/daemon/runtime_probe_concurrency_test.go
@@ -1,0 +1,112 @@
+package daemon
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// TestDetectBuiltinRuntimes_ProbesRunConcurrently proves the registration
+// version probes fan out instead of running serially (MUL-5119). Each stubbed
+// `--version` probe blocks briefly and records the peak number of in-flight
+// probes; a serial loop would never exceed 1 and would take N×block, while the
+// parallel path overlaps them and finishes in roughly one block.
+func TestDetectBuiltinRuntimes_ProbesRunConcurrently(t *testing.T) {
+	origDetect := detectAgentVersion
+	origCheck := checkAgentMinVersion
+	t.Cleanup(func() {
+		detectAgentVersion = origDetect
+		checkAgentMinVersion = origCheck
+	})
+
+	const probeBlock = 100 * time.Millisecond
+	var inFlight, maxInFlight int32
+	detectAgentVersion = func(_ context.Context, _ string) (string, error) {
+		cur := atomic.AddInt32(&inFlight, 1)
+		for {
+			prev := atomic.LoadInt32(&maxInFlight)
+			if cur <= prev || atomic.CompareAndSwapInt32(&maxInFlight, prev, cur) {
+				break
+			}
+		}
+		time.Sleep(probeBlock)
+		atomic.AddInt32(&inFlight, -1)
+		return "9.9.9", nil
+	}
+	checkAgentMinVersion = func(_, _ string) error { return nil }
+
+	d := freshDaemon("")
+	d.cfg.Agents = map[string]AgentEntry{
+		"claude":   {Path: "/usr/bin/true"},
+		"codex":    {Path: "/usr/bin/true"},
+		"cursor":   {Path: "/usr/bin/true"},
+		"opencode": {Path: "/usr/bin/true"},
+		"hermes":   {Path: "/usr/bin/true"},
+		"pi":       {Path: "/usr/bin/true"},
+	}
+
+	start := time.Now()
+	runtimes := d.detectBuiltinRuntimes(context.Background())
+	elapsed := time.Since(start)
+
+	if len(runtimes) != len(d.cfg.Agents) {
+		t.Fatalf("expected %d runtimes, got %d", len(d.cfg.Agents), len(runtimes))
+	}
+	if got := atomic.LoadInt32(&maxInFlight); got < 2 {
+		t.Fatalf("probes did not overlap (peak in-flight = %d); registration is still serial", got)
+	}
+	if serialFloor := time.Duration(len(d.cfg.Agents)) * probeBlock; elapsed >= serialFloor {
+		t.Fatalf("detectBuiltinRuntimes took %v (>= serial floor %v); not parallel", elapsed, serialFloor)
+	}
+
+	// Output is sorted by provider so the registration payload is deterministic
+	// despite random map iteration and nondeterministic completion order.
+	for i := 1; i < len(runtimes); i++ {
+		if runtimes[i-1]["type"] > runtimes[i]["type"] {
+			t.Fatalf("runtimes not sorted by type: %q before %q", runtimes[i-1]["type"], runtimes[i]["type"])
+		}
+	}
+}
+
+// TestDetectBuiltinRuntimes_SkipsFailedProbes confirms a probe that fails
+// version detection or the min-version gate is dropped from the payload while
+// the healthy ones still register — matching the old serial loop's semantics.
+func TestDetectBuiltinRuntimes_SkipsFailedProbes(t *testing.T) {
+	origDetect := detectAgentVersion
+	origCheck := checkAgentMinVersion
+	t.Cleanup(func() {
+		detectAgentVersion = origDetect
+		checkAgentMinVersion = origCheck
+	})
+
+	detectAgentVersion = func(_ context.Context, path string) (string, error) {
+		if path == "/broken" {
+			return "", context.DeadlineExceeded
+		}
+		return "9.9.9", nil
+	}
+	checkAgentMinVersion = func(provider, _ string) error {
+		if provider == "tooold" {
+			return context.Canceled // stand-in for a below-minimum version
+		}
+		return nil
+	}
+
+	d := freshDaemon("")
+	d.cfg.Agents = map[string]AgentEntry{
+		"claude": {Path: "/usr/bin/true"},
+		"codex":  {Path: "/usr/bin/true"},
+		"broken": {Path: "/broken"},
+		"tooold": {Path: "/usr/bin/true"},
+	}
+
+	runtimes := d.detectBuiltinRuntimes(context.Background())
+	got := map[string]bool{}
+	for _, rt := range runtimes {
+		got[rt["type"]] = true
+	}
+	if len(runtimes) != 2 || !got["claude"] || !got["codex"] {
+		t.Fatalf("expected only claude+codex to register, got %v", runtimes)
+	}
+}


### PR DESCRIPTION
## MUL-5119 — fix the Desktop runtime-step "jump" / false-negative flash

Follow-up to the analysis on MUL-5119. The onboarding runtime step (Step 5) jumped **scanning → "No agent runtime found" (false negative) → found** on a machine that *does* have coding tools installed. Two root causes, fixed here.

### 1. Daemon — parallelize version detection (`perf(daemon)`)
`registerRuntimesForWorkspace` probed each agent CLI's `--version` **serially**, so registration latency was the *sum* of every probe (measured 3.5s idle, up to ~9.8s under load; one wedged CLI could eat a full 10s). That routinely outlasted the UI's 5s scanning budget.

- Fan the probes out with a bounded `errgroup` (`SetLimit(8)`) so total latency tracks the *slowest single* probe instead of the sum.
- No cross-registration caching: each probe still self-heals a vanished pinned path (MUL-4486) and re-detects the live version, so an in-place CLI upgrade is still reported correctly.
- Failures still logged & skipped; results sorted by provider for a deterministic payload.
- **Measured after: ~2.0s for 8 CLIs (bounded by openclaw's single ~2s probe); ~2.7s even including a full daemon cold-start.**

### 2. Onboarding — gate the empty state on daemon status (`fix(onboarding)`)
The step flipped to empty on a fixed 5s wall-clock, guaranteeing a false-negative flash whenever registration ran long (cold start / slow CLI / many CLIs).

- New desktop-only `runtimesPending` signal (`useLocalRuntimesPending`) derived from the local daemon's live status — booting, or running with agent CLIs detected on the host. While pending, the scanning skeleton persists past the soft timeout. The daemon's `/health` `agents` list comes from its boot-time PATH scan, so it's populated well before the slow version-registration — a reliable "runtimes are coming" hint.
- An absolute hard-timeout ceiling (20s) still guarantees a fallback so a wedged probe can't pin the step on the skeleton forever.
- **Web is unchanged** — it omits the signal and keeps the plain wall-clock timeout.

### 3. UI cleanup on the step (`fix(onboarding)`)
- The permanently-disabled **"Start exploring"** now renders only in the found phase (was dead/greyed through scanning + empty).
- The empty state's **duplicate "Skip for now"** footer button is removed in favour of its own prominent Skip card; that card now routes through the guarded handler.

## Verification
- **Real Desktop app** (rebuilt daemon from this branch + real 8-CLI machine), driven through the full onboarding flow over CDP:
  - Three fresh-user runs went **scanning → found with the empty state never appearing** (ms-granularity DOM poll: `scanning@~190ms → found@2.5s`, and one run at ~5s where the gate held during the boundary window).
  - Cold-start run (daemon restarted mid-flow): registration finished in ~2.7s, still no flash.
- **Unit tests**
  - `server/internal/daemon/runtime_probe_concurrency_test.go` — proves probes overlap (peak in-flight ≥ 2, completes in one block not N) and that failed probes are skipped. Passes under `-race`.
  - `packages/views/.../step-runtime-connect.test.tsx` — empty flips at 5s with no pending signal; **stays scanning past 5s while pending, then falls back at the hard ceiling**; found short-circuits empty; no dead Start-exploring in scanning; single Skip in empty.
- `pnpm typecheck` (views + desktop), `pnpm lint` (0 errors), `go build ./...`, `go vet`, `gofmt` — all clean. Full `daemon` package green under `-race`.

Before/after screenshots are attached on the MUL-5119 issue comment.
