### PR TITLE
MUL-5152: assign emoji avatars to new agents

### DIFF
--- a/apps/mobile/components/ui/actor-avatar.tsx
+++ b/apps/mobile/components/ui/actor-avatar.tsx
@@ -89,8 +89,29 @@ function BareAvatar({
   // can crash native-side on malformed sources (empty string, plain "foo",
   // etc.). Cheap regex; falsy / bad input falls through to the icon fallback.
   const rawUrl = type && type !== "system" ? getAvatarUrl(type, id) : null;
+  const emoji = rawUrl?.startsWith("emoji:")
+    ? rawUrl.slice("emoji:".length).trim() || null
+    : null;
   const url =
-    rawUrl && /^(https?:|data:|file:|asset:)/.test(rawUrl) ? rawUrl : null;
+    !emoji && rawUrl && /^(https?:|data:|file:|asset:)/.test(rawUrl)
+      ? rawUrl
+      : null;
+
+  if (emoji) {
+    return (
+      <View
+        style={{ width: size, height: size, borderRadius: radius }}
+        className="items-center justify-center bg-muted"
+      >
+        <Text
+          accessibilityLabel={type === "system" ? "" : getName(type, id)}
+          style={{ fontSize: Math.round(size * 0.58), lineHeight: size }}
+        >
+          {emoji}
+        </Text>
+      </View>
+    );
+  }
 
   if (url) {
     return (

--- a/packages/ui/components/common/actor-avatar.tsx
+++ b/packages/ui/components/common/actor-avatar.tsx
@@ -8,6 +8,7 @@ import {
   DEFAULT_AVATAR_SIZE,
   type AvatarSize,
 } from "@multica/ui/lib/avatar-size";
+import { parseAvatarEmoji } from "@multica/ui/lib/avatar-emoji";
 import { MulticaIcon } from "./multica-icon";
 
 interface ActorAvatarProps {
@@ -33,6 +34,7 @@ function ActorAvatar({
 }: ActorAvatarProps) {
   const [imgError, setImgError] = useState(false);
   const px = AVATAR_SIZE_PX[size];
+  const emoji = parseAvatarEmoji(avatarUrl);
 
   useEffect(() => {
     setImgError(false);
@@ -46,7 +48,7 @@ function ActorAvatar({
       data-slot="avatar"
       className={cn(
         "inline-flex shrink-0 items-center justify-center font-medium overflow-hidden",
-        (!avatarUrl || imgError) && "bg-muted text-muted-foreground",
+        (!avatarUrl || emoji || imgError) && "bg-muted text-muted-foreground",
         className,
         // rounded-full stays last so a call-site `className` can never override
         // the circle — avatar shape is a hard invariant, not a per-site choice.
@@ -54,7 +56,16 @@ function ActorAvatar({
       )}
       style={{ width: px, height: px, fontSize: px * 0.45 }}
     >
-      {avatarUrl && !imgError ? (
+      {emoji ? (
+        <span
+          role="img"
+          aria-label={name}
+          className="select-none leading-none"
+          style={{ fontSize: px * 0.58 }}
+        >
+          {emoji}
+        </span>
+      ) : avatarUrl && !imgError ? (
         <img
           src={avatarUrl}
           alt={name}

--- a/packages/ui/lib/avatar-emoji.ts
+++ b/packages/ui/lib/avatar-emoji.ts
@@ -1,0 +1,8 @@
+const AVATAR_EMOJI_PREFIX = "emoji:";
+
+export function parseAvatarEmoji(value?: string | null): string | null {
+  if (!value?.startsWith(AVATAR_EMOJI_PREFIX)) return null;
+
+  const emoji = value.slice(AVATAR_EMOJI_PREFIX.length).trim();
+  return emoji || null;
+}

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -17,6 +17,7 @@
     "./hooks/*": "./hooks/*.ts",
     "./lib/utils": "./lib/utils.ts",
     "./lib/avatar-size": "./lib/avatar-size.ts",
+    "./lib/avatar-emoji": "./lib/avatar-emoji.ts",
     "./lib/data-table": "./lib/data-table.ts",
     "./lib/code-style": "./lib/code-style.ts",
     "./lib/clipboard": "./lib/clipboard.ts",

--- a/packages/views/common/avatar-upload-control.tsx
+++ b/packages/views/common/avatar-upload-control.tsx
@@ -6,6 +6,7 @@ import { toast } from "sonner";
 import { api } from "@multica/core/api";
 import { useFileUpload } from "@multica/core/hooks/use-file-upload";
 import { resolvePublicFileUrl } from "@multica/core/workspace/avatar-url";
+import { parseAvatarEmoji } from "@multica/ui/lib/avatar-emoji";
 import { cn } from "@multica/ui/lib/utils";
 import { useT } from "../i18n";
 import { AvatarCropDialog } from "./avatar-crop-dialog";
@@ -100,8 +101,10 @@ export function AvatarUploadControl({
   const [busy, setBusy] = useState(false);
   const [previewError, setPreviewError] = useState(false);
 
-  const resolved = value ? resolvePublicFileUrl(value) : null;
+  const emoji = parseAvatarEmoji(value);
+  const resolved = value && !emoji ? resolvePublicFileUrl(value) : null;
   const hasImage = !!resolved && !previewError;
+  const hasAvatar = !!emoji || hasImage;
 
   const handlePick = (e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0];
@@ -151,7 +154,16 @@ export function AvatarUploadControl({
         )}
         style={{ width: size, height: size }}
       >
-        {hasImage ? (
+        {emoji ? (
+          <span
+            role="img"
+            aria-label={name}
+            className="select-none leading-none"
+            style={{ fontSize: size * 0.58 }}
+          >
+            {emoji}
+          </span>
+        ) : hasImage ? (
           <img
             src={resolved ?? undefined}
             alt={name}
@@ -173,7 +185,7 @@ export function AvatarUploadControl({
         )}
       </button>
 
-      {onClear && hasImage && !busy && !disabled && (
+      {onClear && hasAvatar && !busy && !disabled && (
         <button
           type="button"
           onClick={(e) => {

--- a/server/internal/handler/agent.go
+++ b/server/internal/handler/agent.go
@@ -1129,7 +1129,7 @@ func (h *Handler) CreateAgent(w http.ResponseWriter, r *http.Request) {
 		Name:                     req.Name,
 		Description:              req.Description,
 		Instructions:             req.Instructions,
-		AvatarUrl:                ptrToText(req.AvatarURL),
+		AvatarUrl:                newAgentAvatar(req.AvatarURL),
 		RuntimeMode:              runtime.RuntimeMode,
 		RuntimeConfig:            rc,
 		RuntimeID:                runtime.ID,

--- a/server/internal/handler/agent_avatar.go
+++ b/server/internal/handler/agent_avatar.go
@@ -1,0 +1,32 @@
+package handler
+
+import (
+	"crypto/rand"
+	"math/big"
+	"strings"
+
+	"github.com/jackc/pgx/v5/pgtype"
+)
+
+const agentEmojiAvatarPrefix = "emoji:"
+
+var agentEmojiAvatars = []string{
+	"🐙", "🦊", "🦉", "🐝", "🐼", "🐸", "🐯", "🦁",
+	"🐨", "🐵", "🐧", "🐳", "🦋", "🌞", "🌙", "⭐",
+	"🔥", "⚡", "🍀", "🌈", "🚀", "🤖", "👾", "🧠",
+}
+
+func randomAgentEmojiAvatar() string {
+	index, err := rand.Int(rand.Reader, big.NewInt(int64(len(agentEmojiAvatars))))
+	if err != nil {
+		return agentEmojiAvatarPrefix + agentEmojiAvatars[0]
+	}
+	return agentEmojiAvatarPrefix + agentEmojiAvatars[index.Int64()]
+}
+
+func newAgentAvatar(avatarURL *string) pgtype.Text {
+	if avatarURL != nil && strings.TrimSpace(*avatarURL) != "" {
+		return pgtype.Text{String: *avatarURL, Valid: true}
+	}
+	return pgtype.Text{String: randomAgentEmojiAvatar(), Valid: true}
+}

--- a/server/internal/handler/agent_template.go
+++ b/server/internal/handler/agent_template.go
@@ -455,10 +455,7 @@ func (h *Handler) CreateAgentFromTemplate(w http.ResponseWriter, r *http.Request
 	if req.Instructions != nil {
 		instructions = *req.Instructions
 	}
-	avatarURL := pgtype.Text{}
-	if req.AvatarURL != nil && *req.AvatarURL != "" {
-		avatarURL = pgtype.Text{String: *req.AvatarURL, Valid: true}
-	}
+	avatarURL := newAgentAvatar(req.AvatarURL)
 
 	agent, err := qtx.CreateAgent(r.Context(), db.CreateAgentParams{
 		WorkspaceID:        wsUUID,

--- a/server/internal/handler/agent_test.go
+++ b/server/internal/handler/agent_test.go
@@ -190,6 +190,70 @@ func TestCreateAgent_RejectsDuplicateName(t *testing.T) {
 	}
 }
 
+func TestCreateAgent_AssignsAvatarDefault(t *testing.T) {
+	if testHandler == nil {
+		t.Skip("database not available")
+	}
+
+	tests := []struct {
+		name       string
+		avatarURL  *string
+		wantAvatar string
+		wantEmoji  bool
+	}{
+		{name: "omitted", wantEmoji: true},
+		{name: "empty", avatarURL: ptr(""), wantEmoji: true},
+		{
+			name:       "explicit",
+			avatarURL:  ptr("https://cdn.example.com/avatars/agent.png"),
+			wantAvatar: "https://cdn.example.com/avatars/agent.png",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			agentName := "avatar-default-test-" + tt.name
+			t.Cleanup(func() {
+				testPool.Exec(context.Background(),
+					`DELETE FROM agent WHERE workspace_id = $1 AND name = $2`,
+					testWorkspaceID, agentName,
+				)
+			})
+
+			body := map[string]any{
+				"name":       agentName,
+				"runtime_id": testRuntimeID,
+			}
+			if tt.avatarURL != nil {
+				body["avatar_url"] = *tt.avatarURL
+			}
+
+			w := httptest.NewRecorder()
+			testHandler.CreateAgent(w, newRequest(http.MethodPost, "/api/agents", body))
+			if w.Code != http.StatusCreated {
+				t.Fatalf("CreateAgent: expected 201, got %d: %s", w.Code, w.Body.String())
+			}
+
+			var response AgentResponse
+			if err := json.NewDecoder(w.Body).Decode(&response); err != nil {
+				t.Fatalf("decode response: %v", err)
+			}
+			if response.AvatarURL == nil {
+				t.Fatal("CreateAgent: avatar_url is nil")
+			}
+			if tt.wantEmoji {
+				if !strings.HasPrefix(*response.AvatarURL, "emoji:") {
+					t.Fatalf("CreateAgent: avatar_url = %q, want emoji avatar", *response.AvatarURL)
+				}
+				return
+			}
+			if *response.AvatarURL != tt.wantAvatar {
+				t.Fatalf("CreateAgent: avatar_url = %q, want %q", *response.AvatarURL, tt.wantAvatar)
+			}
+		})
+	}
+}
+
 func TestWorkspaceAlwaysRedactSecrets(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/server/internal/service/builtin_skills/multica-creating-agents/SKILL.md
+++ b/server/internal/service/builtin_skills/multica-creating-agents/SKILL.md
@@ -62,8 +62,9 @@ non-empty value, the rest (`runtime-config`, `custom-args`, `model`,
 flags fall through to server defaults rather than sending empty strings.
 
 The HTTP body (`CreateAgentRequest`) accepts: `name`, `description`,
-`instructions`, `runtime_id`, `runtime_config`, `custom_env`, `custom_args`,
-`model`, `thinking_level`, `visibility`, `max_concurrent_tasks`, `mcp_config`.
+`instructions`, `avatar_url`, `runtime_id`, `runtime_config`, `custom_env`,
+`custom_args`, `model`, `thinking_level`, `visibility`,
+`max_concurrent_tasks`, `mcp_config`.
 
 ## Field contracts
 
@@ -72,6 +73,7 @@ The HTTP body (`CreateAgentRequest`) accepts: `name`, `description`,
 | `name` | `agent.name` | required, 400 if empty | listings, runtime payload |
 | `description` | `agent.description` | 400 if > 255 code points | catalog/listing only — NOT the runtime prompt |
 | `instructions` | `agent.instructions` | none | daemon → provider at claim time |
+| `avatar_url` | `agent.avatar_url` | none; an explicit non-empty value is preserved, while omitted/empty creates a random `emoji:<glyph>` avatar | catalog/listing UI only — NOT the runtime prompt |
 | `runtime_id` | `agent.runtime_id` | required (400) + must resolve to a runtime in this workspace | selects runtime/provider |
 | `model` | `agent.model` (nullable) | none beyond runtime support | daemon reads; empty = runtime default |
 | `thinking_level` | `agent.thinking_level` (nullable) | provider-level enum; unknown literal → 400 | daemon; empty = runtime default |
@@ -83,7 +85,8 @@ The HTTP body (`CreateAgentRequest`) accepts: `name`, `description`,
 | `max_concurrent_tasks` | `agent.max_concurrent_tasks` | — | scheduler task cap; defaults to `6` |
 
 Defaults when omitted: `runtime_config` → `{}`, `custom_env` → `{}`,
-`custom_args` → `[]`, `visibility` → `private`, `max_concurrent_tasks` → `6`
+`custom_args` → `[]`, `avatar_url` → a random `emoji:<glyph>`, `visibility` →
+`private`, `max_concurrent_tasks` → `6`
 (all materialized server-side before the insert). `custom_args`/`runtime_config`
 are typed `[]string`/`any` and marshaled as-is — the JSON-shape rejection
 happens in the CLI, not the create handler.

--- a/server/internal/service/builtin_skills/multica-creating-agents/references/creating-agents-source-map.md
+++ b/server/internal/service/builtin_skills/multica-creating-agents/references/creating-agents-source-map.md
@@ -50,7 +50,7 @@ only.
 |---|---|---|
 | `maxAgentDescriptionLength = 255` | 31 | Cap is 255 **Unicode code points** (comment: counted via `utf8.RuneCountInString`, matches Postgres `char_length`) |
 | `AgentResponse` omits plaintext `custom_env` | 33–53 | Exposes only `has_custom_env` (52) and `custom_env_key_count` (53); comment cites MUL-2600 |
-| `CreateAgentRequest` fields | 565–585 | `description`, `instructions`, `runtime_config`, `custom_env`, `custom_args`, `model`, `thinking_level` (plus name/avatar/visibility/mcp_config/max_concurrent_tasks) |
+| `CreateAgentRequest` fields | 919–956 | `description`, `instructions`, `avatar_url`, `runtime_config`, `custom_env`, `custom_args`, `model`, `thinking_level` (plus name/visibility/mcp_config/max_concurrent_tasks/permission inputs) |
 | `name` required | 623–625 | 400 "name is required" |
 | `description` ≤ 255 code points | 627–629 | `utf8.RuneCountInString(req.Description) > maxAgentDescriptionLength` → 400 |
 | `runtime_id` required | 631–633 | `if req.RuntimeID == ""` → 400 "runtime_id is required" |
@@ -62,7 +62,8 @@ only.
 | `mcp_config` null-skip on create | 704–705 | raw JSON copied through unless the body value is the literal `null` |
 | `mcp_config` redacted on read | 54, 848–851 | `redactMcpConfig` sets `McpConfigRedacted=true`; a private agent read by a member also redacts (494, 509) |
 | Qwen Code managed-MCP injection | `pkg/agent/qwen.go` | Non-null `mcp_config` is written to a daemon-owned 0600 temporary JSON file and passed with `--mcp-config`; the file is removed after the process exits, while `null` preserves native inheritance. |
-| `CreateAgent` insert params | 708–722 | persists runtime_config, instructions, custom_env, custom_args, model, thinking_level, mcp_config, visibility, max_concurrent_tasks |
+| Random emoji avatar default | `agent_avatar.go` 11–32; `agent.go` 1127–1133 | Omitted, empty, or whitespace-only `avatar_url` becomes a cryptographically selected `emoji:<glyph>` sentinel; explicit values are preserved. The template handler uses the same helper at `agent_template.go` 458. |
+| `CreateAgent` insert params | 1127–1145 | persists avatar_url, runtime_config, instructions, custom_env, custom_args, model, thinking_level, mcp_config, visibility, max_concurrent_tasks |
 | `UpdateAgent` rejects `custom_env` | 910–913 | if `custom_env` present in body → 400 "use PUT /api/agents/{id}/env (or `multica agent env set`)" |
 | `UpdateAgent` persists / clears `mcp_config` | 944–948, 1060–1061 | Tri-state from the raw body: key omitted → no change; literal `null` → `ClearAgentMcpConfig`; object → replace. No 400 like `custom_env` — `mcp_config` IS updatable here |
 | `description` ≤ 255 on update too | 921–924 | same cap re-checked on update |

--- a/server/internal/service/builtin_skills_test.go
+++ b/server/internal/service/builtin_skills_test.go
@@ -335,6 +335,7 @@ func TestCreatingAgentsSkillCoversAgentCreationContracts(t *testing.T) {
 		"not a parameter manual",
 		"`description` is a catalog summary",
 		"`instructions` is the runtime behavior contract",
+		"`avatar_url` → a random `emoji:<glyph>`",
 		"multica agent create --name <name> --runtime-id <runtime-id>",
 		"`model` is a first-class persisted column",
 		"custom_env",


### PR DESCRIPTION
## Summary

- assign a random persisted `emoji:<glyph>` avatar when a new Agent omits or empties `avatar_url`
- render Emoji avatars consistently in web, Desktop, upload controls, and mobile while preserving explicit image URLs
- cover the create contract with handler tests and update the built-in Agent creation skill

## Verification

- `go test ./internal/handler -run '^TestCreateAgent' -count=1`
- `go test ./internal/service -run '^(TestCreatingAgentsSkillCoversAgentCreationContracts|TestBuiltinSkillsConformToTemplate)$' -count=1`
- `pnpm --filter @multica/ui typecheck`
- `pnpm --filter @multica/views typecheck`
- `pnpm --filter @multica/mobile typecheck`
- targeted ESLint for all touched TypeScript/TSX files
- local API creation returned `avatar_url: emoji:🐳`; real browser verification confirmed the new avatar while a pre-existing null avatar kept its legacy fallback

Closes MUL-5152
