### PR TITLE
MUL-5145: open table issues in new tabs

### DIFF
--- a/packages/views/issues/components/table-view-editing.test.tsx
+++ b/packages/views/issues/components/table-view-editing.test.tsx
@@ -78,11 +78,25 @@ vi.mock("@multica/core/auth", () => ({
   ),
 }));
 
+const navigationMocks = vi.hoisted(() => ({
+  push: vi.fn(),
+  openInNewTab: vi.fn(),
+  getShareableUrl: vi.fn((path: string) => `https://app.example${path}`),
+}));
+const navigationState = vi.hoisted(() => ({ hasOpenInNewTab: true }));
+
 vi.mock("../../navigation", () => ({
   AppLink: ({ children, ...props }: React.ComponentProps<"a">) => (
     <a {...props}>{children}</a>
   ),
-  useNavigation: () => ({ push: vi.fn(), pathname: "/" }),
+  useNavigation: () => ({
+    push: navigationMocks.push,
+    openInNewTab: navigationState.hasOpenInNewTab
+      ? navigationMocks.openInNewTab
+      : undefined,
+    getShareableUrl: navigationMocks.getShareableUrl,
+    pathname: "/",
+  }),
 }));
 
 vi.mock("@multica/core/paths", async () => {
@@ -184,6 +198,13 @@ describe("TableView cell editors under data refresh", () => {
   let queryClient: QueryClient;
 
   beforeEach(() => {
+    navigationMocks.push.mockReset();
+    navigationMocks.openInNewTab.mockReset();
+    navigationMocks.getShareableUrl.mockReset();
+    navigationMocks.getShareableUrl.mockImplementation(
+      (path: string) => `https://app.example${path}`,
+    );
+    navigationState.hasOpenInNewTab = true;
     vi.stubGlobal("IntersectionObserver", ObserverStub);
     vi.stubGlobal("ResizeObserver", ObserverStub);
     queryClient = new QueryClient({
@@ -321,6 +342,68 @@ describe("TableView cell editors under data refresh", () => {
       parent_issue_identifier: "MUL-a",
       project_id: "project-1",
     });
+  });
+
+  it("opens title and row clicks in a foreground Desktop tab", async () => {
+    const user = userEvent.setup({ delay: null, pointerEventsCheck: 0 });
+    serverIssues = [makeIssue("a", "Alpha task", "todo")];
+
+    renderWithI18n(
+      <QueryClientProvider client={queryClient}>
+        <Harness
+          childProgressMap={new Map()}
+          surfaceKey={`test-new-tab-${Math.floor(Math.random() * 1e9)}`}
+        />
+      </QueryClientProvider>,
+    );
+
+    const row = (await screen.findByText("MUL-a")).closest("tr")!;
+    await user.click(within(row).getByRole("button", { name: "Alpha task" }));
+    expect(navigationMocks.openInNewTab).toHaveBeenCalledWith(
+      "/test/issues/a",
+      "MUL-a",
+      { activate: true },
+    );
+    expect(navigationMocks.push).not.toHaveBeenCalled();
+
+    navigationMocks.openInNewTab.mockClear();
+    await user.click(row);
+    expect(navigationMocks.openInNewTab).toHaveBeenCalledWith(
+      "/test/issues/a",
+      "MUL-a",
+      { activate: true },
+    );
+    expect(navigationMocks.push).not.toHaveBeenCalled();
+  });
+
+  it("opens a real browser tab when the platform has no tab adapter", async () => {
+    const user = userEvent.setup({ delay: null, pointerEventsCheck: 0 });
+    const windowOpen = vi.fn();
+    vi.stubGlobal("open", windowOpen);
+    navigationState.hasOpenInNewTab = false;
+    serverIssues = [makeIssue("a", "Alpha task", "todo")];
+
+    renderWithI18n(
+      <QueryClientProvider client={queryClient}>
+        <Harness
+          childProgressMap={new Map()}
+          surfaceKey={`test-browser-tab-${Math.floor(Math.random() * 1e9)}`}
+        />
+      </QueryClientProvider>,
+    );
+
+    const row = (await screen.findByText("MUL-a")).closest("tr")!;
+    await user.click(within(row).getByRole("button", { name: "Alpha task" }));
+
+    expect(navigationMocks.getShareableUrl).toHaveBeenCalledWith(
+      "/test/issues/a",
+    );
+    expect(windowOpen).toHaveBeenCalledWith(
+      "https://app.example/test/issues/a",
+      "_blank",
+      "noopener,noreferrer",
+    );
+    expect(navigationMocks.push).not.toHaveBeenCalled();
   });
 });
 

--- a/packages/views/issues/components/table-view.tsx
+++ b/packages/views/issues/components/table-view.tsx
@@ -850,7 +850,7 @@ type TableViewMeta = {
   editingCellKey: string | null;
   setEditingCellKey: (key: string | null) => void;
   updateIssue: (issueId: string, updates: Partial<UpdateIssueRequest>) => void;
-  openIssue: (issueId: string) => void;
+  openIssue: (issue: Issue) => void;
   createSubIssue: (issue: Issue) => void;
   toggleTableParentCollapsed: (issueId: string) => void;
   handleIssueSelection: (issueId: string, shiftKey: boolean) => void;
@@ -1042,7 +1042,7 @@ function IssueTableBodyCell({
           editing={editorOpen}
           onEditingChange={setEditorOpen}
           onUpdate={onUpdate}
-          onOpen={() => meta.openIssue(issue.id)}
+          onOpen={() => meta.openIssue(issue)}
           onCreateSubIssue={() => meta.createSubIssue(issue)}
           onToggleParent={() => meta.toggleTableParentCollapsed(issue.id)}
           toggleLabel={t(($) => $.table.toggle_sub_issues)}
@@ -1976,7 +1976,19 @@ export function TableView({
   );
 
   const openIssue = useCallback(
-    (issueId: string) => navigation.push(paths.issueDetail(issueId)),
+    (issue: Issue) => {
+      const path = paths.issueDetail(issue.id);
+      if (navigation.openInNewTab) {
+        navigation.openInNewTab(path, issue.identifier, { activate: true });
+        return;
+      }
+
+      window.open(
+        navigation.getShareableUrl(path),
+        "_blank",
+        "noopener,noreferrer",
+      );
+    },
     [navigation, paths],
   );
 
@@ -2290,7 +2302,7 @@ export function TableView({
             emptyMessage={t(($) => $.table.empty)}
             onRowClick={(row) => {
               if (row.original.kind === "issue") {
-                openIssue(row.original.issue.id);
+                openIssue(row.original.issue);
               }
             }}
             renderRow={(row) => {


### PR DESCRIPTION
## What

- Open issue titles and rows from Table view in a foreground Desktop tab.
- Keep the Issues tab open instead of replacing it.
- Fall back to a new browser tab when Desktop tab APIs are unavailable.
- Add regression coverage for title clicks, row clicks, and browser fallback.

## Why

Table view used `navigation.push`, so opening an issue replaced the current Issues tab. Other issue entry points use the dedicated new-tab API.

## Impact

This changes only Table view issue activation. Inline editing and browser behavior remain scoped to their existing paths.

## Verification

- `pnpm -C packages/views exec vitest run ./issues/components/table-view-editing.test.tsx --reporter=verbose --pool=threads --maxWorkers=1` (7 passed)
- `pnpm --filter @multica/views typecheck`
- `pnpm -C packages/views exec eslint issues/components/table-view.tsx issues/components/table-view-editing.test.tsx`
- `git diff --check`
- Verified before/after in the isolated Desktop app

Closes MUL-5145
