### PR TITLE
MUL-5142 Preserve New Issue draft options

### DIFF
--- a/packages/core/issues/stores/draft-store.test.ts
+++ b/packages/core/issues/stores/draft-store.test.ts
@@ -32,6 +32,7 @@ const RESET_STATE = {
     priority: "none" as const,
     assigneeType: undefined,
     assigneeId: undefined,
+    projectId: undefined,
     startDate: null,
     dueDate: null,
     labelIds: [],
@@ -111,6 +112,15 @@ describe("issue draft store — last assignee", () => {
     expect(useIssueDraftStore.getState().draft.propertyValues).toEqual({});
   });
 
+  it("clearDraft removes the persisted project selection", () => {
+    const { setDraft, clearDraft } = useIssueDraftStore.getState();
+
+    setDraft({ projectId: "project-1" });
+    clearDraft();
+
+    expect(useIssueDraftStore.getState().draft.projectId).toBeUndefined();
+  });
+
   it("setLastAssignee(undefined) lets the user opt back out of a default", () => {
     const { setLastAssignee, clearDraft } = useIssueDraftStore.getState();
 
@@ -160,6 +170,7 @@ describe("issue draft store — legacy rehydrate", () => {
 
     const { draft } = useIssueDraftStore.getState();
     expect(draft.title).toBe("legacy");
+    expect(draft.projectId).toBeUndefined();
     expect(draft.attachments).toEqual([]);
     expect(draft.propertyValues).toEqual({});
   });

--- a/packages/core/issues/stores/draft-store.ts
+++ b/packages/core/issues/stores/draft-store.ts
@@ -17,6 +17,7 @@ interface IssueDraft {
   priority: IssuePriority;
   assigneeType?: IssueAssigneeType;
   assigneeId?: string;
+  projectId?: string;
   startDate: string | null;
   dueDate: string | null;
   /** Label IDs chosen in the create dialog. Attached to the issue right
@@ -34,6 +35,7 @@ const EMPTY_DRAFT: IssueDraft = {
   priority: "none",
   assigneeType: undefined,
   assigneeId: undefined,
+  projectId: undefined,
   startDate: null,
   dueDate: null,
   labelIds: [],

--- a/packages/views/modals/create-issue.test.tsx
+++ b/packages/views/modals/create-issue.test.tsx
@@ -43,6 +43,7 @@ const mockDraftStore = {
     priority: "none" as const,
     assigneeType: undefined as "agent" | "squad" | "member" | undefined,
     assigneeId: undefined as string | undefined,
+    projectId: undefined as string | undefined,
     startDate: null,
     dueDate: null,
     labelIds: [] as string[],
@@ -385,7 +386,16 @@ vi.mock("../issues/components/pickers/custom-property-picker", () => ({
 }));
 
 vi.mock("../projects/components/project-picker", () => ({
-  ProjectPicker: () => <div data-testid="project-picker" />,
+  ProjectPicker: ({ projectId, onUpdate }: any) => (
+    <button
+      type="button"
+      data-testid="project-picker"
+      data-project-id={projectId ?? "none"}
+      onClick={() => onUpdate({ project_id: "proj-1" })}
+    >
+      Project {projectId ?? "none"}
+    </button>
+  ),
 }));
 
 vi.mock("@multica/ui/components/ui/dialog", () => ({
@@ -510,6 +520,7 @@ describe("CreateIssueModal", () => {
     // doesn't leak into the next test in the suite.
     mockDraftStore.draft.assigneeType = undefined;
     mockDraftStore.draft.assigneeId = undefined;
+    mockDraftStore.draft.projectId = undefined;
     mockDraftStore.draft.startDate = null;
     mockDraftStore.draft.dueDate = null;
     mockDraftStore.draft.labelIds = [];
@@ -526,6 +537,7 @@ describe("CreateIssueModal", () => {
         priority: "none",
         assigneeType: mockDraftStore.lastAssigneeType,
         assigneeId: mockDraftStore.lastAssigneeId,
+        projectId: undefined,
         startDate: null,
         dueDate: null,
         labelIds: [],
@@ -1015,6 +1027,21 @@ describe("CreateIssueModal", () => {
         project_id: "proj-1",
       }),
     );
+  });
+
+  it("restores an unfinished project selection after manual create remounts", async () => {
+    const user = userEvent.setup();
+
+    const firstOpen = renderModal(<CreateIssueModal onClose={vi.fn()} />);
+    expect(screen.getByTestId("project-picker")).toHaveAttribute("data-project-id", "none");
+
+    await user.click(screen.getByTestId("project-picker"));
+    expect(mockSetDraft).toHaveBeenCalledWith({ projectId: "proj-1" });
+
+    firstOpen.unmount();
+    renderModal(<CreateIssueModal onClose={vi.fn()} />);
+
+    expect(screen.getByTestId("project-picker")).toHaveAttribute("data-project-id", "proj-1");
   });
 
   // Manual → agent must forward parent_issue_id when the modal was opened

--- a/packages/views/modals/create-issue.tsx
+++ b/packages/views/modals/create-issue.tsx
@@ -265,9 +265,12 @@ export function ManualCreatePanel({
   const [labelIds, setLabelIds] = useState<string[]>(draft.labelIds);
   const [propertyValues, setPropertyValues] = useState(draft.propertyValues ?? {});
   const [customPropertyPickerId, setCustomPropertyPickerId] = useState<string | null>(null);
-  const [projectId, setProjectId] = useState<string | undefined>(
-    (data?.project_id as string) || undefined,
-  );
+  const [projectId, setProjectId] = useState<string | undefined>(() => {
+    if (data && "project_id" in data) {
+      return (data.project_id as string | null) ?? undefined;
+    }
+    return draft.projectId;
+  });
   const [parentIssueId, setParentIssueId] = useState<string | undefined>(
     (data?.parent_issue_id as string) || undefined,
   );
@@ -358,6 +361,7 @@ export function ManualCreatePanel({
     setAssigneeType(type); setAssigneeId(id);
     setDraft({ assigneeType: type, assigneeId: id });
   };
+  const updateProject = (id?: string) => { setProjectId(id); setDraft({ projectId: id }); };
   const updateStartDate = (v: string | null) => { setStartDate(v); setDraft({ startDate: v }); };
   const updateDueDate = (v: string | null) => { setDueDate(v); setDraft({ dueDate: v }); };
   const updateLabelIds = (ids: string[]) => { setLabelIds(ids); setDraft({ labelIds: ids }); };
@@ -415,6 +419,7 @@ export function ManualCreatePanel({
       priority: "none",
       assigneeType,
       assigneeId,
+      projectId: undefined,
       startDate: null,
       dueDate: null,
       labelIds: [],
@@ -896,7 +901,7 @@ export function ManualCreatePanel({
               {showField.project && (
                 <ProjectPicker
                   projectId={projectId ?? null}
-                  onUpdate={(u) => setProjectId(u.project_id ?? undefined)}
+                  onUpdate={(u) => updateProject(u.project_id ?? undefined)}
                   triggerRender={<PillButton />}
                   align="start"
                   open={fieldPickerOpen === "project" ? true : undefined}

--- a/packages/views/modals/quick-create-issue.test.tsx
+++ b/packages/views/modals/quick-create-issue.test.tsx
@@ -14,6 +14,25 @@ const mockSetLastMode = vi.hoisted(() => vi.fn());
 const mockToastSuccess = vi.hoisted(() => vi.fn());
 const mockUploadWithToast = vi.hoisted(() => vi.fn());
 const mockNavigationPush = vi.hoisted(() => vi.fn());
+const mockSetIssueDraft = vi.hoisted(() => vi.fn());
+
+const mockIssueDraftStore = {
+  draft: {
+    title: "",
+    description: "",
+    status: "todo" as const,
+    priority: "none" as const,
+    assigneeType: undefined as "agent" | "squad" | "member" | undefined,
+    assigneeId: undefined as string | undefined,
+    projectId: undefined as string | undefined,
+    startDate: null as string | null,
+    dueDate: null as string | null,
+    labelIds: [] as string[],
+    propertyValues: {} as Record<string, string | number | boolean | string[]>,
+    attachments: [],
+  },
+  setDraft: mockSetIssueDraft,
+};
 
 const mockQuickCreateStore = {
   lastActorType: null as "agent" | "squad" | null,
@@ -113,6 +132,14 @@ vi.mock("@multica/core/issues/stores/quick-create-store", () => ({
     (selector ? selector(mockQuickCreateStore) : mockQuickCreateStore),
 }));
 
+vi.mock("@multica/core/issues/stores/draft-store", () => ({
+  useIssueDraftStore: Object.assign(
+    (selector?: (state: typeof mockIssueDraftStore) => unknown) =>
+      (selector ? selector(mockIssueDraftStore) : mockIssueDraftStore),
+    { getState: () => mockIssueDraftStore },
+  ),
+}));
+
 vi.mock("@multica/core/issues/stores/issue-create-settings-store", () => ({
   useIssueCreateSettingsStore: (
     selector?: (state: typeof mockCreateSettingsStore) => unknown,
@@ -151,22 +178,22 @@ vi.mock("../common/actor-avatar", () => ({
 
 vi.mock("../issues/components", () => ({
   PriorityIcon: ({ priority }: { priority: string }) => <span>{priority}</span>,
-  PriorityPicker: ({ onUpdate }: any) => (
+  PriorityPicker: ({ priority, onUpdate }: any) => (
     <button type="button" data-testid="priority-picker" onClick={() => onUpdate({ priority: "high" })}>
-      Priority
+      Priority {priority}
     </button>
   ),
-  DueDatePicker: ({ onUpdate }: any) => (
+  DueDatePicker: ({ dueDate, onUpdate }: any) => (
     <button type="button" data-testid="due-date-picker" onClick={() => onUpdate({ due_date: "2026-08-01" })}>
-      Due date
+      Due date {dueDate ?? "none"}
     </button>
   ),
 }));
 
 vi.mock("../projects/components/project-picker", () => ({
-  ProjectPicker: ({ onUpdate }: any) => (
+  ProjectPicker: ({ projectId, onUpdate }: any) => (
     <button type="button" data-testid="project-picker" onClick={() => onUpdate({ project_id: "proj-1" })}>
-      Project
+      Project {projectId ?? "none"}
     </button>
   ),
 }));
@@ -370,6 +397,23 @@ describe("AgentCreatePanel", () => {
     mockCreateSettingsStore.quickCreateFields = ["project"];
     mockQuickCreateStore.prompt = "Persisted draft prompt";
     mockQuickCreateStore.keepOpen = false;
+    mockIssueDraftStore.draft = {
+      title: "",
+      description: "",
+      status: "todo",
+      priority: "none",
+      assigneeType: undefined,
+      assigneeId: undefined,
+      projectId: undefined,
+      startDate: null,
+      dueDate: null,
+      labelIds: [],
+      propertyValues: {},
+      attachments: [],
+    };
+    mockSetIssueDraft.mockImplementation((patch: Partial<typeof mockIssueDraftStore.draft>) => {
+      mockIssueDraftStore.draft = { ...mockIssueDraftStore.draft, ...patch };
+    });
     mockProjectsQuery.data = [];
     mockProjectsQuery.isSuccess = true;
     mockSquadsData.list = [];
@@ -406,6 +450,47 @@ describe("AgentCreatePanel", () => {
     ).toHaveValue("Persisted draft prompt");
   });
 
+  it("restores unfinished actor, project, priority, and due-date selections after remount", async () => {
+    mockSquadsData.list = [
+      { id: "squad-1", name: "Frontend Squad", leader_id: "agent-1", archived_at: null },
+    ];
+    mockProjectsQuery.data = [{ id: "proj-1", title: "Web", icon: null }];
+    mockCreateSettingsStore.quickCreateFields = ["project", "priority", "due_date"];
+    const user = userEvent.setup();
+
+    const firstOpen = renderPanel({
+      onClose: vi.fn(),
+      isExpanded: false,
+      setIsExpanded: vi.fn(),
+    });
+
+    await user.click(screen.getByRole("button", { name: /Frontend Squad/ }));
+    await user.click(screen.getByTestId("project-picker"));
+    await user.click(screen.getByTestId("priority-picker"));
+    await user.click(screen.getByTestId("due-date-picker"));
+
+    expect(mockIssueDraftStore.draft).toEqual(
+      expect.objectContaining({
+        assigneeType: "squad",
+        assigneeId: "squad-1",
+        projectId: "proj-1",
+        priority: "high",
+        dueDate: "2026-08-01",
+      }),
+    );
+
+    firstOpen.unmount();
+    renderPanel({ onClose: vi.fn(), isExpanded: false, setIsExpanded: vi.fn() });
+
+    expect(screen.getByRole("button", { name: /Frontend Squad/ })).toHaveAttribute(
+      "data-selected",
+      "true",
+    );
+    expect(screen.getByTestId("project-picker")).toHaveTextContent("Project proj-1");
+    expect(screen.getByTestId("priority-picker")).toHaveTextContent("Priority high");
+    expect(screen.getByTestId("due-date-picker")).toHaveTextContent("Due date 2026-08-01");
+  });
+
   it("writes prompt changes back to the draft store and clears them after submit", async () => {
     const user = userEvent.setup();
     const onClose = vi.fn();
@@ -434,6 +519,13 @@ describe("AgentCreatePanel", () => {
     // No project picked → persisted project preference is cleared so the
     // store stays in sync with the actual outgoing request.
     expect(mockSetLastProjectId).toHaveBeenCalledWith(null);
+    expect(mockSetIssueDraft).toHaveBeenLastCalledWith({
+      assigneeType: undefined,
+      assigneeId: undefined,
+      projectId: undefined,
+      priority: "none",
+      dueDate: null,
+    });
     expect(mockClearPrompt).toHaveBeenCalled();
     expect(mockSetLastMode).toHaveBeenCalledWith("agent");
     expect(onClose).toHaveBeenCalled();

--- a/packages/views/modals/quick-create-issue.tsx
+++ b/packages/views/modals/quick-create-issue.tsx
@@ -170,6 +170,8 @@ export function AgentCreatePanel({
   const keepOpen = useQuickCreateStore((s) => s.keepOpen);
   const setKeepOpen = useQuickCreateStore((s) => s.setKeepOpen);
   const setLastMode = useCreateModeStore((s) => s.setLastMode);
+  const selectionDraft = useIssueDraftStore((s) => s.draft);
+  const setSelectionDraft = useIssueDraftStore((s) => s.setDraft);
 
   // Resolve a candidate actor against the currently-visible agents / squads.
   // Returns null when the candidate doesn't exist in this workspace right
@@ -194,18 +196,35 @@ export function AgentCreatePanel({
 
   const seedActor = useCallback((): ActorSelection | null => {
     // Caller-provided seed wins (e.g. shell pre-seeds with `agent_id` /
-    // `squad_id`), then persisted preference, then first visible agent.
+    // `squad_id`), then the unfinished draft, the last successful pick, and
+    // finally the first visible agent.
     const dataAgent = data?.agent_id as string | undefined;
     const dataSquad = data?.squad_id as string | undefined;
     return (
       resolveActor("agent", dataAgent) ||
       resolveActor("squad", dataSquad) ||
+      resolveActor(
+        selectionDraft.assigneeType === "agent" ||
+          selectionDraft.assigneeType === "squad"
+          ? selectionDraft.assigneeType
+          : null,
+        selectionDraft.assigneeId,
+      ) ||
       resolveActor(lastActorType, lastActorId) ||
       (visibleAgents[0]
         ? ({ type: "agent", id: visibleAgents[0].id } as const)
         : null)
     );
-  }, [resolveActor, data?.agent_id, data?.squad_id, lastActorType, lastActorId, visibleAgents]);
+  }, [
+    resolveActor,
+    data?.agent_id,
+    data?.squad_id,
+    selectionDraft.assigneeType,
+    selectionDraft.assigneeId,
+    lastActorType,
+    lastActorId,
+    visibleAgents,
+  ]);
 
   const [actor, setActor] = useState<ActorSelection | null>(() => seedActor());
 
@@ -228,19 +247,21 @@ export function AgentCreatePanel({
     return visibleSquads.find((s) => s.id === actor.id);
   }, [actor, visibleSquads]);
 
-  // Project selection — defaults to the last project the user picked in this
-  // workspace. `data?.project_id` lets the modal opener seed a one-shot
-  // override (e.g. a future "+ Issue" button on a project page); it does NOT
-  // replace the persisted default.
+  // Unfinished selections live in the shared issue draft. Last-successful
+  // actor/project values remain separate fallbacks, so closing a draft never
+  // overwrites the defaults established by an actual create.
   const [projectId, setProjectId] = useState<string | null>(() => {
-    const seed = (data?.project_id as string | undefined) ?? lastProjectId;
+    const seed =
+      (data?.project_id as string | undefined) ??
+      selectionDraft.projectId ??
+      lastProjectId;
     return seed ?? null;
   });
   const [priority, setPriority] = useState<IssuePriority>(
-    (data?.priority as IssuePriority | undefined) ?? "none",
+    (data?.priority as IssuePriority | undefined) ?? selectionDraft.priority,
   );
   const [dueDate, setDueDate] = useState<string | null>(
-    (data?.due_date as string | undefined) ?? null,
+    (data?.due_date as string | undefined) ?? selectionDraft.dueDate,
   );
   const [fieldPickerOpen, setFieldPickerOpen] = useState<QuickCreateField | null>(null);
 
@@ -257,15 +278,26 @@ export function AgentCreatePanel({
   // Stale-id sweep. Once the project list query has actually resolved
   // (`isSuccess` — distinct from "data is the empty default during loading"),
   // a `projectId` that isn't in the list means the project was deleted in
-  // another session. Clear BOTH local state and the persisted preference;
-  // dropping only local state would leave the deleted UUID in `lastProjectId`,
-  // and the next open would re-seed it and submit the same dead value.
+  // another session. Clear local state, the unfinished draft, and the
+  // last-successful preference; dropping any persisted copy would make the
+  // next open re-seed and submit the same dead value.
   useEffect(() => {
     if (!projectsLoaded || projectId === null) return;
     if (projects.some((p) => p.id === projectId)) return;
     setProjectId(null);
+    if (selectionDraft.projectId === projectId) {
+      setSelectionDraft({ projectId: undefined });
+    }
     if (lastProjectId === projectId) setLastProjectId(null);
-  }, [projectsLoaded, projects, projectId, lastProjectId, setLastProjectId]);
+  }, [
+    projectsLoaded,
+    projects,
+    projectId,
+    selectionDraft.projectId,
+    lastProjectId,
+    setSelectionDraft,
+    setLastProjectId,
+  ]);
 
   // Daemon CLI version gate. The agent-create flow needs the runtime's
   // bundled multica CLI to be ≥ MIN_QUICK_CREATE_CLI_VERSION; older
@@ -371,6 +403,16 @@ export function AgentCreatePanel({
       });
       setLastActor(actor.type, actor.id);
       setLastProjectId(projectId);
+      // A successful create ends this draft. Keep last-successful actor and
+      // project preferences above, but clear the unfinished selections so a
+      // future draft does not inherit priority or due date accidentally.
+      setSelectionDraft({
+        assigneeType: undefined,
+        assigneeId: undefined,
+        projectId: undefined,
+        priority: "none",
+        dueDate: null,
+      });
       clearPrompt();
       setLastMode("agent");
       toast.success(t(($) => $.create_issue.agent.toast_sent), {
@@ -525,6 +567,7 @@ export function AgentCreatePanel({
             selectedSquad={selectedSquad}
             onPick={(next) => {
               setActor(next);
+              setSelectionDraft({ assigneeType: next.type, assigneeId: next.id });
               setError(null);
             }}
             t={t}
@@ -576,7 +619,7 @@ export function AgentCreatePanel({
 
         {/* Property toolbar — the project is visible by default; priority and
             due date live behind the overflow until exposed in settings or
-            given a value. The project pick remains workspace-persistent.
+            given a value. Unfinished picks remain workspace-persistent.
             When the modal was opened from "Add sub issue" on an existing
             issue, a read-only chip on the same row tells the user that the
             new issue will be filed as a sub-issue of that parent — the agent
@@ -590,7 +633,11 @@ export function AgentCreatePanel({
             fieldPickerOpen === "project") && (
             <ProjectPicker
               projectId={projectId}
-              onUpdate={(u) => setProjectId(u.project_id ?? null)}
+              onUpdate={(u) => {
+                const next = u.project_id ?? null;
+                setProjectId(next);
+                setSelectionDraft({ projectId: next ?? undefined });
+              }}
               triggerRender={<PillButton />}
               align="start"
               open={fieldPickerOpen === "project" ? true : undefined}
@@ -603,7 +650,10 @@ export function AgentCreatePanel({
             <PriorityPicker
               priority={priority}
               onUpdate={(updates) => {
-                if (updates.priority) setPriority(updates.priority);
+                if (updates.priority) {
+                  setPriority(updates.priority);
+                  setSelectionDraft({ priority: updates.priority });
+                }
               }}
               triggerRender={<PillButton />}
               align="start"
@@ -616,7 +666,11 @@ export function AgentCreatePanel({
             fieldPickerOpen === "due_date") && (
             <DueDatePicker
               dueDate={dueDate}
-              onUpdate={(updates) => setDueDate(updates.due_date ?? null)}
+              onUpdate={(updates) => {
+                const next = updates.due_date ?? null;
+                setDueDate(next);
+                setSelectionDraft({ dueDate: next });
+              }}
               triggerRender={<PillButton />}
               align="start"
               open={fieldPickerOpen === "due_date" ? true : undefined}


### PR DESCRIPTION
## Summary

- Persist unfinished Agent/Squad, project, priority, and due-date choices in the workspace-scoped issue draft.
- Restore the project selection in manual create as well as all affected options in quick create.
- Clear unfinished selections after a successful create while keeping last-successful defaults separate.

## Root cause

The quick-create prompt and most manual fields used the persisted issue draft, but quick-create options and the manual project picker were component-local state. Closing the modal therefore discarded those selections even though the prompt remained.

## User impact

Closing and reopening New Issue now restores the full unfinished draft instead of silently resetting its assignment and scheduling choices.

## Validation

- `pnpm --dir packages/core exec vitest run issues/stores/draft-store.test.ts` (7 tests)
- `pnpm --dir packages/views exec vitest run modals/quick-create-issue.test.tsx modals/create-issue.test.tsx` (53 tests)
- Core and views TypeScript checks
- ESLint on all six changed files
- Real Web close/reopen verification with before/after screenshots
