### PR TITLE
MUL-5164: refactor(issues): drop the table toolbar loaded-count and structure-paused copy

### DIFF
--- a/packages/views/issues/components/table-view-editing.test.tsx
+++ b/packages/views/issues/components/table-view-editing.test.tsx
@@ -300,11 +300,11 @@ describe("TableView cell editors under data refresh", () => {
 
   it("opens title and row clicks in a foreground Desktop tab", async () => {
     const user = userEvent.setup({ delay: null, pointerEventsCheck: 0 });
-    serverIssues = [makeIssue("a", "Alpha task", "todo")];
 
     renderWithI18n(
       <QueryClientProvider client={queryClient}>
         <Harness
+          issues={[makeIssue("a", "Alpha task", "todo")]}
           childProgressMap={new Map()}
           surfaceKey={`test-new-tab-${Math.floor(Math.random() * 1e9)}`}
         />
@@ -335,11 +335,11 @@ describe("TableView cell editors under data refresh", () => {
     const windowOpen = vi.fn();
     vi.stubGlobal("open", windowOpen);
     navigationState.hasOpenInNewTab = false;
-    serverIssues = [makeIssue("a", "Alpha task", "todo")];
 
     renderWithI18n(
       <QueryClientProvider client={queryClient}>
         <Harness
+          issues={[makeIssue("a", "Alpha task", "todo")]}
           childProgressMap={new Map()}
           surfaceKey={`test-browser-tab-${Math.floor(Math.random() * 1e9)}`}
         />

--- a/packages/views/issues/components/table-view-model.ts
+++ b/packages/views/issues/components/table-view-model.ts
@@ -41,7 +41,7 @@ export function isTableStructureSuspended(total: number): boolean {
  *
  * - `hasError`: a page that keeps failing leaves `hasNextPage` true and
  *   `isFetchingNextPage` false after each attempt, so an ungated effect
- *   refires forever — a silent request storm behind a stuck "Loaded X of N"
+ *   refires forever — a silent request storm
  *   (round-4 review P1#1). Terminal errors stop the loop; resuming is an
  *   explicit user Retry.
  * - `loadedCount`: an ABSOLUTE stop at the ceiling, independent of any

--- a/packages/views/issues/components/table-view.tsx
+++ b/packages/views/issues/components/table-view.tsx
@@ -111,7 +111,6 @@ import {
 } from "./pickers";
 import { CustomPropertyValueEditor } from "./pickers/custom-property-picker";
 import {
-  TABLE_STRUCTURE_MAX_WINDOW,
   buildIssueTableCsv,
   buildIssueTableRows,
   getIssueTableSelectionRange,
@@ -1141,11 +1140,10 @@ export function TableView({
   // is persisted view state and hierarchy is on by default, so an unbounded
   // loop would re-download entire large workspaces on every visit (round-3
   // review P1#1). Below the ceiling the remaining pages load sequentially
-  // (one per completed fetch — the toolbar's loaded-of-total line is the
-  // visible progress, and flipping the toggles off stops the loop), which
-  // also makes hierarchy apply without scrolling to the last page (round-3
-  // P1#2). Above the ceiling both features suspend and the toolbar notice
-  // explains why; the window keeps the one-page-per-scroll sentinel.
+  // (one per completed fetch — flipping the toggles off stops the loop),
+  // which also makes hierarchy apply without scrolling to the last page
+  // (round-3 P1#2). Above the ceiling both features suspend silently; the
+  // window keeps the one-page-per-scroll sentinel.
   // Advancement gates (error stop, hard loaded-count ceiling, fresh total)
   // live in shouldAutoLoadNextWindowPage — see its doc for the failure
   // modes each gate closes (round-4 review P1#1/P1#2).
@@ -1582,23 +1580,14 @@ export function TableView({
           clearLabel={t(($) => $.table.search_clear)}
         />
         <span className="mr-auto min-w-0 truncate text-xs text-muted-foreground">
-          {t(($) => $.table.loaded_count, { count: issues.length, total })}
           {windowError && hasNextPage && (
             <button
               type="button"
               onClick={() => void fetchNextPage()}
-              className="ml-2 text-destructive underline-offset-2 hover:underline"
+              className="text-destructive underline-offset-2 hover:underline"
             >
               {t(($) => $.table.load_more_failed_retry)}
             </button>
-          )}
-          {structureSuspended && structureWanted && (
-            <span className="ml-2">
-              {t(($) => $.table.structure_paused, {
-                total,
-                limit: TABLE_STRUCTURE_MAX_WINDOW,
-              })}
-            </span>
           )}
         </span>
         <DropdownMenu>

--- a/packages/views/locales/en/issues.json
+++ b/packages/views/locales/en/issues.json
@@ -125,8 +125,6 @@
     "empty": "No issues match this view.",
     "search_placeholder": "Search title or issue ID…",
     "search_clear": "Clear search",
-    "loaded_count": "Loaded {{count}} of {{total}}",
-    "structure_paused": "Grouping and hierarchy are paused — {{total}} issues exceed the {{limit}}-issue limit. Narrow filters to re-enable.",
     "load_failed": "Failed to load issues.",
     "load_failed_retry": "Retry",
     "load_more_failed_retry": "Loading more failed — Retry",

--- a/packages/views/locales/ja/issues.json
+++ b/packages/views/locales/ja/issues.json
@@ -123,8 +123,6 @@
     "empty": "この表示に一致するイシューはありません。",
     "search_placeholder": "タイトルまたは Issue ID を検索…",
     "search_clear": "検索をクリア",
-    "loaded_count": "{{total}} 件中 {{count}} 件を読み込み済み",
-    "structure_paused": "グループと階層は一時停止中です — {{total}} 件が上限 {{limit}} 件を超えています。フィルターで絞り込むと再び有効になります。",
     "load_failed": "イシューを読み込めませんでした。",
     "load_failed_retry": "再試行",
     "load_more_failed_retry": "続きの読み込みに失敗しました — 再試行",

--- a/packages/views/locales/ko/issues.json
+++ b/packages/views/locales/ko/issues.json
@@ -123,8 +123,6 @@
     "empty": "이 보기에 일치하는 이슈가 없습니다.",
     "search_placeholder": "제목 또는 이슈 ID 검색…",
     "search_clear": "검색 지우기",
-    "loaded_count": "{{total}}개 중 {{count}}개 불러옴",
-    "structure_paused": "그룹화와 계층이 일시 중지되었습니다 — 이슈 {{total}}개가 상한 {{limit}}개를 초과했습니다. 필터로 좁히면 다시 활성화됩니다.",
     "load_failed": "이슈를 불러오지 못했습니다.",
     "load_failed_retry": "다시 시도",
     "load_more_failed_retry": "추가 항목을 불러오지 못했습니다 — 다시 시도",

--- a/packages/views/locales/zh-Hans/issues.json
+++ b/packages/views/locales/zh-Hans/issues.json
@@ -123,8 +123,6 @@
     "empty": "当前视图没有匹配的 issue。",
     "search_placeholder": "搜索标题或 issue 编号…",
     "search_clear": "清除搜索",
-    "loaded_count": "已载入 {{count}} / {{total}}",
-    "structure_paused": "分组和层级已暂停——{{total}} 个 issue 超过 {{limit}} 个上限，收窄筛选后自动恢复。",
     "load_failed": "加载 issue 失败。",
     "load_failed_retry": "重试",
     "load_more_failed_retry": "加载更多失败——重试",


### PR DESCRIPTION
## Summary

Removes the long copy from the Issues table toolbar (MUL-5164).

The strip between the search box and Export rendered two always-visible strings:

- `Loaded 300 of 4587`
- `Grouping and hierarchy are paused — 4587 issues exceed the 1000-issue limit. Narrow filters to re-enable.`

Both are gone, along with their `loaded_count` / `structure_paused` keys in all four locales (en / zh-Hans / ja / ko).

**What is kept:** the load-failure **Retry** button that lived in the same span. It only renders when a window fetch has failed, and it is the documented explicit resume path for the infinite-scroll sentinel — dropping it would leave a failed page with no way to recover. Removing the surrounding text means it now renders on its own.

The suspension behavior itself is unchanged: above the window ceiling, grouping and hierarchy still suspend, just silently. Comments in `table-view.tsx` and `table-view-model.ts` that referenced the removed toolbar line were updated so they don't describe UI that no longer exists.

## Unrelated fix included

`packages/views` typecheck and vitest were already failing on `main`: the revert in #5777 removed the server-driven `serverIssues` fixture, but two tests in `table-view-editing.test.tsx` still assigned to it. Repaired in a separate commit (`3b325bf19`) so CI can go green — without it, this PR could not pass.

## Verification

- `pnpm typecheck` — passes (6/6 workspaces). Failed before the test repair; the 4 errors were pre-existing on `main`, verified by stashing.
- `pnpm test` — passes, 250 files / 2839 tests across 8 workspaces, including the locale parity suite that guards key sets across the four languages.
- `pnpm lint` — 0 errors. The remaining warnings are pre-existing and untouched by this change.
