### PR TITLE
MUL-5165: fix(agent): cycle in_review issues back to in_progress on comment-triggered rework

### DIFF
--- a/server/internal/daemon/execenv/runtime_config_sections.go
+++ b/server/internal/daemon/execenv/runtime_config_sections.go
@@ -403,7 +403,7 @@ func writeWorkflowComment(b *strings.Builder, provider string, ctx TaskContextFo
 		b.WriteString(buildCommentReplyInstructionsSlim(provider, ctx.IssueID, ctx.TriggerCommentID))
 	}
 	b.WriteString("8. Before exiting: only if this run produced a fact that clears the high bar (important AND likely to be re-read by future runs on this same issue, e.g. a new PR URL or deploy URL), or you noticed a metadata key from entry that is now stale, pin or clear it via `multica issue metadata set`/`delete`. Most runs write nothing here — that is the expected outcome, not a gap. When in doubt, do not write. See the `## Issue Metadata` section above for the full bar.\n")
-	b.WriteString("9. Do NOT change the issue status unless the comment explicitly asks for it\n\n")
+	b.WriteString("9. Issue status: do NOT change it unless the comment explicitly asks for it, with one exception — rework. If this issue is currently `in_review` and the triggering comment asks you to revise, fix, or redo work this issue already delivered, set the issue to `in_progress` when you start that rework and set it back to `in_review` when you post the reworked result. Questions, discussion, and acknowledgements never change the status.\n\n")
 }
 
 // writeWorkflowAssignment emits the assignment-triggered workflow.

--- a/server/internal/daemon/execenv/runtime_config_test.go
+++ b/server/internal/daemon/execenv/runtime_config_test.go
@@ -143,9 +143,12 @@ func TestBriefHasNoParentNotificationGuidance(t *testing.T) {
 // Comment-triggered briefs must NOT carry any unconditional status-flip
 // command targeting the current issue. Previous revisions had a
 // dedicated protocol step that wrote `multica issue status <this-issue-id> in_review`;
-// the comment-triggered workflow rule "Do NOT change the issue status
-// unless the comment explicitly asks for it" must remain the source of
-// truth (Elon's blocking review on PR #2918).
+// the comment-triggered workflow rule "do NOT change it unless the comment
+// explicitly asks for it" must remain the default (Elon's blocking review
+// on PR #2918). MUL-5165 adds the one conditional exception: a rework
+// request on an `in_review` issue cycles the status through `in_progress`
+// and back to `in_review`, so boards reflect that the agent is actively
+// re-working the issue.
 func TestCommentTriggeredProtocolDoesNotForceInReview(t *testing.T) {
 	t.Parallel()
 	ctx := TaskContextForEnv{
@@ -158,9 +161,16 @@ func TestCommentTriggeredProtocolDoesNotForceInReview(t *testing.T) {
 		t.Errorf("comment-triggered brief must not contain a placeholder `<this-issue-id> in_review` flip — that conflicts with the comment-triggered \"do not change status unless asked\" rule")
 	}
 
-	const guardrail = "Do NOT change the issue status unless the comment explicitly asks for it"
+	const guardrail = "do NOT change it unless the comment explicitly asks for it"
 	if !strings.Contains(out, guardrail) {
 		t.Errorf("expected the comment-triggered workflow guardrail %q to be present", guardrail)
+	}
+
+	// MUL-5165: the rework exception must be present and must stay
+	// conditional on the issue currently sitting in in_review.
+	const rework = "If this issue is currently `in_review` and the triggering comment asks you to revise"
+	if !strings.Contains(out, rework) {
+		t.Errorf("expected the comment-triggered rework status exception %q to be present", rework)
 	}
 }
 


### PR DESCRIPTION
## Problem (MUL-5165)

When an `in_review` issue is re-run by an agent — most commonly because the reviewer left a feedback comment asking for changes — the issue status never moves back to `in_progress`. The board keeps showing `in_review` the whole time the agent is re-working the issue.

## Root cause

Issue status is agent-managed by design (`StartTask` deliberately does not touch it). The assignment-triggered workflow tells the agent to set `in_progress` (step 4) and `in_review` when done (step 8), so assignment/rerun paths already cycle correctly. But the comment-triggered workflow's step 9 said:

> Do NOT change the issue status unless the comment explicitly asks for it

so the dominant re-run path — a rework request in a comment — was forbidden from ever flipping the status.

## Fix

Step 9 now carves out one conditional exception: if the issue is currently `in_review` and the triggering comment asks to revise/fix/redo the delivered work, the agent sets it to `in_progress` while re-working and back to `in_review` when it posts the result. Questions, discussion, and acknowledgements still never change status, and the unconditional-flip ban (Elon's blocking review on PR #2918) still holds — the guard test now asserts both the default and the conditional exception.

The cycle is failure-safe: if the rework run dies mid-way, the existing `HandleFailedTasks` rollback already resets a stuck `in_progress` issue to `todo`.

## Verification

- `go test ./internal/daemon/...` — all pass, including the updated `TestCommentTriggeredProtocolDoesNotForceInReview`.
- `gofmt` / `go vet` clean on changed files.
