### PR TITLE
feat(autopilot): surface run result summary in `autopilot runs` CLI (WS-751)

### DIFF
--- a/server/cmd/multica/cmd_autopilot.go
+++ b/server/cmd/multica/cmd_autopilot.go
@@ -519,7 +519,7 @@ func runAutopilotRuns(cmd *cobra.Command, args []string) error {
 		return cli.PrintJSON(os.Stdout, resp)
 	}
 
-	headers := []string{"ID", "SOURCE", "STATUS", "ISSUE", "TRIGGERED_AT", "COMPLETED_AT"}
+	headers := []string{"ID", "SOURCE", "STATUS", "ISSUE", "SUMMARY", "TRIGGERED_AT", "COMPLETED_AT"}
 	rows := make([][]string, 0, len(resp.Runs))
 	for _, r := range resp.Runs {
 		rows = append(rows, []string{
@@ -527,6 +527,7 @@ func runAutopilotRuns(cmd *cobra.Command, args []string) error {
 			strVal(r, "source"),
 			strVal(r, "status"),
 			strVal(r, "issue_id"),
+			summarizeRun(r),
 			strVal(r, "triggered_at"),
 			strVal(r, "completed_at"),
 		})
@@ -534,6 +535,61 @@ func runAutopilotRuns(cmd *cobra.Command, args []string) error {
 	cli.PrintTable(os.Stdout, headers, rows)
 	return nil
 }
+
+// summarizeRun produces a one-line, table-cell preview of a run's outcome so
+// `autopilot runs` can show what each run actually produced without forcing the
+// operator to open each row. For a completed run_only run the agent's final
+// output is shown; for a failed/skipped run the failure_reason is shown; runs
+// with neither (e.g. create_issue runs, which surface their linked issue in the
+// ISSUE column) render empty. The full structured result stays available via
+// `--output json`.
+func summarizeRun(r map[string]any) string {
+	if out := nestedString(r, "result", "output"); out != "" {
+		return truncateRunSummary(out)
+	}
+	if reason := strVal(r, "failure_reason"); reason != "" {
+		return truncateRunSummary(reason)
+	}
+	return ""
+}
+
+// nestedString walks a chain of map keys (e.g. result.output) in JSON-decoded
+// API responses and returns the leaf as a string, or "" if any step is missing
+// or the wrong type.
+func nestedString(m map[string]any, keys ...string) string {
+	cur := m
+	for i, k := range keys {
+		v, ok := cur[k]
+		if !ok || v == nil {
+			return ""
+		}
+		if i == len(keys)-1 {
+			return fmt.Sprintf("%v", v)
+		}
+		next, ok := v.(map[string]any)
+		if !ok {
+			return ""
+		}
+		cur = next
+	}
+	return ""
+}
+
+// truncateRunSummary collapses whitespace so the preview fits a single table
+// cell and caps it to runSummaryMaxLen runes, appending … when truncated.
+func truncateRunSummary(s string) string {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return ""
+	}
+	rs := []rune(strings.Join(strings.Fields(s), " "))
+	if len(rs) <= runSummaryMaxLen {
+		return string(rs)
+	}
+	return string(rs[:runSummaryMaxLen]) + "…"
+}
+
+const runSummaryMaxLen = 80
 
 func runAutopilotTriggerAdd(cmd *cobra.Command, args []string) error {
 	client, err := newAPIClient(cmd)

--- a/server/cmd/multica/cmd_autopilot_test.go
+++ b/server/cmd/multica/cmd_autopilot_test.go
@@ -473,3 +473,90 @@ func TestUUIDRegexp(t *testing.T) {
 		}
 	}
 }
+
+func TestSummarizeRun(t *testing.T) {
+	long := strings.Repeat("a", 200)
+	truncated := strings.Repeat("a", runSummaryMaxLen) + "…"
+
+	cases := []struct {
+		name string
+		run  map[string]any
+		want string
+	}{
+		{
+			name: "completed run_only shows agent output",
+			run:  map[string]any{"result": map[string]any{"output": "Built feature X, opened PR #123"}},
+			want: "Built feature X, opened PR #123",
+		},
+		{
+			name: "truncates long output to runSummaryMaxLen runes",
+			run:  map[string]any{"result": map[string]any{"output": long}},
+			want: truncated,
+		},
+		{
+			name: "failed run shows failure_reason",
+			run:  map[string]any{"status": "failed", "failure_reason": "task failed: provider timeout"},
+			want: "task failed: provider timeout",
+		},
+		{
+			name: "output preferred over failure_reason",
+			run: map[string]any{
+				"result":         map[string]any{"output": "ok"},
+				"failure_reason": "stale reason",
+			},
+			want: "ok",
+		},
+		{
+			name: "create_issue run has no summary",
+			run:  map[string]any{"status": "completed", "issue_id": "iss-1"},
+			want: "",
+		},
+		{
+			name: "empty output falls back to failure_reason",
+			run: map[string]any{
+				"result":         map[string]any{"output": ""},
+				"failure_reason": "err",
+			},
+			want: "err",
+		},
+		{
+			name: "result without output field falls back to failure_reason",
+			run: map[string]any{
+				"result":         map[string]any{"pr_url": "https://x"},
+				"failure_reason": "err",
+			},
+			want: "err",
+		},
+		{
+			name: "non-object result does not crash and falls back",
+			run: map[string]any{
+				"result":         "raw string",
+				"failure_reason": "err",
+			},
+			want: "err",
+		},
+		{
+			name: "collapses newlines and tabs into single spaces",
+			run:  map[string]any{"result": map[string]any{"output": "line1\nline2\tindented"}},
+			want: "line1 line2 indented",
+		},
+		{
+			name: "trims surrounding whitespace",
+			run:  map[string]any{"result": map[string]any{"output": "   trimmed   "}},
+			want: "trimmed",
+		},
+		{
+			name: "skipped run shows failure_reason",
+			run:  map[string]any{"status": "skipped", "failure_reason": "concurrency_cap"},
+			want: "concurrency_cap",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := summarizeRun(tc.run); got != tc.want {
+				t.Fatalf("summarizeRun() = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}

--- a/server/internal/handler/autopilot_webhook_handler_test.go
+++ b/server/internal/handler/autopilot_webhook_handler_test.go
@@ -1105,6 +1105,50 @@ func TestGetAutopilotRun_ReturnsFullPayload(t *testing.T) {
 	}
 }
 
+// TestListAutopilotRuns_SurfacesRunResult locks in the read-back path that
+// `autopilot runs` relies on: when a run_only task completes, SyncRunFromTask
+// writes the task result to autopilot_run.result via UpdateAutopilotRunCompleted,
+// and the list endpoint must surface it so the CLI can render a per-row summary.
+func TestListAutopilotRuns_SurfacesRunResult(t *testing.T) {
+	agentID := createWebhookTestAgent(t, "RunsResult Agent")
+	apID := createWebhookTestAutopilot(t, agentID, "active", "run_only")
+
+	run, err := testHandler.Queries.CreateAutopilotRun(context.Background(), db.CreateAutopilotRunParams{
+		AutopilotID: parseUUID(apID),
+		Source:      "manual",
+		Status:      "running",
+	})
+	if err != nil {
+		t.Fatalf("create run: %v", err)
+	}
+
+	// Simulate the run_only task completing. SyncRunFromTask calls exactly
+	// this query with task.Result, which the daemon marshals as
+	// {output, pr_url, session_id, work_dir} (see handler.CompleteTask).
+	resultJSON := []byte(`{"output":"Shipped daily digest (PR #42)","pr_url":"https://example.com/pr/42"}`)
+	if _, err := testHandler.Queries.UpdateAutopilotRunCompleted(context.Background(), db.UpdateAutopilotRunCompletedParams{
+		ID:     run.ID,
+		Result: resultJSON,
+	}); err != nil {
+		t.Fatalf("complete run: %v", err)
+	}
+
+	w := httptest.NewRecorder()
+	req := newRequest("GET", "/api/autopilots/"+apID+"/runs", nil)
+	req = withURLParam(req, "id", apID)
+	testHandler.ListAutopilotRuns(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d body=%s", w.Code, w.Body.String())
+	}
+	body := w.Body.String()
+	if !strings.Contains(body, `"output":"Shipped daily digest (PR #42)"`) {
+		t.Fatalf("list response should surface run result output, body=%s", body)
+	}
+	if !strings.Contains(body, `"status":"completed"`) {
+		t.Fatalf("list response should mark run completed, body=%s", body)
+	}
+}
+
 // NOTE: the cross-workspace paranoia branch in autopilot_webhook.go
 // (uuidToString(autopilot.WorkspaceID) != uuidToString(trigRow.AutopilotWorkspaceID))
 // is defense-in-depth against a TOCTOU race between the joined token


### PR DESCRIPTION
## Summary

`multica autopilot runs <id>` rendered no outcome column, forcing operators to open each row to see what a run produced. This adds a SUMMARY column.

**Premise check.** The WS-751 description proposed adding `result_summary`/`result_status` columns + a terminal write-back callback. On investigation the persistence path already exists end-to-end:

- `SyncRunFromTask` (the run_only terminal callback) already writes `result` on completion and `failure_reason` on failure — `server/internal/service/autopilot.go:1002-1023`.
- It is already wired to `EventTaskCompleted/Failed/Cancelled` — `server/cmd/server/autopilot_listeners.go:47-55`.
- The API already exposes it — `runToResponse` returns `result` (`server/internal/handler/autopilot.go:293`), and `ListAutopilotRuns` uses `runToResponseSlim` which keeps `result` (only strips `trigger_payload`).

So the real, observable gap was purely the CLI table. Adding `result_summary`/`result_status` columns would duplicate the existing `result` JSONB and `status` enum, so this PR takes the minimal path: a display-only SUMMARY column.

## Changes

- `server/cmd/multica/cmd_autopilot.go` — add SUMMARY column to `runAutopilotRuns`. `summarizeRun` extracts `result.output` for completed runs, falls back to `failure_reason` for failed/skipped runs, collapses whitespace, caps to 80 runes (+ `…`). `create_issue` runs render empty (their linked issue already shows in the ISSUE column). Full structured result stays available via `--output json`.
- `server/cmd/multica/cmd_autopilot_test.go` — table-driven `TestSummarizeRun` (11 cases: output shown, truncation, failure_reason fallback, output preferred over failure_reason, empty for create_issue, empty-output fallback, non-object result no-crash, whitespace collapse, trim, skipped-run failure_reason).
- `server/internal/handler/autopilot_webhook_handler_test.go` — `TestListAutopilotRuns_SurfacesRunResult` asserts the list endpoint returns `result.output` for a completed run_only run.

## Acceptance criteria

- [x] `autopilot runs` shows a result summary for run_only runs — SUMMARY column populated from `result.output` / `failure_reason`.
- [x] create_issue mode zero regression — SUMMARY renders empty for create_issue runs (issue already in ISSUE column); full handler + service + CLI autopilot suites green.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./cmd/multica/ ./internal/handler/ ./internal/service/`
- [x] `gofmt -l` on changed files (clean)
- [x] `go test ./cmd/multica/` (full CLI autopilot suite incl. `TestSummarizeRun`)
- [x] `go test ./internal/handler/ -run Autopilot` (incl. new `TestListAutopilotRuns_SurfacesRunResult`)
- [x] `go test ./internal/service/ -run Autopilot`

🤖 Generated with [Claude Code](https://claude.com/claude-code)