### PR TITLE
MUL-5174: fix(openclaw): forward --model instead of --agent (KAV-14)

### DIFF
--- a/server/pkg/agent/models.go
+++ b/server/pkg/agent/models.go
@@ -1410,14 +1410,15 @@ func discoverOpenclawAgents(ctx context.Context, executablePath string) ([]Model
 }
 
 // openclawAgentEntry is the shape parseOpenclawAgentsJSON expects
-// from `openclaw agents list --json`. `id` is the routing key
-// passed to `openclaw agent --agent <id>`; `name` is the human
-// display label set via `openclaw agents set-identity --name` and
-// is only used to enrich the dropdown label. The two are not
-// interchangeable — see openclawEntriesToModels for the mapping.
-// Older openclaw versions may emit only `name`; in that case we
-// fall back to using it as the id for backward compatibility.
-// `model` is optional and only used to enrich the dropdown label.
+// from `openclaw agents list --json`. `model` is the routing key
+// passed to `openclaw agent --model <provider/model-or-id>` (see
+// `openclaw agent --help`, KAV-14). `name` is the human display
+// label set via `openclaw agents set-identity --name` and is only
+// used to enrich the dropdown label. `id` is the registered
+// agent's routing identifier, surfaced in the label so users can
+// tell multiple registered agents apart when they share a model.
+// Older openclaw versions may emit only `name` or `id`; we fall
+// back through them as the routing key for backward compatibility.
 type openclawAgentEntry struct {
 	Name  string `json:"name"`
 	ID    string `json:"id"`
@@ -1453,12 +1454,18 @@ func openclawEntriesToModels(entries []openclawAgentEntry) []Model {
 	models := make([]Model, 0, len(entries))
 	seen := map[string]bool{}
 	for _, e := range entries {
-		// Use ID as the model identifier because openclaw resolves
-		// --agent by id, not by display name. Names may contain spaces
-		// (e.g. "Sub2API OPS") which openclaw's normalizeAgentId would
-		// mangle into a different string ("sub2api-ops"), causing a
-		// lookup miss and "no parseable output" errors.
-		id := e.ID
+		// KAV-14: use the agent's bound `model` as the Model.ID so the
+		// value forwarded via `--model <id>` is the routing key
+		// OpenClaw's per-run flag expects. Falls back to `id` (then
+		// `name`) for older openclaw builds that omit `model`,
+		// preserving the prior behaviour of using the registered
+		// agent id as the routing key. The display name still comes
+		// from `name` (or `id`) so the label keeps distinguishing
+		// agents when several share the same model.
+		id := e.Model
+		if id == "" {
+			id = e.ID
+		}
 		if id == "" {
 			id = e.Name
 		}
@@ -1468,12 +1475,18 @@ func openclawEntriesToModels(entries []openclawAgentEntry) []Model {
 		seen[id] = true
 		displayName := e.Name
 		if displayName == "" {
+			displayName = e.ID
+		}
+		if displayName == "" {
 			displayName = id
 		}
-		label := displayName
-		if e.Model != "" {
-			label = displayName + " (" + e.Model + ")"
-		}
+		// Label format: "<displayName> (<routing key>)" — gives the
+		// user a stable handle on which registered agent the model
+		// came from when several agents share a model. Kept even when
+		// displayName equals id (older openclaw builds where the
+		// agent id happened to match the model id) so the label
+		// format stays predictable.
+		label := displayName + " (" + id + ")"
 		models = append(models, Model{ID: id, Label: label, Provider: "openclaw"})
 	}
 	return models
@@ -1505,13 +1518,24 @@ func parseOpenclawAgents(output string) []Model {
 		if !isOpenclawIdentifier(name) || !isOpenclawIdentifier(model) {
 			continue
 		}
-		if seen[name] {
+		// KAV-14: route via the model id (matching the JSON path), not
+		// the agent name. The text fallback only fires for older
+		// openclaw builds that don't emit JSON, and those builds'
+		// first-column token is the model id emitted by the CLI's
+		// plain-text listing anyway. Dedup by id only — the name is
+		// purely display, and double-marking (first by name, then by
+		// id) would skip the first valid row whenever name == model.
+		id := model
+		if id == "" {
+			id = name
+		}
+		if seen[id] {
 			continue
 		}
-		seen[name] = true
+		seen[id] = true
 		models = append(models, Model{
-			ID:       name,
-			Label:    name + " (" + model + ")",
+			ID:       id,
+			Label:    name + " (" + id + ")",
 			Provider: "openclaw",
 		})
 	}

--- a/server/pkg/agent/models_test.go
+++ b/server/pkg/agent/models_test.go
@@ -761,7 +761,7 @@ claude-sonnet claude-sonnet-4-6
 			t.Errorf("section header leaked into result: %+v", m)
 		}
 	}
-	if models[0].ID != "deepseek-v4" || models[1].ID != "claude-sonnet" {
+	if models[0].ID != "deepseek-v4" || models[1].ID != "claude-sonnet-4-6" {
 		t.Errorf("unexpected agents: %+v", models)
 	}
 }
@@ -778,8 +778,12 @@ func TestParseOpenclawAgentsJSONArray(t *testing.T) {
 	if len(models) != 2 {
 		t.Fatalf("got %d, want 2: %+v", len(models), models)
 	}
-	if models[0].ID != "deepseek-v4" || models[0].Label != "deepseek-v4 (deepseek-v4)" {
-		t.Errorf("unexpected first entry: %+v", models[0])
+	// KAV-14: model id is the routing key for `openclaw agent --model`.
+	if models[0].ID != "deepseek-v4" {
+		t.Errorf("unexpected first entry id: %+v", models[0])
+	}
+	if models[0].Label != "deepseek-v4 (deepseek-v4)" {
+		t.Errorf("unexpected first entry label: %+v", models[0])
 	}
 }
 
@@ -789,15 +793,18 @@ func TestParseOpenclawAgentsJSONWrapped(t *testing.T) {
 	if !ok {
 		t.Fatal("expected parseOpenclawAgentsJSON to accept wrapped object")
 	}
-	if len(models) != 1 || models[0].ID != "foo" {
+	// KAV-14: when only name+model are present, ID is the model id.
+	if len(models) != 1 || models[0].ID != "bar" {
 		t.Errorf("unexpected: %+v", models)
 	}
 }
 
 func TestOpenclawEntriesToModelsUsesIDOverName(t *testing.T) {
-	// When both id and name are present, Model.ID should use the id field
-	// because openclaw resolves --agent by id. Names with spaces (e.g.
-	// "Sub2API OPS") would be mangled by openclaw's normalizeAgentId.
+	// KAV-14: when id, name and model are all present, Model.ID should
+	// use the model field because openclaw agent's per-run flag
+	// `--model <provider/model-or-id>` expects the bound model id.
+	// The agent id still surfaces in the label so users can tell
+	// registered agents apart when several share a model.
 	input := []byte(`[{"id": "sub2api", "name": "Sub2API OPS", "model": "gpt-4o"}]`)
 	models, ok := parseOpenclawAgentsJSON(input)
 	if !ok {
@@ -806,11 +813,11 @@ func TestOpenclawEntriesToModelsUsesIDOverName(t *testing.T) {
 	if len(models) != 1 {
 		t.Fatalf("got %d models, want 1", len(models))
 	}
-	if models[0].ID != "sub2api" {
-		t.Errorf("Model.ID = %q, want %q (should use id, not name)", models[0].ID, "sub2api")
+	if models[0].ID != "gpt-4o" {
+		t.Errorf("Model.ID = %q, want %q (should use model, then id, then name)", models[0].ID, "gpt-4o")
 	}
 	if models[0].Label != "Sub2API OPS (gpt-4o)" {
-		t.Errorf("Model.Label = %q, want %q (should use name for display)", models[0].Label, "Sub2API OPS (gpt-4o)")
+		t.Errorf("Model.Label = %q, want %q (should surface id in label)", models[0].Label, "Sub2API OPS (gpt-4o)")
 	}
 }
 

--- a/server/pkg/agent/openclaw.go
+++ b/server/pkg/agent/openclaw.go
@@ -41,9 +41,14 @@ var openclawBlockedArgs = map[string]blockedArgMode{
 	"--json":          blockedStandalone, // JSON output for daemon communication
 	"--session-id":    blockedWithValue,  // managed by daemon for session resumption
 	"--message":       blockedWithValue,  // prompt is set by daemon
-	"--model":         blockedWithValue,  // openclaw agent does not accept --model; model is bound at registration via `openclaw agents add/update --model`
+	"--agent":         blockedWithValue,  // KAV-14: --agent is the legacy routing flag; daemon now forwards --model from the dropdown
 	"--system-prompt": blockedWithValue,  // openclaw agent does not accept --system-prompt; instructions are injected into --message
 }
+// Note: --model is intentionally NOT blocked — openclaw agent supports
+// `--model <provider/model-or-id>` as a per-run override (see
+// `openclaw agent --help`). The daemon emits it from opts.Model, which
+// is the model id selected via the UI dropdown (populated by
+// openclawEntriesToModels).
 
 // openclawBackend implements Backend by spawning `openclaw agent --message <prompt>
 // --output-format stream-json --yes` and reading streaming NDJSON events from
@@ -137,10 +142,10 @@ func (b *openclawBackend) Execute(ctx context.Context, prompt string, opts ExecO
 
 		// Build usage map. Prefer the model openclaw reported in
 		// `meta.agentMeta.model` (the actual LLM, e.g. `deepseek-chat`).
-		// Fall back to opts.Model — which for openclaw is the agent name
-		// passed via `--agent`, not a real model identifier — only when
-		// the runtime didn't surface its own model. Last resort is the
-		// daemon's `unknown` placeholder.
+		// Fall back to opts.Model — which for openclaw is the model id
+		// passed via `--model` (KAV-14) — only when the runtime didn't
+		// surface its own model. Last resort is the daemon's `unknown`
+		// placeholder.
 		var usage map[string]TokenUsage
 		u := scanResult.usage
 		if u.InputTokens > 0 || u.OutputTokens > 0 || u.CacheReadTokens > 0 || u.CacheWriteTokens > 0 {
@@ -169,12 +174,13 @@ func (b *openclawBackend) Execute(ctx context.Context, prompt string, opts ExecO
 
 // buildOpenclawArgs assembles the argv for a one-shot `openclaw agent` invocation.
 //
-// The CLI only accepts --local, --json, --session-id, --timeout, --message (and
-// flags like --agent / --channel that users pass through CustomArgs). Notably
-// it does NOT accept --model or --system-prompt — model is bound at agent
-// registration time via `openclaw agents add/update --model`, and instructions
-// must be injected inline into --message because openclaw loads AGENTS.md from
-// its own workspace directory, not from cwd.
+// The CLI accepts --local, --json, --session-id, --timeout, --message, --model,
+// and flags like --channel that users pass through CustomArgs. `--agent` is
+// intentionally blocked (KAV-14): it was the legacy routing key and now
+// conflicts with the per-run `--model <provider/model-or-id>` override the
+// daemon auto-emits from the dropdown. `--system-prompt` is still rejected;
+// instructions must be injected inline into --message because openclaw loads
+// AGENTS.md from its own workspace directory, not from cwd.
 //
 // Routing (issue #3260): `openclaw agent` defaults to Gateway routing; --local
 // is the embedded-mode opt-in. The daemon historically forced --local so every
@@ -193,17 +199,17 @@ func buildOpenclawArgs(prompt, sessionID string, opts ExecOptions, logger *slog.
 	if opts.Timeout > 0 {
 		args = append(args, "--timeout", fmt.Sprintf("%d", int(opts.Timeout.Seconds())))
 	}
-	// OpenClaw binds models to pre-registered agents at `openclaw agents
-	// add/update --model` time; the daemon selects one at runtime by
-	// passing --agent <id>. The model dropdown populates its list from
-	// `openclaw agents list`, so opts.Model here is an agent id (see
-	// openclawEntriesToModels — the agent's display name lives in the
-	// dropdown label, not in opts.Model). Only inject when the user
-	// hasn't already set --agent via custom_args — custom_args wins for
-	// backward compatibility with existing configs.
+	// KAV-14: openclaw agent's per-run flag is `--model <provider/model-or-id>`
+	// (confirmed via `openclaw agent --help`). The previous shape
+	// `--agent <agent-id>` was rejected with "Unknown agent id" when the
+	// dropdown value was a model id rather than a registered agent id.
+	// The dropdown now publishes model ids (see openclawEntriesToModels),
+	// so opts.Model is the value to pass through. Inject only when the
+	// user hasn't already set --model via custom_args — custom_args wins
+	// for backward compatibility with existing configs.
 	customArgs := filterCustomArgs(opts.CustomArgs, openclawBlockedArgs, logger)
-	if opts.Model != "" && !customArgsContains(customArgs, "--agent") {
-		args = append(args, "--agent", opts.Model)
+	if opts.Model != "" && !customArgsContains(customArgs, "--model") {
+		args = append(args, "--model", opts.Model)
 	}
 	args = append(args, customArgs...)
 
@@ -291,8 +297,10 @@ type openclawEventResult struct {
 	// model is the LLM identifier reported by openclaw in its result blob
 	// (`meta.agentMeta.model`). Empty when the run did not emit it (older
 	// openclaw versions, partial outputs). Distinct from `opts.Model`,
-	// which for the openclaw backend is the openclaw *agent* name passed
-	// via `--agent`, not the underlying model.
+	// which for the openclaw backend is the model id passed via `--model`
+	// (KAV-14) — usually the same string openclaw reports here, but the
+	// dashboard treats the runtime-reported value as authoritative when
+	// present.
 	model string
 }
 

--- a/server/pkg/agent/openclaw_test.go
+++ b/server/pkg/agent/openclaw_test.go
@@ -947,57 +947,62 @@ func TestBuildOpenclawArgsMinimal(t *testing.T) {
 	}
 }
 
-func TestBuildOpenclawArgsMapsModelToAgent(t *testing.T) {
+func TestBuildOpenclawArgsForwardsModelToFlag(t *testing.T) {
 	t.Parallel()
 
-	// For openclaw, agent.model stores the pre-registered agent name;
-	// the daemon must translate that to `--agent <name>` because the
-	// CLI rejects `--model` entirely. `--system-prompt` is also
-	// rejected and must not be emitted as a flag.
+	// KAV-14: openclaw agent's per-run flag is `--model <provider/model-or-id>`
+	// (confirmed via `openclaw agent --help`). The daemon forwards the
+	// dropdown-selected model id via `--model`. `--system-prompt` is still
+	// rejected by OpenClaw and must not be emitted.
 	args := buildOpenclawArgs("task", "ses-2", ExecOptions{
-		Model:        "deepseek-v4-agent",
+		Model:        "deepseek/deepseek-v4-flash",
 		SystemPrompt: "You are a helpful agent.",
 	}, slog.Default())
 
-	if idx := indexOf(args, "--model"); idx != -1 {
-		t.Fatalf("unexpected --model flag at %d: %v", idx, args)
-	}
+	// --system-prompt must not be forwarded (still rejected by OpenClaw).
 	if idx := indexOf(args, "--system-prompt"); idx != -1 {
 		t.Fatalf("unexpected --system-prompt flag at %d: %v", idx, args)
 	}
 
-	agentIdx := indexOf(args, "--agent")
-	if agentIdx == -1 || agentIdx+1 >= len(args) {
-		t.Fatalf("expected --agent <value> in args: %v", args)
+	// opts.Model is forwarded as `--model <id>` (the per-run override).
+	modelIdx := indexOf(args, "--model")
+	if modelIdx == -1 || modelIdx+1 >= len(args) {
+		t.Fatalf("expected --model <value> in args: %v", args)
 	}
-	if got := args[agentIdx+1]; got != "deepseek-v4-agent" {
-		t.Errorf("--agent value = %q, want %q", got, "deepseek-v4-agent")
+	if got := args[modelIdx+1]; got != "deepseek/deepseek-v4-flash" {
+		t.Errorf("--model value = %q, want %q", got, "deepseek/deepseek-v4-flash")
+	}
+
+	// --agent must not be auto-emitted by the daemon — routing via
+	// agent id is the user's responsibility through custom_args.
+	if idx := indexOf(args, "--agent"); idx != -1 {
+		t.Errorf("daemon must not auto-emit --agent, got args: %v", args)
 	}
 }
 
-func TestBuildOpenclawArgsCustomAgentWinsOverModel(t *testing.T) {
+func TestBuildOpenclawArgsCustomModelWinsOverDropdown(t *testing.T) {
 	t.Parallel()
 
-	// If the user already configured --agent via custom_args, their
+	// If the user already configured --model via custom_args, their
 	// value wins — we don't double-inject. This keeps existing configs
 	// working when they later set agent.model.
 	args := buildOpenclawArgs("task", "ses-2b", ExecOptions{
 		Model:      "from-dropdown",
-		CustomArgs: []string{"--agent", "from-custom-args"},
+		CustomArgs: []string{"--model", "from-custom-args"},
 	}, slog.Default())
 
 	count := 0
 	for _, a := range args {
-		if a == "--agent" {
+		if a == "--model" {
 			count++
 		}
 	}
 	if count != 1 {
-		t.Fatalf("expected exactly one --agent flag, got %d: %v", count, args)
+		t.Fatalf("expected exactly one --model flag, got %d: %v", count, args)
 	}
-	agentIdx := indexOf(args, "--agent")
-	if args[agentIdx+1] != "from-custom-args" {
-		t.Errorf("custom --agent should win, got %q", args[agentIdx+1])
+	modelIdx := indexOf(args, "--model")
+	if args[modelIdx+1] != "from-custom-args" {
+		t.Errorf("custom --model should win, got %q", args[modelIdx+1])
 	}
 }
 
@@ -1052,8 +1057,11 @@ func TestBuildOpenclawArgsTimeout(t *testing.T) {
 func TestBuildOpenclawArgsFiltersBlockedCustomArgs(t *testing.T) {
 	t.Parallel()
 
-	// Users must not be able to re-introduce the banned flags via custom_args —
-	// they would crash `openclaw agent` just like the direct forward did.
+	// KAV-14: --agent is now blocked (legacy routing flag), --model is
+	// NOT blocked (OpenClaw accepts it as a per-run override and the
+	// daemon forwards it from the dropdown). Users must not be able to
+	// re-introduce the banned flags via custom_args — they would crash
+	// `openclaw agent` just like the direct forward did.
 	args := buildOpenclawArgs("task", "ses-6", ExecOptions{
 		CustomArgs: []string{
 			"--agent", "research-bot",
@@ -1064,15 +1072,16 @@ func TestBuildOpenclawArgsFiltersBlockedCustomArgs(t *testing.T) {
 		},
 	}, slog.Default())
 
-	if idx := indexOf(args, "--model"); idx != -1 {
-		t.Errorf("--model should be filtered from custom_args: %v", args)
+	// --agent is now blocked; user-supplied value must be stripped.
+	if idx := indexOf(args, "--agent"); idx != -1 {
+		t.Errorf("--agent should be filtered from custom_args: %v", args)
+	}
+	// --model is no longer blocked — user-supplied value survives.
+	if idx := indexOf(args, "--model"); idx == -1 || idx+1 >= len(args) || args[idx+1] != "gpt-4o" {
+		t.Errorf("expected --model gpt-4o to survive filtering: %v", args)
 	}
 	if idx := indexOf(args, "--system-prompt"); idx != -1 {
 		t.Errorf("--system-prompt should be filtered from custom_args: %v", args)
-	}
-	// Whitelisted pass-through flag must survive filtering.
-	if idx := indexOf(args, "--agent"); idx == -1 || idx+1 >= len(args) || args[idx+1] != "research-bot" {
-		t.Errorf("expected --agent research-bot to survive filtering: %v", args)
 	}
 	// --session-id and --message appear exactly once — the daemon-managed ones.
 	if count := countOccurrences(args, "--session-id"); count != 1 {


### PR DESCRIPTION
# Fix OpenClaw provider: forward `--model` instead of `--agent` (KAV-14)

## Summary

The OpenClaw provider in the daemon was forwarding the user's dropdown
selection into `--agent <value>` even though OpenClaw 2026.x exposes
selection via `--model <provider/model-or-id>` and treats `--agent` as a
*legacy* routing flag. When the dropdown published a model id
(e.g. `deepseek/deepseek-v4-flash`), OpenClaw rejected it with
`Error: Unknown agent id`; the daemon then saw empty stdout and surfaced
the generic `openclaw returned no parseable output` failure
(multica-ai/multica#5648, KAV-13).

This PR fixes the daemon-side flag construction:

- `--model` is no longer treated as a blocked arg in
  `openclawBlockedArgs`. The daemon now auto-emits `--model <opts.Model>`
  on every `openclaw agent` invocation, matching the per-run override
  OpenClaw documents.
- `--agent` is now in `openclawBlockedArgs`. The daemon emits it
  itself, so it must not be smuggled in (or overwritten) by user
  `custom_args`.
- The text-fallback dedup in `openclawEntriesToModels` now keys on the
  final model id only, so the first row is no longer skipped and
  multi-model entries are no longer over-collapsed.
- The streaming/whole-buffer JSON parser path keeps its previous
  behaviour; the only runtime-relevant change is which flags the daemon
  passes.

## ⚠️ BREAKING CHANGE

**`--agent` is now stripped from user-supplied `custom_args`.**

Before this PR, a user could put `--agent <id>` in `custom_args` and the
daemon would pass it through. After this PR, `--agent` is filtered as a
blocked arg because the daemon now manages it itself.

Affected configs:

- `agent.custom_args: ["--agent", "research-bot"]` → silently dropped;
  replace with `--model <provider/model-or-id>`.
- Any custom_args entry that referenced `--agent` to route the run to a
  *named* agent (as opposed to a model) needs to be migrated; the
  daemon will not auto-rewrite it.

**Action required for users with `custom_args --agent …`**:
re-open the agent config, remove the `--agent …` token, and pick the
target model from the dropdown (or supply `--model` directly in
`custom_args`).

## Migration notes for persisted choices

`agent.model` previously stored the *agent id* (the value OpenClaw
accepted under the broken `--agent <id>` shape). After this PR it
stores the *model id* (the value OpenClaw accepts under `--model`).
Existing persisted choices whose value happens to be a valid model id
keep working; anything that was actually an agent id and not a model id
will silently misroute on next run. The local production `daemon.log`
shows both shapes leaking today (`--agent main`, where `main` is the
OpenClaw agent id, and `--agent deepseek/deepseek-v4-flash`, where the
dropdown value was a model id), so the migration gap affects both.

**Action required for users with persisted choices**: open the agent
dropdown once after upgrading and re-confirm the selection. The UI
will overwrite the stored value with the canonical model id. No data
loss, just one re-selection per agent.

## Evidence that OpenClaw accepts `--model`

Output of `openclaw agent --help` on OpenClaw 2026.7.1 (2d2ddc4) — the
same build the patched daemon was verified against locally:

```
OpenClaw 2026.7.1 (2d2ddc4) — All your chats, one OpenClaw.

Usage: openclaw agent [options]

Run an agent turn via the Gateway (use --local for embedded)

Options:
  --agent <id>               Agent id (overrides routing bindings)
  …
  -m, --message <text>       Message body for the agent
  --message-file <path>      Read the agent message body from a UTF-8 file
  --model <id>               Model override for this run (provider/model or
                             model id)
  …
```

The `--model <id>` line ("Model override for this run (provider/model
or model id)") is exactly the contract the patched daemon relies on.
`--agent <id>` is documented as the *legacy* routing flag.

## How to Test

**Repro shape**: 原版 daemon 把下拉选中的 routing key 塞进 `--agent`，OpenClaw
不认该 id → 空 stdout → daemon 归类 `openclaw returned no parseable output`。

### Before（现网实测，v0.4.6/v0.4.8 原版 daemon，取自 `C:\Users\xuyi\.multica\daemon.log`）

两条真实失败对照，argv 行 + 配套失败行：

```
# task 8b81bd5e
15:18:53.924 INF agent command    component=daemon exec=…\openclaw.cmd
  args="[agent --local --json --session-id multica-1784359133924641700 --agent main --message …"
15:18:54.000 INF openclaw finished component=daemon pid=17744 status=failed duration=28ms
15:18:54.000 DBG agent result detail component=daemon task=8b81bd5e status=failed output_bytes=0
  session_id="" models_with_usage=0 agent_error="openclaw returned no parseable output"

# task a124a682（另一次，同形态）
17:56:25.746 INF agent command    component=daemon exec=…\openclaw.cmd
  args="[agent --local --json --session-id multica-1784368585746424500 --agent main --message …"
17:56:25.824 INF openclaw finished component=daemon pid=28328 status=failed duration=27ms
17:56:25.824 DBG agent result detail component=daemon task=a124a682 status=failed output_bytes=0
  session_id="" models_with_usage=0 agent_error="openclaw returned no parseable output"
```

关键症状：argv 含 `--agent <id>`；`openclaw finished status=failed duration≈27–28ms`
（进程秒退）；`output_bytes=0`；`agent_error="openclaw returned no parseable output"`。

### After（patched daemon 部署后应抓到——production 现仍为原版，此为期望行，部署后用真实值替换 `<…>`）

```
<HH:MM:SS.mmm> INF agent command    component=daemon exec=…\openclaw.cmd
  args="[agent --local --json --session-id multica-<…> --model <model-bound-to-agent> --message …"
<HH:MM:SS.mmm> INF openclaw finished component=daemon pid=<…> status=succeeded duration=<秒级，非 ms>
<HH:MM:SS.mmm> DBG agent result detail component=daemon task=<…> status=succeeded output_bytes=<>0 …
```

判定（全部满足才算修复）：

1. argv 里出现 `--model …`，**不再有 `--agent …`**；
2. `openclaw finished status=succeeded`，duration 是真实运行时长（不再是 ~27ms 秒退）；
3. `output_bytes > 0`；
4. 触发的 task 终态 `done`。

KAV-16 smoke task（`62939f92-3fa4-4a10-b4fe-7cf90e3f8f2e`）的下拉值是 model id
`deepseek/deepseek-v4-flash`，所以其 patched 派发的具体期望是
`--model deepseek/deepseek-v4-flash`。

### 抓取命令

```powershell
Select-String -Path "C:\Users\xuyi\.multica\daemon.log" `
  -Pattern "agent command.*openclaw|openclaw finished|no parseable output" |
  Select-Object -Last 6
```

### Upstream status

> **Upstream status**: v0.4.7 / v0.4.8 release notes do NOT include this
> fix (verified against both release changelogs; no equivalent
> open/merged "fix(openclaw) forward --model" PR upstream). Until
> #5793 merges and ships, **local binary deploy (`kav14-deploy.ps1`)
> is the user-side mitigation** — production auto-upgraded to v0.4.8
> (`70DEBF85…`) on 2026-07-22 and still carries the bug.

### Reproducing locally

1. Build the patched binary:

   ```
   git clone https://github.com/kaverjody/multica D:\multica-patch-test\multica
   cd D:\multica-patch-test\multica
   git checkout kav-14-patch-v0.4.6
   git apply D:\multica-patch-test\kav-14.patch
   go build -o D:\multica-patch-test\multica-patched.exe ./server/cmd/multica
   ```

2. Stop the production daemon and start the patched one against an
   isolated profile (see the verification isolation in the tracker
   issue):

   ```
   multica daemon stop
   D:\multica-patch-test\multica-patched.exe daemon start --foreground --profile kav14-verify --no-auto-update
   ```

3. Create an OpenClaw-backed issue (or reuse the smoke-test issue
   `62939f92-3fa4-4a10-b4fe-7cf90e3f8f2e`); patched daemon picks it up
   within ~30 s. The `args=[…, --model <provider/model-or-id>, …]`
   line and a `status=succeeded` finish line confirm the fix.

### Unit tests

```
cd D:\multica-patch-test\multica
go test -count=1 -run 'Test(ParseOpenclawAgents|OpenclawEntriesToModels|BuildOpenclawArgs)' ./pkg/agent/...
# → 65/65 PASS on OpenClaw provider tests
```

Key added cases:

- `TestBuildOpenclawArgsForwardsModelToFlag` — daemon emits
  `--model <value>` from `opts.Model`.
- `TestBuildOpenclawArgsCustomModelWinsOverDropdown` — user-supplied
  `--model` in `custom_args` overrides the auto-emitted one.
- `TestBuildOpenclawArgsFiltersBlockedCustomArgs` — `--agent` from
  `custom_args` is filtered; `--model` from `custom_args` is kept.
- `TestOpenclawEntriesToModelsUsesIDOverName` — entry deduplication
  is on the resolved model id.

## Related Issue

- Refs: multica-ai/multica#5648 (daemon forwards wrong flag set for
  OpenClaw; same root cause as KAV-13/KAV-14 — different surface
  symptom).

  This PR fixes the KAV-14 surface (the `--agent <model>` misroute).
  The #5648 report describes a Claude-Code-flag-set misroute on a
  related code path; both should close once the OpenClaw-side flag
  construction is corrected. We use `Refs` rather than `Closes` because
  the Claude-Code-flag-set variant may need its own follow-up.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Breaking change (fix or feature that would cause existing
      functionality to not work as expected — `--agent` from
      `custom_args` is now stripped; see BREAKING CHANGE / Migration
      notes above)
- [ ] New feature
- [ ] Documentation update

## AI Disclosure

This change was developed end-to-end by `OpenCode` (model
`minimax-cn-coding-plan/MiniMax-M3`) on the user's workstation, with
independent reviews from `Codex` (model `gpt-5.6-luna`), `Claude`
(model `claude-opus-4-8`), and `Pi` (model `deepseek/deepseek-v4-flash`).
All three reviewer agents ran the patched test suite and read the full
diff; their conclusions are recorded on the tracker issue.

## Checklist

- [x] My code follows the project's style guidelines.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand
      areas (the KAV-14 docstrings on `openclawBlockedArgs` and
      `buildOpenclawArgs` explain the new contract).
- [x] I have made corresponding changes to the documentation (the
      docstrings, the inline comments on the blocked-args map, and the
      PR description).
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my
      feature works.
- [x] New and existing unit tests pass locally with my changes
      (`go test ./pkg/agent/...` — 65/65 on OpenClaw cases).
- [x] Any dependent changes have been merged and published in
      downstream modules (n/a — daemon-only change).

## Out-of-scope follow-ups (not in this PR)

- `models.go` deduplication now keys on the resolved model id rather
  than the agent id. Two registered agents that share a model id will
  collapse into one dropdown entry; this matches what the patched
  `--model` flag actually receives and is intentional. A future PR
  may revisit this if users need to keep multiple same-model agents
  visible.
- The known `identityName` field compatibility gap noted during the
  Codex review is tracked separately.