### PR TITLE
fix(desktop): make dev diagnostics best effort (MUL-5148)

### DIFF
--- a/apps/desktop/src/main/dev-log.test.ts
+++ b/apps/desktop/src/main/dev-log.test.ts
@@ -1,0 +1,52 @@
+import { EventEmitter } from "node:events";
+import { describe, expect, it, vi } from "vitest";
+import { createBestEffortDevLog } from "./dev-log";
+
+function makeSink(write = vi.fn()) {
+  return Object.assign(new EventEmitter(), {
+    destroyed: false,
+    writable: true,
+    write,
+  });
+}
+
+describe("createBestEffortDevLog", () => {
+  it("formats renderer diagnostics for the sink", () => {
+    const sink = makeSink();
+    const log = createBestEffortDevLog(sink);
+
+    log("console", "first", 2);
+
+    expect(sink.write).toHaveBeenCalledWith("[renderer console] first 2\n");
+  });
+
+  it("does not throw when a synchronous sink write fails", () => {
+    const error = Object.assign(new Error("write EIO"), { code: "EIO" });
+    const sink = makeSink(
+      vi.fn(() => {
+        throw error;
+      }),
+    );
+    const log = createBestEffortDevLog(sink);
+
+    expect(() => log("process-gone", "crashed")).not.toThrow();
+  });
+
+  it("handles asynchronous sink errors without an uncaught exception", () => {
+    const sink = makeSink();
+    createBestEffortDevLog(sink);
+    const error = Object.assign(new Error("write EIO"), { code: "EIO" });
+
+    expect(() => sink.emit("error", error)).not.toThrow();
+  });
+
+  it("skips writes after the sink is no longer writable", () => {
+    const sink = makeSink();
+    const log = createBestEffortDevLog(sink);
+    sink.writable = false;
+
+    log("console", "ignored");
+
+    expect(sink.write).not.toHaveBeenCalled();
+  });
+});

--- a/apps/desktop/src/main/dev-log.test.ts
+++ b/apps/desktop/src/main/dev-log.test.ts
@@ -49,4 +49,14 @@ describe("createBestEffortDevLog", () => {
 
     expect(sink.write).not.toHaveBeenCalled();
   });
+
+  it("skips writes after the sink is destroyed", () => {
+    const sink = makeSink();
+    const log = createBestEffortDevLog(sink);
+    sink.destroyed = true;
+
+    log("console", "ignored");
+
+    expect(sink.write).not.toHaveBeenCalled();
+  });
 });

--- a/apps/desktop/src/main/dev-log.ts
+++ b/apps/desktop/src/main/dev-log.ts
@@ -1,0 +1,30 @@
+export type DevLog = (tag: string, ...args: unknown[]) => void;
+
+type DevLogSink = {
+  readonly destroyed?: boolean;
+  readonly writable?: boolean;
+  on: (event: "error", listener: (error: Error) => void) => unknown;
+  write: (message: string) => unknown;
+};
+
+/**
+ * Renderer diagnostics are best-effort. A dev launch can outlive its terminal
+ * or PTY, so a broken stderr sink must never become a second uncaught error
+ * that hides the renderer failure we were trying to report.
+ */
+export function createBestEffortDevLog(
+  sink: DevLogSink = process.stderr,
+): DevLog {
+  // Stream write failures such as EIO/EPIPE are delivered asynchronously via
+  // `error`; without a listener Node treats them as uncaught exceptions.
+  sink.on("error", () => undefined);
+
+  return (tag, ...args) => {
+    if (sink.destroyed === true || sink.writable === false) return;
+    try {
+      sink.write(`[renderer ${tag}] ${args.map(String).join(" ")}\n`);
+    } catch {
+      // Some sinks fail synchronously once their launcher has disappeared.
+    }
+  };
+}

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -25,6 +25,7 @@ import {
   installRendererRecoveryHandlers,
   type RendererRecoveryWindow,
 } from "./renderer-recovery";
+import { createBestEffortDevLog } from "./dev-log";
 import {
   writeFreezeBreadcrumb,
   readAndClearFreezeBreadcrumb,
@@ -115,6 +116,7 @@ if (process.platform !== "win32") {
 }
 
 const PROTOCOL = "multica";
+const devLog = is.dev ? createBestEffortDevLog() : undefined;
 
 // Where the main process parks a freeze/crash breadcrumb until the next
 // renderer boot flushes it to telemetry. Lives in userData so it survives a
@@ -403,23 +405,20 @@ function createWindow(): BrowserWindow {
   // Dev-mode renderer diagnostics. When the renderer crashes hard enough
   // that DevTools can't be opened (white screen with no clickable surface),
   // the only way to recover the actual JS error is to forward it from the
-  // main process to the terminal running `make dev`. Without these, the
+  // main process to the dev launcher log. Without these, the
   // user sees only the daemon-manager polling noise (`Render frame was
   // disposed before WebFrameMain could be accessed`) which is a downstream
   // symptom, not the cause.
   //
-  // Gated by `is.dev` to keep production stderr clean — packaged builds
-  // don't have a terminal anyway, and we ship to crash-reporting separately.
-  if (is.dev) {
-    const log = (tag: string, ...args: unknown[]) =>
-      process.stderr.write(`[renderer ${tag}] ${args.map(String).join(" ")}\n`);
-
+  // Gated by `is.dev` to keep production logs clean — packaged builds ship
+  // failures to crash-reporting separately.
+  if (devLog) {
     // Forward every renderer-side console.* call. The detail object also
     // carries source URL + line — included so a thrown stack trace from
     // window.onerror is traceable back to a file.
     window.webContents.on("console-message", (details) => {
       const { level, message, sourceId, lineNumber } = details;
-      log(level, `${message} (${sourceId}:${lineNumber})`);
+      devLog(level, `${message} (${sourceId}:${lineNumber})`);
     });
 
     // Fires when loadURL / loadFile can't reach its target (dev server
@@ -429,13 +428,12 @@ function createWindow(): BrowserWindow {
       "did-fail-load",
       (_event, errorCode, errorDescription, validatedURL, isMainFrame) => {
         if (errorCode === -3) return;
-        log(
+        devLog(
           "did-fail-load",
           `code=${errorCode} desc=${errorDescription} url=${validatedURL} mainFrame=${isMainFrame}`,
         );
       },
     );
-
   }
 
   installRendererRecoveryHandlers(window as unknown as RendererRecoveryWindow, {
@@ -467,6 +465,7 @@ function createWindow(): BrowserWindow {
       ? undefined
       : () =>
           clearFreezeBreadcrumb(freezeBreadcrumbPath(), `main:${window.id}`),
+    log: devLog,
   });
 
   installContextMenu(window.webContents);
@@ -549,6 +548,7 @@ function createIssueWindow(context: IssueWindowContext): void {
       ? undefined
       : () =>
           clearFreezeBreadcrumb(freezeBreadcrumbPath(), `issue:${window.id}`),
+    log: devLog,
   });
 
   installContextMenu(window.webContents);

--- a/apps/desktop/src/main/renderer-recovery.ts
+++ b/apps/desktop/src/main/renderer-recovery.ts
@@ -37,6 +37,8 @@ type RendererRecoveryOptions = {
   unresponsivePromptDelayMs?: number;
 };
 
+const noopDevLog = () => undefined;
+
 export function installRendererRecoveryHandlers(
   window: RendererRecoveryWindow,
   {
@@ -45,7 +47,7 @@ export function installRendererRecoveryHandlers(
     getDiagnosticContext,
     persistBreadcrumb,
     clearBreadcrumb,
-    log = defaultDevLog,
+    log = noopDevLog,
     unresponsivePromptDelayMs = 1500,
   }: RendererRecoveryOptions,
 ) {
@@ -184,10 +186,6 @@ function rendererRecoveryDetail(payload: ReloadPromptPayload) {
     `kind: ${payload.kind}`,
     `context: ${JSON.stringify(payload.context)}`,
   ].join("\n");
-}
-
-function defaultDevLog(tag: string, ...args: unknown[]) {
-  process.stderr.write(`[renderer ${tag}] ${args.map(String).join(" ")}\n`);
 }
 
 function readDiagnosticContext(


### PR DESCRIPTION
## Summary

- route Desktop renderer recovery diagnostics through a best-effort dev logger
- tolerate synchronous and asynchronous `stderr` failures such as `EIO`/`EPIPE` so logging cannot mask the original renderer failure
- use the same guarded logger for main and issue windows, with focused regression tests

The workspace Local Dev Environment skill was also updated separately to keep agent-launched services attached to foreground sessions, write Desktop output to a regular per-worktree log, and require same-turn teardown. Contributor-facing launch docs remain unchanged because their foreground terminal workflow is already correct.

## Validation

- `pnpm --filter @multica/desktop run test` (38 files, 369 tests)
- `pnpm --filter @multica/desktop run typecheck`
- `pnpm --filter @multica/desktop run lint` (0 errors; 1 pre-existing Hook dependency warning)
- Local Dev Environment skill `quick_validate.py`

Closes MUL-5148
