### PR TITLE
fix(projects): show owner/repo label for GitHub resource URLs (MUL-5221)

### DIFF
--- a/packages/views/common/github-url.test.ts
+++ b/packages/views/common/github-url.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect } from "vitest";
+import { githubShortLabel, midTruncate } from "./github-url";
+
+describe("githubShortLabel", () => {
+  it("extracts owner/repo from an https URL", () => {
+    expect(githubShortLabel("https://github.com/octocat/hello-world")).toBe(
+      "octocat/hello-world",
+    );
+  });
+
+  it("ignores extra path segments after owner/repo", () => {
+    expect(
+      githubShortLabel("https://github.com/octocat/hello-world/tree/main"),
+    ).toBe("octocat/hello-world");
+  });
+
+  it("strips a trailing .git suffix", () => {
+    expect(githubShortLabel("https://github.com/octocat/hello-world.git")).toBe(
+      "octocat/hello-world",
+    );
+  });
+
+  it("handles the www.github.com host", () => {
+    expect(githubShortLabel("https://www.github.com/octocat/hello-world")).toBe(
+      "octocat/hello-world",
+    );
+  });
+
+  it("handles ssh:// URLs and strips .git", () => {
+    expect(
+      githubShortLabel("ssh://git@github.com/octocat/hello-world.git"),
+    ).toBe("octocat/hello-world");
+  });
+
+  it("handles scp-style shorthand (git@github.com:owner/repo.git)", () => {
+    expect(githubShortLabel("git@github.com:octocat/hello-world.git")).toBe(
+      "octocat/hello-world",
+    );
+  });
+
+  it("handles scp-style shorthand without a .git suffix", () => {
+    expect(githubShortLabel("git@github.com:octocat/hello-world")).toBe(
+      "octocat/hello-world",
+    );
+  });
+
+  it("middle-truncates so a shared long prefix stays distinguishable", () => {
+    const a = githubShortLabel(
+      "https://github.com/example-organization/very-long-repository-name-for-customer-alpha.git",
+    );
+    const b = githubShortLabel(
+      "https://github.com/example-organization/very-long-repository-name-for-customer-beta.git",
+    );
+    expect(a).not.toBe(b);
+    expect(a.length).toBeLessThanOrEqual(40);
+    expect(a.endsWith("alpha")).toBe(true);
+    expect(b.endsWith("beta")).toBe(true);
+  });
+
+  it("returns enterprise-host URLs unchanged", () => {
+    const url = "https://github.enterprise.com/octocat/hello-world";
+    expect(githubShortLabel(url)).toBe(url);
+  });
+
+  it("returns malformed input unchanged", () => {
+    expect(githubShortLabel("not a url")).toBe("not a url");
+  });
+
+  it("returns a github URL without a repo segment unchanged", () => {
+    const url = "https://github.com/octocat";
+    expect(githubShortLabel(url)).toBe(url);
+  });
+});
+
+describe("midTruncate", () => {
+  it("leaves short strings untouched", () => {
+    expect(midTruncate("short")).toBe("short");
+  });
+
+  it("caps the result at maxLen and inserts an ellipsis", () => {
+    const out = midTruncate("a".repeat(100), 21);
+    expect(out.length).toBe(21);
+    expect(out).toContain("…");
+    expect(out.startsWith("aaaaaaaaaa")).toBe(true);
+    expect(out.endsWith("aaaaaaaaaa")).toBe(true);
+  });
+});

--- a/packages/views/common/github-url.ts
+++ b/packages/views/common/github-url.ts
@@ -1,0 +1,35 @@
+// For GitHub URLs, return "owner/repo" so truncated display labels stay
+// meaningful when URLs share a long prefix. Handles:
+//   https://github.com/owner/repo[/...]
+//   https://www.github.com/owner/repo
+//   ssh://git@github.com/owner/repo.git
+//   git@github.com:owner/repo.git   (scp shorthand)
+// The .git suffix is stripped in all cases. When the resulting label is still
+// long, middle-truncation keeps the distinguishing tail visible (the case where
+// many repos share a long common prefix, e.g. customer-alpha vs customer-beta).
+// Non-GitHub input (enterprise hosts, malformed strings) is returned unchanged.
+export function githubShortLabel(url: string): string {
+  // scp shorthand — new URL() throws on these, so match before the try block.
+  const scp = url.match(/^(?:[^@/]+@)?github\.com:([^/]+)\/([^/]+?)(?:\.git)?$/);
+  if (scp) return midTruncate(`${scp[1]}/${scp[2]}`);
+  try {
+    const u = new URL(url);
+    if (u.hostname === "github.com" || u.hostname === "www.github.com") {
+      const [owner, repo] = u.pathname.split("/").filter(Boolean);
+      if (owner && repo) return midTruncate(`${owner}/${repo.replace(/\.git$/, "")}`);
+    }
+  } catch {
+    // not a parseable URL — fall through and return as-is
+  }
+  return url;
+}
+
+// Middle-truncate a string to at most maxLen characters, preserving both the
+// leading and trailing portions. The trailing portion is what distinguishes
+// repos that share a long common prefix (e.g. customer-alpha vs customer-beta).
+export function midTruncate(s: string, maxLen = 40): string {
+  if (s.length <= maxLen) return s;
+  const tail = Math.floor((maxLen - 1) / 2);
+  const head = maxLen - 1 - tail;
+  return `${s.slice(0, head)}…${s.slice(-tail)}`;
+}

--- a/packages/views/modals/create-project.tsx
+++ b/packages/views/modals/create-project.tsx
@@ -60,6 +60,7 @@ import {
 import { ProjectStartDatePicker } from "../projects/components/project-start-date-picker";
 import { ProjectDueDatePicker } from "../projects/components/project-due-date-picker";
 import { PillButton } from "../common/pill-button";
+import { githubShortLabel } from "../common/github-url";
 import {
   isDesktopShell,
   pickDirectory,
@@ -79,7 +80,7 @@ function RepoUrlText({
       <TooltipTrigger
         render={
           <span className={cn("truncate flex-1 text-left", className)}>
-            {url}
+            {githubShortLabel(url)}
           </span>
         }
       />

--- a/packages/views/projects/components/project-resources-section.tsx
+++ b/packages/views/projects/components/project-resources-section.tsx
@@ -387,19 +387,39 @@ export function ProjectResourcesSection({ projectId }: { projectId: string }) {
   );
 }
 
-// For GitHub URLs (https://github.com/owner/repo[/...]), return "owner/repo"
-// so truncated display labels stay meaningful when URLs share a long prefix.
+// For GitHub URLs, return "owner/repo" so truncated display labels stay
+// meaningful when URLs share a long prefix. Handles:
+//   https://github.com/owner/repo[/...]
+//   ssh://git@github.com/owner/repo.git
+//   git@github.com:owner/repo.git   (scp shorthand)
+// .git suffix is stripped in all cases. When the resulting label is still
+// long, middle-truncation keeps the distinguishing tail visible (fixing the
+// case where many repos share a long common prefix).
 function githubShortLabel(url: string): string {
+  // scp shorthand — new URL() throws on these so match before the try block.
+  const scpMatch = url.match(/^git@github\.com:([^/]+)\/([^/]+?)(?:\.git)?$/);
+  if (scpMatch) return midTruncate(`${scpMatch[1]}/${scpMatch[2]}`);
   try {
     const u = new URL(url);
     if (u.hostname === "github.com") {
       const parts = u.pathname.split("/").filter(Boolean);
-      if (parts.length >= 2) return `${parts[0]}/${parts[1]}`;
+      const [owner, repo] = parts;
+      if (owner && repo) return midTruncate(`${owner}/${repo.replace(/\.git$/, "")}`);
     }
   } catch {
-    // not a valid URL — fall through and return as-is
+    // not a parseable URL — fall through and return as-is
   }
   return url;
+}
+
+// Middle-truncate a string to at most maxLen characters, preserving both the
+// leading and trailing portions. The trailing portion is what distinguishes
+// repos that share a long common prefix (e.g. customer-alpha vs customer-beta).
+function midTruncate(s: string, maxLen = 40): string {
+  if (s.length <= maxLen) return s;
+  const tail = Math.floor((maxLen - 1) / 2);
+  const head = maxLen - 1 - tail;
+  return `${s.slice(0, head)}…${s.slice(-tail)}`;
 }
 
 interface ResourceRowProps {

--- a/packages/views/projects/components/project-resources-section.tsx
+++ b/packages/views/projects/components/project-resources-section.tsx
@@ -326,7 +326,7 @@ export function ProjectResourcesSection({ projectId }: { projectId: string }) {
                           <Tooltip>
                             <TooltipTrigger
                               render={
-                                <span className="truncate flex-1">{repo.url}</span>
+                                <span className="truncate flex-1">{githubShortLabel(repo.url)}</span>
                               }
                             />
                             <TooltipContent side="top">{repo.url}</TooltipContent>
@@ -387,6 +387,21 @@ export function ProjectResourcesSection({ projectId }: { projectId: string }) {
   );
 }
 
+// For GitHub URLs (https://github.com/owner/repo[/...]), return "owner/repo"
+// so truncated display labels stay meaningful when URLs share a long prefix.
+function githubShortLabel(url: string): string {
+  try {
+    const u = new URL(url);
+    if (u.hostname === "github.com") {
+      const parts = u.pathname.split("/").filter(Boolean);
+      if (parts.length >= 2) return `${parts[0]}/${parts[1]}`;
+    }
+  } catch {
+    // not a valid URL — fall through and return as-is
+  }
+  return url;
+}
+
 interface ResourceRowProps {
   resource: ProjectResource;
   localDaemonId: string | null;
@@ -408,7 +423,7 @@ function ResourceRow({
   const { t } = useT("projects");
   if (isGithubRef(resource)) {
     const ref = resource.resource_ref;
-    const display = resource.label || (ref.ref ? `${ref.url} @ ${ref.ref}` : ref.url);
+    const display = resource.label || (ref.ref ? `${githubShortLabel(ref.url)} @ ${ref.ref}` : githubShortLabel(ref.url));
     const tooltip = ref.ref ? `${ref.url}\nref: ${ref.ref}` : ref.url;
     return (
       <div className="flex items-center gap-2 text-xs group">

--- a/packages/views/projects/components/project-resources-section.tsx
+++ b/packages/views/projects/components/project-resources-section.tsx
@@ -44,6 +44,7 @@ import {
   type ValidateLocalDirectoryResult,
 } from "../../platform";
 import { useT } from "../../i18n";
+import { githubShortLabel } from "../../common/github-url";
 
 // Project Resources sidebar section.
 //
@@ -385,41 +386,6 @@ export function ProjectResourcesSection({ projectId }: { projectId: string }) {
       )}
     </div>
   );
-}
-
-// For GitHub URLs, return "owner/repo" so truncated display labels stay
-// meaningful when URLs share a long prefix. Handles:
-//   https://github.com/owner/repo[/...]
-//   ssh://git@github.com/owner/repo.git
-//   git@github.com:owner/repo.git   (scp shorthand)
-// .git suffix is stripped in all cases. When the resulting label is still
-// long, middle-truncation keeps the distinguishing tail visible (fixing the
-// case where many repos share a long common prefix).
-function githubShortLabel(url: string): string {
-  // scp shorthand — new URL() throws on these so match before the try block.
-  const scpMatch = url.match(/^git@github\.com:([^/]+)\/([^/]+?)(?:\.git)?$/);
-  if (scpMatch) return midTruncate(`${scpMatch[1]}/${scpMatch[2]}`);
-  try {
-    const u = new URL(url);
-    if (u.hostname === "github.com") {
-      const parts = u.pathname.split("/").filter(Boolean);
-      const [owner, repo] = parts;
-      if (owner && repo) return midTruncate(`${owner}/${repo.replace(/\.git$/, "")}`);
-    }
-  } catch {
-    // not a parseable URL — fall through and return as-is
-  }
-  return url;
-}
-
-// Middle-truncate a string to at most maxLen characters, preserving both the
-// leading and trailing portions. The trailing portion is what distinguishes
-// repos that share a long common prefix (e.g. customer-alpha vs customer-beta).
-function midTruncate(s: string, maxLen = 40): string {
-  if (s.length <= maxLen) return s;
-  const tail = Math.floor((maxLen - 1) / 2);
-  const head = maxLen - 1 - tail;
-  return `${s.slice(0, head)}…${s.slice(-tail)}`;
 }
 
 interface ResourceRowProps {


### PR DESCRIPTION
## Summary

Fixes #5771.

Long GitHub URLs in the project-resources sidebar are end-truncated by CSS `truncate`, making similar repos indistinguishable:

```
Before: https://github.com/my-org/very-long-repo-nam... ← same prefix for all
After:  my-org/very-long-repo-name-a                    ← immediately meaningful
```

**Changes:**
- Add `githubShortLabel(url)` helper that extracts `owner/repo` from `https://github.com/owner/repo[/...]` URLs
- Use it in the resource row display label (when no custom label is set)
- Use it in the repository picker popover list
- Both places keep the full URL in the tooltip, so users can still see it on hover
- Custom labels (`resource.label`) are completely unaffected
- Non-GitHub URLs (enterprise hosts, malformed) fall through and render unchanged

## Test plan

- [ ] Add a GitHub resource with a long repo URL — sidebar shows `owner/repo`, not the truncated full URL
- [ ] Hover the resource row — tooltip shows the full URL
- [ ] Add a GitHub resource with a custom label — label is shown unchanged
- [ ] Open the repository picker — repos show `owner/repo` labels; tooltip shows full URL
- [ ] `pnpm typecheck` passes in `packages/views/`