### PR TITLE
KAP-1061: make comment creation idempotent

### DIFF
--- a/server/cmd/migrate/main.go
+++ b/server/cmd/migrate/main.go
@@ -25,7 +25,7 @@ import (
 // Returning an error aborts the migration run. The corresponding
 // migration is NOT recorded in schema_migrations, so the next run will
 // retry the hook + migration.
-type preMigrationHook func(ctx context.Context, pool *pgxpool.Pool) error
+type preMigrationHook func(ctx context.Context, pool *pgxpool.Pool) (skipSQL bool, err error)
 
 // preMigrationHooks wires migration version → hook. The version key is
 // the file basename without the `.up.sql` suffix, matching what
@@ -51,41 +51,89 @@ type preMigrationHook func(ctx context.Context, pool *pgxpool.Pool) error
 var preMigrationHooks = map[string]preMigrationHook{
 	"103_drop_legacy_daily_rollups":                         runTaskUsageHourlyHook,
 	"198_agent_task_attribution_strict_constraint_validate": runAttributionStrictHook,
+	"213_comment_idempotency_index":                         runCommentIdempotencyIndexHook,
 }
 
-func runTaskUsageHourlyHook(ctx context.Context, pool *pgxpool.Pool) error {
+func runTaskUsageHourlyHook(ctx context.Context, pool *pgxpool.Pool) (bool, error) {
 	res, err := taskusagebackfill.Hook(ctx, pool, taskusagebackfill.HookOptions{})
 	if err != nil {
-		return fmt.Errorf("task_usage_hourly pre-103 hook: %w", err)
+		return false, fmt.Errorf("task_usage_hourly pre-103 hook: %w", err)
 	}
 	if res.Skipped != "" {
 		slog.Info("task_usage hourly rollup hook: skipped",
 			"reason", res.Skipped,
 			"watermark_stamped", res.WatermarkStamped)
-		return nil
+		return false, nil
 	}
 	slog.Info("task_usage hourly rollup hook: backfill complete",
 		"slices", res.SlicesProcessed,
 		"rows_touched", res.RowsTouched,
 		"from", res.From.Format("2006-01-02T15:04:05Z07:00"),
 		"to", res.To.Format("2006-01-02T15:04:05Z07:00"))
-	return nil
+	return false, nil
 }
 
 // runAttributionStrictHook backfills accountable_user_id from
 // originator_user_id before migration 198 validates the strict attribution
 // constraint, so self-hosted upgrades that never ran the out-of-band
 // backfill recover automatically (GH #5544 / MUL-4897).
-func runAttributionStrictHook(ctx context.Context, pool *pgxpool.Pool) error {
+func runAttributionStrictHook(ctx context.Context, pool *pgxpool.Pool) (bool, error) {
 	res, err := attributionbackfill.Hook(ctx, pool, attributionbackfill.HookOptions{})
 	if err != nil {
-		return fmt.Errorf("attribution strict-constraint pre-198 hook: %w", err)
+		return false, fmt.Errorf("attribution strict-constraint pre-198 hook: %w", err)
 	}
 	slog.Info("attribution backfill hook: complete",
 		"rows_backfilled", res.RowsBackfilled,
 		"batches", res.Batches,
 		"mismatch_normalized", res.MismatchNormalized)
-	return nil
+	return false, nil
+}
+
+// runCommentIdempotencyIndexHook makes migration 213 recoverable when a
+// previous CREATE INDEX CONCURRENTLY attempt stopped after PostgreSQL had
+// created the catalog entry but before the migration version was recorded.
+func runCommentIdempotencyIndexHook(ctx context.Context, pool *pgxpool.Pool) (bool, error) {
+	return reconcileConcurrentIndex(ctx, pool,
+		"public.comment_author_idempotency_key_idx", "public.comment")
+}
+
+// reconcileConcurrentIndex returns skipSQL only for a valid, ready, unique
+// index on the expected table. An invalid/not-ready artifact from a failed
+// concurrent build is removed outside a transaction so the migration SQL can
+// create it again. A same-name index on another table (or a non-unique one)
+// fails closed instead of silently accepting an unexpected schema object.
+func reconcileConcurrentIndex(ctx context.Context, pool *pgxpool.Pool, indexName, tableName string) (bool, error) {
+	var valid, ready, unique, expectedTable bool
+	err := pool.QueryRow(ctx, `
+		SELECT i.indisvalid, i.indisready, i.indisunique,
+		       i.indrelid = to_regclass($2)
+		FROM pg_index i
+		WHERE i.indexrelid = to_regclass($1)
+	`, indexName, tableName).Scan(&valid, &ready, &unique, &expectedTable)
+	if err != nil {
+		if err == pgx.ErrNoRows {
+			return false, nil
+		}
+		return false, fmt.Errorf("inspect concurrent index %q: %w", indexName, err)
+	}
+
+	if valid && ready {
+		if !unique || !expectedTable {
+			return false, fmt.Errorf("index %q is valid but does not match the expected unique index on %q", indexName, tableName)
+		}
+		slog.Info("concurrent index already valid; skipping migration SQL", "index", indexName)
+		return true, nil
+	}
+
+	indexIdent, err := quoteQualifiedIdentifier(indexName)
+	if err != nil {
+		return false, fmt.Errorf("invalid concurrent index name %q: %w", indexName, err)
+	}
+	if _, err := pool.Exec(ctx, "DROP INDEX CONCURRENTLY "+indexIdent); err != nil {
+		return false, fmt.Errorf("drop invalid concurrent index %q: %w", indexName, err)
+	}
+	slog.Info("removed invalid concurrent index before retry", "index", indexName)
+	return false, nil
 }
 
 // migrationAdvisoryLockKey is the int64 identifier used with Postgres
@@ -290,17 +338,21 @@ func runMigrations(ctx context.Context, pool *pgxpool.Pool, opts runOptions) err
 		// colliding with migrationAdvisoryLockKey. Hook failures
 		// abort the run before schema_migrations is updated, so the
 		// same version retries cleanly on the next invocation.
+		skipSQL := false
 		if opts.Direction == "up" {
 			if hook, ok := opts.Hooks[version]; ok && hook != nil {
 				slog.Info("running pre-migration hook", "version", version)
-				if err := hook(ctx, pool); err != nil {
+				skipSQL, err = hook(ctx, pool)
+				if err != nil {
 					return fmt.Errorf("pre-migration hook for %q: %w", version, err)
 				}
 			}
 		}
 
-		if _, err := conn.Exec(ctx, string(sql)); err != nil {
-			return fmt.Errorf("apply migration %q: %w", file, err)
+		if !skipSQL {
+			if _, err := conn.Exec(ctx, string(sql)); err != nil {
+				return fmt.Errorf("apply migration %q: %w", file, err)
+			}
 		}
 
 		if opts.Direction == "up" {

--- a/server/cmd/migrate/main.go
+++ b/server/cmd/migrate/main.go
@@ -97,19 +97,29 @@ func runCommentIdempotencyIndexHook(ctx context.Context, pool *pgxpool.Pool) (bo
 		"public.comment_author_idempotency_key_idx", "public.comment")
 }
 
-// reconcileConcurrentIndex returns skipSQL only for a valid, ready, unique
-// index on the expected table. An invalid/not-ready artifact from a failed
+// reconcileConcurrentIndex returns skipSQL only for a valid, ready index whose
+// table, ordered plain keys, uniqueness, and predicate exactly match the
+// runtime ON CONFLICT arbiter. An invalid/not-ready artifact from a failed
 // concurrent build is removed outside a transaction so the migration SQL can
 // create it again. A same-name index on another table (or a non-unique one)
 // fails closed instead of silently accepting an unexpected schema object.
 func reconcileConcurrentIndex(ctx context.Context, pool *pgxpool.Pool, indexName, tableName string) (bool, error) {
-	var valid, ready, unique, expectedTable bool
+	var valid, ready, semanticMatch bool
 	err := pool.QueryRow(ctx, `
-		SELECT i.indisvalid, i.indisready, i.indisunique,
-		       i.indrelid = to_regclass($2)
+		SELECT i.indisvalid, i.indisready,
+		       i.indisunique
+		       AND i.indrelid = to_regclass($2)
+		       AND i.indnkeyatts = 4
+		       AND i.indnatts = 4
+		       AND i.indexprs IS NULL
+		       AND i.indkey[0] = (SELECT attnum FROM pg_attribute WHERE attrelid = i.indrelid AND attname = 'workspace_id' AND NOT attisdropped)
+		       AND i.indkey[1] = (SELECT attnum FROM pg_attribute WHERE attrelid = i.indrelid AND attname = 'author_type' AND NOT attisdropped)
+		       AND i.indkey[2] = (SELECT attnum FROM pg_attribute WHERE attrelid = i.indrelid AND attname = 'author_id' AND NOT attisdropped)
+		       AND i.indkey[3] = (SELECT attnum FROM pg_attribute WHERE attrelid = i.indrelid AND attname = 'idempotency_key' AND NOT attisdropped)
+		       AND pg_get_expr(i.indpred, i.indrelid) = '(idempotency_key IS NOT NULL)'
 		FROM pg_index i
 		WHERE i.indexrelid = to_regclass($1)
-	`, indexName, tableName).Scan(&valid, &ready, &unique, &expectedTable)
+	`, indexName, tableName).Scan(&valid, &ready, &semanticMatch)
 	if err != nil {
 		if err == pgx.ErrNoRows {
 			return false, nil
@@ -118,8 +128,8 @@ func reconcileConcurrentIndex(ctx context.Context, pool *pgxpool.Pool, indexName
 	}
 
 	if valid && ready {
-		if !unique || !expectedTable {
-			return false, fmt.Errorf("index %q is valid but does not match the expected unique index on %q", indexName, tableName)
+		if !semanticMatch {
+			return false, fmt.Errorf("index %q is valid but does not exactly match the expected idempotency arbiter on %q", indexName, tableName)
 		}
 		slog.Info("concurrent index already valid; skipping migration SQL", "index", indexName)
 		return true, nil

--- a/server/cmd/migrate/migrate_concurrent_test.go
+++ b/server/cmd/migrate/migrate_concurrent_test.go
@@ -572,7 +572,89 @@ func TestMigration213RecoversPartialConcurrentIndex(t *testing.T) {
 			if got, want := f.appliedVersions(t), []string{version}; !equalStrings(got, want) {
 				t.Fatalf("schema_migrations after recovery = %v, want %v", got, want)
 			}
+			assertRuntimeArbiter(t, f.pool, tableFQN)
 		})
+	}
+}
+
+func TestMigration213RejectsWrongIndexDefinition(t *testing.T) {
+	for _, tc := range []struct {
+		name       string
+		definition string
+	}{
+		{
+			name:       "wrong_columns_order",
+			definition: "(workspace_id, author_id, author_type, idempotency_key) WHERE idempotency_key IS NOT NULL",
+		},
+		{
+			name:       "wrong_predicate",
+			definition: "(workspace_id, author_type, author_id, idempotency_key) WHERE idempotency_key <> ''",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			f := newFixture(t)
+			ctx, cancel := context.WithTimeout(context.Background(), raceTestTimeout)
+			defer cancel()
+
+			tableName := "comment_213_wrong"
+			indexName := "comment_author_idempotency_key_idx_213_wrong"
+			tableFQN := pgx.Identifier{f.schema, tableName}.Sanitize()
+			indexIdent := pgx.Identifier{indexName}.Sanitize()
+			if _, err := f.pool.Exec(ctx, fmt.Sprintf(`
+				CREATE TABLE %s (
+					workspace_id BIGINT NOT NULL,
+					author_type TEXT NOT NULL,
+					author_id BIGINT NOT NULL,
+					idempotency_key TEXT
+				)`, tableFQN)); err != nil {
+				t.Fatalf("create comment fixture: %v", err)
+			}
+			if _, err := f.pool.Exec(ctx, fmt.Sprintf(
+				"CREATE UNIQUE INDEX CONCURRENTLY %s ON %s %s", indexIdent, tableFQN, tc.definition)); err != nil {
+				t.Fatalf("create wrong-definition index: %v", err)
+			}
+
+			version := "213_comment_idempotency_index"
+			path := filepath.Join(t.TempDir(), version+".up.sql")
+			correctSQL := fmt.Sprintf(
+				"CREATE UNIQUE INDEX CONCURRENTLY %s ON %s (workspace_id, author_type, author_id, idempotency_key) WHERE idempotency_key IS NOT NULL",
+				indexIdent, tableFQN)
+			if err := os.WriteFile(path, []byte(correctSQL), 0o600); err != nil {
+				t.Fatalf("write migration fixture: %v", err)
+			}
+			opts := f.opts()
+			opts.Files = []string{path}
+			opts.Hooks = map[string]preMigrationHook{
+				version: func(ctx context.Context, pool *pgxpool.Pool) (bool, error) {
+					return reconcileConcurrentIndex(ctx, pool, f.schema+"."+indexName, f.schema+"."+tableName)
+				},
+			}
+			err := runMigrations(ctx, f.pool, opts)
+			if err == nil || !strings.Contains(err.Error(), "does not exactly match") {
+				t.Fatalf("migrate up with wrong definition error = %v, want exact-definition rejection", err)
+			}
+			if got := f.appliedVersions(t); len(got) != 0 {
+				t.Fatalf("wrong-definition index recorded migration versions: %v", got)
+			}
+		})
+	}
+}
+
+func assertRuntimeArbiter(t *testing.T, pool *pgxpool.Pool, tableFQN string) {
+	t.Helper()
+	stmt := fmt.Sprintf(`
+		INSERT INTO %s (workspace_id, author_type, author_id, idempotency_key)
+		VALUES (9, 'agent', 11, 'retry-key')
+		ON CONFLICT (workspace_id, author_type, author_id, idempotency_key)
+		WHERE idempotency_key IS NOT NULL DO NOTHING`, tableFQN)
+	for attempt, wantRows := range []int64{1, 0} {
+		result, err := pool.Exec(context.Background(), stmt)
+		if err != nil {
+			t.Fatalf("runtime ON CONFLICT attempt %d: %v", attempt+1, err)
+		}
+		if got := result.RowsAffected(); got != wantRows {
+			t.Fatalf("runtime ON CONFLICT attempt %d rows = %d, want %d", attempt+1, got, wantRows)
+		}
 	}
 }
 

--- a/server/cmd/migrate/migrate_concurrent_test.go
+++ b/server/cmd/migrate/migrate_concurrent_test.go
@@ -497,3 +497,96 @@ func TestRunMigrationsRejectsInvalidDirection(t *testing.T) {
 		}
 	}
 }
+
+// TestMigration213RecoversPartialConcurrentIndex covers both crash windows
+// around migration 213: a failed concurrent build leaves an invalid catalog
+// entry, while a completed build can exist without its schema_migrations row.
+// In both cases a plain migrate up must recover without operator index repair.
+func TestMigration213RecoversPartialConcurrentIndex(t *testing.T) {
+	for _, state := range []string{"invalid", "valid_without_version"} {
+		t.Run(state, func(t *testing.T) {
+			f := newFixture(t)
+			ctx, cancel := context.WithTimeout(context.Background(), raceTestTimeout)
+			defer cancel()
+
+			tableName := "comment_213"
+			indexName := "comment_author_idempotency_key_idx_213"
+			tableFQN := pgx.Identifier{f.schema, tableName}.Sanitize()
+			indexIdent := pgx.Identifier{indexName}.Sanitize()
+			if _, err := f.pool.Exec(ctx, fmt.Sprintf(`
+				CREATE TABLE %s (
+					workspace_id BIGINT NOT NULL,
+					author_type TEXT NOT NULL,
+					author_id BIGINT NOT NULL,
+					idempotency_key TEXT
+				)`, tableFQN)); err != nil {
+				t.Fatalf("create comment fixture: %v", err)
+			}
+
+			createIndexSQL := fmt.Sprintf(`
+				CREATE UNIQUE INDEX CONCURRENTLY %s
+				ON %s (workspace_id, author_type, author_id, idempotency_key)
+				WHERE idempotency_key IS NOT NULL`, indexIdent, tableFQN)
+
+			switch state {
+			case "invalid":
+				if _, err := f.pool.Exec(ctx, fmt.Sprintf(
+					`INSERT INTO %s VALUES (1, 'agent', 7, 'duplicate'), (1, 'agent', 7, 'duplicate')`, tableFQN)); err != nil {
+					t.Fatalf("seed duplicate rows: %v", err)
+				}
+				if _, err := f.pool.Exec(ctx, createIndexSQL); err == nil {
+					t.Fatal("concurrent unique build unexpectedly succeeded")
+				}
+				// Remove the data condition used only to force PostgreSQL to leave
+				// an invalid index. The migration retry itself performs no catalog
+				// or index repair outside runMigrations.
+				if _, err := f.pool.Exec(ctx, fmt.Sprintf(`DELETE FROM %s WHERE ctid IN (SELECT ctid FROM %s LIMIT 1)`, tableFQN, tableFQN)); err != nil {
+					t.Fatalf("remove duplicate fixture row: %v", err)
+				}
+			case "valid_without_version":
+				if _, err := f.pool.Exec(ctx, createIndexSQL); err != nil {
+					t.Fatalf("create valid partial-state index: %v", err)
+				}
+			}
+
+			assertIndexState(t, f.pool, f.schema+"."+indexName, state == "valid_without_version")
+
+			dir := t.TempDir()
+			version := "213_comment_idempotency_index"
+			path := filepath.Join(dir, version+".up.sql")
+			if err := os.WriteFile(path, []byte(createIndexSQL), 0o600); err != nil {
+				t.Fatalf("write migration 213 fixture: %v", err)
+			}
+			opts := f.opts()
+			opts.Files = []string{path}
+			opts.Hooks = map[string]preMigrationHook{
+				version: func(ctx context.Context, pool *pgxpool.Pool) (bool, error) {
+					return reconcileConcurrentIndex(ctx, pool, f.schema+"."+indexName, f.schema+"."+tableName)
+				},
+			}
+			if err := runMigrations(ctx, f.pool, opts); err != nil {
+				t.Fatalf("retry migrate up from %s partial state: %v", state, err)
+			}
+
+			assertIndexState(t, f.pool, f.schema+"."+indexName, true)
+			if got, want := f.appliedVersions(t), []string{version}; !equalStrings(got, want) {
+				t.Fatalf("schema_migrations after recovery = %v, want %v", got, want)
+			}
+		})
+	}
+}
+
+func assertIndexState(t *testing.T, pool *pgxpool.Pool, indexName string, wantValid bool) {
+	t.Helper()
+	var valid, ready bool
+	if err := pool.QueryRow(context.Background(), `
+		SELECT indisvalid, indisready
+		FROM pg_index
+		WHERE indexrelid = to_regclass($1)
+	`, indexName).Scan(&valid, &ready); err != nil {
+		t.Fatalf("inspect index %s: %v", indexName, err)
+	}
+	if valid != wantValid || ready != wantValid {
+		t.Fatalf("index %s state valid=%t ready=%t, want both %t", indexName, valid, ready, wantValid)
+	}
+}

--- a/server/cmd/multica/cmd_issue.go
+++ b/server/cmd/multica/cmd_issue.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"crypto/sha256"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -16,6 +17,7 @@ import (
 	"time"
 	"unicode/utf8"
 
+	"github.com/google/uuid"
 	"github.com/spf13/cobra"
 
 	"github.com/multica-ai/multica/server/internal/cli"
@@ -541,6 +543,7 @@ func init() {
 	issueCommentAddCmd.Flags().String("content-file", "", "Read comment content from a UTF-8 file (preserves multi-line content verbatim; use this on Windows when stdin piping mangles non-ASCII bytes). The path must be inside the current working directory unless --allow-external-file is set.")
 	issueCommentAddCmd.Flags().Bool("allow-external-file", false, "Allow --content-file / --attachment to read a path outside the current working directory. Off by default so a stale file from another run/environment can't be picked up (MUL-4252).")
 	issueCommentAddCmd.Flags().String("parent", "", "Parent comment ID to reply under. A comment-triggered agent task must reply under its trigger comment; omitting --parent to post a top-level comment is rejected")
+	issueCommentAddCmd.Flags().String("idempotency-key", "", "Reuse this key when retrying an ambiguous comment request; omitted keys are generated per invocation")
 	issueCommentAddCmd.Flags().StringSlice("attachment", nil, "File path(s) to attach (can be specified multiple times)")
 	issueCommentAddCmd.Flags().String("output", "json", "Output format: table or json")
 
@@ -1970,7 +1973,22 @@ func runIssueCommentAdd(cmd *cobra.Command, args []string) error {
 		fmt.Fprintf(os.Stderr, "Uploaded %s\n", att.path)
 	}
 
-	body := map[string]any{"content": content}
+	idempotencyKey, _ := cmd.Flags().GetString("idempotency-key")
+	if idempotencyKey == "" {
+		// Agent retries are often a second CLI process, so a random per-process
+		// key cannot connect them. For attachment-free task comments, derive the
+		// default from stable request identity. A deliberate repeated comment can
+		// still opt out by supplying a different explicit --idempotency-key.
+		// Attachment uploads currently mint new IDs per attempt; keep their key
+		// random until upload idempotency can bind the complete request safely.
+		if client.TaskID != "" && len(attachmentIDs) == 0 {
+			parentID, _ := cmd.Flags().GetString("parent")
+			idempotencyKey = defaultCommentIdempotencyKey(client.TaskID, issueID, parentID, content, false)
+		} else {
+			idempotencyKey = defaultCommentIdempotencyKey(client.TaskID, issueID, "", content, len(attachmentIDs) > 0)
+		}
+	}
+	body := map[string]any{"content": content, "idempotency_key": idempotencyKey}
 	if parentID, _ := cmd.Flags().GetString("parent"); parentID != "" {
 		body["parent_id"] = parentID
 	}
@@ -1979,6 +1997,7 @@ func runIssueCommentAdd(cmd *cobra.Command, args []string) error {
 	}
 	var result map[string]any
 	if err := client.PostJSON(ctx, "/api/issues/"+issueID+"/comments", body, &result); err != nil {
+		fmt.Fprintf(os.Stderr, "Comment outcome unknown. Retry with --idempotency-key %q to avoid a duplicate.\n", idempotencyKey)
 		return fmt.Errorf("add comment: %w", err)
 	}
 
@@ -1989,6 +2008,14 @@ func runIssueCommentAdd(cmd *cobra.Command, args []string) error {
 		return nil
 	}
 	return cli.PrintJSON(os.Stdout, result)
+}
+
+func defaultCommentIdempotencyKey(taskID, issueID, parentID, content string, hasAttachments bool) string {
+	if taskID == "" || hasAttachments {
+		return uuid.NewString()
+	}
+	sum := sha256.Sum256([]byte(taskID + "\x00" + issueID + "\x00" + parentID + "\x00" + content))
+	return "task-comment-v1:" + fmt.Sprintf("%x", sum[:])
 }
 
 func runIssueCommentDelete(cmd *cobra.Command, args []string) error {

--- a/server/cmd/multica/cmd_issue_idempotency_test.go
+++ b/server/cmd/multica/cmd_issue_idempotency_test.go
@@ -1,0 +1,23 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestDefaultCommentIdempotencyKey(t *testing.T) {
+	first := defaultCommentIdempotencyKey("task-1", "issue-1", "parent-1", "same content", false)
+	retry := defaultCommentIdempotencyKey("task-1", "issue-1", "parent-1", "same content", false)
+	if first != retry || !strings.HasPrefix(first, "task-comment-v1:") {
+		t.Fatalf("task retry keys = %q and %q, want same deterministic key", first, retry)
+	}
+	changed := defaultCommentIdempotencyKey("task-1", "issue-1", "parent-1", "different content", false)
+	if changed == first {
+		t.Fatal("different content must produce a different key")
+	}
+	withoutTaskA := defaultCommentIdempotencyKey("", "issue-1", "", "same", false)
+	withoutTaskB := defaultCommentIdempotencyKey("", "issue-1", "", "same", false)
+	if withoutTaskA == withoutTaskB {
+		t.Fatal("interactive comments without task identity must get distinct keys")
+	}
+}

--- a/server/internal/handler/comment.go
+++ b/server/internal/handler/comment.go
@@ -1,7 +1,9 @@
 package handler
 
 import (
+	"bytes"
 	"context"
+	"crypto/sha256"
 	"encoding/json"
 	"errors"
 	"log/slog"
@@ -13,6 +15,7 @@ import (
 	"unicode"
 
 	"github.com/go-chi/chi/v5"
+	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgtype"
 	"github.com/multica-ai/multica/server/internal/logger"
 	"github.com/multica-ai/multica/server/internal/service"
@@ -103,6 +106,18 @@ func commentToResponse(c db.Comment, reactions []ReactionResponse, attachments [
 		SourceTaskID:   uuidToPtr(c.SourceTaskID),
 		Reactions:      reactions,
 		Attachments:    attachments,
+	}
+}
+
+func idempotentRowToComment(row db.CreateCommentIdempotentRow) db.Comment {
+	return db.Comment{
+		ID: row.ID, IssueID: row.IssueID, AuthorType: row.AuthorType,
+		AuthorID: row.AuthorID, Content: row.Content, Type: row.Type,
+		CreatedAt: row.CreatedAt, UpdatedAt: row.UpdatedAt, ParentID: row.ParentID,
+		WorkspaceID: row.WorkspaceID, ResolvedAt: row.ResolvedAt,
+		ResolvedByType: row.ResolvedByType, ResolvedByID: row.ResolvedByID,
+		SourceTaskID: row.SourceTaskID, IdempotencyKey: row.IdempotencyKey,
+		IdempotencyHash: row.IdempotencyHash,
 	}
 }
 
@@ -996,6 +1011,43 @@ type CreateCommentRequest struct {
 	ParentID         *string  `json:"parent_id"`
 	AttachmentIDs    []string `json:"attachment_ids"`
 	SuppressAgentIDs []string `json:"suppress_agent_ids"`
+	IdempotencyKey   string   `json:"idempotency_key"`
+}
+
+// commentIdempotencyHash binds a key to the normalized request that first
+// claimed it. Reusing a key with different content, thread, attachments, or
+// trigger suppression is a client error rather than an accidental replay of
+// stale data. Actor/workspace are part of the unique index; issue and task are
+// included here so a key cannot silently cross either boundary.
+func commentIdempotencyHash(issueID, sourceTaskID, content, commentType string, parentID pgtype.UUID, attachmentIDs, suppressAgentIDs []pgtype.UUID) []byte {
+	ids := func(values []pgtype.UUID) []string {
+		out := make([]string, 0, len(values))
+		for _, value := range values {
+			out = append(out, uuidToString(value))
+		}
+		sort.Strings(out)
+		return out
+	}
+	payload := struct {
+		IssueID          string   `json:"issue_id"`
+		SourceTaskID     string   `json:"source_task_id,omitempty"`
+		Content          string   `json:"content"`
+		Type             string   `json:"type"`
+		ParentID         string   `json:"parent_id,omitempty"`
+		AttachmentIDs    []string `json:"attachment_ids"`
+		SuppressAgentIDs []string `json:"suppress_agent_ids"`
+	}{
+		IssueID:          issueID,
+		SourceTaskID:     sourceTaskID,
+		Content:          content,
+		Type:             commentType,
+		ParentID:         uuidToString(parentID),
+		AttachmentIDs:    ids(attachmentIDs),
+		SuppressAgentIDs: ids(suppressAgentIDs),
+	}
+	encoded, _ := json.Marshal(payload) // fixed data-only struct cannot fail
+	sum := sha256.Sum256(encoded)
+	return sum[:]
 }
 
 type CommentTriggerPreviewRequest struct {
@@ -1259,6 +1311,24 @@ func (h *Handler) CreateComment(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusBadRequest, "invalid request body")
 		return
 	}
+	headerKey := r.Header.Get("Idempotency-Key")
+	if headerKey != "" && req.IdempotencyKey != "" && headerKey != req.IdempotencyKey {
+		writeError(w, http.StatusBadRequest, "Idempotency-Key header and idempotency_key body field must match")
+		return
+	}
+	if headerKey != "" {
+		req.IdempotencyKey = headerKey
+	}
+	if req.IdempotencyKey != "" {
+		if strings.TrimSpace(req.IdempotencyKey) == "" {
+			writeError(w, http.StatusBadRequest, "idempotency key must not be blank")
+			return
+		}
+		if len([]rune(req.IdempotencyKey)) > 255 {
+			writeError(w, http.StatusBadRequest, "idempotency key must not exceed 255 characters")
+			return
+		}
+	}
 
 	// Strip bytes PostgreSQL's TEXT column rejects before the empty check. The
 	// case reachable over the JSON API is an embedded NUL (0x00, SQLSTATE
@@ -1382,7 +1452,7 @@ func (h *Handler) CreateComment(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	comment, err := h.Queries.CreateComment(r.Context(), db.CreateCommentParams{
+	createParams := db.CreateCommentParams{
 		IssueID:      issue.ID,
 		WorkspaceID:  issue.WorkspaceID,
 		AuthorType:   authorType,
@@ -1391,7 +1461,52 @@ func (h *Handler) CreateComment(w http.ResponseWriter, r *http.Request) {
 		Type:         req.Type,
 		ParentID:     parentID,
 		SourceTaskID: sourceTaskID,
-	})
+	}
+	var comment db.Comment
+	var err error
+	if req.IdempotencyKey == "" {
+		comment, err = h.Queries.CreateComment(r.Context(), createParams)
+	} else {
+		requestHash := commentIdempotencyHash(
+			issueID, uuidToString(sourceTaskID), req.Content, req.Type, parentID,
+			attachmentIDs, suppressAgentIDs,
+		)
+		var created db.CreateCommentIdempotentRow
+		created, err = h.Queries.CreateCommentIdempotent(r.Context(), db.CreateCommentIdempotentParams{
+			IssueID:         createParams.IssueID,
+			WorkspaceID:     createParams.WorkspaceID,
+			AuthorType:      createParams.AuthorType,
+			AuthorID:        createParams.AuthorID,
+			Content:         createParams.Content,
+			Type:            createParams.Type,
+			ParentID:        createParams.ParentID,
+			SourceTaskID:    createParams.SourceTaskID,
+			IdempotencyKey:  pgtype.Text{String: req.IdempotencyKey, Valid: true},
+			IdempotencyHash: requestHash,
+		})
+		if err == nil {
+			comment = idempotentRowToComment(created)
+		}
+		if errors.Is(err, pgx.ErrNoRows) {
+			comment, err = h.Queries.GetCommentByIdempotencyKey(r.Context(), db.GetCommentByIdempotencyKeyParams{
+				WorkspaceID:    issue.WorkspaceID,
+				AuthorType:     authorType,
+				AuthorID:       parseUUID(authorID),
+				IdempotencyKey: pgtype.Text{String: req.IdempotencyKey, Valid: true},
+			})
+			if err == nil && !bytes.Equal(comment.IdempotencyHash, requestHash) {
+				writeError(w, http.StatusConflict, "idempotency key was already used for a different comment request")
+				return
+			}
+			if err == nil {
+				groupedAtt := h.groupAttachments(r, []pgtype.UUID{comment.ID})
+				resp := commentToResponse(comment, nil, groupedAtt[uuidToString(comment.ID)])
+				slog.Info("comment request deduplicated", append(logger.RequestAttrs(r), "comment_id", uuidToString(comment.ID), "issue_id", issueID)...)
+				writeJSON(w, http.StatusOK, resp)
+				return
+			}
+		}
+	}
 	if err != nil {
 		slog.Warn("create comment failed", append(logger.RequestAttrs(r), "error", err, "issue_id", issueID)...)
 		writeError(w, http.StatusInternalServerError, "failed to create comment: "+err.Error())

--- a/server/internal/handler/comment_idempotency_test.go
+++ b/server/internal/handler/comment_idempotency_test.go
@@ -1,0 +1,164 @@
+package handler
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+)
+
+func createCommentWithKeyForTest(t *testing.T, issueID, content, key string, parentID *string) (int, CommentResponse) {
+	t.Helper()
+	body := map[string]any{"content": content, "idempotency_key": key}
+	if parentID != nil {
+		body["parent_id"] = *parentID
+	}
+	w := httptest.NewRecorder()
+	r := withURLParam(newRequest(http.MethodPost, "/api/issues/"+issueID+"/comments", body), "id", issueID)
+	testHandler.CreateComment(w, r)
+	var resp CommentResponse
+	if w.Code == http.StatusCreated || w.Code == http.StatusOK {
+		if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+			t.Fatalf("decode comment response: %v", err)
+		}
+	}
+	return w.Code, resp
+}
+
+func countCommentsForIssueForTest(t *testing.T, issueID string) int {
+	t.Helper()
+	var count int
+	if err := testPool.QueryRow(context.Background(), `SELECT count(*) FROM comment WHERE issue_id = $1`, issueID).Scan(&count); err != nil {
+		t.Fatalf("count comments: %v", err)
+	}
+	return count
+}
+
+func TestCreateCommentIdempotency(t *testing.T) {
+	if testHandler == nil || testPool == nil {
+		t.Skip("database not available")
+	}
+
+	t.Run("single create", func(t *testing.T) {
+		issueID := createCommentTriggerPreviewIssue(t, "idempotency single", "", "")
+		status, created := createCommentWithKeyForTest(t, issueID, "single", "kap-1061-single", nil)
+		if status != http.StatusCreated || created.ID == "" {
+			t.Fatalf("first request = %d/%+v, want 201 with comment", status, created)
+		}
+		if got := countCommentsForIssueForTest(t, issueID); got != 1 {
+			t.Fatalf("comment count = %d, want 1", got)
+		}
+	})
+
+	t.Run("retry same key returns original", func(t *testing.T) {
+		issueID := createCommentTriggerPreviewIssue(t, "idempotency retry", "", "")
+		status1, first := createCommentWithKeyForTest(t, issueID, "accepted before response loss", "kap-1061-retry", nil)
+		status2, retry := createCommentWithKeyForTest(t, issueID, "accepted before response loss", "kap-1061-retry", nil)
+		if status1 != http.StatusCreated || status2 != http.StatusOK {
+			t.Fatalf("statuses = %d, %d; want 201, 200", status1, status2)
+		}
+		if retry.ID != first.ID {
+			t.Fatalf("retry id = %s, want original %s", retry.ID, first.ID)
+		}
+		if got := countCommentsForIssueForTest(t, issueID); got != 1 {
+			t.Fatalf("comment count = %d, want 1", got)
+		}
+	})
+
+	t.Run("different keys preserve deliberate repeated content", func(t *testing.T) {
+		issueID := createCommentTriggerPreviewIssue(t, "idempotency distinct keys", "", "")
+		_, first := createCommentWithKeyForTest(t, issueID, "repeat me", "kap-1061-distinct-a", nil)
+		status, second := createCommentWithKeyForTest(t, issueID, "repeat me", "kap-1061-distinct-b", nil)
+		if status != http.StatusCreated || first.ID == second.ID {
+			t.Fatalf("second request = %d/%+v; want distinct created comment", status, second)
+		}
+		if got := countCommentsForIssueForTest(t, issueID); got != 2 {
+			t.Fatalf("comment count = %d, want 2", got)
+		}
+	})
+
+	t.Run("same key with different request is rejected", func(t *testing.T) {
+		issueID := createCommentTriggerPreviewIssue(t, "idempotency key conflict", "", "")
+		status1, _ := createCommentWithKeyForTest(t, issueID, "original", "kap-1061-conflict", nil)
+		status2, _ := createCommentWithKeyForTest(t, issueID, "changed", "kap-1061-conflict", nil)
+		if status1 != http.StatusCreated || status2 != http.StatusConflict {
+			t.Fatalf("statuses = %d, %d; want 201, 409", status1, status2)
+		}
+		if got := countCommentsForIssueForTest(t, issueID); got != 1 {
+			t.Fatalf("comment count = %d, want 1", got)
+		}
+	})
+
+	t.Run("concurrent duplicate delivery", func(t *testing.T) {
+		issueID := createCommentTriggerPreviewIssue(t, "idempotency concurrent", "", "")
+		const callers = 8
+		statuses := make(chan int, callers)
+		ids := make(chan string, callers)
+		start := make(chan struct{})
+		var wg sync.WaitGroup
+		for i := 0; i < callers; i++ {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				<-start
+				status, resp := createCommentWithKeyForTest(t, issueID, "race", "kap-1061-concurrent", nil)
+				statuses <- status
+				ids <- resp.ID
+			}()
+		}
+		close(start)
+		wg.Wait()
+		close(statuses)
+		close(ids)
+
+		created := 0
+		for status := range statuses {
+			if status == http.StatusCreated {
+				created++
+			} else if status != http.StatusOK {
+				t.Errorf("unexpected status %d", status)
+			}
+		}
+		var canonical string
+		for id := range ids {
+			if canonical == "" {
+				canonical = id
+			} else if id != canonical {
+				t.Errorf("duplicate returned id %s, want %s", id, canonical)
+			}
+		}
+		if created != 1 {
+			t.Errorf("created responses = %d, want 1", created)
+		}
+		if got := countCommentsForIssueForTest(t, issueID); got != 1 {
+			t.Fatalf("comment count = %d, want 1", got)
+		}
+	})
+}
+
+func TestCreateCommentIdempotencyRunsMentionSideEffectsOnceAndPreservesReply(t *testing.T) {
+	if testHandler == nil || testPool == nil {
+		t.Skip("database not available")
+	}
+	agentID := createHandlerTestAgent(t, "Idempotency Mention Agent", nil)
+	issueID := createCommentTriggerPreviewIssue(t, "idempotency mention side effects", "", "")
+	parentStatus, parent := createCommentWithKeyForTest(t, issueID, "thread root", "kap-1061-parent", nil)
+	if parentStatus != http.StatusCreated {
+		t.Fatalf("create parent: status %d", parentStatus)
+	}
+	content := fmt.Sprintf("[@Agent](mention://agent/%s) handle once", agentID)
+	status1, first := createCommentWithKeyForTest(t, issueID, content, "kap-1061-mention", &parent.ID)
+	status2, retry := createCommentWithKeyForTest(t, issueID, content, "kap-1061-mention", &parent.ID)
+	if status1 != http.StatusCreated || status2 != http.StatusOK || retry.ID != first.ID {
+		t.Fatalf("retry result = (%d,%s) then (%d,%s)", status1, first.ID, status2, retry.ID)
+	}
+	if retry.ParentID == nil || *retry.ParentID != parent.ID {
+		t.Fatalf("retry parent = %v, want %s", retry.ParentID, parent.ID)
+	}
+	if got := countQueuedCommentTriggerTasks(t, issueID, agentID); got != 1 {
+		t.Fatalf("mention tasks = %d, want 1", got)
+	}
+}

--- a/server/migrations/212_comment_idempotency.down.sql
+++ b/server/migrations/212_comment_idempotency.down.sql
@@ -1,0 +1,7 @@
+DROP INDEX CONCURRENTLY IF EXISTS comment_author_idempotency_key_idx;
+
+ALTER TABLE comment
+  DROP CONSTRAINT IF EXISTS comment_idempotency_key_length_check,
+  DROP CONSTRAINT IF EXISTS comment_idempotency_pair_check,
+  DROP COLUMN IF EXISTS idempotency_hash,
+  DROP COLUMN IF EXISTS idempotency_key;

--- a/server/migrations/212_comment_idempotency.down.sql
+++ b/server/migrations/212_comment_idempotency.down.sql
@@ -1,5 +1,3 @@
-DROP INDEX CONCURRENTLY IF EXISTS comment_author_idempotency_key_idx;
-
 ALTER TABLE comment
   DROP CONSTRAINT IF EXISTS comment_idempotency_key_length_check,
   DROP CONSTRAINT IF EXISTS comment_idempotency_pair_check,

--- a/server/migrations/212_comment_idempotency.up.sql
+++ b/server/migrations/212_comment_idempotency.up.sql
@@ -1,0 +1,18 @@
+ALTER TABLE comment
+  ADD COLUMN idempotency_key TEXT,
+  ADD COLUMN idempotency_hash BYTEA;
+
+ALTER TABLE comment
+  ADD CONSTRAINT comment_idempotency_pair_check CHECK (
+    (idempotency_key IS NULL) = (idempotency_hash IS NULL)
+  ) NOT VALID,
+  ADD CONSTRAINT comment_idempotency_key_length_check CHECK (
+    idempotency_key IS NULL OR length(idempotency_key) BETWEEN 1 AND 255
+  ) NOT VALID;
+
+CREATE UNIQUE INDEX CONCURRENTLY comment_author_idempotency_key_idx
+  ON comment (workspace_id, author_type, author_id, idempotency_key)
+  WHERE idempotency_key IS NOT NULL;
+
+ALTER TABLE comment VALIDATE CONSTRAINT comment_idempotency_pair_check;
+ALTER TABLE comment VALIDATE CONSTRAINT comment_idempotency_key_length_check;

--- a/server/migrations/213_comment_idempotency_index.down.sql
+++ b/server/migrations/213_comment_idempotency_index.down.sql
@@ -1,0 +1,1 @@
+DROP INDEX CONCURRENTLY IF EXISTS comment_author_idempotency_key_idx;

--- a/server/migrations/213_comment_idempotency_index.up.sql
+++ b/server/migrations/213_comment_idempotency_index.up.sql
@@ -1,0 +1,3 @@
+CREATE UNIQUE INDEX CONCURRENTLY comment_author_idempotency_key_idx
+  ON comment (workspace_id, author_type, author_id, idempotency_key)
+  WHERE idempotency_key IS NOT NULL;

--- a/server/migrations/214_comment_idempotency_validate.down.sql
+++ b/server/migrations/214_comment_idempotency_validate.down.sql
@@ -1,6 +1,6 @@
 ALTER TABLE comment
-  ADD COLUMN idempotency_key TEXT,
-  ADD COLUMN idempotency_hash BYTEA;
+  DROP CONSTRAINT IF EXISTS comment_idempotency_key_length_check,
+  DROP CONSTRAINT IF EXISTS comment_idempotency_pair_check;
 
 ALTER TABLE comment
   ADD CONSTRAINT comment_idempotency_pair_check CHECK (

--- a/server/migrations/214_comment_idempotency_validate.up.sql
+++ b/server/migrations/214_comment_idempotency_validate.up.sql
@@ -1,0 +1,2 @@
+ALTER TABLE comment VALIDATE CONSTRAINT comment_idempotency_pair_check;
+ALTER TABLE comment VALIDATE CONSTRAINT comment_idempotency_key_length_check;

--- a/server/pkg/db/generated/comment.sql.go
+++ b/server/pkg/db/generated/comment.sql.go
@@ -45,7 +45,7 @@ UPDATE comment SET
 WHERE comment.id IN (SELECT id FROM descendants)
   AND comment.id <> $1
   AND comment.resolved_at IS NOT NULL
-RETURNING id, issue_id, author_type, author_id, content, type, created_at, updated_at, parent_id, workspace_id, resolved_at, resolved_by_type, resolved_by_id, source_task_id
+RETURNING id, issue_id, author_type, author_id, content, type, created_at, updated_at, parent_id, workspace_id, resolved_at, resolved_by_type, resolved_by_id, source_task_id, idempotency_key, idempotency_hash
 `
 
 type ClearOtherThreadResolutionsParams struct {
@@ -88,6 +88,8 @@ func (q *Queries) ClearOtherThreadResolutions(ctx context.Context, arg ClearOthe
 			&i.ResolvedByType,
 			&i.ResolvedByID,
 			&i.SourceTaskID,
+			&i.IdempotencyKey,
+			&i.IdempotencyHash,
 		); err != nil {
 			return nil, err
 		}
@@ -163,7 +165,7 @@ WITH touched_issue AS (
 INSERT INTO comment (issue_id, workspace_id, author_type, author_id, content, type, parent_id, source_task_id)
 SELECT ti.id, ti.workspace_id, $1, $2, $3, $4, $5, $6
 FROM touched_issue ti
-RETURNING id, issue_id, author_type, author_id, content, type, created_at, updated_at, parent_id, workspace_id, resolved_at, resolved_by_type, resolved_by_id, source_task_id
+RETURNING id, issue_id, author_type, author_id, content, type, created_at, updated_at, parent_id, workspace_id, resolved_at, resolved_by_type, resolved_by_id, source_task_id, idempotency_key, idempotency_hash
 `
 
 type CreateCommentParams struct {
@@ -220,6 +222,108 @@ func (q *Queries) CreateComment(ctx context.Context, arg CreateCommentParams) (C
 		&i.ResolvedByType,
 		&i.ResolvedByID,
 		&i.SourceTaskID,
+		&i.IdempotencyKey,
+		&i.IdempotencyHash,
+	)
+	return i, err
+}
+
+const createCommentIdempotent = `-- name: CreateCommentIdempotent :one
+WITH candidate_issue AS (
+    SELECT id, workspace_id FROM issue
+    WHERE issue.id = $1 AND issue.workspace_id = $2
+), inserted AS (
+    INSERT INTO comment (
+        issue_id, workspace_id, author_type, author_id, content, type, parent_id,
+        source_task_id, idempotency_key, idempotency_hash
+    )
+    SELECT ci.id, ci.workspace_id, $3, $4,
+           $5, $6, $7,
+           $8, $9,
+           $10
+    FROM candidate_issue ci
+    ON CONFLICT (workspace_id, author_type, author_id, idempotency_key)
+        WHERE idempotency_key IS NOT NULL
+        DO NOTHING
+    RETURNING id, issue_id, author_type, author_id, content, type, created_at, updated_at, parent_id, workspace_id, resolved_at, resolved_by_type, resolved_by_id, source_task_id, idempotency_key, idempotency_hash
+), touched_issue AS (
+    UPDATE issue SET updated_at = now()
+    WHERE issue.id = (SELECT issue_id FROM inserted)
+    RETURNING issue.id
+)
+SELECT inserted.id, inserted.issue_id, inserted.author_type, inserted.author_id, inserted.content, inserted.type, inserted.created_at, inserted.updated_at, inserted.parent_id, inserted.workspace_id, inserted.resolved_at, inserted.resolved_by_type, inserted.resolved_by_id, inserted.source_task_id, inserted.idempotency_key, inserted.idempotency_hash FROM inserted
+JOIN touched_issue ON touched_issue.id = inserted.issue_id
+`
+
+type CreateCommentIdempotentParams struct {
+	IssueID         pgtype.UUID `json:"issue_id"`
+	WorkspaceID     pgtype.UUID `json:"workspace_id"`
+	AuthorType      string      `json:"author_type"`
+	AuthorID        pgtype.UUID `json:"author_id"`
+	Content         string      `json:"content"`
+	Type            string      `json:"type"`
+	ParentID        pgtype.UUID `json:"parent_id"`
+	SourceTaskID    pgtype.UUID `json:"source_task_id"`
+	IdempotencyKey  pgtype.Text `json:"idempotency_key"`
+	IdempotencyHash []byte      `json:"idempotency_hash"`
+}
+
+type CreateCommentIdempotentRow struct {
+	ID              pgtype.UUID        `json:"id"`
+	IssueID         pgtype.UUID        `json:"issue_id"`
+	AuthorType      string             `json:"author_type"`
+	AuthorID        pgtype.UUID        `json:"author_id"`
+	Content         string             `json:"content"`
+	Type            string             `json:"type"`
+	CreatedAt       pgtype.Timestamptz `json:"created_at"`
+	UpdatedAt       pgtype.Timestamptz `json:"updated_at"`
+	ParentID        pgtype.UUID        `json:"parent_id"`
+	WorkspaceID     pgtype.UUID        `json:"workspace_id"`
+	ResolvedAt      pgtype.Timestamptz `json:"resolved_at"`
+	ResolvedByType  pgtype.Text        `json:"resolved_by_type"`
+	ResolvedByID    pgtype.UUID        `json:"resolved_by_id"`
+	SourceTaskID    pgtype.UUID        `json:"source_task_id"`
+	IdempotencyKey  pgtype.Text        `json:"idempotency_key"`
+	IdempotencyHash []byte             `json:"idempotency_hash"`
+}
+
+// The unique partial index claims an idempotency key for one actor. A losing
+// concurrent delivery returns no row; its caller then loads the winner in a
+// fresh statement, whose READ COMMITTED snapshot can see the committed row.
+// Side effects are deliberately outside this query and run only when this
+// INSERT returns a row. The issue activity timestamp also advances only for
+// the winning insert, not for a deduplicated retry.
+func (q *Queries) CreateCommentIdempotent(ctx context.Context, arg CreateCommentIdempotentParams) (CreateCommentIdempotentRow, error) {
+	row := q.db.QueryRow(ctx, createCommentIdempotent,
+		arg.IssueID,
+		arg.WorkspaceID,
+		arg.AuthorType,
+		arg.AuthorID,
+		arg.Content,
+		arg.Type,
+		arg.ParentID,
+		arg.SourceTaskID,
+		arg.IdempotencyKey,
+		arg.IdempotencyHash,
+	)
+	var i CreateCommentIdempotentRow
+	err := row.Scan(
+		&i.ID,
+		&i.IssueID,
+		&i.AuthorType,
+		&i.AuthorID,
+		&i.Content,
+		&i.Type,
+		&i.CreatedAt,
+		&i.UpdatedAt,
+		&i.ParentID,
+		&i.WorkspaceID,
+		&i.ResolvedAt,
+		&i.ResolvedByType,
+		&i.ResolvedByID,
+		&i.SourceTaskID,
+		&i.IdempotencyKey,
+		&i.IdempotencyHash,
 	)
 	return i, err
 }
@@ -240,7 +344,7 @@ func (q *Queries) DeleteComment(ctx context.Context, arg DeleteCommentParams) er
 }
 
 const getComment = `-- name: GetComment :one
-SELECT id, issue_id, author_type, author_id, content, type, created_at, updated_at, parent_id, workspace_id, resolved_at, resolved_by_type, resolved_by_id, source_task_id FROM comment
+SELECT id, issue_id, author_type, author_id, content, type, created_at, updated_at, parent_id, workspace_id, resolved_at, resolved_by_type, resolved_by_id, source_task_id, idempotency_key, idempotency_hash FROM comment
 WHERE id = $1
 `
 
@@ -262,12 +366,58 @@ func (q *Queries) GetComment(ctx context.Context, id pgtype.UUID) (Comment, erro
 		&i.ResolvedByType,
 		&i.ResolvedByID,
 		&i.SourceTaskID,
+		&i.IdempotencyKey,
+		&i.IdempotencyHash,
+	)
+	return i, err
+}
+
+const getCommentByIdempotencyKey = `-- name: GetCommentByIdempotencyKey :one
+SELECT id, issue_id, author_type, author_id, content, type, created_at, updated_at, parent_id, workspace_id, resolved_at, resolved_by_type, resolved_by_id, source_task_id, idempotency_key, idempotency_hash FROM comment
+WHERE workspace_id = $1
+  AND author_type = $2
+  AND author_id = $3
+  AND idempotency_key = $4
+`
+
+type GetCommentByIdempotencyKeyParams struct {
+	WorkspaceID    pgtype.UUID `json:"workspace_id"`
+	AuthorType     string      `json:"author_type"`
+	AuthorID       pgtype.UUID `json:"author_id"`
+	IdempotencyKey pgtype.Text `json:"idempotency_key"`
+}
+
+func (q *Queries) GetCommentByIdempotencyKey(ctx context.Context, arg GetCommentByIdempotencyKeyParams) (Comment, error) {
+	row := q.db.QueryRow(ctx, getCommentByIdempotencyKey,
+		arg.WorkspaceID,
+		arg.AuthorType,
+		arg.AuthorID,
+		arg.IdempotencyKey,
+	)
+	var i Comment
+	err := row.Scan(
+		&i.ID,
+		&i.IssueID,
+		&i.AuthorType,
+		&i.AuthorID,
+		&i.Content,
+		&i.Type,
+		&i.CreatedAt,
+		&i.UpdatedAt,
+		&i.ParentID,
+		&i.WorkspaceID,
+		&i.ResolvedAt,
+		&i.ResolvedByType,
+		&i.ResolvedByID,
+		&i.SourceTaskID,
+		&i.IdempotencyKey,
+		&i.IdempotencyHash,
 	)
 	return i, err
 }
 
 const getCommentInWorkspace = `-- name: GetCommentInWorkspace :one
-SELECT id, issue_id, author_type, author_id, content, type, created_at, updated_at, parent_id, workspace_id, resolved_at, resolved_by_type, resolved_by_id, source_task_id FROM comment
+SELECT id, issue_id, author_type, author_id, content, type, created_at, updated_at, parent_id, workspace_id, resolved_at, resolved_by_type, resolved_by_id, source_task_id, idempotency_key, idempotency_hash FROM comment
 WHERE id = $1 AND workspace_id = $2
 `
 
@@ -294,12 +444,14 @@ func (q *Queries) GetCommentInWorkspace(ctx context.Context, arg GetCommentInWor
 		&i.ResolvedByType,
 		&i.ResolvedByID,
 		&i.SourceTaskID,
+		&i.IdempotencyKey,
+		&i.IdempotencyHash,
 	)
 	return i, err
 }
 
 const getLatestMemberCommentForIssueSince = `-- name: GetLatestMemberCommentForIssueSince :one
-SELECT id, issue_id, author_type, author_id, content, type, created_at, updated_at, parent_id, workspace_id, resolved_at, resolved_by_type, resolved_by_id, source_task_id FROM comment
+SELECT id, issue_id, author_type, author_id, content, type, created_at, updated_at, parent_id, workspace_id, resolved_at, resolved_by_type, resolved_by_id, source_task_id, idempotency_key, idempotency_hash FROM comment
 WHERE issue_id = $1
   AND author_type = 'member'
   AND created_at > $2
@@ -339,6 +491,8 @@ func (q *Queries) GetLatestMemberCommentForIssueSince(ctx context.Context, arg G
 		&i.ResolvedByType,
 		&i.ResolvedByID,
 		&i.SourceTaskID,
+		&i.IdempotencyKey,
+		&i.IdempotencyHash,
 	)
 	return i, err
 }
@@ -353,7 +507,7 @@ WITH RECURSIVE root_of AS (
     FROM comment p
     JOIN root_of r ON p.id = r.parent_id
 )
-SELECT c.id, c.issue_id, c.author_type, c.author_id, c.content, c.type, c.created_at, c.updated_at, c.parent_id, c.workspace_id, c.resolved_at, c.resolved_by_type, c.resolved_by_id, c.source_task_id FROM comment c
+SELECT c.id, c.issue_id, c.author_type, c.author_id, c.content, c.type, c.created_at, c.updated_at, c.parent_id, c.workspace_id, c.resolved_at, c.resolved_by_type, c.resolved_by_id, c.source_task_id, c.idempotency_key, c.idempotency_hash FROM comment c
 WHERE c.id = (SELECT id FROM root_of WHERE parent_id IS NULL LIMIT 1)
 `
 
@@ -385,6 +539,8 @@ func (q *Queries) GetThreadRoot(ctx context.Context, arg GetThreadRootParams) (C
 		&i.ResolvedByType,
 		&i.ResolvedByID,
 		&i.SourceTaskID,
+		&i.IdempotencyKey,
+		&i.IdempotencyHash,
 	)
 	return i, err
 }
@@ -433,7 +589,7 @@ func (q *Queries) HasAgentRepliedInThread(ctx context.Context, arg HasAgentRepli
 }
 
 const listCommentsForIssue = `-- name: ListCommentsForIssue :many
-SELECT id, issue_id, author_type, author_id, content, type, created_at, updated_at, parent_id, workspace_id, resolved_at, resolved_by_type, resolved_by_id, source_task_id FROM comment
+SELECT id, issue_id, author_type, author_id, content, type, created_at, updated_at, parent_id, workspace_id, resolved_at, resolved_by_type, resolved_by_id, source_task_id, idempotency_key, idempotency_hash FROM comment
 WHERE issue_id = $1 AND workspace_id = $2
 ORDER BY created_at ASC, id ASC
 LIMIT $3
@@ -472,6 +628,8 @@ func (q *Queries) ListCommentsForIssue(ctx context.Context, arg ListCommentsForI
 			&i.ResolvedByType,
 			&i.ResolvedByID,
 			&i.SourceTaskID,
+			&i.IdempotencyKey,
+			&i.IdempotencyHash,
 		); err != nil {
 			return nil, err
 		}
@@ -484,7 +642,7 @@ func (q *Queries) ListCommentsForIssue(ctx context.Context, arg ListCommentsForI
 }
 
 const listCommentsSinceForIssue = `-- name: ListCommentsSinceForIssue :many
-SELECT id, issue_id, author_type, author_id, content, type, created_at, updated_at, parent_id, workspace_id, resolved_at, resolved_by_type, resolved_by_id, source_task_id FROM comment
+SELECT id, issue_id, author_type, author_id, content, type, created_at, updated_at, parent_id, workspace_id, resolved_at, resolved_by_type, resolved_by_id, source_task_id, idempotency_key, idempotency_hash FROM comment
 WHERE issue_id = $1 AND workspace_id = $2 AND created_at > $3
 ORDER BY created_at ASC, id ASC
 LIMIT $4
@@ -528,6 +686,8 @@ func (q *Queries) ListCommentsSinceForIssue(ctx context.Context, arg ListComment
 			&i.ResolvedByType,
 			&i.ResolvedByID,
 			&i.SourceTaskID,
+			&i.IdempotencyKey,
+			&i.IdempotencyHash,
 		); err != nil {
 			return nil, err
 		}
@@ -680,7 +840,7 @@ func (q *Queries) ListRecentThreadCommentsForIssue(ctx context.Context, arg List
 }
 
 const listReconcilableCommentsForIssueSince = `-- name: ListReconcilableCommentsForIssueSince :many
-SELECT id, issue_id, author_type, author_id, content, type, created_at, updated_at, parent_id, workspace_id, resolved_at, resolved_by_type, resolved_by_id, source_task_id FROM comment
+SELECT id, issue_id, author_type, author_id, content, type, created_at, updated_at, parent_id, workspace_id, resolved_at, resolved_by_type, resolved_by_id, source_task_id, idempotency_key, idempotency_hash FROM comment
 WHERE issue_id = $1
   AND author_type IN ('member', 'agent')
   AND (
@@ -747,6 +907,8 @@ func (q *Queries) ListReconcilableCommentsForIssueSince(ctx context.Context, arg
 			&i.ResolvedByType,
 			&i.ResolvedByID,
 			&i.SourceTaskID,
+			&i.IdempotencyKey,
+			&i.IdempotencyHash,
 		); err != nil {
 			return nil, err
 		}
@@ -1235,7 +1397,7 @@ UPDATE comment SET
     resolved_by_id = COALESCE(resolved_by_id, $3),
     updated_at = CASE WHEN resolved_at IS NULL THEN now() ELSE updated_at END
 WHERE id = $1
-RETURNING id, issue_id, author_type, author_id, content, type, created_at, updated_at, parent_id, workspace_id, resolved_at, resolved_by_type, resolved_by_id, source_task_id
+RETURNING id, issue_id, author_type, author_id, content, type, created_at, updated_at, parent_id, workspace_id, resolved_at, resolved_by_type, resolved_by_id, source_task_id, idempotency_key, idempotency_hash
 `
 
 type ResolveCommentParams struct {
@@ -1264,6 +1426,8 @@ func (q *Queries) ResolveComment(ctx context.Context, arg ResolveCommentParams) 
 		&i.ResolvedByType,
 		&i.ResolvedByID,
 		&i.SourceTaskID,
+		&i.IdempotencyKey,
+		&i.IdempotencyHash,
 	)
 	return i, err
 }
@@ -1275,7 +1439,7 @@ UPDATE comment SET
     resolved_by_id = NULL,
     updated_at = CASE WHEN resolved_at IS NOT NULL THEN now() ELSE updated_at END
 WHERE id = $1
-RETURNING id, issue_id, author_type, author_id, content, type, created_at, updated_at, parent_id, workspace_id, resolved_at, resolved_by_type, resolved_by_id, source_task_id
+RETURNING id, issue_id, author_type, author_id, content, type, created_at, updated_at, parent_id, workspace_id, resolved_at, resolved_by_type, resolved_by_id, source_task_id, idempotency_key, idempotency_hash
 `
 
 // Idempotent: a no-op clear (already unresolved) just returns the row.
@@ -1297,6 +1461,8 @@ func (q *Queries) UnresolveComment(ctx context.Context, id pgtype.UUID) (Comment
 		&i.ResolvedByType,
 		&i.ResolvedByID,
 		&i.SourceTaskID,
+		&i.IdempotencyKey,
+		&i.IdempotencyHash,
 	)
 	return i, err
 }
@@ -1307,7 +1473,7 @@ UPDATE comment SET
     source_task_id = $3,
     updated_at = now()
 WHERE id = $1
-RETURNING id, issue_id, author_type, author_id, content, type, created_at, updated_at, parent_id, workspace_id, resolved_at, resolved_by_type, resolved_by_id, source_task_id
+RETURNING id, issue_id, author_type, author_id, content, type, created_at, updated_at, parent_id, workspace_id, resolved_at, resolved_by_type, resolved_by_id, source_task_id, idempotency_key, idempotency_hash
 `
 
 type UpdateCommentParams struct {
@@ -1334,6 +1500,8 @@ func (q *Queries) UpdateComment(ctx context.Context, arg UpdateCommentParams) (C
 		&i.ResolvedByType,
 		&i.ResolvedByID,
 		&i.SourceTaskID,
+		&i.IdempotencyKey,
+		&i.IdempotencyHash,
 	)
 	return i, err
 }

--- a/server/pkg/db/generated/models.go
+++ b/server/pkg/db/generated/models.go
@@ -410,20 +410,22 @@ type ClientUsageDaily struct {
 }
 
 type Comment struct {
-	ID             pgtype.UUID        `json:"id"`
-	IssueID        pgtype.UUID        `json:"issue_id"`
-	AuthorType     string             `json:"author_type"`
-	AuthorID       pgtype.UUID        `json:"author_id"`
-	Content        string             `json:"content"`
-	Type           string             `json:"type"`
-	CreatedAt      pgtype.Timestamptz `json:"created_at"`
-	UpdatedAt      pgtype.Timestamptz `json:"updated_at"`
-	ParentID       pgtype.UUID        `json:"parent_id"`
-	WorkspaceID    pgtype.UUID        `json:"workspace_id"`
-	ResolvedAt     pgtype.Timestamptz `json:"resolved_at"`
-	ResolvedByType pgtype.Text        `json:"resolved_by_type"`
-	ResolvedByID   pgtype.UUID        `json:"resolved_by_id"`
-	SourceTaskID   pgtype.UUID        `json:"source_task_id"`
+	ID              pgtype.UUID        `json:"id"`
+	IssueID         pgtype.UUID        `json:"issue_id"`
+	AuthorType      string             `json:"author_type"`
+	AuthorID        pgtype.UUID        `json:"author_id"`
+	Content         string             `json:"content"`
+	Type            string             `json:"type"`
+	CreatedAt       pgtype.Timestamptz `json:"created_at"`
+	UpdatedAt       pgtype.Timestamptz `json:"updated_at"`
+	ParentID        pgtype.UUID        `json:"parent_id"`
+	WorkspaceID     pgtype.UUID        `json:"workspace_id"`
+	ResolvedAt      pgtype.Timestamptz `json:"resolved_at"`
+	ResolvedByType  pgtype.Text        `json:"resolved_by_type"`
+	ResolvedByID    pgtype.UUID        `json:"resolved_by_id"`
+	SourceTaskID    pgtype.UUID        `json:"source_task_id"`
+	IdempotencyKey  pgtype.Text        `json:"idempotency_key"`
+	IdempotencyHash []byte             `json:"idempotency_hash"`
 }
 
 type CommentReaction struct {

--- a/server/pkg/db/queries/comment.sql
+++ b/server/pkg/db/queries/comment.sql
@@ -418,6 +418,45 @@ SELECT ti.id, ti.workspace_id, sqlc.arg(author_type), sqlc.arg(author_id), sqlc.
 FROM touched_issue ti
 RETURNING *;
 
+-- name: CreateCommentIdempotent :one
+-- The unique partial index claims an idempotency key for one actor. A losing
+-- concurrent delivery returns no row; its caller then loads the winner in a
+-- fresh statement, whose READ COMMITTED snapshot can see the committed row.
+-- Side effects are deliberately outside this query and run only when this
+-- INSERT returns a row. The issue activity timestamp also advances only for
+-- the winning insert, not for a deduplicated retry.
+WITH candidate_issue AS (
+    SELECT id, workspace_id FROM issue
+    WHERE issue.id = sqlc.arg(issue_id) AND issue.workspace_id = sqlc.arg(workspace_id)
+), inserted AS (
+    INSERT INTO comment (
+        issue_id, workspace_id, author_type, author_id, content, type, parent_id,
+        source_task_id, idempotency_key, idempotency_hash
+    )
+    SELECT ci.id, ci.workspace_id, sqlc.arg(author_type), sqlc.arg(author_id),
+           sqlc.arg(content), sqlc.arg(type), sqlc.narg(parent_id),
+           sqlc.narg(source_task_id), sqlc.arg(idempotency_key),
+           sqlc.arg(idempotency_hash)
+    FROM candidate_issue ci
+    ON CONFLICT (workspace_id, author_type, author_id, idempotency_key)
+        WHERE idempotency_key IS NOT NULL
+        DO NOTHING
+    RETURNING *
+), touched_issue AS (
+    UPDATE issue SET updated_at = now()
+    WHERE issue.id = (SELECT issue_id FROM inserted)
+    RETURNING issue.id
+)
+SELECT inserted.* FROM inserted
+JOIN touched_issue ON touched_issue.id = inserted.issue_id;
+
+-- name: GetCommentByIdempotencyKey :one
+SELECT * FROM comment
+WHERE workspace_id = @workspace_id
+  AND author_type = @author_type
+  AND author_id = @author_id
+  AND idempotency_key = @idempotency_key;
+
 -- name: UpdateComment :one
 UPDATE comment SET
     content = $2,


### PR DESCRIPTION
## Summary
- add actor-scoped comment idempotency keys with request-hash conflict detection
- deduplicate concurrent/retried creates before publish, mention, enqueue, attachment-link, and thread side effects
- derive stable CLI keys for attachment-free agent-task comments; expose `--idempotency-key` for explicit retries and deliberate repeated content
- recover migration 213 from both invalid concurrent-index artifacts and valid indexes missing their `schema_migrations` row

## Root cause / provenance
Run task `319bd80d-a4f5-407f-ab77-ea1717aa9737` issued two explicit successful `multica issue comment add` calls (message seq 42 and 44). Existing API had no idempotency identity; each POST inserted, published, and triggered independently. This evidence rules out an ambiguous transport retry for the observed pair, while the same fix also covers accepted-but-unknown retry with a reused key.

## Tests
- `go test -p 1 ./cmd/migrate -count=1`
- `go test -p 1 ./cmd/multica -run TestDefaultCommentIdempotencyKey -count=1`
- `go test -p 1 ./internal/handler -count=1`
- `go test -p 1 ./pkg/db/generated -count=1`
- migration recovery cases: failed concurrent build leaving `indisvalid=false`/`indisready=false`; valid+ready index without migration row; both complete a repeated `migrate up` without manual index/catalog repair
- API cases: single create; same-key retry; different-key same-content; key/payload conflict; 8-way concurrent delivery; one mention enqueue; reply parent preservation

## Migration / compatibility
- 212 adds nullable key/hash columns and NOT VALID checks
- 213 creates the partial unique index concurrently; its pre-migration hook inspects `pg_index.indisvalid` and `indisready`, drops an invalid/not-ready artifact with standalone `DROP INDEX CONCURRENTLY`, or skips CREATE only for a valid+ready unique index on the expected table
- 214 validates the checks
- old clients omit keys and preserve current create behavior
- duplicate response is HTTP 200 with the canonical original comment; first create remains 201

## Targeted rollback / recovery (214 → 213 → 212 only)
Rollback the application first. Do **not** use general `./migrate down`, because it rolls back every applied migration. With the repository checkout matching the deployed release, run each file and delete only its matching bookkeeping row before proceeding:

```bash
psql "$DATABASE_URL" -v ON_ERROR_STOP=1 -f server/migrations/214_comment_idempotency_validate.down.sql
psql "$DATABASE_URL" -v ON_ERROR_STOP=1 -c "DELETE FROM schema_migrations WHERE version = '214_comment_idempotency_validate'"
psql "$DATABASE_URL" -v ON_ERROR_STOP=1 -f server/migrations/213_comment_idempotency_index.down.sql
psql "$DATABASE_URL" -v ON_ERROR_STOP=1 -c "DELETE FROM schema_migrations WHERE version = '213_comment_idempotency_index'"
psql "$DATABASE_URL" -v ON_ERROR_STOP=1 -f server/migrations/212_comment_idempotency.down.sql
psql "$DATABASE_URL" -v ON_ERROR_STOP=1 -c "DELETE FROM schema_migrations WHERE version = '212_comment_idempotency'"
```

Recovery after interruption is targeted `./migrate up`: the 213 hook repairs an invalid index or accepts the completed valid index, then records 213 and continues to 214. No manual index repair is required.

Production migration/rollout remains on HOLD pending repeated DevOps review.

## Residual risk
Attachment-bearing CLI retries still use random default keys because uploads mint new attachment IDs; callers can pass an explicit key, but end-to-end upload idempotency is separate follow-up scope.

Closes KAP-1061
