### PR TITLE
fix(desktop): attach bearer auth to native attachment downloads

### DIFF
--- a/apps/desktop/src/main/external-url.ts
+++ b/apps/desktop/src/main/external-url.ts
@@ -24,12 +24,25 @@ export function openExternalSafely(url: string): Promise<void> | void {
 // to `webContents.downloadURL` elsewhere in the main process are banned by
 // the no-restricted-syntax rule in apps/desktop/eslint.config.mjs.
 // Reuses the same http/https allowlist as openExternalSafely.
-export function downloadURLSafely(win: BrowserWindow, url: string): void {
+export function downloadURLSafely(
+  win: BrowserWindow,
+  url: string,
+  authorization?: string,
+): void {
   if (getHttpProtocol(url) === null) {
     console.warn(`[security] blocked downloadURL: ${describeScheme(url)}`);
     return;
   }
-  win.webContents.downloadURL(url);
+  // Native downloads bypass the renderer's fetch client, so the Bearer token
+  // the API requires is never attached — the request 401s and the save dialog
+  // never appears (self-hosted PAT/JWT auth). Re-attach it here. The caller
+  // (use-download-attachment) only supplies `authorization` for a same-origin
+  // API URL, never for an off-origin CloudFront/S3 presigned download_url, so
+  // the token cannot leak to a foreign host.
+  win.webContents.downloadURL(
+    url,
+    authorization ? { headers: { Authorization: authorization } } : undefined,
+  );
 }
 
 function getHttpProtocol(url: string): "http:" | "https:" | null {

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -690,14 +690,17 @@ if (!gotTheLock) {
       return { ok: true } as const;
     });
 
-    ipcMain.handle("file:download-url", (event, url: string) => {
-      const sourceWindow = BrowserWindow.fromWebContents(event.sender);
-      if (!sourceWindow) {
-        console.warn("[download] ignored file:download-url — source window torn down");
-        return;
-      }
-      downloadURLSafely(sourceWindow, url);
-    });
+    ipcMain.handle(
+      "file:download-url",
+      (event, url: string, authorization?: string) => {
+        const sourceWindow = BrowserWindow.fromWebContents(event.sender);
+        if (!sourceWindow) {
+          console.warn("[download] ignored file:download-url — source window torn down");
+          return;
+        }
+        downloadURLSafely(sourceWindow, url, authorization);
+      },
+    );
 
     // Sync IPC: app version + normalized OS for preload. Sync (not invoke) so
     // preload can attach the values to `desktopAPI.appInfo` before any renderer

--- a/apps/desktop/src/preload/index.d.ts
+++ b/apps/desktop/src/preload/index.d.ts
@@ -44,7 +44,7 @@ interface DesktopAPI {
   openExternal: (url: string) => Promise<void>;
   /** Download a file by URL through Electron's native download system.
    *  Shows a native save dialog. On non-desktop platforms this is undefined. */
-  downloadURL: (url: string) => Promise<void>;
+  downloadURL: (url: string, authorization?: string) => Promise<void>;
   /** Hide macOS traffic lights for full-screen modals; restore when false. */
   setImmersiveMode: (immersive: boolean) => Promise<void>;
   /** Show a native OS notification for a new inbox item. */

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -146,7 +146,8 @@ const desktopAPI = {
    *  Shows a save dialog and saves to disk. Unlike openExternal, this
    *  avoids browser rendering of HTML files on Linux.
    *  On non-desktop platforms this property is undefined. */
-  downloadURL: (url: string) => ipcRenderer.invoke("file:download-url", url),
+  downloadURL: (url: string, authorization?: string) =>
+    ipcRenderer.invoke("file:download-url", url, authorization),
   /** Toggle immersive mode — hide macOS traffic lights for full-screen modals */
   setImmersiveMode: (immersive: boolean) =>
     ipcRenderer.invoke("window:setImmersive", immersive),

--- a/packages/core/api/client.ts
+++ b/packages/core/api/client.ts
@@ -379,6 +379,15 @@ export class ApiClient {
     this.token = token;
   }
 
+  // Authorization header value ("Bearer <token>") for requests that bypass
+  // the fetch-based client — notably Electron's native
+  // `webContents.downloadURL`, which cannot see the in-memory token. Returns
+  // null when unauthenticated. Callers MUST only hand this to same-origin API
+  // URLs (never an off-origin CloudFront/S3 presigned download_url).
+  getAuthorizationHeader(): string | null {
+    return this.token ? `Bearer ${this.token}` : null;
+  }
+
   private readCsrfToken(): string | null {
     if (typeof document === "undefined") return null;
     const match = document.cookie

--- a/packages/views/editor/use-download-attachment.ts
+++ b/packages/views/editor/use-download-attachment.ts
@@ -8,7 +8,7 @@ import { resolvePublicFileUrl } from "@multica/core/workspace/avatar-url";
 import { useT } from "../i18n";
 
 interface DesktopBridge {
-  downloadURL?: (u: string) => Promise<void> | void;
+  downloadURL?: (u: string, authorization?: string) => Promise<void> | void;
 }
 
 function attachmentDownloadEndpoint(
@@ -93,7 +93,22 @@ export function useDownloadAttachment(): (attachmentId: string) => Promise<void>
           const bridge = (
             window as unknown as { desktopAPI?: DesktopBridge }
           ).desktopAPI;
-          await bridge!.downloadURL!(downloadUrl);
+          // Hand the API bearer token to the native downloader ONLY when the
+          // resolved URL is our own API origin. Electron's downloadURL runs
+          // outside the fetch client, so without this the request is
+          // unauthenticated and 401s silently (no save dialog). In
+          // CloudFront/S3 presign mode `download_url` is an off-origin signed
+          // CDN URL that already carries its own auth and must NOT receive our
+          // Authorization header.
+          let authorization: string | undefined;
+          try {
+            if (new URL(downloadUrl).origin === new URL(api.getBaseUrl()).origin) {
+              authorization = api.getAuthorizationHeader() ?? undefined;
+            }
+          } catch {
+            authorization = undefined;
+          }
+          await bridge!.downloadURL!(downloadUrl, authorization);
         } catch {
           failed();
         }


### PR DESCRIPTION
## Problem

On a self-hosted instance where the desktop app authenticates with a PAT (`Authorization: Bearer` header, no `multica_auth` cookie in the Electron session), clicking **download** on an attachment lets you pick a folder and filename in the native save dialog, but **after you click Save no file is written**.

### Root cause

`useDownloadAttachment` desktop path calls `desktopAPI.downloadURL()` -> `webContents.downloadURL()`, which runs **outside** the fetch client and carries neither the bearer header nor a `multica_auth` cookie. `webContents.downloadURL` forces download intent, so `will-download` fires and the save dialog appears normally — but the underlying `GET /api/attachments/{id}/download` responds `401 missing authorization`, so the download item goes straight to `interrupted` and nothing is written to the chosen path. The JS side already resolved after handing the URL to the bridge, so no error toast shows either. On cookie-authed web it works; on PAT-authed desktop the save silently no-ops.

Verified against v0.4.8: `curl` on the endpoint returns `401` without auth and `200` + `Content-Disposition: attachment` + the file bytes with `Authorization: Bearer <PAT>`.

## Fix

Pass the API bearer token from the renderer through the `downloadURL` bridge and attach it as an `Authorization` header in `downloadURLSafely`.

Security: the token is attached **only when the resolved URL is same-origin as the API base**. In CloudFront/S3 presign mode `download_url` is an off-origin signed CDN URL that already carries its own auth and must **not** receive our `Authorization` header — the renderer skips the header in that case, and the same-origin decision is made against `api.getBaseUrl()`.

## Changes
- `packages/core/api/client.ts` — public `getAuthorizationHeader()` for callers that bypass the fetch client.
- `packages/views/editor/use-download-attachment.ts` — desktop branch passes the header, same-origin-gated.
- `apps/desktop/src/preload/index.ts` / `index.d.ts` — `downloadURL(url, authorization?)`.
- `apps/desktop/src/main/index.ts` — IPC handler forwards `authorization`.
- `apps/desktop/src/main/external-url.ts` — `downloadURLSafely` attaches the header.

Manually verified end-to-end on macOS (v0.4.8, Electron 39): with the header attached the file now writes to the chosen location via the native save dialog.

🤖 Generated with [Claude Code](https://claude.com/claude-code)