### PR TITLE
fix(inbox): simplify agent working status

### DIFF
--- a/packages/views/inbox/components/inbox-list-item.test.tsx
+++ b/packages/views/inbox/components/inbox-list-item.test.tsx
@@ -5,8 +5,18 @@ import { InboxListItem } from "./inbox-list-item";
 
 vi.mock("../../issues/components", () => ({ StatusIcon: () => null }));
 vi.mock("../../issues/components/issue-agent-activity-indicator", () => ({
-  IssueAgentActivityIndicator: ({ issueId }: { issueId: string }) => (
-    <span data-testid="issue-agent-activity" data-issue-id={issueId} />
+  IssueAgentActivityIndicator: ({
+    issueId,
+    variant,
+  }: {
+    issueId: string;
+    variant?: string;
+  }) => (
+    <span
+      data-testid="issue-agent-activity"
+      data-issue-id={issueId}
+      data-variant={variant}
+    />
   ),
 }));
 vi.mock("../../common/actor-avatar", () => ({
@@ -105,6 +115,12 @@ describe("InboxListItem issue activity", () => {
     expect(
       getByTestId("issue-agent-activity").getAttribute("data-issue-id"),
     ).toBe("issue-1");
+    expect(
+      getByTestId("issue-agent-activity").getAttribute("data-variant"),
+    ).toBe("status");
+    expect(
+      getByTestId("issue-agent-activity").parentElement?.className,
+    ).toContain("grid-cols-[minmax(0,1fr)_auto_auto]");
   });
 
   it("omits issue activity for a notification without an issue", () => {

--- a/packages/views/inbox/components/inbox-list-item.tsx
+++ b/packages/views/inbox/components/inbox-list-item.tsx
@@ -109,18 +109,19 @@ export function InboxListItem({
             )}
           </div>
         </div>
-        <div className="mt-0.5 flex items-center justify-between gap-2">
+        <div className="mt-0.5 grid grid-cols-[minmax(0,1fr)_auto_auto] items-center gap-x-2">
           <p className={`min-w-0 overflow-hidden text-ellipsis whitespace-nowrap text-xs ${showUnread ? "text-muted-foreground" : "text-muted-foreground/60"}`}>
             <InboxDetailLabel item={item} />
           </p>
-          <div className="flex shrink-0 items-center gap-1.5">
-            {item.issue_id && (
-              <IssueAgentActivityIndicator issueId={item.issue_id} />
-            )}
-            <span className={`text-xs ${showUnread ? "text-muted-foreground" : "text-muted-foreground/60"}`}>
-              {timeAgo(item.created_at)}
-            </span>
-          </div>
+          {item.issue_id && (
+            <IssueAgentActivityIndicator
+              issueId={item.issue_id}
+              variant="status"
+            />
+          )}
+          <span className={`shrink-0 text-xs tabular-nums ${showUnread ? "text-muted-foreground" : "text-muted-foreground/60"}`}>
+            {timeAgo(item.created_at)}
+          </span>
         </div>
       </div>
     </button>

--- a/packages/views/issues/components/issue-agent-activity-indicator.test.tsx
+++ b/packages/views/issues/components/issue-agent-activity-indicator.test.tsx
@@ -22,7 +22,13 @@ vi.mock("@tanstack/react-query", () => ({
 
 vi.mock("@multica/ui/components/ui/hover-card", () => ({
   HoverCard: ({ children }: { children: React.ReactNode }) => children,
-  HoverCardTrigger: ({ children }: { children: React.ReactNode }) => children,
+  HoverCardTrigger: ({
+    children,
+    render,
+  }: {
+    children: React.ReactNode;
+    render: React.ReactElement<{ className?: string }>;
+  }) => <span className={render.props.className}>{children}</span>,
   HoverCardContent: ({ children }: { children: React.ReactNode }) => children,
 }));
 
@@ -47,5 +53,21 @@ describe("IssueAgentActivityIndicator", () => {
     const label = screen.getByText("Working");
     expect(label.classList.contains("leading-4")).toBe(true);
     expect(label.classList.contains("leading-none")).toBe(false);
+  });
+
+  it("renders a quiet status token without an avatar or shimmer", () => {
+    render(
+      <IssueAgentActivityIndicator issueId="issue-1" variant="status" />,
+    );
+
+    const label = screen.getByText("Working");
+    const trigger = label.parentElement;
+    expect(trigger?.className).toContain("text-xs");
+    expect(trigger?.className).toContain("leading-4");
+    expect(trigger?.querySelector('[aria-hidden="true"]')?.className).toContain(
+      "bg-brand",
+    );
+    expect(label.className).not.toContain("animate-chat-text-shimmer");
+    expect(screen.queryByTestId("agent-avatar")).toBeNull();
   });
 });

--- a/packages/views/issues/components/issue-agent-activity-indicator.test.tsx
+++ b/packages/views/issues/components/issue-agent-activity-indicator.test.tsx
@@ -1,0 +1,51 @@
+// @vitest-environment jsdom
+
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("@multica/core/hooks", () => ({
+  useWorkspaceId: () => "workspace-1",
+}));
+
+vi.mock("@multica/core/agents", () => ({
+  agentTaskSnapshotOptions: () => ({}),
+}));
+
+vi.mock("@tanstack/react-query", () => ({
+  useQuery: () => ({
+    data: {
+      running: [{ agent_id: "agent-1" }],
+      queued: [],
+    },
+  }),
+}));
+
+vi.mock("@multica/ui/components/ui/hover-card", () => ({
+  HoverCard: ({ children }: { children: React.ReactNode }) => children,
+  HoverCardTrigger: ({ children }: { children: React.ReactNode }) => children,
+  HoverCardContent: ({ children }: { children: React.ReactNode }) => children,
+}));
+
+vi.mock("../../agents/components/agent-avatar-stack", () => ({
+  AgentAvatarStack: () => <span data-testid="agent-avatar" />,
+}));
+
+vi.mock("../../agents/components/agent-activity-hover-content", () => ({
+  AgentActivityHoverContent: () => null,
+}));
+
+vi.mock("../../i18n", () => ({
+  useT: () => ({ t: () => "Working" }),
+}));
+
+import { IssueAgentActivityIndicator } from "./issue-agent-activity-indicator";
+
+describe("IssueAgentActivityIndicator", () => {
+  it("gives the shimmer enough line height to paint descenders", () => {
+    render(<IssueAgentActivityIndicator issueId="issue-1" />);
+
+    const label = screen.getByText("Working");
+    expect(label.classList.contains("leading-4")).toBe(true);
+    expect(label.classList.contains("leading-none")).toBe(false);
+  });
+});

--- a/packages/views/issues/components/issue-agent-activity-indicator.tsx
+++ b/packages/views/issues/components/issue-agent-activity-indicator.tsx
@@ -25,6 +25,10 @@ interface IssueAgentActivityIndicatorProps {
   // primary control. Default xs (16 px) reads as a dot at typical board
   // densities while still showing the agent's face on hover-zoom.
   size?: AvatarSize;
+  // Dense metadata rows such as Inbox already have a primary actor avatar.
+  // Use a quiet status token there instead of repeating agent identity and
+  // running a continuous shimmer beside every timestamp.
+  variant?: "avatars" | "status";
 }
 
 /**
@@ -32,8 +36,8 @@ interface IssueAgentActivityIndicatorProps {
  * in the top-right of board cards and right after the identifier in list
  * rows. Derives state from the workspace-wide agent task snapshot:
  *
- *   - has ≥1 running task  → tiny avatar stack + shimmering "Working"
- *   - 0 running, ≥1 queued → half-opacity stack + muted "Queued"
+ *   - has ≥1 running task  → "Working" presentation for the selected variant
+ *   - 0 running, ≥1 queued → muted "Queued" presentation
  *   - nothing               → return null (no chrome, no placeholder)
  *
  * The shimmer reuses chat's `animate-chat-text-shimmer` utility (defined
@@ -42,6 +46,12 @@ interface IssueAgentActivityIndicatorProps {
  * dense board. Moving the "alive" signal onto the label keeps the
  * avatars themselves still and lets the cue ride a piece of text the
  * user can already read.
+ *
+ * Inbox uses the `status` variant: a static semantic dot plus a regular
+ * 12 px label. Its primary avatar already identifies the notification actor,
+ * so another tiny face is visually ambiguous; removing the perpetual shimmer
+ * also keeps a frequently scanned list calm. The hover card still exposes the
+ * exact agents and tasks on demand.
  *
  * Hover opens AgentActivityHoverContent which lists every active task
  * with status dot + duration. No link rows — the card itself is the
@@ -59,6 +69,7 @@ interface IssueAgentActivityIndicatorProps {
 export const IssueAgentActivityIndicator = memo(function IssueAgentActivityIndicator({
   issueId,
   size = "xs",
+  variant = "avatars",
 }: IssueAgentActivityIndicatorProps) {
   const { t } = useT("issues");
   const wsId = useWorkspaceId();
@@ -86,32 +97,54 @@ export const IssueAgentActivityIndicator = memo(function IssueAgentActivityIndic
   if (agentIds.length === 0) return null;
   const hoverTasks = [...groups.running, ...groups.queued];
   const isRunning = opacity === "full";
+  const label = isRunning
+    ? t(($) => $.agent_activity.status_running)
+    : t(($) => $.agent_activity.status_queued);
+  const isStatusVariant = variant === "status";
 
   return (
     <HoverCard>
       <HoverCardTrigger
         render={
-          <span className="inline-flex shrink-0 items-center gap-1" />
+          <span
+            className={cn(
+              "inline-flex shrink-0 items-center gap-1",
+              isStatusVariant && "text-xs leading-4 text-muted-foreground",
+            )}
+          />
         }
       >
-        <AgentAvatarStack
-          agentIds={agentIds}
-          size={size}
-          opacity={opacity}
-          max={3}
-        />
-        <span
-          className={cn(
-            "text-[10px] leading-4",
-            isRunning
-              ? "animate-chat-text-shimmer"
-              : "text-muted-foreground",
-          )}
-        >
-          {isRunning
-            ? t(($) => $.agent_activity.status_running)
-            : t(($) => $.agent_activity.status_queued)}
-        </span>
+        {isStatusVariant ? (
+          <>
+            <span
+              aria-hidden="true"
+              className={cn(
+                "size-1.5 shrink-0 rounded-full",
+                isRunning ? "bg-brand" : "bg-muted-foreground/50",
+              )}
+            />
+            <span>{label}</span>
+          </>
+        ) : (
+          <>
+            <AgentAvatarStack
+              agentIds={agentIds}
+              size={size}
+              opacity={opacity}
+              max={3}
+            />
+            <span
+              className={cn(
+                "text-[10px] leading-4",
+                isRunning
+                  ? "animate-chat-text-shimmer"
+                  : "text-muted-foreground",
+              )}
+            >
+              {label}
+            </span>
+          </>
+        )}
       </HoverCardTrigger>
       <HoverCardContent align="end" className="w-72">
         <AgentActivityHoverContent tasks={hoverTasks} />

--- a/packages/views/issues/components/issue-agent-activity-indicator.tsx
+++ b/packages/views/issues/components/issue-agent-activity-indicator.tsx
@@ -102,7 +102,7 @@ export const IssueAgentActivityIndicator = memo(function IssueAgentActivityIndic
         />
         <span
           className={cn(
-            "text-[10px] leading-none",
+            "text-[10px] leading-4",
             isRunning
               ? "animate-chat-text-shimmer"
               : "text-muted-foreground",


### PR DESCRIPTION
## Summary

- replace Inbox's repeated mini agent avatar and continuous shimmer with a quiet, static activity token
- use a semantic brand dot plus a regular 12px `Working` or `Queued` label while preserving the detailed hover card
- align the Inbox detail, activity status, and timestamp in a stable three-column row
- keep the avatar presentation on Issue list and board surfaces, with enough line height to paint shimmer glyphs completely
- add regression coverage for both the Inbox variant and the default activity indicator

## Root cause and design rationale

The original Inbox row combined a primary notification actor avatar with another tiny active-agent avatar, a continuously shimmering label, and a timestamp. That repeated identity, introduced competing motion in a frequently scanned list, and made the second metadata row feel crowded.

The shimmer also used `text-[10px] leading-none`, making its background painting area only 10px tall. Parts of glyphs extending beyond that box—most visibly the `g` in “Working”—were left transparent and appeared clipped.

Inbox now uses a calmer status-only variant. Other Issue surfaces retain the richer agent-avatar presentation where identity is more useful.

## Impact

Inbox activity metadata is quieter, easier to scan, and consistently aligned without losing access to the active-agent details. The default shimmer presentation also renders complete glyphs.

## Validation

- `pnpm --filter @multica/views exec vitest run issues/components/issue-agent-activity-indicator.test.tsx inbox/components/inbox-list-item.test.tsx`
- `pnpm --filter @multica/views typecheck`
- `pnpm --filter @multica/views exec eslint issues/components/issue-agent-activity-indicator.tsx issues/components/issue-agent-activity-indicator.test.tsx inbox/components/inbox-list-item.tsx inbox/components/inbox-list-item.test.tsx`
