### PR TITLE
MUL-5182: fix clipped working label in inbox

### DIFF
--- a/packages/views/issues/components/issue-agent-activity-indicator.test.tsx
+++ b/packages/views/issues/components/issue-agent-activity-indicator.test.tsx
@@ -1,0 +1,97 @@
+// @vitest-environment jsdom
+
+import { cleanup, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { AgentTask } from "@multica/core/types";
+import { renderWithI18n } from "../../test/i18n";
+
+const mockState = vi.hoisted(() => ({
+  running: [] as AgentTask[],
+  queued: [] as AgentTask[],
+}));
+
+vi.mock("@multica/core/hooks", () => ({
+  useWorkspaceId: () => "ws-1",
+}));
+
+vi.mock("@multica/core/agents", () => ({
+  agentTaskSnapshotOptions: () => ({
+    queryKey: ["agents", "task-snapshot", "ws-1"],
+  }),
+}));
+
+vi.mock("@tanstack/react-query", async () => {
+  const actual =
+    await vi.importActual<typeof import("@tanstack/react-query")>(
+      "@tanstack/react-query",
+    );
+  return {
+    ...actual,
+    useQuery: () => ({
+      data: { running: mockState.running, queued: mockState.queued },
+    }),
+  };
+});
+
+vi.mock("@multica/ui/components/ui/hover-card", async () => {
+  const React = await vi.importActual<typeof import("react")>("react");
+  return {
+    HoverCard: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+    HoverCardTrigger: ({
+      render,
+      children,
+    }: {
+      render: React.ReactElement;
+      children: React.ReactNode;
+    }) => React.cloneElement(render, undefined, children),
+    HoverCardContent: ({ children }: { children: React.ReactNode }) => (
+      <div>{children}</div>
+    ),
+  };
+});
+
+vi.mock("../../agents/components/agent-avatar-stack", () => ({
+  AgentAvatarStack: () => <span data-testid="agent-avatar" />,
+}));
+
+vi.mock("../../agents/components/agent-activity-hover-content", () => ({
+  AgentActivityHoverContent: () => null,
+}));
+
+import { IssueAgentActivityIndicator } from "./issue-agent-activity-indicator";
+
+function makeTask(): AgentTask {
+  return {
+    id: "task-1",
+    agent_id: "agent-1",
+    runtime_id: "runtime-1",
+    issue_id: "issue-1",
+    status: "running",
+    priority: 0,
+    dispatched_at: null,
+    started_at: "2026-07-23T08:00:00Z",
+    completed_at: null,
+    result: null,
+    error: null,
+    created_at: "2026-07-23T08:00:00Z",
+  };
+}
+
+beforeEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+  mockState.running = [];
+  mockState.queued = [];
+});
+
+describe("IssueAgentActivityIndicator", () => {
+  it("leaves enough line height for descenders in the running label", () => {
+    mockState.running = [makeTask()];
+
+    renderWithI18n(<IssueAgentActivityIndicator issueId="issue-1" />);
+
+    const label = screen.getByText("Working");
+    expect(label).toHaveClass("leading-4");
+    expect(label).not.toHaveClass("leading-none");
+  });
+});

--- a/packages/views/issues/components/issue-agent-activity-indicator.tsx
+++ b/packages/views/issues/components/issue-agent-activity-indicator.tsx
@@ -102,7 +102,7 @@ export const IssueAgentActivityIndicator = memo(function IssueAgentActivityIndic
         />
         <span
           className={cn(
-            "text-[10px] leading-none",
+            "text-[10px] leading-4",
             isRunning
               ? "animate-chat-text-shimmer"
               : "text-muted-foreground",


### PR DESCRIPTION
## Summary

- give the compact issue-activity label a 1rem line box so English descenders render fully
- add a focused regression test for the running-state label

## Root cause

The 10px shimmering label used `leading-none`, so its gradient background only painted a 10px-high line box. The transparent text outside that painted area made the descender in “Working” appear clipped.

## Impact

Inbox, issue-list, and board activity indicators keep the same compact footprint while rendering full glyphs.

## Validation

- `pnpm --filter @multica/views exec vitest run issues/components/issue-agent-activity-indicator.test.tsx`
- `pnpm --filter @multica/views exec eslint issues/components/issue-agent-activity-indicator.tsx issues/components/issue-agent-activity-indicator.test.tsx`
- `pnpm --filter @multica/views typecheck`
- local Playwright Inbox before/after visual verification
- broader views suite: 2,857 tests passed; one unrelated existing failure remains in `layout/sidebar-resize.test.tsx`

Closes MUL-5182
