### PR TITLE
chore(ci): run test-go.sh self-test in Go test entry points (MUL-5169)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -169,6 +169,9 @@ jobs:
       - name: Run migrations
         run: cd server && go run ./cmd/migrate up
 
+      - name: Verify Go test wrapper
+        run: bash scripts/test-go.test.sh
+
       - name: Test
         run: bash scripts/test-go.sh --race
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,6 +51,9 @@ jobs:
           go-version-file: server/go.mod
           cache-dependency-path: server/go.sum
 
+      - name: Verify Go test wrapper
+        run: bash scripts/test-go.test.sh
+
       - name: Run tests
         run: bash scripts/test-go.sh --race
 

--- a/scripts/check.sh
+++ b/scripts/check.sh
@@ -95,6 +95,8 @@ pnpm test || { EXIT_CODE=1; exit 1; }
 # --------------------------------------------------------------------------
 echo ""
 echo "==> [3/5] Go tests..."
+echo "==> Verifying Go test wrapper..."
+bash scripts/test-go.test.sh || { EXIT_CODE=1; exit 1; }
 echo "==> Running database migrations..."
 (cd server && go run ./cmd/migrate up) || { EXIT_CODE=1; exit 1; }
 bash scripts/test-go.sh || { EXIT_CODE=1; exit 1; }


### PR DESCRIPTION
## What does this PR do?

#5789 added `scripts/test-go.test.sh`, a fast self-test that pins the exact `go test` invocations `scripts/test-go.sh` must produce (regular/pkg-agent package split, flags, and the reject-unknown-option path). It was only runnable manually, so a regression in `test-go.sh` — the wrapper every automated Go test entry point now routes through — would not be caught automatically; a change that, say, drops the pkg/agent parallelism cap or the agent-CLI guard wrapping would land green.

This PR runs that self-test in every entry point that depends on the wrapper, immediately before the wrapped test run. It completes in well under a second and needs no database or real Go toolchain (it PATH-shims `go`), so a broken harness fails fast with the exact unexpected `go test` invocations printed, instead of after (or without) the multi-minute suite.

Thinking path:

1. After #5789, Makefile, `scripts/check.sh`, CI, and release all route Go tests through `scripts/test-go.sh`, making the wrapper a single point of failure for backend test coverage.
2. Its self-test existed but only ran when someone remembered to run it — a silent-regression window on the exact file that guarantees test hermeticity.
3. Wire the self-test into the same jobs that consume the wrapper, right before the real test step, so the guarantee is enforced where it is relied upon.

Risk is limited to CI/scripts: three additive call sites, no change to what the test suite itself runs. The failure mode is a red "Verify Go test wrapper" step with a printed diff of the unexpected `go test` calls.

## Related Issue

Follow-up to #5789 (which closed #5788): wires the self-test added there into the automated entry points. No standalone GitHub issue; tracked internally as MUL-5169.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Refactor / code improvement (no behavior change)
- [ ] Documentation update
- [x] Tests (adding or improving test coverage)
- [x] CI / infrastructure

## Changes Made

- `.github/workflows/ci.yml` — backend job: add a "Verify Go test wrapper" step (`bash scripts/test-go.test.sh`) before the Test step.
- `.github/workflows/release.yml` — verify job: add the same step before "Run tests".
- `scripts/check.sh` — step 3 (Go tests): run the self-test before migrations and `scripts/test-go.sh`.

## How to Test

1. `bash scripts/test-go.test.sh` → prints `test-go.test.sh: PASS`.
2. Simulate a wrapper regression: change `-p 2 -parallel 2` in `scripts/test-go.sh` to any other value and re-run the self-test → exits 1 and prints the unexpected `go test` calls (verified locally). Revert the change.
3. Both workflow files parse as valid YAML and `bash -n scripts/check.sh` passes; the backend CI run on this PR exercises the new step for real.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] If this change affects the UI, I have included before/after screenshots
- [x] I have updated relevant documentation to reflect my changes
- [x] If I added a new runtime / coding tool / UI tab, I synced the change to **landing copy** (`apps/web/features/landing/i18n/`) and **relevant docs** (`apps/docs/content/docs/`)
- [x] If this PR touches Chinese product copy, I checked it against `apps/docs/content/docs/developers/conventions.zh.mdx` (terminology, mixed-rule for `task` / `issue` / `skill`)
- [x] I have considered and documented any risks above
- [x] I will address all reviewer comments before requesting merge

## AI Disclosure

**AI tool used:** Multica Agent (Fabel 5, Claude)

**Prompt / approach:** A post-merge review of #5789 flagged that `scripts/test-go.test.sh` was not wired into any automated entry point; the maintainer asked for a standalone PR to close that gap. The agent added the step to the three wrapper-consuming entry points, validated YAML/shell syntax, ran the self-test from the repo root, and verified end-to-end that an induced `test-go.sh` regression makes the new step fail with a clear diagnostic.

## Screenshots (optional)

Not applicable; there are no UI changes.
