### PR TITLE
MUL-5197: fix(runtime): do not wait for external CI by default

### DIFF
--- a/server/internal/daemon/execenv/execenv_test.go
+++ b/server/internal/daemon/execenv/execenv_test.go
@@ -929,13 +929,18 @@ func TestInjectRuntimeConfigBackgroundTaskSafetyProviderAgnostic(t *testing.T) {
 				// no follow-up wakeup. These pins forbid that shape.
 				"Never background-and-yield",
 				"foreground tool call that blocks",
-				"gh run watch",
+				"only to work owned by the current run",
+				"GitHub Actions after a successful push",
+				"Do not wait for them by default",
 				"running in the background so you can keep working",
 				"standing by",
 			} {
 				if !strings.Contains(s, want) {
 					t.Errorf("%s missing background task safety text %q\n---\n%s", tc.file, want, s)
 				}
+			}
+			if strings.Contains(s, "gh run watch") {
+				t.Errorf("%s should not suggest waiting for external GitHub CI\n---\n%s", tc.file, s)
 			}
 		})
 	}

--- a/server/internal/daemon/execenv/runtime_config_kind_test.go
+++ b/server/internal/daemon/execenv/runtime_config_kind_test.go
@@ -213,12 +213,17 @@ func TestBackgroundTaskSafetySlimHardPins(t *testing.T) {
 		"run the work synchronously instead",
 		"Never background-and-yield",
 		"foreground tool call that blocks",
-		"gh run watch",
+		"only to work owned by the current run",
+		"GitHub Actions after a successful push",
+		"Do not wait for them by default",
 		"running in the background so you can keep working",
 		"standing by",
 	} {
 		if !strings.Contains(out, want) {
 			t.Errorf("slim Background Task Safety missing hardened pin %q\n---\n%s", want, out)
 		}
+	}
+	if strings.Contains(out, "gh run watch") {
+		t.Errorf("slim Background Task Safety should not suggest waiting for external GitHub CI\n---\n%s", out)
 	}
 }

--- a/server/internal/daemon/execenv/runtime_config_sections.go
+++ b/server/internal/daemon/execenv/runtime_config_sections.go
@@ -47,12 +47,14 @@ func writeHeader(b *strings.Builder) {
 // tests assert:
 // "Do NOT end your turn while background tasks", "wait for a future
 // notification/reminder", "run the work synchronously instead", the
-// no-background-and-yield rule, and the no-"standing by" sign-off rule.
+// no-background-and-yield rule, the external-work boundary, and the
+// no-"standing by" sign-off rule.
 func writeBackgroundTaskSafetySlim(b *strings.Builder) {
 	b.WriteString("## Background Task Safety\n\n")
-	b.WriteString("Multica marks the task terminal the moment your top-level turn exits — any background work still running is orphaned, its result lost, and the final comment you meant to post after it never sends. There is no background-completion wakeup here.\n\n")
+	b.WriteString("Multica marks the task terminal the moment your top-level turn exits — any process, tool call, or subagent owned by this run that is still active is orphaned, its result lost, and the final comment you meant to post after it never sends. There is no background-completion wakeup here.\n\n")
 	b.WriteString("- Do NOT end your turn while background tasks, async subagents, background shell commands, or detached tool calls are still running. Never background-and-yield: never end a turn expecting a future notification or wakeup to resume — it will not arrive.\n")
-	b.WriteString("- Do every wait synchronously inside one foreground tool call that blocks to completion (e.g. `gh run watch`, a blocking test command); never split \"start the wait\" and \"collect the result\" across turns.\n")
+	b.WriteString("- This rule applies only to work owned by the current run. External systems triggered by a completed action — for example GitHub Actions after a successful push — are not agent-owned background tasks. Do not wait for them by default; report them as pending and finish the handoff unless the user or acceptance criteria explicitly requires their result.\n")
+	b.WriteString("- When a required result from run-owned work must be collected, wait synchronously inside one foreground tool call that blocks to completion (e.g. a blocking test or build command); never split \"start the wait\" and \"collect the result\" across turns.\n")
 	b.WriteString("- If a tool response says to wait for a future notification/reminder, or that it is running in the background so you can keep working, do not rely on that in Multica-managed runs — block on the appropriate wait / output / collect operation before exiting.\n")
 	b.WriteString("- If you can't observe a background task's result, run the work synchronously instead.\n")
 	b.WriteString("- Never end a turn with a \"standing by\" / \"I'll report back when X finishes\" message — that becomes your final output and the task ends.\n\n")


### PR DESCRIPTION
## Summary

- scope Background Task Safety to processes, tool calls, and subagents owned by the current run
- clarify that external systems such as GitHub Actions are not agent-owned background work
- tell agents to report external checks as pending unless the user or acceptance criteria explicitly requires the result
- remove `gh run watch` as the default synchronous-wait example and lock the boundary with provider-agnostic tests

## Root cause

The runtime brief used `gh run watch` as an example of work that must be collected synchronously. That could lead agents to treat CI triggered by a successful push as unfinished run-owned work and block the issue handoff until every check completed.

## Validation

- `go test ./internal/daemon/execenv` from `server/`
- `git diff --check`
