### PR TITLE
MUL-5184: prevent Inbox working label clipping

### DIFF
--- a/packages/views/issues/components/issue-agent-activity-indicator.test.tsx
+++ b/packages/views/issues/components/issue-agent-activity-indicator.test.tsx
@@ -1,0 +1,72 @@
+// @vitest-environment jsdom
+
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import type { AgentTask } from "@multica/core/types";
+
+const runningTask: AgentTask = {
+  id: "task-1",
+  agent_id: "agent-1",
+  runtime_id: "runtime-1",
+  issue_id: "issue-1",
+  status: "running",
+  priority: 0,
+  dispatched_at: null,
+  started_at: "2026-07-23T00:00:00Z",
+  completed_at: null,
+  result: null,
+  error: null,
+  created_at: "2026-07-23T00:00:00Z",
+};
+
+vi.mock("@multica/core/hooks", () => ({
+  useWorkspaceId: () => "workspace-1",
+}));
+
+vi.mock("@multica/core/agents", () => ({
+  agentTaskSnapshotOptions: () => ({ queryKey: ["agent-tasks"] }),
+}));
+
+vi.mock("@tanstack/react-query", () => ({
+  useQuery: ({
+    select,
+  }: {
+    select: (snapshot: AgentTask[]) => unknown;
+  }) => ({ data: select([runningTask]) }),
+}));
+
+vi.mock("@multica/ui/components/ui/hover-card", () => ({
+  HoverCard: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  HoverCardTrigger: ({ children }: { children: React.ReactNode }) => (
+    <span>{children}</span>
+  ),
+  HoverCardContent: ({ children }: { children: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
+}));
+
+vi.mock("../../agents/components/agent-avatar-stack", () => ({
+  AgentAvatarStack: () => <span data-testid="agent-avatar" />,
+}));
+
+vi.mock("../../agents/components/agent-activity-hover-content", () => ({
+  AgentActivityHoverContent: () => null,
+}));
+
+vi.mock("../../i18n", () => ({
+  useT: () => ({ t: () => "Working" }),
+}));
+
+import { IssueAgentActivityIndicator } from "./issue-agent-activity-indicator";
+
+describe("IssueAgentActivityIndicator", () => {
+  it("gives the shimmering label enough line height for descenders", () => {
+    render(<IssueAgentActivityIndicator issueId="issue-1" />);
+
+    expect(screen.getByText("Working")).toHaveClass(
+      "text-[10px]",
+      "leading-[12px]",
+      "animate-chat-text-shimmer",
+    );
+  });
+});

--- a/packages/views/issues/components/issue-agent-activity-indicator.tsx
+++ b/packages/views/issues/components/issue-agent-activity-indicator.tsx
@@ -102,7 +102,7 @@ export const IssueAgentActivityIndicator = memo(function IssueAgentActivityIndic
         />
         <span
           className={cn(
-            "text-[10px] leading-none",
+            "text-[10px] leading-[12px]",
             isRunning
               ? "animate-chat-text-shimmer"
               : "text-muted-foreground",


### PR DESCRIPTION
## Summary

- give the per-issue agent activity label a 12px line box so shimmer paint covers glyph ascenders and descenders
- add a focused regression test for the compact shimmering “Working” label

## Root cause

The label combined a 10px font with `leading-none`, producing a 10px paint box. Because the shimmer uses `background-clip: text` with transparent text fill, parts of glyphs extending beyond that box—including the descender in `g`—were not painted.

## Validation

- `pnpm --filter @multica/views typecheck`
- `pnpm --filter @multica/views exec eslint issues/components/issue-agent-activity-indicator.tsx issues/components/issue-agent-activity-indicator.test.tsx`
- `pnpm --filter @multica/views exec vitest run issues/components/issue-agent-activity-indicator.test.tsx inbox/components/inbox-list-item.test.tsx` (6 passed)
- Full `@multica/views` suite: 2,849 passed; one unrelated existing failure in `layout/sidebar-resize.test.tsx` (`Storage.prototype.setItem` spy observed 0 calls)

Closes MUL-5184
