### PR TITLE
MUL-5186: fix truncated g in agent Working status label

### DIFF
--- a/packages/views/issues/components/issue-agent-activity-indicator.tsx
+++ b/packages/views/issues/components/issue-agent-activity-indicator.tsx
@@ -102,7 +102,10 @@ export const IssueAgentActivityIndicator = memo(function IssueAgentActivityIndic
         />
         <span
           className={cn(
-            "text-[10px] leading-none",
+            // leading-none + background-clip:text (shimmer) clips descenders
+            // on "Working" / "Queued" (the g/y tails). leading-tight keeps the
+            // dense 10px cue but leaves room for the font metrics.
+            "text-[10px] leading-tight",
             isRunning
               ? "animate-chat-text-shimmer"
               : "text-muted-foreground",


### PR DESCRIPTION
## Summary
- The Inbox / issue list **Working** status cue (`IssueAgentActivityIndicator`) used `text-[10px] leading-none` together with `animate-chat-text-shimmer` (`background-clip: text`). That combination clipped glyph descenders, so the bottom of the **g** in "Working" (and **y** in "Queued") was cut off.
- Switched the label to `leading-tight` so descenders fit while keeping the compact 10px density.

## Test plan
- [ ] Open Inbox with at least one issue that has a running agent task
- [ ] Confirm the **Working** label shows a full, unclipped **g**
- [ ] Confirm **Queued** (if any) shows a full **y**
- [ ] Spot-check the same indicator on issue list rows and board cards

Closes MUL-5186