### PR TITLE
fix(inbox): drop the agent activity hover card from inbox rows (MUL-5189)

### DIFF
--- a/packages/views/inbox/components/inbox-list-item.test.tsx
+++ b/packages/views/inbox/components/inbox-list-item.test.tsx
@@ -5,8 +5,18 @@ import { InboxListItem } from "./inbox-list-item";
 
 vi.mock("../../issues/components", () => ({ StatusIcon: () => null }));
 vi.mock("../../issues/components/issue-agent-activity-indicator", () => ({
-  IssueAgentActivityIndicator: ({ issueId }: { issueId: string }) => (
-    <span data-testid="issue-agent-activity" data-issue-id={issueId} />
+  IssueAgentActivityIndicator: ({
+    issueId,
+    hoverCard,
+  }: {
+    issueId: string;
+    hoverCard?: boolean;
+  }) => (
+    <span
+      data-testid="issue-agent-activity"
+      data-issue-id={issueId}
+      data-hover-card={hoverCard === false ? "false" : "true"}
+    />
   ),
 }));
 vi.mock("../../common/actor-avatar", () => ({
@@ -105,6 +115,17 @@ describe("InboxListItem issue activity", () => {
     expect(
       getByTestId("issue-agent-activity").getAttribute("data-issue-id"),
     ).toBe("issue-1");
+  });
+
+  it("shows the activity badge without its hover card", () => {
+    // Triage rows only need "an agent is on this". The card behind the badge
+    // adds elapsed time, which does not change whether you open the row, and
+    // the row already carries the actor hover card on the left.
+    const { getByTestId } = renderRow({ item: item(), view: "inbox" });
+
+    expect(
+      getByTestId("issue-agent-activity").getAttribute("data-hover-card"),
+    ).toBe("false");
   });
 
   it("omits issue activity for a notification without an issue", () => {

--- a/packages/views/inbox/components/inbox-list-item.tsx
+++ b/packages/views/inbox/components/inbox-list-item.tsx
@@ -114,8 +114,16 @@ export function InboxListItem({
             <InboxDetailLabel item={item} />
           </p>
           <div className="flex shrink-0 items-center gap-1.5">
+            {/* Badge only, no hover card (MUL-5189). "An agent is on this"
+                is worth showing while triaging; the card behind it adds only
+                elapsed time, which does not change whether you open the row.
+                The row already carries the ActorAvatar hover card on the
+                left, so a second popup here was mostly noise. */}
             {item.issue_id && (
-              <IssueAgentActivityIndicator issueId={item.issue_id} />
+              <IssueAgentActivityIndicator
+                issueId={item.issue_id}
+                hoverCard={false}
+              />
             )}
             <span className={`text-xs ${showUnread ? "text-muted-foreground" : "text-muted-foreground/60"}`}>
               {timeAgo(item.created_at)}

--- a/packages/views/issues/components/issue-agent-activity-indicator.test.tsx
+++ b/packages/views/issues/components/issue-agent-activity-indicator.test.tsx
@@ -1,0 +1,144 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { AgentTask } from "@multica/core/types";
+
+const mockState = vi.hoisted(() => ({
+  snapshot: [] as unknown[],
+}));
+
+vi.mock("@multica/core/hooks", () => ({
+  useWorkspaceId: () => "ws-1",
+}));
+
+vi.mock("@multica/core/agents", () => ({
+  agentTaskSnapshotOptions: (wsId: string) => ({
+    queryKey: ["agents", "task-snapshot", wsId],
+  }),
+}));
+
+vi.mock("../../agents/components/agent-avatar-stack", () => ({
+  AgentAvatarStack: ({ agentIds }: { agentIds: string[] }) => (
+    <div data-testid="agent-avatar-stack">{agentIds.length}</div>
+  ),
+}));
+
+vi.mock("../../agents/components/agent-activity-hover-content", () => ({
+  AgentActivityHoverContent: () => <div data-testid="activity-hover" />,
+}));
+
+vi.mock("../../i18n", () => ({
+  useT: () => ({ t: () => "Working" }),
+}));
+
+// The hover card only portals its content once open, so absence of the body
+// cannot distinguish "closed" from "not wired up". Mock the primitive instead
+// and assert on the wrapper itself.
+vi.mock("@multica/ui/components/ui/hover-card", () => ({
+  HoverCard: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="hover-card">{children}</div>
+  ),
+  HoverCardTrigger: ({
+    children,
+    delay,
+    closeDelay,
+  }: {
+    children: React.ReactNode;
+    delay?: number;
+    closeDelay?: number;
+  }) => (
+    <span
+      data-testid="hover-card-trigger"
+      data-delay={String(delay)}
+      data-close-delay={String(closeDelay)}
+    >
+      {children}
+    </span>
+  ),
+  HoverCardContent: ({ children }: { children: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
+}));
+
+vi.mock("@tanstack/react-query", async () => {
+  const actual =
+    await vi.importActual<typeof import("@tanstack/react-query")>(
+      "@tanstack/react-query",
+    );
+  return {
+    ...actual,
+    useQuery: (opts: {
+      queryKey?: readonly unknown[];
+      select?: (data: unknown) => unknown;
+    }) => {
+      if (opts.queryKey?.[1] === "task-snapshot") {
+        return {
+          data: opts.select
+            ? opts.select(mockState.snapshot)
+            : mockState.snapshot,
+        };
+      }
+      return { data: undefined };
+    },
+  };
+});
+
+import { IssueAgentActivityIndicator } from "./issue-agent-activity-indicator";
+
+function makeTask(overrides: Partial<AgentTask> = {}): AgentTask {
+  return {
+    id: "task-1",
+    agent_id: "agent-1",
+    runtime_id: "runtime-1",
+    issue_id: "issue-1",
+    status: "running",
+    priority: 0,
+    dispatched_at: null,
+    started_at: "2026-06-08T08:00:00Z",
+    completed_at: null,
+    result: null,
+    error: null,
+    created_at: "2026-06-08T08:00:00Z",
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  cleanup();
+  mockState.snapshot = [makeTask()];
+});
+
+describe("IssueAgentActivityIndicator", () => {
+  it("wraps the badge in a hover card by default", () => {
+    render(<IssueAgentActivityIndicator issueId="issue-1" />);
+
+    expect(screen.getByTestId("hover-card")).not.toBeNull();
+    expect(screen.getByTestId("agent-avatar-stack")).not.toBeNull();
+  });
+
+  it("opens the card on a deliberate dwell, not on pointer travel", () => {
+    render(<IssueAgentActivityIndicator issueId="issue-1" />);
+
+    const trigger = screen.getByTestId("hover-card-trigger");
+    expect(Number(trigger.getAttribute("data-delay"))).toBeGreaterThan(600);
+    expect(Number(trigger.getAttribute("data-close-delay"))).toBeLessThan(300);
+  });
+
+  it("renders the badge without a hover card when hoverCard is false", () => {
+    render(<IssueAgentActivityIndicator issueId="issue-1" hoverCard={false} />);
+
+    expect(screen.queryByTestId("hover-card")).toBeNull();
+    expect(screen.queryByTestId("hover-card-trigger")).toBeNull();
+    // The cue itself survives — only the popup behind it is dropped.
+    expect(screen.getByTestId("agent-avatar-stack")).not.toBeNull();
+    expect(screen.getByText("Working")).not.toBeNull();
+  });
+
+  it("renders nothing when no agent is on the issue", () => {
+    mockState.snapshot = [];
+    const { container } = render(
+      <IssueAgentActivityIndicator issueId="issue-1" hoverCard={false} />,
+    );
+
+    expect(container.firstChild).toBeNull();
+  });
+});

--- a/packages/views/issues/components/issue-agent-activity-indicator.tsx
+++ b/packages/views/issues/components/issue-agent-activity-indicator.tsx
@@ -19,6 +19,25 @@ import { useT } from "../../i18n";
 
 const EMPTY_GROUPS: IssueTaskGroups = { running: [], queued: [] };
 
+// Dwell threshold before the activity card opens (MUL-5189).
+//
+// This badge is a passive cue riding on the right edge of dense scrolling
+// lists (inbox rows, issue rows, board cards), and it appears on every issue
+// an agent currently touches. Base UI's 600ms default is tuned for a hover
+// target the user aims at; here the pointer crosses the badge constantly on
+// its way to the row, the archive button, or the next row, so 600ms fires on
+// travel rather than on intent and a 288px card lands over the rows below.
+//
+// 900ms sits past casual travel but still inside a deliberate "what is it
+// doing?" pause. The header chip (issue-agent-header-chip) keeps its 150ms
+// on purpose: it is one large chip the user aims at, not a per-row cue.
+//
+// The card body is read-only — no links, no buttons — so there is no hover
+// bridge to protect and the close delay only needs to absorb pointer wobble
+// across the 4px gap.
+const OPEN_DELAY_MS = 900;
+const CLOSE_DELAY_MS = 150;
+
 interface IssueAgentActivityIndicatorProps {
   issueId: string;
   // Avatar tier. Kept very small — this is a corner-of-card cue, not a
@@ -90,6 +109,8 @@ export const IssueAgentActivityIndicator = memo(function IssueAgentActivityIndic
   return (
     <HoverCard>
       <HoverCardTrigger
+        delay={OPEN_DELAY_MS}
+        closeDelay={CLOSE_DELAY_MS}
         render={
           <span className="inline-flex shrink-0 items-center gap-1" />
         }

--- a/packages/views/issues/components/issue-agent-activity-indicator.tsx
+++ b/packages/views/issues/components/issue-agent-activity-indicator.tsx
@@ -44,6 +44,9 @@ interface IssueAgentActivityIndicatorProps {
   // primary control. Default xs (16 px) reads as a dot at typical board
   // densities while still showing the agent's face on hover-zoom.
   size?: AvatarSize;
+  // Whether hovering opens the activity card. Opt OUT where the card's only
+  // incremental information is not worth a popup (Inbox — see below).
+  hoverCard?: boolean;
 }
 
 /**
@@ -66,6 +69,14 @@ interface IssueAgentActivityIndicatorProps {
  * with status dot + duration. No link rows — the card itself is the
  * navigation target for issue detail.
  *
+ * Surfaces that only need the cue can pass `hoverCard={false}` and get the
+ * badge alone. Inbox does (MUL-5189): the badge already shows who is running
+ * and whether they are working or queued, so on a triage surface the card's
+ * only incremental fact is elapsed time — which never changes the one
+ * decision an inbox row exists to support ("do I open this?"). Issue lists
+ * and board cards keep it: monitoring work in flight is what those views are
+ * for, and elapsed time is load-bearing there.
+ *
  * Subscribes to the one shared workspace snapshot query but narrows it to
  * this issue's tasks with a `select`. React Query's structural sharing keeps
  * that selected value referentially stable when this issue's tasks are
@@ -78,6 +89,7 @@ interface IssueAgentActivityIndicatorProps {
 export const IssueAgentActivityIndicator = memo(function IssueAgentActivityIndicator({
   issueId,
   size = "xs",
+  hoverCard = true,
 }: IssueAgentActivityIndicatorProps) {
   const { t } = useT("issues");
   const wsId = useWorkspaceId();
@@ -103,8 +115,38 @@ export const IssueAgentActivityIndicator = memo(function IssueAgentActivityIndic
   }, [groups]);
 
   if (agentIds.length === 0) return null;
-  const hoverTasks = [...groups.running, ...groups.queued];
   const isRunning = opacity === "full";
+
+  const badge = (
+    <>
+      <AgentAvatarStack
+        agentIds={agentIds}
+        size={size}
+        opacity={opacity}
+        max={3}
+      />
+      <span
+        className={cn(
+          "text-[10px] leading-none",
+          isRunning
+            ? "animate-chat-text-shimmer"
+            : "text-muted-foreground",
+        )}
+      >
+        {isRunning
+          ? t(($) => $.agent_activity.status_running)
+          : t(($) => $.agent_activity.status_queued)}
+      </span>
+    </>
+  );
+
+  if (!hoverCard) {
+    return (
+      <span className="inline-flex shrink-0 items-center gap-1">{badge}</span>
+    );
+  }
+
+  const hoverTasks = [...groups.running, ...groups.queued];
 
   return (
     <HoverCard>
@@ -115,24 +157,7 @@ export const IssueAgentActivityIndicator = memo(function IssueAgentActivityIndic
           <span className="inline-flex shrink-0 items-center gap-1" />
         }
       >
-        <AgentAvatarStack
-          agentIds={agentIds}
-          size={size}
-          opacity={opacity}
-          max={3}
-        />
-        <span
-          className={cn(
-            "text-[10px] leading-none",
-            isRunning
-              ? "animate-chat-text-shimmer"
-              : "text-muted-foreground",
-          )}
-        >
-          {isRunning
-            ? t(($) => $.agent_activity.status_running)
-            : t(($) => $.agent_activity.status_queued)}
-        </span>
+        {badge}
       </HoverCardTrigger>
       <HoverCardContent align="end" className="w-72">
         <AgentActivityHoverContent tasks={hoverTasks} />


### PR DESCRIPTION
## Summary

Two commits on the Inbox agent activity badge (`IssueAgentActivityIndicator`).

**1. Raise the hover dwell delay (all surfaces).** The badge was opening its activity card on Base UI's default 600ms — a value no call site had ever set. 600ms is tuned for a hover target the user aims at, but this badge sits on the right edge of dense scrolling lists and appears on every issue an agent touches, so the pointer crosses it on the way to a row, the archive button, or the next item. Open delay → **900ms**, close delay → **150ms** (the card body is read-only, so there is no hover bridge to protect).

**2. Drop the hover card from Inbox rows entirely.** The badge already shows *who* is running and *whether* they are working or queued. On a triage surface the card's only incremental fact is elapsed time, which never changes the one decision an inbox row exists to support — do I open this? The row also carries the `ActorAvatar` hover card on the left, so a second popup was mostly noise.

The badge itself stays in the Inbox: "an agent is on this" is worth showing while triaging, and the component already returns `null` when there is no activity, so it costs no space when idle.

Issue lists and board cards keep the card — monitoring work in flight is what those views are for, and elapsed time is load-bearing there. They get the 900ms delay from commit 1. The issue-detail header chip keeps its deliberate 150ms: one large chip the user aims at, not a per-row cue.

## Changes

- `packages/views/issues/components/issue-agent-activity-indicator.tsx` — `delay` / `closeDelay` on `HoverCardTrigger`; new opt-out `hoverCard` prop (default `true`).
- `packages/views/inbox/components/inbox-list-item.tsx` — pass `hoverCard={false}`.
- `packages/views/issues/components/issue-agent-activity-indicator.test.tsx` — new: hover card present by default, dwell delay is past casual travel, badge renders without the card when opted out, still `null` with no activity.
- `packages/views/inbox/components/inbox-list-item.test.tsx` — assert the inbox row opts out.

## Verification

- `pnpm --filter @multica/views exec vitest run inbox issues` — 460/460 pass (51 files).
- The two new behavioral tests were confirmed non-vacuous: with the source changes stashed and the tests kept, they fail (2 failed / 8 passed).
- `pnpm --filter @multica/views exec tsc --noEmit` — clean.
- `pnpm --filter @multica/views lint` — 0 errors; the 16 warnings are pre-existing and in unrelated files.

MUL-5189
