### PR TITLE
MUL-5200: fix agents working count in issue table

### DIFF
--- a/packages/core/api/client.test.ts
+++ b/packages/core/api/client.test.ts
@@ -105,6 +105,51 @@ describe("ApiClient server Table query", () => {
     });
   });
 
+  it("round-trips the bounded working-agent facet contract", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          query_fingerprint: "sha256:working-agents",
+          total: 0,
+          facets: [
+            {
+              kind: "working_agent",
+              values: [{ key: "agent-1", count: 2 }],
+            },
+          ],
+        }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      ),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const client = new ApiClient("https://api.example.test");
+    await expect(
+      client.listIssueTableFacets({
+        query: {
+          scope: { kind: "workspace" },
+          filters: {
+            working_only: true,
+            working_agent_ids: ["agent-1", "agent-2"],
+          },
+          sort: { field: "position", direction: "asc" },
+        },
+        facets: [{ kind: "working_agent" }],
+        include_total: false,
+      }),
+    ).resolves.toMatchObject({
+      facets: [
+        {
+          kind: "working_agent",
+          values: [{ key: "agent-1", count: 2 }],
+        },
+      ],
+    });
+    expect(fetchMock.mock.calls[0]?.[1]?.body).toContain(
+      '"working_agent_ids":["agent-1","agent-2"]',
+    );
+  });
+
   it("falls back safely when Table responses are malformed", async () => {
     const fetchMock = vi.fn().mockImplementation(() =>
       Promise.resolve(

--- a/packages/core/api/schemas.ts
+++ b/packages/core/api/schemas.ts
@@ -644,7 +644,16 @@ const IssueTableFacetValueSchema = z.object({
 }).loose();
 
 const IssueTableFacetSchema = z.object({
-  kind: z.enum(["status", "priority", "assignee", "creator", "project", "label", "property"]),
+  kind: z.enum([
+    "status",
+    "priority",
+    "assignee",
+    "creator",
+    "project",
+    "label",
+    "working_agent",
+    "property",
+  ]),
   property_id: z.string().optional(),
   values: z.array(IssueTableFacetValueSchema).default([]),
 }).loose();

--- a/packages/core/types/api.ts
+++ b/packages/core/types/api.ts
@@ -245,6 +245,9 @@ export interface IssueTableFilters {
     end: string;
   };
   working_only?: boolean;
+  /** Visible agents whose running issue tasks define the activity window.
+   * Omitted keeps the legacy any-running-agent behavior; [] matches none. */
+  working_agent_ids?: string[];
   include_sub_issues?: boolean;
 }
 
@@ -347,6 +350,7 @@ export type IssueTableFacetSpec =
   | { kind: "creator" }
   | { kind: "project" }
   | { kind: "label" }
+  | { kind: "working_agent" }
   | { kind: "property"; property_id: string };
 
 export interface IssueTableFacetsRequest {

--- a/packages/views/issues/components/issues-header.tsx
+++ b/packages/views/issues/components/issues-header.tsx
@@ -795,6 +795,7 @@ export function ViewRefreshIndicator({ active }: { active: boolean }) {
 export function IssuesHeader({
   scopedIssues,
   workingIssues,
+  workingAgentIds,
   allowGantt = false,
   dateFilter = null,
   onDateFilterChange,
@@ -804,10 +805,12 @@ export function IssuesHeader({
   onTableFacetChange,
 }: {
   scopedIssues: Issue[];
-  /** The rows the agents-working filter would leave on screen — undefined
-   *  when the set is unknown (chip renders indeterminate). Scopes the chip:
-   *  it counts the agents working on these rows. */
+  /** The rows the agents-working filter would leave on screen. Undefined for
+   *  server-backed Table, where workingAgentIds supplies the exact scope. */
   workingIssues: Issue[] | undefined;
+  /** Exact server-backed Table activity scope. Undefined outside Table or
+   * while its bounded facet is unresolved. */
+  workingAgentIds?: string[];
   allowGantt?: boolean;
   dateFilter?: IssueDateFilter | null;
   onDateFilterChange?: (filter: IssueDateFilter | null) => void;
@@ -903,6 +906,7 @@ export function IssuesHeader({
             value={agentRunningFilter}
             onToggle={toggleAgentRunningFilter}
             workingIssues={workingIssues}
+            workingAgentIds={workingAgentIds}
           />
           <IssueDisplayControls
             scopedIssues={scopedIssues}

--- a/packages/views/issues/components/issues-page.tsx
+++ b/packages/views/issues/components/issues-page.tsx
@@ -16,6 +16,7 @@ import { IssuesHeader } from "./issues-header";
 function IssuesSurfaceHeader({
   issues,
   workingIssues,
+  workingAgentIds,
   isRefreshing,
   facetCountsExact,
   tableFacetCounts,
@@ -23,6 +24,7 @@ function IssuesSurfaceHeader({
 }: {
   issues: Issue[];
   workingIssues: Issue[] | undefined;
+  workingAgentIds?: string[];
   isRefreshing: boolean;
   facetCountsExact: boolean;
   tableFacetCounts?: IssueTableFacetsResponse;
@@ -35,6 +37,7 @@ function IssuesSurfaceHeader({
     <IssuesHeader
       scopedIssues={issues}
       workingIssues={workingIssues}
+      workingAgentIds={workingAgentIds}
       dateFilter={dateFilter}
       onDateFilterChange={setDateFilter}
       isRefreshing={isRefreshing}
@@ -60,10 +63,11 @@ export function IssuesPage() {
         scope={{ type: "workspace", actorKind: scope }}
         modes={["board", "list", "table", "swimlane"]}
         batchToolbar="list"
-        renderHeader={({ controller, workingIssues }) => (
+        renderHeader={({ controller, workingIssues, workingAgentIds }) => (
           <IssuesSurfaceHeader
             issues={controller.surfaceIssues}
             workingIssues={workingIssues}
+            workingAgentIds={workingAgentIds}
             isRefreshing={controller.isRefreshing}
             facetCountsExact={controller.viewMode !== "table"}
             tableFacetCounts={controller.tableFacetCounts}

--- a/packages/views/issues/components/workspace-agent-working-chip.test.tsx
+++ b/packages/views/issues/components/workspace-agent-working-chip.test.tsx
@@ -230,6 +230,27 @@ describe("WorkspaceAgentWorkingChip", () => {
     expect(mockState.avatarAgentIds).toBeUndefined();
   });
 
+  it("renders the exact server-backed Table agent scope without issue materialization", () => {
+    mockState.snapshot = [
+      makeTask({ id: "t-1", agent_id: "agent-1", issue_id: "issue-1" }),
+      makeTask({ id: "t-2", agent_id: "agent-off-scope", issue_id: "issue-2" }),
+    ];
+
+    renderWithI18n(
+      <WorkspaceAgentWorkingChip
+        value={false}
+        onToggle={() => {}}
+        workingIssues={undefined}
+        workingAgentIds={["agent-1"]}
+      />,
+    );
+
+    expect(
+      screen.getByRole("button", { name: "1 agent working" }),
+    ).toBeTruthy();
+    expect(mockState.avatarAgentIds).toEqual(["agent-1"]);
+  });
+
   it("shows 0 when nothing is running", () => {
     mockState.snapshot = [];
 

--- a/packages/views/issues/components/workspace-agent-working-chip.tsx
+++ b/packages/views/issues/components/workspace-agent-working-chip.tsx
@@ -31,9 +31,11 @@ interface WorkspaceAgentWorkingChipProps {
   // is what keeps that judgement in step with the list (MUL-4884).
   //
   // `undefined` means the scope is UNKNOWN. Table deliberately does not
-  // materialize all cursor branches just to derive this decoration, so the
-  // chip shows an indeterminate "—" while the toggle remains available.
+  // materialize all cursor branches just to derive this decoration.
   workingIssues: readonly Issue[] | undefined;
+  // Server-backed Table supplies the same scope as a bounded working-agent
+  // facet. Undefined means unresolved/not applicable; [] is a known zero.
+  workingAgentIds?: readonly string[];
 }
 
 export interface WorkingChipView {
@@ -146,12 +148,14 @@ export function WorkspaceAgentWorkingChip({
   value,
   onToggle,
   workingIssues,
+  workingAgentIds,
 }: WorkspaceAgentWorkingChipProps) {
   const { t } = useT("issues");
   const wsId = useWorkspaceId();
   const { data: snapshot = [] } = useQuery(agentTaskSnapshotOptions(wsId));
 
-  const scopeKnown = workingIssues !== undefined;
+  const scopeKnown =
+    workingIssues !== undefined || workingAgentIds !== undefined;
   const view = useMemo(
     () => deriveWorkingChipView(snapshot, workingIssues ?? []),
     [snapshot, workingIssues],
@@ -159,7 +163,8 @@ export function WorkspaceAgentWorkingChip({
 
   // The number and the avatar stack are the same list, so they cannot
   // disagree.
-  const agentCount = view.agentIds.length;
+  const agentIds = workingAgentIds ?? view.agentIds;
+  const agentCount = agentIds.length;
   const hasAgents = scopeKnown && agentCount > 0;
 
   const label = scopeKnown
@@ -183,7 +188,7 @@ export function WorkspaceAgentWorkingChip({
       aria-label={label}
     >
       {hasAgents && (
-        <AgentAvatarStack agentIds={view.agentIds} size="sm" max={3} />
+        <AgentAvatarStack agentIds={agentIds} size="sm" max={3} />
       )}
       <span className="tabular-nums md:hidden">
         {scopeKnown ? agentCount : "—"}
@@ -195,7 +200,7 @@ export function WorkspaceAgentWorkingChip({
   // No hover card while the scope is unknown: there is no issue list to
   // show, and an empty card would read as "nothing running" — the exact
   // claim the unknown state exists to avoid.
-  if (!scopeKnown) return trigger;
+  if (!scopeKnown || workingIssues === undefined) return trigger;
 
   return (
     <HoverCard>

--- a/packages/views/issues/surface/activity.test.ts
+++ b/packages/views/issues/surface/activity.test.ts
@@ -34,6 +34,7 @@ describe("deriveIssueSurfaceActivity", () => {
     ]);
 
     expect(activity.runningIssueIds).toEqual(new Set(["i-1"]));
+    expect(activity.runningAgentIds).toEqual(["agent-1"]);
     expect(activity.activityByIssueId.get("i-1")).toMatchObject({
       isWorking: true,
       isQueued: false,
@@ -47,6 +48,17 @@ describe("deriveIssueSurfaceActivity", () => {
       isQueued: true,
     });
     expect(activity.activityByIssueId.has("i-4")).toBe(false);
+  });
+
+  it("deduplicates running agents and excludes issue-less tasks", () => {
+    const activity = deriveIssueSurfaceActivity([
+      task({ id: "run-1", agent_id: "agent-1", issue_id: "i-1", status: "running" }),
+      task({ id: "run-2", agent_id: "agent-1", issue_id: "i-2", status: "running" }),
+      task({ id: "run-3", agent_id: "agent-2", issue_id: "i-2", status: "running" }),
+      task({ id: "chat", agent_id: "agent-3", issue_id: undefined, status: "running" }),
+    ]);
+
+    expect(activity.runningAgentIds).toEqual(["agent-1", "agent-2"]);
   });
 });
 

--- a/packages/views/issues/surface/activity.ts
+++ b/packages/views/issues/surface/activity.ts
@@ -16,6 +16,9 @@ export interface IssueActivityState {
 export interface IssueSurfaceActivity {
   activityByIssueId: Map<string, IssueActivityState>;
   runningIssueIds: Set<string>;
+  /** Distinct agents with a visible running issue task. Stable snapshot order
+   * is retained so avatar stacks do not reshuffle between equivalent reads. */
+  runningAgentIds: string[];
 }
 
 function isQueuedTaskStatus(status: AgentTask["status"]) {
@@ -58,6 +61,8 @@ export function deriveIssueSurfaceActivity(
   tasks: readonly AgentTask[],
 ): IssueSurfaceActivity {
   const activityByIssueId = new Map<string, IssueActivityState>();
+  const runningAgentIds: string[] = [];
+  const seenRunningAgents = new Set<string>();
 
   for (const task of tasks) {
     if (!task.issue_id) continue;
@@ -76,6 +81,10 @@ export function deriveIssueSurfaceActivity(
     if (task.status === "running") {
       current.runningTasks.push(task);
       current.isWorking = true;
+      if (!seenRunningAgents.has(task.agent_id)) {
+        seenRunningAgents.add(task.agent_id);
+        runningAgentIds.push(task.agent_id);
+      }
     } else {
       current.queuedTasks.push(task);
       current.isQueued = true;
@@ -89,7 +98,7 @@ export function deriveIssueSurfaceActivity(
     if (activity.isWorking) runningIssueIds.add(issueId);
   }
 
-  return { activityByIssueId, runningIssueIds };
+  return { activityByIssueId, runningIssueIds, runningAgentIds };
 }
 
 export function useIssueSurfaceActivity(): IssueSurfaceActivity {

--- a/packages/views/issues/surface/issue-surface.tsx
+++ b/packages/views/issues/surface/issue-surface.tsx
@@ -31,11 +31,12 @@ export interface IssueSurfaceRenderContext {
   controller: IssueSurfaceController;
   issues: Issue[];
   /** The rows the agents-working filter would leave on screen, with this
-   *  surface's `clientFilter` applied — headers feed it to the working chip
-   *  so the chip's count is the post-click row count (MUL-4884). Undefined
-   *  means the set is UNKNOWN (not materialized by the server-backed Table);
-   *  the chip renders an indeterminate state instead of a number. */
+   *  surface's `clientFilter` applied. Undefined means the issue projection
+   *  is not materialized by the server-backed Table; workingAgentIds then
+   *  carries its bounded exact chip scope. */
   workingIssues: Issue[] | undefined;
+  /** Exact Table activity scope, supplied by the bounded server facet. */
+  workingAgentIds: string[] | undefined;
 }
 
 interface IssueSurfaceComponentProps extends IssueSurfaceProps {
@@ -166,7 +167,12 @@ function IssueSurfaceContent({
     [clientFilter, controller.workingScopeIssues],
   );
   const renderContext = useMemo(
-    () => ({ controller, issues, workingIssues }),
+    () => ({
+      controller,
+      issues,
+      workingIssues,
+      workingAgentIds: controller.workingAgentIds,
+    }),
     [controller, issues, workingIssues],
   );
   const openCreateIssue = useCallback(
@@ -208,6 +214,7 @@ function IssueSurfaceContent({
           <IssuesHeader
             scopedIssues={controller.surfaceIssues}
             workingIssues={workingIssues}
+            workingAgentIds={controller.workingAgentIds}
             allowGantt={controller.allowGantt}
             isRefreshing={controller.isRefreshing}
             facetCountsExact={

--- a/packages/views/issues/surface/use-issue-surface-controller.test.tsx
+++ b/packages/views/issues/surface/use-issue-surface-controller.test.tsx
@@ -18,6 +18,8 @@ import type {
   AgentTask,
   Issue,
   IssueStatus,
+  IssueTableFacetsRequest,
+  IssueTableFacetsResponse,
   ListIssuesParams,
   ListIssuesResponse,
 } from "@multica/core/types";
@@ -130,6 +132,7 @@ describe("useIssueSurfaceController", () => {
     getAgentTaskSnapshot = vi.fn(() => never<AgentTask[]>());
     setApiInstance({
       listIssues,
+      listIssueTableFacets: vi.fn(() => never()),
       listGroupedIssues: vi.fn(() => never()),
       listProjects: vi.fn(() => never()),
       getAgentTaskSnapshot,
@@ -655,18 +658,24 @@ describe("useIssueSurfaceController", () => {
     );
   });
 
-  it("sends the agents-working filter as a backend predicate without sending running ids", async () => {
+  it("sends the visible running-agent ids with the Table working predicate", async () => {
     const store = getIssueSurfaceViewStore("project:p1");
     store.getState().setViewMode("table");
     store.getState().toggleAgentRunningFilter();
     listIssues.mockResolvedValue({ issues: [], total: 0 });
     setApiInstance({
       listIssues,
+      listIssueTableFacets: vi.fn(() => never()),
       listGroupedIssues: vi.fn(() => never()),
       listProjects: vi.fn(() => never()),
       getAgentTaskSnapshot: vi.fn(() =>
         Promise.resolve([
-          { id: "task-1", issue_id: "issue-running", status: "running" },
+          {
+            id: "task-1",
+            agent_id: "agent-1",
+            issue_id: "issue-running",
+            status: "running",
+          },
         ] as unknown as AgentTask[]),
       ),
       getChildIssueProgress: vi.fn(() => never()),
@@ -681,8 +690,68 @@ describe("useIssueSurfaceController", () => {
       { wrapper: makeWrapper(qc, "project:p1") },
     );
 
-    expect(result.current.tableQuerySpec.filters.working_only).toBe(true);
+    await waitFor(() => {
+      expect(result.current.tableQuerySpec.filters.working_only).toBe(true);
+      expect(result.current.tableQuerySpec.filters.working_agent_ids).toEqual([
+        "agent-1",
+      ]);
+    });
     expect(listIssues).not.toHaveBeenCalled();
+  });
+
+  it("resolves the Table chip from the bounded working-agent facet", async () => {
+    const store = getIssueSurfaceViewStore("project:p1");
+    store.getState().setViewMode("table");
+    const listIssueTableFacets = vi.fn().mockResolvedValue({
+      query_fingerprint: "sha256:working-agents",
+      total: 0,
+      facets: [
+        {
+          kind: "working_agent",
+          values: [{ key: "agent-1", count: 2 }],
+        },
+      ],
+    });
+    setApiInstance({
+      listIssues,
+      listIssueTableFacets,
+      listGroupedIssues: vi.fn(() => never()),
+      listProjects: vi.fn(() => never()),
+      listProperties: vi.fn(() => Promise.resolve({ properties: [] })),
+      getAgentTaskSnapshot: vi.fn(() =>
+        Promise.resolve([
+          makeRunningTask("task-1", "agent-1", "issue-1"),
+          makeRunningTask("task-2", "agent-2", "issue-2"),
+        ]),
+      ),
+      getChildIssueProgress: vi.fn(() => never()),
+    } as unknown as ApiClient);
+
+    const { result } = renderHook(
+      () =>
+        useIssueSurfaceController({
+          scope: { type: "project", projectId: "p1" },
+          modes: ["table"],
+        }),
+      { wrapper: makeWrapper(qc, "project:p1") },
+    );
+
+    await waitFor(() =>
+      expect(result.current.workingAgentIds).toEqual(["agent-1"]),
+    );
+    expect(listIssueTableFacets).toHaveBeenCalledWith(
+      expect.objectContaining({
+        query: expect.objectContaining({
+          filters: expect.objectContaining({
+            working_only: true,
+            working_agent_ids: ["agent-1", "agent-2"],
+          }),
+        }),
+        facets: [{ kind: "working_agent" }],
+        include_total: false,
+      }),
+    );
+    expect(result.current.workingScopeIssues).toBeUndefined();
   });
 
   it("keeps the table working-chip scope unknown without materializing a second issue window", async () => {
@@ -700,11 +769,17 @@ describe("useIssueSurfaceController", () => {
     );
     setApiInstance({
       listIssues,
+      listIssueTableFacets: vi.fn(() => never()),
       listGroupedIssues: vi.fn(() => never()),
       listProjects: vi.fn(() => never()),
       getAgentTaskSnapshot: vi.fn(() =>
         Promise.resolve([
-          { id: "task-1", issue_id: "issue-running", status: "running" },
+          {
+            id: "task-1",
+            agent_id: "agent-1",
+            issue_id: "issue-running",
+            status: "running",
+          },
         ] as unknown as AgentTask[]),
       ),
       getChildIssueProgress: vi.fn(() => never()),
@@ -779,12 +854,14 @@ describe("useIssueSurfaceController", () => {
     });
     setApiInstance({
       listIssues,
+      listIssueTableFacets: vi.fn(() => never()),
       listGroupedIssues: vi.fn(() => never()),
       listProjects: vi.fn(() => never()),
       getAgentTaskSnapshot: vi.fn(() =>
         Promise.resolve(
           runningIssues.map((issue, index) => ({
             id: `task-${index}`,
+            agent_id: `agent-${index}`,
             issue_id: issue.id,
             status: "running",
           })) as unknown as AgentTask[],
@@ -827,12 +904,14 @@ describe("useIssueSurfaceController", () => {
     });
     setApiInstance({
       listIssues,
+      listIssueTableFacets: vi.fn(() => never()),
       listGroupedIssues: vi.fn(() => never()),
       listProjects: vi.fn(() => never()),
       getAgentTaskSnapshot: vi.fn(() =>
         Promise.resolve(
           runningIssues.map((issue, index) => ({
             id: `task-${index}`,
+            agent_id: `agent-${index}`,
             issue_id: issue.id,
             status: "running",
           })) as unknown as AgentTask[],
@@ -863,29 +942,40 @@ describe("useIssueSurfaceController", () => {
   it("keeps the Table activity scope unknown across task-snapshot rekeys", async () => {
     const store = getIssueSurfaceViewStore("project:p1");
     store.getState().setViewMode("table");
-    // Running set A resolves to a complete window; then the set changes to B
-    // and B's request stays pending. keepPreviousData leaves A's rows as
-    // PLACEHOLDER under the new key — publishing them (paired with the new
-    // snapshot) would be a precise-looking number for a scope nobody fetched
-    // (round-6 review P2#1). Until B resolves, the scope must be unknown.
-    const issueA = makeIssue({ id: "run-A", status: "in_progress" });
-    let snapshotIssueId = "run-A";
-    listIssues.mockImplementation((params?: ListIssuesParams) => {
-      if (params?.ids?.includes("run-A")) {
-        return Promise.resolve({ issues: [issueA], total: 1 });
+    // Agent A's facet resolves; then the snapshot moves to agent B and B's
+    // facet stays pending. The old response must not be published under the
+    // new allowlist.
+    let snapshotAgentId = "agent-A";
+    const listIssueTableFacets = vi.fn(
+      (
+        request: IssueTableFacetsRequest,
+      ): Promise<IssueTableFacetsResponse> => {
+        if (request.query.filters.working_agent_ids?.includes("agent-A")) {
+          return Promise.resolve({
+            query_fingerprint: "sha256:agent-A",
+            total: 0,
+            facets: [
+              {
+                kind: "working_agent",
+                values: [{ key: "agent-A", count: 1 }],
+              },
+            ],
+          });
+        }
+        return never<IssueTableFacetsResponse>();
       }
-      if (params?.ids) return never<ListIssuesResponse>();
-      return Promise.resolve({ issues: [], total: 0 });
-    });
+    );
     setApiInstance({
       listIssues,
+      listIssueTableFacets,
       listGroupedIssues: vi.fn(() => never()),
       listProjects: vi.fn(() => never()),
       getAgentTaskSnapshot: vi.fn(() =>
         Promise.resolve([
           {
             id: "task-1",
-            issue_id: snapshotIssueId,
+            agent_id: snapshotAgentId,
+            issue_id: `issue-${snapshotAgentId}`,
             status: "running",
           },
         ] as unknown as AgentTask[]),
@@ -903,12 +993,11 @@ describe("useIssueSurfaceController", () => {
     );
 
     await waitFor(() =>
-      expect(result.current.workingScopeIssues).toBeUndefined(),
+      expect(result.current.workingAgentIds).toEqual(["agent-A"]),
     );
     expect(listIssues).not.toHaveBeenCalled();
 
-    // The running set moves to B; B's ids window never resolves in this test.
-    snapshotIssueId = "run-B";
+    snapshotAgentId = "agent-B";
     await act(async () => {
       await qc.invalidateQueries({
         queryKey: agentTaskSnapshotOptions("ws-1").queryKey,
@@ -916,7 +1005,7 @@ describe("useIssueSurfaceController", () => {
     });
 
     await waitFor(() => {
-      expect(result.current.workingScopeIssues).toBeUndefined();
+      expect(result.current.workingAgentIds).toBeUndefined();
     });
   });
 

--- a/packages/views/issues/surface/use-issue-surface-controller.ts
+++ b/packages/views/issues/surface/use-issue-surface-controller.ts
@@ -63,10 +63,13 @@ export interface IssueSurfaceController {
   projectIssues: Issue[];
   issues: Issue[];
   swimlaneIssues: Issue[];
-  /** The rows the agents-working filter would leave on screen. Feeds the
-   *  header chip so its count IS the post-click row count (MUL-4884). */
-  /** See IssueSurfaceData.workingScopeIssues — undefined means UNKNOWN. */
+  /** The rows the agents-working filter would leave on non-Table surfaces.
+   * See IssueSurfaceData.workingScopeIssues — undefined means the issue
+   * projection is unknown; Table uses workingAgentIds instead. */
   workingScopeIssues: Issue[] | undefined;
+  /** Exact agent ids from the bounded server Table activity facet. Undefined
+   * outside Table or while the facet is unresolved. */
+  workingAgentIds: string[] | undefined;
   filteredGanttIssues: Issue[];
   assigneeGroups?: IssueAssigneeGroup[];
   assigneeGroupQueryKey?: QueryKey;
@@ -326,7 +329,15 @@ export function useIssueSurfaceController({
           ? { properties: effectivePropertyFilters }
           : {}),
         ...(date ? { date } : {}),
-        ...(agentRunningFilter ? { working_only: true } : {}),
+        ...(agentRunningFilter
+          ? {
+              working_only: true,
+              // The snapshot endpoint already applies agent visibility.
+              // Keep the established intent explicit while the server
+              // narrows it to this visible agent set.
+              working_agent_ids: activity.runningAgentIds,
+            }
+          : {}),
         include_sub_issues: showSubIssues,
       },
       ...(debouncedTableSearch ? { search: debouncedTableSearch } : {}),
@@ -337,6 +348,7 @@ export function useIssueSurfaceController({
     };
   }, [
     agentRunningFilter,
+    activity.runningAgentIds,
     assigneeFilters,
     creatorFilters,
     dateParams,
@@ -376,6 +388,40 @@ export function useIssueSurfaceController({
     // statements and repeatedly scan the issue table after invalidation.
     enabled: usesTable && activeTableFacet !== null,
   });
+  const tableWorkingFacetRequest = useMemo(
+    () => ({
+      query: {
+        ...tableQuerySpec,
+        filters: {
+          ...tableQuerySpec.filters,
+          working_only: true,
+          working_agent_ids: activity.runningAgentIds,
+        },
+      },
+      facets: [{ kind: "working_agent" as const }],
+      include_total: false,
+    }),
+    [activity.runningAgentIds, tableQuerySpec],
+  );
+  const tableWorkingFacetsQuery = useQuery({
+    ...issueTableFacetsOptions(wsId, tableWorkingFacetRequest),
+    // With no visible running issue task the exact answer is already known.
+    enabled: usesTable && activity.runningAgentIds.length > 0,
+  });
+  const workingAgentIds = useMemo(() => {
+    if (!usesTable) return undefined;
+    if (activity.runningAgentIds.length === 0) return [];
+    const response = tableWorkingFacetsQuery.data;
+    if (!response?.query_fingerprint) return undefined;
+    const facet = response.facets.find(
+      (candidate) => candidate.kind === "working_agent",
+    );
+    return facet?.values.map((value) => value.key);
+  }, [
+    activity.runningAgentIds.length,
+    tableWorkingFacetsQuery.data,
+    usesTable,
+  ]);
   useEffect(() => {
     if (!usesTable) setActiveTableFacet(null);
   }, [usesTable]);
@@ -519,6 +565,7 @@ export function useIssueSurfaceController({
     viewMode: effectiveViewMode,
     allowGantt: allowedModes.has("gantt") && !!projectId,
     ...data,
+    workingAgentIds,
     // Keep TableView mounted for an empty search result so its local search
     // control remains available to refine or clear the query. Include the
     // debounced value as well to avoid a brief empty-screen flash while a

--- a/packages/views/issues/surface/use-issue-surface-data.ts
+++ b/packages/views/issues/surface/use-issue-surface-data.ts
@@ -62,9 +62,9 @@ export interface IssueSurfaceData {
   issues: Issue[];
   swimlaneIssues: Issue[];
   /** The rows the agents-working filter would leave on screen. `undefined`
-   *  means the set is genuinely unknown: Table membership is server-owned,
-   *  and the activity chip must not reconstruct a complete issue window just
-   *  to decorate the header. */
+   *  means the issue-object projection is unknown: Table membership is
+   *  server-owned, and its chip uses the controller's bounded agent facet
+   *  rather than reconstructing a complete issue window. */
   workingScopeIssues: Issue[] | undefined;
   filteredGanttIssues: Issue[];
   assigneeGroups?: IssueAssigneeGroup[];
@@ -345,8 +345,8 @@ export function useIssueSurfaceData({
       // second complete issue window merely to decorate the activity chip:
       // that was the final hidden auto-materialization loop behind the old
       // 1,000-row ceiling. An empty task set is trivially known; otherwise
-      // keep the chip indeterminate until a bounded server facet supplies
-      // the matching task/issue projection.
+      // leave the issue-object projection unknown. The controller supplies
+      // the chip's exact agent ids through a bounded server facet.
       if (!hasRunningIssues) return EMPTY_ISSUES;
       return undefined;
     }

--- a/packages/views/my-issues/components/my-issues-header.tsx
+++ b/packages/views/my-issues/components/my-issues-header.tsx
@@ -27,6 +27,7 @@ import {
 export function MyIssuesHeader({
   allIssues,
   workingIssues,
+  workingAgentIds,
   scope,
   onScopeChange,
   isRefreshing = false,
@@ -35,10 +36,10 @@ export function MyIssuesHeader({
   onTableFacetChange,
 }: {
   allIssues: Issue[];
-  /** The rows the agents-working filter would leave on screen — undefined
-   *  when the set is unknown (chip renders indeterminate). Scopes the chip:
-   *  it counts the agents working on these rows. */
+  /** The rows the agents-working filter would leave on screen. Undefined for
+   *  server-backed Table, where workingAgentIds supplies the exact scope. */
   workingIssues: Issue[] | undefined;
+  workingAgentIds?: string[];
   scope: MyIssuesScope;
   onScopeChange: (scope: MyIssuesScope) => void;
   isRefreshing?: boolean;
@@ -125,6 +126,7 @@ export function MyIssuesHeader({
             value={agentRunningFilter}
             onToggle={toggleAgentRunningFilter}
             workingIssues={workingIssues}
+            workingAgentIds={workingAgentIds}
           />
           <IssueDisplayControls
             scopedIssues={allIssues}

--- a/packages/views/my-issues/components/my-issues-page.tsx
+++ b/packages/views/my-issues/components/my-issues-page.tsx
@@ -38,10 +38,11 @@ export function MyIssuesPage() {
           }}
           modes={["board", "list", "table", "swimlane"]}
           batchToolbar="list"
-          renderHeader={({ controller, workingIssues }) => (
+          renderHeader={({ controller, workingIssues, workingAgentIds }) => (
             <MyIssuesHeader
               allIssues={controller.surfaceIssues}
               workingIssues={workingIssues}
+              workingAgentIds={workingAgentIds}
               scope={scope}
               onScopeChange={setScope}
               isRefreshing={controller.isRefreshing}

--- a/server/internal/handler/issue_table_facets.go
+++ b/server/internal/handler/issue_table_facets.go
@@ -15,7 +15,7 @@ import (
 	db "github.com/multica-ai/multica/server/pkg/db/generated"
 )
 
-// The workspace property catalog is capped at 20 active definitions. Six
+// The workspace property catalog is capped at 20 active definitions. Seven
 // built-in dimensions plus that catalog fit under this guard with headroom,
 // while preventing a single request from scheduling hundreds of sequential
 // aggregation scans inside one snapshot transaction.
@@ -63,6 +63,13 @@ func issueTableQueryWithoutFacet(input issueTableQuerySpec, facet issueTableFace
 		output.Filters.IncludeNoProject = false
 	case "label":
 		output.Filters.LabelIDs = nil
+	case "working_agent":
+		// This is a bounded activity projection rather than a filter-menu
+		// facet. The JOIN below applies the caller-visible agent allowlist;
+		// remove it from the base issue predicate so each matching agent gets
+		// its own value instead of merely inheriting an issue-level EXISTS.
+		output.Filters.WorkingOnly = false
+		output.Filters.WorkingAgentIDs = nil
 	case "property":
 		delete(output.Filters.Properties, facet.PropertyID)
 	}
@@ -194,6 +201,33 @@ func (h *Handler) issueTableFacetQuery(w http.ResponseWriter, r *http.Request, r
 		query = fmt.Sprintf(`SELECT COALESCE(i.project_id::text, '__none__'), COUNT(*)::bigint FROM issue i WHERE %s GROUP BY 1`, compiled.where)
 	case "label":
 		query = fmt.Sprintf(`SELECT itl.label_id::text, COUNT(DISTINCT i.id)::bigint FROM issue i JOIN issue_to_label itl ON itl.issue_id = i.id WHERE %s GROUP BY itl.label_id`, compiled.where)
+	case "working_agent":
+		if requestQuery.Filters.WorkingAgentIDs == nil {
+			writeError(w, http.StatusBadRequest, "filters.working_agent_ids is required for working_agent facet")
+			return response, false
+		}
+		workingAgentIDs, ok := parseIssueTableUUIDList(
+			w,
+			sortedUniqueStrings(*requestQuery.Filters.WorkingAgentIDs),
+			"filters.working_agent_ids",
+		)
+		if !ok {
+			return response, false
+		}
+		if len(workingAgentIDs) == 0 {
+			return response, true
+		}
+		agentIDsRef := "$" + fmt.Sprint(len(compiled.args)+1)
+		compiled.args = append(compiled.args, workingAgentIDs)
+		query = fmt.Sprintf(`
+SELECT atq.agent_id::text, COUNT(DISTINCT i.id)::bigint
+FROM issue i
+JOIN agent_task_queue atq
+  ON atq.issue_id = i.id
+ AND atq.status = 'running'
+ AND atq.agent_id = ANY(%s::uuid[])
+WHERE %s
+GROUP BY atq.agent_id`, agentIDsRef, compiled.where)
 	case "property":
 		propertyID, err := util.ParseUUID(facet.PropertyID)
 		if err != nil {

--- a/server/internal/handler/issue_table_query.go
+++ b/server/internal/handler/issue_table_query.go
@@ -92,7 +92,11 @@ type issueTableFiltersRequest struct {
 	Properties        map[string][]string          `json:"properties,omitempty"`
 	Date              *issueTableDateFilterRequest `json:"date,omitempty"`
 	WorkingOnly       bool                         `json:"working_only,omitempty"`
-	IncludeSubIssues  *bool                        `json:"include_sub_issues,omitempty"`
+	// Nil preserves the legacy working_only predicate (any running task).
+	// A present list narrows that predicate to the caller-visible agents;
+	// present-but-empty deliberately matches no issues.
+	WorkingAgentIDs  *[]string `json:"working_agent_ids,omitempty"`
+	IncludeSubIssues *bool     `json:"include_sub_issues,omitempty"`
 }
 
 type issueTableSortRequest struct {
@@ -248,6 +252,13 @@ func canonicalIssueTableFingerprint(workspaceID string, spec issueTableQuerySpec
 	normalized.Filters.LabelIDs = sortedUniqueStrings(normalized.Filters.LabelIDs)
 	normalized.Filters.Assignees = sortedUniqueActors(normalized.Filters.Assignees)
 	normalized.Filters.Creators = sortedUniqueActors(normalized.Filters.Creators)
+	if normalized.Filters.WorkingAgentIDs != nil {
+		values := sortedUniqueStrings(*normalized.Filters.WorkingAgentIDs)
+		if values == nil {
+			values = []string{}
+		}
+		normalized.Filters.WorkingAgentIDs = &values
+	}
 	for key, values := range normalized.Filters.Properties {
 		normalized.Filters.Properties[key] = sortedUniqueStrings(values)
 	}
@@ -574,7 +585,24 @@ func (h *Handler) compileIssueTableQuery(w http.ResponseWriter, r *http.Request,
 		where = append(where, fmt.Sprintf("i.%s >= %s AND i.%s < %s", column, addArg(start), column, addArg(end)))
 	}
 
-	if spec.Filters.WorkingOnly {
+	if spec.Filters.WorkingAgentIDs != nil {
+		workingAgentIDs, ok := parseIssueTableUUIDList(
+			w,
+			sortedUniqueStrings(*spec.Filters.WorkingAgentIDs),
+			"filters.working_agent_ids",
+		)
+		if !ok {
+			return issueTableSQL{}, false
+		}
+		if len(workingAgentIDs) == 0 {
+			where = append(where, "FALSE")
+		} else {
+			where = append(where, fmt.Sprintf(
+				"EXISTS (SELECT 1 FROM agent_task_queue atq WHERE atq.issue_id = i.id AND atq.status = 'running' AND atq.agent_id = ANY(%s::uuid[]))",
+				addArg(workingAgentIDs),
+			))
+		}
+	} else if spec.Filters.WorkingOnly {
 		where = append(where, "EXISTS (SELECT 1 FROM agent_task_queue atq WHERE atq.issue_id = i.id AND atq.status = 'running')")
 	}
 	if spec.Filters.IncludeSubIssues != nil && !*spec.Filters.IncludeSubIssues {

--- a/server/internal/handler/issue_table_query_test.go
+++ b/server/internal/handler/issue_table_query_test.go
@@ -83,19 +83,23 @@ func (tx *issueTableEnrichmentFailTx) QueryRow(ctx context.Context, sql string, 
 }
 
 func TestCanonicalIssueTableFingerprintNormalizesSetLikeArrays(t *testing.T) {
+	leftWorkingAgentIDs := []string{"b", "a", "b"}
 	left := issueTableQuerySpec{
 		Scope: issueTableScope{Kind: "workspace", AssigneeTypes: []string{"agent", "member", "agent"}},
 		Filters: issueTableFiltersRequest{
-			Statuses:   []string{"todo", "backlog", "todo"},
-			ProjectIDs: []string{"b", "a"},
+			Statuses:        []string{"todo", "backlog", "todo"},
+			ProjectIDs:      []string{"b", "a"},
+			WorkingAgentIDs: &leftWorkingAgentIDs,
 		},
 		Sort: issueTableSortRequest{Field: "title", Direction: "asc"},
 	}
+	rightWorkingAgentIDs := []string{"a", "b"}
 	right := issueTableQuerySpec{
 		Scope: issueTableScope{Kind: "workspace", AssigneeTypes: []string{"member", "agent"}},
 		Filters: issueTableFiltersRequest{
-			Statuses:   []string{"backlog", "todo"},
-			ProjectIDs: []string{"a", "b"},
+			Statuses:        []string{"backlog", "todo"},
+			ProjectIDs:      []string{"a", "b"},
+			WorkingAgentIDs: &rightWorkingAgentIDs,
 		},
 		Sort: issueTableSortRequest{Field: "title", Direction: "asc"},
 	}
@@ -252,6 +256,145 @@ func TestIssueTableRowsCommitsBeforeBestEffortEnrichment(t *testing.T) {
 		strings.Contains(rowQuerySQL, "membership AS") ||
 		strings.Contains(rowQuerySQL, "FROM membership child") {
 		t.Fatalf("flat rows query must page directly without hierarchy work:\n%s", rowQuerySQL)
+	}
+}
+
+func TestIssueTableWorkingAgentFacetAndFilter(t *testing.T) {
+	if testHandler == nil {
+		t.Skip("database not available")
+	}
+
+	ctx := context.Background()
+	suffix := time.Now().UnixNano()
+	agentA := createHandlerTestAgent(t, fmt.Sprintf("table-working-a-%d", suffix), []byte(`{}`))
+	agentB := createHandlerTestAgent(t, fmt.Sprintf("table-working-b-%d", suffix), []byte(`{}`))
+
+	var projectID string
+	if err := testPool.QueryRow(ctx, `
+		INSERT INTO project (workspace_id, title)
+		VALUES ($1, $2)
+		RETURNING id
+	`, testWorkspaceID, fmt.Sprintf("Table working agents %d", suffix)).Scan(&projectID); err != nil {
+		t.Fatalf("create project: %v", err)
+	}
+
+	var finalNumber int
+	if err := testPool.QueryRow(ctx, `
+		UPDATE workspace
+		SET issue_counter = GREATEST(
+			issue_counter,
+			(SELECT COALESCE(MAX(number), 0) FROM issue WHERE workspace_id = $1)
+		) + 2
+		WHERE id = $1
+		RETURNING issue_counter
+	`, testWorkspaceID).Scan(&finalNumber); err != nil {
+		t.Fatalf("reserve issue numbers: %v", err)
+	}
+
+	var issueA, issueB string
+	if err := testPool.QueryRow(ctx, `
+		INSERT INTO issue (
+			workspace_id, title, status, priority, creator_type, creator_id,
+			position, number, project_id
+		)
+		VALUES ($1, 'working-agent-a', 'in_progress', 'none', 'member', $2, 1, $3, $4)
+		RETURNING id
+	`, testWorkspaceID, testUserID, finalNumber-1, projectID).Scan(&issueA); err != nil {
+		t.Fatalf("create issue A: %v", err)
+	}
+	if err := testPool.QueryRow(ctx, `
+		INSERT INTO issue (
+			workspace_id, title, status, priority, creator_type, creator_id,
+			position, number, project_id
+		)
+		VALUES ($1, 'working-agent-b', 'in_progress', 'none', 'member', $2, 2, $3, $4)
+		RETURNING id
+	`, testWorkspaceID, testUserID, finalNumber, projectID).Scan(&issueB); err != nil {
+		t.Fatalf("create issue B: %v", err)
+	}
+
+	if _, err := testPool.Exec(ctx, `
+		INSERT INTO agent_task_queue (agent_id, runtime_id, issue_id, status, priority)
+		VALUES
+			($1, $3, $4, 'running', 0),
+			($2, $3, $5, 'running', 0)
+	`, agentA, agentB, testRuntimeID, issueA, issueB); err != nil {
+		t.Fatalf("create running tasks: %v", err)
+	}
+	t.Cleanup(func() {
+		_, _ = testPool.Exec(context.Background(), `DELETE FROM agent_task_queue WHERE issue_id IN ($1, $2)`, issueA, issueB)
+		_, _ = testPool.Exec(context.Background(), `DELETE FROM issue WHERE id IN ($1, $2)`, issueA, issueB)
+		_, _ = testPool.Exec(context.Background(), `DELETE FROM project WHERE id = $1`, projectID)
+	})
+
+	visibleAgentIDs := []string{agentA}
+	query := issueTableQuerySpec{
+		Scope: issueTableScope{Kind: "project", ProjectID: projectID},
+		Filters: issueTableFiltersRequest{
+			WorkingOnly:     true,
+			WorkingAgentIDs: &visibleAgentIDs,
+		},
+		Sort: issueTableSortRequest{Field: "position", Direction: "asc"},
+	}
+
+	includeTotal := false
+	facetsRecorder := httptest.NewRecorder()
+	testHandler.ListIssueTableFacets(facetsRecorder, newRequest("POST", "/api/issues/table/facets", issueTableFacetsRequest{
+		Query:        query,
+		Facets:       []issueTableFacetSpec{{Kind: "working_agent"}},
+		IncludeTotal: &includeTotal,
+	}))
+	if facetsRecorder.Code != http.StatusOK {
+		t.Fatalf("working-agent facets status = %d: %s", facetsRecorder.Code, facetsRecorder.Body.String())
+	}
+	var facets issueTableFacetsResponse
+	if err := json.NewDecoder(facetsRecorder.Body).Decode(&facets); err != nil {
+		t.Fatalf("decode working-agent facets: %v", err)
+	}
+	if len(facets.Facets) != 1 || len(facets.Facets[0].Values) != 1 {
+		t.Fatalf("unexpected working-agent facets: %#v", facets.Facets)
+	}
+	if value := facets.Facets[0].Values[0]; value.Key != agentA || value.Count != 1 {
+		t.Fatalf("working-agent facet = %#v, want agent A with one issue", value)
+	}
+
+	compile := func(filters issueTableFiltersRequest) issueTableSQL {
+		t.Helper()
+		recorder := httptest.NewRecorder()
+		compiled, ok := testHandler.compileIssueTableQuery(
+			recorder,
+			newRequest("POST", "/api/issues/table/rows", nil),
+			issueTableQuerySpec{
+				Scope:   query.Scope,
+				Filters: filters,
+				Sort:    query.Sort,
+			},
+		)
+		if !ok {
+			t.Fatalf("compile working-agent query status = %d: %s", recorder.Code, recorder.Body.String())
+		}
+		return compiled
+	}
+
+	narrowed := compile(query.Filters)
+	if !strings.Contains(narrowed.where, "atq.agent_id = ANY(") ||
+		!strings.Contains(narrowed.where, "atq.status = 'running'") {
+		t.Fatalf("agent-id filter missing from table predicate: %s", narrowed.where)
+	}
+
+	legacy := compile(issueTableFiltersRequest{WorkingOnly: true})
+	if !strings.Contains(legacy.where, "atq.status = 'running'") ||
+		strings.Contains(legacy.where, "atq.agent_id = ANY(") {
+		t.Fatalf("legacy working_only predicate changed: %s", legacy.where)
+	}
+
+	emptyAgentIDs := []string{}
+	empty := compile(issueTableFiltersRequest{
+		WorkingOnly:     true,
+		WorkingAgentIDs: &emptyAgentIDs,
+	})
+	if !strings.Contains(empty.where, "FALSE") {
+		t.Fatalf("empty working-agent list did not compile to an empty window: %s", empty.where)
 	}
 }
 


### PR DESCRIPTION
Closes MUL-5200

- add a bounded working-agent facet for server-backed issue tables
- filter table rows by the visible running-agent ID list while preserving legacy working_only behavior
- render the exact Table activity count and avatars without materializing every matching issue

Validation:
- Go handler contract tests and go vet
- core and views TypeScript typechecks
- 66 focused views tests and 41 core API tests
- targeted ESLint