### PR TITLE
[MUL-5125] Derive Web client_version from Vercel deploy + dedup per version

### DIFF
--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -10,6 +10,22 @@ config({ path: resolve(__dirname, "../../.env") });
 const remoteApiUrl = resolveRemoteApiUrl(process.env);
 const docsUrl = process.env.DOCS_URL || "http://localhost:4000";
 
+// Web build/deploy version exposed to the browser bundle as
+// NEXT_PUBLIC_APP_VERSION (read in components/web-providers.tsx and reported to
+// client_usage_daily.client_version). Priority:
+//   1. explicit NEXT_PUBLIC_APP_VERSION — release workflow / manual override
+//   2. VERCEL_DEPLOYMENT_ID — unique per Vercel deployment
+//   3. VERCEL_GIT_COMMIT_SHA — the deployed commit
+// When none is set (local dev, plain Docker build) we leave it unset so
+// web-providers falls back to the package.json version, preserving today's
+// behavior for the release/Docker paths that already pass the value explicitly.
+// Requires "Automatically expose System Environment Variables" enabled on the
+// Vercel project so VERCEL_* are available at build time.
+const webVersion =
+  process.env.NEXT_PUBLIC_APP_VERSION ||
+  process.env.VERCEL_DEPLOYMENT_ID ||
+  process.env.VERCEL_GIT_COMMIT_SHA;
+
 // Parse hostnames from CORS_ALLOWED_ORIGINS so that Next.js dev server
 // allows cross-origin HMR / webpack requests (e.g. from Tailscale IPs).
 const allowedDevOrigins = process.env.CORS_ALLOWED_ORIGINS
@@ -26,6 +42,7 @@ const allowedDevOrigins = process.env.CORS_ALLOWED_ORIGINS
 
 const nextConfig: NextConfig = {
   ...(process.env.STANDALONE === "true" ? { output: "standalone" as const } : {}),
+  ...(webVersion ? { env: { NEXT_PUBLIC_APP_VERSION: webVersion } } : {}),
   transpilePackages: ["@multica/core", "@multica/ui", "@multica/views"],
   ...(allowedDevOrigins && allowedDevOrigins.length > 0
     ? { allowedDevOrigins }

--- a/docs/analytics.md
+++ b/docs/analytics.md
@@ -731,13 +731,25 @@ and login. Clearing/resetting that profile intentionally creates a new
 installation. Web and Desktop never share an installation ID.
 
 Clients report after authentication when that installation has no successful
-report for the current UTC day, and re-check on focus/resume. Desktop updates
-the same daily row after its first local-runtime probe and whenever the
-same-day runtime signature changes. Reports contain only client kind/version,
-a coarse OS bucket, optional current workspace context, and aggregate runtime
-provider/online/offline counts. The server supplies user, date, and timestamps.
-Device names, hostnames, local usernames, filesystem paths, raw user agents,
-IP addresses, and raw probe errors are not stored here.
+report for the current UTC day **at the current client version**, and re-check
+on focus/resume. Because the per-day dedup marker includes the reported client
+version, a same-day client upgrade (for example a new Vercel Web deployment
+loaded in the browser) re-reports and refreshes `client_version` instead of
+being skipped until the next UTC day. Desktop updates the same daily row after
+its first local-runtime probe and whenever the same-day runtime signature
+changes. Reports contain only client kind/version, a coarse OS bucket, optional
+current workspace context, and aggregate runtime provider/online/offline counts.
+The server supplies user, date, and timestamps. Device names, hostnames, local
+usernames, filesystem paths, raw user agents, IP addresses, and raw probe errors
+are not stored here.
+
+`client_version` is a build/deploy identifier, not a per-user app version. On
+Web it resolves at build time to the first of `NEXT_PUBLIC_APP_VERSION` (release
+workflow or manual override), `VERCEL_DEPLOYMENT_ID` (unique per Vercel
+deployment), or `VERCEL_GIT_COMMIT_SHA`, falling back to the `apps/web`
+package.json version for local/plain-Docker builds. Reading the Vercel
+variables requires "Automatically expose System Environment Variables" enabled
+on the Vercel project.
 
 `first_active_at` and `last_active_at` are the first and latest successful
 reports **within that UTC day**, not lifetime installation timestamps. Compute

--- a/packages/core/client-usage/index.ts
+++ b/packages/core/client-usage/index.ts
@@ -1,2 +1,2 @@
 export { getOrCreateInstallId } from "./install-id";
-export { ClientUsageReporter, utcDay } from "./reporter";
+export { ClientUsageReporter, utcDay, usageReportMarker } from "./reporter";

--- a/packages/core/client-usage/reporter.test.ts
+++ b/packages/core/client-usage/reporter.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+import { usageReportMarker, utcDay } from "./reporter";
+
+describe("usageReportMarker", () => {
+  it("is identical for the same day and version", () => {
+    expect(usageReportMarker("2026-07-23", "v1")).toBe(
+      usageReportMarker("2026-07-23", "v1"),
+    );
+  });
+
+  it("changes when the version changes on the same day", () => {
+    // A same-day client upgrade (e.g. a new Vercel deployment) must produce a
+    // new marker so the reporter re-reports instead of skipping until tomorrow.
+    expect(usageReportMarker("2026-07-23", "deploy-a")).not.toBe(
+      usageReportMarker("2026-07-23", "deploy-b"),
+    );
+  });
+
+  it("changes when the day changes", () => {
+    expect(usageReportMarker("2026-07-23", "v1")).not.toBe(
+      usageReportMarker("2026-07-24", "v1"),
+    );
+  });
+
+  it("falls back to a stable token when version is missing", () => {
+    expect(usageReportMarker("2026-07-23")).toBe("2026-07-23:unknown");
+  });
+});
+
+describe("utcDay", () => {
+  it("formats the UTC calendar date", () => {
+    expect(utcDay(new Date("2026-07-23T23:59:59Z"))).toBe("2026-07-23");
+  });
+});

--- a/packages/core/client-usage/reporter.tsx
+++ b/packages/core/client-usage/reporter.tsx
@@ -13,6 +13,14 @@ export function utcDay(date = new Date()): string {
   return date.toISOString().slice(0, 10);
 }
 
+// Per-day dedup marker. Including the client version means a same-day client
+// upgrade (e.g. a new Vercel deployment loaded in the browser) re-reports and
+// refreshes client_usage_daily.client_version instead of being skipped until
+// the next UTC day.
+export function usageReportMarker(day: string, version?: string): string {
+  return `${day}:${version ?? "unknown"}`;
+}
+
 export function ClientUsageReporter({
   storage,
   identity,
@@ -40,10 +48,11 @@ export function ClientUsageReporter({
     try {
       const installID = getOrCreateInstallId(storage);
       const reportedKey = `${LAST_REPORTED_PREFIX}:${activeUserID}:${platform}:${installID}`;
-      if (storage.getItem(reportedKey) === day) return;
+      const marker = usageReportMarker(day, identity?.version);
+      if (storage.getItem(reportedKey) === marker) return;
       inFlight.current = true;
       await getApi().upsertClientUsage({ install_id: installID });
-      storage.setItem(reportedKey, day);
+      storage.setItem(reportedKey, marker);
     } catch {
       // Usage reporting is best-effort and must never interrupt app startup.
     } finally {
@@ -53,7 +62,7 @@ export function ClientUsageReporter({
         void reportIfNeeded();
       }
     }
-  }, [identity?.platform, storage]);
+  }, [identity?.platform, identity?.version, storage]);
 
   useEffect(() => {
     void reportIfNeeded();


### PR DESCRIPTION
## 背景

MUL-5125 上线后，`client_usage_daily.client_version` 的 Web 值在 Vercel 部署下一直是固定值，无法区分不同部署。根因有两处：

1. Web 只在主仓库的 release tag 流水线里显式传入 `NEXT_PUBLIC_APP_VERSION`；Vercel 部署没有任何步骤自动注入版本，于是回退到 `apps/web/package.json` 的固定值。
2. Web daily reporter 的当天去重值只保存 `day`，同一安装实例当天上报过后，即使加载了新的 Web 构建也会被跳过，要到下一个 UTC 日才会再次上报。

## 改动

**1. `apps/web/next.config.ts` —— 自动注入 Web 部署版本**

按优先级解析并在 build 时固化到浏览器 bundle：

`NEXT_PUBLIC_APP_VERSION`（release/手工）→ `VERCEL_DEPLOYMENT_ID`（每次部署唯一）→ `VERCEL_GIT_COMMIT_SHA`（部署的 commit）。

三者都未设置时（本地 dev、未传参的普通 Docker build）不注入，`web-providers.tsx` 继续回退到 `package.json` 版本——**现有 release/Docker 路径行为完全不变**（它们本就显式传 `NEXT_PUBLIC_APP_VERSION`，优先级最高）。Vercel 上无需每次手工配置，但需确认项目已开启 “Automatically expose System Environment Variables”，否则 `VERCEL_*` 在 build 阶段不可用。

**2. `packages/core/client-usage/reporter.tsx` —— 去重值加入版本**

新增纯函数 `usageReportMarker(day, version)`，把当天去重标记从 `day` 改为 `${day}:${version}`。这样同日客户端升级（例如浏览器加载到新的 Vercel 部署）会重新上报并刷新 `client_version`，而不必等到下一个 UTC 日。同步把 `identity?.version` 加入 `useCallback` 依赖。该 reporter 只服务 Web（Desktop 已在上个 PR 走独立 reporter），改动范围精确。

## 测试重点

- 新增 `packages/core/client-usage/reporter.test.ts`，覆盖：同 day+version 标记一致、同日换版本标记变化（触发重报的核心场景）、跨日变化、version 缺失回退 `unknown`，以及 `utcDay` 的 UTC 归属。
- 已本地验证通过：
  - `@multica/core` client-usage 聚焦测试（7 用例全过）
  - `@multica/core` typecheck、`@multica/web` typecheck
  - 改动文件 ESLint（core reporter/index/test + web `next.config.ts`）
  - `git diff --check` 无空白问题

## 部署侧待办（非本 PR 代码范围）

Vercel 项目需确认 “Automatically expose System Environment Variables” 已开启，才能让 `VERCEL_DEPLOYMENT_ID` 生效。

Relates to MUL-5125
