### PR TITLE
MUL-5218: feat(issues): agents-working chip on the sub-issues header (#5825)

### DIFF
--- a/packages/core/agents/queries.ts
+++ b/packages/core/agents/queries.ts
@@ -16,12 +16,17 @@ export const workspaceWorkingAgentsKeys = {
     wsId: string,
     type?: WorkspaceWorkingAgentType,
     mineRelation?: WorkspaceWorkingAgentMineRelation,
+    parentIssueId?: string,
   ) =>
     [
       ...workspaceWorkingAgentsKeys.all(wsId),
       "list",
       type ?? "all",
-      mineRelation ? `mine:${mineRelation}` : "workspace",
+      mineRelation
+        ? `mine:${mineRelation}`
+        : parentIssueId
+          ? `parent:${parentIssueId}`
+          : "workspace",
     ] as const,
 };
 
@@ -54,17 +59,25 @@ export function agentTaskSnapshotOptions(wsId: string) {
   });
 }
 
-// Working-agent summaries, optionally narrowed to a My Issues relation. Task
-// lifecycle WebSocket events invalidate every relation immediately; the short
-// stale time is the reconnect / missed-event safety net.
+// Working-agent summaries, optionally narrowed to a My Issues relation or to
+// one issue's direct children. Task lifecycle WebSocket events invalidate
+// every narrowing immediately; the short stale time is the reconnect /
+// missed-event safety net.
 export function workspaceWorkingAgentsOptions(
   wsId: string,
   type?: WorkspaceWorkingAgentType,
   mineRelation?: WorkspaceWorkingAgentMineRelation,
+  parentIssueId?: string,
 ) {
   return queryOptions({
-    queryKey: workspaceWorkingAgentsKeys.list(wsId, type, mineRelation),
-    queryFn: () => api.getWorkspaceWorkingAgents(type, mineRelation),
+    queryKey: workspaceWorkingAgentsKeys.list(
+      wsId,
+      type,
+      mineRelation,
+      parentIssueId,
+    ),
+    queryFn: () =>
+      api.getWorkspaceWorkingAgents(type, mineRelation, parentIssueId),
     staleTime: 30 * 1000,
     gcTime: 5 * 60 * 1000,
     refetchOnWindowFocus: true,

--- a/packages/core/api/client.test.ts
+++ b/packages/core/api/client.test.ts
@@ -424,10 +424,20 @@ describe("ApiClient workspace working agents", () => {
       client.getWorkspaceWorkingAgents("issue"),
     ).resolves.toEqual(payload);
     await expect(client.getWorkspaceWorkingAgents()).resolves.toEqual(payload);
+    await expect(
+      client.getWorkspaceWorkingAgents("issue", undefined, "parent-1"),
+    ).resolves.toEqual(payload);
+    // The server rejects parent alongside scope, so a My Issues relation wins
+    // and the parent is dropped rather than sent into a 400.
+    await expect(
+      client.getWorkspaceWorkingAgents("issue", "assigned", "parent-1"),
+    ).resolves.toEqual(payload);
     expect(fetchMock.mock.calls.map(([url]) => url)).toEqual([
       "https://api.example.test/api/working-agents?type=issue&scope=mine&relation=assigned",
       "https://api.example.test/api/working-agents?type=issue",
       "https://api.example.test/api/working-agents",
+      "https://api.example.test/api/working-agents?type=issue&parent=parent-1",
+      "https://api.example.test/api/working-agents?type=issue&scope=mine&relation=assigned",
     ]);
   });
 });

--- a/packages/core/api/client.ts
+++ b/packages/core/api/client.ts
@@ -1733,15 +1733,22 @@ export class ApiClient {
   // already deduplicates running agents and returns only the display fields
   // consumers need. Callers may narrow the projection by task source and, for
   // issue work, the authenticated member's My Issues relation.
+  // `parentIssueId` narrows the projection to that issue's direct children,
+  // which is how the sub-issue header on issue detail reads the same source
+  // as the Issues list header. The server rejects combining it with `scope`,
+  // so callers pass one or the other.
   async getWorkspaceWorkingAgents(
     type?: WorkspaceWorkingAgentType,
     mineRelation?: WorkspaceWorkingAgentMineRelation,
+    parentIssueId?: string,
   ): Promise<WorkspaceWorkingAgent[]> {
     const search = new URLSearchParams();
     if (type) search.set("type", type);
     if (mineRelation) {
       search.set("scope", "mine");
       search.set("relation", mineRelation);
+    } else if (parentIssueId) {
+      search.set("parent", parentIssueId);
     }
     const query = search.toString();
     return this.fetch(`/api/working-agents${query ? `?${query}` : ""}`);

--- a/packages/views/issues/components/issue-detail.test.tsx
+++ b/packages/views/issues/components/issue-detail.test.tsx
@@ -274,6 +274,8 @@ const mockApiObj = vi.hoisted(() => ({
   listChildIssues: vi.fn().mockResolvedValue({ issues: [] }),
   getChildIssueProgress: vi.fn().mockResolvedValue({ progress: [] }),
   getAgentTaskSnapshot: vi.fn().mockResolvedValue([]),
+  // The sub-issues header chip reads this narrowed to the parent issue.
+  getWorkspaceWorkingAgents: vi.fn().mockResolvedValue([]),
   listProperties: vi.fn().mockResolvedValue({ properties: [], total: 0 }),
   listIssues: vi.fn().mockResolvedValue({ issues: [], total: 0 }),
   uploadFile: vi.fn(),
@@ -626,6 +628,7 @@ describe("IssueDetail (shared)", () => {
     mockApiObj.listChildIssues.mockResolvedValue({ issues: [] });
     mockApiObj.getChildIssueProgress.mockResolvedValue({ progress: [] });
     mockApiObj.getAgentTaskSnapshot.mockResolvedValue([]);
+    mockApiObj.getWorkspaceWorkingAgents.mockResolvedValue([]);
     mockApiObj.listProperties.mockResolvedValue({ properties: [], total: 0 });
     mockApiObj.listIssues.mockResolvedValue({ issues: [], total: 0 });
     mockApiObj.getActiveTasksForIssue.mockResolvedValue({ tasks: [] });

--- a/packages/views/issues/components/issue-detail.tsx
+++ b/packages/views/issues/components/issue-detail.tsx
@@ -58,6 +58,7 @@ import { Switch } from "@multica/ui/components/ui/switch";
 import { IssueActionsDropdown, useIssueActions, IssueActionsContextMenu, IssueContextMenuProvider } from "../actions";
 import { LabelChip } from "../../labels/label-chip";
 import { IssueAgentActivityIndicator } from "./issue-agent-activity-indicator";
+import { SubIssuesAgentWorkingChip } from "./sub-issues-agent-working-chip";
 import { ProjectPicker } from "../../projects/components/project-picker";
 import { LocalDirectoryHint } from "../../projects/components/local-directory-hint";
 import { CommentCard } from "./comment-card";
@@ -2478,6 +2479,7 @@ export function IssueDetail({ issueId, onDelete, onDone, defaultSidebarOpen = tr
                       {doneCount}/{childIssues.length}
                     </span>
                   </div>
+                  <SubIssuesAgentWorkingChip issueIds={childIssueIds} />
                   <input
                     type="checkbox"
                     checked={allChildrenSelected}

--- a/packages/views/issues/components/issue-detail.tsx
+++ b/packages/views/issues/components/issue-detail.tsx
@@ -2479,7 +2479,9 @@ export function IssueDetail({ issueId, onDelete, onDone, defaultSidebarOpen = tr
                       {doneCount}/{childIssues.length}
                     </span>
                   </div>
-                  <SubIssuesAgentWorkingChip issueIds={childIssueIds} />
+                  {/* issue.id, not the route param — the endpoint takes a
+                      UUID and the route may carry a human-readable id. */}
+                  <SubIssuesAgentWorkingChip parentIssueId={issue.id} />
                   <input
                     type="checkbox"
                     checked={allChildrenSelected}

--- a/packages/views/issues/components/sub-issues-agent-working-chip.test.tsx
+++ b/packages/views/issues/components/sub-issues-agent-working-chip.test.tsx
@@ -1,0 +1,179 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { AgentTask } from "@multica/core/types";
+
+const mockState = vi.hoisted(() => ({
+  snapshot: [] as unknown[],
+}));
+
+vi.mock("@multica/core/hooks", () => ({
+  useWorkspaceId: () => "ws-1",
+}));
+
+vi.mock("@multica/core/agents", () => ({
+  agentTaskSnapshotOptions: (wsId: string) => ({
+    queryKey: ["agents", "task-snapshot", wsId],
+  }),
+}));
+
+vi.mock("../../agents/components/agent-avatar-stack", () => ({
+  AgentAvatarStack: ({
+    agentIds,
+    opacity,
+  }: {
+    agentIds: string[];
+    opacity?: string;
+  }) => (
+    <div data-testid="agent-avatar-stack" data-opacity={opacity}>
+      {agentIds.length}
+    </div>
+  ),
+}));
+
+vi.mock("../../agents/components/agent-activity-hover-content", () => ({
+  AgentActivityHoverContent: ({ tasks }: { tasks: AgentTask[] }) => (
+    <div data-testid="activity-hover">{tasks.length}</div>
+  ),
+}));
+
+vi.mock("../../i18n", () => ({
+  useT: () => ({
+    t: (
+      selector: (keys: Record<string, Record<string, string>>) => string,
+      options?: { count?: number },
+    ) => {
+      const key = selector(
+        new Proxy(
+          {},
+          {
+            get: (_t, ns: string) =>
+              new Proxy({}, { get: (_n, k: string) => `${ns}.${k}` }),
+          },
+        ) as Record<string, Record<string, string>>,
+      );
+      return options?.count !== undefined ? `${key}:${options.count}` : key;
+    },
+  }),
+}));
+
+// The hover card only portals its content once open, so absence of the body
+// cannot distinguish "closed" from "not wired up". Mock the primitive and
+// assert on the wrapper itself (same approach as the row indicator's test).
+vi.mock("@multica/ui/components/ui/hover-card", () => ({
+  HoverCard: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="hover-card">{children}</div>
+  ),
+  HoverCardTrigger: ({ children }: { children: React.ReactNode }) => (
+    <span data-testid="hover-card-trigger">{children}</span>
+  ),
+  HoverCardContent: ({ children }: { children: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
+}));
+
+vi.mock("@tanstack/react-query", async () => {
+  const actual =
+    await vi.importActual<typeof import("@tanstack/react-query")>(
+      "@tanstack/react-query",
+    );
+  return {
+    ...actual,
+    useQuery: (opts: {
+      queryKey?: readonly unknown[];
+      select?: (data: unknown) => unknown;
+    }) => {
+      if (opts.queryKey?.[1] === "task-snapshot") {
+        return {
+          data: opts.select
+            ? opts.select(mockState.snapshot)
+            : mockState.snapshot,
+        };
+      }
+      return { data: undefined };
+    },
+  };
+});
+
+import { SubIssuesAgentWorkingChip } from "./sub-issues-agent-working-chip";
+
+function makeTask(overrides: Partial<AgentTask> = {}): AgentTask {
+  return {
+    id: "task-1",
+    agent_id: "agent-1",
+    runtime_id: "runtime-1",
+    issue_id: "child-1",
+    status: "running",
+    priority: 0,
+    dispatched_at: null,
+    started_at: "2026-06-08T08:00:00Z",
+    completed_at: null,
+    result: null,
+    error: null,
+    created_at: "2026-06-08T08:00:00Z",
+    ...overrides,
+  } as AgentTask;
+}
+
+const CHILD_IDS = ["child-1", "child-2"];
+
+beforeEach(() => {
+  cleanup();
+  mockState.snapshot = [makeTask()];
+});
+
+describe("SubIssuesAgentWorkingChip", () => {
+  it("shows a working count aggregated across the given sub-issues", () => {
+    mockState.snapshot = [
+      makeTask({ id: "t1", agent_id: "agent-1", issue_id: "child-1" }),
+      makeTask({ id: "t2", agent_id: "agent-2", issue_id: "child-2" }),
+      // Second task by an already-counted agent — counts agents, not tasks.
+      makeTask({ id: "t3", agent_id: "agent-2", issue_id: "child-1" }),
+      // Unrelated issue — must not leak into the aggregate.
+      makeTask({ id: "t4", agent_id: "agent-3", issue_id: "other-issue" }),
+    ];
+
+    render(<SubIssuesAgentWorkingChip issueIds={CHILD_IDS} />);
+
+    expect(screen.getByText("agent_activity.chip_agents_working:2")).not.toBeNull();
+    expect(screen.getByTestId("agent-avatar-stack").textContent).toBe("2");
+  });
+
+  it("falls back to a muted queued state when nothing is running", () => {
+    mockState.snapshot = [
+      makeTask({ id: "t1", agent_id: "agent-1", status: "queued" }),
+    ];
+
+    render(<SubIssuesAgentWorkingChip issueIds={CHILD_IDS} />);
+
+    expect(screen.getByText("agent_activity.hover_header_queued:1")).not.toBeNull();
+    expect(screen.getByTestId("agent-avatar-stack").getAttribute("data-opacity")).toBe(
+      "half",
+    );
+  });
+
+  it("wraps the chip in a hover card listing every active task", () => {
+    mockState.snapshot = [
+      makeTask({ id: "t1", agent_id: "agent-1", issue_id: "child-1" }),
+      makeTask({ id: "t2", agent_id: "agent-2", issue_id: "child-2", status: "queued" }),
+    ];
+
+    render(<SubIssuesAgentWorkingChip issueIds={CHILD_IDS} />);
+
+    expect(screen.getByTestId("hover-card")).not.toBeNull();
+    expect(screen.getByTestId("activity-hover").textContent).toBe("2");
+  });
+
+  it("renders nothing when no agent is on any sub-issue", () => {
+    mockState.snapshot = [
+      makeTask({ id: "t1", issue_id: "other-issue" }),
+      // Terminal statuses belong to history, not the live chip.
+      makeTask({ id: "t2", issue_id: "child-1", status: "completed" }),
+    ];
+
+    const { container } = render(
+      <SubIssuesAgentWorkingChip issueIds={CHILD_IDS} />,
+    );
+
+    expect(container.firstChild).toBeNull();
+  });
+});

--- a/packages/views/issues/components/sub-issues-agent-working-chip.test.tsx
+++ b/packages/views/issues/components/sub-issues-agent-working-chip.test.tsx
@@ -1,9 +1,10 @@
 import { cleanup, render, screen } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import type { AgentTask } from "@multica/core/types";
+import type { WorkspaceWorkingAgent } from "@multica/core/types";
 
 const mockState = vi.hoisted(() => ({
-  snapshot: [] as unknown[],
+  agents: [] as WorkspaceWorkingAgent[],
+  optionsCalls: [] as unknown[][],
 }));
 
 vi.mock("@multica/core/hooks", () => ({
@@ -11,29 +12,24 @@ vi.mock("@multica/core/hooks", () => ({
 }));
 
 vi.mock("@multica/core/agents", () => ({
-  agentTaskSnapshotOptions: (wsId: string) => ({
-    queryKey: ["agents", "task-snapshot", wsId],
-  }),
+  workspaceWorkingAgentsOptions: (...args: unknown[]) => {
+    mockState.optionsCalls.push(args);
+    return { queryKey: ["working-agents", ...args] };
+  },
 }));
 
 vi.mock("../../agents/components/agent-avatar-stack", () => ({
-  AgentAvatarStack: ({
-    agentIds,
-    opacity,
-  }: {
-    agentIds: string[];
-    opacity?: string;
-  }) => (
-    <div data-testid="agent-avatar-stack" data-opacity={opacity}>
-      {agentIds.length}
-    </div>
+  AgentAvatarStack: ({ agentIds }: { agentIds: string[] }) => (
+    <div data-testid="agent-avatar-stack">{agentIds.join(",")}</div>
   ),
 }));
 
-vi.mock("../../agents/components/agent-activity-hover-content", () => ({
-  AgentActivityHoverContent: ({ tasks }: { tasks: AgentTask[] }) => (
-    <div data-testid="activity-hover">{tasks.length}</div>
-  ),
+vi.mock("./workspace-agent-working-chip", () => ({
+  WorkingAgentsHoverContent: ({
+    agents,
+  }: {
+    agents: readonly WorkspaceWorkingAgent[];
+  }) => <div data-testid="hover-body">{agents.length}</div>,
 }));
 
 vi.mock("../../i18n", () => ({
@@ -76,102 +72,79 @@ vi.mock("@tanstack/react-query", async () => {
     await vi.importActual<typeof import("@tanstack/react-query")>(
       "@tanstack/react-query",
     );
-  return {
-    ...actual,
-    useQuery: (opts: {
-      queryKey?: readonly unknown[];
-      select?: (data: unknown) => unknown;
-    }) => {
-      if (opts.queryKey?.[1] === "task-snapshot") {
-        return {
-          data: opts.select
-            ? opts.select(mockState.snapshot)
-            : mockState.snapshot,
-        };
-      }
-      return { data: undefined };
-    },
-  };
+  return { ...actual, useQuery: () => ({ data: mockState.agents }) };
 });
 
 import { SubIssuesAgentWorkingChip } from "./sub-issues-agent-working-chip";
 
-function makeTask(overrides: Partial<AgentTask> = {}): AgentTask {
+function makeAgent(
+  overrides: Partial<WorkspaceWorkingAgent> = {},
+): WorkspaceWorkingAgent {
   return {
-    id: "task-1",
-    agent_id: "agent-1",
-    runtime_id: "runtime-1",
-    issue_id: "child-1",
-    status: "running",
-    priority: 0,
-    dispatched_at: null,
-    started_at: "2026-06-08T08:00:00Z",
-    completed_at: null,
-    result: null,
-    error: null,
-    created_at: "2026-06-08T08:00:00Z",
+    id: "agent-1",
+    name: "Agent One",
+    avatar_url: null,
+    running_task_count: 1,
+    issue_ids: ["child-1"],
     ...overrides,
-  } as AgentTask;
+  };
 }
-
-const CHILD_IDS = ["child-1", "child-2"];
 
 beforeEach(() => {
   cleanup();
-  mockState.snapshot = [makeTask()];
+  mockState.agents = [];
+  mockState.optionsCalls = [];
 });
 
 describe("SubIssuesAgentWorkingChip", () => {
-  it("shows a working count aggregated across the given sub-issues", () => {
-    mockState.snapshot = [
-      makeTask({ id: "t1", agent_id: "agent-1", issue_id: "child-1" }),
-      makeTask({ id: "t2", agent_id: "agent-2", issue_id: "child-2" }),
-      // Second task by an already-counted agent — counts agents, not tasks.
-      makeTask({ id: "t3", agent_id: "agent-2", issue_id: "child-1" }),
-      // Unrelated issue — must not leak into the aggregate.
-      makeTask({ id: "t4", agent_id: "agent-3", issue_id: "other-issue" }),
-    ];
+  it("asks the server to narrow the projection to the parent's children", () => {
+    mockState.agents = [makeAgent()];
 
-    render(<SubIssuesAgentWorkingChip issueIds={CHILD_IDS} />);
+    render(<SubIssuesAgentWorkingChip parentIssueId="parent-1" />);
 
-    expect(screen.getByText("agent_activity.chip_agents_working:2")).not.toBeNull();
-    expect(screen.getByTestId("agent-avatar-stack").textContent).toBe("2");
+    // type=issue plus the parent id, and no My Issues relation. Getting this
+    // wrong silently widens the chip to the whole workspace.
+    expect(mockState.optionsCalls).toEqual([
+      ["ws-1", "issue", undefined, "parent-1"],
+    ]);
   });
 
-  it("falls back to a muted queued state when nothing is running", () => {
-    mockState.snapshot = [
-      makeTask({ id: "t1", agent_id: "agent-1", status: "queued" }),
+  it("counts the agents the server returned", () => {
+    mockState.agents = [
+      makeAgent({ id: "agent-1", issue_ids: ["child-1"] }),
+      makeAgent({ id: "agent-2", issue_ids: ["child-2"] }),
     ];
 
-    render(<SubIssuesAgentWorkingChip issueIds={CHILD_IDS} />);
+    render(<SubIssuesAgentWorkingChip parentIssueId="parent-1" />);
 
-    expect(screen.getByText("agent_activity.hover_header_queued:1")).not.toBeNull();
-    expect(screen.getByTestId("agent-avatar-stack").getAttribute("data-opacity")).toBe(
-      "half",
+    expect(
+      screen.getByText("agent_activity.chip_agents_working:2"),
+    ).not.toBeNull();
+    expect(screen.getByTestId("agent-avatar-stack").textContent).toBe(
+      "agent-1,agent-2",
     );
   });
 
-  it("wraps the chip in a hover card listing every active task", () => {
-    mockState.snapshot = [
-      makeTask({ id: "t1", agent_id: "agent-1", issue_id: "child-1" }),
-      makeTask({ id: "t2", agent_id: "agent-2", issue_id: "child-2", status: "queued" }),
+  it("hands the same agents to the hover body as it counted", () => {
+    mockState.agents = [
+      makeAgent({ id: "agent-1" }),
+      makeAgent({ id: "agent-2" }),
+      makeAgent({ id: "agent-3" }),
     ];
 
-    render(<SubIssuesAgentWorkingChip issueIds={CHILD_IDS} />);
+    render(<SubIssuesAgentWorkingChip parentIssueId="parent-1" />);
 
-    expect(screen.getByTestId("hover-card")).not.toBeNull();
-    expect(screen.getByTestId("activity-hover").textContent).toBe("2");
+    // The number and the hover body must never disagree — they are the same
+    // list, not two derivations of one snapshot.
+    expect(
+      screen.getByText("agent_activity.chip_agents_working:3"),
+    ).not.toBeNull();
+    expect(screen.getByTestId("hover-body").textContent).toBe("3");
   });
 
-  it("renders nothing when no agent is on any sub-issue", () => {
-    mockState.snapshot = [
-      makeTask({ id: "t1", issue_id: "other-issue" }),
-      // Terminal statuses belong to history, not the live chip.
-      makeTask({ id: "t2", issue_id: "child-1", status: "completed" }),
-    ];
-
+  it("renders nothing when no agent is working on a sub-issue", () => {
     const { container } = render(
-      <SubIssuesAgentWorkingChip issueIds={CHILD_IDS} />,
+      <SubIssuesAgentWorkingChip parentIssueId="parent-1" />,
     );
 
     expect(container.firstChild).toBeNull();

--- a/packages/views/issues/components/sub-issues-agent-working-chip.tsx
+++ b/packages/views/issues/components/sub-issues-agent-working-chip.tsx
@@ -1,0 +1,113 @@
+"use client";
+
+import { memo, useCallback, useMemo } from "react";
+import { useQuery } from "@tanstack/react-query";
+import {
+  HoverCard,
+  HoverCardTrigger,
+  HoverCardContent,
+} from "@multica/ui/components/ui/hover-card";
+import { useWorkspaceId } from "@multica/core/hooks";
+import { agentTaskSnapshotOptions } from "@multica/core/agents";
+import type { AgentTask } from "@multica/core/types";
+import { cn } from "@multica/ui/lib/utils";
+import { AgentAvatarStack } from "../../agents/components/agent-avatar-stack";
+import { AgentActivityHoverContent } from "../../agents/components/agent-activity-hover-content";
+import { selectIssuesTasks, type IssueTaskGroups } from "../surface/activity";
+import { useT } from "../../i18n";
+
+const EMPTY_GROUPS: IssueTaskGroups = { running: [], queued: [] };
+
+interface SubIssuesAgentWorkingChipProps {
+  /**
+   * Sub-issue ids to aggregate over. Callers must pass a memoized array —
+   * the id Set (and with it the query select) is rebuilt on identity change.
+   */
+  issueIds: readonly string[];
+}
+
+/**
+ * Aggregate "N agents working" chip for the sub-issues header in issue
+ * detail (multica#5825). The per-row IssueAgentActivityIndicator answers
+ * "which sub-issue is being worked on"; this chip answers "how many agents
+ * are on this parent's children right now" without scanning the rows — and
+ * keeps that signal visible while the list is collapsed.
+ *
+ * Same data path as the row indicators: the one shared workspace agent-task
+ * snapshot, narrowed with a select over the children's ids so only changes
+ * to their own tasks re-render the header (see selectIssuesTasks).
+ *
+ *   - ≥1 running task → avatar stack + shimmering "N agents working"
+ *   - queued only     → half-opacity stack + muted "N agents queued"
+ *   - nothing         → null (no chrome, matching the row indicator)
+ *
+ * N counts unique agents, not tasks, matching the workspace chip whose
+ * locale strings this reuses (`chip_agents_working` / `hover_header_queued`
+ * ship in every locale already). Hovering lists each active task via the
+ * shared activity card; default open delay is fine here — this is one
+ * header chip the user aims at, not a per-row cue (cf. the 900ms rationale
+ * in issue-agent-activity-indicator.tsx).
+ */
+export const SubIssuesAgentWorkingChip = memo(function SubIssuesAgentWorkingChip({
+  issueIds,
+}: SubIssuesAgentWorkingChipProps) {
+  const { t } = useT("issues");
+  const wsId = useWorkspaceId();
+  const idSet = useMemo(() => new Set(issueIds), [issueIds]);
+  const select = useCallback(
+    (snapshot: AgentTask[]) => selectIssuesTasks(snapshot, idSet),
+    [idSet],
+  );
+  const { data: groups = EMPTY_GROUPS } = useQuery({
+    ...agentTaskSnapshotOptions(wsId),
+    select,
+  });
+
+  const { agentIds, isRunning } = useMemo(() => {
+    // Prefer running agents for the stack; fall back to queued so a
+    // queued-only state still offers faces to hover.
+    const primary = groups.running.length > 0 ? groups.running : groups.queued;
+    return {
+      agentIds: [...new Set(primary.map((task) => task.agent_id))],
+      isRunning: groups.running.length > 0,
+    };
+  }, [groups]);
+
+  if (agentIds.length === 0) return null;
+
+  const hoverTasks = [...groups.running, ...groups.queued];
+
+  return (
+    <HoverCard>
+      <HoverCardTrigger
+        render={
+          <span className="inline-flex shrink-0 items-center gap-1.5 rounded-full bg-muted/60 px-2 py-0.5" />
+        }
+      >
+        <AgentAvatarStack
+          agentIds={agentIds}
+          size="xs"
+          opacity={isRunning ? "full" : "half"}
+          max={3}
+        />
+        <span
+          className={cn(
+            "text-[11px] leading-none tabular-nums font-medium",
+            isRunning ? "animate-chat-text-shimmer" : "text-muted-foreground",
+          )}
+        >
+          {isRunning
+            ? t(($) => $.agent_activity.chip_agents_working, {
+                count: agentIds.length,
+              })
+            : t(($) => $.agent_activity.hover_header_queued, {
+                count: agentIds.length,
+              })}
+        </span>
+      </HoverCardTrigger>
+      <HoverCardContent align="start" className="w-72">
+        <AgentActivityHoverContent tasks={hoverTasks} />
+      </HoverCardContent>
+    </HoverCard>
+  );
+});

--- a/packages/views/issues/components/sub-issues-agent-working-chip.tsx
+++ b/packages/views/issues/components/sub-issues-agent-working-chip.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { memo, useCallback, useMemo } from "react";
+import { memo } from "react";
 import { useQuery } from "@tanstack/react-query";
 import {
   HoverCard,
@@ -8,22 +8,14 @@ import {
   HoverCardContent,
 } from "@multica/ui/components/ui/hover-card";
 import { useWorkspaceId } from "@multica/core/hooks";
-import { agentTaskSnapshotOptions } from "@multica/core/agents";
-import type { AgentTask } from "@multica/core/types";
-import { cn } from "@multica/ui/lib/utils";
+import { workspaceWorkingAgentsOptions } from "@multica/core/agents";
 import { AgentAvatarStack } from "../../agents/components/agent-avatar-stack";
-import { AgentActivityHoverContent } from "../../agents/components/agent-activity-hover-content";
-import { selectIssuesTasks, type IssueTaskGroups } from "../surface/activity";
+import { WorkingAgentsHoverContent } from "./workspace-agent-working-chip";
 import { useT } from "../../i18n";
 
-const EMPTY_GROUPS: IssueTaskGroups = { running: [], queued: [] };
-
 interface SubIssuesAgentWorkingChipProps {
-  /**
-   * Sub-issue ids to aggregate over. Callers must pass a memoized array —
-   * the id Set (and with it the query select) is rebuilt on identity change.
-   */
-  issueIds: readonly string[];
+  /** Parent issue whose direct children this chip aggregates over. */
+  parentIssueId: string;
 }
 
 /**
@@ -33,81 +25,49 @@ interface SubIssuesAgentWorkingChipProps {
  * are on this parent's children right now" without scanning the rows — and
  * keeps that signal visible while the list is collapsed.
  *
- * Same data path as the row indicators: the one shared workspace agent-task
- * snapshot, narrowed with a select over the children's ids so only changes
- * to their own tasks re-render the header (see selectIssuesTasks).
+ * It reads the same /api/working-agents projection as the Issues list header,
+ * narrowed with `parent`. That is deliberate: a header count is a claim about
+ * a scope, so the server owns both the scope and the arithmetic, exactly as
+ * it does for the Issues list. Deriving it here from the workspace task
+ * snapshot would put a second definition of "working" in the client, and the
+ * count and the hover body would each have to re-derive it.
  *
- *   - ≥1 running task → avatar stack + shimmering "N agents working"
- *   - queued only     → half-opacity stack + muted "N agents queued"
- *   - nothing         → null (no chrome, matching the row indicator)
- *
- * N counts unique agents, not tasks, matching the workspace chip whose
- * locale strings this reuses (`chip_agents_working` / `hover_header_queued`
- * ship in every locale already). Hovering lists each active task via the
- * shared activity card; default open delay is fine here — this is one
- * header chip the user aims at, not a per-row cue (cf. the 900ms rationale
- * in issue-agent-activity-indicator.tsx).
+ * Row indicators keep reading the snapshot — one shared query sliced per row
+ * is the right shape for a per-row cue, and a stale row decoration costs
+ * nothing. A header number is the opposite: it has to be authoritative.
  */
-export const SubIssuesAgentWorkingChip = memo(function SubIssuesAgentWorkingChip({
-  issueIds,
-}: SubIssuesAgentWorkingChipProps) {
-  const { t } = useT("issues");
-  const wsId = useWorkspaceId();
-  const idSet = useMemo(() => new Set(issueIds), [issueIds]);
-  const select = useCallback(
-    (snapshot: AgentTask[]) => selectIssuesTasks(snapshot, idSet),
-    [idSet],
-  );
-  const { data: groups = EMPTY_GROUPS } = useQuery({
-    ...agentTaskSnapshotOptions(wsId),
-    select,
-  });
+export const SubIssuesAgentWorkingChip = memo(
+  function SubIssuesAgentWorkingChip({
+    parentIssueId,
+  }: SubIssuesAgentWorkingChipProps) {
+    const { t } = useT("issues");
+    const wsId = useWorkspaceId();
+    const { data: agents = [] } = useQuery(
+      workspaceWorkingAgentsOptions(wsId, "issue", undefined, parentIssueId),
+    );
 
-  const { agentIds, isRunning } = useMemo(() => {
-    // Prefer running agents for the stack; fall back to queued so a
-    // queued-only state still offers faces to hover.
-    const primary = groups.running.length > 0 ? groups.running : groups.queued;
-    return {
-      agentIds: [...new Set(primary.map((task) => task.agent_id))],
-      isRunning: groups.running.length > 0,
-    };
-  }, [groups]);
+    if (agents.length === 0) return null;
 
-  if (agentIds.length === 0) return null;
+    const agentIds = agents.map((agent) => agent.id);
 
-  const hoverTasks = [...groups.running, ...groups.queued];
-
-  return (
-    <HoverCard>
-      <HoverCardTrigger
-        render={
-          <span className="inline-flex shrink-0 items-center gap-1.5 rounded-full bg-muted/60 px-2 py-0.5" />
-        }
-      >
-        <AgentAvatarStack
-          agentIds={agentIds}
-          size="xs"
-          opacity={isRunning ? "full" : "half"}
-          max={3}
-        />
-        <span
-          className={cn(
-            "text-[11px] leading-none tabular-nums font-medium",
-            isRunning ? "animate-chat-text-shimmer" : "text-muted-foreground",
-          )}
+    return (
+      <HoverCard>
+        <HoverCardTrigger
+          render={
+            <span className="inline-flex shrink-0 items-center gap-1.5 rounded-full bg-muted/60 px-2 py-0.5" />
+          }
         >
-          {isRunning
-            ? t(($) => $.agent_activity.chip_agents_working, {
-                count: agentIds.length,
-              })
-            : t(($) => $.agent_activity.hover_header_queued, {
-                count: agentIds.length,
-              })}
-        </span>
-      </HoverCardTrigger>
-      <HoverCardContent align="start" className="w-72">
-        <AgentActivityHoverContent tasks={hoverTasks} />
-      </HoverCardContent>
-    </HoverCard>
-  );
-});
+          <AgentAvatarStack agentIds={agentIds} size="xs" max={3} />
+          <span className="animate-chat-text-shimmer text-[11px] font-medium leading-none tabular-nums">
+            {t(($) => $.agent_activity.chip_agents_working, {
+              count: agentIds.length,
+            })}
+          </span>
+        </HoverCardTrigger>
+        <HoverCardContent align="start" className="w-72">
+          <WorkingAgentsHoverContent agents={agents} />
+        </HoverCardContent>
+      </HoverCard>
+    );
+  },
+);

--- a/packages/views/issues/components/workspace-agent-working-chip.tsx
+++ b/packages/views/issues/components/workspace-agent-working-chip.tsx
@@ -38,7 +38,13 @@ export function chipAppearance(
   return { variant: "outline", className: `${layout} text-muted-foreground` };
 }
 
-function WorkingAgentsHoverContent({
+/**
+ * Hover body for every surface that reads the working-agents projection —
+ * the workspace filter chip here and the sub-issues header chip on issue
+ * detail. Shared so a narrowed read and an unnarrowed one describe activity
+ * the same way; the only difference between the two is the query's scope.
+ */
+export function WorkingAgentsHoverContent({
   agents,
 }: {
   agents: readonly WorkspaceWorkingAgent[];

--- a/packages/views/issues/surface/activity.ts
+++ b/packages/views/issues/surface/activity.ts
@@ -54,6 +54,26 @@ export function selectIssueTasks(
   return { running, queued };
 }
 
+/**
+ * Multi-issue variant of `selectIssueTasks`: one slice covering a set of
+ * issues (a parent's sub-issues). Same structural-sharing contract — pass a
+ * stable Set and keep the wrapping select's identity stable upstream so
+ * unrelated snapshot changes don't re-render the subscriber.
+ */
+export function selectIssuesTasks(
+  snapshot: readonly AgentTask[],
+  issueIds: ReadonlySet<string>,
+): IssueTaskGroups {
+  const running: AgentTask[] = [];
+  const queued: AgentTask[] = [];
+  for (const task of snapshot) {
+    if (!task.issue_id || !issueIds.has(task.issue_id)) continue;
+    if (task.status === "running") running.push(task);
+    else if (isQueuedTaskStatus(task.status)) queued.push(task);
+  }
+  return { running, queued };
+}
+
 export function deriveIssueSurfaceActivity(
   tasks: readonly AgentTask[],
 ): IssueSurfaceActivity {

--- a/packages/views/issues/surface/activity.ts
+++ b/packages/views/issues/surface/activity.ts
@@ -54,26 +54,6 @@ export function selectIssueTasks(
   return { running, queued };
 }
 
-/**
- * Multi-issue variant of `selectIssueTasks`: one slice covering a set of
- * issues (a parent's sub-issues). Same structural-sharing contract — pass a
- * stable Set and keep the wrapping select's identity stable upstream so
- * unrelated snapshot changes don't re-render the subscriber.
- */
-export function selectIssuesTasks(
-  snapshot: readonly AgentTask[],
-  issueIds: ReadonlySet<string>,
-): IssueTaskGroups {
-  const running: AgentTask[] = [];
-  const queued: AgentTask[] = [];
-  for (const task of snapshot) {
-    if (!task.issue_id || !issueIds.has(task.issue_id)) continue;
-    if (task.status === "running") running.push(task);
-    else if (isQueuedTaskStatus(task.status)) queued.push(task);
-  }
-  return { running, queued };
-}
-
 export function deriveIssueSurfaceActivity(
   tasks: readonly AgentTask[],
 ): IssueSurfaceActivity {

--- a/packages/views/issues/surface/use-issue-surface-controller.test.tsx
+++ b/packages/views/issues/surface/use-issue-surface-controller.test.tsx
@@ -858,7 +858,7 @@ describe("useIssueSurfaceController", () => {
     );
     expect(result.current.tableQuerySpec.filters.assignees).toBeUndefined();
     expect(result.current.tableQuerySpec.filters.working_only).toBeUndefined();
-    expect(getWorkspaceWorkingAgents).toHaveBeenCalledWith("issue", undefined);
+    expect(getWorkspaceWorkingAgents).toHaveBeenCalledWith("issue", undefined, undefined);
     expect(listIssues).not.toHaveBeenCalled();
   });
 
@@ -891,6 +891,7 @@ describe("useIssueSurfaceController", () => {
       expect(getWorkspaceWorkingAgents).toHaveBeenCalledWith(
         "issue",
         "assigned",
+        undefined,
       ),
     );
     expect(result.current.tableQuerySpec.filters.working_issue_ids).toEqual([]);
@@ -927,7 +928,7 @@ describe("useIssueSurfaceController", () => {
       );
       expect(result.current.tableQuerySpec.filters.assignees).toBeUndefined();
       expect(result.current.tableQuerySpec.filters.working_only).toBeUndefined();
-      expect(getWorkspaceWorkingAgents).toHaveBeenCalledWith("issue", undefined);
+      expect(getWorkspaceWorkingAgents).toHaveBeenCalledWith("issue", undefined, undefined);
       expect(getAgentTaskSnapshot).not.toHaveBeenCalled();
     },
   );
@@ -1336,7 +1337,7 @@ describe("useIssueSurfaceController", () => {
 
     await waitFor(() => expect(result.current.isLoading).toBe(false));
     expect(result.current.workingScopeIssues).toEqual([]);
-    expect(getWorkspaceWorkingAgents).toHaveBeenCalledWith("issue", undefined);
+    expect(getWorkspaceWorkingAgents).toHaveBeenCalledWith("issue", undefined, undefined);
     expect(getAgentTaskSnapshot).not.toHaveBeenCalled();
   });
 
@@ -1508,6 +1509,7 @@ describe("useIssueSurfaceController", () => {
     await waitFor(() =>
       expect(getWorkspaceWorkingAgents).toHaveBeenCalledWith(
         "issue",
+        undefined,
         undefined,
       ),
     );

--- a/server/internal/handler/agent.go
+++ b/server/internal/handler/agent.go
@@ -2188,13 +2188,36 @@ func (h *Handler) ListWorkspaceWorkingAgents(w http.ResponseWriter, r *http.Requ
 		return
 	}
 
+	// Narrows the projection to one issue's direct children, so an issue
+	// detail's sub-issue header reads this endpoint instead of deriving a
+	// count client-side. Left zero when absent, which the query treats as
+	// NULL and therefore as "no narrowing" — an older client that never
+	// sends it keeps the exact workspace-wide behaviour.
+	var parentIssueID pgtype.UUID
+	if raw := strings.TrimSpace(r.URL.Query().Get("parent")); raw != "" {
+		if workType != "issue" {
+			writeError(w, http.StatusBadRequest, "parent requires type=issue")
+			return
+		}
+		if scope != "" {
+			writeError(w, http.StatusBadRequest, "parent cannot be combined with scope")
+			return
+		}
+		var ok bool
+		parentIssueID, ok = parseUUIDOrBadRequest(w, raw, "parent")
+		if !ok {
+			return
+		}
+	}
+
 	rows, err := h.Queries.ListWorkspaceWorkingAgents(
 		r.Context(),
 		db.ListWorkspaceWorkingAgentsParams{
-			WorkspaceID:  parseUUID(workspaceID),
-			WorkType:     workType,
-			MineRelation: mineRelation,
-			MemberID:     memberID,
+			WorkspaceID:   parseUUID(workspaceID),
+			WorkType:      workType,
+			MineRelation:  mineRelation,
+			MemberID:      memberID,
+			ParentIssueID: parentIssueID,
 		},
 	)
 	if err != nil {

--- a/server/internal/handler/agent_test.go
+++ b/server/internal/handler/agent_test.go
@@ -527,6 +527,9 @@ func TestListWorkspaceWorkingAgentsRejectsInvalidFilters(t *testing.T) {
 		"/api/working-agents?type=issue&scope=workspace",
 		"/api/working-agents?type=issue&relation=assigned",
 		"/api/working-agents?type=issue&scope=mine&relation=watching",
+		"/api/working-agents?type=issue&parent=not-a-uuid",
+		"/api/working-agents?type=chat&parent=00000000-0000-0000-0000-000000000000",
+		"/api/working-agents?type=issue&scope=mine&parent=00000000-0000-0000-0000-000000000000",
 	} {
 		t.Run(path, func(t *testing.T) {
 			w := httptest.NewRecorder()
@@ -539,6 +542,151 @@ func TestListWorkspaceWorkingAgentsRejectsInvalidFilters(t *testing.T) {
 			}
 		})
 	}
+}
+
+// The sub-issue header on issue detail reads this endpoint with ?parent=, so
+// the projection must cover exactly one issue's direct children. The final
+// sub-test is the compatibility guard: dropping the parameter has to return
+// the unnarrowed workspace projection, which is what an older installed
+// client keeps sending.
+func TestListWorkspaceWorkingAgentsParentScope(t *testing.T) {
+	if testHandler == nil {
+		t.Skip("database not available")
+	}
+
+	ctx := context.Background()
+	childAgentID := createHandlerTestAgent(t, "working-agents-parent-child", []byte(`{}`))
+	siblingAgentID := createHandlerTestAgent(t, "working-agents-parent-sibling", []byte(`{}`))
+
+	insertedIssueIDs := make([]string, 0, 4)
+	insertIssue := func(title string, parentIssueID any) string {
+		t.Helper()
+		var issueID string
+		if err := testPool.QueryRow(ctx, `
+			INSERT INTO issue (
+				workspace_id, number, title, status, priority,
+				creator_type, creator_id, parent_issue_id
+			)
+			SELECT $1, COALESCE(MIN(number), 0) - 1, $2, 'todo', 'none',
+			       'member', $3, $4
+			FROM issue
+			WHERE workspace_id = $1
+			RETURNING id
+		`, testWorkspaceID, title, testUserID, parentIssueID).Scan(&issueID); err != nil {
+			t.Fatalf("insert issue %q: %v", title, err)
+		}
+		insertedIssueIDs = append(insertedIssueIDs, issueID)
+		return issueID
+	}
+	parentIssueID := insertIssue("working-agents-parent", nil)
+	firstChildID := insertIssue("working-agents-parent-first-child", parentIssueID)
+	secondChildID := insertIssue("working-agents-parent-second-child", parentIssueID)
+	// Same workspace, no parent — must never leak into the narrowed read even
+	// though the same agent is running on it.
+	unrelatedIssueID := insertIssue("working-agents-parent-unrelated", nil)
+	t.Cleanup(func() {
+		for _, issueID := range insertedIssueIDs {
+			testPool.Exec(ctx, `DELETE FROM issue WHERE id = $1`, issueID)
+		}
+	})
+
+	insertedTaskIDs := make([]string, 0, 3)
+	for _, fixture := range []struct {
+		agentID string
+		issueID string
+	}{
+		{childAgentID, firstChildID},
+		{siblingAgentID, secondChildID},
+		{childAgentID, unrelatedIssueID},
+	} {
+		var taskID string
+		if err := testPool.QueryRow(ctx, `
+			INSERT INTO agent_task_queue (
+				agent_id, runtime_id, status, priority, issue_id, started_at
+			)
+			VALUES ($1, $2, 'running', 0, $3, now())
+			RETURNING id
+		`, fixture.agentID, testRuntimeID, fixture.issueID).Scan(&taskID); err != nil {
+			t.Fatalf("insert running task: %v", err)
+		}
+		insertedTaskIDs = append(insertedTaskIDs, taskID)
+	}
+	t.Cleanup(func() {
+		for _, taskID := range insertedTaskIDs {
+			testPool.Exec(ctx, `DELETE FROM agent_task_queue WHERE id = $1`, taskID)
+		}
+	})
+
+	read := func(t *testing.T, query string) map[string]WorkspaceWorkingAgent {
+		t.Helper()
+		w := httptest.NewRecorder()
+		testHandler.ListWorkspaceWorkingAgents(
+			w,
+			newRequest(http.MethodGet, "/api/working-agents"+query, nil),
+		)
+		if w.Code != http.StatusOK {
+			t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+		}
+		var agents []WorkspaceWorkingAgent
+		if err := json.NewDecoder(w.Body).Decode(&agents); err != nil {
+			t.Fatalf("decode response: %v", err)
+		}
+		byID := make(map[string]WorkspaceWorkingAgent, len(agents))
+		for _, agent := range agents {
+			byID[agent.ID] = agent
+		}
+		return byID
+	}
+
+	t.Run("narrows to the parent's direct children", func(t *testing.T) {
+		byID := read(t, "?type=issue&parent="+parentIssueID)
+
+		child, ok := byID[childAgentID]
+		if !ok {
+			t.Fatalf("agent running on a child issue was not returned")
+		}
+		if child.RunningTaskCount != 1 {
+			t.Errorf("running_task_count = %d, want 1", child.RunningTaskCount)
+		}
+		if len(child.IssueIDs) != 1 || child.IssueIDs[0] != firstChildID {
+			t.Errorf("issue_ids = %v, want [%s]", child.IssueIDs, firstChildID)
+		}
+		if _, ok := byID[siblingAgentID]; !ok {
+			t.Errorf("agent running on the second child was not returned")
+		}
+	})
+
+	t.Run("an unrelated issue's parent yields nothing", func(t *testing.T) {
+		byID := read(t, "?type=issue&parent="+unrelatedIssueID)
+
+		if _, ok := byID[childAgentID]; ok {
+			t.Errorf("childless issue must not return the child agent")
+		}
+		if _, ok := byID[siblingAgentID]; ok {
+			t.Errorf("childless issue must not return the sibling agent")
+		}
+	})
+
+	t.Run("omitting parent keeps the workspace projection", func(t *testing.T) {
+		byID := read(t, "?type=issue")
+
+		child, ok := byID[childAgentID]
+		if !ok {
+			t.Fatalf("agent was not returned by the unnarrowed read")
+		}
+		if child.RunningTaskCount != 2 {
+			t.Errorf("running_task_count = %d, want 2", child.RunningTaskCount)
+		}
+		seen := make(map[string]struct{}, len(child.IssueIDs))
+		for _, issueID := range child.IssueIDs {
+			seen[issueID] = struct{}{}
+		}
+		for _, want := range []string{firstChildID, unrelatedIssueID} {
+			if _, ok := seen[want]; !ok {
+				t.Errorf("issue_ids = %v, missing %s", child.IssueIDs, want)
+			}
+		}
+	})
 }
 
 func TestCreateAgent_RejectsDuplicateName(t *testing.T) {

--- a/server/pkg/db/generated/agent.sql.go
+++ b/server/pkg/db/generated/agent.sql.go
@@ -4229,15 +4229,26 @@ WHERE a.workspace_id = $1
         )
     )
   )
+  AND (
+    $5::uuid IS NULL
+    OR EXISTS (
+      SELECT 1
+      FROM issue child
+      WHERE child.id = atq.issue_id
+        AND child.workspace_id = a.workspace_id
+        AND child.parent_issue_id = $5::uuid
+    )
+  )
 GROUP BY a.id, a.name, a.avatar_url, a.created_at
 ORDER BY a.created_at ASC
 `
 
 type ListWorkspaceWorkingAgentsParams struct {
-	WorkspaceID  pgtype.UUID `json:"workspace_id"`
-	WorkType     string      `json:"work_type"`
-	MineRelation string      `json:"mine_relation"`
-	MemberID     pgtype.UUID `json:"member_id"`
+	WorkspaceID   pgtype.UUID `json:"workspace_id"`
+	WorkType      string      `json:"work_type"`
+	MineRelation  string      `json:"mine_relation"`
+	MemberID      pgtype.UUID `json:"member_id"`
+	ParentIssueID pgtype.UUID `json:"parent_issue_id"`
 }
 
 type ListWorkspaceWorkingAgentsRow struct {
@@ -4256,13 +4267,17 @@ type ListWorkspaceWorkingAgentsRow struct {
 // comment-triggered issue work. Quick-create work is present only in the
 // unfiltered projection because it has no source FK yet. mine_relation is
 // optional (empty = workspace); when set it narrows issue work to the
-// authenticated member's My Issues relation.
+// authenticated member's My Issues relation. parent_issue_id is optional
+// (NULL = workspace); when set it narrows issue work to the direct children
+// of that issue, so an issue detail's sub-issue header reads the same
+// projection as the Issues list header instead of deriving its own count.
 func (q *Queries) ListWorkspaceWorkingAgents(ctx context.Context, arg ListWorkspaceWorkingAgentsParams) ([]ListWorkspaceWorkingAgentsRow, error) {
 	rows, err := q.db.Query(ctx, listWorkspaceWorkingAgents,
 		arg.WorkspaceID,
 		arg.WorkType,
 		arg.MineRelation,
 		arg.MemberID,
+		arg.ParentIssueID,
 	)
 	if err != nil {
 		return nil, err

--- a/server/pkg/db/queries/agent.sql
+++ b/server/pkg/db/queries/agent.sql
@@ -1369,7 +1369,10 @@ SELECT t.* FROM (
 -- comment-triggered issue work. Quick-create work is present only in the
 -- unfiltered projection because it has no source FK yet. mine_relation is
 -- optional (empty = workspace); when set it narrows issue work to the
--- authenticated member's My Issues relation.
+-- authenticated member's My Issues relation. parent_issue_id is optional
+-- (NULL = workspace); when set it narrows issue work to the direct children
+-- of that issue, so an issue detail's sub-issue header reads the same
+-- projection as the Issues list header instead of deriving its own count.
 SELECT
   a.id,
   a.name,
@@ -1469,6 +1472,16 @@ WHERE a.workspace_id = $1
             )
           )
         )
+    )
+  )
+  AND (
+    @parent_issue_id::uuid IS NULL
+    OR EXISTS (
+      SELECT 1
+      FROM issue child
+      WHERE child.id = atq.issue_id
+        AND child.workspace_id = a.workspace_id
+        AND child.parent_issue_id = @parent_issue_id::uuid
     )
   )
 GROUP BY a.id, a.name, a.avatar_url, a.created_at


### PR DESCRIPTION
Closes #5825 — a parent issue could not tell you whether any agent was working on its children without scanning every row, and told you nothing at all once the list was collapsed.

## What you get

A live **"N agents working"** chip next to the sub-issues progress ring (`1/7`). Avatar stack + shimmering count while agents are running, nothing at all when idle, and a hover card listing who is working. It stays visible when the sub-issue list is collapsed — that is the thing the per-row indicators from #5721 structurally cannot give you.

## How it is designed, and why

### The chip is a scope, not a new concept

Four surfaces already show "an agent is working here": the Issues list header, an issue's own header, each sub-issue row, and now this. They are one question — *given a set of issues, which agents are working on them right now* — parameterised by **which set**.

The Issues list header already answers it the right way. It asks the server (`GET /api/working-agents`), the server counts, and the returned `issue_ids` double as the filter predicate. One request, two uses, so its number and its filtered result can never disagree.

This chip is the same question with a different set: *this parent's children*. So it asks the same endpoint, narrowed with `parent`:

```
GET /api/working-agents?type=issue&parent=<issue-id>
```

`ListWorkspaceWorkingAgents` grows an optional `parent_issue_id` predicate alongside the existing `mine_relation` one. Scope stays a single axis owned by one place.

### Why not derive it in the client

The first cut of this chip sliced the workspace agent-task snapshot by the children's ids and counted locally. That put a second definition of "working" in the client, and it broke immediately: the number came from running tasks only while the hover body listed running **plus** queued. A parent with 2 running and 3 queued agents rendered **"2 agents working"** above a **five-row** hover card.

That is not a missing filter, it is two derivations of one snapshot drifting apart. Reading the server projection makes the number, the avatars and the hover body literally the same list — the class of bug is gone, not patched.

### Why the row indicators still read the snapshot

They should. One shared query sliced per row is exactly right for a per-row cue, and a stale row decoration costs nothing. A header number is the opposite: it is an assertion about a scope, so it has to be authoritative. The dividing line is now explicit — **per-row decoration reads the snapshot, header counts ask the server.**

### What was deliberately left out

- **Click-to-filter.** The Issues header chip filters because that list has hundreds of rows. A sub-issue list is a handful, fully on screen — filtering it buys nothing.
- **Queued agents.** The endpoint counts `status = 'running'` only, and this PR does not change that. The chip therefore drops its former "N agents queued" state, which is the price of matching the Issues header exactly. The per-row indicators still show queued, so the information is not lost — it just is not aggregated into a header number. Whether queued should count as "working" is one product decision for both surfaces, worth its own change.
- **Mobile.** `packages/views` is web + desktop; mobile owns its UI.

## Compatibility

Additive and one-directional, which is the direction that matters — servers lead, installed clients follow.

Omit `parent` and both the SQL and the response are byte-for-byte what they were, so a desktop build that predates this keeps the workspace-wide behaviour with no error path. `TestListWorkspaceWorkingAgentsParentScope/omitting_parent_keeps_the_workspace_projection` pins exactly that. The response shape is unchanged, so no schema work.

## Test plan

- [x] `go test ./internal/handler -run TestListWorkspaceWorkingAgents -count=1 -v` — new `ParentScope` test: narrows to direct children, an unrelated parent yields nothing, and the omitted-parameter regression guard. Three invalid-filter cases added (bad uuid, `type=chat`, `scope=mine` + `parent`).
- [x] `pnpm typecheck` — 6/6 packages
- [x] `pnpm --filter @multica/views exec vitest run issues/` — 51 files, 481 tests
- [x] `pnpm --filter @multica/core exec vitest run api/ agents/` — 120 tests
- [x] Rebased onto `main` (was 66 commits behind), no conflicts

Pre-existing on this branch and untouched here: `TestDeleteMember_CancelsTasksFromAgentReassignment` fails with and without the server changes in this PR (verified by stashing them).

🤖 Generated with [Claude Code](https://claude.com/claude-code)