### PR TITLE
MUL-5222: fix(agent): stop double-counting Grok cached input tokens

### DIFF
--- a/server/pkg/agent/grok_test.go
+++ b/server/pkg/agent/grok_test.go
@@ -610,7 +610,10 @@ func TestGrokPropagatesMCPAndUsage(t *testing.T) {
 	if !ok {
 		t.Fatalf("usage missing grok-4.5 key: %+v", result.Usage)
 	}
-	if usage.InputTokens != 120 || usage.OutputTokens != 30 || usage.CacheReadTokens != 20 {
+	// The fixture's totalTokens (150) equals input + output, so its 20 cached
+	// reads sit inside inputTokens and are billed once: input is stored as the
+	// uncached remainder 120 - 20 = 100.
+	if usage.InputTokens != 100 || usage.OutputTokens != 30 || usage.CacheReadTokens != 20 {
 		t.Fatalf("unexpected usage: %+v", usage)
 	}
 }

--- a/server/pkg/agent/hermes.go
+++ b/server/pkg/agent/hermes.go
@@ -1649,7 +1649,7 @@ func parseACPTokenUsage(data json.RawMessage) TokenUsage {
 	if err := json.Unmarshal(data, &fields); err != nil {
 		return TokenUsage{}
 	}
-	return TokenUsage{
+	usage := TokenUsage{
 		InputTokens:  acpUsageInt64(fields, "inputTokens", "input_tokens"),
 		OutputTokens: acpUsageInt64(fields, "outputTokens", "output_tokens"),
 		CacheReadTokens: acpUsageInt64(fields,
@@ -1666,6 +1666,37 @@ func parseACPTokenUsage(data json.RawMessage) TokenUsage {
 			"cache_creation_input_tokens",
 		),
 	}
+	return excludeACPCachedInput(usage, acpUsageInt64(fields, "totalTokens", "total_tokens"))
+}
+
+// excludeACPCachedInput re-buckets a usage record whose `inputTokens` already
+// contains `cachedReadTokens`, so the persisted buckets stay mutually
+// exclusive and dashboard cost math does not charge the cached prefix twice
+// (same normalization codex.go applies via codexUncachedInputTokens).
+//
+// ACP does not specify whether cached reads are counted inside inputTokens.
+// Grok Build counts them inside: a real `grok 0.2.106` turn reports
+// inputTokens=12929, cachedReadTokens=10880, outputTokens=29,
+// totalTokens=12958 — i.e. total == input + output, so the cached prefix is
+// counted once, within input. The same payload's costUsdTicks=75360000
+// ($0.007536) matches exactly (12929-10880) uncached input + 10880 cached
+// read + 29 output at xAI's published grok-4.5 rates, confirming how xAI
+// bills it. Kept raw, that turn is priced as if 12929 tokens were uncached —
+// ~4x the real spend on a cache-heavy turn.
+//
+// `totalTokens` is the only self-describing signal available, so the
+// re-bucketing only happens when it is present and equals input + output.
+// Agents that report exclusive buckets (total == input + cached + output) or
+// omit totalTokens keep their counters untouched.
+func excludeACPCachedInput(usage TokenUsage, totalTokens int64) TokenUsage {
+	if totalTokens <= 0 || usage.CacheReadTokens <= 0 || usage.CacheReadTokens > usage.InputTokens {
+		return usage
+	}
+	if totalTokens != usage.InputTokens+usage.OutputTokens {
+		return usage
+	}
+	usage.InputTokens -= usage.CacheReadTokens
+	return usage
 }
 
 func acpUsageInt64(fields map[string]json.RawMessage, names ...string) int64 {

--- a/server/pkg/agent/hermes_test.go
+++ b/server/pkg/agent/hermes_test.go
@@ -1121,6 +1121,58 @@ func TestParseACPTokenUsageAliases(t *testing.T) {
 	}
 }
 
+// TestParseACPTokenUsageCachedInputBucketing pins when cached reads are moved
+// out of inputTokens. Persisting overlapping buckets makes the dashboard
+// charge the cached prefix at both the full input rate and the cache-read
+// rate, so the re-bucketing must fire exactly when totalTokens proves the
+// counters overlap — and never otherwise.
+func TestParseACPTokenUsageCachedInputBucketing(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		raw  string
+		want TokenUsage
+	}{
+		{
+			// Grok Build: totalTokens == input + output, so the cached prefix
+			// lives inside inputTokens.
+			name: "inclusive input is reduced by cached reads",
+			raw:  `{"inputTokens":12929,"outputTokens":29,"totalTokens":12958,"cachedReadTokens":10880}`,
+			want: TokenUsage{InputTokens: 2049, OutputTokens: 29, CacheReadTokens: 10880},
+		},
+		{
+			// totalTokens == input + cached + output: the buckets are already
+			// mutually exclusive.
+			name: "exclusive buckets are left alone",
+			raw:  `{"inputTokens":100,"outputTokens":20,"totalTokens":150,"cachedReadTokens":30}`,
+			want: TokenUsage{InputTokens: 100, OutputTokens: 20, CacheReadTokens: 30},
+		},
+		{
+			// No totalTokens: nothing in the payload describes the overlap, so
+			// the counters are persisted as reported.
+			name: "missing totalTokens keeps counters as reported",
+			raw:  `{"inputTokens":100,"outputTokens":20,"cachedReadTokens":30}`,
+			want: TokenUsage{InputTokens: 100, OutputTokens: 20, CacheReadTokens: 30},
+		},
+		{
+			// Cached reads larger than input cannot be a subset of it.
+			name: "cached larger than input keeps counters as reported",
+			raw:  `{"inputTokens":10,"outputTokens":20,"totalTokens":30,"cachedReadTokens":40}`,
+			want: TokenUsage{InputTokens: 10, OutputTokens: 20, CacheReadTokens: 40},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := parseACPTokenUsage(json.RawMessage(tt.raw)); got != tt.want {
+				t.Fatalf("got %+v, want %+v", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestHermesClientHandleToolCallComplete(t *testing.T) {
 	t.Parallel()
 
@@ -1512,8 +1564,13 @@ func TestHermesClientExtractPromptResultMetaUsage(t *testing.T) {
 	if got.stopReason != "end_turn" {
 		t.Errorf("stopReason: got %q, want %q", got.stopReason, "end_turn")
 	}
-	if got.usage.InputTokens != 12929 {
-		t.Errorf("inputTokens: got %d, want 12929", got.usage.InputTokens)
+	// Grok counts the cached prefix inside inputTokens (totalTokens 12958 ==
+	// 12929 + 29), so the stored input bucket is the uncached remainder:
+	// 12929 - 10880 = 2049. Priced at xAI's grok-4.5 rates that is
+	// 2049*$2 + 10880*$0.30 + 29*$6 per 1M = $0.007536, which is exactly the
+	// costUsdTicks the same payload reports.
+	if got.usage.InputTokens != 2049 {
+		t.Errorf("inputTokens: got %d, want 2049", got.usage.InputTokens)
 	}
 	if got.usage.OutputTokens != 29 {
 		t.Errorf("outputTokens: got %d, want 29", got.usage.OutputTokens)


### PR DESCRIPTION
Closes MUL-5222. Follow-up to #5748 (MUL-5137).

## Problem

Grok Build usage rows charge the cached prompt prefix twice, so the usage dashboard shows roughly 4x the real spend on a typical cache-heavy turn.

#5748 taught the shared ACP parser to read Grok's token counters out of `result._meta`, which fixed "usage is always 0". But it persisted `inputTokens` and `cachedReadTokens` as reported, and Grok counts the cached reads **inside** `inputTokens`.

The real captured payload (already a fixture in `server/pkg/agent/hermes_test.go`) proves it twice over:

```json
{"inputTokens":12929,"outputTokens":29,"totalTokens":12958,
 "cachedReadTokens":10880,"costUsdTicks":75360000}
```

1. `totalTokens` (12958) == `inputTokens` + `outputTokens` — the cached prefix is not added a second time.
2. `costUsdTicks` 75360000 == $0.007536 == `(12929-10880)×$2 + 10880×$0.30 + 29×$6` per 1M, i.e. exactly xAI's published grok-4.5 rates applied to *uncached* input plus cached reads.

The dashboard prices usage as `input×input_rate + cache_read×cache_rate + …` (mutually exclusive buckets), so that turn renders as **$0.029296** against a real **$0.007536** — a 3.9x over-estimate. Agent turns are cache-heavy (84% here), so this is the normal case, not an edge case.

The repo already states this rule for Codex — `server/pkg/agent/codex.go` "persist mutually-exclusive buckets so dashboard cost math does not charge cached input twice", implemented as `codexUncachedInputTokens`. The shared ACP path just never got it.

## Change

`parseACPTokenUsage` now runs `excludeACPCachedInput`, which subtracts cached reads from the input bucket **only** when the payload's own `totalTokens` equals `input + output` (the self-describing proof that the counters overlap).

`parseACPTokenUsage` is shared with kimi / kiro / trae / qoder, so the guard matters: agents that report exclusive buckets (`total == input + cached + output`), omit `totalTokens`, or report `cached > input` keep their counters exactly as before.

## Verification

- `go test ./pkg/agent/ -count=1` — full package passes (~107s)
- `go vet ./pkg/agent/`, `gofmt` clean on changed files
- New table test `TestParseACPTokenUsageCachedInputBucketing` pins all four branches (inclusive / exclusive / no totalTokens / cached > input)
- Updated the two fixtures that carry `totalTokens` (the captured Grok payload and the grok e2e fixture) to the corrected expectations

## Out of scope

- **Existing rows stay inflated.** Correcting them needs a separate backfill over `task_usage` where `provider = 'xai'` and `cache_read_tokens <= input_tokens`.
- **`costUsdTicks` is still ignored.** Grok returns an authoritative per-turn cost that already accounts for the long-context 2x tier, but nothing in the pipeline (`task_usage` → hourly rollup → API → client) has a cost column; cost is always re-estimated client-side from catalog rates. That is also the root of the known "long-context cost is under-estimated" gap, and it needs an end-to-end cost field to close.
