### PR TITLE
MUL-5200: filter working views by active task issues

### DIFF
--- a/packages/core/api/client.test.ts
+++ b/packages/core/api/client.test.ts
@@ -339,6 +339,7 @@ describe("ApiClient workspace working agents", () => {
         name: "Agent 1",
         avatar_url: null,
         running_task_count: 2,
+        issue_ids: ["issue-1"],
       },
     ];
     const fetchMock = vi.fn().mockImplementation(() =>

--- a/packages/core/types/agent.ts
+++ b/packages/core/types/agent.ts
@@ -206,6 +206,9 @@ export interface WorkspaceWorkingAgent {
   name: string;
   avatar_url: string | null;
   running_task_count: number;
+  /** Distinct issues referenced by this agent's currently running tasks after
+   *  applying the endpoint's type/scope/relation filters. */
+  issue_ids: string[];
 }
 
 export type WorkspaceWorkingAgentType = "issue" | "autopilot" | "chat";

--- a/packages/core/types/api.ts
+++ b/packages/core/types/api.ts
@@ -263,6 +263,9 @@ export interface IssueTableFilters {
     end: string;
   };
   working_only?: boolean;
+  /** Match the running-task issue projection returned by
+   *  `/api/working-agents`. An explicit empty list matches nothing. */
+  working_issue_ids?: string[];
   include_sub_issues?: boolean;
 }
 

--- a/packages/views/issues/components/swimlane-view.test.tsx
+++ b/packages/views/issues/components/swimlane-view.test.tsx
@@ -1791,7 +1791,7 @@ describe("SwimLaneView", () => {
     });
   });
 
-  it("filters batch-fetched children using API-derived working assignees", async () => {
+  it("filters batch-fetched children using API-derived running issue ids", async () => {
     mockViewState.swimlaneGrouping = "parent";
 
     const grandparent: Issue = {
@@ -1835,7 +1835,7 @@ describe("SwimLaneView", () => {
       title: "Running Child",
       status: "in_progress",
       assignee_type: "agent",
-      assignee_id: "working-agent",
+      assignee_id: "idle-agent",
       parent_issue_id: "p-3",
       position: 12,
     };
@@ -1847,7 +1847,7 @@ describe("SwimLaneView", () => {
       title: "Non-running Child",
       status: "in_progress",
       assignee_type: "agent",
-      assignee_id: "idle-agent",
+      assignee_id: "working-agent",
       parent_issue_id: "p-3",
       position: 13,
     };
@@ -1865,8 +1865,10 @@ describe("SwimLaneView", () => {
         issues={[grandparent, parent]}
         activeFilters={{
           priorityFilters: [],
-          assigneeFilters: [{ type: "agent", id: "working-agent" }],
+          assigneeFilters: [],
           includeNoAssignee: false,
+          agentRunningFilter: true,
+          runningIssueIds: new Set(["gc-running"]),
           creatorFilters: [],
           projectFilters: [],
           includeNoProject: false,
@@ -1887,7 +1889,7 @@ describe("SwimLaneView", () => {
     });
   });
 
-  it("hides batch-fetched children for an explicitly empty working-assignee predicate", async () => {
+  it("hides batch-fetched children when the running issue set is empty", async () => {
     mockViewState.swimlaneGrouping = "parent";
     const parent = mockIssues[0]!;
     const batchOnlyChild: Issue = {
@@ -1908,7 +1910,8 @@ describe("SwimLaneView", () => {
           priorityFilters: [],
           assigneeFilters: [],
           includeNoAssignee: false,
-          assigneeFilterActive: true,
+          agentRunningFilter: true,
+          runningIssueIds: new Set(),
           creatorFilters: [],
           projectFilters: [],
           includeNoProject: false,

--- a/packages/views/issues/components/swimlane-view.tsx
+++ b/packages/views/issues/components/swimlane-view.tsx
@@ -625,10 +625,7 @@ function SwimLaneViewImpl({
    * a parent in a hidden status still surfaces its label correctly.
    */
   unfilteredIssues?: Issue[];
-  activeFilters?: Omit<
-    IssueFilters,
-    "statusFilters" | "agentRunningFilter" | "runningIssueIds"
-  >;
+  activeFilters?: Omit<IssueFilters, "statusFilters">;
   visibleStatuses?: IssueStatus[];
   hiddenStatuses?: IssueStatus[];
   onMoveIssue: (
@@ -662,11 +659,13 @@ function SwimLaneViewImpl({
     // Status is enforced by visible-column rendering, not by filterIssues
     statusFilters: [],
     priorityFilters: activeFiltersProp?.priorityFilters ?? [],
-    // The controller has already projected `/api/working-agents` into this
-    // assignee list, so extra children use the same membership as Table.
     assigneeFilters: activeFiltersProp?.assigneeFilters ?? [],
     includeNoAssignee: activeFiltersProp?.includeNoAssignee ?? false,
     assigneeFilterActive: activeFiltersProp?.assigneeFilterActive ?? false,
+    // Extra children are not part of the server-grouped page yet, so apply
+    // the same running-task issue ids returned by `/api/working-agents`.
+    agentRunningFilter: activeFiltersProp?.agentRunningFilter ?? false,
+    runningIssueIds: activeFiltersProp?.runningIssueIds,
     creatorFilters: activeFiltersProp?.creatorFilters ?? [],
     projectFilters: activeFiltersProp?.projectFilters ?? [],
     includeNoProject: activeFiltersProp?.includeNoProject ?? false,

--- a/packages/views/issues/components/workspace-agent-working-chip.test.tsx
+++ b/packages/views/issues/components/workspace-agent-working-chip.test.tsx
@@ -84,6 +84,7 @@ function makeAgent(
     name: `Agent ${id}`,
     avatar_url: null,
     running_task_count: runningTaskCount,
+    issue_ids: [],
   };
 }
 

--- a/packages/views/issues/surface/issue-surface.test.tsx
+++ b/packages/views/issues/surface/issue-surface.test.tsx
@@ -337,11 +337,12 @@ describe("IssueSurface — table pagination ownership", () => {
       ),
       getWorkspaceWorkingAgents: vi.fn(() =>
         Promise.resolve(
-          runningIssues.map((_, index) => ({
+          runningIssues.map((issue, index) => ({
             id: `agent-${index}`,
             name: `Agent ${index}`,
             avatar_url: null,
             running_task_count: 1,
+            issue_ids: [issue.id],
           })),
         ),
       ),
@@ -376,10 +377,7 @@ describe("IssueSurface — table pagination ownership", () => {
         parent_id: null,
         query: expect.objectContaining({
           filters: expect.objectContaining({
-            assignees: runningIssues.map((_, index) => ({
-              type: "agent",
-              id: `agent-${index}`,
-            })),
+            working_issue_ids: runningIssues.map((issue) => issue.id),
           }),
         }),
       }),

--- a/packages/views/issues/surface/use-issue-surface-controller.test.tsx
+++ b/packages/views/issues/surface/use-issue-surface-controller.test.tsx
@@ -117,6 +117,7 @@ function makeRunningTask(id: string, agentId: string, issueId: string): AgentTas
 
 function makeWorkingAgent(
   id: string,
+  issueIDs: string[] = [],
   runningTaskCount = 1,
 ): WorkspaceWorkingAgent {
   return {
@@ -124,6 +125,7 @@ function makeWorkingAgent(
     name: id,
     avatar_url: null,
     running_task_count: runningTaskCount,
+    issue_ids: issueIDs,
   };
 }
 
@@ -803,7 +805,7 @@ describe("useIssueSurfaceController", () => {
     );
   });
 
-  it("sends workspace working-agent ids through the Table assignee filter", async () => {
+  it("sends workspace running-task issue ids through the Table filter", async () => {
     const store = getIssueSurfaceViewStore("project:p1");
     store.getState().setViewMode("table");
     store.getState().toggleAgentRunningFilter();
@@ -815,12 +817,14 @@ describe("useIssueSurfaceController", () => {
           name: "Agent 1",
           avatar_url: null,
           running_task_count: 1,
+          issue_ids: ["issue-running"],
         },
         {
           id: "agent-2",
           name: "Agent 2",
           avatar_url: null,
           running_task_count: 2,
+          issue_ids: ["issue-running-2"],
         },
       ] satisfies WorkspaceWorkingAgent[]),
     );
@@ -847,11 +851,12 @@ describe("useIssueSurfaceController", () => {
     );
 
     await waitFor(() =>
-      expect(result.current.tableQuerySpec.filters.assignees).toEqual([
-        { type: "agent", id: "agent-1" },
-        { type: "agent", id: "agent-2" },
+      expect(result.current.tableQuerySpec.filters.working_issue_ids).toEqual([
+        "issue-running",
+        "issue-running-2",
       ]),
     );
+    expect(result.current.tableQuerySpec.filters.assignees).toBeUndefined();
     expect(result.current.tableQuerySpec.filters.working_only).toBeUndefined();
     expect(getWorkspaceWorkingAgents).toHaveBeenCalledWith("issue", undefined);
     expect(listIssues).not.toHaveBeenCalled();
@@ -888,17 +893,17 @@ describe("useIssueSurfaceController", () => {
         "assigned",
       ),
     );
-    expect(result.current.tableQuerySpec.filters.assignees).toEqual([]);
+    expect(result.current.tableQuerySpec.filters.working_issue_ids).toEqual([]);
   });
 
   it.each(["board", "list", "swimlane"] as const)(
-    "uses working-agent assignees for the %s server query without reading the task snapshot",
+    "uses running tasks for the %s server query without reading the task snapshot",
     async (viewMode) => {
       const store = getIssueSurfaceViewStore("project:p1");
       store.getState().setViewMode(viewMode);
       store.getState().toggleAgentRunningFilter();
       getWorkspaceWorkingAgents.mockResolvedValue([
-        makeWorkingAgent("agent-from-working-api"),
+        makeWorkingAgent("agent-from-working-api", ["issue-from-working-api"]),
       ]);
       // Deliberately contradictory legacy data. It must neither be fetched nor
       // influence membership after the quick filter moved to working-agents.
@@ -916,17 +921,18 @@ describe("useIssueSurfaceController", () => {
       );
 
       await waitFor(() =>
-        expect(result.current.tableQuerySpec.filters.assignees).toEqual([
-          { type: "agent", id: "agent-from-working-api" },
-        ]),
+        expect(
+          result.current.tableQuerySpec.filters.working_issue_ids,
+        ).toEqual(["issue-from-working-api"]),
       );
+      expect(result.current.tableQuerySpec.filters.assignees).toBeUndefined();
       expect(result.current.tableQuerySpec.filters.working_only).toBeUndefined();
       expect(getWorkspaceWorkingAgents).toHaveBeenCalledWith("issue", undefined);
       expect(getAgentTaskSnapshot).not.toHaveBeenCalled();
     },
   );
 
-  it("intersects regular assignees with working agents and excludes unassigned rows", async () => {
+  it("combines regular assignees with the independent running-task predicate", async () => {
     const store = getIssueSurfaceViewStore("project:p1");
     store.getState().setViewMode("list");
     store.getState().toggleAssigneeFilter({ type: "agent", id: "agent-1" });
@@ -935,8 +941,8 @@ describe("useIssueSurfaceController", () => {
     store.getState().toggleNoAssignee();
     store.getState().toggleAgentRunningFilter();
     getWorkspaceWorkingAgents.mockResolvedValue([
-      makeWorkingAgent("agent-2"),
-      makeWorkingAgent("agent-3"),
+      makeWorkingAgent("agent-2", ["member-assigned-running-issue"]),
+      makeWorkingAgent("agent-3", ["unassigned-running-issue"]),
     ]);
 
     const { result } = renderHook(
@@ -948,14 +954,18 @@ describe("useIssueSurfaceController", () => {
       { wrapper: makeWrapper(qc, "project:p1") },
     );
 
-    await waitFor(() =>
+    await waitFor(() => {
       expect(result.current.tableQuerySpec.filters.assignees).toEqual([
+        { type: "agent", id: "agent-1" },
         { type: "agent", id: "agent-2" },
-      ]),
-    );
-    expect(
-      result.current.tableQuerySpec.filters.include_no_assignee,
-    ).toBeUndefined();
+        { type: "member", id: "member-1" },
+      ]);
+      expect(result.current.tableQuerySpec.filters.working_issue_ids).toEqual([
+        "member-assigned-running-issue",
+        "unassigned-running-issue",
+      ]);
+    });
+    expect(result.current.tableQuerySpec.filters.include_no_assignee).toBe(true);
   });
 
   it("does not subscribe Table to the legacy offset window", async () => {
@@ -1175,10 +1185,10 @@ describe("useIssueSurfaceController", () => {
 
   // --- working-chip scope (MUL-4884) ------------------------------------
   // The header chip promises "N issues in progress" where N is the number of
-  // rows clicking it leaves. The working-agents endpoint is projected into
-  // the same assignee predicate used by every view's canonical query.
+  // rows clicking it leaves. The working-agents endpoint identifies both the
+  // running agents and the issues referenced by those agents' running tasks.
 
-  it("sends working-agent assignees to the server without reconstructing a local scope", async () => {
+  it("sends working issue ids to the server without reconstructing a local scope", async () => {
     mockListByStatus({
       todo: [
         makeIssue({ id: "todo-1", status: "todo" }),
@@ -1187,8 +1197,8 @@ describe("useIssueSurfaceController", () => {
       in_progress: [makeIssue({ id: "prog-1", status: "in_progress" })],
     });
     getWorkspaceWorkingAgents.mockResolvedValue([
-      makeWorkingAgent("agent-1"),
-      makeWorkingAgent("agent-2"),
+      makeWorkingAgent("agent-1", ["todo-1"]),
+      makeWorkingAgent("agent-2", ["prog-1"]),
     ]);
 
     const store = getIssueSurfaceViewStore("project:p1");
@@ -1204,10 +1214,11 @@ describe("useIssueSurfaceController", () => {
     );
 
     await waitFor(() => expect(result.current.isLoading).toBe(false));
-    expect(result.current.tableQuerySpec.filters.assignees).toEqual([
-      { type: "agent", id: "agent-1" },
-      { type: "agent", id: "agent-2" },
+    expect(result.current.tableQuerySpec.filters.working_issue_ids).toEqual([
+      "todo-1",
+      "prog-1",
     ]);
+    expect(result.current.tableQuerySpec.filters.assignees).toBeUndefined();
     expect(result.current.tableQuerySpec.filters.working_only).toBeUndefined();
     expect(getAgentTaskSnapshot).not.toHaveBeenCalled();
     // Membership is cursor-paged and server-owned. A partial page cannot
@@ -1222,7 +1233,9 @@ describe("useIssueSurfaceController", () => {
         makeIssue({ id: "todo-2", status: "todo" }),
       ],
     });
-    getWorkspaceWorkingAgents.mockResolvedValue([makeWorkingAgent("agent-1")]);
+    getWorkspaceWorkingAgents.mockResolvedValue([
+      makeWorkingAgent("agent-1", ["todo-1"]),
+    ]);
 
     const { result } = renderHook(
       () =>
@@ -1247,8 +1260,8 @@ describe("useIssueSurfaceController", () => {
       in_progress: [makeIssue({ id: "prog-1", status: "in_progress" })],
     });
     getWorkspaceWorkingAgents.mockResolvedValue([
-      makeWorkingAgent("agent-1"),
-      makeWorkingAgent("agent-2"),
+      makeWorkingAgent("agent-1", ["todo-1"]),
+      makeWorkingAgent("agent-2", ["prog-1"]),
     ]);
 
     // ...but the user is only looking at `todo`.
@@ -1270,10 +1283,11 @@ describe("useIssueSurfaceController", () => {
     await waitFor(() => expect(result.current.isLoading).toBe(false));
 
     expect(result.current.tableQuerySpec.filters.statuses).toEqual(["todo"]);
-    expect(result.current.tableQuerySpec.filters.assignees).toEqual([
-      { type: "agent", id: "agent-1" },
-      { type: "agent", id: "agent-2" },
+    expect(result.current.tableQuerySpec.filters.working_issue_ids).toEqual([
+      "todo-1",
+      "prog-1",
     ]);
+    expect(result.current.tableQuerySpec.filters.assignees).toBeUndefined();
     expect(result.current.tableQuerySpec.filters.working_only).toBeUndefined();
     expect(result.current.workingScopeIssues).toBeUndefined();
   });
@@ -1285,7 +1299,9 @@ describe("useIssueSurfaceController", () => {
         makeIssue({ id: "child-1", status: "todo", parent_issue_id: "parent-1" }),
       ],
     });
-    getWorkspaceWorkingAgents.mockResolvedValue([makeWorkingAgent("agent-1")]);
+    getWorkspaceWorkingAgents.mockResolvedValue([
+      makeWorkingAgent("agent-1", ["parent-1"]),
+    ]);
 
     const store = getIssueSurfaceViewStore("project:p1");
     act(() => store.getState().toggleShowSubIssues());
@@ -1330,8 +1346,8 @@ describe("useIssueSurfaceController", () => {
       in_progress: [makeIssue({ id: "prog-1", status: "in_progress" })],
     });
     getWorkspaceWorkingAgents.mockResolvedValue([
-      makeWorkingAgent("agent-1"),
-      makeWorkingAgent("agent-2"),
+      makeWorkingAgent("agent-1", ["todo-1"]),
+      makeWorkingAgent("agent-2", ["prog-1"]),
     ]);
 
     const store = getIssueSurfaceViewStore("project:p1");
@@ -1407,9 +1423,12 @@ describe("useIssueSurfaceController", () => {
     }),
   ];
 
-  it("filters Gantt by working-agent assignees without reading the task snapshot", async () => {
+  it("filters Gantt by running-task issue ids rather than issue assignees", async () => {
     mockGanttIssues(ganttFixture);
-    getWorkspaceWorkingAgents.mockResolvedValue([makeWorkingAgent("agent-1")]);
+    getWorkspaceWorkingAgents.mockResolvedValue([
+      // The editing agent deliberately differs from the issue assignee.
+      makeWorkingAgent("agent-editor", ["gantt-open"]),
+    ]);
     // Contradictory legacy membership must not affect the canvas.
     getAgentTaskSnapshot.mockResolvedValue([
       makeRunningTask("t-2", "agent-2", "gantt-done"),
@@ -1453,8 +1472,8 @@ describe("useIssueSurfaceController", () => {
       selectedAssigneeId: null,
     },
     {
-      name: "the selected assignee has no working-agent intersection",
-      workingAgents: [makeWorkingAgent("agent-1")],
+      name: "the selected assignee excludes all running-task issues",
+      workingAgents: [makeWorkingAgent("agent-1", ["gantt-open"])],
       selectedAssigneeId: "agent-2",
     },
   ])("keeps Gantt empty when $name", async ({
@@ -1493,7 +1512,14 @@ describe("useIssueSurfaceController", () => {
       ),
     );
 
-    expect(result.current.tableQuerySpec.filters.assignees).toEqual([]);
+    expect(result.current.tableQuerySpec.filters.working_issue_ids).toEqual(
+      workingAgents.flatMap((agent) => agent.issue_ids),
+    );
+    expect(result.current.tableQuerySpec.filters.assignees).toEqual(
+      selectedAssigneeId
+        ? [{ type: "agent", id: selectedAssigneeId }]
+        : undefined,
+    );
     expect(result.current.filteredGanttIssues).toEqual([]);
     expect(result.current.workingScopeIssues).toEqual([]);
   });
@@ -1501,8 +1527,7 @@ describe("useIssueSurfaceController", () => {
   it("widens the gantt working scope when show-completed is turned on", async () => {
     mockGanttIssues(ganttFixture);
     getWorkspaceWorkingAgents.mockResolvedValue([
-      makeWorkingAgent("agent-1"),
-      makeWorkingAgent("agent-2"),
+      makeWorkingAgent("agent-editor", ["gantt-open", "gantt-done"]),
     ]);
 
     const store = getIssueSurfaceViewStore("project:p1");

--- a/packages/views/issues/surface/use-issue-surface-controller.ts
+++ b/packages/views/issues/surface/use-issue-surface-controller.ts
@@ -94,10 +94,7 @@ export interface IssueSurfaceController {
   /** Exact group catalog plus independent row cursors for Assignee/Property
    * Board and compound Swimlane cells. */
   groupBranches?: IssueGroupBranches;
-  activeFilters: Omit<
-    IssueFilters,
-    "statusFilters" | "agentRunningFilter" | "runningIssueIds"
-  >;
+  activeFilters: Omit<IssueFilters, "statusFilters">;
   actions: IssueSurfaceActions;
   selection: IssueSurfaceSelection;
   childProgressMap: Map<string, ChildProgress>;
@@ -330,30 +327,13 @@ export function useIssueSurfaceController({
   const { data: workspaceWorkingAgents = [] } = useQuery(
     workspaceWorkingAgentsOptions(wsId, "issue", workingAgentMineRelation),
   );
-  const workingAssigneeFilters = useMemo(() => {
-    const workingAgentIds = new Set(
-      workspaceWorkingAgents.map((agent) => agent.id),
-    );
-    if (assigneeFilters.length === 0) {
-      return workspaceWorkingAgents.map((agent) => ({
-        type: "agent" as const,
-        id: agent.id,
-      }));
+  const workingIssueIDs = useMemo(() => {
+    const issueIDs = new Set<string>();
+    for (const agent of workspaceWorkingAgents) {
+      for (const issueID of agent.issue_ids) issueIDs.add(issueID);
     }
-
-    // The quick filter and the regular assignee picker are both predicates
-    // on the same field, so compose them with intersection (AND semantics).
-    return assigneeFilters.filter(
-      (assignee) =>
-        assignee.type === "agent" && workingAgentIds.has(assignee.id),
-    );
-  }, [assigneeFilters, workspaceWorkingAgents]);
-  const effectiveAssigneeFilters = agentRunningFilter
-    ? workingAssigneeFilters
-    : assigneeFilters;
-  const effectiveIncludeNoAssignee = agentRunningFilter
-    ? false
-    : includeNoAssignee;
+    return issueIDs;
+  }, [workspaceWorkingAgents]);
 
   const tableQuerySpec = useMemo<IssueTableQuerySpec>(() => {
     let queryScope: IssueTableQuerySpec["scope"];
@@ -400,14 +380,8 @@ export function useIssueSurfaceController({
       filters: {
         ...(statusFilters.length > 0 ? { statuses: statusFilters } : {}),
         ...(priorityFilters.length > 0 ? { priorities: priorityFilters } : {}),
-        ...(agentRunningFilter
-          ? { assignees: effectiveAssigneeFilters }
-          : assigneeFilters.length > 0
-            ? { assignees: assigneeFilters }
-            : {}),
-        ...(effectiveIncludeNoAssignee
-          ? { include_no_assignee: true }
-          : {}),
+        ...(assigneeFilters.length > 0 ? { assignees: assigneeFilters } : {}),
+        ...(includeNoAssignee ? { include_no_assignee: true } : {}),
         ...(creatorFilters.length > 0 ? { creators: creatorFilters } : {}),
         ...(viewProjectFilters.length > 0
           ? { project_ids: viewProjectFilters }
@@ -418,6 +392,9 @@ export function useIssueSurfaceController({
           ? { properties: effectivePropertyFilters }
           : {}),
         ...(date ? { date } : {}),
+        ...(agentRunningFilter
+          ? { working_issue_ids: [...workingIssueIDs] }
+          : {}),
         include_sub_issues: showSubIssues,
       },
       ...(debouncedActiveSearch ? { search: debouncedActiveSearch } : {}),
@@ -432,9 +409,8 @@ export function useIssueSurfaceController({
     creatorFilters,
     dateParams,
     debouncedActiveSearch,
-    effectiveAssigneeFilters,
-    effectiveIncludeNoAssignee,
     effectivePropertyFilters,
+    includeNoAssignee,
     labelFilters,
     priorityFilters,
     scope,
@@ -444,6 +420,7 @@ export function useIssueSurfaceController({
     statusFilters,
     viewIncludeNoProject,
     viewProjectFilters,
+    workingIssueIDs,
   ]);
 
   const [activeTableFacet, setActiveTableFacet] =
@@ -604,15 +581,15 @@ export function useIssueSurfaceController({
     sort,
     statusFilters,
     priorityFilters,
-    assigneeFilters: effectiveAssigneeFilters,
-    includeNoAssignee: effectiveIncludeNoAssignee,
-    assigneeFilterActive: agentRunningFilter,
+    assigneeFilters,
+    includeNoAssignee,
+    agentRunningFilter,
     creatorFilters,
     projectFilters: viewProjectFilters,
     includeNoProject: viewIncludeNoProject,
     labelFilters,
     propertyFilters: effectivePropertyFilters,
-    workingAssigneeFilters,
+    workingIssueIDs,
     showSubIssues,
     loadProjects:
       cardProperties.project ||

--- a/packages/views/issues/surface/use-issue-surface-data.ts
+++ b/packages/views/issues/surface/use-issue-surface-data.ts
@@ -81,10 +81,7 @@ export interface IssueSurfaceData {
   visibleStatuses: IssueStatus[];
   hiddenStatuses: IssueStatus[];
   statusPagination: IssueStatusPagination;
-  activeFilters: Omit<
-    IssueFilters,
-    "statusFilters" | "agentRunningFilter" | "runningIssueIds"
-  >;
+  activeFilters: Omit<IssueFilters, "statusFilters">;
   childProgressMap: Map<string, ChildProgress>;
   projectMap: Map<string, Project>;
   resolveTableExportLookups: (needs: {
@@ -118,13 +115,13 @@ export function useIssueSurfaceData({
   priorityFilters,
   assigneeFilters,
   includeNoAssignee,
-  assigneeFilterActive,
+  agentRunningFilter,
   creatorFilters,
   projectFilters,
   includeNoProject,
   labelFilters,
   propertyFilters,
-  workingAssigneeFilters,
+  workingIssueIDs,
   showSubIssues,
   loadProjects,
 }: {
@@ -144,17 +141,14 @@ export function useIssueSurfaceData({
   priorityFilters: IssueFilterState["priorityFilters"];
   assigneeFilters: IssueFilterState["assigneeFilters"];
   includeNoAssignee: boolean;
-  /** True when the working-agent quick filter owns the assignee predicate,
-   *  including when its API-derived intersection is explicitly empty. */
-  assigneeFilterActive: boolean;
+  agentRunningFilter: boolean;
   creatorFilters: IssueFilterState["creatorFilters"];
   projectFilters: string[];
   includeNoProject: boolean;
   labelFilters: string[];
   propertyFilters: Record<string, string[]>;
-  /** The working-agent API projected into the same typed assignee predicate
-   *  used by the canonical Table query. */
-  workingAssigneeFilters: IssueFilterState["assigneeFilters"];
+  /** Distinct running-task issue ids projected by `/api/working-agents`. */
+  workingIssueIDs: ReadonlySet<string>;
   showSubIssues: boolean;
   loadProjects: boolean;
 }): IssueSurfaceData {
@@ -207,7 +201,11 @@ export function useIssueSurfaceData({
     ...issueSurfaceGanttOptions(wsId, projectId ?? ""),
     enabled: usesGantt,
   });
-  const hasWorkingAssignees = workingAssigneeFilters.length > 0;
+  const hasWorkingIssues = workingIssueIDs.size > 0;
+  const workingFilterContext = useMemo(
+    () => ({ runningIssueIds: workingIssueIDs }),
+    [workingIssueIDs],
+  );
   const bucketedIssues = useMemo(() => {
     return serverStatusBranches.enabled
       ? serverStatusBranches.issues
@@ -244,18 +242,17 @@ export function useIssueSurfaceData({
       priorityFilters,
       assigneeFilters,
       includeNoAssignee,
-      assigneeFilterActive,
       creatorFilters,
       projectFilters,
       includeNoProject,
       labelFilters,
       propertyFilters,
-      workingOnly: false,
+      workingOnly: agentRunningFilter,
       showSubIssues,
     }),
     [
       assigneeFilters,
-      assigneeFilterActive,
+      agentRunningFilter,
       creatorFilters,
       includeNoAssignee,
       includeNoProject,
@@ -272,11 +269,16 @@ export function useIssueSurfaceData({
     () =>
       serverStatusBranches.enabled
         ? surfaceIssues
-        : applyIssueFilters(surfaceIssues, baseFilterState),
+        : applyIssueFilters(
+            surfaceIssues,
+            baseFilterState,
+            workingFilterContext,
+          ),
     [
       baseFilterState,
       serverStatusBranches.enabled,
       surfaceIssues,
+      workingFilterContext,
     ],
   );
 
@@ -289,54 +291,65 @@ export function useIssueSurfaceData({
   );
 
   const swimlaneIssues = useMemo(
-    () => applyIssueFilters(surfaceIssues, statuslessFilterState),
-    [statuslessFilterState, surfaceIssues],
+    () =>
+      applyIssueFilters(
+        surfaceIssues,
+        statuslessFilterState,
+        workingFilterContext,
+      ),
+    [statuslessFilterState, surfaceIssues, workingFilterContext],
   );
 
   const filteredGanttIssues = useMemo(
     () =>
       ganttCanvasRows(
-        applyIssueFilters(ganttIssues, baseFilterState),
+        applyIssueFilters(ganttIssues, baseFilterState, workingFilterContext),
         ganttShowCompleted,
       ),
-    [baseFilterState, ganttIssues, ganttShowCompleted],
+    [
+      baseFilterState,
+      ganttIssues,
+      ganttShowCompleted,
+      workingFilterContext,
+    ],
   );
 
   // The assignee-grouped board renders straight from `groups`, bypassing the
   // flat applyIssueFilters output — re-apply the remaining client-only
-  // display filters per group. Working-agent membership is already encoded
-  // in the assignee predicate sent to the server.
+  // display filters per group. Server-owned group paths encode running-task
+  // membership in the canonical query; this fallback uses the same issue ids.
   const filteredAssigneeGroups = useMemo(
     () =>
       filterAssigneeGroups(assigneeGroupsQuery.data?.groups, {
+        agentRunningFilter,
+        runningIssueIds: workingIssueIDs,
         showSubIssues,
         propertyFilters,
       }),
     [
       assigneeGroupsQuery.data?.groups,
+      agentRunningFilter,
       propertyFilters,
       showSubIssues,
+      workingIssueIDs,
     ],
   );
 
   const workingFilterState = useMemo<IssueFilterState>(
     () => ({
       ...baseFilterState,
-      assigneeFilters: workingAssigneeFilters,
-      includeNoAssignee: false,
-      assigneeFilterActive: true,
-      workingOnly: false,
+      workingOnly: true,
     }),
-    [baseFilterState, workingAssigneeFilters],
+    [baseFilterState],
   );
 
   // The rows the agents-working filter leaves on screen — i.e. exactly what
   // you get when you click the header chip.
   //
   // This is deliberately a projection of the render pipeline. The controller
-  // translates `/api/working-agents` into a typed assignee predicate once;
-  // both the canonical server query and client-only Gantt/extra-child paths
-  // reuse that predicate, so there is no task-snapshot membership fallback.
+  // translates `/api/working-agents` into running issue ids once; both the
+  // canonical server query and client-only Gantt/extra-child paths reuse that
+  // returned issue-id set.
   //
   // The chip counts AGENTS, not this list's length, so these are not equal
   // (one agent can hold two of these rows). What this set does decide is
@@ -364,6 +377,7 @@ export function useIssueSurfaceData({
         applyIssueFilters(
           ganttIssues,
           workingFilterState,
+          workingFilterContext,
         ),
         ganttShowCompleted,
       );
@@ -371,28 +385,38 @@ export function useIssueSurfaceData({
     if (usesAssigneeBoard && !serverGroupBranches.enabled) {
       const groupedIssues = (
         filterAssigneeGroups(assigneeGroupsQuery.data?.groups, {
+          agentRunningFilter: true,
+          runningIssueIds: workingIssueIDs,
           showSubIssues,
           propertyFilters,
         }) ?? []
       ).flatMap((group) => group.issues);
-      return applyIssueFilters(groupedIssues, workingFilterState);
+      return applyIssueFilters(
+        groupedIssues,
+        workingFilterState,
+        workingFilterContext,
+      );
     }
     if (usesTable || serverStatusBranches.enabled || serverGroupBranches.enabled) {
       // Table membership is server-owned and cursor paged. Do not rebuild a
       // second complete issue window merely to decorate the activity chip:
       // that was the final hidden auto-materialization loop behind the old
-      // 1,000-row ceiling. An empty working-assignee intersection is trivially
+      // 1,000-row ceiling. An empty running-issue set is trivially
       // known; otherwise keep the chip indeterminate until a bounded server
       // facet supplies the matching task/issue projection.
-      if (!hasWorkingAssignees) return EMPTY_ISSUES;
+      if (!hasWorkingIssues) return EMPTY_ISSUES;
       return undefined;
     }
-    return applyIssueFilters(surfaceIssues, workingFilterState);
+    return applyIssueFilters(
+      surfaceIssues,
+      workingFilterState,
+      workingFilterContext,
+    );
   }, [
     assigneeGroupsQuery.data?.groups,
     ganttIssues,
     ganttShowCompleted,
-    hasWorkingAssignees,
+    hasWorkingIssues,
     propertyFilters,
     showSubIssues,
     surfaceIssues,
@@ -402,6 +426,8 @@ export function useIssueSurfaceData({
     serverStatusBranches.enabled,
     serverGroupBranches.enabled,
     workingFilterState,
+    workingFilterContext,
+    workingIssueIDs,
   ]);
 
   const {
@@ -476,7 +502,8 @@ export function useIssueSurfaceData({
       priorityFilters,
       assigneeFilters,
       includeNoAssignee,
-      assigneeFilterActive,
+      agentRunningFilter,
+      runningIssueIds: workingIssueIDs,
       creatorFilters,
       projectFilters,
       includeNoProject,
@@ -486,7 +513,7 @@ export function useIssueSurfaceData({
     }),
     [
       assigneeFilters,
-      assigneeFilterActive,
+      agentRunningFilter,
       creatorFilters,
       includeNoAssignee,
       includeNoProject,
@@ -495,6 +522,7 @@ export function useIssueSurfaceData({
       priorityFilters,
       projectFilters,
       showSubIssues,
+      workingIssueIDs,
     ],
   );
 

--- a/packages/views/issues/utils/filter.ts
+++ b/packages/views/issues/utils/filter.ts
@@ -19,9 +19,8 @@ export interface IssueFilters {
    *  a definition, AND across definitions; checkbox uses "true"/"false"). */
   propertyFilters?: Record<string, string[]>;
   // When `agentRunningFilter` is true, only keep issues whose id is in
-  // `runningIssueIds`. The set is derived by the caller from
-  // `agentTaskSnapshot` (one pass over running tasks) so filter.ts stays
-  // free of any data-fetching dependency.
+  // `runningIssueIds`. The surface derives this set from the independent
+  // `/api/working-agents` projection so filter.ts stays free of fetching.
   agentRunningFilter?: boolean;
   runningIssueIds?: ReadonlySet<string>;
   // "Show sub-issues" display toggle. When explicitly `false`, hide issues

--- a/server/internal/handler/agent.go
+++ b/server/internal/handler/agent.go
@@ -2096,13 +2096,15 @@ type AgentRunCount struct {
 
 // WorkspaceWorkingAgent is the privacy-safe agent summary returned by the
 // workspace working-agents endpoint. It deliberately carries only display
-// information plus the current running-task count; full AgentResponse fields
-// include runtime and integration configuration that this chip does not need.
+// information plus the current running-task count and referenced issue ids;
+// full AgentResponse fields include runtime and integration configuration that
+// this chip does not need.
 type WorkspaceWorkingAgent struct {
-	ID               string  `json:"id"`
-	Name             string  `json:"name"`
-	AvatarURL        *string `json:"avatar_url"`
-	RunningTaskCount int32   `json:"running_task_count"`
+	ID               string   `json:"id"`
+	Name             string   `json:"name"`
+	AvatarURL        *string  `json:"avatar_url"`
+	RunningTaskCount int32    `json:"running_task_count"`
+	IssueIDs         []string `json:"issue_ids"`
 }
 
 // ListWorkspaceWorkingAgents returns currently working user-authored agents in
@@ -2197,6 +2199,7 @@ func (h *Handler) ListWorkspaceWorkingAgents(w http.ResponseWriter, r *http.Requ
 			Name:             row.Name,
 			AvatarURL:        textToPtr(row.AvatarUrl),
 			RunningTaskCount: row.RunningTaskCount,
+			IssueIDs:         uuidStringsOrEmpty(row.IssueIds),
 		})
 	}
 

--- a/server/internal/handler/agent_test.go
+++ b/server/internal/handler/agent_test.go
@@ -381,19 +381,90 @@ func TestListWorkspaceWorkingAgents(t *testing.T) {
 	})
 
 	for _, tc := range []struct {
-		name      string
-		query     string
-		wantCount int32
+		name         string
+		query        string
+		wantCount    int32
+		wantIssueIDs []string
 	}{
-		{name: "all sources", wantCount: 9},
-		{name: "issue", query: "?type=issue", wantCount: 6},
-		{name: "autopilot", query: "?type=autopilot", wantCount: 1},
-		{name: "chat", query: "?type=chat", wantCount: 1},
-		{name: "mine defaults to any", query: "?type=issue&scope=mine", wantCount: 5},
-		{name: "mine any", query: "?type=issue&scope=mine&relation=any", wantCount: 5},
-		{name: "mine assigned", query: "?type=issue&scope=mine&relation=assigned", wantCount: 1},
-		{name: "mine created", query: "?type=issue&scope=mine&relation=created", wantCount: 1},
-		{name: "mine involved", query: "?type=issue&scope=mine&relation=involved", wantCount: 4},
+		{
+			name:      "all sources",
+			wantCount: 9,
+			wantIssueIDs: []string{
+				assignedIssueID,
+				ownedAgentIssueID,
+				outsideIssueID,
+				directMemberSquadIssueID,
+				ownedLeaderSquadIssueID,
+				ownedMemberSquadIssueID,
+			},
+		},
+		{
+			name:      "issue",
+			query:     "?type=issue",
+			wantCount: 6,
+			wantIssueIDs: []string{
+				assignedIssueID,
+				ownedAgentIssueID,
+				outsideIssueID,
+				directMemberSquadIssueID,
+				ownedLeaderSquadIssueID,
+				ownedMemberSquadIssueID,
+			},
+		},
+		{
+			name:         "autopilot",
+			query:        "?type=autopilot",
+			wantCount:    1,
+			wantIssueIDs: []string{assignedIssueID},
+		},
+		{name: "chat", query: "?type=chat", wantCount: 1, wantIssueIDs: []string{}},
+		{
+			name:      "mine defaults to any",
+			query:     "?type=issue&scope=mine",
+			wantCount: 5,
+			wantIssueIDs: []string{
+				assignedIssueID,
+				ownedAgentIssueID,
+				directMemberSquadIssueID,
+				ownedLeaderSquadIssueID,
+				ownedMemberSquadIssueID,
+			},
+		},
+		{
+			name:      "mine any",
+			query:     "?type=issue&scope=mine&relation=any",
+			wantCount: 5,
+			wantIssueIDs: []string{
+				assignedIssueID,
+				ownedAgentIssueID,
+				directMemberSquadIssueID,
+				ownedLeaderSquadIssueID,
+				ownedMemberSquadIssueID,
+			},
+		},
+		{
+			name:         "mine assigned",
+			query:        "?type=issue&scope=mine&relation=assigned",
+			wantCount:    1,
+			wantIssueIDs: []string{assignedIssueID},
+		},
+		{
+			name:         "mine created",
+			query:        "?type=issue&scope=mine&relation=created",
+			wantCount:    1,
+			wantIssueIDs: []string{assignedIssueID},
+		},
+		{
+			name:      "mine involved",
+			query:     "?type=issue&scope=mine&relation=involved",
+			wantCount: 4,
+			wantIssueIDs: []string{
+				ownedAgentIssueID,
+				directMemberSquadIssueID,
+				ownedLeaderSquadIssueID,
+				ownedMemberSquadIssueID,
+			},
+		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			w := httptest.NewRecorder()
@@ -427,6 +498,18 @@ func TestListWorkspaceWorkingAgents(t *testing.T) {
 			}
 			if working.RunningTaskCount != tc.wantCount {
 				t.Errorf("running_task_count = %d, want %d", working.RunningTaskCount, tc.wantCount)
+			}
+			if len(working.IssueIDs) != len(tc.wantIssueIDs) {
+				t.Fatalf("issue_ids = %v, want %v", working.IssueIDs, tc.wantIssueIDs)
+			}
+			wantIssueIDs := make(map[string]struct{}, len(tc.wantIssueIDs))
+			for _, issueID := range tc.wantIssueIDs {
+				wantIssueIDs[issueID] = struct{}{}
+			}
+			for _, issueID := range working.IssueIDs {
+				if _, ok := wantIssueIDs[issueID]; !ok {
+					t.Errorf("unexpected issue_id %s; want %v", issueID, tc.wantIssueIDs)
+				}
 			}
 		})
 	}

--- a/server/internal/handler/issue_table_query.go
+++ b/server/internal/handler/issue_table_query.go
@@ -92,6 +92,7 @@ type issueTableFiltersRequest struct {
 	Properties        map[string][]string          `json:"properties,omitempty"`
 	Date              *issueTableDateFilterRequest `json:"date,omitempty"`
 	WorkingOnly       bool                         `json:"working_only,omitempty"`
+	WorkingIssueIDs   []string                     `json:"working_issue_ids,omitempty"`
 	IncludeSubIssues  *bool                        `json:"include_sub_issues,omitempty"`
 }
 
@@ -245,6 +246,8 @@ func equalOptionalString(a, b *string) bool {
 func canonicalIssueTableFingerprint(workspaceID string, spec issueTableQuerySpec) (string, error) {
 	explicitEmptyAssignees :=
 		spec.Filters.Assignees != nil && len(spec.Filters.Assignees) == 0
+	explicitEmptyWorkingIssues :=
+		spec.Filters.WorkingIssueIDs != nil && len(spec.Filters.WorkingIssueIDs) == 0
 	normalized := spec
 	normalized.Search = strings.TrimSpace(normalized.Search)
 	normalized.Scope.AssigneeTypes = sortedUniqueStrings(normalized.Scope.AssigneeTypes)
@@ -253,18 +256,21 @@ func canonicalIssueTableFingerprint(workspaceID string, spec issueTableQuerySpec
 	normalized.Filters.ProjectIDs = sortedUniqueStrings(normalized.Filters.ProjectIDs)
 	normalized.Filters.LabelIDs = sortedUniqueStrings(normalized.Filters.LabelIDs)
 	normalized.Filters.Assignees = sortedUniqueActors(normalized.Filters.Assignees)
+	normalized.Filters.WorkingIssueIDs = sortedUniqueStrings(normalized.Filters.WorkingIssueIDs)
 	normalized.Filters.Creators = sortedUniqueActors(normalized.Filters.Creators)
 	for key, values := range normalized.Filters.Properties {
 		normalized.Filters.Properties[key] = sortedUniqueStrings(values)
 	}
 	encoded, err := json.Marshal(struct {
-		WorkspaceID            string              `json:"workspace_id"`
-		Query                  issueTableQuerySpec `json:"query"`
-		ExplicitEmptyAssignees bool                `json:"explicit_empty_assignees,omitempty"`
+		WorkspaceID                string              `json:"workspace_id"`
+		Query                      issueTableQuerySpec `json:"query"`
+		ExplicitEmptyAssignees     bool                `json:"explicit_empty_assignees,omitempty"`
+		ExplicitEmptyWorkingIssues bool                `json:"explicit_empty_working_issues,omitempty"`
 	}{
-		WorkspaceID:            workspaceID,
-		Query:                  normalized,
-		ExplicitEmptyAssignees: explicitEmptyAssignees,
+		WorkspaceID:                workspaceID,
+		Query:                      normalized,
+		ExplicitEmptyAssignees:     explicitEmptyAssignees,
+		ExplicitEmptyWorkingIssues: explicitEmptyWorkingIssues,
 	})
 	if err != nil {
 		return "", err
@@ -513,10 +519,8 @@ func (h *Handler) compileIssueTableQuery(w http.ResponseWriter, r *http.Request,
 		}
 		if len(ors) == 0 {
 			// Omitted assignees means "no assignee filter"; an explicitly
-			// empty list means "match none". The workspace working-agent
-			// quick filter relies on this distinction when the final agent
-			// finishes (or when an explicit assignee selection intersects the
-			// working set to empty).
+			// empty list means "match none", so API callers can preserve an
+			// intentionally active empty predicate.
 			where = append(where, "FALSE")
 		} else {
 			where = append(where, "("+strings.Join(ors, " OR ")+")")
@@ -593,6 +597,20 @@ func (h *Handler) compileIssueTableQuery(w http.ResponseWriter, r *http.Request,
 
 	if spec.Filters.WorkingOnly {
 		where = append(where, "EXISTS (SELECT 1 FROM agent_task_queue atq WHERE atq.issue_id = i.id AND atq.status = 'running')")
+	}
+	workingIssueIDs, ok := parseIssueTableUUIDList(w, spec.Filters.WorkingIssueIDs, "filters.working_issue_ids")
+	if !ok {
+		return issueTableSQL{}, false
+	}
+	if spec.Filters.WorkingIssueIDs != nil {
+		if len(workingIssueIDs) == 0 {
+			where = append(where, "FALSE")
+		} else {
+			where = append(where, fmt.Sprintf(
+				"i.id = ANY(%s::uuid[])",
+				addArg(workingIssueIDs),
+			))
+		}
 	}
 	if spec.Filters.IncludeSubIssues != nil && !*spec.Filters.IncludeSubIssues {
 		where = append(where, "i.parent_issue_id IS NULL")

--- a/server/internal/handler/issue_table_query_test.go
+++ b/server/internal/handler/issue_table_query_test.go
@@ -168,6 +168,215 @@ func TestIssueTableExplicitEmptyAssigneesMatchesNone(t *testing.T) {
 	}
 }
 
+func TestIssueTableWorkingIssueIDsAreExplicitAndAssigneeIndependent(t *testing.T) {
+	if testHandler == nil {
+		t.Skip("database not available")
+	}
+
+	base := issueTableQuerySpec{
+		Scope: issueTableScope{Kind: "workspace"},
+		Sort:  issueTableSortRequest{Field: "position", Direction: "asc"},
+	}
+	withEmpty := base
+	withEmpty.Filters.WorkingIssueIDs = []string{}
+
+	unfilteredFingerprint, err := canonicalIssueTableFingerprint(testWorkspaceID, base)
+	if err != nil {
+		t.Fatal(err)
+	}
+	emptyFingerprint, err := canonicalIssueTableFingerprint(testWorkspaceID, withEmpty)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if unfilteredFingerprint == emptyFingerprint {
+		t.Fatal("explicit empty working_issue_ids must not share the unfiltered cursor fingerprint")
+	}
+
+	w := httptest.NewRecorder()
+	compiled, ok := testHandler.compileIssueTableQuery(
+		w,
+		newRequest(http.MethodPost, "/api/issues/table/rows", nil),
+		withEmpty,
+	)
+	if !ok {
+		t.Fatalf("compile empty filter: %d %s", w.Code, w.Body.String())
+	}
+	if !strings.Contains(compiled.where, "FALSE") {
+		t.Fatalf("explicit empty working_issue_ids predicate = %q, want FALSE", compiled.where)
+	}
+
+	withIssue := base
+	withIssue.Filters.WorkingIssueIDs = []string{
+		"00000000-0000-4000-8000-000000000001",
+	}
+	w = httptest.NewRecorder()
+	compiled, ok = testHandler.compileIssueTableQuery(
+		w,
+		newRequest(http.MethodPost, "/api/issues/table/rows", nil),
+		withIssue,
+	)
+	if !ok {
+		t.Fatalf("compile issue filter: %d %s", w.Code, w.Body.String())
+	}
+	if !strings.Contains(compiled.where, "i.id = ANY(") {
+		t.Errorf("working-issue predicate = %q, want issue-id membership", compiled.where)
+	}
+	if strings.Contains(compiled.where, "i.assignee_id") {
+		t.Fatalf("working-issue predicate must not filter issue assignees: %q", compiled.where)
+	}
+}
+
+func TestIssueTableWorkingIssueProjectionMatchesTaskIssuesNotAssignees(t *testing.T) {
+	if testHandler == nil {
+		t.Skip("database not available")
+	}
+
+	ctx := context.Background()
+	workingAgentID := createHandlerTestAgent(t, "table-working-task-agent", []byte(`{}`))
+	otherAgentID := createHandlerTestAgent(t, "table-other-working-agent", []byte(`{}`))
+
+	var finalNumber int
+	if err := testPool.QueryRow(ctx, `
+		UPDATE workspace
+		SET issue_counter = GREATEST(
+			issue_counter,
+			(SELECT COALESCE(MAX(number), 0) FROM issue WHERE workspace_id = $1)
+		) + 3
+		WHERE id = $1
+		RETURNING issue_counter
+	`, testWorkspaceID).Scan(&finalNumber); err != nil {
+		t.Fatalf("reserve issue numbers: %v", err)
+	}
+
+	insertIssue := func(title string, number int, assigneeType string, assigneeID any) string {
+		t.Helper()
+		var issueID string
+		if err := testPool.QueryRow(ctx, `
+			INSERT INTO issue (
+				workspace_id, title, status, priority, creator_type, creator_id,
+				assignee_type, assignee_id, position, number
+			)
+			VALUES ($1, $2, 'todo', 'none', 'member', $3, $4, $5, $6, $7)
+			RETURNING id
+		`,
+			testWorkspaceID,
+			title,
+			testUserID,
+			assigneeType,
+			assigneeID,
+			number,
+			number,
+		).Scan(&issueID); err != nil {
+			t.Fatalf("insert issue %q: %v", title, err)
+		}
+		t.Cleanup(func() {
+			_, _ = testPool.Exec(context.Background(), `DELETE FROM issue WHERE id = $1`, issueID)
+		})
+		return issueID
+	}
+
+	assignedOnlyIssueID := insertIssue(
+		"assigned to working agent but not being edited",
+		finalNumber-2,
+		"agent",
+		workingAgentID,
+	)
+	editedIssueID := insertIssue(
+		"being edited by working agent but assigned to member",
+		finalNumber-1,
+		"member",
+		testUserID,
+	)
+	otherAgentIssueID := insertIssue(
+		"being edited by another agent",
+		finalNumber,
+		"agent",
+		workingAgentID,
+	)
+	createHandlerTestTaskForAgentOnIssue(t, workingAgentID, editedIssueID)
+	createHandlerTestTaskForAgentOnIssue(t, otherAgentID, otherAgentIssueID)
+
+	workingRecorder := httptest.NewRecorder()
+	testHandler.ListWorkspaceWorkingAgents(
+		workingRecorder,
+		newRequest(http.MethodGet, "/api/working-agents?type=issue", nil),
+	)
+	if workingRecorder.Code != http.StatusOK {
+		t.Fatalf(
+			"list working agents status = %d: %s",
+			workingRecorder.Code,
+			workingRecorder.Body.String(),
+		)
+	}
+	var workingAgents []WorkspaceWorkingAgent
+	if err := json.NewDecoder(workingRecorder.Body).Decode(&workingAgents); err != nil {
+		t.Fatalf("decode working agents: %v", err)
+	}
+	workingIssueIDs := make([]string, 0, 2)
+	for _, agent := range workingAgents {
+		if agent.ID == workingAgentID || agent.ID == otherAgentID {
+			workingIssueIDs = append(workingIssueIDs, agent.IssueIDs...)
+		}
+	}
+
+	listRows := func(issueIDs []string) issueTableRowsResponse {
+		t.Helper()
+		recorder := httptest.NewRecorder()
+		testHandler.ListIssueTableRows(
+			recorder,
+			newRequest(http.MethodPost, "/api/issues/table/rows", map[string]any{
+				"query": map[string]any{
+					"scope": map[string]any{"kind": "workspace"},
+					"filters": map[string]any{
+						// A map intentionally preserves [] in JSON. Marshaling
+						// issueTableFiltersRequest directly would apply its
+						// omitempty tag and turn the match-none case into no filter.
+						"working_issue_ids": issueIDs,
+					},
+					"sort": map[string]any{
+						"field":     "position",
+						"direction": "asc",
+					},
+				},
+				"group":     map[string]any{"kind": "none"},
+				"hierarchy": map[string]any{"enabled": false},
+				"page":      map[string]any{"limit": 10},
+			}),
+		)
+		if recorder.Code != http.StatusOK {
+			t.Fatalf("list rows status = %d: %s", recorder.Code, recorder.Body.String())
+		}
+		var response issueTableRowsResponse
+		if err := json.NewDecoder(recorder.Body).Decode(&response); err != nil {
+			t.Fatalf("decode rows: %v", err)
+		}
+		return response
+	}
+
+	response := listRows(workingIssueIDs)
+	if response.Total != 2 || len(response.Rows) != 2 {
+		t.Fatalf("working rows total=%d rows=%d, want two", response.Total, len(response.Rows))
+	}
+	gotIssueIDs := make(map[string]struct{}, len(response.Rows))
+	for _, row := range response.Rows {
+		gotIssueIDs[row.Issue.ID] = struct{}{}
+	}
+	if _, ok := gotIssueIDs[editedIssueID]; !ok {
+		t.Errorf("missing issue edited by selected working agent: %s", editedIssueID)
+	}
+	if _, ok := gotIssueIDs[otherAgentIssueID]; !ok {
+		t.Errorf("missing issue edited by other working agent: %s", otherAgentIssueID)
+	}
+	if _, ok := gotIssueIDs[assignedOnlyIssueID]; ok {
+		t.Errorf("included assigned-only issue without a running task: %s", assignedOnlyIssueID)
+	}
+
+	empty := listRows([]string{})
+	if empty.Total != 0 || len(empty.Rows) != 0 {
+		t.Fatalf("explicit empty working-issue filter returned total=%d rows=%d", empty.Total, len(empty.Rows))
+	}
+}
+
 func TestIssueTableCursorRejectsAnotherQuery(t *testing.T) {
 	groupKey := "status:todo"
 	cursor := issueTableCursor{

--- a/server/pkg/db/generated/agent.sql.go
+++ b/server/pkg/db/generated/agent.sql.go
@@ -4002,7 +4002,12 @@ SELECT
   a.id,
   a.name,
   a.avatar_url,
-  COUNT(*)::int AS running_task_count
+  COUNT(*)::int AS running_task_count,
+  COALESCE(
+    ARRAY_AGG(DISTINCT atq.issue_id ORDER BY atq.issue_id)
+      FILTER (WHERE atq.issue_id IS NOT NULL),
+    ARRAY[]::uuid[]
+  )::uuid[] AS issue_ids
 FROM agent a
 JOIN agent_task_queue atq ON atq.agent_id = a.id
 WHERE a.workspace_id = $1
@@ -4106,10 +4111,11 @@ type ListWorkspaceWorkingAgentsParams struct {
 }
 
 type ListWorkspaceWorkingAgentsRow struct {
-	ID               pgtype.UUID `json:"id"`
-	Name             string      `json:"name"`
-	AvatarUrl        pgtype.Text `json:"avatar_url"`
-	RunningTaskCount int32       `json:"running_task_count"`
+	ID               pgtype.UUID   `json:"id"`
+	Name             string        `json:"name"`
+	AvatarUrl        pgtype.Text   `json:"avatar_url"`
+	RunningTaskCount int32         `json:"running_task_count"`
+	IssueIds         []pgtype.UUID `json:"issue_ids"`
 }
 
 // Workspace-level source for consumers that show currently working agents.
@@ -4140,6 +4146,7 @@ func (q *Queries) ListWorkspaceWorkingAgents(ctx context.Context, arg ListWorksp
 			&i.Name,
 			&i.AvatarUrl,
 			&i.RunningTaskCount,
+			&i.IssueIds,
 		); err != nil {
 			return nil, err
 		}

--- a/server/pkg/db/queries/agent.sql
+++ b/server/pkg/db/queries/agent.sql
@@ -1246,7 +1246,12 @@ SELECT
   a.id,
   a.name,
   a.avatar_url,
-  COUNT(*)::int AS running_task_count
+  COUNT(*)::int AS running_task_count,
+  COALESCE(
+    ARRAY_AGG(DISTINCT atq.issue_id ORDER BY atq.issue_id)
+      FILTER (WHERE atq.issue_id IS NOT NULL),
+    ARRAY[]::uuid[]
+  )::uuid[] AS issue_ids
 FROM agent a
 JOIN agent_task_queue atq ON atq.agent_id = a.id
 WHERE a.workspace_id = $1


### PR DESCRIPTION
## Summary

- extend `/api/working-agents` with the distinct issue IDs referenced by each agent's filtered running tasks
- filter Table, List, Board, Swimlane, and Gantt by that issue projection instead of treating working agents as issue assignees
- preserve explicit-empty match-none semantics and keep regular assignee filters as an independent predicate
- keep My Issues relation filtering and issue/autopilot/chat source precedence in the working-agents API

## Validation

- fresh fully migrated PostgreSQL database: working-agents type/Mine matrix and endpoint-to-Table task-issue projection tests
- targeted Views Vitest: 151 passed
- Core API Vitest: 43 passed
- Core and Views TypeScript checks
- targeted Core and Views ESLint
- `go vet ./...`
- sqlc v1.31.1 generate/vet
- full Views suite: 2,893 passed; one unrelated existing failure remains in `layout/sidebar-resize.test.tsx`
