### PR TITLE
fix(daemon): probe built-in agent CLIs once per registration batch (MUL-5225)

### DIFF
--- a/server/internal/daemon/daemon.go
+++ b/server/internal/daemon/daemon.go
@@ -1222,10 +1222,14 @@ const runtimeVersionProbeConcurrency = 8
 // well inside the UI's scanning window.
 //
 // Each probe still self-heals a vanished pinned path (MUL-4486) and re-detects
-// the live version — no result is cached across registrations, so an in-place
-// CLI upgrade is still reported with its current version. A probe that fails to
+// the live version — nothing is cached on the Daemon, so an in-place CLI
+// upgrade is still reported with its current version. A probe that fails to
 // detect a version or is below the minimum supported version is logged and
 // skipped, exactly as the serial loop did.
+//
+// The result describes the machine, not a workspace, so a caller registering a
+// batch of workspaces at once calls this ONCE and passes the payload to
+// registerRuntimesForWorkspaceBatch for each workspace (MUL-5225).
 func (d *Daemon) detectBuiltinRuntimes(ctx context.Context) []map[string]string {
 	type detected struct {
 		name    string
@@ -1289,9 +1293,54 @@ func (d *Daemon) detectBuiltinRuntimes(ctx context.Context) []map[string]string 
 	return runtimes
 }
 
+// cloneRuntimeEntries deep-copies a registration runtime payload. Callers that
+// receive a shared built-in payload (see registerRuntimesForWorkspaceBatch) use
+// this before appending their own workspace's custom runtime profiles, so one
+// workspace's profiles can never leak into another's registration.
+func cloneRuntimeEntries(in []map[string]string) []map[string]string {
+	out := make([]map[string]string, 0, len(in))
+	for _, entry := range in {
+		cp := make(map[string]string, len(entry))
+		for k, v := range entry {
+			cp[k] = v
+		}
+		out = append(out, cp)
+	}
+	return out
+}
+
+// registerRuntimesForWorkspace registers this host's runtimes for one
+// workspace, probing the built-in agent CLIs itself. This is the entry point
+// for every standalone registration — a runtime_gone re-register, a profile
+// drift refresh, a recovery retry — so each of those still re-detects versions
+// and picks up an in-place CLI upgrade.
+//
+// Registering a batch of workspaces at once (daemon startup) goes through
+// registerRuntimesForWorkspaceBatch instead, which shares one probe round
+// across the batch.
 func (d *Daemon) registerRuntimesForWorkspace(ctx context.Context, workspaceID string) (*RegisterResponse, string, error) {
+	return d.registerRuntimesForWorkspaceBatch(ctx, workspaceID, d.detectBuiltinRuntimes(ctx))
+}
+
+// registerRuntimesForWorkspaceBatch registers one workspace against an already
+// detected built-in runtime payload.
+//
+// Built-in CLIs are a machine-level fact, not a per-workspace one, but
+// registration is per-workspace — so probing inside every registration made a
+// daemon serving N workspaces spawn N×M `<cli> --version` processes at startup
+// (24 workspaces × 5 agents = 120 instead of 5, MUL-5225 / #5837). Beyond the
+// wasted startup time, some CLI wrappers have visible side effects when
+// executed, and a single slow probe gets multiplied by the workspace count.
+//
+// Taking the payload as a parameter lets one probe round serve a whole
+// registration batch while keeping the refresh semantics: nothing is cached on
+// the Daemon, so the next standalone registration re-probes.
+//
+// builtins is treated as read-only and is copied before this workspace's custom
+// runtime profiles are appended.
+func (d *Daemon) registerRuntimesForWorkspaceBatch(ctx context.Context, workspaceID string, builtins []map[string]string) (*RegisterResponse, string, error) {
 	d.logger.Debug("registering runtimes for workspace", "workspace_id", workspaceID, "agent_count", len(d.cfg.Agents))
-	runtimes := d.detectBuiltinRuntimes(ctx)
+	runtimes := cloneRuntimeEntries(builtins)
 	var failedProfiles []map[string]string
 
 	// Append any workspace custom runtime profiles whose command resolves on
@@ -2158,6 +2207,23 @@ func (d *Daemon) syncWorkspacesFromAPI(ctx context.Context, reconcileProfiles bo
 	}
 	d.mu.Unlock()
 
+	// Built-in agent CLIs are installed per machine, so one probe round serves
+	// every workspace this sync has to register (MUL-5225). Probing is lazy —
+	// a sync that finds nothing new to register never shells out at all, which
+	// is the common case for the periodic sync — and scoped to this call, so
+	// the next sync re-detects and an in-place CLI upgrade is still reported.
+	var (
+		builtins       []map[string]string
+		builtinsProbed bool
+	)
+	probeBuiltins := func() []map[string]string {
+		if !builtinsProbed {
+			builtins = d.detectBuiltinRuntimes(ctx)
+			builtinsProbed = true
+		}
+		return builtins
+	}
+
 	var registered int
 	var removed int
 	for id, name := range apiIDs {
@@ -2183,7 +2249,7 @@ func (d *Daemon) syncWorkspacesFromAPI(ctx context.Context, reconcileProfiles bo
 			registered++
 			continue
 		}
-		resp, profileSig, err := d.registerRuntimesForWorkspace(ctx, id)
+		resp, profileSig, err := d.registerRuntimesForWorkspaceBatch(ctx, id, probeBuiltins())
 		if err != nil {
 			d.logger.Error("failed to register runtimes", "workspace_id", id, "name", name, "error", err)
 			continue

--- a/server/internal/daemon/daemon.go
+++ b/server/internal/daemon/daemon.go
@@ -1234,7 +1234,19 @@ var runtimeVersionProbeRetryDelay = 500 * time.Millisecond
 // and retrying it would double the worst case for the whole round — the same
 // latency that used to push the desktop runtime step into its empty "no runtime
 // found" state before probes were parallelized (MUL-5119). Only fast failures,
-// which are the transient ones, are retried. Overridable for tests.
+// which are the transient ones, are retried.
+//
+// The window is measured over the WHOLE attempt, self-heal included: a vanished
+// pinned path sends resolveAgentEntry through its own version probe of the
+// re-resolved candidate, so an attempt can spend its entire budget there and
+// still fail instantly on the outer probe of the stale path.
+//
+// One deterministic failure does slip through and get retried: a self-heal
+// candidate rejected by the minimum-version gate, whose stale path then fails
+// fast. It is not worth plumbing a reason out of resolveAgentEntry to catch —
+// the retry is bounded, and every probe in it fails fast by construction.
+//
+// Overridable for tests.
 var runtimeVersionProbeRetryWindow = time.Second
 
 // probeBuiltinRuntime resolves and version-detects one built-in provider,
@@ -1261,6 +1273,13 @@ func (d *Daemon) probeBuiltinRuntime(ctx context.Context, name string, entry Age
 			}
 		}
 		attempts++
+		// The attempt is timed from here, not from the detect call below:
+		// resolveAgentEntry runs a version probe of its own on the re-resolved
+		// candidate, and that probe can burn the whole timeout by itself. Timing
+		// only the outer call would read "slow self-heal, then an instant
+		// failure on the stale path" as a fast failure and retry it, paying the
+		// slow half twice.
+		startedAt := time.Now()
 		// Self-heal a pinned executable path an in-place upgrade deleted
 		// (MUL-4486) so version detection — and thus staying registered/online —
 		// recovers without a daemon restart. resolveAgentEntry already
@@ -1270,7 +1289,6 @@ func (d *Daemon) probeBuiltinRuntime(ctx context.Context, name string, entry Age
 		// fixes: the upgrade that removed the old path may not have published
 		// the new one yet on the first attempt.
 		resolved, _ := d.resolveAgentEntry(ctx, name, entry)
-		startedAt := time.Now()
 		version, err := detectAgentVersion(ctx, resolved.Path)
 		if err != nil {
 			lastErr = err

--- a/server/internal/daemon/daemon.go
+++ b/server/internal/daemon/daemon.go
@@ -1207,6 +1207,95 @@ func (d *Daemon) customProfileLaunchForRuntime(runtimeID string) (profileLaunchS
 // fan-out is safe even when a host has many agent CLIs installed.
 const runtimeVersionProbeConcurrency = 8
 
+// runtimeVersionProbeAttempts bounds how many times one provider's `<cli>
+// --version` probe runs inside a single probe round before that provider is
+// dropped from the registration payload.
+//
+// A round now serves a whole batch of workspace registrations (MUL-5225), so a
+// single failed attempt no longer costs one workspace its runtime — it costs
+// every workspace registered in that batch, and nothing re-probes until a
+// daemon restart or a standalone re-registration. That amplification is worth
+// one retry because the failure is usually transient: cfg.Agents only holds
+// CLIs that resolved when the daemon started, so a probe failing later is
+// typically a version manager swapping the binary in place (vanished path,
+// ETXTBSY) or fork/exec briefly failing under a startup burst. Retrying only
+// the failed providers keeps the round O(M) — it never reintroduces
+// per-workspace probing.
+const runtimeVersionProbeAttempts = 2
+
+// runtimeVersionProbeRetryDelay spaces a retry so an in-flight binary swap or a
+// momentary fork/exec failure has time to settle. Providers are probed
+// concurrently, so a round pays this once, not once per failed provider.
+// Overridable for tests.
+var runtimeVersionProbeRetryDelay = 500 * time.Millisecond
+
+// runtimeVersionProbeRetryWindow gates the retry on how quickly the failure
+// came back. A probe that burned its full timeout is a hung CLI, not a hiccup,
+// and retrying it would double the worst case for the whole round — the same
+// latency that used to push the desktop runtime step into its empty "no runtime
+// found" state before probes were parallelized (MUL-5119). Only fast failures,
+// which are the transient ones, are retried. Overridable for tests.
+var runtimeVersionProbeRetryWindow = time.Second
+
+// probeBuiltinRuntime resolves and version-detects one built-in provider,
+// retrying a fast failure up to runtimeVersionProbeAttempts times. It returns
+// false when the provider must be dropped from this round's registration
+// payload: its version could not be detected, or it is below the minimum
+// supported version.
+func (d *Daemon) probeBuiltinRuntime(ctx context.Context, name string, entry AgentEntry) (string, bool) {
+	var (
+		lastErr  error
+		attempts int
+	)
+	for attempts < runtimeVersionProbeAttempts {
+		if attempts > 0 {
+			select {
+			case <-ctx.Done():
+			case <-time.After(runtimeVersionProbeRetryDelay):
+			}
+			// A cancelled round is shutting down or already past its deadline;
+			// keep lastErr pointing at the real probe failure rather than the
+			// cancellation that stopped us from retrying it.
+			if ctx.Err() != nil {
+				break
+			}
+		}
+		attempts++
+		// Self-heal a pinned executable path an in-place upgrade deleted
+		// (MUL-4486) so version detection — and thus staying registered/online —
+		// recovers without a daemon restart. resolveAgentEntry already
+		// version-gates the healed binary; the detect + min-version check below
+		// still runs to produce the version string this registration reports.
+		// It is re-run per attempt because the heal itself can be what a retry
+		// fixes: the upgrade that removed the old path may not have published
+		// the new one yet on the first attempt.
+		resolved, _ := d.resolveAgentEntry(ctx, name, entry)
+		startedAt := time.Now()
+		version, err := detectAgentVersion(ctx, resolved.Path)
+		if err != nil {
+			lastErr = err
+			if time.Since(startedAt) >= runtimeVersionProbeRetryWindow {
+				break
+			}
+			if attempts < runtimeVersionProbeAttempts {
+				d.logger.Debug("agent version probe failed; retrying", "name", name, "attempt", attempts, "error", err)
+			}
+			continue
+		}
+		// The min-version verdict is a pure function of the detected version,
+		// so a retry would reach the same conclusion — drop the provider now.
+		if err := checkAgentMinVersion(name, version); err != nil {
+			d.logger.Warn("skip registering runtime: version too old", "name", name, "version", version, "error", err)
+			return "", false
+		}
+		d.setAgentVersion(name, version)
+		d.logger.Debug("agent version detected", "name", name, "version", version, "path", resolved.Path)
+		return version, true
+	}
+	d.logger.Warn("skip registering runtime", "name", name, "attempts", attempts, "error", lastErr)
+	return "", false
+}
+
 // detectBuiltinRuntimes version-detects every configured built-in agent CLI and
 // returns a registration entry for each one that resolves and clears the
 // minimum-version gate. Probes run concurrently, bounded by
@@ -1223,9 +1312,10 @@ const runtimeVersionProbeConcurrency = 8
 //
 // Each probe still self-heals a vanished pinned path (MUL-4486) and re-detects
 // the live version — nothing is cached on the Daemon, so an in-place CLI
-// upgrade is still reported with its current version. A probe that fails to
-// detect a version or is below the minimum supported version is logged and
-// skipped, exactly as the serial loop did.
+// upgrade is still reported with its current version. A provider whose version
+// stays undetectable across probeBuiltinRuntime's bounded attempts, or which is
+// below the minimum supported version, is logged and skipped, exactly as the
+// serial loop did.
 //
 // The result describes the machine, not a workspace, so a caller registering a
 // batch of workspaces at once calls this ONCE and passes the payload to
@@ -1244,24 +1334,10 @@ func (d *Daemon) detectBuiltinRuntimes(ctx context.Context) []map[string]string 
 	for name, entry := range d.cfg.Agents {
 		name, entry := name, entry
 		g.Go(func() error {
-			// Self-heal a pinned executable path an in-place upgrade deleted
-			// (MUL-4486) so version detection — and thus staying
-			// registered/online — recovers without a daemon restart.
-			// resolveAgentEntry already version-gates the healed binary; the
-			// detect + min-version check below still runs to produce the
-			// version string this registration reports.
-			entry, _ = d.resolveAgentEntry(ctx, name, entry)
-			version, err := detectAgentVersion(ctx, entry.Path)
-			if err != nil {
-				d.logger.Warn("skip registering runtime", "name", name, "error", err)
+			version, ok := d.probeBuiltinRuntime(ctx, name, entry)
+			if !ok {
 				return nil
 			}
-			if err := checkAgentMinVersion(name, version); err != nil {
-				d.logger.Warn("skip registering runtime: version too old", "name", name, "version", version, "error", err)
-				return nil
-			}
-			d.setAgentVersion(name, version)
-			d.logger.Debug("agent version detected", "name", name, "version", version, "path", entry.Path)
 			mu.Lock()
 			results = append(results, detected{name: name, version: version})
 			mu.Unlock()

--- a/server/internal/daemon/runtime_probe_batch_test.go
+++ b/server/internal/daemon/runtime_probe_batch_test.go
@@ -1,0 +1,325 @@
+package daemon
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"sort"
+	"strconv"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+)
+
+// batchFixture wires a Daemon against a fake server that serves a configurable
+// workspace list, per-workspace runtime profiles, and a register endpoint that
+// records the runtime payload each workspace was registered with. It also
+// counts `<cli> --version` probes per executable path so a test can assert the
+// daemon probed the machine's built-in CLIs once per sync instead of once per
+// workspace (MUL-5225).
+type batchFixture struct {
+	daemon *Daemon
+	server *httptest.Server
+
+	mu sync.Mutex
+	// workspaces is the workspace list the fake server returns.
+	workspaces []WorkspaceInfo
+	// profiles maps a workspace ID to the custom runtime profiles the server
+	// reports for it.
+	profiles map[string][]RuntimeProfile
+	// registered records, in call order, the workspace ID and the "type" of
+	// every runtime in that Register call's payload.
+	registered []registeredCall
+	// probes counts detectAgentVersion calls per executable path.
+	probes map[string]int
+}
+
+type registeredCall struct {
+	workspaceID string
+	types       []string
+}
+
+func (fx *batchFixture) setWorkspaces(ws ...WorkspaceInfo) {
+	fx.mu.Lock()
+	defer fx.mu.Unlock()
+	fx.workspaces = ws
+}
+
+func (fx *batchFixture) probeCount(path string) int {
+	fx.mu.Lock()
+	defer fx.mu.Unlock()
+	return fx.probes[path]
+}
+
+// registrationFor returns the runtime types registered for a workspace, and
+// how many Register calls that workspace received.
+func (fx *batchFixture) registrationFor(workspaceID string) ([]string, int) {
+	fx.mu.Lock()
+	defer fx.mu.Unlock()
+	var types []string
+	var calls int
+	for _, call := range fx.registered {
+		if call.workspaceID == workspaceID {
+			types = call.types
+			calls++
+		}
+	}
+	return types, calls
+}
+
+func (fx *batchFixture) registerCallCount() int {
+	fx.mu.Lock()
+	defer fx.mu.Unlock()
+	return len(fx.registered)
+}
+
+func newBatchFixture(t *testing.T) *batchFixture {
+	t.Helper()
+	fx := &batchFixture{
+		profiles: make(map[string][]RuntimeProfile),
+		probes:   make(map[string]int),
+	}
+
+	origDetect := detectAgentVersion
+	origCheck := checkAgentMinVersion
+	t.Cleanup(func() {
+		detectAgentVersion = origDetect
+		checkAgentMinVersion = origCheck
+	})
+	detectAgentVersion = func(_ context.Context, path string) (string, error) {
+		fx.mu.Lock()
+		fx.probes[path]++
+		fx.mu.Unlock()
+		return "9.9.9", nil
+	}
+	checkAgentMinVersion = func(_, _ string) error { return nil }
+
+	var runtimeSeq atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/api/daemon/workspaces":
+			fx.mu.Lock()
+			list := append([]WorkspaceInfo(nil), fx.workspaces...)
+			fx.mu.Unlock()
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(list)
+		case r.URL.Path == "/api/daemon/register":
+			var body struct {
+				WorkspaceID string              `json:"workspace_id"`
+				Runtimes    []map[string]string `json:"runtimes"`
+			}
+			_ = json.NewDecoder(r.Body).Decode(&body)
+			call := registeredCall{workspaceID: body.WorkspaceID}
+			var resp RegisterResponse
+			for _, rt := range body.Runtimes {
+				call.types = append(call.types, rt["type"])
+				resp.Runtimes = append(resp.Runtimes, Runtime{
+					ID:        "rt-" + strconv.Itoa(int(runtimeSeq.Add(1))),
+					Name:      rt["name"],
+					Provider:  rt["type"],
+					Status:    "online",
+					ProfileID: rt["profile_id"],
+				})
+			}
+			fx.mu.Lock()
+			fx.registered = append(fx.registered, call)
+			fx.mu.Unlock()
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(resp)
+		case strings.HasSuffix(r.URL.Path, "/runtime-profiles"):
+			workspaceID := strings.TrimSuffix(strings.TrimPrefix(r.URL.Path, "/api/daemon/workspaces/"), "/runtime-profiles")
+			fx.mu.Lock()
+			profiles := fx.profiles[workspaceID]
+			fx.mu.Unlock()
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(RuntimeProfilesResponse{
+				WorkspaceID:     workspaceID,
+				RuntimeProfiles: profiles,
+			})
+		default:
+			w.WriteHeader(http.StatusOK)
+		}
+	}))
+	t.Cleanup(srv.Close)
+
+	d := freshDaemon(srv.URL)
+	d.profileLaunchSpecs = make(map[string]profileLaunchSpec)
+	fx.daemon = d
+	fx.server = srv
+	return fx
+}
+
+// TestSyncWorkspaces_ProbesBuiltinCLIsOncePerBatch is the MUL-5225 regression:
+// registering N workspaces must execute each built-in agent CLI's `--version`
+// once for the machine, not once per workspace, while still sending one
+// Register call per workspace with the full built-in payload.
+func TestSyncWorkspaces_ProbesBuiltinCLIsOncePerBatch(t *testing.T) {
+	fx := newBatchFixture(t)
+	d := fx.daemon
+	d.cfg.Agents = map[string]AgentEntry{
+		"claude": {Path: "/fake/claude"},
+		"codex":  {Path: "/fake/codex"},
+	}
+	fx.setWorkspaces(
+		WorkspaceInfo{ID: "ws-1", Name: "one"},
+		WorkspaceInfo{ID: "ws-2", Name: "two"},
+	)
+
+	if err := d.syncWorkspacesFromAPI(context.Background(), false); err != nil {
+		t.Fatalf("syncWorkspacesFromAPI: %v", err)
+	}
+
+	for _, path := range []string{"/fake/claude", "/fake/codex"} {
+		if got := fx.probeCount(path); got != 1 {
+			t.Errorf("probed %s %d times, want 1 (built-ins are machine-level, not per-workspace)", path, got)
+		}
+	}
+
+	// Sharing the probe must not collapse the registrations themselves: both
+	// workspaces still register, each with the same built-in runtimes.
+	if got := fx.registerCallCount(); got != 2 {
+		t.Fatalf("got %d Register calls, want 2 (one per workspace)", got)
+	}
+	for _, workspaceID := range []string{"ws-1", "ws-2"} {
+		types, calls := fx.registrationFor(workspaceID)
+		if calls != 1 {
+			t.Errorf("%s registered %d times, want 1", workspaceID, calls)
+		}
+		sort.Strings(types)
+		if len(types) != 2 || types[0] != "claude" || types[1] != "codex" {
+			t.Errorf("%s registered runtimes %v, want [claude codex]", workspaceID, types)
+		}
+	}
+}
+
+// TestSyncWorkspaces_CustomProfilesDoNotLeakAcrossWorkspaces guards the sharing
+// mechanism: the batch built-in payload is reused by reference-free copy, so a
+// workspace-scoped custom runtime profile must land only in its own
+// registration.
+func TestSyncWorkspaces_CustomProfilesDoNotLeakAcrossWorkspaces(t *testing.T) {
+	fx := newBatchFixture(t)
+	stubLookPath(t, map[string]string{"company-codex": "/opt/bin/company-codex"})
+	d := fx.daemon
+	d.cfg.Agents = map[string]AgentEntry{"claude": {Path: "/fake/claude"}}
+	fx.setWorkspaces(
+		WorkspaceInfo{ID: "ws-1", Name: "one"},
+		WorkspaceInfo{ID: "ws-2", Name: "two"},
+	)
+	fx.profiles["ws-1"] = []RuntimeProfile{{
+		ID: "prof-1", WorkspaceID: "ws-1", DisplayName: "Company Codex",
+		ProtocolFamily: "codex", CommandName: "company-codex",
+		Visibility: "workspace", Enabled: true,
+	}}
+
+	if err := d.syncWorkspacesFromAPI(context.Background(), false); err != nil {
+		t.Fatalf("syncWorkspacesFromAPI: %v", err)
+	}
+
+	withProfile, _ := fx.registrationFor("ws-1")
+	sort.Strings(withProfile)
+	if len(withProfile) != 2 || withProfile[0] != "claude" || withProfile[1] != "codex" {
+		t.Errorf("ws-1 registered %v, want its built-in plus its custom profile [claude codex]", withProfile)
+	}
+
+	withoutProfile, _ := fx.registrationFor("ws-2")
+	if len(withoutProfile) != 1 || withoutProfile[0] != "claude" {
+		t.Errorf("ws-2 registered %v, want only the built-in [claude]; ws-1's profile leaked", withoutProfile)
+	}
+}
+
+// TestSyncWorkspaces_ReprobesOnNextSync pins the refresh semantics the sharing
+// must not break: the payload is scoped to one sync, so a workspace that shows
+// up later re-detects versions and picks up an in-place CLI upgrade.
+func TestSyncWorkspaces_ReprobesOnNextSync(t *testing.T) {
+	fx := newBatchFixture(t)
+	d := fx.daemon
+	d.cfg.Agents = map[string]AgentEntry{"claude": {Path: "/fake/claude"}}
+
+	fx.setWorkspaces(WorkspaceInfo{ID: "ws-1", Name: "one"})
+	if err := d.syncWorkspacesFromAPI(context.Background(), false); err != nil {
+		t.Fatalf("first sync: %v", err)
+	}
+	if got := fx.probeCount("/fake/claude"); got != 1 {
+		t.Fatalf("first sync probed %d times, want 1", got)
+	}
+
+	fx.setWorkspaces(
+		WorkspaceInfo{ID: "ws-1", Name: "one"},
+		WorkspaceInfo{ID: "ws-2", Name: "two"},
+	)
+	if err := d.syncWorkspacesFromAPI(context.Background(), false); err != nil {
+		t.Fatalf("second sync: %v", err)
+	}
+	if got := fx.probeCount("/fake/claude"); got != 2 {
+		t.Fatalf("second sync probed %d times total, want 2 (one fresh probe for the new workspace)", got)
+	}
+}
+
+// TestSyncWorkspaces_SkipsProbeWhenNothingToRegister keeps the periodic sync
+// free of side effects. Every workspace is already tracked and healthy, so the
+// lazy probe must never fire — this is what stops a 30-minute sync from
+// re-executing agent CLI wrappers on a steady-state daemon.
+func TestSyncWorkspaces_SkipsProbeWhenNothingToRegister(t *testing.T) {
+	fx := newBatchFixture(t)
+	d := fx.daemon
+	d.cfg.Agents = map[string]AgentEntry{"claude": {Path: "/fake/claude"}}
+	fx.setWorkspaces(WorkspaceInfo{ID: "ws-1", Name: "one"})
+	d.workspaces["ws-1"] = newWorkspaceState("ws-1", []string{"rt-1"}, "", nil, nil)
+	d.runtimeIndex["rt-1"] = Runtime{ID: "rt-1", Provider: "claude"}
+
+	if err := d.syncWorkspacesFromAPI(context.Background(), false); err != nil {
+		t.Fatalf("syncWorkspacesFromAPI: %v", err)
+	}
+
+	if got := fx.probeCount("/fake/claude"); got != 0 {
+		t.Fatalf("steady-state sync probed %d times, want 0", got)
+	}
+}
+
+// TestRegisterRuntimesForWorkspace_ProbesOnStandaloneCall pins the other half of
+// the contract: a standalone registration (runtime_gone re-register, profile
+// drift refresh, recovery retry) still runs its own probe round, so it reports
+// the CLI version live at that moment rather than one cached from startup.
+func TestRegisterRuntimesForWorkspace_ProbesOnStandaloneCall(t *testing.T) {
+	fx := newBatchFixture(t)
+	d := fx.daemon
+	d.cfg.Agents = map[string]AgentEntry{"claude": {Path: "/fake/claude"}}
+
+	for i := 1; i <= 2; i++ {
+		if _, _, err := d.registerRuntimesForWorkspace(context.Background(), "ws-1"); err != nil {
+			t.Fatalf("register #%d: %v", i, err)
+		}
+		if got := fx.probeCount("/fake/claude"); got != i {
+			t.Fatalf("after %d standalone registrations, probed %d times; want %d", i, got, i)
+		}
+	}
+}
+
+// TestRegisterRuntimesForWorkspaceBatch_DoesNotMutateSharedPayload asserts the
+// callee treats the shared built-in payload as read-only. Without the copy, the
+// first workspace's custom profile would be appended into the slice the batch
+// hands to every later workspace.
+func TestRegisterRuntimesForWorkspaceBatch_DoesNotMutateSharedPayload(t *testing.T) {
+	fx := newBatchFixture(t)
+	stubLookPath(t, map[string]string{"company-codex": "/opt/bin/company-codex"})
+	d := fx.daemon
+	d.cfg.Agents = map[string]AgentEntry{}
+	fx.profiles["ws-1"] = []RuntimeProfile{{
+		ID: "prof-1", WorkspaceID: "ws-1", DisplayName: "Company Codex",
+		ProtocolFamily: "codex", CommandName: "company-codex",
+		Visibility: "workspace", Enabled: true,
+	}}
+
+	builtins := []map[string]string{
+		{"name": "Claude Code", "type": "claude", "version": "9.9.9", "status": "online"},
+	}
+	if _, _, err := d.registerRuntimesForWorkspaceBatch(context.Background(), "ws-1", builtins); err != nil {
+		t.Fatalf("batch register: %v", err)
+	}
+
+	if len(builtins) != 1 || builtins[0]["type"] != "claude" {
+		t.Fatalf("shared built-in payload was mutated: %v", builtins)
+	}
+}

--- a/server/internal/daemon/runtime_probe_batch_test.go
+++ b/server/internal/daemon/runtime_probe_batch_test.go
@@ -6,6 +6,9 @@ import (
 	"errors"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"runtime"
 	"sort"
 	"strconv"
 	"strings"
@@ -427,6 +430,117 @@ func TestDetectBuiltinRuntimes_DoesNotRetrySlowProbe(t *testing.T) {
 	}
 	if got := fx.probeCount("/fake/codex"); got != 1 {
 		t.Errorf("probed /fake/codex %d times, want 1 (a probe that ran to its timeout is not retried)", got)
+	}
+}
+
+// vanishedPinnedPath lays out the MUL-4486 shape a probe retry has to reckon
+// with: a stable command name that resolves on PATH to a runnable stub, plus
+// the pinned absolute path an in-place upgrade already deleted. It returns the
+// missing pinned path and the path the self-heal re-resolves to.
+func vanishedPinnedPath(t *testing.T) (missing, healed string) {
+	t.Helper()
+	root := t.TempDir()
+	stableBin := filepath.Join(root, "bin")
+	writeExecStub(t, filepath.Join(stableBin, "codex"))
+	// Prepend rather than replace: exec.LookPath takes the first match, so the
+	// stub still wins deterministically over any codex installed on the host,
+	// while goroutines left running by earlier tests can still resolve git/sh.
+	t.Setenv("PATH", stableBin+string(os.PathListSeparator)+os.Getenv("PATH"))
+	// An unsupported shell disables the login-shell fallback, which would only
+	// run if the lookup above missed.
+	t.Setenv("SHELL", filepath.Join(t.TempDir(), "fish"))
+	return filepath.Join(root, "gone", "codex"), canonicalExecutablePath(filepath.Join(stableBin, "codex"))
+}
+
+// countingVersionProbe swaps detectAgentVersion for a stub that counts calls
+// and answers per path, so a test can assert how many `--version` executions a
+// probe round actually cost.
+func countingVersionProbe(t *testing.T, answer func(path string) (string, error)) *atomic.Int32 {
+	t.Helper()
+	origDetect := detectAgentVersion
+	origCheck := checkAgentMinVersion
+	t.Cleanup(func() {
+		detectAgentVersion = origDetect
+		checkAgentMinVersion = origCheck
+	})
+	var probes atomic.Int32
+	detectAgentVersion = func(_ context.Context, path string) (string, error) {
+		probes.Add(1)
+		return answer(path)
+	}
+	checkAgentMinVersion = func(_, _ string) error { return nil }
+	return &probes
+}
+
+// TestDetectBuiltinRuntimes_DoesNotRetryWhenSelfHealBurnsTheWindow keeps the
+// slow-probe guard honest about where an attempt's time actually goes. When the
+// pinned path has vanished, resolveAgentEntry runs its own version probe on the
+// re-resolved candidate (MUL-4486) — which can burn the full 10s timeout on its
+// own. Timing only the outer probe would read the attempt as a fast failure
+// (the stale path fails instantly), retry, and pay the slow self-heal a second
+// time — exactly the doubled worst case the guard exists to prevent.
+func TestDetectBuiltinRuntimes_DoesNotRetryWhenSelfHealBurnsTheWindow(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("PATH/exec-bit stub layout is POSIX-specific")
+	}
+	const probeWindow = 20 * time.Millisecond
+	stubProbeRetry(t, time.Millisecond, probeWindow)
+	missing, _ := vanishedPinnedPath(t)
+	probes := countingVersionProbe(t, func(path string) (string, error) {
+		if path == missing {
+			// The stale pinned path is gone: this fails immediately.
+			return "", errors.New("no such file or directory")
+		}
+		// The re-resolved candidate hangs and dies on its own timeout.
+		time.Sleep(2 * probeWindow)
+		return "", errors.New("signal: killed")
+	})
+
+	d := freshDaemon("")
+	d.cfg.Agents = map[string]AgentEntry{"codex": {Path: missing, Command: "codex"}}
+
+	if runtimes := d.detectBuiltinRuntimes(context.Background()); len(runtimes) != 0 {
+		t.Fatalf("detected %v, want none", runtimes)
+	}
+	if got := probes.Load(); got != 2 {
+		t.Errorf("ran %d version probes, want 2 (one self-heal + one outer probe); the retry window must cover the whole attempt, not just the outer probe", got)
+	}
+}
+
+// TestDetectBuiltinRuntimes_BoundsRetryWhenSelfHealRejectsVersion documents the
+// cost of the case the retry cannot tell apart: a self-heal candidate rejected
+// by the min-version gate leaves the stale path in place, and the outer probe
+// then fails fast — indistinguishable from a transient failure, so the attempt
+// is retried. The verdict is deterministic, so that retry is wasted work; what
+// matters is that it stays bounded and cheap (every probe in it fails fast).
+func TestDetectBuiltinRuntimes_BoundsRetryWhenSelfHealRejectsVersion(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("PATH/exec-bit stub layout is POSIX-specific")
+	}
+	stubProbeRetry(t, time.Millisecond, time.Second)
+	missing, healed := vanishedPinnedPath(t)
+	probes := countingVersionProbe(t, func(path string) (string, error) {
+		if path == missing {
+			return "", errors.New("no such file or directory")
+		}
+		return "0.0.1", nil
+	})
+	checkAgentMinVersion = func(_, version string) error {
+		if version == "0.0.1" {
+			return errors.New("version too old")
+		}
+		return nil
+	}
+
+	d := freshDaemon("")
+	d.cfg.Agents = map[string]AgentEntry{"codex": {Path: missing, Command: "codex"}}
+
+	if runtimes := d.detectBuiltinRuntimes(context.Background()); len(runtimes) != 0 {
+		t.Fatalf("detected %v (healed path %q), want none: a below-minimum candidate must not be adopted", runtimes, healed)
+	}
+	// Two attempts, each paying one self-heal probe plus one outer probe.
+	if got := probes.Load(); got != int32(2*runtimeVersionProbeAttempts) {
+		t.Errorf("ran %d version probes, want %d (%d bounded attempts)", got, 2*runtimeVersionProbeAttempts, runtimeVersionProbeAttempts)
 	}
 }
 

--- a/server/internal/daemon/runtime_probe_batch_test.go
+++ b/server/internal/daemon/runtime_probe_batch_test.go
@@ -3,6 +3,7 @@ package daemon
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"sort"
@@ -11,6 +12,7 @@ import (
 	"sync"
 	"sync/atomic"
 	"testing"
+	"time"
 )
 
 // batchFixture wires a Daemon against a fake server that serves a configurable
@@ -34,6 +36,10 @@ type batchFixture struct {
 	registered []registeredCall
 	// probes counts detectAgentVersion calls per executable path.
 	probes map[string]int
+	// probeErr, when set, is consulted by the version probe stub before it
+	// succeeds. It receives the executable path and the 1-based attempt count
+	// for that path, and returns a non-nil error to fail that attempt.
+	probeErr func(path string, attempt int) error
 }
 
 type registeredCall struct {
@@ -51,6 +57,12 @@ func (fx *batchFixture) probeCount(path string) int {
 	fx.mu.Lock()
 	defer fx.mu.Unlock()
 	return fx.probes[path]
+}
+
+func (fx *batchFixture) setProbeErr(fn func(path string, attempt int) error) {
+	fx.mu.Lock()
+	defer fx.mu.Unlock()
+	fx.probeErr = fn
 }
 
 // registrationFor returns the runtime types registered for a workspace, and
@@ -91,7 +103,14 @@ func newBatchFixture(t *testing.T) *batchFixture {
 	detectAgentVersion = func(_ context.Context, path string) (string, error) {
 		fx.mu.Lock()
 		fx.probes[path]++
+		attempt := fx.probes[path]
+		probeErr := fx.probeErr
 		fx.mu.Unlock()
+		if probeErr != nil {
+			if err := probeErr(path, attempt); err != nil {
+				return "", err
+			}
+		}
 		return "9.9.9", nil
 	}
 	checkAgentMinVersion = func(_, _ string) error { return nil }
@@ -294,6 +313,143 @@ func TestRegisterRuntimesForWorkspace_ProbesOnStandaloneCall(t *testing.T) {
 		if got := fx.probeCount("/fake/claude"); got != i {
 			t.Fatalf("after %d standalone registrations, probed %d times; want %d", i, got, i)
 		}
+	}
+}
+
+// stubProbeRetry shrinks the version-probe retry knobs so a test can exercise
+// the retry path without paying the production delay, and can classify a probe
+// as "slow" (not worth retrying) without sleeping for a real second.
+func stubProbeRetry(t *testing.T, delay, window time.Duration) {
+	t.Helper()
+	origDelay, origWindow := runtimeVersionProbeRetryDelay, runtimeVersionProbeRetryWindow
+	t.Cleanup(func() {
+		runtimeVersionProbeRetryDelay = origDelay
+		runtimeVersionProbeRetryWindow = origWindow
+	})
+	runtimeVersionProbeRetryDelay = delay
+	runtimeVersionProbeRetryWindow = window
+}
+
+// TestSyncWorkspaces_RetriesFailedProbeForWholeBatch is the fail-once
+// regression for the batch reuse. One probe round now serves every workspace
+// the sync registers, so a single transient `--version` failure would otherwise
+// drop that provider from ALL of them at once — and nothing would restore it,
+// because workspaceNeedsRuntimeRecovery only retries a workspace that lost
+// every runtime. A fast failure gets one more attempt before the provider is
+// dropped.
+func TestSyncWorkspaces_RetriesFailedProbeForWholeBatch(t *testing.T) {
+	fx := newBatchFixture(t)
+	stubProbeRetry(t, time.Millisecond, time.Second)
+	d := fx.daemon
+	d.cfg.Agents = map[string]AgentEntry{
+		"claude": {Path: "/fake/claude"},
+		"codex":  {Path: "/fake/codex"},
+	}
+	// codex fails its first attempt only — the transient shape of an in-place
+	// CLI upgrade briefly removing the binary.
+	fx.setProbeErr(func(path string, attempt int) error {
+		if path == "/fake/codex" && attempt == 1 {
+			return errors.New("fork/exec: resource temporarily unavailable")
+		}
+		return nil
+	})
+	fx.setWorkspaces(
+		WorkspaceInfo{ID: "ws-1", Name: "one"},
+		WorkspaceInfo{ID: "ws-2", Name: "two"},
+	)
+
+	if err := d.syncWorkspacesFromAPI(context.Background(), false); err != nil {
+		t.Fatalf("syncWorkspacesFromAPI: %v", err)
+	}
+
+	if got := fx.probeCount("/fake/codex"); got != 2 {
+		t.Errorf("probed /fake/codex %d times, want 2 (one failure + one retry)", got)
+	}
+	// The retry is scoped to the provider that failed: a healthy CLI is not
+	// re-probed just because a sibling stumbled.
+	if got := fx.probeCount("/fake/claude"); got != 1 {
+		t.Errorf("probed /fake/claude %d times, want 1 (only the failed provider retries)", got)
+	}
+	for _, workspaceID := range []string{"ws-1", "ws-2"} {
+		types, _ := fx.registrationFor(workspaceID)
+		sort.Strings(types)
+		if len(types) != 2 || types[0] != "claude" || types[1] != "codex" {
+			t.Errorf("%s registered %v, want [claude codex]; one transient probe failure cost the whole batch a runtime", workspaceID, types)
+		}
+	}
+}
+
+// TestDetectBuiltinRuntimes_DropsProviderAfterRetriesExhausted keeps the retry
+// bounded: a provider that keeps failing is still dropped from the payload
+// after runtimeVersionProbeAttempts, and the healthy providers still register.
+func TestDetectBuiltinRuntimes_DropsProviderAfterRetriesExhausted(t *testing.T) {
+	fx := newBatchFixture(t)
+	stubProbeRetry(t, time.Millisecond, time.Second)
+	d := fx.daemon
+	d.cfg.Agents = map[string]AgentEntry{
+		"claude": {Path: "/fake/claude"},
+		"codex":  {Path: "/fake/codex"},
+	}
+	fx.setProbeErr(func(path string, _ int) error {
+		if path == "/fake/codex" {
+			return errors.New("no such file or directory")
+		}
+		return nil
+	})
+
+	runtimes := d.detectBuiltinRuntimes(context.Background())
+
+	if got := fx.probeCount("/fake/codex"); got != runtimeVersionProbeAttempts {
+		t.Errorf("probed /fake/codex %d times, want %d (retry must stay bounded)", got, runtimeVersionProbeAttempts)
+	}
+	if len(runtimes) != 1 || runtimes[0]["type"] != "claude" {
+		t.Errorf("detected %v, want only claude", runtimes)
+	}
+}
+
+// TestDetectBuiltinRuntimes_DoesNotRetrySlowProbe protects registration
+// latency. A probe that burned its whole timeout is a hung CLI, not a hiccup;
+// retrying it would double the round's worst case, which is the latency that
+// used to strand the desktop runtime step in its empty state (MUL-5119).
+func TestDetectBuiltinRuntimes_DoesNotRetrySlowProbe(t *testing.T) {
+	fx := newBatchFixture(t)
+	const probeWindow = 20 * time.Millisecond
+	stubProbeRetry(t, time.Millisecond, probeWindow)
+	d := fx.daemon
+	d.cfg.Agents = map[string]AgentEntry{"codex": {Path: "/fake/codex"}}
+	fx.setProbeErr(func(path string, _ int) error {
+		time.Sleep(2 * probeWindow)
+		return errors.New("signal: killed")
+	})
+
+	if runtimes := d.detectBuiltinRuntimes(context.Background()); len(runtimes) != 0 {
+		t.Fatalf("detected %v, want none", runtimes)
+	}
+	if got := fx.probeCount("/fake/codex"); got != 1 {
+		t.Errorf("probed /fake/codex %d times, want 1 (a probe that ran to its timeout is not retried)", got)
+	}
+}
+
+// TestDetectBuiltinRuntimes_DoesNotRetryMinVersionRejection pins the other
+// no-retry case: the minimum-version verdict is a pure function of the detected
+// version, so a second probe would reach the same conclusion.
+func TestDetectBuiltinRuntimes_DoesNotRetryMinVersionRejection(t *testing.T) {
+	fx := newBatchFixture(t)
+	stubProbeRetry(t, time.Millisecond, time.Second)
+	checkAgentMinVersion = func(provider, _ string) error {
+		if provider == "codex" {
+			return errors.New("version too old")
+		}
+		return nil
+	}
+	d := fx.daemon
+	d.cfg.Agents = map[string]AgentEntry{"codex": {Path: "/fake/codex"}}
+
+	if runtimes := d.detectBuiltinRuntimes(context.Background()); len(runtimes) != 0 {
+		t.Fatalf("detected %v, want none", runtimes)
+	}
+	if got := fx.probeCount("/fake/codex"); got != 1 {
+		t.Errorf("probed /fake/codex %d times, want 1 (a below-minimum version is not retried)", got)
 	}
 }
 

--- a/server/internal/daemon/runtime_probe_concurrency_test.go
+++ b/server/internal/daemon/runtime_probe_concurrency_test.go
@@ -73,6 +73,9 @@ func TestDetectBuiltinRuntimes_ProbesRunConcurrently(t *testing.T) {
 // version detection or the min-version gate is dropped from the payload while
 // the healthy ones still register — matching the old serial loop's semantics.
 func TestDetectBuiltinRuntimes_SkipsFailedProbes(t *testing.T) {
+	// /broken fails fast, so it earns its bounded retry before being dropped;
+	// shrink the retry delay so this test doesn't wait out the real one.
+	stubProbeRetry(t, time.Millisecond, time.Second)
 	origDetect := detectAgentVersion
 	origCheck := checkAgentMinVersion
 	t.Cleanup(func() {


### PR DESCRIPTION
Fixes #5837.

## Problem

Built-in agent CLIs are installed per machine, but runtime registration is per-workspace — and `registerRuntimesForWorkspace` called `detectBuiltinRuntimes` every time. On daemon startup `syncWorkspacesFromAPI` registers each workspace in turn, so a host with N workspaces and M built-in agents spawned N×M `<cli> --version` processes instead of M. The reported case (24 workspaces × 5 agents) runs 120 probes where 5 would do.

Probes within a single workspace already fan out concurrently (#5756 / MUL-5119), so this was never a hang — but the process count is real, some CLI wrappers have visible side effects when executed (repeated macOS Dock churn), and a single slow probe (10s timeout) gets multiplied by the workspace count.

## Change

### 1. One probe round per registration batch

Split `registerRuntimesForWorkspaceBatch` out of `registerRuntimesForWorkspace` so it takes an already-detected built-in payload. `syncWorkspacesFromAPI` detects once per sync and reuses that payload for every workspace it registers.

Two properties are deliberately preserved:

- **Nothing is cached on the `Daemon`.** The payload is scoped to one sync call. Every standalone registration — `runtime_gone` re-register, profile drift refresh, recovery retry — still runs its own probe round, so an in-place CLI upgrade is reported with its current version. That was the explicit reason #5756 avoided caching, and a permanent `agentVersions` reuse would have broken it.
- **The probe is lazy.** A sync that finds nothing new to register never shells out. This is the common case for the periodic 30-minute sync on a steady-state daemon.

Each workspace copies the shared payload before appending its own custom runtime profiles, so a workspace-scoped profile can't leak into another workspace's registration.

### 2. A failed probe is retried before the provider is dropped

Sharing the round changes what one failed probe costs: it no longer drops a provider from a single workspace, it drops it from *every* workspace the batch registers — and nothing restores it, because `workspaceNeedsRuntimeRecovery` only retries a workspace that lost **all** of its runtimes. The provider would stay missing until a daemon restart, a profile-drift refresh, or a `runtime_gone` re-registration.

So each failed provider gets one bounded retry (`runtimeVersionProbeAttempts = 2`, 500 ms apart) inside the same round. Only the failed providers retry, so the round stays O(M) and per-workspace probing never comes back.

The dominant failure mode here is transient: `cfg.Agents` only holds CLIs that resolved at daemon startup, so a probe failing later is usually a version manager swapping the binary in place (vanished path, `ETXTBSY`) or fork/exec briefly failing under a startup burst. The agent entry is re-resolved on every attempt, so the MUL-4486 self-heal gets the second chance too.

Two failures are deliberately **not** retried:

- **A probe that ran to its timeout.** That is a hung CLI, not a hiccup, and retrying it would double the round's worst case — the latency that used to strand the desktop runtime step in its empty "no runtime found" state (#5756). The window is measured across the *whole* attempt, self-heal included: `resolveAgentEntry` runs a version probe of its own on the re-resolved candidate, so an attempt can spend its entire budget there and still fail instantly on the outer probe of the stale path.
- **A below-minimum version.** That verdict is a pure function of the detected version.

One deterministic case does still get retried: a self-heal candidate rejected by the min-version gate, whose stale path then fails fast — indistinguishable from a transient failure without plumbing a reason out of `resolveAgentEntry`. It is documented in the code and pinned by a test; the retry is bounded and every probe in it fails fast.

Path self-healing (MUL-4486), the minimum-version gate, and the registration payload shape are unchanged. A provider that keeps failing is still dropped from the payload, now after the bounded retry rather than on the first failure.

## Tests

All in `server/internal/daemon/runtime_probe_batch_test.go`.

Batch reuse:

- 2 workspaces × 2 built-ins → each CLI probed exactly once, but still 2 Register calls, each carrying both built-ins.
- A workspace's custom runtime profile lands only in its own registration.
- A workspace appearing in a later sync triggers a fresh probe round.
- A steady-state sync with nothing to register performs zero probes.
- A standalone `registerRuntimesForWorkspace` call probes every time.
- The shared built-in payload is not mutated by the callee.

Retry and its bounds:

- Fail-once during a batch: the provider still registers for every workspace in the batch, and only the provider that failed re-probes.
- A provider that keeps failing is dropped after exactly `runtimeVersionProbeAttempts`.
- A probe that runs past the retry window is executed once, not retried.
- A below-minimum version is probed once.
- A slow failure *inside* the self-heal is not retried: one self-heal probe plus one outer probe, not two of each. Built on a real missing pinned path with a re-resolvable command.
- A min-version rejection inside the self-heal stays bounded at two attempts.

## Verification

```
go test ./internal/daemon/... -count=1      # ok (all three packages, several runs)
go test ./internal/daemon/ -race -count=1 \
  -run 'TestSyncWorkspaces|TestDetectBuiltinRuntimes|TestRegisterRuntimes|TestResolveAgentEntry'   # ok
go vet ./internal/daemon/...                # clean
go build ./...                              # ok
```

Each regression test was confirmed red before its fix: with `runtimeVersionProbeAttempts = 1` the fail-once test loses the provider for both workspaces; before the timing fix the slow-self-heal test runs 4 probes where 2 are correct.

The change was also exercised outside the stubs, with a throwaway test (not included here) that leaves `detectAgentVersion` at the real `agent.DetectVersion` and probes test-created shell scripts using the production retry knobs: a healthy CLI executes once and registers, a fast-failing one executes twice, a 1.5 s-failing one executes once, and the round costs one slow probe (1.52 s) rather than two.

Existing registration, profile-drift, and runtime-gone tests pass unchanged.
