### PR TITLE
MUL-5232: fix(desktop): authenticate native attachment downloads safely

### DIFF
--- a/apps/desktop/src/main/download-authorization.test.ts
+++ b/apps/desktop/src/main/download-authorization.test.ts
@@ -1,0 +1,245 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  PendingDownloadAuthorizations,
+  sanitizeBearerAuthorization,
+  type DownloadRequestDetails,
+} from "./download-authorization";
+
+const API_BASE_URL = "https://api.example.test";
+const WEB_CONTENTS_ID = 7;
+const ATTACHMENT_URL =
+  "https://api.example.test/api/attachments/11111111-2222-3333-4444-555555555555/download?workspace_slug=acme";
+
+function request(
+  id: number,
+  url: string,
+  requestHeaders: Record<string, string> = {},
+  webContentsId = WEB_CONTENTS_ID,
+): DownloadRequestDetails {
+  return { id, url, webContentsId, requestHeaders };
+}
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("sanitizeBearerAuthorization", () => {
+  it("accepts a non-empty bearer header and trims outer whitespace", () => {
+    expect(sanitizeBearerAuthorization(" Bearer jwt-token ")).toBe(
+      "Bearer jwt-token",
+    );
+  });
+
+  it("rejects malformed, newline-bearing, and oversized values", () => {
+    expect(sanitizeBearerAuthorization(undefined)).toBeNull();
+    expect(sanitizeBearerAuthorization("Bearer ")).toBeNull();
+    expect(sanitizeBearerAuthorization("Token jwt-token")).toBeNull();
+    expect(
+      sanitizeBearerAuthorization("Bearer jwt\r\nX-Evil: value"),
+    ).toBeNull();
+    expect(sanitizeBearerAuthorization("Bearer token\tpart")).toBeNull();
+    expect(sanitizeBearerAuthorization("Bearer töken")).toBeNull();
+    expect(
+      sanitizeBearerAuthorization(`Bearer ${"a".repeat(8_192)}`),
+    ).toBeNull();
+  });
+});
+
+describe("PendingDownloadAuthorizations", () => {
+  it("attaches bearer auth once for the exact trusted attachment URL", () => {
+    const authorizations = new PendingDownloadAuthorizations();
+    const details = request(1, ATTACHMENT_URL);
+
+    expect(
+      authorizations.register(
+        ATTACHMENT_URL,
+        "Bearer jwt-token",
+        API_BASE_URL,
+        WEB_CONTENTS_ID,
+      ),
+    ).toBe(true);
+    expect(authorizations.apply(details)).toBe("attached");
+    expect(details.requestHeaders.Authorization).toBe("Bearer jwt-token");
+
+    const secondRequest = request(2, ATTACHMENT_URL);
+    expect(authorizations.apply(secondRequest)).toBe("unchanged");
+    expect(secondRequest.requestHeaders.Authorization).toBeUndefined();
+    authorizations.clear();
+  });
+
+  it("rejects lookalike paths on foreign origins", () => {
+    const authorizations = new PendingDownloadAuthorizations();
+    const foreignURL =
+      "https://evil.example/api/attachments/11111111-2222-3333-4444-555555555555/download";
+
+    expect(
+      authorizations.register(
+        foreignURL,
+        "Bearer jwt-token",
+        API_BASE_URL,
+        WEB_CONTENTS_ID,
+      ),
+    ).toBe(false);
+    expect(authorizations.apply(request(1, foreignURL))).toBe("unchanged");
+    authorizations.clear();
+  });
+
+  it("rejects subdomains, port changes, credentials, and malformed ids", () => {
+    const authorizations = new PendingDownloadAuthorizations();
+    const urls = [
+      "https://cdn.api.example.test/api/attachments/11111111-2222-3333-4444-555555555555/download",
+      "https://api.example.test:8443/api/attachments/11111111-2222-3333-4444-555555555555/download",
+      "https://user@api.example.test/api/attachments/11111111-2222-3333-4444-555555555555/download",
+      "https://api.example.test/api/attachments/not-a-uuid/download",
+      "https://api.example.test/api/me",
+      "file:///api/attachments/11111111-2222-3333-4444-555555555555/download",
+    ];
+
+    for (const url of urls) {
+      expect(
+        authorizations.register(
+          url,
+          "Bearer jwt-token",
+          API_BASE_URL,
+          WEB_CONTENTS_ID,
+        ),
+      ).toBe(false);
+    }
+    expect(
+      authorizations.register(
+        ATTACHMENT_URL,
+        "Bearer jwt-token",
+        API_BASE_URL,
+        Number.NaN,
+      ),
+    ).toBe(false);
+    authorizations.clear();
+  });
+
+  it("supports an API base URL mounted below the origin root", () => {
+    const authorizations = new PendingDownloadAuthorizations();
+    const url =
+      "https://example.test/multica/api/attachments/11111111-2222-3333-4444-555555555555/download";
+
+    expect(
+      authorizations.register(
+        url,
+        "Bearer jwt-token",
+        "https://example.test/multica/",
+        WEB_CONTENTS_ID,
+      ),
+    ).toBe(true);
+    const details = request(1, url);
+    expect(authorizations.apply(details)).toBe("attached");
+    expect(details.requestHeaders.Authorization).toBe("Bearer jwt-token");
+    authorizations.clear();
+  });
+
+  it("binds pending auth to the source web contents", () => {
+    const authorizations = new PendingDownloadAuthorizations();
+    expect(
+      authorizations.register(
+        ATTACHMENT_URL,
+        "Bearer jwt-token",
+        API_BASE_URL,
+        WEB_CONTENTS_ID,
+      ),
+    ).toBe(true);
+
+    const otherWindow = request(1, ATTACHMENT_URL, {}, 99);
+    expect(authorizations.apply(otherWindow)).toBe("unchanged");
+    expect(otherWindow.requestHeaders.Authorization).toBeUndefined();
+
+    const sourceWindow = request(2, ATTACHMENT_URL);
+    expect(authorizations.apply(sourceWindow)).toBe("attached");
+    expect(sourceWindow.requestHeaders.Authorization).toBe("Bearer jwt-token");
+    authorizations.clear();
+  });
+
+  it("blanks inherited auth on a redirect before it reaches a CDN", () => {
+    const authorizations = new PendingDownloadAuthorizations();
+    expect(
+      authorizations.register(
+        ATTACHMENT_URL,
+        "Bearer jwt-token",
+        API_BASE_URL,
+        WEB_CONTENTS_ID,
+      ),
+    ).toBe(true);
+
+    const initial = request(77, ATTACHMENT_URL);
+    expect(authorizations.apply(initial)).toBe("attached");
+
+    const redirect = request(77, "https://cdn.example.test/signed-file", {
+      authorization: "Bearer jwt-token",
+    });
+    expect(authorizations.apply(redirect)).toBe("stripped");
+    expect(redirect.requestHeaders.authorization).toBe("");
+    expect(Object.values(redirect.requestHeaders)).not.toContain(
+      "Bearer jwt-token",
+    );
+
+    const secondRedirect = request(77, "https://storage.example.test/file", {
+      Authorization: "Bearer jwt-token",
+    });
+    expect(authorizations.apply(secondRedirect)).toBe("stripped");
+    expect(secondRedirect.requestHeaders.Authorization).toBe("");
+    authorizations.clear();
+  });
+
+  it("expires unused and active authorizations", () => {
+    vi.useFakeTimers();
+    const authorizations = new PendingDownloadAuthorizations(100);
+
+    expect(
+      authorizations.register(
+        ATTACHMENT_URL,
+        "Bearer jwt-token",
+        API_BASE_URL,
+        WEB_CONTENTS_ID,
+      ),
+    ).toBe(true);
+    vi.advanceTimersByTime(101);
+    expect(authorizations.apply(request(1, ATTACHMENT_URL))).toBe("unchanged");
+
+    expect(
+      authorizations.register(
+        ATTACHMENT_URL,
+        "Bearer jwt-token",
+        API_BASE_URL,
+        WEB_CONTENTS_ID,
+      ),
+    ).toBe(true);
+    expect(authorizations.apply(request(2, ATTACHMENT_URL))).toBe("attached");
+    vi.advanceTimersByTime(101);
+    const later = request(2, "https://cdn.example.test/signed-file", {
+      Authorization: "Bearer unrelated",
+    });
+    expect(authorizations.apply(later)).toBe("unchanged");
+    expect(later.requestHeaders.Authorization).toBe("Bearer unrelated");
+    authorizations.clear();
+  });
+
+  it("finishes active request tracking without changing unrelated headers", () => {
+    const authorizations = new PendingDownloadAuthorizations();
+    expect(
+      authorizations.register(
+        ATTACHMENT_URL,
+        "Bearer jwt-token",
+        API_BASE_URL,
+        WEB_CONTENTS_ID,
+      ),
+    ).toBe(true);
+    expect(authorizations.apply(request(42, ATTACHMENT_URL))).toBe("attached");
+    authorizations.finish(42);
+
+    const unrelated = request(42, "https://api.example.test/api/me", {
+      Authorization: "Bearer normal-api-request",
+    });
+    expect(authorizations.apply(unrelated)).toBe("unchanged");
+    expect(unrelated.requestHeaders.Authorization).toBe(
+      "Bearer normal-api-request",
+    );
+    authorizations.clear();
+  });
+});

--- a/apps/desktop/src/main/download-authorization.ts
+++ b/apps/desktop/src/main/download-authorization.ts
@@ -1,0 +1,198 @@
+const ATTACHMENT_DOWNLOAD_PATH_RE =
+  /^\/api\/attachments\/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\/download$/i;
+
+const DEFAULT_AUTHORIZATION_TTL_MS = 30_000;
+
+interface PendingAuthorization {
+  authorization: string;
+  timeout: ReturnType<typeof setTimeout>;
+}
+
+interface ActiveAuthorization {
+  timeout: ReturnType<typeof setTimeout>;
+}
+
+export interface DownloadRequestDetails {
+  id: number;
+  url: string;
+  webContentsId?: number;
+  requestHeaders: Record<string, string>;
+}
+
+export type DownloadAuthorizationResult =
+  | "attached"
+  | "stripped"
+  | "unchanged";
+
+export function sanitizeBearerAuthorization(value: unknown): string | null {
+  if (typeof value !== "string") return null;
+  const trimmed = value.trim();
+  if (trimmed.length > 8_192) return null;
+  if (!/^Bearer [\x21-\x7e]+$/.test(trimmed)) return null;
+  return trimmed;
+}
+
+function normalizeHTTPURL(rawURL: unknown): string | null {
+  if (typeof rawURL !== "string") return null;
+  try {
+    const parsed = new URL(rawURL);
+    if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+      return null;
+    }
+    if (parsed.username || parsed.password) return null;
+    parsed.hash = "";
+    return parsed.toString();
+  } catch {
+    return null;
+  }
+}
+
+function normalizeTrustedAttachmentDownloadURL(
+  rawURL: unknown,
+  trustedAPIBaseURL: string | null,
+): string | null {
+  const normalizedURL = normalizeHTTPURL(rawURL);
+  const normalizedBaseURL = normalizeHTTPURL(trustedAPIBaseURL);
+  if (!normalizedURL || !normalizedBaseURL) return null;
+
+  const candidate = new URL(normalizedURL);
+  const apiBase = new URL(normalizedBaseURL);
+  if (candidate.origin !== apiBase.origin) return null;
+
+  const basePath = apiBase.pathname.replace(/\/+$/, "");
+  const expectedPrefix = `${basePath}/api/attachments/`;
+  if (!candidate.pathname.startsWith(expectedPrefix)) return null;
+
+  const relativePath = candidate.pathname.slice(basePath.length);
+  if (!ATTACHMENT_DOWNLOAD_PATH_RE.test(relativePath)) return null;
+  return candidate.toString();
+}
+
+function setAuthorizationHeader(
+  headers: Record<string, string>,
+  authorization: string,
+): void {
+  const names = Object.keys(headers).filter(
+    (name) => name.toLowerCase() === "authorization",
+  );
+  const [firstName, ...duplicateNames] = names;
+  if (!firstName) {
+    headers.Authorization = authorization;
+    return;
+  }
+  headers[firstName] = authorization;
+  for (const name of duplicateNames) headers[name] = "";
+}
+
+function stripAuthorizationHeader(headers: Record<string, string>): void {
+  // Electron/Chromium can crash when a custom header inherited by a redirect
+  // is deleted in onBeforeSendHeaders. An empty value is omitted on the wire.
+  for (const name of Object.keys(headers)) {
+    if (name.toLowerCase() === "authorization") headers[name] = "";
+  }
+}
+
+function armTimeout(
+  callback: () => void,
+  ttlMs: number,
+): ReturnType<typeof setTimeout> {
+  const timeout = setTimeout(callback, ttlMs);
+  timeout.unref?.();
+  return timeout;
+}
+
+function pendingKey(webContentsId: number, url: string): string {
+  return `${webContentsId}\n${url}`;
+}
+
+/**
+ * Hands one bearer header from renderer IPC to one native attachment request.
+ *
+ * Electron carries custom download headers across redirects, including to a
+ * different origin. Pending auth is bound to the source WebContents and exact
+ * URL. The first matching request consumes it; later requests with the same
+ * request id are treated as redirects and have Authorization cleared before
+ * they leave the machine.
+ */
+export class PendingDownloadAuthorizations {
+  private readonly pending = new Map<string, PendingAuthorization>();
+  private readonly active = new Map<number, ActiveAuthorization>();
+
+  constructor(private readonly ttlMs = DEFAULT_AUTHORIZATION_TTL_MS) {}
+
+  register(
+    rawURL: unknown,
+    rawAuthorization: unknown,
+    trustedAPIBaseURL: string | null,
+    webContentsId: number,
+  ): boolean {
+    const url = normalizeTrustedAttachmentDownloadURL(
+      rawURL,
+      trustedAPIBaseURL,
+    );
+    const authorization = sanitizeBearerAuthorization(rawAuthorization);
+    if (!url || !authorization || !Number.isSafeInteger(webContentsId)) {
+      return false;
+    }
+
+    const key = pendingKey(webContentsId, url);
+    this.deletePending(key);
+    const timeout = armTimeout(() => this.pending.delete(key), this.ttlMs);
+    this.pending.set(key, { authorization, timeout });
+    return true;
+  }
+
+  apply(details: DownloadRequestDetails): DownloadAuthorizationResult {
+    const active = this.active.get(details.id);
+    if (active) {
+      clearTimeout(active.timeout);
+      active.timeout = armTimeout(
+        () => this.active.delete(details.id),
+        this.ttlMs,
+      );
+      stripAuthorizationHeader(details.requestHeaders);
+      return "stripped";
+    }
+
+    const url = normalizeHTTPURL(details.url);
+    if (
+      !url ||
+      typeof details.webContentsId !== "number" ||
+      !Number.isSafeInteger(details.webContentsId)
+    ) {
+      return "unchanged";
+    }
+    const key = pendingKey(details.webContentsId, url);
+    const pending = this.pending.get(key);
+    if (!pending) return "unchanged";
+
+    clearTimeout(pending.timeout);
+    this.pending.delete(key);
+    setAuthorizationHeader(details.requestHeaders, pending.authorization);
+
+    const timeout = armTimeout(() => this.active.delete(details.id), this.ttlMs);
+    this.active.set(details.id, { timeout });
+    return "attached";
+  }
+
+  finish(requestId: number): void {
+    const active = this.active.get(requestId);
+    if (!active) return;
+    clearTimeout(active.timeout);
+    this.active.delete(requestId);
+  }
+
+  clear(): void {
+    for (const entry of this.pending.values()) clearTimeout(entry.timeout);
+    for (const entry of this.active.values()) clearTimeout(entry.timeout);
+    this.pending.clear();
+    this.active.clear();
+  }
+
+  private deletePending(key: string): void {
+    const existing = this.pending.get(key);
+    if (!existing) return;
+    clearTimeout(existing.timeout);
+    this.pending.delete(key);
+  }
+}

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -8,6 +8,7 @@ import { setupAutoUpdater } from "./updater";
 import { setupDaemonManager } from "./daemon-manager";
 import { setupLocalDirectory } from "./local-directory";
 import { openExternalSafely, downloadURLSafely } from "./external-url";
+import { PendingDownloadAuthorizations } from "./download-authorization";
 import { installContextMenu } from "./context-menu";
 import { handleAppShortcut } from "./keyboard-shortcuts";
 import { installNavigationGestures } from "./navigation-gestures";
@@ -63,6 +64,8 @@ import {
 // same session. window.webContents.session is shared, and createWindow() can
 // be called again on macOS (app "activate" after all windows are closed).
 const downloadDialogSessions = new WeakSet<Electron.Session>();
+const requestHeaderSessions = new WeakSet<Electron.Session>();
+const pendingDownloadAuthorizations = new PendingDownloadAuthorizations();
 
 function installDownloadSaveDialogHandler(window: BrowserWindow): void {
   const { session } = window.webContents;
@@ -73,6 +76,32 @@ function installDownloadSaveDialogHandler(window: BrowserWindow): void {
       defaultPath: join(app.getPath("downloads"), item.getFilename()),
     });
   });
+}
+
+function installSessionRequestHeaderHandler(window: BrowserWindow): void {
+  const { session } = window.webContents;
+  if (requestHeaderSessions.has(session)) return;
+  requestHeaderSessions.add(session);
+
+  session.webRequest.onBeforeSendHeaders(
+    { urls: ["http://*/*", "https://*/*", "wss://*/*", "ws://*/*"] },
+    (details, callback) => {
+      if (details.url.startsWith("ws://") || details.url.startsWith("wss://")) {
+        delete details.requestHeaders.Origin;
+      } else {
+        pendingDownloadAuthorizations.apply(details);
+      }
+      callback({ requestHeaders: details.requestHeaders });
+    },
+  );
+  session.webRequest.onCompleted(
+    { urls: ["http://*/*", "https://*/*"] },
+    (details) => pendingDownloadAuthorizations.finish(details.id),
+  );
+  session.webRequest.onErrorOccurred(
+    { urls: ["http://*/*", "https://*/*"] },
+    (details) => pendingDownloadAuthorizations.finish(details.id),
+  );
 }
 
 // Bundled icon used for dock/taskbar branding. macOS/Windows production
@@ -369,15 +398,10 @@ function createWindow(): BrowserWindow {
     }
   });
 
-  // Strip Origin header from WebSocket upgrade requests so the server's
-  // origin whitelist doesn't reject connections from localhost dev origins.
-  window.webContents.session.webRequest.onBeforeSendHeaders(
-    { urls: ["wss://*/*", "ws://*/*"] },
-    (details, callback) => {
-      delete details.requestHeaders["Origin"];
-      callback({ requestHeaders: details.requestHeaders });
-    },
-  );
+  // One shared session hook strips WebSocket Origin and injects one-shot
+  // bearer auth for native attachment downloads. It is installed once per
+  // session because Electron only keeps the most recent listener per event.
+  installSessionRequestHeaderHandler(window);
 
   window.on("ready-to-show", () => {
     // Restore max/fullscreen after normal bounds are applied.
@@ -507,6 +531,7 @@ function createIssueWindow(context: IssueWindowContext): void {
   window.on("ready-to-show", () => window.show());
   installLocaleRefresh(window);
   installDownloadSaveDialogHandler(window);
+  installSessionRequestHeaderHandler(window);
 
   window.webContents.setWindowOpenHandler((details) => {
     void openExternalSafely(details.url);
@@ -690,14 +715,37 @@ if (!gotTheLock) {
       return { ok: true } as const;
     });
 
-    ipcMain.handle("file:download-url", (event, url: string) => {
-      const sourceWindow = BrowserWindow.fromWebContents(event.sender);
-      if (!sourceWindow) {
-        console.warn("[download] ignored file:download-url — source window torn down");
-        return;
-      }
-      downloadURLSafely(sourceWindow, url);
-    });
+    ipcMain.handle(
+      "file:download-url",
+      (event, url: unknown, options?: unknown) => {
+        const sourceWindow = BrowserWindow.fromWebContents(event.sender);
+        if (!sourceWindow) {
+          console.warn(
+            "[download] ignored file:download-url — source window torn down",
+          );
+          return;
+        }
+        if (typeof url !== "string") {
+          console.warn("[download] ignored file:download-url — invalid URL");
+          return;
+        }
+
+        const authorization =
+          options && typeof options === "object" && !Array.isArray(options)
+            ? (options as { authorization?: unknown }).authorization
+            : undefined;
+        const trustedAPIBaseURL = runtimeConfigResult.ok
+          ? runtimeConfigResult.config.apiUrl
+          : null;
+        pendingDownloadAuthorizations.register(
+          url,
+          authorization,
+          trustedAPIBaseURL,
+          sourceWindow.webContents.id,
+        );
+        downloadURLSafely(sourceWindow, url);
+      },
+    );
 
     // Sync IPC: app version + normalized OS for preload. Sync (not invoke) so
     // preload can attach the values to `desktopAPI.appInfo` before any renderer

--- a/apps/desktop/src/preload/index.d.ts
+++ b/apps/desktop/src/preload/index.d.ts
@@ -44,7 +44,10 @@ interface DesktopAPI {
   openExternal: (url: string) => Promise<void>;
   /** Download a file by URL through Electron's native download system.
    *  Shows a native save dialog. On non-desktop platforms this is undefined. */
-  downloadURL: (url: string) => Promise<void>;
+  downloadURL: (
+    url: string,
+    options?: { authorization?: string },
+  ) => Promise<void>;
   /** Hide macOS traffic lights for full-screen modals; restore when false. */
   setImmersiveMode: (immersive: boolean) => Promise<void>;
   /** Show a native OS notification for a new inbox item. */

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -146,7 +146,8 @@ const desktopAPI = {
    *  Shows a save dialog and saves to disk. Unlike openExternal, this
    *  avoids browser rendering of HTML files on Linux.
    *  On non-desktop platforms this property is undefined. */
-  downloadURL: (url: string) => ipcRenderer.invoke("file:download-url", url),
+  downloadURL: (url: string, options?: { authorization?: string }) =>
+    ipcRenderer.invoke("file:download-url", url, options),
   /** Toggle immersive mode — hide macOS traffic lights for full-screen modals */
   setImmersiveMode: (immersive: boolean) =>
     ipcRenderer.invoke("window:setImmersive", immersive),

--- a/packages/core/api/client.test.ts
+++ b/packages/core/api/client.test.ts
@@ -530,6 +530,16 @@ describe("ApiClient notification preferences", () => {
 });
 
 describe("ApiClient", () => {
+  it("exposes bearer auth only while a token is set", () => {
+    const client = new ApiClient("https://api.example.test");
+
+    expect(client.getAuthorizationHeader()).toBeNull();
+    client.setToken("jwt-token");
+    expect(client.getAuthorizationHeader()).toBe("Bearer jwt-token");
+    client.setToken(null);
+    expect(client.getAuthorizationHeader()).toBeNull();
+  });
+
   it("preserves HTTP status on failed requests", async () => {
     vi.stubGlobal(
       "fetch",

--- a/packages/core/api/client.ts
+++ b/packages/core/api/client.ts
@@ -398,6 +398,15 @@ export class ApiClient {
     this.token = token;
   }
 
+  /**
+   * Returns the bearer header for a platform transport that cannot use this
+   * client's fetch pipeline. Callers must enforce the destination origin at
+   * their own trusted boundary before putting this value on the wire.
+   */
+  getAuthorizationHeader(): string | null {
+    return this.token ? `Bearer ${this.token}` : null;
+  }
+
   private readCsrfToken(): string | null {
     if (typeof document === "undefined") return null;
     const match = document.cookie

--- a/packages/views/editor/use-download-attachment.test.tsx
+++ b/packages/views/editor/use-download-attachment.test.tsx
@@ -5,12 +5,17 @@ import { act, renderHook, waitFor } from "@testing-library/react";
 // outside-of-scope vars, but vi.hoisted runs before the import graph.
 const getAttachmentMock = vi.hoisted(() => vi.fn());
 const getBaseUrlMock = vi.hoisted(() => vi.fn(() => ""));
+const getAuthorizationHeaderMock = vi.hoisted(() => vi.fn<() => string | null>(() => null));
 const useWorkspaceSlugMock = vi.hoisted(() =>
   vi.fn<() => string | null>(() => "acme"),
 );
 
 vi.mock("@multica/core/api", () => ({
-  api: { getAttachment: getAttachmentMock, getBaseUrl: getBaseUrlMock },
+  api: {
+    getAttachment: getAttachmentMock,
+    getBaseUrl: getBaseUrlMock,
+    getAuthorizationHeader: getAuthorizationHeaderMock,
+  },
 }));
 
 vi.mock("@multica/core/paths", () => ({
@@ -37,6 +42,7 @@ beforeEach(() => {
   // a non-empty base (desktop standalone, server-relative download URL)
   // overrides via getBaseUrlMock.mockReturnValue(...).
   getBaseUrlMock.mockReturnValue("");
+  getAuthorizationHeaderMock.mockReturnValue(null);
   useWorkspaceSlugMock.mockReturnValue("acme");
 });
 
@@ -265,6 +271,58 @@ describe("useDownloadAttachment (desktop)", () => {
     expect(downloadURL).toHaveBeenCalledWith(
       "https://api.example.test/api/attachments/att-1/download",
     );
+  });
+
+  it("passes bearer auth for a stable same-origin API download", async () => {
+    const downloadURL = vi.fn();
+    (window as unknown as { desktopAPI: { downloadURL: typeof downloadURL } }).desktopAPI = {
+      downloadURL,
+    };
+    getBaseUrlMock.mockReturnValue("https://api.example.test");
+    getAuthorizationHeaderMock.mockReturnValue("Bearer jwt-desktop");
+    getAttachmentMock.mockResolvedValueOnce({
+      id: "11111111-2222-3333-4444-555555555555",
+      url: "/uploads/report.html",
+      download_url:
+        "/api/attachments/11111111-2222-3333-4444-555555555555/download",
+      filename: "report.html",
+    });
+
+    const { result } = renderHook(() => useDownloadAttachment());
+
+    await act(async () => {
+      await result.current("11111111-2222-3333-4444-555555555555");
+    });
+
+    expect(downloadURL).toHaveBeenCalledWith(
+      "https://api.example.test/api/attachments/11111111-2222-3333-4444-555555555555/download",
+      { authorization: "Bearer jwt-desktop" },
+    );
+  });
+
+  it("never passes bearer auth to an off-origin attachment-shaped URL", async () => {
+    const downloadURL = vi.fn();
+    (window as unknown as { desktopAPI: { downloadURL: typeof downloadURL } }).desktopAPI = {
+      downloadURL,
+    };
+    getBaseUrlMock.mockReturnValue("https://api.example.test");
+    getAuthorizationHeaderMock.mockReturnValue("Bearer jwt-desktop");
+    const foreignURL =
+      "https://cdn.example.test/api/attachments/11111111-2222-3333-4444-555555555555/download";
+    getAttachmentMock.mockResolvedValueOnce({
+      id: "11111111-2222-3333-4444-555555555555",
+      url: foreignURL,
+      download_url: foreignURL,
+      filename: "report.html",
+    });
+
+    const { result } = renderHook(() => useDownloadAttachment());
+
+    await act(async () => {
+      await result.current("11111111-2222-3333-4444-555555555555");
+    });
+
+    expect(downloadURL).toHaveBeenCalledWith(foreignURL);
   });
 
   it("trims a trailing slash on the API base when resolving a relative download_url", async () => {

--- a/packages/views/editor/use-download-attachment.ts
+++ b/packages/views/editor/use-download-attachment.ts
@@ -4,11 +4,19 @@ import { useCallback } from "react";
 import { toast } from "sonner";
 import { api } from "@multica/core/api";
 import { useWorkspaceSlug } from "@multica/core/paths";
+import { attachmentIdFromDownloadURL } from "@multica/core/types";
 import { resolvePublicFileUrl } from "@multica/core/workspace/avatar-url";
 import { useT } from "../i18n";
 
+interface DesktopDownloadOptions {
+  authorization?: string;
+}
+
 interface DesktopBridge {
-  downloadURL?: (u: string) => Promise<void> | void;
+  downloadURL?: (
+    u: string,
+    options?: DesktopDownloadOptions,
+  ) => Promise<void> | void;
 }
 
 function attachmentDownloadEndpoint(
@@ -45,6 +53,25 @@ function hasDesktopDownloadBridge(): boolean {
   if (typeof window === "undefined") return false;
   const bridge = (window as unknown as { desktopAPI?: DesktopBridge }).desktopAPI;
   return Boolean(bridge?.downloadURL);
+}
+
+function desktopAttachmentAuthorization(downloadURL: string): string | undefined {
+  try {
+    const apiBase = new URL(api.getBaseUrl());
+    const target = new URL(downloadURL);
+    if (target.username || target.password) return undefined;
+    if (target.origin !== apiBase.origin) return undefined;
+
+    const basePath = apiBase.pathname.replace(/\/+$/, "");
+    if (!target.pathname.startsWith(`${basePath}/api/attachments/`)) {
+      return undefined;
+    }
+    const relativePath = target.pathname.slice(basePath.length);
+    if (!attachmentIdFromDownloadURL(relativePath)) return undefined;
+    return api.getAuthorizationHeader() ?? undefined;
+  } catch {
+    return undefined;
+  }
 }
 
 /**
@@ -93,7 +120,12 @@ export function useDownloadAttachment(): (attachmentId: string) => Promise<void>
           const bridge = (
             window as unknown as { desktopAPI?: DesktopBridge }
           ).desktopAPI;
-          await bridge!.downloadURL!(downloadUrl);
+          const authorization = desktopAttachmentAuthorization(downloadUrl);
+          if (authorization) {
+            await bridge!.downloadURL!(downloadUrl, { authorization });
+          } else {
+            await bridge!.downloadURL!(downloadUrl);
+          }
         } catch {
           failed();
         }


### PR DESCRIPTION
## What does this PR do?

Fixes native attachment downloads in Desktop when a self-hosted deployment authenticates with a LocalStorage bearer token.

The attachment endpoint already works when it receives `Authorization`, but Electron's native `downloadURL()` path bypasses the API client's authenticated `fetch` pipeline. Passing the header directly through `downloadURL(url, { headers })` is not safe: Electron 39 forwards custom authorization headers across cross-origin redirects.

This change uses a one-shot bridge instead:

1. The renderer only offers auth for a same-origin, stable `/api/attachments/<uuid>/download` URL.
2. Main validates the URL again against the configured API origin, exact route shape, and bearer syntax.
3. Pending auth is short-lived and bound to the source `WebContents` plus exact URL.
4. The session hook injects it into the first matching native request.
5. Any later request with that request ID is treated as a redirect and has the credential cleared before transmission.

External signed URLs keep the existing unauthenticated download path, so credentials are never forwarded to S3, CloudFront, or another origin.

## Related Issue

Closes #3079

Related alternatives: #5416, #5799

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Refactor / code improvement (no behavior change)
- [ ] Documentation update
- [x] Tests (adding or improving test coverage)
- [ ] CI / infrastructure

## Changes Made

- Extended the Desktop preload bridge with an optional structured authorization value.
- Exposed the API client's current bearer header for platform transports outside its fetch pipeline.
- Added strict origin, path, UUID, protocol, credential, bearer, expiry, and `WebContents` checks in main.
- Merged download handling into the existing per-session `onBeforeSendHeaders` hook so it does not replace the WebSocket Origin listener.
- Added redirect handling that clears inherited credentials on every later hop.
- Preserved the existing native filename/save behavior and the no-auth path for signed external URLs.
- Added renderer, API-client, and main-process regression/security tests.

## How to Test

1. Configure Desktop for a self-hosted LocalStorage/Bearer deployment with local attachment storage.
2. Download an attachment whose `download_url` is `/api/attachments/<uuid>/download`.
3. Confirm the native download completes with the original filename.
4. Download an externally signed attachment and confirm it still works without an authorization value.
5. Run:
   - `pnpm -C apps/desktop test`
   - `pnpm --filter @multica/views test`
   - `pnpm --filter @multica/core test`
   - typechecks and lint for all three packages

Local verification completed:

- Desktop: 40 files, 385 tests passed
- Views: 254 files, 2,901 tests passed
- Core: 99 files, 1,024 tests passed
- Desktop production build passed
- End-to-end self-hosted check: unauthenticated endpoint returned `401`; the patched native flow saved the expected PNG with its original filename, byte count, and SHA-256 matching an authenticated response

## Risks / Security Notes

- The bearer value is never placed in the URL or logged.
- Main is the trust boundary; renderer validation is defense in depth only.
- Authorization is only injected for the configured API origin and exact attachment-download route.
- Redirect credentials are cleared for all subsequent hops, including same-origin and cross-origin redirects.
- In Electron 39, deleting an inherited custom header during a redirect can crash Chromium. Setting its value to empty omits it on the wire without that crash; this behavior was reproduced against local redirect servers and is covered at the state-machine level by tests.
- Pending and active entries expire after 30 seconds and are cleaned up on completion/error.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] If this change affects the UI, I have included before/after screenshots (not applicable: no UI change)
- [x] I have updated relevant documentation to reflect my changes (not applicable: no user-facing behavior/config change)
- [x] If I added a new runtime / coding tool / UI tab, I synced the change to landing copy and docs (not applicable)
- [x] If this PR touches Chinese product copy, I checked conventions (not applicable)
- [x] I have considered and documented risks above
- [x] I will address all reviewer comments before requesting merge

## AI Disclosure

**AI tool used:** Pi coding agent

**Prompt / approach:** Inspected the renderer → preload → Electron main download path, reproduced the missing-header failure and Electron's cross-origin redirect behavior, implemented a narrowly scoped two-boundary validation flow, then ran package-wide tests and a packaged-app end-to-end check against a self-hosted deployment.

## Screenshots (optional)

Not applicable. This changes native download transport behavior without altering UI.
