### PR TITLE
fix(agent): accept ACP configOptions model catalog (kimi-code 0.29) — MUL-5239

### DIFF
--- a/server/pkg/agent/models.go
+++ b/server/pkg/agent/models.go
@@ -833,9 +833,10 @@ func discoverHermesModels(ctx context.Context, executablePath string) ([]Model, 
 
 // discoverKimiModels spins up a throwaway `kimi acp` process and
 // drives the same minimal ACP handshake as Hermes to surface the
-// model catalog advertised by Kimi's `session/new` response. Kimi's
-// ACPServer.new_session returns a `models` block of the same shape
-// (`availableModels`/`currentModelId`) so the parsing path is shared.
+// model catalog advertised by Kimi's `session/new` response. Kimi
+// ≤0.28 returns a `models` block (`availableModels`/`currentModelId`);
+// 0.29 moved the same catalog into `configOptions` (MUL-5239). The
+// shared parser accepts both, so the discovery path stays identical.
 //
 // Failure modes (kimi missing, not logged in, config error) all
 // return an empty list so the UI falls back to manual entry.
@@ -934,8 +935,9 @@ type acpDiscoveryProvider struct {
 // discoverACPModels runs the ACP handshake for any agent CLI that
 // implements the standard `initialize` + `session/new` flow and
 // advertises its model catalog in the response under
-// `models.availableModels` / `models.currentModelId`. Provider-specific
-// `launchArgs` select ACP mode (e.g. `acp` vs `--acp`).
+// `models.availableModels` / `models.currentModelId`, or under the
+// newer `configOptions` list. Provider-specific `launchArgs` select
+// ACP mode (e.g. `acp` vs `--acp`).
 func discoverACPModels(ctx context.Context, executablePath string, p acpDiscoveryProvider) ([]Model, error) {
 	fail := func(stage string, err error) ([]Model, error) {
 		if p.strictErrors {
@@ -1086,6 +1088,18 @@ func discoverACPModels(ctx context.Context, executablePath string, p acpDiscover
 		return fail("session/new", err)
 	}
 	models := parseACPSessionNewModels(sessionResult)
+	if len(models) == 0 {
+		// session/new succeeded but carried no catalog we recognise. This
+		// is what upstream schema drift looks like from here (MUL-5239:
+		// kimi 0.29 moved the catalog from `models` to `configOptions`),
+		// and without this line it is indistinguishable from "the CLI
+		// really has no models". Log the top-level keys only — never the
+		// response body, which carries session ids and account-shaped data.
+		slog.Debug("ACP model discovery found no models in session/new response",
+			"binary", executablePath,
+			"result_keys", strings.Join(acpResultTopLevelKeys(sessionResult), ","),
+		)
+	}
 	if models == nil {
 		return fail("session/new model parsing", fmt.Errorf("response contained no model catalog"))
 	}
@@ -1096,8 +1110,8 @@ func discoverACPModels(ctx context.Context, executablePath string, p acpDiscover
 }
 
 // parseACPSessionNewModels extracts the model catalog from an ACP
-// `session/new` response. Both Hermes and Kimi (and any other ACP
-// agent that follows the standard schema) emit:
+// `session/new` response. Hermes and older Kimi (and any other ACP
+// agent that follows that schema) emit:
 //
 //	{
 //	  "sessionId": "...",
@@ -1108,6 +1122,12 @@ func discoverACPModels(ctx context.Context, executablePath string, p acpDiscover
 //	    "currentModelId": "..."
 //	  }
 //	}
+//
+// Newer agents advertise the same catalog through the ACP
+// `configOptions` list instead — see parseACPConfigOptionModels. Both
+// shapes are accepted: the `models` block wins when present, and
+// `configOptions` is consulted only when it yields nothing, so no
+// existing provider changes behaviour.
 //
 // Returns nil (not an empty slice) when the payload is missing so
 // the caller can distinguish "parsed with no models" (valid but
@@ -1149,19 +1169,125 @@ func parseACPSessionNewModels(raw json.RawMessage) []Model {
 			continue
 		}
 		seen[modelID] = true
-		label := acpModelLabel(m.Name, modelID)
-		provider := ""
-		if idx := strings.Index(modelID, ":"); idx > 0 {
-			provider = modelID[:idx]
-		}
-		models = append(models, Model{
-			ID:       modelID,
-			Label:    label,
-			Provider: provider,
-			Default:  modelID == currentModelID,
-		})
+		models = append(models, acpModelEntry(modelID, m.Name, currentModelID))
+	}
+	if len(models) > 0 {
+		return models
+	}
+	if fromConfig := parseACPConfigOptionModels(raw); len(fromConfig) > 0 {
+		return fromConfig
 	}
 	return models
+}
+
+// parseACPConfigOptionModels extracts the model catalog from the ACP
+// `configOptions` list returned by `session/new`. Kimi Code 0.29 dropped
+// the top-level `models` block in favour of this shape (MUL-5239):
+//
+//	{
+//	  "sessionId": "...",
+//	  "configOptions": [
+//	    {
+//	      "type": "select", "id": "model", "name": "Model", "category": "model",
+//	      "currentValue": "kimi-code/k3",
+//	      "options": [
+//	        {"value": "kimi-code/k3", "name": "K3"},
+//	        {"value": "kimi-code/kimi-for-coding", "name": "K2.7 Coding"}
+//	      ]
+//	    },
+//	    {"id": "thinking", "category": "thought_level", ...}
+//	  ]
+//	}
+//
+// A config option counts as the model picker when its `id` or `category`
+// is "model" (case-insensitive). Every other option — thinking level in
+// particular — is deliberately ignored: those are separate product
+// surfaces, and mapping them into the model dropdown would offer values
+// `session/set_model` cannot honour. `currentValue` marks the default.
+//
+// Returns nil when no model option is present, so the caller can keep
+// whatever the `models` block produced.
+func parseACPConfigOptionModels(raw json.RawMessage) []Model {
+	type acpConfigChoice struct {
+		Value string `json:"value"`
+		Name  string `json:"name"`
+	}
+	type acpConfigOption struct {
+		ID                string            `json:"id"`
+		Category          string            `json:"category"`
+		CurrentValue      string            `json:"currentValue"`
+		CurrentValueSnake string            `json:"current_value"`
+		Options           []acpConfigChoice `json:"options"`
+	}
+	var resp struct {
+		ConfigOptions      []acpConfigOption `json:"configOptions"`
+		ConfigOptionsSnake []acpConfigOption `json:"config_options"`
+	}
+	if err := json.Unmarshal(raw, &resp); err != nil {
+		return nil
+	}
+	configOptions := resp.ConfigOptions
+	if len(configOptions) == 0 {
+		configOptions = resp.ConfigOptionsSnake
+	}
+	for _, opt := range configOptions {
+		if !strings.EqualFold(strings.TrimSpace(opt.ID), "model") &&
+			!strings.EqualFold(strings.TrimSpace(opt.Category), "model") {
+			continue
+		}
+		currentValue := strings.TrimSpace(opt.CurrentValue)
+		if currentValue == "" {
+			currentValue = strings.TrimSpace(opt.CurrentValueSnake)
+		}
+		models := make([]Model, 0, len(opt.Options))
+		seen := map[string]bool{}
+		for _, choice := range opt.Options {
+			modelID := strings.TrimSpace(choice.Value)
+			if modelID == "" || seen[modelID] {
+				continue
+			}
+			seen[modelID] = true
+			models = append(models, acpModelEntry(modelID, choice.Name, currentValue))
+		}
+		if len(models) > 0 {
+			return models
+		}
+	}
+	return nil
+}
+
+// acpModelEntry builds one dropdown entry from an ACP-advertised model id
+// and its display name. Provider is derived from the `provider:model` form
+// only — ids like kimi's `kimi-code/k3` carry no colon and stay ungrouped,
+// which matches how the UI renders a flat catalog.
+func acpModelEntry(modelID, name, currentModelID string) Model {
+	provider := ""
+	if idx := strings.Index(modelID, ":"); idx > 0 {
+		provider = modelID[:idx]
+	}
+	return Model{
+		ID:       modelID,
+		Label:    acpModelLabel(name, modelID),
+		Provider: provider,
+		Default:  modelID == currentModelID,
+	}
+}
+
+// acpResultTopLevelKeys returns the sorted top-level object keys of an ACP
+// result. Keys only, never values: enough to tell `configOptions` drift from
+// a genuinely empty catalog in daemon.log without logging session ids or any
+// other content from the upstream response.
+func acpResultTopLevelKeys(raw json.RawMessage) []string {
+	var obj map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &obj); err != nil {
+		return nil
+	}
+	keys := make([]string, 0, len(obj))
+	for k := range obj {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
 }
 
 func acpModelLabel(name, modelID string) string {

--- a/server/pkg/agent/models_test.go
+++ b/server/pkg/agent/models_test.go
@@ -978,6 +978,140 @@ func TestParseHermesSessionNewModelsGarbage(t *testing.T) {
 	}
 }
 
+// MUL-5239: kimi-code 0.29 dropped the `models` block and advertises the
+// same catalog through ACP `configOptions`. Without this the picker showed
+// an empty catalog for an online kimi runtime.
+func TestParseACPSessionNewModelsFromConfigOptions(t *testing.T) {
+	// Trimmed copy of a real kimi 0.29 session/new result.
+	raw := []byte(`{
+      "sessionId": "session_abc",
+      "configOptions": [
+        {
+          "type": "select",
+          "id": "model",
+          "name": "Model",
+          "category": "model",
+          "currentValue": "kimi-code/k3",
+          "options": [
+            {"value": "kimi-code/kimi-for-coding", "name": "K2.7 Coding"},
+            {"value": "kimi-code/kimi-for-coding-highspeed", "name": "K2.7 Coding Highspeed"},
+            {"value": "kimi-code/k3", "name": "K3"}
+          ]
+        },
+        {
+          "type": "select",
+          "id": "thinking",
+          "category": "thought_level",
+          "currentValue": "high",
+          "options": [
+            {"value": "low", "name": "Low"},
+            {"value": "high", "name": "High"},
+            {"value": "max", "name": "Max"}
+          ]
+        }
+      ]
+    }`)
+	models := parseACPSessionNewModels(raw)
+	if len(models) != 3 {
+		t.Fatalf("expected 3 models from configOptions, got %d: %+v", len(models), models)
+	}
+	if models[0].ID != "kimi-code/kimi-for-coding" || models[0].Label != "K2.7 Coding" {
+		t.Errorf("unexpected first model: %+v", models[0])
+	}
+	// `kimi-code/k3` has no colon, so it must not be split into a provider
+	// group off the slash.
+	if models[2].Provider != "" {
+		t.Errorf("slash-form model id must not derive a provider: %+v", models[2])
+	}
+	if !models[2].Default {
+		t.Errorf("currentValue entry must be marked default: %+v", models[2])
+	}
+	for _, m := range models {
+		if m.ID == "low" || m.ID == "high" || m.ID == "max" {
+			t.Errorf("thinking-level option leaked into the model catalog: %+v", m)
+		}
+	}
+}
+
+// The `models` block stays authoritative: an agent emitting both shapes
+// must not have its catalog replaced by configOptions.
+func TestParseACPSessionNewModelsPrefersModelsBlockOverConfigOptions(t *testing.T) {
+	raw := []byte(`{
+      "sessionId": "session_abc",
+      "models": {
+        "availableModels": [{"modelId": "nous:anthropic/claude-opus-4.7", "name": "Opus"}],
+        "currentModelId": "nous:anthropic/claude-opus-4.7"
+      },
+      "configOptions": [
+        {"id": "model", "category": "model", "currentValue": "other/one",
+         "options": [{"value": "other/one", "name": "Other"}]}
+      ]
+    }`)
+	models := parseACPSessionNewModels(raw)
+	if len(models) != 1 || models[0].ID != "nous:anthropic/claude-opus-4.7" {
+		t.Fatalf("models block must win over configOptions, got %+v", models)
+	}
+}
+
+func TestParseACPSessionNewModelsConfigOptionsSnakeCaseAndCategoryOnly(t *testing.T) {
+	// No `id: "model"` — the option is identified by category alone — and
+	// the response uses snake_case keys.
+	raw := []byte(`{
+      "session_id": "session_abc",
+      "config_options": [
+        {
+          "id": "primary_model",
+          "category": "MODEL",
+          "current_value": "kimi-code/k3",
+          "options": [
+            {"value": "kimi-code/k3", "name": "K3"},
+            {"value": "kimi-code/k3", "name": "duplicate"},
+            {"value": "  ", "name": "blank"},
+            {"value": "kimi-code/kimi-for-coding", "name": ""}
+          ]
+        }
+      ]
+    }`)
+	models := parseACPSessionNewModels(raw)
+	if len(models) != 2 {
+		t.Fatalf("expected 2 models (duplicate and blank dropped), got %d: %+v", len(models), models)
+	}
+	if !models[0].Default {
+		t.Errorf("snake_case current_value should mark default: %+v", models[0])
+	}
+	if models[1].Label != "kimi-code/kimi-for-coding" {
+		t.Errorf("missing name should fall back to the model id, got %+v", models[1])
+	}
+}
+
+func TestParseACPSessionNewModelsIgnoresNonModelConfigOptions(t *testing.T) {
+	// session/new with configOptions but no model picker must still yield an
+	// empty catalog rather than inventing one from the thinking levels.
+	raw := []byte(`{
+      "sessionId": "session_abc",
+      "configOptions": [
+        {"id": "thinking", "category": "thought_level", "currentValue": "high",
+         "options": [{"value": "low", "name": "Low"}, {"value": "high", "name": "High"}]}
+      ]
+    }`)
+	if got := parseACPSessionNewModels(raw); len(got) != 0 {
+		t.Errorf("expected empty catalog, got %+v", got)
+	}
+}
+
+func TestACPResultTopLevelKeys(t *testing.T) {
+	// Diagnostic line must expose key names only — never the values that
+	// carry session ids or catalog contents.
+	keys := acpResultTopLevelKeys([]byte(`{"sessionId":"session_secret","configOptions":[],"modes":{}}`))
+	got := strings.Join(keys, ",")
+	if got != "configOptions,modes,sessionId" {
+		t.Errorf("unexpected keys: %q", got)
+	}
+	if acpResultTopLevelKeys([]byte("not json")) != nil {
+		t.Error("expected nil for non-JSON result")
+	}
+}
+
 func TestHermesModelSelectionSupported(t *testing.T) {
 	// Regression guard: hermes now supports model selection via
 	// the ACP session/set_model RPC, so the UI dropdown should


### PR DESCRIPTION
Fixes #5847 (MUL-5239)

## Problem

kimi-code 0.29 changed its ACP `session/new` response: the top-level `models.availableModels` / `currentModelId` block is gone, and the same catalog now lives in a `configOptions` entry whose `id` and `category` are both `"model"`.

`parseACPSessionNewModels` only understood the old shape, so `discoverKimiModels` returned an empty catalog. The runtime registered fine and `model list requested … provider=kimi` completed without error, but the UI picker showed "no available models" — easy to misdiagnose as a PATH or install failure, since detection had actually succeeded.

## Change

`parseACPSessionNewModels` now falls back to `configOptions` when the `models` block yields nothing:

- `options[].value` → model id, `options[].name` → label, `currentValue` → default flag.
- The model option is identified by `id == "model"` **or** `category == "model"` (case-insensitive), so it survives an upstream rename of either field alone.
- `configOptions` / `config_options` and `currentValue` / `current_value` are both accepted, matching how the existing `models` path handles snake_case.

The `models` block still wins whenever it produces entries, so hermes, kiro, qoder, copilot, trae and grok are byte-for-byte unchanged.

Non-model options are deliberately **not** mapped. The reporter suggested optionally surfacing `thinking` / `thought_level` from the same list; I left it out because thinking level is a separate product surface with no picker to land in, and folding those values into the model dropdown would offer ids that `session/set_model` cannot honour. Worth a follow-up issue once the interaction is defined.

Second half of the fix is diagnostic: when `session/new` succeeds but no catalog is recognised, `discoverACPModels` now logs the **top-level response keys only** — `result_keys=configOptions,modes,sessionId`. Keys, never values, so nothing from the upstream response body (session ids, catalog contents, account-shaped data) reaches `daemon.log`. That is enough to tell schema drift apart from a genuinely empty catalog next time.

## Scope note

This restores the UI catalog. It assumes `session/set_model` still works on 0.29 for the ids advertised in `configOptions` — which the issue's own workaround (`agent create --model kimi-code/k3` / `MULTICA_KIMI_MODEL`) exercises today through the same RPC in `kimi.go`. I could not verify that against a live 0.29 CLI in this environment. If 0.29 also moved model selection to a `session/set_config_option` RPC, that is a separate fix in `kimi.go`, not here.

## Tests

Five new cases in `server/pkg/agent/models_test.go`, built from the trimmed real 0.29 payload in the issue:

- `TestParseACPSessionNewModelsFromConfigOptions` — all three kimi models parsed, `kimi-code/k3` marked default, thinking-level values asserted absent from the catalog, and `kimi-code/k3` asserted **not** split into a provider group (provider derivation is colon-only, so the slash form stays flat).
- `TestParseACPSessionNewModelsPrefersModelsBlockOverConfigOptions` — regression guard for existing providers when both shapes are present.
- `TestParseACPSessionNewModelsConfigOptionsSnakeCaseAndCategoryOnly` — snake_case keys, category-only identification, plus duplicate / blank-value / missing-name handling.
- `TestParseACPSessionNewModelsIgnoresNonModelConfigOptions` — a response with only a thinking option still yields an empty catalog rather than an invented one.
- `TestACPResultTopLevelKeys` — asserts the diagnostic line exposes key names only and stays nil on non-JSON.

Verified locally: `gofmt`, `go vet ./pkg/agent/`, and the full `go test ./pkg/agent/ -count=1` suite (131s) pass. No live kimi 0.29 CLI was available, so end-to-end picker behaviour is covered by the payload-level tests rather than a real handshake.
