### PR TITLE
MUL-5240 refactor(agent): drop dead Cursor cost fields (CLI reports no cost)

### DIFF
--- a/server/pkg/agent/cursor.go
+++ b/server/pkg/agent/cursor.go
@@ -474,7 +474,15 @@ type cursorStreamEvent struct {
 	// tool_result fields
 	Output string `json:"output,omitempty"`
 
-	// result fields
+	// result fields.
+	//
+	// The result event reports token counts only; cursor-agent's stream-json
+	// carries no per-turn cost (no `total_cost_usd`, no per-step `cost`). This
+	// was verified against the real CLI (2026.07.20, both stream-json and json
+	// output) and Cursor's CLI docs. So — unlike Grok, whose turn cost xAI
+	// reports authoritatively — Cursor spend is estimated downstream from the
+	// static rate table, never carried through here. Add a cost field only
+	// when a real payload proves the CLI emits one.
 	ResultText       string       `json:"result,omitempty"`
 	IsError          bool         `json:"is_error,omitempty"`
 	InputTokens      int64        `json:"inputTokens,omitempty"`
@@ -482,7 +490,6 @@ type cursorStreamEvent struct {
 	CacheReadTokens  int64        `json:"cacheReadTokens,omitempty"`
 	CacheWriteTokens int64        `json:"cacheWriteTokens,omitempty"`
 	Usage            *cursorUsage `json:"usage,omitempty"`
-	TotalCost        float64      `json:"total_cost_usd,omitempty"`
 
 	// error fields
 	ErrorMsg string `json:"error,omitempty"`
@@ -572,6 +579,9 @@ type cursorTextPart struct {
 	Text string `json:"text"`
 }
 
+// cursorStepFinishPart carries per-step token counts. cursor-agent does not
+// report a per-step cost (see cursorStreamEvent's result-fields note), so only
+// tokens are parsed here.
 type cursorStepFinishPart struct {
 	Tokens struct {
 		Input  int `json:"input"`
@@ -580,7 +590,6 @@ type cursorStepFinishPart struct {
 			Read int `json:"read"`
 		} `json:"cache"`
 	} `json:"tokens"`
-	Cost float64 `json:"cost"`
 }
 
 // ── Helpers ──

--- a/server/pkg/agent/cursor_test.go
+++ b/server/pkg/agent/cursor_test.go
@@ -446,6 +446,8 @@ func TestCursorStepFinishParsing(t *testing.T) {
 	t.Parallel()
 
 	part := cursorStepFinishPart{}
+	// The trailing "cost" key is ignored: cursor-agent does not report per-step
+	// cost, and unknown keys must not break token parsing.
 	data := `{"tokens":{"input":500,"output":200,"cache":{"read":100}},"cost":0.01}`
 	if err := json.Unmarshal([]byte(data), &part); err != nil {
 		t.Fatalf("unmarshal: %v", err)


### PR DESCRIPTION
## Summary

MUL-5240 set out to wire Cursor's authoritative per-turn cost into `task_usage` (mirroring the Grok work in #5841). Its own design gate said to **confirm the `step_finish` cost semantics against a real payload first, because getting it wrong double-bills**.

Confirming against the real CLI killed the premise: **cursor-agent does not report cost at all.**

Evidence:
- **Real CLI** (`cursor-agent` 2026.07.20 — the version the daemon runs — with the exact daemon flags, both `--output-format stream-json` and `json`): the `result` event's `usage` object carries **only** `inputTokens` / `outputTokens` / `cacheReadTokens` / `cacheWriteTokens`. No `total_cost_usd`, no `cost` anywhere, and **no `step_finish` events at all** (the CLI now emits `tool_call`).
- **Cursor's CLI docs**: the result event lists no cost fields.
- **Cursor forum**: token usage was only recently added to stream-json; cost is not part of the schema.
- **ccusage** (per-CLI usage/cost tool): doesn't support Cursor, and Cursor isn't among the CLIs that report cost natively (unlike Claude Code / Grok / Codex).

So `cursorStreamEvent.TotalCost` (`total_cost_usd`) and `cursorStepFinishPart.Cost` (`cost`) were speculatively copied from Claude Code's stream-json schema in the original Cursor runtime PR (#1057) and were **never read** by any code path. Cursor spend stays estimated downstream from the static rate table — there is no authoritative figure to carry through.

## Changes

- Remove the two dead cost fields (`cursorStreamEvent.TotalCost`, `cursorStepFinishPart.Cost`).
- Document on the result-fields struct that cursor-agent reports token counts only, so the next person doesn't re-file this and reach for a field that never populates.
- Note in the step-finish parsing test that the trailing `cost` key is deliberately ignored.

No behavior change: these fields were never consumed, so cost accounting is byte-identical. This does **not** touch the `CostUSDTicks` plumbing from #5841 (that PR is still open); if Cursor ever starts emitting cost, add the field and the wiring together, gated on a real payload.

## Verification

- `go vet ./pkg/agent` — clean.
- `go test ./pkg/agent -count=1` — pass (full package).
