### PR TITLE
MUL-5245: docs: add Windows install instructions and split OS-specific steps into collapsible sections

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,12 @@ Multica manages the full agent lifecycle: from task assignment to execution moni
 
 ## Quick Install
 
-### macOS / Linux (Homebrew - recommended)
+<details open>
+<summary><b>macOS / Linux</b></summary>
+
+<br/>
+
+### Homebrew (recommended)
 
 ```bash
 brew install multica-ai/tap/multica
@@ -75,19 +80,13 @@ brew install multica-ai/tap/multica
 
 Use `brew upgrade multica-ai/tap/multica` to keep the CLI current.
 
-### macOS / Linux (install script)
+### Install script
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/multica-ai/multica/main/scripts/install.sh | bash
 ```
 
 Use this if Homebrew is not available. The script installs the Multica CLI on macOS and Linux by using Homebrew when it is on `PATH`, otherwise it downloads the binary directly.
-
-### Windows (PowerShell)
-
-```powershell
-irm https://raw.githubusercontent.com/multica-ai/multica/main/scripts/install.ps1 | iex
-```
 
 Then configure, authenticate, and start the daemon in one command:
 
@@ -104,6 +103,36 @@ multica setup          # Connect to Multica Cloud, log in, start daemon
 >
 > This pulls the official Multica images from GHCR (latest stable by default). Requires Docker. See the [Self-Hosting Guide](SELF_HOSTING.md) for details.
 > If the selected GHCR tag has not been published yet, fall back to `make selfhost-build` from a checkout.
+
+</details>
+
+<details>
+<summary><b>Windows (PowerShell)</b></summary>
+
+<br/>
+
+### PowerShell
+
+```powershell
+irm https://raw.githubusercontent.com/multica-ai/multica/main/scripts/install.ps1 | iex
+```
+
+Then configure, authenticate, and start the daemon in one command:
+
+```powershell
+multica setup          # Connect to Multica Cloud, log in, start daemon
+```
+
+> **Self-hosting?** Set the `MULTICA_MODE` environment variable to `with-server` before running the installer to deploy a full Multica server on your machine:
+>
+> ```powershell
+> $env:MULTICA_MODE="with-server"; irm https://raw.githubusercontent.com/multica-ai/multica/main/scripts/install.ps1 | iex
+> multica setup self-host
+> ```
+>
+> This pulls the official Multica images from GHCR (latest stable by default). Requires Docker. See the [Self-Hosting Guide](SELF_HOSTING.md) for details.
+
+</details>
 
 ---
 

--- a/SELF_HOSTING.md
+++ b/SELF_HOSTING.md
@@ -14,7 +14,12 @@ Each user who runs AI agents locally also installs the **`multica` CLI** and run
 
 ## Quick Install (Recommended)
 
-Two commands to set up everything — server, CLI, and configuration:
+Two commands to set up everything — server, CLI, and configuration.
+
+<details open>
+<summary><b>macOS / Linux</b></summary>
+
+<br/>
 
 ```bash
 # 1. Install CLI + provision the self-host server
@@ -23,6 +28,20 @@ curl -fsSL https://raw.githubusercontent.com/multica-ai/multica/main/scripts/ins
 # 2. Configure CLI, authenticate, and start the daemon
 multica setup self-host
 ```
+</details>
+<details>
+<summary><b>Windows (PowerShell)</b></summary>
+
+<br/>
+
+```powershell
+# 1. Install CLI + provision the self-host server
+$env:MULTICA_MODE="with-server"; irm https://raw.githubusercontent.com/multica-ai/multica/main/scripts/install.ps1 | iex
+
+# 2. Configure CLI, authenticate, and start the daemon
+multica setup self-host
+```
+</details>
 
 This installs the `multica` CLI, checks out the latest self-host assets, pulls the official Multica images from GHCR, and configures everything for localhost.
 


### PR DESCRIPTION
_Maintainer note: the **Changes Made** and **AI Disclosure** sections were tidied to match the actual diff — the "CLI only?" note and the WSL 2 / Prerequisites entry mentioned in the original draft aren't part of this PR._

## What does this PR do?

Adds a Windows (PowerShell) self-hosting path to both the README and the Self-Hosting Guide, and reorganizes the OS-specific install steps into collapsible `<details>` sections so readers can quickly find the commands for their platform without scrolling through irrelevant ones. The README previously carried a basic Windows install command but no self-host variant, and the Self-Hosting Guide documented only macOS/Linux.

The Windows self-host flow uses the `MULTICA_MODE` environment variable instead of the `--with-server` flag, since PowerShell's `irm | iex` piping can't forward script arguments the same way bash does.

## Related Issue

Closes #

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Refactor / code improvement (no behavior change)
- [x] Documentation update
- [ ] Tests (adding or improving test coverage)
- [ ] CI / infrastructure

## Changes Made

- `README.md` — split the **Quick Install** section into `<details>` blocks for **macOS / Linux** and **Windows (PowerShell)**
- `README.md` — moved the Windows PowerShell install command (`irm ... | iex`) into the collapsible block and added the self-host variant (`$env:MULTICA_MODE="with-server"; ...`) alongside the `multica setup` step
- `SELF_HOSTING.md` — added a Windows (PowerShell) install block under **Quick Install**, keeping the OS-common setup notes (GHCR images, localhost config) shared outside the collapsible blocks

## How to Test

1. Open the rendered `README.md` and `SELF_HOSTING.md` on GitHub
2. Verify the **macOS / Linux** and **Windows (PowerShell)** sections render as collapsible `<details>` blocks with correct syntax highlighting (`bash` vs `powershell`)
3. On a Windows machine with Docker Desktop, run the documented self-host command and confirm the server provisions and `http://localhost:3000` loads
4. Confirm the macOS/Linux commands are unchanged and still work

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have run tests locally and they pass
- [ ] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [x] I have updated relevant documentation to reflect my changes
- [ ] If I added a new runtime / coding tool / UI tab, I synced the change to **landing copy** (`apps/web/features/landing/i18n/`) and **relevant docs** (`apps/docs/content/docs/`)
- [ ] If this PR touches Chinese product copy, I checked it against `apps/docs/content/docs/developers/conventions.zh.mdx` (terminology, mixed-rule for `task` / `issue` / `s****`)
- [x] I have considered and documented any risks above
- [ ] I will address all reviewer comments before requesting merge

## AI Disclosure

**AI tool used:** Claude

**Prompt / approach:**
Asked the assistant to reorganize the install sections into collapsible OS-specific blocks and to add the Windows PowerShell commands. The assistant proposed the `<details>` structure and the `MULTICA_MODE` env-var approach for Windows self-hosting, which I reviewed and applied.

## Screenshots (optional)

<img width="1068" height="1624" alt="image" src="https://github.com/user-attachments/assets/3f1e1b08-4e6d-4554-8c57-c3a59a27eef9" />

<img width="1297" height="1084" alt="image" src="https://github.com/user-attachments/assets/2bc24bfd-a93e-4109-a7ad-6a534e7be39e" />
