### PR TITLE
fix(agent): ignore Hermes INFO echoes that falsely fail completed runs (#5862)

### DIFF
--- a/server/pkg/agent/hermes.go
+++ b/server/pkg/agent/hermes.go
@@ -2196,12 +2196,14 @@ func (s *acpProviderErrorSniffer) Write(p []byte) (int, error) {
 		} else if s.echoJSON {
 			// A strong, unindented provider-error header is a new bare
 			// error block even if a malformed echo never closed. Indented
-			// error-looking text remains part of the structured echo.
+			// error-looking text remains part of the structured echo. This
+			// also applies when the echo was truncated inside a JSON string:
+			// an unescaped physical newline is not valid inside that string.
 			indented := rawLine[0] == ' ' || rawLine[0] == '\t'
 			bareError := strings.HasPrefix(line, "⚠️") ||
 				strings.HasPrefix(line, "❌") ||
 				strings.HasPrefix(line, "[ERROR]")
-			if !s.echoInString && !indented && bareError && acpErrorHeaderRe.MatchString(line) {
+			if !indented && bareError && acpErrorHeaderRe.MatchString(line) {
 				s.resetEchoJSON()
 			} else {
 				s.consumeEchoJSON(rawLine)

--- a/server/pkg/agent/hermes.go
+++ b/server/pkg/agent/hermes.go
@@ -2115,6 +2115,14 @@ var acpAgentOutputTerminalRe = regexp.MustCompile(`API call failed after \d+ ret
 
 const acpMaxErrorLines = 8
 
+// acpHermesInfoRootRe matches Python logging records where Hermes echoes
+// conversation and tool data to stderr. The payload may itself contain
+// arbitrary error examples, terminal markers, or provider-looking text;
+// it is INFO data and must never participate in provider-error matching.
+var acpHermesInfoRootRe = regexp.MustCompile(
+	`^[0-9]{4}-[0-9]{2}-[0-9]{2} [0-9]{2}:[0-9]{2}:[0-9]{2}(?:,[0-9]+)? \[INFO\] root:`,
+)
+
 // acpMaxErrorLineLen bounds how long a single stderr line may be to
 // still be considered for provider-error matching. Genuine ACP
 // provider-error lines are short (an error header plus a one-line
@@ -2126,9 +2134,8 @@ const acpMaxErrorLines = 8
 // "Error:" / "KeyError:" fragment far apart on the same line — it
 // satisfies both the capture filter and the terminal condition and
 // flips a completed run to failed (GitHub multica#5862). Skipping
-// over-long lines keeps echoed conversation content out of the
-// sniffer entirely while still admitting every real provider-error
-// line.
+// known INFO records above is the primary guard; this length bound is
+// defense in depth for oversized echoes with an unknown log prefix.
 const acpMaxErrorLineLen = 4096
 
 // newACPProviderErrorSniffer returns a sniffer that tags its messages
@@ -2161,13 +2168,16 @@ func (s *acpProviderErrorSniffer) Write(p []byte) (int, error) {
 		if line == "" {
 			continue
 		}
+		// Hermes emits conversation and tool records to stderr through
+		// Python's root logger. Their payload is arbitrary data, not a
+		// provider error, even when it contains strings such as "❌",
+		// "Error:", "HTTP 429", or "API call failed".
+		if acpHermesInfoRootRe.MatchString(line) {
+			continue
+		}
 		// Hermes echoes whole conversation / tool-result records to
-		// stderr as a single oversized line. Such a line is never a
-		// real provider-error line, but its unrelated embedded tokens
-		// (a "❌" bullet plus an "Error:" fragment) would otherwise
-		// satisfy both the capture filter and the terminal condition
-		// and flip a completed run to failed (GitHub multica#5862).
-		// Skip anything longer than a real error line can plausibly be.
+		// stderr as a single line. Keep a length guard as a fallback
+		// for an oversized echo whose logger prefix changes.
 		if len(line) > acpMaxErrorLineLen {
 			continue
 		}

--- a/server/pkg/agent/hermes.go
+++ b/server/pkg/agent/hermes.go
@@ -2085,6 +2085,12 @@ type acpProviderErrorSniffer struct {
 	lines    []string // captured error lines, bounded
 	seen     map[string]bool
 	terminal bool // sticky: at least one line matched acpTerminalErrorRe
+	// skipEcho is true while the sniffer is inside a Python INFO/DEBUG
+	// root-logger record (see acpEchoLogLevels): its first physical line
+	// carried an echo-level prefix, so this line and its prefix-less
+	// continuation lines are conversation/tool data to skip, until the
+	// next record prefix arrives. Persisted across Write calls.
+	skipEcho bool
 }
 
 // acpErrorHeaderRe matches the first line of an API-error block.
@@ -2115,29 +2121,32 @@ var acpAgentOutputTerminalRe = regexp.MustCompile(`API call failed after \d+ ret
 
 const acpMaxErrorLines = 8
 
-// acpHermesInfoRootRe matches Python logging records where Hermes echoes
-// conversation and tool data to stderr. These are pollution sources, not
-// real provider errors: the agent may already have produced a successful
-// final reply while the payload still embeds documentation/code/tool text
-// that looks like an error. INFO data must never participate in
-// provider-error matching.
-var acpHermesInfoRootRe = regexp.MustCompile(
-	`^[0-9]{4}-[0-9]{2}-[0-9]{2} [0-9]{2}:[0-9]{2}:[0-9]{2}(?:,[0-9]+)? \[INFO\] root:`,
+// acpLogRecordPrefixRe matches the start of a Python `logging` record that
+// Hermes writes to stderr: "YYYY-MM-DD HH:MM:SS[,mmm] [LEVEL] root: ...".
+// Capture group 1 is the level. A physical line WITHOUT this prefix is a
+// continuation line of the record above it: Hermes echoes multi-line
+// conversation / tool JSON whose embedded newlines split one logical record
+// across several physical lines (GitHub multica#5862).
+var acpLogRecordPrefixRe = regexp.MustCompile(
+	`^[0-9]{4}-[0-9]{2}-[0-9]{2} [0-9]{2}:[0-9]{2}:[0-9]{2}(?:,[0-9]+)? \[([A-Z]+)\] root:`,
 )
 
-// acpMaxErrorLineLen bounds how long a single stderr line may be to
-// still be considered for provider-error matching. Genuine ACP
-// provider-error lines are short (an error header plus a one-line
-// "Error: ..." detail — see TestHermesProviderErrorSniffer, ~150
-// bytes). Hermes, however, echoes whole conversation / tool-result
-// records to stderr at `[INFO] root:` level as a *single physical
-// line* tens of KB long; when that echoed content happens to embed
-// unrelated skill-doc substrings — a bare "❌" bullet plus an
-// "Error:" / "KeyError:" fragment far apart on the same line — it
-// satisfies both the capture filter and the terminal condition and
-// flips a completed run to failed (GitHub multica#5862). Skipping
-// known INFO records above is the primary guard; this length bound is
-// defense in depth for oversized echoes with an unknown log prefix.
+// acpEchoLogLevels are the Python root-logger levels Hermes uses purely to
+// echo conversation and tool data to stderr. Those records are arbitrary
+// payload, never a provider error, even when they embed strings such as
+// "❌", "Error:", "HTTP 429", or "API call failed". ERROR / WARNING /
+// CRITICAL records are real diagnostics and must still be matched.
+var acpEchoLogLevels = map[string]bool{"INFO": true, "DEBUG": true}
+
+// acpMaxErrorLineLen bounds the length of the persisted provider-error
+// summary. Genuine ACP provider-error lines are short (an error header plus
+// a one-line "Error: ..." detail — see TestHermesProviderErrorSniffer, ~150
+// bytes), but an oversized echo that slips past the log-record filter could
+// otherwise store tens of KB. This bound is applied only when BUILDING the
+// stored message, never as a precondition for *classifying* a line as an
+// error: a real provider failure whose single line happens to exceed this
+// length must still fail the run, not be silently dropped (GitHub
+// multica#5862 — do not gate matching on length).
 const acpMaxErrorLineLen = 4096
 
 // newACPProviderErrorSniffer returns a sniffer that tags its messages
@@ -2170,17 +2179,19 @@ func (s *acpProviderErrorSniffer) Write(p []byte) (int, error) {
 		if line == "" {
 			continue
 		}
-		// Hermes emits conversation and tool records to stderr through
-		// Python's root logger. Their payload is arbitrary data, not a
-		// provider error, even when it contains strings such as "❌",
-		// "Error:", "HTTP 429", or "API call failed".
-		if acpHermesInfoRootRe.MatchString(line) {
-			continue
+		// Track Python root-logger records so conversation/tool echoes
+		// never reach the error matchers. A line carrying a record prefix
+		// starts a new record: INFO/DEBUG records are data (skip them and
+		// their continuation lines); ERROR/WARNING/CRITICAL records are
+		// real diagnostics. A line WITHOUT a prefix is a continuation of
+		// the record above it and inherits that record's skip state —
+		// this is what stops a multi-line INFO echo whose inner JSON
+		// embeds "❌"/"Error:" from flipping a completed run to failed
+		// (GitHub multica#5862).
+		if m := acpLogRecordPrefixRe.FindStringSubmatch(line); m != nil {
+			s.skipEcho = acpEchoLogLevels[m[1]]
 		}
-		// Hermes echoes whole conversation / tool-result records to
-		// stderr as a single line. Keep a length guard as a fallback
-		// for an oversized echo whose logger prefix changes.
-		if len(line) > acpMaxErrorLineLen {
+		if s.skipEcho {
 			continue
 		}
 		if !(acpErrorHeaderRe.MatchString(line) || acpErrorDetailRe.MatchString(line)) {
@@ -2241,16 +2252,27 @@ func (s *acpProviderErrorSniffer) messageLocked() string {
 		if m := acpErrorDetailRe.FindStringSubmatch(line); m != nil {
 			detail := strings.TrimSpace(m[1])
 			if detail != "" {
-				return prefix + detail
+				return acpTruncateError(prefix + detail)
 			}
 		}
 	}
 	for _, line := range s.lines {
 		if acpErrorHeaderRe.MatchString(line) {
-			return prefix + line
+			return acpTruncateError(prefix + line)
 		}
 	}
 	return ""
+}
+
+// acpTruncateError bounds a persisted provider-error summary to
+// acpMaxErrorLineLen bytes on a valid UTF-8 boundary, marking any cut.
+// Classification already happened by the time this runs; it only limits
+// how much of an oversized message is stored, never whether a run fails.
+func acpTruncateError(msg string) string {
+	if len(msg) <= acpMaxErrorLineLen {
+		return msg
+	}
+	return strings.ToValidUTF8(msg[:acpMaxErrorLineLen], "") + "…(truncated)"
 }
 
 // promoteACPResultOnProviderError flips finalStatus to "failed" if

--- a/server/pkg/agent/hermes.go
+++ b/server/pkg/agent/hermes.go
@@ -2116,9 +2116,11 @@ var acpAgentOutputTerminalRe = regexp.MustCompile(`API call failed after \d+ ret
 const acpMaxErrorLines = 8
 
 // acpHermesInfoRootRe matches Python logging records where Hermes echoes
-// conversation and tool data to stderr. The payload may itself contain
-// arbitrary error examples, terminal markers, or provider-looking text;
-// it is INFO data and must never participate in provider-error matching.
+// conversation and tool data to stderr. These are pollution sources, not
+// real provider errors: the agent may already have produced a successful
+// final reply while the payload still embeds documentation/code/tool text
+// that looks like an error. INFO data must never participate in
+// provider-error matching.
 var acpHermesInfoRootRe = regexp.MustCompile(
 	`^[0-9]{4}-[0-9]{2}-[0-9]{2} [0-9]{2}:[0-9]{2}:[0-9]{2}(?:,[0-9]+)? \[INFO\] root:`,
 )

--- a/server/pkg/agent/hermes.go
+++ b/server/pkg/agent/hermes.go
@@ -2085,12 +2085,13 @@ type acpProviderErrorSniffer struct {
 	lines    []string // captured error lines, bounded
 	seen     map[string]bool
 	terminal bool // sticky: at least one line matched acpTerminalErrorRe
-	// skipEcho is true while the sniffer is inside a Python INFO/DEBUG
-	// root-logger record (see acpEchoLogLevels): its first physical line
-	// carried an echo-level prefix, so this line and its prefix-less
-	// continuation lines are conversation/tool data to skip, until the
-	// next record prefix arrives. Persisted across Write calls.
-	skipEcho bool
+	// echoJSON tracks an incomplete structured payload from a Python
+	// INFO/DEBUG root-logger record. The JSON scanner state is persisted
+	// across Write calls so only actual payload continuations are skipped.
+	echoJSON     bool
+	echoDepth    int
+	echoInString bool
+	echoEscaped  bool
 }
 
 // acpErrorHeaderRe matches the first line of an API-error block.
@@ -2122,13 +2123,12 @@ var acpAgentOutputTerminalRe = regexp.MustCompile(`API call failed after \d+ ret
 const acpMaxErrorLines = 8
 
 // acpLogRecordPrefixRe matches the start of a Python `logging` record that
-// Hermes writes to stderr: "YYYY-MM-DD HH:MM:SS[,mmm] [LEVEL] root: ...".
-// Capture group 1 is the level. A physical line WITHOUT this prefix is a
-// continuation line of the record above it: Hermes echoes multi-line
-// conversation / tool JSON whose embedded newlines split one logical record
-// across several physical lines (GitHub multica#5862).
+// Hermes writes to stderr: "YYYY-MM-DD HH:MM:SS[,mmm] [LEVEL] logger: ...".
+// Capture groups are level, logger, and payload. Matching every logger is
+// important because a non-root ERROR record also ends a preceding root INFO
+// record and must remain visible to the provider-error matchers.
 var acpLogRecordPrefixRe = regexp.MustCompile(
-	`^[0-9]{4}-[0-9]{2}-[0-9]{2} [0-9]{2}:[0-9]{2}:[0-9]{2}(?:,[0-9]+)? \[([A-Z]+)\] root:`,
+	`^[0-9]{4}-[0-9]{2}-[0-9]{2} [0-9]{2}:[0-9]{2}:[0-9]{2}(?:,[0-9]+)? \[([A-Z]+)\] ([A-Za-z0-9_.-]+):\s*(.*)$`,
 )
 
 // acpEchoLogLevels are the Python root-logger levels Hermes uses purely to
@@ -2174,25 +2174,39 @@ func (s *acpProviderErrorSniffer) Write(p []byte) (int, error) {
 	complete = string(data[:nl])
 	s.remains = append(s.remains[:0], data[nl+1:]...)
 
-	for _, line := range strings.Split(complete, "\n") {
-		line = strings.TrimSpace(line)
+	for _, rawLine := range strings.Split(complete, "\n") {
+		rawLine = strings.TrimSuffix(rawLine, "\r")
+		line := strings.TrimSpace(rawLine)
 		if line == "" {
 			continue
 		}
-		// Track Python root-logger records so conversation/tool echoes
-		// never reach the error matchers. A line carrying a record prefix
-		// starts a new record: INFO/DEBUG records are data (skip them and
-		// their continuation lines); ERROR/WARNING/CRITICAL records are
-		// real diagnostics. A line WITHOUT a prefix is a continuation of
-		// the record above it and inherits that record's skip state —
-		// this is what stops a multi-line INFO echo whose inner JSON
-		// embeds "❌"/"Error:" from flipping a completed run to failed
+		// INFO/DEBUG root records are conversation/tool echoes and never
+		// reach the error matchers. When their payload is structured JSON,
+		// track brace depth across physical lines and skip only until that
+		// JSON closes. A complete single-line echo therefore cannot hide a
+		// following bare provider error. Any Python logger prefix also
+		// starts a new record, so non-root ERROR diagnostics remain visible
 		// (GitHub multica#5862).
 		if m := acpLogRecordPrefixRe.FindStringSubmatch(line); m != nil {
-			s.skipEcho = acpEchoLogLevels[m[1]]
-		}
-		if s.skipEcho {
-			continue
+			s.resetEchoJSON()
+			if acpEchoLogLevels[m[1]] && m[2] == "root" {
+				s.startEchoJSON(m[3])
+				continue
+			}
+		} else if s.echoJSON {
+			// A strong, unindented provider-error header is a new bare
+			// error block even if a malformed echo never closed. Indented
+			// error-looking text remains part of the structured echo.
+			indented := rawLine[0] == ' ' || rawLine[0] == '\t'
+			bareError := strings.HasPrefix(line, "⚠️") ||
+				strings.HasPrefix(line, "❌") ||
+				strings.HasPrefix(line, "[ERROR]")
+			if !s.echoInString && !indented && bareError && acpErrorHeaderRe.MatchString(line) {
+				s.resetEchoJSON()
+			} else {
+				s.consumeEchoJSON(rawLine)
+				continue
+			}
 		}
 		if !(acpErrorHeaderRe.MatchString(line) || acpErrorDetailRe.MatchString(line)) {
 			continue
@@ -2210,6 +2224,55 @@ func (s *acpProviderErrorSniffer) Write(p []byte) (int, error) {
 		}
 	}
 	return len(p), nil
+}
+
+func (s *acpProviderErrorSniffer) startEchoJSON(payload string) {
+	payload = strings.TrimSpace(payload)
+	if payload == "" || (payload[0] != '{' && payload[0] != '[') {
+		return
+	}
+	s.echoJSON = true
+	s.consumeEchoJSON(payload)
+}
+
+// consumeEchoJSON tracks only structural JSON bytes. It avoids buffering
+// arbitrary conversation/tool payloads while still recognizing their exact
+// multi-line boundary, including braces inside quoted strings.
+func (s *acpProviderErrorSniffer) consumeEchoJSON(fragment string) {
+	for i := 0; i < len(fragment); i++ {
+		switch {
+		case s.echoEscaped:
+			s.echoEscaped = false
+		case s.echoInString:
+			switch fragment[i] {
+			case '\\':
+				s.echoEscaped = true
+			case '"':
+				s.echoInString = false
+			}
+		default:
+			switch fragment[i] {
+			case '"':
+				s.echoInString = true
+			case '{', '[':
+				s.echoDepth++
+			case '}', ']':
+				if s.echoDepth > 0 {
+					s.echoDepth--
+				}
+			}
+		}
+	}
+	if s.echoDepth == 0 {
+		s.resetEchoJSON()
+	}
+}
+
+func (s *acpProviderErrorSniffer) resetEchoJSON() {
+	s.echoJSON = false
+	s.echoDepth = 0
+	s.echoInString = false
+	s.echoEscaped = false
 }
 
 // message returns a single-line summary suitable for the task

--- a/server/pkg/agent/hermes.go
+++ b/server/pkg/agent/hermes.go
@@ -2115,6 +2115,22 @@ var acpAgentOutputTerminalRe = regexp.MustCompile(`API call failed after \d+ ret
 
 const acpMaxErrorLines = 8
 
+// acpMaxErrorLineLen bounds how long a single stderr line may be to
+// still be considered for provider-error matching. Genuine ACP
+// provider-error lines are short (an error header plus a one-line
+// "Error: ..." detail — see TestHermesProviderErrorSniffer, ~150
+// bytes). Hermes, however, echoes whole conversation / tool-result
+// records to stderr at `[INFO] root:` level as a *single physical
+// line* tens of KB long; when that echoed content happens to embed
+// unrelated skill-doc substrings — a bare "❌" bullet plus an
+// "Error:" / "KeyError:" fragment far apart on the same line — it
+// satisfies both the capture filter and the terminal condition and
+// flips a completed run to failed (GitHub multica#5862). Skipping
+// over-long lines keeps echoed conversation content out of the
+// sniffer entirely while still admitting every real provider-error
+// line.
+const acpMaxErrorLineLen = 4096
+
 // newACPProviderErrorSniffer returns a sniffer that tags its messages
 // with the given provider name (e.g. "hermes", "kimi") so failure
 // strings make it obvious which runtime produced the error.
@@ -2143,6 +2159,16 @@ func (s *acpProviderErrorSniffer) Write(p []byte) (int, error) {
 	for _, line := range strings.Split(complete, "\n") {
 		line = strings.TrimSpace(line)
 		if line == "" {
+			continue
+		}
+		// Hermes echoes whole conversation / tool-result records to
+		// stderr as a single oversized line. Such a line is never a
+		// real provider-error line, but its unrelated embedded tokens
+		// (a "❌" bullet plus an "Error:" fragment) would otherwise
+		// satisfy both the capture filter and the terminal condition
+		// and flip a completed run to failed (GitHub multica#5862).
+		// Skip anything longer than a real error line can plausibly be.
+		if len(line) > acpMaxErrorLineLen {
 			continue
 		}
 		if !(acpErrorHeaderRe.MatchString(line) || acpErrorDetailRe.MatchString(line)) {

--- a/server/pkg/agent/hermes_test.go
+++ b/server/pkg/agent/hermes_test.go
@@ -1738,6 +1738,12 @@ func TestHermesProviderErrorSnifferRealErrorsAfterSingleLineInfo(t *testing.T) {
 			stream: "2026-07-24 10:09:00 [INFO] root: {\"message\":\"ordinary echo\"}\n" +
 				"2026-07-24 10:09:01 [ERROR] acp_adapter.server: ❌ API call failed after 3 retries: HTTP 429 rate limit exceeded\n",
 		},
+		{
+			name: "bare provider error after echo truncated inside string",
+			stream: "2026-07-24 10:09:00 [INFO] root: {\"message\":\"truncated echo\n" +
+				"❌ API call failed after 3 retries: RateLimitError [HTTP 429]\n" +
+				"📝 Error: HTTP 429 rate limit exceeded\n",
+		},
 	}
 
 	for _, tt := range tests {

--- a/server/pkg/agent/hermes_test.go
+++ b/server/pkg/agent/hermes_test.go
@@ -1674,8 +1674,13 @@ func TestHermesProviderErrorSnifferIgnoresMultiLineInfoRecords(t *testing.T) {
 		"}\n"
 
 	s := newACPProviderErrorSniffer("hermes")
-	if _, err := s.Write([]byte(record)); err != nil {
-		t.Fatalf("Write: %v", err)
+	for _, physicalLine := range strings.SplitAfter(record, "\n") {
+		if physicalLine == "" {
+			continue
+		}
+		if _, err := s.Write([]byte(physicalLine)); err != nil {
+			t.Fatalf("Write: %v", err)
+		}
 	}
 	if msg := s.message(); msg != "" {
 		t.Errorf("multi-line INFO echo must not be captured, got %q", firstNRunes(msg, 120))
@@ -1708,6 +1713,43 @@ func TestHermesProviderErrorSnifferErrorRecordAfterInfoRecord(t *testing.T) {
 	msg := s.terminalMessage()
 	if !strings.Contains(msg, "HTTP 429") {
 		t.Fatalf("real ERROR record after an INFO echo must stay terminal, got %q", msg)
+	}
+}
+
+// TestHermesProviderErrorSnifferRealErrorsAfterSingleLineInfo guards record
+// boundaries around INFO echoes. A complete single-line INFO record must not
+// make a following bare provider-error block or a non-root logger record look
+// like an INFO continuation.
+func TestHermesProviderErrorSnifferRealErrorsAfterSingleLineInfo(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		stream string
+	}{
+		{
+			name: "bare provider error",
+			stream: "2026-07-24 10:09:00 [INFO] root: {\"message\":\"ordinary echo with an unmatched { in quoted text\"}\n" +
+				"❌ API call failed after 3 retries: RateLimitError [HTTP 429]\n" +
+				"📝 Error: HTTP 429 rate limit exceeded\n",
+		},
+		{
+			name: "non-root error logger",
+			stream: "2026-07-24 10:09:00 [INFO] root: {\"message\":\"ordinary echo\"}\n" +
+				"2026-07-24 10:09:01 [ERROR] acp_adapter.server: ❌ API call failed after 3 retries: HTTP 429 rate limit exceeded\n",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := newACPProviderErrorSniffer("hermes")
+			if _, err := s.Write([]byte(tt.stream)); err != nil {
+				t.Fatalf("Write: %v", err)
+			}
+			if msg := s.terminalMessage(); !strings.Contains(msg, "HTTP 429") {
+				t.Fatalf("real provider error after a single-line INFO record was swallowed, got %q", msg)
+			}
+		})
 	}
 }
 

--- a/server/pkg/agent/hermes_test.go
+++ b/server/pkg/agent/hermes_test.go
@@ -1570,49 +1570,79 @@ func TestHermesProviderErrorSnifferBoundedBuffer(t *testing.T) {
 	}
 }
 
-// TestHermesProviderErrorSnifferIgnoresOversizedEchoedLine guards the
-// regression in GitHub multica#5862: Hermes echoes whole conversation /
-// tool-result records to stderr at `[INFO] root:` level as a *single
-// physical line*. When that echoed content happens to embed unrelated
-// skill-doc substrings — a bare "❌" bullet (matches acpTerminalErrorRe)
-// and an "Error:" / "KeyError:" fragment (matches acpErrorDetailRe) far
-// apart on the same line — the per-line sniffer used to treat the whole
-// line as a terminal provider error and flip a completed run to failed.
-// A genuine provider-error line is short; a conversation echo is tens of
-// KB. The sniffer must skip lines longer than acpMaxErrorLineLen so
-// echoed content can never be mistaken for an error.
-func TestHermesProviderErrorSnifferIgnoresOversizedEchoedLine(t *testing.T) {
+// TestHermesProviderErrorSnifferIgnoresEchoedInfoRecords guards the
+// regression in GitHub multica#5862: Hermes emits conversation and tool
+// records to stderr at `[INFO] root:` level. Those records are data, not
+// provider errors, but embedded documentation, code, or tool output can
+// contain both a terminal marker and an "Error:" fragment. The sniffer
+// must ignore the complete INFO record regardless of its size or payload.
+func TestHermesProviderErrorSnifferIgnoresEchoedInfoRecords(t *testing.T) {
+	t.Parallel()
+
+	oversizedDoc := `2026-07-24 10:08:59 [INFO] root: {"message":{"role":"tool","content":"` +
+		"# ❌ Deprecated approach: do not use this query. " +
+		strings.Repeat("reference documentation body ... ", 500) +
+		`The parser may return KeyError: 'series'; inspect the response shape first."}}`
+
+	tests := []struct {
+		name string
+		line string
+	}{
+		{
+			name: "oversized documentation payload",
+			line: oversizedDoc,
+		},
+		{
+			name: "short tool result payload",
+			line: `2026-07-24 10:09:00 [INFO] root: {"message":{"role":"tool","content":"# ❌ Deprecated example. KeyError: 'series' means the optional field is absent."}}`,
+		},
+		{
+			name: "short llm call payload",
+			line: `2026-07-24 10:09:01 [INFO] root: {"type":"llm_call","finish_reason":"tool_calls","arguments":"print(f\"Error: {err}\")","reasoning_content":"❌ This sample is intentionally invalid."}`,
+		},
+		{
+			name: "provider-looking text inside info payload",
+			line: `2026-07-24 10:09:02 [INFO] root: {"message":{"role":"tool","content":"Troubleshooting example: ❌ API call failed after 3 retries: HTTP 429. This is quoted documentation, not the current run."}}`,
+		},
+	}
+
+	if len(oversizedDoc) < acpMaxErrorLineLen {
+		t.Fatalf("oversized fixture is %d bytes, below the cap %d", len(oversizedDoc), acpMaxErrorLineLen)
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := newACPProviderErrorSniffer("hermes")
+			if _, err := s.Write([]byte(tt.line + "\n")); err != nil {
+				t.Fatalf("Write: %v", err)
+			}
+			if msg := s.message(); msg != "" {
+				t.Errorf("echoed INFO record must not be captured, got %d bytes: %q", len(msg), firstNRunes(msg, 100))
+			}
+			if msg := s.terminalMessage(); msg != "" {
+				t.Errorf("echoed INFO record must not set terminal failure, got %d bytes: %q", len(msg), firstNRunes(msg, 100))
+			}
+
+			status, errStr := promoteACPResultOnProviderError("completed", "", "Done. The requested work completed successfully.", s)
+			if status != "completed" {
+				t.Errorf("completed run flipped to %q (error=%q); regression of multica#5862", status, firstNRunes(errStr, 100))
+			}
+		})
+	}
+}
+
+func TestHermesProviderErrorSnifferStillCapturesErrorRootRecords(t *testing.T) {
 	t.Parallel()
 
 	s := newACPProviderErrorSniffer("hermes")
-
-	// One physical line: a Hermes INFO log echoing a tool result whose
-	// body embeds skill-doc content carrying both trigger tokens.
-	var b strings.Builder
-	b.WriteString(`2026-07-24 10:08:59 [INFO] root: {"message": {"role": "tool", "content": "`)
-	b.WriteString("# \u274c 旧方法：不加 type:pv 过滤，UV 偏高 ~18% ")
-	b.WriteString(strings.Repeat("skill documentation body ... ", 500))
-	b.WriteString("| RUM V2 返回 `KeyError: 'series'` | 代码需兼容 ")
-	b.WriteString(`"}}`)
-	line := b.String()
-	if len(line) < acpMaxErrorLineLen {
-		t.Fatalf("test line is %d bytes, below the cap %d; not exercising the guard", len(line), acpMaxErrorLineLen)
-	}
+	line := `2026-07-24 10:09:03 [ERROR] root: ❌ API call failed after 3 retries: HTTP 429 rate limit exceeded`
 	if _, err := s.Write([]byte(line + "\n")); err != nil {
 		t.Fatalf("Write: %v", err)
 	}
 
-	if msg := s.message(); msg != "" {
-		t.Errorf("oversized echoed line must not be captured as a provider error, got %d bytes: %q", len(msg), firstNRunes(msg, 100))
-	}
-	if msg := s.terminalMessage(); msg != "" {
-		t.Errorf("oversized echoed line must not set terminal failure, got %d bytes: %q", len(msg), firstNRunes(msg, 100))
-	}
-
-	// End-to-end: a completed run with real output must stay completed.
-	status, errStr := promoteACPResultOnProviderError("completed", "", "Done. Notification sent and comment posted.", s)
-	if status != "completed" {
-		t.Errorf("completed run flipped to %q (error=%q); regression of multica#5862", status, firstNRunes(errStr, 100))
+	msg := s.terminalMessage()
+	if !strings.Contains(msg, "HTTP 429") {
+		t.Fatalf("expected genuine ERROR root record to remain terminal, got %q", msg)
 	}
 }
 

--- a/server/pkg/agent/hermes_test.go
+++ b/server/pkg/agent/hermes_test.go
@@ -1570,6 +1570,61 @@ func TestHermesProviderErrorSnifferBoundedBuffer(t *testing.T) {
 	}
 }
 
+// TestHermesProviderErrorSnifferIgnoresOversizedEchoedLine guards the
+// regression in GitHub multica#5862: Hermes echoes whole conversation /
+// tool-result records to stderr at `[INFO] root:` level as a *single
+// physical line*. When that echoed content happens to embed unrelated
+// skill-doc substrings — a bare "❌" bullet (matches acpTerminalErrorRe)
+// and an "Error:" / "KeyError:" fragment (matches acpErrorDetailRe) far
+// apart on the same line — the per-line sniffer used to treat the whole
+// line as a terminal provider error and flip a completed run to failed.
+// A genuine provider-error line is short; a conversation echo is tens of
+// KB. The sniffer must skip lines longer than acpMaxErrorLineLen so
+// echoed content can never be mistaken for an error.
+func TestHermesProviderErrorSnifferIgnoresOversizedEchoedLine(t *testing.T) {
+	t.Parallel()
+
+	s := newACPProviderErrorSniffer("hermes")
+
+	// One physical line: a Hermes INFO log echoing a tool result whose
+	// body embeds skill-doc content carrying both trigger tokens.
+	var b strings.Builder
+	b.WriteString(`2026-07-24 10:08:59 [INFO] root: {"message": {"role": "tool", "content": "`)
+	b.WriteString("# \u274c 旧方法：不加 type:pv 过滤，UV 偏高 ~18% ")
+	b.WriteString(strings.Repeat("skill documentation body ... ", 500))
+	b.WriteString("| RUM V2 返回 `KeyError: 'series'` | 代码需兼容 ")
+	b.WriteString(`"}}`)
+	line := b.String()
+	if len(line) < acpMaxErrorLineLen {
+		t.Fatalf("test line is %d bytes, below the cap %d; not exercising the guard", len(line), acpMaxErrorLineLen)
+	}
+	if _, err := s.Write([]byte(line + "\n")); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+
+	if msg := s.message(); msg != "" {
+		t.Errorf("oversized echoed line must not be captured as a provider error, got %d bytes: %q", len(msg), firstNRunes(msg, 100))
+	}
+	if msg := s.terminalMessage(); msg != "" {
+		t.Errorf("oversized echoed line must not set terminal failure, got %d bytes: %q", len(msg), firstNRunes(msg, 100))
+	}
+
+	// End-to-end: a completed run with real output must stay completed.
+	status, errStr := promoteACPResultOnProviderError("completed", "", "Done. Notification sent and comment posted.", s)
+	if status != "completed" {
+		t.Errorf("completed run flipped to %q (error=%q); regression of multica#5862", status, firstNRunes(errStr, 100))
+	}
+}
+
+// firstNRunes returns at most n runes of s, for bounded error output.
+func firstNRunes(s string, n int) string {
+	r := []rune(s)
+	if len(r) <= n {
+		return s
+	}
+	return string(r[:n]) + "…"
+}
+
 func fakeHermesACPUsageWithDefaultModelScript() string {
 	return `#!/bin/sh
 while IFS= read -r line; do

--- a/server/pkg/agent/hermes_test.go
+++ b/server/pkg/agent/hermes_test.go
@@ -1570,12 +1570,19 @@ func TestHermesProviderErrorSnifferBoundedBuffer(t *testing.T) {
 	}
 }
 
-// TestHermesProviderErrorSnifferIgnoresEchoedInfoRecords guards the
-// regression in GitHub multica#5862: Hermes emits conversation and tool
-// records to stderr at `[INFO] root:` level. Those records are data, not
-// provider errors, but embedded documentation, code, or tool output can
-// contain both a terminal marker and an "Error:" fragment. The sniffer
-// must ignore the complete INFO record regardless of its size or payload.
+// TestHermesProviderErrorSnifferIgnoresEchoedInfoRecords guards pollution
+// failures from GitHub multica#5862.
+//
+// Pollution failure ≠ real provider failure:
+//   - real failure: Hermes/provider crashes; no successful final reply.
+//   - pollution failure: Hermes already produced a correct final reply /
+//     completed the requested work, then Multica suddenly flips the same
+//     run to failed because an `[INFO] root:` conversation/tool echo on
+//     stderr embedded error-looking tokens (Error:, KeyError:, ❌, ...).
+//
+// These fixtures model the pollution class. The sniffer must ignore the
+// full INFO record, and a completed run with a successful final reply
+// must stay completed.
 func TestHermesProviderErrorSnifferIgnoresEchoedInfoRecords(t *testing.T) {
 	t.Parallel()
 
@@ -1623,14 +1630,20 @@ func TestHermesProviderErrorSnifferIgnoresEchoedInfoRecords(t *testing.T) {
 				t.Errorf("echoed INFO record must not set terminal failure, got %d bytes: %q", len(msg), firstNRunes(msg, 100))
 			}
 
-			status, errStr := promoteACPResultOnProviderError("completed", "", "Done. The requested work completed successfully.", s)
+			// Simulate the observed pollution timing: a successful final
+			// reply already exists, then promotion consults the sniffer.
+			successfulFinalReply := "Done. The requested work completed successfully."
+			status, errStr := promoteACPResultOnProviderError("completed", "", successfulFinalReply, s)
 			if status != "completed" {
-				t.Errorf("completed run flipped to %q (error=%q); regression of multica#5862", status, firstNRunes(errStr, 100))
+				t.Errorf("pollution: successful final reply was present, but status flipped to %q (error=%q)", status, firstNRunes(errStr, 100))
 			}
 		})
 	}
 }
 
+// TestHermesProviderErrorSnifferStillCapturesErrorRootRecords is the
+// control for real failures: genuine `[ERROR] root:` provider records
+// must still be terminal. Pollution handling must not swallow those.
 func TestHermesProviderErrorSnifferStillCapturesErrorRootRecords(t *testing.T) {
 	t.Parallel()
 
@@ -1642,7 +1655,7 @@ func TestHermesProviderErrorSnifferStillCapturesErrorRootRecords(t *testing.T) {
 
 	msg := s.terminalMessage()
 	if !strings.Contains(msg, "HTTP 429") {
-		t.Fatalf("expected genuine ERROR root record to remain terminal, got %q", msg)
+		t.Fatalf("real error: expected genuine ERROR root record to remain terminal, got %q", msg)
 	}
 }
 

--- a/server/pkg/agent/hermes_test.go
+++ b/server/pkg/agent/hermes_test.go
@@ -1659,6 +1659,96 @@ func TestHermesProviderErrorSnifferStillCapturesErrorRootRecords(t *testing.T) {
 	}
 }
 
+// TestHermesProviderErrorSnifferIgnoresMultiLineInfoRecords guards the
+// second pollution shape from GitHub multica#5862. Hermes echoes a
+// conversation/tool record whose JSON spans several physical lines: only
+// the first line carries the `[INFO] root:` prefix, the continuation lines
+// do not, yet they may embed both a capture token (`Error:`) and a terminal
+// token (`❌`) on the same physical line. The whole record must be skipped,
+// so a completed run with a successful final reply stays completed.
+func TestHermesProviderErrorSnifferIgnoresMultiLineInfoRecords(t *testing.T) {
+	t.Parallel()
+
+	record := "2026-07-24 10:09:00 [INFO] root: {\n" +
+		"  \"message\": {\"role\": \"tool\", \"content\": \"❌ Error: KeyError 'series' is quoted documentation, not a provider failure\"}\n" +
+		"}\n"
+
+	s := newACPProviderErrorSniffer("hermes")
+	if _, err := s.Write([]byte(record)); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+	if msg := s.message(); msg != "" {
+		t.Errorf("multi-line INFO echo must not be captured, got %q", firstNRunes(msg, 120))
+	}
+	if msg := s.terminalMessage(); msg != "" {
+		t.Errorf("multi-line INFO echo must not be terminal, got %q", firstNRunes(msg, 120))
+	}
+	status, errStr := promoteACPResultOnProviderError("completed", "", "Done. The requested work completed successfully.", s)
+	if status != "completed" {
+		t.Errorf("multi-line INFO echo flipped a completed run to %q (error=%q)", status, firstNRunes(errStr, 120))
+	}
+}
+
+// TestHermesProviderErrorSnifferErrorRecordAfterInfoRecord is the control
+// for the multi-line skip: a genuine `[ERROR] root:` record that FOLLOWS a
+// multi-line INFO echo must still be terminal. The error record's own
+// prefix ends the skipped INFO record, so real failures are not swallowed.
+func TestHermesProviderErrorSnifferErrorRecordAfterInfoRecord(t *testing.T) {
+	t.Parallel()
+
+	stream := "2026-07-24 10:09:00 [INFO] root: {\n" +
+		"  \"content\": \"❌ Error: harmless echoed documentation\"\n" +
+		"}\n" +
+		"2026-07-24 10:09:05 [ERROR] root: ❌ API call failed after 3 retries: HTTP 429 rate limit exceeded\n"
+
+	s := newACPProviderErrorSniffer("hermes")
+	if _, err := s.Write([]byte(stream)); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+	msg := s.terminalMessage()
+	if !strings.Contains(msg, "HTTP 429") {
+		t.Fatalf("real ERROR record after an INFO echo must stay terminal, got %q", msg)
+	}
+}
+
+// TestHermesProviderErrorSnifferLongRealErrorStillFails guards the #1952
+// regression: a genuine provider failure emitted as one long line (well
+// over acpMaxErrorLineLen) with no successful output must still fail the
+// run. Length must never decide whether a line is an error. The shared
+// sniffer backs hermes/kimi/kiro/qoder/grok/traecli, so verify the
+// non-Hermes callers too, and confirm the persisted message stays bounded.
+func TestHermesProviderErrorSnifferLongRealErrorStillFails(t *testing.T) {
+	t.Parallel()
+
+	longReal := "❌ API call failed after 3 retries: BadRequestError [HTTP 400] " +
+		"Error: HTTP 400: Error code: 400 - {'detail': \"" +
+		strings.Repeat("the requested model is not supported for this account; ", 200) +
+		"\"}"
+	if len(longReal) <= acpMaxErrorLineLen {
+		t.Fatalf("fixture is %d bytes, must exceed the cap %d to exercise the path", len(longReal), acpMaxErrorLineLen)
+	}
+
+	for _, provider := range []string{"hermes", "kimi", "kiro", "qoder", "grok", "traecli"} {
+		t.Run(provider, func(t *testing.T) {
+			s := newACPProviderErrorSniffer(provider)
+			if _, err := s.Write([]byte(longReal + "\n")); err != nil {
+				t.Fatalf("Write: %v", err)
+			}
+			// Empty output: no successful reply to fall back on (#1952).
+			status, errStr := promoteACPResultOnProviderError("completed", "", "", s)
+			if status != "failed" {
+				t.Fatalf("long real provider error was dropped; run stayed %q instead of failed", status)
+			}
+			if errStr == "" {
+				t.Fatal("failed run must carry a non-empty provider-error message")
+			}
+			if len(errStr) > acpMaxErrorLineLen+len("…(truncated)") {
+				t.Errorf("persisted error not bounded: %d bytes", len(errStr))
+			}
+		})
+	}
+}
+
 // firstNRunes returns at most n runes of s, for bounded error output.
 func firstNRunes(s string, n int) string {
 	r := []rune(s)


### PR DESCRIPTION
## What does this PR do?

Stops Multica from treating Hermes `[INFO] root:` conversation/tool echoes as provider failures.

Fixes #5862

## Real error vs pollution error

This PR is specifically about **pollution errors**, not real Hermes/provider crashes.

| Class | Meaning | Expected status | Observed before fix |
|---|---|---|---|
| **Real error** | Hermes/provider truly fails (rate limit, auth, AF_UNIX, timeout). No successful final reply. | `failed` | Correctly `failed` |
| **Pollution error** | Hermes already finished and emitted a correct final reply / side effect; Multica then suddenly flips the same run to `failed` because non-error stderr data matched error-looking tokens. | `completed` | Incorrectly `failed` |

Pollution is characterized by timing:

1. `run-messages` already contains a successful final reply.
2. the task then suddenly gets `status=failed`.
3. the stored `error` is truncated conversation / tool / INFO JSON, not a short provider message.

## Production evidence

- Real failures are short and self-contained (`41–95` bytes), e.g. `AF_UNIX path too long`, `HTTP 400: ...`, `HTTP 429: ...`, `Request timed out.`
- Pollution failures are larger (`265–87,286` bytes), contain conversation fingerprints (`finish_reason`, `session_id`, `tool_call_id`, `[INFO] root:`), and often start mid-JSON.
- Sampled polluted runs had already completed their requested work and only failed at final status promotion.
- The same pollution shape appears on at least two Hermes agents.
- A length-only guard is insufficient: shortest polluted sample observed was `265` bytes.

## Root cause

Hermes writes conversation/tool JSON to stderr as:

```text
YYYY-MM-DD HH:MM:SS [INFO] root: {...}
```

Those INFO records are data. Their payload may contain `Error:`, `KeyError:`, `❌`, `HTTP 429`, or `API call failed`. Because one JSON record is one physical line, unrelated payload fragments can satisfy both the sniffer capture filter and terminal condition. After #2323 removed the empty-output precondition, that false terminal match overrides a valid completed turn.

## Changes

- Ignore Hermes `[INFO] root:` records before provider-error matching.
- Keep `acpMaxErrorLineLen` as defense in depth for oversized echoes with an unexpected prefix.
- Keep genuine `[ERROR] root:` / short provider-error behavior.
- Add English-only regression cases covering four pollution shapes, plus a control case for real `[ERROR] root:` records.

## How to test

```bash
cd server
go test ./pkg/agent/ -run 'TestHermesProviderErrorSniffer(IgnoresEchoedInfoRecords|StillCapturesErrorRootRecords)' -v
go test ./pkg/agent/ -run TestHermesProviderErrorSniffer
go test ./pkg/agent/
go vet ./pkg/agent/
```

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
