### PR TITLE
feat(chat): warn when agent daemon is too old for project context MUL-5150

### DIFF
--- a/packages/core/runtimes/cli-version.test.ts
+++ b/packages/core/runtimes/cli-version.test.ts
@@ -1,8 +1,10 @@
 import { describe, it, expect } from "vitest";
 import {
+  chatProjectContextSupported,
   checkQuickCreateCliVersion,
   checkQuickCreateFieldsCliVersion,
   handoffSupported,
+  MIN_CHAT_PROJECT_CONTEXT_CLI_VERSION,
   MIN_HANDOFF_CLI_VERSION,
 } from "./cli-version";
 
@@ -62,5 +64,30 @@ describe("handoffSupported", () => {
   it("treats git-describe dev builds as supported regardless of base tag", () => {
     expect(handoffSupported("v0.3.0-5-gabc1234")).toBe(true);
     expect(handoffSupported("v0.1.0-235-gdaf0e935-dirty")).toBe(true);
+  });
+});
+
+describe("chatProjectContextSupported", () => {
+  it("supports a tagged release at or above the minimum", () => {
+    expect(chatProjectContextSupported(MIN_CHAT_PROJECT_CONTEXT_CLI_VERSION)).toBe(true);
+    expect(chatProjectContextSupported("v0.4.10")).toBe(true);
+    expect(chatProjectContextSupported("0.5.0")).toBe(true);
+  });
+
+  it("does not support a tagged release below the minimum", () => {
+    expect(chatProjectContextSupported("0.4.9")).toBe(false);
+    expect(chatProjectContextSupported("0.3.28")).toBe(false);
+  });
+
+  it("fails closed on empty or unparsable input", () => {
+    expect(chatProjectContextSupported("")).toBe(false);
+    expect(chatProjectContextSupported(undefined)).toBe(false);
+    expect(chatProjectContextSupported(null)).toBe(false);
+    expect(chatProjectContextSupported("garbage")).toBe(false);
+  });
+
+  it("treats git-describe dev builds as supported regardless of base tag", () => {
+    expect(chatProjectContextSupported("v0.4.8-37-g5d0275d68")).toBe(true);
+    expect(chatProjectContextSupported("v0.1.0-235-gdaf0e935-dirty")).toBe(true);
   });
 });

--- a/packages/core/runtimes/cli-version.ts
+++ b/packages/core/runtimes/cli-version.ts
@@ -110,10 +110,37 @@ export const MIN_HANDOFF_CLI_VERSION = "0.3.28";
  * round-trip, exactly like the quick-create version gate.
  */
 export function handoffSupported(detected: string | undefined | null): boolean {
+  return meetsMinCliVersion(detected, MIN_HANDOFF_CLI_VERSION);
+}
+
+/**
+ * First release whose daemon renders the chat session's project context
+ * (description + resources) into the run brief (PR #5765, ships in v0.4.10).
+ * Older daemons still receive and honor the project's repos — the server
+ * pre-extracts those into the generic `repos` claim field — but silently skip
+ * the Project Context section, so the durable description never reaches the
+ * agent. SOFT gate: selecting a project always works; the UI only warns.
+ *
+ * Frontend-only constant: unlike handoff there is no server preview endpoint
+ * computing this, so there is no server twin to keep in lockstep with.
+ */
+export const MIN_CHAT_PROJECT_CONTEXT_CLI_VERSION = "0.4.10";
+
+/**
+ * Whether a daemon-reported CLI version is new enough to inject a chat
+ * session's project description into the run brief. Same degrade rules as
+ * `handoffSupported`: missing / unparsable / below-minimum are `false`,
+ * dev-built daemons (git-describe shape) always pass.
+ */
+export function chatProjectContextSupported(detected: string | undefined | null): boolean {
+  return meetsMinCliVersion(detected, MIN_CHAT_PROJECT_CONTEXT_CLI_VERSION);
+}
+
+function meetsMinCliVersion(detected: string | undefined | null, minimum: string): boolean {
   const current = (detected ?? "").trim();
   if (!current) return false;
   if (DEV_DESCRIBE_RE.test(current)) return true;
   const parsed = parseSemver(current);
   if (!parsed) return false;
-  return !lessThan(parsed, parseSemver(MIN_HANDOFF_CLI_VERSION)!);
+  return !lessThan(parsed, parseSemver(minimum)!);
 }

--- a/packages/views/chat/chat-page.tsx
+++ b/packages/views/chat/chat-page.tsx
@@ -270,6 +270,7 @@ export function ChatPage() {
         agentName={c.activeAgent?.name}
         projects={c.projects}
         projectId={c.activeProjectId}
+        projectContextUnsupported={c.projectContextUnsupported}
         onProjectChange={changeProjectContext}
         isProjectUpdating={c.isProjectUpdating}
         focusRequest={c.focusInputRequest}

--- a/packages/views/chat/components/chat-add-menu.tsx
+++ b/packages/views/chat/components/chat-add-menu.tsx
@@ -24,6 +24,10 @@ interface ChatAddMenuProps {
   projects?: Project[];
   projectId?: string | null;
   onSelectProject?: (projectId: string | null) => void;
+  /** Soft warning: the active agent's daemon is too old to receive the
+   *  project description. Selection stays enabled; the submenu only appends
+   *  an explanatory hint so the user knows before choosing. */
+  projectContextUnsupported?: boolean;
   disabled?: boolean;
 }
 
@@ -38,6 +42,7 @@ export function ChatAddMenu({
   projects = [],
   projectId,
   onSelectProject,
+  projectContextUnsupported,
   disabled,
 }: ChatAddMenuProps) {
   const { t } = useT("chat");
@@ -103,6 +108,14 @@ export function ChatAddMenu({
                     <X />
                     {t(($) => $.input.remove_project_context)}
                   </DropdownMenuItem>
+                )}
+                {projectContextUnsupported && (
+                  <>
+                    <DropdownMenuSeparator />
+                    <div className="max-w-56 px-2 py-1.5 text-xs text-muted-foreground">
+                      {t(($) => $.input.project_context_unsupported)}
+                    </div>
+                  </>
                 )}
               </DropdownMenuSubContent>
             </DropdownMenuSub>

--- a/packages/views/chat/components/chat-input.test.tsx
+++ b/packages/views/chat/components/chat-input.test.tsx
@@ -422,6 +422,39 @@ describe("ChatInput project context", () => {
     resource_count: 0,
   };
 
+  it("warns next to the chip when the agent's daemon cannot apply the project description", () => {
+    renderInput({
+      projects: [sampleProject],
+      projectId: "project-alpha",
+      onProjectChange: vi.fn(),
+      projectContextUnsupported: true,
+    });
+
+    expect(
+      screen.getByText(
+        "Project description won't apply — this agent's daemon needs an upgrade",
+      ),
+    ).toBeInTheDocument();
+    // Soft gate: the warning must not lock the control.
+    expect(
+      screen.getByRole("button", { name: "Change project context" }),
+    ).not.toBeDisabled();
+  });
+
+  it("shows no daemon warning when support is current or unknown", () => {
+    renderInput({
+      projects: [sampleProject],
+      projectId: "project-alpha",
+      onProjectChange: vi.fn(),
+    });
+
+    expect(
+      screen.queryByText(
+        "Project description won't apply — this agent's daemon needs an upgrade",
+      ),
+    ).not.toBeInTheDocument();
+  });
+
   it("renders the selected project chip and forwards context changes", () => {
     const onProjectChange = vi.fn();
     renderInput({

--- a/packages/views/chat/components/chat-input.tsx
+++ b/packages/views/chat/components/chat-input.tsx
@@ -2,6 +2,7 @@
 
 import type { ReactNode } from "react";
 import { useCallback, useEffect, useLayoutEffect, useRef, useState } from "react";
+import { TriangleAlert } from "lucide-react";
 import { cn } from "@multica/ui/lib/utils";
 import {
   ContentEditor,
@@ -101,6 +102,11 @@ interface ChatInputProps {
   projectId?: string | null;
   onProjectChange?: (projectId: string | null) => void;
   isProjectUpdating?: boolean;
+  /** True when the active agent's daemon is too old to inject the project
+   *  description into the run brief. Soft signal: selection stays enabled,
+   *  the composer only surfaces a warning next to the chip and in the
+   *  project submenu. */
+  projectContextUnsupported?: boolean;
   /** Monotonic nonce bumped by the owner whenever the compose box should grab
    *  keyboard focus — currently on "new chat" so the user can type right away.
    *  0 (the initial value) is inert, so a plain deep-link open never steals
@@ -132,6 +138,7 @@ export function ChatInput({
   projectId,
   onProjectChange,
   isProjectUpdating,
+  projectContextUnsupported,
   focusRequest,
   draftKeyOverride,
   editorKeyOverride,
@@ -548,7 +555,7 @@ export function ChatInput({
         aria-disabled={noAgent || undefined}
       >
         {selectedProject && (
-          <div className="px-3 pt-2">
+          <div className="flex flex-wrap items-center gap-x-2 gap-y-1 px-3 pt-2">
             <div
               className={cn(
                 "inline-flex max-w-full",
@@ -570,6 +577,12 @@ export function ChatInput({
                 }
               />
             </div>
+            {projectContextUnsupported && (
+              <span className="inline-flex min-w-0 items-center gap-1 text-xs text-warning">
+                <TriangleAlert className="size-3 shrink-0" />
+                {t(($) => $.input.project_context_unsupported)}
+              </span>
+            )}
           </div>
         )}
         <div className="flex-1 min-h-0 overflow-y-auto px-3 py-2">
@@ -614,6 +627,7 @@ export function ChatInput({
                 projects={projects}
                 projectId={projectId}
                 onSelectProject={projectSelectionEnabled ? onProjectChange : undefined}
+                projectContextUnsupported={projectContextUnsupported}
               />
             )}
             {leftAdornment}

--- a/packages/views/chat/components/chat-window.tsx
+++ b/packages/views/chat/components/chat-window.tsx
@@ -61,6 +61,7 @@ import {
   isStillOnComposeTarget,
   planProjectContextChange,
 } from "./use-chat-controller";
+import { useChatProjectContextSupport } from "./use-chat-project-context-support";
 import { createLogger } from "@multica/core/logger";
 import type { Agent, Attachment, ChatMessage, ChatMessagesPage, ChatPendingTask, ChatSession, PendingChatTasksResponse } from "@multica/core/types";
 import { useT } from "../../i18n";
@@ -267,6 +268,8 @@ export function ChatWindow() {
     availableAgents.find((a) => a.id === selectedAgentId) ??
     availableAgents[0] ??
     null;
+
+  const projectContextSupport = useChatProjectContextSupport(wsId, activeAgent);
 
   // Three-state availability — "loading" stays neutral (no banner, no
   // disable) so the input doesn't flash a fake "no agent" state in the
@@ -938,6 +941,7 @@ export function ChatWindow() {
         projects={projects}
         projectId={activeProjectId}
         onProjectChange={handleProjectChange}
+        projectContextUnsupported={projectContextSupport === false}
         isProjectUpdating={
           setSessionProject.isPending || (!!activeSessionId && !currentSession)
         }

--- a/packages/views/chat/components/use-chat-controller.ts
+++ b/packages/views/chat/components/use-chat-controller.ts
@@ -35,6 +35,7 @@ import {
 import { useChatStore } from "@multica/core/chat";
 import { removeChatMessageFromCaches } from "@multica/core/realtime";
 import { useChatDraftRestore } from "./use-chat-draft-restore";
+import { useChatProjectContextSupport } from "./use-chat-project-context-support";
 import { createLogger } from "@multica/core/logger";
 import type {
   Agent,
@@ -368,6 +369,8 @@ export function useChatController(opts?: { isActive?: boolean }) {
 
   const agentAvailability = useWorkspaceAgentAvailability();
   const noAgent = agentAvailability === "none";
+
+  const projectContextSupport = useChatProjectContextSupport(wsId, activeAgent);
 
   const presenceDetail = useAgentPresenceDetail(wsId, activeAgent?.id);
   const availability =
@@ -842,6 +845,7 @@ export function useChatController(opts?: { isActive?: boolean }) {
     activeSessionId,
     selectedAgentId,
     activeProjectId,
+    projectContextUnsupported: projectContextSupport === false,
     isProjectUpdating:
       setSessionProject.isPending || (!!activeSessionId && !currentSession),
     currentSession,

--- a/packages/views/chat/components/use-chat-project-context-support.test.tsx
+++ b/packages/views/chat/components/use-chat-project-context-support.test.tsx
@@ -1,0 +1,77 @@
+import type { ReactNode } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { renderHook, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { api } from "@multica/core/api";
+import { useChatProjectContextSupport } from "./use-chat-project-context-support";
+
+vi.mock("@multica/core/api", () => ({
+  api: {
+    listRuntimes: vi.fn().mockResolvedValue([]),
+  },
+}));
+
+const WS_ID = "ws-1";
+
+function runtimeRow(cliVersion: string | undefined) {
+  return {
+    id: "runtime-1",
+    workspace_id: WS_ID,
+    provider: "claude",
+    metadata: cliVersion === undefined ? {} : { cli_version: cliVersion },
+  };
+}
+
+function renderSupport(agent: { runtime_id?: string | null } | null) {
+  const qc = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  const wrapper = ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={qc}>{children}</QueryClientProvider>
+  );
+  return renderHook(() => useChatProjectContextSupport(WS_ID, agent), { wrapper });
+}
+
+describe("useChatProjectContextSupport", () => {
+  beforeEach(() => {
+    vi.mocked(api.listRuntimes).mockReset().mockResolvedValue([]);
+  });
+
+  it("returns false when the bound runtime reports a stale release version", async () => {
+    vi.mocked(api.listRuntimes).mockResolvedValue([runtimeRow("v0.4.9")] as never);
+
+    const { result } = renderSupport({ runtime_id: "runtime-1" });
+
+    await waitFor(() => expect(result.current).toBe(false));
+  });
+
+  it("returns true for a new-enough release and for dev-describe builds", async () => {
+    vi.mocked(api.listRuntimes).mockResolvedValue([
+      runtimeRow("v0.4.10-3-gabc1234"),
+    ] as never);
+
+    const { result } = renderSupport({ runtime_id: "runtime-1" });
+
+    await waitFor(() => expect(result.current).toBe(true));
+  });
+
+  it("returns null (no warning) when the agent, runtime binding, or runtime row is unknown", async () => {
+    vi.mocked(api.listRuntimes).mockResolvedValue([runtimeRow("v0.4.9")] as never);
+
+    expect(renderSupport(null).result.current).toBeNull();
+    expect(renderSupport({ runtime_id: null }).result.current).toBeNull();
+
+    const { result } = renderSupport({ runtime_id: "runtime-other" });
+    // The list resolves but never contains this runtime — stays "cannot tell".
+    await waitFor(() => expect(vi.mocked(api.listRuntimes)).toHaveBeenCalled());
+    expect(result.current).toBeNull();
+  });
+
+  it("fails closed to false when the runtime row reports no cli_version", async () => {
+    vi.mocked(api.listRuntimes).mockResolvedValue([runtimeRow(undefined)] as never);
+
+    const { result } = renderSupport({ runtime_id: "runtime-1" });
+
+    await waitFor(() => expect(result.current).toBe(false));
+  });
+});

--- a/packages/views/chat/components/use-chat-project-context-support.ts
+++ b/packages/views/chat/components/use-chat-project-context-support.ts
@@ -1,0 +1,30 @@
+"use client";
+
+import { useQuery } from "@tanstack/react-query";
+import {
+  runtimeListOptions,
+  readRuntimeCliVersion,
+  chatProjectContextSupported,
+} from "@multica/core/runtimes";
+
+/**
+ * Whether the active agent's daemon is new enough to inject a chat session's
+ * project description into the run brief. `null` means "cannot tell" (no
+ * agent, no bound runtime, or the runtime row not in cache yet) and must NOT
+ * warn: this is a soft gate, and a spurious warning is worse than a
+ * description an old daemon drops — same policy as the handoff note gate in
+ * run-confirm.
+ *
+ * Shared by both send chains (chat tab controller and floating ChatWindow) so
+ * the resolution rule cannot drift between the two surfaces.
+ */
+export function useChatProjectContextSupport(
+  wsId: string,
+  agent: { runtime_id?: string | null } | null | undefined,
+): boolean | null {
+  const { data: runtimes = [] } = useQuery({ ...runtimeListOptions(wsId), enabled: !!wsId });
+  if (!agent?.runtime_id) return null;
+  const runtime = runtimes.find((r) => r.id === agent.runtime_id);
+  if (!runtime) return null;
+  return chatProjectContextSupported(readRuntimeCliVersion(runtime.metadata));
+}

--- a/packages/views/locales/en/chat.json
+++ b/packages/views/locales/en/chat.json
@@ -26,7 +26,8 @@
     "project_context": "Project context",
     "change_project_context": "Change project context",
     "remove_project_context": "Remove project context",
-    "no_projects": "No projects yet"
+    "no_projects": "No projects yet",
+    "project_context_unsupported": "Project description won't apply — this agent's daemon needs an upgrade"
   },
   "message_list": {
     "show_details": "Show details",

--- a/packages/views/locales/ja/chat.json
+++ b/packages/views/locales/ja/chat.json
@@ -25,7 +25,8 @@
     "project_context": "プロジェクトコンテキスト",
     "change_project_context": "プロジェクトコンテキストを変更",
     "remove_project_context": "プロジェクトコンテキストを削除",
-    "no_projects": "プロジェクトがまだありません"
+    "no_projects": "プロジェクトがまだありません",
+    "project_context_unsupported": "プロジェクトの説明は適用されません——このエージェントのデーモンのアップグレードが必要です"
   },
   "message_list": {
     "show_details": "詳細を表示",

--- a/packages/views/locales/ko/chat.json
+++ b/packages/views/locales/ko/chat.json
@@ -25,7 +25,8 @@
     "project_context": "프로젝트 컨텍스트",
     "change_project_context": "프로젝트 컨텍스트 변경",
     "remove_project_context": "프로젝트 컨텍스트 제거",
-    "no_projects": "아직 프로젝트가 없습니다"
+    "no_projects": "아직 프로젝트가 없습니다",
+    "project_context_unsupported": "프로젝트 설명이 적용되지 않습니다 — 이 에이전트의 데몬 업그레이드가 필요합니다"
   },
   "message_list": {
     "show_details": "세부 정보 보기",

--- a/packages/views/locales/zh-Hans/chat.json
+++ b/packages/views/locales/zh-Hans/chat.json
@@ -25,7 +25,8 @@
     "project_context": "项目上下文",
     "change_project_context": "更改项目上下文",
     "remove_project_context": "移除项目上下文",
-    "no_projects": "还没有项目"
+    "no_projects": "还没有项目",
+    "project_context_unsupported": "项目描述不会生效——该智能体的守护进程版本过旧，需要升级"
   },
   "message_list": {
     "show_details": "查看详情",


### PR DESCRIPTION
## Summary

Follow-up to #5765 (MUL-5150). Chat project context is rendered into the run brief by the **daemon**, so users on a daemon older than the release that ships #5765 get a silent partial failure: the project's repos still apply (the server pre-extracts them into the generic `repos` claim field), but the project description never reaches the agent — and nothing in the UI says so.

This adds a version soft gate mirroring the existing handoff-note gate:

- `MIN_CHAT_PROJECT_CONTEXT_CLI_VERSION = "0.4.10"` + `chatProjectContextSupported()` in `packages/core/runtimes/cli-version.ts` (third boolean gate, so the shared comparison is now one private `meetsMinCliVersion` helper that `handoffSupported` also delegates to).
- `useChatProjectContextSupport(wsId, agent)` — shared hook resolving active agent → bound runtime → `metadata.cli_version` from the warm runtime cache, used by both send chains (chat tab controller and floating ChatWindow). `null` = cannot tell = no warning, same policy as run-confirm.
- ChatInput: a `text-warning` notice next to the selected-project chip; ChatAddMenu: a muted hint at the bottom of the project submenu, visible before choosing.
- Selection is never blocked (soft gate): repos still work on old daemons, and the server does not gate either. Dev-describe builds (`vX.Y.Z-N-ghash`) always pass, keeping local/staging silent.
- Copy in en / zh-Hans / ja / ko.

## Version constant

#5765 merged after the v0.4.9 tag, so it ships in **v0.4.10** — the constant assumes that. If a different tag ends up carrying #5765, bump the constant in this PR before merge.

## Validation

- `pnpm --filter @multica/core exec vitest run runtimes/cli-version.test.ts` — 13 passed
- `pnpm --filter @multica/views exec vitest run chat/components/use-chat-project-context-support.test.tsx chat/components/chat-input.test.tsx` — 35 passed
- `pnpm --filter @multica/core typecheck` / `pnpm --filter @multica/views typecheck` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)