### PR TITLE
fix(daemon): cache agent --version per provider across workspace registrations

### DIFF
--- a/server/internal/daemon/daemon.go
+++ b/server/internal/daemon/daemon.go
@@ -1221,11 +1221,11 @@ const runtimeVersionProbeConcurrency = 8
 // instead of their sum, so a freshly-created workspace lights up its runtimes
 // well inside the UI's scanning window.
 //
-// Each probe still self-heals a vanished pinned path (MUL-4486) and re-detects
-// the live version — no result is cached across registrations, so an in-place
-// CLI upgrade is still reported with its current version. A probe that fails to
-// detect a version or is below the minimum supported version is logged and
-// skipped, exactly as the serial loop did.
+// Each probe still self-heals a vanished pinned path (MUL-4486). Versions
+// detected during an earlier registration (e.g., workspace 1 of N during
+// startup) are reused by later registrations so the daemon spawns at most M
+// --version subprocesses instead of N×M (#5837). A probe that fails to detect
+// a version or is below the minimum supported version is logged and skipped.
 func (d *Daemon) detectBuiltinRuntimes(ctx context.Context) []map[string]string {
 	type detected struct {
 		name    string
@@ -1243,10 +1243,21 @@ func (d *Daemon) detectBuiltinRuntimes(ctx context.Context) []map[string]string 
 			// Self-heal a pinned executable path an in-place upgrade deleted
 			// (MUL-4486) so version detection — and thus staying
 			// registered/online — recovers without a daemon restart.
-			// resolveAgentEntry already version-gates the healed binary; the
-			// detect + min-version check below still runs to produce the
-			// version string this registration reports.
-			entry, _ = d.resolveAgentEntry(ctx, name, entry)
+			entry, resolvedVersion := d.resolveAgentEntry(ctx, name, entry)
+			// Reuse a version that was already probed and min-version-checked
+			// for this provider earlier in the same daemon run (e.g., by a
+			// prior workspace's registration during startup). setAgentVersion
+			// is only called after the binary passes both detectAgentVersion
+			// and checkAgentMinVersion, so a non-empty cached value is safe to
+			// skip re-probing. This reduces N-workspace × M-agent startup
+			// overhead from N×M --version spawns to at most M (fixes #5837).
+			if resolvedVersion != "" {
+				d.logger.Debug("agent version from cache", "name", name, "version", resolvedVersion, "path", entry.Path)
+				mu.Lock()
+				results = append(results, detected{name: name, version: resolvedVersion})
+				mu.Unlock()
+				return nil
+			}
 			version, err := detectAgentVersion(ctx, entry.Path)
 			if err != nil {
 				d.logger.Warn("skip registering runtime", "name", name, "error", err)


### PR DESCRIPTION
## Problem

During daemon startup, `registerRuntimesForWorkspace` is called once per workspace. Each call invokes `detectBuiltinRuntimes`, which spawns `<cli> --version` for every configured built-in agent regardless of whether that provider was already probed by a prior workspace's registration.

With N workspaces and M built-in agents this produces N×M version-probe subprocesses at startup (e.g. 24 workspaces × 5 agents = ~120 invocations; only ~5 are necessary). On macOS hosts with Antigravity (`agy`) installed the repeated Electron-in-Node-mode launches caused visible Dock churn on every daemon startup.

Fixes #5837.

## Root cause

`detectBuiltinRuntimes` discards the version returned by `resolveAgentEntry` and always calls `detectAgentVersion` unconditionally. `resolveAgentEntry` returns `d.agentVersion(provider)` (the cached version from a prior registration) but that value was thrown away with `_`.

## Fix

Use the version returned by `resolveAgentEntry` when non-empty. `setAgentVersion` is only called after both `detectAgentVersion` and `checkAgentMinVersion` succeed, so the cached value is safe to reuse without re-probing. Result: at most M `--version` probes per daemon run regardless of workspace count.

## Test plan

- [x] `go test ./internal/daemon/` passes
- [ ] On a multi-workspace host, daemon startup log shows each agent version detected once, not once-per-workspace