### PR TITLE
fix(search): stop Home/End propagation in command palette inputs

### DIFF
--- a/packages/ui/components/ui/command.tsx
+++ b/packages/ui/components/ui/command.tsx
@@ -68,6 +68,7 @@ function CommandDialog({
 
 function CommandInput({
   className,
+  onKeyDown,
   ...props
 }: React.ComponentProps<typeof CommandPrimitive.Input>) {
   return (
@@ -79,6 +80,14 @@ function CommandInput({
             "w-full text-sm outline-hidden disabled:cursor-not-allowed disabled:opacity-50",
             className
           )}
+          onKeyDown={(e) => {
+            // cmdk's root handler intercepts Home/End for list navigation;
+            // stop propagation so the browser moves the text caret instead.
+            if (e.key === "Home" || e.key === "End") {
+              e.stopPropagation();
+            }
+            onKeyDown?.(e);
+          }}
           {...props}
         />
         <InputGroupAddon>

--- a/packages/views/search/command-input.test.tsx
+++ b/packages/views/search/command-input.test.tsx
@@ -1,0 +1,54 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+import { Command, CommandInput } from "@multica/ui/components/ui/command";
+
+// Contract for the shared CommandInput: Home/End must stop propagating to
+// cmdk's root keydown handler (which otherwise hijacks them to jump the result
+// list to first/last), while every key — including Home/End — is still handed
+// to a caller-provided onKeyDown. cmdk lives in @multica/ui, which has no test
+// runner, so the contract is pinned here alongside the SearchCommand
+// regression that depends on it.
+describe("CommandInput", () => {
+  const renderInput = () => {
+    // An ancestor listener outside <Command> is the propagation probe: it only
+    // fires if the keydown bubbled past the input (i.e. past cmdk's root).
+    const ancestorKeyDown = vi.fn();
+    const callerKeyDown = vi.fn();
+    render(
+      <div onKeyDown={ancestorKeyDown}>
+        <Command>
+          <CommandInput placeholder="search" onKeyDown={callerKeyDown} />
+        </Command>
+      </div>,
+    );
+    return { ancestorKeyDown, callerKeyDown };
+  };
+
+  it.each(["{Home}", "{End}"])(
+    "stops %s from bubbling past the input while still calling the caller onKeyDown",
+    async (key) => {
+      const user = userEvent.setup();
+      const { ancestorKeyDown, callerKeyDown } = renderInput();
+
+      await user.click(screen.getByPlaceholderText("search"));
+      await user.keyboard(key);
+
+      expect(callerKeyDown).toHaveBeenCalledTimes(1);
+      expect(ancestorKeyDown).not.toHaveBeenCalled();
+    },
+  );
+
+  it("lets other keys bubble so cmdk list navigation keeps working", async () => {
+    const user = userEvent.setup();
+    const { ancestorKeyDown, callerKeyDown } = renderInput();
+
+    await user.click(screen.getByPlaceholderText("search"));
+    await user.keyboard("{ArrowDown}");
+
+    // Not Home/End, so the interception must not apply: the event reaches the
+    // ancestor (and thus cmdk's root), and the caller callback still runs.
+    expect(callerKeyDown).toHaveBeenCalledTimes(1);
+    expect(ancestorKeyDown).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/views/search/search-command.test.tsx
+++ b/packages/views/search/search-command.test.tsx
@@ -783,4 +783,51 @@ describe("SearchCommand", () => {
       ),
     ).toBeInTheDocument();
   });
+
+  it("lets Home/End edit the query caret instead of hijacking result navigation", async () => {
+    const user = userEvent.setup();
+    renderSearch();
+
+    const input = screen.getByPlaceholderText(
+      "Type a command or search...",
+    ) as HTMLInputElement;
+    await user.type(input, "new");
+
+    // "new" surfaces New Issue + New Project, so cmdk has a multi-item list.
+    await waitFor(() => {
+      expect(
+        screen.getByText((_, el) => el?.textContent === "New Issue" && el?.tagName === "SPAN"),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByText((_, el) => el?.textContent === "New Project" && el?.tagName === "SPAN"),
+      ).toBeInTheDocument();
+    });
+
+    const selectedValue = () =>
+      document
+        .querySelector('[cmdk-item=""][aria-selected="true"]')
+        ?.getAttribute("data-value") ?? null;
+
+    // cmdk auto-selects the first item; Arrow keys must still move that selection.
+    const first = selectedValue();
+    expect(first).not.toBeNull();
+
+    await user.keyboard("{ArrowDown}");
+    expect(selectedValue()).not.toBe(first);
+
+    await user.keyboard("{ArrowUp}");
+    expect(selectedValue()).toBe(first);
+
+    // Home moves the text caret to the start — it must NOT jump the result list.
+    await user.keyboard("{Home}");
+    expect(input.selectionStart).toBe(0);
+    expect(input.selectionEnd).toBe(0);
+    expect(selectedValue()).toBe(first);
+
+    // End moves the caret to the end — again leaving the result selection alone.
+    await user.keyboard("{End}");
+    expect(input.selectionStart).toBe(input.value.length);
+    expect(input.selectionEnd).toBe(input.value.length);
+    expect(selectedValue()).toBe(first);
+  });
 });

--- a/packages/views/search/search-command.tsx
+++ b/packages/views/search/search-command.tsx
@@ -513,6 +513,13 @@ export function SearchCommand() {
               placeholder={t(($) => $.placeholder)}
               value={query}
               onValueChange={handleValueChange}
+              onKeyDown={(e) => {
+                // cmdk's root handler intercepts Home/End for list navigation;
+                // stop propagation so the browser moves the text caret instead.
+                if (e.key === "Home" || e.key === "End") {
+                  e.stopPropagation();
+                }
+              }}
               className="flex-1 bg-transparent text-sm outline-none placeholder:text-muted-foreground"
             />
             <ShortcutKeycaps


### PR DESCRIPTION
## Problem

On Windows (and any platform) pressing **Home** or **End** in the Ctrl+K search palette does not move the text caret to the start/end of the query string. Instead the keys jump the selection to the first/last result in the list.

Fixes #5655.

## Root cause

The `cmdk` library registers a `keydown` handler on its root `CommandPrimitive` container that intercepts `Home` and `End` to navigate the list. This handler fires before the browser's native `<input>` caret logic because events bubble from the input up to the container. There is no guard for `event.target` being a text input.

## Fix

Add an `onKeyDown` handler directly on `CommandPrimitive.Input` that calls `e.stopPropagation()` for `Home`/`End`. This prevents the event from reaching the cmdk root listener, so the browser handles it natively and the caret moves as expected.

```tsx
onKeyDown={(e) => {
  if (e.key === "Home" || e.key === "End") {
    e.stopPropagation(); // don't let cmdk steal these from the input
  }
  onKeyDown?.(e);
}}
```

Applied in two places:
- `packages/ui/components/ui/command.tsx` — the shared `CommandInput` wrapper used across the app
- `packages/views/search/search-command.tsx` — the Ctrl+K `SearchCommand` (uses `CommandPrimitive.Input` directly)

## Test plan

- [x] `pnpm typecheck` passes for `@multica/ui` and `@multica/views`
- [ ] Open Ctrl+K, type several characters, press Home → caret moves to position 0
- [ ] Press End → caret moves to end of text
- [ ] Arrow Up/Down still navigate the results list as before