### PR TITLE
MUL-5258: feat(issues): show agent-working indicator in Table view

### DIFF
--- a/packages/views/issues/components/table-inline-title.test.tsx
+++ b/packages/views/issues/components/table-inline-title.test.tsx
@@ -7,6 +7,15 @@ import { describe, expect, it, vi } from "vitest";
 import { useState } from "react";
 
 import type { Issue } from "@multica/core/types";
+
+// InlineTitle renders the self-contained agent-activity badge, which fetches
+// the workspace agent-task snapshot via React Query. These tests exercise
+// rename/navigation behavior only, so stub it out (same pattern as
+// inbox-list-item.test.tsx) instead of standing up query/workspace providers.
+vi.mock("./issue-agent-activity-indicator", () => ({
+  IssueAgentActivityIndicator: () => null,
+}));
+
 import { InlineTitle } from "./table-view";
 import type { IssueTableDisplayRow } from "./table-view-model";
 

--- a/packages/views/issues/components/table-inline-title.test.tsx
+++ b/packages/views/issues/components/table-inline-title.test.tsx
@@ -9,11 +9,15 @@ import { useState } from "react";
 import type { Issue } from "@multica/core/types";
 
 // InlineTitle renders the self-contained agent-activity badge, which fetches
-// the workspace agent-task snapshot via React Query. These tests exercise
-// rename/navigation behavior only, so stub it out (same pattern as
-// inbox-list-item.test.tsx) instead of standing up query/workspace providers.
+// the workspace agent-task snapshot via React Query. Stub it (same pattern as
+// inbox-list-item.test.tsx) instead of standing up query/workspace providers,
+// but render a marker carrying the issue id so a test can assert the badge is
+// wired into the cell with the row's issue — otherwise the badge insertion in
+// table-view.tsx could be deleted and every test here would still pass.
 vi.mock("./issue-agent-activity-indicator", () => ({
-  IssueAgentActivityIndicator: () => null,
+  IssueAgentActivityIndicator: ({ issueId }: { issueId: string }) => (
+    <span data-testid="issue-agent-activity" data-issue-id={issueId} />
+  ),
 }));
 
 import { InlineTitle } from "./table-view";
@@ -200,5 +204,28 @@ describe("InlineTitle", () => {
     expect(screen.getByRole("textbox")).toHaveValue("Local draft");
     fireEvent.keyDown(screen.getByRole("textbox"), { key: "Escape" });
     expect(screen.getByRole("button", { name: "Remote title" })).toBeTruthy();
+  });
+
+  it("renders the agent-activity badge for the row's issue, between the identifier and the title", () => {
+    render(<Harness title="Original" />);
+
+    const identifier = screen.getByText("MUL-1");
+    const badge = screen.getByTestId("issue-agent-activity");
+    const titleButton = screen.getByRole("button", { name: "Original" });
+
+    // Wired to THIS row's issue — deleting the badge insertion in
+    // table-view.tsx would drop the marker and fail this test, so the core
+    // product change is actually covered.
+    expect(badge.getAttribute("data-issue-id")).toBe("issue-1");
+
+    // Same reading order as List/Board: identifier → activity → title.
+    expect(
+      identifier.compareDocumentPosition(badge) &
+        Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
+    expect(
+      badge.compareDocumentPosition(titleButton) &
+        Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
   });
 });

--- a/packages/views/issues/components/table-view.tsx
+++ b/packages/views/issues/components/table-view.tsx
@@ -136,6 +136,7 @@ import {
 } from "./table-view-model";
 import type { ChildProgress } from "./list-row";
 import { InfiniteScrollSentinel } from "./infinite-scroll-sentinel";
+import { IssueAgentActivityIndicator } from "./issue-agent-activity-indicator";
 
 const SELECT_COLUMN_ID = "__select";
 const ADD_COLUMN_ID = "__add";
@@ -666,6 +667,7 @@ export function InlineTitle({
       <span className="w-16 shrink-0 text-xs text-muted-foreground">
         {row.issue.identifier}
       </span>
+      <IssueAgentActivityIndicator issueId={row.issue.id} />
       {editing ? (
         <Input
           autoFocus


### PR DESCRIPTION
## Summary

The List and Board views show an **"agent working"** indicator (a small avatar stack + shimmering "Working" / "Queued" label) next to any issue an agent is currently working on. The Table view was missing it. This adds the **same** component to the Table view — no new abstraction.

`IssueAgentActivityIndicator` is fully self-contained: it takes only an `issueId`, fetches the workspace agent-task snapshot itself, and returns `null` when no agent is active. So this is a one-line insertion plus its import.

### Placement

Rendered in the **Issue column**, right after the identifier (`MUL-XXXX`) and before the title — identical to the List view placement. This keeps the cue in the same visual position across List, Board, and Table, and because it renders `null` when idle it adds zero weight to inactive rows and doesn't disturb title truncation (the badge is `shrink-0`).

## Changes

- `packages/views/issues/components/table-view.tsx`: import `IssueAgentActivityIndicator` and render `<IssueAgentActivityIndicator issueId={row.issue.id} />` inside `InlineTitle`, after the identifier span.
- `packages/views/issues/components/table-inline-title.test.tsx`: stub the self-contained indicator (which now renders inside `InlineTitle` and needs React Query / workspace context), following the existing `inbox-list-item.test.tsx` precedent. The tests here cover rename/navigation only.

## Verification

- `pnpm exec tsc --noEmit` (packages/views) — passes
- `pnpm exec eslint issues/components/table-view.tsx` — passes
- `pnpm exec vitest run` on the affected + adjacent suites (table-inline-title, table-view-editing, issue-agent-activity-indicator, table-group-row, data-table-sticky, table-issue-search, issues-page, inbox-list-item) — 35 passed

MUL-5258
