### PR TITLE
fix(agent): bound the hermes shutdown so an escaped pipe holder can't wedge a turn (MUL-5241)

### DIFF
--- a/server/pkg/agent/hermes.go
+++ b/server/pkg/agent/hermes.go
@@ -18,6 +18,7 @@ import (
 	"strings"
 	"sync"
 	"sync/atomic"
+	"syscall"
 	"time"
 )
 
@@ -164,6 +165,16 @@ type hermesBackend struct {
 var (
 	hermesReaderDrainGrace      = 2 * time.Second
 	hermesNotificationQuietTime = 250 * time.Millisecond
+	// hermesProcessWaitDelay bounds the deferred cmd.Wait() so a lingering
+	// grandchild that inherited an stdout/stderr pipe (e.g. a Git Bash / MSYS
+	// helper on Windows that never exits — see MUL-5241) can't hang reaping
+	// forever. Mirrors codexProcessWaitDelay's 10s default.
+	hermesProcessWaitDelay = 10 * time.Second
+	// hermesForcedShutdownGrace bounds the post-cancel drain wait so the task
+	// always reaches a terminal Result even when a descendant keeps an
+	// inherited pipe open on a platform without process-group signalling
+	// (Windows). The deferred cmd.Wait()+WaitDelay reaps the tree afterward.
+	hermesForcedShutdownGrace = 3 * time.Second
 )
 
 func (b *hermesBackend) Execute(ctx context.Context, prompt string, opts ExecOptions) (*Session, error) {
@@ -190,6 +201,27 @@ func (b *hermesBackend) Execute(ctx context.Context, prompt string, opts ExecOpt
 	hermesArgs := append([]string{"acp"}, filterCustomArgs(opts.CustomArgs, hermesBlockedArgs, b.cfg.Logger)...)
 	cmd := exec.CommandContext(runCtx, execPath, hermesArgs...)
 	hideAgentWindow(cmd)
+	// Run hermes in its own process group so a cancel-on-stuck cleanup reaches
+	// the whole tree — `hermes acp` plus any tool subprocess it spawns (bash on
+	// POSIX, Git Bash / MSYS helpers on Windows) — not just the direct child.
+	// Without this, killing the leader leaves grandchildren as orphans that keep
+	// inherited stdout/stderr pipes open and wedge the drain below. Mirrors the
+	// codex backend; configureProcessGroup is a no-op on Windows.
+	configureProcessGroup(cmd)
+	// Override exec.CommandContext's default cancel (SIGKILL to the leader only)
+	// so we signal the whole process group and descendants die too. Returning
+	// nil keeps exec from logging a spurious error; cmd.WaitDelay still backstops
+	// cmd.Wait() if the kill leaves a pipe held open by a grandchild.
+	cmd.Cancel = func() error {
+		if cmd.Process != nil {
+			signalProcessGroup(cmd.Process, syscall.SIGKILL)
+		}
+		return nil
+	}
+	// Bound the deferred cmd.Wait() so a stuck child — or a pipe held open by a
+	// lingering grandchild (e.g. a Git Bash / MSYS health-check helper that
+	// never exits; see MUL-5241) — can't hang reaping forever.
+	cmd.WaitDelay = hermesProcessWaitDelay
 	b.cfg.Logger.Info("agent command", "exec", execPath, "args", hermesArgs)
 	agentsMDPresent := false
 	if opts.Cwd != "" {
@@ -580,9 +612,22 @@ func (b *hermesBackend) Execute(ctx context.Context, prompt string, opts ExecOpt
 				"pid", cmd.Process.Pid,
 				"grace", hermesReaderDrainGrace.String(),
 			)
+			// cancel() runs cmd.Cancel, which SIGKILLs the whole process group so
+			// descendants release the inherited pipes and the readers hit EOF.
 			cancel()
-			<-readerDone
-			<-stderrDone
+			// On a platform without process-group signalling (Windows), Cancel
+			// terminates only the leader; a descendant can keep an inherited pipe
+			// open indefinitely. Bound this wait so the task still reaches a
+			// terminal Result — the deferred cmd.Wait() (backed by cmd.WaitDelay)
+			// reaps the tree and force-closes the pipes afterward. Without the
+			// bound this was an unconditional <-readerDone/<-stderrDone that could
+			// hang the task forever (MUL-5241).
+			if !waitForHermesPipeDrain(readerDone, stderrDone, hermesForcedShutdownGrace) {
+				b.cfg.Logger.Warn("hermes readers still blocked after forced shutdown; proceeding without full drain",
+					"pid", cmd.Process.Pid,
+					"grace", hermesForcedShutdownGrace.String(),
+				)
+			}
 		}
 		streamingCurrentTurn.Store(false)
 

--- a/server/pkg/agent/hermes_test.go
+++ b/server/pkg/agent/hermes_test.go
@@ -989,6 +989,80 @@ done
 	}
 }
 
+// TestHermesBackendReapsLingeringPipeHoldingDescendant covers the case the
+// sibling test above cannot: after end_turn the agent leaves a *descendant*
+// that inherited stdout/stderr and lingers (e.g. a Git Bash / MSYS health-check
+// helper that never exits on Windows — MUL-5241). The daemon's stdout/stderr
+// readers never see EOF, so the old unconditional <-readerDone/<-stderrDone
+// after the drain grace would hang the task forever. With the process-group
+// cancel + bounded forced-shutdown drain, the task must still reach a terminal
+// Result well before the lingering descendant would exit on its own.
+func TestHermesBackendReapsLingeringPipeHoldingDescendant(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell-script fixture is POSIX-only")
+	}
+
+	fakePath := filepath.Join(t.TempDir(), "hermes")
+	// After answering session/prompt the shell backgrounds a long sleep that
+	// INHERITS fd 1 and 2 (the daemon's read pipes) and then exits. The sleep
+	// keeps those pipes open, so EOF never arrives until it is killed. It shares
+	// the leader's process group, so only a group-directed SIGKILL reaps it —
+	// exactly what cmd.Cancel now does.
+	script := `#!/bin/sh
+while IFS= read -r line; do
+  id=$(printf '%s' "$line" | sed -n 's/.*"id":\([0-9]*\).*/\1/p')
+  case "$line" in
+    *'"method":"initialize"'*)
+      printf '{"jsonrpc":"2.0","id":%s,"result":{"protocolVersion":1,"agentCapabilities":{}}}\n' "$id"
+      ;;
+    *'"method":"session/new"'*)
+      printf '{"jsonrpc":"2.0","id":%s,"result":{"sessionId":"ses_ling_desc"}}\n' "$id"
+      ;;
+    *'"method":"session/prompt"'*)
+      printf '{"jsonrpc":"2.0","id":%s,"result":{"stopReason":"end_turn"}}\n' "$id"
+      sleep 30 &
+      exit 0
+      ;;
+  esac
+done
+`
+	writeTestExecutable(t, fakePath, []byte(script))
+
+	backend, err := New("hermes", Config{ExecutablePath: fakePath, Logger: slog.Default()})
+	if err != nil {
+		t.Fatalf("new hermes backend: %v", err)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+	defer cancel()
+	session, err := backend.Execute(ctx, "prompt", ExecOptions{Timeout: 15 * time.Second})
+	if err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	go func() {
+		for range session.Messages {
+		}
+	}()
+
+	start := time.Now()
+	select {
+	case result, ok := <-session.Result:
+		if !ok {
+			t.Fatal("result channel closed without a value")
+		}
+		if result.Status != "completed" {
+			t.Fatalf("expected completed, got status=%q error=%q", result.Status, result.Error)
+		}
+		// The lingering descendant sleeps 30s. Without the group-kill + bounded
+		// drain the Result would block until that sleep exits; the bounded path
+		// returns within grace + forced-shutdown grace (2s + 3s) plus slack.
+		if elapsed := time.Since(start); elapsed > 8*time.Second {
+			t.Fatalf("result took %s; bounded drain did not reap the lingering descendant", elapsed)
+		}
+	case <-time.After(8 * time.Second):
+		t.Fatal("timeout waiting for result; lingering pipe-holding descendant wedged the drain")
+	}
+}
+
 func TestHermesClientHandleAgentThought(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## What does this PR do?

Rebased on current `main` and rewritten. The original version added process-group ownership plus a bounded cleanup to the hermes backend; [#7531](https://github.com/multica-ai/multica/pull/7531) (GH #7522) has since given **every** runtime a process group, a group-killing `cmd.Cancel` and a Windows Job Object, so that half is upstream already and is dropped here. What is left is the hole #7531 cannot cover.

`cmd.Cancel` kills the owned process tree, so a descendant that inherited the daemon's stdout/stderr dies with it and both readers reach EOF. A descendant **outside** that tree does not: on POSIX because it called `setsid` and left the process group, on Windows because `startOwnedProcessTree` failed open (`proc_windows.go:110`) and the child runs unowned, so the kill reaches the leader alone. The Job Object this daemon creates sets only `KILL_ON_JOB_CLOSE`, so `CREATE_BREAKAWAY_FROM_JOB` is *not* the Windows route. The join that followed the forced shutdown was unbounded, so the turn hung forever: no tool result, no reply, nothing until the user cancelled by hand (MUL-5241).

The fix reaps the process as part of that forced shutdown. `cmd.Wait()` is what closes the parent ends of the pipes, so it frees a reader the kill could not reach, and a `WaitDelay` — the same 10s the claude / codearts / antigravity backends already use — bounds `Wait` itself once the context is cancelled. Both readers are then joined **before** the buffers are read, so `providerErr.Finalize()` keeps its documented precondition (a fully drained stderr pipe) instead of racing the copier: it releases the lock between taking `remains` and writing it back, so a concurrent write there could split a provider error across the flush and land a failed turn as completed. The same reap runs in the deferred cleanup, where joining the readers before the goroutine closes `msgCh` keeps a live reader from panicking in `trySend`.

What this buys is a **bounded recovery, not a repaired turn**: past the existing 2s drain grace the backend reports from the buffers it has, so an exceptional shutdown can deliver a turn without the tail the readers had not handed over — including, in the worst case, a provider-error marker that would have promoted the status. That trade is deliberate: the alternative is a task that never lands at all.

**This does not make the Windows terminal tool usable,** and it does not reap the escaped process — being outside the owned tree is exactly what puts it out of the daemon's reach. The root cause is hermes' own Git Bash startup probe (`_bash_starts` → `subprocess.run(..., timeout=15)`, whose post-timeout cleanup calls an unbounded `communicate()`); the upstream fix, [NousResearch/hermes-agent#69083](https://github.com/NousResearch/hermes-agent/pull/69083) for [#73403](https://github.com/NousResearch/hermes-agent/issues/73403), is still open. What this PR guarantees is that the daemon recovers in bounded time and the task reaches a terminal state.

## Related Issue

MUL-5241

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Tests (adding or improving test coverage)

## Changes Made

- `server/pkg/agent/hermes.go`
  - `reapProcess` — a `sync.Once`-guarded `cmd.Wait()` shared by the forced shutdown and the deferred cleanup, since `Wait` may only be called once.
  - Forced shutdown is now `cancel → reapProcess → join readers`: bounded by `WaitDelay`, and it preserves the drained-stderr precondition `Finalize()` requires. No second grace constant — the earlier revision's arbitrary 3s is gone.
  - `cmd.WaitDelay = 10s`, which is what makes that `Wait` bounded at all.
  - Deferred cleanup joins both readers after the reap, before the lifecycle goroutine closes `msgCh`.
- `server/pkg/agent/hermes_escaped_holder_unix_test.go` — two tests over a shared fixture. It re-executes the test binary so the holder can `setsid(2)` (no portable shell equivalent), inherit the agent's stdout/stderr and outlive the turn; the agent waits for the holder to record its identity before answering, so the escape never races the daemon's kill, and both tests assert the holder's pgid equals its pid — they cannot pass without a genuinely escaped holder.
  - `TestHermesBackendReportsTurnWhenEscapedDescendantHoldsPipes` — the completed turn. Fails on `main` (`no result within 8s`), passes here in ~2.5s.
  - `TestHermesBackendClosesSessionWhenEarlyFailureLeavesEscapedHolder` — a handshake failure returns before the drain runs, so the deferred cleanup is the only thing that closes the pipes. This one passes on `main` too: it pins the contract on that path (terminal `Result` **and** `Messages` closed, both bounded) rather than reproducing a failure.
  - The fake agent and the test wait on one shared budget for the holder to appear (`hermesEscapedHolderReady`). Two different budgets is a load-dependent false failure: the test can give up while the agent is still legitimately waiting.

The original PR's regression test is **not** carried over: its lingering process stays in the agent's process group, so on current `main` it passes without this change (verified — 2.41s) and would protect nothing.

## How to Test

1. `cd server && go test ./pkg/agent -run 'TestHermesBackend(ReportsTurnWhenEscapedDescendantHoldsPipes|ClosesSessionWhenEarlyFailureLeavesEscapedHolder)' -count=3` → both pass, stable (2.5s / 0.4s per run). Also `-count=4` while two full-package runs (one under `-race`) hog the machine: still green, worst case 3.15s / 0.91s against an 8s budget.
2. Restore `hermes.go` from `main`, keep the tests → the first fails: `no result within 8s: the escaped pipe holder wedged the shutdown`.
3. `go test ./pkg/agent -race -run '^TestHermes' -count=1` → pass, no data races.
4. `GOOS=windows GOARCH=amd64 go build ./...` → pass.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable

Full-package `go test ./pkg/agent` is green apart from `TestCodexInitializeParentDeadlineDoesNotPersistOpaqueEnv`, which fails identically on an untouched `main` on this machine (load-sensitive, passes in isolation) and is unrelated to this change.
