### PR TITLE
fix(runtimes): runtime alias display sweeper (MUL-5248)

### DIFF
--- a/apps/desktop/src/renderer/src/pages/runtime-detail-page.tsx
+++ b/apps/desktop/src/renderer/src/pages/runtime-detail-page.tsx
@@ -5,6 +5,7 @@ import {
   RuntimeSettingsPage as SharedRuntimeSettingsPage,
 } from "@multica/views/runtimes";
 import { useWorkspaceId } from "@multica/core/hooks";
+import { runtimeDisplayLabel } from "@multica/core/runtimes";
 import { runtimeListOptions } from "@multica/core/runtimes/queries";
 import { useDocumentTitle } from "@/hooks/use-document-title";
 import { DaemonRuntimeActions } from "../components/daemon-runtime-card";
@@ -17,7 +18,7 @@ export function RuntimeDetailPage() {
   const runtime = runtimes?.find((candidate) => candidate.id === id);
   const context = useDesktopRuntimeContext();
 
-  useDocumentTitle(runtime?.name ?? "Runtimes");
+  useDocumentTitle(runtime ? runtimeDisplayLabel(runtime) : "Runtimes");
 
   if (!id) return null;
   return (
@@ -41,7 +42,7 @@ export function RuntimeSettingsPage() {
   const { data: runtimes } = useQuery(runtimeListOptions(wsId));
   const runtime = runtimes?.find((candidate) => candidate.id === runtimeId);
 
-  useDocumentTitle(runtime?.name ?? "Runtime");
+  useDocumentTitle(runtime ? runtimeDisplayLabel(runtime) : "Runtime");
 
   if (!id || !runtimeId) return null;
   return <SharedRuntimeSettingsPage machineId={id} runtimeId={runtimeId} />;

--- a/apps/docs/content/docs/developers/conventions.mdx
+++ b/apps/docs/content/docs/developers/conventions.mdx
@@ -68,6 +68,17 @@ If logic appears in both apps, it MUST be extracted to a shared package. There a
 - Enums: prefer string literal unions; reserve `enum` for runtime-iterable cases.
 - TanStack Query keys: factory functions in `<feature>/queries.ts`, e.g. `issueKeys.detail(id)`.
 
+### Runtime display names
+
+`AgentRuntime.name` is the daemon's raw technical name (e.g. `Codex (host)`); the user's alias lives in `custom_name`. User-visible copy must never render `runtime.name` directly — use the shared helpers so aliases and provider stay consistent (MUL-5248, #5260):
+
+- Standalone runtime label (lists, chips, confirm dialogs, document titles): `runtimeDisplayLabel(runtime)` → alias + provider, falling back to the daemon name.
+- When a provider icon/text already sits beside it: `runtimeDisplayName(runtime)` → alias only, no duplicated provider.
+- Inside a machine group: machine header uses `machine.title`, child rows use `runtimeRowLabel(runtime, machine.title)`.
+- Runtime selectors group by machine via `buildRuntimeMachines`; do not build a flat list of raw names.
+
+Raw `runtime.name` is allowed only for internal identity — hostname parsing, grouping, search haystacks, and protocol payloads — never for JSX text, i18n params, `<Select>` labels, or window titles.
+
 ### Issue keys
 
 Every issue has a human-readable key like `MUL-123`: workspace `issue_prefix` (uppercase letters and digits, typically 3 chars, max 10) + sequence number. Workspace admins can change the prefix in Settings → General; changing it renumbers every existing issue, so external references that embed the old prefix (PR titles, branch names, links in docs and chat) stop resolving.

--- a/apps/docs/content/docs/developers/conventions.zh.mdx
+++ b/apps/docs/content/docs/developers/conventions.zh.mdx
@@ -68,6 +68,17 @@ monorepo 的包边界是硬约束：
 - 枚举：优先用 string literal union，需要 runtime 迭代时才用 `enum`
 - TanStack Query key：用 `<feature>/queries.ts` 里的工厂函数，例如 `issueKeys.detail(id)`
 
+### Runtime 显示名
+
+`AgentRuntime.name` 是 daemon 的原始技术名（例如 `Codex (host)`），用户别名在 `custom_name`。用户可见文案不得直接渲染 `runtime.name`，要用共享 helper，保证别名和 provider 一致（MUL-5248、#5260）：
+
+- 独立展示 runtime（列表、标签、确认弹窗、窗口标题）：`runtimeDisplayLabel(runtime)` → 别名 + provider，无别名时回退 daemon 名。
+- 旁边已经单独显示 provider 图标/文字时：`runtimeDisplayName(runtime)` → 只显示别名，避免重复 provider。
+- 在机器分组内：机器标题用 `machine.title`，子行用 `runtimeRowLabel(runtime, machine.title)`。
+- runtime 选择器用 `buildRuntimeMachines` 按机器分组，不要自己拼扁平的原始名列表。
+
+原始 `runtime.name` 只允许用于内部识别——hostname 解析、分组、搜索 haystack、协议 payload——绝不能进入 JSX 文本、i18n 参数、`<Select>` label 或窗口标题。
+
 ### Issue 编号
 
 每个 issue 有人类可读的编号，比如 `MUL-123`：工作区 `issue_prefix`（大写字母和数字，通常 3 个字符，最长 10 个）+ 流水号。工作区管理员可以在 Settings → General 中修改前缀；修改会让所有现有 issue 重新编号，外部引用——PR 标题、分支名、文档与聊天里的链接——里的旧前缀会失效。

--- a/packages/views/agents/components/agent-creation-studio.tsx
+++ b/packages/views/agents/components/agent-creation-studio.tsx
@@ -28,6 +28,7 @@ import {
 import { useWorkspaceId } from "@multica/core/hooks";
 import { useWorkspacePaths } from "@multica/core/paths";
 import {
+  runtimeDisplayLabel,
   runtimeListOptions,
   runtimeModelsOptions,
 } from "@multica/core/runtimes";
@@ -814,7 +815,7 @@ export function AgentCreationStudio() {
             </span>
             {selectedRuntime && (
               <span className="rounded-full bg-muted px-2 py-1">
-                {selectedRuntime.name || selectedRuntime.provider}
+                {runtimeDisplayLabel(selectedRuntime)}
               </span>
             )}
           </div>

--- a/packages/views/agents/components/agent-list-toolbar.tsx
+++ b/packages/views/agents/components/agent-list-toolbar.tsx
@@ -14,6 +14,7 @@ import {
   type AgentAvailability,
 } from "@multica/core/agents";
 import type { MemberWithUser } from "@multica/core/types";
+import { runtimeDisplayLabel } from "@multica/core/runtimes";
 import { resolvePublicFileUrl } from "@multica/core/workspace/avatar-url";
 import {
   AGENT_SCOPES,
@@ -154,7 +155,7 @@ export function AgentListToolbar({
     if (rt) {
       const entry = runtimeOptions.get(rt.id);
       if (entry) entry.count += 1;
-      else runtimeOptions.set(rt.id, { name: rt.name, count: 1 });
+      else runtimeOptions.set(rt.id, { name: runtimeDisplayLabel(rt), count: 1 });
     }
     const a = effectiveAccessScope(row.agent.permission_mode, row.agent.invocation_targets);
     accessCounts.set(a, (accessCounts.get(a) ?? 0) + 1);

--- a/packages/views/agents/components/agent-overview-summary.tsx
+++ b/packages/views/agents/components/agent-overview-summary.tsx
@@ -6,6 +6,7 @@ import type {
   AgentRuntime,
   MemberWithUser,
 } from "@multica/core/types";
+import { runtimeDisplayLabel } from "@multica/core/runtimes";
 import { ActorAvatar } from "../../common/actor-avatar";
 import { useT } from "../../i18n";
 import { VisibilityBadge } from "./visibility-badge";
@@ -62,7 +63,9 @@ export function AgentOverviewSummary({
               />
               <Server className="h-3 w-3 shrink-0 text-muted-foreground" aria-hidden="true" />
               <span className="truncate">
-                {runtime?.name ?? t(($) => $.pickers.runtime_none)}
+                {runtime
+                  ? runtimeDisplayLabel(runtime)
+                  : t(($) => $.pickers.runtime_none)}
               </span>
             </span>
           </SummaryRow>

--- a/packages/views/agents/components/tabs/mcp-config-tab.test.tsx
+++ b/packages/views/agents/components/tabs/mcp-config-tab.test.tsx
@@ -17,14 +17,21 @@ const mockRuntimeCapabilities = vi.hoisted(() => vi.fn());
 
 // The tab reads discovery through runtimeCapabilitiesOptions; existing tests
 // render with runtime={null} so the query stays disabled and never fires.
-vi.mock("@multica/core/runtimes", () => ({
-  runtimeCapabilitiesOptions: (runtimeId: string | null) => ({
-    queryKey: ["runtime-capabilities", runtimeId],
-    queryFn: () => mockRuntimeCapabilities(runtimeId),
-    enabled: Boolean(runtimeId),
-    retry: false,
-  }),
-}));
+vi.mock("@multica/core/runtimes", async () => {
+  const actual =
+    await vi.importActual<typeof import("@multica/core/runtimes")>(
+      "@multica/core/runtimes",
+    );
+  return {
+    ...actual,
+    runtimeCapabilitiesOptions: (runtimeId: string | null) => ({
+      queryKey: ["runtime-capabilities", runtimeId],
+      queryFn: () => mockRuntimeCapabilities(runtimeId),
+      enabled: Boolean(runtimeId),
+      retry: false,
+    }),
+  };
+});
 
 vi.mock("sonner", () => ({
   toast: {

--- a/packages/views/agents/components/tabs/mcp-config-tab.tsx
+++ b/packages/views/agents/components/tabs/mcp-config-tab.tsx
@@ -13,7 +13,10 @@ import {
 import { useQuery } from "@tanstack/react-query";
 import type { Agent, AgentRuntime } from "@multica/core/types";
 import { ApiError } from "@multica/core/api";
-import { runtimeCapabilitiesOptions } from "@multica/core/runtimes";
+import {
+  runtimeCapabilitiesOptions,
+  runtimeDisplayLabel,
+} from "@multica/core/runtimes";
 import {
   AlertDialog,
   AlertDialogAction,
@@ -190,7 +193,7 @@ export function McpConfigTab({
             </h3>
             <p className="mt-1 max-w-2xl text-xs leading-5 text-muted-foreground">
               {t(($) => $.tab_body.mcp_config.runtime_hint, {
-                runtime: runtime?.custom_name || runtime?.name || "Runtime",
+                runtime: runtime ? runtimeDisplayLabel(runtime) : "Runtime",
               })}
             </p>
           </div>

--- a/packages/views/agents/components/tabs/skills-tab.test.tsx
+++ b/packages/views/agents/components/tabs/skills-tab.test.tsx
@@ -51,14 +51,21 @@ vi.mock("@multica/core/api", () => ({
   ApiError,
 }));
 
-vi.mock("@multica/core/runtimes", () => ({
-  runtimeCapabilitiesOptions: (runtimeId: string | null) => ({
-    queryKey: ["runtime-capabilities", runtimeId],
-    queryFn: () => mockRuntimeCapabilities(runtimeId),
-    enabled: Boolean(runtimeId),
-    retry: false,
-  }),
-}));
+vi.mock("@multica/core/runtimes", async () => {
+  const actual =
+    await vi.importActual<typeof import("@multica/core/runtimes")>(
+      "@multica/core/runtimes",
+    );
+  return {
+    ...actual,
+    runtimeCapabilitiesOptions: (runtimeId: string | null) => ({
+      queryKey: ["runtime-capabilities", runtimeId],
+      queryFn: () => mockRuntimeCapabilities(runtimeId),
+      enabled: Boolean(runtimeId),
+      retry: false,
+    }),
+  };
+});
 
 vi.mock("sonner", () => ({
   toast: {

--- a/packages/views/agents/components/tabs/skills-tab.tsx
+++ b/packages/views/agents/components/tabs/skills-tab.tsx
@@ -19,7 +19,10 @@ import type {
 } from "@multica/core/types";
 import { api, ApiError } from "@multica/core/api";
 import { useWorkspaceId } from "@multica/core/hooks";
-import { runtimeCapabilitiesOptions } from "@multica/core/runtimes";
+import {
+  runtimeCapabilitiesOptions,
+  runtimeDisplayLabel,
+} from "@multica/core/runtimes";
 import {
   skillDetailOptions,
   skillListOptions,
@@ -229,7 +232,7 @@ export function SkillsTab({
       <CapabilitySection
         title={t(($) => $.tab_body.skills.runtime_title)}
         description={t(($) => $.tab_body.skills.runtime_hint, {
-          runtime: runtime?.custom_name || runtime?.name || "Runtime",
+          runtime: runtime ? runtimeDisplayLabel(runtime) : "Runtime",
         })}
         action={
           runtimeId ? (

--- a/packages/views/common/task-transcript/agent-transcript-dialog.tsx
+++ b/packages/views/common/task-transcript/agent-transcript-dialog.tsx
@@ -42,6 +42,7 @@ import {
   type TranscriptSortDirection,
 } from "@multica/core/agents/stores";
 import type { AgentTask, Agent, AgentRuntime } from "@multica/core/types/agent";
+import { runtimeDisplayName } from "@multica/core/runtimes";
 import { redactSecrets } from "./redact";
 import type { TimelineItem } from "./build-timeline";
 import { useT } from "../../i18n";
@@ -632,7 +633,7 @@ export function AgentTranscriptDialog({
               <MetadataChip
                 icon={runtimeInfo.runtime_mode === "cloud" ? <Cloud className="h-3 w-3" /> : <Monitor className="h-3 w-3" />}
               >
-                {runtimeInfo.name}
+                {runtimeDisplayName(runtimeInfo)}
                 <span className="text-muted-foreground/60 ml-0.5">({runtimeInfo.runtime_mode})</span>
               </MetadataChip>
             )}

--- a/packages/views/onboarding/components/compact-runtime-row.tsx
+++ b/packages/views/onboarding/components/compact-runtime-row.tsx
@@ -1,5 +1,6 @@
 import { cn } from "@multica/ui/lib/utils";
 import type { AgentRuntime } from "@multica/core/types";
+import { runtimeDisplayName } from "@multica/core/runtimes";
 import { ProviderLogo } from "../../runtimes/components/provider-logo";
 import { useT } from "../../i18n";
 
@@ -41,7 +42,9 @@ export function CompactRuntimeRow({
     >
       <ProviderLogo provider={runtime.provider} className="h-5 w-5" />
       <div className="min-w-0 flex-1">
-        <div className="truncate text-sm font-medium">{runtime.name}</div>
+        <div className="truncate text-sm font-medium">
+          {runtimeDisplayName(runtime)}
+        </div>
         <div className="text-xs text-muted-foreground">{runtime.provider}</div>
       </div>
       <span

--- a/packages/views/onboarding/steps/step-platform-fork.tsx
+++ b/packages/views/onboarding/steps/step-platform-fork.tsx
@@ -14,6 +14,7 @@ import {
 import { useScrollFade } from "@multica/ui/hooks/use-scroll-fade";
 import { cn } from "@multica/ui/lib/utils";
 import type { AgentRuntime } from "@multica/core/types";
+import { runtimeDisplayLabel } from "@multica/core/runtimes";
 import { DragStrip } from "@multica/views/platform";
 import { StepHeader } from "../components/step-header";
 import { RuntimeAsidePanel } from "../components/runtime-aside-panel";
@@ -187,7 +188,9 @@ export function StepPlatformFork({
         onSelect={picker.setSelectedId}
         hasRuntimes={picker.hasRuntimes}
         canConnect={picker.selected !== null}
-        selectedName={picker.selected?.name ?? null}
+        selectedName={
+          picker.selected ? runtimeDisplayLabel(picker.selected) : null
+        }
         cliInstructions={cliInstructions}
       />
     </div>

--- a/packages/views/onboarding/steps/step-runtime-connect.tsx
+++ b/packages/views/onboarding/steps/step-runtime-connect.tsx
@@ -7,6 +7,10 @@ import { Button } from "@multica/ui/components/ui/button";
 import { cn } from "@multica/ui/lib/utils";
 import { useScrollFade } from "@multica/ui/hooks/use-scroll-fade";
 import { runtimeKeys } from "@multica/core/runtimes/queries";
+import {
+  runtimeDisplayLabel,
+  runtimeDisplayName,
+} from "@multica/core/runtimes";
 import type { AgentRuntime } from "@multica/core/types";
 import { DragStrip } from "@multica/views/platform";
 import { StepHeader } from "../components/step-header";
@@ -201,7 +205,9 @@ function FancyView({
 
   const footerHint =
     phase === "found" && selected
-      ? t(($) => $.step_runtime.hint_selected, { name: selected.name })
+      ? t(($) => $.step_runtime.hint_selected, {
+          name: runtimeDisplayLabel(selected),
+        })
       : phase === "found"
         ? t(($) => $.step_runtime.hint_pick)
         : phase === "scanning"
@@ -619,7 +625,7 @@ function RuntimeCard({
       </div>
       <div className="min-w-0 flex-1">
         <div className="truncate text-sm font-medium text-foreground">
-          {runtime.name}
+          {runtimeDisplayName(runtime)}
         </div>
         <div className="mt-0.5 flex items-center gap-1.5 font-mono text-[11px] text-muted-foreground">
           <span

--- a/packages/views/runtimes/components/delete-runtime-dialog.tsx
+++ b/packages/views/runtimes/components/delete-runtime-dialog.tsx
@@ -6,6 +6,7 @@ import { toast } from "sonner";
 import { useQuery } from "@tanstack/react-query";
 import { ApiError } from "@multica/core/api";
 import type { Agent, AgentRuntime, MemberWithUser } from "@multica/core/types";
+import { runtimeDisplayLabel } from "@multica/core/runtimes";
 import {
   useDeleteRuntime,
   useArchiveAgentsAndDeleteRuntime,
@@ -284,7 +285,7 @@ function LightBody({
         </h2>
         <p className="mt-1 text-sm leading-5 text-muted-foreground">
           {t(($) => $.detail.delete_dialog.light.description, {
-            name: runtime.name,
+            name: runtimeDisplayLabel(runtime),
           })}
         </p>
         <DeletePersistenceNotice runtime={runtime} />
@@ -359,7 +360,7 @@ function CascadeBody({
         </h2>
         <p className="mt-1 text-sm leading-5 text-muted-foreground">
           {t(($) => $.detail.delete_dialog.cascade.description, {
-            name: runtime.name,
+            name: runtimeDisplayLabel(runtime),
           })}
         </p>
 

--- a/packages/views/runtimes/components/runtime-detail-page.tsx
+++ b/packages/views/runtimes/components/runtime-detail-page.tsx
@@ -315,6 +315,7 @@ export function RuntimeDetailPage({
               <RuntimeList
                 runtimes={machineRuntimes}
                 now={now}
+                machineTitle={machine.title}
                 runtimeHref={(childRuntimeId) =>
                   paths.runtimeSettings(machine.id, childRuntimeId)
                 }

--- a/packages/views/runtimes/components/runtime-list.tsx
+++ b/packages/views/runtimes/components/runtime-list.tsx
@@ -62,7 +62,7 @@ import {
   computeCostInWindow,
   pctChange,
 } from "../utils";
-import { splitRuntimeName } from "./runtime-machines";
+import { runtimeRowLabel } from "./runtime-machines";
 import {
   customRuntimeRegistrationFailure,
   isDisabledCustomRuntime,
@@ -185,8 +185,21 @@ export function buildWorkloadIndex(
 // Cells
 // ---------------------------------------------------------------------------
 
-function RuntimeNameCell({ runtime }: { runtime: AgentRuntime }) {
-  const { base: baseName } = splitRuntimeName(runtime.name);
+function RuntimeNameCell({
+  runtime,
+  machineTitle,
+}: {
+  runtime: AgentRuntime;
+  /**
+   * The containing machine's title. Lets a per-runtime alias surface here
+   * while a machine-level rename (shared by every runtime on the daemon)
+   * collapses to the provider base so it isn't repeated on every row
+   * (MUL-5248). Omitted when the row has no machine context (orphan custom
+   * runtime profiles), where any alias is shown verbatim.
+   */
+  machineTitle?: string;
+}) {
+  const label = runtimeRowLabel(runtime, machineTitle ?? "");
   return (
     <ListGridCell className="gap-2">
       <div className="flex h-8 w-8 shrink-0 items-center justify-center">
@@ -194,7 +207,7 @@ function RuntimeNameCell({ runtime }: { runtime: AgentRuntime }) {
       </div>
       <div className="flex min-w-0 flex-1 items-center gap-1.5">
         <span className="block min-w-0 shrink truncate text-sm font-medium">
-          {baseName}
+          {label}
         </span>
         <RuntimeKindBadge runtime={runtime} />
         <PendingRuntimeBadge runtime={runtime} />
@@ -615,11 +628,18 @@ export function RuntimeList({
   runtimes,
   now,
   runtimeHref,
+  machineTitle,
 }: {
   runtimes: AgentRuntime[];
   now: number;
   /** Machine-detail pages keep runtime settings nested under the machine. */
   runtimeHref?: (runtimeId: string) => string;
+  /**
+   * The containing machine's title, when this list renders the runtimes of a
+   * single machine. Used so a machine-level alias doesn't repeat on every row
+   * while a per-runtime alias still shows (MUL-5248).
+   */
+  machineTitle?: string;
 }) {
   const { t } = useT("runtimes");
   const wsId = useWorkspaceId();
@@ -734,7 +754,7 @@ export function RuntimeList({
                   )
                 : {})}
             >
-              <RuntimeNameCell runtime={row.runtime} />
+              <RuntimeNameCell runtime={row.runtime} machineTitle={machineTitle} />
               <HealthCell
                 runtime={row.runtime}
                 workload={row.workload}

--- a/packages/views/runtimes/components/runtime-machines.test.ts
+++ b/packages/views/runtimes/components/runtime-machines.test.ts
@@ -4,6 +4,7 @@ import {
   buildRuntimeMachines,
   filterRuntimeMachines,
   runtimeMachineCounts,
+  runtimeRowLabel,
   sharedCustomName,
   splitRuntimeName,
 } from "./runtime-machines";
@@ -402,5 +403,36 @@ describe("sharedCustomName", () => {
       ]),
     ).toBeNull();
     expect(sharedCustomName([])).toBeNull();
+  });
+});
+
+describe("runtimeRowLabel", () => {
+  it("falls back to the provider base when no alias is set", () => {
+    expect(
+      runtimeRowLabel(
+        makeRuntime({ name: "Codex (dev.local)", custom_name: null }),
+        "dev.local",
+      ),
+    ).toBe("Codex");
+  });
+
+  it("collapses a machine-level alias (shared with the title) to the base", () => {
+    // A machine rename stamps the same custom_name on every runtime, so the
+    // title already shows it — repeating it per row would be noise.
+    expect(
+      runtimeRowLabel(
+        makeRuntime({ name: "Codex (dev.local)", custom_name: "Dev Box" }),
+        "Dev Box",
+      ),
+    ).toBe("Codex");
+  });
+
+  it("shows a per-runtime alias that differs from the machine title", () => {
+    expect(
+      runtimeRowLabel(
+        makeRuntime({ name: "Codex (dev.local)", custom_name: "just this one" }),
+        "Dev Box",
+      ),
+    ).toBe("just this one");
   });
 });

--- a/packages/views/skills/components/runtime-local-skill-import-panel.test.tsx
+++ b/packages/views/skills/components/runtime-local-skill-import-panel.test.tsx
@@ -36,16 +36,30 @@ vi.mock("@multica/core/auth", () => {
   return { useAuthStore };
 });
 
-vi.mock("@multica/core/runtimes", () => ({
-  runtimeListOptions: (...args: unknown[]) => mockRuntimeListOptions(...args),
-  runtimeLocalSkillsOptions: (...args: unknown[]) =>
-    mockRuntimeLocalSkillsOptions(...args),
-  runtimeLocalSkillsKeys: {
-    forRuntime: (runtimeId: string) => ["runtimes", "local-skills", runtimeId],
-  },
-  resolveRuntimeLocalSkillImport: (...args: unknown[]) =>
-    mockResolveRuntimeLocalSkillImport(...args),
-}));
+// Spread the real module so alias helpers (runtimeDisplayLabel) and the
+// machine-grouping helpers used transitively by buildRuntimeMachines
+// (deriveRuntimeHealth) stay real; only the data/import entrypoints are mocked.
+vi.mock("@multica/core/runtimes", async () => {
+  const actual =
+    await vi.importActual<typeof import("@multica/core/runtimes")>(
+      "@multica/core/runtimes",
+    );
+  return {
+    ...actual,
+    runtimeListOptions: (...args: unknown[]) => mockRuntimeListOptions(...args),
+    runtimeLocalSkillsOptions: (...args: unknown[]) =>
+      mockRuntimeLocalSkillsOptions(...args),
+    runtimeLocalSkillsKeys: {
+      forRuntime: (runtimeId: string) => [
+        "runtimes",
+        "local-skills",
+        runtimeId,
+      ],
+    },
+    resolveRuntimeLocalSkillImport: (...args: unknown[]) =>
+      mockResolveRuntimeLocalSkillImport(...args),
+  };
+});
 
 vi.mock("sonner", () => ({
   toast: {
@@ -215,6 +229,29 @@ describe("RuntimeLocalSkillImportPanel", () => {
       },
       { timeout: 5000 },
     );
+  });
+
+  it("surfaces the runtime alias and provider in the picker, not the raw daemon name (MUL-5248)", async () => {
+    mockRuntimeListOptions.mockReturnValue({
+      queryKey: ["runtimes", "ws-1", "list"],
+      queryFn: () =>
+        Promise.resolve([{ ...MOCK_RUNTIME, custom_name: "Dev Box" }]),
+    });
+
+    renderPanel();
+
+    // The selected-runtime summary surfaces the user's alias plus the provider
+    // ("Dev Box (Claude)"). The old flat label duplicated the provider as
+    // "Claude (MacBook) (claude)" and dropped the alias entirely.
+    const labels = await screen.findAllByText(
+      "Dev Box (Claude)",
+      {},
+      { timeout: 5000 },
+    );
+    expect(labels.length).toBeGreaterThan(0);
+    expect(
+      screen.queryByText("Claude (MacBook) (claude)"),
+    ).not.toBeInTheDocument();
   });
 
   it("imports multiple skills in sequence and shows summary", async () => {

--- a/packages/views/skills/components/runtime-local-skill-import-panel.tsx
+++ b/packages/views/skills/components/runtime-local-skill-import-panel.tsx
@@ -16,7 +16,6 @@ import {
   XCircle,
 } from "lucide-react";
 import type {
-  AgentRuntime,
   RuntimeLocalSkillImportConflict,
   RuntimeLocalSkillSummary,
   Skill,
@@ -24,6 +23,7 @@ import type {
 import { useAuthStore } from "@multica/core/auth";
 import { useWorkspaceId } from "@multica/core/hooks";
 import {
+  runtimeDisplayLabel,
   runtimeListOptions,
   runtimeLocalSkillsKeys,
   runtimeLocalSkillsOptions,
@@ -44,7 +44,9 @@ import { Textarea } from "@multica/ui/components/ui/textarea";
 import {
   Select,
   SelectContent,
+  SelectGroup,
   SelectItem,
+  SelectLabel,
   SelectTrigger,
   SelectValue,
 } from "@multica/ui/components/ui/select";
@@ -56,6 +58,11 @@ import {
 } from "@multica/ui/lib/motion";
 import { useT } from "../../i18n";
 import { HighlightText } from "../../search/highlight-text";
+import { ProviderLogo } from "../../runtimes/components/provider-logo";
+import {
+  buildRuntimeMachines,
+  runtimeRowLabel,
+} from "../../runtimes/components/runtime-machines";
 import { isNameConflictError } from "../lib/utils";
 
 // ---------------------------------------------------------------------------
@@ -108,10 +115,6 @@ const INITIAL_BULK_STATE: BulkImportState = {
  * See also maxLocalSkillImportBatch in server/internal/handler/daemon.go.
  */
 const IMPORT_CONCURRENCY = 10;
-
-function runtimeLabel(runtime: AgentRuntime): string {
-  return `${runtime.name} (${runtime.provider})`;
-}
 
 function defaultRenameName(name: string): string {
   return `${name} copy`;
@@ -522,6 +525,19 @@ export function RuntimeLocalSkillImportPanel({
           (userId == null || r.owner_id === userId),
       ),
     [runtimes, userId],
+  );
+
+  // Group the local runtimes by machine so the picker reads as
+  // "machine → provider/runtime" (alias-aware) instead of a flat list of
+  // raw daemon names (MUL-5248). Reuses the same source of truth as the
+  // agent runtime picker.
+  const runtimeMachines = useMemo(
+    () =>
+      buildRuntimeMachines(localRuntimes, {
+        now: Date.now(),
+        currentUserId: userId,
+      }),
+    [localRuntimes, userId],
   );
 
   const [selectedRuntimeId, setSelectedRuntimeId] = useState<string>("");
@@ -1250,21 +1266,42 @@ export function RuntimeLocalSkillImportPanel({
           <Select
             items={localRuntimes.map((runtime) => ({
               value: runtime.id,
-              label: runtimeLabel(runtime),
+              label: runtimeDisplayLabel(runtime),
             }))}
             value={selectedRuntimeId}
             onValueChange={(v) => v && setSelectedRuntimeId(v)}
           >
             <SelectTrigger className="w-full">
               <SelectValue placeholder={t(($) => $.runtime_import.runtime_placeholder)}>
-                {selectedRuntime ? runtimeLabel(selectedRuntime) : null}
+                {selectedRuntime ? (
+                  <>
+                    <ProviderLogo
+                      provider={selectedRuntime.provider}
+                      className="h-4 w-4 shrink-0"
+                    />
+                    <span className="truncate">
+                      {runtimeDisplayLabel(selectedRuntime)}
+                    </span>
+                  </>
+                ) : null}
               </SelectValue>
             </SelectTrigger>
             <SelectContent>
-              {localRuntimes.map((r) => (
-                <SelectItem key={r.id} value={r.id}>
-                  {runtimeLabel(r)}
-                </SelectItem>
+              {runtimeMachines.map((machine) => (
+                <SelectGroup key={machine.id}>
+                  <SelectLabel>{machine.title}</SelectLabel>
+                  {machine.runtimes.map((r) => (
+                    <SelectItem key={r.id} value={r.id}>
+                      <ProviderLogo
+                        provider={r.provider}
+                        className="h-4 w-4 shrink-0"
+                      />
+                      <span className="truncate">
+                        {runtimeRowLabel(r, machine.title)}
+                      </span>
+                    </SelectItem>
+                  ))}
+                </SelectGroup>
               ))}
             </SelectContent>
           </Select>
@@ -1274,7 +1311,7 @@ export function RuntimeLocalSkillImportPanel({
           <div className="flex items-center gap-2 rounded-md border bg-muted/20 px-3 py-1.5 text-xs text-muted-foreground">
             <HardDrive className="h-3.5 w-3.5 shrink-0" />
             <span className="min-w-0 flex-1 truncate">
-              {runtimeLabel(selectedRuntime)}
+              {runtimeDisplayLabel(selectedRuntime)}
             </span>
             <Badge
               variant={

--- a/packages/views/skills/components/skill-detail-page.tsx
+++ b/packages/views/skills/components/skill-detail-page.tsx
@@ -38,7 +38,11 @@ import {
   workspaceKeys,
 } from "@multica/core/workspace/queries";
 import { resolvePublicFileUrl } from "@multica/core/workspace/avatar-url";
-import { runtimeListOptions } from "@multica/core/runtimes";
+import {
+  runtimeDisplayLabel,
+  runtimeDisplayName,
+  runtimeListOptions,
+} from "@multica/core/runtimes";
 import { ActorAvatar } from "@multica/ui/components/common/actor-avatar";
 import { Button, buttonVariants } from "@multica/ui/components/ui/button";
 import {
@@ -223,7 +227,7 @@ function OriginSidebarCard({
       </div>
       {runtime && (
         <div className="mt-1 break-all text-xs text-foreground">
-          {runtime.name}
+          {runtimeDisplayName(runtime)}
         </div>
       )}
       {origin.source_path && (
@@ -562,7 +566,9 @@ export function SkillDetailPage({ skillId }: { skillId: string }) {
     if (!origin) return null;
     if (origin.type === "runtime_local") {
       return originRuntime
-        ? t(($) => $.detail.subline.origin_runtime_named, { name: originRuntime.name })
+        ? t(($) => $.detail.subline.origin_runtime_named, {
+            name: runtimeDisplayLabel(originRuntime),
+          })
         : origin.provider
           ? t(($) => $.detail.subline.origin_runtime_provider, { provider: origin.provider })
           : t(($) => $.detail.subline.origin_runtime_unknown);

--- a/packages/views/skills/components/skills-page.tsx
+++ b/packages/views/skills/components/skills-page.tsx
@@ -29,7 +29,7 @@ import {
   selectSkillAssignments,
   skillListOptions,
 } from "@multica/core/workspace/queries";
-import { runtimeListOptions } from "@multica/core/runtimes";
+import { runtimeDisplayLabel, runtimeListOptions } from "@multica/core/runtimes";
 import { resolvePublicFileUrl } from "@multica/core/workspace/avatar-url";
 import { Button } from "@multica/ui/components/ui/button";
 import { Checkbox } from "@multica/ui/components/ui/checkbox";
@@ -331,7 +331,7 @@ function SourceCell({
   if (origin.type === "runtime_local") {
     icon = <HardDrive className="h-3 w-3 shrink-0" />;
     label = runtime
-      ? t(($) => $.table.source_runtime_named, { name: runtime.name })
+      ? t(($) => $.table.source_runtime_named, { name: runtimeDisplayLabel(runtime) })
       : origin.provider
         ? t(($) => $.table.source_runtime_provider, {
             provider: origin.provider,


### PR DESCRIPTION
## MUL-5248 — Runtime alias display sweeper

Fixes the reported bug (GH #5863): the Skills → New skill → Copy from runtime selector, and several other surfaces, still showed the raw daemon runtime name and ignored the user's `custom_name` alias. Sweeps every confirmed user-facing surface onto the shared alias-aware display contract.

### Display contract applied everywhere

- **`runtimeDisplayLabel(runtime)`** — standalone labels → `alias (Provider)`, falls back to the daemon name when no alias.
- **`runtimeDisplayName(runtime)`** — alias only, used where a provider icon/text already sits beside it (no duplicated provider).
- **`machine.title` + `runtimeRowLabel(runtime, machine.title)`** — inside machine groups; a machine-level alias collapses to the provider base, a per-runtime alias stays visible.

`runtime.name` remains the source of identity for hostname parsing, machine grouping, search haystacks, and protocol payloads only.

### Changed surfaces

**Skills chain**
- `runtime-local-skill-import-panel.tsx` — "Copy from runtime" selector is now **machine-grouped** (`buildRuntimeMachines`) with alias-aware option / trigger / summary; owner/local filtering, offline gating, and import logic unchanged.
- `skills-page.tsx`, `skill-detail-page.tsx` — source column, detail subtitle, and origin card.

**Agents**
- `agent-creation-studio.tsx` (selected-runtime chip), `agent-list-toolbar.tsx` (runtime filter), `agent-overview-summary.tsx`, `tabs/skills-tab.tsx`, `tabs/mcp-config-tab.tsx` (the last two previously read the alias but dropped the provider).

**Runtimes / Desktop / Transcript**
- `runtime-list.tsx` — `RuntimeNameCell` now takes `machineTitle` and uses `runtimeRowLabel`, so a single-runtime alias shows while a machine-level alias isn't repeated per row (threaded from `runtime-detail-page.tsx`).
- `delete-runtime-dialog.tsx` (light + cascade), desktop `runtime-detail-page.tsx` (window titles), `agent-transcript-dialog.tsx` (runtime metadata chip).

**Onboarding**
- `compact-runtime-row.tsx`, `step-runtime-connect.tsx` (card + selected hint), `step-platform-fork.tsx` (selected hint). These already render the provider adjacently, so they use the inline `alias + provider` form (a spec-allowed presentation) rather than machine-group headers.

**Convention**
- `conventions.mdx` / `conventions.zh.mdx` — new "Runtime display names" rule: user-visible copy must not render `runtime.name` directly.

### Tests

- `runtime-machines.test.ts` — `runtimeRowLabel` coverage (no alias, machine-level alias, per-runtime alias).
- `runtime-local-skill-import-panel.test.tsx` — asserts the picker shows `Dev Box (Claude)` and never the old flat `Claude (MacBook) (claude)`.
- Existing helper unit tests in `display.test.ts` already cover fallback / blank alias / special-provider names.
- Fixed the `@multica/core/runtimes` mocks in the skills/mcp tab tests to spread the real module (needed now that the components pull `runtimeDisplayLabel`).

### Verification

- `pnpm --filter @multica/views typecheck` ✅
- `pnpm --filter @multica/desktop typecheck` ✅
- `pnpm --filter @multica/views test` ✅ — 255 files / 2938 tests pass
- eslint on all changed files ✅

Not run: Web/Desktop app smoke (no running app in this environment).

### Scope note

Reused the existing shared logic (`buildRuntimeMachines` / `runtimeRowLabel` / `runtimeDisplay*`) rather than extracting a brand-new shared selector component — the agent runtime picker already uses these, so there's a single source of truth, not a parallel abstraction. Backend, DB, runtime IDs, online status, and import behavior are untouched; mobile shows no runtime names and is out of scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
