### PR TITLE
MUL-5262: add repository setup preflight to agent brief

### DIFF
--- a/server/internal/daemon/execenv/runtime_config_kind_test.go
+++ b/server/internal/daemon/execenv/runtime_config_kind_test.go
@@ -111,6 +111,10 @@ func TestBuildMetaSkillContentSlimKindMatrix(t *testing.T) {
 			kindCommentTriggered: true, kindAssignmentTriggered: true,
 			kindAutopilotRunOnly: true, kindChat: true,
 		}},
+		{"## Repository Setup Preflight", map[taskKind]bool{
+			kindCommentTriggered: true, kindAssignmentTriggered: true,
+			kindAutopilotRunOnly: true, kindChat: true,
+		}},
 		{"## Issue Metadata", issueKinds},
 		{"## Instruction Precedence", map[taskKind]bool{kindAssignmentTriggered: true}},
 		{"## Sub-issue Creation", issueKinds},
@@ -149,6 +153,51 @@ func TestBuildMetaSkillContentSlimKindMatrix(t *testing.T) {
 				t.Errorf("kind=%d: heading %q should NOT be in slim brief (matrix gating regression)", kind, c.heading)
 			}
 		}
+	}
+}
+
+func TestRepositorySetupPreflightIsStackAgnostic(t *testing.T) {
+	t.Parallel()
+
+	var b strings.Builder
+	writeRepositorySetupPreflight(&b)
+	out := b.String()
+
+	for _, want := range []string{
+		"after `multica repo checkout`",
+		"Before editing code or running build/test commands",
+		"`AGENTS.md`, `README`, development docs",
+		"dependency manifests and lockfiles",
+		"missing, stale, or readiness is uncertain",
+		"documented, reproducible setup command",
+		"Do not reinstall when the existing environment is demonstrably ready",
+		"did not unexpectedly modify dependency manifests or lockfiles",
+		"Do not use a failing build or test run",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("repository setup preflight missing %q\n---\n%s", want, out)
+		}
+	}
+
+	for _, packageManager := range []string{"pnpm", "npm install", "yarn", "bun install", "pip install", "poetry", "cargo"} {
+		if strings.Contains(strings.ToLower(out), packageManager) {
+			t.Errorf("repository setup preflight must stay stack-agnostic; found %q\n---\n%s", packageManager, out)
+		}
+	}
+
+	brief := buildMetaSkillContent("codex", TaskContextForEnv{
+		IssueID: "issue-1",
+		Repos:   []RepoContextForEnv{{URL: "https://example.com/repo.git"}},
+	})
+	repositoriesIndex := strings.Index(brief, "\n## Repositories\n")
+	preflightIndex := strings.Index(brief, "\n## Repository Setup Preflight\n")
+	if repositoriesIndex == -1 || preflightIndex <= repositoriesIndex {
+		t.Errorf("repository setup preflight must follow repository checkout guidance\n---\n%s", brief)
+	}
+
+	localBrief := buildMetaSkillContent("codex", TaskContextForEnv{IssueID: "issue-1"})
+	if !strings.Contains(localBrief, "\n## Repository Setup Preflight\n") {
+		t.Errorf("repository setup preflight must also cover an existing local working directory\n---\n%s", localBrief)
 	}
 }
 

--- a/server/internal/daemon/execenv/runtime_config_sections.go
+++ b/server/internal/daemon/execenv/runtime_config_sections.go
@@ -30,8 +30,8 @@ import (
 //  2. Per-section prose compression — Available Commands, Issue
 //     Metadata, Mentions, Sub-issue Creation, Comment Formatting,
 //     Always Use CLI, Background Task Safety, Task Initiator,
-//     Repositories, Output are all tightened. Every test-asserted phrase
-//     stays.
+//     Repositories, Repository Setup Preflight, Output are all
+//     tightened. Every test-asserted phrase stays.
 //
 // Background Task Safety is emitted by `writeBackgroundTaskSafetySlim`
 // below.
@@ -283,6 +283,20 @@ func writeRepositories(b *strings.Builder, ctx TaskContextForEnv) {
 		}
 	}
 	b.WriteString("\n")
+}
+
+// writeRepositorySetupPreflight emits a stack-agnostic readiness check for
+// every task surface that can perform repository work. It deliberately asks
+// the agent to infer the repository's own setup contract instead of naming a
+// package manager or forcing a reinstall on a warm workdir.
+func writeRepositorySetupPreflight(b *strings.Builder) {
+	b.WriteString("## Repository Setup Preflight\n\n")
+	b.WriteString("Before editing code or running build/test commands in a repository (after `multica repo checkout`, or immediately when working in an existing local directory):\n\n")
+	b.WriteString("- Read the repository instructions and setup documentation (`AGENTS.md`, `README`, development docs), plus the relevant dependency manifests and lockfiles.\n")
+	b.WriteString("- Identify the stack and package/dependency manager, then determine whether the required dependencies and tools are already usable.\n")
+	b.WriteString("- If dependencies are missing, stale, or readiness is uncertain, run the repository's documented, reproducible setup command before proceeding. Do not reinstall when the existing environment is demonstrably ready.\n")
+	b.WriteString("- Check that setup did not unexpectedly modify dependency manifests or lockfiles; investigate unexpected changes before continuing.\n")
+	b.WriteString("- Do not use a failing build or test run as the way to discover that dependencies were not prepared.\n\n")
 }
 
 // writeProjectContext emits the Project Context section when the task carries
@@ -626,6 +640,7 @@ func writeOutput(b *strings.Builder, kind taskKind, ctx TaskContextForEnv) {
 //	Comment Formatting    |    ✓    |   ✓    |     —     |      —       |  —
 //	Repositories          |    △    |   △    |     △     |      —       |  △
 //	Project Context       |    △    |   △    |     △     |      △       |  △
+//	Repository Preflight |    ✓    |   ✓    |     ✓     |      —       |  ✓
 //	Issue Metadata        |    ✓    |   ✓    |     —     |      —       |  —
 //	Instruction Precedence|    —    |   ✓    |     —     |      —       |  —
 //	Sub-issue Creation    |    ✓    |   ✓    |     —     |      —       |  —
@@ -666,6 +681,10 @@ func buildMetaSkillContentSlim(provider string, ctx TaskContextForEnv) string {
 	}
 
 	writeProjectContext(&b, ctx)
+
+	if kind != kindQuickCreate {
+		writeRepositorySetupPreflight(&b)
+	}
 
 	if kind.hasIssueContext() {
 		writeIssueMetadata(&b)


### PR DESCRIPTION
## Summary

- add a stack-agnostic repository setup preflight to every repository-capable runtime brief
- tell agents to inspect repository instructions, manifests, and lockfiles and prepare missing or stale dependencies before editing, building, or testing
- preserve warm environments by checking readiness instead of blindly reinstalling dependencies

## Tests

- `go test ./internal/daemon/... -count=1`
- `git diff --check`

Closes MUL-5262
