### PR TITLE
fix(agents): mark shadowed runtime skills overridden

### DIFF
--- a/packages/views/agents/components/tabs/skills-tab.test.tsx
+++ b/packages/views/agents/components/tabs/skills-tab.test.tsx
@@ -212,6 +212,90 @@ describe("SkillsTab", () => {
     expect(screen.getByText("Host-level review workflow")).toBeInTheDocument();
   });
 
+  it("shows a normalized duplicate inherited skill as overridden", async () => {
+    mockRuntimeCapabilities.mockResolvedValue({
+      skills: [
+        {
+          key: "review_changes",
+          name: "review_changes",
+          source_path: "~/.codex/skills/review_changes",
+          provider: "codex",
+          root: "provider",
+          can_disable: true,
+          file_count: 1,
+        },
+      ],
+      supported: true,
+      mcpServers: [],
+      mcpSupported: true,
+    });
+
+    renderSkillsTab(
+      {
+        skills: [
+          {
+            id: "skill-1",
+            name: " Review changes ",
+            description: "Workspace review workflow",
+            enabled: true,
+          },
+        ],
+      },
+      onlineRuntime,
+    );
+
+    const inheritedSwitch = await screen.findByRole("switch", {
+      name: /Toggle inherited review_changes/i,
+    });
+    expect(inheritedSwitch).not.toBeChecked();
+    expect(inheritedSwitch).toHaveAttribute("aria-disabled", "true");
+    expect(
+      screen.getByText("Overridden by assigned skill"),
+    ).toBeInTheDocument();
+  });
+
+  it("keeps a matching inherited skill enabled when the assignment is off", async () => {
+    mockRuntimeCapabilities.mockResolvedValue({
+      skills: [
+        {
+          key: "local-review",
+          name: "Local review",
+          source_path: "~/.codex/skills/local-review",
+          provider: "codex",
+          root: "provider",
+          can_disable: true,
+          file_count: 1,
+        },
+      ],
+      supported: true,
+      mcpServers: [],
+      mcpSupported: true,
+    });
+
+    renderSkillsTab(
+      {
+        skills: [
+          {
+            id: "skill-1",
+            name: "Local review",
+            description: "Workspace review workflow",
+            enabled: false,
+          },
+        ],
+      },
+      onlineRuntime,
+    );
+
+    expect(
+      await screen.findByRole("switch", {
+        name: /Toggle inherited Local review/i,
+      }),
+    ).toBeChecked();
+    expect(
+      screen.queryByText("Overridden by assigned skill"),
+    ).not.toBeInTheDocument();
+  });
+
   it("turns a controllable inherited skill off for this agent", async () => {
     const user = userEvent.setup();
     mockRuntimeCapabilities.mockResolvedValue({

--- a/packages/views/agents/components/tabs/skills-tab.tsx
+++ b/packages/views/agents/components/tabs/skills-tab.tsx
@@ -136,6 +136,11 @@ export function SkillsTab({
   };
 
   const runtimeSkills = runtimeQuery.data?.skills ?? [];
+  const assignedSkillNames = new Set(
+    agent.skills
+      .filter((skill) => skill.enabled !== false)
+      .map((skill) => normalizeSkillName(skill.name)),
+  );
 
   return (
     <div className="space-y-8">
@@ -278,11 +283,16 @@ export function SkillsTab({
         ) : (
           <ul className="divide-y rounded-lg border bg-surface-raised/40">
             {runtimeSkills.map((skill) => {
-              const disabled = isRuntimeSkillDisabled(
-                agent.disabled_runtime_skills,
-                runtime?.id,
-                skill,
+              const overridden = assignedSkillNames.has(
+                normalizeSkillName(skill.name),
               );
+              const disabled =
+                overridden ||
+                isRuntimeSkillDisabled(
+                  agent.disabled_runtime_skills,
+                  runtime?.id,
+                  skill,
+                );
               const busyKey = runtimeSkillIdentity(skill);
               const busy = busyId === busyKey;
               return (
@@ -317,14 +327,20 @@ export function SkillsTab({
                       </span>
                     </span>
                   </button>
+                  {overridden && (
+                    <Badge variant="outline">
+                      {t(($) => $.tab_body.skills.runtime_overridden_badge)}
+                    </Badge>
+                  )}
                   {canEdit &&
-                    skill.can_disable === true &&
-                    skill.root &&
-                    (busy ? (
+                    (overridden ||
+                      (skill.can_disable === true && Boolean(skill.root))) &&
+                    (busy && !overridden ? (
                       <Loader2 className="h-4 w-4 animate-spin text-muted-foreground motion-reduce:animate-none" />
                     ) : (
                       <Switch
                         checked={!disabled}
+                        disabled={overridden}
                         onCheckedChange={(checked) =>
                           handleRuntimeToggle(skill, checked)
                         }
@@ -354,6 +370,16 @@ export function SkillsTab({
 
 function runtimeSkillIdentity(skill: RuntimeLocalSkillSummary): string {
   return `runtime:${skill.root ?? "unknown"}:${skill.key}:${skill.plugin ?? ""}`;
+}
+
+function normalizeSkillName(name: string): string {
+  // Keep this in sync with execenv.sanitizeSkillName in the daemon.
+  const normalized = name
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+  return normalized || "skill";
 }
 
 function isRuntimeSkillDisabled(

--- a/packages/views/locales/en/agents.json
+++ b/packages/views/locales/en/agents.json
@@ -605,6 +605,7 @@
       "toggle_failed_toast": "Failed to change skill status",
       "runtime_toggle_aria": "Toggle inherited {{name}}",
       "runtime_toggle_failed_toast": "Failed to change inherited skill status",
+      "runtime_overridden_badge": "Overridden by assigned skill",
       "runtime_missing": "Assign a local runtime to discover inherited skills.",
       "runtime_offline": "The local runtime is offline. Reconnect it to refresh inherited skills.",
       "runtime_discovering": "Discovering skills from the local runtime…",

--- a/packages/views/locales/ja/agents.json
+++ b/packages/views/locales/ja/agents.json
@@ -489,6 +489,7 @@
       "toggle_failed_toast": "スキルの状態を変更できませんでした",
       "runtime_toggle_aria": "継承した {{name}} の有効・無効を切り替え",
       "runtime_toggle_failed_toast": "継承スキルの状態を変更できませんでした",
+      "runtime_overridden_badge": "割り当て済みスキルが優先",
       "runtime_missing": "継承スキルを検出するには、ローカルランタイムを割り当ててください。",
       "runtime_offline": "ローカルランタイムはオフラインです。再接続すると更新できます。",
       "runtime_discovering": "ローカルランタイムからスキルを検出中…",

--- a/packages/views/locales/ko/agents.json
+++ b/packages/views/locales/ko/agents.json
@@ -497,6 +497,7 @@
       "toggle_failed_toast": "스킬 상태를 변경하지 못했습니다",
       "runtime_toggle_aria": "상속된 {{name}} 켜기 또는 끄기",
       "runtime_toggle_failed_toast": "상속된 스킬 상태를 변경하지 못했습니다",
+      "runtime_overridden_badge": "할당된 스킬이 우선 적용됨",
       "runtime_missing": "상속된 스킬을 탐색하려면 로컬 런타임을 할당하세요.",
       "runtime_offline": "로컬 런타임이 오프라인입니다. 다시 연결하면 새로고침할 수 있습니다.",
       "runtime_discovering": "로컬 런타임에서 스킬을 탐색하는 중…",

--- a/packages/views/locales/zh-Hans/agents.json
+++ b/packages/views/locales/zh-Hans/agents.json
@@ -594,6 +594,7 @@
       "toggle_failed_toast": "修改 skill 状态失败",
       "runtime_toggle_aria": "启用或关闭继承的 {{name}}",
       "runtime_toggle_failed_toast": "修改继承 skill 状态失败",
+      "runtime_overridden_badge": "分配的 skill 优先",
       "runtime_missing": "请先分配一个本地运行时，以发现继承的 skill。",
       "runtime_offline": "本地运行时处于离线状态，重新连接后即可刷新继承的 skill。",
       "runtime_discovering": "正在从本地运行时发现 skill…",


### PR DESCRIPTION
## What does this PR do?

Shows inherited runtime skills as overridden when an enabled workspace skill assigned to the agent claims the same normalized name.

The runtime row now:

- renders its switch off and disabled
- shows an `Overridden by assigned skill` badge
- uses the daemon's trim/lowercase/non-alphanumeric normalization semantics

Only enabled workspace assignments claim a name, so turning the workspace skill off leaves a matching inherited skill available unless it has its own persisted runtime override.

## Related Issue

Closes #5897

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Refactor / code improvement (no behavior change)
- [ ] Documentation update
- [x] Tests (adding or improving test coverage)
- [ ] CI / infrastructure

## Changes Made

- Updated `packages/views/agents/components/tabs/skills-tab.tsx` to derive shadowed inherited skills from enabled workspace assignments.
- Added regression coverage for normalized name collisions and disabled workspace assignments.
- Added the override badge copy to English, Japanese, Korean, and Simplified Chinese locales.

## How to Test

1. Assign a workspace skill to an agent whose local runtime exposes a skill with the same normalized name.
2. Open the agent's Capabilities tab and confirm the inherited row is off, disabled, and labeled `Overridden by assigned skill`.
3. Turn the workspace assignment off and confirm the inherited row becomes available again unless it has a separate runtime-skill override.

Automated checks:

- `pnpm --filter @multica/views test` — 258 files, 2,985 tests passed
- `pnpm --filter @multica/views typecheck`
- `pnpm --filter @multica/views lint` — 0 errors (15 pre-existing warnings outside this change)
- `git diff --check`

## Thinking Path

The daemon already gives an enabled workspace skill precedence over a same-named inherited skill, but the Capabilities UI only consulted persisted runtime-skill disable records. The fix mirrors the daemon's skill-name sanitizer in the view, derives the active assigned-name set, and folds that effective override into the inherited row's disabled state. Keeping disabled workspace assignments out of the set preserves the actual execution behavior.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] If this change affects the UI, I have included before/after screenshots
- [x] I have updated relevant documentation to reflect my changes (no documentation change required)
- [x] If I added a new runtime / coding tool / UI tab, I synced the change to **landing copy** (`apps/web/features/landing/i18n/`) and **relevant docs** (`apps/docs/content/docs/`) (not applicable)
- [x] If this PR touches Chinese product copy, I checked it against `apps/docs/content/docs/developers/conventions.zh.mdx` (terminology, mixed-rule for `task` / `issue` / `skill`)
- [x] I have considered and documented any risks above
- [x] I will address all reviewer comments before requesting merge

Risk is limited to UI state derivation. The duplicated normalizer is intentionally documented as matching `execenv.sanitizeSkillName` and covered with a punctuation/case regression test.

## AI Disclosure

**AI tool used:** OpenAI Codex through a Multica agent

**Prompt / approach:**

The agent received issue #5897 and the requested contribution workflow. It inspected the runtime shadowing implementation, mirrored its normalization semantics in the shared view, added behavioral and i18n parity coverage, and ran the shared-views verification suite.

The After visual below is an AI-generated edit of the Before screenshot and is explicitly labeled as a mockup rather than a runtime capture.

## Screenshots

### Before

![Both assigned and inherited skills appear enabled](https://github.com/user-attachments/assets/227e474a-24a2-481f-805c-c8707c9df335)

### After

> **Mockup — not a runtime capture.** Generated from the Before image because this agent run had no available browser surface. It illustrates the component state asserted by the regression test: matching inherited skills are muted, their switches are off and disabled, and each row shows the override badge.

![Mocked after state showing inherited skills disabled and labeled as overridden](https://raw.githubusercontent.com/Tr0sT/multica/trs-132-pr-assets/.github/pr-assets/trs-132-after-mock.png)
