### PR TITLE
fix(agent/codex): ignore user echoes as progress (MUL-5277)

### DIFF
--- a/server/pkg/agent/codex.go
+++ b/server/pkg/agent/codex.go
@@ -1929,7 +1929,16 @@ func codexFirstTurnNoProgressTimeout(semanticInactivityTimeout time.Duration) ti
 }
 
 func isCodexFirstTurnProgressActivity(activity string) bool {
-	return activity != "" && activity != "status:running" && activity != "error:retry"
+	if activity == "" || activity == "status:running" || activity == "error:retry" {
+		return false
+	}
+	// Codex 0.145 emits item/started + item/completed for the submitted
+	// userMessage before it has connected to the responses backend. That is
+	// only a local input echo: treating it as agent progress disables the
+	// first-turn watchdog and turns a model-catalog/network failure into a
+	// long, silent reconnect loop.
+	parts := strings.SplitN(activity, ":", 3)
+	return len(parts) < 2 || !strings.HasPrefix(parts[0], "item/") || parts[1] != "userMessage"
 }
 
 func buildCodexTimeoutDiagnosticError(diag codexTimeoutDiagnostic, stderrTail string) string {
@@ -3087,7 +3096,7 @@ func (c *codexClient) handleItemNotification(method string, params map[string]an
 	item, _ := params["item"].(map[string]any)
 	itemType, _ := item["type"].(string)
 	itemID, _ := item["id"].(string)
-	if isCodexItemProgressActivity(method) && c.onSemanticActivity != nil {
+	if isCodexItemProgressActivity(method, itemType) && c.onSemanticActivity != nil {
 		c.onSemanticActivity(describeCodexItemProgressActivity(method, itemType, itemID))
 	}
 	if item == nil {
@@ -3162,8 +3171,11 @@ func (c *codexClient) handleItemNotification(method string, params map[string]an
 	}
 }
 
-func isCodexItemProgressActivity(method string) bool {
-	return strings.HasPrefix(method, "item/")
+func isCodexItemProgressActivity(method, itemType string) bool {
+	// userMessage notifications acknowledge local input only. They do not
+	// prove the provider connection is healthy and must not reset either the
+	// semantic-inactivity timer or the first-turn no-progress watchdog.
+	return strings.HasPrefix(method, "item/") && itemType != "userMessage"
 }
 
 func describeCodexItemProgressActivity(method, itemType, itemID string) string {

--- a/server/pkg/agent/codex_test.go
+++ b/server/pkg/agent/codex_test.go
@@ -716,6 +716,12 @@ func TestCodexFirstTurnProgressActivity(t *testing.T) {
 		{activity: "", want: false},
 		{activity: "status:running", want: false},
 		{activity: "error:retry", want: false},
+		// Codex 0.145 echoes the submitted prompt as userMessage items before
+		// it has connected to the responses backend. Those echoes prove only
+		// that app-server accepted local input; they are not agent progress
+		// and must not disable the first-turn no-progress watchdog.
+		{activity: "item/started:userMessage:user-1", want: false},
+		{activity: "item/completed:userMessage:user-1", want: false},
 		{activity: "error", want: true},
 		{activity: "text", want: true},
 		{activity: "tool-use:exec_command", want: true},
@@ -730,6 +736,57 @@ func TestCodexFirstTurnProgressActivity(t *testing.T) {
 		t.Run(tc.activity, func(t *testing.T) {
 			if got := isCodexFirstTurnProgressActivity(tc.activity); got != tc.want {
 				t.Fatalf("isCodexFirstTurnProgressActivity(%q) = %v, want %v", tc.activity, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestCodexItemProgressActivity(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name     string
+		method   string
+		itemType string
+		want     bool
+	}{
+		{
+			name:     "user message started is local echo",
+			method:   "item/started",
+			itemType: "userMessage",
+			want:     false,
+		},
+		{
+			name:     "user message completed is local echo",
+			method:   "item/completed",
+			itemType: "userMessage",
+			want:     false,
+		},
+		{
+			name:     "agent message is progress",
+			method:   "item/completed",
+			itemType: "agentMessage",
+			want:     true,
+		},
+		{
+			name:     "command output delta is progress",
+			method:   "item/commandExecution/outputDelta",
+			itemType: "commandExecution",
+			want:     true,
+		},
+		{
+			name:     "non-item notification is not progress",
+			method:   "turn/started",
+			itemType: "",
+			want:     false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := isCodexItemProgressActivity(tc.method, tc.itemType); got != tc.want {
+				t.Fatalf("isCodexItemProgressActivity(%q, %q) = %v, want %v",
+					tc.method, tc.itemType, got, tc.want)
 			}
 		})
 	}
@@ -3112,6 +3169,61 @@ func TestCodexExecuteFirstItemWaitLifecycle(t *testing.T) {
 			}
 		}
 	})
+}
+
+func TestCodexExecuteCatalogRefreshRetryAfterUserMessageEcho(t *testing.T) {
+	// Not t.Parallel(): this test shrinks the process cleanup grace globally.
+	if runtime.GOOS == "windows" {
+		t.Skip("shell-script fixture is POSIX-only")
+	}
+	codexGracefulShutdownTimeoutNanos.Store(int64(100 * time.Millisecond))
+	t.Cleanup(func() { codexGracefulShutdownTimeoutNanos.Store(0) })
+
+	// Regression fixture for the observed codex-cli 0.145 sequence:
+	// app-server accepts the turn, echoes the submitted user message, reports
+	// retrying transport errors, and never produces agent output. The local
+	// echo must not suppress the catalog-refresh retry contract above.
+	fakePath := writeFakeCodexAppServer(t, ""+
+		`DIR="$(dirname "$0")"`+"\n"+
+		`ATTEMPT=$(cat "$DIR/attempts" 2>/dev/null || echo 0)`+"\n"+
+		`ATTEMPT=$((ATTEMPT+1))`+"\n"+
+		`echo "$ATTEMPT" > "$DIR/attempts"`+"\n"+
+		`read line`+"\n"+
+		`echo '{"jsonrpc":"2.0","id":1,"result":{}}'`+"\n"+
+		`read line`+"\n"+
+		`read line`+"\n"+
+		`if [ "$ATTEMPT" = "1" ]; then`+"\n"+
+		`  echo '{"jsonrpc":"2.0","id":2,"result":{"thread":{"id":"thr-echo-stuck"}}}'`+"\n"+
+		`  read line`+"\n"+
+		`  echo '{"jsonrpc":"2.0","id":3,"result":{}}'`+"\n"+
+		`  echo '{"jsonrpc":"2.0","method":"turn/started","params":{"threadId":"thr-echo-stuck","turn":{"id":"turn-echo-stuck"}}}'`+"\n"+
+		`  echo '{"jsonrpc":"2.0","method":"item/started","params":{"threadId":"thr-echo-stuck","item":{"type":"userMessage","id":"user-echo"}}}'`+"\n"+
+		`  echo '{"jsonrpc":"2.0","method":"item/completed","params":{"threadId":"thr-echo-stuck","item":{"type":"userMessage","id":"user-echo"}}}'`+"\n"+
+		`  echo '{"jsonrpc":"2.0","method":"error","params":{"threadId":"thr-echo-stuck","error":{"message":"Reconnecting... 2/5"},"willRetry":true}}'`+"\n"+
+		`  echo 'ERROR codex_models_manager::manager: failed to refresh available models: timeout waiting for child process to exit' >&2`+"\n"+
+		`  sleep 2`+"\n"+
+		`else`+"\n"+
+		`  echo '{"jsonrpc":"2.0","id":2,"result":{"thread":{"id":"thr-echo-recovered"}}}'`+"\n"+
+		`  read line`+"\n"+
+		`  echo '{"jsonrpc":"2.0","id":3,"result":{}}'`+"\n"+
+		`  echo '{"jsonrpc":"2.0","method":"turn/started","params":{"threadId":"thr-echo-recovered","turn":{"id":"turn-echo-recovered"}}}'`+"\n"+
+		`  echo '{"jsonrpc":"2.0","method":"item/completed","params":{"threadId":"thr-echo-recovered","item":{"type":"agentMessage","id":"msg-recovered","text":"Recovered after echo"}}}'`+"\n"+
+		`  echo '{"jsonrpc":"2.0","method":"turn/completed","params":{"threadId":"thr-echo-recovered","turn":{"id":"turn-echo-recovered","status":"completed"}}}'`+"\n"+
+		`fi`+"\n")
+
+	result := executeFakeCodex(t, fakePath, ExecOptions{
+		Timeout:                   10 * time.Second,
+		SemanticInactivityTimeout: 100 * time.Millisecond,
+	})
+	if result.Status != "completed" {
+		t.Fatalf("user-message echo must not suppress catalog retry: status=%q error=%q", result.Status, result.Error)
+	}
+	if result.Output != "Recovered after echo" {
+		t.Fatalf("expected output from the recovered attempt, got %q", result.Output)
+	}
+	if result.SessionID != "thr-echo-recovered" {
+		t.Fatalf("expected the recovered thread id, got %q", result.SessionID)
+	}
 }
 
 func TestCodexExecuteFailsWhenProcessExitsDuringActiveTurn(t *testing.T) {


### PR DESCRIPTION
## What does this PR do?

Prevents Codex `userMessage` item notifications from being treated as agent progress.

Codex CLI 0.145 echoes the submitted prompt with `item/started` and `item/completed` notifications before it has established a working responses connection. Multica previously treated those local acknowledgements as semantic and first-turn progress. That disabled the model-catalog recovery added in #5734 and left the task in a reconnect loop until the broader inactivity timeout fired.

This change excludes only `userMessage` items. Agent messages, command execution, file changes, tool activity, completion, and non-retryable errors continue to count as progress.

Risk is limited to Codex first-turn/inactivity classification. The main behavioral risk would be timing out a turn that emits only a local prompt echo; that is intentional because such an echo does not demonstrate provider progress.

## Related Issue

Closes #5901

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Refactor / code improvement (no behavior change)
- [ ] Documentation update
- [x] Tests (adding or improving test coverage)
- [ ] CI / infrastructure

## Changes Made

- Update `server/pkg/agent/codex.go` so `item/*:userMessage` does not reset semantic inactivity or mark the first turn as having model progress.
- Add classifier coverage for `userMessage` start/completion events.
- Add an app-server regression fixture matching the Codex 0.145 sequence: turn start, local prompt echo, retryable transport error, model-catalog refresh timeout, then successful recovery on a fresh process/thread.

## How to Test

1. Run `cd server && go test ./pkg/agent -run '^TestCodex' -count=1`.
2. Confirm `TestCodexExecuteCatalogRefreshRetryAfterUserMessageEcho` retries after the first stuck attempt.
3. Confirm the recovered attempt completes with output from a fresh thread.

Local result:

```text
ok github.com/multica-ai/multica/server/pkg/agent 60.966s
```

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [ ] I have updated relevant documentation to reflect my changes
- [ ] If I added a new runtime / coding tool / UI tab, I synced the change to **landing copy** (`apps/web/features/landing/i18n/`) and **relevant docs** (`apps/docs/content/docs/`)
- [ ] If this PR touches Chinese product copy, I checked it against `apps/docs/content/docs/developers/conventions.zh.mdx` (terminology, mixed-rule for `task` / `issue` / `skill`)
- [x] I have considered and documented any risks above
- [x] I will address all reviewer comments before requesting merge

## AI Disclosure

**AI tool used:** OpenAI Codex

**Prompt / approach:**

Investigated daemon and Codex app-server logs, compared the observed Codex 0.145 notification sequence with Multica's semantic-inactivity and first-turn recovery state machine, added a regression test before the implementation, then verified the complete Codex test suite. Upstream commits #5734 and #5759 were reviewed to keep this change scoped to the uncovered local-user-echo case.

## Screenshots (optional)

Not applicable; this is a backend runtime behavior change covered by an app-server fixture.
