### PR TITLE
fix(lark): recover replies rejected by content audit

### DIFF
--- a/server/internal/integrations/lark/http_client.go
+++ b/server/internal/integrations/lark/http_client.go
@@ -60,6 +60,11 @@ const (
 	// open.feishu.cn/document/server-docs/api-call-guide/server-error-codes.
 	codeTokenExpired = 99991663
 	codeTokenInvalid = 99991664
+
+	// codeMessageAuditRejected means Lark definitively rejected an outbound
+	// message during content auditing. No message was delivered, so callers
+	// may safely retry after removing the rejected content.
+	codeMessageAuditRejected = 230028
 )
 
 // HTTPClientConfig configures the production Lark HTTP APIClient.
@@ -920,6 +925,17 @@ func (c *httpAPIClient) doJSON(ctx context.Context, baseURL, method, path, token
 		return fmt.Errorf("read body: %w", err)
 	}
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		var apiResp struct {
+			Code int    `json:"code"`
+			Msg  string `json:"msg"`
+		}
+		if err := json.Unmarshal(rawBody, &apiResp); err == nil && apiResp.Code != 0 {
+			return &APIError{
+				HTTPStatus: resp.StatusCode,
+				Code:       apiResp.Code,
+				Msg:        apiResp.Msg,
+			}
+		}
 		return fmt.Errorf("http %d: %s", resp.StatusCode, truncate(string(rawBody), 512))
 	}
 	if out != nil && len(rawBody) > 0 {
@@ -934,22 +950,26 @@ func isTokenError(code int) bool {
 	return code == codeTokenExpired || code == codeTokenInvalid
 }
 
-// APIError is a structured Lark business error: the request reached
-// Lark, returned HTTP 200, but Lark rejected it with a non-zero
-// `code`. This is distinct from the transport-level errors doJSON
-// surfaces (network failure, 5xx, timeout), which are returned as
-// plain wrapped errors. The distinction matters for the threaded-reply
-// fallback: a business code is definitive ("nothing was sent, and here
-// is exactly why"), whereas a transport error is ambiguous ("the
-// message may or may not have been delivered") and must NOT trigger a
-// chat-level retry that could duplicate or leak the reply.
+// APIError is a structured Lark business error: the request reached Lark and
+// Lark rejected it with a non-zero code. Lark usually returns business errors
+// in an HTTP 200 response, but some IM content-audit errors arrive as HTTP 400;
+// HTTPStatus preserves that distinction without losing the Lark code. This is
+// distinct from transport-level errors (network failure, unstructured 5xx,
+// timeout), which remain plain wrapped errors.
 type APIError struct {
-	Op   string
-	Code int
-	Msg  string
+	Op         string
+	HTTPStatus int
+	Code       int
+	Msg        string
 }
 
 func (e *APIError) Error() string {
+	if e.HTTPStatus != 0 {
+		if e.Op == "" {
+			return fmt.Sprintf("lark http client: http %d code=%d msg=%q", e.HTTPStatus, e.Code, e.Msg)
+		}
+		return fmt.Sprintf("lark http client: %s: http %d code=%d msg=%q", e.Op, e.HTTPStatus, e.Code, e.Msg)
+	}
 	return fmt.Sprintf("lark http client: %s: code=%d msg=%q", e.Op, e.Code, e.Msg)
 }
 
@@ -972,17 +992,30 @@ var threadReplyUnsupportedCodes = map[int]struct{}{
 	230111: {}, // cannot reply to a self-destructing message
 }
 
-// isThreadReplyUnsupported reports whether err is a Lark APIError whose
-// code means the threaded reply cannot land on this target. Only such
-// errors are safe to retry at the chat level. Transport errors and
-// other business codes return false.
-func isThreadReplyUnsupported(err error) bool {
+func larkErrorCode(err error) (int, bool) {
 	var apiErr *APIError
 	if errors.As(err, &apiErr) {
-		_, ok := threadReplyUnsupportedCodes[apiErr.Code]
-		return ok
+		return apiErr.Code, true
 	}
-	return false
+	return 0, false
+}
+
+func isMessageAuditRejected(err error) bool {
+	code, ok := larkErrorCode(err)
+	return ok && code == codeMessageAuditRejected
+}
+
+// isThreadReplyUnsupported reports whether err is a Lark APIError whose code
+// means the threaded reply cannot land on this target. Only such errors are
+// safe to retry at the chat level. Transport errors and other business codes
+// return false.
+func isThreadReplyUnsupported(err error) bool {
+	code, ok := larkErrorCode(err)
+	if !ok {
+		return false
+	}
+	_, ok = threadReplyUnsupportedCodes[code]
+	return ok
 }
 
 func truncate(s string, n int) string {

--- a/server/internal/integrations/lark/http_client_test.go
+++ b/server/internal/integrations/lark/http_client_test.go
@@ -1109,8 +1109,8 @@ func TestHTTPClient_GetBotInfo_HappyPath(t *testing.T) {
 			"code": 0,
 			"msg":  "ok",
 			"bot": map[string]any{
-				"open_id":   "ou_bot_42",
-				"app_name":  "PersonalAgent",
+				"open_id":    "ou_bot_42",
+				"app_name":   "PersonalAgent",
 				"avatar_url": "https://example/avatar.png",
 			},
 		})
@@ -1231,6 +1231,43 @@ func TestHTTPClient_BadHTTPStatus(t *testing.T) {
 	})
 	if err == nil || !strings.Contains(err.Error(), "http 500") {
 		t.Errorf("want http 500 surfaced, got %v", err)
+	}
+}
+
+func TestHTTPClient_BadHTTPStatusWithLarkCodeReturnsTypedAPIError(t *testing.T) {
+	fake := newLarkFake(t)
+	fake.stubToken("tok", 7200)
+	fake.mux.HandleFunc("/open-apis/im/v1/messages", func(w http.ResponseWriter, r *http.Request) {
+		fake.sendN.Add(1)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusBadRequest)
+		writeJSON(w, map[string]any{
+			"code": codeMessageAuditRejected,
+			"msg":  "The messages do NOT pass the audit, ext=contain sensitive data: EMAIL_ADDRESS",
+		})
+	})
+
+	c := newTestClient(fake, time.Now)
+	_, err := c.SendMarkdownCard(context.Background(), SendMarkdownCardParams{
+		InstallationID: testCreds(),
+		ChatID:         ChatID("oc"),
+		Markdown:       "# Result\n\nperson@example.com",
+	})
+	if err == nil {
+		t.Fatal("want content audit error")
+	}
+	var apiErr *APIError
+	if !errors.As(err, &apiErr) {
+		t.Fatalf("want *APIError, got %T (%v)", err, err)
+	}
+	if apiErr.HTTPStatus != http.StatusBadRequest {
+		t.Errorf("HTTPStatus = %d, want %d", apiErr.HTTPStatus, http.StatusBadRequest)
+	}
+	if apiErr.Code != codeMessageAuditRejected {
+		t.Errorf("Code = %d, want %d", apiErr.Code, codeMessageAuditRejected)
+	}
+	if !isMessageAuditRejected(err) {
+		t.Errorf("expected content audit classifier to recognize %v", err)
 	}
 }
 

--- a/server/internal/integrations/lark/outbound.go
+++ b/server/internal/integrations/lark/outbound.go
@@ -6,11 +6,13 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"regexp"
 	"time"
 
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgtype"
 	"github.com/multica-ai/multica/server/internal/events"
+	"github.com/multica-ai/multica/server/internal/util"
 	db "github.com/multica-ai/multica/server/pkg/db/generated"
 	"github.com/multica-ai/multica/server/pkg/protocol"
 )
@@ -24,7 +26,12 @@ const (
 	CardStatusStreaming CardStatus = "streaming"
 	CardStatusFinal     CardStatus = "final"
 	CardStatusError     CardStatus = "error"
+
+	larkEmailRedactionPlaceholder = "[邮箱已隐藏]"
+	larkContentAuditFallbackText  = "回复包含飞书无法发送的敏感信息。请移除邮箱等内容后重试，或在 Multica 中查看完整回复。"
 )
+
+var larkEmailAddressPattern = regexp.MustCompile(`(?i)\b[A-Z0-9._%+\-]+@[A-Z0-9.\-]+\.[A-Z]{2,63}\b`)
 
 // CardKind enumerates the small set of card variants the patcher
 // renders. The Renderer is plug-replaceable so the on-wire card
@@ -269,10 +276,11 @@ func (p *Patcher) handleEvent(e events.Event) {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 	if err := p.processEvent(ctx, e); err != nil {
+		taskID, chatSessionID, _ := taskAndSessionFromEvent(e)
 		p.cfg.Logger.Warn("lark patcher: event handling failed",
 			"event_type", e.Type,
-			"task_id", e.TaskID,
-			"chat_session_id", e.ChatSessionID,
+			"task_id", util.UUIDToString(taskID),
+			"chat_session_id", util.UUIDToString(chatSessionID),
 			"error", err,
 		)
 	}
@@ -336,7 +344,7 @@ func (p *Patcher) processEvent(ctx context.Context, e events.Event) error {
 
 	switch e.Type {
 	case protocol.EventChatDone:
-		return p.sendChatReply(ctx, creds, binding, e.Payload)
+		return p.sendChatReply(ctx, creds, binding, taskID, e.Payload)
 	case protocol.EventTaskFailed:
 		return p.fail(ctx, creds, binding, taskID, agentName, e.Payload)
 	}
@@ -365,11 +373,53 @@ func (p *Patcher) processEvent(ctx context.Context, e events.Event) error {
 // the task without producing visible output, which only happens for
 // edge cases like a chat task that just acknowledged a system event;
 // not emitting a message there is the right product call.
-func (p *Patcher) sendChatReply(ctx context.Context, creds InstallationCredentials, binding ChatSessionBinding, payload any) error {
+func (p *Patcher) sendChatReply(ctx context.Context, creds InstallationCredentials, binding ChatSessionBinding, taskID pgtype.UUID, payload any) error {
 	content := chatDoneContent(payload)
 	if content == "" {
 		return nil
 	}
+
+	err := p.sendChatContent(ctx, creds, binding, content)
+	if err == nil {
+		return nil
+	}
+	if !isMessageAuditRejected(err) {
+		return err
+	}
+
+	taskIDString := util.UUIDToString(taskID)
+	sanitized, changed := sanitizeLarkAuditContent(content)
+	p.cfg.Logger.Warn("lark reply rejected by content audit",
+		"task_id", taskIDString,
+		"audit_code", codeMessageAuditRejected,
+		"sanitized", changed,
+	)
+	if changed {
+		retryErr := p.sendChatContent(ctx, creds, binding, sanitized)
+		if retryErr == nil {
+			p.cfg.Logger.Info("lark reply delivered after content redaction",
+				"task_id", taskIDString,
+				"audit_code", codeMessageAuditRejected,
+			)
+			return nil
+		}
+		if !isMessageAuditRejected(retryErr) {
+			return fmt.Errorf("send redacted Lark reply: %w", retryErr)
+		}
+		err = retryErr
+	}
+
+	if fallbackErr := p.sendChatContent(ctx, creds, binding, larkContentAuditFallbackText); fallbackErr != nil {
+		return fmt.Errorf("send content-audit fallback after %v: %w", err, fallbackErr)
+	}
+	p.cfg.Logger.Warn("lark content-audit fallback delivered",
+		"task_id", taskIDString,
+		"audit_code", codeMessageAuditRejected,
+	)
+	return nil
+}
+
+func (p *Patcher) sendChatContent(ctx context.Context, creds InstallationCredentials, binding ChatSessionBinding, content string) error {
 	target := threadReplyTarget(binding)
 	if containsMarkdown(content) {
 		return sendWithThreadFallback(p.cfg.Logger, "send markdown card", target, func(t ReplyTarget) error {
@@ -391,6 +441,11 @@ func (p *Patcher) sendChatReply(ctx context.Context, creds InstallationCredentia
 		})
 		return err
 	})
+}
+
+func sanitizeLarkAuditContent(content string) (string, bool) {
+	sanitized := larkEmailAddressPattern.ReplaceAllString(content, larkEmailRedactionPlaceholder)
+	return sanitized, sanitized != content
 }
 
 // outboundChatID recovers the real Lark chat id from the chat binding. The

--- a/server/internal/integrations/lark/outbound_test.go
+++ b/server/internal/integrations/lark/outbound_test.go
@@ -81,8 +81,10 @@ type fakeAPIClient struct {
 	patchErr       error
 	textSendErr    error
 	textSendReturn string
+	textSendErrs   []error
 	mdCardErr      error
 	mdCardReturn   string
+	mdCardErrs     []error
 	bindingSent    []BindingPromptParams
 	// threadReplyErr, when non-nil, is returned by the three send
 	// methods whenever the call carries a thread ReplyTarget, while the
@@ -125,6 +127,11 @@ func (f *fakeAPIClient) SendTextMessage(ctx context.Context, p SendTextParams) (
 	if f.threadReplyErr != nil && p.ReplyTarget.IsSet() {
 		return "", f.threadReplyErr
 	}
+	if len(f.textSendErrs) > 0 {
+		err := f.textSendErrs[0]
+		f.textSendErrs = f.textSendErrs[1:]
+		return f.textSendReturn, err
+	}
 	return f.textSendReturn, f.textSendErr
 }
 func (f *fakeAPIClient) SendMarkdownCard(ctx context.Context, p SendMarkdownCardParams) (string, error) {
@@ -133,6 +140,11 @@ func (f *fakeAPIClient) SendMarkdownCard(ctx context.Context, p SendMarkdownCard
 	f.mdCardSent = append(f.mdCardSent, p)
 	if f.threadReplyErr != nil && p.ReplyTarget.IsSet() {
 		return "", f.threadReplyErr
+	}
+	if len(f.mdCardErrs) > 0 {
+		err := f.mdCardErrs[0]
+		f.mdCardErrs = f.mdCardErrs[1:]
+		return f.mdCardReturn, err
 	}
 	return f.mdCardReturn, f.mdCardErr
 }
@@ -268,6 +280,203 @@ func TestPatcherRoutesMarkdownReplyToCard(t *testing.T) {
 	}
 	if len(api.sent) != 0 || len(api.patched) != 0 {
 		t.Errorf("ChatDone must NOT use legacy card paths; sent=%d patched=%d", len(api.sent), len(api.patched))
+	}
+}
+
+func TestPatcherRetriesAuditedMarkdownWithEmailRedacted(t *testing.T) {
+	p, q, api := newTestPatcher(t)
+	taskID := uuidFromString(t, "ee454545-ee45-ee45-ee45-eeeeeeeeeeee")
+	api.mdCardErrs = []error{
+		&APIError{HTTPStatus: 400, Code: codeMessageAuditRejected, Msg: "contain sensitive data: EMAIL_ADDRESS"},
+		nil,
+	}
+
+	body := "# Identity\n\nEmail: person@example.com"
+	p.handleEvent(events.Event{
+		Type:          protocol.EventChatDone,
+		TaskID:        uuidString(taskID),
+		ChatSessionID: uuidString(q.binding.ChatSessionID),
+		Payload: protocol.ChatDonePayload{
+			TaskID:        uuidString(taskID),
+			ChatSessionID: uuidString(q.binding.ChatSessionID),
+			Content:       body,
+		},
+	})
+
+	api.mu.Lock()
+	defer api.mu.Unlock()
+	if len(api.mdCardSent) != 2 {
+		t.Fatalf("expected original and sanitized markdown attempts; got %d", len(api.mdCardSent))
+	}
+	if api.mdCardSent[0].Markdown != body {
+		t.Errorf("first attempt must preserve the original body; got %q", api.mdCardSent[0].Markdown)
+	}
+	if strings.Contains(api.mdCardSent[1].Markdown, "person@example.com") {
+		t.Errorf("sanitized retry leaked the email: %q", api.mdCardSent[1].Markdown)
+	}
+	if !strings.Contains(api.mdCardSent[1].Markdown, larkEmailRedactionPlaceholder) {
+		t.Errorf("sanitized retry missing placeholder: %q", api.mdCardSent[1].Markdown)
+	}
+	if len(api.textSent) != 0 {
+		t.Errorf("successful sanitized retry must not also send fallback text; got %d", len(api.textSent))
+	}
+}
+
+func TestPatcherRetriesAuditedPlainTextWithEmailRedacted(t *testing.T) {
+	p, q, api := newTestPatcher(t)
+	taskID := uuidFromString(t, "ee464646-ee46-ee46-ee46-eeeeeeeeeeee")
+	api.textSendErrs = []error{
+		&APIError{HTTPStatus: 400, Code: codeMessageAuditRejected, Msg: "contain sensitive data: EMAIL_ADDRESS"},
+		nil,
+	}
+
+	body := "Contact person@example.com for details."
+	p.handleEvent(events.Event{
+		Type:          protocol.EventChatDone,
+		TaskID:        uuidString(taskID),
+		ChatSessionID: uuidString(q.binding.ChatSessionID),
+		Payload: protocol.ChatDonePayload{
+			TaskID:        uuidString(taskID),
+			ChatSessionID: uuidString(q.binding.ChatSessionID),
+			Content:       body,
+		},
+	})
+
+	api.mu.Lock()
+	defer api.mu.Unlock()
+	if len(api.textSent) != 2 {
+		t.Fatalf("expected original and sanitized text attempts; got %d", len(api.textSent))
+	}
+	if api.textSent[0].Text != body {
+		t.Errorf("first attempt must preserve the original body; got %q", api.textSent[0].Text)
+	}
+	if strings.Contains(api.textSent[1].Text, "person@example.com") {
+		t.Errorf("sanitized retry leaked the email: %q", api.textSent[1].Text)
+	}
+	if !strings.Contains(api.textSent[1].Text, larkEmailRedactionPlaceholder) {
+		t.Errorf("sanitized retry missing placeholder: %q", api.textSent[1].Text)
+	}
+}
+
+func TestPatcherSendsFallbackWhenSanitizedRetryIsAlsoAudited(t *testing.T) {
+	p, q, api := newTestPatcher(t)
+	taskID := uuidFromString(t, "ee494949-ee49-ee49-ee49-eeeeeeeeeeee")
+	api.mdCardErrs = []error{
+		&APIError{HTTPStatus: 400, Code: codeMessageAuditRejected, Msg: "contain sensitive data: EMAIL_ADDRESS"},
+		&APIError{HTTPStatus: 400, Code: codeMessageAuditRejected, Msg: "content audit rejected"},
+	}
+
+	p.handleEvent(events.Event{
+		Type:          protocol.EventChatDone,
+		TaskID:        uuidString(taskID),
+		ChatSessionID: uuidString(q.binding.ChatSessionID),
+		Payload: protocol.ChatDonePayload{
+			TaskID:        uuidString(taskID),
+			ChatSessionID: uuidString(q.binding.ChatSessionID),
+			Content:       "# Identity\n\nEmail: person@example.com",
+		},
+	})
+
+	api.mu.Lock()
+	defer api.mu.Unlock()
+	if len(api.mdCardSent) != 2 {
+		t.Fatalf("expected original and sanitized markdown attempts; got %d", len(api.mdCardSent))
+	}
+	if len(api.textSent) != 1 {
+		t.Fatalf("expected one safe fallback after both markdown attempts were audited; got %d", len(api.textSent))
+	}
+	if api.textSent[0].Text != larkContentAuditFallbackText {
+		t.Errorf("fallback text = %q, want %q", api.textSent[0].Text, larkContentAuditFallbackText)
+	}
+}
+
+func TestPatcherPreservesThreadTargetWhenRetryingAuditedMarkdown(t *testing.T) {
+	p, q, api := newTestPatcher(t)
+	taskID := uuidFromString(t, "ee505050-ee50-ee50-ee50-eeeeeeeeeeee")
+	q.binding.LastMessageID = pgtype.Text{String: "om_trigger", Valid: true}
+	q.binding.LastThreadID = pgtype.Text{String: "omt_topic", Valid: true}
+	api.mdCardErrs = []error{
+		&APIError{HTTPStatus: 400, Code: codeMessageAuditRejected, Msg: "contain sensitive data: EMAIL_ADDRESS"},
+		nil,
+	}
+
+	p.handleEvent(events.Event{
+		Type:          protocol.EventChatDone,
+		TaskID:        uuidString(taskID),
+		ChatSessionID: uuidString(q.binding.ChatSessionID),
+		Payload: protocol.ChatDonePayload{
+			TaskID:        uuidString(taskID),
+			ChatSessionID: uuidString(q.binding.ChatSessionID),
+			Content:       "# Identity\n\nEmail: person@example.com",
+		},
+	})
+
+	api.mu.Lock()
+	defer api.mu.Unlock()
+	if len(api.mdCardSent) != 2 {
+		t.Fatalf("expected original and sanitized markdown attempts; got %d", len(api.mdCardSent))
+	}
+	for i, sent := range api.mdCardSent {
+		if sent.ReplyTarget.MessageID != "om_trigger" || !sent.ReplyTarget.InThread {
+			t.Errorf("attempt %d lost thread target: %+v", i+1, sent.ReplyTarget)
+		}
+	}
+}
+
+func TestPatcherSendsSafeFallbackWhenAuditContentCannotBeSanitized(t *testing.T) {
+	p, q, api := newTestPatcher(t)
+	taskID := uuidFromString(t, "ee474747-ee47-ee47-ee47-eeeeeeeeeeee")
+	api.mdCardErrs = []error{
+		&APIError{HTTPStatus: 400, Code: codeMessageAuditRejected, Msg: "content audit rejected"},
+	}
+
+	p.handleEvent(events.Event{
+		Type:          protocol.EventChatDone,
+		TaskID:        uuidString(taskID),
+		ChatSessionID: uuidString(q.binding.ChatSessionID),
+		Payload: protocol.ChatDonePayload{
+			TaskID:        uuidString(taskID),
+			ChatSessionID: uuidString(q.binding.ChatSessionID),
+			Content:       "# Result\n\nContent rejected for an unknown audit reason.",
+		},
+	})
+
+	api.mu.Lock()
+	defer api.mu.Unlock()
+	if len(api.mdCardSent) != 1 {
+		t.Fatalf("unrecognized audit content must not retry the original card; got %d attempts", len(api.mdCardSent))
+	}
+	if len(api.textSent) != 1 {
+		t.Fatalf("expected one safe fallback text message; got %d", len(api.textSent))
+	}
+	if api.textSent[0].Text != larkContentAuditFallbackText {
+		t.Errorf("fallback text = %q, want %q", api.textSent[0].Text, larkContentAuditFallbackText)
+	}
+}
+
+func TestPatcherDoesNotRetryAmbiguousMarkdownFailure(t *testing.T) {
+	p, q, api := newTestPatcher(t)
+	taskID := uuidFromString(t, "ee484848-ee48-ee48-ee48-eeeeeeeeeeee")
+	api.mdCardErrs = []error{errors.New("transport timeout")}
+
+	p.handleEvent(events.Event{
+		Type:          protocol.EventChatDone,
+		TaskID:        uuidString(taskID),
+		ChatSessionID: uuidString(q.binding.ChatSessionID),
+		Payload: protocol.ChatDonePayload{
+			TaskID:        uuidString(taskID),
+			ChatSessionID: uuidString(q.binding.ChatSessionID),
+			Content:       "# Result\n\nperson@example.com",
+		},
+	})
+
+	api.mu.Lock()
+	defer api.mu.Unlock()
+	if len(api.mdCardSent) != 1 {
+		t.Fatalf("ambiguous failures must not retry; got %d attempts", len(api.mdCardSent))
+	}
+	if len(api.textSent) != 0 {
+		t.Errorf("ambiguous failures must not send a fallback that could duplicate delivery; got %d", len(api.textSent))
 	}
 }
 


### PR DESCRIPTION
## Summary

- preserve structured Lark business errors returned with non-2xx HTTP statuses
- retry outbound replies rejected with code `230028` after redacting raw email addresses
- send a safe generic fallback when the content cannot be sanitized or the sanitized retry is also rejected
- resolve task and chat session IDs before logging asynchronous outbound failures

## Root cause

Feishu can return content-audit failures as HTTP 400 with JSON business code `230028`. The HTTP client previously flattened every non-2xx response into a plain string error, so the outbound patcher could not distinguish a definitive rejection from an ambiguous transport failure. The task completed, the send failure was only logged, and the Lark user received no reply.

## Safety

Retries happen only for the definitive `230028` business code. Network errors, timeouts, and unstructured 5xx responses are not retried, avoiding duplicate delivery. Sanitized retries preserve the original chat/thread target, and logs contain task metadata rather than reply content.

## Validation

- `go test -race ./internal/integrations/lark -count=1`
- `go vet ./internal/integrations/lark`
- `git diff --check`
