### PR TITLE
fix(tasks): surface terminal run errors

### DIFF
--- a/apps/mobile/components/issue/run-row.tsx
+++ b/apps/mobile/components/issue/run-row.tsx
@@ -67,7 +67,7 @@ function StatusBadge({ task }: { task: AgentTask }) {
   // For failed tasks, surface the failure_reason inline so users don't have
   // to drill in. Reasons are coarse enums; missing/empty stays as just "Failed".
   if (task.status === "failed" && task.failure_reason) {
-    const reasonLabel = FAILURE_REASON_LABEL[task.failure_reason];
+    const reasonLabel = FAILURE_REASON_LABEL[task.failure_reason as TaskFailureReason];
     if (reasonLabel) {
       return (
         <Text className={`text-xs ${cls}`}>

--- a/packages/core/types/agent.ts
+++ b/packages/core/types/agent.ts
@@ -290,9 +290,9 @@ export interface AgentTask {
   completed_at: string | null;
   result: unknown;
   error: string | null;
-  // Empty string when the task is not in a failed state (the backend uses
-  // `omitempty`, so the field may also be missing on non-failed tasks).
-  failure_reason?: TaskFailureReason | "";
+  // The backend may add refined reason values over time. Keep the wire field
+  // open and let presentation code fall back safely for unknown values.
+  failure_reason?: string;
   created_at: string;
   /** Non-empty when the task was spawned from a chat session. */
   chat_session_id?: string;

--- a/packages/views/common/task-transcript/agent-transcript-dialog.test.tsx
+++ b/packages/views/common/task-transcript/agent-transcript-dialog.test.tsx
@@ -287,6 +287,34 @@ afterEach(() => {
 });
 
 describe("AgentTranscriptDialog", () => {
+  it("shows the terminal error when a failed run recorded no events or result", () => {
+    const error = JSON.stringify({
+      error: {
+        message: "Invalid value: 'max'. Supported values are none, minimal, low, medium, high, and xhigh.",
+        type: "invalid_request_error",
+        param: "reasoning.effort",
+        code: "invalid_value",
+      },
+    });
+
+    renderDialog([], {
+      task: {
+        ...baseTask,
+        status: "failed",
+        result: null,
+        error,
+        failure_reason: "api_invalid_request",
+      },
+    });
+
+    expect(
+      screen.getByText(
+        "Invalid value: 'max'. Supported values are none, minimal, low, medium, high, and xhigh. · reasoning.effort",
+      ),
+    ).toBeInTheDocument();
+    expect(screen.getByText(/"code": "invalid_value"/)).toBeInTheDocument();
+  });
+
   it("explains unavailable live events for an empty Antigravity transcript", async () => {
     vi.mocked(api.listRuntimes).mockResolvedValue([runtimeFor("antigravity")]);
 

--- a/packages/views/common/task-transcript/agent-transcript-dialog.tsx
+++ b/packages/views/common/task-transcript/agent-transcript-dialog.tsx
@@ -48,7 +48,7 @@ import {
 } from "@multica/core/agents/stores";
 import type { AgentTask, Agent, AgentRuntime } from "@multica/core/types/agent";
 import { runtimeDisplayName } from "@multica/core/runtimes";
-import { redactSecrets } from "./redact";
+import { formatTaskError, redactSecrets } from "./redact";
 import type { TimelineItem } from "./build-timeline";
 import {
   traceEventCopyText,
@@ -284,6 +284,8 @@ export function AgentTranscriptDialog({
   );
   const isAntigravityLiveEmpty =
     isLive && displayItems.length === 0 && runtimeInfo?.provider === "antigravity";
+  const terminalError =
+    task.status === "failed" ? formatTaskError(task.error) : null;
 
   // Newest-first shows live events as PREPENDS, and Virtuoso items opt out of
   // native scroll anchoring (`overflow-anchor: none`), so without compensation
@@ -619,6 +621,25 @@ export function AgentTranscriptDialog({
             </div>
           </div>
         </div>
+
+        {terminalError && (
+          <div className="flex shrink-0 items-start gap-2 border-b bg-destructive/5 px-4 py-3">
+            <AlertCircle
+              aria-hidden="true"
+              className="mt-0.5 h-4 w-4 shrink-0 text-destructive"
+            />
+            <div className="min-w-0">
+              <div className="text-sm font-medium text-destructive">
+                {terminalError.summary}
+              </div>
+              {terminalError.detail !== terminalError.summary && (
+                <pre className="mt-1 max-h-32 overflow-auto whitespace-pre-wrap break-words font-mono text-xs text-muted-foreground">
+                  {terminalError.detail}
+                </pre>
+              )}
+            </div>
+          </div>
+        )}
 
         {/* ── List toolbar: read-before-you-read summary (left) + controls
             (right). Duration + event count fill the left, so the row balances
@@ -1128,4 +1149,3 @@ function ToolDetailSurface({ text }: { text: string }) {
     </div>
   );
 }
-

--- a/packages/views/common/task-transcript/redact.test.ts
+++ b/packages/views/common/task-transcript/redact.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { redactSecrets } from "./redact";
+import { formatTaskError, redactSecrets } from "./redact";
 
 describe("redactSecrets", () => {
   it("redacts AWS access key", () => {
@@ -105,5 +105,35 @@ describe("redactSecrets", () => {
     for (const input of inputs) {
       expect(redactSecrets(input)).toBe(input);
     }
+  });
+
+  it("formats a structured provider error and redacts its detail", () => {
+    const secret = ["sk-proj-", "abc123def456ghi789jkl012mno345"].join("");
+    const result = formatTaskError(
+      `OpenAI API error (400): ${JSON.stringify({
+        error: {
+          message: "Invalid value: 'max'. Supported values are none, low, medium, high, and xhigh.",
+          type: "invalid_request_error",
+          param: "reasoning.effort",
+          code: "invalid_value",
+        },
+        authorization: `Bearer ${secret}`,
+      })}`,
+    );
+
+    expect(result?.summary).toBe(
+      "Invalid value: 'max'. Supported values are none, low, medium, high, and xhigh. · reasoning.effort",
+    );
+    expect(result?.detail).toContain('"type": "invalid_request_error"');
+    expect(result?.detail).toContain("OpenAI API error (400):");
+    expect(result?.detail).toContain("[REDACTED API KEY]");
+    expect(result?.detail).not.toContain(secret);
+  });
+
+  it("keeps plain-text provider errors readable", () => {
+    expect(formatTaskError("codex exited with status 1")).toEqual({
+      summary: "codex exited with status 1",
+      detail: "codex exited with status 1",
+    });
   });
 });

--- a/packages/views/common/task-transcript/redact.ts
+++ b/packages/views/common/task-transcript/redact.ts
@@ -39,3 +39,102 @@ export function redactSecrets(text: string): string {
   }
   return result;
 }
+
+export interface FormattedTaskError {
+  summary: string;
+  detail: string;
+}
+
+const taskErrorSummaryLimit = 240;
+
+function clipSummary(value: string): string {
+  return value.length > taskErrorSummaryLimit
+    ? `${value.slice(0, taskErrorSummaryLimit - 3)}...`
+    : value;
+}
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  return value !== null && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : null;
+}
+
+function structuredErrorMessage(value: unknown): string | null {
+  const root = asRecord(value);
+  if (!root) return null;
+
+  const nested = root.error;
+  if (typeof nested === "string") return nested;
+
+  const error = asRecord(nested) ?? root;
+  const message = ["message", "error_description", "detail"]
+    .map((key) => error[key])
+    .find((candidate): candidate is string =>
+      typeof candidate === "string" && candidate.trim().length > 0,
+    );
+  if (!message) return null;
+
+  const param = error.param;
+  return typeof param === "string" &&
+    param.length > 0 &&
+    !message.includes(param)
+    ? `${message} · ${param}`
+    : message;
+}
+
+function parseStructuredError(
+  text: string,
+): { value: unknown; prefix: string } | null {
+  const firstBrace = text.indexOf("{");
+  const lastBrace = text.lastIndexOf("}");
+  const candidates = [
+    { json: text, prefix: "" },
+    ...(firstBrace > 0 && lastBrace > firstBrace
+      ? [{
+          json: text.slice(firstBrace, lastBrace + 1),
+          prefix: text.slice(0, firstBrace).trim(),
+        }]
+      : []),
+  ];
+
+  for (const candidate of candidates) {
+    try {
+      return { value: JSON.parse(candidate.json), prefix: candidate.prefix };
+    } catch {
+      // Plain-text provider errors are expected; try the next shape.
+    }
+  }
+  return null;
+}
+
+/**
+ * Make the persisted terminal task error safe and readable. Providers may
+ * return either plain text or a stringified JSON error envelope.
+ */
+export function formatTaskError(
+  rawError: string | null | undefined,
+): FormattedTaskError | null {
+  const redacted = redactSecrets(rawError?.trim() ?? "");
+  if (!redacted) return null;
+
+  const structured = parseStructuredError(redacted);
+  if (structured) {
+    const pretty = JSON.stringify(structured.value, null, 2);
+    const message = structuredErrorMessage(structured.value);
+    return {
+      summary: clipSummary(
+        ((message ?? structured.prefix) || "Task execution failed")
+          .replace(/\s+/g, " ")
+          .trim(),
+      ),
+      detail: structured.prefix
+        ? `${structured.prefix}\n${pretty}`
+        : pretty,
+    };
+  }
+
+  return {
+    summary: clipSummary(redacted.replace(/\s+/g, " ").trim()),
+    detail: redacted,
+  };
+}


### PR DESCRIPTION
## Root cause

The daemon, task service, REST handlers, and `AgentTaskSchema` all preserve the terminal `error` and `failure_reason`. The shared transcript dialog only rendered task-message timeline data, though, so a failed run with no result, output, or messages discarded the one useful diagnostic already present on the task response.

The TypeScript wire type also constrained `failure_reason` to an obsolete coarse enum even though the API schema and backend now emit refined values such as `api_invalid_request`.

## User impact

Users can open a failed run and immediately see the provider's concrete error instead of only a red failed state and an empty execution log.

## Changes

- Render a redacted terminal-error banner in the shared transcript dialog used by issue, agent, and autopilot run surfaces.
- Format structured JSON envelopes and prefixed/plain-text provider errors into a readable summary while retaining redacted detail.
- Align the task wire type with the backend's extensible failure-reason taxonomy.
- Keep the mobile caller compatible with extensible reasons while preserving its known-label fallback.
- Cover a failed Codex run with `result=null`, no timeline events, `failure_reason=api_invalid_request`, and a persisted OpenAI 400 error.

## Verification

- `pnpm --filter @multica/views exec vitest run common/task-transcript/redact.test.ts common/task-transcript/agent-transcript-dialog.test.tsx --maxWorkers=1` — 28 passed
- `pnpm exec turbo typecheck lint test --filter=@multica/mobile` — passed (33 tests; existing warnings only)
- `pnpm lint` — passed (existing warnings only)
- `pnpm typecheck` — passed
- `pnpm build` — passed (the release-metadata request fell back after a GitHub API 403)

An initial mistargeted views-test command expanded to the full suite: 2,897 tests passed; 17 unrelated timeout/worker-start failures occurred under Node 25. The focused regression suite above was rerun cleanly.

## Screenshot

<img width="1520" height="980" alt="Failed task transcript shows provider error" src="https://github.com/user-attachments/assets/de53cfbd-b969-431b-b652-6e9da2411e85" />
