### PR TITLE
Fix custom runtime delete actions (ZIC-123) (MUL-5342)

### DIFF
--- a/packages/views/locales/en/runtimes.json
+++ b/packages/views/locales/en/runtimes.json
@@ -264,6 +264,7 @@
     "cli_managed_badge": "Desktop",
     "row_actions_aria": "Row actions",
     "delete_action": "Delete",
+    "delete_profile_action": "Delete from workspace",
     "delete_permission_hint": "Only the runtime owner and workspace admins can delete this runtime",
     "delete_admin_hint": "Only the runtime owner and workspace admins can delete a runtime.",
     "badge_builtin": "Built-in",

--- a/packages/views/locales/ja/runtimes.json
+++ b/packages/views/locales/ja/runtimes.json
@@ -252,6 +252,7 @@
     "cli_managed_badge": "デスクトップ",
     "row_actions_aria": "行の操作",
     "delete_action": "削除",
+    "delete_profile_action": "ワークスペースから削除",
     "delete_permission_hint": "ランタイムの所有者とワークスペース管理者のみが、このランタイムを削除できます",
     "delete_admin_hint": "ランタイムの所有者とワークスペース管理者のみが、ランタイムを削除できます。",
     "badge_builtin": "組み込み",

--- a/packages/views/locales/ko/runtimes.json
+++ b/packages/views/locales/ko/runtimes.json
@@ -252,6 +252,7 @@
     "cli_managed_badge": "데스크톱",
     "row_actions_aria": "행 작업",
     "delete_action": "삭제",
+    "delete_profile_action": "워크스페이스에서 삭제",
     "delete_permission_hint": "런타임 소유자와 워크스페이스 관리자만 이 런타임을 삭제할 수 있습니다",
     "delete_admin_hint": "런타임 소유자와 워크스페이스 관리자만 런타임을 삭제할 수 있습니다.",
     "badge_builtin": "기본 제공",

--- a/packages/views/locales/zh-Hans/runtimes.json
+++ b/packages/views/locales/zh-Hans/runtimes.json
@@ -252,6 +252,7 @@
     "cli_managed_badge": "桌面端",
     "row_actions_aria": "行操作",
     "delete_action": "删除",
+    "delete_profile_action": "从工作区删除",
     "delete_permission_hint": "只有运行时所有者和工作区管理员可以删除这个运行时",
     "delete_admin_hint": "只有运行时所有者和工作区管理员可以删除运行时。",
     "badge_builtin": "内置",

--- a/packages/views/runtimes/components/delete-runtime-profile-dialog.tsx
+++ b/packages/views/runtimes/components/delete-runtime-profile-dialog.tsx
@@ -15,6 +15,11 @@ import {
 import { Button } from "@multica/ui/components/ui/button";
 import { useT } from "../../i18n";
 
+export type RuntimeProfileDeleteTarget = Pick<
+  RuntimeProfile,
+  "id" | "display_name"
+>;
+
 // Confirmation dialog for deleting a custom runtime profile. The server
 // refuses with a 409 when agents are still bound to the profile; we surface
 // that refusal inline (and keep the dialog open) instead of dumping a raw
@@ -28,7 +33,7 @@ export function DeleteRuntimeProfileDialog({
 }: {
   open: boolean;
   onOpenChange: (open: boolean) => void;
-  profile: RuntimeProfile;
+  profile: RuntimeProfileDeleteTarget;
   wsId: string;
   onDeleted: () => void;
 }) {

--- a/packages/views/runtimes/components/runtime-detail-visibility.test.tsx
+++ b/packages/views/runtimes/components/runtime-detail-visibility.test.tsx
@@ -268,6 +268,35 @@ describe("RuntimeDetail visibility section", () => {
     );
   });
 
+  it("uses the profile delete endpoint for custom runtimes even when the profile lookup is missing", async () => {
+    mockQueryData.members = [
+      { user_id: "user-me", role: "owner", name: "Me" },
+    ];
+    mockQueryData.profiles = [];
+
+    renderDetail(
+      makeRuntime({
+        name: "Custom Cursor",
+        owner_id: "someone-else",
+        provider: "cursor",
+        profile_id: "profile-missing",
+      }),
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /Delete runtime/i }));
+    expect(
+      screen.getByRole("heading", { name: "Delete custom runtime?" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(/Delete "Custom Cursor"/),
+    ).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Delete" }));
+    await waitFor(() =>
+      expect(mockDeleteRuntimeProfile).toHaveBeenCalledWith("profile-missing"),
+    );
+  });
+
   it("hides custom runtime delete for non-admin runtime owners", () => {
     const profile = makeProfile();
     mockQueryData.profiles = [profile];

--- a/packages/views/runtimes/components/runtime-detail.tsx
+++ b/packages/views/runtimes/components/runtime-detail.tsx
@@ -46,6 +46,7 @@ import { UpdateSection } from "./update-section";
 import { UsageSection } from "./usage-section";
 import { DeleteRuntimeDialog } from "./delete-runtime-dialog";
 import { DeleteRuntimeProfileDialog } from "./delete-runtime-profile-dialog";
+import type { RuntimeProfileDeleteTarget } from "./delete-runtime-profile-dialog";
 import { useT } from "../../i18n";
 
 function getCliVersion(metadata: Record<string, unknown>): string | null {
@@ -74,6 +75,10 @@ function shortDaemonId(id: string | null): string | null {
   if (!id) return null;
   if (id.length <= 10) return id;
   return `${id.slice(0, 6)}··${id.slice(-2)}`;
+}
+
+function runtimeFallbackName(runtime: AgentRuntime): string {
+  return runtime.name;
 }
 
 // 30s tick keeps derived runtime health honest as time-based windows
@@ -126,8 +131,16 @@ export function RuntimeDetail({ runtime }: { runtime: AgentRuntime }) {
     ? profiles.find((p) => p.id === runtime.profile_id) ?? null
     : null;
   const isCustomRuntime = !!runtime.profile_id;
+  const deleteProfileTarget: RuntimeProfileDeleteTarget | null =
+    isCustomRuntime && runtime.profile_id
+      ? {
+          id: runtime.profile_id,
+          display_name:
+            runtimeProfile?.display_name ?? runtimeFallbackName(runtime),
+        }
+      : null;
   const canDelete = isCustomRuntime
-    ? isAdmin && !!runtimeProfile
+    ? isAdmin
     : canEditRuntime;
 
   const servingAgents = agents.filter(
@@ -208,11 +221,11 @@ export function RuntimeDetail({ runtime }: { runtime: AgentRuntime }) {
         </div>
       </div>
 
-      {isCustomRuntime && runtimeProfile ? (
+      {deleteProfileTarget ? (
         <DeleteRuntimeProfileDialog
           open={deleteOpen}
           onOpenChange={setDeleteOpen}
-          profile={runtimeProfile}
+          profile={deleteProfileTarget}
           wsId={wsId}
           onDeleted={handleProfileDeleted}
         />

--- a/packages/views/runtimes/components/runtime-list.tsx
+++ b/packages/views/runtimes/components/runtime-list.tsx
@@ -55,6 +55,7 @@ import { ProviderLogo } from "./provider-logo";
 import { HealthIcon, useHealthLabel } from "./shared";
 import { DeleteRuntimeDialog } from "./delete-runtime-dialog";
 import { DeleteRuntimeProfileDialog } from "./delete-runtime-profile-dialog";
+import type { RuntimeProfileDeleteTarget } from "./delete-runtime-profile-dialog";
 import {
   computeCostInWindow,
   formatLastSeen,
@@ -134,6 +135,10 @@ const EMPTY_WORKLOAD: RuntimeWorkload = {
   runningCount: 0,
   queuedCount: 0,
 };
+
+function runtimeFallbackName(runtime: AgentRuntime): string {
+  return runtime.name;
+}
 
 export interface RuntimeRow {
   runtime: AgentRuntime;
@@ -503,6 +508,13 @@ export function RuntimeRowMenu({
   const { t } = useT("runtimes");
   const [deleteOpen, setDeleteOpen] = useState(false);
   const isCustomRuntime = !!runtime.profile_id;
+  const deleteProfileTarget: RuntimeProfileDeleteTarget | null =
+    isCustomRuntime && runtime.profile_id
+      ? {
+          id: runtime.profile_id,
+          display_name: profile?.display_name ?? runtimeFallbackName(runtime),
+        }
+      : null;
   // Delete is currently the only row action; if the row can't run it, drop
   // the kebab entirely so the column doesn't render an empty popover. We
   // used to also hide it for self-healing runtimes (live local daemon
@@ -535,16 +547,18 @@ export function RuntimeRowMenu({
             onClick={() => setDeleteOpen(true)}
             title={t(($) => $.list.delete_permission_hint)}
           >
-            <Trash2 className="h-3.5 w-3.5" />
-            {t(($) => $.list.delete_action)}
+            <Trash2 aria-hidden="true" className="h-3.5 w-3.5" />
+            {isCustomRuntime
+              ? t(($) => $.list.delete_profile_action)
+              : t(($) => $.list.delete_action)}
           </DropdownMenuItem>
         </DropdownMenuContent>
       </DropdownMenu>
-      {isCustomRuntime && profile ? (
+      {deleteProfileTarget ? (
         <DeleteRuntimeProfileDialog
           open={deleteOpen}
           onOpenChange={setDeleteOpen}
-          profile={profile}
+          profile={deleteProfileTarget}
           wsId={wsId}
           onDeleted={() => setDeleteOpen(false)}
         />
@@ -643,11 +657,10 @@ export function RuntimeList({
           ? memberById.get(runtime.owner_id) ?? null
           : null,
         workload: workloadIndex.get(runtime.id) ?? EMPTY_WORKLOAD,
-        canDelete:
-          !isPendingCustomRuntime(runtime) &&
-          (isCustomRuntime
-            ? isAdmin && !!profile
-            : isAdmin || (!!user && runtime.owner_id === user.id)),
+        canDelete: isCustomRuntime
+          ? isAdmin
+          : !isPendingCustomRuntime(runtime) &&
+            (isAdmin || (!!user && runtime.owner_id === user.id)),
       };
     });
   }, [runtimes, profileById, memberById, workloadIndex, isAdmin, user]);

--- a/packages/views/runtimes/components/runtime-row-menu.test.tsx
+++ b/packages/views/runtimes/components/runtime-row-menu.test.tsx
@@ -2,7 +2,7 @@
 
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import type { AgentRuntime, RuntimeProfile } from "@multica/core/types";
 import { I18nProvider } from "@multica/core/i18n/react";
 import enCommon from "../../locales/en/common.json";
@@ -12,6 +12,8 @@ import enAgents from "../../locales/en/agents.json";
 const TEST_RESOURCES = {
   en: { common: enCommon, runtimes: enRuntimes, agents: enAgents },
 };
+
+const mockDeleteRuntimeProfile = vi.hoisted(() => vi.fn());
 
 // Stub the workspace queries the columns reach into. None of them feed the
 // row menu directly, but `createRuntimeColumns` wires CliCell + CostCell
@@ -42,9 +44,9 @@ vi.mock("@multica/core/runtimes", () => ({
   runtimeProfileListOptions: () => ({ kind: "runtime-profiles" }),
   parseRuntimeProfileBoundConflict: () => null,
   useDeleteRuntimeProfile: () => ({
-    mutate: vi.fn(),
+    mutate: mockDeleteRuntimeProfile,
     isPending: false,
-    mutateAsync: vi.fn(),
+    mutateAsync: (...args: unknown[]) => mockDeleteRuntimeProfile(...args),
   }),
 }));
 
@@ -194,6 +196,36 @@ describe("runtime list row menu", () => {
       ),
     );
     expect(screen.getByLabelText("Row actions")).toBeInTheDocument();
+  });
+
+  it("keeps delete available for a custom runtime when the profile row is missing", async () => {
+    renderActionsCell(
+      makeRow(
+        makeRuntime({
+          runtime_mode: "local",
+          name: "Custom Cursor",
+          provider: "cursor",
+          profile_id: "profile-missing",
+        }),
+        true,
+        null,
+      ),
+    );
+
+    fireEvent.click(screen.getByLabelText("Row actions"));
+    expect(screen.queryByText("Edit custom runtime")).not.toBeInTheDocument();
+    fireEvent.click(screen.getByText("Delete from workspace"));
+
+    expect(
+      screen.getByRole("heading", { name: "Delete custom runtime?" }),
+    ).toBeInTheDocument();
+    expect(screen.getByText(/Custom Cursor/)).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Delete" }));
+
+    await waitFor(() =>
+      expect(mockDeleteRuntimeProfile).toHaveBeenCalledWith("profile-missing"),
+    );
   });
 
   it("hides the kebab menu when the caller lacks delete permission", () => {


### PR DESCRIPTION
<!-- multica-auto-bugfix -->

## What does this PR do?

Fixes custom Cursor/profile-backed runtime rows that could show no actions and could fall back to the unsupported direct runtime delete path when the runtime profile lookup is missing.

The UI already has the stable `profile_id` on the runtime row, so this keeps admin delete available from that id and routes deletion through the runtime-profile delete dialog. Editing still requires the loaded profile object.

## Related Issue

Closes #5853

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Refactor / code improvement (no behavior change)
- [x] Tests (adding or improving test coverage)
- [ ] CI / infrastructure

## Changes Made

- Allow `DeleteRuntimeProfileDialog` to accept the profile id/display-name fields needed for deletion.
- Keep delete available for custom runtime rows/details when `profile_id` exists, even if the profile list did not resolve that profile.
- Add runtime list/detail regression tests for missing-profile custom runtime deletion.
- Add localized list copy for the profile-backed delete action.

## How to Test

1. Create or view a custom Cursor runtime whose runtime row has `profile_id`.
2. As a workspace admin, open the row actions or runtime detail delete action.
3. Confirm the custom runtime profile delete dialog opens and submits through the profile delete endpoint.

Validation run locally:

- `pnpm -C packages/views test runtimes/components/runtime-row-menu.test.tsx runtimes/components/runtime-detail-visibility.test.tsx` passed.
- `pnpm -C packages/views lint` passed with existing warnings only.
- `pnpm -C packages/views typecheck` still fails on unrelated existing editor suggestion tests missing `signal` in `mention-suggestion.test.tsx` / `slash-command-suggestion.test.tsx`.
- `make check-worktree` exited 0, but this environment printed that Docker was unavailable while checking PostgreSQL.

Current PR status: GitHub reports the branch has merge conflicts because the fork is behind upstream `main`; syncing the fork is blocked here because the available GitHub token lacks `workflow` scope for upstream workflow commits.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [ ] I have updated relevant documentation to reflect my changes
- [ ] If I added a new runtime / coding tool / UI tab, I synced the change to **landing copy** (`apps/web/features/landing/i18n/`) and **relevant docs** (`apps/docs/content/docs/`)
- [ ] If this PR touches Chinese product copy, I checked it against `apps/docs/content/docs/developers/conventions.zh.mdx` (terminology, mixed-rule for `task` / `issue` / `skill`)
- [x] I have considered and documented any risks above
- [x] I will address all reviewer comments before requesting merge

## AI Disclosure

**AI tool used:** Multica Agent

**Prompt / approach:**
I inspected the runtime list/detail delete paths, reproduced the missing-profile condition in focused component tests, and kept the fix scoped to using the runtime's existing `profile_id` for profile deletion while leaving edit behavior dependent on loaded profile data.

## Screenshots (optional)

Not included; this is covered by focused component tests around the row action and detail delete dialog.
