### PR TITLE
feat(agent): add Claude Opus 5 to the Claude runtime catalog (MUL-5282)

### DIFF
--- a/packages/views/runtimes/utils.test.ts
+++ b/packages/views/runtimes/utils.test.ts
@@ -209,6 +209,28 @@ describe("estimateCost", () => {
     expect(isModelPriced("claude-opus-4-7[1m]")).toBe(true);
   });
 
+  it("prices Opus 5 on the standard Opus tier across its transport spellings", () => {
+    // Opus 5 is a 5/25 SKU like Opus 4.5-4.8. Claude Code reports the
+    // 1M-context window with a bracketed suffix and openclaw/opencode prefix
+    // the id with the provider, so all three spellings reach the cost
+    // estimator and must land on the same row.
+    for (const model of [
+      "claude-opus-5",
+      "claude-opus-5[1m]",
+      "anthropic/claude-opus-5",
+    ]) {
+      expect(
+        estimateCost({
+          ...zeroUsage,
+          model,
+          input_tokens: 1_000_000,
+          output_tokens: 1_000_000,
+        }),
+      ).toBeCloseTo(5 + 25, 5);
+      expect(isModelPriced(model)).toBe(true);
+    }
+  });
+
   it("prices each dotted Codex catalog SKU at its own tier, not gpt-5", () => {
     // Every dotted minor version is priced independently. The resolver does
     // exact-match-after-date-strip (no startsWith fallback), so each row

--- a/packages/views/runtimes/utils.ts
+++ b/packages/views/runtimes/utils.ts
@@ -168,9 +168,10 @@ const MODEL_PRICING: Record<
   //    intro launch rate ($2 / $10 through 2026-08-31). This static map has
   //    no future-dated pricing support yet, so update the row when the
   //    post-intro $3 / $15 rate takes effect. Fable 5 is a Mythos-class SKU
-  //    at 10/50; Opus 4.5+ stays on the lower 5/25 Opus tier. --
+  //    at 10/50; Opus 4.5 through Opus 5 stay on the lower 5/25 Opus tier. --
   "claude-sonnet-5":     { input: 2,    output: 10,   cacheRead: 0.20, cacheWrite: 2.50 },
   "claude-fable-5":     { input: 10,   output: 50,   cacheRead: 1.00, cacheWrite: 12.50 },
+  "claude-opus-5":      { input: 5,    output: 25,   cacheRead: 0.50, cacheWrite: 6.25 },
   "claude-haiku-4-5":   { input: 1,    output: 5,    cacheRead: 0.10, cacheWrite: 1.25 },
   "claude-sonnet-4-5":  { input: 3,    output: 15,   cacheRead: 0.30, cacheWrite: 3.75 },
   "claude-sonnet-4-6":  { input: 3,    output: 15,   cacheRead: 0.30, cacheWrite: 3.75 },

--- a/server/internal/metrics/pricing.go
+++ b/server/internal/metrics/pricing.go
@@ -42,6 +42,7 @@ var modelPrices = map[string]ModelPrice{
 	// so keep the intro rate here and update the row when catalog support exists.
 	"anthropic:claude-sonnet-5":   {Provider: "anthropic", Model: "claude-sonnet-5", InputPerM: 2.00, CacheReadPerM: 0.20, CacheWritePerM: 2.50, OutputPerM: 10.00},
 	"anthropic:claude-fable-5":    {Provider: "anthropic", Model: "claude-fable-5", InputPerM: 10.00, CacheReadPerM: 1.00, CacheWritePerM: 12.50, OutputPerM: 50.00},
+	"anthropic:claude-opus-5":     {Provider: "anthropic", Model: "claude-opus-5", InputPerM: 5.00, CacheReadPerM: 0.50, CacheWritePerM: 6.25, OutputPerM: 25.00},
 	"anthropic:claude-opus-4.8":   {Provider: "anthropic", Model: "claude-opus-4.8", InputPerM: 5.00, CacheReadPerM: 0.50, CacheWritePerM: 6.25, OutputPerM: 25.00},
 	"anthropic:claude-opus-4.7":   {Provider: "anthropic", Model: "claude-opus-4.7", InputPerM: 5.00, CacheReadPerM: 0.50, CacheWritePerM: 6.25, OutputPerM: 25.00},
 	"anthropic:claude-opus-4.6":   {Provider: "anthropic", Model: "claude-opus-4.6", InputPerM: 5.00, CacheReadPerM: 0.50, CacheWritePerM: 6.25, OutputPerM: 25.00},
@@ -96,6 +97,7 @@ var modelAliasRules = []struct {
 	{regexp.MustCompile(`(^|/|:)gpt-5[.-]2-codex$`), "openai:gpt-5.2-codex"},
 	{regexp.MustCompile(`claude-sonnet-5|claude-5-sonnet`), "anthropic:claude-sonnet-5"},
 	{regexp.MustCompile(`claude-fable-5`), "anthropic:claude-fable-5"},
+	{regexp.MustCompile(`claude-opus-5`), "anthropic:claude-opus-5"},
 	{regexp.MustCompile(`claude-opus-4[-.]8`), "anthropic:claude-opus-4.8"},
 	{regexp.MustCompile(`claude-opus-4[-.]7`), "anthropic:claude-opus-4.7"},
 	{regexp.MustCompile(`claude-opus-4[-.]6`), "anthropic:claude-opus-4.6"},

--- a/server/internal/metrics/pricing_test.go
+++ b/server/internal/metrics/pricing_test.go
@@ -2,7 +2,7 @@ package metrics
 
 import "testing"
 
-func TestPriceForModelAliasAnthropicFableAndOpus48(t *testing.T) {
+func TestPriceForModelAliasAnthropicCurrentGeneration(t *testing.T) {
 	cases := []struct {
 		model string
 		want  ModelPrice
@@ -30,6 +30,20 @@ func TestPriceForModelAliasAnthropicFableAndOpus48(t *testing.T) {
 		{
 			model: "claude-opus-4-8",
 			want:  ModelPrice{Provider: "anthropic", Model: "claude-opus-4.8", InputPerM: 5, CacheReadPerM: 0.5, CacheWritePerM: 6.25, OutputPerM: 25},
+		},
+		// Opus 5 sits on the same 5/25 Opus tier as 4.5-4.8.
+		{
+			model: "claude-opus-5",
+			want:  ModelPrice{Provider: "anthropic", Model: "claude-opus-5", InputPerM: 5, CacheReadPerM: 0.5, CacheWritePerM: 6.25, OutputPerM: 25},
+		},
+		{
+			model: "anthropic/claude-opus-5",
+			want:  ModelPrice{Provider: "anthropic", Model: "claude-opus-5", InputPerM: 5, CacheReadPerM: 0.5, CacheWritePerM: 6.25, OutputPerM: 25},
+		},
+		// Claude Code reports the 1M-context beta with a bracketed suffix.
+		{
+			model: "claude-opus-5[1m]",
+			want:  ModelPrice{Provider: "anthropic", Model: "claude-opus-5", InputPerM: 5, CacheReadPerM: 0.5, CacheWritePerM: 6.25, OutputPerM: 25},
 		},
 	}
 

--- a/server/pkg/agent/models.go
+++ b/server/pkg/agent/models.go
@@ -317,6 +317,7 @@ func claudeStaticModels() []Model {
 		{ID: "claude-sonnet-5", Label: "Claude Sonnet 5", Provider: "anthropic"},
 		{ID: "claude-sonnet-4-6", Label: "Claude Sonnet 4.6", Provider: "anthropic", Default: true},
 		{ID: "claude-fable-5", Label: "Claude Fable 5", Provider: "anthropic"},
+		{ID: "claude-opus-5", Label: "Claude Opus 5", Provider: "anthropic"},
 		{ID: "claude-opus-4-8", Label: "Claude Opus 4.8", Provider: "anthropic"},
 		{ID: "claude-opus-4-7", Label: "Claude Opus 4.7", Provider: "anthropic"},
 		{ID: "claude-haiku-4-5-20251001", Label: "Claude Haiku 4.5", Provider: "anthropic"},

--- a/server/pkg/agent/models_test.go
+++ b/server/pkg/agent/models_test.go
@@ -116,6 +116,45 @@ func TestClaudeStaticModelsExposesSonnet5(t *testing.T) {
 	}
 }
 
+func TestClaudeStaticModelsExposesOpus5(t *testing.T) {
+	models := claudeStaticModels()
+	ids := map[string]Model{}
+	defaults := 0
+	for _, m := range models {
+		ids[m.ID] = m
+		if m.Default {
+			defaults++
+		}
+	}
+
+	opus, ok := ids["claude-opus-5"]
+	if !ok {
+		t.Fatalf("missing Claude Opus 5 in: %+v", models)
+	}
+	if opus.Label != "Claude Opus 5" || opus.Provider != "anthropic" || opus.Default {
+		t.Errorf("unexpected Opus 5 entry: %+v", opus)
+	}
+	// Opus stays a deliberate opt-in: Sonnet remains the everyday workhorse
+	// the catalog badges as its default pick.
+	if defaults != 1 || !ids["claude-sonnet-4-6"].Default {
+		t.Errorf("expected Sonnet 4.6 to remain the sole default, got defaults=%d models=%+v", defaults, models)
+	}
+}
+
+// TestClaudeOpus5AcceptedByProviderCompatibilityGate pins the other half of
+// catalog membership: ModelKnownIncompatibleWithProvider erases a saved model
+// that a runtime's maintained catalog doesn't advertise, so an unlisted
+// `claude-opus-5` would be silently dropped from an agent on save.
+func TestClaudeOpus5AcceptedByProviderCompatibilityGate(t *testing.T) {
+	t.Parallel()
+	if ModelKnownIncompatibleWithProvider("claude", "claude-opus-5") {
+		t.Error("claude-opus-5 must be accepted by the claude provider gate")
+	}
+	if !ModelKnownIncompatibleWithProvider("codex", "claude-opus-5") {
+		t.Error("claude-opus-5 must still be rejected for the codex provider")
+	}
+}
+
 func TestCodexStaticModelsMatchVerifiedFallbackCatalog(t *testing.T) {
 	// This fallback is used for Codex <0.122.0 and whenever dynamic bundled
 	// discovery fails. Keep the latest verified visible models plus 5.3 Codex

--- a/server/pkg/agent/thinking.go
+++ b/server/pkg/agent/thinking.go
@@ -104,6 +104,7 @@ var claudeEffortLabel = map[string]string{
 var claudeModelEffortAllow = map[string]map[string]bool{
 	// Opus is the only model that publicly supports xhigh; the help
 	// list still includes it for Sonnet / Haiku so we filter here.
+	"claude-opus-5":             {"low": true, "medium": true, "high": true, "xhigh": true, "max": true},
 	"claude-opus-4-8":           {"low": true, "medium": true, "high": true, "xhigh": true, "max": true},
 	"claude-opus-4-7":           {"low": true, "medium": true, "high": true, "xhigh": true, "max": true},
 	"claude-opus-4-6":           {"low": true, "medium": true, "high": true, "xhigh": true, "max": true},

--- a/server/pkg/agent/thinking_test.go
+++ b/server/pkg/agent/thinking_test.go
@@ -113,6 +113,19 @@ func TestProjectClaudeLevels_PerModelSubset(t *testing.T) {
 	if !reflect.DeepEqual(values, superset) {
 		t.Fatalf("projectClaudeLevels for Opus: got %v, want %v", values, superset)
 	}
+	// Opus 5 declares `xhigh_effort` + `max_effort` upstream, so it keeps the
+	// full superset like the rest of the Opus family. Without an entry here it
+	// would fall through to "no allow-list" and coincidentally get the same
+	// levels — this pins the mapping so a later Sonnet-style restriction on the
+	// fallback path can't silently widen it.
+	got = projectClaudeLevels(superset, claudeModelEffortAllow["claude-opus-5"])
+	values = values[:0]
+	for _, lvl := range got {
+		values = append(values, lvl.Value)
+	}
+	if !reflect.DeepEqual(values, superset) {
+		t.Fatalf("projectClaudeLevels for Opus 5: got %v, want %v", values, superset)
+	}
 }
 
 // ── Codex discovery argv ────────────────────────────────────────────
@@ -571,6 +584,19 @@ func TestValidateThinkingLevel_ExplicitModel(t *testing.T) {
 	}
 	if !ok {
 		t.Errorf("xhigh should be valid on opus-4-7; got false")
+	}
+
+	// The whole Opus effort range round-trips on Opus 5, which is the point of
+	// adding it to the catalog: an agent pinned to it can still carry a
+	// persisted thinking_level without the daemon dropping the flag.
+	for _, level := range []string{"low", "medium", "high", "xhigh", "max"} {
+		ok, err := ValidateThinkingLevel(ctx, "claude", fakeClaude, "claude-opus-5", level)
+		if err != nil {
+			t.Fatalf("unexpected err for opus-5 %q: %v", level, err)
+		}
+		if !ok {
+			t.Errorf("%q should be valid on opus-5; got false", level)
+		}
 	}
 
 	// xhigh is NOT valid on Sonnet — should fail.


### PR DESCRIPTION
## What

Adds **Claude Opus 5** to the Claude runtime so it can be selected, configured with a thinking level, and priced.

Verified against the locally installed `claude-code` **2.1.219** bundled catalog rather than guessed:

```
{id:"claude-opus-5", family:"opus", display_name:"Opus 5",
 pricing:"tier_5_25",
 capabilities:["effort","max_effort","xhigh_effort", ...], default_effort:"high"}
tier_5_25:{input:5, output:25, cache_write_5m:6.25, cache_read:0.5}
```

## Why

Two user-visible gaps, not just a missing dropdown row:

1. **The picker never offered Opus 5.** `claudeStaticModels()` stopped at Opus 4.8.
2. **Manually entering it was silently reverted.** `ModelKnownIncompatibleWithProvider` treats *any* unlisted `claude-*` id as a known mismatch for the claude provider, so a hand-typed `claude-opus-5` was erased on save. There was no way to run Opus 5 at all.
3. Opus 5 usage fell through to the unmapped-model diagnostic in both the server cost table and the dashboard estimator, so its spend was excluded from cost totals.

## Changes

| Area | Change |
| --- | --- |
| `server/pkg/agent/models.go` | `claude-opus-5` / "Claude Opus 5" added to the Claude catalog |
| `server/pkg/agent/thinking.go` | Full `low/medium/high/xhigh/max` range in `claudeModelEffortAllow`, matching the Opus family |
| `server/internal/metrics/pricing.go` | `anthropic:claude-opus-5` row + alias rule on the 5/25 Opus tier |
| `packages/views/runtimes/utils.ts` | Matching frontend `MODEL_PRICING` row |

**Default is unchanged** — Sonnet 4.6 remains the sole badged default. Opus stays a deliberate opt-in, consistent with the existing catalog comment; a test pins this.

The existing `[1m]` context-tag and `<provider>/` prefix tolerances already cover the other spellings runtimes report (`claude-opus-5[1m]`, `anthropic/claude-opus-5`), so no resolver changes were needed — tests cover both.

## Out of scope

`claude-opus-5[1m]` as its own *picker entry* is not added. Opus 4.8 carries the identical `supports_1m_suffix` config, so that's a family-wide product decision rather than anything Opus 5 introduces.

## Verification

- `go test ./pkg/agent/... ./internal/metrics/...` — pass
- `pnpm exec vitest run runtimes/utils.test.ts` — 73 pass
- `tsc --noEmit` on `packages/views`, `gofmt`/`go vet`, `eslint` on touched files — clean

New tests: catalog membership + default invariant, the compatibility-gate regression, per-model effort projection, effort round-trip across all five levels, and pricing across all three id spellings on both server and frontend.
