### PR TITLE
docs(changelog): add v0.4.11 release entry (2026-07-25) (MUL-5284)

### DIFF
--- a/apps/web/features/landing/i18n/en.ts
+++ b/apps/web/features/landing/i18n/en.ts
@@ -294,6 +294,20 @@ export function createEnDict(allowSignup: boolean): LandingDict {
     },
     entries: [
       {
+        version: "0.4.11",
+        date: "2026-07-25",
+        title: "Live PR status and Claude Opus 5",
+        changes: [],
+        features: [
+          "Pull request cards now show live CI status and whether a PR is ready to merge.",
+          "You can now build agents on Claude Opus 5.",
+        ],
+        improvements: [
+          "Long-running services an agent starts now keep running after its task finishes.",
+          "Non-code workspaces no longer carry software-engineering instructions their agents don't need.",
+        ],
+      },
+      {
         version: "0.4.10",
         date: "2026-07-24",
         title: "Self-hosted Git providers and project-aware Chat",

--- a/apps/web/features/landing/i18n/ja.ts
+++ b/apps/web/features/landing/i18n/ja.ts
@@ -270,6 +270,20 @@ export function createJaDict(allowSignup: boolean): LandingDict {
       },
       entries: [
         {
+          version: "0.4.11",
+          date: "2026-07-25",
+          title: "PR のリアルタイム状態と Claude Opus 5",
+          changes: [],
+          features: [
+            "PR カードに CI の状態と、その PR がマージ可能かどうかがリアルタイムで表示されます。",
+            "Claude Opus 5 でエージェントを構築できるようになりました。",
+          ],
+          improvements: [
+            "エージェントが起動した長時間実行のサービスが、タスク終了後も動き続けるようになりました。",
+            "コード以外のワークスペースに、エージェントに不要なソフトウェア開発向けの指示が含まれなくなりました。",
+          ],
+        },
+        {
           version: "0.4.10",
           date: "2026-07-24",
           title: "セルフホスト Git サービス対応、プロジェクトを理解する Chat",

--- a/apps/web/features/landing/i18n/ko.ts
+++ b/apps/web/features/landing/i18n/ko.ts
@@ -269,6 +269,20 @@ export function createKoDict(allowSignup: boolean): LandingDict {
       },
       entries: [
         {
+          version: "0.4.11",
+          date: "2026-07-25",
+          title: "PR 실시간 상태와 Claude Opus 5",
+          changes: [],
+          features: [
+            "PR 카드에 CI 상태와 해당 PR을 병합할 수 있는지가 실시간으로 표시됩니다.",
+            "이제 Claude Opus 5로 에이전트를 만들 수 있습니다.",
+          ],
+          improvements: [
+            "에이전트가 시작한 장시간 실행 서비스가 작업이 끝난 뒤에도 계속 실행됩니다.",
+            "코드가 아닌 워크스페이스에 에이전트에 필요 없는 소프트웨어 개발 지침이 더 이상 포함되지 않습니다.",
+          ],
+        },
+        {
           version: "0.4.10",
           date: "2026-07-24",
           title: "셀프호스트 Git 서비스 지원, 프로젝트를 이해하는 Chat",

--- a/apps/web/features/landing/i18n/zh.ts
+++ b/apps/web/features/landing/i18n/zh.ts
@@ -294,6 +294,20 @@ export function createZhDict(allowSignup: boolean): LandingDict {
     },
     entries: [
       {
+        version: "0.4.11",
+        date: "2026-07-25",
+        title: "PR 实时状态，新增 Claude Opus 5",
+        changes: [],
+        features: [
+          "PR 卡片现在会显示实时的 CI 状态，以及这个 PR 是否可以合并了。",
+          "现在可以基于 Claude Opus 5 搭建智能体了。",
+        ],
+        improvements: [
+          "智能体启动的长时间运行服务，现在在任务结束后仍会继续运行。",
+          "非代码类工作区不再夹带智能体用不上的软件工程说明了。",
+        ],
+      },
+      {
         version: "0.4.10",
         date: "2026-07-24",
         title: "支持自托管 Git 服务，Chat 更懂你的项目",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@multica/web",
-  "version": "0.4.10",
+  "version": "0.4.11",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## Background

Daily release confirmation for MUL-5284. Adds the `/changelog` entry for today's release and bumps `apps/web/package.json` to the new version. Covers all 4 commits on `main` since the last release tag `v0.4.10`.

## Version

`0.4.10` → `0.4.11` (patch bump). All four changes are enhancements to existing surfaces / small features / a cleanup revert — no headline new product feature, so per the versioning rule this is a patch, not a minor.

## Scope (v0.4.10..main, 4 commits)

**Features**
- `#5910` add Claude Opus 5 to the Claude runtime catalog (MUL-5282) — small (~108 LOC) — Jiayuan Zhang
- `#5889` GitHub API-snapshot PR cards: CI status + mergeability (MUL-5265) — large (~4.3k LOC) — Bohan Jiang

**Improvements**
- `#5895` allow explicit persistent service handoffs (MUL-5274) — small (~55 LOC) — Bohan Jiang
- `#5913` revert domain-specific prompt additions (MUL-5261) — medium (revert, -499 LOC) — Jiayuan Zhang

## Changes in this PR

- 4 locale files `apps/web/features/landing/i18n/{en,zh,ja,ko}.ts` — new `0.4.11` entry prepended to `changelog.entries`, user-facing wording per the changelog language rules.
- `apps/web/package.json` — `version` → `0.4.11`.

## Testing

- `pnpm --filter @multica/web run typecheck` — passed.
- `pnpm --filter @multica/web exec vitest run features/landing/components/changelog-page-client.test.ts` — 3 tests passed.
