### PR TITLE
fix(execenv): relax Codex sandbox in Docker (MUL-5298)

### DIFF
--- a/server/internal/daemon/execenv/codex_sandbox.go
+++ b/server/internal/daemon/execenv/codex_sandbox.go
@@ -69,11 +69,28 @@ func resolveGOOS(goos string) string {
 	return goos
 }
 
+// runningInDocker reports whether the daemon is running in a Docker
+// container. Docker creates /.dockerenv in its containers; the cgroup check
+// covers Docker configurations where that marker is unavailable.
+func runningInDocker() bool {
+	if _, err := os.Stat("/.dockerenv"); err == nil {
+		return true
+	}
+	data, err := os.ReadFile("/proc/1/cgroup")
+	if err != nil {
+		return false
+	}
+	return strings.Contains(string(data), "/docker/") || strings.Contains(string(data), "/docker-")
+}
+
 // codexSandboxPolicyFor picks the default policy for the given platform and
 // detected Codex CLI version. It is the platform baseline; per-task user config
 // can refine it (see codexSandboxPolicyForConfig).
 //
-//   - Linux: workspace-write with network access. Landlock enforces the
+//   - Linux in Docker: danger-full-access. The Docker container is already
+//     the daemon's isolation boundary, and Codex's Landlock workspace-write
+//     sandbox prevents daemon tasks from accessing required container paths.
+//   - Other Linux: workspace-write with network access. Landlock enforces the
 //     filesystem sandbox and is not affected by the macOS Seatbelt bug.
 //   - Windows: danger-full-access, as a deliberate compatibility choice.
 //     Codex ships a native Windows sandbox (windows.sandbox = "unelevated" via
@@ -94,6 +111,13 @@ func resolveGOOS(goos string) string {
 //   - darwin otherwise (including when the version is unknown): fall back to
 //     danger-full-access so the Multica CLI can reach the API.
 func codexSandboxPolicyFor(goos, detectedVersion string) codexSandboxPolicy {
+	return codexSandboxPolicyForEnvironment(goos, detectedVersion, runningInDocker())
+}
+
+// codexSandboxPolicyForEnvironment selects a policy for a platform and
+// container state. Keeping container detection as an argument makes the
+// Docker policy deterministic in tests.
+func codexSandboxPolicyForEnvironment(goos, detectedVersion string, inDocker bool) codexSandboxPolicy {
 	if goos == "" {
 		goos = runtime.GOOS
 	}
@@ -101,6 +125,12 @@ func codexSandboxPolicyFor(goos, detectedVersion string) codexSandboxPolicy {
 		return codexSandboxPolicy{
 			Mode:   "danger-full-access",
 			Reason: "codex on windows: compatibility fallback; no native windows.sandbox configured, so workspace-write cannot be enforced (MUL-4957)",
+		}
+	}
+	if goos == "linux" && inDocker {
+		return codexSandboxPolicy{
+			Mode:   "danger-full-access",
+			Reason: "codex in Docker: container isolation is the boundary; workspace-write blocks required daemon task access",
 		}
 	}
 	if goos != "darwin" {

--- a/server/internal/daemon/execenv/execenv_test.go
+++ b/server/internal/daemon/execenv/execenv_test.go
@@ -2966,7 +2966,7 @@ func TestCodexSandboxPolicyFor(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			p := codexSandboxPolicyFor(tc.goos, tc.version)
+			p := codexSandboxPolicyForEnvironment(tc.goos, tc.version, false)
 			if p.Mode != tc.wantMode {
 				t.Errorf("mode = %q, want %q", p.Mode, tc.wantMode)
 			}
@@ -2980,6 +2980,26 @@ func TestCodexSandboxPolicyFor(t *testing.T) {
 				t.Errorf("hint present = %v, want %v (hint=%q)", p.Hint != "", tc.wantHint, p.Hint)
 			}
 		})
+	}
+}
+
+func TestCodexSandboxPolicyForEnvironmentDocker(t *testing.T) {
+	t.Parallel()
+
+	docker := codexSandboxPolicyForEnvironment("linux", "0.144.5", true)
+	if docker.Mode != "danger-full-access" {
+		t.Errorf("Docker Linux mode = %q, want danger-full-access", docker.Mode)
+	}
+	if docker.NetworkAccess {
+		t.Error("Docker Linux policy must not emit workspace-write network_access")
+	}
+	if docker.Reason == "" {
+		t.Error("expected Docker Linux policy to include a reason")
+	}
+
+	host := codexSandboxPolicyForEnvironment("linux", "0.144.5", false)
+	if host.Mode != "workspace-write" || !host.NetworkAccess {
+		t.Errorf("non-Docker Linux policy = %+v, want workspace-write with network access", host)
 	}
 }
 


### PR DESCRIPTION
Use the Docker container boundary for daemon-launched Codex tasks and retain workspace-write on Linux hosts.

## What does this PR do?

  Uses the Docker container boundary as the isolation boundary for daemon-launched Codex tasks. On Linux hosts, Codex keeps the existing `workspace-
  write` sandbox with network access. Inside Docker, it now uses `danger-full-access`, avoiding Landlock restrictions that prevent daemon tasks from
  accessing required container paths.

  Risk: Docker detection relies on `/.dockerenv` with a `/proc/1/cgroup` fallback. Non-Docker Linux behavior remains unchanged.

  ## Related Issue

  Closes #1370 

  ## Type of Change

  - [x] Bug fix (non-breaking change that fixes an issue)
  - [ ] New feature (non-breaking change that adds functionality)
  - [ ] Refactor / code improvement (no behavior change)
  - [ ] Documentation update
  - [x] Tests (adding or improving test coverage)
  - [ ] CI / infrastructure

  ## Changes Made

  - Updated `server/internal/daemon/execenv/codex_sandbox.go` to detect Docker and select `danger-full-access` only for Linux Docker environments.
  - Extracted environment-aware sandbox policy selection so container behavior is deterministic in tests.
  - Updated `server/internal/daemon/execenv/execenv_test.go` with Docker and non-Docker Linux policy coverage.

  ## How to Test

  1. Run `cd server`.
  2. Run `go test ./internal/daemon/execenv`.
  3. Confirm Docker Linux resolves to `danger-full-access`, while non-Docker Linux remains `workspace-write` with network access.

  ## Checklist

  - [x] I have included a thinking path that traces from project context to this change
  - [x] I have run tests locally and they pass
  - [x] I have added or updated tests where applicable
  - [ ] If this change affects the UI, I have included before/after screenshots
  - [ ] I have updated relevant documentation to reflect my changes
  - [ ] If I added a new runtime / coding tool / UI tab, I synced the change to **landing copy** (`apps/web/features/landing/i18n/`) and **relevant
  docs** (`apps/docs/content/docs/`)
  - [ ] If this PR touches Chinese product copy, I checked it against `apps/docs/content/docs/developers/conventions.zh.mdx` (terminology, mixed-rule
  for `task` / `issue` / `skill`)
  - [x] I have considered and documented any risks above
  - [x] I will address all reviewer comments before requesting merge

  ## AI Disclosure

  **AI tool used:** Codex

  **Prompt / approach:**

  Used Codex to inspect the existing Codex sandbox policy, add Docker-aware policy selection with a testable environment seam, run the focused Go
  package test, review the staged diff, and create commit `c0fe0cff2`.

  ## Screenshots (optional)

  N/A - backend-only change.