### PR TITLE
fix(daemon): skip redundant built-in agent version probes across workspace registrations

### DIFF
--- a/server/internal/daemon/daemon.go
+++ b/server/internal/daemon/daemon.go
@@ -1221,11 +1221,12 @@ const runtimeVersionProbeConcurrency = 8
 // instead of their sum, so a freshly-created workspace lights up its runtimes
 // well inside the UI's scanning window.
 //
-// Each probe still self-heals a vanished pinned path (MUL-4486) and re-detects
-// the live version — no result is cached across registrations, so an in-place
-// CLI upgrade is still reported with its current version. A probe that fails to
-// detect a version or is below the minimum supported version is logged and
-// skipped, exactly as the serial loop did.
+// Each probe self-heals a vanished pinned path (MUL-4486). Built-in agent
+// executables are machine-scoped, so a version detected for one workspace is
+// reused for subsequent workspace registrations via resolveAgentEntry's cache
+// — avoiding N×M subprocess spawns when a daemon serves many workspaces
+// (MUL-5837). A probe that fails to detect a version or is below the minimum
+// supported version is logged and skipped, exactly as the serial loop did.
 func (d *Daemon) detectBuiltinRuntimes(ctx context.Context) []map[string]string {
 	type detected struct {
 		name    string
@@ -1240,17 +1241,22 @@ func (d *Daemon) detectBuiltinRuntimes(ctx context.Context) []map[string]string 
 	for name, entry := range d.cfg.Agents {
 		name, entry := name, entry
 		g.Go(func() error {
-			// Self-heal a pinned executable path an in-place upgrade deleted
-			// (MUL-4486) so version detection — and thus staying
-			// registered/online — recovers without a daemon restart.
-			// resolveAgentEntry already version-gates the healed binary; the
-			// detect + min-version check below still runs to produce the
-			// version string this registration reports.
-			entry, _ = d.resolveAgentEntry(ctx, name, entry)
-			version, err := detectAgentVersion(ctx, entry.Path)
-			if err != nil {
-				d.logger.Warn("skip registering runtime", "name", name, "error", err)
-				return nil
+			// Self-heal a vanished pinned path (MUL-4486) and reuse the
+			// already-cached version when available. Built-in agent executables
+			// are machine-scoped, not workspace-scoped: probing each binary
+			// once per workspace in a N-workspace daemon produces N×M
+			// subprocess spawns. resolveAgentEntry returns the version it
+			// cached for the provider on a prior probe; fall through to
+			// detectAgentVersion only when the cache is empty (first probe for
+			// this provider in this daemon run) (MUL-5837).
+			entry, version := d.resolveAgentEntry(ctx, name, entry)
+			if version == "" {
+				var probeErr error
+				version, probeErr = detectAgentVersion(ctx, entry.Path)
+				if probeErr != nil {
+					d.logger.Warn("skip registering runtime", "name", name, "error", probeErr)
+					return nil
+				}
 			}
 			if err := checkAgentMinVersion(name, version); err != nil {
 				d.logger.Warn("skip registering runtime: version too old", "name", name, "version", version, "error", err)

--- a/server/internal/daemon/runtime_probe_concurrency_test.go
+++ b/server/internal/daemon/runtime_probe_concurrency_test.go
@@ -7,6 +7,53 @@ import (
 	"time"
 )
 
+// TestDetectBuiltinRuntimes_NoDuplicateProbesAcrossWorkspaces verifies that
+// built-in agent version probes are not repeated across multiple workspace
+// registrations (MUL-5837). A daemon with N workspaces and M built-in agents
+// must run at most M probes total, not N×M.
+func TestDetectBuiltinRuntimes_NoDuplicateProbesAcrossWorkspaces(t *testing.T) {
+	origDetect := detectAgentVersion
+	origCheck := checkAgentMinVersion
+	t.Cleanup(func() {
+		detectAgentVersion = origDetect
+		checkAgentMinVersion = origCheck
+	})
+
+	var probeCount int32
+	detectAgentVersion = func(_ context.Context, _ string) (string, error) {
+		atomic.AddInt32(&probeCount, 1)
+		return "9.9.9", nil
+	}
+	checkAgentMinVersion = func(_, _ string) error { return nil }
+
+	d := freshDaemon("")
+	d.cfg.Agents = map[string]AgentEntry{
+		"claude": {Path: "/usr/bin/true"},
+		"codex":  {Path: "/usr/bin/true"},
+	}
+
+	// First workspace registration — each agent is probed once to populate the cache.
+	runtimes1 := d.detectBuiltinRuntimes(context.Background())
+	if len(runtimes1) != len(d.cfg.Agents) {
+		t.Fatalf("first registration: expected %d runtimes, got %d", len(d.cfg.Agents), len(runtimes1))
+	}
+	afterFirst := atomic.LoadInt32(&probeCount)
+	if int(afterFirst) != len(d.cfg.Agents) {
+		t.Fatalf("first registration: expected %d probes, got %d", len(d.cfg.Agents), afterFirst)
+	}
+
+	// Second workspace registration — cached versions must be reused; no new probes.
+	runtimes2 := d.detectBuiltinRuntimes(context.Background())
+	if len(runtimes2) != len(d.cfg.Agents) {
+		t.Fatalf("second registration: expected %d runtimes, got %d", len(d.cfg.Agents), len(runtimes2))
+	}
+	afterSecond := atomic.LoadInt32(&probeCount)
+	if afterSecond != afterFirst {
+		t.Fatalf("second workspace registration triggered %d extra probe(s); want 0 (versions should be cached)",
+			afterSecond-afterFirst)
+	}
+}
+
 // TestDetectBuiltinRuntimes_ProbesRunConcurrently proves the registration
 // version probes fan out instead of running serially (MUL-5119). Each stubbed
 // `--version` probe blocks briefly and records the peak number of in-flight


### PR DESCRIPTION
## Problem

`detectBuiltinRuntimes` is called once per workspace from `registerRuntimesForWorkspace`. Each call spawns `<agent> --version` for every configured built-in agent. A daemon serving **N workspaces** with **M built-in agents** therefore starts **N×M** version-probe subprocesses on startup — 24 workspaces × 5 agents = 120 `--version` invocations in the reported case, when 5 should suffice.

Reported in #5837. The reporter observed visible **Dock churn** on macOS because `agy --version` (the Antigravity wrapper) launches the Electron process each time, and 120 invocations caused repeated Dock animation.

## Root cause

```go
entry, _ = d.resolveAgentEntry(ctx, name, entry)  // ignores the cached version
version, err := detectAgentVersion(ctx, entry.Path) // always spawns the subprocess
```

`resolveAgentEntry` already returns the previously-detected version as its second return value (from `d.agentVersions` via `setAgentVersion`). That value was discarded with `_`, and `detectAgentVersion` was called unconditionally.

## Fix

Capture the version from `resolveAgentEntry`. Call `detectAgentVersion` only when the version is empty (first probe for this provider in this daemon run). Subsequent workspace registrations reuse the cached version without spawning any new subprocesses.

Built-in agent executables are machine-scoped, not workspace-scoped: the same `claude` binary backs every workspace on the daemon. Its version cannot change between two workspace registrations in the same startup pass — an in-place upgrade is only visible on the next daemon restart anyway, since the daemon pins absolute executable paths at startup.

## Validation

New regression test `TestDetectBuiltinRuntimes_NoDuplicateProbesAcrossWorkspaces` (added to `runtime_probe_concurrency_test.go`):
- Stubs `detectAgentVersion` with an atomic counter
- Calls `detectBuiltinRuntimes` twice (two workspace registrations)
- Asserts the counter increments by `len(agents)` on the first call and **zero** on the second

All three `TestDetectBuiltinRuntimes_*` tests pass: `go test ./internal/daemon/ -run TestDetectBuiltinRuntimes -v`

Full daemon package: `go test ./internal/daemon/` — PASS (30s)

Fixes #5837