### PR TITLE
fix(handler,service): return 409/deferred instead of 500 on duplicate-key constraint (Fixes #5914)

### DIFF
--- a/server/internal/handler/agent.go
+++ b/server/internal/handler/agent.go
@@ -1800,6 +1800,15 @@ func (h *Handler) UpdateAgent(w http.ResponseWriter, r *http.Request) {
 
 	updated, err := h.Queries.UpdateAgent(r.Context(), params)
 	if err != nil {
+		var pgErr *pgconn.PgError
+		if errors.As(err, &pgErr) && pgErr.Code == "23505" && pgErr.ConstraintName == "agent_workspace_name_unique" {
+			name := ""
+			if req.Name != nil {
+				name = *req.Name
+			}
+			writeError(w, http.StatusConflict, fmt.Sprintf("an agent named %q already exists in this workspace", name))
+			return
+		}
 		slog.Warn("update agent failed", append(logger.RequestAttrs(r), "error", err, "agent_id", id)...)
 		writeError(w, http.StatusInternalServerError, "failed to update agent: "+err.Error())
 		return

--- a/server/internal/handler/comment.go
+++ b/server/internal/handler/comment.go
@@ -1572,7 +1572,14 @@ func (h *Handler) enqueueCommentAgentTriggers(ctx context.Context, issue db.Issu
 			}
 		}
 		if err := h.enqueueSingleCommentTrigger(ctx, issue, triggerCommentID, trigger, getEscalationDelay); err != nil {
-			record(trigger, DispatchBlocked, commentEnqueueFailureReason(err))
+			if errors.Is(err, service.ErrTaskAlreadyPending) {
+				// A concurrent request raced the pre-check and already enqueued a
+				// task for this (issue, agent). Treat as deferred — the active task
+				// will process this trigger via completion reconciliation.
+				record(trigger, DispatchDeferred, ReasonAlreadyActive)
+			} else {
+				record(trigger, DispatchBlocked, commentEnqueueFailureReason(err))
+			}
 			continue
 		}
 		record(trigger, DispatchQueued, ReasonQueued)

--- a/server/internal/handler/task_enqueue_dedup_test.go
+++ b/server/internal/handler/task_enqueue_dedup_test.go
@@ -1,0 +1,142 @@
+package handler
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/multica-ai/multica/server/internal/service"
+)
+
+// createDedupTestIssue seeds a minimal issue for the enqueue-dedup tests,
+// optionally assigned to an agent. Task rows created against it are cleaned
+// up alongside the issue.
+func createDedupTestIssue(t *testing.T, title, assigneeAgentID string) string {
+	t.Helper()
+	ctx := context.Background()
+
+	var issueID string
+	var assigneeType, assigneeID any
+	if assigneeAgentID != "" {
+		assigneeType = "agent"
+		assigneeID = assigneeAgentID
+	}
+	if err := testPool.QueryRow(ctx, `
+		INSERT INTO issue (workspace_id, title, status, priority, creator_type, creator_id, assignee_type, assignee_id, number)
+		VALUES ($1, $2, 'todo', 'medium', 'member', $3, $4, $5,
+		        COALESCE((SELECT MAX(number) FROM issue WHERE workspace_id = $1), 0) + 1)
+		RETURNING id
+	`, testWorkspaceID, title, testUserID, assigneeType, assigneeID).Scan(&issueID); err != nil {
+		t.Fatalf("create test issue: %v", err)
+	}
+	t.Cleanup(func() {
+		testPool.Exec(context.Background(), `DELETE FROM agent_task_queue WHERE issue_id = $1`, issueID)
+		testPool.Exec(context.Background(), `DELETE FROM issue WHERE id = $1`, issueID)
+	})
+	return issueID
+}
+
+func countPendingTasks(t *testing.T, issueID, agentID string) int {
+	t.Helper()
+	var n int
+	if err := testPool.QueryRow(context.Background(), `
+		SELECT COUNT(*) FROM agent_task_queue
+		WHERE issue_id = $1 AND agent_id = $2 AND status IN ('queued', 'dispatched')
+	`, issueID, agentID).Scan(&n); err != nil {
+		t.Fatalf("count pending tasks: %v", err)
+	}
+	return n
+}
+
+// TestEnqueueTaskForMention_DuplicatePendingIsTypedDedup pins the #5914 fix on
+// the mention path: when a second enqueue for the same (issue, agent) pair
+// trips idx_one_pending_task_per_issue_agent, the service must return the
+// typed ErrTaskAlreadyPending — which the comment dispatch layer maps to
+// DispatchDeferred/ReasonAlreadyActive — instead of a generic wrapped pg error
+// logged at ERROR level.
+func TestEnqueueTaskForMention_DuplicatePendingIsTypedDedup(t *testing.T) {
+	if testHandler == nil {
+		t.Skip("database not available")
+	}
+	ctx := context.Background()
+
+	agentID := createHandlerTestAgent(t, "dedup-mention-agent", nil)
+	issueID := createDedupTestIssue(t, "dedup mention issue", "")
+	issue, err := testHandler.Queries.GetIssue(ctx, parseUUID(issueID))
+	if err != nil {
+		t.Fatalf("load issue: %v", err)
+	}
+
+	if _, err := testHandler.TaskService.EnqueueTaskForMention(ctx, issue, parseUUID(agentID), pgtype.UUID{}); err != nil {
+		t.Fatalf("first enqueue should succeed, got: %v", err)
+	}
+	_, err = testHandler.TaskService.EnqueueTaskForMention(ctx, issue, parseUUID(agentID), pgtype.UUID{})
+	if !errors.Is(err, service.ErrTaskAlreadyPending) {
+		t.Fatalf("second enqueue: want ErrTaskAlreadyPending, got: %v", err)
+	}
+
+	if n := countPendingTasks(t, issueID, agentID); n != 1 {
+		t.Fatalf("expected exactly 1 pending task after duplicate enqueue, got %d", n)
+	}
+}
+
+// TestEnqueueTaskForIssue_DuplicatePendingIsTypedDedup pins the same contract
+// on the issue-assignee path (enqueueIssueTaskWithCommentPlan) — the second
+// write point of idx_one_pending_task_per_issue_agent. Without the shared
+// isPendingTaskDedupViolation check the assignee path kept the pre-#5914
+// behavior: ERROR log plus an untyped error.
+func TestEnqueueTaskForIssue_DuplicatePendingIsTypedDedup(t *testing.T) {
+	if testHandler == nil {
+		t.Skip("database not available")
+	}
+	ctx := context.Background()
+
+	agentID := createHandlerTestAgent(t, "dedup-assignee-agent", nil)
+	issueID := createDedupTestIssue(t, "dedup assignee issue", agentID)
+	issue, err := testHandler.Queries.GetIssue(ctx, parseUUID(issueID))
+	if err != nil {
+		t.Fatalf("load issue: %v", err)
+	}
+
+	if _, err := testHandler.TaskService.EnqueueTaskForIssue(ctx, issue); err != nil {
+		t.Fatalf("first enqueue should succeed, got: %v", err)
+	}
+	_, err = testHandler.TaskService.EnqueueTaskForIssue(ctx, issue)
+	if !errors.Is(err, service.ErrTaskAlreadyPending) {
+		t.Fatalf("second enqueue: want ErrTaskAlreadyPending, got: %v", err)
+	}
+
+	if n := countPendingTasks(t, issueID, agentID); n != 1 {
+		t.Fatalf("expected exactly 1 pending task after duplicate enqueue, got %d", n)
+	}
+}
+
+// TestUpdateAgent_NameCollisionReturns409 pins the #5914 fix on the rename
+// path: renaming an agent to a name already held in the workspace must
+// surface the agent_workspace_name_unique violation as a structured 409
+// Conflict (mirroring CreateAgent), not a 500 leaking the raw constraint.
+func TestUpdateAgent_NameCollisionReturns409(t *testing.T) {
+	if testHandler == nil {
+		t.Skip("database not available")
+	}
+
+	createHandlerTestAgent(t, "dedup-rename-taken", nil)
+	renamedID := createHandlerTestAgent(t, "dedup-rename-source", nil)
+
+	body := map[string]any{"name": "dedup-rename-taken"}
+	req := newRequest(http.MethodPut, "/api/agents/"+renamedID, body)
+	req = withURLParam(req, "id", renamedID)
+	w := httptest.NewRecorder()
+	testHandler.UpdateAgent(w, req)
+
+	if w.Code != http.StatusConflict {
+		t.Fatalf("UpdateAgent name collision: expected 409, got %d: %s", w.Code, w.Body.String())
+	}
+	if !strings.Contains(w.Body.String(), "already exists") {
+		t.Errorf("409 body should name the conflict; got %s", w.Body.String())
+	}
+}

--- a/server/internal/service/task.go
+++ b/server/internal/service/task.go
@@ -555,11 +555,19 @@ func triggerOwnerAttribution(ctx context.Context, q *db.Queries, triggerID, work
 // run never starts.
 var ErrAttributionFailClosed = errors.New("attribution: no precise accountable human and enqueue refused (fail-closed policy, policy read failed, or no agent owner)")
 
-// ErrTaskAlreadyPending is returned by enqueueMentionTaskWithCommentPlan when
+// ErrTaskAlreadyPending is returned by the task enqueue paths when
 // CreateAgentTask hits idx_one_pending_task_per_issue_agent — i.e. a concurrent
 // request already enqueued a task for the same (issue, agent) pair. Callers
 // should treat this as a deferred/already-active outcome, not an error.
 var ErrTaskAlreadyPending = errors.New("task: pending task already exists for this (issue, agent) pair")
+
+// isPendingTaskDedupViolation reports whether err is the unique-constraint
+// violation raised by idx_one_pending_task_per_issue_agent, i.e. a concurrent
+// enqueue won the race for the same (issue, agent) pair.
+func isPendingTaskDedupViolation(err error) bool {
+	var pgErr *pgconn.PgError
+	return errors.As(err, &pgErr) && pgErr.Code == "23505" && pgErr.ConstraintName == "idx_one_pending_task_per_issue_agent"
+}
 
 // applyAttributionFallback applies the workspace's degraded-attribution policy to a
 // resolved attribution whose source came back unattributed (no precise human). A
@@ -1042,6 +1050,12 @@ func (s *TaskService) enqueueIssueTaskWithCommentPlan(ctx context.Context, issue
 		HeadSha: headShaText(s.ResolveIssueReviewSHA(ctx, issue.ID)),
 	})
 	if err != nil {
+		if isPendingTaskDedupViolation(err) {
+			// Same dedup race as the mention path: a concurrent request already
+			// enqueued a task for this (issue, agent) pair. Not a server fault.
+			slog.Info("assignee task already enqueued (concurrent dedup)", "issue_id", util.UUIDToString(issue.ID), "agent_id", util.UUIDToString(issue.AssigneeID))
+			return db.AgentTaskQueue{}, ErrTaskAlreadyPending
+		}
 		slog.Error("task enqueue failed", "issue_id", util.UUIDToString(issue.ID), "error", err)
 		return db.AgentTaskQueue{}, fmt.Errorf("create task: %w", err)
 	}
@@ -1161,8 +1175,7 @@ func (s *TaskService) enqueueMentionTaskWithCommentPlan(ctx context.Context, iss
 		HeadSha: headShaText(s.ResolveIssueReviewSHA(ctx, issue.ID)),
 	})
 	if err != nil {
-		var pgErr *pgconn.PgError
-		if errors.As(err, &pgErr) && pgErr.Code == "23505" && pgErr.ConstraintName == "idx_one_pending_task_per_issue_agent" {
+		if isPendingTaskDedupViolation(err) {
 			// A concurrent request already enqueued a task for this (issue, agent)
 			// pair — the unique index raced us. This is a normal dedup outcome,
 			// not a server fault: log at Info and let callers handle it as

--- a/server/internal/service/task.go
+++ b/server/internal/service/task.go
@@ -13,6 +13,7 @@ import (
 	"unicode/utf8"
 
 	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/jackc/pgx/v5/pgtype"
 	"github.com/multica-ai/multica/server/internal/analytics"
 	"github.com/multica-ai/multica/server/internal/attribution"
@@ -553,6 +554,12 @@ func triggerOwnerAttribution(ctx context.Context, q *db.Queries, triggerID, work
 // owner_fallback has no agent owner to fall back to. Enqueue paths surface it so the
 // run never starts.
 var ErrAttributionFailClosed = errors.New("attribution: no precise accountable human and enqueue refused (fail-closed policy, policy read failed, or no agent owner)")
+
+// ErrTaskAlreadyPending is returned by enqueueMentionTaskWithCommentPlan when
+// CreateAgentTask hits idx_one_pending_task_per_issue_agent — i.e. a concurrent
+// request already enqueued a task for the same (issue, agent) pair. Callers
+// should treat this as a deferred/already-active outcome, not an error.
+var ErrTaskAlreadyPending = errors.New("task: pending task already exists for this (issue, agent) pair")
 
 // applyAttributionFallback applies the workspace's degraded-attribution policy to a
 // resolved attribution whose source came back unattributed (no precise human). A
@@ -1154,6 +1161,15 @@ func (s *TaskService) enqueueMentionTaskWithCommentPlan(ctx context.Context, iss
 		HeadSha: headShaText(s.ResolveIssueReviewSHA(ctx, issue.ID)),
 	})
 	if err != nil {
+		var pgErr *pgconn.PgError
+		if errors.As(err, &pgErr) && pgErr.Code == "23505" && pgErr.ConstraintName == "idx_one_pending_task_per_issue_agent" {
+			// A concurrent request already enqueued a task for this (issue, agent)
+			// pair — the unique index raced us. This is a normal dedup outcome,
+			// not a server fault: log at Info and let callers handle it as
+			// an already-active task.
+			slog.Info("mention task already enqueued (concurrent dedup)", "issue_id", util.UUIDToString(issue.ID), "agent_id", util.UUIDToString(agentID))
+			return db.AgentTaskQueue{}, ErrTaskAlreadyPending
+		}
 		slog.Error("mention task enqueue failed", "issue_id", util.UUIDToString(issue.ID), "agent_id", util.UUIDToString(agentID), "error", err)
 		return db.AgentTaskQueue{}, fmt.Errorf("create task: %w", err)
 	}


### PR DESCRIPTION
## Problem

Two code paths surfaced Postgres unique-constraint errors as HTTP 500 or
misleading `ERR`-level log entries rather than the expected idempotent outcomes
(reported in #5914).

### 1 — `UpdateAgent` name collision (`agent_workspace_name_unique`)

Renaming an agent to a name already held by another agent (including an
archived one) returned HTTP 500 with the raw constraint message. `CreateAgent`
already handles this correctly (409 + human-readable message); `UpdateAgent`
did not.

### 2 — Concurrent task enqueue (`idx_one_pending_task_per_issue_agent`)

When the same agent is triggered twice in rapid succession on one issue, the
second `CreateAgentTask` hits the dedup index. This is a normal concurrent
race, not a server fault, but both write points of that index — the mention
path (`enqueueMentionTaskWithCommentPlan`) and the issue-assignee path
(`enqueueIssueTaskWithCommentPlan`) — logged it at `slog.Error` and propagated
a generic error that `dispatchCommentAgentTriggers` then recorded as
`DispatchBlocked/internal_error`.

## Changes

**`server/internal/handler/agent.go`**
- `UpdateAgent`: add the same `agent_workspace_name_unique` constraint check
  that `CreateAgent` already has; return 409 Conflict with a named-field
  message instead of 500.

**`server/internal/service/task.go`**
- Add `ErrTaskAlreadyPending` sentinel and a shared
  `isPendingTaskDedupViolation(err)` helper.
- Apply it at **both** write points of `idx_one_pending_task_per_issue_agent`:
  `enqueueMentionTaskWithCommentPlan` and `enqueueIssueTaskWithCommentPlan`.
  On the dedup race: log at `slog.Info` (not `slog.Error`) and return the
  typed sentinel so callers can distinguish it from a genuine failure.

**`server/internal/handler/comment.go`**
- In `dispatchCommentAgentTriggers`: recognise `ErrTaskAlreadyPending` and
  record `DispatchDeferred/ReasonAlreadyActive` instead of
  `DispatchBlocked/ReasonInternalError` — the active task's completion
  reconciliation handles the deferred comment (same semantics the
  post-merge-miss path already uses).

**`server/internal/handler/task_enqueue_dedup_test.go`** (new, DB-backed)
- `TestEnqueueTaskForMention_DuplicatePendingIsTypedDedup` — second mention
  enqueue returns `ErrTaskAlreadyPending`, exactly 1 pending task remains.
- `TestEnqueueTaskForIssue_DuplicatePendingIsTypedDedup` — same contract on
  the assignee path.
- `TestUpdateAgent_NameCollisionReturns409` — rename onto a taken name
  returns 409 with a message naming the conflict, not 500.

## Test plan

- [x] `go test ./internal/handler/ ./internal/service/` against a live
  Postgres (migrations at 223) — all pass, including the 3 new regression
  tests.
- [x] `go vet` clean; changed files `gofmt`-clean.
- [x] `go test ./...` (full server suite) — all pass.

Fixes #5914