### PR TITLE
MUL-5317: fix S3-backed inline media in Desktop

### DIFF
--- a/server/internal/handler/file.go
+++ b/server/internal/handler/file.go
@@ -571,7 +571,22 @@ func (h *Handler) GetAttachmentByID(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	writeJSON(w, http.StatusOK, h.attachmentToResponse(att))
+	resp := h.attachmentToResponse(att)
+	// Token-mode clients use this authenticated endpoint to replace the
+	// auth-gated API path with a URL that native media elements can load.
+	if h.CFSigner == nil && h.resolveAttachmentDownloadMode(att.Url) == attachmentDownloadModePresign {
+		if presigner, ok := h.Storage.(storage.Presigner); ok {
+			key := h.Storage.KeyFromURL(att.Url)
+			signedURL, err := presigner.PresignGet(r.Context(), key, h.attachmentDownloadURLTTL())
+			if err != nil {
+				slog.Warn("failed to presign inline attachment URL", "id", uuidToString(att.ID), "key", key, "error", err)
+			} else {
+				resp.DownloadURL = signedURL
+			}
+		}
+	}
+
+	writeJSON(w, http.StatusOK, resp)
 }
 
 func (h *Handler) loadAttachmentForRequest(w http.ResponseWriter, r *http.Request) (db.Attachment, bool) {

--- a/server/internal/handler/file.go
+++ b/server/internal/handler/file.go
@@ -574,10 +574,16 @@ func (h *Handler) GetAttachmentByID(w http.ResponseWriter, r *http.Request) {
 	resp := h.attachmentToResponse(att)
 	// Token-mode clients use this authenticated endpoint to replace the
 	// auth-gated API path with a URL that native media elements can load.
+	// Assert the same storage.DownloadPresigner that resolveAttachmentDownloadMode
+	// keys its presign decision on, so the mode resolution and the presign call
+	// can never disagree. An empty content disposition inherits the object's
+	// stored Content-Disposition (inline for media, attachment otherwise), which
+	// keeps images renderable inline while preserving the original download
+	// filename.
 	if h.CFSigner == nil && h.resolveAttachmentDownloadMode(att.Url) == attachmentDownloadModePresign {
-		if presigner, ok := h.Storage.(storage.Presigner); ok {
+		if presigner, ok := h.Storage.(storage.DownloadPresigner); ok {
 			key := h.Storage.KeyFromURL(att.Url)
-			signedURL, err := presigner.PresignGet(r.Context(), key, h.attachmentDownloadURLTTL())
+			signedURL, err := presigner.PresignGetWithContentDisposition(r.Context(), key, h.attachmentDownloadURLTTL(), "")
 			if err != nil {
 				slog.Warn("failed to presign inline attachment URL", "id", uuidToString(att.ID), "key", key, "error", err)
 			} else {

--- a/server/internal/handler/file_test.go
+++ b/server/internal/handler/file_test.go
@@ -642,6 +642,64 @@ func TestAttachmentToResponse_NonCloudFrontUsesDownloadEndpoint(t *testing.T) {
 	}
 }
 
+func TestGetAttachmentByID_AutoPublicEndpointReturnsPresignedDownloadURL(t *testing.T) {
+	store := &mockStorageNoCdn{}
+	origStorage := testHandler.Storage
+	origCfg := testHandler.cfg
+	origSigner := testHandler.CFSigner
+	testHandler.Storage = store
+	testHandler.cfg.AttachmentDownloadMode = "auto"
+	testHandler.CFSigner = nil
+	t.Cleanup(func() {
+		testHandler.Storage = origStorage
+		testHandler.cfg = origCfg
+		testHandler.CFSigner = origSigner
+	})
+
+	key := "downloads/desktop-inline.png"
+	id := seedAttachmentURL(
+		t,
+		"https://s3.example.com/test-bucket/"+key,
+		"desktop-inline.png",
+		"image/png",
+		10,
+	)
+
+	req := httptest.NewRequest("GET", "/api/attachments/"+id, nil)
+	req.Header.Set("X-User-ID", testUserID)
+	req.Header.Set("X-Workspace-ID", testWorkspaceID)
+	rctx := chi.NewRouteContext()
+	rctx.URLParams.Add("id", id)
+	req = req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, rctx))
+	w := httptest.NewRecorder()
+
+	testHandler.GetAttachmentByID(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", w.Code, w.Body.String())
+	}
+	var resp AttachmentResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode response: %v; body=%s", err, w.Body.String())
+	}
+	parsed, err := url.Parse(resp.DownloadURL)
+	if err != nil {
+		t.Fatalf("parse download_url: %v", err)
+	}
+	if got := parsed.Query().Get("X-Amz-Signature"); got != "mock" {
+		t.Fatalf("download_url = %q, want S3 presigned URL", resp.DownloadURL)
+	}
+	if got := parsed.Query().Get("response-content-disposition"); got != "" {
+		t.Fatalf("response-content-disposition = %q, want inline-loadable URL", got)
+	}
+	if want := "/api/attachments/" + id + "/download"; resp.MarkdownURL != want {
+		t.Fatalf("markdown_url = %q, want stable URL %q", resp.MarkdownURL, want)
+	}
+	if len(store.presignCalls) != 1 || store.presignCalls[0] != key {
+		t.Fatalf("presign calls = %v, want [%s]", store.presignCalls, key)
+	}
+}
+
 func TestDownloadAttachment_CloudFrontRedirectSignsAttachmentDisposition(t *testing.T) {
 	origStorage := testHandler.Storage
 	origCfg := testHandler.cfg


### PR DESCRIPTION
Fixes #5947

## Problem

On a self-hosted v0.4.11 deployment with S3-compatible attachment storage, inline images render in the web app but fail in Desktop. The storage configuration and object are healthy; the failing request chain is:

```text
GET /api/attachments/<id>          200  client_platform=desktop
GET /api/attachments/<id>/download 401  auth: no token found
GET <s3-endpoint>/<bucket>/<key>   200  image/png
```

This was reproduced with a public HTTPS `AWS_ENDPOINT_URL`, `ATTACHMENT_DOWNLOAD_MODE=auto`, and no CloudFront signer. All required S3 settings were present.

## Root cause

Web can load the stable API download path because its same-site session cookie accompanies the native `<img>` request. Desktop and mobile render under `file://` or web views, where native media requests cannot attach the API bearer token.

`useResignedInlineMediaURL` already handles that platform boundary: it calls authenticated `GET /api/attachments/{id}` and expects a fresh directly loadable `download_url`. For a non-CloudFront S3 deployment, `GetAttachmentByID` delegated to `attachmentToResponse`, which returned `/api/attachments/{id}/download` again. The refresh therefore could not upgrade the media URL, and the native request received 401.

## Change

- when attachment download mode resolves to `presign` and storage implements `storage.Presigner`, return a fresh `PresignGet` URL from `GET /api/attachments/{id}`
- update only `download_url`; keep the durable `markdown_url` on `/api/attachments/{id}/download`
- omit a forced `Content-Disposition` override so image and video elements can render inline
- retain the existing API-path fallback and log a warning if presigning fails

CloudFront-signed, proxy-mode, and internal-only storage behavior remains unchanged.

## Regression coverage

The handler-level test reproduces an `auto`-mode public S3 endpoint without a CDN and verifies:

- `download_url` contains an S3 signature
- no attachment disposition is added
- `markdown_url` remains stable
- the expected object key is presigned exactly once

## Related work

- #4048 fixed native image URL selection for local `/uploads` storage
- #3721 / #4085 added presigned S3 attachment downloads
- this PR completes the authenticated metadata refresh path used by Desktop inline media for S3-compatible deployments

## Validation

- `go test ./internal/handler -count=1`
- `go test ./internal/storage -count=1`
- `go vet ./internal/handler ./internal/storage`
- `git diff --check`
- all GitHub Actions checks pass
