### PR TITLE
fix(redact): cover AWS STS, OpenPGP, and Slack browser-session credentials

### DIFF
--- a/server/pkg/redact/redact.go
+++ b/server/pkg/redact/redact.go
@@ -17,14 +17,21 @@ type secretPattern struct {
 
 // Patterns are checked in order; first match wins per position.
 var patterns = []secretPattern{
-	// AWS access key IDs (always start with AKIA)
-	{regexp.MustCompile(`\bAKIA[0-9A-Z]{16}\b`), "[REDACTED AWS KEY]"},
+	// AWS access key IDs. AKIA is the long-term IAM user prefix; ASIA marks the
+	// temporary STS credentials produced by assume-role and SSO logins, which are
+	// just as usable until they expire and are what agent output most often
+	// contains. ABIA and ACCA cover the remaining AWS-issued key ID prefixes.
+	{regexp.MustCompile(`\b(?:AKIA|ASIA|ABIA|ACCA)[0-9A-Z]{16}\b`), "[REDACTED AWS KEY]"},
 
 	// AWS secret access keys (40 char base64-ish, preceded by a common separator)
 	{regexp.MustCompile(`(?i)(?:aws_secret_access_key|secret_?access_?key)\s*[=:]\s*[A-Za-z0-9/+=]{40}`), "[REDACTED AWS SECRET]"},
 
-	// PEM private keys (multi-line)
-	{regexp.MustCompile(`(?s)-----BEGIN[A-Z\s]*PRIVATE KEY-----.*?-----END[A-Z\s]*PRIVATE KEY-----`), "[REDACTED PRIVATE KEY]"},
+	// PEM private keys (multi-line). The trailing [A-Z\s]* is what allows the
+	// OpenPGP armor headers, which carry a BLOCK suffix after PRIVATE KEY
+	// ("-----BEGIN PGP PRIVATE KEY BLOCK-----"). Without it only the
+	// RSA/EC/DSA/OPENSSH style markers match and an armored GPG secret key
+	// exported by `gpg --export-secret-keys --armor` leaks in full.
+	{regexp.MustCompile(`(?s)-----BEGIN[A-Z\s]*PRIVATE KEY[A-Z\s]*-----.*?-----END[A-Z\s]*PRIVATE KEY[A-Z\s]*-----`), "[REDACTED PRIVATE KEY]"},
 
 	// GitHub tokens (classic PAT, OAuth, user-to-server, server-to-server, refresh)
 	{regexp.MustCompile(`\b(ghp|gho|ghu|ghs|ghr)_[A-Za-z0-9_]{36,255}\b`), "[REDACTED GITHUB TOKEN]"},
@@ -39,8 +46,10 @@ var patterns = []secretPattern{
 	{regexp.MustCompile(`\bsk-[A-Za-z0-9_-]{20,}\b`), "[REDACTED API KEY]"},
 
 	// Slack bot/user/legacy tokens. The char class includes 'e' so the
-	// newer xoxe- config/refresh tokens are covered alongside xoxb/p/o/r/a/s.
-	{regexp.MustCompile(`\bxox[bporase]-[A-Za-z0-9\-]{10,}\b`), "[REDACTED SLACK TOKEN]"},
+	// newer xoxe- config/refresh tokens are covered alongside xoxb/p/o/r/a/s,
+	// plus 'c' and 'd' for the xoxc-/xoxd- browser-session pair, which grants
+	// full user-level API access and is commonly pasted into shell sessions.
+	{regexp.MustCompile(`\bxox[bporasecd]-[A-Za-z0-9\-]{10,}\b`), "[REDACTED SLACK TOKEN]"},
 
 	// Slack app-level tokens use the xapp- prefix, which the xox*- rule above
 	// does not match. Without this an app-level token echoed in agent output

--- a/server/pkg/redact/redact_test.go
+++ b/server/pkg/redact/redact_test.go
@@ -70,6 +70,54 @@ func TestRedactGitHubFineGrainedToken(t *testing.T) {
 	}
 }
 
+// TestRedactAWSTemporaryAccessKey guards the ASIA prefix used by AWS STS
+// temporary credentials, which assume-role and SSO logins hand out. They grant
+// the same access as a long-term AKIA key until they expire, but the original
+// pattern only matched AKIA, so an agent printing ~/.aws/credentials or its own
+// environment leaked them unredacted.
+func TestRedactAWSTemporaryAccessKey(t *testing.T) {
+	t.Parallel()
+	if got := Text("AWS_ACCESS_KEY_ID is " + asm("ASIA", "IOSFODNN7EXAMPLE")); strings.Contains(got, asm("ASIA", "IOSFODNN7")) {
+		t.Fatalf("AWS temporary access key not redacted: %s", got)
+	}
+	if got := Text("key " + asm("ABIA", "IOSFODNN7EXAMPLE")); !strings.Contains(got, "[REDACTED AWS KEY]") {
+		t.Fatalf("AWS bearer access key not redacted: %s", got)
+	}
+	// A word that merely starts with ASIA must survive untouched.
+	if got := Text("ASIAPACIFIC region"); !strings.Contains(got, "ASIAPACIFIC") {
+		t.Fatalf("ordinary word should NOT be redacted: %s", got)
+	}
+}
+
+// TestRedactPGPPrivateKeyBlock guards the OpenPGP armor headers, whose BLOCK
+// suffix sits between "PRIVATE KEY" and the closing dashes. The original PEM
+// pattern required those dashes immediately after "PRIVATE KEY", so an armored
+// GPG secret key reached the DB / WS broadcast in full.
+func TestRedactPGPPrivateKeyBlock(t *testing.T) {
+	t.Parallel()
+	input := "backup:\n-----BEGIN PGP PRIVATE KEY BLOCK-----\nlQdGBGT0abcdef\n-----END PGP PRIVATE KEY BLOCK-----\nDone."
+	got := Text(input)
+	if strings.Contains(got, "lQdGBGT0abcdef") {
+		t.Fatalf("PGP private key content not redacted: %s", got)
+	}
+	if !strings.Contains(got, "[REDACTED PRIVATE KEY]") {
+		t.Fatalf("expected [REDACTED PRIVATE KEY] placeholder, got: %s", got)
+	}
+}
+
+// TestRedactSlackBrowserSessionTokens guards the xoxc-/xoxd- pair used by the
+// Slack web client. Together they authenticate as the user against the full
+// Slack API, but the char class covered only b/p/o/r/a/s/e.
+func TestRedactSlackBrowserSessionTokens(t *testing.T) {
+	t.Parallel()
+	if got := Text("client token " + asm("xoxc-", "1234567890-0987654321-abcdefghijklm")); strings.Contains(got, asm("xoxc-", "1234567890")) {
+		t.Fatalf("Slack client token not redacted: %s", got)
+	}
+	if got := Text("cookie " + asm("xoxd-", "1234567890abcdefghijklmnop")); !strings.Contains(got, "[REDACTED SLACK TOKEN]") {
+		t.Fatalf("Slack session cookie token not redacted: %s", got)
+	}
+}
+
 func TestRedactGoogleAPIKeyEndingWithDash(t *testing.T) {
 	t.Parallel()
 	input := `the config file still had "` + asm("AIza", "SyB1cD3fGhIjKlMnOpQrStUvWxYz012345-") + `" in it`


### PR DESCRIPTION
## What does this PR do?

`server/pkg/redact` exists to keep secrets out of the database and the WebSocket broadcast, but three credential formats slip through its pattern table today. Each is a live credential an agent can realistically print, and each reaches the DB and every connected client verbatim.

**1. AWS temporary credentials (`ASIA…`).** The rule matches only `AKIA`, the long-term IAM user prefix. Every `aws sts assume-role` and `aws sso login` session instead issues an `ASIA` key ID of the same 20-character shape, which is exactly what an agent sees when it prints its own environment or `~/.aws/credentials`. Those are the credentials most likely to be in scope on a machine running an agent, and they were the ones not covered. I also added the remaining AWS-issued prefixes `ABIA` and `ACCA` while touching the pattern.

**2. OpenPGP armored private keys.** The PEM rule requires the closing dashes immediately after `PRIVATE KEY`, so it matches `-----BEGIN RSA PRIVATE KEY-----` but not `-----BEGIN PGP PRIVATE KEY BLOCK-----`, where `BLOCK` sits in between. A secret key exported with `gpg --export-secret-keys --armor` therefore leaks in full, key material included.

**3. Slack browser-session tokens (`xoxc-` / `xoxd-`).** The character class covers `b/p/o/r/a/s/e` but not `c` and `d`. That pair is what the Slack web client authenticates with, and together they grant full user-level API access.

Approach is deliberately the same as the two previous fixes to this file (#5274, #4678): extend the existing patterns in place rather than adding parallel rules, and keep each addition narrow enough not to widen the false-positive surface. For AWS that meant a prefix alternation rather than a looser character class, so an ordinary word like `ASIAPACIFIC` is still left alone (covered by a test).

## Related Issue

No existing issue. I did not open one first because a public issue for this would amount to a short guide to which secret formats currently slip past the redactor, and the fix is small enough to review directly. Happy to file one if you'd prefer the tracking record.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Refactor / code improvement (no behavior change)
- [ ] Documentation update
- [ ] Tests (adding or improving test coverage)
- [ ] CI / infrastructure

## Changes Made

- `server/pkg/redact/redact.go`
  - AWS access key ID rule: `\bAKIA[0-9A-Z]{16}\b` → `\b(?:AKIA|ASIA|ABIA|ACCA)[0-9A-Z]{16}\b`
  - PEM private key rule: allow an uppercase-word suffix after `PRIVATE KEY` on both markers, so OpenPGP armor headers match
  - Slack token rule: `xox[bporase]-` → `xox[bporasecd]-`
- `server/pkg/redact/redact_test.go`
  - `TestRedactAWSTemporaryAccessKey` — covers `ASIA` and `ABIA`, plus a negative case asserting `ASIAPACIFIC` is not redacted
  - `TestRedactPGPPrivateKeyBlock` — asserts armored key material is replaced by the `[REDACTED PRIVATE KEY]` placeholder
  - `TestRedactSlackBrowserSessionTokens` — covers `xoxc-` and `xoxd-`

Test fixtures use the existing `asm()` helper so no credential-shaped literal appears contiguously in source, matching what #5274 established for secret-scanner friendliness.

## How to Test

1. `cd server && go test ./pkg/redact/` — passes (whole package, 26 tests).
2. To see the bugs: `git stash push server/pkg/redact/redact.go` (keeping the new tests), then `go test ./pkg/redact/ -run 'TestRedactAWSTemporaryAccessKey|TestRedactPGPPrivateKeyBlock|TestRedactSlackBrowserSessionTokens'`. All three fail, e.g. the PGP one reports `PGP private key content not redacted:` followed by the full unredacted key block. `git stash pop` and they pass.
3. `gofmt -l server/pkg/redact/` is clean and `go vet ./pkg/redact/` passes.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [ ] I have updated relevant documentation to reflect my changes
- [ ] If I added a new runtime / coding tool / UI tab, I synced the change to **landing copy** and **relevant docs**
- [ ] If this PR touches Chinese product copy, I checked it against `conventions.zh.mdx`
- [x] I have considered and documented any risks above
- [x] I will address all reviewer comments before requesting merge

Risk notes: the only behavior change is that more strings get redacted. The AWS change is a bounded prefix alternation, so the false-positive surface grows only by the three added prefixes followed by exactly 16 uppercase-alphanumeric characters. The PEM change accepts uppercase words and whitespace between `PRIVATE KEY` and the closing dashes, which still requires both a full BEGIN and a matching END marker. No behavior outside `redact` changes, and no existing test needed modification.

## AI Disclosure

**AI tool used:** Claude Code

**Prompt / approach:** I had it audit `server/pkg/redact` specifically for credential formats that are issued in the wild but absent from the pattern table, then require a failing Go test against current `main` for each candidate before I'd look at it. Several candidates it proposed I dropped, either because the existing generic `key=value` rule already caught them or because the pattern would have been too loose. For the three that survived, I checked each format against the issuing vendor's documented shape, confirmed the before/after test behavior myself, and reviewed the regex changes for false-positive risk (the `ASIAPACIFIC` negative test came out of that). I can speak to any line of this if you have questions.
