### PR TITLE
fix(agent): drain trailing ACP notifications in kimi, kiro, qoder, and traecli

### DIFF
--- a/server/pkg/agent/grok.go
+++ b/server/pkg/agent/grok.go
@@ -567,31 +567,7 @@ func selectGrokAuthMethod(methods []string, haveAPIKey bool) (string, error) {
 // session/prompt response. Without this window, cancelling the process at the
 // response boundary can truncate the final text or usage update.
 func waitForGrokNotificationQuiescence(ctx context.Context, activity <-chan struct{}, readerDone <-chan struct{}) {
-	quiet := time.NewTimer(grokNotificationQuietTime)
-	defer quiet.Stop()
-	hard := time.NewTimer(grokReaderDrainGrace)
-	defer hard.Stop()
-
-	for {
-		select {
-		case <-activity:
-			if !quiet.Stop() {
-				select {
-				case <-quiet.C:
-				default:
-				}
-			}
-			quiet.Reset(grokNotificationQuietTime)
-		case <-quiet.C:
-			return
-		case <-readerDone:
-			return
-		case <-hard.C:
-			return
-		case <-ctx.Done():
-			return
-		}
-	}
+	waitForACPNotificationQuiescence(ctx, activity, readerDone, grokNotificationQuietTime, grokReaderDrainGrace)
 }
 
 // envHasNonEmpty reports whether an `os/exec`-style env slice

--- a/server/pkg/agent/hermes.go
+++ b/server/pkg/agent/hermes.go
@@ -633,26 +633,45 @@ func (b *hermesBackend) Execute(ctx context.Context, prompt string, opts ExecOpt
 // may deliver the final agent_message_chunk after the response; closing stdin
 // or cancelling immediately at that boundary loses the user-visible answer.
 func waitForHermesNotificationQuiescence(ctx context.Context, activity <-chan struct{}, readerDone <-chan struct{}) {
-	quiet := time.NewTimer(hermesNotificationQuietTime)
-	defer quiet.Stop()
-	hard := time.NewTimer(hermesReaderDrainGrace)
-	defer hard.Stop()
+	waitForACPNotificationQuiescence(ctx, activity, readerDone, hermesNotificationQuietTime, hermesReaderDrainGrace)
+}
+
+// acpNotificationQuietTime is the default lull the shared drain waits out
+// before concluding an ACP agent has stopped emitting notifications. It is a
+// protocol-level heuristic rather than a per-backend trait, so backends that
+// have no reason to differ share it; the hard bound stays per-backend.
+const acpNotificationQuietTime = 250 * time.Millisecond
+
+// waitForACPNotificationQuiescence gives the shared ACP stdout reader a
+// bounded chance to consume notifications a backend may emit just after its
+// session/prompt response returns. Closing stdin and cancelling the context at
+// the response boundary otherwise races the reader and silently truncates the
+// final text or usage update.
+//
+// It returns as soon as any of these happens, so an agent that holds stdout
+// open forever cannot stall the turn: no notification arrived for quiet, the
+// reader finished, hard elapsed, or ctx was cancelled.
+func waitForACPNotificationQuiescence(ctx context.Context, activity <-chan struct{}, readerDone <-chan struct{}, quiet, hard time.Duration) {
+	quietTimer := time.NewTimer(quiet)
+	defer quietTimer.Stop()
+	hardTimer := time.NewTimer(hard)
+	defer hardTimer.Stop()
 
 	for {
 		select {
 		case <-activity:
-			if !quiet.Stop() {
+			if !quietTimer.Stop() {
 				select {
-				case <-quiet.C:
+				case <-quietTimer.C:
 				default:
 				}
 			}
-			quiet.Reset(hermesNotificationQuietTime)
-		case <-quiet.C:
+			quietTimer.Reset(quiet)
+		case <-quietTimer.C:
 			return
 		case <-readerDone:
 			return
-		case <-hard.C:
+		case <-hardTimer.C:
 			return
 		case <-ctx.Done():
 			return

--- a/server/pkg/agent/kimi.go
+++ b/server/pkg/agent/kimi.go
@@ -19,6 +19,11 @@ var kimiBlockedArgs = map[string]blockedArgMode{
 	"acp": blockedStandalone,
 }
 
+// kimiReaderDrainGrace bounds how long the turn waits for trailing ACP
+// notifications after the session/prompt response. A var, not a const, so
+// tests can shorten it. Mirrors qoderReaderDrainGrace / traecliReaderDrainGrace.
+var kimiReaderDrainGrace = 2 * time.Second
+
 // kimiBackend implements Backend by spawning `kimi acp` and communicating
 // via the ACP (Agent Client Protocol) JSON-RPC 2.0 over stdin/stdout.
 //
@@ -115,6 +120,7 @@ func (b *kimiBackend) Execute(ctx context.Context, prompt string, opts ExecOptio
 	var output strings.Builder
 
 	promptDone := make(chan hermesPromptResult, 1)
+	activity := make(chan struct{}, 1)
 
 	// Reuse the hermesClient ACP transport — Kimi speaks the same protocol.
 	c := &hermesClient{
@@ -122,6 +128,12 @@ func (b *kimiBackend) Execute(ctx context.Context, prompt string, opts ExecOptio
 		stdin:        stdin,
 		pending:      make(map[int]*pendingRPC),
 		pendingTools: make(map[string]*pendingToolCall),
+		onActivity: func() {
+			select {
+			case activity <- struct{}{}:
+			default:
+			}
+		},
 		onMessage: func(msg Message) {
 			// hermesClient.handleToolCallStart has already mapped
 			// the raw ACP title via hermesToolNameFromTitle — which
@@ -353,6 +365,7 @@ func (b *kimiBackend) Execute(ctx context.Context, prompt string, opts ExecOptio
 				c.usageMu.Unlock()
 			default:
 			}
+			waitForACPNotificationQuiescence(runCtx, activity, readerDone, acpNotificationQuietTime, kimiReaderDrainGrace)
 		}
 
 		duration := time.Since(startTime)

--- a/server/pkg/agent/kimi_test.go
+++ b/server/pkg/agent/kimi_test.go
@@ -66,7 +66,7 @@ func fakeKimiACPScript() string {
 #
 # Writes the full argv (one arg per line) to $KIMI_ARGS_FILE if that env
 # var is set, so tests can assert that the daemon invokes us with the
-# right flags (`+"`--yolo acp`"+`, not bare `+"`acp`"+`).
+# right flags (` + "`--yolo acp`" + `, not bare ` + "`acp`" + `).
 #
 # Then reads one JSON-RPC request per line from stdin, matches on the
 # method name, and writes back a canned response. Exits after set_model
@@ -156,6 +156,38 @@ func TestKimiBackendSetModelFailureFailsTask(t *testing.T) {
 // actually does — RequestError.invalid_params (-32602) with
 // {"session_id": "Session not found"} in data
 // (src/kimi_cli/acp/server.py, set_session_model).
+// fakeKimiACPPromptScript is a fake `kimi` binary that completes a full
+// ACP turn: initialize, session/new, session/prompt with a streamed
+// message chunk, then the prompt response. When $KIMI_LATE_CHUNK is set
+// it emits one more chunk shortly AFTER the session/prompt response, the
+// way a real ACP agent can, so tests can prove the backend drains
+// trailing notifications instead of cutting the process off at the
+// response boundary.
+func fakeKimiACPPromptScript() string {
+	return `#!/bin/sh
+while IFS= read -r line; do
+  id=$(printf '%s' "$line" | sed -n 's/.*"id":\([0-9]*\).*/\1/p')
+  case "$line" in
+    *'"method":"initialize"'*)
+      printf '{"jsonrpc":"2.0","id":%s,"result":{"protocolVersion":1,"agentCapabilities":{}}}\n' "$id"
+      ;;
+    *'"method":"session/new"'*)
+      printf '{"jsonrpc":"2.0","id":%s,"result":{"sessionId":"ses_fake"}}\n' "$id"
+      ;;
+    *'"method":"session/prompt"'*)
+      printf '{"jsonrpc":"2.0","method":"session/update","params":{"sessionId":"ses_fake","update":{"sessionUpdate":"agent_message_chunk","content":{"type":"text","text":"pong"}}}}\n'
+      printf '{"jsonrpc":"2.0","id":%s,"result":{"stopReason":"end_turn"}}\n' "$id"
+      if [ -n "$KIMI_LATE_CHUNK" ]; then
+        sleep 0.05
+        printf '{"jsonrpc":"2.0","method":"session/update","params":{"sessionId":"ses_fake","update":{"sessionUpdate":"agent_message_chunk","content":{"type":"text","text":" tail"}}}}\n'
+      fi
+      exit 0
+      ;;
+  esac
+done
+`
+}
+
 func fakeKimiACPStaleResumeSetModelScript() string {
 	return `#!/bin/sh
 while IFS= read -r line; do
@@ -333,5 +365,44 @@ func TestKimiResumeIncludesMcpServers(t *testing.T) {
 	}
 	if len(servers) != 1 || servers[0].(map[string]any)["name"] != "fetch" {
 		t.Fatalf("session/resume.mcpServers: got %v, want one entry named fetch", servers)
+	}
+}
+
+// TestKimiDrainsNotificationsAfterPromptResponse pins the trailing-notification
+// drain. kimi ACP can emit a final session update just after the
+// session/prompt response returns; closing stdin and cancelling the context at
+// that boundary raced the stdout reader and silently truncated the last chunk.
+// The same defect was fixed for the sibling ACP backends in #5440 (grok) and
+// #5675 (hermes).
+func TestKimiDrainsNotificationsAfterPromptResponse(t *testing.T) {
+	t.Parallel()
+
+	fakePath := filepath.Join(t.TempDir(), "kimi")
+	writeTestExecutable(t, fakePath, []byte(fakeKimiACPPromptScript()))
+
+	backend, err := New("kimi", Config{
+		ExecutablePath: fakePath,
+		Logger:         slog.Default(),
+		Env:            map[string]string{"KIMI_LATE_CHUNK": "1"},
+	})
+	if err != nil {
+		t.Fatalf("new kimi backend: %v", err)
+	}
+
+	session, err := backend.Execute(context.Background(), "task", ExecOptions{Timeout: 5 * time.Second})
+	if err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	go func() {
+		for range session.Messages {
+		}
+	}()
+
+	result := <-session.Result
+	if result.Status != "completed" {
+		t.Fatalf("expected completed, got status=%q error=%q", result.Status, result.Error)
+	}
+	if !strings.Contains(result.Output, "pong tail") {
+		t.Fatalf("late output was truncated: %q", result.Output)
 	}
 }

--- a/server/pkg/agent/kiro.go
+++ b/server/pkg/agent/kiro.go
@@ -13,6 +13,11 @@ import (
 	"time"
 )
 
+// kiroReaderDrainGrace bounds how long the turn waits for trailing ACP
+// notifications after the session/prompt response. A var, not a const, so
+// tests can shorten it. Mirrors qoderReaderDrainGrace / traecliReaderDrainGrace.
+var kiroReaderDrainGrace = 2 * time.Second
+
 // kiroBlockedArgs are flags hardcoded by the daemon that must not be
 // overridden by user-configured custom_args. `acp` is the protocol subcommand,
 // and --trust-all-tools covers Kiro's CLI-level tool gate while
@@ -132,6 +137,7 @@ func (b *kiroBackend) Execute(ctx context.Context, prompt string, opts ExecOptio
 	var lastFinishingResultStatus string // "", "completed", or "failed"
 
 	promptDone := make(chan hermesPromptResult, 1)
+	activity := make(chan struct{}, 1)
 
 	c := &hermesClient{
 		cfg:          b.cfg,
@@ -140,6 +146,12 @@ func (b *kiroBackend) Execute(ctx context.Context, prompt string, opts ExecOptio
 		pendingTools: make(map[string]*pendingToolCall),
 		acceptNotification: func(string) bool {
 			return streamingCurrentTurn.Load()
+		},
+		onActivity: func() {
+			select {
+			case activity <- struct{}{}:
+			default:
+			}
 		},
 		onMessage: func(msg Message) {
 			if !streamingCurrentTurn.Load() {
@@ -432,6 +444,7 @@ func (b *kiroBackend) Execute(ctx context.Context, prompt string, opts ExecOptio
 				c.usageMu.Unlock()
 			default:
 			}
+			waitForACPNotificationQuiescence(runCtx, activity, readerDone, acpNotificationQuietTime, kiroReaderDrainGrace)
 		}
 
 		duration := time.Since(startTime)

--- a/server/pkg/agent/kiro_test.go
+++ b/server/pkg/agent/kiro_test.go
@@ -107,6 +107,10 @@ while IFS= read -r line; do
       printf '{"jsonrpc":"2.0","method":"session/notification","params":{"sessionId":"ses_loaded","update":{"type":"ToolCallUpdate","toolCallId":"tc-current","status":"completed","name":"Shell","parameters":{"command":"echo current"},"output":"current tool output\\n"}}}\n'
       printf '{"jsonrpc":"2.0","method":"session/notification","params":{"sessionId":"ses_loaded","update":{"type":"AgentMessageChunk","content":{"type":"text","text":"loaded"}}}}\n'
       printf '{"jsonrpc":"2.0","id":%s,"result":{"stopReason":"end_turn","usage":{"inputTokens":2,"outputTokens":1,"cacheReadTokens":7,"cacheWriteTokens":3}}}\n' "$id"
+      if [ -n "$KIRO_LATE_CHUNK" ]; then
+        sleep 0.05
+        printf '{"jsonrpc":"2.0","method":"session/notification","params":{"sessionId":"ses_loaded","update":{"type":"AgentMessageChunk","content":{"type":"text","text":" tail"}}}}\n'
+      fi
       exit 0
       ;;
   esac
@@ -1104,7 +1108,6 @@ func TestKiroLoadIncludesMcpServersFromConfig(t *testing.T) {
 	}
 }
 
-
 // TestIsKiroOversizedHistoryImage pins the detector for the GH #5975 shape: a
 // resumed conversation whose history replays an image exceeding the provider's
 // max pixel dimensions, rejected at session/prompt as a -32603 that names the
@@ -1276,5 +1279,45 @@ func TestKiroFreshOversizedHistoryImageDoesNotSignalResumeRejected(t *testing.T)
 	}
 	if result.SessionID != "ses_fresh" {
 		t.Fatalf("expected the fresh session id, got %q", result.SessionID)
+	}
+}
+
+// TestKiroDrainsNotificationsAfterPromptResponse pins the trailing-notification
+// drain. kiro ACP can emit a final session update just after the
+// session/prompt response returns; closing stdin and cancelling the context at
+// that boundary raced the stdout reader and silently truncated the last chunk.
+// The same defect was fixed for the sibling ACP backends in #5440 (grok) and
+// #5675 (hermes).
+func TestKiroDrainsNotificationsAfterPromptResponse(t *testing.T) {
+	t.Parallel()
+
+	fakePath := filepath.Join(t.TempDir(), "kiro-cli")
+	writeTestExecutable(t, fakePath, []byte(fakeKiroACPScript()))
+
+	backend, err := New("kiro", Config{
+		ExecutablePath: fakePath,
+		Logger:         slog.Default(),
+		Env:            map[string]string{"KIRO_LATE_CHUNK": "1"},
+	})
+	if err != nil {
+		t.Fatalf("new kiro backend: %v", err)
+	}
+
+	session, err := backend.Execute(context.Background(), "task", ExecOptions{Timeout: 5 * time.Second})
+	if err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+
+	go func() {
+		for range session.Messages {
+		}
+	}()
+
+	result := <-session.Result
+	if result.Status != "completed" {
+		t.Fatalf("expected completed, got status=%q error=%q", result.Status, result.Error)
+	}
+	if !strings.Contains(result.Output, "loaded tail") {
+		t.Fatalf("late output was truncated: %q", result.Output)
 	}
 }

--- a/server/pkg/agent/qoder.go
+++ b/server/pkg/agent/qoder.go
@@ -146,6 +146,7 @@ func (b *qoderBackend) Execute(ctx context.Context, prompt string, opts ExecOpti
 	var streamingCurrentTurn atomic.Bool
 
 	promptDone := make(chan hermesPromptResult, 1)
+	activity := make(chan struct{}, 1)
 
 	c := &hermesClient{
 		cfg:          b.cfg,
@@ -154,6 +155,12 @@ func (b *qoderBackend) Execute(ctx context.Context, prompt string, opts ExecOpti
 		pendingTools: make(map[string]*pendingToolCall),
 		acceptNotification: func(string) bool {
 			return streamingCurrentTurn.Load()
+		},
+		onActivity: func() {
+			select {
+			case activity <- struct{}{}:
+			default:
+			}
 		},
 		onMessage: func(msg Message) {
 			if !streamingCurrentTurn.Load() {
@@ -373,6 +380,7 @@ func (b *qoderBackend) Execute(ctx context.Context, prompt string, opts ExecOpti
 				c.usageMu.Unlock()
 			default:
 			}
+			waitForACPNotificationQuiescence(runCtx, activity, readerDone, acpNotificationQuietTime, qoderReaderDrainGrace)
 		}
 
 		duration := time.Since(startTime)

--- a/server/pkg/agent/qoder_test.go
+++ b/server/pkg/agent/qoder_test.go
@@ -35,6 +35,10 @@ while IFS= read -r line; do
     *'"method":"session/prompt"'*)
       printf '{"jsonrpc":"2.0","method":"session/notification","params":{"sessionId":"ses_fake","update":{"type":"AgentMessageChunk","content":{"type":"text","text":"ok"}}}}\n'
       printf '{"jsonrpc":"2.0","id":%s,"result":{"stopReason":"end_turn","usage":{"inputTokens":1,"outputTokens":2}}}\n' "$id"
+      if [ -n "$QODER_LATE_CHUNK" ]; then
+        sleep 0.05
+        printf '{"jsonrpc":"2.0","method":"session/notification","params":{"sessionId":"ses_fake","update":{"type":"AgentMessageChunk","content":{"type":"text","text":" tail"}}}}\n'
+      fi
       exit 0
       ;;
   esac
@@ -789,5 +793,44 @@ func TestQoderBackendClearsSessionIDWhenResumedSessionNotFoundAtSetModel(t *test
 		}
 	case <-time.After(10 * time.Second):
 		t.Fatal("timeout waiting for result")
+	}
+}
+
+// TestQoderDrainsNotificationsAfterPromptResponse pins the trailing-notification
+// drain. qoder ACP can emit a final session update just after the
+// session/prompt response returns; closing stdin and cancelling the context at
+// that boundary raced the stdout reader and silently truncated the last chunk.
+// The same defect was fixed for the sibling ACP backends in #5440 (grok) and
+// #5675 (hermes).
+func TestQoderDrainsNotificationsAfterPromptResponse(t *testing.T) {
+	t.Parallel()
+
+	fakePath := filepath.Join(t.TempDir(), "qoder")
+	writeTestExecutable(t, fakePath, []byte(fakeQoderACPScript()))
+
+	backend, err := New("qoder", Config{
+		ExecutablePath: fakePath,
+		Logger:         slog.Default(),
+		Env:            map[string]string{"QODER_LATE_CHUNK": "1"},
+	})
+	if err != nil {
+		t.Fatalf("new qoder backend: %v", err)
+	}
+
+	session, err := backend.Execute(context.Background(), "task", ExecOptions{Timeout: 5 * time.Second})
+	if err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	go func() {
+		for range session.Messages {
+		}
+	}()
+
+	result := <-session.Result
+	if result.Status != "completed" {
+		t.Fatalf("expected completed, got status=%q error=%q", result.Status, result.Error)
+	}
+	if !strings.Contains(result.Output, "ok tail") {
+		t.Fatalf("late output was truncated: %q", result.Output)
 	}
 }

--- a/server/pkg/agent/traecli.go
+++ b/server/pkg/agent/traecli.go
@@ -163,6 +163,7 @@ func (b *traecliBackend) Execute(ctx context.Context, prompt string, opts ExecOp
 	var streamingCurrentTurn atomic.Bool
 
 	promptDone := make(chan hermesPromptResult, 1)
+	activity := make(chan struct{}, 1)
 
 	c := &hermesClient{
 		cfg:          b.cfg,
@@ -171,6 +172,12 @@ func (b *traecliBackend) Execute(ctx context.Context, prompt string, opts ExecOp
 		pendingTools: make(map[string]*pendingToolCall),
 		acceptNotification: func(string) bool {
 			return streamingCurrentTurn.Load()
+		},
+		onActivity: func() {
+			select {
+			case activity <- struct{}{}:
+			default:
+			}
 		},
 		onMessage: func(msg Message) {
 			if !streamingCurrentTurn.Load() {
@@ -381,6 +388,7 @@ func (b *traecliBackend) Execute(ctx context.Context, prompt string, opts ExecOp
 				c.usageMu.Unlock()
 			default:
 			}
+			waitForACPNotificationQuiescence(runCtx, activity, readerDone, acpNotificationQuietTime, traecliReaderDrainGrace)
 		}
 
 		duration := time.Since(startTime)

--- a/server/pkg/agent/traecli_test.go
+++ b/server/pkg/agent/traecli_test.go
@@ -68,6 +68,10 @@ while IFS= read -r line; do
       printf '{"jsonrpc":"2.0","method":"session/update","params":{"sessionId":"ses_new","update":{"sessionUpdate":"tool_call_update","toolCallId":"tc-1","status":"completed","name":"Shell","output":"hi\\n"}}}\n'
       printf '{"jsonrpc":"2.0","method":"session/update","params":{"sessionId":"ses_new","update":{"sessionUpdate":"agent_message_chunk","content":{"type":"text","text":"pong"}}}}\n'
       printf '{"jsonrpc":"2.0","id":%s,"result":{"stopReason":"end_turn"}}\n' "$id"
+      if [ -n "$TRAECLI_LATE_CHUNK" ]; then
+        sleep 0.05
+        printf '{"jsonrpc":"2.0","method":"session/update","params":{"sessionId":"ses_new","update":{"sessionUpdate":"agent_message_chunk","content":{"type":"text","text":" tail"}}}}\n'
+      fi
       exit 0
       ;;
   esac
@@ -285,5 +289,44 @@ func TestTraecliUsesSessionLoadForResume(t *testing.T) {
 	}
 	if strings.Contains(requests, `"method":"session/resume"`) {
 		t.Fatalf("traecli must use session/load (loadSession:true), not session/resume:\n%s", requests)
+	}
+}
+
+// TestTraecliDrainsNotificationsAfterPromptResponse pins the trailing-notification
+// drain. traecli ACP can emit a final session update just after the
+// session/prompt response returns; closing stdin and cancelling the context at
+// that boundary raced the stdout reader and silently truncated the last chunk.
+// The same defect was fixed for the sibling ACP backends in #5440 (grok) and
+// #5675 (hermes).
+func TestTraecliDrainsNotificationsAfterPromptResponse(t *testing.T) {
+	t.Parallel()
+
+	fakePath := filepath.Join(t.TempDir(), "trae")
+	writeTestExecutable(t, fakePath, []byte(fakeTraecliACPScript()))
+
+	backend, err := New("traecli", Config{
+		ExecutablePath: fakePath,
+		Logger:         slog.Default(),
+		Env:            map[string]string{"TRAECLI_LATE_CHUNK": "1"},
+	})
+	if err != nil {
+		t.Fatalf("new traecli backend: %v", err)
+	}
+
+	session, err := backend.Execute(context.Background(), "task", ExecOptions{Timeout: 5 * time.Second})
+	if err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	go func() {
+		for range session.Messages {
+		}
+	}()
+
+	result := <-session.Result
+	if result.Status != "completed" {
+		t.Fatalf("expected completed, got status=%q error=%q", result.Status, result.Error)
+	}
+	if !strings.Contains(result.Output, "pong tail") {
+		t.Fatalf("late output was truncated: %q", result.Output)
 	}
 }


### PR DESCRIPTION
## What does this PR do?

Four ACP backends lose the last chunk of a turn. `kimi`, `kiro`, `qoder`, and `traecli` all end their session goroutine with

```go
stdin.Close()
cancel()
<-readerDone
```

immediately after the `session/prompt` response returns. An ACP agent is free to emit one more `session/update` just after that response — the response and the trailing notification are separate writes, so the agent has not necessarily finished streaming when the RPC resolves. Cancelling at that boundary kills the process and closes the pipe while the notification is still in flight, and the final text or usage update is dropped silently.

This is the same defect that was already fixed twice for the sibling backends: #5440 for `grok` and #5675 for `hermes`, both of which now wire an `onActivity` callback and wait for notification quiescence before tearing down. The remaining four backends were never updated, so `grok.go` and `hermes.go` have the drain while `kimi.go`, `kiro.go`, `qoder.go`, and `traecli.go` have none.

All six share `hermesClient`, and the shared notification path already calls `c.onActivity()` (hermes.go, in the `session/update` / `session/notification` handler). The plumbing was in place — the four backends simply never set the callback and never waited. So the fix is additive: set `onActivity`, then drain before teardown.

**On the shared helper.** `waitForGrokNotificationQuiescence` and `waitForHermesNotificationQuiescence` were byte-identical apart from their constants. Rather than add four more copies, I extracted `waitForACPNotificationQuiescence(ctx, activity, readerDone, quiet, hard)` and made both existing helpers one-line delegations to it. That is behaviour-preserving — each still passes its own constants — and it is why `grok.go` shows a net deletion. If you would rather I left those two files untouched and duplicated the loop instead, say the word and I will.

**The bound stays per-backend.** `qoder` and `traecli` already own `qoderReaderDrainGrace` / `traecliReaderDrainGrace`, and `TestQoderBackendIgnoresLateReaderOutputAfterGrace` lowers that var to assert the drain is bounded. My first attempt hardcoded the hermes constants and broke that test — correctly, because it bypassed qoder's own bound. The version here passes each backend's grace as the hard cap, so that test still passes unchanged. `kimi` and `kiro` had no such var (they blocked on `<-readerDone` unbounded), so I added `kimiReaderDrainGrace` / `kiroReaderDrainGrace` mirroring the existing two.

## Related Issue

No existing issue. This is the unfinished tail of #5440 and #5675 rather than a new report, so it seemed better as a direct PR referencing them. Happy to file a tracking issue if you prefer one.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Refactor / code improvement (no behavior change)
- [ ] Documentation update
- [ ] Tests (adding or improving test coverage)
- [ ] CI / infrastructure

## Changes Made

- `server/pkg/agent/hermes.go` — added `waitForACPNotificationQuiescence` (parameterised by quiet lull and hard bound) plus the shared `acpNotificationQuietTime` default; `waitForHermesNotificationQuiescence` now delegates to it.
- `server/pkg/agent/grok.go` — `waitForGrokNotificationQuiescence` delegates to the shared helper, passing its existing constants. No behaviour change.
- `server/pkg/agent/{kimi,kiro,qoder,traecli}.go` — added an `activity` channel, wired `onActivity` on the shared `hermesClient`, and called `waitForACPNotificationQuiescence` at the end of the successful-prompt branch, before `stdin.Close()` / `cancel()`. `kimi.go` and `kiro.go` also gain a `ReaderDrainGrace` var mirroring qoder/traecli.
- `server/pkg/agent/{kimi,kiro,qoder,traecli}_test.go` — a `*_LATE_CHUNK` hook in each fake ACP script that emits one more `agent_message_chunk` 50ms after the prompt response, and a `Test*DrainsNotificationsAfterPromptResponse` regression test asserting the tail survives. This mirrors `GROK_LATE_CHUNK` and `TestGrokDrainsNotificationsAfterPromptResponse`. `kimi_test.go` needed a new happy-path fake (`fakeKimiACPPromptScript`) since the existing kimi fakes all stop at `session/set_model`.

## How to Test

1. `cd server && go test ./pkg/agent/ -run 'Test(Kimi|Kiro|Qoder|Traecli)DrainsNotificationsAfterPromptResponse' -count=1` — passes.
2. To see the bug, keep the test files and revert the six source files: `git stash push server/pkg/agent/kimi.go server/pkg/agent/kiro.go server/pkg/agent/qoder.go server/pkg/agent/traecli.go server/pkg/agent/grok.go server/pkg/agent/hermes.go`, then rerun. All four fail with `late output was truncated: "pong"` / `"ok"` / `"loaded"` — the tail chunk is gone. `git stash pop` and they pass.
3. Full package: `go test ./pkg/agent/ -count=1 -parallel 4` — ok, 119s, zero failures.
4. `gofmt -l server/pkg/agent/` clean, `go vet ./pkg/agent/` clean.

A note on step 3: at full default parallelism on my machine (`-parallel` = 16 cores) the package has pre-existing flakiness — a rotating handful of tests time out at exactly 5.00s per run. I verified this is not mine: on a baseline with only the test files applied and the source untouched, `TestHermesSetModelPreservesCustomModelIDWithColon` timed out the same way, and every test that failed in a full run passed in isolation under `-count=3`. At `-parallel 4` the suite is fully green. Flagging it in case it is news to you; I have not tried to fix it here.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [ ] I have updated relevant documentation to reflect my changes
- [ ] If I added a new runtime / coding tool / UI tab, I synced the change to **landing copy** and **relevant docs**
- [ ] If this PR touches Chinese product copy, I checked it against `conventions.zh.mdx`
- [x] I have considered and documented any risks above
- [x] I will address all reviewer comments before requesting merge

Risk notes: the drain is bounded on four independent axes — a quiet lull with no notifications, the reader finishing, the per-backend hard grace, and context cancellation — so an agent that holds stdout open cannot stall a turn. Worst case a turn takes up to that backend's existing `ReaderDrainGrace` longer; in the common case the agent exits, `readerDone` closes, and the wait returns immediately. `grok` and `hermes` keep their exact previous timings.

## AI Disclosure

**AI tool used:** Claude Code

**Prompt / approach:** I started from the observation that #5440 and #5675 fixed the same teardown race in two backends and asked whether the other four ACP backends had been updated — a `grep` for `onActivity` across `server/pkg/agent` answered that immediately (2 hits, 4 files with none). From there I required a failing test per backend against current `main` before writing any fix, which is how I found that my first attempt was wrong: hardcoding the hermes constants made `TestQoderBackendIgnoresLateReaderOutputAfterGrace` fail, since qoder's drain window is deliberately governed by its own var that the test lowers. I reworked it to pass each backend's own bound rather than change that test. I also ran the baseline comparison described above before attributing the parallel-run flakiness to something other than this change. Happy to talk through any of it.
