### PR TITLE
Add server-minted cross-workspace agent tokens (BUS-171)

### DIFF
--- a/server/cmd/multica/cmd_agent.go
+++ b/server/cmd/multica/cmd_agent.go
@@ -109,6 +109,32 @@ var agentEnvSetCmd = &cobra.Command{
 	RunE:  runAgentEnvSet,
 }
 
+// Agent cross-workspace grant subcommands (BUS-171). Owner/admin only —
+// this allow-list is what lets a running agent task mint a second, scoped
+// mat_ token into ANOTHER workspace via `multica auth cross-workspace-token`.
+// Widening it is a privilege grant, so every write goes through the audited
+// `/api/agents/{id}/cross-workspace-grants` endpoint, same pattern as
+// `agent env` above.
+
+var agentCrossWorkspaceCmd = &cobra.Command{
+	Use:   "cross-workspace",
+	Short: "Manage the workspaces an agent may mint a cross-workspace token for (audited; owner/admin only)",
+}
+
+var agentCrossWorkspaceGetCmd = &cobra.Command{
+	Use:   "get <agent-id>",
+	Short: "List the workspace IDs an agent is granted cross-workspace access to",
+	Args:  exactArgs(1),
+	RunE:  runAgentCrossWorkspaceGet,
+}
+
+var agentCrossWorkspaceSetCmd = &cobra.Command{
+	Use:   "set <agent-id>",
+	Short: "Replace an agent's cross-workspace grant list wholesale (workspace owner/admin only; every call is recorded)",
+	Args:  exactArgs(1),
+	RunE:  runAgentCrossWorkspaceSet,
+}
+
 var agentSkillsListCmd = &cobra.Command{
 	Use:   "list <agent-id>",
 	Short: "List skills assigned to an agent",
@@ -141,6 +167,7 @@ func init() {
 	agentCmd.AddCommand(agentAvatarCmd)
 	agentCmd.AddCommand(agentSkillsCmd)
 	agentCmd.AddCommand(agentEnvCmd)
+	agentCmd.AddCommand(agentCrossWorkspaceCmd)
 
 	agentSkillsCmd.AddCommand(agentSkillsListCmd)
 	agentSkillsCmd.AddCommand(agentSkillsSetCmd)
@@ -148,6 +175,9 @@ func init() {
 
 	agentEnvCmd.AddCommand(agentEnvGetCmd)
 	agentEnvCmd.AddCommand(agentEnvSetCmd)
+
+	agentCrossWorkspaceCmd.AddCommand(agentCrossWorkspaceGetCmd)
+	agentCrossWorkspaceCmd.AddCommand(agentCrossWorkspaceSetCmd)
 
 	// agent list
 	agentListCmd.Flags().String("output", "table", "Output format: table or json")
@@ -242,6 +272,14 @@ func init() {
 	agentEnvSetCmd.Flags().Bool("custom-env-stdin", false, "Read the replacement custom_env JSON object from stdin. Keeps secrets out of shell history and 'ps'. Mutually exclusive with --custom-env and --custom-env-file.")
 	agentEnvSetCmd.Flags().String("custom-env-file", "", "Read the replacement custom_env JSON object from a file path (suggested mode: 0600). Mutually exclusive with --custom-env and --custom-env-stdin.")
 	agentEnvSetCmd.Flags().String("output", "json", "Output format: json or table")
+
+	// agent cross-workspace get
+	agentCrossWorkspaceGetCmd.Flags().String("output", "json", "Output format: json or table")
+
+	// agent cross-workspace set. Workspace IDs aren't secret, so a plain
+	// comma-separated flag is fine here (unlike custom-env above).
+	agentCrossWorkspaceSetCmd.Flags().StringSlice("workspace-ids", nil, "Workspace IDs to grant cross-workspace access to (comma-separated; replaces the full list, pass an empty string to clear all)")
+	agentCrossWorkspaceSetCmd.Flags().String("output", "json", "Output format: json or table")
 }
 
 // resolveProfile returns the --profile flag value (empty string means default profile).
@@ -1081,6 +1119,83 @@ func runAgentEnvSet(cmd *cobra.Command, args []string) error {
 
 	env, _ := result["custom_env"].(map[string]any)
 	fmt.Printf("Env updated for agent %s (%d keys)\n", args[0], len(env))
+	return nil
+}
+
+// ---------------------------------------------------------------------------
+// Agent cross-workspace grant subcommands
+// ---------------------------------------------------------------------------
+
+// runAgentCrossWorkspaceGet fetches an agent's cross_workspace_ids
+// allow-list via the audited `/cross-workspace-grants` endpoint (BUS-171).
+func runAgentCrossWorkspaceGet(cmd *cobra.Command, args []string) error {
+	client, err := newAPIClient(cmd)
+	if err != nil {
+		return err
+	}
+
+	ctx, cancel := cli.APIContext(context.Background())
+	defer cancel()
+
+	var resp map[string]any
+	if err := client.GetJSON(ctx, "/api/agents/"+args[0]+"/cross-workspace-grants", &resp); err != nil {
+		return fmt.Errorf("get agent cross-workspace grants: %w", err)
+	}
+
+	output, _ := cmd.Flags().GetString("output")
+	if output == "json" {
+		return cli.PrintJSON(os.Stdout, resp)
+	}
+
+	headers := []string{"WORKSPACE_ID"}
+	ids, _ := resp["cross_workspace_ids"].([]any)
+	rows := make([][]string, 0, len(ids))
+	for _, id := range ids {
+		rows = append(rows, []string{fmt.Sprintf("%v", id)})
+	}
+	cli.PrintTable(os.Stdout, headers, rows)
+	return nil
+}
+
+// runAgentCrossWorkspaceSet replaces an agent's cross_workspace_ids
+// wholesale via the audited `/cross-workspace-grants` endpoint. Workspace
+// IDs aren't secret, so unlike --custom-env this takes a plain
+// comma-separated flag (same convention as --skill-ids).
+func runAgentCrossWorkspaceSet(cmd *cobra.Command, args []string) error {
+	client, err := newAPIClient(cmd)
+	if err != nil {
+		return err
+	}
+
+	if !cmd.Flags().Changed("workspace-ids") {
+		return fmt.Errorf("--workspace-ids is required (comma-separated workspace IDs; use --workspace-ids '' to clear all)")
+	}
+	ids, _ := cmd.Flags().GetStringSlice("workspace-ids")
+	cleanIDs := make([]string, 0, len(ids))
+	for _, id := range ids {
+		id = strings.TrimSpace(id)
+		if id != "" {
+			cleanIDs = append(cleanIDs, id)
+		}
+	}
+
+	body := map[string]any{"cross_workspace_ids": cleanIDs}
+
+	ctx, cancel := cli.APIContext(context.Background())
+	defer cancel()
+
+	var result map[string]any
+	if err := client.PutJSON(ctx, "/api/agents/"+args[0]+"/cross-workspace-grants", body, &result); err != nil {
+		return fmt.Errorf("update agent cross-workspace grants: %w", err)
+	}
+
+	output, _ := cmd.Flags().GetString("output")
+	if output == "json" {
+		return cli.PrintJSON(os.Stdout, result)
+	}
+
+	grantIDs, _ := result["cross_workspace_ids"].([]any)
+	fmt.Printf("Cross-workspace grants updated for agent %s (%d workspace(s))\n", args[0], len(grantIDs))
 	return nil
 }
 

--- a/server/cmd/multica/cmd_auth.go
+++ b/server/cmd/multica/cmd_auth.go
@@ -58,6 +58,19 @@ var authLogoutCmd = &cobra.Command{
 	RunE:  runAuthLogout,
 }
 
+// authCrossWorkspaceTokenCmd replaces the pre-0.4.11 "unset
+// MULTICA_TOKEN/MULTICA_WORKSPACE_ID and fall back to the owner's config
+// token" trick (BUS-171), which 0.4.11's daemon-task-marker guard correctly
+// closed off. Only callable from inside a daemon-managed agent task — the
+// server rejects any caller whose actor source isn't a genuine task_token —
+// and only for a target workspace the agent's owner/admin has explicitly
+// granted via `multica agent cross-workspace set`.
+var authCrossWorkspaceTokenCmd = &cobra.Command{
+	Use:   "cross-workspace-token",
+	Short: "Mint a scoped mat_ task token for another workspace (agent task context only; requires an owner/admin grant)",
+	RunE:  runAuthCrossWorkspaceToken,
+}
+
 // callbackHostFlag lets users override the host/IP that goes into the OAuth
 // cli_callback URL. Useful when the CLI sits behind a reverse proxy or the
 // auto-detected LAN IP isn't the one the browser can reach.
@@ -68,6 +81,10 @@ const callbackHostFlagHelp = "Host/IP the OAuth callback URL points at when the 
 func init() {
 	authCmd.AddCommand(authStatusCmd)
 	authCmd.AddCommand(authLogoutCmd)
+	authCmd.AddCommand(authCrossWorkspaceTokenCmd)
+
+	authCrossWorkspaceTokenCmd.Flags().String("target-workspace-id", "", "Workspace ID to mint a token for (required; must be on the agent's cross_workspace_ids allow-list)")
+	authCrossWorkspaceTokenCmd.Flags().String("output", "json", "Output format: json (full response) or token (prints only the raw token, for TOKEN=$(...) capture)")
 }
 
 func resolveToken(cmd *cobra.Command) string {
@@ -546,4 +563,44 @@ func runAuthLogout(cmd *cobra.Command, _ []string) error {
 
 	fmt.Fprintln(os.Stderr, "Token removed. You are now logged out.")
 	return nil
+}
+
+// runAuthCrossWorkspaceToken calls POST /api/tokens/cross-workspace using
+// newAPIClient (not the plain cli.NewAPIClient used by status/logout above),
+// since this command's entire purpose is running inside a daemon-managed
+// task: newAPIClient enforces that MULTICA_TOKEN is already a mat_ token in
+// that context, which is exactly the identity the server's task_token check
+// requires on the other end.
+func runAuthCrossWorkspaceToken(cmd *cobra.Command, _ []string) error {
+	targetWorkspaceID, _ := cmd.Flags().GetString("target-workspace-id")
+	targetWorkspaceID = strings.TrimSpace(targetWorkspaceID)
+	if targetWorkspaceID == "" {
+		return fmt.Errorf("--target-workspace-id is required")
+	}
+
+	client, err := newAPIClient(cmd)
+	if err != nil {
+		return err
+	}
+
+	ctx, cancel := cli.APIContext(context.Background())
+	defer cancel()
+
+	var resp struct {
+		Token       string `json:"token"`
+		WorkspaceID string `json:"workspace_id"`
+		ExpiresAt   string `json:"expires_at"`
+	}
+	if err := client.PostJSON(ctx, "/api/tokens/cross-workspace", map[string]any{
+		"workspace_id": targetWorkspaceID,
+	}, &resp); err != nil {
+		return fmt.Errorf("mint cross-workspace token: %w", err)
+	}
+
+	output, _ := cmd.Flags().GetString("output")
+	if output == "token" {
+		fmt.Println(resp.Token)
+		return nil
+	}
+	return cli.PrintJSON(os.Stdout, resp)
 }

--- a/server/cmd/server/router.go
+++ b/server/cmd/server/router.go
@@ -1016,6 +1016,12 @@ func NewRouterWithOptions(pool *pgxpool.Pool, hub *realtime.Hub, bus *events.Bus
 			r.Post("/", h.CreatePersonalAccessToken)
 			r.Post("/current/renew", h.RenewCurrentPersonalAccessToken)
 			r.Delete("/{id}", h.RevokePersonalAccessToken)
+			// BUS-171: lets a running agent task mint a second, scoped mat_
+			// token for an owner/admin-granted cross-workspace_id. Self-
+			// referential (the caller's own agent/task come from its
+			// X-Actor-Source: task_token headers, not a URL param), so it
+			// lives alongside /current/renew rather than under /api/agents.
+			r.Post("/cross-workspace", h.MintCrossWorkspaceToken)
 		})
 
 		// Cloud Billing proxy. Same upstream service / port as
@@ -1258,6 +1264,15 @@ func NewRouterWithOptions(pool *pgxpool.Pool, hub *realtime.Hub, bus *events.Bus
 					// internal/handler/agent_env.go.
 					r.Get("/env", h.GetAgentEnv)
 					r.Put("/env", h.UpdateAgentEnv)
+					// Dedicated cross-workspace grant-management endpoint
+					// (BUS-171). Owner/admin only; RequireHumanActor denies
+					// mat_/mcn_ callers before the handler even runs. Every
+					// grant change is audited. Pairs with the self-referential
+					// POST /api/tokens/cross-workspace mint endpoint, which a
+					// running agent task calls once its workspace is granted
+					// here.
+					r.With(handler.RequireHumanActor).Get("/cross-workspace-grants", h.GetAgentCrossWorkspaceGrants)
+					r.With(handler.RequireHumanActor).Put("/cross-workspace-grants", h.UpdateAgentCrossWorkspaceGrants)
 				})
 			})
 

--- a/server/internal/handler/agent_cross_workspace.go
+++ b/server/internal/handler/agent_cross_workspace.go
@@ -1,0 +1,166 @@
+package handler
+
+import (
+	"encoding/json"
+	"log/slog"
+	"net/http"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/jackc/pgx/v5/pgtype"
+
+	"github.com/multica-ai/multica/server/internal/logger"
+	db "github.com/multica-ai/multica/server/pkg/db/generated"
+)
+
+// agentCrossWorkspaceGrantsActivityUpdated is the activity_log `action`
+// constant for grant changes (BUS-171). Rows are written with
+// `issue_id IS NULL`, same convention as the agent env audit trail.
+const agentCrossWorkspaceGrantsActivityUpdated = "agent_cross_workspace_grants_updated"
+
+// AgentCrossWorkspaceGrantsResponse is the wire shape for
+// GET/PUT /api/agents/{id}/cross-workspace-grants.
+type AgentCrossWorkspaceGrantsResponse struct {
+	AgentID           string   `json:"agent_id"`
+	CrossWorkspaceIDs []string `json:"cross_workspace_ids"`
+}
+
+// UpdateAgentCrossWorkspaceGrantsRequest is the wire shape for the PUT.
+// Replaces the allow-list wholesale, same contract as UpdateAgentEnv.
+type UpdateAgentCrossWorkspaceGrantsRequest struct {
+	CrossWorkspaceIDs []string `json:"cross_workspace_ids"`
+}
+
+// authorizeAgentCrossWorkspaceGrants enforces the per-request auth
+// contract for the grant-management endpoints: the caller must be a
+// human workspace owner/admin. Machine-credential rejection is handled
+// by the RequireHumanActor middleware at the route level (see
+// router.go) rather than here, since that gate has no agent-specific
+// context to add — this function only needs the human-role check.
+func (h *Handler) authorizeAgentCrossWorkspaceGrants(w http.ResponseWriter, r *http.Request) (db.Agent, db.Member, bool) {
+	agentID := chi.URLParam(r, "id")
+	agent, ok := h.loadAgentForUser(w, r, agentID)
+	if !ok {
+		return db.Agent{}, db.Member{}, false
+	}
+
+	workspaceID := uuidToString(agent.WorkspaceID)
+	member, ok := h.requireWorkspaceRole(w, r, workspaceID, "agent not found", "owner", "admin")
+	if !ok {
+		return db.Agent{}, db.Member{}, false
+	}
+
+	return agent, member, true
+}
+
+// GetAgentCrossWorkspaceGrants returns an agent's cross_workspace_ids
+// allow-list. These are workspace UUIDs, not secrets, so unlike
+// GetAgentEnv this read is not itself audit-logged — only the grants
+// endpoint's writes are, since that's the security-relevant action
+// (widening what a running task can reach).
+func (h *Handler) GetAgentCrossWorkspaceGrants(w http.ResponseWriter, r *http.Request) {
+	agent, _, ok := h.authorizeAgentCrossWorkspaceGrants(w, r)
+	if !ok {
+		return
+	}
+
+	writeJSON(w, http.StatusOK, AgentCrossWorkspaceGrantsResponse{
+		AgentID:           uuidToString(agent.ID),
+		CrossWorkspaceIDs: uuidStringsOrEmpty(agent.CrossWorkspaceIds),
+	})
+}
+
+// UpdateAgentCrossWorkspaceGrants replaces an agent's cross_workspace_ids
+// wholesale. This is the sole write path for the column — mirrors why
+// UpdateAgentCustomEnv is the sole write path for custom_env: a
+// dedicated, owner/admin-only, audited endpoint so a privilege widening
+// (an agent gaining the ability to mint a token into another workspace)
+// can never happen without a queryable trail.
+//
+// Persist + audit run inside one DB transaction, same fail-closed
+// reasoning as UpdateAgentEnv: an audit-write outage cannot leave an
+// unaudited grant change on disk.
+func (h *Handler) UpdateAgentCrossWorkspaceGrants(w http.ResponseWriter, r *http.Request) {
+	agent, member, ok := h.authorizeAgentCrossWorkspaceGrants(w, r)
+	if !ok {
+		return
+	}
+
+	var req UpdateAgentCrossWorkspaceGrantsRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid request body")
+		return
+	}
+
+	parsed, ok := parseUUIDSliceOrBadRequest(w, req.CrossWorkspaceIDs, "cross_workspace_ids")
+	if !ok {
+		return
+	}
+
+	ownWorkspaceID := uuidToString(agent.WorkspaceID)
+	seen := make(map[string]bool, len(parsed))
+	grantIDs := make([]pgtype.UUID, 0, len(parsed))
+	for _, id := range parsed {
+		s := uuidToString(id)
+		if s == ownWorkspaceID {
+			writeError(w, http.StatusBadRequest, "cross_workspace_ids may not include the agent's own workspace")
+			return
+		}
+		if seen[s] {
+			continue
+		}
+		seen[s] = true
+		grantIDs = append(grantIDs, id)
+	}
+
+	tx, err := h.TxStarter.Begin(r.Context())
+	if err != nil {
+		slog.Error("agent_cross_workspace_grants update: begin tx failed",
+			append(logger.RequestAttrs(r), "error", err, "agent_id", uuidToString(agent.ID))...)
+		writeError(w, http.StatusInternalServerError, "failed to update cross-workspace grants")
+		return
+	}
+	defer tx.Rollback(r.Context())
+	qtx := h.Queries.WithTx(tx)
+
+	updated, err := qtx.UpdateAgentCrossWorkspaceIDs(r.Context(), db.UpdateAgentCrossWorkspaceIDsParams{
+		ID:                agent.ID,
+		CrossWorkspaceIds: grantIDs,
+	})
+	if err != nil {
+		slog.Warn("update agent cross_workspace_ids failed",
+			append(logger.RequestAttrs(r), "error", err, "agent_id", uuidToString(agent.ID))...)
+		writeError(w, http.StatusInternalServerError, "failed to update cross-workspace grants")
+		return
+	}
+
+	details, _ := json.Marshal(map[string]any{
+		"agent_id":            uuidToString(agent.ID),
+		"agent_name":          agent.Name,
+		"cross_workspace_ids": uuidStringsOrEmpty(grantIDs),
+	})
+	if _, err := qtx.CreateActivity(r.Context(), db.CreateActivityParams{
+		WorkspaceID: agent.WorkspaceID,
+		IssueID:     pgtype.UUID{}, // grant changes are not tied to an issue
+		ActorType:   pgtype.Text{String: "member", Valid: true},
+		ActorID:     parseUUID(uuidToString(member.UserID)),
+		Action:      agentCrossWorkspaceGrantsActivityUpdated,
+		Details:     details,
+	}); err != nil {
+		slog.Error("agent_cross_workspace_grants_updated audit write failed; rolling back update",
+			append(logger.RequestAttrs(r), "error", err, "agent_id", uuidToString(agent.ID))...)
+		writeError(w, http.StatusInternalServerError, "audit log write failed; cross-workspace grants update rolled back")
+		return
+	}
+
+	if err := tx.Commit(r.Context()); err != nil {
+		slog.Error("agent_cross_workspace_grants update: tx commit failed",
+			append(logger.RequestAttrs(r), "error", err, "agent_id", uuidToString(agent.ID))...)
+		writeError(w, http.StatusInternalServerError, "failed to update cross-workspace grants")
+		return
+	}
+
+	writeJSON(w, http.StatusOK, AgentCrossWorkspaceGrantsResponse{
+		AgentID:           uuidToString(updated.ID),
+		CrossWorkspaceIDs: uuidStringsOrEmpty(updated.CrossWorkspaceIds),
+	})
+}

--- a/server/internal/handler/agent_cross_workspace_test.go
+++ b/server/internal/handler/agent_cross_workspace_test.go
@@ -1,0 +1,182 @@
+package handler
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/google/uuid"
+)
+
+// createForeignWorkspaceForCrossWorkspaceTest inserts a bare workspace (no
+// agent/runtime needed) to use as a grant target, and registers cleanup.
+func createForeignWorkspaceForCrossWorkspaceTest(t *testing.T, slug string) string {
+	t.Helper()
+	ctx := context.Background()
+
+	var workspaceID string
+	if err := testPool.QueryRow(ctx, `
+		INSERT INTO workspace (name, slug, description, issue_prefix)
+		VALUES ($1, $2, 'cross-workspace grant test', $3)
+		RETURNING id
+	`, "Cross Workspace Grant Test "+slug, slug, "CWG").Scan(&workspaceID); err != nil {
+		t.Fatalf("create foreign workspace: %v", err)
+	}
+	t.Cleanup(func() { testPool.Exec(context.Background(), `DELETE FROM workspace WHERE id = $1`, workspaceID) })
+	return workspaceID
+}
+
+func agentCrossWorkspaceGrantsPath(agentID string) string {
+	return "/api/agents/" + agentID + "/cross-workspace-grants"
+}
+
+// TestAgentCrossWorkspaceGrants_SetAndGetRoundTrip pins the owner/admin happy
+// path: an owner sets a grant list, and a subsequent GET returns exactly what
+// was written (BUS-171).
+func TestAgentCrossWorkspaceGrants_SetAndGetRoundTrip(t *testing.T) {
+	if testHandler == nil || testPool == nil {
+		t.Skip("database not available")
+	}
+
+	agentID := createHandlerTestAgent(t, "cwg-roundtrip-agent", []byte("{}"))
+	foreignWS := createForeignWorkspaceForCrossWorkspaceTest(t, "cwg-roundtrip-"+uuid.NewString()[:8])
+
+	setReq := newRequest(http.MethodPut, agentCrossWorkspaceGrantsPath(agentID), map[string]any{
+		"cross_workspace_ids": []string{foreignWS},
+	})
+	setReq = withURLParam(setReq, "id", agentID)
+	w := httptest.NewRecorder()
+	testHandler.UpdateAgentCrossWorkspaceGrants(w, setReq)
+	if w.Code != http.StatusOK {
+		t.Fatalf("set grants: status = %d, want 200: %s", w.Code, w.Body.String())
+	}
+
+	var setResp AgentCrossWorkspaceGrantsResponse
+	if err := json.NewDecoder(w.Body).Decode(&setResp); err != nil {
+		t.Fatalf("decode set response: %v", err)
+	}
+	if len(setResp.CrossWorkspaceIDs) != 1 || setResp.CrossWorkspaceIDs[0] != foreignWS {
+		t.Fatalf("set response cross_workspace_ids = %v, want [%s]", setResp.CrossWorkspaceIDs, foreignWS)
+	}
+
+	getReq := withURLParam(newRequest(http.MethodGet, agentCrossWorkspaceGrantsPath(agentID), nil), "id", agentID)
+	w = httptest.NewRecorder()
+	testHandler.GetAgentCrossWorkspaceGrants(w, getReq)
+	if w.Code != http.StatusOK {
+		t.Fatalf("get grants: status = %d, want 200: %s", w.Code, w.Body.String())
+	}
+	var getResp AgentCrossWorkspaceGrantsResponse
+	if err := json.NewDecoder(w.Body).Decode(&getResp); err != nil {
+		t.Fatalf("decode get response: %v", err)
+	}
+	if len(getResp.CrossWorkspaceIDs) != 1 || getResp.CrossWorkspaceIDs[0] != foreignWS {
+		t.Fatalf("get response cross_workspace_ids = %v, want [%s]", getResp.CrossWorkspaceIDs, foreignWS)
+	}
+
+	var actionCount int
+	if err := testPool.QueryRow(context.Background(), `
+		SELECT count(*) FROM activity_log
+		WHERE workspace_id = $1 AND action = 'agent_cross_workspace_grants_updated'
+	`, testWorkspaceID).Scan(&actionCount); err != nil {
+		t.Fatalf("query activity_log: %v", err)
+	}
+	if actionCount == 0 {
+		t.Fatal("expected an audit activity_log row for the grant update, found none")
+	}
+}
+
+// TestAgentCrossWorkspaceGrants_RejectsOwnWorkspace pins the guard that an
+// agent can never be granted access to the workspace it already runs in —
+// that access is implicit and always-on, so listing it here would be
+// meaningless allow-list noise.
+func TestAgentCrossWorkspaceGrants_RejectsOwnWorkspace(t *testing.T) {
+	if testHandler == nil || testPool == nil {
+		t.Skip("database not available")
+	}
+
+	agentID := createHandlerTestAgent(t, "cwg-ownws-agent", []byte("{}"))
+
+	req := withURLParam(newRequest(http.MethodPut, agentCrossWorkspaceGrantsPath(agentID), map[string]any{
+		"cross_workspace_ids": []string{testWorkspaceID},
+	}), "id", agentID)
+	w := httptest.NewRecorder()
+	testHandler.UpdateAgentCrossWorkspaceGrants(w, req)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400: %s", w.Code, w.Body.String())
+	}
+}
+
+// TestAgentCrossWorkspaceGrants_DedupesInput pins that duplicate workspace
+// IDs in the request collapse to one entry rather than being stored (and
+// later iterated/minted against) redundantly.
+func TestAgentCrossWorkspaceGrants_DedupesInput(t *testing.T) {
+	if testHandler == nil || testPool == nil {
+		t.Skip("database not available")
+	}
+
+	agentID := createHandlerTestAgent(t, "cwg-dedupe-agent", []byte("{}"))
+	foreignWS := createForeignWorkspaceForCrossWorkspaceTest(t, "cwg-dedupe-"+uuid.NewString()[:8])
+
+	req := withURLParam(newRequest(http.MethodPut, agentCrossWorkspaceGrantsPath(agentID), map[string]any{
+		"cross_workspace_ids": []string{foreignWS, foreignWS},
+	}), "id", agentID)
+	w := httptest.NewRecorder()
+	testHandler.UpdateAgentCrossWorkspaceGrants(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200: %s", w.Code, w.Body.String())
+	}
+	var resp AgentCrossWorkspaceGrantsResponse
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(resp.CrossWorkspaceIDs) != 1 {
+		t.Fatalf("cross_workspace_ids = %v, want exactly one deduped entry", resp.CrossWorkspaceIDs)
+	}
+}
+
+// TestAgentCrossWorkspaceGrants_NonOwnerRejected pins that a plain workspace
+// member (not owner/admin) cannot widen an agent's cross-workspace grants —
+// the same privilege boundary as custom_env.
+func TestAgentCrossWorkspaceGrants_NonOwnerRejected(t *testing.T) {
+	if testHandler == nil || testPool == nil {
+		t.Skip("database not available")
+	}
+
+	agentID := createHandlerTestAgent(t, "cwg-nonowner-agent", []byte("{}"))
+	foreignWS := createForeignWorkspaceForCrossWorkspaceTest(t, "cwg-nonowner-"+uuid.NewString()[:8])
+	memberUserID := createWorkspaceMemberUser(t, "CWG Non Owner", "cwg-nonowner-"+uuid.NewString()[:8]+"@multica.ai")
+
+	req := withURLParam(newRequestAs(memberUserID, http.MethodPut, agentCrossWorkspaceGrantsPath(agentID), map[string]any{
+		"cross_workspace_ids": []string{foreignWS},
+	}), "id", agentID)
+	w := httptest.NewRecorder()
+	testHandler.UpdateAgentCrossWorkspaceGrants(w, req)
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("status = %d, want 403: %s", w.Code, w.Body.String())
+	}
+}
+
+// TestAgentCrossWorkspaceGrants_RequireHumanActorBlocksTaskToken pins the
+// router-level gate (RequireHumanActor, wired in router.go): a request
+// carrying the task_token actor-source marker must never reach either
+// grant-management handler, even indirectly via a chi route group.
+func TestAgentCrossWorkspaceGrants_RequireHumanActorBlocksTaskToken(t *testing.T) {
+	called := false
+	guarded := RequireHumanActor(http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
+		called = true
+	}))
+
+	req := httptest.NewRequest(http.MethodGet, agentCrossWorkspaceGrantsPath(uuid.NewString()), nil)
+	req.Header.Set("X-Actor-Source", "task_token")
+	w := httptest.NewRecorder()
+	guarded.ServeHTTP(w, req)
+
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("status = %d, want 403", w.Code)
+	}
+	if called {
+		t.Fatal("grant-management handler must not run for a task_token actor")
+	}
+}

--- a/server/internal/handler/cross_workspace_token.go
+++ b/server/internal/handler/cross_workspace_token.go
@@ -1,0 +1,210 @@
+package handler
+
+import (
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgtype"
+
+	"github.com/multica-ai/multica/server/internal/auth"
+	"github.com/multica-ai/multica/server/internal/logger"
+	db "github.com/multica-ai/multica/server/pkg/db/generated"
+)
+
+// crossWorkspaceTokenActivityMinted is the activity_log `action` constant
+// written to the TARGET workspace every time a cross-workspace task token
+// is minted (BUS-171) — the queryable trail of which agent reached into
+// which other workspace, and when.
+const crossWorkspaceTokenActivityMinted = "agent_cross_workspace_token_minted"
+
+// crossWorkspaceTokenTTL matches the expiry the daemon uses when minting an
+// agent's primary task token at claim time (see ClaimTasksByRuntime in
+// daemon.go) so a cross-workspace token never outlives that convention.
+const crossWorkspaceTokenTTL = 24 * time.Hour
+
+// MintCrossWorkspaceTokenRequest is the wire shape for
+// POST /api/tokens/cross-workspace.
+type MintCrossWorkspaceTokenRequest struct {
+	WorkspaceID string `json:"workspace_id"`
+}
+
+// MintCrossWorkspaceTokenResponse returns the newly minted mat_ token. The
+// CLI's existing marker-based guard (cmd_agent.go) already accepts any
+// mat_-prefixed token inside a daemon-managed task, so no CLI-side change
+// is needed to use it.
+type MintCrossWorkspaceTokenResponse struct {
+	Token       string `json:"token"`
+	WorkspaceID string `json:"workspace_id"`
+	ExpiresAt   string `json:"expires_at"`
+}
+
+// MintCrossWorkspaceToken lets a running agent task request a second,
+// scoped mat_ task token for a DIFFERENT workspace, replacing the
+// pre-0.4.11 "unset MULTICA_TOKEN/MULTICA_WORKSPACE_ID and fall back to
+// the owner's config-file token" mechanism that 0.4.11's daemon-task-marker
+// guard correctly closed (that fallback was the exact vulnerability class
+// MUL-2600 closed for the primary-workspace case; re-opening it here via a
+// CLI override flag would have been the same hole with extra steps).
+//
+// Why this is safe to add with zero changes to the existing auth guard:
+// the new token is a normal task_token row — same table, same shape, same
+// (task_id, agent_id, user_id) triple as the agent's primary token, just
+// bound to a different workspace_id. Every downstream authorization check
+// (middleware/auth.go's mat_ branch, middleware/workspace.go's
+// X-Actor-Source == "task_token" scoping) already treats the token row as
+// the sole source of truth, so a second row scoped to workspace B is
+// indistinguishable, to the rest of the server, from a token minted for
+// workspace B by the normal claim path. It shares task_id with the
+// primary token, so task cancellation's existing
+// DeleteTaskTokensByTask cleanup revokes it for free.
+//
+// Access is gated three ways before a token is minted:
+//  1. Actor must be a genuine task_token caller (X-Actor-Source ==
+//     "task_token") — not a human PAT, not a cloud-node PAT, and not the
+//     resolveActor legacy-header fallback (which a compromised agent
+//     process could try to forge). This header can only be set by the
+//     Auth middleware itself.
+//  2. The target workspace must be present on the calling agent's
+//     owner/admin-configured cross_workspace_ids allow-list.
+//  3. The task's owning user must actually be a member of the target
+//     workspace (defense-in-depth: a stale or misconfigured grant can
+//     never mint a token into a workspace the owner has no membership
+//     in — every existing workspace-scoped handler still enforces
+//     membership independently, but this fails the request closed at
+//     the point of mint rather than at first use).
+//
+// Persist + audit run in one transaction, same fail-closed reasoning as
+// UpdateAgentEnv / UpdateAgentCrossWorkspaceGrants: an audit-write outage
+// cannot leave an unaudited cross-workspace token in the caller's hands.
+func (h *Handler) MintCrossWorkspaceToken(w http.ResponseWriter, r *http.Request) {
+	if r.Header.Get("X-Actor-Source") != "task_token" {
+		writeError(w, http.StatusForbidden, "this endpoint is only available to a running agent task")
+		return
+	}
+
+	agentID := r.Header.Get("X-Agent-ID")
+	taskID := r.Header.Get("X-Task-ID")
+	originWorkspaceID := r.Header.Get("X-Workspace-ID")
+	userID := r.Header.Get("X-User-ID")
+
+	agentUUID, ok := parseUUIDOrBadRequest(w, agentID, "agent id")
+	if !ok {
+		return
+	}
+	taskUUID, ok := parseUUIDOrBadRequest(w, taskID, "task id")
+	if !ok {
+		return
+	}
+	userUUID, ok := parseUUIDOrBadRequest(w, userID, "user id")
+	if !ok {
+		return
+	}
+
+	var req MintCrossWorkspaceTokenRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid request body")
+		return
+	}
+	targetWorkspaceUUID, ok := parseUUIDOrBadRequest(w, req.WorkspaceID, "workspace_id")
+	if !ok {
+		return
+	}
+	targetWorkspaceID := uuidToString(targetWorkspaceUUID)
+	if targetWorkspaceID == originWorkspaceID {
+		writeError(w, http.StatusBadRequest, "workspace_id must differ from the task's own workspace")
+		return
+	}
+
+	agentRow, err := h.Queries.GetAgent(r.Context(), agentUUID)
+	if err != nil {
+		writeError(w, http.StatusForbidden, "agent not found")
+		return
+	}
+
+	granted := false
+	for _, id := range agentRow.CrossWorkspaceIds {
+		if uuidToString(id) == targetWorkspaceID {
+			granted = true
+			break
+		}
+	}
+	if !granted {
+		writeError(w, http.StatusForbidden, "agent is not granted access to workspace "+targetWorkspaceID)
+		return
+	}
+
+	if _, err := h.Queries.GetMemberByUserAndWorkspace(r.Context(), db.GetMemberByUserAndWorkspaceParams{
+		UserID:      userUUID,
+		WorkspaceID: targetWorkspaceUUID,
+	}); err != nil {
+		writeError(w, http.StatusForbidden, "task owner is not a member of workspace "+targetWorkspaceID)
+		return
+	}
+
+	tokenStr, err := auth.GenerateAgentTaskToken()
+	if err != nil {
+		slog.Error("mint cross-workspace token: generate token failed",
+			append(logger.RequestAttrs(r), "error", err, "agent_id", agentID, "task_id", taskID)...)
+		writeError(w, http.StatusInternalServerError, "failed to mint cross-workspace token")
+		return
+	}
+	expiresAt := time.Now().Add(crossWorkspaceTokenTTL)
+
+	tx, err := h.TxStarter.Begin(r.Context())
+	if err != nil {
+		slog.Error("mint cross-workspace token: begin tx failed",
+			append(logger.RequestAttrs(r), "error", err, "agent_id", agentID, "task_id", taskID)...)
+		writeError(w, http.StatusInternalServerError, "failed to mint cross-workspace token")
+		return
+	}
+	defer tx.Rollback(r.Context())
+	qtx := h.Queries.WithTx(tx)
+
+	if _, err := qtx.CreateTaskToken(r.Context(), db.CreateTaskTokenParams{
+		TokenHash:   auth.HashToken(tokenStr),
+		TaskID:      taskUUID,
+		AgentID:     agentUUID,
+		WorkspaceID: targetWorkspaceUUID,
+		UserID:      userUUID,
+		ExpiresAt:   pgtype.Timestamptz{Time: expiresAt, Valid: true},
+	}); err != nil {
+		slog.Error("mint cross-workspace token: create task_token failed",
+			append(logger.RequestAttrs(r), "error", err, "agent_id", agentID, "task_id", taskID)...)
+		writeError(w, http.StatusInternalServerError, "failed to mint cross-workspace token")
+		return
+	}
+
+	details, _ := json.Marshal(map[string]any{
+		"agent_id":            agentID,
+		"task_id":             taskID,
+		"origin_workspace_id": originWorkspaceID,
+	})
+	if _, err := qtx.CreateActivity(r.Context(), db.CreateActivityParams{
+		WorkspaceID: targetWorkspaceUUID,
+		IssueID:     pgtype.UUID{}, // token minting is not tied to an issue
+		ActorType:   pgtype.Text{String: "agent", Valid: true},
+		ActorID:     agentUUID,
+		Action:      crossWorkspaceTokenActivityMinted,
+		Details:     details,
+	}); err != nil {
+		slog.Error("agent_cross_workspace_token_minted audit write failed; refusing to hand out token",
+			append(logger.RequestAttrs(r), "error", err, "agent_id", agentID, "task_id", taskID)...)
+		writeError(w, http.StatusInternalServerError, "audit log write failed; refusing to mint token without a recorded trail")
+		return
+	}
+
+	if err := tx.Commit(r.Context()); err != nil {
+		slog.Error("mint cross-workspace token: tx commit failed",
+			append(logger.RequestAttrs(r), "error", err, "agent_id", agentID, "task_id", taskID)...)
+		writeError(w, http.StatusInternalServerError, "failed to mint cross-workspace token")
+		return
+	}
+
+	writeJSON(w, http.StatusOK, MintCrossWorkspaceTokenResponse{
+		Token:       tokenStr,
+		WorkspaceID: targetWorkspaceID,
+		ExpiresAt:   expiresAt.UTC().Format(time.RFC3339),
+	})
+}

--- a/server/internal/handler/cross_workspace_token_test.go
+++ b/server/internal/handler/cross_workspace_token_test.go
@@ -1,0 +1,211 @@
+package handler
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/multica-ai/multica/server/internal/auth"
+)
+
+const crossWorkspaceTokenPath = "/api/tokens/cross-workspace"
+
+// crossWorkspaceTokenRequest builds a request shaped like the real
+// task_token-authenticated caller: X-Actor-Source/X-Agent-ID/X-Task-ID/
+// X-Workspace-ID/X-User-ID are exactly what the Auth middleware stamps for a
+// mat_ token, and MintCrossWorkspaceToken trusts them as-is (it never reads
+// the request through resolveActor).
+func crossWorkspaceTokenRequest(agentID, taskID, originWorkspaceID, userID, targetWorkspaceID string) *http.Request {
+	var body strings.Reader
+	if targetWorkspaceID != "" {
+		body = *strings.NewReader(`{"workspace_id":"` + targetWorkspaceID + `"}`)
+	} else {
+		body = *strings.NewReader(`{}`)
+	}
+	req := httptest.NewRequest(http.MethodPost, crossWorkspaceTokenPath, &body)
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-Actor-Source", "task_token")
+	req.Header.Set("X-Agent-ID", agentID)
+	req.Header.Set("X-Task-ID", taskID)
+	req.Header.Set("X-Workspace-ID", originWorkspaceID)
+	req.Header.Set("X-User-ID", userID)
+	return req
+}
+
+// createHandlerTestTask inserts a minimal queued task for agentID in
+// testWorkspaceID's runtime, for tests that need a real agent_task_queue row
+// to satisfy task_token's task_id foreign key.
+func createHandlerTestTask(t *testing.T, agentID string) string {
+	t.Helper()
+	ctx := context.Background()
+
+	var taskID string
+	if err := testPool.QueryRow(ctx, `
+		INSERT INTO agent_task_queue (agent_id, runtime_id, status, priority)
+		VALUES ($1, $2, 'running', 0)
+		RETURNING id
+	`, agentID, handlerTestRuntimeID(t)).Scan(&taskID); err != nil {
+		t.Fatalf("create handler test task: %v", err)
+	}
+	t.Cleanup(func() { testPool.Exec(context.Background(), `DELETE FROM agent_task_queue WHERE id = $1`, taskID) })
+	return taskID
+}
+
+// TestMintCrossWorkspaceToken_RequiresTaskTokenActor pins the strictest
+// layer of the three-layer gate (BUS-171): a caller without the
+// server-stamped X-Actor-Source: task_token header — a human PAT/JWT
+// session, or the resolveActor legacy-header fallback a compromised agent
+// process might try to forge — is rejected before any DB lookup runs.
+func TestMintCrossWorkspaceToken_RequiresTaskTokenActor(t *testing.T) {
+	if testHandler == nil {
+		t.Skip("database not available")
+	}
+
+	req := httptest.NewRequest(http.MethodPost, crossWorkspaceTokenPath, strings.NewReader(`{"workspace_id":"`+uuid.NewString()+`"}`))
+	req.Header.Set("Content-Type", "application/json")
+	// Forged legacy-fallback headers, but deliberately no X-Actor-Source.
+	req.Header.Set("X-Agent-ID", uuid.NewString())
+	req.Header.Set("X-Task-ID", uuid.NewString())
+	req.Header.Set("X-User-ID", testUserID)
+
+	w := httptest.NewRecorder()
+	testHandler.MintCrossWorkspaceToken(w, req)
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("status = %d, want 403: %s", w.Code, w.Body.String())
+	}
+}
+
+// TestMintCrossWorkspaceToken_RejectsSameWorkspace pins that the target
+// workspace_id must differ from the task's own origin workspace — minting a
+// "cross-workspace" token into the workspace the task is already scoped to
+// would just be a confusing no-op path around the normal token.
+func TestMintCrossWorkspaceToken_RejectsSameWorkspace(t *testing.T) {
+	if testHandler == nil {
+		t.Skip("database not available")
+	}
+
+	req := crossWorkspaceTokenRequest(uuid.NewString(), uuid.NewString(), testWorkspaceID, testUserID, testWorkspaceID)
+	w := httptest.NewRecorder()
+	testHandler.MintCrossWorkspaceToken(w, req)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400: %s", w.Code, w.Body.String())
+	}
+}
+
+// TestMintCrossWorkspaceToken_RejectsUngrantedWorkspace pins gate #2: even a
+// real agent with an empty (default) cross_workspace_ids allow-list cannot
+// mint a token into an arbitrary other workspace. No real task row is needed
+// here — the grant check runs, and fails, before task_token is ever created.
+func TestMintCrossWorkspaceToken_RejectsUngrantedWorkspace(t *testing.T) {
+	if testHandler == nil || testPool == nil {
+		t.Skip("database not available")
+	}
+
+	agentID := createHandlerTestAgent(t, "cwt-ungranted-agent", []byte("{}"))
+	targetWS := createForeignWorkspaceForCrossWorkspaceTest(t, "cwt-ungranted-"+uuid.NewString()[:8])
+
+	req := crossWorkspaceTokenRequest(agentID, uuid.NewString(), testWorkspaceID, testUserID, targetWS)
+	w := httptest.NewRecorder()
+	testHandler.MintCrossWorkspaceToken(w, req)
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("status = %d, want 403: %s", w.Code, w.Body.String())
+	}
+}
+
+// TestMintCrossWorkspaceToken_RejectsNonMemberTaskOwner pins gate #3
+// (defense-in-depth): even when the agent IS granted access to the target
+// workspace, the task's owning user must actually be a member of it. A
+// stale or misconfigured grant must never mint a usable token.
+func TestMintCrossWorkspaceToken_RejectsNonMemberTaskOwner(t *testing.T) {
+	if testHandler == nil || testPool == nil {
+		t.Skip("database not available")
+	}
+
+	agentID := createHandlerTestAgent(t, "cwt-nonmember-agent", []byte("{}"))
+	targetWS := createForeignWorkspaceForCrossWorkspaceTest(t, "cwt-nonmember-"+uuid.NewString()[:8])
+	if _, err := testPool.Exec(context.Background(), `
+		UPDATE agent SET cross_workspace_ids = $1::uuid[] WHERE id = $2
+	`, []string{targetWS}, agentID); err != nil {
+		t.Fatalf("grant cross-workspace access: %v", err)
+	}
+
+	// testUserID is not a member of targetWS.
+	req := crossWorkspaceTokenRequest(agentID, uuid.NewString(), testWorkspaceID, testUserID, targetWS)
+	w := httptest.NewRecorder()
+	testHandler.MintCrossWorkspaceToken(w, req)
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("status = %d, want 403: %s", w.Code, w.Body.String())
+	}
+}
+
+// TestMintCrossWorkspaceToken_Success pins the full happy path: a granted
+// agent, whose task owner is a member of the target workspace, mints a
+// mat_-prefixed token scoped to (task_id, agent_id, target_workspace_id,
+// user_id) — the same shape a normal claim-time token has, just pointed at a
+// different workspace — and the mint is recorded in the target workspace's
+// activity_log.
+func TestMintCrossWorkspaceToken_Success(t *testing.T) {
+	if testHandler == nil || testPool == nil {
+		t.Skip("database not available")
+	}
+	ctx := context.Background()
+
+	agentID := createHandlerTestAgent(t, "cwt-success-agent", []byte("{}"))
+	taskID := createHandlerTestTask(t, agentID)
+	targetWS := createForeignWorkspaceForCrossWorkspaceTest(t, "cwt-success-"+uuid.NewString()[:8])
+	if _, err := testPool.Exec(ctx, `
+		UPDATE agent SET cross_workspace_ids = $1::uuid[] WHERE id = $2
+	`, []string{targetWS}, agentID); err != nil {
+		t.Fatalf("grant cross-workspace access: %v", err)
+	}
+	if _, err := testPool.Exec(ctx, `
+		INSERT INTO member (workspace_id, user_id, role) VALUES ($1, $2, 'member')
+	`, targetWS, testUserID); err != nil {
+		t.Fatalf("add task owner as member of target workspace: %v", err)
+	}
+
+	req := crossWorkspaceTokenRequest(agentID, taskID, testWorkspaceID, testUserID, targetWS)
+	w := httptest.NewRecorder()
+	testHandler.MintCrossWorkspaceToken(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200: %s", w.Code, w.Body.String())
+	}
+
+	var resp MintCrossWorkspaceTokenResponse
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if !strings.HasPrefix(resp.Token, "mat_") {
+		t.Fatalf("token = %q, want mat_ prefix", resp.Token)
+	}
+	if resp.WorkspaceID != targetWS {
+		t.Fatalf("response workspace_id = %q, want %q", resp.WorkspaceID, targetWS)
+	}
+
+	var dbAgentID, dbTaskID, dbWorkspaceID, dbUserID string
+	if err := testPool.QueryRow(ctx, `
+		SELECT agent_id, task_id, workspace_id, user_id FROM task_token WHERE token_hash = $1
+	`, auth.HashToken(resp.Token)).Scan(&dbAgentID, &dbTaskID, &dbWorkspaceID, &dbUserID); err != nil {
+		t.Fatalf("query minted task_token row: %v", err)
+	}
+	t.Cleanup(func() { testPool.Exec(context.Background(), `DELETE FROM task_token WHERE token_hash = $1`, auth.HashToken(resp.Token)) })
+	if dbAgentID != agentID || dbTaskID != taskID || dbWorkspaceID != targetWS || dbUserID != testUserID {
+		t.Fatalf("minted task_token row = (agent=%s task=%s ws=%s user=%s), want (agent=%s task=%s ws=%s user=%s)",
+			dbAgentID, dbTaskID, dbWorkspaceID, dbUserID, agentID, taskID, targetWS, testUserID)
+	}
+
+	var actionCount int
+	if err := testPool.QueryRow(ctx, `
+		SELECT count(*) FROM activity_log
+		WHERE workspace_id = $1 AND action = 'agent_cross_workspace_token_minted'
+	`, targetWS).Scan(&actionCount); err != nil {
+		t.Fatalf("query activity_log: %v", err)
+	}
+	if actionCount == 0 {
+		t.Fatal("expected an audit activity_log row in the target workspace, found none")
+	}
+}

--- a/server/migrations/224_agent_cross_workspace_grants.down.sql
+++ b/server/migrations/224_agent_cross_workspace_grants.down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE agent DROP COLUMN IF EXISTS cross_workspace_ids;

--- a/server/migrations/224_agent_cross_workspace_grants.up.sql
+++ b/server/migrations/224_agent_cross_workspace_grants.up.sql
@@ -1,0 +1,9 @@
+-- cross_workspace_ids is an owner/admin-configured allow-list of OTHER
+-- workspace IDs a running agent task may request a scoped mat_ token for.
+-- It exists so an agent whose job is cross-workspace routing (e.g. reading
+-- issues in a second workspace) never needs the daemon owner's full mul_
+-- PAT: the daemon-managed CLI mints a second task_token row bound to
+-- (task_id, agent_id, one target workspace_id) instead, following the same
+-- MUL-2600 task-token model already used for the agent's primary workspace.
+-- Empty (the default) means no cross-workspace access at all.
+ALTER TABLE agent ADD COLUMN cross_workspace_ids UUID[] NOT NULL DEFAULT '{}';

--- a/server/pkg/db/generated/agent.sql.go
+++ b/server/pkg/db/generated/agent.sql.go
@@ -14,7 +14,7 @@ import (
 const archiveAgent = `-- name: ArchiveAgent :one
 UPDATE agent SET archived_at = now(), archived_by = $2, updated_at = now()
 WHERE id = $1
-RETURNING id, workspace_id, name, avatar_url, runtime_mode, runtime_config, visibility, status, max_concurrent_tasks, owner_id, created_at, updated_at, description, runtime_id, instructions, archived_at, archived_by, custom_env, custom_args, mcp_config, model, thinking_level, composio_toolkit_allowlist, permission_mode, kind, system_key, disabled_runtime_skills, service_tier
+RETURNING id, workspace_id, name, avatar_url, runtime_mode, runtime_config, visibility, status, max_concurrent_tasks, owner_id, created_at, updated_at, description, runtime_id, instructions, archived_at, archived_by, custom_env, custom_args, mcp_config, model, thinking_level, composio_toolkit_allowlist, permission_mode, kind, system_key, disabled_runtime_skills, service_tier, cross_workspace_ids
 `
 
 type ArchiveAgentParams struct {
@@ -54,6 +54,7 @@ func (q *Queries) ArchiveAgent(ctx context.Context, arg ArchiveAgentParams) (Age
 		&i.SystemKey,
 		&i.DisabledRuntimeSkills,
 		&i.ServiceTier,
+		&i.CrossWorkspaceIds,
 	)
 	return i, err
 }
@@ -62,7 +63,7 @@ const archiveAgentsByIDs = `-- name: ArchiveAgentsByIDs :many
 UPDATE agent
 SET archived_at = now(), archived_by = $1, updated_at = now()
 WHERE id = ANY($2::uuid[]) AND archived_at IS NULL
-RETURNING id, workspace_id, name, avatar_url, runtime_mode, runtime_config, visibility, status, max_concurrent_tasks, owner_id, created_at, updated_at, description, runtime_id, instructions, archived_at, archived_by, custom_env, custom_args, mcp_config, model, thinking_level, composio_toolkit_allowlist, permission_mode, kind, system_key, disabled_runtime_skills, service_tier
+RETURNING id, workspace_id, name, avatar_url, runtime_mode, runtime_config, visibility, status, max_concurrent_tasks, owner_id, created_at, updated_at, description, runtime_id, instructions, archived_at, archived_by, custom_env, custom_args, mcp_config, model, thinking_level, composio_toolkit_allowlist, permission_mode, kind, system_key, disabled_runtime_skills, service_tier, cross_workspace_ids
 `
 
 type ArchiveAgentsByIDsParams struct {
@@ -116,6 +117,7 @@ func (q *Queries) ArchiveAgentsByIDs(ctx context.Context, arg ArchiveAgentsByIDs
 			&i.SystemKey,
 			&i.DisabledRuntimeSkills,
 			&i.ServiceTier,
+			&i.CrossWorkspaceIds,
 		); err != nil {
 			return nil, err
 		}
@@ -131,7 +133,7 @@ const archiveAgentsByRuntime = `-- name: ArchiveAgentsByRuntime :many
 UPDATE agent
 SET archived_at = now(), archived_by = $1, updated_at = now()
 WHERE runtime_id = ANY($2::uuid[]) AND archived_at IS NULL
-RETURNING id, workspace_id, name, avatar_url, runtime_mode, runtime_config, visibility, status, max_concurrent_tasks, owner_id, created_at, updated_at, description, runtime_id, instructions, archived_at, archived_by, custom_env, custom_args, mcp_config, model, thinking_level, composio_toolkit_allowlist, permission_mode, kind, system_key, disabled_runtime_skills, service_tier
+RETURNING id, workspace_id, name, avatar_url, runtime_mode, runtime_config, visibility, status, max_concurrent_tasks, owner_id, created_at, updated_at, description, runtime_id, instructions, archived_at, archived_by, custom_env, custom_args, mcp_config, model, thinking_level, composio_toolkit_allowlist, permission_mode, kind, system_key, disabled_runtime_skills, service_tier, cross_workspace_ids
 `
 
 type ArchiveAgentsByRuntimeParams struct {
@@ -181,6 +183,7 @@ func (q *Queries) ArchiveAgentsByRuntime(ctx context.Context, arg ArchiveAgentsB
 			&i.SystemKey,
 			&i.DisabledRuntimeSkills,
 			&i.ServiceTier,
+			&i.CrossWorkspaceIds,
 		); err != nil {
 			return nil, err
 		}
@@ -1039,7 +1042,7 @@ func (q *Queries) ClaimChatFinalizeDeferred(ctx context.Context, id pgtype.UUID)
 const clearAgentComposioToolkitAllowlist = `-- name: ClearAgentComposioToolkitAllowlist :one
 UPDATE agent SET composio_toolkit_allowlist = NULL, updated_at = now()
 WHERE id = $1
-RETURNING id, workspace_id, name, avatar_url, runtime_mode, runtime_config, visibility, status, max_concurrent_tasks, owner_id, created_at, updated_at, description, runtime_id, instructions, archived_at, archived_by, custom_env, custom_args, mcp_config, model, thinking_level, composio_toolkit_allowlist, permission_mode, kind, system_key, disabled_runtime_skills, service_tier
+RETURNING id, workspace_id, name, avatar_url, runtime_mode, runtime_config, visibility, status, max_concurrent_tasks, owner_id, created_at, updated_at, description, runtime_id, instructions, archived_at, archived_by, custom_env, custom_args, mcp_config, model, thinking_level, composio_toolkit_allowlist, permission_mode, kind, system_key, disabled_runtime_skills, service_tier, cross_workspace_ids
 `
 
 // Explicit NULL-clear for composio_toolkit_allowlist. The COALESCE-based
@@ -1080,6 +1083,7 @@ func (q *Queries) ClearAgentComposioToolkitAllowlist(ctx context.Context, id pgt
 		&i.SystemKey,
 		&i.DisabledRuntimeSkills,
 		&i.ServiceTier,
+		&i.CrossWorkspaceIds,
 	)
 	return i, err
 }
@@ -1087,7 +1091,7 @@ func (q *Queries) ClearAgentComposioToolkitAllowlist(ctx context.Context, id pgt
 const clearAgentMcpConfig = `-- name: ClearAgentMcpConfig :one
 UPDATE agent SET mcp_config = NULL, updated_at = now()
 WHERE id = $1
-RETURNING id, workspace_id, name, avatar_url, runtime_mode, runtime_config, visibility, status, max_concurrent_tasks, owner_id, created_at, updated_at, description, runtime_id, instructions, archived_at, archived_by, custom_env, custom_args, mcp_config, model, thinking_level, composio_toolkit_allowlist, permission_mode, kind, system_key, disabled_runtime_skills, service_tier
+RETURNING id, workspace_id, name, avatar_url, runtime_mode, runtime_config, visibility, status, max_concurrent_tasks, owner_id, created_at, updated_at, description, runtime_id, instructions, archived_at, archived_by, custom_env, custom_args, mcp_config, model, thinking_level, composio_toolkit_allowlist, permission_mode, kind, system_key, disabled_runtime_skills, service_tier, cross_workspace_ids
 `
 
 func (q *Queries) ClearAgentMcpConfig(ctx context.Context, id pgtype.UUID) (Agent, error) {
@@ -1122,6 +1126,7 @@ func (q *Queries) ClearAgentMcpConfig(ctx context.Context, id pgtype.UUID) (Agen
 		&i.SystemKey,
 		&i.DisabledRuntimeSkills,
 		&i.ServiceTier,
+		&i.CrossWorkspaceIds,
 	)
 	return i, err
 }
@@ -1129,7 +1134,7 @@ func (q *Queries) ClearAgentMcpConfig(ctx context.Context, id pgtype.UUID) (Agen
 const clearAgentServiceTier = `-- name: ClearAgentServiceTier :one
 UPDATE agent SET service_tier = NULL, updated_at = now()
 WHERE id = $1
-RETURNING id, workspace_id, name, avatar_url, runtime_mode, runtime_config, visibility, status, max_concurrent_tasks, owner_id, created_at, updated_at, description, runtime_id, instructions, archived_at, archived_by, custom_env, custom_args, mcp_config, model, thinking_level, composio_toolkit_allowlist, permission_mode, kind, system_key, disabled_runtime_skills, service_tier
+RETURNING id, workspace_id, name, avatar_url, runtime_mode, runtime_config, visibility, status, max_concurrent_tasks, owner_id, created_at, updated_at, description, runtime_id, instructions, archived_at, archived_by, custom_env, custom_args, mcp_config, model, thinking_level, composio_toolkit_allowlist, permission_mode, kind, system_key, disabled_runtime_skills, service_tier, cross_workspace_ids
 `
 
 // Explicit NULL-clear for service_tier. COALESCE-based UpdateAgent cannot
@@ -1166,6 +1171,7 @@ func (q *Queries) ClearAgentServiceTier(ctx context.Context, id pgtype.UUID) (Ag
 		&i.SystemKey,
 		&i.DisabledRuntimeSkills,
 		&i.ServiceTier,
+		&i.CrossWorkspaceIds,
 	)
 	return i, err
 }
@@ -1173,7 +1179,7 @@ func (q *Queries) ClearAgentServiceTier(ctx context.Context, id pgtype.UUID) (Ag
 const clearAgentThinkingLevel = `-- name: ClearAgentThinkingLevel :one
 UPDATE agent SET thinking_level = NULL, updated_at = now()
 WHERE id = $1
-RETURNING id, workspace_id, name, avatar_url, runtime_mode, runtime_config, visibility, status, max_concurrent_tasks, owner_id, created_at, updated_at, description, runtime_id, instructions, archived_at, archived_by, custom_env, custom_args, mcp_config, model, thinking_level, composio_toolkit_allowlist, permission_mode, kind, system_key, disabled_runtime_skills, service_tier
+RETURNING id, workspace_id, name, avatar_url, runtime_mode, runtime_config, visibility, status, max_concurrent_tasks, owner_id, created_at, updated_at, description, runtime_id, instructions, archived_at, archived_by, custom_env, custom_args, mcp_config, model, thinking_level, composio_toolkit_allowlist, permission_mode, kind, system_key, disabled_runtime_skills, service_tier, cross_workspace_ids
 `
 
 // Explicit NULL-clear for thinking_level. COALESCE-based UpdateAgent cannot
@@ -1211,6 +1217,7 @@ func (q *Queries) ClearAgentThinkingLevel(ctx context.Context, id pgtype.UUID) (
 		&i.SystemKey,
 		&i.DisabledRuntimeSkills,
 		&i.ServiceTier,
+		&i.CrossWorkspaceIds,
 	)
 	return i, err
 }
@@ -1316,7 +1323,7 @@ INSERT INTO agent (
     $18::text[],
     COALESCE($19, 'private')
 )
-RETURNING id, workspace_id, name, avatar_url, runtime_mode, runtime_config, visibility, status, max_concurrent_tasks, owner_id, created_at, updated_at, description, runtime_id, instructions, archived_at, archived_by, custom_env, custom_args, mcp_config, model, thinking_level, composio_toolkit_allowlist, permission_mode, kind, system_key, disabled_runtime_skills, service_tier
+RETURNING id, workspace_id, name, avatar_url, runtime_mode, runtime_config, visibility, status, max_concurrent_tasks, owner_id, created_at, updated_at, description, runtime_id, instructions, archived_at, archived_by, custom_env, custom_args, mcp_config, model, thinking_level, composio_toolkit_allowlist, permission_mode, kind, system_key, disabled_runtime_skills, service_tier, cross_workspace_ids
 `
 
 type CreateAgentParams struct {
@@ -1393,6 +1400,7 @@ func (q *Queries) CreateAgent(ctx context.Context, arg CreateAgentParams) (Agent
 		&i.SystemKey,
 		&i.DisabledRuntimeSkills,
 		&i.ServiceTier,
+		&i.CrossWorkspaceIds,
 	)
 	return i, err
 }
@@ -1407,7 +1415,7 @@ INSERT INTO agent (
     'private', 'private', 1, $5, $6,
     '{}'::jsonb, '[]'::jsonb, $7, 'system', $8
 )
-RETURNING id, workspace_id, name, avatar_url, runtime_mode, runtime_config, visibility, status, max_concurrent_tasks, owner_id, created_at, updated_at, description, runtime_id, instructions, archived_at, archived_by, custom_env, custom_args, mcp_config, model, thinking_level, composio_toolkit_allowlist, permission_mode, kind, system_key, disabled_runtime_skills, service_tier
+RETURNING id, workspace_id, name, avatar_url, runtime_mode, runtime_config, visibility, status, max_concurrent_tasks, owner_id, created_at, updated_at, description, runtime_id, instructions, archived_at, archived_by, custom_env, custom_args, mcp_config, model, thinking_level, composio_toolkit_allowlist, permission_mode, kind, system_key, disabled_runtime_skills, service_tier, cross_workspace_ids
 `
 
 type CreateAgentBuilderParams struct {
@@ -1466,6 +1474,7 @@ func (q *Queries) CreateAgentBuilder(ctx context.Context, arg CreateAgentBuilder
 		&i.SystemKey,
 		&i.DisabledRuntimeSkills,
 		&i.ServiceTier,
+		&i.CrossWorkspaceIds,
 	)
 	return i, err
 }
@@ -2430,7 +2439,7 @@ func (q *Queries) FailStaleTasks(ctx context.Context, arg FailStaleTasksParams) 
 }
 
 const getAgent = `-- name: GetAgent :one
-SELECT id, workspace_id, name, avatar_url, runtime_mode, runtime_config, visibility, status, max_concurrent_tasks, owner_id, created_at, updated_at, description, runtime_id, instructions, archived_at, archived_by, custom_env, custom_args, mcp_config, model, thinking_level, composio_toolkit_allowlist, permission_mode, kind, system_key, disabled_runtime_skills, service_tier FROM agent
+SELECT id, workspace_id, name, avatar_url, runtime_mode, runtime_config, visibility, status, max_concurrent_tasks, owner_id, created_at, updated_at, description, runtime_id, instructions, archived_at, archived_by, custom_env, custom_args, mcp_config, model, thinking_level, composio_toolkit_allowlist, permission_mode, kind, system_key, disabled_runtime_skills, service_tier, cross_workspace_ids FROM agent
 WHERE id = $1
 `
 
@@ -2466,12 +2475,13 @@ func (q *Queries) GetAgent(ctx context.Context, id pgtype.UUID) (Agent, error) {
 		&i.SystemKey,
 		&i.DisabledRuntimeSkills,
 		&i.ServiceTier,
+		&i.CrossWorkspaceIds,
 	)
 	return i, err
 }
 
 const getAgentForClaimUpdate = `-- name: GetAgentForClaimUpdate :one
-SELECT id, workspace_id, name, avatar_url, runtime_mode, runtime_config, visibility, status, max_concurrent_tasks, owner_id, created_at, updated_at, description, runtime_id, instructions, archived_at, archived_by, custom_env, custom_args, mcp_config, model, thinking_level, composio_toolkit_allowlist, permission_mode, kind, system_key, disabled_runtime_skills, service_tier FROM agent
+SELECT id, workspace_id, name, avatar_url, runtime_mode, runtime_config, visibility, status, max_concurrent_tasks, owner_id, created_at, updated_at, description, runtime_id, instructions, archived_at, archived_by, custom_env, custom_args, mcp_config, model, thinking_level, composio_toolkit_allowlist, permission_mode, kind, system_key, disabled_runtime_skills, service_tier, cross_workspace_ids FROM agent
 WHERE id = $1
 FOR UPDATE
 `
@@ -2508,12 +2518,13 @@ func (q *Queries) GetAgentForClaimUpdate(ctx context.Context, id pgtype.UUID) (A
 		&i.SystemKey,
 		&i.DisabledRuntimeSkills,
 		&i.ServiceTier,
+		&i.CrossWorkspaceIds,
 	)
 	return i, err
 }
 
 const getAgentForUpdate = `-- name: GetAgentForUpdate :one
-SELECT id, workspace_id, name, avatar_url, runtime_mode, runtime_config, visibility, status, max_concurrent_tasks, owner_id, created_at, updated_at, description, runtime_id, instructions, archived_at, archived_by, custom_env, custom_args, mcp_config, model, thinking_level, composio_toolkit_allowlist, permission_mode, kind, system_key, disabled_runtime_skills, service_tier FROM agent
+SELECT id, workspace_id, name, avatar_url, runtime_mode, runtime_config, visibility, status, max_concurrent_tasks, owner_id, created_at, updated_at, description, runtime_id, instructions, archived_at, archived_by, custom_env, custom_args, mcp_config, model, thinking_level, composio_toolkit_allowlist, permission_mode, kind, system_key, disabled_runtime_skills, service_tier, cross_workspace_ids FROM agent
 WHERE id = $1
 FOR UPDATE
 `
@@ -2552,12 +2563,13 @@ func (q *Queries) GetAgentForUpdate(ctx context.Context, id pgtype.UUID) (Agent,
 		&i.SystemKey,
 		&i.DisabledRuntimeSkills,
 		&i.ServiceTier,
+		&i.CrossWorkspaceIds,
 	)
 	return i, err
 }
 
 const getAgentInWorkspace = `-- name: GetAgentInWorkspace :one
-SELECT id, workspace_id, name, avatar_url, runtime_mode, runtime_config, visibility, status, max_concurrent_tasks, owner_id, created_at, updated_at, description, runtime_id, instructions, archived_at, archived_by, custom_env, custom_args, mcp_config, model, thinking_level, composio_toolkit_allowlist, permission_mode, kind, system_key, disabled_runtime_skills, service_tier FROM agent
+SELECT id, workspace_id, name, avatar_url, runtime_mode, runtime_config, visibility, status, max_concurrent_tasks, owner_id, created_at, updated_at, description, runtime_id, instructions, archived_at, archived_by, custom_env, custom_args, mcp_config, model, thinking_level, composio_toolkit_allowlist, permission_mode, kind, system_key, disabled_runtime_skills, service_tier, cross_workspace_ids FROM agent
 WHERE id = $1 AND workspace_id = $2 AND kind = 'user'
 `
 
@@ -2598,6 +2610,7 @@ func (q *Queries) GetAgentInWorkspace(ctx context.Context, arg GetAgentInWorkspa
 		&i.SystemKey,
 		&i.DisabledRuntimeSkills,
 		&i.ServiceTier,
+		&i.CrossWorkspaceIds,
 	)
 	return i, err
 }
@@ -3108,7 +3121,7 @@ func (q *Queries) LinkTaskToIssue(ctx context.Context, arg LinkTaskToIssueParams
 }
 
 const listActiveAgentsByRuntime = `-- name: ListActiveAgentsByRuntime :many
-SELECT id, workspace_id, name, avatar_url, runtime_mode, runtime_config, visibility, status, max_concurrent_tasks, owner_id, created_at, updated_at, description, runtime_id, instructions, archived_at, archived_by, custom_env, custom_args, mcp_config, model, thinking_level, composio_toolkit_allowlist, permission_mode, kind, system_key, disabled_runtime_skills, service_tier FROM agent
+SELECT id, workspace_id, name, avatar_url, runtime_mode, runtime_config, visibility, status, max_concurrent_tasks, owner_id, created_at, updated_at, description, runtime_id, instructions, archived_at, archived_by, custom_env, custom_args, mcp_config, model, thinking_level, composio_toolkit_allowlist, permission_mode, kind, system_key, disabled_runtime_skills, service_tier, cross_workspace_ids FROM agent
 WHERE runtime_id = $1 AND archived_at IS NULL AND kind = 'user'
 ORDER BY name ASC
 `
@@ -3157,6 +3170,7 @@ func (q *Queries) ListActiveAgentsByRuntime(ctx context.Context, runtimeID pgtyp
 			&i.SystemKey,
 			&i.DisabledRuntimeSkills,
 			&i.ServiceTier,
+			&i.CrossWorkspaceIds,
 		); err != nil {
 			return nil, err
 		}
@@ -3169,7 +3183,7 @@ func (q *Queries) ListActiveAgentsByRuntime(ctx context.Context, runtimeID pgtyp
 }
 
 const listActiveAgentsByRuntimeForUpdate = `-- name: ListActiveAgentsByRuntimeForUpdate :many
-SELECT id, workspace_id, name, avatar_url, runtime_mode, runtime_config, visibility, status, max_concurrent_tasks, owner_id, created_at, updated_at, description, runtime_id, instructions, archived_at, archived_by, custom_env, custom_args, mcp_config, model, thinking_level, composio_toolkit_allowlist, permission_mode, kind, system_key, disabled_runtime_skills, service_tier FROM agent
+SELECT id, workspace_id, name, avatar_url, runtime_mode, runtime_config, visibility, status, max_concurrent_tasks, owner_id, created_at, updated_at, description, runtime_id, instructions, archived_at, archived_by, custom_env, custom_args, mcp_config, model, thinking_level, composio_toolkit_allowlist, permission_mode, kind, system_key, disabled_runtime_skills, service_tier, cross_workspace_ids FROM agent
 WHERE runtime_id = $1 AND archived_at IS NULL AND kind = 'user'
 ORDER BY name ASC
 FOR UPDATE
@@ -3221,6 +3235,7 @@ func (q *Queries) ListActiveAgentsByRuntimeForUpdate(ctx context.Context, runtim
 			&i.SystemKey,
 			&i.DisabledRuntimeSkills,
 			&i.ServiceTier,
+			&i.CrossWorkspaceIds,
 		); err != nil {
 			return nil, err
 		}
@@ -3386,7 +3401,7 @@ func (q *Queries) ListAgentTasks(ctx context.Context, agentID pgtype.UUID) ([]Ag
 }
 
 const listAgents = `-- name: ListAgents :many
-SELECT id, workspace_id, name, avatar_url, runtime_mode, runtime_config, visibility, status, max_concurrent_tasks, owner_id, created_at, updated_at, description, runtime_id, instructions, archived_at, archived_by, custom_env, custom_args, mcp_config, model, thinking_level, composio_toolkit_allowlist, permission_mode, kind, system_key, disabled_runtime_skills, service_tier FROM agent
+SELECT id, workspace_id, name, avatar_url, runtime_mode, runtime_config, visibility, status, max_concurrent_tasks, owner_id, created_at, updated_at, description, runtime_id, instructions, archived_at, archived_by, custom_env, custom_args, mcp_config, model, thinking_level, composio_toolkit_allowlist, permission_mode, kind, system_key, disabled_runtime_skills, service_tier, cross_workspace_ids FROM agent
 WHERE workspace_id = $1 AND archived_at IS NULL AND kind = 'user'
 ORDER BY created_at ASC
 `
@@ -3429,6 +3444,7 @@ func (q *Queries) ListAgents(ctx context.Context, workspaceID pgtype.UUID) ([]Ag
 			&i.SystemKey,
 			&i.DisabledRuntimeSkills,
 			&i.ServiceTier,
+			&i.CrossWorkspaceIds,
 		); err != nil {
 			return nil, err
 		}
@@ -3441,7 +3457,7 @@ func (q *Queries) ListAgents(ctx context.Context, workspaceID pgtype.UUID) ([]Ag
 }
 
 const listAllAgents = `-- name: ListAllAgents :many
-SELECT id, workspace_id, name, avatar_url, runtime_mode, runtime_config, visibility, status, max_concurrent_tasks, owner_id, created_at, updated_at, description, runtime_id, instructions, archived_at, archived_by, custom_env, custom_args, mcp_config, model, thinking_level, composio_toolkit_allowlist, permission_mode, kind, system_key, disabled_runtime_skills, service_tier FROM agent
+SELECT id, workspace_id, name, avatar_url, runtime_mode, runtime_config, visibility, status, max_concurrent_tasks, owner_id, created_at, updated_at, description, runtime_id, instructions, archived_at, archived_by, custom_env, custom_args, mcp_config, model, thinking_level, composio_toolkit_allowlist, permission_mode, kind, system_key, disabled_runtime_skills, service_tier, cross_workspace_ids FROM agent
 WHERE workspace_id = $1 AND kind = 'user'
 ORDER BY created_at ASC
 `
@@ -3484,6 +3500,7 @@ func (q *Queries) ListAllAgents(ctx context.Context, workspaceID pgtype.UUID) ([
 			&i.SystemKey,
 			&i.DisabledRuntimeSkills,
 			&i.ServiceTier,
+			&i.CrossWorkspaceIds,
 		); err != nil {
 			return nil, err
 		}
@@ -4585,7 +4602,7 @@ SET runtime_id = $1,
     model = $3,
     updated_at = now()
 WHERE id = $4 AND kind = 'system' AND system_key LIKE 'agent_builder:%'
-RETURNING id, workspace_id, name, avatar_url, runtime_mode, runtime_config, visibility, status, max_concurrent_tasks, owner_id, created_at, updated_at, description, runtime_id, instructions, archived_at, archived_by, custom_env, custom_args, mcp_config, model, thinking_level, composio_toolkit_allowlist, permission_mode, kind, system_key, disabled_runtime_skills, service_tier
+RETURNING id, workspace_id, name, avatar_url, runtime_mode, runtime_config, visibility, status, max_concurrent_tasks, owner_id, created_at, updated_at, description, runtime_id, instructions, archived_at, archived_by, custom_env, custom_args, mcp_config, model, thinking_level, composio_toolkit_allowlist, permission_mode, kind, system_key, disabled_runtime_skills, service_tier, cross_workspace_ids
 `
 
 type RebindAgentBuilderRuntimeParams struct {
@@ -4648,6 +4665,7 @@ func (q *Queries) RebindAgentBuilderRuntime(ctx context.Context, arg RebindAgent
 		&i.SystemKey,
 		&i.DisabledRuntimeSkills,
 		&i.ServiceTier,
+		&i.CrossWorkspaceIds,
 	)
 	return i, err
 }
@@ -4935,7 +4953,7 @@ SET status = CASE WHEN EXISTS (
 ) THEN 'working' ELSE 'idle' END,
     updated_at = now()
 WHERE a.id = $1
-RETURNING id, workspace_id, name, avatar_url, runtime_mode, runtime_config, visibility, status, max_concurrent_tasks, owner_id, created_at, updated_at, description, runtime_id, instructions, archived_at, archived_by, custom_env, custom_args, mcp_config, model, thinking_level, composio_toolkit_allowlist, permission_mode, kind, system_key, disabled_runtime_skills, service_tier
+RETURNING id, workspace_id, name, avatar_url, runtime_mode, runtime_config, visibility, status, max_concurrent_tasks, owner_id, created_at, updated_at, description, runtime_id, instructions, archived_at, archived_by, custom_env, custom_args, mcp_config, model, thinking_level, composio_toolkit_allowlist, permission_mode, kind, system_key, disabled_runtime_skills, service_tier, cross_workspace_ids
 `
 
 func (q *Queries) RefreshAgentStatusFromTasks(ctx context.Context, id pgtype.UUID) (Agent, error) {
@@ -4970,6 +4988,7 @@ func (q *Queries) RefreshAgentStatusFromTasks(ctx context.Context, id pgtype.UUI
 		&i.SystemKey,
 		&i.DisabledRuntimeSkills,
 		&i.ServiceTier,
+		&i.CrossWorkspaceIds,
 	)
 	return i, err
 }
@@ -5057,7 +5076,7 @@ func (q *Queries) RequeueAgentTaskAfterClaimFailure(ctx context.Context, arg Req
 const restoreAgent = `-- name: RestoreAgent :one
 UPDATE agent SET archived_at = NULL, archived_by = NULL, updated_at = now()
 WHERE id = $1
-RETURNING id, workspace_id, name, avatar_url, runtime_mode, runtime_config, visibility, status, max_concurrent_tasks, owner_id, created_at, updated_at, description, runtime_id, instructions, archived_at, archived_by, custom_env, custom_args, mcp_config, model, thinking_level, composio_toolkit_allowlist, permission_mode, kind, system_key, disabled_runtime_skills, service_tier
+RETURNING id, workspace_id, name, avatar_url, runtime_mode, runtime_config, visibility, status, max_concurrent_tasks, owner_id, created_at, updated_at, description, runtime_id, instructions, archived_at, archived_by, custom_env, custom_args, mcp_config, model, thinking_level, composio_toolkit_allowlist, permission_mode, kind, system_key, disabled_runtime_skills, service_tier, cross_workspace_ids
 `
 
 func (q *Queries) RestoreAgent(ctx context.Context, id pgtype.UUID) (Agent, error) {
@@ -5092,6 +5111,7 @@ func (q *Queries) RestoreAgent(ctx context.Context, id pgtype.UUID) (Agent, erro
 		&i.SystemKey,
 		&i.DisabledRuntimeSkills,
 		&i.ServiceTier,
+		&i.CrossWorkspaceIds,
 	)
 	return i, err
 }
@@ -5236,7 +5256,7 @@ UPDATE agent SET
     composio_toolkit_allowlist = COALESCE($19::text[], composio_toolkit_allowlist),
     updated_at = now()
 WHERE id = $1
-RETURNING id, workspace_id, name, avatar_url, runtime_mode, runtime_config, visibility, status, max_concurrent_tasks, owner_id, created_at, updated_at, description, runtime_id, instructions, archived_at, archived_by, custom_env, custom_args, mcp_config, model, thinking_level, composio_toolkit_allowlist, permission_mode, kind, system_key, disabled_runtime_skills, service_tier
+RETURNING id, workspace_id, name, avatar_url, runtime_mode, runtime_config, visibility, status, max_concurrent_tasks, owner_id, created_at, updated_at, description, runtime_id, instructions, archived_at, archived_by, custom_env, custom_args, mcp_config, model, thinking_level, composio_toolkit_allowlist, permission_mode, kind, system_key, disabled_runtime_skills, service_tier, cross_workspace_ids
 `
 
 type UpdateAgentParams struct {
@@ -5319,6 +5339,60 @@ func (q *Queries) UpdateAgent(ctx context.Context, arg UpdateAgentParams) (Agent
 		&i.SystemKey,
 		&i.DisabledRuntimeSkills,
 		&i.ServiceTier,
+		&i.CrossWorkspaceIds,
+	)
+	return i, err
+}
+
+const updateAgentCrossWorkspaceIDs = `-- name: UpdateAgentCrossWorkspaceIDs :one
+UPDATE agent
+SET cross_workspace_ids = $2, updated_at = now()
+WHERE id = $1
+RETURNING id, workspace_id, name, avatar_url, runtime_mode, runtime_config, visibility, status, max_concurrent_tasks, owner_id, created_at, updated_at, description, runtime_id, instructions, archived_at, archived_by, custom_env, custom_args, mcp_config, model, thinking_level, composio_toolkit_allowlist, permission_mode, kind, system_key, disabled_runtime_skills, service_tier, cross_workspace_ids
+`
+
+type UpdateAgentCrossWorkspaceIDsParams struct {
+	ID                pgtype.UUID   `json:"id"`
+	CrossWorkspaceIds []pgtype.UUID `json:"cross_workspace_ids"`
+}
+
+// Replaces an agent's cross_workspace_ids allow-list wholesale. Owner/admin
+// only, via the dedicated grant-management endpoint (PUT
+// /api/agents/{id}/cross-workspace-grants) so every change is audit-logged;
+// agent actors never reach this query.
+func (q *Queries) UpdateAgentCrossWorkspaceIDs(ctx context.Context, arg UpdateAgentCrossWorkspaceIDsParams) (Agent, error) {
+	row := q.db.QueryRow(ctx, updateAgentCrossWorkspaceIDs, arg.ID, arg.CrossWorkspaceIds)
+	var i Agent
+	err := row.Scan(
+		&i.ID,
+		&i.WorkspaceID,
+		&i.Name,
+		&i.AvatarUrl,
+		&i.RuntimeMode,
+		&i.RuntimeConfig,
+		&i.Visibility,
+		&i.Status,
+		&i.MaxConcurrentTasks,
+		&i.OwnerID,
+		&i.CreatedAt,
+		&i.UpdatedAt,
+		&i.Description,
+		&i.RuntimeID,
+		&i.Instructions,
+		&i.ArchivedAt,
+		&i.ArchivedBy,
+		&i.CustomEnv,
+		&i.CustomArgs,
+		&i.McpConfig,
+		&i.Model,
+		&i.ThinkingLevel,
+		&i.ComposioToolkitAllowlist,
+		&i.PermissionMode,
+		&i.Kind,
+		&i.SystemKey,
+		&i.DisabledRuntimeSkills,
+		&i.ServiceTier,
+		&i.CrossWorkspaceIds,
 	)
 	return i, err
 }
@@ -5327,7 +5401,7 @@ const updateAgentCustomEnv = `-- name: UpdateAgentCustomEnv :one
 UPDATE agent
 SET custom_env = $2, updated_at = now()
 WHERE id = $1
-RETURNING id, workspace_id, name, avatar_url, runtime_mode, runtime_config, visibility, status, max_concurrent_tasks, owner_id, created_at, updated_at, description, runtime_id, instructions, archived_at, archived_by, custom_env, custom_args, mcp_config, model, thinking_level, composio_toolkit_allowlist, permission_mode, kind, system_key, disabled_runtime_skills, service_tier
+RETURNING id, workspace_id, name, avatar_url, runtime_mode, runtime_config, visibility, status, max_concurrent_tasks, owner_id, created_at, updated_at, description, runtime_id, instructions, archived_at, archived_by, custom_env, custom_args, mcp_config, model, thinking_level, composio_toolkit_allowlist, permission_mode, kind, system_key, disabled_runtime_skills, service_tier, cross_workspace_ids
 `
 
 type UpdateAgentCustomEnvParams struct {
@@ -5372,6 +5446,7 @@ func (q *Queries) UpdateAgentCustomEnv(ctx context.Context, arg UpdateAgentCusto
 		&i.SystemKey,
 		&i.DisabledRuntimeSkills,
 		&i.ServiceTier,
+		&i.CrossWorkspaceIds,
 	)
 	return i, err
 }
@@ -5380,7 +5455,7 @@ const updateAgentDisabledRuntimeSkills = `-- name: UpdateAgentDisabledRuntimeSki
 UPDATE agent
 SET disabled_runtime_skills = $2, updated_at = now()
 WHERE id = $1
-RETURNING id, workspace_id, name, avatar_url, runtime_mode, runtime_config, visibility, status, max_concurrent_tasks, owner_id, created_at, updated_at, description, runtime_id, instructions, archived_at, archived_by, custom_env, custom_args, mcp_config, model, thinking_level, composio_toolkit_allowlist, permission_mode, kind, system_key, disabled_runtime_skills, service_tier
+RETURNING id, workspace_id, name, avatar_url, runtime_mode, runtime_config, visibility, status, max_concurrent_tasks, owner_id, created_at, updated_at, description, runtime_id, instructions, archived_at, archived_by, custom_env, custom_args, mcp_config, model, thinking_level, composio_toolkit_allowlist, permission_mode, kind, system_key, disabled_runtime_skills, service_tier, cross_workspace_ids
 `
 
 type UpdateAgentDisabledRuntimeSkillsParams struct {
@@ -5420,6 +5495,7 @@ func (q *Queries) UpdateAgentDisabledRuntimeSkills(ctx context.Context, arg Upda
 		&i.SystemKey,
 		&i.DisabledRuntimeSkills,
 		&i.ServiceTier,
+		&i.CrossWorkspaceIds,
 	)
 	return i, err
 }
@@ -5427,7 +5503,7 @@ func (q *Queries) UpdateAgentDisabledRuntimeSkills(ctx context.Context, arg Upda
 const updateAgentStatus = `-- name: UpdateAgentStatus :one
 UPDATE agent SET status = $2, updated_at = now()
 WHERE id = $1
-RETURNING id, workspace_id, name, avatar_url, runtime_mode, runtime_config, visibility, status, max_concurrent_tasks, owner_id, created_at, updated_at, description, runtime_id, instructions, archived_at, archived_by, custom_env, custom_args, mcp_config, model, thinking_level, composio_toolkit_allowlist, permission_mode, kind, system_key, disabled_runtime_skills, service_tier
+RETURNING id, workspace_id, name, avatar_url, runtime_mode, runtime_config, visibility, status, max_concurrent_tasks, owner_id, created_at, updated_at, description, runtime_id, instructions, archived_at, archived_by, custom_env, custom_args, mcp_config, model, thinking_level, composio_toolkit_allowlist, permission_mode, kind, system_key, disabled_runtime_skills, service_tier, cross_workspace_ids
 `
 
 type UpdateAgentStatusParams struct {
@@ -5467,6 +5543,7 @@ func (q *Queries) UpdateAgentStatus(ctx context.Context, arg UpdateAgentStatusPa
 		&i.SystemKey,
 		&i.DisabledRuntimeSkills,
 		&i.ServiceTier,
+		&i.CrossWorkspaceIds,
 	)
 	return i, err
 }

--- a/server/pkg/db/generated/models.go
+++ b/server/pkg/db/generated/models.go
@@ -47,11 +47,12 @@ type Agent struct {
 	// Composio toolkit slugs this agent is allowed to mount as MCP. NULL or empty array = no MCP overlay. Mounted for any run that passes the agent invocation-permission gate (MUL-3963); the overlay uses the agent OWNER's active Composio connection, so sharing the agent (public_to) shares these apps with whoever may invoke it. No longer gated on originator == owner. Stored as TEXT[] so the dispatch path can intersect against the owner's active connections with a single SQL ANY() filter.
 	ComposioToolkitAllowlist []string `json:"composio_toolkit_allowlist"`
 	// Agent invocation permission mode (MUL-3963). private = owner only; public_to = allow-list in agent_invocation_target. Replaces visibility as the authorization source for triggering runs; visibility is now a derived legacy field. Default private = deny-by-default.
-	PermissionMode        string      `json:"permission_mode"`
-	Kind                  string      `json:"kind"`
-	SystemKey             pgtype.Text `json:"system_key"`
-	DisabledRuntimeSkills []byte      `json:"disabled_runtime_skills"`
-	ServiceTier           pgtype.Text `json:"service_tier"`
+	PermissionMode        string        `json:"permission_mode"`
+	Kind                  string        `json:"kind"`
+	SystemKey             pgtype.Text   `json:"system_key"`
+	DisabledRuntimeSkills []byte        `json:"disabled_runtime_skills"`
+	ServiceTier           pgtype.Text   `json:"service_tier"`
+	CrossWorkspaceIds     []pgtype.UUID `json:"cross_workspace_ids"`
 }
 
 // Allow-list of who may invoke a public_to agent (MUL-3963). One row per (agent, target_type, target); targets stack and canInvokeAgent OR-matches. workspace rows store the agent workspace_id in target_id; member rows store the user id; team rows are reserved and inert in V1. Rows only matter when agent.permission_mode = public_to. No DB foreign keys: agent_id / created_by / member target_id relationships are maintained in the application layer (see migration comment).

--- a/server/pkg/db/queries/agent.sql
+++ b/server/pkg/db/queries/agent.sql
@@ -166,6 +166,16 @@ SET disabled_runtime_skills = $2, updated_at = now()
 WHERE id = $1
 RETURNING *;
 
+-- name: UpdateAgentCrossWorkspaceIDs :one
+-- Replaces an agent's cross_workspace_ids allow-list wholesale. Owner/admin
+-- only, via the dedicated grant-management endpoint (PUT
+-- /api/agents/{id}/cross-workspace-grants) so every change is audit-logged;
+-- agent actors never reach this query.
+UPDATE agent
+SET cross_workspace_ids = $2, updated_at = now()
+WHERE id = $1
+RETURNING *;
+
 -- name: ArchiveAgent :one
 UPDATE agent SET archived_at = now(), archived_by = $2, updated_at = now()
 WHERE id = $1


### PR DESCRIPTION
## Summary

0.4.11's daemon-task-marker guard correctly closed the pre-existing trick some agents used for cross-workspace calls — `env -u MULTICA_TOKEN -u MULTICA_WORKSPACE_ID multica ... --workspace-id <target>` — which fell back to an owner's config token and handed the agent full owner privileges via whatever credential the daemon happened to be using (the same class of issue MUL-2600 fixed for the normal single-workspace case). Adding a raw override flag/env accepted despite the daemon-task marker would reopen that hole, so this ships the alternative the issue calls out as "the intended long-term fix": a first-class, audited, allow-listed mechanism for an agent task to mint a second `mat_` token scoped to another workspace.

- `agent.cross_workspace_ids` (migration 224): an owner/admin-managed allow-list of workspaces an agent may mint a cross-workspace token into. Empty by default — opt-in only.
- `POST /api/tokens/cross-workspace`: only callable by a genuine `task_token` actor (server-stamped `X-Actor-Source`, not a header an agent process can forge). Checks the calling agent's grant list, re-verifies the task's owning user is actually a member of the target workspace (defense-in-depth against a stale/misconfigured grant), then mints a normal `(task_id, agent_id, workspace_id, user_id)`-scoped `mat_` token and audit-logs the mint into the target workspace's activity log.
- `GET`/`PUT /api/agents/{id}/cross-workspace-grants`: owner/admin-only (`RequireHumanActor`), audited, mirrors the existing `/api/agents/{id}/env` pattern.
- `multica auth cross-workspace-token --target-workspace-id <id> [--output json|token]`
- `multica agent cross-workspace get|set <agent-id>`

Rejected the same-issue alternative (a supported override flag/env honored even with the daemon-task marker present) because it's structurally the same bypass MUL-2600 closed — any such override is reachable by a compromised/malicious agent process, not just a legitimate owner-run script.

## Test plan

Verified against a real Postgres 17 (docker), not just compiled:

- [x] `go build ./...` — clean
- [x] `go vet ./...` — clean
- [x] Migrations apply cleanly through 224 (`go run ./cmd/migrate up`)
- [x] `go test ./internal/handler/... ./cmd/multica/...` — full suite passes (26s), zero regressions
- [x] All 11 new tests pass individually, exercising every gate:
  - `TestMintCrossWorkspaceToken_RequiresTaskTokenActor`
  - `TestMintCrossWorkspaceToken_RejectsSameWorkspace`
  - `TestMintCrossWorkspaceToken_RejectsUngrantedWorkspace`
  - `TestMintCrossWorkspaceToken_RejectsNonMemberTaskOwner`
  - `TestMintCrossWorkspaceToken_Success` (confirms minted token row shape + audit log entry)
  - `TestAgentCrossWorkspaceGrants_SetAndGetRoundTrip`
  - `TestAgentCrossWorkspaceGrants_RejectsOwnWorkspace`
  - `TestAgentCrossWorkspaceGrants_DedupesInput`
  - `TestAgentCrossWorkspaceGrants_NonOwnerRejected`
  - `TestAgentCrossWorkspaceGrants_RequireHumanActorBlocksTaskToken`
- [ ] CLI commands (`multica auth cross-workspace-token`, `multica agent cross-workspace get|set`) not manually smoke-tested against a running daemon — no daemon environment available here; relying on `go vet`/`go build`/`go test ./cmd/multica/...` for correctness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
