### PR TITLE
HYP-1338: fix realtime websocket send channel teardown

### DIFF
--- a/server/internal/realtime/hub.go
+++ b/server/internal/realtime/hub.go
@@ -217,6 +217,11 @@ type Client struct {
 	userID      string
 	workspaceID string
 
+	// sendMu guards sendClosed so inbound frame responses cannot race with
+	// hub teardown closing the send channel.
+	sendMu     sync.Mutex
+	sendClosed bool
+
 	// subscriptions is guarded by hub.mu. Tracks the scopes this client is
 	// currently in. Used to clean up rooms on disconnect.
 	subscriptions map[scopeKey]bool
@@ -255,6 +260,36 @@ func (c *Client) markSeen(eventID string) bool {
 		c.seenList = c.seenList[1:]
 		delete(c.seenIDs, drop)
 	}
+	return true
+}
+
+// trySend delivers frame to the write pump without blocking and without ever
+// writing to a closed channel. It returns false when the buffer is full or the
+// connection is closing.
+func (c *Client) trySend(frame []byte) bool {
+	c.sendMu.Lock()
+	defer c.sendMu.Unlock()
+	if c.sendClosed {
+		return false
+	}
+	select {
+	case c.send <- frame:
+		return true
+	default:
+		return false
+	}
+}
+
+// closeSend marks the client as closed before closing the channel, making late
+// trySend calls no-ops and duplicate teardown calls harmless.
+func (c *Client) closeSend() bool {
+	c.sendMu.Lock()
+	defer c.sendMu.Unlock()
+	if c.sendClosed {
+		return false
+	}
+	c.sendClosed = true
+	close(c.send)
 	return true
 }
 
@@ -354,7 +389,7 @@ func (h *Hub) removeClient(client *Client) {
 			}
 		}
 	}
-	close(client.send)
+	client.closeSend()
 	cb := h.onLastSubscriber
 	total := len(h.clients)
 	h.mu.Unlock()
@@ -499,10 +534,9 @@ func (h *Hub) BroadcastToScopeDedup(scopeType, scopeID string, message []byte, e
 		if !client.markSeen(eventID) {
 			continue
 		}
-		select {
-		case client.send <- message:
+		if client.trySend(message) {
 			sent++
-		default:
+		} else {
 			slow = append(slow, client)
 		}
 	}
@@ -535,10 +569,9 @@ func (h *Hub) fanoutAllDedup(message []byte, excludeWorkspace, eventID string) {
 		if !client.markSeen(eventID) {
 			continue
 		}
-		select {
-		case client.send <- message:
+		if client.trySend(message) {
 			sent++
-		default:
+		} else {
 			slow = append(slow, client)
 		}
 	}
@@ -587,10 +620,9 @@ func (h *Hub) fanoutUser(userID string, message []byte, excludeWorkspace, eventI
 		if !client.markSeen(eventID) {
 			continue
 		}
-		select {
-		case client.send <- message:
+		if client.trySend(message) {
 			sent++
-		default:
+		} else {
 			slow = append(slow, client)
 		}
 	}
@@ -631,7 +663,7 @@ func (h *Hub) evictSlow(slow []*Client) {
 			}
 		}
 		c.subscriptions = nil
-		close(c.send)
+		c.closeSend()
 		evicted++
 	}
 	cb := h.onLastSubscriber
@@ -985,10 +1017,7 @@ func (c *Client) sendJSON(v any) {
 	if err != nil {
 		return
 	}
-	select {
-	case c.send <- data:
-	default:
-	}
+	c.trySend(data)
 }
 
 func (c *Client) writePump() {

--- a/server/internal/realtime/hub_test.go
+++ b/server/internal/realtime/hub_test.go
@@ -90,6 +90,29 @@ func totalClients(hub *Hub) int {
 	return len(hub.clients)
 }
 
+func newRegisteredTestClient(hub *Hub) *Client {
+	client := &Client{
+		hub:           hub,
+		send:          make(chan []byte, 1),
+		userID:        testUserID,
+		workspaceID:   testWorkspaceID,
+		subscriptions: map[scopeKey]bool{sk(ScopeWorkspace, testWorkspaceID): true},
+	}
+	hub.clients[client] = true
+	hub.rooms[sk(ScopeWorkspace, testWorkspaceID)] = map[*Client]bool{client: true}
+	return client
+}
+
+func assertNoPanic(t *testing.T, fn func()) {
+	t.Helper()
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("unexpected panic: %v", r)
+		}
+	}()
+	fn()
+}
+
 func TestHub_ClientRegistration(t *testing.T) {
 	hub, server := newTestHub(t)
 	defer server.Close()
@@ -103,6 +126,61 @@ func TestHub_ClientRegistration(t *testing.T) {
 	if count != 1 {
 		t.Fatalf("expected 1 client, got %d", count)
 	}
+}
+
+func TestClientSendJSONAfterRemoveClientDoesNotPanic(t *testing.T) {
+	hub := NewHub()
+	client := newRegisteredTestClient(hub)
+
+	hub.removeClient(client)
+
+	assertNoPanic(t, func() {
+		client.sendJSON(map[string]string{"type": "pong"})
+	})
+}
+
+func TestClientSendJSONAfterEvictSlowDoesNotPanic(t *testing.T) {
+	hub := NewHub()
+	client := newRegisteredTestClient(hub)
+
+	hub.evictSlow([]*Client{client})
+
+	assertNoPanic(t, func() {
+		client.sendJSON(map[string]string{"type": "pong"})
+	})
+}
+
+func TestClientSendJSONConcurrentWithCloseSendDoesNotPanic(t *testing.T) {
+	client := &Client{
+		send: make(chan []byte, 1024),
+	}
+
+	var wg sync.WaitGroup
+	start := make(chan struct{})
+	done := make(chan struct{})
+	for i := 0; i < 8; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start
+			for {
+				select {
+				case <-done:
+					return
+				default:
+					client.sendJSON(map[string]string{"type": "pong"})
+				}
+			}
+		}()
+	}
+
+	assertNoPanic(t, func() {
+		close(start)
+		time.Sleep(10 * time.Millisecond)
+		client.closeSend()
+		close(done)
+		wg.Wait()
+	})
 }
 
 func TestHub_Broadcast(t *testing.T) {


### PR DESCRIPTION
Closes HYP-1338

Tracking issue: HYP-1338.

## Summary
- Guard realtime websocket client sends with a `sendMu` / `sendClosed` lifecycle, matching the daemon websocket pattern.
- Route `sendJSON` and broadcast fanout through non-blocking `trySend`, preserving drop-on-full behavior while avoiding send-on-closed-channel panics.
- Close client send channels via `closeSend` from both `removeClient` and `evictSlow`, making teardown idempotent and safe against late inbound responses.

## Validation
- `go test ./internal/realtime` (pass; with writable `GOCACHE`)
- `go test -race ./internal/realtime` (pass; with writable `GOCACHE`)
- `git diff --check` (pass)

## Blocked local gates
- `go build ./...`, `go vet ./...`, and `scripts/test-go.sh --race` were attempted with writable caches and direct Go 1.26.1 toolchain invocation, but the environment timed out downloading uncached modules from `proxy.golang.org`.

## Risk
- Scoped to realtime websocket send/close lifecycle.
- Does not change subscription protocol, broadcast routing, slow-client eviction policy, or normal response payloads.
