### PR TITLE
MUL-5329: fix(codex): honor configured first-turn timeout

### DIFF
--- a/server/pkg/agent/codex.go
+++ b/server/pkg/agent/codex.go
@@ -42,11 +42,10 @@ const (
 // rejects). Kept as its own constant so bumping codex independently of
 // other agents stays easy if codex starts shipping longer failure traces.
 const (
-	codexStderrTailBytes                   = 2048
-	defaultCodexSemanticInactivityTimeout  = 10 * time.Minute
-	defaultCodexFirstTurnNoProgressTimeout = 30 * time.Second
-	defaultCodexHandshakeTimeout           = 30 * time.Second
-	codexVersionDiagnosticTimeout          = 2 * time.Second
+	codexStderrTailBytes                  = 2048
+	defaultCodexSemanticInactivityTimeout = 10 * time.Minute
+	defaultCodexHandshakeTimeout          = 30 * time.Second
+	codexVersionDiagnosticTimeout         = 2 * time.Second
 	// codexGracefulShutdownTimeout bounds how long the lifecycle goroutine
 	// waits for codex to exit on its own after stdin is closed, before forcing
 	// a context-cancel kill. A clean exit lets codex run its shutdown path and
@@ -1714,9 +1713,16 @@ func stopTimer(timer *time.Timer) {
 }
 
 func codexFirstTurnNoProgressTimeout(semanticInactivityTimeout time.Duration) time.Duration {
-	if semanticInactivityTimeout <= 0 || semanticInactivityTimeout > defaultCodexFirstTurnNoProgressTimeout {
-		return defaultCodexFirstTurnNoProgressTimeout
+	// The first turn can legitimately be quiet while Codex assembles the
+	// task context and establishes its upstream response stream. It must use
+	// the configured semantic-inactivity budget rather than a hidden 30-second
+	// cap; otherwise the public timeout setting cannot help the exact startup
+	// stall it is meant to control.
+	if semanticInactivityTimeout <= 0 {
+		return defaultCodexSemanticInactivityTimeout
 	}
+	// Keep a small distinction between a quiet first turn and a later semantic
+	// stall, while preserving the caller's configured budget at every scale.
 	scaled := semanticInactivityTimeout * 4 / 5
 	if scaled <= 0 {
 		return semanticInactivityTimeout

--- a/server/pkg/agent/codex_test.go
+++ b/server/pkg/agent/codex_test.go
@@ -2720,6 +2720,16 @@ func TestCodexExecuteTimesOutWhenTurnStopsAfterToolResult(t *testing.T) {
 	}
 }
 
+func TestCodexFirstTurnNoProgressTimeoutScalesConfiguredBudget(t *testing.T) {
+	t.Parallel()
+
+	const configured = 2 * time.Minute
+	const want = 96 * time.Second
+	if got := codexFirstTurnNoProgressTimeout(configured); got != want {
+		t.Fatalf("codexFirstTurnNoProgressTimeout(%s) = %s, want %s", configured, got, want)
+	}
+}
+
 func TestCodexExecuteFirstTurnNoProgressSurfacesDiagnostics(t *testing.T) {
 	// Not t.Parallel(): this test mutates codexGracefulShutdownTimeoutNanos.
 	// The model catalog signal below makes both attempts retry safe, so this


### PR DESCRIPTION
Summary:
- remove the hidden 30-second cap from the first-turn Codex progress watchdog
- scale the first-turn window from the configured semantic inactivity timeout
- add a regression test for a two-minute setting

Reproduction:
A WSL Codex app-server emitted status: running and its first model event about 39 seconds later. The unmodified daemon killed it at 30 seconds even with --codex-semantic-inactivity-timeout 2m; the patched build completed successfully.

Test:
go test ./pkg/agent -run TestCodex -count=1