### PR TITLE
WS-768 feat(autopilot): chain triggers for cross-autopilot orchestration

### DIFF
--- a/server/cmd/multica/cmd_autopilot.go
+++ b/server/cmd/multica/cmd_autopilot.go
@@ -152,9 +152,11 @@ func init() {
 	autopilotRunsCmd.Flags().String("output", "table", "Output format: table or json")
 
 	// trigger-add — supports schedule and webhook
-	autopilotTriggerAddCmd.Flags().String("kind", "schedule", "Trigger kind: schedule or webhook")
+	autopilotTriggerAddCmd.Flags().String("kind", "schedule", "Trigger kind: schedule, webhook, or chain")
 	autopilotTriggerAddCmd.Flags().String("cron", "", "Cron expression (required for --kind schedule)")
 	autopilotTriggerAddCmd.Flags().String("timezone", "", "IANA timezone (default UTC; schedule only)")
+	autopilotTriggerAddCmd.Flags().String("upstream", "", "Upstream autopilot ID (required for --kind chain)")
+	autopilotTriggerAddCmd.Flags().String("on-status", "", "Fire on upstream terminal status: completed, failed, or any (chain only; default completed)")
 	autopilotTriggerAddCmd.Flags().String("label", "", "Optional human-readable label")
 	autopilotTriggerAddCmd.Flags().String("output", "json", "Output format: table or json")
 
@@ -167,6 +169,7 @@ func init() {
 	autopilotTriggerUpdateCmd.Flags().String("cron", "", "New cron expression")
 	autopilotTriggerUpdateCmd.Flags().String("timezone", "", "New IANA timezone")
 	autopilotTriggerUpdateCmd.Flags().String("label", "", "New label")
+	autopilotTriggerUpdateCmd.Flags().String("on-status", "", "New chain fire-on status: completed, failed, or any (chain only)")
 	autopilotTriggerUpdateCmd.Flags().String("output", "json", "Output format: table or json")
 }
 
@@ -545,8 +548,8 @@ func runAutopilotTriggerAdd(cmd *cobra.Command, args []string) error {
 	if kind == "" {
 		kind = "schedule"
 	}
-	if kind != "schedule" && kind != "webhook" {
-		return fmt.Errorf("--kind must be schedule or webhook")
+	if kind != "schedule" && kind != "webhook" && kind != "chain" {
+		return fmt.Errorf("--kind must be schedule, webhook, or chain")
 	}
 	cron, _ := cmd.Flags().GetString("cron")
 	if kind == "schedule" && cron == "" {
@@ -560,6 +563,27 @@ func runAutopilotTriggerAdd(cmd *cobra.Command, args []string) error {
 			return fmt.Errorf("--cron is only valid with --kind schedule")
 		}
 	}
+	upstream, _ := cmd.Flags().GetString("upstream")
+	onStatus, _ := cmd.Flags().GetString("on-status")
+	if kind == "chain" {
+		if upstream == "" {
+			return fmt.Errorf("--upstream is required for --kind chain")
+		}
+		if cron != "" {
+			return fmt.Errorf("--cron is only valid with --kind schedule")
+		}
+		if v, _ := cmd.Flags().GetString("timezone"); v != "" {
+			return fmt.Errorf("--timezone is only valid with --kind schedule")
+		}
+		if onStatus == "" {
+			onStatus = "completed"
+		}
+		if onStatus != "completed" && onStatus != "failed" && onStatus != "any" {
+			return fmt.Errorf("--on-status must be completed, failed, or any")
+		}
+	} else if upstream != "" || onStatus != "" {
+		return fmt.Errorf("--upstream and --on-status are only valid with --kind chain")
+	}
 
 	body := map[string]any{"kind": kind}
 	if kind == "schedule" {
@@ -567,6 +591,10 @@ func runAutopilotTriggerAdd(cmd *cobra.Command, args []string) error {
 		if v, _ := cmd.Flags().GetString("timezone"); v != "" {
 			body["timezone"] = v
 		}
+	}
+	if kind == "chain" {
+		body["upstream_autopilot_id"] = upstream
+		body["chain_on_status"] = onStatus
 	}
 	if v, _ := cmd.Flags().GetString("label"); v != "" {
 		body["label"] = v
@@ -682,8 +710,15 @@ func runAutopilotTriggerUpdate(cmd *cobra.Command, args []string) error {
 		v, _ := cmd.Flags().GetString("label")
 		body["label"] = v
 	}
+	if cmd.Flags().Changed("on-status") {
+		v, _ := cmd.Flags().GetString("on-status")
+		if v != "completed" && v != "failed" && v != "any" {
+			return fmt.Errorf("--on-status must be completed, failed, or any")
+		}
+		body["chain_on_status"] = v
+	}
 	if len(body) == 0 {
-		return fmt.Errorf("no fields to update; use --enabled, --cron, --timezone, or --label")
+		return fmt.Errorf("no fields to update; use --enabled, --cron, --timezone, --label, or --on-status")
 	}
 
 	ctx, cancel := cli.APIContext(context.Background())

--- a/server/internal/handler/autopilot.go
+++ b/server/internal/handler/autopilot.go
@@ -139,6 +139,13 @@ type AutopilotTriggerResponse struct {
 	// a JSON array of {event, actions?} objects — never as a base64 string
 	// (which is what []byte would produce through encoding/json).
 	EventFilters []WebhookEventFilter `json:"event_filters,omitempty"`
+	// UpstreamAutopilotID names the upstream autopilot whose run reaching a
+	// terminal state fires this trigger. Only present for kind=chain.
+	UpstreamAutopilotID *string `json:"upstream_autopilot_id,omitempty"`
+	// ChainOnStatus is the terminal status filter on the chain edge:
+	// 'completed' (success chain), 'failed' (error-handler chain), or 'any'.
+	// Only present for kind=chain.
+	ChainOnStatus *string `json:"chain_on_status,omitempty"`
 }
 
 type AutopilotRunResponse struct {
@@ -243,6 +250,14 @@ func (h *Handler) triggerToResponse(t db.AutopilotTrigger) AutopilotTriggerRespo
 			// is supposed to make this branch unreachable, and the matcher
 			// fails closed if a corrupt row ever slips through.
 		}
+	}
+	if t.Kind == "chain" {
+		resp.UpstreamAutopilotID = uuidToPtr(t.UpstreamAutopilotID)
+		status := t.ChainOnStatus
+		if status == "" {
+			status = "completed"
+		}
+		resp.ChainOnStatus = &status
 	}
 	return resp
 }
@@ -350,6 +365,13 @@ type CreateAutopilotTriggerRequest struct {
 	// EventFilters is an optional list of {event, actions?} scopes. Only
 	// meaningful for webhook triggers. nil/empty means "accept all events".
 	EventFilters []WebhookEventFilter `json:"event_filters,omitempty"`
+	// UpstreamAutopilotID is required for kind=chain: the upstream autopilot
+	// whose run reaching a terminal state fires this downstream trigger.
+	UpstreamAutopilotID *string `json:"upstream_autopilot_id,omitempty"`
+	// ChainOnStatus filters which terminal status of the upstream run fires
+	// the edge. Only meaningful for kind=chain. Defaults to "completed".
+	// Allowed: "completed", "failed", "any".
+	ChainOnStatus *string `json:"chain_on_status,omitempty"`
 }
 
 // SetSigningSecretRequest is the body shape for PUT
@@ -384,6 +406,11 @@ type UpdateAutopilotTriggerRequest struct {
 	// there is no way to tell "field absent from the PATCH body" from "field
 	// present but empty", and the user can never clear filters once set.
 	EventFilters *[]WebhookEventFilter `json:"event_filters,omitempty"`
+	// ChainOnStatus updates the chain edge's terminal-status filter. Only
+	// meaningful for kind=chain. The upstream autopilot itself cannot be
+	// repointed here - delete and recreate the trigger so the new edge goes
+	// through the cycle check.
+	ChainOnStatus *string `json:"chain_on_status,omitempty"`
 }
 
 // ── Handlers ────────────────────────────────────────────────────────────────
@@ -1234,13 +1261,13 @@ func (h *Handler) CreateAutopilotTrigger(w http.ResponseWriter, r *http.Request)
 		writeError(w, http.StatusBadRequest, "kind is required")
 		return
 	}
-	if req.Kind != "schedule" && req.Kind != "webhook" {
+	if req.Kind != "schedule" && req.Kind != "webhook" && req.Kind != "chain" {
 		// "api" kind is deprecated: it was reserved-but-inert (no scheduler,
 		// no ingress route), and the only way to actually fire one was via
 		// the manual /trigger endpoint — which already works regardless of
 		// trigger kind. Surface stragglers with 400 so callers move to
 		// schedule or webhook.
-		writeError(w, http.StatusBadRequest, "kind must be schedule or webhook")
+		writeError(w, http.StatusBadRequest, "kind must be schedule, webhook, or chain")
 		return
 	}
 	if req.Kind == "schedule" && (req.CronExpression == nil || *req.CronExpression == "") {
@@ -1263,6 +1290,31 @@ func (h *Handler) CreateAutopilotTrigger(w http.ResponseWriter, r *http.Request)
 	if err := validateWebhookEventFilters(req.EventFilters); err != nil {
 		writeError(w, http.StatusBadRequest, err.Error())
 		return
+	}
+	// Chain triggers are configured by the upstream relationship, not by a
+	// cron / timezone / webhook_token / event_filter set - reject those fields
+	// loudly so a caller mixing kinds does not silently drop config.
+	if req.Kind == "chain" {
+		if req.CronExpression != nil && *req.CronExpression != "" {
+			writeError(w, http.StatusBadRequest, "cron_expression is not valid for chain triggers")
+			return
+		}
+		if req.Timezone != nil && *req.Timezone != "" {
+			writeError(w, http.StatusBadRequest, "timezone is not valid for chain triggers")
+			return
+		}
+		if req.UpstreamAutopilotID == nil || *req.UpstreamAutopilotID == "" {
+			writeError(w, http.StatusBadRequest, "upstream_autopilot_id is required for chain triggers")
+			return
+		}
+		if req.ChainOnStatus != nil && *req.ChainOnStatus != "" {
+			switch *req.ChainOnStatus {
+			case "completed", "failed", "any":
+			default:
+				writeError(w, http.StatusBadRequest, "chain_on_status must be completed, failed, or any")
+				return
+			}
+		}
 	}
 	// Provider only applies to webhook triggers and the value space is
 	// closed — reject unknowns early so a typo on create doesn't quietly
@@ -1336,7 +1388,49 @@ func (h *Handler) CreateAutopilotTrigger(w http.ResponseWriter, r *http.Request)
 		return
 	}
 
-	// Schedule create: write the trigger and republish the rule version atomically.
+	// Schedule / chain create: write the trigger and republish the rule version atomically.
+	var (
+		chainUpstreamID pgtype.UUID
+		chainOnStatus   pgtype.Text
+	)
+	if req.Kind == "chain" {
+		chainUpstreamID = parseUUID(*req.UpstreamAutopilotID)
+		if !chainUpstreamID.Valid {
+			writeError(w, http.StatusBadRequest, "upstream_autopilot_id is not a valid UUID")
+			return
+		}
+		if chainUpstreamID == ap.ID {
+			writeError(w, http.StatusBadRequest, "a chain trigger cannot point at its own autopilot")
+			return
+		}
+		// The upstream must live in the same workspace - a cross-workspace
+		// edge would let one tenant's runs fire another tenant's autopilots.
+		wsUUID := parseUUID(workspaceID)
+		if _, err := h.Queries.GetAutopilotInWorkspace(r.Context(), db.GetAutopilotInWorkspaceParams{
+			ID:          chainUpstreamID,
+			WorkspaceID: wsUUID,
+		}); err != nil {
+			writeError(w, http.StatusBadRequest, "upstream_autopilot_id not found in this workspace")
+			return
+		}
+		// Config-time cycle guard: adding upstream -> downstream closes a
+		// cycle iff downstream can already reach upstream through existing
+		// chain edges. The read is not locked; a concurrent chain create that
+		// individually passes DFS but together forms a cycle is caught at
+		// runtime by the MaxChainDepth backstop (autopilot_chain.go).
+		cycle, err := service.DetectChainCycle(r.Context(), h.Queries, wsUUID, ap.ID, chainUpstreamID)
+		if err != nil {
+			writeError(w, http.StatusInternalServerError, "failed to validate chain trigger")
+			return
+		}
+		if cycle {
+			writeError(w, http.StatusBadRequest, "chain trigger would create a cycle")
+			return
+		}
+		if req.ChainOnStatus != nil && *req.ChainOnStatus != "" {
+			chainOnStatus = pgtype.Text{String: *req.ChainOnStatus, Valid: true}
+		}
+	}
 	tx, err := h.TxStarter.Begin(r.Context())
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, "failed to create trigger")
@@ -1357,8 +1451,10 @@ func (h *Handler) CreateAutopilotTrigger(w http.ResponseWriter, r *http.Request)
 		// Seed the responsible publisher = creator; a later substantive edit re-stamps
 		// it to the editor so runs attribute to whoever last shaped this trigger
 		// (source=trigger_owner, MUL-4302).
-		PublishedByType: pgtype.Text{String: "member", Valid: publisherID.Valid},
-		PublishedByID:   publisherID,
+		PublishedByType:     pgtype.Text{String: "member", Valid: publisherID.Valid},
+		PublishedByID:       publisherID,
+		UpstreamAutopilotID: chainUpstreamID,
+		ChainOnStatus:       chainOnStatus,
 	})
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, "failed to create trigger")
@@ -1570,6 +1666,21 @@ func (h *Handler) UpdateAutopilotTrigger(w http.ResponseWriter, r *http.Request)
 			return
 		}
 	}
+	// chain_on_status is only meaningful on a chain trigger; the upstream
+	// autopilot itself cannot be repointed here (delete + recreate forces a
+	// fresh cycle check).
+	if req.ChainOnStatus != nil && prev.Kind != "chain" {
+		writeError(w, http.StatusBadRequest, "chain_on_status is only valid for chain triggers")
+		return
+	}
+	if req.ChainOnStatus != nil && *req.ChainOnStatus != "" {
+		switch *req.ChainOnStatus {
+		case "completed", "failed", "any":
+		default:
+			writeError(w, http.StatusBadRequest, "chain_on_status must be completed, failed, or any")
+			return
+		}
+	}
 
 	params := db.UpdateAutopilotTriggerParams{
 		ID:             prev.ID,
@@ -1577,6 +1688,7 @@ func (h *Handler) UpdateAutopilotTrigger(w http.ResponseWriter, r *http.Request)
 		Timezone:       prev.Timezone,
 		NextRunAt:      prev.NextRunAt,
 		Label:          prev.Label,
+		ChainOnStatus:  pgtype.Text{String: prev.ChainOnStatus, Valid: prev.ChainOnStatus != ""},
 	}
 	if req.Enabled != nil {
 		params.Enabled = pgtype.Bool{Bool: *req.Enabled, Valid: true}
@@ -1595,6 +1707,9 @@ func (h *Handler) UpdateAutopilotTrigger(w http.ResponseWriter, r *http.Request)
 	}
 	if req.Label != nil {
 		params.Label = pgtype.Text{String: *req.Label, Valid: true}
+	}
+	if req.ChainOnStatus != nil && *req.ChainOnStatus != "" {
+		params.ChainOnStatus = pgtype.Text{String: *req.ChainOnStatus, Valid: true}
 	}
 	// Tri-state PATCH for event_filters. A nil pointer (field omitted or
 	// JSON null) leaves the existing row untouched — params.EventFilters
@@ -1669,6 +1784,7 @@ func (h *Handler) UpdateAutopilotTrigger(w http.ResponseWriter, r *http.Request)
 	triggerSubstantiveChange := prev.Enabled != trigger.Enabled ||
 		prev.CronExpression != trigger.CronExpression ||
 		prev.Timezone != trigger.Timezone ||
+		prev.ChainOnStatus != trigger.ChainOnStatus ||
 		!bytes.Equal(prev.EventFilters, trigger.EventFilters)
 	if triggerSubstantiveChange {
 		if err := h.recordAutopilotRuleVersion(r.Context(), qtx, ap, "member", parseUUID(userID)); err != nil {

--- a/server/internal/handler/autopilot_webhook_handler_test.go
+++ b/server/internal/handler/autopilot_webhook_handler_test.go
@@ -984,8 +984,172 @@ func TestCreateAutopilotTrigger_RejectsAPIKind(t *testing.T) {
 	if w.Code != http.StatusBadRequest {
 		t.Fatalf("expected 400 on kind=api, got %d body=%s", w.Code, w.Body.String())
 	}
-	if !strings.Contains(w.Body.String(), "schedule or webhook") {
+	if !strings.Contains(w.Body.String(), "schedule, webhook, or chain") {
 		t.Fatalf("expected message to name allowed kinds, body=%s", w.Body.String())
+	}
+}
+
+// TestCreateAutopilotTrigger_AcceptsChainWithUpstream verifies a kind=chain
+// trigger with a same-workspace upstream and an explicit chain_on_status is
+// created (201) and the response echoes the chain config.
+func TestCreateAutopilotTrigger_AcceptsChainWithUpstream(t *testing.T) {
+	agentID := createWebhookTestAgent(t, "ChainAccept Agent")
+	upstreamAP := createWebhookTestAutopilot(t, agentID, "active", "run_only")
+	downstreamAP := createWebhookTestAutopilot(t, agentID, "active", "run_only")
+
+	w := httptest.NewRecorder()
+	req := newRequest("POST", "/api/autopilots/"+downstreamAP+"/triggers", map[string]any{
+		"kind":                  "chain",
+		"upstream_autopilot_id": upstreamAP,
+		"chain_on_status":       "failed",
+	})
+	req = withURLParam(req, "id", downstreamAP)
+	testHandler.CreateAutopilotTrigger(w, req)
+	if w.Code != http.StatusCreated {
+		t.Fatalf("expected 201 on chain create, got %d body=%s", w.Code, w.Body.String())
+	}
+	var resp AutopilotTriggerResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if resp.Kind != "chain" {
+		t.Errorf("kind = %q, want chain", resp.Kind)
+	}
+	if resp.UpstreamAutopilotID == nil || *resp.UpstreamAutopilotID != upstreamAP {
+		got := "(nil)"
+		if resp.UpstreamAutopilotID != nil {
+			got = *resp.UpstreamAutopilotID
+		}
+		t.Errorf("upstream_autopilot_id = %s, want %s", got, upstreamAP)
+	}
+	if resp.ChainOnStatus == nil || *resp.ChainOnStatus != "failed" {
+		got := "(nil)"
+		if resp.ChainOnStatus != nil {
+			got = *resp.ChainOnStatus
+		}
+		t.Errorf("chain_on_status = %s, want failed", got)
+	}
+}
+
+// TestCreateAutopilotTrigger_RejectsChainWithoutUpstream verifies a chain
+// trigger missing the upstream_autopilot_id is rejected with 400.
+func TestCreateAutopilotTrigger_RejectsChainWithoutUpstream(t *testing.T) {
+	agentID := createWebhookTestAgent(t, "ChainNoUp Agent")
+	apID := createWebhookTestAutopilot(t, agentID, "active", "run_only")
+
+	w := httptest.NewRecorder()
+	req := newRequest("POST", "/api/autopilots/"+apID+"/triggers", map[string]any{
+		"kind": "chain",
+	})
+	req = withURLParam(req, "id", apID)
+	testHandler.CreateAutopilotTrigger(w, req)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 on chain without upstream, got %d body=%s", w.Code, w.Body.String())
+	}
+	if !strings.Contains(w.Body.String(), "upstream_autopilot_id is required") {
+		t.Fatalf("expected upstream-required message, body=%s", w.Body.String())
+	}
+}
+
+// TestCreateAutopilotTrigger_RejectsChainSelfEdge verifies a chain trigger that
+// names its own autopilot as upstream is rejected (self-cycle).
+func TestCreateAutopilotTrigger_RejectsChainSelfEdge(t *testing.T) {
+	agentID := createWebhookTestAgent(t, "ChainSelf Agent")
+	apID := createWebhookTestAutopilot(t, agentID, "active", "run_only")
+
+	w := httptest.NewRecorder()
+	req := newRequest("POST", "/api/autopilots/"+apID+"/triggers", map[string]any{
+		"kind":                  "chain",
+		"upstream_autopilot_id": apID,
+	})
+	req = withURLParam(req, "id", apID)
+	testHandler.CreateAutopilotTrigger(w, req)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 on self-edge, got %d body=%s", w.Code, w.Body.String())
+	}
+	if !strings.Contains(w.Body.String(), "cannot point at its own autopilot") {
+		t.Fatalf("expected self-edge message, body=%s", w.Body.String())
+	}
+}
+
+// TestCreateAutopilotTrigger_RejectsChainCycle verifies the config-time DFS
+// guard end-to-end through the handler: after seeding edge A->B, creating the
+// closing edge B->A (proposed upstream=B, downstream=A) is rejected with 400.
+func TestCreateAutopilotTrigger_RejectsChainCycle(t *testing.T) {
+	agentID := createWebhookTestAgent(t, "ChainCycle Agent")
+	apA := createWebhookTestAutopilot(t, agentID, "active", "run_only")
+	apB := createWebhookTestAutopilot(t, agentID, "active", "run_only")
+
+	// Seed edge A->B: trigger on B naming A upstream.
+	if _, err := testPool.Exec(context.Background(), `
+		INSERT INTO autopilot_trigger (autopilot_id, kind, enabled, upstream_autopilot_id, chain_on_status)
+		VALUES ($1, 'chain', true, $2, 'completed')`, apB, apA); err != nil {
+		t.Fatalf("seed A->B edge: %v", err)
+	}
+
+	// Propose closing edge B->A: trigger on A naming B upstream. A already
+	// reaches B (A->B), so B->A closes the cycle.
+	w := httptest.NewRecorder()
+	req := newRequest("POST", "/api/autopilots/"+apA+"/triggers", map[string]any{
+		"kind":                  "chain",
+		"upstream_autopilot_id": apB,
+	})
+	req = withURLParam(req, "id", apA)
+	testHandler.CreateAutopilotTrigger(w, req)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 on cycle, got %d body=%s", w.Code, w.Body.String())
+	}
+	if !strings.Contains(w.Body.String(), "cycle") {
+		t.Fatalf("expected cycle message, body=%s", w.Body.String())
+	}
+}
+
+// TestUpdateAutopilotTrigger_UpdatesChainOnStatus verifies the PATCH path
+// updates a chain trigger's chain_on_status and echoes it back.
+func TestUpdateAutopilotTrigger_UpdatesChainOnStatus(t *testing.T) {
+	agentID := createWebhookTestAgent(t, "ChainUpd Agent")
+	upstreamAP := createWebhookTestAutopilot(t, agentID, "active", "run_only")
+	downstreamAP := createWebhookTestAutopilot(t, agentID, "active", "run_only")
+
+	// Create a chain trigger (default chain_on_status=completed).
+	create := httptest.NewRecorder()
+	createReq := newRequest("POST", "/api/autopilots/"+downstreamAP+"/triggers", map[string]any{
+		"kind":                  "chain",
+		"upstream_autopilot_id": upstreamAP,
+	})
+	createReq = withURLParam(createReq, "id", downstreamAP)
+	testHandler.CreateAutopilotTrigger(create, createReq)
+	if create.Code != http.StatusCreated {
+		t.Fatalf("create chain trigger: expected 201, got %d body=%s", create.Code, create.Body.String())
+	}
+	var created AutopilotTriggerResponse
+	if err := json.Unmarshal(create.Body.Bytes(), &created); err != nil {
+		t.Fatalf("decode created: %v", err)
+	}
+	if created.ChainOnStatus == nil || *created.ChainOnStatus != "completed" {
+		t.Fatalf("expected default chain_on_status=completed, got %v", created.ChainOnStatus)
+	}
+
+	// Update chain_on_status to 'any'.
+	w := httptest.NewRecorder()
+	req := newRequest("PATCH", "/api/autopilots/"+downstreamAP+"/triggers/"+created.ID, map[string]any{
+		"chain_on_status": "any",
+	})
+	req = withURLParams(req, "id", downstreamAP, "triggerId", created.ID)
+	testHandler.UpdateAutopilotTrigger(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200 on update, got %d body=%s", w.Code, w.Body.String())
+	}
+	var updated AutopilotTriggerResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &updated); err != nil {
+		t.Fatalf("decode updated: %v", err)
+	}
+	if updated.ChainOnStatus == nil || *updated.ChainOnStatus != "any" {
+		got := "(nil)"
+		if updated.ChainOnStatus != nil {
+			got = *updated.ChainOnStatus
+		}
+		t.Errorf("chain_on_status = %s, want any", got)
 	}
 }
 

--- a/server/internal/service/autopilot.go
+++ b/server/internal/service/autopilot.go
@@ -983,6 +983,7 @@ func (s *AutopilotService) SyncRunFromIssue(ctx context.Context, issue db.Issue)
 		}
 		s.captureAutopilotRunCompleted(autopilot, updatedRun)
 		s.publishRunDone(wsID, updatedRun, "completed")
+		s.dispatchChainSuccessors(ctx, updatedRun, "completed")
 	case "cancelled", "blocked":
 		reason := "issue " + issue.Status
 		updatedRun, err := s.Queries.UpdateAutopilotRunFailed(ctx, db.UpdateAutopilotRunFailedParams{
@@ -995,6 +996,7 @@ func (s *AutopilotService) SyncRunFromIssue(ctx context.Context, issue db.Issue)
 		}
 		s.captureAutopilotRunFailed(autopilot, updatedRun, updatedRun.Source, reason)
 		s.publishRunDone(wsID, updatedRun, "failed")
+		s.dispatchChainSuccessors(ctx, updatedRun, "failed")
 	}
 }
 
@@ -1027,6 +1029,7 @@ func (s *AutopilotService) SyncRunFromTask(ctx context.Context, task db.AgentTas
 		}
 		s.captureAutopilotRunCompleted(autopilot, updatedRun)
 		s.publishRunDone(wsID, updatedRun, "completed")
+		s.dispatchChainSuccessors(ctx, updatedRun, "completed")
 	case "failed", "cancelled":
 		reason := "task " + task.Status
 		if task.Error.Valid {
@@ -1042,6 +1045,7 @@ func (s *AutopilotService) SyncRunFromTask(ctx context.Context, task db.AgentTas
 		}
 		s.captureAutopilotRunFailed(autopilot, updatedRun, updatedRun.Source, reason)
 		s.publishRunDone(wsID, updatedRun, "failed")
+		s.dispatchChainSuccessors(ctx, updatedRun, "failed")
 	}
 }
 
@@ -1106,6 +1110,7 @@ func (s *AutopilotService) SyncRunFromLinkedIssueTask(ctx context.Context, task 
 	}
 	s.captureAutopilotRunFailed(autopilot, updatedRun, updatedRun.Source, reason)
 	s.publishRunDone(util.UUIDToString(autopilot.WorkspaceID), updatedRun, "failed")
+	s.dispatchChainSuccessors(ctx, updatedRun, "failed")
 }
 
 func taskFailureReasonForAutopilotRun(task db.AgentTaskQueue) string {

--- a/server/internal/service/autopilot_chain.go
+++ b/server/internal/service/autopilot_chain.go
@@ -1,0 +1,418 @@
+package service
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log/slog"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
+	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/multica-ai/multica/server/internal/util"
+	db "github.com/multica-ai/multica/server/pkg/db/generated"
+)
+
+// MaxChainDepth is the runtime backstop against a cycle that slipped past the
+// config-time DFS check (concurrent chain-trigger creation) or a pathologically
+// deep legitimate chain. Each fan-out increments the downstream run's chain_depth;
+// when it would exceed this cap the successor is recorded as a `skipped` run with
+// failure_reason=chain_depth_exceeded instead of being dispatched. Skipped runs
+// do not themselves fire chain edges, so the recursion stops here.
+const MaxChainDepth = 16
+
+// chainEdgeStatuses returns the chain_on_status values that match an upstream
+// run's terminal status: a 'completed' upstream fires 'completed'+'any' edges,
+// a 'failed' upstream fires 'failed'+'any' edges. Anything else (e.g. a stray
+// 'skipped') returns nil so the fan-out query matches nothing.
+func chainEdgeStatuses(terminalStatus string) []string {
+	switch terminalStatus {
+	case "completed":
+		return []string{"completed", "any"}
+	case "failed":
+		return []string{"failed", "any"}
+	default:
+		return nil
+	}
+}
+
+// chainUpstreamStatuses are the terminal run statuses that fan out to chain
+// successors. A `skipped` run is deliberately excluded: it is not an outcome
+// (the work was never attempted / a concurrency cap held it back), so it must
+// not fire a 'failed' edge and must not be treated as success either.
+var chainUpstreamStatuses = map[string]bool{"completed": true, "failed": true}
+
+// dispatchChainSuccessors fans out one downstream run per enabled chain
+// trigger whose upstream is the given run's autopilot and whose chain_on_status
+// matches the run's terminal status. It is the hook called at the terminal
+// state transition (right after publishRunDone) - NOT inside publishRunDone,
+// to keep that function single-responsibility.
+//
+// A `skipped` terminal status is a no-op (see chainUpstreamStatuses). Fan-out is
+// synchronous for now (fan-out counts are small); a threshold-based move to the
+// webhook-delivery worker pattern is a documented future option. Failures
+// dispatching a single successor are logged and do not abort the remaining
+// fan-out - siblings are isolated, by design (A -> {B, C}: B's dispatch error
+// must not starve C).
+func (s *AutopilotService) dispatchChainSuccessors(ctx context.Context, upstreamRun db.AutopilotRun, terminalStatus string) {
+	if !chainUpstreamStatuses[terminalStatus] {
+		return
+	}
+	if !upstreamRun.AutopilotID.Valid {
+		return
+	}
+	if upstreamRun.ChainDepth >= MaxChainDepth {
+		// This run is already at the depth cap - its successors would exceed it.
+		// The cap is normally enforced in DispatchAutopilotForChain (which
+		// records the skipped successor); reaching it here means this run was
+		// created outside the chain path but somehow carries a maxed depth, so
+		// just stop the fan-out defensively.
+		slog.Warn("autopilot chain fan-out aborted: upstream run at depth cap",
+			"upstream_run_id", util.UUIDToString(upstreamRun.ID),
+			"autopilot_id", util.UUIDToString(upstreamRun.AutopilotID),
+			"chain_depth", upstreamRun.ChainDepth,
+		)
+		return
+	}
+
+	successors, err := s.Queries.ListEnabledChainSuccessors(ctx, db.ListEnabledChainSuccessorsParams{
+		UpstreamAutopilotID: upstreamRun.AutopilotID,
+		AllowedStatuses:     chainEdgeStatuses(terminalStatus),
+	})
+	if err != nil {
+		slog.Warn("autopilot chain fan-out: list successors failed",
+			"upstream_run_id", util.UUIDToString(upstreamRun.ID),
+			"autopilot_id", util.UUIDToString(upstreamRun.AutopilotID),
+			"terminal_status", terminalStatus,
+			"error", err,
+		)
+		return
+	}
+	if len(successors) == 0 {
+		return
+	}
+
+	// Cache downstream autopilots so a fan-out to N successors on the same
+	// downstream (rare but possible) loads it once.
+	loaded := make(map[string]db.Autopilot, len(successors))
+	for _, trig := range successors {
+		downstream, ok := loaded[util.UUIDToString(trig.AutopilotID)]
+		if !ok {
+			downstream, err = s.Queries.GetAutopilot(ctx, trig.AutopilotID)
+			if err != nil {
+				slog.Warn("autopilot chain fan-out: load downstream autopilot failed",
+					"upstream_run_id", util.UUIDToString(upstreamRun.ID),
+					"downstream_autopilot_id", util.UUIDToString(trig.AutopilotID),
+					"chain_trigger_id", util.UUIDToString(trig.ID),
+					"error", err,
+				)
+				continue
+			}
+			loaded[util.UUIDToString(trig.AutopilotID)] = downstream
+		}
+		payload := buildChainPayload(upstreamRun, downstream, terminalStatus, trig.ChainOnStatus)
+		if _, err := s.DispatchAutopilotForChain(ctx, upstreamRun, downstream, trig, payload); err != nil {
+			slog.Warn("autopilot chain fan-out: dispatch successor failed",
+				"upstream_run_id", util.UUIDToString(upstreamRun.ID),
+				"downstream_autopilot_id", util.UUIDToString(downstream.ID),
+				"chain_trigger_id", util.UUIDToString(trig.ID),
+				"error", err,
+			)
+			continue
+		}
+	}
+}
+
+// DispatchAutopilotForChain is the per-successor dispatch entry point fired by
+// dispatchChainSuccessors. It mirrors the webhook-delivery admission path:
+// admission gate -> idempotent run creation (anchored on
+// (chain_upstream_run_id, trigger_id)) -> downstream side effect.
+//
+// Depth cap: the downstream run's chain_depth is upstream_run.chain_depth + 1.
+// If that exceeds MaxChainDepth the successor is recorded as a `skipped` run
+// with failure_reason=chain_depth_exceeded and NO side effect / NO further
+// fan-out - the backstop stops the recursion cleanly without phantom failures
+// cascading down a 'failed' edge.
+//
+// The downstream cap (max_concurrent_runs from Stage 2, not yet on main) applies
+// naturally because this entry point funnels through the same dispatchAutopilotRun
+// path as schedule / webhook / api. When Stage 2 lands, a capped dispatch records
+// `skipped`(reason=concurrency_cap) and - per the chain semantics - that skipped
+// run fires no further chain edges.
+func (s *AutopilotService) DispatchAutopilotForChain(
+	ctx context.Context,
+	upstreamRun db.AutopilotRun,
+	downstreamAP db.Autopilot,
+	chainTrigger db.AutopilotTrigger,
+	payload []byte,
+) (*db.AutopilotRun, error) {
+	if chainTrigger.Kind != "chain" || !chainTrigger.UpstreamAutopilotID.Valid {
+		return nil, fmt.Errorf("chain dispatch: trigger %s is not a chain trigger", util.UUIDToString(chainTrigger.ID))
+	}
+	if !upstreamRun.ID.Valid {
+		return nil, fmt.Errorf("chain dispatch: upstream run id is required")
+	}
+
+	depth := upstreamRun.ChainDepth + 1
+	if depth > MaxChainDepth {
+		return s.recordChainDepthExceededRun(ctx, downstreamAP, chainTrigger, upstreamRun, depth, payload)
+	}
+
+	// Idempotency fast path: a replayed terminal event (SyncRunFrom* racing
+	// itself, event redelivery) reuses the run already anchored on
+	// (upstream_run, chain trigger) instead of creating a second downstream
+	// run. The partial unique index (migration 215) is the hard guard.
+	if existing, err := s.Queries.GetAutopilotRunByChainUpstream(ctx, db.GetAutopilotRunByChainUpstreamParams{
+		ChainUpstreamRunID: upstreamRun.ID,
+		TriggerID:          chainTrigger.ID,
+	}); err == nil {
+		return &existing, nil
+	} else if !errors.Is(err, pgx.ErrNoRows) {
+		return nil, fmt.Errorf("chain dispatch: lookup existing run: %w", err)
+	}
+
+	// Admission gate (same as schedule / webhook / api): an offline assignee
+	// runtime records a `skipped` run instead of enqueuing a doomed task.
+	if reason, _, skip := s.shouldSkipDispatch(ctx, downstreamAP, pgtype.UUID{}); skip {
+		return s.recordChainSkippedRun(ctx, downstreamAP, chainTrigger, upstreamRun, depth, payload, reason)
+	}
+
+	initialStatus := "issue_created"
+	if downstreamAP.ExecutionMode == "run_only" {
+		initialStatus = "running"
+	}
+	run, err := s.Queries.CreateAutopilotRun(ctx, db.CreateAutopilotRunParams{
+		AutopilotID:        downstreamAP.ID,
+		TriggerID:          chainTrigger.ID,
+		Source:             "chain",
+		Status:             initialStatus,
+		TriggerPayload:     payload,
+		SquadID:            autopilotSquadAttribution(downstreamAP),
+		ChainDepth:         pgtype.Int4{Int32: int32(depth), Valid: true},
+		ChainUpstreamRunID: upstreamRun.ID,
+	})
+	if err != nil {
+		// Race: another caller won the idempotent-insert race between our
+		// lookup and our INSERT. Reuse the winner.
+		if existing, ok := s.recoverConcurrentChainAdmission(ctx, upstreamRun.ID, chainTrigger.ID, err); ok {
+			return existing, nil
+		}
+		return nil, fmt.Errorf("chain dispatch: create run: %w", err)
+	}
+	s.captureAutopilotRunStarted(downstreamAP, run, "chain")
+
+	// Drive the downstream side effect (create_issue / run_only). dispatchAutopilotRun
+	// owns the post-admission errDispatchSkipped -> skipped rewrite and the
+	// run-start event publish, mirroring every other dispatch entry point.
+	finalRun, _, err := s.dispatchAutopilotRun(ctx, downstreamAP, chainTrigger.ID, "chain", &run, pgtype.UUID{})
+	if err != nil {
+		slog.Warn("autopilot chain dispatch: downstream side effect failed",
+			"upstream_run_id", util.UUIDToString(upstreamRun.ID),
+			"downstream_run_id", util.UUIDToString(run.ID),
+			"downstream_autopilot_id", util.UUIDToString(downstreamAP.ID),
+			"error", err,
+		)
+	}
+	return finalRun, nil
+}
+
+// recoverConcurrentChainAdmission mirrors recoverConcurrentWebhookAdmission: a
+// 23505 (unique_violation) on CreateAutopilotRun means another replica / event
+// replay won the idempotent-insert race and already created the downstream run
+// for this (upstream run, chain trigger) pair. Reuse it.
+func (s *AutopilotService) recoverConcurrentChainAdmission(ctx context.Context, upstreamRunID, chainTriggerID pgtype.UUID, cause error) (*db.AutopilotRun, bool) {
+	var pgErr *pgconn.PgError
+	if !errors.As(cause, &pgErr) || pgErr.Code != "23505" {
+		return nil, false
+	}
+	existing, err := s.Queries.GetAutopilotRunByChainUpstream(ctx, db.GetAutopilotRunByChainUpstreamParams{
+		ChainUpstreamRunID: upstreamRunID,
+		TriggerID:          chainTriggerID,
+	})
+	if err == nil {
+		return &existing, true
+	}
+	return nil, false
+}
+
+// recordChainSkippedRun writes a `skipped` chain run when the downstream
+// admission gate fails (offline assignee runtime, archived agent, etc.). The
+// run is anchored on (chain_upstream_run_id, trigger_id) so a replayed terminal
+// event reuses it instead of stacking duplicate skipped runs. Skipped runs do
+// not fire chain edges, so this never cascades.
+func (s *AutopilotService) recordChainSkippedRun(
+	ctx context.Context,
+	downstreamAP db.Autopilot,
+	chainTrigger db.AutopilotTrigger,
+	upstreamRun db.AutopilotRun,
+	depth int32,
+	payload []byte,
+	reason string,
+) (*db.AutopilotRun, error) {
+	run, err := s.Queries.CreateAutopilotRun(ctx, db.CreateAutopilotRunParams{
+		AutopilotID:        downstreamAP.ID,
+		TriggerID:          chainTrigger.ID,
+		Source:             "chain",
+		Status:             "skipped",
+		TriggerPayload:     payload,
+		SquadID:            autopilotSquadAttribution(downstreamAP),
+		ChainDepth:         pgtype.Int4{Int32: depth, Valid: true},
+		ChainUpstreamRunID: upstreamRun.ID,
+	})
+	if err != nil {
+		if existing, ok := s.recoverConcurrentChainAdmission(ctx, upstreamRun.ID, chainTrigger.ID, err); ok {
+			return existing, nil
+		}
+		return nil, fmt.Errorf("chain dispatch: create skipped run: %w", err)
+	}
+	updated, uerr := s.Queries.UpdateAutopilotRunSkipped(ctx, db.UpdateAutopilotRunSkippedParams{
+		ID:            run.ID,
+		FailureReason: pgtype.Text{String: reason, Valid: true},
+	})
+	if uerr == nil {
+		run = updated
+	}
+	slog.Info("autopilot chain dispatch skipped at admission",
+		"upstream_run_id", util.UUIDToString(upstreamRun.ID),
+		"downstream_autopilot_id", util.UUIDToString(downstreamAP.ID),
+		"run_id", util.UUIDToString(run.ID),
+		"reason", reason,
+	)
+	s.captureAutopilotRunStarted(downstreamAP, run, "chain")
+	s.publishRunDone(util.UUIDToString(downstreamAP.WorkspaceID), run, "skipped")
+	return &run, nil
+}
+
+// recordChainDepthExceededRun is the depth-cap backstop: the downstream would
+// land at chain_depth > MaxChainDepth, so instead of dispatching its side
+// effect we record a single `skipped` run carrying failure_reason=
+// chain_depth_exceeded. Skipped (not failed): it must not fire any
+// chain_on_status='failed' edge and must not trip the failure-rate auto-pause.
+func (s *AutopilotService) recordChainDepthExceededRun(
+	ctx context.Context,
+	downstreamAP db.Autopilot,
+	chainTrigger db.AutopilotTrigger,
+	upstreamRun db.AutopilotRun,
+	depth int32,
+	payload []byte,
+) (*db.AutopilotRun, error) {
+	run, err := s.Queries.CreateAutopilotRun(ctx, db.CreateAutopilotRunParams{
+		AutopilotID:        downstreamAP.ID,
+		TriggerID:          chainTrigger.ID,
+		Source:             "chain",
+		Status:             "skipped",
+		TriggerPayload:     payload,
+		SquadID:            autopilotSquadAttribution(downstreamAP),
+		ChainDepth:         pgtype.Int4{Int32: depth, Valid: true},
+		ChainUpstreamRunID: upstreamRun.ID,
+	})
+	if err != nil {
+		if existing, ok := s.recoverConcurrentChainAdmission(ctx, upstreamRun.ID, chainTrigger.ID, err); ok {
+			return existing, nil
+		}
+		return nil, fmt.Errorf("chain dispatch: create depth-exceeded run: %w", err)
+	}
+	updated, uerr := s.Queries.UpdateAutopilotRunSkipped(ctx, db.UpdateAutopilotRunSkippedParams{
+		ID:            run.ID,
+		FailureReason: pgtype.Text{String: "chain_depth_exceeded", Valid: true},
+	})
+	if uerr == nil {
+		run = updated
+	}
+	slog.Warn("autopilot chain dispatch aborted: chain depth exceeded",
+		"upstream_run_id", util.UUIDToString(upstreamRun.ID),
+		"downstream_autopilot_id", util.UUIDToString(downstreamAP.ID),
+		"run_id", util.UUIDToString(run.ID),
+		"chain_depth", depth,
+	)
+	s.captureAutopilotRunStarted(downstreamAP, run, "chain")
+	s.publishRunDone(util.UUIDToString(downstreamAP.WorkspaceID), run, "skipped")
+	return &run, nil
+}
+
+// chainRunPayload is the structured trigger_payload stored on a chain-fired
+// downstream run. It carries enough upstream context for observability and for
+// a future template-interpolation hook (out of scope: parameterized manual run,
+// gap #4). chain_depth lives on the column, not here.
+type chainRunPayload struct {
+	Chain struct {
+		UpstreamRunID       string `json:"upstream_run_id"`
+		UpstreamAutopilotID string `json:"upstream_autopilot_id"`
+		UpstreamStatus      string `json:"upstream_status"`
+		ChainOnStatus       string `json:"chain_on_status"`
+	} `json:"chain"`
+	UpstreamResult json.RawMessage `json:"upstream_result,omitempty"`
+}
+
+func buildChainPayload(upstreamRun db.AutopilotRun, downstreamAP db.Autopilot, terminalStatus, chainOnStatus string) []byte {
+	p := chainRunPayload{}
+	p.Chain.UpstreamRunID = util.UUIDToString(upstreamRun.ID)
+	p.Chain.UpstreamAutopilotID = util.UUIDToString(upstreamRun.AutopilotID)
+	p.Chain.UpstreamStatus = terminalStatus
+	p.Chain.ChainOnStatus = chainOnStatus
+	if len(upstreamRun.Result) > 0 {
+		p.UpstreamResult = json.RawMessage(upstreamRun.Result)
+	}
+	b, err := json.Marshal(p)
+	if err != nil {
+		return nil
+	}
+	return b
+}
+
+// DetectChainCycle is the config-time cycle guard. proposedUpstream ->
+// proposedDownstream is the chain edge about to be created (the trigger lives
+// on proposedDownstream, naming proposedUpstream as its upstream). A cycle
+// exists iff proposedDownstream can already reach proposedUpstream through the
+// existing chain edges in the workspace - because then adding the edge closes
+// the loop (proposedUpstream -> proposedDownstream -> ... -> proposedUpstream).
+// A self-edge (proposedUpstream == proposedDownstream) is also a cycle.
+//
+// The walk is in Go (not SQL) because depth-bounded recursive CTEs are awkward
+// to bound correctly and the per-workspace chain graph is small. q is the
+// caller's *db.Queries (tx-scoped where the caller wants the cycle check to
+// see in-flight rows from the same transaction).
+//
+// This is the PRIMARY cycle defense; the runtime depth cap (MaxChainDepth) is
+// the documented backstop for the concurrent-create race where two edges that
+// individually pass DFS together form a cycle.
+func DetectChainCycle(ctx context.Context, q *db.Queries, workspaceID, proposedDownstream, proposedUpstream pgtype.UUID) (bool, error) {
+	if !workspaceID.Valid || !proposedDownstream.Valid || !proposedUpstream.Valid {
+		return false, nil
+	}
+	if proposedDownstream == proposedUpstream {
+		return true, nil
+	}
+	edges, err := q.ListChainTriggersInWorkspace(ctx, workspaceID)
+	if err != nil {
+		return false, fmt.Errorf("list chain triggers for cycle check: %w", err)
+	}
+	// adjacency: upstream -> [downstreams]. An edge "U fires D" is stored as
+	// trigger(upstream_autopilot_id=U, autopilot_id=D), so from U we can
+	// reach D.
+	adj := make(map[string][]string, len(edges))
+	for _, e := range edges {
+		from := util.UUIDToString(e.UpstreamAutopilotID)
+		to := util.UUIDToString(e.AutopilotID)
+		adj[from] = append(adj[from], to)
+	}
+	target := util.UUIDToString(proposedUpstream)
+	start := util.UUIDToString(proposedDownstream)
+	visited := map[string]bool{start: true}
+	stack := []string{start}
+	for len(stack) > 0 {
+		cur := stack[len(stack)-1]
+		stack = stack[:len(stack)-1]
+		for _, next := range adj[cur] {
+			if next == target {
+				return true, nil
+			}
+			if !visited[next] {
+				visited[next] = true
+				stack = append(stack, next)
+			}
+		}
+	}
+	return false, nil
+}

--- a/server/internal/service/autopilot_chain_test.go
+++ b/server/internal/service/autopilot_chain_test.go
@@ -1,0 +1,355 @@
+package service
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
+	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/multica-ai/multica/server/internal/util"
+	db "github.com/multica-ai/multica/server/pkg/db/generated"
+)
+
+// TestChainEdgeStatuses pins the per-edge status filter: a 'completed'
+// upstream fires 'completed'+'any' edges, a 'failed' upstream fires
+// 'failed'+'any' edges, and a non-terminal / non-outcome status (e.g.
+// 'skipped', 'running') fans out nothing. This is the observable core of the
+// failure-semantics config (chain_on_status) and the skipped-does-not-trigger
+// rule.
+func TestChainEdgeStatuses(t *testing.T) {
+	cases := map[string][]string{
+		"completed": {"completed", "any"},
+		"failed":    {"failed", "any"},
+		"skipped":   nil,
+		"running":   nil,
+		"pending":   nil,
+		"":          nil,
+	}
+	for status, want := range cases {
+		got := chainEdgeStatuses(status)
+		if len(got) != len(want) {
+			t.Errorf("chainEdgeStatuses(%q) = %v, want %v", status, got, want)
+			continue
+		}
+		for i := range got {
+			if got[i] != want[i] {
+				t.Errorf("chainEdgeStatuses(%q)[%d] = %q, want %q", status, i, got[i], want[i])
+			}
+		}
+	}
+}
+
+// TestChainUpstreamStatusesGate pins the terminal-status gate that
+// dispatchChainSuccessors opens on: completed and failed fan out, skipped and
+// anything else do not. A 'skipped' run is deliberately excluded so a depth
+// cap or admission cap never cascades down a 'failed' edge.
+func TestChainUpstreamStatusesGate(t *testing.T) {
+	if !chainUpstreamStatuses["completed"] {
+		t.Errorf("completed must fan out")
+	}
+	if !chainUpstreamStatuses["failed"] {
+		t.Errorf("failed must fan out")
+	}
+	if chainUpstreamStatuses["skipped"] {
+		t.Errorf("skipped must NOT fan out (no cascade)")
+	}
+	if chainUpstreamStatuses["running"] {
+		t.Errorf("running must NOT fan out (not terminal)")
+	}
+}
+
+// TestBuildChainPayload verifies the chain-fired downstream payload carries the
+// upstream context needed for observability and (future) template hooks, and
+// that the upstream run's result is passed through when present.
+func TestBuildChainPayload(t *testing.T) {
+	upstreamRun := db.AutopilotRun{
+		ID:          util.MustParseUUID("11111111-1111-1111-1111-111111111111"),
+		AutopilotID: pgtype.UUID{Bytes: [16]byte{0x22}, Valid: true},
+		Result:      json.RawMessage(`{"summary":"ok","count":3}`),
+	}
+	b := buildChainPayload(upstreamRun, db.Autopilot{}, "completed", "completed")
+	if b == nil {
+		t.Fatal("payload is nil")
+	}
+	var got map[string]any
+	if err := json.Unmarshal(b, &got); err != nil {
+		t.Fatalf("payload not valid json: %v", err)
+	}
+	chain, ok := got["chain"].(map[string]any)
+	if !ok {
+		t.Fatalf("payload missing chain block: %v", got)
+	}
+	if chain["upstream_run_id"] != "11111111-1111-1111-1111-111111111111" {
+		t.Errorf("upstream_run_id = %v", chain["upstream_run_id"])
+	}
+	if chain["upstream_status"] != "completed" {
+		t.Errorf("upstream_status = %v", chain["upstream_status"])
+	}
+	if chain["chain_on_status"] != "completed" {
+		t.Errorf("chain_on_status = %v", chain["chain_on_status"])
+	}
+	res, ok := got["upstream_result"].(map[string]any)
+	if !ok {
+		t.Fatalf("upstream_result missing or wrong type: %v", got["upstream_result"])
+	}
+	if res["summary"] != "ok" || res["count"] != float64(3) {
+		t.Errorf("upstream_result not passed through: %v", res)
+	}
+}
+
+// TestBuildChainPayload_EmptyResult verifies a payload built from an upstream
+// run with no result still carries the chain block and does not crash.
+func TestBuildChainPayload_EmptyResult(t *testing.T) {
+	upstreamRun := db.AutopilotRun{
+		ID:          util.MustParseUUID("22222222-2222-2222-2222-222222222222"),
+		AutopilotID: pgtype.UUID{Bytes: [16]byte{0x22}, Valid: true},
+	}
+	b := buildChainPayload(upstreamRun, db.Autopilot{}, "failed", "failed")
+	var got map[string]any
+	if err := json.Unmarshal(b, &got); err != nil {
+		t.Fatalf("payload not valid json: %v", err)
+	}
+	chain, ok := got["chain"].(map[string]any)
+	if !ok {
+		t.Fatalf("payload missing chain block: %v", got)
+	}
+	if chain["upstream_status"] != "failed" {
+		t.Errorf("upstream_status = %v", chain["upstream_status"])
+	}
+}
+
+// DetectChainCycle tests are DB-backed (CI Postgres, skip-if-unavailable like
+// the rest of the suite). They seed a real chain graph and assert the DFS cycle
+// guard: a proposed edge closing a loop is rejected, a non-closing edge and a
+// self-edge behave correctly, and an empty graph never reports a cycle.
+func TestDetectChainCycle(t *testing.T) {
+	pool := newResolveOriginatorPool(t)
+	ctx := context.Background()
+	q := db.New(pool)
+	wsID, apA, apB, apC := seedChainFixtureReal(t)
+
+	// Seed edges A->B and B->C (trigger on the downstream, naming upstream).
+	seedChainEdge(t, pool, apB, apA, "completed") // A fires B
+	seedChainEdge(t, pool, apC, apB, "completed") // B fires C
+
+	// Proposed edge C->A (C fires A; trigger on A naming C upstream): does A
+	// already reach C? A->B->C yes => adding C->A closes the loop => cycle.
+	cycle, err := DetectChainCycle(ctx, q, wsID, apA, apC) // proposedDownstream=A, proposedUpstream=C
+	if err != nil {
+		t.Fatalf("DetectChainCycle C->A: %v", err)
+	}
+	if !cycle {
+		t.Errorf("C->A should be a cycle (A->B->C already exists)")
+	}
+
+	// Proposed edge A->C (A fires C; trigger on C naming A upstream): does C
+	// already reach A? C has no outgoing edges => no cycle.
+	cycle, err = DetectChainCycle(ctx, q, wsID, apC, apA) // proposedDownstream=C, proposedUpstream=A
+	if err != nil {
+		t.Fatalf("DetectChainCycle A->C: %v", err)
+	}
+	if cycle {
+		t.Errorf("A->C should NOT be a cycle (C cannot reach A)")
+	}
+
+	// Self-edge: an autopilot naming itself upstream is always a cycle.
+	cycle, err = DetectChainCycle(ctx, q, wsID, apB, apB)
+	if err != nil {
+		t.Fatalf("DetectChainCycle self-edge: %v", err)
+	}
+	if !cycle {
+		t.Errorf("self-edge should be a cycle")
+	}
+
+	// Empty graph: a workspace with no chain edges never reports a cycle.
+	empty := seedEmptyWorkspaceAutopilot(t, pool)
+	if cycle, err := DetectChainCycle(ctx, q, empty.ws, empty.ap, apA); err != nil {
+		t.Fatalf("DetectChainCycle empty graph: %v", err)
+	} else if cycle {
+		t.Errorf("empty graph should not report a cycle")
+	}
+}
+
+// TestChainRunIdempotencyIndex validates migration 215 at the DB level: two
+// chain runs anchored on the same (chain_upstream_run_id, trigger_id) cannot
+// coexist - the second INSERT must fail with unique_violation (23505). A
+// non-chain run, or a chain run anchored on a different upstream run, must
+// remain free to coexist. This is the hard guard behind the idempotency fast
+// path + recoverConcurrentChainAdmission in DispatchAutopilotForChain.
+func TestChainRunIdempotencyIndex(t *testing.T) {
+	pool := newResolveOriginatorPool(t)
+	ctx := context.Background()
+	_, apA, apB, _ := seedChainFixtureReal(t)
+
+	// A chain trigger on B naming A upstream.
+	triggerID := seedChainEdge(t, pool, apB, apA, "completed")
+
+	// Upstream run on A.
+	upstreamRunID := seedAutopilotRun(t, pool, apA, "completed")
+
+	// First chain run on B anchored on (upstreamRunID, triggerID).
+	if _, err := pool.Exec(ctx, `
+		INSERT INTO autopilot_run (autopilot_id, trigger_id, source, status, chain_depth, chain_upstream_run_id)
+		VALUES ($1, $2, 'chain', 'completed', 1, $3)`,
+		apB, triggerID, upstreamRunID); err != nil {
+		t.Fatalf("seed first chain run: %v", err)
+	}
+
+	// Second chain run with the same anchor must violate the partial unique index.
+	_, err := pool.Exec(ctx, `
+		INSERT INTO autopilot_run (autopilot_id, trigger_id, source, status, chain_depth, chain_upstream_run_id)
+		VALUES ($1, $2, 'chain', 'completed', 1, $3)`,
+		apB, triggerID, upstreamRunID)
+	if err == nil {
+		t.Fatalf("duplicate chain run insert unexpectedly succeeded; idempotency index missing")
+	}
+	var pgErr *pgconn.PgError
+	if !errors.As(err, &pgErr) {
+		t.Fatalf("expected pgconn.PgError, got %T: %v", err, err)
+	}
+	if pgErr.Code != "23505" {
+		t.Errorf("duplicate chain run error code = %s, want 23505 (unique_violation)", pgErr.Code)
+	}
+
+	// A non-chain run on the same trigger + upstream may coexist: the partial
+	// index only covers source='chain'.
+	if _, err := pool.Exec(ctx, `
+		INSERT INTO autopilot_run (autopilot_id, trigger_id, source, status, chain_upstream_run_id)
+		VALUES ($1, $2, 'manual', 'completed', $3)`,
+		apB, triggerID, upstreamRunID); err != nil {
+		t.Fatalf("non-chain run on same trigger/upstream should be allowed: %v", err)
+	}
+
+	// A chain run anchored on a DIFFERENT upstream run is allowed.
+	otherUpstreamRunID := seedAutopilotRun(t, pool, apA, "completed")
+	if _, err := pool.Exec(ctx, `
+		INSERT INTO autopilot_run (autopilot_id, trigger_id, source, status, chain_depth, chain_upstream_run_id)
+		VALUES ($1, $2, 'chain', 'completed', 1, $3)`,
+		apB, triggerID, otherUpstreamRunID); err != nil {
+		t.Fatalf("chain run on different upstream should be allowed: %v", err)
+	}
+}
+
+// --- helpers ---
+
+// chainTestPool is the subset of *pgxpool.Pool the seed helpers need.
+type chainTestPool interface {
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
+}
+
+// seedChainFixtureReal creates a workspace + agent + three autopilots A/B/C
+// (assignee = that agent) for chain tests, reusing seedAttributionFixture for
+// the workspace/user/agent/runtime graph. Returns the workspace + autopilot
+// UUIDs.
+func seedChainFixtureReal(t *testing.T) (wsID, apA, apB, apC pgtype.UUID) {
+	t.Helper()
+	pool := newResolveOriginatorPool(t)
+	ctx := context.Background()
+	workspaceID, userID, agentID, _ := seedAttributionFixture(t, pool)
+
+	mk := func(name string) pgtype.UUID {
+		var id string
+		if err := pool.QueryRow(ctx, `
+			INSERT INTO autopilot (workspace_id, title, assignee_id, assignee_type, execution_mode, status,
+				created_by_type, created_by_id)
+			VALUES ($1, $2, $3, 'agent', 'run_only', 'active', 'member', $4)
+			RETURNING id`, workspaceID, name, agentID, userID).Scan(&id); err != nil {
+			t.Fatalf("seed autopilot %s: %v", name, err)
+		}
+		return util.MustParseUUID(id)
+	}
+	return util.MustParseUUID(workspaceID), mk("chain-A"), mk("chain-B"), mk("chain-C")
+}
+
+// seedChainEdge inserts a chain trigger on `downstream` naming `upstream` as
+// its upstream, enabled, with the given chain_on_status. Returns the trigger id.
+func seedChainEdge(t *testing.T, pool chainTestPool, downstream, upstream pgtype.UUID, onStatus string) pgtype.UUID {
+	t.Helper()
+	ctx := context.Background()
+	var id string
+	if err := pool.QueryRow(ctx, `
+		INSERT INTO autopilot_trigger (autopilot_id, kind, enabled, upstream_autopilot_id, chain_on_status)
+		VALUES ($1, 'chain', true, $2, $3)
+		RETURNING id`, downstream, upstream, onStatus).Scan(&id); err != nil {
+		t.Fatalf("seed chain edge: %v", err)
+	}
+	return util.MustParseUUID(id)
+}
+
+// seedAutopilotRun inserts a minimal manual autopilot_run and returns its id.
+func seedAutopilotRun(t *testing.T, pool chainTestPool, autopilotID pgtype.UUID, status string) pgtype.UUID {
+	t.Helper()
+	ctx := context.Background()
+	var id string
+	if err := pool.QueryRow(ctx, `
+		INSERT INTO autopilot_run (autopilot_id, source, status)
+		VALUES ($1, 'manual', $2)
+		RETURNING id`, autopilotID, status).Scan(&id); err != nil {
+		t.Fatalf("seed autopilot run: %v", err)
+	}
+	return util.MustParseUUID(id)
+}
+
+// seedEmptyWorkspaceAutopilot returns a fresh workspace + a single autopilot
+// with no chain edges, for the empty-graph cycle case. Cleanup is on t.
+func seedEmptyWorkspaceAutopilot(t *testing.T, pool chainTestPool) struct{ ws, ap pgtype.UUID } {
+	t.Helper()
+	ctx := context.Background()
+	suffix := fmt.Sprintf("%d", time.Now().UnixNano())
+
+	var userID string
+	if err := pool.QueryRow(ctx, `INSERT INTO "user" (name, email) VALUES ('chain empty', $1) RETURNING id`,
+		"chain-empty-"+suffix+"@multica.test").Scan(&userID); err != nil {
+		t.Fatalf("seed user: %v", err)
+	}
+	t.Cleanup(func() { pool.Exec(context.Background(), `DELETE FROM "user" WHERE id = $1`, userID) })
+
+	var wsID string
+	if err := pool.QueryRow(ctx, `INSERT INTO workspace (name, slug) VALUES ('chain empty ws', $1) RETURNING id`,
+		"chain-empty-"+suffix).Scan(&wsID); err != nil {
+		t.Fatalf("seed workspace: %v", err)
+	}
+	t.Cleanup(func() { pool.Exec(context.Background(), `DELETE FROM workspace WHERE id = $1`, wsID) })
+
+	if _, err := pool.Exec(ctx, `INSERT INTO member (workspace_id, user_id, role) VALUES ($1, $2, 'owner')`, wsID, userID); err != nil {
+		t.Fatalf("seed member: %v", err)
+	}
+
+	var runtimeID string
+	if err := pool.QueryRow(ctx, `
+		INSERT INTO agent_runtime (workspace_id, name, runtime_mode, provider, status, device_info, metadata, owner_id)
+		VALUES ($1, 'chain-empty-rt', 'cloud', 'codex', 'online', '', '{}'::jsonb, $2)
+		RETURNING id`, wsID, userID).Scan(&runtimeID); err != nil {
+		t.Fatalf("seed runtime: %v", err)
+	}
+
+	var agentID string
+	if err := pool.QueryRow(ctx, `
+		INSERT INTO agent (workspace_id, name, runtime_mode, runtime_config, runtime_id, visibility,
+			max_concurrent_tasks, owner_id, instructions, custom_env, custom_args)
+		VALUES ($1, 'chain-empty-agent', 'cloud', '{}'::jsonb, $2, 'workspace', 1, $3, '', '{}'::jsonb, '[]'::jsonb)
+		RETURNING id`, wsID, runtimeID, userID).Scan(&agentID); err != nil {
+		t.Fatalf("seed agent: %v", err)
+	}
+
+	var apID string
+	if err := pool.QueryRow(ctx, `
+		INSERT INTO autopilot (workspace_id, title, assignee_id, assignee_type, execution_mode, status,
+			created_by_type, created_by_id)
+		VALUES ($1, 'chain-empty-ap', $2, 'agent', 'run_only', 'active', 'member', $3)
+		RETURNING id`, wsID, agentID, userID).Scan(&apID); err != nil {
+		t.Fatalf("seed autopilot: %v", err)
+	}
+	return struct{ ws, ap pgtype.UUID }{ws: util.MustParseUUID(wsID), ap: util.MustParseUUID(apID)}
+}
+
+// ensure the unused-import guard for pgxpool stays accurate: newResolveOriginatorPool
+// returns *pgxpool.Pool, which satisfies chainTestPool.
+var _ chainTestPool = (*pgxpool.Pool)(nil)

--- a/server/migrations/214_autopilot_chain_triggers.down.sql
+++ b/server/migrations/214_autopilot_chain_triggers.down.sql
@@ -1,0 +1,21 @@
+-- Reverse migration 214: drop chain trigger columns and restore the original
+-- kind / source CHECKs. The partial unique index from migration 215 is dropped
+-- by its own down migration before this runs (lower number down runs first).
+
+ALTER TABLE autopilot_run
+    DROP COLUMN IF EXISTS chain_upstream_run_id,
+    DROP COLUMN IF EXISTS chain_depth;
+
+ALTER TABLE autopilot_run DROP CONSTRAINT IF EXISTS autopilot_run_source_check;
+ALTER TABLE autopilot_run ADD CONSTRAINT autopilot_run_source_check
+    CHECK (source IN ('schedule', 'manual', 'webhook', 'api'));
+
+ALTER TABLE autopilot_trigger DROP CONSTRAINT IF EXISTS autopilot_trigger_chain_upstream_check;
+
+ALTER TABLE autopilot_trigger
+    DROP COLUMN IF EXISTS upstream_autopilot_id,
+    DROP COLUMN IF EXISTS chain_on_status;
+
+ALTER TABLE autopilot_trigger DROP CONSTRAINT IF EXISTS autopilot_trigger_kind_check;
+ALTER TABLE autopilot_trigger ADD CONSTRAINT autopilot_trigger_kind_check
+    CHECK (kind IN ('schedule', 'webhook', 'api'));

--- a/server/migrations/214_autopilot_chain_triggers.up.sql
+++ b/server/migrations/214_autopilot_chain_triggers.up.sql
@@ -1,0 +1,50 @@
+-- Autopilot chain / cross-autopilot orchestration triggers (WS-768 / S4).
+--
+-- A chain trigger lives on the DOWNSTREAM autopilot (same shape as schedule /
+-- webhook: the trigger declares "who gets fired"). Its `upstream_autopilot_id`
+-- names the upstream autopilot whose run reaching a terminal state fans out a
+-- downstream run. `chain_on_status` filters which terminal status of the
+-- upstream run fires the edge: 'completed' (success chain), 'failed' (error
+-- handler chain), or 'any'.
+--
+-- Reuses autopilot_trigger rather than a separate relationship table: every
+-- other dispatch source is already a trigger kind, so a chain edge is just
+-- one more kind on the downstream. This keeps trigger CRUD / publisher /
+-- enable-disable / permissions uniform, and lets a downstream compose its own
+-- chain triggers to form a DAG naturally (the rejected alternative - an
+-- autopilot-level successor_autopilot_ids[] array - could not FK, could not be
+-- enabled/disabled per-edge, and could not carry per-edge status filters).
+--
+-- The downstream run records `chain_depth` (backstop cycle guard) and
+-- `chain_upstream_run_id` (idempotency anchor). The partial unique index on
+-- (chain_upstream_run_id, trigger_id) is added in migration 215 so it can be
+-- built CONCURRENTLY in its own single-statement file (per repo migration rule).
+
+-- Extend the trigger kind CHECK to admit 'chain'.
+ALTER TABLE autopilot_trigger DROP CONSTRAINT autopilot_trigger_kind_check;
+ALTER TABLE autopilot_trigger ADD CONSTRAINT autopilot_trigger_kind_check
+    CHECK (kind IN ('schedule', 'webhook', 'api', 'chain'));
+
+-- Chain edge config columns.
+ALTER TABLE autopilot_trigger
+    ADD COLUMN upstream_autopilot_id UUID REFERENCES autopilot(id) ON DELETE CASCADE,
+    ADD COLUMN chain_on_status TEXT NOT NULL DEFAULT 'completed'
+        CHECK (chain_on_status IN ('completed', 'failed', 'any'));
+
+-- A chain trigger must name its upstream; non-chain triggers must not.
+ALTER TABLE autopilot_trigger ADD CONSTRAINT autopilot_trigger_chain_upstream_check
+    CHECK (kind <> 'chain' OR upstream_autopilot_id IS NOT NULL);
+
+-- Extend the run source CHECK to admit 'chain' (downstream runs fired by an
+-- upstream terminal transition).
+ALTER TABLE autopilot_run DROP CONSTRAINT autopilot_run_source_check;
+ALTER TABLE autopilot_run ADD CONSTRAINT autopilot_run_source_check
+    CHECK (source IN ('schedule', 'manual', 'webhook', 'api', 'chain'));
+
+-- Chain depth (0 for non-chain runs; upstream_depth + 1 for a chain run) and
+-- the upstream run that fired this run. chain_upstream_run_id is the
+-- idempotency anchor: at most one downstream run per (upstream run, chain
+-- trigger), enforced by migration 215's partial unique index.
+ALTER TABLE autopilot_run
+    ADD COLUMN chain_depth INT NOT NULL DEFAULT 0,
+    ADD COLUMN chain_upstream_run_id UUID REFERENCES autopilot_run(id) ON DELETE SET NULL;

--- a/server/migrations/215_autopilot_run_chain_idempotency.down.sql
+++ b/server/migrations/215_autopilot_run_chain_idempotency.down.sql
@@ -1,0 +1,1 @@
+DROP INDEX IF EXISTS uq_autopilot_run_chain_upstream;

--- a/server/migrations/215_autopilot_run_chain_idempotency.up.sql
+++ b/server/migrations/215_autopilot_run_chain_idempotency.up.sql
@@ -1,0 +1,18 @@
+-- Chain dispatch idempotency: at most one downstream run per
+-- (upstream run, chain trigger). When an upstream run reaches a terminal
+-- state and the terminal transition fires twice (event replay, worker
+-- resume, or a SyncRunFrom* listener racing itself), the partial unique
+-- index turns the second CreateAutopilotRun into a 23505 conflict the
+-- caller recovers into "reuse the existing run" - mirroring the webhook
+-- delivery admission path (migration 177) and the scheduled
+-- (trigger_id, planned_at) guard (migration 124).
+--
+-- Partial because only source='chain' runs carry the anchor; every other
+-- source leaves chain_upstream_run_id NULL and must not participate.
+--
+-- Single-statement file + CONCURRENTLY per the repo migration rule (index
+-- builds cannot share a transaction / multi-command string with the
+-- ALTERs in 214).
+CREATE UNIQUE INDEX CONCURRENTLY IF NOT EXISTS uq_autopilot_run_chain_upstream
+    ON autopilot_run(chain_upstream_run_id, trigger_id)
+    WHERE source = 'chain' AND chain_upstream_run_id IS NOT NULL;

--- a/server/pkg/db/generated/autopilot.sql.go
+++ b/server/pkg/db/generated/autopilot.sql.go
@@ -206,23 +206,27 @@ const createAutopilotRun = `-- name: CreateAutopilotRun :one
 
 INSERT INTO autopilot_run (
     autopilot_id, trigger_id, source, status, trigger_payload, squad_id, planned_at,
-    webhook_delivery_id
+    webhook_delivery_id, chain_depth, chain_upstream_run_id
 ) VALUES (
     $1, $4, $2, $3, $5,
     $6, $7,
-    $8
-) RETURNING id, autopilot_id, trigger_id, source, status, issue_id, task_id, triggered_at, completed_at, failure_reason, trigger_payload, result, created_at, squad_id, planned_at, webhook_delivery_id
+    $8,
+    COALESCE($9::int, 0),
+    $10
+) RETURNING id, autopilot_id, trigger_id, source, status, issue_id, task_id, triggered_at, completed_at, failure_reason, trigger_payload, result, created_at, squad_id, planned_at, webhook_delivery_id, chain_depth, chain_upstream_run_id
 `
 
 type CreateAutopilotRunParams struct {
-	AutopilotID       pgtype.UUID        `json:"autopilot_id"`
-	Source            string             `json:"source"`
-	Status            string             `json:"status"`
-	TriggerID         pgtype.UUID        `json:"trigger_id"`
-	TriggerPayload    []byte             `json:"trigger_payload"`
-	SquadID           pgtype.UUID        `json:"squad_id"`
-	PlannedAt         pgtype.Timestamptz `json:"planned_at"`
-	WebhookDeliveryID pgtype.UUID        `json:"webhook_delivery_id"`
+	AutopilotID        pgtype.UUID        `json:"autopilot_id"`
+	Source             string             `json:"source"`
+	Status             string             `json:"status"`
+	TriggerID          pgtype.UUID        `json:"trigger_id"`
+	TriggerPayload     []byte             `json:"trigger_payload"`
+	SquadID            pgtype.UUID        `json:"squad_id"`
+	PlannedAt          pgtype.Timestamptz `json:"planned_at"`
+	WebhookDeliveryID  pgtype.UUID        `json:"webhook_delivery_id"`
+	ChainDepth         pgtype.Int4        `json:"chain_depth"`
+	ChainUpstreamRunID pgtype.UUID        `json:"chain_upstream_run_id"`
 }
 
 // =====================
@@ -249,6 +253,8 @@ func (q *Queries) CreateAutopilotRun(ctx context.Context, arg CreateAutopilotRun
 		arg.SquadID,
 		arg.PlannedAt,
 		arg.WebhookDeliveryID,
+		arg.ChainDepth,
+		arg.ChainUpstreamRunID,
 	)
 	var i AutopilotRun
 	err := row.Scan(
@@ -268,6 +274,8 @@ func (q *Queries) CreateAutopilotRun(ctx context.Context, arg CreateAutopilotRun
 		&i.SquadID,
 		&i.PlannedAt,
 		&i.WebhookDeliveryID,
+		&i.ChainDepth,
+		&i.ChainUpstreamRunID,
 	)
 	return i, err
 }
@@ -391,29 +399,34 @@ const createAutopilotTrigger = `-- name: CreateAutopilotTrigger :one
 INSERT INTO autopilot_trigger (
     autopilot_id, kind, enabled, cron_expression, timezone,
     next_run_at, webhook_token, label, provider, event_filters,
-    published_by_type, published_by_id
+    published_by_type, published_by_id,
+    upstream_autopilot_id, chain_on_status
 ) VALUES (
     $1, $2, $3, $4, $5,
     $6, $7, $8,
     COALESCE($9::text, 'generic'),
     $10,
-    $11, $12
-) RETURNING id, autopilot_id, kind, enabled, cron_expression, timezone, next_run_at, webhook_token, label, last_fired_at, created_at, updated_at, provider, signing_secret, event_filters, published_by_type, published_by_id
+    $11, $12,
+    $13,
+    COALESCE($14::text, 'completed')
+) RETURNING id, autopilot_id, kind, enabled, cron_expression, timezone, next_run_at, webhook_token, label, last_fired_at, created_at, updated_at, provider, signing_secret, event_filters, published_by_type, published_by_id, upstream_autopilot_id, chain_on_status
 `
 
 type CreateAutopilotTriggerParams struct {
-	AutopilotID     pgtype.UUID        `json:"autopilot_id"`
-	Kind            string             `json:"kind"`
-	Enabled         bool               `json:"enabled"`
-	CronExpression  pgtype.Text        `json:"cron_expression"`
-	Timezone        pgtype.Text        `json:"timezone"`
-	NextRunAt       pgtype.Timestamptz `json:"next_run_at"`
-	WebhookToken    pgtype.Text        `json:"webhook_token"`
-	Label           pgtype.Text        `json:"label"`
-	Provider        pgtype.Text        `json:"provider"`
-	EventFilters    []byte             `json:"event_filters"`
-	PublishedByType pgtype.Text        `json:"published_by_type"`
-	PublishedByID   pgtype.UUID        `json:"published_by_id"`
+	AutopilotID         pgtype.UUID        `json:"autopilot_id"`
+	Kind                string             `json:"kind"`
+	Enabled             bool               `json:"enabled"`
+	CronExpression      pgtype.Text        `json:"cron_expression"`
+	Timezone            pgtype.Text        `json:"timezone"`
+	NextRunAt           pgtype.Timestamptz `json:"next_run_at"`
+	WebhookToken        pgtype.Text        `json:"webhook_token"`
+	Label               pgtype.Text        `json:"label"`
+	Provider            pgtype.Text        `json:"provider"`
+	EventFilters        []byte             `json:"event_filters"`
+	PublishedByType     pgtype.Text        `json:"published_by_type"`
+	PublishedByID       pgtype.UUID        `json:"published_by_id"`
+	UpstreamAutopilotID pgtype.UUID        `json:"upstream_autopilot_id"`
+	ChainOnStatus       pgtype.Text        `json:"chain_on_status"`
 }
 
 func (q *Queries) CreateAutopilotTrigger(ctx context.Context, arg CreateAutopilotTriggerParams) (AutopilotTrigger, error) {
@@ -430,6 +443,8 @@ func (q *Queries) CreateAutopilotTrigger(ctx context.Context, arg CreateAutopilo
 		arg.EventFilters,
 		arg.PublishedByType,
 		arg.PublishedByID,
+		arg.UpstreamAutopilotID,
+		arg.ChainOnStatus,
 	)
 	var i AutopilotTrigger
 	err := row.Scan(
@@ -450,6 +465,8 @@ func (q *Queries) CreateAutopilotTrigger(ctx context.Context, arg CreateAutopilo
 		&i.EventFilters,
 		&i.PublishedByType,
 		&i.PublishedByID,
+		&i.UpstreamAutopilotID,
+		&i.ChainOnStatus,
 	)
 	return i, err
 }
@@ -607,7 +624,7 @@ func (q *Queries) GetAutopilotInWorkspace(ctx context.Context, arg GetAutopilotI
 }
 
 const getAutopilotRun = `-- name: GetAutopilotRun :one
-SELECT id, autopilot_id, trigger_id, source, status, issue_id, task_id, triggered_at, completed_at, failure_reason, trigger_payload, result, created_at, squad_id, planned_at, webhook_delivery_id FROM autopilot_run
+SELECT id, autopilot_id, trigger_id, source, status, issue_id, task_id, triggered_at, completed_at, failure_reason, trigger_payload, result, created_at, squad_id, planned_at, webhook_delivery_id, chain_depth, chain_upstream_run_id FROM autopilot_run
 WHERE id = $1
 `
 
@@ -631,13 +648,59 @@ func (q *Queries) GetAutopilotRun(ctx context.Context, id pgtype.UUID) (Autopilo
 		&i.SquadID,
 		&i.PlannedAt,
 		&i.WebhookDeliveryID,
+		&i.ChainDepth,
+		&i.ChainUpstreamRunID,
+	)
+	return i, err
+}
+
+const getAutopilotRunByChainUpstream = `-- name: GetAutopilotRunByChainUpstream :one
+SELECT id, autopilot_id, trigger_id, source, status, issue_id, task_id, triggered_at, completed_at, failure_reason, trigger_payload, result, created_at, squad_id, planned_at, webhook_delivery_id, chain_depth, chain_upstream_run_id FROM autopilot_run
+WHERE chain_upstream_run_id = $1 AND trigger_id = $2 AND source = 'chain'
+LIMIT 1
+`
+
+type GetAutopilotRunByChainUpstreamParams struct {
+	ChainUpstreamRunID pgtype.UUID `json:"chain_upstream_run_id"`
+	TriggerID          pgtype.UUID `json:"trigger_id"`
+}
+
+// Idempotent lookup for chain dispatch: if a run already exists for this
+// (upstream run, chain trigger) pair, the caller reuses it instead of
+// creating a duplicate. The partial unique index uq_autopilot_run_chain_upstream
+// (migration 215) covers the same key, so a race between "look up then insert"
+// still resolves to a single row - this query is the fast path that lets us
+// skip the INSERT when we can see the prior row clearly. Returns no rows for
+// the (much more common) first-time chain dispatch.
+func (q *Queries) GetAutopilotRunByChainUpstream(ctx context.Context, arg GetAutopilotRunByChainUpstreamParams) (AutopilotRun, error) {
+	row := q.db.QueryRow(ctx, getAutopilotRunByChainUpstream, arg.ChainUpstreamRunID, arg.TriggerID)
+	var i AutopilotRun
+	err := row.Scan(
+		&i.ID,
+		&i.AutopilotID,
+		&i.TriggerID,
+		&i.Source,
+		&i.Status,
+		&i.IssueID,
+		&i.TaskID,
+		&i.TriggeredAt,
+		&i.CompletedAt,
+		&i.FailureReason,
+		&i.TriggerPayload,
+		&i.Result,
+		&i.CreatedAt,
+		&i.SquadID,
+		&i.PlannedAt,
+		&i.WebhookDeliveryID,
+		&i.ChainDepth,
+		&i.ChainUpstreamRunID,
 	)
 	return i, err
 }
 
 const getAutopilotRunByIssue = `-- name: GetAutopilotRunByIssue :one
 
-SELECT id, autopilot_id, trigger_id, source, status, issue_id, task_id, triggered_at, completed_at, failure_reason, trigger_payload, result, created_at, squad_id, planned_at, webhook_delivery_id FROM autopilot_run
+SELECT id, autopilot_id, trigger_id, source, status, issue_id, task_id, triggered_at, completed_at, failure_reason, trigger_payload, result, created_at, squad_id, planned_at, webhook_delivery_id, chain_depth, chain_upstream_run_id FROM autopilot_run
 WHERE issue_id = $1 AND status IN ('issue_created', 'running')
 LIMIT 1
 `
@@ -665,12 +728,14 @@ func (q *Queries) GetAutopilotRunByIssue(ctx context.Context, issueID pgtype.UUI
 		&i.SquadID,
 		&i.PlannedAt,
 		&i.WebhookDeliveryID,
+		&i.ChainDepth,
+		&i.ChainUpstreamRunID,
 	)
 	return i, err
 }
 
 const getAutopilotRunByTriggerAndPlanned = `-- name: GetAutopilotRunByTriggerAndPlanned :one
-SELECT id, autopilot_id, trigger_id, source, status, issue_id, task_id, triggered_at, completed_at, failure_reason, trigger_payload, result, created_at, squad_id, planned_at, webhook_delivery_id FROM autopilot_run
+SELECT id, autopilot_id, trigger_id, source, status, issue_id, task_id, triggered_at, completed_at, failure_reason, trigger_payload, result, created_at, squad_id, planned_at, webhook_delivery_id, chain_depth, chain_upstream_run_id FROM autopilot_run
 WHERE trigger_id = $1
   AND planned_at = $2
 LIMIT 1
@@ -709,12 +774,14 @@ func (q *Queries) GetAutopilotRunByTriggerAndPlanned(ctx context.Context, arg Ge
 		&i.SquadID,
 		&i.PlannedAt,
 		&i.WebhookDeliveryID,
+		&i.ChainDepth,
+		&i.ChainUpstreamRunID,
 	)
 	return i, err
 }
 
 const getAutopilotRunByWebhookDelivery = `-- name: GetAutopilotRunByWebhookDelivery :one
-SELECT id, autopilot_id, trigger_id, source, status, issue_id, task_id, triggered_at, completed_at, failure_reason, trigger_payload, result, created_at, squad_id, planned_at, webhook_delivery_id FROM autopilot_run
+SELECT id, autopilot_id, trigger_id, source, status, issue_id, task_id, triggered_at, completed_at, failure_reason, trigger_payload, result, created_at, squad_id, planned_at, webhook_delivery_id, chain_depth, chain_upstream_run_id FROM autopilot_run
 WHERE webhook_delivery_id = $1
 LIMIT 1
 `
@@ -739,6 +806,8 @@ func (q *Queries) GetAutopilotRunByWebhookDelivery(ctx context.Context, webhookD
 		&i.SquadID,
 		&i.PlannedAt,
 		&i.WebhookDeliveryID,
+		&i.ChainDepth,
+		&i.ChainUpstreamRunID,
 	)
 	return i, err
 }
@@ -808,7 +877,7 @@ func (q *Queries) GetAutopilotTaskByRun(ctx context.Context, autopilotRunID pgty
 }
 
 const getAutopilotTrigger = `-- name: GetAutopilotTrigger :one
-SELECT id, autopilot_id, kind, enabled, cron_expression, timezone, next_run_at, webhook_token, label, last_fired_at, created_at, updated_at, provider, signing_secret, event_filters, published_by_type, published_by_id FROM autopilot_trigger
+SELECT id, autopilot_id, kind, enabled, cron_expression, timezone, next_run_at, webhook_token, label, last_fired_at, created_at, updated_at, provider, signing_secret, event_filters, published_by_type, published_by_id, upstream_autopilot_id, chain_on_status FROM autopilot_trigger
 WHERE id = $1
 `
 
@@ -833,12 +902,14 @@ func (q *Queries) GetAutopilotTrigger(ctx context.Context, id pgtype.UUID) (Auto
 		&i.EventFilters,
 		&i.PublishedByType,
 		&i.PublishedByID,
+		&i.UpstreamAutopilotID,
+		&i.ChainOnStatus,
 	)
 	return i, err
 }
 
 const getWebhookTriggerByToken = `-- name: GetWebhookTriggerByToken :one
-SELECT t.id, t.autopilot_id, t.kind, t.enabled, t.cron_expression, t.timezone, t.next_run_at, t.webhook_token, t.label, t.last_fired_at, t.created_at, t.updated_at, t.provider, t.signing_secret, t.event_filters, t.published_by_type, t.published_by_id, a.workspace_id AS autopilot_workspace_id
+SELECT t.id, t.autopilot_id, t.kind, t.enabled, t.cron_expression, t.timezone, t.next_run_at, t.webhook_token, t.label, t.last_fired_at, t.created_at, t.updated_at, t.provider, t.signing_secret, t.event_filters, t.published_by_type, t.published_by_id, t.upstream_autopilot_id, t.chain_on_status, a.workspace_id AS autopilot_workspace_id
 FROM autopilot_trigger t
 JOIN autopilot a ON a.id = t.autopilot_id
 WHERE t.kind = 'webhook'
@@ -863,6 +934,8 @@ type GetWebhookTriggerByTokenRow struct {
 	EventFilters         []byte             `json:"event_filters"`
 	PublishedByType      pgtype.Text        `json:"published_by_type"`
 	PublishedByID        pgtype.UUID        `json:"published_by_id"`
+	UpstreamAutopilotID  pgtype.UUID        `json:"upstream_autopilot_id"`
+	ChainOnStatus        string             `json:"chain_on_status"`
 	AutopilotWorkspaceID pgtype.UUID        `json:"autopilot_workspace_id"`
 }
 
@@ -892,6 +965,8 @@ func (q *Queries) GetWebhookTriggerByToken(ctx context.Context, webhookToken pgt
 		&i.EventFilters,
 		&i.PublishedByType,
 		&i.PublishedByID,
+		&i.UpstreamAutopilotID,
+		&i.ChainOnStatus,
 		&i.AutopilotWorkspaceID,
 	)
 	return i, err
@@ -980,7 +1055,7 @@ func (q *Queries) ListAutopilotIDsForCollaborator(ctx context.Context, userID pg
 }
 
 const listAutopilotRuns = `-- name: ListAutopilotRuns :many
-SELECT id, autopilot_id, trigger_id, source, status, issue_id, task_id, triggered_at, completed_at, failure_reason, trigger_payload, result, created_at, squad_id, planned_at, webhook_delivery_id FROM autopilot_run
+SELECT id, autopilot_id, trigger_id, source, status, issue_id, task_id, triggered_at, completed_at, failure_reason, trigger_payload, result, created_at, squad_id, planned_at, webhook_delivery_id, chain_depth, chain_upstream_run_id FROM autopilot_run
 WHERE autopilot_id = $1
 ORDER BY created_at DESC
 LIMIT $2 OFFSET $3
@@ -1018,6 +1093,8 @@ func (q *Queries) ListAutopilotRuns(ctx context.Context, arg ListAutopilotRunsPa
 			&i.SquadID,
 			&i.PlannedAt,
 			&i.WebhookDeliveryID,
+			&i.ChainDepth,
+			&i.ChainUpstreamRunID,
 		); err != nil {
 			return nil, err
 		}
@@ -1067,7 +1144,7 @@ func (q *Queries) ListAutopilotSubscribers(ctx context.Context, autopilotID pgty
 
 const listAutopilotTriggers = `-- name: ListAutopilotTriggers :many
 
-SELECT id, autopilot_id, kind, enabled, cron_expression, timezone, next_run_at, webhook_token, label, last_fired_at, created_at, updated_at, provider, signing_secret, event_filters, published_by_type, published_by_id FROM autopilot_trigger
+SELECT id, autopilot_id, kind, enabled, cron_expression, timezone, next_run_at, webhook_token, label, last_fired_at, created_at, updated_at, provider, signing_secret, event_filters, published_by_type, published_by_id, upstream_autopilot_id, chain_on_status FROM autopilot_trigger
 WHERE autopilot_id = $1
 ORDER BY created_at ASC
 `
@@ -1102,6 +1179,8 @@ func (q *Queries) ListAutopilotTriggers(ctx context.Context, autopilotID pgtype.
 			&i.EventFilters,
 			&i.PublishedByType,
 			&i.PublishedByID,
+			&i.UpstreamAutopilotID,
+			&i.ChainOnStatus,
 		); err != nil {
 			return nil, err
 		}
@@ -1192,6 +1271,123 @@ func (q *Queries) ListAutopilots(ctx context.Context, arg ListAutopilotsParams) 
 			&i.TriggerKinds,
 			&i.NextRunAt,
 			&i.LastRunStatus,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+const listChainTriggersInWorkspace = `-- name: ListChainTriggersInWorkspace :many
+SELECT t.id, t.autopilot_id, t.kind, t.enabled, t.cron_expression, t.timezone, t.next_run_at, t.webhook_token, t.label, t.last_fired_at, t.created_at, t.updated_at, t.provider, t.signing_secret, t.event_filters, t.published_by_type, t.published_by_id, t.upstream_autopilot_id, t.chain_on_status FROM autopilot_trigger t
+JOIN autopilot a ON a.id = t.autopilot_id
+WHERE a.workspace_id = $1 AND t.kind = 'chain'
+ORDER BY t.created_at ASC
+`
+
+// Every chain edge in a workspace, joined to autopilot for workspace scoping.
+// Used by the config-time DFS cycle check: the caller builds the directed
+// graph (upstream_autopilot_id -> autopilot_id) and walks it in Go so the
+// proposed new edge can be included in the visit set before it is persisted.
+func (q *Queries) ListChainTriggersInWorkspace(ctx context.Context, workspaceID pgtype.UUID) ([]AutopilotTrigger, error) {
+	rows, err := q.db.Query(ctx, listChainTriggersInWorkspace, workspaceID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []AutopilotTrigger{}
+	for rows.Next() {
+		var i AutopilotTrigger
+		if err := rows.Scan(
+			&i.ID,
+			&i.AutopilotID,
+			&i.Kind,
+			&i.Enabled,
+			&i.CronExpression,
+			&i.Timezone,
+			&i.NextRunAt,
+			&i.WebhookToken,
+			&i.Label,
+			&i.LastFiredAt,
+			&i.CreatedAt,
+			&i.UpdatedAt,
+			&i.Provider,
+			&i.SigningSecret,
+			&i.EventFilters,
+			&i.PublishedByType,
+			&i.PublishedByID,
+			&i.UpstreamAutopilotID,
+			&i.ChainOnStatus,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+const listEnabledChainSuccessors = `-- name: ListEnabledChainSuccessors :many
+
+SELECT id, autopilot_id, kind, enabled, cron_expression, timezone, next_run_at, webhook_token, label, last_fired_at, created_at, updated_at, provider, signing_secret, event_filters, published_by_type, published_by_id, upstream_autopilot_id, chain_on_status FROM autopilot_trigger
+WHERE kind = 'chain'
+  AND upstream_autopilot_id = $1
+  AND enabled = true
+  AND chain_on_status = ANY($2::text[])
+ORDER BY created_at ASC
+`
+
+type ListEnabledChainSuccessorsParams struct {
+	UpstreamAutopilotID pgtype.UUID `json:"upstream_autopilot_id"`
+	AllowedStatuses     []string    `json:"allowed_statuses"`
+}
+
+// ───────────────────────────────────────────────────────────────────────────
+// Chain triggers (cross-autopilot orchestration, WS-768 / S4)
+// ───────────────────────────────────────────────────────────────────────────
+// Fan-out query: the enabled chain triggers fired when the autopilot named by
+// $1 reaches a terminal status. The caller picks the matching edge set by
+// passing the allowed chain_on_status values explicitly - $2 is the text array
+// of statuses that match the upstream's terminal status ('completed' upstream
+// -> {'completed','any'}; 'failed' upstream -> {'failed','any'}). 'skipped'
+// never matches because it is not passed in. Splitting the match set in the
+// caller (rather than comparing a status param to a literal in SQL) keeps the
+// param typed. Ordered by created_at so fan-out is deterministic for tests.
+func (q *Queries) ListEnabledChainSuccessors(ctx context.Context, arg ListEnabledChainSuccessorsParams) ([]AutopilotTrigger, error) {
+	rows, err := q.db.Query(ctx, listEnabledChainSuccessors, arg.UpstreamAutopilotID, arg.AllowedStatuses)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []AutopilotTrigger{}
+	for rows.Next() {
+		var i AutopilotTrigger
+		if err := rows.Scan(
+			&i.ID,
+			&i.AutopilotID,
+			&i.Kind,
+			&i.Enabled,
+			&i.CronExpression,
+			&i.Timezone,
+			&i.NextRunAt,
+			&i.WebhookToken,
+			&i.Label,
+			&i.LastFiredAt,
+			&i.CreatedAt,
+			&i.UpdatedAt,
+			&i.Provider,
+			&i.SigningSecret,
+			&i.EventFilters,
+			&i.PublishedByType,
+			&i.PublishedByID,
+			&i.UpstreamAutopilotID,
+			&i.ChainOnStatus,
 		); err != nil {
 			return nil, err
 		}
@@ -1305,7 +1501,7 @@ SET webhook_token = $2,
     updated_at = now()
 WHERE id = $1
   AND kind = 'webhook'
-RETURNING id, autopilot_id, kind, enabled, cron_expression, timezone, next_run_at, webhook_token, label, last_fired_at, created_at, updated_at, provider, signing_secret, event_filters, published_by_type, published_by_id
+RETURNING id, autopilot_id, kind, enabled, cron_expression, timezone, next_run_at, webhook_token, label, last_fired_at, created_at, updated_at, provider, signing_secret, event_filters, published_by_type, published_by_id, upstream_autopilot_id, chain_on_status
 `
 
 type RotateAutopilotTriggerWebhookTokenParams struct {
@@ -1337,6 +1533,8 @@ func (q *Queries) RotateAutopilotTriggerWebhookToken(ctx context.Context, arg Ro
 		&i.EventFilters,
 		&i.PublishedByType,
 		&i.PublishedByID,
+		&i.UpstreamAutopilotID,
+		&i.ChainOnStatus,
 	)
 	return i, err
 }
@@ -1471,7 +1669,7 @@ SET signing_secret = $2,
     updated_at = now()
 WHERE id = $1
   AND kind = 'webhook'
-RETURNING id, autopilot_id, kind, enabled, cron_expression, timezone, next_run_at, webhook_token, label, last_fired_at, created_at, updated_at, provider, signing_secret, event_filters, published_by_type, published_by_id
+RETURNING id, autopilot_id, kind, enabled, cron_expression, timezone, next_run_at, webhook_token, label, last_fired_at, created_at, updated_at, provider, signing_secret, event_filters, published_by_type, published_by_id, upstream_autopilot_id, chain_on_status
 `
 
 type SetAutopilotTriggerSigningSecretParams struct {
@@ -1505,6 +1703,8 @@ func (q *Queries) SetAutopilotTriggerSigningSecret(ctx context.Context, arg SetA
 		&i.EventFilters,
 		&i.PublishedByType,
 		&i.PublishedByID,
+		&i.UpstreamAutopilotID,
+		&i.ChainOnStatus,
 	)
 	return i, err
 }
@@ -1514,7 +1714,7 @@ UPDATE autopilot_trigger
 SET webhook_token = $2,
     updated_at = now()
 WHERE id = $1
-RETURNING id, autopilot_id, kind, enabled, cron_expression, timezone, next_run_at, webhook_token, label, last_fired_at, created_at, updated_at, provider, signing_secret, event_filters, published_by_type, published_by_id
+RETURNING id, autopilot_id, kind, enabled, cron_expression, timezone, next_run_at, webhook_token, label, last_fired_at, created_at, updated_at, provider, signing_secret, event_filters, published_by_type, published_by_id, upstream_autopilot_id, chain_on_status
 `
 
 type SetAutopilotTriggerWebhookTokenParams struct {
@@ -1548,6 +1748,8 @@ func (q *Queries) SetAutopilotTriggerWebhookToken(ctx context.Context, arg SetAu
 		&i.EventFilters,
 		&i.PublishedByType,
 		&i.PublishedByID,
+		&i.UpstreamAutopilotID,
+		&i.ChainOnStatus,
 	)
 	return i, err
 }
@@ -1676,7 +1878,7 @@ const updateAutopilotRunCompleted = `-- name: UpdateAutopilotRunCompleted :one
 UPDATE autopilot_run
 SET status = 'completed', completed_at = now(), result = $2
 WHERE id = $1
-RETURNING id, autopilot_id, trigger_id, source, status, issue_id, task_id, triggered_at, completed_at, failure_reason, trigger_payload, result, created_at, squad_id, planned_at, webhook_delivery_id
+RETURNING id, autopilot_id, trigger_id, source, status, issue_id, task_id, triggered_at, completed_at, failure_reason, trigger_payload, result, created_at, squad_id, planned_at, webhook_delivery_id, chain_depth, chain_upstream_run_id
 `
 
 type UpdateAutopilotRunCompletedParams struct {
@@ -1704,6 +1906,8 @@ func (q *Queries) UpdateAutopilotRunCompleted(ctx context.Context, arg UpdateAut
 		&i.SquadID,
 		&i.PlannedAt,
 		&i.WebhookDeliveryID,
+		&i.ChainDepth,
+		&i.ChainUpstreamRunID,
 	)
 	return i, err
 }
@@ -1712,7 +1916,7 @@ const updateAutopilotRunFailed = `-- name: UpdateAutopilotRunFailed :one
 UPDATE autopilot_run
 SET status = 'failed', completed_at = now(), failure_reason = $2
 WHERE id = $1
-RETURNING id, autopilot_id, trigger_id, source, status, issue_id, task_id, triggered_at, completed_at, failure_reason, trigger_payload, result, created_at, squad_id, planned_at, webhook_delivery_id
+RETURNING id, autopilot_id, trigger_id, source, status, issue_id, task_id, triggered_at, completed_at, failure_reason, trigger_payload, result, created_at, squad_id, planned_at, webhook_delivery_id, chain_depth, chain_upstream_run_id
 `
 
 type UpdateAutopilotRunFailedParams struct {
@@ -1740,6 +1944,8 @@ func (q *Queries) UpdateAutopilotRunFailed(ctx context.Context, arg UpdateAutopi
 		&i.SquadID,
 		&i.PlannedAt,
 		&i.WebhookDeliveryID,
+		&i.ChainDepth,
+		&i.ChainUpstreamRunID,
 	)
 	return i, err
 }
@@ -1748,7 +1954,7 @@ const updateAutopilotRunIssueCreated = `-- name: UpdateAutopilotRunIssueCreated 
 UPDATE autopilot_run
 SET status = 'issue_created', issue_id = $2
 WHERE id = $1
-RETURNING id, autopilot_id, trigger_id, source, status, issue_id, task_id, triggered_at, completed_at, failure_reason, trigger_payload, result, created_at, squad_id, planned_at, webhook_delivery_id
+RETURNING id, autopilot_id, trigger_id, source, status, issue_id, task_id, triggered_at, completed_at, failure_reason, trigger_payload, result, created_at, squad_id, planned_at, webhook_delivery_id, chain_depth, chain_upstream_run_id
 `
 
 type UpdateAutopilotRunIssueCreatedParams struct {
@@ -1776,6 +1982,8 @@ func (q *Queries) UpdateAutopilotRunIssueCreated(ctx context.Context, arg Update
 		&i.SquadID,
 		&i.PlannedAt,
 		&i.WebhookDeliveryID,
+		&i.ChainDepth,
+		&i.ChainUpstreamRunID,
 	)
 	return i, err
 }
@@ -1784,7 +1992,7 @@ const updateAutopilotRunRunning = `-- name: UpdateAutopilotRunRunning :one
 UPDATE autopilot_run
 SET status = 'running', task_id = $2
 WHERE id = $1
-RETURNING id, autopilot_id, trigger_id, source, status, issue_id, task_id, triggered_at, completed_at, failure_reason, trigger_payload, result, created_at, squad_id, planned_at, webhook_delivery_id
+RETURNING id, autopilot_id, trigger_id, source, status, issue_id, task_id, triggered_at, completed_at, failure_reason, trigger_payload, result, created_at, squad_id, planned_at, webhook_delivery_id, chain_depth, chain_upstream_run_id
 `
 
 type UpdateAutopilotRunRunningParams struct {
@@ -1812,6 +2020,8 @@ func (q *Queries) UpdateAutopilotRunRunning(ctx context.Context, arg UpdateAutop
 		&i.SquadID,
 		&i.PlannedAt,
 		&i.WebhookDeliveryID,
+		&i.ChainDepth,
+		&i.ChainUpstreamRunID,
 	)
 	return i, err
 }
@@ -1820,7 +2030,7 @@ const updateAutopilotRunSkipped = `-- name: UpdateAutopilotRunSkipped :one
 UPDATE autopilot_run
 SET status = 'skipped', completed_at = now(), failure_reason = $2
 WHERE id = $1
-RETURNING id, autopilot_id, trigger_id, source, status, issue_id, task_id, triggered_at, completed_at, failure_reason, trigger_payload, result, created_at, squad_id, planned_at, webhook_delivery_id
+RETURNING id, autopilot_id, trigger_id, source, status, issue_id, task_id, triggered_at, completed_at, failure_reason, trigger_payload, result, created_at, squad_id, planned_at, webhook_delivery_id, chain_depth, chain_upstream_run_id
 `
 
 type UpdateAutopilotRunSkippedParams struct {
@@ -1854,6 +2064,8 @@ func (q *Queries) UpdateAutopilotRunSkipped(ctx context.Context, arg UpdateAutop
 		&i.SquadID,
 		&i.PlannedAt,
 		&i.WebhookDeliveryID,
+		&i.ChainDepth,
+		&i.ChainUpstreamRunID,
 	)
 	return i, err
 }
@@ -1865,7 +2077,7 @@ SET status = 'skipped',
     failure_reason = $2,
     result = $3
 WHERE id = $1
-RETURNING id, autopilot_id, trigger_id, source, status, issue_id, task_id, triggered_at, completed_at, failure_reason, trigger_payload, result, created_at, squad_id, planned_at, webhook_delivery_id
+RETURNING id, autopilot_id, trigger_id, source, status, issue_id, task_id, triggered_at, completed_at, failure_reason, trigger_payload, result, created_at, squad_id, planned_at, webhook_delivery_id, chain_depth, chain_upstream_run_id
 `
 
 type UpdateAutopilotRunSkippedWithResultParams struct {
@@ -1894,6 +2106,8 @@ func (q *Queries) UpdateAutopilotRunSkippedWithResult(ctx context.Context, arg U
 		&i.SquadID,
 		&i.PlannedAt,
 		&i.WebhookDeliveryID,
+		&i.ChainDepth,
+		&i.ChainUpstreamRunID,
 	)
 	return i, err
 }
@@ -1906,9 +2120,10 @@ UPDATE autopilot_trigger SET
     next_run_at = $5,
     label = COALESCE($6, label),
     event_filters = COALESCE($7, event_filters),
+    chain_on_status = COALESCE($8::text, chain_on_status),
     updated_at = now()
 WHERE id = $1
-RETURNING id, autopilot_id, kind, enabled, cron_expression, timezone, next_run_at, webhook_token, label, last_fired_at, created_at, updated_at, provider, signing_secret, event_filters, published_by_type, published_by_id
+RETURNING id, autopilot_id, kind, enabled, cron_expression, timezone, next_run_at, webhook_token, label, last_fired_at, created_at, updated_at, provider, signing_secret, event_filters, published_by_type, published_by_id, upstream_autopilot_id, chain_on_status
 `
 
 type UpdateAutopilotTriggerParams struct {
@@ -1919,6 +2134,7 @@ type UpdateAutopilotTriggerParams struct {
 	NextRunAt      pgtype.Timestamptz `json:"next_run_at"`
 	Label          pgtype.Text        `json:"label"`
 	EventFilters   []byte             `json:"event_filters"`
+	ChainOnStatus  pgtype.Text        `json:"chain_on_status"`
 }
 
 func (q *Queries) UpdateAutopilotTrigger(ctx context.Context, arg UpdateAutopilotTriggerParams) (AutopilotTrigger, error) {
@@ -1930,6 +2146,7 @@ func (q *Queries) UpdateAutopilotTrigger(ctx context.Context, arg UpdateAutopilo
 		arg.NextRunAt,
 		arg.Label,
 		arg.EventFilters,
+		arg.ChainOnStatus,
 	)
 	var i AutopilotTrigger
 	err := row.Scan(
@@ -1950,6 +2167,8 @@ func (q *Queries) UpdateAutopilotTrigger(ctx context.Context, arg UpdateAutopilo
 		&i.EventFilters,
 		&i.PublishedByType,
 		&i.PublishedByID,
+		&i.UpstreamAutopilotID,
+		&i.ChainOnStatus,
 	)
 	return i, err
 }

--- a/server/pkg/db/generated/models.go
+++ b/server/pkg/db/generated/models.go
@@ -213,22 +213,24 @@ type AutopilotRuleVersion struct {
 }
 
 type AutopilotRun struct {
-	ID                pgtype.UUID        `json:"id"`
-	AutopilotID       pgtype.UUID        `json:"autopilot_id"`
-	TriggerID         pgtype.UUID        `json:"trigger_id"`
-	Source            string             `json:"source"`
-	Status            string             `json:"status"`
-	IssueID           pgtype.UUID        `json:"issue_id"`
-	TaskID            pgtype.UUID        `json:"task_id"`
-	TriggeredAt       pgtype.Timestamptz `json:"triggered_at"`
-	CompletedAt       pgtype.Timestamptz `json:"completed_at"`
-	FailureReason     pgtype.Text        `json:"failure_reason"`
-	TriggerPayload    []byte             `json:"trigger_payload"`
-	Result            []byte             `json:"result"`
-	CreatedAt         pgtype.Timestamptz `json:"created_at"`
-	SquadID           pgtype.UUID        `json:"squad_id"`
-	PlannedAt         pgtype.Timestamptz `json:"planned_at"`
-	WebhookDeliveryID pgtype.UUID        `json:"webhook_delivery_id"`
+	ID                 pgtype.UUID        `json:"id"`
+	AutopilotID        pgtype.UUID        `json:"autopilot_id"`
+	TriggerID          pgtype.UUID        `json:"trigger_id"`
+	Source             string             `json:"source"`
+	Status             string             `json:"status"`
+	IssueID            pgtype.UUID        `json:"issue_id"`
+	TaskID             pgtype.UUID        `json:"task_id"`
+	TriggeredAt        pgtype.Timestamptz `json:"triggered_at"`
+	CompletedAt        pgtype.Timestamptz `json:"completed_at"`
+	FailureReason      pgtype.Text        `json:"failure_reason"`
+	TriggerPayload     []byte             `json:"trigger_payload"`
+	Result             []byte             `json:"result"`
+	CreatedAt          pgtype.Timestamptz `json:"created_at"`
+	SquadID            pgtype.UUID        `json:"squad_id"`
+	PlannedAt          pgtype.Timestamptz `json:"planned_at"`
+	WebhookDeliveryID  pgtype.UUID        `json:"webhook_delivery_id"`
+	ChainDepth         int32              `json:"chain_depth"`
+	ChainUpstreamRunID pgtype.UUID        `json:"chain_upstream_run_id"`
 }
 
 type AutopilotSubscriber struct {
@@ -257,7 +259,9 @@ type AutopilotTrigger struct {
 	// Actor type of the trigger's current responsible publisher: member | agent. Set to the creator at creation and re-stamped to the editor on any substantive edit governing this trigger. Consumed only for attribution (source=trigger_owner) — never authorization. NULL on pre-migration triggers (MUL-4302).
 	PublishedByType pgtype.Text `json:"published_by_type"`
 	// The member/agent currently responsible for this trigger's effective config (creator, then last substantive editor). For a member this is the accountable human of runs the trigger fires (source=trigger_owner). No FK, app-layer integrity. NULL on pre-migration triggers, which degrade to rule_owner (MUL-4302).
-	PublishedByID pgtype.UUID `json:"published_by_id"`
+	PublishedByID       pgtype.UUID `json:"published_by_id"`
+	UpstreamAutopilotID pgtype.UUID `json:"upstream_autopilot_id"`
+	ChainOnStatus       string      `json:"chain_on_status"`
 }
 
 type ChannelBindingToken struct {

--- a/server/pkg/db/queries/autopilot.sql
+++ b/server/pkg/db/queries/autopilot.sql
@@ -123,13 +123,16 @@ WHERE id = $1;
 INSERT INTO autopilot_trigger (
     autopilot_id, kind, enabled, cron_expression, timezone,
     next_run_at, webhook_token, label, provider, event_filters,
-    published_by_type, published_by_id
+    published_by_type, published_by_id,
+    upstream_autopilot_id, chain_on_status
 ) VALUES (
     $1, $2, $3, sqlc.narg('cron_expression'), sqlc.narg('timezone'),
     sqlc.narg('next_run_at'), sqlc.narg('webhook_token'), sqlc.narg('label'),
     COALESCE(sqlc.narg('provider')::text, 'generic'),
     sqlc.narg('event_filters'),
-    sqlc.narg('published_by_type'), sqlc.narg('published_by_id')
+    sqlc.narg('published_by_type'), sqlc.narg('published_by_id'),
+    sqlc.narg('upstream_autopilot_id'),
+    COALESCE(sqlc.narg('chain_on_status')::text, 'completed')
 ) RETURNING *;
 
 -- name: SetAutopilotTriggerPublisher :exec
@@ -158,12 +161,43 @@ UPDATE autopilot_trigger SET
     next_run_at = sqlc.narg('next_run_at'),
     label = COALESCE(sqlc.narg('label'), label),
     event_filters = COALESCE(sqlc.narg('event_filters'), event_filters),
+    chain_on_status = COALESCE(sqlc.narg('chain_on_status')::text, chain_on_status),
     updated_at = now()
 WHERE id = $1
 RETURNING *;
 
 -- name: DeleteAutopilotTrigger :exec
 DELETE FROM autopilot_trigger WHERE id = $1;
+
+-- ───────────────────────────────────────────────────────────────────────────
+-- Chain triggers (cross-autopilot orchestration, WS-768 / S4)
+-- ───────────────────────────────────────────────────────────────────────────
+
+-- name: ListEnabledChainSuccessors :many
+-- Fan-out query: the enabled chain triggers fired when the autopilot named by
+-- $1 reaches a terminal status. The caller picks the matching edge set by
+-- passing the allowed chain_on_status values explicitly - $2 is the text array
+-- of statuses that match the upstream's terminal status ('completed' upstream
+-- -> {'completed','any'}; 'failed' upstream -> {'failed','any'}). 'skipped'
+-- never matches because it is not passed in. Splitting the match set in the
+-- caller (rather than comparing a status param to a literal in SQL) keeps the
+-- param typed. Ordered by created_at so fan-out is deterministic for tests.
+SELECT * FROM autopilot_trigger
+WHERE kind = 'chain'
+  AND upstream_autopilot_id = $1
+  AND enabled = true
+  AND chain_on_status = ANY(@allowed_statuses::text[])
+ORDER BY created_at ASC;
+
+-- name: ListChainTriggersInWorkspace :many
+-- Every chain edge in a workspace, joined to autopilot for workspace scoping.
+-- Used by the config-time DFS cycle check: the caller builds the directed
+-- graph (upstream_autopilot_id -> autopilot_id) and walks it in Go so the
+-- proposed new edge can be included in the visit set before it is persisted.
+SELECT t.* FROM autopilot_trigger t
+JOIN autopilot a ON a.id = t.autopilot_id
+WHERE a.workspace_id = $1 AND t.kind = 'chain'
+ORDER BY t.created_at ASC;
 
 -- name: AdvanceTriggerNextRun :exec
 UPDATE autopilot_trigger
@@ -248,11 +282,13 @@ RETURNING *;
 -- a second run for the same (trigger_id, planned_at) pair (MUL-3551).
 INSERT INTO autopilot_run (
     autopilot_id, trigger_id, source, status, trigger_payload, squad_id, planned_at,
-    webhook_delivery_id
+    webhook_delivery_id, chain_depth, chain_upstream_run_id
 ) VALUES (
     $1, sqlc.narg('trigger_id'), $2, $3, sqlc.narg('trigger_payload'),
     sqlc.narg('squad_id'), sqlc.narg('planned_at'),
-    sqlc.narg('webhook_delivery_id')
+    sqlc.narg('webhook_delivery_id'),
+    COALESCE(sqlc.narg('chain_depth')::int, 0),
+    sqlc.narg('chain_upstream_run_id')
 ) RETURNING *;
 
 -- name: GetAutopilotRunByTriggerAndPlanned :one
@@ -272,6 +308,18 @@ LIMIT 1;
 -- name: GetAutopilotRunByWebhookDelivery :one
 SELECT * FROM autopilot_run
 WHERE webhook_delivery_id = $1
+LIMIT 1;
+
+-- name: GetAutopilotRunByChainUpstream :one
+-- Idempotent lookup for chain dispatch: if a run already exists for this
+-- (upstream run, chain trigger) pair, the caller reuses it instead of
+-- creating a duplicate. The partial unique index uq_autopilot_run_chain_upstream
+-- (migration 215) covers the same key, so a race between "look up then insert"
+-- still resolves to a single row - this query is the fast path that lets us
+-- skip the INSERT when we can see the prior row clearly. Returns no rows for
+-- the (much more common) first-time chain dispatch.
+SELECT * FROM autopilot_run
+WHERE chain_upstream_run_id = $1 AND trigger_id = $2 AND source = 'chain'
 LIMIT 1;
 
 -- name: RecoverPartialAutopilotRun :exec


### PR DESCRIPTION
## Summary

Implements Stage 4 of WS-719/WS-768: cross-autopilot orchestration via **chain triggers**. When an autopilot run reaches a terminal state, it fans out one downstream run per configured chain edge, with per-edge status filtering, config-time cycle rejection, a runtime depth backstop, and replay-safe idempotency.

- **Migrations 214/215**: `chain` trigger kind; `upstream_autopilot_id` + `chain_on_status` on `autopilot_trigger`; `chain_depth` + `chain_upstream_run_id` on `autopilot_run`; partial unique index on `(chain_upstream_run_id, trigger_id) WHERE source='chain'` as the idempotency anchor (CONCURRENTLY, own file per repo rule).
- **service/autopilot_chain.go**: `dispatchChainSuccessors` hooks at the `completed`/`failed` terminal transitions (after `publishRunDone`); `DispatchAutopilotForChain` (admission gate → idempotent run create → downstream side effect, reusing the shared `dispatchAutopilotRun` path); `DetectChainCycle` (per-workspace DFS, the primary cycle defense); `MaxChainDepth=16` runtime backstop. `skipped` and depth-exceeded runs never fire chain edges — no cascade, no failure-rate auto-pause trip.
- **handler**: `kind=chain` create/update with same-workspace upstream validation + config-time cycle rejection; chain fields on request/response.
- **CLI**: `trigger-add --kind chain --upstream <id> --on-status <completed|failed|any>`; `trigger-update --on-status`.

### Failure semantics
`chain_on_status` per edge: `completed` (success chain), `failed` (error-handler chain), `any` (both). A `completed` upstream fires `completed`+`any` edges; a `failed` upstream fires `failed`+`any` edges; a `skipped` run (admission cap, depth cap) fires nothing.

### Stage 2 interaction
Stage 2 (`max_concurrent_runs`) is not on `main` yet. Chain dispatch funnels through the same `dispatchAutopilotRun` path as schedule/webhook/api, so the concurrency cap applies naturally when it lands; a capped chain dispatch records a `skipped` run that fires no further edges.

## Test plan
- [x] `go build ./...`, `gofmt` clean, `go vet` on touched packages clean
- [x] Pure unit tests: `chainEdgeStatuses`, `chainUpstreamStatuses` gate, `buildChainPayload` (+ empty-result)
- [x] DB-backed: `TestDetectChainCycle` (cycle / no-cycle / self-edge / empty graph), `TestChainRunIdempotencyIndex` (23505 on duplicate anchor; non-chain + different-upstream allowed) — run against a clean 215-migration schema
- [x] Handler: accept chain w/ upstream, reject w/o upstream, reject self-edge, reject cycle (end-to-end DFS through handler), update `chain_on_status`
- [x] `internal/service` + `internal/handler` full suites green
- [ ] CI (pgvector pg17)

Local CLI (`cmd/multica`) tests are blocked by the agent-runtime `daemon_task_context.json` marker in this worktree (environmental, not from this change); the CLI compiles, vets, and its API surface is covered by the handler tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)