### PR TITLE
test(issues): stabilize table-view editor test against CI CPU starvation (MUL-5326)

### DIFF
--- a/packages/views/issues/components/table-view-editing.test.tsx
+++ b/packages/views/issues/components/table-view-editing.test.tsx
@@ -237,10 +237,16 @@ describe("TableView cell editors under data refresh", () => {
   });
 
   // Explicit timeout: this mounts the full TableView with every picker + a
-  // QueryClient, so it is heavier than a unit test. `delay: null` drives
-  // userEvent off fake-synchronous timing instead of the default real-timer
-  // gaps between events, which were what let the whole gesture blow past the
-  // 5s default under concurrent CI worker load (MUL-5108 review R1#1).
+  // QueryClient and drives three realistic userEvent click gestures, each
+  // re-rendering the whole table — far heavier than a unit test. `delay: null`
+  // strips the default real-timer gaps between events (MUL-5108 review R1#1).
+  // Even so, the frontend CI job runs the entire `turbo build typecheck lint
+  // test` pipeline on a 2-core runner, so builds/lints/typechecks and 258
+  // vitest files all oversubscribe both cores at once; at the worst-case
+  // scheduling peak this test's wall clock blew past the earlier 20s cap
+  // (MUL-5326). It runs in ~1s in isolation, so the generous 60s ceiling
+  // (matching the repo's heaviest FE tests) only absorbs CI CPU starvation —
+  // it never masks a real hang.
   it("keeps the status picker open and the row order frozen across a refresh, then catches up on close", async () => {
     const user = userEvent.setup({ delay: null, pointerEventsCheck: 0 });
     const issueA = makeIssue("a", "Alpha task", "todo");
@@ -311,7 +317,7 @@ describe("TableView cell editors under data refresh", () => {
     await user.click(screen.getByRole("button", { name: /Backlog/ }));
     expect(screen.queryByRole("button", { name: /Backlog/ })).toBeNull();
     expect(identifiers()).toEqual(["MUL-b", "MUL-a"]);
-  }, 20_000);
+  }, 60_000);
 
   it("opens creation with the row as parent and inherits its project", async () => {
     const user = userEvent.setup({ delay: null, pointerEventsCheck: 0 });


### PR DESCRIPTION
## Summary

`main`'s frontend CI was red. The failing job was `frontend` → `Build, type check, lint, and test`, and the single failure was a **20s wall-clock timeout** in:

```
packages/views/issues/components/table-view-editing.test.tsx:244
TableView cell editors under data refresh
  > keeps the status picker open and the row order frozen across a refresh, then catches up on close
Error: Test timed out in 20000ms.
```

(Run: [#5946 on main](https://github.com/multica-ai/multica/actions/runs/30215546163) — `2983 passed | 1 failed`.)

## Root cause

This is CPU-starvation flakiness, not a regression:

- The test is **correct** — it passes reliably in isolation (~0.9s) and even under 2.2× CPU oversubscription (whole file ~2.6s).
- The `frontend` job runs the entire `turbo build typecheck lint test` pipeline on a **2-core `ubuntu-latest` runner**. Builds, lints, typechecks and 258 vitest files across 7 packages all oversubscribe both cores at once. `test` only depends on `^typecheck`, so nothing serializes it against the heavy Next.js/desktop builds.
- This test is uniquely heavy: it mounts the full `TableView` with every picker + a `QueryClient` and drives three realistic `userEvent` click gestures, each re-rendering the whole table. At the worst-case scheduling peak its wall clock crossed the 20s cap that MUL-5108 had already bumped it to (from the 5s default).
- The commit that surfaced the red run (#5946, presign desktop inline media) is unrelated to table-view editing.

## Change

Raise this one test's explicit timeout `20_000` → `60_000`, matching the repo's existing ceiling for heavy FE tests (`apps/web/app/brand-variant-cascade.test.ts` already uses `60_000`), and refresh the explanatory comment. It runs in ~1s locally, so the 60s ceiling only absorbs CI CPU starvation and never masks a real hang. No product/component code changes.

## Verification

- `pnpm exec vitest run issues/components/table-view-editing.test.tsx` → 7/7 pass.
- Full package suite `pnpm --filter @multica/views run test` → **258 files / 2984 tests pass**.
- `eslint` on the changed file → clean.

MUL-5326
