### PR TITLE
MUL-5336: feat(agent): Kimi model listing, thinking effort and usage reporting

### DIFF
--- a/e2e/agent-thinking-kimi.spec.ts
+++ b/e2e/agent-thinking-kimi.spec.ts
@@ -1,0 +1,241 @@
+import { test, expect, type Page } from "@playwright/test";
+import { TestApiClient } from "./fixtures";
+import { waitForPageText } from "./helpers";
+
+// M-96: kimi thinking-effort (thought_level) selection reuses the existing
+// provider-generic Thinking picker — no frontend changes were made for this
+// feature, on the assumption that `ThinkingPropRow`/`ThinkingPicker` already
+// render off `model.thinking.supported_levels` with no provider allowlist
+// (see thinking-picker.tsx's own comment: "Claude, Codex, and OpenCode
+// today", which is the exact claim this spec checks against a live UI for a
+// provider that isn't in that list).
+//
+// Auth + workspace bootstrap go through the real backend. The runtime,
+// agent, and model-discovery endpoints are mocked at the network boundary
+// (same approach as agent-mcp.spec.ts) so the test runs without a live kimi
+// CLI/daemon bound to this workspace. PUT /api/agents write is intercepted
+// so we assert the exact `thinking_level` the picker sends, rather than
+// depending on a mocked GET reflecting persisted state after invalidation.
+
+const E2E_WORKER =
+  process.env.TEST_PARALLEL_INDEX ?? process.env.TEST_WORKER_INDEX ?? "0";
+const E2E_RUN_ID =
+  process.env.E2E_RUN_ID ?? `${Date.now().toString(36)}-${process.pid.toString(36)}`;
+const EMAIL = `e2e-kimi-thinking-${E2E_WORKER}-${E2E_RUN_ID}@multica.ai`;
+const NAME = "E2E Kimi Thinking User";
+
+const AGENT_ID = "33333333-3333-4333-8333-333333333333";
+const RUNTIME_ID = "44444444-4444-4444-8444-444444444444";
+
+interface SetupResult {
+  slug: string;
+  userId: string;
+}
+
+/** Log in via the real API, capture the authed user id, inject the token,
+ * and return the workspace slug + user id so the mocked agent can be owned
+ * by the current user (required for the inspector's edit-permission gate). */
+async function loginCapturingUser(page: Page): Promise<SetupResult> {
+  const api = new TestApiClient();
+  const data = await api.login(EMAIL, NAME);
+  const userId: string | undefined = data?.user?.id;
+  if (!userId) throw new Error("login did not return a user id");
+  const workspace = await api.ensureWorkspace(
+    `E2E Kimi Thinking WS ${E2E_WORKER}`,
+    `e2e-kimi-thinking-${E2E_WORKER}`,
+  );
+  const token = api.getToken();
+  if (!token) throw new Error("login did not return a token");
+  await page.addInitScript((t) => {
+    localStorage.setItem("multica_token", t);
+    localStorage.setItem("multica:chat:isOpen", "false");
+  }, token);
+  return { slug: workspace.slug, userId };
+}
+
+function mockAgent(ownerId: string, workspaceId: string, thinkingLevel: string) {
+  return {
+    id: AGENT_ID,
+    workspace_id: workspaceId,
+    runtime_id: RUNTIME_ID,
+    name: "Kimi Thinking Test Agent",
+    description: "",
+    instructions: "",
+    avatar_url: null,
+    runtime_mode: "local",
+    runtime_config: {},
+    custom_args: [],
+    visibility: "workspace",
+    status: "idle",
+    max_concurrent_tasks: 1,
+    model: "k3",
+    thinking_level: thinkingLevel,
+    owner_id: ownerId,
+    skills: [],
+    created_at: "2026-07-20T00:00:00Z",
+    updated_at: "2026-07-20T00:00:00Z",
+    archived_at: null,
+    archived_by: null,
+  };
+}
+
+function mockRuntime(ownerId: string, workspaceId: string) {
+  return {
+    id: RUNTIME_ID,
+    workspace_id: workspaceId,
+    daemon_id: "daemon-1",
+    name: "Kimi Runtime",
+    runtime_mode: "local",
+    provider: "kimi",
+    launch_header: "kimi",
+    status: "online",
+    device_info: "e2e",
+    metadata: {},
+    owner_id: ownerId,
+    visibility: "private",
+    last_seen_at: "2026-07-22T00:00:00Z",
+    created_at: "2026-07-20T00:00:00Z",
+  };
+}
+
+/** Mock the runtime list, agent list/write, and model-discovery endpoints
+ * for a single kimi runtime/agent pair. `thinkingLevels` is the discovered
+ * `thought_level` catalog attached to the `k3` model. Returns a getter for
+ * the last `thinking_level` sent in a PUT /api/agents/<id> body. */
+async function mockApis(
+  page: Page,
+  ownerId: string,
+  thinkingLevels: { value: string; label: string }[],
+) {
+  const captured: { thinkingLevel?: string } = {};
+
+  await page.route("**/api/runtimes**", (route) => {
+    const req = route.request();
+    if (req.method() !== "GET") return route.fallback();
+    const url = new URL(req.url());
+    const workspaceId = url.searchParams.get("workspace_id") ?? "ws-mock";
+    return route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify([mockRuntime(ownerId, workspaceId)]),
+    });
+  });
+
+  await page.route(`**/api/runtimes/${RUNTIME_ID}/models`, (route) => {
+    const req = route.request();
+    if (req.method() !== "POST") return route.fallback();
+    return route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        id: "models-req-1",
+        runtime_id: RUNTIME_ID,
+        status: "completed",
+        supported: true,
+        models: [
+          {
+            id: "k3",
+            label: "k3",
+            default: true,
+            thinking:
+              thinkingLevels.length > 0
+                ? { supported_levels: thinkingLevels, default_level: "on" }
+                : undefined,
+          },
+        ],
+        created_at: "2026-07-22T00:00:00Z",
+        updated_at: "2026-07-22T00:00:00Z",
+      }),
+    });
+  });
+
+  await page.route("**/api/agents**", (route) => {
+    const req = route.request();
+    const url = new URL(req.url());
+    const workspaceId = url.searchParams.get("workspace_id") ?? "ws-mock";
+
+    if (req.method() === "PUT" && url.pathname.endsWith(`/api/agents/${AGENT_ID}`)) {
+      const body = req.postDataJSON?.() ?? {};
+      captured.thinkingLevel = body.thinking_level;
+      return route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          ...mockAgent(ownerId, workspaceId, body.thinking_level ?? ""),
+        }),
+      });
+    }
+
+    if (req.method() === "GET" && url.pathname.endsWith("/api/agents")) {
+      return route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify([mockAgent(ownerId, workspaceId, "")]),
+      });
+    }
+
+    return route.fallback();
+  });
+
+  return () => captured.thinkingLevel;
+}
+
+test.describe("Kimi thinking-effort picker (M-96)", () => {
+  test("kimi agent's Thinking picker offers the discovered thought_level catalog and persists a pick", async ({
+    page,
+  }) => {
+    const { slug, userId } = await loginCapturingUser(page);
+    const getThinkingLevel = await mockApis(page, userId, [
+      { value: "on", label: "Thinking On" },
+      { value: "max", label: "Max" },
+    ]);
+
+    await page.goto(`/${slug}/agents/${AGENT_ID}?view=general`, {
+      waitUntil: "domcontentloaded",
+    });
+    await waitForPageText(page, "Kimi Thinking Test Agent");
+
+    // Not hidden and not stuck on a hardcoded provider allowlist: kimi
+    // reaches the same row Claude/Codex/OpenCode use, with no value
+    // persisted yet, so it starts on the "no override" sentinel.
+    const trigger = page.getByRole("button", { name: /Thinking/i }).last();
+    await expect(trigger).toBeVisible({ timeout: 15000 });
+    await expect(trigger).toContainText("Follow CLI config");
+
+    await trigger.click();
+    await page.getByText("Max", { exact: true }).click();
+
+    // PUT body carries exactly the value the user picked — never
+    // normalised across providers.
+    await expect.poll(() => getThinkingLevel()).toBe("max");
+    await expect(trigger).toContainText("Max");
+  });
+
+  test("kimi model advertising a single thought_level option still renders a usable picker", async ({
+    page,
+  }) => {
+    // Regression guard for the real discovery fixture (kimi 0.27.0):
+    // session/new's configOptions carries exactly one option
+    // (`{"value":"on"}`) for this model. The row must not require 2+
+    // options to show — unlike codex's empty-model preview, which is
+    // hidden by design (see pickModelEntry in thinking-prop-row.tsx),
+    // a real single-option catalog is a legitimate, pickable state.
+    const { slug, userId } = await loginCapturingUser(page);
+    const getThinkingLevel = await mockApis(page, userId, [
+      { value: "on", label: "Thinking On" },
+    ]);
+
+    await page.goto(`/${slug}/agents/${AGENT_ID}?view=general`, {
+      waitUntil: "domcontentloaded",
+    });
+    await waitForPageText(page, "Kimi Thinking Test Agent");
+
+    const trigger = page.getByRole("button", { name: /Thinking/i }).last();
+    await expect(trigger).toBeVisible({ timeout: 15000 });
+
+    await trigger.click();
+    await page.getByText("Thinking On", { exact: true }).click();
+
+    await expect.poll(() => getThinkingLevel()).toBe("on");
+  });
+});

--- a/packages/core/types/agent.ts
+++ b/packages/core/types/agent.ts
@@ -960,7 +960,7 @@ export interface RuntimeModel {
   default?: boolean;
   /**
    * Per-model reasoning/effort catalog discovered by the daemon. Currently
-   * populated for claude, codex, and opencode runtimes; omitted (or undefined)
+   * populated for claude, codex, opencode, and kimi runtimes; omitted (or undefined)
    * for every other provider, which the UI treats as "no thinking-level
    * picker for this model". See MUL-2339.
    */

--- a/packages/views/agents/components/inspector/thinking-picker.tsx
+++ b/packages/views/agents/components/inspector/thinking-picker.tsx
@@ -14,7 +14,7 @@ import { useT } from "../../../i18n";
 /**
  * Per-agent reasoning/effort picker (MUL-2339). Renders only when the
  * current model exposes a non-empty `supported_levels` set — Claude, Codex,
- * and OpenCode today; every other provider gets nothing. The catalog is daemon-
+ * OpenCode, and Kimi today; every other provider gets nothing. The catalog is daemon-
  * discovered, so the value/label pairs match each CLI's own UI (`Low`,
  * `Extra high`, …) verbatim; never normalised across providers.
  *

--- a/server/pkg/agent/agent.go
+++ b/server/pkg/agent/agent.go
@@ -60,8 +60,9 @@ type ExecOptions struct {
 	// "use the runtime/model default" —
 	// every backend that consumes this skips its --effort / reasoning_effort
 	// injection so the upstream CLI's own default applies. Currently honoured
-	// by the claude, codex, opencode, codebuddy, and grok (ACP
-	// `--effort` on `grok agent`) backends; other backends ignore
+	// by the claude, codex, opencode, codebuddy, grok (ACP
+	// `--effort` on `grok agent`), and kimi (ACP
+	// `session/set_config_option`) backends; other backends ignore
 	// the field rather than fail (so MUL-2339 can grow runtime support
 	// incrementally without breaking unrelated agents).
 	ThinkingLevel string

--- a/server/pkg/agent/kimi.go
+++ b/server/pkg/agent/kimi.go
@@ -313,6 +313,39 @@ func (b *kimiBackend) Execute(ctx context.Context, prompt string, opts ExecOptio
 			b.cfg.Logger.Info("kimi session model set", "model", opts.Model)
 		}
 
+		// 3b. If the caller picked a thinking level, ask kimi to set it
+		// via session/set_config_option before the prompt. The runtime
+		// advertises the control as the configOptions select with
+		// category "thought_level" and id "thinking". Like set_model,
+		// this fails the task on error so a persisted thinking_level
+		// that the runtime rejects doesn't silently fall back.
+		if opts.ThinkingLevel != "" {
+			if _, err := c.request(runCtx, "session/set_config_option", map[string]any{
+				"sessionId": sessionID,
+				"configId":  "thinking",
+				"value":     opts.ThinkingLevel,
+			}); err != nil {
+				b.cfg.Logger.Warn("kimi set_config_option/thinking failed", "error", err, "requested_level", opts.ThinkingLevel)
+				finalStatus = "failed"
+				finalError = fmt.Sprintf("kimi could not set thinking level %q: %v", opts.ThinkingLevel, err)
+				if opts.ResumeSessionID != "" && isACPSessionNotFound(err) {
+					b.cfg.Logger.Warn("resumed session not found at set_config_option time; clearing session id so the daemon retries fresh",
+						"backend", "kimi",
+						"session_id", sessionID,
+					)
+					sessionID = ""
+				}
+				resCh <- Result{
+					Status:     finalStatus,
+					Error:      finalError,
+					DurationMs: time.Since(startTime).Milliseconds(),
+					SessionID:  sessionID,
+				}
+				return
+			}
+			b.cfg.Logger.Info("kimi session thinking level set", "level", opts.ThinkingLevel)
+		}
+
 		// 4. Build the prompt content. If we have a system prompt, prepend it.
 		userText := prompt
 		if opts.SystemPrompt != "" {

--- a/server/pkg/agent/kimi.go
+++ b/server/pkg/agent/kimi.go
@@ -2,10 +2,15 @@ package agent
 
 import (
 	"bufio"
+	"bytes"
 	"context"
+	"encoding/json"
 	"fmt"
 	"io"
+	"log/slog"
+	"os"
 	"os/exec"
+	"path/filepath"
 	"strings"
 	"sync"
 	"time"
@@ -183,6 +188,9 @@ func (b *kimiBackend) Execute(ctx context.Context, prompt string, opts ExecOptio
 		// resume. Only that is curable by starting a fresh session, so
 		// handshake/network failures below must leave it false.
 		var resumeRejected bool
+		// Per-model usage recovered from kimi's on-disk session wire
+		// when the ACP stream carries none (always, on kimi ≤ 0.27).
+		var wireUsage map[string]TokenUsage
 
 		// 1. Initialize handshake.
 		initResult, err := c.request(runCtx, "initialize", map[string]any{
@@ -353,6 +361,20 @@ func (b *kimiBackend) Execute(ctx context.Context, prompt string, opts ExecOptio
 				c.usageMu.Unlock()
 			default:
 			}
+
+			// Kimi answers session/prompt *before* flushing the turn's
+			// usage.record to the session wire, and the teardown below
+			// SIGKILLs the process — without this pause the record is
+			// lost and the run reports no usage. Poll briefly while the
+			// process is still alive, but only when the ACP stream
+			// itself carried no usage (kimi ≤ 0.27 never sends any).
+			c.usageMu.Lock()
+			acpUsageEmpty := c.usage.InputTokens == 0 && c.usage.OutputTokens == 0 &&
+				c.usage.CacheReadTokens == 0 && c.usage.CacheWriteTokens == 0
+			c.usageMu.Unlock()
+			if acpUsageEmpty && sessionID != "" && finalStatus == "completed" {
+				wireUsage = waitKimiWireUsage(sessionID, startTime, b.cfg.Logger)
+			}
 		}
 
 		duration := time.Since(startTime)
@@ -389,6 +411,15 @@ func (b *kimiBackend) Execute(ctx context.Context, prompt string, opts ExecOptio
 				model = "unknown"
 			}
 			usageMap = map[string]TokenUsage{model: u}
+		} else {
+			// Kimi (verified on 0.27.0) reports no usage over ACP at
+			// all: session/prompt returns only stopReason and no
+			// usage_update notifications flow. The per-turn usage lands
+			// in the session's wire.jsonl instead, recovered above so
+			// the run report carries the real model id and token counts
+			// (and therefore cost). Nil when nothing usable was found —
+			// the run then reports no usage, matching prior behavior.
+			usageMap = wireUsage
 		}
 
 		resCh <- Result{
@@ -450,4 +481,121 @@ func kimiToolNameFromTitle(title string) string {
 
 	// Fallback: snake_case the title so the UI gets a stable identifier.
 	return strings.ReplaceAll(lower, " ", "_")
+}
+
+// kimiWireUsageGrace absorbs clock granularity between the daemon's run
+// start and kimi's record timestamps (same host, same clock). It stays
+// far below the age of any previous task's records on a resumed session.
+const kimiWireUsageGrace = 5 * time.Second
+
+// kimiWireUsagePoll bounds the post-prompt wait for kimi to flush the
+// turn's usage.record to the session wire. Kimi answers session/prompt
+// before the record hits disk; without a brief poll the teardown SIGKILL
+// lands first and usage is lost. Typical flush is well under a second.
+const (
+	kimiWireUsagePollTimeout  = 2 * time.Second
+	kimiWireUsagePollInterval = 100 * time.Millisecond
+)
+
+// waitKimiWireUsage polls readKimiWireUsage until the turn's usage
+// record appears on disk or the poll budget runs out (nil).
+func waitKimiWireUsage(sessionID string, since time.Time, logger *slog.Logger) map[string]TokenUsage {
+	deadline := time.Now().Add(kimiWireUsagePollTimeout)
+	for {
+		if usage := readKimiWireUsage(sessionID, since, logger); usage != nil {
+			return usage
+		}
+		if time.Now().After(deadline) {
+			return nil
+		}
+		time.Sleep(kimiWireUsagePollInterval)
+	}
+}
+
+// readKimiWireUsage recovers per-model token usage from kimi's on-disk
+// session wire (<KIMI_CODE_HOME|~/.kimi-code>/sessions/<cwd-hash>/<sessionID>/agents/*/wire.jsonl).
+// Kimi appends one record per turn:
+//
+//	{"type":"usage.record","model":"kimi-code/k3","usageScope":"turn",
+//	 "usage":{"inputOther":1884,"output":35,"inputCacheRead":19200,"inputCacheCreation":0},
+//	 "time":1784398522242}
+//
+// Only records at or after `since` count: a resumed session's wire
+// accumulates every past turn, and re-summing history would double-report
+// tokens already billed to earlier tasks. Records are summed per model so
+// multi-model runs attribute correctly. The KIMI_CODE_HOME lookup uses the
+// daemon process env, which is what the child inherits in the common case.
+// Returns nil when nothing usable is found — the caller then reports no
+// usage, matching the pre-recovery behavior.
+func readKimiWireUsage(sessionID string, since time.Time, logger *slog.Logger) map[string]TokenUsage {
+	home := os.Getenv("KIMI_CODE_HOME")
+	if home == "" {
+		if h, err := os.UserHomeDir(); err == nil {
+			home = filepath.Join(h, ".kimi-code")
+		}
+	}
+	if home == "" {
+		return nil
+	}
+	files, err := filepath.Glob(filepath.Join(home, "sessions", "*", sessionID, "agents", "*", "wire.jsonl"))
+	if err != nil || len(files) == 0 {
+		return nil
+	}
+	cutoff := since.Add(-kimiWireUsageGrace).UnixMilli()
+	totals := map[string]TokenUsage{}
+	for _, f := range files {
+		if err := accumulateKimiWireFile(f, cutoff, totals); err != nil {
+			logger.Debug("kimi wire usage read failed", "file", f, "error", err)
+		}
+	}
+	if len(totals) == 0 {
+		return nil
+	}
+	return totals
+}
+
+// accumulateKimiWireFile sums usage.record entries newer than cutoffMs
+// into totals, keyed by the record's model id. Malformed lines are
+// skipped — the wire is an append-only log best read leniently.
+func accumulateKimiWireFile(path string, cutoffMs int64, totals map[string]TokenUsage) error {
+	fh, err := os.Open(path)
+	if err != nil {
+		return err
+	}
+	defer fh.Close()
+	scanner := bufio.NewScanner(fh)
+	scanner.Buffer(make([]byte, 0, 256*1024), 4*1024*1024)
+	for scanner.Scan() {
+		line := scanner.Bytes()
+		// Cheap pre-filter: almost no wire line is a usage record, and
+		// lines carrying tool output can be large.
+		if !bytes.Contains(line, []byte(`"usage.record"`)) {
+			continue
+		}
+		var rec struct {
+			Type  string `json:"type"`
+			Model string `json:"model"`
+			Usage struct {
+				InputOther         int64 `json:"inputOther"`
+				Output             int64 `json:"output"`
+				InputCacheRead     int64 `json:"inputCacheRead"`
+				InputCacheCreation int64 `json:"inputCacheCreation"`
+			} `json:"usage"`
+			Time int64 `json:"time"` // epoch ms
+		}
+		if err := json.Unmarshal(line, &rec); err != nil || rec.Type != "usage.record" {
+			continue
+		}
+		model := strings.TrimSpace(rec.Model)
+		if model == "" || rec.Time < cutoffMs {
+			continue
+		}
+		u := totals[model]
+		u.InputTokens += rec.Usage.InputOther
+		u.OutputTokens += rec.Usage.Output
+		u.CacheReadTokens += rec.Usage.InputCacheRead
+		u.CacheWriteTokens += rec.Usage.InputCacheCreation
+		totals[model] = u
+	}
+	return scanner.Err()
 }

--- a/server/pkg/agent/kimi.go
+++ b/server/pkg/agent/kimi.go
@@ -12,6 +12,8 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"regexp"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -436,6 +438,32 @@ func (b *kimiBackend) Execute(ctx context.Context, prompt string, opts ExecOptio
 			}
 		}
 
+		// Kimi answers session/prompt with stopReason=end_turn even when
+		// the turn died provider-side (upstream kimi bug; the failure is
+		// only recorded in the session's logs/kimi-code.log). A
+		// "completed" run with no output AND no usage.record for the turn
+		// is therefore not a valid empty completion: cross-check the
+		// session log for an in-window turn failure and fail loudly with
+		// the real provider error instead of reporting a silent success.
+		// The session id is dropped as well — a failed turn can leave the
+		// context corrupt (empty assistant message) and brick every
+		// follow-up resume, so the empty SessionID routes the daemon's
+		// resume-failure fallback to a fresh session. Healthy empty
+		// completions flushed a usage.record and never reach this check.
+		if finalStatus == "completed" && finalOutput == "" && sessionID != "" &&
+			u.InputTokens == 0 && u.OutputTokens == 0 && u.CacheReadTokens == 0 && u.CacheWriteTokens == 0 &&
+			wireUsage == nil {
+			if failMsg, failed := readKimiTurnFailure(sessionID, startTime, b.cfg.Logger); failed {
+				b.cfg.Logger.Warn("kimi turn failed provider-side behind end_turn; failing the run and dropping the poisoned session",
+					"session_id", sessionID,
+					"error", failMsg,
+				)
+				finalStatus = "failed"
+				finalError = failMsg
+				sessionID = ""
+			}
+		}
+
 		resCh <- Result{
 			Status:         finalStatus,
 			Output:         finalOutput,
@@ -561,12 +589,7 @@ func waitKimiWireUsage(sessionID string, since time.Time, logger *slog.Logger) m
 // nothing usable is found — the caller then reports no usage, matching
 // the pre-recovery behavior.
 func readKimiWireUsage(sessionID string, since time.Time, logger *slog.Logger) (map[string]TokenUsage, bool) {
-	home := os.Getenv("KIMI_CODE_HOME")
-	if home == "" {
-		if h, err := os.UserHomeDir(); err == nil {
-			home = filepath.Join(h, ".kimi-code")
-		}
-	}
+	home := kimiCodeHome()
 	if home == "" {
 		return nil, false
 	}
@@ -648,4 +671,169 @@ func accumulateKimiWireLine(line []byte, cutoffMs int64, totals map[string]Token
 	u.CacheReadTokens += rec.Usage.InputCacheRead
 	u.CacheWriteTokens += rec.Usage.InputCacheCreation
 	totals[model] = u
+}
+
+// kimiCodeHome returns kimi-cli's data dir: $KIMI_CODE_HOME when set,
+// else ~/.kimi-code. The KIMI_CODE_HOME lookup uses the daemon process
+// env, which is what the child inherits in the common case.
+func kimiCodeHome() string {
+	if home := os.Getenv("KIMI_CODE_HOME"); home != "" {
+		return home
+	}
+	if h, err := os.UserHomeDir(); err == nil {
+		return filepath.Join(h, ".kimi-code")
+	}
+	return ""
+}
+
+// Markers recorded in the session's logs/kimi-code.log when a turn dies
+// provider-side while ACP still reports stopReason=end_turn (upstream
+// kimi bug; see M-95). The ERROR line marks the failure, the WARN line
+// carries the provider error payload:
+//
+//	2026-07-19T15:03:24.931Z ERROR turn failed  turnId=1
+//	2026-07-19T15:03:24.933Z WARN  acp: turn ended with failed reason  error="{...}"
+const (
+	kimiTurnFailedMarker       = "turn failed"
+	kimiTurnFailedDetailMarker = "acp: turn ended with failed reason"
+)
+
+// kimiTurnFailedErrorRe extracts the slog-style quoted error attribute
+// from the detail line: `error="{\"code\":\"provider.api_error\",...}"`.
+var kimiTurnFailedErrorRe = regexp.MustCompile(`\berror="((?:[^"\\]|\\.)*)"`)
+
+// readKimiTurnFailure cross-checks the session's logs/kimi-code.log (same
+// directory layout as the wire: sessions/<cwd-hash>/<sessionID>/logs/) for
+// a turn failure recorded at or after `since`, returning a message that
+// surfaces the provider error. It exists because kimi reports failed
+// turns over ACP as stopReason=end_turn with no output, so the session
+// log is the only place the failure — and its cause — is visible.
+//
+// Only entries newer than `since` (minus kimiWireUsageGrace, same host
+// clock) count: the log accumulates every past turn on a resumed session,
+// and a failure from a previous run must not flag the current one. Lines
+// whose timestamp can't be parsed are skipped for the same reason.
+// Returns ("", false) when no log exists at all (older kimi builds,
+// custom data dir) — no signal, never a false positive.
+func readKimiTurnFailure(sessionID string, since time.Time, logger *slog.Logger) (string, bool) {
+	home := kimiCodeHome()
+	if home == "" {
+		return "", false
+	}
+	files, err := filepath.Glob(filepath.Join(home, "sessions", "*", sessionID, "logs", "kimi-code.log"))
+	if err != nil || len(files) == 0 {
+		return "", false
+	}
+	cutoff := since.Add(-kimiWireUsageGrace)
+	failed := false
+	detail := ""
+	for _, f := range files {
+		fileDetail, fileFailed, err := scanKimiTurnFailureLog(f, cutoff)
+		if err != nil {
+			logger.Debug("kimi turn-failure log read failed", "file", f, "error", err)
+			continue
+		}
+		if fileFailed {
+			failed = true
+			if fileDetail != "" {
+				detail = fileDetail
+			}
+		}
+	}
+	if !failed {
+		return "", false
+	}
+	const prefix = "kimi turn failed provider-side (acp reported end_turn)"
+	if detail == "" {
+		return prefix + "; see the session's logs/kimi-code.log", true
+	}
+	return prefix + ": " + detail, true
+}
+
+// scanKimiTurnFailureLog reads one kimi-code.log and reports whether it
+// holds an in-window turn failure, plus the extracted provider error
+// detail from the most recent matching WARN line ("" when only the bare
+// ERROR marker matched). Like the wire, the log is an append-only file
+// best read leniently, with an unbounded reader so an oversized line
+// can't hide failure entries appended after it.
+func scanKimiTurnFailureLog(path string, cutoff time.Time) (string, bool, error) {
+	fh, err := os.Open(path)
+	if err != nil {
+		return "", false, err
+	}
+	defer func() { _ = fh.Close() }()
+	found := false
+	detail := ""
+	r := bufio.NewReader(fh)
+	for {
+		line, err := r.ReadBytes('\n')
+		if len(line) > 0 {
+			if d, ok := parseKimiTurnFailureLine(line, cutoff); ok {
+				found = true
+				if d != "" {
+					detail = d
+				}
+			}
+		}
+		if err != nil {
+			if err == io.EOF {
+				break
+			}
+			return detail, found, err
+		}
+	}
+	return detail, found, nil
+}
+
+// parseKimiTurnFailureLine reports whether one kimi-code.log line records
+// a turn failure at or after cutoff. Lines are Go-slog text
+// ("<rfc3339> <LEVEL> <msg> key=value …"); the leading timestamp decides
+// whether the entry belongs to the current run.
+func parseKimiTurnFailureLine(line []byte, cutoff time.Time) (string, bool) {
+	if !bytes.Contains(line, []byte(kimiTurnFailedMarker)) &&
+		!bytes.Contains(line, []byte(kimiTurnFailedDetailMarker)) {
+		return "", false
+	}
+	sp := bytes.IndexByte(line, ' ')
+	if sp <= 0 {
+		return "", false
+	}
+	ts, err := time.Parse(time.RFC3339Nano, string(line[:sp]))
+	if err != nil || ts.Before(cutoff) {
+		return "", false
+	}
+	if !bytes.Contains(line, []byte(kimiTurnFailedDetailMarker)) {
+		// Bare ERROR marker; the paired WARN detail line carries the cause.
+		return "", true
+	}
+	return extractKimiTurnFailureDetail(line), true
+}
+
+// extractKimiTurnFailureDetail pulls the provider error out of the WARN
+// detail line's error attribute — a quoted JSON payload such as
+// {"code":"provider.api_error","message":"400 the message at position 168
+// ..."}. Returns "code: message" (or just the message), "" when the
+// attribute is missing or malformed.
+func extractKimiTurnFailureDetail(line []byte) string {
+	m := kimiTurnFailedErrorRe.FindSubmatch(line)
+	if m == nil {
+		return ""
+	}
+	raw, err := strconv.Unquote(`"` + string(m[1]) + `"`)
+	if err != nil {
+		return ""
+	}
+	var payload struct {
+		Code    string `json:"code"`
+		Message string `json:"message"`
+	}
+	if err := json.Unmarshal([]byte(raw), &payload); err != nil {
+		return ""
+	}
+	switch {
+	case payload.Code != "" && payload.Message != "":
+		return payload.Code + ": " + payload.Message
+	default:
+		return payload.Message
+	}
 }

--- a/server/pkg/agent/kimi.go
+++ b/server/pkg/agent/kimi.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
+	"maps"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -417,9 +418,22 @@ func (b *kimiBackend) Execute(ctx context.Context, prompt string, opts ExecOptio
 			// usage_update notifications flow. The per-turn usage lands
 			// in the session's wire.jsonl instead, recovered above so
 			// the run report carries the real model id and token counts
-			// (and therefore cost). Nil when nothing usable was found —
-			// the run then reports no usage, matching prior behavior.
+			// (and therefore cost).
 			usageMap = wireUsage
+			if usageMap == nil && sessionID != "" && finalStatus != "completed" {
+				// Failed/aborted/timeout runs skipped the polling wait
+				// above (only worthwhile on the completed path, where a
+				// flush is imminent). By now the process is dead and the
+				// wire holds whatever it will hold, so a single
+				// non-polling read recovers the partial turn's usage
+				// with no added latency. The daemon bills usage even
+				// for cancelled tasks (see the ReportTaskUsage comment
+				// in server/internal/daemon/daemon.go), so the report
+				// should carry what the run consumed. Still nil when
+				// nothing usable was found — the run then reports no
+				// usage, matching prior behavior.
+				usageMap, _ = readKimiWireUsage(sessionID, startTime, b.cfg.Logger)
+			}
 		}
 
 		resCh <- Result{
@@ -498,18 +512,34 @@ const (
 )
 
 // waitKimiWireUsage polls readKimiWireUsage until the turn's usage
-// record appears on disk or the poll budget runs out (nil).
+// totals settle — non-empty and unchanged across one more poll interval —
+// or the poll budget runs out, in which case the latest read wins (nil
+// when nothing was ever found).
 func waitKimiWireUsage(sessionID string, since time.Time, logger *slog.Logger) map[string]TokenUsage {
+	// Fast path: kimi creates the session wire at session start, long
+	// before this post-prompt poll. A first probe matching no wire file
+	// at all therefore means this build writes none (older CLI, custom
+	// data dir) — bail now instead of burning the whole budget per run.
+	usage, foundWire := readKimiWireUsage(sessionID, since, logger)
+	if !foundWire {
+		return nil
+	}
+
+	// Settle rather than returning on the first non-empty read: the main
+	// agent's record can land a beat before a sub-agent's, and the
+	// per-model totals only stop growing once every agent wire for this
+	// session has flushed. On budget expiry return the latest read —
+	// partial usage still beats none.
 	deadline := time.Now().Add(kimiWireUsagePollTimeout)
-	for {
-		if usage := readKimiWireUsage(sessionID, since, logger); usage != nil {
+	for !time.Now().After(deadline) {
+		time.Sleep(kimiWireUsagePollInterval)
+		prev := usage
+		usage, _ = readKimiWireUsage(sessionID, since, logger)
+		if usage != nil && maps.Equal(usage, prev) {
 			return usage
 		}
-		if time.Now().After(deadline) {
-			return nil
-		}
-		time.Sleep(kimiWireUsagePollInterval)
 	}
+	return usage
 }
 
 // readKimiWireUsage recovers per-model token usage from kimi's on-disk
@@ -525,9 +555,12 @@ func waitKimiWireUsage(sessionID string, since time.Time, logger *slog.Logger) m
 // tokens already billed to earlier tasks. Records are summed per model so
 // multi-model runs attribute correctly. The KIMI_CODE_HOME lookup uses the
 // daemon process env, which is what the child inherits in the common case.
-// Returns nil when nothing usable is found — the caller then reports no
-// usage, matching the pre-recovery behavior.
-func readKimiWireUsage(sessionID string, since time.Time, logger *slog.Logger) map[string]TokenUsage {
+// The second return value reports whether any wire file matched at all —
+// callers use it to tell "this kimi build writes no wire" from "wire
+// exists but the turn's record isn't flushed yet". Totals are nil when
+// nothing usable is found — the caller then reports no usage, matching
+// the pre-recovery behavior.
+func readKimiWireUsage(sessionID string, since time.Time, logger *slog.Logger) (map[string]TokenUsage, bool) {
 	home := os.Getenv("KIMI_CODE_HOME")
 	if home == "" {
 		if h, err := os.UserHomeDir(); err == nil {
@@ -535,11 +568,11 @@ func readKimiWireUsage(sessionID string, since time.Time, logger *slog.Logger) m
 		}
 	}
 	if home == "" {
-		return nil
+		return nil, false
 	}
 	files, err := filepath.Glob(filepath.Join(home, "sessions", "*", sessionID, "agents", "*", "wire.jsonl"))
 	if err != nil || len(files) == 0 {
-		return nil
+		return nil, false
 	}
 	cutoff := since.Add(-kimiWireUsageGrace).UnixMilli()
 	totals := map[string]TokenUsage{}
@@ -549,53 +582,70 @@ func readKimiWireUsage(sessionID string, since time.Time, logger *slog.Logger) m
 		}
 	}
 	if len(totals) == 0 {
-		return nil
+		return nil, true
 	}
-	return totals
+	return totals, true
 }
 
 // accumulateKimiWireFile sums usage.record entries newer than cutoffMs
 // into totals, keyed by the record's model id. Malformed lines are
 // skipped — the wire is an append-only log best read leniently.
+//
+// Lines are read with an unbounded bufio.Reader on purpose: tool-output
+// frames on this log can exceed any fixed scanner buffer, and a capped
+// reader would stop at the oversized line and hide usage.record entries
+// appended after it.
 func accumulateKimiWireFile(path string, cutoffMs int64, totals map[string]TokenUsage) error {
 	fh, err := os.Open(path)
 	if err != nil {
 		return err
 	}
 	defer fh.Close()
-	scanner := bufio.NewScanner(fh)
-	scanner.Buffer(make([]byte, 0, 256*1024), 4*1024*1024)
-	for scanner.Scan() {
-		line := scanner.Bytes()
-		// Cheap pre-filter: almost no wire line is a usage record, and
-		// lines carrying tool output can be large.
-		if !bytes.Contains(line, []byte(`"usage.record"`)) {
-			continue
+	r := bufio.NewReader(fh)
+	for {
+		line, err := r.ReadBytes('\n')
+		if len(line) > 0 {
+			accumulateKimiWireLine(line, cutoffMs, totals)
 		}
-		var rec struct {
-			Type  string `json:"type"`
-			Model string `json:"model"`
-			Usage struct {
-				InputOther         int64 `json:"inputOther"`
-				Output             int64 `json:"output"`
-				InputCacheRead     int64 `json:"inputCacheRead"`
-				InputCacheCreation int64 `json:"inputCacheCreation"`
-			} `json:"usage"`
-			Time int64 `json:"time"` // epoch ms
+		if err != nil {
+			if err == io.EOF {
+				return nil
+			}
+			return err
 		}
-		if err := json.Unmarshal(line, &rec); err != nil || rec.Type != "usage.record" {
-			continue
-		}
-		model := strings.TrimSpace(rec.Model)
-		if model == "" || rec.Time < cutoffMs {
-			continue
-		}
-		u := totals[model]
-		u.InputTokens += rec.Usage.InputOther
-		u.OutputTokens += rec.Usage.Output
-		u.CacheReadTokens += rec.Usage.InputCacheRead
-		u.CacheWriteTokens += rec.Usage.InputCacheCreation
-		totals[model] = u
 	}
-	return scanner.Err()
+}
+
+// accumulateKimiWireLine folds one wire line into totals when it is an
+// in-window usage.record; anything else is ignored.
+func accumulateKimiWireLine(line []byte, cutoffMs int64, totals map[string]TokenUsage) {
+	// Cheap pre-filter: almost no wire line is a usage record, and
+	// lines carrying tool output can be large.
+	if !bytes.Contains(line, []byte(`"usage.record"`)) {
+		return
+	}
+	var rec struct {
+		Type  string `json:"type"`
+		Model string `json:"model"`
+		Usage struct {
+			InputOther         int64 `json:"inputOther"`
+			Output             int64 `json:"output"`
+			InputCacheRead     int64 `json:"inputCacheRead"`
+			InputCacheCreation int64 `json:"inputCacheCreation"`
+		} `json:"usage"`
+		Time int64 `json:"time"` // epoch ms
+	}
+	if err := json.Unmarshal(line, &rec); err != nil || rec.Type != "usage.record" {
+		return
+	}
+	model := strings.TrimSpace(rec.Model)
+	if model == "" || rec.Time < cutoffMs {
+		return
+	}
+	u := totals[model]
+	u.InputTokens += rec.Usage.InputOther
+	u.OutputTokens += rec.Usage.Output
+	u.CacheReadTokens += rec.Usage.InputCacheRead
+	u.CacheWriteTokens += rec.Usage.InputCacheCreation
+	totals[model] = u
 }

--- a/server/pkg/agent/kimi.go
+++ b/server/pkg/agent/kimi.go
@@ -194,6 +194,11 @@ func (b *kimiBackend) Execute(ctx context.Context, prompt string, opts ExecOptio
 		// Per-model usage recovered from kimi's on-disk session wire
 		// when the ACP stream carries none (always, on kimi ≤ 0.27).
 		var wireUsage map[string]TokenUsage
+		// Largest usage.record timestamp already present in the session
+		// wire right after session/new or session/resume. Only records
+		// strictly after this snapshot are counted, preventing double-
+		// billing on resumed sessions.
+		var wireSnapshotMs int64 = -1
 
 		// 1. Initialize handshake.
 		initResult, err := c.request(runCtx, "initialize", map[string]any{
@@ -271,16 +276,22 @@ func (b *kimiBackend) Execute(ctx context.Context, prompt string, opts ExecOptio
 		c.sessionID = sessionID
 		b.cfg.Logger.Info("kimi session created", "session_id", sessionID)
 
+		// Snapshot the session wire before the prompt so usage and failure
+		// recovery only counts records appended by this turn. On a resumed
+		// session the wire holds every past turn; without the snapshot we
+		// would double-bill tokens already billed to earlier tasks.
+		wireSnapshotMs = snapshotKimiWire(sessionID, b.cfg.Logger)
+
 		// 3. If the caller picked a model (via agent.model from the
 		// UI dropdown), ask kimi to switch the session to it before
 		// we send any prompt. Kimi's ACP server exposes
 		// `session/set_model` and advertises available models via
-		// the `models.availableModels` block returned by
-		// `session/new` — we pass the chosen modelId through
-		// verbatim. This MUST fail the task on error: silently
-		// falling back to kimi's default model would let the user
-		// believe their pick was honoured while the task actually
-		// ran on something else.
+		// `configOptions` (kimi-code ≥ 0.29) or the legacy
+		// `models.availableModels` block returned by `session/new` —
+		// we pass the chosen modelId through verbatim. This MUST fail
+		// the task on error: silently falling back to kimi's default
+		// model would let the user believe their pick was honoured
+		// while the task actually ran on something else.
 		if opts.Model != "" {
 			if _, err := c.request(runCtx, "session/set_model", map[string]any{
 				"sessionId": sessionID,
@@ -409,7 +420,7 @@ func (b *kimiBackend) Execute(ctx context.Context, prompt string, opts ExecOptio
 				c.usage.CacheReadTokens == 0 && c.usage.CacheWriteTokens == 0
 			c.usageMu.Unlock()
 			if acpUsageEmpty && sessionID != "" && finalStatus == "completed" {
-				wireUsage = waitKimiWireUsage(sessionID, startTime, b.cfg.Logger)
+				wireUsage = waitKimiWireUsage(sessionID, time.UnixMilli(wireSnapshotMs), b.cfg.Logger)
 			}
 		}
 
@@ -467,26 +478,26 @@ func (b *kimiBackend) Execute(ctx context.Context, prompt string, opts ExecOptio
 				// should carry what the run consumed. Still nil when
 				// nothing usable was found — the run then reports no
 				// usage, matching prior behavior.
-				usageMap, _ = readKimiWireUsage(sessionID, startTime, b.cfg.Logger)
+				usageMap, _ = readKimiWireUsage(sessionID, time.UnixMilli(wireSnapshotMs), b.cfg.Logger)
 			}
 		}
 
 		// Kimi answers session/prompt with stopReason=end_turn even when
 		// the turn died provider-side (upstream kimi bug; the failure is
 		// only recorded in the session's logs/kimi-code.log). A
-		// "completed" run with no output AND no usage.record for the turn
-		// is therefore not a valid empty completion: cross-check the
-		// session log for an in-window turn failure and fail loudly with
-		// the real provider error instead of reporting a silent success.
-		// The session id is dropped as well — a failed turn can leave the
+		// "completed" run with no output and no ACP-stream usage is
+		// therefore not a valid empty completion: cross-check the session
+		// log for an in-window turn failure and fail loudly with the real
+		// provider error instead of reporting a silent success. The
+		// session id is dropped as well — a failed turn can leave the
 		// context corrupt (empty assistant message) and brick every
 		// follow-up resume, so the empty SessionID routes the daemon's
 		// resume-failure fallback to a fresh session. Healthy empty
-		// completions flushed a usage.record and never reach this check.
+		// completions flushed a usage.record; the snapshot keeps stale
+		// failure entries from previous runs out of the check.
 		if finalStatus == "completed" && finalOutput == "" && sessionID != "" &&
-			u.InputTokens == 0 && u.OutputTokens == 0 && u.CacheReadTokens == 0 && u.CacheWriteTokens == 0 &&
-			wireUsage == nil {
-			if failMsg, failed := readKimiTurnFailure(sessionID, startTime, b.cfg.Logger); failed {
+			u.InputTokens == 0 && u.OutputTokens == 0 && u.CacheReadTokens == 0 && u.CacheWriteTokens == 0 {
+			if failMsg, failed := readKimiTurnFailure(sessionID, time.UnixMilli(wireSnapshotMs), b.cfg.Logger); failed {
 				b.cfg.Logger.Warn("kimi turn failed provider-side behind end_turn; failing the run and dropping the poisoned session",
 					"session_id", sessionID,
 					"error", failMsg,
@@ -558,11 +569,6 @@ func kimiToolNameFromTitle(title string) string {
 	return strings.ReplaceAll(lower, " ", "_")
 }
 
-// kimiWireUsageGrace absorbs clock granularity between the daemon's run
-// start and kimi's record timestamps (same host, same clock). It stays
-// far below the age of any previous task's records on a resumed session.
-const kimiWireUsageGrace = 5 * time.Second
-
 // kimiWireUsagePoll bounds the post-prompt wait for kimi to flush the
 // turn's usage.record to the session wire. Kimi answers session/prompt
 // before the record hits disk; without a brief poll the teardown SIGKILL
@@ -611,16 +617,18 @@ func waitKimiWireUsage(sessionID string, since time.Time, logger *slog.Logger) m
 //	 "usage":{"inputOther":1884,"output":35,"inputCacheRead":19200,"inputCacheCreation":0},
 //	 "time":1784398522242}
 //
-// Only records at or after `since` count: a resumed session's wire
+// Only records strictly after `since` count: a resumed session's wire
 // accumulates every past turn, and re-summing history would double-report
-// tokens already billed to earlier tasks. Records are summed per model so
-// multi-model runs attribute correctly. The KIMI_CODE_HOME lookup uses the
-// daemon process env, which is what the child inherits in the common case.
-// The second return value reports whether any wire file matched at all —
-// callers use it to tell "this kimi build writes no wire" from "wire
-// exists but the turn's record isn't flushed yet". Totals are nil when
-// nothing usable is found — the caller then reports no usage, matching
-// the pre-recovery behavior.
+// tokens already billed to earlier tasks. The caller snapshots the wire
+// right after session/new or session/resume and passes that snapshot as
+// `since`, so previous task records are ignored regardless of clock skew.
+// Records are summed per model so multi-model runs attribute correctly.
+// The KIMI_CODE_HOME lookup uses the daemon process env, which is what the
+// child inherits in the common case. The second return value reports whether
+// any wire file matched at all — callers use it to tell "this kimi build
+// writes no wire" from "wire exists but the turn's record isn't flushed
+// yet". Totals are nil when nothing usable is found — the caller then
+// reports no usage, matching the pre-recovery behavior.
 func readKimiWireUsage(sessionID string, since time.Time, logger *slog.Logger) (map[string]TokenUsage, bool) {
 	home := kimiCodeHome()
 	if home == "" {
@@ -630,7 +638,7 @@ func readKimiWireUsage(sessionID string, since time.Time, logger *slog.Logger) (
 	if err != nil || len(files) == 0 {
 		return nil, false
 	}
-	cutoff := since.Add(-kimiWireUsageGrace).UnixMilli()
+	cutoff := since.UnixMilli()
 	totals := map[string]TokenUsage{}
 	for _, f := range files {
 		if err := accumulateKimiWireFile(f, cutoff, totals); err != nil {
@@ -643,7 +651,7 @@ func readKimiWireUsage(sessionID string, since time.Time, logger *slog.Logger) (
 	return totals, true
 }
 
-// accumulateKimiWireFile sums usage.record entries newer than cutoffMs
+// accumulateKimiWireFile sums usage.record entries strictly after cutoffMs
 // into totals, keyed by the record's model id. Malformed lines are
 // skipped — the wire is an append-only log best read leniently.
 //
@@ -672,8 +680,8 @@ func accumulateKimiWireFile(path string, cutoffMs int64, totals map[string]Token
 	}
 }
 
-// accumulateKimiWireLine folds one wire line into totals when it is an
-// in-window usage.record; anything else is ignored.
+// accumulateKimiWireLine folds one wire line into totals when it is a
+// usage.record strictly after cutoffMs; anything else is ignored.
 func accumulateKimiWireLine(line []byte, cutoffMs int64, totals map[string]TokenUsage) {
 	// Cheap pre-filter: almost no wire line is a usage record, and
 	// lines carrying tool output can be large.
@@ -695,7 +703,7 @@ func accumulateKimiWireLine(line []byte, cutoffMs int64, totals map[string]Token
 		return
 	}
 	model := strings.TrimSpace(rec.Model)
-	if model == "" || rec.Time < cutoffMs {
+	if model == "" || rec.Time <= cutoffMs {
 		return
 	}
 	u := totals[model]
@@ -717,6 +725,84 @@ func kimiCodeHome() string {
 		return filepath.Join(h, ".kimi-code")
 	}
 	return ""
+}
+
+// snapshotKimiWire returns the largest usage.record timestamp (epoch ms)
+// already present in the session's wire files right after session/new or
+// session/resume. The caller passes this value back as the `since` cutoff
+// for readKimiWireUsage and readKimiTurnFailure, so only records appended
+// after the snapshot are counted.
+//
+// When the session has no wire file yet (fresh session, older build) or
+// the wire holds no usage.record, the snapshot falls back to the current
+// time. That keeps stale failure log entries from previous runs from
+// looking in-window when there is no usage record to anchor the cutoff.
+func snapshotKimiWire(sessionID string, logger *slog.Logger) int64 {
+	home := kimiCodeHome()
+	if home == "" {
+		return time.Now().UnixMilli()
+	}
+	files, err := filepath.Glob(filepath.Join(home, "sessions", "*", sessionID, "agents", "*", "wire.jsonl"))
+	if err != nil || len(files) == 0 {
+		return time.Now().UnixMilli()
+	}
+	var maxTime int64 = -1
+	for _, f := range files {
+		t, err := maxKimiWireRecordTime(f)
+		if err != nil {
+			logger.Debug("kimi wire snapshot read failed", "file", f, "error", err)
+			continue
+		}
+		if t > maxTime {
+			maxTime = t
+		}
+	}
+	if maxTime < 0 {
+		return time.Now().UnixMilli()
+	}
+	return maxTime
+}
+
+// maxKimiWireRecordTime returns the largest usage.record timestamp in a
+// single wire file, or -1 when the file contains no usage.record lines.
+func maxKimiWireRecordTime(path string) (int64, error) {
+	fh, err := os.Open(path)
+	if err != nil {
+		return -1, err
+	}
+	defer fh.Close()
+	var maxTime int64 = -1
+	r := bufio.NewReader(fh)
+	for {
+		line, err := r.ReadBytes('\n')
+		if len(line) > 0 {
+			if t := kimiWireRecordTime(line); t > maxTime {
+				maxTime = t
+			}
+		}
+		if err != nil {
+			if err == io.EOF {
+				return maxTime, nil
+			}
+			return maxTime, err
+		}
+	}
+}
+
+// kimiWireRecordTime extracts the timestamp from a usage.record line, or
+// -1 if the line is not a usage.record or is malformed.
+func kimiWireRecordTime(line []byte) int64 {
+	if !bytes.Contains(line, []byte(`"usage.record"`)) {
+		return -1
+	}
+	var rec struct {
+		Type string `json:"type"`
+		Time int64  `json:"time"`
+	}
+	if err := json.Unmarshal(line, &rec); err != nil || rec.Type != "usage.record" {
+		return -1
+	}
+	return rec.Time
 }
 
 // Markers recorded in the session's logs/kimi-code.log when a turn dies
@@ -742,11 +828,10 @@ var kimiTurnFailedErrorRe = regexp.MustCompile(`\berror="((?:[^"\\]|\\.)*)"`)
 // turns over ACP as stopReason=end_turn with no output, so the session
 // log is the only place the failure — and its cause — is visible.
 //
-// Only entries newer than `since` (minus kimiWireUsageGrace, same host
-// clock) count: the log accumulates every past turn on a resumed session,
-// and a failure from a previous run must not flag the current one. Lines
-// whose timestamp can't be parsed are skipped for the same reason.
-// Returns ("", false) when no log exists at all (older kimi builds,
+// The caller snapshots the wire right after session/new or session/resume
+// and passes that snapshot as `since`, so failures from previous runs are
+// ignored. Lines whose timestamp can't be parsed are skipped for the same
+// reason. Returns ("", false) when no log exists at all (older kimi builds,
 // custom data dir) — no signal, never a false positive.
 func readKimiTurnFailure(sessionID string, since time.Time, logger *slog.Logger) (string, bool) {
 	home := kimiCodeHome()
@@ -757,11 +842,10 @@ func readKimiTurnFailure(sessionID string, since time.Time, logger *slog.Logger)
 	if err != nil || len(files) == 0 {
 		return "", false
 	}
-	cutoff := since.Add(-kimiWireUsageGrace)
 	failed := false
 	detail := ""
 	for _, f := range files {
-		fileDetail, fileFailed, err := scanKimiTurnFailureLog(f, cutoff)
+		fileDetail, fileFailed, err := scanKimiTurnFailureLog(f, since)
 		if err != nil {
 			logger.Debug("kimi turn-failure log read failed", "file", f, "error", err)
 			continue

--- a/server/pkg/agent/kimi.go
+++ b/server/pkg/agent/kimi.go
@@ -773,14 +773,6 @@ func accumulateKimiWireLine(line []byte, cutoffMs int64, totals map[string]Token
 	totals[model] = u
 }
 
-// kimiCodeHome returns kimi-cli's data dir from the daemon process env:
-// $KIMI_CODE_HOME when set, else ~/.kimi-code. It is a fallback for callers
-// that do not have a child-process env slice; the Execute path prefers
-// kimiHomeFromEnv(cmd.Env).
-func kimiCodeHome() string {
-	return kimiHomeFromEnv(os.Environ())
-}
-
 // kimiHomeFromEnv extracts KIMI_CODE_HOME from an env slice (last wins),
 // falling back to ~/.kimi-code. This lets the kimi backend read session
 // files from the same directory the child process writes them to, even when
@@ -887,6 +879,7 @@ func kimiWireRecordTime(line []byte) int64 {
 //	2026-07-19T15:03:24.933Z WARN  acp: turn ended with failed reason  error="{...}"
 const (
 	kimiTurnFailedMarker       = "turn failed"
+	kimiTurnFailedErrorPrefix  = " ERROR turn failed"
 	kimiTurnFailedDetailMarker = "acp: turn ended with failed reason"
 )
 
@@ -974,10 +967,11 @@ func scanKimiTurnFailureLog(path string, cutoff time.Time) (string, bool, error)
 }
 
 // isKimiTurnFailureLine reports whether a (possibly partial) line looks like
-// a turn-failure marker. Both the ERROR marker and the WARN detail marker
-// appear near the start of their lines.
+// a turn-failure marker. Both markers appear near the start of their lines;
+// the bare ERROR marker requires the level prefix so echoed content does not
+// false-match.
 func isKimiTurnFailureLine(line []byte) bool {
-	return bytes.Contains(line, []byte(kimiTurnFailedMarker)) ||
+	return bytes.Contains(line, []byte(kimiTurnFailedErrorPrefix)) ||
 		bytes.Contains(line, []byte(kimiTurnFailedDetailMarker))
 }
 
@@ -986,8 +980,9 @@ func isKimiTurnFailureLine(line []byte) bool {
 // ("<rfc3339> <LEVEL> <msg> key=value …"); the leading timestamp decides
 // whether the entry belongs to the current run.
 func parseKimiTurnFailureLine(line []byte, cutoff time.Time) (string, bool) {
-	if !bytes.Contains(line, []byte(kimiTurnFailedMarker)) &&
-		!bytes.Contains(line, []byte(kimiTurnFailedDetailMarker)) {
+	hasErrorMarker := bytes.Contains(line, []byte(kimiTurnFailedErrorPrefix))
+	hasDetailMarker := bytes.Contains(line, []byte(kimiTurnFailedDetailMarker))
+	if !hasErrorMarker && !hasDetailMarker {
 		return "", false
 	}
 	sp := bytes.IndexByte(line, ' ')
@@ -998,7 +993,7 @@ func parseKimiTurnFailureLine(line []byte, cutoff time.Time) (string, bool) {
 	if err != nil || ts.Before(cutoff) {
 		return "", false
 	}
-	if !bytes.Contains(line, []byte(kimiTurnFailedDetailMarker)) {
+	if !hasDetailMarker {
 		// Bare ERROR marker; the paired WARN detail line carries the cause.
 		return "", true
 	}

--- a/server/pkg/agent/kimi.go
+++ b/server/pkg/agent/kimi.go
@@ -72,6 +72,11 @@ func (b *kimiBackend) Execute(ctx context.Context, prompt string, opts ExecOptio
 		cmd.Dir = opts.Cwd
 	}
 	cmd.Env = buildEnv(b.cfg.Env)
+	// Resolve the effective Kimi data directory from the child-process
+	// environment. The daemon's own KIMI_CODE_HOME may differ (custom_env,
+	// task-local overrides), and usage/failure recovery must read the files
+	// the child actually writes.
+	kimiHome := kimiHomeFromEnv(cmd.Env)
 
 	stdout, err := cmd.StdoutPipe()
 	if err != nil {
@@ -280,7 +285,7 @@ func (b *kimiBackend) Execute(ctx context.Context, prompt string, opts ExecOptio
 		// recovery only counts records appended by this turn. On a resumed
 		// session the wire holds every past turn; without the snapshot we
 		// would double-bill tokens already billed to earlier tasks.
-		wireSnapshotMs = snapshotKimiWire(sessionID, b.cfg.Logger)
+		wireSnapshotMs = snapshotKimiWire(sessionID, kimiHome, b.cfg.Logger)
 
 		// 3. If the caller picked a model (via agent.model from the
 		// UI dropdown), ask kimi to switch the session to it before
@@ -420,7 +425,7 @@ func (b *kimiBackend) Execute(ctx context.Context, prompt string, opts ExecOptio
 				c.usage.CacheReadTokens == 0 && c.usage.CacheWriteTokens == 0
 			c.usageMu.Unlock()
 			if acpUsageEmpty && sessionID != "" && finalStatus == "completed" {
-				wireUsage = waitKimiWireUsage(sessionID, time.UnixMilli(wireSnapshotMs), b.cfg.Logger)
+				wireUsage = waitKimiWireUsage(sessionID, time.UnixMilli(wireSnapshotMs), kimiHome, b.cfg.Logger)
 			}
 		}
 
@@ -478,7 +483,7 @@ func (b *kimiBackend) Execute(ctx context.Context, prompt string, opts ExecOptio
 				// should carry what the run consumed. Still nil when
 				// nothing usable was found — the run then reports no
 				// usage, matching prior behavior.
-				usageMap, _ = readKimiWireUsage(sessionID, time.UnixMilli(wireSnapshotMs), b.cfg.Logger)
+				usageMap, _ = readKimiWireUsage(sessionID, time.UnixMilli(wireSnapshotMs), kimiHome, b.cfg.Logger)
 			}
 		}
 
@@ -497,7 +502,7 @@ func (b *kimiBackend) Execute(ctx context.Context, prompt string, opts ExecOptio
 		// failure entries from previous runs out of the check.
 		if finalStatus == "completed" && finalOutput == "" && sessionID != "" &&
 			u.InputTokens == 0 && u.OutputTokens == 0 && u.CacheReadTokens == 0 && u.CacheWriteTokens == 0 {
-			if failMsg, failed := readKimiTurnFailure(sessionID, time.UnixMilli(wireSnapshotMs), b.cfg.Logger); failed {
+			if failMsg, failed := readKimiTurnFailure(sessionID, time.UnixMilli(wireSnapshotMs), kimiHome, b.cfg.Logger); failed {
 				b.cfg.Logger.Warn("kimi turn failed provider-side behind end_turn; failing the run and dropping the poisoned session",
 					"session_id", sessionID,
 					"error", failMsg,
@@ -578,16 +583,65 @@ const (
 	kimiWireUsagePollInterval = 100 * time.Millisecond
 )
 
+const (
+	// kimiLineBufSize is the chunk size used when scanning wire/log files.
+	// It is large enough to absorb most lines in one ReadSlice but small
+	// enough that a 5 MiB tool-output frame is never held whole.
+	kimiLineBufSize = 64 * 1024
+	// kimiMaxTargetLineBytes caps how much of a target line we are willing
+	// to buffer. Usage records and turn-failure log lines are well under
+	// this; oversized target lines are skipped rather than risking OOM.
+	kimiMaxTargetLineBytes = 1024 * 1024
+)
+
+// kimiReadLineBounded reads one line from r. If the line does not look like
+// a target line according to isTarget, it is discarded chunk by chunk without
+// ever buffering the whole line. Target lines are buffered only up to
+// kimiMaxTargetLineBytes; anything beyond that is discarded.
+func kimiReadLineBounded(r *bufio.Reader, isTarget func([]byte) bool) ([]byte, error) {
+	chunk, err := r.ReadSlice('\n')
+	if err != bufio.ErrBufferFull {
+		return chunk, err
+	}
+	// Line longer than the internal buffer. Decide from the leading chunk
+	// whether this is a line we care about.
+	if !isTarget(chunk) {
+		for err == bufio.ErrBufferFull {
+			chunk, err = r.ReadSlice('\n')
+		}
+		return nil, err
+	}
+	// Target line that exceeds the buffer: accumulate up to the cap.
+	var buf bytes.Buffer
+	buf.Grow(len(chunk))
+	buf.Write(chunk)
+	for err == bufio.ErrBufferFull {
+		chunk, err = r.ReadSlice('\n')
+		if buf.Len()+len(chunk) > kimiMaxTargetLineBytes {
+			// Too big: discard the remainder and treat as skipped.
+			for err == bufio.ErrBufferFull {
+				chunk, err = r.ReadSlice('\n')
+			}
+			return nil, err
+		}
+		buf.Write(chunk)
+	}
+	if err != nil && err != io.EOF {
+		return nil, err
+	}
+	return buf.Bytes(), err
+}
+
 // waitKimiWireUsage polls readKimiWireUsage until the turn's usage
 // totals settle — non-empty and unchanged across one more poll interval —
 // or the poll budget runs out, in which case the latest read wins (nil
 // when nothing was ever found).
-func waitKimiWireUsage(sessionID string, since time.Time, logger *slog.Logger) map[string]TokenUsage {
+func waitKimiWireUsage(sessionID string, since time.Time, home string, logger *slog.Logger) map[string]TokenUsage {
 	// Fast path: kimi creates the session wire at session start, long
 	// before this post-prompt poll. A first probe matching no wire file
 	// at all therefore means this build writes none (older CLI, custom
 	// data dir) — bail now instead of burning the whole budget per run.
-	usage, foundWire := readKimiWireUsage(sessionID, since, logger)
+	usage, foundWire := readKimiWireUsage(sessionID, since, home, logger)
 	if !foundWire {
 		return nil
 	}
@@ -601,7 +655,7 @@ func waitKimiWireUsage(sessionID string, since time.Time, logger *slog.Logger) m
 	for !time.Now().After(deadline) {
 		time.Sleep(kimiWireUsagePollInterval)
 		prev := usage
-		usage, _ = readKimiWireUsage(sessionID, since, logger)
+		usage, _ = readKimiWireUsage(sessionID, since, home, logger)
 		if usage != nil && maps.Equal(usage, prev) {
 			return usage
 		}
@@ -623,14 +677,13 @@ func waitKimiWireUsage(sessionID string, since time.Time, logger *slog.Logger) m
 // right after session/new or session/resume and passes that snapshot as
 // `since`, so previous task records are ignored regardless of clock skew.
 // Records are summed per model so multi-model runs attribute correctly.
-// The KIMI_CODE_HOME lookup uses the daemon process env, which is what the
-// child inherits in the common case. The second return value reports whether
-// any wire file matched at all — callers use it to tell "this kimi build
-// writes no wire" from "wire exists but the turn's record isn't flushed
-// yet". Totals are nil when nothing usable is found — the caller then
-// reports no usage, matching the pre-recovery behavior.
-func readKimiWireUsage(sessionID string, since time.Time, logger *slog.Logger) (map[string]TokenUsage, bool) {
-	home := kimiCodeHome()
+// The `home` argument must be the effective Kimi data directory (resolved
+// from the child-process environment by the caller). The second return value
+// reports whether any wire file matched at all — callers use it to tell
+// "this kimi build writes no wire" from "wire exists but the turn's record
+// isn't flushed yet". Totals are nil when nothing usable is found — the
+// caller then reports no usage, matching the pre-recovery behavior.
+func readKimiWireUsage(sessionID string, since time.Time, home string, logger *slog.Logger) (map[string]TokenUsage, bool) {
 	if home == "" {
 		return nil, false
 	}
@@ -655,19 +708,18 @@ func readKimiWireUsage(sessionID string, since time.Time, logger *slog.Logger) (
 // into totals, keyed by the record's model id. Malformed lines are
 // skipped — the wire is an append-only log best read leniently.
 //
-// Lines are read with an unbounded bufio.Reader on purpose: tool-output
-// frames on this log can exceed any fixed scanner buffer, and a capped
-// reader would stop at the oversized line and hide usage.record entries
-// appended after it.
+// Non-target lines are discarded chunk-by-chunk so a huge tool-output frame
+// never gets buffered whole; target lines are buffered only up to
+// kimiMaxTargetLineBytes.
 func accumulateKimiWireFile(path string, cutoffMs int64, totals map[string]TokenUsage) error {
 	fh, err := os.Open(path)
 	if err != nil {
 		return err
 	}
 	defer fh.Close()
-	r := bufio.NewReader(fh)
+	r := bufio.NewReaderSize(fh, kimiLineBufSize)
 	for {
-		line, err := r.ReadBytes('\n')
+		line, err := kimiReadLineBounded(r, isUsageRecordLine)
 		if len(line) > 0 {
 			accumulateKimiWireLine(line, cutoffMs, totals)
 		}
@@ -678,6 +730,13 @@ func accumulateKimiWireFile(path string, cutoffMs int64, totals map[string]Token
 			return err
 		}
 	}
+}
+
+// isUsageRecordLine reports whether a (possibly partial) line looks like a
+// usage.record entry. The marker sits near the start, so a leading chunk is
+// enough to decide.
+func isUsageRecordLine(line []byte) bool {
+	return bytes.Contains(line, []byte(`"usage.record"`))
 }
 
 // accumulateKimiWireLine folds one wire line into totals when it is a
@@ -714,17 +773,32 @@ func accumulateKimiWireLine(line []byte, cutoffMs int64, totals map[string]Token
 	totals[model] = u
 }
 
-// kimiCodeHome returns kimi-cli's data dir: $KIMI_CODE_HOME when set,
-// else ~/.kimi-code. The KIMI_CODE_HOME lookup uses the daemon process
-// env, which is what the child inherits in the common case.
+// kimiCodeHome returns kimi-cli's data dir from the daemon process env:
+// $KIMI_CODE_HOME when set, else ~/.kimi-code. It is a fallback for callers
+// that do not have a child-process env slice; the Execute path prefers
+// kimiHomeFromEnv(cmd.Env).
 func kimiCodeHome() string {
-	if home := os.Getenv("KIMI_CODE_HOME"); home != "" {
-		return home
+	return kimiHomeFromEnv(os.Environ())
+}
+
+// kimiHomeFromEnv extracts KIMI_CODE_HOME from an env slice (last wins),
+// falling back to ~/.kimi-code. This lets the kimi backend read session
+// files from the same directory the child process writes them to, even when
+// the daemon's own environment points elsewhere.
+func kimiHomeFromEnv(env []string) string {
+	prefix := "KIMI_CODE_HOME="
+	var home string
+	for _, e := range env {
+		if strings.HasPrefix(e, prefix) {
+			home = strings.TrimPrefix(e, prefix)
+		}
 	}
-	if h, err := os.UserHomeDir(); err == nil {
-		return filepath.Join(h, ".kimi-code")
+	if home == "" {
+		if h, err := os.UserHomeDir(); err == nil {
+			home = filepath.Join(h, ".kimi-code")
+		}
 	}
-	return ""
+	return home
 }
 
 // snapshotKimiWire returns the largest usage.record timestamp (epoch ms)
@@ -737,8 +811,7 @@ func kimiCodeHome() string {
 // the wire holds no usage.record, the snapshot falls back to the current
 // time. That keeps stale failure log entries from previous runs from
 // looking in-window when there is no usage record to anchor the cutoff.
-func snapshotKimiWire(sessionID string, logger *slog.Logger) int64 {
-	home := kimiCodeHome()
+func snapshotKimiWire(sessionID string, home string, logger *slog.Logger) int64 {
 	if home == "" {
 		return time.Now().UnixMilli()
 	}
@@ -772,9 +845,9 @@ func maxKimiWireRecordTime(path string) (int64, error) {
 	}
 	defer fh.Close()
 	var maxTime int64 = -1
-	r := bufio.NewReader(fh)
+	r := bufio.NewReaderSize(fh, kimiLineBufSize)
 	for {
-		line, err := r.ReadBytes('\n')
+		line, err := kimiReadLineBounded(r, isUsageRecordLine)
 		if len(line) > 0 {
 			if t := kimiWireRecordTime(line); t > maxTime {
 				maxTime = t
@@ -833,8 +906,7 @@ var kimiTurnFailedErrorRe = regexp.MustCompile(`\berror="((?:[^"\\]|\\.)*)"`)
 // ignored. Lines whose timestamp can't be parsed are skipped for the same
 // reason. Returns ("", false) when no log exists at all (older kimi builds,
 // custom data dir) — no signal, never a false positive.
-func readKimiTurnFailure(sessionID string, since time.Time, logger *slog.Logger) (string, bool) {
-	home := kimiCodeHome()
+func readKimiTurnFailure(sessionID string, since time.Time, home string, logger *slog.Logger) (string, bool) {
 	if home == "" {
 		return "", false
 	}
@@ -870,9 +942,8 @@ func readKimiTurnFailure(sessionID string, since time.Time, logger *slog.Logger)
 // scanKimiTurnFailureLog reads one kimi-code.log and reports whether it
 // holds an in-window turn failure, plus the extracted provider error
 // detail from the most recent matching WARN line ("" when only the bare
-// ERROR marker matched). Like the wire, the log is an append-only file
-// best read leniently, with an unbounded reader so an oversized line
-// can't hide failure entries appended after it.
+// ERROR marker matched). Non-target lines are discarded chunk-by-chunk so
+// an oversized line can't hide failure entries appended after it.
 func scanKimiTurnFailureLog(path string, cutoff time.Time) (string, bool, error) {
 	fh, err := os.Open(path)
 	if err != nil {
@@ -881,9 +952,9 @@ func scanKimiTurnFailureLog(path string, cutoff time.Time) (string, bool, error)
 	defer func() { _ = fh.Close() }()
 	found := false
 	detail := ""
-	r := bufio.NewReader(fh)
+	r := bufio.NewReaderSize(fh, kimiLineBufSize)
 	for {
-		line, err := r.ReadBytes('\n')
+		line, err := kimiReadLineBounded(r, isKimiTurnFailureLine)
 		if len(line) > 0 {
 			if d, ok := parseKimiTurnFailureLine(line, cutoff); ok {
 				found = true
@@ -900,6 +971,14 @@ func scanKimiTurnFailureLog(path string, cutoff time.Time) (string, bool, error)
 		}
 	}
 	return detail, found, nil
+}
+
+// isKimiTurnFailureLine reports whether a (possibly partial) line looks like
+// a turn-failure marker. Both the ERROR marker and the WARN detail marker
+// appear near the start of their lines.
+func isKimiTurnFailureLine(line []byte) bool {
+	return bytes.Contains(line, []byte(kimiTurnFailedMarker)) ||
+		bytes.Contains(line, []byte(kimiTurnFailedDetailMarker))
 }
 
 // parseKimiTurnFailureLine reports whether one kimi-code.log line records

--- a/server/pkg/agent/kimi_test.go
+++ b/server/pkg/agent/kimi_test.go
@@ -366,7 +366,10 @@ func TestReadKimiWireUsageSumsRecentRecordsPerModel(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	got := readKimiWireUsage("session-abc", now.Add(-10*time.Second), slog.Default())
+	got, foundWire := readKimiWireUsage("session-abc", now.Add(-10*time.Second), slog.Default())
+	if !foundWire {
+		t.Fatal("expected foundWire=true with a wire file present")
+	}
 	if len(got) != 2 {
 		t.Fatalf("expected 2 models, got %+v", got)
 	}
@@ -381,8 +384,12 @@ func TestReadKimiWireUsageSumsRecentRecordsPerModel(t *testing.T) {
 
 func TestReadKimiWireUsageMissingSessionReturnsNil(t *testing.T) {
 	t.Setenv("KIMI_CODE_HOME", t.TempDir())
-	if got := readKimiWireUsage("session-nope", time.Now().Add(-time.Minute), slog.Default()); got != nil {
+	got, foundWire := readKimiWireUsage("session-nope", time.Now().Add(-time.Minute), slog.Default())
+	if got != nil {
 		t.Fatalf("expected nil for missing wire, got %+v", got)
+	}
+	if foundWire {
+		t.Fatal("expected foundWire=false when no wire file matches")
 	}
 }
 
@@ -400,8 +407,212 @@ func TestReadKimiWireUsageSumsAcrossAgentWires(t *testing.T) {
 			t.Fatal(err)
 		}
 	}
-	got := readKimiWireUsage("session-abc", now.Add(-10*time.Second), slog.Default())
+	got, foundWire := readKimiWireUsage("session-abc", now.Add(-10*time.Second), slog.Default())
+	if !foundWire {
+		t.Fatal("expected foundWire=true with wire files present")
+	}
 	if u := got["kimi-code/k3"]; u.InputTokens != 20 || u.OutputTokens != 2 {
 		t.Fatalf("expected both agent wires summed, got %+v", got)
+	}
+}
+
+// TestWaitKimiWireUsageSettlesAcrossAgentWires pins the flush-race fix:
+// the main agent's usage.record commonly lands a poll tick before a
+// sub-agent's. waitKimiWireUsage must not return on the first non-empty
+// read — it waits for the totals to hold steady across one more interval,
+// so the late second wire is counted too.
+func TestWaitKimiWireUsageSettlesAcrossAgentWires(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("KIMI_CODE_HOME", home)
+
+	now := time.Now()
+	mainDir := filepath.Join(home, "sessions", "wd_x_deadbeef", "session-abc", "agents", "main")
+	if err := os.MkdirAll(mainDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// The wire exists from session start but holds no usage record yet —
+	// kimi flushes it only after answering session/prompt.
+	mainWire := filepath.Join(mainDir, "wire.jsonl")
+	if err := os.WriteFile(mainWire, []byte(`{"type":"llm.request","kind":"loop","model":"k3"}`+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	resultCh := make(chan map[string]TokenUsage, 1)
+	go func() {
+		resultCh <- waitKimiWireUsage("session-abc", now, slog.Default())
+	}()
+
+	// Main agent flushes first…
+	time.Sleep(kimiWireUsagePollInterval / 2)
+	f, err := os.OpenFile(mainWire, os.O_APPEND|os.O_WRONLY, 0o644)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := f.WriteString(kimiWireRec("kimi-code/k3", 100, 10, 0, 0, now) + "\n"); err != nil {
+		f.Close()
+		t.Fatal(err)
+	}
+	f.Close()
+
+	// …and the sub-agent's wire appears one tick later. The read that
+	// settles the totals must happen after this write.
+	time.Sleep(kimiWireUsagePollInterval)
+	criticDir := filepath.Join(home, "sessions", "wd_x_deadbeef", "session-abc", "agents", "task-critic")
+	if err := os.MkdirAll(criticDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(criticDir, "wire.jsonl"), []byte(kimiWireRec("kimi-code/k3", 7, 3, 0, 0, now)+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	select {
+	case got := <-resultCh:
+		u := got["kimi-code/k3"]
+		if u.InputTokens != 107 || u.OutputTokens != 13 {
+			t.Fatalf("expected both agent wires summed (107 in / 13 out), got %+v", got)
+		}
+	case <-time.After(kimiWireUsagePollTimeout + 5*time.Second):
+		t.Fatal("waitKimiWireUsage did not return")
+	}
+}
+
+// TestWaitKimiWireUsageNoWireReturnsImmediately pins the no-wire fast
+// path: kimi creates the session wire at session start, long before the
+// post-prompt poll, so a first probe matching nothing means this build
+// writes none (older CLI, custom data dir). The wait must bail at once,
+// not burn the whole poll budget on every completed run.
+func TestWaitKimiWireUsageNoWireReturnsImmediately(t *testing.T) {
+	t.Setenv("KIMI_CODE_HOME", t.TempDir())
+
+	start := time.Now()
+	if got := waitKimiWireUsage("session-nope", start.Add(-time.Minute), slog.Default()); got != nil {
+		t.Fatalf("expected nil usage, got %+v", got)
+	}
+	if elapsed := time.Since(start); elapsed > kimiWireUsagePollTimeout/2 {
+		t.Fatalf("expected immediate return on missing wire, took %s", elapsed)
+	}
+}
+
+// TestAccumulateKimiWireFileReadsPastOversizedLines pins the unbounded
+// line reader: a huge tool-output frame must not stop the scan and hide
+// usage.record entries appended after it — the old 4 MiB bufio.Scanner
+// cap aborted the read at exactly that line.
+func TestAccumulateKimiWireFileReadsPastOversizedLines(t *testing.T) {
+	t.Parallel()
+
+	now := time.Now()
+	// 5 MiB of tool output — over the old 4 MiB scanner cap.
+	big := strings.Repeat("x", 5*1024*1024)
+	wire := strings.Join([]string{
+		kimiWireRec("kimi-code/k3", 100, 10, 0, 0, now),
+		`{"type":"tool.output","data":"` + big + `"}`,
+		kimiWireRec("kimi-code/k3", 50, 5, 0, 0, now),
+	}, "\n") + "\n"
+
+	path := filepath.Join(t.TempDir(), "wire.jsonl")
+	if err := os.WriteFile(path, []byte(wire), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	totals := map[string]TokenUsage{}
+	if err := accumulateKimiWireFile(path, now.Add(-time.Minute).UnixMilli(), totals); err != nil {
+		t.Fatalf("accumulateKimiWireFile: %v", err)
+	}
+	if u := totals["kimi-code/k3"]; u.InputTokens != 150 || u.OutputTokens != 15 {
+		t.Fatalf("expected records on both sides of the oversized line summed, got %+v", totals)
+	}
+}
+
+// fakeKimiACPPromptOutcomeScript impersonates `kimi acp` for a session
+// whose prompt ends with the given canned JSON-RPC fragment — e.g.
+// `"error":{"code":-32603,...}` for a failed turn or
+// `"result":{"stopReason":"cancelled"}` for a cancelled one.
+func fakeKimiACPPromptOutcomeScript(outcome string) string {
+	return `#!/bin/sh
+while IFS= read -r line; do
+  id=$(printf '%s' "$line" | sed -n 's/.*"id":\([0-9]*\).*/\1/p')
+  case "$line" in
+    *'"method":"initialize"'*)
+      printf '{"jsonrpc":"2.0","id":%s,"result":{"protocolVersion":1,"agentCapabilities":{}}}\n' "$id"
+      ;;
+    *'"method":"session/new"'*)
+      printf '{"jsonrpc":"2.0","id":%s,"result":{"sessionId":"ses_wire"}}\n' "$id"
+      ;;
+    *'"method":"session/prompt"'*)
+      printf '{"jsonrpc":"2.0","id":%s,` + outcome + `}\n' "$id"
+      exit 0
+      ;;
+  esac
+done
+`
+}
+
+// TestKimiBackendRecoversWireUsageOnNonCompletedRun pins the failure-path
+// usage recovery: a run that consumed tokens but ended failed or
+// cancelled must still report the partial turn's usage, recovered with a
+// single non-polling wire read at usage-build time — no settle wait on
+// these paths. The daemon bills usage even for cancelled tasks (see the
+// ReportTaskUsage comment in server/internal/daemon/daemon.go).
+func TestKimiBackendRecoversWireUsageOnNonCompletedRun(t *testing.T) {
+	tests := []struct {
+		name       string
+		outcome    string
+		wantStatus string
+	}{
+		{"failed prompt", `"error":{"code":-32603,"message":"upstream boom"}`, "failed"},
+		{"cancelled turn", `"result":{"stopReason":"cancelled"}`, "aborted"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+
+			home := t.TempDir()
+			t.Setenv("KIMI_CODE_HOME", home)
+
+			// Pre-seed the session wire the way kimi leaves it after a
+			// turn that consumed tokens but did not complete.
+			wireDir := filepath.Join(home, "sessions", "wd_x_deadbeef", "ses_wire", "agents", "main")
+			if err := os.MkdirAll(wireDir, 0o755); err != nil {
+				t.Fatal(err)
+			}
+			wire := kimiWireRec("kimi-code/k3", 120, 30, 8, 2, time.Now()) + "\n"
+			if err := os.WriteFile(filepath.Join(wireDir, "wire.jsonl"), []byte(wire), 0o644); err != nil {
+				t.Fatal(err)
+			}
+
+			fakePath := filepath.Join(t.TempDir(), "kimi")
+			writeTestExecutable(t, fakePath, []byte(fakeKimiACPPromptOutcomeScript(tt.outcome)))
+
+			backend, err := New("kimi", Config{ExecutablePath: fakePath, Logger: slog.Default()})
+			if err != nil {
+				t.Fatalf("new kimi backend: %v", err)
+			}
+
+			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+			defer cancel()
+			session, err := backend.Execute(ctx, "prompt-ignored", ExecOptions{Timeout: 5 * time.Second})
+			if err != nil {
+				t.Fatalf("execute: %v", err)
+			}
+			go func() {
+				for range session.Messages {
+				}
+			}()
+
+			select {
+			case result, ok := <-session.Result:
+				if !ok {
+					t.Fatal("result channel closed without a value")
+				}
+				if result.Status != tt.wantStatus {
+					t.Fatalf("expected status=%q, got %q (error=%q)", tt.wantStatus, result.Status, result.Error)
+				}
+				u := result.Usage["kimi-code/k3"]
+				if u.InputTokens != 120 || u.OutputTokens != 30 || u.CacheReadTokens != 8 || u.CacheWriteTokens != 2 {
+					t.Fatalf("expected wire usage on the %s path, got %+v", tt.wantStatus, result.Usage)
+				}
+			case <-time.After(10 * time.Second):
+				t.Fatal("timeout waiting for result")
+			}
+		})
 	}
 }

--- a/server/pkg/agent/kimi_test.go
+++ b/server/pkg/agent/kimi_test.go
@@ -7,6 +7,7 @@ import (
 	"log/slog"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -67,7 +68,7 @@ func fakeKimiACPScript() string {
 #
 # Writes the full argv (one arg per line) to $KIMI_ARGS_FILE if that env
 # var is set, so tests can assert that the daemon invokes us with the
-# right flags (`+"`--yolo acp`"+`, not bare `+"`acp`"+`).
+# right flags (` + "`--yolo acp`" + `, not bare ` + "`acp`" + `).
 #
 # Then reads one JSON-RPC request per line from stdin, matches on the
 # method name, and writes back a canned response. Exits after set_model
@@ -614,5 +615,291 @@ func TestKimiBackendRecoversWireUsageOnNonCompletedRun(t *testing.T) {
 				t.Fatal("timeout waiting for result")
 			}
 		})
+	}
+}
+
+// fakeKimiACPSwallowedFailureScript impersonates `kimi acp` for the
+// swallowed-failure scenario (M-95): the turn dies provider-side but the
+// ACP server still answers session/prompt with stopReason=end_turn and
+// streams no output. Handles both session/new and session/resume so tests
+// can cover fresh and poisoned-resume runs.
+func fakeKimiACPSwallowedFailureScript() string {
+	return `#!/bin/sh
+while IFS= read -r line; do
+  id=$(printf '%s' "$line" | sed -n 's/.*"id":\([0-9]*\).*/\1/p')
+  case "$line" in
+    *'"method":"initialize"'*)
+      printf '{"jsonrpc":"2.0","id":%s,"result":{"protocolVersion":1,"agentCapabilities":{}}}\n' "$id"
+      ;;
+    *'"method":"session/new"'*)
+      printf '{"jsonrpc":"2.0","id":%s,"result":{"sessionId":"ses_swallowed"}}\n' "$id"
+      ;;
+    *'"method":"session/resume"'*)
+      sid=$(printf '%s' "$line" | sed -n 's/.*"sessionId":"\([^"]*\)".*/\1/p')
+      printf '{"jsonrpc":"2.0","id":%s,"result":{"sessionId":"%s"}}\n' "$id" "$sid"
+      ;;
+    *'"method":"session/prompt"'*)
+      # The swallowed failure: end_turn, no text, no error — the real
+      # failure only exists in the session's logs/kimi-code.log.
+      printf '{"jsonrpc":"2.0","id":%s,"result":{"stopReason":"end_turn"}}\n' "$id"
+      exit 0
+      ;;
+  esac
+done
+`
+}
+
+// kimiTurnFailedLogLines builds the kimi-code.log line pair kimi-cli
+// writes when a turn dies provider-side while ACP reports end_turn —
+// captured verbatim from a real poisoned session (see M-95):
+//
+//	2026-07-19T15:03:24.931Z ERROR turn failed  turnId=1
+//	2026-07-19T15:03:24.933Z WARN  acp: turn ended with failed reason  error="{...}"
+func kimiTurnFailedLogLines(at time.Time, turnID int, message string) string {
+	ts := at.UTC().Format("2006-01-02T15:04:05.000Z07:00")
+	payload := fmt.Sprintf(`{"code":"provider.api_error","message":%s,"name":"APIStatusError","details":{"statusCode":400,"requestId":null,"turnId":%d},"retryable":false}`,
+		strconv.Quote(message), turnID)
+	return fmt.Sprintf("%s ERROR turn failed  turnId=%d\n%s WARN  acp: turn ended with failed reason  error=%s\n",
+		ts, turnID, ts, strconv.Quote(payload))
+}
+
+// seedKimiSessionFiles writes the session wire and/or session log under a
+// fake KIMI_CODE_HOME with the same on-disk layout kimi-cli uses:
+// sessions/<cwd-hash>/<sessionID>/{agents/main/wire.jsonl,logs/kimi-code.log}.
+// Empty content skips that file.
+func seedKimiSessionFiles(t *testing.T, home, sessionID, wire, log string) {
+	t.Helper()
+	if wire != "" {
+		dir := filepath.Join(home, "sessions", "wd_x_deadbeef", sessionID, "agents", "main")
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(dir, "wire.jsonl"), []byte(wire), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if log != "" {
+		dir := filepath.Join(home, "sessions", "wd_x_deadbeef", sessionID, "logs")
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(dir, "kimi-code.log"), []byte(log), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+}
+
+// runFakeKimi executes the backend against a fake kimi binary and drains
+// the session, returning the final Result.
+func runFakeKimi(t *testing.T, fakePath string, opts ExecOptions) Result {
+	t.Helper()
+	backend, err := New("kimi", Config{ExecutablePath: fakePath, Logger: slog.Default()})
+	if err != nil {
+		t.Fatalf("new kimi backend: %v", err)
+	}
+	if opts.Timeout == 0 {
+		opts.Timeout = 15 * time.Second
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	session, err := backend.Execute(ctx, "prompt-ignored", opts)
+	if err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	go func() {
+		for range session.Messages {
+		}
+	}()
+	select {
+	case result, ok := <-session.Result:
+		if !ok {
+			t.Fatal("result channel closed without a value")
+		}
+		return result
+	case <-time.After(30 * time.Second):
+		t.Fatal("timeout waiting for result")
+		return Result{}
+	}
+}
+
+// TestKimiBackendSwallowedTurnFailureFailsRun is the M-95 core regression
+// test: kimi answers session/prompt with stopReason=end_turn even though
+// the turn died provider-side, streaming no output and flushing no
+// usage.record. The backend must not report a silent success — it must
+// cross-check the session's logs/kimi-code.log, fail the run with the
+// real provider error, and drop the session id so the next run starts
+// fresh instead of resuming the poisoned context.
+func TestKimiBackendSwallowedTurnFailureFailsRun(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("KIMI_CODE_HOME", home)
+
+	providerMsg := "400 the message at position 168 with role 'assistant' must not be empty"
+	// The wire exists (kimi creates it at session start) but the failed
+	// turn flushed no usage.record; the log holds the in-window failure.
+	seedKimiSessionFiles(t, home, "ses_swallowed",
+		`{"type":"llm.request","kind":"loop","model":"k3"}`+"\n",
+		kimiTurnFailedLogLines(time.Now(), 1, providerMsg))
+
+	fakePath := filepath.Join(t.TempDir(), "kimi")
+	writeTestExecutable(t, fakePath, []byte(fakeKimiACPSwallowedFailureScript()))
+
+	result := runFakeKimi(t, fakePath, ExecOptions{})
+
+	if result.Status != "failed" {
+		t.Fatalf("expected status=failed, got %q (error=%q)", result.Status, result.Error)
+	}
+	if !strings.Contains(result.Error, "provider.api_error") {
+		t.Errorf("expected error to name the provider error code, got %q", result.Error)
+	}
+	if !strings.Contains(result.Error, providerMsg) {
+		t.Errorf("expected error to surface the provider message, got %q", result.Error)
+	}
+	if result.SessionID != "" {
+		t.Errorf("expected session id to be dropped so the next run starts fresh, got %q", result.SessionID)
+	}
+}
+
+// TestKimiBackendSwallowedTurnFailureDropsPoisonedSession covers the
+// poisoned-session loop from M-95: a resumed session whose context is
+// corrupt fails every turn the same silent way. When the swallowed
+// failure is detected on a resume, the Result must carry an empty
+// SessionID so the daemon's resume-failure fallback retries with a fresh
+// session instead of resuming the brick forever.
+func TestKimiBackendSwallowedTurnFailureDropsPoisonedSession(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("KIMI_CODE_HOME", home)
+
+	providerMsg := "400 the message at position 168 with role 'assistant' must not be empty"
+	seedKimiSessionFiles(t, home, "ses_poisoned",
+		`{"type":"llm.request","kind":"loop","model":"k3"}`+"\n",
+		kimiTurnFailedLogLines(time.Now(), 7, providerMsg))
+
+	fakePath := filepath.Join(t.TempDir(), "kimi")
+	writeTestExecutable(t, fakePath, []byte(fakeKimiACPSwallowedFailureScript()))
+
+	result := runFakeKimi(t, fakePath, ExecOptions{ResumeSessionID: "ses_poisoned"})
+
+	if result.Status != "failed" {
+		t.Fatalf("expected status=failed, got %q (error=%q)", result.Status, result.Error)
+	}
+	if result.SessionID != "" {
+		t.Errorf("expected empty session id so the daemon's fresh-session retry fires, got %q", result.SessionID)
+	}
+}
+
+// TestKimiBackendHealthyEmptyCompletionNotFlagged guards the false-positive
+// side: a legit answer with no text (the turn really ran and flushed its
+// usage.record) is a valid empty completion and must NOT be failed by the
+// kimi-code.log cross-check — even when the log still holds failure
+// entries from a previous run on the same session.
+func TestKimiBackendHealthyEmptyCompletionNotFlagged(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("KIMI_CODE_HOME", home)
+
+	now := time.Now()
+	// In-window usage.record for the turn; only stale (previous run)
+	// failure entries in the log.
+	seedKimiSessionFiles(t, home, "ses_swallowed",
+		kimiWireRec("kimi-code/k3", 100, 10, 0, 0, now)+"\n",
+		kimiTurnFailedLogLines(now.Add(-time.Hour), 1, "400 the message at position 168 with role 'assistant' must not be empty"))
+
+	fakePath := filepath.Join(t.TempDir(), "kimi")
+	writeTestExecutable(t, fakePath, []byte(fakeKimiACPSwallowedFailureScript()))
+
+	result := runFakeKimi(t, fakePath, ExecOptions{})
+
+	if result.Status != "completed" {
+		t.Fatalf("expected status=completed, got %q (error=%q)", result.Status, result.Error)
+	}
+	if result.SessionID != "ses_swallowed" {
+		t.Errorf("expected session id preserved on a healthy run, got %q", result.SessionID)
+	}
+	if u := result.Usage["kimi-code/k3"]; u.InputTokens != 100 || u.OutputTokens != 10 {
+		t.Errorf("expected wire usage on the healthy run, got %+v", result.Usage)
+	}
+}
+
+// TestReadKimiTurnFailure pins the kimi-code.log cross-check itself:
+// in-window failures are found with the provider error extracted, stale
+// entries from previous runs are ignored, and a missing log means "no
+// signal" (older kimi builds), never a false positive.
+func TestReadKimiTurnFailure(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("KIMI_CODE_HOME", home)
+
+	now := time.Now()
+	providerMsg := "400 the message at position 168 with role 'assistant' must not be empty"
+
+	tests := []struct {
+		name        string
+		log         string
+		wantFound   bool
+		wantMsgPart string
+	}{
+		{
+			name:        "in-window failure surfaces the provider error",
+			log:         kimiTurnFailedLogLines(now, 3, providerMsg),
+			wantFound:   true,
+			wantMsgPart: providerMsg,
+		},
+		{
+			name:        "stale failure from a previous run is ignored",
+			log:         kimiTurnFailedLogLines(now.Add(-time.Hour), 3, providerMsg),
+			wantFound:   false,
+			wantMsgPart: "",
+		},
+		{
+			name: "mixed stale and in-window failures finds the new one",
+			log: kimiTurnFailedLogLines(now.Add(-time.Hour), 1, "stale boom") +
+				kimiTurnFailedLogLines(now, 2, providerMsg),
+			wantFound:   true,
+			wantMsgPart: providerMsg,
+		},
+		{
+			name:        "bare turn failed without detail line still flags",
+			log:         fmt.Sprintf("%s ERROR turn failed  turnId=4\n", now.UTC().Format("2006-01-02T15:04:05.000Z07:00")),
+			wantFound:   true,
+			wantMsgPart: "turn failed",
+		},
+		{
+			name:        "healthy log with no failure entries",
+			log:         fmt.Sprintf("%s INFO  llm response  turnStep=0/1 outputTokens=42\n", now.UTC().Format("2006-01-02T15:04:05.000Z07:00")),
+			wantFound:   false,
+			wantMsgPart: "",
+		},
+		{
+			name: "malformed lines are skipped",
+			log: "not a log line at all\n" +
+				"ERROR turn failed without timestamp\n" +
+				kimiTurnFailedLogLines(now, 5, providerMsg),
+			wantFound:   true,
+			wantMsgPart: providerMsg,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			seedKimiSessionFiles(t, home, "ses_log", "", tt.log)
+			msg, found := readKimiTurnFailure("ses_log", now.Add(-time.Minute), slog.Default())
+			if found != tt.wantFound {
+				t.Fatalf("found = %v, want %v (msg=%q)", found, tt.wantFound, msg)
+			}
+			if tt.wantMsgPart != "" && !strings.Contains(msg, tt.wantMsgPart) {
+				t.Fatalf("expected message to contain %q, got %q", tt.wantMsgPart, msg)
+			}
+			// Clean up so subtests don't see each other's files.
+			if err := os.RemoveAll(filepath.Join(home, "sessions")); err != nil {
+				t.Fatal(err)
+			}
+		})
+	}
+}
+
+// TestReadKimiTurnFailureMissingLog pins the no-signal case: kimi builds
+// that write no session log (or a custom data dir) must not false-positive.
+func TestReadKimiTurnFailureMissingLog(t *testing.T) {
+	t.Setenv("KIMI_CODE_HOME", t.TempDir())
+	msg, found := readKimiTurnFailure("session-nope", time.Now().Add(-time.Minute), slog.Default())
+	if found {
+		t.Fatalf("expected found=false for missing log, got msg=%q", msg)
 	}
 }

--- a/server/pkg/agent/kimi_test.go
+++ b/server/pkg/agent/kimi_test.go
@@ -903,3 +903,138 @@ func TestReadKimiTurnFailureMissingLog(t *testing.T) {
 		t.Fatalf("expected found=false for missing log, got msg=%q", msg)
 	}
 }
+
+// fakeKimiACPSetConfigRecordingScript impersonates `kimi acp` and writes the
+// JSON-RPC request bodies it receives to requestsFile so tests can assert the
+// shape of session/set_config_option calls.
+func fakeKimiACPSetConfigRecordingScript(requestsFile string) string {
+	return `#!/bin/sh
+while IFS= read -r line; do
+  id=$(printf '%s' "$line" | sed -n 's/.*"id":\([0-9]*\).*/\1/p')
+  printf '%s\n' "$line" >> ` + strconv.Quote(requestsFile) + `
+  case "$line" in
+    *'"method":"initialize"'*)
+      printf '{"jsonrpc":"2.0","id":%s,"result":{"protocolVersion":1,"agentCapabilities":{}}}\n' "$id"
+      ;;
+    *'"method":"session/new"'*)
+      printf '{"jsonrpc":"2.0","id":%s,"result":{"sessionId":"ses_thinking"}}\n' "$id"
+      ;;
+    *'"method":"session/set_config_option"'*)
+      printf '{"jsonrpc":"2.0","id":%s,"result":{"configOptions":[]}}\n' "$id"
+      ;;
+    *'"method":"session/prompt"'*)
+      printf '{"jsonrpc":"2.0","id":%s,"result":{"stopReason":"end_turn"}}\n' "$id"
+      exit 0
+      ;;
+  esac
+done
+`
+}
+
+// TestKimiBackendSetsThinkingLevel verifies that a non-empty ThinkingLevel
+// is forwarded via session/set_config_option with configId "thinking" and
+// the chosen value before session/prompt.
+func TestKimiBackendSetsThinkingLevel(t *testing.T) {
+	t.Parallel()
+
+	requestsFile := filepath.Join(t.TempDir(), "requests.jsonl")
+	fakePath := filepath.Join(t.TempDir(), "kimi")
+	writeTestExecutable(t, fakePath, []byte(fakeKimiACPSetConfigRecordingScript(requestsFile)))
+
+	result := runFakeKimi(t, fakePath, ExecOptions{ThinkingLevel: "max"})
+	if result.Status != "completed" {
+		t.Fatalf("expected status=completed, got %q (error=%q)", result.Status, result.Error)
+	}
+
+	raw, err := os.ReadFile(requestsFile)
+	if err != nil {
+		t.Fatalf("read requests file: %v", err)
+	}
+
+	var found bool
+	for _, line := range strings.Split(strings.TrimSpace(string(raw)), "\n") {
+		if !strings.Contains(line, `"method":"session/set_config_option"`) {
+			continue
+		}
+		found = true
+		if !strings.Contains(line, `"configId":"thinking"`) {
+			t.Errorf("set_config_option missing configId=thinking: %s", line)
+		}
+		if !strings.Contains(line, `"value":"max"`) {
+			t.Errorf("set_config_option missing value=max: %s", line)
+		}
+		if !strings.Contains(line, `"sessionId":"ses_thinking"`) {
+			t.Errorf("set_config_option missing sessionId: %s", line)
+		}
+	}
+	if !found {
+		t.Fatalf("session/set_config_option call not recorded")
+	}
+}
+
+// fakeKimiACPSetConfigFailureScript impersonates `kimi acp` rejecting the
+// thinking-level change. The backend must fail the task (not silently run
+// on the default level).
+func fakeKimiACPSetConfigFailureScript() string {
+	return `#!/bin/sh
+while IFS= read -r line; do
+  id=$(printf '%s' "$line" | sed -n 's/.*"id":\([0-9]*\).*/\1/p')
+  case "$line" in
+    *'"method":"initialize"'*)
+      printf '{"jsonrpc":"2.0","id":%s,"result":{"protocolVersion":1,"agentCapabilities":{}}}\n' "$id"
+      ;;
+    *'"method":"session/new"'*)
+      printf '{"jsonrpc":"2.0","id":%s,"result":{"sessionId":"ses_thinking_fail"}}\n' "$id"
+      ;;
+    *'"method":"session/set_config_option"'*)
+      printf '{"jsonrpc":"2.0","id":%s,"error":{"code":-32602,"message":"Invalid params","data":{"value":"Unsupported thinking level"}}}\n' "$id"
+      exit 0
+      ;;
+  esac
+done
+`
+}
+
+// TestKimiBackendSetThinkingLevelFailureFailsTask pins the fail-hard
+// behaviour: if the runtime rejects the requested thinking level, the task
+// must fail rather than falling back to the default.
+func TestKimiBackendSetThinkingLevelFailureFailsTask(t *testing.T) {
+	t.Parallel()
+
+	fakePath := filepath.Join(t.TempDir(), "kimi")
+	writeTestExecutable(t, fakePath, []byte(fakeKimiACPSetConfigFailureScript()))
+
+	result := runFakeKimi(t, fakePath, ExecOptions{ThinkingLevel: "max"})
+	if result.Status != "failed" {
+		t.Fatalf("expected status=failed, got %q (error=%q)", result.Status, result.Error)
+	}
+	if !strings.Contains(result.Error, `could not set thinking level "max"`) {
+		t.Errorf("expected error to name the requested level, got %q", result.Error)
+	}
+	if !strings.Contains(result.Error, "Unsupported thinking level") {
+		t.Errorf("expected error to surface upstream message, got %q", result.Error)
+	}
+}
+
+// TestKimiBackendOmitsSetConfigOptionWhenNoThinkingLevel verifies that no
+// session/set_config_option call is made when ThinkingLevel is empty.
+func TestKimiBackendOmitsSetConfigOptionWhenNoThinkingLevel(t *testing.T) {
+	t.Parallel()
+
+	requestsFile := filepath.Join(t.TempDir(), "requests.jsonl")
+	fakePath := filepath.Join(t.TempDir(), "kimi")
+	writeTestExecutable(t, fakePath, []byte(fakeKimiACPSetConfigRecordingScript(requestsFile)))
+
+	result := runFakeKimi(t, fakePath, ExecOptions{})
+	if result.Status != "completed" {
+		t.Fatalf("expected status=completed, got %q (error=%q)", result.Status, result.Error)
+	}
+
+	raw, err := os.ReadFile(requestsFile)
+	if err != nil {
+		t.Fatalf("read requests file: %v", err)
+	}
+	if strings.Contains(string(raw), `"method":"session/set_config_option"`) {
+		t.Fatalf("set_config_option should not be called when ThinkingLevel is empty")
+	}
+}

--- a/server/pkg/agent/kimi_test.go
+++ b/server/pkg/agent/kimi_test.go
@@ -3,6 +3,7 @@ package agent
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"log/slog"
 	"os"
 	"path/filepath"
@@ -333,5 +334,74 @@ func TestKimiResumeIncludesMcpServers(t *testing.T) {
 	}
 	if len(servers) != 1 || servers[0].(map[string]any)["name"] != "fetch" {
 		t.Fatalf("session/resume.mcpServers: got %v, want one entry named fetch", servers)
+	}
+}
+
+// kimiWireRec builds one wire.jsonl usage.record line for tests.
+func kimiWireRec(model string, in, out, cacheR, cacheW int64, at time.Time) string {
+	return fmt.Sprintf(`{"type":"usage.record","model":%q,"usage":{"inputOther":%d,"output":%d,"inputCacheRead":%d,"inputCacheCreation":%d},"usageScope":"turn","time":%d}`,
+		model, in, out, cacheR, cacheW, at.UnixMilli())
+}
+
+func TestReadKimiWireUsageSumsRecentRecordsPerModel(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("KIMI_CODE_HOME", home)
+
+	now := time.Now()
+	wire := strings.Join([]string{
+		`{"type":"llm.request","kind":"loop","model":"k3"}`,
+		"not json at all",
+		kimiWireRec("kimi-code/k3", 100, 10, 5, 1, now.Add(-2*time.Second)),           // in window
+		kimiWireRec("kimi-code/k3", 50, 5, 2, 0, now.Add(-3*time.Second)),             // in window, same model
+		kimiWireRec("kimi-code/kimi-for-coding", 7, 3, 0, 0, now.Add(-4*time.Second)), // in window, second model
+		kimiWireRec("kimi-code/k3", 9999, 9999, 0, 0, now.Add(-time.Hour)),            // previous task on a resumed session
+		kimiWireRec("", 4, 2, 0, 0, now),                                              // no model — skipped
+	}, "\n") + "\n"
+
+	dir := filepath.Join(home, "sessions", "wd_x_deadbeef", "session-abc", "agents", "main")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "wire.jsonl"), []byte(wire), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	got := readKimiWireUsage("session-abc", now.Add(-10*time.Second), slog.Default())
+	if len(got) != 2 {
+		t.Fatalf("expected 2 models, got %+v", got)
+	}
+	u := got["kimi-code/k3"]
+	if u.InputTokens != 150 || u.OutputTokens != 15 || u.CacheReadTokens != 7 || u.CacheWriteTokens != 1 {
+		t.Errorf("unexpected k3 totals: %+v", u)
+	}
+	if u := got["kimi-code/kimi-for-coding"]; u.InputTokens != 7 || u.OutputTokens != 3 {
+		t.Errorf("unexpected coding totals: %+v", u)
+	}
+}
+
+func TestReadKimiWireUsageMissingSessionReturnsNil(t *testing.T) {
+	t.Setenv("KIMI_CODE_HOME", t.TempDir())
+	if got := readKimiWireUsage("session-nope", time.Now().Add(-time.Minute), slog.Default()); got != nil {
+		t.Fatalf("expected nil for missing wire, got %+v", got)
+	}
+}
+
+func TestReadKimiWireUsageSumsAcrossAgentWires(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("KIMI_CODE_HOME", home)
+	now := time.Now()
+	line := kimiWireRec("kimi-code/k3", 10, 1, 0, 0, now) + "\n"
+	for _, agentName := range []string{"main", "task-critic"} {
+		dir := filepath.Join(home, "sessions", "wd_x_deadbeef", "session-abc", "agents", agentName)
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(dir, "wire.jsonl"), []byte(line), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	got := readKimiWireUsage("session-abc", now.Add(-10*time.Second), slog.Default())
+	if u := got["kimi-code/k3"]; u.InputTokens != 20 || u.OutputTokens != 2 {
+		t.Fatalf("expected both agent wires summed, got %+v", got)
 	}
 }

--- a/server/pkg/agent/kimi_test.go
+++ b/server/pkg/agent/kimi_test.go
@@ -432,7 +432,9 @@ func TestWaitKimiWireUsageSettlesAcrossAgentWires(t *testing.T) {
 		t.Fatal(err)
 	}
 	// The wire exists from session start but holds no usage record yet —
-	// kimi flushes it only after answering session/prompt.
+	// kimi flushes it only after answering session/prompt. The snapshot
+	// taken right after session/new therefore has no usage.record, and
+	// every flushed record lands strictly after it.
 	mainWire := filepath.Join(mainDir, "wire.jsonl")
 	if err := os.WriteFile(mainWire, []byte(`{"type":"llm.request","kind":"loop","model":"k3"}`+"\n"), 0o644); err != nil {
 		t.Fatal(err)
@@ -449,7 +451,7 @@ func TestWaitKimiWireUsageSettlesAcrossAgentWires(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if _, err := f.WriteString(kimiWireRec("kimi-code/k3", 100, 10, 0, 0, now) + "\n"); err != nil {
+	if _, err := f.WriteString(kimiWireRec("kimi-code/k3", 100, 10, 0, 0, now.Add(kimiWireUsagePollInterval)) + "\n"); err != nil {
 		f.Close()
 		t.Fatal(err)
 	}
@@ -462,7 +464,7 @@ func TestWaitKimiWireUsageSettlesAcrossAgentWires(t *testing.T) {
 	if err := os.MkdirAll(criticDir, 0o755); err != nil {
 		t.Fatal(err)
 	}
-	if err := os.WriteFile(filepath.Join(criticDir, "wire.jsonl"), []byte(kimiWireRec("kimi-code/k3", 7, 3, 0, 0, now)+"\n"), 0o644); err != nil {
+	if err := os.WriteFile(filepath.Join(criticDir, "wire.jsonl"), []byte(kimiWireRec("kimi-code/k3", 7, 3, 0, 0, now.Add(2*kimiWireUsagePollInterval))+"\n"), 0o644); err != nil {
 		t.Fatal(err)
 	}
 
@@ -491,6 +493,37 @@ func TestWaitKimiWireUsageNoWireReturnsImmediately(t *testing.T) {
 	}
 	if elapsed := time.Since(start); elapsed > kimiWireUsagePollTimeout/2 {
 		t.Fatalf("expected immediate return on missing wire, took %s", elapsed)
+	}
+}
+
+// TestReadKimiWireUsageIgnoresRecordsBeforeSnapshot is the regression
+// guard for the grace-window double-billing bug: a previous task's
+// usage.record that landed shortly before the current task started must
+// NOT be summed into the current task's usage.
+func TestReadKimiWireUsageIgnoresRecordsBeforeSnapshot(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("KIMI_CODE_HOME", home)
+
+	now := time.Now()
+	dir := filepath.Join(home, "sessions", "wd_x_deadbeef", "session-abc", "agents", "main")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	wire := strings.Join([]string{
+		kimiWireRec("kimi-code/k3", 9999, 9999, 0, 0, now.Add(-2*time.Second)), // previous task
+		kimiWireRec("kimi-code/k3", 50, 5, 0, 0, now.Add(time.Second)),         // current task
+	}, "\n") + "\n"
+	if err := os.WriteFile(filepath.Join(dir, "wire.jsonl"), []byte(wire), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	got, foundWire := readKimiWireUsage("session-abc", now, slog.Default())
+	if !foundWire {
+		t.Fatal("expected foundWire=true with a wire file present")
+	}
+	u := got["kimi-code/k3"]
+	if u.InputTokens != 50 || u.OutputTokens != 5 {
+		t.Fatalf("expected only the current task's usage (50 in / 5 out), got %+v", got)
 	}
 }
 
@@ -528,6 +561,8 @@ func TestAccumulateKimiWireFileReadsPastOversizedLines(t *testing.T) {
 // whose prompt ends with the given canned JSON-RPC fragment — e.g.
 // `"error":{"code":-32603,...}` for a failed turn or
 // `"result":{"stopReason":"cancelled"}` for a cancelled one.
+// It writes a usage.record to the session wire during session/prompt so
+// the record lands strictly after the snapshot taken at session start.
 func fakeKimiACPPromptOutcomeScript(outcome string) string {
 	return `#!/bin/sh
 while IFS= read -r line; do
@@ -540,6 +575,11 @@ while IFS= read -r line; do
       printf '{"jsonrpc":"2.0","id":%s,"result":{"sessionId":"ses_wire"}}\n' "$id"
       ;;
     *'"method":"session/prompt"'*)
+      if [ -n "$KIMI_CODE_HOME" ]; then
+        wire_dir="$KIMI_CODE_HOME/sessions/wd_x_deadbeef/ses_wire/agents/main"
+        mkdir -p "$wire_dir"
+        printf '{"type":"usage.record","model":"kimi-code/k3","usage":{"inputOther":120,"output":30,"inputCacheRead":8,"inputCacheCreation":2},"usageScope":"turn","time":%s}\n' "$(date +%s%3N)" >> "$wire_dir/wire.jsonl"
+      fi
       printf '{"jsonrpc":"2.0","id":%s,` + outcome + `}\n' "$id"
       exit 0
       ;;
@@ -568,17 +608,6 @@ func TestKimiBackendRecoversWireUsageOnNonCompletedRun(t *testing.T) {
 
 			home := t.TempDir()
 			t.Setenv("KIMI_CODE_HOME", home)
-
-			// Pre-seed the session wire the way kimi leaves it after a
-			// turn that consumed tokens but did not complete.
-			wireDir := filepath.Join(home, "sessions", "wd_x_deadbeef", "ses_wire", "agents", "main")
-			if err := os.MkdirAll(wireDir, 0o755); err != nil {
-				t.Fatal(err)
-			}
-			wire := kimiWireRec("kimi-code/k3", 120, 30, 8, 2, time.Now()) + "\n"
-			if err := os.WriteFile(filepath.Join(wireDir, "wire.jsonl"), []byte(wire), 0o644); err != nil {
-				t.Fatal(err)
-			}
 
 			fakePath := filepath.Join(t.TempDir(), "kimi")
 			writeTestExecutable(t, fakePath, []byte(fakeKimiACPPromptOutcomeScript(tt.outcome)))
@@ -735,10 +764,12 @@ func TestKimiBackendSwallowedTurnFailureFailsRun(t *testing.T) {
 
 	providerMsg := "400 the message at position 168 with role 'assistant' must not be empty"
 	// The wire exists (kimi creates it at session start) but the failed
-	// turn flushed no usage.record; the log holds the in-window failure.
+	// turn flushed no usage.record. The failure log is seeded with a
+	// future timestamp so it is strictly after the wire snapshot taken at
+	// session start, simulating an in-window turn failure.
 	seedKimiSessionFiles(t, home, "ses_swallowed",
 		`{"type":"llm.request","kind":"loop","model":"k3"}`+"\n",
-		kimiTurnFailedLogLines(time.Now(), 1, providerMsg))
+		kimiTurnFailedLogLines(time.Now().Add(time.Hour), 1, providerMsg))
 
 	fakePath := filepath.Join(t.TempDir(), "kimi")
 	writeTestExecutable(t, fakePath, []byte(fakeKimiACPSwallowedFailureScript()))
@@ -770,9 +801,13 @@ func TestKimiBackendSwallowedTurnFailureDropsPoisonedSession(t *testing.T) {
 	t.Setenv("KIMI_CODE_HOME", home)
 
 	providerMsg := "400 the message at position 168 with role 'assistant' must not be empty"
+	// The poisoned session carries a stale failure from a previous turn
+	// plus a fresh failure seeded with a future timestamp so it is after
+	// the snapshot taken at session/resume.
 	seedKimiSessionFiles(t, home, "ses_poisoned",
 		`{"type":"llm.request","kind":"loop","model":"k3"}`+"\n",
-		kimiTurnFailedLogLines(time.Now(), 7, providerMsg))
+		kimiTurnFailedLogLines(time.Now().Add(-time.Hour), 7, "previous poisoned turn")+
+			kimiTurnFailedLogLines(time.Now().Add(time.Hour), 8, providerMsg))
 
 	fakePath := filepath.Join(t.TempDir(), "kimi")
 	writeTestExecutable(t, fakePath, []byte(fakeKimiACPSwallowedFailureScript()))
@@ -787,6 +822,34 @@ func TestKimiBackendSwallowedTurnFailureDropsPoisonedSession(t *testing.T) {
 	}
 }
 
+// fakeKimiACPHealthyEmptyCompletionScript impersonates `kimi acp` for a
+// turn that returns stopReason=end_turn with no text but still flushes a
+// usage.record to the session wire.
+func fakeKimiACPHealthyEmptyCompletionScript() string {
+	return `#!/bin/sh
+while IFS= read -r line; do
+  id=$(printf '%s' "$line" | sed -n 's/.*"id":\([0-9]*\).*/\1/p')
+  case "$line" in
+    *'"method":"initialize"'*)
+      printf '{"jsonrpc":"2.0","id":%s,"result":{"protocolVersion":1,"agentCapabilities":{}}}\n' "$id"
+      ;;
+    *'"method":"session/new"'*)
+      printf '{"jsonrpc":"2.0","id":%s,"result":{"sessionId":"ses_swallowed"}}\n' "$id"
+      ;;
+    *'"method":"session/prompt"'*)
+      if [ -n "$KIMI_CODE_HOME" ]; then
+        wire_dir="$KIMI_CODE_HOME/sessions/wd_x_deadbeef/ses_swallowed/agents/main"
+        mkdir -p "$wire_dir"
+        printf '{"type":"usage.record","model":"kimi-code/k3","usage":{"inputOther":100,"output":10,"inputCacheRead":0,"inputCacheCreation":0},"usageScope":"turn","time":%s}\n' "$(date +%s%3N)" >> "$wire_dir/wire.jsonl"
+      fi
+      printf '{"jsonrpc":"2.0","id":%s,"result":{"stopReason":"end_turn"}}\n' "$id"
+      exit 0
+      ;;
+  esac
+done
+`
+}
+
 // TestKimiBackendHealthyEmptyCompletionNotFlagged guards the false-positive
 // side: a legit answer with no text (the turn really ran and flushed its
 // usage.record) is a valid empty completion and must NOT be failed by the
@@ -797,14 +860,15 @@ func TestKimiBackendHealthyEmptyCompletionNotFlagged(t *testing.T) {
 	t.Setenv("KIMI_CODE_HOME", home)
 
 	now := time.Now()
-	// In-window usage.record for the turn; only stale (previous run)
-	// failure entries in the log.
+	// Only stale (previous run) failure entries in the log; the current
+	// turn's usage.record is written by the fake script during
+	// session/prompt, strictly after the wire snapshot.
 	seedKimiSessionFiles(t, home, "ses_swallowed",
-		kimiWireRec("kimi-code/k3", 100, 10, 0, 0, now)+"\n",
+		"",
 		kimiTurnFailedLogLines(now.Add(-time.Hour), 1, "400 the message at position 168 with role 'assistant' must not be empty"))
 
 	fakePath := filepath.Join(t.TempDir(), "kimi")
-	writeTestExecutable(t, fakePath, []byte(fakeKimiACPSwallowedFailureScript()))
+	writeTestExecutable(t, fakePath, []byte(fakeKimiACPHealthyEmptyCompletionScript()))
 
 	result := runFakeKimi(t, fakePath, ExecOptions{})
 

--- a/server/pkg/agent/kimi_test.go
+++ b/server/pkg/agent/kimi_test.go
@@ -858,9 +858,12 @@ func TestKimiBackendHealthyEmptyCompletionNotFlagged(t *testing.T) {
 	// Only stale (previous run) failure entries in the log; the current
 	// turn's usage.record is written by the fake script during
 	// session/prompt, strictly after the wire snapshot.
-	seedKimiSessionFiles(t, home, "ses_swallowed",
-		"",
-		kimiTurnFailedLogLines(now.Add(-time.Hour), 1, "400 the message at position 168 with role 'assistant' must not be empty"))
+	logLines := kimiTurnFailedLogLines(now.Add(-time.Hour), 1, "400 the message at position 168 with role 'assistant' must not be empty")
+	// In-window echoed content containing the substring "turn failed" must
+	// not be misread as a failure marker — the bare marker requires the
+	// ERROR level prefix.
+	logLines += fmt.Sprintf("%s INFO  echo: user said 'turn failed' in the prompt\n", now.UTC().Format("2006-01-02T15:04:05.000Z07:00"))
+	seedKimiSessionFiles(t, home, "ses_swallowed", "", logLines)
 
 	fakePath := filepath.Join(t.TempDir(), "kimi")
 	writeTestExecutable(t, fakePath, []byte(fakeKimiACPHealthyEmptyCompletionScript()))

--- a/server/pkg/agent/kimi_test.go
+++ b/server/pkg/agent/kimi_test.go
@@ -367,7 +367,7 @@ func TestReadKimiWireUsageSumsRecentRecordsPerModel(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	got, foundWire := readKimiWireUsage("session-abc", now.Add(-10*time.Second), slog.Default())
+	got, foundWire := readKimiWireUsage("session-abc", now.Add(-10*time.Second), home, slog.Default())
 	if !foundWire {
 		t.Fatal("expected foundWire=true with a wire file present")
 	}
@@ -384,8 +384,7 @@ func TestReadKimiWireUsageSumsRecentRecordsPerModel(t *testing.T) {
 }
 
 func TestReadKimiWireUsageMissingSessionReturnsNil(t *testing.T) {
-	t.Setenv("KIMI_CODE_HOME", t.TempDir())
-	got, foundWire := readKimiWireUsage("session-nope", time.Now().Add(-time.Minute), slog.Default())
+	got, foundWire := readKimiWireUsage("session-nope", time.Now().Add(-time.Minute), t.TempDir(), slog.Default())
 	if got != nil {
 		t.Fatalf("expected nil for missing wire, got %+v", got)
 	}
@@ -408,7 +407,7 @@ func TestReadKimiWireUsageSumsAcrossAgentWires(t *testing.T) {
 			t.Fatal(err)
 		}
 	}
-	got, foundWire := readKimiWireUsage("session-abc", now.Add(-10*time.Second), slog.Default())
+	got, foundWire := readKimiWireUsage("session-abc", now.Add(-10*time.Second), home, slog.Default())
 	if !foundWire {
 		t.Fatal("expected foundWire=true with wire files present")
 	}
@@ -424,7 +423,6 @@ func TestReadKimiWireUsageSumsAcrossAgentWires(t *testing.T) {
 // so the late second wire is counted too.
 func TestWaitKimiWireUsageSettlesAcrossAgentWires(t *testing.T) {
 	home := t.TempDir()
-	t.Setenv("KIMI_CODE_HOME", home)
 
 	now := time.Now()
 	mainDir := filepath.Join(home, "sessions", "wd_x_deadbeef", "session-abc", "agents", "main")
@@ -442,7 +440,7 @@ func TestWaitKimiWireUsageSettlesAcrossAgentWires(t *testing.T) {
 
 	resultCh := make(chan map[string]TokenUsage, 1)
 	go func() {
-		resultCh <- waitKimiWireUsage("session-abc", now, slog.Default())
+		resultCh <- waitKimiWireUsage("session-abc", now, home, slog.Default())
 	}()
 
 	// Main agent flushes first…
@@ -485,10 +483,8 @@ func TestWaitKimiWireUsageSettlesAcrossAgentWires(t *testing.T) {
 // writes none (older CLI, custom data dir). The wait must bail at once,
 // not burn the whole poll budget on every completed run.
 func TestWaitKimiWireUsageNoWireReturnsImmediately(t *testing.T) {
-	t.Setenv("KIMI_CODE_HOME", t.TempDir())
-
 	start := time.Now()
-	if got := waitKimiWireUsage("session-nope", start.Add(-time.Minute), slog.Default()); got != nil {
+	if got := waitKimiWireUsage("session-nope", start.Add(-time.Minute), t.TempDir(), slog.Default()); got != nil {
 		t.Fatalf("expected nil usage, got %+v", got)
 	}
 	if elapsed := time.Since(start); elapsed > kimiWireUsagePollTimeout/2 {
@@ -502,7 +498,6 @@ func TestWaitKimiWireUsageNoWireReturnsImmediately(t *testing.T) {
 // NOT be summed into the current task's usage.
 func TestReadKimiWireUsageIgnoresRecordsBeforeSnapshot(t *testing.T) {
 	home := t.TempDir()
-	t.Setenv("KIMI_CODE_HOME", home)
 
 	now := time.Now()
 	dir := filepath.Join(home, "sessions", "wd_x_deadbeef", "session-abc", "agents", "main")
@@ -517,7 +512,7 @@ func TestReadKimiWireUsageIgnoresRecordsBeforeSnapshot(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	got, foundWire := readKimiWireUsage("session-abc", now, slog.Default())
+	got, foundWire := readKimiWireUsage("session-abc", now, home, slog.Default())
 	if !foundWire {
 		t.Fatal("expected foundWire=true with a wire file present")
 	}
@@ -883,13 +878,90 @@ func TestKimiBackendHealthyEmptyCompletionNotFlagged(t *testing.T) {
 	}
 }
 
+// fakeKimiACPChildEnvWireScript impersonates `kimi acp` and writes a
+// usage.record to the session wire using the child process's
+// KIMI_CODE_HOME. Used to prove that usage recovery reads from the child's
+// env, not the daemon's.
+func fakeKimiACPChildEnvWireScript() string {
+	return `#!/bin/sh
+while IFS= read -r line; do
+  id=$(printf '%s' "$line" | sed -n 's/.*"id":\([0-9]*\).*/\1/p')
+  case "$line" in
+    *'"method":"initialize"'*)
+      printf '{"jsonrpc":"2.0","id":%s,"result":{"protocolVersion":1,"agentCapabilities":{}}}\n' "$id"
+      ;;
+    *'"method":"session/new"'*)
+      printf '{"jsonrpc":"2.0","id":%s,"result":{"sessionId":"ses_env_child"}}\n' "$id"
+      ;;
+    *'"method":"session/prompt"'*)
+      if [ -n "$KIMI_CODE_HOME" ]; then
+        wire_dir="$KIMI_CODE_HOME/sessions/wd_x_deadbeef/ses_env_child/agents/main"
+        mkdir -p "$wire_dir"
+        printf '{"type":"usage.record","model":"kimi-code/k3","usage":{"inputOther":42,"output":7,"inputCacheRead":0,"inputCacheCreation":0},"usageScope":"turn","time":%s}\n' "$(date +%s%3N)" >> "$wire_dir/wire.jsonl"
+      fi
+      printf '{"jsonrpc":"2.0","id":%s,"result":{"stopReason":"end_turn"}}\n' "$id"
+      exit 0
+      ;;
+  esac
+done
+`
+}
+
+// TestKimiBackendUsesChildEnvKimiCodeHome is the regression guard for
+// must-fix #2: usage recovery must resolve KIMI_CODE_HOME from the child
+// process's environment (built from Config.Env), not from the daemon's own
+// environment. The daemon env points to an empty directory, while Config.Env
+// points to the real session wire.
+func TestKimiBackendUsesChildEnvKimiCodeHome(t *testing.T) {
+	daemonHome := t.TempDir()
+	childHome := t.TempDir()
+	t.Setenv("KIMI_CODE_HOME", daemonHome)
+
+	fakePath := filepath.Join(t.TempDir(), "kimi")
+	writeTestExecutable(t, fakePath, []byte(fakeKimiACPChildEnvWireScript()))
+
+	backend, err := New("kimi", Config{
+		ExecutablePath: fakePath,
+		Logger:         slog.Default(),
+		Env:            map[string]string{"KIMI_CODE_HOME": childHome},
+	})
+	if err != nil {
+		t.Fatalf("new kimi backend: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	session, err := backend.Execute(ctx, "prompt-ignored", ExecOptions{Timeout: 5 * time.Second})
+	if err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	go func() {
+		for range session.Messages {
+		}
+	}()
+
+	select {
+	case result, ok := <-session.Result:
+		if !ok {
+			t.Fatal("result channel closed without a value")
+		}
+		if result.Status != "completed" {
+			t.Fatalf("expected status=completed, got %q (error=%q)", result.Status, result.Error)
+		}
+		if u := result.Usage["kimi-code/k3"]; u.InputTokens != 42 || u.OutputTokens != 7 {
+			t.Fatalf("expected usage from child-env KIMI_CODE_HOME, got %+v", result.Usage)
+		}
+	case <-time.After(10 * time.Second):
+		t.Fatal("timeout waiting for result")
+	}
+}
+
 // TestReadKimiTurnFailure pins the kimi-code.log cross-check itself:
 // in-window failures are found with the provider error extracted, stale
 // entries from previous runs are ignored, and a missing log means "no
 // signal" (older kimi builds), never a false positive.
 func TestReadKimiTurnFailure(t *testing.T) {
 	home := t.TempDir()
-	t.Setenv("KIMI_CODE_HOME", home)
 
 	now := time.Now()
 	providerMsg := "400 the message at position 168 with role 'assistant' must not be empty"
@@ -943,7 +1015,7 @@ func TestReadKimiTurnFailure(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			seedKimiSessionFiles(t, home, "ses_log", "", tt.log)
-			msg, found := readKimiTurnFailure("ses_log", now.Add(-time.Minute), slog.Default())
+			msg, found := readKimiTurnFailure("ses_log", now.Add(-time.Minute), home, slog.Default())
 			if found != tt.wantFound {
 				t.Fatalf("found = %v, want %v (msg=%q)", found, tt.wantFound, msg)
 			}
@@ -961,8 +1033,7 @@ func TestReadKimiTurnFailure(t *testing.T) {
 // TestReadKimiTurnFailureMissingLog pins the no-signal case: kimi builds
 // that write no session log (or a custom data dir) must not false-positive.
 func TestReadKimiTurnFailureMissingLog(t *testing.T) {
-	t.Setenv("KIMI_CODE_HOME", t.TempDir())
-	msg, found := readKimiTurnFailure("session-nope", time.Now().Add(-time.Minute), slog.Default())
+	msg, found := readKimiTurnFailure("session-nope", time.Now().Add(-time.Minute), t.TempDir(), slog.Default())
 	if found {
 		t.Fatalf("expected found=false for missing log, got msg=%q", msg)
 	}

--- a/server/pkg/agent/models.go
+++ b/server/pkg/agent/models.go
@@ -840,6 +840,16 @@ func discoverHermesModels(ctx context.Context, executablePath string) ([]Model, 
 // the `models.availableModels` block — parseACPSessionNewModels
 // handles both shapes.
 //
+// Kimi also advertises a per-session thinking-effort select under
+// `configOptions` with `category: "thought_level"` and `id: "thinking"`.
+// We capture the raw session/new response and attach the advertised
+// levels to every discovered model so the UI thinking picker works
+// for kimi the same way it does for claude/codex. If the runtime only
+// advertises "on" (kimi 0.27.0's current behavior), the picker shows
+// that single option. Levels may vary by model/version in future
+// builds; the discovery path is generic and follows whatever the CLI
+// returns.
+//
 // There is deliberately NO static fallback: the picker must reflect
 // what the installed CLI actually offers so the list stays in sync
 // with the account and CLI version. On failure we return an empty
@@ -847,11 +857,17 @@ func discoverHermesModels(ctx context.Context, executablePath string) ([]Model, 
 // UI then offers manual model entry, and cachedDiscovery never caches
 // empty results so the next load retries discovery.
 func discoverKimiModels(ctx context.Context, executablePath string) ([]Model, error) {
+	var capturedThinking *ModelThinking
+	captureRaw := func(raw json.RawMessage) {
+		capturedThinking = parseACPThoughtLevelOptions(raw)
+	}
+
 	models, err := discoverACPModels(ctx, executablePath, acpDiscoveryProvider{
 		defaultBin:   "kimi",
 		clientName:   "multica-model-discovery",
 		tmpdirPrefix: "multica-kimi-discovery-",
 		strictErrors: true,
+		captureRaw:   captureRaw,
 	})
 	if err != nil || len(models) == 0 {
 		if err != nil {
@@ -865,8 +881,76 @@ func discoverKimiModels(ctx context.Context, executablePath string) ([]Model, er
 		if models[i].Provider == "" {
 			models[i].Provider = "kimi"
 		}
+		if capturedThinking != nil {
+			models[i].Thinking = capturedThinking
+		}
 	}
 	return models, nil
+}
+
+// parseACPThoughtLevelOptions extracts the thinking-effort catalog from an
+// ACP session/new configOptions response. It looks for the select entry whose
+// category is "thought_level" (or id is "thinking" as a fallback) and returns
+// the advertised options as a ModelThinking catalog. nil means the runtime did
+// not surface a thinking control for this session/model.
+func parseACPThoughtLevelOptions(raw json.RawMessage) *ModelThinking {
+	var resp struct {
+		ConfigOptions []struct {
+			Type         string `json:"type"`
+			ID           string `json:"id"`
+			Category     string `json:"category"`
+			CurrentValue string `json:"currentValue"`
+			Options      []struct {
+				Value       string `json:"value"`
+				Name        string `json:"name"`
+				Description string `json:"description"`
+			} `json:"options"`
+		} `json:"configOptions"`
+	}
+	if err := json.Unmarshal(raw, &resp); err != nil {
+		return nil
+	}
+	for _, opt := range resp.ConfigOptions {
+		if opt.Type != "select" {
+			continue
+		}
+		if opt.Category != "thought_level" {
+			// Allow a bare "thinking" id only when the runtime omitted
+			// the category field.
+			if opt.Category != "" || opt.ID != "thinking" {
+				continue
+			}
+		}
+		if len(opt.Options) == 0 {
+			return nil
+		}
+		levels := make([]ThinkingLevel, 0, len(opt.Options))
+		seen := map[string]bool{}
+		for _, o := range opt.Options {
+			value := strings.TrimSpace(o.Value)
+			if value == "" || seen[value] {
+				continue
+			}
+			seen[value] = true
+			label := strings.TrimSpace(o.Name)
+			if label == "" || strings.EqualFold(label, "unknown") {
+				label = value
+			}
+			levels = append(levels, ThinkingLevel{
+				Value:       value,
+				Label:       label,
+				Description: strings.TrimSpace(o.Description),
+			})
+		}
+		if len(levels) == 0 {
+			return nil
+		}
+		return &ModelThinking{
+			SupportedLevels: levels,
+			DefaultLevel:    strings.TrimSpace(opt.CurrentValue),
+		}
+	}
+	return nil
 }
 
 // discoverKiroModels spins up a throwaway `kiro-cli acp` process and parses
@@ -951,6 +1035,11 @@ type acpDiscoveryProvider struct {
 	// Legacy discovery providers keep their empty-list behavior; Grok enables
 	// this so it can log the actual fallback reason.
 	strictErrors bool
+	// captureRaw receives the raw session/new response before it is parsed.
+	// It is used by providers (currently Kimi) that need to inspect config
+	// options beyond the model catalog. Shared callers leave this nil so the
+	// hook stays a no-op for Hermes/Kiro/Copilot/Qoder/Trae/Grok.
+	captureRaw func(json.RawMessage)
 }
 
 // discoverACPModels runs the ACP handshake for any agent CLI that
@@ -1107,6 +1196,9 @@ func discoverACPModels(ctx context.Context, executablePath string, p acpDiscover
 	})
 	if err != nil {
 		return fail("session/new", err)
+	}
+	if p.captureRaw != nil {
+		p.captureRaw(sessionResult)
 	}
 	models := parseACPSessionNewModels(sessionResult)
 	if len(models) == 0 {

--- a/server/pkg/agent/models.go
+++ b/server/pkg/agent/models.go
@@ -834,36 +834,39 @@ func discoverHermesModels(ctx context.Context, executablePath string) ([]Model, 
 
 // discoverKimiModels spins up a throwaway `kimi acp` process and
 // drives the same minimal ACP handshake as Hermes to surface the
-// model catalog advertised by Kimi's `session/new` response. Kimi
-// ≤0.28 returns a `models` block (`availableModels`/`currentModelId`);
-// 0.29 moved the same catalog into `configOptions` (MUL-5239). The
-// shared parser accepts both, so the discovery path stays identical.
+// model catalog the installed CLI advertises from `session/new`.
+// Current kimi builds (≥ 0.2x) return it via the ACP configOptions
+// schema (the select entry with category "model"); older builds used
+// the `models.availableModels` block — parseACPSessionNewModels
+// handles both shapes.
 //
-// On any failure (kimi missing, not logged in, config error) falls
-// back to kimiStaticModels so the UI picker stays usable offline.
+// There is deliberately NO static fallback: the picker must reflect
+// what the installed CLI actually offers so the list stays in sync
+// with the account and CLI version. On failure we return an empty
+// catalog (reason logged at debug, mirroring the Grok pattern); the
+// UI then offers manual model entry, and cachedDiscovery never caches
+// empty results so the next load retries discovery.
 func discoverKimiModels(ctx context.Context, executablePath string) ([]Model, error) {
 	models, err := discoverACPModels(ctx, executablePath, acpDiscoveryProvider{
 		defaultBin:   "kimi",
 		clientName:   "multica-model-discovery",
 		tmpdirPrefix: "multica-kimi-discovery-",
+		strictErrors: true,
 	})
 	if err != nil || len(models) == 0 {
 		if err != nil {
-			slog.Debug("kimi model discovery fell back to static catalog", "error", err)
+			slog.Debug("kimi model discovery returned no models", "error", err)
 		}
-		return kimiStaticModels(), nil
+		return []Model{}, nil
+	}
+	// Kimi model IDs (e.g. "kimi-code/k3") carry no colon prefix, so
+	// the shared parser leaves Provider empty — backfill it like Grok.
+	for i := range models {
+		if models[i].Provider == "" {
+			models[i].Provider = "kimi"
+		}
 	}
 	return models, nil
-}
-
-// kimiStaticModels is the offline fallback catalog for the Kimi CLI.
-// IDs match the model keys advertised by the Kimi Code platform.
-func kimiStaticModels() []Model {
-	return []Model{
-		{ID: "kimi-k2.7-coding", Label: "K2.7 Coding", Provider: "kimi", Default: true},
-		{ID: "kimi-k2.7-coding-highspeed", Label: "K2.7 Coding Highspeed", Provider: "kimi"},
-		{ID: "kimi-k3", Label: "K3", Provider: "kimi"},
-	}
 }
 
 // discoverKiroModels spins up a throwaway `kiro-cli acp` process and parses
@@ -1128,8 +1131,9 @@ func discoverACPModels(ctx context.Context, executablePath string, p acpDiscover
 }
 
 // parseACPSessionNewModels extracts the model catalog from an ACP
-// `session/new` response. Hermes and older Kimi (and any other ACP
-// agent that follows that schema) emit:
+// `session/new` response. Two shapes exist in the wild.
+//
+// The original SessionModelState block (Hermes and older runtimes):
 //
 //	{
 //	  "sessionId": "...",
@@ -1141,13 +1145,20 @@ func discoverACPModels(ctx context.Context, executablePath string, p acpDiscover
 //	  }
 //	}
 //
-// Newer agents advertise the same catalog through the ACP
-// `configOptions` list instead — see parseACPConfigOptionModels. Both
-// shapes are accepted: the `models` block wins when present, and
-// `configOptions` is consulted only when it yields nothing, so no
-// existing provider changes behaviour.
+// The newer ACP session config-options schema (current Kimi builds),
+// where the catalog is one select entry among several:
 //
-// Returns nil (not an empty slice) when the payload is missing so
+//	{
+//	  "sessionId": "...",
+//	  "configOptions": [
+//	    {"type": "select", "id": "model", "category": "model",
+//	     "currentValue": "kimi-code/k3",
+//	     "options": [{"value": "kimi-code/k3", "name": "K3"}, ...]},
+//	    ...
+//	  ]
+//	}
+//
+// Returns nil (not an empty slice) when neither payload is present so
 // the caller can distinguish "parsed with no models" (valid but
 // empty catalog) from "couldn't find the structure at all".
 func parseACPSessionNewModels(raw json.RawMessage) []Model {
@@ -1164,6 +1175,16 @@ func parseACPSessionNewModels(raw json.RawMessage) []Model {
 			CurrentModelID       string         `json:"currentModelId"`
 			CurrentModelIDSnake  string         `json:"current_model_id"`
 		} `json:"models"`
+		ConfigOptions []struct {
+			Type         string `json:"type"`
+			ID           string `json:"id"`
+			Category     string `json:"category"`
+			CurrentValue string `json:"currentValue"`
+			Options      []struct {
+				Value string `json:"value"`
+				Name  string `json:"name"`
+			} `json:"options"`
+		} `json:"configOptions"`
 	}
 	if err := json.Unmarshal(raw, &resp); err != nil {
 		return nil
@@ -1171,6 +1192,33 @@ func parseACPSessionNewModels(raw json.RawMessage) []Model {
 	availableModels := resp.Models.AvailableModels
 	if len(availableModels) == 0 && resp.Models.AvailableModelsSnake != nil {
 		availableModels = resp.Models.AvailableModelsSnake
+	}
+	if len(availableModels) == 0 {
+		// No legacy models block — try the config-options schema. The
+		// catalog is the select entry whose category is "model"; the
+		// plain id match is a weaker fallback for runtimes that omit
+		// the category field.
+		for _, opt := range resp.ConfigOptions {
+			if opt.Category == "model" || (opt.Category == "" && opt.ID == "model") {
+				currentModelID := strings.TrimSpace(opt.CurrentValue)
+				models := make([]Model, 0, len(opt.Options))
+				seen := map[string]bool{}
+				for _, o := range opt.Options {
+					modelID := strings.TrimSpace(o.Value)
+					if modelID == "" || seen[modelID] {
+						continue
+					}
+					seen[modelID] = true
+					models = append(models, Model{
+						ID:      modelID,
+						Label:   acpModelLabel(o.Name, modelID),
+						Default: modelID == currentModelID,
+					})
+				}
+				return models
+			}
+		}
+		return nil
 	}
 	currentModelID := strings.TrimSpace(resp.Models.CurrentModelID)
 	if currentModelID == "" {

--- a/server/pkg/agent/models.go
+++ b/server/pkg/agent/models.go
@@ -839,14 +839,31 @@ func discoverHermesModels(ctx context.Context, executablePath string) ([]Model, 
 // 0.29 moved the same catalog into `configOptions` (MUL-5239). The
 // shared parser accepts both, so the discovery path stays identical.
 //
-// Failure modes (kimi missing, not logged in, config error) all
-// return an empty list so the UI falls back to manual entry.
+// On any failure (kimi missing, not logged in, config error) falls
+// back to kimiStaticModels so the UI picker stays usable offline.
 func discoverKimiModels(ctx context.Context, executablePath string) ([]Model, error) {
-	return discoverACPModels(ctx, executablePath, acpDiscoveryProvider{
+	models, err := discoverACPModels(ctx, executablePath, acpDiscoveryProvider{
 		defaultBin:   "kimi",
 		clientName:   "multica-model-discovery",
 		tmpdirPrefix: "multica-kimi-discovery-",
 	})
+	if err != nil || len(models) == 0 {
+		if err != nil {
+			slog.Debug("kimi model discovery fell back to static catalog", "error", err)
+		}
+		return kimiStaticModels(), nil
+	}
+	return models, nil
+}
+
+// kimiStaticModels is the offline fallback catalog for the Kimi CLI.
+// IDs match the model keys advertised by the Kimi Code platform.
+func kimiStaticModels() []Model {
+	return []Model{
+		{ID: "kimi-k2.7-coding", Label: "K2.7 Coding", Provider: "kimi", Default: true},
+		{ID: "kimi-k2.7-coding-highspeed", Label: "K2.7 Coding Highspeed", Provider: "kimi"},
+		{ID: "kimi-k3", Label: "K3", Provider: "kimi"},
+	}
 }
 
 // discoverKiroModels spins up a throwaway `kiro-cli acp` process and parses

--- a/server/pkg/agent/models.go
+++ b/server/pkg/agent/models.go
@@ -846,9 +846,19 @@ func discoverHermesModels(ctx context.Context, executablePath string) ([]Model, 
 // levels to every discovered model so the UI thinking picker works
 // for kimi the same way it does for claude/codex. If the runtime only
 // advertises "on" (kimi 0.27.0's current behavior), the picker shows
-// that single option. Levels may vary by model/version in future
-// builds; the discovery path is generic and follows whatever the CLI
-// returns.
+// that single option.
+//
+// KNOWN LIMITATION (v1): the thought_level select is read from the
+// single discovery session/new — i.e. the default model — and the same
+// catalog is reused for every model, so this is not truly per-model.
+// It is harmless today because kimi 0.27.0 advertises only "on" and the
+// daemon's ValidateThinkingLevel guard drops any UI-over-advertised pick
+// before it reaches session/set_config_option. If a future kimi build
+// diverges thought_level per model, the picker would over-advertise
+// levels for non-default models; making it per-model then means probing
+// session/new once per model. Levels may otherwise vary by model/version
+// in future builds; the discovery path is generic and follows whatever
+// the CLI returns.
 //
 // There is deliberately NO static fallback: the picker must reflect
 // what the installed CLI actually offers so the list stays in sync

--- a/server/pkg/agent/models.go
+++ b/server/pkg/agent/models.go
@@ -1131,9 +1131,8 @@ func discoverACPModels(ctx context.Context, executablePath string, p acpDiscover
 }
 
 // parseACPSessionNewModels extracts the model catalog from an ACP
-// `session/new` response. Two shapes exist in the wild.
-//
-// The original SessionModelState block (Hermes and older runtimes):
+// `session/new` response. Hermes and older Kimi (and any other ACP
+// agent that follows that schema) emit:
 //
 //	{
 //	  "sessionId": "...",
@@ -1145,20 +1144,13 @@ func discoverACPModels(ctx context.Context, executablePath string, p acpDiscover
 //	  }
 //	}
 //
-// The newer ACP session config-options schema (current Kimi builds),
-// where the catalog is one select entry among several:
+// Newer agents advertise the same catalog through the ACP
+// `configOptions` list instead — see parseACPConfigOptionModels. Both
+// shapes are accepted: the `models` block wins when present, and
+// `configOptions` is consulted only when it yields nothing, so no
+// existing provider changes behaviour.
 //
-//	{
-//	  "sessionId": "...",
-//	  "configOptions": [
-//	    {"type": "select", "id": "model", "category": "model",
-//	     "currentValue": "kimi-code/k3",
-//	     "options": [{"value": "kimi-code/k3", "name": "K3"}, ...]},
-//	    ...
-//	  ]
-//	}
-//
-// Returns nil (not an empty slice) when neither payload is present so
+// Returns nil (not an empty slice) when the payload is missing so
 // the caller can distinguish "parsed with no models" (valid but
 // empty catalog) from "couldn't find the structure at all".
 func parseACPSessionNewModels(raw json.RawMessage) []Model {
@@ -1175,16 +1167,6 @@ func parseACPSessionNewModels(raw json.RawMessage) []Model {
 			CurrentModelID       string         `json:"currentModelId"`
 			CurrentModelIDSnake  string         `json:"current_model_id"`
 		} `json:"models"`
-		ConfigOptions []struct {
-			Type         string `json:"type"`
-			ID           string `json:"id"`
-			Category     string `json:"category"`
-			CurrentValue string `json:"currentValue"`
-			Options      []struct {
-				Value string `json:"value"`
-				Name  string `json:"name"`
-			} `json:"options"`
-		} `json:"configOptions"`
 	}
 	if err := json.Unmarshal(raw, &resp); err != nil {
 		return nil
@@ -1192,33 +1174,6 @@ func parseACPSessionNewModels(raw json.RawMessage) []Model {
 	availableModels := resp.Models.AvailableModels
 	if len(availableModels) == 0 && resp.Models.AvailableModelsSnake != nil {
 		availableModels = resp.Models.AvailableModelsSnake
-	}
-	if len(availableModels) == 0 {
-		// No legacy models block — try the config-options schema. The
-		// catalog is the select entry whose category is "model"; the
-		// plain id match is a weaker fallback for runtimes that omit
-		// the category field.
-		for _, opt := range resp.ConfigOptions {
-			if opt.Category == "model" || (opt.Category == "" && opt.ID == "model") {
-				currentModelID := strings.TrimSpace(opt.CurrentValue)
-				models := make([]Model, 0, len(opt.Options))
-				seen := map[string]bool{}
-				for _, o := range opt.Options {
-					modelID := strings.TrimSpace(o.Value)
-					if modelID == "" || seen[modelID] {
-						continue
-					}
-					seen[modelID] = true
-					models = append(models, Model{
-						ID:      modelID,
-						Label:   acpModelLabel(o.Name, modelID),
-						Default: modelID == currentModelID,
-					})
-				}
-				return models
-			}
-		}
-		return nil
 	}
 	currentModelID := strings.TrimSpace(resp.Models.CurrentModelID)
 	if currentModelID == "" {

--- a/server/pkg/agent/models.go
+++ b/server/pkg/agent/models.go
@@ -834,11 +834,10 @@ func discoverHermesModels(ctx context.Context, executablePath string) ([]Model, 
 
 // discoverKimiModels spins up a throwaway `kimi acp` process and
 // drives the same minimal ACP handshake as Hermes to surface the
-// model catalog the installed CLI advertises from `session/new`.
-// Current kimi builds (≥ 0.2x) return it via the ACP configOptions
-// schema (the select entry with category "model"); older builds used
-// the `models.availableModels` block — parseACPSessionNewModels
-// handles both shapes.
+// model catalog advertised by Kimi's `session/new` response. Kimi
+// ≤0.28 returns a `models` block (`availableModels`/`currentModelId`);
+// 0.29 moved the same catalog into `configOptions` (MUL-5239). The
+// shared parser accepts both, so the discovery path stays identical.
 //
 // Kimi also advertises a per-session thinking-effort select under
 // `configOptions` with `category: "thought_level"` and `id: "thinking"`.

--- a/server/pkg/agent/models.go
+++ b/server/pkg/agent/models.go
@@ -897,29 +897,49 @@ func discoverKimiModels(ctx context.Context, executablePath string) ([]Model, er
 	return models, nil
 }
 
+// acpThoughtLevelOption is the configOptions/config_options entry shape
+// consumed by parseACPThoughtLevelOptions.
+type acpThoughtLevelOption struct {
+	Type              string `json:"type"`
+	ID                string `json:"id"`
+	Category          string `json:"category"`
+	CurrentValue      string `json:"currentValue"`
+	CurrentValueSnake string `json:"current_value"`
+	Options           []struct {
+		Value       string `json:"value"`
+		Name        string `json:"name"`
+		Description string `json:"description"`
+	} `json:"options"`
+}
+
+func (o acpThoughtLevelOption) currentValue() string {
+	if v := strings.TrimSpace(o.CurrentValue); v != "" {
+		return v
+	}
+	return strings.TrimSpace(o.CurrentValueSnake)
+}
+
 // parseACPThoughtLevelOptions extracts the thinking-effort catalog from an
 // ACP session/new configOptions response. It looks for the select entry whose
 // category is "thought_level" (or id is "thinking" as a fallback) and returns
 // the advertised options as a ModelThinking catalog. nil means the runtime did
 // not surface a thinking control for this session/model.
+//
+// Like parseACPConfigOptionModels, this accepts both camelCase
+// (`configOptions`) and snake_case (`config_options`) top-level keys.
 func parseACPThoughtLevelOptions(raw json.RawMessage) *ModelThinking {
 	var resp struct {
-		ConfigOptions []struct {
-			Type         string `json:"type"`
-			ID           string `json:"id"`
-			Category     string `json:"category"`
-			CurrentValue string `json:"currentValue"`
-			Options      []struct {
-				Value       string `json:"value"`
-				Name        string `json:"name"`
-				Description string `json:"description"`
-			} `json:"options"`
-		} `json:"configOptions"`
+		ConfigOptions      []acpThoughtLevelOption `json:"configOptions"`
+		ConfigOptionsSnake []acpThoughtLevelOption `json:"config_options"`
 	}
 	if err := json.Unmarshal(raw, &resp); err != nil {
 		return nil
 	}
-	for _, opt := range resp.ConfigOptions {
+	configOptions := resp.ConfigOptions
+	if len(configOptions) == 0 {
+		configOptions = resp.ConfigOptionsSnake
+	}
+	for _, opt := range configOptions {
 		if opt.Type != "select" {
 			continue
 		}
@@ -956,7 +976,7 @@ func parseACPThoughtLevelOptions(raw json.RawMessage) *ModelThinking {
 		}
 		return &ModelThinking{
 			SupportedLevels: levels,
-			DefaultLevel:    strings.TrimSpace(opt.CurrentValue),
+			DefaultLevel:    opt.currentValue(),
 		}
 	}
 	return nil

--- a/server/pkg/agent/models_test.go
+++ b/server/pkg/agent/models_test.go
@@ -1232,3 +1232,59 @@ func TestCachedDiscovery(t *testing.T) {
 		t.Errorf("expected 1 underlying call due to cache, got %d", calls)
 	}
 }
+
+func TestKimiStaticModels(t *testing.T) {
+	t.Parallel()
+	models := kimiStaticModels()
+	if len(models) == 0 {
+		t.Fatal("expected static models, got empty list")
+	}
+
+	ids := map[string]Model{}
+	defaults := 0
+	for _, m := range models {
+		ids[m.ID] = m
+		if m.Default {
+			defaults++
+		}
+		if m.Provider != "kimi" {
+			t.Errorf("model %q has provider %q, want kimi", m.ID, m.Provider)
+		}
+	}
+
+	expectedIDs := []string{"kimi-k2.7-coding", "kimi-k2.7-coding-highspeed", "kimi-k3"}
+	for _, id := range expectedIDs {
+		if _, ok := ids[id]; !ok {
+			t.Errorf("missing expected model %q in: %+v", id, models)
+		}
+	}
+
+	if defaults != 1 {
+		t.Errorf("expected exactly 1 default model, got %d", defaults)
+	}
+	if !ids["kimi-k2.7-coding"].Default {
+		t.Error("expected kimi-k2.7-coding to be the default")
+	}
+}
+
+func TestDiscoverKimiModelsFallsBackToStatic(t *testing.T) {
+	t.Parallel()
+	// With a nonexistent binary, ACP discovery must fail and fall
+	// back to the static catalog so the UI stays usable.
+	ctx := context.Background()
+	models, err := discoverKimiModels(ctx, "/nonexistent/kimi")
+	if err != nil {
+		t.Fatalf("discoverKimiModels returned error: %v", err)
+	}
+	if len(models) == 0 {
+		t.Fatal("expected static fallback models, got empty list")
+	}
+
+	ids := map[string]bool{}
+	for _, m := range models {
+		ids[m.ID] = true
+	}
+	if !ids["kimi-k2.7-coding"] || !ids["kimi-k3"] {
+		t.Errorf("static fallback missing expected models: %+v", models)
+	}
+}

--- a/server/pkg/agent/models_test.go
+++ b/server/pkg/agent/models_test.go
@@ -5,6 +5,7 @@ import (
 	"path/filepath"
 	"reflect"
 	"runtime"
+	"slices"
 	"strconv"
 	"strings"
 	"testing"
@@ -1270,6 +1271,141 @@ func TestParseKimiSessionNewConfigOptions(t *testing.T) {
 		if m.ID == "on" || m.ID == "default" {
 			t.Errorf("thinking/mode select values leaked into the model catalog: %+v", models)
 		}
+	}
+}
+
+func TestParseACPThoughtLevelOptions(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name string
+		raw  string
+		want []string
+	}{
+		{
+			name: "kimi 0.27.0 single on option",
+			raw: `{
+				"sessionId": "s1",
+				"configOptions": [
+					{"type": "select", "id": "thinking", "name": "Thinking", "category": "thought_level",
+					 "currentValue": "on", "options": [{"value": "on", "name": "Thinking On"}]}
+				]
+			}`,
+			want: []string{"on"},
+		},
+		{
+			name: "multiple effort levels",
+			raw: `{
+				"configOptions": [
+					{"type": "select", "id": "thinking", "category": "thought_level",
+					 "currentValue": "max",
+					 "options": [
+						{"value": "on", "name": "On"},
+						{"value": "max", "name": "Max"},
+						{"value": "high", "name": "High"}
+					 ]}
+				]
+			}`,
+			want: []string{"on", "max", "high"},
+		},
+		{
+			name: "fallback to id when category omitted",
+			raw: `{
+				"configOptions": [
+					{"type": "select", "id": "thinking", "currentValue": "on",
+					 "options": [{"value": "on", "name": "On"}]}
+				]
+			}`,
+			want: []string{"on"},
+		},
+		{
+			name: "model select ignored",
+			raw: `{
+				"configOptions": [
+					{"type": "select", "id": "model", "category": "model",
+					 "currentValue": "m", "options": [{"value": "m", "name": "M"}]}
+				]
+			}`,
+			want: nil,
+		},
+		{
+			name: "no configOptions",
+			raw:  `{"sessionId": "s1"}`,
+			want: nil,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := parseACPThoughtLevelOptions([]byte(tc.raw))
+			if tc.want == nil {
+				if got != nil {
+					t.Fatalf("expected nil, got %+v", got)
+				}
+				return
+			}
+			if got == nil {
+				t.Fatalf("expected non-nil, got nil")
+			}
+			var values []string
+			for _, lvl := range got.SupportedLevels {
+				values = append(values, lvl.Value)
+			}
+			if !slices.Equal(values, tc.want) {
+				t.Errorf("got values %v, want %v", values, tc.want)
+			}
+		})
+	}
+}
+
+func TestDiscoverKimiModelsAnnotatesThinking(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell-script fake binary requires a POSIX shell")
+	}
+	t.Parallel()
+
+	script := `#!/bin/sh
+while IFS= read -r line; do
+  id=$(printf '%s' "$line" | sed -n 's/.*"id":\([0-9]*\).*/\1/p')
+  case "$line" in
+    *'"method":"initialize"'*)
+      printf '{"jsonrpc":"2.0","id":%s,"result":{"protocolVersion":1,"agentCapabilities":{}}}\n' "$id"
+      ;;
+    *'"method":"session/new"'*)
+      printf '{"jsonrpc":"2.0","id":%s,"result":{"sessionId":"ses_discover","configOptions":[{"type":"select","id":"model","category":"model","currentValue":"kimi-code/k3","options":[{"value":"kimi-code/k3","name":"K3"}]},{"type":"select","id":"thinking","category":"thought_level","currentValue":"on","options":[{"value":"on","name":"Thinking On"},{"value":"max","name":"Max"}]}]}}\n' "$id"
+      ;;
+  esac
+done
+`
+	dir := t.TempDir()
+	fake := filepath.Join(dir, "kimi")
+	writeTestExecutable(t, fake, []byte(script))
+
+	ctx := context.Background()
+	modelCacheMu.Lock()
+	delete(modelCache, "kimi")
+	modelCacheMu.Unlock()
+
+	models, err := discoverKimiModels(ctx, fake)
+	if err != nil {
+		t.Fatalf("discoverKimiModels: %v", err)
+	}
+	if len(models) != 1 {
+		t.Fatalf("expected 1 model, got %+v", models)
+	}
+	if models[0].ID != "kimi-code/k3" {
+		t.Errorf("unexpected model id: %q", models[0].ID)
+	}
+	if models[0].Provider != "kimi" {
+		t.Errorf("unexpected provider: %q", models[0].Provider)
+	}
+	if models[0].Thinking == nil {
+		t.Fatalf("expected thinking catalog, got nil")
+	}
+	if len(models[0].Thinking.SupportedLevels) != 2 {
+		t.Fatalf("expected 2 thinking levels, got %+v", models[0].Thinking)
+	}
+	if models[0].Thinking.DefaultLevel != "on" {
+		t.Errorf("expected default level on, got %q", models[0].Thinking.DefaultLevel)
 	}
 }
 

--- a/server/pkg/agent/models_test.go
+++ b/server/pkg/agent/models_test.go
@@ -1233,58 +1233,57 @@ func TestCachedDiscovery(t *testing.T) {
 	}
 }
 
-func TestKimiStaticModels(t *testing.T) {
-	t.Parallel()
-	models := kimiStaticModels()
-	if len(models) == 0 {
-		t.Fatal("expected static models, got empty list")
+func TestParseKimiSessionNewConfigOptions(t *testing.T) {
+	// Mirrors the real shape emitted by kimi 0.27.0's ACP server:
+	// no `models` block; the catalog is the configOptions select
+	// entry with category "model" (alongside thinking/mode selects).
+	raw := []byte(`{
+      "sessionId": "session_4a38f007-ca7e-4f44-a4ce-e88e9d042767",
+      "configOptions": [
+        {"type": "select", "id": "model", "name": "Model", "category": "model",
+         "currentValue": "kimi-code/k3",
+         "options": [
+           {"value": "kimi-code/kimi-for-coding", "name": "K2.7 Coding"},
+           {"value": "kimi-code/kimi-for-coding-highspeed", "name": "K2.7 Coding Highspeed"},
+           {"value": "kimi-code/k3", "name": "K3"}
+         ]},
+        {"type": "select", "id": "thinking", "name": "Thinking", "category": "thought_level",
+         "currentValue": "on", "options": [{"value": "on", "name": "Thinking On"}]},
+        {"type": "select", "id": "mode", "name": "Mode", "category": "mode",
+         "currentValue": "default", "options": [{"value": "default", "name": "Default"}]}
+      ]
+    }`)
+	models := parseACPSessionNewModels(raw)
+	if len(models) != 3 {
+		t.Fatalf("expected 3 models, got %d: %+v", len(models), models)
 	}
-
-	ids := map[string]Model{}
-	defaults := 0
+	if models[0].ID != "kimi-code/kimi-for-coding" || models[0].Label != "K2.7 Coding" {
+		t.Errorf("unexpected first model: %+v", models[0])
+	}
+	if models[0].Default {
+		t.Errorf("non-current entry must not be marked default: %+v", models[0])
+	}
+	if !models[2].Default || models[2].ID != "kimi-code/k3" {
+		t.Errorf("currentValue kimi-code/k3 must be the default: %+v", models[2])
+	}
 	for _, m := range models {
-		ids[m.ID] = m
-		if m.Default {
-			defaults++
+		if m.ID == "on" || m.ID == "default" {
+			t.Errorf("thinking/mode select values leaked into the model catalog: %+v", models)
 		}
-		if m.Provider != "kimi" {
-			t.Errorf("model %q has provider %q, want kimi", m.ID, m.Provider)
-		}
-	}
-
-	expectedIDs := []string{"kimi-k2.7-coding", "kimi-k2.7-coding-highspeed", "kimi-k3"}
-	for _, id := range expectedIDs {
-		if _, ok := ids[id]; !ok {
-			t.Errorf("missing expected model %q in: %+v", id, models)
-		}
-	}
-
-	if defaults != 1 {
-		t.Errorf("expected exactly 1 default model, got %d", defaults)
-	}
-	if !ids["kimi-k2.7-coding"].Default {
-		t.Error("expected kimi-k2.7-coding to be the default")
 	}
 }
 
-func TestDiscoverKimiModelsFallsBackToStatic(t *testing.T) {
+func TestDiscoverKimiModelsNonexistentBinaryReturnsEmpty(t *testing.T) {
 	t.Parallel()
-	// With a nonexistent binary, ACP discovery must fail and fall
-	// back to the static catalog so the UI stays usable.
+	// With a nonexistent binary, discovery fails soft: an empty
+	// catalog (no error) so the UI offers manual entry, and the
+	// uncached result lets the next load retry. No static fallback.
 	ctx := context.Background()
 	models, err := discoverKimiModels(ctx, "/nonexistent/kimi")
 	if err != nil {
 		t.Fatalf("discoverKimiModels returned error: %v", err)
 	}
-	if len(models) == 0 {
-		t.Fatal("expected static fallback models, got empty list")
-	}
-
-	ids := map[string]bool{}
-	for _, m := range models {
-		ids[m.ID] = true
-	}
-	if !ids["kimi-k2.7-coding"] || !ids["kimi-k3"] {
-		t.Errorf("static fallback missing expected models: %+v", models)
+	if len(models) != 0 {
+		t.Fatalf("expected empty catalog on discovery failure, got %+v", models)
 	}
 }

--- a/server/pkg/agent/models_test.go
+++ b/server/pkg/agent/models_test.go
@@ -1328,6 +1328,20 @@ func TestParseACPThoughtLevelOptions(t *testing.T) {
 			want: nil,
 		},
 		{
+			name: "snake_case config_options",
+			raw: `{
+				"config_options": [
+					{"type": "select", "id": "thinking", "category": "thought_level",
+					 "current_value": "max",
+					 "options": [
+						{"value": "on", "name": "On"},
+						{"value": "max", "name": "Max"}
+					 ]}
+				]
+			}`,
+			want: []string{"on", "max"},
+		},
+		{
 			name: "no configOptions",
 			raw:  `{"sessionId": "s1"}`,
 			want: nil,
@@ -1354,6 +1368,61 @@ func TestParseACPThoughtLevelOptions(t *testing.T) {
 				t.Errorf("got values %v, want %v", values, tc.want)
 			}
 		})
+	}
+}
+
+// TestParseACPSessionNewModelsAndThoughtLevelsSnakeCase verifies that both
+// the model catalog and the thinking-effort catalog can be parsed from a
+// session/new response that uses snake_case `config_options` keys.
+func TestParseACPSessionNewModelsAndThoughtLevelsSnakeCase(t *testing.T) {
+	raw := []byte(`{
+      "session_id": "session_abc",
+      "config_options": [
+        {
+          "id": "primary_model",
+          "category": "MODEL",
+          "current_value": "kimi-code/k3",
+          "options": [
+            {"value": "kimi-code/k3", "name": "K3"},
+            {"value": "kimi-code/kimi-for-coding", "name": "K2.7 Coding"}
+          ]
+        },
+        {
+          "type": "select",
+          "id": "thinking",
+          "category": "thought_level",
+          "current_value": "max",
+          "options": [
+            {"value": "on", "name": "On"},
+            {"value": "max", "name": "Max"},
+            {"value": "high", "name": "High"}
+          ]
+        }
+      ]
+    }`)
+
+	models := parseACPSessionNewModels(raw)
+	if len(models) != 2 {
+		t.Fatalf("expected 2 models from snake_case config_options, got %d: %+v", len(models), models)
+	}
+	if !models[0].Default || models[0].ID != "kimi-code/k3" {
+		t.Errorf("expected k3 default, got %+v", models[0])
+	}
+
+	thinking := parseACPThoughtLevelOptions(raw)
+	if thinking == nil {
+		t.Fatal("expected thinking catalog from snake_case config_options, got nil")
+	}
+	if thinking.DefaultLevel != "max" {
+		t.Errorf("expected default thought level max, got %q", thinking.DefaultLevel)
+	}
+	if len(thinking.SupportedLevels) != 3 {
+		t.Fatalf("expected 3 thought levels, got %+v", thinking.SupportedLevels)
+	}
+	for i, want := range []string{"on", "max", "high"} {
+		if thinking.SupportedLevels[i].Value != want {
+			t.Errorf("thought level[%d] = %q, want %q", i, thinking.SupportedLevels[i].Value, want)
+		}
 	}
 }
 

--- a/server/pkg/agent/thinking.go
+++ b/server/pkg/agent/thinking.go
@@ -735,8 +735,9 @@ var providerThinkingEnums = map[string]map[string]bool{
 // IsKnownThinkingValue reports whether `value` is a recognised effort
 // token for the given provider. Empty string is always accepted (means
 // "use runtime default"). Unknown providers (no thinking concept) accept
-// only empty; Codex and OpenCode accept well-formed tokens here because their
-// daemon-local catalogs perform the exact per-model check before execution.
+// only empty; Codex, OpenCode, and Kimi accept well-formed tokens here because
+// their daemon-local catalogs perform the exact per-model check before
+// execution.
 //
 // This is the cheap synchronous gate the server uses on CreateAgent /
 // UpdateAgent. Unlike ValidateThinkingLevel it does NOT consult the live
@@ -745,7 +746,7 @@ func IsKnownThinkingValue(providerType, value string) bool {
 	if value == "" {
 		return true
 	}
-	if providerType == "codex" || providerType == "opencode" {
+	if providerType == "codex" || providerType == "opencode" || providerType == "kimi" {
 		return isValidDynamicThinkingValue(value)
 	}
 	enum, ok := providerThinkingEnums[providerType]

--- a/server/pkg/agent/thinking_test.go
+++ b/server/pkg/agent/thinking_test.go
@@ -478,6 +478,12 @@ func TestIsKnownThinkingValue(t *testing.T) {
 		{"grok", "xhigh", false},
 		{"grok", "max", false},
 		{"grok", "bogus", false},
+		{"kimi", "", true},
+		{"kimi", "on", true},
+		{"kimi", "max", true},
+		{"kimi", "future-level", true}, // discovered levels may outpace the server enum
+		{"kimi", ".hidden", false},
+		{"kimi", "bad value", false},
 	}
 	for _, tc := range tests {
 		if got := IsKnownThinkingValue(tc.provider, tc.value); got != tc.want {


### PR DESCRIPTION
## Summary

Fixes #5954 .

Makes Kimi a first-class provider in Multica: thinking effort is configurable, token usage is reported accurately, and provider-side failures surface instead of silently succeeding.

- **Thinking effort:** expose kimi's `thought_level` ACP config option through the existing ThinkingPicker UI. Discovery parses the `configOptions`/`config_options` catalog from `session/new` (camelCase and snake_case, consistent with the model catalog parser), validates against known values, and applies the pick via `session/set_config_option` with fail-hard on rejection. Per-model thought_level limitation documented. Covered by Playwright E2E (`e2e/agent-thinking-kimi.spec.ts`).
- **Usage reporting:** recover run usage from the on-disk ACP session wire (`usage.record` entries), with settle-detection polling, a no-wire fast path, bounded chunked scanning (no unbounded line buffering), and recovery on failed/cancelled runs. Records are counted strictly after a wire snapshot taken at `session/new`/`session/resume`, so rapid session reuse can never double-bill the previous task's tokens. The kimi home is resolved from the child-process environment (`buildEnv(Config.Env)`), not the daemon's, so task-local `KIMI_CODE_HOME` works.
- **Reliability:** kimi runs fail loudly on swallowed provider-side turn failures (detected via `kimi-code.log` markers, ERROR-level match) instead of reporting success with zero output; poisoned sessions are dropped.
- Builds on #5851's `parseACPConfigOptionModels` for model discovery — no duplicated catalog logic.


## Test plan

- [x] `go test ./pkg/agent/` green (unit + wire-recovery regression tests)
- [x] Playwright E2E for the thinking-effort picker
- [x] Validated on staging — model list confirmed working
- [x] Two review rounds passed; all blockers fixed with a regression test each (split-env home, snapshot billing boundary, oversized-line scanning, healthy-empty-completion false-positive guard)