### PR TITLE
fix(issues): keep issue row pages in sync on observer reattach (MUL-5341)

### DIFF
--- a/packages/core/issues/queries.test.ts
+++ b/packages/core/issues/queries.test.ts
@@ -245,6 +245,67 @@ describe("issueTableRowPageOptions", () => {
     unsubscribe2();
     qc.clear();
   });
+
+  it("does not auto-retry a background-refetch error on a page that still has data", async () => {
+    // The tricky case: a page loads OK, then an invalidation-triggered background
+    // refetch fails. TanStack flags such a page `isInvalidated: true` (see its
+    // "error" reducer), so it is stale AND errored while keeping the old data. A
+    // plain `refetchOnMount: true` would re-fire the failing request on every
+    // observer reattach; `retryOnMount: false` alone does NOT cover this path
+    // because it only guards no-data first-load errors. The `refetchOnMount`
+    // status guard is what keeps the errored page stable until an explicit Retry.
+    const qc = new QueryClient({
+      defaultOptions: { queries: { staleTime: Infinity } },
+    });
+    const listIssueTableRows = vi
+      .fn<
+        (params: IssueTableRowsRequest) => Promise<IssueTableRowsResponse>
+      >()
+      .mockResolvedValueOnce(makeRowsResponse([makeIssue(1)])) // initial load
+      .mockRejectedValueOnce(new Error("refetch failed")) // background refetch
+      .mockResolvedValueOnce(makeRowsResponse([makeIssue(1), makeIssue(2)])); // explicit Retry
+    installFakeTableRowsApi(listIssueTableRows);
+
+    const options = issueTableRowPageOptions(WS_ID, request);
+
+    const observer1 = new QueryObserver(qc, options);
+    const unsubscribe1 = observer1.subscribe(() => {});
+    await vi.waitFor(() => {
+      expect(observer1.getCurrentResult().status).toBe("success");
+      expect(rowIssueIds(observer1.getCurrentResult().data)).toEqual([
+        "issue-1",
+      ]);
+    });
+
+    // Invalidate while the observer is active: the background refetch fires and
+    // fails, leaving the page errored-with-data and flagged invalidated.
+    void qc.invalidateQueries({ queryKey: options.queryKey }).catch(() => {});
+    await vi.waitFor(() => {
+      expect(observer1.getCurrentResult().status).toBe("error");
+    });
+    expect(listIssueTableRows).toHaveBeenCalledTimes(2);
+    expect(rowIssueIds(observer1.getCurrentResult().data)).toEqual(["issue-1"]);
+    expect(qc.getQueryState(options.queryKey)?.isInvalidated).toBe(true);
+
+    // Detach + reattach must NOT re-fire the failing request.
+    unsubscribe1();
+    const observer2 = new QueryObserver(qc, options);
+    const unsubscribe2 = observer2.subscribe(() => {});
+    expect(observer2.getCurrentResult().status).toBe("error");
+    expect(observer2.getCurrentResult().fetchStatus).toBe("idle");
+    expect(listIssueTableRows).toHaveBeenCalledTimes(2);
+
+    // Only an explicit Retry re-runs it — and then the fresh page renders.
+    await observer2.refetch();
+    expect(listIssueTableRows).toHaveBeenCalledTimes(3);
+    expect(rowIssueIds(observer2.getCurrentResult().data)).toEqual([
+      "issue-1",
+      "issue-2",
+    ]);
+
+    unsubscribe2();
+    qc.clear();
+  });
 });
 
 describe("projectGanttIssuesOptions", () => {

--- a/packages/core/issues/queries.test.ts
+++ b/packages/core/issues/queries.test.ts
@@ -5,6 +5,8 @@ import { setApiInstance } from "../api";
 import type { ApiClient } from "../api/client";
 import type {
   Issue,
+  IssueTableRowsRequest,
+  IssueTableRowsResponse,
   ListIssuesParams,
   ListIssuesResponse,
   SearchIssuesResponse,
@@ -21,6 +23,7 @@ import {
   issueFlatListOptions,
   issueIdentifierOptions,
   issueKeys,
+  issueTableRowPageOptions,
   projectGanttIssuesOptions,
 } from "./queries";
 
@@ -109,6 +112,137 @@ describe("childIssuesOptions", () => {
     });
 
     unsubscribe();
+    qc.clear();
+  });
+});
+
+describe("issueTableRowPageOptions", () => {
+  // Reproduces the "count correct, issue missing until page refresh" bug: a row
+  // page gets invalidated while its dynamic useQueries observer is detached, then
+  // the observer reattaches. Under the global `staleTime: Infinity` default the
+  // page is stale only because it is invalidated, so the reattaching observer
+  // MUST refetch it. `refetchOnMount: false` used to suppress that refetch and
+  // strand the row stale; `retryOnMount: false` does not.
+  const request: IssueTableRowsRequest = {
+    query: {
+      scope: { kind: "workspace" },
+      filters: {},
+      sort: { field: "position", direction: "asc" },
+    },
+    group: { kind: "status" },
+    group_key: "todo",
+    hierarchy: { enabled: false },
+    parent_id: null,
+    page: { limit: 50, cursor: null },
+  };
+
+  function makeRowsResponse(issues: Issue[]): IssueTableRowsResponse {
+    return {
+      query_fingerprint: "fp",
+      group_key: "todo",
+      parent_id: null,
+      total: issues.length,
+      rows: issues.map((issue) => ({ issue, direct_child_count: 0 })),
+      branch_total: issues.length,
+      next_cursor: null,
+    };
+  }
+
+  function rowIssueIds(response: IssueTableRowsResponse | undefined): string[] {
+    return response?.rows.map((row) => row.issue.id) ?? [];
+  }
+
+  function installFakeTableRowsApi(
+    listIssueTableRows: (
+      params: IssueTableRowsRequest,
+    ) => Promise<IssueTableRowsResponse>,
+  ) {
+    setApiInstance({ listIssueTableRows } as unknown as ApiClient);
+  }
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("refetches an invalidated page when its observer reattaches", async () => {
+    // Global default: server state stays fresh until explicitly invalidated.
+    const qc = new QueryClient({
+      defaultOptions: { queries: { staleTime: Infinity } },
+    });
+    const listIssueTableRows = vi
+      .fn<
+        (params: IssueTableRowsRequest) => Promise<IssueTableRowsResponse>
+      >()
+      // Head snapshot, then the post-move snapshot that includes the new issue.
+      .mockResolvedValueOnce(makeRowsResponse([makeIssue(1)]))
+      .mockResolvedValueOnce(makeRowsResponse([makeIssue(1), makeIssue(2)]));
+    installFakeTableRowsApi(listIssueTableRows);
+
+    const options = issueTableRowPageOptions(WS_ID, request);
+
+    const observer1 = new QueryObserver(qc, options);
+    const unsubscribe1 = observer1.subscribe(() => {});
+    await vi.waitFor(() => {
+      expect(listIssueTableRows).toHaveBeenCalledTimes(1);
+      expect(rowIssueIds(observer1.getCurrentResult().data)).toEqual([
+        "issue-1",
+      ]);
+    });
+
+    // Observer detaches (sibling branch left the viewport), then the row page is
+    // invalidated while no observer is active — it only gets marked stale.
+    unsubscribe1();
+    await qc.invalidateQueries({ queryKey: options.queryKey });
+    const cached = qc.getQueryState(options.queryKey);
+    expect(cached?.isInvalidated).toBe(true);
+    expect(cached?.fetchStatus).toBe("idle");
+
+    // Observer reattaches: the invalidated page must refetch and pick up issue-2.
+    const observer2 = new QueryObserver(qc, options);
+    const unsubscribe2 = observer2.subscribe(() => {});
+    await vi.waitFor(() => {
+      expect(listIssueTableRows).toHaveBeenCalledTimes(2);
+      expect(rowIssueIds(observer2.getCurrentResult().data)).toEqual([
+        "issue-1",
+        "issue-2",
+      ]);
+    });
+
+    unsubscribe2();
+    qc.clear();
+  });
+
+  it("keeps an errored page errored on reattach (no auto-retry)", async () => {
+    const qc = new QueryClient({
+      defaultOptions: { queries: { staleTime: Infinity } },
+    });
+    const listIssueTableRows = vi
+      .fn<
+        (params: IssueTableRowsRequest) => Promise<IssueTableRowsResponse>
+      >()
+      .mockRejectedValue(new Error("boom"));
+    installFakeTableRowsApi(listIssueTableRows);
+
+    const options = issueTableRowPageOptions(WS_ID, request);
+
+    const observer1 = new QueryObserver(qc, options);
+    const unsubscribe1 = observer1.subscribe(() => {});
+    await vi.waitFor(() => {
+      expect(observer1.getCurrentResult().status).toBe("error");
+    });
+    expect(listIssueTableRows).toHaveBeenCalledTimes(1);
+    unsubscribe1();
+
+    // Reattaching an errored page stays idle — `retryOnMount: false` blocks the
+    // automatic retry; only an explicit Retry re-runs it. The fetch decision is
+    // synchronous, so the observer never enters `fetching`.
+    const observer2 = new QueryObserver(qc, options);
+    const unsubscribe2 = observer2.subscribe(() => {});
+    expect(observer2.getCurrentResult().status).toBe("error");
+    expect(observer2.getCurrentResult().fetchStatus).toBe("idle");
+    expect(listIssueTableRows).toHaveBeenCalledTimes(1);
+
+    unsubscribe2();
     qc.clear();
   });
 });

--- a/packages/core/issues/queries.ts
+++ b/packages/core/issues/queries.ts
@@ -456,13 +456,20 @@ export function issueTableRowPageOptions(
     queryFn: () => api.listIssueTableRows(request),
     placeholderData: keepPreviousData,
     retry: false,
-    // Dynamic useQueries observers can detach/reinstall as sibling branches
-    // enter the viewport. Keep an errored page errored until an explicit Retry,
-    // but — unlike `refetchOnMount: false` — let a successful-but-invalidated
-    // page refetch when its observer reattaches. Otherwise a row page that gets
-    // WS-invalidated while its observer is detached stays stranded stale under
-    // the global `staleTime: Infinity` default (correct count, missing issue).
+    // Dynamic useQueries observers detach/reinstall as sibling branches enter
+    // and leave the viewport. Keep an errored page errored until the user hits
+    // Retry — but still let a successful-but-invalidated page refetch on
+    // reattach, so a row page that gets WS-invalidated while its observer is
+    // detached doesn't stay stranded stale under the global `staleTime: Infinity`
+    // default (correct count, missing issue).
+    //
+    // Both guards are needed: `retryOnMount` covers a first-load error (no
+    // data), while the `refetchOnMount` guard covers a background-refetch error
+    // on a page that still holds data — TanStack flags such a page
+    // `isInvalidated`, so a plain `refetchOnMount: true` would re-fire the
+    // failing request on every reattach instead of waiting for explicit Retry.
     retryOnMount: false,
+    refetchOnMount: (query) => query.state.status !== "error",
   });
 }
 

--- a/packages/core/issues/queries.ts
+++ b/packages/core/issues/queries.ts
@@ -457,8 +457,12 @@ export function issueTableRowPageOptions(
     placeholderData: keepPreviousData,
     retry: false,
     // Dynamic useQueries observers can detach/reinstall as sibling branches
-    // enter the viewport. An errored page stays errored until explicit Retry.
-    refetchOnMount: false,
+    // enter the viewport. Keep an errored page errored until an explicit Retry,
+    // but — unlike `refetchOnMount: false` — let a successful-but-invalidated
+    // page refetch when its observer reattaches. Otherwise a row page that gets
+    // WS-invalidated while its observer is detached stays stranded stale under
+    // the global `staleTime: Infinity` default (correct count, missing issue).
+    retryOnMount: false,
   });
 }
 

--- a/packages/views/issues/surface/use-issue-status-branches.test.tsx
+++ b/packages/views/issues/surface/use-issue-status-branches.test.tsx
@@ -80,8 +80,11 @@ describe("useIssueStatusBranches", () => {
       },
     );
     setApiInstance({ listIssueTableRows } as unknown as ApiClient);
+    // Mirror the production client (createQueryClient): row pages stay fresh
+    // until explicitly invalidated, so re-expanding a collapsed section reuses
+    // settled cursor pages instead of refetching them on observer reattach.
     const queryClient = new QueryClient({
-      defaultOptions: { queries: { retry: false } },
+      defaultOptions: { queries: { retry: false, staleTime: Infinity } },
     });
 
     const { result, rerender } = renderHook(


### PR DESCRIPTION
## Summary

Fixes the "issue count is correct but the issue is not there" cache bug (MUL-5341), where a moved/updated issue disappears from a List/Board/Swimlane/Table section while its status count stays right, and only a full page refresh restores it.

**Root cause.** `issueTableRowPageOptions` in `packages/core/issues/queries.ts` set `refetchOnMount: false`. That option blocks the mount refetch of **any** stale page — including a *successful-but-invalidated* one, not just an errored one. Row pages are rendered through a dynamic `useQueries` whose observers detach/reinstall as sibling branches enter/leave the viewport. When a row page is WS-invalidated while its observer is detached, and the observer later reattaches, the page stays:

- `invalidated: true`
- `fetchStatus: idle`

So the client knows the page is stale but refuses to fetch it. The facet (count) query has an always-active observer and no such override, so the count updates while the list keeps a stale snapshot missing the moved issue — exactly the reported symptom.

Under the global `staleTime: Infinity` default (`packages/core/query-client.ts`), a page is stale only when explicitly invalidated, which is why the bug is intermittent and clears on refresh.

## Fix

```ts
retryOnMount: false,
refetchOnMount: (query) => query.state.status !== "error",
```

Both guards are needed — verified against the pinned `@tanstack/query-core@5.96.2` source:

- **`retryOnMount: false`** covers a **first-load error** (no data). `shouldLoadOnMount` guards on `status === "error" && retryOnMount === false`, which is the behavior the original comment intended but `refetchOnMount: false` did not actually deliver (it only affects pages that already have data).
- **The `refetchOnMount` status guard** covers a **background-refetch error on a page that still holds data**. TanStack's `error` reducer sets `isInvalidated: true` unconditionally ("flag existing data as invalidated if we get a background error"), so such a page is simultaneously stale and errored. Under a plain `refetchOnMount: true` it would re-fire the failing request on every observer reattach, bypassing the page's explicit Retry.

Resulting behavior across all four cases:

| Page state | On observer reattach |
| --- | --- |
| Successful, invalidated | ✅ Refetches (the reported bug) |
| Successful, fresh | ✅ No fetch (`staleTime: Infinity`) |
| First-load error (no data) | ✅ Waits for explicit Retry |
| Background-refetch error (has data) | ✅ Waits for explicit Retry |

## Changes

- `packages/core/issues/queries.ts` — replace `refetchOnMount: false` in `issueTableRowPageOptions` with the `retryOnMount: false` + `refetchOnMount` status-guard pair, with an updated comment explaining why both are required.
- `packages/core/issues/queries.test.ts` — three regression tests for `issueTableRowPageOptions`: an invalidated page refetches on reattach; a first-load errored page stays errored; and a has-data background-refetch error stays errored on detach/reattach until an explicit refetch.
- `packages/views/issues/surface/use-issue-status-branches.test.tsx` — align the test fixture's `QueryClient` with the production client's `staleTime: Infinity` (the collapse/re-expand "reuse settled pages" assertion depends on it; the old blanket `refetchOnMount: false` masked the dependency).

## Verification

Each regression test was confirmed to fail against the option it guards (the invalidated-refetch tests against the old `refetchOnMount: false`, and the background-refetch-error test against `retryOnMount: false` alone) and to pass with the final fix.

- `pnpm vitest run packages/core/issues/` — 218 passed
- `pnpm vitest run packages/views/issues/` — 463 passed
- `pnpm tsc -p packages/core/tsconfig.json --noEmit` — clean
- `pnpm tsc -p packages/views/tsconfig.json --noEmit` — clean
