### PR TITLE
MUL-5348: allow spaces in mention search

### DIFF
--- a/packages/views/editor/extensions/mention-suggestion.test.tsx
+++ b/packages/views/editor/extensions/mention-suggestion.test.tsx
@@ -136,6 +136,25 @@ describe("createMentionSuggestion", () => {
     Element.prototype.scrollIntoView = vi.fn();
   });
 
+  it("keeps the mention query active across spaces for multi-word search", () => {
+    const qc = fakeQc({
+      issues: [
+        {
+          id: "i-login",
+          identifier: "MUL-1",
+          title: "Login redirect bug",
+          status: "todo",
+        },
+      ],
+    });
+    const config = createMentionSuggestion(qc);
+
+    expect(config.allowSpaces).toBe(true);
+    expect(config.items!(itemArgs("login redirect"))).toEqual([
+      expect.objectContaining({ id: "i-login", type: "issue" }),
+    ]);
+  });
+
   it("returns members and agents synchronously without waiting for the server search", () => {
     const qc = fakeQc({
       members: [{ user_id: "u1", name: "Alice", role: "member" }],

--- a/packages/views/editor/extensions/mention-suggestion.tsx
+++ b/packages/views/editor/extensions/mention-suggestion.tsx
@@ -616,6 +616,7 @@ export function createMentionSuggestion(
 
   return {
     pluginKey,
+    allowSpaces: true,
     items: ({ query }) => {
       if (options.mode === "context") {
         const normalizedQuery = query.trim();


### PR DESCRIPTION
## Summary

- keep Tiptap mention suggestions active when the query contains spaces
- cover multi-word issue-title matching with a regression test

## Validation

- `pnpm --filter @multica/views exec vitest run editor/extensions/mention-suggestion.test.tsx`
- `pnpm --filter @multica/views typecheck`
- `pnpm --filter @multica/views exec eslint editor/extensions/mention-suggestion.tsx editor/extensions/mention-suggestion.test.tsx`
- `git diff --check`

Closes MUL-5348
