### PR TITLE
perf(ci): split frontend jobs and cache turbo results (MUL-5347)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,6 +113,16 @@ jobs:
         if: ${{ needs.changes.outputs.frontend == 'true' }}
         run: pnpm install
 
+      # `node-version: 22` above floats across patch releases, and turbo's
+      # global hash does not include the interpreter at all (`engines` is null
+      # in its dry-run cache inputs). Without the resolved version in the key,
+      # a runner silently moving to another 22.x would restore a cache built by
+      # the old interpreter and report green without executing anything.
+      - name: Resolve runtime for cache key
+        id: runtime
+        if: ${{ needs.changes.outputs.frontend == 'true' }}
+        run: echo "node=$(node --version)" >> "$GITHUB_OUTPUT"
+
       # Cache entries are immutable, so the key carries the commit SHA to make
       # every run publish a fresh one and `restore-keys` falls back to the most
       # recent prefix match. The two frontend jobs run disjoint task sets, so
@@ -121,12 +131,12 @@ jobs:
       # tasks hit on the first push) and writes its own (so re-pushes hit too).
       - name: Restore turbo cache
         if: ${{ needs.changes.outputs.frontend == 'true' }}
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: .turbo/cache
-          key: turbo-build-${{ runner.os }}-${{ github.sha }}
+          key: turbo-build-${{ runner.os }}-${{ runner.arch }}-${{ steps.runtime.outputs.node }}-${{ github.sha }}
           restore-keys: |
-            turbo-build-${{ runner.os }}-
+            turbo-build-${{ runner.os }}-${{ runner.arch }}-${{ steps.runtime.outputs.node }}-
 
       - name: Test self-host env derivation
         if: ${{ needs.changes.outputs.frontend == 'true' }}
@@ -176,24 +186,30 @@ jobs:
         if: ${{ needs.changes.outputs.frontend == 'true' }}
         run: pnpm install
 
+      - name: Resolve runtime for cache key
+        id: runtime
+        if: ${{ needs.changes.outputs.frontend == 'true' }}
+        run: echo "node=$(node --version)" >> "$GITHUB_OUTPUT"
+
       # See frontend-build for the key strategy. These entries are tiny (~60KB
       # measured): `test` declares no outputs, so turbo caches exit codes and
       # logs rather than artifacts -- yet a hit still skips the whole suite,
       # which is the single most expensive task in the graph.
       - name: Restore turbo cache
         if: ${{ needs.changes.outputs.frontend == 'true' }}
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: .turbo/cache
-          key: turbo-test-${{ runner.os }}-${{ github.sha }}
+          key: turbo-test-${{ runner.os }}-${{ runner.arch }}-${{ steps.runtime.outputs.node }}-${{ github.sha }}
           restore-keys: |
-            turbo-test-${{ runner.os }}-
+            turbo-test-${{ runner.os }}-${{ runner.arch }}-${{ steps.runtime.outputs.node }}-
 
       - name: Test
         if: ${{ needs.changes.outputs.frontend == 'true' }}
         # Same filter rationale as frontend-build. Type errors are not this
-        # job's responsibility — the `typecheck` task in frontend-build owns
-        # them, which is why `test` no longer depends on `^typecheck`.
+        # job's responsibility -- frontend-build owns the `typecheck` task.
+        # `test` reaches dependency sources through the hash-only
+        # `^cache-inputs` edge (see turbo.json), so no `tsc` runs here.
         run: pnpm exec turbo test --filter='!@multica/docs' --filter='!@multica/mobile'
 
   # Aggregate gate. `frontend` is the status-check name the repository's
@@ -204,7 +220,10 @@ jobs:
   # trivially in that case because every step is gated off.
   frontend:
     needs: [frontend-build, frontend-test]
-    if: ${{ always() }}
+    # `!cancelled()` rather than `always()`: a run superseded by a newer push
+    # is cancelled by the concurrency group above, and there is no reason to
+    # spend a runner reporting a verdict nobody will read.
+    if: ${{ !cancelled() }}
     runs-on: ubuntu-latest
     steps:
       - name: Check frontend job results

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,6 +90,9 @@ jobs:
   frontend-build:
     needs: changes
     runs-on: ubuntu-latest
+    env:
+      # Pin turbo's filesystem cache somewhere actions/cache can address.
+      TURBO_CACHE_DIR: .turbo/cache
     steps:
       - name: Checkout
         if: ${{ needs.changes.outputs.frontend == 'true' }}
@@ -109,6 +112,21 @@ jobs:
       - name: Install dependencies
         if: ${{ needs.changes.outputs.frontend == 'true' }}
         run: pnpm install
+
+      # Cache entries are immutable, so the key carries the commit SHA to make
+      # every run publish a fresh one and `restore-keys` falls back to the most
+      # recent prefix match. The two frontend jobs run disjoint task sets, so
+      # they get their own prefixes rather than racing to save one key.
+      # GitHub scopes caches by branch: a PR reads main's entries (so unchanged
+      # tasks hit on the first push) and writes its own (so re-pushes hit too).
+      - name: Restore turbo cache
+        if: ${{ needs.changes.outputs.frontend == 'true' }}
+        uses: actions/cache@v4
+        with:
+          path: .turbo/cache
+          key: turbo-build-${{ runner.os }}-${{ github.sha }}
+          restore-keys: |
+            turbo-build-${{ runner.os }}-
 
       - name: Test self-host env derivation
         if: ${{ needs.changes.outputs.frontend == 'true' }}
@@ -136,6 +154,8 @@ jobs:
   frontend-test:
     needs: changes
     runs-on: ubuntu-latest
+    env:
+      TURBO_CACHE_DIR: .turbo/cache
     steps:
       - name: Checkout
         if: ${{ needs.changes.outputs.frontend == 'true' }}
@@ -155,6 +175,19 @@ jobs:
       - name: Install dependencies
         if: ${{ needs.changes.outputs.frontend == 'true' }}
         run: pnpm install
+
+      # See frontend-build for the key strategy. These entries are tiny (~60KB
+      # measured): `test` declares no outputs, so turbo caches exit codes and
+      # logs rather than artifacts -- yet a hit still skips the whole suite,
+      # which is the single most expensive task in the graph.
+      - name: Restore turbo cache
+        if: ${{ needs.changes.outputs.frontend == 'true' }}
+        uses: actions/cache@v4
+        with:
+          path: .turbo/cache
+          key: turbo-test-${{ runner.os }}-${{ github.sha }}
+          restore-keys: |
+            turbo-test-${{ runner.os }}-
 
       - name: Test
         if: ${{ needs.changes.outputs.frontend == 'true' }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,7 +75,19 @@ jobs:
             echo "frontend=false" >> "$GITHUB_OUTPUT"
           fi
 
-  frontend:
+  # The frontend validation is split across two runners on purpose. Both
+  # `@multica/web:build` (a webpack production build) and `@multica/views:test`
+  # (259 jsdom files) are CPU-saturating, and a standard runner only has
+  # 4 vCPUs. Running them in one job made them starve each other: the views
+  # suite needs ~104s wall when it owns 4 cores but took ~500s sharing them,
+  # and the identical webpack compile went from ~26s to ~342s. Splitting buys
+  # a second 4-vCPU box rather than reducing the work; total runner-minutes go
+  # up slightly, wall-clock feedback time goes down.
+  #
+  # The split is weighted, not even: the test group is by far the heavier half
+  # (~575 CPU-seconds vs ~250 for build + typecheck + lint), so it gets a
+  # runner to itself and everything else shares the other one.
+  frontend-build:
     needs: changes
     runs-on: ubuntu-latest
     steps:
@@ -112,14 +124,67 @@ jobs:
           pnpm generate:reserved-slugs
           git diff --exit-code -- packages/core/paths/reserved-slugs.ts
 
-      - name: Build, type check, lint, and test
+      - name: Build, type check, and lint
         if: ${{ needs.changes.outputs.frontend == 'true' }}
         # Mobile lives in a parallel mobile-verify workflow (path-filtered
         # to apps/mobile/** + packages/core/**) so it doesn't add
         # ~50s of expo-lint + tsc to every web/desktop PR. Keep this
         # filter in sync with the root package.json scripts, which also
         # exclude @multica/mobile.
-        run: pnpm exec turbo build typecheck lint test --filter='!@multica/docs' --filter='!@multica/mobile'
+        run: pnpm exec turbo build typecheck lint --filter='!@multica/docs' --filter='!@multica/mobile'
+
+  frontend-test:
+    needs: changes
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        if: ${{ needs.changes.outputs.frontend == 'true' }}
+        uses: actions/checkout@v6
+
+      - name: Setup pnpm
+        if: ${{ needs.changes.outputs.frontend == 'true' }}
+        uses: pnpm/action-setup@v4
+
+      - name: Setup Node.js
+        if: ${{ needs.changes.outputs.frontend == 'true' }}
+        uses: actions/setup-node@v6
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: Install dependencies
+        if: ${{ needs.changes.outputs.frontend == 'true' }}
+        run: pnpm install
+
+      - name: Test
+        if: ${{ needs.changes.outputs.frontend == 'true' }}
+        # Same filter rationale as frontend-build. Type errors are not this
+        # job's responsibility — the `typecheck` task in frontend-build owns
+        # them, which is why `test` no longer depends on `^typecheck`.
+        run: pnpm exec turbo test --filter='!@multica/docs' --filter='!@multica/mobile'
+
+  # Aggregate gate. `frontend` is the status-check name the repository's
+  # branch rules refer to, so it has to survive the split above: this job
+  # keeps reporting under that name and simply fails when either half fails.
+  # It also inherits the old contract that the check goes green (rather than
+  # staying pending) on PRs the path filter excluded — both halves succeed
+  # trivially in that case because every step is gated off.
+  frontend:
+    needs: [frontend-build, frontend-test]
+    if: ${{ always() }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check frontend job results
+        env:
+          BUILD_RESULT: ${{ needs.frontend-build.result }}
+          TEST_RESULT: ${{ needs.frontend-test.result }}
+        run: |
+          echo "frontend-build: $BUILD_RESULT"
+          echo "frontend-test:  $TEST_RESULT"
+          if [ "$BUILD_RESULT" != "success" ] || [ "$TEST_RESULT" != "success" ]; then
+            echo "::error::frontend validation failed"
+            exit 1
+          fi
 
   backend:
     runs-on: ubuntu-latest

--- a/turbo.json
+++ b/turbo.json
@@ -32,11 +32,13 @@
     "typecheck": {
       "dependsOn": ["^typecheck"]
     },
-    "test": {
-      "dependsOn": ["^typecheck"]
-    },
-    "lint": {
-      "dependsOn": ["^typecheck"]
-    }
+    // `test` and `lint` deliberately have no `^typecheck` dependency. No
+    // package emits build artifacts (core/ui/views export raw .ts that the
+    // consumer transpiles), so depending on a dependency's `tsc --noEmit`
+    // bought nothing but head-of-line blocking: the heaviest task in the
+    // graph, `@multica/views:test`, sat idle until core/ui typechecked.
+    // Type errors still fail CI through the `typecheck` task itself.
+    "test": {},
+    "lint": {}
   }
 }

--- a/turbo.json
+++ b/turbo.json
@@ -43,16 +43,24 @@
     "typecheck": {
       "dependsOn": ["^typecheck"]
     },
-    // `^typecheck` is load-bearing here, but not for ordering: a turbo task
-    // hash only covers a workspace dependency's sources if a task edge
-    // reaches them. Without this edge, editing packages/views left
+    // Hash-only transit task. No package implements a `cache-inputs` script,
+    // so every node resolves to <NONEXISTENT> and nothing is ever executed --
+    // but the edges still pull each dependency's file hashes into whatever
+    // depends on it. `dependsOn: ["^cache-inputs"]` makes that recursive, so
+    // the chain stays complete if a package ever gains a purely transitive
+    // dependency. This exists because a turbo task hash covers a workspace
+    // dependency's sources only when a task edge reaches them.
+    "cache-inputs": {
+      "dependsOn": ["^cache-inputs"]
+    },
+    // Without a dependency edge, editing packages/views or packages/ui left
     // `@multica/web#test` and `@multica/desktop#test` byte-identical in hash,
-    // so a cached pass would be replayed for code that changed underneath.
-    // `typecheck` is the one task every package defines, which is what makes
-    // it the usable edge -- `^test` would miss packages/ui, which has no test
-    // script. Harmless to omit while nothing was cached; not once it is.
+    // so a cached pass would be replayed over changed code. `^cache-inputs`
+    // closes that without side effects: `^typecheck` would also work but drags
+    // three real `tsc --noEmit` runs (~223 CPU-seconds) into the test job, and
+    // `^test` would serialise the suites behind each other.
     "test": {
-      "dependsOn": ["^typecheck"]
+      "dependsOn": ["^cache-inputs"]
     },
     // `lint` keeps no dependency edge: eslint here is not type-aware (no
     // `projectService` / `parserOptions.project` anywhere in

--- a/turbo.json
+++ b/turbo.json
@@ -1,5 +1,10 @@
 {
   "$schema": "https://turbo.build/schema.json",
+  // The CI workflow pins the toolchain these tasks run under (Node 22 today).
+  // Without it in the global hash, bumping that version would replay cached
+  // typecheck/test results produced by the old runtime and hide an
+  // incompatibility behind a green check.
+  "globalDependencies": [".github/workflows/ci.yml"],
   "globalEnv": [
     "DATABASE_URL",
     "PORT",
@@ -18,7 +23,13 @@
   "tasks": {
     "build": {
       "dependsOn": ["^build"],
-      "inputs": ["src/**", "app/**", "**/*.ts", "**/*.tsx", "**/*.css"],
+      // No explicit `inputs`: turbo's default (every git-tracked file in the
+      // package) is the only safe hash source now that the cache is actually
+      // restored in CI. The previous narrow glob list matched neither
+      // `content/**/*.mdx` (compiled by fumadocs-mdx during the build),
+      // `public/**` assets, nor `package.json` / `tsconfig.json`, so the task
+      // hash was unchanged by edits to any of them -- harmless while nothing
+      // was ever cached, a stale-build bug the moment it is.
       "outputs": [".next/**", "!.next/cache/**", "dist/**", "out/**"]
     },
     "dev": {
@@ -32,13 +43,21 @@
     "typecheck": {
       "dependsOn": ["^typecheck"]
     },
-    // `test` and `lint` deliberately have no `^typecheck` dependency. No
-    // package emits build artifacts (core/ui/views export raw .ts that the
-    // consumer transpiles), so depending on a dependency's `tsc --noEmit`
-    // bought nothing but head-of-line blocking: the heaviest task in the
-    // graph, `@multica/views:test`, sat idle until core/ui typechecked.
-    // Type errors still fail CI through the `typecheck` task itself.
-    "test": {},
+    // `^typecheck` is load-bearing here, but not for ordering: a turbo task
+    // hash only covers a workspace dependency's sources if a task edge
+    // reaches them. Without this edge, editing packages/views left
+    // `@multica/web#test` and `@multica/desktop#test` byte-identical in hash,
+    // so a cached pass would be replayed for code that changed underneath.
+    // `typecheck` is the one task every package defines, which is what makes
+    // it the usable edge -- `^test` would miss packages/ui, which has no test
+    // script. Harmless to omit while nothing was cached; not once it is.
+    "test": {
+      "dependsOn": ["^typecheck"]
+    },
+    // `lint` keeps no dependency edge: eslint here is not type-aware (no
+    // `projectService` / `parserOptions.project` anywhere in
+    // packages/eslint-config), so it only ever reads its own package's files
+    // and a dependency's source cannot change its result.
     "lint": {}
   }
 }


### PR DESCRIPTION
Implements levers 1, 4 and 2 from the CI timing analysis in MUL-5347. Two commits, reviewable independently.

## Commit 1 — split frontend build and test onto separate runners

The `frontend` job was the critical path of every CI run touching web code (p50 **576s** vs 267s for `backend`), and 94% of it was one `turbo build typecheck lint test` invocation.

The cost was **contention, not slow tasks**. A standard runner has 4 vCPUs (confirmed: Next spawns `cpus-1` = 3 workers on CI), and the job ran two CPU-saturating tasks on them concurrently:

| task | owning the machine | sharing 4 vCPUs |
| --- | --- | --- |
| `@multica/views:test` (259 jsdom files) | **104s** | **500s** |
| `@multica/web:build` (webpack) | **26s** | **342s** |

Split weighted, not evenly — the test group is ~575 CPU-seconds against ~250 for build+typecheck+lint, so tests get a runner alone. `frontend` is retained as an aggregate gate so the existing status-check name keeps reporting, including the established behaviour that it goes green rather than pending on path-filtered PRs.

**Measured on this PR's own CI run:** frontend-test 344s, frontend-build 272s, whole run wall **585s → 357s (9.8m → 6.0m, −39%)**.

## Commit 2 — cache turbo task results across runs

Every run rebuilt all 16 tasks cold: turbo reported `Remote caching disabled` / `Cached: 0 cached, 16 total`, because only the pnpm store was cached. This persists turbo's filesystem cache via `actions/cache`. No Vercel remote-cache credentials exist in this repo, so this is the local cache, keyed per job.

Simulating a fresh checkout against a warm cache:

| job | cold | warm |
| --- | --- | --- |
| `frontend-build` | 54.7s | **184ms** (12/12 cached) |
| `frontend-test` | 115.7s | **50ms** (7/7 cached) |

Footprint is 20MB for build and ~60KB for test — `test` declares no outputs, so turbo stores exit codes and logs, yet a hit still skips the most expensive task in the graph.

### Two latent hashing bugs that caching would have made real

Both are fixed in the same commit, because enabling the cache is what makes them exploitable.

**1. `build` had narrow `inputs` globs.** They matched neither `content/**/*.mdx` (compiled by fumadocs-mdx during the build), `public/**` assets, nor `package.json` / `tsconfig.json`. Verified against the task hash:

```
                          before fix          after fix
baseline                  f026498647bcc4bd    cad1a77380464920
after MDX content edit    f026498647bcc4bd    e0093423a6c07717
after public/ asset edit  f026498647bcc4bd    38e50db291679839
after tsconfig.json edit  f026498647bcc4bd    a94e559017224ff2
```

Identical hashes mean a stale build would be served. Replaced with turbo's default input set.

**2. `test` regains its `^typecheck` edge — this partially reverts commit 1.** I justified removing it there on the grounds that it only imposed ordering. That was true *without* a cache, and wrong once there is one: a turbo task hash covers a workspace dependency's sources only if a task edge reaches them. With no edge, editing `packages/views` or `packages/ui` left `@multica/web#test` and `@multica/desktop#test` byte-identical in hash — a cached pass replayed over changed code:

```
                     @multica/web#test   @multica/desktop#test
baseline             e66a6d29724ae675    22963fbc9cdbd8d0
after views/ edit    e66a6d29724ae675    22963fbc9cdbd8d0   <- unchanged, wrong
after ui/ edit       e66a6d29724ae675    22963fbc9cdbd8d0   <- unchanged, wrong
```

`typecheck` is the only task every package defines, which is what makes it the usable edge — `^test` would miss `packages/ui`, which has no test script. After the fix all four hashes differ, and a `packages/ui` edit correctly re-runs views/web/desktop tests while `core:test` stays cached.

`lint` keeps no edge: eslint here is not type-aware (no `projectService` / `parserOptions.project` anywhere in `packages/eslint-config`), so a dependency's sources cannot change its result.

**3. `globalDependencies` now includes `.github/workflows/ci.yml`**, which pins the Node version. Without it, a toolchain bump would replay results produced by the old runtime behind a green check.

## Trade-offs

- Two runners duplicate checkout + install (~30s each), so **total runner-minutes rise slightly** while wall-clock feedback drops. If CI cost matters more than latency, the caching commit is the one that helps and the split is the one that costs.
- A cached `test` result means a green check without executing tests. That is turbo's intended behaviour and the point of the change, but it does mean a flaky failure will not resurface on a re-run of identical inputs.
- Cache entries are keyed by SHA with a `restore-keys` prefix fallback. GitHub scopes caches by branch, so a PR reads main's entries on first push and writes its own for re-pushes.

## Verification

Run locally on this branch:

- Cold → warm cycle for both jobs, simulating fresh checkouts (numbers above)
- Partial invalidation: editing `packages/ui` re-runs `views:test`, `web:test`, `desktop:test` and correctly leaves `core:test` cached
- Both hashing bugs verified before and after by diffing task hashes directly
- `turbo build typecheck lint` 12/12 and `turbo test` 7/7 pass from cold
- `actionlint .github/workflows/ci.yml` clean

Not verified locally: `actions/cache` restore/save across real runs, and the aggregate gate's skipped/failed permutations — both only exist on GitHub. The first CI run here writes a cold cache; the hit rate shows from the second push onward.


---

## Commit 3 — review fixes

**Must-fix: the cache was not isolated by interpreter.** `node-version: 22` floats across patch releases, and turbo's global hash does not include the interpreter at all — `engines` is `null` in its dry-run cache inputs, which I confirmed directly. A runner moving to another 22.x would leave the workflow text and every task hash unchanged, restore the old cache through `restore-keys`, and report green without executing anything. Both jobs now resolve `node --version` into a step output and carry it, plus `runner.arch`, in the key and the restore prefix.

**Must-fix: `actions/cache@v4` runs on the deprecated Node 20 runtime** and was being force-migrated to Node 24 with a warning on every run (confirmed in the run logs). Moved to **v6** — the review suggested v5, but v6.1.0 is current and satisfies the same runner floor (≥ 2.327.1; hosted runners are on 2.335.1).

**`test` no longer depends on `^typecheck`.** It needs dependency *sources* in its hash, not a type check. A hash-only `cache-inputs` transit task now carries them: no package implements that script, so every node resolves to `<NONEXISTENT>` and nothing executes, while the edges still pull each dependency's files into the hash. Declared recursively (`dependsOn: ["^cache-inputs"]`) so the chain survives a package gaining a purely transitive dependency — every workspace dep is direct today, but that is not worth relying on.

This returns the ~223 CPU-seconds the previous commit gave up:

| test job (cold) | tasks | wall |
| --- | --- | --- |
| with `^typecheck` | 7 | 115.7s |
| with `^cache-inputs` | 4 | **67.2s** |

Correctness is unchanged — editing `packages/ui` still re-runs the views, web and desktop suites while `core:test` stays cached, verified by hash and by execution.

**Corrected an inaccurate comment.** The previous commit claimed `^test` would miss `packages/ui` because it has no test script. It would not — turbo materialises a `<NONEXISTENT>` node that participates in hashing, which I verified against the dry graph after the review flagged it. `^test` is still the wrong edge here, but because it serialises the suites behind each other, not for the reason I gave.

**Also:** dropped the stale comment saying tests no longer depend on `^typecheck`, and swapped the aggregate gate's `always()` for `!cancelled()` so a run superseded by a newer push does not spend a runner on a verdict nobody reads.

### Verification

- Cold → warm cycle re-run end to end: `frontend-build` 52.3s → **184ms** (12/12 cached), `frontend-test` 67.2s → **52ms** (4/4 cached)
- `packages/ui` and `packages/views` edits both propagate to views/web/desktop test hashes with `core` constant; `turbo test` executes exactly 4 real commands with 8 no-op transit nodes
- Step sets diffed structurally against the previous commit to confirm only the new `Resolve runtime for cache key` step was added and nothing dropped
- `actionlint` clean
