### PR TITLE
refactor(core): drop unused issue view store singletons

### DIFF
--- a/packages/core/issues/stores/index.ts
+++ b/packages/core/issues/stores/index.ts
@@ -35,11 +35,8 @@ export {
   type ActorIssuesScope,
 } from "./actor-issues-view-store";
 export {
-  useIssueViewStore,
-  createIssueViewStore,
   viewStoreSlice,
   viewStorePersistOptions,
-  useClearFiltersOnWorkspaceChange,
   SORT_OPTIONS,
   CARD_PROPERTY_OPTIONS,
   TABLE_SYSTEM_COLUMNS,

--- a/packages/core/issues/stores/view-store.ts
+++ b/packages/core/issues/stores/view-store.ts
@@ -1,12 +1,10 @@
 "use client";
 
-import { useEffect, useRef } from "react";
-import { create } from "zustand";
-import { createStore, type StoreApi } from "zustand/vanilla";
-import { createJSONStorage, persist } from "zustand/middleware";
+import type { StoreApi } from "zustand/vanilla";
+import { createJSONStorage } from "zustand/middleware";
 import type { IssueStatus, IssuePriority } from "../../types";
 import { ALL_STATUSES } from "../config";
-import { createWorkspaceAwareStorage, registerForWorkspaceRehydration } from "../../platform/workspace-storage";
+import { createWorkspaceAwareStorage } from "../../platform/workspace-storage";
 import { defaultStorage } from "../../platform/storage";
 
 export type ViewMode = "board" | "list" | "table" | "gantt" | "swimlane";
@@ -569,41 +567,4 @@ export function mergeViewStatePersisted<T extends IssueViewState>(
       ? p.tableCollapsedParents
       : current.tableCollapsedParents,
   };
-}
-
-/** Factory: creates a vanilla StoreApi for use with React Context. */
-export function createIssueViewStore(persistKey: string): StoreApi<IssueViewState> {
-  const store = createStore<IssueViewState>()(
-    persist(viewStoreSlice, viewStorePersistOptions(persistKey))
-  );
-  registerForWorkspaceRehydration(() => store.persist.rehydrate());
-  return store;
-}
-
-/** Global singleton for the /issues page. */
-export const useIssueViewStore = create<IssueViewState>()(
-  persist(viewStoreSlice, viewStorePersistOptions("multica_issues_view"))
-);
-
-registerForWorkspaceRehydration(() => useIssueViewStore.persist.rehydrate());
-
-/**
- * Clears the given view store's filters whenever the workspace id changes.
- *
- * URL-driven: wsId arrives from `useWorkspaceId()` (Context fed by the
- * `[workspaceSlug]` route). We track the previous id via ref so the first
- * render doesn't wipe persisted filters — clearing only fires on transitions
- * from one defined workspace to another.
- */
-export function useClearFiltersOnWorkspaceChange(
-  store: StoreApi<IssueViewState> | { getState: () => IssueViewState },
-  wsId: string | undefined,
-) {
-  const prevIdRef = useRef<string | undefined>(undefined);
-  useEffect(() => {
-    if (prevIdRef.current && wsId && wsId !== prevIdRef.current) {
-      store.getState().clearFilters();
-    }
-    prevIdRef.current = wsId;
-  }, [wsId, store]);
 }

--- a/packages/core/platform/storage-cleanup.ts
+++ b/packages/core/platform/storage-cleanup.ts
@@ -10,6 +10,9 @@ import type { StorageAdapter } from "../types/storage";
 const WORKSPACE_SCOPED_KEYS = [
   "multica_issue_draft",
   "multica_issue_surface_views",
+  // Legacy: no store writes this key anymore (issue views moved to
+  // `multica_issue_surface_views`). Kept so existing entries still get cleaned
+  // up on workspace deletion / logout.
   "multica_issues_view",
   "multica_issues_scope",
   "multica_my_issues_view",

--- a/packages/views/issues/components/issues-page.test.tsx
+++ b/packages/views/issues/components/issues-page.test.tsx
@@ -329,22 +329,12 @@ const mockViewState = {
 };
 
 vi.mock("@multica/core/issues/stores/view-store", () => ({
-  useClearFiltersOnWorkspaceChange: () => {},
   PROPERTY_VIEW_PREFIX: "property:",
   propertyIdFromViewKey: (key: string) =>
     key.startsWith("property:") ? key.slice("property:".length) : null,
   viewStorePersistOptions: () => ({ name: "test", storage: undefined, partialize: (s: any) => s }),
   mergeViewStatePersisted: (_p: unknown, c: any) => c,
   viewStoreSlice: vi.fn(),
-  useIssueViewStore: Object.assign(
-    (selector?: any) => (selector ? selector(mockViewState) : mockViewState),
-    { getState: () => mockViewState, setState: vi.fn() },
-  ),
-  createIssueViewStore: () => ({
-    getState: () => mockViewState,
-    setState: vi.fn(),
-    subscribe: vi.fn(),
-  }),
   SORT_OPTIONS: [
     { value: "position", label: "Manual" },
     { value: "priority", label: "Priority" },


### PR DESCRIPTION
Removes the issue view store singletons that no longer have any production caller. Issue surfaces get their view state from `getIssueSurfaceViewStore()` (`surface-view-store.ts`); these three exports were left behind by that migration.

Deleted from `packages/core/issues/stores/view-store.ts`:

- `useIssueViewStore` — the `multica_issues_view` global singleton
- `createIssueViewStore` — the per-key factory
- `useClearFiltersOnWorkspaceChange` — superseded by workspace-namespaced storage (`createWorkspaceAwareStorage` + `registerForWorkspaceRehydration`), which already gives each workspace its own view state

Before this, the only references were the barrel re-export in `stores/index.ts` and a mock in `issues-page.test.tsx`. Both dead stores also registered workspace rehydration callbacks that ran on every workspace switch for nothing.

Beyond the dead weight, the singleton was an active trap: it looks like *the* issue view store, so changing view defaults there would silently never take effect anywhere in the product.

### Not affected

- **Mobile** keeps its own `useClearFiltersOnWorkspaceChange` in `apps/mobile/lib/use-clear-filters-on-workspace-change.ts`. It never imported the core one, so nothing changes there.
- **`multica_issues_view` stays in `storage-cleanup.ts`'s key list** — no store writes it anymore, but existing users still have entries under it, and workspace deletion / logout should keep purging them. Added a comment marking it legacy.

### Verification

- `pnpm typecheck` — 6/6 pass
- `pnpm lint` — 8/8 pass, 0 errors
- `packages/views` — 3017/3018 pass, `apps/desktop` — 375/375 pass
- Pre-existing failures on `main`, unrelated and unchanged by this PR (verified by re-running each against a clean tree): 8 in `packages/core` (`workspace/mutations`, `projects/mutations`, `realtime/use-realtime-sync-ws-instance` — all `localStorage.removeItem is not a function` in the test env) and 1 in `packages/views` (`layout/sidebar-resize`).
