### PR TITLE
fix(issues): 快速跳转导航条移到右侧、贴近滚动条 (MUL-4522)

### DIFF
--- a/packages/views/issues/components/issue-detail.tsx
+++ b/packages/views/issues/components/issue-detail.tsx
@@ -2200,9 +2200,14 @@ export function IssueDetail({ issueId, onDelete, onDone, defaultSidebarOpen = tr
             z-30: must beat every sticky affordance pinned at the timeline's
             top-0 (comment headers z-10, resolve collapse bars z-20) — at equal
             z the later-in-DOM sticky bar paints over the find bar and orphans
-            its close button (MUL-4414). */}
+            its close button (MUL-4414). On desktop it also steps inside the
+            thread rail's right-edge strip, so an open find bar can't cover
+            the topmost ticks. */}
         {find.open && (
-          <FindBar find={find} className="absolute right-4 top-14 z-30" />
+          <FindBar
+            find={find}
+            className={cn("absolute top-14 z-30", isMobile ? "right-4" : "right-10")}
+          />
         )}
         <BreadcrumbHeader
           segments={breadcrumbSegments}
@@ -2704,16 +2709,22 @@ export function IssueDetail({ issueId, onDelete, onDone, defaultSidebarOpen = tr
         </div>
         </div>
 
-        {/* Thread quick-jump rail — overlays the scroll container's left
-            gutter (inside the px-8 content padding, so it never covers
-            text). Hover previews a thread, click jumps to it. Hidden on
-            mobile: no hover, and the gutter is too tight. */}
+        {/* Thread quick-jump rail — rides the scroll container's right edge,
+            next to the scrollbar, where the pointer already is while
+            scrolling (MUL-4522). right-3 is the inset that works in both
+            scrollbar modes: it clears a classic scrollbar's ~11px gutter,
+            and the rail's own 20px width lands it exactly on the content
+            column's px-8 padding when the gutter is 0 (overlay scrollbars),
+            so it covers neither the scrollbar nor body text. It also clears
+            the resize handle's 4px drag strip at the panel edge. Hover
+            previews a thread, click jumps to it. Hidden on mobile: no
+            hover, and the gutter is too tight. */}
         {!isMobile && (
           <ThreadMinimap
             threads={minimapThreads}
             scrollContainerEl={scrollContainerEl}
             onJump={jumpToThread}
-            className="absolute bottom-0 left-2 top-12"
+            className="absolute bottom-0 right-3 top-12"
           />
         )}
       </div>

--- a/packages/views/issues/components/thread-minimap.test.tsx
+++ b/packages/views/issues/components/thread-minimap.test.tsx
@@ -128,6 +128,33 @@ describe("ThreadMinimap", () => {
     }
   });
 
+  it("hugs the scrollbar side: ticks are right-aligned and the card opens inward", () => {
+    vi.useFakeTimers({
+      toFake: ["setTimeout", "clearTimeout", "requestAnimationFrame", "cancelAnimationFrame"],
+    });
+    try {
+      renderWithI18n(
+        <ThreadMinimap threads={threads} scrollContainerEl={null} onJump={vi.fn()} />,
+      );
+
+      // The rail sits in the right gutter, so ticks flush right and the wave
+      // grows them inward (away from the scrollbar) rather than over it.
+      const tick = screen.getByRole("button", { name: "First thread opener" });
+      expect(tick).toHaveClass("justify-end");
+      expect(tick.firstElementChild).toHaveClass("origin-right");
+
+      const nav = screen.getByRole("navigation", { name: "Jump to comment thread" });
+      fireEvent.pointerMove(nav, { clientY: 0 });
+      act(() => vi.advanceTimersByTime(30 + 150)); // rAF flush + intent delay
+
+      const card = screen.getByText("with details").closest("div");
+      expect(card).toHaveClass("right-8");
+      expect(card?.className).not.toMatch(/(?:^|\s)left-/);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("jumps to the clicked thread", () => {
     const onJump = vi.fn();
     renderWithI18n(

--- a/packages/views/issues/components/thread-minimap.tsx
+++ b/packages/views/issues/components/thread-minimap.tsx
@@ -8,14 +8,19 @@ import { useT } from "../../i18n";
 // ThreadMinimap — Linear-style quick-jump rail for comment threads
 // ---------------------------------------------------------------------------
 //
-// A vertical column of tick marks overlaid on the left edge of the issue
-// detail scroll area, one tick per top-level comment thread (folded resolved
-// bars included — they are jump targets too). Ticks whose thread is currently
-// inside the scroll viewport render darker, so the rail doubles as a "you are
-// here" minimap. Hovering magnifies ticks in a Dock-style wave around the
-// cursor (the hovered tick peaks, neighbours taper off) and shows a preview
-// card (bold first line + muted body excerpt); clicking jumps the timeline
-// to that thread.
+// A vertical column of tick marks overlaid on the right edge of the issue
+// detail scroll area, just inside the scrollbar, one tick per top-level
+// comment thread (folded resolved bars included — they are jump targets too).
+// Ticks whose thread is currently inside the scroll viewport render darker, so
+// the rail doubles as a "you are here" minimap. Hovering magnifies ticks in a
+// Dock-style wave around the cursor (the hovered tick peaks, neighbours taper
+// off) and shows a preview card (bold first line + muted body excerpt);
+// clicking jumps the timeline to that thread.
+//
+// It rides the scrollbar side on purpose: it looks and behaves like a scroll
+// affordance, and every precedent for that (the scrollbar itself, editor
+// minimaps, floating outlines) lives on the right — so the pointer is already
+// there, and the travel from scrolling to jumping is short (MUL-4522).
 //
 // The preview is ONE card owned by the rail, not a popover per tick: the
 // open-intent delay is paid once when the pointer enters the rail, and while
@@ -111,7 +116,7 @@ interface ThreadMinimapProps {
   /** The issue detail scroll container; null until its callback ref populates. */
   scrollContainerEl: HTMLElement | null;
   onJump: (threadId: string) => void;
-  /** Positioning within the page (e.g. `absolute left-2 top-12 bottom-0`) — owned by the caller, like FindBar. */
+  /** Positioning within the page (e.g. `absolute right-3 top-12 bottom-0`) — owned by the caller, like FindBar. */
   className?: string;
 }
 
@@ -195,14 +200,21 @@ function MinimapTick({
       type="button"
       aria-label={label}
       onClick={onClick}
-      className="group/tick flex min-h-[5px] w-6 flex-[0_1_0.875rem] cursor-pointer items-center focus-visible:outline-none"
+      // 20px wide, tick flushed to the right end: with the rail inset 12px
+      // (see the caller's className) the strip spans 12–32px from the panel
+      // edge, which clears a classic scrollbar's ~11px gutter on one side and
+      // stops exactly at the content column's 32px padding on the other — so
+      // it never sits on the scrollbar nor on body text, in either scrollbar
+      // mode.
+      className="group/tick flex min-h-[5px] w-5 flex-[0_1_0.875rem] cursor-pointer items-center justify-end focus-visible:outline-none"
     >
       <span
         className={cn(
-          // Enlargement is a left-anchored `scale` (compositor-friendly, and
-          // what the JS wave writes inline). The 100ms ease-out doubles as
-          // smoothing between pointer samples and as the settle on leave.
-          "h-0.5 w-3 origin-left rounded-full transition-[scale,background-color] duration-100 ease-out",
+          // Enlargement is a right-anchored `scale` (compositor-friendly, and
+          // what the JS wave writes inline), so ticks grow inward, away from
+          // the scrollbar. The 100ms ease-out doubles as smoothing between
+          // pointer samples and as the settle on leave.
+          "h-0.5 w-3 origin-right rounded-full transition-[scale,background-color] duration-100 ease-out",
           inViewport ? "bg-foreground/70" : "bg-muted-foreground/30",
           "group-hover/tick:bg-foreground",
           // CSS floor states for when no inline wave value is present:
@@ -430,13 +442,15 @@ export function ThreadMinimap({ threads, scrollContainerEl, onJump, className }:
           (the open-intent delay already gates accidental flashes; once the
           user waited, showing content instantly is the responsive choice)
           and slid between ticks with a short transform transition. Hovering
-          the card keeps it open so its text stays selectable. */}
+          the card keeps it open so its text stays selectable. It opens
+          inward (leftward, over the content) — the only direction with room
+          next to the scrollbar. */}
       {preview && activeThread && activePreview && (
         <div
           ref={cardRef}
           onPointerEnter={cancelClose}
           onPointerLeave={scheduleClose}
-          className="pointer-events-auto absolute left-9 top-0 w-72 rounded-lg bg-popover p-2.5 text-sm text-popover-foreground shadow-md ring-1 ring-foreground/10 transition-transform duration-150 ease-out motion-reduce:transition-none"
+          className="pointer-events-auto absolute right-8 top-0 w-72 rounded-lg bg-popover p-2.5 text-sm text-popover-foreground shadow-md ring-1 ring-foreground/10 transition-transform duration-150 ease-out motion-reduce:transition-none"
           style={{ transform: `translateY(${preview.y}px) translateY(-50%)` }}
         >
           <p className="truncate text-sm font-semibold text-foreground">{activeTitle}</p>


### PR DESCRIPTION
## What

评论线程的快速跳转导航条（`ThreadMinimap`）从内容面板最左缘移到右缘、紧贴滚动条内侧。不加「左/右切换」设置。

Discord 反馈（Anderson Oki）：导航条长着滚动条的样子却在左边，宽屏下离正文和鼠标所在的滚动区域都很远，每次跳转都要横跨整页。

## How

- `issue-detail.tsx`：`absolute left-2` → `absolute right-3`。
- `thread-minimap.tsx`：刻度 `justify-end` 靠右、`origin-left` → `origin-right`（放大波向内长，不压滚动条）；按钮 `w-6` → `w-5`；预览卡 `left-9` → `right-8`（向内开）。
- FindBar 桌面端 `right-4` → `right-10`，避免打开查找时盖住最上面几个刻度。

`right-3` + 20px 宽这个组合是两种滚动条模式下都成立的内缩量：

| | 滚动条占位 | 导航条 | 正文右缘 |
|---|---|---|---|
| 经典滚动条（`scrollbar-width: thin`） | 0–11px | 12–32px | 43px |
| overlay 滚动条（gutter = 0） | 覆盖式、自动隐藏 | 12–32px | 32px |

两种模式下都既不压滚动条也不压正文；同时也让开了面板拖拽把手在面板边缘的 4px 热区。

## Verification

- `pnpm exec vitest run issues/`：50 files / 464 tests 通过，含新增的右侧锚定回归测试。
- `pnpm typecheck`、`pnpm lint`：通过（lint 仅剩既有 warning，0 error）。
- 用 Playwright + 仓库真实 Tailwind 产物搭了一次性静态画板量几何：实测 gutter 11px/边，导航条落在 12–32px，正文右缘 43px——与上表一致。窄面板（正文列跑满、滚动条真实出现）下同样不重叠。

## Notes

未做左/右偏好设置：目前证据是单边的，加设置意味着永久维护和测试两套布局。改完之后如果真有人要左侧，再谈不迟。

Closes MUL-4522

🤖 Generated with [Claude Code](https://claude.com/claude-code)
