### PR TITLE
refactor(channel): claim media ledger rows one at a time (MUL-5367)

### DIFF
--- a/server/internal/service/channel_media_reconciler.go
+++ b/server/internal/service/channel_media_reconciler.go
@@ -2,10 +2,12 @@ package service
 
 import (
 	"context"
+	"errors"
 	"log/slog"
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgtype"
 
 	"github.com/multica-ai/multica/server/internal/metrics"
@@ -52,10 +54,10 @@ const (
 	// channelMediaReconcileLease bounds how long a claimed row stays owned by
 	// a worker before another replica may reclaim it (crash recovery).
 	channelMediaReconcileLease = 2 * time.Minute
-	// channelMediaReconcileBatchLimit bounds one sweep's claim (and thus its
-	// object-storage work) — the reconciler's concurrency is one batch,
-	// processed sequentially.
-	channelMediaReconcileBatchLimit = 50
+	// channelMediaReconcileSweepLimit bounds how many rows one sweep settles
+	// (and thus its object-storage work). Rows are claimed one at a time and
+	// settled sequentially; the limit just keeps a sweep from running away.
+	channelMediaReconcileSweepLimit = 50
 	// Backoff for failed object-storage deletes: base << (attempt-1), capped.
 	channelMediaReconcileBackoffBase = time.Minute
 	channelMediaReconcileBackoffCap  = time.Hour
@@ -136,9 +138,13 @@ func (r *ChannelMediaReconciler) Run(ctx context.Context) {
 	}
 }
 
-// RunOnce claims one batch of due ledger rows and settles each. All errors
-// are per-row and non-fatal: a row that cannot be settled now backs off and
-// is retried on a later sweep (or by another replica after lease expiry).
+// RunOnce settles due ledger rows one at a time: claim a row, settle it, claim
+// the next, up to the per-sweep limit. Each claim is taken immediately before
+// that row's work, so a row is never left holding a lease it has to wait for —
+// its attempt counter and backoff describe deletes that were actually tried.
+// All errors are per-row and non-fatal: a row that cannot be settled now backs
+// off and is retried on a later sweep (or by another replica after lease
+// expiry).
 func (r *ChannelMediaReconciler) RunOnce(ctx context.Context) {
 	if r.Storage == nil {
 		// The wiring only builds a reconciler when a storage backend exists,
@@ -149,18 +155,25 @@ func (r *ChannelMediaReconciler) RunOnce(ctx context.Context) {
 		r.logger().Error("channel media reconciler: no storage backend; skipping sweep")
 		return
 	}
-	leaseToken := pgtype.UUID{Bytes: uuid.New(), Valid: true}
-	rows, err := r.Queries.ClaimChannelMediaPendingObjectsForReconcile(ctx, db.ClaimChannelMediaPendingObjectsForReconcileParams{
-		LeaseToken:  leaseToken,
-		Lease:       pgInterval(channelMediaReconcileLease),
-		SettleDelay: pgInterval(ChannelMediaReconcileSettleDelay),
-		BatchLimit:  channelMediaReconcileBatchLimit,
-	})
-	if err != nil {
-		r.logger().Warn("channel media reconciler: claim failed", "error", err)
-		return
-	}
-	for _, row := range rows {
+	for settled := 0; settled < channelMediaReconcileSweepLimit; settled++ {
+		leaseToken := pgtype.UUID{Bytes: uuid.New(), Valid: true}
+		row, err := r.Queries.ClaimNextChannelMediaPendingObjectForReconcile(ctx, db.ClaimNextChannelMediaPendingObjectForReconcileParams{
+			LeaseToken:  leaseToken,
+			Lease:       pgInterval(channelMediaReconcileLease),
+			SettleDelay: pgInterval(ChannelMediaReconcileSettleDelay),
+		})
+		if errors.Is(err, pgx.ErrNoRows) {
+			break
+		}
+		if err != nil {
+			// Shutdown cancels the sweep mid-loop; that is the normal way a
+			// sweep ends, not a failure worth waking anyone for.
+			if ctx.Err() != nil {
+				return
+			}
+			r.logger().Warn("channel media reconciler: claim failed", "error", err)
+			break
+		}
 		r.settle(ctx, row, leaseToken)
 	}
 	if r.Metrics != nil {
@@ -171,29 +184,12 @@ func (r *ChannelMediaReconciler) RunOnce(ctx context.Context) {
 	}
 }
 
+// settle runs the row the caller just claimed. The lease it holds only has to
+// cover this one row (delete timeout << lease, see the invariant test), so no
+// heartbeat is needed: the claim was taken moments ago and every write below
+// is lease-token guarded, so a row reclaimed after an expiry ignores the old
+// owner's writes rather than being corrupted by them.
 func (r *ChannelMediaReconciler) settle(ctx context.Context, row db.ChannelMediaPendingObject, leaseToken pgtype.UUID) {
-	// Heartbeat the shared batch lease before this row's work: the lease only
-	// ever needs to cover ONE row's worst case (delete timeout << lease, see
-	// the invariant test), not the whole sequential batch. Losing the renewal
-	// means another replica already reclaimed the row after an expiry — skip
-	// it; touching it now would duplicate its delete and fight the new
-	// owner's attempt/backoff accounting.
-	renewed, err := r.Queries.RenewChannelMediaPendingObjectLease(ctx, db.RenewChannelMediaPendingObjectLeaseParams{
-		StorageKey:  row.StorageKey,
-		WorkspaceID: row.WorkspaceID,
-		LeaseToken:  leaseToken,
-		Lease:       pgInterval(channelMediaReconcileLease),
-	})
-	if err != nil {
-		r.logger().Warn("channel media reconciler: lease renew failed; skipping row",
-			"storage_key", row.StorageKey, "error", err)
-		return
-	}
-	if renewed == 0 {
-		r.logger().Info("channel media reconciler: row reclaimed by another worker; skipping",
-			"storage_key", row.StorageKey, "workspace_id", row.WorkspaceID)
-		return
-	}
 	// The reference check runs AFTER the claim flipped the row to 'deleting':
 	// from that point BindMediaRefs cannot attach this key, so a negative
 	// answer is terminal, not a snapshot race. It runs on tombstone passes too:

--- a/server/internal/service/channel_media_reconciler.go
+++ b/server/internal/service/channel_media_reconciler.go
@@ -315,6 +315,12 @@ func (r *ChannelMediaReconciler) nextTombstonePass(row db.ChannelMediaPendingObj
 }
 
 func (r *ChannelMediaReconciler) tombstoneRow(ctx context.Context, row db.ChannelMediaPendingObject, leaseToken pgtype.UUID, next time.Duration, idx int) bool {
+	if ctx.Err() != nil {
+		// Same as release: a cancelled context cannot carry the write, and
+		// shutdown is not a failure. The row stays claimed until its lease
+		// expires, and the next pass re-deletes it idempotently.
+		return false
+	}
 	n, err := r.Queries.TombstoneChannelMediaPendingObject(ctx, db.TombstoneChannelMediaPendingObjectParams{
 		StorageKey:    row.StorageKey,
 		WorkspaceID:   row.WorkspaceID,
@@ -332,6 +338,13 @@ func (r *ChannelMediaReconciler) tombstoneRow(ctx context.Context, row db.Channe
 // release keeps the row in 'deleting' (a bind must still never attach it),
 // drops the lease, and backs off the next attempt.
 func (r *ChannelMediaReconciler) release(ctx context.Context, row db.ChannelMediaPendingObject, leaseToken pgtype.UUID, cause error) {
+	if ctx.Err() != nil {
+		// Shutdown cancelled the settle itself (a DELETE or a query in
+		// flight). The backoff write would fail on the same cancelled context,
+		// so there is nothing to record and nothing worth waking anyone for —
+		// the lease expiry reclaims the row like any other interrupted worker.
+		return
+	}
 	backoff := channelMediaReconcileBackoffBase << min(row.Attempt-1, 10)
 	if backoff > channelMediaReconcileBackoffCap || backoff <= 0 {
 		backoff = channelMediaReconcileBackoffCap
@@ -355,6 +368,11 @@ func (r *ChannelMediaReconciler) release(ctx context.Context, row db.ChannelMedi
 }
 
 func (r *ChannelMediaReconciler) clearRow(ctx context.Context, row db.ChannelMediaPendingObject, leaseToken pgtype.UUID) bool {
+	if ctx.Err() != nil {
+		// See release: shutdown mid-settle leaves the row to its lease expiry
+		// rather than logging a write that never had a chance to land.
+		return false
+	}
 	n, err := r.Queries.DeleteChannelMediaPendingObject(ctx, db.DeleteChannelMediaPendingObjectParams{
 		StorageKey:  row.StorageKey,
 		WorkspaceID: row.WorkspaceID,

--- a/server/internal/service/channel_media_reconciler.go
+++ b/server/internal/service/channel_media_reconciler.go
@@ -54,9 +54,12 @@ const (
 	// channelMediaReconcileLease bounds how long a claimed row stays owned by
 	// a worker before another replica may reclaim it (crash recovery).
 	channelMediaReconcileLease = 2 * time.Minute
-	// channelMediaReconcileSweepLimit bounds how many rows one sweep settles
-	// (and thus its object-storage work). Rows are claimed one at a time and
-	// settled sequentially; the limit just keeps a sweep from running away.
+	// channelMediaReconcileSweepLimit bounds how many settle operations one
+	// sweep performs (and thus its object-storage work). Rows are claimed one
+	// at a time and settled sequentially, so a row released early with a
+	// 1-minute backoff can be re-claimed within a long sweep — the limit
+	// counts settles, not distinct rows, and just keeps a sweep from running
+	// away.
 	channelMediaReconcileSweepLimit = 50
 	// Backoff for failed object-storage deletes: base << (attempt-1), capped.
 	channelMediaReconcileBackoffBase = time.Minute
@@ -155,7 +158,7 @@ func (r *ChannelMediaReconciler) RunOnce(ctx context.Context) {
 		r.logger().Error("channel media reconciler: no storage backend; skipping sweep")
 		return
 	}
-	for settled := 0; settled < channelMediaReconcileSweepLimit; settled++ {
+	for settles := 0; settles < channelMediaReconcileSweepLimit; settles++ {
 		leaseToken := pgtype.UUID{Bytes: uuid.New(), Valid: true}
 		row, err := r.Queries.ClaimNextChannelMediaPendingObjectForReconcile(ctx, db.ClaimNextChannelMediaPendingObjectForReconcileParams{
 			LeaseToken:  leaseToken,

--- a/server/internal/service/channel_media_reconciler_test.go
+++ b/server/internal/service/channel_media_reconciler_test.go
@@ -1,9 +1,11 @@
 package service
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
+	"log/slog"
 	"sync"
 	"testing"
 	"time"
@@ -313,10 +315,10 @@ func TestChannelMediaReconciler_SettleInvariantDwarfsPipelineBudgets(t *testing.
 	if channelMediaReconcileLease <= 0 || channelMediaReconcileLease >= ChannelMediaReconcileSettleDelay {
 		t.Fatalf("lease %v must be positive and well under settle %v", channelMediaReconcileLease, ChannelMediaReconcileSettleDelay)
 	}
-	// The lease is heartbeated per row, so it only ever needs to cover ONE
-	// row's worst case (a delete at its full timeout plus DB round-trips) —
-	// never the whole sequential batch. 2x margin keeps renewal comfortably
-	// ahead of expiry.
+	// A row is claimed immediately before its own settle, so the lease only
+	// ever needs to cover ONE row's worst case (a delete at its full timeout
+	// plus DB round-trips) — never a whole sweep. 2x margin keeps the owner
+	// comfortably ahead of expiry.
 	if channelMediaReconcileLease < 2*channelMediaReconcileDeleteTimeout {
 		t.Fatalf("lease %v must be >= 2x the per-delete timeout %v", channelMediaReconcileLease, channelMediaReconcileDeleteTimeout)
 	}
@@ -419,52 +421,75 @@ func TestChannelMediaReconciler_StalledDeleteIsBoundedAndBacksOff(t *testing.T) 
 	}
 }
 
-// The batch shares one claim but the lease is heartbeated per row: a row
-// reclaimed by another replica mid-batch (its lease expired while earlier
-// deletes ran long) must be skipped — no duplicate delete, no clobbered
-// attempt/backoff on the new owner's row.
-func TestChannelMediaReconciler_SkipsRowReclaimedMidBatch(t *testing.T) {
+// Shutdown cancels the sweep mid-loop. That is how a sweep normally ends, so
+// it must settle nothing and stay silent rather than page someone with a
+// claim-failure warning for its own cancellation.
+func TestChannelMediaReconciler_CancelledSweepIsQuiet(t *testing.T) {
 	pool := newCancelFinalizePool(t)
 	f := seedReconcilerFixture(t, pool)
-	foreign := util.MustParseUUID("66666666-6666-4666-8666-666666666666")
+	key := "ws/lark/cancelled"
+	f.seedLedgerRow(t, key, "https://cdn.test/cancelled", "pending", ChannelMediaReconcileSettleDelay+time.Minute)
+	var logs bytes.Buffer
 	deleter := &fakeObjectDeleter{}
-	// While row 1's delete runs, another replica reclaims row 2 (its shared
-	// lease "expired"): simulated by swapping in a foreign lease token.
+	rec := &ChannelMediaReconciler{
+		Queries: db.New(pool),
+		Storage: deleter,
+		Logger:  slog.New(slog.NewTextHandler(&logs, &slog.HandlerOptions{Level: slog.LevelDebug})),
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	rec.RunOnce(ctx)
+
+	if logs.Len() != 0 {
+		t.Fatalf("cancelled sweep logged %q, want silence", logs.String())
+	}
+	if deleted := deleter.deletedKeys(); len(deleted) != 0 {
+		t.Fatalf("cancelled sweep deleted %v, want nothing", deleted)
+	}
+	if state, attempt, exists := f.rowState(t, key); !exists || state != "pending" || attempt != 0 {
+		t.Fatalf("row = (%q, attempt=%d, %v), want an untouched ('pending', 0)", state, attempt, exists)
+	}
+}
+
+// Rows are claimed one at a time, immediately before their own work: while
+// the first row's delete runs, the next row must still be untouched
+// ('pending', attempt 0). Claiming the whole batch up front made that row hold
+// a lease through work it was not part of — it could expire and be reclaimed
+// before its first DELETE was ever tried, so attempt/backoff counted attempts
+// that never happened.
+func TestChannelMediaReconciler_TailRowIsUnclaimedUntilItsTurn(t *testing.T) {
+	pool := newCancelFinalizePool(t)
+	f := seedReconcilerFixture(t, pool)
+	deleter := &fakeObjectDeleter{}
+	var tailState string
+	var tailAttempt int
 	deleter.onDelete = func(key string) {
 		if key != "ws/lark/first" {
 			return
 		}
-		if _, err := pool.Exec(context.Background(), `
-			UPDATE channel_media_pending_object
-			SET lease_token = $2, attempt = attempt + 1
-			WHERE storage_key = $1
-		`, "ws/lark/second", foreign); err != nil {
-			t.Errorf("simulate reclaim: %v", err)
-		}
+		tailState, tailAttempt, _ = f.rowState(t, "ws/lark/second")
 	}
 	rec := &ChannelMediaReconciler{Queries: db.New(pool), Storage: deleter}
 
-	// Ordered by next_attempt_at: "first" is older, processed first.
+	// Ordered by next_attempt_at: "first" is older, so it is claimed first.
 	f.seedLedgerRow(t, "ws/lark/first", "https://cdn.test/first", "pending", ChannelMediaReconcileSettleDelay+2*time.Minute)
 	f.seedLedgerRow(t, "ws/lark/second", "https://cdn.test/second", "pending", ChannelMediaReconcileSettleDelay+time.Minute)
 
 	rec.RunOnce(context.Background())
 
-	if deleted := deleter.deletedKeys(); len(deleted) != 1 || deleted[0] != "ws/lark/first" {
-		t.Fatalf("deleted keys = %v, want only the first row (second was reclaimed)", deleted)
+	if tailState != "pending" || tailAttempt != 0 {
+		t.Fatalf("tail row during the first delete = (%q, attempt=%d), want an unclaimed ('pending', 0)", tailState, tailAttempt)
 	}
-	state, attempt, exists := f.rowState(t, "ws/lark/second")
-	if !exists || state != "deleting" || attempt != 2 {
-		t.Fatalf("reclaimed row = (%q, attempt=%d, %v), want untouched under the new owner ('deleting', 2, true)", state, attempt, exists)
+	// Both rows are still settled by the same sweep, just in turn.
+	if deleted := deleter.deletedKeys(); len(deleted) != 2 {
+		t.Fatalf("deleted keys = %v, want both rows settled in one sweep", deleted)
 	}
-	var token pgtype.UUID
-	if err := pool.QueryRow(context.Background(), `
-		SELECT lease_token FROM channel_media_pending_object WHERE storage_key = $1
-	`, "ws/lark/second").Scan(&token); err != nil {
-		t.Fatalf("load lease: %v", err)
-	}
-	if token != foreign {
-		t.Fatalf("lease token = %v, want the new owner's %v", token, foreign)
+	for _, key := range []string{"ws/lark/first", "ws/lark/second"} {
+		state, attempt, exists := f.rowState(t, key)
+		if !exists || state != "tombstoned" || attempt != 1 {
+			t.Fatalf("row %s = (%q, attempt=%d, %v), want ('tombstoned', 1, true) — one claim, one delete", key, state, attempt, exists)
+		}
 	}
 }
 

--- a/server/internal/service/channel_media_reconciler_test.go
+++ b/server/internal/service/channel_media_reconciler_test.go
@@ -434,7 +434,9 @@ func TestChannelMediaReconciler_CancelledSweepIsQuiet(t *testing.T) {
 	rec := &ChannelMediaReconciler{
 		Queries: db.New(pool),
 		Storage: deleter,
-		Logger:  slog.New(slog.NewTextHandler(&logs, &slog.HandlerOptions{Level: slog.LevelDebug})),
+		// Warn and above only: shutdown must not page anyone. Debug/info
+		// tracing a future RunOnce may add is not what this test guards.
+		Logger: slog.New(slog.NewTextHandler(&logs, &slog.HandlerOptions{Level: slog.LevelWarn})),
 	}
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
@@ -442,13 +444,46 @@ func TestChannelMediaReconciler_CancelledSweepIsQuiet(t *testing.T) {
 	rec.RunOnce(ctx)
 
 	if logs.Len() != 0 {
-		t.Fatalf("cancelled sweep logged %q, want silence", logs.String())
+		t.Fatalf("cancelled sweep logged %q, want no warnings", logs.String())
 	}
 	if deleted := deleter.deletedKeys(); len(deleted) != 0 {
 		t.Fatalf("cancelled sweep deleted %v, want nothing", deleted)
 	}
 	if state, attempt, exists := f.rowState(t, key); !exists || state != "pending" || attempt != 0 {
 		t.Fatalf("row = (%q, attempt=%d, %v), want an untouched ('pending', 0)", state, attempt, exists)
+	}
+}
+
+// Cancellation that lands INSIDE a settle — the common case, since a sweep
+// spends its time in object-storage deletes — must be as quiet as one at the
+// claim boundary. The row keeps its lease and is reclaimed after expiry, so
+// there is nothing to record: writing the backoff would fail on the same
+// cancelled context and log twice per in-flight row on every shutdown.
+func TestChannelMediaReconciler_CancelledSettleIsQuiet(t *testing.T) {
+	pool := newCancelFinalizePool(t)
+	f := seedReconcilerFixture(t, pool)
+	key := "ws/lark/cancelled-mid-settle"
+	f.seedLedgerRow(t, key, "https://cdn.test/cancelled-mid-settle", "pending", ChannelMediaReconcileSettleDelay+time.Minute)
+	ctx, cancel := context.WithCancel(context.Background())
+	deleter := &fakeObjectDeleter{err: context.Canceled}
+	deleter.onDelete = func(string) { cancel() }
+	var logs bytes.Buffer
+	rec := &ChannelMediaReconciler{
+		Queries: db.New(pool),
+		Storage: deleter,
+		Logger:  slog.New(slog.NewTextHandler(&logs, &slog.HandlerOptions{Level: slog.LevelWarn})),
+	}
+	defer cancel()
+
+	rec.RunOnce(ctx)
+
+	if logs.Len() != 0 {
+		t.Fatalf("sweep cancelled during a delete logged %q, want no warnings", logs.String())
+	}
+	// The claim stands: the row waits for its lease to expire, exactly like a
+	// worker that crashed mid-delete.
+	if state, attempt, exists := f.rowState(t, key); !exists || state != "deleting" || attempt != 1 {
+		t.Fatalf("row = (%q, attempt=%d, %v), want a still-claimed ('deleting', 1)", state, attempt, exists)
 	}
 }
 

--- a/server/migrations/232_channel_media_pending_object_due_index.down.sql
+++ b/server/migrations/232_channel_media_pending_object_due_index.down.sql
@@ -1,0 +1,1 @@
+DROP INDEX CONCURRENTLY IF EXISTS idx_channel_media_pending_object_due;

--- a/server/migrations/232_channel_media_pending_object_due_index.up.sql
+++ b/server/migrations/232_channel_media_pending_object_due_index.up.sql
@@ -1,0 +1,9 @@
+-- The reconciler claims one row per statement, ordered by next_attempt_at
+-- across all three states. Migration 230's index leads with state, so it
+-- cannot serve that ordering: under backlog the planner falls back to a seq
+-- scan plus an external merge sort, and FOR UPDATE blocks the bounded top-N
+-- optimization, so every claim in a sweep pays the full sort. Ordering on
+-- next_attempt_at alone lets the claim walk the index and stop at the first
+-- due row. Same CONCURRENTLY-in-its-own-file convention as migration 230.
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_channel_media_pending_object_due
+    ON channel_media_pending_object (next_attempt_at);

--- a/server/pkg/db/generated/channel.sql.go
+++ b/server/pkg/db/generated/channel.sql.go
@@ -178,7 +178,7 @@ func (q *Queries) ClaimChannelMediaPendingObjectsForBind(ctx context.Context, ar
 	return items, nil
 }
 
-const claimChannelMediaPendingObjectsForReconcile = `-- name: ClaimChannelMediaPendingObjectsForReconcile :many
+const claimNextChannelMediaPendingObjectForReconcile = `-- name: ClaimNextChannelMediaPendingObjectForReconcile :one
 UPDATE channel_media_pending_object AS obj
 SET state = CASE WHEN obj.state = 'tombstoned' THEN 'tombstoned' ELSE 'deleting' END,
     lease_token = $1,
@@ -190,70 +190,57 @@ FROM (
       AND (
           (cand.state = 'pending' AND cand.created_at <= now() - $3::interval)
           OR (cand.state = 'deleting' AND (cand.lease_expires_at IS NULL OR cand.lease_expires_at <= now()))
-          -- Tombstones: the object was deleted, but a PUT the client abandoned
-          -- may still materialize it afterwards, so each due tombstone gets
-          -- another idempotent delete before the row is finally dropped.
           OR (cand.state = 'tombstoned' AND (cand.lease_expires_at IS NULL OR cand.lease_expires_at <= now()))
       )
     ORDER BY cand.next_attempt_at
-    LIMIT $4
+    LIMIT 1
     FOR UPDATE SKIP LOCKED
 ) AS due
 WHERE obj.storage_key = due.storage_key
 RETURNING obj.storage_key, obj.workspace_id, obj.chat_message_id, obj.storage_url, obj.installation_id, obj.state, obj.lease_token, obj.lease_expires_at, obj.attempt, obj.next_attempt_at, obj.last_error, obj.tombstone_pass, obj.created_at
 `
 
-type ClaimChannelMediaPendingObjectsForReconcileParams struct {
+type ClaimNextChannelMediaPendingObjectForReconcileParams struct {
 	LeaseToken  pgtype.UUID     `json:"lease_token"`
 	Lease       pgtype.Interval `json:"lease"`
 	SettleDelay pgtype.Interval `json:"settle_delay"`
-	BatchLimit  int32           `json:"batch_limit"`
 }
 
-// Short-transaction claim: flips due rows to 'deleting' under a fresh lease.
+// Short-transaction claim of ONE due row, taken immediately before that row is
+// settled. Claiming a whole batch up front made the claim a promise the sweep
+// might not keep: a tail row sat in 'deleting' with attempt already bumped
+// while earlier rows ran, and could expire and be reclaimed before its own
+// DELETE was ever tried, inflating attempt/backoff for work that never
+// happened. One row per claim means attempt counts attempts.
+//
 // Due means (a) 'pending' rows older than the settle delay — an operational
 // buffer only; correctness comes from the state flip, after which a bind can
 // never succeed on the key — or (b) 'deleting' rows whose lease expired (a
-// crashed or failed worker). FOR UPDATE SKIP LOCKED keeps replicas from
-// claiming the same rows; the object-storage DELETE happens outside any
-// transaction, gated by the lease token.
-func (q *Queries) ClaimChannelMediaPendingObjectsForReconcile(ctx context.Context, arg ClaimChannelMediaPendingObjectsForReconcileParams) ([]ChannelMediaPendingObject, error) {
-	rows, err := q.db.Query(ctx, claimChannelMediaPendingObjectsForReconcile,
-		arg.LeaseToken,
-		arg.Lease,
-		arg.SettleDelay,
-		arg.BatchLimit,
+// crashed or failed worker) — or (c) tombstones: the object was deleted, but a
+// PUT the client abandoned may still materialize it afterwards, so each due
+// tombstone gets another idempotent delete before the row is finally dropped.
+// FOR UPDATE SKIP LOCKED keeps replicas off each other's row; the
+// object-storage DELETE happens outside any transaction, gated by the lease
+// token. No row (ErrNoRows) means nothing is due — the sweep is done.
+func (q *Queries) ClaimNextChannelMediaPendingObjectForReconcile(ctx context.Context, arg ClaimNextChannelMediaPendingObjectForReconcileParams) (ChannelMediaPendingObject, error) {
+	row := q.db.QueryRow(ctx, claimNextChannelMediaPendingObjectForReconcile, arg.LeaseToken, arg.Lease, arg.SettleDelay)
+	var i ChannelMediaPendingObject
+	err := row.Scan(
+		&i.StorageKey,
+		&i.WorkspaceID,
+		&i.ChatMessageID,
+		&i.StorageUrl,
+		&i.InstallationID,
+		&i.State,
+		&i.LeaseToken,
+		&i.LeaseExpiresAt,
+		&i.Attempt,
+		&i.NextAttemptAt,
+		&i.LastError,
+		&i.TombstonePass,
+		&i.CreatedAt,
 	)
-	if err != nil {
-		return nil, err
-	}
-	defer rows.Close()
-	items := []ChannelMediaPendingObject{}
-	for rows.Next() {
-		var i ChannelMediaPendingObject
-		if err := rows.Scan(
-			&i.StorageKey,
-			&i.WorkspaceID,
-			&i.ChatMessageID,
-			&i.StorageUrl,
-			&i.InstallationID,
-			&i.State,
-			&i.LeaseToken,
-			&i.LeaseExpiresAt,
-			&i.Attempt,
-			&i.NextAttemptAt,
-			&i.LastError,
-			&i.TombstonePass,
-			&i.CreatedAt,
-		); err != nil {
-			return nil, err
-		}
-		items = append(items, i)
-	}
-	if err := rows.Err(); err != nil {
-		return nil, err
-	}
-	return items, nil
+	return i, err
 }
 
 const consumeChannelBindingToken = `-- name: ConsumeChannelBindingToken :one
@@ -1539,41 +1526,6 @@ type ReleaseChannelWSLeaseParams struct {
 func (q *Queries) ReleaseChannelWSLease(ctx context.Context, arg ReleaseChannelWSLeaseParams) error {
 	_, err := q.db.Exec(ctx, releaseChannelWSLease, arg.ID, arg.CurrentToken)
 	return err
-}
-
-const renewChannelMediaPendingObjectLease = `-- name: RenewChannelMediaPendingObjectLease :execrows
-UPDATE channel_media_pending_object
-SET lease_expires_at = now() + $1::interval
-WHERE storage_key = $2
-  AND workspace_id = $3
-  AND lease_token = $4
-`
-
-type RenewChannelMediaPendingObjectLeaseParams struct {
-	Lease       pgtype.Interval `json:"lease"`
-	StorageKey  string          `json:"storage_key"`
-	WorkspaceID pgtype.UUID     `json:"workspace_id"`
-	LeaseToken  pgtype.UUID     `json:"lease_token"`
-}
-
-// Per-row heartbeat: the batch shares one claim, so the lease must be
-// extended before EACH row's settle work — otherwise a few storage deletes
-// running at their full timeout could outlive the lease mid-batch and a
-// second replica would reclaim the tail, duplicating deletes and inflating
-// attempt/backoff. Zero rows affected means another worker already reclaimed
-// this row: the caller must skip it. workspace_id explicit per the tenancy
-// rule.
-func (q *Queries) RenewChannelMediaPendingObjectLease(ctx context.Context, arg RenewChannelMediaPendingObjectLeaseParams) (int64, error) {
-	result, err := q.db.Exec(ctx, renewChannelMediaPendingObjectLease,
-		arg.Lease,
-		arg.StorageKey,
-		arg.WorkspaceID,
-		arg.LeaseToken,
-	)
-	if err != nil {
-		return 0, err
-	}
-	return result.RowsAffected(), nil
 }
 
 const setChannelInstallationConfig = `-- name: SetChannelInstallationConfig :exec

--- a/server/pkg/db/queries/channel.sql
+++ b/server/pkg/db/queries/channel.sql
@@ -668,14 +668,23 @@ WHERE storage_key = ANY(@storage_keys::text[])
   AND state = 'pending'
 RETURNING storage_key;
 
--- name: ClaimChannelMediaPendingObjectsForReconcile :many
--- Short-transaction claim: flips due rows to 'deleting' under a fresh lease.
+-- name: ClaimNextChannelMediaPendingObjectForReconcile :one
+-- Short-transaction claim of ONE due row, taken immediately before that row is
+-- settled. Claiming a whole batch up front made the claim a promise the sweep
+-- might not keep: a tail row sat in 'deleting' with attempt already bumped
+-- while earlier rows ran, and could expire and be reclaimed before its own
+-- DELETE was ever tried, inflating attempt/backoff for work that never
+-- happened. One row per claim means attempt counts attempts.
+--
 -- Due means (a) 'pending' rows older than the settle delay — an operational
 -- buffer only; correctness comes from the state flip, after which a bind can
 -- never succeed on the key — or (b) 'deleting' rows whose lease expired (a
--- crashed or failed worker). FOR UPDATE SKIP LOCKED keeps replicas from
--- claiming the same rows; the object-storage DELETE happens outside any
--- transaction, gated by the lease token.
+-- crashed or failed worker) — or (c) tombstones: the object was deleted, but a
+-- PUT the client abandoned may still materialize it afterwards, so each due
+-- tombstone gets another idempotent delete before the row is finally dropped.
+-- FOR UPDATE SKIP LOCKED keeps replicas off each other's row; the
+-- object-storage DELETE happens outside any transaction, gated by the lease
+-- token. No row (ErrNoRows) means nothing is due — the sweep is done.
 UPDATE channel_media_pending_object AS obj
 SET state = CASE WHEN obj.state = 'tombstoned' THEN 'tombstoned' ELSE 'deleting' END,
     lease_token = @lease_token,
@@ -687,31 +696,14 @@ FROM (
       AND (
           (cand.state = 'pending' AND cand.created_at <= now() - @settle_delay::interval)
           OR (cand.state = 'deleting' AND (cand.lease_expires_at IS NULL OR cand.lease_expires_at <= now()))
-          -- Tombstones: the object was deleted, but a PUT the client abandoned
-          -- may still materialize it afterwards, so each due tombstone gets
-          -- another idempotent delete before the row is finally dropped.
           OR (cand.state = 'tombstoned' AND (cand.lease_expires_at IS NULL OR cand.lease_expires_at <= now()))
       )
     ORDER BY cand.next_attempt_at
-    LIMIT @batch_limit
+    LIMIT 1
     FOR UPDATE SKIP LOCKED
 ) AS due
 WHERE obj.storage_key = due.storage_key
 RETURNING obj.*;
-
--- name: RenewChannelMediaPendingObjectLease :execrows
--- Per-row heartbeat: the batch shares one claim, so the lease must be
--- extended before EACH row's settle work — otherwise a few storage deletes
--- running at their full timeout could outlive the lease mid-batch and a
--- second replica would reclaim the tail, duplicating deletes and inflating
--- attempt/backoff. Zero rows affected means another worker already reclaimed
--- this row: the caller must skip it. workspace_id explicit per the tenancy
--- rule.
-UPDATE channel_media_pending_object
-SET lease_expires_at = now() + @lease::interval
-WHERE storage_key = @storage_key
-  AND workspace_id = @workspace_id
-  AND lease_token = @lease_token;
 
 -- name: ReleaseChannelMediaPendingObject :exec
 -- Object-storage DELETE failed: keep the row in 'deleting' (bind must still


### PR DESCRIPTION
Follow-up to #5580, taking the non-blocking point from that review: the reconciler claimed a batch of rows under one lease and processed them serially, so a tail row could expire and be reclaimed before its own DELETE was ever tried, inflating `attempt`/backoff for work that never happened — and the backoff it produced then delayed the row's first real attempt.

**What changes**

- `ClaimChannelMediaPendingObjectsForReconcile` (`:many`, `LIMIT @batch_limit`) becomes `ClaimNextChannelMediaPendingObjectForReconcile` (`:one`, `LIMIT 1`). `RunOnce` loops claim → settle → claim, up to the same per-sweep limit of 50. A claim is now always taken immediately before the work it authorizes.
- The per-row lease heartbeat (`RenewChannelMediaPendingObjectLease`) is removed. It existed only because a single lease had to span a whole batch; with on-demand claiming the lease covers one row's settle (delete timeout 30s ≪ lease 2m), and every settle write is already lease-token guarded, so a row reclaimed after an expiry ignores the previous owner's writes rather than being corrupted by them.

**What does not change**

Due-ness (settle delay for `pending`, lease expiry for `deleting`, `next_attempt_at` for tombstones), `FOR UPDATE SKIP LOCKED`, the workspace predicate on every settle write, the reference check on every pass including tombstones, the tombstone re-delete schedule, the backoff curve, and the metrics. Deadlines are still computed by Postgres from `now()`.

**Cost**

N round-trips per sweep instead of one — at the 50-row cap that is 50 short transactions per minute, against a sweep that already does one object-storage DELETE per row.

**Test**

`TestChannelMediaReconciler_SkipsRowReclaimedMidBatch` is replaced by `TestChannelMediaReconciler_TailRowIsUnclaimedUntilItsTurn`, which pins the invariant the old test was working around: while the first row's DELETE runs, the next row is still `pending` with `attempt = 0`, and both rows are still settled by the same sweep with `attempt = 1` each. Run against the batch-claiming implementation it fails with `tail row during the first delete = ("deleting", attempt=1)`.

Validation: full server suite on a freshly migrated database, `-race` on `internal/service`, `go vet ./...`.
