### PR TITLE
fix(issues): MUL-5362 return to the source list after deleting an issue

### DIFF
--- a/apps/desktop/src/renderer/src/platform/navigation.test.tsx
+++ b/apps/desktop/src/renderer/src/platform/navigation.test.tsx
@@ -219,6 +219,44 @@ describe("back", () => {
   });
 });
 
+// Consumed by `useBackOrReplace` — a page whose subject was deleted steps back
+// only when this says there is somewhere to step back to.
+describe("canGoBack", () => {
+  it("is false on a tab sitting at the start of its history", () => {
+    const getAdapter = renderProvider();
+
+    expect(getActiveTab(useTabStore.getState())!.history.index).toBe(0);
+    expect(getAdapter().canGoBack!()).toBe(false);
+  });
+
+  it("is true once the tab has navigated in place", () => {
+    const getAdapter = renderProvider();
+
+    getAdapter().push("/acme/projects");
+
+    expect(getActiveTab(useTabStore.getState())!.history.index).toBe(1);
+    expect(getAdapter().canGoBack!()).toBe(true);
+  });
+
+  it("is false again after stepping back to the start", () => {
+    const getAdapter = renderProvider();
+    getAdapter().push("/acme/projects");
+
+    getAdapter().back!();
+
+    expect(getAdapter().canGoBack!()).toBe(false);
+  });
+
+  it("is false for a freshly opened tab, which starts its own history", () => {
+    const getAdapter = renderProvider();
+    getAdapter().push("/acme/projects");
+
+    getAdapter().openInNewTab!("/acme/agents", "Agents", { activate: true });
+
+    expect(getAdapter().canGoBack!()).toBe(false);
+  });
+});
+
 describe("routeContentLinkPath (links inside content — MUL-5208)", () => {
   it("opens a same-workspace path in a foreground tab of its own", () => {
     routeContentLinkPath("/acme/issues/MUL-1");

--- a/apps/desktop/src/renderer/src/platform/navigation.tsx
+++ b/apps/desktop/src/renderer/src/platform/navigation.tsx
@@ -195,6 +195,13 @@ export function DesktopNavigationProvider({
       back: () => {
         useTabStore.getState().goBack();
       },
+      // The active tab's virtual history, same source the shell's back button
+      // reads. A tab opened straight onto a destination sits at index 0 and
+      // has nothing behind it.
+      canGoBack: () => {
+        const active = getActiveTab(useTabStore.getState());
+        return (active?.history.index ?? 0) > 0;
+      },
       pathname: location.pathname,
       searchParams: new URLSearchParams(location.search),
       openInNewTab: (

--- a/apps/web/platform/in-app-history.test.ts
+++ b/apps/web/platform/in-app-history.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "vitest";
+import { createInAppHistoryTracker, probeNavigationApi } from "./in-app-history";
+
+describe("createInAppHistoryTracker", () => {
+  it("trusts the Navigation API when the browser exposes it", () => {
+    expect(createInAppHistoryTracker(() => true).canGoBack()).toBe(true);
+    // False even though nothing was pushed is the point: arriving from an
+    // external site leaves same-origin history empty.
+    expect(createInAppHistoryTracker(() => false).canGoBack()).toBe(false);
+  });
+
+  it("ignores its own push count once the Navigation API answers", () => {
+    const tracker = createInAppHistoryTracker(() => false);
+    tracker.recordPush();
+
+    expect(tracker.canGoBack()).toBe(false);
+  });
+
+  it("reports nothing to go back to before any in-app push", () => {
+    expect(createInAppHistoryTracker(() => undefined).canGoBack()).toBe(false);
+  });
+
+  it("reports history once the adapter has pushed in this document", () => {
+    const tracker = createInAppHistoryTracker(() => undefined);
+    tracker.recordPush();
+
+    expect(tracker.canGoBack()).toBe(true);
+  });
+});
+
+describe("probeNavigationApi", () => {
+  it("returns undefined when the browser has no Navigation API", () => {
+    // jsdom ships no `window.navigation`, which is the fallback path itself.
+    expect(probeNavigationApi()).toBeUndefined();
+  });
+
+  it("reads canGoBack when the Navigation API is present", () => {
+    const win = window as unknown as { navigation?: unknown };
+    win.navigation = { canGoBack: true };
+    try {
+      expect(probeNavigationApi()).toBe(true);
+    } finally {
+      delete win.navigation;
+    }
+  });
+
+  it("ignores a `navigation` global that is not the Navigation API", () => {
+    const win = window as unknown as { navigation?: unknown };
+    win.navigation = { somethingElse: true };
+    try {
+      expect(probeNavigationApi()).toBeUndefined();
+    } finally {
+      delete win.navigation;
+    }
+  });
+});

--- a/apps/web/platform/in-app-history.test.ts
+++ b/apps/web/platform/in-app-history.test.ts
@@ -1,107 +1,47 @@
-import { describe, expect, it } from "vitest";
-import { createInAppHistoryTracker, probeNavigationApi } from "./in-app-history";
+import { afterEach, describe, expect, it } from "vitest";
+import { canGoBackInApp } from "./in-app-history";
 
-describe("createInAppHistoryTracker", () => {
-  it("trusts the Navigation API when the browser exposes it", () => {
-    expect(createInAppHistoryTracker(() => true).canGoBack()).toBe(true);
-    // False even though nothing was pushed is the point: arriving from an
-    // external site leaves same-origin history empty.
-    expect(createInAppHistoryTracker(() => false).canGoBack()).toBe(false);
-  });
+const win = window as unknown as { navigation?: unknown };
 
-  it("ignores its own depth once the Navigation API answers", () => {
-    const tracker = createInAppHistoryTracker(() => false);
-    tracker.recordPush();
+function withNavigationApi(navigation: unknown) {
+  win.navigation = navigation;
+}
 
-    expect(tracker.canGoBack()).toBe(false);
-  });
-
-  describe("without the Navigation API", () => {
-    const makeTracker = () => createInAppHistoryTracker(() => undefined);
-
-    it("reports nothing to go back to before any in-app push", () => {
-      expect(makeTracker().canGoBack()).toBe(false);
-    });
-
-    it("reports history once the adapter has pushed in this document", () => {
-      const tracker = makeTracker();
-      tracker.recordPush();
-
-      expect(tracker.canGoBack()).toBe(true);
-    });
-
-    // Regression: the depth used to only ever grow, so this sequence left the
-    // user on the document's first entry still claiming a page behind it —
-    // and `back()` would then step off Multica entirely.
-    it("reports no history after a push is undone by a browser Back", () => {
-      const tracker = makeTracker();
-      tracker.recordPush();
-      tracker.recordTraversal();
-
-      expect(tracker.canGoBack()).toBe(false);
-    });
-
-    it("stays negative-proof across more traversals than pushes", () => {
-      const tracker = makeTracker();
-      tracker.recordPush();
-      tracker.recordTraversal();
-      tracker.recordTraversal();
-      tracker.recordTraversal();
-
-      expect(tracker.canGoBack()).toBe(false);
-
-      // One push must be enough to make it answer again — a clamped-out
-      // counter that had gone deeply negative would swallow it.
-      tracker.recordPush();
-      expect(tracker.canGoBack()).toBe(true);
-    });
-
-    it("keeps reporting history while pushes outnumber traversals", () => {
-      const tracker = makeTracker();
-      tracker.recordPush();
-      tracker.recordPush();
-      tracker.recordTraversal();
-
-      expect(tracker.canGoBack()).toBe(true);
-    });
-
-    // Forward re-enters an entry that does have a page behind it, but we
-    // cannot tell forward from back without the Navigation API. Reporting
-    // "no history" here costs a legitimate back() and is the safe direction.
-    it("is conservative after a browser Forward", () => {
-      const tracker = makeTracker();
-      tracker.recordPush();
-      tracker.recordTraversal(); // back
-      tracker.recordTraversal(); // forward
-
-      expect(tracker.canGoBack()).toBe(false);
-    });
-  });
+afterEach(() => {
+  delete win.navigation;
 });
 
-describe("probeNavigationApi", () => {
-  it("returns undefined when the browser has no Navigation API", () => {
-    // jsdom ships no `window.navigation`, which is the fallback path itself.
-    expect(probeNavigationApi()).toBeUndefined();
+describe("canGoBackInApp", () => {
+  it("reports the Navigation API's answer when the browser has one", () => {
+    withNavigationApi({ canGoBack: true });
+
+    expect(canGoBackInApp()).toBe(true);
   });
 
-  it("reads canGoBack when the Navigation API is present", () => {
-    const win = window as unknown as { navigation?: unknown };
-    win.navigation = { canGoBack: true };
-    try {
-      expect(probeNavigationApi()).toBe(true);
-    } finally {
-      delete win.navigation;
-    }
+  // Not "nothing was pushed yet" — arriving from an external site leaves the
+  // same-origin run empty, which is the whole reason we ask the browser.
+  it("reports false when the Navigation API says there is no same-origin entry", () => {
+    withNavigationApi({ canGoBack: false });
+
+    expect(canGoBackInApp()).toBe(false);
   });
 
-  it("ignores a `navigation` global that is not the Navigation API", () => {
-    const win = window as unknown as { navigation?: unknown };
-    win.navigation = { somethingElse: true };
-    try {
-      expect(probeNavigationApi()).toBeUndefined();
-    } finally {
-      delete win.navigation;
-    }
+  // jsdom ships no `window.navigation`. Callers then take their fallback path,
+  // which is what these browsers did before any of this existed — deliberately
+  // no guessing, because a wrong `true` walks the user out of the app.
+  it("reports false when the browser has no Navigation API", () => {
+    expect(canGoBackInApp()).toBe(false);
+  });
+
+  it("reports false for a `navigation` global that is not the Navigation API", () => {
+    withNavigationApi({ somethingElse: true });
+
+    expect(canGoBackInApp()).toBe(false);
+  });
+
+  it("reports false for a non-boolean canGoBack", () => {
+    withNavigationApi({ canGoBack: "yes" });
+
+    expect(canGoBackInApp()).toBe(false);
   });
 });

--- a/apps/web/platform/in-app-history.test.ts
+++ b/apps/web/platform/in-app-history.test.ts
@@ -9,22 +9,73 @@ describe("createInAppHistoryTracker", () => {
     expect(createInAppHistoryTracker(() => false).canGoBack()).toBe(false);
   });
 
-  it("ignores its own push count once the Navigation API answers", () => {
+  it("ignores its own depth once the Navigation API answers", () => {
     const tracker = createInAppHistoryTracker(() => false);
     tracker.recordPush();
 
     expect(tracker.canGoBack()).toBe(false);
   });
 
-  it("reports nothing to go back to before any in-app push", () => {
-    expect(createInAppHistoryTracker(() => undefined).canGoBack()).toBe(false);
-  });
+  describe("without the Navigation API", () => {
+    const makeTracker = () => createInAppHistoryTracker(() => undefined);
 
-  it("reports history once the adapter has pushed in this document", () => {
-    const tracker = createInAppHistoryTracker(() => undefined);
-    tracker.recordPush();
+    it("reports nothing to go back to before any in-app push", () => {
+      expect(makeTracker().canGoBack()).toBe(false);
+    });
 
-    expect(tracker.canGoBack()).toBe(true);
+    it("reports history once the adapter has pushed in this document", () => {
+      const tracker = makeTracker();
+      tracker.recordPush();
+
+      expect(tracker.canGoBack()).toBe(true);
+    });
+
+    // Regression: the depth used to only ever grow, so this sequence left the
+    // user on the document's first entry still claiming a page behind it —
+    // and `back()` would then step off Multica entirely.
+    it("reports no history after a push is undone by a browser Back", () => {
+      const tracker = makeTracker();
+      tracker.recordPush();
+      tracker.recordTraversal();
+
+      expect(tracker.canGoBack()).toBe(false);
+    });
+
+    it("stays negative-proof across more traversals than pushes", () => {
+      const tracker = makeTracker();
+      tracker.recordPush();
+      tracker.recordTraversal();
+      tracker.recordTraversal();
+      tracker.recordTraversal();
+
+      expect(tracker.canGoBack()).toBe(false);
+
+      // One push must be enough to make it answer again — a clamped-out
+      // counter that had gone deeply negative would swallow it.
+      tracker.recordPush();
+      expect(tracker.canGoBack()).toBe(true);
+    });
+
+    it("keeps reporting history while pushes outnumber traversals", () => {
+      const tracker = makeTracker();
+      tracker.recordPush();
+      tracker.recordPush();
+      tracker.recordTraversal();
+
+      expect(tracker.canGoBack()).toBe(true);
+    });
+
+    // Forward re-enters an entry that does have a page behind it, but we
+    // cannot tell forward from back without the Navigation API. Reporting
+    // "no history" here costs a legitimate back() and is the safe direction.
+    it("is conservative after a browser Forward", () => {
+      const tracker = makeTracker();
+      tracker.recordPush();
+      tracker.recordTraversal(); // back
+      tracker.recordTraversal(); // forward
+
+      expect(tracker.canGoBack()).toBe(false);
+    });
   });
 });
 

--- a/apps/web/platform/in-app-history.ts
+++ b/apps/web/platform/in-app-history.ts
@@ -3,59 +3,37 @@
  *
  * Callers that want to step back (deleting an issue returns the user to the
  * list they opened it from) must not step back off the app when the current
- * page was opened cold — a shared link, a pasted URL, a new tab. The browser
- * knows the answer; `history.length` does not, because it counts entries from
- * other origins too.
+ * page was opened cold — a shared link, a pasted URL, a new tab.
  *
- * The Navigation API answers exactly the right question: `entries()` spans
- * only the contiguous same-origin run around the current entry, so arriving
- * from an external site reports `canGoBack === false` even though the browser
- * technically has somewhere to go.
+ * Only the browser can answer this, and exactly one API does: the Navigation
+ * API's `entries()` spans just the contiguous same-origin run around the
+ * current entry, so arriving from an external site reports `canGoBack` false
+ * even though the browser technically has somewhere to go. `history.length`
+ * is no substitute — it counts other origins' entries too.
  *
- * Where it is unavailable we track our own depth: how many in-app pushes are
- * still "below" the current entry. A push adds one; any history traversal
- * (browser Back/Forward, or our own `back()`) may have moved us off that
- * entry, so it takes one away. Since reaching the document's first entry
- * requires traversing back at least as many times as we pushed, a positive
- * depth can never be claimed while sitting on it — the failure direction is
- * always "report no history and use the fallback", never "step off the app".
- * Going forward again is the cost: the depth stays spent, so we fall back
- * where a step back would in fact have been fine.
+ * Nothing else here is a guess. Counting the adapter's own `router.push`
+ * calls looks like a workable fallback and is not: a push is a request, not a
+ * committed history entry. Next drops it to `replaceState` when the canonical
+ * URL is unchanged (`app-router.js`, the `pendingPush && href !== canonicalUrl`
+ * branch), and pushes can also be superseded or abandoned mid-transition. Any
+ * count derived from calls can therefore claim history that does not exist,
+ * and a wrong `true` walks the user out of Multica — the precise failure this
+ * exists to prevent. So where the browser cannot answer we report `false`,
+ * and callers take their fallback path.
  */
 
 /** Minimal shape of the Navigation API — not in TypeScript's DOM lib yet. */
 type NavigationApi = { canGoBack: boolean };
 
-/** `undefined` when the browser can't tell us, so callers can fall back. */
-export function probeNavigationApi(): boolean | undefined {
-  if (typeof window === "undefined") return undefined;
+/**
+ * Whether a step back stays inside the app. `false` whenever the browser has
+ * no Navigation API: the caller then navigates to its fallback, which is the
+ * behaviour those browsers had before any of this existed.
+ */
+export function canGoBackInApp(): boolean {
+  if (typeof window === "undefined") return false;
   const navigation = (window as { navigation?: unknown }).navigation as
     | NavigationApi
     | undefined;
-  return typeof navigation?.canGoBack === "boolean"
-    ? navigation.canGoBack
-    : undefined;
-}
-
-export function createInAppHistoryTracker(
-  probe: () => boolean | undefined = probeNavigationApi,
-) {
-  let depth = 0;
-  return {
-    /** An in-app push: the entry it creates has this page behind it. */
-    recordPush(): void {
-      depth += 1;
-    },
-    /**
-     * A history traversal — `popstate`. We can't tell forward from back
-     * without the Navigation API, so assume the direction that can only cost
-     * us a `back()` we were entitled to, never one we weren't.
-     */
-    recordTraversal(): void {
-      depth = Math.max(0, depth - 1);
-    },
-    canGoBack(): boolean {
-      return probe() ?? depth > 0;
-    },
-  };
+  return navigation?.canGoBack === true;
 }

--- a/apps/web/platform/in-app-history.ts
+++ b/apps/web/platform/in-app-history.ts
@@ -1,0 +1,45 @@
+/**
+ * "Is there a Multica page behind this one?" for the web navigation adapter.
+ *
+ * Callers that want to step back (deleting an issue returns the user to the
+ * list they opened it from) must not step back off the app when the current
+ * page was opened cold — a shared link, a pasted URL, a new tab. The browser
+ * knows the answer; `history.length` does not, because it counts entries from
+ * other origins too.
+ *
+ * The Navigation API answers exactly the right question: `entries()` spans
+ * only the contiguous same-origin run around the current entry, so arriving
+ * from an external site reports `canGoBack === false` even though the browser
+ * technically has somewhere to go. Where it is unavailable we fall back to
+ * counting the pushes this adapter performed in this document, which is zero
+ * for every cold-open case.
+ */
+
+/** Minimal shape of the Navigation API — not in TypeScript's DOM lib yet. */
+type NavigationApi = { canGoBack: boolean };
+
+/** `undefined` when the browser can't tell us, so callers can fall back. */
+export function probeNavigationApi(): boolean | undefined {
+  if (typeof window === "undefined") return undefined;
+  const navigation = (window as { navigation?: unknown }).navigation as
+    | NavigationApi
+    | undefined;
+  return typeof navigation?.canGoBack === "boolean"
+    ? navigation.canGoBack
+    : undefined;
+}
+
+export function createInAppHistoryTracker(
+  probe: () => boolean | undefined = probeNavigationApi,
+) {
+  let pushes = 0;
+  return {
+    /** Call for every in-app push; a push is what creates something to go back to. */
+    recordPush(): void {
+      pushes += 1;
+    },
+    canGoBack(): boolean {
+      return probe() ?? pushes > 0;
+    },
+  };
+}

--- a/apps/web/platform/in-app-history.ts
+++ b/apps/web/platform/in-app-history.ts
@@ -10,9 +10,17 @@
  * The Navigation API answers exactly the right question: `entries()` spans
  * only the contiguous same-origin run around the current entry, so arriving
  * from an external site reports `canGoBack === false` even though the browser
- * technically has somewhere to go. Where it is unavailable we fall back to
- * counting the pushes this adapter performed in this document, which is zero
- * for every cold-open case.
+ * technically has somewhere to go.
+ *
+ * Where it is unavailable we track our own depth: how many in-app pushes are
+ * still "below" the current entry. A push adds one; any history traversal
+ * (browser Back/Forward, or our own `back()`) may have moved us off that
+ * entry, so it takes one away. Since reaching the document's first entry
+ * requires traversing back at least as many times as we pushed, a positive
+ * depth can never be claimed while sitting on it — the failure direction is
+ * always "report no history and use the fallback", never "step off the app".
+ * Going forward again is the cost: the depth stays spent, so we fall back
+ * where a step back would in fact have been fine.
  */
 
 /** Minimal shape of the Navigation API — not in TypeScript's DOM lib yet. */
@@ -32,14 +40,22 @@ export function probeNavigationApi(): boolean | undefined {
 export function createInAppHistoryTracker(
   probe: () => boolean | undefined = probeNavigationApi,
 ) {
-  let pushes = 0;
+  let depth = 0;
   return {
-    /** Call for every in-app push; a push is what creates something to go back to. */
+    /** An in-app push: the entry it creates has this page behind it. */
     recordPush(): void {
-      pushes += 1;
+      depth += 1;
+    },
+    /**
+     * A history traversal — `popstate`. We can't tell forward from back
+     * without the Navigation API, so assume the direction that can only cost
+     * us a `back()` we were entitled to, never one we weren't.
+     */
+    recordTraversal(): void {
+      depth = Math.max(0, depth - 1);
     },
     canGoBack(): boolean {
-      return probe() ?? pushes > 0;
+      return probe() ?? depth > 0;
     },
   };
 }

--- a/apps/web/platform/navigation.test.tsx
+++ b/apps/web/platform/navigation.test.tsx
@@ -6,8 +6,8 @@
  * deployment's own origin. Desktop answers it by opening a tab; the web must
  * answer it with a router push, or those links silently do nothing.
  */
-import { describe, expect, it, vi, beforeEach } from "vitest";
-import { act, render } from "@testing-library/react";
+import { describe, expect, it, vi, afterEach, beforeEach } from "vitest";
+import { render } from "@testing-library/react";
 
 const router = vi.hoisted(() => ({
   push: vi.fn(),
@@ -29,10 +29,6 @@ function navigate(path: string) {
   window.dispatchEvent(
     new CustomEvent("multica:navigate", { detail: { path } }),
   );
-}
-
-function popstate() {
-  window.dispatchEvent(new PopStateEvent("popstate"));
 }
 
 function renderAdapter(): () => NavigationAdapter {
@@ -84,59 +80,46 @@ describe("WebNavigationProvider internal link bridge", () => {
 
 /**
  * `canGoBack` decides whether a page whose subject was just deleted steps back
- * or replaces with a fallback. Getting it wrong in the optimistic direction
- * walks the user out of Multica, so the wiring — not just the tracker — needs
- * covering. jsdom has no Navigation API, which is exactly the fallback path.
+ * or replaces with a fallback. A wrong `true` walks the user out of Multica,
+ * so the adapter must expose the browser's own answer and nothing derived.
  */
-describe("WebNavigationProvider in-app history", () => {
-  // The tracker is document-scoped, so normalize it instead of assuming a
-  // fresh module: traversals clamp at zero, so draining always lands on "no
-  // in-app history" no matter what earlier tests pushed.
-  function drainToColdOpen() {
-    for (let i = 0; i < 5; i += 1) popstate();
-  }
+describe("WebNavigationProvider canGoBack", () => {
+  const win = window as unknown as { navigation?: unknown };
 
-  it("reports no history for a cold open", () => {
+  afterEach(() => {
+    delete win.navigation;
+  });
+
+  it("passes through the Navigation API's answer", () => {
+    win.navigation = { canGoBack: true };
+
+    expect(renderAdapter()().canGoBack!()).toBe(true);
+  });
+
+  it("reads the answer live rather than freezing it at render", () => {
+    win.navigation = { canGoBack: true };
     const adapter = renderAdapter();
-    drainToColdOpen();
+
+    win.navigation = { canGoBack: false };
 
     expect(adapter().canGoBack!()).toBe(false);
   });
 
-  it("reports history once the user has navigated in-app", () => {
+  // Regression (PR review, twice): a count of `push` calls stood in for real
+  // history here. It could not — Next drops a push to `replaceState` when the
+  // canonical URL is unchanged, so a push that committed no entry still made
+  // this claim `true`. Calling push must not move this answer at all.
+  it("is unmoved by a push that committed no history entry", () => {
+    win.navigation = { canGoBack: false };
     const adapter = renderAdapter();
-    drainToColdOpen();
 
-    act(() => adapter().push("/acme/issues/MUL-1"));
+    adapter().push("/acme/issues");
 
-    expect(adapter().canGoBack!()).toBe(true);
-  });
-
-  // Regression (PR review): a push followed by the browser's own Back button
-  // left the user on the entry the document opened at while `canGoBack` still
-  // said true — `back()` from there leaves the app.
-  it("reports no history after a browser Back undoes the push", () => {
-    const adapter = renderAdapter();
-    drainToColdOpen();
-
-    act(() => adapter().push("/acme/issues/MUL-1"));
-    popstate();
-
+    expect(router.push).toHaveBeenCalledWith("/acme/issues");
     expect(adapter().canGoBack!()).toBe(false);
   });
 
-  it("stops tracking traversals once unmounted", () => {
-    const adapter = renderAdapter();
-    drainToColdOpen();
-    act(() => adapter().push("/acme/issues/MUL-1"));
-
-    const { unmount } = render(
-      <WebNavigationProvider>{null}</WebNavigationProvider>,
-    );
-    unmount();
-    // The remaining mounted provider still listens, so this must still count.
-    popstate();
-
-    expect(adapter().canGoBack!()).toBe(false);
+  it("reports false where the browser cannot answer, so callers use the fallback", () => {
+    expect(renderAdapter()().canGoBack!()).toBe(false);
   });
 });

--- a/apps/web/platform/navigation.test.tsx
+++ b/apps/web/platform/navigation.test.tsx
@@ -7,7 +7,7 @@
  * answer it with a router push, or those links silently do nothing.
  */
 import { describe, expect, it, vi, beforeEach } from "vitest";
-import { render } from "@testing-library/react";
+import { act, render } from "@testing-library/react";
 
 const router = vi.hoisted(() => ({
   push: vi.fn(),
@@ -23,11 +23,30 @@ vi.mock("next/navigation", () => ({
 }));
 
 import { WebNavigationProvider } from "./navigation";
+import { useNavigation, type NavigationAdapter } from "@multica/views/navigation";
 
 function navigate(path: string) {
   window.dispatchEvent(
     new CustomEvent("multica:navigate", { detail: { path } }),
   );
+}
+
+function popstate() {
+  window.dispatchEvent(new PopStateEvent("popstate"));
+}
+
+function renderAdapter(): () => NavigationAdapter {
+  let adapter: NavigationAdapter | null = null;
+  function Probe() {
+    adapter = useNavigation();
+    return null;
+  }
+  render(
+    <WebNavigationProvider>
+      <Probe />
+    </WebNavigationProvider>,
+  );
+  return () => adapter!;
 }
 
 beforeEach(() => {
@@ -60,5 +79,64 @@ describe("WebNavigationProvider internal link bridge", () => {
     navigate("/acme/issues/MUL-1");
 
     expect(router.push).not.toHaveBeenCalled();
+  });
+});
+
+/**
+ * `canGoBack` decides whether a page whose subject was just deleted steps back
+ * or replaces with a fallback. Getting it wrong in the optimistic direction
+ * walks the user out of Multica, so the wiring — not just the tracker — needs
+ * covering. jsdom has no Navigation API, which is exactly the fallback path.
+ */
+describe("WebNavigationProvider in-app history", () => {
+  // The tracker is document-scoped, so normalize it instead of assuming a
+  // fresh module: traversals clamp at zero, so draining always lands on "no
+  // in-app history" no matter what earlier tests pushed.
+  function drainToColdOpen() {
+    for (let i = 0; i < 5; i += 1) popstate();
+  }
+
+  it("reports no history for a cold open", () => {
+    const adapter = renderAdapter();
+    drainToColdOpen();
+
+    expect(adapter().canGoBack!()).toBe(false);
+  });
+
+  it("reports history once the user has navigated in-app", () => {
+    const adapter = renderAdapter();
+    drainToColdOpen();
+
+    act(() => adapter().push("/acme/issues/MUL-1"));
+
+    expect(adapter().canGoBack!()).toBe(true);
+  });
+
+  // Regression (PR review): a push followed by the browser's own Back button
+  // left the user on the entry the document opened at while `canGoBack` still
+  // said true — `back()` from there leaves the app.
+  it("reports no history after a browser Back undoes the push", () => {
+    const adapter = renderAdapter();
+    drainToColdOpen();
+
+    act(() => adapter().push("/acme/issues/MUL-1"));
+    popstate();
+
+    expect(adapter().canGoBack!()).toBe(false);
+  });
+
+  it("stops tracking traversals once unmounted", () => {
+    const adapter = renderAdapter();
+    drainToColdOpen();
+    act(() => adapter().push("/acme/issues/MUL-1"));
+
+    const { unmount } = render(
+      <WebNavigationProvider>{null}</WebNavigationProvider>,
+    );
+    unmount();
+    // The remaining mounted provider still listens, so this must still count.
+    popstate();
+
+    expect(adapter().canGoBack!()).toBe(false);
   });
 });

--- a/apps/web/platform/navigation.tsx
+++ b/apps/web/platform/navigation.tsx
@@ -1,11 +1,16 @@
 "use client";
 
-import { Suspense, useEffect } from "react";
+import { Suspense, useCallback, useEffect } from "react";
 import { useRouter, usePathname, useSearchParams } from "next/navigation";
 import {
   NavigationProvider,
   type NavigationAdapter,
 } from "@multica/views/navigation";
+import { createInAppHistoryTracker } from "./in-app-history";
+
+// Document-scoped, like the browser history it shadows: a remount must not
+// convince us there is somewhere to go back to.
+const inAppHistory = createInAppHistoryTracker();
 
 /**
  * Web half of the `multica:navigate` bridge — the event shared content
@@ -14,16 +19,16 @@ import {
  * equivalent is a router push in place. Without this the event has no listener
  * and such links do nothing at all.
  */
-function useInternalLinkHandler(router: ReturnType<typeof useRouter>) {
+function useInternalLinkHandler(push: (path: string) => void) {
   useEffect(() => {
     const handler = (e: Event) => {
       const path = (e as CustomEvent<{ path?: string }>).detail?.path;
       if (!path) return;
-      router.push(path);
+      push(path);
     };
     window.addEventListener("multica:navigate", handler);
     return () => window.removeEventListener("multica:navigate", handler);
-  }, [router]);
+  }, [push]);
 }
 
 function NavigationProviderInner({
@@ -34,12 +39,20 @@ function NavigationProviderInner({
   const router = useRouter();
   const pathname = usePathname();
   const searchParams = useSearchParams();
-  useInternalLinkHandler(router);
+  const push = useCallback(
+    (path: string) => {
+      inAppHistory.recordPush();
+      router.push(path);
+    },
+    [router],
+  );
+  useInternalLinkHandler(push);
 
   const adapter: NavigationAdapter = {
-    push: router.push,
+    push,
     replace: router.replace,
     back: router.back,
+    canGoBack: inAppHistory.canGoBack,
     pathname,
     searchParams: new URLSearchParams(searchParams.toString()),
     getShareableUrl: (path: string) =>

--- a/apps/web/platform/navigation.tsx
+++ b/apps/web/platform/navigation.tsx
@@ -1,16 +1,12 @@
 "use client";
 
-import { Suspense, useCallback, useEffect } from "react";
+import { Suspense, useEffect } from "react";
 import { useRouter, usePathname, useSearchParams } from "next/navigation";
 import {
   NavigationProvider,
   type NavigationAdapter,
 } from "@multica/views/navigation";
-import { createInAppHistoryTracker } from "./in-app-history";
-
-// Document-scoped, like the browser history it shadows: a remount must not
-// convince us there is somewhere to go back to.
-const inAppHistory = createInAppHistoryTracker();
+import { canGoBackInApp } from "./in-app-history";
 
 /**
  * Web half of the `multica:navigate` bridge — the event shared content
@@ -19,30 +15,16 @@ const inAppHistory = createInAppHistoryTracker();
  * equivalent is a router push in place. Without this the event has no listener
  * and such links do nothing at all.
  */
-function useInternalLinkHandler(push: (path: string) => void) {
+function useInternalLinkHandler(router: ReturnType<typeof useRouter>) {
   useEffect(() => {
     const handler = (e: Event) => {
       const path = (e as CustomEvent<{ path?: string }>).detail?.path;
       if (!path) return;
-      push(path);
+      router.push(path);
     };
     window.addEventListener("multica:navigate", handler);
     return () => window.removeEventListener("multica:navigate", handler);
-  }, [push]);
-}
-
-/**
- * Keep the in-app depth honest about history traversals — the browser's own
- * Back/Forward buttons and `router.back()` both land here. Without it a push
- * followed by a browser Back would still look like "there is a page behind
- * us" while sitting on the entry the document opened at.
- */
-function useHistoryTraversalTracking() {
-  useEffect(() => {
-    const onPopState = () => inAppHistory.recordTraversal();
-    window.addEventListener("popstate", onPopState);
-    return () => window.removeEventListener("popstate", onPopState);
-  }, []);
+  }, [router]);
 }
 
 function NavigationProviderInner({
@@ -53,21 +35,13 @@ function NavigationProviderInner({
   const router = useRouter();
   const pathname = usePathname();
   const searchParams = useSearchParams();
-  const push = useCallback(
-    (path: string) => {
-      inAppHistory.recordPush();
-      router.push(path);
-    },
-    [router],
-  );
-  useInternalLinkHandler(push);
-  useHistoryTraversalTracking();
+  useInternalLinkHandler(router);
 
   const adapter: NavigationAdapter = {
-    push,
+    push: router.push,
     replace: router.replace,
     back: router.back,
-    canGoBack: inAppHistory.canGoBack,
+    canGoBack: canGoBackInApp,
     pathname,
     searchParams: new URLSearchParams(searchParams.toString()),
     getShareableUrl: (path: string) =>

--- a/apps/web/platform/navigation.tsx
+++ b/apps/web/platform/navigation.tsx
@@ -31,6 +31,20 @@ function useInternalLinkHandler(push: (path: string) => void) {
   }, [push]);
 }
 
+/**
+ * Keep the in-app depth honest about history traversals — the browser's own
+ * Back/Forward buttons and `router.back()` both land here. Without it a push
+ * followed by a browser Back would still look like "there is a page behind
+ * us" while sitting on the entry the document opened at.
+ */
+function useHistoryTraversalTracking() {
+  useEffect(() => {
+    const onPopState = () => inAppHistory.recordTraversal();
+    window.addEventListener("popstate", onPopState);
+    return () => window.removeEventListener("popstate", onPopState);
+  }, []);
+}
+
 function NavigationProviderInner({
   children,
 }: {
@@ -47,6 +61,7 @@ function NavigationProviderInner({
     [router],
   );
   useInternalLinkHandler(push);
+  useHistoryTraversalTracking();
 
   const adapter: NavigationAdapter = {
     push,

--- a/packages/views/issues/actions/__tests__/issue-actions-menu.test.tsx
+++ b/packages/views/issues/actions/__tests__/issue-actions-menu.test.tsx
@@ -238,7 +238,7 @@ describe("IssueActionsDropdown", () => {
         <IssueActionsDropdown
           issue={mockIssue}
           trigger={<button data-testid="trigger">Menu</button>}
-          onDeletedNavigateTo="/test/issues"
+          onDeletedFallbackPath="/test/issues"
         />,
       ),
     );
@@ -250,7 +250,7 @@ describe("IssueActionsDropdown", () => {
     expect(mockOpenModal).toHaveBeenCalledWith("issue-delete-confirm", {
       issueId: "issue-1",
       identifier: "TES-1",
-      onDeletedNavigateTo: "/test/issues",
+      onDeletedFallbackPath: "/test/issues",
     });
   });
 });

--- a/packages/views/issues/actions/__tests__/use-issue-actions.test.tsx
+++ b/packages/views/issues/actions/__tests__/use-issue-actions.test.tsx
@@ -226,12 +226,12 @@ describe("useIssueActions", () => {
     });
 
     act(() => {
-      result.current.openDeleteConfirm({ onDeletedNavigateTo: "/test/issues" });
+      result.current.openDeleteConfirm({ onDeletedFallbackPath: "/test/issues" });
     });
     expect(mockOpenModal).toHaveBeenLastCalledWith("issue-delete-confirm", {
       issueId: "issue-1",
       identifier: "TES-1",
-      onDeletedNavigateTo: "/test/issues",
+      onDeletedFallbackPath: "/test/issues",
     });
   });
 

--- a/packages/views/issues/actions/issue-actions-dropdown.tsx
+++ b/packages/views/issues/actions/issue-actions-dropdown.tsx
@@ -19,15 +19,16 @@ interface IssueActionsDropdownProps {
   /** A single React element cloned by Base UI as the trigger (via `render` prop). */
   trigger: ReactElement;
   align?: "start" | "end" | "center";
-  /** If set, navigate here after the issue is deleted. */
-  onDeletedNavigateTo?: string;
+  /** If set, leave the page after the issue is deleted — back to wherever the
+   *  user came from, or to this path when there is no in-app history. */
+  onDeletedFallbackPath?: string;
 }
 
 export function IssueActionsDropdown({
   issue,
   trigger,
   align = "end",
-  onDeletedNavigateTo,
+  onDeletedFallbackPath,
 }: IssueActionsDropdownProps) {
   const actions = useIssueActions(issue);
   const [assigneeOpen, setAssigneeOpen] = useState(false);
@@ -46,7 +47,7 @@ export function IssueActionsDropdown({
             actions={actions}
             primitives={dropdownPrimitives}
             onOpenAssignee={() => setAssigneeOpen(true)}
-            onDeletedNavigateTo={onDeletedNavigateTo}
+            onDeletedFallbackPath={onDeletedFallbackPath}
           />
         </DropdownMenuContent>
       </DropdownMenu>

--- a/packages/views/issues/actions/issue-actions-menu-items.tsx
+++ b/packages/views/issues/actions/issue-actions-menu-items.tsx
@@ -86,8 +86,11 @@ interface IssueActionsMenuItemsProps {
    *  Decoupled this way so the same item can drive both the dropdown
    *  (3-dot button) and the context menu (right-click) wrappers. */
   onOpenAssignee: () => void;
-  /** If set, navigate here after the issue is deleted (used by the detail page). */
-  onDeletedNavigateTo?: string;
+  /** If set, leave the page after the issue is deleted (used by the detail
+   *  page, which renders the issue being deleted). The delete modal goes back
+   *  to the list the user came from and only falls back to this path when
+   *  there is no in-app history. List surfaces leave it unset and stay put. */
+  onDeletedFallbackPath?: string;
 }
 
 export function IssueActionsMenuItems({
@@ -95,7 +98,7 @@ export function IssueActionsMenuItems({
   actions,
   primitives: P,
   onOpenAssignee,
-  onDeletedNavigateTo,
+  onDeletedFallbackPath,
 }: IssueActionsMenuItemsProps) {
   const { t } = useT("issues");
   const {
@@ -305,7 +308,7 @@ export function IssueActionsMenuItems({
 
       <P.Item
         variant="destructive"
-        onClick={() => openDeleteConfirm({ onDeletedNavigateTo })}
+        onClick={() => openDeleteConfirm({ onDeletedFallbackPath })}
       >
         <Trash2 className="h-3.5 w-3.5" />
         {t(($) => $.actions.delete_issue)}

--- a/packages/views/issues/actions/use-issue-actions.ts
+++ b/packages/views/issues/actions/use-issue-actions.ts
@@ -24,7 +24,7 @@ export interface UseIssueActionsResult {
   openSetParent: () => void;
   removeParent: () => void;
   openAddChild: () => void;
-  openDeleteConfirm: (opts?: { onDeletedNavigateTo?: string }) => void;
+  openDeleteConfirm: (opts?: { onDeletedFallbackPath?: string }) => void;
 }
 
 /**
@@ -185,12 +185,12 @@ export function useIssueActions(issue: Issue | null): UseIssueActionsResult {
   }, [openModal, issueId]);
 
   const openDeleteConfirm = useCallback(
-    (opts?: { onDeletedNavigateTo?: string }) => {
+    (opts?: { onDeletedFallbackPath?: string }) => {
       if (!issueId) return;
       openModal("issue-delete-confirm", {
         issueId,
         identifier: issueIdentifier,
-        onDeletedNavigateTo: opts?.onDeletedNavigateTo,
+        onDeletedFallbackPath: opts?.onDeletedFallbackPath,
       });
     },
     [openModal, issueId, issueIdentifier],

--- a/packages/views/issues/components/issue-detail.test.tsx
+++ b/packages/views/issues/components/issue-detail.test.tsx
@@ -115,6 +115,7 @@ vi.mock("../../navigation", () => ({
     pathname: "/issues/issue-1",
     getShareableUrl: (p: string) => `https://app.multica.com${p}`,
   }),
+  useBackOrReplace: () => vi.fn(),
   NavigationProvider: ({ children }: { children: React.ReactNode }) => children,
 }));
 
@@ -897,13 +898,13 @@ describe("IssueDetail (shared)", () => {
     });
   });
 
-  it("shows 'Back to Issues' button when issue is not found and no onDelete prop", async () => {
+  it("shows 'Back' button when issue is not found and no onDelete prop", async () => {
     mockApiObj.getIssue.mockRejectedValue(new Error("Not found"));
 
     renderIssueDetail("nonexistent-id");
 
     await waitFor(() => {
-      expect(screen.getByText("Back to Issues")).toBeInTheDocument();
+      expect(screen.getByText("Back")).toBeInTheDocument();
     });
   });
 

--- a/packages/views/issues/components/issue-detail.tsx
+++ b/packages/views/issues/components/issue-detail.tsx
@@ -3,8 +3,7 @@
 import { useState, useEffect, useCallback, useMemo, useRef, Fragment } from "react";
 import { Virtuoso, type VirtuosoHandle } from "react-virtuoso";
 import { useDefaultLayout, usePanelRef } from "react-resizable-panels";
-import { AppLink } from "../../navigation";
-import { useNavigation } from "../../navigation";
+import { AppLink, useBackOrReplace } from "../../navigation";
 import {
   Archive,
   Calendar,
@@ -904,7 +903,7 @@ export function IssueDetail({ issueId, onDelete, onDone, defaultSidebarOpen = tr
   const { t } = useT("issues");
   const timeAgo = useTimeAgo();
   const id = issueId;
-  const router = useNavigation();
+  const backOrReplace = useBackOrReplace();
   const user = useAuthStore((s) => s.user);
   const paths = useWorkspacePaths();
 
@@ -1105,7 +1104,7 @@ export function IssueDetail({ issueId, onDelete, onDone, defaultSidebarOpen = tr
   // Fire `onDelete` once when the issue transitions from loaded to missing.
   // Delete goes through a shell-level modal, so the caller (e.g. inbox) can't
   // be notified directly — instead, the detail page observes its own cache
-  // clearing and runs the callback. We navigate via `onDeletedNavigateTo` on
+  // clearing and runs the callback. We navigate via `onDeletedFallbackPath` on
   // the actions menu when no callback is supplied (standalone routes).
   const hadIssueRef = useRef(false);
   const firedDeleteCallbackRef = useRef(false);
@@ -1754,9 +1753,9 @@ export function IssueDetail({ issueId, onDelete, onDone, defaultSidebarOpen = tr
       <div className="flex flex-1 min-h-0 flex-col items-center justify-center gap-3 text-sm text-muted-foreground">
         <p>{t(($) => $.detail.not_found)}</p>
         {!onDelete && (
-          <Button variant="outline" size="sm" onClick={() => router.push(paths.issues())}>
+          <Button variant="outline" size="sm" onClick={() => backOrReplace(paths.issues())}>
             <ChevronLeft className="mr-1 h-3.5 w-3.5" />
-            {t(($) => $.detail.back_to_issues)}
+            {t(($) => $.detail.back)}
           </Button>
         )}
       </div>
@@ -2280,8 +2279,9 @@ export function IssueDetail({ issueId, onDelete, onDone, defaultSidebarOpen = tr
               issue={issue}
               align="end"
               // When a parent passes `onDelete`, we detect deletion via effect
-              // above and skip navigation. Otherwise the modal navigates for us.
-              onDeletedNavigateTo={onDelete ? undefined : paths.issues()}
+              // above and skip navigation. Otherwise the modal takes us back
+              // to the list we came from, falling back to all issues.
+              onDeletedFallbackPath={onDelete ? undefined : paths.issues()}
               trigger={
                 <Button variant="ghost" size="icon-sm" className="text-muted-foreground">
                   <MoreHorizontal />

--- a/packages/views/locales/en/issues.json
+++ b/packages/views/locales/en/issues.json
@@ -233,7 +233,7 @@
   "detail": {
     "not_found": "This issue does not exist or has been deleted in this workspace.",
     "breadcrumb_project_unknown": "Unknown project",
-    "back_to_issues": "Back to Issues",
+    "back": "Back",
     "title_placeholder": "Issue title",
     "desc_placeholder": "Add description...",
     "sub_issues_label": "Sub-issues",

--- a/packages/views/locales/ja/issues.json
+++ b/packages/views/locales/ja/issues.json
@@ -231,7 +231,7 @@
   "detail": {
     "not_found": "このイシューはこのワークスペースに存在しないか、削除されています。",
     "breadcrumb_project_unknown": "不明なプロジェクト",
-    "back_to_issues": "イシューに戻る",
+    "back": "戻る",
     "title_placeholder": "イシューのタイトル",
     "desc_placeholder": "説明を追加...",
     "sub_issues_label": "サブイシュー",

--- a/packages/views/locales/ko/issues.json
+++ b/packages/views/locales/ko/issues.json
@@ -231,7 +231,7 @@
   "detail": {
     "not_found": "이 워크스페이스에 해당 이슈가 없거나 삭제되었습니다.",
     "breadcrumb_project_unknown": "알 수 없는 프로젝트",
-    "back_to_issues": "이슈로 돌아가기",
+    "back": "뒤로",
     "title_placeholder": "이슈 제목",
     "desc_placeholder": "설명 추가...",
     "sub_issues_label": "하위 이슈",

--- a/packages/views/locales/zh-Hans/issues.json
+++ b/packages/views/locales/zh-Hans/issues.json
@@ -231,7 +231,7 @@
   "detail": {
     "not_found": "这个 issue 不存在或已在该工作区被删除。",
     "breadcrumb_project_unknown": "未知项目",
-    "back_to_issues": "返回 issue 列表",
+    "back": "返回",
     "title_placeholder": "issue 标题",
     "desc_placeholder": "添加描述...",
     "sub_issues_label": "子 issue",

--- a/packages/views/modals/delete-issue-confirm.test.tsx
+++ b/packages/views/modals/delete-issue-confirm.test.tsx
@@ -1,0 +1,129 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { DeleteIssueConfirmModal } from "./delete-issue-confirm";
+import { NavigationProvider } from "../navigation";
+import type { NavigationAdapter } from "../navigation";
+
+const mockDelete = vi.fn().mockResolvedValue(undefined);
+vi.mock("@multica/core/issues/mutations", () => ({
+  useDeleteIssue: () => ({ mutateAsync: mockDelete }),
+}));
+
+vi.mock("sonner", () => ({
+  toast: { success: vi.fn(), error: vi.fn() },
+}));
+
+vi.mock("../i18n", () => ({
+  useT: () => ({
+    t: (sel: (x: Record<string, Record<string, string>>) => string) =>
+      sel({
+        delete_issue: {
+          title: "Delete issue?",
+          description: "This cannot be undone.",
+          hint: "Sub-issues are deleted too.",
+          cancel: "Cancel",
+          confirm: "Delete",
+          deleting: "Deleting...",
+          toast_deleted: "Issue deleted",
+          toast_delete_failed: "Delete failed",
+        },
+      }),
+  }),
+}));
+
+function makeAdapter(
+  overrides: Partial<NavigationAdapter> = {},
+): NavigationAdapter {
+  return {
+    push: vi.fn(),
+    replace: vi.fn(),
+    back: vi.fn(),
+    pathname: "/acme/issues/issue-1",
+    searchParams: new URLSearchParams(),
+    getShareableUrl: (p) => p,
+    ...overrides,
+  };
+}
+
+async function deleteWith(
+  adapter: NavigationAdapter,
+  data: Record<string, unknown> | null,
+) {
+  const onClose = vi.fn();
+  render(
+    <NavigationProvider value={adapter}>
+      <DeleteIssueConfirmModal onClose={onClose} data={data} />
+    </NavigationProvider>,
+  );
+  fireEvent.click(screen.getByText("Delete"));
+  await waitFor(() => expect(mockDelete).toHaveBeenCalledWith("issue-1"));
+  return onClose;
+}
+
+describe("DeleteIssueConfirmModal", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  // The bug this guards (GH #5995): deleting from an issue opened out of My
+  // Issues used to hard-push the workspace Issues list, dropping the user's
+  // navigation context. The same applied to project lists, search and pins.
+  it("returns to the list the issue was opened from", async () => {
+    const adapter = makeAdapter({ canGoBack: () => true });
+
+    await deleteWith(adapter, {
+      issueId: "issue-1",
+      onDeletedFallbackPath: "/acme/issues",
+    });
+
+    await waitFor(() => expect(adapter.back).toHaveBeenCalledTimes(1));
+    expect(adapter.replace).not.toHaveBeenCalled();
+    expect(adapter.push).not.toHaveBeenCalled();
+  });
+
+  it("falls back to the workspace list when the issue was opened cold", async () => {
+    const adapter = makeAdapter({ canGoBack: () => false });
+
+    await deleteWith(adapter, {
+      issueId: "issue-1",
+      onDeletedFallbackPath: "/acme/issues",
+    });
+
+    await waitFor(() =>
+      expect(adapter.replace).toHaveBeenCalledWith("/acme/issues"),
+    );
+    expect(adapter.back).not.toHaveBeenCalled();
+  });
+
+  // List surfaces delete in place (row context menu, batch toolbar): there is
+  // no page to leave, so the modal must not navigate at all.
+  it("does not navigate when no fallback path is supplied", async () => {
+    const adapter = makeAdapter({ canGoBack: () => true });
+
+    const onClose = await deleteWith(adapter, { issueId: "issue-1" });
+
+    await waitFor(() => expect(onClose).toHaveBeenCalled());
+    expect(adapter.back).not.toHaveBeenCalled();
+    expect(adapter.replace).not.toHaveBeenCalled();
+    expect(adapter.push).not.toHaveBeenCalled();
+  });
+
+  it("stays put when the delete fails", async () => {
+    mockDelete.mockRejectedValueOnce(new Error("nope"));
+    const adapter = makeAdapter({ canGoBack: () => true });
+
+    render(
+      <NavigationProvider value={adapter}>
+        <DeleteIssueConfirmModal
+          onClose={vi.fn()}
+          data={{ issueId: "issue-1", onDeletedFallbackPath: "/acme/issues" }}
+        />
+      </NavigationProvider>,
+    );
+    fireEvent.click(screen.getByText("Delete"));
+
+    await waitFor(() => expect(screen.getByText("Delete")).toBeInTheDocument());
+    expect(adapter.back).not.toHaveBeenCalled();
+    expect(adapter.replace).not.toHaveBeenCalled();
+  });
+});

--- a/packages/views/modals/delete-issue-confirm.tsx
+++ b/packages/views/modals/delete-issue-confirm.tsx
@@ -13,7 +13,7 @@ import {
   AlertDialogTitle,
 } from "@multica/ui/components/ui/alert-dialog";
 import { useDeleteIssue } from "@multica/core/issues/mutations";
-import { useNavigation } from "../navigation";
+import { useBackOrReplace } from "../navigation";
 import { useT } from "../i18n";
 
 export function DeleteIssueConfirmModal({
@@ -25,10 +25,12 @@ export function DeleteIssueConfirmModal({
 }) {
   const { t } = useT("modals");
   const issueId = (data?.issueId as string) || "";
-  const navigateTo = (data?.onDeletedNavigateTo as string | undefined) || undefined;
+  // Set only by callers that are rendering the issue we are about to delete
+  // (the detail page). List surfaces leave it undefined and simply stay put.
+  const fallbackPath = (data?.onDeletedFallbackPath as string | undefined) || undefined;
   const [deleting, setDeleting] = useState(false);
   const deleteIssue = useDeleteIssue();
-  const navigation = useNavigation();
+  const backOrReplace = useBackOrReplace();
 
   const handleDelete = async () => {
     if (!issueId) return;
@@ -37,7 +39,9 @@ export function DeleteIssueConfirmModal({
       await deleteIssue.mutateAsync(issueId);
       toast.success(t(($) => $.delete_issue.toast_deleted));
       onClose();
-      if (navigateTo) navigation.push(navigateTo);
+      // Back to whichever list the user opened this issue from; `fallbackPath`
+      // only kicks in when there is no in-app history to step back into.
+      if (fallbackPath) backOrReplace(fallbackPath);
     } catch (err) {
       toast.error(
         err instanceof Error && err.message

--- a/packages/views/navigation/index.ts
+++ b/packages/views/navigation/index.ts
@@ -6,4 +6,5 @@ export {
 export { AppLink } from "./app-link";
 export { useAppOrigin } from "./use-app-origin";
 export { useRowLink } from "./use-row-link";
+export { useBackOrReplace } from "./use-back-or-replace";
 export type { NavigationAdapter } from "./types";

--- a/packages/views/navigation/types.ts
+++ b/packages/views/navigation/types.ts
@@ -26,4 +26,14 @@ export interface NavigationAdapter {
    * already loads the whole SPA. Callers must invoke via `prefetch?.(href)`.
    */
   prefetch?: (path: string) => void;
+  /**
+   * Optional: is there an in-app page behind the current one, so that `back()`
+   * lands somewhere inside Multica rather than stepping off the app? Only the
+   * platform can answer — web reads the browser's session history, desktop the
+   * active tab's virtual history. Adapters that cannot answer leave this
+   * undefined and callers must treat that as `false`.
+   *
+   * Read it through `useBackOrReplace()` rather than calling it directly.
+   */
+  canGoBack?: () => boolean;
 }

--- a/packages/views/navigation/use-back-or-replace.test.tsx
+++ b/packages/views/navigation/use-back-or-replace.test.tsx
@@ -1,0 +1,73 @@
+import { describe, expect, it, vi } from "vitest";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { NavigationProvider } from "./context";
+import { useBackOrReplace } from "./use-back-or-replace";
+import type { NavigationAdapter } from "./types";
+
+function makeAdapter(
+  overrides: Partial<NavigationAdapter> = {},
+): NavigationAdapter {
+  return {
+    push: vi.fn(),
+    replace: vi.fn(),
+    back: vi.fn(),
+    pathname: "/",
+    searchParams: new URLSearchParams(),
+    getShareableUrl: (p) => p,
+    ...overrides,
+  };
+}
+
+function Probe() {
+  const backOrReplace = useBackOrReplace();
+  return (
+    <button onClick={() => backOrReplace("/acme/issues")}>leave</button>
+  );
+}
+
+function renderProbe(adapter: NavigationAdapter) {
+  render(
+    <NavigationProvider value={adapter}>
+      <Probe />
+    </NavigationProvider>,
+  );
+  fireEvent.click(screen.getByRole("button", { name: "leave" }));
+}
+
+describe("useBackOrReplace", () => {
+  it("goes back when the platform reports in-app history", () => {
+    const adapter = makeAdapter({ canGoBack: () => true });
+
+    renderProbe(adapter);
+
+    expect(adapter.back).toHaveBeenCalledTimes(1);
+    expect(adapter.replace).not.toHaveBeenCalled();
+    expect(adapter.push).not.toHaveBeenCalled();
+  });
+
+  it("replaces with the fallback when there is nothing to go back to", () => {
+    const adapter = makeAdapter({ canGoBack: () => false });
+
+    renderProbe(adapter);
+
+    expect(adapter.replace).toHaveBeenCalledWith("/acme/issues");
+    expect(adapter.back).not.toHaveBeenCalled();
+  });
+
+  it("replaces with the fallback when the adapter cannot report history", () => {
+    const adapter = makeAdapter();
+
+    renderProbe(adapter);
+
+    expect(adapter.replace).toHaveBeenCalledWith("/acme/issues");
+    expect(adapter.back).not.toHaveBeenCalled();
+  });
+
+  it("never pushes — the page being left is dead and must not stay in history", () => {
+    const adapter = makeAdapter({ canGoBack: () => false });
+
+    renderProbe(adapter);
+
+    expect(adapter.push).not.toHaveBeenCalled();
+  });
+});

--- a/packages/views/navigation/use-back-or-replace.ts
+++ b/packages/views/navigation/use-back-or-replace.ts
@@ -19,8 +19,10 @@ import { useNavigation } from "./context";
  * can't report history (test stubs, the desktop issue window) always take this
  * branch, which is exactly the pre-existing behaviour.
  *
- * Always `replace`, never `push`: the page we are leaving is dead, so its URL
- * must not stay in history for the back button to land on a 404.
+ * Never `push`: the page we are leaving is dead, so its URL must not be left
+ * on the back stack for the back button to land on a 404. Stepping back still
+ * leaves it ahead of us in forward history — that is the browser's own
+ * contract, and reachable only by an explicit Forward.
  */
 export function useBackOrReplace(): (fallback: string) => void {
   const { back, replace, canGoBack } = useNavigation();

--- a/packages/views/navigation/use-back-or-replace.ts
+++ b/packages/views/navigation/use-back-or-replace.ts
@@ -1,0 +1,34 @@
+"use client";
+
+import { useCallback } from "react";
+import { useNavigation } from "./context";
+
+/**
+ * Leave a page whose subject no longer exists, returning the user to wherever
+ * they came from.
+ *
+ * Deleting an issue from its detail page is the canonical case: the user may
+ * have opened it from My Issues, a project's list, a search result or a pin,
+ * and every one of those is a better destination than a hardcoded workspace
+ * list. Going back is the only thing that knows which — no caller has to
+ * thread a "source view" through the URL or a store.
+ *
+ * `fallback` covers the case where there is nothing to go back to: a shared
+ * link opened cold, a new tab, a pasted URL. Stepping back from those would
+ * leave Multica entirely, so we navigate to `fallback` instead. Adapters that
+ * can't report history (test stubs, the desktop issue window) always take this
+ * branch, which is exactly the pre-existing behaviour.
+ *
+ * Always `replace`, never `push`: the page we are leaving is dead, so its URL
+ * must not stay in history for the back button to land on a 404.
+ */
+export function useBackOrReplace(): (fallback: string) => void {
+  const { back, replace, canGoBack } = useNavigation();
+  return useCallback(
+    (fallback: string) => {
+      if (canGoBack?.() === true) back();
+      else replace(fallback);
+    },
+    [back, replace, canGoBack],
+  );
+}

--- a/packages/views/navigation/use-back-or-replace.ts
+++ b/packages/views/navigation/use-back-or-replace.ts
@@ -15,9 +15,14 @@ import { useNavigation } from "./context";
  *
  * `fallback` covers the case where there is nothing to go back to: a shared
  * link opened cold, a new tab, a pasted URL. Stepping back from those would
- * leave Multica entirely, so we navigate to `fallback` instead. Adapters that
- * can't report history (test stubs, the desktop issue window) always take this
- * branch, which is exactly the pre-existing behaviour.
+ * leave Multica entirely, so we navigate to `fallback` instead.
+ *
+ * It also covers every platform that cannot answer the question — the desktop
+ * issue window, test stubs, and browsers with no Navigation API. That branch
+ * is the behaviour those surfaces had before this hook existed, so a platform
+ * going quiet costs the user a better destination and nothing more. Only ever
+ * answer `canGoBack` from something that knows; a hopeful guess here is what
+ * puts a user outside the app.
  *
  * Never `push`: the page we are leaving is dead, so its URL must not be left
  * on the back stack for the back button to land on a 404. Stepping back still


### PR DESCRIPTION
Fixes #5995. MUL-5362.

## The problem

Deleting an issue from its detail page always navigated to the workspace-level **Issues** list, because the destination was hardcoded:

```tsx
// packages/views/issues/components/issue-detail.tsx
onDeletedNavigateTo={onDelete ? undefined : paths.issues()}
```

`IssueDetail` has no idea which list the user came from — there is no referrer, no `from` param, no "source view" anywhere in the codebase. So this is not a My Issues bug: **every** entry point that lands on `/{slug}/issues/{id}` and then deletes gets dropped on the workspace list — My Issues, a project's issue list, an agent/member/squad panel, search results, sidebar pins, `@`-mentions in comments.

Two surfaces were already immune because they pass `onDelete` and override navigation entirely (Inbox split view, the desktop dedicated issue window). Mobile was already correct — it uses `router.back()`.

## The fix

Go back to wherever the user came from, with a safe fallback.

- **`useBackOrReplace(fallback)`** (`packages/views/navigation/`) — steps back when the platform reports in-app history, otherwise replaces with `fallback`. One decision, shared by web and desktop.
- **`NavigationAdapter.canGoBack?()`** — a new optional platform capability. Only the platform can answer, and the answer differs:
  - **Web** uses the Navigation API, whose `entries()` spans only the contiguous same-origin run around the current entry — so arriving from an external site, a shared link, or a fresh tab correctly reports "nothing to go back to". Browsers without it fall back to counting the pushes the adapter made in this document, which is zero in exactly those cold-open cases.
  - **Desktop** reads the active tab's virtual history index, the same source the shell's back button uses.
  - Adapters that don't implement it (the desktop issue window, test stubs) always take the fallback branch — i.e. today's behaviour.
- **`replace`, not `push`.** The deleted issue's URL must not stay in history; previously the browser back button landed on a 404 detail page.
- The prop is renamed `onDeletedNavigateTo` → **`onDeletedFallbackPath`**, since it is no longer the destination — only the destination of last resort. List surfaces still pass nothing and still stay put on delete.
- The not-found **"Back to Issues"** button lost the same context, so it moves to the same helper. Its label becomes a plain **"Back"** (`detail.back_to_issues` → `detail.back`, all four locales), which is accurate whichever branch it takes.

No data-layer change was needed: `useDeleteIssue` already prunes `issueKeys.myAll` and the other list caches in `onMutate`, so the list the user returns to is already correct.

## Testing

`pnpm typecheck`, `pnpm lint` (0 errors) and `pnpm test` (3032 tests, 262 files) all pass locally.

New coverage:

- `packages/views/modals/delete-issue-confirm.test.tsx` — returns to the source list; falls back to the workspace list when opened cold; does not navigate at all when no fallback is supplied (list-surface deletes); stays put when the delete fails.
- `packages/views/navigation/use-back-or-replace.test.tsx` — the three `canGoBack` states (true / false / not implemented) and that it never pushes.
- `apps/web/platform/in-app-history.test.ts` — Navigation API takes precedence over the push count; the fallback reports nothing to go back to before the first in-app push; a non-Navigation-API `window.navigation` global is ignored.

Updated: the three existing tests that pinned the old prop name and the old button label.

Not covered by unit tests, worth a manual pass on staging: the real browser history behaviour (open an issue from My Issues → delete → land back on My Issues) and the desktop tab-history path.
