### PR TITLE
feat(channel): extract shared async /issue quick-create flow

### DIFF
--- a/server/cmd/server/router.go
+++ b/server/cmd/server/router.go
@@ -280,11 +280,15 @@ func NewRouterWithOptions(pool *pgxpool.Pool, hub *realtime.Hub, bus *events.Bus
 	// connection of its own outside the per-installation supervisor. The Router
 	// is the single shared inbound handler injected into every Channel.
 	channelRegistry := channel.NewRegistry()
-	channelRouter := engine.NewRouter(h.IssueService, h.TaskService, queries, engine.RouterConfig{Logger: slog.Default()})
+	channelRouter := engine.NewRouter(h.IssueService, h.TaskService, queries, engine.RouterConfig{
+		Logger:   slog.Default(),
+		Messages: queries,
+	})
 	// Debounce the per-session run trigger so a burst of messages collapses
 	// into one agent run instead of one per message (MUL-2968).
 	channelRouter.EnableRunBatching(engine.DefaultChatRunBatchWindow)
 	h.ChannelRouter = channelRouter
+	h.TaskService.AppURL = appURLFromEnv()
 	// Media intent-ledger reconciler: settles uploaded-but-unbound objects.
 	// Built ONLY when a storage backend exists — store is nil when S3 is not
 	// configured and the local upload dir failed to initialize, and a

--- a/server/internal/handler/daemon.go
+++ b/server/internal/handler/daemon.go
@@ -2374,6 +2374,33 @@ func (h *Handler) buildClaimedTaskResponse(r *http.Request, task *db.AgentTaskQu
 			resp.ThreadName = qc.Prompt
 			resp.WorkspaceID = qc.WorkspaceID
 
+			// Channel media is bound durably to the quick-create task after the
+			// context JSON is written. Read those task-owned rows at claim time
+			// so a crash between binding and promotion cannot lose attachments.
+			if workspaceID, err := util.ParseUUID(qc.WorkspaceID); err == nil {
+				ids, listErr := h.Queries.ListUnboundAttachmentIDsByTaskLineage(r.Context(), db.ListUnboundAttachmentIDsByTaskLineageParams{
+					TaskID:      task.ID,
+					WorkspaceID: workspaceID,
+				})
+				if listErr != nil {
+					slog.Warn("quick-create claim: list task attachments failed",
+						"task_id", uuidToString(task.ID), "error", listErr)
+				} else {
+					seen := make(map[string]struct{}, len(resp.QuickCreateAttachmentIDs)+len(ids))
+					for _, id := range resp.QuickCreateAttachmentIDs {
+						seen[id] = struct{}{}
+					}
+					for _, id := range ids {
+						value := uuidToString(id)
+						if _, ok := seen[value]; ok {
+							continue
+						}
+						seen[value] = struct{}{}
+						resp.QuickCreateAttachmentIDs = append(resp.QuickCreateAttachmentIDs, value)
+					}
+				}
+			}
+
 			// When the user picked a project in the modal, surface its title
 			// and resources to the daemon so the agent has the same context
 			// it would for an issue-bound task: the prompt template can name

--- a/server/internal/handler/daemon_test.go
+++ b/server/internal/handler/daemon_test.go
@@ -3910,6 +3910,7 @@ func TestClaimTask_QuickCreatePopulatesThreadName(t *testing.T) {
 
 	quickPrompt := "create a follow-up issue for Codex session titles"
 	attachmentID := "019ec09d-6222-722b-bdfa-427b105d80be"
+	taskAttachmentID := "019ec09d-6222-722b-bdfa-427b105d80bf"
 	quickContext, _ := json.Marshal(map[string]any{
 		"type":           "quick_create",
 		"prompt":         quickPrompt,
@@ -3920,19 +3921,41 @@ func TestClaimTask_QuickCreatePopulatesThreadName(t *testing.T) {
 		"attachment_ids": []string{attachmentID},
 	})
 
-	if _, err := testPool.Exec(ctx, `
-		INSERT INTO agent_task_queue (agent_id, runtime_id, status, priority, context)
-		VALUES ($1, $2, 'queued', 2, $3)
-	`, agentID, runtimeID, quickContext); err != nil {
-		t.Fatalf("setup: create quick-create task: %v", err)
+	var ancestorTaskID string
+	if err := testPool.QueryRow(ctx, `
+		INSERT INTO agent_task_queue (agent_id, runtime_id, status, priority, context, completed_at)
+		VALUES ($1, $2, 'failed', 2, $3, now())
+		RETURNING id
+	`, agentID, runtimeID, quickContext).Scan(&ancestorTaskID); err != nil {
+		t.Fatalf("setup: create failed quick-create ancestor: %v", err)
 	}
+	if _, err := testPool.Exec(ctx, `
+		INSERT INTO agent_task_queue (agent_id, runtime_id, status, priority, context, parent_task_id)
+		VALUES ($1, $2, 'queued', 2, $3, $4)
+	`, agentID, runtimeID, quickContext, ancestorTaskID); err != nil {
+		t.Fatalf("setup: create quick-create retry: %v", err)
+	}
+	if _, err := testPool.Exec(ctx, `
+		INSERT INTO attachment (
+			id, workspace_id, task_id, uploader_type, uploader_id,
+			filename, url, content_type, size_bytes
+		)
+		VALUES ($1, $2, $3, 'member', $4, 'channel.png', 'https://example.test/channel.png', 'image/png', 3)
+	`, taskAttachmentID, testWorkspaceID, ancestorTaskID, testUserID); err != nil {
+		t.Fatalf("setup: create task-owned attachment: %v", err)
+	}
+	t.Cleanup(func() {
+		_, _ = testPool.Exec(context.Background(), `DELETE FROM attachment WHERE id = $1`, taskAttachmentID)
+	})
 
 	task := claimTaskForRuntimeGuard(t, runtimeID, daemonID)
 	if task.ThreadName != quickPrompt {
 		t.Fatalf("quick-create task thread_name = %q, want prompt", task.ThreadName)
 	}
-	if len(task.QuickCreateAttachmentIDs) != 1 || task.QuickCreateAttachmentIDs[0] != attachmentID {
-		t.Fatalf("quick-create attachment ids = %#v, want [%q]", task.QuickCreateAttachmentIDs, attachmentID)
+	if len(task.QuickCreateAttachmentIDs) != 2 ||
+		task.QuickCreateAttachmentIDs[0] != attachmentID ||
+		task.QuickCreateAttachmentIDs[1] != taskAttachmentID {
+		t.Fatalf("quick-create attachment ids = %#v, want [%q, %q]", task.QuickCreateAttachmentIDs, attachmentID, taskAttachmentID)
 	}
 	if task.QuickCreatePriority != "high" || task.QuickCreateDueDate != "2026-08-01" {
 		t.Fatalf("quick-create fields = {%q, %q}, want {high, 2026-08-01}", task.QuickCreatePriority, task.QuickCreateDueDate)

--- a/server/internal/integrations/channel/engine/quick_create.go
+++ b/server/internal/integrations/channel/engine/quick_create.go
@@ -1,0 +1,103 @@
+package engine
+
+import (
+	"context"
+	"strings"
+
+	"github.com/jackc/pgx/v5/pgtype"
+
+	"github.com/multica-ai/multica/server/internal/integrations/channel"
+	db "github.com/multica-ai/multica/server/pkg/db/generated"
+)
+
+const (
+	IssueQueuedAckText   = "👀 On it — I'm turning that into an issue. I'll post the result here when it's ready."
+	IssueUsageText       = "Tell me what to file, e.g. `/issue the login button does nothing on Safari`."
+	IssueQueueFailedText = "⚠️ Something went wrong creating the issue. Please try again."
+)
+
+// quickCreatePrompt removes the command token from this turn's own content.
+// Unlike the synchronous direct-create path, a bare /issue never falls back to
+// an earlier message: the user gets a usage hint instead of filing stale text.
+func quickCreatePrompt(msg channel.InboundMessage) string {
+	commandText := msg.CommandText
+	if commandText == "" {
+		commandText = msg.Text
+	}
+	rest, _ := stripIssuePrefix(commandText)
+	return strings.TrimSpace(rest)
+}
+
+func stripIssuePrefix(s string) (string, bool) {
+	lines := strings.Split(s, "\n")
+	first := -1
+	for i, line := range lines {
+		if strings.TrimSpace(line) != "" {
+			first = i
+			break
+		}
+	}
+	if first == -1 {
+		return s, false
+	}
+	trimmed := strings.TrimLeft(lines[first], " \t")
+	if !strings.HasPrefix(trimmed, issueCommandPrefix) {
+		return s, false
+	}
+	rest := trimmed[len(issueCommandPrefix):]
+	if rest != "" {
+		if r0 := rest[0]; r0 != ' ' && r0 != '\t' && r0 != '\n' {
+			return s, false
+		}
+	}
+	lines[first] = rest
+	return strings.Join(lines[first:], "\n"), true
+}
+
+// handleQuickCreate queues the background issue-authoring task after the user
+// turn is durable. When media is pending, the task is created deferred and the
+// existing media pipeline promotes it after task-owned attachments are bound.
+func (r *Router) handleQuickCreate(ctx context.Context, set ResolverSet, inst ResolvedInstallation, requesterID, sessionID, messageID pgtype.UUID, prompt string, mediaPending bool, res *Result) (db.AgentTaskQueue, bool) {
+	if prompt == "" {
+		r.appendAssistantNote(ctx, sessionID, IssueUsageText)
+		res.IssueUsage = true
+		return db.AgentTaskQueue{}, false
+	}
+	task, err := set.QuickCreate.EnqueueQuickCreateChatTask(ctx, inst.WorkspaceID, requesterID, inst.AgentID, prompt, sessionID, messageID, mediaPending)
+	if err != nil {
+		r.logger.Error("channel router: quick-create enqueue failed",
+			"chat_session_id", uuidString(sessionID), "err", err.Error())
+		if mediaPending {
+			// No resolver will run now, so clear the durable marker immediately.
+			if clearErr := set.Session.BindMedia(ctx, BindMediaParams{
+				MessageID:   messageID,
+				SessionID:   sessionID,
+				WorkspaceID: inst.WorkspaceID,
+				Sender:      requesterID,
+			}); clearErr != nil {
+				r.logger.Warn("channel router: quick-create enqueue failure marker clear failed",
+					"chat_session_id", uuidString(sessionID), "err", clearErr)
+			}
+		}
+		r.appendAssistantNote(ctx, sessionID, IssueQueueFailedText)
+		res.IssueQueueFailed = true
+		return db.AgentTaskQueue{}, false
+	}
+	r.appendAssistantNote(ctx, sessionID, IssueQueuedAckText)
+	res.IssueQueued = true
+	return task, true
+}
+
+func (r *Router) appendAssistantNote(ctx context.Context, sessionID pgtype.UUID, text string) {
+	if r.messages == nil {
+		return
+	}
+	if _, err := r.messages.CreateChatMessage(ctx, db.CreateChatMessageParams{
+		ChatSessionID: sessionID,
+		Role:          "assistant",
+		Content:       text,
+	}); err != nil {
+		r.logger.Warn("channel router: assistant note append failed",
+			"chat_session_id", uuidString(sessionID), "err", err.Error())
+	}
+}

--- a/server/internal/integrations/channel/engine/quick_create_test.go
+++ b/server/internal/integrations/channel/engine/quick_create_test.go
@@ -1,0 +1,39 @@
+package engine
+
+import (
+	"testing"
+
+	"github.com/multica-ai/multica/server/internal/integrations/channel"
+)
+
+func TestQuickCreatePrompt(t *testing.T) {
+	tests := []struct {
+		name string
+		text string
+		want string
+	}{
+		{name: "title", text: "/issue fix login", want: "fix login"},
+		{name: "description", text: "/issue fix login\nsteps to reproduce", want: "fix login\nsteps to reproduce"},
+		{name: "bare", text: "/issue", want: ""},
+		{name: "newline boundary", text: "/issue\nsteps to reproduce", want: "steps to reproduce"},
+		{name: "leading blank lines", text: "\n  \n\t/issue fix login\nsteps", want: "fix login\nsteps"},
+		{name: "token boundary", text: "/issuetracker foo", want: "/issuetracker foo"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := quickCreatePrompt(channel.InboundMessage{Text: tt.text}); got != tt.want {
+				t.Fatalf("quickCreatePrompt(%q) = %q, want %q", tt.text, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestQuickCreatePromptUsesUnenrichedCommandText(t *testing.T) {
+	msg := channel.InboundMessage{
+		Text:        "<quoted_message>prior context</quoted_message>\n/issue fix login",
+		CommandText: "/issue fix login",
+	}
+	if got := quickCreatePrompt(msg); got != "fix login" {
+		t.Fatalf("quickCreatePrompt() = %q, want command-only prompt", got)
+	}
+}

--- a/server/internal/integrations/channel/engine/resolvers.go
+++ b/server/internal/integrations/channel/engine/resolvers.go
@@ -58,6 +58,16 @@ type Result struct {
 	IssueNumber     int32
 	IssueIdentifier string
 	IssueTitle      string
+	// IssueQueued reports that /issue was accepted onto a background
+	// quick-create path. Direct-create channels populate IssueID instead.
+	IssueQueued bool
+	// IssueUsage reports a bare /issue with no prompt of its own.
+	IssueUsage bool
+	// IssueQueueFailed reports that the quick-create task could not be queued.
+	IssueQueueFailed bool
+	// RunScheduled reports whether this ingest scheduled a normal chat run.
+	// Non-run outcomes leave it false and must not start a typing indicator.
+	RunScheduled bool
 }
 
 // ResolvedInstallation is the channel-agnostic installation context the Router
@@ -119,11 +129,12 @@ type AppendResult struct {
 // attachment transaction. MessageID is the durable chat_message created by
 // AppendMessage; media downloads must never run inside this transaction.
 type BindMediaParams struct {
-	MessageID   pgtype.UUID
-	SessionID   pgtype.UUID
-	WorkspaceID pgtype.UUID
-	Sender      pgtype.UUID
-	MediaRefs   []channel.MediaRef
+	MessageID         pgtype.UUID
+	SessionID         pgtype.UUID
+	WorkspaceID       pgtype.UUID
+	Sender            pgtype.UUID
+	MediaRefs         []channel.MediaRef
+	QuickCreateTaskID pgtype.UUID
 }
 
 // IssueCommand is the parsed /issue command.
@@ -299,12 +310,33 @@ type ResolverSet struct {
 	Replier      OutboundReplier
 	Typing       TypingNotifier
 	OriginType   string
+	// QuickCreate switches /issue from synchronous issue creation to a
+	// background agent-authored issue whose result is posted back into the
+	// originating conversation. Nil preserves the direct-create behavior.
+	// A channel enabling it must populate InboundMessage.CommandText with the
+	// same user-authored source AppendMessage parses into IssueCommand, because
+	// the Router removes the /issue token from CommandText to build the prompt.
+	QuickCreate QuickCreator
 }
 
 // IssueCreator is the narrow subset of service.IssueService the Router needs
 // for the /issue command. Shared across platforms.
 type IssueCreator interface {
 	Create(ctx context.Context, p service.IssueCreateParams, opts service.IssueCreateOpts) (service.IssueCreateResult, error)
+}
+
+// QuickCreator enqueues and promotes chat-originated quick-create tasks.
+// mediaPending asks the implementation to defer the task until the Router's
+// durable media pipeline has bound task-owned attachments or timed out.
+type QuickCreator interface {
+	EnqueueQuickCreateChatTask(ctx context.Context, workspaceID, requesterID, agentID pgtype.UUID, prompt string, chatSessionID, chatMessageID pgtype.UUID, mediaPending bool) (db.AgentTaskQueue, error)
+	PromoteQuickCreateChatTask(ctx context.Context, taskID pgtype.UUID) error
+}
+
+// MessageAppender writes Router-authored acknowledgement rows into the
+// transcript. *db.Queries satisfies it.
+type MessageAppender interface {
+	CreateChatMessage(ctx context.Context, arg db.CreateChatMessageParams) (db.ChatMessage, error)
 }
 
 // TaskEnqueuer is the narrow subset of service.TaskService the Router needs to

--- a/server/internal/integrations/channel/engine/router.go
+++ b/server/internal/integrations/channel/engine/router.go
@@ -35,9 +35,10 @@ type Router struct {
 	mu   sync.RWMutex
 	sets map[channel.Type]ResolverSet
 
-	issues IssueCreator
-	tasks  TaskEnqueuer
-	reader SessionReader
+	issues   IssueCreator
+	tasks    TaskEnqueuer
+	reader   SessionReader
+	messages MessageAppender
 
 	batcher *pendingBatcher
 
@@ -77,6 +78,9 @@ type RouterConfig struct {
 	// Per-session ordering is unaffected. Defaults to 8.
 	MediaConcurrency int
 	Logger           *slog.Logger
+	// Messages writes Router-authored quick-create acknowledgement notes.
+	// Nil skips transcript notes.
+	Messages MessageAppender
 }
 
 // NewRouter builds a Router around the shared (platform-agnostic) services:
@@ -102,6 +106,7 @@ func NewRouter(issues IssueCreator, tasks TaskEnqueuer, reader SessionReader, cf
 		issues:       issues,
 		tasks:        tasks,
 		reader:       reader,
+		messages:     cfg.Messages,
 		replyTimeout: cfg.ReplyTimeout,
 		mediaTimeout: cfg.MediaTimeout,
 		mediaCtx:     mediaCtx,
@@ -223,7 +228,7 @@ func (r *Router) Handle(ctx context.Context, msg channel.InboundMessage) error {
 
 	// Typing indicator on ingest, detached so the reaction HTTP call never
 	// blocks the connector ACK path.
-	if res.Outcome == OutcomeIngested && set.Typing != nil {
+	if res.Outcome == OutcomeIngested && res.RunScheduled && set.Typing != nil {
 		go func() {
 			tctx, cancel := context.WithTimeout(context.Background(), r.replyTimeout)
 			defer cancel()
@@ -388,6 +393,14 @@ func (r *Router) processClaimed(ctx context.Context, set ResolverSet, msg channe
 
 	// 7. /issue command, if present. chat_message is already durable; all
 	//    error returns from here signal finalizeNone (or the defensive Mark).
+	if appendRes.IssueCommand != nil && set.QuickCreate != nil {
+		prompt := quickCreatePrompt(msg)
+		task, queued := r.handleQuickCreate(ctx, set, inst, identity.UserID, sessionID, appendRes.MessageID, prompt, resolveMedia, &res)
+		if queued && resolveMedia {
+			r.enqueueMedia(set, inst, identity, appendRes.MessageID, msg, sessionID, localMediaDeadline, task.ID)
+		}
+		return res, postAppendFinalize, nil
+	}
 	if appendRes.IssueCommand != nil {
 		// One lookup feeds both the broadcast payload's identifier and the
 		// chat reply's.
@@ -411,8 +424,9 @@ func (r *Router) processClaimed(ctx context.Context, set ResolverSet, msg channe
 	//    in a window wins (MUL-2645).
 	r.scheduleRun(set, inst, msg, sessionID, identity.UserID)
 	if resolveMedia {
-		r.enqueueMedia(set, inst, identity, appendRes.MessageID, msg, sessionID, localMediaDeadline)
+		r.enqueueMedia(set, inst, identity, appendRes.MessageID, msg, sessionID, localMediaDeadline, pgtype.UUID{})
 	}
+	res.RunScheduled = true
 	return res, postAppendFinalize, nil
 }
 
@@ -420,7 +434,7 @@ func (r *Router) processClaimed(ctx context.Context, set ResolverSet, msg channe
 // order within a chat session. Run scheduling is independent and durable: the
 // task service defers a task to the persisted media deadline, then media
 // completion promotes it early.
-func (r *Router) enqueueMedia(set ResolverSet, inst ResolvedInstallation, identity ResolvedIdentity, chatMessageID pgtype.UUID, msg channel.InboundMessage, sessionID pgtype.UUID, deadline time.Time) {
+func (r *Router) enqueueMedia(set ResolverSet, inst ResolvedInstallation, identity ResolvedIdentity, chatMessageID pgtype.UUID, msg channel.InboundMessage, sessionID pgtype.UUID, deadline time.Time, quickCreateTaskID pgtype.UUID) {
 	key := keyForSession(sessionID)
 	done := make(chan struct{})
 
@@ -475,13 +489,13 @@ func (r *Router) enqueueMedia(set ResolverSet, inst ResolvedInstallation, identi
 				// sees the dead deadline and runs only the empty finalize.
 			}
 		}
-		r.resolveAndBindMedia(set, inst, identity, chatMessageID, msg, sessionID, deadline)
+		r.resolveAndBindMedia(set, inst, identity, chatMessageID, msg, sessionID, deadline, quickCreateTaskID)
 	}()
 }
 
 const mediaFinalizeTimeout = 5 * time.Second
 
-func (r *Router) resolveAndBindMedia(set ResolverSet, inst ResolvedInstallation, identity ResolvedIdentity, chatMessageID pgtype.UUID, msg channel.InboundMessage, sessionID pgtype.UUID, deadline time.Time) {
+func (r *Router) resolveAndBindMedia(set ResolverSet, inst ResolvedInstallation, identity ResolvedIdentity, chatMessageID pgtype.UUID, msg channel.InboundMessage, sessionID pgtype.UUID, deadline time.Time, quickCreateTaskID pgtype.UUID) {
 	ctx, cancel := context.WithDeadline(r.mediaCtx, deadline)
 	defer cancel()
 
@@ -506,13 +520,15 @@ func (r *Router) resolveAndBindMedia(set ResolverSet, inst ResolvedInstallation,
 			"message_id", msg.MessageID,
 			"error", err)
 	}
-	if err := set.Session.BindMedia(finalizeCtx, BindMediaParams{
-		MessageID:   chatMessageID,
-		SessionID:   sessionID,
-		WorkspaceID: inst.WorkspaceID,
-		Sender:      identity.UserID,
-		MediaRefs:   resolved.MediaRefs,
-	}); err != nil {
+	bindErr := set.Session.BindMedia(finalizeCtx, BindMediaParams{
+		MessageID:         chatMessageID,
+		SessionID:         sessionID,
+		WorkspaceID:       inst.WorkspaceID,
+		Sender:            identity.UserID,
+		MediaRefs:         resolved.MediaRefs,
+		QuickCreateTaskID: quickCreateTaskID,
+	})
+	if bindErr != nil {
 		// Never delete inline: the attachments may or may not have landed
 		// (an ambiguous commit), but the intent rows are deleted in the SAME
 		// transaction, so the ledger already reflects whichever outcome is
@@ -521,7 +537,24 @@ func (r *Router) resolveAndBindMedia(set ResolverSet, inst ResolvedInstallation,
 			"channel_type", string(msg.Source.ChannelType),
 			"event_id", msg.EventID,
 			"message_id", msg.MessageID,
-			"err", err)
+			"err", bindErr)
+	}
+	if quickCreateTaskID.Valid && set.QuickCreate != nil {
+		if bindErr != nil {
+			// Keep the task deferred. Its durable fire_at fallback will queue
+			// it after the media budget instead of racing a failed/ambiguous
+			// bind transaction.
+			return
+		}
+		if err := set.QuickCreate.PromoteQuickCreateChatTask(finalizeCtx, quickCreateTaskID); err != nil {
+			r.logger.Warn("channel router: quick-create media-ready promotion failed",
+				"channel_type", string(msg.Source.ChannelType),
+				"event_id", msg.EventID,
+				"message_id", msg.MessageID,
+				"task_id", uuidString(quickCreateTaskID),
+				"err", err)
+		}
+		return
 	}
 	if err := r.tasks.PromoteChannelChatTasksIfMediaReady(finalizeCtx, sessionID); err != nil {
 		r.logger.Warn("channel router: media-ready task promotion failed",

--- a/server/internal/integrations/channel/engine/router_test.go
+++ b/server/internal/integrations/channel/engine/router_test.go
@@ -309,6 +309,78 @@ func (f *fakeReader) GetWorkspace(_ context.Context, _ pgtype.UUID) (db.Workspac
 	return f.ws, nil
 }
 
+type fakeQuickCreator struct {
+	mu               sync.Mutex
+	task             db.AgentTaskQueue
+	enqueueErr       error
+	promoteErr       error
+	enqueueCalls     int
+	promoteCalls     int
+	prompt           string
+	chatSessionID    pgtype.UUID
+	chatMessageID    pgtype.UUID
+	mediaPending     bool
+	promotedTaskID   pgtype.UUID
+	promotionReached chan struct{}
+}
+
+func (f *fakeQuickCreator) EnqueueQuickCreateChatTask(_ context.Context, _, _, _ pgtype.UUID, prompt string, chatSessionID, chatMessageID pgtype.UUID, mediaPending bool) (db.AgentTaskQueue, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.enqueueCalls++
+	f.prompt = prompt
+	f.chatSessionID = chatSessionID
+	f.chatMessageID = chatMessageID
+	f.mediaPending = mediaPending
+	return f.task, f.enqueueErr
+}
+
+func (f *fakeQuickCreator) messageID() pgtype.UUID {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.chatMessageID
+}
+
+func (f *fakeQuickCreator) PromoteQuickCreateChatTask(_ context.Context, taskID pgtype.UUID) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.promoteCalls++
+	f.promotedTaskID = taskID
+	if f.promotionReached != nil {
+		close(f.promotionReached)
+		f.promotionReached = nil
+	}
+	return f.promoteErr
+}
+
+func (f *fakeQuickCreator) snapshot() (enqueueCalls, promoteCalls int, prompt string, mediaPending bool, promotedTaskID pgtype.UUID) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.enqueueCalls, f.promoteCalls, f.prompt, f.mediaPending, f.promotedTaskID
+}
+
+type fakeMessageAppender struct {
+	mu     sync.Mutex
+	params []db.CreateChatMessageParams
+}
+
+func (f *fakeMessageAppender) CreateChatMessage(_ context.Context, p db.CreateChatMessageParams) (db.ChatMessage, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.params = append(f.params, p)
+	return db.ChatMessage{}, nil
+}
+
+func (f *fakeMessageAppender) contents() []string {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	out := make([]string, 0, len(f.params))
+	for _, p := range f.params {
+		out = append(out, p.Content)
+	}
+	return out
+}
+
 // ---- harness ----
 
 func activeResolved(t *testing.T) ResolvedInstallation {
@@ -337,18 +409,20 @@ func p2pMessage(t *testing.T) channel.InboundMessage {
 }
 
 type harness struct {
-	router  *Router
-	inst    *fakeInstaller
-	ident   *fakeIdentity
-	dedup   *fakeDedup
-	binder  *fakeBinder
-	audit   *fakeAuditor
-	replier *fakeReplier
-	typing  *fakeTyping
-	media   *fakeMedia
-	issues  *fakeIssues
-	tasks   *fakeTasks
-	reader  *fakeReader
+	router   *Router
+	inst     *fakeInstaller
+	ident    *fakeIdentity
+	dedup    *fakeDedup
+	binder   *fakeBinder
+	audit    *fakeAuditor
+	replier  *fakeReplier
+	typing   *fakeTyping
+	media    *fakeMedia
+	issues   *fakeIssues
+	tasks    *fakeTasks
+	reader   *fakeReader
+	quick    *fakeQuickCreator
+	messages *fakeMessageAppender
 }
 
 func newHarness(t *testing.T) *harness {
@@ -364,15 +438,17 @@ func newHarness(t *testing.T) *harness {
 				DedupMarked: true,
 			},
 		},
-		audit:   &fakeAuditor{},
-		replier: &fakeReplier{},
-		typing:  &fakeTyping{},
-		media:   &fakeMedia{},
-		issues:  &fakeIssues{},
-		tasks:   &fakeTasks{},
-		reader:  &fakeReader{ws: db.Workspace{IssuePrefix: "MUL"}},
+		audit:    &fakeAuditor{},
+		replier:  &fakeReplier{},
+		typing:   &fakeTyping{},
+		media:    &fakeMedia{},
+		issues:   &fakeIssues{},
+		tasks:    &fakeTasks{},
+		reader:   &fakeReader{ws: db.Workspace{IssuePrefix: "MUL"}},
+		quick:    &fakeQuickCreator{task: db.AgentTaskQueue{ID: uuidFromString(t, "77777777-7777-4777-8777-777777777777")}},
+		messages: &fakeMessageAppender{},
 	}
-	h.router = NewRouter(h.issues, h.tasks, h.reader, RouterConfig{Logger: discardLogger()})
+	h.router = NewRouter(h.issues, h.tasks, h.reader, RouterConfig{Logger: discardLogger(), Messages: h.messages})
 	h.router.Register(channel.TypeFeishu, ResolverSet{
 		Installation: h.inst,
 		Identity:     h.ident,
@@ -385,6 +461,21 @@ func newHarness(t *testing.T) *harness {
 		OriginType:   "lark_chat",
 	})
 	return h
+}
+
+func (h *harness) enableQuickCreate() {
+	h.router.Register(channel.TypeFeishu, ResolverSet{
+		Installation: h.inst,
+		Identity:     h.ident,
+		Dedup:        h.dedup,
+		Session:      h.binder,
+		Audit:        h.audit,
+		Replier:      h.replier,
+		Typing:       h.typing,
+		Media:        h.media,
+		OriginType:   "lark_chat",
+		QuickCreate:  h.quick,
+	})
 }
 
 func TestRouter_NoResolverSet_ReturnsError(t *testing.T) {
@@ -986,6 +1077,7 @@ func TestRouter_AdapterFreshBodyIsNotParsedAgain(t *testing.T) {
 	msg := p2pMessage(t)
 	msg.ForceFresh = true
 	msg.Text = "<recent_context>\n/new from history\n</recent_context>\n\ncurrent prompt"
+	msg.CommandText = "/new current prompt"
 
 	if err := h.router.Handle(context.Background(), msg); err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -1210,5 +1302,133 @@ func TestRouter_MediaDeadlineStartsBeforeAppend(t *testing.T) {
 		}
 	case <-time.After(2 * time.Second):
 		t.Fatal("resolver did not run")
+	}
+}
+
+func TestRouter_QuickCreateQueuesWithoutSchedulingChatRun(t *testing.T) {
+	h := newHarness(t)
+	h.enableQuickCreate()
+	h.media.noMedia = true
+	h.binder.appendResult.IssueCommand = &IssueCommand{Title: "fix login"}
+
+	msg := p2pMessage(t)
+	msg.Text = "/issue fix login"
+	if err := h.router.Handle(context.Background(), msg); err != nil {
+		t.Fatalf("Handle: %v", err)
+	}
+	if !waitFor(time.Second, func() bool { return len(h.replier.calls()) == 1 }) {
+		t.Fatal("quick-create outcome reply missing")
+	}
+	enqueues, promotions, prompt, mediaPending, _ := h.quick.snapshot()
+	if enqueues != 1 || promotions != 0 {
+		t.Fatalf("quick-create calls = enqueue %d, promote %d", enqueues, promotions)
+	}
+	if prompt != "fix login" || mediaPending {
+		t.Fatalf("quick-create prompt=%q mediaPending=%v", prompt, mediaPending)
+	}
+	if h.quick.messageID() != h.binder.appendResult.MessageID {
+		t.Fatalf("quick-create message = %v, want %v", h.quick.messageID(), h.binder.appendResult.MessageID)
+	}
+	if h.tasks.wasCalled() {
+		t.Fatal("quick-create must not also schedule a normal chat run")
+	}
+	if h.typing.calls() != 0 {
+		t.Fatal("quick-create acknowledgement must not start normal chat typing")
+	}
+	if got := h.messages.contents(); len(got) != 1 || got[0] != IssueQueuedAckText {
+		t.Fatalf("assistant notes = %#v", got)
+	}
+	if results := h.replier.calls(); !results[0].IssueQueued || results[0].RunScheduled {
+		t.Fatalf("result = %+v", results[0])
+	}
+}
+
+func TestRouter_QuickCreateBareIssueShowsUsage(t *testing.T) {
+	h := newHarness(t)
+	h.enableQuickCreate()
+	h.media.noMedia = true
+	h.binder.appendResult.IssueCommand = &IssueCommand{}
+
+	msg := p2pMessage(t)
+	msg.Text = "/issue"
+	if err := h.router.Handle(context.Background(), msg); err != nil {
+		t.Fatalf("Handle: %v", err)
+	}
+	if !waitFor(time.Second, func() bool { return len(h.replier.calls()) == 1 }) {
+		t.Fatal("usage outcome reply missing")
+	}
+	enqueues, _, _, _, _ := h.quick.snapshot()
+	if enqueues != 0 {
+		t.Fatalf("bare /issue enqueues = %d, want 0", enqueues)
+	}
+	if got := h.messages.contents(); len(got) != 1 || got[0] != IssueUsageText {
+		t.Fatalf("assistant notes = %#v", got)
+	}
+	if !h.replier.calls()[0].IssueUsage {
+		t.Fatalf("result = %+v", h.replier.calls()[0])
+	}
+}
+
+func TestRouter_QuickCreateMediaBindsToDeferredTaskThenPromotes(t *testing.T) {
+	h := newHarness(t)
+	h.enableQuickCreate()
+	h.binder.appendResult.IssueCommand = &IssueCommand{Title: "broken screenshot"}
+
+	msg := p2pMessage(t)
+	msg.Text = "/issue broken screenshot [Image]"
+	if err := h.router.Handle(context.Background(), msg); err != nil {
+		t.Fatalf("Handle: %v", err)
+	}
+	if !waitFor(2*time.Second, func() bool {
+		_, promotions, _, _, _ := h.quick.snapshot()
+		return promotions == 1
+	}) {
+		t.Fatal("media-ready quick-create promotion missing")
+	}
+	enqueues, promotions, _, mediaPending, promotedTaskID := h.quick.snapshot()
+	if enqueues != 1 || promotions != 1 || !mediaPending {
+		t.Fatalf("quick-create calls = enqueue %d, promote %d, mediaPending=%v", enqueues, promotions, mediaPending)
+	}
+	if promotedTaskID != h.quick.task.ID {
+		t.Fatalf("promoted task = %v, want %v", promotedTaskID, h.quick.task.ID)
+	}
+	bound := h.binder.boundMedia()
+	if bound.QuickCreateTaskID != h.quick.task.ID {
+		t.Fatalf("media quick-create task = %v, want %v", bound.QuickCreateTaskID, h.quick.task.ID)
+	}
+	if len(bound.MediaRefs) != 1 {
+		t.Fatalf("bound media refs = %d, want 1", len(bound.MediaRefs))
+	}
+	if h.tasks.promotionCalls() != 0 {
+		t.Fatal("quick-create media must not promote normal chat tasks")
+	}
+}
+
+func TestRouter_QuickCreateEnqueueFailureClearsMediaMarkerWithoutResolving(t *testing.T) {
+	h := newHarness(t)
+	h.enableQuickCreate()
+	h.quick.enqueueErr = errors.New("queue unavailable")
+	h.binder.appendResult.IssueCommand = &IssueCommand{Title: "broken screenshot"}
+
+	msg := p2pMessage(t)
+	msg.Text = "/issue broken screenshot [Image]"
+	if err := h.router.Handle(context.Background(), msg); err != nil {
+		t.Fatalf("Handle: %v", err)
+	}
+	if !waitFor(time.Second, func() bool { return len(h.replier.calls()) == 1 }) {
+		t.Fatal("failure outcome reply missing")
+	}
+	if h.media.calls() != 0 {
+		t.Fatal("media must not resolve when the owning quick-create task failed to enqueue")
+	}
+	bound := h.binder.boundMedia()
+	if bound.MessageID != h.binder.appendResult.MessageID || len(bound.MediaRefs) != 0 {
+		t.Fatalf("marker clear bind = %+v", bound)
+	}
+	if !h.replier.calls()[0].IssueQueueFailed {
+		t.Fatalf("result = %+v", h.replier.calls()[0])
+	}
+	if got := h.messages.contents(); len(got) != 1 || got[0] != IssueQueueFailedText {
+		t.Fatalf("assistant notes = %#v", got)
 	}
 }

--- a/server/internal/integrations/channel/engine/session.go
+++ b/server/internal/integrations/channel/engine/session.go
@@ -274,11 +274,12 @@ type AppendInput struct {
 // short database-only transaction. Remote downloads/uploads happen before
 // this call and outside the connector ACK path.
 type BindMediaInput struct {
-	MessageID   pgtype.UUID
-	SessionID   pgtype.UUID
-	WorkspaceID pgtype.UUID
-	Sender      pgtype.UUID
-	MediaRefs   []channel.MediaRef
+	MessageID         pgtype.UUID
+	SessionID         pgtype.UUID
+	WorkspaceID       pgtype.UUID
+	Sender            pgtype.UUID
+	MediaRefs         []channel.MediaRef
+	QuickCreateTaskID pgtype.UUID
 }
 
 // AppendUserMessage writes the user message into the chat_session (touching it
@@ -364,10 +365,12 @@ func (s *ChatSession) AppendUserMessage(ctx context.Context, in AppendInput) (Ap
 	return AppendResult{MessageID: msg.ID, IssueCommand: cmd, DedupMarked: markedInTx}, nil
 }
 
-// BindMediaRefs creates attachment rows, links them to an existing durable chat
-// message, and clears its media-pending marker. A link failure rolls back the
-// attachment rows, then clears the marker separately so the placeholder can be
-// promoted immediately for graceful degradation.
+// BindMediaRefs creates attachment rows and clears the message's media-pending
+// marker. Normal chat media is linked to the durable chat message; quick-create
+// media remains task-owned until the issue is created or the terminal failure
+// path restores it to the original message. A bind failure rolls back the
+// attachment rows, then clears the marker separately so the task can fall back
+// to the persisted deadline.
 func (s *ChatSession) BindMediaRefs(ctx context.Context, in BindMediaInput) error {
 	tx, err := s.tx.Begin(ctx)
 	if err != nil {
@@ -461,7 +464,8 @@ func (s *ChatSession) bindMediaRefs(ctx context.Context, qtx SessionQueries, in 
 		att, err := qtx.CreateAttachment(ctx, db.CreateAttachmentParams{
 			ID:            pgtype.UUID{Bytes: id, Valid: true},
 			WorkspaceID:   in.WorkspaceID,
-			ChatSessionID: in.SessionID,
+			ChatSessionID: pgtype.UUID{Bytes: in.SessionID.Bytes, Valid: in.SessionID.Valid && !in.QuickCreateTaskID.Valid},
+			TaskID:        in.QuickCreateTaskID,
 			UploaderType:  "member",
 			UploaderID:    in.Sender,
 			Filename:      filename,
@@ -470,11 +474,11 @@ func (s *ChatSession) bindMediaRefs(ctx context.Context, qtx SessionQueries, in 
 			SizeBytes:     ref.SizeBytes,
 		})
 		if err != nil {
-			return fmt.Errorf("create chat attachment: %w", err)
+			return fmt.Errorf("create channel attachment: %w", err)
 		}
 		ids = append(ids, att.ID)
 	}
-	if len(ids) == 0 {
+	if len(ids) == 0 || in.QuickCreateTaskID.Valid {
 		return nil
 	}
 	if _, err := qtx.LinkAttachmentsToChatMessage(ctx, db.LinkAttachmentsToChatMessageParams{

--- a/server/internal/integrations/channel/engine/session_db_test.go
+++ b/server/internal/integrations/channel/engine/session_db_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgtype"
 	"github.com/jackc/pgx/v5/pgxpool"
@@ -153,6 +154,76 @@ func TestBindMediaRefs_PersistsAndLinksAttachmentToDurableMessage(t *testing.T) 
 	}
 	if !channelIngested {
 		t.Fatal("channel append must stamp channel_ingested for the cancel-path provenance gate")
+	}
+}
+
+func TestBindMediaRefs_QuickCreatePersistsTaskOwnedAttachment(t *testing.T) {
+	pool := sessionPersistenceTestDB(t)
+	fixture := seedSessionPersistenceFixture(t, pool)
+	session := NewChatSession(db.New(pool), pool, channel.TypeFeishu, SessionTitles{})
+
+	appendRes, err := session.AppendUserMessage(context.Background(), AppendInput{
+		SessionID:           fixture.sessionID,
+		Sender:              fixture.userID,
+		Body:                "/issue Fix image upload",
+		MediaPendingSeconds: 60,
+	})
+	if err != nil {
+		t.Fatalf("AppendUserMessage: %v", err)
+	}
+	taskUUID, err := uuid.NewV7()
+	if err != nil {
+		t.Fatalf("new task UUID: %v", err)
+	}
+	taskID := pgtype.UUID{Bytes: taskUUID, Valid: true}
+	seedPendingMediaObject(t, pool, fixture, appendRes.MessageID, "workspaces/ws/lark/quick-create", "https://cdn.example.test/quick-create.png", "pending")
+
+	err = session.BindMediaRefs(context.Background(), BindMediaInput{
+		MessageID:         appendRes.MessageID,
+		SessionID:         fixture.sessionID,
+		WorkspaceID:       fixture.workspaceID,
+		Sender:            fixture.userID,
+		QuickCreateTaskID: taskID,
+		MediaRefs: []channel.MediaRef{{
+			Type:       channel.MsgTypeImage,
+			StorageKey: "workspaces/ws/lark/quick-create",
+			StorageURL: "https://cdn.example.test/quick-create.png",
+			Filename:   "quick-create.png",
+			MimeType:   "image/png",
+			SizeBytes:  5,
+		}},
+	})
+	if err != nil {
+		t.Fatalf("BindMediaRefs: %v", err)
+	}
+	if _, exists := pendingMediaObjectState(t, pool, "workspaces/ws/lark/quick-create"); exists {
+		t.Fatal("quick-create bind must clear the intent row in the same transaction")
+	}
+
+	var gotTaskID, chatSessionID, chatMessageID, issueID pgtype.UUID
+	if err := pool.QueryRow(context.Background(), `
+		SELECT task_id, chat_session_id, chat_message_id, issue_id
+		FROM attachment
+		WHERE task_id = $1`, taskID).
+		Scan(&gotTaskID, &chatSessionID, &chatMessageID, &issueID); err != nil {
+		t.Fatalf("load task-owned attachment: %v", err)
+	}
+	if gotTaskID != taskID {
+		t.Fatalf("task_id = %v, want %v", gotTaskID, taskID)
+	}
+	if chatSessionID.Valid || chatMessageID.Valid || issueID.Valid {
+		t.Fatalf("quick-create attachment has competing owner: session=%v message=%v issue=%v", chatSessionID, chatMessageID, issueID)
+	}
+
+	var mediaPendingUntil pgtype.Timestamptz
+	if err := pool.QueryRow(context.Background(), `
+		SELECT channel_media_pending_until
+		FROM chat_message
+		WHERE id = $1`, appendRes.MessageID).Scan(&mediaPendingUntil); err != nil {
+		t.Fatalf("load media marker: %v", err)
+	}
+	if mediaPendingUntil.Valid {
+		t.Fatalf("media pending deadline was not cleared: %v", mediaPendingUntil.Time)
 	}
 }
 

--- a/server/internal/integrations/channel/engine/session_test.go
+++ b/server/internal/integrations/channel/engine/session_test.go
@@ -380,6 +380,45 @@ func TestBindMediaRefs_CreatesAndLinksChatAttachments(t *testing.T) {
 	}
 }
 
+func TestBindMediaRefs_QuickCreateOwnsAttachmentsByTask(t *testing.T) {
+	f := newFake()
+	s := newTestSession(f)
+	err := s.BindMediaRefs(context.Background(), BindMediaInput{
+		MessageID:         uid(42),
+		SessionID:         uid(1),
+		WorkspaceID:       uid(9),
+		Sender:            uid(7),
+		QuickCreateTaskID: uid(8),
+		MediaRefs: []channel.MediaRef{{
+			Type:       channel.MsgTypeImage,
+			StorageKey: "channels/quick-create/image.png",
+			StorageURL: "https://cdn.example.test/quick-create/image.png",
+			Filename:   "screenshot.png",
+			MimeType:   "image/png",
+			SizeBytes:  3,
+		}},
+	})
+	if err != nil {
+		t.Fatalf("BindMediaRefs: %v", err)
+	}
+	if len(f.attachments) != 1 {
+		t.Fatalf("attachments created = %d, want 1", len(f.attachments))
+	}
+	att := f.attachments[0]
+	if att.TaskID != uid(8) {
+		t.Fatalf("task_id = %v, want %v", att.TaskID, uid(8))
+	}
+	if att.ChatSessionID.Valid {
+		t.Fatalf("quick-create attachment must not carry cascade-prone chat_session_id: %v", att.ChatSessionID)
+	}
+	if f.linked.ChatMessageID.Valid {
+		t.Fatalf("quick-create attachment must not be linked to chat_message: %+v", f.linked)
+	}
+	if f.mediaCleared != 1 {
+		t.Fatalf("media marker clears = %d, want 1", f.mediaCleared)
+	}
+}
+
 func TestAppendUserMessage_BareIssueUsesPreviousMessage(t *testing.T) {
 	f := newFake()
 	prev := "Make the export button work"

--- a/server/internal/integrations/channel/message.go
+++ b/server/internal/integrations/channel/message.go
@@ -134,9 +134,10 @@ type InboundMessage struct {
 	// itself is in MediaRefs.
 	Text string
 
-	// CommandText is the user's normalized text before command stripping or
-	// contextual enrichment. Shared command classifiers read this field so a
-	// rewritten Text is never interpreted as a second command. Empty means Text.
+	// CommandText is the user's normalized text before contextual enrichment.
+	// Shared command classifiers such as /new and /issue read this field so a
+	// rewritten Text is never interpreted as another command or handed to a
+	// background task as the user's prompt. Empty falls back to Text.
 	CommandText string
 
 	// MediaRefs is the OUTPUT channel of engine.MediaResolver.ResolveMedia:

--- a/server/internal/integrations/lark/feishu_channel.go
+++ b/server/internal/integrations/lark/feishu_channel.go
@@ -127,6 +127,10 @@ func installationCredentialsFor(inst Installation, resolver CredentialsResolver)
 // the normalized CommandText field because command classification is shared.
 func channelMessageFromLark(lm InboundMessage) channel.InboundMessage {
 	raw, _ := json.Marshal(lm)
+	commandText := lm.CommandBody
+	if commandText == "" {
+		commandText = lm.Body
+	}
 	var reply *channel.ReplyCtx
 	if lm.ParentID != "" || lm.RootID != "" {
 		reply = &channel.ReplyCtx{MessageID: lm.ParentID, RootID: lm.RootID}
@@ -136,7 +140,7 @@ func channelMessageFromLark(lm InboundMessage) channel.InboundMessage {
 		MessageID:      lm.MessageID,
 		Type:           channelMsgType(lm.MessageType),
 		Text:           lm.Body,
-		CommandText:    lm.CommandBody,
+		CommandText:    commandText,
 		ReplyTo:        reply,
 		AddressedToBot: lm.AddressedToBot,
 		ForceFresh:     lm.ForceFreshSession,

--- a/server/internal/integrations/lark/feishu_channel_test.go
+++ b/server/internal/integrations/lark/feishu_channel_test.go
@@ -719,6 +719,9 @@ func TestChannelMessageFromLark_NormalizesAndStashesRaw(t *testing.T) {
 	if cm.EventID != "evt" || cm.MessageID != "om" || cm.Text != "enriched body" || cm.CommandText != "/issue do it" {
 		t.Fatalf("scalar fields not mapped: %+v", cm)
 	}
+	if cm.CommandText != "/issue do it" {
+		t.Fatalf("command fields not mapped: %+v", cm)
+	}
 	if cm.Type != channel.MsgTypeText {
 		t.Fatalf("post must normalize to text, got %q", cm.Type)
 	}
@@ -741,6 +744,31 @@ func TestChannelMessageFromLark_NormalizesAndStashesRaw(t *testing.T) {
 	}
 	if got.AppID != "cli" || got.CommandBody != "/issue do it" || got.MessageType != "post" {
 		t.Fatalf("raw round-trip lost platform fields: %+v", got)
+	}
+}
+
+func TestChannelMessageFromLark_PreservesFreshCommandBeforeEnrichment(t *testing.T) {
+	cm := channelMessageFromLark(InboundMessage{
+		Body:              "<quoted_message>old context</quoted_message>",
+		CommandBody:       "/new",
+		ForceFreshSession: true,
+	})
+	if !cm.ForceFresh {
+		t.Fatal("fresh flag was not mapped")
+	}
+	if cm.CommandText != "/new" {
+		t.Fatalf("command text = %q, want original command source", cm.CommandText)
+	}
+}
+
+func TestChannelMessageFromLark_PreservesFreshIssueCommandText(t *testing.T) {
+	cm := channelMessageFromLark(InboundMessage{
+		Body:              "<quoted_message>old context</quoted_message>\n/issue create follow-up",
+		CommandBody:       "/new /issue create follow-up",
+		ForceFreshSession: true,
+	})
+	if cm.CommandText != "/new /issue create follow-up" {
+		t.Fatalf("command text = %q", cm.CommandText)
 	}
 }
 

--- a/server/internal/integrations/lark/feishu_resolvers.go
+++ b/server/internal/integrations/lark/feishu_resolvers.go
@@ -222,11 +222,12 @@ func (r *feishuSessionBinder) AppendMessage(ctx context.Context, p engine.Append
 
 func (r *feishuSessionBinder) BindMedia(ctx context.Context, p engine.BindMediaParams) error {
 	return r.session.BindMediaRefs(ctx, engine.BindMediaInput{
-		MessageID:   p.MessageID,
-		SessionID:   p.SessionID,
-		WorkspaceID: p.WorkspaceID,
-		Sender:      p.Sender,
-		MediaRefs:   p.MediaRefs,
+		MessageID:         p.MessageID,
+		SessionID:         p.SessionID,
+		WorkspaceID:       p.WorkspaceID,
+		Sender:            p.Sender,
+		MediaRefs:         p.MediaRefs,
+		QuickCreateTaskID: p.QuickCreateTaskID,
 	})
 }
 

--- a/server/internal/integrations/slack/resolvers.go
+++ b/server/internal/integrations/slack/resolvers.go
@@ -353,11 +353,12 @@ func (r *sessionBinder) AppendMessage(ctx context.Context, p engine.AppendParams
 
 func (r *sessionBinder) BindMedia(ctx context.Context, p engine.BindMediaParams) error {
 	return r.session.BindMediaRefs(ctx, engine.BindMediaInput{
-		MessageID:   p.MessageID,
-		SessionID:   p.SessionID,
-		WorkspaceID: p.WorkspaceID,
-		Sender:      p.Sender,
-		MediaRefs:   p.MediaRefs,
+		MessageID:         p.MessageID,
+		SessionID:         p.SessionID,
+		WorkspaceID:       p.WorkspaceID,
+		Sender:            p.Sender,
+		MediaRefs:         p.MediaRefs,
+		QuickCreateTaskID: p.QuickCreateTaskID,
 	})
 }
 

--- a/server/internal/service/attribution_stamp_test.go
+++ b/server/internal/service/attribution_stamp_test.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"testing"
@@ -1264,6 +1265,145 @@ func TestEnqueueChatTaskStampsChatEvidence(t *testing.T) {
 	}
 	if !evidenceRef.Valid || evidenceRef.Bytes != util.MustParseUUID(chatSessionID).Bytes {
 		t.Errorf("trigger_evidence_ref_id = %s, want chat session %s", util.UUIDToString(evidenceRef), chatSessionID)
+	}
+}
+
+func TestEnqueueQuickCreateChatTaskPersistsRoutingEvidenceAndDeferral(t *testing.T) {
+	pool := newResolveOriginatorPool(t)
+	ctx := context.Background()
+	q := db.New(pool)
+	workspaceID, userID, agentID, _ := seedAttributionFixture(t, pool)
+
+	var chatSessionID, chatMessageID string
+	if err := pool.QueryRow(ctx, `
+		INSERT INTO chat_session (workspace_id, agent_id, creator_id)
+		VALUES ($1, $2, $3) RETURNING id`, workspaceID, agentID, userID).Scan(&chatSessionID); err != nil {
+		t.Fatalf("seed chat session: %v", err)
+	}
+	t.Cleanup(func() {
+		_, _ = pool.Exec(context.Background(), `DELETE FROM chat_session WHERE id = $1`, chatSessionID)
+	})
+	deadline := time.Now().Add(time.Minute)
+	if err := pool.QueryRow(ctx, `
+		INSERT INTO chat_message (
+			chat_session_id, role, content, channel_media_pending_until, channel_ingested
+		)
+		VALUES ($1, 'user', '/issue inspect the screenshot', $2, true)
+		RETURNING id`, chatSessionID, deadline).Scan(&chatMessageID); err != nil {
+		t.Fatalf("seed channel message: %v", err)
+	}
+
+	svc := &TaskService{Queries: q, TxStarter: pool, Bus: events.New()}
+	task, err := svc.EnqueueQuickCreateChatTask(
+		ctx,
+		util.MustParseUUID(workspaceID),
+		util.MustParseUUID(userID),
+		util.MustParseUUID(agentID),
+		"inspect the screenshot",
+		util.MustParseUUID(chatSessionID),
+		util.MustParseUUID(chatMessageID),
+		true,
+	)
+	if err != nil {
+		t.Fatalf("EnqueueQuickCreateChatTask: %v", err)
+	}
+	t.Cleanup(func() {
+		_, _ = pool.Exec(context.Background(), `DELETE FROM agent_task_queue WHERE id = $1`, task.ID)
+	})
+	if task.Status != "deferred" || !task.FireAt.Valid {
+		t.Fatalf("task = status %q fire_at %v, want deferred", task.Status, task.FireAt)
+	}
+	if task.FireAt.Time.Before(deadline.Add(-time.Second)) || task.FireAt.Time.After(deadline.Add(time.Second)) {
+		t.Fatalf("task fire_at = %v, want %v", task.FireAt.Time, deadline)
+	}
+
+	var linkedTaskID pgtype.UUID
+	if err := pool.QueryRow(ctx, `SELECT task_id FROM chat_message WHERE id = $1`, chatMessageID).Scan(&linkedTaskID); err != nil {
+		t.Fatalf("load linked message: %v", err)
+	}
+	if linkedTaskID != task.ID {
+		t.Fatalf("message task_id = %s, want %s", util.UUIDToString(linkedTaskID), util.UUIDToString(task.ID))
+	}
+
+	var qc QuickCreateContext
+	if err := json.Unmarshal(task.Context, &qc); err != nil {
+		t.Fatalf("decode quick-create context: %v", err)
+	}
+	if qc.ChatSessionID != chatSessionID || qc.ChatMessageID != chatMessageID {
+		t.Fatalf("quick-create routing = session:%q message:%q", qc.ChatSessionID, qc.ChatMessageID)
+	}
+
+	var source, evidenceKind pgtype.Text
+	var originator, accountable, evidenceRef pgtype.UUID
+	if err := pool.QueryRow(ctx, `
+		SELECT originator_source, originator_user_id, accountable_user_id,
+		       trigger_evidence_kind, trigger_evidence_ref_id
+		FROM agent_task_queue WHERE id = $1`, task.ID).
+		Scan(&source, &originator, &accountable, &evidenceKind, &evidenceRef); err != nil {
+		t.Fatalf("read stored attribution: %v", err)
+	}
+	if source.String != string(attribution.SourceDirectHuman) ||
+		originator != util.MustParseUUID(userID) ||
+		accountable != originator ||
+		evidenceKind.String != string(attribution.EvidenceChat) ||
+		evidenceRef != util.MustParseUUID(chatSessionID) {
+		t.Fatalf("stored attribution = source:%q originator:%s accountable:%s evidence:%q/%s",
+			source.String,
+			util.UUIDToString(originator),
+			util.UUIDToString(accountable),
+			evidenceKind.String,
+			util.UUIDToString(evidenceRef))
+	}
+
+	if err := svc.PromoteQuickCreateChatTask(ctx, task.ID); err != nil {
+		t.Fatalf("PromoteQuickCreateChatTask: %v", err)
+	}
+	var status string
+	var fireAt pgtype.Timestamptz
+	if err := pool.QueryRow(ctx, `SELECT status, fire_at FROM agent_task_queue WHERE id = $1`, task.ID).Scan(&status, &fireAt); err != nil {
+		t.Fatalf("load promoted task: %v", err)
+	}
+	if status != "queued" || fireAt.Valid {
+		t.Fatalf("promoted task = status %q fire_at %v, want queued without deadline", status, fireAt)
+	}
+
+	var retryTaskID pgtype.UUID
+	if err := pool.QueryRow(ctx, `
+		INSERT INTO agent_task_queue (
+			agent_id, runtime_id, status, priority, context, parent_task_id
+		)
+		SELECT agent_id, runtime_id, 'failed', priority, context, id
+		FROM agent_task_queue
+		WHERE id = $1
+		RETURNING id`, task.ID).Scan(&retryTaskID); err != nil {
+		t.Fatalf("seed failed retry: %v", err)
+	}
+	t.Cleanup(func() {
+		_, _ = pool.Exec(context.Background(), `DELETE FROM agent_task_queue WHERE id = $1`, retryTaskID)
+	})
+	var attachmentID pgtype.UUID
+	if err := pool.QueryRow(ctx, `
+		INSERT INTO attachment (
+			workspace_id, task_id, uploader_type, uploader_id,
+			filename, url, content_type, size_bytes
+		)
+		VALUES ($1, $2, 'member', $3, 'retry.png', 'https://example.test/retry.png', 'image/png', 3)
+		RETURNING id`, workspaceID, task.ID, userID).Scan(&attachmentID); err != nil {
+		t.Fatalf("seed ancestor-owned attachment: %v", err)
+	}
+
+	svc.preserveFailedQuickCreateAttachments(ctx, db.AgentTaskQueue{ID: retryTaskID}, qc)
+	var restoredSessionID, restoredMessageID pgtype.UUID
+	if err := pool.QueryRow(ctx, `
+		SELECT chat_session_id, chat_message_id
+		FROM attachment
+		WHERE id = $1`, attachmentID).Scan(&restoredSessionID, &restoredMessageID); err != nil {
+		t.Fatalf("load restored attachment: %v", err)
+	}
+	if restoredSessionID != util.MustParseUUID(chatSessionID) ||
+		restoredMessageID != util.MustParseUUID(chatMessageID) {
+		t.Fatalf("restored attachment = session:%s message:%s",
+			util.UUIDToString(restoredSessionID), util.UUIDToString(restoredMessageID))
 	}
 }
 

--- a/server/internal/service/task.go
+++ b/server/internal/service/task.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"net/url"
 	"strconv"
 	"strings"
 	"sync"
@@ -57,6 +58,9 @@ type TaskService struct {
 	// exactly as before. Wired in router.go after composiointeg.NewService
 	// succeeds; the concrete type is *composio.Service.
 	Composio ComposioOverlayBuilder
+	// AppURL is the web-app base URL used to build issue links posted back
+	// into channel conversations. Empty omits the link.
+	AppURL string
 	// QuickActions generates chat follow-up suggestions through the
 	// server-internal LLM layer. Optional: nil (or a disabled client) turns the
 	// whole feature off — no pending marker, no pills — which is the expected
@@ -1306,10 +1310,64 @@ type QuickCreateContext struct {
 	// pass `--parent <uuid>` so the sub-issue relationship is preserved
 	// across the manual→agent mode flip.
 	ParentIssueID string `json:"parent_issue_id,omitempty"`
+	// ChatSessionID is set for channel-originated /issue quick-create tasks so
+	// terminal outcomes can be appended and delivered to that conversation.
+	ChatSessionID string `json:"chat_session_id,omitempty"`
+	// ChatMessageID identifies the original channel user message. If every
+	// quick-create attempt fails, task-owned media is returned to this message
+	// instead of remaining permanently ownerless.
+	ChatMessageID string `json:"chat_message_id,omitempty"`
 }
 
 // QuickCreateContextType marks a task as a quick-create job.
 const QuickCreateContextType = "quick_create"
+
+type quickCreateEnqueueInput struct {
+	WorkspaceID   pgtype.UUID
+	RequesterID   pgtype.UUID
+	SquadID       pgtype.UUID
+	ProjectID     pgtype.UUID
+	ParentIssueID pgtype.UUID
+	ChatSessionID pgtype.UUID
+	ChatMessageID pgtype.UUID
+	Prompt        string
+	Priority      string
+	DueDate       string
+	AttachmentIDs []pgtype.UUID
+	MediaPending  bool
+}
+
+func buildQuickCreateContext(in quickCreateEnqueueInput) QuickCreateContext {
+	payload := QuickCreateContext{
+		Type:        QuickCreateContextType,
+		Prompt:      in.Prompt,
+		RequesterID: util.UUIDToString(in.RequesterID),
+		WorkspaceID: util.UUIDToString(in.WorkspaceID),
+		Priority:    in.Priority,
+		DueDate:     in.DueDate,
+	}
+	if in.ProjectID.Valid {
+		payload.ProjectID = util.UUIDToString(in.ProjectID)
+	}
+	if in.SquadID.Valid {
+		payload.SquadID = util.UUIDToString(in.SquadID)
+	}
+	if in.ParentIssueID.Valid {
+		payload.ParentIssueID = util.UUIDToString(in.ParentIssueID)
+	}
+	if in.ChatSessionID.Valid {
+		payload.ChatSessionID = util.UUIDToString(in.ChatSessionID)
+	}
+	if in.ChatMessageID.Valid {
+		payload.ChatMessageID = util.UUIDToString(in.ChatMessageID)
+	}
+	for _, id := range in.AttachmentIDs {
+		if id.Valid {
+			payload.AttachmentIDs = append(payload.AttachmentIDs, util.UUIDToString(id))
+		}
+	}
+	return payload
+}
 
 // EnqueueQuickCreateTask creates a queued task that has no issue / chat /
 // autopilot link — the user's natural-language prompt is stored in the
@@ -1331,6 +1389,35 @@ const QuickCreateContextType = "quick_create"
 // open the modal from "Add sub issue"). The handler is responsible for
 // validating it belongs to the same workspace before passing it in.
 func (s *TaskService) EnqueueQuickCreateTask(ctx context.Context, workspaceID, requesterID pgtype.UUID, agentID, squadID pgtype.UUID, prompt, priority, dueDate string, projectID, parentIssueID pgtype.UUID, attachmentIDs []pgtype.UUID) (db.AgentTaskQueue, error) {
+	return s.enqueueQuickCreate(ctx, agentID, quickCreateEnqueueInput{
+		WorkspaceID:   workspaceID,
+		RequesterID:   requesterID,
+		SquadID:       squadID,
+		ProjectID:     projectID,
+		ParentIssueID: parentIssueID,
+		Prompt:        prompt,
+		Priority:      priority,
+		DueDate:       dueDate,
+		AttachmentIDs: attachmentIDs,
+	})
+}
+
+// EnqueueQuickCreateChatTask creates the channel-chat variant of a quick-create
+// task. It remains context-owned (not a normal chat task), while ChatSessionID
+// routes terminal replies back to the conversation. Media-bearing tasks start
+// deferred until the channel media pipeline binds task-owned attachments.
+func (s *TaskService) EnqueueQuickCreateChatTask(ctx context.Context, workspaceID, requesterID, agentID pgtype.UUID, prompt string, chatSessionID, chatMessageID pgtype.UUID, mediaPending bool) (db.AgentTaskQueue, error) {
+	return s.enqueueQuickCreate(ctx, agentID, quickCreateEnqueueInput{
+		WorkspaceID:   workspaceID,
+		RequesterID:   requesterID,
+		ChatSessionID: chatSessionID,
+		ChatMessageID: chatMessageID,
+		Prompt:        prompt,
+		MediaPending:  mediaPending,
+	})
+}
+
+func (s *TaskService) enqueueQuickCreate(ctx context.Context, agentID pgtype.UUID, in quickCreateEnqueueInput) (db.AgentTaskQueue, error) {
 	agent, err := s.Queries.GetAgent(ctx, agentID)
 	if err != nil {
 		return db.AgentTaskQueue{}, fmt.Errorf("load agent: %w", err)
@@ -1342,45 +1429,24 @@ func (s *TaskService) EnqueueQuickCreateTask(ctx context.Context, workspaceID, r
 		return db.AgentTaskQueue{}, fmt.Errorf("agent has no runtime")
 	}
 
-	payload := QuickCreateContext{
-		Type:        QuickCreateContextType,
-		Prompt:      prompt,
-		RequesterID: util.UUIDToString(requesterID),
-		WorkspaceID: util.UUIDToString(workspaceID),
-		Priority:    priority,
-		DueDate:     dueDate,
-	}
-	if projectID.Valid {
-		payload.ProjectID = util.UUIDToString(projectID)
-	}
-	if squadID.Valid {
-		payload.SquadID = util.UUIDToString(squadID)
-	}
-	if parentIssueID.Valid {
-		payload.ParentIssueID = util.UUIDToString(parentIssueID)
-	}
-	if len(attachmentIDs) > 0 {
-		payload.AttachmentIDs = make([]string, 0, len(attachmentIDs))
-		for _, id := range attachmentIDs {
-			if id.Valid {
-				payload.AttachmentIDs = append(payload.AttachmentIDs, util.UUIDToString(id))
-			}
-		}
-	}
+	payload := buildQuickCreateContext(in)
 	contextJSON, err := json.Marshal(payload)
 	if err != nil {
 		return db.AgentTaskQueue{}, fmt.Errorf("marshal quick-create context: %w", err)
 	}
 
-	// The requester who submitted the quick-create modal is the direct_human
-	// originator and accountable. Quick-create is the ONE enqueue path with no
-	// antecedent row to point the uniform evidence pair at: the run's whole job is
-	// to CREATE the issue, so at enqueue time there is no comment / issue / session
-	// / run to reference (the issue is linked back later via LinkTaskToIssue).
-	// Evidence is therefore intentionally NULL; the accountable human is captured on
-	// originator/accountable_user_id, so this is not a NULL-source bypass — source
-	// is still stamped direct_human (MUL-4302 §2).
-	attr := attribution.DirectHumanRun(requesterID, "", pgtype.UUID{})
+	// The requester is the direct_human originator and accountable. Web modal
+	// quick-create has no antecedent row, so its evidence remains NULL until
+	// LinkTaskToIssue runs. A channel quick-create does have a durable
+	// chat_session and uses it as the uniform evidence pair, matching normal
+	// channel chat tasks (MUL-4302 §2).
+	var evidenceKind attribution.EvidenceKind
+	var evidenceRefID pgtype.UUID
+	if in.ChatSessionID.Valid {
+		evidenceKind = attribution.EvidenceChat
+		evidenceRefID = in.ChatSessionID
+	}
+	attr := attribution.DirectHumanRun(in.RequesterID, evidenceKind, evidenceRefID)
 	// An unresolved requester degrades to owner_fallback (accountable = agent
 	// owner), or is refused if the workspace is fail-closed (MUL-4302 §3.5).
 	attr, err = s.applyAttributionFallback(ctx, attr, agent)
@@ -1388,40 +1454,91 @@ func (s *TaskService) EnqueueQuickCreateTask(ctx context.Context, workspaceID, r
 		return db.AgentTaskQueue{}, err
 	}
 	attrSource, _, attrEvidenceKind, attrEvidenceRef := attributionCreateParams(attr)
-	runtimeMCPOverlay := s.buildRuntimeMCPOverlay(ctx, requesterID, agent)
-	task, err := s.Queries.CreateQuickCreateTask(ctx, db.CreateQuickCreateTaskParams{
+	runtimeMCPOverlay := s.buildRuntimeMCPOverlay(ctx, in.RequesterID, agent)
+	var fireAt pgtype.Timestamptz
+	if in.MediaPending {
+		fireAt, err = s.Queries.GetChannelMediaPendingUntil(ctx, in.ChatSessionID)
+		if errors.Is(err, pgx.ErrNoRows) {
+			return db.AgentTaskQueue{}, errors.New("quick-create media marker missing")
+		}
+		if err != nil {
+			return db.AgentTaskQueue{}, fmt.Errorf("load quick-create media pending deadline: %w", err)
+		}
+	}
+	q := s.Queries
+	var tx pgx.Tx
+	if in.ChatMessageID.Valid {
+		tx, err = s.TxStarter.Begin(ctx)
+		if err != nil {
+			return db.AgentTaskQueue{}, fmt.Errorf("begin channel quick-create enqueue: %w", err)
+		}
+		defer tx.Rollback(ctx)
+		q = s.Queries.WithTx(tx)
+	}
+	task, err := q.CreateQuickCreateTask(ctx, db.CreateQuickCreateTaskParams{
 		AgentID:              agentID,
 		RuntimeID:            agent.RuntimeID,
 		Priority:             priorityToInt("high"),
 		Context:              contextJSON,
-		OriginatorUserID:     requesterID,
+		OriginatorUserID:     in.RequesterID,
 		AccountableUserID:    attr.AccountableUserID,
 		RuntimeMcpOverlay:    runtimeMCPOverlay.Overlay,
 		RuntimeConnectedApps: runtimeMCPOverlay.ConnectedApps,
 		OriginatorSource:     attrSource,
 		TriggerEvidenceKind:  attrEvidenceKind,
 		TriggerEvidenceRefID: attrEvidenceRef,
+		FireAt:               fireAt,
 	})
 	if err != nil {
 		return db.AgentTaskQueue{}, fmt.Errorf("create quick-create task: %w", err)
+	}
+	if in.ChatMessageID.Valid {
+		if _, err := q.LinkChatMessageToTask(ctx, db.LinkChatMessageToTaskParams{
+			ID:     in.ChatMessageID,
+			TaskID: task.ID,
+		}); err != nil {
+			return db.AgentTaskQueue{}, fmt.Errorf("link channel quick-create message: %w", err)
+		}
+		if err := tx.Commit(ctx); err != nil {
+			return db.AgentTaskQueue{}, fmt.Errorf("commit channel quick-create enqueue: %w", err)
+		}
 	}
 
 	slog.Info("quick-create task enqueued",
 		"task_id", util.UUIDToString(task.ID),
 		"agent_id", util.UUIDToString(agentID),
 		"squad_id", payload.SquadID,
-		"requester_id", util.UUIDToString(requesterID),
-		"workspace_id", util.UUIDToString(workspaceID),
+		"requester_id", payload.RequesterID,
+		"workspace_id", payload.WorkspaceID,
 		"project_id", payload.ProjectID,
 		"parent_issue_id", payload.ParentIssueID,
+		"chat_session_id", payload.ChatSessionID,
+		"status", task.Status,
 	)
 	// Match every other Enqueue* path: kick the daemon WS so the task
 	// gets claimed promptly instead of waiting for the next 30 s poll
 	// cycle. Without this the user perceives "quick create never
 	// triggered" because the modal closes immediately and the task
 	// sits in 'queued' until the next sleepWithContextOrWakeup tick.
-	s.NotifyTaskEnqueued(ctx, task)
+	if task.Status == "queued" {
+		s.NotifyTaskEnqueued(ctx, task)
+	}
 	return task, nil
+}
+
+// PromoteQuickCreateChatTask releases a media-deferred channel quick-create.
+// If its deadline already promoted or claimed it, pgx.ErrNoRows is a no-op.
+func (s *TaskService) PromoteQuickCreateChatTask(ctx context.Context, taskID pgtype.UUID) error {
+	task, err := s.Queries.PromoteQuickCreateTaskAfterMedia(ctx, taskID)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("promote quick-create task after media: %w", err)
+	}
+	s.broadcastTaskEvent(ctx, protocol.EventTaskQueued, task)
+	s.NotifyTaskEnqueued(ctx, task)
+	return nil
 }
 
 // ErrChatTaskAgentArchived signals that EnqueueChatTask refused to
@@ -4733,6 +4850,138 @@ func quickCreateFailureDetail(result []byte) string {
 	return body
 }
 
+const quickCreateReplyQuoteLimit = 1000
+
+const quickCreateChatFailedReasonText = "⚠️ I couldn't create the issue from your /issue request."
+
+const quickCreateChatFailedText = quickCreateChatFailedReasonText + " Please try again."
+
+func truncateRunes(s string, limit int) string {
+	runes := []rune(s)
+	if len(runes) <= limit {
+		return s
+	}
+	return string(runes[:limit]) + "…"
+}
+
+func buildQuickCreateDoneReply(identifier, title, link string) string {
+	var b strings.Builder
+	b.WriteString("✅ " + identifier)
+	if title != "" {
+		b.WriteString(" — " + title)
+	}
+	if link != "" {
+		b.WriteString("\n\n" + link)
+	}
+	return b.String()
+}
+
+func buildQuickCreateFailedReply(prompt, reason string) string {
+	reason = strings.TrimSpace(reason)
+	reply := quickCreateChatFailedText
+	if reason != "" {
+		reply = quickCreateChatFailedReasonText
+	}
+	if p := strings.TrimSpace(prompt); p != "" {
+		quoted := strings.ReplaceAll(truncateRunes(p, quickCreateReplyQuoteLimit), "\n", "\n> ")
+		reply += "\n\n> " + quoted
+	}
+	if reason != "" {
+		reply += "\n\n" + truncateRunes(reason, quickCreateReplyQuoteLimit)
+	}
+	return reply
+}
+
+func (s *TaskService) postQuickCreateChatReply(ctx context.Context, task db.AgentTaskQueue, qc QuickCreateContext, content string) {
+	if qc.ChatSessionID == "" || content == "" {
+		return
+	}
+	sessionID, err := util.ParseUUID(qc.ChatSessionID)
+	if err != nil || !sessionID.Valid {
+		return
+	}
+	ctx, cancel := context.WithTimeout(context.WithoutCancel(ctx), quickCreateNotifyTimeout)
+	defer cancel()
+	if _, err := s.Queries.CreateChatMessage(ctx, db.CreateChatMessageParams{
+		ChatSessionID: sessionID,
+		Role:          "assistant",
+		Content:       content,
+		TaskID:        task.ID,
+		ElapsedMs:     computeChatElapsedMs(task),
+	}); err != nil {
+		slog.Warn("quick-create chat reply: transcript append failed",
+			"task_id", util.UUIDToString(task.ID), "error", err)
+	}
+	if s.Bus != nil {
+		s.Bus.Publish(events.Event{
+			Type:          protocol.EventQuickCreateDone,
+			WorkspaceID:   qc.WorkspaceID,
+			ActorType:     "agent",
+			ActorID:       util.UUIDToString(task.AgentID),
+			ChatSessionID: qc.ChatSessionID,
+			TaskID:        util.UUIDToString(task.ID),
+			Payload: protocol.QuickCreateDonePayload{
+				ChatSessionID: qc.ChatSessionID,
+				TaskID:        util.UUIDToString(task.ID),
+				Content:       content,
+			},
+		})
+	}
+}
+
+func (s *TaskService) listQuickCreateAttachmentIDs(ctx context.Context, taskID pgtype.UUID, qc QuickCreateContext) []pgtype.UUID {
+	workspaceID, err := util.ParseUUID(qc.WorkspaceID)
+	if err != nil || !workspaceID.Valid {
+		return nil
+	}
+	ids, err := s.Queries.ListUnboundAttachmentIDsByTaskLineage(ctx, db.ListUnboundAttachmentIDsByTaskLineageParams{
+		TaskID:      taskID,
+		WorkspaceID: workspaceID,
+	})
+	if err != nil {
+		slog.Warn("quick-create attachments: list task lineage failed",
+			"task_id", util.UUIDToString(taskID), "error", err)
+		return nil
+	}
+	return ids
+}
+
+func (s *TaskService) preserveFailedQuickCreateAttachments(ctx context.Context, task db.AgentTaskQueue, qc QuickCreateContext) {
+	if qc.ChatSessionID == "" || qc.ChatMessageID == "" {
+		return
+	}
+	ctx, cancel := context.WithTimeout(context.WithoutCancel(ctx), quickCreateNotifyTimeout)
+	defer cancel()
+	sessionID, sessionErr := util.ParseUUID(qc.ChatSessionID)
+	messageID, messageErr := util.ParseUUID(qc.ChatMessageID)
+	workspaceID, workspaceErr := util.ParseUUID(qc.WorkspaceID)
+	requesterID, requesterErr := util.ParseUUID(qc.RequesterID)
+	if sessionErr != nil || messageErr != nil || workspaceErr != nil || requesterErr != nil {
+		return
+	}
+	ids := s.listQuickCreateAttachmentIDs(ctx, task.ID, qc)
+	if len(ids) == 0 {
+		return
+	}
+	bound, err := s.Queries.LinkAttachmentsToChatMessage(ctx, db.LinkAttachmentsToChatMessageParams{
+		ChatMessageID: messageID,
+		ChatSessionID: sessionID,
+		WorkspaceID:   workspaceID,
+		UploaderType:  "member",
+		UploaderID:    requesterID,
+		AttachmentIds: ids,
+	})
+	if err != nil {
+		slog.Warn("quick-create attachments: restore to chat message failed",
+			"task_id", util.UUIDToString(task.ID), "error", err)
+		return
+	}
+	if len(bound) != len(ids) {
+		slog.Warn("quick-create attachments: restore to chat message incomplete",
+			"task_id", util.UUIDToString(task.ID), "expected", len(ids), "bound", len(bound))
+	}
+}
+
 // notifyQuickCreateCompleted writes a success inbox notification to the
 // requester pointing at the issue the agent just created. The issue is
 // stamped with origin_type=quick_create + origin_id=<task_id> by the
@@ -4808,6 +5057,22 @@ func (s *TaskService) notifyQuickCreateCompleted(ctx context.Context, task db.Ag
 		)
 	}
 
+	// The daemon normally links every supplied attachment during issue create.
+	// Recover any still-unbound lineage rows here so a partial/best-effort
+	// attachment-link failure cannot strand durable channel media.
+	if attachmentIDs := s.listQuickCreateAttachmentIDs(ctx, task.ID, qc); len(attachmentIDs) > 0 {
+		if err := s.Queries.LinkAttachmentsToIssue(ctx, db.LinkAttachmentsToIssueParams{
+			IssueID:     issue.ID,
+			WorkspaceID: workspaceID,
+			Column3:     attachmentIDs,
+		}); err != nil {
+			slog.Warn("quick-create completion: link channel attachments failed",
+				"task_id", util.UUIDToString(task.ID),
+				"issue_id", util.UUIDToString(issue.ID),
+				"error", err)
+		}
+	}
+
 	// Subscribing the requester used to happen here, at completion. It now
 	// happens at issue-creation time in the shared delegated-subscriber rule
 	// (cmd/server/subscriber_listeners.go → subscribeDelegatedHuman), which
@@ -4820,7 +5085,7 @@ func (s *TaskService) notifyQuickCreateCompleted(ctx context.Context, task db.Ag
 	// agent-created sub-issues). Keeping a second write here would leave the
 	// same decision encoded in two places that can drift.
 	prefix := s.getIssuePrefix(workspaceID)
-	identifier := fmt.Sprintf("%s-%d", prefix, issue.Number)
+	identifier := IssueIdentifier(prefix, issue.Number)
 	details, _ := json.Marshal(map[string]any{
 		"task_id":         util.UUIDToString(task.ID),
 		"agent_id":        util.UUIDToString(task.AgentID),
@@ -4843,9 +5108,16 @@ func (s *TaskService) notifyQuickCreateCompleted(ctx context.Context, task db.Ag
 	})
 	if err != nil {
 		slog.Error("quick-create completion: inbox write failed", "task_id", util.UUIDToString(task.ID), "error", err)
-		return
+	} else {
+		s.publishQuickCreateInbox(item, qc.WorkspaceID, util.UUIDToString(task.AgentID), issue.Status)
 	}
-	s.publishQuickCreateInbox(item, qc.WorkspaceID, util.UUIDToString(task.AgentID), issue.Status)
+	link := ""
+	if s.AppURL != "" && qc.ChatSessionID != "" && prefix != "" {
+		if ws, werr := s.Queries.GetWorkspace(ctx, workspaceID); werr == nil && ws.Slug != "" {
+			link = strings.TrimRight(s.AppURL, "/") + "/" + url.PathEscape(ws.Slug) + "/issues/" + url.PathEscape(identifier)
+		}
+	}
+	s.postQuickCreateChatReply(ctx, task, qc, buildQuickCreateDoneReply(identifier, issue.Title, link))
 }
 
 // Inbox types for the two non-success quick-create outcomes. They are distinct
@@ -4870,6 +5142,8 @@ func (s *TaskService) notifyQuickCreateFailed(ctx context.Context, task db.Agent
 		errMsg = "Quick create did not finish successfully"
 	}
 	s.writeQuickCreateOutcomeInbox(ctx, task, qc, inboxTypeQuickCreateFailed, "Quick create failed", errMsg)
+	s.preserveFailedQuickCreateAttachments(ctx, task, qc)
+	s.postQuickCreateChatReply(ctx, task, qc, buildQuickCreateFailedReply(qc.Prompt, redact.Text(errMsg)))
 }
 
 // quickCreateUnconfirmedDetail is the user-facing message for a quick-create
@@ -4891,6 +5165,8 @@ const quickCreateUnconfirmedDetail = "Couldn't confirm whether the issue was cre
 // Severity stays action_required because the user does need to look.
 func (s *TaskService) notifyQuickCreateUnconfirmed(ctx context.Context, task db.AgentTaskQueue, qc QuickCreateContext) {
 	s.writeQuickCreateOutcomeInbox(ctx, task, qc, inboxTypeQuickCreateUnconfirmed, "Quick create needs a check", quickCreateUnconfirmedDetail)
+	s.preserveFailedQuickCreateAttachments(ctx, task, qc)
+	s.postQuickCreateChatReply(ctx, task, qc, "⚠️ "+quickCreateUnconfirmedDetail)
 }
 
 // quickCreateNotifyTimeout bounds the detached terminal-notification write in

--- a/server/internal/service/task_channel_quick_create_test.go
+++ b/server/internal/service/task_channel_quick_create_test.go
@@ -1,0 +1,74 @@
+package service
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/multica-ai/multica/server/internal/util"
+)
+
+func TestBuildQuickCreateContext_ChannelSession(t *testing.T) {
+	got := buildQuickCreateContext(quickCreateEnqueueInput{
+		WorkspaceID:   testUUID(1),
+		RequesterID:   testUUID(2),
+		ChatSessionID: testUUID(3),
+		ChatMessageID: testUUID(4),
+		Prompt:        "analyze the branch",
+	})
+	if got.Type != QuickCreateContextType {
+		t.Fatalf("type = %q, want %q", got.Type, QuickCreateContextType)
+	}
+	if got.ChatSessionID != util.UUIDToString(testUUID(3)) {
+		t.Fatalf("chat_session_id = %q", got.ChatSessionID)
+	}
+	if got.ChatMessageID != util.UUIDToString(testUUID(4)) {
+		t.Fatalf("chat_message_id = %q", got.ChatMessageID)
+	}
+	raw, err := json.Marshal(got)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if !strings.Contains(string(raw), `"chat_session_id"`) {
+		t.Fatalf("marshaled context missing chat_session_id: %s", raw)
+	}
+	if !strings.Contains(string(raw), `"chat_message_id"`) {
+		t.Fatalf("marshaled context missing chat_message_id: %s", raw)
+	}
+}
+
+func TestBuildQuickCreateContext_WebOmitsChannelSession(t *testing.T) {
+	got := buildQuickCreateContext(quickCreateEnqueueInput{
+		WorkspaceID: testUUID(1),
+		RequesterID: testUUID(2),
+		Prompt:      "analyze the branch",
+	})
+	raw, err := json.Marshal(got)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if strings.Contains(string(raw), "chat_session_id") {
+		t.Fatalf("web context must omit chat_session_id: %s", raw)
+	}
+	if strings.Contains(string(raw), "chat_message_id") {
+		t.Fatalf("web context must omit chat_message_id: %s", raw)
+	}
+}
+
+func TestBuildQuickCreateDoneReply(t *testing.T) {
+	got := buildQuickCreateDoneReply("MUL-42", "Fix login", "https://app.example.com/acme/issues/MUL-42")
+	want := "✅ MUL-42 — Fix login\n\nhttps://app.example.com/acme/issues/MUL-42"
+	if got != want {
+		t.Fatalf("reply = %q, want %q", got, want)
+	}
+}
+
+func TestBuildQuickCreateFailedReply(t *testing.T) {
+	got := buildQuickCreateFailedReply("login broken\nsteps to reproduce", "An active issue already exists: MUL-42 — Fix login")
+	want := quickCreateChatFailedReasonText +
+		"\n\n> login broken\n> steps to reproduce" +
+		"\n\nAn active issue already exists: MUL-42 — Fix login"
+	if got != want {
+		t.Fatalf("reply = %q, want %q", got, want)
+	}
+}

--- a/server/pkg/db/generated/agent.sql.go
+++ b/server/pkg/db/generated/agent.sql.go
@@ -1817,33 +1817,37 @@ const createQuickCreateTask = `-- name: CreateQuickCreateTask :one
 INSERT INTO agent_task_queue (
     agent_id, runtime_id, issue_id, status, priority, context, originator_user_id,
     accountable_user_id, runtime_mcp_overlay, runtime_connected_apps,
-    originator_source, trigger_evidence_kind, trigger_evidence_ref_id
+    originator_source, trigger_evidence_kind, trigger_evidence_ref_id, fire_at
 )
 VALUES (
-    $1, $2, NULL, 'queued', $3, $4,
-    $5,
+    $1, $2, NULL,
+    CASE WHEN $5::timestamptz IS NULL THEN 'queued' ELSE 'deferred' END,
+    $3, $4,
     $6,
     $7,
     $8,
     $9,
     $10,
-    $11
+    $11,
+    $12,
+    $5
 )
 RETURNING id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id, chat_session_id, autopilot_run_id, attempt, max_attempts, parent_task_id, failure_reason, trigger_summary, force_fresh_session, is_leader_task, wait_reason, initiator_user_id, handoff_note, prepare_lease_expires_at, squad_id, runtime_mcp_overlay, escalation_for_task_id, fire_at, originator_user_id, runtime_connected_apps, coalesced_comment_ids, delivered_comment_ids, chat_input_task_id, chat_finalize_deferred_at, originator_source, delegated_from_task_id, retry_of_task_id, rerun_of_task_id, rule_version_id, trigger_evidence_kind, trigger_evidence_ref_id, accountable_user_id, session_rollout_missing, retired_session_id, quick_actions_disabled, regenerate_quick_actions_for
 `
 
 type CreateQuickCreateTaskParams struct {
-	AgentID              pgtype.UUID `json:"agent_id"`
-	RuntimeID            pgtype.UUID `json:"runtime_id"`
-	Priority             int32       `json:"priority"`
-	Context              []byte      `json:"context"`
-	OriginatorUserID     pgtype.UUID `json:"originator_user_id"`
-	AccountableUserID    pgtype.UUID `json:"accountable_user_id"`
-	RuntimeMcpOverlay    []byte      `json:"runtime_mcp_overlay"`
-	RuntimeConnectedApps []byte      `json:"runtime_connected_apps"`
-	OriginatorSource     pgtype.Text `json:"originator_source"`
-	TriggerEvidenceKind  pgtype.Text `json:"trigger_evidence_kind"`
-	TriggerEvidenceRefID pgtype.UUID `json:"trigger_evidence_ref_id"`
+	AgentID              pgtype.UUID        `json:"agent_id"`
+	RuntimeID            pgtype.UUID        `json:"runtime_id"`
+	Priority             int32              `json:"priority"`
+	Context              []byte             `json:"context"`
+	FireAt               pgtype.Timestamptz `json:"fire_at"`
+	OriginatorUserID     pgtype.UUID        `json:"originator_user_id"`
+	AccountableUserID    pgtype.UUID        `json:"accountable_user_id"`
+	RuntimeMcpOverlay    []byte             `json:"runtime_mcp_overlay"`
+	RuntimeConnectedApps []byte             `json:"runtime_connected_apps"`
+	OriginatorSource     pgtype.Text        `json:"originator_source"`
+	TriggerEvidenceKind  pgtype.Text        `json:"trigger_evidence_kind"`
+	TriggerEvidenceRefID pgtype.UUID        `json:"trigger_evidence_ref_id"`
 }
 
 // Quick-create tasks have no issue / chat / autopilot link; the entire job
@@ -1858,6 +1862,7 @@ func (q *Queries) CreateQuickCreateTask(ctx context.Context, arg CreateQuickCrea
 		arg.RuntimeID,
 		arg.Priority,
 		arg.Context,
+		arg.FireAt,
 		arg.OriginatorUserID,
 		arg.AccountableUserID,
 		arg.RuntimeMcpOverlay,
@@ -5067,6 +5072,75 @@ func (q *Queries) PromoteDueDeferredTasksForRuntimes(ctx context.Context, runtim
 		return nil, err
 	}
 	return items, nil
+}
+
+const promoteQuickCreateTaskAfterMedia = `-- name: PromoteQuickCreateTaskAfterMedia :one
+UPDATE agent_task_queue
+SET status = 'queued', fire_at = NULL
+WHERE id = $1 AND status = 'deferred'
+RETURNING id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id, chat_session_id, autopilot_run_id, attempt, max_attempts, parent_task_id, failure_reason, trigger_summary, force_fresh_session, is_leader_task, wait_reason, initiator_user_id, handoff_note, prepare_lease_expires_at, squad_id, runtime_mcp_overlay, escalation_for_task_id, fire_at, originator_user_id, runtime_connected_apps, coalesced_comment_ids, delivered_comment_ids, chat_input_task_id, chat_finalize_deferred_at, originator_source, delegated_from_task_id, retry_of_task_id, rerun_of_task_id, rule_version_id, trigger_evidence_kind, trigger_evidence_ref_id, accountable_user_id, session_rollout_missing, retired_session_id, quick_actions_disabled, regenerate_quick_actions_for
+`
+
+// A channel quick-create with inbound media starts deferred so the daemon
+// cannot claim it before the durable media pipeline has bound task-owned
+// attachments. No row means the fire_at fallback already promoted/claimed it.
+func (q *Queries) PromoteQuickCreateTaskAfterMedia(ctx context.Context, id pgtype.UUID) (AgentTaskQueue, error) {
+	row := q.db.QueryRow(ctx, promoteQuickCreateTaskAfterMedia, id)
+	var i AgentTaskQueue
+	err := row.Scan(
+		&i.ID,
+		&i.AgentID,
+		&i.IssueID,
+		&i.Status,
+		&i.Priority,
+		&i.DispatchedAt,
+		&i.StartedAt,
+		&i.CompletedAt,
+		&i.Result,
+		&i.Error,
+		&i.CreatedAt,
+		&i.Context,
+		&i.RuntimeID,
+		&i.SessionID,
+		&i.WorkDir,
+		&i.TriggerCommentID,
+		&i.ChatSessionID,
+		&i.AutopilotRunID,
+		&i.Attempt,
+		&i.MaxAttempts,
+		&i.ParentTaskID,
+		&i.FailureReason,
+		&i.TriggerSummary,
+		&i.ForceFreshSession,
+		&i.IsLeaderTask,
+		&i.WaitReason,
+		&i.InitiatorUserID,
+		&i.HandoffNote,
+		&i.PrepareLeaseExpiresAt,
+		&i.SquadID,
+		&i.RuntimeMcpOverlay,
+		&i.EscalationForTaskID,
+		&i.FireAt,
+		&i.OriginatorUserID,
+		&i.RuntimeConnectedApps,
+		&i.CoalescedCommentIds,
+		&i.DeliveredCommentIds,
+		&i.ChatInputTaskID,
+		&i.ChatFinalizeDeferredAt,
+		&i.OriginatorSource,
+		&i.DelegatedFromTaskID,
+		&i.RetryOfTaskID,
+		&i.RerunOfTaskID,
+		&i.RuleVersionID,
+		&i.TriggerEvidenceKind,
+		&i.TriggerEvidenceRefID,
+		&i.AccountableUserID,
+		&i.SessionRolloutMissing,
+		&i.RetiredSessionID,
+		&i.QuickActionsDisabled,
+		&i.RegenerateQuickActionsFor,
+	)
+	return i, err
 }
 
 const rebindAgentBuilderRuntime = `-- name: RebindAgentBuilderRuntime :one

--- a/server/pkg/db/generated/attachment.sql.go
+++ b/server/pkg/db/generated/attachment.sql.go
@@ -685,6 +685,54 @@ func (q *Queries) ListAttachmentsByIssue(ctx context.Context, arg ListAttachment
 	return items, nil
 }
 
+const listUnboundAttachmentIDsByTaskLineage = `-- name: ListUnboundAttachmentIDsByTaskLineage :many
+WITH RECURSIVE task_lineage AS (
+  SELECT task.id, task.parent_task_id
+  FROM agent_task_queue task
+  WHERE task.id = $2
+  UNION ALL
+  SELECT parent.id, parent.parent_task_id
+  FROM agent_task_queue parent
+  JOIN task_lineage child ON parent.id = child.parent_task_id
+)
+SELECT attachment.id FROM attachment
+WHERE attachment.task_id IN (SELECT task_lineage.id FROM task_lineage)
+  AND attachment.workspace_id = $1
+  AND attachment.issue_id IS NULL
+  AND attachment.comment_id IS NULL
+  AND attachment.chat_message_id IS NULL
+ORDER BY attachment.created_at ASC
+`
+
+type ListUnboundAttachmentIDsByTaskLineageParams struct {
+	WorkspaceID pgtype.UUID `json:"workspace_id"`
+	TaskID      pgtype.UUID `json:"task_id"`
+}
+
+// Channel quick-create media is durably owned by task_id while the background
+// agent authors the issue. Follow parent_task_id so an automatic retry sees
+// media owned by its failed ancestor; retries inherit the quick-create context
+// but intentionally receive a new task id.
+func (q *Queries) ListUnboundAttachmentIDsByTaskLineage(ctx context.Context, arg ListUnboundAttachmentIDsByTaskLineageParams) ([]pgtype.UUID, error) {
+	rows, err := q.db.Query(ctx, listUnboundAttachmentIDsByTaskLineage, arg.WorkspaceID, arg.TaskID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []pgtype.UUID{}
+	for rows.Next() {
+		var id pgtype.UUID
+		if err := rows.Scan(&id); err != nil {
+			return nil, err
+		}
+		items = append(items, id)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const replaceCommentAttachments = `-- name: ReplaceCommentAttachments :exec
 UPDATE attachment
 SET comment_id = CASE

--- a/server/pkg/db/generated/chat.sql.go
+++ b/server/pkg/db/generated/chat.sql.go
@@ -916,10 +916,11 @@ func (q *Queries) HasPendingChatTasksByCreator(ctx context.Context, arg HasPendi
 	return has_pending, err
 }
 
-const linkChatMessageToTask = `-- name: LinkChatMessageToTask :exec
+const linkChatMessageToTask = `-- name: LinkChatMessageToTask :one
 UPDATE chat_message
 SET task_id = $2
 WHERE id = $1 AND role = 'user'
+RETURNING id
 `
 
 type LinkChatMessageToTaskParams struct {
@@ -927,9 +928,11 @@ type LinkChatMessageToTaskParams struct {
 	TaskID pgtype.UUID `json:"task_id"`
 }
 
-func (q *Queries) LinkChatMessageToTask(ctx context.Context, arg LinkChatMessageToTaskParams) error {
-	_, err := q.db.Exec(ctx, linkChatMessageToTask, arg.ID, arg.TaskID)
-	return err
+func (q *Queries) LinkChatMessageToTask(ctx context.Context, arg LinkChatMessageToTaskParams) (pgtype.UUID, error) {
+	row := q.db.QueryRow(ctx, linkChatMessageToTask, arg.ID, arg.TaskID)
+	var id pgtype.UUID
+	err := row.Scan(&id)
+	return id, err
 }
 
 const linkUnownedChannelChatMessagesToTask = `-- name: LinkUnownedChannelChatMessagesToTask :exec
@@ -1030,6 +1033,7 @@ type ListAgentBuilderSessionsByCreatorRow struct {
 // neither is also wrong: a session opened and abandoned untouched is not a
 // draft, and would put an empty row in front of the user on every accidental
 // entry into the flow.
+//
 // The stored draft rides along instead of needing its own fetch: the studio
 // renders this list beside the conversation it is switching between, so the
 // configuration for the row the user picks has to be in hand at click time.

--- a/server/pkg/db/queries/agent.sql
+++ b/server/pkg/db/queries/agent.sql
@@ -319,18 +319,30 @@ RETURNING *;
 INSERT INTO agent_task_queue (
     agent_id, runtime_id, issue_id, status, priority, context, originator_user_id,
     accountable_user_id, runtime_mcp_overlay, runtime_connected_apps,
-    originator_source, trigger_evidence_kind, trigger_evidence_ref_id
+    originator_source, trigger_evidence_kind, trigger_evidence_ref_id, fire_at
 )
 VALUES (
-    $1, $2, NULL, 'queued', $3, $4,
+    $1, $2, NULL,
+    CASE WHEN sqlc.narg(fire_at)::timestamptz IS NULL THEN 'queued' ELSE 'deferred' END,
+    $3, $4,
     sqlc.narg(originator_user_id),
     sqlc.narg(accountable_user_id),
     sqlc.narg(runtime_mcp_overlay),
     sqlc.narg(runtime_connected_apps),
     sqlc.narg(originator_source),
     sqlc.narg(trigger_evidence_kind),
-    sqlc.narg(trigger_evidence_ref_id)
+    sqlc.narg(trigger_evidence_ref_id),
+    sqlc.narg(fire_at)
 )
+RETURNING *;
+
+-- name: PromoteQuickCreateTaskAfterMedia :one
+-- A channel quick-create with inbound media starts deferred so the daemon
+-- cannot claim it before the durable media pipeline has bound task-owned
+-- attachments. No row means the fire_at fallback already promoted/claimed it.
+UPDATE agent_task_queue
+SET status = 'queued', fire_at = NULL
+WHERE id = $1 AND status = 'deferred'
 RETURNING *;
 
 -- name: CreateDeferredAgentTask :one

--- a/server/pkg/db/queries/attachment.sql
+++ b/server/pkg/db/queries/attachment.sql
@@ -145,3 +145,25 @@ DELETE FROM attachment WHERE id = $1 AND workspace_id = $2;
 SELECT * FROM attachment
 WHERE id = ANY(sqlc.arg(attachment_ids)::uuid[]) AND workspace_id = sqlc.arg(workspace_id)
 ORDER BY created_at ASC;
+
+-- name: ListUnboundAttachmentIDsByTaskLineage :many
+-- Channel quick-create media is durably owned by task_id while the background
+-- agent authors the issue. Follow parent_task_id so an automatic retry sees
+-- media owned by its failed ancestor; retries inherit the quick-create context
+-- but intentionally receive a new task id.
+WITH RECURSIVE task_lineage AS (
+  SELECT task.id, task.parent_task_id
+  FROM agent_task_queue task
+  WHERE task.id = sqlc.arg(task_id)
+  UNION ALL
+  SELECT parent.id, parent.parent_task_id
+  FROM agent_task_queue parent
+  JOIN task_lineage child ON parent.id = child.parent_task_id
+)
+SELECT attachment.id FROM attachment
+WHERE attachment.task_id IN (SELECT task_lineage.id FROM task_lineage)
+  AND attachment.workspace_id = sqlc.arg(workspace_id)
+  AND attachment.issue_id IS NULL
+  AND attachment.comment_id IS NULL
+  AND attachment.chat_message_id IS NULL
+ORDER BY attachment.created_at ASC;

--- a/server/pkg/db/queries/chat.sql
+++ b/server/pkg/db/queries/chat.sql
@@ -324,10 +324,11 @@ UPDATE chat_message
 SET channel_media_pending_until = NULL
 WHERE id = $1 AND chat_session_id = $2;
 
--- name: LinkChatMessageToTask :exec
+-- name: LinkChatMessageToTask :one
 UPDATE chat_message
 SET task_id = $2
-WHERE id = $1 AND role = 'user';
+WHERE id = $1 AND role = 'user'
+RETURNING id;
 
 -- name: LinkUnownedChannelChatMessagesToTask :exec
 -- Seals the trailing channel-message batch to its task. The task row and these

--- a/server/pkg/protocol/events.go
+++ b/server/pkg/protocol/events.go
@@ -84,6 +84,7 @@ const (
 	// draft restore (#5219). Channel outbounds (Slack/Lark) deliberately do
 	// not subscribe to it — cancellation stays silent on external channels.
 	EventChatCancelFinalized = "chat:cancel_finalized"
+	EventQuickCreateDone     = "quick_create:done"
 	EventChatSessionRead     = "chat:session_read"
 	EventChatSessionDeleted  = "chat:session_deleted"
 	EventChatSessionUpdated  = "chat:session_updated"

--- a/server/pkg/protocol/messages.go
+++ b/server/pkg/protocol/messages.go
@@ -259,6 +259,15 @@ type ChatCancelFinalizedPayload struct {
 	ElapsedMs   int64  `json:"elapsed_ms,omitempty"`
 }
 
+// QuickCreateDonePayload is broadcast when a chat-originated quick-create task
+// reaches a terminal outcome. Content is ready for the channel outbound to
+// deliver into the originating conversation.
+type QuickCreateDonePayload struct {
+	ChatSessionID string `json:"chat_session_id"`
+	TaskID        string `json:"task_id,omitempty"`
+	Content       string `json:"content,omitempty"`
+}
+
 // ChatSessionReadPayload is broadcast when the creator marks a session as read.
 // Fires to other devices so their unread counts stay in sync.
 type ChatSessionReadPayload struct {


### PR DESCRIPTION
## What does this PR do?

Extracts the channel-agnostic async `/issue` quick-create flow from #4829 so Lark, Slack, and the upcoming DingTalk integration can share the same engine, task, media, retry, attribution, and terminal-event behavior.

This PR deliberately keeps platform enablement and outbound delivery in each adapter. It does not switch the existing Lark or Slack product behavior to the async path.

Thinking path:

1. Follow #4829 review feedback by retaining main's `ForceFresh` and `MediaResolver`/intent-ledger architecture instead of introducing session rebinding, a private media interface, or migrations.
2. Normalize the user's un-enriched command text at the adapter boundary, then keep `/new` and `/issue` decisions in the shared channel engine.
3. Keep quick-create tasks durable across media resolution and automatic retries, and publish one shared terminal event that each channel adapter can deliver.

## Related Issue

Follow-up to #4829.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [x] Refactor / code improvement (no behavior change)
- [ ] Documentation update
- [x] Tests (adding or improving test coverage)
- [ ] CI / infrastructure

## Changes Made

- Added the shared async `/issue` quick-create engine contract and result handling under `server/internal/integrations/channel/engine/`.
- Added normalized `CommandText` and `BareFresh` fields so platform enrichment cannot change command semantics.
- Kept bare `/new` on main's `ForceFresh` model without creating empty messages, session-rebinding state, or migrations.
- Reused `MediaResolver`, `MediaRef`, and the media intent ledger; media-bearing quick-create tasks remain deferred until attachments are bound or the durable deadline expires.
- Added task-lineage attachment lookup so automatic retries inherit channel media, with terminal success/failure ownership recovery.
- Added chat evidence attribution, transcript acknowledgements, shared `quick_create:done` events, and channel-ready terminal replies.
- Updated Lark and Slack adapters to populate the normalized command fields without enabling the async quick-create path.

## How to Test

1. Run `make sqlc`.
2. Run `go test ./internal/integrations/channel/engine -run 'Test(QuickCreatePrompt|Router_BareFresh|Router_QuickCreate)' -count=1`.
3. Run `go test ./internal/integrations/lark ./internal/integrations/slack -count=1`.
4. Run `go test ./internal/service -run 'Test(BuildQuickCreateContext|BuildQuickCreateDoneReply|BuildQuickCreateFailedReply)' -count=1`.
5. Run `go vet ./internal/integrations/channel/engine ./internal/integrations/lark ./internal/integrations/slack ./internal/service ./internal/handler`.

Automated checks above pass locally. Slack and Lark have not been manually tested. DB-backed integration tests were not run against a current schema locally because the available test database is missing main-branch columns such as `channel_media_pending_until`, `channel_ingested`, and `session_rollout_missing`.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [ ] I have updated relevant documentation to reflect my changes
- [ ] If I added a new runtime / coding tool / UI tab, I synced the change to **landing copy** (`apps/web/features/landing/i18n/`) and **relevant docs** (`apps/docs/content/docs/`)
- [ ] If this PR touches Chinese product copy, I checked it against `apps/docs/content/docs/developers/conventions.zh.mdx` (terminology, mixed-rule for `task` / `issue` / `skill`)
- [x] I have considered and documented any risks above
- [x] I will address all reviewer comments before requesting merge

## AI Disclosure

**AI tool used:** Codex

**Prompt / approach:**

Used Codex to review the staged extraction against #4829 feedback and the `feat/dingtalk-integration` branch, fix verified high/medium findings in a review loop, add focused tests, regenerate sqlc output, and re-review the final staged diff.

## Screenshots (optional)

N/A — backend/shared channel infrastructure only.
