### PR TITLE
feat(channel): deliver final reply text to IM

### DIFF
--- a/server/internal/integrations/lark/outbound.go
+++ b/server/internal/integrations/lark/outbound.go
@@ -351,7 +351,9 @@ func (p *Patcher) processEvent(ctx context.Context, e events.Event) error {
 	return nil
 }
 
-// sendChatReply turns ChatDonePayload.Content into a Lark message.
+// sendChatReply turns the channel-deliverable ChatDonePayload text into a Lark
+// message. ReplyText is preferred so interim narration stays in Multica's
+// transcript; Content remains the compatibility fallback.
 // The wire shape is chosen per-reply based on whether the body
 // contains any markdown syntax:
 //
@@ -556,8 +558,14 @@ func taskAndSessionFromEvent(e events.Event) (taskID, chatSessionID pgtype.UUID,
 func chatDoneContent(payload any) string {
 	switch p := payload.(type) {
 	case protocol.ChatDonePayload:
+		if p.ReplyText != "" {
+			return p.ReplyText
+		}
 		return p.Content
 	case map[string]any:
+		if s, ok := p["reply_text"].(string); ok && s != "" {
+			return s
+		}
 		if s, ok := p["content"].(string); ok {
 			return s
 		}

--- a/server/internal/integrations/lark/outbound_test.go
+++ b/server/internal/integrations/lark/outbound_test.go
@@ -773,3 +773,23 @@ func TestPatcherThreadReplyDoesNotFallBackOnAmbiguousError(t *testing.T) {
 		t.Errorf("the single attempt should be the thread reply; got %+v", api.textSent[0].ReplyTarget)
 	}
 }
+
+func TestChatDoneContent_PrefersReplyText(t *testing.T) {
+	tests := []struct {
+		name    string
+		payload any
+		want    string
+	}{
+		{"typed reply text", protocol.ChatDonePayload{Content: "narration + reply", ReplyText: "reply"}, "reply"},
+		{"typed fallback to content", protocol.ChatDonePayload{Content: "reply"}, "reply"},
+		{"map reply text", map[string]any{"content": "narration + reply", "reply_text": "reply"}, "reply"},
+		{"map fallback to content", map[string]any{"content": "reply"}, "reply"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if got := chatDoneContent(test.payload); got != test.want {
+				t.Fatalf("chatDoneContent() = %q, want %q", got, test.want)
+			}
+		})
+	}
+}

--- a/server/internal/integrations/slack/outbound.go
+++ b/server/internal/integrations/slack/outbound.go
@@ -187,8 +187,14 @@ func outboundTarget(b db.ChannelChatSessionBinding) (channelID, threadTS string)
 func chatDoneContent(payload any) string {
 	switch p := payload.(type) {
 	case protocol.ChatDonePayload:
+		if p.ReplyText != "" {
+			return p.ReplyText
+		}
 		return p.Content
 	case map[string]any:
+		if s, ok := p["reply_text"].(string); ok && s != "" {
+			return s
+		}
 		if s, ok := p["content"].(string); ok {
 			return s
 		}

--- a/server/internal/integrations/slack/outbound_test.go
+++ b/server/internal/integrations/slack/outbound_test.go
@@ -202,3 +202,23 @@ func TestOutbound_IgnoresNonSlackAndEmptyAndRevoked(t *testing.T) {
 		})
 	}
 }
+
+func TestChatDoneContent_PrefersReplyText(t *testing.T) {
+	tests := []struct {
+		name    string
+		payload any
+		want    string
+	}{
+		{"typed reply text", protocol.ChatDonePayload{Content: "narration + reply", ReplyText: "reply"}, "reply"},
+		{"typed fallback to content", protocol.ChatDonePayload{Content: "reply"}, "reply"},
+		{"map reply text", map[string]any{"content": "narration + reply", "reply_text": "reply"}, "reply"},
+		{"map fallback to content", map[string]any{"content": "reply"}, "reply"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if got := chatDoneContent(test.payload); got != test.want {
+				t.Fatalf("chatDoneContent() = %q, want %q", got, test.want)
+			}
+		})
+	}
+}

--- a/server/internal/service/reply_text.go
+++ b/server/internal/service/reply_text.go
@@ -1,0 +1,64 @@
+package service
+
+import (
+	"context"
+	"strings"
+
+	"github.com/jackc/pgx/v5/pgtype"
+
+	"github.com/multica-ai/multica/server/internal/util"
+	db "github.com/multica-ai/multica/server/pkg/db/generated"
+	"github.com/multica-ai/multica/server/pkg/redact"
+)
+
+// deliverableReplyText derives the user-facing reply from a task's persisted
+// transcript, using the web timeline's region split (splitTimeline in
+// packages/views/chat/lib/copy-text.ts): adjacent "text" rows are one logical
+// block (they are split only by daemon flush timing), and the reply is the
+// text block after the last non-text row — interim narration between tool
+// calls is process detail, not reply. A transcript with no non-text rows is
+// all reply. Unlike web Copy, which joins preface + final, delivery is
+// deliberately final-only; the preface block before the first non-text row
+// is used only when the run ended on a tool call and left no trailing text.
+// Returns "" when the transcript yields no text at all.
+func deliverableReplyText(msgs []db.TaskMessage) string {
+	var preface, final strings.Builder
+	sawNonText := false
+	for _, msg := range msgs {
+		if msg.Type != "text" {
+			sawNonText = true
+			final.Reset()
+			continue
+		}
+		if !sawNonText {
+			preface.WriteString(msg.Content.String)
+		}
+		final.WriteString(msg.Content.String)
+	}
+	reply := strings.TrimSpace(final.String())
+	if reply == "" && sawNonText {
+		reply = strings.TrimSpace(preface.String())
+	}
+	// Each task-message row is redacted independently when it is persisted,
+	// but a credential may span two daemon flushes and become recognizable
+	// only after the rows are joined. Unescape first, then redact the complete
+	// delivery body so ReplyText cannot bypass the whole-output redaction
+	// applied to ChatDonePayload.Content.
+	return redact.Text(util.UnescapeBackslashEscapes(reply))
+}
+
+// replyTextForTask loads the persisted transcript and returns the deliverable
+// reply, decoded like chat_message content. fallback is used for legacy tasks,
+// a transcript with no deliverable text, or a final message batch that has not
+// landed yet.
+func (s *TaskService) replyTextForTask(ctx context.Context, taskID pgtype.UUID, fallback string) string {
+	msgs, err := s.Queries.ListTaskMessages(ctx, taskID)
+	if err != nil || len(msgs) == 0 {
+		return fallback
+	}
+	reply := deliverableReplyText(msgs)
+	if reply == "" {
+		return fallback
+	}
+	return reply
+}

--- a/server/internal/service/reply_text_test.go
+++ b/server/internal/service/reply_text_test.go
@@ -1,0 +1,129 @@
+package service
+
+import (
+	"testing"
+
+	"github.com/jackc/pgx/v5/pgtype"
+
+	db "github.com/multica-ai/multica/server/pkg/db/generated"
+)
+
+func taskMessageForReplyText(seq int32, typ, content string) db.TaskMessage {
+	return db.TaskMessage{
+		Seq:     seq,
+		Type:    typ,
+		Content: pgtype.Text{String: content, Valid: content != ""},
+	}
+}
+
+func TestDeliverableReplyText(t *testing.T) {
+	tests := []struct {
+		name     string
+		messages []db.TaskMessage
+		want     string
+	}{
+		{name: "empty transcript"},
+		{
+			name: "text-only transcript is all reply",
+			messages: []db.TaskMessage{
+				taskMessageForReplyText(1, "text", "Hello, "),
+				taskMessageForReplyText(2, "text", "world."),
+			},
+			want: "Hello, world.",
+		},
+		{
+			name: "drops interim narration and keeps final block",
+			messages: []db.TaskMessage{
+				taskMessageForReplyText(1, "text", "Let me check."),
+				taskMessageForReplyText(2, "tool_use", ""),
+				taskMessageForReplyText(3, "tool_result", ""),
+				taskMessageForReplyText(4, "text", "Now verifying."),
+				taskMessageForReplyText(5, "tool_use", ""),
+				taskMessageForReplyText(6, "tool_result", ""),
+				taskMessageForReplyText(7, "text", "The bug is in foo()."),
+			},
+			want: "The bug is in foo().",
+		},
+		{
+			name: "rejoins final text flushes",
+			messages: []db.TaskMessage{
+				taskMessageForReplyText(1, "tool_use", ""),
+				taskMessageForReplyText(2, "tool_result", ""),
+				taskMessageForReplyText(3, "text", "First half, "),
+				taskMessageForReplyText(4, "text", "second half."),
+			},
+			want: "First half, second half.",
+		},
+		{
+			name: "redacts a credential split across text flushes",
+			messages: []db.TaskMessage{
+				taskMessageForReplyText(1, "text", "ghp_ABCDEFGHIJKLMNO"),
+				taskMessageForReplyText(2, "text", "PQRSTUVWXYZabcdefghij"),
+			},
+			want: "[REDACTED GITHUB TOKEN]",
+		},
+		{
+			name: "unescapes the complete reply before final redaction",
+			messages: []db.TaskMessage{
+				taskMessageForReplyText(1, "text", `First line.\nSecond line.`),
+			},
+			want: "First line.\nSecond line.",
+		},
+		{
+			name: "thinking is process detail",
+			messages: []db.TaskMessage{
+				taskMessageForReplyText(1, "thinking", "hmm"),
+				taskMessageForReplyText(2, "text", "The answer."),
+			},
+			want: "The answer.",
+		},
+		{
+			name: "tool-terminated run falls back to preface",
+			messages: []db.TaskMessage{
+				taskMessageForReplyText(1, "text", "Posting the reply via CLI."),
+				taskMessageForReplyText(2, "tool_use", ""),
+				taskMessageForReplyText(3, "tool_result", ""),
+			},
+			want: "Posting the reply via CLI.",
+		},
+		{
+			name: "tools only have no reply",
+			messages: []db.TaskMessage{
+				taskMessageForReplyText(1, "tool_use", ""),
+				taskMessageForReplyText(2, "tool_result", ""),
+			},
+		},
+		{
+			name: "whitespace final falls back to preface",
+			messages: []db.TaskMessage{
+				taskMessageForReplyText(1, "text", "Preface."),
+				taskMessageForReplyText(2, "tool_use", ""),
+				taskMessageForReplyText(3, "text", "\n\n"),
+			},
+			want: "Preface.",
+		},
+		{
+			name: "middle narration is never a reply",
+			messages: []db.TaskMessage{
+				taskMessageForReplyText(1, "tool_use", ""),
+				taskMessageForReplyText(2, "text", "middle narration"),
+				taskMessageForReplyText(3, "tool_use", ""),
+			},
+		},
+		{
+			name: "whitespace preface is empty",
+			messages: []db.TaskMessage{
+				taskMessageForReplyText(1, "text", "   "),
+				taskMessageForReplyText(2, "tool_use", ""),
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if got := deliverableReplyText(test.messages); got != test.want {
+				t.Fatalf("deliverableReplyText() = %q, want %q", got, test.want)
+			}
+		})
+	}
+}

--- a/server/internal/service/task.go
+++ b/server/internal/service/task.go
@@ -4253,6 +4253,14 @@ func (s *TaskService) broadcastChatDone(ctx context.Context, task db.AgentTaskQu
 		payload.MessageID = util.UUIDToString(msg.ID)
 		payload.Content = msg.Content
 		payload.MessageKind = msg.MessageKind
+		// A no_response row carries a compatibility fallback in Content, but it
+		// has no transcript reply to derive. Channel outbounds already reject
+		// the direct-chat task origin that can produce this row.
+		if msg.MessageKind != protocol.ChatMessageKindNoResponse {
+			// Empty fallback is intentional: outbounds already fall back to
+			// Content when ReplyText is absent.
+			payload.ReplyText = s.replyTextForTask(ctx, task.ID, "")
+		}
 		if msg.CreatedAt.Valid {
 			payload.CreatedAt = msg.CreatedAt.Time.UTC().Format(time.RFC3339Nano)
 		}

--- a/server/pkg/protocol/messages.go
+++ b/server/pkg/protocol/messages.go
@@ -165,9 +165,14 @@ type ChatDonePayload struct {
 	TaskID        string `json:"task_id"`
 	MessageID     string `json:"message_id,omitempty"`
 	Content       string `json:"content,omitempty"`
-	ElapsedMs     int64  `json:"elapsed_ms,omitempty"`
-	CreatedAt     string `json:"created_at,omitempty"`
-	MessageKind   string `json:"message_kind,omitempty"`
+	// ReplyText is the channel-deliverable reply: the final text block after
+	// the task's last non-text timeline row. Content remains the full
+	// accumulated output for transcript-shaped consumers. Channel outbounds
+	// prefer ReplyText and fall back to Content for legacy payloads.
+	ReplyText   string `json:"reply_text,omitempty"`
+	ElapsedMs   int64  `json:"elapsed_ms,omitempty"`
+	CreatedAt   string `json:"created_at,omitempty"`
+	MessageKind string `json:"message_kind,omitempty"`
 }
 
 // Outcome values carried by ChatCancelFinalizedPayload.


### PR DESCRIPTION
## What does this PR do?

Slack and Lark previously forwarded ChatDonePayload.Content as the channel reply. For tool-using runs that content can contain interim narration together with the final answer, making the IM reply noisy and exposing process details that belong only in the Multica transcript.

This change derives a channel-deliverable reply from the ordered task_message timeline. It keeps the final text block after the last non-text row, treats adjacent text rows as daemon flush fragments, and retains Content as a compatibility fallback when the transcript is unavailable or has no deliverable text.

Thinking path: chat:done is already the single outbound completion event, and task_message is the persisted ordered timeline used by the web UI. Deriving the final region in the service layer keeps Slack and Lark consistent without adding platform-specific state. Because individual rows are redacted before persistence, the reconstructed reply is redacted again after joining and unescaping so a credential split across flush boundaries cannot bypass protection.

## Related Issue

Closes #6006

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Refactor / code improvement (no behavior change)
- [ ] Documentation update
- [x] Tests (adding or improving test coverage)
- [ ] CI / infrastructure

## Changes Made

- Add ReplyText to server/pkg/protocol/messages.go as an additive chat:done payload field.
- Derive the deliverable reply from persisted task messages in server/internal/service/reply_text.go.
- Reconstruct, unescape, and redact the complete delivery body after joining text fragments.
- Populate ReplyText during chat completion while preserving the existing no_response and compatibility behavior.
- Prefer ReplyText in both Slack and Lark outbound delivery.
- Add service extraction, cross-fragment redaction, typed payload, and serialized map payload tests.

## How to Test

1. Run GOCACHE=/private/tmp/multica-review-go-cache go test ./internal/service -run TestDeliverableReplyText -count=1.
2. Run GOCACHE=/private/tmp/multica-review-go-cache go test ./internal/integrations/lark ./internal/integrations/slack -count=1.
3. Run git diff --check.

All three checks pass. A broader internal/service package run was also attempted; unrelated database-backed tests are blocked locally because the shared test database is missing current columns such as session_rollout_missing and channel_ingested.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] If this change affects the UI, I have included before/after screenshots (not applicable: server-side channel delivery only)
- [x] I have updated relevant documentation to reflect my changes (not applicable: additive internal event payload and no user-facing docs change)
- [x] If I added a new runtime / coding tool / UI tab, I synced the change to landing copy and relevant docs (not applicable)
- [x] If this PR touches Chinese product copy, I checked it against the Chinese conventions (not applicable)
- [x] I have considered and documented any risks above
- [x] I will address all reviewer comments before requesting merge

## AI Disclosure

**AI tool used:** OpenAI Codex

**Prompt / approach:**
Reviewed commit e8979d22 with a repeated review-and-fix loop. Traced chat completion, persisted task messages, daemon flush ordering, Slack/Lark outbound extraction, compatibility fallbacks, and redaction boundaries. Added the final-reply derivation tests, identified and fixed cross-fragment credential leakage, reran focused and integration tests, and completed a final pass with no surviving high- or medium-severity findings.

## Screenshots (optional)

Not applicable; this is a server-side outbound message selection change.