### PR TITLE
fix(agent): add mutation deny policy for headless runtimes

### DIFF
--- a/server/pkg/agent/antigravity.go
+++ b/server/pkg/agent/antigravity.go
@@ -42,6 +42,9 @@ type antigravityBackend struct {
 }
 
 func (b *antigravityBackend) Execute(ctx context.Context, prompt string, opts ExecOptions) (*Session, error) {
+	if mutationPolicyDenies(b.cfg.Env) {
+		return nil, fmt.Errorf("mutation policy denies antigravity execution because daemon mode requires --dangerously-skip-permissions")
+	}
 	execPath := b.cfg.ExecutablePath
 	if execPath == "" {
 		execPath = "agy"

--- a/server/pkg/agent/antigravity_test.go
+++ b/server/pkg/agent/antigravity_test.go
@@ -39,6 +39,23 @@ func TestBuildAntigravityArgsBasic(t *testing.T) {
 	}
 }
 
+func TestAntigravityMutationPolicyRejectsUnsafeBypassBackend(t *testing.T) {
+	t.Parallel()
+
+	backend := &antigravityBackend{cfg: Config{
+		ExecutablePath: "/definitely/missing/agy",
+		Logger:         quietAntigravityLogger(),
+		Env:            map[string]string{"MULTICA_AGENT_MUTATION_POLICY": "deny"},
+	}}
+	_, err := backend.Execute(context.Background(), "read only", ExecOptions{})
+	if err == nil {
+		t.Fatal("expected mutation policy to reject antigravity before spawning")
+	}
+	if !strings.Contains(err.Error(), "mutation policy") {
+		t.Fatalf("error should name mutation policy, got %v", err)
+	}
+}
+
 func TestBuildAntigravityArgsModel(t *testing.T) {
 	t.Parallel()
 

--- a/server/pkg/agent/codex.go
+++ b/server/pkg/agent/codex.go
@@ -2239,11 +2239,19 @@ func (c *codexClient) handleServerRequest(raw map[string]json.RawMessage) {
 	// Auto-approve all exec/patch requests in daemon mode
 	switch method {
 	case "item/commandExecution/requestApproval", "execCommandApproval":
+		if mutationPolicyDenies(c.cfg.Env) {
+			c.respond(id, map[string]any{"decision": "reject"})
+			return
+		}
 		c.respond(id, map[string]any{"decision": "accept"})
 	case "item/fileChange/requestApproval", "applyPatchApproval":
+		if mutationPolicyDenies(c.cfg.Env) {
+			c.respond(id, map[string]any{"decision": "reject"})
+			return
+		}
 		c.respond(id, map[string]any{"decision": "accept"})
 	case "item/permissions/requestApproval":
-		c.respond(id, codexPermissionsApprovalResponse(raw["params"], c.cfg.Logger))
+		c.respond(id, codexPermissionsApprovalResponseWithPolicy(raw["params"], c.cfg.Logger, mutationPolicyDenies(c.cfg.Env)))
 	case "mcpServer/elicitation/request":
 		c.respond(id, map[string]any{"action": "accept", "content": nil, "_meta": nil})
 	default:
@@ -2265,6 +2273,10 @@ func (c *codexClient) handleServerRequest(raw map[string]json.RawMessage) {
 // app-server protocol that adds a new permission shape is visible in daemon
 // logs instead of being silently narrowed away.
 func codexPermissionsApprovalResponse(params json.RawMessage, logger *slog.Logger) map[string]any {
+	return codexPermissionsApprovalResponseWithPolicy(params, logger, false)
+}
+
+func codexPermissionsApprovalResponseWithPolicy(params json.RawMessage, logger *slog.Logger, denyMutations bool) map[string]any {
 	var payload struct {
 		Permissions map[string]any `json:"permissions"`
 	}
@@ -2278,6 +2290,9 @@ func codexPermissionsApprovalResponse(params json.RawMessage, logger *slog.Logge
 		switch key {
 		case "network", "fileSystem":
 			if value != nil {
+				if denyMutations && key == "fileSystem" {
+					value = stripMutatingFileSystemPermissions(value)
+				}
 				granted[key] = value
 			}
 		default:

--- a/server/pkg/agent/codex_test.go
+++ b/server/pkg/agent/codex_test.go
@@ -187,6 +187,85 @@ func TestCodexHandleServerRequestFileChangeApproval(t *testing.T) {
 	}
 }
 
+func TestCodexMutationPolicyDeniesCommandAndPatchApprovals(t *testing.T) {
+	t.Parallel()
+
+	c, fs, _ := newTestCodexClient(t)
+	c.cfg.Env = map[string]string{"MULTICA_AGENT_MUTATION_POLICY": "deny"}
+
+	c.handleLine(`{"jsonrpc":"2.0","id":31,"method":"item/commandExecution/requestApproval","params":{"command":"touch should-not-exist"}}`)
+	c.handleLine(`{"jsonrpc":"2.0","id":32,"method":"applyPatchApproval","params":{"changes":[{"path":"reply.md"}]}}`)
+
+	lines := fs.Lines()
+	if len(lines) != 2 {
+		t.Fatalf("expected 2 responses, got %d: %v", len(lines), lines)
+	}
+	for _, line := range lines {
+		var resp map[string]any
+		if err := json.Unmarshal([]byte(line), &resp); err != nil {
+			t.Fatalf("unmarshal %q: %v", line, err)
+		}
+		result := resp["result"].(map[string]any)
+		if result["decision"] != "reject" {
+			t.Fatalf("expected mutation approval decision=reject, got response: %v", resp)
+		}
+	}
+}
+
+func TestCodexMutationPolicyNarrowsFileSystemPermissionsToReadOnly(t *testing.T) {
+	t.Parallel()
+
+	c, fs, _ := newTestCodexClient(t)
+	c.cfg.Env = map[string]string{"MULTICA_AGENT_MUTATION_POLICY": "deny"}
+
+	c.handleLine(`{"jsonrpc":"2.0","id":33,"method":"item/permissions/requestApproval","params":{"permissions":{"network":{"enabled":true},"fileSystem":{"read":["/tmp/repo"],"write":["/tmp/repo"],"delete":["/tmp/repo"]}}}}`)
+
+	lines := fs.Lines()
+	if len(lines) != 1 {
+		t.Fatalf("expected 1 response, got %d", len(lines))
+	}
+	var resp map[string]any
+	if err := json.Unmarshal([]byte(lines[0]), &resp); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	result := resp["result"].(map[string]any)
+	permissions := result["permissions"].(map[string]any)
+	fileSystem := permissions["fileSystem"].(map[string]any)
+	if _, ok := fileSystem["read"]; !ok {
+		t.Fatalf("read permissions should be preserved, got %v", fileSystem)
+	}
+	if _, ok := fileSystem["write"]; ok {
+		t.Fatalf("write permissions should be stripped under deny policy, got %v", fileSystem)
+	}
+	if _, ok := fileSystem["delete"]; ok {
+		t.Fatalf("delete permissions should be stripped under deny policy, got %v", fileSystem)
+	}
+}
+
+func TestCodexMutationPolicyDropsUnexpectedFileSystemShape(t *testing.T) {
+	t.Parallel()
+
+	c, fs, _ := newTestCodexClient(t)
+	c.cfg.Env = map[string]string{"MULTICA_AGENT_MUTATION_POLICY": "deny"}
+
+	c.handleLine(`{"jsonrpc":"2.0","id":34,"method":"item/permissions/requestApproval","params":{"permissions":{"fileSystem":"write:/tmp/repo"}}}`)
+
+	lines := fs.Lines()
+	if len(lines) != 1 {
+		t.Fatalf("expected 1 response, got %d", len(lines))
+	}
+	var resp map[string]any
+	if err := json.Unmarshal([]byte(lines[0]), &resp); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	result := resp["result"].(map[string]any)
+	permissions := result["permissions"].(map[string]any)
+	fileSystem := permissions["fileSystem"].(map[string]any)
+	if len(fileSystem) != 0 {
+		t.Fatalf("unexpected filesystem shape should fail closed to empty permissions, got %v", fileSystem)
+	}
+}
+
 func TestCodexHandleServerRequestMCPElicitation(t *testing.T) {
 	t.Parallel()
 

--- a/server/pkg/agent/hermes.go
+++ b/server/pkg/agent/hermes.go
@@ -854,6 +854,33 @@ func (c *hermesClient) handleAgentRequest(raw map[string]json.RawMessage) {
 	var resp map[string]any
 	switch method {
 	case "session/request_permission":
+		if mutationPolicyDenies(c.cfg.Env) && acpPermissionRequestMutates(raw["params"]) {
+			optionID, ok := selectACPRejectOnce(raw["params"])
+			if ok {
+				resp = map[string]any{
+					"jsonrpc": "2.0",
+					"id":      json.RawMessage(rawID),
+					"result": map[string]any{
+						"outcome": map[string]any{
+							"outcome":  "selected",
+							"optionId": optionID,
+						},
+					},
+				}
+				c.cfg.Logger.Warn("mutation policy denied agent permission request", "method", method, "optionId", optionID)
+				break
+			}
+			resp = map[string]any{
+				"jsonrpc": "2.0",
+				"id":      json.RawMessage(rawID),
+				"error": map[string]any{
+					"code":    -32603,
+					"message": "mutation policy denied permission request and no reject_once option was offered",
+				},
+			}
+			c.cfg.Logger.Warn("mutation policy denied agent permission request without reject_once; returning error", "method", method)
+			break
+		}
 		optionID, grant, ok := selectACPPermissionOption(raw["params"])
 		if ok {
 			// Select an offered option — either a safe grant (approve) or,

--- a/server/pkg/agent/hermes_test.go
+++ b/server/pkg/agent/hermes_test.go
@@ -738,6 +738,102 @@ func TestHermesClientAutoApprovesPermissionRequest(t *testing.T) {
 	}
 }
 
+func TestHermesClientMutationPolicyAllowsReadOnlyPermissionRequest(t *testing.T) {
+	t.Parallel()
+
+	w := &bufferWriter{}
+	c := &hermesClient{
+		cfg: Config{
+			Logger: slog.Default(),
+			Env:    map[string]string{"MULTICA_AGENT_MUTATION_POLICY": "deny"},
+		},
+		stdin:   w,
+		pending: make(map[int]*pendingRPC),
+	}
+
+	c.handleLine(`{"jsonrpc":"2.0","id":43,"method":"session/request_permission","params":{"sessionId":"ses_1","options":[{"optionId":"allow_once","kind":"allow_once"},{"optionId":"deny","kind":"reject_once"}],"toolCall":{"toolCallId":"tc_read","title":"read: README.md","content":[]}}}`)
+
+	got := w.String()
+	var resp struct {
+		Result struct {
+			Outcome struct {
+				OptionID string `json:"optionId"`
+			} `json:"outcome"`
+		} `json:"result"`
+	}
+	if err := json.Unmarshal([]byte(strings.TrimSpace(got)), &resp); err != nil {
+		t.Fatalf("reply is not valid JSON: %q err=%v", got, err)
+	}
+	if resp.Result.Outcome.OptionID != "allow_once" {
+		t.Fatalf("read-only permission should remain allowed, got optionId=%q response=%s", resp.Result.Outcome.OptionID, got)
+	}
+}
+
+func TestHermesClientMutationPolicyDeniesWritePermissionRequest(t *testing.T) {
+	t.Parallel()
+
+	w := &bufferWriter{}
+	c := &hermesClient{
+		cfg: Config{
+			Logger: slog.Default(),
+			Env:    map[string]string{"MULTICA_AGENT_MUTATION_POLICY": "deny"},
+		},
+		stdin:   w,
+		pending: make(map[int]*pendingRPC),
+	}
+
+	c.handleLine(`{"jsonrpc":"2.0","id":44,"method":"session/request_permission","params":{"sessionId":"ses_1","options":[{"optionId":"allow_once","kind":"allow_once"},{"optionId":"deny","kind":"reject_once"}],"toolCall":{"toolCallId":"tc_write","title":"write: reply.md","content":[]}}}`)
+
+	got := w.String()
+	var resp struct {
+		Result struct {
+			Outcome struct {
+				OptionID string `json:"optionId"`
+			} `json:"outcome"`
+		} `json:"result"`
+	}
+	if err := json.Unmarshal([]byte(strings.TrimSpace(got)), &resp); err != nil {
+		t.Fatalf("reply is not valid JSON: %q err=%v", got, err)
+	}
+	if resp.Result.Outcome.OptionID != "deny" {
+		t.Fatalf("mutating permission should select offered reject_once, got optionId=%q response=%s", resp.Result.Outcome.OptionID, got)
+	}
+}
+
+func TestHermesClientMutationPolicyFailsClosedWithoutRejectOnce(t *testing.T) {
+	t.Parallel()
+
+	w := &bufferWriter{}
+	c := &hermesClient{
+		cfg: Config{
+			Logger: slog.Default(),
+			Env:    map[string]string{"MULTICA_AGENT_MUTATION_POLICY": "deny"},
+		},
+		stdin:   w,
+		pending: make(map[int]*pendingRPC),
+	}
+
+	c.handleLine(`{"jsonrpc":"2.0","id":45,"method":"session/request_permission","params":{"sessionId":"ses_1","options":[{"optionId":"allow_once","kind":"allow_once"}],"toolCall":{"toolCallId":"tc_write","title":"write: reply.md","content":[]}}}`)
+
+	got := w.String()
+	var resp struct {
+		Error *struct {
+			Code    int    `json:"code"`
+			Message string `json:"message"`
+		} `json:"error"`
+		Result any `json:"result"`
+	}
+	if err := json.Unmarshal([]byte(strings.TrimSpace(got)), &resp); err != nil {
+		t.Fatalf("reply is not valid JSON: %q err=%v", got, err)
+	}
+	if resp.Error == nil || resp.Error.Code != -32603 {
+		t.Fatalf("mutating permission without reject_once must fail closed with error, got response=%s", got)
+	}
+	if resp.Result != nil {
+		t.Fatalf("error response must not include result, got response=%s", got)
+	}
+}
+
 // TestHermesClientReplesMethodNotFoundForUnknownAgentRequest ensures
 // that any agent → client request we don't explicitly handle gets a
 // proper JSON-RPC error back, not silence. Silence would block the

--- a/server/pkg/agent/mutation_policy.go
+++ b/server/pkg/agent/mutation_policy.go
@@ -1,0 +1,87 @@
+package agent
+
+import (
+	"encoding/json"
+	"strings"
+)
+
+const mutationPolicyEnv = "MULTICA_AGENT_MUTATION_POLICY"
+
+// mutationPolicyDenies reports whether this runtime should fail closed on
+// mutating agent actions. The phase-0 POC uses this to keep Multica's headless
+// auto-approval paths available for read-only work while denying writes before
+// they reach the provider tool runtime.
+func mutationPolicyDenies(env map[string]string) bool {
+	return strings.EqualFold(strings.TrimSpace(env[mutationPolicyEnv]), "deny")
+}
+
+func acpPermissionRequestMutates(params json.RawMessage) bool {
+	if len(params) == 0 || string(params) == "null" {
+		return true
+	}
+	var p struct {
+		ToolCall struct {
+			Title   string          `json:"title"`
+			Name    string          `json:"name"`
+			Kind    string          `json:"kind"`
+			Content json.RawMessage `json:"content"`
+		} `json:"toolCall"`
+	}
+	if err := json.Unmarshal(params, &p); err != nil {
+		return true
+	}
+	probe := strings.ToLower(strings.TrimSpace(strings.Join([]string{
+		p.ToolCall.Title,
+		p.ToolCall.Name,
+		p.ToolCall.Kind,
+	}, " ")))
+	if probe == "" {
+		return true
+	}
+	// Permit-by-exception: only known read-only operation labels pass. Every
+	// other ACP permission request is treated as mutating under the deny policy.
+	for _, token := range []string{"read", "list", "search", "grep", "inspect", "view", "stat"} {
+		if hasACPReadOnlyLabel(probe, token) {
+			return false
+		}
+	}
+	return true
+}
+
+func hasACPReadOnlyLabel(probe, label string) bool {
+	probe = strings.TrimSpace(probe)
+	return probe == label ||
+		strings.HasPrefix(probe, label+":") ||
+		strings.HasPrefix(probe, label+" ") ||
+		strings.Contains(probe, " "+label+":") ||
+		strings.Contains(probe, " "+label+" ")
+}
+
+func selectACPRejectOnce(params json.RawMessage) (optionID string, ok bool) {
+	var p struct {
+		Options []acpPermissionOption `json:"options"`
+	}
+	if len(params) > 0 {
+		if err := json.Unmarshal(params, &p); err != nil {
+			return "", false
+		}
+	}
+	for _, opt := range p.Options {
+		if opt.OptionID != "" && strings.EqualFold(strings.TrimSpace(opt.Kind), acpKindRejectOnce) {
+			return opt.OptionID, true
+		}
+	}
+	return "", false
+}
+
+func stripMutatingFileSystemPermissions(value any) any {
+	fs, ok := value.(map[string]any)
+	if !ok {
+		return map[string]any{}
+	}
+	readOnly := map[string]any{}
+	if read, ok := fs["read"]; ok && read != nil {
+		readOnly["read"] = read
+	}
+	return readOnly
+}

--- a/server/pkg/agent/qwen.go
+++ b/server/pkg/agent/qwen.go
@@ -75,6 +75,9 @@ func (b *qwenBackend) Execute(ctx context.Context, prompt string, opts ExecOptio
 	timeout := opts.Timeout
 	runCtx, cancel := runContext(ctx, timeout)
 	args := buildQwenArgs(prompt, opts, b.cfg.Logger)
+	if mutationPolicyDenies(b.cfg.Env) {
+		args = filterCustomArgs(args, map[string]blockedArgMode{"--yolo": blockedStandalone}, b.cfg.Logger)
+	}
 
 	// Qwen Code 0.20.0 accepts a JSON string or a file path through
 	// --mcp-config. Materialise a managed config into a 0600 temp file so it

--- a/server/pkg/agent/qwen_test.go
+++ b/server/pkg/agent/qwen_test.go
@@ -72,6 +72,31 @@ func TestBuildQwenArgsYoloAlwaysPresent(t *testing.T) {
 	}
 }
 
+func TestQwenBackendMutationPolicyOmitsYoloBypass(t *testing.T) {
+	t.Parallel()
+
+	argsPath := filepath.Join(t.TempDir(), "qwen.args")
+	backend := newFakeQwenBackend(t, map[string]string{
+		"QWEN_ARGS_FILE":                argsPath,
+		"MULTICA_AGENT_MUTATION_POLICY": "deny",
+	})
+	session, err := backend.Execute(context.Background(), "read only", ExecOptions{Timeout: 5 * time.Second})
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	_, result := awaitQwenResult(t, session)
+	if result.Status != "completed" {
+		t.Fatalf("result status = %s error=%s", result.Status, result.Error)
+	}
+	data, err := os.ReadFile(argsPath)
+	if err != nil {
+		t.Fatalf("read qwen args: %v", err)
+	}
+	if strings.Contains(string(data), "--yolo") {
+		t.Fatalf("mutation deny policy must not launch qwen with --yolo bypass, args=%s", string(data))
+	}
+}
+
 func fakeQwenScript() string {
 	return `#!/bin/sh
 if [ -n "$QWEN_ARGS_FILE" ]; then printf '%s\n' "$@" > "$QWEN_ARGS_FILE"; fi


### PR DESCRIPTION
## Summary
- Add `MULTICA_AGENT_MUTATION_POLICY=deny` as a fail-closed guard for mutating headless agent actions.
- Deny Codex command/patch approvals and narrow Codex filesystem permission grants to read-only under the deny policy.
- Deny mutating Hermes ACP permission requests while preserving known read-only requests.
- Prevent Qwen YOLO bypass and reject Antigravity unsafe daemon execution when mutation denial is active.

## Test Plan
- [x] `go test ./pkg/agent -run 'TestCodexExecuteSemanticInactivityAllowsContinuousDeltaProgress|TestCodexExecuteSemanticInactivityAllowsContinuousMessages|TestCodexExecuteLegacyFirstTurnMessageSatisfiesProgress|TestCodexExecuteFirstTurnRetryErrorDoesNotSatisfyProgress' -count=1 -v`
- [x] `go test ./pkg/agent -run 'TestHermesClientMutationPolicy|TestCodexMutationPolicy|TestQwenBackendMutationPolicy|TestAntigravityMutationPolicy' -count=1 -v`
- [x] `go test ./... -run 'TestHermesClientMutationPolicy|TestCodexMutationPolicy|TestQwenBackendMutationPolicy|TestAntigravityMutationPolicy' -count=1`

Note: `go test ./pkg/agent -count=1` had an initial timing-sensitive failure in existing Codex inactivity tests; rerunning those exact tests individually passed.
