### PR TITLE
fix(channel): deliver the final answer only to Slack and Lark (MUL-5378)

### DIFF
--- a/server/internal/daemon/prompt.go
+++ b/server/internal/daemon/prompt.go
@@ -371,11 +371,8 @@ func buildChatPrompt(task Task) string {
 		} else {
 			fmt.Fprintf(&b, "Work from the context already provided to you below — Multica has no history reader for %s, so there is no command that can fetch more of this conversation. If you genuinely need earlier context that is not here, ask the user for it rather than guessing.\n", platform)
 		}
-		// The rule targets PROCESS, not results. "I just created the issue" is the
-		// deliverable for a do-this request, so the wording must forbid planned /
-		// in-progress narration while explicitly protecting the completion
-		// confirmation — otherwise a task-doing agent has nothing left to say.
-		fmt.Fprintf(&b, "What you send to %s is the deliverable, not a log of how you produced it. Do NOT narrate planned or in-progress steps: no \"我先读取…\" / \"let me look into that first\", and no progress notes from the middle of your work. Reply with the final outcome only. Stating what you completed IS that outcome, not narration — when the user asked you to do something, \"已创建 Issue\" / \"deployed to staging\" is exactly the confirmation they need.\n", platform)
+		// Scoped to process, not results — a completion confirmation IS the deliverable.
+		fmt.Fprintf(&b, "Reply to %s with the final outcome only. Do NOT narrate planned or in-progress steps (\"我先读取…\"); completed actions are part of the outcome.\n", platform)
 		b.WriteString("\n")
 	}
 	if task.Agent != nil && len(task.Agent.Skills) > 0 {

--- a/server/internal/daemon/prompt.go
+++ b/server/internal/daemon/prompt.go
@@ -346,6 +346,12 @@ func buildChatPrompt(task Task) string {
 	// from the context the inbound enricher already injected, so it gets the
 	// awareness statement without the commands, and ChatInThread — which only ever
 	// picks between those two commands — does not apply to it (MUL-4899).
+	//
+	// The no-narration rule is a THIRD axis and belongs to neither half: it is a
+	// property of delivering to an IM channel at all, so it is emitted for every
+	// channel type. #4776 introduced it that way; the MUL-4899 split moved it into
+	// the Slack branch along with the read commands it happened to mention, which
+	// silently dropped it for Feishu/Lark (GH #6006).
 	if task.ChatChannelType != "" {
 		platform := channelDisplayName(task.ChatChannelType)
 		fmt.Fprintf(&b, "You are operating inside a %s conversation — not the Multica web app. This conversation and its history live in %s, NOT in Multica; never look in Multica issues or comments for it.\n", platform, platform)
@@ -361,10 +367,11 @@ func buildChatPrompt(task Task) string {
 			// These reads are the agent's private context-gathering; narrating them
 			// into a chat reply reads as noise (the user reported every reply being
 			// prefixed with "我先读取…"). Tell the agent to keep them out of its answer.
-			b.WriteString("Do these reads SILENTLY as an internal step — they are how you gather context, not part of your answer. Do NOT narrate them: your reply must not begin with what you are about to read or just read (no \"我先读取…\" / \"let me read the history / open the thread\"). Reply to the user with your answer only.\n")
+			b.WriteString("Do these reads SILENTLY as an internal step — they are how you gather context, not part of your answer.\n")
 		} else {
 			fmt.Fprintf(&b, "Work from the context already provided to you below — Multica has no history reader for %s, so there is no command that can fetch more of this conversation. If you genuinely need earlier context that is not here, ask the user for it rather than guessing.\n", platform)
 		}
+		fmt.Fprintf(&b, "What you send to %s is the deliverable, not a log of how you produced it. Do NOT narrate: your reply must not say what you are about to do or just did (no \"我先读取…\" / \"let me read the history / check the code\"), and must not carry progress notes from the middle of your work. Reply with the final answer only.\n", platform)
 		b.WriteString("\n")
 	}
 	if task.Agent != nil && len(task.Agent.Skills) > 0 {

--- a/server/internal/daemon/prompt.go
+++ b/server/internal/daemon/prompt.go
@@ -371,7 +371,11 @@ func buildChatPrompt(task Task) string {
 		} else {
 			fmt.Fprintf(&b, "Work from the context already provided to you below — Multica has no history reader for %s, so there is no command that can fetch more of this conversation. If you genuinely need earlier context that is not here, ask the user for it rather than guessing.\n", platform)
 		}
-		fmt.Fprintf(&b, "What you send to %s is the deliverable, not a log of how you produced it. Do NOT narrate: your reply must not say what you are about to do or just did (no \"我先读取…\" / \"let me read the history / check the code\"), and must not carry progress notes from the middle of your work. Reply with the final answer only.\n", platform)
+		// The rule targets PROCESS, not results. "I just created the issue" is the
+		// deliverable for a do-this request, so the wording must forbid planned /
+		// in-progress narration while explicitly protecting the completion
+		// confirmation — otherwise a task-doing agent has nothing left to say.
+		fmt.Fprintf(&b, "What you send to %s is the deliverable, not a log of how you produced it. Do NOT narrate planned or in-progress steps: no \"我先读取…\" / \"let me look into that first\", and no progress notes from the middle of your work. Reply with the final outcome only. Stating what you completed IS that outcome, not narration — when the user asked you to do something, \"已创建 Issue\" / \"deployed to staging\" is exactly the confirmation they need.\n", platform)
 		b.WriteString("\n")
 	}
 	if task.Agent != nil && len(task.Agent.Skills) > 0 {

--- a/server/internal/daemon/prompt_test.go
+++ b/server/internal/daemon/prompt_test.go
@@ -348,7 +348,7 @@ func TestBuildChatPromptChannelAwareness(t *testing.T) {
 func TestBuildChatPromptNoNarrationOnEveryChannel(t *testing.T) {
 	const (
 		prohibition = "Do NOT narrate planned or in-progress steps"
-		carveOut    = "Stating what you completed IS that outcome"
+		carveOut    = "completed actions are part of the outcome"
 	)
 
 	for _, tc := range []struct {

--- a/server/internal/daemon/prompt_test.go
+++ b/server/internal/daemon/prompt_test.go
@@ -340,7 +340,17 @@ func TestBuildChatPromptChannelAwareness(t *testing.T) {
 // its wording happened to mention, so Feishu/Lark replies silently went back to
 // carrying interim narration. The two-layer matrix below could not catch that —
 // it only ever asserted the rule on the Slack case.
+//
+// The carve-out is pinned alongside the prohibition on purpose. A rule phrased
+// as "don't say what you just did" reads as forbidding "已创建 Issue X" — the
+// actual deliverable for a do-this request — so the two must move together: the
+// prohibition covers PROCESS, never the completed outcome.
 func TestBuildChatPromptNoNarrationOnEveryChannel(t *testing.T) {
+	const (
+		prohibition = "Do NOT narrate planned or in-progress steps"
+		carveOut    = "Stating what you completed IS that outcome"
+	)
+
 	for _, tc := range []struct {
 		name        string
 		channelType string
@@ -356,10 +366,19 @@ func TestBuildChatPromptNoNarrationOnEveryChannel(t *testing.T) {
 				ChatChannelType: tc.channelType,
 				ChatMessage:     "hi",
 			})
-			for _, phrase := range []string{"Do NOT narrate", "Reply with the final answer only."} {
+			for _, phrase := range []string{prohibition, carveOut} {
 				if got := strings.Contains(out, phrase); got != tc.want {
 					t.Errorf("%q present=%v, want %v\n--- output ---\n%s", phrase, got, tc.want, out)
 				}
+			}
+			if !tc.want {
+				return
+			}
+			// The prohibition must not read as a blanket ban on past tense. If a
+			// future edit drops the carve-out, an agent asked to create an issue
+			// has no way left to report that it did.
+			if strings.Contains(out, "must not say what you are about to do or just did") {
+				t.Errorf("prohibition must scope to process, not completed outcomes\n--- output ---\n%s", out)
 			}
 		})
 	}

--- a/server/internal/daemon/prompt_test.go
+++ b/server/internal/daemon/prompt_test.go
@@ -331,6 +331,40 @@ func TestBuildChatPromptChannelAwareness(t *testing.T) {
 	})
 }
 
+// TestBuildChatPromptNoNarrationOnEveryChannel pins the THIRD axis of the chat
+// channel policy: the no-narration delivery rule keys off "is there a channel at
+// all", like the upload axis and unlike the Slack-only history axis.
+//
+// Regression guard for GH #6006. #4776 introduced the rule for every channel;
+// the MUL-4899 split moved it into the Slack branch along with the read commands
+// its wording happened to mention, so Feishu/Lark replies silently went back to
+// carrying interim narration. The two-layer matrix below could not catch that —
+// it only ever asserted the rule on the Slack case.
+func TestBuildChatPromptNoNarrationOnEveryChannel(t *testing.T) {
+	for _, tc := range []struct {
+		name        string
+		channelType string
+		want        bool
+	}{
+		{name: "slack", channelType: execenv.ChannelTypeSlack, want: true},
+		{name: "feishu", channelType: execenv.ChannelTypeFeishu, want: true},
+		{name: "direct chat has no channel to deliver into", channelType: "", want: false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			out := buildChatPrompt(Task{
+				ChatSessionID:   "sess-1",
+				ChatChannelType: tc.channelType,
+				ChatMessage:     "hi",
+			})
+			for _, phrase := range []string{"Do NOT narrate", "Reply with the final answer only."} {
+				if got := strings.Contains(out, phrase); got != tc.want {
+					t.Errorf("%q present=%v, want %v\n--- output ---\n%s", phrase, got, tc.want, out)
+				}
+			}
+		})
+	}
+}
+
 // TestBuildChatPromptTwoLayerChannelPolicy pins the two INDEPENDENT axes of the
 // chat channel policy (MUL-4899). Collapsing them into one condition is exactly
 // the bug this matrix exists to catch:

--- a/server/pkg/agent/codex.go
+++ b/server/pkg/agent/codex.go
@@ -953,7 +953,13 @@ func (b *codexBackend) executeOnce(ctx context.Context, prompt string, opts Exec
 	semanticActivityCh := make(chan string, 256)
 
 	var outputMu sync.Mutex
-	var output strings.Builder
+	// Result.Output is "final user-facing output selected by the backend"
+	// (agent.go), so it holds the deliverable only. finalAnswer is the text the
+	// app-server labelled `phase: "final_answer"`; lastAgentMessage is the
+	// fallback for the legacy `agent_message` protocol, which carries no phase.
+	// Every agent message still flows to msgCh, so the transcript is unchanged —
+	// only what the daemon forwards to a chat/channel reply narrows (GH #6006).
+	var finalAnswer, lastAgentMessage string
 	var semanticObserved atomic.Bool
 	turnNotificationGate := &codexTurnNotificationGate{}
 
@@ -982,7 +988,7 @@ func (b *codexBackend) executeOnce(ctx context.Context, prompt string, opts Exec
 			logCodexAgentMessage(b.cfg.Logger, msg)
 			if msg.Type == MessageText {
 				outputMu.Lock()
-				output.WriteString(msg.Content)
+				lastAgentMessage = msg.Content
 				outputMu.Unlock()
 			}
 			trySend(msgCh, msg)
@@ -990,6 +996,11 @@ func (b *codexBackend) executeOnce(ctx context.Context, prompt string, opts Exec
 			if describeCodexSemanticActivity(msg) != "" {
 				semanticObserved.Store(true)
 			}
+		},
+		onFinalAnswer: func(text string) {
+			outputMu.Lock()
+			finalAnswer = text
+			outputMu.Unlock()
 		},
 		onSemanticActivity: func(description string) {
 			semanticObserved.Store(true)
@@ -1471,7 +1482,7 @@ func (b *codexBackend) executeOnce(ctx context.Context, prompt string, opts Exec
 		}
 
 		outputMu.Lock()
-		finalOutput := output.String()
+		finalOutput := codexDeliverableOutput(finalAnswer, lastAgentMessage)
 		outputMu.Unlock()
 
 		// Build usage map from accumulated codex usage.
@@ -1809,6 +1820,19 @@ func trySendString(ch chan<- string, value string) {
 	}
 }
 
+// codexDeliverableOutput picks Result.Output from what the turn produced: the
+// message the app-server itself labelled `phase: "final_answer"`, or — for the
+// legacy `agent_message` protocol, which carries no phase — the most recent
+// agent message. Never every message joined: the intermediate ones narrate the
+// work between tool calls, which belongs to the transcript and not to a chat or
+// IM reply (GH #6006).
+func codexDeliverableOutput(finalAnswer, lastAgentMessage string) string {
+	if finalAnswer != "" {
+		return finalAnswer
+	}
+	return lastAgentMessage
+}
+
 func logCodexAgentMessage(logger *slog.Logger, msg Message) {
 	if logger == nil {
 		return
@@ -1862,6 +1886,12 @@ type codexClient struct {
 	onMessage          func(Message)
 	onSemanticActivity func(description string)
 	onTurnDone         func(aborted bool)
+	// onFinalAnswer fires only for an agent message the app-server itself
+	// labelled `phase: "final_answer"` — the turn's deliverable, as opposed to
+	// the intermediate agent messages that narrate work between tool calls.
+	// Both still reach onMessage: the transcript keeps the whole timeline, only
+	// Result.Output is narrowed to the deliverable (GH #6006).
+	onFinalAnswer func(text string)
 	// acceptNotification isolates the active turn from same-thread history
 	// replay emitted while thread/resume is restoring prior conversation.
 	// Unit-level protocol tests leave it nil and exercise dispatch directly.
@@ -2578,8 +2608,17 @@ func (c *codexClient) handleItemNotification(method string, params map[string]an
 			c.onMessage(Message{Type: MessageText, Content: text})
 		}
 		phase, _ := item["phase"].(string)
-		if phase == "final_answer" && c.turnStarted {
-			if c.onTurnDone != nil {
+		if phase == "final_answer" {
+			// Deliberately NOT gated on turnStarted, unlike onTurnDone below:
+			// the gate exists so a subagent or a replayed history turn cannot
+			// end OUR turn early, and the thread guard at the top of this
+			// function already keeps foreign threads out. A final answer that
+			// arrives before we observed turn/started is still this thread's
+			// deliverable, and dropping it would fall back to narration.
+			if text != "" && c.onFinalAnswer != nil {
+				c.onFinalAnswer(text)
+			}
+			if c.turnStarted && c.onTurnDone != nil {
 				c.onTurnDone(false)
 			}
 		}

--- a/server/pkg/agent/codex_test.go
+++ b/server/pkg/agent/codex_test.go
@@ -1188,6 +1188,83 @@ func TestCodexRawItemAgentMessageFinalAnswer(t *testing.T) {
 	}
 }
 
+// TestCodexDeliverableOutputExcludesNarration pins Result.Output to the turn's
+// deliverable. Codex used to concatenate every agent message, so a tool-using
+// run shipped its intermediate narration to Slack and Lark along with the answer
+// (GH #6006). The wiring mirrors executeOnce: onMessage tracks the last agent
+// message, onFinalAnswer captures the phase-labelled one, and
+// codexDeliverableOutput picks between them.
+func TestCodexDeliverableOutputExcludesNarration(t *testing.T) {
+	t.Parallel()
+
+	const (
+		rawNarration   = `{"jsonrpc":"2.0","method":"item/completed","params":{"item":{"type":"agentMessage","id":"m1","text":"Let me check the logs."}}}`
+		rawFinal       = `{"jsonrpc":"2.0","method":"item/completed","params":{"item":{"type":"agentMessage","id":"m2","text":"The retry loop is the cause.","phase":"final_answer"}}}`
+		legacyFirst    = `{"jsonrpc":"2.0","method":"codex/event","params":{"msg":{"type":"agent_message","message":"Let me check the logs."}}}`
+		legacySecond   = `{"jsonrpc":"2.0","method":"codex/event","params":{"msg":{"type":"agent_message","message":"The retry loop is the cause."}}}`
+		wantDeliverabl = "The retry loop is the cause."
+	)
+
+	cases := []struct {
+		name     string
+		protocol string
+		lines    []string
+		want     string
+	}{
+		{
+			name:     "raw protocol keeps only the labelled final answer",
+			protocol: "raw",
+			lines:    []string{rawNarration, rawFinal},
+			want:     wantDeliverabl,
+		},
+		{
+			name:     "raw protocol without a final_answer falls back to the last message",
+			protocol: "raw",
+			lines:    []string{rawNarration, `{"jsonrpc":"2.0","method":"item/completed","params":{"item":{"type":"agentMessage","id":"m2","text":"The retry loop is the cause."}}}`},
+			want:     wantDeliverabl,
+		},
+		{
+			name:     "legacy protocol carries no phase and falls back to the last message",
+			protocol: "legacy",
+			lines:    []string{legacyFirst, legacySecond},
+			want:     wantDeliverabl,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			c, _, _ := newTestCodexClient(t)
+			c.notificationProtocol = tc.protocol
+			c.turnStarted = true
+
+			var finalAnswer, lastAgentMessage string
+			var streamed []string
+			c.onMessage = func(msg Message) {
+				if msg.Type == MessageText {
+					lastAgentMessage = msg.Content
+					streamed = append(streamed, msg.Content)
+				}
+			}
+			c.onFinalAnswer = func(text string) { finalAnswer = text }
+
+			for _, line := range tc.lines {
+				c.handleLine(line)
+			}
+
+			if got := codexDeliverableOutput(finalAnswer, lastAgentMessage); got != tc.want {
+				t.Fatalf("Result.Output = %q, want %q", got, tc.want)
+			}
+			// Narrowing delivery must not narrow the transcript: both messages
+			// still stream to the timeline the Multica UI renders.
+			if len(streamed) != 2 || streamed[0] != "Let me check the logs." {
+				t.Fatalf("expected both agent messages streamed, got %q", streamed)
+			}
+		})
+	}
+}
+
 func TestCodexRawThreadStatusIdle(t *testing.T) {
 	t.Parallel()
 
@@ -1299,11 +1376,15 @@ func TestCodexRawItemAgentMessageFinalAnswerFromSubagentIgnored(t *testing.T) {
 
 	var messages []Message
 	var doneCount int
+	var finalAnswer string
 	c.onMessage = func(msg Message) {
 		messages = append(messages, msg)
 	}
 	c.onTurnDone = func(aborted bool) {
 		doneCount++
+	}
+	c.onFinalAnswer = func(text string) {
+		finalAnswer = text
 	}
 
 	c.handleLine(`{"jsonrpc":"2.0","method":"item/completed","params":{"threadId":"thr_subagent","item":{"type":"agentMessage","id":"sub-1","text":"subagent leakage","phase":"final_answer"}}}`)
@@ -1313,6 +1394,12 @@ func TestCodexRawItemAgentMessageFinalAnswerFromSubagentIgnored(t *testing.T) {
 	}
 	if doneCount != 0 {
 		t.Fatalf("subagent final_answer must not trigger onTurnDone, got %d calls", doneCount)
+	}
+	// onFinalAnswer selects Result.Output, so a subagent reaching it would ship
+	// another thread's answer as this run's reply. It rides the same
+	// isNotificationFromOtherThread guard; pin that it stays behind it.
+	if finalAnswer != "" {
+		t.Fatalf("subagent final_answer must not become the deliverable, got %q", finalAnswer)
 	}
 }
 

--- a/server/pkg/agent/copilot.go
+++ b/server/pkg/agent/copilot.go
@@ -26,12 +26,31 @@ type copilotBackend struct {
 // event stream. It is shared between production (Execute) and tests via
 // handleCopilotEvent, so the parsing logic is never duplicated.
 type copilotEventState struct {
-	output      strings.Builder
-	sessionID   string
-	activeModel string
-	finalStatus string
-	finalError  string
-	usage       map[string]TokenUsage
+	// output holds the latest COMPLETE assistant turn, not every turn joined:
+	// Result.Output is "final user-facing output selected by the backend"
+	// (agent.go), and a tool-using run's earlier turns are narration around the
+	// work, not the deliverable (GH #6006). Every turn still reaches the
+	// transcript through the emitted MessageText.
+	output strings.Builder
+	// pendingDelta buffers the turn currently streaming. It is cleared when that
+	// turn's authoritative assistant.message lands, so it is non-empty only when
+	// the process died mid-turn — the one case where a partial beats the
+	// previous turn's complete text.
+	pendingDelta strings.Builder
+	sessionID    string
+	activeModel  string
+	finalStatus  string
+	finalError   string
+	usage        map[string]TokenUsage
+}
+
+// finalOutput is the deliverable for Result.Output: the last complete assistant
+// turn, or the partial turn that was still streaming when the process died.
+func (st *copilotEventState) finalOutput() string {
+	if st.pendingDelta.Len() > 0 {
+		return st.pendingDelta.String()
+	}
+	return st.output.String()
 }
 
 func newCopilotEventState(seedModel string) *copilotEventState {
@@ -68,9 +87,9 @@ func handleCopilotEvent(evt copilotEvent, st *copilotEventState) []Message {
 	case "assistant.message_delta":
 		var delta copilotMessageDelta
 		if err := json.Unmarshal(evt.Data, &delta); err == nil && delta.DeltaContent != "" {
-			// Write to output as defense-in-depth: if the process is killed
-			// before the final assistant.message arrives, we still have text.
-			st.output.WriteString(delta.DeltaContent)
+			// Buffer deltas as defense-in-depth: if the process is killed before
+			// this turn's assistant.message arrives, we still have its text.
+			st.pendingDelta.WriteString(delta.DeltaContent)
 			msgs = append(msgs, Message{Type: MessageText, Content: delta.DeltaContent})
 		}
 
@@ -79,18 +98,14 @@ func handleCopilotEvent(evt copilotEvent, st *copilotEventState) []Message {
 		if err := json.Unmarshal(evt.Data, &msg); err != nil {
 			return nil
 		}
-		// assistant.message carries the full turn content. Since deltas
-		// already wrote to output incrementally, we reset and write the
-		// authoritative content once to avoid double-counting.
+		// assistant.message carries the full turn content and supersedes both the
+		// deltas that streamed it and whatever earlier turn output held: a run
+		// that narrates, calls a tool, then answers must deliver the answer, not
+		// the pair joined together.
 		if msg.Content != "" {
-			// Separator between turns.
-			trimmed := strings.TrimSuffix(st.output.String(), msg.Content)
 			st.output.Reset()
-			st.output.WriteString(trimmed)
-			if st.output.Len() > 0 && !strings.HasSuffix(st.output.String(), "\n\n") {
-				st.output.WriteString("\n\n")
-			}
 			st.output.WriteString(msg.Content)
+			st.pendingDelta.Reset()
 		}
 		if msg.ReasoningText != "" {
 			msgs = append(msgs, Message{Type: MessageThinking, Content: msg.ReasoningText})
@@ -296,7 +311,7 @@ func (b *copilotBackend) Execute(ctx context.Context, prompt string, opts ExecOp
 
 		resCh <- Result{
 			Status:     st.finalStatus,
-			Output:     st.output.String(),
+			Output:     st.finalOutput(),
 			Error:      st.finalError,
 			DurationMs: duration.Milliseconds(),
 			SessionID:  st.sessionID,

--- a/server/pkg/agent/copilot.go
+++ b/server/pkg/agent/copilot.go
@@ -105,8 +105,12 @@ func handleCopilotEvent(evt copilotEvent, st *copilotEventState) []Message {
 		if msg.Content != "" {
 			st.output.Reset()
 			st.output.WriteString(msg.Content)
-			st.pendingDelta.Reset()
 		}
+		// Clear unconditionally — this event IS the turn boundary. A tool-only
+		// turn reports content:"" (the toolRequests below are the whole turn), and
+		// leaving its deltas buffered would let them be stitched onto the NEXT
+		// turn's partial text if the process then died mid-stream.
+		st.pendingDelta.Reset()
 		if msg.ReasoningText != "" {
 			msgs = append(msgs, Message{Type: MessageThinking, Content: msg.ReasoningText})
 		}

--- a/server/pkg/agent/copilot_test.go
+++ b/server/pkg/agent/copilot_test.go
@@ -693,6 +693,35 @@ func TestCopilotEventLoopDeliversFinalTurnOnly(t *testing.T) {
 	}
 }
 
+// TestCopilotEventLoopToolOnlyTurnClearsPendingDelta covers the turn shape the
+// delta fallback can get wrong: a turn whose authoritative assistant.message
+// reports content:"" because the tool requests ARE the turn. Its deltas must not
+// stay buffered, or a later turn that dies mid-stream would deliver the two
+// stitched together.
+func TestCopilotEventLoopToolOnlyTurnClearsPendingDelta(t *testing.T) {
+	t.Parallel()
+	lines := []string{
+		`{"type":"assistant.message_delta","data":{"messageId":"m1","deltaContent":"Checking the logs now."},"id":"d1","timestamp":"2026-04-16T08:43:38.000Z","parentId":"p1","ephemeral":true}`,
+		`{"type":"assistant.message","data":{"messageId":"m1","content":"","toolRequests":[{"toolCallId":"t1","name":"shell","arguments":{}}]},"id":"a1","timestamp":"2026-04-16T08:43:38.100Z","parentId":"p1"}`,
+		// Next turn starts streaming, then the process dies before its
+		// assistant.message lands.
+		`{"type":"assistant.message_delta","data":{"messageId":"m2","deltaContent":"The retry loop"},"id":"d2","timestamp":"2026-04-16T08:43:40.000Z","parentId":"p1","ephemeral":true}`,
+	}
+
+	st := newCopilotEventState("copilot")
+	for _, line := range lines {
+		var evt copilotEvent
+		if err := json.Unmarshal([]byte(line), &evt); err != nil {
+			t.Fatal(err)
+		}
+		handleCopilotEvent(evt, st)
+	}
+
+	if got := st.finalOutput(); got != "The retry loop" {
+		t.Fatalf("killed mid-turn should deliver that turn's partial only, got %q", got)
+	}
+}
+
 func TestCopilotExecuteSurfacesStderrOnNonZeroResult(t *testing.T) {
 	t.Parallel()
 	if runtime.GOOS == "windows" {

--- a/server/pkg/agent/copilot_test.go
+++ b/server/pkg/agent/copilot_test.go
@@ -649,8 +649,47 @@ func TestCopilotEventLoopDeltaFallbackOutput(t *testing.T) {
 		handleCopilotEvent(evt, st)
 	}
 
-	if st.output.String() != "hello world" {
-		t.Fatalf("expected output 'hello world', got %q", st.output.String())
+	if st.finalOutput() != "hello world" {
+		t.Fatalf("expected output 'hello world', got %q", st.finalOutput())
+	}
+}
+
+// TestCopilotEventLoopDeliversFinalTurnOnly pins Result.Output to the LAST
+// assistant turn. Copilot used to join every turn with "\n\n", so a run that
+// narrated, called a tool, then answered shipped narration + answer to Slack and
+// Lark as one reply (GH #6006). The narration still reaches the transcript as
+// MessageText; only the deliverable narrows.
+func TestCopilotEventLoopDeliversFinalTurnOnly(t *testing.T) {
+	t.Parallel()
+	lines := []string{
+		`{"type":"assistant.message_delta","data":{"messageId":"m1","deltaContent":"Let me check the logs."},"id":"d1","timestamp":"2026-04-16T08:43:38.000Z","parentId":"p1","ephemeral":true}`,
+		`{"type":"assistant.message","data":{"messageId":"m1","content":"Let me check the logs.","toolRequests":[{"toolCallId":"t1","name":"shell","arguments":{}}]},"id":"a1","timestamp":"2026-04-16T08:43:38.100Z","parentId":"p1"}`,
+		`{"type":"tool.execution_complete","data":{"toolCallId":"t1","success":true,"result":{"content":"nothing there"}},"id":"tc1","timestamp":"2026-04-16T08:43:39.000Z","parentId":"p1"}`,
+		`{"type":"assistant.message_delta","data":{"messageId":"m2","deltaContent":"The retry loop is the cause."},"id":"d2","timestamp":"2026-04-16T08:43:40.000Z","parentId":"p1","ephemeral":true}`,
+		`{"type":"assistant.message","data":{"messageId":"m2","content":"The retry loop is the cause."},"id":"a2","timestamp":"2026-04-16T08:43:40.100Z","parentId":"p1"}`,
+	}
+
+	st := newCopilotEventState("copilot")
+	var streamed []string
+	for _, line := range lines {
+		var evt copilotEvent
+		if err := json.Unmarshal([]byte(line), &evt); err != nil {
+			t.Fatal(err)
+		}
+		for _, m := range handleCopilotEvent(evt, st) {
+			if m.Type == MessageText {
+				streamed = append(streamed, m.Content)
+			}
+		}
+	}
+
+	if got := st.finalOutput(); got != "The retry loop is the cause." {
+		t.Fatalf("Result.Output should be the final turn only, got %q", got)
+	}
+	// The transcript must still see the narration — this fix narrows delivery,
+	// not the timeline the Multica UI renders.
+	if len(streamed) != 2 || streamed[0] != "Let me check the logs." {
+		t.Fatalf("expected both turns streamed as MessageText, got %q", streamed)
 	}
 }
 


### PR DESCRIPTION
## What does this PR do?

Slack and Lark replies could arrive as the agent's interim narration glued to its actual answer. There are two independent causes, and each is fixed at the layer that owns the deliverable.

**1. A prompt regression that dropped the rule for Lark.** #4776 (MUL-3871) told every channel-backed chat to reply with the answer only and not narrate. The MUL-4899 split in #5557 made the `chat history` / `chat thread` guidance Slack-only — correct, those endpoints are hardwired to `h.SlackHistory` — but it moved the no-narration rule into the Slack branch along with the read commands its wording happened to mention. Feishu/Lark lost the rule on 2026-07-17 and has been narrating since.

That rule is a *third* axis of the channel policy: it keys off "is there a channel at all", exactly like the attachment-upload axis and unlike the Slack-only history axis. It now lives outside the Slack gate.

The rule is scoped to **process, not results**: it bans planned and in-progress narration ("我先读取…", mid-run progress notes) and explicitly protects the completion confirmation, because for a do-this request "created the issue" *is* the deliverable rather than narration. Both halves are pinned by tests so a later edit cannot quietly turn it into a blanket ban on past tense.

**2. Two runtimes violating the `Result.Output` contract.** `agent.go` documents `Output` as *"final user-facing output selected by the backend"*, but:

- Codex concatenated **every** `agent_message` into one string, even though its app-server already labels the deliverable with `phase: "final_answer"`.
- Copilot joined **every** assistant turn with `"\n\n"` — the code literally called it "Separator between turns".

So a tool-using run handed the daemon `narration + answer`, and every downstream surface (chat reply, IM reply, issue fallback comment) inherited it. Both now select the final turn. Claude Code, CodeBuddy and qwen already go through `finalizeStreamResult`, which returns a terminal result only, and are untouched. pi was fixed this way in #4894.

**Thinking path.** GH #6006 reports the symptom on both Slack and Lark. Tracing `Result.Output` → `chat_message.Content` → `ChatDonePayload.Content` → the two outbound patchers shows the delivery path is a faithful pipe: it forwards whatever the backend selected. So the defect is upstream of delivery, in two places — the prompt that tells the agent what a reply is, and the runtime adapters that decide what `Output` means. Fixing it there keeps one definition of "the deliverable" instead of teaching each IM adapter to re-derive one.

This is deliberately **not** the approach in #6007, which adds a `ReplyText` field and reconstructs the answer in the service layer from the persisted `task_message` timeline. That reconstruction cannot hold today: the daemon buffers text and only flushes on a 500 ms ticker or at drain (`daemon.go`), while tool rows take their `seq` immediately — so a tool call that starts and finishes inside one tick window lands as `tool row → "narration+answer" in one text row`, and the derivation returns exactly the string it was meant to remove.

## Related Issue

Closes #6006

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Refactor / code improvement (no behavior change)
- [ ] Documentation update
- [x] Tests (adding or improving test coverage)
- [ ] CI / infrastructure

## Changes Made

- `server/internal/daemon/prompt.go` — move the no-narration delivery rule out of the Slack-only branch so every channel type gets it; scope it to planned / in-progress steps and state that a completed-action confirmation is the outcome, not narration.
- `server/internal/daemon/prompt_test.go` — `TestBuildChatPromptNoNarrationOnEveryChannel` pins the prohibition *and* the completion carve-out across slack / feishu / no-channel, plus a negative assertion against the blanket "what you just did" phrasing. The existing two-layer matrix only asserted the rule on Slack, which is why the regression shipped.
- `server/pkg/agent/codex.go` — add `onFinalAnswer`, fired only for `phase == "final_answer"`; `codexDeliverableOutput` prefers it and falls back to the most recent agent message for the legacy `agent_message` protocol, which carries no phase.
- `server/pkg/agent/copilot.go` — `output` holds the latest complete assistant turn instead of all turns joined; streaming deltas move to `pendingDelta`, cleared on every `assistant.message` since that event is the turn boundary — including a tool-only turn, which reports `content:""` and would otherwise leave its deltas to be stitched onto the next turn's partial text.
- `server/pkg/agent/codex_test.go` — deliverable selection across raw-with-phase / raw-without-phase / legacy; extend the subagent test to assert a foreign thread's `final_answer` cannot become this run's `Output`.
- `server/pkg/agent/copilot_test.go` — a narrate → tool → answer run delivers the answer only; a tool-only turn followed by a mid-stream death delivers just the partial latest turn (before the fix this returned the two concatenated).

Both runtime changes narrow **delivery only**. Every message still streams as `MessageText`, so the Multica transcript and the live timeline are byte-for-byte unchanged.

## How to Test

1. `cd server && go test ./internal/daemon/... -count=1`
2. `cd server && go test ./pkg/agent -count=1`
3. Targeted: `go test ./pkg/agent -run 'TestCodexDeliverableOutputExcludesNarration|TestCopilotEventLoopDeliversFinalTurnOnly|TestCopilotEventLoopToolOnlyTurnClearsPendingDelta' -count=1` and `go test ./internal/daemon -run TestBuildChatPromptNoNarrationOnEveryChannel -count=1`

All pass locally, along with `go build ./...` and `go vet ./pkg/agent/ ./internal/daemon/`. To see the regression itself, `buildChatPrompt` with `ChatChannelType: "feishu"` on `main` contains no no-narration instruction at all; with this PR both channel types do.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] If this change affects the UI, I have included before/after screenshots (n/a — server-side prompt and runtime output selection)
- [x] I have updated relevant documentation to reflect my changes (n/a — no CLI flag, API field or built-in skill behavior changes)
- [x] If I added a new runtime / coding tool / UI tab, I synced the change to landing copy and relevant docs (n/a)
- [x] If this PR touches Chinese product copy, I checked it against the conventions (the Chinese in the diff is inside English prompt sentences: the observed `我先读取…` narration example and `已创建 Issue` as a completion example, which follows the mixed rule for `Issue`)
- [x] I have considered and documented any risks above
- [x] I will address all reviewer comments before requesting merge

## Risks and follow-ups

- **Codex legacy protocol.** With no `phase` to key on, the fallback is the last agent message rather than the labelled final answer. For a run ending on a tool call that is the last narration — same semantics Claude Code's `lastAssistantText` already has, and strictly better than today's full concatenation.
- **Copilot mid-turn kill.** `pendingDelta` is returned only when a turn was still streaming, so a killed process yields the partial latest turn rather than the previous complete one. That matches the intent of the original defense-in-depth write.
- **Remaining adapters tracked as MUL-5387.** `opencode`, `deveco` and `openclaw` share the accumulating shape and want the same audit. Left out of this PR deliberately — I have no fixture to verify their turn boundaries against, and guessing at an adapter I cannot exercise is how this class of bug gets introduced. Filed separately so the gap does not disappear when this PR closes #6006.
- **Not in scope:** the daemon persists text rows out of order relative to tool rows (text takes its `seq` at flush time, tools take theirs immediately). That is a real defect for the web timeline and worth its own PR, but no correctness in this one depends on it.

## AI Disclosure

**AI tool used:** Claude Code (Multica agent)

**Prompt / approach:** Asked to verify GH #6006 at the code level and review the proposed fix in #6007. Traced the delivery chain from each runtime adapter through the daemon to both outbound patchers, found the delivery path blameless, then bisected the history to date the Lark regression to #5557 and confirmed it empirically by rendering `buildChatPrompt` for both channel types. Reviewed #6007 against that and concluded its timeline reconstruction is defeated by the daemon's 500 ms flush batching, so this PR fixes the two upstream causes instead. Review feedback on the first revision (the rule over-reaching into completion confirmations, and the Copilot tool-only turn boundary) was reproduced with failing tests before being fixed.
