### PR TITLE
feat(usage): cap the leaderboard at the top 10 agents behind a Show all toggle (MUL-5388)

### DIFF
--- a/packages/views/dashboard/components/dashboard-page.test.tsx
+++ b/packages/views/dashboard/components/dashboard-page.test.tsx
@@ -14,9 +14,9 @@ import type { NavigationAdapter } from "../../navigation";
 // dashboard options builders runs for real, so the key is the production key.
 const queryKeys = vi.hoisted(() => [] as unknown[][]);
 const dashboardDataRef = vi.hoisted(() => ({ current: false }));
-// Swaps the by-agent fixture for one with enough agents to exercise the
-// top-offenders cap. Kept off by default so the other tests keep their exact
-// 4-of-10 arithmetic.
+// Swaps the per-agent fixtures for ones with enough agents to exercise the
+// top-offenders and leaderboard caps. Kept off by default so the other tests
+// keep their exact 4-of-10 arithmetic.
 const manyAgentsRef = vi.hoisted(() => ({ current: false }));
 
 function todayIso() {
@@ -48,6 +48,49 @@ vi.mock("@tanstack/react-query", async () => {
           };
         }
         const kind = opts.queryKey[2];
+        // Bulk fixture: 12 agents, every per-agent metric strictly descending
+        // so both caps (leaderboard top 10, offenders top 8) are testable by
+        // rank without the ties an equal-valued fixture would create. The
+        // date-bucketed series stay on the small fixture below — the caps are
+        // a property of the per-agent lists only.
+        const bulkRows =
+          !manyAgentsRef.current
+            ? null
+            : kind === "by-agent"
+              ? Array.from({ length: 12 }, (_, i) => ({
+                  agent_id: `bulk-${i}`,
+                  provider: "anthropic",
+                  model: "claude-sonnet-4-6",
+                  input_tokens: (12 - i) * 1_000,
+                  output_tokens: 0,
+                  cache_read_tokens: 0,
+                  cache_write_tokens: 0,
+                  task_count: 12 - i,
+                }))
+              : kind === "agent-runtime"
+                ? Array.from({ length: 12 }, (_, i) => ({
+                    agent_id: `bulk-${i}`,
+                    total_seconds: (12 - i) * 600,
+                    task_count: 12 - i,
+                    failed_count: 12 - i,
+                  }))
+                : kind === "failures-by-agent"
+                  ? Array.from({ length: 12 }, (_, i) => [
+                      {
+                        agent_id: `bulk-${i}`,
+                        failure_reason: "",
+                        task_count: 100,
+                      },
+                      {
+                        agent_id: `bulk-${i}`,
+                        failure_reason: "timeout",
+                        task_count: 12 - i,
+                      },
+                    ]).flat()
+                  : null;
+        if (bulkRows) {
+          return { data: bulkRows, isLoading: false, isSuccess: true };
+        }
         const data =
           kind === "daily"
             ? [
@@ -93,21 +136,7 @@ vi.mock("@tanstack/react-query", async () => {
                       { date: todayIso(), failure_reason: "timeout", task_count: 1 },
                     ]
                   : kind === "failures-by-agent"
-                    ? manyAgentsRef.current
-                      ? Array.from({ length: 12 }, (_, i) => [
-                          {
-                            agent_id: `bulk-${i}`,
-                            failure_reason: "",
-                            task_count: 100,
-                          },
-                          {
-                            agent_id: `bulk-${i}`,
-                            failure_reason: "timeout",
-                            // Descending so rank order is unambiguous.
-                            task_count: 12 - i,
-                          },
-                        ]).flat()
-                      : [
+                    ? [
                         { agent_id: "agent-1", failure_reason: "", task_count: 6 },
                         {
                           agent_id: "agent-1",
@@ -411,6 +440,65 @@ describe("DashboardPage — Errors card placement and density", () => {
 
     expect(
       screen.queryByRole("button", { name: /Show all/ }),
+    ).not.toBeInTheDocument();
+  });
+});
+
+describe("DashboardPage — leaderboard density", () => {
+  beforeEach(() => {
+    queryKeys.length = 0;
+    dashboardDataRef.current = true;
+    manyAgentsRef.current = false;
+    tzRef.current = "UTC";
+    cleanup();
+  });
+
+  it("ranks the top 10 agents and keeps the tail behind a toggle", async () => {
+    manyAgentsRef.current = true;
+    const user = userEvent.setup();
+    renderDashboard();
+
+    const list = () => within(screen.getByRole("list", { name: "Leaderboard" }));
+    // 12 agents have usage. Flattening all of them is what pushed the Errors
+    // card a full screen below the fold (MUL-5388).
+    expect(list().getAllByRole("listitem")).toHaveLength(10);
+    // Ranked by tokens desc, so the two smallest spenders are the ones cut.
+    expect(list().getByText("Bulk Agent 0")).toBeInTheDocument();
+    expect(list().queryByText("Bulk Agent 10")).not.toBeInTheDocument();
+    expect(list().queryByText("Bulk Agent 11")).not.toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "Show all" }));
+    expect(list().getAllByRole("listitem")).toHaveLength(12);
+    expect(list().getByText("Bulk Agent 11")).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "Show top 10" }));
+    expect(list().getAllByRole("listitem")).toHaveLength(10);
+  });
+
+  it("keeps the cap honest when the ranking metric changes", async () => {
+    manyAgentsRef.current = true;
+    const user = userEvent.setup();
+    renderDashboard();
+
+    // Scoped to the leaderboard card — the trend chart's metric toggle owns
+    // a "Time" button too.
+    const card = screen.getByRole("list", { name: "Leaderboard" })
+      .parentElement as HTMLElement;
+    // Re-ranking must not quietly reveal the tail: the cap belongs to the
+    // list, not to one metric.
+    await user.click(within(card).getByRole("button", { name: "Time" }));
+
+    const list = within(screen.getByRole("list", { name: "Leaderboard" }));
+    expect(list.getAllByRole("listitem")).toHaveLength(10);
+  });
+
+  it("shows no expand affordance when every agent already fits", () => {
+    renderDashboard();
+
+    const list = within(screen.getByRole("list", { name: "Leaderboard" }));
+    expect(list.getAllByRole("listitem")).toHaveLength(1);
+    expect(
+      screen.queryByRole("button", { name: "Show all" }),
     ).not.toBeInTheDocument();
   });
 });

--- a/packages/views/dashboard/components/dashboard-page.tsx
+++ b/packages/views/dashboard/components/dashboard-page.tsx
@@ -1161,6 +1161,13 @@ const SORT_METRIC: Record<LeaderboardSort, (r: AgentDashboardRow) => number> = {
   tasks: (r) => r.taskCount,
 };
 
+// How many agents the leaderboard ranks before collapsing the tail behind a
+// toggle, mirroring the Errors card's top-offenders cap. A workspace with
+// dozens of agents rendered every one of them, which pushed the Errors card a
+// full screen or more below the fold (MUL-5388). Ten answers "who is spending
+// the most" — the tail is reachable via the toggle.
+const LEADERBOARD_LIMIT = 10;
+
 function Leaderboard({
   rows,
   agents,
@@ -1174,6 +1181,7 @@ function Leaderboard({
 }) {
   const { t } = useT("usage");
   const [sortBy, setSortBy] = useState<LeaderboardSort>("tokens");
+  const [showAll, setShowAll] = useState(false);
 
   const sortOptions = useMemo(
     () => [
@@ -1193,10 +1201,17 @@ function Leaderboard({
     return rows.toSorted((a, b) => metric(b) - metric(a));
   }, [rows, sortBy]);
 
+  // Measured across every row, not just the visible ones, so a bar's width
+  // means the same thing collapsed and expanded — the leader always fills the
+  // track and nothing re-scales when the tail comes into view.
   const maxValue = useMemo(() => {
     const metric = SORT_METRIC[sortBy];
     return sortedRows.reduce((m, r) => Math.max(m, metric(r)), 0);
   }, [sortedRows, sortBy]);
+
+  const visibleRows = showAll
+    ? sortedRows
+    : sortedRows.slice(0, LEADERBOARD_LIMIT);
 
   // Active column gets foreground text; others stay muted. Helps the user
   // see "this is what the bar is measuring" at a glance.
@@ -1207,7 +1222,7 @@ function Leaderboard({
     <div className="rounded-lg border bg-card">
       <div className="flex flex-wrap items-center justify-between gap-3 border-b px-4 pt-4 pb-3">
         <h4 className="text-sm font-semibold">{t(($) => $.leaderboard.title)}</h4>
-        <div className="flex items-center gap-3">
+        <div className="flex flex-wrap items-center justify-end gap-3">
           <Segmented value={sortBy} onChange={setSortBy} options={sortOptions} />
           <span className="text-xs text-muted-foreground">
             {deletedAgentCount > 0
@@ -1217,6 +1232,21 @@ function Leaderboard({
                 })
               : t(($) => $.leaderboard.caption, { count: rows.length })}
           </span>
+          {/* The caption right beside this already states how many agents the
+              window covers, so the toggle carries a count only when
+              collapsing — spelling the total out twice reads as two different
+              numbers once the deleted-agents bucket splits the caption. */}
+          {sortedRows.length > LEADERBOARD_LIMIT ? (
+            <button
+              type="button"
+              onClick={() => setShowAll((v) => !v)}
+              className="text-xs text-muted-foreground underline-offset-2 hover:text-foreground hover:underline"
+            >
+              {showAll
+                ? t(($) => $.leaderboard.show_less, { count: LEADERBOARD_LIMIT })
+                : t(($) => $.leaderboard.show_all)}
+            </button>
+          ) : null}
         </div>
       </div>
       {sortedRows.length === 0 ? (
@@ -1233,8 +1263,11 @@ function Leaderboard({
             <span className={colClass("time")}>{t(($) => $.leaderboard.header_time)}</span>
             <span className={colClass("tasks")}>{t(($) => $.leaderboard.header_tasks)}</span>
           </div>
-          <div className="divide-y">
-            {sortedRows.map((row) => {
+          {/* A real list, like the Errors card's offender list: the rows are
+              now a truncated ranking, so screen readers need the count and the
+              item boundaries rather than a bag of divs. */}
+          <ul aria-label={t(($) => $.leaderboard.title)} className="divide-y">
+            {visibleRows.map((row) => {
               // The deleted-agents bucket is a synthetic row, not a real agent:
               // render a neutral placeholder (no avatar fetch / hover card / UUID)
               // and dash out Time/Tasks, which it never carries (see
@@ -1244,7 +1277,7 @@ function Leaderboard({
               const value = SORT_METRIC[sortBy](row);
               const pct = maxValue > 0 ? (value / maxValue) * 100 : 0;
               return (
-                <div
+                <li
                   key={row.agentId}
                   className="grid grid-cols-[minmax(0,1.6fr)_minmax(0,1fr)_5rem_5rem_5rem_4rem] items-center gap-3 px-4 py-2"
                 >
@@ -1300,10 +1333,10 @@ function Leaderboard({
                   >
                     {isDeletedBucket ? "—" : row.taskCount}
                   </div>
-                </div>
+                </li>
               );
             })}
-          </div>
+          </ul>
         </>
       )}
     </div>

--- a/packages/views/locales/en/usage.json
+++ b/packages/views/locales/en/usage.json
@@ -74,6 +74,8 @@
     "header_cost": "Cost",
     "header_time": "Time",
     "header_tasks": "Tasks",
+    "show_all": "Show all",
+    "show_less": "Show top {{count}}",
     "no_data": "No agent activity in this window."
   },
   "empty": {

--- a/packages/views/locales/ja/usage.json
+++ b/packages/views/locales/ja/usage.json
@@ -74,6 +74,8 @@
     "header_cost": "コスト",
     "header_time": "時間",
     "header_tasks": "タスク",
+    "show_all": "すべて表示",
+    "show_less": "上位 {{count}} 件のみ",
     "no_data": "この期間にエージェントの活動はありません。"
   },
   "empty": {

--- a/packages/views/locales/ko/usage.json
+++ b/packages/views/locales/ko/usage.json
@@ -74,6 +74,8 @@
     "header_cost": "비용",
     "header_time": "시간",
     "header_tasks": "작업",
+    "show_all": "전체 보기",
+    "show_less": "상위 {{count}}개만",
     "no_data": "이 기간에는 에이전트 활동이 없습니다."
   },
   "empty": {

--- a/packages/views/locales/zh-Hans/usage.json
+++ b/packages/views/locales/zh-Hans/usage.json
@@ -74,6 +74,8 @@
     "header_cost": "费用",
     "header_time": "运行时长",
     "header_tasks": "任务数",
+    "show_all": "展开全部",
+    "show_less": "只看前 {{count}} 个",
     "no_data": "所选时间范围内暂无智能体活动。"
   },
   "empty": {


### PR DESCRIPTION
## Summary

The Usage leaderboard rendered every agent in the workspace. Once a workspace has dozens of agents, that list runs long enough to push the Errors card a full screen or more below the fold, so reading the error board meant scrolling past the entire roster.

The leaderboard now ranks the **top 10** agents by the selected metric and collapses the tail behind a **Show all** toggle — the same affordance the Errors card's "Top offenders" list already uses.

- `LEADERBOARD_LIMIT = 10`; the toggle only renders when there is actually a tail to reveal, and flips between `Show all` and `Show top 10`.
- Bar widths keep measuring against the max across **all** rows, not just the visible ones, so nothing re-scales when the tail comes into view.
- The cap survives a metric switch — re-ranking by Cost / Time / Tasks re-picks the top 10 rather than revealing everything.
- Rows became a real `<ul>` / `<li>`, matching the offender list. A truncated ranking needs item boundaries and a count for screen readers.
- Copy added to all four locales (`en` / `zh-Hans` / `ja` / `ko`). The card caption already states the total agent count, so the expand label stays count-free — carrying the total in both spots would print two different numbers whenever the deleted-agents bucket splits the caption.

## Verification

- `pnpm test` — 3110 tests, 267 files, all passing.
- `pnpm typecheck` — clean.
- `pnpm lint` — no new warnings.
- Three new cases in `packages/views/dashboard/components/dashboard-page.test.tsx`: the cap + expand/collapse round trip, the cap holding across a metric change, and no toggle when every agent already fits. Mutation-checked by raising the limit to 999 — the two cap tests fail, confirming they are not tautological.
