### PR TITLE
fix(qoder): deliver final answer only (MUL-5394)

### DIFF
--- a/server/pkg/agent/qoder.go
+++ b/server/pkg/agent/qoder.go
@@ -142,7 +142,12 @@ func (b *qoderBackend) Execute(ctx context.Context, prompt string, opts ExecOpti
 	resCh := make(chan Result, 1)
 
 	var outputMu sync.Mutex
-	var output strings.Builder
+	// Result.Output is the final user-facing output selected by the backend.
+	// Qoder emits interim narration and the final answer as the same ACP
+	// AgentMessageChunk type, with tool calls as the only reliable boundary.
+	// Keep the complete text for provider-error detection, while deliverable
+	// holds only the text block after the latest tool call.
+	var fullOutput, deliverableOutput strings.Builder
 	var streamingCurrentTurn atomic.Bool
 
 	promptDone := make(chan hermesPromptResult, 1)
@@ -162,11 +167,15 @@ func (b *qoderBackend) Execute(ctx context.Context, prompt string, opts ExecOpti
 			if msg.Type == MessageToolUse {
 				msg.Tool = kimiToolNameFromTitle(msg.Tool)
 			}
-			if msg.Type == MessageText {
-				outputMu.Lock()
-				output.WriteString(msg.Content)
-				outputMu.Unlock()
+			outputMu.Lock()
+			switch msg.Type {
+			case MessageText:
+				fullOutput.WriteString(msg.Content)
+				deliverableOutput.WriteString(msg.Content)
+			case MessageToolUse:
+				deliverableOutput.Reset()
 			}
+			outputMu.Unlock()
 			msgStream.send(msg)
 		},
 		onPromptDone: func(result hermesPromptResult) {
@@ -406,7 +415,8 @@ func (b *qoderBackend) Execute(ctx context.Context, prompt string, opts ExecOpti
 		streamingCurrentTurn.Store(false)
 
 		outputMu.Lock()
-		finalOutput := output.String()
+		finalOutput := deliverableOutput.String()
+		providerErrorOutput := fullOutput.String()
 		outputMu.Unlock()
 
 		// Promote completed→failed when stderr or the agent text stream show a
@@ -414,7 +424,7 @@ func (b *qoderBackend) Execute(ctx context.Context, prompt string, opts ExecOpti
 		// Mirrors hermes/kimi/kiro; without it a run that exhausts retries still
 		// reports "completed" because session/prompt ends with stopReason=end_turn
 		// even though qodercli wrote a terminal error to stderr.
-		finalStatus, finalError = promoteACPResultOnProviderError(finalStatus, finalError, finalOutput, providerErr)
+		finalStatus, finalError = promoteACPResultOnProviderError(finalStatus, finalError, providerErrorOutput, providerErr)
 
 		c.usageMu.Lock()
 		u := c.usage

--- a/server/pkg/agent/qoder.go
+++ b/server/pkg/agent/qoder.go
@@ -146,8 +146,10 @@ func (b *qoderBackend) Execute(ctx context.Context, prompt string, opts ExecOpti
 	// Qoder emits interim narration and the final answer as the same ACP
 	// AgentMessageChunk type, with tool calls as the only reliable boundary.
 	// Keep the complete text for provider-error detection, while deliverable
-	// holds only the text block after the latest tool call.
+	// holds only the text block after the latest tool call. This boundary is a
+	// heuristic until Qoder exposes an explicit final-answer marker.
 	var fullOutput, deliverableOutput strings.Builder
+	var lastTextBlock string
 	var streamingCurrentTurn atomic.Bool
 
 	promptDone := make(chan hermesPromptResult, 1)
@@ -173,6 +175,9 @@ func (b *qoderBackend) Execute(ctx context.Context, prompt string, opts ExecOpti
 				fullOutput.WriteString(msg.Content)
 				deliverableOutput.WriteString(msg.Content)
 			case MessageToolUse:
+				if block := deliverableOutput.String(); strings.TrimSpace(block) != "" {
+					lastTextBlock = block
+				}
 				deliverableOutput.Reset()
 			}
 			outputMu.Unlock()
@@ -416,6 +421,9 @@ func (b *qoderBackend) Execute(ctx context.Context, prompt string, opts ExecOpti
 
 		outputMu.Lock()
 		finalOutput := deliverableOutput.String()
+		if strings.TrimSpace(finalOutput) == "" {
+			finalOutput = lastTextBlock
+		}
 		providerErrorOutput := fullOutput.String()
 		outputMu.Unlock()
 

--- a/server/pkg/agent/qoder_test.go
+++ b/server/pkg/agent/qoder_test.go
@@ -42,6 +42,38 @@ done
 `
 }
 
+func fakeQoderACPScriptWithNarrationAndFinalAnswer() string {
+	return `#!/bin/sh
+# Mirrors a real Qoder ACP turn: interim narration, a tool call, then the
+# user-facing answer. All text chunks belong in the transcript, but only the
+# post-tool chunk is the backend's deliverable Result.Output.
+while IFS= read -r line; do
+  id=$(printf '%s' "$line" | sed -n 's/.*"id":\([0-9]*\).*/\1/p')
+  case "$line" in
+    *'"method":"initialize"'*)
+      printf '{"jsonrpc":"2.0","id":%s,"result":{"protocolVersion":1,"agentCapabilities":{}}}\n' "$id"
+      ;;
+    *'"method":"session/new"'*)
+      printf '{"jsonrpc":"2.0","id":%s,"result":{"sessionId":"ses_final"}}\n' "$id"
+      ;;
+    *'"method":"session/prompt"'*)
+      narration='I will inspect the attachment.'
+      if [ "$QODER_TERMINAL_ERROR_BEFORE_TOOL" = "1" ]; then
+        narration='API call failed after 3 retries: HTTP 429'
+      fi
+      printf '{"jsonrpc":"2.0","method":"session/notification","params":{"sessionId":"ses_final","update":{"type":"AgentMessageChunk","content":{"type":"text","text":"%s"}}}}\n' "$narration"
+      printf '{"jsonrpc":"2.0","method":"session/notification","params":{"sessionId":"ses_final","update":{"type":"ToolCall","toolCallId":"tc-read","name":"read_file","status":"pending","parameters":{"path":"diagram.svg"}}}}\n'
+      printf '{"jsonrpc":"2.0","method":"session/notification","params":{"sessionId":"ses_final","update":{"type":"ToolCallUpdate","toolCallId":"tc-read","name":"read_file","status":"completed","output":"<svg />"}}}\n'
+      printf '{"jsonrpc":"2.0","method":"session/notification","params":{"sessionId":"ses_final","update":{"type":"AgentMessageChunk","content":{"type":"text","text":"The diagram shows "}}}}\n'
+      printf '{"jsonrpc":"2.0","method":"session/notification","params":{"sessionId":"ses_final","update":{"type":"AgentMessageChunk","content":{"type":"text","text":"the service architecture."}}}}\n'
+      printf '{"jsonrpc":"2.0","id":%s,"result":{"stopReason":"end_turn","usage":{"inputTokens":10,"outputTokens":20}}}\n' "$id"
+      exit 0
+      ;;
+  esac
+done
+`
+}
+
 func fakeQoderACPStaleResumeScript() string {
 	return `#!/bin/sh
 while IFS= read -r line; do
@@ -357,6 +389,95 @@ func TestQoderBackendHappyPath(t *testing.T) {
 	}
 	if u := result.Usage["unknown"]; u.InputTokens != 1 || u.OutputTokens != 2 {
 		t.Fatalf("usage=%+v", u)
+	}
+}
+
+func TestQoderBackendDeliversFinalAnswerWithoutNarration(t *testing.T) {
+	t.Parallel()
+
+	fakePath := filepath.Join(t.TempDir(), "qodercli")
+	writeTestExecutable(t, fakePath, []byte(fakeQoderACPScriptWithNarrationAndFinalAnswer()))
+
+	backend, err := New("qoder", Config{ExecutablePath: fakePath, Logger: slog.Default()})
+	if err != nil {
+		t.Fatalf("new qoder backend: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	session, err := backend.Execute(ctx, "inspect this attachment", ExecOptions{Timeout: 30 * time.Second})
+	if err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+
+	var streamed []Message
+	messagesDone := make(chan struct{})
+	go func() {
+		defer close(messagesDone)
+		for msg := range session.Messages {
+			streamed = append(streamed, msg)
+		}
+	}()
+
+	result := <-session.Result
+	<-messagesDone
+
+	const want = "The diagram shows the service architecture."
+	if result.Status != "completed" {
+		t.Fatalf("status=%q err=%q", result.Status, result.Error)
+	}
+	if result.Output != want {
+		t.Fatalf("Result.Output = %q, want %q", result.Output, want)
+	}
+
+	var text []string
+	for _, msg := range streamed {
+		if msg.Type == MessageText {
+			text = append(text, msg.Content)
+		}
+	}
+	if got := strings.Join(text, "|"); got != "I will inspect the attachment.|The diagram shows |the service architecture." {
+		t.Fatalf("transcript text = %q, want narration and final answer", got)
+	}
+}
+
+func TestQoderBackendProviderErrorDetectionUsesFullOutput(t *testing.T) {
+	t.Parallel()
+
+	fakePath := filepath.Join(t.TempDir(), "qodercli")
+	writeTestExecutable(t, fakePath, []byte(fakeQoderACPScriptWithNarrationAndFinalAnswer()))
+
+	backend, err := New("qoder", Config{
+		ExecutablePath: fakePath,
+		Logger:         slog.Default(),
+		Env:            map[string]string{"QODER_TERMINAL_ERROR_BEFORE_TOOL": "1"},
+	})
+	if err != nil {
+		t.Fatalf("new qoder backend: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	session, err := backend.Execute(ctx, "inspect this attachment", ExecOptions{Timeout: 30 * time.Second})
+	if err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	go func() {
+		for range session.Messages {
+		}
+	}()
+
+	result := <-session.Result
+	if result.Status != "failed" {
+		t.Fatalf("status=%q, want failed (output=%q error=%q)", result.Status, result.Output, result.Error)
+	}
+	if result.Output != "The diagram shows the service architecture." {
+		t.Fatalf("Result.Output = %q, want final answer only", result.Output)
+	}
+	if !strings.Contains(result.Error, "API call failed after 3 retries") {
+		t.Fatalf("error=%q, want provider error from the full text stream", result.Error)
 	}
 }
 

--- a/server/pkg/agent/qoder_test.go
+++ b/server/pkg/agent/qoder_test.go
@@ -58,14 +58,23 @@ while IFS= read -r line; do
       ;;
     *'"method":"session/prompt"'*)
       narration='I will inspect the attachment.'
+      if [ -n "$QODER_TEXT_BEFORE_TOOL" ]; then
+        narration=$QODER_TEXT_BEFORE_TOOL
+      fi
       if [ "$QODER_TERMINAL_ERROR_BEFORE_TOOL" = "1" ]; then
         narration='API call failed after 3 retries: HTTP 429'
       fi
       printf '{"jsonrpc":"2.0","method":"session/notification","params":{"sessionId":"ses_final","update":{"type":"AgentMessageChunk","content":{"type":"text","text":"%s"}}}}\n' "$narration"
-      printf '{"jsonrpc":"2.0","method":"session/notification","params":{"sessionId":"ses_final","update":{"type":"ToolCall","toolCallId":"tc-read","name":"read_file","status":"pending","parameters":{"path":"diagram.svg"}}}}\n'
+      if [ "$QODER_DEFERRED_TOOL" = "1" ]; then
+        printf '{"jsonrpc":"2.0","method":"session/notification","params":{"sessionId":"ses_final","update":{"type":"ToolCall","toolCallId":"tc-read","name":"read_file","status":"pending"}}}\n'
+      else
+        printf '{"jsonrpc":"2.0","method":"session/notification","params":{"sessionId":"ses_final","update":{"type":"ToolCall","toolCallId":"tc-read","name":"read_file","status":"pending","parameters":{"path":"diagram.svg"}}}}\n'
+      fi
       printf '{"jsonrpc":"2.0","method":"session/notification","params":{"sessionId":"ses_final","update":{"type":"ToolCallUpdate","toolCallId":"tc-read","name":"read_file","status":"completed","output":"<svg />"}}}\n'
-      printf '{"jsonrpc":"2.0","method":"session/notification","params":{"sessionId":"ses_final","update":{"type":"AgentMessageChunk","content":{"type":"text","text":"The diagram shows "}}}}\n'
-      printf '{"jsonrpc":"2.0","method":"session/notification","params":{"sessionId":"ses_final","update":{"type":"AgentMessageChunk","content":{"type":"text","text":"the service architecture."}}}}\n'
+      if [ "$QODER_TOOL_TERMINATED" != "1" ]; then
+        printf '{"jsonrpc":"2.0","method":"session/notification","params":{"sessionId":"ses_final","update":{"type":"AgentMessageChunk","content":{"type":"text","text":"The diagram shows "}}}}\n'
+        printf '{"jsonrpc":"2.0","method":"session/notification","params":{"sessionId":"ses_final","update":{"type":"AgentMessageChunk","content":{"type":"text","text":"the service architecture."}}}}\n'
+      fi
       printf '{"jsonrpc":"2.0","id":%s,"result":{"stopReason":"end_turn","usage":{"inputTokens":10,"outputTokens":20}}}\n' "$id"
       exit 0
       ;;
@@ -393,12 +402,84 @@ func TestQoderBackendHappyPath(t *testing.T) {
 }
 
 func TestQoderBackendDeliversFinalAnswerWithoutNarration(t *testing.T) {
+	for _, test := range []struct {
+		name string
+		env  map[string]string
+	}{
+		{name: "tool use emitted at start"},
+		{name: "tool use deferred until completion", env: map[string]string{"QODER_DEFERRED_TOOL": "1"}},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			fakePath := filepath.Join(t.TempDir(), "qodercli")
+			writeTestExecutable(t, fakePath, []byte(fakeQoderACPScriptWithNarrationAndFinalAnswer()))
+
+			backend, err := New("qoder", Config{
+				ExecutablePath: fakePath,
+				Logger:         slog.Default(),
+				Env:            test.env,
+			})
+			if err != nil {
+				t.Fatalf("new qoder backend: %v", err)
+			}
+
+			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+			defer cancel()
+
+			session, err := backend.Execute(ctx, "inspect this attachment", ExecOptions{Timeout: 30 * time.Second})
+			if err != nil {
+				t.Fatalf("execute: %v", err)
+			}
+
+			var streamed []Message
+			messagesDone := make(chan struct{})
+			go func() {
+				defer close(messagesDone)
+				for msg := range session.Messages {
+					streamed = append(streamed, msg)
+				}
+			}()
+
+			result := <-session.Result
+			<-messagesDone
+
+			const want = "The diagram shows the service architecture."
+			if result.Status != "completed" {
+				t.Fatalf("status=%q err=%q", result.Status, result.Error)
+			}
+			if result.Output != want {
+				t.Fatalf("Result.Output = %q, want %q", result.Output, want)
+			}
+
+			var text []string
+			for _, msg := range streamed {
+				if msg.Type == MessageText {
+					text = append(text, msg.Content)
+				}
+			}
+			if got := strings.Join(text, "|"); got != "I will inspect the attachment.|The diagram shows |the service architecture." {
+				t.Fatalf("transcript text = %q, want narration and final answer", got)
+			}
+		})
+	}
+}
+
+func TestQoderBackendToolTerminatedTurnFallsBackToLatestTextBlock(t *testing.T) {
 	t.Parallel()
 
 	fakePath := filepath.Join(t.TempDir(), "qodercli")
 	writeTestExecutable(t, fakePath, []byte(fakeQoderACPScriptWithNarrationAndFinalAnswer()))
 
-	backend, err := New("qoder", Config{ExecutablePath: fakePath, Logger: slog.Default()})
+	const want = "Done. Posted the summary to the issue."
+	backend, err := New("qoder", Config{
+		ExecutablePath: fakePath,
+		Logger:         slog.Default(),
+		Env: map[string]string{
+			"QODER_TEXT_BEFORE_TOOL": want,
+			"QODER_TOOL_TERMINATED":  "1",
+		},
+	})
 	if err != nil {
 		t.Fatalf("new qoder backend: %v", err)
 	}
@@ -406,39 +487,21 @@ func TestQoderBackendDeliversFinalAnswerWithoutNarration(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 
-	session, err := backend.Execute(ctx, "inspect this attachment", ExecOptions{Timeout: 30 * time.Second})
+	session, err := backend.Execute(ctx, "post the summary", ExecOptions{Timeout: 30 * time.Second})
 	if err != nil {
 		t.Fatalf("execute: %v", err)
 	}
-
-	var streamed []Message
-	messagesDone := make(chan struct{})
 	go func() {
-		defer close(messagesDone)
-		for msg := range session.Messages {
-			streamed = append(streamed, msg)
+		for range session.Messages {
 		}
 	}()
 
 	result := <-session.Result
-	<-messagesDone
-
-	const want = "The diagram shows the service architecture."
 	if result.Status != "completed" {
 		t.Fatalf("status=%q err=%q", result.Status, result.Error)
 	}
 	if result.Output != want {
-		t.Fatalf("Result.Output = %q, want %q", result.Output, want)
-	}
-
-	var text []string
-	for _, msg := range streamed {
-		if msg.Type == MessageText {
-			text = append(text, msg.Content)
-		}
-	}
-	if got := strings.Join(text, "|"); got != "I will inspect the attachment.|The diagram shows |the service architecture." {
-		t.Fatalf("transcript text = %q, want narration and final answer", got)
+		t.Fatalf("Result.Output = %q, want fallback %q", result.Output, want)
 	}
 }
 


### PR DESCRIPTION
## What does this PR do?

Qoder can emit interim narration and the final answer as separate ACP `AgentMessageChunk` sequences around tool calls. The backend currently concatenates every text chunk into `Result.Output`, so channel replies and synthesized issue comments can receive `narration + answer` even though `Result.Output` is documented as the final user-facing output selected by the backend.

This is a Qoder follow-up to #6016. Qoder has no `phase: final_answer` label, so the adapter uses the ordered ACP stream itself: consecutive text chunks form the current deliverable block, and a `MessageToolUse` starts a new block. Every message still streams to the transcript; only `Result.Output` narrows to the text after the latest tool call.

The backend keeps a second complete text buffer for `promoteACPResultOnProviderError`. This preserves terminal provider-error detection even when the matching synthetic error text appeared before a tool boundary and is excluded from the deliverable.

## Changes

- Track complete Qoder text separately from channel-deliverable text.
- Reset only the deliverable block when a tool starts.
- Keep provider-error promotion based on the complete text stream.
- Add an ACP regression fixture covering narration, a tool call, multi-chunk final output, and unchanged transcript streaming.
- Add a regression test proving pre-tool provider errors remain detectable.

## Verification

- `go test ./pkg/agent -run "^TestQoderBackend(DeliversFinalAnswerWithoutNarration|ProviderErrorDetectionUsesFullOutput)$" -count=1`
- `go test ./pkg/agent -run Qoder -count=1`
- `go test ./pkg/agent -count=1`

All pass locally.