### PR TITLE
fix(editor): re-sign cross-origin attachment URLs

### DIFF
--- a/packages/views/editor/attachment.test.tsx
+++ b/packages/views/editor/attachment.test.tsx
@@ -335,7 +335,7 @@ describe("Attachment — image dispatch", () => {
     // through to the durable markdown_url instead.
     configStore.setState({ cdnDomain: "cdn.example.test", cdnSigned: true });
     const id = "11111111-2222-3333-4444-555555555555";
-    const markdownUrl = `https://multica-api.copilothub.ai/api/attachments/${id}/download`;
+    const markdownUrl = `/api/attachments/${id}/download`;
     const att = makeRecord({
       id,
       url: "https://cdn.example.test/uploads/ws/shot.png",
@@ -360,6 +360,44 @@ describe("Attachment — image dispatch", () => {
     // Web (same-origin proxy / same-site cookie): the API endpoint loads
     // natively, so no metadata re-fetch is needed.
     expect(getAttachmentMock).not.toHaveBeenCalled();
+  });
+
+  it("re-signs a cross-origin API image URL in the web editor", async () => {
+    // The web app normally uses the same-origin /api proxy, so getBaseUrl is
+    // empty. A self-hosted server can still persist an absolute markdown_url
+    // on a different origin, though. Native <img> loading cannot rely on the
+    // app session cookie being accepted by that host, while an authenticated
+    // metadata request can return a freshly signed storage URL.
+    configStore.setState({ cdnDomain: "cdn.example.test", cdnSigned: true });
+    const id = "11111111-2222-3333-4444-555555555555";
+    const markdownUrl = `https://api.example.test/api/attachments/${id}/download`;
+    const signed =
+      "https://cdn.example.test/uploads/ws/shot.png?Signature=fresh&Key-Pair-Id=K";
+    resolverState.attachments = [
+      makeRecord({
+        id,
+        url: "https://cdn.example.test/uploads/ws/shot.png",
+        markdown_url: markdownUrl,
+        download_url: `/api/attachments/${id}/download`,
+      }),
+    ];
+    getAttachmentMock.mockResolvedValue(makeRecord({ id, download_url: signed }));
+
+    renderWithQuery(
+      <Attachment
+        attachment={{
+          kind: "url",
+          url: markdownUrl,
+          filename: "shot.png",
+          forceKind: "image",
+        }}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(document.querySelector("img")?.getAttribute("src")).toBe(signed);
+    });
+    expect(getAttachmentMock).toHaveBeenCalledWith(id);
   });
 
   it("re-signs the inline media URL through getAttachment on token-mode clients (MUL-3254)", async () => {

--- a/packages/views/editor/attachment.tsx
+++ b/packages/views/editor/attachment.tsx
@@ -321,11 +321,12 @@ const RESIGN_STALE_MS = 20 * 60 * 1000;
 // endpoint (e.g. a reopened issue draft, whose persisted record deliberately
 // strips the short-lived signed `download_url`). That endpoint needs
 // credentials: web loads it because the session cookie rides on the <img>
-// request (same-site), but Desktop's file:// renderer and the mobile webview
-// are cross-site — no cookie is attached and the Bearer token cannot be put
-// on a native resource fetch, so the image 401s. Those clients are exactly
-// the ones with a non-empty `api.getBaseUrl()` (no same-origin /api proxy),
-// which is the existing platform signal `absolutizeMediaURL` keys off.
+// request when it is genuinely same-origin. Desktop's file:// renderer, the
+// mobile webview, and split-origin web deployments cannot rely on that: no
+// cookie is attached and the Bearer token cannot be put on a native resource
+// fetch, so the image 401s. Desktop/mobile expose a non-empty
+// `api.getBaseUrl()`; web can also hit this path when the server emits an
+// absolute markdown URL whose origin differs from the current page.
 //
 // For them, fetch fresh attachment metadata through the authenticated API —
 // the same re-sign the click-time download path already does — and swap in
@@ -338,11 +339,21 @@ function useResignedInlineMediaURL(
 ): string {
   const idFromPickedUrl = attachmentIdFromDownloadURL(pickedUrl);
   const resignAttachmentId = attachmentId ?? idFromPickedUrl;
+  const isCrossOriginWebURL = (() => {
+    if (!/^https?:\/\//i.test(pickedUrl) || typeof window === "undefined") {
+      return false;
+    }
+    try {
+      return new URL(pickedUrl).origin !== window.location.origin;
+    } catch {
+      return false;
+    }
+  })();
   const needsResign =
     !!resignAttachmentId &&
     !!pickedUrl &&
     idFromPickedUrl !== undefined &&
-    (api.getBaseUrl?.() ?? "") !== "";
+    ((api.getBaseUrl?.() ?? "") !== "" || isCrossOriginWebURL);
 
   const { data: fresh } = useQuery({
     queryKey: ["attachment-inline-resign", resignAttachmentId],


### PR DESCRIPTION
## What does this PR do?

Fixes broken inline attachment previews in split-origin self-hosted web deployments backed by presign-capable or CloudFront-signed storage.

The editor can persist an absolute attachment API URL whose origin differs from the web app, even while the API client itself uses a same-origin proxy and therefore reports an empty base URL. The existing inline re-sign hook treats every web URL in that state as natively loadable, so a newly pasted image can remain on an auth-gated URL until the attachment record is fetched again.

This change also treats absolute cross-origin attachment API URLs as requiring an authenticated metadata refresh. Same-origin relative URLs keep their existing no-refetch path.

## Scope and known limitation

Detecting that a URL needs a refresh is only half the repair — the renderer accepts the refreshed URL only when `GET /api/attachments/{id}` returns an absolute, non-API-shaped URL. That endpoint upgrades `download_url` under CloudFront signing or presign mode, so those deployments get a working draft preview.

Deployments that resolve to **proxy** download mode are not fixed here. With the default `ATTACHMENT_DOWNLOAD_MODE=auto`, proxy is selected whenever the storage URL points at an internal host — a hostname with no dot (e.g. `http://minio:9000` in a Compose setup), `localhost`, a `.local` / `.internal` / `.lan` suffix, or a private IP. In that mode the endpoint returns the relative API path again, the renderer correctly falls back to the original URL, and the draft image stays broken at the cost of one extra metadata request. That configuration is tracked separately in #6087; the reporter of #6049 confirmed their environment is S3-compatible presign, so it does not affect `Fixes #6049`.

## Related Issue
Fixes #6049

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Refactor / code improvement (no behavior change)
- [ ] Documentation update
- [x] Tests (adding or improving test coverage)
- [ ] CI / infrastructure

## Changes Made

- Update `packages/views/editor/attachment.tsx` to re-sign cross-origin attachment API URLs in web renderers.
- Add regression coverage in `packages/views/editor/attachment.test.tsx`.
- Preserve the existing same-origin proxy behavior without an extra metadata request.

## How to Test

1. Configure a self-hosted web frontend that proxies API calls while the server emits absolute attachment URLs on another origin.
2. Paste an image into a comment editor backed by private/signed storage.
3. Confirm the draft image loads before submission and its rendered URL is refreshed from authenticated attachment metadata.

Local verification:

- `pnpm --filter @multica/views test` — 268 files, 3132 tests passed
- `pnpm --filter @multica/views typecheck` — passed
- `pnpm --filter @multica/views lint` — 0 errors (existing warnings only)

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [x] I have updated relevant documentation to reflect my changes (not applicable; no documented behavior changes)
- [x] If I added a new runtime / coding tool / UI tab, I synced the change to **landing copy** (`apps/web/features/landing/i18n/`) and **relevant docs** (`apps/docs/content/docs/`) (not applicable)
- [x] If this PR touches Chinese product copy, I checked it against `apps/docs/content/docs/developers/conventions.zh.mdx` (not applicable)
- [x] I have considered and documented any risks above
- [x] I will address all reviewer comments before requesting merge

Risk is limited to one additional authenticated metadata request for attachment API URLs that are absolute and cross-origin. External image URLs and same-origin attachment URLs — relative or absolute — are unaffected and fire no extra request. In proxy download mode that extra request cannot produce a loadable URL (see *Scope and known limitation* above); the renderer falls back safely, so behavior there is no worse than today.

## AI Disclosure

**AI tool used:** OpenAI Codex

**Prompt / approach:**

Traced the paste-upload flow through the editor renderer, reproduced the split-origin case with a focused unit test, implemented the smallest URL classification change, and ran the full `@multica/views` test suite plus type checking and linting.

## Screenshots (optional)

Not included. The change affects whether a draft image URL can load rather than the visual design, and the regression is covered by the new renderer test.

