### PR TITLE
fix(agents): MUL-5358 add skills incrementally so disabled ones stay off

### DIFF
--- a/packages/views/agents/components/skill-add-dialog.test.tsx
+++ b/packages/views/agents/components/skill-add-dialog.test.tsx
@@ -1,0 +1,224 @@
+// @vitest-environment jsdom
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, screen, cleanup, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import type { Agent, SkillSummary } from "@multica/core/types";
+import { I18nProvider } from "@multica/core/i18n/react";
+import enCommon from "../../locales/en/common.json";
+import enAgents from "../../locales/en/agents.json";
+
+const TEST_RESOURCES = { en: { common: enCommon, agents: enAgents } };
+
+const mockListSkills = vi.hoisted(() => vi.fn());
+const mockAddAgentSkills = vi.hoisted(() => vi.fn());
+const mockSetAgentSkills = vi.hoisted(() => vi.fn());
+const mockToastError = vi.hoisted(() => vi.fn());
+
+vi.mock("@multica/core/hooks", () => ({
+  useWorkspaceId: () => "ws-1",
+}));
+
+vi.mock("@multica/core/api", () => ({
+  api: {
+    listSkills: (...args: unknown[]) => mockListSkills(...args),
+    addAgentSkills: (...args: unknown[]) => mockAddAgentSkills(...args),
+    setAgentSkills: (...args: unknown[]) => mockSetAgentSkills(...args),
+  },
+}));
+
+vi.mock("sonner", () => ({
+  toast: {
+    error: (...args: unknown[]) => mockToastError(...args),
+    success: vi.fn(),
+  },
+}));
+
+import { SkillAddDialog } from "./skill-add-dialog";
+
+function makeSkill(
+  id: string,
+  name: string,
+  description: string,
+  enabled: boolean,
+): SkillSummary {
+  return {
+    id,
+    workspace_id: "ws-1",
+    name,
+    description,
+    config: {},
+    created_by: "user-1",
+    created_at: "2026-07-28T00:00:00Z",
+    updated_at: "2026-07-28T00:00:00Z",
+    enabled,
+  };
+}
+
+/** Already on the agent and deliberately switched off by the user. */
+const DISABLED_ASSIGNED = makeSkill(
+  "skill-refunds",
+  "Refund handling",
+  "Process refunds",
+  false,
+);
+
+/** Already on the agent and left on. */
+const ENABLED_ASSIGNED = makeSkill(
+  "skill-kb",
+  "Knowledge base",
+  "Answer from the knowledge base",
+  true,
+);
+
+const SHIPPING = makeSkill(
+  "skill-shipping",
+  "Shipping lookup",
+  "Track a shipment",
+  true,
+);
+
+const RETURNS = makeSkill(
+  "skill-returns",
+  "Returns policy",
+  "Explain the returns policy",
+  true,
+);
+
+const agent: Agent = {
+  id: "agent-1",
+  workspace_id: "ws-1",
+  runtime_id: "runtime-1",
+  name: "Support agent",
+  description: "",
+  instructions: "",
+  avatar_url: null,
+  runtime_mode: "local",
+  runtime_config: {},
+  custom_args: [],
+  visibility: "workspace",
+  permission_mode: "public_to",
+  invocation_targets: [{ target_type: "workspace", target_id: null }],
+  status: "idle",
+  max_concurrent_tasks: 1,
+  model: "",
+  owner_id: "user-1",
+  skills: [ENABLED_ASSIGNED, DISABLED_ASSIGNED],
+  created_at: "2026-07-28T00:00:00Z",
+  updated_at: "2026-07-28T00:00:00Z",
+  archived_at: null,
+  archived_by: null,
+};
+
+function renderDialog(agentOverrides: Partial<Agent> = {}) {
+  const onOpenChange = vi.fn();
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+
+  render(
+    <I18nProvider locale="en" resources={TEST_RESOURCES}>
+      <QueryClientProvider client={queryClient}>
+        <SkillAddDialog
+          agent={{ ...agent, ...agentOverrides }}
+          open
+          onOpenChange={onOpenChange}
+        />
+      </QueryClientProvider>
+    </I18nProvider>,
+  );
+
+  return { onOpenChange };
+}
+
+describe("SkillAddDialog", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockListSkills.mockResolvedValue([
+      ENABLED_ASSIGNED,
+      DISABLED_ASSIGNED,
+      SHIPPING,
+      RETURNS,
+    ]);
+    mockAddAgentSkills.mockResolvedValue(undefined);
+    mockSetAgentSkills.mockResolvedValue(undefined);
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("lists only workspace skills that are not attached yet", async () => {
+    renderDialog();
+
+    expect(await screen.findByText("Shipping lookup")).toBeInTheDocument();
+    expect(screen.getByText("Returns policy")).toBeInTheDocument();
+    expect(screen.queryByText("Refund handling")).not.toBeInTheDocument();
+    expect(screen.queryByText("Knowledge base")).not.toBeInTheDocument();
+  });
+
+  // MUL-5358: the dialog used to merge `agent.skills` into the payload and
+  // PUT the whole set, which deleted and reinserted every binding — the
+  // reinserted rows came back at the `enabled` default, so adding one skill
+  // silently re-enabled the ones the user had turned off.
+  it("adds only the newly selected skill and leaves existing bindings alone", async () => {
+    const user = userEvent.setup();
+    const { onOpenChange } = renderDialog();
+
+    await user.click(await screen.findByText("Shipping lookup"));
+    await user.click(screen.getByRole("button", { name: "Add 1 skill" }));
+
+    await waitFor(() => {
+      expect(mockAddAgentSkills).toHaveBeenCalledWith("agent-1", {
+        skill_ids: ["skill-shipping"],
+      });
+    });
+    // The disabled binding must never appear in the request — the payload is
+    // exactly what the user picked.
+    expect(mockAddAgentSkills).toHaveBeenCalledTimes(1);
+    expect(mockSetAgentSkills).not.toHaveBeenCalled();
+    await waitFor(() => expect(onOpenChange).toHaveBeenCalledWith(false));
+  });
+
+  it("sends every selected skill when several are added at once", async () => {
+    const user = userEvent.setup();
+    renderDialog();
+
+    await user.click(await screen.findByText("Shipping lookup"));
+    await user.click(screen.getByText("Returns policy"));
+    await user.click(screen.getByRole("button", { name: "Add 2 skills" }));
+
+    await waitFor(() => {
+      expect(mockAddAgentSkills).toHaveBeenCalledWith("agent-1", {
+        skill_ids: ["skill-shipping", "skill-returns"],
+      });
+    });
+    expect(mockSetAgentSkills).not.toHaveBeenCalled();
+  });
+
+  it("does not touch skills when the user cancels", async () => {
+    const user = userEvent.setup();
+    const { onOpenChange } = renderDialog();
+
+    await user.click(await screen.findByText("Shipping lookup"));
+    await user.click(screen.getByRole("button", { name: "Cancel" }));
+
+    expect(mockAddAgentSkills).not.toHaveBeenCalled();
+    expect(mockSetAgentSkills).not.toHaveBeenCalled();
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+  });
+
+  it("keeps the dialog open and surfaces a toast when the add fails", async () => {
+    const user = userEvent.setup();
+    mockAddAgentSkills.mockRejectedValue(new Error("network down"));
+    const { onOpenChange } = renderDialog();
+
+    await user.click(await screen.findByText("Shipping lookup"));
+    await user.click(screen.getByRole("button", { name: "Add 1 skill" }));
+
+    await waitFor(() => expect(mockToastError).toHaveBeenCalledWith("network down"));
+    expect(onOpenChange).not.toHaveBeenCalled();
+    expect(screen.getByRole("button", { name: "Add 1 skill" })).toBeEnabled();
+  });
+});

--- a/packages/views/agents/components/skill-add-dialog.tsx
+++ b/packages/views/agents/components/skill-add-dialog.tsx
@@ -79,11 +79,13 @@ export function SkillAddDialog({
     if (selectedIds.size === 0) return;
     setSaving(true);
     try {
-      const newIds = [
-        ...agent.skills.map((s) => s.id),
-        ...selectedIds,
-      ];
-      await api.setAgentSkills(agent.id, { skill_ids: newIds });
+      // Incremental add, never replace-all. `setAgentSkills` (PUT) drops
+      // every existing agent_skill row and reinserts it, so any binding the
+      // user had switched off comes back at the column default (enabled) —
+      // adding one skill silently re-enabled the others (MUL-5358).
+      // `addAgentSkills` (POST /skills/add) only inserts the picked ids and
+      // leaves existing bindings, including their enabled state, untouched.
+      await api.addAgentSkills(agent.id, { skill_ids: [...selectedIds] });
       qc.invalidateQueries({ queryKey: workspaceKeys.agents(wsId) });
       handleOpenChange(false);
     } catch (e) {

--- a/server/internal/handler/handler_test.go
+++ b/server/internal/handler/handler_test.go
@@ -2206,8 +2206,11 @@ func TestAddAgentSkillsPreservesExistingAssignments(t *testing.T) {
 	existingSkillID := insertHandlerTestSkill(t, "add-preserve-existing", "existing body")
 	newSkillID := insertHandlerTestSkill(t, "add-preserve-new", "new body")
 
+	// MUL-5358: the existing assignment is deliberately switched off. Adding
+	// another skill must not resurrect it — the replace-all PUT path did,
+	// because reinserted rows fall back to the `enabled` column default.
 	if _, err := testPool.Exec(context.Background(),
-		`INSERT INTO agent_skill (agent_id, skill_id) VALUES ($1, $2)`,
+		`INSERT INTO agent_skill (agent_id, skill_id, enabled) VALUES ($1, $2, false)`,
 		agentID, existingSkillID,
 	); err != nil {
 		t.Fatalf("seed existing skill assignment: %v", err)
@@ -2229,6 +2232,40 @@ func TestAddAgentSkillsPreservesExistingAssignments(t *testing.T) {
 	}
 	assertSkillIDsPresent(t, resp, existingSkillID, newSkillID)
 	assertAgentSkillRowCount(t, agentID, 2)
+	assertAgentSkillEnabled(t, agentID, existingSkillID, false)
+	assertAgentSkillEnabled(t, agentID, newSkillID, true)
+	assertSkillSummaryEnabled(t, resp, existingSkillID, false)
+	assertSkillSummaryEnabled(t, resp, newSkillID, true)
+}
+
+// TestSetAgentSkillsResetsEnabledState pins the semantics that make the
+// replace-all endpoint the wrong tool for "add a skill": PUT rebuilds the
+// whole binding set, so a disabled assignment comes back enabled. Callers
+// that only mean to attach new skills must use AddAgentSkills (MUL-5358).
+func TestSetAgentSkillsResetsEnabledState(t *testing.T) {
+	agentID := createHandlerTestAgent(t, "Handler Set Skills Resets Enabled", nil)
+	existingSkillID := insertHandlerTestSkill(t, "set-reset-existing", "existing body")
+	newSkillID := insertHandlerTestSkill(t, "set-reset-new", "new body")
+
+	if _, err := testPool.Exec(context.Background(),
+		`INSERT INTO agent_skill (agent_id, skill_id, enabled) VALUES ($1, $2, false)`,
+		agentID, existingSkillID,
+	); err != nil {
+		t.Fatalf("seed existing skill assignment: %v", err)
+	}
+
+	w := httptest.NewRecorder()
+	req := newRequest("PUT", "/api/agents/"+agentID+"/skills", map[string]any{
+		"skill_ids": []string{existingSkillID, newSkillID},
+	})
+	req = withURLParam(req, "id", agentID)
+	testHandler.SetAgentSkills(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("SetAgentSkills: expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	assertAgentSkillRowCount(t, agentID, 2)
+	assertAgentSkillEnabled(t, agentID, existingSkillID, true)
 }
 
 func TestAddAgentSkillsAddsMultipleAndIsIdempotent(t *testing.T) {
@@ -2323,6 +2360,37 @@ func assertSkillIDsPresent(t *testing.T, skills []SkillSummaryResponse, wantIDs 
 		if !got[want] {
 			t.Fatalf("response missing skill %s; got %+v", want, skills)
 		}
+	}
+}
+
+func assertSkillSummaryEnabled(t *testing.T, skills []SkillSummaryResponse, skillID string, want bool) {
+	t.Helper()
+	for _, s := range skills {
+		if s.ID != skillID {
+			continue
+		}
+		if s.Enabled == nil {
+			t.Fatalf("skill %s: enabled is nil, want %t", skillID, want)
+		}
+		if *s.Enabled != want {
+			t.Fatalf("skill %s: enabled=%t, want %t", skillID, *s.Enabled, want)
+		}
+		return
+	}
+	t.Fatalf("response missing skill %s; got %+v", skillID, skills)
+}
+
+func assertAgentSkillEnabled(t *testing.T, agentID, skillID string, want bool) {
+	t.Helper()
+	var got bool
+	if err := testPool.QueryRow(context.Background(),
+		`SELECT enabled FROM agent_skill WHERE agent_id = $1 AND skill_id = $2`,
+		agentID, skillID,
+	).Scan(&got); err != nil {
+		t.Fatalf("read agent_skill.enabled for skill %s: %v", skillID, err)
+	}
+	if got != want {
+		t.Fatalf("agent_skill.enabled for skill %s: got %t, want %t", skillID, got, want)
 	}
 }
 


### PR DESCRIPTION
Fixes MUL-5358 · Closes #5988

## Problem

Turning a skill off on an agent, then adding an unrelated skill, silently turned the disabled skill back on.

The Add-skill dialog merged `agent.skills` into the payload and called `setAgentSkills` — `PUT /api/agents/:id/skills`, a replace-all. The handler runs `RemoveAllAgentSkills` and reinserts every id, so each reinserted row lands at the `agent_skill.enabled` column default (`true`). The user's explicit "off" was discarded without any confirmation, and the agent's effective capability set widened behind their back.

## Fix

`packages/views/agents/components/skill-add-dialog.tsx` now submits only the ids the user picked, via `addAgentSkills` — `POST /api/agents/:id/skills/add`. That handler inserts only the given ids (`ON CONFLICT DO NOTHING`) and leaves existing bindings and their `enabled` state alone. It's the same endpoint the Skills page bulk-assign action already uses, so this brings the two attach surfaces onto one pattern.

Out of scope by design: explicit toggle / remove / replace semantics and runtime-local (inherited) skills are untouched. The dialog already filters out attached skills, and `ON CONFLICT DO NOTHING` means a stale `agent.skills` list can no longer clobber a binding either.

## Regression tests

New `packages/views/agents/components/skill-add-dialog.test.tsx` (5 cases): with a disabled binding on the agent, confirming the dialog posts **only** the newly selected ids and never calls `setAgentSkills`; plus multi-select, cancel, and the failure path (toast shown, dialog stays open). Verified red before the fix — 3 of 5 fail on the old code.

Backend, in `server/internal/handler/handler_test.go`:
- `TestAddAgentSkillsPreservesExistingAssignments` now seeds the existing binding as `enabled=false` and asserts it is still `false` after the add, in both the DB row and the response payload.
- `TestSetAgentSkillsResetsEnabledState` (new) pins the replace-all semantics that make PUT the wrong endpoint for this flow, so the reason for the split stays documented in tests.

## Verification

All run locally on this branch:

- `pnpm typecheck` — pass
- `pnpm lint` — 0 errors (16 pre-existing warnings in unrelated files)
- `pnpm test` — 5/5 tasks, 3136 tests pass in `@multica/views`
- `go test ./internal/handler -count=1` — pass (22s, full package, against a migrated local Postgres)
- `gofmt` / `go vet` on the changed Go file — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
