### PR TITLE
test(daemon): extend the byte-identity guarantee to chat and the other kinds (MUL-5377)

### DIFF
--- a/server/internal/daemon/execenv/runtime_config_test.go
+++ b/server/internal/daemon/execenv/runtime_config_test.go
@@ -1674,3 +1674,73 @@ func firstBriefDiff(want, got string) string {
 		"\n--- baseline ---\n" + want[lo:hiW] +
 		"\n--- variant ---\n" + got[lo:hiG]
 }
+
+// TestBriefByteIdenticalAcrossRunsForEveryKind extends the MUL-5377 guarantee
+// past issue runs.
+//
+// Chat sessions resume too — handler/daemon.go:2172 hands the daemon a
+// PriorSessionID from the chat_session row, with the same PriorWorkDir and
+// PriorSessionResumeUnavailable plumbing as an issue task. So a chat brief that
+// varied per turn would lose the prompt cache exactly the same way, and a long
+// chat is precisely where that hurts most. Autopilot and quick-create are
+// single-shot today, but the invariant is free to hold for them too and stops a
+// future resume path from silently reintroducing the bug.
+func TestBriefByteIdenticalAcrossRunsForEveryKind(t *testing.T) {
+	t.Parallel()
+
+	kinds := map[string]TaskContextForEnv{
+		"chat":         {ChatSessionID: "chat-1", ChatChannelType: ChannelTypeSlack, AgentID: "a-1", AgentName: "Eve"},
+		"quick-create": {QuickCreatePrompt: "make an issue", AgentID: "a-1", AgentName: "Eve"},
+		"autopilot":    {AutopilotRunID: "run-1", AutopilotID: "ap-1", AgentID: "a-1", AgentName: "Eve"},
+	}
+
+	// Per-run state that changes between turns of one resumed session.
+	variants := []struct {
+		name   string
+		mutate func(c *TaskContextForEnv)
+	}{
+		{"baseline", func(c *TaskContextForEnv) {}},
+		{"resumed", func(c *TaskContextForEnv) { c.PriorSessionResumed = true }},
+		{"resume-unavailable", func(c *TaskContextForEnv) { c.PriorSessionResumeUnavailable = true }},
+		{"member-initiator", func(c *TaskContextForEnv) {
+			c.InitiatorType, c.InitiatorID = "member", "u-1"
+			c.InitiatorName, c.InitiatorEmail = "Bohan", "bohan@example.com"
+		}},
+		{"other-initiator", func(c *TaskContextForEnv) {
+			// A Slack channel lets a different person trigger each turn.
+			c.InitiatorType, c.InitiatorID = "member", "u-2"
+			c.InitiatorName, c.InitiatorEmail = "Someone Else", "else@example.com"
+		}},
+		{"agent-initiator", func(c *TaskContextForEnv) {
+			c.InitiatorType, c.InitiatorID = "agent", "a-9"
+			c.InitiatorName = "GPT-Boy"
+		}},
+		{"connected-apps", func(c *TaskContextForEnv) {
+			c.ConnectedApps = []runtimeapps.ConnectedApp{{
+				Provider: "composio", ServerName: "composio",
+				ToolkitSlug: "notion", ToolkitName: "Notion",
+			}}
+		}},
+	}
+
+	for kindName, baseCtx := range kinds {
+		kindName, baseCtx := kindName, baseCtx
+		t.Run(kindName, func(t *testing.T) {
+			t.Parallel()
+			var want string
+			for i, v := range variants {
+				ctx := baseCtx
+				v.mutate(&ctx)
+				got := buildMetaSkillContent("claude", ctx)
+				if i == 0 {
+					want = got
+					continue
+				}
+				if got != want {
+					t.Errorf("%s brief differs for variant %q — per-run state leaked into the cached prefix (MUL-5377).\n%s",
+						kindName, v.name, firstBriefDiff(want, got))
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
Follow-up to #6021. Test-only.

#6021's regression guard (`TestInjectRuntimeConfigByteIdenticalAcrossTriggers`) builds its base context with an `IssueID`, so it only ever exercises the issue path. Chat sessions resume too — `handler/daemon.go:2172` hands the daemon a `PriorSessionID` off the `chat_session` row, with the same `PriorWorkDir` and `PriorSessionResumeUnavailable` plumbing as an issue task — so a chat brief that varied per turn would lose the prompt cache the same way, and a long chat is exactly where that costs most.

The three blocks #6021 moved out of the brief (Task Initiator, Session Continuity Notice, Connected Apps) were removed for *every* kind, so chat is already byte-stable today. This locks that in rather than leaving it as an accident of how the removal was written.

`TestBriefByteIdenticalAcrossRunsForEveryKind` renders chat / quick-create / autopilot across seven per-run variants — baseline, resumed, resume-unavailable, member initiator, **a different member initiator**, agent initiator, connected apps — and requires `bytes.Equal`.

The different-initiator variant is the one that matters: in a Slack- or Feishu-backed session a different person can trigger each turn, and that is precisely the condition under which the old brief's Task Initiator block changed. A 1:1 web chat never hit it, which is why this went unnoticed.

Autopilot and quick-create are single-shot today. Including them costs nothing and stops a future resume path from silently reintroducing the bug.

```
go test ./internal/daemon/...
ok  	github.com/multica-ai/multica/server/internal/daemon
ok  	github.com/multica-ai/multica/server/internal/daemon/execenv
ok  	github.com/multica-ai/multica/server/internal/daemon/repocache
```
