### PR TITLE
MUL-5391 follow-up: widen handleUpload contract, fix interrupted doc drift

### DIFF
--- a/packages/core/chat/store.ts
+++ b/packages/core/chat/store.ts
@@ -120,7 +120,8 @@ function readDraftAttachments(storage: StorageAdapter, key: string): Record<stri
       if (!Array.isArray(value)) continue;
       // Normalize on every load (MUL-5181 L2): bare Attachment rows persisted
       // by pre-L2 builds become `uploaded` placeholders, and an upload still
-      // `uploading` at load time is coerced to `interrupted` (bytes are gone).
+      // `uploading` at load time is dropped (bytes are gone, and nothing in the
+      // body references it).
       const uploads = normalizeStoredUploads(value);
       if (uploads.length > 0) out[draftKey] = uploads;
     }

--- a/packages/core/drafts/draft-upload.test.ts
+++ b/packages/core/drafts/draft-upload.test.ts
@@ -73,6 +73,9 @@ describe("draft-upload helpers", () => {
     expect(normalizeStoredUploads([pending("a")])).toEqual([]);
   });
 
+  // `interrupted` is legacy: no code path produces it any more (builds before
+  // MUL-5391 coerced a reload-surviving `uploading` record into it). It stays
+  // accepted here so a blob one of those builds persisted still renders.
   it("keeps failed/interrupted/uploaded placeholders across load", () => {
     const stored: DraftUpload[] = [
       { clientUploadId: "f", status: "failed", filename: "f", size: 1 },

--- a/packages/core/drafts/draft-upload.ts
+++ b/packages/core/drafts/draft-upload.ts
@@ -31,8 +31,10 @@ interface DraftUploadBase {
  * A placeholder whose bytes are not (or no longer) resolvable to an attachment:
  *  - `uploading`: request in flight (owned by the coordinator).
  *  - `failed`: the request errored; keep it so the user sees the failure.
- *  - `interrupted`: was `uploading` when the app was reloaded/restarted; the
- *    bytes were never persisted so the request cannot be resumed.
+ *  - `interrupted`: LEGACY, no longer produced. Builds before MUL-5391 coerced
+ *    a reload-surviving `uploading` record into this; that record is now
+ *    dropped instead. Still accepted, rendered, and dismissable so blobs those
+ *    builds persisted keep working.
  */
 export interface PendingDraftUpload extends DraftUploadBase {
   status: "uploading" | "failed" | "interrupted";
@@ -106,7 +108,8 @@ function isDraftUploadShape(value: unknown): value is DraftUpload {
 /**
  * Normalize a raw persisted array into `DraftUpload[]`:
  *  - already-`DraftUpload` entries are kept, EXCEPT any still in `uploading`,
- *    which become `interrupted` — a reload/restart cannot resume the bytes.
+ *    which are DROPPED — a reload/restart cannot resume the bytes, and no
+ *    placeholder node survives in the body either (see the branch below).
  *  - bare `Attachment` rows (persisted by pre-L2 builds that stored only
  *    completed attachments) are wrapped as `uploaded`.
  *  - anything else is dropped.

--- a/packages/core/drafts/upload-coordinator.ts
+++ b/packages/core/drafts/upload-coordinator.ts
@@ -44,10 +44,9 @@ export interface StartUploadArgs {
   ctx?: UploadCoordinatorContext;
   /**
    * Settled outcome. NOT called on abort — an aborted upload leaves its
-   * placeholder in `uploading`, which the store coerces to `interrupted` only
-   * on the next load (aborts happen on logout, where the placeholder is cleared
-   * anyway). The caller MUST re-check its draft still tracks `clientUploadId`
-   * before writing the result.
+   * placeholder in `uploading`, which the store drops on the next load (aborts
+   * happen on logout, where the placeholder is cleared anyway). The caller MUST
+   * re-check its draft still tracks `clientUploadId` before writing the result.
    */
   onSettled: (outcome: UploadOutcome) => void;
 }
@@ -83,8 +82,9 @@ export function startUpload({
       );
       onSettled({ clientUploadId, status: "uploaded", attachment });
     } catch (err) {
-      // An abort is not a failure: leave the placeholder untouched so it reads
-      // as "interrupted" on the next load. Every other error surfaces.
+      // An abort is not a failure: leave the placeholder untouched. It stays
+      // `uploading` for the rest of the session and is dropped on the next
+      // load. Every other error surfaces.
       if (controller.signal.aborted || (err instanceof Error && err.name === "AbortError")) {
         logger.info("upload aborted", { clientUploadId });
         return;

--- a/packages/core/issues/stores/comment-draft-store.ts
+++ b/packages/core/issues/stores/comment-draft-store.ts
@@ -26,7 +26,7 @@ import type { Attachment } from "../../types";
  * text. Each upload is a {@link DraftUpload} that carries its status — an
  * in-flight placeholder (owned by the upload coordinator) becomes the full
  * attachment once it settles, and a placeholder still `uploading` at load time
- * is coerced to `interrupted` because the bytes were never persisted.
+ * is dropped because the bytes were never persisted.
  *
  * Keys are issue-scoped because createWorkspaceAwareStorage only partitions
  * by workspace, not by issue. Without issueId in the key, two issues with
@@ -142,8 +142,8 @@ function pruneStaleDrafts(drafts: Record<string, CommentDraft>): Record<string, 
   const out: Record<string, CommentDraft> = {};
   for (const [k, v] of Object.entries(drafts)) {
     // Normalize every persisted draft: legacy `Attachment[]` becomes uploaded
-    // placeholders, and any placeholder still `uploading` becomes `interrupted`
-    // (the bytes were never persisted, so the upload cannot resume).
+    // placeholders, and any placeholder still `uploading` is dropped (the bytes
+    // were never persisted, so the upload cannot resume).
     const uploads = normalizeStoredUploads(v.attachments);
     if (v.updatedAt >= cutoff && isMeaningful(v.content, uploads)) {
       out[k] = { ...v, attachments: uploads };

--- a/packages/core/issues/stores/draft-store.ts
+++ b/packages/core/issues/stores/draft-store.ts
@@ -40,7 +40,7 @@ export interface IssueCreateShared {
    *  image survives a mode switch from either side; each submit path sends
    *  only the ids its own content references. Coordinator-owned (MUL-5181 L2):
    *  a placeholder written at pick time survives dialog close, and one still
-   *  `uploading` at load time is coerced to `interrupted` on rehydrate. */
+   *  `uploading` at load time is dropped on rehydrate. */
   attachments: DraftUpload[];
 }
 
@@ -135,7 +135,7 @@ function migrateDraft(raw: unknown): IssueCreateDraft {
         priority: (d.priority as IssuePriority) ?? "none",
         dueDate: (d.dueDate as string | null) ?? null,
         // Legacy builds persisted bare Attachment rows; normalize wraps them
-        // as `uploaded` placeholders (and coerces stale `uploading` ones).
+        // as `uploaded` placeholders (and drops stale `uploading` ones).
         attachments: normalizeStoredUploads(d.attachments),
       },
       manual: {
@@ -163,7 +163,7 @@ function migrateDraft(raw: unknown): IssueCreateDraft {
       ...emptyShared(),
       ...sharedRaw,
       // Pre-L2 nested drafts stored bare Attachment rows; every load also
-      // coerces `uploading` placeholders to `interrupted` (bytes are gone).
+      // drops `uploading` placeholders (bytes are gone).
       attachments: normalizeStoredUploads(sharedRaw.attachments),
     },
     manual: { ...emptyManual(), ...((d.manual as Partial<IssueCreateManual>) ?? {}) },

--- a/packages/views/chat/components/chat-input.tsx
+++ b/packages/views/chat/components/chat-input.tsx
@@ -277,7 +277,7 @@ export function ChatInput({
     [makeUploadBinding, draftKey],
   );
   // Coordinator-owned uploads (MUL-5181 L2): survive window close, abort on
-  // logout, read `interrupted` after a reload. `gate` widens the editor gate
+  // logout, are dropped after a reload. `gate` widens the editor gate
   // with the draft's placeholders so a REOPENED composer over a still-running
   // upload cannot send past it.
   const {

--- a/packages/views/editor/use-coordinated-uploads.ts
+++ b/packages/views/editor/use-coordinated-uploads.ts
@@ -9,7 +9,8 @@
  * surface's draft IMMEDIATELY (through the {@link UploadDraftBinding}), then
  * hands the file to the coordinator. Closing or scrolling the composer away no
  * longer aborts the upload; logout aborts every tracked request; a placeholder
- * still `uploading` at load time is coerced to `interrupted` by the store.
+ * still `uploading` at load time is DROPPED by the store — the bytes were never
+ * persisted, so it can neither resume nor be retried.
  *
  * `onSettled` is generation-guarded: it re-reads the draft and only writes if
  * the placeholder is still tracked (the draft may have been submitted or
@@ -205,8 +206,17 @@ export interface CoordinatedUploads {
   /** Completed attachment rows — the editor preview set; submit binds the
    *  subset whose link the body still references. */
   attachments: Attachment[];
-  /** Wire to `<ContentEditor onUploadFile={...} />`. */
-  handleUpload: (file: File) => Promise<UploadResult | null>;
+  /**
+   * Wire to `<ContentEditor onUploadFile={...} />`.
+   *
+   * The editor mints `uploadId` when it draws the placeholder node and hands it
+   * in here, so the document node and the draft record share ONE id — that is
+   * what lets a settle reaching a mount which did not start the upload find the
+   * node again. Keep this second parameter in the type: a mock or a hand-rolled
+   * caller that drops it silently mints a second id and breaks that link.
+   * Optional only for a caller with no editor placeholder to match.
+   */
+  handleUpload: (file: File, uploadId?: string) => Promise<UploadResult | null>;
   /** Drop a placeholder (dismiss a failure / interrupted). */
   removeUpload: (clientUploadId: string) => void;
   /**
@@ -444,9 +454,9 @@ export function useCoordinatedUploads(
               // `isMeaningful` counts it, so a single flaky request keeps an
               // otherwise-empty draft alive for the full 30-day TTL.
               //
-              // `interrupted` is the opposite case and still gets a chip: it
-              // is discovered a session later, when the user no longer
-              // remembers attaching anything.
+              // Legacy `interrupted` records still get a chip for the reason
+              // this one does not: they are discovered a session later, when
+              // the user no longer remembers attaching anything.
               if (target) {
                 if (target.getUploads().some((u) => u.clientUploadId === clientUploadId)) {
                   target.removeUpload(clientUploadId);

--- a/packages/views/modals/create-issue.tsx
+++ b/packages/views/modals/create-issue.tsx
@@ -340,8 +340,8 @@ export function ManualCreatePanel({
   // carry a stripped body across).
   const uploadGate = useUploadGate(descEditorRef);
   // Coordinator-owned uploads in the shared pool (MUL-5181, L2): a file picked
-  // here survives dialog close, aborts on logout, and reads `interrupted`
-  // after a reload. `gate` widens the editor gate with the pool's placeholders.
+  // here survives dialog close, aborts on logout, and is dropped after a
+  // reload. `gate` widens the editor gate with the pool's placeholders.
   const {
     attachments: draftAttachments,
     handleUpload,

--- a/packages/views/modals/quick-create-issue.tsx
+++ b/packages/views/modals/quick-create-issue.tsx
@@ -347,8 +347,8 @@ export function AgentCreatePanel({
   const uploadGate = useUploadGate(editorRef);
   // Coordinator-owned uploads in the shared draft pool (MUL-5181, L2): a file
   // pasted into the prompt survives dialog close and mode switches, aborts on
-  // logout, and reads `interrupted` after a reload. `gate` widens the editor
-  // gate with the pool's placeholders.
+  // logout, and is dropped after a reload. `gate` widens the editor gate with
+  // the pool's placeholders.
   const {
     attachments: pendingAttachments,
     handleUpload: handleUploadFile,


### PR DESCRIPTION
Follow-up to #6025 (MUL-5391). Both items are the non-blocking cleanups raised in review on that PR; neither changes runtime behaviour.

## 1. `handleUpload` exposed a one-arg contract

`CoordinatedUploads.handleUpload` was typed `(file: File) => Promise<UploadResult | null>`, but the real `ContentEditor` contract is `onUploadFile?: (file, uploadId) => ...` and the hook's implementation already accepted `uploadId?: string`.

Runtime was safe, but the declared return type of `useCoordinatedUploads` erased the second parameter at the boundary. That id is what ties the editor's placeholder node to the persisted draft record — a mock or hand-rolled caller that drops it mints a *second* id, and a settle reaching a mount that did not start the upload can no longer find the node.

Widened the interface to `(file: File, uploadId?: string)` and documented why the id has to be threaded through. Optional rather than required because the implementation deliberately keeps a `?? createSafeId()` fallback for callers with no editor placeholder to match.

## 2. `interrupted` doc drift

#6025 changed `normalizeStoredUploads` to **drop** persisted `uploading` records instead of coercing them to `interrupted` — but eleven comments across `packages/core` and `packages/views` still described the old coercion. Review flagged two; the same false claim appeared in nine more places, so all of them are corrected here rather than leaving the codebase half-lying.

While tracing it: `interrupted` is now produced by **no code path at all**. It stays in the `UploadStatus` union and `normalizeStoredUploads` still preserves it, because builds shipped before this change persisted such records into local storage and their chips must keep rendering and dismissing. That is a persisted-format boundary, so the status is kept and marked LEGACY at the type, plus a note on the test that pins the behaviour (`draft-upload.test.ts`).

The drop behaviour was already covered by `draft-upload.test.ts:67` — the comments simply contradicted a tested guarantee, so no new test is needed.

## Verification

- `pnpm typecheck` — 6/6 tasks pass
- `packages/core` Vitest — 107 files, 1133 tests pass
- `packages/views` Vitest — 271 files, 3178 tests pass
- `git diff --check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
