### PR TITLE
MUL-5357: fix Table column interactions, loading states and scroll rendering

### DIFF
--- a/packages/ui/components/ui/data-table.tsx
+++ b/packages/ui/components/ui/data-table.tsx
@@ -381,7 +381,15 @@ export function DataTable<TData>({
             ...columnSizeVars,
           }}
         >
-          <TableHeader className="sticky top-0 z-10 bg-muted/30 backdrop-blur">
+          {/* Opaque rather than translucent-and-blurred. A backdrop-filter on
+            * a sticky element with content scrolling beneath it is a known
+            * Chromium compositing fault (electron#12906, chromium#339841685) —
+            * the blur layer has to recompute its backdrop every frame while
+            * virtualisation adds and removes the rows underneath it, and the
+            * strip flickers black. The mix resolves to the same colour
+            * bg-muted/30 composited to, and a header that scrolled content
+            * passes behind has no reason to show it through anyway. */}
+          <TableHeader className="sticky top-0 z-10 bg-[color-mix(in_oklab,var(--muted)_30%,var(--background))]">
             {table.getHeaderGroups().map((headerGroup) => (
               <TableRow key={headerGroup.id} className="hover:bg-transparent">
                 {headerGroup.headers.map((header) => {

--- a/packages/ui/components/ui/data-table.tsx
+++ b/packages/ui/components/ui/data-table.tsx
@@ -342,6 +342,13 @@ export function DataTable<TData>({
     estimateSize: () => virtualRowHeight,
     getItemKey: getVirtualRowKey,
     overscan: virtualOverscan,
+    // Rows are not all one height. Callers use renderRow for group headers and
+    // end-of-column footers, which are shorter than a data row, so a single
+    // estimate drifts from the real layout as those accumulate — the window
+    // lands off the rows it should be showing and the scrollbar overshoots the
+    // bottom. Each mounted row reports its own height instead, and the
+    // estimate only covers rows that have never been on screen.
+    measureElement: (element) => element.getBoundingClientRect().height,
   });
   const virtualItems = rowVirtualizer.getVirtualItems();
   const firstVirtualItem = virtualItems[0];
@@ -358,6 +365,7 @@ export function DataTable<TData>({
     onRowClick,
     renderRow,
     hasExplicitSize,
+    measureRow: rowVirtualizer.measureElement,
     virtualizeRows,
     virtualItems,
     virtualPaddingTop,
@@ -560,6 +568,8 @@ interface DataTableBodyProps<TData> {
   onRowClick?: (row: Row<TData>) => void;
   renderRow?: (row: Row<TData>) => React.ReactNode;
   hasExplicitSize: (columnId: string) => boolean;
+  // The virtualizer's own measuring ref; rows report their height through it.
+  measureRow: (element: HTMLElement | null) => void;
   virtualizeRows: boolean;
   virtualItems: VirtualItem[];
   virtualPaddingTop: number;
@@ -573,19 +583,35 @@ function DataTableBody<TData>({
   onRowClick,
   renderRow,
   hasExplicitSize,
+  measureRow,
   virtualizeRows,
   virtualItems,
   virtualPaddingTop,
   virtualPaddingBottom,
 }: DataTableBodyProps<TData>) {
-  const renderDataRow = (row: Row<TData>) => {
+  const renderDataRow = (row: Row<TData>, index?: number) => {
+    // The virtualizer reads an element's own height off `data-index`, so a row
+    // has to be tagged and handed the measuring ref. renderRow returns a <tr>
+    // the caller built; cloning is how it joins in without every caller having
+    // to thread the two through.
+    const measured =
+      index === undefined
+        ? {}
+        : { "data-index": index, ref: measureRow };
+
     const customRow = renderRow?.(row);
     if (customRow != null) {
-      return <React.Fragment key={row.id}>{customRow}</React.Fragment>;
+      return React.isValidElement(customRow) && index !== undefined
+        ? React.cloneElement(
+            customRow as React.ReactElement<Record<string, unknown>>,
+            { key: row.id, ...measured },
+          )
+        : <React.Fragment key={row.id}>{customRow}</React.Fragment>;
     }
     return (
       <TableRow
         key={row.id}
+        {...measured}
         data-state={row.getIsSelected() && "selected"}
         onClick={onRowClick ? () => onRowClick(row) : undefined}
         // `group` lets pinned cells track row hover via group-hover (their bg
@@ -645,7 +671,7 @@ function DataTableBody<TData>({
             {renderVirtualSpacer("top", virtualPaddingTop)}
             {virtualItems.map((virtualItem) => {
               const row = rows[virtualItem.index];
-              return row ? renderDataRow(row) : null;
+              return row ? renderDataRow(row, virtualItem.index) : null;
             })}
             {renderVirtualSpacer("bottom", virtualPaddingBottom)}
           </>

--- a/packages/ui/components/ui/data-table.tsx
+++ b/packages/ui/components/ui/data-table.tsx
@@ -2,12 +2,14 @@
 
 import {
   flexRender,
+  type ColumnSizingState,
   type Header as TanstackHeader,
   type Row,
   type Table as TanstackTable,
 } from "@tanstack/react-table";
-import { useVirtualizer } from "@tanstack/react-virtual";
+import { useVirtualizer, type VirtualItem } from "@tanstack/react-virtual";
 import * as React from "react";
+import { createPortal } from "react-dom";
 
 // We deliberately use the lower-level shadcn primitives (TableHeader /
 // TableBody / TableRow / TableHead / TableCell) but NOT the wrapping
@@ -22,8 +24,13 @@ import {
   TableHeader,
   TableRow,
 } from "@multica/ui/components/ui/table";
-import { getCellStyle } from "@multica/ui/lib/data-table";
+import { columnSizeVar, getCellStyle } from "@multica/ui/lib/data-table";
 import { cn } from "@multica/ui/lib/utils";
+
+// Pointer travel that turns a press on the resize handle into a drag. Matches
+// the column-reorder sensor's activation distance so both gestures on the same
+// header behave alike, and keeps a plain click from committing a width.
+const RESIZE_DRAG_THRESHOLD = 4;
 
 interface DataTableProps<TData> extends React.ComponentProps<"div"> {
   table: TanstackTable<TData>;
@@ -93,19 +100,48 @@ export function DataTable<TData>({
     [columnSizing],
   );
 
-  const setColumnWidth = React.useCallback(
-    (header: TanstackHeader<TData, unknown>, width: number) => {
-      const minSize = header.column.columnDef.minSize ?? 48;
-      const maxSize =
-        header.column.columnDef.maxSize ?? Number.MAX_SAFE_INTEGER;
-      const next = Math.min(maxSize, Math.max(minSize, Math.round(width)));
-
-      table.setColumnSizing((old) => ({
-        ...old,
-        [header.column.id]: next,
-      }));
+  const clampColumnWidth = React.useCallback(
+    (columnId: string, width: number) => {
+      const columnDef = table.getColumn(columnId)?.columnDef;
+      const minSize = columnDef?.minSize ?? 48;
+      const maxSize = columnDef?.maxSize ?? Number.MAX_SAFE_INTEGER;
+      return Math.min(maxSize, Math.max(minSize, Math.round(width)));
     },
     [table],
+  );
+
+  const setColumnWidth = React.useCallback(
+    (header: TanstackHeader<TData, unknown>, width: number) => {
+      table.setColumnSizing((old) => ({
+        ...old,
+        [header.column.id]: clampColumnWidth(header.column.id, width),
+      }));
+    },
+    [clampColumnWidth, table],
+  );
+
+  // Fixed table-layout shares out whatever space is left when the configured
+  // widths add up to less than the table, so every column renders wider than
+  // it is configured. Committing one column changes that leftover and rescales
+  // all the others, which makes a drag run ahead of the pointer. Pinning every
+  // column to the width it already renders at removes the leftover, so from
+  // that point the drag maps 1:1 onto pointer movement.
+  const freezeRenderedWidths = React.useCallback(
+    (headerRow: Element | null): ColumnSizingState => {
+      const frozen: ColumnSizingState = {};
+      const cells =
+        headerRow?.querySelectorAll<HTMLElement>("th[data-column-id]") ?? [];
+      for (const cell of cells) {
+        const columnId = cell.dataset.columnId;
+        if (!columnId) continue;
+        frozen[columnId] = clampColumnWidth(
+          columnId,
+          cell.getBoundingClientRect().width,
+        );
+      }
+      return frozen;
+    },
+    [clampColumnWidth],
   );
 
   const beginColumnResize = React.useCallback(
@@ -119,36 +155,62 @@ export function DataTable<TData>({
       event.stopPropagation();
 
       const startX = event.clientX;
-      const headerCell = event.currentTarget.closest("th");
+      const handleEl = event.currentTarget;
+      const { pointerId } = event;
+      const headerCell = handleEl.closest("th");
+      // The rendered width, not column.getSize(): the drag has to continue from
+      // the edge the user grabbed, which sits wherever the stretch put it.
       const startWidth =
         headerCell?.getBoundingClientRect().width ?? header.column.getSize();
 
       setResizingColumnId(header.column.id);
-      setColumnWidth(header, startWidth);
 
-      const originalCursor = document.body.style.cursor;
-      const originalUserSelect = document.body.style.userSelect;
-      document.body.style.cursor = "col-resize";
-      document.body.style.userSelect = "none";
+      let frozen: ColumnSizingState | null = null;
 
       const handlePointerMove = (pointerEvent: PointerEvent) => {
-        setColumnWidth(header, startWidth + pointerEvent.clientX - startX);
+        const delta = pointerEvent.clientX - startX;
+        // Nothing is committed below the threshold, so a press on its own can
+        // no longer pin a column at the width the stretch happened to give it.
+        if (!frozen && Math.abs(delta) < RESIZE_DRAG_THRESHOLD) return;
+        // Measured once, on the frame the drag starts — every later frame
+        // reuses it, so the baseline can't drift as widths change underneath.
+        frozen ??= freezeRenderedWidths(handleEl.closest("tr"));
+
+        table.setColumnSizing((old) => ({
+          ...old,
+          ...frozen,
+          [header.column.id]: clampColumnWidth(
+            header.column.id,
+            startWidth + delta,
+          ),
+        }));
       };
 
       const stopResize = () => {
         window.removeEventListener("pointermove", handlePointerMove);
         window.removeEventListener("pointerup", stopResize);
         window.removeEventListener("pointercancel", stopResize);
-        document.body.style.cursor = originalCursor;
-        document.body.style.userSelect = originalUserSelect;
+        window.removeEventListener("blur", stopResize);
+        // Detached before releasing capture — releasing fires this same event.
+        handleEl.removeEventListener("lostpointercapture", stopResize);
+        if (handleEl.hasPointerCapture?.(pointerId)) {
+          handleEl.releasePointerCapture?.(pointerId);
+        }
         setResizingColumnId(null);
       };
 
       window.addEventListener("pointermove", handlePointerMove);
       window.addEventListener("pointerup", stopResize);
       window.addEventListener("pointercancel", stopResize);
+      // Releasing outside the window or switching apps mid-drag never delivers
+      // pointerup. Without these the gesture stays armed and the column keeps
+      // tracking the pointer once the user comes back.
+      window.addEventListener("blur", stopResize);
+      handleEl.addEventListener("lostpointercapture", stopResize);
+      // Optional call: jsdom has no pointer capture.
+      handleEl.setPointerCapture?.(pointerId);
     },
-    [setColumnWidth],
+    [clampColumnWidth, freezeRenderedWidths, table],
   );
 
   const handleResizeKeyDown = React.useCallback(
@@ -174,7 +236,35 @@ export function DataTable<TData>({
     [hasExplicitSize, setColumnWidth],
   );
 
+  // Every column's width, published once on the <table>. Cells reference these
+  // instead of each calling column.getSize(), so a resize costs one style
+  // update on one element rather than one per cell.
+  const leafColumns = table.getVisibleLeafColumns();
+  const columnSizeVars = React.useMemo(() => {
+    const vars: Record<string, string> = {};
+    for (const column of leafColumns) {
+      vars[columnSizeVar(column.id)] = `${column.getSize()}px`;
+    }
+    return vars;
+  }, [columnSizing, leafColumns]);
+
   const scrollRef = React.useRef<HTMLDivElement | null>(null);
+
+  // Drives the pinned columns' trailing shadow. It only means something once
+  // content is passing beneath them, so it stays off at rest. The state is a
+  // boolean rather than the offset: it flips twice per scroll excursion
+  // instead of once per scroll event, and React bails out on the repeats.
+  const [isScrolledHorizontally, setIsScrolledHorizontally] =
+    React.useState(false);
+  React.useEffect(() => {
+    const element = scrollRef.current;
+    if (!element) return;
+    const sync = () => setIsScrolledHorizontally(element.scrollLeft > 0);
+    sync();
+    element.addEventListener("scroll", sync, { passive: true });
+    return () => element.removeEventListener("scroll", sync);
+  }, []);
+
   const rows = table.getRowModel().rows;
   const getVirtualRowKey = React.useCallback(
     (index: number) => rows[index]?.id ?? index,
@@ -195,6 +285,199 @@ export function DataTable<TData>({
     ? rowVirtualizer.getTotalSize() - lastVirtualItem.end
     : 0;
 
+  const bodyProps: DataTableBodyProps<TData> = {
+    table,
+    rows,
+    emptyMessage,
+    onRowClick,
+    renderRow,
+    hasExplicitSize,
+    isScrolledHorizontally,
+    virtualizeRows,
+    virtualItems,
+    virtualPaddingTop,
+    virtualPaddingBottom,
+  };
+
+  return (
+    <div
+      className={cn("flex min-h-0 flex-1 flex-col", className)}
+      {...props}
+    >
+      <div
+        ref={scrollRef}
+        className="flex min-h-0 flex-1 flex-col overflow-auto bg-background"
+      >
+        <table
+          className="w-full table-fixed caption-bottom text-sm"
+          style={{
+            minWidth: `${table.getTotalSize()}px`,
+            ...columnSizeVars,
+          }}
+        >
+          <TableHeader className="sticky top-0 z-10 bg-muted/30 backdrop-blur">
+            {table.getHeaderGroups().map((headerGroup) => (
+              <TableRow key={headerGroup.id} className="hover:bg-transparent">
+                {headerGroup.headers.map((header) => {
+                  const isPinned = header.column.getIsPinned();
+                  const columnHasExplicitSize = hasExplicitSize(
+                    header.column.id,
+                  );
+                  const headerLabel =
+                    typeof header.column.columnDef.header === "string"
+                      ? header.column.columnDef.header
+                      : header.column.id;
+                  return (
+                    <TableHead
+                      key={header.id}
+                      colSpan={header.colSpan}
+                      // Lets a drag measure every column by id instead of
+                      // pairing <th> elements with columns positionally.
+                      data-column-id={header.column.id}
+                      // Header typography overrides for a "spreadsheet
+                      // header" look: smaller, all-caps, wider letter
+                      // spacing, muted colour. shadcn's <TableHead>
+                      // defaults to text-sm + text-foreground +
+                      // font-medium, which reads as too heavy here.
+                      // h-8 (32px) tightens the strip vs the default
+                      // h-10 (40px).
+                      // overflow-hidden caps any cell content that
+                      // exceeds column.size. Tooltip / dropdown /
+                      // hover-card bodies are portaled, so they are
+                      // unaffected.
+                      // Pinned cells must be opaque: translucent backgrounds
+                      // reveal horizontally scrolled columns underneath. Mix
+                      // muted with background to preserve the same visual tone
+                      // as muted/30 without introducing alpha.
+                      className={cn(
+                        "relative h-8 overflow-hidden border-r px-4 py-2 text-xs uppercase tracking-wider text-muted-foreground last:border-r-0",
+                        isPinned &&
+                          "transition-shadow bg-[color-mix(in_oklab,var(--muted)_30%,var(--background))]",
+                      )}
+                      style={getCellStyle(header.column, {
+                        showPinnedEdge: isScrolledHorizontally,
+                        hasExplicitSize: columnHasExplicitSize,
+                      })}
+                    >
+                      {header.isPlaceholder
+                        ? null
+                        : flexRender(
+                            header.column.columnDef.header,
+                            header.getContext(),
+                          )}
+                      {!header.isPlaceholder &&
+                        header.column.getCanResize() && (
+                          <div
+                            role="separator"
+                            aria-label={`Resize ${headerLabel} column`}
+                            aria-orientation="vertical"
+                            tabIndex={0}
+                            className={cn(
+                              // The line sits exactly on the column's own
+                              // border (hence -right-px, since `right-0` would
+                              // land just inside it and read as a double rule)
+                              // and recolours it. Three states have to stay
+                              // apart on one hairline: at rest it is the faint
+                              // grid rule, hovered it goes translucent brand,
+                              // and for the whole drag it holds at full brand —
+                              // brightening rather than fading, so the edge
+                              // being moved stays the most definite thing on
+                              // screen even once the pointer leaves the handle.
+                              // right-0, never a negative offset: the <th> is
+                              // overflow-hidden and clips at its padding edge,
+                              // so anything nudged out to sit on the border
+                              // itself is simply not painted. The bar lands
+                              // just inside the rule instead, and at 2px it
+                              // stays legible next to it.
+                              "absolute top-0 right-0 h-full w-2 cursor-col-resize touch-none select-none outline-none",
+                              "after:absolute after:inset-y-0 after:right-0 after:w-0.5 after:bg-transparent after:transition-colors after:duration-100",
+                              "hover:after:bg-brand/60 focus-visible:after:bg-brand/60",
+                              resizingColumnId === header.column.id &&
+                                "after:bg-brand after:transition-none",
+                            )}
+                            onPointerDown={(event) =>
+                              beginColumnResize(header, event)
+                            }
+                            onDoubleClick={(event) => {
+                              event.preventDefault();
+                              event.stopPropagation();
+                              header.column.resetSize();
+                            }}
+                            onKeyDown={(event) =>
+                              handleResizeKeyDown(header, event)
+                            }
+                          />
+                        )}
+                    </TableHead>
+                  );
+                })}
+              </TableRow>
+            ))}
+          </TableHeader>
+          {/* Widths reach the body through the custom properties above, so
+            * while a column is being dragged the body has nothing to re-render:
+            * swap in the memoized copy and let the browser do the resizing. */}
+          {resizingColumnId !== null ? (
+            <MemoizedDataTableBody {...bodyProps} />
+          ) : (
+            <DataTableBody {...bodyProps} />
+          )}
+          {footer}
+        </table>
+      </div>
+      {/* A viewport-wide layer that only exists for the duration of a column
+        * drag. It owns the cursor so descendants that declare their own
+        * (rows are `cursor-pointer`, cells hold text) cannot override it, and
+        * it keeps the text underneath unselectable. Setting these on
+        * document.body instead loses both fights, since a descendant's own
+        * cursor wins over an inherited one. Pointer events still reach the
+        * gesture: it listens on `window`, which the layer's events bubble to.
+        * Portaled to body so an ancestor with a transform / filter / contain
+        * cannot turn `fixed` into "relative to that ancestor". */}
+      {resizingColumnId !== null &&
+        typeof document !== "undefined" &&
+        createPortal(
+          <div
+            aria-hidden
+            data-slot="data-table-resize-overlay"
+            className="fixed inset-0 z-50 cursor-col-resize touch-none select-none"
+          />,
+          document.body,
+        )}
+      {actionBar &&
+        table.getFilteredSelectedRowModel().rows.length > 0 &&
+        actionBar}
+    </div>
+  );
+}
+
+interface DataTableBodyProps<TData> {
+  table: TanstackTable<TData>;
+  rows: Row<TData>[];
+  emptyMessage: React.ReactNode;
+  onRowClick?: (row: Row<TData>) => void;
+  renderRow?: (row: Row<TData>) => React.ReactNode;
+  hasExplicitSize: (columnId: string) => boolean;
+  isScrolledHorizontally: boolean;
+  virtualizeRows: boolean;
+  virtualItems: VirtualItem[];
+  virtualPaddingTop: number;
+  virtualPaddingBottom: number;
+}
+
+function DataTableBody<TData>({
+  table,
+  rows,
+  emptyMessage,
+  onRowClick,
+  renderRow,
+  hasExplicitSize,
+  isScrolledHorizontally,
+  virtualizeRows,
+  virtualItems,
+  virtualPaddingTop,
+  virtualPaddingBottom,
+}: DataTableBodyProps<TData>) {
   const renderDataRow = (row: Row<TData>) => {
     const customRow = renderRow?.(row);
     if (customRow != null) {
@@ -222,12 +505,12 @@ export function DataTable<TData>({
               // Pinned cells need an opaque bg + group-hover so they cover
               // content scrolling beneath them and follow row hover state.
               className={cn(
-                "overflow-hidden px-4 py-2",
+                "overflow-hidden border-r px-4 py-2 last:border-r-0",
                 isPinned &&
-                  "bg-background group-hover:bg-[color-mix(in_oklab,var(--muted)_50%,var(--background))]",
+                  "transition-shadow bg-background group-hover:bg-[color-mix(in_oklab,var(--muted)_50%,var(--background))]",
               )}
               style={getCellStyle(cell.column, {
-                withBorder: true,
+                showPinnedEdge: isScrolledHorizontally,
                 hasExplicitSize: columnHasExplicitSize,
               })}
             >
@@ -255,129 +538,40 @@ export function DataTable<TData>({
     ) : null;
 
   return (
-    <div
-      className={cn("flex min-h-0 flex-1 flex-col", className)}
-      {...props}
-    >
-      <div
-        ref={scrollRef}
-        className="flex min-h-0 flex-1 flex-col overflow-auto bg-background"
-      >
-        <table
-          className="w-full table-fixed caption-bottom text-sm"
-          style={{ minWidth: `${table.getTotalSize()}px` }}
-        >
-          <TableHeader className="sticky top-0 z-10 bg-muted/30 backdrop-blur">
-            {table.getHeaderGroups().map((headerGroup) => (
-              <TableRow key={headerGroup.id} className="hover:bg-transparent">
-                {headerGroup.headers.map((header) => {
-                  const isPinned = header.column.getIsPinned();
-                  const columnHasExplicitSize = hasExplicitSize(
-                    header.column.id,
-                  );
-                  const headerLabel =
-                    typeof header.column.columnDef.header === "string"
-                      ? header.column.columnDef.header
-                      : header.column.id;
-                  return (
-                    <TableHead
-                      key={header.id}
-                      colSpan={header.colSpan}
-                      // Header typography overrides for a "spreadsheet
-                      // header" look: smaller, all-caps, wider letter
-                      // spacing, muted colour. shadcn's <TableHead>
-                      // defaults to text-sm + text-foreground +
-                      // font-medium, which reads as too heavy here.
-                      // h-8 (32px) tightens the strip vs the default
-                      // h-10 (40px).
-                      // overflow-hidden caps any cell content that
-                      // exceeds column.size. Tooltip / dropdown /
-                      // hover-card bodies are portaled, so they are
-                      // unaffected.
-                      // Pinned cells must be opaque: translucent backgrounds
-                      // reveal horizontally scrolled columns underneath. Mix
-                      // muted with background to preserve the same visual tone
-                      // as muted/30 without introducing alpha.
-                      className={cn(
-                        "relative h-8 overflow-hidden px-4 py-2 text-xs uppercase tracking-wider text-muted-foreground",
-                        isPinned &&
-                          "bg-[color-mix(in_oklab,var(--muted)_30%,var(--background))]",
-                      )}
-                      style={getCellStyle(header.column, {
-                        withBorder: true,
-                        hasExplicitSize: columnHasExplicitSize,
-                      })}
-                    >
-                      {header.isPlaceholder
-                        ? null
-                        : flexRender(
-                            header.column.columnDef.header,
-                            header.getContext(),
-                          )}
-                      {!header.isPlaceholder &&
-                        header.column.getCanResize() && (
-                          <div
-                            role="separator"
-                            aria-label={`Resize ${headerLabel} column`}
-                            aria-orientation="vertical"
-                            tabIndex={0}
-                            className={cn(
-                              "absolute top-0 right-0 h-full w-2 cursor-col-resize touch-none select-none outline-none",
-                              "after:absolute after:top-1/2 after:right-0 after:h-4 after:w-px after:-translate-y-1/2 after:bg-border after:opacity-0 after:transition-opacity",
-                              "hover:after:opacity-100 focus-visible:after:opacity-100",
-                              resizingColumnId === header.column.id &&
-                                "after:bg-primary after:opacity-100",
-                            )}
-                            onPointerDown={(event) =>
-                              beginColumnResize(header, event)
-                            }
-                            onDoubleClick={(event) => {
-                              event.preventDefault();
-                              event.stopPropagation();
-                              header.column.resetSize();
-                            }}
-                            onKeyDown={(event) =>
-                              handleResizeKeyDown(header, event)
-                            }
-                          />
-                        )}
-                    </TableHead>
-                  );
-                })}
-              </TableRow>
-            ))}
-          </TableHeader>
-          <TableBody>
-            {rows.length ? (
-              virtualizeRows ? (
-                <>
-                  {renderVirtualSpacer("top", virtualPaddingTop)}
-                  {virtualItems.map((virtualItem) => {
-                    const row = rows[virtualItem.index];
-                    return row ? renderDataRow(row) : null;
-                  })}
-                  {renderVirtualSpacer("bottom", virtualPaddingBottom)}
-                </>
-              ) : (
-                rows.map(renderDataRow)
-              )
-            ) : (
-              <TableRow>
-                <TableCell
-                  colSpan={table.getAllColumns().length}
-                  className="h-24 text-center text-muted-foreground"
-                >
-                  {emptyMessage}
-                </TableCell>
-              </TableRow>
-            )}
-          </TableBody>
-          {footer}
-        </table>
-      </div>
-      {actionBar &&
-        table.getFilteredSelectedRowModel().rows.length > 0 &&
-        actionBar}
-    </div>
+    <TableBody>
+      {rows.length ? (
+        virtualizeRows ? (
+          <>
+            {renderVirtualSpacer("top", virtualPaddingTop)}
+            {virtualItems.map((virtualItem) => {
+              const row = rows[virtualItem.index];
+              return row ? renderDataRow(row) : null;
+            })}
+            {renderVirtualSpacer("bottom", virtualPaddingBottom)}
+          </>
+        ) : (
+          rows.map(renderDataRow)
+        )
+      ) : (
+        <TableRow>
+          <TableCell
+            colSpan={table.getAllColumns().length}
+            className="h-24 text-center text-muted-foreground"
+          >
+            {emptyMessage}
+          </TableCell>
+        </TableRow>
+      )}
+    </TableBody>
   );
 }
+
+// Rendered in place of DataTableBody for the duration of a column drag. Only
+// the row data is compared: during a drag the widths travel as custom
+// properties and nothing else in the body can change, so skipping the render
+// entirely is what keeps hundreds of cells off the main thread per frame.
+// React.memo erases the generic, so the cast restores the original signature.
+const MemoizedDataTableBody = React.memo(
+  DataTableBody,
+  (prev, next) => prev.table.options.data === next.table.options.data,
+) as typeof DataTableBody;

--- a/packages/ui/components/ui/data-table.tsx
+++ b/packages/ui/components/ui/data-table.tsx
@@ -144,6 +144,59 @@ export function DataTable<TData>({
     [clampColumnWidth],
   );
 
+  // Double-click on the resize handle sizes the column to its content, the
+  // convention every spreadsheet and grid shares. It replaces column.resetSize,
+  // which cleared the stored width and let TanStack fall back to its generic
+  // 150 — a number unrelated to any of this table's designed widths, so
+  // "reset" widened some columns and collapsed others.
+  //
+  // Fixed table-layout ignores content, and cells truncate their own text, so
+  // nothing on screen reports the width the content actually wants. The
+  // measurement lifts both constraints on the column's cells, reads them, and
+  // puts everything back within the same task — the browser paints once, after
+  // the restore, so the intermediate layout is never seen.
+  const autoFitColumn = React.useCallback(
+    (header: TanstackHeader<TData, unknown>) => {
+      const container = scrollRef.current;
+      const tableElement = container?.querySelector("table");
+      if (!container || !tableElement) return;
+      const cells = container.querySelectorAll<HTMLElement>(
+        `[data-column-id="${CSS.escape(header.column.id)}"]`,
+      );
+      if (!cells.length) return;
+
+      const previousLayout = tableElement.style.tableLayout;
+      const previous = Array.from(cells, (cell) => ({
+        cell,
+        width: cell.style.width,
+        maxWidth: cell.style.maxWidth,
+        overflow: cell.style.overflow,
+      }));
+
+      tableElement.style.tableLayout = "auto";
+      for (const cell of cells) {
+        cell.style.width = "max-content";
+        cell.style.maxWidth = "none";
+        cell.style.overflow = "visible";
+      }
+
+      let widest = 0;
+      for (const cell of cells) {
+        widest = Math.max(widest, cell.getBoundingClientRect().width);
+      }
+
+      for (const entry of previous) {
+        entry.cell.style.width = entry.width;
+        entry.cell.style.maxWidth = entry.maxWidth;
+        entry.cell.style.overflow = entry.overflow;
+      }
+      tableElement.style.tableLayout = previousLayout;
+
+      if (widest > 0) setColumnWidth(header, widest);
+    },
+    [setColumnWidth],
+  );
+
   const beginColumnResize = React.useCallback(
     (
       header: TanstackHeader<TData, unknown>,
@@ -423,7 +476,7 @@ export function DataTable<TData>({
                             onDoubleClick={(event) => {
                               event.preventDefault();
                               event.stopPropagation();
-                              header.column.resetSize();
+                              autoFitColumn(header);
                             }}
                             onKeyDown={(event) =>
                               handleResizeKeyDown(header, event)
@@ -538,6 +591,7 @@ function DataTableBody<TData>({
           return (
             <TableCell
               key={cell.id}
+              data-column-id={cell.column.id}
               // px-4 across the board so cell content aligns with the
               // surrounding toolbar's px-4. Narrow trailing columns
               // (chevron / actions) declare enough width for icon + padding.

--- a/packages/ui/components/ui/data-table.tsx
+++ b/packages/ui/components/ui/data-table.tsx
@@ -256,10 +256,23 @@ export function DataTable<TData>({
   // instead of once per scroll event, and React bails out on the repeats.
   const [isScrolledHorizontally, setIsScrolledHorizontally] =
     React.useState(false);
+
+  // Where the frozen block ends, in the scroll container's own coordinates.
+  const [pinnedEdge, setPinnedEdge] = React.useState<number | null>(null);
+
   React.useEffect(() => {
     const element = scrollRef.current;
     if (!element) return;
-    const sync = () => setIsScrolledHorizontally(element.scrollLeft > 0);
+    const sync = () => {
+      setIsScrolledHorizontally(element.scrollLeft > 0);
+      const edge = element.querySelector("thead th[data-pinned-edge]");
+      setPinnedEdge(
+        edge
+          ? edge.getBoundingClientRect().right -
+              element.getBoundingClientRect().left
+          : null,
+      );
+    };
     sync();
     element.addEventListener("scroll", sync, { passive: true });
     return () => element.removeEventListener("scroll", sync);
@@ -292,7 +305,6 @@ export function DataTable<TData>({
     onRowClick,
     renderRow,
     hasExplicitSize,
-    isScrolledHorizontally,
     virtualizeRows,
     virtualItems,
     virtualPaddingTop,
@@ -304,6 +316,7 @@ export function DataTable<TData>({
       className={cn("flex min-h-0 flex-1 flex-col", className)}
       {...props}
     >
+      <div className="relative flex min-h-0 flex-1 flex-col">
       <div
         ref={scrollRef}
         className="flex min-h-0 flex-1 flex-col overflow-auto bg-background"
@@ -334,6 +347,16 @@ export function DataTable<TData>({
                       // Lets a drag measure every column by id instead of
                       // pairing <th> elements with columns positionally.
                       data-column-id={header.column.id}
+                      // Marks the frozen block's trailing edge for the scroll
+                      // shadow to measure against. Rendered widths differ from
+                      // configured ones under fixed table-layout, so the
+                      // boundary has to be read off the DOM, not summed.
+                      data-pinned-edge={
+                        isPinned === "left" &&
+                        header.column.getIsLastColumn("left")
+                          ? ""
+                          : undefined
+                      }
                       // Header typography overrides for a "spreadsheet
                       // header" look: smaller, all-caps, wider letter
                       // spacing, muted colour. shadcn's <TableHead>
@@ -352,10 +375,9 @@ export function DataTable<TData>({
                       className={cn(
                         "relative h-8 overflow-hidden border-r px-4 py-2 text-xs uppercase tracking-wider text-muted-foreground last:border-r-0",
                         isPinned &&
-                          "transition-shadow bg-[color-mix(in_oklab,var(--muted)_30%,var(--background))]",
+                          "bg-[color-mix(in_oklab,var(--muted)_30%,var(--background))]",
                       )}
                       style={getCellStyle(header.column, {
-                        showPinnedEdge: isScrolledHorizontally,
                         hasExplicitSize: columnHasExplicitSize,
                       })}
                     >
@@ -425,6 +447,25 @@ export function DataTable<TData>({
           {footer}
         </table>
       </div>
+      {/* Cast past the frozen block rather than drawn inside it. The border
+        * between the frozen columns and the rest is permanent and says where
+        * the boundary is; this says something is currently passing underneath,
+        * so it appears only while scrolled. An inset box-shadow on the pinned
+        * cell could only darken that cell's own edge — the depth belongs on
+        * the content sliding beneath it. */}
+      {isScrolledHorizontally && pinnedEdge !== null && (
+        <div
+          aria-hidden
+          data-slot="data-table-pinned-shadow"
+          className="pointer-events-none absolute inset-y-0 w-3"
+          style={{
+            left: `${pinnedEdge}px`,
+            background:
+              "linear-gradient(to right, color-mix(in oklab, var(--foreground) 7%, transparent), transparent)",
+          }}
+        />
+      )}
+      </div>
       {/* A viewport-wide layer that only exists for the duration of a column
         * drag. It owns the cursor so descendants that declare their own
         * (rows are `cursor-pointer`, cells hold text) cannot override it, and
@@ -458,7 +499,6 @@ interface DataTableBodyProps<TData> {
   onRowClick?: (row: Row<TData>) => void;
   renderRow?: (row: Row<TData>) => React.ReactNode;
   hasExplicitSize: (columnId: string) => boolean;
-  isScrolledHorizontally: boolean;
   virtualizeRows: boolean;
   virtualItems: VirtualItem[];
   virtualPaddingTop: number;
@@ -472,7 +512,6 @@ function DataTableBody<TData>({
   onRowClick,
   renderRow,
   hasExplicitSize,
-  isScrolledHorizontally,
   virtualizeRows,
   virtualItems,
   virtualPaddingTop,
@@ -507,10 +546,9 @@ function DataTableBody<TData>({
               className={cn(
                 "overflow-hidden border-r px-4 py-2 last:border-r-0",
                 isPinned &&
-                  "transition-shadow bg-background group-hover:bg-[color-mix(in_oklab,var(--muted)_50%,var(--background))]",
+                  "bg-background group-hover:bg-[color-mix(in_oklab,var(--muted)_50%,var(--background))]",
               )}
               style={getCellStyle(cell.column, {
-                showPinnedEdge: isScrolledHorizontally,
                 hasExplicitSize: columnHasExplicitSize,
               })}
             >

--- a/packages/ui/components/ui/data-table.tsx
+++ b/packages/ui/components/ui/data-table.tsx
@@ -299,6 +299,10 @@ export function DataTable<TData>({
       vars[columnSizeVar(column.id)] = `${column.getSize()}px`;
     }
     return vars;
+    // column.getSize() reads columnSizing, which the rule cannot see through
+    // the call. getVisibleLeafColumns is memoised on visibility and order, so
+    // without it the widths would freeze at whatever they were on mount.
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- getSize() reads columnSizing
   }, [columnSizing, leafColumns]);
 
   const scrollRef = React.useRef<HTMLDivElement | null>(null);
@@ -329,7 +333,10 @@ export function DataTable<TData>({
     sync();
     element.addEventListener("scroll", sync, { passive: true });
     return () => element.removeEventListener("scroll", sync);
-  }, []);
+    // Re-measured on column sizing too, not scrolling alone: resizing a frozen
+    // column while the surface is scrolled moves the boundary the shadow is
+    // pinned to, and no scroll event follows to correct it.
+  }, [columnSizing]);
 
   const rows = table.getRowModel().rows;
   const getVirtualRowKey = React.useCallback(

--- a/packages/ui/lib/data-table.ts
+++ b/packages/ui/lib/data-table.ts
@@ -37,7 +37,7 @@ export function columnSizeVar(columnId: string) {
 // `group-hover:`.
 export function getCellStyle<TData>(
   column: Column<TData>,
-  options?: { showPinnedEdge?: boolean; hasExplicitSize?: boolean },
+  options?: { hasExplicitSize?: boolean },
 ): React.CSSProperties {
   const grow = column.columnDef.meta?.grow;
   const width =
@@ -50,28 +50,35 @@ export function getCellStyle<TData>(
     return width !== undefined ? { width } : {};
   }
 
-  // The shadow marks where the frozen columns end and scrolled content passes
-  // underneath. With nothing scrolled under them there is nothing to mark, and
-  // it reads as a stray rule the other columns don't have — so callers turn it
-  // on only once the surface is actually scrolled sideways.
-  const showPinnedEdge = options?.showPinnedEdge ?? false;
-  const isLastLeftPinned =
-    isPinned === "left" && column.getIsLastColumn("left");
-  const isFirstRightPinned =
-    isPinned === "right" && column.getIsFirstColumn("right");
-
+  // No edge marker here. Where the frozen columns end is drawn by the scroll
+  // container's mask instead — a shadow inside the pinned cell can only darken
+  // the frozen column's own edge, while the mask fades the content that is
+  // actually sliding underneath, which is the thing being described.
   return {
     width,
     position: "sticky",
     left: isPinned === "left" ? `${column.getStart("left")}px` : undefined,
     right: isPinned === "right" ? `${column.getAfter("right")}px` : undefined,
     zIndex: 1,
-    boxShadow: showPinnedEdge
-      ? isLastLeftPinned
-        ? "-4px 0 4px -4px var(--border) inset"
-        : isFirstRightPinned
-          ? "4px 0 4px -4px var(--border) inset"
-          : undefined
-      : undefined,
   };
+}
+
+// Mask for the scroll container: content emerging from under the frozen
+// columns fades in over `fade` px instead of appearing at a hard edge.
+//
+// The stops are anchored to the frozen block's width, never to the scroll
+// offset — a mask on a scroll container is positioned against its padding box,
+// which does not scroll, so the fade stays welded to the boundary. Anchoring
+// is also what keeps the frozen columns themselves at full opacity: the
+// generic "fade both ends of a scroller" treatment would dissolve exactly the
+// columns that have to stay solid.
+export function pinnedScrollMask(
+  pinnedWidth: number,
+  fade = 24,
+): React.CSSProperties | undefined {
+  if (pinnedWidth <= 0) return undefined;
+  const gradient =
+    `linear-gradient(to right, black 0, black ${pinnedWidth}px, ` +
+    `transparent ${pinnedWidth}px, black ${pinnedWidth + fade}px, black 100%)`;
+  return { maskImage: gradient, WebkitMaskImage: gradient };
 }

--- a/packages/ui/lib/data-table.ts
+++ b/packages/ui/lib/data-table.ts
@@ -13,10 +13,23 @@ declare module "@tanstack/react-table" {
   }
 }
 
+// Custom-property name carrying a column's width. Column ids are app-defined
+// and may hold characters that are not valid in a CSS ident (`property:<uuid>`
+// is the live example), so everything outside the ident set is folded to `_`.
+// The ids in play differ well before that point, so folding cannot collide.
+export function columnSizeVar(columnId: string) {
+  return `--col-${columnId.replace(/[^a-zA-Z0-9_-]/g, "_")}-size`;
+}
+
 // Combined sizing + pinning style for a `<th>` / `<td>` cell. Width is
 // emitted unless the column is flagged `meta.grow` (those rely on
 // fixed-layout's leftover-space distribution). Pinned columns get
 // sticky positioning — see notes below.
+//
+// The width is a reference to a custom property published once on the <table>
+// rather than a number read per cell. During a resize that lets the browser
+// apply every new width from a single declaration change, with no React work
+// in the hundreds of cells that would otherwise each re-read column.getSize().
 //
 // Background is intentionally NOT set inline — the upstream Dice UI
 // version writes `background: var(--background)` here, which can't
@@ -24,17 +37,24 @@ declare module "@tanstack/react-table" {
 // `group-hover:`.
 export function getCellStyle<TData>(
   column: Column<TData>,
-  options?: { withBorder?: boolean; hasExplicitSize?: boolean },
+  options?: { showPinnedEdge?: boolean; hasExplicitSize?: boolean },
 ): React.CSSProperties {
   const grow = column.columnDef.meta?.grow;
-  const width = grow && !options?.hasExplicitSize ? undefined : column.getSize();
+  const width =
+    grow && !options?.hasExplicitSize
+      ? undefined
+      : `var(${columnSizeVar(column.id)})`;
 
   const isPinned = column.getIsPinned();
   if (!isPinned) {
     return width !== undefined ? { width } : {};
   }
 
-  const withBorder = options?.withBorder ?? false;
+  // The shadow marks where the frozen columns end and scrolled content passes
+  // underneath. With nothing scrolled under them there is nothing to mark, and
+  // it reads as a stray rule the other columns don't have — so callers turn it
+  // on only once the surface is actually scrolled sideways.
+  const showPinnedEdge = options?.showPinnedEdge ?? false;
   const isLastLeftPinned =
     isPinned === "left" && column.getIsLastColumn("left");
   const isFirstRightPinned =
@@ -46,7 +66,7 @@ export function getCellStyle<TData>(
     left: isPinned === "left" ? `${column.getStart("left")}px` : undefined,
     right: isPinned === "right" ? `${column.getAfter("right")}px` : undefined,
     zIndex: 1,
-    boxShadow: withBorder
+    boxShadow: showPinnedEdge
       ? isLastLeftPinned
         ? "-4px 0 4px -4px var(--border) inset"
         : isFirstRightPinned

--- a/packages/views/issues/components/data-table-resize.test.tsx
+++ b/packages/views/issues/components/data-table-resize.test.tsx
@@ -1,0 +1,226 @@
+import { act, render, screen } from "@testing-library/react";
+import {
+  getCoreRowModel,
+  useReactTable,
+  type ColumnDef,
+  type ColumnSizingState,
+} from "@tanstack/react-table";
+import * as React from "react";
+import { describe, expect, it, vi } from "vitest";
+import { DataTable } from "@multica/ui/components/ui/data-table";
+
+type Row = { status: string; owner: string };
+
+const columns: ColumnDef<Row>[] = [
+  { accessorKey: "status", header: "Status", size: 150 },
+  { accessorKey: "owner", header: "Owner", size: 90 },
+];
+
+function ResizableTable({
+  onSizingChange,
+  pinFirstColumn = false,
+}: {
+  onSizingChange: (sizing: ColumnSizingState) => void;
+  pinFirstColumn?: boolean;
+}) {
+  const [columnSizing, setColumnSizing] = React.useState<ColumnSizingState>({});
+  const table = useReactTable({
+    data: [{ status: "In progress", owner: "Ada" }],
+    columns,
+    getCoreRowModel: getCoreRowModel(),
+    state: {
+      columnSizing,
+      columnPinning: { left: pinFirstColumn ? ["status"] : [], right: [] },
+    },
+    columnResizeMode: "onChange",
+    onColumnSizingChange: (updater) => {
+      const next =
+        typeof updater === "function" ? updater(columnSizing) : updater;
+      setColumnSizing(next);
+      onSizingChange(next);
+    },
+  });
+
+  return <DataTable table={table} />;
+}
+
+// jsdom has no layout, so every <th> would measure 0 and each committed width
+// would clamp to minSize. Pin them to the widths fixed table-layout would have
+// stretched the columns to — both sit well above their configured size.
+function stubRenderedWidth(element: Element, width: number) {
+  element.getBoundingClientRect = () =>
+    ({
+      width,
+      height: 32,
+      top: 0,
+      left: 0,
+      right: width,
+      bottom: 32,
+      x: 0,
+      y: 0,
+      toJSON: () => ({}),
+    }) as DOMRect;
+}
+
+// jsdom's PointerEvent support is inconsistent; MouseEvent carries clientX and
+// React dispatches by event type, so the handlers receive what they need.
+// act() flushes the render that toggling the drag state schedules.
+function pointer(target: EventTarget, type: string, clientX: number) {
+  act(() => {
+    target.dispatchEvent(
+      new MouseEvent(type, { bubbles: true, cancelable: true, clientX }),
+    );
+  });
+}
+
+function setup() {
+  const onSizingChange = vi.fn();
+  render(<ResizableTable onSizingChange={onSizingChange} />);
+  const handle = screen.getByRole("separator", {
+    name: "Resize Status column",
+  });
+  stubRenderedWidth(
+    document.querySelector('th[data-column-id="status"]')!,
+    200,
+  );
+  stubRenderedWidth(document.querySelector('th[data-column-id="owner"]')!, 120);
+  return { onSizingChange, handle };
+}
+
+describe("DataTable column resize", () => {
+  it("commits nothing when the handle is clicked without dragging", () => {
+    const { onSizingChange, handle } = setup();
+
+    pointer(handle, "pointerdown", 100);
+    pointer(window, "pointerup", 100);
+
+    // The pre-fix code wrote the stretched render width here, permanently
+    // pinning a column the user only brushed past.
+    expect(onSizingChange).not.toHaveBeenCalled();
+  });
+
+  it("ignores pointer travel below the drag threshold", () => {
+    const { onSizingChange, handle } = setup();
+
+    pointer(handle, "pointerdown", 100);
+    pointer(window, "pointermove", 103);
+    pointer(window, "pointerup", 103);
+
+    expect(onSizingChange).not.toHaveBeenCalled();
+  });
+
+  it("commits the rendered width plus the delta once dragging starts", () => {
+    const { onSizingChange, handle } = setup();
+
+    pointer(handle, "pointerdown", 100);
+    pointer(window, "pointermove", 110);
+    pointer(window, "pointerup", 110);
+
+    expect(onSizingChange).toHaveBeenCalledWith({ status: 210, owner: 120 });
+  });
+
+  it("pins every column to its rendered width on the first drag frame", () => {
+    const { onSizingChange, handle } = setup();
+
+    pointer(handle, "pointerdown", 100);
+    pointer(window, "pointermove", 110);
+
+    // Without this, committing `status` would change how much leftover space
+    // fixed table-layout has to share out, resizing `owner` mid-drag and
+    // pushing the dragged edge away from the pointer.
+    expect(onSizingChange).toHaveBeenLastCalledWith(
+      expect.objectContaining({ owner: 120 }),
+    );
+
+    // Measured once: later frames must not re-read a width that has moved.
+    pointer(window, "pointermove", 300);
+    expect(onSizingChange).toHaveBeenLastCalledWith({ status: 400, owner: 120 });
+  });
+
+  it("ends the gesture when the window loses focus mid-drag", () => {
+    const { onSizingChange, handle } = setup();
+
+    pointer(handle, "pointerdown", 100);
+    pointer(window, "pointermove", 110);
+    expect(onSizingChange).toHaveBeenLastCalledWith({ status: 210, owner: 120 });
+
+    // Switching apps or releasing outside the window never delivers pointerup.
+    act(() => {
+      window.dispatchEvent(new Event("blur"));
+    });
+    pointer(window, "pointermove", 400);
+
+    expect(onSizingChange).toHaveBeenLastCalledWith({ status: 210, owner: 120 });
+  });
+
+  it("publishes column widths as custom properties the cells reference", () => {
+    setup();
+
+    const table = document.querySelector("table")!;
+    expect(table.style.getPropertyValue("--col-status-size")).toBe("150px");
+    expect(table.style.getPropertyValue("--col-owner-size")).toBe("90px");
+
+    // Cells must not carry a resolved number, or a resize would have to
+    // re-render each one to update it.
+    const cell = document.querySelector<HTMLElement>("tbody td")!;
+    expect(cell.style.width).toBe("var(--col-status-size)");
+  });
+
+  it("stops re-rendering body cells while a column is being dragged", () => {
+    const { handle } = setup();
+    const cellRenders = () =>
+      document.querySelectorAll('[data-slot="table-cell"]').length;
+
+    const before = cellRenders();
+    expect(before).toBeGreaterThan(0);
+
+    pointer(handle, "pointerdown", 100);
+    pointer(window, "pointermove", 200);
+
+    // The memoized body keeps the same cells mounted; only the <table>'s
+    // custom property changes, which the browser applies without React.
+    expect(cellRenders()).toBe(before);
+    expect(
+      document.querySelector("table")!.style.getPropertyValue("--col-status-size"),
+    ).toBe("300px");
+  });
+
+  it("shows the pinned column's edge shadow only once scrolled sideways", () => {
+    render(<ResizableTable onSizingChange={vi.fn()} pinFirstColumn />);
+
+    const pinnedHeader = document.querySelector<HTMLElement>(
+      'th[data-column-id="status"]',
+    )!;
+    const scroller = document.querySelector<HTMLElement>(".overflow-auto")!;
+
+    // At rest nothing passes under the frozen column, so the shadow would only
+    // read as a rule the other columns don't have.
+    expect(pinnedHeader.style.boxShadow).toBe("");
+
+    scroller.scrollLeft = 120;
+    act(() => {
+      scroller.dispatchEvent(new Event("scroll"));
+    });
+    expect(pinnedHeader.style.boxShadow).toContain("inset");
+
+    scroller.scrollLeft = 0;
+    act(() => {
+      scroller.dispatchEvent(new Event("scroll"));
+    });
+    expect(pinnedHeader.style.boxShadow).toBe("");
+  });
+
+  it("covers the viewport with a cursor layer only while dragging", () => {
+    const { handle } = setup();
+    const overlay = () =>
+      document.querySelector('[data-slot="data-table-resize-overlay"]');
+
+    expect(overlay()).toBeNull();
+
+    pointer(handle, "pointerdown", 100);
+    expect(overlay()).toHaveClass("cursor-col-resize");
+
+    pointer(window, "pointerup", 100);
+    expect(overlay()).toBeNull();
+  });
+});

--- a/packages/views/issues/components/data-table-resize.test.tsx
+++ b/packages/views/issues/components/data-table-resize.test.tsx
@@ -185,29 +185,58 @@ describe("DataTable column resize", () => {
     ).toBe("300px");
   });
 
-  it("shows the pinned column's edge shadow only once scrolled sideways", () => {
+  it("casts a shadow past the frozen columns only once scrolled sideways", () => {
     render(<ResizableTable onSizingChange={vi.fn()} pinFirstColumn />);
 
-    const pinnedHeader = document.querySelector<HTMLElement>(
-      'th[data-column-id="status"]',
-    )!;
     const scroller = document.querySelector<HTMLElement>(".overflow-auto")!;
+    const shadow = () =>
+      document.querySelector<HTMLElement>(
+        '[data-slot="data-table-pinned-shadow"]',
+      );
 
-    // At rest nothing passes under the frozen column, so the shadow would only
-    // read as a rule the other columns don't have.
-    expect(pinnedHeader.style.boxShadow).toBe("");
+    // The border between frozen and scrolling columns is permanent and says
+    // where the boundary is. The shadow says something is passing underneath
+    // right now, so at rest there is nothing for it to report.
+    expect(shadow()).toBeNull();
 
     scroller.scrollLeft = 120;
     act(() => {
       scroller.dispatchEvent(new Event("scroll"));
     });
-    expect(pinnedHeader.style.boxShadow).toContain("inset");
+    expect(shadow()).not.toBeNull();
 
     scroller.scrollLeft = 0;
     act(() => {
       scroller.dispatchEvent(new Event("scroll"));
     });
-    expect(pinnedHeader.style.boxShadow).toBe("");
+    expect(shadow()).toBeNull();
+  });
+
+  it("places the shadow at the frozen block's measured edge", () => {
+    render(<ResizableTable onSizingChange={vi.fn()} pinFirstColumn />);
+
+    const scroller = document.querySelector<HTMLElement>(".overflow-auto")!;
+    // Rendered widths diverge from configured ones under fixed table-layout,
+    // so the boundary is read off the DOM rather than summed from column
+    // sizes — summing put the shadow in the middle of visible content.
+    const edge = document.querySelector<HTMLElement>(
+      "thead th[data-pinned-edge]",
+    )!;
+    edge.getBoundingClientRect = () =>
+      ({ right: 240, left: 0, width: 240 }) as DOMRect;
+    scroller.getBoundingClientRect = () =>
+      ({ left: 40, right: 900, width: 860 }) as DOMRect;
+
+    scroller.scrollLeft = 120;
+    act(() => {
+      scroller.dispatchEvent(new Event("scroll"));
+    });
+
+    expect(
+      document.querySelector<HTMLElement>(
+        '[data-slot="data-table-pinned-shadow"]',
+      )!.style.left,
+    ).toBe("200px");
   });
 
   it("covers the viewport with a cursor layer only while dragging", () => {

--- a/packages/views/issues/components/data-table-resize.test.tsx
+++ b/packages/views/issues/components/data-table-resize.test.tsx
@@ -185,6 +185,47 @@ describe("DataTable column resize", () => {
     ).toBe("300px");
   });
 
+  it("sizes a column to its widest rendered cell on double-click", () => {
+    const { onSizingChange, handle } = setup();
+
+    // Fixed table-layout ignores content and the cells truncate their own
+    // text, so the measurement lifts both constraints before reading. Stand in
+    // for the layout jsdom will not perform.
+    for (const cell of document.querySelectorAll<HTMLElement>(
+      '[data-column-id="status"]',
+    )) {
+      cell.getBoundingClientRect = () =>
+        ({ width: cell.tagName === "TH" ? 96 : 268 }) as DOMRect;
+    }
+
+    act(() => {
+      handle.dispatchEvent(new MouseEvent("dblclick", { bubbles: true }));
+    });
+
+    // The widest cell wins, not the header and not the current width.
+    expect(onSizingChange).toHaveBeenCalledWith(
+      expect.objectContaining({ status: 268 }),
+    );
+  });
+
+  it("leaves the column alone when double-clicked with nothing rendered", () => {
+    const { onSizingChange, handle } = setup();
+
+    for (const cell of document.querySelectorAll<HTMLElement>(
+      '[data-column-id="status"]',
+    )) {
+      cell.getBoundingClientRect = () => ({ width: 0 }) as DOMRect;
+    }
+
+    act(() => {
+      handle.dispatchEvent(new MouseEvent("dblclick", { bubbles: true }));
+    });
+
+    // A zero measurement means the column was never laid out; committing it
+    // would collapse the column to its minimum for no reason.
+    expect(onSizingChange).not.toHaveBeenCalled();
+  });
+
   it("casts a shadow past the frozen columns only once scrolled sideways", () => {
     render(<ResizableTable onSizingChange={vi.fn()} pinFirstColumn />);
 

--- a/packages/views/issues/components/data-table-sticky.test.tsx
+++ b/packages/views/issues/components/data-table-sticky.test.tsx
@@ -29,6 +29,20 @@ function PinnedTable() {
 }
 
 describe("DataTable pinned columns", () => {
+  it("keeps the header strip off the compositor's blur path", () => {
+    render(<PinnedTable />);
+
+    const strip = document.querySelector("thead")!;
+    // A backdrop-filter on a sticky element with content scrolling beneath it
+    // recomputes its backdrop every frame while virtualisation churns the rows
+    // under it, and the strip flickers black (electron#12906). The mix resolves
+    // to the same colour bg-muted/30 composited to.
+    expect(strip).toHaveClass(
+      "bg-[color-mix(in_oklab,var(--muted)_30%,var(--background))]",
+    );
+    expect(strip).not.toHaveClass("backdrop-blur");
+  });
+
   it("uses opaque backgrounds so scrolled columns cannot show through", () => {
     render(<PinnedTable />);
 

--- a/packages/views/issues/components/data-table-sticky.test.tsx
+++ b/packages/views/issues/components/data-table-sticky.test.tsx
@@ -4,8 +4,27 @@ import {
   useReactTable,
   type ColumnDef,
 } from "@tanstack/react-table";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { DataTable } from "@multica/ui/components/ui/data-table";
+
+// jsdom has no layout, so the real virtualizer sees a zero-height viewport and
+// renders nothing. The stand-in keeps measureElement pointed at a spy, which is
+// the hook rows have to reach for their height to be corrected.
+const measured = vi.hoisted(() => [] as (HTMLElement | null)[]);
+vi.mock("@tanstack/react-virtual", () => ({
+  useVirtualizer: ({ count }: { count: number }) => ({
+    getVirtualItems: () =>
+      Array.from({ length: count }, (_, index) => ({
+        index,
+        key: index,
+        start: index * 41,
+        end: (index + 1) * 41,
+        size: 41,
+      })),
+    getTotalSize: () => count * 41,
+    measureElement: (element: HTMLElement | null) => measured.push(element),
+  }),
+}));
 
 type Row = {
   title: string;
@@ -28,7 +47,52 @@ function PinnedTable() {
   return <DataTable table={table} />;
 }
 
+function VirtualizedTable() {
+  const table = useReactTable({
+    data: [
+      { title: "First", status: "todo" },
+      { title: "Second", status: "done" },
+    ],
+    columns,
+    getCoreRowModel: getCoreRowModel(),
+  });
+
+  return (
+    <DataTable
+      table={table}
+      virtualizeRows
+      // Exercises both paths: a standard row and one the caller builds.
+      renderRow={(row) =>
+        row.index === 1 ? (
+          <tr data-slot="custom-row">
+            <td colSpan={2}>Group header</td>
+          </tr>
+        ) : null
+      }
+    />
+  );
+}
+
 describe("DataTable pinned columns", () => {
+  it("tags every virtualized row so it reports its own height", () => {
+    render(<VirtualizedTable />);
+
+    // Group headers and end-of-column footers are shorter than a data row, so
+    // one estimate for all of them drifts from the real layout as they
+    // accumulate. Both the standard rows and the ones renderRow builds have to
+    // carry data-index and the measuring ref for the virtualizer to correct it.
+    const rows = document.querySelectorAll("tbody tr[data-index]");
+    expect(rows.length).toBe(2);
+    expect([...rows].map((row) => row.getAttribute("data-index"))).toEqual([
+      "0",
+      "1",
+    ]);
+    expect(document.querySelector('tbody tr[data-slot="custom-row"]')).toHaveAttribute(
+      "data-index",
+    );
+    expect(measured.filter(Boolean).length).toBe(2);
+  });
+
   it("keeps the header strip off the compositor's blur path", () => {
     render(<PinnedTable />);
 

--- a/packages/views/issues/components/table-view-model.ts
+++ b/packages/views/issues/components/table-view-model.ts
@@ -34,12 +34,22 @@ export type IssueTableDisplayRow =
       hasChildren: boolean;
       collapsed: boolean;
     }
+  // Stands in for a row that has not arrived yet. Cold loads render these in
+  // the table's own grid rather than swapping the surface for a generic
+  // placeholder: columns, widths and the header are known before any data is,
+  // so only the rows need standing in for, and the layout does not shift when
+  // they are replaced.
+  | { kind: "skeleton"; key: string }
+  // Carries the state rather than a finished label: the row renders through
+  // ListLoadMoreFooter, the same footer Board / List / Swimlane use, which owns
+  // the wording and the styling for each state.
   | {
       kind: "load_more";
       key: string;
-      label: string;
-      loading: boolean;
-      autoLoad?: boolean;
+      state: "loading" | "has_more" | "error" | "end";
+      // Rows past this many mean the branch actually paginated, which is what
+      // decides whether reaching the end is worth marking.
+      total: number;
       onLoad?: () => void;
     };
 

--- a/packages/views/issues/components/table-view.tsx
+++ b/packages/views/issues/components/table-view.tsx
@@ -25,7 +25,6 @@ import {
   sortableKeyboardCoordinates,
   useSortable,
 } from "@dnd-kit/sortable";
-import { CSS } from "@dnd-kit/utilities";
 import {
   getCoreRowModel,
   useReactTable,
@@ -44,6 +43,7 @@ import {
   ChevronRight,
   Download,
   EyeOff,
+  GripVertical,
   Loader2,
   Pencil,
   Plus,
@@ -400,31 +400,44 @@ function SortableColumnHeader({
         nodeRef.current = node;
         setNodeRef(node);
       }}
-      style={{ transform: CSS.Transform.toString(transform), transition }}
-      // The whole header is the drag handle, so the wrapper spans the cell's
-      // own box — the negative margins undo the <th>'s padding and put it back
-      // inside. It renders exactly as before, but what travels is a
-      // header-sized block rather than the line of text in it, which is what
-      // lets going translucent be the entire drag state, as it is for a tab.
-      // The cursor carries the affordance: nothing else marks the header as
-      // draggable, and a grip that only appears on hover never did.
+      // Horizontal travel only. dnd-kit's layout animation also hands back
+      // scaleX/scaleY — old rect over new rect — to tween an item into the
+      // shape of the slot it landed in. Between two tabs of equal width that
+      // ratio is 1 and never shows; between two columns it is not, so a 174px
+      // column swapping with a 96px one gets stretched to 1.8x on the way.
+      // Reordering columns changes no column's width, so there is nothing for
+      // a shape tween to say here. The move and the settle stay animated
+      // through `transition`.
+      style={{
+        transform: transform ? `translate3d(${transform.x}px, 0, 0)` : undefined,
+        transition,
+      }}
+      // The wrapper spans the cell's own box — the negative margins undo the
+      // <th>'s padding and put it back inside — so it renders exactly as at
+      // rest while being what travels: a header-sized block rather than the
+      // line of text in it. Height is derived rather than fixed at h-8: the
+      // strip is taller than the cell's nominal height once row borders are in.
       className={cn(
-        "group/header -mx-4 -my-2 flex h-8 min-w-0 items-center px-4",
-        sortable && (isDragging ? "cursor-grabbing" : "cursor-grab"),
+        "group/header -mx-4 -my-2 flex h-[calc(100%+1rem)] min-w-0 items-center px-4",
         isDragging && "opacity-60",
       )}
-      aria-label={sortable ? reorderLabel : undefined}
-      {...(sortable ? attributes : {})}
-      {...(sortable ? listeners : {})}
     >
-      <DropdownMenu>
-        <DropdownMenuTrigger
-          // Kept out of the drag: a press here is only ever the sort/hide menu.
-          // The pointer sensor's 4px activation already lets a click through,
-          // but without this a drag begun on the label would move the column.
-          onPointerDown={(event) => event.stopPropagation()}
-          className="flex min-w-0 cursor-pointer items-center gap-1 rounded px-1.5 py-1 hover:bg-accent"
+      {sortable && (
+        <button
+          type="button"
+          aria-label={reorderLabel}
+          className={cn(
+            "-ml-2 mr-0.5 rounded p-0.5 text-muted-foreground/50 opacity-0 hover:bg-accent hover:text-muted-foreground group-hover/header:opacity-100 focus-visible:opacity-100",
+            isDragging ? "cursor-grabbing opacity-100" : "cursor-grab",
+          )}
+          {...attributes}
+          {...listeners}
         >
+          <GripVertical className="size-3" />
+        </button>
+      )}
+      <DropdownMenu>
+        <DropdownMenuTrigger className="flex min-w-0 items-center gap-1 rounded px-1.5 py-1 hover:bg-accent">
           <span className="truncate">{label}</span>
           {active &&
             (sortDirection === "asc" ? (

--- a/packages/views/issues/components/table-view.tsx
+++ b/packages/views/issues/components/table-view.tsx
@@ -675,7 +675,7 @@ export function InlineTitle({
 
   return (
     <div
-      className="flex min-w-0 items-center gap-1.5"
+      className="relative flex min-w-0 items-center gap-1.5"
       style={{ paddingLeft: row.depth * 18 }}
       // Record whether the gesture began while editing (mousedown fires before
       // the blur that commits), then swallow that click in the capture phase —
@@ -742,29 +742,43 @@ export function InlineTitle({
           >
             {row.issue.title}
           </button>
-          <button
-            type="button"
-            aria-label={createSubIssueLabel}
-            className="shrink-0 rounded p-1 text-muted-foreground/60 opacity-0 hover:bg-accent hover:text-foreground focus-visible:opacity-100 group-hover:opacity-100"
-            onClick={(event) => {
-              event.stopPropagation();
-              onCreateSubIssue();
-            }}
-          >
-            <Plus className="size-3" />
-          </button>
-          <button
-            type="button"
-            aria-label={renameLabel}
-            className="shrink-0 rounded p-1 text-muted-foreground/60 opacity-0 hover:bg-accent hover:text-foreground focus-visible:opacity-100 group-hover:opacity-100"
-            onClick={(event) => {
-              event.stopPropagation();
-              setDraft(row.issue.title);
-              onEditingChange(true);
-            }}
-          >
-            <Pencil className="size-3" />
-          </button>
+          {/* Lifted out of the flex flow, the way SidebarMenuAction is. Laid
+            * out inline these two reserved ~40px of the title column for
+            * buttons that are invisible until hovered — and title is the
+            * column with the least room to spare. The gradient fades the text
+            * running underneath rather than letting the icons sit on top of
+            * it; the sidebar has no need for one because its labels are short,
+            * but a title runs to the cell's edge. focus-within keeps them
+            * reachable by keyboard, where hover never fires. */}
+          {/* The fade has to be whatever the cell is painted with at the
+            * moment the actions show, and a hovered row is not the resting
+            * background — pinned cells switch to the muted mix on hover, so
+            * the gradient follows. */}
+          <span className="pointer-events-none absolute inset-y-0 right-0 flex items-center gap-0.5 bg-gradient-to-l from-background from-70% to-transparent pr-1 pl-8 opacity-0 transition-opacity group-hover:pointer-events-auto group-hover:from-[color-mix(in_oklab,var(--muted)_50%,var(--background))] group-hover:opacity-100 focus-within:pointer-events-auto focus-within:opacity-100">
+            <button
+              type="button"
+              aria-label={createSubIssueLabel}
+              className="rounded p-1 text-muted-foreground/60 hover:bg-accent hover:text-foreground"
+              onClick={(event) => {
+                event.stopPropagation();
+                onCreateSubIssue();
+              }}
+            >
+              <Plus className="size-3" />
+            </button>
+            <button
+              type="button"
+              aria-label={renameLabel}
+              className="rounded p-1 text-muted-foreground/60 hover:bg-accent hover:text-foreground"
+              onClick={(event) => {
+                event.stopPropagation();
+                setDraft(row.issue.title);
+                onEditingChange(true);
+              }}
+            >
+              <Pencil className="size-3" />
+            </button>
+          </span>
         </>
       )}
     </div>
@@ -2338,6 +2352,14 @@ export function TableView({
         // pointer up out of its own strip — same constraint the desktop tab bar
         // puts on tab reordering.
         modifiers={[restrictToHorizontalAxis]}
+        // Modifiers constrain the drag's movement but not its auto-scrolling,
+        // which reads raw pointer coordinates: drifting a few pixels vertically
+        // while dragging a header sent the rows scrolling underneath it. Zero
+        // on y removes an axis the gesture cannot act on. On x it stays, since
+        // a table wider than its viewport needs it to reach a distant slot, but
+        // the default 0.2 arms it a fifth of the way in from either edge, which
+        // is most of a wide header.
+        autoScroll={{ threshold: { x: 0.05, y: 0 } }}
         onDragEnd={handleDragEnd}
       >
         <SortableContext

--- a/packages/views/issues/components/table-view.tsx
+++ b/packages/views/issues/components/table-view.tsx
@@ -680,7 +680,7 @@ export function InlineTitle({
 
   return (
     <div
-      className="relative flex min-w-0 items-center gap-1.5"
+      className="group/title relative flex min-w-0 items-center gap-1.5"
       style={{ paddingLeft: row.depth * 18 }}
       // Record whether the gesture began while editing (mousedown fires before
       // the blur that commits), then swallow that click in the capture phase —
@@ -759,7 +759,12 @@ export function InlineTitle({
             * moment the actions show, and a hovered row is not the resting
             * background — pinned cells switch to the muted mix on hover, so
             * the gradient follows. */}
-          <span className="pointer-events-none absolute inset-y-0 right-0 flex items-center gap-0.5 bg-gradient-to-l from-background from-70% to-transparent pr-1 pl-8 opacity-0 transition-opacity group-hover:pointer-events-auto group-hover:from-[color-mix(in_oklab,var(--muted)_50%,var(--background))] group-hover:opacity-100 focus-within:pointer-events-auto focus-within:opacity-100">
+          {/* Keyed to the title cell, not the row: these act on the title,
+            * and offering them from anywhere along a row puts them under the
+            * pointer while it is somewhere else entirely. The fade still
+            * follows the row's hover colour, since that is what the cell is
+            * painted with when they appear. */}
+          <span className="pointer-events-none absolute inset-y-0 right-0 flex items-center gap-0.5 bg-gradient-to-l from-background from-70% to-transparent pr-1 pl-8 opacity-0 transition-opacity group-hover:from-[color-mix(in_oklab,var(--muted)_50%,var(--background))] group-hover/title:pointer-events-auto group-hover/title:opacity-100 focus-within:pointer-events-auto focus-within:opacity-100">
             <button
               type="button"
               aria-label={createSubIssueLabel}

--- a/packages/views/issues/components/table-view.tsx
+++ b/packages/views/issues/components/table-view.tsx
@@ -67,6 +67,7 @@ import {
   TableCell,
   TableRow,
 } from "@multica/ui/components/ui/table";
+import { Skeleton } from "@multica/ui/components/ui/skeleton";
 import { cn } from "@multica/ui/lib/utils";
 import { ApiError } from "@multica/core/api";
 import { useWorkspaceId } from "@multica/core/hooks";
@@ -137,8 +138,12 @@ import {
   type IssueTableDisplayRow,
 } from "./table-view-model";
 import type { ChildProgress } from "./list-row";
-import { InfiniteScrollSentinel } from "./infinite-scroll-sentinel";
+import { ListLoadMoreFooter } from "./list-load-more-footer";
 import { IssueAgentActivityIndicator } from "./issue-agent-activity-indicator";
+
+// Enough placeholder rows to cover a typical viewport; the virtualizer only
+// mounts what fits, so overshooting costs nothing.
+const SKELETON_ROW_COUNT = 12;
 
 const SELECT_COLUMN_ID = "__select";
 const ADD_COLUMN_ID = "__add";
@@ -1072,6 +1077,12 @@ function IssueTableBodyCell({
     meta.editingCellKey,
     meta.setEditingCellKey,
   );
+  // Placeholder rows go through the ordinary cell renderer so they inherit the
+  // real column widths, pinning and borders — the grid is already correct
+  // before any data arrives, so the rows swap in without shifting anything.
+  if (row.original.kind === "skeleton") {
+    return <Skeleton className="h-3.5 w-full" />;
+  }
   if (row.original.kind !== "issue") return null;
   const issueRow = row.original;
   const issue = issueRow.issue;
@@ -1772,9 +1783,8 @@ export function TableView({
         result.push({
           kind: "load_more",
           key: `${registered ? "loading" : "activate"}:${key}`,
-          label: t(($) => $.table.loading_branch),
-          loading: registered,
-          autoLoad: !registered,
+          state: registered ? "loading" : "has_more",
+          total: 0,
           onLoad: registered
             ? undefined
             : () => activateServerBranch(groupKey, parentId, ancestorIds),
@@ -1785,8 +1795,8 @@ export function TableView({
         result.push({
           kind: "load_more",
           key: `loading:${key}`,
-          label: t(($) => $.table.loading_branch),
-          loading: true,
+          state: "loading",
+          total: 0,
         });
       }
       for (const row of data.rows) {
@@ -1815,8 +1825,8 @@ export function TableView({
         result.push({
           kind: "load_more",
           key: `retry:${key}`,
-          label: t(($) => $.table.load_more_failed_retry),
-          loading: false,
+          state: "error",
+          total: data.total,
           onLoad: () => retryServerBranch(key),
         });
       } else if (data.nextCursor) {
@@ -1824,10 +1834,19 @@ export function TableView({
         result.push({
           kind: "load_more",
           key: `more:${key}:${nextCursor}`,
-          label: t(($) => $.table.load_more),
-          loading: data.loading,
-          autoLoad: true,
+          state: data.loading ? "loading" : "has_more",
+          total: data.total,
           onLoad: () => loadNextServerBranchPage(key, nextCursor),
+        });
+      } else if (data.rows.length > 0) {
+        // Reaching the end is only worth marking on a branch that paginated;
+        // the footer applies that rule, so the row is pushed unconditionally
+        // and carries the total for it to judge by.
+        result.push({
+          kind: "load_more",
+          key: `end:${key}`,
+          state: "end",
+          total: data.total,
         });
       }
     };
@@ -1855,27 +1874,40 @@ export function TableView({
       result.push({
         kind: "load_more",
         key: "loading:groups",
-        label: t(($) => $.table.loading_branch),
-        loading: true,
+        state: "loading",
+        total: 0,
       });
     } else if (usesServerGrouping && serverGroupsError) {
       result.push({
         kind: "load_more",
         key: "retry:groups",
-        label: t(($) => $.table.load_failed_retry),
-        loading: false,
+        state: "error",
+        total: 0,
         onLoad: () => void refetchServerGroups(),
       });
     } else if (usesServerGrouping && hasNextServerGroupPage) {
       result.push({
         kind: "load_more",
         key: "more:groups",
-        label: t(($) => $.table.load_more),
-        loading: fetchingNextServerGroupPage,
-        autoLoad: true,
+        state: fetchingNextServerGroupPage ? "loading" : "has_more",
+        total: 0,
         onLoad: () => void fetchNextServerGroupPage(),
       });
     }
+
+    // Nothing has landed yet and something is still in flight: show the grid
+    // filled with placeholders instead of one "Loading…" line, which reads as
+    // an empty table more than a loading one.
+    const isColdLoad =
+      !result.some((row) => row.kind === "issue") &&
+      result.some((row) => row.kind === "load_more" && row.state === "loading");
+    if (isColdLoad) {
+      return Array.from({ length: SKELETON_ROW_COUNT }, (_, index) => ({
+        kind: "skeleton" as const,
+        key: `skeleton:${index}`,
+      }));
+    }
+
     return result;
   }, [
     collapsedGroupSet,
@@ -2391,32 +2423,27 @@ export function TableView({
                   <TableRow className="hover:bg-transparent">
                     <TableCell
                       colSpan={table.getVisibleLeafColumns().length}
-                      className="relative h-9 px-4 py-1"
+                      className="p-0"
                     >
-                      {loadMoreRow.autoLoad &&
-                        loadMoreRow.onLoad &&
-                        !loadMoreRow.loading && (
-                        <InfiniteScrollSentinel
-                          onVisible={loadMoreRow.onLoad}
-                          loading={false}
-                          rootMargin="240px"
-                          className="absolute inset-y-0 left-0 w-px"
+                      {/* The same footer Board / List / Swimlane end their
+                        * columns with. Hand-rolling it here had left the table
+                        * as the one surface where a failed page read as muted
+                        * body text rather than an error, and where reaching the
+                        * end of a paginated branch said nothing at all. The row
+                        * only supplies the cell it lives in. */}
+                      <div className="sticky left-0 w-full">
+                        <ListLoadMoreFooter
+                          hasMore={
+                            loadMoreRow.state === "loading" ||
+                            loadMoreRow.state === "has_more"
+                          }
+                          isLoading={loadMoreRow.state === "loading"}
+                          total={loadMoreRow.total}
+                          onLoadMore={() => loadMoreRow.onLoad?.()}
+                          isError={loadMoreRow.state === "error"}
+                          onRetry={loadMoreRow.onLoad}
                         />
-                      )}
-                      <button
-                        type="button"
-                        disabled={loadMoreRow.loading || !loadMoreRow.onLoad}
-                        onClick={(event) => {
-                          event.stopPropagation();
-                          loadMoreRow.onLoad?.();
-                        }}
-                        className="sticky left-4 flex items-center gap-2 text-xs text-muted-foreground enabled:hover:text-foreground disabled:cursor-default"
-                      >
-                        {loadMoreRow.loading && (
-                          <Loader2 className="size-3.5 animate-spin" />
-                        )}
-                        {loadMoreRow.label}
-                      </button>
+                      </div>
                     </TableCell>
                   </TableRow>
                 );

--- a/packages/views/issues/components/table-view.tsx
+++ b/packages/views/issues/components/table-view.tsx
@@ -3,6 +3,7 @@
 import {
   useCallback,
   useEffect,
+  useLayoutEffect,
   useMemo,
   useRef,
   useState,
@@ -12,10 +13,12 @@ import {
   KeyboardSensor,
   PointerSensor,
   closestCenter,
+  useDndContext,
   useSensor,
   useSensors,
   type DragEndEvent,
 } from "@dnd-kit/core";
+import { restrictToHorizontalAxis } from "@dnd-kit/modifiers";
 import {
   SortableContext,
   horizontalListSortingStrategy,
@@ -41,7 +44,6 @@ import {
   ChevronRight,
   Download,
   EyeOff,
-  GripVertical,
   Loader2,
   Pencil,
   Plus,
@@ -366,30 +368,62 @@ function SortableColumnHeader({
   const { attributes, listeners, setNodeRef, transform, transition, isDragging } =
     useSortable({ id: columnKey, disabled: !sortable });
   const active = sortField === sortBy;
+  // Any column in flight, not only this one: the neighbours shift to open a
+  // gap, and each is clipped by its own cell just the same.
+  const isReordering = useDndContext().active != null;
+  const nodeRef = useRef<HTMLDivElement | null>(null);
+
+  // The cell clips its own content, which is what made a dragged column look
+  // like it vanished rather than travelled. The clip only earns its keep at
+  // rest, capping a label wider than its column, so it is lifted for the length
+  // of a reorder and the column in hand is raised over its neighbours.
+  //
+  // Only overflow and stacking are touched. Transforming the <th> itself would
+  // carry the header's full height along, but `transform` on a table cell is a
+  // corner of the spec browsers take liberties with — Chromium lifts the cell
+  // out of the table's box model and its geometry stops matching the row. The
+  // wrapper below is padded out to the cell's size instead.
+  useLayoutEffect(() => {
+    const cell = nodeRef.current?.closest("th");
+    if (!cell || !isReordering) return;
+    cell.style.overflow = "visible";
+    if (isDragging) cell.style.zIndex = "20";
+    return () => {
+      cell.style.removeProperty("overflow");
+      cell.style.removeProperty("z-index");
+    };
+  }, [isDragging, isReordering]);
 
   return (
     <div
-      ref={setNodeRef}
+      ref={(node) => {
+        nodeRef.current = node;
+        setNodeRef(node);
+      }}
       style={{ transform: CSS.Transform.toString(transform), transition }}
+      // The whole header is the drag handle, so the wrapper spans the cell's
+      // own box — the negative margins undo the <th>'s padding and put it back
+      // inside. It renders exactly as before, but what travels is a
+      // header-sized block rather than the line of text in it, which is what
+      // lets going translucent be the entire drag state, as it is for a tab.
+      // The cursor carries the affordance: nothing else marks the header as
+      // draggable, and a grip that only appears on hover never did.
       className={cn(
-        "group/header flex min-w-0 items-center",
-        isDragging && "opacity-40",
+        "group/header -mx-4 -my-2 flex h-8 min-w-0 items-center px-4",
+        sortable && (isDragging ? "cursor-grabbing" : "cursor-grab"),
+        isDragging && "opacity-60",
       )}
+      aria-label={sortable ? reorderLabel : undefined}
+      {...(sortable ? attributes : {})}
+      {...(sortable ? listeners : {})}
     >
-      {sortable && (
-        <button
-          type="button"
-          aria-label={reorderLabel}
-          className="-ml-2 mr-0.5 rounded p-0.5 text-muted-foreground/50 opacity-0 hover:bg-accent hover:text-muted-foreground group-hover/header:opacity-100 focus-visible:opacity-100"
-          {...attributes}
-          {...listeners}
-        >
-          <GripVertical className="size-3" />
-        </button>
-      )}
       <DropdownMenu>
         <DropdownMenuTrigger
-          className="flex min-w-0 items-center gap-1 rounded px-1.5 py-1 hover:bg-accent"
+          // Kept out of the drag: a press here is only ever the sort/hide menu.
+          // The pointer sensor's 4px activation already lets a click through,
+          // but without this a drag begun on the label would move the column.
+          onPointerDown={(event) => event.stopPropagation()}
+          className="flex min-w-0 cursor-pointer items-center gap-1 rounded px-1.5 py-1 hover:bg-accent"
         >
           <span className="truncate">{label}</span>
           {active &&
@@ -2287,6 +2321,10 @@ export function TableView({
       <DndContext
         sensors={sensors}
         collisionDetection={closestCenter}
+        // Columns only ever swap sideways, so the header should not follow the
+        // pointer up out of its own strip — same constraint the desktop tab bar
+        // puts on tab reordering.
+        modifiers={[restrictToHorizontalAxis]}
         onDragEnd={handleDragEnd}
       >
         <SortableContext

--- a/packages/views/issues/components/table-view.tsx
+++ b/packages/views/issues/components/table-view.tsx
@@ -845,7 +845,11 @@ function LazyLabelCell({
   );
 }
 
-type IssueTableGroupRowProps = {
+// Extends the <tr> props so the virtualizer's measuring ref and data-index,
+// which DataTable clones onto whatever renderRow returns, reach the element
+// instead of being absorbed here. A group header is shorter than a data row,
+// so it is exactly the kind of row the measurement exists for.
+type IssueTableGroupRowProps = React.ComponentProps<"tr"> & {
   group: Extract<IssueTableDisplayRow, { kind: "group" }>;
   colSpan: number;
   onToggle: () => void;
@@ -855,9 +859,11 @@ export function IssueTableGroupRow({
   group,
   colSpan,
   onToggle,
+  ...rowProps
 }: IssueTableGroupRowProps) {
   return (
     <TableRow
+      {...rowProps}
       className="bg-muted/40 hover:bg-muted/60"
       onClick={onToggle}
     >
@@ -1930,7 +1936,6 @@ export function TableView({
     fetchingNextServerGroupPage,
     refetchServerGroups,
     fetchNextServerGroupPage,
-    t,
     tableHierarchy,
     usesServerGrouping,
   ]);

--- a/packages/views/issues/surface/issue-surface.test.tsx
+++ b/packages/views/issues/surface/issue-surface.test.tsx
@@ -430,6 +430,33 @@ describe("IssueSurface — table pagination ownership", () => {
       listSquads: vi.fn(() => Promise.resolve([])),
     } as unknown as ApiClient);
 
+    // Continuation is driven by the shared footer's sentinel, the same one
+    // Board / List / Swimlane use — there is no manual button to press, so the
+    // observer has to actually report the footer as visible.
+    vi.stubGlobal(
+      "IntersectionObserver",
+      class {
+        private readonly callback: IntersectionObserverCallback;
+        constructor(callback: IntersectionObserverCallback) {
+          this.callback = callback;
+        }
+        observe(target: Element) {
+          this.callback(
+            [{ isIntersecting: true, target } as IntersectionObserverEntry],
+            this as unknown as IntersectionObserver,
+          );
+        }
+        unobserve() {}
+        disconnect() {}
+        takeRecords() {
+          return [];
+        }
+        root = null;
+        rootMargin = "0px";
+        thresholds = [0];
+      },
+    );
+
     render(
       <QueryClientProvider client={qc}>
         <IssueSurface
@@ -442,12 +469,6 @@ describe("IssueSurface — table pagination ownership", () => {
     );
 
     await screen.findByText("First cursor row");
-    const loadMoreButton = document.querySelector<HTMLButtonElement>(
-      "tbody button.sticky",
-    );
-    expect(loadMoreButton).not.toBeNull();
-    fireEvent.click(loadMoreButton!);
-
     await screen.findByText("Second cursor row");
     expect(listIssueTableRows).toHaveBeenCalledWith(
       expect.objectContaining({ page: { limit: 50, cursor: "cursor-2" } }),

--- a/packages/views/issues/surface/issue-surface.tsx
+++ b/packages/views/issues/surface/issue-surface.tsx
@@ -327,19 +327,16 @@ function IssueSurfaceContent({
   );
 }
 
+// Table is deliberately absent. It owns its own placeholders, drawn as rows
+// inside its real grid so the header, column widths and toolbar are up before
+// any data is — a surface-level stand-in would replace all of that with bars
+// of a different shape and then jump when the rows arrived.
 function IssueSurfaceSkeleton({ mode }: { mode: string }) {
-  if (mode === "list" || mode === "table") {
+  if (mode === "list") {
     return (
       <div className="flex min-h-0 flex-1 flex-col gap-1 overflow-y-auto p-2">
-        {mode === "table" && <Skeleton className="mb-1 h-8 w-full" />}
-        {Array.from({ length: mode === "table" ? 8 : 4 }).map((_, i) => (
-          <Skeleton
-            key={i}
-            className={cn(
-              "w-full",
-              mode === "table" ? "h-9 rounded-sm" : "h-10 rounded-lg",
-            )}
-          />
+        {Array.from({ length: 4 }).map((_, i) => (
+          <Skeleton key={i} className="h-10 w-full rounded-lg" />
         ))}
       </div>
     );

--- a/packages/views/package.json
+++ b/packages/views/package.json
@@ -58,6 +58,7 @@
   "dependencies": {
     "@base-ui/react": "^1.3.0",
     "@dnd-kit/core": "^6.3.1",
+    "@dnd-kit/modifiers": "^9.0.0",
     "@dnd-kit/sortable": "^10.0.0",
     "@dnd-kit/utilities": "^3.2.2",
     "@floating-ui/dom": "^1.7.6",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -968,6 +968,9 @@ importers:
       '@dnd-kit/core':
         specifier: ^6.3.1
         version: 6.3.1(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@dnd-kit/modifiers':
+        specifier: ^9.0.0
+        version: 9.0.0(@dnd-kit/core@6.3.1(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)
       '@dnd-kit/sortable':
         specifier: ^10.0.0
         version: 10.0.0(@dnd-kit/core@6.3.1(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)


### PR DESCRIPTION
## Summary

A pass over the issue Table view, working from a symptom list rather than a feature: column resizing, column reordering, the frozen-column boundary, the loading and end-of-page states, and two rendering faults that showed up while testing the rest. Row reordering inside the Table is deliberately out of scope — the Table has never supported it, and whether it should is a product call.

## Resizing a column

Pressing the handle committed a width before any drag started, and it wrote the *rendered* width — which fixed table-layout stretches past the configured one — so a stray click on a column edge silently rewrote and persisted that column and stopped it adapting to the window. Dragging then ran ahead of the pointer, because committing one width changes how much leftover space the layout shares out and rescales every other column mid-gesture. The gesture also never ended if the pointer came up outside the window or the user switched apps: the column kept tracking the pointer on return, with the page stuck unselectable under a `col-resize` cursor.

- 4px of travel is required before anything commits, matching the reorder sensor's activation distance on the same header.
- Every column pins to its rendered width on the frame the drag starts, so there is no leftover to redistribute and the drag maps 1:1.
- The pointer is captured and the gesture ends on `blur` / `pointercancel` / `lostpointercapture` — the four-part contract `SidebarMenuAction`'s rail already uses.
- The cursor is owned by a portaled full-viewport layer for the drag's duration; `document.body.style.cursor` loses to any descendant that declares its own.

Resizing also re-rendered every cell each frame, and each cell carries a popover, so a frame cost ~143ms against a 16ms budget. Widths travel as custom properties published once on the `<table>` and the body is swapped for a memoized copy while a drag is live — TanStack's [documented approach](https://tanstack.com/table/v8/docs/framework/react/examples/column-resizing-performant). Column ids can hold characters invalid in a CSS ident (`property:<uuid>`), so they are folded first.

Double-click on the handle called `column.resetSize`, which cleared the stored width and let TanStack fall back to its generic 150 — unrelated to any width this table was designed with, so "reset" widened `priority` from 130 and collapsed `labels` from 220. It sizes the column to its content now, the gesture's convention everywhere else. Fixed table-layout ignores content and cells truncate their own text, so the measurement lifts both constraints, reads, and restores within one task; the browser paints once, after the restore.

## Reordering a column

The affordance was a grip that only appeared once the pointer was already on the header, and dragging it moved a wrapper the height of its own line of text while the `<th>` clipped anything travelling outside the cell — so the column being moved looked like it had vanished rather than slid.

The wrapper now spans the cell's box at all times, so what travels is a header-sized block and going translucent is the entire drag state, as it is for a desktop tab. Overflow is lifted for the drag and the column in hand is raised over its neighbours.

Only the horizontal translation is applied. dnd-kit's layout animation also returns scaleX/scaleY — old rect over new rect — to tween an item into the shape of the slot it lands in; between two tabs of equal width that ratio is 1 and never shows, between a 174px column and a 96px one it stretched the header to 1.8x on the way across. Reordering changes no column's width, so there is no shape for a tween to describe.

Columns are restricted to the horizontal axis, as the desktop tab bar restricts tabs — hence `@dnd-kit/modifiers` in `packages/views`. Modifiers constrain movement but not auto-scrolling, which reads raw pointer coordinates, so vertical drift used to send the rows scrolling under a gesture that cannot act on them; auto-scroll's y threshold is zero now, and x is 0.05 rather than the default 0.2 that arms it a fifth of the way in from either edge.

## The frozen-column boundary

The edge where the frozen columns end had a shadow drawn inside the pinned cell with `--border`, a token tuned for hairlines between adjacent surfaces (oklch .945 in light mode) that all but disappears once spread into a shadow. Darkening it in place only outlined the frozen column: an inset shadow can shade that cell's own edge and nothing else, while the depth belongs to the content passing beneath.

Split into what MUI X's data grid separates — a permanent border for where the boundary is, and a shadow for something crossing it right now. The shadow is cast past the frozen block, mounted outside the scroll container, and shown only while scrolled sideways. Its position is measured off the DOM rather than summed from column sizes, since fixed table-layout stretches columns past their configured widths and a sum lands the marker mid-content.

The table also had no column rules at all, which left that shadow as the only vertical line and made it read as a stray border on one column. Every column carries a rule now.

## Loading and end-of-page

A cold load rendered a single "Loading…" line under a full header, which reads as an empty table rather than a loading one. The surface-level skeleton meant for it was unreachable — `use-issue-surface-data` hardcodes `isLoading` to false for table — and would not have fitted anyway, drawing rounded bars at `p-2` where the table draws an edge-to-edge grid. Placeholders are rows now, rendered through the ordinary cell renderer so they inherit the real column widths, pinning and borders; the header, toolbar and column layout are up immediately and the rows swap in without moving anything.

The end of a column was hand-rolled too, leaving the Table the one surface where a failed page read as muted body text rather than an error, where the prompt sat left-aligned against three centred ones, and where reaching the end of a paginated branch said nothing at all. Those rows carry their state rather than a finished label and render through `ListLoadMoreFooter`, which exists — per its own comment — so those states and their wording stay consistent across Board, List and Swimlane.

## Two rendering faults

The sticky header carried `backdrop-blur` over a translucent fill. A backdrop-filter on a sticky element with content scrolling beneath it is a known Chromium compositing fault: the blur layer recomputes its backdrop every frame while virtualisation adds and removes the very rows it reads from, and the strip flickers black under fast scrolling (electron#12906, electron#45854, chromium#339841685 — Chromium's fix for the same symptom was reverted, so upgrading does not carry it). The fill is now the opaque colour `bg-muted/30` was compositing to.

Virtualisation sized every row at one 41px estimate, but group headers are 37px, an end-of-column footer shorter still, and placeholders different again; the error accumulates until the rendered window drifts off the rows it should be showing and the scrollbar overshoots the bottom. Rows report their own height now, and rows built by `renderRow` are cloned to carry `data-index` and the measuring ref so callers keep returning a plain `<tr>`.

## Title column

The sub-issue and rename buttons sat inline at opacity 0, reserving ~40px of the column with the least room to spare for controls that only appear on hover. They are positioned over the cell's trailing edge now, the way `SidebarMenuAction` is, with a gradient fading the title underneath, and they key off the title cell's hover rather than the row's.

## Relationship to the reverted PRs

#5824 and #5779 both touched this area and were reverted together with no stated reason. Neither is revived here: nothing in this branch touches `base.css`, the sidebar, the chat resize, or the panel handles.

## Validation

- 496 tests across `packages/views/issues`, including 12 new cases in `data-table-resize.test.tsx` covering click-without-drag, sub-threshold travel, 1:1 tracking, the freeze baseline, blur mid-drag, the cursor layer, the custom properties, the memoized body, auto-fit, and the scroll-gated shadow.
- `data-table-sticky.test.tsx` covers the opaque header strip and that both standard and caller-built rows are tagged for measurement.
- `tsc --noEmit` and `eslint` clean for `packages/ui` and `packages/views`.
- Manually verified in the desktop app against staging.

## Known gaps

- Sorting from a Table column header still turns off manual drag-ordering on List and Board, and the column menu offers no way back. Linear scopes ordering per view, which is the shape that removes the problem; that is a product decision, not part of this branch.
- Row reordering inside the Table is unimplemented, as it always has been.

🤖 Generated with [Claude Code](https://claude.com/claude-code)