### PR TITLE
refactor(agent): share the ACP deliverable boundary across backends (MUL-5405)

### DIFF
--- a/server/pkg/agent/acp_deliverable.go
+++ b/server/pkg/agent/acp_deliverable.go
@@ -1,0 +1,81 @@
+package agent
+
+import (
+	"strings"
+	"sync"
+)
+
+// acpDeliverableTracker splits an ACP agent's text stream into the two strings
+// a finished turn needs, because they are not the same string.
+//
+//   - Result.Output is "the final user-facing output selected by the backend"
+//     (agent.go). It reaches channel replies and synthesized issue comments, so
+//     it must hold the deliverable only — not the narration an agent emits
+//     between tool calls (GH #6006).
+//   - promoteACPResultOnProviderError needs the COMPLETE text, because the
+//     synthetic "API call failed after N retries..." turn an adapter injects on
+//     give-up can land before a tool boundary and would otherwise be invisible
+//     to terminal-error detection.
+//
+// ACP gives no explicit final-answer marker the way Codex's app-server does
+// (see codexDeliverableOutput), so the boundary is the ordered stream itself:
+// consecutive MessageText chunks form the current block and a MessageToolUse
+// starts a new one. That is a heuristic — replace it with an explicit marker if
+// one of these protocols ever exposes a `phase: final_answer` equivalent.
+//
+// A turn whose last event is a tool call is common rather than exotic: an agent
+// told to deliver its result through a CLI ends on that tool call, and whether
+// it adds a closing sentence afterwards is up to the model. Such a turn has an
+// empty trailing block, so the tracker falls back to the most recent non-empty
+// one — matching codexDeliverableOutput's fallback to the latest agent message.
+// Without that fallback the reply silently arrives empty, since the daemon
+// treats an empty Output as a valid tool-only completion.
+//
+// The zero value is ready to use. All methods are safe for concurrent use: the
+// streaming callback and the goroutine that assembles Result run separately.
+type acpDeliverableTracker struct {
+	mu sync.Mutex
+	// complete is every text chunk of the turn, for provider-error detection.
+	complete strings.Builder
+	// block is the text since the most recent tool call — the deliverable
+	// unless the turn ended on a tool call.
+	block strings.Builder
+	// lastBlock is the most recent non-blank completed block, used as the
+	// fallback for a tool-terminated turn.
+	lastBlock string
+}
+
+// observe folds one streamed message into the tracker. Non-text, non-tool-use
+// messages (thinking, tool results, status) are ignored: they never belong to
+// the deliverable and never end a text block.
+func (t *acpDeliverableTracker) observe(msg Message) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	switch msg.Type {
+	case MessageText:
+		t.complete.WriteString(msg.Content)
+		t.block.WriteString(msg.Content)
+	case MessageToolUse:
+		// Keep the block only if it carried real text; a blank one must not
+		// shadow a genuine earlier answer.
+		if block := t.block.String(); strings.TrimSpace(block) != "" {
+			t.lastBlock = block
+		}
+		t.block.Reset()
+	}
+}
+
+// result returns the deliverable for Result.Output and the complete text for
+// promoteACPResultOnProviderError. Both are sampled under a single lock so they
+// cannot disagree about where the stream ended.
+func (t *acpDeliverableTracker) result() (deliverable, complete string) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	deliverable = t.block.String()
+	if strings.TrimSpace(deliverable) == "" {
+		deliverable = t.lastBlock
+	}
+	return deliverable, t.complete.String()
+}

--- a/server/pkg/agent/acp_deliverable_backends_test.go
+++ b/server/pkg/agent/acp_deliverable_backends_test.go
@@ -1,0 +1,177 @@
+package agent
+
+import (
+	"context"
+	"log/slog"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// acpDeliverableProviders are the backends wired to acpDeliverableTracker. They
+// all drive hermesClient over the same ACP stream, so one fixture pins all of
+// them and a backend that forgets to wire the tracker fails here rather than in
+// production.
+var acpDeliverableProviders = []string{"hermes", "kimi", "kiro", "traecli", "grok", "qoder"}
+
+// fakeACPDeliverableScript impersonates any of the ACP CLIs above. The
+// handshake is the union of what they need — grok is the only one that requires
+// an advertised auth method and an explicit `authenticate`, and the others
+// never send it — and the turn shape is switched by env vars:
+//
+//	ACP_NARRATION       text emitted before the tool call
+//	ACP_TOOL_TERMINATED turn ends on the tool call, with no text after it
+//	ACP_DEFERRED_TOOL   tool_call frame carries no parameters, so hermesClient
+//	                    defers MessageToolUse to the completed tool_call_update
+func fakeACPDeliverableScript() string {
+	return `#!/bin/sh
+while IFS= read -r line; do
+  id=$(printf '%s' "$line" | sed -n 's/.*"id":\([0-9]*\).*/\1/p')
+  case "$line" in
+    *'"method":"initialize"'*)
+      printf '{"jsonrpc":"2.0","id":%s,"result":{"protocolVersion":1,"authMethods":[{"id":"cached_token","name":"Cached login"}],"agentCapabilities":{"loadSession":true}}}\n' "$id"
+      ;;
+    *'"method":"authenticate"'*)
+      printf '{"jsonrpc":"2.0","id":%s,"result":{}}\n' "$id"
+      ;;
+    *'"method":"session/new"'*)
+      printf '{"jsonrpc":"2.0","id":%s,"result":{"sessionId":"ses_deliverable"}}\n' "$id"
+      ;;
+    *'"method":"session/prompt"'*)
+      printf '{"jsonrpc":"2.0","method":"session/update","params":{"sessionId":"ses_deliverable","update":{"sessionUpdate":"agent_thought_chunk","content":{"type":"text","text":"thinking about it"}}}}\n'
+      printf '{"jsonrpc":"2.0","method":"session/update","params":{"sessionId":"ses_deliverable","update":{"sessionUpdate":"agent_message_chunk","content":{"type":"text","text":"%s"}}}}\n' "$ACP_NARRATION"
+      if [ "$ACP_DEFERRED_TOOL" = "1" ]; then
+        printf '{"jsonrpc":"2.0","method":"session/update","params":{"sessionId":"ses_deliverable","update":{"sessionUpdate":"tool_call","toolCallId":"tc-1","name":"read_file","status":"pending"}}}\n'
+      else
+        printf '{"jsonrpc":"2.0","method":"session/update","params":{"sessionId":"ses_deliverable","update":{"sessionUpdate":"tool_call","toolCallId":"tc-1","name":"read_file","status":"pending","parameters":{"path":"diagram.svg"}}}}\n'
+      fi
+      printf '{"jsonrpc":"2.0","method":"session/update","params":{"sessionId":"ses_deliverable","update":{"sessionUpdate":"tool_call_update","toolCallId":"tc-1","name":"read_file","status":"completed","output":"<svg />"}}}\n'
+      if [ "$ACP_TOOL_TERMINATED" != "1" ]; then
+        printf '{"jsonrpc":"2.0","method":"session/update","params":{"sessionId":"ses_deliverable","update":{"sessionUpdate":"agent_message_chunk","content":{"type":"text","text":"The diagram shows "}}}}\n'
+        printf '{"jsonrpc":"2.0","method":"session/update","params":{"sessionId":"ses_deliverable","update":{"sessionUpdate":"agent_message_chunk","content":{"type":"text","text":"the service architecture."}}}}\n'
+      fi
+      printf '{"jsonrpc":"2.0","id":%s,"result":{"stopReason":"end_turn"}}\n' "$id"
+      exit 0
+      ;;
+  esac
+done
+`
+}
+
+// runFakeACPTurn executes one turn against the fixture above and returns the
+// result together with the text chunks that reached the transcript.
+func runFakeACPTurn(t *testing.T, provider string, env map[string]string) (Result, []string) {
+	t.Helper()
+
+	fakePath := filepath.Join(t.TempDir(), provider)
+	writeTestExecutable(t, fakePath, []byte(fakeACPDeliverableScript()))
+
+	backend, err := New(provider, Config{
+		ExecutablePath: fakePath,
+		Logger:         slog.Default(),
+		Env:            env,
+	})
+	if err != nil {
+		t.Fatalf("new %s backend: %v", provider, err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+	defer cancel()
+
+	session, err := backend.Execute(ctx, "inspect this attachment", ExecOptions{Timeout: 30 * time.Second})
+	if err != nil {
+		t.Fatalf("execute %s: %v", provider, err)
+	}
+
+	var streamed []string
+	messagesDone := make(chan struct{})
+	go func() {
+		defer close(messagesDone)
+		for msg := range session.Messages {
+			if msg.Type == MessageText {
+				streamed = append(streamed, msg.Content)
+			}
+		}
+	}()
+
+	select {
+	case result, ok := <-session.Result:
+		if !ok {
+			t.Fatalf("%s: result channel closed without a value", provider)
+		}
+		<-messagesDone
+		return result, streamed
+	case <-time.After(20 * time.Second):
+		t.Fatalf("%s: timeout waiting for result", provider)
+		return Result{}, nil
+	}
+}
+
+// Interim narration belongs to the transcript, not to Result.Output — the
+// contract Result.Output documents in agent.go (GH #6006).
+func TestACPBackendsDeliverFinalAnswerOnly(t *testing.T) {
+	t.Parallel()
+
+	const narration = "I will inspect the attachment."
+	const want = "The diagram shows the service architecture."
+
+	for _, provider := range acpDeliverableProviders {
+		for _, tool := range []struct {
+			name string
+			env  map[string]string
+		}{
+			// hermesClient emits MessageToolUse at tool start when the frame
+			// carries rawInput, and defers it to completion when it does not.
+			// Both orderings must put the boundary before the final answer.
+			{name: "tool use emitted at start", env: map[string]string{"ACP_NARRATION": narration}},
+			{name: "tool use deferred until completion", env: map[string]string{"ACP_NARRATION": narration, "ACP_DEFERRED_TOOL": "1"}},
+		} {
+			t.Run(provider+"/"+tool.name, func(t *testing.T) {
+				t.Parallel()
+
+				result, streamed := runFakeACPTurn(t, provider, tool.env)
+
+				if result.Status != "completed" {
+					t.Fatalf("status = %q, want completed (error=%q)", result.Status, result.Error)
+				}
+				if result.Output != want {
+					t.Errorf("Result.Output = %q, want %q", result.Output, want)
+				}
+				if got := strings.Join(streamed, "|"); got != narration+"|The diagram shows |the service architecture." {
+					t.Errorf("transcript text = %q, want narration and final answer", got)
+				}
+			})
+		}
+	}
+}
+
+// A turn whose last event is a tool call has no trailing text block. Without
+// the fallback Result.Output is empty, and the daemon treats an empty output as
+// a valid tool-only completion — so the reply silently disappears.
+func TestACPBackendsToolTerminatedTurnFallsBackToLatestTextBlock(t *testing.T) {
+	t.Parallel()
+
+	const want = "Done. Posted the summary to the issue."
+
+	for _, provider := range acpDeliverableProviders {
+		t.Run(provider, func(t *testing.T) {
+			t.Parallel()
+
+			result, streamed := runFakeACPTurn(t, provider, map[string]string{
+				"ACP_NARRATION":       want,
+				"ACP_TOOL_TERMINATED": "1",
+			})
+
+			if result.Status != "completed" {
+				t.Fatalf("status = %q, want completed (error=%q)", result.Status, result.Error)
+			}
+			if result.Output != want {
+				t.Errorf("Result.Output = %q, want fallback %q", result.Output, want)
+			}
+			if got := strings.Join(streamed, "|"); got != want {
+				t.Errorf("transcript text = %q, want the single text chunk", got)
+			}
+		})
+	}
+}

--- a/server/pkg/agent/acp_deliverable_test.go
+++ b/server/pkg/agent/acp_deliverable_test.go
@@ -1,0 +1,156 @@
+package agent
+
+import (
+	"strings"
+	"sync"
+	"testing"
+)
+
+func acpText(s string) Message { return Message{Type: MessageText, Content: s} }
+func acpToolUse(name string) Message {
+	return Message{Type: MessageToolUse, Tool: name, CallID: "tc-" + name}
+}
+
+func TestACPDeliverableTracker(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name            string
+		stream          []Message
+		wantDeliverable string
+		wantComplete    string
+	}{
+		{
+			name:            "no tool calls delivers the whole turn",
+			stream:          []Message{acpText("The answer "), acpText("is 42.")},
+			wantDeliverable: "The answer is 42.",
+			wantComplete:    "The answer is 42.",
+		},
+		{
+			name: "narration before a tool call is dropped from the deliverable",
+			stream: []Message{
+				acpText("I will inspect the attachment."),
+				acpToolUse("read_file"),
+				acpText("The diagram shows "),
+				acpText("the service architecture."),
+			},
+			wantDeliverable: "The diagram shows the service architecture.",
+			wantComplete:    "I will inspect the attachment.The diagram shows the service architecture.",
+		},
+		{
+			// The shape that made replies silently empty: an agent told to
+			// deliver through a CLI ends its turn on that tool call.
+			name: "turn ending on a tool call falls back to the last block",
+			stream: []Message{
+				acpText("Done. Posted the summary to the issue."),
+				acpToolUse("bash"),
+			},
+			wantDeliverable: "Done. Posted the summary to the issue.",
+			wantComplete:    "Done. Posted the summary to the issue.",
+		},
+		{
+			name: "the most recent non-blank block wins the fallback",
+			stream: []Message{
+				acpText("First I will read the file."),
+				acpToolUse("read_file"),
+				acpText("Now I will post the result."),
+				acpToolUse("bash"),
+			},
+			wantDeliverable: "Now I will post the result.",
+			wantComplete:    "First I will read the file.Now I will post the result.",
+		},
+		{
+			// A blank trailing block must not shadow a real earlier answer.
+			name: "a whitespace-only block does not become the fallback",
+			stream: []Message{
+				acpText("The migration is safe to apply."),
+				acpToolUse("read_file"),
+				acpText("\n  \n"),
+				acpToolUse("bash"),
+			},
+			wantDeliverable: "The migration is safe to apply.",
+			wantComplete:    "The migration is safe to apply.\n  \n",
+		},
+		{
+			name: "thinking and tool results neither deliver nor end a block",
+			stream: []Message{
+				{Type: MessageThinking, Content: "let me think"},
+				acpText("The answer "),
+				{Type: MessageToolResult, CallID: "tc-1", Output: "some output"},
+				{Type: MessageStatus, Status: "running"},
+				acpText("is 42."),
+			},
+			wantDeliverable: "The answer is 42.",
+			wantComplete:    "The answer is 42.",
+		},
+		{
+			// promoteACPResultOnProviderError must still see the synthetic
+			// give-up turn even though a tool boundary excluded it from the
+			// deliverable.
+			name: "a provider error before a tool boundary stays in the complete text",
+			stream: []Message{
+				acpText("API call failed after 3 retries: HTTP 429"),
+				acpToolUse("read_file"),
+				acpText("Recovered and finished."),
+			},
+			wantDeliverable: "Recovered and finished.",
+			wantComplete:    "API call failed after 3 retries: HTTP 429Recovered and finished.",
+		},
+		{
+			name:            "a turn with no text at all delivers nothing",
+			stream:          []Message{acpToolUse("bash"), {Type: MessageToolResult, CallID: "tc-bash"}},
+			wantDeliverable: "",
+			wantComplete:    "",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			var tracker acpDeliverableTracker
+			for _, msg := range tc.stream {
+				tracker.observe(msg)
+			}
+
+			deliverable, complete := tracker.result()
+			if deliverable != tc.wantDeliverable {
+				t.Errorf("deliverable = %q, want %q", deliverable, tc.wantDeliverable)
+			}
+			if complete != tc.wantComplete {
+				t.Errorf("complete = %q, want %q", complete, tc.wantComplete)
+			}
+		})
+	}
+}
+
+// The streaming callback and the goroutine assembling Result run separately, so
+// observe and result must not race. Meaningful under -race.
+func TestACPDeliverableTrackerConcurrentAccess(t *testing.T) {
+	t.Parallel()
+
+	var tracker acpDeliverableTracker
+	var wg sync.WaitGroup
+
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		for i := 0; i < 200; i++ {
+			tracker.observe(acpText("chunk"))
+			tracker.observe(acpToolUse("bash"))
+		}
+	}()
+	go func() {
+		defer wg.Done()
+		for i := 0; i < 200; i++ {
+			tracker.result()
+		}
+	}()
+	wg.Wait()
+
+	deliverable, complete := tracker.result()
+	if deliverable != "chunk" {
+		t.Errorf("deliverable = %q, want the last completed block", deliverable)
+	}
+	if want := strings.Repeat("chunk", 200); complete != want {
+		t.Errorf("complete length = %d, want %d", len(complete), len(want))
+	}
+}

--- a/server/pkg/agent/grok.go
+++ b/server/pkg/agent/grok.go
@@ -190,8 +190,11 @@ func (b *grokBackend) Execute(ctx context.Context, prompt string, opts ExecOptio
 	msgStream := newGrokMessageStream(256)
 	resCh := make(chan Result, 1)
 
-	var outputMu sync.Mutex
-	var output strings.Builder
+	// Grok emits interim narration and the final answer as the same ACP
+	// agent_message_chunk type; the tracker keeps Result.Output to the
+	// deliverable while provider-error detection still sees the complete
+	// stream (GH #6006). See acpDeliverableTracker.
+	var output acpDeliverableTracker
 	var streamingCurrentTurn atomic.Bool
 
 	promptDone := make(chan hermesPromptResult, 1)
@@ -220,11 +223,7 @@ func (b *grokBackend) Execute(ctx context.Context, prompt string, opts ExecOptio
 				// kimi/traecli do so the UI sees consistent snake_case names.
 				msg.Tool = kimiToolNameFromTitle(msg.Tool)
 			}
-			if msg.Type == MessageText {
-				outputMu.Lock()
-				output.WriteString(msg.Content)
-				outputMu.Unlock()
-			}
+			output.observe(msg)
 			msgStream.send(msg)
 		},
 		onPromptDone: func(result hermesPromptResult) {
@@ -486,13 +485,13 @@ func (b *grokBackend) Execute(ctx context.Context, prompt string, opts ExecOptio
 		drainCancel()
 		streamingCurrentTurn.Store(false)
 
-		outputMu.Lock()
-		finalOutput := output.String()
-		outputMu.Unlock()
+		finalOutput, providerErrorOutput := output.result()
 
 		// Promote completed→failed when stderr or the agent text stream show a
 		// terminal upstream-LLM failure (auth / rate-limit / HTTP 4xx).
-		finalStatus, finalError = promoteACPResultOnProviderError(finalStatus, finalError, finalOutput, providerErr)
+		// Detection reads the complete stream, not the deliverable: the
+		// synthetic give-up turn can land before a tool boundary.
+		finalStatus, finalError = promoteACPResultOnProviderError(finalStatus, finalError, providerErrorOutput, providerErr)
 
 		c.usageMu.Lock()
 		u := c.usage

--- a/server/pkg/agent/hermes.go
+++ b/server/pkg/agent/hermes.go
@@ -259,8 +259,11 @@ func (b *hermesBackend) Execute(ctx context.Context, prompt string, opts ExecOpt
 	msgCh := make(chan Message, 256)
 	resCh := make(chan Result, 1)
 
-	var outputMu sync.Mutex
-	var output strings.Builder
+	// Hermes emits interim narration and the final answer as the same ACP
+	// agent_message_chunk type; the tracker keeps Result.Output to the
+	// deliverable while provider-error detection still sees the complete
+	// stream (GH #6006). See acpDeliverableTracker.
+	var output acpDeliverableTracker
 	// streamingCurrentTurn gates all session updates so that history
 	// replay (Hermes sends full prior-turn transcripts on session/resume,
 	// and may flush queued chunks before our session/prompt response
@@ -289,11 +292,7 @@ func (b *hermesBackend) Execute(ctx context.Context, prompt string, opts ExecOpt
 			if !streamingCurrentTurn.Load() {
 				return
 			}
-			if msg.Type == MessageText {
-				outputMu.Lock()
-				output.WriteString(msg.Content)
-				outputMu.Unlock()
-			}
+			output.observe(msg)
 			trySend(msgCh, msg)
 		},
 		onPromptDone: func(result hermesPromptResult) {
@@ -586,9 +585,7 @@ func (b *hermesBackend) Execute(ctx context.Context, prompt string, opts ExecOpt
 		}
 		streamingCurrentTurn.Store(false)
 
-		outputMu.Lock()
-		finalOutput := output.String()
-		outputMu.Unlock()
+		finalOutput, providerErrorOutput := output.result()
 
 		// Hermes reports stopReason=end_turn even when the upstream
 		// LLM call ultimately fails (HTTP 429 rate-limit, expired
@@ -598,7 +595,9 @@ func (b *hermesBackend) Execute(ctx context.Context, prompt string, opts ExecOpt
 		// warning), the agent text stream contains the synthetic
 		// "API call failed after N retries..." turn the adapter
 		// injects on give-up, or there's no output to fall back on.
-		finalStatus, finalError = promoteACPResultOnProviderError(finalStatus, finalError, finalOutput, providerErr)
+		// Detection reads the complete stream, not the deliverable: the
+		// synthetic give-up turn can land before a tool boundary.
+		finalStatus, finalError = promoteACPResultOnProviderError(finalStatus, finalError, providerErrorOutput, providerErr)
 
 		// Build usage map.
 		c.usageMu.Lock()

--- a/server/pkg/agent/kimi.go
+++ b/server/pkg/agent/kimi.go
@@ -7,7 +7,6 @@ import (
 	"io"
 	"os/exec"
 	"strings"
-	"sync"
 	"time"
 )
 
@@ -111,8 +110,11 @@ func (b *kimiBackend) Execute(ctx context.Context, prompt string, opts ExecOptio
 	msgCh := make(chan Message, 256)
 	resCh := make(chan Result, 1)
 
-	var outputMu sync.Mutex
-	var output strings.Builder
+	// Kimi emits interim narration and the final answer as the same ACP
+	// agent_message_chunk type; the tracker keeps Result.Output to the
+	// deliverable while provider-error detection still sees the complete
+	// stream (GH #6006). See acpDeliverableTracker.
+	var output acpDeliverableTracker
 
 	promptDone := make(chan hermesPromptResult, 1)
 
@@ -134,11 +136,7 @@ func (b *kimiBackend) Execute(ctx context.Context, prompt string, opts ExecOptio
 			if msg.Type == MessageToolUse {
 				msg.Tool = kimiToolNameFromTitle(msg.Tool)
 			}
-			if msg.Type == MessageText {
-				outputMu.Lock()
-				output.WriteString(msg.Content)
-				outputMu.Unlock()
-			}
+			output.observe(msg)
 			trySend(msgCh, msg)
 		},
 		onPromptDone: func(result hermesPromptResult) {
@@ -366,17 +364,17 @@ func (b *kimiBackend) Execute(ctx context.Context, prompt string, opts ExecOptio
 		// provider-error sniffer; see hermes.go for the failure mode.
 		<-stderrDone
 
-		outputMu.Lock()
-		finalOutput := output.String()
-		outputMu.Unlock()
+		finalOutput, providerErrorOutput := output.result()
 
 		// Promote completed→failed when stderr or the agent text
 		// stream show a terminal upstream-LLM failure (HTTP 4xx /
 		// rate-limit / expired token). See the helper docs for the
 		// full signal set; the key safety property is that transient
 		// per-attempt warnings followed by a successful retry stay
-		// "completed".
-		finalStatus, finalError = promoteACPResultOnProviderError(finalStatus, finalError, finalOutput, providerErr)
+		// "completed". Detection reads the complete stream, not the
+		// deliverable: the synthetic give-up turn can land before a
+		// tool boundary.
+		finalStatus, finalError = promoteACPResultOnProviderError(finalStatus, finalError, providerErrorOutput, providerErr)
 
 		c.usageMu.Lock()
 		u := c.usage

--- a/server/pkg/agent/kiro.go
+++ b/server/pkg/agent/kiro.go
@@ -104,8 +104,11 @@ func (b *kiroBackend) Execute(ctx context.Context, prompt string, opts ExecOptio
 	msgCh := make(chan Message, 256)
 	resCh := make(chan Result, 1)
 
-	var outputMu sync.Mutex
-	var output strings.Builder
+	// Kiro emits interim narration and the final answer as the same ACP
+	// agent_message_chunk type; the tracker keeps Result.Output to the
+	// deliverable while provider-error detection still sees the complete
+	// stream (GH #6006). See acpDeliverableTracker.
+	var output acpDeliverableTracker
 	var streamingCurrentTurn atomic.Bool
 	// Completion-preservation state for the -32603 close-handshake guard.
 	//
@@ -174,11 +177,7 @@ func (b *kiroBackend) Execute(ctx context.Context, prompt string, opts ExecOptio
 					finishingMu.Unlock()
 				}
 			}
-			if msg.Type == MessageText {
-				outputMu.Lock()
-				output.WriteString(msg.Content)
-				outputMu.Unlock()
-			}
+			output.observe(msg)
 			trySend(msgCh, msg)
 		},
 		onPromptDone: func(result hermesPromptResult) {
@@ -445,17 +444,17 @@ func (b *kiroBackend) Execute(ctx context.Context, prompt string, opts ExecOptio
 		// provider-error sniffer; see hermes.go for the failure mode.
 		<-stderrDone
 
-		outputMu.Lock()
-		finalOutput := output.String()
-		outputMu.Unlock()
+		finalOutput, providerErrorOutput := output.result()
 
 		// Promote completed→failed when stderr or the agent text
 		// stream show a terminal upstream-LLM failure (HTTP 4xx /
 		// rate-limit / expired token). See the helper docs for the
 		// full signal set; the key safety property is that transient
 		// per-attempt warnings followed by a successful retry stay
-		// "completed".
-		finalStatus, finalError = promoteACPResultOnProviderError(finalStatus, finalError, finalOutput, providerErr)
+		// "completed". Detection reads the complete stream, not the
+		// deliverable: the synthetic give-up turn can land before a
+		// tool boundary.
+		finalStatus, finalError = promoteACPResultOnProviderError(finalStatus, finalError, providerErrorOutput, providerErr)
 
 		c.usageMu.Lock()
 		u := c.usage

--- a/server/pkg/agent/qoder.go
+++ b/server/pkg/agent/qoder.go
@@ -141,15 +141,12 @@ func (b *qoderBackend) Execute(ctx context.Context, prompt string, opts ExecOpti
 	msgStream := newQoderMessageStream(256)
 	resCh := make(chan Result, 1)
 
-	var outputMu sync.Mutex
-	// Result.Output is the final user-facing output selected by the backend.
 	// Qoder emits interim narration and the final answer as the same ACP
-	// AgentMessageChunk type, with tool calls as the only reliable boundary.
-	// Keep the complete text for provider-error detection, while deliverable
-	// holds only the text block after the latest tool call. This boundary is a
-	// heuristic until Qoder exposes an explicit final-answer marker.
-	var fullOutput, deliverableOutput strings.Builder
-	var lastTextBlock string
+	// AgentMessageChunk type, so the tracker splits the stream on tool calls:
+	// Result.Output gets the deliverable, provider-error detection gets the
+	// complete text. See acpDeliverableTracker for why the boundary is a
+	// heuristic and how a tool-terminated turn falls back.
+	var output acpDeliverableTracker
 	var streamingCurrentTurn atomic.Bool
 
 	promptDone := make(chan hermesPromptResult, 1)
@@ -169,18 +166,7 @@ func (b *qoderBackend) Execute(ctx context.Context, prompt string, opts ExecOpti
 			if msg.Type == MessageToolUse {
 				msg.Tool = kimiToolNameFromTitle(msg.Tool)
 			}
-			outputMu.Lock()
-			switch msg.Type {
-			case MessageText:
-				fullOutput.WriteString(msg.Content)
-				deliverableOutput.WriteString(msg.Content)
-			case MessageToolUse:
-				if block := deliverableOutput.String(); strings.TrimSpace(block) != "" {
-					lastTextBlock = block
-				}
-				deliverableOutput.Reset()
-			}
-			outputMu.Unlock()
+			output.observe(msg)
 			msgStream.send(msg)
 		},
 		onPromptDone: func(result hermesPromptResult) {
@@ -419,13 +405,7 @@ func (b *qoderBackend) Execute(ctx context.Context, prompt string, opts ExecOpti
 		// send and close so the late send is dropped instead of panicking.
 		streamingCurrentTurn.Store(false)
 
-		outputMu.Lock()
-		finalOutput := deliverableOutput.String()
-		if strings.TrimSpace(finalOutput) == "" {
-			finalOutput = lastTextBlock
-		}
-		providerErrorOutput := fullOutput.String()
-		outputMu.Unlock()
+		finalOutput, providerErrorOutput := output.result()
 
 		// Promote completed→failed when stderr or the agent text stream show a
 		// terminal upstream-LLM failure (HTTP 4xx / rate-limit / expired token).

--- a/server/pkg/agent/traecli.go
+++ b/server/pkg/agent/traecli.go
@@ -158,8 +158,11 @@ func (b *traecliBackend) Execute(ctx context.Context, prompt string, opts ExecOp
 	msgStream := newTraecliMessageStream(256)
 	resCh := make(chan Result, 1)
 
-	var outputMu sync.Mutex
-	var output strings.Builder
+	// Trae emits interim narration and the final answer as the same ACP
+	// agent_message_chunk type; the tracker keeps Result.Output to the
+	// deliverable while provider-error detection still sees the complete
+	// stream (GH #6006). See acpDeliverableTracker.
+	var output acpDeliverableTracker
 	var streamingCurrentTurn atomic.Bool
 
 	promptDone := make(chan hermesPromptResult, 1)
@@ -179,11 +182,7 @@ func (b *traecliBackend) Execute(ctx context.Context, prompt string, opts ExecOp
 			if msg.Type == MessageToolUse {
 				msg.Tool = kimiToolNameFromTitle(msg.Tool)
 			}
-			if msg.Type == MessageText {
-				outputMu.Lock()
-				output.WriteString(msg.Content)
-				outputMu.Unlock()
-			}
+			output.observe(msg)
 			msgStream.send(msg)
 		},
 		onPromptDone: func(result hermesPromptResult) {
@@ -410,14 +409,14 @@ func (b *traecliBackend) Execute(ctx context.Context, prompt string, opts ExecOp
 		// late send is dropped instead of panicking.
 		streamingCurrentTurn.Store(false)
 
-		outputMu.Lock()
-		finalOutput := output.String()
-		outputMu.Unlock()
+		finalOutput, providerErrorOutput := output.result()
 
 		// Promote completed→failed when stderr or the agent text stream show a
 		// terminal upstream-LLM failure (HTTP 4xx / rate-limit / expired token).
-		// Mirrors hermes/kimi/kiro/qoder.
-		finalStatus, finalError = promoteACPResultOnProviderError(finalStatus, finalError, finalOutput, providerErr)
+		// Mirrors hermes/kimi/kiro/qoder. Detection reads the complete stream,
+		// not the deliverable: the synthetic give-up turn can land before a
+		// tool boundary.
+		finalStatus, finalError = promoteACPResultOnProviderError(finalStatus, finalError, providerErrorOutput, providerErr)
 
 		c.usageMu.Lock()
 		u := c.usage


### PR DESCRIPTION
Follow-up to #6022. MUL-5405.

## What does this PR do?

#6022 narrowed `Result.Output` to the deliverable for qoder. The same accumulate-every-`MessageText` shape is duplicated verbatim in five more ACP backends, with the same bug:

| backend | declaration | accumulate | read |
| --- | --- | --- | --- |
| `hermes.go` | 263 | 294 | 590 |
| `kimi.go` | 115 | 139 | 370 |
| `kiro.go` | 108 | 179 | 449 |
| `traecli.go` | 162 | 184 | 414 |
| `grok.go` | 194 | 225 | 490 |

`Result.Output` is documented as "the final user-facing output selected by the backend" (`agent.go`) and reaches channel replies and synthesized issue comments, so all five still hand the daemon `narration + answer` as one string (GH #6006).

Rather than copy qoder's block a fifth time, this extracts `acpDeliverableTracker` and wires all six backends to it. The tracker owns the whole rule: text chunks accumulate into the current block, a `MessageToolUse` starts a new one, and a turn that ends on a tool call falls back to the most recent non-blank block.

That fallback is load-bearing, not defensive. An agent told to deliver its result through a CLI ends its turn on that tool call, and `daemon.go:5119` treats an empty `Output` as a *valid* tool-only completion — so without the fallback the reply silently disappears with no error anywhere.

## Changes

- Add `acpDeliverableTracker` (`observe` / `result`) as the single home for the boundary rule and its fallback.
- Wire `hermes`, `kimi`, `kiro`, `traecli`, `grok` and `qoder` to it; each backend's `outputMu` goes away since the tracker owns its own.
- Keep provider-error detection on the complete stream in all six.
- Add tracker unit tests and a cross-backend regression fixture.

## Why provider-error detection keeps the complete text

Two reasons, and the second is easy to miss. The synthetic "API call failed after N retries..." turn can land before a tool boundary, so the deliverable would not contain it. Beyond that, `hermes.go:2477` has an `if finalOutput == ""` branch that promotes completed → failed from any sniffer message — feeding it the deliverable would make **every** tool-terminated turn a spurious-failure candidate whenever stderr had noise.

`result()` returns both strings under a single lock so they cannot disagree about where the stream ended.

## Known gap, unchanged by this PR

If a tool call never reaches `completed`/`failed` (aborted turn, process dies mid-tool), `MessageToolUse` is never emitted, so no boundary is recorded and pre-tool narration stays in the deliverable. That was true before this PR too. Fixing it needs a turn-abort signal the tracker does not currently see; left out deliberately rather than guessed at.

The boundary remains a heuristic — ACP exposes no `phase: final_answer` marker the way Codex's app-server does. The doc comment says so, so the next reader knows to switch if one appears.

## Verification

```
go build ./...
go vet ./pkg/agent
go test ./pkg/agent -race          # includes the tracker concurrency case
go test ./pkg/agent                # full suite, 116s
go test ./internal/daemon/...      # Result.Output consumer
```

All pass locally.

Both new assertions are mutation-checked, so they are not vacuous:

- Removing the fallback → `TestACPBackendsToolTerminatedTurnFallsBackToLatestTextBlock` fails on all six providers with `Result.Output = ""`.
- Removing the tool boundary → `TestACPBackendsDeliverFinalAnswerOnly` fails with `Result.Output = "I will inspect the attachment.The diagram shows the service architecture."`, which is exactly the bug this PR fixes in the five untouched backends.

The cross-backend fixture also runs each case across both `MessageToolUse` emission paths — immediate when the `tool_call` frame carries `rawInput`, and deferred to the completed `tool_call_update` when it does not (`hermes.go:1417`), which is the path the Kimi-shaped adapters actually take.
