### PR TITLE
fix(editor): limit paste-as-file to chat

### DIFF
--- a/packages/views/editor/content-editor.tsx
+++ b/packages/views/editor/content-editor.tsx
@@ -138,10 +138,12 @@ interface ContentEditorBaseProps {
    * `pasted-text.txt` attachment instead of being inserted as body text.
    * Requires `onUploadFile`; without an uploader the paste stays text.
    *
-   * Opt-in ON PURPOSE. It belongs to turn-based composers (chat, comments),
-   * where a wall of pasted text is context for one message and reads better
-   * as an attachment. Document-style editors — issue and project descriptions
-   * — must never pass it: there, a long paste IS the content.
+   * Opt-in ON PURPOSE, and today only chat passes it: a wall of pasted text
+   * there is context handed to an agent for one turn, and reads better as an
+   * attachment than as a body nobody scrolls. Every other editor keeps the
+   * paste inline — in issue and project descriptions a long paste IS the
+   * content, and in issue comments it is prose a human reader is expected to
+   * see in the thread.
    */
   pasteAsFileThreshold?: number;
   /**

--- a/packages/views/editor/paste-as-file.ts
+++ b/packages/views/editor/paste-as-file.ts
@@ -2,9 +2,11 @@
  * Character count above which a plain-text paste is uploaded as a
  * `pasted-text.txt` attachment instead of being inserted as body text.
  *
- * One shared value so every turn-based composer converts at the same point —
- * a comment and its edit form disagreeing would let the same content be a file
- * on the way in and text on the way back out.
+ * Chat is the only editor that opts in; see `pasteAsFileThreshold` in
+ * `content-editor.tsx` for why. The constant stays separate from that call
+ * site so any composer that later joins converts at the same point — two
+ * surfaces disagreeing would let the same content be a file on the way in and
+ * text on the way back out.
  *
  * The number is a product judgement, not a technical limit: nothing in this
  * stack caps message length (no client schema max, the server only rejects

--- a/packages/views/editor/use-coordinated-uploads.test.tsx
+++ b/packages/views/editor/use-coordinated-uploads.test.tsx
@@ -1,10 +1,14 @@
 // @vitest-environment jsdom
-import { useLayoutEffect, useMemo, useRef, type ReactNode } from "react";
-import { describe, expect, it } from "vitest";
-import { render } from "@testing-library/react";
+import { useEffect, useLayoutEffect, useMemo, useRef, type ReactNode } from "react";
+import { describe, expect, it, vi } from "vitest";
+import { act, render } from "@testing-library/react";
 import { I18nProvider } from "@multica/core/i18n/react";
+import type { DraftUpload } from "@multica/core/drafts";
+import type { UploadResult } from "@multica/core/hooks/use-file-upload";
+import type { Attachment } from "@multica/core/types";
 import enCommon from "../locales/en/common.json";
 import enEditor from "../locales/en/editor.json";
+import { markPastedTextFile, PASTED_TEXT_FILENAME } from "./extensions/file-upload";
 import type { ContentEditorRef } from "./content-editor";
 import type { UploadGate } from "./use-upload-gate";
 import {
@@ -12,6 +16,12 @@ import {
   __liveEditorRegistryKeysForTest,
   type UploadDraftBinding,
 } from "./use-coordinated-uploads";
+
+// The coordinator (MUL-5181 L2) is what actually performs the request; tests
+// drive an upload's outcome by controlling THAT promise.
+const mockApiUploadFile = vi.hoisted(() => vi.fn());
+vi.mock("@multica/core/api", () => ({ api: { uploadFile: mockApiUploadFile } }));
+vi.mock("sonner", () => ({ toast: { error: vi.fn(), success: vi.fn() } }));
 
 const TEST_RESOURCES = { en: { common: enCommon, editor: enEditor } };
 
@@ -92,5 +102,103 @@ describe("useCoordinatedUploads live-editor registry timing", () => {
 
     view.unmount();
     expect(__liveEditorRegistryKeysForTest()).not.toContain("probe:b");
+  });
+});
+
+/**
+ * A store-backed binding, in memory. Real enough for the write-back paths,
+ * which only ever go through these accessors — and, like the real ones, still
+ * callable after the component that started the upload is gone.
+ */
+function makeRecordingBinding(key: string) {
+  const state = { uploads: [] as DraftUpload[], body: "" };
+  const binding: UploadDraftBinding = {
+    registryKey: key,
+    getUploads: () => state.uploads,
+    addUpload: (upload) => {
+      state.uploads = [...state.uploads, upload];
+    },
+    settleUpload: () => {},
+    failUpload: () => {},
+    removeUpload: (clientUploadId) => {
+      state.uploads = state.uploads.filter((u) => u.clientUploadId !== clientUploadId);
+    },
+    getBody: () => state.body,
+    appendToBody: (markdown) => {
+      state.body = state.body ? `${state.body}\n\n${markdown}` : markdown;
+    },
+  };
+  return { binding, state };
+}
+
+function UploadHost({
+  binding,
+  expose,
+}: {
+  binding: UploadDraftBinding;
+  expose: (upload: (file: File) => Promise<UploadResult | null>) => void;
+}) {
+  const editorRef = useRef<ContentEditorRef | null>(null);
+  const { handleUpload } = useCoordinatedUploads(binding, [], {}, inertGate, editorRef);
+  useEffect(() => {
+    expose(handleUpload);
+  }, [handleUpload, expose]);
+  return null;
+}
+
+/**
+ * Paste-as-file recovery lives here, not in a composer test, because the hook
+ * is the single responder for it: the upload outlives its mount, so no editor
+ * can own the failure path. Only chat opts into paste-as-file today
+ * (`pasteAsFileThreshold`), but the recovery contract is the hook's regardless
+ * of which surface turns the feature on.
+ */
+describe("useCoordinatedUploads paste-as-file recovery", () => {
+  it("puts a failed paste's source text back into the persisted body after the mount dies", async () => {
+    const pastedText = "a long pasted wall of text that became an attachment";
+    const { binding, state } = makeRecordingBinding("probe:paste");
+    let upload!: (file: File) => Promise<UploadResult | null>;
+
+    let rejectUpload!: (err: Error) => void;
+    mockApiUploadFile.mockImplementationOnce(
+      () =>
+        new Promise<Attachment>((_resolve, reject) => {
+          rejectUpload = reject;
+        }),
+    );
+
+    const view = render(
+      <I18nProvider locale="en" resources={TEST_RESOURCES}>
+        <UploadHost
+          binding={binding}
+          expose={(fn) => {
+            upload = fn;
+          }}
+        />
+      </I18nProvider>,
+    );
+
+    await act(async () => {
+      void upload(
+        markPastedTextFile(
+          new File([pastedText], PASTED_TEXT_FILENAME, { type: "text/plain" }),
+          pastedText,
+        ),
+      );
+    });
+    expect(state.uploads).toHaveLength(1);
+
+    view.unmount();
+    await act(async () => {
+      rejectUpload(new Error("upload failed"));
+      await Promise.resolve();
+    });
+
+    // A dropped file survives a failed upload on disk; this text does not exist
+    // anywhere else — it was never written into the document — so the draft
+    // must get it back rather than keep a chip standing in for content the
+    // user can never recover.
+    expect(state.body).toContain(pastedText);
+    expect(state.uploads).toHaveLength(0);
   });
 });

--- a/packages/views/issues/components/comment-card.tsx
+++ b/packages/views/issues/components/comment-card.tsx
@@ -30,7 +30,6 @@ import { copyText } from "@multica/ui/lib/clipboard";
 import { useActorName } from "@multica/core/workspace/hooks";
 import { useTimeAgo } from "../../i18n";
 import { ContentEditor, type ContentEditorRef, ReadonlyContent, useFileDropZone, FileDropOverlay, Attachment as AttachmentRenderer, AttachmentDownloadProvider, useUploadGate, useComposerSubmit } from "../../editor";
-import { PASTE_AS_FILE_THRESHOLD } from "../../editor/paste-as-file";
 import { useCommentUploads } from "./use-comment-uploads";
 import { FileUploadButton } from "@multica/ui/components/common/file-upload-button";
 import { api, dispatchReasonCode } from "@multica/core/api";
@@ -673,7 +672,6 @@ function CommentRow({
               }}
               onSubmit={edit.saveEdit}
               onUploadFile={edit.handleUpload}
-              pasteAsFileThreshold={PASTE_AS_FILE_THRESHOLD}
               onUploadingChange={edit.onUploadingChange}
               debounceMs={100}
               currentIssueId={issueId}
@@ -983,7 +981,6 @@ function CommentCardImpl({
                     }}
                     onSubmit={edit.saveEdit}
                     onUploadFile={edit.handleUpload}
-                    pasteAsFileThreshold={PASTE_AS_FILE_THRESHOLD}
                     onUploadingChange={edit.onUploadingChange}
                     debounceMs={100}
                     currentIssueId={issueId}

--- a/packages/views/issues/components/comment-composers.test.tsx
+++ b/packages/views/issues/components/comment-composers.test.tsx
@@ -6,10 +6,6 @@ import type { UploadResult } from "@multica/core/hooks/use-file-upload";
 import type { Attachment } from "@multica/core/types";
 import { useCommentComposerStore, useCommentDraftStore } from "@multica/core/issues/stores";
 import { renderWithI18n } from "../../test/i18n";
-import {
-  markPastedTextFile,
-  PASTED_TEXT_FILENAME,
-} from "../../editor/extensions/file-upload";
 import { CommentInput } from "./comment-input";
 import { ReplyInput } from "./reply-input";
 
@@ -581,11 +577,7 @@ describe("comment composers — upload submit gate", () => {
    * coordinator calls `api.uploadFile`, so this controls THAT promise: resolve
    * it with an attachment (success) or reject it (failure).
    */
-  function startPendingUpload(
-    container: HTMLElement,
-    filename = "slow.png",
-    file?: File,
-  ) {
+  function startPendingUpload(container: HTMLElement, filename = "slow.png") {
     let resolveUpload!: (att: Attachment) => void;
     let rejectUpload!: (err: Error) => void;
     apiUploadFile.mockImplementationOnce(
@@ -600,7 +592,7 @@ describe("comment composers — upload submit gate", () => {
     const input = container.querySelector('input[type="file"]');
     if (!input) throw new Error("Expected a file input to render");
     fireEvent.change(input, {
-      target: { files: [file ?? new File(["x"], filename, { type: "image/png" })] },
+      target: { files: [new File(["x"], filename, { type: "image/png" })] },
     });
     return {
       resolve: (att: Attachment) => resolveUpload(att),
@@ -892,35 +884,6 @@ describe("comment composers — upload submit gate", () => {
     const uploads = useCommentDraftStore.getState().getUploads("new:issue-1");
     expect(uploads).toHaveLength(1);
     expect(uploads[0]?.status).toBe("uploaded");
-  });
-
-  it("restores a failed paste-as-file's text into the draft even after the composer unmounts", async () => {
-    const pastedText = "a long pasted wall of text that became an attachment";
-    const { container, unmount } = renderCommentInput();
-    activateComposer("comment-composer-shell");
-    fireEvent.change(screen.getByTestId("editor"), { target: { value: "wip text" } });
-
-    const pending = startPendingUpload(
-      container,
-      PASTED_TEXT_FILENAME,
-      markPastedTextFile(
-        new File([pastedText], PASTED_TEXT_FILENAME, { type: "text/plain" }),
-        pastedText,
-      ),
-    );
-    unmount();
-
-    await act(async () => {
-      pending.fail();
-    });
-
-    // A dropped file survives a failed upload on disk; this text does not
-    // exist anywhere else, so the draft must get it back rather than keep a
-    // failed chip standing in for content the user can never recover.
-    const draft = useCommentDraftStore.getState().getDraft("new:issue-1");
-    expect(draft).toContain("wip text");
-    expect(draft).toContain(pastedText);
-    expect(useCommentDraftStore.getState().getUploads("new:issue-1")).toHaveLength(0);
   });
 
   it("hands the finished upload's link to a REOPENED composer's live editor", async () => {

--- a/packages/views/issues/components/comment-input.tsx
+++ b/packages/views/issues/components/comment-input.tsx
@@ -3,7 +3,6 @@
 import { useRef, useState, useCallback, useEffect } from "react";
 import { cn } from "@multica/ui/lib/utils";
 import { ContentEditor, type ContentEditorRef, useFileDropZone, FileDropOverlay, useLazyEditor, useUploadGate, useComposerSubmit } from "../../editor";
-import { PASTE_AS_FILE_THRESHOLD } from "../../editor/paste-as-file";
 import { FileUploadButton } from "@multica/ui/components/common/file-upload-button";
 import { SubmitButton } from "@multica/ui/components/common/submit-button";
 import { contentReferencesAttachment } from "@multica/core/types";
@@ -220,7 +219,6 @@ function CommentInput({ issueId, onSubmit }: CommentInputProps) {
           }}
           onSubmit={submit}
           onUploadFile={handleUpload}
-          pasteAsFileThreshold={PASTE_AS_FILE_THRESHOLD}
           onUploadingChange={uploadGate.onUploadingChange}
           debounceMs={100}
           currentIssueId={issueId}

--- a/packages/views/issues/components/reply-input.tsx
+++ b/packages/views/issues/components/reply-input.tsx
@@ -2,7 +2,6 @@
 
 import { useRef, useState, useCallback, useEffect } from "react";
 import { ContentEditor, type ContentEditorRef, useFileDropZone, FileDropOverlay, useLazyEditor, useUploadGate, useComposerSubmit } from "../../editor";
-import { PASTE_AS_FILE_THRESHOLD } from "../../editor/paste-as-file";
 import { FileUploadButton } from "@multica/ui/components/common/file-upload-button";
 import { SubmitButton } from "@multica/ui/components/common/submit-button";
 import { ActorAvatar } from "../../common/actor-avatar";
@@ -241,7 +240,6 @@ function ReplyInput({
             }}
             onSubmit={submit}
             onUploadFile={handleUpload}
-            pasteAsFileThreshold={PASTE_AS_FILE_THRESHOLD}
             onUploadingChange={uploadGate.onUploadingChange}
             debounceMs={100}
             currentIssueId={issueId}


### PR DESCRIPTION
#6019 opted four composers into converting an over-threshold plain-text paste into a `pasted-text.txt` attachment. Only chat should. A wall of text there is context handed to an agent for one turn, and the body is not what anyone reads. In an issue comment the paste **is** prose a human reader is expected to see in the thread, so hiding it behind an attachment chip makes the thread worse, not better.

## What changed

Three comment surfaces stop passing `pasteAsFileThreshold`:

- `comment-input.tsx` — new comment
- `reply-input.tsx` — reply
- `comment-card.tsx` — comment edit (both render branches)

`chat-input.tsx` is untouched and is now the only editor that passes the threshold.

The mechanism stays whole — the extension, `PASTE_AS_FILE_THRESHOLD = 4000`, and the failed-paste recovery. The prop was always opt-in per editor, and chat still uses every part of it.

Two comments that had become false are updated: the prop's docs in `content-editor.tsx` and the constant's docs in `paste-as-file.ts`, both of which claimed "chat, comments".

## Tests

The recovery test moves from `comment-composers.test.tsx` to `use-coordinated-uploads.test.tsx`. Comments can no longer produce a paste-as-file upload at all, so hosting the test there would pin a path that cannot happen. The hook is where the contract actually lives: the upload outlives its mount, so no editor can own the failure path.

| | |
|---|---|
| 4 affected test files | 62 cases, all passing |
| `pnpm typecheck` | not run |

🤖 Generated with [Claude Code](https://claude.com/claude-code)