### PR TITLE
fix(comment): @all no longer swallows an explicit @agent mention (MUL-5411)

### DIFF
--- a/server/cmd/server/comment_trigger_integration_test.go
+++ b/server/cmd/server/comment_trigger_integration_test.go
@@ -408,6 +408,17 @@ func TestCommentTriggerAtAllSuppression(t *testing.T) {
 			t.Errorf("expected 0 pending tasks (@all in agent thread), got %d", n)
 		}
 	})
+
+	// MUL-5411: @all suppresses only the IMPLICIT routes. An explicit @agent in
+	// the same comment is a direct request and must still enqueue that agent.
+	t.Run("@all with explicit @agent still triggers the agent", func(t *testing.T) {
+		clearTasks(t, issueID)
+		content := fmt.Sprintf("[@All](mention://all/all) heads up — [@Agent](mention://agent/%s) please take this", agentID)
+		postComment(t, issueID, content, nil)
+		if n := countPendingTasks(t, issueID); n != 1 {
+			t.Errorf("expected 1 pending task (@all must not swallow the explicit @agent), got %d", n)
+		}
+	})
 }
 
 // TestCommentTriggerOnAssignNoStatusGate verifies that assigning an agent to

--- a/server/internal/handler/comment.go
+++ b/server/internal/handler/comment.go
@@ -2502,7 +2502,18 @@ func (h *Handler) resolveMentionedAgentCommentTriggers(ctx context.Context, issu
 	for _, m := range mentions {
 		if m.Type == "squad" {
 			// @squad mention → trigger the squad's leader agent.
-			squadUUID := parseUUID(m.ID)
+			// The mention id comes from untrusted comment text and MentionRe
+			// accepts any hex/dash run (`mention://squad/-`), so it is parsed
+			// with the error-returning ParseUUID — the Must* variant would
+			// panic the request, and on the create path the comment row is
+			// already committed by then. A malformed id is indistinguishable
+			// from a well-formed id that owns no squad: same target_unavailable
+			// outcome, no run.
+			squadUUID, err := util.ParseUUID(m.ID)
+			if err != nil {
+				blockTarget("squad", m.ID, ReasonTargetUnavailable)
+				continue
+			}
 			squad, err := h.Queries.GetSquadInWorkspace(ctx, db.GetSquadInWorkspaceParams{
 				ID:          squadUUID,
 				WorkspaceID: issue.WorkspaceID,
@@ -2561,7 +2572,14 @@ func (h *Handler) resolveMentionedAgentCommentTriggers(ctx context.Context, issu
 		if m.Type != "agent" {
 			continue
 		}
-		agentUUID := parseUUID(m.ID)
+		agentUUID, err := util.ParseUUID(m.ID)
+		if err != nil {
+			// Untrusted comment text: MentionRe matches any hex/dash run, so a
+			// malformed id must not reach the panicking Must* parser. It gets
+			// the same enumeration-safe outcome as an id that owns no agent.
+			blockTarget("agent", m.ID, ReasonInvocationNotAllowed)
+			continue
+		}
 		// Load the agent scoped to the current issue's workspace. Using the
 		// bare GetAgent here would let a mention resolve to an agent in a
 		// different workspace, and the visibility check below would then be

--- a/server/internal/handler/comment.go
+++ b/server/internal/handler/comment.go
@@ -2118,12 +2118,19 @@ func (h *Handler) computeCommentAgentTriggers(ctx context.Context, issue db.Issu
 	// creator's authority by commenting on that autopilot's issue.
 
 	mentions := util.ParseMentions(content)
-	if util.HasMentionAll(mentions) {
-		return nil, nil
-	}
 
+	// EXPLICIT @agent / @squad mentions are a direct request and win over the
+	// @all broadcast (MUL-5411). @all only suppresses the IMPLICIT routing
+	// fallbacks (assignee / thread parent / conversation) below — it must not
+	// swallow a target the author named by hand. Before this ordering, a
+	// comment carrying both `@all` and `@Preflight` enqueued nothing at all.
+	// `all` is neither "agent" nor "squad", so it is skipped inside
+	// resolveMentionedAgentCommentTriggers and never enqueues a run of its own.
 	if hasAgentOrSquadMention(mentions) {
 		return h.resolveMentionedAgentCommentTriggers(ctx, issue, mentions, actorType, actorID, opts)
+	}
+	if util.HasMentionAll(mentions) {
+		return nil, nil
 	}
 	if hasMemberMention(mentions) {
 		return nil, nil

--- a/server/internal/handler/comment_trigger_preview_test.go
+++ b/server/internal/handler/comment_trigger_preview_test.go
@@ -1129,6 +1129,94 @@ func TestPreviewCommentTriggers_AllPlusMemberMentionStaysSuppressed(t *testing.T
 	}
 }
 
+// TestPreviewCommentTriggers_MalformedMentionIDDoesNotPanic pins the review
+// finding on PR #6048: MentionRe accepts any `[0-9a-fA-F-]+` id, so
+// `mention://agent/-` parses as a real mention. The resolver used to hand that
+// straight to the panicking parseUUID (util.MustParseUUID), turning attacker-
+// controlled comment text into a 500 — and on the create path the comment row
+// was already committed before the panic. Malformed ids must be reported as
+// blocked mentions, exactly like a well-formed id that owns no entity.
+func TestPreviewCommentTriggers_MalformedMentionIDDoesNotPanic(t *testing.T) {
+	if testHandler == nil || testPool == nil {
+		t.Skip("database not available")
+	}
+
+	assigneeID := createHandlerTestAgent(t, "Preview Malformed Assignee", nil)
+	issueID := createCommentTriggerPreviewIssue(t, "comment trigger malformed mention id", "agent", assigneeID)
+
+	cases := []struct {
+		name       string
+		content    string
+		targetType string
+		targetID   string
+		reason     DispatchReasonCode
+	}{
+		{
+			name:       "bare dash agent id",
+			content:    "[@Broken](mention://agent/-) please look",
+			targetType: "agent",
+			targetID:   "-",
+			reason:     ReasonInvocationNotAllowed,
+		},
+		{
+			name:       "short hex agent id",
+			content:    "[@Broken](mention://agent/dead-beef) please look",
+			targetType: "agent",
+			targetID:   "dead-beef",
+			reason:     ReasonInvocationNotAllowed,
+		},
+		{
+			name:       "malformed squad id",
+			content:    "[@BrokenSquad](mention://squad/-) please look",
+			targetType: "squad",
+			targetID:   "-",
+			reason:     ReasonTargetUnavailable,
+		},
+		{
+			name:       "all plus malformed agent id",
+			content:    "[@all](mention://all/all) heads up [@Broken](mention://agent/-) please look",
+			targetType: "agent",
+			targetID:   "-",
+			reason:     ReasonInvocationNotAllowed,
+		},
+		{
+			name:       "all plus malformed squad id",
+			content:    "[@all](mention://all/all) heads up [@BrokenSquad](mention://squad/-) please look",
+			targetType: "squad",
+			targetID:   "-",
+			reason:     ReasonTargetUnavailable,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			preview := previewCommentTriggersForTest(t, issueID, map[string]any{"content": tc.content})
+			if got := len(preview.Agents); got != 0 {
+				t.Fatalf("malformed mention preview agents = %d, want 0: %+v", got, preview.Agents)
+			}
+			if len(preview.Blocked) != 1 {
+				t.Fatalf("malformed mention blocked = %+v, want exactly 1 outcome", preview.Blocked)
+			}
+			blocked := preview.Blocked[0]
+			if blocked.TargetType != tc.targetType || blocked.TargetID != tc.targetID {
+				t.Fatalf("blocked target = %s/%s, want %s/%s", blocked.TargetType, blocked.TargetID, tc.targetType, tc.targetID)
+			}
+			if blocked.Status != DispatchBlocked {
+				t.Fatalf("blocked status = %q, want %q", blocked.Status, DispatchBlocked)
+			}
+			if blocked.ReasonCode != tc.reason {
+				t.Fatalf("blocked reason = %q, want %q", blocked.ReasonCode, tc.reason)
+			}
+
+			// The create path must survive the same input and enqueue nothing.
+			postCommentForTriggerPreviewTest(t, issueID, map[string]any{"content": tc.content})
+			if got := countQueuedCommentTriggerTasks(t, issueID, assigneeID); got != 0 {
+				t.Fatalf("assignee queued tasks = %d, want 0", got)
+			}
+		})
+	}
+}
+
 func TestPreviewCommentTriggers_AllSuppressesAssigneeAndPendingDedupes(t *testing.T) {
 	if testHandler == nil || testPool == nil {
 		t.Skip("database not available")

--- a/server/internal/handler/comment_trigger_preview_test.go
+++ b/server/internal/handler/comment_trigger_preview_test.go
@@ -1049,6 +1049,86 @@ func TestPreviewCommentTriggers_AssigneeAndSuppress(t *testing.T) {
 	}
 }
 
+// TestPreviewCommentTriggers_AllPlusExplicitAgentMentionStillTriggers pins
+// MUL-5411: `@all` only suppresses the IMPLICIT assignee auto-trigger. A comment
+// that carries `@all` AND an explicit `@agent` must still enqueue that agent —
+// the old ordering short-circuited on `@all` and dropped every trigger, so a
+// "[@all] ... [@Preflight]" comment silently ran nothing.
+func TestPreviewCommentTriggers_AllPlusExplicitAgentMentionStillTriggers(t *testing.T) {
+	if testHandler == nil || testPool == nil {
+		t.Skip("database not available")
+	}
+
+	assigneeID := createHandlerTestAgent(t, "Preview All Assignee", nil)
+	mentionedID := createHandlerTestAgent(t, "Preview All Mentioned", nil)
+	issueID := createCommentTriggerPreviewIssue(t, "comment trigger all plus mention", "agent", assigneeID)
+	content := fmt.Sprintf("[@all](mention://all/all) heads up — [@Mentioned](mention://agent/%s) please take this", mentionedID)
+
+	preview := previewCommentTriggersForTest(t, issueID, map[string]any{"content": content})
+	// Only the explicitly named agent runs: @all does not fan out to agents and
+	// does not resurrect the assignee fallback.
+	requirePreviewAgents(t, preview, mentionedID)
+	if preview.Agents[0].Source != string(commentTriggerSourceMentionAgent) {
+		t.Fatalf("preview source = %q, want %q", preview.Agents[0].Source, commentTriggerSourceMentionAgent)
+	}
+
+	postCommentForTriggerPreviewTest(t, issueID, map[string]any{"content": content})
+	if got := countQueuedCommentTriggerTasks(t, issueID, mentionedID); got != 1 {
+		t.Fatalf("mentioned agent queued tasks = %d, want 1", got)
+	}
+	if got := countQueuedCommentTriggerTasks(t, issueID, assigneeID); got != 0 {
+		t.Fatalf("assignee queued tasks = %d, want 0 (@all suppresses the assignee fallback)", got)
+	}
+}
+
+// TestPreviewCommentTriggers_AllPlusExplicitSquadMentionStillTriggers is the
+// squad half of MUL-5411: an `@all` broadcast must not swallow an explicit
+// `@squad` mention either — the squad leader still wakes.
+func TestPreviewCommentTriggers_AllPlusExplicitSquadMentionStillTriggers(t *testing.T) {
+	if testHandler == nil || testPool == nil {
+		t.Skip("database not available")
+	}
+
+	leaderID := createHandlerTestAgent(t, "Preview All Squad Leader", nil)
+	squadID := createCommentTriggerPreviewSquad(t, "Preview All Squad "+t.Name(), leaderID)
+	issueID := createCommentTriggerPreviewIssue(t, "comment trigger all plus squad mention", "", "")
+	content := fmt.Sprintf("[@all](mention://all/all) FYI — [@Squad](mention://squad/%s) please pick this up", squadID)
+
+	preview := previewCommentTriggersForTest(t, issueID, map[string]any{"content": content})
+	requirePreviewAgents(t, preview, leaderID)
+	if preview.Agents[0].Source != string(commentTriggerSourceMentionSquadLeader) {
+		t.Fatalf("preview source = %q, want %q", preview.Agents[0].Source, commentTriggerSourceMentionSquadLeader)
+	}
+
+	postCommentForTriggerPreviewTest(t, issueID, map[string]any{"content": content})
+	if got := countQueuedCommentTriggerTasks(t, issueID, leaderID); got != 1 {
+		t.Fatalf("squad leader queued tasks = %d, want 1", got)
+	}
+}
+
+// TestPreviewCommentTriggers_AllPlusMemberMentionStaysSuppressed guards the
+// other side of the MUL-5411 reorder: `@all` alongside a `@member` mention (no
+// agent/squad named) still triggers nothing.
+func TestPreviewCommentTriggers_AllPlusMemberMentionStaysSuppressed(t *testing.T) {
+	if testHandler == nil || testPool == nil {
+		t.Skip("database not available")
+	}
+
+	assigneeID := createHandlerTestAgent(t, "Preview All Member Assignee", nil)
+	issueID := createCommentTriggerPreviewIssue(t, "comment trigger all plus member mention", "agent", assigneeID)
+	content := fmt.Sprintf("[@all](mention://all/all) and [@Member](mention://member/%s) heads up", testUserID)
+
+	preview := previewCommentTriggersForTest(t, issueID, map[string]any{"content": content})
+	if got := len(preview.Agents); got != 0 {
+		t.Fatalf("@all + @member preview agents = %d, want 0: %+v", got, preview.Agents)
+	}
+
+	postCommentForTriggerPreviewTest(t, issueID, map[string]any{"content": content})
+	if got := countQueuedCommentTriggerTasks(t, issueID, assigneeID); got != 0 {
+		t.Fatalf("assignee queued tasks = %d, want 0", got)
+	}
+}
+
 func TestPreviewCommentTriggers_AllSuppressesAssigneeAndPendingDedupes(t *testing.T) {
 	if testHandler == nil || testPool == nil {
 		t.Skip("database not available")

--- a/server/internal/service/builtin_skills/multica-mentioning/SKILL.md
+++ b/server/internal/service/builtin_skills/multica-mentioning/SKILL.md
@@ -97,11 +97,19 @@ is a no-op; a malformed UUID is rejected at the request boundary.
     [@all](mention://all/all)
 
 It addresses everyone on the issue. It does NOT make any specific agent run.
-And it is special at trigger time: in `commentMentionsOthersButNotAssignee`
-(`server/internal/handler/comment.go`), a comment that carries an `@all`
-mention is treated as a broadcast that SUPPRESSES the issue assignee's
-automatic on-comment trigger. Use `@all` to announce, not to request work from
-the assignee.
+And it is special at trigger time: a comment that carries an `@all` mention is
+treated as a broadcast that SUPPRESSES the issue assignee's automatic
+on-comment trigger (and the other implicit routing fallbacks — thread parent /
+conversation owner). Use `@all` to announce, not to request work from the
+assignee.
+
+`@all` only suppresses those IMPLICIT routes. An EXPLICIT `@agent` / `@squad`
+mention in the same comment still fires normally (MUL-5411): a comment reading
+`[@all](mention://all/all) heads up — [@Preflight](mention://agent/<uuid>)
+please take this` enqueues Preflight and nobody else. Explicit mentions win over
+the broadcast; see `computeCommentAgentTriggers` in
+`server/internal/handler/comment.go`, where the explicit-mention branch is
+evaluated BEFORE the `@all` short-circuit.
 
 ## What does NOT happen (so the result doesn't surprise you)
 

--- a/server/internal/service/builtin_skills/multica-mentioning/SKILL.md
+++ b/server/internal/service/builtin_skills/multica-mentioning/SKILL.md
@@ -121,7 +121,10 @@ These are all silent no-ops — no error, no run:
 - **A hex-ish but wrong UUID.** A well-formed-looking UUID that no entity owns
   DOES parse, then no-ops at lookup: the workspace-scoped query finds no agent
   and the loop `continue`s. Same agent-visible result (nothing fires), but the
-  mechanism is the lookup miss, not a parse failure.
+  mechanism is the lookup miss, not a parse failure. An id that matches the
+  pattern but is NOT a valid UUID at all (`mention://agent/-`) is rejected by
+  the id parser itself and reported as a blocked mention with the same
+  enumeration-safe reason code — never an error response.
 - **An already-pending task.** Even a correct `@agent`/`@squad` is skipped when
   the target already has a pending task on this issue
   (`HasPendingTaskForIssueAndAgent` → `continue`). Edit preview is the only

--- a/server/internal/service/builtin_skills/multica-mentioning/references/mentioning-source-map.md
+++ b/server/internal/service/builtin_skills/multica-mentioning/references/mentioning-source-map.md
@@ -96,10 +96,11 @@ a pointer.
 
 | Fact | Source |
 | --- | --- |
-| `commentMentionsOthersButNotAssignee` — decides whether to suppress the assignee's on-comment trigger | `server/internal/handler/comment.go:1246-1288` |
-| `@all` is treated as a broadcast → returns true → assignee auto-trigger suppressed | `server/internal/handler/comment.go:1257-1261` |
-| Comment-flow computation that consults it | `server/internal/handler/comment.go:1175-1177` |
-| `@all` never enqueues a specific agent: it is neither `squad` nor `agent`, so it is skipped in the mention trigger computation | `server/internal/handler/comment.go:1437-1439` |
+| `HasMentionAll` reports whether any parsed mention is `all` | `server/internal/util/mention.go` (search `func HasMentionAll`) |
+| `@all` with no explicit `@agent`/`@squad` suppresses every implicit route (assignee / thread parent / conversation) → no run | `server/internal/handler/comment.go` (search `if util.HasMentionAll(mentions)` inside `computeCommentAgentTriggers`) |
+| `@all` does NOT suppress an EXPLICIT `@agent`/`@squad` in the same comment — the explicit branch is evaluated first (MUL-5411) | `server/internal/handler/comment.go` (the `hasAgentOrSquadMention` branch immediately above the `HasMentionAll` short-circuit) |
+| `@all` never enqueues a specific agent: it is neither `squad` nor `agent`, so it is skipped in the mention trigger computation | `server/internal/handler/comment.go` (search `if m.Type != "agent"` in `resolveMentionedAgentCommentTriggers`) |
+| Tests: `@all` alone → 0 agents; `@all` + `@agent` → the mentioned agent only; `@all` + `@squad` → the leader; `@all` + `@member` → 0 agents | `server/internal/handler/comment_trigger_preview_test.go` (search `AllPlusExplicitAgentMentionStillTriggers`) |
 
 ## CLI id sources (where the UUID comes from)
 

--- a/server/internal/service/builtin_skills/multica-mentioning/references/mentioning-source-map.md
+++ b/server/internal/service/builtin_skills/multica-mentioning/references/mentioning-source-map.md
@@ -101,6 +101,7 @@ a pointer.
 | `@all` does NOT suppress an EXPLICIT `@agent`/`@squad` in the same comment — the explicit branch is evaluated first (MUL-5411) | `server/internal/handler/comment.go` (the `hasAgentOrSquadMention` branch immediately above the `HasMentionAll` short-circuit) |
 | `@all` never enqueues a specific agent: it is neither `squad` nor `agent`, so it is skipped in the mention trigger computation | `server/internal/handler/comment.go` (search `if m.Type != "agent"` in `resolveMentionedAgentCommentTriggers`) |
 | Tests: `@all` alone → 0 agents; `@all` + `@agent` → the mentioned agent only; `@all` + `@squad` → the leader; `@all` + `@member` → 0 agents | `server/internal/handler/comment_trigger_preview_test.go` (search `AllPlusExplicitAgentMentionStillTriggers`) |
+| A mention id that matches `MentionRe` but is not a valid UUID (`mention://agent/-`) is parsed with the error-returning `util.ParseUUID` and reported as a blocked mention — never a panic / 500 | `server/internal/handler/comment.go` (search `util.ParseUUID(m.ID)` in `resolveMentionedAgentCommentTriggers`); test `server/internal/handler/comment_trigger_preview_test.go` (search `MalformedMentionIDDoesNotPanic`) |
 
 ## CLI id sources (where the UUID comes from)
 


### PR DESCRIPTION
## Background

MUL-5411. A comment containing both `@all` and an explicit `@agent` triggered **nothing**. Real case: a comment with `@all` + `@Preflight` produced no Preflight task, while the same mention posted alone in a follow-up comment enqueued immediately.

Root cause is ordering inside `computeCommentAgentTriggers` (`server/internal/handler/comment.go`): the `util.HasMentionAll(mentions)` short-circuit ran **before** the explicit-mention branch, so any `@all` in the body cleared the whole trigger set — including targets the author named by hand.

## Change

Evaluate the explicit `@agent` / `@squad` branch first; keep the `@all` short-circuit immediately after it.

```go
if hasAgentOrSquadMention(mentions) {
    return h.resolveMentionedAgentCommentTriggers(...)
}
if util.HasMentionAll(mentions) {
    return nil, nil
}
```

`@all` now means what it was intended to mean: it suppresses only the **implicit** routes (issue assignee, thread parent, conversation owner). It never fans out to agents itself — `all` is neither `"agent"` nor `"squad"`, so it is still skipped inside `resolveMentionedAgentCommentTriggers`.

Behavior table:

| Comment | Before | After |
| --- | --- | --- |
| `@all` only | no run | no run (unchanged) |
| `@all` + `@agent` | **no run** | the mentioned agent runs |
| `@all` + `@squad` | **no run** | the squad leader runs |
| `@all` + `@member` | no run | no run (unchanged) |

Assignee behavior with `@all` + explicit mention is unchanged from any other explicit-mention comment: only the named target runs, the assignee fallback stays suppressed.

Also refreshed the builtin `multica-mentioning` skill and its source map — they described the old short-circuit and pointed at `commentMentionsOthersButNotAssignee`, a function that no longer exists (line-number references replaced with searchable symbol names).

## Testing

Local, against a migrated Postgres (`go build ./...` clean):

- `go test ./internal/handler/ ./cmd/server/ ./internal/util/ ./internal/service/` — all pass.
- New: `TestPreviewCommentTriggers_AllPlusExplicitAgentMentionStillTriggers`, `..._AllPlusExplicitSquadMentionStillTriggers`, `..._AllPlusMemberMentionStaysSuppressed` — cover both preview and create/enqueue paths.
- New subtest `TestCommentTriggerAtAllSuppression/@all with explicit @agent still triggers the agent` (end-to-end).
- Regression check: reverting only the reordering makes the two new "still triggers" tests fail, so they genuinely pin the fix.
- Existing `@all`-only suppression assertions (integration + preview + squad routing) still pass, so the broadcast semantics did not regress.

## Review focus

The ordering of the three mention branches. `@all` + `@member` must stay suppressed (covered), and the explicit-mention path already carries every gate it needs — invoke/private-agent gate, archived/offline checks, pending dedup — so nothing new can slip past authorization.
