### PR TITLE
refactor(agent): drop unreachable inline system-prompt branches (MUL-5392)

### DIFF
--- a/server/internal/daemon/daemon.go
+++ b/server/internal/daemon/daemon.go
@@ -3887,6 +3887,24 @@ func providerDisplayName(name string) string {
 	return strings.ToUpper(name[:1]) + name[1:]
 }
 
+// providerNeedsInlineSystemPrompt reports whether the runtime brief must ride
+// along in the turn itself (agent.ExecOptions.SystemPrompt) because the CLI
+// will not pick up the per-task context file execenv writes into the workdir.
+// This is the ONLY place that decides it, and it is the reason every other
+// backend sees an empty SystemPrompt.
+//
+// Adding a provider here is a real fix only when that CLI genuinely ignores its
+// context file — traecli was added because it reads .trae/rules/ and not
+// AGENTS.md, so its agents were silently missing the workflow section and left
+// issues stuck in `todo` with no comment and no error. Adding one that DOES
+// read the file just duplicates the brief on every turn.
+//
+// Confirmed to load their context file, so deliberately absent here. MUL-5392
+// probed each one over its real launch path with a canary in the context file
+// and no inline delivery: claude 2.1.220 (CLAUDE.md), codex 0.144.6 driving the
+// app-server (AGENTS.md), opencode 1.17.7 (AGENTS.md), pi 0.67.2 (AGENTS.md),
+// hermes 0.18.2 over ACP (AGENTS.md). kiro was confirmed earlier by a kiro-cli
+// 2.13.0 ACP smoke — see the call site. Still unprobed: grok, qoder, codebuddy.
 func providerNeedsInlineSystemPrompt(provider string) bool {
 	switch provider {
 	case "openclaw", "kimi", "traecli":

--- a/server/pkg/agent/agent.go
+++ b/server/pkg/agent/agent.go
@@ -25,9 +25,14 @@ type Backend interface {
 type ExecOptions struct {
 	Cwd   string
 	Model string
-	// SystemPrompt is consumed only by providers that can pass or safely inline
-	// developer/system instructions. Hermes ACP intentionally ignores it and
-	// relies on cwd-scoped context files such as AGENTS.md instead.
+	// SystemPrompt carries the Multica runtime brief for the few providers
+	// that cannot pick it up from disk. The daemon leaves it empty for every
+	// other provider (see daemon.providerNeedsInlineSystemPrompt), because the
+	// brief is already delivered as a per-task context file in the workdir —
+	// CLAUDE.md, AGENTS.md, CODEBUDDY.md or QWEN.md depending on the runtime.
+	//
+	// A backend must therefore NOT assume this is populated, and adding a new
+	// backend that only reads SystemPrompt will silently receive nothing.
 	SystemPrompt              string
 	ThreadName                string
 	MaxTurns                  int

--- a/server/pkg/agent/claude.go
+++ b/server/pkg/agent/claude.go
@@ -699,9 +699,10 @@ func buildClaudeArgs(opts ExecOptions, logger *slog.Logger) []string {
 	if opts.MaxTurns > 0 {
 		args = append(args, "--max-turns", fmt.Sprintf("%d", opts.MaxTurns))
 	}
-	if opts.SystemPrompt != "" {
-		args = append(args, "--append-system-prompt", opts.SystemPrompt)
-	}
+	// SystemPrompt is intentionally not forwarded as --append-system-prompt:
+	// Claude Code loads the per-task CLAUDE.md the daemon writes into the
+	// workdir, so inlining the same runtime brief would duplicate it on every
+	// turn. Verified against Claude Code 2.1.220 (MUL-5392).
 	if opts.ResumeSessionID != "" {
 		args = append(args, "--resume", opts.ResumeSessionID)
 	}

--- a/server/pkg/agent/claude_test.go
+++ b/server/pkg/agent/claude_test.go
@@ -346,6 +346,23 @@ func TestBuildClaudeArgsUsesStrictMCPForManagedConfig(t *testing.T) {
 	}
 }
 
+// Claude Code reads the per-task CLAUDE.md the daemon writes into the workdir,
+// so the daemon never populates SystemPrompt for it (see
+// providerNeedsInlineSystemPrompt). Forwarding it as --append-system-prompt
+// would duplicate the whole runtime brief on every turn.
+func TestBuildClaudeArgsIgnoresSystemPrompt(t *testing.T) {
+	t.Parallel()
+
+	const brief = "the entire multica runtime brief"
+	args := buildClaudeArgs(ExecOptions{SystemPrompt: brief}, slog.Default())
+	if slices.Contains(args, "--append-system-prompt") {
+		t.Fatalf("unexpected --append-system-prompt in args: %v", args)
+	}
+	if slices.Contains(args, brief) {
+		t.Fatalf("SystemPrompt leaked into args: %v", args)
+	}
+}
+
 func TestArgsRequestBypassPermissions(t *testing.T) {
 	t.Parallel()
 

--- a/server/pkg/agent/codex.go
+++ b/server/pkg/agent/codex.go
@@ -1561,11 +1561,13 @@ func (c *codexClient) startOrResumeThread(ctx context.Context, opts ExecOptions,
 	if priorThreadID := opts.ResumeSessionID; priorThreadID != "" {
 		// thread/resume reuses the thread's persisted model and reasoning
 		// effort; only override fields the daemon actually cares about.
+		// developerInstructions stays nil for the reason given on thread/start
+		// below.
 		resumeParams := map[string]any{
 			"threadId":              priorThreadID,
 			"cwd":                   opts.Cwd,
 			"model":                 nilIfEmpty(opts.Model),
-			"developerInstructions": nilIfEmpty(opts.SystemPrompt),
+			"developerInstructions": nil,
 		}
 		// Explicit override of the persisted reasoning effort: without
 		// this, a Codex resume silently reuses whatever level the prior
@@ -1589,6 +1591,12 @@ func (c *codexClient) startOrResumeThread(ctx context.Context, opts ExecOptions,
 		}
 	}
 
+	// developerInstructions is always nil: a thread started with this cwd loads
+	// the per-task AGENTS.md the daemon wrote there, so the runtime brief is
+	// already in context and inlining it would duplicate it on every turn.
+	// Confirmed end-to-end against codex-cli 0.144.6 driving the real
+	// app-server (thread/start -> turn/start) with developerInstructions unset
+	// (MUL-5392).
 	startParams := map[string]any{
 		"model":                  nilIfEmpty(opts.Model),
 		"modelProvider":          nil,
@@ -1598,7 +1606,7 @@ func (c *codexClient) startOrResumeThread(ctx context.Context, opts ExecOptions,
 		"sandbox":                nil,
 		"config":                 nil,
 		"baseInstructions":       nil,
-		"developerInstructions":  nilIfEmpty(opts.SystemPrompt),
+		"developerInstructions":  nil,
 		"compactPrompt":          nil,
 		"includeApplyPatchTool":  nil,
 		"experimentalRawEvents":  false,

--- a/server/pkg/agent/codex_test.go
+++ b/server/pkg/agent/codex_test.go
@@ -1790,6 +1790,74 @@ func TestCodexStartOrResumeThreadResumesPriorThread(t *testing.T) {
 	}
 }
 
+// codexRuntimeBriefCanary stands in for the Multica runtime brief the daemon
+// would inline if developerInstructions were ever wired back up.
+const codexRuntimeBriefCanary = "MULTICA-RUNTIME-BRIEF-CANARY"
+
+// assertNoDeveloperInstructions pins the MUL-5392 contract: Codex loads the
+// per-task AGENTS.md from the thread's cwd, so the daemon never inlines the
+// runtime brief here. The field must still be sent — the app-server treats a
+// missing key differently from an explicit null — but always as null.
+func assertNoDeveloperInstructions(t *testing.T, params map[string]any) {
+	t.Helper()
+	got, ok := params["developerInstructions"]
+	if !ok {
+		t.Error("developerInstructions must be sent explicitly, even when null")
+		return
+	}
+	if got != nil {
+		t.Errorf("developerInstructions = %v, want null: the runtime brief is delivered via the workdir AGENTS.md, not inline (MUL-5392)", got)
+	}
+}
+
+func TestCodexThreadStartNeverInlinesSystemPrompt(t *testing.T) {
+	t.Parallel()
+
+	c, fs, _ := newTestCodexClient(t)
+
+	wait := drainRPCScript(t, c, fs, []rpcResponse{
+		{
+			method:   "thread/start",
+			result:   json.RawMessage(`{"thread":{"id":"thr_fresh"}}`),
+			assertFn: assertNoDeveloperInstructions,
+		},
+	})
+	defer wait()
+
+	// SystemPrompt is set deliberately; it must not reach the app-server.
+	if _, _, err := c.startOrResumeThread(
+		context.Background(),
+		ExecOptions{Cwd: "/work", SystemPrompt: codexRuntimeBriefCanary},
+		slog.Default(),
+	); err != nil {
+		t.Fatalf("startOrResumeThread: %v", err)
+	}
+}
+
+func TestCodexThreadResumeNeverInlinesSystemPrompt(t *testing.T) {
+	t.Parallel()
+
+	c, fs, _ := newTestCodexClient(t)
+
+	wait := drainRPCScript(t, c, fs, []rpcResponse{
+		{
+			method:   "thread/resume",
+			result:   json.RawMessage(`{"thread":{"id":"thr_prior"}}`),
+			assertFn: assertNoDeveloperInstructions,
+		},
+	})
+	defer wait()
+
+	// SystemPrompt is set deliberately; it must not reach the app-server.
+	if _, _, err := c.startOrResumeThread(
+		context.Background(),
+		ExecOptions{Cwd: "/work", ResumeSessionID: "thr_prior", SystemPrompt: codexRuntimeBriefCanary},
+		slog.Default(),
+	); err != nil {
+		t.Fatalf("startOrResumeThread: %v", err)
+	}
+}
+
 func TestCodexStartOrResumeThreadFallsBackOnResumeError(t *testing.T) {
 	t.Parallel()
 

--- a/server/pkg/agent/opencode.go
+++ b/server/pkg/agent/opencode.go
@@ -85,9 +85,12 @@ func (b *opencodeBackend) Execute(ctx context.Context, prompt string, opts ExecO
 	if opts.ThinkingLevel != "" {
 		args = append(args, "--variant", opts.ThinkingLevel)
 	}
-	if opts.SystemPrompt != "" {
-		args = append(args, "--prompt", opts.SystemPrompt)
-	}
+	// OpenCode's `run` subcommand has no --prompt flag — passing one makes the
+	// CLI exit 1 with a usage dump before sending anything (checked against
+	// OpenCode 1.17.7). SystemPrompt is therefore never forwarded; the runtime
+	// brief reaches the agent through the per-task AGENTS.md the daemon writes
+	// into the workdir, which OpenCode loads itself (MUL-5392). Same constraint
+	// as the DevEco backend, which was forked from this one.
 	if opts.MaxTurns > 0 {
 		b.cfg.Logger.Warn("opencode does not support --max-turns; ignoring", "maxTurns", opts.MaxTurns)
 	}

--- a/server/pkg/agent/opencode_test.go
+++ b/server/pkg/agent/opencode_test.go
@@ -1223,6 +1223,68 @@ func TestOpencodeBackendAnchorsDirAndPWD(t *testing.T) {
 	}
 }
 
+// TestOpencodeBackendNeverEmitsPromptFlag pins MUL-5392: `opencode run` has no
+// --prompt flag, so emitting one makes the real CLI exit 1 with a usage dump
+// before a single token is sent. The backend carried that dead branch from the
+// day OpenCode was added (#341); it never fired because the daemon leaves
+// SystemPrompt empty for opencode, which is the correct delivery path — the
+// runtime brief reaches the agent through the workdir AGENTS.md instead. This
+// test exists so re-adding the flag fails here rather than in production.
+func TestOpencodeBackendNeverEmitsPromptFlag(t *testing.T) {
+	t.Parallel()
+
+	tempDir := t.TempDir()
+	argsFile := filepath.Join(tempDir, "argv.txt")
+	fakePath := filepath.Join(tempDir, "opencode")
+	writeTestExecutable(t, fakePath, []byte(fakeOpencodeScript()))
+
+	workDir := t.TempDir()
+
+	backend, err := New("opencode", Config{
+		ExecutablePath: fakePath,
+		Logger:         slog.Default(),
+		Env:            map[string]string{"OPENCODE_ARGS_FILE": argsFile},
+	})
+	if err != nil {
+		t.Fatalf("new opencode backend: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	// SystemPrompt is set deliberately; the backend must NOT forward it.
+	const brief = "the entire multica runtime brief"
+	session, err := backend.Execute(ctx, "do the thing", ExecOptions{
+		Cwd:          workDir,
+		SystemPrompt: brief,
+		Timeout:      5 * time.Second,
+	})
+	if err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	go func() {
+		for range session.Messages {
+		}
+	}()
+	<-session.Result
+
+	raw, err := os.ReadFile(argsFile)
+	if err != nil {
+		t.Fatalf("read args file: %v", err)
+	}
+	args := strings.Split(strings.TrimSpace(string(raw)), "\n")
+	if containsString(args, "--prompt") {
+		t.Errorf("argv must NOT contain --prompt (OpenCode's run has no such flag): %v", args)
+	}
+	if containsString(args, brief) {
+		t.Errorf("SystemPrompt leaked into argv: %v", args)
+	}
+	// The user prompt is still the final positional arg.
+	if len(args) == 0 || args[len(args)-1] != "do the thing" {
+		t.Errorf("expected prompt as final positional arg, got %v", args)
+	}
+}
+
 func TestOpencodeBackendInjectsThinkingVariant(t *testing.T) {
 	t.Parallel()
 

--- a/server/pkg/agent/pi.go
+++ b/server/pkg/agent/pi.go
@@ -491,7 +491,6 @@ var piBlockedArgs = map[string]blockedArgMode{
 //	--session <path>            session log file (created upfront, reused on resume)
 //	--provider <name>           provider, when Model is "provider/id"
 //	--model <id>                model identifier
-//	--append-system-prompt <s>  extra system instructions
 //
 // Custom args appended before the positional prompt. The prompt is a
 // positional argument and must be last.

--- a/server/pkg/agent/pi.go
+++ b/server/pkg/agent/pi.go
@@ -517,9 +517,11 @@ func buildPiArgs(prompt, sessionPath string, opts ExecOptions, logger *slog.Logg
 	// tools. Passing --tools acts as a restrictive allowlist that
 	// silently filters out extension-registered tools (#2379).
 	// Users who want to restrict tools can do so via custom_args.
-	if opts.SystemPrompt != "" {
-		args = append(args, "--append-system-prompt", opts.SystemPrompt)
-	}
+	//
+	// SystemPrompt is intentionally not forwarded as --append-system-prompt:
+	// Pi loads the per-task AGENTS.md the daemon writes into the workdir, so
+	// inlining the same runtime brief would duplicate it on every turn.
+	// Verified against Pi 0.67.2 (MUL-5392).
 	args = append(args, filterCustomArgs(opts.CustomArgs, piBlockedArgs, logger)...)
 	args = append(args, prompt)
 	return args

--- a/server/pkg/agent/pi_test.go
+++ b/server/pkg/agent/pi_test.go
@@ -24,12 +24,11 @@ func TestBuildPiArgsNoToolAllowlist(t *testing.T) {
 
 func TestBuildPiArgsBasicFlags(t *testing.T) {
 	args := buildPiArgs("hello world", "/tmp/s.jsonl", ExecOptions{
-		Model:        "anthropic/claude-sonnet-4-20250514",
-		SystemPrompt: "be helpful",
+		Model: "anthropic/claude-sonnet-4-20250514",
 	}, slog.Default())
 
 	joined := strings.Join(args, " ")
-	for _, want := range []string{"-p", "--mode json", "--session /tmp/s.jsonl", "--provider anthropic", "--model claude-sonnet-4-20250514", "--append-system-prompt"} {
+	for _, want := range []string{"-p", "--mode json", "--session /tmp/s.jsonl", "--provider anthropic", "--model claude-sonnet-4-20250514"} {
 		if !strings.Contains(joined, want) {
 			t.Errorf("expected %q in args, got: %v", want, args)
 		}
@@ -38,6 +37,24 @@ func TestBuildPiArgsBasicFlags(t *testing.T) {
 	// Prompt must be the last positional argument.
 	if args[len(args)-1] != "hello world" {
 		t.Errorf("prompt should be last arg, got %q", args[len(args)-1])
+	}
+}
+
+// Pi reads the per-task AGENTS.md the daemon writes into the workdir, so the
+// daemon never populates SystemPrompt for it (providerNeedsInlineSystemPrompt).
+// Forwarding it anyway would duplicate the whole runtime brief on every turn.
+func TestBuildPiArgsIgnoresSystemPrompt(t *testing.T) {
+	args := buildPiArgs("hello world", "/tmp/s.jsonl", ExecOptions{
+		SystemPrompt: "the entire multica runtime brief",
+	}, slog.Default())
+
+	for _, a := range args {
+		if a == "--append-system-prompt" {
+			t.Fatalf("unexpected --append-system-prompt in args: %v", args)
+		}
+		if a == "the entire multica runtime brief" {
+			t.Fatalf("SystemPrompt leaked into args: %v", args)
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary

`agent.ExecOptions.SystemPrompt` carries the Multica runtime brief inline. The daemon populates it in exactly one place, behind a whitelist:

```go
func providerNeedsInlineSystemPrompt(provider string) bool {
	switch provider {
	case "openclaw", "kimi", "traecli":
		return true
	default:
		return false
	}
}
```

Every other backend gets the brief as a per-task context file in the workdir (`CLAUDE.md` / `AGENTS.md` / `CODEBUDDY.md` / `QWEN.md`) — so the `if opts.SystemPrompt != ""` branches in `claude`, `codex`, `opencode` and `pi` could never fire. They read as if they were the live delivery path, which is actively misleading: the next person debugging brief delivery for one of these runtimes would look at the wrong mechanism.

This PR removes those four branches and pins the contract with tests. **Runtime behaviour is unchanged** — every deleted branch was already unreachable.

## `opencode` was worse than dead code

`opencode run` has **no `--prompt` flag**. Passing one makes the CLI exit 1 with a usage dump before sending a single token:

```
$ opencode run --dir . --dangerously-skip-permissions --prompt "..." "Say hello."
<usage dump>
$ echo $?
1
```

So the branch wasn't a dormant fallback — it was a trap. Anyone "fixing" opencode brief delivery by adding `"opencode"` to the whitelist would have broken every opencode task at launch, with a yargs usage dump as the only diagnostic.

The `deveco` backend, forked from `opencode`, already documents this exact constraint (`deveco.go`: *"DevEco's `run` subcommand has no --prompt flag…"*, plus `TestDevecoBackendArgvShapeAndNoPrompt`). The fix just never made it back to the file it was forked from.

## How this was verified

Not inferred from docs. Each backend was launched over **its real production path** — same argv / RPC params as the Go code, `SystemPrompt` and `developerInstructions` left empty — against a workdir whose context file contained a random canary token, then asked for the token with tool use disallowed:

| backend | version | launch path exercised | result |
|---|---|---|---|
| claude | 2.1.220 | `claude -p`, cwd=workdir | ✅ read `CLAUDE.md` |
| codex | 0.144.6 | `codex app-server` → `thread/start{cwd}` → `turn/start` | ✅ read `AGENTS.md` |
| opencode | 1.17.7 | `opencode run --dir` | ✅ read `AGENTS.md` |
| pi | 0.67.2 | `pi -p --mode json`, cwd=workdir | ✅ read `AGENTS.md` |
| hermes | 0.18.2 | ACP `session/new{cwd}` → `session/prompt` | ✅ read `AGENTS.md` |

Negative control: the same probe against an empty workdir returned `NONE`, so it can detect a CLI that *doesn't* read its file.

## Changes

- `claude.go` / `pi.go` / `opencode.go` — drop the dead branch, leave a comment naming the real delivery path and the version it was checked against
- `codex.go` — `developerInstructions` is now a literal `nil` at both `thread/start` and `thread/resume` instead of `nilIfEmpty(opts.SystemPrompt)`, which was always nil
- `agent.go` — `ExecOptions.SystemPrompt` doc states the contract: the daemon leaves it empty for everything outside the whitelist, so a backend must not assume it is populated
- `daemon.go` — `providerNeedsInlineSystemPrompt` gets a doc comment recording *why* a provider belongs on the list (traecli reads `.trae/rules/`, not `AGENTS.md`), what was verified, and what is still unprobed

**Deliberately untouched:** `hermes.go:202` is an explicit no-op with a debug log, not a dead branch, and hermes + kiro exclusions are already covered by `TestProviderNeedsInlineSystemPrompt` — kiro's rests on the kiro-cli 2.13.0 ACP smoke recorded in `21613131c fix(kiro): stop repeating runtime brief every turn (#5605)`. `grok`, `qoder` and `codebuddy` are left exactly as they are — they haven't been probed yet (see below).

## Testing

- `TestBuildClaudeArgsIgnoresSystemPrompt`, `TestBuildPiArgsIgnoresSystemPrompt`, `TestOpencodeBackendNeverEmitsPromptFlag` — new; each asserts the flag is absent **and** that the brief never leaks into argv
- `TestCodexThreadStartNeverInlinesSystemPrompt`, `TestCodexThreadResumeNeverInlinesSystemPrompt` — new; both run with a canary `SystemPrompt` and assert `developerInstructions` arrives as an explicit null (present-but-null, since the app-server distinguishes that from a missing key)
- `TestBuildPiArgsBasicFlags` — dropped its `--append-system-prompt` expectation
- Mutation-checked: reverting any of the five sites fails exactly its own test, then restored
- `go build ./...`, `go vet`, `go test ./pkg/agent/... ./internal/daemon/...` all pass locally

## Follow-up (not in this PR)

Three backends still haven't been probed: **grok, qoder, codebuddy**. (Kiro is *not* one of them — its exclusion rests on the kiro-cli 2.13.0 ACP smoke recorded in #5605.) If any of the three doesn't read the file we write, its agents are silently receiving no runtime brief at all — the traecli failure mode: the agent doesn't know the `multica` CLI exists, so the issue stays in `todo` with no comment while the task logs `completed` with no error. That's tracked in MUL-5392 and is the higher-value half of the work; this PR deliberately leaves those three alone rather than guessing.

