### PR TITLE
MUL-5406: propagate non-ErrNoRows scope DB errors

### DIFF
--- a/server/cmd/server/scope_authorizer.go
+++ b/server/cmd/server/scope_authorizer.go
@@ -2,7 +2,9 @@ package main
 
 import (
 	"context"
+	"errors"
 
+	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgtype"
 	"github.com/multica-ai/multica/server/internal/realtime"
 	"github.com/multica-ai/multica/server/internal/util"
@@ -28,6 +30,20 @@ type dbScopeAuthorizer struct{ q scopeAuthQuerier }
 
 func newScopeAuthorizer(q scopeAuthQuerier) *dbScopeAuthorizer { return &dbScopeAuthorizer{q: q} }
 
+// scopeLookupErr converts a scope-resource query error into an authorizer
+// result. A missing resource (pgx.ErrNoRows) is a legitimate denial — the
+// HTTP layer treats not-found as 404 rather than 403, so the realtime layer
+// reports it as a plain "forbidden" refusal. Any other error (pool
+// exhaustion, a cancelled context, a network blip) is a transient lookup
+// failure and must propagate so handleSubscribe reports "lookup_failed"
+// instead of masking a database outage as a wave of permission denials.
+func scopeLookupErr(err error) (bool, error) {
+	if errors.Is(err, pgx.ErrNoRows) {
+		return false, nil
+	}
+	return false, err
+}
+
 func (a *dbScopeAuthorizer) AuthorizeScope(ctx context.Context, userID, workspaceID, scopeType, scopeID string) (bool, error) {
 	if workspaceID == "" || scopeID == "" {
 		return false, nil
@@ -44,13 +60,13 @@ func (a *dbScopeAuthorizer) AuthorizeScope(ctx context.Context, userID, workspac
 	case realtime.ScopeTask:
 		task, err := a.q.GetAgentTask(ctx, idUUID)
 		if err != nil {
-			return false, nil
+			return scopeLookupErr(err)
 		}
 		// Issue tasks: visible to any workspace member.
 		if task.IssueID.Valid {
 			issue, err := a.q.GetIssue(ctx, task.IssueID)
 			if err != nil {
-				return false, nil
+				return scopeLookupErr(err)
 			}
 			return issue.WorkspaceID == wsUUID, nil
 		}
@@ -59,7 +75,7 @@ func (a *dbScopeAuthorizer) AuthorizeScope(ctx context.Context, userID, workspac
 		if task.ChatSessionID.Valid {
 			sess, err := a.q.GetChatSession(ctx, task.ChatSessionID)
 			if err != nil {
-				return false, nil
+				return scopeLookupErr(err)
 			}
 			if sess.WorkspaceID != wsUUID {
 				return false, nil
@@ -74,7 +90,7 @@ func (a *dbScopeAuthorizer) AuthorizeScope(ctx context.Context, userID, workspac
 	case realtime.ScopeChat:
 		sess, err := a.q.GetChatSession(ctx, idUUID)
 		if err != nil {
-			return false, nil
+			return scopeLookupErr(err)
 		}
 		if sess.WorkspaceID != wsUUID {
 			return false, nil

--- a/server/cmd/server/scope_authorizer_test.go
+++ b/server/cmd/server/scope_authorizer_test.go
@@ -280,4 +280,3 @@ func TestScopeAuthorizer_MissingResourceIsPlainDenial(t *testing.T) {
 		t.Fatalf("missing chat session must be a plain denial: ok=%v err=%v", ok, err)
 	}
 }
-

--- a/server/cmd/server/scope_authorizer_test.go
+++ b/server/cmd/server/scope_authorizer_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgtype"
 	"github.com/multica-ai/multica/server/internal/realtime"
 	db "github.com/multica-ai/multica/server/pkg/db/generated"
@@ -22,19 +23,19 @@ func (f *fakeScopeQuerier) GetAgentTask(_ context.Context, id pgtype.UUID) (db.A
 	if t, ok := f.tasks[id.Bytes]; ok {
 		return t, nil
 	}
-	return db.AgentTaskQueue{}, errors.New("not found")
+	return db.AgentTaskQueue{}, pgx.ErrNoRows
 }
 func (f *fakeScopeQuerier) GetIssue(_ context.Context, id pgtype.UUID) (db.Issue, error) {
 	if i, ok := f.issues[id.Bytes]; ok {
 		return i, nil
 	}
-	return db.Issue{}, errors.New("not found")
+	return db.Issue{}, pgx.ErrNoRows
 }
 func (f *fakeScopeQuerier) GetChatSession(_ context.Context, id pgtype.UUID) (db.ChatSession, error) {
 	if s, ok := f.sessions[id.Bytes]; ok {
 		return s, nil
 	}
-	return db.ChatSession{}, errors.New("not found")
+	return db.ChatSession{}, pgx.ErrNoRows
 }
 
 func mustUUID(t *testing.T) (string, pgtype.UUID) {
@@ -184,3 +185,99 @@ func TestScopeAuthorizer_IssueTaskWorkspaceOnly(t *testing.T) {
 		t.Fatalf("cross-workspace must be denied: ok=%v err=%v", ok, err)
 	}
 }
+
+// failingScopeQuerier returns a non-ErrNoRows error from every lookup,
+// simulating a transient database failure (pool exhaustion, cancelled
+// context, network blip). Such errors must propagate out of AuthorizeScope
+// so handleSubscribe reports "lookup_failed" rather than "forbidden".
+type failingScopeQuerier struct{}
+
+func (failingScopeQuerier) GetAgentTask(context.Context, pgtype.UUID) (db.AgentTaskQueue, error) {
+	return db.AgentTaskQueue{}, errors.New("connection reset by peer")
+}
+func (failingScopeQuerier) GetIssue(context.Context, pgtype.UUID) (db.Issue, error) {
+	return db.Issue{}, errors.New("connection reset by peer")
+}
+func (failingScopeQuerier) GetChatSession(context.Context, pgtype.UUID) (db.ChatSession, error) {
+	return db.ChatSession{}, errors.New("connection reset by peer")
+}
+
+// errOnInnerQuerier succeeds for GetAgentTask (so the task path reaches its
+// inner lookups) but fails GetIssue / GetChatSession with a non-ErrNoRows
+// error. This isolates the inner lookup points from the outer GetAgentTask.
+type errOnInnerQuerier struct {
+	task db.AgentTaskQueue
+}
+
+func (q *errOnInnerQuerier) GetAgentTask(_ context.Context, _ pgtype.UUID) (db.AgentTaskQueue, error) {
+	return q.task, nil
+}
+func (*errOnInnerQuerier) GetIssue(context.Context, pgtype.UUID) (db.Issue, error) {
+	return db.Issue{}, errors.New("connection reset by peer")
+}
+func (*errOnInnerQuerier) GetChatSession(context.Context, pgtype.UUID) (db.ChatSession, error) {
+	return db.ChatSession{}, errors.New("connection reset by peer")
+}
+
+// TestScopeAuthorizer_DoesNotSwallowQueryErrors pins #6037: a real database
+// error at any of the four lookup points must be returned to the caller as a
+// non-nil error, not silently converted to a (false, nil) "forbidden" denial.
+// Only a missing resource (pgx.ErrNoRows) stays a plain denial.
+func TestScopeAuthorizer_DoesNotSwallowQueryErrors(t *testing.T) {
+	wsStr, _ := mustUUID(t)
+	userStr, _ := mustUUID(t)
+	taskStr, taskUUID := mustUUID(t)
+	_, issueUUID := mustUUID(t)
+	_, sessUUID := mustUUID(t)
+	chatScopeStr, _ := mustUUID(t)
+
+	a := newScopeAuthorizer(failingScopeQuerier{})
+	ctx := context.Background()
+
+	// Point 1: GetAgentTask fails on the task path.
+	if _, err := a.AuthorizeScope(ctx, userStr, wsStr, realtime.ScopeTask, taskStr); err == nil {
+		t.Fatalf("task-path GetAgentTask error must propagate, got err=nil")
+	}
+	// Point 4: GetChatSession fails on the chat path.
+	if _, err := a.AuthorizeScope(ctx, userStr, wsStr, realtime.ScopeChat, chatScopeStr); err == nil {
+		t.Fatalf("chat-path GetChatSession error must propagate, got err=nil")
+	}
+
+	// Point 2: GetIssue fails (task resolves to an issue task).
+	issueAuth := newScopeAuthorizer(&errOnInnerQuerier{
+		task: db.AgentTaskQueue{ID: taskUUID, IssueID: issueUUID},
+	})
+	if _, err := issueAuth.AuthorizeScope(ctx, userStr, wsStr, realtime.ScopeTask, taskStr); err == nil {
+		t.Fatalf("task-path GetIssue error must propagate, got err=nil")
+	}
+
+	// Point 3: GetChatSession fails on the task path (task resolves to a chat task).
+	chatTaskAuth := newScopeAuthorizer(&errOnInnerQuerier{
+		task: db.AgentTaskQueue{ID: taskUUID, ChatSessionID: sessUUID},
+	})
+	if _, err := chatTaskAuth.AuthorizeScope(ctx, userStr, wsStr, realtime.ScopeTask, taskStr); err == nil {
+		t.Fatalf("task-path GetChatSession error must propagate, got err=nil")
+	}
+}
+
+// TestScopeAuthorizer_MissingResourceIsPlainDenial pins the other half of
+// #6037: a missing resource (pgx.ErrNoRows) must remain a (false, nil)
+// denial — not-found is reported as "forbidden", matching the HTTP layer's
+// 404-not-403 convention.
+func TestScopeAuthorizer_MissingResourceIsPlainDenial(t *testing.T) {
+	wsStr, _ := mustUUID(t)
+	userStr, _ := mustUUID(t)
+	missingTask, _ := mustUUID(t)
+	missingChat, _ := mustUUID(t)
+
+	a := newScopeAuthorizer(&fakeScopeQuerier{})
+	ctx := context.Background()
+
+	if ok, err := a.AuthorizeScope(ctx, userStr, wsStr, realtime.ScopeTask, missingTask); err != nil || ok {
+		t.Fatalf("missing task must be a plain denial: ok=%v err=%v", ok, err)
+	}
+	if ok, err := a.AuthorizeScope(ctx, userStr, wsStr, realtime.ScopeChat, missingChat); err != nil || ok {
+		t.Fatalf("missing chat session must be a plain denial: ok=%v err=%v", ok, err)
+	}
+}
+

--- a/server/internal/realtime/hub_test.go
+++ b/server/internal/realtime/hub_test.go
@@ -83,6 +83,55 @@ func connectWS(t *testing.T, server *httptest.Server) *websocket.Conn {
 	return conn
 }
 
+type failingScopeAuthorizer struct{}
+
+func (failingScopeAuthorizer) AuthorizeScope(context.Context, string, string, string, string) (bool, error) {
+	return false, errors.New("database unavailable")
+}
+
+func TestClientHandleSubscribeReportsLookupFailure(t *testing.T) {
+	hub := NewHub()
+	hub.SetAuthorizer(failingScopeAuthorizer{})
+	client := &Client{
+		hub:           hub,
+		send:          make(chan []byte, 1),
+		userID:        testUserID,
+		workspaceID:   testWorkspaceID,
+		subscriptions: make(map[scopeKey]bool),
+	}
+
+	client.handleSubscribe(ScopeTask, "task-id")
+
+	select {
+	case raw := <-client.send:
+		var frame struct {
+			Type    string            `json:"type"`
+			Payload map[string]string `json:"payload"`
+		}
+		if err := json.Unmarshal(raw, &frame); err != nil {
+			t.Fatalf("unmarshal subscribe error: %v", err)
+		}
+		if frame.Type != "subscribe_error" {
+			t.Fatalf("frame type = %q, want subscribe_error", frame.Type)
+		}
+		if got := frame.Payload["error"]; got != "lookup_failed" {
+			t.Fatalf("error = %q, want lookup_failed", got)
+		}
+		if got := frame.Payload["scope"]; got != ScopeTask {
+			t.Fatalf("scope = %q, want %q", got, ScopeTask)
+		}
+		if got := frame.Payload["id"]; got != "task-id" {
+			t.Fatalf("id = %q, want task-id", got)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for subscribe_error")
+	}
+
+	if len(client.subscriptions) != 0 {
+		t.Fatalf("lookup failure must not subscribe client, got %d subscriptions", len(client.subscriptions))
+	}
+}
+
 // totalClients counts all currently registered clients.
 func totalClients(hub *Hub) int {
 	hub.mu.RLock()


### PR DESCRIPTION
## Summary

Closes #6037.
Closes MUL-5406.

`dbScopeAuthorizer.AuthorizeScope` returned `(false, nil)` on **every** query error at all four lookup points (`GetAgentTask`, `GetIssue`, `GetChatSession` ×2), masking transient DB failures as plain "forbidden" denials. This made the `lookup_failed` branch in `server/internal/realtime/hub.go` `handleSubscribe` unreachable dead code and hid database outages from users and operators — a wave of permission denials would surface instead of a single lookup-failed signal.

## Fix

Only `pgx.ErrNoRows` (a legitimate missing resource) yields `(false, nil)`; any other error (pool exhaustion, cancelled context, network blip) propagates as `(false, err)` so `handleSubscribe` reports `lookup_failed`.

A small helper centralizes the conversion:

```go
func scopeLookupErr(err error) (bool, error) {
	if errors.Is(err, pgx.ErrNoRows) {
		return false, nil
	}
	return false, err
}
```

This matches the codebase convention (`errors.Is(err, pgx.ErrNoRows)` is used in 20+ places) and the HTTP layer's 404-not-403 convention for not-found resources.

## Tests

- Updated `fakeScopeQuerier` to return `pgx.ErrNoRows` for misses (was `errors.New("not found")`) so the not-found denial semantics hold after the fix.
- Added `TestScopeAuthorizer_DoesNotSwallowQueryErrors` — pins that a non-`ErrNoRows` error at each of the four lookup points propagates as a non-nil error.
- Added `TestScopeAuthorizer_MissingResourceIsPlainDenial` — pins that `pgx.ErrNoRows` stays a `(false, nil)` denial.
- Added `TestClientHandleSubscribeReportsLookupFailure` — pins the realtime wire response as `subscribe_error` with `lookup_failed`, preserves scope/id, and confirms no subscription is created.

## Verification

- `go test -v ./internal/realtime -run '^TestClientHandleSubscribeReportsLookupFailure$' -count=1` — clean
- Targeted scope authorizer regression tests — clean
- `go test ./internal/realtime -count=1` — clean
- `go vet ./cmd/server ./internal/realtime` — clean
- `go build ./...` — clean
