### PR TITLE
Enqueue a run when an assigned issue is reopened into todo, and gate the direct-agent dispatch

### DIFF
--- a/packages/views/issues/components/batch-action-toolbar.tsx
+++ b/packages/views/issues/components/batch-action-toolbar.tsx
@@ -111,9 +111,10 @@ export function BatchActionToolbar({
   };
 
   // Batch status changes apply directly — no run-confirm modal (MUL-4155).
-  // done/cancelled can never start a run, and a backlog → active promotion now
-  // starts its run the same way a single-issue status change or the CLI does,
-  // without an extra confirmation step (product decision on MUL-4155). The
+  // moving TO done/cancelled can never start a run, and the moves that do
+  // (backlog → active, in_review/done/cancelled → todo) start their run the
+  // same way a single-issue status change or the CLI does, without an extra
+  // confirmation step (product decision on MUL-4155). The
   // status change was previously routed through the pre-trigger modal, which for
   // the common done/cancelled case only rendered a misleading "现在开始处理？ →
   // 不会开始处理" box. Agent/squad assignment still confirms via

--- a/server/internal/handler/issue.go
+++ b/server/internal/handler/issue.go
@@ -2968,7 +2968,8 @@ func (h *Handler) UpdateIssue(w http.ResponseWriter, r *http.Request) {
 		},
 		h.issueTriggerWriteProbe(r, actorType, issue),
 	); ok && !req.SuppressRun {
-		h.dispatchIssueRun(r.Context(), issue, trigger, actorType, actorID, req.HandoffNote)
+		h.dispatchIssueRun(r.Context(), issue, trigger, actorType, actorID,
+			h.invokeOriginatorFromRequest(r, actorType, actorID), req.HandoffNote)
 	}
 
 	// Platform-driven parent notification: when this issue transitions into
@@ -3466,7 +3467,8 @@ func (h *Handler) BatchUpdateIssues(w http.ResponseWriter, r *http.Request) {
 			},
 			h.issueTriggerWriteProbe(r, actorType, issue),
 		); ok && !req.Updates.SuppressRun {
-			h.dispatchIssueRun(r.Context(), issue, trigger, actorType, actorID, req.Updates.HandoffNote)
+			h.dispatchIssueRun(r.Context(), issue, trigger, actorType, actorID,
+				h.invokeOriginatorFromRequest(r, actorType, actorID), req.Updates.HandoffNote)
 		}
 
 		// No status change — not even → cancelled — cancels active tasks here,

--- a/server/internal/handler/issue_dispatch_private_agent_test.go
+++ b/server/internal/handler/issue_dispatch_private_agent_test.go
@@ -1,0 +1,217 @@
+package handler
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// previewIssueTriggerAs runs the preview endpoint as a specific member, so the
+// private-agent gate is evaluated against that member rather than the fixture's
+// workspace owner.
+func previewIssueTriggerAs(t *testing.T, userID string, body map[string]any) IssueTriggerPreviewResponse {
+	t.Helper()
+	w := httptest.NewRecorder()
+	req := newRequestAs(userID, "POST", "/api/issues/preview-trigger?workspace_id="+testWorkspaceID, body)
+	testHandler.PreviewIssueTrigger(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("PreviewIssueTrigger: expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	var resp IssueTriggerPreviewResponse
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode preview: %v", err)
+	}
+	return resp
+}
+
+// setIssueStatusAs drives the single-issue status-only write path as a specific
+// member — the shape `multica issue status <id> <status>` sends.
+func setIssueStatusAs(t *testing.T, userID, issueID, status string) {
+	t.Helper()
+	w := httptest.NewRecorder()
+	req := withURLParam(newRequestAs(userID, "PUT", "/api/issues/"+issueID, map[string]any{"status": status}), "id", issueID)
+	testHandler.UpdateIssue(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("UpdateIssue status=%s: expected 200, got %d: %s", status, w.Code, w.Body.String())
+	}
+}
+
+// batchSetIssueStatusAs drives the batch status-only write path as a specific
+// member.
+func batchSetIssueStatusAs(t *testing.T, userID string, issueIDs []string, status string) {
+	t.Helper()
+	w := httptest.NewRecorder()
+	req := newRequestAs(userID, "POST", "/api/issues/batch-update", map[string]any{
+		"issue_ids": issueIDs,
+		"updates":   map[string]any{"status": status},
+	})
+	testHandler.BatchUpdateIssues(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("BatchUpdateIssues status=%s: expected 200, got %d: %s", status, w.Code, w.Body.String())
+	}
+}
+
+// TestStatusSourceDispatchHonoursPrivateAgentGate is the permission-boundary
+// regression for the status source (both the backlog promotion and the reopen).
+//
+// UpdateIssue only runs validateAssigneePair when the write TOUCHES an assignee
+// field, so a status-only write never passed through the private-agent gate at
+// the HTTP boundary. Preview did evaluate canInvokeAgent, so a member with no
+// invoke permission saw total_count=0 and yet the very same write enqueued a
+// real task against the private agent — preview and the write path disagreed,
+// and an unauthorised member could spend a private agent's runtime.
+//
+// The gate now runs on the direct-agent dispatch, mirroring the squad branch's
+// canEnqueueSquadLeader. The status change itself still applies (existing
+// product semantics); only the task must not be created.
+func TestStatusSourceDispatchHonoursPrivateAgentGate(t *testing.T) {
+	if testHandler == nil {
+		t.Skip("database not available")
+	}
+
+	cases := []struct {
+		name       string
+		prevStatus string
+		baseNumber int
+	}{
+		{"reopen_from_in_review", "in_review", 92400},
+		{"reopen_from_done", "done", 92410},
+		{"promote_from_backlog", "backlog", 92420},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			agentID, ownerID, memberID := privateAgentTestFixture(t)
+
+			// --- unauthorised member: preview 0, write enqueues nothing ---
+			denied := insertAssignedIssueWithStatus(t, "agent", agentID, tc.baseNumber, tc.name+"-denied", tc.prevStatus)
+
+			pv := previewIssueTriggerAs(t, memberID, map[string]any{
+				"issue_ids": []string{denied}, "status": "todo",
+			})
+			if pv.TotalCount != 0 {
+				t.Fatalf("unauthorised member preview: expected 0 triggers, got %+v", pv)
+			}
+
+			setIssueStatusAs(t, memberID, denied, "todo")
+			if got := taskCountForIssue(t, denied); got != 0 {
+				t.Fatalf("unauthorised member must not enqueue against a private agent, got %d tasks", got)
+			}
+			if got := issueStatusOf(t, denied); got != "todo" {
+				t.Fatalf("the status change itself must still apply, got %q", got)
+			}
+
+			// --- agent owner: preview 1, write enqueues exactly one ---
+			allowed := insertAssignedIssueWithStatus(t, "agent", agentID, tc.baseNumber+1, tc.name+"-allowed", tc.prevStatus)
+
+			pvOwner := previewIssueTriggerAs(t, ownerID, map[string]any{
+				"issue_ids": []string{allowed}, "status": "todo",
+			})
+			if pvOwner.TotalCount != 1 {
+				t.Fatalf("agent owner preview: expected 1 trigger, got %+v", pvOwner)
+			}
+
+			setIssueStatusAs(t, ownerID, allowed, "todo")
+			if got := queuedTaskCountFor(t, allowed, agentID); got != 1 {
+				t.Fatalf("agent owner must get exactly 1 queued task, got %d", got)
+			}
+		})
+	}
+}
+
+// TestBatchStatusSourceDispatchHonoursPrivateAgentGate is the batch-path mirror:
+// the batch write shares the same predicate and dispatch, so the gate must hold
+// there too.
+func TestBatchStatusSourceDispatchHonoursPrivateAgentGate(t *testing.T) {
+	if testHandler == nil {
+		t.Skip("database not available")
+	}
+
+	agentID, ownerID, memberID := privateAgentTestFixture(t)
+
+	deniedReopen := insertAssignedIssueWithStatus(t, "agent", agentID, 92430, "batch-gate-denied-reopen", "in_review")
+	deniedPromote := insertAssignedIssueWithStatus(t, "agent", agentID, 92431, "batch-gate-denied-promote", "backlog")
+
+	pv := previewIssueTriggerAs(t, memberID, map[string]any{
+		"issue_ids": []string{deniedReopen, deniedPromote}, "status": "todo",
+	})
+	if pv.TotalCount != 0 {
+		t.Fatalf("unauthorised member batch preview: expected 0 triggers, got %+v", pv)
+	}
+
+	batchSetIssueStatusAs(t, memberID, []string{deniedReopen, deniedPromote}, "todo")
+	for _, id := range []string{deniedReopen, deniedPromote} {
+		if got := taskCountForIssue(t, id); got != 0 {
+			t.Fatalf("unauthorised member batch must not enqueue on %s, got %d tasks", id, got)
+		}
+	}
+
+	allowedReopen := insertAssignedIssueWithStatus(t, "agent", agentID, 92432, "batch-gate-allowed-reopen", "done")
+	allowedPromote := insertAssignedIssueWithStatus(t, "agent", agentID, 92433, "batch-gate-allowed-promote", "backlog")
+
+	pvOwner := previewIssueTriggerAs(t, ownerID, map[string]any{
+		"issue_ids": []string{allowedReopen, allowedPromote}, "status": "todo",
+	})
+	if pvOwner.TotalCount != 2 {
+		t.Fatalf("agent owner batch preview: expected 2 triggers, got %+v", pvOwner)
+	}
+
+	batchSetIssueStatusAs(t, ownerID, []string{allowedReopen, allowedPromote}, "todo")
+	for _, id := range []string{allowedReopen, allowedPromote} {
+		if got := queuedTaskCountFor(t, id, agentID); got != 1 {
+			t.Fatalf("agent owner batch: expected exactly 1 queued task on %s, got %d", id, got)
+		}
+	}
+}
+
+// TestAssignSourceDispatchStillEnqueuesForAuthorisedMember guards the other
+// direction: adding the dispatch gate must not silently swallow the run on the
+// assign source, which is already gated at the HTTP boundary. The agent owner
+// assigning their own private agent still gets a task; an unauthorised member
+// is rejected by validateAssigneePair with 403 before any of this.
+func TestAssignSourceDispatchStillEnqueuesForAuthorisedMember(t *testing.T) {
+	if testHandler == nil {
+		t.Skip("database not available")
+	}
+
+	agentID, ownerID, memberID := privateAgentTestFixture(t)
+
+	assigned := insertAssignedIssueWithStatus(t, "", "", 92440, "assign-gate-owner", "todo")
+	w := httptest.NewRecorder()
+	req := withURLParam(newRequestAs(ownerID, "PUT", "/api/issues/"+assigned, map[string]any{
+		"assignee_type": "agent", "assignee_id": agentID,
+	}), "id", assigned)
+	testHandler.UpdateIssue(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("owner assign: expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	if got := queuedTaskCountFor(t, assigned, agentID); got != 1 {
+		t.Fatalf("owner assign must still enqueue exactly 1 task, got %d", got)
+	}
+
+	rejected := insertAssignedIssueWithStatus(t, "", "", 92441, "assign-gate-member", "todo")
+	w2 := httptest.NewRecorder()
+	req2 := withURLParam(newRequestAs(memberID, "PUT", "/api/issues/"+rejected, map[string]any{
+		"assignee_type": "agent", "assignee_id": agentID,
+	}), "id", rejected)
+	testHandler.UpdateIssue(w2, req2)
+	if w2.Code != http.StatusForbidden {
+		t.Fatalf("unauthorised assign: expected 403 from validateAssigneePair, got %d: %s", w2.Code, w2.Body.String())
+	}
+	if got := taskCountForIssue(t, rejected); got != 0 {
+		t.Fatalf("unauthorised assign must enqueue nothing, got %d tasks", got)
+	}
+}
+
+// issueStatusOf reads an issue's persisted status.
+func issueStatusOf(t *testing.T, issueID string) string {
+	t.Helper()
+	var status string
+	if err := testPool.QueryRow(t.Context(),
+		`SELECT status FROM issue WHERE id = $1`, issueID,
+	).Scan(&status); err != nil {
+		t.Fatalf("read issue status: %v", err)
+	}
+	return status
+}

--- a/server/internal/handler/issue_reopen_wake_test.go
+++ b/server/internal/handler/issue_reopen_wake_test.go
@@ -1,0 +1,268 @@
+package handler
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// insertAssignedIssueWithStatus inserts an issue in the given status with the
+// given assignee, bypassing CreateIssue so the seeding itself never enqueues a
+// run. assigneeType/assigneeID may be empty for an unassigned issue.
+func insertAssignedIssueWithStatus(t *testing.T, assigneeType, assigneeID string, number int, title, status string) string {
+	t.Helper()
+	var (
+		issueID  string
+		typeArg  any = nil
+		idArg    any = nil
+		nullUUID     = "00000000-0000-0000-0000-000000000000"
+	)
+	if assigneeType != "" && assigneeID != "" && assigneeID != nullUUID {
+		typeArg, idArg = assigneeType, assigneeID
+	}
+	if err := testPool.QueryRow(context.Background(), `
+		INSERT INTO issue (workspace_id, title, status, priority, creator_id, creator_type, number, position, assignee_type, assignee_id)
+		VALUES ($1, $2, $3, 'medium', $4, 'member', $5, 0, $6, $7)
+		RETURNING id
+	`, testWorkspaceID, title, status, testUserID, number, typeArg, idArg).Scan(&issueID); err != nil {
+		t.Fatalf("insert issue: %v", err)
+	}
+	t.Cleanup(func() {
+		testPool.Exec(context.Background(), `DELETE FROM agent_task_queue WHERE issue_id = $1`, issueID)
+		testPool.Exec(context.Background(), `DELETE FROM issue WHERE id = $1`, issueID)
+	})
+	return issueID
+}
+
+// setIssueStatus drives the real single-issue write path with a status-only
+// change — exactly what `multica issue status <id> <status>` sends.
+func setIssueStatus(t *testing.T, issueID, status string) {
+	t.Helper()
+	w := httptest.NewRecorder()
+	req := withURLParam(newRequest("PUT", "/api/issues/"+issueID, map[string]any{"status": status}), "id", issueID)
+	testHandler.UpdateIssue(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("UpdateIssue status=%s: expected 200, got %d: %s", status, w.Code, w.Body.String())
+	}
+}
+
+// TestUpdateIssueReopenToTodoEnqueuesRun is the reopen regression: an issue
+// already assigned to a ready agent that is reopened from a terminal or review
+// status back into `todo` must hand the agent a fresh run, with no assignee
+// change and no @mention. Before the fix the rework request sat silently in the
+// queue because only `backlog` → active enqueued.
+func TestUpdateIssueReopenToTodoEnqueuesRun(t *testing.T) {
+	if testHandler == nil {
+		t.Skip("database not available")
+	}
+
+	cases := []struct {
+		name       string
+		prevStatus string
+		number     int
+	}{
+		{"in_review", "in_review", 92300},
+		{"done", "done", 92301},
+		{"cancelled", "cancelled", 92302},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			agentID := createHandlerTestAgent(t, "ReopenWake-"+tc.name, []byte("[]"))
+			issueID := insertAssignedIssueWithStatus(t, "agent", agentID, tc.number, "reopen-"+tc.name, tc.prevStatus)
+
+			// Preview must promise the run before the write makes it.
+			pv := previewIssueTrigger(t, map[string]any{
+				"issue_ids": []string{issueID},
+				"status":    "todo",
+			})
+			if pv.TotalCount != 1 {
+				t.Fatalf("preview %s → todo: expected 1 trigger, got %+v", tc.prevStatus, pv)
+			}
+			if pv.Triggers[0].AgentID != agentID || pv.Triggers[0].Source != "status" {
+				t.Fatalf("preview %s → todo: wrong trigger %+v", tc.prevStatus, pv.Triggers[0])
+			}
+
+			setIssueStatus(t, issueID, "todo")
+
+			if got := queuedTaskCountFor(t, issueID, agentID); got != 1 {
+				t.Fatalf("%s → todo: expected exactly 1 queued task for the unchanged assignee, got %d", tc.prevStatus, got)
+			}
+		})
+	}
+}
+
+// TestUpdateIssueReopenToTodoIsIdempotent locks the dedup contract: a retried
+// or duplicated reopen must not stack runs, and a reopen against an agent that
+// already holds a pending task must coalesce onto that one.
+func TestUpdateIssueReopenToTodoIsIdempotent(t *testing.T) {
+	if testHandler == nil {
+		t.Skip("database not available")
+	}
+
+	t.Run("repeated reopen", func(t *testing.T) {
+		agentID := createHandlerTestAgent(t, "ReopenWakeRetry", []byte("[]"))
+		issueID := insertAssignedIssueWithStatus(t, "agent", agentID, 92310, "reopen-retry", "in_review")
+
+		setIssueStatus(t, issueID, "todo")
+		// Same write again: status is unchanged now, so it is not a transition.
+		setIssueStatus(t, issueID, "todo")
+		// And a full round trip back and forth while the first run is still queued.
+		setIssueStatus(t, issueID, "in_review")
+		setIssueStatus(t, issueID, "todo")
+
+		if got := queuedTaskCountFor(t, issueID, agentID); got != 1 {
+			t.Fatalf("repeated reopen must coalesce onto one pending run, got %d queued tasks", got)
+		}
+	})
+
+	t.Run("existing pending task", func(t *testing.T) {
+		agentID := createHandlerTestAgent(t, "ReopenWakePending", []byte("[]"))
+		issueID := insertAssignedIssueWithStatus(t, "agent", agentID, 92311, "reopen-pending", "in_review")
+		// A mention-raised run is already waiting for this agent on this issue.
+		insertRunningIssueTask(t, agentID, issueID)
+
+		pv := previewIssueTrigger(t, map[string]any{"issue_ids": []string{issueID}, "status": "todo"})
+		if pv.TotalCount != 1 {
+			t.Fatalf("running task is not a pending queue slot; expected preview 1, got %+v", pv)
+		}
+
+		setIssueStatus(t, issueID, "todo")
+		if got := queuedTaskCountFor(t, issueID, agentID); got != 1 {
+			t.Fatalf("expected 1 queued task alongside the running one, got %d", got)
+		}
+	})
+}
+
+// TestUpdateIssueReopenNonAgentAssigneeEnqueuesNothing covers the two negative
+// assignee shapes: no assignee at all, and a member assignee.
+func TestUpdateIssueReopenNonAgentAssigneeEnqueuesNothing(t *testing.T) {
+	if testHandler == nil {
+		t.Skip("database not available")
+	}
+
+	unassigned := insertAssignedIssueWithStatus(t, "", "", 92320, "reopen-unassigned", "done")
+	setIssueStatus(t, unassigned, "todo")
+	if got := taskCountForIssue(t, unassigned); got != 0 {
+		t.Fatalf("unassigned reopen must enqueue nothing, got %d tasks", got)
+	}
+
+	member := insertAssignedIssueWithStatus(t, "member", testUserID, 92321, "reopen-member", "done")
+	setIssueStatus(t, member, "todo")
+	if got := taskCountForIssue(t, member); got != 0 {
+		t.Fatalf("member-assignee reopen must enqueue nothing, got %d tasks", got)
+	}
+}
+
+// TestUpdateIssueReopenPreservesBacklogAndNonTodoSemantics guards the blast
+// radius: parking an issue in `backlog` still never wakes anyone, and a move
+// out of `in_review` into a status other than `todo` is not a re-dispatch.
+func TestUpdateIssueReopenPreservesBacklogAndNonTodoSemantics(t *testing.T) {
+	if testHandler == nil {
+		t.Skip("database not available")
+	}
+
+	parkAgent := createHandlerTestAgent(t, "ReopenWakePark", []byte("[]"))
+	parked := insertAssignedIssueWithStatus(t, "agent", parkAgent, 92330, "reopen-park", "in_review")
+	setIssueStatus(t, parked, "backlog")
+	if got := queuedTaskCountFor(t, parked, parkAgent); got != 0 {
+		t.Fatalf("in_review → backlog must not wake the assignee, got %d queued tasks", got)
+	}
+
+	blockedAgent := createHandlerTestAgent(t, "ReopenWakeBlocked", []byte("[]"))
+	blocked := insertAssignedIssueWithStatus(t, "agent", blockedAgent, 92331, "reopen-blocked", "in_review")
+	setIssueStatus(t, blocked, "blocked")
+	if got := queuedTaskCountFor(t, blocked, blockedAgent); got != 0 {
+		t.Fatalf("in_review → blocked must not wake the assignee, got %d queued tasks", got)
+	}
+}
+
+// TestBatchUpdateIssueReopenToTodoEnqueuesRun mirrors the single-issue reopen
+// on the batch write path, which shares the same predicate.
+func TestBatchUpdateIssueReopenToTodoEnqueuesRun(t *testing.T) {
+	if testHandler == nil {
+		t.Skip("database not available")
+	}
+
+	agentID := createHandlerTestAgent(t, "ReopenWakeBatch", []byte("[]"))
+	i1 := insertAssignedIssueWithStatus(t, "agent", agentID, 92340, "reopen-batch-1", "in_review")
+	i2 := insertAssignedIssueWithStatus(t, "agent", agentID, 92341, "reopen-batch-2", "done")
+
+	w := httptest.NewRecorder()
+	req := newRequest("POST", "/api/issues/batch-update", map[string]any{
+		"issue_ids": []string{i1, i2},
+		"updates":   map[string]any{"status": "todo"},
+	})
+	testHandler.BatchUpdateIssues(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("BatchUpdateIssues reopen: expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	for _, id := range []string{i1, i2} {
+		if got := queuedTaskCountFor(t, id, agentID); got != 1 {
+			t.Fatalf("batch reopen: expected 1 queued task on %s, got %d", id, got)
+		}
+	}
+}
+
+// TestUpdateIssueReopenSuppressRunSkipsEnqueue verifies the reopen source
+// honours suppress_run like every other enqueue source.
+func TestUpdateIssueReopenSuppressRunSkipsEnqueue(t *testing.T) {
+	if testHandler == nil {
+		t.Skip("database not available")
+	}
+
+	agentID := createHandlerTestAgent(t, "ReopenWakeSuppress", []byte("[]"))
+	issueID := insertAssignedIssueWithStatus(t, "agent", agentID, 92350, "reopen-suppress", "in_review")
+
+	w := httptest.NewRecorder()
+	req := withURLParam(newRequest("PUT", "/api/issues/"+issueID, map[string]any{
+		"status": "todo", "suppress_run": true,
+	}), "id", issueID)
+	testHandler.UpdateIssue(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("UpdateIssue suppressed reopen: %d %s", w.Code, w.Body.String())
+	}
+	if got := queuedTaskCountFor(t, issueID, agentID); got != 0 {
+		t.Fatalf("suppress_run must skip the reopen enqueue, got %d queued tasks", got)
+	}
+}
+
+// TestUpdateIssueReopenSelfLoopIsSuppressed verifies the reopen source keeps
+// the existing self-loop guard: an agent flipping its own in-flight issue back
+// to `todo` from inside its own run must not re-trigger itself.
+func TestUpdateIssueReopenSelfLoopIsSuppressed(t *testing.T) {
+	if testHandler == nil {
+		t.Skip("database not available")
+	}
+
+	agentID := createHandlerTestAgent(t, "ReopenWakeSelfLoop", []byte("[]"))
+	issueID := insertAssignedIssueWithStatus(t, "agent", agentID, 92360, "reopen-self-loop", "in_review")
+	taskID := insertRunningIssueTask(t, agentID, issueID)
+
+	w := httptest.NewRecorder()
+	req := withURLParam(newRequest("PUT", "/api/issues/"+issueID, map[string]any{"status": "todo"}), "id", issueID)
+	req.Header.Set("X-Actor-Source", "task_token")
+	req.Header.Set("X-Agent-ID", agentID)
+	req.Header.Set("X-Task-ID", taskID)
+	testHandler.UpdateIssue(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("UpdateIssue self-loop reopen: %d %s", w.Code, w.Body.String())
+	}
+	if got := queuedTaskCountFor(t, issueID, agentID); got != 0 {
+		t.Fatalf("agent reopening its own running issue must not self-trigger, got %d queued tasks", got)
+	}
+}
+
+// taskCountForIssue counts every task on the issue regardless of agent — used
+// by the negative assignee cases where no agent id exists to key on.
+func taskCountForIssue(t *testing.T, issueID string) int {
+	t.Helper()
+	var n int
+	if err := testPool.QueryRow(context.Background(),
+		`SELECT count(*) FROM agent_task_queue WHERE issue_id = $1`, issueID,
+	).Scan(&n); err != nil {
+		t.Fatalf("count tasks: %v", err)
+	}
+	return n
+}

--- a/server/internal/handler/issue_trigger.go
+++ b/server/internal/handler/issue_trigger.go
@@ -17,13 +17,16 @@ import (
 const maxPreviewTriggerIssues = 500
 
 // issueTriggerWriteProbe builds the probe the write paths feed to
-// WillEnqueueRun. The private-agent gate is already enforced at the HTTP
-// boundary (validateAssigneePair on assign) and inside enqueueSquadLeaderTask
-// (canEnqueueSquadLeader), so a write must NOT re-run or sink it — it passes
-// allow-all. The self-loop check needs the request's X-Task-ID header.
+// WillEnqueueRun. It passes allow-all for the access gate: the gate is not
+// skipped, it simply lives on the enqueue side instead — validateAssigneePair
+// rejects an unauthorised assign with 403 at the HTTP boundary, and every
+// dispatch then re-checks it (canDispatchIssueAgent for a direct agent,
+// canEnqueueSquadLeader inside enqueueSquadLeaderTask for a squad leader), so
+// sinking a second copy here would only add drift. The self-loop check needs
+// the request's X-Task-ID header.
 func (h *Handler) issueTriggerWriteProbe(r *http.Request, actorType string, issue db.Issue) service.IssueTriggerProbe {
 	return service.IssueTriggerProbe{
-		CanAccessAgent: nil, // allow-all; gate lives at the write boundary
+		CanAccessAgent: nil, // allow-all; the gate runs on dispatch
 		IsSelfLoop: func() bool {
 			return h.isAgentRunningOnIssue(r, actorType, issue)
 		},
@@ -48,11 +51,17 @@ func (h *Handler) issueTriggerPreviewProbe(r *http.Request, actorType, actorID, 
 
 // dispatchIssueRun executes the enqueue side effect for a decision produced by
 // WillEnqueueRun, carrying an optional handoff note into the run's opening
-// context. The squad path still flows through enqueueSquadLeaderTask so the
-// leader access gate and pending dedup stay in one place.
-func (h *Handler) dispatchIssueRun(ctx context.Context, issue db.Issue, trigger service.IssueRunTrigger, actorType, actorID, handoffNote string) {
+// context. Both branches gate on the invoke permission before enqueueing: the
+// squad path through enqueueSquadLeaderTask (canEnqueueSquadLeader), the direct
+// agent path through canDispatchIssueAgent. originatorUserID must be the value
+// the caller already resolved with invokeOriginatorFromRequest, so the gate
+// judges the exact same principal the preview endpoint did.
+func (h *Handler) dispatchIssueRun(ctx context.Context, issue db.Issue, trigger service.IssueRunTrigger, actorType, actorID, originatorUserID, handoffNote string) {
 	switch trigger.AssigneeType {
 	case "agent":
+		if !h.canDispatchIssueAgent(ctx, trigger.AgentID, actorType, actorID, originatorUserID, uuidToString(issue.WorkspaceID)) {
+			return
+		}
 		// The member who performed this assign/promote is the accountable human
 		// for the run (MUL-4302 §4). An agent actor is not a human, so only a
 		// member actor is threaded; otherwise attribution falls back to the chain.
@@ -60,6 +69,28 @@ func (h *Handler) dispatchIssueRun(ctx context.Context, issue db.Issue, trigger 
 	case "squad":
 		h.enqueueSquadLeaderTask(ctx, issue, pgtype.UUID{}, actorType, actorID, handoffNote)
 	}
+}
+
+// canDispatchIssueAgent is the direct-agent counterpart of
+// enqueueSquadLeaderTask's canEnqueueSquadLeader: the last gate before an issue
+// write spends a private agent's runtime.
+//
+// It closes a hole the assign-time boundary check cannot see. UpdateIssue and
+// BatchUpdateIssues only call validateAssigneePair when the write TOUCHES an
+// assignee field, so a status-only write — promoting out of backlog, or
+// reopening a reviewed/closed issue into todo — reached the enqueue with no
+// permission check at all. Preview did evaluate canInvokeAgent, so an
+// unauthorised member saw "0 runs will start" and then started one anyway.
+// Gating here restores preview/write parity and stops that member from
+// spending the agent's runtime; the status change itself still applies.
+//
+// Errors fail closed: an agent we cannot load is an agent we cannot authorise.
+func (h *Handler) canDispatchIssueAgent(ctx context.Context, agentID pgtype.UUID, actorType, actorID, originatorUserID, workspaceID string) bool {
+	agent, err := h.Queries.GetAgent(ctx, agentID)
+	if err != nil {
+		return false
+	}
+	return h.canInvokeAgent(ctx, agent, actorType, actorID, originatorUserID, workspaceID)
 }
 
 // memberActorUserID returns the acting member's user id as a pgtype.UUID when the

--- a/server/internal/service/issue_trigger.go
+++ b/server/internal/service/issue_trigger.go
@@ -15,10 +15,42 @@ const (
 	// RunSourceAssign covers issue creation and assignee changes — the issue
 	// is being handed to an agent/squad. Parks silently on backlog.
 	RunSourceAssign RunEnqueueSource = "assign"
-	// RunSourceStatus covers promoting an already-assigned issue out of
-	// backlog into an active status.
+	// RunSourceStatus covers a status-only move that hands an already-assigned
+	// issue back to its agent: promoting out of backlog, or reopening a
+	// reviewed/closed issue into todo.
 	RunSourceStatus RunEnqueueSource = "status"
 )
+
+// isRunEnqueueingStatusMove reports whether a status-only change on an
+// already-assigned issue hands the work back to the agent. Two distinct moves
+// qualify, and they are deliberately asymmetric:
+//
+//   - backlog → anything active: promotion out of the parking lot. The issue
+//     was never dispatched, so any landing status other than the terminal ones
+//     means "start now".
+//   - in_review / done / cancelled → todo: a reopen. The reviewer rejecting a
+//     delivery, or anyone pulling a closed issue back into the ready queue, is
+//     re-dispatching it to the same assignee. Only `todo` counts here: it is
+//     the one status that means "this is ready to be worked", whereas moving a
+//     reviewed issue to in_progress/blocked/backlog is bookkeeping, not a
+//     hand-off.
+//
+// Before the reopen arm existed, a rework request with an unchanged assignee
+// produced no task at all and the returned issue sat silently in the queue
+// until someone re-@mentioned the agent.
+//
+// Every other move (in_progress → todo churn, → backlog parking, → in_review
+// hand-off to a reviewer) stays inert, so parking and reviewing keep their
+// no-wake semantics.
+func isRunEnqueueingStatusMove(prev, next string) bool {
+	switch prev {
+	case "backlog":
+		return next != "done" && next != "cancelled"
+	case "in_review", "done", "cancelled":
+		return next == "todo"
+	}
+	return false
+}
 
 // IssueTriggerProbe carries the request-scoped checks WillEnqueueRun cannot
 // resolve from issue state alone.
@@ -30,9 +62,10 @@ const (
 // gate so it never leaks a private agent's readiness to a member who cannot
 // see it. A nil func is treated as allow-all.
 //
-// IsSelfLoop reports whether promoting this issue out of backlog would be the
-// calling agent re-triggering its own running task. Only the status source
-// consults it; create and assign never do. A nil func means "not a self-loop".
+// IsSelfLoop reports whether the status move (promoting out of backlog, or
+// reopening into todo) would be the calling agent re-triggering its own running
+// task. Only the status source consults it; create and assign never do. A nil
+// func means "not a self-loop".
 type IssueTriggerProbe struct {
 	CanAccessAgent func(agent db.Agent) bool
 	IsSelfLoop     func() bool
@@ -77,10 +110,11 @@ func allowAllAgents(db.Agent) bool { return true }
 // CreateAgentTask, guarded by the (issue_id, agent_id) partial unique index
 // over pending (queued/dispatched) tasks; the pending check below mirrors that
 // guard, and only the status source needs it:
-//   - status source (backlog → active) can re-fire against an assignee that
-//     already holds a pending task (e.g. one a @mention raised while the issue
-//     sat in backlog); the check keeps preview from promising a run the unique
-//     index would coalesce away.
+//   - status source (backlog → active, or reopen → todo) can re-fire against an
+//     assignee that already holds a pending task (e.g. one a @mention raised
+//     while the issue sat in backlog, or a rework request flipped twice); the
+//     check keeps preview from promising a run the unique index would coalesce
+//     away.
 //   - assign source (create / assignee change) skips the check: a create
 //     targets a fresh issue with no prior task, and a reassignment no longer
 //     cancels existing tasks (#4963 / MUL-4113) — in the rare case the new
@@ -104,8 +138,7 @@ func (s *IssueService) WillEnqueueRun(ctx context.Context, in IssueTriggerInput,
 			return IssueRunTrigger{}, false
 		}
 		source = RunSourceAssign
-	case in.StatusChanged && in.PrevStatus == "backlog" &&
-		issue.Status != "done" && issue.Status != "cancelled":
+	case in.StatusChanged && isRunEnqueueingStatusMove(in.PrevStatus, issue.Status):
 		if probe.IsSelfLoop != nil && probe.IsSelfLoop() {
 			return IssueRunTrigger{}, false
 		}

--- a/server/internal/service/issue_trigger.go
+++ b/server/internal/service/issue_trigger.go
@@ -55,12 +55,14 @@ func isRunEnqueueingStatusMove(prev, next string) bool {
 // IssueTriggerProbe carries the request-scoped checks WillEnqueueRun cannot
 // resolve from issue state alone.
 //
-// CanAccessAgent is the private-agent gate. The write paths enforce it at the
-// HTTP boundary (validateAssigneePair on assign, canEnqueueSquadLeader inside
-// the squad enqueue helper) and therefore pass an allow-all probe so the gate
-// is never duplicated or sunk into the service layer. Preview passes the real
-// gate so it never leaks a private agent's readiness to a member who cannot
-// see it. A nil func is treated as allow-all.
+// CanAccessAgent is the private-agent gate. The write paths enforce it on the
+// enqueue side instead (canDispatchIssueAgent for a direct agent,
+// canEnqueueSquadLeader inside the squad enqueue helper, plus the 403 that
+// validateAssigneePair raises on an unauthorised assign) and therefore pass an
+// allow-all probe so the gate is never duplicated or sunk into the service
+// layer. Preview passes the real gate so it never leaks a private agent's
+// readiness to a member who cannot see it, and so preview and the write path
+// reach the same verdict. A nil func is treated as allow-all.
 //
 // IsSelfLoop reports whether the status move (promoting out of backlog, or
 // reopening into todo) would be the calling agent re-triggering its own running


### PR DESCRIPTION
## Summary

Two related fixes to the issue → agent dispatch path.

**1. Reopening an assigned issue never enqueued a run.** `WillEnqueueRun`'s status arm only fired on `backlog` → active, so:

- `in_review` → `todo` (a reviewer rejecting a delivery and asking for rework)
- `done` → `todo` / `cancelled` → `todo` (pulling a closed issue back into the ready queue)

produced **no task at all** — the assignee did not change, and no comment mention was involved. The rework request then sat silently until a human re-`@mentioned` the agent.

Observed in production: an issue was reopened to `todo` with a rework checklist at 09:07 UTC and the assignee's task list was still unchanged four hours later; a follow-up comment carrying an `@mention` produced a task in the same second. Mention triggering was healthy — the status transition simply was not a dispatch.

**2. A status-only write bypassed the private-agent invoke gate.** `UpdateIssue` / `BatchUpdateIssues` only call `validateAssigneePair` when the write **touches an assignee field**, so a status-only write reached the enqueue with no permission check. Preview *did* evaluate `canInvokeAgent`, so a member with no invoke permission saw `total_count=0` and the very same write still enqueued a real task against the private agent. That is both a preview/write disagreement and an unauthorised member spending a private agent's runtime. The bug predates this PR (it applies to the existing `backlog` → active promotion) and fix 1 would have widened its reach, so it is fixed here.

## Change

### Reopen dispatch

`isRunEnqueueingStatusMove(prev, next)` replaces the inline `prev == "backlog"` condition:

| prev | next | dispatch |
|---|---|---|
| `backlog` | anything except `done` / `cancelled` | yes (unchanged) |
| `in_review` / `done` / `cancelled` | `todo` | **yes (new)** |
| everything else | — | no |

Only `todo` counts as a reopen target: it is the one status meaning "ready to be worked". Moving a reviewed issue to `in_progress` / `blocked` / `backlog` is bookkeeping, so parking and hand-off-to-reviewer keep their no-wake semantics.

The fix lands in the single shared predicate, so single update, batch update and `POST /api/issues/preview-trigger` pick it up together and cannot drift (MUL-3375). The new source reuses `RunSourceStatus`, so no client-side enum or i18n change is needed, and it inherits the existing guards unchanged: self-loop, `suppress_run`, and the `(issue_id, agent_id)` pending dedup.

### Permission gate

The squad branch was already covered — `enqueueSquadLeaderTask` gates on `canEnqueueSquadLeader` before enqueueing. The direct-agent branch had no counterpart. `canDispatchIssueAgent` adds it, called from `dispatchIssueRun`, threading the originator the caller already resolved with `invokeOriginatorFromRequest` so the gate judges **exactly the principal preview judged** — same function, same actor, same originator, same workspace.

Scope of that gate:

- Covers both status moves (the pre-existing `backlog` → active and the new reopen → `todo`), single and batch write paths.
- The status change itself still applies; only the task is withheld. That matches the existing product semantics for a write that is allowed to mutate the issue but not to spend the agent.
- The assign source is unaffected: `validateAssigneePair` already 403s an unauthorised assign with the identical predicate and identical arguments (`resolveActor` reads the same `X-User-ID` header in both places), so the dispatch check is a no-op there. Covered by a regression test in both directions.
- Errors fail closed.

## Tests

`server/internal/handler/issue_reopen_wake_test.go` — all three reopen cases fail on `main`, pass here:

- `in_review` / `done` / `cancelled` → `todo` each enqueue exactly one task for the **unchanged** assignee, and preview agrees (`source=status`)
- idempotency: repeated reopens and a `todo → in_review → todo` round trip coalesce onto one pending run; a reopen against an agent that already holds a running task adds exactly one queued task
- negatives: unassigned issue and member assignee enqueue nothing
- blast radius: `in_review` → `backlog` and `in_review` → `blocked` still wake nobody
- batch write path mirror, `suppress_run`, and the self-loop guard

`server/internal/handler/issue_dispatch_private_agent_test.go` — the unauthorised-member cases fail on `main` (preview 0, write enqueued 1) and pass here:

- private direct agent, `in_review` → `todo`, `done` → `todo`, and `backlog` → `todo`: an unauthorised member gets preview 0 **and** 0 tasks, while the status change still lands; the agent owner gets preview 1 and exactly 1 task
- the batch write path mirror of both directions
- the assign source still enqueues exactly 1 task for the agent owner, and still 403s + enqueues 0 for the unauthorised member

Run:

```
go test ./internal/handler/ ./internal/service/ -count=1   # ok  11.1s / 2.4s
bash scripts/test-go.sh                                    # full Go suite
```

Two unrelated failures in this environment, both reproduced on unmodified `main`:

- `internal/metrics` `TestBusinessSamplerStatementTimeoutCutsHungQuery` — local PostgreSQL 16 returns a client-side context deadline instead of a `*pgconn.PgError` for the `pg_sleep` cancellation.
- `pkg/agent` `TestCodexExecuteRetriesInitializeTimeoutOnceAfterCleanup` — its 2s handshake deadline is flaky under a loaded parallel run; passes on every isolated re-run.

## Note for reviewers

Batch status changes apply directly without the run-confirm modal (MUL-4155), so a batch reopen of N issues now fans out N runs with no confirmation step — same shape as the existing batch `backlog` → active promotion. Flagging it in case you would rather route reopens through the confirm modal; happy to add that here.
