### PR TITLE
MUL-5427: KAP-1227: safely retry run-only provider stream cuts

### DIFF
--- a/apps/docs/content/docs/daemon-runtimes.mdx
+++ b/apps/docs/content/docs/daemon-runtimes.mdx
@@ -156,7 +156,7 @@ Multica uses heartbeats to decide whether a runtime is online. Three key numbers
 Missing is not permanent — as soon as the daemon sends another heartbeat it returns to online, and the runtime record is preserved. Restarting the daemon does not lose runtimes.
 
 <Callout type="warning">
-**Tasks running on a missing runtime are marked as failed** (failure reason `runtime_offline`). For retryable sources (issues, chat), Multica automatically requeues them; Autopilot-triggered tasks are not retried automatically. See [Tasks → Which failures retry automatically](/tasks#which-failures-retry-automatically-which-dont).
+**Tasks running on a missing runtime are marked as failed** (failure reason `runtime_offline`). Multica automatically requeues retryable issue and chat tasks. Run-only Autopilots have only the narrower zero-tool provider-network retry described in [Tasks → Which failures retry automatically](/tasks#which-failures-retry-automatically-which-dont).
 </Callout>
 
 ## How many tasks can run in parallel

--- a/apps/docs/content/docs/tasks.mdx
+++ b/apps/docs/content/docs/tasks.mdx
@@ -51,18 +51,19 @@ Failures fall into two categories: **retryable** and **non-retryable**.
 - `runtime_offline` — the daemon went missing after the task was dispatched
 - `runtime_recovery` — the daemon crashed and restarted, reclaiming tasks it didn't finish
 - `timeout` — runtime or dispatch timeout
+- `agent_error.provider_network` — the provider stream disconnected or stalled
 
 **Non-retryable** (the task stays in failed):
 
-- `agent_error` — the AI coding tool itself reported an error (API error, quota exceeded, internal bug). Underlying problems aren't retried — that would loop forever.
+- other `agent_error.*` reasons — the AI coding tool or provider reported a durable error (quota, auth, invalid request, internal bug).
 
 Automatic retry also has two extra conditions:
 
-1. **At most 2 attempts** — 1 original + 1 retry. If the retry also fails, no further retries, even if the reason is retryable.
-2. **Only for issue- and chat-triggered tasks** — Autopilot-triggered tasks do **not** retry automatically.
+1. **At most 2 attempts** by default. Provider-network cuts get up to 3 attempts.
+2. **Issue and chat tasks retry normally.** A run-only Autopilot retries only a provider-network cut for which the daemon positively observed zero tool calls.
 
 <Callout type="warning">
-**Autopilot tasks don't retry automatically** by design. An Autopilot has its own firing cadence (e.g. daily); automatic retries on failure would overlap with the next scheduled run. If you need an immediate re-run after failure, use a manual rerun (next section).
+**Autopilot retry is fail-closed.** Once any tool call was observed, a provider-network failure stays terminal because replaying the run could duplicate an external side effect. Older daemons that do not report the tool count also do not enable this retry.
 
 **How you'll know an Autopilot task failed**: a notification lands in your [Inbox](/inbox), and the associated issue's status reverts from `in_progress` back to `todo`. The [Autopilots](/autopilots) page also shows the latest run result per autopilot.
 </Callout>

--- a/apps/docs/content/docs/tasks.zh.mdx
+++ b/apps/docs/content/docs/tasks.zh.mdx
@@ -53,18 +53,19 @@ Multica 服务器每 30 秒扫描一次，有两种超时会触发失败：
 - `runtime_offline`——任务派发后，守护进程失联了
 - `runtime_recovery`——守护进程崩溃重启，回收上次没跑完的任务
 - `timeout`——运行超时或派发超时
+- `agent_error.provider_network`——provider 流式响应断开或停滞
 
 **不可重试**（任务停在失败状态）：
 
-- `agent_error`——AI 编程工具自己报错（API 错误、超额度、内部 bug）。底层问题不重试，避免无限循环。
+- 其它 `agent_error.*`——AI 编程工具或 provider 报告了持久错误（额度、认证、非法请求、内部 bug）。
 
 自动重试有两个额外条件：
 
-1. **最多 2 次**——1 次原任务 + 1 次重试。重试也失败就不再重试，即使原因可重试。
-2. **只对 issue 和聊天触发的任务生效**——Autopilots 触发的任务**不自动重试**。
+1. **默认最多 2 次**；provider 网络中断最多 3 次。
+2. **Issue 和聊天任务按常规重试。** 直跑模式 Autopilot 只有在 provider 网络中断、且守护进程明确观察到 0 次工具调用时才重试。
 
 <Callout type="warning">
-**Autopilots 任务不自动重试**是刻意设计。Autopilot 有自己的触发周期（例如每天一次）；如果失败又自动重试，会和下一个周期的任务重叠。需要失败后立即重跑，用手动重跑（下一节）。
+**Autopilot 重试采用 fail-closed 策略。** 一旦观察到任何工具调用，provider 网络失败就保持 terminal，避免重放造成外部副作用重复。旧版守护进程不报告工具次数，也不会启用该重试。
 
 **怎么知道 Autopilot 失败了**：失败的 Autopilot 任务会在你的 [收件箱](/inbox) 里出现一条通知，关联的 issue 状态也会从 `in_progress` 退回 `todo`。直接打开 [Autopilots](/autopilots) 页面也能看到每条 autopilot 的最近运行结果。
 </Callout>

--- a/docs/analytics.md
+++ b/docs/analytics.md
@@ -366,7 +366,7 @@ Fires from `autopilot_run` lifecycle changes. `source` is always
 | `duration_ms` | int64 | Terminal events only. |
 | `failure_reason` | string | Failed events only. |
 | `error_type` | string | Failed events only; stable coarse classifier such as `configuration`, `issue_terminal`, `dispatch_error`, `task_error`, or `autopilot_error`. |
-| `will_retry` | bool | Failed events only; currently `false` because autopilot retry cadence is owned by triggers/schedules. |
+| `will_retry` | bool | Failed events only. Terminal run events currently report `false`; a zero-tool provider-network retry keeps the run open and therefore does not emit a failed run event yet. |
 
 ### `issue_executed`
 

--- a/server/cmd/server/autopilot_listeners_test.go
+++ b/server/cmd/server/autopilot_listeners_test.go
@@ -122,6 +122,95 @@ func TestAutopilotRunOnlyTaskTerminalEventsUpdateRun(t *testing.T) {
 	}
 }
 
+func TestAutopilotRunOnlyProviderNetworkRetrySync(t *testing.T) {
+	ctx := context.Background()
+	queries := db.New(testPool)
+	bus := events.New()
+	taskSvc := service.NewTaskService(queries, testPool, nil, bus)
+	autopilotSvc := service.NewAutopilotService(queries, testPool, bus, taskSvc)
+	registerAutopilotListeners(bus, autopilotSvc)
+
+	var agentID string
+	if err := testPool.QueryRow(ctx,
+		`SELECT id::text FROM agent WHERE workspace_id = $1 ORDER BY created_at ASC LIMIT 1`,
+		testWorkspaceID,
+	).Scan(&agentID); err != nil {
+		t.Fatalf("load fixture agent: %v", err)
+	}
+
+	for _, tc := range []struct {
+		name        string
+		tools       int32
+		wantRetry   bool
+		wantRunStat string
+	}{
+		{name: "connection closed before tools retries", tools: 0, wantRetry: true, wantRunStat: "running"},
+		{name: "stalled stream after tool stays terminal", tools: 1, wantRetry: false, wantRunStat: "failed"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			ap, err := queries.CreateAutopilot(ctx, db.CreateAutopilotParams{
+				WorkspaceID:        parseUUID(testWorkspaceID),
+				Title:              "Run-only provider network " + tc.name,
+				Description:        pgtype.Text{String: "KAP-1227 regression", Valid: true},
+				AssigneeType:       "agent",
+				AssigneeID:         parseUUID(agentID),
+				Status:             "active",
+				ExecutionMode:      "run_only",
+				IssueTitleTemplate: pgtype.Text{},
+				CreatedByType:      "member",
+				CreatedByID:        parseUUID(testUserID),
+			})
+			if err != nil {
+				t.Fatalf("CreateAutopilot: %v", err)
+			}
+			t.Cleanup(func() {
+				_, _ = testPool.Exec(context.Background(), `DELETE FROM autopilot WHERE id = $1`, ap.ID)
+			})
+
+			run, err := autopilotSvc.DispatchAutopilot(ctx, ap, pgtype.UUID{}, "schedule", nil)
+			if err != nil {
+				t.Fatalf("DispatchAutopilot: %v", err)
+			}
+			if _, err := testPool.Exec(ctx,
+				`UPDATE agent_task_queue SET status = 'dispatched', dispatched_at = now() WHERE id = $1`,
+				run.TaskID,
+			); err != nil {
+				t.Fatalf("mark task dispatched: %v", err)
+			}
+			if _, err := queries.StartAgentTask(ctx, run.TaskID); err != nil {
+				t.Fatalf("StartAgentTask: %v", err)
+			}
+
+			errMsg := "API Error: Connection closed mid-response."
+			if tc.tools > 0 {
+				errMsg = "API Error: Response stalled mid-stream."
+			}
+			if _, err := taskSvc.FailTaskWithObservedTools(ctx, run.TaskID, errMsg, "session", "/tmp/workdir", "agent_error.provider_network", &tc.tools, false); err != nil {
+				t.Fatalf("FailTaskWithObservedTools: %v", err)
+			}
+
+			var children int
+			if err := testPool.QueryRow(ctx,
+				`SELECT count(*) FROM agent_task_queue WHERE parent_task_id = $1`,
+				run.TaskID,
+			).Scan(&children); err != nil {
+				t.Fatalf("count retry children: %v", err)
+			}
+			if got := children == 1; got != tc.wantRetry {
+				t.Fatalf("retry child present = %v, want %v", got, tc.wantRetry)
+			}
+
+			updated, err := queries.GetAutopilotRun(ctx, run.ID)
+			if err != nil {
+				t.Fatalf("GetAutopilotRun: %v", err)
+			}
+			if updated.Status != tc.wantRunStat {
+				t.Fatalf("run status = %q, want %q", updated.Status, tc.wantRunStat)
+			}
+		})
+	}
+}
+
 // linkedIssueAutopilotFixture is the starting state every create_issue
 // linked-issue listener test shares: a dispatched create_issue run sitting in
 // issue_created with exactly one issue task that carries no autopilot_run_id

--- a/server/internal/daemon/client.go
+++ b/server/internal/daemon/client.go
@@ -396,7 +396,7 @@ func (c *Client) ReportTaskUsage(ctx context.Context, taskID string, usage []Tas
 	}, nil)
 }
 
-func (c *Client) FailTask(ctx context.Context, taskID, errMsg, sessionID, workDir, failureReason string, sessionRolloutMissing bool) error {
+func (c *Client) FailTask(ctx context.Context, taskID, errMsg, sessionID, workDir, failureReason string, observedToolCalls *int32, sessionRolloutMissing bool) error {
 	body := map[string]any{"error": errMsg}
 	if sessionID != "" {
 		body["session_id"] = sessionID
@@ -406,6 +406,9 @@ func (c *Client) FailTask(ctx context.Context, taskID, errMsg, sessionID, workDi
 	}
 	if failureReason != "" {
 		body["failure_reason"] = failureReason
+	}
+	if observedToolCalls != nil {
+		body["observed_tool_calls"] = *observedToolCalls
 	}
 	if sessionRolloutMissing {
 		body["session_rollout_missing"] = true

--- a/server/internal/daemon/client_test.go
+++ b/server/internal/daemon/client_test.go
@@ -290,7 +290,8 @@ func TestFailTask_RetriesOnTransient5xxThenSucceeds(t *testing.T) {
 	defer srv.Close()
 
 	c := NewClient(srv.URL)
-	if err := c.FailTask(context.Background(), "task-1", "boom", "", "", "timeout", true); err != nil {
+	zeroTools := int32(0)
+	if err := c.FailTask(context.Background(), "task-1", "boom", "", "", "timeout", &zeroTools, true); err != nil {
 		t.Fatalf("FailTask: %v", err)
 	}
 	if got := calls.Load(); got != 3 {

--- a/server/internal/daemon/daemon.go
+++ b/server/internal/daemon/daemon.go
@@ -141,6 +141,9 @@ type terminalTaskReport struct {
 	sessionID     string
 	workDir       string
 	failureReason string
+	// observedToolCalls is nil for failure paths that never reached the agent
+	// stream. RunTask terminal failures always provide a value, including zero.
+	observedToolCalls *int32
 	// sessionRolloutMissing is true when the daemon withheld this task's Codex
 	// session because its rollout was not in the store (MUL-5305). The server
 	// clears the resume pointer and flags the continuity gap for the next claim.
@@ -3808,6 +3811,7 @@ func (d *Daemon) reportTaskResult(ctx context.Context, taskID string, result Tas
 			sessionID:             result.SessionID,
 			workDir:               result.WorkDir,
 			failureReason:         failureReason,
+			observedToolCalls:     &result.ObservedToolCalls,
 			sessionRolloutMissing: result.SessionRolloutMissing,
 		}); err != nil {
 			taskLog.Error("report failed task failed", "error", err)
@@ -3828,7 +3832,7 @@ func (d *Daemon) reportTerminalTask(parentCtx context.Context, report terminalTa
 	case terminalTaskReportComplete:
 		return d.client.CompleteTask(ctx, report.taskID, report.output, report.branchName, report.sessionID, report.workDir, report.sessionRolloutMissing)
 	case terminalTaskReportFail:
-		return d.client.FailTask(ctx, report.taskID, report.errorMessage, report.sessionID, report.workDir, report.failureReason, report.sessionRolloutMissing)
+		return d.client.FailTask(ctx, report.taskID, report.errorMessage, report.sessionID, report.workDir, report.failureReason, report.observedToolCalls, report.sessionRolloutMissing)
 	default:
 		return fmt.Errorf("unsupported terminal task report kind %d", report.kind)
 	}
@@ -5131,6 +5135,7 @@ func (d *Daemon) runTask(ctx context.Context, task Task, provider string, slot i
 	// returns (SessionID is already blanked above); reportTaskResult forwards it
 	// as session_rollout_missing on the terminal callback (MUL-5305).
 	defer func() { taskResult.SessionRolloutMissing = sessionRolloutMissing }()
+	defer func() { taskResult.ObservedToolCalls = tools }()
 
 	switch result.Status {
 	case "completed":

--- a/server/internal/daemon/types.go
+++ b/server/internal/daemon/types.go
@@ -259,6 +259,10 @@ type TaskResult struct {
 	WorkDir       string `json:"work_dir,omitempty"`   // working directory used during execution
 	EnvRoot       string `json:"-"`                    // env root dir for writing GC metadata (not sent to server)
 	FailureReason string `json:"-"`                    // classifier forwarded to FailTask on the blocked path; empty falls back to 'agent_error'
+	// ObservedToolCalls is the number of tool-use events seen during this run.
+	// The fail callback forwards it so the server can retry a run-only
+	// provider-network cut only when the daemon positively observed no tools.
+	ObservedToolCalls int32 `json:"-"`
 	// SessionRolloutMissing is set when the daemon withheld this task's Codex
 	// session because its rollout was not in the store (MUL-5305). Forwarded to
 	// the terminal report so the server clears the resume pointer and flags the

--- a/server/internal/handler/daemon.go
+++ b/server/internal/handler/daemon.go
@@ -3571,6 +3571,9 @@ type TaskFailRequest struct {
 	SessionID     string `json:"session_id,omitempty"`
 	WorkDir       string `json:"work_dir,omitempty"`
 	FailureReason string `json:"failure_reason,omitempty"`
+	// ObservedToolCalls is pointer-shaped so omitted (older daemon) is
+	// distinguishable from an explicit zero-tool observation.
+	ObservedToolCalls *int32 `json:"observed_tool_calls,omitempty"`
 	// SessionRolloutMissing: the daemon withheld this task's Codex session
 	// because its rollout was missing (MUL-5305). Clear the resume pointer and
 	// flag the continuity gap for the next claim.
@@ -3597,7 +3600,7 @@ func (h *Handler) FailTask(w http.ResponseWriter, r *http.Request) {
 	// keep a stale mid-flight pin) and flagging the row in the same commit that
 	// creates and wakes the auto-retry, so the retry can never claim the withheld
 	// pointer or miss the continuity gap.
-	task, err := h.TaskService.FailTask(r.Context(), parseUUID(taskID), req.Error, req.SessionID, req.WorkDir, req.FailureReason, req.SessionRolloutMissing)
+	task, err := h.TaskService.FailTaskWithObservedTools(r.Context(), parseUUID(taskID), req.Error, req.SessionID, req.WorkDir, req.FailureReason, req.ObservedToolCalls, req.SessionRolloutMissing)
 	if err != nil {
 		// A FailTask error is an infrastructure failure (the terminal
 		// transaction that also clears the withheld session, writes the

--- a/server/internal/service/autopilot.go
+++ b/server/internal/service/autopilot.go
@@ -1028,6 +1028,20 @@ func (s *AutopilotService) SyncRunFromTask(ctx context.Context, task db.AgentTas
 		s.captureAutopilotRunCompleted(autopilot, updatedRun)
 		s.publishRunDone(wsID, updatedRun, "completed")
 	case "failed", "cancelled":
+		if task.Status == "failed" {
+			hasActive, err := s.Queries.HasActiveTaskForAutopilotRun(ctx, task.AutopilotRunID)
+			if err != nil {
+				slog.Warn("failed to check active tasks for run-only autopilot failure",
+					"run_id", util.UUIDToString(run.ID),
+					"task_id", util.UUIDToString(task.ID),
+					"error", err,
+				)
+				return
+			}
+			if hasActive {
+				return
+			}
+		}
 		reason := "task " + task.Status
 		if task.Error.Valid {
 			reason = task.Error.String

--- a/server/internal/service/task.go
+++ b/server/internal/service/task.go
@@ -3096,6 +3096,13 @@ func (s *TaskService) observeChatOutputLocalPath(task db.AgentTaskQueue, body st
 // (via classifyPoisonedError, the timeout / runtime classifier, etc.)
 // will have their value preserved untouched.
 func (s *TaskService) FailTask(ctx context.Context, taskID pgtype.UUID, errMsg, sessionID, workDir, failureReason string, sessionRolloutMissing bool) (*db.AgentTaskQueue, error) {
+	return s.FailTaskWithObservedTools(ctx, taskID, errMsg, sessionID, workDir, failureReason, nil, sessionRolloutMissing)
+}
+
+// FailTaskWithObservedTools is the daemon-facing failure path. A non-nil
+// observedToolCalls is positive stream evidence from a current daemon; nil
+// means an older daemon or a failure before the agent stream was observed.
+func (s *TaskService) FailTaskWithObservedTools(ctx context.Context, taskID pgtype.UUID, errMsg, sessionID, workDir, failureReason string, observedToolCalls *int32, sessionRolloutMissing bool) (*db.AgentTaskQueue, error) {
 	// MUL-2946: synthesise a refined reason from the error text whenever the
 	// caller didn't supply one. This is the last write-path guard against
 	// "agent_error" coarse rows ending up in agent_task_queue.failure_reason
@@ -3133,7 +3140,7 @@ func (s *TaskService) FailTask(ctx context.Context, taskID pgtype.UUID, errMsg, 
 		if parent, perr := s.Queries.GetAgentTask(ctx, taskID); perr != nil {
 			slog.Warn("fail task auto-retry: load parent failed",
 				"task_id", util.UUIDToString(taskID), "error", perr)
-		} else if retryEligible(failureReason, parent) {
+		} else if retryEligibleWithObservedTools(failureReason, parent, observedToolCalls) {
 			wantRetry = true
 			// Persist the reason-aware effective budget into the child so the
 			// retry chain self-describes (e.g. provider_network → max_attempts=3),
@@ -3421,10 +3428,23 @@ func ResumeUnsafeFailure(failureReason, errorText string) bool {
 // FailTask's in-transaction retry and the orphan sweeper's MaybeRetryFailedTask
 // so both agree on which failures re-run.
 func retryEligible(failureReason string, t db.AgentTaskQueue) bool {
+	return retryEligibleWithObservedTools(failureReason, t, nil)
+}
+
+// retryEligibleWithObservedTools keeps the historical issue/chat policy and
+// adds one deliberately narrow run-only exception. A provider-network stream
+// cut may retry an autopilot task only when a current daemon positively
+// reports zero tool calls. Any tool may have caused an external side effect,
+// so one or more tools suppress retry. Missing evidence also suppresses retry,
+// making rolling upgrades fail closed.
+func retryEligibleWithObservedTools(failureReason string, t db.AgentTaskQueue, observedToolCalls *int32) bool {
+	runOnlyProviderNetworkSafe := t.AutopilotRunID.Valid &&
+		failureReason == string(taskfailure.ReasonAgentProviderNetwork) &&
+		observedToolCalls != nil && *observedToolCalls == 0
 	return retryableReasons[failureReason] &&
 		t.Attempt < retryAttemptCeiling(failureReason, t.MaxAttempts) &&
-		!t.AutopilotRunID.Valid &&
-		(t.IssueID.Valid || t.ChatSessionID.Valid)
+		((!t.AutopilotRunID.Valid && (t.IssueID.Valid || t.ChatSessionID.Valid)) ||
+			runOnlyProviderNetworkSafe)
 }
 
 // MaybeRetryFailedTask spawns a fresh queued attempt for a recently-failed

--- a/server/internal/service/task_complete_race_test.go
+++ b/server/internal/service/task_complete_race_test.go
@@ -280,6 +280,29 @@ func TestTaskFailureClassifiers(t *testing.T) {
 	}
 }
 
+func TestRetryEligibleRunOnlyProviderNetworkRequiresZeroObservedTools(t *testing.T) {
+	task := db.AgentTaskQueue{
+		AutopilotRunID: pgtype.UUID{Valid: true},
+		Attempt:        1,
+		MaxAttempts:    2,
+	}
+	zero := int32(0)
+	one := int32(1)
+
+	if !retryEligibleWithObservedTools("agent_error.provider_network", task, &zero) {
+		t.Fatal("run-only provider-network failure with explicit zero tools should retry")
+	}
+	if retryEligibleWithObservedTools("agent_error.provider_network", task, &one) {
+		t.Fatal("run-only provider-network failure after a tool call must not retry")
+	}
+	if retryEligibleWithObservedTools("agent_error.provider_network", task, nil) {
+		t.Fatal("run-only provider-network failure without tool evidence must fail closed")
+	}
+	if retryEligibleWithObservedTools("timeout", task, &zero) {
+		t.Fatal("run-only timeout is outside the narrow provider-network policy")
+	}
+}
+
 // TestSkillBundleFailureFromLegacyDaemonRetries is the mixed-version
 // regression for MUL-5370. It walks the exact chain FailTask runs for a task
 // an un-upgraded daemon just failed, and asserts the user-visible outcome:

--- a/server/pkg/db/generated/agent.sql.go
+++ b/server/pkg/db/generated/agent.sql.go
@@ -3084,6 +3084,24 @@ func (q *Queries) GetWorkspaceAgentRunCounts(ctx context.Context, workspaceID pg
 	return items, nil
 }
 
+const hasActiveTaskForAutopilotRun = `-- name: HasActiveTaskForAutopilotRun :one
+SELECT EXISTS (
+  SELECT 1
+  FROM agent_task_queue
+  WHERE autopilot_run_id = $1
+    AND status IN ('queued', 'deferred', 'dispatched', 'running', 'waiting_local_directory')
+)
+`
+
+// A failed run-only task may already have an atomic provider-network retry.
+// Keep the run open until that child reaches its own terminal state.
+func (q *Queries) HasActiveTaskForAutopilotRun(ctx context.Context, autopilotRunID pgtype.UUID) (bool, error) {
+	row := q.db.QueryRow(ctx, hasActiveTaskForAutopilotRun, autopilotRunID)
+	var exists bool
+	err := row.Scan(&exists)
+	return exists, err
+}
+
 const hasActiveTaskForIssue = `-- name: HasActiveTaskForIssue :one
 SELECT count(*) > 0 AS has_active FROM agent_task_queue
 WHERE issue_id = $1 AND status IN ('queued', 'dispatched', 'running', 'waiting_local_directory')

--- a/server/pkg/db/queries/agent.sql
+++ b/server/pkg/db/queries/agent.sql
@@ -420,6 +420,16 @@ FROM agent_task_queue p
 WHERE p.id = $1
 RETURNING *;
 
+-- name: HasActiveTaskForAutopilotRun :one
+-- A failed run-only task may already have an atomic provider-network retry.
+-- Keep the run open until that child reaches its own terminal state.
+SELECT EXISTS (
+  SELECT 1
+  FROM agent_task_queue
+  WHERE autopilot_run_id = $1
+    AND status IN ('queued', 'deferred', 'dispatched', 'running', 'waiting_local_directory')
+);
+
 -- name: CancelAgentTasksByIssue :many
 -- Cancels every active task on the issue and returns the affected rows so the
 -- caller can reconcile each agent's status and broadcast task:cancelled events

--- a/server/pkg/taskfailure/classify.go
+++ b/server/pkg/taskfailure/classify.go
@@ -180,6 +180,7 @@ func Classify(rawError string) Reason {
 	//    Mirror these substrings into the MUL-1949 offline backfill SQL.
 	case containsAny(lower,
 		"stream disconnected",
+		"response stalled mid-stream",
 		"connection closed",
 		"mid-response",
 		"error sending request",

--- a/server/pkg/taskfailure/classify_test.go
+++ b/server/pkg/taskfailure/classify_test.go
@@ -93,6 +93,7 @@ func TestClassifyRules(t *testing.T) {
 
 		// 7. Provider network.
 		{"stream disconnected", "stream disconnected before completion", ReasonAgentProviderNetwork},
+		{"response stalled mid-stream", "API Error: Response stalled mid-stream. The response above may be incomplete.", ReasonAgentProviderNetwork},
 		{"connection closed mid-response", "API Error: Connection closed mid-response. The response above may be incomplete.", ReasonAgentProviderNetwork},
 		{"connection closed with exit status wins over process failure", "claude exited with error: exit status 1\nAPI Error: Connection closed mid-response.", ReasonAgentProviderNetwork},
 		{"error sending request", "error sending request for url (https://api.example.com/v1)", ReasonAgentProviderNetwork},


### PR DESCRIPTION
Closes KAP-1227

## Summary

- forward daemon-observed tool-call count on task failures
- retry run-only provider-network cuts only with explicit zero-tool evidence; missing evidence and post-tool failures fail closed
- keep the autopilot run open while its retry child is active
- classify Claude's `Response stalled mid-stream` as provider-network and document the policy

## Tests

- `go test ./pkg/taskfailure -run 'TestClassifyRules$' -count=1`
- `go test ./internal/service -run 'Test(RetryEligibleRunOnlyProviderNetworkRequiresZeroObservedTools|ProviderNetworkRetrySchedule)$' -count=1`
- `go test ./internal/daemon -run 'TestFailTask_RetriesOnTransient5xxThenSucceeds$' -count=1`
- `go test ./cmd/server -run 'TestAutopilotRunOnlyProviderNetworkRetrySync$' -count=1`

Full `go test ./...` also ran: changed packages passed; existing environment/baseline failures remain in `cmd/multica` (daemon task marker affects config tests) and `internal/handler` (`TestIssueTableStatusGroupingOverOneThousandRows`: invalid cursor).
