### PR TITLE
KAP-1184: enforce local release capacity loop

### DIFF
--- a/scripts/macos/CAPACITY_LOOP.md
+++ b/scripts/macos/CAPACITY_LOOP.md
@@ -1,0 +1,101 @@
+# Local release capacity loop
+
+This directory contains the macOS guardrails for heavy local release work.
+They complement the daemon claim admission gate: the daemon gate protects new
+claims, while these entrypoints protect heavy work started by an already-running
+agent task.
+
+## Entrypoint matrix
+
+| Operation | Required host headroom | Entrypoint | Terminal cleanup owner |
+| --- | ---: | --- | --- |
+| amd64 production image build/push | 22 GiB | `multica-heavy-batch --operation release-amd64` | wrapper: declared temp roots/images, builder cache, guest `fstrim`; deletes a profile created for this batch only when it has zero running containers |
+| amd64 local preview build | 22 GiB | `multica-heavy-batch --operation preview-amd64` | wrapper, same rules |
+| other Docker/BuildKit build | 22 GiB | `multica-heavy-batch --operation docker-build` | wrapper, same rules |
+| local Next.js build without VM | 12 GiB | `multica-heavy-batch --operation next-build` | wrapper: declared batch temp roots |
+| Multica CLI/desktop release | 16 GiB | `multica-heavy-batch --operation multica-release` | wrapper: declared batch temp roots |
+| local preview container | budget belongs to its build operation | `multica-preview-run` | `multica-preview-cleanup`: only labelled, expired, non-running containers |
+| terminal agent run workdir | threshold GC at host free space below 22 GiB; 24h TTL | `multica-workspace-cleanup` | cleanup script after process, terminal metadata, Git dirty, upstream, and ahead checks |
+
+`--required-gib` may raise an operation budget. It cannot lower the floor.
+Insufficient headroom exits `75` with `result=PARKED` before command, VM, build,
+manifest, or temp-root side effects.
+
+## Colima policy
+
+- `default` is reserved and is never accepted by the wrapper.
+- New amd64 builds use an ephemeral owner-bound profile:
+  `KAP-1184` must use `kap1184-amd64`. The global heavy-batch lock permits one
+  such profile at a time.
+- The wrapper rejects mismatched profile names. A newly created profile is
+  deleted after success or failure only when it has zero running containers.
+- A pre-existing profile is never deleted by the wrapper.
+- The wrapper never stops a profile that was already running when the batch
+  began.
+- A profile with running containers is preserved.
+- Images are removed only when passed as exact `--cleanup-image` values.
+- Builder cache is regenerable and is pruned only after the wrapped command has
+  terminated and no other local Docker build process is visible.
+- `fstrim` runs after Docker cleanup; guest and host free-space observations are
+  printed. A profile containing a configured protected production/rollback
+  baseline is retained.
+
+## Examples
+
+```bash
+build_root="$(mktemp -d /tmp/kap-1184-release.XXXXXX)"
+
+multica-heavy-batch \
+  --operation release-amd64 \
+  --owner KAP-1184 \
+  --profile kap1184-amd64 \
+  --temp-root "$build_root" \
+  -- \
+  docker --host "unix://${HOME}/.colima/kap1184-amd64/docker.sock" \
+    buildx build --platform linux/amd64 --push "$build_root/repo"
+```
+
+```bash
+multica-preview-run \
+  --profile kap1184-amd64 \
+  --owner KAP-1184 \
+  --ttl-hours 8 \
+  -- --detach --name kap1184-preview IMAGE
+```
+
+## Workspace GC safety
+
+A whole task root is eligible only when all conditions hold:
+
+1. `.gc_meta.json` has a supported kind and `completed_at`.
+2. The completion age exceeds the configured TTL.
+3. A global open-file scan does not map any live path into the task root.
+4. Every nested repository has an upstream, `ahead=0`, and no dirty files
+   outside the explicit regenerable directory names.
+5. A second recursive open-file scan passes immediately before deletion.
+6. The resolved path matches exactly
+   `<approved-root>/<workspace-uuid>/<8-hex-task-id>`.
+
+Any missing or failed signal protects the task root. The cleanup never touches
+credentials, profiles, volumes, project directories, or arbitrary cache roots.
+
+Run dry first:
+
+```bash
+MULTICA_CLEANUP_DRY_RUN=1 multica-workspace-cleanup --dry-run
+```
+
+## Verification
+
+```bash
+scripts/macos/test-capacity-loop.sh
+```
+
+The fixture verifies:
+
+- insufficient headroom creates no command side effect and exits `75`;
+- clean terminal workdirs are eligible;
+- dirty, ahead, active, and young workdirs survive;
+- success and controlled failure remove only declared batch temp roots;
+- wrapper cleanup invokes `fstrim` and stops only an idle profile it started;
+- expired terminal previews are removed while a running preview survives.

--- a/scripts/macos/canary/Dockerfile
+++ b/scripts/macos/canary/Dockerfile
@@ -1,0 +1,3 @@
+FROM scratch
+
+COPY payload.txt /capacity-canary.txt

--- a/scripts/macos/canary/payload.txt
+++ b/scripts/macos/canary/payload.txt
@@ -1,0 +1,1 @@
+KAP-1184 capacity-loop canary

--- a/scripts/macos/multica-heavy-batch
+++ b/scripts/macos/multica-heavy-batch
@@ -1,0 +1,283 @@
+#!/usr/bin/env bash
+set -u
+
+PATH="/usr/bin:/bin:/usr/sbin:/sbin:/opt/homebrew/bin:/usr/local/bin:${HOME}/.local/bin"
+export PATH
+umask 077
+
+OPERATION=""
+OWNER=""
+PROFILE=""
+REQUIRED_GIB=""
+TEMP_ROOTS=("")
+CLEANUP_IMAGES=("")
+COMMAND=()
+STATE_DIR="${MULTICA_HEAVY_BATCH_STATE_DIR:-${HOME}/.multica/local-ops/state}"
+LOCK_DIR="${STATE_DIR}/heavy-batch.lock"
+DATA_VOLUME="${MULTICA_HEAVY_BATCH_VOLUME:-/System/Volumes/Data}"
+FREE_GIB_OVERRIDE="${MULTICA_HEAVY_BATCH_FREE_GIB_OVERRIDE:-}"
+COLIMA_BIN="${MULTICA_HEAVY_BATCH_COLIMA_BIN:-$(command -v colima 2>/dev/null || true)}"
+DOCKER_BIN="${MULTICA_HEAVY_BATCH_DOCKER_BIN:-$(command -v docker 2>/dev/null || true)}"
+PROFILE_WAS_RUNNING=0
+PROFILE_EXISTED=0
+LOCKED=0
+EXPECTED_PROFILE=""
+
+usage() {
+  printf '%s\n' \
+    "usage: multica-heavy-batch --operation TYPE --owner KAP-NNN [options] -- command [args...]" \
+    "" \
+    "operations: release-amd64, preview-amd64, docker-build, next-build, multica-release" \
+    "options:" \
+    "  --profile NAME         dedicated Colima profile; never default" \
+    "  --required-gib N       may raise, but not lower, the operation budget" \
+    "  --temp-root PATH       batch-owned temporary root to delete on exit (repeatable)" \
+    "  --cleanup-image REF    exact batch-owned local image to remove on exit (repeatable)"
+}
+
+default_budget() {
+  case "$1" in
+    release-amd64) printf '22' ;;
+    preview-amd64) printf '22' ;;
+    docker-build) printf '22' ;;
+    next-build) printf '12' ;;
+    multica-release) printf '16' ;;
+    *) return 1 ;;
+  esac
+}
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --operation)
+      shift
+      [ "$#" -gt 0 ] || { usage >&2; exit 64; }
+      OPERATION="$1"
+      ;;
+    --owner)
+      shift
+      [ "$#" -gt 0 ] || { usage >&2; exit 64; }
+      OWNER="$1"
+      ;;
+    --profile)
+      shift
+      [ "$#" -gt 0 ] || { usage >&2; exit 64; }
+      PROFILE="$1"
+      ;;
+    --required-gib)
+      shift
+      [ "$#" -gt 0 ] || { usage >&2; exit 64; }
+      REQUIRED_GIB="$1"
+      ;;
+    --temp-root)
+      shift
+      [ "$#" -gt 0 ] || { usage >&2; exit 64; }
+      TEMP_ROOTS+=("$1")
+      ;;
+    --cleanup-image)
+      shift
+      [ "$#" -gt 0 ] || { usage >&2; exit 64; }
+      CLEANUP_IMAGES+=("$1")
+      ;;
+    --)
+      shift
+      COMMAND=("$@")
+      break
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      usage >&2
+      exit 64
+      ;;
+  esac
+  shift
+done
+
+BASE_BUDGET="$(default_budget "$OPERATION")" || {
+  printf 'result=BLOCKED reason=unknown_operation operation=%s\n' "$OPERATION" >&2
+  exit 64
+}
+[[ "$OWNER" =~ ^KAP-[0-9]+$ ]] || {
+  printf 'result=BLOCKED reason=invalid_owner owner=%s\n' "$OWNER" >&2
+  exit 64
+}
+[ "${#COMMAND[@]}" -gt 0 ] || {
+  printf 'result=BLOCKED reason=command_missing\n' >&2
+  exit 64
+}
+
+if [ -z "$REQUIRED_GIB" ]; then
+  REQUIRED_GIB="$BASE_BUDGET"
+fi
+case "$REQUIRED_GIB" in
+  ''|*[!0-9]*)
+    printf 'result=BLOCKED reason=invalid_budget required_gib=%s\n' "$REQUIRED_GIB" >&2
+    exit 64
+    ;;
+esac
+if [ "$REQUIRED_GIB" -lt "$BASE_BUDGET" ]; then
+  printf 'result=BLOCKED reason=budget_below_operation_floor required_gib=%s floor_gib=%s\n' \
+    "$REQUIRED_GIB" "$BASE_BUDGET" >&2
+  exit 64
+fi
+
+if [ -n "$PROFILE" ]; then
+  EXPECTED_PROFILE="$(printf '%s' "$OWNER" | tr '[:upper:]' '[:lower:]' | tr -d '-')-amd64"
+  if [ "$PROFILE" != "$EXPECTED_PROFILE" ]; then
+    printf 'result=BLOCKED reason=profile_owner_mismatch profile=%s expected_profile=%s\n' \
+      "$PROFILE" "$EXPECTED_PROFILE" >&2
+    exit 64
+  fi
+fi
+
+if [ -n "$FREE_GIB_OVERRIDE" ]; then
+  case "$FREE_GIB_OVERRIDE" in
+    ''|*[!0-9]*)
+      printf 'result=BLOCKED reason=invalid_free_override\n' >&2
+      exit 64
+      ;;
+  esac
+  FREE_KIB=$((FREE_GIB_OVERRIDE * 1024 * 1024))
+else
+  FREE_KIB="$(df -Pk "$DATA_VOLUME" | awk 'NR == 2 {print $4}')"
+  case "$FREE_KIB" in
+    ''|*[!0-9]*)
+      printf 'result=PARKED reason=df_failed volume=%s\n' "$DATA_VOLUME" >&2
+      exit 75
+      ;;
+  esac
+fi
+REQUIRED_KIB=$((REQUIRED_GIB * 1024 * 1024))
+if [ "$FREE_KIB" -lt "$REQUIRED_KIB" ]; then
+  printf 'result=PARKED reason=insufficient_headroom operation=%s owner=%s free_kib=%s required_gib=%s side_effects=none\n' \
+    "$OPERATION" "$OWNER" "$FREE_KIB" "$REQUIRED_GIB"
+  exit 75
+fi
+
+mkdir -p "$STATE_DIR"
+if ! mkdir "$LOCK_DIR" 2>/dev/null; then
+  printf 'result=PARKED reason=another_heavy_batch_running owner=%s\n' "$OWNER"
+  exit 75
+fi
+LOCKED=1
+
+if [ -n "$PROFILE" ] && [ -n "$COLIMA_BIN" ]; then
+  if "$COLIMA_BIN" list 2>/dev/null | awk -v profile="$PROFILE" 'NR > 1 && $1 == profile { found=1 } END { exit found ? 0 : 1 }'; then
+    PROFILE_EXISTED=1
+  fi
+  if "$COLIMA_BIN" status --profile "$PROFILE" >/dev/null 2>&1; then
+    PROFILE_WAS_RUNNING=1
+  else
+    if ! "$COLIMA_BIN" start --profile "$PROFILE" --arch x86_64 --cpus 4 --memory 6 --disk 30 --dns 8.8.8.8 --dns 1.1.1.1; then
+      printf 'result=BLOCKED reason=profile_start_failed profile=%s\n' "$PROFILE" >&2
+      exit 1
+    fi
+  fi
+fi
+
+safe_remove_temp_root() {
+  local target="$1"
+  TARGET_TO_REMOVE="$target" EXPECTED_OWNER="$(printf '%s' "$OWNER" | tr '[:upper:]' '[:lower:]')" \
+    /usr/bin/python3 - <<'PY'
+import os
+import shutil
+import tempfile
+from pathlib import Path
+
+target = Path(os.environ["TARGET_TO_REMOVE"]).expanduser().resolve()
+owner = os.environ["EXPECTED_OWNER"]
+temp_root = Path(tempfile.gettempdir()).resolve()
+mac_temp_parent = any(
+    parent.name == "T" and str(parent).startswith("/private/var/folders/")
+    for parent in target.parents
+)
+under_temp_root = target != temp_root and temp_root in target.parents
+under_private_tmp = target != Path("/private/tmp") and Path("/private/tmp") in target.parents
+if not (under_temp_root or under_private_tmp or mac_temp_parent):
+    raise SystemExit(f"refuse temp cleanup outside approved temp roots: {target}")
+if owner not in target.name.lower():
+    raise SystemExit(f"refuse temp cleanup without owner {owner}: {target}")
+if target.exists():
+    shutil.rmtree(target)
+PY
+}
+
+external_build_running() {
+  ps -axo pid=,command= | awk -v self="$$" '
+    $1 != self && $0 ~ /docker([[:space:]].*)?(buildx[[:space:]]+build|[[:space:]]build[[:space:]])/ { found=1 }
+    END { exit found ? 0 : 1 }
+  '
+}
+
+runtime_cleanup() {
+  local socket running_count image protected_match
+  [ -n "$PROFILE" ] || return 0
+  [ -n "$COLIMA_BIN" ] || return 0
+  [ -n "$DOCKER_BIN" ] || return 0
+  "$COLIMA_BIN" status --profile "$PROFILE" >/dev/null 2>&1 || return 0
+  socket="unix://${HOME}/.colima/${PROFILE}/docker.sock"
+
+  if external_build_running; then
+    printf 'cleanup=SKIP reason=external_build_running profile=%s\n' "$PROFILE"
+    return 0
+  fi
+
+  for image in "${CLEANUP_IMAGES[@]}"; do
+    [ -n "$image" ] || continue
+    "$DOCKER_BIN" --host "$socket" image rm "$image" >/dev/null 2>&1 || true
+  done
+  "$DOCKER_BIN" --host "$socket" builder prune -af >/dev/null 2>&1 || true
+
+  GUEST_BEFORE="$("$COLIMA_BIN" ssh --profile "$PROFILE" -- df -Pk / 2>/dev/null | awk 'NR == 2 {print $4}' || true)"
+  TRIM_OUTPUT="$("$COLIMA_BIN" ssh --profile "$PROFILE" -- sudo fstrim -av 2>&1 || true)"
+  GUEST_AFTER="$("$COLIMA_BIN" ssh --profile "$PROFILE" -- df -Pk / 2>/dev/null | awk 'NR == 2 {print $4}' || true)"
+  HOST_AFTER="$(df -Pk "$DATA_VOLUME" | awk 'NR == 2 {print $4}')"
+  printf 'cleanup=fstrim profile=%s guest_before_kib=%s guest_after_kib=%s host_after_kib=%s output=%q\n' \
+    "$PROFILE" "${GUEST_BEFORE:-unknown}" "${GUEST_AFTER:-unknown}" "${HOST_AFTER:-unknown}" "$TRIM_OUTPUT"
+
+  running_count="$("$DOCKER_BIN" --host "$socket" ps -q 2>/dev/null | awk 'NF {count++} END {print count+0}')"
+  protected_match="$("$DOCKER_BIN" --host "$socket" images --no-trunc --format '{{.Repository}}:{{.Tag}}|{{.ID}}' 2>/dev/null \
+    | grep -E 'sha-ab9c9122|sha-01c29e12|sha256:a0c66125' || true)"
+  if [ -n "$protected_match" ]; then
+    printf 'cleanup=profile_preserved profile=%s reason=protected_baseline_present\n' "$PROFILE"
+  elif [ "$PROFILE_EXISTED" -eq 0 ] && [ "$running_count" -eq 0 ]; then
+    "$COLIMA_BIN" delete --force --profile "$PROFILE" >/dev/null 2>&1 || true
+    printf 'cleanup=profile_deleted profile=%s reason=batch_owned_no_active_containers\n' "$PROFILE"
+  elif [ "$PROFILE_WAS_RUNNING" -eq 0 ] && [ "$running_count" -eq 0 ]; then
+    "$COLIMA_BIN" stop --profile "$PROFILE" >/dev/null 2>&1 || true
+    printf 'cleanup=profile_stopped profile=%s reason=preexisting_idle_profile\n' "$PROFILE"
+  elif [ "$running_count" -gt 0 ]; then
+    printf 'cleanup=profile_preserved profile=%s reason=active_containers count=%s\n' \
+      "$PROFILE" "$running_count"
+  fi
+}
+
+cleanup() {
+  local rc="$?"
+  local target
+  trap - EXIT INT TERM
+  for target in "${TEMP_ROOTS[@]}"; do
+    [ -n "$target" ] || continue
+    if safe_remove_temp_root "$target"; then
+      printf 'cleanup=temp_root_removed path=%s\n' "$target"
+    else
+      printf 'cleanup=SKIP reason=temp_root_guard path=%s\n' "$target" >&2
+    fi
+  done
+  runtime_cleanup
+  if [ "$LOCKED" -eq 1 ]; then
+    rmdir "$LOCK_DIR" 2>/dev/null || true
+  fi
+  printf 'result=%s operation=%s owner=%s command_rc=%s\n' \
+    "$([ "$rc" -eq 0 ] && printf PASS || printf FAIL)" "$OPERATION" "$OWNER" "$rc"
+  exit "$rc"
+}
+trap cleanup EXIT INT TERM
+
+HOST_BEFORE_KIB="$(df -Pk "$DATA_VOLUME" | awk 'NR == 2 {print $4}')"
+printf 'result=START operation=%s owner=%s free_kib=%s required_gib=%s profile=%s\n' \
+  "$OPERATION" "$OWNER" "$HOST_BEFORE_KIB" "$REQUIRED_GIB" "${PROFILE:-none}"
+
+"${COMMAND[@]}"

--- a/scripts/macos/multica-preview-cleanup
+++ b/scripts/macos/multica-preview-cleanup
@@ -1,0 +1,159 @@
+#!/usr/bin/env python3
+"""Remove only expired, terminal, explicitly labelled local preview containers."""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import json
+import os
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+
+OWNER_RE = re.compile(r"^KAP-[0-9]+$")
+TERMINAL = {"exited", "dead", "created"}
+
+
+def emit(event: str, **fields: object) -> None:
+    print(json.dumps({"event": event, **fields}, sort_keys=True))
+
+
+def run(args: list[str], timeout: int = 30) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(args, check=False, capture_output=True, text=True, timeout=timeout)
+
+
+def expiry(value: str) -> dt.datetime | None:
+    try:
+        parsed = dt.datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    return parsed if parsed.tzinfo else parsed.replace(tzinfo=dt.timezone.utc)
+
+
+def profiles() -> list[str]:
+    configured = os.environ.get("MULTICA_PREVIEW_PROFILES")
+    if configured:
+        return [item for item in configured.split(",") if item and item != "default"]
+    root = Path(os.environ.get("MULTICA_PREVIEW_COLIMA_ROOT", "~/.colima")).expanduser()
+    return sorted(
+        child.name
+        for child in root.iterdir()
+        if child.is_dir()
+        and child.name != "default"
+        and (child / "docker.sock").exists()
+    ) if root.is_dir() else []
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--dry-run", action="store_true")
+    args = parser.parse_args()
+    docker = os.environ.get("MULTICA_PREVIEW_DOCKER_BIN", "docker")
+    colima = os.environ.get("MULTICA_PREVIEW_COLIMA_BIN", "colima")
+    now = dt.datetime.now(dt.timezone.utc)
+    removed = protected = invalid = 0
+
+    for profile in profiles():
+        profile_removed = 0
+        profile_owners: set[str] = set()
+        socket = f"unix://{Path.home()}/.colima/{profile}/docker.sock"
+        listed = run([
+            docker,
+            "--host",
+            socket,
+            "ps",
+            "-aq",
+            "--filter",
+            "label=ai.multica.preview=true",
+        ])
+        if listed.returncode != 0:
+            emit("profile", profile=profile, action="protect", reason="docker_unavailable")
+            continue
+        for container_id in listed.stdout.split():
+            inspected = run([docker, "--host", socket, "inspect", container_id])
+            if inspected.returncode != 0:
+                invalid += 1
+                emit("container", profile=profile, id=container_id, action="protect", reason="inspect_failed")
+                continue
+            record = json.loads(inspected.stdout)[0]
+            labels = record.get("Config", {}).get("Labels", {}) or {}
+            status = str(record.get("State", {}).get("Status", "")).lower()
+            owner = labels.get("ai.multica.owner", "")
+            expires_raw = labels.get("ai.multica.expires-at", "")
+            expires = expiry(expires_raw)
+            name = str(record.get("Name", "")).lstrip("/")
+
+            if not OWNER_RE.fullmatch(owner) or expires is None:
+                invalid += 1
+                emit("container", profile=profile, id=container_id, name=name, action="protect", reason="invalid_ownership_labels")
+            elif status not in TERMINAL:
+                protected += 1
+                emit("container", profile=profile, id=container_id, name=name, action="protect", reason=f"active:{status}")
+            elif expires > now:
+                protected += 1
+                emit("container", profile=profile, id=container_id, name=name, action="protect", reason="ttl_not_elapsed")
+            elif args.dry_run:
+                emit("container", profile=profile, id=container_id, name=name, action="would_delete", reason="terminal_ttl_elapsed")
+            else:
+                deleted = run([docker, "--host", socket, "rm", container_id])
+                if deleted.returncode == 0:
+                    removed += 1
+                    profile_removed += 1
+                    profile_owners.add(owner)
+                    emit("container", profile=profile, id=container_id, name=name, action="deleted", reason="terminal_ttl_elapsed")
+                else:
+                    invalid += 1
+                    emit("container", profile=profile, id=container_id, name=name, action="protect", reason="remove_failed")
+
+        if profile_removed > 0 and len(profile_owners) == 1:
+            owner = next(iter(profile_owners))
+            expected_profile = f"{owner.lower().replace('-', '')}-amd64"
+            remaining = run([docker, "--host", socket, "ps", "-aq"])
+            protected_images = run([
+                docker,
+                "--host",
+                socket,
+                "images",
+                "--no-trunc",
+                "--format",
+                "{{.Repository}}:{{.Tag}}|{{.ID}}",
+            ])
+            has_protected_baseline = any(
+                marker in protected_images.stdout
+                for marker in ("sha-ab9c9122", "sha-01c29e12", "sha256:a0c66125")
+            )
+            if (
+                profile == expected_profile
+                and remaining.returncode == 0
+                and not remaining.stdout.strip()
+                and not has_protected_baseline
+            ):
+                trim = run([colima, "ssh", "--profile", profile, "--", "sudo", "fstrim", "-av"], timeout=60)
+                deleted_profile = run([colima, "delete", "--force", "--profile", profile], timeout=120)
+                if deleted_profile.returncode == 0:
+                    emit(
+                        "profile",
+                        profile=profile,
+                        action="deleted",
+                        reason="owner_bound_terminal_preview_empty",
+                        fstrim_rc=trim.returncode,
+                    )
+                else:
+                    invalid += 1
+                    emit("profile", profile=profile, action="protect", reason="profile_delete_failed")
+
+    emit(
+        "summary",
+        result="DRY_RUN" if args.dry_run else ("PASS" if invalid == 0 else "PASS_WITH_NOTES"),
+        removed=removed,
+        protected=protected,
+        invalid=invalid,
+    )
+    return 0 if invalid == 0 else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/macos/multica-preview-run
+++ b/scripts/macos/multica-preview-run
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+set -u
+
+PROFILE=""
+OWNER=""
+TTL_HOURS="8"
+DOCKER_BIN="${MULTICA_PREVIEW_DOCKER_BIN:-$(command -v docker 2>/dev/null || true)}"
+EXPECTED_PROFILE=""
+
+usage() {
+  printf '%s\n' \
+    "usage: multica-preview-run --profile NAME --owner KAP-NNN [--ttl-hours N] -- docker-run-args..."
+}
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --profile) shift; PROFILE="${1:-}" ;;
+    --owner) shift; OWNER="${1:-}" ;;
+    --ttl-hours) shift; TTL_HOURS="${1:-}" ;;
+    --) shift; break ;;
+    -h|--help) usage; exit 0 ;;
+    *) usage >&2; exit 64 ;;
+  esac
+  shift
+done
+
+[ -n "$PROFILE" ] || { printf 'empty profile forbidden\n' >&2; exit 64; }
+EXPECTED_PROFILE="$(printf '%s' "$OWNER" | tr '[:upper:]' '[:lower:]' | tr -d '-')-amd64"
+[ "$PROFILE" = "$EXPECTED_PROFILE" ] || {
+  printf 'profile owner mismatch: %s (want %s)\n' "$PROFILE" "$EXPECTED_PROFILE" >&2
+  exit 64
+}
+[[ "$OWNER" =~ ^KAP-[0-9]+$ ]] || { printf 'invalid owner\n' >&2; exit 64; }
+case "$TTL_HOURS" in ''|*[!0-9]*) printf 'invalid ttl\n' >&2; exit 64 ;; esac
+[ "$#" -gt 0 ] || { usage >&2; exit 64; }
+[ -n "$DOCKER_BIN" ] || { printf 'docker unavailable\n' >&2; exit 69; }
+
+EXPIRES_AT="$(date -u -v+"${TTL_HOURS}"H '+%Y-%m-%dT%H:%M:%SZ')"
+SOCKET="unix://${HOME}/.colima/${PROFILE}/docker.sock"
+
+exec "$DOCKER_BIN" --host "$SOCKET" run \
+  --label ai.multica.preview=true \
+  --label "ai.multica.owner=${OWNER}" \
+  --label "ai.multica.expires-at=${EXPIRES_AT}" \
+  "$@"

--- a/scripts/macos/multica-workspace-cleanup
+++ b/scripts/macos/multica-workspace-cleanup
@@ -1,0 +1,468 @@
+#!/usr/bin/env python3
+"""Threshold-triggered, fail-closed GC for terminal Multica task workdirs."""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import json
+import os
+import re
+import shutil
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+
+GIB_KIB = 1024 * 1024
+TASK_RE = re.compile(r"^[0-9a-f]{8}$")
+WORKSPACE_RE = re.compile(r"^[0-9a-f-]{36}$")
+REGENERABLE = {
+    "node_modules",
+    ".next",
+    ".turbo",
+    "dist",
+    "build",
+    "coverage",
+}
+TERMINAL_KINDS = {"issue", "chat", "autopilot_run", "quick_create"}
+
+
+@dataclass
+class RepoAudit:
+    path: Path
+    safe: bool
+    reason: str
+
+
+@dataclass
+class Candidate:
+    task_root: Path
+    action: str
+    reason: str
+    completed_at: str | None
+    repos: list[RepoAudit]
+    regenerable: list[Path]
+
+
+def emit(event: str, **fields: object) -> None:
+    payload = {"event": event, **fields}
+    print(json.dumps(payload, ensure_ascii=False, sort_keys=True))
+
+
+def command(args: list[str], *, timeout: int = 30) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        args,
+        check=False,
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+    )
+
+
+def parse_roots() -> list[Path]:
+    configured = os.environ.get("MULTICA_CLEANUP_ROOTS", "")
+    values = configured.split(os.pathsep) if configured else [
+        "~/multica_workspaces",
+        "~/multica_workspaces_desktop-api.multica.ai",
+    ]
+    roots: list[Path] = []
+    for value in values:
+        if not value:
+            continue
+        path = Path(value).expanduser().resolve()
+        if path.is_dir():
+            roots.append(path)
+    return roots
+
+
+def available_kib(path: Path) -> int:
+    override = os.environ.get("MULTICA_CLEANUP_FREE_GIB_OVERRIDE")
+    if override is not None:
+        return int(override) * GIB_KIB
+    usage = shutil.disk_usage(path)
+    return usage.free // 1024
+
+
+def completed_at(meta: dict[str, object]) -> dt.datetime | None:
+    raw = meta.get("completed_at")
+    if not isinstance(raw, str) or not raw:
+        return None
+    try:
+        return dt.datetime.fromisoformat(raw.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+
+
+def task_roots(roots: list[Path]) -> list[Path]:
+    found: list[Path] = []
+    for root in roots:
+        for workspace in root.iterdir():
+            if not workspace.is_dir() or not WORKSPACE_RE.fullmatch(workspace.name):
+                continue
+            for task in workspace.iterdir():
+                if task.is_dir() and TASK_RE.fullmatch(task.name):
+                    found.append(task.resolve())
+    return sorted(found)
+
+
+def active_task_roots(roots: list[Path]) -> tuple[set[Path], str | None]:
+    override = os.environ.get("MULTICA_CLEANUP_ACTIVE_PATHS")
+    if override is not None:
+        paths = [Path(value).expanduser().resolve() for value in override.split(os.pathsep) if value]
+        return map_paths_to_tasks(paths, roots), None
+
+    lsof_bin = os.environ.get("MULTICA_CLEANUP_LSOF_BIN", "/usr/sbin/lsof")
+    try:
+        result = command([lsof_bin, "-nP", "-F", "n"], timeout=30)
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        return set(), f"lsof_failed:{type(exc).__name__}"
+    if result.returncode not in (0, 1):
+        return set(), f"lsof_rc:{result.returncode}"
+    paths = [
+        Path(line[1:]).resolve()
+        for line in result.stdout.splitlines()
+        if line.startswith("n/") and "(deleted)" not in line
+    ]
+    paths.append(Path.cwd().resolve())
+    return map_paths_to_tasks(paths, roots), None
+
+
+def map_paths_to_tasks(paths: list[Path], roots: list[Path]) -> set[Path]:
+    active: set[Path] = set()
+    for path in paths:
+        for root in roots:
+            try:
+                rel = path.relative_to(root)
+            except ValueError:
+                continue
+            parts = rel.parts
+            if len(parts) >= 2 and WORKSPACE_RE.fullmatch(parts[0]) and TASK_RE.fullmatch(parts[1]):
+                active.add(root / parts[0] / parts[1])
+    return active
+
+
+def nested_repos(workdir: Path) -> list[Path]:
+    if not workdir.is_dir():
+        return []
+    repos: list[Path] = []
+    for current, dirs, files in os.walk(workdir, topdown=True):
+        has_git = ".git" in dirs or ".git" in files
+        dirs[:] = [name for name in dirs if name not in REGENERABLE and name != ".git"]
+        if has_git:
+            repos.append(Path(current).resolve())
+            dirs[:] = []
+    return repos
+
+
+def regenerable_dirs(workdir: Path) -> list[Path]:
+    if not workdir.is_dir():
+        return []
+    found: list[Path] = []
+    for current, dirs, _files in os.walk(workdir, topdown=True, followlinks=False):
+        retained: list[str] = []
+        for name in dirs:
+            path = Path(current) / name
+            if name in REGENERABLE:
+                if not path.is_symlink():
+                    found.append(path.resolve())
+                continue
+            retained.append(name)
+        dirs[:] = retained
+    return sorted(found)
+
+
+def dirty_paths(repo: Path) -> tuple[list[str], str | None]:
+    result = command(
+        ["git", "-C", str(repo), "status", "--porcelain=v1", "-z", "--untracked-files=all"]
+    )
+    if result.returncode != 0:
+        return [], "git_status_failed"
+    dirty: list[str] = []
+    for record in result.stdout.split("\0"):
+        if not record:
+            continue
+        path = record[3:] if len(record) > 3 else record
+        if " -> " in path:
+            path = path.split(" -> ", 1)[1]
+        parts = Path(path).parts
+        if not any(part in REGENERABLE for part in parts):
+            dirty.append(path)
+    return dirty, None
+
+
+def audit_repo(repo: Path) -> RepoAudit:
+    dirty, error = dirty_paths(repo)
+    if error:
+        return RepoAudit(repo, False, error)
+    if dirty:
+        return RepoAudit(repo, False, f"dirty:{len(dirty)}")
+
+    upstream = command(
+        ["git", "-C", str(repo), "rev-parse", "--abbrev-ref", "--symbolic-full-name", "@{upstream}"]
+    )
+    if upstream.returncode != 0 or not upstream.stdout.strip():
+        return RepoAudit(repo, False, "upstream_missing")
+    ahead = command(
+        ["git", "-C", str(repo), "rev-list", "--count", "@{upstream}..HEAD"]
+    )
+    if ahead.returncode != 0:
+        return RepoAudit(repo, False, "ahead_check_failed")
+    try:
+        ahead_count = int(ahead.stdout.strip())
+    except ValueError:
+        return RepoAudit(repo, False, "ahead_check_invalid")
+    if ahead_count > 0:
+        return RepoAudit(repo, False, f"ahead:{ahead_count}")
+    return RepoAudit(repo, True, "clean_ahead_0")
+
+
+def audit_task(
+    task_root: Path,
+    *,
+    active: set[Path],
+    process_scan_error: str | None,
+    ttl: dt.timedelta,
+    now: dt.datetime,
+) -> Candidate:
+    if process_scan_error:
+        return Candidate(task_root, "protect", process_scan_error, None, [], [])
+    if task_root in active:
+        return Candidate(task_root, "protect", "active_path", None, [], [])
+
+    meta_path = task_root / ".gc_meta.json"
+    try:
+        meta = json.loads(meta_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return Candidate(task_root, "protect", "terminal_metadata_missing", None, [], [])
+    if meta.get("kind") not in TERMINAL_KINDS:
+        return Candidate(task_root, "protect", "unknown_task_kind", None, [], [])
+    finished = completed_at(meta)
+    if finished is None:
+        return Candidate(task_root, "protect", "run_not_terminal", None, [], [])
+    if finished.tzinfo is None:
+        finished = finished.replace(tzinfo=dt.timezone.utc)
+    if now - finished < ttl:
+        return Candidate(task_root, "protect", "ttl_not_elapsed", finished.isoformat(), [], [])
+
+    workdir = task_root / "workdir"
+    audits = [audit_repo(repo) for repo in nested_repos(workdir)]
+    unsafe = [audit for audit in audits if not audit.safe]
+    if unsafe:
+        reasons = ",".join(sorted({audit.reason for audit in unsafe}))
+        return Candidate(
+            task_root,
+            "prune",
+            f"repo_guard:{reasons}",
+            finished.isoformat(),
+            audits,
+            regenerable_dirs(workdir),
+        )
+    return Candidate(
+        task_root,
+        "delete",
+        "terminal_ttl_git_safe",
+        finished.isoformat(),
+        audits,
+        [],
+    )
+
+
+def recheck_inactive(task_root: Path) -> tuple[bool, str]:
+    lsof_bin = os.environ.get("MULTICA_CLEANUP_LSOF_BIN", "/usr/sbin/lsof")
+    if os.environ.get("MULTICA_CLEANUP_ACTIVE_PATHS") is not None:
+        active = [
+            Path(value).expanduser().resolve()
+            for value in os.environ["MULTICA_CLEANUP_ACTIVE_PATHS"].split(os.pathsep)
+            if value
+        ]
+        if any(path == task_root or task_root in path.parents for path in active):
+            return False, "active_path_recheck"
+        return True, "inactive"
+    try:
+        result = command([lsof_bin, "-nP", "-F", "n", "+D", str(task_root)], timeout=60)
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        return False, f"lsof_recheck_failed:{type(exc).__name__}"
+    if any(
+        line.startswith("n/") and "(deleted)" not in line
+        for line in result.stdout.splitlines()
+    ):
+        return False, "active_path_recheck"
+    if result.returncode not in (0, 1):
+        return False, f"lsof_recheck_rc:{result.returncode}"
+    return True, "inactive"
+
+
+def safe_delete(task_root: Path, roots: list[Path]) -> tuple[bool, str]:
+    resolved = task_root.resolve()
+    if not any(
+        resolved.parent.parent == root
+        and WORKSPACE_RE.fullmatch(resolved.parent.name)
+        and TASK_RE.fullmatch(resolved.name)
+        for root in roots
+    ):
+        return False, "path_allowlist_failed"
+    inactive, reason = recheck_inactive(resolved)
+    if not inactive:
+        return False, reason
+    shutil.rmtree(resolved)
+    return not resolved.exists(), "deleted"
+
+
+def safe_prune(path: Path, task_root: Path) -> tuple[bool, str]:
+    resolved = path.resolve()
+    workdir = (task_root / "workdir").resolve()
+    if (
+        path.is_symlink()
+        or resolved.name not in REGENERABLE
+        or resolved == workdir
+        or workdir not in resolved.parents
+    ):
+        return False, "regenerable_allowlist_failed"
+    inactive, reason = recheck_inactive(resolved)
+    if not inactive:
+        return False, reason
+    if resolved.is_dir():
+        shutil.rmtree(resolved)
+    return not resolved.exists(), "pruned"
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--dry-run", action="store_true")
+    parser.add_argument("--force", action="store_true", help="run audit even above threshold")
+    args = parser.parse_args()
+
+    roots = parse_roots()
+    if not roots:
+        emit("summary", result="SKIP", reason="no_roots")
+        return 0
+
+    threshold_gib = int(os.environ.get("MULTICA_CLEANUP_MIN_FREE_GIB", "22"))
+    ttl_minutes = int(os.environ.get("MULTICA_CLEANUP_AGE_MINUTES", "1440"))
+    before_kib = min(available_kib(root) for root in roots)
+    if not args.force and before_kib >= threshold_gib * GIB_KIB:
+        emit(
+            "summary",
+            result="SKIP",
+            reason="enough_free",
+            free_kib=before_kib,
+            threshold_gib=threshold_gib,
+        )
+        return 0
+
+    active, scan_error = active_task_roots(roots)
+    now = dt.datetime.now(dt.timezone.utc)
+    candidates = [
+        audit_task(
+            task_root,
+            active=active,
+            process_scan_error=scan_error,
+            ttl=dt.timedelta(minutes=ttl_minutes),
+            now=now,
+        )
+        for task_root in task_roots(roots)
+    ]
+
+    deleted = 0
+    pruned = 0
+    protected = 0
+    failed = 0
+    for candidate in candidates:
+        repos = [
+            {"path": str(audit.path), "safe": audit.safe, "reason": audit.reason}
+            for audit in candidate.repos
+        ]
+        if candidate.action == "delete" and not args.dry_run:
+            ok, reason = safe_delete(candidate.task_root, roots)
+            if ok:
+                deleted += 1
+                emit(
+                    "task",
+                    action="deleted",
+                    path=str(candidate.task_root),
+                    reason=candidate.reason,
+                    completed_at=candidate.completed_at,
+                    repos=repos,
+                )
+            else:
+                failed += 1
+                emit(
+                    "task",
+                    action="protect",
+                    path=str(candidate.task_root),
+                    reason=reason,
+                    completed_at=candidate.completed_at,
+                    repos=repos,
+                )
+        elif candidate.action == "prune" and not args.dry_run:
+            protected += 1
+            for path in candidate.regenerable:
+                ok, reason = safe_prune(path, candidate.task_root)
+                if ok:
+                    pruned += 1
+                    emit(
+                        "artifact",
+                        action="pruned",
+                        path=str(path),
+                        task_path=str(candidate.task_root),
+                        reason=candidate.reason,
+                    )
+                else:
+                    failed += 1
+                    emit(
+                        "artifact",
+                        action="protect",
+                        path=str(path),
+                        task_path=str(candidate.task_root),
+                        reason=reason,
+                    )
+            emit(
+                "task",
+                action="protected_after_prune",
+                path=str(candidate.task_root),
+                reason=candidate.reason,
+                completed_at=candidate.completed_at,
+                repos=repos,
+                regenerable=[str(path) for path in candidate.regenerable],
+            )
+        else:
+            if candidate.action in {"protect", "prune"}:
+                protected += 1
+            emit(
+                "task",
+                action={
+                    "delete": "would_delete",
+                    "prune": "would_prune",
+                    "protect": "protect",
+                }[candidate.action],
+                path=str(candidate.task_root),
+                reason=candidate.reason,
+                completed_at=candidate.completed_at,
+                repos=repos,
+                regenerable=[str(path) for path in candidate.regenerable],
+            )
+
+    after_kib = min(available_kib(root) for root in roots)
+    emit(
+        "summary",
+        result="DRY_RUN" if args.dry_run else ("PASS" if failed == 0 else "PASS_WITH_NOTES"),
+        scanned=len(candidates),
+        would_delete=sum(candidate.action == "delete" for candidate in candidates),
+        would_prune=sum(len(candidate.regenerable) for candidate in candidates),
+        deleted=deleted,
+        pruned=pruned,
+        protected=protected,
+        failed=failed,
+        free_before_kib=before_kib,
+        free_after_kib=after_kib,
+        threshold_gib=threshold_gib,
+        ttl_minutes=ttl_minutes,
+        process_scan_error=scan_error,
+    )
+    return 0 if failed == 0 else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/macos/test-capacity-loop.sh
+++ b/scripts/macos/test-capacity-loop.sh
@@ -1,0 +1,204 @@
+#!/bin/bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+FIXTURE="$(mktemp -d -t multica-capacity-loop-test.XXXXXX)"
+trap 'rm -rf "$FIXTURE"' EXIT
+
+fail() {
+  printf 'FAIL: %s\n' "$*" >&2
+  exit 1
+}
+
+WORKSPACE="11111111-1111-1111-1111-111111111111"
+ROOT="$FIXTURE/workspaces"
+REMOTE="$FIXTURE/remote.git"
+mkdir -p "$ROOT/$WORKSPACE"
+git init --bare "$REMOTE" >/dev/null
+SEED="$FIXTURE/seed"
+git clone "$REMOTE" "$SEED" >/dev/null
+git -C "$SEED" config user.email test@example.com
+git -C "$SEED" config user.name Test
+printf 'seed\n' > "$SEED/tracked.txt"
+git -C "$SEED" add tracked.txt
+git -C "$SEED" commit -m seed >/dev/null
+git -C "$SEED" push -u origin HEAD >/dev/null
+
+make_task() {
+  local id="$1" completed="$2"
+  local task="$ROOT/$WORKSPACE/$id"
+  mkdir -p "$task/workdir"
+  printf '{"kind":"issue","issue_id":"%s","workspace_id":"%s","completed_at":"%s"}\n' \
+    "$id" "$WORKSPACE" "$completed" > "$task/.gc_meta.json"
+}
+
+OLD="2020-01-01T00:00:00Z"
+YOUNG="$(date -u '+%Y-%m-%dT%H:%M:%SZ')"
+make_task aaaaaaaa "$OLD"
+git clone "$REMOTE" "$ROOT/$WORKSPACE/aaaaaaaa/workdir/repo" >/dev/null
+
+make_task bbbbbbbb "$OLD"
+git clone "$REMOTE" "$ROOT/$WORKSPACE/bbbbbbbb/workdir/repo" >/dev/null
+printf 'dirty\n' > "$ROOT/$WORKSPACE/bbbbbbbb/workdir/repo/unique.txt"
+mkdir -p "$ROOT/$WORKSPACE/bbbbbbbb/workdir/repo/node_modules/pkg"
+printf 'cache\n' > "$ROOT/$WORKSPACE/bbbbbbbb/workdir/repo/node_modules/pkg/cache"
+
+make_task cccccccc "$OLD"
+git clone "$REMOTE" "$ROOT/$WORKSPACE/cccccccc/workdir/repo" >/dev/null
+git -C "$ROOT/$WORKSPACE/cccccccc/workdir/repo" config user.email test@example.com
+git -C "$ROOT/$WORKSPACE/cccccccc/workdir/repo" config user.name Test
+printf 'ahead\n' >> "$ROOT/$WORKSPACE/cccccccc/workdir/repo/tracked.txt"
+git -C "$ROOT/$WORKSPACE/cccccccc/workdir/repo" add tracked.txt
+git -C "$ROOT/$WORKSPACE/cccccccc/workdir/repo" commit -m ahead >/dev/null
+mkdir -p "$ROOT/$WORKSPACE/cccccccc/workdir/repo/.next/cache"
+printf 'cache\n' > "$ROOT/$WORKSPACE/cccccccc/workdir/repo/.next/cache/data"
+
+make_task dddddddd "$OLD"
+mkdir -p "$ROOT/$WORKSPACE/dddddddd/workdir/node_modules/pkg"
+printf 'active\n' > "$ROOT/$WORKSPACE/dddddddd/workdir/node_modules/pkg/cache"
+make_task eeeeeeee "$YOUNG"
+
+COMMON_ENV=(
+  "MULTICA_CLEANUP_ROOTS=$ROOT"
+  "MULTICA_CLEANUP_FREE_GIB_OVERRIDE=1"
+  "MULTICA_CLEANUP_MIN_FREE_GIB=22"
+  "MULTICA_CLEANUP_AGE_MINUTES=60"
+  "MULTICA_CLEANUP_ACTIVE_PATHS=$ROOT/$WORKSPACE/dddddddd/workdir"
+)
+
+env "${COMMON_ENV[@]}" "$SCRIPT_DIR/multica-workspace-cleanup" --dry-run > "$FIXTURE/workspace-dry.jsonl"
+grep -q '"path": ".*aaaaaaaa".*"action": "would_delete"\|"action": "would_delete".*"path": ".*aaaaaaaa"' "$FIXTURE/workspace-dry.jsonl" || fail "clean terminal task not selected"
+grep -q 'repo_guard:dirty:1' "$FIXTURE/workspace-dry.jsonl" || fail "dirty task not protected"
+grep -q 'repo_guard:ahead:1' "$FIXTURE/workspace-dry.jsonl" || fail "ahead task not protected"
+grep -q '"reason": "active_path"' "$FIXTURE/workspace-dry.jsonl" || fail "active task not protected"
+grep -q '"reason": "ttl_not_elapsed"' "$FIXTURE/workspace-dry.jsonl" || fail "young task not protected"
+
+env "${COMMON_ENV[@]}" "$SCRIPT_DIR/multica-workspace-cleanup" > "$FIXTURE/workspace-real.jsonl"
+[ ! -e "$ROOT/$WORKSPACE/aaaaaaaa" ] || fail "clean task not deleted"
+[ -e "$ROOT/$WORKSPACE/bbbbbbbb/workdir/repo/unique.txt" ] || fail "dirty task changed"
+[ -e "$ROOT/$WORKSPACE/cccccccc/workdir/repo/tracked.txt" ] || fail "ahead task changed"
+[ -e "$ROOT/$WORKSPACE/dddddddd" ] || fail "active task deleted"
+[ -e "$ROOT/$WORKSPACE/eeeeeeee" ] || fail "young task deleted"
+[ ! -e "$ROOT/$WORKSPACE/bbbbbbbb/workdir/repo/node_modules" ] || fail "dirty task regenerable artifact not pruned"
+[ ! -e "$ROOT/$WORKSPACE/cccccccc/workdir/repo/.next" ] || fail "ahead task regenerable artifact not pruned"
+[ -e "$ROOT/$WORKSPACE/dddddddd/workdir/node_modules/pkg/cache" ] || fail "active task artifact pruned"
+
+MARKER="$FIXTURE/insufficient-side-effect"
+set +e
+MULTICA_HEAVY_BATCH_FREE_GIB_OVERRIDE=21 \
+MULTICA_HEAVY_BATCH_STATE_DIR="$FIXTURE/state-insufficient" \
+  "$SCRIPT_DIR/multica-heavy-batch" \
+  --operation release-amd64 --owner KAP-1184 -- /usr/bin/touch "$MARKER" \
+  > "$FIXTURE/heavy-insufficient.log" 2>&1
+RC=$?
+set -e
+[ "$RC" -eq 75 ] || fail "insufficient preflight rc=$RC"
+[ ! -e "$MARKER" ] || fail "insufficient preflight created side effect"
+grep -q 'side_effects=none' "$FIXTURE/heavy-insufficient.log" || fail "parked result missing"
+
+FAKE_COLIMA="$FIXTURE/fake-colima"
+FAKE_DOCKER="$FIXTURE/fake-docker"
+cat > "$FAKE_COLIMA" <<'SH'
+#!/bin/bash
+set -u
+case "$1" in
+  list) printf 'PROFILE STATUS\n' ;;
+  status) [ -e "$FAKE_RUNTIME_STATE/profile-running" ] ;;
+  start) touch "$FAKE_RUNTIME_STATE/profile-running" ;;
+  ssh)
+    if printf '%s\n' "$*" | grep -q fstrim; then
+      touch "$FAKE_RUNTIME_STATE/fstrim"
+      printf '/: 1073741824 bytes trimmed\n'
+    else
+      printf 'Filesystem 1024-blocks Used Available Capacity Mounted on\n'
+      printf '/dev/test 999999 1 999998 1%% /\n'
+    fi
+    ;;
+  stop) touch "$FAKE_RUNTIME_STATE/stopped"; rm -f "$FAKE_RUNTIME_STATE/profile-running" ;;
+  delete) touch "$FAKE_RUNTIME_STATE/deleted"; rm -f "$FAKE_RUNTIME_STATE/profile-running" ;;
+  *) exit 0 ;;
+esac
+SH
+cat > "$FAKE_DOCKER" <<'SH'
+#!/bin/bash
+set -u
+case "$*" in
+  *" ps -q"*) exit 0 ;;
+  *) exit 0 ;;
+esac
+SH
+chmod +x "$FAKE_COLIMA" "$FAKE_DOCKER"
+
+SUCCESS_TEMP="$FIXTURE/tmp.kap-1184.success"
+PROTECTED_TEMP="$FIXTURE/tmp.keep"
+mkdir -p "$SUCCESS_TEMP" "$PROTECTED_TEMP"
+export FAKE_RUNTIME_STATE="$FIXTURE/fake-runtime"
+mkdir -p "$FAKE_RUNTIME_STATE"
+MULTICA_HEAVY_BATCH_FREE_GIB_OVERRIDE=30 \
+MULTICA_HEAVY_BATCH_STATE_DIR="$FIXTURE/state-success" \
+MULTICA_HEAVY_BATCH_COLIMA_BIN="$FAKE_COLIMA" \
+MULTICA_HEAVY_BATCH_DOCKER_BIN="$FAKE_DOCKER" \
+  "$SCRIPT_DIR/multica-heavy-batch" \
+  --operation release-amd64 --owner KAP-1184 \
+  --profile kap1184-amd64 --temp-root "$SUCCESS_TEMP" \
+  -- /usr/bin/true \
+  > "$FIXTURE/heavy-success.log"
+[ ! -e "$SUCCESS_TEMP" ] || fail "success temp root not removed"
+[ -e "$PROTECTED_TEMP" ] || fail "unowned sibling removed"
+[ -e "$FAKE_RUNTIME_STATE/fstrim" ] || fail "fstrim not called"
+[ -e "$FAKE_RUNTIME_STATE/deleted" ] || fail "batch-owned idle profile not deleted"
+
+FAIL_TEMP="$FIXTURE/tmp.kap-1184.failure"
+mkdir -p "$FAIL_TEMP"
+set +e
+MULTICA_HEAVY_BATCH_FREE_GIB_OVERRIDE=30 \
+MULTICA_HEAVY_BATCH_STATE_DIR="$FIXTURE/state-failure" \
+  "$SCRIPT_DIR/multica-heavy-batch" \
+  --operation next-build --owner KAP-1184 --temp-root "$FAIL_TEMP" \
+  -- /bin/sh -c 'exit 7' > "$FIXTURE/heavy-failure.log"
+RC=$?
+set -e
+[ "$RC" -eq 7 ] || fail "controlled failure rc=$RC"
+[ ! -e "$FAIL_TEMP" ] || fail "failure temp root not removed"
+[ -e "$PROTECTED_TEMP" ] || fail "failure removed unowned sibling"
+
+FAKE_PREVIEW_DOCKER="$FIXTURE/fake-preview-docker"
+cat > "$FAKE_PREVIEW_DOCKER" <<'SH'
+#!/bin/bash
+set -u
+if printf '%s\n' "$*" | grep -q 'ps -aq'; then
+  printf 'expired\nactive\n'
+elif printf '%s\n' "$*" | grep -q 'inspect expired'; then
+  printf '[{"Name":"/expired","Config":{"Labels":{"ai.multica.owner":"KAP-1184","ai.multica.expires-at":"2020-01-01T00:00:00Z"}},"State":{"Status":"exited"}}]\n'
+elif printf '%s\n' "$*" | grep -q 'inspect active'; then
+  printf '[{"Name":"/active","Config":{"Labels":{"ai.multica.owner":"KAP-1184","ai.multica.expires-at":"2020-01-01T00:00:00Z"}},"State":{"Status":"running"}}]\n'
+elif printf '%s\n' "$*" | grep -q 'rm expired'; then
+  touch "$FAKE_PREVIEW_STATE/expired-removed"
+elif printf '%s\n' "$*" | grep -q 'ps -aq'; then
+  exit 0
+elif printf '%s\n' "$*" | grep -q 'images --no-trunc'; then
+  exit 0
+fi
+SH
+chmod +x "$FAKE_PREVIEW_DOCKER"
+FAKE_PREVIEW_COLIMA="$FIXTURE/fake-preview-colima"
+cat > "$FAKE_PREVIEW_COLIMA" <<'SH'
+#!/bin/bash
+set -u
+case "$1" in
+  ssh) touch "$FAKE_PREVIEW_STATE/fstrim" ;;
+  delete) touch "$FAKE_PREVIEW_STATE/profile-deleted" ;;
+esac
+SH
+chmod +x "$FAKE_PREVIEW_COLIMA"
+export FAKE_PREVIEW_STATE="$FIXTURE/fake-preview-state"
+mkdir -p "$FAKE_PREVIEW_STATE"
+MULTICA_PREVIEW_PROFILES=kap1184-amd64 \
+MULTICA_PREVIEW_DOCKER_BIN="$FAKE_PREVIEW_DOCKER" \
+MULTICA_PREVIEW_COLIMA_BIN="$FAKE_PREVIEW_COLIMA" \
+  "$SCRIPT_DIR/multica-preview-cleanup" > "$FIXTURE/preview.log"
+[ -e "$FAKE_PREVIEW_STATE/expired-removed" ] || fail "expired terminal preview not removed"
+grep -q '"reason": "active:running"' "$FIXTURE/preview.log" || fail "active preview not protected"
+[ ! -e "$FAKE_PREVIEW_STATE/profile-deleted" ] || fail "profile with active preview deleted"
+
+printf 'PASS: capacity loop protection and cleanup tests\n'


### PR DESCRIPTION
## Summary

- add fail-closed T-0 budgets and serialized owner-bound Colima batch cleanup
- add threshold/TTL workspace GC with terminal, lsof, dirty, upstream and ahead guards
- add labelled preview TTL cleanup, fstrim, canary fixture and operating matrix

## Verification

- `python3 -m py_compile scripts/macos/multica-workspace-cleanup scripts/macos/multica-preview-cleanup`
- `bash -n scripts/macos/multica-heavy-batch scripts/macos/multica-preview-run scripts/macos/test-capacity-loop.sh`
- `scripts/macos/test-capacity-loop.sh`
- real non-production KAP-1184 canary: PASS; post-batch delta -0.83 GiB; profile removed
- synthetic 21 GiB release preflight: exit 75, no side effects

Closes KAP-1184
