### PR TITLE
MUL-5433: fix(agent/hermes): pin session id mid-flight for daemon resume

### DIFF
--- a/server/pkg/agent/hermes.go
+++ b/server/pkg/agent/hermes.go
@@ -431,6 +431,8 @@ func (b *hermesBackend) Execute(ctx context.Context, prompt string, opts ExecOpt
 
 		c.sessionID = sessionID
 		b.cfg.Logger.Info("hermes session created", "session_id", sessionID)
+		// Mid-flight pin: daemon PinTaskSession keys off MessageStatus+SessionID.
+		trySend(msgCh, Message{Type: MessageStatus, Status: "running", SessionID: sessionID})
 
 		// 3. If the caller picked a model (via agent.model from the
 		// UI dropdown), ask hermes to switch the session to it

--- a/server/pkg/agent/hermes_test.go
+++ b/server/pkg/agent/hermes_test.go
@@ -864,6 +864,97 @@ func TestHermesClientAcceptNotificationGate(t *testing.T) {
 	}
 }
 
+// TestHermesBackendEmitsSessionStatusBeforeCompletion pins the producer side
+// of the daemon's mid-flight resume contract. Both a fresh session and a
+// resumed session must reveal the effective session ID before the prompt
+// finishes, otherwise a daemon restart can lose the only usable resume pointer.
+func TestHermesBackendEmitsSessionStatusBeforeCompletion(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell-script fixture is POSIX-only")
+	}
+
+	tests := []struct {
+		name            string
+		resumeSessionID string
+		effectiveID     string
+	}{
+		{name: "fresh", effectiveID: "ses_new"},
+		{name: "resume uses returned id", resumeSessionID: "ses_old", effectiveID: "ses_resumed"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tempDir := t.TempDir()
+			fakePath := filepath.Join(tempDir, "hermes")
+			gatePath := filepath.Join(tempDir, "release-prompt")
+			script := fmt.Sprintf(`#!/bin/sh
+while IFS= read -r line; do
+  id=$(printf '%%s' "$line" | sed -n 's/.*"id":\([0-9]*\).*/\1/p')
+  case "$line" in
+    *'"method":"initialize"'*)
+      printf '{"jsonrpc":"2.0","id":%%s,"result":{"protocolVersion":1,"agentCapabilities":{}}}\n' "$id"
+      ;;
+    *'"method":"session/new"'*|*'"method":"session/resume"'*)
+      printf '{"jsonrpc":"2.0","id":%%s,"result":{"sessionId":"%s"}}\n' "$id"
+      ;;
+    *'"method":"session/prompt"'*)
+      while [ ! -f "$HERMES_TEST_GATE" ]; do sleep 0.01; done
+      printf '{"jsonrpc":"2.0","id":%%s,"result":{"stopReason":"end_turn"}}\n' "$id"
+      exit 0
+      ;;
+  esac
+done
+`, tt.effectiveID)
+			writeTestExecutable(t, fakePath, []byte(script))
+
+			backend, err := New("hermes", Config{
+				ExecutablePath: fakePath,
+				Logger:         slog.Default(),
+				Env:            map[string]string{"HERMES_TEST_GATE": gatePath},
+			})
+			if err != nil {
+				t.Fatalf("new hermes backend: %v", err)
+			}
+
+			ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+			defer cancel()
+			session, err := backend.Execute(ctx, "prompt", ExecOptions{
+				ResumeSessionID: tt.resumeSessionID,
+				Timeout:         10 * time.Second,
+			})
+			if err != nil {
+				t.Fatalf("execute: %v", err)
+			}
+
+			select {
+			case msg, ok := <-session.Messages:
+				if !ok {
+					t.Fatal("message channel closed before session status")
+				}
+				if msg.Type != MessageStatus || msg.Status != "running" || msg.SessionID != tt.effectiveID {
+					t.Fatalf("session status = %+v, want running with session ID %q", msg, tt.effectiveID)
+				}
+			case result := <-session.Result:
+				t.Fatalf("terminal result arrived before session status: %+v", result)
+			case <-time.After(5 * time.Second):
+				t.Fatal("timeout waiting for mid-flight session status")
+			}
+
+			if err := os.WriteFile(gatePath, []byte("release"), 0o600); err != nil {
+				t.Fatalf("release prompt: %v", err)
+			}
+			select {
+			case result := <-session.Result:
+				if result.Status != "completed" || result.SessionID != tt.effectiveID {
+					t.Fatalf("result = %+v, want completed with session ID %q", result, tt.effectiveID)
+				}
+			case <-time.After(10 * time.Second):
+				t.Fatal("timeout waiting for terminal result")
+			}
+		})
+	}
+}
+
 func TestHermesBackendDrainsLateFinalNotificationAfterPromptResponse(t *testing.T) {
 	t.Parallel()
 	if runtime.GOOS == "windows" {


### PR DESCRIPTION
## Summary

Hermes was the only ACP-backed agent that created a session without emitting a
running status carrying the session id, so a daemon restart or mid-flight cancel
left the resume pointer empty and the task could not resume.

This adds the missing mid-flight session pin — a single `MessageStatus`+`SessionID`
emit immediately after session create — matching `claude`, `codebuddy`, `codex`,
`grok`, and `qwen`.

## Why

`server/internal/daemon/daemon.go` already listens for `MessageStatus` carrying a
`SessionID` and calls `PinTaskSession` so an in-flight task can resume after a
daemon crash/restart. Every other ACP/streaming backend emits that pin the moment
its session id is known. Hermes logged `hermes session created` and then moved on
without emitting it, so for Hermes tasks the pin never fired and resume silently
failed.

## Change

`server/pkg/agent/hermes.go` — 2 lines, immediately after
`b.cfg.Logger.Info("hermes session created", ...)`:

```go
// Mid-flight pin: daemon PinTaskSession keys off MessageStatus+SessionID.
trySend(msgCh, Message{Type: MessageStatus, Status: "running", SessionID: sessionID})
```

No daemon, SQL, or other-backend changes.

## Relationship to #4969

Companion to #4969, which owns the daemon/SQL cancel-salvage path
(`UpdateAgentTaskSession` for failed/cancelled tasks). This PR is intentionally
Hermes-only so the two do not collide on the same branch.

Note: the daemon `MessageStatus` → `PinTaskSession` listener is already on `main`,
so this Hermes pin takes effect on its own once merged — full mid-cancel resume for
failed/cancelled tasks additionally depends on the #4969 work landing.

## Verification

Branched from latest `main` (`0abee490`); head `88f5056b`.

```
$ go build ./pkg/agent/...      # exit 0, clean
$ go test ./pkg/agent/ -run Hermes -count=1
ok  	github.com/multica-ai/multica/server/pkg/agent	3.556s
```

The diff mirrors the pattern already used by the sibling backends listed above.
