### PR TITLE
fix(editor): open mention and slash pickers only for typed triggers (MUL-5429)

### DIFF
--- a/packages/views/editor/extensions/index.ts
+++ b/packages/views/editor/extensions/index.ts
@@ -45,6 +45,7 @@ import {
 } from "./issue-identifier-autolink";
 import { SlashCommandExtension } from "./slash-command-extension";
 import { createSlashCommandSuggestion, createBuiltinCommandSuggestion } from "./slash-command-suggestion";
+import { SuggestionTriggerArmingExtension } from "./suggestion-trigger-arming";
 import { CodeBlockView } from "./code-block-view";
 import { PatchedListItem, PatchedTaskItem } from "./list-item";
 import { createMarkdownPasteExtension } from "./markdown-paste";
@@ -241,6 +242,9 @@ export function createEditorExtensions(
     // so users can copy rich content out as the original Markdown.
     createMarkdownCopyExtension(),
     FileCardExtension,
+    // Must precede the mention and slash pickers: it supplies the "the user
+    // typed this trigger" signal their `shouldShow` reads (MUL-5429).
+    SuggestionTriggerArmingExtension,
     BaseMentionExtension.configure({
       HTMLAttributes: { class: "mention" },
       ...(options.disableMentions

--- a/packages/views/editor/extensions/issue-identifier-autolink.test.ts
+++ b/packages/views/editor/extensions/issue-identifier-autolink.test.ts
@@ -3,8 +3,10 @@ import { Editor } from "@tiptap/core";
 import StarterKit from "@tiptap/starter-kit";
 import Link from "@tiptap/extension-link";
 import { Markdown } from "@tiptap/markdown";
+import { EditorView } from "@tiptap/pm/view";
 import type { RefObject } from "react";
 import { BaseMentionExtension } from "./mention-extension";
+import { createMarkdownPasteExtension } from "./markdown-paste";
 import {
   createIssueIdentifierAutolinkExtension,
   type IssueIdentifierResolver,
@@ -48,6 +50,12 @@ function makeEditor(): Editor {
       TestMention,
       createIssueIdentifierAutolinkExtension({ resolveRef }),
       Markdown.configure({ indentation: { style: "space", size: 3 } }),
+      // The extension the real editor pastes through. It is a catch-all
+      // `handlePaste` that dispatches its own transaction, so it — not
+      // ProseMirror — decides whether this extension can tell a paste from
+      // typing. Leaving it out is what let the paste cases below pass against a
+      // hand-stamped meta the product never produced (MUL-5429).
+      createMarkdownPasteExtension(),
     ],
   });
 }
@@ -55,6 +63,19 @@ function makeEditor(): Editor {
 /** Flush the resolver microtask + the follow-up replacement dispatch. */
 function flush(): Promise<void> {
   return new Promise((r) => setTimeout(r, 0));
+}
+
+/** Fire a real paste event, so the whole handlePaste chain runs. */
+function paste(ed: Editor, text: string): void {
+  ed.commands.focus("start");
+  const event = new Event("paste", { bubbles: false, cancelable: true });
+  Object.defineProperty(event, "clipboardData", {
+    value: {
+      files: [],
+      getData: (type: string) => (type === "text/plain" ? text : ""),
+    },
+  });
+  ed.view.dom.dispatchEvent(event);
 }
 
 /** Simulate user typing `text` at position 1 (empty paragraph start). */
@@ -65,6 +86,10 @@ function typeAt1(ed: Editor, text: string): void {
 
 beforeEach(() => {
   resolveMock.mockReset();
+  // jsdom has no layout; ProseMirror's post-dispatch scroll needs client rects.
+  (EditorView.prototype as unknown as { scrollToSelection: () => void }).scrollToSelection =
+    () => {};
+  Element.prototype.scrollIntoView = () => {};
 });
 
 afterEach(() => {
@@ -106,9 +131,7 @@ describe("createIssueIdentifierAutolinkExtension", () => {
     resolveMock.mockResolvedValue({ id: "uuid-2", identifier: "MUL-2" });
     editor = makeEditor();
 
-    const tr = editor.state.tr.insertText("See MUL-2 now", 1);
-    tr.setMeta("paste", true);
-    editor.view.dispatch(tr);
+    paste(editor, "See MUL-2 now");
     await flush();
 
     expect(resolveMock).toHaveBeenCalledWith("MUL-2");
@@ -208,9 +231,7 @@ describe("createIssueIdentifierAutolinkExtension", () => {
     await flush();
 
     // Paste two identifiers at the very start of the doc.
-    const tr = editor.state.tr.insertText("MUL-2 plus MUL-3 x ", 1);
-    tr.setMeta("paste", true);
-    editor.view.dispatch(tr);
+    paste(editor, "MUL-2 plus MUL-3 x ");
     await flush();
 
     const md = editor.getMarkdown();

--- a/packages/views/editor/extensions/markdown-paste.ts
+++ b/packages/views/editor/extensions/markdown-paste.ts
@@ -26,7 +26,8 @@
  * enough by themselves, because those should still paste as Markdown source.
  */
 import { Extension } from "@tiptap/core";
-import { Plugin, PluginKey } from "@tiptap/pm/state";
+import { Plugin, PluginKey, type Transaction } from "@tiptap/pm/state";
+import type { EditorView } from "@tiptap/pm/view";
 import {
   Fragment,
   Slice,
@@ -407,6 +408,26 @@ function repairFragmentedOrderedLists(slice: Slice): Slice {
   return new Slice(content, slice.openStart, slice.openEnd);
 }
 
+/**
+ * Marks a transaction as the commit of a paste, the way ProseMirror marks its
+ * own.
+ *
+ * `doPaste` stamps `paste` / `uiEvent` on the transaction it dispatches, but it
+ * returns early once a `handlePaste` prop claims the event — and this extension
+ * is a catch-all that claims nearly every paste. Anything downstream that asks
+ * "did this text arrive by paste?" therefore sees an unmarked transaction and
+ * treats a paste as typing. `issueIdentifierAutolink` reads exactly that, and
+ * without the mark it only ever inspects the token before the caret, so pasting
+ * `See MUL-2 now` autolinks nothing (MUL-5429).
+ *
+ * ProseMirror's author describes these metas as the contract third-party code
+ * relies on to tell user events apart, so any custom `handlePaste` that
+ * dispatches its own transaction owes them.
+ */
+function dispatchPaste(view: EditorView, tr: Transaction): void {
+  view.dispatch(tr.setMeta("paste", true).setMeta("uiEvent", "paste"));
+}
+
 export function createMarkdownPasteExtension() {
   return Extension.create({
     name: "markdownPaste",
@@ -438,12 +459,10 @@ export function createMarkdownPasteExtension() {
                 if (html && !html.includes("data-pm-slice")) {
                   const repaired = repairFragmentedOrderedLists(slice);
                   if (repaired !== slice) {
-                    const tr = view.state.tr
-                      .replaceSelection(repaired)
-                      .scrollIntoView()
-                      .setMeta("paste", true)
-                      .setMeta("uiEvent", "paste");
-                    view.dispatch(tr);
+                    dispatchPaste(
+                      view,
+                      view.state.tr.replaceSelection(repaired).scrollIntoView(),
+                    );
                     return true;
                   }
                 }
@@ -451,7 +470,7 @@ export function createMarkdownPasteExtension() {
               }
 
               if (mode === "literal") {
-                view.dispatch(view.state.tr.insertText(text));
+                dispatchPaste(view, view.state.tr.insertText(text));
                 return true;
               }
 
@@ -470,13 +489,12 @@ export function createMarkdownPasteExtension() {
                   first?.type.name === "paragraph" &&
                   first.content.size === 0);
               if (text.trim() && parsedEmpty) {
-                view.dispatch(view.state.tr.insertText(text));
+                dispatchPaste(view, view.state.tr.insertText(text));
                 return true;
               }
 
               const parsedSlice = Slice.maxOpen(node.content);
-              const tr = view.state.tr.replaceSelection(parsedSlice);
-              view.dispatch(tr);
+              dispatchPaste(view, view.state.tr.replaceSelection(parsedSlice));
               return true;
             },
           },

--- a/packages/views/editor/extensions/mention-suggestion.test.tsx
+++ b/packages/views/editor/extensions/mention-suggestion.test.tsx
@@ -51,6 +51,7 @@ vi.mock("@multica/core/auth", () => ({
 
 import {
   createMentionSuggestion,
+  MAX_MENTION_QUERY_LENGTH,
   MentionList,
   type MentionListRef,
   type MentionItem,
@@ -129,11 +130,77 @@ function itemArgs(query: string) {
   };
 }
 
+// shouldShow() args. `uiEvent` mirrors the meta ProseMirror stamps on the
+// transaction that inserts pasted ("paste") or dropped ("drop") content;
+// ordinary typing leaves it undefined.
+function shouldShowArgs(query: string, uiEvent?: "paste" | "drop") {
+  return {
+    query,
+    text: `@${query}`,
+    editor: {} as never,
+    range: { from: 0, to: query.length + 1 },
+    transaction: {
+      getMeta: (key: string) => (key === "uiEvent" ? uiEvent : undefined),
+    } as never,
+  };
+}
+
 describe("createMentionSuggestion", () => {
   beforeEach(() => {
     searchIssuesMock.mockReset();
     searchProjectsMock.mockReset();
     Element.prototype.scrollIntoView = vi.fn();
+  });
+
+  // -------------------------------------------------------------------------
+  // shouldShow — MUL-5429. `allowSpaces` lets the suggestion regex run from the
+  // `@` to the end of the line, so pasting `npx @scope/pkg --token=eyJ...`
+  // opened an empty picker that then swallowed Enter (the empty-list Enter
+  // capture below is deliberate, so the fix has to stop the picker opening at
+  // all rather than change that key handling).
+  // -------------------------------------------------------------------------
+
+  it("keeps the picker shut for the transaction that pastes text containing @", () => {
+    const config = createMentionSuggestion(fakeQc({}));
+
+    expect(config.shouldShow!(shouldShowArgs("aiforui/install --token=eyJhbG", "paste"))).toBe(false);
+  });
+
+  it("keeps the picker shut for dropped text containing @", () => {
+    const config = createMentionSuggestion(fakeQc({}));
+
+    expect(config.shouldShow!(shouldShowArgs("aiforui/install", "drop"))).toBe(false);
+  });
+
+  it("keeps the picker shut once the query outgrows any real mention target", () => {
+    const config = createMentionSuggestion(fakeQc({}));
+    const overLong = "a".repeat(MAX_MENTION_QUERY_LENGTH + 1);
+
+    // Not a paste transaction — this is the tail guard for edits made after the
+    // pasted text has already landed in the document.
+    expect(config.shouldShow!(shouldShowArgs(overLong))).toBe(false);
+  });
+
+  it("still opens for a typed query, including a long multi-word issue search", () => {
+    const config = createMentionSuggestion(fakeQc({}));
+
+    expect(config.shouldShow!(shouldShowArgs("alice"))).toBe(true);
+    expect(config.shouldShow!(shouldShowArgs("login redirect bug on desktop"))).toBe(true);
+    // Exactly at the cap is still a mention; the cap is inclusive.
+    expect(config.shouldShow!(shouldShowArgs("a".repeat(MAX_MENTION_QUERY_LENGTH)))).toBe(true);
+  });
+
+  // Known boundary, documented in the MUL-5429 PR: a SHORT pasted `@` token
+  // (query under the cap) is blocked on the paste transaction itself, but the
+  // next keystroke is an ordinary transaction with a still-short query, so the
+  // picker legitimately re-opens. No threshold can close this — it is inherent
+  // to `allowSpaces`. It is acceptable because the Escape fix means one Escape
+  // now dismisses just the picker instead of the whole dialog.
+  it("re-opens after a short pasted token once the user keeps typing (known boundary)", () => {
+    const config = createMentionSuggestion(fakeQc({}));
+
+    expect(config.shouldShow!(shouldShowArgs("foo/bar", "paste"))).toBe(false);
+    expect(config.shouldShow!(shouldShowArgs("foo/bar"))).toBe(true);
   });
 
   it("keeps the mention query active across spaces for multi-word search", () => {

--- a/packages/views/editor/extensions/mention-suggestion.test.tsx
+++ b/packages/views/editor/extensions/mention-suggestion.test.tsx
@@ -51,7 +51,6 @@ vi.mock("@multica/core/auth", () => ({
 
 import {
   createMentionSuggestion,
-  MAX_MENTION_QUERY_LENGTH,
   MentionList,
   type MentionListRef,
   type MentionItem,
@@ -130,77 +129,11 @@ function itemArgs(query: string) {
   };
 }
 
-// shouldShow() args. `uiEvent` mirrors the meta ProseMirror stamps on the
-// transaction that inserts pasted ("paste") or dropped ("drop") content;
-// ordinary typing leaves it undefined.
-function shouldShowArgs(query: string, uiEvent?: "paste" | "drop") {
-  return {
-    query,
-    text: `@${query}`,
-    editor: {} as never,
-    range: { from: 0, to: query.length + 1 },
-    transaction: {
-      getMeta: (key: string) => (key === "uiEvent" ? uiEvent : undefined),
-    } as never,
-  };
-}
-
 describe("createMentionSuggestion", () => {
   beforeEach(() => {
     searchIssuesMock.mockReset();
     searchProjectsMock.mockReset();
     Element.prototype.scrollIntoView = vi.fn();
-  });
-
-  // -------------------------------------------------------------------------
-  // shouldShow — MUL-5429. `allowSpaces` lets the suggestion regex run from the
-  // `@` to the end of the line, so pasting `npx @scope/pkg --token=eyJ...`
-  // opened an empty picker that then swallowed Enter (the empty-list Enter
-  // capture below is deliberate, so the fix has to stop the picker opening at
-  // all rather than change that key handling).
-  // -------------------------------------------------------------------------
-
-  it("keeps the picker shut for the transaction that pastes text containing @", () => {
-    const config = createMentionSuggestion(fakeQc({}));
-
-    expect(config.shouldShow!(shouldShowArgs("aiforui/install --token=eyJhbG", "paste"))).toBe(false);
-  });
-
-  it("keeps the picker shut for dropped text containing @", () => {
-    const config = createMentionSuggestion(fakeQc({}));
-
-    expect(config.shouldShow!(shouldShowArgs("aiforui/install", "drop"))).toBe(false);
-  });
-
-  it("keeps the picker shut once the query outgrows any real mention target", () => {
-    const config = createMentionSuggestion(fakeQc({}));
-    const overLong = "a".repeat(MAX_MENTION_QUERY_LENGTH + 1);
-
-    // Not a paste transaction — this is the tail guard for edits made after the
-    // pasted text has already landed in the document.
-    expect(config.shouldShow!(shouldShowArgs(overLong))).toBe(false);
-  });
-
-  it("still opens for a typed query, including a long multi-word issue search", () => {
-    const config = createMentionSuggestion(fakeQc({}));
-
-    expect(config.shouldShow!(shouldShowArgs("alice"))).toBe(true);
-    expect(config.shouldShow!(shouldShowArgs("login redirect bug on desktop"))).toBe(true);
-    // Exactly at the cap is still a mention; the cap is inclusive.
-    expect(config.shouldShow!(shouldShowArgs("a".repeat(MAX_MENTION_QUERY_LENGTH)))).toBe(true);
-  });
-
-  // Known boundary, documented in the MUL-5429 PR: a SHORT pasted `@` token
-  // (query under the cap) is blocked on the paste transaction itself, but the
-  // next keystroke is an ordinary transaction with a still-short query, so the
-  // picker legitimately re-opens. No threshold can close this — it is inherent
-  // to `allowSpaces`. It is acceptable because the Escape fix means one Escape
-  // now dismisses just the picker instead of the whole dialog.
-  it("re-opens after a short pasted token once the user keeps typing (known boundary)", () => {
-    const config = createMentionSuggestion(fakeQc({}));
-
-    expect(config.shouldShow!(shouldShowArgs("foo/bar", "paste"))).toBe(false);
-    expect(config.shouldShow!(shouldShowArgs("foo/bar"))).toBe(true);
   });
 
   it("keeps the mention query active across spaces for multi-word search", () => {

--- a/packages/views/editor/extensions/mention-suggestion.tsx
+++ b/packages/views/editor/extensions/mention-suggestion.tsx
@@ -42,11 +42,8 @@ import {
   sortUserItemsByRecency,
 } from "./mention-recency";
 import { matchesPinyin } from "./pinyin-match";
-import {
-  createSuggestionPopupRender,
-  isPasteLikeTransaction,
-  isPickerAcceptKey,
-} from "./suggestion-popup";
+import { createSuggestionPopupRender, isPickerAcceptKey } from "./suggestion-popup";
+import { isTriggerArmedAt } from "./suggestion-trigger-arming";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -123,17 +120,6 @@ function groupItems(items: MentionItem[]): MentionGroup[] {
 // ---------------------------------------------------------------------------
 
 const MAX_ITEMS = 20;
-/**
- * Longest `@` query the picker will stay open for.
- *
- * `allowSpaces` makes the suggestion regex run from the `@` to the end of the
- * line, so a pasted line like `npx @scope/pkg --token=eyJ...` becomes one
- * enormous query that matches nothing — and the resulting empty popup captures
- * Enter, so the user cannot type a newline (MUL-5429). Real targets (member /
- * agent / squad names, issue identifiers and titles) sit well under this cap,
- * so it only ever fires on text that was never a mention in the first place.
- */
-export const MAX_MENTION_QUERY_LENGTH = 60;
 const SERVER_ISSUE_SEARCH_LIMIT = 20;
 const SERVER_CONTEXT_SEARCH_LIMIT = 8;
 const SERVER_SEARCH_DEBOUNCE_MS = 150;
@@ -632,15 +618,10 @@ export function createMentionSuggestion(
   return {
     pluginKey,
     allowSpaces: true,
-    shouldShow: ({ query, transaction }) => {
-      // Pasted/dropped text is not a mention intent even when it contains `@`.
-      if (isPasteLikeTransaction(transaction)) return false;
-
-      // Guards the tail of the same bug: once pasted `@…` text sits in the
-      // document, later edits are ordinary transactions that the check above no
-      // longer covers. A query this long is never a real mention target.
-      return query.length <= MAX_MENTION_QUERY_LENGTH;
-    },
+    // Only open over an `@` the user actually typed. Tiptap matches on document
+    // content alone, so without this a pasted, dropped, undone or server-loaded
+    // `@` opens the picker just as readily (MUL-5429).
+    shouldShow: ({ editor, range }) => isTriggerArmedAt(editor, range.from),
     items: ({ query }) => {
       if (options.mode === "context") {
         const normalizedQuery = query.trim();

--- a/packages/views/editor/extensions/mention-suggestion.tsx
+++ b/packages/views/editor/extensions/mention-suggestion.tsx
@@ -42,7 +42,11 @@ import {
   sortUserItemsByRecency,
 } from "./mention-recency";
 import { matchesPinyin } from "./pinyin-match";
-import { createSuggestionPopupRender, isPickerAcceptKey } from "./suggestion-popup";
+import {
+  createSuggestionPopupRender,
+  isPasteLikeTransaction,
+  isPickerAcceptKey,
+} from "./suggestion-popup";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -119,6 +123,17 @@ function groupItems(items: MentionItem[]): MentionGroup[] {
 // ---------------------------------------------------------------------------
 
 const MAX_ITEMS = 20;
+/**
+ * Longest `@` query the picker will stay open for.
+ *
+ * `allowSpaces` makes the suggestion regex run from the `@` to the end of the
+ * line, so a pasted line like `npx @scope/pkg --token=eyJ...` becomes one
+ * enormous query that matches nothing — and the resulting empty popup captures
+ * Enter, so the user cannot type a newline (MUL-5429). Real targets (member /
+ * agent / squad names, issue identifiers and titles) sit well under this cap,
+ * so it only ever fires on text that was never a mention in the first place.
+ */
+export const MAX_MENTION_QUERY_LENGTH = 60;
 const SERVER_ISSUE_SEARCH_LIMIT = 20;
 const SERVER_CONTEXT_SEARCH_LIMIT = 8;
 const SERVER_SEARCH_DEBOUNCE_MS = 150;
@@ -617,6 +632,15 @@ export function createMentionSuggestion(
   return {
     pluginKey,
     allowSpaces: true,
+    shouldShow: ({ query, transaction }) => {
+      // Pasted/dropped text is not a mention intent even when it contains `@`.
+      if (isPasteLikeTransaction(transaction)) return false;
+
+      // Guards the tail of the same bug: once pasted `@…` text sits in the
+      // document, later edits are ordinary transactions that the check above no
+      // longer covers. A query this long is never a real mention target.
+      return query.length <= MAX_MENTION_QUERY_LENGTH;
+    },
     items: ({ query }) => {
       if (options.mode === "context") {
         const normalizedQuery = query.trim();

--- a/packages/views/editor/extensions/slash-command-suggestion.tsx
+++ b/packages/views/editor/extensions/slash-command-suggestion.tsx
@@ -19,7 +19,11 @@ import { isImeComposing } from "@multica/core/utils";
 import { workspaceKeys } from "@multica/core/workspace/queries";
 import type { Agent, MemberWithUser } from "@multica/core/types";
 import { useT } from "../../i18n";
-import { createSuggestionPopupRender, isPickerAcceptKey } from "./suggestion-popup";
+import {
+  createSuggestionPopupRender,
+  isPasteLikeTransaction,
+  isPickerAcceptKey,
+} from "./suggestion-popup";
 
 const MAX_ITEMS = 20;
 
@@ -202,6 +206,8 @@ export function createSlashCommandSuggestion(qc: QueryClient): Omit<
   return {
     char: "/",
     pluginKey,
+    // Pasting a path (`/usr/local/bin`) must not open the skill picker.
+    shouldShow: ({ transaction }) => !isPasteLikeTransaction(transaction),
     items: ({ query }) => buildItems(qc, query),
     command: ({ editor, range, props }) => {
       const nodeAfter = editor.view.state.selection.$to.nodeAfter;
@@ -273,6 +279,8 @@ export function createBuiltinCommandSuggestion(): Omit<
   return {
     char: "/",
     pluginKey,
+    // Pasting a path (`/usr/local/bin`) must not open the command menu.
+    shouldShow: ({ transaction }) => !isPasteLikeTransaction(transaction),
     items: ({ query }) => buildBuiltinCommandItems(query),
     command: ({ editor, range, props }) => {
       // Insert the plain-text prefix (e.g. "/note ") rather than a rich node,

--- a/packages/views/editor/extensions/slash-command-suggestion.tsx
+++ b/packages/views/editor/extensions/slash-command-suggestion.tsx
@@ -19,11 +19,8 @@ import { isImeComposing } from "@multica/core/utils";
 import { workspaceKeys } from "@multica/core/workspace/queries";
 import type { Agent, MemberWithUser } from "@multica/core/types";
 import { useT } from "../../i18n";
-import {
-  createSuggestionPopupRender,
-  isPasteLikeTransaction,
-  isPickerAcceptKey,
-} from "./suggestion-popup";
+import { createSuggestionPopupRender, isPickerAcceptKey } from "./suggestion-popup";
+import { isTriggerArmedAt } from "./suggestion-trigger-arming";
 
 const MAX_ITEMS = 20;
 
@@ -206,8 +203,9 @@ export function createSlashCommandSuggestion(qc: QueryClient): Omit<
   return {
     char: "/",
     pluginKey,
-    // Pasting a path (`/usr/local/bin`) must not open the skill picker.
-    shouldShow: ({ transaction }) => !isPasteLikeTransaction(transaction),
+    // Only open over a `/` the user actually typed, so a pasted path
+    // (`/usr/local/bin`) never opens the skill picker (MUL-5429).
+    shouldShow: ({ editor, range }) => isTriggerArmedAt(editor, range.from),
     items: ({ query }) => buildItems(qc, query),
     command: ({ editor, range, props }) => {
       const nodeAfter = editor.view.state.selection.$to.nodeAfter;
@@ -279,8 +277,9 @@ export function createBuiltinCommandSuggestion(): Omit<
   return {
     char: "/",
     pluginKey,
-    // Pasting a path (`/usr/local/bin`) must not open the command menu.
-    shouldShow: ({ transaction }) => !isPasteLikeTransaction(transaction),
+    // Only open over a `/` the user actually typed, so a pasted path
+    // (`/usr/local/bin`) never opens the command menu (MUL-5429).
+    shouldShow: ({ editor, range }) => isTriggerArmedAt(editor, range.from),
     items: ({ query }) => buildBuiltinCommandItems(query),
     command: ({ editor, range, props }) => {
       // Insert the plain-text prefix (e.g. "/note ") rather than a rich node,

--- a/packages/views/editor/extensions/suggestion-popup.test.tsx
+++ b/packages/views/editor/extensions/suggestion-popup.test.tsx
@@ -4,9 +4,13 @@ import StarterKit from "@tiptap/starter-kit";
 import { Suggestion, type SuggestionProps } from "@tiptap/suggestion";
 import { PluginKey } from "@tiptap/pm/state";
 import { forwardRef, useImperativeHandle } from "react";
-import { afterEach, beforeAll, describe, expect, it } from "vitest";
+import { afterEach, beforeAll, describe, expect, it, vi } from "vitest";
 import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
-import { createSuggestionPopupRender, isPickerAcceptKey } from "./suggestion-popup";
+import {
+  createSuggestionPopupRender,
+  isPasteLikeTransaction,
+  isPickerAcceptKey,
+} from "./suggestion-popup";
 import { PatchedListItem } from "./list-item";
 
 interface TestItem {
@@ -72,7 +76,7 @@ afterEach(() => {
   document.body.innerHTML = "";
 });
 
-function makeEditor(char: "@" | "/") {
+function makeEditor(char: "@" | "/", options: { pasteGuard?: boolean } = {}) {
   const pluginKey = new PluginKey(`test-${char}-suggestion`);
   const item = char === "@"
     ? { id: "u1", label: "Alice" }
@@ -86,6 +90,10 @@ function makeEditor(char: "@" | "/") {
           editor: this.editor,
           char,
           pluginKey,
+          // Mirrors the real mention/slash wiring's paste guard (MUL-5429).
+          ...(options.pasteGuard
+            ? { shouldShow: ({ transaction }) => !isPasteLikeTransaction(transaction) }
+            : {}),
           items: () => [item],
           command: ({ editor: ed, range, props }) => {
             ed.commands.insertContentAt(range, `${char}${props.label}`);
@@ -214,6 +222,123 @@ describe("createSuggestionPopupRender", () => {
       });
     },
   );
+});
+
+// ---------------------------------------------------------------------------
+// isPasteLikeTransaction (MUL-5429) — driven through the REAL Suggestion plugin
+// rather than a hand-built props object, so these also pin the meta contract:
+// prosemirror-view commits a paste with `uiEvent: "paste"` and a drop with
+// `uiEvent: "drop"`. If upstream ever renames those, the paired "typed text
+// still opens the picker" case stays green while these go red.
+// ---------------------------------------------------------------------------
+
+describe("paste guard", () => {
+  // Focus first, in its own act(): focusing dispatches selection transactions
+  // of its own, and those carry no uiEvent meta. Landing them BEFORE the
+  // insert keeps the paste/drop transaction the last one applied, so the
+  // assertion reads the picker state that transaction produced. (A later
+  // meta-less transaction re-opening the picker is the documented MUL-5429
+  // boundary, covered in mention-suggestion.test.tsx — not what these pin.)
+  async function pasteLike(ed: Editor, char: "@" | "/", uiEvent: "paste" | "drop") {
+    await act(async () => {
+      ed.commands.focus("end");
+    });
+    await act(async () => {
+      ed.view.dispatch(
+        ed.state.tr.insertText(`npx ${char}scope`).setMeta("uiEvent", uiEvent),
+      );
+    });
+  }
+
+  it.each(["@", "/"] as const)(
+    "keeps the %s picker shut when the trigger arrives in a pasted transaction",
+    async (char) => {
+      const ed = makeEditor(char, { pasteGuard: true });
+
+      await pasteLike(ed, char, "paste");
+
+      expect(screen.queryByTestId("suggestion-popup")).not.toBeInTheDocument();
+    },
+  );
+
+  it.each(["@", "/"] as const)(
+    "keeps the %s picker shut when the trigger arrives in a dropped transaction",
+    async (char) => {
+      const ed = makeEditor(char, { pasteGuard: true });
+
+      await pasteLike(ed, char, "drop");
+
+      expect(screen.queryByTestId("suggestion-popup")).not.toBeInTheDocument();
+    },
+  );
+
+  it.each(["@", "/"] as const)(
+    "still opens the %s picker when the identical text is typed instead of pasted",
+    async (char) => {
+      const ed = makeEditor(char, { pasteGuard: true });
+
+      // Same text, ordinary transaction — proves the two cases above fail for
+      // the paste meta specifically, not because the text never matched.
+      await triggerSuggestion(ed, `npx ${char}scope`);
+
+      expect(screen.getByTestId("suggestion-popup")).toBeInTheDocument();
+    },
+  );
+});
+
+// ---------------------------------------------------------------------------
+// Escape containment (MUL-5429): Escape while a picker is open must close ONLY
+// the picker. ProseMirror calls preventDefault() for a handled key but never
+// stops propagation, and Base UI's dismiss layer listens for Escape on
+// `document` in the BUBBLE phase without consulting defaultPrevented — so
+// without an explicit stopPropagation the same keypress also closed the host
+// create-issue dialog and threw the draft away. The plain document listener
+// below stands in for that dismiss layer.
+// ---------------------------------------------------------------------------
+
+describe("Escape containment while a picker is open", () => {
+  function watchHostEscape() {
+    const hostEscape = vi.fn();
+    document.addEventListener("keydown", hostEscape);
+    return {
+      hostEscape,
+      stop: () => document.removeEventListener("keydown", hostEscape),
+    };
+  }
+
+  it.each(["@", "/"] as const)(
+    "closes the %s popup on Escape without letting the key reach the host dialog",
+    async (char) => {
+      const ed = makeEditor(char);
+      await triggerSuggestion(ed, `${char}a`);
+      const { hostEscape, stop } = watchHostEscape();
+
+      await act(async () => {
+        fireEvent.keyDown(ed.view.dom, { key: "Escape" });
+      });
+      stop();
+
+      await expectPopupClosed();
+      expect(hostEscape).not.toHaveBeenCalled();
+    },
+  );
+
+  it("still lets Escape reach the host when no picker is open", async () => {
+    const ed = makeEditor("@");
+    await act(async () => {
+      ed.commands.focus("end");
+    });
+    const { hostEscape, stop } = watchHostEscape();
+
+    await act(async () => {
+      fireEvent.keyDown(ed.view.dom, { key: "Escape" });
+    });
+    stop();
+
+    // With no picker open Escape is the host dialog's own close shortcut and
+    // must keep working — the fix must not swallow Escape unconditionally.
+    expect(hostEscape).toHaveBeenCalledTimes(1);
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/packages/views/editor/extensions/suggestion-popup.test.tsx
+++ b/packages/views/editor/extensions/suggestion-popup.test.tsx
@@ -6,11 +6,7 @@ import { PluginKey } from "@tiptap/pm/state";
 import { forwardRef, useImperativeHandle } from "react";
 import { afterEach, beforeAll, describe, expect, it, vi } from "vitest";
 import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
-import {
-  createSuggestionPopupRender,
-  isPasteLikeTransaction,
-  isPickerAcceptKey,
-} from "./suggestion-popup";
+import { createSuggestionPopupRender, isPickerAcceptKey } from "./suggestion-popup";
 import { PatchedListItem } from "./list-item";
 
 interface TestItem {
@@ -76,7 +72,7 @@ afterEach(() => {
   document.body.innerHTML = "";
 });
 
-function makeEditor(char: "@" | "/", options: { pasteGuard?: boolean } = {}) {
+function makeEditor(char: "@" | "/") {
   const pluginKey = new PluginKey(`test-${char}-suggestion`);
   const item = char === "@"
     ? { id: "u1", label: "Alice" }
@@ -90,10 +86,6 @@ function makeEditor(char: "@" | "/", options: { pasteGuard?: boolean } = {}) {
           editor: this.editor,
           char,
           pluginKey,
-          // Mirrors the real mention/slash wiring's paste guard (MUL-5429).
-          ...(options.pasteGuard
-            ? { shouldShow: ({ transaction }) => !isPasteLikeTransaction(transaction) }
-            : {}),
           items: () => [item],
           command: ({ editor: ed, range, props }) => {
             ed.commands.insertContentAt(range, `${char}${props.label}`);
@@ -220,68 +212,6 @@ describe("createSuggestionPopupRender", () => {
       await waitFor(() => {
         expect(ed.getText()).toContain(`${char}${label}`);
       });
-    },
-  );
-});
-
-// ---------------------------------------------------------------------------
-// isPasteLikeTransaction (MUL-5429) — driven through the REAL Suggestion plugin
-// rather than a hand-built props object, so these also pin the meta contract:
-// prosemirror-view commits a paste with `uiEvent: "paste"` and a drop with
-// `uiEvent: "drop"`. If upstream ever renames those, the paired "typed text
-// still opens the picker" case stays green while these go red.
-// ---------------------------------------------------------------------------
-
-describe("paste guard", () => {
-  // Focus first, in its own act(): focusing dispatches selection transactions
-  // of its own, and those carry no uiEvent meta. Landing them BEFORE the
-  // insert keeps the paste/drop transaction the last one applied, so the
-  // assertion reads the picker state that transaction produced. (A later
-  // meta-less transaction re-opening the picker is the documented MUL-5429
-  // boundary, covered in mention-suggestion.test.tsx — not what these pin.)
-  async function pasteLike(ed: Editor, char: "@" | "/", uiEvent: "paste" | "drop") {
-    await act(async () => {
-      ed.commands.focus("end");
-    });
-    await act(async () => {
-      ed.view.dispatch(
-        ed.state.tr.insertText(`npx ${char}scope`).setMeta("uiEvent", uiEvent),
-      );
-    });
-  }
-
-  it.each(["@", "/"] as const)(
-    "keeps the %s picker shut when the trigger arrives in a pasted transaction",
-    async (char) => {
-      const ed = makeEditor(char, { pasteGuard: true });
-
-      await pasteLike(ed, char, "paste");
-
-      expect(screen.queryByTestId("suggestion-popup")).not.toBeInTheDocument();
-    },
-  );
-
-  it.each(["@", "/"] as const)(
-    "keeps the %s picker shut when the trigger arrives in a dropped transaction",
-    async (char) => {
-      const ed = makeEditor(char, { pasteGuard: true });
-
-      await pasteLike(ed, char, "drop");
-
-      expect(screen.queryByTestId("suggestion-popup")).not.toBeInTheDocument();
-    },
-  );
-
-  it.each(["@", "/"] as const)(
-    "still opens the %s picker when the identical text is typed instead of pasted",
-    async (char) => {
-      const ed = makeEditor(char, { pasteGuard: true });
-
-      // Same text, ordinary transaction — proves the two cases above fail for
-      // the paste meta specifically, not because the text never matched.
-      await triggerSuggestion(ed, `npx ${char}scope`);
-
-      expect(screen.getByTestId("suggestion-popup")).toBeInTheDocument();
     },
   );
 });

--- a/packages/views/editor/extensions/suggestion-popup.tsx
+++ b/packages/views/editor/extensions/suggestion-popup.tsx
@@ -4,7 +4,23 @@ import type { ComponentType } from "react";
 import { autoUpdate, computePosition, flip, offset, shift, size } from "@floating-ui/dom";
 import { ReactRenderer } from "@tiptap/react";
 import { exitSuggestion, type SuggestionKeyDownProps, type SuggestionProps } from "@tiptap/suggestion";
-import type { PluginKey } from "@tiptap/pm/state";
+import type { PluginKey, Transaction } from "@tiptap/pm/state";
+
+/**
+ * True when a transaction is ProseMirror inserting pasted or dropped content
+ * rather than the user typing.
+ *
+ * The suggestion plugin re-runs `findSuggestionMatch` on EVERY transaction, so
+ * without this check pasting a line that merely happens to contain the trigger
+ * character — `npx @scope/pkg`, a `/usr/local/bin` path — pops the picker open
+ * over content the user never meant as a mention or command (MUL-5429).
+ * ProseMirror tags those transactions with a `uiEvent` meta; every picker built
+ * on this module feeds it to the Suggestion `shouldShow` hook.
+ */
+export function isPasteLikeTransaction(transaction: Transaction): boolean {
+  const uiEvent = transaction.getMeta("uiEvent");
+  return uiEvent === "paste" || uiEvent === "drop";
+}
 
 /**
  * Keys that accept the currently highlighted suggestion row.
@@ -216,7 +232,19 @@ export function createSuggestionPopupRender<
       },
 
       onKeyDown: (props: SuggestionKeyDownProps) => {
-        if (props.event.key === "Escape") {
+        // `Esc` is the legacy alias the suggestion plugin also matches on.
+        if (props.event.key === "Escape" || props.event.key === "Esc") {
+          // Escape while a picker is open must close ONLY the picker. Returning
+          // true makes ProseMirror call preventDefault(), but ProseMirror never
+          // stops propagation, and Base UI's dismiss layer listens for Escape on
+          // `document` in the bubble phase without consulting defaultPrevented.
+          // Without stopPropagation the same keypress that closes this popup
+          // also closes the host Dialog and discards the draft (MUL-5429).
+          // This handler is the only layer that knows a picker is open, so
+          // stopping here fixes every host at once (create-issue dialog, chat
+          // input, comment composer).
+          props.event.preventDefault();
+          props.event.stopPropagation();
           cleanup();
           return true;
         }

--- a/packages/views/editor/extensions/suggestion-popup.tsx
+++ b/packages/views/editor/extensions/suggestion-popup.tsx
@@ -4,23 +4,7 @@ import type { ComponentType } from "react";
 import { autoUpdate, computePosition, flip, offset, shift, size } from "@floating-ui/dom";
 import { ReactRenderer } from "@tiptap/react";
 import { exitSuggestion, type SuggestionKeyDownProps, type SuggestionProps } from "@tiptap/suggestion";
-import type { PluginKey, Transaction } from "@tiptap/pm/state";
-
-/**
- * True when a transaction is ProseMirror inserting pasted or dropped content
- * rather than the user typing.
- *
- * The suggestion plugin re-runs `findSuggestionMatch` on EVERY transaction, so
- * without this check pasting a line that merely happens to contain the trigger
- * character — `npx @scope/pkg`, a `/usr/local/bin` path — pops the picker open
- * over content the user never meant as a mention or command (MUL-5429).
- * ProseMirror tags those transactions with a `uiEvent` meta; every picker built
- * on this module feeds it to the Suggestion `shouldShow` hook.
- */
-export function isPasteLikeTransaction(transaction: Transaction): boolean {
-  const uiEvent = transaction.getMeta("uiEvent");
-  return uiEvent === "paste" || uiEvent === "drop";
-}
+import type { PluginKey } from "@tiptap/pm/state";
 
 /**
  * Keys that accept the currently highlighted suggestion row.

--- a/packages/views/editor/extensions/suggestion-trigger-arming.test.ts
+++ b/packages/views/editor/extensions/suggestion-trigger-arming.test.ts
@@ -1,0 +1,241 @@
+import { describe, it, expect, beforeAll } from "vitest";
+import { Editor, Extension } from "@tiptap/core";
+import StarterKit from "@tiptap/starter-kit";
+import { Markdown } from "@tiptap/markdown";
+import { Suggestion } from "@tiptap/suggestion";
+import { PluginKey, TextSelection } from "@tiptap/pm/state";
+import { EditorView } from "@tiptap/pm/view";
+import { createMarkdownPasteExtension } from "./markdown-paste";
+import {
+  SuggestionTriggerArmingExtension,
+  isTriggerArmedAt,
+} from "./suggestion-trigger-arming";
+
+// ---------------------------------------------------------------------------
+// MUL-5429. These drive the REAL pipeline end to end — a `paste` event on the
+// editor DOM, and typing routed through `handleTextInput` exactly the way
+// prosemirror-view's readDOMChange does it. That matters: the previous attempt
+// at this fix passed its tests by hand-building transactions carrying a
+// `uiEvent: "paste"` meta, which the real paste path never produces, because
+// markdownPaste's catch-all `handlePaste` returns true and so short-circuits
+// `doPaste` before ProseMirror stamps that meta. Anything that stubs the
+// transaction instead of the event can be green while the product is broken.
+// ---------------------------------------------------------------------------
+
+const key = new PluginKey("test-mention-suggestion");
+const slashKey = new PluginKey("test-slash-suggestion");
+
+function suggestionProbe(name: string, char: "@" | "/", pluginKey: PluginKey) {
+  return Extension.create({
+    name,
+    addProseMirrorPlugins() {
+      return [
+        Suggestion({
+          editor: this.editor,
+          char,
+          pluginKey,
+          // The mention picker's real config; `allowSpaces` is what lets a
+          // single stray `@` swallow the rest of the line.
+          allowSpaces: char === "@",
+          shouldShow: ({ editor, range }) => isTriggerArmedAt(editor, range.from),
+          items: () => [{ id: "1", label: "Alice" }],
+          render: () => ({}),
+        }),
+      ];
+    },
+  });
+}
+
+function makeEditor(content?: object) {
+  const element = document.createElement("div");
+  document.body.appendChild(element);
+  return new Editor({
+    element,
+    extensions: [
+      StarterKit,
+      Markdown,
+      createMarkdownPasteExtension(),
+      SuggestionTriggerArmingExtension,
+      suggestionProbe("mentionProbe", "@", key),
+      suggestionProbe("slashProbe", "/", slashKey),
+    ],
+    content: content ?? { type: "doc", content: [{ type: "paragraph" }] },
+  });
+}
+
+/** Fires a real `paste` event, so the whole handlePaste chain runs. */
+function paste(editor: Editor, text: string, html = ""): void {
+  const event = new Event("paste", { bubbles: false, cancelable: true });
+  Object.defineProperty(event, "clipboardData", {
+    value: {
+      files: [],
+      getData: (type: string) =>
+        type === "text/plain" ? text : type === "text/html" ? html : "",
+    },
+  });
+  editor.view.dom.dispatchEvent(event);
+}
+
+/**
+ * Types text the way ProseMirror does: `readDOMChange` consults
+ * `handleTextInput` and, when no plugin claims the keystroke, dispatches the
+ * insertion itself. Going through the prop is the point — that is the only
+ * signal that separates typing from pasting.
+ */
+function type(editor: Editor, text: string): void {
+  for (const ch of text) {
+    const { from, to } = editor.state.selection;
+    const handled = editor.view.someProp("handleTextInput", (fn) =>
+      fn(editor.view, from, to, ch, () => editor.state.tr.insertText(ch, from, to)),
+    );
+    if (!handled) editor.view.dispatch(editor.state.tr.insertText(ch, from, to));
+  }
+}
+
+function picker(editor: Editor, pluginKey: PluginKey = key) {
+  const state = pluginKey.getState(editor.state);
+  return { active: state?.active, query: state?.query };
+}
+
+beforeAll(() => {
+  // jsdom has no layout, so ProseMirror's post-dispatch scroll walks
+  // coordsAtPos into getClientRects() on nodes jsdom does not implement.
+  // Scrolling is irrelevant here; these tests read plugin state.
+  (EditorView.prototype as unknown as { scrollToSelection: () => void }).scrollToSelection =
+    () => {};
+  Element.prototype.scrollIntoView = () => {};
+});
+
+describe("suggestion trigger arming", () => {
+  describe("text the user did not type never opens a picker", () => {
+    it("pasted text containing @", () => {
+      const editor = makeEditor();
+      editor.commands.focus("end");
+
+      paste(editor, "npx @aiforui/install --token=abc");
+
+      expect(editor.getText()).toContain("@aiforui/install");
+      expect(picker(editor).active).toBe(false);
+    });
+
+    it("pasted text containing a / path", () => {
+      const editor = makeEditor();
+      editor.commands.focus("end");
+
+      paste(editor, "binary lives in /usr/local/bin");
+
+      expect(picker(editor, slashKey).active).toBe(false);
+    });
+
+    it("stays shut across the transactions that follow the paste", () => {
+      const editor = makeEditor();
+      editor.commands.focus("end");
+      paste(editor, "npx @aiforui/install");
+
+      // A bare selection change. Under the previous fix this single extra
+      // transaction was enough to re-open the picker: the paste meta was gone,
+      // and `shouldShow` cannot see that the picker was closed a moment ago.
+      editor.view.dispatch(
+        editor.state.tr.setSelection(
+          TextSelection.create(editor.state.doc, editor.state.doc.content.size - 1),
+        ),
+      );
+
+      expect(picker(editor).active).toBe(false);
+    });
+
+    it("stays shut when the user keeps typing after the pasted @", () => {
+      const editor = makeEditor();
+      editor.commands.focus("end");
+      paste(editor, "npx @aiforui");
+
+      type(editor, "x");
+
+      expect(picker(editor).active).toBe(false);
+    });
+
+    it("text already in the document when the editor mounts", () => {
+      // No paste at all — a loaded draft, an undo, a collaborative edit. Tiptap
+      // matches on document content alone, so this opened the picker too.
+      const editor = makeEditor({
+        type: "doc",
+        content: [
+          { type: "paragraph", content: [{ type: "text", text: "npx @aiforui/install" }] },
+        ],
+      });
+
+      editor.commands.focus("end");
+
+      expect(picker(editor).active).toBe(false);
+    });
+  });
+
+  describe("typing still works exactly as before", () => {
+    it("typing @ opens the mention picker", () => {
+      const editor = makeEditor();
+      editor.commands.focus("end");
+
+      type(editor, "hi @al");
+
+      expect(picker(editor)).toEqual({ active: true, query: "al" });
+    });
+
+    it("typing / opens the slash picker", () => {
+      const editor = makeEditor();
+      editor.commands.focus("end");
+
+      type(editor, "/shi");
+
+      expect(picker(editor, slashKey)).toEqual({ active: true, query: "shi" });
+    });
+
+    it("keeps multi-word queries alive, so allowSpaces issue search survives", () => {
+      const editor = makeEditor();
+      editor.commands.focus("end");
+
+      type(editor, "@login redirect bug");
+
+      expect(picker(editor)).toEqual({ active: true, query: "login redirect bug" });
+    });
+
+    it("pasting into a query the user opened by typing keeps it open", () => {
+      // Arming is about the trigger character, not about every later edit —
+      // pasting a name into a mention you deliberately started is still a
+      // mention.
+      const editor = makeEditor();
+      editor.commands.focus("end");
+      type(editor, "@");
+
+      paste(editor, "alice");
+
+      expect(picker(editor)).toEqual({ active: true, query: "alice" });
+    });
+  });
+
+  describe("disarming", () => {
+    it("deleting the typed @ disarms it", () => {
+      const editor = makeEditor();
+      editor.commands.focus("end");
+      type(editor, "@al");
+
+      editor.commands.deleteRange({ from: 1, to: 4 });
+      type(editor, "x");
+
+      expect(picker(editor).active).toBe(false);
+    });
+
+    it("moving the caret away and back does not re-open the picker", () => {
+      // ueberdosis/tiptap#7371: after leaving a half-typed mention, arrowing
+      // back onto it re-opened the menu. A deliberate caret move disarms.
+      const editor = makeEditor();
+      editor.commands.focus("end");
+      type(editor, "@al");
+      expect(picker(editor).active).toBe(true);
+
+      editor.commands.setTextSelection(1);
+      editor.commands.setTextSelection(editor.state.doc.content.size - 1);
+
+      expect(picker(editor).active).toBe(false);
+    });
+  });
+});

--- a/packages/views/editor/extensions/suggestion-trigger-arming.ts
+++ b/packages/views/editor/extensions/suggestion-trigger-arming.ts
@@ -1,0 +1,142 @@
+import { Extension, type Editor } from "@tiptap/core";
+import { Plugin, PluginKey } from "@tiptap/pm/state";
+import type { Node as ProseMirrorNode } from "@tiptap/pm/model";
+
+/**
+ * Records that the user *typed* a suggestion trigger character, so a picker can
+ * refuse to open over a `@` or `/` that merely happens to sit in the document.
+ *
+ * ## Why this exists
+ *
+ * Tiptap's Suggestion plugin is state-derived, not event-driven: it re-runs
+ * `findSuggestionMatch` on EVERY transaction and asks "does the text before the
+ * cursor look like a trigger?" — never "did the user just type one?". Pasted,
+ * dropped, undone and server-loaded text produce a document identical to typed
+ * text, so the plugin cannot tell them apart. With `allowSpaces` the match then
+ * runs from the `@` to the end of the line, so pasting `npx @scope/pkg --token=…`
+ * opens an empty picker that swallows Enter (MUL-5429).
+ *
+ * That is upstream's known, unfixed design: ueberdosis/tiptap#4183 ("Suggestion
+ * opens even if current user didn't type the trigger", open since 2023, labelled
+ * `complexity: hard`) and #7371 ("Suggestion should only start when user
+ * explicitly types suggestion char"). Upstream's answer was to expose
+ * `shouldShow` and let applications supply the missing provenance themselves —
+ * but `shouldShow` receives the transaction without `prev.active`, while `allow`
+ * receives `prev.active` without the transaction, so no transaction-inspecting
+ * predicate can express "only on the transaction that opened it". Provenance has
+ * to come from outside the transaction stream.
+ *
+ * ## How it works
+ *
+ * `handleTextInput` is the one ProseMirror hook that fires for real keyboard and
+ * IME input only — paste goes through `handlePaste`/`doPaste` and drop through
+ * `handleDrop`, neither of which reaches it. This is the same signal Tiptap's own
+ * InputRules run on, which is why typing `- ` makes a list but pasting it does
+ * not. Suggestion is the one Tiptap feature that does not use it; this plugin
+ * supplies it.
+ *
+ * Typing a trigger character arms its document position. The pickers' `shouldShow`
+ * then opens only for a match anchored at the armed position. Anything the user
+ * did not type is never armed, so it never opens a picker.
+ */
+
+/** Trigger characters any suggestion in this editor listens for. */
+const TRIGGER_CHARS = new Set(["@", "/"]);
+
+/**
+ * Latest armed position per editor.
+ *
+ * `shouldShow` runs inside the Suggestion plugin's `apply`, where `editor.state`
+ * is still the PREVIOUS state — so the armed position for the transaction being
+ * applied is not yet readable through a PluginKey. This map mirrors it as the
+ * arming plugin's `apply` computes it. Extension priority (below) puts that
+ * `apply` ahead of every suggestion plugin, so the mirror is always current by
+ * the time `shouldShow` reads it.
+ */
+const armedPositions = new WeakMap<Editor, number | null>();
+
+/** True when `from` is where the user typed a trigger character. */
+export function isTriggerArmedAt(editor: Editor, from: number): boolean {
+  const armed = armedPositions.get(editor);
+  return armed !== null && armed !== undefined && armed === from;
+}
+
+/** Offset of the last trigger character in typed text, or -1. */
+function lastTriggerIndex(text: string): number {
+  for (let i = text.length - 1; i >= 0; i--) {
+    if (TRIGGER_CHARS.has(text[i]!)) return i;
+  }
+  return -1;
+}
+
+/** True when the armed position still holds its trigger character. */
+function stillHoldsTrigger(doc: ProseMirrorNode, pos: number): boolean {
+  if (pos < 0 || pos + 1 > doc.content.size) return false;
+  return TRIGGER_CHARS.has(doc.textBetween(pos, pos + 1));
+}
+
+export const SuggestionTriggerArmingExtension = Extension.create({
+  name: "suggestionTriggerArming",
+  // Ahead of every suggestion plugin so both `handleTextInput` (which must see
+  // the keystroke before an input rule can consume it) and `apply` (which must
+  // refresh the mirror before `shouldShow` reads it) run first.
+  priority: 1000,
+
+  addProseMirrorPlugins() {
+    const editor = this.editor;
+    // Set by `handleTextInput` just before ProseMirror dispatches the insertion,
+    // consumed by the very next `apply`. Holds a position in the NEW document:
+    // text typed at `from` puts its i-th character at `from + i`.
+    let pendingArm: number | null = null;
+
+    return [
+      new Plugin<number | null>({
+        key: new PluginKey("suggestionTriggerArming"),
+
+        state: {
+          init() {
+            armedPositions.set(editor, null);
+            return null;
+          },
+
+          apply(tr, prev, _oldState, newState) {
+            const next = ((): number | null => {
+              // A trigger character was just typed — arm it unconditionally.
+              if (pendingArm !== null) return pendingArm;
+              if (prev === null) return null;
+
+              // A deliberate caret move (click, arrow key) abandons the trigger.
+              // Typing never sets the selection explicitly, so it survives.
+              // IME excluded: composition dispatches selection transactions of
+              // its own mid-word.
+              if (tr.selectionSet && !tr.docChanged && !editor.view.composing) {
+                return null;
+              }
+
+              const mapped = tr.docChanged ? tr.mapping.map(prev, -1) : prev;
+              if (!stillHoldsTrigger(newState.doc, mapped)) return null;
+              // Cursor no longer sits after the trigger inside the same query.
+              if (!newState.selection.empty || newState.selection.from <= mapped) {
+                return null;
+              }
+              return mapped;
+            })();
+
+            pendingArm = null;
+            armedPositions.set(editor, next);
+            return next;
+          },
+        },
+
+        props: {
+          handleTextInput(_view, from, _to, text) {
+            const index = lastTriggerIndex(text);
+            if (index !== -1) pendingArm = from + index;
+            // Never handle the input — every other plugin must still see it.
+            return false;
+          },
+        },
+      }),
+    ];
+  },
+});


### PR DESCRIPTION
Pasting a line containing `@` into a composer opened an empty mention picker that swallowed Enter. The first commit on this branch aimed at the wrong target and did not work in the product; this PR replaces that approach.

## What was actually wrong

The picker also opened with **no paste involved at all** — placing the caret at the end of a line that already contained `@` was enough. Reproduced end to end:

| Scenario | Picker opened |
| --- | --- |
| Real `paste` event with `npx @aiforui/install --token=abc` | yes |
| Any transaction following the paste (a bare selection change) | yes |
| Caret placed after an `@` already in the document — no paste | yes |

Tiptap's Suggestion plugin is **state-derived, not event-driven**: it re-runs `findSuggestionMatch` on every transaction and asks whether the text before the cursor *looks like* a trigger, never whether the user just *typed* one. Pasted, dropped, undone and server-loaded text produce an identical document, so it cannot tell them apart. With `allowSpaces` the match then runs from the `@` to the end of the line, so the whole pasted tail became one query that matched nothing — and the empty popup deliberately captures Enter.

This is upstream's known, unfixed design:

- [ueberdosis/tiptap#4183](https://github.com/ueberdosis/tiptap/issues/4183) — "Suggestion opens even if current user didn't type the trigger". Open since 2023, labelled `complexity: hard`. Closed in January when `shouldShow` was added, **reopened three days later** when it proved insufficient.
- [ueberdosis/tiptap#7371](https://github.com/ueberdosis/tiptap/issues/7371) — "Suggestion should only start when user explicitly types suggestion char". Open.

Upstream's position is that applications supply the missing provenance themselves. `shouldShow` alone cannot express it: it receives the transaction without `prev.active`, while `allow` receives `prev.active` without the transaction, so no transaction-inspecting predicate can say "only on the transaction that opened the picker". Verified against `@tiptap/suggestion@3.29.2`, newer than the version in this repo — the gap is unchanged.

## The fix

A trigger-arming plugin. `handleTextInput` is the one ProseMirror hook that fires for real keyboard and IME input only — paste goes through `handlePaste`/`doPaste` and drop through `handleDrop`, neither of which reaches it.

- Typing a trigger character arms its document position.
- The pickers' `shouldShow` opens only for a match anchored there.
- A deliberate caret move, or losing the trigger character, disarms it.

This is the same signal Tiptap's own InputRules run on — which is why typing `- ` makes a list but pasting it does not. Suggestion is the one Tiptap feature that does not use it.

`allowSpaces` is untouched, so multi-word issue search (`@login redirect bug`) still works.

## Second bug, same root

`markdownPaste` was dropping the paste metas. ProseMirror's `doPaste` returns early once a `handlePaste` prop claims the event, and `markdownPaste` is a catch-all that claims nearly every paste, so the transaction that commits a paste carried no `paste` / `uiEvent` mark.

That is why the previous fix never fired in the product — and it independently broke `issueIdentifierAutolink`, which reads exactly that mark. Pasting `See MUL-2 now` autolinked **nothing**: the unmarked transaction went down the typing path, which only inspects the token before the caret. Both dispatch sites now stamp the metas, matching what ProseMirror does and what its author describes as the contract third-party code relies on.

Dropped text still carries `uiEvent: "drop"`, which `issueIdentifierAutolink` does not treat as a paste. Left as is — that is a product decision, not a defect introduced here.

## Why the old tests were green

Both features' paste tests hand-built transactions carrying a `uiEvent: "paste"` meta the real paste path never produces. Every paste case now fires a **real paste event**, and typing is routed through `handleTextInput` the way `readDOMChange` does, so a test cannot be green while the product is broken. Confirmed by reverting the `markdownPaste` change: the two autolink paste tests go red.

The Escape containment from the first commit is unrelated to all of this and is kept as is.

## Verification

- `pnpm exec vitest run` in `packages/views` — 3192 passed / 272 files
- `pnpm typecheck` — 6/6
- `pnpm lint` — 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)
