### PR TITLE
fix(featureflags): publish the hang stack capture flag to clients (MUL-5345)

### DIFF
--- a/server/internal/featureflags/keys.go
+++ b/server/internal/featureflags/keys.go
@@ -16,6 +16,12 @@ const (
 	// ResourceLabels controls the agent- and skill-scoped label namespaces.
 	// Issue labels remain available while this release flag is off.
 	ResourceLabels = "settings_resource_labels"
+	// DesktopHangStackCapture gates reading a JS call stack out of a hung
+	// desktop renderer (MUL-5345). Capture holds a debugger channel open on
+	// every renderer, so the desktop client is fail-closed: it stays off unless
+	// this key arrives as an explicit true. That makes publishing the key here
+	// mandatory — a key the client never receives can never be turned on.
+	DesktopHangStackCapture = "desktop_hang_stack_capture"
 	// agentBuilderCompat is no longer a release flag. Keep publishing the key
 	// as enabled so installed desktop clients that still gate the AI creation
 	// entry on this config decision receive the permanently enabled behavior.
@@ -29,6 +35,7 @@ const (
 var frontendPublicFlags = []string{
 	ComposioMCPApps,
 	ResourceLabels,
+	DesktopHangStackCapture,
 }
 
 func ComposioMCPAppsEnabled(ctx context.Context, flags *featureflag.Service) bool {
@@ -37,6 +44,10 @@ func ComposioMCPAppsEnabled(ctx context.Context, flags *featureflag.Service) boo
 
 func ResourceLabelsEnabled(ctx context.Context, flags *featureflag.Service) bool {
 	return flags.IsEnabled(ctx, ResourceLabels, false)
+}
+
+func DesktopHangStackCaptureEnabled(ctx context.Context, flags *featureflag.Service) bool {
+	return flags.IsEnabled(ctx, DesktopHangStackCapture, false)
 }
 
 func EvaluateFrontendPublicFlags(ctx context.Context, flags *featureflag.Service) map[string]bool {

--- a/server/internal/featureflags/keys_test.go
+++ b/server/internal/featureflags/keys_test.go
@@ -12,6 +12,29 @@ func TestResourceLabelsReleaseFlagDefaultsToOff(t *testing.T) {
 	}
 }
 
+// MUL-5345: the desktop client is fail-closed on this flag, so it stays off
+// unless the key arrives as an explicit true. A key that is never published
+// can therefore never be turned on — which is exactly what happened when the
+// desktop side shipped without this entry: hang stack capture was inert in
+// production and no amount of flag configuration could have enabled it.
+func TestDesktopHangStackCaptureIsPublishedToClients(t *testing.T) {
+	flags := EvaluateFrontendPublicFlags(context.Background(), nil)
+	if _, published := flags[DesktopHangStackCapture]; !published {
+		t.Fatal("desktop hang stack capture flag must be published, or the client can never enable it")
+	}
+}
+
+func TestDesktopHangStackCaptureDefaultsToOff(t *testing.T) {
+	ctx := context.Background()
+	if DesktopHangStackCaptureEnabled(ctx, nil) {
+		t.Fatal("hang stack capture must default to off")
+	}
+	flags := EvaluateFrontendPublicFlags(ctx, nil)
+	if flags[DesktopHangStackCapture] {
+		t.Fatal("published default must be off until it is deliberately enabled")
+	}
+}
+
 func TestAgentBuilderCompatDecisionStaysEnabled(t *testing.T) {
 	flags := EvaluateFrontendPublicFlags(context.Background(), nil)
 	if !flags[agentBuilderCompat] {


### PR DESCRIPTION
MUL-5345. Follow-up to #6026.

## The bug

#6026 shipped hang stack capture fail-closed on the desktop side: the renderer forwards `desktop_hang_stack_capture` to the main process, and main only warms a debugger channel when that arrives as an explicit `true`.

The server half was never written. The key is not in `frontendPublicFlags`, so `EvaluateFrontendPublicFlags` never puts it in the `/api/config` response, so the client has nothing to receive and stays off forever.

## Why it matters

Capture has been inert since release. 0.4.13's first 14 hours recorded two genuine hard hangs — one on the agent creation page, one on the projects list — and both came back with `stack_depth` / `stack_function` / `stack_url` / `stack_line` all empty.

That reads like "nobody enabled the flag", but it was not fixable that way: with the key absent from the published set, turning it on in the flag service would not have reached a single client. Confirmed against production config, where the key is missing rather than `false`.

## The fix

Add the key to the published list. No behaviour changes on its own:

- the published default is `false`,
- the desktop side still requires an explicit `true`,
- so this only makes the switch reachable.

Turning it on afterwards is a separate, deliberate production config action.

## Tests

Two, and they encode the failure rather than the implementation:

- the key must appear in the published set at all — this is the assertion whose absence let the gap ship;
- the default must be off, so publishing it does not silently enable capture.

## Verification

- `go test ./internal/featureflags/` — pass
- `go vet ./internal/featureflags/` — clean
- `gofmt` — clean

`./internal/handler/` fails locally on an unrelated schema drift (`channel_media_pending_until` missing in my local DB). I confirmed it reproduces on a clean `origin/main` with my changes stashed, so it is environmental and not from this change; CI runs migrations and will cover it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
