### PR TITLE
fix(autopilots): keep configuration panel visible for wide runbooks

### DIFF
--- a/packages/views/autopilots/components/autopilot-dialog.tsx
+++ b/packages/views/autopilots/components/autopilot-dialog.tsx
@@ -516,7 +516,7 @@ export function AutopilotDialog(props: AutopilotDialogProps) {
           className="flex-1 min-h-0 flex flex-col lg:flex-row overflow-y-auto lg:overflow-hidden"
         >
           {/* Left: Runbook */}
-          <div className="flex-none lg:flex-1 min-h-0 flex flex-col border-b lg:border-b-0 lg:border-r">
+          <div className="flex-none lg:flex-1 min-h-0 min-w-0 flex flex-col border-b lg:border-b-0 lg:border-r">
             <div className="px-6 pt-5 pb-3 shrink-0">
               <TitleEditor
                 autoFocus={isCreate}


### PR DESCRIPTION
## What does this PR do?

Prevents a wide table in an Autopilot Runbook from expanding the left flex column and pushing the configuration panel outside the dialog.

Adding `min-w-0` allows the Runbook column to shrink within the available space. The existing table wrapper continues to handle horizontal scrolling.

## Related Issue

N/A — small layout fix with no associated issue.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Refactor / code improvement (no behavior change)
- [ ] Documentation update
- [ ] Tests (adding or improving test coverage)
- [ ] CI / infrastructure

## Changes Made

- Added `min-w-0` to the Autopilot Runbook flex column.
- Kept the existing table overflow behavior unchanged.

## How to Test

1. Open the create or edit Autopilot dialog.
2. Add a wide table with several columns to the Runbook.
3. Confirm that the configuration panel remains fully visible.
4. Confirm that the table scrolls horizontally within the Runbook editor.

## Risk

Low. This changes only the minimum-width behavior of one flex item.

## AI Disclosure

**AI tool used:** OpenAI Codex

**Prompt / approach:**

Used Codex to compare the downstream layout fix with the current upstream Autopilot dialog and table-wrapper implementation, identify the minimal required change, and verify the flex layout with a controlled wide-table reproduction.

## Screenshots

Controlled reproduction using the current Autopilot dialog layout and a wide Runbook table.
<img width="1325" height="1780" alt="image" src="https://github.com/user-attachments/assets/92c4849d-d967-4b81-9c51-f4579757f32c" />