### PR TITLE
fix(daemon): diagnose silent OpenClaw npm shim failures on Windows (MUL-5422)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -345,12 +345,17 @@ jobs:
       - name: Test Windows OpenClaw npm shim interpreter resolution
         working-directory: server
         # #6061: every OpenClaw task failed execenv prep on a Windows host with
-        # a bare `exit status 1` and no stderr. An npm `.cmd` shim resolves and
-        # runs fine while the `node` it re-execs is unresolvable, so the daemon
-        # cannot distinguish the two without a real cmd.exe host. These tests
-        # pin the positive control (node on PATH → success), the failure being
-        # actionable rather than silent, and that TEMP/TMP are NOT load-bearing
-        # (the originally reported root cause, since retracted upstream).
+        # a bare `exit status 1` and no stderr. A batch shim resolves and runs
+        # fine while the `node` it re-execs is unreachable, and npm's real
+        # template prefers a co-located node.exe over PATH — none of which can
+        # be proven without a real cmd.exe host. These tests pin: the positive
+        # control (node on PATH → success), that a missing node surfaces
+        # cmd.exe's own stderr (the first run of this job disproved #6061's
+        # premise that it does not), that a genuinely silent shim DOES reach the
+        # new diagnostic, that a co-located interpreter is credited, that a
+        # context timeout is not misdiagnosed as a missing interpreter, and that
+        # TEMP/TMP are NOT load-bearing (the originally reported root cause,
+        # since retracted upstream).
         # Scoped to the windows-tagged shim tests — the package's legacy
         # OpenClaw HOME tests are not Windows-safe; the backend job still runs
         # the full package plus the cross-platform half on Linux.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -342,6 +342,22 @@ jobs:
         # blocked forever. -v makes RUN/PASS evidence explicit in CI logs.
         run: go test ./pkg/agent -v -run '^TestCodexWindowsInheritedStdoutDescendantCleanupIsBounded$' -count=1 -timeout=5m
 
+      - name: Test Windows OpenClaw npm shim interpreter resolution
+        working-directory: server
+        # #6061: every OpenClaw task failed execenv prep on a Windows host with
+        # a bare `exit status 1` and no stderr. An npm `.cmd` shim resolves and
+        # runs fine while the `node` it re-execs is unresolvable, so the daemon
+        # cannot distinguish the two without a real cmd.exe host. These tests
+        # pin the positive control (node on PATH → success), the failure being
+        # actionable rather than silent, and that TEMP/TMP are NOT load-bearing
+        # (the originally reported root cause, since retracted upstream).
+        # Scoped to the windows-tagged shim tests — the package's legacy
+        # OpenClaw HOME tests are not Windows-safe; the backend job still runs
+        # the full package plus the cross-platform half on Linux.
+        # -v so a skip (no node on the runner) is visible instead of passing
+        # silently as "ok".
+        run: go test ./internal/daemon/execenv -v -run '^TestWindowsOpenclawShim' -count=1 -timeout=5m
+
       - name: Build Windows CLI helper entrypoint
         working-directory: server
         run: go build ./cmd/multica

--- a/server/internal/daemon/execenv/openclaw_config.go
+++ b/server/internal/daemon/execenv/openclaw_config.go
@@ -760,6 +760,11 @@ var openclawExec = execOpenclawCLI
 // stderr is captured separately and appended to error messages — failures
 // here surface up to the daemon log, and a `openclaw doctor` hint there is
 // more useful than just an exit code.
+//
+// When the CLI is an npm batch shim that exits non-zero and says nothing at
+// all, openclawShimDiagnostic adds the interpreter-resolution detail that a
+// bare `exit status 1` hides (MUL-5422 / #6061). Real stderr always wins — the
+// diagnostic is a fallback for the silent case, not a replacement.
 func execOpenclawCLI(ctx context.Context, bin string, args ...string) (string, error) {
 	cmd := exec.CommandContext(ctx, bin, args...)
 	cmd.Env = os.Environ()
@@ -770,6 +775,9 @@ func execOpenclawCLI(ctx context.Context, bin string, args ...string) (string, e
 		stderrMsg := strings.TrimSpace(stderr.String())
 		if stderrMsg != "" {
 			return "", fmt.Errorf("openclaw %s: %w (stderr: %s)", strings.Join(args, " "), err, stderrMsg)
+		}
+		if diag := openclawShimDiagnostic(bin, err); diag != "" {
+			return "", fmt.Errorf("openclaw %s: %w (%s)", strings.Join(args, " "), err, diag)
 		}
 		return "", fmt.Errorf("openclaw %s: %w", strings.Join(args, " "), err)
 	}

--- a/server/internal/daemon/execenv/openclaw_config.go
+++ b/server/internal/daemon/execenv/openclaw_config.go
@@ -28,9 +28,11 @@ const openclawConfigFile = "openclaw-config.json"
 // at 0o600 next to the wrapper.
 const openclawUserSnapshotFile = "openclaw-user-snapshot.json"
 
-// openclawCLITimeout caps each `openclaw config ...` invocation during task
-// setup. The CLI is fast (<200ms normal); 5s leaves headroom for a cold
-// node start without letting a hung CLI stall task dispatch indefinitely.
+// openclawCLITimeout is the context deadline set on each `openclaw config ...`
+// invocation during task setup. The CLI is fast (<200ms normal); 5s leaves
+// headroom for a cold node start.
+//
+// It is a deadline, not a guaranteed cap — see the gap below.
 //
 // Known gap (deliberately not fixed here): this deadline does not actually
 // bound the call when the CLI leaves a descendant holding stdout.
@@ -46,7 +48,7 @@ const openclawUserSnapshotFile = "openclaw-user-snapshot.json"
 // preparationProcessController.finish() is a no-op there. Closing this properly
 // needs process-tree ownership (Unix process group, Windows Job Object) so the
 // deadline can terminate the whole tree, which is its own change with its own
-// risk surface. Tracked separately; this file intentionally keeps the existing
+// risk surface. Tracked in MUL-5467; this file intentionally keeps the existing
 // behaviour rather than shipping half of it.
 const openclawCLITimeout = 5 * time.Second
 

--- a/server/internal/daemon/execenv/openclaw_config.go
+++ b/server/internal/daemon/execenv/openclaw_config.go
@@ -31,18 +31,24 @@ const openclawUserSnapshotFile = "openclaw-user-snapshot.json"
 // openclawCLITimeout caps each `openclaw config ...` invocation during task
 // setup. The CLI is fast (<200ms normal); 5s leaves headroom for a cold
 // node start without letting a hung CLI stall task dispatch indefinitely.
-const openclawCLITimeout = 5 * time.Second
-
-// openclawCLIWaitDelay bounds how long execOpenclawCLI waits after
-// openclawCLITimeout fires before forcing the child's pipes shut and reaping it.
 //
-// Without this the timeout above is not actually enforceable. CommandContext
-// kills only the direct child, and `cmd.Output()` blocks in Wait() until the
-// stdout pipe closes — so any surviving grandchild that inherited stdout keeps
-// the call parked long past 5s. An npm shim is exactly that shape on Windows
-// (cmd.exe → node), so a wedged node would stall task dispatch indefinitely.
-// Mirrors the same backstop detectCLIVersion uses for the `--version` probe.
-const openclawCLIWaitDelay = 2 * time.Second
+// Known gap (deliberately not fixed here): this deadline does not actually
+// bound the call when the CLI leaves a descendant holding stdout.
+// CommandContext kills only the direct child, and cmd.Output() blocks in
+// Wait() until the stdout pipe closes, so the call runs for the descendant's
+// lifetime. Measured on linux/dash: a shim whose backgrounded child slept 6s
+// took 6.01s against a 150ms deadline. An npm shim is that shape on Windows
+// (cmd.exe → node).
+//
+// A cmd.WaitDelay backstop bounds the call but leaves the descendant running
+// (measured: returns in 2.17s with the grandchild still in state S), trading a
+// hang for a process leak — and on Unix nothing reaps it, because
+// preparationProcessController.finish() is a no-op there. Closing this properly
+// needs process-tree ownership (Unix process group, Windows Job Object) so the
+// deadline can terminate the whole tree, which is its own change with its own
+// risk surface. Tracked separately; this file intentionally keeps the existing
+// behaviour rather than shipping half of it.
+const openclawCLITimeout = 5 * time.Second
 
 // OpenclawConfigPrep is the input to prepareOpenclawConfig. Only OpenclawBin
 // is meaningful in production — Timeout is here for tests that need a tight
@@ -783,12 +789,14 @@ var openclawExec = execOpenclawCLI
 // context is checked FIRST; otherwise a timeout gets reported as "node is not
 // on PATH, install Node.js", sending the user to fix something that was never
 // broken.
+//
+// In that branch the CONTEXT error is what gets %w-wrapped, not the process
+// error, so errors.Is(err, context.DeadlineExceeded) holds for callers that
+// check cancellation the standard way. The process error is still printed for
+// diagnosis, just not as the wrapped cause.
 func execOpenclawCLI(ctx context.Context, bin string, args ...string) (string, error) {
 	cmd := exec.CommandContext(ctx, bin, args...)
 	cmd.Env = os.Environ()
-	// See openclawCLIWaitDelay: without this the context timeout above cannot
-	// actually bound this call when the CLI leaves a grandchild holding stdout.
-	cmd.WaitDelay = openclawCLIWaitDelay
 	var stderr strings.Builder
 	cmd.Stderr = &stderr
 	raw, err := cmd.Output()
@@ -796,9 +804,9 @@ func execOpenclawCLI(ctx context.Context, bin string, args ...string) (string, e
 		stderrMsg := strings.TrimSpace(stderr.String())
 		if ctxErr := ctx.Err(); ctxErr != nil {
 			if stderrMsg != "" {
-				return "", fmt.Errorf("openclaw %s: %w (%v; stderr: %s)", strings.Join(args, " "), err, ctxErr, stderrMsg)
+				return "", fmt.Errorf("openclaw %s: %w (process: %v; stderr: %s)", strings.Join(args, " "), ctxErr, err, stderrMsg)
 			}
-			return "", fmt.Errorf("openclaw %s: %w (%v)", strings.Join(args, " "), err, ctxErr)
+			return "", fmt.Errorf("openclaw %s: %w (process: %v)", strings.Join(args, " "), ctxErr, err)
 		}
 		if stderrMsg != "" {
 			return "", fmt.Errorf("openclaw %s: %w (stderr: %s)", strings.Join(args, " "), err, stderrMsg)

--- a/server/internal/daemon/execenv/openclaw_config.go
+++ b/server/internal/daemon/execenv/openclaw_config.go
@@ -33,6 +33,17 @@ const openclawUserSnapshotFile = "openclaw-user-snapshot.json"
 // node start without letting a hung CLI stall task dispatch indefinitely.
 const openclawCLITimeout = 5 * time.Second
 
+// openclawCLIWaitDelay bounds how long execOpenclawCLI waits after
+// openclawCLITimeout fires before forcing the child's pipes shut and reaping it.
+//
+// Without this the timeout above is not actually enforceable. CommandContext
+// kills only the direct child, and `cmd.Output()` blocks in Wait() until the
+// stdout pipe closes — so any surviving grandchild that inherited stdout keeps
+// the call parked long past 5s. An npm shim is exactly that shape on Windows
+// (cmd.exe → node), so a wedged node would stall task dispatch indefinitely.
+// Mirrors the same backstop detectCLIVersion uses for the `--version` probe.
+const openclawCLIWaitDelay = 2 * time.Second
+
 // OpenclawConfigPrep is the input to prepareOpenclawConfig. Only OpenclawBin
 // is meaningful in production — Timeout is here for tests that need a tight
 // cap to assert error paths.
@@ -775,6 +786,9 @@ var openclawExec = execOpenclawCLI
 func execOpenclawCLI(ctx context.Context, bin string, args ...string) (string, error) {
 	cmd := exec.CommandContext(ctx, bin, args...)
 	cmd.Env = os.Environ()
+	// See openclawCLIWaitDelay: without this the context timeout above cannot
+	// actually bound this call when the CLI leaves a grandchild holding stdout.
+	cmd.WaitDelay = openclawCLIWaitDelay
 	var stderr strings.Builder
 	cmd.Stderr = &stderr
 	raw, err := cmd.Output()

--- a/server/internal/daemon/execenv/openclaw_config.go
+++ b/server/internal/daemon/execenv/openclaw_config.go
@@ -761,10 +761,17 @@ var openclawExec = execOpenclawCLI
 // here surface up to the daemon log, and a `openclaw doctor` hint there is
 // more useful than just an exit code.
 //
-// When the CLI is an npm batch shim that exits non-zero and says nothing at
-// all, openclawShimDiagnostic adds the interpreter-resolution detail that a
-// bare `exit status 1` hides (MUL-5422 / #6061). Real stderr always wins — the
+// When the CLI is a batch shim that exits non-zero and says nothing at all,
+// openclawShimDiagnostic adds the interpreter-resolution detail that a bare
+// `exit status 1` hides (MUL-5422 / #6061). Real stderr always wins — the
 // diagnostic is a fallback for the silent case, not a replacement.
+//
+// Attribution order matters. openclawCLITimeout kills the child via
+// CommandContext, and a killed process surfaces as *exec.ExitError
+// ("signal: killed") — indistinguishable by type from a genuine exit 1. So the
+// context is checked FIRST; otherwise a timeout gets reported as "node is not
+// on PATH, install Node.js", sending the user to fix something that was never
+// broken.
 func execOpenclawCLI(ctx context.Context, bin string, args ...string) (string, error) {
 	cmd := exec.CommandContext(ctx, bin, args...)
 	cmd.Env = os.Environ()
@@ -773,6 +780,12 @@ func execOpenclawCLI(ctx context.Context, bin string, args ...string) (string, e
 	raw, err := cmd.Output()
 	if err != nil {
 		stderrMsg := strings.TrimSpace(stderr.String())
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			if stderrMsg != "" {
+				return "", fmt.Errorf("openclaw %s: %w (%v; stderr: %s)", strings.Join(args, " "), err, ctxErr, stderrMsg)
+			}
+			return "", fmt.Errorf("openclaw %s: %w (%v)", strings.Join(args, " "), err, ctxErr)
+		}
 		if stderrMsg != "" {
 			return "", fmt.Errorf("openclaw %s: %w (stderr: %s)", strings.Join(args, " "), err, stderrMsg)
 		}

--- a/server/internal/daemon/execenv/openclaw_config.go
+++ b/server/internal/daemon/execenv/openclaw_config.go
@@ -54,12 +54,14 @@ const openclawCLITimeout = 5 * time.Second
 
 // OpenclawConfigPrep is the input to prepareOpenclawConfig. Only OpenclawBin
 // is meaningful in production — Timeout is here for tests that need a tight
-// cap to assert error paths.
+// deadline to assert error paths.
 type OpenclawConfigPrep struct {
 	// OpenclawBin is the openclaw CLI binary to invoke for config introspection.
 	// Empty means resolve "openclaw" from PATH at exec time.
 	OpenclawBin string
-	// Timeout caps each CLI invocation. Zero falls back to openclawCLITimeout.
+	// Timeout sets the context deadline for each CLI invocation — not a
+	// guaranteed cap on how long the call takes; see openclawCLITimeout. Zero
+	// falls back to openclawCLITimeout.
 	Timeout time.Duration
 	// McpConfig is the agent's saved `mcp_config` JSON (Claude-style
 	// `{"mcpServers": {"<name>": {...}}}`). When non-null the wrapper pins

--- a/server/internal/daemon/execenv/openclaw_shim.go
+++ b/server/internal/daemon/execenv/openclaw_shim.go
@@ -1,0 +1,105 @@
+package execenv
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+// openclawShimExtensions are the batch-wrapper extensions npm uses when it
+// installs the `openclaw` command on Windows. The shim is not the real
+// program: it re-execs OpenClaw's JavaScript entrypoint through an
+// interpreter, so a shim path that resolves and is executable says nothing
+// about whether the interpreter it depends on is reachable.
+var openclawShimExtensions = map[string]struct{}{
+	".cmd": {},
+	".bat": {},
+}
+
+// openclawShimInterpreter is the interpreter an npm-installed OpenClaw shim
+// re-execs. OpenClaw's package `bin` entry points at `openclaw.mjs`, whose
+// shebang is `#!/usr/bin/env node`, so a missing `node` breaks the shim from
+// the inside while the shim itself still looks perfectly valid to the daemon.
+const openclawShimInterpreter = "node"
+
+// isOpenclawShimPath reports whether bin is a batch shim rather than a directly
+// executable binary.
+//
+// Keyed on the file extension alone, deliberately not on runtime.GOOS: a
+// `.cmd`/`.bat` shim only ever appears on Windows in production, and testing
+// the extension instead of the host OS lets the whole diagnostic be exercised
+// from the normal Linux/macOS test job rather than only on a Windows runner.
+func isOpenclawShimPath(bin string) bool {
+	ext := strings.ToLower(filepath.Ext(strings.TrimSpace(bin)))
+	_, ok := openclawShimExtensions[ext]
+	return ok
+}
+
+// openclawShimDiagnostic explains a batch-shim invocation that failed without
+// writing anything to stderr, and returns "" when it has nothing to add.
+//
+// Why this exists (MUL-5422 / #6061): a Windows user reported every OpenClaw
+// task failing in execenv prep with a bare `exit status 1` and no stderr. The
+// daemon pins `openclaw` to an absolute path, so the failing command looked
+// correct; what the error could not show is that the shim's own `node` lookup
+// is a second, invisible resolution step that can fail independently. The
+// reporter needed hand-run `subprocess` experiments to discover that, which is
+// exactly the diagnostic the daemon should have handed them.
+//
+// This only enriches the error text — it never changes control flow, and it
+// never suppresses a real stderr message (callers try stderr first). It also
+// deliberately reports the interpreter lookup result in BOTH directions:
+//
+//   - interpreter missing → names it as the likely cause, with a fix hint.
+//   - interpreter present → says so, which is the more valuable evidence. It
+//     rules the PATH theory out and points at the remaining hypotheses (PATH
+//     drift between the runtime's `--version` gate and task prep, a broken
+//     OpenClaw install, or a shim failing for an unrelated reason).
+//
+// The PATH itself is summarised as an entry count rather than dumped: this
+// string lands in daemon logs and issue reports, and a full PATH is both noisy
+// and more environment detail than a bug report needs.
+func openclawShimDiagnostic(bin string, runErr error) string {
+	// Only an actual non-zero exit is in scope. A context deadline, a missing
+	// binary, or a permission error already describes itself, and appending an
+	// interpreter lookup to those would be misleading noise.
+	var exitErr *exec.ExitError
+	if !errors.As(runErr, &exitErr) {
+		return ""
+	}
+	if !isOpenclawShimPath(bin) {
+		return ""
+	}
+
+	// LookPath reads the current process PATH, which is the same environment
+	// execOpenclawCLI hands the child via os.Environ() — so this reports the
+	// interpreter visibility the shim actually had, not a different view.
+	pathSummary := openclawPathEntrySummary()
+	interpreterPath, lookErr := exec.LookPath(openclawShimInterpreter)
+	if lookErr != nil {
+		return fmt.Sprintf(
+			"no stderr output; %s shim %s re-execs %q, which is not resolvable on the daemon PATH (%s) — "+
+				"install Node.js or restart the daemon from an environment where %q is on PATH",
+			strings.ToLower(filepath.Ext(bin)), bin, openclawShimInterpreter, pathSummary, openclawShimInterpreter,
+		)
+	}
+	return fmt.Sprintf(
+		"no stderr output; %s shim %s failed even though %q resolves to %s on the daemon PATH (%s) — "+
+			"the interpreter is reachable, so check the OpenClaw install itself",
+		strings.ToLower(filepath.Ext(bin)), bin, openclawShimInterpreter, interpreterPath, pathSummary,
+	)
+}
+
+// openclawPathEntrySummary describes the daemon PATH by size alone. A count is
+// enough to tell "the daemon inherited a stripped environment" apart from "PATH
+// looks normal but the interpreter still is not on it", without copying the
+// user's full PATH into a daemon log or a pasted bug report.
+func openclawPathEntrySummary() string {
+	if n := len(filepath.SplitList(os.Getenv("PATH"))); n != 1 {
+		return fmt.Sprintf("%d entries", n)
+	}
+	return "1 entry"
+}

--- a/server/internal/daemon/execenv/openclaw_shim.go
+++ b/server/internal/daemon/execenv/openclaw_shim.go
@@ -21,8 +21,8 @@ var openclawShimExtensions = map[string]struct{}{
 
 // openclawShimInterpreter is the interpreter an npm-installed OpenClaw shim
 // re-execs. OpenClaw's package `bin` entry points at `openclaw.mjs`, whose
-// shebang is `#!/usr/bin/env node`, so a missing `node` breaks the shim from
-// the inside while the shim itself still looks perfectly valid to the daemon.
+// shebang is `#!/usr/bin/env node`, so an unreachable `node` breaks the shim
+// from the inside while the shim itself still looks valid to the daemon.
 const openclawShimInterpreter = "node"
 
 // isOpenclawShimPath reports whether bin is a batch shim rather than a directly
@@ -32,10 +32,50 @@ const openclawShimInterpreter = "node"
 // `.cmd`/`.bat` shim only ever appears on Windows in production, and testing
 // the extension instead of the host OS lets the whole diagnostic be exercised
 // from the normal Linux/macOS test job rather than only on a Windows runner.
+//
+// A batch extension is NOT proof the file is an npm shim — an operator can
+// point MULTICA_OPENCLAW_PATH at any batch file. The diagnostic below is
+// therefore phrased conditionally and never asserts npm shim semantics as fact.
 func isOpenclawShimPath(bin string) bool {
 	ext := strings.ToLower(filepath.Ext(strings.TrimSpace(bin)))
 	_, ok := openclawShimExtensions[ext]
 	return ok
+}
+
+// openclawInterpreterOrigin describes where a shim's interpreter was found,
+// without disclosing an absolute path. See openclawShimDiagnostic for why the
+// path itself is withheld.
+type openclawInterpreterOrigin struct {
+	found bool
+	// where is a human phrase ("alongside the shim", "on the daemon PATH"),
+	// empty when the interpreter was not found at all.
+	where string
+}
+
+// findOpenclawShimInterpreter resolves the interpreter the way npm's generated
+// shim does, in npm's own order.
+//
+// npm's cmd-shim template emits:
+//
+//	IF EXIST "%dp0%\node.exe" ( SET "_prog=%dp0%\node.exe" ) ELSE ( SET "_prog=node" )
+//
+// so a Node binary sitting next to the shim wins over PATH entirely. Checking
+// only PATH (as the first version of this diagnostic did) would report "node is
+// not resolvable" for an install that actually runs fine off its co-located
+// interpreter — a confidently wrong root cause, which is worse than no hint.
+func findOpenclawShimInterpreter(shimPath string) openclawInterpreterOrigin {
+	dir := filepath.Dir(shimPath)
+	// `.exe` first, matching npm's IF EXIST check; the bare name keeps the
+	// helper meaningful on the non-Windows hosts the tests run on.
+	for _, name := range []string{openclawShimInterpreter + ".exe", openclawShimInterpreter} {
+		if info, err := os.Stat(filepath.Join(dir, name)); err == nil && !info.IsDir() {
+			return openclawInterpreterOrigin{found: true, where: "alongside the shim"}
+		}
+	}
+	if _, err := exec.LookPath(openclawShimInterpreter); err == nil {
+		return openclawInterpreterOrigin{found: true, where: "on the daemon PATH"}
+	}
+	return openclawInterpreterOrigin{}
 }
 
 // openclawShimDiagnostic explains a batch-shim invocation that failed without
@@ -44,28 +84,34 @@ func isOpenclawShimPath(bin string) bool {
 // Why this exists (MUL-5422 / #6061): a Windows user reported every OpenClaw
 // task failing in execenv prep with a bare `exit status 1` and no stderr. The
 // daemon pins `openclaw` to an absolute path, so the failing command looked
-// correct; what the error could not show is that the shim's own `node` lookup
-// is a second, invisible resolution step that can fail independently. The
-// reporter needed hand-run `subprocess` experiments to discover that, which is
-// exactly the diagnostic the daemon should have handed them.
+// correct; what the error could not show is that a shim's interpreter lookup is
+// a second, invisible resolution step that can fail on its own.
 //
-// This only enriches the error text — it never changes control flow, and it
-// never suppresses a real stderr message (callers try stderr first). It also
-// deliberately reports the interpreter lookup result in BOTH directions:
+// Scope note: CI on windows-latest showed that when `node` is genuinely missing,
+// cmd.exe's "'node' is not recognized" DOES reach Go's stderr pipe, so that case
+// takes the caller's stderr branch and never arrives here. This diagnostic is
+// the fallback for a shim that fails while saying nothing at all — which is what
+// #6061's daemon log actually showed, and remains unexplained.
 //
-//   - interpreter missing → names it as the likely cause, with a fix hint.
-//   - interpreter present → says so, which is the more valuable evidence. It
-//     rules the PATH theory out and points at the remaining hypotheses (PATH
-//     drift between the runtime's `--version` gate and task prep, a broken
-//     OpenClaw install, or a shim failing for an unrelated reason).
+// This only enriches error text — it never changes control flow, and never
+// suppresses a real stderr message (callers try stderr first).
 //
-// The PATH itself is summarised as an entry count rather than dumped: this
-// string lands in daemon logs and issue reports, and a full PATH is both noisy
-// and more environment detail than a bug report needs.
+// # Redaction
+//
+// The returned string is NOT local-log-only: on prep failure it travels through
+// reportTerminalTask → Client.FailTask to the server and is persisted as the
+// task's error. A Windows shim path embeds the account name and install layout
+// (`C:\Users\<name>\AppData\Roaming\npm\...`), so this reports only the shim's
+// base name, whether the interpreter resolved, and a PATH entry count — never an
+// absolute path and never the PATH contents.
 func openclawShimDiagnostic(bin string, runErr error) string {
-	// Only an actual non-zero exit is in scope. A context deadline, a missing
-	// binary, or a permission error already describes itself, and appending an
-	// interpreter lookup to those would be misleading noise.
+	// Only an actual non-zero exit is in scope. A missing binary or permission
+	// error already describes itself.
+	//
+	// Note this gate is necessary but NOT sufficient: a context timeout kills
+	// the child and also surfaces as *exec.ExitError ("signal: killed"), which
+	// would be misdiagnosed here as an interpreter problem. Callers must
+	// attribute context cancellation before consulting this function.
 	var exitErr *exec.ExitError
 	if !errors.As(runErr, &exitErr) {
 		return ""
@@ -74,29 +120,31 @@ func openclawShimDiagnostic(bin string, runErr error) string {
 		return ""
 	}
 
-	// LookPath reads the current process PATH, which is the same environment
-	// execOpenclawCLI hands the child via os.Environ() — so this reports the
-	// interpreter visibility the shim actually had, not a different view.
+	name := filepath.Base(strings.TrimSpace(bin))
 	pathSummary := openclawPathEntrySummary()
-	interpreterPath, lookErr := exec.LookPath(openclawShimInterpreter)
-	if lookErr != nil {
+	origin := findOpenclawShimInterpreter(bin)
+	if !origin.found {
 		return fmt.Sprintf(
-			"no stderr output; %s shim %s re-execs %q, which is not resolvable on the daemon PATH (%s) — "+
-				"install Node.js or restart the daemon from an environment where %q is on PATH",
-			strings.ToLower(filepath.Ext(bin)), bin, openclawShimInterpreter, pathSummary, openclawShimInterpreter,
+			"no stderr output; if %s is an npm-generated shim it re-execs %q, which resolves neither "+
+				"alongside the shim nor on the daemon PATH (%s) — install Node.js, or restart the daemon "+
+				"from an environment where %q is on PATH",
+			name, openclawShimInterpreter, pathSummary, openclawShimInterpreter,
 		)
 	}
+	// The interpreter being reachable is the more valuable report: it clears
+	// PATH of blame and redirects to the remaining hypotheses (PATH drift
+	// between the runtime `--version` gate and task prep, or a broken install).
 	return fmt.Sprintf(
-		"no stderr output; %s shim %s failed even though %q resolves to %s on the daemon PATH (%s) — "+
-			"the interpreter is reachable, so check the OpenClaw install itself",
-		strings.ToLower(filepath.Ext(bin)), bin, openclawShimInterpreter, interpreterPath, pathSummary,
+		"no stderr output; %q resolves %s, so the interpreter is reachable — if %s is an "+
+			"npm-generated shim, check the OpenClaw install itself rather than the daemon PATH (%s)",
+		openclawShimInterpreter, origin.where, name, pathSummary,
 	)
 }
 
 // openclawPathEntrySummary describes the daemon PATH by size alone. A count is
 // enough to tell "the daemon inherited a stripped environment" apart from "PATH
 // looks normal but the interpreter still is not on it", without copying the
-// user's full PATH into a daemon log or a pasted bug report.
+// user's PATH into a task error that is persisted server-side.
 func openclawPathEntrySummary() string {
 	if n := len(filepath.SplitList(os.Getenv("PATH"))); n != 1 {
 		return fmt.Sprintf("%d entries", n)

--- a/server/internal/daemon/execenv/openclaw_shim_test.go
+++ b/server/internal/daemon/execenv/openclaw_shim_test.go
@@ -1,0 +1,331 @@
+package execenv
+
+import (
+	"context"
+	"errors"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+// TestIsOpenclawShimPath locks the shim-detection surface. Case-insensitivity
+// matters because Windows PATH resolution is case-insensitive and npm/PATHEXT
+// can hand back `OPENCLAW.CMD`; paths containing spaces and non-ASCII segments
+// are included because those are the Windows install locations most likely to
+// be mis-parsed, and #6061's open questions called them out explicitly.
+func TestIsOpenclawShimPath(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name string
+		bin  string
+		want bool
+	}{
+		{"npm cmd shim", `C:\Users\dev\AppData\Roaming\npm\openclaw.cmd`, true},
+		{"uppercase extension", `C:\npm\OPENCLAW.CMD`, true},
+		{"mixed case extension", `C:\npm\openclaw.Cmd`, true},
+		{"legacy bat shim", `C:\npm\openclaw.bat`, true},
+		{"path with spaces", `C:\Program Files\node modules\openclaw.cmd`, true},
+		{"path with unicode segment", `C:\用户\开发\npm\openclaw.cmd`, true},
+		{"surrounding whitespace", "  C:\\npm\\openclaw.cmd  ", true},
+		{"real executable", `C:\npm\openclaw.exe`, false},
+		{"powershell shim is not a batch shim", `C:\npm\openclaw.ps1`, false},
+		{"unix binary without extension", "/usr/local/bin/openclaw", false},
+		{"unix path with dotted directory", "/opt/openclaw.cmd.d/openclaw", false},
+		{"empty", "", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if got := isOpenclawShimPath(tc.bin); got != tc.want {
+				t.Fatalf("isOpenclawShimPath(%q) = %v, want %v", tc.bin, got, tc.want)
+			}
+		})
+	}
+}
+
+// exitError produces a real *exec.ExitError so the diagnostic's errors.As gate
+// is exercised against the same type production sees, not a stand-in.
+//
+// The interpreter is invoked by absolute path on purpose: callers stub PATH to
+// control the interpreter lookup, and a PATH-dependent helper would break
+// depending on the order those two happen in.
+func exitError(t *testing.T) error {
+	t.Helper()
+	var cmd *exec.Cmd
+	if runtime.GOOS == "windows" {
+		shell := os.Getenv("ComSpec")
+		if shell == "" {
+			shell = filepath.Join(os.Getenv("SystemRoot"), "System32", "cmd.exe")
+		}
+		cmd = exec.Command(shell, "/c", "exit 1")
+	} else {
+		cmd = exec.Command("/bin/sh", "-c", "exit 1")
+	}
+	err := cmd.Run()
+	var exitErr *exec.ExitError
+	if !errors.As(err, &exitErr) {
+		t.Fatalf("expected *exec.ExitError, got %T (%v)", err, err)
+	}
+	return err
+}
+
+// pathWithout points PATH at an empty directory so the interpreter cannot
+// resolve. Setting PATH rather than clearing it keeps LookPath on its normal
+// code path instead of its empty-PATH special case.
+func pathWithout(t *testing.T) {
+	t.Helper()
+	t.Setenv("PATH", t.TempDir())
+}
+
+// pathWithFakeNode puts an executable named like the interpreter on PATH.
+// The file only has to be *resolvable* — the diagnostic reports lookup results
+// and never runs it.
+func pathWithFakeNode(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	name := openclawShimInterpreter
+	if runtime.GOOS == "windows" {
+		name += ".exe"
+	}
+	fake := filepath.Join(dir, name)
+	if err := os.WriteFile(fake, []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
+		t.Fatalf("write fake interpreter: %v", err)
+	}
+	t.Setenv("PATH", dir)
+	return fake
+}
+
+// TestOpenclawShimDiagnosticNamesMissingInterpreter is the core #6061
+// regression: a silent shim exit must be reported as an unresolvable
+// interpreter, with an actionable next step, instead of a bare exit code.
+func TestOpenclawShimDiagnosticNamesMissingInterpreter(t *testing.T) {
+	pathWithout(t)
+	got := openclawShimDiagnostic(`C:\npm\openclaw.cmd`, exitError(t))
+	if got == "" {
+		t.Fatal("expected a diagnostic for a silent .cmd shim failure, got none")
+	}
+	for _, want := range []string{
+		"not resolvable on the daemon PATH",
+		openclawShimInterpreter,
+		`C:\npm\openclaw.cmd`,
+		"restart the daemon",
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("diagnostic missing %q\ngot: %s", want, got)
+		}
+	}
+}
+
+// TestOpenclawShimDiagnosticReportsResolvableInterpreter guards the other
+// direction, which is the evidence that actually discriminates between the
+// competing #6061 hypotheses. If the interpreter resolves, the diagnostic must
+// say so rather than blaming PATH, otherwise the next bug report gets steered
+// toward the wrong root cause.
+func TestOpenclawShimDiagnosticReportsResolvableInterpreter(t *testing.T) {
+	fake := pathWithFakeNode(t)
+	got := openclawShimDiagnostic(`C:\npm\openclaw.cmd`, exitError(t))
+	if got == "" {
+		t.Fatal("expected a diagnostic for a silent .cmd shim failure, got none")
+	}
+	if !strings.Contains(got, "the interpreter is reachable") {
+		t.Errorf("diagnostic should clear PATH of blame\ngot: %s", got)
+	}
+	if !strings.Contains(got, fake) {
+		t.Errorf("diagnostic should name the resolved interpreter %q\ngot: %s", fake, got)
+	}
+	if strings.Contains(got, "not resolvable") {
+		t.Errorf("diagnostic must not claim the interpreter is missing\ngot: %s", got)
+	}
+}
+
+// TestOpenclawShimDiagnosticDoesNotLeakFullPath keeps the message log-safe:
+// it summarises PATH as a count, so daemon logs and pasted bug reports do not
+// carry a full environment dump.
+func TestOpenclawShimDiagnosticDoesNotLeakFullPath(t *testing.T) {
+	secret := filepath.Join(t.TempDir(), "totally-not-a-secret-dir")
+	if err := os.MkdirAll(secret, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	t.Setenv("PATH", secret)
+	got := openclawShimDiagnostic(`C:\npm\openclaw.cmd`, exitError(t))
+	if got == "" {
+		t.Fatal("expected a diagnostic, got none")
+	}
+	if strings.Contains(got, secret) {
+		t.Errorf("diagnostic leaked a raw PATH entry\ngot: %s", got)
+	}
+	if !strings.Contains(got, "1 entry") {
+		t.Errorf("diagnostic should summarise PATH as a count\ngot: %s", got)
+	}
+}
+
+// TestOpenclawShimDiagnosticStaysSilentOutOfScope pins the no-op cases. A
+// diagnostic attached to a timeout, a missing binary, or a normal native
+// executable would be actively misleading.
+func TestOpenclawShimDiagnosticStaysSilentOutOfScope(t *testing.T) {
+	pathWithout(t)
+	realExit := exitError(t)
+	cases := []struct {
+		name string
+		bin  string
+		err  error
+	}{
+		{"native executable", `C:\npm\openclaw.exe`, realExit},
+		{"unix binary", "/usr/local/bin/openclaw", realExit},
+		{"context deadline", `C:\npm\openclaw.cmd`, context.DeadlineExceeded},
+		{"context canceled", `C:\npm\openclaw.cmd`, context.Canceled},
+		{"binary not found", `C:\npm\openclaw.cmd`, exec.ErrNotFound},
+		{"nil error", `C:\npm\openclaw.cmd`, nil},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := openclawShimDiagnostic(tc.bin, tc.err); got != "" {
+				t.Fatalf("expected no diagnostic, got: %s", got)
+			}
+		})
+	}
+}
+
+// TestOpenclawShimDiagnosticSurvivesWrappedError confirms the errors.As gate
+// still fires when the exit error arrives wrapped, which is how it reaches this
+// code once callers have annotated it.
+func TestOpenclawShimDiagnosticSurvivesWrappedError(t *testing.T) {
+	pathWithout(t)
+	wrapped := errors.Join(errors.New("openclaw config file"), exitError(t))
+	if got := openclawShimDiagnostic(`C:\npm\openclaw.cmd`, wrapped); got == "" {
+		t.Fatal("expected diagnostic through a wrapped exit error, got none")
+	}
+}
+
+// writeSilentFailingShim creates an executable named with a `.cmd` extension
+// that exits 1 without writing to stderr — the exact shape #6061 reported.
+//
+// On Unix the shebang makes a `.cmd`-named file genuinely executable, so the
+// full execOpenclawCLI integration path is provable on the normal test job.
+// The real npm-shim-plus-interpreter reproduction lives in the windows-tagged
+// test file.
+func writeSilentFailingShim(t *testing.T, dir string) string {
+	t.Helper()
+	shim := filepath.Join(dir, "openclaw.cmd")
+	body := "#!/bin/sh\nexit 1\n"
+	if runtime.GOOS == "windows" {
+		body = "@echo off\r\nexit /b 1\r\n"
+	}
+	if err := os.WriteFile(shim, []byte(body), 0o755); err != nil {
+		t.Fatalf("write shim: %v", err)
+	}
+	return shim
+}
+
+// TestExecOpenclawCLIAnnotatesSilentShimFailure is the end-to-end proof that
+// the diagnostic reaches the error the daemon logs. Before this change the
+// message stopped at `exit status 1`, which is what left #6061's reporter
+// running their own subprocess experiments to find the cause.
+func TestExecOpenclawCLIAnnotatesSilentShimFailure(t *testing.T) {
+	shim := writeSilentFailingShim(t, t.TempDir())
+	// Set PATH after creating the shim: the shim is invoked by absolute path,
+	// while the interpreter lookup must miss.
+	pathWithout(t)
+
+	_, err := execOpenclawCLI(context.Background(), shim, "config", "file")
+	if err == nil {
+		t.Fatal("expected the shim failure to surface as an error")
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, "openclaw config file") {
+		t.Errorf("error should name the failing subcommand\ngot: %s", msg)
+	}
+	if !strings.Contains(msg, "not resolvable on the daemon PATH") {
+		t.Errorf("error should carry the shim diagnostic\ngot: %s", msg)
+	}
+}
+
+// TestExecOpenclawCLIPrefersRealStderr guarantees the diagnostic never masks a
+// genuine message from the CLI. #6061 asserted that a failing `.cmd` produces
+// stderr Go cannot capture; that claim is unproven, so the code must behave
+// correctly either way — and when stderr does arrive, it wins.
+func TestExecOpenclawCLIPrefersRealStderr(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("covered by the windows-tagged shim test with a real cmd.exe host")
+	}
+	dir := t.TempDir()
+	shim := filepath.Join(dir, "openclaw.cmd")
+	body := "#!/bin/sh\necho 'openclaw doctor says hello' >&2\nexit 1\n"
+	if err := os.WriteFile(shim, []byte(body), 0o755); err != nil {
+		t.Fatalf("write shim: %v", err)
+	}
+	pathWithout(t)
+
+	_, err := execOpenclawCLI(context.Background(), shim, "config", "file")
+	if err == nil {
+		t.Fatal("expected the shim failure to surface as an error")
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, "openclaw doctor says hello") {
+		t.Errorf("real stderr must be preserved\ngot: %s", msg)
+	}
+	if strings.Contains(msg, "no stderr output") {
+		t.Errorf("diagnostic must not fire when stderr is present\ngot: %s", msg)
+	}
+}
+
+// TestExecOpenclawCLIMissingTempDoesNotChangeOutcome pins the root cause #6061
+// originally reported and then retracted. The reporter's own follow-up
+// experiment showed `{PATH, SystemRoot}` alone succeeds, so TEMP/TMP must not
+// be load-bearing for the OpenClaw CLI invocation. Locking that keeps a future
+// change from quietly reintroducing a temp-dir dependency and resurrecting a
+// root cause we already ruled out.
+func TestExecOpenclawCLIMissingTempDoesNotChangeOutcome(t *testing.T) {
+	dir := t.TempDir()
+	shim := filepath.Join(dir, "openclaw.cmd")
+	body := "#!/bin/sh\necho '/tmp/openclaw/config.json'\n"
+	if runtime.GOOS == "windows" {
+		body = "@echo off\r\necho C:\\openclaw\\config.json\r\n"
+	}
+	if err := os.WriteFile(shim, []byte(body), 0o755); err != nil {
+		t.Fatalf("write shim: %v", err)
+	}
+	t.Setenv("TEMP", "")
+	t.Setenv("TMP", "")
+
+	out, err := execOpenclawCLI(context.Background(), shim, "config", "file")
+	if err != nil {
+		t.Fatalf("invocation must not depend on TEMP/TMP: %v", err)
+	}
+	if strings.TrimSpace(out) == "" {
+		t.Fatal("expected the shim's stdout to be returned")
+	}
+}
+
+// TestExecOpenclawCLIHandlesShimInPathWithSpacesAndUnicode covers the install
+// locations #6061's open questions flagged as unverified. A directory
+// containing a space or non-ASCII characters must not break invocation or
+// mangle the captured output.
+func TestExecOpenclawCLIHandlesShimInPathWithSpacesAndUnicode(t *testing.T) {
+	for _, segment := range []string{"Program Files", "用户 開發", "café dir"} {
+		t.Run(segment, func(t *testing.T) {
+			dir := filepath.Join(t.TempDir(), segment)
+			if err := os.MkdirAll(dir, 0o755); err != nil {
+				t.Fatalf("mkdir %q: %v", dir, err)
+			}
+			shim := filepath.Join(dir, "openclaw.cmd")
+			body := "#!/bin/sh\necho 'ok-marker'\n"
+			if runtime.GOOS == "windows" {
+				body = "@echo off\r\necho ok-marker\r\n"
+			}
+			if err := os.WriteFile(shim, []byte(body), 0o755); err != nil {
+				t.Fatalf("write shim: %v", err)
+			}
+			out, err := execOpenclawCLI(context.Background(), shim, "config", "file")
+			if err != nil {
+				t.Fatalf("shim in %q should be invocable: %v", dir, err)
+			}
+			if !strings.Contains(out, "ok-marker") {
+				t.Fatalf("expected shim stdout to survive intact, got %q", out)
+			}
+		})
+	}
+}

--- a/server/internal/daemon/execenv/openclaw_shim_test.go
+++ b/server/internal/daemon/execenv/openclaw_shim_test.go
@@ -319,6 +319,12 @@ func TestExecOpenclawCLIAnnotatesSilentShimFailure(t *testing.T) {
 // genuine exit 1 produces. Without checking the context first, a slow or hung
 // CLI was reported as "node is not resolvable, install Node.js", pointing the
 // user at something that was never broken.
+//
+// The shim sleeps only briefly on purpose. execOpenclawCLI sets no WaitDelay
+// (see openclawCLITimeout's note on why that is left alone), so cmd.Output()
+// stays parked until the descendant closes stdout — a long sleep here would
+// make the test hostage to it AND leave a live process behind. A short sleep
+// keeps the assertion about attribution, which is what this test is for.
 func TestExecOpenclawCLITimeoutIsNotMisdiagnosedAsMissingInterpreter(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("covered by TestWindowsOpenclawShimTimeoutIsNotMisdiagnosed with a real cmd.exe host")
@@ -330,42 +336,58 @@ func TestExecOpenclawCLITimeoutIsNotMisdiagnosedAsMissingInterpreter(t *testing.
 	// `sleep` pass locally and fail in CI with "sleep: not found".
 	sleepBin, err := exec.LookPath("sleep")
 	if err != nil {
-		t.Skipf("no sleep binary available to build a hanging shim: %v", err)
+		t.Skipf("no sleep binary available to build a slow shim: %v", err)
 	}
-	// `sleep` is a grandchild of the shim, and CommandContext kills only the
-	// direct child. Verified on linux/dash: without a WaitDelay backstop this
-	// call ran for the shim's FULL duration despite a 150ms deadline (5.01s for
-	// a 5s sleep), because cmd.Output() blocks in Wait() until the inherited
-	// stdout pipe closes; with openclawCLIWaitDelay it returns in ~2.2s. macOS
-	// does not reproduce it either way, which is why CI caught this and local
-	// runs did not.
-	shim := writeShim(t, t.TempDir(), "#!/bin/sh\n"+sleepBin+" 30\n", "")
+	shim := writeShim(t, t.TempDir(), "#!/bin/sh\n"+sleepBin+" 1\n", "")
 	pathWithout(t) // an interpreter lookup, if reached, would report "missing"
 
-	ctx, cancel := context.WithTimeout(context.Background(), 150*time.Millisecond)
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
 	defer cancel()
-	start := time.Now()
 	_, err = execOpenclawCLI(ctx, shim, "config", "file")
 	if err == nil {
 		t.Fatal("expected the timed-out invocation to fail")
 	}
-	// The bound also proves openclawCLIWaitDelay is doing its job. `sh` runs
-	// `sleep` as a grandchild that inherits stdout; CommandContext kills only
-	// the direct child, and cmd.Output() blocks in Wait() until the stdout pipe
-	// closes. Without a WaitDelay backstop this call parked for the shim's full
-	// 30s despite a 150ms deadline — CI caught exactly that.
-	if elapsed := time.Since(start); elapsed > openclawCLIWaitDelay+5*time.Second {
-		t.Fatalf("invocation did not honour the context deadline (took %s)", elapsed)
-	}
 	msg := err.Error()
 	t.Logf("timeout error: %s", msg)
-	if !strings.Contains(msg, context.DeadlineExceeded.Error()) {
-		t.Errorf("error should attribute the deadline\ngot: %s", msg)
+
+	// The nit from round 2: the context error must be the wrapped cause, so
+	// standard cancellation checks work instead of only string matching.
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Errorf("errors.Is(err, context.DeadlineExceeded) must hold\ngot: %s", msg)
 	}
 	for _, forbidden := range []string{"install Node.js", "resolves neither", "the interpreter is reachable"} {
 		if strings.Contains(msg, forbidden) {
 			t.Errorf("timeout must not be diagnosed as an interpreter problem (found %q)\ngot: %s", forbidden, msg)
 		}
+	}
+}
+
+// TestExecOpenclawCLICancellationIsWrapped pins the same cancellation contract
+// for an explicitly cancelled context, not just a deadline, so a caller can
+// distinguish "we gave up" from "the CLI failed" without parsing strings.
+func TestExecOpenclawCLICancellationIsWrapped(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell shim shape is covered by the windows-tagged tests")
+	}
+	sleepBin, err := exec.LookPath("sleep")
+	if err != nil {
+		t.Skipf("no sleep binary available to build a slow shim: %v", err)
+	}
+	shim := writeShim(t, t.TempDir(), "#!/bin/sh\n"+sleepBin+" 1\n", "")
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(100 * time.Millisecond)
+		cancel()
+	}()
+	defer cancel()
+
+	_, err = execOpenclawCLI(ctx, shim, "config", "file")
+	if err == nil {
+		t.Fatal("expected the cancelled invocation to fail")
+	}
+	if !errors.Is(err, context.Canceled) {
+		t.Errorf("errors.Is(err, context.Canceled) must hold\ngot: %s", err)
 	}
 }
 

--- a/server/internal/daemon/execenv/openclaw_shim_test.go
+++ b/server/internal/daemon/execenv/openclaw_shim_test.go
@@ -322,11 +322,12 @@ func TestExecOpenclawCLIAnnotatesSilentShimFailure(t *testing.T) {
 //
 // The shim sleeps only briefly on purpose. execOpenclawCLI sets no WaitDelay
 // (see openclawCLITimeout's note on why that is left alone), so cmd.Output()
-// stays parked until the descendant closes stdout — meaning the call returns
-// only once that descendant has exited, and a long sleep would just make this
-// test hostage to it. The descendant is NOT still running at the return point;
-// its exit is what produced the EOF that let Wait finish. A short sleep keeps
-// the assertion about attribution, which is what this test is for.
+// stays parked until the output pipes os/exec manages for it — stdout AND
+// stderr, since both are set to in-memory writers — reach EOF. A long sleep
+// would just make this test hostage to that; it would not leak. The `sleep`
+// here inherits those write ends and holds them until it exits, so by the time
+// this call returns the helper has finished. (That is a property of this
+// helper, not a general rule: a process may close its pipes and keep running.)
 func TestExecOpenclawCLITimeoutIsNotMisdiagnosedAsMissingInterpreter(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("covered by TestWindowsOpenclawShimTimeoutIsNotMisdiagnosed with a real cmd.exe host")

--- a/server/internal/daemon/execenv/openclaw_shim_test.go
+++ b/server/internal/daemon/execenv/openclaw_shim_test.go
@@ -9,6 +9,7 @@ import (
 	"runtime"
 	"strings"
 	"testing"
+	"time"
 )
 
 // TestIsOpenclawShimPath locks the shim-detection surface. Case-insensitivity
@@ -80,38 +81,45 @@ func pathWithout(t *testing.T) {
 	t.Setenv("PATH", t.TempDir())
 }
 
-// pathWithFakeNode puts an executable named like the interpreter on PATH.
-// The file only has to be *resolvable* — the diagnostic reports lookup results
-// and never runs it.
-func pathWithFakeNode(t *testing.T) string {
+// writeFakeInterpreter drops an executable named like the interpreter into dir.
+// It only has to be resolvable — the diagnostic reports lookup results and
+// never runs it.
+func writeFakeInterpreter(t *testing.T, dir, name string) string {
+	t.Helper()
+	p := filepath.Join(dir, name)
+	if err := os.WriteFile(p, []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
+		t.Fatalf("write fake interpreter: %v", err)
+	}
+	return p
+}
+
+// pathWithFakeNode puts a resolvable interpreter on PATH and nowhere else.
+func pathWithFakeNode(t *testing.T) {
 	t.Helper()
 	dir := t.TempDir()
 	name := openclawShimInterpreter
 	if runtime.GOOS == "windows" {
 		name += ".exe"
 	}
-	fake := filepath.Join(dir, name)
-	if err := os.WriteFile(fake, []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
-		t.Fatalf("write fake interpreter: %v", err)
-	}
+	writeFakeInterpreter(t, dir, name)
 	t.Setenv("PATH", dir)
-	return fake
 }
 
-// TestOpenclawShimDiagnosticNamesMissingInterpreter is the core #6061
-// regression: a silent shim exit must be reported as an unresolvable
+// TestOpenclawShimDiagnosticNamesUnreachableInterpreter is the core #6061
+// regression: a silent shim exit must be reported as an unreachable
 // interpreter, with an actionable next step, instead of a bare exit code.
-func TestOpenclawShimDiagnosticNamesMissingInterpreter(t *testing.T) {
+func TestOpenclawShimDiagnosticNamesUnreachableInterpreter(t *testing.T) {
 	pathWithout(t)
-	got := openclawShimDiagnostic(`C:\npm\openclaw.cmd`, exitError(t))
+	shim := filepath.Join(t.TempDir(), "openclaw.cmd")
+	got := openclawShimDiagnostic(shim, exitError(t))
 	if got == "" {
 		t.Fatal("expected a diagnostic for a silent .cmd shim failure, got none")
 	}
 	for _, want := range []string{
-		"not resolvable on the daemon PATH",
+		"resolves neither alongside the shim nor on the daemon PATH",
 		openclawShimInterpreter,
-		`C:\npm\openclaw.cmd`,
-		"restart the daemon",
+		"openclaw.cmd",
+		"install Node.js",
 	} {
 		if !strings.Contains(got, want) {
 			t.Errorf("diagnostic missing %q\ngot: %s", want, got)
@@ -119,43 +127,105 @@ func TestOpenclawShimDiagnosticNamesMissingInterpreter(t *testing.T) {
 	}
 }
 
-// TestOpenclawShimDiagnosticReportsResolvableInterpreter guards the other
+// TestOpenclawShimDiagnosticFindsColocatedInterpreter is Sol-Boy's must-fix 2.
+// npm's cmd-shim template checks `%dp0%\node.exe` BEFORE falling back to PATH:
+//
+//	IF EXIST "%dp0%\node.exe" ( SET "_prog=%dp0%\node.exe" ) ELSE ( SET "_prog=node" )
+//
+// So an install whose Node sits next to the shim runs fine with nothing on
+// PATH. Reporting "node is not resolvable" there would be confidently wrong,
+// which is worse than staying quiet.
+func TestOpenclawShimDiagnosticFindsColocatedInterpreter(t *testing.T) {
+	pathWithout(t) // nothing on PATH — only the co-located copy can be found
+	dir := t.TempDir()
+	shim := filepath.Join(dir, "openclaw.cmd")
+	name := openclawShimInterpreter
+	if runtime.GOOS == "windows" {
+		name += ".exe"
+	}
+	writeFakeInterpreter(t, dir, name)
+
+	got := openclawShimDiagnostic(shim, exitError(t))
+	if got == "" {
+		t.Fatal("expected a diagnostic, got none")
+	}
+	if !strings.Contains(got, "alongside the shim") {
+		t.Errorf("diagnostic should credit the co-located interpreter\ngot: %s", got)
+	}
+	if strings.Contains(got, "resolves neither") {
+		t.Errorf("diagnostic must not claim the interpreter is unreachable\ngot: %s", got)
+	}
+}
+
+// TestOpenclawShimDiagnosticReportsInterpreterOnPath guards the other
 // direction, which is the evidence that actually discriminates between the
 // competing #6061 hypotheses. If the interpreter resolves, the diagnostic must
 // say so rather than blaming PATH, otherwise the next bug report gets steered
 // toward the wrong root cause.
-func TestOpenclawShimDiagnosticReportsResolvableInterpreter(t *testing.T) {
-	fake := pathWithFakeNode(t)
-	got := openclawShimDiagnostic(`C:\npm\openclaw.cmd`, exitError(t))
-	if got == "" {
-		t.Fatal("expected a diagnostic for a silent .cmd shim failure, got none")
-	}
-	if !strings.Contains(got, "the interpreter is reachable") {
-		t.Errorf("diagnostic should clear PATH of blame\ngot: %s", got)
-	}
-	if !strings.Contains(got, fake) {
-		t.Errorf("diagnostic should name the resolved interpreter %q\ngot: %s", fake, got)
-	}
-	if strings.Contains(got, "not resolvable") {
-		t.Errorf("diagnostic must not claim the interpreter is missing\ngot: %s", got)
-	}
-}
-
-// TestOpenclawShimDiagnosticDoesNotLeakFullPath keeps the message log-safe:
-// it summarises PATH as a count, so daemon logs and pasted bug reports do not
-// carry a full environment dump.
-func TestOpenclawShimDiagnosticDoesNotLeakFullPath(t *testing.T) {
-	secret := filepath.Join(t.TempDir(), "totally-not-a-secret-dir")
-	if err := os.MkdirAll(secret, 0o755); err != nil {
-		t.Fatalf("mkdir: %v", err)
-	}
-	t.Setenv("PATH", secret)
-	got := openclawShimDiagnostic(`C:\npm\openclaw.cmd`, exitError(t))
+func TestOpenclawShimDiagnosticReportsInterpreterOnPath(t *testing.T) {
+	pathWithFakeNode(t)
+	shim := filepath.Join(t.TempDir(), "openclaw.cmd")
+	got := openclawShimDiagnostic(shim, exitError(t))
 	if got == "" {
 		t.Fatal("expected a diagnostic, got none")
 	}
-	if strings.Contains(got, secret) {
-		t.Errorf("diagnostic leaked a raw PATH entry\ngot: %s", got)
+	if !strings.Contains(got, "on the daemon PATH") || !strings.Contains(got, "the interpreter is reachable") {
+		t.Errorf("diagnostic should clear PATH of blame\ngot: %s", got)
+	}
+	if strings.Contains(got, "resolves neither") {
+		t.Errorf("diagnostic must not claim the interpreter is unreachable\ngot: %s", got)
+	}
+}
+
+// TestOpenclawShimDiagnosticIsPhrasedConditionally is the rest of must-fix 2. A
+// batch extension does not prove npm authorship — an operator can point
+// MULTICA_OPENCLAW_PATH at any batch file — so the text must not assert npm
+// shim semantics as established fact for whatever failed.
+func TestOpenclawShimDiagnosticIsPhrasedConditionally(t *testing.T) {
+	pathWithout(t)
+	shim := filepath.Join(t.TempDir(), "custom-wrapper.cmd")
+	got := openclawShimDiagnostic(shim, exitError(t))
+	if got == "" {
+		t.Fatal("expected a diagnostic, got none")
+	}
+	if !strings.Contains(got, "if custom-wrapper.cmd is an npm-generated shim") {
+		t.Errorf("diagnostic should be conditional about npm authorship\ngot: %s", got)
+	}
+}
+
+// TestOpenclawShimDiagnosticRedactsLocalPaths is Sol-Boy's must-fix 3, and the
+// reason it matters is the blast radius: on prep failure this text is not
+// log-local. It travels reportTerminalTask → Client.FailTask and is persisted
+// server-side as the task error, so an absolute Windows shim path would upload
+// the account name and install layout.
+func TestOpenclawShimDiagnosticRedactsLocalPaths(t *testing.T) {
+	secretDir := filepath.Join(t.TempDir(), "Users", "a-real-person", "AppData", "Roaming", "npm")
+	if err := os.MkdirAll(secretDir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	shim := filepath.Join(secretDir, "openclaw.cmd")
+	pathDir := filepath.Join(t.TempDir(), "another-private-location")
+	if err := os.MkdirAll(pathDir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	name := openclawShimInterpreter
+	if runtime.GOOS == "windows" {
+		name += ".exe"
+	}
+	interpreter := writeFakeInterpreter(t, pathDir, name)
+	t.Setenv("PATH", pathDir)
+
+	got := openclawShimDiagnostic(shim, exitError(t))
+	if got == "" {
+		t.Fatal("expected a diagnostic, got none")
+	}
+	for _, leak := range []string{secretDir, shim, pathDir, interpreter, "a-real-person", "another-private-location"} {
+		if strings.Contains(got, leak) {
+			t.Errorf("diagnostic leaked local path detail %q\ngot: %s", leak, got)
+		}
+	}
+	if !strings.Contains(got, "openclaw.cmd") {
+		t.Errorf("diagnostic should still name the shim's base name\ngot: %s", got)
 	}
 	if !strings.Contains(got, "1 entry") {
 		t.Errorf("diagnostic should summarise PATH as a count\ngot: %s", got)
@@ -163,8 +233,8 @@ func TestOpenclawShimDiagnosticDoesNotLeakFullPath(t *testing.T) {
 }
 
 // TestOpenclawShimDiagnosticStaysSilentOutOfScope pins the no-op cases. A
-// diagnostic attached to a timeout, a missing binary, or a normal native
-// executable would be actively misleading.
+// diagnostic attached to a missing binary or a normal native executable would
+// be actively misleading.
 func TestOpenclawShimDiagnosticStaysSilentOutOfScope(t *testing.T) {
 	pathWithout(t)
 	realExit := exitError(t)
@@ -175,8 +245,6 @@ func TestOpenclawShimDiagnosticStaysSilentOutOfScope(t *testing.T) {
 	}{
 		{"native executable", `C:\npm\openclaw.exe`, realExit},
 		{"unix binary", "/usr/local/bin/openclaw", realExit},
-		{"context deadline", `C:\npm\openclaw.cmd`, context.DeadlineExceeded},
-		{"context canceled", `C:\npm\openclaw.cmd`, context.Canceled},
 		{"binary not found", `C:\npm\openclaw.cmd`, exec.ErrNotFound},
 		{"nil error", `C:\npm\openclaw.cmd`, nil},
 	}
@@ -195,24 +263,23 @@ func TestOpenclawShimDiagnosticStaysSilentOutOfScope(t *testing.T) {
 func TestOpenclawShimDiagnosticSurvivesWrappedError(t *testing.T) {
 	pathWithout(t)
 	wrapped := errors.Join(errors.New("openclaw config file"), exitError(t))
-	if got := openclawShimDiagnostic(`C:\npm\openclaw.cmd`, wrapped); got == "" {
+	shim := filepath.Join(t.TempDir(), "openclaw.cmd")
+	if got := openclawShimDiagnostic(shim, wrapped); got == "" {
 		t.Fatal("expected diagnostic through a wrapped exit error, got none")
 	}
 }
 
-// writeSilentFailingShim creates an executable named with a `.cmd` extension
-// that exits 1 without writing to stderr — the exact shape #6061 reported.
+// writeShim creates an executable named with a `.cmd` extension running body.
 //
 // On Unix the shebang makes a `.cmd`-named file genuinely executable, so the
-// full execOpenclawCLI integration path is provable on the normal test job.
-// The real npm-shim-plus-interpreter reproduction lives in the windows-tagged
-// test file.
-func writeSilentFailingShim(t *testing.T, dir string) string {
+// full execOpenclawCLI integration path is provable on the normal test job. The
+// real npm-shim reproduction lives in the windows-tagged test file.
+func writeShim(t *testing.T, dir, unixBody, windowsBody string) string {
 	t.Helper()
 	shim := filepath.Join(dir, "openclaw.cmd")
-	body := "#!/bin/sh\nexit 1\n"
+	body := unixBody
 	if runtime.GOOS == "windows" {
-		body = "@echo off\r\nexit /b 1\r\n"
+		body = windowsBody
 	}
 	if err := os.WriteFile(shim, []byte(body), 0o755); err != nil {
 		t.Fatalf("write shim: %v", err)
@@ -221,11 +288,11 @@ func writeSilentFailingShim(t *testing.T, dir string) string {
 }
 
 // TestExecOpenclawCLIAnnotatesSilentShimFailure is the end-to-end proof that
-// the diagnostic reaches the error the daemon logs. Before this change the
-// message stopped at `exit status 1`, which is what left #6061's reporter
-// running their own subprocess experiments to find the cause.
+// the diagnostic reaches the error the daemon logs and reports. Before this
+// change the message stopped at `exit status 1`, which is what left #6061's
+// reporter running their own subprocess experiments to find the cause.
 func TestExecOpenclawCLIAnnotatesSilentShimFailure(t *testing.T) {
-	shim := writeSilentFailingShim(t, t.TempDir())
+	shim := writeShim(t, t.TempDir(), "#!/bin/sh\nexit 1\n", "@echo off\r\nexit /b 1\r\n")
 	// Set PATH after creating the shim: the shim is invoked by absolute path,
 	// while the interpreter lookup must miss.
 	pathWithout(t)
@@ -238,25 +305,59 @@ func TestExecOpenclawCLIAnnotatesSilentShimFailure(t *testing.T) {
 	if !strings.Contains(msg, "openclaw config file") {
 		t.Errorf("error should name the failing subcommand\ngot: %s", msg)
 	}
-	if !strings.Contains(msg, "not resolvable on the daemon PATH") {
+	if !strings.Contains(msg, "resolves neither alongside the shim nor on the daemon PATH") {
 		t.Errorf("error should carry the shim diagnostic\ngot: %s", msg)
 	}
 }
 
+// TestExecOpenclawCLITimeoutIsNotMisdiagnosedAsMissingInterpreter is Sol-Boy's
+// must-fix 1, exercised through the real code path rather than by handing the
+// diagnostic a synthetic context error.
+//
+// openclawCLITimeout kills the child through CommandContext, and a killed
+// process surfaces as *exec.ExitError ("signal: killed") — the same type a
+// genuine exit 1 produces. Without checking the context first, a slow or hung
+// CLI was reported as "node is not resolvable, install Node.js", pointing the
+// user at something that was never broken.
+func TestExecOpenclawCLITimeoutIsNotMisdiagnosedAsMissingInterpreter(t *testing.T) {
+	shim := writeShim(t, t.TempDir(),
+		"#!/bin/sh\nsleep 30\n",
+		"@echo off\r\nping -n 30 127.0.0.1 >NUL\r\n",
+	)
+	pathWithout(t) // an interpreter lookup, if reached, would report "missing"
+
+	ctx, cancel := context.WithTimeout(context.Background(), 150*time.Millisecond)
+	defer cancel()
+	start := time.Now()
+	_, err := execOpenclawCLI(ctx, shim, "config", "file")
+	if err == nil {
+		t.Fatal("expected the timed-out invocation to fail")
+	}
+	if elapsed := time.Since(start); elapsed > 20*time.Second {
+		t.Fatalf("invocation did not honour the context deadline (took %s)", elapsed)
+	}
+	msg := err.Error()
+	t.Logf("timeout error: %s", msg)
+	if !strings.Contains(msg, context.DeadlineExceeded.Error()) {
+		t.Errorf("error should attribute the deadline\ngot: %s", msg)
+	}
+	for _, forbidden := range []string{"install Node.js", "resolves neither", "the interpreter is reachable"} {
+		if strings.Contains(msg, forbidden) {
+			t.Errorf("timeout must not be diagnosed as an interpreter problem (found %q)\ngot: %s", forbidden, msg)
+		}
+	}
+}
+
 // TestExecOpenclawCLIPrefersRealStderr guarantees the diagnostic never masks a
-// genuine message from the CLI. #6061 asserted that a failing `.cmd` produces
-// stderr Go cannot capture; that claim is unproven, so the code must behave
-// correctly either way — and when stderr does arrive, it wins.
+// genuine message from the CLI. This is not hypothetical: windows-latest CI
+// showed that a missing `node` DOES reach Go's stderr pipe as "'node' is not
+// recognized", so on real Windows the missing-interpreter case takes this
+// branch and the diagnostic is only a fallback for a truly silent failure.
 func TestExecOpenclawCLIPrefersRealStderr(t *testing.T) {
 	if runtime.GOOS == "windows" {
-		t.Skip("covered by the windows-tagged shim test with a real cmd.exe host")
+		t.Skip("covered by the windows-tagged shim tests with a real cmd.exe host")
 	}
-	dir := t.TempDir()
-	shim := filepath.Join(dir, "openclaw.cmd")
-	body := "#!/bin/sh\necho 'openclaw doctor says hello' >&2\nexit 1\n"
-	if err := os.WriteFile(shim, []byte(body), 0o755); err != nil {
-		t.Fatalf("write shim: %v", err)
-	}
+	shim := writeShim(t, t.TempDir(), "#!/bin/sh\necho 'openclaw doctor says hello' >&2\nexit 1\n", "")
 	pathWithout(t)
 
 	_, err := execOpenclawCLI(context.Background(), shim, "config", "file")
@@ -279,15 +380,10 @@ func TestExecOpenclawCLIPrefersRealStderr(t *testing.T) {
 // change from quietly reintroducing a temp-dir dependency and resurrecting a
 // root cause we already ruled out.
 func TestExecOpenclawCLIMissingTempDoesNotChangeOutcome(t *testing.T) {
-	dir := t.TempDir()
-	shim := filepath.Join(dir, "openclaw.cmd")
-	body := "#!/bin/sh\necho '/tmp/openclaw/config.json'\n"
-	if runtime.GOOS == "windows" {
-		body = "@echo off\r\necho C:\\openclaw\\config.json\r\n"
-	}
-	if err := os.WriteFile(shim, []byte(body), 0o755); err != nil {
-		t.Fatalf("write shim: %v", err)
-	}
+	shim := writeShim(t, t.TempDir(),
+		"#!/bin/sh\necho '/tmp/openclaw/config.json'\n",
+		"@echo off\r\necho C:\\openclaw\\config.json\r\n",
+	)
 	t.Setenv("TEMP", "")
 	t.Setenv("TMP", "")
 
@@ -311,14 +407,7 @@ func TestExecOpenclawCLIHandlesShimInPathWithSpacesAndUnicode(t *testing.T) {
 			if err := os.MkdirAll(dir, 0o755); err != nil {
 				t.Fatalf("mkdir %q: %v", dir, err)
 			}
-			shim := filepath.Join(dir, "openclaw.cmd")
-			body := "#!/bin/sh\necho 'ok-marker'\n"
-			if runtime.GOOS == "windows" {
-				body = "@echo off\r\necho ok-marker\r\n"
-			}
-			if err := os.WriteFile(shim, []byte(body), 0o755); err != nil {
-				t.Fatalf("write shim: %v", err)
-			}
+			shim := writeShim(t, dir, "#!/bin/sh\necho 'ok-marker'\n", "@echo off\r\necho ok-marker\r\n")
 			out, err := execOpenclawCLI(context.Background(), shim, "config", "file")
 			if err != nil {
 				t.Fatalf("shim in %q should be invocable: %v", dir, err)

--- a/server/internal/daemon/execenv/openclaw_shim_test.go
+++ b/server/internal/daemon/execenv/openclaw_shim_test.go
@@ -332,6 +332,13 @@ func TestExecOpenclawCLITimeoutIsNotMisdiagnosedAsMissingInterpreter(t *testing.
 	if err != nil {
 		t.Skipf("no sleep binary available to build a hanging shim: %v", err)
 	}
+	// `sleep` is a grandchild of the shim, and CommandContext kills only the
+	// direct child. Verified on linux/dash: without a WaitDelay backstop this
+	// call ran for the shim's FULL duration despite a 150ms deadline (5.01s for
+	// a 5s sleep), because cmd.Output() blocks in Wait() until the inherited
+	// stdout pipe closes; with openclawCLIWaitDelay it returns in ~2.2s. macOS
+	// does not reproduce it either way, which is why CI caught this and local
+	// runs did not.
 	shim := writeShim(t, t.TempDir(), "#!/bin/sh\n"+sleepBin+" 30\n", "")
 	pathWithout(t) // an interpreter lookup, if reached, would report "missing"
 
@@ -342,7 +349,12 @@ func TestExecOpenclawCLITimeoutIsNotMisdiagnosedAsMissingInterpreter(t *testing.
 	if err == nil {
 		t.Fatal("expected the timed-out invocation to fail")
 	}
-	if elapsed := time.Since(start); elapsed > 20*time.Second {
+	// The bound also proves openclawCLIWaitDelay is doing its job. `sh` runs
+	// `sleep` as a grandchild that inherits stdout; CommandContext kills only
+	// the direct child, and cmd.Output() blocks in Wait() until the stdout pipe
+	// closes. Without a WaitDelay backstop this call parked for the shim's full
+	// 30s despite a 150ms deadline — CI caught exactly that.
+	if elapsed := time.Since(start); elapsed > openclawCLIWaitDelay+5*time.Second {
 		t.Fatalf("invocation did not honour the context deadline (took %s)", elapsed)
 	}
 	msg := err.Error()

--- a/server/internal/daemon/execenv/openclaw_shim_test.go
+++ b/server/internal/daemon/execenv/openclaw_shim_test.go
@@ -320,16 +320,25 @@ func TestExecOpenclawCLIAnnotatesSilentShimFailure(t *testing.T) {
 // CLI was reported as "node is not resolvable, install Node.js", pointing the
 // user at something that was never broken.
 func TestExecOpenclawCLITimeoutIsNotMisdiagnosedAsMissingInterpreter(t *testing.T) {
-	shim := writeShim(t, t.TempDir(),
-		"#!/bin/sh\nsleep 30\n",
-		"@echo off\r\nping -n 30 127.0.0.1 >NUL\r\n",
-	)
+	if runtime.GOOS == "windows" {
+		t.Skip("covered by TestWindowsOpenclawShimTimeoutIsNotMisdiagnosed with a real cmd.exe host")
+	}
+	// Resolve the blocking helper BEFORE PATH is stripped and embed it by
+	// absolute path. The shim has to keep running with an empty PATH, so it
+	// cannot rely on a PATH lookup of its own: `sh` on macOS quietly falls back
+	// to a default PATH, but dash on Linux does not, which made a PATH-relative
+	// `sleep` pass locally and fail in CI with "sleep: not found".
+	sleepBin, err := exec.LookPath("sleep")
+	if err != nil {
+		t.Skipf("no sleep binary available to build a hanging shim: %v", err)
+	}
+	shim := writeShim(t, t.TempDir(), "#!/bin/sh\n"+sleepBin+" 30\n", "")
 	pathWithout(t) // an interpreter lookup, if reached, would report "missing"
 
 	ctx, cancel := context.WithTimeout(context.Background(), 150*time.Millisecond)
 	defer cancel()
 	start := time.Now()
-	_, err := execOpenclawCLI(ctx, shim, "config", "file")
+	_, err = execOpenclawCLI(ctx, shim, "config", "file")
 	if err == nil {
 		t.Fatal("expected the timed-out invocation to fail")
 	}

--- a/server/internal/daemon/execenv/openclaw_shim_test.go
+++ b/server/internal/daemon/execenv/openclaw_shim_test.go
@@ -322,9 +322,11 @@ func TestExecOpenclawCLIAnnotatesSilentShimFailure(t *testing.T) {
 //
 // The shim sleeps only briefly on purpose. execOpenclawCLI sets no WaitDelay
 // (see openclawCLITimeout's note on why that is left alone), so cmd.Output()
-// stays parked until the descendant closes stdout — a long sleep here would
-// make the test hostage to it AND leave a live process behind. A short sleep
-// keeps the assertion about attribution, which is what this test is for.
+// stays parked until the descendant closes stdout — meaning the call returns
+// only once that descendant has exited, and a long sleep would just make this
+// test hostage to it. The descendant is NOT still running at the return point;
+// its exit is what produced the EOF that let Wait finish. A short sleep keeps
+// the assertion about attribution, which is what this test is for.
 func TestExecOpenclawCLITimeoutIsNotMisdiagnosedAsMissingInterpreter(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("covered by TestWindowsOpenclawShimTimeoutIsNotMisdiagnosed with a real cmd.exe host")

--- a/server/internal/daemon/execenv/openclaw_shim_windows_test.go
+++ b/server/internal/daemon/execenv/openclaw_shim_windows_test.go
@@ -192,10 +192,10 @@ func TestWindowsOpenclawShimColocatedNodeIsCredited(t *testing.T) {
 // context check keeps this correct.
 //
 // The shim waits only briefly: execOpenclawCLI sets no WaitDelay, so
-// cmd.Output() stays parked until the descendant closes stdout, i.e. the call
-// returns only once that descendant has exited. A long wait would just make
-// this test hostage to it, not leave a process behind — the ~2s observed in CI
-// is the ping finishing, not a leak.
+// cmd.Output() stays parked until the output pipes os/exec manages for it
+// (stdout and stderr both) reach EOF. `ping` inherits those write ends and
+// holds them until it exits, so the ~2s observed in CI is it finishing rather
+// than a process left behind; a long wait would only make the test slower.
 func TestWindowsOpenclawShimTimeoutIsNotMisdiagnosed(t *testing.T) {
 	dir := t.TempDir()
 	shim := filepath.Join(dir, "openclaw.cmd")

--- a/server/internal/daemon/execenv/openclaw_shim_windows_test.go
+++ b/server/internal/daemon/execenv/openclaw_shim_windows_test.go
@@ -192,8 +192,10 @@ func TestWindowsOpenclawShimColocatedNodeIsCredited(t *testing.T) {
 // context check keeps this correct.
 //
 // The shim waits only briefly: execOpenclawCLI sets no WaitDelay, so
-// cmd.Output() stays parked until the descendant closes stdout. A long wait
-// would make the test hostage to it and leave a live process behind.
+// cmd.Output() stays parked until the descendant closes stdout, i.e. the call
+// returns only once that descendant has exited. A long wait would just make
+// this test hostage to it, not leave a process behind — the ~2s observed in CI
+// is the ping finishing, not a leak.
 func TestWindowsOpenclawShimTimeoutIsNotMisdiagnosed(t *testing.T) {
 	dir := t.TempDir()
 	shim := filepath.Join(dir, "openclaw.cmd")

--- a/server/internal/daemon/execenv/openclaw_shim_windows_test.go
+++ b/server/internal/daemon/execenv/openclaw_shim_windows_test.go
@@ -1,0 +1,167 @@
+//go:build windows
+
+package execenv
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// This file is the Windows half of the MUL-5422 / #6061 regression. The
+// cross-platform file proves the diagnostic's logic; only a real cmd.exe host
+// can prove how an npm batch shim actually behaves when its interpreter is
+// missing — which is the specific claim #6061 made and could not substantiate
+// ("the error goes to the .cmd layer and Go's stderr pipe misses it").
+//
+// Run via the ci.yml `windows-execenv` job, which scopes -run patterns to the
+// Windows-safe tests in this package.
+
+// writeNpmStyleShim writes a batch shim shaped like the one npm generates for
+// `openclaw`: it re-execs a JavaScript entrypoint through `node`, resolved from
+// PATH rather than by absolute path. That PATH-relative interpreter lookup is
+// the invisible second resolution step at the heart of #6061.
+func writeNpmStyleShim(t *testing.T, dir string) string {
+	t.Helper()
+	entry := filepath.Join(dir, "openclaw.mjs")
+	if err := os.WriteFile(entry, []byte("console.log(String.raw`C:\\openclaw\\config.json`);\n"), 0o644); err != nil {
+		t.Fatalf("write entrypoint: %v", err)
+	}
+	shim := filepath.Join(dir, "openclaw.cmd")
+	body := "@echo off\r\nnode \"%~dp0openclaw.mjs\" %*\r\n"
+	if err := os.WriteFile(shim, []byte(body), 0o644); err != nil {
+		t.Fatalf("write shim: %v", err)
+	}
+	return shim
+}
+
+// nodeDir returns the directory holding a real node.exe, skipping the test when
+// the runner has no Node installed.
+func nodeDir(t *testing.T) string {
+	t.Helper()
+	resolved, err := exec.LookPath("node")
+	if err != nil {
+		t.Skipf("no node on PATH, cannot exercise a real npm shim: %v", err)
+	}
+	abs, err := filepath.Abs(resolved)
+	if err != nil {
+		t.Fatalf("resolve node path: %v", err)
+	}
+	return filepath.Dir(abs)
+}
+
+// systemPath is the minimum PATH a batch shim needs to run at all (cmd.exe and
+// friends live there), without any Node directory on it.
+func systemPath(t *testing.T) string {
+	t.Helper()
+	root := os.Getenv("SystemRoot")
+	if root == "" {
+		root = `C:\Windows`
+	}
+	return strings.Join([]string{
+		filepath.Join(root, "System32"),
+		root,
+	}, string(os.PathListSeparator))
+}
+
+// TestWindowsOpenclawShimMissingNodeProducesActionableError is the empirical
+// answer #6061 needs. With a real npm-style shim and no Node on PATH, the
+// failure the daemon reports must be actionable — either cmd.exe's own
+// "not recognized" text reached Go's stderr pipe, or our diagnostic supplied
+// the equivalent. Asserting the disjunction (rather than guessing which)
+// is deliberate: the test stays honest about an unresolved platform question
+// while still forbidding the bare `exit status 1` that started this issue.
+func TestWindowsOpenclawShimMissingNodeProducesActionableError(t *testing.T) {
+	nodeDir(t) // skip early if the runner has no Node to remove from PATH
+	shim := writeNpmStyleShim(t, t.TempDir())
+	t.Setenv("PATH", systemPath(t))
+
+	out, err := execOpenclawCLI(context.Background(), shim, "config", "file")
+	if err == nil {
+		t.Fatalf("shim must fail without node on PATH, got output %q", out)
+	}
+	msg := err.Error()
+	t.Logf("observed error: %s", msg)
+
+	stderrReachedGo := strings.Contains(strings.ToLower(msg), "not recognized")
+	diagnosticFired := strings.Contains(msg, "not resolvable on the daemon PATH")
+	switch {
+	case stderrReachedGo:
+		t.Log("cmd.exe stderr DID reach Go's pipe; #6061's stderr claim does not hold")
+	case diagnosticFired:
+		t.Log("cmd.exe stderr did NOT reach Go's pipe; the shim diagnostic supplied the cause")
+	default:
+		t.Fatalf("error is not actionable — no stderr and no shim diagnostic: %s", msg)
+	}
+	if !strings.Contains(msg, "openclaw config file") {
+		t.Errorf("error should name the failing subcommand\ngot: %s", msg)
+	}
+}
+
+// TestWindowsOpenclawShimSucceedsWithNodeOnPath is the positive control. The
+// same shim, same absolute path, differing only by whether Node is reachable —
+// this is what makes interpreter resolution the proven discriminator rather
+// than an assumed one.
+func TestWindowsOpenclawShimSucceedsWithNodeOnPath(t *testing.T) {
+	dir := nodeDir(t)
+	shim := writeNpmStyleShim(t, t.TempDir())
+	t.Setenv("PATH", strings.Join([]string{dir, systemPath(t)}, string(os.PathListSeparator)))
+
+	out, err := execOpenclawCLI(context.Background(), shim, "config", "file")
+	if err != nil {
+		t.Fatalf("shim should succeed with node on PATH: %v", err)
+	}
+	if !strings.Contains(out, `C:\openclaw\config.json`) {
+		t.Fatalf("expected the entrypoint's stdout, got %q", out)
+	}
+}
+
+// TestWindowsOpenclawShimSucceedsWithoutTempVars closes out the root cause
+// #6061 first reported and then retracted: with Node reachable but TEMP and TMP
+// both unset, the shim must still succeed. Node falls back to a system temp
+// directory, so these variables are not load-bearing — and pinning that stops a
+// future change from reintroducing the dependency.
+func TestWindowsOpenclawShimSucceedsWithoutTempVars(t *testing.T) {
+	dir := nodeDir(t)
+	shim := writeNpmStyleShim(t, t.TempDir())
+	t.Setenv("PATH", strings.Join([]string{dir, systemPath(t)}, string(os.PathListSeparator)))
+	t.Setenv("TEMP", "")
+	t.Setenv("TMP", "")
+
+	out, err := execOpenclawCLI(context.Background(), shim, "config", "file")
+	if err != nil {
+		t.Fatalf("shim must not depend on TEMP/TMP: %v", err)
+	}
+	if !strings.Contains(out, `C:\openclaw\config.json`) {
+		t.Fatalf("expected the entrypoint's stdout, got %q", out)
+	}
+}
+
+// TestWindowsOpenclawShimInPathWithSpacesAndUnicode covers the install
+// locations #6061's open questions flagged. `%~dp0` expansion and Go's batch
+// argument handling both have to survive a directory with a space or non-ASCII
+// characters — `C:\Program Files\...` is a completely ordinary install target.
+func TestWindowsOpenclawShimInPathWithSpacesAndUnicode(t *testing.T) {
+	nodeRoot := nodeDir(t)
+	for _, segment := range []string{"Program Files copy", "用户 開發"} {
+		t.Run(segment, func(t *testing.T) {
+			dir := filepath.Join(t.TempDir(), segment)
+			if err := os.MkdirAll(dir, 0o755); err != nil {
+				t.Fatalf("mkdir %q: %v", dir, err)
+			}
+			shim := writeNpmStyleShim(t, dir)
+			t.Setenv("PATH", strings.Join([]string{nodeRoot, systemPath(t)}, string(os.PathListSeparator)))
+
+			out, err := execOpenclawCLI(context.Background(), shim, "config", "file")
+			if err != nil {
+				t.Fatalf("shim in %q should be invocable: %v", dir, err)
+			}
+			if !strings.Contains(out, `C:\openclaw\config.json`) {
+				t.Fatalf("expected the entrypoint's stdout, got %q", out)
+			}
+		})
+	}
+}

--- a/server/internal/daemon/execenv/openclaw_shim_windows_test.go
+++ b/server/internal/daemon/execenv/openclaw_shim_windows_test.go
@@ -9,21 +9,48 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 )
 
 // This file is the Windows half of the MUL-5422 / #6061 regression. The
 // cross-platform file proves the diagnostic's logic; only a real cmd.exe host
-// can prove how an npm batch shim actually behaves when its interpreter is
-// missing — which is the specific claim #6061 made and could not substantiate
-// ("the error goes to the .cmd layer and Go's stderr pipe misses it").
+// can prove how a batch shim actually behaves, which is where #6061's central
+// claim lived ("the error goes to the .cmd layer and Go's stderr pipe misses
+// it"). The first CI run of this job disproved that claim, and the assertions
+// below now encode the observed behaviour instead of the reported guess.
 //
 // Run via the ci.yml `windows-execenv` job, which scopes -run patterns to the
 // Windows-safe tests in this package.
 
-// writeNpmStyleShim writes a batch shim shaped like the one npm generates for
-// `openclaw`: it re-execs a JavaScript entrypoint through `node`, resolved from
-// PATH rather than by absolute path. That PATH-relative interpreter lookup is
-// the invisible second resolution step at the heart of #6061.
+// npmCmdShimBody reproduces npm's actual generated cmd-shim, not a
+// hand-simplified `node ...` one-liner. Faithfulness matters here: the real
+// template resolves a co-located `node.exe` BEFORE falling back to PATH, and a
+// simplified shim would hide exactly the case Sol-Boy's must-fix 2 called out.
+//
+// Source: https://github.com/npm/cmd-shim/blob/main/lib/index.js (writeShim_),
+// with longProg="%dp0%\node.exe", prog="node", target="%dp0%\openclaw.mjs".
+func npmCmdShimBody() string {
+	return "@ECHO off\r\n" +
+		"GOTO start\r\n" +
+		":find_dp0\r\n" +
+		"SET dp0=%~dp0\r\n" +
+		"EXIT /b\r\n" +
+		":start\r\n" +
+		"SETLOCAL\r\n" +
+		"CALL :find_dp0\r\n" +
+		"\r\n" +
+		"IF EXIST \"%dp0%\\node.exe\" (\r\n" +
+		"  SET \"_prog=%dp0%\\node.exe\"\r\n" +
+		") ELSE (\r\n" +
+		"  SET \"_prog=node\"\r\n" +
+		"  SET PATHEXT=%PATHEXT:;.JS;=;%\r\n" +
+		")\r\n" +
+		"\r\n" +
+		"endLocal & goto #_undefined_# 2>NUL || title %COMSPEC% & " +
+		"set PATHEXT=%PATHEXT:;.JS;=;% & \"%_prog%\" \"%dp0%\\openclaw.mjs\" %*\r\n"
+}
+
+// writeNpmStyleShim writes npm's real shim plus the JS entrypoint it re-execs.
 func writeNpmStyleShim(t *testing.T, dir string) string {
 	t.Helper()
 	entry := filepath.Join(dir, "openclaw.mjs")
@@ -31,8 +58,7 @@ func writeNpmStyleShim(t *testing.T, dir string) string {
 		t.Fatalf("write entrypoint: %v", err)
 	}
 	shim := filepath.Join(dir, "openclaw.cmd")
-	body := "@echo off\r\nnode \"%~dp0openclaw.mjs\" %*\r\n"
-	if err := os.WriteFile(shim, []byte(body), 0o644); err != nil {
+	if err := os.WriteFile(shim, []byte(npmCmdShimBody()), 0o644); err != nil {
 		t.Fatalf("write shim: %v", err)
 	}
 	return shim
@@ -61,20 +87,21 @@ func systemPath(t *testing.T) string {
 	if root == "" {
 		root = `C:\Windows`
 	}
-	return strings.Join([]string{
-		filepath.Join(root, "System32"),
-		root,
-	}, string(os.PathListSeparator))
+	return strings.Join([]string{filepath.Join(root, "System32"), root}, string(os.PathListSeparator))
 }
 
-// TestWindowsOpenclawShimMissingNodeProducesActionableError is the empirical
-// answer #6061 needs. With a real npm-style shim and no Node on PATH, the
-// failure the daemon reports must be actionable — either cmd.exe's own
-// "not recognized" text reached Go's stderr pipe, or our diagnostic supplied
-// the equivalent. Asserting the disjunction (rather than guessing which)
-// is deliberate: the test stays honest about an unresolved platform question
-// while still forbidding the bare `exit status 1` that started this issue.
-func TestWindowsOpenclawShimMissingNodeProducesActionableError(t *testing.T) {
+// TestWindowsOpenclawShimMissingNodeSurfacesCmdStderr records what actually
+// happens on Windows when a real npm shim cannot find its interpreter.
+//
+// The first CI run of this job showed cmd.exe's "'node' is not recognized"
+// reaching Go's stderr pipe, which refutes #6061's premise and means this case
+// takes execOpenclawCLI's stderr branch — the shim diagnostic is NOT involved.
+// Asserting that directly (rather than "either branch is fine") is deliberate:
+// the earlier disjunction let the diagnostic go completely unexercised on
+// Windows while still reporting a pass. If this ever flips, this test fails
+// loudly and TestWindowsOpenclawShimSilentFailureIsDiagnosed still proves the
+// fallback works.
+func TestWindowsOpenclawShimMissingNodeSurfacesCmdStderr(t *testing.T) {
 	nodeDir(t) // skip early if the runner has no Node to remove from PATH
 	shim := writeNpmStyleShim(t, t.TempDir())
 	t.Setenv("PATH", systemPath(t))
@@ -86,25 +113,113 @@ func TestWindowsOpenclawShimMissingNodeProducesActionableError(t *testing.T) {
 	msg := err.Error()
 	t.Logf("observed error: %s", msg)
 
-	stderrReachedGo := strings.Contains(strings.ToLower(msg), "not recognized")
-	diagnosticFired := strings.Contains(msg, "not resolvable on the daemon PATH")
-	switch {
-	case stderrReachedGo:
-		t.Log("cmd.exe stderr DID reach Go's pipe; #6061's stderr claim does not hold")
-	case diagnosticFired:
-		t.Log("cmd.exe stderr did NOT reach Go's pipe; the shim diagnostic supplied the cause")
-	default:
-		t.Fatalf("error is not actionable — no stderr and no shim diagnostic: %s", msg)
+	if !strings.Contains(strings.ToLower(msg), "not recognized") {
+		t.Errorf("expected cmd.exe's own stderr to reach Go's pipe; if this now fails, "+
+			"the platform behaviour changed and the shim diagnostic is carrying this case instead\ngot: %s", msg)
 	}
 	if !strings.Contains(msg, "openclaw config file") {
 		t.Errorf("error should name the failing subcommand\ngot: %s", msg)
 	}
 }
 
+// TestWindowsOpenclawShimSilentFailureIsDiagnosed is Sol-Boy's must-fix 4: prove
+// the new fallback actually executes on Windows. The missing-node case above
+// never reaches it because cmd.exe supplies stderr, so a shim that exits
+// non-zero while writing nothing at all is the only way to cover this branch —
+// and that silent shape is precisely what #6061's daemon log reported.
+func TestWindowsOpenclawShimSilentFailureIsDiagnosed(t *testing.T) {
+	dir := t.TempDir()
+	shim := filepath.Join(dir, "openclaw.cmd")
+	// No output on either stream, non-zero exit.
+	if err := os.WriteFile(shim, []byte("@ECHO off\r\nexit /b 1\r\n"), 0o644); err != nil {
+		t.Fatalf("write shim: %v", err)
+	}
+	t.Setenv("PATH", systemPath(t)) // no Node anywhere, and none co-located
+
+	_, err := execOpenclawCLI(context.Background(), shim, "config", "file")
+	if err == nil {
+		t.Fatal("expected the silent shim to fail")
+	}
+	msg := err.Error()
+	t.Logf("observed error: %s", msg)
+	if !strings.Contains(msg, "resolves neither alongside the shim nor on the daemon PATH") {
+		t.Fatalf("the shim diagnostic must carry a silent failure\ngot: %s", msg)
+	}
+	// Redaction holds on the platform where the path is actually sensitive.
+	if strings.Contains(msg, dir) {
+		t.Errorf("diagnostic leaked the absolute shim path\ngot: %s", msg)
+	}
+	if !strings.Contains(msg, "openclaw.cmd") {
+		t.Errorf("diagnostic should name the shim's base name\ngot: %s", msg)
+	}
+}
+
+// TestWindowsOpenclawShimColocatedNodeIsCredited covers must-fix 2 on the real
+// platform. npm's template runs `%dp0%\node.exe` when it exists, so an install
+// with a co-located interpreter is healthy even with nothing on PATH. The
+// diagnostic must credit that instead of claiming Node is unreachable.
+//
+// A placeholder file is enough: this asserts our resolution order, and the file
+// is only ever stat'd, never executed.
+func TestWindowsOpenclawShimColocatedNodeIsCredited(t *testing.T) {
+	dir := t.TempDir()
+	shim := filepath.Join(dir, "openclaw.cmd")
+	if err := os.WriteFile(shim, []byte("@ECHO off\r\nexit /b 1\r\n"), 0o644); err != nil {
+		t.Fatalf("write shim: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "node.exe"), []byte("placeholder"), 0o644); err != nil {
+		t.Fatalf("write co-located node.exe: %v", err)
+	}
+	t.Setenv("PATH", systemPath(t)) // nothing Node-ish on PATH
+
+	_, err := execOpenclawCLI(context.Background(), shim, "config", "file")
+	if err == nil {
+		t.Fatal("expected the silent shim to fail")
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, "alongside the shim") {
+		t.Errorf("diagnostic should credit the co-located interpreter\ngot: %s", msg)
+	}
+	if strings.Contains(msg, "resolves neither") {
+		t.Errorf("diagnostic must not claim Node is unreachable\ngot: %s", msg)
+	}
+}
+
+// TestWindowsOpenclawShimTimeoutIsNotMisdiagnosed is must-fix 1 on Windows: a
+// hung shim killed by the context deadline must not be reported as a missing
+// interpreter. Go surfaces the kill as *exec.ExitError, so only the explicit
+// context check keeps this correct.
+func TestWindowsOpenclawShimTimeoutIsNotMisdiagnosed(t *testing.T) {
+	dir := t.TempDir()
+	shim := filepath.Join(dir, "openclaw.cmd")
+	body := "@ECHO off\r\nping -n 30 127.0.0.1 >NUL\r\n"
+	if err := os.WriteFile(shim, []byte(body), 0o644); err != nil {
+		t.Fatalf("write shim: %v", err)
+	}
+	t.Setenv("PATH", systemPath(t))
+
+	ctx, cancel := context.WithTimeout(context.Background(), 300*time.Millisecond)
+	defer cancel()
+	_, err := execOpenclawCLI(ctx, shim, "config", "file")
+	if err == nil {
+		t.Fatal("expected the timed-out invocation to fail")
+	}
+	msg := err.Error()
+	t.Logf("observed error: %s", msg)
+	if !strings.Contains(msg, context.DeadlineExceeded.Error()) {
+		t.Errorf("error should attribute the deadline\ngot: %s", msg)
+	}
+	for _, forbidden := range []string{"install Node.js", "resolves neither", "the interpreter is reachable"} {
+		if strings.Contains(msg, forbidden) {
+			t.Errorf("timeout must not be diagnosed as an interpreter problem (found %q)\ngot: %s", forbidden, msg)
+		}
+	}
+}
+
 // TestWindowsOpenclawShimSucceedsWithNodeOnPath is the positive control. The
-// same shim, same absolute path, differing only by whether Node is reachable —
-// this is what makes interpreter resolution the proven discriminator rather
-// than an assumed one.
+// same real npm shim, same absolute path, differing only by whether Node is
+// reachable — this is what makes interpreter resolution the proven
+// discriminator rather than an assumed one.
 func TestWindowsOpenclawShimSucceedsWithNodeOnPath(t *testing.T) {
 	dir := nodeDir(t)
 	shim := writeNpmStyleShim(t, t.TempDir())

--- a/server/internal/daemon/execenv/openclaw_shim_windows_test.go
+++ b/server/internal/daemon/execenv/openclaw_shim_windows_test.go
@@ -4,6 +4,7 @@ package execenv
 
 import (
 	"context"
+	"errors"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -186,19 +187,24 @@ func TestWindowsOpenclawShimColocatedNodeIsCredited(t *testing.T) {
 }
 
 // TestWindowsOpenclawShimTimeoutIsNotMisdiagnosed is must-fix 1 on Windows: a
-// hung shim killed by the context deadline must not be reported as a missing
+// slow shim killed by the context deadline must not be reported as a missing
 // interpreter. Go surfaces the kill as *exec.ExitError, so only the explicit
 // context check keeps this correct.
+//
+// The shim waits only briefly: execOpenclawCLI sets no WaitDelay, so
+// cmd.Output() stays parked until the descendant closes stdout. A long wait
+// would make the test hostage to it and leave a live process behind.
 func TestWindowsOpenclawShimTimeoutIsNotMisdiagnosed(t *testing.T) {
 	dir := t.TempDir()
 	shim := filepath.Join(dir, "openclaw.cmd")
-	body := "@ECHO off\r\nping -n 30 127.0.0.1 >NUL\r\n"
+	// ~2s: ping sends 3 packets one second apart.
+	body := "@ECHO off\r\nping -n 3 127.0.0.1 >NUL\r\n"
 	if err := os.WriteFile(shim, []byte(body), 0o644); err != nil {
 		t.Fatalf("write shim: %v", err)
 	}
 	t.Setenv("PATH", systemPath(t))
 
-	ctx, cancel := context.WithTimeout(context.Background(), 300*time.Millisecond)
+	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
 	defer cancel()
 	_, err := execOpenclawCLI(ctx, shim, "config", "file")
 	if err == nil {
@@ -206,8 +212,8 @@ func TestWindowsOpenclawShimTimeoutIsNotMisdiagnosed(t *testing.T) {
 	}
 	msg := err.Error()
 	t.Logf("observed error: %s", msg)
-	if !strings.Contains(msg, context.DeadlineExceeded.Error()) {
-		t.Errorf("error should attribute the deadline\ngot: %s", msg)
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Errorf("errors.Is(err, context.DeadlineExceeded) must hold\ngot: %s", msg)
 	}
 	for _, forbidden := range []string{"install Node.js", "resolves neither", "the interpreter is reachable"} {
 		if strings.Contains(msg, forbidden) {


### PR DESCRIPTION
## 背景

[#6061](https://github.com/multica-ai/multica/issues/6061)：一位 Windows 用户的所有 OpenClaw 任务都在 execenv 准备阶段失败，日志里只有一个 `exit status 1`，没有任何 stderr。用户完全无从下手，只能自己写 `subprocess` 实验去逐层剥环境。

根因类别是批处理 shim 的**第二次、不可见的解析**：`openclaw.cmd` 把 OpenClaw 的 `openclaw.mjs` 入口通过解释器再执行一次。daemon 把 `openclaw` 固定成绝对路径，所以 shim 本身永远「看起来是对的」，但它依赖的解释器可以独立失败。

**本 PR 范围：只改错误信息，不改运行时行为。**

## 改动内容

**1. 静默失败时补上解释器解析结果**

按 npm 自己的顺序解析 —— `IF EXIST "%dp0%\node.exe"` 优先于 PATH，这是 npm cmd-shim 模板的实际行为。三种结果都报，措辞是**有条件的**（批处理扩展名不能证明是 npm shim，`MULTICA_OPENCLAW_PATH` 可以指向任意批处理文件）：

```
exit status 1 (no stderr output; if openclaw.cmd is an npm-generated shim it re-execs "node",
which resolves neither alongside the shim nor on the daemon PATH (2 entries) — install Node.js,
or restart the daemon from an environment where "node" is on PATH)

exit status 1 (no stderr output; "node" resolves alongside the shim, so the interpreter is
reachable — if openclaw.cmd is an npm-generated shim, check the OpenClaw install itself
rather than the daemon PATH (5 entries))
```

**2. 超时不再被误诊，且 context 是被 `%w` 包装的那个 error。** `CommandContext` 杀进程后返回的仍是 `*exec.ExitError`（`signal: killed`），与真实 exit 1 同类型；原先会被附加「Node 不在 PATH，请安装」。现在先归因 `ctx.Err()`，并且包装的是 context error，所以 `errors.Is(err, context.DeadlineExceeded)` / `context.Canceled` 对调用方成立，不必靠字符串匹配：

```
openclaw config file: context deadline exceeded (process: signal: killed)
```

**3. 脱敏。** 这段文本**不是**只留在本机日志：准备失败后它经 `reportTerminalTask` → `Client.FailTask` 上传并作为任务错误持久化在服务端。Windows shim 路径含账户名与安装布局。现在只报 shim 的 base name、解释器是否可解析及来源、PATH 条目数 —— 绝不含绝对路径，绝不含 PATH 内容。

## 刻意**没有**包含的部分

**`openclawCLITimeout` 的 5s 其实约束不住这个调用** —— 但修它需要跨平台进程树 ownership，不适合塞进这个 PR，已拆到 **MUL-5467**。

二次 review 指出我上一版加的 `WaitDelay` 是「用泄漏换挂起」，这一点是对的，而且我原先对机制的判断有误。重新在 linux/dash 容器里记录孙进程 PID，并在 `Output` 返回瞬间读 `/proc/<pid>/stat`：

| 配置 | deadline | 子进程 sleep | 实际耗时 | 返回时孙进程状态 |
|---|---|---|---|---|
| 无 `WaitDelay`（现状，本 PR 保持） | 150ms | 6s | **6.01s** | `Z`（已退出） |
| 加 `WaitDelay=2s`（已撤回） | 150ms | 60s | **2.17s** | `S`（仍存活） |

即：不加 `WaitDelay` 时调用被后代生命周期绑架，但返回后没有活进程残留（它之所以返回，正是因为后代已退出）；加了之后调用有界，却留下活进程。我上一轮说「orphan 本来就存在」是错的 —— 那是 sleep 时长恰好等于返回时刻造成的假象。Go 的 `WaitDelay` 合约不负责回收 orphan，而 Unix 侧 `preparationProcessController.finish()` 是 no-op，没有兜底。所以本 PR 撤回该行为变更，只在 `openclawCLITimeout` 注释里把这个缺口和实测数据记下来。

另外两条建议（在 Windows 重建/冻结 PATH）同样没做：`probeBuiltinRuntime` 在 `detectAgentVersion` 失败后跳过 provider，而 `detectCLIVersion` 与 `runPreparationProcess` **都没有设置 `cmd.Env`**，继承同一份 daemon 环境 —— 若 daemon PATH 真解析不到 `node`，OpenClaw 根本不会注册成 runtime。冻结启动期快照还会与 MUL-4486「每次重新解析」的自愈设计冲突。

## 测试重点

跨平台部分随普通 backend job 跑（Unix 上用 shebang 让 `.cmd` 命名文件真正可执行，完整链路在 Linux 上即可证）：解析顺序（同目录优先于 PATH）、三种诊断措辞、条件化措辞、脱敏、越界即静默、真实 `CommandContext` 超时与取消的 `errors.Is` 断言。超时用例改用短 sleep，既不依赖 `WaitDelay`、也不残留活进程。

windows-tagged 部分用 **npm 真实生成的 cmd-shim 模板**（不是手写单行），因此同目录分支被忠实复现。首轮 CI 曾暴露一个覆盖缺口：缺 node 时 cmd.exe 的 stderr **确实**进了 Go 管道（推翻 #6061 的前提），该场景走既有 stderr 分支，新诊断从未执行，被「二选一即可通过」的断言掩盖。现已拆成两条独立用例，上一轮 Windows CI 实测确认新分支确有执行且文案已脱敏（只有 `openclaw.cmd`，无绝对路径）。同时钉住 **TEMP/TMP 不是必要条件** —— 最初上报、后被报告者自己撤回的根因。

## 验证

- 已 rebase 到最新 `main`（`bdae0d2a0`）。
- Linux/dash 容器（CI 平台，非仅 macOS）：`execenv` 全包 `-race` 通过；`ps` 确认测试后无残留 `sleep` 进程。
- macOS 全包通过；`go vet` 含 `GOOS=windows` 交叉；`go build ./...`。
