### PR TITLE
fix(agent): make cursor stream protocol drift loud instead of silent (MUL-5434)

### DIFF
--- a/server/pkg/agent/cursor.go
+++ b/server/pkg/agent/cursor.go
@@ -120,7 +120,17 @@ func (b *cursorBackend) Execute(ctx context.Context, prompt string, opts ExecOpt
 		// and surfaced once as a bounded, content-free diagnostic so an upstream
 		// protocol addition is visible instead of silent.
 		unknownSubtypeCount := 0
+		// unknownTypes tracks top-level event types the switch below does not
+		// handle. See cursorUnknownTypeTally: this is what makes a renamed
+		// tool/reasoning event loud instead of silent (MUL-5434).
+		var unknownTypes cursorUnknownTypeTally
 		lastEventType := "none"
+		// assistantBytes counts only model-authored streamed text. It is kept
+		// separate from `output` because the result event also writes into
+		// `output`, which made the reported last_assistant_bytes equal to
+		// result_bytes on a run where the assistant streamed nothing at all —
+		// hiding the exact signal needed to tell those two cases apart.
+		assistantBytes := 0
 		// stepUsage accumulates per-step token counts from "step_finish" events.
 		// resultUsage holds authoritative session totals from "result" events.
 		// If the result event includes usage, we use resultUsage exclusively;
@@ -167,7 +177,7 @@ func (b *cursorBackend) Execute(ctx context.Context, prompt string, opts ExecOpt
 
 			case "assistant":
 				assistantEventCount++
-				b.handleCursorAssistant(&evt, msgCh, &output)
+				assistantBytes += b.handleCursorAssistant(&evt, msgCh, &output)
 
 			case "thinking":
 				// Reasoning is a top-level event streamed as deltas, not a
@@ -272,6 +282,7 @@ func (b *cursorBackend) Execute(ctx context.Context, prompt string, opts ExecOpt
 					_ = json.Unmarshal(evt.Part, &part)
 					if part.Text != "" {
 						output.WriteString(part.Text)
+						assistantBytes += len(part.Text)
 						trySend(msgCh, Message{Type: MessageText, Content: part.Text})
 					}
 				}
@@ -286,6 +297,22 @@ func (b *cursorBackend) Execute(ctx context.Context, prompt string, opts ExecOpt
 					u.OutputTokens += int64(part.Tokens.Output)
 					u.CacheReadTokens += int64(part.Tokens.Cache.Read)
 					stepUsage[model] = u
+				}
+
+			default:
+				// A top-level type this parser does not handle. Falling through
+				// here is completely silent otherwise, and that silence is the
+				// bug: if the CLI renames `tool_call` or `thinking`, every tool
+				// and reasoning row vanishes while the run still reports
+				// success, tool_use_count=0 and no diagnostic at all — which is
+				// indistinguishable from a model that legitimately used no
+				// tools (MUL-5434). Count it so the two cases can be told apart.
+				//
+				// Counting is all we do. An unrecognized event is never coerced
+				// into a tool or reasoning message: guessing at upstream
+				// additions is the failure mode MUL-5231 already fixed once.
+				if !cursorBenignEventType(evt.Type) {
+					unknownTypes.observe(evt.Type)
 				}
 			}
 		}
@@ -363,20 +390,23 @@ func (b *cursorBackend) Execute(ctx context.Context, prompt string, opts ExecOpt
 		}
 
 		logStreamProtocolObservation(b.cfg.Logger, streamProtocolObservation{
-			provider:            "cursor-agent",
-			cliVersion:          b.cfg.CLIVersion,
-			model:               opts.Model,
-			exitCode:            streamProcessExitCode(exitErr),
-			eventCount:          eventCount,
-			invalidEventCount:   invalidEventCount,
-			assistantEventCount: assistantEventCount,
-			toolUseCount:        toolUseCount,
-			sawResult:           resultSeen,
-			resultIsError:       resultIsError,
-			resultBytes:         resultBytes,
-			lastAssistantBytes:  output.Len(),
-			scannerError:        scanErr != nil && !resultSeen,
-			lastEventType:       lastEventType,
+			provider:              "cursor-agent",
+			cliVersion:            b.cfg.CLIVersion,
+			model:                 opts.Model,
+			exitCode:              streamProcessExitCode(exitErr),
+			eventCount:            eventCount,
+			invalidEventCount:     invalidEventCount,
+			assistantEventCount:   assistantEventCount,
+			toolUseCount:          toolUseCount,
+			sawResult:             resultSeen,
+			resultIsError:         resultIsError,
+			resultBytes:           resultBytes,
+			lastAssistantBytes:    assistantBytes,
+			scannerError:          scanErr != nil && !resultSeen,
+			lastEventType:         lastEventType,
+			unknownEventTypeCount: unknownTypes.total,
+			unknownEventTypes:     unknownTypes.summary(),
+			unknownSubtypeCount:   unknownSubtypeCount,
 		})
 
 		if unknownSubtypeCount > 0 {
@@ -384,6 +414,17 @@ func (b *cursorBackend) Execute(ctx context.Context, prompt string, opts ExecOpt
 			// thinking/tool_call subtype we chose to ignore, so a protocol
 			// addition is diagnosable without the parser having guessed at it.
 			b.cfg.Logger.Warn("cursor-agent ignored unknown event subtypes", "count", unknownSubtypeCount)
+		}
+
+		if unknownTypes.total > 0 {
+			// Same contract one level up, and the higher-value signal of the
+			// two: an unhandled top-level type means whole events — possibly
+			// every tool call in the run — never reached the transcript. Read
+			// this together with tool_use_count in the summary above.
+			b.cfg.Logger.Warn("cursor-agent ignored unknown event types",
+				"count", unknownTypes.total,
+				"types", unknownTypes.summary(),
+			)
 		}
 
 		b.cfg.Logger.Info("cursor-agent finished", "pid", cmd.Process.Pid, "status", finalStatus, "duration", duration.Round(time.Millisecond).String())
@@ -443,25 +484,100 @@ func observedCursorEventType(value string) string {
 	return value
 }
 
-func (b *cursorBackend) handleCursorAssistant(evt *cursorStreamEvent, ch chan<- Message, output *strings.Builder) {
+// cursorBenignEventTypes are top-level events the parser knowingly does not
+// forward and which are NOT evidence of protocol drift. `user` is the CLI
+// echoing our own prompt back on the stream (present in every recorded run), so
+// tallying it would fire the unknown-type warning on every single task — and a
+// warning that always fires is a warning nobody reads.
+var cursorBenignEventTypes = map[string]struct{}{
+	"user": {},
+}
+
+func cursorBenignEventType(eventType string) bool {
+	_, ok := cursorBenignEventTypes[strings.TrimSpace(eventType)]
+	return ok
+}
+
+// cursorUnknownTypeCardinalityCap bounds how many distinct unknown type names
+// the tally retains. A stream emitting novel type names (or garbage that still
+// parses as JSON) must not grow the map without limit inside a long-running
+// daemon; names past the cap collapse into one overflow bucket.
+const cursorUnknownTypeCardinalityCap = 16
+
+// cursorUnknownTypeOverflowKey holds the counts that exceeded the cardinality
+// cap. The parentheses cannot collide with a real type name: observedCursorEventType
+// only ever returns identifier characters, "unknown", or "invalid".
+const cursorUnknownTypeOverflowKey = "(overflow)"
+
+// cursorUnknownTypeTally counts top-level event types the parser does not
+// handle. It is the signal that separates "the CLI renamed an event we rely on"
+// from "the model genuinely used no tools" — before this existed, a renamed
+// `tool_call` fell through the type switch and the run reported success with
+// tool_use_count=0 and no diagnostic whatsoever, which is exactly what a
+// tool-free run looks like (MUL-5434).
+//
+// Only normalized identifiers and counts are retained, never payload content,
+// so the tally is safe to log beside the rest of the protocol summary.
+type cursorUnknownTypeTally struct {
+	total  int
+	counts map[string]int
+}
+
+func (t *cursorUnknownTypeTally) observe(eventType string) {
+	t.total++
+	if t.counts == nil {
+		t.counts = make(map[string]int, 4)
+	}
+	key := observedCursorEventType(eventType)
+	if _, seen := t.counts[key]; !seen && len(t.counts) >= cursorUnknownTypeCardinalityCap {
+		key = cursorUnknownTypeOverflowKey
+	}
+	t.counts[key]++
+}
+
+// summary renders the tally as a stable, sorted "name=count" list (e.g.
+// "reasoning=9,tool_calls=6") so it can be grepped and diffed across runs.
+func (t *cursorUnknownTypeTally) summary() string {
+	if len(t.counts) == 0 {
+		return ""
+	}
+	keys := make([]string, 0, len(t.counts))
+	for key := range t.counts {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	parts := make([]string, 0, len(keys))
+	for _, key := range keys {
+		parts = append(parts, fmt.Sprintf("%s=%d", key, t.counts[key]))
+	}
+	return strings.Join(parts, ",")
+}
+
+// handleCursorAssistant forwards one assistant event's content blocks and
+// returns how many bytes of model-authored text it appended to output. The
+// caller tracks that separately from output.Len(), which also absorbs the
+// terminal result text.
+func (b *cursorBackend) handleCursorAssistant(evt *cursorStreamEvent, ch chan<- Message, output *strings.Builder) int {
 	if evt.Message == nil {
-		return
+		return 0
 	}
 
 	var content cursorAssistantMessage
 	if err := json.Unmarshal(evt.Message, &content); err != nil {
-		return
+		return 0
 	}
 
 	// Note: per-message usage in assistant events is intentionally ignored.
 	// Token usage is taken exclusively from "result" events (session totals)
 	// to avoid double-counting.
 
+	written := 0
 	for _, block := range content.Content {
 		switch block.Type {
 		case "output_text", "text":
 			if block.Text != "" {
 				output.WriteString(block.Text)
+				written += len(block.Text)
 				trySend(ch, Message{Type: MessageText, Content: block.Text})
 			}
 		case "thinking":
@@ -481,6 +597,7 @@ func (b *cursorBackend) handleCursorAssistant(evt *cursorStreamEvent, ch chan<- 
 			})
 		}
 	}
+	return written
 }
 
 // cursorThinkingStream turns the CLI's `thinking` event sequence into the

--- a/server/pkg/agent/cursor.go
+++ b/server/pkg/agent/cursor.go
@@ -115,15 +115,16 @@ func (b *cursorBackend) Execute(ctx context.Context, prompt string, opts ExecOpt
 		invalidEventCount := 0
 		assistantEventCount := 0
 		toolUseCount := 0
-		// unknownSubtypeCount tracks thinking/tool_call events whose subtype we
+		// unhandledSubtypeCount tracks thinking/tool_call events whose subtype we
 		// don't recognize. They are ignored (never synthesized into a message)
 		// and surfaced once as a bounded, content-free diagnostic so an upstream
 		// protocol addition is visible instead of silent.
-		unknownSubtypeCount := 0
-		// unknownTypes tracks top-level event types the switch below does not
-		// handle. See cursorUnknownTypeTally: this is what makes a renamed
-		// tool/reasoning event loud instead of silent (MUL-5434).
-		var unknownTypes cursorUnknownTypeTally
+		unhandledSubtypeCount := 0
+		// unhandledTypes tracks top-level event types the switch below does not
+		// handle. See cursorUnhandledTypeTally: it makes a dropped event
+		// observable, and documents what the count does and does not establish
+		// (MUL-5434).
+		var unhandledTypes cursorUnhandledTypeTally
 		lastEventType := "none"
 		// assistantBytes counts only model-authored streamed text. It is kept
 		// separate from `output` because the result event also writes into
@@ -195,7 +196,7 @@ func (b *cursorBackend) Execute(ctx context.Context, prompt string, opts ExecOpt
 				case "completed":
 					thinking.complete()
 				default:
-					unknownSubtypeCount++
+					unhandledSubtypeCount++
 				}
 
 			case "tool_call":
@@ -225,7 +226,7 @@ func (b *cursorBackend) Execute(ctx context.Context, prompt string, opts ExecOpt
 						Output: call.Result,
 					})
 				default:
-					unknownSubtypeCount++
+					unhandledSubtypeCount++
 				}
 
 			case "tool_use":
@@ -301,18 +302,22 @@ func (b *cursorBackend) Execute(ctx context.Context, prompt string, opts ExecOpt
 
 			default:
 				// A top-level type this parser does not handle. Falling through
-				// here is completely silent otherwise, and that silence is the
+				// here used to be completely silent, and that silence is the
 				// bug: if the CLI renames `tool_call` or `thinking`, every tool
 				// and reasoning row vanishes while the run still reports
-				// success, tool_use_count=0 and no diagnostic at all — which is
-				// indistinguishable from a model that legitimately used no
-				// tools (MUL-5434). Count it so the two cases can be told apart.
+				// success and tool_use_count=0, with no diagnostic to
+				// distinguish that from a tool-free run (MUL-5434).
 				//
-				// Counting is all we do. An unrecognized event is never coerced
-				// into a tool or reasoning message: guessing at upstream
-				// additions is the failure mode MUL-5231 already fixed once.
-				if !cursorBenignEventType(evt.Type) {
-					unknownTypes.observe(evt.Type)
+				// Counting makes the drop observable. It does not identify the
+				// cause on its own — see cursorUnhandledTypeTally for what a
+				// non-zero and a zero tally each do and do not establish.
+				//
+				// Counting is also all we do. An unrecognized event is never
+				// coerced into a tool or reasoning message: guessing at
+				// upstream additions is the failure mode MUL-5231 already
+				// fixed once.
+				if !cursorNonTranscriptEventType(evt.Type) {
+					unhandledTypes.observe(evt.Type)
 				}
 			}
 		}
@@ -390,40 +395,40 @@ func (b *cursorBackend) Execute(ctx context.Context, prompt string, opts ExecOpt
 		}
 
 		logStreamProtocolObservation(b.cfg.Logger, streamProtocolObservation{
-			provider:              "cursor-agent",
-			cliVersion:            b.cfg.CLIVersion,
-			model:                 opts.Model,
-			exitCode:              streamProcessExitCode(exitErr),
-			eventCount:            eventCount,
-			invalidEventCount:     invalidEventCount,
-			assistantEventCount:   assistantEventCount,
-			toolUseCount:          toolUseCount,
-			sawResult:             resultSeen,
-			resultIsError:         resultIsError,
-			resultBytes:           resultBytes,
-			lastAssistantBytes:    assistantBytes,
-			scannerError:          scanErr != nil && !resultSeen,
-			lastEventType:         lastEventType,
-			unknownEventTypeCount: unknownTypes.total,
-			unknownEventTypes:     unknownTypes.summary(),
-			unknownSubtypeCount:   unknownSubtypeCount,
+			provider:                "cursor-agent",
+			cliVersion:              b.cfg.CLIVersion,
+			model:                   opts.Model,
+			exitCode:                streamProcessExitCode(exitErr),
+			eventCount:              eventCount,
+			invalidEventCount:       invalidEventCount,
+			assistantEventCount:     assistantEventCount,
+			toolUseCount:            toolUseCount,
+			sawResult:               resultSeen,
+			resultIsError:           resultIsError,
+			resultBytes:             resultBytes,
+			lastAssistantBytes:      assistantBytes,
+			scannerError:            scanErr != nil && !resultSeen,
+			lastEventType:           lastEventType,
+			unhandledEventTypeCount: unhandledTypes.total,
+			unhandledEventTypes:     unhandledTypes.summary(),
+			unhandledSubtypeCount:   unhandledSubtypeCount,
 		})
 
-		if unknownSubtypeCount > 0 {
+		if unhandledSubtypeCount > 0 {
 			// Content-free and emitted once per run: signals that the CLI sent a
 			// thinking/tool_call subtype we chose to ignore, so a protocol
 			// addition is diagnosable without the parser having guessed at it.
-			b.cfg.Logger.Warn("cursor-agent ignored unknown event subtypes", "count", unknownSubtypeCount)
+			b.cfg.Logger.Warn("cursor-agent ignored unhandled event subtypes", "count", unhandledSubtypeCount)
 		}
 
-		if unknownTypes.total > 0 {
-			// Same contract one level up, and the higher-value signal of the
-			// two: an unhandled top-level type means whole events — possibly
-			// every tool call in the run — never reached the transcript. Read
-			// this together with tool_use_count in the summary above.
-			b.cfg.Logger.Warn("cursor-agent ignored unknown event types",
-				"count", unknownTypes.total,
-				"types", unknownTypes.summary(),
+		if unhandledTypes.total > 0 {
+			// Same contract one level up, and the broader signal of the two: an
+			// unhandled top-level type means whole events never reached the
+			// transcript. What was in them is not decided here — the type names
+			// are the starting point for that, not the conclusion.
+			b.cfg.Logger.Warn("cursor-agent ignored unhandled event types",
+				"count", unhandledTypes.total,
+				"types", unhandledTypes.summary(),
 			)
 		}
 
@@ -484,60 +489,84 @@ func observedCursorEventType(value string) string {
 	return value
 }
 
-// cursorBenignEventTypes are top-level events the parser knowingly does not
-// forward and which are NOT evidence of protocol drift. `user` is the CLI
-// echoing our own prompt back on the stream (present in every recorded run), so
-// tallying it would fire the unknown-type warning on every single task — and a
-// warning that always fires is a warning nobody reads.
-var cursorBenignEventTypes = map[string]struct{}{
-	"user": {},
+// cursorNonTranscriptEventTypes are top-level events that are known to exist,
+// carry nothing the transcript needs, and are therefore NOT reported as
+// protocol drift. Dropping them is the behaviour that already shipped; listing
+// them here only keeps them out of the diagnostic, because a warning that fires
+// on every task is a warning nobody reads.
+//
+// Provenance differs per entry and matters when revisiting this list:
+//   - `user` — the CLI echoing our own prompt back. Confirmed present in the
+//     recorded 2026.07.20 stream, i.e. in every real run.
+//   - `connection`, `retry` — transport/control frames reported on newer CLI
+//     builds (MUL-5434 review). Not reproduced locally, so they are listed
+//     defensively: if a build does not emit them the entry is inert, and if it
+//     does we must not call a known control frame an unhandled protocol event.
+//
+// An entry here is a claim that the type carries no transcript content. Do not
+// add a type merely to silence the warning.
+var cursorNonTranscriptEventTypes = map[string]struct{}{
+	"user":       {},
+	"connection": {},
+	"retry":      {},
 }
 
-func cursorBenignEventType(eventType string) bool {
-	_, ok := cursorBenignEventTypes[strings.TrimSpace(eventType)]
+func cursorNonTranscriptEventType(eventType string) bool {
+	_, ok := cursorNonTranscriptEventTypes[strings.TrimSpace(eventType)]
 	return ok
 }
 
-// cursorUnknownTypeCardinalityCap bounds how many distinct unknown type names
-// the tally retains. A stream emitting novel type names (or garbage that still
+// cursorUnhandledTypeCardinalityCap bounds how many distinct type names the
+// tally retains. A stream emitting novel type names (or garbage that still
 // parses as JSON) must not grow the map without limit inside a long-running
 // daemon; names past the cap collapse into one overflow bucket.
-const cursorUnknownTypeCardinalityCap = 16
+const cursorUnhandledTypeCardinalityCap = 16
 
-// cursorUnknownTypeOverflowKey holds the counts that exceeded the cardinality
+// cursorUnhandledTypeOverflowKey holds the counts that exceeded the cardinality
 // cap. The parentheses cannot collide with a real type name: observedCursorEventType
 // only ever returns identifier characters, "unknown", or "invalid".
-const cursorUnknownTypeOverflowKey = "(overflow)"
+const cursorUnhandledTypeOverflowKey = "(overflow)"
 
-// cursorUnknownTypeTally counts top-level event types the parser does not
-// handle. It is the signal that separates "the CLI renamed an event we rely on"
-// from "the model genuinely used no tools" — before this existed, a renamed
+// cursorUnhandledTypeTally counts top-level event types this parser does not
+// handle, so that dropping them stops being silent. Before it existed a renamed
 // `tool_call` fell through the type switch and the run reported success with
-// tool_use_count=0 and no diagnostic whatsoever, which is exactly what a
-// tool-free run looks like (MUL-5434).
+// tool_use_count=0 and no diagnostic whatsoever (MUL-5434).
+//
+// Read it as evidence, not as a verdict — in both directions:
+//
+//   - A non-zero tally shows the stream carried top-level events we do not
+//     handle. Which events, and whether they are what the transcript lost,
+//     still has to be established from the type names, invalid_event_count and
+//     ultimately a captured stream.
+//   - A zero tally shows only that no unhandled top-level type was observed. It
+//     does NOT establish that the model used no tools: the CLI may have executed
+//     tools without handing the updates to its stream serializer at all, a new
+//     shape may be nested inside an event type we already recognize (e.g. an
+//     assistant content block), or the events may have been lost to invalid
+//     framing or a scanner boundary. Those branches are open on #6071.
 //
 // Only normalized identifiers and counts are retained, never payload content,
 // so the tally is safe to log beside the rest of the protocol summary.
-type cursorUnknownTypeTally struct {
+type cursorUnhandledTypeTally struct {
 	total  int
 	counts map[string]int
 }
 
-func (t *cursorUnknownTypeTally) observe(eventType string) {
+func (t *cursorUnhandledTypeTally) observe(eventType string) {
 	t.total++
 	if t.counts == nil {
 		t.counts = make(map[string]int, 4)
 	}
 	key := observedCursorEventType(eventType)
-	if _, seen := t.counts[key]; !seen && len(t.counts) >= cursorUnknownTypeCardinalityCap {
-		key = cursorUnknownTypeOverflowKey
+	if _, seen := t.counts[key]; !seen && len(t.counts) >= cursorUnhandledTypeCardinalityCap {
+		key = cursorUnhandledTypeOverflowKey
 	}
 	t.counts[key]++
 }
 
 // summary renders the tally as a stable, sorted "name=count" list (e.g.
 // "reasoning=9,tool_calls=6") so it can be grepped and diffed across runs.
-func (t *cursorUnknownTypeTally) summary() string {
+func (t *cursorUnhandledTypeTally) summary() string {
 	if len(t.counts) == 0 {
 		return ""
 	}

--- a/server/pkg/agent/cursor_stream_fixture_unix_test.go
+++ b/server/pkg/agent/cursor_stream_fixture_unix_test.go
@@ -299,7 +299,7 @@ func countCursorMessageTypes(messages []Message) map[MessageType]int {
 	return counts
 }
 
-// TestCursorExecuteReportsUnknownTopLevelTypes is the MUL-5434 regression.
+// TestCursorExecuteReportsUnhandledTopLevelTypes is the MUL-5434 regression.
 //
 // Reported symptom: a Cursor run that demonstrably used tools produced a single
 // blob of agent text, tools=0, no reasoning — and not one diagnostic. This test
@@ -309,10 +309,13 @@ func countCursorMessageTypes(messages []Message) map[MessageType]int {
 //
 // The parser must still refuse to guess: no tool or reasoning message may be
 // synthesized from an event it does not recognize. What it must NOT do is stay
-// silent, because a silent drop is indistinguishable from a model that
-// legitimately used no tools — that ambiguity is what made the original report
-// impossible to triage from logs alone.
-func TestCursorExecuteReportsUnknownTopLevelTypes(t *testing.T) {
+// silent — a silent drop leaves no trace at all, which is what made the original
+// report impossible to triage from logs.
+//
+// This asserts only that the signal exists and that nothing is fabricated. The
+// tally is deliberately not treated as a verdict on WHY the transcript is empty;
+// see cursorUnhandledTypeTally for the branches it cannot rule out.
+func TestCursorExecuteReportsUnhandledTopLevelTypes(t *testing.T) {
 	t.Parallel()
 
 	lines := []string{
@@ -333,16 +336,16 @@ func TestCursorExecuteReportsUnknownTopLevelTypes(t *testing.T) {
 	// Unrecognized events are never coerced into transcript rows.
 	counts := countCursorMessageTypes(messages)
 	if counts[MessageToolUse] != 0 || counts[MessageToolResult] != 0 {
-		t.Errorf("unknown types synthesized tool rows: tool_use=%d tool_result=%d",
+		t.Errorf("unhandled types synthesized tool rows: tool_use=%d tool_result=%d",
 			counts[MessageToolUse], counts[MessageToolResult])
 	}
 	if counts[MessageThinking] != 0 {
-		t.Errorf("unknown type folded into reasoning: thinking=%d", counts[MessageThinking])
+		t.Errorf("unhandled type folded into reasoning: thinking=%d", counts[MessageThinking])
 	}
 
-	// ...but the drop is now loud, and names the events that went missing.
-	if !strings.Contains(logs, "cursor-agent ignored unknown event types") {
-		t.Fatalf("no unknown-type warning emitted; logs:\n%s", logs)
+	// ...but the drop is now observable, and names the events that were dropped.
+	if !strings.Contains(logs, "cursor-agent ignored unhandled event types") {
+		t.Fatalf("no unhandled-type warning emitted; logs:\n%s", logs)
 	}
 	for _, want := range []string{`count=4`, `reasoning=1`, `toolCall=1`, `tool_calls=2`} {
 		if !strings.Contains(logs, want) {
@@ -350,27 +353,30 @@ func TestCursorExecuteReportsUnknownTopLevelTypes(t *testing.T) {
 		}
 	}
 
-	// The structured summary is where tools=0 and the unknown tally sit side by
-	// side; that pairing is what identifies a rename rather than a tool-free run.
-	if !strings.Contains(logs, "unknown_event_type_count=4") {
-		t.Errorf("protocol summary missing unknown_event_type_count=4; logs:\n%s", logs)
+	// The tally is also on the structured summary line, next to the other
+	// protocol counters an operator has to weigh alongside it.
+	if !strings.Contains(logs, "unhandled_event_type_count=4") {
+		t.Errorf("protocol summary missing unhandled_event_type_count=4; logs:\n%s", logs)
 	}
 	if !strings.Contains(logs, "tool_use_count=0") {
 		t.Errorf("protocol summary missing tool_use_count=0; logs:\n%s", logs)
 	}
 }
 
-// TestCursorExecuteDoesNotWarnOnBenignStream guards the other half of the fix:
-// the warning has to stay quiet on a healthy run. The recorded stream contains
-// a top-level `user` event (the CLI echoing our prompt) which the parser
-// deliberately drops — if that counted as drift, the warning would fire on
-// every task and stop meaning anything.
-func TestCursorExecuteDoesNotWarnOnBenignStream(t *testing.T) {
+// TestCursorExecuteDoesNotWarnOnHealthyStream guards the other half of the fix:
+// the warning has to stay quiet on a run with nothing wrong with it. Top-level
+// `user` (the CLI echoing our prompt, present in every recorded run) and the
+// `connection` / `retry` control frames carry no transcript content and are
+// dropped by design — if those counted as drift the warning would fire on every
+// task and stop meaning anything.
+func TestCursorExecuteDoesNotWarnOnHealthyStream(t *testing.T) {
 	t.Parallel()
 
 	lines := []string{
 		`{"type":"system","subtype":"init","session_id":"sess-ok"}`,
 		`{"type":"user","message":{"role":"user","content":[{"type":"text","text":"hello"}]}}`,
+		`{"type":"connection","subtype":"reconnecting"}`,
+		`{"type":"retry","subtype":"scheduled"}`,
 		`{"type":"thinking","subtype":"delta","text":"thinking"}`,
 		`{"type":"thinking","subtype":"completed"}`,
 		`{"type":"tool_call","subtype":"started","call_id":"call-a","tool_call":{"readToolCall":{"args":{"path":"/a"}},"toolCallId":"call-a"}}`,
@@ -378,16 +384,23 @@ func TestCursorExecuteDoesNotWarnOnBenignStream(t *testing.T) {
 		`{"type":"result","subtype":"success","is_error":false,"result":"done","session_id":"sess-ok"}`,
 	}
 
-	_, result, logs := runCursorStreamLines(t, lines)
+	messages, result, logs := runCursorStreamLines(t, lines)
 
 	if result.Status != "completed" {
 		t.Fatalf("status = %q, want completed; error=%q", result.Status, result.Error)
 	}
-	if strings.Contains(logs, "cursor-agent ignored unknown event types") {
-		t.Errorf("unknown-type warning fired on a healthy stream; logs:\n%s", logs)
+	if strings.Contains(logs, "cursor-agent ignored unhandled event types") {
+		t.Errorf("unhandled-type warning fired on a healthy stream; logs:\n%s", logs)
 	}
-	if !strings.Contains(logs, "unknown_event_type_count=0") {
-		t.Errorf("protocol summary should report unknown_event_type_count=0; logs:\n%s", logs)
+	if !strings.Contains(logs, "unhandled_event_type_count=0") {
+		t.Errorf("protocol summary should report unhandled_event_type_count=0; logs:\n%s", logs)
+	}
+	// Suppressing the warning must not have suppressed the real rows: the
+	// known-good `thinking` / `tool_call` events still reach the transcript.
+	counts := countCursorMessageTypes(messages)
+	if counts[MessageToolUse] != 1 || counts[MessageToolResult] != 1 || counts[MessageThinking] != 1 {
+		t.Errorf("healthy stream lost rows: tool_use=%d tool_result=%d thinking=%d",
+			counts[MessageToolUse], counts[MessageToolResult], counts[MessageThinking])
 	}
 }
 

--- a/server/pkg/agent/cursor_stream_fixture_unix_test.go
+++ b/server/pkg/agent/cursor_stream_fixture_unix_test.go
@@ -3,6 +3,7 @@
 package agent
 
 import (
+	"bytes"
 	"fmt"
 	"log/slog"
 	"path/filepath"
@@ -248,4 +249,191 @@ func TestCursorExecuteIgnoresUnknownSubtypes(t *testing.T) {
 // single quote, so a JSON line reaches printf verbatim.
 func shellSingleQuote(s string) string {
 	return "'" + strings.ReplaceAll(s, "'", `'\''`) + "'"
+}
+
+// runCursorStreamLines replays the given NDJSON lines through the real cursor
+// backend and returns the messages, the result, and everything the backend
+// logged.
+func runCursorStreamLines(t *testing.T, lines []string) ([]Message, Result, string) {
+	t.Helper()
+
+	script := "#!/bin/sh\n"
+	for _, line := range lines {
+		script += fmt.Sprintf("printf '%%s\\n' %s\n", shellSingleQuote(line))
+	}
+
+	fakePath := filepath.Join(t.TempDir(), "cursor-agent")
+	writeTestExecutable(t, fakePath, []byte(script))
+
+	var logBuf bytes.Buffer
+	logger := slog.New(slog.NewTextHandler(&logBuf, nil))
+
+	backend, err := New("cursor", Config{ExecutablePath: fakePath, Logger: logger})
+	if err != nil {
+		t.Fatalf("New(cursor): %v", err)
+	}
+	session, err := backend.Execute(t.Context(), "hello", ExecOptions{Timeout: 30 * time.Second})
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+
+	var messages []Message
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		for msg := range session.Messages {
+			messages = append(messages, msg)
+		}
+	}()
+	result := <-session.Result
+	<-done
+
+	return messages, result, logBuf.String()
+}
+
+func countCursorMessageTypes(messages []Message) map[MessageType]int {
+	counts := make(map[MessageType]int)
+	for _, msg := range messages {
+		counts[msg.Type]++
+	}
+	return counts
+}
+
+// TestCursorExecuteReportsUnknownTopLevelTypes is the MUL-5434 regression.
+//
+// Reported symptom: a Cursor run that demonstrably used tools produced a single
+// blob of agent text, tools=0, no reasoning — and not one diagnostic. This test
+// reproduces that exact stream shape by renaming only the top-level event types
+// (`thinking`→`reasoning`, `tool_call`→`tool_calls`) and leaving every nested
+// field untouched, which is what an upstream protocol rename looks like.
+//
+// The parser must still refuse to guess: no tool or reasoning message may be
+// synthesized from an event it does not recognize. What it must NOT do is stay
+// silent, because a silent drop is indistinguishable from a model that
+// legitimately used no tools — that ambiguity is what made the original report
+// impossible to triage from logs alone.
+func TestCursorExecuteReportsUnknownTopLevelTypes(t *testing.T) {
+	t.Parallel()
+
+	lines := []string{
+		`{"type":"system","subtype":"init","session_id":"sess-drift"}`,
+		`{"type":"reasoning","subtype":"delta","text":"reasoning under a renamed type"}`,
+		`{"type":"tool_calls","subtype":"started","call_id":"call-y","tool_call":{"readToolCall":{"args":{"path":"/y"}},"toolCallId":"call-y"}}`,
+		`{"type":"tool_calls","subtype":"completed","call_id":"call-y","tool_call":{"readToolCall":{"args":{"path":"/y"},"result":{"success":{}}},"toolCallId":"call-y"}}`,
+		`{"type":"toolCall","subtype":"started","call_id":"call-z","tool_call":{"readToolCall":{"args":{"path":"/z"}},"toolCallId":"call-z"}}`,
+		`{"type":"result","subtype":"success","is_error":false,"result":"single blob","session_id":"sess-drift"}`,
+	}
+
+	messages, result, logs := runCursorStreamLines(t, lines)
+
+	if result.Status != "completed" {
+		t.Fatalf("status = %q, want completed; error=%q", result.Status, result.Error)
+	}
+
+	// Unrecognized events are never coerced into transcript rows.
+	counts := countCursorMessageTypes(messages)
+	if counts[MessageToolUse] != 0 || counts[MessageToolResult] != 0 {
+		t.Errorf("unknown types synthesized tool rows: tool_use=%d tool_result=%d",
+			counts[MessageToolUse], counts[MessageToolResult])
+	}
+	if counts[MessageThinking] != 0 {
+		t.Errorf("unknown type folded into reasoning: thinking=%d", counts[MessageThinking])
+	}
+
+	// ...but the drop is now loud, and names the events that went missing.
+	if !strings.Contains(logs, "cursor-agent ignored unknown event types") {
+		t.Fatalf("no unknown-type warning emitted; logs:\n%s", logs)
+	}
+	for _, want := range []string{`count=4`, `reasoning=1`, `toolCall=1`, `tool_calls=2`} {
+		if !strings.Contains(logs, want) {
+			t.Errorf("warning/summary missing %q; logs:\n%s", want, logs)
+		}
+	}
+
+	// The structured summary is where tools=0 and the unknown tally sit side by
+	// side; that pairing is what identifies a rename rather than a tool-free run.
+	if !strings.Contains(logs, "unknown_event_type_count=4") {
+		t.Errorf("protocol summary missing unknown_event_type_count=4; logs:\n%s", logs)
+	}
+	if !strings.Contains(logs, "tool_use_count=0") {
+		t.Errorf("protocol summary missing tool_use_count=0; logs:\n%s", logs)
+	}
+}
+
+// TestCursorExecuteDoesNotWarnOnBenignStream guards the other half of the fix:
+// the warning has to stay quiet on a healthy run. The recorded stream contains
+// a top-level `user` event (the CLI echoing our prompt) which the parser
+// deliberately drops — if that counted as drift, the warning would fire on
+// every task and stop meaning anything.
+func TestCursorExecuteDoesNotWarnOnBenignStream(t *testing.T) {
+	t.Parallel()
+
+	lines := []string{
+		`{"type":"system","subtype":"init","session_id":"sess-ok"}`,
+		`{"type":"user","message":{"role":"user","content":[{"type":"text","text":"hello"}]}}`,
+		`{"type":"thinking","subtype":"delta","text":"thinking"}`,
+		`{"type":"thinking","subtype":"completed"}`,
+		`{"type":"tool_call","subtype":"started","call_id":"call-a","tool_call":{"readToolCall":{"args":{"path":"/a"}},"toolCallId":"call-a"}}`,
+		`{"type":"tool_call","subtype":"completed","call_id":"call-a","tool_call":{"readToolCall":{"args":{"path":"/a"},"result":{"success":{}}},"toolCallId":"call-a"}}`,
+		`{"type":"result","subtype":"success","is_error":false,"result":"done","session_id":"sess-ok"}`,
+	}
+
+	_, result, logs := runCursorStreamLines(t, lines)
+
+	if result.Status != "completed" {
+		t.Fatalf("status = %q, want completed; error=%q", result.Status, result.Error)
+	}
+	if strings.Contains(logs, "cursor-agent ignored unknown event types") {
+		t.Errorf("unknown-type warning fired on a healthy stream; logs:\n%s", logs)
+	}
+	if !strings.Contains(logs, "unknown_event_type_count=0") {
+		t.Errorf("protocol summary should report unknown_event_type_count=0; logs:\n%s", logs)
+	}
+}
+
+// TestCursorLastAssistantBytesExcludesResultText pins the second half of
+// MUL-5434's diagnostic gap. The result event writes its text into the same
+// builder as assistant text, so the summary used to report
+// last_assistant_bytes == result_bytes even when the assistant streamed
+// nothing — erasing the one signal that says "no incremental output arrived,
+// only the final answer", which is precisely the reported failure.
+func TestCursorLastAssistantBytesExcludesResultText(t *testing.T) {
+	t.Parallel()
+
+	t.Run("result only", func(t *testing.T) {
+		t.Parallel()
+		_, result, logs := runCursorStreamLines(t, []string{
+			`{"type":"system","subtype":"init","session_id":"sess-blob"}`,
+			`{"type":"result","subtype":"success","is_error":false,"result":"0123456789","session_id":"sess-blob"}`,
+		})
+		if result.Status != "completed" {
+			t.Fatalf("status = %q, want completed; error=%q", result.Status, result.Error)
+		}
+		if !strings.Contains(logs, "result_bytes=10") {
+			t.Errorf("summary missing result_bytes=10; logs:\n%s", logs)
+		}
+		if !strings.Contains(logs, "last_assistant_bytes=0") {
+			t.Errorf("assistant streamed nothing, so last_assistant_bytes must be 0; logs:\n%s", logs)
+		}
+	})
+
+	t.Run("assistant text counted", func(t *testing.T) {
+		t.Parallel()
+		_, result, logs := runCursorStreamLines(t, []string{
+			`{"type":"system","subtype":"init","session_id":"sess-text"}`,
+			`{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"abcde"}]}}`,
+			`{"type":"result","subtype":"success","is_error":false,"result":"0123456789","session_id":"sess-text"}`,
+		})
+		if result.Status != "completed" {
+			t.Fatalf("status = %q, want completed; error=%q", result.Status, result.Error)
+		}
+		// The result text is NOT appended (output is already non-empty), and the
+		// assistant's own 5 bytes are what gets reported.
+		if !strings.Contains(logs, "last_assistant_bytes=5") {
+			t.Errorf("summary should report the assistant's 5 bytes; logs:\n%s", logs)
+		}
+		if result.Output != "abcde" {
+			t.Errorf("output = %q, want %q", result.Output, "abcde")
+		}
+	})
 }

--- a/server/pkg/agent/cursor_test.go
+++ b/server/pkg/agent/cursor_test.go
@@ -2,6 +2,7 @@ package agent
 
 import (
 	"encoding/json"
+	"fmt"
 	"log/slog"
 	"strings"
 	"testing"
@@ -839,5 +840,99 @@ func TestCursorToolPayloadKeyIsDeterministic(t *testing.T) {
 	}
 	if got := cursorToolPayloadKey(map[string]json.RawMessage{"toolCallId": json.RawMessage(`"x"`)}); got != "" {
 		t.Fatalf("key without a tool payload = %q, want empty", got)
+	}
+}
+
+// TestCursorUnknownTypeTallySummary pins the rendering the daemon log depends
+// on: sorted so it diffs cleanly across runs, and "name=count" so an operator
+// can see at a glance which event went missing and how often.
+func TestCursorUnknownTypeTallySummary(t *testing.T) {
+	t.Parallel()
+
+	var tally cursorUnknownTypeTally
+	if got := tally.summary(); got != "" {
+		t.Errorf("empty tally summary = %q, want %q", got, "")
+	}
+	if tally.total != 0 {
+		t.Errorf("empty tally total = %d, want 0", tally.total)
+	}
+
+	for _, eventType := range []string{"tool_calls", "reasoning", "tool_calls", "reasoning", "tool_calls"} {
+		tally.observe(eventType)
+	}
+	if want := "reasoning=2,tool_calls=3"; tally.summary() != want {
+		t.Errorf("summary = %q, want %q", tally.summary(), want)
+	}
+	if tally.total != 5 {
+		t.Errorf("total = %d, want 5", tally.total)
+	}
+}
+
+// TestCursorUnknownTypeTallyNormalizesKeys keeps the tally content-free: a type
+// value carrying punctuation or arbitrary length must not be copied into daemon
+// logs verbatim, it collapses to the same bounded labels observedCursorEventType
+// produces everywhere else.
+func TestCursorUnknownTypeTallyNormalizesKeys(t *testing.T) {
+	t.Parallel()
+
+	var tally cursorUnknownTypeTally
+	tally.observe("")
+	tally.observe("   ")
+	tally.observe("tool call with spaces")
+	tally.observe(strings.Repeat("x", 65))
+
+	if want := "invalid=2,unknown=2"; tally.summary() != want {
+		t.Errorf("summary = %q, want %q", tally.summary(), want)
+	}
+}
+
+// TestCursorUnknownTypeTallyBoundsCardinality guards the daemon against a
+// stream that emits an unbounded set of novel type names: the map must stop
+// growing at the cap and fold the rest into the overflow bucket, while the
+// total still counts every event.
+func TestCursorUnknownTypeTallyBoundsCardinality(t *testing.T) {
+	t.Parallel()
+
+	var tally cursorUnknownTypeTally
+	const extra = 50
+	for i := 0; i < cursorUnknownTypeCardinalityCap+extra; i++ {
+		tally.observe(fmt.Sprintf("type-%03d", i))
+	}
+
+	if len(tally.counts) != cursorUnknownTypeCardinalityCap+1 {
+		t.Errorf("distinct keys = %d, want %d (cap + overflow bucket)",
+			len(tally.counts), cursorUnknownTypeCardinalityCap+1)
+	}
+	if got := tally.counts[cursorUnknownTypeOverflowKey]; got != extra {
+		t.Errorf("overflow bucket = %d, want %d", got, extra)
+	}
+	if tally.total != cursorUnknownTypeCardinalityCap+extra {
+		t.Errorf("total = %d, want %d", tally.total, cursorUnknownTypeCardinalityCap+extra)
+	}
+	// A capped key already in the map keeps accumulating under its own name.
+	tally.observe("type-000")
+	if got := tally.counts["type-000"]; got != 2 {
+		t.Errorf("known key count = %d, want 2", got)
+	}
+	// The overflow label cannot be produced by normalizing a real type name, so
+	// a stream cannot forge counts into the bucket.
+	if observedCursorEventType(cursorUnknownTypeOverflowKey) != "invalid" {
+		t.Errorf("overflow key %q is collidable with a real type name", cursorUnknownTypeOverflowKey)
+	}
+}
+
+// TestCursorBenignEventType pins which unhandled types must stay silent. `user`
+// is the CLI echoing our own prompt and appears in every run: tallying it would
+// make the unknown-type warning fire always, which is the same as never.
+func TestCursorBenignEventType(t *testing.T) {
+	t.Parallel()
+
+	if !cursorBenignEventType("user") {
+		t.Error("`user` must be treated as benign; it is present in every recorded run")
+	}
+	for _, eventType := range []string{"tool_calls", "reasoning", "toolCall", ""} {
+		if cursorBenignEventType(eventType) {
+			t.Errorf("%q must NOT be benign — it has to be reported as protocol drift", eventType)
+		}
 	}
 }

--- a/server/pkg/agent/cursor_test.go
+++ b/server/pkg/agent/cursor_test.go
@@ -843,13 +843,13 @@ func TestCursorToolPayloadKeyIsDeterministic(t *testing.T) {
 	}
 }
 
-// TestCursorUnknownTypeTallySummary pins the rendering the daemon log depends
+// TestCursorUnhandledTypeTallySummary pins the rendering the daemon log depends
 // on: sorted so it diffs cleanly across runs, and "name=count" so an operator
 // can see at a glance which event went missing and how often.
-func TestCursorUnknownTypeTallySummary(t *testing.T) {
+func TestCursorUnhandledTypeTallySummary(t *testing.T) {
 	t.Parallel()
 
-	var tally cursorUnknownTypeTally
+	var tally cursorUnhandledTypeTally
 	if got := tally.summary(); got != "" {
 		t.Errorf("empty tally summary = %q, want %q", got, "")
 	}
@@ -868,14 +868,14 @@ func TestCursorUnknownTypeTallySummary(t *testing.T) {
 	}
 }
 
-// TestCursorUnknownTypeTallyNormalizesKeys keeps the tally content-free: a type
+// TestCursorUnhandledTypeTallyNormalizesKeys keeps the tally content-free: a type
 // value carrying punctuation or arbitrary length must not be copied into daemon
 // logs verbatim, it collapses to the same bounded labels observedCursorEventType
 // produces everywhere else.
-func TestCursorUnknownTypeTallyNormalizesKeys(t *testing.T) {
+func TestCursorUnhandledTypeTallyNormalizesKeys(t *testing.T) {
 	t.Parallel()
 
-	var tally cursorUnknownTypeTally
+	var tally cursorUnhandledTypeTally
 	tally.observe("")
 	tally.observe("   ")
 	tally.observe("tool call with spaces")
@@ -886,28 +886,28 @@ func TestCursorUnknownTypeTallyNormalizesKeys(t *testing.T) {
 	}
 }
 
-// TestCursorUnknownTypeTallyBoundsCardinality guards the daemon against a
+// TestCursorUnhandledTypeTallyBoundsCardinality guards the daemon against a
 // stream that emits an unbounded set of novel type names: the map must stop
 // growing at the cap and fold the rest into the overflow bucket, while the
 // total still counts every event.
-func TestCursorUnknownTypeTallyBoundsCardinality(t *testing.T) {
+func TestCursorUnhandledTypeTallyBoundsCardinality(t *testing.T) {
 	t.Parallel()
 
-	var tally cursorUnknownTypeTally
+	var tally cursorUnhandledTypeTally
 	const extra = 50
-	for i := 0; i < cursorUnknownTypeCardinalityCap+extra; i++ {
+	for i := 0; i < cursorUnhandledTypeCardinalityCap+extra; i++ {
 		tally.observe(fmt.Sprintf("type-%03d", i))
 	}
 
-	if len(tally.counts) != cursorUnknownTypeCardinalityCap+1 {
+	if len(tally.counts) != cursorUnhandledTypeCardinalityCap+1 {
 		t.Errorf("distinct keys = %d, want %d (cap + overflow bucket)",
-			len(tally.counts), cursorUnknownTypeCardinalityCap+1)
+			len(tally.counts), cursorUnhandledTypeCardinalityCap+1)
 	}
-	if got := tally.counts[cursorUnknownTypeOverflowKey]; got != extra {
+	if got := tally.counts[cursorUnhandledTypeOverflowKey]; got != extra {
 		t.Errorf("overflow bucket = %d, want %d", got, extra)
 	}
-	if tally.total != cursorUnknownTypeCardinalityCap+extra {
-		t.Errorf("total = %d, want %d", tally.total, cursorUnknownTypeCardinalityCap+extra)
+	if tally.total != cursorUnhandledTypeCardinalityCap+extra {
+		t.Errorf("total = %d, want %d", tally.total, cursorUnhandledTypeCardinalityCap+extra)
 	}
 	// A capped key already in the map keeps accumulating under its own name.
 	tally.observe("type-000")
@@ -916,23 +916,37 @@ func TestCursorUnknownTypeTallyBoundsCardinality(t *testing.T) {
 	}
 	// The overflow label cannot be produced by normalizing a real type name, so
 	// a stream cannot forge counts into the bucket.
-	if observedCursorEventType(cursorUnknownTypeOverflowKey) != "invalid" {
-		t.Errorf("overflow key %q is collidable with a real type name", cursorUnknownTypeOverflowKey)
+	if observedCursorEventType(cursorUnhandledTypeOverflowKey) != "invalid" {
+		t.Errorf("overflow key %q is collidable with a real type name", cursorUnhandledTypeOverflowKey)
 	}
 }
 
-// TestCursorBenignEventType pins which unhandled types must stay silent. `user`
-// is the CLI echoing our own prompt and appears in every run: tallying it would
-// make the unknown-type warning fire always, which is the same as never.
-func TestCursorBenignEventType(t *testing.T) {
+// TestCursorNonTranscriptEventType pins which unhandled types must stay silent.
+// `user` is the CLI echoing our own prompt and appears in every run; `connection`
+// and `retry` are transport control frames. None carry transcript content, so
+// tallying them would make the warning fire always, which is the same as never.
+func TestCursorNonTranscriptEventType(t *testing.T) {
 	t.Parallel()
 
-	if !cursorBenignEventType("user") {
-		t.Error("`user` must be treated as benign; it is present in every recorded run")
+	for _, eventType := range []string{"user", "connection", "retry"} {
+		if !cursorNonTranscriptEventType(eventType) {
+			t.Errorf("%q must be non-transcript; it carries nothing the transcript needs", eventType)
+		}
 	}
 	for _, eventType := range []string{"tool_calls", "reasoning", "toolCall", ""} {
-		if cursorBenignEventType(eventType) {
-			t.Errorf("%q must NOT be benign — it has to be reported as protocol drift", eventType)
+		if cursorNonTranscriptEventType(eventType) {
+			t.Errorf("%q must NOT be suppressed — it has to be reported as unhandled", eventType)
+		}
+	}
+	// The suppression list must never shadow a type the parser actually handles,
+	// otherwise silencing the diagnostic would silence the transcript too.
+	handled := []string{
+		"system", "assistant", "thinking", "tool_call", "tool_use",
+		"tool_result", "result", "error", "text", "step_finish",
+	}
+	for _, eventType := range handled {
+		if cursorNonTranscriptEventType(eventType) {
+			t.Errorf("%q is handled by the parser and must not be in the suppression list", eventType)
 		}
 	}
 }

--- a/server/pkg/agent/stream_json_result.go
+++ b/server/pkg/agent/stream_json_result.go
@@ -102,16 +102,21 @@ type streamProtocolObservation struct {
 	scannerError               bool
 	lastEventType              string
 	anthropicBaseURLConfigured bool
-	// unknownEventTypeCount / unknownEventTypes / unknownSubtypeCount report
-	// stream events the parser did not turn into messages. They belong on this
-	// line rather than only in a separate warning because the diagnosis needs
-	// them side by side with toolUseCount: "tools=0 AND unknown types present"
-	// means a renamed upstream event ate the tool rows, while "tools=0 and
-	// nothing unknown" means the model really used no tools. Set by providers
-	// that track them; zero elsewhere.
-	unknownEventTypeCount int
-	unknownEventTypes     string
-	unknownSubtypeCount   int
+	// unhandledEventTypeCount / unhandledEventTypes / unhandledSubtypeCount
+	// report stream events the parser did not turn into messages. They belong on
+	// this line rather than only in a separate warning so they can be read
+	// together with toolUseCount and invalidEventCount.
+	//
+	// They are evidence, not a verdict. A non-zero count means the stream
+	// carried events we do not handle and is the starting point for identifying
+	// a protocol change; a zero count means only that none were observed at the
+	// top level, and does not establish that the agent used no tools — a CLI can
+	// execute tools without serializing the updates at all, and a new shape can
+	// be nested inside a type we already recognize. Set by providers that track
+	// them; zero elsewhere.
+	unhandledEventTypeCount int
+	unhandledEventTypes     string
+	unhandledSubtypeCount   int
 }
 
 // logStreamProtocolObservation records only protocol metadata. It deliberately
@@ -134,9 +139,9 @@ func logStreamProtocolObservation(logger *slog.Logger, obs streamProtocolObserva
 		"last_assistant_bytes", obs.lastAssistantBytes,
 		"scanner_error", obs.scannerError,
 		"last_event_type", obs.lastEventType,
-		"unknown_event_type_count", obs.unknownEventTypeCount,
-		"unknown_event_types", obs.unknownEventTypes,
-		"unknown_subtype_count", obs.unknownSubtypeCount,
+		"unhandled_event_type_count", obs.unhandledEventTypeCount,
+		"unhandled_event_types", obs.unhandledEventTypes,
+		"unhandled_subtype_count", obs.unhandledSubtypeCount,
 		"anthropic_base_url_configured", obs.anthropicBaseURLConfigured,
 	)
 }

--- a/server/pkg/agent/stream_json_result.go
+++ b/server/pkg/agent/stream_json_result.go
@@ -102,6 +102,16 @@ type streamProtocolObservation struct {
 	scannerError               bool
 	lastEventType              string
 	anthropicBaseURLConfigured bool
+	// unknownEventTypeCount / unknownEventTypes / unknownSubtypeCount report
+	// stream events the parser did not turn into messages. They belong on this
+	// line rather than only in a separate warning because the diagnosis needs
+	// them side by side with toolUseCount: "tools=0 AND unknown types present"
+	// means a renamed upstream event ate the tool rows, while "tools=0 and
+	// nothing unknown" means the model really used no tools. Set by providers
+	// that track them; zero elsewhere.
+	unknownEventTypeCount int
+	unknownEventTypes     string
+	unknownSubtypeCount   int
 }
 
 // logStreamProtocolObservation records only protocol metadata. It deliberately
@@ -124,6 +134,9 @@ func logStreamProtocolObservation(logger *slog.Logger, obs streamProtocolObserva
 		"last_assistant_bytes", obs.lastAssistantBytes,
 		"scanner_error", obs.scannerError,
 		"last_event_type", obs.lastEventType,
+		"unknown_event_type_count", obs.unknownEventTypeCount,
+		"unknown_event_types", obs.unknownEventTypes,
+		"unknown_subtype_count", obs.unknownSubtypeCount,
 		"anthropic_base_url_configured", obs.anthropicBaseURLConfigured,
 	)
 }


### PR DESCRIPTION
Closes the **diagnostic** gap behind #6071 / MUL-5434. It does not restore the missing tool trails — see Scope.

## Background

#6071 reports Cursor tasks that demonstrably read files, ran commands and called the Multica CLI, but showed a **single blob of agent text** — no reasoning, no tool rows. The run still reported success with `tools=0`.

`switch evt.Type` in `cursor.go` had **no `default` branch**. Any top-level event type the parser does not handle was dropped with no counter and no warning.

Renaming *only* the top-level types of a healthy stream (`thinking`→`reasoning`, `tool_call`→`tool_calls`), leaving every nested field untouched, reproduces the report exactly:

```
status="completed" output="one single blob of agent text" tool_use=0 tool_result=0 thinking=0
event_count=5 invalid_event_count=0 assistant_event_count=0 saw_result=true last_event_type=result
```

The existing unhandled-*subtype* warning cannot catch this — it only increments once the type has already matched — so "no unknown-subtype warning" does **not** rule out protocol drift, which is how the earlier triage on this issue reached the wrong conclusion.

## Changes

1. **Add the `default` branch** with a bounded, content-free tally of unhandled top-level types, warned once per run and carried on the protocol summary line beside the other counters.
   - Type names go through the existing `observedCursorEventType` normalizer (identifier chars only, ≤64 bytes), so no payload can reach the logs.
   - Distinct names capped at 16 + an `(overflow)` bucket, so a noisy or hostile stream cannot grow the map inside a long-running daemon. The overflow label uses parentheses precisely because the normalizer can never emit them, so counts cannot be forged into the bucket.
   - `user` (the CLI echoing our own prompt), `connection` and `retry` (transport control frames) are classified as non-transcript, with per-entry provenance in the code: `user` is confirmed in the recorded 2026.07.20 stream; the control frames are reported on newer builds and listed defensively. Without this the warning would fire on every task, which is the same as never firing.
2. **Count assistant text separately from the terminal result text.** The `result` event writes into the same `strings.Builder`, so `last_assistant_bytes` equalled `result_bytes` even when the assistant streamed nothing at all — erasing the one signal that says "only the final answer arrived". This also aligns cursor with claude, which already reports `len(lastAssistantText)`.

Naming is `unhandled*` rather than `unknown*` throughout (fields, log keys, warning text, and the pre-existing subtype counter) so the diagnostic never implies the type is unrecognized *upstream* — only that this parser does not handle it.

## What the counters do and do not establish

Deliberately stated in the code as well, because getting this wrong sends triage down the wrong path:

- **Non-zero** means the stream carried top-level events we do not parse. Which events, and whether they are what the transcript lost, still has to be established from the type names, `invalid_event_count`, and ultimately a captured stream.
- **Zero** means only that no unhandled top-level type was observed. It does **not** establish that the agent used no tools: the CLI may execute tools without handing the updates to its stream serializer at all (the main branch #6071 has not ruled out), a new shape may be nested inside a type we already recognize such as an `assistant` content block, or events may be lost to invalid framing or a scanner boundary.

Unrecognized events are still **never coerced** into tool or reasoning messages. Guessing at upstream additions is the failure mode MUL-5231 already fixed once, and synthesizing a `tool_result` from a non-terminal event would decrement the daemon's in-flight tool count early and drop a still-running long tool onto the shorter idle watchdog.

## Scope / what this does NOT do

This is **diagnosis only** and must not be read as closing #6071. Identifying which upstream shape changed needs a captured `2026.07.23` stream, and `cursor-agent` was not available on the machine this was written on. What this buys is that the next occurrence is identifiable from a single production log line instead of requiring a packet capture.

Deliberately out of scope, tracked on MUL-5434:
- extending the parser for a new envelope shape + a 2026.07.23 fixture (needs the capture first);
- counting unhandled `assistant` content-block types and decode failures, so nested drift is loud too;
- parameterizing the gated real-binary smoke test over `grok-4.5` / `composer-2.5` (it currently passes no `--model`, so it only covers default/Auto).

## Testing

Added regression coverage, all in `server/pkg/agent`. The tests assert that the signal exists and that nothing is fabricated — they deliberately do not encode the tally as a causal determiner:

- `TestCursorExecuteReportsUnhandledTopLevelTypes` — replays the renamed-type stream; asserts no tool/reasoning rows are synthesized, and that the warning fires naming `reasoning=1,toolCall=1,tool_calls=2` with `unhandled_event_type_count=4` on the summary line.
- `TestCursorExecuteDoesNotWarnOnHealthyStream` — a stream carrying `user`, `connection` and `retry` stays silent (`unhandled_event_type_count=0`) **and** still delivers its real thinking/tool rows, so suppressing the warning cannot silently suppress the transcript.
- `TestCursorLastAssistantBytesExcludesResultText` — result-only run reports `last_assistant_bytes=0` with `result_bytes=10`; a run with assistant text reports the assistant's own byte count.
- `TestCursorUnhandledTypeTallySummary` / `NormalizesKeys` / `BoundsCardinality` — sorted rendering, punctuation and over-length names collapsing to `invalid`/`unknown`, the cardinality cap and overflow bucket.
- `TestCursorNonTranscriptEventType` — the suppression list contains the three control/echo types, rejects drift candidates, and cannot shadow any type the parser actually handles.

Verified locally:

```
go build ./...                          # ok
go vet ./...                            # clean
go test -race ./pkg/agent -count=1      # ok (158s)
go test ./pkg/agent -count=1            # ok (137s)
go test ./internal/daemon -count=1      # ok (23s)
git diff --check                        # clean
```

Both behavioural tests were confirmed to **fail** when each fix is neutered individually (tally call removed → `TestCursorExecuteReportsUnhandledTopLevelTypes` FAIL; `lastAssistantBytes` reverted to `output.Len()` → `TestCursorLastAssistantBytesExcludesResultText/result_only` FAIL), so neither assertion is vacuous. The pre-existing 2026.07.20 fixture regression still passes unchanged.
