### PR TITLE
fix(typography): CJK landing headlines, AA contrast, tabular timers, mono weight, prose measure

### DIFF
--- a/apps/desktop/src/renderer/src/main.tsx
+++ b/apps/desktop/src/renderer/src/main.tsx
@@ -9,7 +9,13 @@ import "@fontsource-variable/inter";
 // (see tokens.css @theme inline). Variable font = one file covers all weights.
 import "@fontsource-variable/source-serif-4";
 import "@fontsource-variable/source-serif-4/wght-italic.css";
+// 400/500/700 mirror the weights shared components actually ask for. Web gets
+// Geist Mono from next/font as a variable face (every weight available), so a
+// weight missing here renders lighter on desktop than on web for the same
+// component — `font-mono font-medium` in packages/ui/components/ui/chart.tsx is
+// the case that surfaced it. Add the file here when a new mono weight appears.
 import "@fontsource/geist-mono/400.css";
+import "@fontsource/geist-mono/500.css";
 import "@fontsource/geist-mono/700.css";
 import "./globals.css";
 

--- a/apps/mobile/components/chat/status-pill.tsx
+++ b/apps/mobile/components/chat/status-pill.tsx
@@ -145,7 +145,9 @@ export function StatusPill({
       {stage.static ? null : <BreathingDots />}
       <Text className="text-xs text-muted-foreground" numberOfLines={1}>
         {stage.label}
-        <Text className="text-xs text-muted-foreground/70">
+        {/* useTick re-renders this every second; proportional figures would
+            change the pill's width on each tick (9s -> 10s). */}
+        <Text className="text-xs text-muted-foreground/70 tabular-nums">
           {" · "}
           {formatElapsedSecs(elapsedSec)}
         </Text>

--- a/apps/web/app/(landing)/layout.tsx
+++ b/apps/web/app/(landing)/layout.tsx
@@ -1,17 +1,15 @@
-import { Instrument_Serif, Noto_Serif_SC } from "next/font/google";
+import { Instrument_Serif } from "next/font/google";
 import { LocaleProvider } from "@/features/landing/i18n";
 import { getRequestLocale } from "@/lib/request-locale";
 
+// Latin-only display serif for landing headlines. It exposes its own variable
+// rather than `--font-serif` directly: Instrument Serif has no CJK coverage, so
+// the landing `--font-serif` is composed in app/custom.css as this family plus a
+// system Song/Mincho/Myeongjo tail, the same way globals.css builds `--font-sans`.
 const instrumentSerif = Instrument_Serif({
   subsets: ["latin"],
   weight: "400",
-  variable: "--font-serif",
-});
-
-const notoSerifSC = Noto_Serif_SC({
-  subsets: ["latin"],
-  weight: "400",
-  variable: "--font-serif-zh",
+  variable: "--font-instrument-serif",
 });
 
 const jsonLd = {
@@ -52,7 +50,7 @@ export default async function LandingLayout({
         type="application/ld+json"
         dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
       />
-      <div className={`${instrumentSerif.variable} ${notoSerifSC.variable} landing-light h-full overflow-x-hidden overflow-y-auto bg-white`}>
+      <div className={`${instrumentSerif.variable} landing-light h-full overflow-x-hidden overflow-y-auto bg-white`}>
         <LocaleProvider initialLocale={initialLocale}>{children}</LocaleProvider>
       </div>
     </>

--- a/apps/web/app/(landing)/usecases/[slug]/page.tsx
+++ b/apps/web/app/(landing)/usecases/[slug]/page.tsx
@@ -231,7 +231,7 @@ export default async function UseCasePage(props: { params: Promise<Params> }) {
           )}
         >
           <article>
-            <h1 className="font-[family-name:var(--font-serif)] text-[2.6rem] leading-[1.05] tracking-[-0.03em] sm:text-[3.4rem]">
+            <h1 className="landing-display text-[2.6rem] leading-[1.05] tracking-[-0.03em] sm:text-[3.4rem]">
               {page.data.title}
             </h1>
             <div className="mt-10 text-[16px] leading-[1.85] text-[#0a0d12]/72 [&>:first-child]:mt-0 [&>p]:my-5 sm:text-[17px]">

--- a/apps/web/app/(landing)/usecases/page.tsx
+++ b/apps/web/app/(landing)/usecases/page.tsx
@@ -49,7 +49,7 @@ export default async function UseCasesIndexPage() {
         <LandingHeader variant="dark" />
         <section className="relative overflow-hidden bg-[#05070b] text-white">
           <div className="relative z-10 mx-auto max-w-[1120px] px-4 pb-20 pt-32 text-center sm:px-6 sm:pt-40 lg:px-8 lg:pb-24">
-            <h1 className="mx-auto max-w-[880px] font-[family-name:var(--font-serif)] text-[3rem] leading-[1.02] tracking-[-0.035em] drop-shadow-[0_10px_34px_rgba(0,0,0,0.32)] sm:text-[4rem] lg:text-[5rem]">
+            <h1 className="mx-auto max-w-[880px] landing-display text-[3rem] leading-[1.02] tracking-[-0.035em] drop-shadow-[0_10px_34px_rgba(0,0,0,0.32)] sm:text-[4rem] lg:text-[5rem]">
               {text.indexTitle}
             </h1>
             <p className="mx-auto mt-6 max-w-[620px] text-[15px] leading-7 text-white/84 sm:text-[17px]">

--- a/apps/web/app/custom.css
+++ b/apps/web/app/custom.css
@@ -39,7 +39,10 @@
     --secondary: oklch(0.967 0.001 286.375);
     --secondary-foreground: oklch(0.21 0.006 285.885);
     --muted: oklch(0.967 0.001 286.375);
-    --muted-foreground: oklch(0.552 0.016 285.938);
+    /* Mirrors the AA-corrected light value in @multica/ui/styles/tokens.css.
+       Keep the two in step — this block exists to re-declare the light palette,
+       not to hold a second opinion about it. */
+    --muted-foreground: oklch(0.505 0.016 285.938);
     --accent: oklch(0.967 0.001 286.375);
     --accent-foreground: oklch(0.21 0.006 285.885);
     --destructive: oklch(0.577 0.245 27.325);
@@ -54,4 +57,50 @@
     --scrollbar-thumb: oklch(0 0 0 / 10%);
     --scrollbar-thumb-hover: oklch(0 0 0 / 18%);
     --scrollbar-track: transparent;
+
+    /* Landing editorial serif. Instrument Serif is Latin-only — it has zero CJK
+       coverage — so a zh/ja/ko headline drops out of the family entirely and gets
+       whatever the UA picks for the script, sitting next to Latin glyphs from a
+       different typeface. Compose the CJK tail here rather than in next/font's
+       `fallback`, matching how globals.css builds --font-sans: it must be
+       overridable per <html lang>, and a hashed next/font family can only be
+       referenced from CSS through its variable.
+       These are system Song / Mincho / Myeongjo faces — real serif companions to
+       Instrument Serif at zero download. Chinese stays ahead of Korean for the
+       same reason as --font-sans: Han ideographs share one Unicode block, while
+       Hangul is separate, so ko readers still get a Korean face for Hangul. */
+    --font-serif: var(--font-instrument-serif), "Songti SC", "STSong", SimSun,
+        "Source Han Serif SC", "Noto Serif CJK SC", "AppleMyungjo",
+        "Nanum Myeongjo", "Noto Serif CJK KR", ui-serif, serif;
+}
+
+/* Japanese Kanji share the Han block with Chinese and CSS font-fallback order is
+   NOT affected by <html lang>, so the Chinese-first chain above would hand
+   Japanese readers Chinese glyph shapes. Promote Mincho faces for Japanese only.
+   Mirrors the [lang|="ja"] override for --font-sans in app/globals.css. */
+html[lang|="ja"] .landing-light {
+    --font-serif: var(--font-instrument-serif), "Hiragino Mincho ProN",
+        "Hiragino Mincho Pro", "Yu Mincho", YuMincho, "MS Mincho",
+        "Noto Serif CJK JP", "Source Han Serif JP", ui-serif, serif;
+}
+
+/* Landing display headings (hero, section titles). Owns the family so call sites
+   don't each repeat `font-[family-name:var(--font-serif)]`, and — more to the
+   point — gives the CJK reset below a single hook to attach to. */
+.landing-display {
+    font-family: var(--font-serif);
+}
+
+/* The per-site tracking and leading on these headings are tuned for Latin display
+   type: negative letter-spacing and a sub-1 line-height. Han and Kana glyphs
+   already fill their em box, so negative tracking crowds them, and a sub-1
+   line-height collides consecutive lines — landing-hero.tsx renders two
+   <br />-separated lines at up to 6.4rem. Reset both for CJK only; Latin keeps
+   the tuned values. custom.css is unlayered, so these win over Tailwind's
+   `tracking-[…]` / `leading-[…]` utilities without !important. */
+html[lang|="zh"] .landing-display,
+html[lang|="ja"] .landing-display,
+html[lang|="ko"] .landing-display {
+    letter-spacing: normal;
+    line-height: 1.25;
 }

--- a/apps/web/features/landing/components/about-page-client.tsx
+++ b/apps/web/features/landing/components/about-page-client.tsx
@@ -15,7 +15,7 @@ export function AboutPageClient() {
       <LandingHeader variant="light" />
       <main className="bg-white text-[#0a0d12]">
         <div className="mx-auto max-w-[720px] px-4 py-16 sm:px-6 sm:py-20 lg:py-24">
-          <h1 className="font-[family-name:var(--font-serif)] text-[2.6rem] leading-[1.05] tracking-[-0.03em] sm:text-[3.4rem]">
+          <h1 className="landing-display text-[2.6rem] leading-[1.05] tracking-[-0.03em] sm:text-[3.4rem]">
             {t.about.title}
           </h1>
           <div className="mt-8 space-y-6 text-[15px] leading-[1.8] text-[#0a0d12]/70 sm:text-[16px]">

--- a/apps/web/features/landing/components/changelog-page-client.tsx
+++ b/apps/web/features/landing/components/changelog-page-client.tsx
@@ -260,7 +260,7 @@ export function ChangelogPageClient() {
             </aside>
 
             <div className="mx-auto min-w-0 max-w-[720px] lg:mx-0">
-              <h1 className="font-[family-name:var(--font-serif)] text-[2.6rem] leading-[1.05] tracking-[-0.03em] sm:text-[3.4rem]">
+              <h1 className="landing-display text-[2.6rem] leading-[1.05] tracking-[-0.03em] sm:text-[3.4rem]">
                 {t.changelog.title}
               </h1>
               <p className="mt-4 text-[15px] leading-7 text-[#0a0d12]/60 sm:text-[16px]">

--- a/apps/web/features/landing/components/contact-sales-page-client.tsx
+++ b/apps/web/features/landing/components/contact-sales-page-client.tsx
@@ -163,7 +163,7 @@ export function ContactSalesPageClient() {
             <p className="text-[12px] font-semibold uppercase tracking-[0.12em] text-[#0a0d12]/45">
               {c.eyebrow}
             </p>
-            <h1 className="mt-2 font-[family-name:var(--font-serif)] text-[2.4rem] leading-[1.1] tracking-[-0.02em] sm:text-[2.8rem]">
+            <h1 className="mt-2 landing-display text-[2.4rem] leading-[1.1] tracking-[-0.02em] sm:text-[2.8rem]">
               {c.title}
             </h1>
             <p className="mt-3 text-[14px] text-[#0a0d12]/60 sm:text-[15px]">
@@ -206,7 +206,7 @@ function SuccessCard({
 }) {
   return (
     <div className="rounded-[16px] border border-[#0a0d12]/8 bg-white p-8 shadow-[0_1px_2px_rgba(10,13,18,0.04)] sm:p-10">
-      <h2 className="font-[family-name:var(--font-serif)] text-[1.8rem] leading-[1.15] tracking-[-0.02em]">
+      <h2 className="landing-display text-[1.8rem] leading-[1.15] tracking-[-0.02em]">
         {title}
       </h2>
       <p className="mt-3 text-[15px] leading-[1.7] text-[#0a0d12]/70">

--- a/apps/web/features/landing/components/download/all-platforms.tsx
+++ b/apps/web/features/landing/components/download/all-platforms.tsx
@@ -28,7 +28,7 @@ export function AllPlatforms({
       className="bg-white py-20 text-[#0a0d12] sm:py-24"
     >
       <div className="mx-auto max-w-[920px] px-4 sm:px-6 lg:px-8">
-        <h2 className="font-[family-name:var(--font-serif)] text-[2.2rem] leading-[1.1] tracking-[-0.03em] sm:text-[2.6rem]">
+        <h2 className="landing-display text-[2.2rem] leading-[1.1] tracking-[-0.03em] sm:text-[2.6rem]">
           {d.title}
         </h2>
 

--- a/apps/web/features/landing/components/download/cli-section.tsx
+++ b/apps/web/features/landing/components/download/cli-section.tsx
@@ -21,7 +21,7 @@ export function CliSection() {
   return (
     <section id="cli" className="bg-[#f7f7f5] py-20 text-[#0a0d12] sm:py-24">
       <div className="mx-auto max-w-[820px] px-4 sm:px-6 lg:px-8">
-        <h2 className="font-[family-name:var(--font-serif)] text-[2.2rem] leading-[1.1] tracking-[-0.03em] sm:text-[2.6rem]">
+        <h2 className="landing-display text-[2.2rem] leading-[1.1] tracking-[-0.03em] sm:text-[2.6rem]">
           {d.title}
         </h2>
         <p className="mt-4 max-w-[620px] text-[15px] leading-7 text-[#0a0d12]/72">

--- a/apps/web/features/landing/components/download/cloud-section.tsx
+++ b/apps/web/features/landing/components/download/cloud-section.tsx
@@ -19,7 +19,7 @@ export function CloudSection() {
   return (
     <section className="bg-white py-20 text-[#0a0d12] sm:py-24">
       <div className="mx-auto max-w-[720px] px-4 sm:px-6 lg:px-8">
-        <h2 className="font-[family-name:var(--font-serif)] text-[2.2rem] leading-[1.1] tracking-[-0.03em] sm:text-[2.6rem]">
+        <h2 className="landing-display text-[2.2rem] leading-[1.1] tracking-[-0.03em] sm:text-[2.6rem]">
           {d.title}
         </h2>
         <p className="mt-4 max-w-[560px] text-[15px] leading-7 text-[#0a0d12]/72">

--- a/apps/web/features/landing/components/download/hero.tsx
+++ b/apps/web/features/landing/components/download/hero.tsx
@@ -32,7 +32,7 @@ export function DownloadHero({
     <section className="relative overflow-hidden bg-[#05070b] text-white">
       <BackdropGradient />
       <div className="relative z-10 mx-auto max-w-[1120px] px-4 pb-24 pt-32 text-center sm:px-6 sm:pt-40 lg:px-8 lg:pb-28">
-        <h1 className="mx-auto max-w-[880px] font-[family-name:var(--font-serif)] text-[3rem] leading-[1.02] tracking-[-0.035em] drop-shadow-[0_10px_34px_rgba(0,0,0,0.32)] sm:text-[4rem] lg:text-[5rem]">
+        <h1 className="mx-auto max-w-[880px] landing-display text-[3rem] leading-[1.02] tracking-[-0.035em] drop-shadow-[0_10px_34px_rgba(0,0,0,0.32)] sm:text-[4rem] lg:text-[5rem]">
           {content.title}
         </h1>
         <p className="mx-auto mt-6 max-w-[620px] text-[15px] leading-7 text-white/84 sm:text-[17px]">

--- a/apps/web/features/landing/components/faq-section.tsx
+++ b/apps/web/features/landing/components/faq-section.tsx
@@ -15,7 +15,7 @@ export function FAQSection() {
           <p className="text-[11px] font-semibold uppercase tracking-[0.16em] text-[#0a0d12]/40">
             {t.faq.label}
           </p>
-          <h2 className="mt-4 font-[family-name:var(--font-serif)] text-[2.6rem] leading-[1.05] tracking-[-0.03em] sm:text-[3.4rem] lg:text-[4.2rem]">
+          <h2 className="mt-4 landing-display text-[2.6rem] leading-[1.05] tracking-[-0.03em] sm:text-[3.4rem] lg:text-[4.2rem]">
             {t.faq.headline}
           </h2>
         </div>

--- a/apps/web/features/landing/components/features-section.tsx
+++ b/apps/web/features/landing/components/features-section.tsx
@@ -1048,7 +1048,7 @@ export function FeaturesSection() {
                 )}
               >
                 {/* Title + description */}
-                <h2 className="font-[family-name:var(--font-serif)] text-[2.6rem] leading-[1.05] tracking-[-0.03em] text-[#0a0d12] sm:text-[3.4rem] lg:text-[4.2rem]">
+                <h2 className="landing-display text-[2.6rem] leading-[1.05] tracking-[-0.03em] text-[#0a0d12] sm:text-[3.4rem] lg:text-[4.2rem]">
                   {feature.title}
                 </h2>
                 <p className="mt-5 max-w-[640px] text-[15px] leading-7 text-[#0a0d12]/60 sm:text-[16px]">

--- a/apps/web/features/landing/components/how-it-works-section.tsx
+++ b/apps/web/features/landing/components/how-it-works-section.tsx
@@ -17,7 +17,7 @@ export function HowItWorksSection() {
         <p className="text-[11px] font-semibold uppercase tracking-[0.16em] text-white/40">
           {t.howItWorks.label}
         </p>
-        <h2 className="mt-4 font-[family-name:var(--font-serif)] text-[2.6rem] leading-[1.05] tracking-[-0.03em] sm:text-[3.4rem] lg:text-[4.2rem]">
+        <h2 className="mt-4 landing-display text-[2.6rem] leading-[1.05] tracking-[-0.03em] sm:text-[3.4rem] lg:text-[4.2rem]">
           {t.howItWorks.headlineMain}
           <br />
           <span className="text-white/40">{t.howItWorks.headlineFaded}</span>

--- a/apps/web/features/landing/components/landing-footer.tsx
+++ b/apps/web/features/landing/components/landing-footer.tsx
@@ -136,7 +136,10 @@ export function LandingFooter() {
               className="size-[clamp(4rem,12vw,10rem)] shrink-0 text-white"
               noSpin
             />
-            <span className="font-[family-name:var(--font-serif)] text-[clamp(6rem,22vw,16rem)] font-normal leading-[0.82] tracking-[-0.04em] text-white lowercase">
+            {/* Plain `font-serif`, not `landing-display`: this is the Latin
+                wordmark and is never localized, so it must keep its tuned
+                leading/tracking instead of picking up the CJK reset. */}
+            <span className="font-serif text-[clamp(6rem,22vw,16rem)] font-normal leading-[0.82] tracking-[-0.04em] text-white lowercase">
               multica
             </span>
           </div>

--- a/apps/web/features/landing/components/landing-hero.tsx
+++ b/apps/web/features/landing/components/landing-hero.tsx
@@ -30,7 +30,7 @@ export function LandingHero() {
           className="mx-auto max-w-[1320px] px-4 pb-16 pt-28 sm:px-6 sm:pt-32 lg:px-8 lg:pb-24 lg:pt-36"
         >
           <div className="mx-auto max-w-[1120px] text-center">
-            <h1 className="font-[family-name:var(--font-serif)] text-[3.65rem] leading-[0.93] tracking-[-0.038em] text-white drop-shadow-[0_10px_34px_rgba(0,0,0,0.32)] sm:text-[4.85rem] lg:text-[6.4rem]">
+            <h1 className="landing-display text-[3.65rem] leading-[0.93] tracking-[-0.038em] text-white drop-shadow-[0_10px_34px_rgba(0,0,0,0.32)] sm:text-[4.85rem] lg:text-[6.4rem]">
               {t.hero.headlineLine1}
               <br />
               {t.hero.headlineLine2}

--- a/apps/web/features/landing/components/open-source-section.tsx
+++ b/apps/web/features/landing/components/open-source-section.tsx
@@ -16,7 +16,7 @@ export function OpenSourceSection() {
             <p className="text-[11px] font-semibold uppercase tracking-[0.16em] text-[#0a0d12]/40">
               {t.openSource.label}
             </p>
-            <h2 className="mt-4 font-[family-name:var(--font-serif)] text-[2.6rem] leading-[1.05] tracking-[-0.03em] sm:text-[3.4rem] lg:text-[4.2rem]">
+            <h2 className="mt-4 landing-display text-[2.6rem] leading-[1.05] tracking-[-0.03em] sm:text-[3.4rem] lg:text-[4.2rem]">
               {t.openSource.headlineLine1}
               <br />
               {t.openSource.headlineLine2}

--- a/packages/ui/styles/tokens.css
+++ b/packages/ui/styles/tokens.css
@@ -90,7 +90,13 @@
     --secondary: oklch(0.967 0.001 286.375);
     --secondary-foreground: oklch(0.21 0.006 285.885);
     --muted: oklch(0.967 0.001 286.375);
-    --muted-foreground: oklch(0.552 0.016 285.938);
+    /* Lightness is capped by the darkest light-mode surface this token has to
+       stay legible on, not by the page canvas. --sidebar-accent (0.935) is that
+       surface — sidebar nav labels are text-muted-foreground and switch to it on
+       hover — and WCAG AA 4.5:1 there needs L <= 0.523. 0.505 keeps a margin
+       (4.87:1 on sidebar-accent, 5.89:1 on white). Hue and chroma are unchanged
+       so the neutral ramp does not shift. */
+    --muted-foreground: oklch(0.505 0.016 285.938);
     --accent: oklch(0.967 0.001 286.375);
     --accent-foreground: oklch(0.21 0.006 285.885);
     --destructive: oklch(0.577 0.245 27.325);

--- a/packages/views/chat/components/task-status-pill.tsx
+++ b/packages/views/chat/components/task-status-pill.tsx
@@ -174,7 +174,9 @@ export function TaskStatusPill({
         <span className={cn(!stage.static && "animate-chat-text-shimmer")}>
           {stage.label}
         </span>
-        <span className="opacity-70"> · {formatElapsedSecs(elapsedSecs)}</span>
+        {/* Ticks every second; proportional figures would re-measure the pill on
+            every change (9s -> 10s) and shove the neighbouring controls sideways. */}
+        <span className="opacity-70 tabular-nums"> · {formatElapsedSecs(elapsedSecs)}</span>
       </span>
     </div>
   );

--- a/packages/views/common/task-transcript/agent-transcript-dialog.tsx
+++ b/packages/views/common/task-transcript/agent-transcript-dialog.tsx
@@ -747,7 +747,10 @@ export function AgentTranscriptDialog({
             )}
             {duration && (
               <>
-                <span>{t(($) => $.transcript.fact_took, { duration })}</span>
+                {/* Live tasks re-render this every second, and the fact row is a
+                    flex line — proportional figures would shift FactDot and every
+                    fact after it on each tick. */}
+                <span className="tabular-nums">{t(($) => $.transcript.fact_took, { duration })}</span>
                 <FactDot />
               </>
             )}

--- a/packages/views/editor/styles/prose.css
+++ b/packages/views/editor/styles/prose.css
@@ -36,6 +36,23 @@
   overflow-wrap: break-word;
 }
 
+/* Measure cap. The issue-detail column is max-w-4xl minus px-8 = 832px, which at
+   the 14px body size is ~120 characters per line — the eye loses its return path
+   well before that. 64ch lands near 72 Latin characters (and ~36 Han characters,
+   since `ch` resolves against Inter's digit width either way), inside the 45-75
+   range that reads comfortably.
+   Scoped to text-bearing blocks only: `pre`, `table`, images, `.math-node` and
+   node views keep the full column width, because a code block or a diagram
+   squeezed to reading width is worse than a long line. Table cells are excluded
+   by the direct-child selector — a `p` inside a `td` must follow the cell.
+   Applies to the editable and readonly renders alike; prose.css already treats
+   a wrap difference between the two as a bug (see the overflow-wrap note above).
+   The cap only binds on wide viewports; narrower columns were already inside it. */
+.rich-text-editor > :is(p, h1, h2, h3, blockquote),
+.rich-text-editor > :is(ul, ol) li {
+  max-width: 64ch;
+}
+
 /* Headings — compact but with clear visual hierarchy */
 .rich-text-editor h1 {
   font-size: 1.375rem;


### PR DESCRIPTION
Lands 5 of the 7 findings from the typography review in MUL-5431.

| Sub-issue | Fix |
| --- | --- |
| MUL-5446 | Landing CJK headlines get a real serif stack + CJK-safe metrics |
| MUL-5447 | Light-mode `--muted-foreground` raised to WCAG AA |
| MUL-5448 | `tabular-nums` on the three live elapsed counters |
| MUL-5449 | Desktop loads Geist Mono 500 (partial — see below) |
| MUL-5450 | Prose measure capped at 64ch |

## The one worth looking at closely

**MUL-5446 — the zh/ja/ko landing headlines were genuinely broken.** Three causes stacked on the same `<h1>`:

- `--font-serif-zh` was dead code. `Noto_Serif_SC` was loaded and attached to the landing wrapper, but nothing referenced the variable — and it was declared `subsets: ["latin"]`, so a Chinese serif was being loaded with only its Latin slice. It could not have supplied Han glyphs even wired up.
- With no CJK tail, `--font-serif` resolved to Instrument Serif (zero CJK coverage), so Han/Kana/Hangul dropped out of the family and landed on whatever the UA picks — next to Latin glyphs from a different typeface.
- `tracking-[-0.038em]` + `leading-[0.93]` are Latin display values. Han and Kana already fill their em box, so negative tracking crowds them and sub-1 leading collides lines — the hero renders two `<br />`-separated lines at up to `6.4rem`.

Fixed by composing `--font-serif` in `custom.css` from Instrument Serif plus a system Song/Mincho/Myeongjo tail — same structure `globals.css` already uses for `--font-sans`, so zero download. The 15 localized headings moved to a `.landing-display` class, which gives the CJK metric reset one hook. The footer wordmark deliberately keeps plain `font-serif`: it is Latin-only and must not pick up that reset.

## Deliberately not included

**`font-synthesis: none` (the second half of MUL-5449) is not in this PR.** I went to add it and found it is not a drop-in: neither web nor desktop loads an Inter *italic* face (`next/font` defaults to `style: ['normal']`; desktop imports `@fontsource-variable/inter` without `wght-italic.css`). So the ~15 italic UI labels — chat empty states, `model-picker`'s "Managed by runtime", dashboard/squad placeholders — plus every markdown `<em>` and blockquote are currently *synthesized* italic. Turning synthesis off without first loading a real italic face would silently flip all of them upright.

That is a font-payload decision, so I left it on MUL-5449 rather than making it here. The mono weight half — the actual web/desktop divergence — is fixed.

## Verification

- `pnpm typecheck` — 6/6 pass
- `pnpm lint` — 0 errors (16 pre-existing warnings in untouched files)
- `pnpm test` — desktop 47/47, web 20/20, docs 4/4, views 270/271, core 104/107

The 4 failing test files (3 in `packages/core`, 1 in `packages/views`) fail identically on a clean checkout of this branch point — verified by stashing. They are `localStorage.removeItem is not a function` in workspace/project/realtime mutation tests and one sidebar-resize test; unrelated to these changes, which touch no `packages/core` file.

Not verified: rendered appearance. These are visual changes and I had no running app or screenshots — the CJK headline stack in particular deserves a look on a real zh/ja/ko page, and the 64ch prose cap on a wide display.
