### PR TITLE
fix(ui): tabular figures on live task timers (MUL-5448)

### DIFF
--- a/apps/mobile/components/chat/status-pill.tsx
+++ b/apps/mobile/components/chat/status-pill.tsx
@@ -22,7 +22,7 @@
  * fallback. Differences are visual-only.
  */
 import { useEffect, useRef, useState } from "react";
-import { View } from "react-native";
+import { View, type TextStyle } from "react-native";
 import Animated, {
   cancelAnimation,
   useAnimatedStyle,
@@ -109,6 +109,16 @@ function pickStage(
   return { label: "Thinking" };
 }
 
+// Tabular figures for the 1Hz counter — proportional digits change the text
+// width on 9s → 10s, which reflows the whole row once a second.
+//
+// This CANNOT be `className="tabular-nums"`. Tailwind compiles that utility to
+// `font-variant-numeric`, and react-native-css-interop's property allow-list
+// only carries `font-variant-caps` — the declaration is dropped, so the class
+// is a silent no-op on RN. `fontVariant` is the working equivalent. Hoisted so
+// the once-a-second re-render doesn't hand Text a fresh style object.
+const TABULAR_NUMS: TextStyle = { fontVariant: ["tabular-nums"] };
+
 export function StatusPill({
   pendingTask,
   taskMessages = [],
@@ -145,7 +155,7 @@ export function StatusPill({
       {stage.static ? null : <BreathingDots />}
       <Text className="text-xs text-muted-foreground" numberOfLines={1}>
         {stage.label}
-        <Text className="text-xs text-muted-foreground/70">
+        <Text className="text-xs text-muted-foreground/70" style={TABULAR_NUMS}>
           {" · "}
           {formatElapsedSecs(elapsedSec)}
         </Text>

--- a/packages/views/chat/components/task-status-pill.tsx
+++ b/packages/views/chat/components/task-status-pill.tsx
@@ -174,7 +174,7 @@ export function TaskStatusPill({
         <span className={cn(!stage.static && "animate-chat-text-shimmer")}>
           {stage.label}
         </span>
-        <span className="opacity-70"> · {formatElapsedSecs(elapsedSecs)}</span>
+        <span className="opacity-70 tabular-nums"> · {formatElapsedSecs(elapsedSecs)}</span>
       </span>
     </div>
   );

--- a/packages/views/common/task-transcript/agent-transcript-dialog.tsx
+++ b/packages/views/common/task-transcript/agent-transcript-dialog.tsx
@@ -747,7 +747,7 @@ export function AgentTranscriptDialog({
             )}
             {duration && (
               <>
-                <span>{t(($) => $.transcript.fact_took, { duration })}</span>
+                <span className="tabular-nums">{t(($) => $.transcript.fact_took, { duration })}</span>
                 <FactDot />
               </>
             )}


### PR DESCRIPTION
Closes MUL-5448. From the MUL-5431 typography review, item 5.

## Problem

The elapsed counters refresh on a 1Hz `setInterval` but render with proportional figures. In Inter, `1` is narrow and `4` is wide, so the string width changes on `9s → 10s` and `1m 9s → 1m 10s` and the neighbouring elements shift. A task running for a minute jitters ~60 times.

Three sites were missing `tabular-nums`:

- `packages/views/chat/components/task-status-pill.tsx:177` — running-task pill; shares the row with the shimmer label and cancel button.
- `packages/views/common/task-transcript/agent-transcript-dialog.tsx:750` — the "took X" fact, followed by a `<FactDot />` and more facts, so the shift is more visible. Confirmed live: `duration` falls back to `elapsed`, which a `setInterval` updates every second while `isLive`.
- `apps/mobile/components/chat/status-pill.tsx:150` — the same pill on mobile.

## Mobile needed a different fix

The issue asked to confirm `tabular-nums` works under NativeWind. **It does not** — it is a silent no-op on React Native, verified two ways:

1. Compiling the class against the repo's own NativeWind preset emits
   ```css
   .tabular-nums { --tw-numeric-spacing: tabular-nums;
     font-variant-numeric: var(--tw-ordinal) … var(--tw-numeric-spacing) … }
   ```
2. `react-native-css-interop@0.2.4` (behind NativeWind 4.2.4) gates every declaration through a `validProperties` allow-list (`src/css-to-rn/parseDeclaration.ts:97`, checked at `isValid()` line 1611). The list contains `font-variant-caps` and **no** `font-variant-numeric`, so the declaration is dropped before it reaches RN.

So mobile uses RN's `fontVariant` style prop, hoisted to a module constant so the once-a-second re-render doesn't hand `Text` a fresh object. `className` + inline `style` on one element is an established pattern here (e.g. `apps/mobile/components/ui/otp-input.tsx:57`).

## Follow-up, not fixed here

The same dead-class problem affects three pre-existing mobile call sites, which look correct but do nothing at runtime:

- `apps/mobile/components/project/project-row.tsx:62`
- `apps/mobile/components/issue/reaction-bar.tsx:83`
- `apps/mobile/components/issue/activity-row.tsx:143`

Left alone deliberately — per `apps/mobile/CLAUDE.md` Lesson 7, unrelated files don't get rewritten just because they're adjacent. Worth a grouped follow-up.

## Verification

All run locally on this branch:

- `pnpm typecheck` — 6/6 tasks pass
- `pnpm lint` — 0 errors (16 pre-existing warnings, all in untouched files)
- `packages/views` tests for both changed components — 14/14 pass
- `apps/mobile` lint 0 errors, `pnpm test` 33/33 pass

Not verified: the on-device mobile render. The reasoning above is from the css-interop source and a real Tailwind compile, not a simulator run.
