### PR TITLE
feat(inbox): jump to latest unread item on double-click

### DIFF
--- a/packages/views/inbox/components/inbox-list.test.tsx
+++ b/packages/views/inbox/components/inbox-list.test.tsx
@@ -1,0 +1,136 @@
+import { forwardRef, useImperativeHandle } from "react";
+import { render, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { InboxItem } from "@multica/core/types";
+import { InboxList } from "./inbox-list";
+
+const scrollToIndex = vi.fn();
+
+vi.mock("react-virtuoso", () => ({
+  Virtuoso: forwardRef(function MockVirtuoso(
+    props: {
+      data: InboxItem[];
+      itemContent: (index: number, item: InboxItem) => React.ReactNode;
+    },
+    ref,
+  ) {
+    useImperativeHandle(ref, () => ({ scrollToIndex }));
+    return (
+      <div>
+        {props.data.map((item, index) => (
+          <div key={item.id}>{props.itemContent(index, item)}</div>
+        ))}
+      </div>
+    );
+  }),
+}));
+
+vi.mock("./inbox-list-item", () => ({
+  InboxListItem: ({ item }: { item: InboxItem }) => <div>{item.id}</div>,
+}));
+
+vi.mock("../../i18n", () => ({
+  useT: () => ({ t: () => "Inbox" }),
+}));
+
+function item(id: string): InboxItem {
+  return {
+    id,
+    workspace_id: "workspace-1",
+    recipient_type: "member",
+    recipient_id: "member-1",
+    actor_type: "agent",
+    actor_id: "agent-1",
+    type: "new_comment",
+    severity: "info",
+    issue_id: `issue-${id}`,
+    title: id,
+    body: null,
+    issue_status: null,
+    read: false,
+    archived: false,
+    created_at: "2026-06-15T08:00:00Z",
+    details: null,
+  };
+}
+
+describe("InboxList unread scrolling", () => {
+  beforeEach(() => {
+    scrollToIndex.mockReset();
+  });
+
+  it("smoothly aligns the requested unread item to the top", async () => {
+    const { container, rerender } = render(
+      <InboxList
+        items={[item("first"), item("target"), item("last")]}
+        view="inbox"
+        selectedKey=""
+        archivedCount={0}
+        onSelect={vi.fn()}
+        onAction={vi.fn()}
+        onOpenArchived={vi.fn()}
+        scrollRequest={null}
+      />,
+    );
+    const scrollContainer = container.firstElementChild as HTMLDivElement;
+    Object.defineProperties(scrollContainer, {
+      clientHeight: { configurable: true, value: 500 },
+      scrollHeight: { configurable: true, value: 1200 },
+    });
+    rerender(
+      <InboxList
+        items={[item("first"), item("target"), item("last")]}
+        view="inbox"
+        selectedKey=""
+        archivedCount={0}
+        onSelect={vi.fn()}
+        onAction={vi.fn()}
+        onOpenArchived={vi.fn()}
+        scrollRequest={{ itemId: "target", sequence: 1 }}
+      />,
+    );
+
+    await waitFor(() =>
+      expect(scrollToIndex).toHaveBeenCalledWith({
+        index: 1,
+        align: "start",
+        behavior: "smooth",
+      }),
+    );
+  });
+
+  it("does not reposition the item when the list fits in one viewport", async () => {
+    const { container, rerender } = render(
+      <InboxList
+        items={[item("first"), item("target")]}
+        view="inbox"
+        selectedKey=""
+        archivedCount={0}
+        onSelect={vi.fn()}
+        onAction={vi.fn()}
+        onOpenArchived={vi.fn()}
+        scrollRequest={null}
+      />,
+    );
+    const scrollContainer = container.firstElementChild as HTMLDivElement;
+    Object.defineProperties(scrollContainer, {
+      clientHeight: { configurable: true, value: 500 },
+      scrollHeight: { configurable: true, value: 500 },
+    });
+
+    rerender(
+      <InboxList
+        items={[item("first"), item("target")]}
+        view="inbox"
+        selectedKey=""
+        archivedCount={0}
+        onSelect={vi.fn()}
+        onAction={vi.fn()}
+        onOpenArchived={vi.fn()}
+        scrollRequest={{ itemId: "target", sequence: 1 }}
+      />,
+    );
+
+    await waitFor(() => expect(scrollToIndex).not.toHaveBeenCalled());
+  });
+});

--- a/packages/views/inbox/components/inbox-list.tsx
+++ b/packages/views/inbox/components/inbox-list.tsx
@@ -1,7 +1,7 @@
 "use client";
 
-import { useCallback, useMemo, useState } from "react";
-import { Virtuoso } from "react-virtuoso";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { Virtuoso, type VirtuosoHandle } from "react-virtuoso";
 import { Archive, ChevronRight, Inbox } from "lucide-react";
 import type { InboxItem } from "@multica/core/types";
 import type { InboxView } from "./inbox-view";
@@ -38,6 +38,7 @@ export function InboxList({
   onSelect,
   onAction,
   onOpenArchived,
+  scrollRequest,
 }: {
   items: InboxItem[];
   view: InboxView;
@@ -48,13 +49,29 @@ export function InboxList({
   onSelect: (item: InboxItem) => void;
   onAction: (id: string) => void;
   onOpenArchived: () => void;
+  scrollRequest: { itemId: string; sequence: number } | null;
 }) {
   const { t } = useT("inbox");
   // Virtuoso's `customScrollParent` wants the actual HTMLElement, not a ref.
   // A callback ref into state hands the element over once it mounts and
   // triggers the re-render that lets Virtuoso attach to it.
   const [scrollEl, setScrollEl] = useState<HTMLDivElement | null>(null);
+  const virtuosoRef = useRef<VirtuosoHandle>(null);
   const isArchivedView = view === "archived";
+  const scrollTargetIndex = scrollRequest
+    ? items.findIndex((item) => item.id === scrollRequest.itemId)
+    : -1;
+  const scrollRequestSequence = scrollRequest?.sequence;
+
+  useEffect(() => {
+    if (!scrollEl || scrollTargetIndex < 0) return;
+    if (scrollEl.scrollHeight <= scrollEl.clientHeight) return;
+    virtuosoRef.current?.scrollToIndex({
+      index: scrollTargetIndex,
+      align: "start",
+      behavior: "smooth",
+    });
+  }, [scrollEl, scrollTargetIndex, scrollRequestSequence]);
 
   // The entry into the archive sits below the last row and scrolls with the
   // list (same placement as chat's). Virtuoso mounts it via `components.Footer`,
@@ -124,6 +141,7 @@ export function InboxList({
       <div className="px-2 py-1">
         {scrollEl ? (
           <Virtuoso
+            ref={virtuosoRef}
             customScrollParent={scrollEl}
             data={items}
             computeItemKey={computeItemKey}

--- a/packages/views/inbox/components/inbox-page.test.tsx
+++ b/packages/views/inbox/components/inbox-page.test.tsx
@@ -1,6 +1,7 @@
 import { fireEvent, render, screen } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 import type { InboxItem } from "@multica/core/types";
+import { INBOX_SCROLL_TO_LATEST_UNREAD_EVENT } from "../inbox-scroll-event";
 import { InboxPage } from "./inbox-page";
 
 vi.mock("react-resizable-panels", () => ({
@@ -81,12 +82,18 @@ vi.mock("./inbox-list", () => ({
     items,
     view,
     onSelect,
+    scrollRequest,
   }: {
     items: InboxItem[];
     view: string;
     onSelect: (item: InboxItem) => void;
+    scrollRequest: { itemId: string; sequence: number } | null;
   }) => (
-    <div data-testid="list" data-view={view}>
+    <div
+      data-testid="list"
+      data-view={view}
+      data-scroll-target={scrollRequest?.itemId}
+    >
       {items.map((i) => (
         <button key={i.id} data-testid="row" onClick={() => onSelect(i)}>
           {i.id}
@@ -149,6 +156,53 @@ describe("InboxPage", () => {
 
     expect(screen.getByTestId("list").dataset.view).toBe("inbox");
     expect(screen.getByTestId("row").textContent).toBe("active-1");
+  });
+
+  it("targets the newest unread item when the inbox navigation is double-clicked", () => {
+    reset();
+    listData.active = [
+      item({ id: "newest-read", read: true }),
+      item({ id: "newest-unread", read: false }),
+      item({ id: "older-unread", read: false }),
+    ];
+
+    render(<InboxPage />);
+    fireEvent(window, new Event(INBOX_SCROLL_TO_LATEST_UNREAD_EVENT));
+
+    expect(screen.getByTestId("list")).toHaveAttribute(
+      "data-scroll-target",
+      "newest-unread",
+    );
+  });
+
+  it("does not request scrolling when every inbox item is read", () => {
+    reset();
+    listData.active = [
+      item({ id: "newest-read", read: true }),
+      item({ id: "older-read", read: true }),
+    ];
+
+    render(<InboxPage />);
+    fireEvent(window, new Event(INBOX_SCROLL_TO_LATEST_UNREAD_EVENT));
+
+    expect(screen.getByTestId("list")).not.toHaveAttribute("data-scroll-target");
+  });
+
+  it("returns from the archive before targeting an unread item", () => {
+    reset();
+    searchParams = new URLSearchParams("view=archived");
+    listData.active = [item({ id: "unread", read: false })];
+    listData.archived = [item({ id: "archived", archived: true })];
+
+    render(<InboxPage />);
+    fireEvent(window, new Event(INBOX_SCROLL_TO_LATEST_UNREAD_EVENT));
+
+    expect(screen.getByTestId("list")).toHaveAttribute("data-view", "inbox");
+    expect(screen.getByTestId("list")).toHaveAttribute(
+      "data-scroll-target",
+      "unread",
+    );
+    expect(replace).toHaveBeenCalledWith("/acme/inbox");
   });
 
   it("renders the archived list when the URL asks for it", () => {

--- a/packages/views/inbox/components/inbox-page.tsx
+++ b/packages/views/inbox/components/inbox-page.tsx
@@ -63,6 +63,12 @@ import { ARCHIVED_VIEW_PARAM, type InboxView } from "./inbox-view";
 import { useTypeLabels } from "./inbox-detail-label";
 import { getInboxDisplayTitle, isQuickCreateOutcome } from "./inbox-display";
 import { useT } from "../../i18n";
+import { INBOX_SCROLL_TO_LATEST_UNREAD_EVENT } from "../inbox-scroll-event";
+
+interface UnreadScrollRequest {
+  itemId: string;
+  sequence: number;
+}
 
 export function InboxPage() {
   const { t } = useT("inbox");
@@ -74,6 +80,8 @@ export function InboxPage() {
 
   const [selectedKey, setSelectedKeyState] = useState(() => urlIssue);
   const [view, setViewState] = useState<InboxView>(() => urlView);
+  const [unreadScrollRequest, setUnreadScrollRequest] =
+    useState<UnreadScrollRequest | null>(null);
 
   // Sync from URL when searchParams change (e.g. navigation)
   useEffect(() => {
@@ -147,6 +155,30 @@ export function InboxPage() {
   // Stable identity: InboxList memoizes the archive entry on this callback, so
   // an inline arrow here would rebuild (and remount) the entry every render.
   const openArchived = useCallback(() => setView("archived"), [setView]);
+
+  useEffect(() => {
+    const handleLatestUnreadScroll = () => {
+      const latestUnread = items.find((item) => item.read !== true);
+      if (!latestUnread) return;
+
+      if (isArchivedView) setView("inbox");
+      setUnreadScrollRequest((current) => ({
+        itemId: latestUnread.id,
+        sequence: (current?.sequence ?? 0) + 1,
+      }));
+    };
+
+    window.addEventListener(
+      INBOX_SCROLL_TO_LATEST_UNREAD_EVENT,
+      handleLatestUnreadScroll,
+    );
+    return () => {
+      window.removeEventListener(
+        INBOX_SCROLL_TO_LATEST_UNREAD_EVENT,
+        handleLatestUnreadScroll,
+      );
+    };
+  }, [isArchivedView, items, setView]);
 
   // Whether the list currently on screen has finished its first load. The
   // fallback and drain effects below both key on this, and getting it wrong in
@@ -416,6 +448,7 @@ export function InboxPage() {
       onSelect={handleSelect}
       onAction={isArchivedView ? handleUnarchive : handleArchive}
       onOpenArchived={openArchived}
+      scrollRequest={unreadScrollRequest}
     />
   );
 

--- a/packages/views/inbox/inbox-scroll-event.ts
+++ b/packages/views/inbox/inbox-scroll-event.ts
@@ -1,0 +1,6 @@
+export const INBOX_SCROLL_TO_LATEST_UNREAD_EVENT =
+  "multica:inbox-scroll-to-latest-unread";
+
+export function requestLatestUnreadInboxScroll(): void {
+  window.dispatchEvent(new Event(INBOX_SCROLL_TO_LATEST_UNREAD_EVENT));
+}

--- a/packages/views/layout/app-sidebar.test.tsx
+++ b/packages/views/layout/app-sidebar.test.tsx
@@ -1,6 +1,7 @@
-import { render, screen, waitFor } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { ApiError } from "@multica/core/api";
+import { INBOX_SCROLL_TO_LATEST_UNREAD_EVENT } from "../inbox/inbox-scroll-event";
 import { AppSidebar } from "./app-sidebar";
 
 const { appForeground, chatSessions, chatStore, detail, deletePin, inboxItems, navigation, pins, summary, workspaces } = vi.hoisted(() => ({
@@ -56,12 +57,19 @@ vi.mock("@multica/ui/components/ui/sidebar", () => ({
     children,
     isActive,
     render,
+    ...props
   }: {
     children: React.ReactNode;
     isActive?: boolean;
     render?: React.ReactElement<{ href?: string }>;
+    onDoubleClick?: React.MouseEventHandler<HTMLButtonElement>;
   }) => (
-    <button type="button" data-active={isActive ? "true" : undefined} data-href={render?.props.href}>
+    <button
+      type="button"
+      data-active={isActive ? "true" : undefined}
+      data-href={render?.props.href}
+      {...props}
+    >
       {children}
     </button>
   ),
@@ -186,6 +194,35 @@ vi.mock("@tanstack/react-query", async (importOriginal) => ({
   },
   useQueryClient: () => ({ fetchQuery: vi.fn(), invalidateQueries: vi.fn() }),
 }));
+
+describe("inbox navigation", () => {
+  beforeEach(() => {
+    navigation.current.pathname = "/acme/inbox";
+  });
+
+  it("requests the latest unread row when the active inbox item is double-clicked", () => {
+    const listener = vi.fn();
+    window.addEventListener(INBOX_SCROLL_TO_LATEST_UNREAD_EVENT, listener);
+
+    const { container } = render(<AppSidebar />);
+    fireEvent.doubleClick(container.querySelector('button[data-href="/acme/inbox"]')!);
+
+    expect(listener).toHaveBeenCalledTimes(1);
+    window.removeEventListener(INBOX_SCROLL_TO_LATEST_UNREAD_EVENT, listener);
+  });
+
+  it("does not request unread scrolling from another page", () => {
+    navigation.current.pathname = "/acme/issues";
+    const listener = vi.fn();
+    window.addEventListener(INBOX_SCROLL_TO_LATEST_UNREAD_EVENT, listener);
+
+    const { container } = render(<AppSidebar />);
+    fireEvent.doubleClick(container.querySelector('button[data-href="/acme/inbox"]')!);
+
+    expect(listener).not.toHaveBeenCalled();
+    window.removeEventListener(INBOX_SCROLL_TO_LATEST_UNREAD_EVENT, listener);
+  });
+});
 
 describe("PinRow", () => {
   beforeEach(() => {

--- a/packages/views/layout/app-sidebar.tsx
+++ b/packages/views/layout/app-sidebar.tsx
@@ -81,6 +81,7 @@ import {
 } from "@multica/core/shortcuts";
 import { ShortcutKeycaps } from "../common/shortcut-keycaps";
 import { useAppForeground } from "../common/use-app-foreground";
+import { requestLatestUnreadInboxScroll } from "../inbox/inbox-scroll-event";
 
 // Top-level nav items stay active when the user is on a child route
 // (e.g. "Projects" stays lit on /:slug/projects/:id). Pinned items keep
@@ -670,6 +671,11 @@ export function AppSidebar({ topSlot, searchSlot, headerClassName, headerStyle }
                       <SidebarMenuButton
                         isActive={isActive}
                         render={<AppLink href={href} />}
+                        onDoubleClick={
+                          item.key === "inbox" && isActive
+                            ? requestLatestUnreadInboxScroll
+                            : undefined
+                        }
                         className="text-muted-foreground hover:not-data-active:bg-sidebar-accent/70 data-active:bg-sidebar-accent data-active:text-sidebar-accent-foreground"
                       >
                         <Icon />


### PR DESCRIPTION
## Summary

- add a double-click shortcut on the active Inbox navigation item
- locate the newest unread item in the deduplicated, newest-first inbox list
- return from the archived view before locating the unread item
- smoothly align the unread row to the top when the list overflows
- keep the current layout unchanged when the inbox fits within one viewport

## Why

Unread notifications can be difficult to find in a long inbox. This gives users a quick way to jump to the newest unread item without changing the existing single-click navigation behavior or introducing new global state.

## User impact

Users can double-click the active Inbox item in the sidebar to bring the newest unread notification to the top of the list. If there are no unread notifications, or the full inbox already fits on screen, the list does not move.

## Validation

- [x] `pnpm --filter @multica/views test` — 273 files, 3209 tests passed
- [x] `pnpm --filter @multica/views typecheck`
- [x] ESLint passed for the changed files
- [x] manually verified with a long inbox and a remote backend

Closes #6102
