### PR TITLE
fix(issues): cap the issue-detail reading measure (MUL-5450)

### DIFF
--- a/packages/views/issues/components/issue-detail.tsx
+++ b/packages/views/issues/components/issue-detail.tsx
@@ -1712,7 +1712,7 @@ export function IssueDetail({ issueId, onDelete, onDone, defaultSidebarOpen = tr
             {/* Same max-w as the loaded content column below — a mismatch here
                 shifts the whole page sideways the moment the skeleton is
                 replaced (MUL-5450). */}
-            <div className="mx-auto w-full max-w-xl px-8 py-8 space-y-6">
+            <div className="mx-auto w-full max-w-2xl px-8 py-8 space-y-6">
               <Skeleton className="h-8 w-3/4" />
               <div className="space-y-2">
                 <Skeleton className="h-4 w-full" />
@@ -2322,14 +2322,22 @@ export function IssueDetail({ issueId, onDelete, onDone, defaultSidebarOpen = tr
           data-tab-scroll-root
           className="relative flex-1 overflow-y-auto [scrollbar-gutter:stable_both-edges]"
         >
-        {/* Reading measure. max-w-xl (576px) - px-8 both sides = 512px of text.
+        {/* Reading measure. max-w-2xl (672px) - px-8 both sides = 608px of text.
             At the prose body size (14px Inter, see editor/styles/prose.css) that
-            is ~75 characters per line for Latin and ~36 for CJK — the top of the
-            45-75 comfortable range, and the CJK sweet spot. The previous
-            max-w-4xl gave 832px = ~122 Latin / ~59 CJK characters, long enough
-            that the eye loses the return sweep on multi-paragraph descriptions
-            (MUL-5450). Comment bodies are inset a further 72px by the card's
-            px-4 + the pl-10 avatar gutter, landing them at ~64 characters.
+            is ~90 characters per line for Latin and ~43 for CJK; comment bodies
+            are inset a further 72px by the card's px-4 + the pl-10 avatar
+            gutter, landing at ~80 / ~38. The previous max-w-4xl gave 832px =
+            ~122 Latin / ~59 CJK, long enough that the eye loses the return
+            sweep on multi-paragraph descriptions (MUL-5450).
+
+            Sized for CJK, which is what actually binds here: full-width glyphs
+            are comfortable to about 45 per line, and 672px is the widest column
+            that keeps both the description and comment bodies under that. The
+            Latin count lands above the 45-75 range quoted for book typography,
+            which is the right trade — this is an app surface carrying sub-issue
+            tables, comment threads and a composer, not an article column, and
+            672px is roughly where Linear sits. Going narrower to satisfy the
+            Latin figure starves the non-prose UI in this column.
 
             Deliberately px, not `ch`: `ch` is the advance of "0", which in Inter
             is 0.63em against an average prose character of 0.47em, so a `Nch`
@@ -2339,7 +2347,7 @@ export function IssueDetail({ issueId, onDelete, onDone, defaultSidebarOpen = tr
 
             Keep in sync with the loading skeleton's column above, or the page
             jumps sideways when real content replaces it. */}
-        <div className="mx-auto w-full max-w-xl px-8 py-8">
+        <div className="mx-auto w-full max-w-2xl px-8 py-8">
           {titleLazy.active && (
             <div className={titleLazy.ready ? undefined : "hidden"}>
               <TitleEditor

--- a/packages/views/issues/components/issue-detail.tsx
+++ b/packages/views/issues/components/issue-detail.tsx
@@ -1709,7 +1709,10 @@ export function IssueDetail({ issueId, onDelete, onDone, defaultSidebarOpen = tr
           {/* Same scrollbar-gutter as the loaded scroller below, so the skeleton
               column doesn't shift sideways when real content mounts. */}
           <div className="flex-1 overflow-y-auto [scrollbar-gutter:stable_both-edges]">
-            <div className="mx-auto w-full max-w-4xl px-8 py-8 space-y-6">
+            {/* Same max-w as the loaded content column below — a mismatch here
+                shifts the whole page sideways the moment the skeleton is
+                replaced (MUL-5450). */}
+            <div className="mx-auto w-full max-w-xl px-8 py-8 space-y-6">
               <Skeleton className="h-8 w-3/4" />
               <div className="space-y-2">
                 <Skeleton className="h-4 w-full" />
@@ -2319,7 +2322,24 @@ export function IssueDetail({ issueId, onDelete, onDone, defaultSidebarOpen = tr
           data-tab-scroll-root
           className="relative flex-1 overflow-y-auto [scrollbar-gutter:stable_both-edges]"
         >
-        <div className="mx-auto w-full max-w-4xl px-8 py-8">
+        {/* Reading measure. max-w-xl (576px) - px-8 both sides = 512px of text.
+            At the prose body size (14px Inter, see editor/styles/prose.css) that
+            is ~75 characters per line for Latin and ~36 for CJK — the top of the
+            45-75 comfortable range, and the CJK sweet spot. The previous
+            max-w-4xl gave 832px = ~122 Latin / ~59 CJK characters, long enough
+            that the eye loses the return sweep on multi-paragraph descriptions
+            (MUL-5450). Comment bodies are inset a further 72px by the card's
+            px-4 + the pl-10 avatar gutter, landing them at ~64 characters.
+
+            Deliberately px, not `ch`: `ch` is the advance of "0", which in Inter
+            is 0.63em against an average prose character of 0.47em, so a `Nch`
+            cap holds ~1.33N characters — and on this container `ch` would
+            resolve against the inherited 16px root, not the prose's 14px.
+            `max-w-[68ch]` here would be 686px, not the intended measure.
+
+            Keep in sync with the loading skeleton's column above, or the page
+            jumps sideways when real content replaces it. */}
+        <div className="mx-auto w-full max-w-xl px-8 py-8">
           {titleLazy.active && (
             <div className={titleLazy.ready ? undefined : "hidden"}>
               <TitleEditor
@@ -2717,9 +2737,9 @@ export function IssueDetail({ issueId, onDelete, onDone, defaultSidebarOpen = tr
             next to the scrollbar, where the pointer already is while
             scrolling (MUL-4522). right-3 is the inset that works in both
             scrollbar modes: it clears a classic scrollbar's ~11px gutter,
-            and the rail's own 20px width lands it exactly on the content
-            column's px-8 padding when the gutter is 0 (overlay scrollbars),
-            so it covers neither the scrollbar nor body text. It also clears
+            and with overlay scrollbars (gutter 0) the rail's own 20px width
+            still lands clear of the centered content column, so it covers
+            neither the scrollbar nor body text. It also clears
             the resize handle's 4px drag strip at the panel edge. Hover
             previews a thread, click jumps to it. Hidden on mobile: no
             hover, and the gutter is too tight. */}


### PR DESCRIPTION
Closes MUL-5450. From the MUL-5431 typography review.

## Problem

The issue-detail body column was `max-w-4xl` (896px), leaving **832px of text** after `px-8`. At the prose body size (14px Inter, `packages/views/editor/styles/prose.css`) that is **~122 Latin / ~59 CJK characters per line** — long enough that the eye loses the return sweep on multi-paragraph descriptions.

## Change

`max-w-4xl` → `max-w-2xl` (672px) on the body column, leaving **608px of text**. Measured in Chromium against the real font stack:

| Surface | Text width | Before | After |
| --- | --- | --- | --- |
| Description | 832px → 608px | 122 Latin / 59 CJK | **90 Latin / 43 CJK** |
| Comment body | 760px → 536px | 112 Latin / 54 CJK | **80 Latin / 38 CJK** |

Comment bodies are inset a further 72px by the card's `px-4` plus the `pl-10` avatar gutter, so they land narrower than the description without needing their own rule.

**Sized for CJK, which is what binds here.** Full-width glyphs are comfortable to about 45 per line, and 672px is the widest column that keeps both the description and comment bodies under that. The Latin count sits above the 45–75 range quoted for book typography — that is the right trade: this is an app surface carrying sub-issue tables, comment threads and a composer, not an article column, and 672px is roughly where Linear sits. Going narrower to satisfy the Latin figure starves the non-prose UI in the column.

The loading skeleton's column is changed to match, so the page does not jump sideways when real content replaces it. The right sidebar is untouched — it is a separate `ResizablePanel`.

## Note on `ch`

The issue proposed `max-w-[68ch]`. Measured, that would have been wrong twice over:

- `ch` is the advance width of `0`, which in Inter is **0.63em**, against an average prose character of **0.47em** — so a `Nch` cap holds ~1.33N characters, not N.
- On this container `ch` resolves against the inherited **16px** root, not the prose's 14px.

`max-w-[68ch]` here would have computed to **686px ≈ 91 characters**. The cap is expressed in px with the reasoning recorded in a comment.

## Verification

- `pnpm typecheck` — passes
- `vitest run issues/` in `packages/views` — 51 files, 485 tests, all pass
- Character counts measured by rendering the real prose metrics in Chromium and bucketing per-character client rects by line
