### PR TITLE
fix(web): give landing CJK headlines a real serif and CJK metrics (MUL-5446)

### DIFF
--- a/apps/web/app/(landing)/layout.tsx
+++ b/apps/web/app/(landing)/layout.tsx
@@ -1,17 +1,17 @@
-import { Instrument_Serif, Noto_Serif_SC } from "next/font/google";
+import { Instrument_Serif } from "next/font/google";
 import { LocaleProvider } from "@/features/landing/i18n";
 import { getRequestLocale } from "@/lib/request-locale";
 
+// Instrument Serif is the landing display face and is Latin-only. The full
+// `--font-serif` stack (Instrument Serif + the per-locale CJK serif tail) is
+// composed in static CSS in app/custom.css, not here — same reasoning as
+// `--font-sans` in app/globals.css: the CJK tail must be overridable per
+// `<html lang>`, and a hashed next/font family can only be referenced from CSS
+// through its variable.
 const instrumentSerif = Instrument_Serif({
   subsets: ["latin"],
   weight: "400",
-  variable: "--font-serif",
-});
-
-const notoSerifSC = Noto_Serif_SC({
-  subsets: ["latin"],
-  weight: "400",
-  variable: "--font-serif-zh",
+  variable: "--font-instrument-serif",
 });
 
 const jsonLd = {
@@ -52,7 +52,7 @@ export default async function LandingLayout({
         type="application/ld+json"
         dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
       />
-      <div className={`${instrumentSerif.variable} ${notoSerifSC.variable} landing-light h-full overflow-x-hidden overflow-y-auto bg-white`}>
+      <div className={`${instrumentSerif.variable} landing-light h-full overflow-x-hidden overflow-y-auto bg-white`}>
         <LocaleProvider initialLocale={initialLocale}>{children}</LocaleProvider>
       </div>
     </>

--- a/apps/web/app/(landing)/usecases/[slug]/page.tsx
+++ b/apps/web/app/(landing)/usecases/[slug]/page.tsx
@@ -231,7 +231,7 @@ export default async function UseCasePage(props: { params: Promise<Params> }) {
           )}
         >
           <article>
-            <h1 className="font-[family-name:var(--font-serif)] text-[2.6rem] leading-[1.05] tracking-[-0.03em] sm:text-[3.4rem]">
+            <h1 className="landing-serif text-[2.6rem] leading-[1.05] tracking-[-0.03em] sm:text-[3.4rem]">
               {page.data.title}
             </h1>
             <div className="mt-10 text-[16px] leading-[1.85] text-[#0a0d12]/72 [&>:first-child]:mt-0 [&>p]:my-5 sm:text-[17px]">

--- a/apps/web/app/(landing)/usecases/page.tsx
+++ b/apps/web/app/(landing)/usecases/page.tsx
@@ -49,7 +49,7 @@ export default async function UseCasesIndexPage() {
         <LandingHeader variant="dark" />
         <section className="relative overflow-hidden bg-[#05070b] text-white">
           <div className="relative z-10 mx-auto max-w-[1120px] px-4 pb-20 pt-32 text-center sm:px-6 sm:pt-40 lg:px-8 lg:pb-24">
-            <h1 className="mx-auto max-w-[880px] font-[family-name:var(--font-serif)] text-[3rem] leading-[1.02] tracking-[-0.035em] drop-shadow-[0_10px_34px_rgba(0,0,0,0.32)] sm:text-[4rem] lg:text-[5rem]">
+            <h1 className="mx-auto max-w-[880px] landing-serif text-[3rem] leading-[1.02] tracking-[-0.035em] drop-shadow-[0_10px_34px_rgba(0,0,0,0.32)] sm:text-[4rem] lg:text-[5rem]">
               {text.indexTitle}
             </h1>
             <p className="mx-auto mt-6 max-w-[620px] text-[15px] leading-7 text-white/84 sm:text-[17px]">

--- a/apps/web/app/custom.css
+++ b/apps/web/app/custom.css
@@ -55,3 +55,80 @@
     --scrollbar-thumb-hover: oklch(0 0 0 / 18%);
     --scrollbar-track: transparent;
 }
+
+/* -----------------------------------------------------------------------------
+ * Landing editorial serif
+ *
+ * The landing tree swaps the app's `--font-serif` (Source Serif 4, set on <html>
+ * by app/layout.tsx) for Instrument Serif, loaded by app/(landing)/layout.tsx as
+ * `--font-instrument-serif`. The stack is composed here in static CSS rather
+ * than in next/font's `fallback` for the same reasons `--font-sans` is composed
+ * in app/globals.css: it has to be overridable per `<html lang>`, and it stays
+ * CSP-safe (no inline <style>). Keep the CJK ordering here in sync with the
+ * `--font-sans` chain in app/globals.css.
+ *
+ * Instrument Serif ships Latin only, so CJK headlines used to fall out of the
+ * stack entirely and land on the browser's default face — a sans, next to Latin
+ * set in a high-contrast display serif. The tail hands Han and Hangul to a
+ * platform Songti/Mincho/Myeongjo instead of shipping a multi-megabyte CJK
+ * webfont (an earlier `Noto_Serif_SC` next/font entry was never referenced by
+ * any rule and requested `subsets: ["latin"]`, so it downloaded no CJK glyphs).
+ *
+ * Default (en / zh / ko): Latin renders with Instrument Serif; Han falls through
+ * to the Chinese serifs, then Hangul to the Korean ones. Chinese MUST stay
+ * before Korean so zh users never get Korean Hanja glyph shapes (Hangul is a
+ * separate Unicode block, so ko users still get Korean fonts for Hangul). */
+.landing-light {
+    --font-serif: var(--font-instrument-serif), "Songti SC", "SimSun",
+        "Noto Serif CJK SC", "Nanum Myeongjo", "AppleMyungjo", "Batang",
+        "Noto Serif CJK KR", ui-serif, serif;
+}
+
+/* Japanese: Kanji are Han ideographs sharing the same Unicode block as Chinese,
+   and CSS font-fallback order is NOT affected by `<html lang>` — so the
+   Chinese-first default above would hand Japanese users Chinese glyph shapes for
+   shared ideographs. Promote a Mincho-first chain only for Japanese. Instrument
+   Serif still leads for Latin; zh/ko remain as a deep fallback. */
+html[lang|="ja"] .landing-light {
+    --font-serif: var(--font-instrument-serif), "Hiragino Mincho ProN",
+        "Yu Mincho", "MS Mincho", "Noto Serif CJK JP", "Songti SC", "SimSun",
+        "Noto Serif CJK SC", "Nanum Myeongjo", "AppleMyungjo", "Batang",
+        "Noto Serif CJK KR", ui-serif, serif;
+}
+
+/* Single hook for every landing surface set in the editorial serif. Declared
+   outside Tailwind's layers so the per-locale resets below outrank the inline
+   `tracking-*` / `leading-*` utilities they have to correct. */
+.landing-serif {
+    font-family: var(--font-serif);
+}
+
+/* The landing display sizes are tuned for Latin: negative tracking and sub-1
+   leading, down to `tracking-[-0.038em] leading-[0.93]` at 6.4rem on the hero.
+   Both are wrong for CJK — Han and Hangul already fill their em box, so negative
+   tracking jams the glyphs together and a 0.93 line-height collides the two
+   lines of a `<br />`-split headline. Reset them for CJK locales only; Latin
+   locales keep the original treatment untouched.
+
+   `[lang|="zh"]` is the BCP-47 language-range selector: it matches exactly `zh`
+   or `zh-<region>` (app/layout.tsx emits `zh-CN`, `ja-JP`, `ko-KR`), never an
+   unrelated subtag such as `zha`. Scoped to headings so the footer wordmark — a
+   Latin-only <span> rendering "multica" at up to 16rem — keeps its tuned
+   tracking on every locale. */
+html[lang|="zh"] :is(h1, h2).landing-serif,
+html[lang|="ja"] :is(h1, h2).landing-serif,
+html[lang|="ko"] :is(h1, h2).landing-serif {
+    letter-spacing: 0;
+    line-height: 1.25;
+}
+
+/* Korean only: Hangul is written with spaces between words, but the default
+   line-break rules treat every syllable as a break opportunity, so a wrapped
+   headline splits mid-word (모릅니 / 다). `keep-all` restores word-boundary
+   breaking; `break-word` is the escape hatch so a word wider than the column
+   still breaks instead of overflowing at narrow viewports. Chinese and Japanese
+   are written without spaces and break per character correctly by default. */
+html[lang|="ko"] :is(h1, h2).landing-serif {
+    word-break: keep-all;
+    overflow-wrap: break-word;
+}

--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -43,3 +43,7 @@ html[lang|="ja"] {
     "Microsoft YaHei", "Noto Sans CJK SC", "Apple SD Gothic Neo", "Malgun Gothic",
     "Noto Sans CJK KR", sans-serif;
 }
+
+/* The landing tree overrides `--font-serif` with its own Instrument Serif +
+   per-locale CJK chain, built on the same structure; see "Landing editorial
+   serif" in ./custom.css and keep the two CJK orderings in sync. */

--- a/apps/web/features/landing/components/about-page-client.tsx
+++ b/apps/web/features/landing/components/about-page-client.tsx
@@ -15,7 +15,7 @@ export function AboutPageClient() {
       <LandingHeader variant="light" />
       <main className="bg-white text-[#0a0d12]">
         <div className="mx-auto max-w-[720px] px-4 py-16 sm:px-6 sm:py-20 lg:py-24">
-          <h1 className="font-[family-name:var(--font-serif)] text-[2.6rem] leading-[1.05] tracking-[-0.03em] sm:text-[3.4rem]">
+          <h1 className="landing-serif text-[2.6rem] leading-[1.05] tracking-[-0.03em] sm:text-[3.4rem]">
             {t.about.title}
           </h1>
           <div className="mt-8 space-y-6 text-[15px] leading-[1.8] text-[#0a0d12]/70 sm:text-[16px]">

--- a/apps/web/features/landing/components/changelog-page-client.tsx
+++ b/apps/web/features/landing/components/changelog-page-client.tsx
@@ -260,7 +260,7 @@ export function ChangelogPageClient() {
             </aside>
 
             <div className="mx-auto min-w-0 max-w-[720px] lg:mx-0">
-              <h1 className="font-[family-name:var(--font-serif)] text-[2.6rem] leading-[1.05] tracking-[-0.03em] sm:text-[3.4rem]">
+              <h1 className="landing-serif text-[2.6rem] leading-[1.05] tracking-[-0.03em] sm:text-[3.4rem]">
                 {t.changelog.title}
               </h1>
               <p className="mt-4 text-[15px] leading-7 text-[#0a0d12]/60 sm:text-[16px]">

--- a/apps/web/features/landing/components/contact-sales-page-client.tsx
+++ b/apps/web/features/landing/components/contact-sales-page-client.tsx
@@ -163,7 +163,7 @@ export function ContactSalesPageClient() {
             <p className="text-[12px] font-semibold uppercase tracking-[0.12em] text-[#0a0d12]/45">
               {c.eyebrow}
             </p>
-            <h1 className="mt-2 font-[family-name:var(--font-serif)] text-[2.4rem] leading-[1.1] tracking-[-0.02em] sm:text-[2.8rem]">
+            <h1 className="mt-2 landing-serif text-[2.4rem] leading-[1.1] tracking-[-0.02em] sm:text-[2.8rem]">
               {c.title}
             </h1>
             <p className="mt-3 text-[14px] text-[#0a0d12]/60 sm:text-[15px]">
@@ -206,7 +206,7 @@ function SuccessCard({
 }) {
   return (
     <div className="rounded-[16px] border border-[#0a0d12]/8 bg-white p-8 shadow-[0_1px_2px_rgba(10,13,18,0.04)] sm:p-10">
-      <h2 className="font-[family-name:var(--font-serif)] text-[1.8rem] leading-[1.15] tracking-[-0.02em]">
+      <h2 className="landing-serif text-[1.8rem] leading-[1.15] tracking-[-0.02em]">
         {title}
       </h2>
       <p className="mt-3 text-[15px] leading-[1.7] text-[#0a0d12]/70">

--- a/apps/web/features/landing/components/download/all-platforms.tsx
+++ b/apps/web/features/landing/components/download/all-platforms.tsx
@@ -28,7 +28,7 @@ export function AllPlatforms({
       className="bg-white py-20 text-[#0a0d12] sm:py-24"
     >
       <div className="mx-auto max-w-[920px] px-4 sm:px-6 lg:px-8">
-        <h2 className="font-[family-name:var(--font-serif)] text-[2.2rem] leading-[1.1] tracking-[-0.03em] sm:text-[2.6rem]">
+        <h2 className="landing-serif text-[2.2rem] leading-[1.1] tracking-[-0.03em] sm:text-[2.6rem]">
           {d.title}
         </h2>
 

--- a/apps/web/features/landing/components/download/cli-section.tsx
+++ b/apps/web/features/landing/components/download/cli-section.tsx
@@ -21,7 +21,7 @@ export function CliSection() {
   return (
     <section id="cli" className="bg-[#f7f7f5] py-20 text-[#0a0d12] sm:py-24">
       <div className="mx-auto max-w-[820px] px-4 sm:px-6 lg:px-8">
-        <h2 className="font-[family-name:var(--font-serif)] text-[2.2rem] leading-[1.1] tracking-[-0.03em] sm:text-[2.6rem]">
+        <h2 className="landing-serif text-[2.2rem] leading-[1.1] tracking-[-0.03em] sm:text-[2.6rem]">
           {d.title}
         </h2>
         <p className="mt-4 max-w-[620px] text-[15px] leading-7 text-[#0a0d12]/72">

--- a/apps/web/features/landing/components/download/cloud-section.tsx
+++ b/apps/web/features/landing/components/download/cloud-section.tsx
@@ -19,7 +19,7 @@ export function CloudSection() {
   return (
     <section className="bg-white py-20 text-[#0a0d12] sm:py-24">
       <div className="mx-auto max-w-[720px] px-4 sm:px-6 lg:px-8">
-        <h2 className="font-[family-name:var(--font-serif)] text-[2.2rem] leading-[1.1] tracking-[-0.03em] sm:text-[2.6rem]">
+        <h2 className="landing-serif text-[2.2rem] leading-[1.1] tracking-[-0.03em] sm:text-[2.6rem]">
           {d.title}
         </h2>
         <p className="mt-4 max-w-[560px] text-[15px] leading-7 text-[#0a0d12]/72">

--- a/apps/web/features/landing/components/download/hero.tsx
+++ b/apps/web/features/landing/components/download/hero.tsx
@@ -32,7 +32,7 @@ export function DownloadHero({
     <section className="relative overflow-hidden bg-[#05070b] text-white">
       <BackdropGradient />
       <div className="relative z-10 mx-auto max-w-[1120px] px-4 pb-24 pt-32 text-center sm:px-6 sm:pt-40 lg:px-8 lg:pb-28">
-        <h1 className="mx-auto max-w-[880px] font-[family-name:var(--font-serif)] text-[3rem] leading-[1.02] tracking-[-0.035em] drop-shadow-[0_10px_34px_rgba(0,0,0,0.32)] sm:text-[4rem] lg:text-[5rem]">
+        <h1 className="mx-auto max-w-[880px] landing-serif text-[3rem] leading-[1.02] tracking-[-0.035em] drop-shadow-[0_10px_34px_rgba(0,0,0,0.32)] sm:text-[4rem] lg:text-[5rem]">
           {content.title}
         </h1>
         <p className="mx-auto mt-6 max-w-[620px] text-[15px] leading-7 text-white/84 sm:text-[17px]">

--- a/apps/web/features/landing/components/faq-section.tsx
+++ b/apps/web/features/landing/components/faq-section.tsx
@@ -15,7 +15,7 @@ export function FAQSection() {
           <p className="text-[11px] font-semibold uppercase tracking-[0.16em] text-[#0a0d12]/40">
             {t.faq.label}
           </p>
-          <h2 className="mt-4 font-[family-name:var(--font-serif)] text-[2.6rem] leading-[1.05] tracking-[-0.03em] sm:text-[3.4rem] lg:text-[4.2rem]">
+          <h2 className="mt-4 landing-serif text-[2.6rem] leading-[1.05] tracking-[-0.03em] sm:text-[3.4rem] lg:text-[4.2rem]">
             {t.faq.headline}
           </h2>
         </div>

--- a/apps/web/features/landing/components/features-section.tsx
+++ b/apps/web/features/landing/components/features-section.tsx
@@ -1048,7 +1048,7 @@ export function FeaturesSection() {
                 )}
               >
                 {/* Title + description */}
-                <h2 className="font-[family-name:var(--font-serif)] text-[2.6rem] leading-[1.05] tracking-[-0.03em] text-[#0a0d12] sm:text-[3.4rem] lg:text-[4.2rem]">
+                <h2 className="landing-serif text-[2.6rem] leading-[1.05] tracking-[-0.03em] text-[#0a0d12] sm:text-[3.4rem] lg:text-[4.2rem]">
                   {feature.title}
                 </h2>
                 <p className="mt-5 max-w-[640px] text-[15px] leading-7 text-[#0a0d12]/60 sm:text-[16px]">

--- a/apps/web/features/landing/components/how-it-works-section.tsx
+++ b/apps/web/features/landing/components/how-it-works-section.tsx
@@ -17,7 +17,7 @@ export function HowItWorksSection() {
         <p className="text-[11px] font-semibold uppercase tracking-[0.16em] text-white/40">
           {t.howItWorks.label}
         </p>
-        <h2 className="mt-4 font-[family-name:var(--font-serif)] text-[2.6rem] leading-[1.05] tracking-[-0.03em] sm:text-[3.4rem] lg:text-[4.2rem]">
+        <h2 className="mt-4 landing-serif text-[2.6rem] leading-[1.05] tracking-[-0.03em] sm:text-[3.4rem] lg:text-[4.2rem]">
           {t.howItWorks.headlineMain}
           <br />
           <span className="text-white/40">{t.howItWorks.headlineFaded}</span>

--- a/apps/web/features/landing/components/landing-footer.tsx
+++ b/apps/web/features/landing/components/landing-footer.tsx
@@ -136,7 +136,7 @@ export function LandingFooter() {
               className="size-[clamp(4rem,12vw,10rem)] shrink-0 text-white"
               noSpin
             />
-            <span className="font-[family-name:var(--font-serif)] text-[clamp(6rem,22vw,16rem)] font-normal leading-[0.82] tracking-[-0.04em] text-white lowercase">
+            <span className="landing-serif text-[clamp(6rem,22vw,16rem)] font-normal leading-[0.82] tracking-[-0.04em] text-white lowercase">
               multica
             </span>
           </div>

--- a/apps/web/features/landing/components/landing-hero.tsx
+++ b/apps/web/features/landing/components/landing-hero.tsx
@@ -30,7 +30,7 @@ export function LandingHero() {
           className="mx-auto max-w-[1320px] px-4 pb-16 pt-28 sm:px-6 sm:pt-32 lg:px-8 lg:pb-24 lg:pt-36"
         >
           <div className="mx-auto max-w-[1120px] text-center">
-            <h1 className="font-[family-name:var(--font-serif)] text-[3.65rem] leading-[0.93] tracking-[-0.038em] text-white drop-shadow-[0_10px_34px_rgba(0,0,0,0.32)] sm:text-[4.85rem] lg:text-[6.4rem]">
+            <h1 className="landing-serif text-[3.65rem] leading-[0.93] tracking-[-0.038em] text-white drop-shadow-[0_10px_34px_rgba(0,0,0,0.32)] sm:text-[4.85rem] lg:text-[6.4rem]">
               {t.hero.headlineLine1}
               <br />
               {t.hero.headlineLine2}

--- a/apps/web/features/landing/components/open-source-section.tsx
+++ b/apps/web/features/landing/components/open-source-section.tsx
@@ -16,7 +16,7 @@ export function OpenSourceSection() {
             <p className="text-[11px] font-semibold uppercase tracking-[0.16em] text-[#0a0d12]/40">
               {t.openSource.label}
             </p>
-            <h2 className="mt-4 font-[family-name:var(--font-serif)] text-[2.6rem] leading-[1.05] tracking-[-0.03em] sm:text-[3.4rem] lg:text-[4.2rem]">
+            <h2 className="mt-4 landing-serif text-[2.6rem] leading-[1.05] tracking-[-0.03em] sm:text-[3.4rem] lg:text-[4.2rem]">
               {t.openSource.headlineLine1}
               <br />
               {t.openSource.headlineLine2}


### PR DESCRIPTION
Fixes MUL-5446 (item 4 of the MUL-5431 typography review).

## Problem

Three stacked issues on the landing page's CJK headlines:

1. `apps/web/app/(landing)/layout.tsx` loaded `Noto_Serif_SC` into `--font-serif-zh`, which **no rule anywhere referenced** — and it asked for `subsets: ["latin"]`, so it carried no CJK glyphs even if something had. A font download for nothing.
2. `--font-serif` was Instrument Serif, which is Latin-only. zh/ja/ko headlines fell out of the stack onto the browser default (a sans), sitting next to Latin set in a high-contrast display serif.
3. The Latin display metrics — `tracking-[-0.038em] leading-[0.93]` at up to `6.4rem` — were applied to ideographs, which already fill their em box. Negative tracking crowded them and 0.93 leading collided the two lines of the `<br />`-split hero headline.

## Fix

**Font stack.** Removed the dead `Noto_Serif_SC`. Instrument Serif now loads as `--font-instrument-serif`, and `--font-serif` is composed for the landing tree in static CSS with a per-`<html lang>` CJK tail — the same structure as the `--font-sans` chain in `globals.css`, including the reasoning that Chinese must precede Korean by default and that `ja` needs a Mincho-first chain so Kanji don't get Chinese glyph shapes. Platform Songti / Mincho / Myeongjo faces rather than a multi-megabyte CJK webfont, matching how `--font-sans` already handles CJK.

**Metrics.** The 16 landing surfaces that inlined `font-[family-name:var(--font-serif)]` now share a `.landing-serif` hook, which gives the per-locale reset a precise target: under `html[lang|="zh"|"ja"|"ko"]`, headings get `letter-spacing: 0` and `line-height: 1.25`. Korean additionally gets `word-break: keep-all` (with `overflow-wrap: break-word` as the narrow-viewport escape hatch) so wrapped Hangul breaks at word boundaries instead of mid-word.

Scoped to `h1`/`h2` so the Latin-only footer wordmark keeps its tuned `-0.04em` tracking on every locale.

## Verification

Measured in Chromium against `next dev`, four locale cookies, 1440px and 390px:

| locale | `<html lang>` | letter-spacing | line-height | word-break | overflow-x |
| --- | --- | --- | --- | --- | --- |
| en | `en` | -3.89px *(unchanged)* | 95.23px *(unchanged)* | normal | none |
| zh | `zh-CN` | 0 | 128px | normal | none |
| ja | `ja-JP` | 0 | 128px | normal | none |
| ko | `ko-KR` | 0 | 128px | keep-all | none |

- Resolved families: zh → Songti SC, ja → Hiragino Mincho ProN, ko → Nanum Myeongjo.
- Footer wordmark stays at `-10.24px` tracking / `209.92px` leading in all four locales.
- **The English hero screenshot is byte-identical (same SHA-256) before and after the change.**
- `tsc --noEmit` and `eslint` clean for `apps/web`.

Before/after screenshots are attached to the issue.
