### PR TITLE
fix(agent): deny CodeBuddy's interactive plan-mode tools in headless runs (MUL-5383)

### DIFF
--- a/server/pkg/agent/codebuddy.go
+++ b/server/pkg/agent/codebuddy.go
@@ -44,7 +44,22 @@ func buildCodebuddyArgs(opts ExecOptions, logger *slog.Logger) []string {
 		"--verbose",
 		"--strict-mcp-config",
 		"--permission-mode", "bypassPermissions",
-		"--disallowedTools", "AskUserQuestion",
+		// CodeBuddy's interactive tools have no UI to render in under the
+		// daemon's headless stream-json transport. AskUserQuestion and
+		// ExitPlanMode are both exempted from CodeBuddy's permission-mode
+		// finalization, so --permission-mode bypassPermissions does NOT
+		// auto-approve them — they always reach the permission bridge and
+		// stall the turn waiting for a confirmation nobody can give
+		// (GitHub #6012). EnterPlanMode is denied alongside them: leaving it
+		// enabled would let the model enter a plan mode it then has no tool
+		// to leave. Plan-shaped work still happens — the plan is written as
+		// ordinary assistant output instead of behind an approval gate.
+		//
+		// Pass one value per tool: --disallowedTools is variadic and
+		// CodeBuddy compares each entry against the tool name exactly
+		// (PermissionUtils.matchPermissionRules), so a comma-joined string
+		// would match nothing despite what the CLI's own help text claims.
+		"--disallowedTools", "AskUserQuestion", "EnterPlanMode", "ExitPlanMode",
 	}
 	if opts.Model != "" {
 		args = append(args, "--model", opts.Model)
@@ -404,6 +419,11 @@ func (b *codebuddyBackend) handleControlRequest(msg codebuddySDKMessage, stdin i
 			"subtype":    "success",
 			"request_id": msg.RequestID,
 			"response": map[string]any{
+				// CodeBuddy's SdkPermissionClient reads `allowed` and treats a
+				// missing key as a denial; `behavior` is Claude Code's spelling,
+				// which the fork still honours on its other permission paths.
+				// Send both so an approval is never read as a silent reject.
+				"allowed":      true,
 				"behavior":     "allow",
 				"updatedInput": inputMap,
 			},

--- a/server/pkg/agent/codebuddy_test.go
+++ b/server/pkg/agent/codebuddy_test.go
@@ -1,6 +1,7 @@
 package agent
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"log/slog"
@@ -27,7 +28,7 @@ func TestBuildCodebuddyArgs_Basic(t *testing.T) {
 		"--verbose",
 		"--strict-mcp-config",
 		"--permission-mode", "bypassPermissions",
-		"--disallowedTools", "AskUserQuestion",
+		"--disallowedTools", "AskUserQuestion", "EnterPlanMode", "ExitPlanMode",
 		"--model", "claude-sonnet-4-20250514",
 		"--max-turns", "25",
 		"--append-system-prompt", "You are an agent.",
@@ -39,6 +40,37 @@ func TestBuildCodebuddyArgs_Basic(t *testing.T) {
 	for i, want := range expected {
 		if args[i] != want {
 			t.Fatalf("args[%d] = %q, want %q\nfull args: %v", i, args[i], want, args)
+		}
+	}
+}
+
+func TestBuildCodebuddyArgs_DisallowsInteractiveTools(t *testing.T) {
+	t.Parallel()
+
+	// The daemon runs CodeBuddy headless, so every tool that waits on a human
+	// confirmation stalls the turn instead of ending it (GitHub #6012).
+	// CodeBuddy matches each --disallowedTools entry against the tool name
+	// exactly, so each tool must arrive as its own argv value.
+	args := buildCodebuddyArgs(ExecOptions{}, slog.Default())
+
+	idx := -1
+	for i, a := range args {
+		if a == "--disallowedTools" {
+			idx = i
+			break
+		}
+	}
+	if idx == -1 {
+		t.Fatalf("expected --disallowedTools in args: %v", args)
+	}
+
+	for offset, want := range []string{"AskUserQuestion", "EnterPlanMode", "ExitPlanMode"} {
+		got := ""
+		if idx+1+offset < len(args) {
+			got = args[idx+1+offset]
+		}
+		if got != want {
+			t.Fatalf("disallowed tool %d = %q, want %q\nfull args: %v", offset, got, want, args)
 		}
 	}
 }
@@ -472,5 +504,64 @@ func TestCodebuddyHandleUserToolResult(t *testing.T) {
 		}
 	default:
 		t.Fatal("expected message on channel")
+	}
+}
+
+func TestCodebuddyHandleControlRequestApprovesInCodebuddyShape(t *testing.T) {
+	t.Parallel()
+
+	b := &codebuddyBackend{cfg: Config{Logger: slog.Default()}}
+
+	var written bytes.Buffer
+
+	msg := codebuddySDKMessage{
+		Type:      "control_request",
+		RequestID: "perm_1730000000000_1",
+		Request: mustMarshal(t, codebuddyControlRequestPayload{
+			Subtype:  "can_use_tool",
+			ToolName: "Bash",
+			Input:    mustMarshal(t, map[string]any{"command": "ls"}),
+		}),
+	}
+
+	b.handleControlRequest(msg, &written)
+
+	var resp map[string]any
+	if err := json.Unmarshal(bytes.TrimSpace(written.Bytes()), &resp); err != nil {
+		t.Fatalf("unmarshal response: %v", err)
+	}
+
+	if resp["type"] != "control_response" {
+		t.Fatalf("expected type control_response, got %v", resp["type"])
+	}
+	respInner, ok := resp["response"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected response object, got %v", resp["response"])
+	}
+	if respInner["subtype"] != "success" {
+		t.Fatalf("expected subtype success, got %v", respInner["subtype"])
+	}
+	if respInner["request_id"] != "perm_1730000000000_1" {
+		t.Fatalf("expected the request_id to be echoed back, got %v", respInner["request_id"])
+	}
+
+	innerResp, ok := respInner["response"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected inner response object, got %v", respInner["response"])
+	}
+	// CodeBuddy reads `allowed`; a missing key is read as a denial, which
+	// leaves the CLI waiting on a confirmation the daemon can never deliver.
+	if innerResp["allowed"] != true {
+		t.Fatalf("expected allowed=true, got %v", innerResp["allowed"])
+	}
+	if innerResp["behavior"] != "allow" {
+		t.Fatalf("expected behavior allow, got %v", innerResp["behavior"])
+	}
+	updatedInput, ok := innerResp["updatedInput"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected updatedInput object, got %v", innerResp["updatedInput"])
+	}
+	if updatedInput["command"] != "ls" {
+		t.Fatalf("expected the original tool input to be preserved, got %v", updatedInput["command"])
 	}
 }


### PR DESCRIPTION
Fixes #6012 · MUL-5383

## Problem

When a CodeBuddy agent finished planning, the CLI called `ExitPlanMode` to ask the user to confirm. Multica never answered, the task stayed in-flight, and the operator had to kill it by hand.

## Root cause

Verified against `@tencent-ai/codebuddy-code@2.128.1`:

1. `AskUserQuestion` and `ExitPlanMode` are explicitly exempted from CodeBuddy's permission-mode finalization — `--permission-mode bypassPermissions` does **not** auto-approve them. They always resolve to `ask`.
2. The daemon's `bypassPermissions` fast-path also misses `ExitPlanMode`: entering plan mode switches the session's permission mode to `Plan`, so by the time the model exits, the mode is no longer `BypassPermissions`.
3. The request therefore reaches the SDK permission bridge, which sends a `can_use_tool` control request and waits on a deferred with **no timeout**.
4. The daemon does reply, but in Claude Code's shape (`{"behavior": "allow"}`). CodeBuddy's `SdkPermissionClient.handleResponse` reads `response.allowed` and defaults a missing key to `false` — so our "auto-approval" was read as a denial.

Net effect: an approval-gated tool with no way to be approved, and a run that only ends when the 2 h tool watchdog fires.

## Fix

- Deny the interactive plan-mode tools in `buildCodebuddyArgs`, alongside the `AskUserQuestion` we already deny:
  `--disallowedTools AskUserQuestion EnterPlanMode ExitPlanMode`
  `EnterPlanMode` goes with `ExitPlanMode` — denying only the exit would let the model enter a mode it has no tool to leave. Each tool is a separate argv value on purpose: CodeBuddy compares each `disallowedTools` entry against the tool name exactly (`PermissionUtils.matchPermissionRules`) and does **not** split on commas, despite what its `--help` text says. A comma-joined string would silently match nothing.
- Send `"allowed": true` alongside `"behavior": "allow"` on the control response, so an approval that does reach the bridge is not read as a denial.

This deliberately does not auto-approve `ExitPlanMode`. Auto-approving would silently fake a plan confirmation the user never gave. Removing the tool keeps planning working — the plan is written as ordinary assistant output instead of behind an approval gate no one can open.

## Verification

- `go test ./pkg/agent/ -count=1` — pass (full package, 123 s).
- New `TestBuildCodebuddyArgs_DisallowsInteractiveTools` pins all three tools as separate argv values.
- New `TestCodebuddyHandleControlRequestApprovesInCodebuddyShape` pins `allowed: true`, the echoed `request_id`, and input preservation.
- `gofmt` / `go vet` clean on the changed files.

Not verified against a live CodeBuddy account — no credentials in this environment. The behaviour above was read directly from the shipped CLI bundle rather than inferred.
