### PR TITLE
test(channel): fix flaky TestRouter_Ingested_InTxMark_FinalizeNone media assertions

### DIFF
--- a/server/internal/integrations/channel/engine/router_test.go
+++ b/server/internal/integrations/channel/engine/router_test.go
@@ -538,11 +538,17 @@ func TestRouter_Ingested_InTxMark_FinalizeNone(t *testing.T) {
 	if !waitFor(time.Second, func() bool { return h.typing.calls() == 1 }) {
 		t.Fatalf("ingest must show the typing indicator")
 	}
-	if h.media.calls() != 1 {
+	// Media resolution runs on its own goroutine (r.mediaWg), and the binding
+	// happens only after it returns, so both of these are downstream of work
+	// that Handle does not wait for. Reading them bare raced with that
+	// goroutine and made this test fail intermittently on loaded CI runners
+	// with "resolved media 0 times, want 1". The waits below match what the
+	// sibling media assertions in this file already do.
+	if !waitFor(time.Second, func() bool { return h.media.calls() == 1 }) {
 		t.Fatalf("ingested message resolved media %d times, want 1", h.media.calls())
 	}
-	if refs := h.binder.boundMedia().MediaRefs; len(refs) != 1 {
-		t.Fatalf("resolved media not bound after append: %+v", refs)
+	if !waitFor(time.Second, func() bool { return len(h.binder.boundMedia().MediaRefs) == 1 }) {
+		t.Fatalf("resolved media not bound after append: %+v", h.binder.boundMedia().MediaRefs)
 	}
 }
 


### PR DESCRIPTION
`TestRouter_Ingested_InTxMark_FinalizeNone` fails intermittently on CI with:

```
router_test.go:542: ingested message resolved media 0 times, want 1
```

Seen on #6083, whose diff did not touch this package. Re-running the identical commit with no code change went green — same code, two outcomes.

## Cause

The test asserts on two pieces of state produced by the **async media goroutine** (spawned in `router.go`, tracked by `r.mediaWg`), without waiting for it:

```go
if h.media.calls() != 1 { ... }                              // set inside ResolveMedia
if refs := h.binder.boundMedia().MediaRefs; len(refs) != 1 { ... }  // set only AFTER it returns
```

`Router.Handle` returns before either has happened, so both are a race against goroutine scheduling. The `waitFor` calls just above them cover different fakes (`tasks`, `typing`), so they don't happen to synchronise these.

The accessors are mutex-guarded, so this is an ordering race, not a data race — `-race` stays clean either way, which is why it only shows up as an intermittent assertion failure under load.

The sibling test in the same file already does this correctly for the same counter:

```go
// TestRouter_AppendErrorReleasesClaimAndAllowsMediaRetry
if !waitFor(time.Second, func() bool { return h.media.calls() == 1 }) { ... }
```

## Reproduction

Deterministic, using the harness's existing `release` channel to hold `ResolveMedia` open for 80ms:

```
OLD bare read immediately after Handle: MediaRefs=0 (test asserts ==1)
  -> would FAIL this run: the flake
NEW waitFor read: satisfied=true
```

(scratch test, not included in the diff)

## Fix

Wrap both assertions in `waitFor`, matching the sibling test. The assertions themselves are unchanged — same conditions, same failure messages, just synchronised.

## Verification

Against a freshly migrated database:

- `go test ./internal/integrations/channel/engine -count=3` — pass
- `-run TestRouter_Ingested_InTxMark_FinalizeNone -count=100 -cpu=1` — pass (`-cpu=1` to starve the goroutine, the condition that triggers it on CI)
- `-run TestRouter_ -race -count=5` — pass

Test-only change; no production code touched.
