### PR TITLE
fix(daemon): model list should enumerate the custom runtime profile's binary (MUL-5471)

### DIFF
--- a/server/internal/daemon/daemon.go
+++ b/server/internal/daemon/daemon.go
@@ -189,6 +189,11 @@ var (
 	detectAgentVersion   = agent.DetectVersion
 	checkAgentMinVersion = agent.CheckMinVersion
 
+	// listModels is an indirection over agent.ListModels so model-discovery
+	// tests can assert which executable path the daemon enumerates without
+	// shelling out to a real CLI. Mirrors the detectAgentVersion hook above.
+	listModels = agent.ListModels
+
 	// lookPath is an indirection over exec.LookPath so registration tests can
 	// resolve custom runtime-profile commands without manipulating the
 	// process PATH. Mirrors the detectAgentVersion hook above.
@@ -2910,18 +2915,31 @@ func (d *Daemon) handlePendingWorkHint(runtimeID, kind string) {
 func (d *Daemon) handleModelList(ctx context.Context, rt Runtime, requestID string) {
 	d.logger.Info("model list requested", "runtime_id", rt.ID, "request_id", requestID, "provider", rt.Provider)
 
-	entry, ok := d.agents()[rt.Provider]
-	if !ok {
+	// Discovery must enumerate the binary this runtime will actually execute,
+	// otherwise the picker advertises models the launched CLI may not accept
+	// (MUL-5471). Mirror runTask's resolution order: a custom runtime profile
+	// (MUL-3284) owns the executable path, and such a runtime can live on a
+	// host with NO built-in agent of the same provider installed — so a custom
+	// runtime must never fail on the built-in lookup.
+	var execPath string
+	if customSpec, isCustom := d.customProfileLaunchForRuntime(rt.ID); isCustom {
+		execPath = customSpec.path
+		d.logger.Info("model list uses custom runtime profile command",
+			"runtime_id", rt.ID, "provider", rt.Provider, "command_path", execPath)
+	} else if entry, ok := d.agents()[rt.Provider]; ok {
+		// Built-in provider: self-heal a pinned executable path an in-place
+		// upgrade deleted (MUL-4486).
+		entry, _ = d.resolveAgentEntry(ctx, rt.Provider, entry)
+		execPath = entry.Path
+	} else {
 		d.reportModelListResult(ctx, rt, requestID, map[string]any{
 			"status": "failed",
 			"error":  fmt.Sprintf("no agent configured for provider %q", rt.Provider),
 		})
 		return
 	}
-	// Self-heal a pinned executable path an in-place upgrade deleted (MUL-4486).
-	entry, _ = d.resolveAgentEntry(ctx, rt.Provider, entry)
 
-	models, err := agent.ListModels(ctx, rt.Provider, entry.Path)
+	models, err := listModels(ctx, rt.Provider, execPath)
 	if err != nil {
 		d.reportModelListResult(ctx, rt, requestID, map[string]any{
 			"status": "failed",

--- a/server/internal/daemon/model_list_binary_test.go
+++ b/server/internal/daemon/model_list_binary_test.go
@@ -1,0 +1,192 @@
+package daemon
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+
+	"github.com/multica-ai/multica/server/pkg/agent"
+)
+
+// modelListFixture stands up a Daemon whose model-list reports are captured and
+// whose agent.ListModels call is stubbed, so a test can assert exactly which
+// executable path model discovery enumerated.
+type modelListFixture struct {
+	daemon *Daemon
+
+	mu             sync.Mutex
+	listedProvider string
+	listedPath     string
+	listCalls      int
+	report         map[string]any
+}
+
+func newModelListFixture(t *testing.T) *modelListFixture {
+	t.Helper()
+	withFastLocalSkillReportBackoffs(t)
+
+	fx := &modelListFixture{}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var body map[string]any
+		_ = json.NewDecoder(r.Body).Decode(&body)
+		fx.mu.Lock()
+		fx.report = body
+		fx.mu.Unlock()
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"status":"ok"}`))
+	}))
+	t.Cleanup(srv.Close)
+
+	d := freshDaemon(srv.URL)
+	d.profileLaunchSpecs = make(map[string]profileLaunchSpec)
+	fx.daemon = d
+
+	orig := listModels
+	listModels = func(_ context.Context, provider, execPath string) ([]agent.Model, error) {
+		fx.mu.Lock()
+		fx.listedProvider = provider
+		fx.listedPath = execPath
+		fx.listCalls++
+		fx.mu.Unlock()
+		return []agent.Model{{ID: "m-1", Label: "M 1"}}, nil
+	}
+	t.Cleanup(func() { listModels = orig })
+
+	return fx
+}
+
+// addCustomRuntime registers a custom-profile runtime the way
+// registerRuntimesForWorkspace would: a runtime row carrying profile_id plus
+// the profile's resolved executable path.
+func (fx *modelListFixture) addCustomRuntime(runtimeID, provider, profileID, path string) Runtime {
+	rt := Runtime{ID: runtimeID, Provider: provider, ProfileID: profileID, Status: "online"}
+	fx.daemon.mu.Lock()
+	fx.daemon.runtimeIndex[runtimeID] = rt
+	fx.daemon.mu.Unlock()
+	fx.daemon.recordProfileLaunch(profileID, path, "1.2.3", nil)
+	return rt
+}
+
+func (fx *modelListFixture) listed() (provider, path string, calls int) {
+	fx.mu.Lock()
+	defer fx.mu.Unlock()
+	return fx.listedProvider, fx.listedPath, fx.listCalls
+}
+
+func (fx *modelListFixture) reported() map[string]any {
+	fx.mu.Lock()
+	defer fx.mu.Unlock()
+	return fx.report
+}
+
+// TestHandleModelList_CustomProfileEnumeratesProfileBinary pins MUL-5471: a
+// custom runtime profile executes its own command_name, so the model picker
+// must enumerate that binary — not the built-in provider binary that happens to
+// share the protocol family on this host.
+func TestHandleModelList_CustomProfileEnumeratesProfileBinary(t *testing.T) {
+	fx := newModelListFixture(t)
+	// Built-in codex is installed too, at a different (newer) path. Before the
+	// fix this path is what discovery enumerated.
+	fx.daemon.cfg.Agents = map[string]AgentEntry{
+		"codex": {Path: "/usr/local/bin/codex", Command: "codex"},
+	}
+	rt := fx.addCustomRuntime("rt-1", "codex", "prof-1", "/opt/bin/company-codex")
+
+	fx.daemon.handleModelList(context.Background(), rt, "req-1")
+
+	provider, path, calls := fx.listed()
+	if calls != 1 {
+		t.Fatalf("ListModels calls = %d, want 1", calls)
+	}
+	if provider != "codex" {
+		t.Errorf("ListModels provider = %q, want codex", provider)
+	}
+	if path != "/opt/bin/company-codex" {
+		t.Errorf("ListModels executable path = %q, want the profile command /opt/bin/company-codex", path)
+	}
+	if got := fx.reported()["status"]; got != "completed" {
+		t.Errorf("reported status = %v, want completed", got)
+	}
+}
+
+// TestHandleModelList_CustomProfileWithoutBuiltInProvider pins the harsher
+// variant of MUL-5471: on a host with no built-in agent of the profile's
+// protocol family, discovery used to fail with "no agent configured for
+// provider" even though the profile's binary exists and is what would run.
+func TestHandleModelList_CustomProfileWithoutBuiltInProvider(t *testing.T) {
+	fx := newModelListFixture(t)
+	// Custom-only host: no built-in agents at all.
+	fx.daemon.cfg.Agents = map[string]AgentEntry{}
+	rt := fx.addCustomRuntime("rt-2", "codex", "prof-2", "/opt/bin/company-codex")
+
+	fx.daemon.handleModelList(context.Background(), rt, "req-2")
+
+	_, path, calls := fx.listed()
+	if calls != 1 {
+		t.Fatalf("ListModels calls = %d, want 1 (custom profile must not fail the built-in lookup)", calls)
+	}
+	if path != "/opt/bin/company-codex" {
+		t.Errorf("ListModels executable path = %q, want /opt/bin/company-codex", path)
+	}
+	report := fx.reported()
+	if got := report["status"]; got != "completed" {
+		t.Fatalf("reported status = %v (error=%v), want completed", got, report["error"])
+	}
+}
+
+// TestHandleModelList_BuiltInRuntimeUsesProviderBinary guards the unchanged
+// half of the contract: a runtime with no profile still enumerates the
+// configured built-in provider binary.
+func TestHandleModelList_BuiltInRuntimeUsesProviderBinary(t *testing.T) {
+	fx := newModelListFixture(t)
+	// Command is intentionally empty: resolveAgentEntry then returns the pinned
+	// entry as-is instead of re-resolving `codex` on the test host, so the
+	// assertion below is about branch selection, not MUL-4486 self-healing.
+	fx.daemon.cfg.Agents = map[string]AgentEntry{
+		"codex": {Path: "/usr/local/bin/codex"},
+	}
+	// A stale profile spec for an unrelated profile must not leak into a
+	// built-in runtime's discovery.
+	fx.daemon.recordProfileLaunch("prof-other", "/opt/bin/company-codex", "1.2.3", nil)
+	rt := Runtime{ID: "rt-3", Provider: "codex", Status: "online"}
+	fx.daemon.mu.Lock()
+	fx.daemon.runtimeIndex[rt.ID] = rt
+	fx.daemon.mu.Unlock()
+
+	fx.daemon.handleModelList(context.Background(), rt, "req-3")
+
+	_, path, calls := fx.listed()
+	if calls != 1 {
+		t.Fatalf("ListModels calls = %d, want 1", calls)
+	}
+	if path != "/usr/local/bin/codex" {
+		t.Errorf("ListModels executable path = %q, want the built-in /usr/local/bin/codex", path)
+	}
+}
+
+// TestHandleModelList_UnknownProviderStillFails keeps the genuine
+// misconfiguration loud: no profile and no built-in entry means there is no
+// binary to enumerate, and the UI should say so rather than show an empty list
+// silently.
+func TestHandleModelList_UnknownProviderStillFails(t *testing.T) {
+	fx := newModelListFixture(t)
+	fx.daemon.cfg.Agents = map[string]AgentEntry{}
+	rt := Runtime{ID: "rt-4", Provider: "codex", Status: "online"}
+
+	fx.daemon.handleModelList(context.Background(), rt, "req-4")
+
+	if _, _, calls := fx.listed(); calls != 0 {
+		t.Fatalf("ListModels calls = %d, want 0", calls)
+	}
+	report := fx.reported()
+	if got := report["status"]; got != "failed" {
+		t.Fatalf("reported status = %v, want failed", got)
+	}
+	if got, _ := report["error"].(string); got != `no agent configured for provider "codex"` {
+		t.Errorf("reported error = %q", got)
+	}
+}

--- a/server/pkg/agent/model_discovery_cache_key_test.go
+++ b/server/pkg/agent/model_discovery_cache_key_test.go
@@ -1,0 +1,84 @@
+package agent
+
+import (
+	"context"
+	"testing"
+)
+
+// TestDiscoveryCacheKeyIsPathScoped pins that the 60s discovery memo is keyed
+// by (provider, executable path). One host can run a built-in provider CLI and
+// a custom runtime profile (MUL-3284) of the same protocol family pointing at a
+// different, often differently versioned, binary; a provider-only key served
+// one binary's catalog for the other for the full TTL (MUL-5471).
+func TestDiscoveryCacheKeyIsPathScoped(t *testing.T) {
+	builtIn := discoveryCacheKey("codex", "/usr/local/bin/codex")
+	custom := discoveryCacheKey("codex", "/opt/bin/company-codex")
+	if builtIn == custom {
+		t.Fatalf("cache keys collide: %q", builtIn)
+	}
+	// An empty path (caller wants the provider default on PATH) keeps the bare
+	// provider key so existing callers and tests stay compatible.
+	if got := discoveryCacheKey("codex", ""); got != "codex" {
+		t.Errorf("discoveryCacheKey(codex, \"\") = %q, want codex", got)
+	}
+}
+
+// TestCachedDiscoveryDoesNotShareAcrossPaths exercises the memo itself: two
+// distinct paths must each run their own discovery instead of the second one
+// inheriting the first one's cached models.
+func TestCachedDiscoveryDoesNotShareAcrossPaths(t *testing.T) {
+	keyA := discoveryCacheKey("codex", t.TempDir()+"/codex-a")
+	keyB := discoveryCacheKey("codex", t.TempDir()+"/codex-b")
+	t.Cleanup(func() {
+		modelCacheMu.Lock()
+		delete(modelCache, keyA)
+		delete(modelCache, keyB)
+		modelCacheMu.Unlock()
+	})
+
+	calls := 0
+	discover := func(id string) func() ([]Model, error) {
+		return func() ([]Model, error) {
+			calls++
+			return []Model{{ID: id}}, nil
+		}
+	}
+
+	gotA, err := cachedDiscovery(keyA, discover("model-a"))
+	if err != nil {
+		t.Fatalf("cachedDiscovery(A): %v", err)
+	}
+	gotB, err := cachedDiscovery(keyB, discover("model-b"))
+	if err != nil {
+		t.Fatalf("cachedDiscovery(B): %v", err)
+	}
+	if calls != 2 {
+		t.Fatalf("discovery calls = %d, want 2 (one per binary)", calls)
+	}
+	if len(gotA) != 1 || gotA[0].ID != "model-a" {
+		t.Errorf("path A models = %+v, want [model-a]", gotA)
+	}
+	if len(gotB) != 1 || gotB[0].ID != "model-b" {
+		t.Errorf("path B models = %+v, want [model-b]", gotB)
+	}
+
+	// Same key again is served from the memo.
+	if _, err := cachedDiscovery(keyA, discover("model-a")); err != nil {
+		t.Fatalf("cachedDiscovery(A, cached): %v", err)
+	}
+	if calls != 2 {
+		t.Errorf("discovery calls = %d after cached re-read, want 2", calls)
+	}
+}
+
+// TestListModelsStaticProviderIgnoresCache is a light guard that switching the
+// dynamic branches to a path-scoped key did not disturb static catalogs.
+func TestListModelsStaticProviderIgnoresCache(t *testing.T) {
+	models, err := ListModels(context.Background(), "claude", missingAgentExecutable(t, "claude"))
+	if err != nil {
+		t.Fatalf("ListModels(claude): %v", err)
+	}
+	if len(models) == 0 {
+		t.Fatal("claude static catalog is empty")
+	}
+}

--- a/server/pkg/agent/models.go
+++ b/server/pkg/agent/models.go
@@ -266,10 +266,10 @@ func modelHasKnownPrefix(model string) bool {
 		isOpenAIReasoningSeriesID(model)
 }
 
-// cachedDiscovery invokes fn and caches the result for modelCacheTTL.
-// The cache is keyed on providerType only; callers that need to
-// distinguish discovery by host/user should include that in the key
-// if we ever introduce such a mode.
+// cachedDiscovery invokes fn and caches the result for modelCacheTTL under key.
+// Every dynamic-discovery caller builds that key with discoveryCacheKey, so the
+// cache is scoped to (providerType, executable path) — never providerType alone.
+// See discoveryCacheKey for why the path belongs in the key.
 func cachedDiscovery(key string, fn func() ([]Model, error)) ([]Model, error) {
 	modelCacheMu.Lock()
 	if entry, ok := modelCache[key]; ok && time.Now().Before(entry.expiresAt) {

--- a/server/pkg/agent/models.go
+++ b/server/pkg/agent/models.go
@@ -116,38 +116,38 @@ func ListModels(ctx context.Context, providerType, executablePath string) ([]Mod
 		// agy 1.0.6 added a `--model` flag plus an `agy models` catalog
 		// command (MUL-3125). Enumerate it on demand like the other
 		// dynamic-discovery backends.
-		return cachedDiscovery(providerType, func() ([]Model, error) {
+		return cachedDiscovery(discoveryCacheKey(providerType, executablePath), func() ([]Model, error) {
 			return discoverAntigravityModels(ctx, executablePath)
 		})
 	case "traecli":
 		// Official TRAE CLI is ACP-native: it returns its model catalog from
 		// session/new. Enumerate it on demand like the other ACP backends
 		// (requires a logged-in traecli; falls back to manual entry on error).
-		return cachedDiscovery(providerType, func() ([]Model, error) {
+		return cachedDiscovery(discoveryCacheKey(providerType, executablePath), func() ([]Model, error) {
 			return discoverTraecliModels(ctx, executablePath)
 		})
 	case "cursor":
-		return cachedDiscovery(providerType, func() ([]Model, error) {
+		return cachedDiscovery(discoveryCacheKey(providerType, executablePath), func() ([]Model, error) {
 			return discoverCursorModels(ctx, executablePath)
 		})
 	case "copilot":
-		return cachedDiscovery(providerType, func() ([]Model, error) {
+		return cachedDiscovery(discoveryCacheKey(providerType, executablePath), func() ([]Model, error) {
 			return discoverCopilotModels(ctx, executablePath)
 		})
 	case "hermes":
-		return cachedDiscovery(providerType, func() ([]Model, error) {
+		return cachedDiscovery(discoveryCacheKey(providerType, executablePath), func() ([]Model, error) {
 			return discoverHermesModels(ctx, executablePath)
 		})
 	case "kimi":
-		return cachedDiscovery(providerType, func() ([]Model, error) {
+		return cachedDiscovery(discoveryCacheKey(providerType, executablePath), func() ([]Model, error) {
 			return discoverKimiModels(ctx, executablePath)
 		})
 	case "kiro":
-		return cachedDiscovery(providerType, func() ([]Model, error) {
+		return cachedDiscovery(discoveryCacheKey(providerType, executablePath), func() ([]Model, error) {
 			return discoverKiroModels(ctx, executablePath)
 		})
 	case "qoder":
-		return cachedDiscovery(providerType, func() ([]Model, error) {
+		return cachedDiscovery(discoveryCacheKey(providerType, executablePath), func() ([]Model, error) {
 			return discoverQoderModels(ctx, executablePath)
 		})
 	case "opencode":
@@ -159,15 +159,15 @@ func ListModels(ctx context.Context, providerType, executablePath string) ([]Mod
 			return discoverDevecoModels(ctx, executablePath)
 		})
 	case "pi":
-		return cachedDiscovery(providerType, func() ([]Model, error) {
+		return cachedDiscovery(discoveryCacheKey(providerType, executablePath), func() ([]Model, error) {
 			return discoverPiModels(ctx, executablePath)
 		})
 	case "openclaw":
-		return cachedDiscovery(providerType, func() ([]Model, error) {
+		return cachedDiscovery(discoveryCacheKey(providerType, executablePath), func() ([]Model, error) {
 			return discoverOpenclawAgents(ctx, executablePath)
 		})
 	case "codebuddy":
-		return cachedDiscovery(providerType, func() ([]Model, error) {
+		return cachedDiscovery(discoveryCacheKey(providerType, executablePath), func() ([]Model, error) {
 			models, err := discoverCodebuddyModels(ctx, executablePath)
 			if err != nil {
 				return nil, err
@@ -184,7 +184,7 @@ func ListModels(ctx context.Context, providerType, executablePath string) ([]Mod
 		// xAI Grok Build is ACP-native (`grok agent stdio`); model catalog
 		// comes from session/new. Falls back to a small static list so the
 		// UI picker stays usable offline / unauthenticated.
-		return cachedDiscovery(providerType, func() ([]Model, error) {
+		return cachedDiscovery(discoveryCacheKey(providerType, executablePath), func() ([]Model, error) {
 			return discoverGrokModels(ctx, executablePath)
 		})
 	default:
@@ -299,6 +299,12 @@ func cachedDiscovery(key string, fn func() ([]Model, error)) ([]Model, error) {
 	return models, nil
 }
 
+// discoveryCacheKey scopes a memoized discovery result to the exact binary it
+// was enumerated from. Every dynamic-discovery branch above must use it: one
+// host can run both a built-in provider CLI and a custom runtime profile
+// (MUL-3284) of the same protocol_family pointing at a different — often
+// differently versioned — executable, and a provider-only key would serve one
+// binary's catalog for the other for the full TTL (MUL-5471).
 func discoveryCacheKey(providerType, executablePath string) string {
 	if executablePath == "" {
 		return providerType


### PR DESCRIPTION
Fixes MUL-5471.

## 背景

`handleModelList` 只按 `provider` 从 `cfg.Agents` 解析要枚举的可执行文件，而 `runTask` 启动的是自定义 runtime profile（MUL-3284）自己的 `command_name`。两条路径不对称，后果：

- 同一台机器上「内置 codex + profile 指向另一版本 codex」时，picker 展示的是内置二进制的模型目录，实际执行用 profile 的二进制 —— 用户选了对端不认的模型，要到任务真正跑起来才失败。
- 机器上没装对应内置 provider 时，`cfg.Agents[provider]` 取不到，model 列表直接以 `no agent configured for provider "codex"` 失败 —— 即使 profile 的二进制存在且可用，picker 也只能手填。

## 改动

**1. `server/internal/daemon/daemon.go` — `handleModelList` 按 runTask 的顺序解析**

```go
if customSpec, isCustom := d.customProfileLaunchForRuntime(rt.ID); isCustom {
    execPath = customSpec.path
} else if entry, ok := d.agents()[rt.Provider]; ok {
    entry, _ = d.resolveAgentEntry(ctx, rt.Provider, entry)   // MUL-4486 self-heal 保留
    execPath = entry.Path
} else {
    // 只有既没有 profile、也没有内置 entry 时才失败
}
```

行为对齐 `runTask`（`daemon.go` 内 `customProfileLaunchForRuntime(task.RuntimeID)` 分支）：custom profile 不走 `resolveAgentEntry` 自愈，profile 的路径不被二次猜测；custom-only 主机不再硬失败。built-in runtime 的行为完全不变。

新增 `listModels = agent.ListModels` 包级 indirection，和已有的 `detectAgentVersion` / `lookPath` 测试钩子同一模式，便于断言「传给 ListModels 的路径」而不真的 shell 出去。

**2. `server/pkg/agent/models.go` — 发现记忆 key 统一带上可执行文件路径**

`discoveryCacheKey(provider, path)` 之前只有 codex / opencode / deveco 在用，其余 provider 的 60s memo key 只有 provider 名。同一台机器上「内置 + 同族 custom profile」会共用一份记忆，等于把上面这个 bug 又原样复现在缓存层。现在 12 个动态发现分支全部改为 path-scoped key。`path == ""` 仍退回裸 provider key，调用方兼容。

## 不在本次范围

profile 的 `fixed_args` 里写死 `--model xxx` 时，agent 上的 model 选择在执行时会被覆盖 —— 这种 profile 该不该展示可选 model（或标注「由 profile 固定」）是产品选择，issue 里已单独记录，这里不动。

## 验证

- `go test ./internal/daemon/ ./pkg/agent/ -count=1` 全绿（daemon 25s / agent 125s），`go vet` 干净，`go build ./...` 通过。
- 新增回归测试 `server/internal/daemon/model_list_binary_test.go`：
  - custom profile runtime + 内置 codex 同时存在 → 传给 `ListModels` 的路径是 profile 的路径；
  - custom-only 主机（`cfg.Agents` 为空）→ 不再报 `no agent configured`，正常返回 `completed`；
  - built-in runtime（无 profile，且存在无关的 profile spec）→ 仍走 provider 路径；
  - 既无 profile 又无内置 entry → 保持 `failed` + 原错误文案。
- 新增 `server/pkg/agent/model_discovery_cache_key_test.go`：同 provider 不同路径不共享 memo，同 key 二次读命中缓存，空路径保持裸 provider key。
- **未做真机复现**：没有在「custom profile + 双版本 codex」的真实环境上跑过，issue 里的复现步骤仍建议在 staging 上实测一次确认表现。
