### PR TITLE
perf(agents): raise the model catalog serve window to 24h (MUL-5444)

### DIFF
--- a/server/internal/handler/runtime_model_catalog.go
+++ b/server/internal/handler/runtime_model_catalog.go
@@ -22,12 +22,22 @@ import (
 // stale-while-revalidate candidate: answer from the last known good snapshot
 // immediately, and refresh in the background so the NEXT open is also warm.
 //
-// Windows are deliberately conservative:
-//   - modelCatalogServeWindow bounds how stale an answer the API will hand a
-//     client without waiting for the daemon.
-//   - modelCatalogRevalidateAfter bounds how long a snapshot can be served
-//     without triggering a background refresh, so a CLI upgrade converges
-//     within one open instead of lingering for the whole serve window.
+// The two windows do different jobs, and only one of them governs freshness:
+//   - modelCatalogRevalidateAfter is the freshness knob. Serving a snapshot
+//     older than this also queues a background refresh, so a CLI upgrade
+//     converges after one open no matter how long the serve window is.
+//   - modelCatalogServeWindow only bounds how long an UNUSED snapshot survives,
+//     and how stale the answer is for someone who opens the picker exactly once
+//     and never returns. It is deliberately day-scale: nothing keeps an entry
+//     warm in the background, the browser's own react-query cache dies with the
+//     tab, and agent CLIs are upgraded on a scale of days — so a minutes-scale
+//     window made every first-open-of-the-day a cold miss (the exact multi-second
+//     wait this cache exists to remove) while buying no real freshness.
+//
+// The window is not unbounded because a *failed* report deliberately leaves the
+// snapshot in place (a transient discovery failure must not empty the picker).
+// For a runtime whose discovery keeps failing — CLI uninstalled, logged out —
+// expiry is the only thing that eventually retires the stale catalog.
 //
 // Only successful, non-empty, `supported` catalogs are cached. An empty list is
 // almost always a transient discovery failure (CLI not logged in, timeout) —
@@ -36,10 +46,15 @@ import (
 
 const (
 	// modelCatalogServeWindow is how long a cached catalog may answer a
-	// list-models request without waiting for the daemon.
-	modelCatalogServeWindow = 15 * time.Minute
+	// list-models request without waiting for the daemon. Day-scale on purpose
+	// (MUL-5444): see the freshness discussion above — every served snapshot
+	// past modelCatalogRevalidateAfter queues its own refresh, so this bounds
+	// unused-entry lifetime and the open-once worst case, not staleness for an
+	// active user.
+	modelCatalogServeWindow = 24 * time.Hour
 	// modelCatalogRevalidateAfter is the age past which serving from cache also
-	// enqueues a background refresh.
+	// enqueues a background refresh. This is the knob that actually keeps the
+	// catalog honest; keep it short.
 	modelCatalogRevalidateAfter = 60 * time.Second
 )
 

--- a/server/internal/handler/runtime_model_catalog_test.go
+++ b/server/internal/handler/runtime_model_catalog_test.go
@@ -194,6 +194,86 @@ func TestInMemoryModelCatalogCache_ExpiresAndInvalidates(t *testing.T) {
 	}
 }
 
+// TestModelCatalogServeWindow_ServesDayOldSnapshotAndRevalidates pins the
+// day-scale serve window (MUL-5444). Nothing keeps a snapshot warm in the
+// background and the browser's own react-query cache dies with the tab, so a
+// minutes-scale window turned every first-open-of-the-day into a cold daemon
+// round trip — the multi-second wait this cache exists to remove. Freshness is
+// not traded away for it: a snapshot past modelCatalogRevalidateAfter is still
+// served, but serving it queues the refresh that makes the next open correct.
+func TestModelCatalogServeWindow_ServesDayOldSnapshotAndRevalidates(t *testing.T) {
+	ctx := context.Background()
+
+	if modelCatalogRevalidateAfter >= modelCatalogServeWindow {
+		t.Fatalf("revalidate threshold %s must stay well below the serve window %s, otherwise nothing refreshes",
+			modelCatalogRevalidateAfter, modelCatalogServeWindow)
+	}
+	if modelCatalogServeWindow < 12*time.Hour {
+		t.Fatalf("serve window %s is not day-scale; agent CLIs are upgraded on a scale of days, so a shorter window only makes the first open of each day slow",
+			modelCatalogServeWindow)
+	}
+
+	cache := NewInMemoryModelCatalogCache()
+	store := NewInMemoryModelListStore()
+	rec := &pendingWorkRecorder{}
+	h := &Handler{ModelCatalogCache: cache, ModelListStore: store, DaemonPendingWork: rec}
+
+	seed := func(runtimeID string, age time.Duration) {
+		cache.mu.Lock()
+		defer cache.mu.Unlock()
+		cache.entries[runtimeID] = ModelCatalogSnapshot{
+			RuntimeID: runtimeID,
+			Models:    sampleCatalog(),
+			Supported: true,
+			StoredAt:  time.Now().Add(-age),
+		}
+	}
+
+	for _, tc := range []struct {
+		name   string
+		age    time.Duration
+		served bool
+	}{
+		{name: "hours old is still served", age: 2 * time.Hour, served: true},
+		{name: "just inside the window is served", age: modelCatalogServeWindow - time.Minute, served: true},
+		{name: "past the window is a miss", age: modelCatalogServeWindow + time.Minute, served: false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			runtimeID := "rt-" + tc.name
+			seed(runtimeID, tc.age)
+			got := h.cachedModelCatalog(ctx, runtimeID)
+			if tc.served && got == nil {
+				t.Fatalf("snapshot aged %s should still answer without waiting for the daemon", tc.age)
+			}
+			if !tc.served && got != nil {
+				t.Fatalf("snapshot aged %s is past the serve window and must not be served: %+v", tc.age, got)
+			}
+		})
+	}
+
+	// Serving an aged snapshot must still queue the refresh — the whole reason a
+	// long window is safe.
+	seed("rt-revalidate", 2*time.Hour)
+	served := h.cachedModelCatalog(ctx, "rt-revalidate")
+	if served == nil {
+		t.Fatal("expected the aged snapshot to be served")
+	}
+	if age := served.Age(time.Now()); age < modelCatalogRevalidateAfter {
+		t.Fatalf("test fixture is younger than the revalidate threshold (%s < %s)", age, modelCatalogRevalidateAfter)
+	}
+	h.revalidateModelCatalog(ctx, "rt-revalidate")
+	pending, err := store.HasPending(ctx, "rt-revalidate")
+	if err != nil {
+		t.Fatalf("has pending: %v", err)
+	}
+	if !pending {
+		t.Fatal("serving an aged snapshot must enqueue a background refresh")
+	}
+	if rec.count() != 1 {
+		t.Fatalf("expected exactly 1 pending-work hint, got %d", rec.count())
+	}
+}
+
 // failingModelCatalogCache reports a backend error on every read.
 type failingModelCatalogCache struct{}
 


### PR DESCRIPTION
## Background

Follow-up to #6098 (MUL-5444). The model-catalog serve window shipped at 15 minutes, calibrated for a constraint that no longer exists: in the first cut the browser held a flat 5-minute `staleTime` decoupled from the server, so the two windows compounded and a short server window was the only bound on observable staleness. Since the review round, a server-cached response is stale on arrival client-side, so nothing compounds.

What 15 minutes actually cost: **no background job keeps a snapshot warm** — only a picker open reads or refreshes it — and the browser's react-query cache dies with the tab (no persister, and `refetchOnWindowFocus` is off app-wide). So opening the agent form once today and again tomorrow was guaranteed to be a cold miss both times, paying the full 1–15s daemon round trip. The cache only helped inside a single session. Guarding a change that happens on a scale of days (a CLI upgrade) with a minutes-scale window bought no freshness for that price.

## Change

`modelCatalogServeWindow`: 15 minutes → **24 hours**. One constant; both backends derive from it (the in-memory `retainFor` and the Redis TTL), so there is no second place to keep in sync. `modelCatalogRevalidateAfter` stays at 60s, and no frontend change is needed — the existing comments reference the constant by name, not by value.

**Freshness is not traded away**, because the two constants do different jobs and only the other one governs it:

- Any served snapshot older than `modelCatalogRevalidateAfter` (60s) queues a background refresh, debounced by `HasPending`.
- The client treats a `cached` answer as immediately revalidatable (`staleTimeFor` → 0), so the refreshed catalog is picked up on the next mount / runtime switch.

So the observable behaviour is "this open shows the old list, the next open shows the new one" at any window length. The window only bounds how long an **unused** snapshot survives, and how stale the answer is for someone who opens the picker exactly once and never returns.

**Why bounded rather than infinite:** a *failed* discovery report deliberately leaves the snapshot in place — a transient failure must not empty the picker. For a runtime whose CLI was uninstalled or logged out, expiry is the only thing that eventually retires the stale catalog. 24h keeps that backstop inside a day while covering the dominant daily-usage pattern.

Also unchanged and worth noting for review: an offline runtime never reaches the cache (the `rt.Status != "online"` 503 sits above the cache read), and a completed-but-empty report still invalidates. Neither depends on the window.

Storage is not a factor — I measured real snapshots: 206 bytes for a Claude catalog, 6.4KB for a codex catalog with full thinking levels and service tiers, so even 10k codex-scale runtimes is ~60MB in Redis.

## Testing

- `go build ./...`, `go vet ./internal/handler/` — clean.
- New `TestModelCatalogServeWindow_ServesDayOldSnapshotAndRevalidates`: a behavioural test rather than a restatement of the constant — an hours-old snapshot and one just inside the window are still served, one past the window is a miss, and serving an aged snapshot still enqueues the refresh plus its wakeup hint. It also fails loudly if the window is ever dropped back to minutes, or if the revalidate threshold stops sitting well below it.
- `go test ./internal/handler/ -run "ModelCatalog|Cacheable|CachedModel|PendingWork"` — pass, and again under `-race`.
- Redis backend re-verified against a throwaway `redis:7-alpine` with the new TTL (`REDIS_TEST_URL=... -run "RedisModelCatalogCache|..."`) — pass, including the TTL-upper-bound assertion which derives from the constant.
- Pre-existing/unrelated: `internal/handler` reports 648 failures in this environment with and without the change (local test DB predates recent migrations); baseline confirmed by comparison.

## Risk

Worst case is unchanged in kind and longer in duration only for the open-once user: after a CLI upgrade, one open can show a catalog up to a day old instead of up to 15 minutes old, and that same open queues the refresh that corrects the next one. If that is judged too loose, the follow-up we discussed on the issue — invalidating the snapshot when a runtime registers with a different CLI version (the version is already persisted in the runtime row's metadata) — makes "new catalog on the first open after an upgrade" deterministic and takes the pressure off this constant entirely. Deliberately not in this PR to keep the diff to the one decision.
