### PR TITLE
fix(issues): confirm successful task retries and cancellations

### DIFF
--- a/packages/views/issues/components/execution-log-section.test.tsx
+++ b/packages/views/issues/components/execution-log-section.test.tsx
@@ -41,7 +41,18 @@ vi.mock("../../common/task-transcript", () => ({
 }));
 
 vi.mock("./terminate-task-confirm-dialog", () => ({
-  TerminateTaskConfirmDialog: () => null,
+  TerminateTaskConfirmDialog: ({
+    open,
+    onConfirm,
+  }: {
+    open: boolean;
+    onConfirm: () => void;
+  }) =>
+    open ? (
+      <button type="button" onClick={onConfirm}>
+        Confirm stop
+      </button>
+    ) : null,
 }));
 
 import {
@@ -108,6 +119,22 @@ describe("ExecutionLogSection", () => {
 });
 
 describe("ActiveTaskRow", () => {
+  it("confirms a successful task cancellation", async () => {
+    mockState.cancelTask.mockResolvedValue(undefined);
+    const successToast = vi.spyOn(toast, "success").mockReturnValue("toast-id");
+
+    renderWithI18n(<ActiveTaskRow task={makeTask()} issueId="issue-1" />);
+    fireEvent.click(screen.getByRole("button", { name: "Cancel task" }));
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: "Confirm stop" }));
+      await Promise.resolve();
+    });
+
+    expect(mockState.cancelTask).toHaveBeenCalledWith("issue-1", "task-1");
+    expect(successToast).toHaveBeenCalledWith("Task cancelled");
+  });
+
   it("renders running status as elapsed time only", () => {
     renderWithI18n(
       <ActiveTaskRow

--- a/packages/views/issues/components/execution-log-section.test.tsx
+++ b/packages/views/issues/components/execution-log-section.test.tsx
@@ -1,12 +1,29 @@
 // @vitest-environment jsdom
 
-import { cleanup, screen } from "@testing-library/react";
+import { act, cleanup, fireEvent, screen } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { AgentTask } from "@multica/core/types";
+import { toast } from "sonner";
 import { renderWithI18n } from "../../test/i18n";
 
 const mockState = vi.hoisted(() => ({
+  cancelTask: vi.fn(),
+  dispatchReasonCode: vi.fn(),
+  rerunIssue: vi.fn(),
   taskMessagesOptions: vi.fn(),
+  useQuery: vi.fn(),
+}));
+
+vi.mock("@tanstack/react-query", () => ({
+  useQuery: mockState.useQuery,
+}));
+
+vi.mock("@multica/core/api", () => ({
+  api: {
+    cancelTask: mockState.cancelTask,
+    rerunIssue: mockState.rerunIssue,
+  },
+  dispatchReasonCode: mockState.dispatchReasonCode,
 }));
 
 vi.mock("@multica/core/chat/queries", () => ({
@@ -27,7 +44,11 @@ vi.mock("./terminate-task-confirm-dialog", () => ({
   TerminateTaskConfirmDialog: () => null,
 }));
 
-import { ActiveTaskRow, TaskCommentCoverage } from "./execution-log-section";
+import {
+  ActiveTaskRow,
+  ExecutionLogSection,
+  TaskCommentCoverage,
+} from "./execution-log-section";
 
 function makeTask(overrides: Partial<AgentTask> = {}): AgentTask {
   return {
@@ -56,7 +77,34 @@ beforeEach(() => {
 });
 
 afterEach(() => {
+  vi.restoreAllMocks();
   vi.useRealTimers();
+});
+
+describe("ExecutionLogSection", () => {
+  it("confirms a successful task retry", async () => {
+    const failedTask = makeTask({
+      status: "failed",
+      completed_at: "2026-06-08T08:04:00Z",
+      failure_reason: "agent_error",
+    });
+    mockState.rerunIssue.mockResolvedValue(
+      makeTask({ id: "task-2", status: "queued" }),
+    );
+    const successToast = vi.spyOn(toast, "success").mockReturnValue("toast-id");
+    mockState.useQuery.mockReturnValue({ data: [failedTask] });
+
+    renderWithI18n(<ExecutionLogSection issueId="issue-1" />);
+    fireEvent.click(screen.getByRole("button", { name: "Show past runs (1)" }));
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: "Retry task" }));
+      await Promise.resolve();
+    });
+
+    expect(mockState.rerunIssue).toHaveBeenCalledWith("issue-1", "task-1");
+    expect(successToast).toHaveBeenCalledWith("Task retried");
+  });
 });
 
 describe("ActiveTaskRow", () => {

--- a/packages/views/issues/components/execution-log-section.tsx
+++ b/packages/views/issues/components/execution-log-section.tsx
@@ -291,6 +291,7 @@ export function ActiveTaskRow({
     setCancelling(true);
     try {
       await api.cancelTask(issueId, task.id);
+      toast.success(t(($) => $.execution_log.cancel_success));
     } catch (e) {
       toast.error(e instanceof Error ? e.message : t(($) => $.execution_log.cancel_failed));
       setCancelling(false);

--- a/packages/views/issues/components/execution-log-section.tsx
+++ b/packages/views/issues/components/execution-log-section.tsx
@@ -384,6 +384,7 @@ function PastRow({ task, issueId }: { task: AgentTask; issueId: string }) {
     setRetrying(true);
     try {
       await api.rerunIssue(issueId, task.id);
+      toast.success(t(($) => $.execution_log.retry_success));
     } catch (e) {
       // A rerun is now re-gated on the operator's invoke permission (MUL-4525):
       // a structured 403 means the agent can't be triggered, not a transient

--- a/packages/views/locales/en/issues.json
+++ b/packages/views/locales/en/issues.json
@@ -463,6 +463,7 @@
     "retry_task_aria": "Retry task",
     "retry_failed": "Failed to retry task",
     "retry_blocked": "Not retried — you don't have permission to use this agent",
+    "retry_success": "Task retried",
     "transcript_tooltip": "View transcript",
     "cancel_failed": "Failed to cancel task",
     "trigger_retry": "Retry",

--- a/packages/views/locales/en/issues.json
+++ b/packages/views/locales/en/issues.json
@@ -465,6 +465,7 @@
     "retry_blocked": "Not retried — you don't have permission to use this agent",
     "retry_success": "Task retried",
     "transcript_tooltip": "View transcript",
+    "cancel_success": "Task cancelled",
     "cancel_failed": "Failed to cancel task",
     "trigger_retry": "Retry",
     "trigger_retry_attempt": "Retry #{{attempt}}",

--- a/packages/views/locales/ja/issues.json
+++ b/packages/views/locales/ja/issues.json
@@ -443,6 +443,7 @@
     "retry_task_aria": "タスクを再試行",
     "retry_failed": "タスクを再試行できませんでした",
     "retry_blocked": "再試行されませんでした — このエージェントを使用する権限がありません",
+    "retry_success": "タスクを再試行しました",
     "transcript_tooltip": "トランスクリプトを表示",
     "cancel_failed": "タスクをキャンセルできませんでした",
     "trigger_retry": "再試行",

--- a/packages/views/locales/ja/issues.json
+++ b/packages/views/locales/ja/issues.json
@@ -445,6 +445,7 @@
     "retry_blocked": "再試行されませんでした — このエージェントを使用する権限がありません",
     "retry_success": "タスクを再試行しました",
     "transcript_tooltip": "トランスクリプトを表示",
+    "cancel_success": "タスクをキャンセルしました",
     "cancel_failed": "タスクをキャンセルできませんでした",
     "trigger_retry": "再試行",
     "trigger_retry_attempt": "再試行 #{{attempt}}",

--- a/packages/views/locales/ko/issues.json
+++ b/packages/views/locales/ko/issues.json
@@ -443,6 +443,7 @@
     "retry_task_aria": "작업 다시 시도",
     "retry_failed": "작업을 다시 시도하지 못했습니다",
     "retry_blocked": "다시 시도되지 않음 — 이 에이전트를 사용할 권한이 없습니다",
+    "retry_success": "작업을 다시 시도했습니다",
     "transcript_tooltip": "트랜스크립트 보기",
     "cancel_failed": "작업을 취소하지 못했습니다",
     "trigger_retry": "다시 시도",

--- a/packages/views/locales/ko/issues.json
+++ b/packages/views/locales/ko/issues.json
@@ -445,6 +445,7 @@
     "retry_blocked": "다시 시도되지 않음 — 이 에이전트를 사용할 권한이 없습니다",
     "retry_success": "작업을 다시 시도했습니다",
     "transcript_tooltip": "트랜스크립트 보기",
+    "cancel_success": "작업을 취소했습니다",
     "cancel_failed": "작업을 취소하지 못했습니다",
     "trigger_retry": "다시 시도",
     "trigger_retry_attempt": "{{attempt}}번째 다시 시도",

--- a/packages/views/locales/zh-Hans/issues.json
+++ b/packages/views/locales/zh-Hans/issues.json
@@ -443,6 +443,7 @@
     "retry_task_aria": "重试 task",
     "retry_failed": "重试 task 失败",
     "retry_blocked": "未重试——你没有该智能体的使用权限",
+    "retry_success": "已重试 task",
     "transcript_tooltip": "查看记录",
     "cancel_failed": "取消 task 失败",
     "trigger_retry": "重试",

--- a/packages/views/locales/zh-Hans/issues.json
+++ b/packages/views/locales/zh-Hans/issues.json
@@ -445,6 +445,7 @@
     "retry_blocked": "未重试——你没有该智能体的使用权限",
     "retry_success": "已重试 task",
     "transcript_tooltip": "查看记录",
+    "cancel_success": "已取消 task",
     "cancel_failed": "取消 task 失败",
     "trigger_retry": "重试",
     "trigger_retry_attempt": "重试 #{{attempt}}",


### PR DESCRIPTION
## What does this PR do?

Adds localized success feedback for two user-initiated task actions in the execution log:

- retrying a failed or cancelled task;
- confirming cancellation of an active task.

Both success toasts appear only after their API calls resolve. Existing failure handling, authorization, request payloads, and task state transitions remain unchanged.

Thinking path: these actions live in the same execution-log surface and previously reported failures but ended silently on success. Keeping them together produces one consistent interaction fix, one shared test setup, and avoids overlapping PRs in the same component and locale files.

Server-driven automatic retries are intentionally out of scope. Their attempts already remain visible in execution history, while transient background toasts could be missed or become noisy.

## Related Issue

- Supersedes the earlier closed retry iteration in #5603.
- Cancellation reproduction and scope were tracked in [Jetiaime/multica#6](https://github.com/Jetiaime/multica/issues/6).
- Incorporates and supersedes #6127.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Refactor / code improvement (no behavior change)
- [ ] Documentation update
- [x] Tests (adding or improving test coverage)
- [ ] CI / infrastructure

## Changes Made

- Show `retry_success` after `api.rerunIssue` resolves.
- Show `cancel_success` after `api.cancelTask` resolves.
- Cover both rendered user flows, their API arguments, and their success toasts.
- Add matching English, Japanese, Korean, and Simplified Chinese locale entries.

The production change is two toast calls; the rest is focused tests and localization.

## How to Test

1. Open an issue with a failed or cancelled task, expand **Past runs**, and retry it.
2. Verify a new task is created and the localized retry-success toast appears.
3. Open an issue with an active task, cancel it, and confirm the destructive action.
4. Verify the task moves into execution history and the localized cancellation-success toast appears.

Local verification:

- Views Vitest suite: 273 files / 3,224 tests passed.
- Focused component and locale tests: 2 files / 176 tests passed.
- TypeScript: `tsc --noEmit` passed.
- ESLint: the changed component and test passed.
- Real local retry created a task retaining the original task relationship.
- Real local cancellation persisted `cancelled` with `completed_at` set.

Risk is limited to feedback after already-successful API calls. Automatic retries, cancellation semantics, rerun eligibility, and error handling are unchanged.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] If this change affects the UI, I have included before/after screenshots
- [x] I have updated relevant documentation to reflect my changes (no documentation change is needed for this feedback-only fix)
- [x] If I added a new runtime / coding tool / UI tab, I synced the change to **landing copy** (`apps/web/features/landing/i18n/`) and **relevant docs** (`apps/docs/content/docs/`) (not applicable)
- [x] If this PR touches Chinese product copy, I checked it against `apps/docs/content/docs/developers/conventions.zh.mdx` (terminology, mixed-rule for `task` / `issue` / `skill`)
- [x] I have considered and documented any risks above
- [x] I will address all reviewer comments before requesting merge

## AI Disclosure

**AI tool used:** OpenAI Codex

**Prompt / approach:**
I asked Codex to compare both proposals with current upstream, consolidate their overlapping test setup, preserve a minimal two-line production change, run a separate local Multica web/API/Postgres stack for live evidence, and execute lint, typecheck, focused tests, and the full views suite. Both behaviors were first reviewed and merged separately in my fork before this upstream consolidation.

## Screenshots

Captured from a separate local development stack. The API results and resulting database task records were also verified.

### Retry

Before:

![Failed task ready to retry](https://raw.githubusercontent.com/Jetiaime/multica/pr-assets/retry-before.jpg)

After:

![Localized successful retry toast](https://raw.githubusercontent.com/Jetiaime/multica/pr-assets/retry-after.jpg)

### Cancellation

Before:

![Active task before cancellation](https://raw.githubusercontent.com/Jetiaime/multica/pr-assets/cancel-task-feedback/before.png)

After:

![Localized successful cancellation toast](https://raw.githubusercontent.com/Jetiaime/multica/pr-assets/cancel-task-feedback/after.png)
