### PR TITLE
fix(inbox): restore archived issues from detail header

### DIFF
--- a/packages/views/inbox/components/inbox-page.tsx
+++ b/packages/views/inbox/components/inbox-page.tsx
@@ -446,8 +446,13 @@ export function InboxPage() {
           // longer exists.
           setSelectedKey("");
         }}
+        doneAction={isArchivedView ? "unarchive" : "archive"}
         onDone={() => {
-          handleArchive(selected.id);
+          if (isArchivedView) {
+            handleUnarchive(selected.id);
+          } else {
+            handleArchive(selected.id);
+          }
         }}
       />
     </ErrorBoundary>

--- a/packages/views/issues/components/issue-detail.test.tsx
+++ b/packages/views/issues/components/issue-detail.test.tsx
@@ -565,12 +565,18 @@ function createTestQueryClient() {
   });
 }
 
-function renderIssueDetail(issueId = "issue-1") {
+function renderIssueDetail(
+  issueId = "issue-1",
+  options: {
+    onDone?: () => void;
+    doneAction?: "archive" | "unarchive";
+  } = {},
+) {
   const queryClient = createTestQueryClient();
   return render(
     <I18nProvider locale="en" resources={TEST_RESOURCES}>
       <QueryClientProvider client={queryClient}>
-        <IssueDetail issueId={issueId} />
+        <IssueDetail issueId={issueId} {...options} />
       </QueryClientProvider>
     </I18nProvider>,
   );
@@ -741,6 +747,34 @@ describe("IssueDetail (shared)", () => {
     // from the inline Inbox pane). A bare issue has no ancestor crumbs.
     const leaf = await screen.findByText("TES-1 Implement authentication");
     expect(leaf.closest("a")).toHaveAttribute("href", "/test/issues/issue-1");
+  });
+
+  it("shows the restore action for archived Inbox issues", async () => {
+    const onDone = vi.fn();
+    const { container } = renderIssueDetail("issue-1", {
+      onDone,
+      doneAction: "unarchive",
+    });
+
+    await screen.findByText("TES-1 Implement authentication");
+    const restoreButton = container.querySelector(".lucide-archive-restore")?.closest("button");
+
+    expect(restoreButton).not.toBeNull();
+    expect(container.querySelector(".lucide-circle-check")).toBeNull();
+
+    fireEvent.click(restoreButton!);
+    expect(onDone).toHaveBeenCalledOnce();
+    expect(mockApiObj.updateIssue).not.toHaveBeenCalled();
+  });
+
+  it("keeps the archive action for completed Inbox issues", async () => {
+    mockApiObj.getIssue.mockResolvedValue({ ...mockIssue, status: "done" });
+    const { container } = renderIssueDetail("issue-1", { onDone: vi.fn() });
+
+    await screen.findByText("TES-1 Implement authentication");
+
+    expect(container.querySelector(".lucide-archive")).not.toBeNull();
+    expect(container.querySelector(".lucide-archive-restore")).toBeNull();
   });
 
   it("omits the project breadcrumb segment when the issue has no project_id", async () => {

--- a/packages/views/issues/components/issue-detail.tsx
+++ b/packages/views/issues/components/issue-detail.tsx
@@ -6,6 +6,7 @@ import { useDefaultLayout, usePanelRef } from "react-resizable-panels";
 import { AppLink, useBackOrReplace } from "../../navigation";
 import {
   Archive,
+  ArchiveRestore,
   Calendar,
   CalendarClock,
   CalendarDays,
@@ -888,8 +889,9 @@ function SubIssueDisplayPopover({
 interface IssueDetailProps {
   issueId: string;
   onDelete?: () => void;
-  /** Called after the issue is marked as done via the toolbar button. */
+  /** Called by the Inbox action in the toolbar. */
   onDone?: () => void;
+  doneAction?: "archive" | "unarchive";
   defaultSidebarOpen?: boolean;
   layoutId?: string;
   /** When set, the issue detail will auto-scroll to this comment and briefly highlight it. */
@@ -900,7 +902,7 @@ interface IssueDetailProps {
 // IssueDetail
 // ---------------------------------------------------------------------------
 
-export function IssueDetail({ issueId, onDelete, onDone, defaultSidebarOpen = true, layoutId = "multica_issue_detail_layout", highlightCommentId }: IssueDetailProps) {
+export function IssueDetail({ issueId, onDelete, onDone, doneAction = "archive", defaultSidebarOpen = true, layoutId = "multica_issue_detail_layout", highlightCommentId }: IssueDetailProps) {
   const { t } = useT("issues");
   const timeAgo = useTimeAgo();
   const id = issueId;
@@ -2227,7 +2229,24 @@ export function IssueDetail({ issueId, onDelete, onDone, defaultSidebarOpen = tr
                 it never overlaps the title (which truncates to make room).
                 It self-hides when no agent is active. */}
             <IssueAgentHeaderChip issueId={id} />
-            {onDone && issue.status !== "done" && issue.status !== "cancelled" && (
+            {onDone && doneAction === "unarchive" && (
+              <Tooltip>
+                <TooltipTrigger
+                  render={
+                    <Button
+                      variant="ghost"
+                      size="icon-sm"
+                      className="text-muted-foreground"
+                      onClick={onDone}
+                    >
+                      <ArchiveRestore />
+                    </Button>
+                  }
+                />
+                <TooltipContent side="bottom">{t(($) => $.detail.unarchive_tooltip)}</TooltipContent>
+              </Tooltip>
+            )}
+            {onDone && doneAction === "archive" && issue.status !== "done" && issue.status !== "cancelled" && (
               <Tooltip>
                 <TooltipTrigger
                   render={
@@ -2244,7 +2263,7 @@ export function IssueDetail({ issueId, onDelete, onDone, defaultSidebarOpen = tr
                 <TooltipContent side="bottom">{t(($) => $.detail.mark_done_tooltip)}</TooltipContent>
               </Tooltip>
             )}
-            {onDone && issue.status === "done" && (
+            {onDone && doneAction === "archive" && issue.status === "done" && (
               <Tooltip>
                 <TooltipTrigger
                   render={

--- a/packages/views/locales/en/issues.json
+++ b/packages/views/locales/en/issues.json
@@ -297,6 +297,7 @@
     "agents_group": "Agents",
     "mark_done_tooltip": "Mark as done",
     "archive_tooltip": "Archive",
+    "unarchive_tooltip": "Unarchive",
     "pin_tooltip": "Pin to sidebar",
     "unpin_tooltip": "Unpin from sidebar",
     "thread_nav_label": "Jump to comment thread",

--- a/packages/views/locales/ja/issues.json
+++ b/packages/views/locales/ja/issues.json
@@ -294,6 +294,7 @@
     "agents_group": "エージェント",
     "mark_done_tooltip": "完了にする",
     "archive_tooltip": "アーカイブ",
+    "unarchive_tooltip": "アーカイブ解除",
     "pin_tooltip": "サイドバーにピン留め",
     "unpin_tooltip": "サイドバーのピン留めを解除",
     "thread_nav_label": "スレッドへ移動",

--- a/packages/views/locales/ko/issues.json
+++ b/packages/views/locales/ko/issues.json
@@ -294,6 +294,7 @@
     "agents_group": "에이전트",
     "mark_done_tooltip": "완료로 표시",
     "archive_tooltip": "보관",
+    "unarchive_tooltip": "보관 해제",
     "pin_tooltip": "사이드바에 고정",
     "unpin_tooltip": "사이드바 고정 해제",
     "thread_nav_label": "스레드로 이동",

--- a/packages/views/locales/zh-Hans/issues.json
+++ b/packages/views/locales/zh-Hans/issues.json
@@ -294,6 +294,7 @@
     "agents_group": "智能体",
     "mark_done_tooltip": "标记为已完成",
     "archive_tooltip": "归档",
+    "unarchive_tooltip": "取消归档",
     "pin_tooltip": "固定到侧边栏",
     "unpin_tooltip": "从侧边栏取消固定",
     "thread_nav_label": "快速跳转到讨论",


### PR DESCRIPTION
## What does this PR do?

The archived Inbox list already restores notifications correctly from its row action, but opening an archived issue in the detail pane shows the normal completed-issue **Archive** action. That action cannot restore the item and leaves the detail header inconsistent with the list.

`IssueDetail` now accepts an optional `doneAction` mode. The archived Inbox passes `unarchive`, which renders one `ArchiveRestore` action for any issue status and calls the existing unarchive mutation. The default remains `archive`, so issue pages and the normal Inbox retain their current mark-done/archive behavior.

## Related Issue

Internal Multica issue PRTS-93 (no public GitHub issue).

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Refactor / code improvement (no behavior change)
- [ ] Documentation update
- [x] Tests (adding or improving test coverage)
- [ ] CI / infrastructure

## Changes Made

- `packages/views/issues/components/issue-detail.tsx` — add the optional `doneAction` mode and render the restore action in archived Inbox details.
- `packages/views/inbox/components/inbox-page.tsx` — select archive or unarchive based on the active Inbox view.
- `packages/views/issues/components/issue-detail.test.tsx` — verify archived details expose restore without changing issue status, while completed normal-Inbox details keep archive.
- `packages/views/locales/{en,ja,ko,zh-Hans}/issues.json` — add the localized restore tooltip.

Risk is limited by the optional prop's existing-behavior default. No backend, API, or data-model change is included.

## How to Test

1. Start Multica with a web/API/Postgres development stack and archive an Inbox notification for a completed issue.
2. Open **Inbox → Archived**, select the item, and confirm the detail header shows the restore action instead of archive.
3. Click restore. Confirm the app returns to the main Inbox and the notification is persisted with `archived=false`.
4. Run:
   - `pnpm -C packages/views exec eslint inbox/components/inbox-page.tsx issues/components/issue-detail.tsx issues/components/issue-detail.test.tsx` — passed.
   - `pnpm --filter @multica/views typecheck` — passed.
   - `pnpm -C packages/views exec vitest run` — 273 files / 3224 tests passed.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] If this change affects the UI, I have included before/after screenshots
- [x] I have updated relevant documentation to reflect my changes (no documentation change is needed for this scoped Inbox fix)
- [x] If I added a new runtime / coding tool / UI tab, I synced the change to **landing copy** (`apps/web/features/landing/i18n/`) and **relevant docs** (`apps/docs/content/docs/`) (not applicable)
- [x] If this PR touches Chinese product copy, I checked it against `apps/docs/content/docs/developers/conventions.zh.mdx` (terminology, mixed-rule for `task` / `issue` / `skill`)
- [x] I have considered and documented any risks above
- [x] I will address all reviewer comments before requesting merge

## AI Disclosure

**AI tool used:** OpenAI Codex

**Prompt / approach:**
I asked Codex to review the earlier proposal against current upstream, reduce it to the smallest reusable UI contract, run an isolated local Multica web/API/Postgres stack, reproduce the bug with seeded archived Inbox data, capture live before/after evidence, click the real restore action, verify the persisted database state, and run lint, typecheck, and the full views test suite. The same commit was first reviewed and merged in my fork before this upstream submission.

## Screenshots (optional)

Both captures come from the same separate local development stack and seeded archived notification. After capturing the fixed header, I clicked its real restore action; the app returned to the main Inbox and Postgres reported `archived=false`.

### Before — archived detail exposes Archive

![Before: archived Inbox detail with archive action](https://raw.githubusercontent.com/Jetiaime/multica/pr-assets/inbox-archived-before.jpg)

### After — archived detail exposes Restore

![After: archived Inbox detail with restore action](https://raw.githubusercontent.com/Jetiaime/multica/pr-assets/inbox-archived-after.jpg)
