### PR TITLE
feat(issues): add "Open in new tab" to the issue actions menu (MUL-5455)

### DIFF
--- a/packages/views/issues/actions/__tests__/issue-actions-menu.test.tsx
+++ b/packages/views/issues/actions/__tests__/issue-actions-menu.test.tsx
@@ -86,6 +86,14 @@ vi.mock("@multica/core/paths", async () => {
   };
 });
 
+// Module-level flag toggled per-test: desktop implements `openInNewTab`,
+// web omits it and the menu has to fall back to a real browser tab.
+const { openInNewTabMock, getShareableUrlMock, navState } = vi.hoisted(() => ({
+  openInNewTabMock: vi.fn(),
+  getShareableUrlMock: vi.fn((p: string) => `https://app.example${p}`),
+  navState: { hasOpenInNewTab: true },
+}));
+
 vi.mock("../../../navigation", () => ({
   useNavigation: () => ({
     push: vi.fn(),
@@ -93,6 +101,8 @@ vi.mock("../../../navigation", () => ({
     searchParams: new URLSearchParams(),
     back: vi.fn(),
     replace: vi.fn(),
+    ...(navState.hasOpenInNewTab ? { openInNewTab: openInNewTabMock } : {}),
+    getShareableUrl: getShareableUrlMock,
   }),
 }));
 
@@ -145,6 +155,9 @@ function wrap(ui: React.ReactNode) {
 
 beforeEach(() => {
   mockOpenModal.mockReset();
+  openInNewTabMock.mockReset();
+  getShareableUrlMock.mockClear();
+  navState.hasOpenInNewTab = true;
 });
 
 describe("IssueActionsDropdown", () => {
@@ -165,6 +178,7 @@ describe("IssueActionsDropdown", () => {
     expect(screen.getByText("Priority")).toBeInTheDocument();
     expect(screen.getByText("Assignee")).toBeInTheDocument();
     expect(screen.getByText("Due date")).toBeInTheDocument();
+    expect(screen.getByText("Open in new tab")).toBeInTheDocument();
     expect(screen.getByText("Copy link")).toBeInTheDocument();
     expect(screen.getByText("Relations")).toBeInTheDocument();
     expect(screen.getByText("Delete issue")).toBeInTheDocument();
@@ -255,6 +269,59 @@ describe("IssueActionsDropdown", () => {
   });
 });
 
+describe("Open in new tab", () => {
+  async function openMenuAndClickOpenInNewTab() {
+    render(
+      wrap(
+        <IssueActionsDropdown
+          issue={mockIssue}
+          trigger={<button data-testid="trigger">Menu</button>}
+        />,
+      ),
+    );
+    fireEvent.click(screen.getByTestId("trigger"));
+    fireEvent.click(await screen.findByText("Open in new tab"));
+  }
+
+  it("uses the desktop adapter and focuses the new tab", async () => {
+    const windowOpen = vi
+      .spyOn(window, "open")
+      .mockReturnValue(null as unknown as Window);
+
+    await openMenuAndClickOpenInNewTab();
+
+    // `activate: true` — an explicit CTA moves the user into the new context,
+    // unlike modifier-click, which stashes a background tab.
+    expect(openInNewTabMock).toHaveBeenCalledWith(
+      "/test/issues/issue-1",
+      "TES-1",
+      { activate: true },
+    );
+    expect(windowOpen).not.toHaveBeenCalled();
+
+    windowOpen.mockRestore();
+  });
+
+  it("falls back to a browser tab when the adapter is absent (web)", async () => {
+    navState.hasOpenInNewTab = false;
+    const windowOpen = vi
+      .spyOn(window, "open")
+      .mockReturnValue(null as unknown as Window);
+
+    await openMenuAndClickOpenInNewTab();
+
+    expect(openInNewTabMock).not.toHaveBeenCalled();
+    expect(getShareableUrlMock).toHaveBeenCalledWith("/test/issues/issue-1");
+    expect(windowOpen).toHaveBeenCalledWith(
+      "https://app.example/test/issues/issue-1",
+      "_blank",
+      "noopener,noreferrer",
+    );
+
+    windowOpen.mockRestore();
+  });
+});
+
 describe("IssueActionsContextMenu", () => {
   it("renders the menu when the wrapped element receives a contextmenu event", async () => {
     render(
@@ -270,6 +337,9 @@ describe("IssueActionsContextMenu", () => {
     fireEvent.contextMenu(screen.getByTestId("row"));
 
     expect(await screen.findByText("Status")).toBeInTheDocument();
+    // The right-click surface is what list rows, board cards, gantt bars and
+    // sub-issue rows all share, so this one assertion covers them together.
+    expect(screen.getByText("Open in new tab")).toBeInTheDocument();
     expect(screen.getByText("Delete issue")).toBeInTheDocument();
   });
 });

--- a/packages/views/issues/actions/issue-actions-menu-items.tsx
+++ b/packages/views/issues/actions/issue-actions-menu-items.tsx
@@ -8,6 +8,7 @@ import {
   ArrowUp,
   Calendar,
   CalendarClock,
+  ExternalLink,
   FolderOpen,
   Link2,
   Network,
@@ -104,6 +105,7 @@ export function IssueActionsMenuItems({
   const {
     isPinned,
     updateField,
+    openInNewTab,
     togglePin,
     copyLink,
     openCreateSubIssue,
@@ -254,6 +256,13 @@ export function IssueActionsMenuItems({
 
       <P.Separator />
 
+      {/* Leads the "do something with this issue itself" group: the only
+          discoverable way to open an issue elsewhere for users who don't know
+          modifier-click, so it sits above the copy actions. */}
+      <P.Item onClick={openInNewTab}>
+        <ExternalLink className="h-3.5 w-3.5" />
+        {t(($) => $.actions.open_in_new_tab)}
+      </P.Item>
       <P.Item onClick={togglePin}>
         {isPinned ? (
           <PinOff className="h-3.5 w-3.5" />

--- a/packages/views/issues/actions/use-issue-actions.ts
+++ b/packages/views/issues/actions/use-issue-actions.ts
@@ -18,6 +18,7 @@ import { useIssueSurfaceActionsOptional } from "../surface/actions-context";
 export interface UseIssueActionsResult {
   isPinned: boolean;
   updateField: (updates: Partial<UpdateIssueRequest>) => void;
+  openInNewTab: () => void;
   togglePin: () => void;
   copyLink: () => Promise<void>;
   openCreateSubIssue: () => void;
@@ -109,6 +110,29 @@ export function useIssueActions(issue: Issue | null): UseIssueActionsResult {
     [issueId, issueStatus, surfaceActions, updateIssue, openModal, t],
   );
 
+  // Explicit "open it somewhere else" CTA, so the new tab takes focus
+  // (`activate: true`) — the user is asking to move into the new context, not
+  // to stash it for later the way modifier-click does. Same contract as the
+  // table row open and the attachment preview's "Open in new tab".
+  //
+  // Only desktop implements `openInNewTab`; on web it is undefined and we fall
+  // back to a real browser tab via the shareable URL.
+  const openInNewTab = useCallback(() => {
+    if (!issueId) return;
+    const path = paths.issueDetail(issueId);
+    if (navigation.openInNewTab) {
+      navigation.openInNewTab(path, issueIdentifier ?? undefined, {
+        activate: true,
+      });
+      return;
+    }
+    window.open(
+      navigation.getShareableUrl(path),
+      "_blank",
+      "noopener,noreferrer",
+    );
+  }, [issueId, issueIdentifier, navigation, paths]);
+
   const togglePin = useCallback(() => {
     if (!issueId) return;
     if (isPinned) {
@@ -199,6 +223,7 @@ export function useIssueActions(issue: Issue | null): UseIssueActionsResult {
   return {
     isPinned,
     updateField,
+    openInNewTab,
     togglePin,
     copyLink,
     openCreateSubIssue,

--- a/packages/views/locales/en/issues.json
+++ b/packages/views/locales/en/issues.json
@@ -540,6 +540,7 @@
     "due_next_week": "Next week",
     "due_clear": "Clear date",
     "unassigned": "Unassigned",
+    "open_in_new_tab": "Open in new tab",
     "pin_to_sidebar": "Pin to sidebar",
     "unpin_from_sidebar": "Unpin from sidebar",
     "copy_link": "Copy link",

--- a/packages/views/locales/ja/issues.json
+++ b/packages/views/locales/ja/issues.json
@@ -515,6 +515,7 @@
     "due_next_week": "来週",
     "due_clear": "日付をクリア",
     "unassigned": "未割り当て",
+    "open_in_new_tab": "新しいタブで開く",
     "pin_to_sidebar": "サイドバーにピン留め",
     "unpin_from_sidebar": "サイドバーのピン留めを解除",
     "copy_link": "リンクをコピー",

--- a/packages/views/locales/ko/issues.json
+++ b/packages/views/locales/ko/issues.json
@@ -515,6 +515,7 @@
     "due_next_week": "다음 주",
     "due_clear": "날짜 지우기",
     "unassigned": "담당자 없음",
+    "open_in_new_tab": "새 탭에서 열기",
     "pin_to_sidebar": "사이드바에 고정",
     "unpin_from_sidebar": "사이드바 고정 해제",
     "copy_link": "링크 복사",

--- a/packages/views/locales/zh-Hans/issues.json
+++ b/packages/views/locales/zh-Hans/issues.json
@@ -515,6 +515,7 @@
     "due_next_week": "下周",
     "due_clear": "清除日期",
     "unassigned": "未分配",
+    "open_in_new_tab": "在新标签页打开",
     "pin_to_sidebar": "固定到侧边栏",
     "unpin_from_sidebar": "从侧边栏取消固定",
     "copy_link": "复制链接",


### PR DESCRIPTION
Closes MUL-5455. Stage 1 of the MUL-5453 「导航 vs 引用」 cleanup — the escape hatch that has to land before any default-behavior change.

## What

The issue right-click / kebab menu had status, priority, assignee, dates, pin, copy link, copy workdir path, relations and delete — but no way to **open** the issue. Users who don't know Cmd+click had no affordance at all for opening an issue somewhere else.

Adds `openInNewTab` to `useIssueActions` and surfaces it at the top of the "act on this issue" group, above the copy actions.

## Behavior

Foreground tab (`activate: true`) — this is an explicit CTA, so focus follows the user into the new context, unlike modifier-click which stashes a background tab. Same contract as `table-view.tsx`'s `openIssue` and the attachment preview's "Open in new tab".

- **Desktop** — routes through the tab adapter. `openTab` dedupes by pathname, so invoking it on an issue that already has a tab focuses the existing one.
- **Web** — no `openInNewTab` adapter, so it falls back to `window.open(getShareableUrl(path), "_blank", "noopener,noreferrer")`. Current page is not hijacked.

## Copy

Reuses the wording already established by the preferences toggle (`settings.json`) and the attachment preview (`editor.json`) — 在新标签页打开 / Open in new tab / 新しいタブで開く / 새 탭에서 열기. No 新页签 / 新窗口 mixing anywhere in the zh locale.

## Scope note — the `table` bullet in the acceptance criteria

The issue states the menu is shared by "list 行、board 卡片、table 行、sub-issue 行". That is true for three of the four: **table rows have no issue context menu at all today.** `table-view.tsx`'s `renderRow` returns `null` for issue rows, so they fall through to `DataTable`'s default row, which is never wrapped in `IssueActionsContextMenu` (`table-view.tsx:2300-2350`).

So this PR covers every surface that has the shared menu — list rows, board cards, gantt bars, sub-issue rows, and the detail page's 3-dot dropdown — and table rows still have none. Giving them one is a separate change with its own design questions (right-click inside the open rename `<Input>` would hijack the native input menu; it also overlaps MUL-5459, which is queued to change table row click semantics). Flagged rather than folded in silently.

## Verification

- `pnpm typecheck` — clean, all 6 workspaces.
- `pnpm lint` — 0 errors.
- `packages/views` suite — 3205 passed. One unrelated pre-existing failure in `layout/sidebar-resize.test.tsx`, confirmed failing on a clean tree at this commit.
- New tests in `issue-actions-menu.test.tsx` cover both branches (desktop adapter present → `openInNewTab(path, identifier, {activate: true})` and no `window.open`; adapter absent → `window.open` with the shareable URL and no adapter call), plus presence of the item on both the dropdown and the right-click surface.
