### PR TITLE
fix(views): open a real browser tab on modifier-click for non-anchor surfaces (MUL-5456)

### DIFF
--- a/packages/views/common/actor-avatar-profile-link.test.tsx
+++ b/packages/views/common/actor-avatar-profile-link.test.tsx
@@ -1,0 +1,121 @@
+/**
+ * Avatar profile-link modifier-click (MUL-5456).
+ *
+ * The trigger is a `<span role="link">`, not an anchor — deliberately, so it
+ * can sit inside rows and menus without nesting interactive elements. That
+ * also means the browser has nothing native to fall back on: whatever the
+ * handler does IS the behaviour. On web (no `openInNewTab` adapter) a
+ * cmd/ctrl-click used to fall through to `push()` and navigate in place,
+ * throwing away the user's "keep me here" intent.
+ */
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { NavigationProvider } from "../navigation/context";
+import type { NavigationAdapter } from "../navigation/types";
+
+vi.mock("@multica/core/workspace/hooks", () => ({
+  useActorName: () => ({
+    getActorName: () => "Ada Lovelace",
+    getActorInitials: () => "AL",
+    getActorAvatarUrl: () => null,
+  }),
+}));
+
+vi.mock("@multica/core/paths", () => ({
+  useWorkspacePaths: () => ({
+    memberDetail: (id: string) => `/acme/members/${id}`,
+    agentDetail: (id: string) => `/acme/agents/${id}`,
+    squadDetail: (id: string) => `/acme/squads/${id}`,
+  }),
+  useCurrentWorkspace: () => ({ id: "ws1", slug: "acme" }),
+}));
+
+vi.mock("@multica/core/agents", () => ({
+  useAgentPresenceDetail: () => ({ availability: "offline", workload: null }),
+}));
+
+vi.mock("../agents/components/agent-profile-card", () => ({
+  AgentProfileCard: () => null,
+}));
+vi.mock("../agents/components/agent-live-peek-card", () => ({
+  AgentLivePeekCard: () => null,
+}));
+vi.mock("../members/member-profile-card", () => ({
+  MemberProfileCard: () => null,
+}));
+vi.mock("../squads/components/squad-profile-card", () => ({
+  SquadProfileCard: () => null,
+}));
+
+import { ActorAvatar } from "./actor-avatar";
+
+const MEMBER_ID = "8f14e45f-ceea-4d0e-a1a2-9b1c0d3e4f5a";
+const HREF = `/acme/members/${MEMBER_ID}`;
+
+function makeAdapter(overrides: Partial<NavigationAdapter> = {}): NavigationAdapter {
+  return {
+    push: vi.fn(),
+    replace: vi.fn(),
+    back: vi.fn(),
+    pathname: "/",
+    searchParams: new URLSearchParams(),
+    getShareableUrl: (p) => `https://app.example${p}`,
+    ...overrides,
+  };
+}
+
+function renderAvatar(adapter: NavigationAdapter) {
+  return render(
+    <NavigationProvider value={adapter}>
+      <ActorAvatar actorType="member" actorId={MEMBER_ID} />
+    </NavigationProvider>,
+  );
+}
+
+describe("ActorAvatar profile link", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("pushes on plain click", () => {
+    const push = vi.fn();
+    const open = vi.spyOn(window, "open").mockReturnValue(null);
+
+    renderAvatar(makeAdapter({ push }));
+    fireEvent.click(screen.getByRole("link"));
+
+    expect(push).toHaveBeenCalledWith(HREF);
+    expect(open).not.toHaveBeenCalled();
+  });
+
+  it("uses openInNewTab for cmd/ctrl click when available (desktop)", () => {
+    const push = vi.fn();
+    const openInNewTab = vi.fn();
+    const open = vi.spyOn(window, "open").mockReturnValue(null);
+
+    renderAvatar(makeAdapter({ push, openInNewTab }));
+    fireEvent.click(screen.getByRole("link"), { metaKey: true });
+
+    expect(openInNewTab).toHaveBeenCalledWith(HREF);
+    expect(push).not.toHaveBeenCalled();
+    expect(open).not.toHaveBeenCalled();
+  });
+
+  it("opens a browser tab against the shareable URL when openInNewTab is absent (web)", () => {
+    const push = vi.fn();
+    const open = vi.spyOn(window, "open").mockReturnValue(null);
+
+    renderAvatar(makeAdapter({ push }));
+    fireEvent.click(screen.getByRole("link"), { metaKey: true });
+    fireEvent.click(screen.getByRole("link"), { ctrlKey: true });
+
+    expect(open).toHaveBeenCalledTimes(2);
+    expect(open).toHaveBeenNthCalledWith(
+      1,
+      `https://app.example${HREF}`,
+      "_blank",
+      "noopener,noreferrer",
+    );
+    expect(push).not.toHaveBeenCalled();
+  });
+});

--- a/packages/views/common/actor-avatar.tsx
+++ b/packages/views/common/actor-avatar.tsx
@@ -151,7 +151,7 @@ function ActorAvatarProfileLink({
   href: string;
   children: React.ReactNode;
 }) {
-  const { push, openInNewTab } = useNavigation();
+  const { push, openInNewTab, getShareableUrl } = useNavigation();
 
   const navigate = (event: React.MouseEvent | React.KeyboardEvent) => {
     const controlAncestor = event.currentTarget.parentElement?.closest(
@@ -161,12 +161,15 @@ function ActorAvatarProfileLink({
 
     event.preventDefault();
     event.stopPropagation();
-    if (
-      "metaKey" in event &&
-      (event.metaKey || event.ctrlKey || event.shiftKey) &&
-      openInNewTab
-    ) {
-      openInNewTab(href);
+    if ("metaKey" in event && (event.metaKey || event.ctrlKey || event.shiftKey)) {
+      if (openInNewTab) {
+        openInNewTab(href);
+        return;
+      }
+      // Web: the trigger is a `<span role="link">`, not an anchor, so there is
+      // no native modifier-click behaviour to fall back to — open the browser
+      // tab here rather than letting the click navigate in place.
+      window.open(getShareableUrl(href), "_blank", "noopener,noreferrer");
       return;
     }
     push(href);

--- a/packages/views/editor/extensions/mention-view.test.tsx
+++ b/packages/views/editor/extensions/mention-view.test.tsx
@@ -1,0 +1,171 @@
+/**
+ * Editor mention modifier-click (MUL-5456).
+ *
+ * Both mention chips render a real `<a href>`, so on web the correct move is
+ * to leave a modifier-click alone and let the browser do it — that keeps
+ * cmd+click (background tab), shift+click (new window) and cmd+shift+click
+ * (foreground tab) distinct, which `window.open` would flatten into one.
+ *
+ * The project mention used to `preventDefault()` at the top of the handler and
+ * then return without an adapter, producing a dead click on web. These tests
+ * pin the no-adapter path for both chips.
+ */
+import { describe, expect, it, vi } from "vitest";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { NavigationProvider } from "../../navigation/context";
+import type { NavigationAdapter } from "../../navigation/types";
+
+// Tiptap NodeView primitives can't be instantiated without a full editor.
+vi.mock("@tiptap/react", () => ({
+  NodeViewWrapper: ({ children, ...rest }: any) => <span {...rest}>{children}</span>,
+}));
+
+vi.mock("@multica/core/paths", () => ({
+  useWorkspacePaths: () => ({
+    issueDetail: (id: string) => `/acme/issues/${id}`,
+    projectDetail: (id: string) => `/acme/projects/${id}`,
+  }),
+}));
+
+const { newTabPreferred } = vi.hoisted(() => ({ newTabPreferred: { value: false } }));
+
+vi.mock("@multica/core/issues/stores", () => ({
+  useIssueLinkStore: (selector: (s: { openInNewTab: boolean }) => unknown) =>
+    selector({ openInNewTab: newTabPreferred.value }),
+}));
+
+vi.mock("../../issues/components/issue-chip", () => ({
+  IssueChip: ({ fallbackLabel }: { fallbackLabel?: string }) => (
+    <span data-testid="issue-chip">{fallbackLabel}</span>
+  ),
+}));
+
+vi.mock("../../projects/components/project-chip", () => ({
+  ProjectChip: ({ fallbackLabel }: { fallbackLabel?: string }) => (
+    <span data-testid="project-chip">{fallbackLabel}</span>
+  ),
+}));
+
+import { MentionView } from "./mention-view";
+
+const PROJECT_ID = "8f14e45f-ceea-4d0e-a1a2-9b1c0d3e4f5a";
+const PROJECT_PATH = `/acme/projects/${PROJECT_ID}`;
+
+function makeAdapter(overrides: Partial<NavigationAdapter> = {}): NavigationAdapter {
+  return {
+    push: vi.fn(),
+    replace: vi.fn(),
+    back: vi.fn(),
+    pathname: "/",
+    searchParams: new URLSearchParams(),
+    getShareableUrl: (p) => `https://app.example${p}`,
+    ...overrides,
+  };
+}
+
+function renderMention(
+  attrs: { type: string; id: string; label?: string },
+  adapter: NavigationAdapter,
+) {
+  return render(
+    <NavigationProvider value={adapter}>
+      <MentionView {...({ node: { attrs } } as any)} />
+    </NavigationProvider>,
+  );
+}
+
+function renderProjectMention(adapter: NavigationAdapter) {
+  return renderMention({ type: "project", id: PROJECT_ID, label: "Roadmap" }, adapter);
+}
+
+describe("MentionView project mention", () => {
+  it("renders an anchor carrying the project path", () => {
+    renderProjectMention(makeAdapter());
+
+    expect(screen.getByTestId("project-chip").closest("a")).toHaveAttribute(
+      "href",
+      PROJECT_PATH,
+    );
+  });
+
+  it("pushes on plain click and prevents the anchor's default navigation", () => {
+    const push = vi.fn();
+    renderProjectMention(makeAdapter({ push }));
+
+    // fireEvent returns false when preventDefault was called.
+    const defaultNotPrevented = fireEvent.click(screen.getByTestId("project-chip"));
+
+    expect(defaultNotPrevented).toBe(false);
+    expect(push).toHaveBeenCalledWith(PROJECT_PATH);
+  });
+
+  it("uses openInNewTab for cmd/ctrl click when available (desktop)", () => {
+    const push = vi.fn();
+    const openInNewTab = vi.fn();
+    renderProjectMention(makeAdapter({ push, openInNewTab }));
+
+    const defaultNotPrevented = fireEvent.click(screen.getByTestId("project-chip"), {
+      metaKey: true,
+    });
+
+    expect(defaultNotPrevented).toBe(false);
+    expect(openInNewTab).toHaveBeenCalledWith(PROJECT_PATH, "Roadmap");
+    expect(push).not.toHaveBeenCalled();
+  });
+
+  it("leaves modifier-click to the browser when openInNewTab is absent (web)", () => {
+    const push = vi.fn();
+    const open = vi.spyOn(window, "open").mockReturnValue(null);
+    renderProjectMention(makeAdapter({ push }));
+
+    for (const modifier of [{ metaKey: true }, { ctrlKey: true }, { shiftKey: true }]) {
+      const defaultNotPrevented = fireEvent.click(
+        screen.getByTestId("project-chip"),
+        modifier,
+      );
+      expect(defaultNotPrevented).toBe(true);
+    }
+
+    expect(push).not.toHaveBeenCalled();
+    // Native anchor behaviour, not window.open — the latter would collapse
+    // background tab / new window / foreground tab into one outcome.
+    expect(open).not.toHaveBeenCalled();
+    open.mockRestore();
+  });
+});
+
+describe("MentionView issue mention", () => {
+  const ISSUE_ID = "1b9d6bcd-bbfd-4b2d-9b5d-ab8dfbbd4bed";
+  const ISSUE_PATH = `/acme/issues/${ISSUE_ID}`;
+
+  // The reference implementation the project mention was aligned to — guard it
+  // so the two chips can't drift apart again.
+  it("leaves modifier-click to the browser when openInNewTab is absent (web)", () => {
+    const push = vi.fn();
+    renderMention({ type: "issue", id: ISSUE_ID, label: "MUL-7" }, makeAdapter({ push }));
+
+    const defaultNotPrevented = fireEvent.click(screen.getByTestId("issue-chip"), {
+      metaKey: true,
+    });
+
+    expect(defaultNotPrevented).toBe(true);
+    expect(push).not.toHaveBeenCalled();
+  });
+
+  it("uses openInNewTab for cmd/ctrl click when available (desktop)", () => {
+    const push = vi.fn();
+    const openInNewTab = vi.fn();
+    renderMention(
+      { type: "issue", id: ISSUE_ID, label: "MUL-7" },
+      makeAdapter({ push, openInNewTab }),
+    );
+
+    const defaultNotPrevented = fireEvent.click(screen.getByTestId("issue-chip"), {
+      metaKey: true,
+    });
+
+    expect(defaultNotPrevented).toBe(false);
+    expect(openInNewTab).toHaveBeenCalledWith(ISSUE_PATH, "MUL-7");
+    expect(push).not.toHaveBeenCalled();
+  });
+});

--- a/packages/views/editor/extensions/mention-view.tsx
+++ b/packages/views/editor/extensions/mention-view.tsx
@@ -60,12 +60,18 @@ function ProjectMention({
   const projectPath = p.projectDetail(projectId);
 
   const handleClick = (e: React.MouseEvent) => {
-    e.preventDefault();
     e.stopPropagation();
     if (e.metaKey || e.ctrlKey || e.shiftKey) {
-      if (openInNewTab) openInNewTab(projectPath, fallbackLabel);
+      if (openInNewTab) {
+        e.preventDefault();
+        openInNewTab(projectPath, fallbackLabel);
+      }
+      // Web: no adapter — leave the event alone so the browser's native
+      // modifier-click on the anchor opens the tab (or window for shift),
+      // preserving background/foreground semantics window.open would flatten.
       return;
     }
+    e.preventDefault();
     push(projectPath);
   };
 

--- a/packages/views/navigation/use-row-link.test.tsx
+++ b/packages/views/navigation/use-row-link.test.tsx
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { fireEvent, render, screen } from "@testing-library/react";
 import { NavigationProvider } from "./context";
 import { useRowLink } from "./use-row-link";
@@ -36,6 +36,10 @@ function renderProbe(adapter: NavigationAdapter) {
 }
 
 describe("useRowLink", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
   it("pushes on plain left click", () => {
     const push = vi.fn();
     const adapter = makeAdapter({ push });
@@ -62,17 +66,35 @@ describe("useRowLink", () => {
     expect(push).not.toHaveBeenCalled();
   });
 
-  it("falls back to a single push for cmd/ctrl click without openInNewTab", () => {
+  // Web has no adapter, and the row is a <div> — there is no native
+  // modifier-click behaviour to inherit, so without an explicit window.open
+  // the row would navigate in place and swallow the user's intent (MUL-5456).
+  it("opens a browser tab against the shareable URL for cmd/ctrl click without openInNewTab (web)", () => {
     const push = vi.fn();
-    const adapter = makeAdapter({ push });
+    const open = vi.spyOn(window, "open").mockReturnValue(null);
+    const adapter = makeAdapter({
+      push,
+      getShareableUrl: (p) => `https://app.example${p}`,
+    });
 
     renderProbe(adapter);
     fireEvent.click(screen.getByRole("row"), { metaKey: true });
     fireEvent.click(screen.getByRole("row"), { ctrlKey: true });
 
-    expect(push).toHaveBeenCalledTimes(2);
-    expect(push).toHaveBeenNthCalledWith(1, "/acme/projects/p1");
-    expect(push).toHaveBeenNthCalledWith(2, "/acme/projects/p1");
+    expect(open).toHaveBeenCalledTimes(2);
+    expect(open).toHaveBeenNthCalledWith(
+      1,
+      "https://app.example/acme/projects/p1",
+      "_blank",
+      "noopener,noreferrer",
+    );
+    expect(open).toHaveBeenNthCalledWith(
+      2,
+      "https://app.example/acme/projects/p1",
+      "_blank",
+      "noopener,noreferrer",
+    );
+    expect(push).not.toHaveBeenCalled();
   });
 
   it("opens a background tab and prevents default for middle click when available", () => {
@@ -93,9 +115,13 @@ describe("useRowLink", () => {
     expect(push).not.toHaveBeenCalled();
   });
 
-  it("falls back to one prevented push for middle click without openInNewTab", () => {
+  it("opens a browser tab for middle click without openInNewTab (web)", () => {
     const push = vi.fn();
-    const adapter = makeAdapter({ push });
+    const open = vi.spyOn(window, "open").mockReturnValue(null);
+    const adapter = makeAdapter({
+      push,
+      getShareableUrl: (p) => `https://app.example${p}`,
+    });
 
     renderProbe(adapter);
     const event = new MouseEvent("auxclick", {
@@ -106,7 +132,11 @@ describe("useRowLink", () => {
     screen.getByRole("row").dispatchEvent(event);
 
     expect(event.defaultPrevented).toBe(true);
-    expect(push).toHaveBeenCalledWith("/acme/projects/p1");
-    expect(push).toHaveBeenCalledTimes(1);
+    expect(open).toHaveBeenCalledWith(
+      "https://app.example/acme/projects/p1",
+      "_blank",
+      "noopener,noreferrer",
+    );
+    expect(push).not.toHaveBeenCalled();
   });
 });

--- a/packages/views/navigation/use-row-link.ts
+++ b/packages/views/navigation/use-row-link.ts
@@ -17,19 +17,30 @@ import { useNavigation } from "./context";
  * call `stopPropagation` so clicking them never reaches these handlers.
  *
  * Mirrors AppLink's modifier semantics: a plain left click pushes; cmd/ctrl
- * (or a middle click) opens a background tab on desktop.
+ * (or a middle click) opens a background tab on desktop. On web there is no
+ * adapter and — because the row is a `<div>`, not an `<a>` — no native
+ * modifier-click behaviour to inherit either, so the browser tab is opened
+ * here against the shareable URL. Without that fallback a modifier or middle
+ * click would silently navigate in place.
  *
  * Callers add `cursor-pointer` to the row's own className (kept out of the
  * returned props so it can't clash with the row's existing className).
  */
 export function useRowLink() {
-  const { push, openInNewTab, prefetch } = useNavigation();
+  const { push, openInNewTab, prefetch, getShareableUrl } = useNavigation();
 
   return useCallback(
     (href: string) => {
       const open = (newTab: boolean) => {
-        if (newTab && openInNewTab) openInNewTab(href);
-        else push(href);
+        if (!newTab) {
+          push(href);
+          return;
+        }
+        if (openInNewTab) {
+          openInNewTab(href);
+          return;
+        }
+        window.open(getShareableUrl(href), "_blank", "noopener,noreferrer");
       };
       return {
         onClick: (e: React.MouseEvent) => {
@@ -47,6 +58,6 @@ export function useRowLink() {
         onMouseEnter: () => prefetch?.(href),
       };
     },
-    [push, openInNewTab, prefetch],
+    [push, openInNewTab, prefetch, getShareableUrl],
   );
 }

--- a/packages/views/projects/components/projects-page.test.tsx
+++ b/packages/views/projects/components/projects-page.test.tsx
@@ -309,8 +309,12 @@ describe("ProjectsPage compact row navigation", () => {
     expect(push).not.toHaveBeenCalled();
   });
 
+  // Web (no adapter): the row is a <div>, so nothing native catches a
+  // modifier or middle click — rowLink opens the browser tab itself instead
+  // of navigating in place (MUL-5456).
   it("has a single rowLink path for modifier and middle clicks without openInNewTab", () => {
     const push = vi.fn();
+    const open = vi.spyOn(window, "open").mockReturnValue(null);
     renderProjects(makeAdapter({ push }));
     const row = projectRow();
 
@@ -324,9 +328,16 @@ describe("ProjectsPage compact row navigation", () => {
     row.dispatchEvent(middleClick);
 
     expect(middleClick.defaultPrevented).toBe(true);
-    expect(push).toHaveBeenCalledTimes(3);
-    expect(push).toHaveBeenNthCalledWith(1, "/test-workspace/projects/project-1");
-    expect(push).toHaveBeenNthCalledWith(2, "/test-workspace/projects/project-1");
-    expect(push).toHaveBeenNthCalledWith(3, "/test-workspace/projects/project-1");
+    expect(open).toHaveBeenCalledTimes(3);
+    for (const nth of [1, 2, 3]) {
+      expect(open).toHaveBeenNthCalledWith(
+        nth,
+        "/test-workspace/projects/project-1",
+        "_blank",
+        "noopener,noreferrer",
+      );
+    }
+    expect(push).not.toHaveBeenCalled();
+    open.mockRestore();
   });
 });


### PR DESCRIPTION
Fixes MUL-5456. From the MUL-5453 audit, Stage 1.

## Problem

Web has no `NavigationAdapter.openInNewTab`. Real anchors don't need one — the browser's native modifier-click handles them. But three surfaces aren't anchors and had no fallback, so cmd/ctrl/middle-click silently did the wrong thing:

| Surface | Before |
|---|---|
| List rows (`useRowLink`) — projects / agents / skills / squads / runtimes / autopilots | navigated in place |
| Avatar profile link (`<span role="link">`) | navigated in place |
| Editor project mention | **nothing at all** — dead click |

The mention case was the worst: `handleClick` called `preventDefault()` at the top, then hit the modifier branch, found no adapter, and returned.

## Why not just define `openInNewTab` on the web adapter

That was the original suggestion on MUL-5453 and it's wrong — it regresses `AppLink`, which relies on the adapter being `undefined` to let native anchor behaviour through (`app-link.tsx:22-28`). Defining it makes `AppLink` `preventDefault()` and route through `window.open`, collapsing cmd+click (background tab), shift+click (new window) and cmd+shift+click (foreground tab) into one outcome, subject to popup blocking. On a real anchor, native beats `window.open`.

So this fixes each surface on its own terms.

## Changes

- **`use-row-link.ts`, `actor-avatar.tsx`** (non-anchors): fall back to `window.open(getShareableUrl(href), "_blank", "noopener,noreferrer")` — the pattern already used by `table-view.tsx` and `html-attachment-preview.tsx`.
- **`mention-view.tsx`** (real anchor): `preventDefault()` moves out of the function head into the branches that actually handle the click, so with no adapter the event reaches the browser untouched. This is exactly what `IssueMention` in the same file already does.

`apps/web/platform/navigation.tsx` is untouched. Desktop is unchanged — the adapter still wins on every path.

## Tests

Four new "adapter absent" cases, one per bug; each fails on `main` and passes here. Plus a desktop-path case per surface so the adapter branch stays pinned, and an `IssueMention` case so the two editor chips can't drift apart again.

- `navigation/use-row-link.test.tsx` — modifier + middle click (the two pre-existing tests asserted the buggy in-place `push`; rewritten)
- `common/actor-avatar-profile-link.test.tsx` — new
- `editor/extensions/mention-view.test.tsx` — new; asserts the web path does **not** call `window.open`, since native is the point
- `projects/components/projects-page.test.tsx` — updated at the integration level

## Verification

- `packages/views` suite: 3212 passed. One unrelated pre-existing failure in `layout/sidebar-resize.test.tsx`, confirmed failing on a clean tree at this base.
- `tsc --noEmit` and `eslint` clean on the changed files.
