### PR TITLE
fix(views): open a background tab on middle-click of AppLink (MUL-5457)

### DIFF
--- a/packages/views/navigation/app-link.test.tsx
+++ b/packages/views/navigation/app-link.test.tsx
@@ -158,6 +158,130 @@ describe("AppLink", () => {
     });
   });
 
+  describe("middle click (aux click)", () => {
+    // `fireEvent` has no auxClick helper, so dispatch the real event — same
+    // approach as use-row-link.test.tsx. Returns the event so the caller can
+    // assert on defaultPrevented, which is the whole point on desktop.
+    function auxClick(el: HTMLElement, button = 1) {
+      const event = new MouseEvent("auxclick", {
+        bubbles: true,
+        button,
+        cancelable: true,
+      });
+      el.dispatchEvent(event);
+      return event;
+    }
+
+    it("opens a BACKGROUND tab via the adapter (desktop) and does NOT push", () => {
+      const push = vi.fn();
+      const openInNewTab = vi.fn();
+      const adapter = makeAdapter({ push, openInNewTab });
+
+      renderLink(adapter);
+      const event = auxClick(screen.getByText("go"));
+
+      // No `activate` — a middle click means "keep me where I am".
+      expect(openInNewTab).toHaveBeenCalledWith("/issues", undefined);
+      expect(push).not.toHaveBeenCalled();
+      // The native window-open must be suppressed: on desktop it is a dead
+      // end (denied by setWindowOpenHandler, then dropped by the http/https
+      // allowlist because the packaged renderer is file://).
+      expect(event.defaultPrevented).toBe(true);
+    });
+
+    it("passes newTabTitle through as the tab label", () => {
+      const openInNewTab = vi.fn();
+      const adapter = makeAdapter({ openInNewTab });
+
+      renderLink(adapter, { href: "/issues", newTabTitle: "MUL-7" });
+      auxClick(screen.getByText("go"));
+      expect(openInNewTab).toHaveBeenCalledWith("/issues", "MUL-7");
+    });
+
+    it("without an adapter (web) neither pushes nor prevents default, so the browser's native background tab still opens", () => {
+      const push = vi.fn();
+      const adapter = makeAdapter({ push });
+
+      renderLink(adapter);
+      const event = auxClick(screen.getByText("go"));
+
+      expect(event.defaultPrevented).toBe(false);
+      expect(push).not.toHaveBeenCalled();
+    });
+
+    it("stays background even on a target=_blank link, where a plain click would foreground", () => {
+      const openInNewTab = vi.fn();
+      const adapter = makeAdapter({ openInNewTab });
+
+      renderLink(adapter, {
+        href: "/issues",
+        target: "_blank",
+        newTabTitle: "MUL-7",
+      });
+      auxClick(screen.getByText("go"));
+      expect(openInNewTab).toHaveBeenCalledWith("/issues", "MUL-7");
+    });
+
+    it.each([
+      ["right button", 2],
+      ["browser back button", 3],
+      ["browser forward button", 4],
+    ])("ignores a non-middle aux click (%s)", (_label, button) => {
+      const push = vi.fn();
+      const openInNewTab = vi.fn();
+      const adapter = makeAdapter({ push, openInNewTab });
+
+      renderLink(adapter);
+      const event = auxClick(screen.getByText("go"), button);
+
+      expect(openInNewTab).not.toHaveBeenCalled();
+      expect(push).not.toHaveBeenCalled();
+      expect(event.defaultPrevented).toBe(false);
+    });
+
+    it("runs the caller's onAuxClick, which can opt out of the new tab with preventDefault", () => {
+      const openInNewTab = vi.fn();
+      const callerAuxClick = vi.fn((e: React.MouseEvent) => e.preventDefault());
+      const adapter = makeAdapter({ openInNewTab });
+
+      renderLink(adapter, { href: "/issues", onAuxClick: callerAuxClick });
+      auxClick(screen.getByText("go"));
+
+      expect(callerAuxClick).toHaveBeenCalledTimes(1);
+      expect(openInNewTab).not.toHaveBeenCalled();
+    });
+
+    it("runs the caller's onAuxClick and still opens the tab when it does not preventDefault", () => {
+      const openInNewTab = vi.fn();
+      const callerAuxClick = vi.fn();
+      const adapter = makeAdapter({ openInNewTab });
+
+      renderLink(adapter, { href: "/issues", onAuxClick: callerAuxClick });
+      auxClick(screen.getByText("go"));
+
+      expect(callerAuxClick).toHaveBeenCalledTimes(1);
+      expect(openInNewTab).toHaveBeenCalledWith("/issues", undefined);
+    });
+
+    it("a caller-supplied onAuxClick passed via spread cannot silently override the aux handler", () => {
+      const openInNewTab = vi.fn();
+      const adapter = makeAdapter({ openInNewTab });
+      const spreadAuxClick = vi.fn();
+
+      render(
+        <NavigationProvider value={adapter}>
+          <AppLink href="/issues" {...{ onAuxClick: spreadAuxClick }}>
+            go
+          </AppLink>
+        </NavigationProvider>,
+      );
+
+      auxClick(screen.getByText("go"));
+      expect(spreadAuxClick).toHaveBeenCalled();
+      expect(openInNewTab).toHaveBeenCalledWith("/issues", undefined);
+    });
+  });
+
   it("a caller-supplied onClick passed via spread cannot silently override the navigation handler", () => {
     const push = vi.fn();
     const adapter = makeAdapter({ push });

--- a/packages/views/navigation/app-link.tsx
+++ b/packages/views/navigation/app-link.tsx
@@ -7,14 +7,25 @@ interface AppLinkProps extends React.AnchorHTMLAttributes<HTMLAnchorElement> {
   href: string;
   /**
    * Desktop only: label for the tab created when the click opens a new tab
-   * (modifier-click or `target="_blank"`). Falls back to the path.
+   * (modifier-click, middle click, or `target="_blank"`). Falls back to the
+   * path.
    */
   newTabTitle?: string;
 }
 
 export const AppLink = forwardRef<HTMLAnchorElement, AppLinkProps>(
   function AppLink(
-    { href, children, onClick, onMouseEnter, onFocus, target, newTabTitle, ...props },
+    {
+      href,
+      children,
+      onClick,
+      onAuxClick,
+      onMouseEnter,
+      onFocus,
+      target,
+      newTabTitle,
+      ...props
+    },
     ref,
   ) {
     const { push, openInNewTab, prefetch } = useNavigation();
@@ -48,6 +59,35 @@ export const AppLink = forwardRef<HTMLAnchorElement, AppLinkProps>(
       push(href);
     };
 
+    // A middle click never produces a `click` event, so handleClick above
+    // never sees one — it has to be handled on its own event.
+    //
+    // Desktop needs this because the native path is a dead end: Chromium
+    // raises a window-open request that the shell's setWindowOpenHandler
+    // denies and hands to openExternalSafely. In a packaged build the
+    // renderer is `file://`, so this href resolves to `file:///<path>` and
+    // the http/https allowlist drops it — the click does nothing at all. In
+    // dev the renderer is `http://localhost:<port>`, which clears the
+    // allowlist and throws the click out into the system browser instead.
+    // Both were reproduced against Electron 39 before this handler existed.
+    const handleAuxClick = (e: React.MouseEvent<HTMLAnchorElement>) => {
+      // The caller sees every aux click, and can opt out of the new tab by
+      // calling preventDefault — the same escape hatch a child element inside
+      // the link has.
+      onAuxClick?.(e);
+      if (e.defaultPrevented || e.button !== 1) return; // middle click only
+      // Web: no adapter, and this is a real anchor, so the browser already
+      // opens a background tab — exactly what a middle click should do.
+      // Preventing the default here would break it.
+      if (!openInNewTab) return;
+      e.preventDefault();
+      // Background tab, never activated: a middle click means "keep me here",
+      // matching the cmd/ctrl branch in handleClick. That holds for
+      // target="_blank" links too — browsers background a middle click
+      // regardless of target.
+      openInNewTab(href, newTabTitle);
+    };
+
     const handleMouseEnter = (e: React.MouseEvent<HTMLAnchorElement>) => {
       prefetch?.(href);
       onMouseEnter?.(e);
@@ -67,10 +107,12 @@ export const AppLink = forwardRef<HTMLAnchorElement, AppLinkProps>(
         // even though the destination is our own app.
         rel={target === "_blank" ? "noopener noreferrer" : undefined}
         // Spread props first so that the navigation handlers below cannot be
-        // silently overridden by a caller passing onClick/onMouseEnter/onFocus
-        // through {...rest}. AppLink owns these three events.
+        // silently overridden by a caller passing
+        // onClick/onAuxClick/onMouseEnter/onFocus through {...rest}. AppLink
+        // owns these four events.
         {...props}
         onClick={handleClick}
+        onAuxClick={handleAuxClick}
         onMouseEnter={handleMouseEnter}
         onFocus={handleFocus}
       >


### PR DESCRIPTION
Closes MUL-5457.

## Reproduced first

The issue's failure chain was inferred from code, so I reproduced it in real Electron 39 before touching anything — a `file://` renderer, a root-relative `<a href>`, and the same `setWindowOpenHandler` / `openExternalSafely` the desktop shell installs.

Packaged build (`file://` renderer):

```
dom  mousedown button=1
dom  mouseup   button=1
dom  auxclick  button=1        <- no `click` event, so handleClick never runs
setWindowOpenHandler  url=file:///acme/issues/MUL-1234  disposition=background-tab
-> openExternal BLOCKED by scheme allowlist (nothing happens)
```

Dev build (`http://localhost:<port>` renderer): same up to the handler, then the URL clears the http/https allowlist and `shell.openExternal` throws the click out into the system browser.

Both match the issue exactly. I also confirmed the premise of the fix — `preventDefault()` inside an `auxclick` listener does suppress the window-open request (stable across repeated runs).

## The fix

`AppLink` gains `onAuxClick`, matching `useRowLink`'s semantics: middle button only, background tab through the adapter.

Web is deliberately left alone. `AppLink` renders a real anchor, so the browser's native middle-click background tab is already the right outcome; preventing it would replace correct native behavior with a worse imitation.

## Verified end to end

Bundled the **real** `AppLink` (post-fix) into an Electron window on a `file://` origin and sent an actual middle click:

| adapter | result |
|---|---|
| with `openInNewTab` (desktop) | `openInNewTab("/acme/issues/MUL-1234", "MUL-1234", activate=undefined)` — background tab. **No window-open reached `setWindowOpenHandler`; no `[security] blocked openExternal`.** |
| without `openInNewTab` (web) | event left untouched, native background-tab request raised as before |

All six surfaces in the acceptance criteria (sub-issue row, list row, board card, gantt bar, parent breadcrumb, content mention) route through `AppLink`, so they are all covered by this one change.

## Tests

10 new cases in `app-link.test.tsx`: background-tab open with `preventDefault`, `newTabTitle` pass-through, the no-adapter web branch asserting default is *not* prevented, `target="_blank"` staying background, non-middle aux clicks (buttons 2/3/4) ignored, and the caller's `onAuxClick` running with `preventDefault` as an opt-out.

`fireEvent` has no `auxClick` helper in this version of Testing Library, so the tests dispatch a real `MouseEvent("auxclick")` — same approach as the existing `use-row-link.test.tsx`.

## Checks

- `pnpm vitest run navigation/` — 31 passed
- `pnpm typecheck` — 6/6 successful
- `pnpm lint` (views) — 0 errors, no findings in changed files
- Full `packages/views` suite — 3213 passed, 1 failed: `layout/sidebar-resize.test.tsx`, which fails identically on a clean tree (pre-existing, unrelated)

## Note for the follow-ups

`PickerWrapper` in `board-card.tsx` stops `click`/`mousedown`/`pointerdown` but not `auxclick`, so middle-clicking a picker inside a board card now opens the card's issue in a background tab. That is exactly what web already does today, so this makes desktop match rather than diverge — left as is, flagging it in case MUL-5462 wants to tighten it.
