### PR TITLE
fix(issues): confirm successful task cancellation

### DIFF
--- a/packages/views/issues/components/execution-log-section.test.tsx
+++ b/packages/views/issues/components/execution-log-section.test.tsx
@@ -1,12 +1,20 @@
 // @vitest-environment jsdom
 
-import { cleanup, screen } from "@testing-library/react";
+import { act, cleanup, fireEvent, screen } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { AgentTask } from "@multica/core/types";
+import { toast } from "sonner";
 import { renderWithI18n } from "../../test/i18n";
 
 const mockState = vi.hoisted(() => ({
+  cancelTask: vi.fn(),
   taskMessagesOptions: vi.fn(),
+}));
+
+vi.mock("@multica/core/api", () => ({
+  api: {
+    cancelTask: mockState.cancelTask,
+  },
 }));
 
 vi.mock("@multica/core/chat/queries", () => ({
@@ -24,7 +32,18 @@ vi.mock("../../common/task-transcript", () => ({
 }));
 
 vi.mock("./terminate-task-confirm-dialog", () => ({
-  TerminateTaskConfirmDialog: () => null,
+  TerminateTaskConfirmDialog: ({
+    open,
+    onConfirm,
+  }: {
+    open: boolean;
+    onConfirm: () => void;
+  }) =>
+    open ? (
+      <button type="button" onClick={onConfirm}>
+        Confirm stop
+      </button>
+    ) : null,
 }));
 
 import { ActiveTaskRow, TaskCommentCoverage } from "./execution-log-section";
@@ -56,10 +75,27 @@ beforeEach(() => {
 });
 
 afterEach(() => {
+  vi.restoreAllMocks();
   vi.useRealTimers();
 });
 
 describe("ActiveTaskRow", () => {
+  it("confirms a successful task cancellation", async () => {
+    mockState.cancelTask.mockResolvedValue(undefined);
+    const successToast = vi.spyOn(toast, "success").mockReturnValue("toast-id");
+
+    renderWithI18n(<ActiveTaskRow task={makeTask()} issueId="issue-1" />);
+    fireEvent.click(screen.getByRole("button", { name: "Cancel task" }));
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: "Confirm stop" }));
+      await Promise.resolve();
+    });
+
+    expect(mockState.cancelTask).toHaveBeenCalledWith("issue-1", "task-1");
+    expect(successToast).toHaveBeenCalledWith("Task cancelled");
+  });
+
   it("renders running status as elapsed time only", () => {
     renderWithI18n(
       <ActiveTaskRow

--- a/packages/views/issues/components/execution-log-section.tsx
+++ b/packages/views/issues/components/execution-log-section.tsx
@@ -291,6 +291,7 @@ export function ActiveTaskRow({
     setCancelling(true);
     try {
       await api.cancelTask(issueId, task.id);
+      toast.success(t(($) => $.execution_log.cancel_success));
     } catch (e) {
       toast.error(e instanceof Error ? e.message : t(($) => $.execution_log.cancel_failed));
       setCancelling(false);

--- a/packages/views/locales/en/issues.json
+++ b/packages/views/locales/en/issues.json
@@ -464,6 +464,7 @@
     "retry_failed": "Failed to retry task",
     "retry_blocked": "Not retried — you don't have permission to use this agent",
     "transcript_tooltip": "View transcript",
+    "cancel_success": "Task cancelled",
     "cancel_failed": "Failed to cancel task",
     "trigger_retry": "Retry",
     "trigger_retry_attempt": "Retry #{{attempt}}",

--- a/packages/views/locales/ja/issues.json
+++ b/packages/views/locales/ja/issues.json
@@ -444,6 +444,7 @@
     "retry_failed": "タスクを再試行できませんでした",
     "retry_blocked": "再試行されませんでした — このエージェントを使用する権限がありません",
     "transcript_tooltip": "トランスクリプトを表示",
+    "cancel_success": "タスクをキャンセルしました",
     "cancel_failed": "タスクをキャンセルできませんでした",
     "trigger_retry": "再試行",
     "trigger_retry_attempt": "再試行 #{{attempt}}",

--- a/packages/views/locales/ko/issues.json
+++ b/packages/views/locales/ko/issues.json
@@ -444,6 +444,7 @@
     "retry_failed": "작업을 다시 시도하지 못했습니다",
     "retry_blocked": "다시 시도되지 않음 — 이 에이전트를 사용할 권한이 없습니다",
     "transcript_tooltip": "트랜스크립트 보기",
+    "cancel_success": "작업을 취소했습니다",
     "cancel_failed": "작업을 취소하지 못했습니다",
     "trigger_retry": "다시 시도",
     "trigger_retry_attempt": "{{attempt}}번째 다시 시도",

--- a/packages/views/locales/zh-Hans/issues.json
+++ b/packages/views/locales/zh-Hans/issues.json
@@ -444,6 +444,7 @@
     "retry_failed": "重试 task 失败",
     "retry_blocked": "未重试——你没有该智能体的使用权限",
     "transcript_tooltip": "查看记录",
+    "cancel_success": "已取消 task",
     "cancel_failed": "取消 task 失败",
     "trigger_retry": "重试",
     "trigger_retry_attempt": "重试 #{{attempt}}",


### PR DESCRIPTION
## What does this PR do?

Adds a success toast after a user confirms task cancellation and the cancellation API resolves. The existing failure toast remains unchanged.

Thinking path: the retry action in this execution-log surface confirms successful user actions, while cancellation currently reports only failures. `cancelTask` resolves after the backend persists the task as `cancelled`, so “Task cancelled” accurately reflects the completed result. Server-driven automatic retries are intentionally out of scope: attempts already remain visible in execution history, while transient background toasts could be missed or become noisy.

## Related Issue

No matching upstream issue or open PR was found. Reproduction and scope were tracked in [Jetiaime/multica#6](https://github.com/Jetiaime/multica/issues/6).

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Refactor / code improvement (no behavior change)
- [ ] Documentation update
- [x] Tests (adding or improving test coverage)
- [ ] CI / infrastructure

## Changes Made

- Show the localized cancellation success toast from `ActiveTaskRow` after `api.cancelTask` resolves.
- Add focused coverage for the confirm → cancel API → success toast flow.
- Add matching English, Japanese, Korean, and Simplified Chinese locale entries.

## How to Test

1. Start the app and open an issue with an active task.
2. Cancel the task and confirm the destructive action.
3. Verify the task moves into execution history and the localized success toast appears.

Local verification on current `upstream/main`:

- Views Vitest suite: 273 files / 3,223 tests passed.
- Focused component test: 15 tests passed.
- Locale parity: 160 tests passed.
- TypeScript: `tsc --noEmit` passed.
- ESLint: the changed component and test passed.
- Real local UI cancellation persisted the task as `cancelled` with `completed_at` set.

The fork PR also completed all GitHub CI checks before merge: [Jetiaime/multica#9](https://github.com/Jetiaime/multica/pull/9).

Risk is limited to one additional toast after an already-successful API call; cancellation behavior and error handling are unchanged.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] If this change affects the UI, I have included before/after screenshots
- [ ] I have updated relevant documentation to reflect my changes
- [ ] If I added a new runtime / coding tool / UI tab, I synced the change to **landing copy** (`apps/web/features/landing/i18n/`) and **relevant docs** (`apps/docs/content/docs/`)
- [x] If this PR touches Chinese product copy, I checked it against `apps/docs/content/docs/developers/conventions.zh.mdx` (terminology, mixed-rule for `task` / `issue` / `skill`)
- [x] I have considered and documented any risks above
- [x] I will address all reviewer comments before requesting merge

## AI Disclosure

**AI tool used:** OpenAI Codex

**Prompt / approach:**
Used Codex to trace the cancellation and automatic-retry paths, search existing upstream issues/PRs, implement the smallest cancellation-only change test-first, run the repository checks, and validate the behavior against a locally running multica instance. I reviewed the final diff and UI result before submission.

## Screenshots (optional)

Before — active task awaiting cancellation:

![Active task before cancellation](https://raw.githubusercontent.com/Jetiaime/multica/pr-assets/cancel-task-feedback/before.png)

After — backend-confirmed cancellation with localized success feedback:

![Successful task cancellation toast](https://raw.githubusercontent.com/Jetiaime/multica/pr-assets/cancel-task-feedback/after.png)
