### PR TITLE
MUL-5491: feat(metrics): add MiniMax-M3 to pricing registry

### DIFF
--- a/server/internal/metrics/pricing.go
+++ b/server/internal/metrics/pricing.go
@@ -52,9 +52,11 @@ var modelPrices = map[string]ModelPrice{
 	"anthropic:claude-haiku-4.5":  {Provider: "anthropic", Model: "claude-haiku-4.5", InputPerM: 1.00, CacheReadPerM: 0.10, CacheWritePerM: 1.25, OutputPerM: 5.00},
 	"deepseek:v4-pro":             {Provider: "deepseek", Model: "v4-pro", InputPerM: 1.74, CacheReadPerM: 0.0145, CacheWritePerM: 1.74, OutputPerM: 3.48},
 	"deepseek:v4-flash":           {Provider: "deepseek", Model: "v4-flash", InputPerM: 0.56, CacheReadPerM: 0.0112, CacheWritePerM: 0.56, OutputPerM: 1.12},
-	// MiniMax-M3 (platform.minimax.io): input $0.60, output $2.40, cache read
-	// $0.12 (0.2x input). MiniMax lists no separate cache-write rate, so writes
-	// mirror the input rate instead of being treated as free.
+	// MiniMax-M3 (platform.minimax.io/subscribe/token-plan?tab=api-enterprise).
+	// The target configuration exposes the full 1M-token context window, so this
+	// row uses the >512K tier: input $0.60, output $2.40, cache read $0.12. MiniMax
+	// lists no separate cache-write rate, so writes mirror input instead of being
+	// treated as free.
 	"minimax:m3":              {Provider: "minimax", Model: "m3", InputPerM: 0.60, CacheReadPerM: 0.12, CacheWritePerM: 0.60, OutputPerM: 2.40},
 	"minimax:m2.7":            {Provider: "minimax", Model: "m2.7", InputPerM: 0.30, CacheReadPerM: 0.06, CacheWritePerM: 0.375, OutputPerM: 1.20},
 	"minimax:m2.7-highspeed":  {Provider: "minimax", Model: "m2.7-highspeed", InputPerM: 0.60, CacheReadPerM: 0.06, CacheWritePerM: 0.375, OutputPerM: 2.40},

--- a/server/internal/metrics/pricing.go
+++ b/server/internal/metrics/pricing.go
@@ -52,10 +52,10 @@ var modelPrices = map[string]ModelPrice{
 	"anthropic:claude-haiku-4.5":  {Provider: "anthropic", Model: "claude-haiku-4.5", InputPerM: 1.00, CacheReadPerM: 0.10, CacheWritePerM: 1.25, OutputPerM: 5.00},
 	"deepseek:v4-pro":             {Provider: "deepseek", Model: "v4-pro", InputPerM: 1.74, CacheReadPerM: 0.0145, CacheWritePerM: 1.74, OutputPerM: 3.48},
 	"deepseek:v4-flash":           {Provider: "deepseek", Model: "v4-flash", InputPerM: 0.56, CacheReadPerM: 0.0112, CacheWritePerM: 0.56, OutputPerM: 1.12},
-	// MiniMax-M3 (api.minimax.io): input $0.60, output $2.40, cache read $0.12
-	// (0.2x input). MiniMax does not list a separate cache-write charge for M3,
-	// so leave CacheWritePerM at zero rather than inferring one.
-	"minimax:m3":              {Provider: "minimax", Model: "m3", InputPerM: 0.60, CacheReadPerM: 0.12, CacheWritePerM: 0, OutputPerM: 2.40},
+	// MiniMax-M3 (platform.minimax.io): input $0.60, output $2.40, cache read
+	// $0.12 (0.2x input). MiniMax lists no separate cache-write rate, so writes
+	// mirror the input rate instead of being treated as free.
+	"minimax:m3":              {Provider: "minimax", Model: "m3", InputPerM: 0.60, CacheReadPerM: 0.12, CacheWritePerM: 0.60, OutputPerM: 2.40},
 	"minimax:m2.7":            {Provider: "minimax", Model: "m2.7", InputPerM: 0.30, CacheReadPerM: 0.06, CacheWritePerM: 0.375, OutputPerM: 1.20},
 	"minimax:m2.7-highspeed":  {Provider: "minimax", Model: "m2.7-highspeed", InputPerM: 0.60, CacheReadPerM: 0.06, CacheWritePerM: 0.375, OutputPerM: 2.40},
 	"google:gemini-3-flash":   {Provider: "google", Model: "gemini-3-flash", InputPerM: 0.50, CacheReadPerM: 0.05, CacheWritePerM: 0.50, OutputPerM: 3.00},

--- a/server/internal/metrics/pricing.go
+++ b/server/internal/metrics/pricing.go
@@ -53,11 +53,9 @@ var modelPrices = map[string]ModelPrice{
 	"deepseek:v4-pro":             {Provider: "deepseek", Model: "v4-pro", InputPerM: 1.74, CacheReadPerM: 0.0145, CacheWritePerM: 1.74, OutputPerM: 3.48},
 	"deepseek:v4-flash":           {Provider: "deepseek", Model: "v4-flash", InputPerM: 0.56, CacheReadPerM: 0.0112, CacheWritePerM: 0.56, OutputPerM: 1.12},
 	// MiniMax-M3 (api.minimax.io): input $0.60, output $2.40, cache read $0.12
-	// (0.2x input). Unlike M2.7, MiniMax publishes no separate cache-write rate
-	// for M3, so cache-write tokens bill at the input rate — the same way the
-	// Google, DeepSeek, and xAI rows in this table encode a missing cache-write
-	// rate.
-	"minimax:m3":              {Provider: "minimax", Model: "m3", InputPerM: 0.60, CacheReadPerM: 0.12, CacheWritePerM: 0.60, OutputPerM: 2.40},
+	// (0.2x input). MiniMax does not list a separate cache-write charge for M3,
+	// so leave CacheWritePerM at zero rather than inferring one.
+	"minimax:m3":              {Provider: "minimax", Model: "m3", InputPerM: 0.60, CacheReadPerM: 0.12, CacheWritePerM: 0, OutputPerM: 2.40},
 	"minimax:m2.7":            {Provider: "minimax", Model: "m2.7", InputPerM: 0.30, CacheReadPerM: 0.06, CacheWritePerM: 0.375, OutputPerM: 1.20},
 	"minimax:m2.7-highspeed":  {Provider: "minimax", Model: "m2.7-highspeed", InputPerM: 0.60, CacheReadPerM: 0.06, CacheWritePerM: 0.375, OutputPerM: 2.40},
 	"google:gemini-3-flash":   {Provider: "google", Model: "gemini-3-flash", InputPerM: 0.50, CacheReadPerM: 0.05, CacheWritePerM: 0.50, OutputPerM: 3.00},
@@ -115,7 +113,7 @@ var modelAliasRules = []struct {
 	{regexp.MustCompile(`deepseek-v4-flash|^deepseek-chat$|^deepseek-reasoner$`), "deepseek:v4-flash"},
 	{regexp.MustCompile(`minimax-m2[.]7.*highspeed|highspeed.*minimax-m2[.]7`), "minimax:m2.7-highspeed"},
 	{regexp.MustCompile(`minimax-m2[.]7`), "minimax:m2.7"},
-	{regexp.MustCompile(`minimax-m3`), "minimax:m3"},
+	{regexp.MustCompile(`(^|/|:)minimax-m3$`), "minimax:m3"},
 	{regexp.MustCompile(`gemini-3-flash`), "google:gemini-3-flash"},
 	{regexp.MustCompile(`gemini-3[.]1-pro`), "google:gemini-3.1-pro"},
 	{regexp.MustCompile(`gemini-2[.]5-pro`), "google:gemini-2.5-pro"},

--- a/server/internal/metrics/pricing.go
+++ b/server/internal/metrics/pricing.go
@@ -52,12 +52,18 @@ var modelPrices = map[string]ModelPrice{
 	"anthropic:claude-haiku-4.5":  {Provider: "anthropic", Model: "claude-haiku-4.5", InputPerM: 1.00, CacheReadPerM: 0.10, CacheWritePerM: 1.25, OutputPerM: 5.00},
 	"deepseek:v4-pro":             {Provider: "deepseek", Model: "v4-pro", InputPerM: 1.74, CacheReadPerM: 0.0145, CacheWritePerM: 1.74, OutputPerM: 3.48},
 	"deepseek:v4-flash":           {Provider: "deepseek", Model: "v4-flash", InputPerM: 0.56, CacheReadPerM: 0.0112, CacheWritePerM: 0.56, OutputPerM: 1.12},
-	"minimax:m2.7":                {Provider: "minimax", Model: "m2.7", InputPerM: 0.30, CacheReadPerM: 0.06, CacheWritePerM: 0.375, OutputPerM: 1.20},
-	"minimax:m2.7-highspeed":      {Provider: "minimax", Model: "m2.7-highspeed", InputPerM: 0.60, CacheReadPerM: 0.06, CacheWritePerM: 0.375, OutputPerM: 2.40},
-	"google:gemini-3-flash":       {Provider: "google", Model: "gemini-3-flash", InputPerM: 0.50, CacheReadPerM: 0.05, CacheWritePerM: 0.50, OutputPerM: 3.00},
-	"google:gemini-3.1-pro":       {Provider: "google", Model: "gemini-3.1-pro", InputPerM: 2.00, CacheReadPerM: 0.20, CacheWritePerM: 2.00, OutputPerM: 12.00},
-	"google:gemini-2.5-pro":       {Provider: "google", Model: "gemini-2.5-pro", InputPerM: 1.25, CacheReadPerM: 0.31, CacheWritePerM: 1.25, OutputPerM: 10.00},
-	"google:gemini-2.5-flash":     {Provider: "google", Model: "gemini-2.5-flash", InputPerM: 0.30, CacheReadPerM: 0.03, CacheWritePerM: 0.30, OutputPerM: 2.50},
+	// MiniMax-M3 (api.minimax.io): input $0.60, output $2.40, cache read $0.12
+	// (0.2x input). Unlike M2.7, MiniMax publishes no separate cache-write rate
+	// for M3, so cache-write tokens bill at the input rate — the same way the
+	// Google, DeepSeek, and xAI rows in this table encode a missing cache-write
+	// rate.
+	"minimax:m3":              {Provider: "minimax", Model: "m3", InputPerM: 0.60, CacheReadPerM: 0.12, CacheWritePerM: 0.60, OutputPerM: 2.40},
+	"minimax:m2.7":            {Provider: "minimax", Model: "m2.7", InputPerM: 0.30, CacheReadPerM: 0.06, CacheWritePerM: 0.375, OutputPerM: 1.20},
+	"minimax:m2.7-highspeed":  {Provider: "minimax", Model: "m2.7-highspeed", InputPerM: 0.60, CacheReadPerM: 0.06, CacheWritePerM: 0.375, OutputPerM: 2.40},
+	"google:gemini-3-flash":   {Provider: "google", Model: "gemini-3-flash", InputPerM: 0.50, CacheReadPerM: 0.05, CacheWritePerM: 0.50, OutputPerM: 3.00},
+	"google:gemini-3.1-pro":   {Provider: "google", Model: "gemini-3.1-pro", InputPerM: 2.00, CacheReadPerM: 0.20, CacheWritePerM: 2.00, OutputPerM: 12.00},
+	"google:gemini-2.5-pro":   {Provider: "google", Model: "gemini-2.5-pro", InputPerM: 1.25, CacheReadPerM: 0.31, CacheWritePerM: 1.25, OutputPerM: 10.00},
+	"google:gemini-2.5-flash": {Provider: "google", Model: "gemini-2.5-flash", InputPerM: 0.30, CacheReadPerM: 0.03, CacheWritePerM: 0.30, OutputPerM: 2.50},
 	// xAI Grok (docs.x.ai/developers/pricing). Short-context tier: xAI bills
 	// a request at 2x once its prompt reaches 200K tokens, but a usage record
 	// aggregates every model call in a turn, so it cannot say which tier any
@@ -109,6 +115,7 @@ var modelAliasRules = []struct {
 	{regexp.MustCompile(`deepseek-v4-flash|^deepseek-chat$|^deepseek-reasoner$`), "deepseek:v4-flash"},
 	{regexp.MustCompile(`minimax-m2[.]7.*highspeed|highspeed.*minimax-m2[.]7`), "minimax:m2.7-highspeed"},
 	{regexp.MustCompile(`minimax-m2[.]7`), "minimax:m2.7"},
+	{regexp.MustCompile(`minimax-m3`), "minimax:m3"},
 	{regexp.MustCompile(`gemini-3-flash`), "google:gemini-3-flash"},
 	{regexp.MustCompile(`gemini-3[.]1-pro`), "google:gemini-3.1-pro"},
 	{regexp.MustCompile(`gemini-2[.]5-pro`), "google:gemini-2.5-pro"},

--- a/server/internal/metrics/pricing_test.go
+++ b/server/internal/metrics/pricing_test.go
@@ -182,11 +182,11 @@ func TestPriceForModelAliasGrok(t *testing.T) {
 	}
 }
 
-// TestPriceForModelAliasMinimaxM3 pins the MiniMax-M3 row to its current
-// published rates (input $0.60, output $2.40, cache read $0.12 = 0.2x input).
-// M3 has no separate cache-write rate, so writes mirror input. The alias must
-// resolve M3 without borrowing the older M2.7 row, and M2.7 must keep its own
-// distinct rates.
+// TestPriceForModelAliasMinimaxM3 pins the MiniMax-M3 row to the >512K tier
+// used by the full 1M-token target configuration (input $0.60, output $2.40,
+// cache read $0.12). M3 has no separate cache-write rate, so writes mirror
+// input. The alias must resolve M3 without borrowing the older M2.7 row, and
+// M2.7 must keep its own distinct rates.
 func TestPriceForModelAliasMinimaxM3(t *testing.T) {
 	cases := []struct {
 		model string

--- a/server/internal/metrics/pricing_test.go
+++ b/server/internal/metrics/pricing_test.go
@@ -184,9 +184,8 @@ func TestPriceForModelAliasGrok(t *testing.T) {
 
 // TestPriceForModelAliasMinimaxM3 pins the MiniMax-M3 row to its current
 // published rates (input $0.60, output $2.40, cache read $0.12 = 0.2x input).
-// M3 has no separate cache-write rate, so writes bill at the input rate. The
-// alias must resolve M3 without borrowing the older M2.7 row, and M2.7 must
-// keep its own distinct rates.
+// M3 has no listed cache-write charge. The alias must resolve M3 without
+// borrowing the older M2.7 row, and M2.7 must keep its own distinct rates.
 func TestPriceForModelAliasMinimaxM3(t *testing.T) {
 	cases := []struct {
 		model string
@@ -194,15 +193,15 @@ func TestPriceForModelAliasMinimaxM3(t *testing.T) {
 	}{
 		{
 			model: "minimax-m3",
-			want:  ModelPrice{Provider: "minimax", Model: "m3", InputPerM: 0.6, CacheReadPerM: 0.12, CacheWritePerM: 0.6, OutputPerM: 2.4},
+			want:  ModelPrice{Provider: "minimax", Model: "m3", InputPerM: 0.6, CacheReadPerM: 0.12, CacheWritePerM: 0, OutputPerM: 2.4},
 		},
 		{
 			model: "codebuddy/minimax-m3",
-			want:  ModelPrice{Provider: "minimax", Model: "m3", InputPerM: 0.6, CacheReadPerM: 0.12, CacheWritePerM: 0.6, OutputPerM: 2.4},
+			want:  ModelPrice{Provider: "minimax", Model: "m3", InputPerM: 0.6, CacheReadPerM: 0.12, CacheWritePerM: 0, OutputPerM: 2.4},
 		},
 		{
 			model: "MiniMax-M3",
-			want:  ModelPrice{Provider: "minimax", Model: "m3", InputPerM: 0.6, CacheReadPerM: 0.12, CacheWritePerM: 0.6, OutputPerM: 2.4},
+			want:  ModelPrice{Provider: "minimax", Model: "m3", InputPerM: 0.6, CacheReadPerM: 0.12, CacheWritePerM: 0, OutputPerM: 2.4},
 		},
 		// The older M2.7 row must stay separate and keep its distinct rates.
 		{
@@ -218,6 +217,12 @@ func TestPriceForModelAliasMinimaxM3(t *testing.T) {
 		}
 		if got != tc.want {
 			t.Fatalf("PriceForModelAlias(%q) = %+v, want %+v", tc.model, got, tc.want)
+		}
+	}
+
+	for _, model := range []string{"minimax-m3.5", "minimax-m3-highspeed", "some-vendor/minimax-m3-preview"} {
+		if got, ok := PriceForModelAlias(model); ok {
+			t.Fatalf("PriceForModelAlias(%q) unexpectedly resolved to %+v; want unmapped", model, got)
 		}
 	}
 }

--- a/server/internal/metrics/pricing_test.go
+++ b/server/internal/metrics/pricing_test.go
@@ -184,8 +184,9 @@ func TestPriceForModelAliasGrok(t *testing.T) {
 
 // TestPriceForModelAliasMinimaxM3 pins the MiniMax-M3 row to its current
 // published rates (input $0.60, output $2.40, cache read $0.12 = 0.2x input).
-// M3 has no listed cache-write charge. The alias must resolve M3 without
-// borrowing the older M2.7 row, and M2.7 must keep its own distinct rates.
+// M3 has no separate cache-write rate, so writes mirror input. The alias must
+// resolve M3 without borrowing the older M2.7 row, and M2.7 must keep its own
+// distinct rates.
 func TestPriceForModelAliasMinimaxM3(t *testing.T) {
 	cases := []struct {
 		model string
@@ -193,15 +194,15 @@ func TestPriceForModelAliasMinimaxM3(t *testing.T) {
 	}{
 		{
 			model: "minimax-m3",
-			want:  ModelPrice{Provider: "minimax", Model: "m3", InputPerM: 0.6, CacheReadPerM: 0.12, CacheWritePerM: 0, OutputPerM: 2.4},
+			want:  ModelPrice{Provider: "minimax", Model: "m3", InputPerM: 0.6, CacheReadPerM: 0.12, CacheWritePerM: 0.6, OutputPerM: 2.4},
 		},
 		{
 			model: "codebuddy/minimax-m3",
-			want:  ModelPrice{Provider: "minimax", Model: "m3", InputPerM: 0.6, CacheReadPerM: 0.12, CacheWritePerM: 0, OutputPerM: 2.4},
+			want:  ModelPrice{Provider: "minimax", Model: "m3", InputPerM: 0.6, CacheReadPerM: 0.12, CacheWritePerM: 0.6, OutputPerM: 2.4},
 		},
 		{
 			model: "MiniMax-M3",
-			want:  ModelPrice{Provider: "minimax", Model: "m3", InputPerM: 0.6, CacheReadPerM: 0.12, CacheWritePerM: 0, OutputPerM: 2.4},
+			want:  ModelPrice{Provider: "minimax", Model: "m3", InputPerM: 0.6, CacheReadPerM: 0.12, CacheWritePerM: 0.6, OutputPerM: 2.4},
 		},
 		// The older M2.7 row must stay separate and keep its distinct rates.
 		{

--- a/server/internal/metrics/pricing_test.go
+++ b/server/internal/metrics/pricing_test.go
@@ -182,6 +182,46 @@ func TestPriceForModelAliasGrok(t *testing.T) {
 	}
 }
 
+// TestPriceForModelAliasMinimaxM3 pins the MiniMax-M3 row to its current
+// published rates (input $0.60, output $2.40, cache read $0.12 = 0.2x input).
+// M3 has no separate cache-write rate, so writes bill at the input rate. The
+// alias must resolve M3 without borrowing the older M2.7 row, and M2.7 must
+// keep its own distinct rates.
+func TestPriceForModelAliasMinimaxM3(t *testing.T) {
+	cases := []struct {
+		model string
+		want  ModelPrice
+	}{
+		{
+			model: "minimax-m3",
+			want:  ModelPrice{Provider: "minimax", Model: "m3", InputPerM: 0.6, CacheReadPerM: 0.12, CacheWritePerM: 0.6, OutputPerM: 2.4},
+		},
+		{
+			model: "codebuddy/minimax-m3",
+			want:  ModelPrice{Provider: "minimax", Model: "m3", InputPerM: 0.6, CacheReadPerM: 0.12, CacheWritePerM: 0.6, OutputPerM: 2.4},
+		},
+		{
+			model: "MiniMax-M3",
+			want:  ModelPrice{Provider: "minimax", Model: "m3", InputPerM: 0.6, CacheReadPerM: 0.12, CacheWritePerM: 0.6, OutputPerM: 2.4},
+		},
+		// The older M2.7 row must stay separate and keep its distinct rates.
+		{
+			model: "minimax-m2.7",
+			want:  ModelPrice{Provider: "minimax", Model: "m2.7", InputPerM: 0.3, CacheReadPerM: 0.06, CacheWritePerM: 0.375, OutputPerM: 1.2},
+		},
+	}
+
+	for _, tc := range cases {
+		got, ok := PriceForModelAlias(tc.model)
+		if !ok {
+			t.Fatalf("PriceForModelAlias(%q) did not resolve", tc.model)
+		}
+		if got != tc.want {
+			t.Fatalf("PriceForModelAlias(%q) = %+v, want %+v", tc.model, got, tc.want)
+		}
+	}
+}
+
 // TestGrokPricingMatchesRecordedTurn re-derives the cost of a real
 // grok 0.2.106 turn from the table and checks it against the costUsdTicks xAI
 // returned for that same turn (1 tick = 1e-10 USD). This is the end-to-end


### PR DESCRIPTION
Reason: The backend pricing registry maps MiniMax-M2.7 but has no MiniMax-M3 row or alias, so usage from MiniMax-M3 falls into the unpriced bucket.

## What changed

- Added a `minimax:m3` row to `modelPrices` in `server/internal/metrics/pricing.go` with input $0.60/M, output $2.40/M, and cache read $0.12/M. MiniMax does not list a separate cache-write rate for M3, so `CacheWritePerM` mirrors the input rate instead of treating cache writes as free.
- Added an anchored MiniMax-M3 alias rule that accepts bare and provider-prefixed IDs while leaving unknown variants unmapped.
- Added `TestPriceForModelAliasMinimaxM3` in `server/internal/metrics/pricing_test.go` covering bare, path-prefixed, and mixed-case IDs, unknown M3 variants, and the existing M2.7 rates.

This PR is limited to server-side cost metrics; it does not change the separate user-facing usage-page pricing table.

## Checks

- `gofmt -l server/internal/metrics/pricing.go server/internal/metrics/pricing_test.go` (clean)
- `go vet ./internal/metrics` (run from `server/`)
- `go test ./internal/metrics` (run from `server/`)