### PR TITLE
feat(issues): open sub-issue rows and the parent issue as references (MUL-5458)

### DIFF
--- a/packages/views/issues/components/issue-detail.test.tsx
+++ b/packages/views/issues/components/issue-detail.test.tsx
@@ -107,20 +107,24 @@ vi.mock("@multica/core/paths", async () => {
   };
 });
 
-// Mock navigation
-vi.mock("../../navigation", () => ({
-  AppLink: ({ children, href, ...props }: any) => (
-    <a href={href} {...props}>
-      {children}
-    </a>
-  ),
-  useNavigation: () => ({
-    push: vi.fn(),
-    pathname: "/issues/issue-1",
-    getShareableUrl: (p: string) => `https://app.multica.com${p}`,
-  }),
-  useBackOrReplace: () => vi.fn(),
-  NavigationProvider: ({ children }: { children: React.ReactNode }) => children,
+// Navigation is NOT mocked: the real AppLink and NavigationProvider run, with
+// a fake adapter standing in for the platform. Where a sub-issue row or the
+// parent breadcrumb lands is decided inside AppLink, so a stub anchor here
+// would only prove that props were forwarded, never that a click opens a tab.
+//
+// `openInNewTab` is the platform switch — defined on desktop, deliberately
+// undefined on web so real anchors keep their native behaviour. Tests set it
+// per case; `beforeEach` resets it to the web shape.
+const navigationAdapter = vi.hoisted(() => ({
+  push: vi.fn(),
+  replace: vi.fn(),
+  back: vi.fn(),
+  pathname: "/test/issues/issue-1",
+  searchParams: new URLSearchParams(),
+  getShareableUrl: (p: string) => `https://app.multica.com${p}`,
+  openInNewTab: undefined as
+    | undefined
+    | ((path: string, title?: string, opts?: { activate?: boolean }) => void),
 }));
 
 // Mock editor components (Tiptap requires real DOM)
@@ -551,6 +555,7 @@ const mockTimeline: TimelineEntry[] = [
 // ---------------------------------------------------------------------------
 
 import { IssueDetail, groupSubIssuesByStage } from "./issue-detail";
+import { NavigationProvider } from "../../navigation";
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -565,15 +570,24 @@ function createTestQueryClient() {
   });
 }
 
+/**
+ * Every render of IssueDetail goes through here. NavigationProvider is not
+ * optional scaffolding: IssueDetail calls useBackOrReplace, and its AppLinks
+ * read the adapter to decide whether a click navigates or opens a tab.
+ */
+function withProviders(queryClient: QueryClient, ui: React.ReactNode) {
+  return (
+    <I18nProvider locale="en" resources={TEST_RESOURCES}>
+      <NavigationProvider value={navigationAdapter}>
+        <QueryClientProvider client={queryClient}>{ui}</QueryClientProvider>
+      </NavigationProvider>
+    </I18nProvider>
+  );
+}
+
 function renderIssueDetail(issueId = "issue-1") {
   const queryClient = createTestQueryClient();
-  return render(
-    <I18nProvider locale="en" resources={TEST_RESOURCES}>
-      <QueryClientProvider client={queryClient}>
-        <IssueDetail issueId={issueId} />
-      </QueryClientProvider>
-    </I18nProvider>,
-  );
+  return render(withProviders(queryClient, <IssueDetail issueId={issueId} />));
 }
 
 function renderIssueDetailWithHighlight(
@@ -591,11 +605,10 @@ function renderIssueDetailWithHighlight(
     queryClient.setQueryData(["issues", "timeline", issueId], mockTimeline);
   }
   const result = render(
-    <I18nProvider locale="en" resources={TEST_RESOURCES}>
-      <QueryClientProvider client={queryClient}>
-        <IssueDetail issueId={issueId} highlightCommentId={highlightCommentId} />
-      </QueryClientProvider>
-    </I18nProvider>,
+    withProviders(
+      queryClient,
+      <IssueDetail issueId={issueId} highlightCommentId={highlightCommentId} />,
+    ),
   );
   return { ...result, queryClient };
 }
@@ -624,6 +637,8 @@ describe("IssueDetail (shared)", () => {
     vi.clearAllMocks();
     contentEditorMounts.count = 0;
     mockViewport.isMobile = false;
+    // Web shape by default — no adapter, so real anchors keep native behaviour.
+    navigationAdapter.openInNewTab = undefined;
     // Default: issue loads successfully
     mockApiObj.getIssue.mockResolvedValue(mockIssue);
     // /timeline returns the entries flat in chronological order (oldest first).
@@ -713,13 +728,8 @@ describe("IssueDetail (shared)", () => {
     );
     // Pre-seed issue-2 so its first render skips the loading skeleton.
     queryClient.setQueryData(["issues", "ws-1", "detail", "issue-2"], issue2);
-    const ui = (issueId: string) => (
-      <I18nProvider locale="en" resources={TEST_RESOURCES}>
-        <QueryClientProvider client={queryClient}>
-          <IssueDetail issueId={issueId} />
-        </QueryClientProvider>
-      </I18nProvider>
-    );
+    const ui = (issueId: string) =>
+      withProviders(queryClient, <IssueDetail issueId={issueId} />);
     const { rerender } = render(ui("issue-1"));
 
     await screen.findByDisplayValue("Add JWT auth to the backend");
@@ -1413,11 +1423,10 @@ describe("IssueDetail (shared)", () => {
 
       const queryClient = createTestQueryClient();
       render(
-        <I18nProvider locale="en" resources={TEST_RESOURCES}>
-          <QueryClientProvider client={queryClient}>
-            <IssueDetail issueId="issue-1" highlightCommentId="reply-1" />
-          </QueryClientProvider>
-        </I18nProvider>,
+        withProviders(
+          queryClient,
+          <IssueDetail issueId="issue-1" highlightCommentId="reply-1" />,
+        ),
       );
 
       // After expansion, the reply must appear in the DOM (inside the now
@@ -1611,6 +1620,196 @@ describe("IssueDetail (shared)", () => {
       const due = screen.getByText("Jan 1");
       expect(due.closest("span")?.className).not.toContain("text-destructive");
       expect(due.closest("span")?.className).toContain("text-muted-foreground");
+    });
+
+    // A sub-issue row is a Reference, not Navigation: the list is part of the
+    // parent's reading context, so opening a child must not cost the reader
+    // their scroll position, expanded sections or comment draft. This is
+    // deliberately unlike an issue list row — see the rule at the top of
+    // packages/views/navigation/types.ts.
+    describe("opens as a reference, not in place", () => {
+      async function renderOneRow() {
+        mockApiObj.listChildIssues.mockResolvedValue({
+          issues: [
+            subIssue({
+              id: "child-1",
+              number: 11,
+              identifier: "TES-11",
+              title: "Fix login flow",
+            }),
+          ],
+        });
+        renderIssueDetail();
+        const title = await screen.findByText("Fix login flow");
+        const link = title.closest("a");
+        if (!link) throw new Error("sub-issue row is not a link");
+        return link;
+      }
+
+      it("opens a FOREGROUND tab on desktop and does not navigate in place", async () => {
+        const openInNewTab = vi.fn();
+        navigationAdapter.openInNewTab = openInNewTab;
+
+        fireEvent.click(await renderOneRow());
+
+        expect(openInNewTab).toHaveBeenCalledWith(
+          "/test/issues/child-1",
+          "TES-11",
+          { activate: true },
+        );
+        expect(navigationAdapter.push).not.toHaveBeenCalled();
+      });
+
+      it("leaves the click to the browser on web, where the anchor already opens a real tab", async () => {
+        // No adapter (web). The row must be a real anchor carrying target and
+        // a rel guard, and the click must reach the browser unprevented —
+        // window.open would flatten the modifier semantics the browser has.
+        const link = await renderOneRow();
+
+        expect(link).toHaveAttribute("href", "/test/issues/child-1");
+        expect(link).toHaveAttribute("target", "_blank");
+        expect(link).toHaveAttribute("rel", "noopener noreferrer");
+        // fireEvent returns false when preventDefault was called.
+        expect(fireEvent.click(link)).toBe(true);
+        expect(navigationAdapter.push).not.toHaveBeenCalled();
+      });
+
+      it("inverts to a BACKGROUND tab on cmd/ctrl-click", async () => {
+        const openInNewTab = vi.fn();
+        navigationAdapter.openInNewTab = openInNewTab;
+
+        fireEvent.click(await renderOneRow(), { metaKey: true });
+
+        // No `activate` — the modifier means "keep me where I am".
+        expect(openInNewTab).toHaveBeenCalledWith("/test/issues/child-1", "TES-11");
+        expect(navigationAdapter.push).not.toHaveBeenCalled();
+      });
+
+      it("inverts to a BACKGROUND tab on middle click", async () => {
+        const openInNewTab = vi.fn();
+        navigationAdapter.openInNewTab = openInNewTab;
+        const link = await renderOneRow();
+
+        // fireEvent has no auxClick helper, so dispatch the real event.
+        link.dispatchEvent(
+          new MouseEvent("auxclick", { bubbles: true, button: 1, cancelable: true }),
+        );
+
+        expect(openInNewTab).toHaveBeenCalledWith("/test/issues/child-1", "TES-11");
+        expect(navigationAdapter.push).not.toHaveBeenCalled();
+      });
+
+      it("keeps the inline pickers and the select checkbox off the navigation path", async () => {
+        // The pickers and checkbox are siblings of the AppLink, not children,
+        // so a click on them can never reach it. Guards the row's structure:
+        // nesting them inside the link would open a tab on every status edit.
+        const openInNewTab = vi.fn();
+        navigationAdapter.openInNewTab = openInNewTab;
+        const link = await renderOneRow();
+        const row = link.parentElement;
+
+        expect(row?.contains(screen.getByLabelText("Select TES-11"))).toBe(true);
+        expect(link.contains(screen.getByLabelText("Select TES-11"))).toBe(false);
+
+        fireEvent.click(screen.getByLabelText("Select TES-11"));
+        expect(openInNewTab).not.toHaveBeenCalled();
+        expect(navigationAdapter.push).not.toHaveBeenCalled();
+      });
+
+      it("still opens the shared actions menu on right-click, with a single Open in new tab item", async () => {
+        // The context menu is a surface-level singleton, so the row's own
+        // new-tab default must not have grown a second copy of the action.
+        const link = await renderOneRow();
+
+        fireEvent.contextMenu(link);
+
+        expect(await screen.findAllByText("Open in new tab")).toHaveLength(1);
+      });
+    });
+  });
+
+  // The parent issue is reachable from two places on this page and both are
+  // References for the same reason as the sub-issue rows — they point out of
+  // what the user is reading. The header breadcrumb is deliberately NOT one:
+  // an ancestor crumb is a "go up" affordance, so it stays in place.
+  describe("parent issue links", () => {
+    const parentIssue: Issue = {
+      ...mockIssue,
+      id: "parent-1",
+      number: 9,
+      identifier: "TES-9",
+      title: "Auth epic",
+    };
+
+    beforeEach(() => {
+      mockApiObj.getIssue.mockImplementation((issueId: string) =>
+        Promise.resolve(
+          issueId === "parent-1"
+            ? parentIssue
+            : { ...mockIssue, parent_issue_id: "parent-1" },
+        ),
+      );
+    });
+
+    /** The "Sub-issue of …" line under the title, and the sidebar card. */
+    async function findParentLinks() {
+      await screen.findAllByText("Auth epic");
+      return screen
+        .getAllByText("Auth epic")
+        .map((el) => el.closest("a"))
+        .filter((a): a is HTMLAnchorElement => a !== null);
+    }
+
+    it("opens a FOREGROUND tab on desktop from every entry point", async () => {
+      const openInNewTab = vi.fn();
+      navigationAdapter.openInNewTab = openInNewTab;
+      renderIssueDetail();
+
+      const links = await findParentLinks();
+      // The breadcrumb under the title plus the sidebar "Parent issue" card.
+      expect(links.length).toBeGreaterThan(1);
+
+      for (const link of links) {
+        openInNewTab.mockClear();
+        fireEvent.click(link);
+        expect(openInNewTab).toHaveBeenCalledWith(
+          "/test/issues/parent-1",
+          "TES-9",
+          { activate: true },
+        );
+      }
+      expect(navigationAdapter.push).not.toHaveBeenCalled();
+    });
+
+    it("leaves the click to the browser on web", async () => {
+      renderIssueDetail();
+
+      for (const link of await findParentLinks()) {
+        expect(link).toHaveAttribute("href", "/test/issues/parent-1");
+        expect(link).toHaveAttribute("target", "_blank");
+        expect(fireEvent.click(link)).toBe(true);
+      }
+      expect(navigationAdapter.push).not.toHaveBeenCalled();
+    });
+
+    it("keeps the header breadcrumb crumb navigating in place", async () => {
+      const openInNewTab = vi.fn();
+      navigationAdapter.openInNewTab = openInNewTab;
+      renderIssueDetail();
+
+      // "TES-9" labels three links: the header crumb, the breadcrumb under
+      // the title, and the sidebar card. Exactly one of them — the crumb —
+      // must still be an in-place link.
+      await screen.findAllByText("TES-9");
+      const inPlace = screen
+        .getAllByText("TES-9")
+        .map((el) => el.closest("a"))
+        .filter((a): a is HTMLAnchorElement => a !== null && !a.hasAttribute("target"));
+      expect(inPlace).toHaveLength(1);
+
+      fireEvent.click(inPlace[0]!);
+      expect(openInNewTab).not.toHaveBeenCalled();
+      expect(navigationAdapter.push).toHaveBeenCalledWith("/test/issues/parent-1");
     });
   });
 });

--- a/packages/views/issues/components/issue-detail.tsx
+++ b/packages/views/issues/components/issue-detail.tsx
@@ -636,6 +636,12 @@ function SubIssueRow({
   // and no risk of the native checkbox / picker triggers being blocked.
   // Right-click anywhere on the row opens the shared issue actions menu
   // (priority, labels, dates, delete, …) — the same menu as list rows.
+  //
+  // target="_blank": a sub-issue row is a Reference, not Navigation — the list
+  // is part of the parent's reading context rather than a picker, so opening a
+  // child must not cost the reader their place in the parent. This is
+  // deliberately unlike an issue list row; see the rule at the top of
+  // packages/views/navigation/types.ts.
   return (
     <IssueActionsContextMenu issue={child}>
       <div
@@ -685,6 +691,8 @@ function SubIssueRow({
         />
         <AppLink
           href={paths.issueDetail(child.id)}
+          target="_blank"
+          newTabTitle={child.identifier}
           className="flex min-w-0 flex-1 items-center gap-2.5"
         >
           <span className="text-[11px] text-muted-foreground tabular-nums font-medium shrink-0">
@@ -1972,8 +1980,13 @@ export function IssueDetail({ issueId, onDelete, onDone, defaultSidebarOpen = tr
           </button>
           {parentIssueOpen && <div className="pl-2">
             <div className="flex items-center gap-0.5 rounded-md px-2 -mx-2 hover:bg-accent/50 transition-colors group">
+              {/* Same parent, same rule as the breadcrumb under the title —
+                  the sidebar card is a second entry point to one reference,
+                  and the two must not disagree about where a click lands. */}
               <AppLink
                 href={paths.issueDetail(parentIssue.id)}
+                target="_blank"
+                newTabTitle={parentIssue.identifier}
                 className="flex flex-1 min-w-0 items-center gap-1.5 py-1.5 text-xs"
               >
                 <StatusIcon status={parentIssue.status} className="h-3.5 w-3.5 shrink-0" />
@@ -2359,8 +2372,13 @@ export function IssueDetail({ issueId, onDelete, onDone, defaultSidebarOpen = tr
           )}
 
           {parentIssue && (
+            // Reference, like the sub-issue rows below it: the breadcrumb
+            // points out of what the user is reading, so it opens beside it
+            // rather than replacing it (packages/views/navigation/types.ts).
             <AppLink
               href={paths.issueDetail(parentIssue.id)}
+              target="_blank"
+              newTabTitle={parentIssue.identifier}
               className="mt-2 inline-flex max-w-full items-center gap-1.5 text-xs text-muted-foreground hover:text-foreground transition-colors group/parent"
             >
               <span className="font-medium shrink-0">{t(($) => $.detail.sub_issue_of)}</span>

--- a/packages/views/navigation/app-link.test.tsx
+++ b/packages/views/navigation/app-link.test.tsx
@@ -143,6 +143,42 @@ describe("AppLink", () => {
       expect(order).toEqual(["onClick", "openInNewTab"]);
     });
 
+    it("cmd/ctrl-click inverts the default to a BACKGROUND tab", () => {
+      // A Reference surface opens foreground on a plain click, so the
+      // modifier has to mean the opposite of what it means on a Navigation
+      // surface — not "open a tab" but "open it without taking me there".
+      const push = vi.fn();
+      const openInNewTab = vi.fn();
+      const adapter = makeAdapter({ push, openInNewTab });
+
+      renderLink(adapter, {
+        href: "/issues",
+        target: "_blank",
+        newTabTitle: "MUL-7",
+      });
+      fireEvent.click(screen.getByText("go"), { metaKey: true });
+
+      expect(openInNewTab).toHaveBeenCalledWith("/issues", "MUL-7");
+      expect(push).not.toHaveBeenCalled();
+    });
+
+    it("cmd/ctrl-click without an adapter (web) stays out of the browser's way", () => {
+      // The browser backgrounds a modifier-click even on target=_blank, so
+      // the inversion is already correct natively. preventDefault here would
+      // replace three distinct behaviours (background, new window, foreground)
+      // with one.
+      const push = vi.fn();
+      const adapter = makeAdapter({ push });
+
+      renderLink(adapter, { href: "/issues", target: "_blank" });
+      const defaultNotPrevented = fireEvent.click(screen.getByText("go"), {
+        metaKey: true,
+      });
+
+      expect(defaultNotPrevented).toBe(true);
+      expect(push).not.toHaveBeenCalled();
+    });
+
     it("renders the target and a rel guard on the anchor", () => {
       renderLink(makeAdapter(), { href: "/issues", target: "_blank" });
       const anchor = screen.getByText("go");

--- a/packages/views/navigation/types.ts
+++ b/packages/views/navigation/types.ts
@@ -1,3 +1,48 @@
+// ---------------------------------------------------------------------------
+// Where a click lands: Navigation vs Reference
+// ---------------------------------------------------------------------------
+//
+// Read this before changing the click behaviour of any surface that opens an
+// entity. Every "should this open in a new tab?" question in the app is
+// answered by one distinction — and answering it per component is exactly how
+// the behaviour ended up spread across five layers that disagreed with each
+// other, with the same issue opening differently depending on which view you
+// clicked it from (MUL-5453).
+//
+// NAVIGATION — open in place: plain `<AppLink>` or `push()`.
+//   The user is in a container whose purpose is to be consumed; they are
+//   picking which thing to look at. The container has done its job the moment
+//   they pick, so replacing it costs them nothing.
+//   → List / Board / Table / Gantt / Swimlane rows, search results, Inbox,
+//     and the header breadcrumb's ancestor crumbs — a crumb is a "go up"
+//     affordance, so the user is asking to leave, not to glance sideways.
+//
+// REFERENCE — open in a foreground new tab: `<AppLink target="_blank">`.
+//   The user is reading A, and A points at B. Leaving A costs them scroll
+//   position, expanded sections, a half-written comment draft — state the app
+//   cannot restore for them. Most readers come back.
+//   → Mentions and bare links inside content, sub-issue rows, the parent-issue
+//     breadcrumb, an avatar leading to a profile, PRs and attachments.
+//
+// The question is never "is the destination an issue?" or "which component is
+// this?" — it is "is the surface the user is standing on worth preserving?"
+// A sub-issue row and an issue list row both open an issue and are
+// deliberately different: the sub-issue list is part of the parent's reading
+// context, the issue list is a picker.
+//
+// Modifiers invert the surface's default and always land in the background: on
+// a Reference, cmd/ctrl-click and middle-click open a background tab instead
+// of a foreground one; on a Navigation surface they open a tab instead of
+// navigating in place. An explicit "Open in new tab" menu item is always
+// foreground — the user asked to move.
+//
+// On web `openInNewTab` is deliberately left undefined. `AppLink` renders a
+// real anchor, so leaving the event alone hands the click to the browser,
+// which already implements this entire table — and does it better than
+// `window.open` can (it distinguishes background, foreground and new window,
+// and no popup blocker gets a say). Only non-anchor surfaces need a
+// `window.open` fallback; see `use-row-link.ts`.
+
 export interface NavigationAdapter {
   push(path: string): void;
   replace(path: string): void;


### PR DESCRIPTION
MUL-5458 — Stage 2 of the "Navigation vs Reference" cleanup (MUL-5453).

## What changed

Three links on the issue detail page now open a **foreground** new tab instead of navigating in place:

| Surface | Location |
|---|---|
| Sub-issue row | `issue-detail.tsx:693` |
| "Sub-issue of …" breadcrumb under the title | `issue-detail.tsx:2375` |
| Sidebar "Parent issue" card | `issue-detail.tsx:1984` |

Implementation matches issue mentions in content (`issue-mention-card.tsx`): `<AppLink target="_blank">`, so desktop goes through `openInNewTab(..., { activate: true })` and web hands the click to the browser's native anchor handling. No new branching — Stage 1 already put all of this inside `AppLink`.

The **third row is beyond the issue's literal scope**: the issue named the row and the breadcrumb. The sidebar card is a second entry point to the same parent from the same page, and leaving it in place would have created a fresh inconsistency inside the component this PR is fixing. Easy to back out if you disagree.

The **header breadcrumb's ancestor crumb stays in place** (`issue-detail.tsx:2204`). A crumb is a "go up" affordance — the user is asking to leave, not to glance sideways. Recorded as a decision, not an omission; there's a test pinning it.

## The rule, written down

`packages/views/navigation/types.ts` now opens with the Navigation vs Reference rule and the reasoning behind it, including the modifier-key table and why web deliberately has no `openInNewTab`. This was the half of the issue marked "don't skip it" — the reason this logic had spread across five layers that disagreed with each other is that the rule had never been written anywhere.

## This is deliberately inconsistent with list rows

A sub-issue row and an issue list row both open an issue and now behave differently. That is the conclusion of the rule, not an oversight: the sub-issue list is part of the parent's reading context, the issue list is a picker. MUL-5459 brings Table rows back in line on the Navigation side.

## Acceptance criteria

- Desktop → foreground app tab; an already-open tab for that issue is focused rather than duplicated (`openTab` dedupes by `resourceKey`, unchanged).
- Web → real browser tab, via the native anchor rather than `window.open`.
- Inline status / assignee / due-date pickers and the select checkbox still don't navigate — they are siblings of the `AppLink`, and a test now guards that structure.
- Cmd/Ctrl+click and middle click invert to a **background** tab.
- Right-click still opens the shared actions menu with exactly one "Open in new tab" (it's a surface-level singleton, so no duplication).

## Tests

`issue-detail.test.tsx` stopped stubbing `AppLink` with a bare `<a>` and now runs the real `AppLink` under a real `NavigationProvider` with a fake adapter — a stub could only ever prove that props were forwarded, never that a click opens a tab. `openInNewTab` is the platform switch: set for desktop cases, left undefined for web ones.

9 new tests there (foreground/background/web × sub-issue row and parent, plus picker isolation, context-menu non-duplication, and the header crumb staying in place) and 2 in `app-link.test.tsx` for modifier-click on a `target="_blank"` link on both platforms. Each was checked to fail against the unmodified component.

## Verification

- `pnpm --filter @multica/views exec vitest run` → 3253 passed, 1 failed: `layout/sidebar-resize.test.tsx`, which **fails identically on the base commit** (confirmed by stashing) and is unrelated.
- `pnpm typecheck` (whole monorepo) → clean.
- `pnpm lint` → 0 errors.

Not manually exercised in a running desktop build.
