### PR TITLE
fix(issues): open a table row in place, like List / Board / Gantt (MUL-5459)

### DIFF
--- a/packages/ui/components/ui/data-table.tsx
+++ b/packages/ui/components/ui/data-table.tsx
@@ -44,8 +44,14 @@ interface DataTableProps<TData> extends React.ComponentProps<"div"> {
   // descendant — buttons / dropdowns inside cells should call
   // event.stopPropagation in their own handlers). Used to navigate to
   // a detail page on row click without nesting an <a> around <tr>,
-  // which is invalid HTML.
-  onRowClick?: (row: Row<TData>) => void;
+  // which is invalid HTML. The event is handed over so the caller can read
+  // modifier keys, which is how a plain <tr> gets the cmd/ctrl-click
+  // semantics a real anchor would have given it for free.
+  onRowClick?: (row: Row<TData>, event: React.MouseEvent) => void;
+  // Middle click, which never raises a `click` event and so never reaches
+  // onRowClick. Kept a separate prop for the same reason useRowLink splits
+  // its two handlers: only this one needs the button check and preventDefault.
+  onRowAuxClick?: (row: Row<TData>, event: React.MouseEvent) => void;
   // Optional escape hatch for semantic rows such as collapsible group
   // headers. Return null/undefined to use the standard data row renderer.
   renderRow?: (row: Row<TData>) => React.ReactNode;
@@ -81,6 +87,7 @@ export function DataTable<TData>({
   actionBar,
   emptyMessage = "No results.",
   onRowClick,
+  onRowAuxClick,
   renderRow,
   footer,
   virtualizeRows = false,
@@ -370,6 +377,7 @@ export function DataTable<TData>({
     rows,
     emptyMessage,
     onRowClick,
+    onRowAuxClick,
     renderRow,
     hasExplicitSize,
     measureRow: rowVirtualizer.measureElement,
@@ -572,7 +580,8 @@ interface DataTableBodyProps<TData> {
   table: TanstackTable<TData>;
   rows: Row<TData>[];
   emptyMessage: React.ReactNode;
-  onRowClick?: (row: Row<TData>) => void;
+  onRowClick?: (row: Row<TData>, event: React.MouseEvent) => void;
+  onRowAuxClick?: (row: Row<TData>, event: React.MouseEvent) => void;
   renderRow?: (row: Row<TData>) => React.ReactNode;
   hasExplicitSize: (columnId: string) => boolean;
   // The virtualizer's own measuring ref; rows report their height through it.
@@ -588,6 +597,7 @@ function DataTableBody<TData>({
   rows,
   emptyMessage,
   onRowClick,
+  onRowAuxClick,
   renderRow,
   hasExplicitSize,
   measureRow,
@@ -620,7 +630,10 @@ function DataTableBody<TData>({
         key={row.id}
         {...measured}
         data-state={row.getIsSelected() && "selected"}
-        onClick={onRowClick ? () => onRowClick(row) : undefined}
+        onClick={onRowClick ? (event) => onRowClick(row, event) : undefined}
+        onAuxClick={
+          onRowAuxClick ? (event) => onRowAuxClick(row, event) : undefined
+        }
         // `group` lets pinned cells track row hover via group-hover (their bg
         // is in className, not on the row, so they stay opaque enough to cover
         // content scrolling beneath them).

--- a/packages/views/issues/components/table-view-editing.test.tsx
+++ b/packages/views/issues/components/table-view-editing.test.tsx
@@ -12,6 +12,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   act,
   cleanup,
+  fireEvent,
   render,
   screen,
   waitFor,
@@ -29,6 +30,8 @@ import type {
   IssueTableQuerySpec,
   IssueTableRowsResponse,
 } from "@multica/core/types";
+import { NavigationProvider } from "../../navigation";
+import type { NavigationAdapter } from "../../navigation";
 import { renderWithI18n } from "../../test/i18n";
 import { IssueSurfaceSelectionProvider } from "../surface/selection-context";
 import type { IssueSurfaceSelection } from "../surface/selection-context";
@@ -78,26 +81,29 @@ vi.mock("@multica/core/auth", () => ({
   ),
 }));
 
-const navigationMocks = vi.hoisted(() => ({
+// The real NavigationProvider rather than a module mock: row clicks go through
+// useRowLink, and stubbing the navigation module out would replace the very
+// hook whose semantics these tests are pinning down (MUL-5459).
+const navigationMocks = {
   push: vi.fn(),
   openInNewTab: vi.fn(),
   getShareableUrl: vi.fn((path: string) => `https://app.example${path}`),
-}));
-const navigationState = vi.hoisted(() => ({ hasOpenInNewTab: true }));
+};
 
-vi.mock("../../navigation", () => ({
-  AppLink: ({ children, ...props }: React.ComponentProps<"a">) => (
-    <a {...props}>{children}</a>
-  ),
-  useNavigation: () => ({
+/** Desktop supplies openInNewTab; web leaves it undefined. */
+function makeAdapter(withTabAdapter: boolean): NavigationAdapter {
+  return {
     push: navigationMocks.push,
-    openInNewTab: navigationState.hasOpenInNewTab
-      ? navigationMocks.openInNewTab
-      : undefined,
-    getShareableUrl: navigationMocks.getShareableUrl,
+    replace: vi.fn(),
+    back: vi.fn(),
     pathname: "/",
-  }),
-}));
+    searchParams: new URLSearchParams(),
+    getShareableUrl: navigationMocks.getShareableUrl,
+    ...(withTabAdapter ? { openInNewTab: navigationMocks.openInNewTab } : {}),
+  };
+}
+
+let navigationAdapter: NavigationAdapter = makeAdapter(true);
 
 vi.mock("@multica/core/paths", async () => {
   const actual = await vi.importActual<typeof import("@multica/core/paths")>(
@@ -172,25 +178,27 @@ function Harness({
   onCreateIssue?: (defaults: IssueCreateDefaults) => void;
 }) {
   return (
-    <ViewStoreProvider store={getIssueSurfaceViewStore(surfaceKey)}>
-      <IssueSurfaceSelectionProvider selection={selection}>
-        <TableView
-          serverQuery={serverQuery}
-          childProgressMap={childProgressMap}
-          search=""
-          onSearchChange={() => {}}
-          onLoadedIssuesChange={() => {}}
-          onCreateIssue={onCreateIssue}
-          exportIssues={() => Promise.resolve(serverIssues)}
-          resolveExportLookups={() =>
-            Promise.resolve({
-              projectMap: new Map(),
-              childProgressMap: new Map(),
-            })
-          }
-        />
-      </IssueSurfaceSelectionProvider>
-    </ViewStoreProvider>
+    <NavigationProvider value={navigationAdapter}>
+      <ViewStoreProvider store={getIssueSurfaceViewStore(surfaceKey)}>
+        <IssueSurfaceSelectionProvider selection={selection}>
+          <TableView
+            serverQuery={serverQuery}
+            childProgressMap={childProgressMap}
+            search=""
+            onSearchChange={() => {}}
+            onLoadedIssuesChange={() => {}}
+            onCreateIssue={onCreateIssue}
+            exportIssues={() => Promise.resolve(serverIssues)}
+            resolveExportLookups={() =>
+              Promise.resolve({
+                projectMap: new Map(),
+                childProgressMap: new Map(),
+              })
+            }
+          />
+        </IssueSurfaceSelectionProvider>
+      </ViewStoreProvider>
+    </NavigationProvider>
   );
 }
 
@@ -204,7 +212,7 @@ describe("TableView cell editors under data refresh", () => {
     navigationMocks.getShareableUrl.mockImplementation(
       (path: string) => `https://app.example${path}`,
     );
-    navigationState.hasOpenInNewTab = true;
+    navigationAdapter = makeAdapter(true);
     vi.stubGlobal("IntersectionObserver", ObserverStub);
     vi.stubGlobal("ResizeObserver", ObserverStub);
     queryClient = new QueryClient({
@@ -350,7 +358,7 @@ describe("TableView cell editors under data refresh", () => {
     });
   });
 
-  it("opens title and row clicks in a foreground Desktop tab", async () => {
+  it("opens the title's explicit affordance in a foreground Desktop tab", async () => {
     const user = userEvent.setup({ delay: null, pointerEventsCheck: 0 });
     serverIssues = [makeIssue("a", "Alpha task", "todo")];
 
@@ -371,22 +379,13 @@ describe("TableView cell editors under data refresh", () => {
       { activate: true },
     );
     expect(navigationMocks.push).not.toHaveBeenCalled();
-
-    navigationMocks.openInNewTab.mockClear();
-    await user.click(row);
-    expect(navigationMocks.openInNewTab).toHaveBeenCalledWith(
-      "/test/issues/a",
-      "MUL-a",
-      { activate: true },
-    );
-    expect(navigationMocks.push).not.toHaveBeenCalled();
   });
 
-  it("opens a real browser tab when the platform has no tab adapter", async () => {
+  it("opens a real browser tab from the title when the platform has no tab adapter", async () => {
     const user = userEvent.setup({ delay: null, pointerEventsCheck: 0 });
     const windowOpen = vi.fn();
     vi.stubGlobal("open", windowOpen);
-    navigationState.hasOpenInNewTab = false;
+    navigationAdapter = makeAdapter(false);
     serverIssues = [makeIssue("a", "Alpha task", "todo")];
 
     renderWithI18n(
@@ -410,6 +409,147 @@ describe("TableView cell editors under data refresh", () => {
       "noopener,noreferrer",
     );
     expect(navigationMocks.push).not.toHaveBeenCalled();
+  });
+
+  // MUL-5459: a table row is navigation, not a reference — the same gesture on
+  // a List row, a Board card and a Gantt bar all stay on the page, and the
+  // table was the one surface that used to jump the user into a new tab.
+  it("navigates in place on a plain row click", async () => {
+    const user = userEvent.setup({ delay: null, pointerEventsCheck: 0 });
+    serverIssues = [makeIssue("a", "Alpha task", "todo")];
+
+    renderWithI18n(
+      <QueryClientProvider client={queryClient}>
+        <Harness
+          childProgressMap={new Map()}
+          surfaceKey={`test-row-push-${Math.floor(Math.random() * 1e9)}`}
+        />
+      </QueryClientProvider>,
+    );
+
+    const row = (await screen.findByText("MUL-a")).closest("tr")!;
+    await user.click(row);
+
+    expect(navigationMocks.push).toHaveBeenCalledWith("/test/issues/a");
+    expect(navigationMocks.openInNewTab).not.toHaveBeenCalled();
+  });
+
+  // A <tr> cannot be an <a>, so the modifier semantics a real link inherits
+  // from the browser have to be wired by hand — before this the table row
+  // ignored modifiers entirely.
+  it("opens a background tab on cmd/ctrl-click and on middle click", async () => {
+    serverIssues = [makeIssue("a", "Alpha task", "todo")];
+
+    renderWithI18n(
+      <QueryClientProvider client={queryClient}>
+        <Harness
+          childProgressMap={new Map()}
+          surfaceKey={`test-row-modifier-${Math.floor(Math.random() * 1e9)}`}
+        />
+      </QueryClientProvider>,
+    );
+
+    const row = (await screen.findByText("MUL-a")).closest("tr")!;
+
+    fireEvent.click(row, { metaKey: true });
+    fireEvent.click(row, { ctrlKey: true });
+    // No `activate`, i.e. a BACKGROUND tab: a modifier click means "keep me
+    // here", unlike the title's explicit open.
+    expect(navigationMocks.openInNewTab).toHaveBeenCalledTimes(2);
+    expect(navigationMocks.openInNewTab).toHaveBeenNthCalledWith(
+      1,
+      "/test/issues/a",
+    );
+
+    navigationMocks.openInNewTab.mockClear();
+    const auxClick = new MouseEvent("auxclick", {
+      bubbles: true,
+      button: 1,
+      cancelable: true,
+    });
+    act(() => {
+      row.dispatchEvent(auxClick);
+    });
+    expect(auxClick.defaultPrevented).toBe(true);
+    expect(navigationMocks.openInNewTab).toHaveBeenCalledWith(
+      "/test/issues/a",
+    );
+    expect(navigationMocks.push).not.toHaveBeenCalled();
+  });
+
+  // On web the row is still a <tr> with no adapter behind it, so the two
+  // gestures have to split here rather than both falling through to the same
+  // window.open the way they used to.
+  it("splits plain and modifier row clicks when the platform has no tab adapter", async () => {
+    const windowOpen = vi.fn();
+    vi.stubGlobal("open", windowOpen);
+    navigationAdapter = makeAdapter(false);
+    serverIssues = [makeIssue("a", "Alpha task", "todo")];
+
+    renderWithI18n(
+      <QueryClientProvider client={queryClient}>
+        <Harness
+          childProgressMap={new Map()}
+          surfaceKey={`test-row-modifier-web-${Math.floor(Math.random() * 1e9)}`}
+        />
+      </QueryClientProvider>,
+    );
+
+    const row = (await screen.findByText("MUL-a")).closest("tr")!;
+
+    fireEvent.click(row);
+    expect(navigationMocks.push).toHaveBeenCalledWith("/test/issues/a");
+    expect(windowOpen).not.toHaveBeenCalled();
+
+    navigationMocks.push.mockClear();
+    fireEvent.click(row, { metaKey: true });
+    expect(windowOpen).toHaveBeenCalledWith(
+      "https://app.example/test/issues/a",
+      "_blank",
+      "noopener,noreferrer",
+    );
+    expect(navigationMocks.push).not.toHaveBeenCalled();
+  });
+
+  // Inline editors sit inside the row, so every gesture they own has to be
+  // stopped on BOTH click and auxclick or the new middle-click handler would
+  // navigate out from under an open picker.
+  it("leaves inline editing and selection alone", async () => {
+    const user = userEvent.setup({ delay: null, pointerEventsCheck: 0 });
+    serverIssues = [makeIssue("a", "Alpha task", "todo")];
+
+    renderWithI18n(
+      <QueryClientProvider client={queryClient}>
+        <Harness
+          childProgressMap={new Map()}
+          surfaceKey={`test-row-editors-${Math.floor(Math.random() * 1e9)}`}
+        />
+      </QueryClientProvider>,
+    );
+
+    const row = (await screen.findByText("MUL-a")).closest("tr")!;
+
+    // Status picker: opens, and neither its click nor a middle click on it
+    // navigates.
+    const statusTrigger = within(row).getByRole("button", { name: /Todo/ });
+    await user.click(statusTrigger);
+    expect(screen.getByRole("button", { name: /Backlog/ })).toBeTruthy();
+
+    act(() => {
+      statusTrigger.dispatchEvent(
+        new MouseEvent("auxclick", {
+          bubbles: true,
+          button: 1,
+          cancelable: true,
+        }),
+      );
+    });
+
+    // Selection checkbox: toggles without navigating.
+    await user.click(within(row).getByRole("checkbox"));
+
+    expect(navigationMocks.push).not.toHaveBeenCalled();
+    expect(navigationMocks.openInNewTab).not.toHaveBeenCalled();
   });
 });
 

--- a/packages/views/issues/components/table-view.tsx
+++ b/packages/views/issues/components/table-view.tsx
@@ -114,7 +114,7 @@ import {
 } from "@tanstack/react-query";
 import { ActorAvatar } from "../../common/actor-avatar";
 import { LabelChip } from "../../labels/label-chip";
-import { useNavigation } from "../../navigation";
+import { useNavigation, useRowLink } from "../../navigation";
 import { ProjectPicker } from "../../projects/components/project-picker";
 import { useT } from "../../i18n";
 import { useIssueSurfaceActionsOptional } from "../surface/actions-context";
@@ -284,9 +284,13 @@ const SORTABLE_COLUMNS: Partial<Record<TableSystemColumnKey, SortField>> = {
   updated_at: "updated_at",
 };
 
-function stopRowNavigation(event: React.SyntheticEvent) {
-  event.stopPropagation();
-}
+// Row navigation listens on click AND auxclick (middle click opens a
+// background tab), so a cell that owns its own gesture has to stop both —
+// otherwise middle-clicking an inline editor would navigate out from under it.
+const stopRowNavigation = {
+  onClick: (event: React.SyntheticEvent) => event.stopPropagation(),
+  onAuxClick: (event: React.SyntheticEvent) => event.stopPropagation(),
+};
 
 function SelectAllCheckbox({
   issueIds,
@@ -678,24 +682,29 @@ export function InlineTitle({
     else setDraft(row.issue.title);
   };
 
+  // Swallow the gesture in the capture phase — before it can reach the row
+  // (navigation) or the title's own open handler. A gesture that began while
+  // NOT editing passes through untouched, so clicking dead space still opens
+  // the issue. Middle click goes through the same guard: it raises `auxclick`
+  // rather than `click`, and row navigation now listens on both.
+  const swallowGestureWhileEditing = (event: React.SyntheticEvent) => {
+    if (editing || gestureStartedWhileEditingRef.current) {
+      event.stopPropagation();
+    }
+    gestureStartedWhileEditingRef.current = false;
+  };
+
   return (
     <div
       className="group/title relative flex min-w-0 items-center gap-1.5"
       style={{ paddingLeft: row.depth * 18 }}
       // Record whether the gesture began while editing (mousedown fires before
-      // the blur that commits), then swallow that click in the capture phase —
-      // before it can reach the row (navigation) or the title's open handler.
-      // A gesture that began while NOT editing passes through untouched, so
-      // clicking dead space still opens the issue.
+      // the blur that commits).
       onMouseDownCapture={() => {
         gestureStartedWhileEditingRef.current = editingRef.current;
       }}
-      onClickCapture={(event) => {
-        if (editing || gestureStartedWhileEditingRef.current) {
-          event.stopPropagation();
-        }
-        gestureStartedWhileEditingRef.current = false;
-      }}
+      onClickCapture={swallowGestureWhileEditing}
+      onAuxClickCapture={swallowGestureWhileEditing}
     >
       {row.hasChildren ? (
         <button
@@ -808,7 +817,7 @@ function LazyLabelCell({
   const labels = issue.labels ?? [];
   if (open) {
     return (
-      <div onClick={stopRowNavigation}>
+      <div {...stopRowNavigation}>
         <LabelPicker
           issueId={issue.id}
           open
@@ -1109,7 +1118,7 @@ function IssueTableBodyCell({
     const property = meta.propertyById.get(propertyId);
     if (!property) return null;
     return (
-      <div onClick={stopRowNavigation}>
+      <div {...stopRowNavigation}>
         <CustomPropertyValueEditor
           issue={issue}
           property={property}
@@ -1141,7 +1150,7 @@ function IssueTableBodyCell({
       );
     case "status":
       return (
-        <div onClick={stopRowNavigation}>
+        <div {...stopRowNavigation}>
           <StatusPicker
             status={issue.status}
             onUpdate={onUpdate}
@@ -1153,7 +1162,7 @@ function IssueTableBodyCell({
       );
     case "priority":
       return (
-        <div onClick={stopRowNavigation}>
+        <div {...stopRowNavigation}>
           <PriorityPicker
             priority={issue.priority}
             onUpdate={onUpdate}
@@ -1165,7 +1174,7 @@ function IssueTableBodyCell({
       );
     case "assignee":
       return (
-        <div onClick={stopRowNavigation}>
+        <div {...stopRowNavigation}>
           <AssigneePicker
             assigneeType={issue.assignee_type}
             assigneeId={issue.assignee_id}
@@ -1186,7 +1195,7 @@ function IssueTableBodyCell({
       );
     case "project":
       return (
-        <div onClick={stopRowNavigation}>
+        <div {...stopRowNavigation}>
           <ProjectPicker
             projectId={issue.project_id}
             onUpdate={onUpdate}
@@ -1203,7 +1212,7 @@ function IssueTableBodyCell({
       );
     case "start_date":
       return (
-        <div onClick={stopRowNavigation}>
+        <div {...stopRowNavigation}>
           <StartDatePicker
             startDate={issue.start_date}
             onUpdate={onUpdate}
@@ -1214,7 +1223,7 @@ function IssueTableBodyCell({
       );
     case "due_date":
       return (
-        <div onClick={stopRowNavigation}>
+        <div {...stopRowNavigation}>
           <DueDatePicker
             dueDate={issue.due_date}
             onUpdate={onUpdate}
@@ -1276,6 +1285,13 @@ export function TableView({
   const wsId = useWorkspaceId();
   const queryClient = useQueryClient();
   const navigation = useNavigation();
+  // Same whole-row click contract the projects / agents / skills lists use:
+  // a plain click navigates in place, cmd/ctrl and middle click open a
+  // background tab. A table row is navigation — the user is picking what to
+  // read out of a list — so it opens in place like List / Board / Gantt do,
+  // and like them it is a <tr>, never an <a>, so the modifier semantics an
+  // anchor gets for free have to be wired here (MUL-5459).
+  const rowLink = useRowLink();
   const paths = useWorkspacePaths();
   const actions = useIssueSurfaceActionsOptional();
   const selection = useIssueSurfaceSelection();
@@ -2083,6 +2099,10 @@ export function TableView({
     [actions],
   );
 
+  // Explicit "open this issue" CTA — the title's own affordance, not the row.
+  // Asking for it means asking to move into that context, so it takes the
+  // foreground tab, matching the actions menu's "Open in new tab" (MUL-5455).
+  // Whole-row clicks are plain navigation and go through rowLink below.
   const openIssue = useCallback(
     (issue: Issue) => {
       const path = paths.issueDetail(issue.id);
@@ -2412,10 +2432,15 @@ export function TableView({
             table={table}
             virtualizeRows
             emptyMessage={t(($) => $.table.empty)}
-            onRowClick={(row) => {
-              if (row.original.kind === "issue") {
-                openIssue(row.original.issue);
-              }
+            onRowClick={(row, event) => {
+              if (row.original.kind !== "issue") return;
+              rowLink(paths.issueDetail(row.original.issue.id)).onClick(event);
+            }}
+            onRowAuxClick={(row, event) => {
+              if (row.original.kind !== "issue") return;
+              rowLink(
+                paths.issueDetail(row.original.issue.id),
+              ).onAuxClick(event);
             }}
             renderRow={(row) => {
               if (row.original.kind === "group") {

--- a/packages/views/issues/surface/issue-surface.test.tsx
+++ b/packages/views/issues/surface/issue-surface.test.tsx
@@ -86,6 +86,14 @@ vi.mock("../../navigation", () => ({
     </a>
   ),
   useNavigation: () => ({ push: vi.fn(), pathname: "/" }),
+  // TableView routes whole-row clicks through this. Inert here — these tests
+  // are about pagination and selection, and row navigation has its own
+  // coverage in table-view-editing.test.tsx.
+  useRowLink: () => () => ({
+    onClick: () => {},
+    onAuxClick: () => {},
+    onMouseEnter: () => {},
+  }),
 }));
 
 vi.mock("@multica/core/paths", async () => {


### PR DESCRIPTION
Closes MUL-5459.

## What

Table 视图的整行点击从「前台新标签页」改为「原地打开」，与 List / Board / Gantt 对齐。同一个 issues 页面切换视图模式不该改变点击语义。

| 视图 | 改前 | 改后 |
|---|---|---|
| List 行 | 原地 | 原地 |
| Board 卡片 | 原地 | 原地 |
| Gantt 条 | 原地 | 原地 |
| **Table 行** | **前台新 tab** | **原地** |

## 怎么改的

整行走 `useRowLink` —— projects / agents / skills 那批列表已经在用的同一套整行点击契约：普通左键 `push`，Cmd/Ctrl + 中键开后台标签页。`<tr>` 不可能是 `<a>`，所以真锚点白拿的修饰键语义必须手动接上；**改之前 table 行完全不认修饰键**，Cmd+click 和中键都是死的。

`openIssue` 保留不动：标题文字上的显式「打开」是 CTA，用户在主动要求换个地方看，继续走前台新标签页，与 MUL-5455 加的右键菜单项一致。

行导航现在同时监听 `click` 和 `auxclick`，所以内联编辑器（状态/优先级/指派/项目/日期/标签）和标题的编辑守卫两个事件都要拦 —— 否则中键点一个已展开的 picker 会把用户从它下面导航走。

`DataTable` 把事件透给 `onRowClick`，并新增 `onRowAuxClick`（中键不产生 `click` 事件，且只有这条路径需要 button 判断和 `preventDefault`）。

## 验收对照

- ✅ Table 行点击 → 当前 tab 内打开
- ✅ `InlineTitle` 显式打开不变（前台新标签页）
- ✅ Cmd/Ctrl+click 和中键 → 后台新标签页（Desktop 走 `openInNewTab`，Web 走 `window.open(getShareableUrl(...))`）
- ✅ 内联编辑与选择框不受影响
- ✅ 测试补在 `packages/views/issues/components/table-view-editing.test.tsx`

## 测试

`table-view-editing.test.tsx` 里的 navigation 模块 mock 换成了真的 `NavigationProvider` —— 这些用例要钉的就是 `useRowLink` 的语义，把它 mock 掉等于把被测对象换掉。新增 4 条用例：普通点击原地、修饰键/中键开后台 tab、无 adapter（web）时普通与修饰键点击分流、内联编辑与选择框不被导航打扰。每条都验证过在旧代码上会红。

## 一个 MUL-5455 的遗留缺口（本 PR 未修）

MUL-5455 的验收写的是「list / board / table / sub-issue 四个入口都有右键『在新标签页打开』」，但 **table 行实际上没有**：`IssueActionsContextMenu` 只包在 `list-row.tsx` / `board-card.tsx` / `gantt-view.tsx` / `issue-detail.tsx` 的子 issue 行上，`table-view.tsx` 从来没接过 `onContextMenu`（`TableView` 确实在 `IssueContextMenuProvider` 里面，只是没人调 `openMenu`）。

对本 PR 的影响有限 —— table 行的逃生口还有两个：点标题文字开前台新 tab（未变），以及本 PR 新加的 Cmd+click / 中键开后台 tab。补右键菜单是 MUL-5455 的验收项，另开一个改动做更合适。
