### PR TITLE
fix(views): navigate mention/slash pickers with Ctrl+N/J/P/K (MUL-5495)

### DIFF
--- a/packages/views/editor/extensions/mention-suggestion.test.tsx
+++ b/packages/views/editor/extensions/mention-suggestion.test.tsx
@@ -362,6 +362,86 @@ describe("createMentionSuggestion", () => {
     expect(command.mock.calls[0]?.[0]?.label).toBe("MUL-2");
   });
 
+  // MUL-5495: the command bar (cmdk) navigates on Ctrl+N/J and Ctrl+P/K as well
+  // as the arrows. The mention picker used to accept arrows only, so the same
+  // muscle memory silently did nothing here.
+  it("navigates with Ctrl+N/J and Ctrl+P/K, like the command bar", () => {
+    const command = vi.fn<(item: MentionItem) => void>();
+    const ref = createRef<MentionListRef>();
+    const items: MentionItem[] = [
+      { id: "i-1", label: "MUL-1", type: "issue" },
+      { id: "i-2", label: "MUL-2", type: "issue" },
+      { id: "i-3", label: "MUL-3", type: "issue" },
+    ];
+
+    render(
+      <I18nWrapper>
+        <MentionList ref={ref} items={items} query="" command={command} />
+      </I18nWrapper>,
+    );
+
+    const highlightedLabel = () => {
+      const buttons = Array.from(document.querySelectorAll<HTMLButtonElement>("button"));
+      return buttons.find((b) => b.classList.contains("bg-accent"))?.textContent ?? "";
+    };
+    let handled: boolean | undefined;
+    const press = (init: KeyboardEventInit) =>
+      act(() => {
+        handled = ref.current?.onKeyDown({ event: new KeyboardEvent("keydown", init) });
+      });
+
+    expect(highlightedLabel()).toBe("MUL-1");
+
+    press({ key: "n", ctrlKey: true });
+    expect(handled).toBe(true);
+    expect(highlightedLabel()).toBe("MUL-2");
+
+    press({ key: "j", ctrlKey: true });
+    expect(highlightedLabel()).toBe("MUL-3");
+
+    press({ key: "p", ctrlKey: true });
+    expect(highlightedLabel()).toBe("MUL-2");
+
+    press({ key: "k", ctrlKey: true });
+    expect(highlightedLabel()).toBe("MUL-1");
+
+    // The highlight the aliases moved is the row Enter commits.
+    press({ key: "n", ctrlKey: true });
+    press({ key: "Enter" });
+    expect(command).toHaveBeenCalledTimes(1);
+    expect(command.mock.calls[0]?.[0]?.label).toBe("MUL-2");
+  });
+
+  // Without Ctrl these letters are ordinary query characters; swallowing them
+  // would make "@nick" unsearchable.
+  it("leaves bare n/j/p/k to the query instead of moving the highlight", () => {
+    const ref = createRef<MentionListRef>();
+    const items: MentionItem[] = [
+      { id: "i-1", label: "MUL-1", type: "issue" },
+      { id: "i-2", label: "MUL-2", type: "issue" },
+    ];
+
+    render(
+      <I18nWrapper>
+        <MentionList ref={ref} items={items} query="" command={vi.fn()} />
+      </I18nWrapper>,
+    );
+
+    const highlightedLabel = () => {
+      const buttons = Array.from(document.querySelectorAll<HTMLButtonElement>("button"));
+      return buttons.find((b) => b.classList.contains("bg-accent"))?.textContent ?? "";
+    };
+
+    for (const key of ["n", "j", "p", "k"]) {
+      let handled: boolean | undefined;
+      act(() => {
+        handled = ref.current?.onKeyDown({ event: new KeyboardEvent("keydown", { key }) });
+      });
+      expect(handled).toBe(false);
+    }
+    expect(highlightedLabel()).toBe("MUL-1");
+  });
+
   it("hides personal agents owned by someone else from a regular member", () => {
     const qc = fakeQc({
       members: [

--- a/packages/views/editor/extensions/mention-suggestion.tsx
+++ b/packages/views/editor/extensions/mention-suggestion.tsx
@@ -42,7 +42,11 @@ import {
   sortUserItemsByRecency,
 } from "./mention-recency";
 import { matchesPinyin } from "./pinyin-match";
-import { createSuggestionPopupRender, isPickerAcceptKey } from "./suggestion-popup";
+import {
+  createSuggestionPopupRender,
+  isPickerAcceptKey,
+  pickerNavigationDirection,
+} from "./suggestion-popup";
 import { isTriggerArmedAt } from "./suggestion-trigger-arming";
 
 // ---------------------------------------------------------------------------
@@ -277,15 +281,13 @@ export const MentionList = forwardRef<MentionListRef, MentionListProps>(
         // IME is composing — don't intercept Enter/Arrow as picker actions;
         // those keys belong to the IME (Enter commits composition, etc).
         if (isImeComposing(event)) return false;
-        if (event.key === "ArrowUp") {
+        // Arrow keys plus the Ctrl+N/J/P/K aliases the command bar accepts —
+        // see pickerNavigationDirection.
+        const direction = pickerNavigationDirection(event);
+        if (direction !== null) {
           if (orderedItems.length === 0) return true;
-          const next = (selectedIndex + orderedItems.length - 1) % orderedItems.length;
-          setSelectedKey(mentionItemKey(orderedItems[next]!));
-          return true;
-        }
-        if (event.key === "ArrowDown") {
-          if (orderedItems.length === 0) return true;
-          const next = (selectedIndex + 1) % orderedItems.length;
+          const delta = direction === "next" ? 1 : orderedItems.length - 1;
+          const next = (selectedIndex + delta) % orderedItems.length;
           setSelectedKey(mentionItemKey(orderedItems[next]!));
           return true;
         }

--- a/packages/views/editor/extensions/slash-command-suggestion.test.tsx
+++ b/packages/views/editor/extensions/slash-command-suggestion.test.tsx
@@ -1,4 +1,4 @@
-import { render } from "@testing-library/react";
+import { act, render } from "@testing-library/react";
 import { createRef, type ReactNode } from "react";
 import { beforeAll, describe, expect, it, vi } from "vitest";
 import { I18nProvider } from "@multica/core/i18n/react";
@@ -312,6 +312,60 @@ describe("SlashCommandList keyboard handling", () => {
         event: new KeyboardEvent("keydown", { key: "Enter" }),
       }),
     ).toBe(true);
+    expect(command).toHaveBeenCalledWith(selectableItems[0]);
+  });
+
+  // MUL-5495: same Ctrl aliases the command bar (cmdk) accepts, so the slash
+  // picker navigates like every other list in the product.
+  it("navigates with Ctrl+N/J and Ctrl+P/K, and leaves the bare letters alone", () => {
+    const ref = createRef<SlashCommandListRef>();
+    const command = vi.fn();
+    const selectableItems: SlashCommandItem[] = [
+      { id: "s1", label: "deploy", description: "Ship changes" },
+      { id: "s2", label: "review", description: "Review code" },
+      { id: "s3", label: "note", description: "Leave a note" },
+    ];
+
+    render(
+      <I18nWrapper>
+        <SlashCommandList
+          ref={ref}
+          items={selectableItems}
+          query=""
+          command={command}
+        />
+      </I18nWrapper>,
+    );
+
+    const highlightedLabel = () => {
+      const buttons = Array.from(document.querySelectorAll<HTMLButtonElement>("button"));
+      return buttons.find((b) => b.classList.contains("bg-accent"))?.textContent ?? "";
+    };
+    let handled: boolean | undefined;
+    const press = (init: KeyboardEventInit) =>
+      act(() => {
+        handled = ref.current?.onKeyDown({ event: new KeyboardEvent("keydown", init) });
+      });
+
+    press({ key: "n", ctrlKey: true });
+    expect(handled).toBe(true);
+    expect(highlightedLabel()).toContain("/review");
+
+    press({ key: "j", ctrlKey: true });
+    expect(highlightedLabel()).toContain("/note");
+
+    press({ key: "p", ctrlKey: true });
+    expect(highlightedLabel()).toContain("/review");
+
+    press({ key: "k", ctrlKey: true });
+    expect(highlightedLabel()).toContain("/deploy");
+
+    // Bare letters stay query characters — "/note" must remain typeable.
+    press({ key: "n" });
+    expect(handled).toBe(false);
+    expect(highlightedLabel()).toContain("/deploy");
+
+    press({ key: "Enter" });
     expect(command).toHaveBeenCalledWith(selectableItems[0]);
   });
 

--- a/packages/views/editor/extensions/slash-command-suggestion.tsx
+++ b/packages/views/editor/extensions/slash-command-suggestion.tsx
@@ -19,7 +19,11 @@ import { isImeComposing } from "@multica/core/utils";
 import { workspaceKeys } from "@multica/core/workspace/queries";
 import type { Agent, MemberWithUser } from "@multica/core/types";
 import { useT } from "../../i18n";
-import { createSuggestionPopupRender, isPickerAcceptKey } from "./suggestion-popup";
+import {
+  createSuggestionPopupRender,
+  isPickerAcceptKey,
+  pickerNavigationDirection,
+} from "./suggestion-popup";
 import { isTriggerArmedAt } from "./suggestion-trigger-arming";
 
 const MAX_ITEMS = 20;
@@ -86,14 +90,13 @@ export const SlashCommandList = forwardRef<
   useImperativeHandle(ref, () => ({
     onKeyDown: ({ event }) => {
       if (isImeComposing(event)) return false;
-      if (event.key === "ArrowUp") {
+      // Arrow keys plus the Ctrl+N/J/P/K aliases the command bar accepts —
+      // see pickerNavigationDirection.
+      const direction = pickerNavigationDirection(event);
+      if (direction !== null) {
         if (items.length === 0) return false;
-        setSelectedIndex((i) => (i + items.length - 1) % items.length);
-        return true;
-      }
-      if (event.key === "ArrowDown") {
-        if (items.length === 0) return false;
-        setSelectedIndex((i) => (i + 1) % items.length);
+        const delta = direction === "next" ? 1 : items.length - 1;
+        setSelectedIndex((i) => (i + delta) % items.length);
         return true;
       }
       // Enter is the canonical accept; plain Tab is an additive alias (see

--- a/packages/views/editor/extensions/suggestion-popup.test.tsx
+++ b/packages/views/editor/extensions/suggestion-popup.test.tsx
@@ -6,7 +6,11 @@ import { PluginKey } from "@tiptap/pm/state";
 import { forwardRef, useImperativeHandle } from "react";
 import { afterEach, beforeAll, describe, expect, it, vi } from "vitest";
 import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
-import { createSuggestionPopupRender, isPickerAcceptKey } from "./suggestion-popup";
+import {
+  createSuggestionPopupRender,
+  isPickerAcceptKey,
+  pickerNavigationDirection,
+} from "./suggestion-popup";
 import { PatchedListItem } from "./list-item";
 
 interface TestItem {
@@ -299,6 +303,62 @@ describe("isPickerAcceptKey", () => {
     expect(accepts({ key: "ArrowDown" })).toBe(false);
     expect(accepts({ key: "Escape" })).toBe(false);
     expect(accepts({ key: "a" })).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// pickerNavigationDirection — the shared navigation-key policy (MUL-5495)
+// ---------------------------------------------------------------------------
+
+describe("pickerNavigationDirection", () => {
+  const direction = (init: KeyboardEventInit) =>
+    pickerNavigationDirection(new KeyboardEvent("keydown", init));
+
+  it("maps the arrow keys regardless of modifiers", () => {
+    expect(direction({ key: "ArrowDown" })).toBe("next");
+    expect(direction({ key: "ArrowUp" })).toBe("prev");
+    expect(direction({ key: "ArrowDown", ctrlKey: true })).toBe("next");
+    expect(direction({ key: "ArrowUp", metaKey: true })).toBe("prev");
+  });
+
+  // The set cmdk's `vimBindings` gives the command bar for free; the pickers
+  // must accept exactly the same chords.
+  it("maps Ctrl+N/J to next and Ctrl+P/K to prev", () => {
+    expect(direction({ key: "n", ctrlKey: true })).toBe("next");
+    expect(direction({ key: "j", ctrlKey: true })).toBe("next");
+    expect(direction({ key: "p", ctrlKey: true })).toBe("prev");
+    expect(direction({ key: "k", ctrlKey: true })).toBe("prev");
+  });
+
+  it("still maps the letter aliases with Caps Lock on", () => {
+    expect(direction({ key: "N", ctrlKey: true })).toBe("next");
+    expect(direction({ key: "K", ctrlKey: true })).toBe("prev");
+  });
+
+  it("ignores the letters without Ctrl so typing a query is never hijacked", () => {
+    expect(direction({ key: "n" })).toBe(null);
+    expect(direction({ key: "j" })).toBe(null);
+    expect(direction({ key: "p" })).toBe(null);
+    expect(direction({ key: "k" })).toBe(null);
+  });
+
+  // Cmd+P prints and Cmd+N opens a window: browser/OS accelerators the app does
+  // not own on web, and chords cmdk never bound either.
+  it("does not treat Cmd+P/N as navigation", () => {
+    expect(direction({ key: "p", metaKey: true })).toBe(null);
+    expect(direction({ key: "n", metaKey: true })).toBe(null);
+  });
+
+  it("leaves Ctrl chords that carry another modifier alone", () => {
+    expect(direction({ key: "n", ctrlKey: true, shiftKey: true })).toBe(null);
+    expect(direction({ key: "n", ctrlKey: true, altKey: true })).toBe(null);
+    expect(direction({ key: "n", ctrlKey: true, metaKey: true })).toBe(null);
+  });
+
+  it("ignores unrelated keys", () => {
+    expect(direction({ key: "Enter" })).toBe(null);
+    expect(direction({ key: "Escape" })).toBe(null);
+    expect(direction({ key: "a", ctrlKey: true })).toBe(null);
   });
 });
 

--- a/packages/views/editor/extensions/suggestion-popup.tsx
+++ b/packages/views/editor/extensions/suggestion-popup.tsx
@@ -32,6 +32,55 @@ export function isPickerAcceptKey(event: KeyboardEvent): boolean {
   );
 }
 
+/** Which way a key press moves the highlight in a suggestion list. */
+export type PickerNavigationDirection = "next" | "prev";
+
+/**
+ * Resolves a key press to a suggestion-list move, or `null` when the key is not
+ * navigation.
+ *
+ * Arrow keys are the canonical bindings. `Ctrl+N`/`Ctrl+J` (down) and
+ * `Ctrl+P`/`Ctrl+K` (up) are additive Emacs/readline aliases that the command
+ * bar already accepts for free: it is built on cmdk, whose `vimBindings` option
+ * (on by default) maps exactly this set. Mirroring it here means the pickers
+ * stop being the one place in the product where that muscle memory dies
+ * (MUL-5495).
+ *
+ * `Cmd`-based aliases are deliberately absent. cmdk does not bind them either,
+ * so the command bar never supported them, and `Cmd+P`/`Cmd+N` are browser and
+ * OS accelerators (print, new window) that a web page cannot own — the same
+ * rule `isReservedShortcut` in `@multica/core/shortcuts` already encodes.
+ *
+ * The letter aliases require Ctrl *alone*. With another modifier the chord
+ * belongs to the browser or OS (`Ctrl+Shift+N` opens an incognito window), so
+ * those fall through untouched. Arrow keys stay modifier-agnostic, exactly as
+ * before.
+ *
+ * Centralizing this next to `isPickerAcceptKey` keeps every picker built on
+ * `createSuggestionPopupRender` navigating identically instead of each list
+ * re-deciding what counts as "move down".
+ */
+export function pickerNavigationDirection(
+  event: KeyboardEvent,
+): PickerNavigationDirection | null {
+  if (event.key === "ArrowDown") return "next";
+  if (event.key === "ArrowUp") return "prev";
+  if (!event.ctrlKey || event.metaKey || event.altKey || event.shiftKey) {
+    return null;
+  }
+  // Lowercase because Caps Lock reports "N" without setting shiftKey.
+  switch (event.key.toLowerCase()) {
+    case "n":
+    case "j":
+      return "next";
+    case "p":
+    case "k":
+      return "prev";
+    default:
+      return null;
+  }
+}
+
 interface SuggestionPopupRenderOptions<
   TItem,
   TSelected = TItem,


### PR DESCRIPTION
Fixes MUL-5495.

## Problem

The command bar is built on `cmdk`, whose `vimBindings` option (on by default) navigates the result list on **Ctrl+N / Ctrl+J** (down) and **Ctrl+P / Ctrl+K** (up). The editor pickers — the `@` mention menu and the `/` command menu — handled arrow keys only, so the same muscle memory silently did nothing there.

## Change

Adds `pickerNavigationDirection()` next to the existing `isPickerAcceptKey` policy in `packages/views/editor/extensions/suggestion-popup.tsx`, and routes both list components through it. Every picker built on `createSuggestionPopupRender` now navigates identically instead of each one re-deciding what "move down" means.

- `MentionList` and `SlashCommandList` both accept Ctrl+N/J (next) and Ctrl+P/K (prev) on top of the arrows.
- Bare `n`/`j`/`p`/`k` stay query characters, so `@nick` and `/note` remain typeable.
- The letter aliases require Ctrl **alone** — with another modifier the chord belongs to the browser or OS (Ctrl+Shift+N opens an incognito window).
- Arrow keys keep their existing modifier-agnostic behavior.

## On `Cmd+P` / `Cmd+N`

The issue asked for these too, but they never worked in the command bar either: cmdk gates the aliases on `ctrlKey`, so `Cmd+P` just prints. They are also browser/OS accelerators a web page cannot own — the rule `isReservedShortcut` in `@multica/core/shortcuts` already encodes (`P` and `N` are in `BROWSER_ONLY_PRIMARY_RESERVED_KEYS`). So this PR delivers the real command-bar parity set rather than binding chords that would break Print on web.

## Tests

- `suggestion-popup.test.tsx` — the policy itself: the alias set, Caps Lock, bare letters, `Cmd+P`/`Cmd+N`, and Ctrl chords carrying a second modifier.
- `mention-suggestion.test.tsx` / `slash-command-suggestion.test.tsx` — the highlight actually moves and the row the aliases landed on is the row Enter commits.

`pnpm --filter @multica/views test` → 3252 passed. The one failure, `layout/sidebar-resize.test.tsx`, reproduces on the base commit unchanged and is unrelated. `typecheck` clean; `lint` reports 0 errors and no warnings on the touched files.
