### PR TITLE
refactor(views): make the sidebar Discord promo a footer row (MUL-5454)

### DIFF
--- a/packages/views/layout/app-sidebar.tsx
+++ b/packages/views/layout/app-sidebar.tsx
@@ -783,8 +783,11 @@ export function AppSidebar({ topSlot, searchSlot, headerClassName, headerStyle }
         </SidebarContent>
 
         <SidebarFooter className="p-2">
-          <JoinDiscordCard />
-          <div className="flex justify-end">
+          {/* One utility strip: the Discord link takes the leading space the
+              help trigger was leaving empty. `justify-end` keeps the trigger
+              right-aligned once the Discord link is dismissed. */}
+          <div className="flex items-center justify-end gap-1">
+            <JoinDiscordCard />
             <HelpLauncher />
           </div>
         </SidebarFooter>

--- a/packages/views/layout/join-discord-card.test.tsx
+++ b/packages/views/layout/join-discord-card.test.tsx
@@ -12,7 +12,6 @@ vi.mock("../i18n", () => ({
         sidebar: {
           discord_card: {
             title: "Join our Discord",
-            description: "Chat with the team and other builders.",
             dismiss: "Dismiss",
           },
         },

--- a/packages/views/layout/join-discord-card.tsx
+++ b/packages/views/layout/join-discord-card.tsx
@@ -1,15 +1,22 @@
 "use client";
 
-import { X } from "lucide-react";
+import { ArrowUpRight, X } from "lucide-react";
 import { useAuthStore } from "@multica/core/auth";
 import { DISCORD_URL, DiscordIcon } from "./discord";
 import { useDiscordCardDismissed } from "./use-discord-card-dismissed";
 import { useT } from "../i18n";
 
 /**
- * Dismissible "Join our Discord" promo pinned to the bottom of the left
+ * Dismissible "Join our Discord" entry pinned to the bottom of the left
  * sidebar (above the help launcher). Once dismissed it stays hidden for
  * that user on this browser — see {@link useDiscordCardDismissed}.
+ *
+ * Deliberately shaped as a sidebar row, not a bordered card: it matches
+ * SidebarMenuButton metrics (h-8 / rounded-md / gap-2 / text-body) and
+ * carries no resting border or fill. A dismissible promo is the
+ * lowest-priority item in the sidebar, so it must not be drawn heavier than
+ * the navigation above it. The external-link arrow mirrors the Help menu's
+ * outbound items.
  */
 export function JoinDiscordCard() {
   const { t } = useT("layout");
@@ -19,32 +26,28 @@ export function JoinDiscordCard() {
   if (dismissed) return null;
 
   return (
-    <div className="relative">
+    <div className="group/discord relative">
       <a
         href={DISCORD_URL}
         target="_blank"
         rel="noopener noreferrer"
-        className="flex items-start gap-2.5 rounded-md border border-sidebar-border bg-sidebar-accent/50 p-2.5 pr-7 transition-colors hover:bg-sidebar-accent"
+        className="flex h-8 items-center gap-2 rounded-md px-2 pr-8 text-body text-muted-foreground ring-sidebar-ring outline-hidden transition-colors hover:bg-sidebar-accent/70 hover:text-sidebar-accent-foreground focus-visible:ring-2"
       >
-        {/* Discord blurple (#5865F2) is the brand mark color — an intentional
-            exception to the semantic-token rule, like the landing social icons. */}
-        <DiscordIcon className="mt-px size-4 shrink-0 text-[#5865F2]" />
-        <span className="min-w-0">
-          <span className="block text-caption font-medium text-sidebar-foreground">
-            {t(($) => $.sidebar.discord_card.title)}
-          </span>
-          <span className="mt-0.5 block text-micro leading-snug text-muted-foreground">
-            {t(($) => $.sidebar.discord_card.description)}
-          </span>
+        <DiscordIcon className="size-4 shrink-0" />
+        <span className="truncate">
+          {t(($) => $.sidebar.discord_card.title)}
         </span>
+        <ArrowUpRight className="size-3 shrink-0 text-muted-foreground/50" />
       </a>
+      {/* Revealed on hover/focus so the resting row stays quiet. Coarse
+          pointers get no hover, so keep it permanently visible there. */}
       <button
         type="button"
         aria-label={t(($) => $.sidebar.discord_card.dismiss)}
         onClick={dismiss}
-        className="absolute top-1.5 right-1.5 flex size-5 items-center justify-center rounded-sm text-muted-foreground transition-colors hover:bg-sidebar-border hover:text-foreground"
+        className="absolute inset-y-0 right-1 my-auto flex size-6 cursor-pointer items-center justify-center rounded-sm text-muted-foreground opacity-0 ring-sidebar-ring transition-opacity hover:bg-sidebar-accent hover:text-foreground focus-visible:opacity-100 focus-visible:ring-2 group-hover/discord:opacity-100 [@media(hover:none)]:opacity-100"
       >
-        <X className="size-3" />
+        <X className="size-3.5" />
       </button>
     </div>
   );

--- a/packages/views/layout/join-discord-card.tsx
+++ b/packages/views/layout/join-discord-card.tsx
@@ -1,22 +1,28 @@
 "use client";
 
-import { ArrowUpRight, X } from "lucide-react";
+import { X } from "lucide-react";
 import { useAuthStore } from "@multica/core/auth";
 import { DISCORD_URL, DiscordIcon } from "./discord";
 import { useDiscordCardDismissed } from "./use-discord-card-dismissed";
 import { useT } from "../i18n";
 
 /**
- * Dismissible "Join our Discord" entry pinned to the bottom of the left
- * sidebar (above the help launcher). Once dismissed it stays hidden for
- * that user on this browser — see {@link useDiscordCardDismissed}.
+ * Dismissible "Join our Discord" entry sharing the sidebar footer strip with
+ * the help launcher. Once dismissed it stays hidden for that user on this
+ * browser — see {@link useDiscordCardDismissed}.
  *
  * Deliberately shaped as a sidebar row, not a bordered card: it matches
  * SidebarMenuButton metrics (h-8 / rounded-md / gap-2 / text-body) and
  * carries no resting border or fill. A dismissible promo is the
  * lowest-priority item in the sidebar, so it must not be drawn heavier than
- * the navigation above it. The external-link arrow mirrors the Help menu's
- * outbound items.
+ * the navigation above it.
+ *
+ * No external-link arrow, unlike the Help menu's outbound items: sharing one
+ * 224px strip with the help trigger leaves 128px for the label, and the arrow
+ * plus the dismiss button together overflow that in en (109px) and zh (125px).
+ * The dismiss affordance wins because it is a user-facing capability and the
+ * arrow is only a hint — the Discord mark already signals the destination.
+ * `flex-1 min-w-0` makes the label truncate rather than push the trigger off.
  */
 export function JoinDiscordCard() {
   const { t } = useT("layout");
@@ -26,7 +32,7 @@ export function JoinDiscordCard() {
   if (dismissed) return null;
 
   return (
-    <div className="group/discord relative">
+    <div className="group/discord relative min-w-0 flex-1">
       <a
         href={DISCORD_URL}
         target="_blank"
@@ -37,7 +43,6 @@ export function JoinDiscordCard() {
         <span className="truncate">
           {t(($) => $.sidebar.discord_card.title)}
         </span>
-        <ArrowUpRight className="size-3 shrink-0 text-muted-foreground/50" />
       </a>
       {/* Revealed on hover/focus so the resting row stays quiet. Coarse
           pointers get no hover, so keep it permanently visible there. */}

--- a/packages/views/locales/en/layout.json
+++ b/packages/views/locales/en/layout.json
@@ -56,7 +56,6 @@
     "unread_overflow": "99+",
     "discord_card": {
       "title": "Join our Discord",
-      "description": "Chat with the team and other builders.",
       "dismiss": "Dismiss"
     }
   }

--- a/packages/views/locales/ja/layout.json
+++ b/packages/views/locales/ja/layout.json
@@ -56,7 +56,6 @@
     "unread_overflow": "99+",
     "discord_card": {
       "title": "Discord に参加",
-      "description": "チームや他のユーザーと交流しましょう。",
       "dismiss": "閉じる"
     }
   }

--- a/packages/views/locales/ko/layout.json
+++ b/packages/views/locales/ko/layout.json
@@ -56,7 +56,6 @@
     "unread_overflow": "99+",
     "discord_card": {
       "title": "Discord 참여하기",
-      "description": "팀과 다른 사용자들과 교류해 보세요.",
       "dismiss": "닫기"
     }
   }

--- a/packages/views/locales/zh-Hans/layout.json
+++ b/packages/views/locales/zh-Hans/layout.json
@@ -56,7 +56,6 @@
     "unread_overflow": "99+",
     "discord_card": {
       "title": "加入我们的 Discord",
-      "description": "和团队及其他用户一起交流。",
       "dismiss": "关闭"
     }
   }


### PR DESCRIPTION
Closes MUL-5454.

The sidebar's "Join our Discord" promo was drawn heavier than the navigation above it: border + fill + saturated brand mark + a permanently visible close button, on a dismissible promo that is the lowest-priority item in the sidebar. At full-window scale it was the only bordered container anywhere in the interface — board cards have borders because they are content; the sidebar is chrome.

## What was wrong

Measured against the actual tokens:

| | light | dark |
| --- | --- | --- |
| card fill vs `--sidebar` | 1.04:1 | 1.10:1 |
| border vs card fill | 1.10:1 | 2.52:1 |
| hover vs resting fill | 1.05:1 | 1.09:1 |

Light mode drew two structural layers that were both invisible — it read as a smudge rather than a surface. Dark mode inverted it into a bright ring around a dim box, with the `#5865F2` mark at 7.33:1 the highest-contrast object in the footer. The hover state was imperceptible on what is a link. The description line used `text-[11px]`, the only hardcoded 11px in `packages/views/`.

The dismiss button had a 20px hit area with no `focus-visible` ring and no `cursor-pointer`, and used `hover:bg-sidebar-border` — a border token as a background, which is near-invisible in light mode. The card also duplicated the Discord entry already present in the Help menu ~8px below it, with no external-link affordance while that menu item has one.

## What changed

**1. Reshaped as a sidebar row.** Matches `SidebarMenuButton` metrics (`h-8` / `rounded-md` / `gap-2` / `text-sm`), no resting border or fill, mark in `currentColor`, description line dropped. The dismiss button gets a 24px hit area, a focus ring, and hover/focus reveal with an `[@media(hover:none)]` fallback so coarse pointers keep it.

**2. Merged into the help footer strip.** The footer stacked a full-width Discord row above a right-aligned help trigger, leaving that trigger's leading two-thirds empty and the promo isolated in its own band. Both now share one strip; `justify-end` keeps the trigger right-aligned once the link is dismissed. Footer height drops 68px → 48px.

### Why there is no external-link arrow

Sharing a 224px strip with the help trigger leaves 128px for the label. Measured label widths are en 109px, zh 125px, ja 97px, ko 103px, and the arrow (12px + gap) plus the dismiss button's 32px reserve together overflow that — zh with both needs 241px against a 224px strip. The two cannot coexist at the default sidebar width, so one had to go.

The dismiss button won: it is a user-facing capability, while the arrow is only a hint that the Discord mark already carries. No locale clips at the default width. `flex-1 min-w-0` makes the label truncate rather than push the trigger off the edge.

## Notes

- `discord_card.description` is removed from all four locales; `locales/parity.test.ts` covers the removal.
- Two findings surfaced during review are **not** addressed here because they are token-level and affect the whole sidebar, not this component: the light-mode hover fill is ~1.06:1 for every nav item (`--sidebar-accent` is only 3% darker than `--sidebar`), and the card previously sat below WCAG AA — that second one was independently fixed upstream by #6095, which raised light `--muted-foreground` to `oklch(0.505)`, putting this row at 5.31:1.

## Verification

`packages/views` typecheck, eslint, `join-discord-card.test.tsx` (3 passed), and `locales/parity.test.ts` (160 passed) all pass on the rebased branch. Before/after screenshots in both themes were captured from the real app running locally, with the component swapped between passes so nothing else differed.
