### PR TITLE
MUL-5516: fix(issues): re-trigger blocked issues when resumed

### DIFF
--- a/server/internal/handler/issue.go
+++ b/server/internal/handler/issue.go
@@ -3061,8 +3061,8 @@ func (h *Handler) validateAssigneePair(ctx context.Context, r *http.Request, wor
 // shouldEnqueueAgentTask returns true when an issue creation or assignment
 // should trigger the assigned agent. Backlog issues are skipped — backlog
 // acts as a parking lot where issues can be pre-assigned without immediately
-// triggering execution. Moving out of backlog is handled separately in
-// UpdateIssue.
+// triggering execution. Moving out of backlog or blocked is handled separately
+// in UpdateIssue.
 func (h *Handler) shouldEnqueueAgentTask(ctx context.Context, issue db.Issue) bool {
 	if issue.Status == "backlog" {
 		return false

--- a/server/internal/handler/issue.go
+++ b/server/internal/handler/issue.go
@@ -2968,7 +2968,7 @@ func (h *Handler) UpdateIssue(w http.ResponseWriter, r *http.Request) {
 			AssigneeChanged: assigneeChanged,
 			StatusChanged:   statusChanged,
 		},
-		h.issueTriggerWriteProbe(r, actorType, issue),
+		h.issueTriggerProbe(r, actorType, actorID, workspaceID, issue),
 	); ok && !req.SuppressRun {
 		h.dispatchIssueRun(r.Context(), issue, trigger, actorType, actorID, req.HandoffNote)
 	}
@@ -3466,7 +3466,7 @@ func (h *Handler) BatchUpdateIssues(w http.ResponseWriter, r *http.Request) {
 				AssigneeChanged: assigneeChanged,
 				StatusChanged:   statusChanged,
 			},
-			h.issueTriggerWriteProbe(r, actorType, issue),
+			h.issueTriggerProbe(r, actorType, actorID, workspaceID, issue),
 		); ok && !req.Updates.SuppressRun {
 			h.dispatchIssueRun(r.Context(), issue, trigger, actorType, actorID, req.Updates.HandoffNote)
 		}

--- a/server/internal/handler/issue_trigger.go
+++ b/server/internal/handler/issue_trigger.go
@@ -16,25 +16,10 @@ import (
 // selection cannot fan out into thousands of readiness probes.
 const maxPreviewTriggerIssues = 500
 
-// issueTriggerWriteProbe builds the probe the write paths feed to
-// WillEnqueueRun. The private-agent gate is already enforced at the HTTP
-// boundary (validateAssigneePair on assign) and inside enqueueSquadLeaderTask
-// (canEnqueueSquadLeader), so a write must NOT re-run or sink it — it passes
-// allow-all. The self-loop check needs the request's X-Task-ID header.
-func (h *Handler) issueTriggerWriteProbe(r *http.Request, actorType string, issue db.Issue) service.IssueTriggerProbe {
-	return service.IssueTriggerProbe{
-		CanAccessAgent: nil, // allow-all; gate lives at the write boundary
-		IsSelfLoop: func() bool {
-			return h.isAgentRunningOnIssue(r, actorType, issue)
-		},
-	}
-}
-
-// issueTriggerPreviewProbe mirrors the real write-time gates for the read-only
-// preview: the private-agent gate (so preview never leaks a private agent's
-// readiness to a member who cannot see it — matching validateAssigneePair /
-// canEnqueueSquadLeader) and the same self-loop guard.
-func (h *Handler) issueTriggerPreviewProbe(r *http.Request, actorType, actorID, workspaceID string, issue db.Issue) service.IssueTriggerProbe {
+// issueTriggerProbe builds the request-scoped gates shared by preview and the
+// real write paths. Status-only updates do not pass through validateAssigneePair,
+// so the invocation gate must remain part of the enqueue decision itself.
+func (h *Handler) issueTriggerProbe(r *http.Request, actorType, actorID, workspaceID string, issue db.Issue) service.IssueTriggerProbe {
 	originatorUserID := h.invokeOriginatorFromRequest(r, actorType, actorID)
 	return service.IssueTriggerProbe{
 		CanAccessAgent: func(agent db.Agent) bool {
@@ -158,7 +143,7 @@ func (h *Handler) PreviewIssueTrigger(w http.ResponseWriter, r *http.Request) {
 	resp := IssueTriggerPreviewResponse{Triggers: make([]IssueTriggerPreviewItem, 0)}
 
 	appendTrigger := func(issue db.Issue, in service.IssueTriggerInput) {
-		probe := h.issueTriggerPreviewProbe(r, actorType, actorID, workspaceID, issue)
+		probe := h.issueTriggerProbe(r, actorType, actorID, workspaceID, issue)
 		if trigger, ok := h.IssueService.WillEnqueueRun(r.Context(), in, probe); ok {
 			resp.Triggers = append(resp.Triggers, IssueTriggerPreviewItem{
 				IssueID:          uuidToString(trigger.IssueID),

--- a/server/internal/handler/issue_trigger_preview_test.go
+++ b/server/internal/handler/issue_trigger_preview_test.go
@@ -24,9 +24,13 @@ func seededReadyAgentID(t *testing.T) string {
 }
 
 func previewIssueTrigger(t *testing.T, body map[string]any) IssueTriggerPreviewResponse {
+	return previewIssueTriggerAs(t, testUserID, body)
+}
+
+func previewIssueTriggerAs(t *testing.T, userID string, body map[string]any) IssueTriggerPreviewResponse {
 	t.Helper()
 	w := httptest.NewRecorder()
-	req := newRequest("POST", "/api/issues/preview-trigger?workspace_id="+testWorkspaceID, body)
+	req := newRequestAs(userID, "POST", "/api/issues/preview-trigger?workspace_id="+testWorkspaceID, body)
 	testHandler.PreviewIssueTrigger(w, req)
 	if w.Code != http.StatusOK {
 		t.Fatalf("PreviewIssueTrigger: expected 200, got %d: %s", w.Code, w.Body.String())
@@ -66,6 +70,15 @@ func taskCountFor(t *testing.T, issueID, agentID string) int {
 		t.Fatalf("count tasks: %v", err)
 	}
 	return n
+}
+
+func assignIssueToAgentForTest(t *testing.T, issueID, agentID string) {
+	t.Helper()
+	if _, err := testPool.Exec(context.Background(), `
+		UPDATE issue SET assignee_type = 'agent', assignee_id = $2 WHERE id = $1
+	`, issueID, agentID); err != nil {
+		t.Fatalf("assign issue to agent: %v", err)
+	}
 }
 
 // TestPreviewIssueTrigger_CreateAgentVsBacklog covers the create entry point:
@@ -211,6 +224,125 @@ func TestBlockedToNonRunnableStatusDoesNotRestart(t *testing.T) {
 				t.Fatalf("blocked->%s: expected no trigger, got %+v", status, preview)
 			}
 		})
+	}
+}
+
+// TestBlockedPrivateAgentResumeRequiresInvokePermission covers status-only
+// writes, which keep the existing assignee and therefore do not pass through
+// validateAssigneePair. Preview and write must both deny an unrelated member,
+// while still applying the requested issue status.
+func TestBlockedPrivateAgentResumeRequiresInvokePermission(t *testing.T) {
+	agentID, _, memberID := privateAgentTestFixture(t)
+
+	for _, status := range []string{"todo", "in_progress", "in_review"} {
+		t.Run(status, func(t *testing.T) {
+			issue := createIssueForTest(t, map[string]any{
+				"title":  "private agent resume denied " + status,
+				"status": "blocked",
+			})
+			assignIssueToAgentForTest(t, issue.ID, agentID)
+
+			preview := previewIssueTriggerAs(t, memberID, map[string]any{
+				"issue_ids": []string{issue.ID},
+				"status":    status,
+			})
+			if preview.TotalCount != 0 {
+				t.Fatalf("blocked->%s preview: expected no trigger, got %+v", status, preview)
+			}
+
+			w := httptest.NewRecorder()
+			req := withURLParam(newRequestAs(memberID, "PUT", "/api/issues/"+issue.ID, map[string]any{
+				"status": status,
+			}), "id", issue.ID)
+			testHandler.UpdateIssue(w, req)
+			if w.Code != http.StatusOK {
+				t.Fatalf("UpdateIssue blocked->%s: %d %s", status, w.Code, w.Body.String())
+			}
+			var updated IssueResponse
+			if err := json.NewDecoder(w.Body).Decode(&updated); err != nil {
+				t.Fatalf("decode blocked->%s response: %v", status, err)
+			}
+			if updated.Status != status {
+				t.Fatalf("blocked->%s status was not applied: got %q", status, updated.Status)
+			}
+			if got := taskCountFor(t, issue.ID, agentID); got != 0 {
+				t.Fatalf("blocked->%s write disagreed with preview: enqueued %d tasks", status, got)
+			}
+		})
+	}
+}
+
+func TestBatchBlockedPrivateAgentResumeRequiresInvokePermission(t *testing.T) {
+	agentID, _, memberID := privateAgentTestFixture(t)
+	issues := []IssueResponse{
+		createIssueForTest(t, map[string]any{"title": "private batch resume 1", "status": "blocked"}),
+		createIssueForTest(t, map[string]any{"title": "private batch resume 2", "status": "blocked"}),
+	}
+	issueIDs := make([]string, 0, len(issues))
+	for _, issue := range issues {
+		assignIssueToAgentForTest(t, issue.ID, agentID)
+		issueIDs = append(issueIDs, issue.ID)
+	}
+
+	preview := previewIssueTriggerAs(t, memberID, map[string]any{
+		"issue_ids": issueIDs,
+		"status":    "todo",
+	})
+	if preview.TotalCount != 0 {
+		t.Fatalf("batch preview: expected no triggers, got %+v", preview)
+	}
+
+	w := httptest.NewRecorder()
+	req := newRequestAs(memberID, "POST", "/api/issues/batch-update", map[string]any{
+		"issue_ids": issueIDs,
+		"updates":   map[string]any{"status": "todo"},
+	})
+	testHandler.BatchUpdateIssues(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("BatchUpdateIssues: %d %s", w.Code, w.Body.String())
+	}
+	var batchResp struct {
+		Updated int `json:"updated"`
+	}
+	if err := json.NewDecoder(w.Body).Decode(&batchResp); err != nil {
+		t.Fatalf("decode batch response: %v", err)
+	}
+	if batchResp.Updated != len(issues) {
+		t.Fatalf("batch status update: expected %d updated, got %d", len(issues), batchResp.Updated)
+	}
+	for _, issue := range issues {
+		if got := taskCountFor(t, issue.ID, agentID); got != 0 {
+			t.Fatalf("batch write disagreed with preview for issue %s: enqueued %d tasks", issue.ID, got)
+		}
+	}
+}
+
+func TestBlockedPrivateAgentResumeAllowsOwner(t *testing.T) {
+	agentID, ownerID, _ := privateAgentTestFixture(t)
+	issue := createIssueForTest(t, map[string]any{
+		"title":  "private agent owner resume",
+		"status": "blocked",
+	})
+	assignIssueToAgentForTest(t, issue.ID, agentID)
+
+	preview := previewIssueTriggerAs(t, ownerID, map[string]any{
+		"issue_ids": []string{issue.ID},
+		"status":    "todo",
+	})
+	if preview.TotalCount != 1 || len(preview.Triggers) != 1 {
+		t.Fatalf("owner preview: expected one trigger, got %+v", preview)
+	}
+
+	w := httptest.NewRecorder()
+	req := withURLParam(newRequestAs(ownerID, "PUT", "/api/issues/"+issue.ID, map[string]any{
+		"status": "todo",
+	}), "id", issue.ID)
+	testHandler.UpdateIssue(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("UpdateIssue as owner: %d %s", w.Code, w.Body.String())
+	}
+	if got := taskCountFor(t, issue.ID, agentID); got != 1 {
+		t.Fatalf("owner write disagreed with preview: expected 1 task, got %d", got)
 	}
 }
 

--- a/server/internal/handler/issue_trigger_preview_test.go
+++ b/server/internal/handler/issue_trigger_preview_test.go
@@ -138,6 +138,82 @@ func TestPreviewIssueTrigger_BatchAggregates(t *testing.T) {
 	}
 }
 
+// TestBlockedToTodoRestartsSquad verifies that once a squad-assigned issue is
+// parked as blocked and its previous run has ended, moving it back to todo must
+// preview and enqueue a fresh leader task.
+func TestBlockedToTodoRestartsSquad(t *testing.T) {
+	ctx := context.Background()
+	leaderID := seededReadyAgentID(t)
+
+	var squadID string
+	if err := testPool.QueryRow(ctx, `
+		INSERT INTO squad (workspace_id, name, description, leader_id, creator_id)
+		VALUES ($1, $2, '', $3, $4)
+		RETURNING id
+	`, testWorkspaceID, "Blocked Recovery Squad", leaderID, testUserID).Scan(&squadID); err != nil {
+		t.Fatalf("create squad: %v", err)
+	}
+	t.Cleanup(func() { _, _ = testPool.Exec(ctx, `DELETE FROM squad WHERE id = $1`, squadID) })
+
+	issue := createIssueForTest(t, map[string]any{
+		"title":  "blocked squad recovery",
+		"status": "blocked",
+	})
+	if _, err := testPool.Exec(ctx, `
+		UPDATE issue SET assignee_type = 'squad', assignee_id = $2 WHERE id = $1
+	`, issue.ID, squadID); err != nil {
+		t.Fatalf("assign blocked issue to squad: %v", err)
+	}
+
+	preview := previewIssueTrigger(t, map[string]any{
+		"issue_ids": []string{issue.ID},
+		"status":    "todo",
+	})
+	if preview.TotalCount != 1 || len(preview.Triggers) != 1 {
+		t.Fatalf("blocked->todo preview: expected 1 trigger, got %+v", preview)
+	}
+	if trigger := preview.Triggers[0]; trigger.AgentID != leaderID || trigger.Source != "status" {
+		t.Fatalf("blocked->todo preview: wrong trigger %+v", trigger)
+	}
+
+	w := httptest.NewRecorder()
+	req := withURLParam(newRequest("PUT", "/api/issues/"+issue.ID, map[string]any{
+		"status": "todo",
+	}), "id", issue.ID)
+	testHandler.UpdateIssue(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("UpdateIssue blocked->todo: %d %s", w.Code, w.Body.String())
+	}
+	if got := taskCountFor(t, issue.ID, leaderID); got != 1 {
+		t.Fatalf("blocked->todo: expected 1 squad-leader task, got %d", got)
+	}
+}
+
+func TestBlockedToNonRunnableStatusDoesNotRestart(t *testing.T) {
+	agentID := seededReadyAgentID(t)
+	for _, status := range []string{"backlog", "done", "cancelled"} {
+		t.Run(status, func(t *testing.T) {
+			issue := createIssueForTest(t, map[string]any{
+				"title":  "blocked non-runnable " + status,
+				"status": "blocked",
+			})
+			if _, err := testPool.Exec(context.Background(), `
+				UPDATE issue SET assignee_type = 'agent', assignee_id = $2 WHERE id = $1
+			`, issue.ID, agentID); err != nil {
+				t.Fatalf("assign blocked issue: %v", err)
+			}
+
+			preview := previewIssueTrigger(t, map[string]any{
+				"issue_ids": []string{issue.ID},
+				"status":    status,
+			})
+			if preview.TotalCount != 0 {
+				t.Fatalf("blocked->%s: expected no trigger, got %+v", status, preview)
+			}
+		})
+	}
+}
+
 // TestPreviewIssueTrigger_MatchesWritePath is the core invariant: when preview
 // says a run will start, the real write path enqueues it; when preview says it
 // won't, the write path enqueues nothing.

--- a/server/internal/service/issue_trigger.go
+++ b/server/internal/service/issue_trigger.go
@@ -15,8 +15,8 @@ const (
 	// RunSourceAssign covers issue creation and assignee changes — the issue
 	// is being handed to an agent/squad. Parks silently on backlog.
 	RunSourceAssign RunEnqueueSource = "assign"
-	// RunSourceStatus covers promoting an already-assigned issue out of
-	// backlog into an active status.
+	// RunSourceStatus covers activating an already-assigned parked issue by
+	// moving it out of backlog or blocked into a runnable status.
 	RunSourceStatus RunEnqueueSource = "status"
 )
 
@@ -30,9 +30,9 @@ const (
 // gate so it never leaks a private agent's readiness to a member who cannot
 // see it. A nil func is treated as allow-all.
 //
-// IsSelfLoop reports whether promoting this issue out of backlog would be the
-// calling agent re-triggering its own running task. Only the status source
-// consults it; create and assign never do. A nil func means "not a self-loop".
+// IsSelfLoop reports whether activating this parked issue would be the calling
+// agent re-triggering its own running task. Only the status source consults it;
+// create and assign never do. A nil func means "not a self-loop".
 type IssueTriggerProbe struct {
 	CanAccessAgent func(agent db.Agent) bool
 	IsSelfLoop     func() bool
@@ -77,7 +77,7 @@ func allowAllAgents(db.Agent) bool { return true }
 // CreateAgentTask, guarded by the (issue_id, agent_id) partial unique index
 // over pending (queued/dispatched) tasks; the pending check below mirrors that
 // guard, and only the status source needs it:
-//   - status source (backlog → active) can re-fire against an assignee that
+//   - status source (parked → runnable) can re-fire against an assignee that
 //     already holds a pending task (e.g. one a @mention raised while the issue
 //     sat in backlog); the check keeps preview from promising a run the unique
 //     index would coalesce away.
@@ -104,8 +104,8 @@ func (s *IssueService) WillEnqueueRun(ctx context.Context, in IssueTriggerInput,
 			return IssueRunTrigger{}, false
 		}
 		source = RunSourceAssign
-	case in.StatusChanged && in.PrevStatus == "backlog" &&
-		issue.Status != "done" && issue.Status != "cancelled":
+	case in.StatusChanged && isParkedIssueStatus(in.PrevStatus) &&
+		isRunnableIssueStatus(issue.Status):
 		if probe.IsSelfLoop != nil && probe.IsSelfLoop() {
 			return IssueRunTrigger{}, false
 		}
@@ -163,6 +163,19 @@ func (s *IssueService) WillEnqueueRun(ctx context.Context, in IssueTriggerInput,
 		}, true
 	}
 	return IssueRunTrigger{}, false
+}
+
+func isParkedIssueStatus(status string) bool {
+	return status == "backlog" || status == "blocked"
+}
+
+func isRunnableIssueStatus(status string) bool {
+	switch status {
+	case "todo", "in_progress", "in_review":
+		return true
+	default:
+		return false
+	}
 }
 
 // hasPendingRun reports whether the agent already holds a queued or dispatched

--- a/server/internal/service/issue_trigger.go
+++ b/server/internal/service/issue_trigger.go
@@ -23,12 +23,10 @@ const (
 // IssueTriggerProbe carries the request-scoped checks WillEnqueueRun cannot
 // resolve from issue state alone.
 //
-// CanAccessAgent is the private-agent gate. The write paths enforce it at the
-// HTTP boundary (validateAssigneePair on assign, canEnqueueSquadLeader inside
-// the squad enqueue helper) and therefore pass an allow-all probe so the gate
-// is never duplicated or sunk into the service layer. Preview passes the real
-// gate so it never leaks a private agent's readiness to a member who cannot
-// see it. A nil func is treated as allow-all.
+// CanAccessAgent is the invocation-permission gate shared by preview and write
+// paths. Keeping it in this decision is required for status-only writes, which
+// do not revalidate an unchanged assignee. A nil func is treated as allow-all
+// for callers that have no request-scoped permission model.
 //
 // IsSelfLoop reports whether activating this parked issue would be the calling
 // agent re-triggering its own running task. Only the status source consults it;


### PR DESCRIPTION
## Summary
- restart assigned agent or squad runs when blocked issues move to todo, in progress, or in review
- keep backlog, done, and cancelled transitions non-triggering
- cover squad recovery and non-runnable destinations with regression tests

## Tests
- `go test ./internal/handler -run "Test(BlockedToTodoRestartsSquad|BlockedToNonRunnableStatusDoesNotRestart|PreviewIssueTrigger_BatchAggregates|PreviewIssueTrigger_MatchesWritePath)$" -count=1`
- `go test ./internal/service -count=1`