### PR TITLE
fix(codex): record file-change payloads, and render them as diffs

### DIFF
--- a/packages/views/common/task-transcript/agent-transcript-dialog.test.tsx
+++ b/packages/views/common/task-transcript/agent-transcript-dialog.test.tsx
@@ -505,6 +505,32 @@ describe("AgentTranscriptDialog", () => {
     expect(css).toContain(".transcript-code");
   });
 
+  it("renders a patch-applying provider's changes as diffs, one per file", () => {
+    useTranscriptViewStore.setState({ density: "expanded" });
+    const { container } = renderDialog([
+      {
+        seq: 1,
+        type: "tool_use",
+        // Provider-native name and payload shape — nothing Claude-specific.
+        tool: "patch_apply",
+        input: {
+          changes: [
+            { path: "/repo/a.py", diff: '@@ -1 +1 @@\n-old = 1\n+new = 2\n' },
+            { path: "/repo/b.py", diff: "@@ -1 +1 @@\n-x\n+y\n" },
+          ],
+        },
+      },
+    ]);
+
+    const rows = (selector: string) =>
+      Array.from(container.querySelectorAll(selector)).map((el) => el.textContent?.trim());
+    expect(rows(".bg-destructive\\/10")).toEqual(["- old = 1", "- x"]);
+    expect(rows(".bg-success\\/10")).toEqual(["+ new = 2", "+ y"]);
+    // Both paths are named, since the row label can only name one.
+    expect(container.textContent).toContain("repo/a.py");
+    expect(container.textContent).toContain("repo/b.py");
+  });
+
   it("leaves an unknown extension unhighlighted rather than guessing", () => {
     useTranscriptViewStore.setState({ density: "expanded" });
     const { container } = renderDialog([

--- a/packages/views/common/task-transcript/agent-transcript-dialog.tsx
+++ b/packages/views/common/task-transcript/agent-transcript-dialog.tsx
@@ -64,8 +64,9 @@ import {
   traceEventLabel,
   traceEventSummary,
   traceEventSummaryIsMono,
+  shortenTracePath,
 } from "./trace-event-presenter";
-import type { TraceDiffLine } from "./trace-event-presenter";
+import type { TraceDiffFile, TraceDiffLine } from "./trace-event-presenter";
 import { highlightBlock, highlightToLines, languageForPath } from "./diff-highlight";
 import { useT } from "../../i18n";
 import "../../editor/styles/code.css";
@@ -1220,7 +1221,7 @@ const TranscriptEventRow = ({
             <div className="px-4 pb-3">
               <div className="ml-[72px] rounded-md bg-muted/40">
                 {detail.kind === "diff" ? (
-                  <DiffDetailSurface lines={detail.lines} path={detail.path} />
+                  <DiffDetailSurface files={detail.files} />
                 ) : detail.kind === "file" ? (
                   <FileWriteSurface text={detail.text} lineCount={detail.lineCount} path={detail.path} />
                 ) : (
@@ -1334,32 +1335,40 @@ function FileWriteSurface({
  * fade/"show all" shell as the text surface so both bodies behave alike inside
  * the virtualized list.
  */
-function DiffDetailSurface({ lines, path }: { lines: TraceDiffLine[]; path: string }) {
+function DiffDetailSurface({ files }: { files: TraceDiffFile[] }) {
   const { t } = useT("agents");
   const [showAll, setShowAll] = useState(false);
+  const lines = files.flatMap((f) => f.lines);
   const isLong = lines.length > 14;
   const added = lines.filter((l) => l.kind === "add").length;
   const removed = lines.filter((l) => l.kind === "remove").length;
+  // A patch can touch several files; the row label only names one, so each
+  // file's own path has to be visible when there is more than one.
+  const showPaths = files.length > 1;
 
   // Each side is highlighted as one block so multi-line strings and comments
   // keep their grammar, then split back per line to sit in the diff gutter.
   // Runs only when the row is expanded, which is where this component mounts.
-  const highlighted = useMemo(() => {
-    const language = languageForPath(path);
-    if (!language) return null;
-    const sides: Record<"add" | "remove" | "context", string[] | null> = {
-      add: null,
-      remove: null,
-      context: null,
-    };
-    for (const kind of ["add", "remove", "context"] as const) {
-      const side = lines.filter((l) => l.kind === kind);
-      if (side.length > 0) {
-        sides[kind] = highlightToLines(side.map((l) => l.text).join("\n"), language);
-      }
-    }
-    return sides;
-  }, [lines, path]);
+  const highlighted = useMemo(
+    () =>
+      files.map((file) => {
+        const language = languageForPath(file.path);
+        if (!language) return null;
+        const sides: Record<"add" | "remove" | "context", string[] | null> = {
+          add: null,
+          remove: null,
+          context: null,
+        };
+        for (const kind of ["add", "remove", "context"] as const) {
+          const side = file.lines.filter((l) => l.kind === kind);
+          if (side.length > 0) {
+            sides[kind] = highlightToLines(side.map((l) => l.text).join("\n"), language);
+          }
+        }
+        return sides;
+      }),
+    [files],
+  );
 
   return (
     <div className="relative">
@@ -1373,7 +1382,18 @@ function DiffDetailSurface({ lines, path }: { lines: TraceDiffLine[]; path: stri
           isLong && !showAll && "max-h-52 overflow-hidden",
         )}
       >
-        {renderDiffRows(lines, highlighted)}
+        {files.map((file, fileIndex) => (
+          // Transcript events are immutable once persisted, so index is stable.
+          <div key={fileIndex}>
+            {showPaths && (
+              <div className="pt-1 pb-0.5 text-[10px] text-muted-foreground/70">
+                {shortenTracePath(file.path)}
+                {file.movePath ? ` → ${shortenTracePath(file.movePath)}` : ""}
+              </div>
+            )}
+            {renderDiffRows(file.lines, highlighted[fileIndex] ?? null)}
+          </div>
+        ))}
       </pre>
       {isLong && !showAll && (
         <div className="absolute inset-x-0 bottom-0 flex h-12 items-end justify-center rounded-b-md bg-gradient-to-b from-transparent to-background">

--- a/packages/views/common/task-transcript/trace-event-presenter.test.ts
+++ b/packages/views/common/task-transcript/trace-event-presenter.test.ts
@@ -383,3 +383,24 @@ describe("traceEventDetail — patch-applying providers", () => {
     expect(none.kind).toBe("text");
   });
 });
+
+describe("traceToolArgSummary — patch payloads", () => {
+  it("names the patched file, so the collapsed row is not blank", () => {
+    expect(
+      traceToolArgSummary({ changes: [{ path: "/repo/src/greet.py", diff: "@@ -1 +1 @@\n-a\n+b\n" }] }),
+    ).toBe(".../src/greet.py");
+  });
+
+  it("counts the rest when a patch touches several files", () => {
+    expect(
+      traceToolArgSummary({
+        changes: [{ path: "/repo/a.py" }, { path: "/repo/b.py" }, { path: "/repo/c.py" }],
+      }),
+    ).toBe("/repo/a.py +2 more");
+  });
+
+  it("falls through to the string ladder when changes carries no path", () => {
+    expect(traceToolArgSummary({ changes: [{ diff: "@@" }], command: "ls" })).toBe("ls");
+    expect(traceToolArgSummary({ changes: "not-an-array", command: "ls" })).toBe("ls");
+  });
+});

--- a/packages/views/common/task-transcript/trace-event-presenter.test.ts
+++ b/packages/views/common/task-transcript/trace-event-presenter.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
   collapseDiffContext,
+  parseUnifiedDiff,
   stripShellWrapper,
   traceEventCopyText,
   traceEventDefaultExpanded,
@@ -170,8 +171,9 @@ describe("traceEventDetail", () => {
     });
     expect(detail.kind).toBe("diff");
     if (detail.kind !== "diff") return;
-    expect(detail.path).toBe("/repo/src/counter.rs");
-    expect(detail.lines).toEqual([
+    expect(detail.files).toHaveLength(1);
+    expect(detail.files[0]?.path).toBe("/repo/src/counter.rs");
+    expect(detail.files[0]?.lines).toEqual([
       { kind: "context", text: "let a = 1;" },
       { kind: "remove", text: "let b = 2;" },
       { kind: "add", text: "let b = 3;" },
@@ -202,7 +204,7 @@ describe("traceEventDetail", () => {
     });
     expect(detail.kind).toBe("diff");
     if (detail.kind !== "diff") return;
-    expect(detail.lines).toEqual([{ kind: "add", text: "added" }]);
+    expect(detail.files[0]?.lines).toEqual([{ kind: "add", text: "added" }]);
   });
 
   it("keeps a deletion visible when new_string is empty", () => {
@@ -212,7 +214,7 @@ describe("traceEventDetail", () => {
     });
     expect(detail.kind).toBe("diff");
     if (detail.kind !== "diff") return;
-    expect(detail.lines).toEqual([{ kind: "remove", text: "gone" }]);
+    expect(detail.files[0]?.lines).toEqual([{ kind: "remove", text: "gone" }]);
   });
 
   it("falls back to pretty JSON for a tool call that is not an edit", () => {
@@ -286,5 +288,98 @@ describe("collapseDiffContext", () => {
       { kind: "add" as const, text: "b" },
     ];
     expect(collapseDiffContext(lines)).toEqual(lines);
+  });
+});
+
+describe("parseUnifiedDiff", () => {
+  // Fixture captured from codex-cli 0.145.0: a `fileChange` item hands over a
+  // ready-made unified diff rather than before/after text.
+  const codexDiff =
+    '@@ -1,2 +1,2 @@\n def greet(name):\n-    return f"Hello, {name}!"\n+    return f"Hey, {name}!"\n';
+
+  it("reads a hunk into rows without re-diffing anything", () => {
+    expect(parseUnifiedDiff(codexDiff)).toEqual([
+      { kind: "context", text: "def greet(name):" },
+      { kind: "remove", text: '    return f"Hello, {name}!"' },
+      { kind: "add", text: '    return f"Hey, {name}!"' },
+    ]);
+  });
+
+  it("marks a hunk boundary as a gap, but not before the first hunk", () => {
+    const kinds = parseUnifiedDiff("@@ -1 +1 @@\n-a\n+b\n@@ -9 +9 @@\n-y\n+z\n").map(
+      (l) => l.kind,
+    );
+    expect(kinds).toEqual(["remove", "add", "gap", "remove", "add"]);
+  });
+
+  it("drops file headers and the no-newline marker", () => {
+    const out = parseUnifiedDiff("--- a/f\n+++ b/f\n@@ -1 +1 @@\n-a\n+b\n\\ No newline at end of file\n");
+    expect(out).toEqual([
+      { kind: "remove", text: "a" },
+      { kind: "add", text: "b" },
+    ]);
+  });
+
+  it("keeps an unmarked body line as context rather than dropping evidence", () => {
+    expect(parseUnifiedDiff("@@ -1 +1 @@\nunmarked\n")).toEqual([
+      { kind: "context", text: "unmarked" },
+    ]);
+  });
+
+  it("survives an empty or marker-only diff", () => {
+    expect(parseUnifiedDiff("")).toEqual([]);
+    expect(parseUnifiedDiff("@@ -0,0 +0,0 @@\n")).toEqual([]);
+  });
+});
+
+describe("traceEventDetail — patch-applying providers", () => {
+  const change = (path: string, diff: string, movePath?: string) => ({
+    path,
+    diff,
+    ...(movePath ? { move_path: movePath } : {}),
+  });
+
+  it("renders a patch_apply payload as one diff per touched file", () => {
+    const detail = traceEventDetail({
+      type: "tool_use",
+      tool: "patch_apply",
+      input: {
+        changes: [
+          change("/repo/a.py", "@@ -1 +1 @@\n-old\n+new\n"),
+          change("/repo/b.py", "@@ -1 +1 @@\n-x\n+y\n"),
+        ],
+      },
+    });
+    expect(detail.kind).toBe("diff");
+    if (detail.kind !== "diff") return;
+    expect(detail.files.map((f) => f.path)).toEqual(["/repo/a.py", "/repo/b.py"]);
+    expect(detail.files[0]?.lines).toEqual([
+      { kind: "remove", text: "old" },
+      { kind: "add", text: "new" },
+    ]);
+  });
+
+  it("carries a rename target through", () => {
+    const detail = traceEventDetail({
+      type: "tool_use",
+      input: { changes: [change("/repo/old.py", "@@ -1 +1 @@\n-a\n+b\n", "/repo/new.py")] },
+    });
+    expect(detail.kind).toBe("diff");
+    if (detail.kind !== "diff") return;
+    expect(detail.files[0]?.movePath).toBe("/repo/new.py");
+  });
+
+  it("skips entries with no usable path or diff, and falls back when none are usable", () => {
+    const partial = traceEventDetail({
+      type: "tool_use",
+      input: { changes: [{ path: "/only-path" }, change("/repo/ok.py", "@@ -1 +1 @@\n+ok\n")] },
+    });
+    expect(partial.kind).toBe("diff");
+    if (partial.kind !== "diff") return;
+    expect(partial.files.map((f) => f.path)).toEqual(["/repo/ok.py"]);
+
+    // Nothing usable: the JSON view is more honest than an empty diff.
+    const none = traceEventDetail({ type: "tool_use", input: { changes: [{ path: "/p" }] } });
+    expect(none.kind).toBe("text");
   });
 });

--- a/packages/views/common/task-transcript/trace-event-presenter.ts
+++ b/packages/views/common/task-transcript/trace-event-presenter.ts
@@ -203,8 +203,16 @@ export interface TraceDiffLine {
  * plain content, because nothing was compared — marking all of it `+` adds
  * noise, not information. Everything else is text.
  */
+/** One file's worth of change inside an edit event. */
+export interface TraceDiffFile {
+  path: string;
+  lines: TraceDiffLine[];
+  /** Rename target, when the change moves the file. */
+  movePath?: string;
+}
+
 export type TraceEventDetail =
-  | { kind: "diff"; path: string; lines: TraceDiffLine[] }
+  | { kind: "diff"; files: TraceDiffFile[] }
   | { kind: "file"; path: string; text: string; lineCount: number }
   | { kind: "text"; text: string };
 
@@ -312,12 +320,73 @@ export function collapseDiffContext(
  * providers call this Edit, patch_apply, str_replace, write_file… and the
  * presenter's contract is to keep provider-native names verbatim.
  */
+/**
+ * Parse a unified diff hunk into rows. Providers that apply patches (Codex's
+ * `patch_apply`) hand over a ready-made unified diff rather than before/after
+ * text, so there is nothing to diff — only to read.
+ *
+ * `@@` headers become a `gap`, since that is exactly what they mark: skipped
+ * context. `\ No newline at end of file` is dropped; it describes the file, not
+ * a line of it.
+ */
+export function parseUnifiedDiff(diff: string): TraceDiffLine[] {
+  const out: TraceDiffLine[] = [];
+  for (const raw of diff.split("\n")) {
+    if (raw.startsWith("\\")) continue;
+    if (raw.startsWith("@@")) {
+      // Only mark a break between hunks, not before the first one.
+      if (out.length > 0) out.push({ kind: "gap", text: "" });
+      continue;
+    }
+    // File headers appear when a diff carries more than its hunks.
+    if (raw.startsWith("+++") || raw.startsWith("---")) continue;
+    if (raw.startsWith("+")) {
+      out.push({ kind: "add", text: raw.slice(1) });
+    } else if (raw.startsWith("-")) {
+      out.push({ kind: "remove", text: raw.slice(1) });
+    } else if (raw.startsWith(" ")) {
+      out.push({ kind: "context", text: raw.slice(1) });
+    } else if (raw.length > 0) {
+      // A hunk body line should always carry a marker; keep an unmarked one as
+      // context rather than dropping evidence.
+      out.push({ kind: "context", text: raw });
+    }
+  }
+  // A trailing newline in the diff yields one empty context row; drop it.
+  while (out.length > 0 && out[out.length - 1]?.kind === "context" && out[out.length - 1]?.text === "") {
+    out.pop();
+  }
+  return out;
+}
+
 type FileMutation =
   | { mode: "replace"; path: string; before: string[]; after: string[] }
-  | { mode: "write"; path: string; content: string };
+  | { mode: "write"; path: string; content: string }
+  | { mode: "patch"; files: TraceDiffFile[] };
 
 function readFileMutation(input: Record<string, unknown>): FileMutation | null {
   const str = (v: unknown): string | null => (typeof v === "string" ? v : null);
+
+  // A patch-applying provider sends one entry per touched file, each with its
+  // own ready-made unified diff.
+  if (Array.isArray(input.changes)) {
+    const files: TraceDiffFile[] = [];
+    for (const entry of input.changes) {
+      if (typeof entry !== "object" || entry === null) continue;
+      const change = entry as Record<string, unknown>;
+      const changePath = str(change.path);
+      const diff = str(change.diff);
+      if (changePath === null || diff === null) continue;
+      const movePath = str(change.move_path);
+      files.push({
+        path: changePath,
+        lines: parseUnifiedDiff(diff),
+        ...(movePath !== null ? { movePath } : {}),
+      });
+    }
+    if (files.length > 0) return { mode: "patch", files };
+  }
+
   const path = str(input.file_path) ?? str(input.path);
   if (path === null) return null;
 
@@ -346,11 +415,18 @@ export function traceEventDetail(event: TraceEvent): TraceEventDetail {
     case "tool_use": {
       if (!event.input) return { kind: "text", text: "" };
       const mutation = readFileMutation(event.input);
+      if (mutation?.mode === "patch") {
+        return { kind: "diff", files: mutation.files };
+      }
       if (mutation?.mode === "replace") {
         return {
           kind: "diff",
-          path: mutation.path,
-          lines: collapseDiffContext(diffTraceLines(mutation.before, mutation.after)),
+          files: [
+            {
+              path: mutation.path,
+              lines: collapseDiffContext(diffTraceLines(mutation.before, mutation.after)),
+            },
+          ],
         };
       }
       if (mutation?.mode === "write") {

--- a/packages/views/common/task-transcript/trace-event-presenter.ts
+++ b/packages/views/common/task-transcript/trace-event-presenter.ts
@@ -103,6 +103,11 @@ function clip(value: string, max: number): string {
 export function traceToolArgSummary(input: Record<string, unknown> | undefined): string {
   if (!input) return "";
   const str = (v: unknown): string => (typeof v === "string" ? v : "");
+  // A patch payload names its files in an array, so the string-field ladder
+  // below would leave the collapsed row blank — the one line that reads without
+  // a click.
+  const patched = patchedPathsSummary(input);
+  if (patched) return patched;
   if (str(input.query)) return str(input.query);
   if (str(input.file_path)) return shortenTracePath(str(input.file_path));
   if (str(input.path)) return shortenTracePath(str(input.path));
@@ -115,6 +120,20 @@ export function traceToolArgSummary(input: Record<string, unknown> | undefined):
     if (typeof v === "string" && v.length > 0 && v.length < 120) return v;
   }
   return "";
+}
+
+/** "…/a.py" for one file, "…/a.py +2 more" beyond that. */
+function patchedPathsSummary(input: Record<string, unknown>): string {
+  if (!Array.isArray(input.changes)) return "";
+  const paths: string[] = [];
+  for (const entry of input.changes) {
+    if (typeof entry !== "object" || entry === null) continue;
+    const path = (entry as Record<string, unknown>).path;
+    if (typeof path === "string" && path.length > 0) paths.push(shortenTracePath(path));
+  }
+  if (paths.length === 0) return "";
+  const first = paths[0] ?? "";
+  return paths.length === 1 ? first : `${first} +${paths.length - 1} more`;
 }
 
 function firstLine(value: string | undefined): string {

--- a/server/pkg/agent/codex.go
+++ b/server/pkg/agent/codex.go
@@ -1541,6 +1541,84 @@ const codexResumeUnavailableNotice = "[System notice] You were expected to conti
 // prior context was lost instead of the run silently continuing as new. The
 // notice is folded into the same text block as the prompt to stay within the
 // single-text-block turn input Codex already accepts.
+// codexFileChangeInput lifts a `fileChange` item's edits into the tool-use
+// payload. Codex sends one entry per touched file:
+//
+//	changes: [ { path, kind: { type, move_path }, diff } ]
+//
+// where `diff` is already a unified diff. Without this the event records only
+// that a patch happened, which is the one thing the transcript does not need to
+// be told. Shape confirmed against codex-cli 0.145.0 driving
+// `app-server --listen stdio://` (both item/started and item/completed carry
+// the same `changes` array; only `status` differs).
+//
+// Kept faithful rather than reshaped: the renderer decides how to present a
+// unified diff, and a lossy translation here would throw away the rename target
+// and the add/delete/update distinction.
+func codexFileChangeInput(item map[string]any) map[string]any {
+	raw, ok := item["changes"].([]any)
+	if !ok || len(raw) == 0 {
+		return nil
+	}
+	changes := make([]any, 0, len(raw))
+	for _, entry := range raw {
+		change, ok := entry.(map[string]any)
+		if !ok {
+			continue
+		}
+		normalized := map[string]any{}
+		if path, ok := change["path"].(string); ok && path != "" {
+			normalized["path"] = path
+		}
+		if diff, ok := change["diff"].(string); ok && diff != "" {
+			normalized["diff"] = diff
+		}
+		// `kind` is an object ({type: "update", move_path: null}); flatten the
+		// discriminator and keep the rename target only when there is one.
+		if kind, ok := change["kind"].(map[string]any); ok {
+			if kindType, ok := kind["type"].(string); ok && kindType != "" {
+				normalized["kind"] = kindType
+			}
+			if movePath, ok := kind["move_path"].(string); ok && movePath != "" {
+				normalized["move_path"] = movePath
+			}
+		}
+		if len(normalized) > 0 {
+			changes = append(changes, normalized)
+		}
+	}
+	if len(changes) == 0 {
+		return nil
+	}
+	return map[string]any{"changes": changes}
+}
+
+// codexFileChangeSummary is the result line for a completed `fileChange`. The
+// item carries no stdout of its own, so report what landed: the status Codex
+// reports plus one path per change. The diffs stay on the tool-use side rather
+// than being repeated here.
+func codexFileChangeSummary(item map[string]any) string {
+	status, _ := item["status"].(string)
+	if status == "" {
+		status = "completed"
+	}
+	raw, _ := item["changes"].([]any)
+	paths := make([]string, 0, len(raw))
+	for _, entry := range raw {
+		change, ok := entry.(map[string]any)
+		if !ok {
+			continue
+		}
+		if path, ok := change["path"].(string); ok && path != "" {
+			paths = append(paths, path)
+		}
+	}
+	if len(paths) == 0 {
+		return status
+	}
+	return status + ": " + strings.Join(paths, ", ")
+}
+
 func codexTurnInput(prompt string, resumeExpected, resumed bool) []map[string]any {
 	text := prompt
 	if resumeExpected && !resumed {
@@ -2598,6 +2676,7 @@ func (c *codexClient) handleItemNotification(method string, params map[string]an
 				Type:   MessageToolUse,
 				Tool:   "patch_apply",
 				CallID: itemID,
+				Input:  codexFileChangeInput(item),
 			})
 		}
 
@@ -2607,6 +2686,7 @@ func (c *codexClient) handleItemNotification(method string, params map[string]an
 				Type:   MessageToolResult,
 				Tool:   "patch_apply",
 				CallID: itemID,
+				Output: codexFileChangeSummary(item),
 			})
 		}
 

--- a/server/pkg/agent/codex_filechange_test.go
+++ b/server/pkg/agent/codex_filechange_test.go
@@ -1,0 +1,106 @@
+package agent
+
+import "testing"
+
+// Payloads captured from codex-cli 0.145.0 driving
+// `app-server --listen stdio://`, so these fixtures document the real schema
+// rather than an assumed one. item/started and item/completed carry the same
+// `changes` array; only `status` differs.
+
+func fileChangeItem(status string) map[string]any {
+	return map[string]any{
+		"type":   "fileChange",
+		"id":     "call_vxAMM6SbYYIxsWptB3Jmk3JW",
+		"status": status,
+		"changes": []any{
+			map[string]any{
+				"path": "/tmp/probe/sample.py",
+				"kind": map[string]any{"type": "update", "move_path": nil},
+				"diff": "@@ -1,2 +1,2 @@\n def greet(name):\n-    return f\"Hello, {name}!\"\n+    return f\"Hey, {name}!\"\n",
+			},
+		},
+	}
+}
+
+func TestCodexFileChangeInputCarriesPathKindAndDiff(t *testing.T) {
+	t.Parallel()
+
+	got := codexFileChangeInput(fileChangeItem("inProgress"))
+	changes, ok := got["changes"].([]any)
+	if !ok || len(changes) != 1 {
+		t.Fatalf("expected one change, got %#v", got)
+	}
+	change, ok := changes[0].(map[string]any)
+	if !ok {
+		t.Fatalf("expected a change object, got %#v", changes[0])
+	}
+	if change["path"] != "/tmp/probe/sample.py" {
+		t.Errorf("path = %v", change["path"])
+	}
+	if change["kind"] != "update" {
+		t.Errorf("kind should flatten to its discriminator, got %v", change["kind"])
+	}
+	if _, present := change["move_path"]; present {
+		t.Errorf("a null move_path must not be carried through: %#v", change)
+	}
+	diff, _ := change["diff"].(string)
+	if diff == "" || diff[:2] != "@@" {
+		t.Errorf("diff should be the unified diff verbatim, got %q", diff)
+	}
+}
+
+func TestCodexFileChangeInputKeepsRenameTarget(t *testing.T) {
+	t.Parallel()
+
+	item := map[string]any{"changes": []any{map[string]any{
+		"path": "/tmp/old.py",
+		"kind": map[string]any{"type": "update", "move_path": "/tmp/new.py"},
+		"diff": "@@ -1 +1 @@\n-a\n+b\n",
+	}}}
+	changes, _ := codexFileChangeInput(item)["changes"].([]any)
+	change, _ := changes[0].(map[string]any)
+	if change["move_path"] != "/tmp/new.py" {
+		t.Errorf("a rename must keep its target, got %#v", change)
+	}
+}
+
+func TestCodexFileChangeInputIsNilWhenThereIsNothingToRecord(t *testing.T) {
+	t.Parallel()
+
+	// An absent, empty, or unusably-shaped `changes` must produce no payload
+	// rather than an empty object: the UI treats an empty input as "no detail"
+	// and would otherwise offer an expander with nothing behind it.
+	for name, item := range map[string]map[string]any{
+		"absent":     {"type": "fileChange"},
+		"empty":      {"changes": []any{}},
+		"wrong type": {"changes": "not-an-array"},
+		"junk entry": {"changes": []any{"not-an-object"}},
+		"no fields":  {"changes": []any{map[string]any{"unrelated": 1}}},
+	} {
+		if got := codexFileChangeInput(item); got != nil {
+			t.Errorf("%s: expected nil, got %#v", name, got)
+		}
+	}
+}
+
+func TestCodexFileChangeSummaryReportsStatusAndPaths(t *testing.T) {
+	t.Parallel()
+
+	if got := codexFileChangeSummary(fileChangeItem("completed")); got != "completed: /tmp/probe/sample.py" {
+		t.Errorf("got %q", got)
+	}
+
+	multi := map[string]any{"status": "completed", "changes": []any{
+		map[string]any{"path": "/a.py"},
+		map[string]any{"path": "/b.py"},
+	}}
+	if got := codexFileChangeSummary(multi); got != "completed: /a.py, /b.py" {
+		t.Errorf("multi-file summary = %q", got)
+	}
+
+	// A missing status still reads as a result rather than an empty string,
+	// which the transcript renders as "no output".
+	if got := codexFileChangeSummary(map[string]any{"changes": []any{}}); got != "completed" {
+		t.Errorf("fallback status = %q", got)
+	}
+}

--- a/server/pkg/agent/codex_filechange_test.go
+++ b/server/pkg/agent/codex_filechange_test.go
@@ -1,6 +1,11 @@
 package agent
 
-import "testing"
+import (
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+)
 
 // Payloads captured from codex-cli 0.145.0 driving
 // `app-server --listen stdio://`, so these fixtures document the real schema
@@ -102,5 +107,70 @@ func TestCodexFileChangeSummaryReportsStatusAndPaths(t *testing.T) {
 	// which the transcript renders as "no output".
 	if got := codexFileChangeSummary(map[string]any{"changes": []any{}}); got != "completed" {
 		t.Errorf("fallback status = %q", got)
+	}
+}
+
+// End-to-end through the app-server client: the notification lines below are the
+// ones codex-cli 0.145.0 actually emits for an edit, so this covers the wiring
+// (params.item -> handler -> Message) and not just the extraction helpers.
+func TestCodexAppServerFileChangeMessagesCarryTheDiff(t *testing.T) {
+	t.Parallel()
+	if runtime.GOOS == "windows" {
+		t.Skip("shell-script fixture is POSIX-only")
+	}
+
+	const changes = `[{"path":"/tmp/probe/sample.py","kind":{"type":"update","move_path":null},` +
+		`"diff":"@@ -1,2 +1,2 @@\n def greet(name):\n-    return f\"Hello\"\n+    return f\"Hey\"\n"}]`
+
+	fakePath := writeFakeCodexAppServer(t, ""+
+		`read line`+"\n"+
+		`echo '{"jsonrpc":"2.0","id":1,"result":{}}'`+"\n"+
+		`read line`+"\n"+
+		`read line`+"\n"+
+		`echo '{"jsonrpc":"2.0","id":2,"result":{"thread":{"id":"thr-fc"}}}'`+"\n"+
+		`read line`+"\n"+
+		`echo '{"jsonrpc":"2.0","id":3,"result":{}}'`+"\n"+
+		`echo '{"jsonrpc":"2.0","method":"turn/started","params":{"threadId":"thr-fc","turn":{"id":"turn-fc"}}}'`+"\n"+
+		// printf, not echo: /bin/sh's echo expands the `\n` inside the diff and
+		// splits the JSON across lines, which the client then drops.
+		`printf '%s\n' '{"jsonrpc":"2.0","method":"item/started","params":{"threadId":"thr-fc","item":{"type":"fileChange","id":"call-1","status":"inProgress","changes":`+changes+`}}}'`+"\n"+
+		`printf '%s\n' '{"jsonrpc":"2.0","method":"item/completed","params":{"threadId":"thr-fc","item":{"type":"fileChange","id":"call-1","status":"completed","changes":`+changes+`}}}'`+"\n"+
+		`echo '{"jsonrpc":"2.0","method":"item/completed","params":{"threadId":"thr-fc","item":{"type":"agentMessage","id":"msg-1","text":"Done","phase":"final_answer"}}}'`+"\n"+
+		`echo '{"jsonrpc":"2.0","method":"turn/completed","params":{"threadId":"thr-fc","turn":{"id":"turn-fc","status":"completed"}}}'`+"\n")
+
+	_, messages := executeFakeCodexCollectingMessages(t, fakePath, ExecOptions{
+		Timeout: 10 * time.Second,
+	}, 15*time.Second)
+
+	var use, result *Message
+	for i := range messages {
+		if messages[i].Tool != "patch_apply" {
+			continue
+		}
+		switch messages[i].Type {
+		case MessageToolUse:
+			use = &messages[i]
+		case MessageToolResult:
+			result = &messages[i]
+		}
+	}
+
+	if use == nil || result == nil {
+		t.Fatalf("expected a patch_apply use and result, got %d messages", len(messages))
+	}
+
+	changeList, ok := use.Input["changes"].([]any)
+	if !ok || len(changeList) != 1 {
+		t.Fatalf("tool_use input should carry the changes, got %#v", use.Input)
+	}
+	change, _ := changeList[0].(map[string]any)
+	if change["path"] != "/tmp/probe/sample.py" || change["kind"] != "update" {
+		t.Errorf("change = %#v", change)
+	}
+	if diff, _ := change["diff"].(string); !strings.Contains(diff, `-    return f"Hello"`) {
+		t.Errorf("diff should survive verbatim, got %q", diff)
+	}
+	if result.Output != "completed: /tmp/probe/sample.py" {
+		t.Errorf("result output = %q", result.Output)
 	}
 }


### PR DESCRIPTION
Fixes #6157.

A Codex run recorded that a patch happened and nothing about it. Every
`patch_apply` event carried an empty `input`, `output` and `content`, so the
transcript showed one bare, unexpandable row per edit — six edits, six empty
rows, no way to see which file changed or how. Since #6134 renders edits as
diffs, the difference is now very visible: the same work reads as a diff on
Claude or Grok and as nothing at all on Codex.

## The data was already arriving

`item/started` and `item/completed` for a `fileChange` item both carry

```json
"changes": [
  { "path": "…", "kind": { "type": "update", "move_path": null },
    "diff": "@@ -1,2 +1,2 @@\n def greet(name):\n-    …\n+    …\n" }
]
```

with `diff` already a unified diff; only `status` differs between the two. The
handlers read `itemID` and dropped the rest, while the neighbouring
`exec_command` handlers read `command` and `output` in full.

Schema confirmed against **codex-cli 0.145.0** driving
`app-server --listen stdio://` with this repo's own handshake
(`initialize` → `initialized` → `thread/start` → `turn/start`, auto-accepting
`item/fileChange/requestApproval` the way daemon mode does). The test fixtures
are that captured payload rather than an assumed shape.

## What each commit does

1. **`fix(codex)`** — record the payload. Kept faithful rather than reshaped:
   `kind` flattens to its discriminator and a null `move_path` is dropped, but
   the diff is verbatim and the add/delete/update distinction survives. An
   absent or unusable `changes` yields no payload at all, so the UI does not
   offer an expander with nothing behind it.
2. **`feat(transcript)`** — render it. `parseUnifiedDiff` reads a hunk into rows
   (an `@@` header becomes the gap it marks; file headers and the no-newline
   marker are dropped). An edit's detail now carries a **list** of files rather
   than one path, because one patch can touch several; the existing before/after
   shapes produce a one-element list, so there is one model instead of two
   parallel ones, and each file is highlighted with the grammar for its own
   extension.
3. **`test(codex)`** — cover it end to end through the fake app-server, so the
   wiring from `params.item` to the streamed `Message` is exercised and not only
   the helpers.

## Deliberately out of scope

The legacy `codex/event` path (`patch_apply_begin` / `patch_apply_end`) has the
same gap and is **left alone**: codex 0.145.0 does not emit it even with
`experimentalRawEvents: true`, so its schema could only have been guessed at.
Happy to extend it if you can point me at a version that still speaks it, or
confirm the field names.

## Verification

- `go test ./pkg/agent -run 'TestCodexFileChange|TestCodexAppServerFileChange'` — 5 pass
- `gofmt`, `go vet`, `go build ./...` clean
- `packages/views` — 94 tests in `common/task-transcript/`, `tsc --noEmit` and `eslint` clean

Two notes on the existing suites, both reproduced on an unmodified `main`:
`go test ./pkg/agent` fails intermittently under load — a random subset, always
at exactly 5.00s, spanning providers this change does not touch (5 clean-tree
runs: 4 pass, 1 fail with 6 tests). And `pkg/agent/kimi_test.go` /
`kiro_test.go` are already unreported by `gofmt`; I left them as they are.
