### PR TITLE
fix(daemon): discover qodercli via the login shell (MUL-5524)

### DIFF
--- a/server/internal/daemon/agent_command_names_test.go
+++ b/server/internal/daemon/agent_command_names_test.go
@@ -16,16 +16,24 @@ import (
 // TestDefaultAgentCommandNamesCoversAllProbes guards the invariant documented
 // on defaultAgentCommandNames: the shell-fallback resolver only pre-fetches
 // canonical paths for the bare command names in that list, so every agent the
-// LoadConfig probe loop tries must appear there. A GUI/Launchpad-started
-// daemon does not inherit the interactive shell PATH, so an agent missing from
-// this list is undetectable when its binary lives only on the login-shell PATH
-// (e.g. an `npm install -g` global). This test parses config.go's probe(...)
-// calls so a new probe can't silently diverge from the fallback list.
+// probe loop tries must appear there. A GUI/Launchpad-started daemon does not
+// inherit the interactive shell PATH, so an agent missing from this list is
+// undetectable when its binary lives only on the login-shell PATH (e.g. an
+// `npm install -g` global). This test parses the probe(...) calls so a new
+// probe can't silently diverge from the fallback list.
+//
+// It parses agents_probe.go, which is where probeAgentCLIs now lives. It used
+// to parse config.go and silently degraded into a no-op when the probe loop
+// moved out of that file — which is how the missing "qodercli" entry survived
+// (MUL-5524). probeSourceFile is asserted to actually contain probe() calls so
+// a future move fails loudly instead of vacuously passing.
+const probeSourceFile = "agents_probe.go"
+
 func TestDefaultAgentCommandNamesCoversAllProbes(t *testing.T) {
 	fset := token.NewFileSet()
-	file, err := parser.ParseFile(fset, "config.go", nil, 0)
+	file, err := parser.ParseFile(fset, probeSourceFile, nil, 0)
 	if err != nil {
-		t.Fatalf("parse config.go: %v", err)
+		t.Fatalf("parse %s: %v", probeSourceFile, err)
 	}
 
 	known := make(map[string]bool, len(defaultAgentCommandNames))
@@ -34,6 +42,7 @@ func TestDefaultAgentCommandNamesCoversAllProbes(t *testing.T) {
 	}
 
 	var missing []string
+	var probeCalls int
 	ast.Inspect(file, func(n ast.Node) bool {
 		call, ok := n.(*ast.CallExpr)
 		if !ok {
@@ -52,6 +61,7 @@ func TestDefaultAgentCommandNamesCoversAllProbes(t *testing.T) {
 		if !ok || lit.Kind != token.STRING {
 			return true
 		}
+		probeCalls++
 		name := lit.Value
 		if len(name) >= 2 {
 			name = name[1 : len(name)-1] // strip surrounding quotes
@@ -61,6 +71,15 @@ func TestDefaultAgentCommandNamesCoversAllProbes(t *testing.T) {
 		}
 		return true
 	})
+
+	// Without this the whole test passes vacuously the moment probeAgentCLIs
+	// moves to another file, which is exactly how this guard failed before.
+	if probeCalls < len(defaultAgentCommandNames) {
+		t.Fatalf("found only %d probe() call(s) with a literal command name in %s, "+
+			"expected at least %d (one per default agent command); "+
+			"did the probe loop move, or is a provider probed without probe()?",
+			probeCalls, probeSourceFile, len(defaultAgentCommandNames))
+	}
 
 	if len(missing) > 0 {
 		sort.Strings(missing)
@@ -90,9 +109,6 @@ func TestAgentCLIGuardCoversDefaultCommands(t *testing.T) {
 		if !guarded[name] {
 			t.Errorf("default agent command %q is not covered by the test guard", name)
 		}
-	}
-	if !guarded["qodercli"] {
-		t.Error("default qoder command \"qodercli\" is not covered by the test guard")
 	}
 }
 

--- a/server/internal/daemon/agents_probe.go
+++ b/server/internal/daemon/agents_probe.go
@@ -190,13 +190,14 @@ var probeAgentCLIs = func() map[string]AgentEntry {
 	if e, ok := probe("MULTICA_ANTIGRAVITY_PATH", "agy", "MULTICA_ANTIGRAVITY_MODEL"); ok {
 		agents["antigravity"] = e
 	}
-	qoderPath := envOrDefault("MULTICA_QODER_PATH", "qodercli")
-	if path, err := resolveAgentExecutablePath(qoderPath); err == nil {
-		agents["qoder"] = AgentEntry{
-			Path:    path,
-			Command: qoderPath,
-			Model:   strings.TrimSpace(os.Getenv("MULTICA_QODER_MODEL")),
-		}
+	// Qoder CLI ships as the `qodercli` binary (Qoder Desktop does not put it
+	// on PATH; users install it separately, often via an npm global prefix).
+	// It must go through probe() like every other provider so the login-shell
+	// fallback applies: a GUI/Launchpad-started daemon does not inherit the
+	// interactive shell PATH, and without the fallback a perfectly good
+	// qodercli install stayed invisible across restarts (MUL-5524).
+	if e, ok := probe("MULTICA_QODER_PATH", "qodercli", "MULTICA_QODER_MODEL"); ok {
+		agents["qoder"] = e
 	}
 	// ByteDance official TRAE CLI (the `traecli` binary from https://docs.trae.cn/cli),
 	// driven over ACP via `traecli acp serve --yolo`. MULTICA_TRAECLI_MODEL seeds

--- a/server/internal/daemon/agents_probe_qoder_test.go
+++ b/server/internal/daemon/agents_probe_qoder_test.go
@@ -1,0 +1,75 @@
+package daemon
+
+import (
+	"testing"
+)
+
+// TestProbeAgentCLIs_QoderResolvesViaLoginShell locks down the fix for the
+// Qoder discovery gap reported from the desktop app (MUL-5524).
+//
+// Every other provider is probed through the shared probe() helper, which falls
+// back to the user's login shell when the daemon's own PATH can't see a bare
+// command name. Qoder was probed with a bare resolveAgentExecutablePath call
+// and therefore had no fallback at all: a GUI/Launchpad-started daemon (the
+// apple.dmg desktop build) does not inherit the interactive shell PATH, so a
+// `qodercli` living in an npm global prefix or any ~/.zshrc-added dir was
+// undetectable no matter how many times the daemon restarted.
+func TestProbeAgentCLIs_QoderResolvesViaLoginShell(t *testing.T) {
+	orig := resolveAgentsViaLoginShell
+	t.Cleanup(func() { resolveAgentsViaLoginShell = orig })
+	resolveAgentsViaLoginShell = func([]string) map[string]string {
+		return map[string]string{"qodercli": "/fake/npm-global/bin/qodercli"}
+	}
+	resetShellResolveCacheForTest(t)
+
+	// An empty PATH guarantees the exec.LookPath leg misses, so the only way
+	// qoder can resolve is the login-shell fallback.
+	t.Setenv("PATH", "")
+
+	agents := probeAgentCLIs()
+	entry, ok := agents["qoder"]
+	if !ok {
+		t.Fatal("qoder was not discovered via the login-shell fallback; " +
+			"a GUI-launched daemon cannot see a qodercli installed on the interactive shell PATH")
+	}
+	if entry.Path != "/fake/npm-global/bin/qodercli" {
+		t.Errorf("qoder path = %q, want /fake/npm-global/bin/qodercli", entry.Path)
+	}
+	if entry.Command != "qodercli" {
+		t.Errorf("qoder command = %q, want qodercli", entry.Command)
+	}
+}
+
+// TestProbeAgentCLIs_QoderPinnedPathStaysHardMiss keeps the fallback from
+// rescuing an operator-pinned MULTICA_QODER_PATH. A pinned absolute path that
+// no longer exists must stay a miss rather than silently resolve a different
+// binary — the same rule probe() applies to every other provider.
+func TestProbeAgentCLIs_QoderPinnedPathStaysHardMiss(t *testing.T) {
+	orig := resolveAgentsViaLoginShell
+	t.Cleanup(func() { resolveAgentsViaLoginShell = orig })
+	resolveAgentsViaLoginShell = func([]string) map[string]string {
+		return map[string]string{"qodercli": "/fake/npm-global/bin/qodercli"}
+	}
+	resetShellResolveCacheForTest(t)
+
+	t.Setenv("PATH", "")
+	t.Setenv("MULTICA_QODER_PATH", "/nonexistent/pinned/qodercli")
+
+	if entry, ok := probeAgentCLIs()["qoder"]; ok {
+		t.Errorf("pinned-but-missing MULTICA_QODER_PATH resolved to %q, want a hard miss", entry.Path)
+	}
+}
+
+// TestDefaultAgentCommandNamesIncludesQoder guards the other half of the same
+// bug: cachedShellResolvedAgents only asks the login shell about the names in
+// defaultAgentCommandNames, so omitting "qodercli" would leave the fallback
+// permanently blind to Qoder even once the probe consults it.
+func TestDefaultAgentCommandNamesIncludesQoder(t *testing.T) {
+	for _, name := range defaultAgentCommandNames {
+		if name == "qodercli" {
+			return
+		}
+	}
+	t.Fatal(`defaultAgentCommandNames is missing "qodercli"; the login-shell resolver ` +
+		"only pre-fetches names in that list, so Qoder stays undetectable on a GUI-launched daemon")
+}

--- a/server/internal/daemon/config.go
+++ b/server/internal/daemon/config.go
@@ -731,7 +731,7 @@ func isExecutableFile(path string) bool {
 // invocation, instead of paying the cost-per-miss.
 var defaultAgentCommandNames = []string{
 	"claude", "codex", "opencode", "deveco", "openclaw", "hermes",
-	"pi", "cursor-agent", "copilot", "kimi", "kiro-cli", "codebuddy", "agy", "traecli", "grok", "qwen",
+	"pi", "cursor-agent", "copilot", "kimi", "kiro-cli", "codebuddy", "agy", "qodercli", "traecli", "grok", "qwen",
 }
 
 // codexDesktopAppBundlePaths returns candidate macOS app-bundle locations for


### PR DESCRIPTION
## Background

From a Discord report (MUL-5524): a user on the v0.4.14 macOS desktop build installed Qoder (desktop + `qodercli`), but the runtime never listed `qoder`. They had already picked up the "no restart needed" fix, so re-registering did not help.

Qoder *is* a fully supported provider — ACP backend (`server/pkg/agent/qoder.go`), runtime profile migration 134, provider logo, native `.qoder/skills` context, docs. The problem is purely in agent discovery.

## Root cause

Two gaps, both in `probeAgentCLIs`:

1. **No login-shell fallback for qoder.** Every other provider goes through the shared `probe()` helper, which falls back to resolving the command through the user's login shell when `exec.LookPath` misses. Qoder called `resolveAgentExecutablePath` directly, so it was the only provider with no fallback. A daemon started from Finder/Launchpad (the `apple.dmg` desktop build) does not inherit the interactive shell PATH, so a `qodercli` installed into an npm global prefix — or any dir added by `~/.zshrc` — was undetectable regardless of restarts. That is exactly the reported symptom.

2. **`qodercli` missing from `defaultAgentCommandNames`.** That list is the only set of names `cachedShellResolvedAgents` asks the login shell about. Even with the fallback wired up, the resolver would not have looked for Qoder.

## Why the existing guard didn't catch it

`TestDefaultAgentCommandNamesCoversAllProbes` exists precisely to prevent gap 2, and its doc comment describes this failure mode. But it parses `config.go` for `probe(...)` calls, and `probeAgentCLIs` has since moved to `agents_probe.go`. It found zero probes and passed vacuously.

## Changes

- `agents_probe.go`: route qoder through `probe("MULTICA_QODER_PATH", "qodercli", "MULTICA_QODER_MODEL")`.
- `config.go`: add `"qodercli"` to `defaultAgentCommandNames`.
- `agent_command_names_test.go`: parse `agents_probe.go`, and assert at least one `probe()` call per default command so a future file move fails loudly instead of silently. Dropped the now-redundant qoder special case.
- New `agents_probe_qoder_test.go` with three regression tests.

## Behaviour notes

- Pinned-path semantics unchanged: an absolute/relative `MULTICA_QODER_PATH` that does not exist stays a hard miss rather than silently resolving a different binary. Covered by a test.
- No new shell forks on the happy path — qoder now shares the same cached, lazy, TTL-bounded resolution as every other provider, so this removes a special case rather than adding cost.
- Discovery-only change: no migration, no API surface, no version gate touched.

## Testing

Reproduced first — `TestProbeAgentCLIs_QoderResolvesViaLoginShell` and `TestDefaultAgentCommandNamesIncludesQoder` both failed before the fix:

```
--- FAIL: TestProbeAgentCLIs_QoderResolvesViaLoginShell
    qoder was not discovered via the login-shell fallback
--- FAIL: TestDefaultAgentCommandNamesIncludesQoder
    defaultAgentCommandNames is missing "qodercli"
```

Verified the repaired guard is non-vacuous by pointing `probeSourceFile` back at `config.go`:

```
found only 0 probe() call(s) with a literal command name in config.go, expected at least 17
```

After the fix, under `scripts/go-test-with-agent-cli-guard.sh`:

- `go build ./...` and `go vet ./internal/daemon/` clean
- `go test ./internal/daemon/...` — ok (daemon, execenv, repocache)
- `go test ./pkg/agent/...` — ok

## Review focus

- The `probeCalls < len(defaultAgentCommandNames)` assertion is currently an exact 17-vs-17 match. It is intentionally strict: it assumes every default command is probed via `probe()`. If a provider ever legitimately needs bespoke probing, that assertion is the line to revisit.
- Worth confirming separately: the reporter also hit `multica daemon restart` → "no multica". The desktop `.dmg` does not put the `multica` CLI on PATH, which is a separate install-path concern and not addressed here.
