### PR TITLE
refactor(skills): one icon for the skill entity everywhere (MUL-5443)

### DIFF
--- a/packages/views/agents/components/skill-picker-list.tsx
+++ b/packages/views/agents/components/skill-picker-list.tsx
@@ -1,7 +1,8 @@
 "use client";
 
 import { useState } from "react";
-import { FileText, Search } from "lucide-react";
+import { Search } from "lucide-react";
+import { SkillIcon } from "../../skills/lib/skill-icon";
 import type { SkillSummary } from "@multica/core/types";
 import { Checkbox } from "@multica/ui/components/ui/checkbox";
 import { Input } from "@multica/ui/components/ui/input";
@@ -122,7 +123,7 @@ export function SkillPickerList({
                   tabIndex={-1}
                   className="pointer-events-none"
                 />
-                <FileText className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
+                <SkillIcon className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
                 <div className="min-w-0 flex-1">
                   <div className="truncate text-body font-medium">{skill.name}</div>
                   {skill.description ? (

--- a/packages/views/agents/components/tabs/skills-tab.tsx
+++ b/packages/views/agents/components/tabs/skills-tab.tsx
@@ -2,13 +2,13 @@
 
 import { useState } from "react";
 import {
-  FileText,
   Loader2,
   Plus,
   RefreshCw,
   Server,
   Trash2,
 } from "lucide-react";
+import { SkillIcon } from "../../../skills/lib/skill-icon";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { toast } from "sonner";
 import type {
@@ -162,7 +162,7 @@ export function SkillsTab({
       >
         {agent.skills.length === 0 ? (
           <EmptyState
-            icon={<FileText className="h-6 w-6" />}
+            icon={<SkillIcon className="h-6 w-6" />}
             title={t(($) => $.tab_body.skills.empty_title)}
             hint={t(($) => $.tab_body.skills.empty_hint)}
           />
@@ -184,7 +184,7 @@ export function SkillsTab({
                         !enabled && "opacity-50",
                       )}
                     >
-                      <FileText className="h-4 w-4" />
+                      <SkillIcon className="h-4 w-4" />
                     </span>
                     <span className="min-w-0 flex-1">
                       <span className={cn("block text-body font-medium", !enabled && "text-muted-foreground")}>

--- a/packages/views/onboarding/steps/step-workspace.tsx
+++ b/packages/views/onboarding/steps/step-workspace.tsx
@@ -4,7 +4,6 @@ import { type ReactNode, useRef, useState } from "react";
 import {
   ArrowLeft,
   ArrowRight,
-  BookOpenText,
   Bot,
   FolderKanban,
   Inbox,
@@ -15,6 +14,7 @@ import {
   Plus,
   Zap,
 } from "lucide-react";
+import { SkillIcon } from "../../skills/lib/skill-icon";
 import { toast } from "sonner";
 import { Button } from "@multica/ui/components/ui/button";
 import { Input } from "@multica/ui/components/ui/input";
@@ -626,7 +626,7 @@ function WorkspacePreviewCard({
           meta={t(($) => $.step_workspace.preview.runtimes_meta)}
         />
         <EntityRow
-          icon={<BookOpenText className="h-4 w-4" />}
+          icon={<SkillIcon className="h-4 w-4" />}
           label={t(($) => $.step_workspace.preview.skills_label)}
           meta={t(($) => $.step_workspace.preview.skills_meta)}
         />

--- a/packages/views/skills/components/skill-detail-page.test.tsx
+++ b/packages/views/skills/components/skill-detail-page.test.tsx
@@ -53,7 +53,10 @@ vi.mock("@multica/core/auth", () => {
     ),
   };
 });
-vi.mock("@multica/core/paths", () => ({
+// Partial: `WORKSPACE_PAGES` also comes from here and backs the shared
+// SkillIcon, so the real module has to stay reachable.
+vi.mock("@multica/core/paths", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@multica/core/paths")>()),
   useWorkspacePaths: () => ({ skills: () => "/acme/skills" }),
 }));
 vi.mock("@multica/core/permissions", () => ({

--- a/packages/views/skills/components/skill-detail-page.tsx
+++ b/packages/views/skills/components/skill-detail-page.tsx
@@ -16,6 +16,7 @@ import {
   UserPlus,
   Users,
 } from "lucide-react";
+import { SkillIcon } from "../lib/skill-icon";
 import type {
   Agent,
   AgentRuntime,
@@ -241,9 +242,10 @@ function SkillIdentity({
       <div className="mx-auto flex max-w-[1440px] flex-wrap items-center gap-x-4 gap-y-1.5">
         <div className="flex min-w-0 items-center gap-2.5">
           <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg border bg-muted text-muted-foreground">
-            <Sparkles className="h-4 w-4" aria-hidden="true" />
+            <SkillIcon className="h-4 w-4" aria-hidden="true" />
           </div>
           <h1 className="min-w-0 truncate font-mono text-title font-semibold tracking-tight">
+
             {skill.name}
           </h1>
         </div>

--- a/packages/views/skills/components/skills-page.tsx
+++ b/packages/views/skills/components/skills-page.tsx
@@ -4,13 +4,13 @@ import { useMemo, useRef, useState } from "react";
 import {
   AlertCircle,
   AlertTriangle,
-  BookOpen,
   Download,
   HardDrive,
   Lock,
   Pencil,
   Plus,
 } from "lucide-react";
+import { SkillIcon } from "../lib/skill-icon";
 import type {
   Agent,
   AgentRuntime,
@@ -173,7 +173,7 @@ function PageHeaderBar({
   const { t } = useT("skills");
   return (
     <CollectionPageHeader
-      icon={BookOpen}
+      icon={SkillIcon}
       title={t(($) => $.page.title)}
       count={totalCount}
       description={t(($) => $.page.tagline)}
@@ -384,7 +384,7 @@ function EmptyState({ onCreate }: { onCreate: () => void }) {
   const { t } = useT("skills");
   return (
     <CollectionPageState
-      icon={BookOpen}
+      icon={SkillIcon}
       title={t(($) => $.page.empty.title)}
       description={t(($) => $.page.empty.description)}
       actions={

--- a/packages/views/skills/lib/skill-icon.test.ts
+++ b/packages/views/skills/lib/skill-icon.test.ts
@@ -1,0 +1,17 @@
+import { describe, it, expect } from "vitest";
+import { routeIconForPath } from "../../layout/route-icon-components";
+import { SkillIcon } from "./skill-icon";
+
+describe("SkillIcon", () => {
+  // The sidebar and desktop tab bar both render the route icon, while every
+  // in-page surface renders SkillIcon. Before they were derived from one
+  // declaration the product showed four icons for the same entity
+  // (BookOpenText, BookOpen, FileText, Sparkles).
+  it("is the same component the sidebar and tab bar resolve for /skills", () => {
+    expect(SkillIcon).toBe(routeIconForPath("/acme/skills"));
+  });
+
+  it("keeps matching for a nested skill detail path", () => {
+    expect(SkillIcon).toBe(routeIconForPath("/acme/skills/skill-1"));
+  });
+});

--- a/packages/views/skills/lib/skill-icon.ts
+++ b/packages/views/skills/lib/skill-icon.ts
@@ -1,0 +1,18 @@
+import type { LucideIcon } from "lucide-react";
+import { WORKSPACE_PAGES } from "@multica/core/paths";
+import { ROUTE_ICON_COMPONENTS } from "../../layout/route-icon-components";
+
+/**
+ * The icon that means "a skill", anywhere one is rendered as an entity: list
+ * header, empty states, detail identity, agent skill rows, skill pickers.
+ *
+ * Derived from the skills route icon rather than re-declared, so the sidebar,
+ * the desktop tab bar, and every in-page surface can never drift apart again
+ * — they previously showed four different icons (BookOpenText, BookOpen,
+ * FileText, Sparkles) for the same thing.
+ *
+ * This is for the skill *entity*. A file inside a skill is not a skill; those
+ * keep the file-type icons in `file-tree.tsx`.
+ */
+export const SkillIcon: LucideIcon =
+  ROUTE_ICON_COMPONENTS[WORKSPACE_PAGES.skills.icon];


### PR DESCRIPTION
Follow-up to #6100 (merged). The icon commit was pushed to that branch after it had already merged, so it never reached main — this is the same change, on its own branch off current main.

## Why

Skills were drawn with four different icons for the same entity:

| Surface | Icon |
|---|---|
| Sidebar, desktop tab bar, onboarding preview | `BookOpenText` |
| Skills list header + empty state | `BookOpen` |
| Skill rows in an agent's Skills tab, skill picker | `FileText` |
| Detail page identity mark | `Sparkles` |

The last one is worse than a mismatch: `Sparkles` already means "imported origin" thirteen lines further down the same file, so one glyph carried two meanings on one screen.

## What changed

`WORKSPACE_PAGES.skills.icon` already declares the icon name, and `ROUTE_ICON_COMPONENTS` already resolves it to a component for the sidebar and tab bar. This derives a `SkillIcon` export from that pair rather than re-declaring `BookOpenText` at five call sites, so navigation and in-page surfaces cannot drift apart again.

A test asserts `SkillIcon` is the same component the tab bar resolves for a `/skills` path — changing one without the other fails.

**Deliberately untouched:** file-type icons in the skill file tree (a file inside a skill is not a skill), `Sparkles` as the imported-origin marker, and `FileText` as the "N files" count glyph. Those three are correct as-is.

## Verification

```
pnpm typecheck   ✅ 6/6
pnpm test        ✅ 5/5 packages (views 286 files)
pnpm lint        ✅ 0 errors (16 pre-existing warnings, none in changed files)
```

Not verified: no visual pass against a running app. The change swaps one lucide component for another at each site with sizing untouched, so the risk is confined to which glyph renders.

MUL-5443

🤖 Generated with [Claude Code](https://claude.com/claude-code)
