### PR TITLE
perf(issues): make the issue URL rewrite cost no extra request (MUL-5354 follow-up)

### DIFF
--- a/packages/core/issues/canonical-id.test.tsx
+++ b/packages/core/issues/canonical-id.test.tsx
@@ -91,6 +91,28 @@ describe("useCanonicalIssue", () => {
   // The whole point of `initialData` over a post-resolve cache seed: the
   // canonical query must never observe an empty cache and start its own fetch.
   // A seed from an effect runs after that decision.
+  // The common path: an in-app link carries the UUID, the route rewrites the
+  // address bar to the identifier, and that rewrite re-renders this hook with
+  // the identifier as its segment. Without the identifier-keyed seed the
+  // resolution query missed and re-fetched an issue already in hand, so one
+  // issue open cost two requests.
+  it("costs no extra request when the URL is rewritten to the identifier", async () => {
+    const { result, rerender } = renderHook(
+      ({ routeId }: { routeId: string }) => useCanonicalIssue("ws-1", routeId),
+      { wrapper: createWrapper(qc), initialProps: { routeId: ISSUE_UUID } },
+    );
+
+    await waitFor(() => expect(result.current.issue).toEqual(issue));
+    expect(getIssue).toHaveBeenCalledTimes(1);
+
+    rerender({ routeId: "TRS-134" });
+
+    await waitFor(() => expect(result.current.canonicalId).toBe(ISSUE_UUID));
+    expect(result.current.issue).toEqual(issue);
+    await new Promise((resolve) => setTimeout(resolve, 100));
+    expect(getIssue).toHaveBeenCalledTimes(1);
+  });
+
   it("opens an identifier URL with exactly one request", async () => {
     const { result } = renderHook(() => useCanonicalIssue("ws-1", "TRS-134"), {
       wrapper: createWrapper(qc),

--- a/packages/core/issues/canonical-id.ts
+++ b/packages/core/issues/canonical-id.ts
@@ -1,6 +1,7 @@
-import { useQuery } from "@tanstack/react-query";
+import { useEffect } from "react";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
 import type { Issue } from "../types";
-import { issueDetailOptions } from "./queries";
+import { issueDetailOptions, issueKeys } from "./queries";
 
 const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 
@@ -51,6 +52,7 @@ export interface CanonicalIssue {
  * and leave the single-request property resting on hook ordering.
  */
 export function useCanonicalIssue(wsId: string, routeId: string): CanonicalIssue {
+  const qc = useQueryClient();
   const isUuid = isIssueUuid(routeId);
   const resolveEnabled = !isUuid && !!wsId && !!routeId;
 
@@ -68,6 +70,26 @@ export function useCanonicalIssue(wsId: string, routeId: string): CanonicalIssue
     // event is never overwritten by this older resolution response.
     initialData: isUuid ? undefined : resolve.data,
   });
+
+  // Mirror the loaded row into its identifier-keyed entry, the reverse of the
+  // `initialData` hop above.
+  //
+  // In-app links still carry the UUID, so opening one lands on the UUID URL and
+  // the route then rewrites the address bar to the identifier. That rewrite is
+  // a navigation: the route re-renders with the identifier as its segment, and
+  // without this seed the resolution query above would miss on a cache entry
+  // nothing has filled and re-fetch an issue already in hand — a second request
+  // for one issue open. The `??` keeps a realtime-patched entry intact, and
+  // only `.id` is ever read back out, which never changes.
+  const loadedIdentifier = detail.data?.identifier;
+  const loadedIssue = detail.data;
+  useEffect(() => {
+    if (!loadedIssue || !loadedIdentifier || loadedIdentifier === routeId) return;
+    qc.setQueryData<Issue>(
+      issueKeys.detail(wsId, loadedIdentifier),
+      (old) => old ?? loadedIssue,
+    );
+  }, [qc, wsId, loadedIdentifier, loadedIssue, routeId]);
 
   // Read the resolution query's own settled state rather than "pending and no
   // data": a failed resolution must present as terminally not-found, never as


### PR DESCRIPTION
Follow-up to #6117 (MUL-5354), which is already merged. This commit was pushed to that PR's branch after it merged, so it never landed — re-opened here on its own branch.

## The problem

Opening an issue from any in-app link fetched it twice.

In-app links still carry the UUID (list rows, board cards, mentions, pins, search results — several of those only hold an id, so building an identifier link there would mean fetching the issue just to build a link). The route lands on the UUID URL, loads the issue, then rewrites the address bar to the identifier.

That rewrite is a real navigation. The route re-renders with the identifier as its segment, `useCanonicalIssue` sees a non-UUID and runs its resolution query, and that query misses on an identifier-keyed cache entry nothing has ever filled — so it re-fetches an issue already in hand.

Measured across the full sequence (mount on UUID → rewrite → re-render on identifier), with the app's own `createQueryClient()`:

```
before:  afterUuid=1  afterFlip=2  args=["cb240efb-…","TRS-134"]
after:   afterUuid=1  afterFlip=1  args=["cb240efb-…"]
```

## The fix

Mirror the loaded row into its identifier-keyed entry — the reverse of the `initialData` hop that already covered the identifier-first direction. Both directions now hold at one request.

`(old) => old ?? loadedIssue` so a realtime-patched entry is never overwritten, and only `.id` is ever read back out of that entry, which never changes.

## Why the existing tests missed it

They measured each URL form in isolation — open a UUID URL (1 request), open an identifier URL (1 request) — and never the rewrite in between, which is the common path. The new test drives the actual transition: mount on the UUID, rerender with the identifier, assert the count does not move.

## Testing

`pnpm typecheck` 6/6, `pnpm lint` 0 errors, `pnpm test` green (views 285 / core 109 / desktop 47 / web 22 / docs 4). No Go changes.

Two unrelated flakes surfaced on first runs and passed both in isolation and on a full re-run — `preferences-tab` (language switcher) and `app/(auth)/login/page`. Neither is in a package this change touches; flagging them as pre-existing rather than silently re-running.
