### PR TITLE
fix(skills): carry built-in skill descriptions into the runtime brief (MUL-5529)

### DIFF
--- a/server/internal/daemon/execenv/runtime_config_test.go
+++ b/server/internal/daemon/execenv/runtime_config_test.go
@@ -1744,3 +1744,28 @@ func TestBriefByteIdenticalAcrossRunsForEveryKind(t *testing.T) {
 		})
 	}
 }
+
+// TestBriefSkillsListRendersDescriptions pins the render half of MUL-5529: a
+// skill carrying a description is listed with it, and one without degrades to a
+// bare name. The bare form is the fallback for a malformed skill, never the
+// normal case — for a provider that has no native SKILL.md discovery this list
+// is the only place a model learns which skill matches the task, so a missing
+// description makes the skill effectively unroutable.
+func TestBriefSkillsListRendersDescriptions(t *testing.T) {
+	t.Parallel()
+
+	out := buildMetaSkillContent("claude", TaskContextForEnv{
+		IssueID: "issue-1",
+		AgentSkills: []SkillContextForEnv{
+			{Name: "multica-mentioning", Description: "Use when a comment needs to @mention someone.", Content: "---\nname: multica-mentioning\n---\n\nbody"},
+			{Name: "multica-undocumented", Content: "---\nname: multica-undocumented\n---\n\nbody"},
+		},
+	})
+
+	if !strings.Contains(out, "- **multica-mentioning** — Use when a comment needs to @mention someone.\n") {
+		t.Errorf("described skill is not listed with its description\n---\n%s", out)
+	}
+	if !strings.Contains(out, "- **multica-undocumented**\n") {
+		t.Errorf("skill without a description is not listed at all\n---\n%s", out)
+	}
+}

--- a/server/internal/service/builtin_skills.go
+++ b/server/internal/service/builtin_skills.go
@@ -5,6 +5,8 @@ import (
 	"io/fs"
 	"path"
 	"strings"
+
+	skillpkg "github.com/multica-ai/multica/server/internal/skill"
 )
 
 //go:embed builtin_skills
@@ -50,7 +52,19 @@ func loadBuiltinSkill(name string) (AgentSkillData, bool) {
 		// than ship an empty skill.
 		return AgentSkillData{}, false
 	}
-	skill := AgentSkillData{Name: name, Content: string(content)}
+	// The description is the routing signal: it is what a model reads when
+	// deciding whether a skill matches the task at hand. Workspace skills carry
+	// it in a database column, so the runtime brief's `## Skills` list renders
+	// them as "name — description" (see writeSkills). Built-in skills keep theirs
+	// in the SKILL.md frontmatter, so read it out here — otherwise they reach the
+	// brief as a row of bare names and, on runtimes without native skill
+	// discovery, nothing tells the model which one to open (MUL-5529).
+	//
+	// Name stays the directory name, not the frontmatter name: it is the slug
+	// writeSkillFiles lays down on disk, and the multica- prefix invariant is
+	// enforced against it.
+	_, description := skillpkg.ParseSkillFrontmatter(string(content))
+	skill := AgentSkillData{Name: name, Description: strings.TrimSpace(description), Content: string(content)}
 	// Any other file in the directory becomes a supporting file, preserving
 	// its relative path so subdirectories (e.g. rules/styling.md) survive.
 	_ = fs.WalkDir(builtinSkillsFS, dir, func(p string, d fs.DirEntry, walkErr error) error {

--- a/server/internal/service/builtin_skills/multica-creating-agents/references/creating-agents-source-map.md
+++ b/server/internal/service/builtin_skills/multica-creating-agents/references/creating-agents-source-map.md
@@ -136,8 +136,9 @@ only.
 
 | Contract | Line | Behavior |
 |---|---|---|
-| `go:embed builtin_skills` | 10–11 | skills embedded at compile time |
-| `loadBuiltinSkill` | 45 | reads `<name>/SKILL.md` (47) + walks sibling files into `Files` (56–68) |
+| `go:embed builtin_skills` | 12–13 | skills embedded at compile time |
+| `loadBuiltinSkill` | 47 | reads `<name>/SKILL.md` (49) + walks sibling files into `Files` (70–84) |
+| `Name` / `Description` | 66–67 | `Name` is the directory slug; `Description` is parsed out of the SKILL.md frontmatter, so built-ins are listed with a description in the runtime brief exactly like workspace skills (MUL-5529) |
 
 ## Persisted columns — `server/pkg/db/generated/agent.sql.go`
 

--- a/server/internal/service/builtin_skills/multica-mentioning/references/mentioning-source-map.md
+++ b/server/internal/service/builtin_skills/multica-mentioning/references/mentioning-source-map.md
@@ -24,7 +24,7 @@ a pointer.
 | `mention://all/all` parses to `{all, all}` | `server/internal/util/mention_test.go:47-50` |
 | `mention://agent/<uuid>` parses; label may contain `[brackets]` | `server/internal/util/mention_test.go:13-35` |
 | plain text with no `mention://` parses to `nil` | `server/internal/util/mention_test.go:57-60` |
-| Skill eval: a name where a UUID belongs (`mention://member/Alice`) parses to `nil`; a bare `@name` parses to `nil`; a real UUID parses; `@all` → `{all, all}`; a **wrong** type with a real UUID still parses (points at the wrong entity) | `server/internal/service/builtin_skills_test.go:101-157` |
+| Skill eval: a name where a UUID belongs (`mention://member/Alice`) parses to `nil`; a bare `@name` parses to `nil`; a real UUID parses; `@all` → `{all, all}`; a **wrong** type with a real UUID still parses (points at the wrong entity) | `server/internal/service/builtin_skills_test.go:186-242` |
 
 ## What each mention type enqueues
 

--- a/server/internal/service/builtin_skills_test.go
+++ b/server/internal/service/builtin_skills_test.go
@@ -4,6 +4,7 @@ import (
 	"strings"
 	"testing"
 
+	skillpkg "github.com/multica-ai/multica/server/internal/skill"
 	"github.com/multica-ai/multica/server/internal/util"
 	"gopkg.in/yaml.v3"
 )
@@ -69,6 +70,44 @@ func TestBuiltinSkillsConformToTemplate(t *testing.T) {
 				if strings.Contains(lower, "eval") || strings.HasSuffix(lower, "_test.go") || strings.HasSuffix(lower, "_test.md") {
 					t.Errorf("supporting file %q looks like an eval/test; evals belong in _test.go, not the shipped skill payload", f.Path)
 				}
+			}
+		})
+	}
+}
+
+// TestBuiltinSkillsCarryFrontmatterDescription is the regression guard for
+// MUL-5529: loadBuiltinSkill used to set only Name and Content, so every
+// built-in skill travelled to the daemon with an empty Description and the
+// runtime brief's `## Skills` list rendered it as a bare name (writeSkills only
+// appends "— description" when one exists). Workspace skills, whose description
+// comes from a database column, were listed with theirs — so the platform's own
+// skills were the only ones a model could not route by reading the brief, and
+// on a runtime without native SKILL.md discovery nothing else supplied it.
+//
+// Asserting equality with the frontmatter (rather than just non-emptiness)
+// keeps the two descriptions from drifting: the same string has to serve the
+// brief listing and the runtime's own frontmatter-driven index.
+func TestBuiltinSkillsCarryFrontmatterDescription(t *testing.T) {
+	skills := loadBuiltinSkills()
+	if len(skills) == 0 {
+		t.Fatal("no built-in skills loaded; embed or layout is broken")
+	}
+
+	for _, skill := range skills {
+		t.Run(skill.Name, func(t *testing.T) {
+			if strings.TrimSpace(skill.Description) == "" {
+				t.Fatal("Description is empty; the brief lists this skill as a bare name and nothing tells the model when to load it")
+			}
+
+			fmName, fmDesc := skillpkg.ParseSkillFrontmatter(skill.Content)
+			if want := strings.TrimSpace(fmDesc); skill.Description != want {
+				t.Errorf("Description = %q, want the frontmatter description %q", skill.Description, want)
+			}
+			// The brief lists skill.Name while a native-discovery runtime keys on
+			// the frontmatter name. If they diverge, the model reads about a skill
+			// under one name and can only invoke it under another.
+			if fmName != skill.Name {
+				t.Errorf("frontmatter name %q does not match the skill directory %q", fmName, skill.Name)
 			}
 		})
 	}


### PR DESCRIPTION
## The bug

`loadBuiltinSkill` returned `AgentSkillData{Name: name, Content: content}` and never set `Description` (`server/internal/service/builtin_skills.go`). Every built-in skill therefore travelled to the daemon with an empty description, and `writeSkills` only appends `— description` when one exists — so the brief's `## Skills` section looked like this:

```
- **safe-change-guardrails** — Apply scoped production-safety review ...   ← workspace skill
- **multica-autopilots**                                                   ← built-in
- **multica-creating-agents**
- **multica-mentioning**
```

The platform's own skills were the only ones a model could not route by reading the brief.

Why it stayed invisible: on runtimes with native SKILL.md discovery (`claude`, `codex`, `copilot`, …) the CLI reads the frontmatter off disk and builds its own listing with descriptions, because `ensureSkillFrontmatter` leaves a valid block untouched. So the model got the descriptions from a second source. Providers outside that switch (`grok`, `agy`, `trae`) hit the `default` branch — "Detailed skill instructions are in `.agent_context/skills/`" — where the brief list is the only index. A bare name gives the model nothing to choose on, so it either opens all 8 SKILL.md files or opens none.

## The fix

Parse the description out of the SKILL.md frontmatter, which every built-in already carries and which `builtin_skills_test.go` already enforces as non-empty, strict-YAML, and ≤1024 chars. `Name` deliberately stays the directory slug — it is what `writeSkillFiles` lays down on disk and what the `multica-` prefix invariant is checked against.

Result:

```
- **multica-autopilots** — Use when creating, updating, inspecting, triggering, or debugging Mult…
- **multica-mentioning** — Use when an issue comment needs to @mention someone — link to a pers…
- **multica-working-on-issues** — Use when working on a Multica issue after the runtime has provided the…
```

## Tests

- `TestBuiltinSkillsCarryFrontmatterDescription` (service) — every built-in has a non-empty `Description` equal to its frontmatter description, and the frontmatter `name` matches the directory slug so the brief and a native runtime's index name the same skill. Verified non-vacuous: fails on all 8 skills without the loader change.
- `TestBriefSkillsListRendersDescriptions` (execenv) — pins the render half: a described skill lists as `- **name** — desc`, one without degrades to a bare name.

## Notes for review

- **Bundle hashes change.** `Description` is hashed in `skillbundle.BuildManifest`, so every built-in's hash moves. Daemons miss the hash-keyed cache once and re-fetch through the existing resolve endpoint; `validateSkillBundle` recomputes from whatever the server sent, so an older daemon against a newer server is fine. Same self-healing path any SKILL.md edit already takes on release.
- **Brief size.** +3,465 chars (~870 tokens) across the 8 descriptions, in every brief. That is the cost of the routing signal; workspace skills already pay it. `multica-mentioning` is the outlier at 927 of those chars and reads like a summary rather than a trigger — worth tightening separately if we want the tokens back.
- Both source maps that cited line numbers in the touched files are updated in this PR, per the CLAUDE.md rule.

## Verification

- `go test ./internal/service/ -run 'TestBuiltinSkills|TestMentioning|TestCreatingAgents'` — pass
- `go test ./internal/daemon/execenv/ ./internal/skill/` — pass
- `gofmt` / `go vet ./internal/service/` — clean
- Full `./internal/service/` has 70 pre-existing failures from a stale local test-DB schema (`column "coalesced_comment_ids" does not exist`); the count is identical with and without this change.

MUL-5529
