### PR TITLE
fix(chat): put the follow-up queue on the role-named type scale (MUL-5536)

### DIFF
--- a/packages/views/chat/components/chat-queue.tsx
+++ b/packages/views/chat/components/chat-queue.tsx
@@ -28,7 +28,7 @@ export function ChatQueue({ tasks, onRemove }: ChatQueueProps) {
 
   return (
     <div className="mx-3 mb-2 rounded-lg border bg-muted/30 p-2" aria-live="polite">
-      <div className="mb-1 px-1 text-xs font-medium text-muted-foreground">
+      <div className="mb-1 px-1 text-caption font-medium text-muted-foreground">
         {t(($) => $.queue.title, { count: tasks.length })}
       </div>
       <div className="space-y-0.5">
@@ -37,9 +37,9 @@ export function ChatQueue({ tasks, onRemove }: ChatQueueProps) {
           return (
             <div
               key={task.task_id}
-              className="flex min-w-0 items-center gap-2 rounded-md px-1.5 py-1 text-sm"
+              className="flex min-w-0 items-center gap-2 rounded-md px-1.5 py-1 text-body"
             >
-              <span className="w-4 shrink-0 text-center text-xs tabular-nums text-muted-foreground">
+              <span className="w-4 shrink-0 text-center text-caption tabular-nums text-muted-foreground">
                 {index + 1}
               </span>
               <span className="min-w-0 flex-1 truncate">


### PR DESCRIPTION
## What

`main` has been red since b13657be7. Not flaky — a semantic merge conflict.

- #6136 (`feat(ui): establish a role-named type scale`) landed at 13:42 CST and added `apps/web/app/type-scale.test.ts`, which fails on any Tailwind default font-size class in product UI.
- #6133 (`feat(chat): add a visible follow-up queue`) branched from 9e3b661d4 the previous evening, i.e. before that guard existed. Its own CI ran a test suite that did not contain the check, so the PR was green, and `packages/views/chat/components/chat-queue.tsx` merged with `text-xs` / `text-sm` still in it.

Neither PR is wrong on its own; only their combination fails, which is why every merge after 07:14 UTC is red.

## Fix

`chat-queue.tsx` is the only file off the scale. `text-xs -> text-caption` and `text-sm -> text-body` reuse Tailwind's exact size/line-height pairs (12/16 and 14/20), so this is a rename with no visual change.

## Verification

- `pnpm exec vitest run app/type-scale.test.ts` in `apps/web` — 13 passed (was 1 failed).
- `pnpm test` at the repo root — 5/5 packages, all suites green.

## Follow-up (not in this PR)

The class of failure will recur: any repo-wide guard merged while other PRs are in flight goes un-run on those PRs. Turning on "Require branches to be up to date before merging" (or a merge queue) for `main` is what actually prevents it.
