### PR TITLE
feat(agents): pick an emoji as the agent avatar (MUL-5534)

### DIFF
--- a/packages/ui/lib/avatar-emoji.ts
+++ b/packages/ui/lib/avatar-emoji.ts
@@ -1,8 +1,30 @@
 const AVATAR_EMOJI_PREFIX = "emoji:";
 
+/**
+ * Emojis offered as one-click choices by the avatar picker. Deliberately the
+ * same set the server hands a brand-new agent at random
+ * (`agentEmojiAvatars` in server/internal/handler/agent_avatar.go), so the
+ * suggestions read as the product's own family of faces rather than an
+ * unrelated second list. Eight per row.
+ */
+export const AVATAR_EMOJI_SUGGESTIONS = [
+  "🐙", "🦊", "🦉", "🐝", "🐼", "🐸", "🐯", "🦁",
+  "🐨", "🐵", "🐧", "🐳", "🦋", "🌞", "🌙", "⭐",
+  "🔥", "⚡", "🍀", "🌈", "🚀", "🤖", "👾", "🧠",
+];
+
 export function parseAvatarEmoji(value?: string | null): string | null {
   if (!value?.startsWith(AVATAR_EMOJI_PREFIX)) return null;
 
   const emoji = value.slice(AVATAR_EMOJI_PREFIX.length).trim();
   return emoji || null;
+}
+
+/**
+ * Builds the value to persist in `avatar_url` for an emoji avatar. The prefix
+ * stays private to this module so the marker format has one owner on the
+ * client, matching `agentEmojiAvatarPrefix` on the server.
+ */
+export function formatAvatarEmoji(emoji: string): string {
+  return AVATAR_EMOJI_PREFIX + emoji.trim();
 }

--- a/packages/views/agents/components/agent-creation-studio.tsx
+++ b/packages/views/agents/components/agent-creation-studio.tsx
@@ -1249,6 +1249,7 @@ function ConfigurationPanel({
                 name={draft.name}
                 size={compact ? 52 : 56}
                 onUploaded={(url) => set("avatarUrl", url)}
+                onEmojiSelected={(value) => set("avatarUrl", value)}
                 onClear={() => set("avatarUrl", null)}
               />
             </div>

--- a/packages/views/agents/components/agent-detail-inspector.tsx
+++ b/packages/views/agents/components/agent-detail-inspector.tsx
@@ -174,6 +174,7 @@ export function AgentDetailInspector({
                 size={56}
                 disabled={!canEdit}
                 onUploaded={(url) => update({ avatar_url: url })}
+                onEmojiSelected={(value) => update({ avatar_url: value })}
               />
             </div>
           </SettingsRow>

--- a/packages/views/agents/components/create-agent-dialog.tsx
+++ b/packages/views/agents/components/create-agent-dialog.tsx
@@ -324,6 +324,7 @@ export function CreateAgentDialog({
                 name={name}
                 size={64}
                 onUploaded={setAvatarUrl}
+                onEmojiSelected={setAvatarUrl}
                 onClear={() => setAvatarUrl(null)}
               />
               <div className="flex-1 min-w-0 space-y-3">

--- a/packages/views/common/avatar-upload-control.test.tsx
+++ b/packages/views/common/avatar-upload-control.test.tsx
@@ -1,0 +1,143 @@
+// @vitest-environment jsdom
+
+import { cleanup, fireEvent, screen, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { renderWithI18n } from "../test/i18n";
+
+vi.mock("@multica/core/api", () => ({
+  api: { getBaseUrl: () => "https://api.test" },
+}));
+
+vi.mock("@multica/core/hooks/use-file-upload", () => ({
+  useFileUpload: () => ({ upload: vi.fn() }),
+}));
+
+// The crop dialog only matters after a file is picked; nothing here picks one.
+vi.mock("./avatar-crop-dialog", () => ({
+  AvatarCropDialog: () => null,
+}));
+
+import { AvatarUploadControl } from "./avatar-upload-control";
+
+afterEach(cleanup);
+
+function openPicker() {
+  fireEvent.click(screen.getByRole("button", { name: "Change avatar" }));
+}
+
+function spyOnFileDialog(container: HTMLElement) {
+  const input = container.querySelector<HTMLInputElement>('input[type="file"]');
+  if (!input) throw new Error("file input not rendered");
+  return vi.spyOn(input, "click").mockImplementation(() => {});
+}
+
+describe("AvatarUploadControl", () => {
+  // Without an emoji handler the control keeps its original single-purpose
+  // shape: one click, one file dialog, no menu in between.
+  it("goes straight to the file dialog when emoji is not offered", () => {
+    const { container } = renderWithI18n(
+      <AvatarUploadControl variant="agent" value={null} onUploaded={vi.fn()} />,
+    );
+    const openDialog = spyOnFileDialog(container);
+
+    fireEvent.click(screen.getByRole("button", { name: "Change avatar" }));
+
+    expect(openDialog).toHaveBeenCalledTimes(1);
+    expect(screen.queryByText("Upload image")).not.toBeInTheDocument();
+  });
+
+  it("offers both an image upload and emoji suggestions", async () => {
+    renderWithI18n(
+      <AvatarUploadControl
+        variant="agent"
+        value={null}
+        onUploaded={vi.fn()}
+        onEmojiSelected={vi.fn()}
+      />,
+    );
+
+    openPicker();
+
+    expect(
+      await screen.findByRole("button", { name: "Upload image" }),
+    ).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "🦊" })).toBeInTheDocument();
+  });
+
+  // The caller persists whatever it gets straight into `avatar_url`, so the
+  // control has to emit the marker the renderers parse, not the bare emoji.
+  it("emits the emoji marker value the server stores", async () => {
+    const onEmojiSelected = vi.fn();
+    renderWithI18n(
+      <AvatarUploadControl
+        variant="agent"
+        value={null}
+        onUploaded={vi.fn()}
+        onEmojiSelected={onEmojiSelected}
+      />,
+    );
+
+    openPicker();
+    fireEvent.click(await screen.findByRole("button", { name: "🦊" }));
+
+    await waitFor(() =>
+      expect(onEmojiSelected).toHaveBeenCalledWith("emoji:🦊"),
+    );
+  });
+
+  it("still reaches the file dialog through the picker", async () => {
+    const { container } = renderWithI18n(
+      <AvatarUploadControl
+        variant="agent"
+        value={null}
+        onUploaded={vi.fn()}
+        onEmojiSelected={vi.fn()}
+      />,
+    );
+    const openDialog = spyOnFileDialog(container);
+
+    openPicker();
+    fireEvent.click(await screen.findByRole("button", { name: "Upload image" }));
+
+    expect(openDialog).toHaveBeenCalledTimes(1);
+  });
+
+  it("marks the agent's current emoji as the selected suggestion", async () => {
+    renderWithI18n(
+      <AvatarUploadControl
+        variant="agent"
+        value="emoji:🚀"
+        onUploaded={vi.fn()}
+        onEmojiSelected={vi.fn()}
+      />,
+    );
+
+    openPicker();
+
+    expect(await screen.findByRole("button", { name: "🚀" })).toHaveAttribute(
+      "aria-pressed",
+      "true",
+    );
+    expect(screen.getByRole("button", { name: "🦊" })).toHaveAttribute(
+      "aria-pressed",
+      "false",
+    );
+  });
+
+  it("cannot be opened when the caller lacks edit permission", () => {
+    renderWithI18n(
+      <AvatarUploadControl
+        variant="agent"
+        value={null}
+        disabled
+        onUploaded={vi.fn()}
+        onEmojiSelected={vi.fn()}
+      />,
+    );
+
+    const trigger = screen.getByRole("button", { name: "Change avatar" });
+    expect(trigger).toBeDisabled();
+    fireEvent.click(trigger);
+    expect(screen.queryByText("Upload image")).not.toBeInTheDocument();
+  });
+});

--- a/packages/views/common/avatar-upload-control.test.tsx
+++ b/packages/views/common/avatar-upload-control.test.tsx
@@ -1,34 +1,73 @@
 // @vitest-environment jsdom
 
-import { cleanup, fireEvent, screen, waitFor } from "@testing-library/react";
+import { act, cleanup, fireEvent, screen, waitFor } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { renderWithI18n } from "../test/i18n";
+
+const uploadMock = vi.hoisted(() => vi.fn());
+const toastError = vi.hoisted(() => vi.fn());
+const toastSuccess = vi.hoisted(() => vi.fn());
+
+vi.mock("sonner", () => ({
+  toast: { error: toastError, success: toastSuccess },
+}));
 
 vi.mock("@multica/core/api", () => ({
   api: { getBaseUrl: () => "https://api.test" },
 }));
 
 vi.mock("@multica/core/hooks/use-file-upload", () => ({
-  useFileUpload: () => ({ upload: vi.fn() }),
+  useFileUpload: () => ({ upload: uploadMock }),
 }));
 
-// The crop dialog only matters after a file is picked; nothing here picks one.
+// Stands in for the crop UI so the upload path is reachable without a real
+// canvas; the cropping itself is covered by avatar-crop.test.ts.
 vi.mock("./avatar-crop-dialog", () => ({
-  AvatarCropDialog: () => null,
+  AvatarCropDialog: ({
+    open,
+    onCropped,
+  }: {
+    open: boolean;
+    onCropped: (file: File) => void;
+  }) =>
+    open ? (
+      <button type="button" onClick={() => onCropped(imageFile())}>
+        crop
+      </button>
+    ) : null,
 }));
 
 import { AvatarUploadControl } from "./avatar-upload-control";
 
-afterEach(cleanup);
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+function imageFile() {
+  return new File(["x"], "avatar.png", { type: "image/png" });
+}
 
 function openPicker() {
   fireEvent.click(screen.getByRole("button", { name: "Change avatar" }));
 }
 
-function spyOnFileDialog(container: HTMLElement) {
+function fileInput(container: HTMLElement) {
   const input = container.querySelector<HTMLInputElement>('input[type="file"]');
   if (!input) throw new Error("file input not rendered");
-  return vi.spyOn(input, "click").mockImplementation(() => {});
+  return input;
+}
+
+function spyOnFileDialog(container: HTMLElement) {
+  return vi.spyOn(fileInput(container), "click").mockImplementation(() => {});
+}
+
+// Drives the whole image path: choose a file, then crop-and-save.
+function uploadImage(container: HTMLElement) {
+  fireEvent.change(fileInput(container), {
+    target: { files: [imageFile()] },
+  });
+  fireEvent.click(screen.getByRole("button", { name: "crop" }));
 }
 
 describe("AvatarUploadControl", () => {
@@ -122,6 +161,94 @@ describe("AvatarUploadControl", () => {
       "aria-pressed",
       "false",
     );
+  });
+
+  // An edit caller PATCHes on every pick. Two in flight at once are
+  // last-one-to-arrive-wins on the server, so the user's newer choice can lose
+  // to the older one and stick — the avatar has to be locked until the save
+  // settles.
+  it("locks the avatar until a pick has finished saving", async () => {
+    let settle = () => {};
+    const onEmojiSelected = vi.fn(
+      () =>
+        new Promise<void>((resolve) => {
+          settle = resolve;
+        }),
+    );
+    renderWithI18n(
+      <AvatarUploadControl
+        variant="agent"
+        value={null}
+        onUploaded={vi.fn()}
+        onEmojiSelected={onEmojiSelected}
+      />,
+    );
+
+    openPicker();
+    fireEvent.click(await screen.findByRole("button", { name: "🦊" }));
+
+    const trigger = screen.getByRole("button", { name: "Change avatar" });
+    await waitFor(() => expect(trigger).toBeDisabled());
+
+    // A second pick must not even be reachable while the first is in flight.
+    fireEvent.click(trigger);
+    expect(screen.queryByText("Upload image")).not.toBeInTheDocument();
+    expect(onEmojiSelected).toHaveBeenCalledTimes(1);
+
+    await act(async () => settle());
+    await waitFor(() => expect(trigger).not.toBeDisabled());
+  });
+
+  // The caller that performed the write reports its own failure and rethrows so
+  // autosave can show a failed state; toasting here too would double it up.
+  it("leaves a failed save to the caller that performed it", async () => {
+    renderWithI18n(
+      <AvatarUploadControl
+        variant="agent"
+        value={null}
+        onUploaded={vi.fn()}
+        onEmojiSelected={() => Promise.reject(new Error("nope"))}
+      />,
+    );
+
+    openPicker();
+    fireEvent.click(await screen.findByRole("button", { name: "🦊" }));
+
+    await waitFor(() =>
+      expect(screen.getByRole("button", { name: "Change avatar" })).not
+        .toBeDisabled(),
+    );
+    expect(toastError).not.toHaveBeenCalled();
+    expect(toastSuccess).not.toHaveBeenCalled();
+  });
+
+  it("leaves a failed image save to the caller too", async () => {
+    uploadMock.mockResolvedValueOnce({ link: "https://cdn.test/a.png" });
+    const { container } = renderWithI18n(
+      <AvatarUploadControl
+        variant="agent"
+        value={null}
+        onUploaded={() => Promise.reject(new Error("nope"))}
+      />,
+    );
+
+    uploadImage(container);
+
+    await waitFor(() => expect(uploadMock).toHaveBeenCalled());
+    await waitFor(() => expect(toastSuccess).not.toHaveBeenCalled());
+    expect(toastError).not.toHaveBeenCalled();
+  });
+
+  // The upload is the one failure this control owns — nothing else reports it.
+  it("reports an upload failure itself", async () => {
+    uploadMock.mockRejectedValueOnce(new Error("network down"));
+    const { container } = renderWithI18n(
+      <AvatarUploadControl variant="agent" value={null} onUploaded={vi.fn()} />,
+    );
+
+    uploadImage(container);
+
+    await waitFor(() => expect(toastError).toHaveBeenCalledWith("network down"));
   });
 
   it("cannot be opened when the caller lacks edit permission", () => {

--- a/packages/views/common/avatar-upload-control.tsx
+++ b/packages/views/common/avatar-upload-control.tsx
@@ -1,15 +1,33 @@
 "use client";
 
-import { useRef, useState } from "react";
-import { Bot, Camera, Loader2, Users, X } from "lucide-react";
+import { Suspense, lazy, useRef, useState } from "react";
+import { Bot, Camera, ImagePlus, Loader2, Users, X } from "lucide-react";
 import { toast } from "sonner";
 import { api } from "@multica/core/api";
 import { useFileUpload } from "@multica/core/hooks/use-file-upload";
 import { resolvePublicFileUrl } from "@multica/core/workspace/avatar-url";
-import { parseAvatarEmoji } from "@multica/ui/lib/avatar-emoji";
+import {
+  AVATAR_EMOJI_SUGGESTIONS,
+  formatAvatarEmoji,
+  parseAvatarEmoji,
+} from "@multica/ui/lib/avatar-emoji";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@multica/ui/components/ui/popover";
+import { Separator } from "@multica/ui/components/ui/separator";
 import { cn } from "@multica/ui/lib/utils";
 import { useT } from "../i18n";
 import { AvatarCropDialog } from "./avatar-crop-dialog";
+
+// The full emoji-mart picker is ~1MB of emoji data. Only the handful of
+// suggestions render eagerly; the searchable set loads when asked for.
+const EmojiPicker = lazy(() =>
+  import("@multica/ui/components/common/emoji-picker").then((m) => ({
+    default: m.EmojiPicker,
+  })),
+);
 
 export type AvatarUploadVariant = "user" | "agent" | "squad" | "workspace";
 
@@ -30,6 +48,14 @@ interface AvatarUploadControlProps {
    * its busy state until this resolves, then closes.
    */
   onUploaded: (url: string) => void | Promise<unknown>;
+  /**
+   * When provided, the avatar offers emoji as an alternative to an image:
+   * clicking it opens a picker with the suggested set, full emoji search, and
+   * the upload entry. Fires with the value to persist (`emoji:🚀`) — the same
+   * `avatar_url` shape as `onUploaded`, so the caller stores both the same
+   * way. Omit it and the control keeps its click-straight-to-upload behavior.
+   */
+  onEmojiSelected?: (value: string) => void | Promise<unknown>;
   /**
    * When provided, shows a small clear affordance. Used by create flows to
    * drop a not-yet-persisted choice; edit flows omit it (removing a saved
@@ -80,7 +106,9 @@ function AvatarFallback({
  * avatar with a hover "change" affordance; on pick it opens {@link
  * AvatarCropDialog} for reposition/zoom, then uploads the cropped image
  * through the existing `/api/upload-file` chain and hands the URL back via
- * `onUploaded`. Business persistence stays with the caller.
+ * `onUploaded`. With `onEmojiSelected` the click opens a picker that offers
+ * an emoji instead — both paths produce an `avatar_url` value. Business
+ * persistence stays with the caller.
  */
 export function AvatarUploadControl({
   value,
@@ -89,6 +117,7 @@ export function AvatarUploadControl({
   size = 64,
   disabled = false,
   onUploaded,
+  onEmojiSelected,
   onClear,
   className,
   ariaLabel,
@@ -100,11 +129,26 @@ export function AvatarUploadControl({
   const [dialogOpen, setDialogOpen] = useState(false);
   const [busy, setBusy] = useState(false);
   const [previewError, setPreviewError] = useState(false);
+  const [pickerOpen, setPickerOpen] = useState(false);
+  const [emojiSearchOpen, setEmojiSearchOpen] = useState(false);
 
   const emoji = parseAvatarEmoji(value);
   const resolved = value && !emoji ? resolvePublicFileUrl(value) : null;
   const hasImage = !!resolved && !previewError;
   const hasAvatar = !!emoji || hasImage;
+  const emojiEnabled = !!onEmojiSelected;
+
+  const openFileDialog = () => fileInputRef.current?.click();
+
+  const closePicker = () => {
+    setPickerOpen(false);
+    setEmojiSearchOpen(false);
+  };
+
+  const handlePickerOpenChange = (next: boolean) => {
+    setPickerOpen(next);
+    if (!next) setEmojiSearchOpen(false);
+  };
 
   const handlePick = (e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0];
@@ -137,53 +181,145 @@ export function AvatarUploadControl({
     }
   };
 
+  // No success toast here on purpose: the avatar swaps to the chosen emoji in
+  // place, so the change is already visible. Only a failure needs announcing.
+  const handleEmojiSelected = async (picked: string) => {
+    closePicker();
+    setPreviewError(false);
+    try {
+      await onEmojiSelected?.(formatAvatarEmoji(picked));
+    } catch (err) {
+      toast.error(
+        err instanceof Error ? err.message : t(($) => $.avatar_upload.failed),
+      );
+    }
+  };
+
+  const avatarButton = (
+    <button
+      type="button"
+      // With emoji enabled this button is the popover trigger and Base UI
+      // supplies the click handler; without it the click goes straight to the
+      // file dialog, which is this control's original single-purpose shape.
+      onClick={emojiEnabled ? undefined : openFileDialog}
+      disabled={disabled || busy}
+      aria-label={ariaLabel ?? t(($) => $.avatar_upload.change)}
+      className={cn(
+        "group relative h-full w-full overflow-hidden bg-muted text-muted-foreground outline-none",
+        "flex items-center justify-center",
+        "focus-visible:ring-2 focus-visible:ring-ring",
+        "disabled:cursor-not-allowed disabled:opacity-60",
+        "rounded-full",
+        className,
+      )}
+      style={{ width: size, height: size }}
+    >
+      {emoji ? (
+        <span
+          role="img"
+          aria-label={name}
+          className="select-none leading-none"
+          style={{ fontSize: size * 0.58 }}
+        >
+          {emoji}
+        </span>
+      ) : hasImage ? (
+        <img
+          src={resolved ?? undefined}
+          alt={name}
+          className="h-full w-full object-cover"
+          onError={() => setPreviewError(true)}
+        />
+      ) : (
+        <AvatarFallback variant={variant} name={name} size={size} />
+      )}
+
+      {!disabled && (
+        <div className="absolute inset-0 flex items-center justify-center bg-black/40 opacity-0 transition-opacity group-hover:opacity-100">
+          {busy ? (
+            <Loader2 className="h-5 w-5 animate-spin text-white" />
+          ) : (
+            <Camera className="h-5 w-5 text-white" />
+          )}
+        </div>
+      )}
+    </button>
+  );
+
   return (
     <div className="relative shrink-0" style={{ width: size, height: size }}>
-      <button
-        type="button"
-        onClick={() => fileInputRef.current?.click()}
-        disabled={disabled || busy}
-        aria-label={ariaLabel ?? t(($) => $.avatar_upload.change)}
-        className={cn(
-          "group relative h-full w-full overflow-hidden bg-muted text-muted-foreground outline-none",
-          "flex items-center justify-center",
-          "focus-visible:ring-2 focus-visible:ring-ring",
-          "disabled:cursor-not-allowed disabled:opacity-60",
-          "rounded-full",
-          className,
-        )}
-        style={{ width: size, height: size }}
-      >
-        {emoji ? (
-          <span
-            role="img"
-            aria-label={name}
-            className="select-none leading-none"
-            style={{ fontSize: size * 0.58 }}
+      {emojiEnabled ? (
+        <Popover open={pickerOpen} onOpenChange={handlePickerOpenChange}>
+          <PopoverTrigger render={avatarButton} />
+          <PopoverContent
+            align="start"
+            // The emoji-mart picker sizes itself; only the suggestion grid is
+            // laid out against the popover's own width.
+            className={cn("gap-0 p-0", emojiSearchOpen ? "w-auto" : "w-72")}
           >
-            {emoji}
-          </span>
-        ) : hasImage ? (
-          <img
-            src={resolved ?? undefined}
-            alt={name}
-            className="h-full w-full object-cover"
-            onError={() => setPreviewError(true)}
-          />
-        ) : (
-          <AvatarFallback variant={variant} name={name} size={size} />
-        )}
-
-        {!disabled && (
-          <div className="absolute inset-0 flex items-center justify-center bg-black/40 opacity-0 transition-opacity group-hover:opacity-100">
-            {busy ? (
-              <Loader2 className="h-5 w-5 animate-spin text-white" />
+            {emojiSearchOpen ? (
+              <Suspense
+                fallback={
+                  <div className="p-4 text-body text-muted-foreground">
+                    {t(($) => $.avatar_upload.emoji_loading)}
+                  </div>
+                }
+              >
+                <EmojiPicker onSelect={handleEmojiSelected} />
+              </Suspense>
             ) : (
-              <Camera className="h-5 w-5 text-white" />
+              <>
+                <div className="p-1">
+                  <button
+                    type="button"
+                    onClick={() => {
+                      closePicker();
+                      openFileDialog();
+                    }}
+                    className="flex w-full items-center gap-1.5 rounded-md px-1.5 py-1.5 text-body outline-hidden transition-colors hover:bg-accent hover:text-accent-foreground focus-visible:bg-accent focus-visible:text-accent-foreground"
+                  >
+                    <ImagePlus className="size-4 shrink-0 text-muted-foreground" />
+                    {t(($) => $.avatar_upload.upload_image)}
+                  </button>
+                </div>
+
+                <Separator />
+
+                <div className="p-1">
+                  <p className="px-1.5 py-1 text-caption font-medium text-muted-foreground">
+                    {t(($) => $.avatar_upload.emoji_label)}
+                  </p>
+                  <div className="grid grid-cols-8 gap-0.5">
+                    {AVATAR_EMOJI_SUGGESTIONS.map((suggestion) => (
+                      <button
+                        key={suggestion}
+                        type="button"
+                        aria-pressed={emoji === suggestion}
+                        onClick={() => handleEmojiSelected(suggestion)}
+                        className={cn(
+                          "flex h-8 w-8 items-center justify-center rounded-md text-title-sm leading-none outline-hidden transition-colors hover:bg-accent focus-visible:ring-2 focus-visible:ring-ring",
+                          emoji === suggestion && "bg-accent ring-1 ring-ring",
+                        )}
+                      >
+                        {suggestion}
+                      </button>
+                    ))}
+                  </div>
+                  <button
+                    type="button"
+                    onClick={() => setEmojiSearchOpen(true)}
+                    className="mt-1 w-full rounded-md px-1.5 py-1 text-caption text-muted-foreground outline-hidden transition-colors hover:bg-accent hover:text-foreground focus-visible:bg-accent focus-visible:text-foreground"
+                  >
+                    {t(($) => $.avatar_upload.more_emojis)}
+                  </button>
+                </div>
+              </>
             )}
-          </div>
-        )}
-      </button>
+          </PopoverContent>
+        </Popover>
+      ) : (
+        avatarButton
+      )}
 
       {onClear && hasAvatar && !busy && !disabled && (
         <button

--- a/packages/views/common/avatar-upload-control.tsx
+++ b/packages/views/common/avatar-upload-control.tsx
@@ -102,6 +102,28 @@ function AvatarFallback({
 }
 
 /**
+ * Runs the caller's persistence callback and reports whether it succeeded.
+ *
+ * A rejection is deliberately swallowed rather than toasted: the caller that
+ * performed the write already owns that feedback. `AgentDetailPage.handleUpdate`
+ * toasts and then rethrows so autosave can render a failed state, and the
+ * settings tabs toast their own; the create flows only stash the value in
+ * local state and cannot fail at all. Reporting it here too would show the
+ * same failure twice. The upload this control runs itself has no other owner,
+ * so that one is still announced.
+ */
+async function persistedByCaller(
+  save: () => void | Promise<unknown>,
+): Promise<boolean> {
+  try {
+    await save();
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
  * Shared click-to-upload avatar control for web/desktop. Renders the current
  * avatar with a hover "change" affordance; on pick it opens {@link
  * AvatarCropDialog} for reposition/zoom, then uploads the cropped image
@@ -168,11 +190,12 @@ export function AvatarUploadControl({
     try {
       const result = await upload(cropped);
       if (!result) return;
-      await onUploaded(result.link);
+      if (!(await persistedByCaller(() => onUploaded(result.link)))) return;
       setDialogOpen(false);
       setPickedFile(null);
       toast.success(t(($) => $.avatar_upload.updated));
     } catch (err) {
+      // Only the upload above can land here — see persistedByCaller.
       toast.error(
         err instanceof Error ? err.message : t(($) => $.avatar_upload.failed),
       );
@@ -181,17 +204,24 @@ export function AvatarUploadControl({
     }
   };
 
-  // No success toast here on purpose: the avatar swaps to the chosen emoji in
-  // place, so the change is already visible. Only a failure needs announcing.
+  // Busy for the whole save, same as an upload: an edit caller PATCHes on every
+  // pick, so leaving the trigger live would let a second pick race the first.
+  // Both writes are last-one-to-arrive-wins on the server, and the loser can be
+  // the one the user chose last — a permanently wrong avatar, since the
+  // invalidate that follows only converges on whatever the server kept.
+  //
+  // No success toast on purpose: the avatar swaps to the chosen emoji in place,
+  // so the change is already visible.
   const handleEmojiSelected = async (picked: string) => {
     closePicker();
     setPreviewError(false);
+    setBusy(true);
     try {
-      await onEmojiSelected?.(formatAvatarEmoji(picked));
-    } catch (err) {
-      toast.error(
-        err instanceof Error ? err.message : t(($) => $.avatar_upload.failed),
+      await persistedByCaller(() =>
+        onEmojiSelected?.(formatAvatarEmoji(picked)),
       );
+    } finally {
+      setBusy(false);
     }
   };
 

--- a/packages/views/locales/en/common.json
+++ b/packages/views/locales/en/common.json
@@ -4,7 +4,11 @@
     "remove": "Remove",
     "select_image": "Please choose an image file.",
     "updated": "Avatar updated",
-    "failed": "Failed to upload avatar"
+    "failed": "Failed to upload avatar",
+    "upload_image": "Upload image",
+    "emoji_label": "Emoji",
+    "more_emojis": "More emojis…",
+    "emoji_loading": "Loading…"
   },
   "avatar_crop": {
     "title": "Edit avatar",

--- a/packages/views/locales/ja/common.json
+++ b/packages/views/locales/ja/common.json
@@ -4,7 +4,11 @@
     "remove": "削除",
     "select_image": "画像ファイルを選択してください。",
     "updated": "アバターを更新しました",
-    "failed": "アバターのアップロードに失敗しました"
+    "failed": "アバターのアップロードに失敗しました",
+    "upload_image": "画像をアップロード",
+    "emoji_label": "絵文字",
+    "more_emojis": "他の絵文字…",
+    "emoji_loading": "読み込み中…"
   },
   "avatar_crop": {
     "title": "アバターを編集",

--- a/packages/views/locales/ko/common.json
+++ b/packages/views/locales/ko/common.json
@@ -4,7 +4,11 @@
     "remove": "제거",
     "select_image": "이미지 파일을 선택하세요.",
     "updated": "아바타를 업데이트했어요",
-    "failed": "아바타 업로드에 실패했어요"
+    "failed": "아바타 업로드에 실패했어요",
+    "upload_image": "이미지 업로드",
+    "emoji_label": "이모지",
+    "more_emojis": "이모지 더 보기…",
+    "emoji_loading": "불러오는 중…"
   },
   "avatar_crop": {
     "title": "아바타 편집",

--- a/packages/views/locales/zh-Hans/common.json
+++ b/packages/views/locales/zh-Hans/common.json
@@ -4,7 +4,11 @@
     "remove": "移除",
     "select_image": "请选择一张图片文件。",
     "updated": "头像已更新",
-    "failed": "头像上传失败"
+    "failed": "头像上传失败",
+    "upload_image": "上传图片",
+    "emoji_label": "表情",
+    "more_emojis": "更多表情…",
+    "emoji_loading": "加载中…"
   },
   "avatar_crop": {
     "title": "编辑头像",


### PR DESCRIPTION
## What

Agent avatars can now be an emoji, picked in the UI.

The server has always seeded a new agent with a random `emoji:<char>` avatar (`agentEmojiAvatars` in `server/internal/handler/agent_avatar.go`) and every renderer already parsed the marker — but the only way for a user to *change* one was to upload an image, so an agent could never get back to an emoji once its avatar was replaced.

Clicking an agent avatar now opens a picker with both options:

- **Upload image** — the crop + upload flow the control always had, unchanged.
- **Emoji** — the same 24 faces the server hands out, one click each, with the full searchable emoji-mart picker behind "More emojis…". The agent's current emoji is marked as selected.

## Scope

Emoji is opt-in per call site via the new `onEmojiSelected` prop, wired only into the three agent surfaces (create dialog, creation studio, detail → Settings → General). User, workspace, and squad avatars keep their click-straight-to-upload behavior.

No backend change: `acceptAvatarURL` already passes an emoji marker through untouched, and it never reaches the storage-object authorization path.

## Notes

- `formatAvatarEmoji` joins `parseAvatarEmoji` in `packages/ui/lib/avatar-emoji.ts` so the `emoji:` prefix keeps one owner on the client.
- No success toast on an emoji pick — the avatar swaps in place, so the change is already visible. Failures still surface.
- The emoji data set (~1MB) stays lazy; only the suggestion grid renders eagerly.

## Verification

- `pnpm typecheck` — 6/6 pass
- `pnpm --filter @multica/views test` — 3355 pass; the one failure (`layout/sidebar-resize.test.tsx`) reproduces on a clean checkout and is unrelated
- New `packages/views/common/avatar-upload-control.test.tsx` covers both paths, the emitted marker value, the selected-state marker, and the disabled case
- `pnpm lint` — 0 errors
- Verified end to end against a local stack: picked an emoji on an existing agent, saw it persist and propagate to the page header
