### PR TITLE
test(agent): stop the cursor fixtures racing their own prompt write (MUL-5536)

### DIFF
--- a/server/pkg/agent/cursor_execute_unix_test.go
+++ b/server/pkg/agent/cursor_execute_unix_test.go
@@ -11,6 +11,23 @@ import (
 	"time"
 )
 
+// A real cursor-agent reads the prompt from stdin to EOF (see buildCursorArgs).
+// A fake that exits without reading it leaves the prompt write racing the
+// child's exit: win and the ~64 KiB pipe buffer swallows it, lose and the read
+// end is already closed and the write fails with EPIPE.
+//
+// That matters because writeErr outranks both `exitErr` and the generic
+// "stream ended without terminal result" when finalizing the error (cursor.go),
+// so a lost race replaces the failure the test is asserting on with
+// "cursor-agent prompt write failed: broken pipe" — the flake that turned main
+// red on 2026-07-30 (MUL-5536).
+//
+// Draining stdin first makes the fake honour the same contract as the real CLI,
+// which removes the race instead of papering over it. Only fixtures whose
+// expected error ranks below writeErr need it; the scanner-overflow and
+// structured-stream-error cases rank above it and are unaffected.
+const drainStdin = "cat > /dev/null"
+
 func TestCursorExecuteStopsAfterTerminalResult(t *testing.T) {
 	t.Parallel()
 
@@ -108,6 +125,7 @@ func TestCursorExecuteReportsSanitizedStderrOnProcessFailure(t *testing.T) {
 	}
 
 	script := `#!/bin/sh
+` + drainStdin + `
 dd if=/dev/zero bs=4096 count=1 2>/dev/null | tr '\000' x >&2
 printf '\nAuthorization: Bearer cursor-secret-token-value\npath=%s/private\n' "$HOME" >&2
 exit 1
@@ -196,6 +214,7 @@ printf '\n'
 
 func TestCursorExecuteFailsOnCleanEOFWithoutResult(t *testing.T) {
 	script := `#!/bin/sh
+` + drainStdin + `
 printf '%s\n' '{"type":"system","subtype":"init","session_id":"sess-no-result"}'
 printf '%s\n' '{"type":"assistant","message":{"content":[{"type":"text","text":"partial answer"}]}}'
 `


### PR DESCRIPTION
## What

`main` is red on the **backend** job (run 30523539480, commit 9072cef12):

```
--- FAIL: TestCursorExecuteFailsOnCleanEOFWithoutResult
cursor_execute_unix_test.go:214: error = "cursor-agent prompt write failed: write |1: broken pipe
    (result_seen=false, exit_code=0, scanner_error=false, event_count=2, ...)",
    want substring "cursor-agent stream ended without terminal result"
```

This one really is flaky (unlike the frontend failure it followed).

## Why it flakes

The fake `cursor-agent` emits two events and exits without ever reading stdin. The prompt write therefore races the child's exit:

- parent wins → the ~64 KiB pipe buffer swallows the prompt, `writeErr == nil`, finalization falls through to the asserted error;
- child wins → the read end is already closed, the write returns `EPIPE`.

`writeErr` deliberately outranks both `exitErr` and the generic "stream ended without terminal result" in `cursor.go`, so losing the race swaps the failure the test asserts on for the EPIPE one. The ranking is correct as written — the comment there already notes that a child exiting early makes our write fail with EPIPE as a side effect, and the stderr tail carries the real cause — so this is a fixture bug, not a production one.

## Fix

A real `cursor-agent` reads the prompt from stdin to EOF; the fixtures now do too (`cat > /dev/null`). The writer goroutine closes stdin immediately after the write, so the drain returns at once — no added latency and no deadlock.

Only the two fixtures whose expected error ranks *below* `writeErr` need it. `TestCursorExecuteReportsScannerOverflow` (scanner error) and `TestCursorExecutePreservesStructuredStreamError` (protocol error) rank above it, and `TestCursorExecuteReportsMalformedTerminalEvent` asserts only on the diagnostic tail, which is appended on every branch.

## Verification

- `go vet ./pkg/agent`, `gofmt` clean.
- `go test ./pkg/agent` — full package green (123s).
- 60 runs of the two touched tests: green, 0.29s per run — unchanged from before the drain, confirming no deadlock.
- I could **not** reproduce the original flake locally: 1,360 runs across 12-way process contention and `GOMAXPROCS=1` on darwin/arm64 all passed. The diagnosis rests on the CI error string naming the EPIPE branch verbatim plus the fixture not reading stdin, not on a local repro.
