### PR TITLE
feat(skills): floating save pill with change summary + one skill icon everywhere

### DIFF
--- a/packages/views/agents/components/skill-picker-list.tsx
+++ b/packages/views/agents/components/skill-picker-list.tsx
@@ -1,7 +1,8 @@
 "use client";
 
 import { useState } from "react";
-import { FileText, Search } from "lucide-react";
+import { Search } from "lucide-react";
+import { SkillIcon } from "../../skills/lib/skill-icon";
 import type { SkillSummary } from "@multica/core/types";
 import { Checkbox } from "@multica/ui/components/ui/checkbox";
 import { Input } from "@multica/ui/components/ui/input";
@@ -122,7 +123,7 @@ export function SkillPickerList({
                   tabIndex={-1}
                   className="pointer-events-none"
                 />
-                <FileText className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
+                <SkillIcon className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
                 <div className="min-w-0 flex-1">
                   <div className="truncate text-body font-medium">{skill.name}</div>
                   {skill.description ? (

--- a/packages/views/agents/components/tabs/skills-tab.tsx
+++ b/packages/views/agents/components/tabs/skills-tab.tsx
@@ -2,13 +2,13 @@
 
 import { useState } from "react";
 import {
-  FileText,
   Loader2,
   Plus,
   RefreshCw,
   Server,
   Trash2,
 } from "lucide-react";
+import { SkillIcon } from "../../../skills/lib/skill-icon";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { toast } from "sonner";
 import type {
@@ -162,7 +162,7 @@ export function SkillsTab({
       >
         {agent.skills.length === 0 ? (
           <EmptyState
-            icon={<FileText className="h-6 w-6" />}
+            icon={<SkillIcon className="h-6 w-6" />}
             title={t(($) => $.tab_body.skills.empty_title)}
             hint={t(($) => $.tab_body.skills.empty_hint)}
           />
@@ -184,7 +184,7 @@ export function SkillsTab({
                         !enabled && "opacity-50",
                       )}
                     >
-                      <FileText className="h-4 w-4" />
+                      <SkillIcon className="h-4 w-4" />
                     </span>
                     <span className="min-w-0 flex-1">
                       <span className={cn("block text-body font-medium", !enabled && "text-muted-foreground")}>

--- a/packages/views/locales/en/skills.json
+++ b/packages/views/locales/en/skills.json
@@ -129,11 +129,12 @@
       "body": "Your edits are preserved. Discard to pull their changes, or Save to overwrite."
     },
     "save_bar": {
-      "unsaved": "Unsaved changes — will overwrite the live skill on save",
+      "changed_summary": "Changed: {{parts}}",
+      "changed_files_one": "{{count}} file",
+      "changed_files_other": "{{count}} files",
       "discard": "Discard",
       "save": "Save changes",
-      "saving": "Saving…",
-      "saved": "All changes saved"
+      "saving": "Saving…"
     },
     "not_found": {
       "title": "Skill not found",

--- a/packages/views/locales/ja/skills.json
+++ b/packages/views/locales/ja/skills.json
@@ -124,11 +124,11 @@
       "body": "あなたの編集内容は保持されています。破棄すると相手の変更を取り込み、保存すると上書きします。"
     },
     "save_bar": {
-      "unsaved": "未保存の変更 — 保存すると現在のスキルを上書きします",
+      "changed_summary": "変更あり:{{parts}}",
+      "changed_files_other": "ファイル{{count}}件",
       "discard": "破棄",
       "save": "変更を保存",
-      "saving": "保存中…",
-      "saved": "変更は保存済みです"
+      "saving": "保存中…"
     },
     "not_found": {
       "title": "スキルが見つかりません",

--- a/packages/views/locales/ko/skills.json
+++ b/packages/views/locales/ko/skills.json
@@ -124,11 +124,11 @@
       "body": "내 수정 내용은 보존되어 있습니다. 버리기를 누르면 상대 변경사항을 가져오고, 저장을 누르면 덮어씁니다."
     },
     "save_bar": {
-      "unsaved": "저장하지 않은 변경사항 — 저장하면 현재 스킬을 덮어씁니다",
+      "changed_summary": "변경됨: {{parts}}",
+      "changed_files_other": "파일 {{count}}개",
       "discard": "버리기",
       "save": "변경사항 저장",
-      "saving": "저장하는 중...",
-      "saved": "모든 변경 사항이 저장됨"
+      "saving": "저장하는 중..."
     },
     "not_found": {
       "title": "스킬을 찾을 수 없습니다",

--- a/packages/views/locales/zh-Hans/skills.json
+++ b/packages/views/locales/zh-Hans/skills.json
@@ -124,11 +124,11 @@
       "body": "你的修改已保留。Discard 来拉取他们的版本，或 Save 覆盖。"
     },
     "save_bar": {
-      "unsaved": "未保存的修改——保存会覆盖当前的 skill",
+      "changed_summary": "已修改:{{parts}}",
+      "changed_files_other": "{{count}} 个文件",
       "discard": "丢弃",
       "save": "保存修改",
-      "saving": "保存中...",
-      "saved": "改动已保存"
+      "saving": "保存中..."
     },
     "not_found": {
       "title": "未找到该 skill",

--- a/packages/views/onboarding/steps/step-workspace.tsx
+++ b/packages/views/onboarding/steps/step-workspace.tsx
@@ -4,7 +4,6 @@ import { type ReactNode, useRef, useState } from "react";
 import {
   ArrowLeft,
   ArrowRight,
-  BookOpenText,
   Bot,
   FolderKanban,
   Inbox,
@@ -15,6 +14,7 @@ import {
   Plus,
   Zap,
 } from "lucide-react";
+import { SkillIcon } from "../../skills/lib/skill-icon";
 import { toast } from "sonner";
 import { Button } from "@multica/ui/components/ui/button";
 import { Input } from "@multica/ui/components/ui/input";
@@ -626,7 +626,7 @@ function WorkspacePreviewCard({
           meta={t(($) => $.step_workspace.preview.runtimes_meta)}
         />
         <EntityRow
-          icon={<BookOpenText className="h-4 w-4" />}
+          icon={<SkillIcon className="h-4 w-4" />}
           label={t(($) => $.step_workspace.preview.skills_label)}
           meta={t(($) => $.step_workspace.preview.skills_meta)}
         />

--- a/packages/views/skills/components/file-viewer.tsx
+++ b/packages/views/skills/components/file-viewer.tsx
@@ -50,7 +50,8 @@ export function FileViewer({
   if (isMd && mode === "preview") {
     return (
       <div className="h-full overflow-y-auto">
-        <div className="mx-auto max-w-[68ch] px-6 py-7 sm:px-8">
+        {/* pb-24: keeps the last lines readable under the floating save pill. */}
+        <div className="mx-auto max-w-[68ch] px-6 pb-24 pt-7 sm:px-8">
           <RichContent
             content={body || t(($) => $.file_viewer.no_content)}
             density="document"
@@ -72,7 +73,7 @@ export function FileViewer({
           ? t(($) => $.file_viewer.markdown_placeholder)
           : t(($) => $.file_viewer.raw_placeholder)
       }
-      className="h-full min-h-full resize-none rounded-none border-0 px-6 py-5 font-mono text-body leading-relaxed read-only:cursor-default focus-visible:ring-0 sm:px-8"
+      className="h-full min-h-full resize-none rounded-none border-0 px-6 pb-24 pt-5 font-mono text-body leading-relaxed read-only:cursor-default focus-visible:ring-0 sm:px-8"
     />
   );
 }

--- a/packages/views/skills/components/skill-detail-page.test.tsx
+++ b/packages/views/skills/components/skill-detail-page.test.tsx
@@ -195,20 +195,40 @@ describe("SkillDetailPage file mode", () => {
   });
 });
 
-describe("SkillDetailPage save bar", () => {
-  it("stays mounted and disabled while clean so committing an edit never shifts the layout", async () => {
+describe("SkillDetailPage save pill", () => {
+  it("is absent while clean and floats in with a change summary once dirty", async () => {
     renderPage();
-    expect(await screen.findByText("All changes saved")).toBeTruthy();
-    expect(
-      screen.getByRole("button", { name: /Save changes/ }).hasAttribute("disabled"),
-    ).toBe(true);
+    await screen.findByRole("tab", { name: "Overview" });
+    expect(screen.queryByRole("button", { name: /Save changes/ })).toBeNull();
 
     fireEvent.change(screen.getByLabelText("Description"), {
       target: { value: "changed" },
     });
+    expect(screen.getByText("Changed: Description")).toBeTruthy();
     expect(
       screen.getByRole("button", { name: /Save changes/ }).hasAttribute("disabled"),
     ).toBe(false);
+  });
+
+  it("lists every dirty part in the summary, reusing the field labels", async () => {
+    renderPage();
+    fireEvent.change(await screen.findByLabelText("Name"), {
+      target: { value: "renamed-skill" },
+    });
+    fireEvent.change(screen.getByLabelText("Description"), {
+      target: { value: "changed" },
+    });
+    expect(screen.getByText("Changed: Name · Description")).toBeTruthy();
+  });
+
+  it("counts a supporting-file edit as one changed file", async () => {
+    renderPage(new URLSearchParams("view=files"));
+    fireEvent.click(await screen.findByRole("tab", { name: "patterns.md" }));
+    fireEvent.click(screen.getByRole("button", { name: "Plain text" }));
+    fireEvent.change(screen.getByRole("textbox", { name: /patterns\.md/ }), {
+      target: { value: "edited content" },
+    });
+    expect(screen.getByText("Changed: 1 file")).toBeTruthy();
   });
 
   it("is absent for read-only viewers, who get the capability banner instead", async () => {

--- a/packages/views/skills/components/skill-detail-page.test.tsx
+++ b/packages/views/skills/components/skill-detail-page.test.tsx
@@ -53,7 +53,10 @@ vi.mock("@multica/core/auth", () => {
     ),
   };
 });
-vi.mock("@multica/core/paths", () => ({
+// Partial: `WORKSPACE_PAGES` also comes from here and backs the shared
+// SkillIcon, so the real module has to stay reachable.
+vi.mock("@multica/core/paths", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@multica/core/paths")>()),
   useWorkspacePaths: () => ({ skills: () => "/acme/skills" }),
 }));
 vi.mock("@multica/core/permissions", () => ({

--- a/packages/views/skills/components/skill-detail-page.tsx
+++ b/packages/views/skills/components/skill-detail-page.tsx
@@ -797,20 +797,35 @@ export function SkillDetailPage({ skillId }: { skillId: string }) {
     }
   }, [fileMap, selectedPath]);
 
-  const isDirty = useMemo(() => {
-    if (!skill) return false;
-    const serverFiles = (skill.files ?? []).map((f: SkillFile) => ({
-      path: f.path,
-      content: f.content,
-    }));
-    const draftFiles = files.map((f) => ({ path: f.path, content: f.content }));
-    return (
-      name.trim() !== skill.name ||
-      description.trim() !== skill.description ||
-      content !== skill.content ||
-      JSON.stringify(draftFiles) !== JSON.stringify(serverFiles)
-    );
+  // Files are matched by id so a rename counts as one changed file, not a
+  // delete plus an add; SKILL.md is its own entry since it lives in `content`.
+  const dirtySummary = useMemo(() => {
+    if (!skill) return { nameChanged: false, descChanged: false, changedFileCount: 0 };
+    const serverFiles: SkillFile[] = skill.files ?? [];
+    const serverById = new Map(serverFiles.map((f) => [f.id, f]));
+    let changedFileCount = content !== skill.content ? 1 : 0;
+    const draftIds = new Set<string>();
+    for (const f of files) {
+      if (f.id) draftIds.add(f.id);
+      const server = f.id ? serverById.get(f.id) : undefined;
+      if (!server || server.path !== f.path || server.content !== f.content) {
+        changedFileCount += 1;
+      }
+    }
+    for (const f of serverFiles) {
+      if (!draftIds.has(f.id)) changedFileCount += 1;
+    }
+    return {
+      nameChanged: name.trim() !== skill.name,
+      descChanged: description.trim() !== skill.description,
+      changedFileCount,
+    };
   }, [skill, name, description, content, files]);
+
+  const isDirty =
+    dirtySummary.nameChanged ||
+    dirtySummary.descChanged ||
+    dirtySummary.changedFileCount > 0;
 
   const seedFromSkill = (s: Skill) => {
     setName(s.name);
@@ -969,6 +984,18 @@ export function SkillDetailPage({ skillId }: { skillId: string }) {
     );
   }
 
+  // Segments reuse the overview field labels so the pill and the fields it
+  // points at never use different words for the same thing.
+  const changedParts = [
+    dirtySummary.nameChanged ? t(($) => $.detail.overview.name) : null,
+    dirtySummary.descChanged ? t(($) => $.detail.overview.description) : null,
+    dirtySummary.changedFileCount > 0
+      ? t(($) => $.detail.save_bar.changed_files, {
+          count: dirtySummary.changedFileCount,
+        })
+      : null,
+  ].filter((part): part is string => part !== null);
+
   const TABS: { id: DetailView; label: string }[] = [
     { id: "overview", label: t(($) => $.detail.tabs.overview) },
     {
@@ -978,7 +1005,9 @@ export function SkillDetailPage({ skillId }: { skillId: string }) {
   ];
 
   return (
-    <div className="flex flex-1 min-h-0 flex-col">
+    // relative: positioning anchor for the floating save pill (page-centered,
+    // same rule as the skills list batch toolbar).
+    <div className="relative flex flex-1 min-h-0 flex-col">
       <BreadcrumbHeader
         segments={[{ href: paths.skills(), label: t(($) => $.page.title) }]}
         leaf={
@@ -1135,55 +1164,49 @@ export function SkillDetailPage({ skillId }: { skillId: string }) {
         )}
       </div>
 
-      {/* Page-level so it covers edits made on either tab, and always present
-          while editable so committing a change never shifts the layout. */}
-      {canEdit && (
+      {/* Page-level so it covers edits made on either tab. Dirty-only and
+          floating, matching the skills list batch toolbar; anchored to the
+          page root (relative), NOT the viewport. */}
+      {canEdit && isDirty && (
         <div
           role="status"
           aria-live="polite"
-          className="pe-chat-launcher flex shrink-0 flex-wrap items-center gap-2 border-t bg-muted/30 py-2 pl-4 sm:pl-6"
+          className="absolute bottom-6 left-1/2 z-50 flex -translate-x-1/2 animate-in items-center gap-1 rounded-lg border bg-background px-2 py-1.5 fade-in slide-in-from-bottom-2 shadow-lg"
         >
-          {isDirty ? (
-            <>
-              <span className="h-1.5 w-1.5 rounded-full bg-brand" />
-              <span className="text-caption text-muted-foreground">
-                {t(($) => $.detail.save_bar.unsaved)}
-              </span>
-            </>
-          ) : (
-            <span className="text-caption text-muted-foreground">
-              {t(($) => $.detail.save_bar.saved)}
+          <div className="mr-1 flex items-center border-r pl-1 pr-2">
+            <span className="whitespace-nowrap text-caption text-muted-foreground">
+              {t(($) => $.detail.save_bar.changed_summary, {
+                parts: changedParts.join(" · "),
+              })}
             </span>
-          )}
-          <div className="ml-auto flex items-center gap-1.5">
-            <Button
-              type="button"
-              variant="ghost"
-              size="xs"
-              onClick={handleDiscard}
-              disabled={!isDirty || saving}
-            >
-              {t(($) => $.detail.save_bar.discard)}
-            </Button>
-            <Button
-              type="button"
-              size="xs"
-              onClick={handleSave}
-              disabled={!isDirty || saving || !name.trim()}
-            >
-              {saving ? (
-                <>
-                  <Loader2 className="h-3 w-3 animate-spin" />
-                  {t(($) => $.detail.save_bar.saving)}
-                </>
-              ) : (
-                <>
-                  <Save className="h-3 w-3" />
-                  {t(($) => $.detail.save_bar.save)}
-                </>
-              )}
-            </Button>
           </div>
+          <Button
+            type="button"
+            variant="ghost"
+            size="xs"
+            onClick={handleDiscard}
+            disabled={saving}
+          >
+            {t(($) => $.detail.save_bar.discard)}
+          </Button>
+          <Button
+            type="button"
+            size="xs"
+            onClick={handleSave}
+            disabled={saving || !name.trim()}
+          >
+            {saving ? (
+              <>
+                <Loader2 className="h-3 w-3 animate-spin" />
+                {t(($) => $.detail.save_bar.saving)}
+              </>
+            ) : (
+              <>
+                <Save className="h-3 w-3" />
+                {t(($) => $.detail.save_bar.save)}
+              </>
+            )}
+          </Button>
         </div>
       )}
 

--- a/packages/views/skills/components/skill-detail-page.tsx
+++ b/packages/views/skills/components/skill-detail-page.tsx
@@ -16,6 +16,7 @@ import {
   UserPlus,
   Users,
 } from "lucide-react";
+import { SkillIcon } from "../lib/skill-icon";
 import type {
   Agent,
   AgentRuntime,
@@ -241,9 +242,10 @@ function SkillIdentity({
       <div className="mx-auto flex max-w-[1440px] flex-wrap items-center gap-x-4 gap-y-1.5">
         <div className="flex min-w-0 items-center gap-2.5">
           <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg border bg-muted text-muted-foreground">
-            <Sparkles className="h-4 w-4" aria-hidden="true" />
+            <SkillIcon className="h-4 w-4" aria-hidden="true" />
           </div>
           <h1 className="min-w-0 truncate font-mono text-title font-semibold tracking-tight">
+
             {skill.name}
           </h1>
         </div>

--- a/packages/views/skills/components/skills-page.tsx
+++ b/packages/views/skills/components/skills-page.tsx
@@ -4,13 +4,13 @@ import { useMemo, useRef, useState } from "react";
 import {
   AlertCircle,
   AlertTriangle,
-  BookOpen,
   Download,
   HardDrive,
   Lock,
   Pencil,
   Plus,
 } from "lucide-react";
+import { SkillIcon } from "../lib/skill-icon";
 import type {
   Agent,
   AgentRuntime,
@@ -173,7 +173,7 @@ function PageHeaderBar({
   const { t } = useT("skills");
   return (
     <CollectionPageHeader
-      icon={BookOpen}
+      icon={SkillIcon}
       title={t(($) => $.page.title)}
       count={totalCount}
       description={t(($) => $.page.tagline)}
@@ -384,7 +384,7 @@ function EmptyState({ onCreate }: { onCreate: () => void }) {
   const { t } = useT("skills");
   return (
     <CollectionPageState
-      icon={BookOpen}
+      icon={SkillIcon}
       title={t(($) => $.page.empty.title)}
       description={t(($) => $.page.empty.description)}
       actions={

--- a/packages/views/skills/lib/skill-icon.test.ts
+++ b/packages/views/skills/lib/skill-icon.test.ts
@@ -1,0 +1,17 @@
+import { describe, it, expect } from "vitest";
+import { routeIconForPath } from "../../layout/route-icon-components";
+import { SkillIcon } from "./skill-icon";
+
+describe("SkillIcon", () => {
+  // The sidebar and desktop tab bar both render the route icon, while every
+  // in-page surface renders SkillIcon. Before they were derived from one
+  // declaration the product showed four icons for the same entity
+  // (BookOpenText, BookOpen, FileText, Sparkles).
+  it("is the same component the sidebar and tab bar resolve for /skills", () => {
+    expect(SkillIcon).toBe(routeIconForPath("/acme/skills"));
+  });
+
+  it("keeps matching for a nested skill detail path", () => {
+    expect(SkillIcon).toBe(routeIconForPath("/acme/skills/skill-1"));
+  });
+});

--- a/packages/views/skills/lib/skill-icon.ts
+++ b/packages/views/skills/lib/skill-icon.ts
@@ -1,0 +1,18 @@
+import type { LucideIcon } from "lucide-react";
+import { WORKSPACE_PAGES } from "@multica/core/paths";
+import { ROUTE_ICON_COMPONENTS } from "../../layout/route-icon-components";
+
+/**
+ * The icon that means "a skill", anywhere one is rendered as an entity: list
+ * header, empty states, detail identity, agent skill rows, skill pickers.
+ *
+ * Derived from the skills route icon rather than re-declared, so the sidebar,
+ * the desktop tab bar, and every in-page surface can never drift apart again
+ * — they previously showed four different icons (BookOpenText, BookOpen,
+ * FileText, Sparkles) for the same thing.
+ *
+ * This is for the skill *entity*. A file inside a skill is not a skill; those
+ * keep the file-type icons in `file-tree.tsx`.
+ */
+export const SkillIcon: LucideIcon =
+  ROUTE_ICON_COMPONENTS[WORKSPACE_PAGES.skills.icon];


### PR DESCRIPTION
Two follow-ups to the skill detail/list pages, shipped together.

## Floating save pill (replaces the docked save bar)

The skill detail page kept an always-mounted, muted save bar at the bottom; the dirty state was a 1.5px dot most people never noticed. It is now a dirty-only floating pill, page-root anchored, using the same container language as the skills list batch toolbar:

- Shows a summary of what changed — `Changed: Name · Description · 3 files` — reusing the overview field labels so the pill and the fields never use different words. Files are matched by id, so a rename counts as one changed file, not a delete plus an add.
- Discard / Save actions, save disabled while saving or when the name is empty.
- Enters with a 150ms fade + 8px slide-up (`tw-animate-css`, same vocabulary as popover/tooltip); disappears instantly on save/discard.
- Editor surfaces gain bottom padding so the last lines stay readable under the pill.
- `role="status" aria-live="polite"` preserved.

The draft model is unchanged: name, description, SKILL.md, and supporting files remain one draft with one atomic save.

## One icon for the skill entity (MUL-5443)

Includes the icon unification from #6167 (same commit, cherry-picked): `SkillIcon` is derived from `WORKSPACE_PAGES.skills.icon` + `ROUTE_ICON_COMPONENTS`, replacing the four different glyphs (`BookOpenText` / `BookOpen` / `FileText` / `Sparkles`) that all meant "skill". `Sparkles` as the imported-origin marker and `FileText` as the file/count glyph are deliberately kept. Supersedes #6167.

## Verification

- `packages/views` targeted tests: `skill-detail-page.test.tsx` (10) + `skill-icon.test.ts` (2) pass.
- Not run: full typecheck/lint/test suite.
- Manual: pill appears on first edit with correct summary on both tabs, disappears on save/discard; verified in web.

🤖 Generated with [Claude Code](https://claude.com/claude-code)