### PR TITLE
fix(issues): stabilize the Table query identity across a workspace switch (MUL-5477)

### DIFF
--- a/packages/views/issues/components/table-view-virtualized-hierarchy.test.tsx
+++ b/packages/views/issues/components/table-view-virtualized-hierarchy.test.tsx
@@ -1,0 +1,355 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * MUL-5477 regression coverage for the PRODUCTION Table path.
+ *
+ * Production mounts the Table with `virtualizeRows` (table-view.tsx) and
+ * `tableHierarchy` defaults to on (view-store.ts), so every parent row carries
+ * an auto-activating branch sentinel and the row window is driven by the real
+ * @tanstack/react-virtual. No other test covered that combination: they all
+ * replace the virtualizer with a stand-in that renders every row, because jsdom
+ * reports a zero-height viewport and the real one would render nothing.
+ *
+ * This file supplies the missing layout instead of removing the virtualizer,
+ * because the virtualizer is what closes the circuit MUL-5477 runs around:
+ * `serverDisplayRows` feeds the row list, the row list feeds the virtualizer's
+ * `getItemKey`, and a new-but-equal row list makes the virtualizer re-key,
+ * notify and re-render — which rebuilds the row list again. Any dependency of
+ * `serverDisplayRows` that loses referential stability turns that circuit into a
+ * sustained commit storm with no fetching and no DOM measurement, which is why a
+ * convergence assertion is only meaningful with the real virtualizer mounted.
+ *
+ * Every mock below therefore returns HOISTED, stable references, mirroring the
+ * real hooks (`useActorName` memoises `getActorName`). That is not incidental
+ * tidiness: while writing this test, per-render mock closures alone were enough
+ * to reproduce the storm, so an unstable mock here would assert the fixture
+ * rather than the product.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { cleanup, screen, waitFor } from "@testing-library/react";
+import { Profiler } from "react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { setApiInstance } from "@multica/core/api";
+import type { ApiClient } from "@multica/core/api/client";
+import { ViewStoreProvider } from "@multica/core/issues/stores/view-store-context";
+import { getIssueSurfaceViewStore } from "@multica/core/issues/stores/surface-view-store";
+import type {
+  Issue,
+  IssueTableQuerySpec,
+  IssueTableRowsRequest,
+} from "@multica/core/types";
+import { renderWithI18n } from "../../test/i18n";
+import { IssueSurfaceSelectionProvider } from "../surface/selection-context";
+import type { IssueSurfaceSelection } from "../surface/selection-context";
+import { TableView } from "./table-view";
+
+vi.mock("@multica/core/hooks", () => ({ useWorkspaceId: () => "ws-1" }));
+
+const actorNames = vi.hoisted(() => {
+  const getActorName = () => "Someone";
+  return { getActorName, result: { getActorName } };
+});
+vi.mock("@multica/core/workspace/hooks", () => ({
+  useActorName: () => actorNames.result,
+  buildActorNameResolver: () => actorNames.getActorName,
+}));
+
+const authState = vi.hoisted(() => ({
+  value: {
+    user: { id: "user-1", email: "t@t.co", name: "Tester" },
+    isAuthenticated: true,
+  },
+}));
+vi.mock("@multica/core/auth", () => ({
+  useAuthStore: Object.assign(
+    (selector?: (state: unknown) => unknown) =>
+      selector ? selector(authState.value) : authState.value,
+    { getState: () => authState.value },
+  ),
+}));
+
+const navigation = vi.hoisted(() => ({
+  value: {
+    push: () => {},
+    openInNewTab: () => {},
+    getShareableUrl: (path: string) => `https://app.example${path}`,
+    pathname: "/",
+  },
+}));
+vi.mock("../../navigation", () => ({
+  AppLink: ({ children, ...props }: React.ComponentProps<"a">) => (
+    <a {...props}>{children}</a>
+  ),
+  useNavigation: () => navigation.value,
+}));
+
+vi.mock("@multica/core/paths", async () => {
+  const actual =
+    await vi.importActual<typeof import("@multica/core/paths")>(
+      "@multica/core/paths",
+    );
+  const workspacePaths = actual.paths.workspace("test");
+  return { ...actual, useWorkspacePaths: () => workspacePaths };
+});
+
+/** Matches the DataTable virtualizer's own `virtualRowHeight` default. */
+const ROW_HEIGHT = 41;
+const VIEWPORT_HEIGHT = 600;
+
+/**
+ * The virtualizer reads its viewport from `offsetWidth`/`offsetHeight` on the
+ * scroll element, and each row's height through `measureElement`, which the
+ * DataTable implements with `getBoundingClientRect().height`. jsdom returns 0
+ * for all three, so all three are supplied. The measured height equals
+ * `estimateSize`, so a settled table has nothing left to correct — drift there
+ * would be a real measurement loop rather than a fixture artifact.
+ */
+function installLayout() {
+  const restore: Array<() => void> = [];
+  for (const [property, value] of [
+    ["offsetHeight", VIEWPORT_HEIGHT],
+    ["offsetWidth", 1200],
+  ] as const) {
+    const original = Object.getOwnPropertyDescriptor(
+      HTMLElement.prototype,
+      property,
+    );
+    Object.defineProperty(HTMLElement.prototype, property, {
+      configurable: true,
+      get: () => value,
+    });
+    restore.push(() => {
+      if (original) {
+        Object.defineProperty(HTMLElement.prototype, property, original);
+      } else {
+        delete (HTMLElement.prototype as unknown as Record<string, unknown>)[
+          property
+        ];
+      }
+    });
+  }
+
+  const originalRect = Element.prototype.getBoundingClientRect;
+  Element.prototype.getBoundingClientRect = function stubbedRect() {
+    return {
+      width: 1200,
+      height: ROW_HEIGHT,
+      top: 0,
+      left: 0,
+      right: 1200,
+      bottom: ROW_HEIGHT,
+      x: 0,
+      y: 0,
+      toJSON: () => ({}),
+    } as DOMRect;
+  };
+  restore.push(() => {
+    Element.prototype.getBoundingClientRect = originalRect;
+  });
+
+  return () => {
+    for (const undo of restore.reverse()) undo();
+  };
+}
+
+class ResizeObserverStub {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+  takeRecords() {
+    return [];
+  }
+}
+
+/**
+ * A viewport that reports everything handed to it as visible.
+ *
+ * Hierarchy branch sentinels activate on intersection, so this expands the whole
+ * loaded tree at once rather than a scroll at a time — the aggressive end of
+ * production, and the shape most likely to run the circuit away.
+ */
+class VisibleIntersectionObserver {
+  #callback: IntersectionObserverCallback;
+  constructor(callback: IntersectionObserverCallback) {
+    this.#callback = callback;
+  }
+  observe(target: Element) {
+    setTimeout(() => {
+      this.#callback(
+        [{ isIntersecting: true, target } as IntersectionObserverEntry],
+        this as unknown as IntersectionObserver,
+      );
+    }, 0);
+  }
+  unobserve() {}
+  disconnect() {}
+  takeRecords() {
+    return [];
+  }
+}
+
+function makeIssue(id: string): Issue {
+  return {
+    id,
+    workspace_id: "ws-1",
+    number: 1,
+    identifier: `MUL-${id}`,
+    title: `Task ${id}`,
+    description: null,
+    status: "todo",
+    priority: "none",
+    assignee_type: null,
+    assignee_id: null,
+    creator_type: "member",
+    creator_id: "member-1",
+    parent_issue_id: null,
+    project_id: null,
+    position: 1,
+    stage: null,
+    start_date: null,
+    due_date: null,
+    labels: [],
+    metadata: {},
+    properties: {},
+    created_at: "2026-01-01T00:00:00Z",
+    updated_at: "2026-01-01T00:00:00Z",
+  };
+}
+
+/** Three roots, two leaf children each. Bounded, so settling is observable. */
+const TREE: Record<string, string[]> = {
+  root: ["a", "b", "c"],
+  a: ["a1", "a2"],
+  b: ["b1", "b2"],
+  c: ["c1", "c2"],
+};
+
+const serverQuery: IssueTableQuerySpec = {
+  scope: { kind: "workspace" },
+  filters: {},
+  sort: { field: "position", direction: "asc" },
+};
+
+const selection: IssueSurfaceSelection = {
+  selectedIds: new Set<string>(),
+  toggle: () => {},
+  select: () => {},
+  deselect: () => {},
+  clear: () => {},
+};
+
+const EMPTY_PROGRESS = new Map();
+const noop = () => {};
+const exportIssues = () => Promise.resolve([]);
+const resolveExportLookups = () =>
+  Promise.resolve({ projectMap: new Map(), childProgressMap: new Map() });
+
+let commits = 0;
+
+function Harness({ surfaceKey }: { surfaceKey: string }) {
+  return (
+    <Profiler
+      id="table"
+      onRender={() => {
+        commits += 1;
+      }}
+    >
+      <ViewStoreProvider store={getIssueSurfaceViewStore(surfaceKey)}>
+        <IssueSurfaceSelectionProvider selection={selection}>
+          <TableView
+            serverQuery={serverQuery}
+            childProgressMap={EMPTY_PROGRESS}
+            search=""
+            onSearchChange={noop}
+            onLoadedIssuesChange={noop}
+            onCreateIssue={noop}
+            exportIssues={exportIssues}
+            resolveExportLookups={resolveExportLookups}
+          />
+        </IssueSurfaceSelectionProvider>
+      </ViewStoreProvider>
+    </Profiler>
+  );
+}
+
+describe("Table view on the production virtualized hierarchy path", () => {
+  let queryClient: QueryClient;
+  let restoreLayout: () => void;
+  let rowRequests: string[];
+
+  beforeEach(() => {
+    commits = 0;
+    rowRequests = [];
+    restoreLayout = installLayout();
+    vi.stubGlobal("IntersectionObserver", VisibleIntersectionObserver);
+    vi.stubGlobal("ResizeObserver", ResizeObserverStub);
+    queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false, staleTime: Infinity } },
+    });
+    setApiInstance({
+      listProperties: async () => ({ properties: [] }),
+      listMembers: async () => [],
+      listAgents: async () => [],
+      listSquads: async () => [],
+      getAssigneeFrequency: async () => [],
+      listIssueTableRows: async (request: IssueTableRowsRequest) => {
+        const parent = request.parent_id ?? "root";
+        rowRequests.push(parent);
+        const ids = TREE[parent] ?? [];
+        return {
+          query_fingerprint: "test",
+          group_key: request.group_key ?? null,
+          parent_id: request.parent_id ?? null,
+          total: ids.length,
+          rows: ids.map((id) => ({
+            issue: makeIssue(id),
+            direct_child_count: (TREE[id] ?? []).length,
+          })),
+          branch_total: ids.length,
+          next_cursor: null,
+        };
+      },
+    } as unknown as ApiClient);
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.unstubAllGlobals();
+    restoreLayout();
+  });
+
+  it("renders the hierarchy through the real virtualizer and stops committing once it settles", async () => {
+    renderWithI18n(
+      <QueryClientProvider client={queryClient}>
+        <Harness surfaceKey={`virtualized-${Math.floor(Math.random() * 1e9)}`} />
+      </QueryClientProvider>,
+    );
+
+    // The virtualizer is real, so rows appear only if it saw a viewport. This is
+    // the part every other Table test skips by replacing it.
+    await screen.findByText("MUL-a");
+    // Depth 1 arrives only by a branch sentinel activating its own query.
+    await waitFor(() => expect(screen.queryByText("MUL-a1")).toBeTruthy(), {
+      timeout: 5000,
+    });
+    await waitFor(() => expect(screen.queryByText("MUL-c2")).toBeTruthy(), {
+      timeout: 5000,
+    });
+
+    // One request per branch: the root plus its three parents. A churning query
+    // list detaches and reinstalls observers, which shows up here as repeats.
+    await waitFor(() => expect(rowRequests).toHaveLength(4));
+    expect([...rowRequests].sort()).toEqual(["a", "b", "c", "root"]);
+
+    // Convergence. Nothing external touches the table past this point, so any
+    // further commit is the table driving itself — the shape of the hang. It is
+    // sampled twice because a loop presents as steady growth, not as one late
+    // commit.
+    const settled = commits;
+    await new Promise((resolve) => setTimeout(resolve, 300));
+    const afterIdle = commits;
+    await new Promise((resolve) => setTimeout(resolve, 300));
+    expect(afterIdle).toBe(settled);
+    expect(commits).toBe(settled);
+  }, 30000);
+});

--- a/packages/views/issues/components/table-view.tsx
+++ b/packages/views/issues/components/table-view.tsx
@@ -1482,7 +1482,16 @@ export function TableView({
           // keepPreviousData alone cannot bridge a changed table query inside
           // useQueries. Retain the last settled head per structural branch to
           // keep the previous table painted while the new query is pending.
-          ...(placeholder ? { placeholderData: () => placeholder } : {}),
+          //
+          // Passed as a VALUE, not a closure. QueryObserver reuses the previous
+          // placeholder result only while `options.placeholderData` compares
+          // equal BY REFERENCE to the previous render's, so `() => placeholder`
+          // — a fresh arrow on every rebuild of this array — forced the
+          // placeholder to be recomputed and the result re-derived on every
+          // render. The value comes from a ref Map and is already stable, and
+          // the closure ignored both of the arguments the function form
+          // receives, so the two forms are equivalent (MUL-5477).
+          ...(placeholder ? { placeholderData: placeholder } : {}),
           enabled:
             (branch.groupKey === null ||
               !collapsedGroupSet.has(branch.groupKey)) &&

--- a/packages/views/issues/surface/use-issue-surface-controller.test.tsx
+++ b/packages/views/issues/surface/use-issue-surface-controller.test.tsx
@@ -216,6 +216,56 @@ describe("useIssueSurfaceController", () => {
     );
   });
 
+  // MUL-5477. `tableQuerySpec` is the identity every downstream consumer keys
+  // off: the facet request, the status/group branch hooks, and — the expensive
+  // one — the Table's `useQueries` branch list, which is rebuilt whenever this
+  // object changes. Two of the queries feeding the spec defaulted their data to
+  // a fresh `[]` while un-settled, so for the whole pending window after a
+  // workspace switch every render produced a new-but-identical spec and rebuilt
+  // all of them.
+  it("keeps the table query spec identity while its source queries are still pending", async () => {
+    setApiInstance({
+      listIssues,
+      listIssueTableRows,
+      listIssueTableFacets,
+      listGroupedIssues: vi.fn(() => never()),
+      listProjects: vi.fn(() => never()),
+      getAgentTaskSnapshot,
+      getChildIssueProgress: vi.fn(() => never()),
+      // Both held pending: this is the state right after a workspace switch,
+      // and it is the state in which the identity used to churn.
+      listProperties: vi.fn(() => never()),
+      getWorkspaceWorkingAgents: vi.fn(() => never()),
+    } as unknown as ApiClient);
+
+    const store = getIssueSurfaceViewStore("workspace:identity");
+    const { result, rerender } = renderHook(
+      () =>
+        useIssueSurfaceController({
+          scope: { type: "workspace", actorKind: "all" },
+          modes: ["table"],
+        }),
+      { wrapper: makeWrapper(qc, "workspace:identity") },
+    );
+
+    const first = result.current.tableQuerySpec;
+    rerender();
+    rerender();
+    expect(result.current.tableQuerySpec).toBe(first);
+
+    // A real change to the query must still produce a new identity, otherwise
+    // this would be pinned rather than stable.
+    act(() => store.getState().setSortBy("priority"));
+    await waitFor(() =>
+      expect(result.current.tableQuerySpec.sort.field).toBe("priority"),
+    );
+    const afterSort = result.current.tableQuerySpec;
+    expect(afterSort).not.toBe(first);
+
+    rerender();
+    expect(result.current.tableQuerySpec).toBe(afterSort);
+  });
+
   it("uses the unified workspace query for workspace scope", async () => {
     const { result } = renderHook(
       () =>

--- a/packages/views/issues/surface/use-issue-surface-controller.ts
+++ b/packages/views/issues/surface/use-issue-surface-controller.ts
@@ -1,7 +1,7 @@
 "use client";
 
 import { useCallback, useEffect, useMemo, useState } from "react";
-import { keepPreviousData, useQuery } from "@tanstack/react-query";
+import { hashKey, keepPreviousData, useQuery } from "@tanstack/react-query";
 import type { QueryKey } from "@tanstack/react-query";
 import { api } from "@multica/core/api";
 import type {
@@ -162,6 +162,35 @@ function useDebouncedTableSearch(value: string, delayMs = 250) {
   return debouncedValue;
 }
 
+/** One shared reference for every un-settled list default in this hook.
+ *
+ * `const { data = [] } = useQuery(...)` allocates a new array on every render
+ * for as long as the query has no data — which is the whole window right after
+ * a workspace switch. Downstream that array is a memo dependency, so the empty
+ * default alone was enough to rebuild the derived Sets, the table query spec,
+ * and the branch query list once per render (MUL-5477). */
+const EMPTY_LIST: never[] = [];
+
+/**
+ * Pin a derived value's identity to its CONTENT.
+ *
+ * `tableQuerySpec` is rebuilt from 17 dependencies, so any one of them losing
+ * referential stability hands every consumer a new object even though the query
+ * it describes is unchanged. Consumers use it as a memo dependency and, in the
+ * Table's case, as the source of a `useQueries` list — so a new-but-equal spec
+ * rebuilt that list on every render.
+ *
+ * Hashed with TanStack's own `hashKey` rather than `JSON.stringify` so this
+ * agrees exactly with how the same spec is hashed into a `queryKey`: object
+ * keys are sorted, so two specs that resolve to one query also resolve to one
+ * identity here.
+ */
+function useStableByContent<T>(value: T): T {
+  const contentKey = hashKey([value]);
+  // eslint-disable-next-line react-hooks/exhaustive-deps -- identity follows the content hash, not the reference
+  return useMemo(() => value, [contentKey]);
+}
+
 export function useIssueSurfaceController({
   scope,
   modes,
@@ -225,7 +254,7 @@ export function useIssueSurfaceController({
   // (archive/delete): filters keyed by a non-active definition are stripped
   // before they reach the predicates, and a sort on a non-active definition
   // degrades to manual order — matching what the header already shows.
-  const { data: workspaceProperties = [], isSuccess: catalogSettled } = useQuery(propertyListOptions(wsId));
+  const { data: workspaceProperties = EMPTY_LIST, isSuccess: catalogSettled } = useQuery(propertyListOptions(wsId));
   const activePropertyIds = useMemo(
     () => new Set(workspaceProperties.map((p) => p.id)),
     [workspaceProperties],
@@ -324,7 +353,7 @@ export function useIssueSurfaceController({
         ? "any"
         : scope.relation
       : undefined;
-  const { data: workspaceWorkingAgents = [] } = useQuery(
+  const { data: workspaceWorkingAgents = EMPTY_LIST } = useQuery(
     workspaceWorkingAgentsOptions(wsId, "issue", workingAgentMineRelation),
   );
   const workingIssueIDs = useMemo(() => {
@@ -335,7 +364,7 @@ export function useIssueSurfaceController({
     return issueIDs;
   }, [workspaceWorkingAgents]);
 
-  const tableQuerySpec = useMemo<IssueTableQuerySpec>(() => {
+  const derivedTableQuerySpec = useMemo<IssueTableQuerySpec>(() => {
     let queryScope: IssueTableQuerySpec["scope"];
     switch (scope.type) {
       case "workspace":
@@ -422,6 +451,11 @@ export function useIssueSurfaceController({
     viewProjectFilters,
     workingIssueIDs,
   ]);
+  // Every consumer below — the facet request, the status/group branch hooks and
+  // the Table's own `useQueries` list — keys off this object's identity. Pin it
+  // to the content so an unstable dependency upstream cannot rebuild all of
+  // them for a query that did not change.
+  const tableQuerySpec = useStableByContent(derivedTableQuerySpec);
 
   const [activeTableFacet, setActiveTableFacet] =
     useState<IssueTableFacetSpec | null>(null);


### PR DESCRIPTION
MUL-5477.

## The bug

Switching workspaces onto a persisted Table + hierarchy surface pins the desktop renderer at ~150% CPU. Three reference-stability defects sit on that path, and all three bite in the same window: while the surface's own queries have not settled yet — which is exactly the window a workspace switch opens.

**1. `tableQuerySpec` loses its identity every render.** It is built from 17 dependencies, and two of them default their un-settled data to a fresh array:

```ts
const { data: workspaceProperties = [] } = useQuery(propertyListOptions(wsId));
const { data: workspaceWorkingAgents = [] } = useQuery(workspaceWorkingAgentsOptions(...));
```

A new `[]` per render rebuilds the derived `Set`, which rebuilds the spec. Every consumer keys off that identity: the facet request, the status and group branch hooks, and — the expensive one — the Table's `useQueries` branch list, rebuilt once per render for a query that had not changed.

**2. Each rebuilt branch query carried a fresh placeholder closure.** `placeholderData: () => placeholder`. `QueryObserver` reuses a placeholder result only while that option compares equal *by reference* to the previous render's, so a new arrow per render forced the placeholder to be recomputed and the result re-derived every time.

## The fix

The smallest changes that remove those edges rather than damp them:

- The two empty defaults become one module-level `EMPTY_LIST`. This is not a new pattern — `useActorName` already uses module-level `EMPTY_MEMBERS` / `EMPTY_AGENTS` / `EMPTY_SQUADS` for exactly this reason.
- `tableQuerySpec`'s identity is pinned to its content via `useStableByContent`, hashed with TanStack's own `hashKey` so it agrees exactly with how the same spec is hashed into a `queryKey` (sorted keys — two specs that resolve to one query resolve to one identity). Implemented with `useMemo`, not a render-phase ref write, so nothing mutates during render.
- The placeholder is passed as the value it always was. The old closure ignored both arguments the function form receives and only returned a stable ref-Map entry, so the two forms are semantically equivalent.

## What this does and does not claim

It removes feedback edges on the reported path. **It is not a confirmed root cause for the production hang.** The loop has not been reproduced against the affected client, and acceptance is still a live check on that machine: switch to `ys-workspace` and confirm CPU drops from ~153% to single digits. Do not clear that machine's `multica_issue_surface_views:ys-workspace` before that check — clearing it removes the repro.

`FF_DESKTOP_HANG_STACK_CAPTURE` should still ship independently. Production's hard hangs cluster on `/:slug/agents/new`, not the Issues table, so stack capture remains the only way to confirm this fix addressed the production loop and to cover the other scenarios. That work is out of scope here.

## Regression coverage

This closes a real gap rather than restating the fix. Production mounts the Table with `virtualizeRows` and `tableHierarchy` defaults to on, and **no test covered that combination** — every existing Table test replaces `@tanstack/react-virtual` with a stand-in, because jsdom reports a zero-height viewport and the real virtualizer would render nothing.

`table-view-virtualized-hierarchy.test.tsx` supplies the missing layout instead of removing the virtualizer, so the real measuring virtualizer sits in the circuit, hierarchy sentinels auto-expand the tree, and the test asserts the table stops committing once it settles.

That circuit is load-bearing, and I confirmed it empirically while writing the test: an unstable mock closure alone — nothing else changed — reproduced a sustained storm of ~35 commits/s that never decayed, with **zero** refetches, zero sentinel re-fires, and zero DOM measurement. That is why the mocks in this file return hoisted references (mirroring the real `useActorName`, which memoises `getActorName`), and why the convergence assertion only means something with the real virtualizer mounted. It also explains why earlier jsdom probes found nothing: with the virtualizer mocked out, the circuit cannot close.

The controller test is the one that fails without this change. I verified the negative control: with `useStableByContent` and `EMPTY_LIST` reverted, `keeps the table query spec identity while its source queries are still pending` fails on `Object.is` equality. It also asserts the inverse — a real sort change still produces a new identity — so the spec is stable, not pinned.

## Verification

Run in `packages/views`:

- `pnpm exec tsc --noEmit` — clean
- `pnpm exec eslint` on the four changed files — clean
- `pnpm exec vitest run` — 286 files / 3348 tests pass
- Negative control on the new controller test — fails without the fix, passes with it

Not run: the live desktop check on the affected machine, which is the acceptance gate above and needs that machine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
