### PR TITLE
fix(onboarding): add logout escape

### DIFF
--- a/packages/views/locales/en/onboarding.json
+++ b/packages/views/locales/en/onboarding.json
@@ -41,7 +41,8 @@
     "continue": "Continue",
     "skip": "Skip",
     "cancel": "Cancel",
-    "close": "Close"
+    "close": "Close",
+    "log_out": "Log out"
   },
   "source_backfill": {
     "eyebrow": "Quick question",

--- a/packages/views/locales/ja/onboarding.json
+++ b/packages/views/locales/ja/onboarding.json
@@ -41,7 +41,8 @@
     "continue": "続ける",
     "skip": "スキップ",
     "cancel": "キャンセル",
-    "close": "閉じる"
+    "close": "閉じる",
+    "log_out": "ログアウト"
   },
   "source_backfill": {
     "eyebrow": "ちょっと質問",

--- a/packages/views/locales/ko/onboarding.json
+++ b/packages/views/locales/ko/onboarding.json
@@ -41,7 +41,8 @@
     "continue": "계속",
     "skip": "건너뛰기",
     "cancel": "취소",
-    "close": "닫기"
+    "close": "닫기",
+    "log_out": "로그아웃"
   },
   "source_backfill": {
     "eyebrow": "간단한 질문 하나",

--- a/packages/views/locales/zh-Hans/onboarding.json
+++ b/packages/views/locales/zh-Hans/onboarding.json
@@ -41,7 +41,8 @@
     "continue": "继续",
     "skip": "跳过",
     "cancel": "取消",
-    "close": "关闭"
+    "close": "关闭",
+    "log_out": "退出登录"
   },
   "source_backfill": {
     "eyebrow": "顺便问一句",

--- a/packages/views/onboarding/components/onboarding-logout-button.test.tsx
+++ b/packages/views/onboarding/components/onboarding-logout-button.test.tsx
@@ -1,0 +1,37 @@
+import type { ReactNode } from "react";
+import { describe, expect, it, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { I18nProvider } from "@multica/core/i18n/react";
+import enCommon from "../../locales/en/common.json";
+import enOnboarding from "../../locales/en/onboarding.json";
+import { OnboardingLogoutButton } from "./onboarding-logout-button";
+
+const { logout } = vi.hoisted(() => ({ logout: vi.fn() }));
+
+vi.mock("../../auth", () => ({
+  useLogout: () => logout,
+}));
+
+const TEST_RESOURCES = {
+  en: { common: enCommon, onboarding: enOnboarding },
+};
+
+function I18nWrapper({ children }: { children: ReactNode }) {
+  return (
+    <I18nProvider locale="en" resources={TEST_RESOURCES}>
+      {children}
+    </I18nProvider>
+  );
+}
+
+describe("OnboardingLogoutButton", () => {
+  it("logs out from onboarding", async () => {
+    const user = userEvent.setup();
+    render(<OnboardingLogoutButton />, { wrapper: I18nWrapper });
+
+    await user.click(screen.getByRole("button", { name: "Log out" }));
+
+    expect(logout).toHaveBeenCalledOnce();
+  });
+});

--- a/packages/views/onboarding/components/onboarding-logout-button.test.tsx
+++ b/packages/views/onboarding/components/onboarding-logout-button.test.tsx
@@ -30,7 +30,10 @@ describe("OnboardingLogoutButton", () => {
     const user = userEvent.setup();
     render(<OnboardingLogoutButton />, { wrapper: I18nWrapper });
 
-    await user.click(screen.getByRole("button", { name: "Log out" }));
+    const button = screen.getByRole("button", { name: "Log out" });
+    expect(button).toHaveClass("right-8", "top-8");
+
+    await user.click(button);
 
     expect(logout).toHaveBeenCalledOnce();
   });

--- a/packages/views/onboarding/components/onboarding-logout-button.tsx
+++ b/packages/views/onboarding/components/onboarding-logout-button.tsx
@@ -19,7 +19,7 @@ export function OnboardingLogoutButton() {
     <Button
       variant="ghost"
       size="sm"
-      className="fixed right-4 top-4 z-50 text-muted-foreground hover:text-destructive sm:right-6 sm:top-6 lg:right-12 lg:top-16"
+      className="fixed right-8 top-8 z-50 text-muted-foreground hover:text-destructive"
       style={{ WebkitAppRegion: "no-drag" } as React.CSSProperties}
       onClick={logout}
     >

--- a/packages/views/onboarding/components/onboarding-logout-button.tsx
+++ b/packages/views/onboarding/components/onboarding-logout-button.tsx
@@ -1,0 +1,30 @@
+"use client";
+
+import { LogOut } from "lucide-react";
+import { Button } from "@multica/ui/components/ui/button";
+import { useLogout } from "../../auth";
+import { useT } from "../../i18n";
+
+/**
+ * Account-switch escape hatch shared by every onboarding step.
+ *
+ * The fixed position keeps it available across the flow's full-bleed layouts,
+ * including the narrow mobile layout where the issue was originally reported.
+ */
+export function OnboardingLogoutButton() {
+  const { t } = useT("onboarding");
+  const logout = useLogout();
+
+  return (
+    <Button
+      variant="ghost"
+      size="sm"
+      className="fixed right-4 top-4 z-50 text-muted-foreground hover:text-destructive sm:right-6 sm:top-6 lg:right-12 lg:top-16"
+      style={{ WebkitAppRegion: "no-drag" } as React.CSSProperties}
+      onClick={logout}
+    >
+      <LogOut />
+      {t(($) => $.common.log_out)}
+    </Button>
+  );
+}

--- a/packages/views/onboarding/onboarding-flow.tsx
+++ b/packages/views/onboarding/onboarding-flow.tsx
@@ -20,6 +20,7 @@ import { StepAboutYou } from "./steps/step-about-you";
 import { StepWorkspace } from "./steps/step-workspace";
 import { StepRuntimeConnect } from "./steps/step-runtime-connect";
 import { StepPlatformFork } from "./steps/step-platform-fork";
+import { OnboardingLogoutButton } from "./components/onboarding-logout-button";
 import { useT } from "../i18n";
 
 const EMPTY_QUESTIONNAIRE: QuestionnaireAnswers = {
@@ -100,12 +101,7 @@ function mergeQuestionnaire(
  * "what runs in the workspace shell after onboarding" decision is in
  * `packages/views/workspace/welcome-after-onboarding.tsx`.
  */
-export function OnboardingFlow({
-  onComplete,
-  runtimeInstructions,
-  onRuntimeRefresh,
-  runtimesPending,
-}: {
+interface OnboardingFlowProps {
   onComplete: (workspace?: Workspace, issueId?: string) => void;
   runtimeInstructions?: React.ReactNode;
   /** Desktop wires this to restart the bundled daemon so a freshly
@@ -117,7 +113,23 @@ export function OnboardingFlow({
    *  step doesn't flash "no runtime found" while the daemon is still booting
    *  or probing CLI versions (MUL-5119). Web omits it. */
   runtimesPending?: boolean;
-}) {
+}
+
+export function OnboardingFlow(props: OnboardingFlowProps) {
+  return (
+    <>
+      <OnboardingLogoutButton />
+      <OnboardingStepFlow {...props} />
+    </>
+  );
+}
+
+function OnboardingStepFlow({
+  onComplete,
+  runtimeInstructions,
+  onRuntimeRefresh,
+  runtimesPending,
+}: OnboardingFlowProps) {
   const { t } = useT("onboarding");
   const user = useAuthStore((s) => s.user);
   if (!user) {


### PR DESCRIPTION
## Summary

- add a persistent **Log out** action to every onboarding step on web and desktop
- reuse the existing complete logout flow so auth state, query cache, workspace storage, and navigation are cleared correctly
- keep the action usable on narrow/mobile layouts and outside the Electron drag region
- add localized copy for English, Simplified Chinese, Japanese, and Korean
- add a component test for the logout action

## Why

Users who sign in with the wrong account currently have no way to switch accounts until onboarding is complete. The escape needs to remain visible throughout onboarding, including the mobile layout where the issue was originally reported.

Closes #3960

## Validation

- `vitest run onboarding` — 12 files, 77 tests passed
- targeted ESLint — 0 errors (one pre-existing `react-hooks/exhaustive-deps` warning in `onboarding-flow.tsx`)
- `git diff --check`

## Known baseline check

The package typecheck remains blocked on current `main` by unresolved `hast` and `mdast` type modules in unrelated rich-content files.
