### PR TITLE
fix(issues): stop the sub-issues shimmer chip clipping descenders

### DIFF
--- a/packages/views/issues/components/issue-agent-activity-indicator.tsx
+++ b/packages/views/issues/components/issue-agent-activity-indicator.tsx
@@ -125,9 +125,12 @@ export const IssueAgentActivityIndicator = memo(function IssueAgentActivityIndic
         opacity={opacity}
         max={3}
       />
+      {/* No leading-none: the shimmer paints glyphs via background-clip:
+          text, and the background only covers the line box — a squeezed
+          line box leaves descenders transparent. */}
       <span
         className={cn(
-          "text-micro leading-none",
+          "text-micro",
           isRunning
             ? "animate-chat-text-shimmer"
             : "text-muted-foreground",

--- a/packages/views/issues/components/sub-issues-agent-working-chip.tsx
+++ b/packages/views/issues/components/sub-issues-agent-working-chip.tsx
@@ -58,7 +58,10 @@ export const SubIssuesAgentWorkingChip = memo(
           }
         >
           <AgentAvatarStack agentIds={agentIds} size="xs" max={3} />
-          <span className="animate-chat-text-shimmer text-micro font-medium leading-none tabular-nums">
+          {/* No leading-none: the shimmer paints glyphs via background-clip:
+              text, and the background only covers the line box — a squeezed
+              line box leaves descenders transparent. */}
+          <span className="animate-chat-text-shimmer text-micro font-medium tabular-nums">
             {t(($) => $.agent_activity.chip_agents_working, {
               count: agentIds.length,
             })}


### PR DESCRIPTION
## Why

The sub-issues header chip renders "1 agent working" — and the per-row activity indicator renders "Working" — with descenders (g) cut off.

Two harmless-alone choices collided:

- `leading-none` squeezes the line box to 1em for a compact pill — fine for normal text, whose glyphs may overflow the line box as ink.
- `animate-chat-text-shimmer` paints glyphs via `background-clip: text` with transparent text color, and a background only paints inside the element box — there is no ink overflow.

With the glyph extent (~1.2em) taller than the 1em line box, descenders fell outside the box, got no background to shine through, and vanished.

## What changed

Drop `leading-none` from both labels:

- `sub-issues-agent-working-chip.tsx` — the "N agents working" chip in issue detail.
- `issue-agent-activity-indicator.tsx` — the "Working" / "Queued" indicator in inbox and issue rows (same pairing, found in the wild after the first fix).

Row/pill heights are governed by the adjacent avatar stacks, so the visual size is unchanged; only the clipped descenders come back. Comments record the constraint so the pairing doesn't return.

`task-status-pill.tsx` uses the same shimmer without `leading-none` and was never affected.

## Verification

- Manual: both surfaces re-checked in web; descenders render fully.
- Not run: automated suites (class-only change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)