### PR TITLE
feat(issues): badge resolved threads on the comment rail's preview card (MUL-5543)

### DIFF
--- a/packages/views/issues/components/issue-detail.test.tsx
+++ b/packages/views/issues/components/issue-detail.test.tsx
@@ -1437,6 +1437,37 @@ describe("IssueDetail (shared)", () => {
     });
   });
 
+  it("marks a reply-resolved thread as resolved on the quick-jump rail", async () => {
+    // A resolution on a REPLY leaves the thread expanded, so it flattens to a
+    // plain `comment` item, not a `resolved-bar`. The rail must still read it
+    // as resolved — proof the flag comes from deriveThreadResolution and not
+    // from the fold state.
+    mockApiObj.listTimeline.mockResolvedValue([
+      ...mockTimeline,
+      {
+        type: "comment",
+        id: "reply-1",
+        actor_type: "member",
+        actor_id: "user-1",
+        content: "That fixed it",
+        parent_id: "comment-1",
+        created_at: "2026-01-18T00:00:00Z",
+        updated_at: "2026-01-18T00:00:00Z",
+        comment_type: "comment",
+        resolved_at: "2026-01-19T00:00:00Z",
+      } as TimelineEntry,
+    ]);
+
+    renderIssueDetail();
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("button", { name: "Started working on this (resolved)" }),
+      ).toBeInTheDocument();
+    });
+    expect(screen.getByRole("button", { name: "I can help with this" })).toBeInTheDocument();
+  });
+
   it("sends empty description when editor is cleared", async () => {
     renderIssueDetail();
 

--- a/packages/views/issues/components/issue-detail.tsx
+++ b/packages/views/issues/components/issue-detail.tsx
@@ -1390,14 +1390,28 @@ export function IssueDetail({ issueId, onDelete, onDone, defaultSidebarOpen = tr
   // Quick-jump minimap rail: one tick per comment thread (folded resolved
   // bars included), activity groups skipped. Derived from the same flat
   // `items` array Virtuoso renders so tick order always matches the page.
+  // The resolved flag comes from `deriveThreadResolution`, not from the
+  // `resolved-bar` kind: that kind only covers root resolutions that are
+  // currently folded, so it would miss reply resolutions and would flip off
+  // as soon as the user expanded a resolved thread.
   const minimapThreads = useMemo<ThreadMinimapThread[]>(
     () =>
       items.flatMap((it) =>
         it.kind === "comment" || it.kind === "resolved-bar"
-          ? [{ id: it.id, entry: it.entry }]
+          ? [
+              {
+                id: it.id,
+                entry: it.entry,
+                resolved:
+                  deriveThreadResolution(
+                    it.entry,
+                    timelineView.threadReplies.get(it.id) ?? EMPTY_REPLIES,
+                  ).kind !== "none",
+              },
+            ]
           : [],
       ),
-    [items],
+    [items, timelineView.threadReplies],
   );
 
   // When the timeline renders flat (deep-link or in-page find), there is no

--- a/packages/views/issues/components/thread-minimap.test.tsx
+++ b/packages/views/issues/components/thread-minimap.test.tsx
@@ -74,9 +74,9 @@ describe("waveScale", () => {
 
 describe("ThreadMinimap", () => {
   const threads = [
-    { id: "c1", entry: comment("c1", "First thread opener\nwith details") },
-    { id: "c2", entry: comment("c2", "Second thread opener") },
-    { id: "c3", entry: comment("c3", "") },
+    { id: "c1", entry: comment("c1", "First thread opener\nwith details"), resolved: false },
+    { id: "c2", entry: comment("c2", "Second thread opener"), resolved: false },
+    { id: "c3", entry: comment("c3", ""), resolved: false },
   ];
 
   it("renders nothing below the thread threshold", () => {
@@ -153,6 +153,52 @@ describe("ThreadMinimap", () => {
     } finally {
       vi.useRealTimers();
     }
+  });
+
+  it("badges the preview card of a resolved thread, and only that one", () => {
+    vi.useFakeTimers({
+      toFake: ["setTimeout", "clearTimeout", "requestAnimationFrame", "cancelAnimationFrame"],
+    });
+    try {
+      renderWithI18n(
+        <ThreadMinimap
+          threads={[{ ...threads[0]!, resolved: true }, threads[1]!, threads[2]!]}
+          scrollContainerEl={null}
+          onJump={vi.fn()}
+        />,
+      );
+      const nav = screen.getByRole("navigation", { name: "Jump to comment thread" });
+
+      // jsdom rects are all zero → the nearest tick resolves to index 0, the
+      // resolved thread.
+      fireEvent.pointerMove(nav, { clientY: 0 });
+      act(() => vi.advanceTimersByTime(30 + 150)); // rAF flush + intent delay
+      expect(screen.getByText("Resolved")).toBeInTheDocument();
+
+      // The badge belongs to the hovered thread, not to the card: closing it
+      // must take the badge with it.
+      fireEvent.pointerLeave(nav);
+      act(() => vi.advanceTimersByTime(30 + 150));
+      expect(screen.queryByText("Resolved")).not.toBeInTheDocument();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("carries the resolved state in the tick's accessible name", () => {
+    renderWithI18n(
+      <ThreadMinimap
+        threads={[{ ...threads[0]!, resolved: true }, threads[1]!, threads[2]!]}
+        scrollContainerEl={null}
+        onJump={vi.fn()}
+      />,
+    );
+
+    // The card is visual only — a screen reader gets the state from the tick.
+    expect(
+      screen.getByRole("button", { name: "First thread opener (resolved)" }),
+    ).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Second thread opener" })).toBeInTheDocument();
   });
 
   it("jumps to the clicked thread", () => {

--- a/packages/views/issues/components/thread-minimap.tsx
+++ b/packages/views/issues/components/thread-minimap.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { CheckCircle2 } from "lucide-react";
 import type { TimelineEntry } from "@multica/core/types";
 import { useActorName } from "@multica/core/workspace/hooks";
 import { cn } from "@multica/ui/lib/utils";
@@ -14,8 +15,10 @@ import { useT } from "../../i18n";
 // Ticks whose thread is currently inside the scroll viewport render darker, so
 // the rail doubles as a "you are here" minimap. Hovering magnifies ticks in a
 // Dock-style wave around the cursor (the hovered tick peaks, neighbours taper
-// off) and shows a preview card (bold first line + muted body excerpt);
-// clicking jumps the timeline to that thread.
+// off) and shows a preview card (bold first line + muted body excerpt, plus a
+// "Resolved" badge when the thread carries a resolution — the rail is the one
+// place a folded resolved thread is otherwise indistinguishable from an open
+// one); clicking jumps the timeline to that thread.
 //
 // It rides the scrollbar side on purpose: it looks and behaves like a scroll
 // affordance, and every precedent for that (the scrollbar itself, editor
@@ -109,6 +112,13 @@ export interface ThreadMinimapThread {
   id: string;
   /** The thread's root comment entry (preview text + author fallback). */
   entry: TimelineEntry;
+  /**
+   * Whether the thread carries a resolution — derived by the caller with
+   * `deriveThreadResolution`, so it covers both "Resolve thread" (root) and
+   * "Resolve thread with comment" (reply), and stays true while the user has
+   * a folded resolved thread expanded.
+   */
+  resolved: boolean;
 }
 
 interface ThreadMinimapProps {
@@ -424,18 +434,27 @@ export function ThreadMinimap({ threads, scrollContainerEl, onJump, className }:
         // flex compresses the spacing (down to min-h) instead of overflowing.
         className="pointer-events-auto flex max-h-full flex-col overflow-hidden"
       >
-        {threads.map((thread, i) => (
-          <MinimapTick
-            key={thread.id}
-            label={
-              previews[i]!.title ||
-              getActorName(thread.entry.actor_type, thread.entry.actor_id)
-            }
-            inViewport={visibleIds.has(thread.id)}
-            isPreviewOpen={preview?.index === i}
-            onClick={() => onJump(thread.id)}
-          />
-        ))}
+        {threads.map((thread, i) => {
+          const title =
+            previews[i]!.title ||
+            getActorName(thread.entry.actor_type, thread.entry.actor_id);
+          return (
+            <MinimapTick
+              key={thread.id}
+              // The card is the visual channel for the resolved state, but a
+              // screen reader never sees it — the tick's name is the only
+              // thing announced on focus, so it carries the state too.
+              label={
+                thread.resolved
+                  ? t(($) => $.detail.thread_nav_resolved_label, { title })
+                  : title
+              }
+              inViewport={visibleIds.has(thread.id)}
+              isPreviewOpen={preview?.index === i}
+              onClick={() => onJump(thread.id)}
+            />
+          );
+        })}
       </nav>
 
       {/* The rail's single preview card. Mounted without an enter animation
@@ -444,7 +463,9 @@ export function ThreadMinimap({ threads, scrollContainerEl, onJump, className }:
           and slid between ticks with a short transform transition. Hovering
           the card keeps it open so its text stays selectable. It opens
           inward (leftward, over the content) — the only direction with room
-          next to the scrollbar. */}
+          next to the scrollbar. The resolved badge leads so the state is read
+          before the content, in the same `text-success` CommentCard uses for
+          its Resolution badge. */}
       {preview && activeThread && activePreview && (
         <div
           ref={cardRef}
@@ -453,6 +474,12 @@ export function ThreadMinimap({ threads, scrollContainerEl, onJump, className }:
           className="pointer-events-auto absolute right-8 top-0 w-72 rounded-lg bg-popover p-2.5 text-body text-popover-foreground shadow-md ring-1 ring-foreground/10 transition-transform duration-150 ease-out motion-reduce:transition-none"
           style={{ transform: `translateY(${preview.y}px) translateY(-50%)` }}
         >
+          {activeThread.resolved && (
+            <p className="mb-1 flex items-center gap-1.5 text-caption font-medium text-success">
+              <CheckCircle2 className="h-3.5 w-3.5 shrink-0" />
+              {t(($) => $.comment.resolve.thread_resolved_badge)}
+            </p>
+          )}
           <p className="truncate text-body font-semibold text-foreground">{activeTitle}</p>
           {activePreview.body && (
             <p className="mt-1 line-clamp-3 text-body text-muted-foreground">{activePreview.body}</p>

--- a/packages/views/locales/en/issues.json
+++ b/packages/views/locales/en/issues.json
@@ -300,6 +300,7 @@
     "pin_tooltip": "Pin to sidebar",
     "unpin_tooltip": "Unpin from sidebar",
     "thread_nav_label": "Jump to comment thread",
+    "thread_nav_resolved_label": "{{title}} (resolved)",
     "sidebar_tooltip": "Toggle sidebar",
     "find": {
       "placeholder": "Find in issue...",
@@ -407,6 +408,7 @@
       "resolve_with_comment_action": "Resolve thread with comment",
       "unresolve_action": "Unresolve",
       "resolution_badge": "Resolution",
+      "thread_resolved_badge": "Resolved",
       "collapse": "Collapse",
       "bar_one": "{{count}} resolved comment from {{authors}}",
       "bar_other": "{{count}} resolved comments from {{authors}}",

--- a/packages/views/locales/ja/issues.json
+++ b/packages/views/locales/ja/issues.json
@@ -297,6 +297,7 @@
     "pin_tooltip": "サイドバーにピン留め",
     "unpin_tooltip": "サイドバーのピン留めを解除",
     "thread_nav_label": "スレッドへ移動",
+    "thread_nav_resolved_label": "{{title}}（解決済み）",
     "sidebar_tooltip": "サイドバーの開閉",
     "find": {
       "placeholder": "イシュー内を検索...",
@@ -397,6 +398,7 @@
       "resolve_with_comment_action": "このコメントでスレッドを解決",
       "unresolve_action": "解決を取り消す",
       "resolution_badge": "解決",
+      "thread_resolved_badge": "解決済み",
       "collapse": "折りたたむ",
       "bar_other": "{{authors}} による解決済みコメント {{count}} 件",
       "fold_other": "{{authors}} のコメント {{count}} 件",

--- a/packages/views/locales/ko/issues.json
+++ b/packages/views/locales/ko/issues.json
@@ -297,6 +297,7 @@
     "pin_tooltip": "사이드바에 고정",
     "unpin_tooltip": "사이드바 고정 해제",
     "thread_nav_label": "스레드로 이동",
+    "thread_nav_resolved_label": "{{title}} (해결됨)",
     "sidebar_tooltip": "사이드바 열기/닫기",
     "find": {
       "placeholder": "이슈에서 찾기...",
@@ -397,6 +398,7 @@
       "resolve_with_comment_action": "이 댓글로 스레드 해결",
       "unresolve_action": "해결 취소",
       "resolution_badge": "해결",
+      "thread_resolved_badge": "해결됨",
       "collapse": "접기",
       "bar_other": "{{authors}}님의 해결된 댓글 {{count}}개",
       "fold_other": "{{authors}}님의 댓글 {{count}}개",

--- a/packages/views/locales/zh-Hans/issues.json
+++ b/packages/views/locales/zh-Hans/issues.json
@@ -297,6 +297,7 @@
     "pin_tooltip": "固定到侧边栏",
     "unpin_tooltip": "从侧边栏取消固定",
     "thread_nav_label": "快速跳转到讨论",
+    "thread_nav_resolved_label": "{{title}}（已解决）",
     "sidebar_tooltip": "切换侧边栏",
     "find": {
       "placeholder": "在 issue 中查找...",
@@ -397,6 +398,7 @@
       "resolve_with_comment_action": "以此评论解决讨论",
       "unresolve_action": "重新打开",
       "resolution_badge": "结论",
+      "thread_resolved_badge": "已解决",
       "collapse": "收起",
       "bar_other": "来自 {{authors}} 的 {{count}} 条已解决评论",
       "fold_other": "来自 {{authors}} 的 {{count}} 条评论",


### PR DESCRIPTION
Closes MUL-5543.

The comment quick-jump rail was the one place where a resolved thread looked exactly like an open one — same tick, and a preview card showing only the title and body excerpt. Scanning the rail gave no way to tell "settled" from "still open" without jumping into the thread.

## What changed

- The rail's preview card now leads with a **Resolved** badge when the thread carries a resolution — `CheckCircle2` + `text-success` at `text-caption`, the same treatment `CommentCard` already uses for its Resolution badge. The state reads before the content; the title and body excerpt are untouched.
- The flag is derived with `deriveThreadResolution`, **not** taken from the `resolved-bar` item kind. That kind only covers root resolutions that are currently folded, so it would miss "Resolve thread with comment" (reply) resolutions and would flip off the moment a user expanded a folded thread.
- The card is invisible to screen readers — focusing a tick announces only its `aria-label` — so the tick's accessible name carries the state too: `"<title> (resolved)"`.
- New i18n keys in all four locales: `comment.resolve.thread_resolved_badge` and `detail.thread_nav_resolved_label`.

## Verification

- `pnpm typecheck` — passes.
- `pnpm lint` — 0 errors (the remaining warnings are pre-existing, in unrelated files).
- `pnpm --filter @multica/views test` — 3376 passed. One failure, `layout/sidebar-resize.test.tsx`, reproduces on a clean checkout of this base commit and is unrelated to this change.
- New tests: card badge appears/disappears with the card, tick accessible name carries the state (`thread-minimap.test.tsx`), and a reply-resolved thread reads as resolved on the rail end-to-end through `IssueDetail` (`issue-detail.test.tsx`).
- Rendered the card at real token values in both themes to check the visual result. Contrast of `--success` on `--popover`: 4.54:1 light, 5.48:1 dark — both clear WCAG AA.
