### PR TITLE
feat(agents): show which runtime backs an agent

### DIFF
--- a/packages/core/agents/index.ts
+++ b/packages/core/agents/index.ts
@@ -4,6 +4,7 @@ export * from "./failure-reason";
 export * from "./effective-access";
 export * from "./queries";
 export * from "./use-agent-presence";
+export * from "./use-agent-runtime";
 export * from "./use-update-agent-allowlist";
 export * from "./use-agent-activity";
 export * from "./use-workspace-presence-prefetch";

--- a/packages/core/agents/use-agent-runtime.ts
+++ b/packages/core/agents/use-agent-runtime.ts
@@ -1,0 +1,42 @@
+"use client";
+
+import { useMemo } from "react";
+import { useQuery } from "@tanstack/react-query";
+import { agentListOptions } from "../workspace/queries";
+import { runtimeListOptions } from "../runtimes/queries";
+
+/**
+ * The provider slug ("claude", "codex", …) backing an agent's runtime, or
+ * `null` when it can't be resolved — lists still loading, an agent outside the
+ * workspace list (archived assignee on an old issue), a runtime that no longer
+ * exists, or a backend that omitted the field. Callers render nothing on null
+ * rather than a placeholder: a wrong provider mark is worse than none.
+ *
+ * Derived from `runtime_id` on every read instead of stored on the agent, so
+ * moving an agent from one runtime to another moves its provider mark with it.
+ *
+ * Both queries are ones the surfaces that show a provider mark already
+ * subscribe to (`useActorName`, presence), so this costs a cache read rather
+ * than a request.
+ */
+export function useAgentRuntimeProvider(
+  wsId: string | undefined,
+  agentId: string | undefined,
+): string | null {
+  const { data: agents } = useQuery({
+    ...agentListOptions(wsId ?? ""),
+    enabled: !!wsId,
+  });
+  const { data: runtimes } = useQuery({
+    ...runtimeListOptions(wsId ?? ""),
+    enabled: !!wsId,
+  });
+
+  return useMemo(() => {
+    if (!agentId || !agents || !runtimes) return null;
+    const agent = agents.find((a) => a.id === agentId);
+    if (!agent) return null;
+    const runtime = runtimes.find((r) => r.id === agent.runtime_id);
+    return runtime?.provider?.trim() || null;
+  }, [agentId, agents, runtimes]);
+}

--- a/packages/views/agents/components/agent-detail-page.tsx
+++ b/packages/views/agents/components/agent-detail-page.tsx
@@ -430,6 +430,7 @@ function DetailHeader({
               actorId={agent.id}
               size="2xl"
               profileLink={false}
+              showRuntimeBadge
               className="ring-1 ring-border"
             />
             <div className="min-w-0 pt-0.5">

--- a/packages/views/agents/components/agent-profile-card.test.tsx
+++ b/packages/views/agents/components/agent-profile-card.test.tsx
@@ -16,6 +16,8 @@ vi.mock("@multica/core/paths", () => ({
   useWorkspacePaths: () => ({
     agentDetail: (id: string) => `/test/agents/${id}`,
   }),
+  // The runtime badge on the card's avatar resolves the provider per workspace.
+  useCurrentWorkspace: () => ({ id: "ws-1", slug: "test" }),
 }));
 
 vi.mock("@multica/core/api", () => ({

--- a/packages/views/agents/components/agent-profile-card.tsx
+++ b/packages/views/agents/components/agent-profile-card.tsx
@@ -16,6 +16,7 @@ import { useWorkspacePaths } from "@multica/core/paths";
 import { ActorAvatar as ActorAvatarBase } from "@multica/ui/components/common/actor-avatar";
 import { Skeleton } from "@multica/ui/components/ui/skeleton";
 import { AppLink } from "../../navigation";
+import { AgentRuntimeBadge } from "../../common/agent-runtime-badge";
 import { HealthIcon } from "../../runtimes/components/shared";
 import { availabilityConfig } from "../presence";
 import { VisibilityBadge } from "./visibility-badge";
@@ -75,13 +76,19 @@ export function AgentProfileCard({ agentId }: AgentProfileCardProps) {
           availability dot is surfaced here; last-task state lives in the
           agents list and the agent detail page. */}
       <div className="flex items-start gap-3">
-        <ActorAvatarBase
-          name={agent.name}
-          initials={initials}
-          avatarUrl={resolvePublicFileUrl(agent.avatar_url)}
-          isAgent
-          size="xl"
-        />
+        {/* Base avatar + runtime badge rather than the ActorAvatar wrapper:
+            this card IS a hover-card payload, so it must not nest another
+            hover card or profile link inside itself. */}
+        <span className="relative inline-flex shrink-0">
+          <ActorAvatarBase
+            name={agent.name}
+            initials={initials}
+            avatarUrl={resolvePublicFileUrl(agent.avatar_url)}
+            isAgent
+            size="xl"
+          />
+          <AgentRuntimeBadge agentId={agent.id} size="xl" />
+        </span>
         <div className="min-w-0 flex-1">
           <div className="flex items-center gap-1.5">
             <p className="truncate text-body font-semibold">{agent.name}</p>

--- a/packages/views/agents/components/agents-page.tsx
+++ b/packages/views/agents/components/agents-page.tsx
@@ -60,6 +60,7 @@ import {
 } from "@multica/ui/components/ui/tooltip";
 import { useNavigation, useRowLink } from "../../navigation";
 import { ActorAvatar } from "../../common/actor-avatar";
+import { ProviderLogo } from "../../runtimes/components/provider-logo";
 import {
   CollectionPageHeader,
   CollectionPageHeaderAction,
@@ -507,8 +508,16 @@ function RuntimeCell({ row }: { row: AgentListRow }) {
   return (
     <ListGridCell className="hidden @2xl:flex">
       {runtime ? (
-        <span className="min-w-0 truncate text-caption text-muted-foreground">
-          {runtimeDisplayLabel(runtime)}
+        // Provider mark before the label: scanning this column for "which of
+        // these run on Codex" is a shape match, not a read.
+        <span className="inline-flex min-w-0 items-center gap-1.5">
+          <ProviderLogo
+            provider={runtime.provider}
+            className="h-3.5 w-3.5 shrink-0"
+          />
+          <span className="min-w-0 truncate text-caption text-muted-foreground">
+            {runtimeDisplayLabel(runtime)}
+          </span>
         </span>
       ) : (
         <span className="text-caption text-muted-foreground/40">—</span>

--- a/packages/views/chat/components/chat-session-header.tsx
+++ b/packages/views/chat/components/chat-session-header.tsx
@@ -105,7 +105,14 @@ export function ChatSessionHeader({
   return (
     <div className="flex h-12 shrink-0 items-center gap-3 border-b px-4">
       {agent ? (
-        <ActorAvatar actorType="agent" actorId={agent.id} size="lg" enableHoverCard showStatusDot />
+        <ActorAvatar
+          actorType="agent"
+          actorId={agent.id}
+          size="lg"
+          enableHoverCard
+          showStatusDot
+          showRuntimeBadge
+        />
       ) : (
         <span className="size-[30px] shrink-0" />
       )}

--- a/packages/views/common/actor-avatar.tsx
+++ b/packages/views/common/actor-avatar.tsx
@@ -11,6 +11,10 @@ import {
 import { useActorName } from "@multica/core/workspace/hooks";
 import { useAgentPresenceDetail } from "@multica/core/agents";
 import { useCurrentWorkspace, useWorkspacePaths } from "@multica/core/paths";
+import {
+  AgentRuntimeBadge,
+  RUNTIME_BADGE_MIN_AVATAR_PX,
+} from "./agent-runtime-badge";
 import { AgentProfileCard } from "../agents/components/agent-profile-card";
 import { AgentLivePeekCard } from "../agents/components/agent-live-peek-card";
 import { MemberProfileCard } from "../members/member-profile-card";
@@ -52,6 +56,18 @@ interface ActorAvatarProps {
    */
   showStatusDot?: boolean;
   /**
+   * Overlay the provider mark of the agent's runtime at the avatar's top-right.
+   * Use on identity/config surfaces — the agent's own page, its profile card,
+   * a chat session header — where "what is running underneath this?" is a live
+   * question. Has no effect for non-agent actors.
+   *
+   * Independent of `showStatusDot`, and the two are designed to coexist: they
+   * sit at opposite ends of the circle and answer different questions (can it
+   * take work right now, vs what backs it). No-ops below
+   * {@link RUNTIME_BADGE_MIN_AVATAR_PX} — see that constant for why.
+   */
+  showRuntimeBadge?: boolean;
+  /**
    * When `enableHoverCard` is on for an agent, choose which payload to
    * render. See {@link AgentHoverCardVariant}. Defaults to `"profile"` so
    * existing call sites keep their identity-card behaviour.
@@ -76,6 +92,7 @@ export function ActorAvatar({
   className,
   enableHoverCard,
   showStatusDot,
+  showRuntimeBadge,
   hoverCardVariant = "profile",
   profileLink,
 }: ActorAvatarProps) {
@@ -94,19 +111,23 @@ export function ActorAvatar({
     />
   );
 
-  // Optional presence dot overlay. Only meaningful for agents — members have
-  // no presence backbone. Wrapping unconditionally with relative inline-flex
-  // would create extra DOM for every avatar; we only wrap when a dot is asked
-  // for.
-  const wrapDot = showStatusDot && actorType === "agent";
-  const dotted = wrapDot ? (
-    <span className="relative inline-flex">
-      {avatar}
-      <AgentStatusDot agentId={actorId} size={size} />
-    </span>
-  ) : (
-    avatar
-  );
+  // Optional overlays. Only meaningful for agents — members have no presence
+  // backbone and no runtime. Wrapping unconditionally with relative inline-flex
+  // would create extra DOM for every avatar; we only wrap when an overlay is
+  // asked for.
+  const isAgent = actorType === "agent";
+  const wrapDot = showStatusDot && isAgent;
+  const wrapBadge = showRuntimeBadge && isAgent;
+  const dotted =
+    wrapDot || wrapBadge ? (
+      <span className="relative inline-flex">
+        {avatar}
+        {wrapBadge && <AgentRuntimeBadge agentId={actorId} size={size} />}
+        {wrapDot && <AgentStatusDot agentId={actorId} size={size} />}
+      </span>
+    ) : (
+      avatar
+    );
   const shouldLinkToProfile =
     profileLink ??
     (actorType === "member" || actorType === "agent" || actorType === "squad");
@@ -215,6 +236,7 @@ export function AgentStatusDot({ agentId, size }: { agentId: string; size?: Avat
     />
   );
 }
+
 
 /**
  * Wraps an agent avatar in a hover-card. The trigger is keyboard-focusable

--- a/packages/views/common/agent-runtime-badge.test.tsx
+++ b/packages/views/common/agent-runtime-badge.test.tsx
@@ -1,0 +1,115 @@
+/**
+ * Runtime provider badge on agent avatars.
+ *
+ * The badge and the presence dot are two overlays on one circle, so the rules
+ * that keep them from fighting each other are the ones worth pinning: the
+ * badge only appears where a provider mark is actually legible, it never
+ * displaces the dot, and it stays away from anything it can't resolve.
+ */
+import type { ReactElement } from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { cleanup, render, screen } from "@testing-library/react";
+import { NavigationProvider } from "../navigation/context";
+import type { NavigationAdapter } from "../navigation/types";
+
+const provider = vi.hoisted(() => ({ current: "claude" as string | null }));
+
+vi.mock("@multica/core/workspace/hooks", () => ({
+  useActorName: () => ({
+    getActorName: () => "Lambda",
+    getActorInitials: () => "L",
+    getActorAvatarUrl: () => null,
+  }),
+}));
+
+vi.mock("@multica/core/paths", () => ({
+  useWorkspacePaths: () => ({
+    memberDetail: (id: string) => `/acme/members/${id}`,
+    agentDetail: (id: string) => `/acme/agents/${id}`,
+    squadDetail: (id: string) => `/acme/squads/${id}`,
+  }),
+  useCurrentWorkspace: () => ({ id: "ws1", slug: "acme" }),
+}));
+
+vi.mock("@multica/core/agents", () => ({
+  useAgentPresenceDetail: () => ({ availability: "online", workload: "idle" }),
+  useAgentRuntimeProvider: () => provider.current,
+}));
+
+vi.mock("../agents/components/agent-profile-card", () => ({
+  AgentProfileCard: () => null,
+}));
+vi.mock("../agents/components/agent-live-peek-card", () => ({
+  AgentLivePeekCard: () => null,
+}));
+vi.mock("../members/member-profile-card", () => ({
+  MemberProfileCard: () => null,
+}));
+vi.mock("../squads/components/squad-profile-card", () => ({
+  SquadProfileCard: () => null,
+}));
+
+import { ActorAvatar } from "./actor-avatar";
+
+const AGENT_ID = "8f14e45f-ceea-4d0e-a1a2-9b1c0d3e4f5a";
+
+// The avatar wraps itself in a profile link, which needs the adapter.
+const ADAPTER: NavigationAdapter = {
+  push: vi.fn(),
+  replace: vi.fn(),
+  back: vi.fn(),
+  pathname: "/",
+  searchParams: new URLSearchParams(),
+  getShareableUrl: (p) => `https://app.example${p}`,
+};
+
+function renderAvatar(ui: ReactElement) {
+  return render(<NavigationProvider value={ADAPTER}>{ui}</NavigationProvider>);
+}
+
+afterEach(() => {
+  cleanup();
+  provider.current = "claude";
+});
+
+describe("AgentRuntimeBadge", () => {
+  it("marks the avatar with the runtime's provider", () => {
+    renderAvatar(<ActorAvatar actorType="agent" actorId={AGENT_ID} size="2xl" showRuntimeBadge />);
+    expect(screen.getByLabelText("Runtime: Claude")).toBeInTheDocument();
+  });
+
+  // Provider marks are detailed artwork; at the ~8px a badge gets on a 20px
+  // picker row they're a smudge. That size is the status dot's home turf, so
+  // the badge has to stay out of it even when a caller asks for one.
+  it("stays off avatars too small to render a legible mark", () => {
+    renderAvatar(<ActorAvatar actorType="agent" actorId={AGENT_ID} size="sm" showRuntimeBadge />);
+    expect(screen.queryByLabelText("Runtime: Claude")).not.toBeInTheDocument();
+  });
+
+  it("renders both overlays when a surface asks for the dot too", () => {
+    renderAvatar(
+      <ActorAvatar
+        actorType="agent"
+        actorId={AGENT_ID}
+        size="lg"
+        showStatusDot
+        showRuntimeBadge
+      />,
+    );
+    expect(screen.getByLabelText("Runtime: Claude")).toBeInTheDocument();
+    expect(screen.getByLabelText("Status: Online")).toBeInTheDocument();
+  });
+
+  // Archived agent, deleted runtime, or a backend that omitted the field. A
+  // mark that names the wrong runtime is worse than no mark.
+  it("renders nothing when the provider cannot be resolved", () => {
+    provider.current = null;
+    renderAvatar(<ActorAvatar actorType="agent" actorId={AGENT_ID} size="2xl" showRuntimeBadge />);
+    expect(screen.queryByLabelText(/^Runtime:/)).not.toBeInTheDocument();
+  });
+
+  it("has no effect for non-agent actors", () => {
+    renderAvatar(<ActorAvatar actorType="member" actorId={AGENT_ID} size="2xl" showRuntimeBadge />);
+    expect(screen.queryByLabelText(/^Runtime:/)).not.toBeInTheDocument();
+  });
+});

--- a/packages/views/common/agent-runtime-badge.tsx
+++ b/packages/views/common/agent-runtime-badge.tsx
@@ -52,12 +52,19 @@ export function AgentRuntimeBadge({
   // Codex's ring) are airy line art with no silhouette of their own, and
   // without an edge the badge loses its anchor. Same treatment as ProviderChip.
   const disc = Math.round(px * 0.42);
+  // Push the badge out past the bounding box so its centre lands on the
+  // avatar's rim instead of inside it. Flush to the corner (`top-0 right-0`)
+  // looks correct on a square but not on a circle: at 45° the edge has already
+  // curved ~29% of the diameter away from that corner, so the badge ends up
+  // sitting over the face. Offsetting by (badge radius − rim inset) leaves
+  // roughly half of it overhanging, which is the usual platform-badge look.
+  const offset = Math.round(px * 0.064);
 
   return (
     <span
       aria-label={`Runtime: ${providerDisplayName(provider)}`}
-      className="absolute right-0 top-0 inline-flex items-center justify-center rounded-full bg-background ring-1 ring-border"
-      style={{ width: disc, height: disc }}
+      className="absolute inline-flex items-center justify-center rounded-full bg-background ring-1 ring-border"
+      style={{ width: disc, height: disc, top: -offset, right: -offset }}
     >
       <ProviderLogo provider={provider} className="h-[72%] w-[72%]" />
     </span>

--- a/packages/views/common/agent-runtime-badge.tsx
+++ b/packages/views/common/agent-runtime-badge.tsx
@@ -1,0 +1,65 @@
+"use client";
+
+import { useAgentRuntimeProvider } from "@multica/core/agents";
+import { providerDisplayName } from "@multica/core/runtimes";
+import { useCurrentWorkspace } from "@multica/core/paths";
+import { AVATAR_SIZE_PX, type AvatarSize } from "@multica/ui/lib/avatar-size";
+import { ProviderLogo } from "../runtimes/components/provider-logo";
+
+/**
+ * Smallest avatar that can carry a provider mark.
+ *
+ * A badge gets roughly 40% of the avatar's diameter, and provider marks are
+ * detailed artwork (Claude's glyph, CodeBuddy's tile) rather than a flat shape
+ * like the presence dot — below ~12px they read as a smudge. 32px is the first
+ * tier that clears it. That rules the badge out of exactly the surfaces the
+ * status dot lives on: nearly every `showStatusDot` call site is a 20px picker
+ * row, where "can it take work right now" is the question and the provider
+ * isn't.
+ */
+export const RUNTIME_BADGE_MIN_AVATAR_PX = 32;
+
+/**
+ * Provider mark overlaid on the top-right of an agent avatar — the opposite
+ * end from the presence dot, so a surface can carry both without them
+ * touching.
+ *
+ * Derived from the agent's current runtime on every render, so switching
+ * runtimes moves the mark with it. Renders nothing when the provider can't be
+ * resolved (loading, archived agent, deleted runtime): a wrong mark is worse
+ * than none.
+ *
+ * Lives in its own module rather than beside `AgentStatusDot` because the
+ * agent profile card needs it, and `actor-avatar` already imports that card
+ * for its hover payload — importing back would close a cycle.
+ */
+export function AgentRuntimeBadge({
+  agentId,
+  size,
+}: {
+  agentId: string;
+  size?: AvatarSize;
+}) {
+  const ws = useCurrentWorkspace();
+  const provider = useAgentRuntimeProvider(ws?.id, agentId);
+  const px = size ? AVATAR_SIZE_PX[size] : 24;
+  if (!provider || px < RUNTIME_BADGE_MIN_AVATAR_PX) return null;
+
+  // The disc is background-coloured so a multi-coloured mark stays legible
+  // over an emoji or photo avatar; the mark itself fills most of it. The
+  // hairline is what makes it read as a chip sitting ON the avatar rather than
+  // an icon floating beside it — several provider marks (Claude's asterisk,
+  // Codex's ring) are airy line art with no silhouette of their own, and
+  // without an edge the badge loses its anchor. Same treatment as ProviderChip.
+  const disc = Math.round(px * 0.42);
+
+  return (
+    <span
+      aria-label={`Runtime: ${providerDisplayName(provider)}`}
+      className="absolute right-0 top-0 inline-flex items-center justify-center rounded-full bg-background ring-1 ring-border"
+      style={{ width: disc, height: disc }}
+    >
+      <ProviderLogo provider={provider} className="h-[72%] w-[72%]" />
+    </span>
+  );
+}


### PR DESCRIPTION
## What

Make the runtime behind an agent visible at a glance. Today it's text-only — a Runtime column on the agents list, a meta line on the agent page — even though `ProviderLogo` already ships a mark for every provider we support and only runtimes surfaces ever used it.

Two additions, split by what each surface is for:

**Agents list Runtime column** — provider mark before the label, so "which of these run on Codex" is a shape match instead of a read.

**Identity surfaces get a badge on the avatar** (`showRuntimeBadge` on `ActorAvatar`): the agent's own page header, its profile/hover card, the chat session header.

## Design notes

**Derived, never stored.** The badge resolves `runtime_id` → runtime → provider on every render (`useAgentRuntimeProvider`). Moving an agent between runtimes moves its mark with it. A snapshot written at create time would silently go stale and the avatar would then actively misstate what's running.

**Not the avatar itself.** Provider-as-avatar was the other option and it loses identity: agents show up on assignee chips, comment authors, mentions, inbox rows, and in a workspace where most run Claude they'd collapse into one mark. The emoji/photo keeps identity; the badge carries the attribute.

**Coexists with the presence dot rather than competing.** Badge top-right, dot bottom-right — they answer different questions (what backs it vs can it take work now). In practice they rarely want the same avatar: the badge no-ops below 32px, and nearly every `showStatusDot` call site is a 20px picker row. A badge gets ~40% of the diameter, and provider marks are detailed artwork that turns to mush at ~8px. The chat session header is the one surface that carries both, and at 32px they sit 13px apart.

**Unresolvable → nothing.** Archived agent, deleted runtime, backend that omitted the field: no mark. Naming the wrong runtime is worse than naming none.

**The hairline matters.** Several provider marks (Claude's asterisk, Codex's ring) are airy line art with no silhouette, and without a chip edge the badge reads as an icon floating beside the avatar instead of sitting on it. Same `border + background` treatment as the existing `ProviderChip`.

## Not done, deliberately

The agents-list row avatar keeps the dot only — that row already has a Runtime column, and a full column icon beats a 13px corner mark. The detail page's meta-row icons (`Bot` for model, `Server` for runtime) stay generic: they label the category of the line that follows, so swapping one for a Claude glyph would break the parallel.

## Verification

- `pnpm typecheck` — 6/6 pass
- `pnpm lint` — 0 errors
- views tests: 3378 pass; the single failure (`layout/sidebar-resize.test.tsx`) reproduces on a clean checkout
- core tests: 8 failures, all reproducing on a clean checkout (projects/realtime/workspace mutations), none in touched code
- New `packages/views/common/agent-runtime-badge.test.tsx`: renders the mark, no-ops below the legibility floor, coexists with the dot, renders nothing when unresolved, no effect for non-agent actors
- Verified against a local stack with five agents on five providers (Claude / Codex / Cursor / Kimi / Grok)
