### PR TITLE
refactor(skills): imported-origin marker uses Download, not Sparkles

### DIFF
--- a/packages/views/locales/en/skills.json
+++ b/packages/views/locales/en/skills.json
@@ -122,7 +122,7 @@
       "origin_clawhub": "Imported · ClawHub",
       "origin_skills_sh": "Imported · Skills.sh",
       "origin_github": "Imported · GitHub",
-      "origin_workspace": "Workspace"
+      "origin_workspace": "Created manually"
     },
     "conflict_banner": {
       "title": "Someone else updated this skill",

--- a/packages/views/locales/ja/skills.json
+++ b/packages/views/locales/ja/skills.json
@@ -117,7 +117,7 @@
       "origin_clawhub": "インポート済み · ClawHub",
       "origin_skills_sh": "インポート済み · Skills.sh",
       "origin_github": "インポート済み · GitHub",
-      "origin_workspace": "ワークスペース"
+      "origin_workspace": "手動で作成"
     },
     "conflict_banner": {
       "title": "他のユーザーがこのスキルを更新しました",

--- a/packages/views/locales/ko/skills.json
+++ b/packages/views/locales/ko/skills.json
@@ -117,7 +117,7 @@
       "origin_clawhub": "가져옴 · ClawHub",
       "origin_skills_sh": "가져옴 · Skills.sh",
       "origin_github": "가져옴 · GitHub",
-      "origin_workspace": "워크스페이스"
+      "origin_workspace": "직접 생성"
     },
     "conflict_banner": {
       "title": "다른 사람이 이 스킬을 업데이트했습니다",

--- a/packages/views/locales/zh-Hans/skills.json
+++ b/packages/views/locales/zh-Hans/skills.json
@@ -117,7 +117,7 @@
       "origin_clawhub": "导入自 · ClawHub",
       "origin_skills_sh": "导入自 · Skills.sh",
       "origin_github": "导入自 · GitHub",
-      "origin_workspace": "工作区"
+      "origin_workspace": "手动创建"
     },
     "conflict_banner": {
       "title": "其他人更新了这个 skill",

--- a/packages/views/skills/components/skill-detail-page.tsx
+++ b/packages/views/skills/components/skill-detail-page.tsx
@@ -5,13 +5,13 @@ import {
   AlertCircle,
   AlertTriangle,
   Clock3,
+  Download,
   FileText,
   HardDrive,
   Loader2,
   Lock,
   Plus,
   Save,
-  Sparkles,
   Trash2,
   UserPlus,
   Users,
@@ -255,7 +255,7 @@ function SkillIdentity({
               {isRuntimeOrigin ? (
                 <HardDrive className="h-3.5 w-3.5 shrink-0" aria-hidden="true" />
               ) : (
-                <Sparkles className="h-3.5 w-3.5 shrink-0" aria-hidden="true" />
+                <Download className="h-3.5 w-3.5 shrink-0" aria-hidden="true" />
               )}
               <span className="truncate">{originLabel}</span>
             </span>

--- a/packages/views/skills/components/skill-detail-page.tsx
+++ b/packages/views/skills/components/skill-detail-page.tsx
@@ -10,6 +10,7 @@ import {
   HardDrive,
   Loader2,
   Lock,
+  Pencil,
   Plus,
   Save,
   Trash2,
@@ -252,8 +253,12 @@ function SkillIdentity({
         <div className="flex min-w-0 flex-wrap items-center gap-x-4 gap-y-1 text-caption text-muted-foreground sm:ml-auto">
           {originLabel && (
             <span className="inline-flex min-w-0 items-center gap-1.5">
+              {/* Same three-way split as the list's Source column: runtime,
+                  created here, imported. */}
               {isRuntimeOrigin ? (
                 <HardDrive className="h-3.5 w-3.5 shrink-0" aria-hidden="true" />
+              ) : origin?.type === "manual" ? (
+                <Pencil className="h-3.5 w-3.5 shrink-0" aria-hidden="true" />
               ) : (
                 <Download className="h-3.5 w-3.5 shrink-0" aria-hidden="true" />
               )}


### PR DESCRIPTION
Follow-up to #6177. The icon unification kept `Sparkles` as the imported-origin marker on the skill detail identity strip. This aligns the detail page's origin marker with the list's Source column, which already had the right three-way vocabulary:

| Origin | Icon | Label |
|---|---|---|
| Local runtime | `HardDrive` (unchanged) | Local runtime · name |
| ClawHub / Skills.sh / GitHub | `Download` (was `Sparkles`) | Imported · source |
| Created manually | `Pencil` (was `Sparkles`) | Created manually (was "Workspace") |

`Download` is already the repo's import glyph (skills list-toolbar import button, URL import in the create dialog). The manual label change fixes "Workspace" telling a user nothing — the list already says "Created manually", so the detail page now uses the same wording in all four locales. `Sparkles` no longer appears anywhere on skill surfaces.

## Verification

- Manual: detail pages of an imported, a runtime-local, and a manually created skill checked against the list's Source column.
- Not run: automated suites (icon + copy change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)