### PR TITLE
refactor(skills): trim 8 built-in skill descriptions, 3,465 → 1,353 chars (MUL-5546)

### DIFF
--- a/server/internal/service/builtin_skills/multica-autopilots/SKILL.md
+++ b/server/internal/service/builtin_skills/multica-autopilots/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: multica-autopilots
-description: "Use when creating, updating, inspecting, triggering, or debugging Multica autopilots. Covers the full chain: schedule/webhook/manual trigger, create_issue vs run_only execution, agent/squad leader admission, runs, created issues/tasks, webhook URL rotation, and side-effect boundaries."
+description: "Use when creating, updating, inspecting, triggering, or debugging a Multica autopilot (scheduled, webhook, or manual)."
 user-invocable: false
 allowed-tools: Bash(multica *)
 ---

--- a/server/internal/service/builtin_skills/multica-creating-agents/SKILL.md
+++ b/server/internal/service/builtin_skills/multica-creating-agents/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: multica-creating-agents
-description: "Use when creating, inspecting, or debugging a Multica agent through the `multica agent` CLI or `POST /api/agents` — what each field is, its persisted shape, whether it is metadata-only or consumed by the daemon at claim time, which inputs are validated/rejected, how custom_env secrets are gated, and how skill binding behaves. Not for assigning issues to existing agents or for runtime task prompts."
+description: "Use when creating, inspecting, or debugging a Multica agent definition via the `multica agent` CLI or POST /api/agents. Not for assigning issues to agents that already exist, and not for runtime task prompts."
 user-invocable: false
 allowed-tools: Bash(multica *)
 ---

--- a/server/internal/service/builtin_skills/multica-mentioning/SKILL.md
+++ b/server/internal/service/builtin_skills/multica-mentioning/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: multica-mentioning
-description: "Use when an issue comment needs to @mention someone — link to a person, trigger another agent, hand work to a squad, or broadcast with @all. Documents the verified mention contract: how a mention link is built from a real UUID, the four mention types and exactly what each one enqueues (agent → a run for that agent, squad → a run for the squad leader, member and issue → a rendered link with NO run), comment create/edit preview and suppression, the @all broadcast and how it suppresses the assignee's auto-trigger, and the silent no-op cases (a name where a UUID belongs, a bad/unknown UUID, an already-pending task, an archived agent, a private agent you cannot access). WHETHER to mention — loop avoidance, staying silent on acknowledgements — lives in the runtime brief's Mentions section, not here. This skill is the backend contract only, traced to server/internal/util/mention.go and server/internal/handler/comment.go."
+description: "Use when an issue comment needs to @mention someone — link to a person, trigger another agent, hand work to a squad, or broadcast with @all. Whether to mention at all is covered by the runtime brief, not here."
 user-invocable: false
 allowed-tools: Bash(multica *)
 ---

--- a/server/internal/service/builtin_skills/multica-projects-and-resources/SKILL.md
+++ b/server/internal/service/builtin_skills/multica-projects-and-resources/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: multica-projects-and-resources
-description: "Use when creating, inspecting, updating, or debugging Multica projects and project resources. Covers durable project context, github_repo and local_directory resources, how resources affect future agent task context, when to bind repos, and when not to mutate resources."
+description: "Use when creating, inspecting, updating, or debugging Multica projects and their resources (github_repo, local_directory)."
 user-invocable: false
 allowed-tools: Bash(multica *)
 ---

--- a/server/internal/service/builtin_skills/multica-runtimes-and-repos/SKILL.md
+++ b/server/internal/service/builtin_skills/multica-runtimes-and-repos/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: multica-runtimes-and-repos
-description: "Use when inspecting or debugging Multica runtimes, daemon task claiming, agent not running, workdir/session reuse, or repository checkout. Covers runtime online/offline state, daemon heartbeat/claim chain, task-scoped repo checkout, project repo context, local_directory caveats, and safe diagnostic commands."
+description: "Use when a Multica runtime or daemon misbehaves: agent not running, task not claimed, runtime offline, workdir or session reuse, repository checkout."
 user-invocable: false
 allowed-tools: Bash(multica *)
 ---

--- a/server/internal/service/builtin_skills/multica-skill-importing/SKILL.md
+++ b/server/internal/service/builtin_skills/multica-skill-importing/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: multica-skill-importing
-description: "Use when a user provides a skill URL, slug, or clear intent to import/install a specific skill into the current Multica workspace. Teaches the workspace import API/CLI path (POST /api/skills/import), the supported URL source families, --on-conflict fail|overwrite|rename|skip behavior and structured import results, additive agent binding vs replace-all, and the reserved SKILL.md supporting-file rule. Do not use it to decide which skill the user needs, and never treat an external local installer like npx skills add as the final Multica install."
+description: "Use when asked to import or install a specific skill into this Multica workspace from a URL or slug. Not for choosing which skill the user needs; never treat a local installer such as `npx skills add` as the final install."
 user-invocable: false
 allowed-tools: Bash(multica *)
 ---

--- a/server/internal/service/builtin_skills/multica-squads/SKILL.md
+++ b/server/internal/service/builtin_skills/multica-squads/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: multica-squads
-description: "Use when creating, inspecting, updating, assigning, mentioning, or debugging Multica squads. Explains what squads are, squad/member fields, CLI commands, leader routing, issue assignment, comments, mentions, autopilot behavior, leader briefing, side effects, and product-gap handling."
+description: "Use when creating, inspecting, updating, assigning to, or debugging a Multica squad, including how leader routing picks who runs."
 user-invocable: false
 allowed-tools: Bash(multica *)
 ---

--- a/server/internal/service/builtin_skills/multica-working-on-issues/SKILL.md
+++ b/server/internal/service/builtin_skills/multica-working-on-issues/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: multica-working-on-issues
-description: "Use when working on a Multica issue after the runtime has provided the trigger context — to apply the product contracts the runtime brief does not encode: how PR linking differs from close intent, how to read a linked PR's real state via the pull-requests CLI, which metadata keys are high-signal, what status changes trigger on the server, and how sub-issue create status (todo vs backlog) controls whether assigned agents start immediately."
+description: "Use when acting on a Multica issue beyond what the brief covers: PR linking vs close intent, reading a linked PR's real state, metadata keys, status-change side effects, sub-issue todo vs backlog."
 user-invocable: false
 allowed-tools: Bash(multica *), Bash(git *), Bash(gh *)
 ---

--- a/server/internal/service/builtin_skills_test.go
+++ b/server/internal/service/builtin_skills_test.go
@@ -24,8 +24,14 @@ const (
 	// files, not the always-loaded body.
 	maxSkillBodyLines = 500
 	// maxDescriptionChars is the frontmatter description cap — it is the only
-	// thing an agent sees when deciding whether to load the skill.
-	maxDescriptionChars = 1024
+	// thing an agent sees when deciding whether to load the skill, and every
+	// runtime CLI pays for it in the always-loaded skill listing. A description
+	// earns its characters two ways only: trigger wording that matches how the
+	// task actually arrives, and reverse boundaries that prevent mis-routing.
+	// A "Covers A, B, C..." content inventory does neither — the agent reads the
+	// body once it opens the skill. The cap is deliberately tight (the longest
+	// built-in sits at 222) so that inventory prose cannot creep back in.
+	maxDescriptionChars = 300
 )
 
 // TestBuiltinSkillsConformToTemplate enforces the standard-template invariants


### PR DESCRIPTION
MUL-5546 — step 2 of the three-step skill-listing optimization (parent MUL-5529).

## Why

Every runtime CLI (11 verified locally) scans `SKILL.md` frontmatter itself and renders the `description` into its own always-loaded skill listing. Those 3,465 characters are paid on every single run, regardless of whether the skill is ever opened.

Most of them did no work. Each description followed the same shape:

```
Use when creating, updating, inspecting, triggering, or debugging Multica autopilots.   <- this routes
Covers the full chain: schedule/webhook/manual trigger, create_issue vs run_only
execution, agent/squad leader admission, runs, created issues/tasks, webhook URL
rotation, and side-effect boundaries.                                                   <- this changes no decision
```

The `Covers ...` inventory contributes nothing to routing: the agent decides from the trigger condition, and once it opens the skill it reads the whole body anyway.

A description earns its characters two ways only — **trigger wording** that matches how the task actually arrives, and **reverse boundaries** that prevent mis-routing. Everything else goes.

## What changed

`description` frontmatter only. **No skill body was touched** (one line changed per `SKILL.md`).

| skill | before | after |
|---|---:|---:|
| multica-autopilots | 285 | 118 |
| multica-creating-agents | 400 | 208 |
| multica-mentioning | 927 | 209 |
| multica-projects-and-resources | 270 | 122 |
| multica-runtimes-and-repos | 309 | 149 |
| multica-skill-importing | 548 | 222 |
| multica-squads | 284 | 129 |
| multica-working-on-issues | 442 | 196 |
| **total** | **3465** | **1353 (-61%)** |

Roughly ~866 → ~338 tokens off every run's always-loaded context.

Plus one guard: **`maxDescriptionChars` 1024 → 300** in `builtin_skills_test.go`. The 927-char description grew precisely because the old cap never pushed back — trimming the text without moving the gate fixes the symptom, not the system. Longest description now sits at 222, so 300 leaves real headroom without leaving room for inventory prose to creep back.

## Notes on specific descriptions

- **multica-mentioning** keeps its original first sentence verbatim (`link to a person, trigger another agent, hand work to a squad, or broadcast with @all`). That sentence is the best trigger line of the eight — it is stuffed with the wording tasks actually arrive in (`@all`, "叫某个 agent 来干活"). Replacing it with solution vocabulary ("writing a mention link", "UUID format") would have traded routing quality for characters. 209 chars, still -77%.
- **multica-skill-importing** keeps *both* reverse boundaries. Dropping "not for choosing which skill the user needs" would allow a side-effecting mis-route: user says "I need a skill that does X", the agent opens the import skill and actually imports something into the workspace.
- **multica-creating-agents** keeps "and not for runtime task prompts" for the same reason — cheap, and it is a boundary, not inventory.
- **multica-squads** intentionally drops `mentioning` from its verb list. Squad-mention mechanics belong to `multica-mentioning`; removing the verb here eliminates a double-routing path rather than losing coverage.

## Verification

```
go test ./internal/service/ -run TestBuiltinSkills -count=1   # PASS (both suites, all 8 skills)
go test ./internal/service/ -run 'TestMentioningSkill|TestWorkingOnIssues|TestSkillImporting|
  TestCreatingAgents|TestSquadsSkill|TestAutopilotsSkill|TestRuntimesAndRepos|
  TestProjectsAndResources' -count=1                          # ok
gofmt -l internal/service/  /  go vet ./internal/service/     # clean for touched files
go build ./...                                                # ok
```

All 8 new descriptions pass strict YAML parse (`TestBuiltinSkillsFrontmatterIsStrictYAML` — the Codex-drop regression guard); the `:` and backticks inside the double-quoted scalars are safe.

The full `./internal/service/` package has 5 unrelated failures on a stale local test DB (`column "retired_session_id" does not exist`, `relation "vcs_pull_request" does not exist`). Verified identical on a clean tree with these changes stashed — pre-existing, not from this PR. CI runs against a fresh schema.

## No source-map update needed

The repo rule is to update `references/*-source-map.md` in the same PR when a built-in skill's documented CLI commands / API fields / product behavior change. This PR touches only frontmatter descriptions — no documented behavior, no Go code, so no line drift. Grepped the whole repo: no source-map, test, or frontend code embeds these description strings or hardcodes a bundle hash.

## Bundle hash

`description` lives inside `SKILL.md`, so all 8 bundle hashes change. Daemon skill caches are hash-keyed: one cache miss, then a re-pull, and `validateSkillBundle` recomputes the manifest hash from the server-delivered content. Same self-healing path as editing any `SKILL.md`; old daemons against the new server are fine. No coordinated action required.

## Out of scope

- Workspace-skill descriptions (user-authored content — not ours to rewrite)
- `## Skills` names-only in the runtime brief — parent's step 3, blocked on provider coverage tests
- Skill-name inconsistency across three places — MUL-5539
