### PR TITLE
MUL-5542: fix(codex): raise the first-turn no-progress ceiling to 60s

### DIFF
--- a/server/pkg/agent/codex.go
+++ b/server/pkg/agent/codex.go
@@ -44,9 +44,20 @@ const (
 // rejects). Kept as its own constant so bumping codex independently of
 // other agents stays easy if codex starts shipping longer failure traces.
 const (
-	codexStderrTailBytes                   = 2048
-	defaultCodexSemanticInactivityTimeout  = 10 * time.Minute
-	defaultCodexFirstTurnNoProgressTimeout = 30 * time.Second
+	codexStderrTailBytes                  = 2048
+	defaultCodexSemanticInactivityTimeout = 10 * time.Minute
+	// defaultCodexFirstTurnNoProgressTimeout caps how long the first turn may
+	// stay completely silent after the app-server reports turn/started. Its only
+	// job is to fail fast instead of waiting out
+	// defaultCodexSemanticInactivityTimeout, so it only has to stay well under
+	// that 10 minute backstop.
+	//
+	// 30s turned out to sit inside the normal range rather than above it: two
+	// independent field reports measured the first progress event landing just
+	// past 30s on gpt-5.5, and ~39s for a WSL app-server (GH #5959). Both were
+	// healthy turns the watchdog killed. 60s clears that evidence with margin
+	// while keeping the fast-fail value (MUL-5542).
+	defaultCodexFirstTurnNoProgressTimeout = 60 * time.Second
 	defaultCodexHandshakeTimeout           = 30 * time.Second
 	codexVersionDiagnosticTimeout          = 2 * time.Second
 	// codexGracefulShutdownTimeout bounds how long the lifecycle goroutine

--- a/server/pkg/agent/codex_test.go
+++ b/server/pkg/agent/codex_test.go
@@ -735,6 +735,37 @@ func TestCodexFirstTurnProgressActivity(t *testing.T) {
 	}
 }
 
+// TestCodexFirstTurnNoProgressTimeoutClamp pins both halves of the first-turn
+// window: the 60s ceiling that a healthy gpt-5.5 turn has to fit under
+// (MUL-5542), and the fact that the configured semantic inactivity timeout can
+// only ever shrink it, never raise it. The second half is easy to misread as a
+// knob for the ceiling — it is not, and GH #5959 proposed removing the ceiling
+// entirely on that reading.
+func TestCodexFirstTurnNoProgressTimeoutClamp(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name     string
+		semantic time.Duration
+		want     time.Duration
+	}{
+		{name: "unset falls back to the ceiling", semantic: 0, want: 60 * time.Second},
+		{name: "negative falls back to the ceiling", semantic: -1 * time.Second, want: 60 * time.Second},
+		{name: "default 10m is capped at the ceiling", semantic: 10 * time.Minute, want: 60 * time.Second},
+		{name: "raising semantic cannot raise the ceiling", semantic: 2 * time.Minute, want: 60 * time.Second},
+		{name: "equal to the ceiling scales to 4/5", semantic: 60 * time.Second, want: 48 * time.Second},
+		{name: "below the ceiling scales to 4/5", semantic: 30 * time.Second, want: 24 * time.Second},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := codexFirstTurnNoProgressTimeout(tc.semantic); got != tc.want {
+				t.Fatalf("codexFirstTurnNoProgressTimeout(%s) = %s, want %s", tc.semantic, got, tc.want)
+			}
+		})
+	}
+}
+
 func TestCodexSetTurnErrorFirstWins(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

Raise `defaultCodexFirstTurnNoProgressTimeout` from 30s to 60s (`server/pkg/agent/codex.go`). Nothing else changes.

The first-turn watchdog fires when Codex reports `turn/started` and then emits no item, message, tool, completion, or terminal error event within the window. 30s turned out to sit inside the normal range rather than above it, so it was killing healthy turns:

- A user reported repeated `codex app-server no progress timeout after 30s` failures on `gpt-5.5` (`codex-cli 0.146.0`), patched the constant to 60 locally, and the failures stopped. Their measurements clustered just past 30s.
- #5959 reports the same shape on a WSL app-server, with the first model event about 39s after `status: running`.

The window's only job is to fail fast instead of waiting out the 10 minute `defaultCodexSemanticInactivityTimeout` backstop, so 60s keeps the fast-fail value while clearing the observed evidence with margin. `MULTICA_AGENT_TIMEOUT` defaults to 0, so that 10 minute backstop is the real ceiling and 60s stays well under it.

## Consequences worth naming

- A genuinely hung first turn is now detected at 60s instead of 30s. With the one automatic retry that `codex_semantic_inactivity` gets, worst case before the user sees a failure goes from roughly 70s to roughly 130s.
- The model-catalog-refresh stall (`failed to refresh available models`), which rides the same window to reach its safe retry, is also detected at 60s instead of 30s. Left alone deliberately — carving out a separate window for it is a different change.

## Deliberately out of scope

- **No new config knob.** This window is still derived as `min(ceiling, 0.8 × codex_semantic_inactivity_timeout)`, which means the documented `codex_semantic_inactivity_timeout` can only shrink it, never raise it. That trap is what forced the reporter to patch source, and #5959 removes the ceiling entirely on that reading (making the effective default 8 minutes at the default config). A dedicated `codex_first_turn_no_progress_timeout` is the right fix and belongs in its own PR.
- **No change to how `willRetry=true` retry notifications are classified.** Codex's own transient reconnects still count as "no progress", which is a separate false-positive path for real network flapping.

## Verification

- Added `TestCodexFirstTurnNoProgressTimeoutClamp`, which had no coverage before: it pins the 60s ceiling and the fact that raising `codex_semantic_inactivity_timeout` cannot raise it.
- `go test ./pkg/agent -count=1` — full package green (one earlier failure on a filtered subset run did not reproduce across 6 subsequent runs, and no test in the package depends on this constant's value; every no-progress test injects its own short timeout).
- `gofmt -l` clean on both touched files; `go vet ./pkg/agent` clean.
