### PR TITLE
docs(license): scope the branding condition to all UI code and add NOTICE (MUL-5558)

### DIFF
--- a/.vercelignore
+++ b/.vercelignore
@@ -80,6 +80,7 @@ dist-electron
 /.gitattributes
 /.gitignore
 /LICENSE
+/NOTICE
 
 *.app
 *.dmg

--- a/Dockerfile
+++ b/Dockerfile
@@ -35,6 +35,7 @@ COPY --from=builder /src/server/bin/migrate .
 COPY --from=builder /src/server/bin/backfill_task_usage_hourly .
 COPY --from=builder /src/server/bin/backfill_codex_usage_cache .
 COPY server/migrations/ ./migrations/
+COPY LICENSE NOTICE ./
 COPY docker/entrypoint.sh .
 RUN sed -i 's/\r$//' entrypoint.sh && chmod +x entrypoint.sh
 

--- a/Dockerfile.web
+++ b/Dockerfile.web
@@ -66,6 +66,8 @@ COPY --from=builder --chown=nextjs:nodejs /app/apps/web/.next/standalone ./
 COPY --from=builder --chown=nextjs:nodejs /app/apps/web/.next/static ./apps/web/.next/static
 # Copy public assets
 COPY --from=builder --chown=nextjs:nodejs /app/apps/web/public ./apps/web/public
+# Ship the license and attribution notices with the image (LICENSE condition 1b)
+COPY --chown=nextjs:nodejs LICENSE NOTICE ./
 
 USER nextjs
 

--- a/LICENSE
+++ b/LICENSE
@@ -5,7 +5,9 @@ Multica is licensed under a modified version of the Apache License 2.0, with the
 1. Multica may be utilized commercially, including as a backend service for
    other applications or as a task management platform for enterprises.
    Should the conditions below be met, a commercial license must be obtained
-   from the producer:
+   from the producer. Condition 1a determines when a commercial license is
+   required; conditions 1b and 1c are branding and attribution obligations
+   that apply to all use, whether or not a commercial license is required.
 
    a. Hosted or embedded service: Unless explicitly authorized by Multica
       in writing, you may not use the Multica source code to provide a
@@ -20,14 +22,51 @@ Multica is licensed under a modified version of the Apache License 2.0, with the
         workspaces) does not require a commercial license.
 
    b. LOGO and copyright information: In the process of using Multica's
-      frontend, you may not remove or modify the LOGO or copyright
-      information in the Multica console or applications. This restriction
-      is inapplicable to uses of Multica that do not involve its frontend.
+      user interface, you may not remove or modify the Multica LOGO or
+      wordmark, the copyright information displayed in the Multica console
+      or applications, or the attribution notices in the `NOTICE` file at
+      the root of this repository.
 
-      - Frontend Definition: For the purposes of this license, the
-        "frontend" of Multica includes all components located in the
-        `apps/web/` directory when running Multica from the raw source
-        code, or the "web" image when running Multica with Docker.
+      - User Interface Definition: For the purposes of this license, the
+        "user interface" of Multica means any source code, asset, or build
+        artifact in this repository that renders the Multica console or a
+        Multica client application, regardless of where it is located in
+        the repository. This includes, without limitation, the
+        `apps/web/`, `apps/desktop/`, `apps/mobile/`, `packages/views/`,
+        and `packages/ui/` directories. That enumeration is illustrative
+        rather than exhaustive: code that renders the Multica user
+        interface remains covered when it is modified, moved, renamed, or
+        extracted into another package or repository.
+
+      - Distribution Forms: This restriction applies to every form in
+        which the Multica user interface is distributed, including raw
+        source code, the frontend container image (published as
+        `ghcr.io/multica-ai/multica-web`), and compiled desktop and mobile
+        application binaries.
+
+      - Non-Interface Uses: This restriction is inapplicable to uses of
+        Multica that do not involve its user interface, such as running
+        only the `server/` backend, the local daemon, or the CLI, or
+        building your own independent interface on top of the Multica API.
+        Those uses are subject to condition 1c instead.
+
+   c. Attribution for non-interface use: If you use Multica without its
+      user interface — for example by running only the `server/` backend,
+      the local daemon, or the CLI, or by building your own interface on
+      top of the Multica API — condition 1b does not apply, but the
+      following attribution requirements do:
+
+      - You must retain the copyright, attribution, and license notices
+        present in the Multica source code you use, including the `NOTICE`
+        file at the root of this repository. Any redistribution of Multica
+        or of a derivative work must include a readable copy of that file,
+        as required by section 4 of the Apache License 2.0.
+
+      - If you distribute, publish, or otherwise make available to others
+        a product that incorporates Multica, you must state in your
+        product documentation, README, or another place visible to your
+        users that the product is built on Multica, with a link to
+        https://github.com/multica-ai/multica.
 
 2. As a contributor, you should agree that:
 

--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,16 @@
+Multica
+Copyright © 2025 Multica, Inc.
+
+This product includes software developed by Multica, Inc.
+https://github.com/multica-ai/multica
+
+Multica is licensed under a modified version of the Apache License 2.0. The
+full terms are in the LICENSE file at the root of this repository, including
+the additional conditions on commercial hosted or embedded use (1a), the
+Multica LOGO and copyright information in the Multica user interface (1b),
+and attribution for use that does not involve the Multica user interface
+(1c).
+
+If you redistribute Multica or a derivative work of it, you must include a
+readable copy of the attribution notices in this file, as required by
+section 4(d) of the Apache License 2.0.

--- a/README.md
+++ b/README.md
@@ -221,3 +221,11 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for the full development workflow, worktr
 
 An iOS mobile client lives in [`apps/mobile/`](apps/mobile/) — see its [README](apps/mobile/README.md) for how to build it onto your own iPhone.
 
+## License
+
+[Modified Apache 2.0 (with commercial restrictions)](LICENSE) — see [NOTICE](NOTICE) for attribution notices.
+
+- Providing Multica as a hosted service to third parties, or embedding it in a commercially distributed product, requires written authorization (condition 1a).
+- When you use Multica's user interface, the Multica LOGO, wordmark, and copyright information may not be removed or modified. "User interface" is defined by what renders the console or a client app — including `apps/web/`, `apps/desktop/`, `apps/mobile/`, `packages/views/`, and `packages/ui/` — and covers source, the frontend container image, and compiled desktop and mobile binaries (condition 1b).
+- Non-interface use (running only the `server/` backend, the daemon, or the CLI, or building your own interface on the Multica API) is exempt from the branding condition, but must retain the source attribution notices and state that the product is built on Multica with a link back to this repository (condition 1c).
+

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -178,3 +178,7 @@ iOS 移动端代码位于 [`apps/mobile/`](apps/mobile/)，自己编译装到手
 ## 开源协议
 
 [Modified Apache 2.0 (with commercial restrictions)](LICENSE)
+
+- 面向第三方的托管服务或嵌入式商业分发需要事先获得书面授权（条款 1a）。
+- 使用 Multica 界面时不得移除或修改 LOGO、字标与署名信息。界面按「渲染 Multica 控制台或客户端的代码」界定，包含 `apps/web/`、`apps/desktop/`、`apps/mobile/`、`packages/views/`、`packages/ui/`，并覆盖源码、前端容器镜像与编译后的桌面 / 移动端二进制（条款 1b）。
+- 不使用 Multica 界面的用法（只跑 `server/` 后端、daemon 或 CLI，或自建界面）不受品牌限制，但需保留源码中的署名信息与 [NOTICE](NOTICE)，并在产品文档中声明基于 Multica 构建且回链本仓库（条款 1c）。


### PR DESCRIPTION
## Problem

Clause 1b of `LICENSE` defined its own scope by directory:

> **Frontend Definition:** ... all components located in the `apps/web/` directory when running Multica from the raw source code, or the "web" image when running Multica with Docker.

Measured line counts (`.ts` / `.tsx` / `.go`, excluding `node_modules`):

| Directory | Lines | Covered by old 1b |
|---|---|---|
| `apps/web` | 20,750 | yes |
| `packages/views` | 200,713 | no |
| `packages/core` | 52,753 | no |
| `apps/mobile` | 28,049 | no |
| `apps/desktop` | 18,914 | no |
| `packages/ui` | 11,504 | no |

Three concrete defects:

1. **Desktop and iOS were entirely outside the clause.** `apps/desktop/src/renderer/src/routes.tsx` mounts every business page from `@multica/views`, so a rebranded Electron client can ship without touching one line of `apps/web/`.
2. **The clause excluded the code it was written to protect.** Multica branding is rendered in `packages/views/layout/app-sidebar.tsx`, `packages/views/invite/invite-page.tsx`, and `packages/views/workspace/new-workspace-page.tsx` — none of them under `apps/web/`.
3. **Attribution had no landing point.** No root `NOTICE`, no per-file copyright headers, and the only rendered `©` is the marketing footer (`apps/web/features/landing/components/landing-footer.tsx`) — nothing in the console. Apache 2.0 §4(c)/(d) had nothing to attach to.

Also stale: 1b named the Docker `"web"` image, but the published artifact is `ghcr.io/multica-ai/multica-web` and the compose service is `frontend`.

## Change

**`LICENSE` 1b — definition instead of enumeration.** The "user interface" is now any source, asset, or build artifact that renders the Multica console or a client application, *wherever it lives in the repo*. The five directories (`apps/web/`, `apps/desktop/`, `apps/mobile/`, `packages/views/`, `packages/ui/`) are listed as illustrative, not exhaustive, and coverage explicitly survives code being modified, moved, renamed, or extracted elsewhere — so the clause can't be defeated by relocation. All three distribution forms are named: source, the frontend container image, and compiled desktop/mobile binaries.

**`LICENSE` 1c — new attribution clause.** The non-interface exemption is preserved (backend-only / daemon / CLI / your own interface stays free of the branding condition, so 1b doesn't bleed into 1a's commercial boundary), but it now has a counterpart: retain the source attribution notices and `NOTICE`, and if you ship a product built on Multica, say so with a backlink.

**Root `NOTICE`.** The landing point that 1b and 1c both reference.

Design posture: **forkable, but brand and attribution not strippable.** Deliberately *not* "no fork may rebrand" — that would make the project effectively un-forkable, read as hostile, and cut off the cross-harness ecosystem. The commercial boundary stays entirely with 1a.

## Judgment calls worth a reviewer's attention

Three things beyond the literal ask — each easy to drop:

1. **Clause 1 preamble.** It read "Should the conditions below be met, a commercial license must be obtained from the producer:", which made the new 1c look like "fail to attribute → buy a commercial license". Added one sentence: 1a determines when a license is required; 1b/1c are obligations that apply to all use. **1a's boundary is unchanged.**
2. **`Dockerfile` / `Dockerfile.web`** now `COPY LICENSE NOTICE` into the final stage, so §4(d) attribution travels with the two images we publish rather than living only in git.
3. **`README.md` had no License section at all** — added one; expanded `README.zh-CN.md`'s. (`apps/docs/` and `CONTRIBUTING.md` contain no license text — verified by grep, nothing to sync.)

## Verification

- No application code changed, so `pnpm typecheck` / `pnpm test` / `make test` are unaffected by this diff. CI's frontend path filter doesn't match these paths.
- The Dockerfile change **was** verified: image builds only run on release tags, never in CI, so I built a throwaway stage against the real repo-root context asserting `test -s /app/LICENSE && test -s /app/NOTICE`. It passed — both files are in the build context (not `.dockerignore`d) and land non-empty. In `Dockerfile.web` the `--chown=nextjs:nodejs` COPY is placed after the `adduser` that creates that user.

## Known follow-ups (not in this PR)

- **CLI archives and desktop installers don't carry `NOTICE`.** goreleaser's default `archives.files` globs only `LICENSE*` / `README*` / `CHANGELOG*`; adding `NOTICE` means re-declaring the whole default set, and I won't guess at a release pipeline I can't execute here. `apps/desktop/electron-builder.yml` is the same story. Flagging rather than silently leaving the gap.
- **The console still renders no `©`.** 1b protects displayed copyright information, but outside the marketing footer there is none, so that half of the clause has a thin target. Adding a console attribution line is a UI change and outside this issue's acceptance criteria.
- `.goreleaser.yml` declares `license: "Apache-2.0"` for the Homebrew formula, which isn't accurate for a modified Apache 2.0. Untouched deliberately.
- Written authorization for the team that asked (the 1a "explicitly authorized ... in writing" path) is a business decision, not a code change.

Clause 2a lets the producer tighten terms only for *future* versions — already-published snapshots keep the text they shipped with, so this fix is forward-looking.

MUL-5558
