### PR TITLE
MUL-5560: avoid H1 headings in issue bodies

### DIFF
--- a/server/internal/daemon/execenv/runtime_config_kind_test.go
+++ b/server/internal/daemon/execenv/runtime_config_kind_test.go
@@ -76,6 +76,38 @@ func TestBuildMetaSkillContentBriefContent(t *testing.T) {
 	}
 }
 
+// TestBuildMetaSkillContentIssueBodyFormatting pins the shared issue-body
+// hierarchy rule across every task kind that can author an issue.
+func TestBuildMetaSkillContentIssueBodyFormatting(t *testing.T) {
+	t.Parallel()
+
+	fixtures := map[string]TaskContextForEnv{
+		"issue":        {IssueID: "i-1"},
+		"autopilot":    {AutopilotRunID: "r-1"},
+		"quick-create": {QuickCreatePrompt: "create an issue"},
+		"chat":         {ChatSessionID: "c-1"},
+	}
+
+	for name, ctx := range fixtures {
+		name, ctx := name, ctx
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			out := buildMetaSkillContent("codex", ctx)
+			for _, want := range []string{
+				"## Issue Body Formatting",
+				"An issue title already serves as its H1.",
+				"do not add a Markdown H1 (`# ...`)",
+				"start with prose or `##` subheadings",
+				"Only add an H1 when the user specifically requests one",
+			} {
+				if !strings.Contains(out, want) {
+					t.Errorf("brief is missing issue-body formatting guidance %q\n---\n%s", want, out)
+				}
+			}
+		})
+	}
+}
+
 // TestBuildMetaSkillContentSlimKindMatrix locks in which sections the
 // slim brief emits per task kind, machine-checking the matrix documented
 // on `buildMetaSkillContentSlim`. Heading is matched as a discrete line
@@ -100,6 +132,7 @@ func TestBuildMetaSkillContentSlimKindMatrix(t *testing.T) {
 		{"## Background Task Safety", allKinds},
 		{"## Agent Identity", allKinds},
 		{"## Available Commands", allKinds},
+		{"## Issue Body Formatting", allKinds},
 		{"### Workflow", allKinds},
 		{"## Important: Always Use the `multica` CLI", allKinds},
 		{"## Output", allKinds},

--- a/server/internal/daemon/execenv/runtime_config_sections.go
+++ b/server/internal/daemon/execenv/runtime_config_sections.go
@@ -28,8 +28,8 @@ import (
 //     skip sections they have no use for (Mentions, Comment Formatting,
 //     Issue Metadata, Sub-issue, ...).
 //  2. Per-section prose compression — Available Commands, Issue
-//     Metadata, Mentions, Sub-issue Creation, Comment Formatting,
-//     Always Use CLI, Background Task Safety, Task Initiator,
+//     Body Formatting, Metadata, Mentions, Sub-issue Creation,
+//     Comment Formatting, Always Use CLI, Background Task Safety, Task Initiator,
 //     Repositories, Output are all tightened. Every test-asserted phrase
 //     stays.
 //
@@ -280,6 +280,15 @@ func writeAvailableCommandsQuickCreate(b *strings.Builder) {
 	b.WriteString("**Use `--output json` for structured data.** For anything beyond `issue create`, run `multica --help` or `multica <command> --help`.\n\n")
 	b.WriteString("### Core\n")
 	b.WriteString("- `multica issue create --title \"...\" [--description \"...\" | --description-file <path> | --description-stdin] [--priority X] [--status X] [--assignee X | --assignee-id <uuid>] [--parent <issue-id>] [--stage N] [--project <project-id>] [--due-date <RFC3339>] [--attachment <path>]` — Create a new issue; `--attachment` may be repeated. For agent-authored long descriptions, prefer `--description-file <path>` over `--description-stdin` (flags after a HEREDOC terminator can be silently swallowed, #4182). Write that file inside your working directory (e.g. `./description.md`), never `/tmp` or shared paths, and treat a failed write as fatal — the CLI rejects a path outside the workdir so a stale file from another run can't leak in (MUL-4252).\n\n")
+}
+
+// writeIssueBodyFormatting emits the default Markdown hierarchy for issue
+// descriptions. It is shared by every task kind because issue creation and
+// updates can be requested from issue, chat, autopilot, and quick-create
+// surfaces.
+func writeIssueBodyFormatting(b *strings.Builder) {
+	b.WriteString("## Issue Body Formatting\n\n")
+	b.WriteString("An issue title already serves as its H1. By default, do not add a Markdown H1 (`# ...`) to an issue body or description; start with prose or `##` subheadings instead. Only add an H1 when the user specifically requests one.\n\n")
 }
 
 // writeCommentFormatting emits the cross-platform file-first guardrail.
@@ -665,6 +674,7 @@ func writeOutput(b *strings.Builder, kind taskKind, ctx TaskContextForEnv) {
 //	Section               | comment | assign | autopilot | quick_create | chat
 //	----------------------+---------+--------+-----------+--------------+------
 //	Available Commands    |   full  |  full  |   full    |   minimal    | full
+//	Issue Body Formatting |    ✓    |   ✓    |     ✓     |      ✓       |  ✓
 //	Comment Formatting    |    ✓    |   ✓    |     —     |      —       |  —
 //	Repositories          |    △    |   △    |     △     |      —       |  △
 //	Project Context       |    △    |   △    |     △     |      △       |  △
@@ -699,6 +709,7 @@ func buildMetaSkillContentSlim(provider string, ctx TaskContextForEnv) string {
 	default:
 		writeAvailableCommands(&b)
 	}
+	writeIssueBodyFormatting(&b)
 
 	if kind == kindIssue {
 		writeCommentFormatting(&b)


### PR DESCRIPTION
## Summary

- add shared issue-body formatting guidance to the Multica agent runtime brief
- tell agents that the issue title already serves as H1, so descriptions should default to prose or H2 subheadings
- allow H1 only when the user specifically requests one
- cover issue, chat, autopilot, and quick-create task kinds with regression tests

## Impact

Agent-authored issue descriptions no longer duplicate the issue title hierarchy with a top-level Markdown heading by default.

## Validation

- `go test ./internal/daemon/execenv -count=1`
- `go test ./internal/daemon/... -count=1`
- `git diff --check`

Closes MUL-5560
