### PR TITLE
MUL-5493: feat(chat): restore the visible follow-up queue

### DIFF
--- a/packages/core/api/client.test.ts
+++ b/packages/core/api/client.test.ts
@@ -1351,6 +1351,26 @@ describe("ApiClient", () => {
       expect(init.headers["X-Client-Capabilities"]).toBe(CHAT_DRAFT_RESTORE_CAPABILITY);
     });
 
+    it("scopes queued-only cancellation to the expected chat session", async () => {
+      const fetchMock = vi.fn().mockResolvedValue(
+        new Response(JSON.stringify(taskResponse), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        }),
+      );
+      vi.stubGlobal("fetch", fetchMock);
+
+      await new ApiClient("https://api.example.test").cancelTaskById("task-1", {
+        queuedOnly: true,
+        sessionId: "session-1",
+      });
+
+      expect(fetchMock.mock.calls[0]?.[0]).toBe(
+        "https://api.example.test/api/tasks/task-1/cancel" +
+          "?expected_status=queued&chat_session_id=session-1",
+      );
+    });
+
     it("treats a null cancelled chat message as absent", async () => {
       vi.stubGlobal(
         "fetch",
@@ -1404,6 +1424,18 @@ describe("ApiClient", () => {
       expect(result.id).toBe("");
       expect(result.cancelled_chat_message).toBeUndefined();
     });
+  });
+
+  it("clears a chat queue with one session-scoped request", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(new Response(null, { status: 204 }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await new ApiClient("https://api.example.test").clearQueuedChatTasks("session-1");
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://api.example.test/api/chat/sessions/session-1/queued-tasks",
+      expect.objectContaining({ method: "DELETE" }),
+    );
   });
 
   describe("chat attachment wiring", () => {

--- a/packages/core/api/client.ts
+++ b/packages/core/api/client.ts
@@ -88,6 +88,7 @@ import type {
   ChatMessagesPage,
   ChatDraftRestoresResponse,
   ChatPendingTask,
+  PrioritizeQueuedChatTaskResponse,
   PendingChatTasksResponse,
   HasPendingChatTasksResponse,
   SendChatMessageResponse,
@@ -183,6 +184,8 @@ import {
   AttachmentResponseSchema,
   CancelTaskResponseSchema,
   ChatDraftRestoresResponseSchema,
+  ChatPendingTaskSchema,
+  PrioritizeQueuedChatTaskResponseSchema,
   ChildIssuesResponseSchema,
   CommentsListSchema,
   CommentTriggerPreviewSchema,
@@ -203,6 +206,8 @@ import {
   EMPTY_AGENT_TEMPLATE_SUMMARY_LIST,
   EMPTY_APP_CONFIG,
   EMPTY_ATTACHMENT,
+  EMPTY_CHAT_PENDING_TASK,
+  EMPTY_PRIORITIZE_QUEUED_CHAT_TASK_RESPONSE,
   EMPTY_CLOUD_RUNTIME_NODE,
   EMPTY_CLOUD_RUNTIME_NODE_LIST,
   EMPTY_CREATE_AGENT_FROM_TEMPLATE_RESPONSE,
@@ -2284,7 +2289,32 @@ export class ApiClient {
   }
 
   async getPendingChatTask(sessionId: string): Promise<ChatPendingTask> {
-    return this.fetch(`/api/chat/sessions/${sessionId}/pending-task`);
+    const raw = await this.fetch<unknown>(`/api/chat/sessions/${sessionId}/pending-task`);
+    return parseWithFallback(raw, ChatPendingTaskSchema, EMPTY_CHAT_PENDING_TASK, {
+      endpoint: "GET /api/chat/sessions/:id/pending-task",
+    });
+  }
+
+  async prioritizeQueuedChatTask(
+    sessionId: string,
+    taskId: string,
+  ): Promise<PrioritizeQueuedChatTaskResponse> {
+    const raw = await this.fetch<unknown>(
+      `/api/chat/sessions/${sessionId}/queued-tasks/${taskId}/prioritize`,
+      { method: "POST" },
+    );
+    return parseWithFallback(
+      raw,
+      PrioritizeQueuedChatTaskResponseSchema,
+      EMPTY_PRIORITIZE_QUEUED_CHAT_TASK_RESPONSE,
+      { endpoint: "POST /api/chat/sessions/:id/queued-tasks/:taskId/prioritize" },
+    );
+  }
+
+  async clearQueuedChatTasks(sessionId: string): Promise<void> {
+    await this.fetch(`/api/chat/sessions/${sessionId}/queued-tasks`, {
+      method: "DELETE",
+    });
   }
 
   /**
@@ -2330,8 +2360,18 @@ export class ApiClient {
   // defers the empty-transcript judgment — and therefore only withholds the
   // synchronous restore from the response — for clients that send this; without
   // it we would be treated as a pre-#5219 client and get the legacy behaviour.
-  async cancelTaskById(taskId: string): Promise<CancelTaskResponse> {
-    const raw = await this.fetch<unknown>(`/api/tasks/${taskId}/cancel`, {
+  async cancelTaskById(
+    taskId: string,
+    options?: { queuedOnly?: boolean; sessionId?: string },
+  ): Promise<CancelTaskResponse> {
+    const params = new URLSearchParams();
+    if (options?.queuedOnly) {
+      if (!options.sessionId) throw new Error("sessionId is required for queued-only cancellation");
+      params.set("expected_status", "queued");
+      params.set("chat_session_id", options.sessionId);
+    }
+    const query = params.size > 0 ? `?${params}` : "";
+    const raw = await this.fetch<unknown>(`/api/tasks/${taskId}/cancel${query}`, {
       method: "POST",
       headers: { "X-Client-Capabilities": CHAT_DRAFT_RESTORE_CAPABILITY },
     });

--- a/packages/core/api/schemas.test.ts
+++ b/packages/core/api/schemas.test.ts
@@ -11,9 +11,13 @@ import {
   DashboardUsageByAgentListSchema,
   DashboardUsageDailyListSchema,
   ChatDraftRestoresResponseSchema,
+  ChatPendingTaskSchema,
+  PrioritizeQueuedChatTaskResponseSchema,
   CreateFeedbackResponseSchema,
   DuplicateIssueErrorBodySchema,
   EMPTY_CHAT_DRAFT_RESTORES,
+  EMPTY_CHAT_PENDING_TASK,
+  EMPTY_PRIORITIZE_QUEUED_CHAT_TASK_RESPONSE,
   EMPTY_CREATE_FEEDBACK_RESPONSE,
   EMPTY_INBOX_ITEMS,
   EMPTY_INBOX_UNREAD_SUMMARY,
@@ -407,6 +411,97 @@ describe("ChatDraftRestoresResponseSchema", () => {
       { endpoint: "test" },
     );
     expect(parsed).toEqual(EMPTY_CHAT_DRAFT_RESTORES);
+  });
+});
+
+describe("ChatPendingTaskSchema", () => {
+  const ENDPOINT = { endpoint: "GET /api/chat/sessions/:id/pending-task" };
+
+  it("keeps legacy responses compatible when queued_tasks is absent", () => {
+    const parsed = parseWithFallback(
+      {
+        task_id: "task-active",
+        status: "running",
+        created_at: "2026-07-01T00:00:00Z",
+      },
+      ChatPendingTaskSchema,
+      EMPTY_CHAT_PENDING_TASK,
+      ENDPOINT,
+    );
+
+    expect(parsed).toMatchObject({
+      task_id: "task-active",
+      status: "running",
+    });
+    expect(parsed.queued_tasks).toBeUndefined();
+  });
+
+  it("parses queued task summaries", () => {
+    const parsed = ChatPendingTaskSchema.parse({
+      task_id: "task-active",
+      status: "running",
+      queued_tasks: [
+        {
+          task_id: "task-queued",
+          status: "queued",
+          content: "Follow up after the current task",
+          created_at: "2026-07-01T00:01:00Z",
+        },
+      ],
+    });
+
+    expect(parsed.queued_tasks).toEqual([
+      expect.objectContaining({
+        task_id: "task-queued",
+        content: "Follow up after the current task",
+      }),
+    ]);
+  });
+
+  it("keeps a valid head and ignores only malformed queued rows", () => {
+    const parsed = parseWithFallback(
+      {
+        task_id: "task-active",
+        queued_tasks: [{ task_id: 42, status: "queued" }],
+      },
+      ChatPendingTaskSchema,
+      EMPTY_CHAT_PENDING_TASK,
+      ENDPOINT,
+    );
+
+    expect(parsed).toEqual({
+      task_id: "task-active",
+      queued_tasks: [],
+    });
+  });
+});
+
+describe("PrioritizeQueuedChatTaskResponseSchema", () => {
+  const ENDPOINT = {
+    endpoint: "POST /api/chat/sessions/:id/queued-tasks/:taskId/prioritize",
+  };
+
+  it("parses the prioritized task id", () => {
+    expect(
+      PrioritizeQueuedChatTaskResponseSchema.parse({
+        task_id: "task-queued",
+        active_task_id: "task-active",
+      }),
+    ).toEqual({
+      task_id: "task-queued",
+      active_task_id: "task-active",
+    });
+  });
+
+  it("falls back when task_id is malformed", () => {
+    expect(
+      parseWithFallback(
+        { task_id: 42 },
+        PrioritizeQueuedChatTaskResponseSchema,
+        EMPTY_PRIORITIZE_QUEUED_CHAT_TASK_RESPONSE,
+        ENDPOINT,
+      ),
+    ).toBe(EMPTY_PRIORITIZE_QUEUED_CHAT_TASK_RESPONSE);
   });
 });
 

--- a/packages/core/api/schemas.ts
+++ b/packages/core/api/schemas.ts
@@ -15,6 +15,8 @@ import type {
   BillingTransactionsPage,
   CancelTaskResponse,
   ChatDraftRestoresResponse,
+  ChatPendingTask,
+  PrioritizeQueuedChatTaskResponse,
   CreateAgentFromTemplateResponse,
   CreateBillingCheckoutSessionResponse,
   CreateBillingPortalSessionResponse,
@@ -1112,6 +1114,43 @@ const ChatDraftRestoreSchema = z.object({
 export const ChatDraftRestoresResponseSchema = z.object({
   restores: z.array(ChatDraftRestoreSchema).default([]),
 }).loose();
+
+const ChatQueuedTaskSchema = z.object({
+  task_id: z.string(),
+  status: z.string().default("queued"),
+  created_at: z.string().default(""),
+  message_id: z.string().optional(),
+  content: z.string().optional(),
+}).loose();
+
+const ChatQueuedTasksSchema = z.array(z.unknown()).transform((tasks) =>
+  tasks.flatMap((task) => {
+    const parsed = ChatQueuedTaskSchema.safeParse(task);
+    return parsed.success ? [parsed.data] : [];
+  }),
+);
+
+// Root fields retain the legacy single-task response shape. Keep additive
+// fields optional so callers can distinguish an older server from an empty
+// queue. A malformed queue row is ignored without discarding a valid head.
+export const ChatPendingTaskSchema: z.ZodType<ChatPendingTask> = z.object({
+  task_id: z.string().optional(),
+  status: z.string().optional(),
+  created_at: z.string().optional(),
+  supports_queue: z.boolean().optional(),
+  queued_tasks: ChatQueuedTasksSchema.optional(),
+}).loose();
+
+export const EMPTY_CHAT_PENDING_TASK: ChatPendingTask = {};
+
+export const PrioritizeQueuedChatTaskResponseSchema:
+  z.ZodType<PrioritizeQueuedChatTaskResponse> = z.object({
+    task_id: z.string(),
+    active_task_id: z.string().optional(),
+  }).loose();
+
+export const EMPTY_PRIORITIZE_QUEUED_CHAT_TASK_RESPONSE:
+  PrioritizeQueuedChatTaskResponse = { task_id: "" };
 
 export const EMPTY_CHAT_DRAFT_RESTORES: ChatDraftRestoresResponse = {
   restores: [],

--- a/packages/core/chat/pending.test.ts
+++ b/packages/core/chat/pending.test.ts
@@ -1,0 +1,197 @@
+import { describe, expect, it } from "vitest";
+import {
+  enqueuePendingChatTask,
+  hideQueuedChatMessages,
+  prioritizePendingChatTask,
+  promotePendingChatTask,
+  removePendingChatTask,
+} from "./pending";
+
+const task = (task_id: string, created_at: string) => ({
+  task_id,
+  status: "queued",
+  created_at,
+  content: `message ${task_id}`,
+});
+
+describe("pending chat queue", () => {
+  it("keeps the active task at the head and follow-ups in FIFO order", () => {
+    const active = { ...task("active", "2026-01-01T00:00:00Z"), status: "running" };
+    const withLater = enqueuePendingChatTask(active, task("later", "2026-01-01T00:00:02Z"));
+    const result = enqueuePendingChatTask(withLater, task("next", "2026-01-01T00:00:01Z"));
+
+    expect(result.task_id).toBe("active");
+    expect(result.queued_tasks?.map((item) => item.task_id)).toEqual(["next", "later"]);
+  });
+
+  it("keeps the first queued prompt in the queue until it starts running", () => {
+    const queued = {
+      ...task("next", "2026-01-01T00:00:01Z"),
+      message_id: "message-next",
+    };
+    const pending = enqueuePendingChatTask(undefined, queued);
+
+    expect(pending.queued_tasks).toEqual([queued]);
+    expect(promotePendingChatTask(pending, "next", "running").queued_tasks).toEqual([]);
+  });
+
+  it("keeps a send response preview when a sparse queued event arrives later", () => {
+    const current = {
+      ...task("active", "2026-01-01T00:00:00Z"),
+      status: "running",
+      queued_tasks: [
+        {
+          ...task("next", "2026-01-01T00:00:01Z"),
+          message_id: "message-next",
+          content: "Keep this visible preview",
+        },
+      ],
+    };
+
+    const result = enqueuePendingChatTask(current, {
+      task_id: "next",
+      status: "queued",
+      created_at: "2026-01-01T00:00:03Z",
+    });
+
+    expect(result.queued_tasks).toEqual([
+      expect.objectContaining({
+        task_id: "next",
+        created_at: "2026-01-01T00:00:01Z",
+        message_id: "message-next",
+        content: "Keep this visible preview",
+      }),
+    ]);
+  });
+
+  it("promotes a queued task without losing later work", () => {
+    const current = {
+      ...task("active", "2026-01-01T00:00:00Z"),
+      status: "running",
+      supports_queue: true,
+      queued_tasks: [
+        task("next", "2026-01-01T00:00:01Z"),
+        task("later", "2026-01-01T00:00:02Z"),
+      ],
+    };
+
+    const result = promotePendingChatTask(current, "next", "running");
+    expect(result.task_id).toBe("next");
+    expect(result.status).toBe("running");
+    expect(result.supports_queue).toBe(true);
+    expect(result.queued_tasks?.map((item) => item.task_id)).toEqual(["later"]);
+  });
+
+  it("ignores a stale dispatch for an unknown task while another task is active", () => {
+    const current = {
+      ...task("active", "2026-01-01T00:00:00Z"),
+      status: "running",
+      queued_tasks: [task("next", "2026-01-01T00:00:01Z")],
+    };
+
+    expect(promotePendingChatTask(current, "stale", "running")).toBe(current);
+  });
+
+  it("does not resurrect an unknown task after the pending query cleared", () => {
+    expect(promotePendingChatTask(undefined, "stale", "running")).toEqual({});
+    expect(promotePendingChatTask({ supports_queue: true }, "stale", "running")).toEqual({
+      supports_queue: true,
+    });
+  });
+
+  it("removes only the selected queued task", () => {
+    const current = {
+      ...task("active", "2026-01-01T00:00:00Z"),
+      status: "running",
+      queued_tasks: [task("next", "2026-01-01T00:00:01Z")],
+    };
+
+    expect(removePendingChatTask(current, "next")).toEqual({
+      ...current,
+      queued_tasks: [],
+    });
+  });
+
+  it("promotes the first queued task when the active task finishes", () => {
+    const current = {
+      ...task("active", "2026-01-01T00:00:00Z"),
+      status: "running",
+      supports_queue: true,
+      queued_tasks: [
+        task("next", "2026-01-01T00:00:01Z"),
+        task("later", "2026-01-01T00:00:02Z"),
+      ],
+    };
+
+    const result = removePendingChatTask(current, "active");
+    expect(result.task_id).toBe("next");
+    expect(result.supports_queue).toBe(true);
+    expect(result.queued_tasks?.map((item) => item.task_id)).toEqual(["next", "later"]);
+  });
+
+  it("keeps queued prompts out of the settled transcript", () => {
+    const messages = [
+      {
+        id: "message-active",
+        chat_session_id: "session",
+        role: "user" as const,
+        content: "active",
+        task_id: "active",
+        created_at: "2026-01-01T00:00:00Z",
+      },
+      {
+        id: "message-next",
+        chat_session_id: "session",
+        role: "user" as const,
+        content: "next",
+        task_id: "next",
+        created_at: "2026-01-01T00:00:01Z",
+      },
+    ];
+    const pending = {
+      ...task("active", "2026-01-01T00:00:00Z"),
+      status: "running",
+      queued_tasks: [{ ...task("next", "2026-01-01T00:00:01Z"), message_id: "message-next" }],
+    };
+
+    expect(hideQueuedChatMessages(messages, pending)).toEqual([messages[0]]);
+    const waiting = removePendingChatTask(pending, "active");
+    expect(hideQueuedChatMessages(messages, waiting)).toEqual([messages[0]]);
+    expect(
+      hideQueuedChatMessages(messages, promotePendingChatTask(waiting, "next", "running")),
+    ).toEqual(
+      messages,
+    );
+  });
+
+  it("moves a send-now task to the front without disturbing the remaining queue", () => {
+    const current = {
+      ...task("active", "2026-01-01T00:00:00Z"),
+      status: "running",
+      queued_tasks: [
+        task("next", "2026-01-01T00:00:01Z"),
+        task("send-now", "2026-01-01T00:00:02Z"),
+        task("later", "2026-01-01T00:00:03Z"),
+      ],
+    };
+
+    expect(
+      prioritizePendingChatTask(current, "send-now").queued_tasks?.map((item) => item.task_id),
+    ).toEqual(["send-now", "next", "later"]);
+  });
+
+  it("preserves send-now order when the active task is removed", () => {
+    const current = prioritizePendingChatTask({
+      ...task("active", "2026-01-01T00:00:00Z"),
+      status: "running",
+      queued_tasks: [
+        task("next", "2026-01-01T00:00:01Z"),
+        task("send-now", "2026-01-01T00:00:02Z"),
+      ],
+    }, "send-now");
+
+    const result = removePendingChatTask(current, "active");
+    expect(result.task_id).toBe("send-now");
+    expect(result.queued_tasks?.map((item) => item.task_id)).toEqual(["send-now", "next"]);
+  });
+});

--- a/packages/core/chat/pending.ts
+++ b/packages/core/chat/pending.ts
@@ -1,0 +1,134 @@
+import type { ChatMessage, ChatPendingTask, ChatQueuedTask } from "../types/chat";
+
+const EMPTY_PENDING_TASK: ChatPendingTask = {};
+
+function compareQueuedTasks(left: ChatQueuedTask, right: ChatQueuedTask): number {
+  const leftTime = Date.parse(left.created_at);
+  const rightTime = Date.parse(right.created_at);
+  if (Number.isFinite(leftTime) && Number.isFinite(rightTime) && leftTime !== rightTime) {
+    return leftTime - rightTime;
+  }
+  return left.task_id.localeCompare(right.task_id);
+}
+
+function uniqueQueue(tasks: ChatQueuedTask[]): ChatQueuedTask[] {
+  const byID = new Map<string, ChatQueuedTask>();
+  // Keep the first observation of a task. The send response carries the
+  // authoritative created_at plus the message preview, while the later
+  // task:queued event only carries an id/status. Letting that sparse event win
+  // would replace visible text with the fallback label.
+  for (const task of tasks) {
+    if (!byID.has(task.task_id)) byID.set(task.task_id, task);
+  }
+  return [...byID.values()];
+}
+
+function normalizeQueue(tasks: ChatQueuedTask[]): ChatQueuedTask[] {
+  return uniqueQueue(tasks).sort(compareQueuedTasks);
+}
+
+function asSummary(task: ChatPendingTask): ChatQueuedTask | undefined {
+  if (!task.task_id) return undefined;
+  return {
+    task_id: task.task_id,
+    status: task.status ?? "queued",
+    created_at: task.created_at ?? "",
+  };
+}
+
+export function enqueuePendingChatTask(
+  current: ChatPendingTask | undefined,
+  task: ChatQueuedTask,
+): ChatPendingTask {
+  if (!current?.task_id) {
+    return { ...task, queued_tasks: [task] };
+  }
+  if (current.task_id === task.task_id) {
+    return {
+      ...current,
+      status: task.status,
+      created_at: current.created_at || task.created_at,
+      queued_tasks: normalizeQueue([...(current.queued_tasks ?? []), task]),
+    };
+  }
+  return {
+    ...current,
+    queued_tasks: normalizeQueue([...(current.queued_tasks ?? []), task]),
+  };
+}
+
+export function promotePendingChatTask(
+  current: ChatPendingTask | undefined,
+  taskID: string,
+  status: string,
+  createdAt?: string,
+): ChatPendingTask {
+  const queue = current?.queued_tasks ?? [];
+  if (current?.task_id === taskID) {
+    return {
+      ...current,
+      status,
+      queued_tasks: queue.filter((task) => task.task_id !== taskID),
+    };
+  }
+
+  const promoted = queue.find((task) => task.task_id === taskID);
+  // Lifecycle events are only hints. A late event for an unknown task must
+  // not synthesize a new head after the authoritative pending query cleared.
+  if (!current?.task_id || !promoted) return current ?? EMPTY_PENDING_TASK;
+  const previousHead = asSummary(current ?? {});
+  return {
+    ...promoted,
+    supports_queue: current.supports_queue,
+    status,
+    created_at: promoted.created_at || createdAt || "",
+    queued_tasks: uniqueQueue([
+      ...(previousHead?.status === "queued" ? [previousHead] : []),
+      ...queue.filter((task) => task.task_id !== taskID),
+    ]),
+  };
+}
+
+export function removePendingChatTask(
+  current: ChatPendingTask | undefined,
+  taskID: string,
+): ChatPendingTask {
+  if (!current?.task_id) return EMPTY_PENDING_TASK;
+  if (current.task_id !== taskID) {
+    return {
+      ...current,
+      queued_tasks: (current.queued_tasks ?? []).filter((task) => task.task_id !== taskID),
+    };
+  }
+
+  const [next, ...rest] = uniqueQueue(
+    (current.queued_tasks ?? []).filter((task) => task.task_id !== taskID),
+  );
+  if (!next) return EMPTY_PENDING_TASK;
+  return { ...next, supports_queue: current.supports_queue, queued_tasks: [next, ...rest] };
+}
+
+export function prioritizePendingChatTask(
+  current: ChatPendingTask | undefined,
+  taskID: string,
+): ChatPendingTask {
+  if (!current?.task_id) return EMPTY_PENDING_TASK;
+  const queue = current.queued_tasks ?? [];
+  const selected = queue.find((task) => task.task_id === taskID);
+  if (!selected) return current;
+  return {
+    ...current,
+    queued_tasks: [selected, ...queue.filter((task) => task.task_id !== taskID)],
+  };
+}
+
+export function hideQueuedChatMessages(
+  messages: ChatMessage[],
+  pending: ChatPendingTask | undefined,
+): ChatMessage[] {
+  const queuedMessageIDs = new Set(
+    (pending?.queued_tasks ?? []).flatMap((task) => task.message_id ? [task.message_id] : []),
+  );
+  if (queuedMessageIDs.size === 0) return messages;
+  return messages.filter((message) => !queuedMessageIDs.has(message.id));
+}

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -53,6 +53,7 @@
     "./chat": "./chat/index.ts",
     "./chat/queries": "./chat/queries.ts",
     "./chat/mutations": "./chat/mutations.ts",
+    "./chat/pending": "./chat/pending.ts",
     "./chat/unread": "./chat/unread.ts",
     "./runtimes": "./runtimes/index.ts",
     "./runtimes/queries": "./runtimes/queries.ts",

--- a/packages/core/realtime/use-realtime-sync.test.ts
+++ b/packages/core/realtime/use-realtime-sync.test.ts
@@ -326,6 +326,85 @@ describe("applyChatCancelFinalizedToCache", () => {
     expect(qc.getQueryData<ChatPendingTask>(pendingKey)).toEqual({});
   });
 
+  it("promotes the next queued task when the restored task was the head", () => {
+    const qc = createQueryClient();
+    const invalidate = vi.spyOn(qc, "invalidateQueries");
+    qc.setQueryData<ChatPendingTask>(pendingKey, {
+      task_id: taskId,
+      status: "running",
+      queued_tasks: [
+        {
+          task_id: "task-next",
+          status: "queued",
+          created_at: "2026-05-13T05:00:01Z",
+          content: "next",
+        },
+        {
+          task_id: "task-later",
+          status: "queued",
+          created_at: "2026-05-13T05:00:02Z",
+          content: "later",
+        },
+      ],
+    });
+
+    applyChatCancelFinalizedToCache(qc, {
+      outcome: "restored",
+      chat_session_id: sessionId,
+      task_id: taskId,
+      message_id: "msg-cancelled-user",
+    });
+
+    expect(qc.getQueryData<ChatPendingTask>(pendingKey)).toEqual({
+      task_id: "task-next",
+      status: "queued",
+      created_at: "2026-05-13T05:00:01Z",
+      content: "next",
+      queued_tasks: [
+        {
+          task_id: "task-next",
+          status: "queued",
+          created_at: "2026-05-13T05:00:01Z",
+          content: "next",
+        },
+        {
+          task_id: "task-later",
+          status: "queued",
+          created_at: "2026-05-13T05:00:02Z",
+          content: "later",
+        },
+      ],
+    });
+    expect(invalidate).toHaveBeenCalledWith({ queryKey: pendingKey });
+  });
+
+  it("keeps a promoted successor when the restored event arrives late", () => {
+    const qc = createQueryClient();
+    const successor: ChatPendingTask = {
+      task_id: "task-next",
+      status: "running",
+      created_at: "2026-05-13T05:00:01Z",
+      queued_tasks: [
+        {
+          task_id: "task-later",
+          status: "queued",
+          created_at: "2026-05-13T05:00:02Z",
+          content: "later",
+        },
+      ],
+    };
+    qc.setQueryData<ChatPendingTask>(pendingKey, successor);
+
+    applyChatCancelFinalizedToCache(qc, {
+      outcome: "restored",
+      chat_session_id: sessionId,
+      task_id: taskId,
+      message_id: "msg-cancelled-user",
+    });
+
+    expect(qc.getQueryData<ChatPendingTask>(pendingKey)).toEqual(successor);
+  });
+
   it("invalidates the draft-restores query for the initiator", () => {
     const qc = createQueryClient();
     const invalidate = vi.spyOn(qc, "invalidateQueries");

--- a/packages/core/realtime/use-realtime-sync.ts
+++ b/packages/core/realtime/use-realtime-sync.ts
@@ -50,6 +50,10 @@ import {
 import type { Workspace } from "../types/workspace";
 import { chatKeys, mergeTaskMessagesBySeq, sortChatSessions } from "../chat/queries";
 import { useChatStore } from "../chat";
+import {
+  promotePendingChatTask,
+  removePendingChatTask,
+} from "../chat/pending";
 import { resolvePostAuthDestination, useHasOnboarded } from "../paths";
 import type {
   MemberAddedPayload,
@@ -163,8 +167,12 @@ export function applyChatDoneToCache(
       (old) => patchLatestChatMessagePage(old, assistant),
     );
   }
-  // Replacement is in the messages list now; safe to drop pending.
-  qc.setQueryData(chatKeys.pendingTask(sessionId), {});
+  // Replacement is in the messages list now; remove only this task. If a
+  // follow-up is queued, it becomes the next head in the same render tick.
+  qc.setQueryData<ChatPendingTask>(
+    chatKeys.pendingTask(sessionId),
+    (old) => removePendingChatTask(old, taskId),
+  );
   // Authoritative refetch reconciles redaction / migrations / clients
   // that took the fallback branch above.
   invalidateChatMessageQueries(qc, sessionId);
@@ -317,8 +325,14 @@ export function applyChatCancelFinalizedToCache(
     if (payload.message_id) {
       removeChatMessageFromCaches(qc, sessionId, payload.message_id);
     }
-    qc.setQueryData(chatKeys.pendingTask(sessionId), {});
+    // Deferred finalization can arrive after a queued successor was promoted.
+    // Remove only the cancelled task so a late restore cannot hide newer work.
+    qc.setQueryData<ChatPendingTask>(
+      chatKeys.pendingTask(sessionId),
+      (old) => removePendingChatTask(old, payload.task_id),
+    );
     invalidateChatMessageQueries(qc, sessionId);
+    qc.invalidateQueries({ queryKey: chatKeys.pendingTask(sessionId) });
     const isInitiator =
       !!payload.initiator_user_id &&
       !!currentUserId &&
@@ -1197,27 +1211,13 @@ export function useRealtimeSync(
       }
     });
 
-    // Chat task lifecycle writethrough: keep `chatKeys.pendingTask(sessionId)`
-    // synchronized with the server state machine via setQueryData rather than
-    // invalidate-refetch. Same pattern as task:message — the WS payload
-    // carries everything we need, and an HTTP roundtrip just to read what we
-    // already know would add latency to every stage transition.
-    //
-    // task:queued is emitted by EnqueueChatTask. The optimistic seed in
-    // chat-window.tsx may have already populated the cache with a temporary
-    // id; this handler upgrades it to the real task_id (and reaffirms status
-    // when reconnect replays the event for an already-running task).
+    // Lifecycle events are invalidation hints. They intentionally omit queue
+    // previews and message ids, so only the pending-task endpoint can author
+    // the complete queue shape.
     const unsubTaskQueued = ws.on("task:queued", (p) => {
       const payload = p as TaskQueuedPayload;
       if (!payload.chat_session_id) return;
-      qc.setQueryData<ChatPendingTask>(
-        chatKeys.pendingTask(payload.chat_session_id),
-        (old) => ({
-          ...(old ?? {}),
-          task_id: payload.task_id,
-          status: "queued",
-        }),
-      );
+      qc.invalidateQueries({ queryKey: chatKeys.pendingTask(payload.chat_session_id) });
       invalidatePendingAggregate();
     });
 
@@ -1232,11 +1232,9 @@ export function useRealtimeSync(
       if (!payload.chat_session_id) return;
       qc.setQueryData<ChatPendingTask>(
         chatKeys.pendingTask(payload.chat_session_id),
-        (old) => {
-          if (!old || old.task_id !== payload.task_id) return old;
-          return { ...old, status: "running" };
-        },
+        (old) => promotePendingChatTask(old, payload.task_id, "running"),
       );
+      qc.invalidateQueries({ queryKey: chatKeys.pendingTask(payload.chat_session_id) });
       invalidatePendingAggregate();
     });
 
@@ -1250,11 +1248,9 @@ export function useRealtimeSync(
       if (!payload.chat_session_id) return;
       qc.setQueryData<ChatPendingTask>(
         chatKeys.pendingTask(payload.chat_session_id),
-        (old) => {
-          if (!old || old.task_id !== payload.task_id) return old;
-          return { ...old, status: "running" };
-        },
+        (old) => promotePendingChatTask(old, payload.task_id, "running"),
       );
+      qc.invalidateQueries({ queryKey: chatKeys.pendingTask(payload.chat_session_id) });
       invalidatePendingAggregate();
     });
 
@@ -1270,11 +1266,14 @@ export function useRealtimeSync(
         if (!payload.chat_session_id) return;
         qc.setQueryData<ChatPendingTask>(
           chatKeys.pendingTask(payload.chat_session_id),
-          (old) => {
-            if (!old || old.task_id !== payload.task_id) return old;
-            return { ...old, status: "waiting_local_directory" };
-          },
+          (old) =>
+            promotePendingChatTask(
+              old,
+              payload.task_id,
+              "waiting_local_directory",
+            ),
         );
+        qc.invalidateQueries({ queryKey: chatKeys.pendingTask(payload.chat_session_id) });
         invalidatePendingAggregate();
       },
     );
@@ -1294,7 +1293,11 @@ export function useRealtimeSync(
         task_id: payload.task_id,
         chat_session_id: payload.chat_session_id,
       });
-      qc.setQueryData(chatKeys.pendingTask(payload.chat_session_id), {});
+      qc.setQueryData<ChatPendingTask>(
+        chatKeys.pendingTask(payload.chat_session_id),
+        (old) => removePendingChatTask(old, payload.task_id),
+      );
+      qc.invalidateQueries({ queryKey: chatKeys.pendingTask(payload.chat_session_id) });
       invalidateChatMessageQueries(qc, payload.chat_session_id);
       invalidatePendingAggregate();
     });
@@ -1306,12 +1309,11 @@ export function useRealtimeSync(
         task_id: payload.task_id,
         chat_session_id: payload.chat_session_id,
       });
-      // `chat:done` (broadcast immediately before this event in CompleteTask)
-      // already wrote the assistant message into the messages cache and
-      // cleared `chatKeys.pendingTask`. This event is now only responsible
-      // for refreshing the per-user cross-session aggregate that drives the
-      // FAB indicator — `chat:done` is per-session and doesn't carry that
-      // information.
+      qc.setQueryData<ChatPendingTask>(
+        chatKeys.pendingTask(payload.chat_session_id),
+        (old) => removePendingChatTask(old, payload.task_id),
+      );
+      qc.invalidateQueries({ queryKey: chatKeys.pendingTask(payload.chat_session_id) });
       invalidatePendingAggregate();
     });
 
@@ -1328,7 +1330,10 @@ export function useRealtimeSync(
       // failure bubble shows up without requiring a page refresh. Pre-#1823
       // this branch only flipped pending — the comment "No new message"
       // was true then, but FailTask now persists a row.
-      qc.setQueryData(chatKeys.pendingTask(payload.chat_session_id), {});
+      qc.setQueryData<ChatPendingTask>(
+        chatKeys.pendingTask(payload.chat_session_id),
+        (old) => removePendingChatTask(old, payload.task_id),
+      );
       invalidateChatMessageQueries(qc, payload.chat_session_id);
       qc.invalidateQueries({ queryKey: chatKeys.pendingTask(payload.chat_session_id) });
       invalidatePendingAggregate();

--- a/packages/core/types/chat.ts
+++ b/packages/core/types/chat.ts
@@ -125,6 +125,8 @@ export interface ChatMessagesPage {
 export interface SendChatMessageResponse {
   message_id: string;
   task_id: string;
+  /** True when the server supports queued follow-up sends. */
+  supports_queue?: boolean;
   /**
    * Server-authoritative task creation time. Optimistic StatusPill seed
    * uses this as its anchor so the timer starts from the real `0s` —
@@ -192,8 +194,29 @@ export interface ChatDraftRestoresResponse {
  * task_id/status only, then this query catches up with the real created_at
  * so the timer survives refresh / reopen without "resetting to 0s".
  */
+export interface ChatQueuedTask {
+  task_id: string;
+  status: string;
+  created_at: string;
+  message_id?: string;
+  content?: string;
+}
+
+export interface PrioritizeQueuedChatTaskResponse {
+  task_id: string;
+  /** Server-authoritative task to stop after the selected task is prioritized. */
+  active_task_id?: string;
+}
+
 export interface ChatPendingTask {
   task_id?: string;
   status?: string;
   created_at?: string;
+  /** Explicit capability gate; absent on servers predating follow-up queues. */
+  supports_queue?: boolean;
+  /**
+   * Ordered prompts that are still queued. When no task is active, the legacy
+   * root fields mirror the first entry for backward compatibility.
+   */
+  queued_tasks?: ChatQueuedTask[];
 }

--- a/packages/core/types/index.ts
+++ b/packages/core/types/index.ts
@@ -100,6 +100,8 @@ export type {
   ChatMessage,
   ChatMessagesPage,
   ChatPendingTask,
+  ChatQueuedTask,
+  PrioritizeQueuedChatTaskResponse,
   PendingChatTaskItem,
   PendingChatTasksResponse,
   HasPendingChatTasksResponse,

--- a/packages/ui/components/common/submit-button.tsx
+++ b/packages/ui/components/common/submit-button.tsx
@@ -24,6 +24,8 @@ interface SubmitButtonProps {
   busy?: boolean;
   running?: boolean;
   onStop?: () => void;
+  /** Keep a send control beside Stop so callers can enqueue follow-up work. */
+  allowSubmitWhileRunning?: boolean;
   /**
    * Tooltip shown over the send button when idle. Pass a string or a node
    * (e.g. `Send · ⌘↵`). Omit to render no tooltip.
@@ -46,11 +48,13 @@ function SubmitButton({
   busy,
   running,
   onStop,
+  allowSubmitWhileRunning,
   tooltip,
   ariaLabel,
   stopTooltip,
   stopAriaLabel,
 }: SubmitButtonProps) {
+  let stopControl: ReactNode = null;
   if (running) {
     const stopButton = (
       <Button
@@ -62,13 +66,13 @@ function SubmitButton({
         <Square className="fill-current" aria-hidden="true" />
       </Button>
     );
-    if (!stopTooltip) return stopButton;
-    return (
+    stopControl = stopTooltip ? (
       <Tooltip>
         <TooltipTrigger render={stopButton} />
         <TooltipContent side="top">{stopTooltip}</TooltipContent>
       </Tooltip>
-    );
+    ) : stopButton;
+    if (!allowSubmitWhileRunning) return stopControl;
   }
 
   const submitButton = (
@@ -77,7 +81,7 @@ function SubmitButton({
       className="rounded-full"
       disabled={disabled || loading || busy}
       aria-disabled={busy || undefined}
-      aria-busy={busy || undefined}
+      aria-busy={loading || busy || undefined}
       onClick={onClick}
       aria-label={ariaLabel}
     >
@@ -93,12 +97,20 @@ function SubmitButton({
       )}
     </Button>
   );
-  if (!tooltip) return submitButton;
+  const submitControl = !tooltip
+    ? submitButton
+    : (
+        <Tooltip>
+          <TooltipTrigger render={submitButton} />
+          <TooltipContent side="top">{tooltip}</TooltipContent>
+        </Tooltip>
+      );
+  if (!stopControl) return submitControl;
   return (
-    <Tooltip>
-      <TooltipTrigger render={submitButton} />
-      <TooltipContent side="top">{tooltip}</TooltipContent>
-    </Tooltip>
+    <>
+      {stopControl}
+      {submitControl}
+    </>
   );
 }
 

--- a/packages/views/chat/chat-page.tsx
+++ b/packages/views/chat/chat-page.tsx
@@ -19,6 +19,7 @@ import { useNavigation } from "../navigation";
 import { useT } from "../i18n";
 import { ChatMessageList, ChatMessageSkeleton } from "./components/chat-message-list";
 import { ChatInput } from "./components/chat-input";
+import { ChatQueue } from "./components/chat-queue";
 import { ChatThreadList } from "./components/chat-thread-list";
 import { ChatSessionHeader } from "./components/chat-session-header";
 import { EmptyState } from "./components/chat-empty-state";
@@ -259,6 +260,14 @@ export function ChatPage() {
         <OfflineBanner agentName={c.activeAgent?.name} availability={c.availability} />
       )}
 
+      <ChatQueue
+        tasks={c.pendingTask?.queued_tasks ?? []}
+        onSendNow={c.handleSendQueuedTaskNow}
+        onEdit={c.handleEditQueuedTask}
+        onRemove={c.handleRemoveQueuedTask}
+        onClear={c.handleClearQueuedTasks}
+      />
+
       <ChatInput
         onSend={c.handleSend}
         restoreDraftRequest={c.restoreDraftRequest}
@@ -266,6 +275,7 @@ export function ChatPage() {
         uploadEnabled={c.uploadEnabled}
         onStop={c.handleStop}
         isRunning={!!c.pendingTaskId}
+        allowSubmitWhileRunning={c.pendingTask?.supports_queue === true}
         disabled={c.isSessionArchived || c.isAgentArchived}
         noAgent={c.noAgent}
         agentArchived={c.isAgentArchived}

--- a/packages/views/chat/components/chat-input.test.tsx
+++ b/packages/views/chat/components/chat-input.test.tsx
@@ -593,6 +593,30 @@ describe("ChatInput project context", () => {
     expect(onProjectChange).toHaveBeenCalledWith(null);
   });
 
+  it("keeps Stop and Queue Send available while the agent is running", async () => {
+    const onSend = vi.fn<ChatInputOnSend>(async () => true);
+    const onStop = vi.fn();
+    renderInput({ isRunning: true, allowSubmitWhileRunning: true, onSend, onStop });
+
+    fireEvent.change(screen.getByTestId("editor"), {
+      target: { value: "follow-up" },
+    });
+
+    expect(screen.getByRole("button", { name: "Stop" })).toBeInTheDocument();
+    const queueButton = screen.getByRole("button", { name: "Queue message" });
+    expect(queueButton).not.toBeDisabled();
+    fireEvent.click(queueButton);
+
+    await waitFor(() => expect(onSend).toHaveBeenCalledTimes(1));
+  });
+
+  it("shows only Stop while an older server is running", () => {
+    renderInput({ isRunning: true, onStop: vi.fn() });
+
+    expect(screen.getByRole("button", { name: "Stop" })).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Queue message" })).not.toBeInTheDocument();
+  });
+
   it("locks the project control while a send is in flight so a mid-send switch cannot retarget the session", async () => {
     // A brand-new chat creates its session row lazily during send, bound to
     // the project selected at click time. If the user could switch project

--- a/packages/views/chat/components/chat-input.tsx
+++ b/packages/views/chat/components/chat-input.tsx
@@ -87,6 +87,8 @@ interface ChatInputProps {
   uploadEnabled?: boolean;
   onStop?: () => void;
   isRunning?: boolean;
+  /** Enabled only after the server explicitly advertises follow-up queues. */
+  allowSubmitWhileRunning?: boolean;
   disabled?: boolean;
   /** True when the user has no agent available — disables the editor and
    *  surfaces a distinct placeholder. Kept separate from `disabled` so
@@ -133,6 +135,7 @@ export function ChatInput({
   uploadEnabled: uploadAllowed,
   onStop,
   isRunning,
+  allowSubmitWhileRunning,
   disabled,
   noAgent,
   agentArchived,
@@ -429,8 +432,12 @@ export function ChatInput({
       editorScrubbedRef.current = false;
       // These states disable the SubmitButton, but Mod+Enter bypasses it — so a
       // read-only or busy composer must still refuse the keyboard path.
-      if (isRunning || disabled || noAgent) {
-        logger.debug("input.send skipped", { isRunning, disabled, noAgent });
+      if (disabled || noAgent || (isRunning && !allowSubmitWhileRunning)) {
+        logger.debug("input.send skipped", {
+          disabled,
+          noAgent,
+          runningWithoutQueueSupport: !!isRunning && !allowSubmitWhileRunning,
+        });
         return false;
       }
       // The editor is still holding a DIFFERENT draft's document than the one
@@ -673,13 +680,18 @@ export function ChatInput({
             busy={gate.uploading}
             running={isRunning}
             onStop={onStop}
+            allowSubmitWhileRunning={allowSubmitWhileRunning}
             tooltip={gate.uploading
               ? tEditor(($) => $.upload.in_progress)
-              : sendShortcut
-                ? `${t(($) => $.input.send_tooltip)} · ${formatShortcut(sendShortcut)}`
-                : t(($) => $.input.send_tooltip)}
+              : isRunning
+                ? t(($) => $.input.queue_send_tooltip)
+                : sendShortcut
+                  ? `${t(($) => $.input.send_tooltip)} · ${formatShortcut(sendShortcut)}`
+                  : t(($) => $.input.send_tooltip)}
             ariaLabel={gate.uploading
               ? tEditor(($) => $.upload.in_progress)
+              : isRunning
+                ? t(($) => $.input.queue_send_tooltip)
               : t(($) => $.input.send_tooltip)}
             stopTooltip={t(($) => $.input.stop_tooltip)}
             stopAriaLabel={t(($) => $.input.stop_tooltip)}

--- a/packages/views/chat/components/chat-queue.test.tsx
+++ b/packages/views/chat/components/chat-queue.test.tsx
@@ -1,0 +1,65 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { I18nProvider } from "@multica/core/i18n/react";
+import { describe, expect, it, vi } from "vitest";
+import enChat from "../../locales/en/chat.json";
+import { ChatQueue } from "./chat-queue";
+
+const TEST_RESOURCES = { en: { chat: enChat } };
+
+function renderQueue() {
+  const callbacks = {
+    onSendNow: vi.fn<(taskId: string) => Promise<void>>().mockResolvedValue(),
+    onEdit: vi.fn<(taskId: string) => Promise<void>>().mockResolvedValue(),
+    onRemove: vi.fn<(taskId: string) => Promise<void>>().mockResolvedValue(),
+    onClear: vi.fn<() => Promise<void>>().mockResolvedValue(),
+  };
+  render(
+    <I18nProvider locale="en" resources={TEST_RESOURCES}>
+      <ChatQueue
+        tasks={[
+          {
+            task_id: "task-2",
+            status: "queued",
+            content: "First follow-up",
+            created_at: "2026-07-01T00:01:00Z",
+          },
+          {
+            task_id: "task-3",
+            status: "queued",
+            content: "",
+            created_at: "2026-07-01T00:02:00Z",
+          },
+        ]}
+        {...callbacks}
+      />
+    </I18nProvider>,
+  );
+  return callbacks;
+}
+
+describe("ChatQueue", () => {
+  it("renders queued messages in order and falls back for empty content", () => {
+    renderQueue();
+
+    expect(screen.getByText("2 queued messages")).toBeInTheDocument();
+    expect(screen.getByText("First follow-up")).toBeInTheDocument();
+    expect(screen.getByText("Queued message")).toBeInTheDocument();
+    expect(screen.getAllByLabelText("Send now")).toHaveLength(2);
+    expect(screen.getAllByLabelText("Edit queued message")).toHaveLength(2);
+    expect(screen.getAllByLabelText("Remove queued message")).toHaveLength(2);
+    expect(screen.getByRole("button", { name: "Clear all" })).toBeInTheDocument();
+  });
+
+  it("runs send-now, edit, remove, and clear against the selected queue state", async () => {
+    const actions = renderQueue();
+
+    fireEvent.click(screen.getAllByLabelText("Send now")[1]!);
+    await waitFor(() => expect(actions.onSendNow).toHaveBeenCalledWith("task-3"));
+    fireEvent.click(screen.getAllByLabelText("Edit queued message")[0]!);
+    await waitFor(() => expect(actions.onEdit).toHaveBeenCalledWith("task-2"));
+    fireEvent.click(screen.getAllByLabelText("Remove queued message")[1]!);
+    await waitFor(() => expect(actions.onRemove).toHaveBeenCalledWith("task-3"));
+    fireEvent.click(screen.getByRole("button", { name: "Clear all" }));
+    await waitFor(() => expect(actions.onClear).toHaveBeenCalledTimes(1));
+  });
+});

--- a/packages/views/chat/components/chat-queue.tsx
+++ b/packages/views/chat/components/chat-queue.tsx
@@ -1,0 +1,119 @@
+"use client";
+
+import { useState } from "react";
+import { Loader2, Pencil, Send, X } from "lucide-react";
+import type { ChatQueuedTask } from "@multica/core/types";
+import { Button } from "@multica/ui/components/ui/button";
+import { useT } from "../../i18n";
+
+interface ChatQueueProps {
+  tasks: ChatQueuedTask[];
+  onSendNow: (taskId: string) => Promise<void> | void;
+  onEdit: (taskId: string) => Promise<void> | void;
+  onRemove: (taskId: string) => Promise<void> | void;
+  onClear: () => Promise<void> | void;
+}
+
+export function ChatQueue({ tasks, onSendNow, onEdit, onRemove, onClear }: ChatQueueProps) {
+  const { t } = useT("chat");
+  const [busyAction, setBusyAction] = useState<string | null>(null);
+
+  if (tasks.length === 0) return null;
+
+  const run = async (key: string, action: () => Promise<void> | void) => {
+    setBusyAction(key);
+    try {
+      await action();
+    } finally {
+      setBusyAction((current) => current === key ? null : current);
+    }
+  };
+
+  return (
+    <div
+      className="mx-3 mb-2 rounded-lg border bg-muted/30 p-2"
+      aria-live="polite"
+      aria-busy={busyAction !== null || undefined}
+    >
+      <div className="mb-1 flex items-center justify-between gap-2 px-1">
+        <span className="text-caption font-medium text-muted-foreground">
+          {t(($) => $.queue.title, { count: tasks.length })}
+        </span>
+        <Button
+          variant="ghost"
+          size="xs"
+          disabled={busyAction !== null}
+          onClick={() => void run("clear", onClear)}
+        >
+          {busyAction === "clear" && <Loader2 className="animate-spin" aria-hidden="true" />}
+          {t(($) => $.queue.clear)}
+        </Button>
+      </div>
+      <div className="max-h-40 space-y-0.5 overflow-y-auto">
+        {tasks.map((task, index) => {
+          const sendNowKey = `send-now:${task.task_id}`;
+          const editKey = `edit:${task.task_id}`;
+          const removeKey = `remove:${task.task_id}`;
+          return (
+            <div
+              key={task.task_id}
+              className="flex min-w-0 items-center gap-2 rounded-md px-1.5 py-1 text-body"
+            >
+              <span className="w-4 shrink-0 text-center text-caption tabular-nums text-muted-foreground">
+                {index + 1}
+              </span>
+              <span className="min-w-0 flex-1 truncate">
+                {task.content?.trim() || t(($) => $.queue.fallback)}
+              </span>
+              <Button
+                variant="ghost"
+                size="icon-xs"
+                className="shrink-0 text-muted-foreground"
+                disabled={busyAction !== null}
+                title={t(($) => $.queue.send_now)}
+                aria-label={t(($) => $.queue.send_now)}
+                onClick={() => void run(sendNowKey, () => onSendNow(task.task_id))}
+              >
+                {busyAction === sendNowKey ? (
+                  <Loader2 className="animate-spin" aria-hidden="true" />
+                ) : (
+                  <Send aria-hidden="true" />
+                )}
+              </Button>
+              <Button
+                variant="ghost"
+                size="icon-xs"
+                className="shrink-0 text-muted-foreground"
+                disabled={busyAction !== null}
+                title={t(($) => $.queue.edit)}
+                aria-label={t(($) => $.queue.edit)}
+                onClick={() => void run(editKey, () => onEdit(task.task_id))}
+              >
+                {busyAction === editKey ? (
+                  <Loader2 className="animate-spin" aria-hidden="true" />
+                ) : (
+                  <Pencil aria-hidden="true" />
+                )}
+              </Button>
+              <Button
+                variant="ghost"
+                size="icon-xs"
+                className="shrink-0 text-muted-foreground"
+                disabled={busyAction !== null}
+                title={t(($) => $.queue.remove)}
+                aria-label={t(($) => $.queue.remove)}
+                onClick={() => void run(removeKey, () => onRemove(task.task_id))}
+              >
+                {busyAction === removeKey ? (
+                  <Loader2 className="animate-spin" aria-hidden="true" />
+                ) : (
+                  <X aria-hidden="true" />
+                )}
+              </Button>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/packages/views/chat/components/chat-window.tsx
+++ b/packages/views/chat/components/chat-window.tsx
@@ -48,11 +48,17 @@ import {
   useUpdateChatSession,
 } from "@multica/core/chat/mutations";
 import { useChatStore } from "@multica/core/chat";
+import {
+  enqueuePendingChatTask,
+  hideQueuedChatMessages,
+} from "@multica/core/chat/pending";
 import { removeChatMessageFromCaches } from "@multica/core/realtime";
 import { useChatDraftRestore } from "./use-chat-draft-restore";
+import { useChatTaskActions } from "./use-chat-task-actions";
 import { useChatInputFocus } from "./use-chat-input-focus";
 import { ChatMessageList, ChatMessageSkeleton } from "./chat-message-list";
 import { ChatInput } from "./chat-input";
+import { ChatQueue } from "./chat-queue";
 import { ChatResizeHandles } from "./chat-resize-handles";
 import { useChatContextItems } from "./use-chat-context-items";
 import { useChatResize } from "./use-chat-resize";
@@ -138,24 +144,28 @@ export function ChatWindow() {
   // it starts from a large stable base and only subtracts the count of loaded
   // prepended rows, so concurrent server inserts cannot drift the scroll anchor.
   const messagePages = activeSessionId ? rawMessagePages?.pages ?? [] : [];
-  const messages = [...messagePages].reverse().flatMap((page) => page.messages);
-  const olderMessageCount = messagePages.slice(1).reduce((sum, page) => sum + page.messages.length, 0);
-  const firstItemIndex = messages.length > 0
-    ? CHAT_VIRTUOSO_INITIAL_FIRST_ITEM_INDEX - olderMessageCount
-    : 0;
+  const allMessages = [...messagePages].reverse().flatMap((page) => page.messages);
   // Skeleton only shows for an un-cached session fetch. Cached switches
   // return data synchronously — no flash. `enabled: false` (new chat)
   // keeps isLoading false so the starter prompts aren't hidden.
-  const showSkeleton = !!activeSessionId && messagesLoading;
-
   // Server-authoritative pending task. Survives refresh / reopen / session
   // switch because it's keyed on sessionId in the Query cache; WS events
   // (chat:message / chat:done / task:*) keep it invalidated in real time.
   //
   // This is the SOLE source for pendingTaskId — no mirror in the store.
-  const { data: pendingTask } = useQuery(
+  const { data: pendingTask, isLoading: pendingTaskLoading } = useQuery(
     pendingChatTaskOptions(activeSessionId ?? ""),
   );
+  const showSkeleton =
+    !!activeSessionId && (messagesLoading || pendingTaskLoading);
+  const messages = hideQueuedChatMessages(allMessages, pendingTask);
+  const olderMessageCount = messagePages.slice(1).reduce(
+    (sum, page) => sum + page.messages.length,
+    0,
+  );
+  const firstItemIndex = messages.length > 0
+    ? CHAT_VIRTUOSO_INITIAL_FIRST_ITEM_INDEX - olderMessageCount
+    : 0;
   const pendingTaskId = pendingTask?.task_id ?? null;
   const stopRequestedBeforeTaskRef = useRef(false);
   // Durable deferred-cancellation draft restores (#5219). Same hook as the chat
@@ -172,6 +182,13 @@ export function ChatWindow() {
   const appForeground = useAppForeground();
   const { restoreDraftRequest, enqueueLocalRestore, handleRestoreDraftApplied } =
     useChatDraftRestore(activeSessionId, isOpen && appForeground);
+  const {
+    cancelChatTask,
+    handleEditQueuedTask,
+    handleRemoveQueuedTask,
+    handleClearQueuedTasks,
+    handleSendQueuedTaskNow,
+  } = useChatTaskActions(activeSessionId, enqueueLocalRestore);
   // Nonce handed to ChatInput to pull focus into the compose box: when a new
   // chat starts (⊕ or switching agent), and whenever the window itself opens.
   const { focusRequest, requestInputFocus } = useChatInputFocus(isOpen);
@@ -378,55 +395,6 @@ export function ChatWindow() {
   // remain workspace-scoped drafts — sending is still the point where a
   // session is created (if needed) and attachment_ids bind to the message.
 
-  const cancelChatTask = useCallback(
-    async (
-      taskId: string,
-      sessionId: string,
-      options: { restoreDraftToInput: boolean; source: string },
-    ) => {
-      apiLogger.info("cancelTask.start", {
-        taskId,
-        sessionId,
-        source: options.source,
-      });
-      qc.setQueryData(chatKeys.pendingTask(sessionId), {});
-
-      try {
-        const result = await api.cancelTaskById(taskId);
-        const restored = result.cancelled_chat_message;
-        if (restored?.restore_to_input) {
-          removeChatMessageFromCaches(qc, restored.chat_session_id, restored.message_id);
-          if (options.restoreDraftToInput && restored.chat_session_id === sessionId) {
-            enqueueLocalRestore({
-              id: restored.message_id,
-              content: restored.content,
-              attachments: restored.attachments,
-              sessionId: restored.chat_session_id,
-            });
-          }
-        }
-        qc.invalidateQueries({ queryKey: chatKeys.messages(sessionId) });
-        qc.invalidateQueries({ queryKey: chatKeys.messagesPage(sessionId) });
-        apiLogger.info("cancelTask.success", {
-          taskId,
-          sessionId,
-          restoredToInput: !!restored?.restore_to_input && options.restoreDraftToInput,
-        });
-        return result;
-      } catch (err) {
-        apiLogger.warn("cancelTask.error (task may have already finished)", {
-          taskId,
-          sessionId,
-          err,
-        });
-        qc.invalidateQueries({ queryKey: chatKeys.messages(sessionId) });
-        qc.invalidateQueries({ queryKey: chatKeys.messagesPage(sessionId) });
-        return null;
-      }
-    },
-    [qc, enqueueLocalRestore],
-  );
-
   const handleSend = useCallback(
     async (
       content: string,
@@ -445,6 +413,12 @@ export function ChatWindow() {
         apiLogger.warn("sendChatMessage skipped: agent is archived", {
           sessionId: activeSessionId,
           agentId: activeAgent.id,
+        });
+        return false;
+      }
+      if (pendingTaskId && pendingTask?.supports_queue !== true) {
+        apiLogger.warn("sendChatMessage skipped: server does not support follow-up queues", {
+          sessionId: activeSessionId,
         });
         return false;
       }
@@ -518,11 +492,22 @@ export function ChatWindow() {
         chatKeys.messages(sessionId),
         (old) => (old ? [...old, sent] : [sent]),
       );
-      qc.setQueryData<ChatPendingTask>(chatKeys.pendingTask(sessionId), {
-        task_id: result.task_id,
-        status: "queued",
-        created_at: result.created_at,
-      });
+      qc.setQueryData<ChatPendingTask>(
+        chatKeys.pendingTask(sessionId),
+        (old) => {
+          const next = enqueuePendingChatTask(old, {
+            task_id: result.task_id,
+            status: "queued",
+            created_at: result.created_at,
+            message_id: result.message_id,
+            content: finalContent,
+          });
+          if (result.supports_queue === true || old?.supports_queue === true) {
+            next.supports_queue = true;
+          }
+          return next;
+        },
+      );
       // Cache primed → publish the new active session, but only if the user
       // hasn't navigated away mid-send. Compare the live store against the
       // closure-captured target; see isStillOnComposeTarget for the rule, which
@@ -568,6 +553,8 @@ export function ChatWindow() {
       activeSessionId,
       activeAgent,
       isAgentArchived,
+      pendingTask,
+      pendingTaskId,
       ensureSession,
       cancelChatTask,
       qc,
@@ -855,6 +842,14 @@ export function ChatWindow() {
         <OfflineBanner agentName={activeAgent?.name} availability={availability} />
       )}
 
+      <ChatQueue
+        tasks={pendingTask?.queued_tasks ?? []}
+        onSendNow={handleSendQueuedTaskNow}
+        onEdit={handleEditQueuedTask}
+        onRemove={handleRemoveQueuedTask}
+        onClear={handleClearQueuedTasks}
+      />
+
       {/* Input — disabled for legacy archived sessions and for sessions whose
        *  agent has been archived (read-only); locked out entirely when there's
        *  no agent (the EmptyState above carries the CTA). */}
@@ -865,6 +860,7 @@ export function ChatWindow() {
         uploadEnabled={!!activeAgent}
         onStop={handleStop}
         isRunning={!!pendingTaskId}
+        allowSubmitWhileRunning={pendingTask?.supports_queue === true}
         disabled={isSessionArchived || isAgentArchived}
         noAgent={noAgent}
         agentArchived={isAgentArchived}

--- a/packages/views/chat/components/use-chat-controller.test.tsx
+++ b/packages/views/chat/components/use-chat-controller.test.tsx
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { act, renderHook } from "@testing-library/react";
-import type { Agent, ChatSession, Project } from "@multica/core/types";
+import type { Agent, ChatPendingTask, ChatSession, Project } from "@multica/core/types";
 
 interface QueuedRestore {
   id: string;
@@ -53,8 +53,15 @@ const h = vi.hoisted(() => {
       store.pendingSendRestores = next;
     }),
   };
+  const queryClient = {
+    getQueryData: vi.fn(),
+    setQueryData: vi.fn(),
+    invalidateQueries: vi.fn(),
+    cancelQueries: vi.fn(),
+  };
   return {
     store,
+    queryClient,
     archivedMutate: vi.fn(),
     markReadMutate: vi.fn(),
     // Stable across renders so tests can assert on it; lazy-creates the session
@@ -69,6 +76,7 @@ const h = vi.hoisted(() => {
     sessions: [] as ChatSession[],
     agents: [] as Agent[],
     projects: [] as Project[],
+    pendingTask: null as ChatPendingTask | null,
     draftRestores: null as
       | { restores: { id: string; chat_session_id: string; content: string }[] }
       | null,
@@ -89,7 +97,12 @@ vi.mock("@multica/core/projects/queries", () => ({
 }));
 vi.mock("@multica/views/issues/components", () => ({ canAssignAgent: () => true }));
 vi.mock("@multica/core/api", () => ({
-  api: { sendChatMessage: vi.fn(), cancelTaskById: vi.fn() },
+  api: {
+    sendChatMessage: vi.fn(),
+    cancelTaskById: vi.fn(),
+    clearQueuedChatTasks: vi.fn(),
+    prioritizeQueuedChatTask: vi.fn(),
+  },
   // Names the 403 that a revoked invoke permission raises (MUL-4525); plain
   // failures have no reason code.
   dispatchReasonCode: () => undefined,
@@ -141,6 +154,7 @@ vi.mock("@tanstack/react-query", async (importOriginal) => {
       }
       if (key.includes("sessions")) return { data: h.sessions, isSuccess: true };
       if (key.includes("projects")) return { data: h.projects, isSuccess: true };
+      if (key.includes("pending-task")) return { data: h.pendingTask };
       if (key.includes("draft-restores")) return { data: h.draftRestores };
       return { data: null };
     },
@@ -151,11 +165,7 @@ vi.mock("@tanstack/react-query", async (importOriginal) => {
       hasNextPage: false,
       isFetchingNextPage: false,
     }),
-    useQueryClient: () => ({
-      getQueryData: vi.fn(),
-      setQueryData: vi.fn(),
-      invalidateQueries: vi.fn(),
-    }),
+    useQueryClient: () => h.queryClient,
   };
 });
 
@@ -189,13 +199,19 @@ const sA = makeSession({ id: "sA", agent_id: "agent-a", updated_at: "2026-07-08T
 const sB = makeSession({ id: "sB", agent_id: "agent-b", updated_at: "2026-07-08T02:00:00Z" });
 const sC = makeSession({ id: "sC", agent_id: "agent-a", updated_at: "2026-07-08T01:00:00Z" });
 
-function setup(activeSessionId: string | null, sessions: ChatSession[], agents: Agent[]) {
+function setup(
+  activeSessionId: string | null,
+  sessions: ChatSession[],
+  agents: Agent[],
+  pendingTask: ChatPendingTask | null = null,
+) {
   h.store.activeSessionId = activeSessionId;
   h.store.selectedAgentId = null;
   h.store.selectedProjectId = null;
   h.sessions = sessions;
   h.agents = agents;
   h.projects = [];
+  h.pendingTask = pendingTask;
   const { result } = renderHook(() => useChatController());
   // Ignore any render-time store writes (self-heal etc.); we assert only the
   // effect of the call under test.
@@ -478,6 +494,168 @@ describe("useChatController.archiveSession", () => {
     act(() => result.current.archiveSession("sA"));
 
     expect(h.archivedMutate).toHaveBeenCalledWith({ sessionId: "sA", archived: true });
+  });
+});
+
+describe("useChatController queued task actions", () => {
+  beforeEach(() => {
+    vi.mocked(api.cancelTaskById).mockReset();
+    vi.mocked(api.clearQueuedChatTasks).mockReset();
+    vi.mocked(api.prioritizeQueuedChatTask).mockReset();
+    h.removeFromCaches.mockClear();
+    h.store.enqueuePendingSendRestore.mockClear();
+    h.store.pendingSendRestores = {};
+    h.queryClient.getQueryData.mockReset();
+    h.queryClient.setQueryData.mockReset();
+    h.queryClient.invalidateQueries.mockReset();
+    h.queryClient.cancelQueries.mockReset();
+  });
+
+  it("returns a cancelled queued prompt to the current composer", async () => {
+    vi.mocked(api.cancelTaskById).mockResolvedValue({
+      id: "task-queued",
+      cancelled_chat_message: {
+        chat_session_id: "sA",
+        message_id: "message-queued",
+        content: "Revise this follow-up",
+        restore_to_input: true,
+        attachments: [],
+      },
+    } as Awaited<ReturnType<typeof api.cancelTaskById>>);
+    const result = setup("sA", [sA], [agentA]);
+
+    await act(async () => {
+      await result.current.handleEditQueuedTask("task-queued");
+    });
+
+    expect(api.cancelTaskById).toHaveBeenCalledWith("task-queued", {
+      queuedOnly: true,
+      sessionId: "sA",
+    });
+    expect(h.removeFromCaches).toHaveBeenCalledWith(
+      expect.anything(),
+      "sA",
+      "message-queued",
+    );
+    expect(h.store.enqueuePendingSendRestore).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: "message-queued",
+        content: "Revise this follow-up",
+        sessionId: "sA",
+      }),
+    );
+  });
+
+  it("removes a queued prompt without restoring it", async () => {
+    vi.mocked(api.cancelTaskById).mockResolvedValue({
+      id: "task-queued",
+      cancelled_chat_message: {
+        chat_session_id: "sA",
+        message_id: "message-queued",
+        content: "Discard this follow-up",
+        restore_to_input: true,
+        attachments: [],
+      },
+    } as Awaited<ReturnType<typeof api.cancelTaskById>>);
+    const result = setup("sA", [sA], [agentA]);
+
+    await act(async () => {
+      await result.current.handleRemoveQueuedTask("task-queued");
+    });
+
+    expect(h.removeFromCaches).toHaveBeenCalled();
+    expect(h.store.enqueuePendingSendRestore).not.toHaveBeenCalled();
+  });
+
+  it("restores the pending snapshot when queued-only cancellation loses a race", async () => {
+    const pending: ChatPendingTask = {
+      task_id: "task-active",
+      status: "running",
+      queued_tasks: [
+        { task_id: "task-queued", status: "queued", created_at: "2026-07-01T00:00:01Z" },
+      ],
+    };
+    h.queryClient.getQueryData.mockReturnValue(pending);
+    vi.mocked(api.cancelTaskById).mockRejectedValue(new Error("task is no longer queued"));
+    const result = setup("sA", [sA], [agentA], pending);
+
+    await act(async () => {
+      await result.current.handleRemoveQueuedTask("task-queued");
+    });
+
+    expect(h.queryClient.setQueryData).toHaveBeenLastCalledWith(
+      expect.anything(),
+      pending,
+    );
+  });
+
+  it("clears the queue with one session-scoped request", async () => {
+    vi.mocked(api.clearQueuedChatTasks).mockResolvedValue();
+    const pending: ChatPendingTask = {
+      task_id: "task-active",
+      status: "running",
+      queued_tasks: [
+        {
+          task_id: "task-1",
+          status: "queued",
+          created_at: "2026-07-01T00:00:01Z",
+          message_id: "message-1",
+        },
+        {
+          task_id: "task-2",
+          status: "queued",
+          created_at: "2026-07-01T00:00:02Z",
+          message_id: "message-2",
+        },
+      ],
+    };
+    h.queryClient.getQueryData.mockReturnValue(pending);
+    const result = setup("sA", [sA], [agentA], pending);
+
+    await act(async () => {
+      await result.current.handleClearQueuedTasks();
+    });
+
+    expect(api.clearQueuedChatTasks).toHaveBeenCalledTimes(1);
+    expect(api.clearQueuedChatTasks).toHaveBeenCalledWith("sA");
+    expect(api.cancelTaskById).not.toHaveBeenCalled();
+    expect(h.removeFromCaches).toHaveBeenCalledWith(
+      expect.anything(),
+      "sA",
+      "message-1",
+    );
+    expect(h.removeFromCaches).toHaveBeenCalledWith(
+      expect.anything(),
+      "sA",
+      "message-2",
+    );
+  });
+
+  it("prioritizes send-now before stopping the active task", async () => {
+    vi.mocked(api.prioritizeQueuedChatTask).mockResolvedValue({
+      task_id: "task-queued",
+      active_task_id: "task-active",
+    });
+    vi.mocked(api.cancelTaskById).mockResolvedValue({
+      id: "task-active",
+    } as Awaited<ReturnType<typeof api.cancelTaskById>>);
+    const result = setup("sA", [sA], [agentA], {
+      task_id: "task-active",
+      status: "running",
+      queued_tasks: [
+        { task_id: "task-queued", status: "queued", created_at: "2026-07-01T00:00:01Z" },
+      ],
+    });
+
+    await act(async () => {
+      await result.current.handleSendQueuedTaskNow("task-queued");
+    });
+
+    expect(api.prioritizeQueuedChatTask).toHaveBeenCalledWith("sA", "task-queued");
+    expect(api.cancelTaskById).toHaveBeenCalledWith("task-active", undefined);
+    expect(
+      vi.mocked(api.prioritizeQueuedChatTask).mock.invocationCallOrder[0],
+    ).toBeLessThan(vi.mocked(api.cancelTaskById).mock.invocationCallOrder[0]!);
   });
 });
 

--- a/packages/views/chat/components/use-chat-controller.ts
+++ b/packages/views/chat/components/use-chat-controller.ts
@@ -30,8 +30,12 @@ import {
   useSetChatSessionArchived,
 } from "@multica/core/chat/mutations";
 import { useChatStore } from "@multica/core/chat";
-import { removeChatMessageFromCaches } from "@multica/core/realtime";
+import {
+  enqueuePendingChatTask,
+  hideQueuedChatMessages,
+} from "@multica/core/chat/pending";
 import { useChatDraftRestore } from "./use-chat-draft-restore";
+import { useChatTaskActions } from "./use-chat-task-actions";
 import { useChatProjectContextSupport } from "./use-chat-project-context-support";
 import { createLogger } from "@multica/core/logger";
 import type {
@@ -225,7 +229,14 @@ export function useChatController(opts?: { isActive?: boolean }) {
   } = useInfiniteQuery(chatMessagesPageOptions(activeSessionId ?? ""));
 
   const messagePages = activeSessionId ? rawMessagePages?.pages ?? [] : [];
-  const messages = [...messagePages].reverse().flatMap((page) => page.messages);
+  const allMessages = [...messagePages].reverse().flatMap((page) => page.messages);
+
+  const { data: pendingTask, isLoading: pendingTaskLoading } = useQuery(
+    pendingChatTaskOptions(activeSessionId ?? ""),
+  );
+  const showSkeleton =
+    !!activeSessionId && (messagesLoading || pendingTaskLoading);
+  const messages = hideQueuedChatMessages(allMessages, pendingTask);
   const olderMessageCount = messagePages
     .slice(1)
     .reduce((sum, page) => sum + page.messages.length, 0);
@@ -233,11 +244,6 @@ export function useChatController(opts?: { isActive?: boolean }) {
     messages.length > 0
       ? CHAT_VIRTUOSO_INITIAL_FIRST_ITEM_INDEX - olderMessageCount
       : 0;
-  const showSkeleton = !!activeSessionId && messagesLoading;
-
-  const { data: pendingTask } = useQuery(
-    pendingChatTaskOptions(activeSessionId ?? ""),
-  );
   const pendingTaskId = pendingTask?.task_id ?? null;
   const stopRequestedBeforeTaskRef = useRef(false);
   // Durable deferred-cancellation draft restores (#5219). The whole lifecycle —
@@ -252,6 +258,13 @@ export function useChatController(opts?: { isActive?: boolean }) {
   const appForeground = useAppForeground();
   const { restoreDraftRequest, enqueueLocalRestore, handleRestoreDraftApplied } =
     useChatDraftRestore(activeSessionId, isActive && appForeground);
+  const {
+    cancelChatTask,
+    handleEditQueuedTask,
+    handleRemoveQueuedTask,
+    handleClearQueuedTasks,
+    handleSendQueuedTaskNow,
+  } = useChatTaskActions(activeSessionId, enqueueLocalRestore);
   // Nonce handed to ChatInput to pull focus into the compose box when a new
   // chat starts. Bumped by handleNewChat / handleStartNewChat only, so
   // selecting an existing chat or a deep link never steals focus.
@@ -430,55 +443,6 @@ export function useChatController(opts?: { isActive?: boolean }) {
   // (MUL-5181 L2); surfaces only forward whether the affordance exists.
   const uploadEnabled = !!activeAgent;
 
-  const cancelChatTask = useCallback(
-    async (
-      taskId: string,
-      sessionId: string,
-      options: { restoreDraftToInput: boolean; source: string },
-    ) => {
-      apiLogger.info("cancelTask.start", {
-        taskId,
-        sessionId,
-        source: options.source,
-      });
-      qc.setQueryData(chatKeys.pendingTask(sessionId), {});
-
-      try {
-        const result = await api.cancelTaskById(taskId);
-        const restored = result.cancelled_chat_message;
-        if (restored?.restore_to_input) {
-          removeChatMessageFromCaches(qc, restored.chat_session_id, restored.message_id);
-          if (options.restoreDraftToInput && restored.chat_session_id === sessionId) {
-            enqueueLocalRestore({
-              id: restored.message_id,
-              content: restored.content,
-              attachments: restored.attachments,
-              sessionId: restored.chat_session_id,
-            });
-          }
-        }
-        qc.invalidateQueries({ queryKey: chatKeys.messages(sessionId) });
-        qc.invalidateQueries({ queryKey: chatKeys.messagesPage(sessionId) });
-        apiLogger.info("cancelTask.success", {
-          taskId,
-          sessionId,
-          restoredToInput: !!restored?.restore_to_input && options.restoreDraftToInput,
-        });
-        return result;
-      } catch (err) {
-        apiLogger.warn("cancelTask.error (task may have already finished)", {
-          taskId,
-          sessionId,
-          err,
-        });
-        qc.invalidateQueries({ queryKey: chatKeys.messages(sessionId) });
-        qc.invalidateQueries({ queryKey: chatKeys.messagesPage(sessionId) });
-        return null;
-      }
-    },
-    [qc, enqueueLocalRestore],
-  );
-
   const handleSend = useCallback(
     async (
       content: string,
@@ -497,6 +461,12 @@ export function useChatController(opts?: { isActive?: boolean }) {
         apiLogger.warn("sendChatMessage skipped: agent is archived", {
           sessionId: activeSessionId,
           agentId: activeAgent.id,
+        });
+        return false;
+      }
+      if (pendingTaskId && pendingTask?.supports_queue !== true) {
+        apiLogger.warn("sendChatMessage skipped: server does not support follow-up queues", {
+          sessionId: activeSessionId,
         });
         return false;
       }
@@ -580,11 +550,22 @@ export function useChatController(opts?: { isActive?: boolean }) {
         chatKeys.messages(sessionId),
         (old) => (old ? [...old, sent] : [sent]),
       );
-      qc.setQueryData<ChatPendingTask>(chatKeys.pendingTask(sessionId), {
-        task_id: result.task_id,
-        status: "queued",
-        created_at: result.created_at,
-      });
+      qc.setQueryData<ChatPendingTask>(
+        chatKeys.pendingTask(sessionId),
+        (old) => {
+          const next = enqueuePendingChatTask(old, {
+            task_id: result.task_id,
+            status: "queued",
+            created_at: result.created_at,
+            message_id: result.message_id,
+            content: finalContent,
+          });
+          if (result.supports_queue === true || old?.supports_queue === true) {
+            next.supports_queue = true;
+          }
+          return next;
+        },
+      );
       // Cache primed → publish the new active session, but only if the user
       // hasn't navigated away mid-send. See isStillOnComposeTarget. commitInput
       // clears the sent draft, and scrubs the shared editor only when the user
@@ -624,6 +605,8 @@ export function useChatController(opts?: { isActive?: boolean }) {
       activeSessionId,
       activeAgent,
       isAgentArchived,
+      pendingTask,
+      pendingTaskId,
       ensureSession,
       cancelChatTask,
       qc,
@@ -820,6 +803,10 @@ export function useChatController(opts?: { isActive?: boolean }) {
     // actions
     handleSend,
     handleStop,
+    handleSendQueuedTaskNow,
+    handleEditQueuedTask,
+    handleRemoveQueuedTask,
+    handleClearQueuedTasks,
     uploadEnabled,
     handleNewChat,
     handleStartNewChat,

--- a/packages/views/chat/components/use-chat-task-actions.ts
+++ b/packages/views/chat/components/use-chat-task-actions.ts
@@ -1,0 +1,203 @@
+"use client";
+
+import { useCallback } from "react";
+import { useQueryClient } from "@tanstack/react-query";
+import { toast } from "sonner";
+import { api } from "@multica/core/api";
+import { useWorkspaceId } from "@multica/core/hooks";
+import { chatKeys } from "@multica/core/chat/queries";
+import {
+  prioritizePendingChatTask,
+  removePendingChatTask,
+} from "@multica/core/chat/pending";
+import { removeChatMessageFromCaches } from "@multica/core/realtime";
+import { createLogger } from "@multica/core/logger";
+import type {
+  Attachment,
+  CancelTaskResponse,
+  ChatPendingTask,
+} from "@multica/core/types";
+import { useT } from "../../i18n";
+
+const apiLogger = createLogger("chat.api");
+
+type EnqueueLocalRestore = (restore: {
+  id: string;
+  content: string;
+  attachments?: Attachment[];
+  sessionId: string;
+}) => void;
+
+type CancelOptions = {
+  restoreDraftToInput: boolean;
+  source: string;
+  queuedOnly?: boolean;
+};
+
+export function useChatTaskActions(
+  activeSessionId: string | null,
+  enqueueLocalRestore: EnqueueLocalRestore,
+) {
+  const { t } = useT("chat");
+  const wsId = useWorkspaceId();
+  const qc = useQueryClient();
+
+  const cancelChatTask = useCallback(
+    async (
+      taskId: string,
+      sessionId: string,
+      options: CancelOptions,
+    ): Promise<CancelTaskResponse | null> => {
+      apiLogger.info("cancelTask.start", {
+        taskId,
+        sessionId,
+        source: options.source,
+      });
+      const pendingKey = chatKeys.pendingTask(sessionId);
+      await qc.cancelQueries({ queryKey: pendingKey });
+      const pendingSnapshot = qc.getQueryData<ChatPendingTask>(pendingKey);
+      qc.setQueryData<ChatPendingTask>(
+        pendingKey,
+        (old) => removePendingChatTask(old, taskId),
+      );
+
+      try {
+        const result = await api.cancelTaskById(
+          taskId,
+          options.queuedOnly ? { queuedOnly: true, sessionId } : undefined,
+        );
+        const restored = result.cancelled_chat_message;
+        if (restored?.restore_to_input) {
+          removeChatMessageFromCaches(qc, restored.chat_session_id, restored.message_id);
+          if (options.restoreDraftToInput && restored.chat_session_id === sessionId) {
+            enqueueLocalRestore({
+              id: restored.message_id,
+              content: restored.content,
+              attachments: restored.attachments,
+              sessionId: restored.chat_session_id,
+            });
+          }
+        }
+        qc.invalidateQueries({ queryKey: chatKeys.messages(sessionId) });
+        qc.invalidateQueries({ queryKey: chatKeys.messagesPage(sessionId) });
+        apiLogger.info("cancelTask.success", {
+          taskId,
+          sessionId,
+          restoredToInput: !!restored?.restore_to_input && options.restoreDraftToInput,
+        });
+        return result;
+      } catch (err) {
+        qc.setQueryData(pendingKey, pendingSnapshot);
+        apiLogger.warn("cancelTask.error (task may have already finished)", {
+          taskId,
+          sessionId,
+          err,
+        });
+        qc.invalidateQueries({ queryKey: chatKeys.messages(sessionId) });
+        qc.invalidateQueries({ queryKey: chatKeys.messagesPage(sessionId) });
+        return null;
+      } finally {
+        qc.invalidateQueries({ queryKey: pendingKey });
+        if (wsId) qc.invalidateQueries({ queryKey: chatKeys.pendingTasks(wsId) });
+      }
+    },
+    [qc, enqueueLocalRestore, wsId],
+  );
+
+  const handleEditQueuedTask = useCallback(
+    async (taskId: string) => {
+      if (!activeSessionId) return;
+      const result = await cancelChatTask(taskId, activeSessionId, {
+        restoreDraftToInput: true,
+        source: "queued-message-edit",
+        queuedOnly: true,
+      });
+      if (!result) toast.error(t(($) => $.queue.action_failed_toast));
+    },
+    [activeSessionId, cancelChatTask, t],
+  );
+
+  const handleRemoveQueuedTask = useCallback(
+    async (taskId: string) => {
+      if (!activeSessionId) return;
+      const result = await cancelChatTask(taskId, activeSessionId, {
+        restoreDraftToInput: false,
+        source: "queued-message-remove",
+        queuedOnly: true,
+      });
+      if (!result) toast.error(t(($) => $.queue.action_failed_toast));
+    },
+    [activeSessionId, cancelChatTask, t],
+  );
+
+  const handleClearQueuedTasks = useCallback(async () => {
+    if (!activeSessionId) return;
+    const pendingKey = chatKeys.pendingTask(activeSessionId);
+    await qc.cancelQueries({ queryKey: pendingKey });
+    try {
+      await api.clearQueuedChatTasks(activeSessionId);
+      const pending = qc.getQueryData<ChatPendingTask>(pendingKey);
+      for (const task of pending?.queued_tasks ?? []) {
+        if (task.message_id) {
+          removeChatMessageFromCaches(qc, activeSessionId, task.message_id);
+        }
+      }
+      qc.setQueryData<ChatPendingTask>(pendingKey, (old) =>
+        (old?.queued_tasks ?? []).reduce<ChatPendingTask | undefined>(
+          (current, task) => removePendingChatTask(current, task.task_id),
+          old,
+        )
+      );
+      qc.invalidateQueries({ queryKey: chatKeys.messages(activeSessionId) });
+      qc.invalidateQueries({ queryKey: chatKeys.messagesPage(activeSessionId) });
+    } catch (err) {
+      apiLogger.warn("clearQueuedTasks.error", {
+        sessionId: activeSessionId,
+        err,
+      });
+      toast.error(t(($) => $.queue.action_failed_toast));
+    } finally {
+      qc.invalidateQueries({ queryKey: pendingKey });
+      if (wsId) qc.invalidateQueries({ queryKey: chatKeys.pendingTasks(wsId) });
+    }
+  }, [activeSessionId, qc, t, wsId]);
+
+  const handleSendQueuedTaskNow = useCallback(
+    async (taskId: string) => {
+      if (!activeSessionId) return;
+      qc.setQueryData<ChatPendingTask>(
+        chatKeys.pendingTask(activeSessionId),
+        (old) => prioritizePendingChatTask(old, taskId),
+      );
+      try {
+        const result = await api.prioritizeQueuedChatTask(activeSessionId, taskId);
+        if (result.task_id !== taskId) throw new Error("invalid prioritize response");
+        if (result.active_task_id) {
+          const cancelled = await cancelChatTask(result.active_task_id, activeSessionId, {
+            restoreDraftToInput: true,
+            source: "queued-message-send-now",
+          });
+          if (!cancelled) throw new Error("current task could not be stopped");
+        }
+      } catch (err) {
+        apiLogger.warn("sendQueuedTaskNow.error", {
+          taskId,
+          sessionId: activeSessionId,
+          err,
+        });
+        toast.error(t(($) => $.queue.action_failed_toast));
+      } finally {
+        qc.invalidateQueries({ queryKey: chatKeys.pendingTask(activeSessionId) });
+      }
+    },
+    [activeSessionId, cancelChatTask, qc, t],
+  );
+
+  return {
+    cancelChatTask,
+    handleEditQueuedTask,
+    handleRemoveQueuedTask,
+    handleClearQueuedTasks,
+    handleSendQueuedTaskNow,
+  };
+}

--- a/packages/views/locales/en/chat.json
+++ b/packages/views/locales/en/chat.json
@@ -17,6 +17,7 @@
     "placeholder_named": "Message {{name}}…",
     "placeholder_default": "Start a message…",
     "send_tooltip": "Send",
+    "queue_send_tooltip": "Queue message",
     "stop_tooltip": "Stop",
     "send_failed_toast": "Failed to send message",
     "send_blocked_toast": "Message not sent — you no longer have permission to use this agent",
@@ -28,6 +29,16 @@
     "remove_project_context": "Remove project context",
     "no_projects": "No projects yet",
     "project_context_unsupported": "Project description won't apply — this agent's daemon needs an upgrade"
+  },
+  "queue": {
+    "title_one": "{{count}} queued message",
+    "title_other": "{{count}} queued messages",
+    "clear": "Clear all",
+    "send_now": "Send now",
+    "edit": "Edit queued message",
+    "remove": "Remove queued message",
+    "fallback": "Queued message",
+    "action_failed_toast": "Couldn't update the queued message"
   },
   "message_list": {
     "show_details": "Show details",

--- a/packages/views/locales/ja/chat.json
+++ b/packages/views/locales/ja/chat.json
@@ -16,6 +16,7 @@
     "placeholder_named": "{{name}} にメッセージ…",
     "placeholder_default": "メッセージを入力…",
     "send_tooltip": "送信",
+    "queue_send_tooltip": "キューに追加",
     "stop_tooltip": "停止",
     "send_failed_toast": "メッセージを送信できませんでした",
     "send_blocked_toast": "メッセージは送信されませんでした — このエージェントを使用する権限がありません",
@@ -27,6 +28,15 @@
     "remove_project_context": "プロジェクトコンテキストを削除",
     "no_projects": "プロジェクトがまだありません",
     "project_context_unsupported": "プロジェクトの説明は適用されません——このエージェントのデーモンのアップグレードが必要です"
+  },
+  "queue": {
+    "title_other": "キュー内のメッセージ {{count}} 件",
+    "clear": "すべて削除",
+    "send_now": "今すぐ送信",
+    "edit": "キュー内のメッセージを編集",
+    "remove": "キューから削除",
+    "fallback": "キュー内のメッセージ",
+    "action_failed_toast": "キュー内のメッセージを更新できませんでした"
   },
   "message_list": {
     "show_details": "詳細を表示",

--- a/packages/views/locales/ko/chat.json
+++ b/packages/views/locales/ko/chat.json
@@ -16,6 +16,7 @@
     "placeholder_named": "{{name}}에게 메시지 보내기…",
     "placeholder_default": "메시지 입력…",
     "send_tooltip": "보내기",
+    "queue_send_tooltip": "대기열에 추가",
     "stop_tooltip": "중지",
     "send_failed_toast": "메시지를 보내지 못했습니다",
     "send_blocked_toast": "메시지가 전송되지 않았습니다 — 이 에이전트를 사용할 권한이 없습니다",
@@ -27,6 +28,15 @@
     "remove_project_context": "프로젝트 컨텍스트 제거",
     "no_projects": "아직 프로젝트가 없습니다",
     "project_context_unsupported": "프로젝트 설명이 적용되지 않습니다 — 이 에이전트의 데몬 업그레이드가 필요합니다"
+  },
+  "queue": {
+    "title_other": "대기 중인 메시지 {{count}}개",
+    "clear": "모두 지우기",
+    "send_now": "지금 보내기",
+    "edit": "대기 중인 메시지 편집",
+    "remove": "대기열에서 삭제",
+    "fallback": "대기 중인 메시지",
+    "action_failed_toast": "대기 중인 메시지를 업데이트하지 못했습니다"
   },
   "message_list": {
     "show_details": "세부 정보 보기",

--- a/packages/views/locales/zh-Hans/chat.json
+++ b/packages/views/locales/zh-Hans/chat.json
@@ -16,6 +16,7 @@
     "placeholder_named": "给 {{name}} 发消息…",
     "placeholder_default": "输入消息…",
     "send_tooltip": "发送",
+    "queue_send_tooltip": "排队发送",
     "stop_tooltip": "停止",
     "send_failed_toast": "发送消息失败",
     "send_blocked_toast": "消息未发送——你已没有该智能体的使用权限",
@@ -27,6 +28,15 @@
     "remove_project_context": "移除项目上下文",
     "no_projects": "还没有项目",
     "project_context_unsupported": "项目描述不会生效——该智能体的守护进程版本过旧，需要升级"
+  },
+  "queue": {
+    "title_other": "{{count}} 条排队消息",
+    "clear": "全部清空",
+    "send_now": "立即发送",
+    "edit": "编辑排队消息",
+    "remove": "移除排队消息",
+    "fallback": "排队消息",
+    "action_failed_toast": "无法更新排队消息"
   },
   "message_list": {
     "show_details": "查看详情",

--- a/server/cmd/server/router.go
+++ b/server/cmd/server/router.go
@@ -1422,6 +1422,8 @@ func NewRouterWithOptions(pool *pgxpool.Pool, hub *realtime.Hub, bus *events.Bus
 					r.Get("/messages", h.ListChatMessages)
 					r.Get("/messages/page", h.ListChatMessagesPage)
 					r.Get("/pending-task", h.GetPendingChatTask)
+					r.Delete("/queued-tasks", h.ClearQueuedChatTasks)
+					r.Post("/queued-tasks/{taskId}/prioritize", h.PrioritizeQueuedChatTask)
 					r.Post("/read", h.MarkChatSessionRead)
 					// Deferred-cancellation draft restores (#5219):
 					// creator-only fetch + idempotent consume.

--- a/server/internal/handler/cancel_task_by_user_test.go
+++ b/server/internal/handler/cancel_task_by_user_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/multica-ai/multica/server/internal/util"
 	"github.com/multica-ai/multica/server/pkg/protocol"
 )
 
@@ -141,6 +142,32 @@ func cancelTaskByUserRequest(t *testing.T, userID, taskID string) *http.Request 
 	req := newRequestAs(userID, "POST", "/api/tasks/"+taskID+"/cancel", nil)
 	req = withURLParam(req, "taskId", taskID)
 	return withChatTestWorkspaceCtx(t, req)
+}
+
+func TestCancelTaskByUser_QueuedOnlyDoesNotCancelPromotedTask(t *testing.T) {
+	if testHandler == nil {
+		t.Skip("database not available")
+	}
+
+	agentID := createHandlerTestAgent(t, "CancelQueuedOnlyAgent", []byte("[]"))
+	sessionID := createHandlerTestChatSession(t, agentID)
+	taskID := insertPendingChatTask(t, agentID, sessionID, "running")
+	req := newRequestAs(
+		testUserID,
+		http.MethodPost,
+		"/api/tasks/"+taskID+"/cancel?expected_status=queued&chat_session_id="+sessionID,
+		nil,
+	)
+	req = withURLParam(req, "taskId", taskID)
+	w := httptest.NewRecorder()
+	testHandler.CancelTaskByUser(w, withChatTestWorkspaceCtx(t, req))
+
+	if w.Code != http.StatusConflict {
+		t.Fatalf("expected 409, got %d: %s", w.Code, w.Body.String())
+	}
+	if got := taskStatus(t, taskID); got != "running" {
+		t.Fatalf("queued-only cancellation changed promoted task status to %q", got)
+	}
 }
 
 // createStartedEmptyChatTask seeds the exact shape the deferred cancel is about:
@@ -575,6 +602,89 @@ func TestCancelTaskByUser_ChatTaskWithoutTranscript_RestoresUserDraft(t *testing
 	}
 	if count != 0 {
 		t.Fatalf("expected linked user message to be deleted, got %d", count)
+	}
+}
+
+func TestCancelTaskByUser_ChatRetryRestoresRootInput(t *testing.T) {
+	if testHandler == nil {
+		t.Skip("database not available")
+	}
+
+	agentID := createHandlerTestAgent(t, "CancelChatRetryAgent", []byte("[]"))
+	sessionID := createHandlerTestChatSession(t, agentID)
+	var rootTaskID string
+	if err := testPool.QueryRow(context.Background(), `
+		INSERT INTO agent_task_queue (
+			agent_id, runtime_id, status, priority, chat_session_id, completed_at
+		)
+		VALUES ($1, (SELECT runtime_id FROM agent WHERE id = $1), 'completed', 0, $2, now())
+		RETURNING id
+	`, agentID, sessionID).Scan(&rootTaskID); err != nil {
+		t.Fatalf("create root chat task: %v", err)
+	}
+	t.Cleanup(func() {
+		testPool.Exec(context.Background(), `DELETE FROM agent_task_queue WHERE id = $1`, rootTaskID)
+	})
+	if _, err := testPool.Exec(
+		context.Background(),
+		`UPDATE agent_task_queue SET chat_input_task_id = id WHERE id = $1`,
+		rootTaskID,
+	); err != nil {
+		t.Fatalf("seal root chat input: %v", err)
+	}
+
+	var messageID string
+	const content = "restore the retry input"
+	if err := testPool.QueryRow(context.Background(), `
+		INSERT INTO chat_message (chat_session_id, role, content, task_id)
+		VALUES ($1, 'user', $2, $3)
+		RETURNING id
+	`, sessionID, content, rootTaskID).Scan(&messageID); err != nil {
+		t.Fatalf("create root chat message: %v", err)
+	}
+
+	var retryTaskID string
+	if err := testPool.QueryRow(context.Background(), `
+		INSERT INTO agent_task_queue (
+			agent_id, runtime_id, status, priority, chat_session_id,
+			parent_task_id, retry_of_task_id, chat_input_task_id, attempt
+		)
+		VALUES (
+			$1, (SELECT runtime_id FROM agent WHERE id = $1), 'queued', 0, $2,
+			$3, $3, $3, 1
+		)
+		RETURNING id
+	`, agentID, sessionID, rootTaskID).Scan(&retryTaskID); err != nil {
+		t.Fatalf("create retry chat task: %v", err)
+	}
+	t.Cleanup(func() {
+		testPool.Exec(context.Background(), `DELETE FROM agent_task_queue WHERE id = $1`, retryTaskID)
+	})
+
+	transcript, err := testHandler.Queries.ListChatMessages(
+		context.Background(),
+		util.MustParseUUID(sessionID),
+	)
+	if err != nil {
+		t.Fatalf("list transcript with queued retry: %v", err)
+	}
+	if len(transcript) != 1 || transcript[0].Content != content {
+		t.Fatalf("queued retry hid its historical root input: %+v", transcript)
+	}
+
+	w := httptest.NewRecorder()
+	testHandler.CancelTaskByUser(w, cancelTaskByUserRequest(t, testUserID, retryTaskID))
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	var resp CancelTaskByUserResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode retry cancel response: %v", err)
+	}
+	if resp.CancelledChatMessage == nil ||
+		resp.CancelledChatMessage.MessageID != messageID ||
+		resp.CancelledChatMessage.Content != content {
+		t.Fatalf("retry did not restore its root input: %#v", resp.CancelledChatMessage)
 	}
 }
 

--- a/server/internal/handler/chat.go
+++ b/server/internal/handler/chat.go
@@ -670,8 +670,9 @@ type SendChatMessageRequest struct {
 }
 
 type SendChatMessageResponse struct {
-	MessageID string `json:"message_id"`
-	TaskID    string `json:"task_id"`
+	MessageID     string `json:"message_id"`
+	TaskID        string `json:"task_id"`
+	SupportsQueue bool   `json:"supports_queue"`
 	// AttachmentIDs are the attachment rows actually bound to this message by
 	// the server. The client diffs these against the ids it requested so it
 	// can warn the user when an attachment silently failed to bind — no extra
@@ -843,6 +844,7 @@ func (h *Handler) SendChatMessage(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusCreated, SendChatMessageResponse{
 		MessageID:     uuidToString(msg.ID),
 		TaskID:        uuidToString(task.ID),
+		SupportsQueue: true,
 		CreatedAt:     timestampToString(task.CreatedAt),
 		AttachmentIDs: boundAttachmentIDs,
 	})
@@ -994,9 +996,24 @@ func (h *Handler) ListChatMessagesPage(w http.ResponseWriter, r *http.Request) {
 // optimistic seeds don't have a real task created_at and the timer needs to
 // survive refresh / reopen.
 type PendingChatTaskResponse struct {
-	TaskID    string `json:"task_id,omitempty"`
-	Status    string `json:"status,omitempty"`
-	CreatedAt string `json:"created_at,omitempty"`
+	TaskID        string                   `json:"task_id,omitempty"`
+	Status        string                   `json:"status,omitempty"`
+	CreatedAt     string                   `json:"created_at,omitempty"`
+	SupportsQueue bool                     `json:"supports_queue"`
+	QueuedTasks   []QueuedChatTaskResponse `json:"queued_tasks,omitempty"`
+}
+
+type QueuedChatTaskResponse struct {
+	TaskID    string `json:"task_id"`
+	Status    string `json:"status"`
+	CreatedAt string `json:"created_at"`
+	MessageID string `json:"message_id,omitempty"`
+	Content   string `json:"content,omitempty"`
+}
+
+type PrioritizeQueuedChatTaskResponse struct {
+	TaskID       string `json:"task_id"`
+	ActiveTaskID string `json:"active_task_id,omitempty"`
 }
 
 // MarkChatSessionRead clears the session's unread_since (→ has_unread=false)
@@ -1320,9 +1337,9 @@ func (h *Handler) HasPendingChatTasks(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusOK, HasPendingChatTasksResponse{HasPending: hasPending})
 }
 
-// GetPendingChatTask returns the most recent in-flight task (queued / dispatched
-// / running) for a chat session. The frontend polls this on mount / session
-// switch so pending UI state survives refresh and reopen.
+// GetPendingChatTask returns the current task plus its ordered follow-ups. The
+// root fields retain the original response shape so older clients continue to
+// recover a single pending task after refresh / reopen.
 func (h *Handler) GetPendingChatTask(w http.ResponseWriter, r *http.Request) {
 	userID, ok := requireUserID(w, r)
 	if !ok {
@@ -1336,18 +1353,115 @@ func (h *Handler) GetPendingChatTask(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	task, err := h.Queries.GetPendingChatTask(r.Context(), session.ID)
+	tasks, err := h.Queries.ListPendingChatTasksForSession(r.Context(), session.ID)
 	if err != nil {
-		// No in-flight task — return an empty object, not an error.
-		writeJSON(w, http.StatusOK, PendingChatTaskResponse{})
+		writeError(w, http.StatusInternalServerError, "failed to list pending chat tasks")
+		return
+	}
+	if len(tasks) == 0 {
+		writeJSON(w, http.StatusOK, PendingChatTaskResponse{SupportsQueue: true})
 		return
 	}
 
+	head := tasks[0]
+	queued := make([]QueuedChatTaskResponse, 0, len(tasks))
+	for _, task := range tasks {
+		if task.Status != "queued" {
+			continue
+		}
+		queued = append(queued, QueuedChatTaskResponse{
+			TaskID:    uuidToString(task.ID),
+			Status:    task.Status,
+			CreatedAt: timestampToString(task.CreatedAt),
+			MessageID: uuidToString(task.MessageID),
+			Content:   task.Content,
+		})
+	}
+
 	writeJSON(w, http.StatusOK, PendingChatTaskResponse{
-		TaskID:    uuidToString(task.ID),
-		Status:    task.Status,
-		CreatedAt: timestampToString(task.CreatedAt),
+		TaskID:        uuidToString(head.ID),
+		Status:        head.Status,
+		CreatedAt:     timestampToString(head.CreatedAt),
+		SupportsQueue: true,
+		QueuedTasks:   queued,
 	})
+}
+
+// PrioritizeQueuedChatTask moves one queued follow-up ahead of its FIFO peers.
+// The client then cancels the current task through the existing cancellation
+// endpoint, preserving that path's transcript and draft-restore semantics.
+func (h *Handler) PrioritizeQueuedChatTask(w http.ResponseWriter, r *http.Request) {
+	userID, ok := requireUserID(w, r)
+	if !ok {
+		return
+	}
+	workspaceID := ctxWorkspaceID(r.Context())
+	sessionID := chi.URLParam(r, "sessionId")
+	taskID, ok := parseUUIDOrBadRequest(w, chi.URLParam(r, "taskId"), "task id")
+	if !ok {
+		return
+	}
+
+	session, ok := h.gateChatSessionForUser(w, r, userID, workspaceID, sessionID)
+	if !ok {
+		return
+	}
+	tx, err := h.TxStarter.Begin(r.Context())
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to start prioritize transaction")
+		return
+	}
+	defer tx.Rollback(r.Context())
+	qtx := h.Queries.WithTx(tx)
+
+	// ClaimTask takes this same row lock before selecting work. Holding it here
+	// makes "prioritize + report the active task" one server-authoritative
+	// decision instead of two client requests racing the daemon.
+	if _, err := qtx.GetAgentForClaimUpdate(r.Context(), session.AgentID); err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to lock chat agent")
+		return
+	}
+	prioritized, err := qtx.PrioritizeQueuedChatTask(
+		r.Context(),
+		db.PrioritizeQueuedChatTaskParams{ID: taskID, ChatSessionID: session.ID},
+	)
+	if errors.Is(err, pgx.ErrNoRows) {
+		writeError(w, http.StatusConflict, "task is no longer queued")
+		return
+	}
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to prioritize queued task")
+		return
+	}
+	if err := tx.Commit(r.Context()); err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to commit queued task priority")
+		return
+	}
+
+	writeJSON(w, http.StatusOK, PrioritizeQueuedChatTaskResponse{
+		TaskID:       uuidToString(prioritized.TaskID),
+		ActiveTaskID: uuidToString(prioritized.ActiveTaskID),
+	})
+}
+
+// ClearQueuedChatTasks cancels every queued follow-up without touching the
+// task already running for the session.
+func (h *Handler) ClearQueuedChatTasks(w http.ResponseWriter, r *http.Request) {
+	userID, ok := requireUserID(w, r)
+	if !ok {
+		return
+	}
+	workspaceID := ctxWorkspaceID(r.Context())
+	sessionID := chi.URLParam(r, "sessionId")
+	session, ok := h.gateChatSessionForUser(w, r, userID, workspaceID, sessionID)
+	if !ok {
+		return
+	}
+	if err := h.TaskService.CancelQueuedChatTasks(r.Context(), session.ID, session.AgentID); err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to clear queued tasks")
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
 }
 
 // ---------------------------------------------------------------------------
@@ -1399,6 +1513,28 @@ func (h *Handler) CancelTaskByUser(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	var (
+		queuedOnly      bool
+		expectedSession pgtype.UUID
+	)
+	if expectedStatus := r.URL.Query().Get("expected_status"); expectedStatus != "" {
+		if expectedStatus != "queued" {
+			writeError(w, http.StatusBadRequest, "expected_status must be queued")
+			return
+		}
+		sessionID := r.URL.Query().Get("chat_session_id")
+		var ok bool
+		expectedSession, ok = parseUUIDOrBadRequest(w, sessionID, "chat_session_id")
+		if !ok {
+			return
+		}
+		if !task.ChatSessionID.Valid || task.ChatSessionID != expectedSession {
+			writeError(w, http.StatusConflict, "task does not belong to the expected chat session")
+			return
+		}
+		queuedOnly = true
+	}
+
 	if task.ChatSessionID.Valid {
 		// Chat privacy: only the member who opened the conversation may
 		// cancel its task, even though the workspace is shared.
@@ -1435,7 +1571,13 @@ func (h *Handler) CancelTaskByUser(w http.ResponseWriter, r *http.Request) {
 
 	cancelled, err := h.TaskService.CancelTaskWithResult(r.Context(), taskUUID, service.CancelTaskOptions{
 		ClientSupportsDraftRestore: requestHasClientCapability(r, protocol.AppCapabilityChatDraftRestoreV1),
+		QueuedOnly:                 queuedOnly,
+		ExpectedChatSession:        expectedSession,
 	})
+	if errors.Is(err, service.ErrTaskNoLongerQueued) {
+		writeError(w, http.StatusConflict, err.Error())
+		return
+	}
 	if err != nil {
 		writeError(w, http.StatusBadRequest, err.Error())
 		return

--- a/server/internal/handler/chat_pending_tasks_test.go
+++ b/server/internal/handler/chat_pending_tasks_test.go
@@ -98,6 +98,227 @@ func containsPendingTask(tasks []PendingChatTaskItem, taskID string) bool {
 	return false
 }
 
+func TestGetPendingChatTask_ReturnsActiveHeadAndFIFOQueue(t *testing.T) {
+	if testHandler == nil {
+		t.Skip("database not available")
+	}
+
+	agentID := createHandlerTestAgent(t, "PendingSessionQueueAgent", []byte("[]"))
+	sessionID := createHandlerTestChatSession(t, agentID)
+	activeID := insertPendingChatTask(t, agentID, sessionID, "running")
+	nextID := insertPendingChatTask(t, agentID, sessionID, "queued")
+	laterID := insertPendingChatTask(t, agentID, sessionID, "queued")
+
+	for _, row := range []struct {
+		id        string
+		createdAt string
+		content   string
+	}{
+		{activeID, "2026-07-29T01:00:00Z", "active prompt"},
+		{nextID, "2026-07-29T01:00:01Z", "next prompt"},
+		{laterID, "2026-07-29T01:00:02Z", "later prompt"},
+	} {
+		if _, err := testPool.Exec(context.Background(), `
+			UPDATE agent_task_queue
+			SET created_at = $2, chat_input_task_id = id
+			WHERE id = $1
+		`, row.id, row.createdAt); err != nil {
+			t.Fatalf("stamp pending task %s: %v", row.id, err)
+		}
+		if _, err := testPool.Exec(context.Background(), `
+			INSERT INTO chat_message (chat_session_id, role, content, task_id, created_at)
+			VALUES ($1, 'user', $2, $3, $4)
+		`, sessionID, row.content, row.id, row.createdAt); err != nil {
+			t.Fatalf("insert pending message %s: %v", row.id, err)
+		}
+	}
+	transcript, err := testHandler.Queries.ListChatMessages(
+		context.Background(),
+		util.MustParseUUID(sessionID),
+	)
+	if err != nil {
+		t.Fatalf("list compatibility transcript: %v", err)
+	}
+	if len(transcript) != 1 || util.UUIDToString(transcript[0].TaskID) != activeID {
+		t.Fatalf("queued prompts leaked into legacy transcript: %+v", transcript)
+	}
+	page, err := testHandler.Queries.ListChatMessagesPage(
+		context.Background(),
+		db.ListChatMessagesPageParams{
+			ChatSessionID: util.MustParseUUID(sessionID),
+			Limit:         50,
+		},
+	)
+	if err != nil {
+		t.Fatalf("list paged compatibility transcript: %v", err)
+	}
+	if len(page) != 1 || util.UUIDToString(page[0].TaskID) != activeID {
+		t.Fatalf("queued prompts leaked into paged transcript: %+v", page)
+	}
+
+	req := withURLParam(
+		newRequestAs(
+			testUserID,
+			http.MethodGet,
+			"/api/chat/sessions/"+sessionID+"/pending-task",
+			nil,
+		),
+		"sessionId",
+		sessionID,
+	)
+	w := httptest.NewRecorder()
+	testHandler.GetPendingChatTask(w, chatPendingCtxAs(t, req, testUserID))
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	var resp PendingChatTaskResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode pending task queue: %v", err)
+	}
+	if resp.TaskID != activeID || resp.Status != "running" {
+		t.Fatalf("unexpected active head: %+v", resp)
+	}
+	if !resp.SupportsQueue {
+		t.Fatal("pending response must advertise queue support")
+	}
+	if len(resp.QueuedTasks) != 2 {
+		t.Fatalf("expected two queued tasks, got %+v", resp.QueuedTasks)
+	}
+	if resp.QueuedTasks[0].TaskID != nextID ||
+		resp.QueuedTasks[0].Content != "next prompt" ||
+		resp.QueuedTasks[1].TaskID != laterID ||
+		resp.QueuedTasks[1].Content != "later prompt" {
+		t.Fatalf("queue is not FIFO with message summaries: %+v", resp.QueuedTasks)
+	}
+	if _, err := testPool.Exec(
+		context.Background(),
+		`UPDATE agent_task_queue SET priority = 4 WHERE id = $1`,
+		nextID,
+	); err != nil {
+		t.Fatalf("seed prior send-now selection: %v", err)
+	}
+
+	prioritizeReq := newRequestAs(
+		testUserID,
+		http.MethodPost,
+		"/api/chat/sessions/"+sessionID+"/queued-tasks/"+laterID+"/prioritize",
+		nil,
+	)
+	prioritizeReq = withURLParams(
+		prioritizeReq,
+		"sessionId", sessionID,
+		"taskId", laterID,
+	)
+	prioritizeW := httptest.NewRecorder()
+	testHandler.PrioritizeQueuedChatTask(
+		prioritizeW,
+		chatPendingCtxAs(t, prioritizeReq, testUserID),
+	)
+	if prioritizeW.Code != http.StatusOK {
+		t.Fatalf("expected prioritize 200, got %d: %s", prioritizeW.Code, prioritizeW.Body.String())
+	}
+	var prioritized PrioritizeQueuedChatTaskResponse
+	if err := json.Unmarshal(prioritizeW.Body.Bytes(), &prioritized); err != nil {
+		t.Fatalf("decode prioritize response: %v", err)
+	}
+	if prioritized.TaskID != laterID || prioritized.ActiveTaskID != activeID {
+		t.Fatalf("prioritize response is not server-authoritative: %+v", prioritized)
+	}
+
+	w = httptest.NewRecorder()
+	testHandler.GetPendingChatTask(w, chatPendingCtxAs(t, req, testUserID))
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode prioritized queue: %v", err)
+	}
+	if resp.TaskID != activeID ||
+		len(resp.QueuedTasks) != 2 ||
+		resp.QueuedTasks[0].TaskID != laterID ||
+		resp.QueuedTasks[1].TaskID != nextID {
+		t.Fatalf("send-now priority did not move only the selected follow-up: %+v", resp)
+	}
+
+	if _, err := testPool.Exec(
+		context.Background(),
+		`UPDATE agent_task_queue SET status = 'completed' WHERE id = $1`,
+		activeID,
+	); err != nil {
+		t.Fatalf("complete active task: %v", err)
+	}
+	w = httptest.NewRecorder()
+	testHandler.GetPendingChatTask(w, chatPendingCtxAs(t, req, testUserID))
+	resp = PendingChatTaskResponse{}
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode all-queued state: %v", err)
+	}
+	if resp.TaskID != laterID ||
+		resp.Status != "queued" ||
+		len(resp.QueuedTasks) != 2 ||
+		resp.QueuedTasks[0].TaskID != laterID ||
+		resp.QueuedTasks[1].TaskID != nextID {
+		t.Fatalf("all queued prompts must remain in the dedicated queue: %+v", resp)
+	}
+}
+
+func TestClearQueuedChatTasks_CancelsWholeQueueAndDeletesInputs(t *testing.T) {
+	if testHandler == nil {
+		t.Skip("database not available")
+	}
+
+	agentID := createHandlerTestAgent(t, "ClearPendingQueueAgent", []byte("[]"))
+	sessionID := createHandlerTestChatSession(t, agentID)
+	taskIDs := []string{
+		insertPendingChatTask(t, agentID, sessionID, "queued"),
+		insertPendingChatTask(t, agentID, sessionID, "queued"),
+	}
+	for index, taskID := range taskIDs {
+		if _, err := testPool.Exec(
+			context.Background(),
+			`UPDATE agent_task_queue SET chat_input_task_id = id WHERE id = $1`,
+			taskID,
+		); err != nil {
+			t.Fatalf("stamp queued input owner %s: %v", taskID, err)
+		}
+		if _, err := testPool.Exec(context.Background(), `
+			INSERT INTO chat_message (chat_session_id, role, content, task_id)
+			VALUES ($1, 'user', $2, $3)
+		`, sessionID, []string{"queued prompt A", "queued prompt B"}[index], taskID); err != nil {
+			t.Fatalf("seed queued input %s: %v", taskID, err)
+		}
+	}
+
+	req := withURLParam(
+		newRequestAs(
+			testUserID,
+			http.MethodDelete,
+			"/api/chat/sessions/"+sessionID+"/queued-tasks",
+			nil,
+		),
+		"sessionId",
+		sessionID,
+	)
+	w := httptest.NewRecorder()
+	testHandler.ClearQueuedChatTasks(w, chatPendingCtxAs(t, req, testUserID))
+	if w.Code != http.StatusNoContent {
+		t.Fatalf("expected 204, got %d: %s", w.Code, w.Body.String())
+	}
+
+	for _, taskID := range taskIDs {
+		if got := taskStatus(t, taskID); got != "cancelled" {
+			t.Fatalf("queued task %s status = %q, want cancelled", taskID, got)
+		}
+	}
+	var inputCount int
+	if err := testPool.QueryRow(context.Background(), `
+		SELECT count(*) FROM chat_message WHERE task_id = $1 OR task_id = $2
+	`, taskIDs[0], taskIDs[1]).Scan(&inputCount); err != nil {
+		t.Fatalf("count queued inputs after clear: %v", err)
+	}
+	if inputCount != 0 {
+		t.Fatalf("clear left %d queued input messages", inputCount)
+	}
+}
+
 // TestListPendingChatTasks_HidesPrivateAgentFromLostAccessCreator verifies the
 // P1 rewrite still enforces the private-agent gate now that filtering keys off
 // the agent_id returned by the query (instead of a second session-list scan).
@@ -235,7 +456,6 @@ func TestHasPendingChatTasks_IgnoresTerminalTasks(t *testing.T) {
 		t.Fatalf("has-any returned true for a terminal (completed) task")
 	}
 }
-
 
 // TestHasPendingChatTasks_HidesOtherCreatorsTask locks the cs.creator_id gate:
 // user A's in-flight task on a workspace-visible agent — one B can freely

--- a/server/internal/service/task.go
+++ b/server/internal/service/task.go
@@ -1834,6 +1834,8 @@ type CancelTaskResult struct {
 	CancelledChatMessage *CancelledChatMessageResult
 }
 
+var ErrTaskNoLongerQueued = errors.New("task is no longer queued")
+
 // CancelTaskOptions carries what the caller knows about the client that asked
 // for the cancellation.
 type CancelTaskOptions struct {
@@ -1843,6 +1845,9 @@ type CancelTaskOptions struct {
 	// stays synchronous, because the cancel response is their only chance to get
 	// the prompt back. See protocol.AppCapabilityChatDraftRestoreV1.
 	ClientSupportsDraftRestore bool
+	// QueuedOnly turns queue edit/remove into a session-scoped compare-and-set.
+	QueuedOnly          bool
+	ExpectedChatSession pgtype.UUID
 }
 
 // CancelTask cancels a single task by ID. It broadcasts a task:cancelled event
@@ -1864,8 +1869,22 @@ func (s *TaskService) CancelTask(ctx context.Context, taskID pgtype.UUID) (*db.A
 // CancelTaskWithResult cancels a single task and returns any chat-specific
 // cleanup result needed by user-facing callers.
 func (s *TaskService) CancelTaskWithResult(ctx context.Context, taskID pgtype.UUID, opts CancelTaskOptions) (*CancelTaskResult, error) {
-	task, err := s.Queries.CancelAgentTask(ctx, taskID)
+	var (
+		task db.AgentTaskQueue
+		err  error
+	)
+	if opts.QueuedOnly {
+		task, err = s.Queries.CancelQueuedAgentTask(ctx, db.CancelQueuedAgentTaskParams{
+			ID:            taskID,
+			ChatSessionID: opts.ExpectedChatSession,
+		})
+	} else {
+		task, err = s.Queries.CancelAgentTask(ctx, taskID)
+	}
 	if errors.Is(err, pgx.ErrNoRows) {
+		if opts.QueuedOnly {
+			return nil, ErrTaskNoLongerQueued
+		}
 		existing, err := s.Queries.GetAgentTask(ctx, taskID)
 		if err != nil {
 			return nil, fmt.Errorf("cancel task: %w", err)
@@ -1891,6 +1910,40 @@ func (s *TaskService) CancelTaskWithResult(ctx context.Context, taskID pgtype.UU
 		Task:                 task,
 		CancelledChatMessage: cancelledChatMessage,
 	}, nil
+}
+
+// CancelQueuedChatTasks atomically cancels every queued follow-up in a chat
+// session. It takes the same agent lock as ClaimTask so a daemon cannot promote
+// one row while the bulk update is in progress.
+func (s *TaskService) CancelQueuedChatTasks(ctx context.Context, sessionID, agentID pgtype.UUID) error {
+	var tasks []db.AgentTaskQueue
+	if err := s.runInTx(ctx, func(qtx *db.Queries) error {
+		if _, err := qtx.GetAgentForClaimUpdate(ctx, agentID); err != nil {
+			return fmt.Errorf("lock chat agent: %w", err)
+		}
+		var err error
+		tasks, err = qtx.CancelQueuedAgentTasksForSession(ctx, sessionID)
+		if err != nil {
+			return fmt.Errorf("cancel queued chat tasks: %w", err)
+		}
+		return nil
+	}); err != nil {
+		return err
+	}
+
+	for _, task := range tasks {
+		slog.Info("task cancelled", "task_id", util.UUIDToString(task.ID), "issue_id", util.UUIDToString(task.IssueID))
+		s.captureTaskCancelled(ctx, task)
+		s.finalizeCancelledChatMessage(ctx, task, CancelTaskOptions{})
+	}
+	if len(tasks) > 0 {
+		s.ReconcileAgentStatus(ctx, agentID)
+	}
+	for _, task := range tasks {
+		s.broadcastTaskEvent(ctx, protocol.EventTaskCancelled, task)
+	}
+	s.notifyTasksFinished(tasks)
+	return nil
 }
 
 // chatInputOwnerID resolves the id the task's user-message input batch is
@@ -1953,14 +2006,15 @@ func (s *TaskService) finalizeCancelledChatMessage(ctx context.Context, task db.
 			return nil
 		}
 		if restorable {
+			inputOwnerID := chatInputOwnerID(task)
 			// Detach attachments BEFORE deleting the user message — the
 			// attachment FK is ON DELETE CASCADE, so deleting first would
 			// destroy rows the restored draft needs to re-bind.
-			detached, err := qtx.DetachAttachmentsFromUserChatMessageByTask(ctx, task.ID)
+			detached, err := qtx.DetachAttachmentsFromUserChatMessageByTask(ctx, inputOwnerID)
 			if err != nil {
 				return fmt.Errorf("detach cancelled chat message attachments: %w", err)
 			}
-			deleted, err := qtx.DeleteUserChatMessageByTask(ctx, task.ID)
+			deleted, err := qtx.DeleteUserChatMessageByTask(ctx, inputOwnerID)
 			if errors.Is(err, pgx.ErrNoRows) {
 				return nil
 			}
@@ -2072,6 +2126,7 @@ func (s *TaskService) FinalizeDeferredCancelledChat(ctx context.Context, taskID 
 			restorable = !channelIngested
 		}
 		if restorable {
+			inputOwnerID := chatInputOwnerID(claimed)
 			// The transcript stayed empty through the daemon flush: same
 			// outcome as the synchronous empty branch, but the cancel HTTP
 			// response is long gone and the broadcast is best-effort. The
@@ -2080,11 +2135,11 @@ func (s *TaskService) FinalizeDeferredCancelledChat(ctx context.Context, taskID 
 			// misses the event recovers it on the next session open; the
 			// event itself carries no content and is only an invalidation
 			// hint.
-			detached, err := qtx.DetachAttachmentsFromUserChatMessageByTask(ctx, claimed.ID)
+			detached, err := qtx.DetachAttachmentsFromUserChatMessageByTask(ctx, inputOwnerID)
 			if err != nil {
 				return fmt.Errorf("detach cancelled chat message attachments: %w", err)
 			}
-			deleted, err := qtx.DeleteUserChatMessageByTask(ctx, claimed.ID)
+			deleted, err := qtx.DeleteUserChatMessageByTask(ctx, inputOwnerID)
 			if errors.Is(err, pgx.ErrNoRows) {
 				payload.Outcome = ""
 				return nil

--- a/server/pkg/db/generated/agent.sql.go
+++ b/server/pkg/db/generated/agent.sql.go
@@ -889,6 +889,157 @@ func (q *Queries) CancelDeferredEscalationsForTask(ctx context.Context, escalati
 	return items, nil
 }
 
+const cancelQueuedAgentTask = `-- name: CancelQueuedAgentTask :one
+UPDATE agent_task_queue
+SET status = 'cancelled', completed_at = now(), prepare_lease_expires_at = NULL
+WHERE id = $1
+  AND chat_session_id = $2
+  AND status = 'queued'
+RETURNING id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id, chat_session_id, autopilot_run_id, attempt, max_attempts, parent_task_id, failure_reason, trigger_summary, force_fresh_session, is_leader_task, wait_reason, initiator_user_id, handoff_note, prepare_lease_expires_at, squad_id, runtime_mcp_overlay, escalation_for_task_id, fire_at, originator_user_id, runtime_connected_apps, coalesced_comment_ids, delivered_comment_ids, chat_input_task_id, chat_finalize_deferred_at, originator_source, delegated_from_task_id, retry_of_task_id, rerun_of_task_id, rule_version_id, trigger_evidence_kind, trigger_evidence_ref_id, accountable_user_id, session_rollout_missing, retired_session_id
+`
+
+type CancelQueuedAgentTaskParams struct {
+	ID            pgtype.UUID `json:"id"`
+	ChatSessionID pgtype.UUID `json:"chat_session_id"`
+}
+
+// Queue editing is a compare-and-set: never cancel a task that the daemon
+// promoted between the user's click and this statement.
+func (q *Queries) CancelQueuedAgentTask(ctx context.Context, arg CancelQueuedAgentTaskParams) (AgentTaskQueue, error) {
+	row := q.db.QueryRow(ctx, cancelQueuedAgentTask, arg.ID, arg.ChatSessionID)
+	var i AgentTaskQueue
+	err := row.Scan(
+		&i.ID,
+		&i.AgentID,
+		&i.IssueID,
+		&i.Status,
+		&i.Priority,
+		&i.DispatchedAt,
+		&i.StartedAt,
+		&i.CompletedAt,
+		&i.Result,
+		&i.Error,
+		&i.CreatedAt,
+		&i.Context,
+		&i.RuntimeID,
+		&i.SessionID,
+		&i.WorkDir,
+		&i.TriggerCommentID,
+		&i.ChatSessionID,
+		&i.AutopilotRunID,
+		&i.Attempt,
+		&i.MaxAttempts,
+		&i.ParentTaskID,
+		&i.FailureReason,
+		&i.TriggerSummary,
+		&i.ForceFreshSession,
+		&i.IsLeaderTask,
+		&i.WaitReason,
+		&i.InitiatorUserID,
+		&i.HandoffNote,
+		&i.PrepareLeaseExpiresAt,
+		&i.SquadID,
+		&i.RuntimeMcpOverlay,
+		&i.EscalationForTaskID,
+		&i.FireAt,
+		&i.OriginatorUserID,
+		&i.RuntimeConnectedApps,
+		&i.CoalescedCommentIds,
+		&i.DeliveredCommentIds,
+		&i.ChatInputTaskID,
+		&i.ChatFinalizeDeferredAt,
+		&i.OriginatorSource,
+		&i.DelegatedFromTaskID,
+		&i.RetryOfTaskID,
+		&i.RerunOfTaskID,
+		&i.RuleVersionID,
+		&i.TriggerEvidenceKind,
+		&i.TriggerEvidenceRefID,
+		&i.AccountableUserID,
+		&i.SessionRolloutMissing,
+		&i.RetiredSessionID,
+	)
+	return i, err
+}
+
+const cancelQueuedAgentTasksForSession = `-- name: CancelQueuedAgentTasksForSession :many
+UPDATE agent_task_queue
+SET status = 'cancelled', completed_at = now(), prepare_lease_expires_at = NULL
+WHERE chat_session_id = $1
+  AND status = 'queued'
+RETURNING id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id, chat_session_id, autopilot_run_id, attempt, max_attempts, parent_task_id, failure_reason, trigger_summary, force_fresh_session, is_leader_task, wait_reason, initiator_user_id, handoff_note, prepare_lease_expires_at, squad_id, runtime_mcp_overlay, escalation_for_task_id, fire_at, originator_user_id, runtime_connected_apps, coalesced_comment_ids, delivered_comment_ids, chat_input_task_id, chat_finalize_deferred_at, originator_source, delegated_from_task_id, retry_of_task_id, rerun_of_task_id, rule_version_id, trigger_evidence_kind, trigger_evidence_ref_id, accountable_user_id, session_rollout_missing, retired_session_id
+`
+
+func (q *Queries) CancelQueuedAgentTasksForSession(ctx context.Context, chatSessionID pgtype.UUID) ([]AgentTaskQueue, error) {
+	rows, err := q.db.Query(ctx, cancelQueuedAgentTasksForSession, chatSessionID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []AgentTaskQueue{}
+	for rows.Next() {
+		var i AgentTaskQueue
+		if err := rows.Scan(
+			&i.ID,
+			&i.AgentID,
+			&i.IssueID,
+			&i.Status,
+			&i.Priority,
+			&i.DispatchedAt,
+			&i.StartedAt,
+			&i.CompletedAt,
+			&i.Result,
+			&i.Error,
+			&i.CreatedAt,
+			&i.Context,
+			&i.RuntimeID,
+			&i.SessionID,
+			&i.WorkDir,
+			&i.TriggerCommentID,
+			&i.ChatSessionID,
+			&i.AutopilotRunID,
+			&i.Attempt,
+			&i.MaxAttempts,
+			&i.ParentTaskID,
+			&i.FailureReason,
+			&i.TriggerSummary,
+			&i.ForceFreshSession,
+			&i.IsLeaderTask,
+			&i.WaitReason,
+			&i.InitiatorUserID,
+			&i.HandoffNote,
+			&i.PrepareLeaseExpiresAt,
+			&i.SquadID,
+			&i.RuntimeMcpOverlay,
+			&i.EscalationForTaskID,
+			&i.FireAt,
+			&i.OriginatorUserID,
+			&i.RuntimeConnectedApps,
+			&i.CoalescedCommentIds,
+			&i.DeliveredCommentIds,
+			&i.ChatInputTaskID,
+			&i.ChatFinalizeDeferredAt,
+			&i.OriginatorSource,
+			&i.DelegatedFromTaskID,
+			&i.RetryOfTaskID,
+			&i.RerunOfTaskID,
+			&i.RuleVersionID,
+			&i.TriggerEvidenceKind,
+			&i.TriggerEvidenceRefID,
+			&i.AccountableUserID,
+			&i.SessionRolloutMissing,
+			&i.RetiredSessionID,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const claimAgentTask = `-- name: ClaimAgentTask :one
 UPDATE agent_task_queue
 SET status = 'dispatched',

--- a/server/pkg/db/generated/chat.sql.go
+++ b/server/pkg/db/generated/chat.sql.go
@@ -1051,9 +1051,19 @@ func (q *Queries) ListChatInputMessages(ctx context.Context, taskID pgtype.UUID)
 }
 
 const listChatMessages = `-- name: ListChatMessages :many
-SELECT id, chat_session_id, role, content, task_id, created_at, failure_reason, elapsed_ms, message_kind, channel_media_pending_until, channel_ingested FROM chat_message
-WHERE chat_session_id = $1
-ORDER BY created_at ASC, id ASC
+SELECT message.id, message.chat_session_id, message.role, message.content, message.task_id, message.created_at, message.failure_reason, message.elapsed_ms, message.message_kind, message.channel_media_pending_until, message.channel_ingested FROM chat_message AS message
+WHERE message.chat_session_id = $1
+  AND NOT (
+    message.role = 'user'
+    AND EXISTS (
+      SELECT 1
+      FROM agent_task_queue AS task
+      WHERE task.chat_session_id = message.chat_session_id
+        AND task.status = 'queued'
+        AND task.id = message.task_id
+    )
+  )
+ORDER BY message.created_at ASC, message.id ASC
 `
 
 func (q *Queries) ListChatMessages(ctx context.Context, chatSessionID pgtype.UUID) ([]ChatMessage, error) {
@@ -1089,13 +1099,23 @@ func (q *Queries) ListChatMessages(ctx context.Context, chatSessionID pgtype.UUI
 }
 
 const listChatMessagesPage = `-- name: ListChatMessagesPage :many
-SELECT id, chat_session_id, role, content, task_id, created_at, failure_reason, elapsed_ms, message_kind, channel_media_pending_until, channel_ingested FROM chat_message
-WHERE chat_session_id = $1
+SELECT message.id, message.chat_session_id, message.role, message.content, message.task_id, message.created_at, message.failure_reason, message.elapsed_ms, message.message_kind, message.channel_media_pending_until, message.channel_ingested FROM chat_message AS message
+WHERE message.chat_session_id = $1
+  AND NOT (
+    message.role = 'user'
+    AND EXISTS (
+      SELECT 1
+      FROM agent_task_queue AS task
+      WHERE task.chat_session_id = message.chat_session_id
+        AND task.status = 'queued'
+        AND task.id = message.task_id
+    )
+  )
   AND (
     $3::timestamptz IS NULL
-    OR (created_at, id) < ($3::timestamptz, $4::uuid)
+    OR (message.created_at, message.id) < ($3::timestamptz, $4::uuid)
   )
-ORDER BY created_at DESC, id DESC
+ORDER BY message.created_at DESC, message.id DESC
 LIMIT $2
 `
 
@@ -1301,6 +1321,70 @@ func (q *Queries) ListPendingChatTasksByCreator(ctx context.Context, arg ListPen
 	return items, nil
 }
 
+const listPendingChatTasksForSession = `-- name: ListPendingChatTasksForSession :many
+SELECT
+    task.id,
+    task.status,
+    task.created_at,
+    message.id AS message_id,
+    COALESCE(message.content, '')::text AS content
+FROM agent_task_queue AS task
+LEFT JOIN LATERAL (
+    SELECT input.id, input.content
+    FROM chat_message AS input
+    WHERE input.task_id = COALESCE(task.chat_input_task_id, task.id)
+      AND input.role = 'user'
+    ORDER BY input.created_at ASC, input.id ASC
+    LIMIT 1
+) AS message ON TRUE
+WHERE task.chat_session_id = $1
+  AND task.status IN ('queued', 'dispatched', 'running', 'waiting_local_directory')
+ORDER BY
+    CASE WHEN task.status = 'queued' THEN 1 ELSE 0 END,
+    task.priority DESC,
+    task.created_at ASC,
+    task.id ASC
+`
+
+type ListPendingChatTasksForSessionRow struct {
+	ID        pgtype.UUID        `json:"id"`
+	Status    string             `json:"status"`
+	CreatedAt pgtype.Timestamptz `json:"created_at"`
+	MessageID pgtype.UUID        `json:"message_id"`
+	Content   string             `json:"content"`
+}
+
+// Returns the active task first, followed by prioritized then FIFO follow-ups.
+// The message lateral join reads only the immutable input owned by each task;
+// it avoids loading the session's complete message history just to render a
+// one-line queue preview. GetPendingChatTask remains for legacy callers that
+// only need an existence check.
+func (q *Queries) ListPendingChatTasksForSession(ctx context.Context, chatSessionID pgtype.UUID) ([]ListPendingChatTasksForSessionRow, error) {
+	rows, err := q.db.Query(ctx, listPendingChatTasksForSession, chatSessionID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []ListPendingChatTasksForSessionRow{}
+	for rows.Next() {
+		var i ListPendingChatTasksForSessionRow
+		if err := rows.Scan(
+			&i.ID,
+			&i.Status,
+			&i.CreatedAt,
+			&i.MessageID,
+			&i.Content,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const lockChatSessionForDelete = `-- name: LockChatSessionForDelete :one
 SELECT id FROM chat_session
 WHERE id = $1
@@ -1486,6 +1570,52 @@ WHERE id = $1
 func (q *Queries) MarkChatSessionRead(ctx context.Context, id pgtype.UUID) error {
 	_, err := q.db.Exec(ctx, markChatSessionRead, id)
 	return err
+}
+
+const prioritizeQueuedChatTask = `-- name: PrioritizeQueuedChatTask :one
+WITH demoted AS (
+  UPDATE agent_task_queue AS queued
+  SET priority = 3
+  WHERE queued.chat_session_id = $1
+    AND queued.id <> $2
+    AND queued.status = 'queued'
+    AND queued.priority >= 4
+), prioritized AS (
+  UPDATE agent_task_queue AS selected
+  SET priority = 4
+  WHERE selected.id = $2
+    AND selected.chat_session_id = $1
+    AND selected.status = 'queued'
+  RETURNING selected.id
+)
+SELECT
+  prioritized.id AS task_id,
+  (
+    SELECT active.id
+    FROM agent_task_queue AS active
+    WHERE active.chat_session_id = $1
+      AND active.status IN ('dispatched', 'running', 'waiting_local_directory')
+    ORDER BY active.created_at ASC, active.id ASC
+    LIMIT 1
+  )::uuid AS active_task_id
+FROM prioritized
+`
+
+type PrioritizeQueuedChatTaskParams struct {
+	ChatSessionID pgtype.UUID `json:"chat_session_id"`
+	ID            pgtype.UUID `json:"id"`
+}
+
+type PrioritizeQueuedChatTaskRow struct {
+	TaskID       pgtype.UUID `json:"task_id"`
+	ActiveTaskID pgtype.UUID `json:"active_task_id"`
+}
+
+func (q *Queries) PrioritizeQueuedChatTask(ctx context.Context, arg PrioritizeQueuedChatTaskParams) (PrioritizeQueuedChatTaskRow, error) {
+	row := q.db.QueryRow(ctx, prioritizeQueuedChatTask, arg.ChatSessionID, arg.ID)
+	var i PrioritizeQueuedChatTaskRow
+	err := row.Scan(&i.TaskID, &i.ActiveTaskID)
+	return i, err
 }
 
 const promoteChannelChatTasksIfMediaReady = `-- name: PromoteChannelChatTasksIfMediaReady :many

--- a/server/pkg/db/queries/agent.sql
+++ b/server/pkg/db/queries/agent.sql
@@ -1017,6 +1017,23 @@ SET status = 'cancelled', completed_at = now(), prepare_lease_expires_at = NULL
 WHERE id = $1 AND status IN ('queued', 'dispatched', 'running', 'waiting_local_directory', 'deferred')
 RETURNING *;
 
+-- name: CancelQueuedAgentTask :one
+-- Queue editing is a compare-and-set: never cancel a task that the daemon
+-- promoted between the user's click and this statement.
+UPDATE agent_task_queue
+SET status = 'cancelled', completed_at = now(), prepare_lease_expires_at = NULL
+WHERE id = sqlc.arg('id')
+  AND chat_session_id = sqlc.arg('chat_session_id')
+  AND status = 'queued'
+RETURNING *;
+
+-- name: CancelQueuedAgentTasksForSession :many
+UPDATE agent_task_queue
+SET status = 'cancelled', completed_at = now(), prepare_lease_expires_at = NULL
+WHERE chat_session_id = $1
+  AND status = 'queued'
+RETURNING *;
+
 -- name: MarkChatFinalizeDeferred :one
 -- Arms the deferred chat-finalize marker for a cancelled chat task whose
 -- empty-transcript judgment must wait for the daemon's flush ack (#5219).

--- a/server/pkg/db/queries/chat.sql
+++ b/server/pkg/db/queries/chat.sql
@@ -312,9 +312,19 @@ WHERE task_id = $1 AND role = 'user'
 RETURNING *;
 
 -- name: ListChatMessages :many
-SELECT * FROM chat_message
-WHERE chat_session_id = $1
-ORDER BY created_at ASC, id ASC;
+SELECT message.* FROM chat_message AS message
+WHERE message.chat_session_id = $1
+  AND NOT (
+    message.role = 'user'
+    AND EXISTS (
+      SELECT 1
+      FROM agent_task_queue AS task
+      WHERE task.chat_session_id = message.chat_session_id
+        AND task.status = 'queued'
+        AND task.id = message.task_id
+    )
+  )
+ORDER BY message.created_at ASC, message.id ASC;
 
 -- name: ListChatInputMessages :many
 -- Loads the immutable user-message input batch owned by a direct-chat task.
@@ -329,13 +339,23 @@ WHERE task_id = $1 AND role = 'user'
 ORDER BY created_at ASC, id ASC;
 
 -- name: ListChatMessagesPage :many
-SELECT * FROM chat_message
-WHERE chat_session_id = $1
+SELECT message.* FROM chat_message AS message
+WHERE message.chat_session_id = $1
+  AND NOT (
+    message.role = 'user'
+    AND EXISTS (
+      SELECT 1
+      FROM agent_task_queue AS task
+      WHERE task.chat_session_id = message.chat_session_id
+        AND task.status = 'queued'
+        AND task.id = message.task_id
+    )
+  )
   AND (
     sqlc.narg('before_created_at')::timestamptz IS NULL
-    OR (created_at, id) < (sqlc.narg('before_created_at')::timestamptz, sqlc.narg('before_id')::uuid)
+    OR (message.created_at, message.id) < (sqlc.narg('before_created_at')::timestamptz, sqlc.narg('before_id')::uuid)
   )
-ORDER BY created_at DESC, id DESC
+ORDER BY message.created_at DESC, message.id DESC
 LIMIT $2;
 
 -- name: GetChatMessage :one
@@ -463,6 +483,63 @@ SELECT id, status, created_at FROM agent_task_queue
 WHERE chat_session_id = $1 AND status IN ('queued', 'dispatched', 'running', 'waiting_local_directory')
 ORDER BY created_at DESC
 LIMIT 1;
+
+-- name: ListPendingChatTasksForSession :many
+-- Returns the active task first, followed by prioritized then FIFO follow-ups.
+-- The message lateral join reads only the immutable input owned by each task;
+-- it avoids loading the session's complete message history just to render a
+-- one-line queue preview. GetPendingChatTask remains for legacy callers that
+-- only need an existence check.
+SELECT
+    task.id,
+    task.status,
+    task.created_at,
+    message.id AS message_id,
+    COALESCE(message.content, '')::text AS content
+FROM agent_task_queue AS task
+LEFT JOIN LATERAL (
+    SELECT input.id, input.content
+    FROM chat_message AS input
+    WHERE input.task_id = COALESCE(task.chat_input_task_id, task.id)
+      AND input.role = 'user'
+    ORDER BY input.created_at ASC, input.id ASC
+    LIMIT 1
+) AS message ON TRUE
+WHERE task.chat_session_id = $1
+  AND task.status IN ('queued', 'dispatched', 'running', 'waiting_local_directory')
+ORDER BY
+    CASE WHEN task.status = 'queued' THEN 1 ELSE 0 END,
+    task.priority DESC,
+    task.created_at ASC,
+    task.id ASC;
+
+-- name: PrioritizeQueuedChatTask :one
+WITH demoted AS (
+  UPDATE agent_task_queue AS queued
+  SET priority = 3
+  WHERE queued.chat_session_id = sqlc.arg('chat_session_id')
+    AND queued.id <> sqlc.arg('id')
+    AND queued.status = 'queued'
+    AND queued.priority >= 4
+), prioritized AS (
+  UPDATE agent_task_queue AS selected
+  SET priority = 4
+  WHERE selected.id = sqlc.arg('id')
+    AND selected.chat_session_id = sqlc.arg('chat_session_id')
+    AND selected.status = 'queued'
+  RETURNING selected.id
+)
+SELECT
+  prioritized.id AS task_id,
+  (
+    SELECT active.id
+    FROM agent_task_queue AS active
+    WHERE active.chat_session_id = sqlc.arg('chat_session_id')
+      AND active.status IN ('dispatched', 'running', 'waiting_local_directory')
+    ORDER BY active.created_at ASC, active.id ASC
+    LIMIT 1
+  )::uuid AS active_task_id
+FROM prioritized;
 
 -- name: ListPendingChatTasksByCreator :many
 -- Aggregate view of all in-flight chat tasks owned by a given creator in a


### PR DESCRIPTION
## What does this PR do?

Reintroduces the visible chat follow-up queue from #6133 on top of the latest official `main`, with the concurrency and cross-version issues that led to #6171 addressed.

The implementation keeps PostgreSQL as the source of truth and uses the existing chat task model:

- follow-up prompts are persisted and shown in FIFO order while a task is active;
- users can send a queued prompt now, edit it, remove it, or clear the queue;
- queue editing uses a session-scoped queued-only compare-and-set, while bulk clear takes the same agent row lock as task claiming;
- transcript queries hide only a queued task's own new prompt, so older clients do not render queued follow-ups and queued retries do not hide historical root messages;
- realtime cache transitions ignore stale lifecycle events and preserve the server queue capability across head changes;
- Web, Desktop, and the floating chat window share the same queue UI and action hook.

Thinking path: the reverted implementation exposed three sources of divergence—generic cancellation could stop a task after it had been promoted, Send Now trusted stale client state, and queued prompts could leak into clients that did not understand the queue field. This version moves the authority for those decisions to session-scoped SQL/transactions, keeps protocol changes additive, and limits client optimism to reversible cache updates followed by authoritative invalidation.

## Related Issue

Reworks #6133 after the rollback in #6171.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Refactor / code improvement (no behavior change)
- [ ] Documentation update
- [x] Tests (adding or improving test coverage)
- [ ] CI / infrastructure

## Changes Made

- Added queue response schemas, API methods, pure pending-state transitions, and realtime reconciliation in `packages/core/`.
- Added the shared queue UI and queue actions for the main and floating chat surfaces in `packages/views/`, plus the running-state submit affordance in `packages/ui/`.
- Added session-scoped prioritize/clear handlers, queued-only cancellation, retry input ownership, old-client transcript filtering, and sqlc-generated queries in `server/`.
- Added unit and database-backed regression coverage for FIFO ordering, stale events, capability fallback, rollback, repeated prioritization, queued-only CAS, atomic clear, and queued retry restoration.

## How to Test

1. Start a chat task, then submit two more prompts while it is running. Confirm both appear in FIFO order below the transcript.
2. Exercise **Send now**, **Edit**, **Remove**, and **Clear all**; refresh the page and repeat from the floating chat window.
3. Run:
   - `pnpm typecheck`
   - `pnpm lint`
   - `pnpm test`
   - `go vet ./internal/handler ./internal/service ./pkg/db/generated ./cmd/server`
   - the queue-focused Core, Views, and Go handler tests
   - `make sqlc` and confirm no generated drift

Local results:

- TypeScript typecheck: passed.
- TypeScript unit tests: passed; queue-focused rerun was Core 188/188 and Views 72/72.
- Lint: 0 errors; 16 warnings are in pre-existing, untouched files.
- Queue-focused Go handler tests and affected-package `go vet`: passed.
- Full Go run passed all touched packages; two existing heartbeat tests failed because the host clock was about 2.5 seconds ahead of the local PostgreSQL container.
- Playwright: 22/29 passed. The seven failures were in untouched MCP Apps, issue-table fixture counts, and settings/Composio flows.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [ ] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [x] I have updated relevant documentation to reflect my changes
- [x] If I added a new runtime / coding tool / UI tab, I synced the change to **landing copy** (`apps/web/features/landing/i18n/`) and **relevant docs** (`apps/docs/content/docs/`) — not applicable
- [x] If this PR touches Chinese product copy, I checked it against `apps/docs/content/docs/developers/conventions.zh.mdx` (terminology, mixed-rule for `task` / `issue` / `skill`)
- [x] I have considered and documented any risks above
- [x] I will address all reviewer comments before requesting merge

## AI Disclosure

**AI tool used:** Codex (GPT-5), Kimi K3, and Cursor/Grok 4.5

**Prompt / approach:**

Codex implemented and verified the change against the official upstream repository. Independent Kimi K3 and Cursor/Grok 4.5 reviews focused on queue concurrency, cross-version behavior, realtime monotonicity, retry ownership, package boundaries, and test gaps. Findings were reproduced, fixed, and re-reviewed until both reported `BLOCKER=NO`.

## Screenshots (optional)

Captured locally at 3038×1858 during running-state validation; attachment upload is pending.
