### PR TITLE
chore(release): drop the inaccurate Apache-2.0 SPDX declaration from the Homebrew formula (MUL-5558)

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -76,7 +76,9 @@ brews:
     directory: Formula
     homepage: "https://github.com/multica-ai/multica"
     description: "Multica CLI — local agent runtime and management tool for the Multica platform"
-    license: "Apache-2.0"
+    # No license stanza: Multica ships under a modified Apache 2.0 with
+    # additional conditions (see LICENSE), which has no SPDX identifier, so
+    # declaring "Apache-2.0" here would be a false machine-readable claim.
     install: |
       bin.install "multica"
     test: |


### PR DESCRIPTION
## Problem

`.goreleaser.yml` declared `license: "Apache-2.0"` for the Homebrew formula. That is a machine-readable SPDX assertion that the CLI is licensed under unmodified Apache 2.0 — inaccurate, since Multica ships under a modified Apache 2.0 with additional conditions (LICENSE conditions 1a–1d, see MUL-5558).

This is distinct from the LICENSE file's Dify-style "modified version of the Apache License 2.0" wording, which is a referential description and stays as-is per the maintainer's decision. The formula field was the one place in the repo that flatly claimed `Apache-2.0`; GitHub's own classification of the repo is already "Other / NOASSERTION".

## Change

Remove the `license` stanza from the brews section (it is optional for tap formulas) and leave a comment explaining why, so it doesn't get re-added in good faith.

## Verification

YAML parses cleanly (`js-yaml`). The stanza only affects the generated formula's metadata on the next release tag; no build or install behavior changes. Not runnable locally — goreleaser executes on release tags only.

Closes nothing; follow-up to MUL-5558 (merged PR #6197).
