### PR TITLE
docs(license): name it the Multica License and restore the verbatim Apache 2.0 text (MUL-5558)

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -76,9 +76,9 @@ brews:
     directory: Formula
     homepage: "https://github.com/multica-ai/multica"
     description: "Multica CLI — local agent runtime and management tool for the Multica platform"
-    # No license stanza: Multica ships under a modified Apache 2.0 with
-    # additional conditions (see LICENSE), which has no SPDX identifier, so
-    # declaring "Apache-2.0" here would be a false machine-readable claim.
+    # No license stanza: Multica ships under the Multica License (Apache 2.0
+    # terms with additional conditions, see LICENSE), which has no SPDX
+    # identifier, so declaring "Apache-2.0" here would be a false claim.
     install: |
       bin.install "multica"
     test: |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,6 +12,21 @@ It covers:
 - full-stack isolated testing (backend + frontend + daemon from source)
 - troubleshooting and destructive reset options
 
+## Contribution Terms
+
+By submitting a contribution to Multica — a pull request, a patch, or any
+other work — you agree to condition 2 of the [Multica License](LICENSE):
+
+- your contribution is submitted under the Multica License as a whole (the
+  additional conditions in Part I together with the incorporated Apache
+  License 2.0 text in Part II), not under the Apache License 2.0 alone;
+- your contributed code may be used for commercial purposes, including the
+  producer's cloud business operations;
+- the producer can adjust the Multica License to be more strict or relaxed
+  as deemed necessary.
+
+See the [LICENSE](LICENSE) file for the full terms.
+
 ## Development Model
 
 Local development uses one shared PostgreSQL container and one database per checkout.

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,8 @@
-# Open Source License
+# Multica License
 
-Multica is licensed under a modified version of the Apache License 2.0, with the following additional conditions:
+Multica is provided under the terms of the Apache License, Version 2.0 —
+the complete, unmodified text of which is reproduced at the end of this
+file — subject to the following additional conditions:
 
 1. Multica may be utilized commercially, including as a backend service for
    other applications or as a task management platform for enterprises,
@@ -67,7 +69,212 @@ Multica is licensed under a modified version of the Apache License 2.0, with the
       but not limited to its cloud business operations.
 
 Apart from the specific conditions mentioned above, all other rights and
-restrictions follow the Apache License 2.0. Detailed information about the
-Apache License 2.0 can be found at http://www.apache.org/licenses/LICENSE-2.0.
+restrictions follow the Apache License, Version 2.0, as reproduced in full
+below. It is also available at http://www.apache.org/licenses/LICENSE-2.0.
 
 © 2025 Multica, Inc.
+
+------------------------------------------------------------------------
+
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/LICENSE
+++ b/LICENSE
@@ -1,8 +1,16 @@
 # Multica License
 
 Multica is provided under the terms of the Apache License, Version 2.0 —
-the complete, unmodified text of which is reproduced at the end of this
-file — subject to the following additional conditions:
+the complete, unmodified text of which is reproduced in Part II of this
+file — subject to the additional conditions in Part I.
+
+Part I and Part II together constitute the "Multica License". Neither part
+grants any rights on its own. Condition 3 states how the two parts fit
+together and what must be delivered when you redistribute.
+
+------------------------------------------------------------------------
+
+                       Part I — Additional Conditions
 
 1. Multica may be utilized commercially, including as a backend service for
    other applications or as a task management platform for enterprises,
@@ -60,19 +68,46 @@ file — subject to the following additional conditions:
       or from the producer's silence, review, or acceptance of your
       contributions.
 
-2. As a contributor, you should agree that:
+2. Contributions: By submitting a contribution to Multica, you agree that:
 
-   a. The producer can adjust the open-source agreement to be more strict
-      or relaxed as deemed necessary.
+   a. The producer can adjust this Multica License to be more strict or
+      relaxed as deemed necessary.
 
    b. Your contributed code may be used for commercial purposes, including
       but not limited to its cloud business operations.
 
-Apart from the specific conditions mentioned above, all other rights and
-restrictions follow the Apache License, Version 2.0, as reproduced in full
-below. It is also available at http://www.apache.org/licenses/LICENSE-2.0.
+   c. Your contribution is submitted under this Multica License as a whole,
+      as described in condition 3, and not under Part II alone.
 
-© 2025 Multica, Inc.
+3. Composition, precedence, and redistribution:
+
+   a. This entire file is the Multica License. Part I (these additional
+      conditions) and Part II (the incorporated Apache License, Version
+      2.0) together form a single set of terms. Apart from the conditions
+      stated in Part I, all other rights and restrictions follow Part II.
+
+   b. Wherever Part II refers to "this License", that reference means the
+      Multica License as a whole — Part I and Part II together — and not
+      Part II in isolation. This includes the copy of the License that
+      section 4(a) of Part II requires you to give to recipients, and the
+      terms under which section 5 of Part II treats a contribution as
+      submitted.
+
+   c. If Part I and Part II conflict, Part I controls.
+
+   d. If you redistribute Multica or a derivative work of it, you must
+      deliver this complete file. Delivering Part II alone does not
+      satisfy the Multica License or section 4(a) of Part II.
+
+© 2025-2026 Multica, Inc.
+
+------------------------------------------------------------------------
+
+               Part II — Incorporated Apache License 2.0 Text
+
+The text below is reproduced verbatim and unmodified from
+https://www.apache.org/licenses/LICENSE-2.0.txt. It is incorporated into
+the Multica License as described in condition 3 above.
 
 ------------------------------------------------------------------------
 

--- a/NOTICE
+++ b/NOTICE
@@ -4,11 +4,11 @@ Copyright 2025 Multica, Inc.
 This product includes software developed at Multica, Inc.
 (https://github.com/multica-ai/multica).
 
-Multica is licensed under a modified version of the Apache License 2.0, with
-additional conditions covering hosted or embedded commercial use, branding and
-copyright information displayed by a Multica user interface, and attribution
-for non-interface use. See the LICENSE file for the full text of those
-conditions.
+Multica is distributed under the Multica License: the Apache License,
+Version 2.0 with additional conditions covering hosted or embedded
+commercial use, branding and copyright information displayed by a Multica
+user interface, and attribution for non-interface use. See the LICENSE file
+for the full text.
 
 If you redistribute this software or a derivative work, you must reproduce the
 contents of this NOTICE file as required by section 4(d) of the Apache License

--- a/NOTICE
+++ b/NOTICE
@@ -1,15 +1,14 @@
 Multica
-Copyright 2025 Multica, Inc.
+Copyright 2025-2026 Multica, Inc.
 
 This product includes software developed at Multica, Inc.
 (https://github.com/multica-ai/multica).
 
-Multica is distributed under the Multica License: the Apache License,
-Version 2.0 with additional conditions covering hosted or embedded
-commercial use, branding and copyright information displayed by a Multica
-user interface, and attribution for non-interface use. See the LICENSE file
-for the full text.
+Multica is distributed under the Multica License, which incorporates the
+complete text of the Apache License, Version 2.0 together with additional
+conditions covering hosted or embedded commercial use, branding and
+copyright information displayed by a Multica user interface, and
+attribution for non-interface use. See the LICENSE file for the full text.
 
-If you redistribute this software or a derivative work, you must reproduce the
-contents of this NOTICE file as required by section 4(d) of the Apache License
-2.0.
+This NOTICE file is provided for attribution purposes only and does not
+modify the Multica License.

--- a/README.md
+++ b/README.md
@@ -224,7 +224,7 @@ An iOS mobile client lives in [`apps/mobile/`](apps/mobile/) — see its [README
 
 ## License
 
-[Multica License](LICENSE) — the Apache License 2.0 with additional conditions — see [NOTICE](NOTICE) for attribution notices.
+[Multica License](LICENSE) — the complete Apache License 2.0 text incorporated together with additional conditions — see [NOTICE](NOTICE) for attribution notices.
 
 - Providing Multica as a hosted service to third parties, or embedding it in a commercially distributed product, requires a commercial license obtained from the producer (condition 1a).
 - Unless the producer has granted a written branding waiver, the Multica LOGO, product name, and copyright information may not be removed or modified in a Multica user interface. The user interface is defined by derivation — including `apps/web/`, `apps/desktop/`, `apps/mobile/`, `packages/views/`, and `packages/ui/` — and covers raw source, the frontend container image, and compiled desktop and mobile binaries (condition 1b).

--- a/README.md
+++ b/README.md
@@ -224,7 +224,7 @@ An iOS mobile client lives in [`apps/mobile/`](apps/mobile/) — see its [README
 
 ## License
 
-[Modified Apache 2.0 (with commercial restrictions)](LICENSE) — see [NOTICE](NOTICE) for attribution notices.
+[Multica License](LICENSE) — the Apache License 2.0 with additional conditions — see [NOTICE](NOTICE) for attribution notices.
 
 - Providing Multica as a hosted service to third parties, or embedding it in a commercially distributed product, requires a commercial license obtained from the producer (condition 1a).
 - Unless the producer has granted a written branding waiver, the Multica LOGO, product name, and copyright information may not be removed or modified in a Multica user interface. The user interface is defined by derivation — including `apps/web/`, `apps/desktop/`, `apps/mobile/`, `packages/views/`, and `packages/ui/` — and covers raw source, the frontend container image, and compiled desktop and mobile binaries (condition 1b).

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -177,7 +177,7 @@ iOS 移动端代码位于 [`apps/mobile/`](apps/mobile/)，自己编译装到手
 
 ## 开源协议
 
-[Modified Apache 2.0 (with commercial restrictions)](LICENSE)，署名信息见 [NOTICE](NOTICE)。
+[Multica License](LICENSE)（Apache License 2.0 全文并入 + 附加条件），署名信息见 [NOTICE](NOTICE)。
 
 - 面向第三方的托管服务或嵌入式商业分发，需向 producer 取得商业授权（条款 1a）。
 - 除非取得 producer 的书面品牌豁免，不得移除或修改 Multica 界面中的 LOGO、产品名与署名信息。「界面」按派生关系界定——包含 `apps/web/`、`apps/desktop/`、`apps/mobile/`、`packages/views/`、`packages/ui/`——并覆盖源码、前端容器镜像与编译后的桌面 / 移动端二进制（条款 1b）。


### PR DESCRIPTION
## Problem

The ASF license FAQ is explicit on two points: a license with added conditions is "NOT the Apache License", and names of the form "Apache License with such-and-such clause" are not acceptable. Our label — "a modified version of the Apache License 2.0" / "Modified Apache 2.0 (with commercial restrictions)" — is exactly that prohibited naming pattern.

Separately, the complete Apache 2.0 text has not been in the repository since `f4ba27f2f` (2026-04-08) — the LICENSE says "all other rights and restrictions follow the Apache License 2.0" but ships only a URL. Apache §4(a) requires distributors to give recipients *a copy of the License*, which downstream users currently cannot do from our artifacts.

The problem is the **label and the missing text — not the terms**. As copyright holder, Multica may attach any conditions it wants; referencing the *unmodified, incorporated* Apache text by name is the use the FAQ permits.

## Change

Conditions 1a–1d and clause 2 are **byte-identical** to what merged in #6197. Only labels and the appended text change:

- **`LICENSE`** — titled **Multica License**; the intro now says Multica is provided "under the terms of the Apache License, Version 2.0 — the complete, unmodified text of which is reproduced at the end of this file — subject to the following additional conditions". The full canonical Apache 2.0 text is appended, verified byte-identical to https://www.apache.org/licenses/LICENSE-2.0.txt.
- **`NOTICE`, `README.md`, `README.zh-CN.md`** — "Modified Apache 2.0" labels → "Multica License"; nothing else touched. The "open source" positioning wording is deliberately unchanged (maintainer decision, Dify precedent).
- **`.goreleaser.yml`** — comment wording synced (the SPDX stanza itself was already removed in #6205).

Note on the appendix: the pre-April LICENSE (`c52c6e69c`) was *not* actually verbatim ASF text — it contained subtle wording drift and one spurious sentence ("Please also get an 'Implied Patent License' from your patent counsel") not present in the canonical license. This PR appends the true canonical text, not the historical file.

## Verification

- `tail -n 202 LICENSE` diffed byte-identical against the canonical apache.org text.
- Zero remaining occurrences of "Modified Apache" / "modified version of the Apache" / "Open Source License" in the repo.
- YAML parses cleanly. Docs-only change otherwise.

Follow-up to MUL-5558 (PRs #6197, #6205). The 04-01 → 04-08 pure-permissive snapshot window and contributor rights chain remain flagged for legal review — not addressable by text changes.


## Round 2 — review must-fixes applied (`5236dc3`)

Both must-fixes from the follow-up review are in: the file is split into `Part I — Additional Conditions` / `Part II — Incorporated Apache License 2.0 Text` with a new operative condition 3 (composition, "this License" = whole file including §4(a)/§5, Part I precedence, whole-file redistribution); condition 2 is now binding ("By submitting a contribution ... you agree") with 2c pinning contributions to the whole license, mirrored in CONTRIBUTING.md; NOTICE's incorrect §4(d) claim replaced with an informational statement; © bumped to 2025-2026.

Final review verified: conditions 1a–1d byte-identical to main; Part II byte-identical to the canonical apache.org text (sha256 `cfc7749b…3d30`); no prohibited "Modified Apache" naming remains; CI green.
