### PR TITLE
SAN-107: guard provider/model mismatches

### DIFF
--- a/server/internal/daemon/daemon.go
+++ b/server/internal/daemon/daemon.go
@@ -4744,6 +4744,9 @@ func (d *Daemon) runTask(ctx context.Context, task Task, provider string, slot i
 	if task.WorkspaceID == "" {
 		return TaskResult{}, fmt.Errorf("refusing to spawn agent: task has no workspace_id (task_id=%s)", task.ID)
 	}
+	if task.Agent != nil && agent.ModelKnownIncompatibleWithProvider(provider, task.Agent.Model) {
+		return TaskResult{}, fmt.Errorf("refusing to invoke provider %q with incompatible agent model %q", provider, task.Agent.Model)
+	}
 
 	// A new turn on a chat session supersedes any background suggestion pass
 	// still running for the previous turn (see chat_suggest.go).

--- a/server/internal/daemon/model_guard_test.go
+++ b/server/internal/daemon/model_guard_test.go
@@ -1,0 +1,24 @@
+package daemon
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"strings"
+	"testing"
+)
+
+func TestRunTaskRejectsStoredIncompatibleModelBeforeProviderSetup(t *testing.T) {
+	d := &Daemon{}
+	_, err := d.runTask(context.Background(), Task{
+		ID:          "task-model-mismatch",
+		WorkspaceID: "workspace-model-mismatch",
+		Agent:       &AgentData{Model: "claude-opus-5"},
+	}, "codex", 0, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	if err == nil {
+		t.Fatal("runTask succeeded with a Claude model on the Codex provider")
+	}
+	if !strings.Contains(err.Error(), "incompatible agent model") {
+		t.Fatalf("runTask error = %q, want incompatible-model rejection", err)
+	}
+}

--- a/server/internal/handler/agent.go
+++ b/server/internal/handler/agent.go
@@ -1065,6 +1065,10 @@ func (h *Handler) CreateAgent(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusForbidden, "this runtime is private; only its owner or a workspace admin can create agents on it")
 		return
 	}
+	if agent.ModelKnownIncompatibleWithProvider(runtime.Provider, req.Model) {
+		writeError(w, http.StatusBadRequest, fmt.Sprintf("model %q is not compatible with runtime provider %q", req.Model, runtime.Provider))
+		return
+	}
 
 	// thinking_level validation: fixed-enum providers reject unknown literals;
 	// dynamic-catalog providers (Codex/OpenCode) reject malformed tokens here.
@@ -1676,6 +1680,19 @@ func (h *Handler) UpdateAgent(w http.ResponseWriter, r *http.Request) {
 		params.MaxConcurrentTasks = pgtype.Int4{Int32: *req.MaxConcurrentTasks, Valid: true}
 	}
 	if req.Model != nil {
+		provider := targetProvider
+		if provider == "" {
+			var ok bool
+			provider, ok = h.resolveAgentProvider(r, existing.WorkspaceID, targetRuntimeID)
+			if !ok {
+				writeError(w, http.StatusInternalServerError, "failed to resolve runtime for model validation")
+				return
+			}
+		}
+		if agent.ModelKnownIncompatibleWithProvider(provider, *req.Model) {
+			writeError(w, http.StatusBadRequest, fmt.Sprintf("model %q is not compatible with runtime provider %q", *req.Model, provider))
+			return
+		}
 		params.Model = pgtype.Text{String: *req.Model, Valid: true}
 	} else if req.RuntimeID != nil && existing.Model.Valid && agent.ModelKnownIncompatibleWithProvider(targetProvider, existing.Model.String) {
 		// Model is runtime-native. When moving an agent across known provider

--- a/server/internal/handler/agent_thinking_test.go
+++ b/server/internal/handler/agent_thinking_test.go
@@ -473,6 +473,42 @@ func TestUpdateAgent_RuntimeSwitch_ClearsKnownIncompatibleModel(t *testing.T) {
 	})
 }
 
+func TestAgentModelProviderCompatibilityGuard(t *testing.T) {
+	if testHandler == nil {
+		t.Skip("database not available")
+	}
+
+	codexRuntimeID := createCodexProviderRuntime(t)
+	claudeRuntimeID := createClaudeProviderRuntime(t)
+
+	t.Run("create rejects a known foreign model", func(t *testing.T) {
+		w := httptest.NewRecorder()
+		testHandler.CreateAgent(w, newRequest(http.MethodPost, "/api/agents", map[string]any{
+			"name":                 "provider-model-create-rejected",
+			"runtime_id":           codexRuntimeID,
+			"visibility":           "private",
+			"max_concurrent_tasks": 1,
+			"model":                "claude-opus-5",
+		}))
+		if w.Code != http.StatusBadRequest {
+			t.Fatalf("create incompatible model: got %d, want 400: %s", w.Code, w.Body.String())
+		}
+	})
+
+	t.Run("update rejects a known foreign model", func(t *testing.T) {
+		agentID := createAgentOnRuntimeWithModel(t, "provider-model-update-rejected", claudeRuntimeID, "claude-opus-5")
+		w := httptest.NewRecorder()
+		req := withURLParam(newRequest(http.MethodPatch, "/api/agents/"+agentID, map[string]any{
+			"runtime_id": codexRuntimeID,
+			"model":      "claude-opus-5",
+		}), "id", agentID)
+		testHandler.UpdateAgent(w, req)
+		if w.Code != http.StatusBadRequest {
+			t.Fatalf("update incompatible model: got %d, want 400: %s", w.Code, w.Body.String())
+		}
+	})
+}
+
 // createCodexProviderRuntime mirrors createClaudeProviderRuntime but for
 // the codex provider, so runtime-switch tests can exercise a real
 // cross-provider transition.

--- a/server/internal/handler/task_terminal_wakeup_test.go
+++ b/server/internal/handler/task_terminal_wakeup_test.go
@@ -124,3 +124,61 @@ func TestTerminalTransitionsNotifyRuntime(t *testing.T) {
 		t.Fatalf("unexpected cancellation wakeups: %#v", recorder.calls)
 	}
 }
+
+func TestFailTask_ProviderFailureDoesNotCreateIssueComment(t *testing.T) {
+	if testHandler == nil || testPool == nil {
+		t.Skip("database not available")
+	}
+	ctx := context.Background()
+
+	var agentID, runtimeID string
+	if err := testPool.QueryRow(ctx,
+		`SELECT id, runtime_id FROM agent WHERE workspace_id = $1 AND runtime_id IS NOT NULL LIMIT 1`,
+		testWorkspaceID).Scan(&agentID, &runtimeID); err != nil {
+		t.Fatalf("setup: get agent: %v", err)
+	}
+
+	var issueID, taskID string
+	if err := testPool.QueryRow(ctx, `
+		INSERT INTO issue (workspace_id, title, status, priority, creator_id, creator_type, number, position, assignee_type, assignee_id)
+		VALUES ($1, 'provider failure comment fixture', 'in_progress', 'none', $2, 'member', 999100, 0, 'agent', $3)
+		RETURNING id
+	`, testWorkspaceID, testUserID, agentID).Scan(&issueID); err != nil {
+		t.Fatalf("setup: create issue: %v", err)
+	}
+	t.Cleanup(func() { testPool.Exec(ctx, `DELETE FROM issue WHERE id = $1`, issueID) })
+	if err := testPool.QueryRow(ctx, `
+		INSERT INTO agent_task_queue (agent_id, runtime_id, issue_id, status, priority, created_at, started_at)
+		VALUES ($1, $2, $3, 'running', 0, now() - interval '2 minutes', now() - interval '1 minute')
+		RETURNING id
+	`, agentID, runtimeID, issueID).Scan(&taskID); err != nil {
+		t.Fatalf("setup: create task: %v", err)
+	}
+
+	w := httptest.NewRecorder()
+	req := newDaemonTokenRequest("POST", "/api/daemon/tasks/"+taskID+"/fail", map[string]any{
+		"error":          `{"type":"error","status":400,"error":{"type":"invalid_request_error"}}`,
+		"failure_reason": "api_invalid_request",
+	}, testWorkspaceID, "legit-daemon")
+	rctx := chi.NewRouteContext()
+	rctx.URLParams.Add("taskId", taskID)
+	testHandler.FailTask(w, req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, rctx)))
+	if w.Code != http.StatusOK {
+		t.Fatalf("FailTask: expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var failureReason string
+	if err := testPool.QueryRow(ctx, `SELECT failure_reason FROM agent_task_queue WHERE id = $1`, taskID).Scan(&failureReason); err != nil {
+		t.Fatalf("read failed task: %v", err)
+	}
+	if failureReason != "api_invalid_request" {
+		t.Fatalf("failure_reason = %q, want api_invalid_request", failureReason)
+	}
+	var comments int
+	if err := testPool.QueryRow(ctx, `SELECT count(*) FROM comment WHERE source_task_id = $1`, taskID).Scan(&comments); err != nil {
+		t.Fatalf("count task comments: %v", err)
+	}
+	if comments != 0 {
+		t.Fatalf("provider failure created %d issue comments, want 0", comments)
+	}
+}

--- a/server/internal/service/task.go
+++ b/server/internal/service/task.go
@@ -3537,7 +3537,7 @@ func (s *TaskService) FailTask(ctx context.Context, taskID pgtype.UUID, errMsg, 
 	// the new task will surface its own status to the user, and we don't
 	// want to spam the issue with "task timed out" messages on every
 	// daemon hiccup.
-	if errMsg != "" && task.IssueID.Valid && retried == nil {
+	if errMsg != "" && task.IssueID.Valid && retried == nil && !suppressFailureIssueComment(failureReason) {
 		s.createAgentComment(ctx, task.IssueID, task.AgentID, redact.Text(errMsg), "system", task.TriggerCommentID, task.ID)
 	}
 
@@ -3584,6 +3584,15 @@ func (s *TaskService) FailTask(ctx context.Context, taskID pgtype.UUID, errMsg, 
 	s.broadcastTaskEvent(ctx, protocol.EventTaskFailed, task)
 
 	return &task, nil
+}
+
+// suppressFailureIssueComment keeps provider failures in the task record and
+// notifications instead of presenting untrusted provider payloads as an agent
+// reply on the issue. A provider rejection can include raw JSON, account
+// details, or transport diagnostics; none of that is useful issue-thread copy.
+func suppressFailureIssueComment(failureReason string) bool {
+	return failureReason == string(taskfailure.ReasonAPIInvalidRequest) ||
+		strings.HasPrefix(failureReason, "agent_error.provider_")
 }
 
 // resolveFailedRegenerateQuickActions resolves a refresh whose regeneration

--- a/server/internal/service/task_failure_comment_test.go
+++ b/server/internal/service/task_failure_comment_test.go
@@ -1,0 +1,25 @@
+package service
+
+import "testing"
+
+func TestSuppressFailureIssueComment(t *testing.T) {
+	tests := []struct {
+		name   string
+		reason string
+		want   bool
+	}{
+		{name: "provider invalid request", reason: "api_invalid_request", want: true},
+		{name: "provider auth failure", reason: "agent_error.provider_auth_or_access", want: true},
+		{name: "provider quota failure", reason: "agent_error.provider_quota_limit", want: true},
+		{name: "agent process failure", reason: "agent_error.process_failure", want: false},
+		{name: "runtime offline", reason: "runtime_offline", want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := suppressFailureIssueComment(tt.reason); got != tt.want {
+				t.Fatalf("suppressFailureIssueComment(%q) = %v, want %v", tt.reason, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- Reject known model/runtime provider mismatches on agent create and update.
- Refuse stale mismatched rows in the daemon before provider setup or invocation.
- Retain provider failures on task records while suppressing raw provider payloads in issue comments.

## Verification

- `git diff --check` passed.
- Added focused regression tests for create/update guards, daemon pre-invocation rejection, and provider-failure comment suppression.
- Local Go tests could not run because this execution environment has no `go` or `gofmt` binary. `make test` stops before tests because no `.env` or `.env.worktree` is present.

Security pre-push review: no Critical or High findings.
