### PR TITLE
chore: add flake.nix to support reproducible dev environments

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+use flake

--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,7 @@ node_modules
 dist
 *.log
 .DS_Store
-.envrc
+.direnv/
 
 # build outputs
 .turbo
@@ -20,6 +20,7 @@ dist-electron
 # env
 .env*
 !.env.example
+!.envrc
 # Desktop production config is public (backend URL, etc.) — track it so
 # `pnpm package` produces a release-ready build without extra setup.
 !apps/desktop/.env.production

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1785110946,
+        "narHash": "sha256-WWuWxmXKzGZWryswWlijP3Mjp6aGy4Ngmeil5nGMMjk=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "d3498f786f97ac0bded21b34bae0bf3809b45aa3",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,46 @@
+{
+  inputs = {
+    nixpkgs.url = "github:nixos/nixpkgs/nixpkgs-unstable";
+  };
+
+  outputs = {nixpkgs, ...}: let
+    forAllSystems = function:
+      nixpkgs.lib.genAttrs nixpkgs.lib.systems.flakeExposed (system:
+        function (import nixpkgs {
+          inherit system;
+          config = {
+            allowUnfree = true;
+            android_sdk.accept_license = true;
+          };
+        }));
+  in {
+    formatter = forAllSystems (pkgs: pkgs.alejandra);
+    devShells = forAllSystems (pkgs: let
+      androidSdk = pkgs.androidenv.composeAndroidPackages {
+        platformVersions = ["36"];
+        buildToolsVersions = ["35.0.0" "36.0.0"];
+        cmakeVersions = ["3.22.1"];
+        includeNDK = true;
+        ndkVersions = ["27.1.12297006"];
+      };
+    in {
+      default = pkgs.mkShell {
+        packages = with pkgs; [
+          androidSdk.androidsdk
+          corepack
+          docker-client
+          git
+          go_1_26
+          gnumake
+          jdk17
+          nodejs_22
+          sqlc
+        ];
+
+        ANDROID_HOME = "${androidSdk.androidsdk}/libexec/android-sdk";
+        ANDROID_SDK_ROOT = "${androidSdk.androidsdk}/libexec/android-sdk";
+        JAVA_HOME = pkgs.jdk17.home;
+      };
+    });
+  };
+}


### PR DESCRIPTION
This allows users who use nix to contribute to multica, without having to install all the dependencies on their machine.

It ensures all the tools needed to work on the project are installed.
