### PR TITLE
fix(inbox)[🛢️]: STR-509 이슈 제목 변경을 목록에 즉시 반영

### DIFF
--- a/packages/core/inbox/ws-updaters.ts
+++ b/packages/core/inbox/ws-updaters.ts
@@ -23,11 +23,21 @@ export function patchInboxIssueStatus(
   issueId: string,
   status: IssueStatus,
 ) {
-  const patch = (old: InboxItem[] | undefined) =>
-    old?.map((i) => (i.issue_id === issueId ? { ...i, issue_status: status } : i));
-  qc.setQueryData<InboxItem[]>(inboxKeys.list(wsId), patch);
-  // Archived rows render the same status icon, so they need the same patch.
-  qc.setQueryData<InboxItem[]>(inboxKeys.archived(wsId), patch);
+  patchInboxIssue(qc, wsId, issueId, { issue_status: status });
+}
+
+export function patchInboxIssue(
+  qc: QueryClient,
+  wsId: string,
+  issueId: string,
+  patch: Partial<Pick<InboxItem, "title" | "issue_status">>,
+) {
+  const patchRows = (old: InboxItem[] | undefined) =>
+    old?.map((i) => (i.issue_id === issueId ? { ...i, ...patch } : i));
+  qc.setQueryData<InboxItem[]>(inboxKeys.list(wsId), patchRows);
+  // Archived rows render the same issue title and status projection, so they
+  // follow issue edits too.
+  qc.setQueryData<InboxItem[]>(inboxKeys.archived(wsId), patchRows);
 }
 
 export function onInboxIssueStatusChanged(

--- a/packages/core/issues/cache-coordinator.test.ts
+++ b/packages/core/issues/cache-coordinator.test.ts
@@ -32,6 +32,7 @@ const membersKey = issueKeys.myListSorted(
   sort,
 );
 const inboxKey = inboxKeys.list(WS_ID);
+const archivedInboxKey = inboxKeys.archived(WS_ID);
 const flatKey = issueKeys.flat(WS_ID, "workspace:all", {}, sort);
 const flatTitleKey = issueKeys.flat(
   WS_ID,
@@ -131,6 +132,32 @@ function makeIssue(idx: number, overrides: Partial<Issue> = {}): Issue {
   };
 }
 
+function makeInboxItem(
+  id: string,
+  issueId: string,
+  overrides: Partial<InboxItem> = {},
+): InboxItem {
+  return {
+    id,
+    workspace_id: WS_ID,
+    recipient_type: "member",
+    recipient_id: "me",
+    actor_type: null,
+    actor_id: null,
+    type: "mentioned",
+    severity: "info",
+    issue_id: issueId,
+    title: `Inbox ${id}`,
+    body: null,
+    issue_status: "todo",
+    read: false,
+    archived: false,
+    created_at: "2025-01-01T00:00:00Z",
+    details: null,
+    ...overrides,
+  };
+}
+
 function bucketed(issues: Issue[], extraTotal = 0): ListIssuesCache {
   return {
     byStatus: {
@@ -187,6 +214,42 @@ describe("applyIssueChange", () => {
       "renamed",
     );
     expect(result.staleKeys).toEqual([]);
+  });
+
+  it("patches and rolls back the issue title in active and archived inbox rows", () => {
+    const activeInbox = [
+      makeInboxItem("inbox-1", "issue-1", { title: "Old title" }),
+      makeInboxItem("inbox-2", "issue-2", { title: "Other issue" }),
+    ];
+    const archivedInbox = [
+      makeInboxItem("archived-1", "issue-1", {
+        title: "Old title",
+        archived: true,
+      }),
+    ];
+    qc.setQueryData<InboxItem[]>(inboxKey, activeInbox);
+    qc.setQueryData<InboxItem[]>(archivedInboxKey, archivedInbox);
+
+    const patch = { title: "Renamed issue" };
+    const result = applyIssueChange(qc, WS_ID, "issue-1", patch, {
+      changed: issueChangedDims(patch, issue()),
+      baseIssue: issue(),
+    });
+
+    expect(qc.getQueryData<InboxItem[]>(inboxKey)).toEqual([
+      { ...activeInbox[0], title: "Renamed issue" },
+      activeInbox[1],
+    ]);
+    expect(qc.getQueryData<InboxItem[]>(archivedInboxKey)).toEqual([
+      { ...archivedInbox[0], title: "Renamed issue" },
+    ]);
+
+    rollbackIssueChange(qc, WS_ID, "issue-1", result);
+
+    expect(qc.getQueryData<InboxItem[]>(inboxKey)).toEqual(activeInbox);
+    expect(qc.getQueryData<InboxItem[]>(archivedInboxKey)).toEqual(
+      archivedInbox,
+    );
   });
 
   it("patches a loaded flat row without refetching an unrelated position window", () => {

--- a/packages/core/issues/cache-coordinator.ts
+++ b/packages/core/issues/cache-coordinator.ts
@@ -11,7 +11,7 @@ import {
   type MyIssuesFilter,
 } from "./queries";
 import { inboxKeys } from "../inbox/queries";
-import { patchInboxIssueStatus } from "../inbox/ws-updaters";
+import { patchInboxIssue } from "../inbox/ws-updaters";
 import { projectKeys } from "../projects/queries";
 import {
   decrementBucketTotal,
@@ -73,8 +73,8 @@ export type IssueTableRowCache = IssueTableRowsResponse;
  * uncommitted state and stomp the optimistic patch), the WS path invalidates
  * immediately (the server already committed).
  *
- * The detail cache and the Inbox `issue_status` projection are patched in the
- * same pass. Aggregate projections that cannot be recomputed from one entity
+ * The detail cache and Inbox title/status projections are patched in the same
+ * pass. Aggregate projections that cannot be recomputed from one entity
  * (assignee-grouped boards, Gantt, project metrics) go through
  * {@link invalidateIssueDerivatives}.
  */
@@ -87,6 +87,7 @@ export interface IssueCacheChangeResult {
   prevTableRows: [QueryKey, IssueTableRowCache][];
   prevDetail: Issue | undefined;
   prevInboxList: InboxItem[] | undefined;
+  prevArchivedInboxList: InboxItem[] | undefined;
   /** Loaded list keys whose server result may have drifted (membership
    *  unknown, possible enter/leave beyond the loaded window, bucket-count
    *  drift). Invalidate on settle (mutation) or immediately (WS). */
@@ -428,12 +429,20 @@ export function applyIssueChange(
     if (!prevIssue) prevIssue = prevDetail;
   }
 
-  // Inbox rows carry an `issue_status` display snapshot; the issue's status
-  // is the real state, so the projection follows every status write.
+  // Inbox rows carry issue title/status display snapshots. The issue is the
+  // real state, so both projections follow every issue write that touches
+  // either field.
   let prevInboxList: InboxItem[] | undefined;
-  if (patch.status !== undefined) {
+  let prevArchivedInboxList: InboxItem[] | undefined;
+  if (patch.title !== undefined || patch.status !== undefined) {
     prevInboxList = qc.getQueryData<InboxItem[]>(inboxKeys.list(wsId));
-    if (prevInboxList) patchInboxIssueStatus(qc, wsId, id, patch.status);
+    prevArchivedInboxList = qc.getQueryData<InboxItem[]>(
+      inboxKeys.archived(wsId),
+    );
+    patchInboxIssue(qc, wsId, id, {
+      ...(patch.title !== undefined ? { title: patch.title } : {}),
+      ...(patch.status !== undefined ? { issue_status: patch.status } : {}),
+    });
   }
 
   return {
@@ -442,6 +451,7 @@ export function applyIssueChange(
     prevTableRows,
     prevDetail,
     prevInboxList,
+    prevArchivedInboxList,
     staleKeys,
     prevIssue,
   };
@@ -460,6 +470,7 @@ export function rollbackIssueChange(
     | "prevTableRows"
     | "prevDetail"
     | "prevInboxList"
+    | "prevArchivedInboxList"
   >,
 ) {
   for (const [key, snapshot] of result.prevLists) {
@@ -476,6 +487,12 @@ export function rollbackIssueChange(
   }
   if (result.prevInboxList !== undefined) {
     qc.setQueryData(inboxKeys.list(wsId), result.prevInboxList);
+  }
+  if (result.prevArchivedInboxList !== undefined) {
+    qc.setQueryData(
+      inboxKeys.archived(wsId),
+      result.prevArchivedInboxList,
+    );
   }
 }
 

--- a/packages/core/issues/mutations.ts
+++ b/packages/core/issues/mutations.ts
@@ -251,8 +251,8 @@ export function useUpdateIssue() {
       qc.cancelQueries({ queryKey: issueKeys.myAll(wsId) });
       qc.cancelQueries({ queryKey: issueKeys.flatAll(wsId) });
       qc.cancelQueries({ queryKey: issueKeys.tableAll(wsId) });
-      if (patch.status !== undefined) {
-        qc.cancelQueries({ queryKey: inboxKeys.list(wsId) });
+      if (patch.title !== undefined || patch.status !== undefined) {
+        qc.cancelQueries({ queryKey: inboxKeys.all(wsId) });
       }
       const prevDetail = qc.getQueryData<Issue>(issueKeys.detail(wsId, id));
       // The coordinator owns the cross-cache rules: surgical patch/rebucket
@@ -517,8 +517,8 @@ export function useBatchUpdateIssues() {
       await qc.cancelQueries({ queryKey: issueKeys.myAll(wsId) });
       await qc.cancelQueries({ queryKey: issueKeys.flatAll(wsId) });
       await qc.cancelQueries({ queryKey: issueKeys.tableAll(wsId) });
-      if (patch.status !== undefined) {
-        await qc.cancelQueries({ queryKey: inboxKeys.list(wsId) });
+      if (patch.title !== undefined || patch.status !== undefined) {
+        await qc.cancelQueries({ queryKey: inboxKeys.all(wsId) });
       }
 
       // Run every issue through the coordinator — the same rules table the
@@ -535,6 +535,7 @@ export function useBatchUpdateIssues() {
       >();
       const prevDetailById = new Map<string, Issue>();
       let prevInboxList: InboxItem[] | undefined;
+      let prevArchivedInboxList: InboxItem[] | undefined;
       const staleKeys: QueryKey[] = [];
       for (const id of ids) {
         const base = qc.getQueryData<Issue>(issueKeys.detail(wsId, id));
@@ -561,6 +562,12 @@ export function useBatchUpdateIssues() {
         if (change.prevDetail) prevDetailById.set(id, change.prevDetail);
         if (prevInboxList === undefined && change.prevInboxList !== undefined) {
           prevInboxList = change.prevInboxList;
+        }
+        if (
+          prevArchivedInboxList === undefined &&
+          change.prevArchivedInboxList !== undefined
+        ) {
+          prevArchivedInboxList = change.prevArchivedInboxList;
         }
         staleKeys.push(...change.staleKeys);
       }
@@ -590,6 +597,7 @@ export function useBatchUpdateIssues() {
         prevTableRows: [...prevTableRowByHash.values()],
         prevDetailById,
         prevInboxList,
+        prevArchivedInboxList,
         staleKeys,
         prevChildren,
         affectedParentIds,
@@ -618,6 +626,12 @@ export function useBatchUpdateIssues() {
       }
       if (ctx?.prevInboxList !== undefined) {
         qc.setQueryData(inboxKeys.list(wsId), ctx.prevInboxList);
+      }
+      if (ctx?.prevArchivedInboxList !== undefined) {
+        qc.setQueryData(
+          inboxKeys.archived(wsId),
+          ctx.prevArchivedInboxList,
+        );
       }
       if (ctx?.prevChildren) {
         for (const [parentId, snapshot] of ctx.prevChildren) {

--- a/server/internal/handler/inbox.go
+++ b/server/internal/handler/inbox.go
@@ -53,6 +53,10 @@ func inboxToResponse(i db.InboxItem) InboxItemResponse {
 }
 
 func inboxRowToResponse(r db.ListInboxItemsRow) InboxItemResponse {
+	title := r.Title
+	if r.IssueTitle.Valid {
+		title = r.IssueTitle.String
+	}
 	return InboxItemResponse{
 		ID:            uuidToString(r.ID),
 		WorkspaceID:   uuidToString(r.WorkspaceID),
@@ -61,7 +65,7 @@ func inboxRowToResponse(r db.ListInboxItemsRow) InboxItemResponse {
 		Type:          r.Type,
 		Severity:      r.Severity,
 		IssueID:       uuidToPtr(r.IssueID),
-		Title:         r.Title,
+		Title:         title,
 		Body:          textToPtr(r.Body),
 		Read:          r.Read,
 		Archived:      r.Archived,
@@ -74,9 +78,10 @@ func inboxRowToResponse(r db.ListInboxItemsRow) InboxItemResponse {
 }
 
 // ListArchivedInboxItemsRow carries the same columns as ListInboxItemsRow (both
-// queries select `inbox_item.*` plus the joined issue status), so the archived
-// row converts to the active one and reuses its mapper. If either query's
-// column list drifts, this conversion stops compiling — which is the point.
+// queries select `inbox_item.*` plus the joined issue status and title), so the
+// archived row converts to the active one and reuses its mapper. If either
+// query's column list drifts, this conversion stops compiling — which is the
+// point.
 func archivedInboxRowToResponse(r db.ListArchivedInboxItemsRow) InboxItemResponse {
 	return inboxRowToResponse(db.ListInboxItemsRow(r))
 }

--- a/server/internal/handler/inbox_test.go
+++ b/server/internal/handler/inbox_test.go
@@ -1,0 +1,29 @@
+package handler
+
+import (
+	"testing"
+
+	"github.com/jackc/pgx/v5/pgtype"
+	db "github.com/multica-ai/multica/server/pkg/db/generated"
+)
+
+func TestInboxRowToResponseUsesCurrentIssueTitle(t *testing.T) {
+	resp := inboxRowToResponse(db.ListInboxItemsRow{
+		Title:      "title captured when the notification was created",
+		IssueTitle: pgtype.Text{String: "current issue title", Valid: true},
+	})
+
+	if resp.Title != "current issue title" {
+		t.Fatalf("expected current issue title, got %q", resp.Title)
+	}
+}
+
+func TestInboxRowToResponseFallsBackToStoredTitleWithoutIssue(t *testing.T) {
+	resp := inboxRowToResponse(db.ListInboxItemsRow{
+		Title: "standalone inbox title",
+	})
+
+	if resp.Title != "standalone inbox title" {
+		t.Fatalf("expected stored title fallback, got %q", resp.Title)
+	}
+}

--- a/server/pkg/db/generated/inbox.sql.go
+++ b/server/pkg/db/generated/inbox.sql.go
@@ -347,7 +347,8 @@ func (q *Queries) GetInboxItemInWorkspace(ctx context.Context, arg GetInboxItemI
 
 const listArchivedInboxItems = `-- name: ListArchivedInboxItems :many
 SELECT i.id, i.workspace_id, i.recipient_type, i.recipient_id, i.type, i.severity, i.issue_id, i.title, i.body, i.read, i.archived, i.created_at, i.actor_type, i.actor_id, i.details,
-       iss.status as issue_status
+       iss.status as issue_status,
+       iss.title as issue_title
 FROM inbox_item i
 LEFT JOIN issue iss ON iss.id = i.issue_id
 WHERE i.workspace_id = $1 AND i.recipient_type = $2 AND i.recipient_id = $3 AND i.archived = true
@@ -387,6 +388,7 @@ type ListArchivedInboxItemsRow struct {
 	ActorID       pgtype.UUID        `json:"actor_id"`
 	Details       []byte             `json:"details"`
 	IssueStatus   pgtype.Text        `json:"issue_status"`
+	IssueTitle    pgtype.Text        `json:"issue_title"`
 }
 
 // Archived counterpart of ListInboxItems, backing the inbox's "Archived"
@@ -430,6 +432,7 @@ func (q *Queries) ListArchivedInboxItems(ctx context.Context, arg ListArchivedIn
 			&i.ActorID,
 			&i.Details,
 			&i.IssueStatus,
+			&i.IssueTitle,
 		); err != nil {
 			return nil, err
 		}
@@ -443,7 +446,8 @@ func (q *Queries) ListArchivedInboxItems(ctx context.Context, arg ListArchivedIn
 
 const listInboxItems = `-- name: ListInboxItems :many
 SELECT i.id, i.workspace_id, i.recipient_type, i.recipient_id, i.type, i.severity, i.issue_id, i.title, i.body, i.read, i.archived, i.created_at, i.actor_type, i.actor_id, i.details,
-       iss.status as issue_status
+       iss.status as issue_status,
+       iss.title as issue_title
 FROM inbox_item i
 LEFT JOIN issue iss ON iss.id = i.issue_id
 WHERE i.workspace_id = $1 AND i.recipient_type = $2 AND i.recipient_id = $3 AND i.archived = false
@@ -473,6 +477,7 @@ type ListInboxItemsRow struct {
 	ActorID       pgtype.UUID        `json:"actor_id"`
 	Details       []byte             `json:"details"`
 	IssueStatus   pgtype.Text        `json:"issue_status"`
+	IssueTitle    pgtype.Text        `json:"issue_title"`
 }
 
 func (q *Queries) ListInboxItems(ctx context.Context, arg ListInboxItemsParams) ([]ListInboxItemsRow, error) {
@@ -501,6 +506,7 @@ func (q *Queries) ListInboxItems(ctx context.Context, arg ListInboxItemsParams) 
 			&i.ActorID,
 			&i.Details,
 			&i.IssueStatus,
+			&i.IssueTitle,
 		); err != nil {
 			return nil, err
 		}

--- a/server/pkg/db/queries/inbox.sql
+++ b/server/pkg/db/queries/inbox.sql
@@ -1,6 +1,7 @@
 -- name: ListInboxItems :many
 SELECT i.*,
-       iss.status as issue_status
+       iss.status as issue_status,
+       iss.title as issue_title
 FROM inbox_item i
 LEFT JOIN issue iss ON iss.id = i.issue_id
 WHERE i.workspace_id = $1 AND i.recipient_type = $2 AND i.recipient_id = $3 AND i.archived = false
@@ -23,7 +24,8 @@ ORDER BY i.created_at DESC;
 -- pagination). Rows are newest-first, so truncation drops the OLDEST rows and
 -- can never hide a group's newest row — the one the deduplicated UI renders.
 SELECT i.*,
-       iss.status as issue_status
+       iss.status as issue_status,
+       iss.title as issue_title
 FROM inbox_item i
 LEFT JOIN issue iss ON iss.id = i.issue_id
 WHERE i.workspace_id = $1 AND i.recipient_type = $2 AND i.recipient_id = $3 AND i.archived = true


### PR DESCRIPTION
## 한눈에 보기

- 문제: 이슈 제목을 바꿔도 인박스에는 알림 생성 당시 제목이 계속 보였습니다.
- 해결: 인박스가 연결된 이슈의 현재 제목을 반환하고, 로컬·실시간 변경도 목록 캐시에 즉시 반영합니다.
- 영향: 활성 인박스와 보관 인박스 모두 새 제목을 표시하며, 이슈와 무관한 시스템 알림 제목은 그대로 유지됩니다.
- 운영 참고: DB 스키마나 마이그레이션 변경은 없고 기존 API의 `title` 필드 형식도 유지됩니다.

## What does this PR do?

인박스 행은 알림이 만들어질 때의 이슈 제목을 스냅샷으로 저장했고, 목록 조회는 현재 이슈에서 상태만 조인했습니다. 클라이언트의 공통 이슈 캐시 조정기도 인박스의 상태만 갱신했습니다. 그 결과 같은 화면에서 제목을 수정하거나 다른 탭·에이전트가 제목을 수정해도 오래된 제목이 남았고, 새로고침 후에도 DB 스냅샷이 다시 반환됐습니다.

이 PR은 목록 조회 시 연결된 이슈의 현재 제목을 우선 사용하고, 연결된 이슈가 없으면 기존 저장 제목으로 fallback합니다. 또한 공통 캐시 조정기가 제목과 상태를 활성/보관 인박스에 함께 반영하고 mutation 실패 시 두 캐시를 원래 값으로 되돌립니다.

## Related Issue

Closes STR-509

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Tests (adding or improving test coverage)

## Changes Made

- `server/pkg/db/queries/inbox.sql`: 활성/보관 목록에 현재 이슈 제목 projection 추가
- `server/internal/handler/inbox.go`: 현재 이슈 제목 우선, 독립 알림은 저장 제목 fallback
- `packages/core/issues/cache-coordinator.ts`: 제목/상태를 활성·보관 인박스 캐시에 패치하고 오류 시 모두 롤백
- `packages/core/issues/mutations.ts`: 제목/상태 변경 중 인박스 쿼리 경합 방지
- 서버 응답 mapper와 프런트 캐시 동작에 회귀 테스트 추가

## Completion Criteria

- [x] 이슈 제목을 수정하면 열린 인박스 목록에서 즉시 새 제목이 보입니다.
- [x] 다른 탭이나 에이전트의 `issue:updated` 이벤트도 같은 캐시 경로로 새 제목을 반영합니다.
- [x] 새로고침 후 API 응답도 현재 이슈 제목을 반환합니다.
- [x] 보관 인박스와 이슈가 없는 독립 알림의 기존 동작을 유지합니다.

## How to Test

1. 인박스에 표시되는 이슈를 열고 제목을 변경합니다.
2. 활성 인박스와 보관 인박스에서 변경된 제목이 즉시 표시되는지 확인합니다.
3. 페이지를 새로고침한 뒤에도 변경된 제목이 유지되는지 확인합니다.

## Test Scenarios

### 핵심 성공 경로

- 조건: 이슈에 연결된 활성 또는 보관 인박스 행이 캐시에 있음
- 조작: 해당 이슈 제목 변경
- 기대: 대상 이슈의 모든 인박스 행만 새 제목으로 바뀌고 다른 이슈 행은 유지됨

### 회귀 경로

- 조건: 이슈가 연결되지 않은 quick-create 실패/시스템 알림
- 조작: 인박스 목록 조회
- 기대: 조인된 제목이 없으므로 저장된 알림 제목을 그대로 표시함

## Verification

- [x] `pnpm exec vitest run packages/core/issues/cache-coordinator.test.ts packages/core/issues/mutations.test.tsx packages/core/inbox/ws-updaters.test.ts` — 21 files, 197 tests passed
- [x] `pnpm --filter @multica/core typecheck` — passed
- [x] `pnpm --filter @multica/core lint` — passed
- [x] clean worktree에서 `go test ./internal/handler -run 'TestInboxRowToResponse' -count=1` — passed
- [x] `sqlc v1.31.1 generate` — generated output has zero diff
- [ ] `pnpm typecheck` — unrelated existing UI dependency resolution errors (`@tanstack/react-virtual`, `@number-flow/react`) 때문에 전체 실행은 완료하지 못함; 변경 패키지 typecheck로 대체 검증

## Risks / Unknowns

- 리스크는 낮습니다. API shape은 유지하고 read-only 목록 projection만 현재 제목으로 바꿉니다.
- UI 수동 스크린샷 검증은 수행하지 않았습니다. 캐시 및 응답 경계 단위 테스트로 동작을 검증했습니다.
- 롤백은 이 커밋을 되돌리면 되며 데이터 마이그레이션은 없습니다.

## Schema / SQL

- 변경 파일: inbox 목록 SELECT query 및 sqlc 생성 코드
- 마이그레이션: 없음
- DB 스키마/데이터 변경: 없음
- 생성 검증: sqlc v1.31.1 재생성 결과 zero diff

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have run the relevant local tests and they pass
- [x] I have added or updated tests where applicable
- [x] I have considered and documented risks above
- [ ] If this change affects the UI, I have included before/after screenshots — data freshness fix; no visual layout change, not captured locally
- [ ] I have updated relevant documentation — no public behavior contract or setup documentation changed
- [ ] I will address all reviewer comments before requesting merge

## AI Disclosure

**AI tool used:** Multica Codex agent

**Prompt / approach:** STR-509의 필수 이슈 이력과 저장소 규칙을 읽고, 인박스 API projection과 React Query 캐시 전파 경로를 추적했습니다. 회귀 테스트를 먼저 실패시키고 서버의 현재 제목 projection, 공통 캐시 패치/롤백, 관련 검증 순서로 최소 수정했습니다.

## Screenshots (optional)

미첨부 — 시각 스타일 변경이 아닌 제목 데이터 신선도 수정입니다.
