### PR TITLE
MUL-5580: fix(issues): use a solid tone for the filtered empty-state icon

### DIFF
--- a/packages/views/issues/surface/issue-surface.tsx
+++ b/packages/views/issues/surface/issue-surface.tsx
@@ -334,7 +334,7 @@ function FilteredEmptyState() {
 
   return (
     <div className="flex flex-1 min-h-0 flex-col items-center justify-center gap-3 text-muted-foreground">
-      <FilterX className="h-10 w-10 text-muted-foreground/40" />
+      <FilterX className="h-10 w-10 text-faint-foreground" />
       <p className="text-body">{t(($) => $.filtered_empty.title)}</p>
       <p className="text-caption">{t(($) => $.filtered_empty.hint)}</p>
       <Button variant="outline" size="sm" className="mt-1" onClick={clearFilters}>


### PR DESCRIPTION
## What broke

`main`'s `frontend-test` job has failed on every commit since 13b06f038 (#6191). One assertion, in `apps/web/app/text-contrast.test.ts`:

```
Transparency standing in for a text tone:
packages/views/issues/surface/issue-surface.tsx  text-muted-foreground/40
(use a solid tone: text-foreground / text-muted-foreground, or text-faint-foreground for icons and glyphs)
```

## Why

#6152 replaced the text-transparency ladder with solid tones and added this test to keep it from coming back. #6191 was cut before that guard landed, so its new `FilteredEmptyState` still wrote its `FilterX` glyph as `text-muted-foreground/40` — exactly the shape the rule rejects — and the merge reintroduced it. Nothing was wrong with the test; the branch just predated it.

## Fix

One line: `text-muted-foreground/40` → `text-faint-foreground`, the token the rule names for icons and glyphs. That is the same class every other empty-state glyph already uses (`inbox-page.tsx`, `chat-page.tsx`, `autopilots-page.tsx`), so the empty state now matches them instead of rendering a slightly different grey.

## Verification

- `pnpm vitest run app/text-contrast.test.ts` in `apps/web` — 23/23 pass (failed 1/23 before the change).
- `pnpm test` at the repo root — 5/5 turbo tasks successful; `@multica/views` 3427 tests across 292 files pass.
