### PR TITLE
fix(labels): always enable resource labels (MUL-5563)

### DIFF
--- a/docs/feature-flags.md
+++ b/docs/feature-flags.md
@@ -179,24 +179,15 @@ function Checkout() {
 
 Outside a `FeatureFlagsProvider` (Storybook, unit tests, error pages) `useFlag` / `useVariant` return the supplied default. You never have to mount the provider just to render a component in isolation.
 
-### v0.3.44 compatibility rollout
+### Completed v0.3.44 compatibility rollouts
 
-The following release flag defaults to `false` so the schema can ship before
-the new persisted state is visible to older server pods or a rollback:
-
-```yaml
-# Enable only after every v0.3.43 server pod has drained and rollback reads
-# have been validated against the migrated database.
-settings_resource_labels:
-  default: true
-```
-
-Keep it off for v0.3.44: it is a schema-only deployment for resource labels. A
-later rollout may enable it only after it ships and verifies a rollback
-normalizer for resource-label rows. Do not rely on turning the flag off to make
-a database safe for an older binary; it prevents new writes but cannot remove
-states that already exist. Until that normalizer exists, rollbacks must target
-a version that understands these states or happen before the flag is enabled.
+Resource Labels has completed its schema-first rollout and is now always
+available. Current clients always render agent- and skill-scoped labels, and
+the backend no longer gates their catalog or assignment endpoints.
+`/api/config` still reports `settings_resource_labels: true` so installed
+desktop clients that still gate the UI on this config decision also receive
+the permanently enabled behavior; this is a client-compatibility decision, not
+an operator-controlled flag.
 
 Agent Builder has completed this rollout and is now always available. Current
 clients always render the AI creation entry, and the backend no longer gates the

--- a/docs/feature-flags.md
+++ b/docs/feature-flags.md
@@ -185,9 +185,20 @@ Resource Labels has completed its schema-first rollout and is now always
 available. Current clients always render agent- and skill-scoped labels, and
 the backend no longer gates their catalog or assignment endpoints.
 `/api/config` still reports `settings_resource_labels: true` so installed
-desktop clients that still gate the UI on this config decision also receive
-the permanently enabled behavior; this is a client-compatibility decision, not
-an operator-controlled flag.
+v0.4.0 desktop clients that still gate the UI on this config decision also
+receive the permanently enabled behavior; this is a client-compatibility
+decision, not an operator-controlled flag.
+
+The rollback prerequisite that originally justified the flag is implemented by
+the down-migration chain: `174_legacy_label_index_rollback_prep.down.sql`
+deletes all agent- and skill-scoped label rows before
+`171_drop_legacy_label_namespace_index.down.sql` recreates the pre-162
+workspace-wide unique name index. The remaining down migrations then remove
+the resource-label junction tables and `resource_type` column.
+
+Now that users can create resource-scoped labels, rollback to the pre-v0.3.44
+schema is no longer supported: migration 174 would delete user data. Roll back
+only to a release that understands resource-scoped labels.
 
 Agent Builder has completed this rollout and is now always available. Current
 clients always render the AI creation entry, and the backend no longer gates the

--- a/docs/feature-flags.md
+++ b/docs/feature-flags.md
@@ -185,9 +185,11 @@ Resource Labels has completed its schema-first rollout and is now always
 available. Current clients always render agent- and skill-scoped labels, and
 the backend no longer gates their catalog or assignment endpoints.
 `/api/config` still reports `settings_resource_labels: true` so installed
-v0.4.0 desktop clients that still gate the UI on this config decision also
-receive the permanently enabled behavior; this is a client-compatibility
-decision, not an operator-controlled flag.
+desktop clients from v0.4.0 through at least v0.4.15 (every release before this
+change) receive the permanently enabled behavior. Every client in that range
+fails closed to `false` when the key is absent, so this compatibility decision
+must remain until those clients are no longer supported; it is not an
+operator-controlled flag.
 
 The rollback prerequisite that originally justified the flag is implemented by
 the down-migration chain: `174_legacy_label_index_rollback_prep.down.sql`

--- a/packages/core/feature-flags/index.ts
+++ b/packages/core/feature-flags/index.ts
@@ -17,10 +17,7 @@ export type {
 export { FeatureFlagService } from "./service";
 export { StaticProvider } from "./static-provider";
 export { ChainProvider } from "./chain-provider";
-export {
-  COMPOSIO_MCP_APPS_FLAG,
-  RESOURCE_LABELS_FLAG,
-} from "./keys";
+export { COMPOSIO_MCP_APPS_FLAG } from "./keys";
 export {
   FeatureFlagsProvider,
   useFeatureFlagService,

--- a/packages/core/feature-flags/keys.ts
+++ b/packages/core/feature-flags/keys.ts
@@ -1,2 +1,1 @@
 export const COMPOSIO_MCP_APPS_FLAG = "composio_mcp_apps";
-export const RESOURCE_LABELS_FLAG = "settings_resource_labels";

--- a/packages/views/labels/index.ts
+++ b/packages/views/labels/index.ts
@@ -1,5 +1,2 @@
 export { LabelChip } from "./label-chip";
-export {
-  ResourceLabelPicker,
-  useResourceLabelsEnabled,
-} from "./resource-label-picker";
+export { ResourceLabelPicker } from "./resource-label-picker";

--- a/packages/views/labels/resource-label-picker.tsx
+++ b/packages/views/labels/resource-label-picker.tsx
@@ -4,8 +4,6 @@ import { useMemo, useState } from "react";
 import { useQuery } from "@tanstack/react-query";
 import { Check, Search, Tag } from "lucide-react";
 import { useWorkspaceId } from "@multica/core/hooks";
-import { useFeatureEnabled } from "@multica/core/config";
-import { RESOURCE_LABELS_FLAG } from "@multica/core/feature-flags";
 import {
   labelListOptions,
   resourceLabelsOptions,
@@ -22,17 +20,6 @@ import {
 import { useT } from "../i18n";
 import { LabelChip } from "./label-chip";
 
-/**
- * Whether agent- and skill-scoped labels are available. The server gates the
- * attach/detach routes on the same release flag, so with it off the picker has
- * no working endpoint to call — and callers need to know that before they lay
- * out a row for it, since a row whose only control renders nothing reads as a
- * broken field rather than an absent feature.
- */
-export function useResourceLabelsEnabled() {
-  return useFeatureEnabled(RESOURCE_LABELS_FLAG, false);
-}
-
 export function ResourceLabelPicker({
   resourceType,
   resourceId,
@@ -44,18 +31,11 @@ export function ResourceLabelPicker({
 }) {
   const { t } = useT("labels");
   const wsId = useWorkspaceId();
-  const resourceLabelsEnabled = useResourceLabelsEnabled();
   const [open, setOpen] = useState(false);
   const [query, setQuery] = useState("");
-  const { data: catalog = [] } = useQuery({
-    ...labelListOptions(wsId, resourceType),
-    enabled: resourceLabelsEnabled,
-  });
+  const { data: catalog = [] } = useQuery(labelListOptions(wsId, resourceType));
   const { data: selected = [] } = useQuery(
-    {
-      ...resourceLabelsOptions(wsId, resourceType, resourceId),
-      enabled: resourceLabelsEnabled,
-    },
+    resourceLabelsOptions(wsId, resourceType, resourceId),
   );
   const attach = useAttachResourceLabel(resourceType, resourceId);
   const detach = useDetachResourceLabel(resourceType, resourceId);
@@ -63,8 +43,6 @@ export function ResourceLabelPicker({
   const filtered = catalog.filter((label) =>
     label.name.toLowerCase().includes(query.trim().toLowerCase()),
   );
-
-  if (!resourceLabelsEnabled) return null;
 
   const content = selected.length > 0 ? (
     <div className="flex flex-wrap justify-start gap-1 sm:justify-end">

--- a/packages/views/settings/components/labels-tab.tsx
+++ b/packages/views/settings/components/labels-tab.tsx
@@ -4,8 +4,6 @@ import { useEffect, useMemo, useState } from "react";
 import { useQuery } from "@tanstack/react-query";
 import { MoreHorizontal, Pencil, Plus, Search, Tag, Trash2 } from "lucide-react";
 import { toast } from "sonner";
-import { useFeatureEnabled } from "@multica/core/config";
-import { RESOURCE_LABELS_FLAG } from "@multica/core/feature-flags";
 import { useWorkspaceId } from "@multica/core/hooks";
 import {
   labelListOptions,
@@ -48,7 +46,6 @@ import { useT } from "../../i18n";
 import { SettingsTab } from "./settings-layout";
 
 const RESOURCE_TYPES: LabelResourceType[] = ["issue", "agent", "skill"];
-const ISSUE_RESOURCE_TYPES: LabelResourceType[] = ["issue"];
 
 interface LabelDraft {
   name: string;
@@ -65,22 +62,12 @@ const EMPTY_DRAFT: LabelDraft = {
 export function LabelsTab() {
   const { t } = useT("settings");
   const wsId = useWorkspaceId();
-  const resourceLabelsEnabled = useFeatureEnabled(RESOURCE_LABELS_FLAG, false);
 
   const [resourceType, setResourceType] = useState<LabelResourceType>("issue");
   const [query, setQuery] = useState("");
   const [editing, setEditing] = useState<Label | null>(null);
   const [createOpen, setCreateOpen] = useState(false);
   const [pendingDelete, setPendingDelete] = useState<Label | null>(null);
-
-  const resourceTypes = resourceLabelsEnabled ? RESOURCE_TYPES : ISSUE_RESOURCE_TYPES;
-
-  useEffect(() => {
-    if (!resourceLabelsEnabled && resourceType !== "issue") {
-      setResourceType("issue");
-      setQuery("");
-    }
-  }, [resourceLabelsEnabled, resourceType]);
 
   const { data: labels = [], isLoading } = useQuery(
     labelListOptions(wsId, resourceType),
@@ -104,7 +91,7 @@ export function LabelsTab() {
     >
       <div className="space-y-5">
         <div className="flex flex-wrap items-center gap-2 border-b border-surface-border pb-3">
-          {resourceTypes.map((type) => (
+          {RESOURCE_TYPES.map((type) => (
             <Button
               key={type}
               type="button"

--- a/packages/views/skills/components/skill-detail-page.test.tsx
+++ b/packages/views/skills/components/skill-detail-page.test.tsx
@@ -81,9 +81,6 @@ vi.mock("../../rich-content", () => ({
 }));
 vi.mock("../../labels/resource-label-picker", () => ({
   ResourceLabelPicker: () => <div data-testid="labels" />,
-  // The row is only laid out when the release flag is on; with it off the
-  // picker renders nothing and the label would sit above an empty field.
-  useResourceLabelsEnabled: () => true,
 }));
 vi.mock("./skill-list-actions", () => ({ AddToAgentDialog: () => null }));
 vi.mock("@multica/ui/components/common/capability-banner", () => ({
@@ -158,6 +155,11 @@ describe("SkillDetailPage tabs", () => {
     expect(
       screen.getByRole("tab", { name: "Overview" }).getAttribute("aria-selected"),
     ).toBe("true");
+  });
+
+  it("shows resource labels in Overview without a release flag", async () => {
+    renderPage();
+    expect(await screen.findByTestId("labels")).toBeTruthy();
   });
 
   it("mirrors the active tab into ?view= so the pane survives a reload", async () => {

--- a/packages/views/skills/components/skill-detail-page.tsx
+++ b/packages/views/skills/components/skill-detail-page.tsx
@@ -77,10 +77,7 @@ import {
   type SkillActionsContext,
 } from "./skill-list-actions";
 import { useT } from "../../i18n";
-import {
-  ResourceLabelPicker,
-  useResourceLabelsEnabled,
-} from "../../labels/resource-label-picker";
+import { ResourceLabelPicker } from "../../labels/resource-label-picker";
 
 const SKILL_MD = "SKILL.md";
 
@@ -370,7 +367,6 @@ function OverviewTab({
   onAddToAgents: () => void;
 }) {
   const { t } = useT("skills");
-  const labelsEnabled = useResourceLabelsEnabled();
 
   return (
     <div className="mx-auto w-full max-w-3xl p-4 sm:p-6 md:p-8">
@@ -414,15 +410,13 @@ function OverviewTab({
             </p>
           </PropertyRow>
 
-          {labelsEnabled && (
-            <PropertyRow label={t(($) => $.detail.overview.labels)}>
-              <ResourceLabelPicker
-                resourceType="skill"
-                resourceId={skill.id}
-                canEdit={canEdit}
-              />
-            </PropertyRow>
-          )}
+          <PropertyRow label={t(($) => $.detail.overview.labels)}>
+            <ResourceLabelPicker
+              resourceType="skill"
+              resourceId={skill.id}
+              canEdit={canEdit}
+            />
+          </PropertyRow>
         </div>
       </section>
 

--- a/server/internal/featureflags/keys.go
+++ b/server/internal/featureflags/keys.go
@@ -28,8 +28,11 @@ const (
 	// switch on this config decision, receive the permanently enabled behavior.
 	agentSkillTogglesCompat = "agents_skill_toggles"
 	// resourceLabelsCompat is no longer a release flag. Keep publishing the key
-	// as enabled so installed v0.4.0 desktop clients, which still gate resource
-	// labels on this config decision, receive the permanently enabled behavior.
+	// as enabled for installed desktop clients from v0.4.0 through at least
+	// v0.4.15, every release shipped before this change. Unlike the skill-toggle
+	// gate above, which was removed client-side in v0.4.1, the resource-label
+	// gate remained in every such client and fails closed (default false) if
+	// the key stops being published.
 	resourceLabelsCompat = "settings_resource_labels"
 )
 

--- a/server/internal/featureflags/keys.go
+++ b/server/internal/featureflags/keys.go
@@ -13,9 +13,6 @@ const (
 	// The access model exists to gate Composio sharing, so the two ship on the
 	// same switch.
 	ComposioMCPApps = "composio_mcp_apps"
-	// ResourceLabels controls the agent- and skill-scoped label namespaces.
-	// Issue labels remain available while this release flag is off.
-	ResourceLabels = "settings_resource_labels"
 	// DesktopHangStackCapture gates reading a JS call stack out of a hung
 	// desktop renderer (MUL-5345). Capture holds a debugger channel open on
 	// every renderer, so the desktop client is fail-closed: it stays off unless
@@ -30,11 +27,14 @@ const (
 	// key as enabled so installed v0.4.0 desktop clients, which still gate the
 	// switch on this config decision, receive the permanently enabled behavior.
 	agentSkillTogglesCompat = "agents_skill_toggles"
+	// resourceLabelsCompat is no longer a release flag. Keep publishing the key
+	// as enabled so installed desktop clients that still gate resource labels
+	// on this config decision receive the permanently enabled behavior.
+	resourceLabelsCompat = "settings_resource_labels"
 )
 
 var frontendPublicFlags = []string{
 	ComposioMCPApps,
-	ResourceLabels,
 	DesktopHangStackCapture,
 }
 
@@ -42,20 +42,17 @@ func ComposioMCPAppsEnabled(ctx context.Context, flags *featureflag.Service) boo
 	return flags.IsEnabled(ctx, ComposioMCPApps, false)
 }
 
-func ResourceLabelsEnabled(ctx context.Context, flags *featureflag.Service) bool {
-	return flags.IsEnabled(ctx, ResourceLabels, false)
-}
-
 func DesktopHangStackCaptureEnabled(ctx context.Context, flags *featureflag.Service) bool {
 	return flags.IsEnabled(ctx, DesktopHangStackCapture, false)
 }
 
 func EvaluateFrontendPublicFlags(ctx context.Context, flags *featureflag.Service) map[string]bool {
-	out := make(map[string]bool, len(frontendPublicFlags)+2)
+	out := make(map[string]bool, len(frontendPublicFlags)+3)
 	for _, key := range frontendPublicFlags {
 		out[key] = flags.IsEnabled(ctx, key, false)
 	}
 	out[agentBuilderCompat] = true
 	out[agentSkillTogglesCompat] = true
+	out[resourceLabelsCompat] = true
 	return out
 }

--- a/server/internal/featureflags/keys.go
+++ b/server/internal/featureflags/keys.go
@@ -28,8 +28,8 @@ const (
 	// switch on this config decision, receive the permanently enabled behavior.
 	agentSkillTogglesCompat = "agents_skill_toggles"
 	// resourceLabelsCompat is no longer a release flag. Keep publishing the key
-	// as enabled so installed desktop clients that still gate resource labels
-	// on this config decision receive the permanently enabled behavior.
+	// as enabled so installed v0.4.0 desktop clients, which still gate resource
+	// labels on this config decision, receive the permanently enabled behavior.
 	resourceLabelsCompat = "settings_resource_labels"
 )
 

--- a/server/internal/featureflags/keys_test.go
+++ b/server/internal/featureflags/keys_test.go
@@ -5,10 +5,10 @@ import (
 	"testing"
 )
 
-func TestResourceLabelsReleaseFlagDefaultsToOff(t *testing.T) {
-	ctx := context.Background()
-	if ResourceLabelsEnabled(ctx, nil) {
-		t.Fatal("resource labels release flag must default to off")
+func TestResourceLabelsCompatDecisionStaysEnabled(t *testing.T) {
+	flags := EvaluateFrontendPublicFlags(context.Background(), nil)
+	if !flags[resourceLabelsCompat] {
+		t.Fatal("resource labels must stay enabled for installed clients")
 	}
 }
 

--- a/server/internal/handler/config_test.go
+++ b/server/internal/handler/config_test.go
@@ -415,6 +415,9 @@ func TestGetConfigExposesFrontendFeatureFlags(t *testing.T) {
 	if !cfg.FeatureFlags["agents_skill_toggles"] {
 		t.Fatalf("agents_skill_toggles: want true for installed v0.4.0 clients, got false")
 	}
+	if !cfg.FeatureFlags["settings_resource_labels"] {
+		t.Fatalf("settings_resource_labels: want true for installed clients, got false")
+	}
 
 	withComposioMCPAppsFlag(t, h, true)
 	w = httptest.NewRecorder()

--- a/server/internal/handler/featureflag_test.go
+++ b/server/internal/handler/featureflag_test.go
@@ -11,10 +11,6 @@ func withComposioMCPAppsFlag(t *testing.T, h *Handler, enabled bool) {
 	withFeatureFlag(t, h, featureflags.ComposioMCPApps, enabled)
 }
 
-func withResourceLabelsFlag(t *testing.T, h *Handler, enabled bool) {
-	withFeatureFlag(t, h, featureflags.ResourceLabels, enabled)
-}
-
 func withFeatureFlag(t *testing.T, h *Handler, key string, enabled bool) {
 	t.Helper()
 	provider := featureflag.NewStaticProvider()

--- a/server/internal/handler/label.go
+++ b/server/internal/handler/label.go
@@ -13,7 +13,6 @@ import (
 	"github.com/go-chi/chi/v5"
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgtype"
-	"github.com/multica-ai/multica/server/internal/featureflags"
 	"github.com/multica-ai/multica/server/internal/logger"
 	db "github.com/multica-ai/multica/server/pkg/db/generated"
 	"github.com/multica-ai/multica/server/pkg/protocol"
@@ -149,10 +148,6 @@ func (h *Handler) ListLabels(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusBadRequest, err.Error())
 		return
 	}
-	if resourceType != defaultLabelResourceType && !featureflags.ResourceLabelsEnabled(r.Context(), h.FeatureFlags) {
-		writeError(w, http.StatusNotFound, "resource labels are not enabled")
-		return
-	}
 	labels, err := h.Queries.ListLabels(r.Context(), db.ListLabelsParams{
 		WorkspaceID: parseUUID(workspaceID), ResourceType: resourceType,
 	})
@@ -213,10 +208,6 @@ func (h *Handler) CreateLabel(w http.ResponseWriter, r *http.Request) {
 	resourceType, err := parseLabelResourceType(req.ResourceType)
 	if err != nil {
 		writeError(w, http.StatusBadRequest, err.Error())
-		return
-	}
-	if resourceType != defaultLabelResourceType && !featureflags.ResourceLabelsEnabled(r.Context(), h.FeatureFlags) {
-		writeError(w, http.StatusNotFound, "resource labels are not enabled")
 		return
 	}
 	workspaceID := h.resolveWorkspaceID(r)
@@ -557,10 +548,6 @@ func (h *Handler) DetachLabel(w http.ResponseWriter, r *http.Request) {
 // ---------------------------------------------------------------------------
 
 func (h *Handler) ListLabelsForAgent(w http.ResponseWriter, r *http.Request) {
-	if !featureflags.ResourceLabelsEnabled(r.Context(), h.FeatureFlags) {
-		writeError(w, http.StatusNotFound, "resource labels are not enabled")
-		return
-	}
 	agent, ok := h.loadAgentForUser(w, r, chi.URLParam(r, "id"))
 	if !ok {
 		return
@@ -576,10 +563,6 @@ func (h *Handler) ListLabelsForAgent(w http.ResponseWriter, r *http.Request) {
 }
 
 func (h *Handler) AttachLabelToAgent(w http.ResponseWriter, r *http.Request) {
-	if !featureflags.ResourceLabelsEnabled(r.Context(), h.FeatureFlags) {
-		writeError(w, http.StatusNotFound, "resource labels are not enabled")
-		return
-	}
 	agent, ok := h.loadAgentForUser(w, r, chi.URLParam(r, "id"))
 	if !ok || !h.canManageAgent(w, r, agent) {
 		return
@@ -609,10 +592,6 @@ func (h *Handler) AttachLabelToAgent(w http.ResponseWriter, r *http.Request) {
 }
 
 func (h *Handler) DetachLabelFromAgent(w http.ResponseWriter, r *http.Request) {
-	if !featureflags.ResourceLabelsEnabled(r.Context(), h.FeatureFlags) {
-		writeError(w, http.StatusNotFound, "resource labels are not enabled")
-		return
-	}
 	agent, ok := h.loadAgentForUser(w, r, chi.URLParam(r, "id"))
 	if !ok || !h.canManageAgent(w, r, agent) {
 		return
@@ -632,10 +611,6 @@ func (h *Handler) DetachLabelFromAgent(w http.ResponseWriter, r *http.Request) {
 }
 
 func (h *Handler) ListLabelsForSkill(w http.ResponseWriter, r *http.Request) {
-	if !featureflags.ResourceLabelsEnabled(r.Context(), h.FeatureFlags) {
-		writeError(w, http.StatusNotFound, "resource labels are not enabled")
-		return
-	}
 	skill, ok := h.loadSkillForUser(w, r, chi.URLParam(r, "id"))
 	if !ok {
 		return
@@ -651,10 +626,6 @@ func (h *Handler) ListLabelsForSkill(w http.ResponseWriter, r *http.Request) {
 }
 
 func (h *Handler) AttachLabelToSkill(w http.ResponseWriter, r *http.Request) {
-	if !featureflags.ResourceLabelsEnabled(r.Context(), h.FeatureFlags) {
-		writeError(w, http.StatusNotFound, "resource labels are not enabled")
-		return
-	}
 	skill, ok := h.loadSkillForUser(w, r, chi.URLParam(r, "id"))
 	if !ok || !h.canManageSkill(w, r, skill) {
 		return
@@ -684,10 +655,6 @@ func (h *Handler) AttachLabelToSkill(w http.ResponseWriter, r *http.Request) {
 }
 
 func (h *Handler) DetachLabelFromSkill(w http.ResponseWriter, r *http.Request) {
-	if !featureflags.ResourceLabelsEnabled(r.Context(), h.FeatureFlags) {
-		writeError(w, http.StatusNotFound, "resource labels are not enabled")
-		return
-	}
 	skill, ok := h.loadSkillForUser(w, r, chi.URLParam(r, "id"))
 	if !ok || !h.canManageSkill(w, r, skill) {
 		return

--- a/server/internal/handler/label_test.go
+++ b/server/internal/handler/label_test.go
@@ -199,7 +199,6 @@ func TestIssueLabelAttachDetach(t *testing.T) {
 }
 
 func TestIssueLabelRejectsNonIssueScope(t *testing.T) {
-	withResourceLabelsFlag(t, testHandler, true)
 	w := httptest.NewRecorder()
 	req := newRequest("POST", "/api/issues?workspace_id="+testWorkspaceID, map[string]any{
 		"title":    "Issue rejects agent label",
@@ -499,7 +498,6 @@ func TestLabelNameAllowsEmoji(t *testing.T) {
 }
 
 func TestLabelResourceTypesHaveIndependentNamespaces(t *testing.T) {
-	withResourceLabelsFlag(t, testHandler, true)
 	name := "shared-scope-label-" + uuid.NewString()[:8]
 	for _, resourceType := range []string{"issue", "agent", "skill"} {
 		w := httptest.NewRecorder()
@@ -529,22 +527,7 @@ func TestLabelResourceTypesHaveIndependentNamespaces(t *testing.T) {
 	}
 }
 
-func TestResourceLabelWritesRequireReleaseFlag(t *testing.T) {
-	withResourceLabelsFlag(t, testHandler, false)
-	w := httptest.NewRecorder()
-	req := newRequest("POST", "/api/labels", map[string]any{
-		"resource_type": "agent",
-		"name":          "blocked-resource-label-" + uuid.NewString()[:8],
-		"color":         "#3b82f6",
-	})
-	testHandler.CreateLabel(w, req)
-	if w.Code != http.StatusNotFound {
-		t.Fatalf("CreateLabel without release flag: expected 404, got %d: %s", w.Code, w.Body.String())
-	}
-}
-
 func TestDeleteResourceLabelCleansAssignments(t *testing.T) {
-	withResourceLabelsFlag(t, testHandler, true)
 	agentID := createHandlerTestAgent(t, "Resource Label Cleanup", nil)
 	skillID := insertHandlerTestSkill(t, "resource-label-cleanup", "# cleanup")
 


### PR DESCRIPTION
## Summary

- remove the `settings_resource_labels` release flag from current backend and frontend paths
- always expose agent and skill label catalogs and assignments
- keep `/api/config` reporting the legacy key as `true` for installed desktop clients
- update compatibility docs and regression coverage

## Validation

- `go test ./internal/featureflags ./internal/handler -run 'Test(ResourceLabelsCompatDecisionStaysEnabled|GetConfigExposesFrontendFeatureFlags|IssueLabelRejectsNonIssueScope|LabelResourceTypesHaveIndependentNamespaces|DeleteResourceLabelCleansAssignments)$' -count=1`
- `pnpm exec vitest run skills/components/skill-detail-page.test.tsx`
- `pnpm --filter @multica/core --filter @multica/views typecheck`
- `pnpm --filter @multica/core --filter @multica/views lint`
- `git diff --check`
