### PR TITLE
MUL-5503 fix(daemon): retire agent sessions that keep failing on resume

### DIFF
--- a/apps/mobile/components/issue/run-row.tsx
+++ b/apps/mobile/components/issue/run-row.tsx
@@ -168,6 +168,7 @@ const FAILURE_REASON_LABEL: Record<string, string> = {
   iteration_limit: "Iteration limit",
   agent_blocked: "Needs input",
   api_invalid_request: "Request rejected",
+  session_resume_exhausted: "Session retired",
   skill_bundle_unavailable: "Skill download failed",
 
   "agent_error.provider_auth_or_access": "Auth failed",

--- a/apps/mobile/lib/failure-reason-label.ts
+++ b/apps/mobile/lib/failure-reason-label.ts
@@ -26,6 +26,7 @@ const LABELS: Record<string, string> = {
   iteration_limit: "Hit the iteration limit",
   agent_blocked: "Waiting on human input",
   api_invalid_request: "Rejected by the model API",
+  session_resume_exhausted: "Conversation retired after repeated failures",
   skill_bundle_unavailable: "Couldn't download the agent's skills",
 
   // Agent process side — provider.

--- a/packages/core/dashboard/failure-class.ts
+++ b/packages/core/dashboard/failure-class.ts
@@ -52,6 +52,10 @@ const REASON_CLASS: Record<string, FailureClass> = {
   "agent_error.provider_network": "provider",
   "agent_error.model_not_found_or_unavailable": "provider",
   api_invalid_request: "provider",
+  // Retiring a session that kept failing on resume. Grouped with provider
+  // because the underlying rejection came from the model API — the circuit
+  // breaker is our response to it, not a separate class of fault.
+  session_resume_exhausted: "provider",
 
   // Multica-side execution substrate: daemon offline / restarted, task never
   // got picked up, runner binary missing or too old.

--- a/packages/views/agents/components/tabs/task-failure.ts
+++ b/packages/views/agents/components/tabs/task-failure.ts
@@ -23,6 +23,7 @@ const REASON_LABEL: Record<string, string> = {
   iteration_limit: "Hit the iteration limit",
   agent_blocked: "Waiting on human input",
   api_invalid_request: "Rejected by the model API",
+  session_resume_exhausted: "Conversation retired after repeated failures",
   skill_bundle_unavailable: "Couldn't download the agent's skills",
 
   // Agent process side — provider.

--- a/server/internal/handler/daemon.go
+++ b/server/internal/handler/daemon.go
@@ -2008,8 +2008,14 @@ func (h *Handler) buildClaimedTaskResponse(r *http.Request, task *db.AgentTaskQu
 				if src.WorkDir.Valid {
 					resp.PriorWorkDir = src.WorkDir.String
 				}
+				// The retired check is separate from ResumeUnsafeFailure on
+				// purpose: that predicate judges the SOURCE task's own failure,
+				// so it cannot see a session some LATER run abandoned. Reruns of
+				// an older task would otherwise resurrect a conversation the
+				// circuit breaker already retired (GH #6143 review).
 				if !service.ResumeUnsafeFailure(src.FailureReason.String, src.Error.String) &&
-					src.SessionID.Valid && src.RuntimeID == task.RuntimeID {
+					src.SessionID.Valid && src.RuntimeID == task.RuntimeID &&
+					!h.sessionRetiredForIssue(r.Context(), task.AgentID, task.IssueID, src.SessionID.String) {
 					resp.PriorSessionID = src.SessionID.String
 				}
 				// MUL-5305: if the source task withheld its Codex session because
@@ -2046,6 +2052,17 @@ func (h *Handler) buildClaimedTaskResponse(r *http.Request, task *db.AgentTaskQu
 				AgentID: task.AgentID,
 				IssueID: task.IssueID,
 			}); err == nil && missing {
+				resp.PriorSessionResumeUnavailable = true
+			}
+			// GH #6143: same disclosure when the circuit breaker retired the
+			// previous conversation. Without this the breaker would be silent,
+			// and silence is half of what made the original bug so hard to
+			// diagnose — the user saw an agent that had lost its memory with no
+			// explanation anywhere in the product.
+			if exhausted, err := h.Queries.GetLatestTaskResumeExhausted(r.Context(), db.GetLatestTaskResumeExhaustedParams{
+				AgentID: task.AgentID,
+				IssueID: task.IssueID,
+			}); err == nil && exhausted {
 				resp.PriorSessionResumeUnavailable = true
 			}
 		}
@@ -2505,6 +2522,31 @@ func (h *Handler) buildClaimedTaskResponse(r *http.Request, task *db.AgentTaskQu
 	}
 
 	return resp, deliveredCommentIDs, agentSkillCount, builtinSkillCount, nil
+}
+
+// sessionRetiredForIssue reports whether any run on this (agent, issue) pair
+// has retired sessionID. Used by the manual-rerun claim path, which resolves
+// its session from one specific source task and so bypasses the
+// retired_sessions CTE that guards the (agent, issue) resume lookup.
+//
+// Fails OPEN — a lookup error resumes as before. The breaker exists to bound a
+// failure loop, and refusing to resume on a transient DB error would turn that
+// safety net into a way to lose healthy conversation context.
+func (h *Handler) sessionRetiredForIssue(ctx context.Context, agentID, issueID pgtype.UUID, sessionID string) bool {
+	if sessionID == "" || !agentID.Valid || !issueID.Valid {
+		return false
+	}
+	retired, err := h.Queries.IsSessionRetiredForIssue(ctx, db.IsSessionRetiredForIssueParams{
+		AgentID:          agentID,
+		IssueID:          issueID,
+		RetiredSessionID: pgtype.Text{String: sessionID, Valid: true},
+	})
+	if err != nil {
+		slog.Warn("task claim: retired-session lookup failed",
+			"agent_id", uuidToString(agentID), "error", err)
+		return false
+	}
+	return retired
 }
 
 // ClaimTaskByRuntime atomically claims the next queued task for a runtime.

--- a/server/internal/service/session_resume_exhausted_test.go
+++ b/server/internal/service/session_resume_exhausted_test.go
@@ -1,0 +1,239 @@
+package service
+
+import "testing"
+
+// The GLM gateway rejection from GH #6143. It matches none of the poisoned-
+// session text patterns, so a current daemon still files it as unknown — which
+// is exactly the case the breaker exists to bound.
+const gh6143GatewayError = "agent_error.unknown"
+
+// TestEvaluateResumeExhaustionThreshold covers the core of GH #6143: an error
+// nobody recognises must cost one wasted run, not a permanently dead
+// (agent, issue) pair.
+//
+// The first failure deliberately still resumes. An unrecognised error is not
+// yet evidence that the transcript is at fault, and starting fresh on every
+// first stumble would throw away conversation context whenever a provider
+// hiccupped in a way the classifier has not seen.
+func TestEvaluateResumeExhaustionThreshold(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name          string
+		currentReason string
+		sessionID     string
+		prior         []priorResumeFailure
+		wantRetire    bool
+		wantSessionID string
+	}{
+		{
+			name:          "first unrecognised failure still resumes",
+			currentReason: gh6143GatewayError,
+			sessionID:     "sess-a",
+			prior:         nil,
+			wantRetire:    false,
+		},
+		{
+			name:          "second consecutive failure retires the conversation",
+			currentReason: gh6143GatewayError,
+			sessionID:     "sess-a",
+			prior:         []priorResumeFailure{{SessionID: "sess-a", FailureReason: gh6143GatewayError}},
+			wantRetire:    true,
+			wantSessionID: "sess-a",
+		},
+		{
+			// The window resets on success, so these two failures are not
+			// consecutive — ListResumeFailuresSinceLastSuccess would not
+			// return the pre-success row at all.
+			name:          "a success in between clears the window",
+			currentReason: gh6143GatewayError,
+			sessionID:     "sess-b",
+			prior:         nil,
+			wantRetire:    false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			retire, sessionID := evaluateResumeExhaustion(tc.currentReason, tc.sessionID, tc.prior)
+			if retire != tc.wantRetire {
+				t.Fatalf("retire = %v, want %v", retire, tc.wantRetire)
+			}
+			if retire && sessionID != tc.wantSessionID {
+				t.Fatalf("retired session = %q, want %q", sessionID, tc.wantSessionID)
+			}
+		})
+	}
+}
+
+// TestEvaluateResumeExhaustionTransient is the false-positive guard. Discarding
+// a healthy session costs real conversation context, which is why the GH #6143
+// review rejected the reporter's "any 400 is poison" patch — under it a single
+// rate-limit whose body mentions 400ms would have burned the session.
+func TestEvaluateResumeExhaustionTransient(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name          string
+		currentReason string
+		prior         []priorResumeFailure
+		wantRetire    bool
+	}{
+		{
+			name:          "repeated daemon outages never retire",
+			currentReason: "runtime_offline",
+			prior: []priorResumeFailure{
+				{SessionID: "sess-a", FailureReason: "runtime_offline"},
+				{SessionID: "sess-a", FailureReason: "runtime_offline"},
+			},
+			wantRetire: false,
+		},
+		{
+			// Not auto-retried, but unambiguously transient: two rate-limited
+			// runs say nothing about whether the transcript can be replayed.
+			name:          "repeated rate limits never retire",
+			currentReason: "agent_error.provider_capacity_or_rate_limit",
+			prior: []priorResumeFailure{
+				{SessionID: "sess-a", FailureReason: "agent_error.provider_capacity_or_rate_limit"},
+			},
+			wantRetire: false,
+		},
+		{
+			name:          "provider 5xx never retires",
+			currentReason: "agent_error.provider_server_error",
+			prior: []priorResumeFailure{
+				{SessionID: "sess-a", FailureReason: "agent_error.provider_server_error"},
+			},
+			wantRetire: false,
+		},
+		{
+			// The interleaving case. A transient blip between two real
+			// failures is skipped, NOT treated as a reset: letting a flaky
+			// daemon clear the count would hide a genuinely dead session
+			// forever.
+			name:          "a transient blip between two real failures does not reset the count",
+			currentReason: gh6143GatewayError,
+			prior: []priorResumeFailure{
+				{SessionID: "sess-a", FailureReason: gh6143GatewayError},
+				{SessionID: "sess-a", FailureReason: "runtime_offline"},
+			},
+			wantRetire: true,
+		},
+		{
+			// One real failure plus noise is still only one real failure.
+			name:          "transient noise alone cannot reach the threshold",
+			currentReason: gh6143GatewayError,
+			prior: []priorResumeFailure{
+				{SessionID: "sess-a", FailureReason: "runtime_offline"},
+				{SessionID: "sess-a", FailureReason: "timeout"},
+				{SessionID: "sess-a", FailureReason: "queued_expired"},
+			},
+			wantRetire: false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			retire, _ := evaluateResumeExhaustion(tc.currentReason, "sess-a", tc.prior)
+			if retire != tc.wantRetire {
+				t.Fatalf("retire = %v, want %v", retire, tc.wantRetire)
+			}
+		})
+	}
+}
+
+// TestEvaluateResumeExhaustionSessionDrift covers the ACP backends, whose
+// resolveResumedSessionID may answer a resume with a DIFFERENT session id when
+// the provider's own state is gone.
+//
+// The upgraded failure_reason only excludes the row it is written on, so under
+// drift the EARLIER id would stay eligible and be resumed on the next turn —
+// the loop would survive the fix. Retiring the earlier id is what closes that.
+func TestEvaluateResumeExhaustionSessionDrift(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name          string
+		sessionID     string
+		prior         []priorResumeFailure
+		wantSessionID string
+	}{
+		{
+			name:          "stable id retires itself",
+			sessionID:     "sess-a",
+			prior:         []priorResumeFailure{{SessionID: "sess-a", FailureReason: gh6143GatewayError}},
+			wantSessionID: "sess-a",
+		},
+		{
+			// The current id is already covered by the reason written on this
+			// row; the drifted predecessor is the one that needs retiring.
+			name:          "drifted id retires the predecessor",
+			sessionID:     "sess-b",
+			prior:         []priorResumeFailure{{SessionID: "sess-a", FailureReason: gh6143GatewayError}},
+			wantSessionID: "sess-a",
+		},
+		{
+			// A run that died before establishing a session records no id.
+			name:          "empty prior id falls back to the current session",
+			sessionID:     "sess-b",
+			prior:         []priorResumeFailure{{SessionID: "", FailureReason: gh6143GatewayError}},
+			wantSessionID: "sess-b",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			retire, sessionID := evaluateResumeExhaustion(gh6143GatewayError, tc.sessionID, tc.prior)
+			if !retire {
+				t.Fatalf("retire = false, want true")
+			}
+			if sessionID != tc.wantSessionID {
+				t.Fatalf("retired session = %q, want %q", sessionID, tc.wantSessionID)
+			}
+		})
+	}
+}
+
+// TestSessionResumeExhaustedIsResumeUnsafe pins the wiring that makes the
+// breaker reach the manual-rerun path. That path reads the exact source task
+// through ResumeUnsafeFailure and never consults the retired_sessions CTE, so
+// without this the Rerun button would keep resuming a retired conversation —
+// and Rerun is the first thing a user reaches for.
+func TestSessionResumeExhaustedIsResumeUnsafe(t *testing.T) {
+	t.Parallel()
+
+	if !ResumeUnsafeFailure("session_resume_exhausted", "") {
+		t.Fatal("session_resume_exhausted must be resume-unsafe so manual rerun starts fresh")
+	}
+	if !resumeUnsafeFailureReason("session_resume_exhausted") {
+		t.Fatal("session_resume_exhausted missing from the resume-unsafe reason set")
+	}
+}
+
+// TestTransientResumeSafeSupersetOfRetryable pins the superset relationship. If
+// a reason is safe enough to auto-retry it is safe enough not to burn the
+// session, and a future addition to retryableReasons must not silently start
+// tripping the breaker.
+func TestTransientResumeSafeSupersetOfRetryable(t *testing.T) {
+	t.Parallel()
+
+	for reason := range retryableReasons {
+		if !transientResumeSafeReasons[reason] {
+			t.Errorf("retryable reason %q is not in transientResumeSafeReasons", reason)
+		}
+	}
+	// The members that are NOT auto-retryable are the whole reason this set
+	// exists separately; losing them would reintroduce the false positive.
+	for _, reason := range []string{
+		"agent_error.provider_capacity_or_rate_limit",
+		"agent_error.provider_server_error",
+		"queued_expired",
+	} {
+		if !transientResumeSafeReasons[reason] {
+			t.Errorf("transient reason %q must not count toward the breaker", reason)
+		}
+	}
+}

--- a/server/internal/service/session_resume_exhausted_test.go
+++ b/server/internal/service/session_resume_exhausted_test.go
@@ -131,6 +131,54 @@ func TestEvaluateResumeExhaustionTransient(t *testing.T) {
 			},
 			wantRetire: false,
 		},
+		{
+			// The regression the PR review caught. An expired key fails every
+			// run until the user re-auths, so without this the second failure
+			// would retire a healthy session AND relabel the failure — hiding
+			// "Auth failed", the one thing the user could act on.
+			name:          "expired credentials never retire",
+			currentReason: "agent_error.provider_auth_or_access",
+			prior: []priorResumeFailure{
+				{SessionID: "sess-a", FailureReason: "agent_error.provider_auth_or_access"},
+			},
+			wantRetire: false,
+		},
+		{
+			name:          "exhausted billing never retires",
+			currentReason: "agent_error.provider_quota_limit",
+			prior: []priorResumeFailure{
+				{SessionID: "sess-a", FailureReason: "agent_error.provider_quota_limit"},
+			},
+			wantRetire: false,
+		},
+		{
+			name:          "misconfigured model never retires",
+			currentReason: "agent_error.model_not_found_or_unavailable",
+			prior: []priorResumeFailure{
+				{SessionID: "sess-a", FailureReason: "agent_error.model_not_found_or_unavailable"},
+			},
+			wantRetire: false,
+		},
+		{
+			name:          "missing runner binary never retires",
+			currentReason: "agent_error.runtime_missing_executable",
+			prior: []priorResumeFailure{
+				{SessionID: "sess-a", FailureReason: "agent_error.missing_config"},
+				{SessionID: "sess-a", FailureReason: "agent_error.runtime_version_unsupported"},
+			},
+			wantRetire: false,
+		},
+		{
+			// Counting these IS intended: replaying an oversized or malformed
+			// history is a plausible cause, so the fail-safe direction is to
+			// treat them as evidence about the transcript.
+			name:          "agent process crashes still count",
+			currentReason: "agent_error.process_failure",
+			prior: []priorResumeFailure{
+				{SessionID: "sess-a", FailureReason: "agent_error.process_failure"},
+			},
+			wantRetire: true,
+		},
 	}
 
 	for _, tc := range cases {
@@ -213,27 +261,70 @@ func TestSessionResumeExhaustedIsResumeUnsafe(t *testing.T) {
 	}
 }
 
-// TestTransientResumeSafeSupersetOfRetryable pins the superset relationship. If
-// a reason is safe enough to auto-retry it is safe enough not to burn the
+// TestTranscriptNeutralSupersetOfRetryable pins the superset relationship. If a
+// reason is safe enough to auto-retry it is safe enough not to burn the
 // session, and a future addition to retryableReasons must not silently start
 // tripping the breaker.
-func TestTransientResumeSafeSupersetOfRetryable(t *testing.T) {
+func TestTranscriptNeutralSupersetOfRetryable(t *testing.T) {
 	t.Parallel()
 
 	for reason := range retryableReasons {
-		if !transientResumeSafeReasons[reason] {
-			t.Errorf("retryable reason %q is not in transientResumeSafeReasons", reason)
+		if !transcriptNeutralReasons[reason] {
+			t.Errorf("retryable reason %q is not in transcriptNeutralReasons", reason)
 		}
 	}
 	// The members that are NOT auto-retryable are the whole reason this set
-	// exists separately; losing them would reintroduce the false positive.
+	// exists separately; losing any of them reintroduces a false positive that
+	// costs the user their conversation context.
 	for _, reason := range []string{
+		// Transient, but with no safe idempotent replay.
 		"agent_error.provider_capacity_or_rate_limit",
 		"agent_error.provider_server_error",
 		"queued_expired",
+		// Not transient at all — they persist until the user fixes the
+		// environment — but equally silent about whether the transcript
+		// replays, which is the actual membership test for this set.
+		"agent_error.provider_auth_or_access",
+		"agent_error.provider_quota_limit",
+		"agent_error.model_not_found_or_unavailable",
+		"agent_error.missing_config",
+		"agent_error.runtime_version_unsupported",
+		"agent_error.runtime_missing_executable",
 	} {
-		if !transientResumeSafeReasons[reason] {
-			t.Errorf("transient reason %q must not count toward the breaker", reason)
+		if !transcriptNeutralReasons[reason] {
+			t.Errorf("transcript-neutral reason %q must not count toward the breaker", reason)
 		}
+	}
+	// The counting side of the contract. These can plausibly be CAUSED by
+	// replaying a bad history, so excluding them would blind the breaker.
+	for _, reason := range []string{
+		"agent_error.unknown",
+		"agent_error.process_failure",
+		"agent_error.empty_or_unparseable_output",
+		"agent_error.agent_timeout",
+	} {
+		if transcriptNeutralReasons[reason] {
+			t.Errorf("reason %q must keep counting toward the breaker", reason)
+		}
+	}
+}
+
+// TestEvaluateResumeExhaustionPrefersMostRecentDriftedID pins the ordering
+// contract with ListResumeFailuresSinceLastSuccess, which returns newest-first.
+// Only one id fits in retired_session_id, so when several drifted predecessors
+// exist the one worth retiring is the session this run was actually told to
+// resume — the most recent.
+func TestEvaluateResumeExhaustionPrefersMostRecentDriftedID(t *testing.T) {
+	t.Parallel()
+
+	retire, sessionID := evaluateResumeExhaustion(gh6143GatewayError, "sess-c", []priorResumeFailure{
+		{SessionID: "sess-b", FailureReason: gh6143GatewayError},
+		{SessionID: "sess-a", FailureReason: gh6143GatewayError},
+	})
+	if !retire {
+		t.Fatal("retire = false, want true")
+	}
+	if sessionID != "sess-b" {
+		t.Fatalf("retired session = %q, want %q (the most recent drifted id)", sessionID, "sess-b")
 	}
 }

--- a/server/internal/service/task.go
+++ b/server/internal/service/task.go
@@ -3667,30 +3667,70 @@ var retryableReasons = map[string]bool{
 // resume itself that just demonstrably failed. The cost of an unrecognised
 // error therefore tops out at one wasted run rather than a permanently dead
 // (agent, issue) pair.
+//
+// The threshold latches, by design. session_resume_exhausted is itself a
+// counting reason, so once the breaker has fired the window stays at or above
+// the threshold until a run finally succeeds — meaning every subsequent fresh
+// session is retired on its FIRST failure rather than its second. For a
+// genuinely broken pairing (a gateway that keeps rejecting) that is the right
+// behaviour: each turn gets a clean conversation and an explicit disclosure
+// instead of inheriting a known-dead one. Practically it means "2" describes
+// the first round only. Treating an exhausted row as a window boundary would
+// give each new session its own two attempts; that trades faster recovery for
+// more wasted runs in the case that is already known to be failing, so it is
+// deliberately not done.
 const sessionResumeExhaustedThreshold = 2
 
-// transientResumeSafeReasons are failures that say nothing about whether the
-// conversation can be replayed, so they neither count toward
-// sessionResumeExhaustedThreshold nor reset it. A daemon that went offline
-// twice has not shown the transcript to be bad, and treating it as such would
-// discard a healthy session — the exact false positive the GH #6143 review
-// pushed back on when a broad "any 400" text match was proposed.
+// transcriptNeutralReasons are failures that carry NO evidence about whether
+// the conversation can be replayed, so they neither count toward
+// sessionResumeExhaustedThreshold nor reset it.
 //
-// Explicitly a SUPERSET of retryableReasons, and the extra members are the
-// point: provider_capacity_or_rate_limit and provider_server_error are not
-// auto-retried (they have no safe idempotent replay) but are unambiguously
-// transient, so two rate-limited runs in a row must not burn the session.
-// queued_expired never started an agent process at all.
+// "Transcript-neutral" rather than "transient" is the actual criterion, and
+// the distinction matters when deciding whether a new reason belongs here: an
+// expired API key is not transient at all — it persists until the user acts —
+// but it says exactly as much about the transcript as a daemon outage does,
+// which is nothing. The question to ask of a candidate is "could replaying the
+// conversation have caused this?", not "will it go away on its own?".
+//
+// Getting that wrong is a real regression, not a theoretical one. Two runs
+// failing on an expired key would otherwise retire a perfectly healthy session
+// AND relabel the failure as session_resume_exhausted — destroying the one
+// signal the user could act on ("Auth failed") and losing their context for a
+// problem that had nothing to do with it.
+//
+// Explicitly a SUPERSET of retryableReasons, because auto-retry safety implies
+// transcript-neutrality but not the reverse: rate limit and provider 5xx are
+// not auto-retried (no safe idempotent replay) yet are plainly neutral here.
+//
+// Deliberately NOT listed, so they keep counting: process_failure,
+// empty_or_unparseable_output and agent_timeout can all be produced BY
+// replaying an oversized or malformed history, so counting them is the
+// fail-safe direction. agent_error.unknown is the whole point of the breaker.
+// A legacy or un-upgraded daemon reporting a bare agent_error also counts,
+// which is intended for genuinely unclassified failures and is an accepted
+// deploy-window cost for the transient ones it may mislabel.
 //
 // Skipping without resetting is deliberate: fail(unknown) → fail(runtime_offline)
 // → fail(unknown) is two pieces of evidence about the conversation with an
 // unrelated infrastructure blip in the middle, not one. Letting the blip clear
 // the count would let a flaky daemon mask a genuinely dead session forever.
-var transientResumeSafeReasons = func() map[string]bool {
+var transcriptNeutralReasons = func() map[string]bool {
 	m := map[string]bool{
+		// Transient provider conditions.
 		string(taskfailure.ReasonAgentProviderCapacityOrRateLimit): true,
 		string(taskfailure.ReasonAgentProviderServerError):         true,
-		string(taskfailure.ReasonQueuedExpired):                    true,
+		// Never reached an agent process at all.
+		string(taskfailure.ReasonQueuedExpired): true,
+		// The user must fix something OUTSIDE the conversation: credentials,
+		// billing, model id, runner install. Each persists until they act, and
+		// each leaves the transcript untouched — so a second failure is the
+		// same unfixed environment, not a second piece of evidence.
+		string(taskfailure.ReasonAgentProviderAuthOrAccess):       true,
+		string(taskfailure.ReasonAgentProviderQuotaLimit):         true,
+		string(taskfailure.ReasonAgentModelNotFoundOrUnavailable): true,
+		string(taskfailure.ReasonAgentMissingConfig):              true,
+		string(taskfailure.ReasonAgentRuntimeVersionUnsupported):  true,
+		string(taskfailure.ReasonAgentRuntimeMissingExecutable):   true,
 	}
 	for reason := range retryableReasons {
 		m[reason] = true
@@ -3716,7 +3756,7 @@ var transientResumeSafeReasons = func() map[string]bool {
 func (s *TaskService) sessionResumeExhausted(ctx context.Context, taskID pgtype.UUID, failureReason, sessionID string) (bool, string) {
 	// Cheap gate before any query: the overwhelmingly common failure is a
 	// transient one that can never trip the breaker.
-	if transientResumeSafeReasons[failureReason] {
+	if transcriptNeutralReasons[failureReason] {
 		return false, ""
 	}
 	parent, err := s.Queries.GetAgentTask(ctx, taskID)
@@ -3760,18 +3800,24 @@ type priorResumeFailure struct {
 // this failure and the earlier ones since the last success, decide whether the
 // conversation is retired and which session id to record.
 func evaluateResumeExhaustion(currentReason, currentSessionID string, prior []priorResumeFailure) (bool, string) {
-	if transientResumeSafeReasons[currentReason] {
+	if transcriptNeutralReasons[currentReason] {
 		return false, ""
 	}
 	count := 1 // this failure
 	retireSessionID := currentSessionID
 	for _, p := range prior {
-		if transientResumeSafeReasons[p.FailureReason] {
+		if transcriptNeutralReasons[p.FailureReason] {
 			continue
 		}
 		count++
-		// Prefer an id the upgraded reason on THIS row cannot retire.
-		if p.SessionID != "" && p.SessionID != currentSessionID {
+		// Prefer an id the upgraded reason on THIS row cannot retire, taking
+		// the most recent such id — prior is ordered newest-first, so the
+		// first match is the session this run was actually told to resume.
+		// Only one id fits in retired_session_id, so with more than one
+		// drifted predecessor the older ones are left to their own rows: each
+		// carries its own failure reason and is re-evaluated on the next
+		// failure, which bounds the leak at an extra run rather than a loop.
+		if retireSessionID == currentSessionID && p.SessionID != "" && p.SessionID != currentSessionID {
 			retireSessionID = p.SessionID
 		}
 	}

--- a/server/internal/service/task.go
+++ b/server/internal/service/task.go
@@ -3344,6 +3344,23 @@ func (s *TaskService) FailTask(ctx context.Context, taskID pgtype.UUID, errMsg, 
 	// reason is what decides retry eligibility.
 	failureReason = taskfailure.NormalizeDaemonReason(failureReason, errMsg).String()
 
+	// GH #6143: retire a conversation that has now failed on resume twice with
+	// no success in between. This runs BEFORE the retry pre-compute and before
+	// the chat-pointer writes inside the transaction, because both branch on
+	// failureReason and must see the upgraded value — otherwise this would
+	// retire the session and then immediately re-pin it as resumable.
+	//
+	// Only the reason is upgraded when the caller already named a retired
+	// session: the daemon detected the dead conversation itself, which is
+	// strictly better evidence than our count, and clobbering its id could
+	// leave the session it abandoned resumable.
+	if retire, retireID := s.sessionResumeExhausted(ctx, taskID, failureReason, sessionID); retire {
+		failureReason = string(taskfailure.ReasonSessionResumeExhausted)
+		if retiredSessionID == "" {
+			retiredSessionID = retireID
+		}
+	}
+
 	// Pre-compute the auto-retry so the retry child can be created inside the
 	// SAME transaction as the fail (MUL-4351). Doing it atomically closes the
 	// window between the fail committing and the retry appearing during which a
@@ -3639,6 +3656,131 @@ var retryableReasons = map[string]bool{
 	string(taskfailure.ReasonSkillBundleUnavailable): true,
 }
 
+// sessionResumeExhaustedThreshold is how many consecutive non-transient
+// failures on one (agent, issue) pair retire the conversation (GH #6143).
+//
+// Two, so the first failure still resumes normally. Something the classifier
+// has never seen is not yet evidence that the transcript is the problem, and
+// starting over on the first stumble would throw away conversation context
+// every time a provider hiccupped in a way we do not recognise. A second
+// consecutive failure with no success in between IS that evidence — it is the
+// resume itself that just demonstrably failed. The cost of an unrecognised
+// error therefore tops out at one wasted run rather than a permanently dead
+// (agent, issue) pair.
+const sessionResumeExhaustedThreshold = 2
+
+// transientResumeSafeReasons are failures that say nothing about whether the
+// conversation can be replayed, so they neither count toward
+// sessionResumeExhaustedThreshold nor reset it. A daemon that went offline
+// twice has not shown the transcript to be bad, and treating it as such would
+// discard a healthy session — the exact false positive the GH #6143 review
+// pushed back on when a broad "any 400" text match was proposed.
+//
+// Explicitly a SUPERSET of retryableReasons, and the extra members are the
+// point: provider_capacity_or_rate_limit and provider_server_error are not
+// auto-retried (they have no safe idempotent replay) but are unambiguously
+// transient, so two rate-limited runs in a row must not burn the session.
+// queued_expired never started an agent process at all.
+//
+// Skipping without resetting is deliberate: fail(unknown) → fail(runtime_offline)
+// → fail(unknown) is two pieces of evidence about the conversation with an
+// unrelated infrastructure blip in the middle, not one. Letting the blip clear
+// the count would let a flaky daemon mask a genuinely dead session forever.
+var transientResumeSafeReasons = func() map[string]bool {
+	m := map[string]bool{
+		string(taskfailure.ReasonAgentProviderCapacityOrRateLimit): true,
+		string(taskfailure.ReasonAgentProviderServerError):         true,
+		string(taskfailure.ReasonQueuedExpired):                    true,
+	}
+	for reason := range retryableReasons {
+		m[reason] = true
+	}
+	return m
+}()
+
+// sessionResumeExhausted reports whether this failure retires the
+// conversation, and which session id to record as retired.
+//
+// The count is per (agent, issue) rather than per session id: see
+// ListResumeFailuresSinceLastSuccess for why keying on the id breaks on ACP
+// backends that hand back a different id on resume. retireSessionID prefers a
+// DIFFERENT id seen earlier in the window over the current one, because that
+// is the id the upgraded failure_reason cannot cover — the reason only
+// excludes the row it is written on, so under id drift the earlier session
+// would stay eligible and be resumed next turn.
+//
+// Scoped to issue tasks. Chat tasks are excluded because the count is keyed on
+// issue_id, and a chat-only task carries none; chat sessions keep their
+// existing resume-unsafe handling until a follow-up extends the window to
+// chat_session_id.
+func (s *TaskService) sessionResumeExhausted(ctx context.Context, taskID pgtype.UUID, failureReason, sessionID string) (bool, string) {
+	// Cheap gate before any query: the overwhelmingly common failure is a
+	// transient one that can never trip the breaker.
+	if transientResumeSafeReasons[failureReason] {
+		return false, ""
+	}
+	parent, err := s.Queries.GetAgentTask(ctx, taskID)
+	if err != nil {
+		// Best-effort: a failed lookup must not block recording the failure.
+		slog.Warn("session resume breaker: load task failed",
+			"task_id", util.UUIDToString(taskID), "error", err)
+		return false, ""
+	}
+	if !parent.IssueID.Valid || !parent.AgentID.Valid {
+		return false, ""
+	}
+	prior, err := s.Queries.ListResumeFailuresSinceLastSuccess(ctx, db.ListResumeFailuresSinceLastSuccessParams{
+		AgentID: parent.AgentID,
+		IssueID: parent.IssueID,
+		ID:      taskID,
+	})
+	if err != nil {
+		slog.Warn("session resume breaker: count prior failures failed",
+			"task_id", util.UUIDToString(taskID), "error", err)
+		return false, ""
+	}
+	window := make([]priorResumeFailure, 0, len(prior))
+	for _, row := range prior {
+		window = append(window, priorResumeFailure{
+			SessionID:     row.SessionID.String,
+			FailureReason: row.FailureReason,
+		})
+	}
+	return evaluateResumeExhaustion(failureReason, sessionID, window)
+}
+
+// priorResumeFailure is one earlier failed run in the current window, reduced
+// to the two fields the decision needs.
+type priorResumeFailure struct {
+	SessionID     string
+	FailureReason string
+}
+
+// evaluateResumeExhaustion is the pure half of sessionResumeExhausted: given
+// this failure and the earlier ones since the last success, decide whether the
+// conversation is retired and which session id to record.
+func evaluateResumeExhaustion(currentReason, currentSessionID string, prior []priorResumeFailure) (bool, string) {
+	if transientResumeSafeReasons[currentReason] {
+		return false, ""
+	}
+	count := 1 // this failure
+	retireSessionID := currentSessionID
+	for _, p := range prior {
+		if transientResumeSafeReasons[p.FailureReason] {
+			continue
+		}
+		count++
+		// Prefer an id the upgraded reason on THIS row cannot retire.
+		if p.SessionID != "" && p.SessionID != currentSessionID {
+			retireSessionID = p.SessionID
+		}
+	}
+	if count < sessionResumeExhaustedThreshold {
+		return false, ""
+	}
+	return true, retireSessionID
+}
+
 // Transient provider stream cuts (provider_network) get a bespoke three-tier
 // schedule (MUL-4910): first run + immediate retry + one retry deferred ~5s.
 // A blip that survives the immediate retry gets a short cooldown before the
@@ -3691,7 +3833,12 @@ func resumeUnsafeFailureReason(reason string) bool {
 	// blacklists. (CreateRetryTask's fresh-session CASE WHEN only needs the
 	// subset of these that is also auto-retryable, currently
 	// codex_semantic_inactivity.)
-	case "iteration_limit", "agent_fallback_message", "api_invalid_request", "codex_semantic_inactivity", "agent_error.context_overflow":
+	// session_resume_exhausted is the behavioural member of this set: the other
+	// reasons name a defect recognised in the provider's error text, it names a
+	// conversation that simply kept failing (GH #6143). Listing it here is what
+	// makes the manual-rerun path honour the breaker — that path reads the exact
+	// source task and never consults the retired_sessions CTE.
+	case "iteration_limit", "agent_fallback_message", "api_invalid_request", "codex_semantic_inactivity", "agent_error.context_overflow", "session_resume_exhausted":
 		return true
 	default:
 		return false

--- a/server/pkg/db/generated/agent.sql.go
+++ b/server/pkg/db/generated/agent.sql.go
@@ -2877,7 +2877,7 @@ WHERE session_id NOT IN (SELECT session_id FROM retired_sessions)
     status = 'completed'
     OR (
       status = 'failed'
-      AND COALESCE(failure_reason, '') NOT IN ('iteration_limit', 'agent_fallback_message', 'api_invalid_request', 'codex_semantic_inactivity', 'agent_error.context_overflow')
+      AND COALESCE(failure_reason, '') NOT IN ('iteration_limit', 'agent_fallback_message', 'api_invalid_request', 'codex_semantic_inactivity', 'agent_error.context_overflow', 'session_resume_exhausted')
       AND NOT (COALESCE(error, '') ILIKE '%400%' AND COALESCE(error, '') ILIKE '%invalid_request_error%')
       AND NOT (COALESCE(error, '') ILIKE '%image dimensions exceed max allowed size%' AND COALESCE(error, '') ILIKE '%image.source.base64.data%')
       AND NOT (COALESCE(error, '') ~* 'must not be empty|must be non-?empty|must have non-?empty|non-?empty content|cannot be empty|should not be empty'
@@ -2922,7 +2922,8 @@ type GetLastTaskSessionRow struct {
 // Tasks that ended in a known "poisoned" terminal state are also excluded
 // here so even auto-retry does not inherit the bad session. The daemon
 // classifies these failures (iteration_limit, agent_fallback_message,
-// api_invalid_request, codex_semantic_inactivity, agent_error.context_overflow)
+// api_invalid_request, codex_semantic_inactivity, agent_error.context_overflow,
+// session_resume_exhausted)
 // when it detects either an agent fallback marker in the output, an upstream
 // API 400 that means the conversation history itself is unprocessable
 // (oversized image, malformed base64, etc.), a Codex semantic inactivity
@@ -3031,6 +3032,34 @@ func (q *Queries) GetLatestChatTaskRolloutMissing(ctx context.Context, chatSessi
 	var session_rollout_missing bool
 	err := row.Scan(&session_rollout_missing)
 	return session_rollout_missing, err
+}
+
+const getLatestTaskResumeExhausted = `-- name: GetLatestTaskResumeExhausted :one
+SELECT COALESCE(failure_reason, '') = 'session_resume_exhausted' AS exhausted
+FROM agent_task_queue
+WHERE agent_id = $1 AND issue_id = $2
+  AND status IN ('completed', 'failed')
+  AND started_at IS NOT NULL
+ORDER BY COALESCE(completed_at, started_at, dispatched_at, created_at) DESC
+LIMIT 1
+`
+
+type GetLatestTaskResumeExhaustedParams struct {
+	AgentID pgtype.UUID `json:"agent_id"`
+	IssueID pgtype.UUID `json:"issue_id"`
+}
+
+// Reports whether the most recent terminal task on this (agent_id, issue_id)
+// pair retired its conversation for repeated failures. Drives the same
+// PriorSessionResumeUnavailable disclosure as GetLatestTaskRolloutMissing
+// (MUL-5305): without it the circuit breaker would silently drop the
+// conversation, which is the behaviour GH #6143 complained about in the first
+// place — the user could not tell why the agent had lost its context.
+func (q *Queries) GetLatestTaskResumeExhausted(ctx context.Context, arg GetLatestTaskResumeExhaustedParams) (bool, error) {
+	row := q.db.QueryRow(ctx, getLatestTaskResumeExhausted, arg.AgentID, arg.IssueID)
+	var exhausted bool
+	err := row.Scan(&exhausted)
+	return exhausted, err
 }
 
 const getLatestTaskRoleForIssueAndAgent = `-- name: GetLatestTaskRoleForIssueAndAgent :one
@@ -3311,6 +3340,33 @@ func (q *Queries) HasPendingTaskForIssueAndAgentExcludingTriggerComment(ctx cont
 	var has_pending bool
 	err := row.Scan(&has_pending)
 	return has_pending, err
+}
+
+const isSessionRetiredForIssue = `-- name: IsSessionRetiredForIssue :one
+SELECT EXISTS (
+    SELECT 1 FROM agent_task_queue
+    WHERE agent_id = $1 AND issue_id = $2
+      AND retired_session_id = $3
+) AS retired
+`
+
+type IsSessionRetiredForIssueParams struct {
+	AgentID          pgtype.UUID `json:"agent_id"`
+	IssueID          pgtype.UUID `json:"issue_id"`
+	RetiredSessionID pgtype.Text `json:"retired_session_id"`
+}
+
+// Reports whether any task on this (agent_id, issue_id) pair has retired the
+// given session id. The manual-rerun claim path reads the exact source task
+// rather than GetLastTaskSession, so it never consulted the retired_sessions
+// CTE and would happily resume a session a later run had already abandoned
+// (GH #6143 review). Session ids are opaque per-provider strings, so the
+// (agent, issue) scope is what keeps the lookup from colliding across issues.
+func (q *Queries) IsSessionRetiredForIssue(ctx context.Context, arg IsSessionRetiredForIssueParams) (bool, error) {
+	row := q.db.QueryRow(ctx, isSessionRetiredForIssue, arg.AgentID, arg.IssueID, arg.RetiredSessionID)
+	var retired bool
+	err := row.Scan(&retired)
+	return retired, err
 }
 
 const linkTaskToIssue = `-- name: LinkTaskToIssue :exec
@@ -4125,6 +4181,75 @@ func (q *Queries) ListQueuedClaimCandidatesByRuntimes(ctx context.Context, runti
 			&i.QuickActionsDisabled,
 			&i.RegenerateQuickActionsFor,
 		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+const listResumeFailuresSinceLastSuccess = `-- name: ListResumeFailuresSinceLastSuccess :many
+SELECT t.session_id, COALESCE(t.failure_reason, '') AS failure_reason
+FROM agent_task_queue t
+WHERE t.agent_id = $1 AND t.issue_id = $2
+  AND t.id <> $3
+  AND t.status = 'failed'
+  AND COALESCE(t.completed_at, t.started_at, t.dispatched_at, t.created_at) > COALESCE((
+      SELECT MAX(COALESCE(c.completed_at, c.started_at, c.dispatched_at, c.created_at))
+      FROM agent_task_queue c
+      WHERE c.agent_id = $1 AND c.issue_id = $2 AND c.status = 'completed'
+  ), '-infinity'::timestamptz)
+`
+
+type ListResumeFailuresSinceLastSuccessParams struct {
+	AgentID pgtype.UUID `json:"agent_id"`
+	IssueID pgtype.UUID `json:"issue_id"`
+	ID      pgtype.UUID `json:"id"`
+}
+
+type ListResumeFailuresSinceLastSuccessRow struct {
+	SessionID     pgtype.Text `json:"session_id"`
+	FailureReason string      `json:"failure_reason"`
+}
+
+// Returns the failed tasks for this (agent_id, issue_id) pair since its last
+// successful run, excluding the caller's own row ($3). TaskService.FailTask
+// counts them to decide whether the conversation has proved unresumable and
+// should be retired (GH #6143) — see sessionResumeExhausted.
+//
+// Deliberately NOT keyed on session_id, even though the thing being judged is
+// a session. ACP backends (resolveResumedSessionID in pkg/agent/hermes.go)
+// may answer a resume with a DIFFERENT session id when their server-side
+// state is gone, and a run that dies before establishing a session records no
+// id at all. Keying on the id would restart the count on every drift and the
+// threshold would never be reached in exactly the situation it exists for.
+// The (agent, issue) pair is the unit the user actually experiences as stuck,
+// and every id seen in the window is retired together.
+//
+// "Since the last success" is the reset: one completed run proves the
+// conversation is healthy, so older failures must not count toward retiring
+// the session it left behind. Tasks with no terminal timestamp at all sort as
+// -infinity and are therefore included, which is the safe direction.
+//
+// failure_reason is returned rather than filtered here on purpose: which
+// reasons are transient enough to skip is decided ONCE in Go
+// (transientResumeSafeReasons). This file and internal/service/task.go have
+// drifted apart before — the sibling NOT IN blacklist above exists in three
+// places precisely because of that — so the set that is expected to grow
+// lives in one language only.
+func (q *Queries) ListResumeFailuresSinceLastSuccess(ctx context.Context, arg ListResumeFailuresSinceLastSuccessParams) ([]ListResumeFailuresSinceLastSuccessRow, error) {
+	rows, err := q.db.Query(ctx, listResumeFailuresSinceLastSuccess, arg.AgentID, arg.IssueID, arg.ID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []ListResumeFailuresSinceLastSuccessRow{}
+	for rows.Next() {
+		var i ListResumeFailuresSinceLastSuccessRow
+		if err := rows.Scan(&i.SessionID, &i.FailureReason); err != nil {
 			return nil, err
 		}
 		items = append(items, i)

--- a/server/pkg/db/generated/agent.sql.go
+++ b/server/pkg/db/generated/agent.sql.go
@@ -3055,6 +3055,13 @@ type GetLatestTaskResumeExhaustedParams struct {
 // (MUL-5305): without it the circuit breaker would silently drop the
 // conversation, which is the behaviour GH #6143 complained about in the first
 // place — the user could not tell why the agent had lost its context.
+//
+// Only the LATEST terminal row is consulted, mirroring
+// GetLatestTaskRolloutMissing. A transcript-neutral failure landing between the
+// breaker and the next claim (retirement, then a runtime_offline run) therefore
+// hides the disclosure, and that turn starts fresh without saying so. Rare, and
+// the alternative — scanning back to the last success — would keep re-announcing
+// the same retirement on every later turn, which is worse.
 func (q *Queries) GetLatestTaskResumeExhausted(ctx context.Context, arg GetLatestTaskResumeExhaustedParams) (bool, error) {
 	row := q.db.QueryRow(ctx, getLatestTaskResumeExhausted, arg.AgentID, arg.IssueID)
 	var exhausted bool
@@ -4202,6 +4209,7 @@ WHERE t.agent_id = $1 AND t.issue_id = $2
       FROM agent_task_queue c
       WHERE c.agent_id = $1 AND c.issue_id = $2 AND c.status = 'completed'
   ), '-infinity'::timestamptz)
+ORDER BY COALESCE(t.completed_at, t.started_at, t.dispatched_at, t.created_at) DESC, t.id DESC
 `
 
 type ListResumeFailuresSinceLastSuccessParams struct {
@@ -4236,10 +4244,13 @@ type ListResumeFailuresSinceLastSuccessRow struct {
 //
 // failure_reason is returned rather than filtered here on purpose: which
 // reasons are transient enough to skip is decided ONCE in Go
-// (transientResumeSafeReasons). This file and internal/service/task.go have
+// (transcriptNeutralReasons). This file and internal/service/task.go have
 // drifted apart before — the sibling NOT IN blacklist above exists in three
 // places precisely because of that — so the set that is expected to grow
 // lives in one language only.
+// Newest first, with id as a tiebreak so rows sharing a timestamp keep a
+// stable order. The caller retires the most recent DIFFERENT session id it
+// sees, which is only well-defined if this ordering is.
 func (q *Queries) ListResumeFailuresSinceLastSuccess(ctx context.Context, arg ListResumeFailuresSinceLastSuccessParams) ([]ListResumeFailuresSinceLastSuccessRow, error) {
 	rows, err := q.db.Query(ctx, listResumeFailuresSinceLastSuccess, arg.AgentID, arg.IssueID, arg.ID)
 	if err != nil {

--- a/server/pkg/db/generated/chat.sql.go
+++ b/server/pkg/db/generated/chat.sql.go
@@ -732,7 +732,7 @@ WHERE session_id NOT IN (SELECT session_id FROM retired_sessions)
     status = 'completed'
     OR (
       status = 'failed'
-      AND COALESCE(failure_reason, '') NOT IN ('iteration_limit', 'agent_fallback_message', 'api_invalid_request', 'codex_semantic_inactivity', 'agent_error.context_overflow')
+      AND COALESCE(failure_reason, '') NOT IN ('iteration_limit', 'agent_fallback_message', 'api_invalid_request', 'codex_semantic_inactivity', 'agent_error.context_overflow', 'session_resume_exhausted')
       AND NOT (COALESCE(error, '') ILIKE '%400%' AND COALESCE(error, '') ILIKE '%invalid_request_error%')
       AND NOT (COALESCE(error, '') ~* 'must not be empty|must be non-?empty|must have non-?empty|non-?empty content|cannot be empty|should not be empty'
                AND COALESCE(error, '') ~* 'role[^a-z0-9]{0,2}assistant|assistant message|message at position|messages\.[0-9]|messages\[[0-9]')

--- a/server/pkg/db/queries/agent.sql
+++ b/server/pkg/db/queries/agent.sql
@@ -838,7 +838,7 @@ LIMIT 1;
 --
 -- failure_reason is returned rather than filtered here on purpose: which
 -- reasons are transient enough to skip is decided ONCE in Go
--- (transientResumeSafeReasons). This file and internal/service/task.go have
+-- (transcriptNeutralReasons). This file and internal/service/task.go have
 -- drifted apart before — the sibling NOT IN blacklist above exists in three
 -- places precisely because of that — so the set that is expected to grow
 -- lives in one language only.
@@ -851,7 +851,11 @@ WHERE t.agent_id = $1 AND t.issue_id = $2
       SELECT MAX(COALESCE(c.completed_at, c.started_at, c.dispatched_at, c.created_at))
       FROM agent_task_queue c
       WHERE c.agent_id = $1 AND c.issue_id = $2 AND c.status = 'completed'
-  ), '-infinity'::timestamptz);
+  ), '-infinity'::timestamptz)
+-- Newest first, with id as a tiebreak so rows sharing a timestamp keep a
+-- stable order. The caller retires the most recent DIFFERENT session id it
+-- sees, which is only well-defined if this ordering is.
+ORDER BY COALESCE(t.completed_at, t.started_at, t.dispatched_at, t.created_at) DESC, t.id DESC;
 
 -- name: IsSessionRetiredForIssue :one
 -- Reports whether any task on this (agent_id, issue_id) pair has retired the
@@ -873,6 +877,13 @@ SELECT EXISTS (
 -- (MUL-5305): without it the circuit breaker would silently drop the
 -- conversation, which is the behaviour GH #6143 complained about in the first
 -- place — the user could not tell why the agent had lost its context.
+--
+-- Only the LATEST terminal row is consulted, mirroring
+-- GetLatestTaskRolloutMissing. A transcript-neutral failure landing between the
+-- breaker and the next claim (retirement, then a runtime_offline run) therefore
+-- hides the disclosure, and that turn starts fresh without saying so. Rare, and
+-- the alternative — scanning back to the last success — would keep re-announcing
+-- the same retirement on every later turn, which is worse.
 SELECT COALESCE(failure_reason, '') = 'session_resume_exhausted' AS exhausted
 FROM agent_task_queue
 WHERE agent_id = $1 AND issue_id = $2

--- a/server/pkg/db/queries/agent.sql
+++ b/server/pkg/db/queries/agent.sql
@@ -725,7 +725,8 @@ RETURNING *;
 -- Tasks that ended in a known "poisoned" terminal state are also excluded
 -- here so even auto-retry does not inherit the bad session. The daemon
 -- classifies these failures (iteration_limit, agent_fallback_message,
--- api_invalid_request, codex_semantic_inactivity, agent_error.context_overflow)
+-- api_invalid_request, codex_semantic_inactivity, agent_error.context_overflow,
+-- session_resume_exhausted)
 -- when it detects either an agent fallback marker in the output, an upstream
 -- API 400 that means the conversation history itself is unprocessable
 -- (oversized image, malformed base64, etc.), a Codex semantic inactivity
@@ -805,7 +806,7 @@ WHERE session_id NOT IN (SELECT session_id FROM retired_sessions)
     status = 'completed'
     OR (
       status = 'failed'
-      AND COALESCE(failure_reason, '') NOT IN ('iteration_limit', 'agent_fallback_message', 'api_invalid_request', 'codex_semantic_inactivity', 'agent_error.context_overflow')
+      AND COALESCE(failure_reason, '') NOT IN ('iteration_limit', 'agent_fallback_message', 'api_invalid_request', 'codex_semantic_inactivity', 'agent_error.context_overflow', 'session_resume_exhausted')
       AND NOT (COALESCE(error, '') ILIKE '%400%' AND COALESCE(error, '') ILIKE '%invalid_request_error%')
       AND NOT (COALESCE(error, '') ILIKE '%image dimensions exceed max allowed size%' AND COALESCE(error, '') ILIKE '%image.source.base64.data%')
       AND NOT (COALESCE(error, '') ~* 'must not be empty|must be non-?empty|must have non-?empty|non-?empty content|cannot be empty|should not be empty'
@@ -813,6 +814,71 @@ WHERE session_id NOT IN (SELECT session_id FROM retired_sessions)
     )
   )
 ORDER BY terminal_at DESC
+LIMIT 1;
+
+-- name: ListResumeFailuresSinceLastSuccess :many
+-- Returns the failed tasks for this (agent_id, issue_id) pair since its last
+-- successful run, excluding the caller's own row ($3). TaskService.FailTask
+-- counts them to decide whether the conversation has proved unresumable and
+-- should be retired (GH #6143) — see sessionResumeExhausted.
+--
+-- Deliberately NOT keyed on session_id, even though the thing being judged is
+-- a session. ACP backends (resolveResumedSessionID in pkg/agent/hermes.go)
+-- may answer a resume with a DIFFERENT session id when their server-side
+-- state is gone, and a run that dies before establishing a session records no
+-- id at all. Keying on the id would restart the count on every drift and the
+-- threshold would never be reached in exactly the situation it exists for.
+-- The (agent, issue) pair is the unit the user actually experiences as stuck,
+-- and every id seen in the window is retired together.
+--
+-- "Since the last success" is the reset: one completed run proves the
+-- conversation is healthy, so older failures must not count toward retiring
+-- the session it left behind. Tasks with no terminal timestamp at all sort as
+-- -infinity and are therefore included, which is the safe direction.
+--
+-- failure_reason is returned rather than filtered here on purpose: which
+-- reasons are transient enough to skip is decided ONCE in Go
+-- (transientResumeSafeReasons). This file and internal/service/task.go have
+-- drifted apart before — the sibling NOT IN blacklist above exists in three
+-- places precisely because of that — so the set that is expected to grow
+-- lives in one language only.
+SELECT t.session_id, COALESCE(t.failure_reason, '') AS failure_reason
+FROM agent_task_queue t
+WHERE t.agent_id = $1 AND t.issue_id = $2
+  AND t.id <> $3
+  AND t.status = 'failed'
+  AND COALESCE(t.completed_at, t.started_at, t.dispatched_at, t.created_at) > COALESCE((
+      SELECT MAX(COALESCE(c.completed_at, c.started_at, c.dispatched_at, c.created_at))
+      FROM agent_task_queue c
+      WHERE c.agent_id = $1 AND c.issue_id = $2 AND c.status = 'completed'
+  ), '-infinity'::timestamptz);
+
+-- name: IsSessionRetiredForIssue :one
+-- Reports whether any task on this (agent_id, issue_id) pair has retired the
+-- given session id. The manual-rerun claim path reads the exact source task
+-- rather than GetLastTaskSession, so it never consulted the retired_sessions
+-- CTE and would happily resume a session a later run had already abandoned
+-- (GH #6143 review). Session ids are opaque per-provider strings, so the
+-- (agent, issue) scope is what keeps the lookup from colliding across issues.
+SELECT EXISTS (
+    SELECT 1 FROM agent_task_queue
+    WHERE agent_id = $1 AND issue_id = $2
+      AND retired_session_id = $3
+) AS retired;
+
+-- name: GetLatestTaskResumeExhausted :one
+-- Reports whether the most recent terminal task on this (agent_id, issue_id)
+-- pair retired its conversation for repeated failures. Drives the same
+-- PriorSessionResumeUnavailable disclosure as GetLatestTaskRolloutMissing
+-- (MUL-5305): without it the circuit breaker would silently drop the
+-- conversation, which is the behaviour GH #6143 complained about in the first
+-- place — the user could not tell why the agent had lost its context.
+SELECT COALESCE(failure_reason, '') = 'session_resume_exhausted' AS exhausted
+FROM agent_task_queue
+WHERE agent_id = $1 AND issue_id = $2
+  AND status IN ('completed', 'failed')
+  AND started_at IS NOT NULL
+ORDER BY COALESCE(completed_at, started_at, dispatched_at, created_at) DESC
 LIMIT 1;
 
 -- name: GetLatestTaskRolloutMissing :one

--- a/server/pkg/db/queries/chat.sql
+++ b/server/pkg/db/queries/chat.sql
@@ -447,7 +447,7 @@ WHERE session_id NOT IN (SELECT session_id FROM retired_sessions)
     status = 'completed'
     OR (
       status = 'failed'
-      AND COALESCE(failure_reason, '') NOT IN ('iteration_limit', 'agent_fallback_message', 'api_invalid_request', 'codex_semantic_inactivity', 'agent_error.context_overflow')
+      AND COALESCE(failure_reason, '') NOT IN ('iteration_limit', 'agent_fallback_message', 'api_invalid_request', 'codex_semantic_inactivity', 'agent_error.context_overflow', 'session_resume_exhausted')
       AND NOT (COALESCE(error, '') ILIKE '%400%' AND COALESCE(error, '') ILIKE '%invalid_request_error%')
       AND NOT (COALESCE(error, '') ~* 'must not be empty|must be non-?empty|must have non-?empty|non-?empty content|cannot be empty|should not be empty'
                AND COALESCE(error, '') ~* 'role[^a-z0-9]{0,2}assistant|assistant message|message at position|messages\.[0-9]|messages\[[0-9]')

--- a/server/pkg/taskfailure/failure.go
+++ b/server/pkg/taskfailure/failure.go
@@ -100,6 +100,27 @@ const (
 	// resume lookup. Written by classifyPoisonedError in daemon/poisoned.go.
 	ReasonAPIInvalidRequest Reason = "api_invalid_request"
 
+	// ReasonSessionResumeExhausted: the conversation was resumed and
+	// failed again, repeatedly, with no success in between. Unlike
+	// ReasonAPIInvalidRequest this is not recognised from the provider's
+	// error text — it is concluded from the session's own track record,
+	// which is the only signal that survives a provider wording we have
+	// never seen (GH #6143).
+	//
+	// The distinction matters because error text has no contract across
+	// the compatible-gateway ecosystem: a vendor code like GLM's 1210
+	// lives in that vendor's namespace, HTTP 400 covers both poisoned
+	// history and plain misconfiguration, and any of it can be reworded
+	// or localised at will. Pattern matching therefore both misses new
+	// shapes and collides with old ones, and an unrecognised shape used
+	// to mean "resume forever" — permanently bricking the (agent, issue)
+	// pair with no in-product recovery, since manual rerun resumes too.
+	// Counting consecutive failures instead downgrades "unrecognised"
+	// from unbounded retries to exactly one, so the cost of a wording we
+	// cannot classify is a single wasted run rather than a dead issue.
+	// Written by TaskService.FailTask, never by the daemon.
+	ReasonSessionResumeExhausted Reason = "session_resume_exhausted"
+
 	// ReasonSkillBundleUnavailable: the daemon could not download the
 	// agent's skill bundles from the control plane during task
 	// preparation — the agent process was never launched. Platform-side
@@ -204,6 +225,7 @@ var allReasons = []Reason{
 	ReasonIterationLimit,
 	ReasonAgentBlocked,
 	ReasonAPIInvalidRequest,
+	ReasonSessionResumeExhausted,
 	ReasonSkillBundleUnavailable,
 
 	// Agent process side: provider errors.

--- a/server/pkg/taskfailure/failure_test.go
+++ b/server/pkg/taskfailure/failure_test.go
@@ -112,8 +112,8 @@ func TestAllReasonsContents(t *testing.T) {
 	t.Parallel()
 
 	got := AllReasons()
-	if len(got) != 22 {
-		t.Fatalf("AllReasons() returned %d entries, want 22", len(got))
+	if len(got) != 23 {
+		t.Fatalf("AllReasons() returned %d entries, want 23", len(got))
 	}
 
 	seen := make(map[Reason]bool, len(got))
@@ -130,8 +130,8 @@ func TestAllReasonsContents(t *testing.T) {
 		}
 	}
 
-	if platformCount != 8 {
-		t.Errorf("AllReasons(): platform-side count = %d, want 8", platformCount)
+	if platformCount != 9 {
+		t.Errorf("AllReasons(): platform-side count = %d, want 9", platformCount)
 	}
 	if agentCount != 14 {
 		t.Errorf("AllReasons(): agent-side count = %d, want 14", agentCount)
@@ -144,7 +144,8 @@ func TestAllReasonsContents(t *testing.T) {
 	required := []Reason{
 		ReasonQueuedExpired, ReasonRuntimeOffline, ReasonRuntimeRecovery,
 		ReasonTimeout, ReasonIterationLimit, ReasonAgentBlocked,
-		ReasonAPIInvalidRequest, ReasonSkillBundleUnavailable,
+		ReasonAPIInvalidRequest, ReasonSessionResumeExhausted,
+		ReasonSkillBundleUnavailable,
 		ReasonAgentProviderAuthOrAccess, ReasonAgentProviderQuotaLimit,
 		ReasonAgentProviderCapacityOrRateLimit, ReasonAgentProviderServerError,
 		ReasonAgentProviderNetwork, ReasonAgentProcessFailure,


### PR DESCRIPTION
Fixes #6143. Multica issue: MUL-5503.

## The problem

A conversation whose resume kept failing could only be recognised by matching the provider's **error text**. That works for Anthropic's own `400 invalid_request_error` shape and for the empty-message wordings added since, but the compatible-gateway ecosystem has no contract on error text:

- vendor codes live in the vendor's namespace (GLM's `1210` means nothing elsewhere),
- HTTP `400` covers both a poisoned transcript and plain misconfiguration,
- any of it can be reworded or localised at will.

So an unrecognised rejection meant *"safe to resume"* by omission, and the `(agent, issue)` pair was bricked permanently — every later trigger resumed the same dead conversation and failed within seconds.

Manual **Rerun did not help either**: that path resolves its session from the source task and applies the same text-based predicate. Deleting the task's workdir on the host was the only way out.

This is the fourth report of this shape after #5975, #6066 and #5760, each previously closed by adding another pattern.

### Why not just broaden the match

The reporter suggested `contains("400") && (contains("api error") || ...)`. Implemented and measured against the current classifier:

| today's classification | proposed patch | error string |
| --- | --- | --- |
| `provider_capacity_or_rate_limit` | poisoned ✗ | `429 rate limit reached, retry after 400ms` |
| `provider_capacity_or_rate_limit` | poisoned ✗ | `529 overloaded, request_id req_400ab2` |
| `provider_server_error` | poisoned ✗ | `500 Internal Server Error (trace 88400)` |
| `context_overflow` | poisoned ✗ | `prompt is too long: 400123 tokens` |
| `unknown` | poisoned ✓ | `400 [1210][API 调用参数有误]` |

Five matches, four of them already classified correctly today. The 429/529/500 cases are transient — precisely where the session *should* be kept — so the patch would discard healthy conversation context to recognise one gateway. `pkg/taskfailure/classify.go` already documents this trap and uses digit-boundary regexes (`(^|[^0-9])(429|529)([^0-9]|$)`) for exactly this reason.

## The change

Conclude it from **behaviour** instead of text. Two consecutive non-transient failures on one `(agent, issue)` pair with no success in between retire the conversation, so the next run starts clean. No error text is parsed, which is what makes it hold for a wording nobody has seen yet.

Design points worth reviewing:

- **Threshold is 2, not 1.** The first failure still resumes. An unrecognised error is not yet evidence that the transcript is at fault, and restarting on every first stumble would discard context whenever a provider hiccupped. The cost of an unrecognised error drops from a dead issue to one wasted run.
- **Transient reasons are skipped without resetting the count.** Daemon offline, rate limit, provider 5xx and queue expiry say nothing about whether the transcript replays. `fail(unknown) → fail(runtime_offline) → fail(unknown)` counts as two, so a flaky daemon can neither trip the breaker nor mask a genuinely dead session. `transientResumeSafeReasons` is an explicit superset of `retryableReasons` — rate limit and 5xx are not auto-retried but are unambiguously transient.
- **Counting is keyed on `(agent, issue)`, not `session_id`.** ACP backends (`resolveResumedSessionID`) may answer a resume with a *different* id, and a run that dies early records none. Keying on the id would restart the count in exactly the case this exists for. `retired_session_id` holds one id, so the run retires the most recent *differing* id it saw — the session it was actually told to resume — while the current one is covered by the upgraded reason on its own row. Older drifted predecessors are left to their own rows and re-evaluated on the next failure, which bounds the leak at an extra run rather than a loop.
- **Decided server-side**, in `FailTask`, ahead of the retry pre-compute and the chat-pointer writes so both observe the upgraded reason — otherwise this would retire the session and immediately re-pin it as resumable. Daemons upgrade on their own cadence and the sibling fixes above have already been reissued once for hosts that never picked them up.
- **No migration.** Reuses the existing `retired_session_id` mechanism (migration 234) and its `retired_sessions` CTE; only the trigger is new.

Two gaps the new behaviour would otherwise widen are closed in the same change:

- the manual-rerun claim path never consulted the retired-session set, so a rerun of an older task could resurrect a retired conversation;
- the breaker would have dropped conversations silently — it now raises the same `PriorSessionResumeUnavailable` disclosure as MUL-5305, so the next run tells the user its context was not carried over.

Scoped to issue tasks; chat sessions keep their existing handling (the window is keyed on `issue_id`).

## Honest expectation on #6143 specifically

The reporter's own retry log shows two successful tool calls **after** the resume before the 400. A genuinely unprocessable history fails on the first request of the turn, since every request replays the full transcript — so this may not be history poisoning at all, and a fresh session may fail too.

That is still the right outcome: the loop is bounded, and the user's signal changes from "this issue is cursed" to "my gateway has a compatibility problem." **The breaker's job is to stop the bleeding and attribute correctly, not to fix someone else's gateway.**

## Verification

- `make test ENV_FILE=.env.worktree` (isolated DB) — all packages pass except `cmd/multica`, which fails **identically (94 tests) on clean `origin/main`** in this sandbox; unrelated CLI/config-env tests.
- `pnpm typecheck` — 6/6 tasks pass.
- `@multica/core` 1182 tests, `@multica/views` 3427 tests — pass.
- New: `server/internal/service/session_resume_exhausted_test.go` — threshold, window reset on success, transient exclusion (including the interleaved-blip case), ACP id drift, and the resume-unsafe wiring that makes Rerun honour the breaker.

