### PR TITLE
refactor(issues): move sidebar Details below the execution log (MUL-5599)

### DIFF
--- a/packages/views/issues/components/issue-detail.test.tsx
+++ b/packages/views/issues/components/issue-detail.test.tsx
@@ -921,6 +921,38 @@ describe("IssueDetail (shared)", () => {
     expect(screen.getByText("Updated")).toBeInTheDocument();
   });
 
+  // Details is creator + immutable timestamps, so it ranks below the
+  // execution log, which is what people actually open the sidebar for.
+  it("orders the Details section after the execution log", async () => {
+    mockApiObj.listTasksByIssue.mockResolvedValue([
+      {
+        id: "task-past",
+        agent_id: "agent-1",
+        runtime_id: "runtime-1",
+        issue_id: "issue-1",
+        status: "completed",
+        priority: 0,
+        dispatched_at: null,
+        started_at: "2026-06-08T08:00:00Z",
+        completed_at: "2026-06-08T08:05:00Z",
+        result: null,
+        error: null,
+        created_at: "2026-06-08T08:00:00Z",
+        trigger_summary: "Started from comment",
+      },
+    ]);
+
+    renderIssueDetail();
+
+    const executionLog = await screen.findByText("Execution log");
+    const details = screen.getByText("Details");
+
+    // DOCUMENT_POSITION_FOLLOWING: Details comes after the execution log.
+    expect(
+      executionLog.compareDocumentPosition(details) & Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
+  });
+
   it("shows 'not found' message when issue does not exist", async () => {
     mockApiObj.getIssue.mockRejectedValue(new Error("Not found"));
 

--- a/packages/views/issues/components/issue-detail.tsx
+++ b/packages/views/issues/components/issue-detail.tsx
@@ -2072,7 +2072,15 @@ export function IssueDetail({ issueId, onDelete, onDone, defaultSidebarOpen = tr
         </div>
       )}
 
-      {/* Details */}
+      {/* Execution log — active runs + collapsed past runs. Self-contained;
+          owns its own collapse state and WS subscriptions. Hides itself
+          when there are no runs to show. */}
+      <ExecutionLogSection issueId={id} />
+
+      {/* Details — creator and timestamps. Sits below the execution log
+          because it is the least-read block in the sidebar: the values
+          never change once the issue exists, while the log above it is
+          what people actually come here to check. */}
       <div>
         <button
           type="button"
@@ -2095,11 +2103,6 @@ export function IssueDetail({ issueId, onDelete, onDone, defaultSidebarOpen = tr
           </PropRow>
         </div>}
       </div>
-
-      {/* Execution log — active runs + collapsed past runs. Self-contained;
-          owns its own collapse state and WS subscriptions. Hides itself
-          when there are no runs to show. */}
-      <ExecutionLogSection issueId={id} />
 
       {/* Token usage */}
       {usage && usage.task_count > 0 && (


### PR DESCRIPTION
## Summary

Moves the issue sidebar's **Details** section (Created by / Created / Updated) below **Execution log**.

Details holds the creator plus two timestamps that never change once the issue exists — it's the least-read block in the sidebar, but it was sitting directly above the execution log, which is what people actually open the sidebar to check. Swapping the two puts the live content first.

Sidebar order is now: Properties → Quick actions → Parent issue → Pull requests → **Execution log → Details** → Token usage → Metadata.

Both sidebar render sites (docked panel and the mobile sheet) share one `sidebarContent` value, so the single move covers both.

## Testing

- Added `orders the Details section after the execution log` in `packages/views/issues/components/issue-detail.test.tsx`, asserting DOM order via `compareDocumentPosition`. Verified it fails against the pre-change ordering and passes after.
- `pnpm exec vitest run issues/` in `packages/views` — 56 files, 538 tests passing.
- `pnpm typecheck` and `pnpm lint` in `packages/views` — clean (lint reports 0 errors; the remaining warnings are pre-existing and in untouched files).

MUL-5599
