### PR TITLE
feat(labels): remove agent labels from the product (MUL-5600)

### DIFF
--- a/packages/views/agents/components/agent-detail-inspector.labels.test.tsx
+++ b/packages/views/agents/components/agent-detail-inspector.labels.test.tsx
@@ -1,0 +1,72 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { cleanup, screen } from "@testing-library/react";
+import type { Agent } from "@multica/core/types";
+import { renderWithI18n } from "../../test/i18n";
+import { AgentDetailInspector } from "./agent-detail-inspector";
+
+vi.mock("@tanstack/react-query", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@tanstack/react-query")>()),
+  useQuery: () => ({ data: undefined, isSuccess: false }),
+}));
+
+// The picker is the only way agent labels ever reached the agent settings
+// form. Mocking it means the assertion below fails loudly if the row is
+// re-added, instead of passing because a real picker rendered nothing.
+vi.mock("../../labels/resource-label-picker", () => ({
+  ResourceLabelPicker: () => <div data-testid="resource-label-picker" />,
+}));
+
+vi.mock("../../common/avatar-upload-control", () => ({
+  AvatarUploadControl: () => <div data-testid="avatar-upload" />,
+}));
+
+vi.mock("./inspector/model-picker", () => ({
+  ModelPicker: () => <div data-testid="model-picker" />,
+}));
+
+vi.mock("./inspector/runtime-picker", () => ({
+  RuntimePicker: () => <div data-testid="runtime-picker" />,
+}));
+
+vi.mock("./inspector/thinking-prop-row", () => ({
+  ThinkingSettingField: () => <div data-testid="thinking-field" />,
+}));
+
+vi.mock("./inspector/service-tier-setting-field", () => ({
+  ServiceTierSettingField: () => <div data-testid="service-tier-field" />,
+}));
+
+const agent = {
+  id: "agent-1",
+  workspace_id: "workspace-1",
+  name: "Lambda",
+  description: "Test agent",
+  runtime_id: "runtime-1",
+} as Agent;
+
+describe("AgentDetailInspector labels", () => {
+  afterEach(cleanup);
+
+  // Agent labels were removed from the product (MUL-5600). Label Settings no
+  // longer manages an agent catalog, so an attach-only picker here would be a
+  // dead end pointing at a catalog the user cannot populate.
+  it("does not offer a label picker", () => {
+    renderWithI18n(
+      <AgentDetailInspector
+        agent={agent}
+        runtime={null}
+        runtimes={[]}
+        members={[]}
+        currentUserId="user-1"
+        canEdit
+        onUpdate={vi.fn(async () => {})}
+      />,
+    );
+
+    // Sanity check: the profile card actually rendered.
+    expect(screen.getByLabelText("Name")).toBeInTheDocument();
+
+    expect(screen.queryByTestId("resource-label-picker")).toBeNull();
+    expect(screen.queryByText("Labels")).toBeNull();
+  });
+});

--- a/packages/views/agents/components/agent-detail-inspector.tsx
+++ b/packages/views/agents/components/agent-detail-inspector.tsx
@@ -26,7 +26,6 @@ import {
 import { useAutoSave } from "../../settings/components/use-auto-save";
 import { useT } from "../../i18n";
 import { CharCounter } from "./char-counter";
-import { ResourceLabelPicker } from "../../labels/resource-label-picker";
 import { ModelPicker } from "./inspector/model-picker";
 import {
   buildModelChangeUpdate,
@@ -227,18 +226,6 @@ export function AgentDetailInspector({
                 max={AGENT_DESCRIPTION_MAX_LENGTH}
               />
             </div>
-          </SettingsRow>
-          <SettingsRow
-            label={t(($) => $.inspector.labels_label)}
-            description={t(($) => $.inspector.labels_hint)}
-            size="text"
-            align="start"
-          >
-            <ResourceLabelPicker
-              resourceType="agent"
-              resourceId={agent.id}
-              canEdit={canEdit}
-            />
           </SettingsRow>
         </SettingsCard>
       </SettingsSection>

--- a/packages/views/locales/en/agents.json
+++ b/packages/views/locales/en/agents.json
@@ -183,8 +183,6 @@
     "avatar_hint": "Shown in assignments, activity, and chat.",
     "name_label": "Name",
     "description_label": "Description",
-    "labels_label": "Labels",
-    "labels_hint": "Workspace labels used to classify this agent.",
     "change_avatar_aria": "Change avatar",
     "avatar_updated_toast": "Avatar updated",
     "avatar_upload_failed_toast": "Failed to upload avatar",

--- a/packages/views/locales/en/settings.json
+++ b/packages/views/locales/en/settings.json
@@ -254,10 +254,9 @@
   },
   "labels": {
     "title": "Labels",
-    "description": "Manage the separate label catalogs used to organize issues, agents, and skills in this workspace.",
+    "description": "Manage the separate label catalogs used to organize issues and skills in this workspace.",
     "scopes": {
       "issue": "Issues",
-      "agent": "Agents",
       "skill": "Skills"
     },
     "search_placeholder": "Filter by name or description...",

--- a/packages/views/locales/ja/agents.json
+++ b/packages/views/locales/ja/agents.json
@@ -167,8 +167,6 @@
     "avatar_hint": "割り当て、アクティビティ、チャットに表示されます。",
     "name_label": "名前",
     "description_label": "説明",
-    "labels_label": "ラベル",
-    "labels_hint": "このエージェントを分類するワークスペースラベルです。",
     "change_avatar_aria": "アバターを変更",
     "avatar_updated_toast": "アバターを更新しました",
     "avatar_upload_failed_toast": "アバターをアップロードできませんでした",

--- a/packages/views/locales/ja/settings.json
+++ b/packages/views/locales/ja/settings.json
@@ -253,10 +253,9 @@
   },
   "labels": {
     "title": "ラベル",
-    "description": "このワークスペースの Issue、エージェント、Skill 用ラベルを個別に管理します。",
+    "description": "このワークスペースの Issue、Skill 用ラベルを個別に管理します。",
     "scopes": {
       "issue": "Issue",
-      "agent": "エージェント",
       "skill": "Skill"
     },
     "search_placeholder": "名前または説明で絞り込み...",

--- a/packages/views/locales/ko/agents.json
+++ b/packages/views/locales/ko/agents.json
@@ -175,8 +175,6 @@
     "avatar_hint": "할당, 활동 및 채팅에 표시됩니다.",
     "name_label": "이름",
     "description_label": "설명",
-    "labels_label": "레이블",
-    "labels_hint": "이 에이전트를 분류하는 워크스페이스 레이블입니다.",
     "change_avatar_aria": "아바타 변경",
     "avatar_updated_toast": "아바타를 업데이트했습니다",
     "avatar_upload_failed_toast": "아바타를 업로드하지 못했습니다",

--- a/packages/views/locales/ko/settings.json
+++ b/packages/views/locales/ko/settings.json
@@ -253,10 +253,9 @@
   },
   "labels": {
     "title": "레이블",
-    "description": "이 워크스페이스의 이슈, 에이전트, 스킬 레이블을 각각 관리합니다.",
+    "description": "이 워크스페이스의 이슈, 스킬 레이블을 각각 관리합니다.",
     "scopes": {
       "issue": "이슈",
-      "agent": "에이전트",
       "skill": "스킬"
     },
     "search_placeholder": "이름 또는 설명으로 필터링...",

--- a/packages/views/locales/zh-Hans/agents.json
+++ b/packages/views/locales/zh-Hans/agents.json
@@ -175,8 +175,6 @@
     "avatar_hint": "显示在任务分配、动态和聊天中。",
     "name_label": "名称",
     "description_label": "描述",
-    "labels_label": "标签",
-    "labels_hint": "用于分类这个智能体的工作区标签。",
     "change_avatar_aria": "更换头像",
     "avatar_updated_toast": "已更新头像",
     "avatar_upload_failed_toast": "头像上传失败",

--- a/packages/views/locales/zh-Hans/settings.json
+++ b/packages/views/locales/zh-Hans/settings.json
@@ -253,10 +253,9 @@
   },
   "labels": {
     "title": "标签",
-    "description": "分别管理工作区中用于整理 issue、智能体和 skill 的标签。三类标签相互独立。",
+    "description": "分别管理工作区中用于整理 issue 和 skill 的标签。两类标签相互独立。",
     "scopes": {
       "issue": "Issue",
-      "agent": "智能体",
       "skill": "Skill"
     },
     "search_placeholder": "按名称或描述筛选...",

--- a/packages/views/settings/components/labels-tab.test.tsx
+++ b/packages/views/settings/components/labels-tab.test.tsx
@@ -1,0 +1,42 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { cleanup, screen } from "@testing-library/react";
+import { renderWithI18n } from "../../test/i18n";
+import { LabelsTab } from "./labels-tab";
+
+vi.mock("@multica/core/hooks", () => ({
+  useWorkspaceId: () => "workspace-1",
+}));
+
+vi.mock("@tanstack/react-query", () => ({
+  useQuery: () => ({ data: [], isLoading: false }),
+}));
+
+vi.mock("@multica/core/labels", () => ({
+  labelListOptions: (wsId: string, resourceType: string) => ({
+    queryKey: ["labels", wsId, "list", resourceType],
+  }),
+  useCreateLabel: () => ({ mutate: vi.fn(), isPending: false }),
+  useUpdateLabel: () => ({ mutate: vi.fn(), isPending: false }),
+  useDeleteLabel: () => ({ mutate: vi.fn(), isPending: false }),
+}));
+
+describe("LabelsTab scopes", () => {
+  afterEach(cleanup);
+
+  // Agent labels were removed from the product (MUL-5600). The backend still
+  // models the `agent` resource type, so the guard here is that the settings
+  // UI never offers it as a manageable catalog again.
+  it("offers only the issue and skill catalogs", () => {
+    renderWithI18n(<LabelsTab />);
+
+    expect(screen.getByRole("button", { name: /Issues/ })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /Skills/ })).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /Agents/ })).toBeNull();
+  });
+
+  it("describes the tab without promising an agent catalog", () => {
+    renderWithI18n(<LabelsTab />);
+
+    expect(screen.getByText(/organize issues and skills/i)).toBeInTheDocument();
+  });
+});

--- a/packages/views/settings/components/labels-tab.tsx
+++ b/packages/views/settings/components/labels-tab.tsx
@@ -45,7 +45,14 @@ import { ColorPicker, COLOR_PICKER_PRESETS } from "../../common/color-picker";
 import { useT } from "../../i18n";
 import { SettingsTab } from "./settings-layout";
 
-const RESOURCE_TYPES: LabelResourceType[] = ["issue", "agent", "skill"];
+/**
+ * Label scopes this settings tab manages. Narrower than `LabelResourceType`:
+ * the backend still models agent labels, but the product no longer exposes
+ * any way to create, apply, or view them, so they are not manageable here.
+ */
+type LabelScope = Extract<LabelResourceType, "issue" | "skill">;
+
+const RESOURCE_TYPES: LabelScope[] = ["issue", "skill"];
 
 interface LabelDraft {
   name: string;
@@ -63,7 +70,7 @@ export function LabelsTab() {
   const { t } = useT("settings");
   const wsId = useWorkspaceId();
 
-  const [resourceType, setResourceType] = useState<LabelResourceType>("issue");
+  const [resourceType, setResourceType] = useState<LabelScope>("issue");
   const [query, setQuery] = useState("");
   const [editing, setEditing] = useState<Label | null>(null);
   const [createOpen, setCreateOpen] = useState(false);
@@ -236,7 +243,7 @@ function LabelEditorDialog({
 }: {
   open: boolean;
   onOpenChange: (open: boolean) => void;
-  resourceType: LabelResourceType;
+  resourceType: LabelScope;
   label?: Label | null;
 }) {
   const { t } = useT("settings");


### PR DESCRIPTION
Closes MUL-5600.

## What changed

Label Settings no longer exposes an **Agents** catalog. Agent labels can't be created, renamed, recolored, or deleted from the UI anymore — only Issues and Skills remain.

The agent detail settings form also loses its **Labels** row. That was an attach-only `ResourceLabelPicker`; leaving it after removing the catalog would have pointed users at a label set they could no longer populate.

## On the open question in the issue

The issue asked to confirm whether agent settings already had no agent-label entry. It did have one — `AgentDetailInspector` rendered a Labels row in the Profile section (`packages/views/agents/components/agent-detail-inspector.tsx`). Removing it here is what makes the removal coherent rather than half-done.

A full sweep found no other agent-label surface: no list column, chip, filter, or search facet, and the `multica label` CLI never supported agent labels.

## Scope

Product surface only. The backend still models the `agent` resource type and keeps `GET/POST/DELETE /api/agents/{id}/labels`, and `agent_labels` rows are untouched — the frontend simply stops calling them. `LabelResourceType` keeps `"agent"` so the API client stays honest about what the server supports; the settings tab narrows to a local `LabelScope` instead.

Any agent labels already in a workspace become invisible and unmanageable after this. No data is deleted. Happy to follow up with backend/schema removal or a cleanup migration if that's wanted.

## Tests

Two new regression tests, both verified to fail when the source change is reverted:

- `packages/views/settings/components/labels-tab.test.tsx` — only the issue and skill catalogs are offered
- `packages/views/agents/components/agent-detail-inspector.labels.test.tsx` — the inspector renders no label picker

## Verification

- `pnpm typecheck` — passes
- `pnpm lint` — 0 errors
- `packages/views` tests — 3459 passed, 1 failure (`layout/sidebar-resize.test.tsx`), confirmed pre-existing on a clean tree
- `apps/desktop` tests — 487 passed
- `packages/core` tests — 8 failures, all confirmed pre-existing on a clean tree (workspace/project delete + `localStorage`, unrelated to labels)
