### PR TITLE
fix(studio): archive builder session on unmount instead of hard-deleting (#6246)

### DIFF
--- a/packages/views/agents/components/agent-creation-studio.tsx
+++ b/packages/views/agents/components/agent-creation-studio.tsx
@@ -287,8 +287,9 @@ export function AgentCreationStudio() {
       const sessionId = builderSessionIdRef.current;
       if (sessionId) {
         // Covers route/sidebar navigation that bypasses the Studio back button.
-        // The endpoint atomically cancels any running task before deletion.
-        void api.deleteChatSession(sessionId).catch(() => {
+        // Archive instead of delete so accidental navigation does not destroy
+        // the builder conversation permanently (#6246).
+        void api.setChatSessionArchived(sessionId, true).catch(() => {
           // A hard page unload may interrupt cleanup; runtime teardown remains
           // the final safety net for an orphaned hidden Builder Agent.
         });


### PR DESCRIPTION
## What

Replace `deleteChatSession` with `setChatSessionArchived` in the Agent Creation Studio's unmount cleanup effect so accidental navigation (sidebar click, tab close) preserves the builder conversation instead of destroying it permanently.

## Related Issue

Closes #6246

## Type

Bug fix

## Changes

- `packages/views/agents/components/agent-creation-studio.tsx`: unmount effect now calls `api.setChatSessionArchived(sessionId, true)` instead of `api.deleteChatSession(sessionId)`

The explicit back-button path (`deleteBuilderSession`) and the post-create cleanup path are unchanged — they still hard-delete, which is appropriate for intentional user actions and committed agents respectively.

## How to Test

1. Open Agents → Build with AI
2. Hold a multi-turn conversation with the builder
3. Click any sidebar entry (Issues, Inbox, etc.)
4. Return to Chat → the builder session should appear in the archived list, not be gone entirely

## Checklist

- [x] Single concern
- [x] Minimal diff (3 insertions, 2 deletions)
- [x] No interface changes
- [x] Existing tests unaffected (tests cover pure helpers, not lifecycle effects)

## AI Disclosure

This PR was authored by an AI agent ([@kagura-agent](https://github.com/kagura-agent)).