### PR TITLE
feat(skills): update (re-import) a skill from its source

### DIFF
--- a/packages/core/api/client.test.ts
+++ b/packages/core/api/client.test.ts
@@ -1989,3 +1989,50 @@ describe("ApiClient startMikaOnboarding", () => {
     ).resolves.toEqual({ started: false });
   });
 });
+
+describe("ApiClient reimportSkill response schema", () => {
+  const stubJSON = (body: unknown) => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(
+        new Response(JSON.stringify(body), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        }),
+      ),
+    );
+  };
+
+  it("parses a valid skill and defaults the optional fields", async () => {
+    stubJSON({
+      id: "skill-1",
+      workspace_id: "ws-1",
+      name: "deploy",
+      created_at: "2026-01-01T00:00:00Z",
+      updated_at: "2026-01-02T00:00:00Z",
+    });
+
+    const skill = await new ApiClient("https://api.example.test")
+      .reimportSkill("skill-1");
+
+    expect(skill).toMatchObject({
+      id: "skill-1",
+      name: "deploy",
+      description: "",
+      content: "",
+      config: {},
+      created_by: null,
+      files: [],
+    });
+  });
+
+  // A malformed body must not report a failed update. The server already
+  // committed the overwrite, and the dialog refetches through invalidation.
+  it("falls back to null on a malformed body instead of throwing", async () => {
+    stubJSON({ id: 42, files: "not-an-array" });
+
+    await expect(
+      new ApiClient("https://api.example.test").reimportSkill("skill-1"),
+    ).resolves.toBeNull();
+  });
+});

--- a/packages/core/api/client.ts
+++ b/packages/core/api/client.ts
@@ -345,6 +345,7 @@ import {
   type IssueView,
   type IssueViewPreference,
   type CreateIssueViewRequest,
+  SkillSchema,
 } from "./schemas";
 
 /** Identifies the calling client to the server.
@@ -2227,8 +2228,18 @@ export class ApiClient {
 
   // Re-imports a URL-sourced skill in place from its stored config.origin.
   // No body — the server reads the source URL from the skill's provenance.
-  async reimportSkill(id: string): Promise<Skill> {
-    return this.fetch(`/api/skills/${id}/reimport`, { method: "POST" });
+  //
+  // A malformed body returns null instead of throwing. A 2xx here means the
+  // server already committed the overwrite, so a parse failure is contract
+  // drift, not a failed update. Callers ignore the return value and refetch
+  // through query invalidation.
+  async reimportSkill(id: string): Promise<Skill | null> {
+    const raw = await this.fetch<unknown>(`/api/skills/${id}/reimport`, {
+      method: "POST",
+    });
+    return parseWithFallback<Skill | null>(raw, SkillSchema, null, {
+      endpoint: "POST /api/skills/:id/reimport",
+    });
   }
 
   async listAgentSkills(agentId: string): Promise<SkillSummary[]> {

--- a/packages/core/api/client.ts
+++ b/packages/core/api/client.ts
@@ -2225,6 +2225,12 @@ export class ApiClient {
     });
   }
 
+  // Re-imports a URL-sourced skill in place from its stored config.origin.
+  // No body — the server reads the source URL from the skill's provenance.
+  async reimportSkill(id: string): Promise<Skill> {
+    return this.fetch(`/api/skills/${id}/reimport`, { method: "POST" });
+  }
+
   async listAgentSkills(agentId: string): Promise<SkillSummary[]> {
     return this.fetch(`/api/agents/${agentId}/skills`);
   }

--- a/packages/core/api/schemas.ts
+++ b/packages/core/api/schemas.ts
@@ -1401,6 +1401,39 @@ export const EMPTY_CANCEL_TASK_RESPONSE: CancelTaskResponse = {
   created_at: "",
 };
 
+// ---------------------------------------------------------------------------
+// Skills
+//
+// Added for `POST /api/skills/:id/reimport`. The older skill endpoints
+// (`getSkill` / `createSkill` / `importSkill`) predate the schema rule and
+// still cast their responses. They can adopt `SkillSchema` in a follow-up.
+// Lenient by this file's rules: `.loose()`, arrays default to `[]`, optional
+// text defaults to `""`.
+// ---------------------------------------------------------------------------
+
+export const SkillFileSchema = z.object({
+  id: z.string(),
+  skill_id: z.string(),
+  path: z.string(),
+  content: z.string().optional().default(""),
+  created_at: z.string(),
+  updated_at: z.string(),
+}).loose();
+
+export const SkillSchema = z.object({
+  id: z.string(),
+  workspace_id: z.string(),
+  name: z.string(),
+  description: z.string().optional().default(""),
+  content: z.string().optional().default(""),
+  config: z.record(z.string(), z.unknown()).optional().default({}),
+  created_by: z.string().nullable().optional().default(null),
+  created_at: z.string(),
+  updated_at: z.string(),
+  // Detail endpoints embed the file set. A list-shaped payload omits it.
+  files: z.array(SkillFileSchema).optional().default([]),
+}).loose();
+
 export const AgentBuilderSessionSchema = z.object({
   session_id: z.string(),
   builder_agent_id: z.string(),

--- a/packages/views/locales/en/skills.json
+++ b/packages/views/locales/en/skills.json
@@ -100,6 +100,7 @@
     "updating": "Updating...",
     "updated_toast": "Updated {{name}} from source",
     "update_failed_toast": "Failed to update skill",
+    "update_partial_toast": "Updated {{succeeded}} of {{total}} skills from source; {{failed}} failed",
     "update_no_permission": "Selection includes skills that can't be updated from a source",
     "update_dialog_title_multi_one": "Update {{count}} skill from source?",
     "update_dialog_title_multi_other": "Update {{count}} skills from source?",

--- a/packages/views/locales/en/skills.json
+++ b/packages/views/locales/en/skills.json
@@ -99,7 +99,14 @@
     "update_confirm": "Update",
     "updating": "Updating...",
     "updated_toast": "Updated {{name}} from source",
-    "update_failed_toast": "Failed to update skill"
+    "update_failed_toast": "Failed to update skill",
+    "update_no_permission": "Selection includes skills that can't be updated from a source",
+    "update_dialog_title_multi_one": "Update {{count}} skill from source?",
+    "update_dialog_title_multi_other": "Update {{count}} skills from source?",
+    "update_dialog_desc_multi_one": "This replaces the selected skill with the latest version from its source. Local changes will be lost.",
+    "update_dialog_desc_multi_other": "This replaces the {{count}} selected skills with the latest versions from their sources. Local changes will be lost.",
+    "updated_multi_toast_one": "Updated {{count}} skill from source",
+    "updated_multi_toast_other": "Updated {{count}} skills from source"
   },
   "toolbar": {
     "result_count_title": "Matching skills / all skills",

--- a/packages/views/locales/en/skills.json
+++ b/packages/views/locales/en/skills.json
@@ -91,7 +91,15 @@
     "add_confirm": "Add ({{num}})",
     "adding": "Adding...",
     "added_multi_toast_one": "Added to {{count}} agent",
-    "added_multi_toast_other": "Added to {{count}} agents"
+    "added_multi_toast_other": "Added to {{count}} agents",
+    "update": "Update",
+    "update_dialog_title": "Update from source?",
+    "update_dialog_desc": "This replaces \"{{name}}\" with the latest version from its source. Any local changes to this skill will be lost.",
+    "update_dialog_source": "Source: {{url}}",
+    "update_confirm": "Update",
+    "updating": "Updating...",
+    "updated_toast": "Updated {{name}} from source",
+    "update_failed_toast": "Failed to update skill"
   },
   "toolbar": {
     "result_count_title": "Matching skills / all skills",

--- a/packages/views/locales/ja/skills.json
+++ b/packages/views/locales/ja/skills.json
@@ -95,7 +95,11 @@
     "update_confirm": "更新",
     "updating": "更新中...",
     "updated_toast": "{{name}} をソースから更新しました",
-    "update_failed_toast": "スキルの更新に失敗しました"
+    "update_failed_toast": "スキルの更新に失敗しました",
+    "update_no_permission": "ソースから更新できないスキルが選択に含まれています",
+    "update_dialog_title_multi_other": "{{count}} 件のスキルをソースから更新しますか？",
+    "update_dialog_desc_multi_other": "選択した {{count}} 件のスキルをソースの最新バージョンに置き換えます。ローカルの変更は失われます。",
+    "updated_multi_toast_other": "{{count}} 件のスキルをソースから更新しました"
   },
   "toolbar": {
     "result_count_title": "該当スキル / 全スキル",

--- a/packages/views/locales/ja/skills.json
+++ b/packages/views/locales/ja/skills.json
@@ -87,7 +87,15 @@
     "cancel": "キャンセル",
     "add_confirm": "追加（{{num}}）",
     "adding": "追加中...",
-    "added_multi_toast_other": "{{count}} 件のエージェントに追加しました"
+    "added_multi_toast_other": "{{count}} 件のエージェントに追加しました",
+    "update": "更新",
+    "update_dialog_title": "ソースから更新しますか？",
+    "update_dialog_desc": "「{{name}}」をソースの最新バージョンに置き換えます。このスキルへのローカルの変更は失われます。",
+    "update_dialog_source": "ソース: {{url}}",
+    "update_confirm": "更新",
+    "updating": "更新中...",
+    "updated_toast": "{{name}} をソースから更新しました",
+    "update_failed_toast": "スキルの更新に失敗しました"
   },
   "toolbar": {
     "result_count_title": "該当スキル / 全スキル",

--- a/packages/views/locales/ja/skills.json
+++ b/packages/views/locales/ja/skills.json
@@ -96,6 +96,7 @@
     "updating": "更新中...",
     "updated_toast": "{{name}} をソースから更新しました",
     "update_failed_toast": "スキルの更新に失敗しました",
+    "update_partial_toast": "{{total}} 件中 {{succeeded}} 件のスキルをソースから更新しました（{{failed}} 件失敗）",
     "update_no_permission": "ソースから更新できないスキルが選択に含まれています",
     "update_dialog_title_multi_other": "{{count}} 件のスキルをソースから更新しますか？",
     "update_dialog_desc_multi_other": "選択した {{count}} 件のスキルをソースの最新バージョンに置き換えます。ローカルの変更は失われます。",

--- a/packages/views/locales/ko/skills.json
+++ b/packages/views/locales/ko/skills.json
@@ -87,7 +87,15 @@
     "cancel": "취소",
     "add_confirm": "추가 ({{num}})",
     "adding": "추가 중...",
-    "added_multi_toast_other": "에이전트 {{count}}개에 추가했습니다"
+    "added_multi_toast_other": "에이전트 {{count}}개에 추가했습니다",
+    "update": "업데이트",
+    "update_dialog_title": "소스에서 업데이트할까요?",
+    "update_dialog_desc": "\"{{name}}\"을(를) 소스의 최신 버전으로 교체합니다. 이 스킬의 로컬 변경 사항은 사라집니다.",
+    "update_dialog_source": "소스: {{url}}",
+    "update_confirm": "업데이트",
+    "updating": "업데이트 중...",
+    "updated_toast": "{{name}}을(를) 소스에서 업데이트했습니다",
+    "update_failed_toast": "스킬 업데이트에 실패했습니다"
   },
   "toolbar": {
     "result_count_title": "일치하는 스킬 / 전체 스킬",

--- a/packages/views/locales/ko/skills.json
+++ b/packages/views/locales/ko/skills.json
@@ -96,6 +96,7 @@
     "updating": "업데이트 중...",
     "updated_toast": "{{name}}을(를) 소스에서 업데이트했습니다",
     "update_failed_toast": "스킬 업데이트에 실패했습니다",
+    "update_partial_toast": "스킬 {{total}}개 중 {{succeeded}}개를 소스에서 업데이트했습니다({{failed}}개 실패)",
     "update_no_permission": "소스에서 업데이트할 수 없는 스킬이 선택에 포함되어 있습니다",
     "update_dialog_title_multi_other": "스킬 {{count}}개를 소스에서 업데이트할까요?",
     "update_dialog_desc_multi_other": "선택한 스킬 {{count}}개를 소스의 최신 버전으로 교체합니다. 로컬 변경 사항은 사라집니다.",

--- a/packages/views/locales/ko/skills.json
+++ b/packages/views/locales/ko/skills.json
@@ -95,7 +95,11 @@
     "update_confirm": "업데이트",
     "updating": "업데이트 중...",
     "updated_toast": "{{name}}을(를) 소스에서 업데이트했습니다",
-    "update_failed_toast": "스킬 업데이트에 실패했습니다"
+    "update_failed_toast": "스킬 업데이트에 실패했습니다",
+    "update_no_permission": "소스에서 업데이트할 수 없는 스킬이 선택에 포함되어 있습니다",
+    "update_dialog_title_multi_other": "스킬 {{count}}개를 소스에서 업데이트할까요?",
+    "update_dialog_desc_multi_other": "선택한 스킬 {{count}}개를 소스의 최신 버전으로 교체합니다. 로컬 변경 사항은 사라집니다.",
+    "updated_multi_toast_other": "스킬 {{count}}개를 소스에서 업데이트했습니다"
   },
   "toolbar": {
     "result_count_title": "일치하는 스킬 / 전체 스킬",

--- a/packages/views/locales/zh-Hans/skills.json
+++ b/packages/views/locales/zh-Hans/skills.json
@@ -95,7 +95,11 @@
     "update_confirm": "更新",
     "updating": "更新中...",
     "updated_toast": "已从来源更新 {{name}}",
-    "update_failed_toast": "更新 skill 失败"
+    "update_failed_toast": "更新 skill 失败",
+    "update_no_permission": "所选内容包含无法从来源更新的 skill",
+    "update_dialog_title_multi_other": "从来源更新这 {{count}} 个 skill？",
+    "update_dialog_desc_multi_other": "这会用来源的最新版本替换所选的 {{count}} 个 skill。本地修改将会丢失。",
+    "updated_multi_toast_other": "已从来源更新 {{count}} 个 skill"
   },
   "toolbar": {
     "result_count_title": "当前结果 / 全部 skill",

--- a/packages/views/locales/zh-Hans/skills.json
+++ b/packages/views/locales/zh-Hans/skills.json
@@ -96,6 +96,7 @@
     "updating": "更新中...",
     "updated_toast": "已从来源更新 {{name}}",
     "update_failed_toast": "更新 skill 失败",
+    "update_partial_toast": "已从来源更新 {{total}} 个 skill 中的 {{succeeded}} 个，{{failed}} 个失败",
     "update_no_permission": "所选内容包含无法从来源更新的 skill",
     "update_dialog_title_multi_other": "从来源更新这 {{count}} 个 skill？",
     "update_dialog_desc_multi_other": "这会用来源的最新版本替换所选的 {{count}} 个 skill。本地修改将会丢失。",

--- a/packages/views/locales/zh-Hans/skills.json
+++ b/packages/views/locales/zh-Hans/skills.json
@@ -87,7 +87,15 @@
     "cancel": "取消",
     "add_confirm": "添加（{{num}}）",
     "adding": "添加中...",
-    "added_multi_toast_other": "已添加到 {{count}} 个智能体"
+    "added_multi_toast_other": "已添加到 {{count}} 个智能体",
+    "update": "更新",
+    "update_dialog_title": "从来源更新这个 skill？",
+    "update_dialog_desc": "这会用来源的最新版本替换 \"{{name}}\"。对该 skill 的本地修改将会丢失。",
+    "update_dialog_source": "来源: {{url}}",
+    "update_confirm": "更新",
+    "updating": "更新中...",
+    "updated_toast": "已从来源更新 {{name}}",
+    "update_failed_toast": "更新 skill 失败"
   },
   "toolbar": {
     "result_count_title": "当前结果 / 全部 skill",

--- a/packages/views/skills/components/skill-list-actions.tsx
+++ b/packages/views/skills/components/skill-list-actions.tsx
@@ -510,35 +510,46 @@ export function DeleteSkillsDialog({
 }
 
 // ---------------------------------------------------------------------------
-// Update-from-source confirmation (single row; creator + URL origin only)
+// Update-from-source confirmation (single row or batch; creator + URL origin)
 // ---------------------------------------------------------------------------
 
 export function UpdateSkillDialog({
-  row,
+  rows,
   ctx,
   open,
   onOpenChange,
+  onUpdated,
 }: {
-  row: SkillRow;
+  rows: SkillRow[];
   ctx: SkillActionsContext;
   open: boolean;
   onOpenChange: (open: boolean) => void;
+  onUpdated?: () => void;
 }) {
   const { t } = useT("skills");
   const qc = useQueryClient();
   const [updating, setUpdating] = useState(false);
-  const sourceUrl = readOrigin(row.skill).source_url ?? "";
+  const single = rows.length === 1 ? rows[0] : null;
+  const count = rows.length;
+  const sourceUrl = single ? readOrigin(single.skill).source_url ?? "" : "";
 
   const handleConfirm = async () => {
     setUpdating(true);
     try {
-      await api.reimportSkill(row.skill.id);
+      for (const row of rows) {
+        await api.reimportSkill(row.skill.id);
+      }
       // Prefix key invalidates both the skills list and the skill detail; the
       // agent list carries each skill's name/description inline, so refresh it too.
       qc.invalidateQueries({ queryKey: workspaceKeys.skills(ctx.wsId) });
       qc.invalidateQueries({ queryKey: workspaceKeys.agents(ctx.wsId) });
-      toast.success(t(($) => $.actions.updated_toast, { name: row.skill.name }));
+      toast.success(
+        single
+          ? t(($) => $.actions.updated_toast, { name: single.skill.name })
+          : t(($) => $.actions.updated_multi_toast, { count }),
+      );
       onOpenChange(false);
+      onUpdated?.();
     } catch (e) {
       toast.error(
         e instanceof Error && e.message
@@ -559,12 +570,18 @@ export function UpdateSkillDialog({
     >
       <DialogContent className="sm:max-w-md">
         <DialogHeader>
-          <DialogTitle>{t(($) => $.actions.update_dialog_title)}</DialogTitle>
+          <DialogTitle>
+            {single
+              ? t(($) => $.actions.update_dialog_title)
+              : t(($) => $.actions.update_dialog_title_multi, { count })}
+          </DialogTitle>
           <DialogDescription>
-            {t(($) => $.actions.update_dialog_desc, { name: row.skill.name })}
+            {single
+              ? t(($) => $.actions.update_dialog_desc, { name: single.skill.name })
+              : t(($) => $.actions.update_dialog_desc_multi, { count })}
           </DialogDescription>
         </DialogHeader>
-        {sourceUrl && (
+        {single && sourceUrl && (
           <div className="truncate rounded-md bg-muted px-3 py-2 text-caption text-muted-foreground">
             {t(($) => $.actions.update_dialog_source, { url: sourceUrl })}
           </div>
@@ -686,7 +703,7 @@ export function SkillRowActions({
       />
       {canReimport && (
         <UpdateSkillDialog
-          row={row}
+          rows={[row]}
           ctx={ctx}
           open={updateOpen}
           onOpenChange={setUpdateOpen}
@@ -717,11 +734,30 @@ export function SkillBatchToolbar({
 }) {
   const { t } = useT("skills");
   const [addOpen, setAddOpen] = useState(false);
+  const [updateOpen, setUpdateOpen] = useState(false);
   const [deleteOpen, setDeleteOpen] = useState(false);
 
   if (rows.length === 0) return null;
 
   const allDeletable = rows.every((r) => r.canEdit);
+  // Update applies only when every selected skill is editable AND URL-sourced;
+  // mixed selections (e.g. a manual skill) disable it, matching Delete's gate.
+  const allUpdatable = rows.every(
+    (r) => r.canEdit && isUpdatableOrigin(readOrigin(r.skill)),
+  );
+
+  const updateButton = (
+    <Button
+      variant="ghost"
+      size="sm"
+      disabled={!allUpdatable}
+      onClick={() => setUpdateOpen(true)}
+      className={cn(!allUpdatable && "pointer-events-none")}
+    >
+      <RefreshCw className="mr-1 size-3.5" />
+      {t(($) => $.actions.update)}
+    </Button>
+  );
 
   const deleteButton = (
     <Button
@@ -765,6 +801,19 @@ export function SkillBatchToolbar({
           {t(($) => $.actions.add_to_agent)}
         </Button>
 
+        {allUpdatable ? (
+          updateButton
+        ) : (
+          <Tooltip>
+            <TooltipTrigger
+              render={<span className="inline-flex">{updateButton}</span>}
+            />
+            <TooltipContent side="top">
+              {t(($) => $.actions.update_no_permission)}
+            </TooltipContent>
+          </Tooltip>
+        )}
+
         {allDeletable ? (
           deleteButton
         ) : (
@@ -784,6 +833,13 @@ export function SkillBatchToolbar({
         ctx={ctx}
         open={addOpen}
         onOpenChange={setAddOpen}
+      />
+      <UpdateSkillDialog
+        rows={rows}
+        ctx={ctx}
+        open={updateOpen}
+        onOpenChange={setUpdateOpen}
+        onUpdated={onClear}
       />
       <DeleteSkillsDialog
         rows={rows}

--- a/packages/views/skills/components/skill-list-actions.tsx
+++ b/packages/views/skills/components/skill-list-actions.tsx
@@ -513,6 +513,34 @@ export function DeleteSkillsDialog({
 // Update-from-source confirmation (single row or batch; creator + URL origin)
 // ---------------------------------------------------------------------------
 
+// A re-import holds a server-side upstream fetch open for up to 45s. Cap a
+// large selection instead of sending it all at once.
+const UPDATE_BATCH_CONCURRENCY = 4;
+
+// Promise.allSettled with a concurrency cap. Results keep input order.
+async function runBounded<T>(
+  items: T[],
+  fn: (item: T) => Promise<unknown>,
+  limit: number,
+): Promise<PromiseSettledResult<unknown>[]> {
+  const results: PromiseSettledResult<unknown>[] = new Array(items.length);
+  let next = 0;
+  const worker = async () => {
+    for (let index = next++; index < items.length; index = next++) {
+      const item = items[index] as T;
+      try {
+        results[index] = { status: "fulfilled", value: await fn(item) };
+      } catch (reason) {
+        results[index] = { status: "rejected", reason };
+      }
+    }
+  };
+  await Promise.all(
+    Array.from({ length: Math.min(limit, items.length) }, () => worker()),
+  );
+  return results;
+}
+
 export function UpdateSkillDialog({
   rows,
   ctx,
@@ -533,32 +561,57 @@ export function UpdateSkillDialog({
   const count = rows.length;
   const sourceUrl = single ? readOrigin(single.skill).source_url ?? "" : "";
 
+  // Each re-import overwrites its skill in its own server transaction. A
+  // failure part-way through a batch leaves the earlier skills replaced. So
+  // settle every row rather than abort on the first rejection. Aborting would
+  // skip the cache invalidation and report "nothing happened", while the
+  // finished overwrites are already committed and unrecoverable.
   const handleConfirm = async () => {
     setUpdating(true);
-    try {
-      for (const row of rows) {
-        await api.reimportSkill(row.skill.id);
-      }
+    const results = await runBounded(
+      rows,
+      (row) => api.reimportSkill(row.skill.id),
+      UPDATE_BATCH_CONCURRENCY,
+    );
+    const rejected = results.filter((r) => r.status === "rejected");
+    const failed = rejected.length;
+    const succeeded = results.length - failed;
+
+    if (succeeded > 0) {
       // Prefix key invalidates both the skills list and the skill detail; the
       // agent list carries each skill's name/description inline, so refresh it too.
       qc.invalidateQueries({ queryKey: workspaceKeys.skills(ctx.wsId) });
       qc.invalidateQueries({ queryKey: workspaceKeys.agents(ctx.wsId) });
+    }
+
+    if (failed === 0) {
       toast.success(
         single
           ? t(($) => $.actions.updated_toast, { name: single.skill.name })
           : t(($) => $.actions.updated_multi_toast, { count }),
       );
-      onOpenChange(false);
-      onUpdated?.();
-    } catch (e) {
+    } else if (succeeded === 0) {
+      const reason = (rejected[0] as PromiseRejectedResult | undefined)?.reason;
       toast.error(
-        e instanceof Error && e.message
-          ? e.message
+        reason instanceof Error && reason.message
+          ? reason.message
           : t(($) => $.actions.update_failed_toast),
       );
-    } finally {
-      setUpdating(false);
+    } else {
+      toast.warning(
+        t(($) => $.actions.update_partial_toast, {
+          succeeded,
+          failed,
+          total: count,
+        }),
+      );
     }
+
+    setUpdating(false);
+    onOpenChange(false);
+    // Clear the selection only when every row landed. On a partial failure the
+    // selection stays, so the user can see what was picked and retry.
+    if (failed === 0) onUpdated?.();
   };
 
   return (

--- a/packages/views/skills/components/skill-list-actions.tsx
+++ b/packages/views/skills/components/skill-list-actions.tsx
@@ -513,33 +513,13 @@ export function DeleteSkillsDialog({
 // Update-from-source confirmation (single row or batch; creator + URL origin)
 // ---------------------------------------------------------------------------
 
-// A re-import holds a server-side upstream fetch open for up to 45s. Cap a
-// large selection instead of sending it all at once.
+// Send a few re-imports at a time rather than the whole selection at once.
+// Each one already fans out on the server (treeDownloadConcurrency = 8 parallel
+// file downloads), so client-side concurrency multiplies: 4 skills can mean ~32
+// sockets to the upstream host. GitHub also caps unauthenticated API calls at
+// 60/hour per IP — an unbounded batch exhausts that in one click and surfaces
+// as 403s (see doGitHubAPIGet in server/internal/handler/skill.go).
 const UPDATE_BATCH_CONCURRENCY = 4;
-
-// Promise.allSettled with a concurrency cap. Results keep input order.
-async function runBounded<T>(
-  items: T[],
-  fn: (item: T) => Promise<unknown>,
-  limit: number,
-): Promise<PromiseSettledResult<unknown>[]> {
-  const results: PromiseSettledResult<unknown>[] = new Array(items.length);
-  let next = 0;
-  const worker = async () => {
-    for (let index = next++; index < items.length; index = next++) {
-      const item = items[index] as T;
-      try {
-        results[index] = { status: "fulfilled", value: await fn(item) };
-      } catch (reason) {
-        results[index] = { status: "rejected", reason };
-      }
-    }
-  };
-  await Promise.all(
-    Array.from({ length: Math.min(limit, items.length) }, () => worker()),
-  );
-  return results;
-}
 
 export function UpdateSkillDialog({
   rows,
@@ -568,11 +548,15 @@ export function UpdateSkillDialog({
   // finished overwrites are already committed and unrecoverable.
   const handleConfirm = async () => {
     setUpdating(true);
-    const results = await runBounded(
-      rows,
-      (row) => api.reimportSkill(row.skill.id),
-      UPDATE_BATCH_CONCURRENCY,
-    );
+    const results: PromiseSettledResult<unknown>[] = [];
+    for (let i = 0; i < rows.length; i += UPDATE_BATCH_CONCURRENCY) {
+      const chunk = rows.slice(i, i + UPDATE_BATCH_CONCURRENCY);
+      results.push(
+        ...(await Promise.allSettled(
+          chunk.map((row) => api.reimportSkill(row.skill.id)),
+        )),
+      );
+    }
     const rejected = results.filter((r) => r.status === "rejected");
     const failed = rejected.length;
     const succeeded = results.length - failed;

--- a/packages/views/skills/components/skill-list-actions.tsx
+++ b/packages/views/skills/components/skill-list-actions.tsx
@@ -52,7 +52,7 @@ import { ActorAvatar } from "@multica/ui/components/common/actor-avatar";
 import { cn } from "@multica/ui/lib/utils";
 import { useT } from "../../i18n";
 import { useIntentNavigate } from "../../navigation";
-import { canReimportSkill, readOrigin } from "../lib/origin";
+import { isUpdatableOrigin, readOrigin } from "../lib/origin";
 import type { SkillRow } from "./skills-page";
 
 // Shared context the row kebab and the batch toolbar both need. Assembled
@@ -619,7 +619,9 @@ export function SkillRowActions({
   const [addOpen, setAddOpen] = useState(false);
   const [updateOpen, setUpdateOpen] = useState(false);
   const [deleteOpen, setDeleteOpen] = useState(false);
-  const canReimport = canReimportSkill(row.skill, ctx.currentUserId);
+  // Anyone who can edit the skill (workspace owner/admin, or its creator) may
+  // update it from source — mirrors the server's canManageSkill authorization.
+  const canReimport = row.canEdit && isUpdatableOrigin(readOrigin(row.skill));
 
   return (
     <span

--- a/packages/views/skills/components/skill-list-actions.tsx
+++ b/packages/views/skills/components/skill-list-actions.tsx
@@ -8,6 +8,7 @@ import {
   Loader2,
   MoreHorizontal,
   Plus,
+  RefreshCw,
   Search,
   Trash2,
   X,
@@ -51,6 +52,7 @@ import { ActorAvatar } from "@multica/ui/components/common/actor-avatar";
 import { cn } from "@multica/ui/lib/utils";
 import { useT } from "../../i18n";
 import { useIntentNavigate } from "../../navigation";
+import { canReimportSkill, readOrigin } from "../lib/origin";
 import type { SkillRow } from "./skills-page";
 
 // Shared context the row kebab and the batch toolbar both need. Assembled
@@ -508,6 +510,94 @@ export function DeleteSkillsDialog({
 }
 
 // ---------------------------------------------------------------------------
+// Update-from-source confirmation (single row; creator + URL origin only)
+// ---------------------------------------------------------------------------
+
+export function UpdateSkillDialog({
+  row,
+  ctx,
+  open,
+  onOpenChange,
+}: {
+  row: SkillRow;
+  ctx: SkillActionsContext;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}) {
+  const { t } = useT("skills");
+  const qc = useQueryClient();
+  const [updating, setUpdating] = useState(false);
+  const sourceUrl = readOrigin(row.skill).source_url ?? "";
+
+  const handleConfirm = async () => {
+    setUpdating(true);
+    try {
+      await api.reimportSkill(row.skill.id);
+      // Prefix key invalidates both the skills list and the skill detail; the
+      // agent list carries each skill's name/description inline, so refresh it too.
+      qc.invalidateQueries({ queryKey: workspaceKeys.skills(ctx.wsId) });
+      qc.invalidateQueries({ queryKey: workspaceKeys.agents(ctx.wsId) });
+      toast.success(t(($) => $.actions.updated_toast, { name: row.skill.name }));
+      onOpenChange(false);
+    } catch (e) {
+      toast.error(
+        e instanceof Error && e.message
+          ? e.message
+          : t(($) => $.actions.update_failed_toast),
+      );
+    } finally {
+      setUpdating(false);
+    }
+  };
+
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={(v) => {
+        if (!updating) onOpenChange(v);
+      }}
+    >
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle>{t(($) => $.actions.update_dialog_title)}</DialogTitle>
+          <DialogDescription>
+            {t(($) => $.actions.update_dialog_desc, { name: row.skill.name })}
+          </DialogDescription>
+        </DialogHeader>
+        {sourceUrl && (
+          <div className="truncate rounded-md bg-muted px-3 py-2 text-caption text-muted-foreground">
+            {t(($) => $.actions.update_dialog_source, { url: sourceUrl })}
+          </div>
+        )}
+        <DialogFooter>
+          <Button
+            type="button"
+            variant="ghost"
+            onClick={() => onOpenChange(false)}
+            disabled={updating}
+          >
+            {t(($) => $.actions.cancel)}
+          </Button>
+          <Button type="button" onClick={handleConfirm} disabled={updating}>
+            {updating ? (
+              <>
+                <Loader2 className="h-3 w-3 animate-spin" />
+                {t(($) => $.actions.updating)}
+              </>
+            ) : (
+              <>
+                <RefreshCw className="h-3 w-3" />
+                {t(($) => $.actions.update_confirm)}
+              </>
+            )}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+// ---------------------------------------------------------------------------
 // Row kebab
 // ---------------------------------------------------------------------------
 
@@ -527,7 +617,9 @@ export function SkillRowActions({
   const paths = useWorkspacePaths();
   const intentNavigate = useIntentNavigate();
   const [addOpen, setAddOpen] = useState(false);
+  const [updateOpen, setUpdateOpen] = useState(false);
   const [deleteOpen, setDeleteOpen] = useState(false);
+  const canReimport = canReimportSkill(row.skill, ctx.currentUserId);
 
   return (
     <span
@@ -564,6 +656,12 @@ export function SkillRowActions({
             <Plus className="size-3.5" />
             {t(($) => $.actions.add_to_agent)}
           </DropdownMenuItem>
+          {canReimport && (
+            <DropdownMenuItem onClick={() => setUpdateOpen(true)}>
+              <RefreshCw className="size-3.5" />
+              {t(($) => $.actions.update)}
+            </DropdownMenuItem>
+          )}
           {row.canEdit && (
             <>
               <DropdownMenuSeparator />
@@ -584,6 +682,14 @@ export function SkillRowActions({
         open={addOpen}
         onOpenChange={setAddOpen}
       />
+      {canReimport && (
+        <UpdateSkillDialog
+          row={row}
+          ctx={ctx}
+          open={updateOpen}
+          onOpenChange={setUpdateOpen}
+        />
+      )}
       <DeleteSkillsDialog
         rows={[row]}
         ctx={ctx}

--- a/packages/views/skills/components/update-skill-dialog.test.tsx
+++ b/packages/views/skills/components/update-skill-dialog.test.tsx
@@ -13,6 +13,13 @@ vi.mock("@multica/core/api", () => ({
   api: { reimportSkill: (...a: unknown[]) => mockReimportSkill(...a) },
 }));
 
+const mockToast = vi.hoisted(() => ({
+  success: vi.fn(),
+  error: vi.fn(),
+  warning: vi.fn(),
+}));
+vi.mock("sonner", () => ({ toast: mockToast }));
+
 import { UpdateSkillDialog } from "./skill-list-actions";
 
 const TEST_RESOURCES = { en: { common: enCommon, skills: enSkills } };
@@ -97,5 +104,63 @@ describe("UpdateSkillDialog", () => {
     });
     fireEvent.click(screen.getByRole("button", { name: "Update" }));
     await waitFor(() => expect(mockReimportSkill).toHaveBeenCalled());
+  });
+
+  // When the second skill fails, the server has already overwritten the first.
+  // The batch must keep going, refresh the caches, and report what landed.
+  it("reports a partial result when one skill in a batch fails", async () => {
+    mockReimportSkill.mockClear();
+    mockToast.warning.mockClear();
+    mockReimportSkill.mockImplementation((id: string) =>
+      id === "s2" ? Promise.reject(new Error("boom")) : Promise.resolve({}),
+    );
+    const qc = new QueryClient();
+    const invalidate = vi.spyOn(qc, "invalidateQueries");
+    const onOpenChange = vi.fn();
+    const onUpdated = vi.fn();
+    render(
+      <UpdateSkillDialog
+        rows={[row("s1"), row("s2")]}
+        ctx={ctx}
+        open
+        onOpenChange={onOpenChange}
+        onUpdated={onUpdated}
+      />,
+      { wrapper: wrap(qc) },
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Update" }));
+
+    await waitFor(() => expect(mockToast.warning).toHaveBeenCalled());
+    expect(mockReimportSkill).toHaveBeenCalledTimes(2);
+    expect(invalidate).toHaveBeenCalledWith({
+      queryKey: ["workspaces", "ws1", "skills"],
+    });
+    expect(mockToast.warning).toHaveBeenCalledWith(
+      "Updated 1 of 2 skills from source; 1 failed",
+    );
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+    // Selection survives a partial failure so the user can retry.
+    expect(onUpdated).not.toHaveBeenCalled();
+  });
+
+  it("does not invalidate when every skill in a batch fails", async () => {
+    mockReimportSkill.mockClear();
+    mockToast.error.mockClear();
+    mockReimportSkill.mockRejectedValue(new Error("boom"));
+    const qc = new QueryClient();
+    const invalidate = vi.spyOn(qc, "invalidateQueries");
+    render(
+      <UpdateSkillDialog
+        rows={[row("s1"), row("s2")]}
+        ctx={ctx}
+        open
+        onOpenChange={() => {}}
+      />,
+      { wrapper: wrap(qc) },
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Update" }));
+
+    await waitFor(() => expect(mockToast.error).toHaveBeenCalledWith("boom"));
+    expect(invalidate).not.toHaveBeenCalled();
   });
 });

--- a/packages/views/skills/components/update-skill-dialog.test.tsx
+++ b/packages/views/skills/components/update-skill-dialog.test.tsx
@@ -30,10 +30,10 @@ function wrap(qc: QueryClient) {
   return Wrapper;
 }
 
-function row(): SkillRow {
+function row(id = "s1"): SkillRow {
   return {
     skill: {
-      id: "s1",
+      id,
       workspace_id: "ws1",
       name: "My Skill",
       description: "",
@@ -60,7 +60,7 @@ describe("UpdateSkillDialog", () => {
     mockReimportSkill.mockResolvedValue({});
     const qc = new QueryClient();
     const invalidate = vi.spyOn(qc, "invalidateQueries");
-    render(<UpdateSkillDialog row={row()} ctx={ctx} open onOpenChange={() => {}} />, {
+    render(<UpdateSkillDialog rows={[row()]} ctx={ctx} open onOpenChange={() => {}} />, {
       wrapper: wrap(qc),
     });
     fireEvent.click(screen.getByRole("button", { name: "Update" }));
@@ -70,10 +70,29 @@ describe("UpdateSkillDialog", () => {
     });
   });
 
+  it("re-imports every selected skill on batch confirm", async () => {
+    mockReimportSkill.mockClear();
+    mockReimportSkill.mockResolvedValue({});
+    const qc = new QueryClient();
+    render(
+      <UpdateSkillDialog
+        rows={[row("s1"), row("s2")]}
+        ctx={ctx}
+        open
+        onOpenChange={() => {}}
+      />,
+      { wrapper: wrap(qc) },
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Update" }));
+    await waitFor(() => expect(mockReimportSkill).toHaveBeenCalledTimes(2));
+    expect(mockReimportSkill).toHaveBeenCalledWith("s1");
+    expect(mockReimportSkill).toHaveBeenCalledWith("s2");
+  });
+
   it("does not throw on failure (error toast path)", async () => {
     mockReimportSkill.mockRejectedValue(new Error("boom"));
     const qc = new QueryClient();
-    render(<UpdateSkillDialog row={row()} ctx={ctx} open onOpenChange={() => {}} />, {
+    render(<UpdateSkillDialog rows={[row()]} ctx={ctx} open onOpenChange={() => {}} />, {
       wrapper: wrap(qc),
     });
     fireEvent.click(screen.getByRole("button", { name: "Update" }));

--- a/packages/views/skills/components/update-skill-dialog.test.tsx
+++ b/packages/views/skills/components/update-skill-dialog.test.tsx
@@ -143,6 +143,38 @@ describe("UpdateSkillDialog", () => {
     expect(onUpdated).not.toHaveBeenCalled();
   });
 
+  // The batch is sent in chunks (UPDATE_BATCH_CONCURRENCY = 4), so 6 rows span
+  // two chunks. Nothing may be dropped at the boundary, and a failure in the
+  // first chunk must not stop the second from being sent.
+  it("processes every row across chunk boundaries despite an early failure", async () => {
+    mockReimportSkill.mockClear();
+    mockToast.warning.mockClear();
+    mockReimportSkill.mockImplementation((id: string) =>
+      id === "s2" ? Promise.reject(new Error("boom")) : Promise.resolve({}),
+    );
+    const ids = ["s1", "s2", "s3", "s4", "s5", "s6"];
+    const qc = new QueryClient();
+    render(
+      <UpdateSkillDialog
+        rows={ids.map((id) => row(id))}
+        ctx={ctx}
+        open
+        onOpenChange={() => {}}
+      />,
+      { wrapper: wrap(qc) },
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Update" }));
+
+    await waitFor(() => expect(mockToast.warning).toHaveBeenCalled());
+    expect(mockReimportSkill).toHaveBeenCalledTimes(ids.length);
+    for (const id of ids) {
+      expect(mockReimportSkill).toHaveBeenCalledWith(id);
+    }
+    expect(mockToast.warning).toHaveBeenCalledWith(
+      "Updated 5 of 6 skills from source; 1 failed",
+    );
+  });
+
   it("does not invalidate when every skill in a batch fails", async () => {
     mockReimportSkill.mockClear();
     mockToast.error.mockClear();

--- a/packages/views/skills/components/update-skill-dialog.test.tsx
+++ b/packages/views/skills/components/update-skill-dialog.test.tsx
@@ -53,15 +53,8 @@ function row(): SkillRow {
 const ctx = { wsId: "ws1", agents: [], currentUserId: "u1", isAdmin: false };
 
 describe("UpdateSkillDialog", () => {
-  // No beforeEach reset: each test below sets its own mock implementation
-  // (mockResolvedValue / mockRejectedValue) before use, so a shared
-  // beforeEach isn't needed for isolation. (mockReimportSkill.mockReset()
-  // in a beforeEach here reproducibly triggers a Vitest 4.1.0/tinyspy false
-  // "unhandled rejection" on the second test even though the component's
-  // try/catch fully handles the rejection — verified by tracing execution
-  // order with temporary logging; the catch, toast.error, and finally all
-  // run before the test completes. Isolate the two tests' mock state via
-  // explicit mockResolvedValue/mockRejectedValue instead of a reset hook.)
+  // Each test sets its own mock outcome (mockResolvedValue / mockRejectedValue),
+  // so no shared reset hook is needed.
 
   it("calls reimportSkill and invalidates skills on confirm", async () => {
     mockReimportSkill.mockResolvedValue({});

--- a/packages/views/skills/components/update-skill-dialog.test.tsx
+++ b/packages/views/skills/components/update-skill-dialog.test.tsx
@@ -1,0 +1,89 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi } from "vitest";
+import type { ReactNode } from "react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { I18nProvider } from "@multica/core/i18n/react";
+import enCommon from "../../locales/en/common.json";
+import enSkills from "../../locales/en/skills.json";
+import type { SkillRow } from "./skills-page";
+
+const mockReimportSkill = vi.hoisted(() => vi.fn());
+vi.mock("@multica/core/api", () => ({
+  api: { reimportSkill: (...a: unknown[]) => mockReimportSkill(...a) },
+}));
+
+import { UpdateSkillDialog } from "./skill-list-actions";
+
+const TEST_RESOURCES = { en: { common: enCommon, skills: enSkills } };
+
+function wrap(qc: QueryClient) {
+  function Wrapper({ children }: { children: ReactNode }) {
+    return (
+      <QueryClientProvider client={qc}>
+        <I18nProvider locale="en" resources={TEST_RESOURCES}>
+          {children}
+        </I18nProvider>
+      </QueryClientProvider>
+    );
+  }
+  return Wrapper;
+}
+
+function row(): SkillRow {
+  return {
+    skill: {
+      id: "s1",
+      workspace_id: "ws1",
+      name: "My Skill",
+      description: "",
+      config: { origin: { type: "github", source_url: "https://github.com/a/b" } },
+      created_by: "u1",
+      created_at: "",
+      updated_at: "",
+    },
+    agents: [],
+    creator: null,
+    runtime: null,
+    originType: "github",
+    canEdit: true,
+  } as SkillRow;
+}
+
+const ctx = { wsId: "ws1", agents: [], currentUserId: "u1", isAdmin: false };
+
+describe("UpdateSkillDialog", () => {
+  // No beforeEach reset: each test below sets its own mock implementation
+  // (mockResolvedValue / mockRejectedValue) before use, so a shared
+  // beforeEach isn't needed for isolation. (mockReimportSkill.mockReset()
+  // in a beforeEach here reproducibly triggers a Vitest 4.1.0/tinyspy false
+  // "unhandled rejection" on the second test even though the component's
+  // try/catch fully handles the rejection — verified by tracing execution
+  // order with temporary logging; the catch, toast.error, and finally all
+  // run before the test completes. Isolate the two tests' mock state via
+  // explicit mockResolvedValue/mockRejectedValue instead of a reset hook.)
+
+  it("calls reimportSkill and invalidates skills on confirm", async () => {
+    mockReimportSkill.mockResolvedValue({});
+    const qc = new QueryClient();
+    const invalidate = vi.spyOn(qc, "invalidateQueries");
+    render(<UpdateSkillDialog row={row()} ctx={ctx} open onOpenChange={() => {}} />, {
+      wrapper: wrap(qc),
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Update" }));
+    await waitFor(() => expect(mockReimportSkill).toHaveBeenCalledWith("s1"));
+    expect(invalidate).toHaveBeenCalledWith({
+      queryKey: ["workspaces", "ws1", "skills"],
+    });
+  });
+
+  it("does not throw on failure (error toast path)", async () => {
+    mockReimportSkill.mockRejectedValue(new Error("boom"));
+    const qc = new QueryClient();
+    render(<UpdateSkillDialog row={row()} ctx={ctx} open onOpenChange={() => {}} />, {
+      wrapper: wrap(qc),
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Update" }));
+    await waitFor(() => expect(mockReimportSkill).toHaveBeenCalled());
+  });
+});

--- a/packages/views/skills/lib/origin.test.ts
+++ b/packages/views/skills/lib/origin.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect } from "vitest";
+import type { SkillSummary } from "@multica/core/types";
+import { canReimportSkill, isUpdatableOrigin } from "./origin";
+
+function skill(config: Record<string, unknown>, createdBy: string | null): SkillSummary {
+  return {
+    id: "s1",
+    workspace_id: "ws1",
+    name: "n",
+    description: "",
+    config,
+    created_by: createdBy,
+    created_at: "",
+    updated_at: "",
+  } as SkillSummary;
+}
+
+describe("isUpdatableOrigin", () => {
+  it("is true for URL sources with a source_url", () => {
+    expect(isUpdatableOrigin({ type: "github", source_url: "https://github.com/a/b" })).toBe(true);
+    expect(isUpdatableOrigin({ type: "clawhub", source_url: "https://clawhub.ai/a/b" })).toBe(true);
+    expect(isUpdatableOrigin({ type: "skills_sh", source_url: "https://skills.sh/a" })).toBe(true);
+  });
+  it("is false without a source_url, for runtime_local, and for manual", () => {
+    expect(isUpdatableOrigin({ type: "github" })).toBe(false);
+    expect(isUpdatableOrigin({ type: "runtime_local", source_path: "/x" })).toBe(false);
+    expect(isUpdatableOrigin({ type: "manual" })).toBe(false);
+  });
+});
+
+describe("canReimportSkill", () => {
+  const origin = { origin: { type: "github", source_url: "https://github.com/a/b" } };
+  it("is true only for the creator of a URL-sourced skill", () => {
+    expect(canReimportSkill(skill(origin, "u1"), "u1")).toBe(true);
+  });
+  it("is false for a non-creator (admins must edit in-app, not re-import)", () => {
+    expect(canReimportSkill(skill(origin, "u1"), "u2")).toBe(false);
+  });
+  it("is false for a manual skill even for its creator", () => {
+    expect(canReimportSkill(skill({}, "u1"), "u1")).toBe(false);
+  });
+  it("is false when there is no current user", () => {
+    expect(canReimportSkill(skill(origin, "u1"), null)).toBe(false);
+  });
+});

--- a/packages/views/skills/lib/origin.test.ts
+++ b/packages/views/skills/lib/origin.test.ts
@@ -1,19 +1,5 @@
 import { describe, it, expect } from "vitest";
-import type { SkillSummary } from "@multica/core/types";
-import { canReimportSkill, isUpdatableOrigin } from "./origin";
-
-function skill(config: Record<string, unknown>, createdBy: string | null): SkillSummary {
-  return {
-    id: "s1",
-    workspace_id: "ws1",
-    name: "n",
-    description: "",
-    config,
-    created_by: createdBy,
-    created_at: "",
-    updated_at: "",
-  } as SkillSummary;
-}
+import { isUpdatableOrigin } from "./origin";
 
 describe("isUpdatableOrigin", () => {
   it("is true for URL sources with a source_url", () => {
@@ -25,21 +11,5 @@ describe("isUpdatableOrigin", () => {
     expect(isUpdatableOrigin({ type: "github" })).toBe(false);
     expect(isUpdatableOrigin({ type: "runtime_local", source_path: "/x" })).toBe(false);
     expect(isUpdatableOrigin({ type: "manual" })).toBe(false);
-  });
-});
-
-describe("canReimportSkill", () => {
-  const origin = { origin: { type: "github", source_url: "https://github.com/a/b" } };
-  it("is true only for the creator of a URL-sourced skill", () => {
-    expect(canReimportSkill(skill(origin, "u1"), "u1")).toBe(true);
-  });
-  it("is false for a non-creator (admins must edit in-app, not re-import)", () => {
-    expect(canReimportSkill(skill(origin, "u1"), "u2")).toBe(false);
-  });
-  it("is false for a manual skill even for its creator", () => {
-    expect(canReimportSkill(skill({}, "u1"), "u1")).toBe(false);
-  });
-  it("is false when there is no current user", () => {
-    expect(canReimportSkill(skill(origin, "u1"), null)).toBe(false);
   });
 });

--- a/packages/views/skills/lib/origin.ts
+++ b/packages/views/skills/lib/origin.ts
@@ -45,22 +45,6 @@ export function isUpdatableOrigin(origin: OriginInfo): boolean {
 }
 
 /**
- * Whether the current user may re-import (update) the skill. Creator-only,
- * mirroring the server rule (`canOverwriteSkillByLocalImport`): admins/owners
- * who did not create the skill must edit it in-app rather than re-import.
- */
-export function canReimportSkill(
-  skill: SkillSummary,
-  currentUserId: string | null,
-): boolean {
-  return (
-    isUpdatableOrigin(readOrigin(skill)) &&
-    !!currentUserId &&
-    skill.created_by === currentUserId
-  );
-}
-
-/**
  * SKILL.md is always present plus any additional attached files. Accepts a
  * `SkillSummary` because list endpoints don't return the `files` array — in
  * that case we only know the body exists, so the count falls back to 1.

--- a/packages/views/skills/lib/origin.ts
+++ b/packages/views/skills/lib/origin.ts
@@ -25,6 +25,41 @@ export function readOrigin(skill: SkillSummary): OriginInfo {
   return { type: "manual" };
 }
 
+const UPDATABLE_ORIGIN_TYPES = new Set<OriginInfo["type"]>([
+  "github",
+  "skills_sh",
+  "clawhub",
+]);
+
+/**
+ * Whether a skill's origin can be re-imported from a stored URL. True only for
+ * the URL-based sources (github / skills_sh / clawhub) that carry a re-fetchable
+ * `source_url`; runtime_local and manual skills return false.
+ */
+export function isUpdatableOrigin(origin: OriginInfo): boolean {
+  return (
+    UPDATABLE_ORIGIN_TYPES.has(origin.type) &&
+    typeof origin.source_url === "string" &&
+    origin.source_url.length > 0
+  );
+}
+
+/**
+ * Whether the current user may re-import (update) the skill. Creator-only,
+ * mirroring the server rule (`canOverwriteSkillByLocalImport`): admins/owners
+ * who did not create the skill must edit it in-app rather than re-import.
+ */
+export function canReimportSkill(
+  skill: SkillSummary,
+  currentUserId: string | null,
+): boolean {
+  return (
+    isUpdatableOrigin(readOrigin(skill)) &&
+    !!currentUserId &&
+    skill.created_by === currentUserId
+  );
+}
+
 /**
  * SKILL.md is always present plus any additional attached files. Accepts a
  * `SkillSummary` because list endpoints don't return the `files` array — in

--- a/server/cmd/server/router.go
+++ b/server/cmd/server/router.go
@@ -1591,6 +1591,7 @@ func NewRouterWithOptions(pool *pgxpool.Pool, hub *realtime.Hub, bus *events.Bus
 					r.Get("/", h.GetSkill)
 					r.Put("/", h.UpdateSkill)
 					r.Delete("/", h.DeleteSkill)
+					r.Post("/reimport", h.ReimportSkill)
 					r.Get("/labels", h.ListLabelsForSkill)
 					r.Post("/labels", h.AttachLabelToSkill)
 					r.Delete("/labels/{labelId}", h.DetachLabelFromSkill)

--- a/server/internal/handler/skill.go
+++ b/server/internal/handler/skill.go
@@ -426,6 +426,39 @@ func canOverwriteSkillByLocalImport(userID string, skill db.Skill) bool {
 	return skill.CreatedBy.Valid && uuidToString(skill.CreatedBy) == userID
 }
 
+// updatableSkillOrigin is the subset of skill.config.origin that ReimportSkill
+// needs: the source type and the re-fetchable URL. Only URL-based imports
+// (github / skills_sh / clawhub) carry a source_url; runtime_local and manual
+// skills do not, and are not updatable from a URL.
+type updatableSkillOrigin struct {
+	Type      string `json:"type"`
+	SourceURL string `json:"source_url"`
+}
+
+// parseUpdatableSkillOrigin reads config.origin and reports whether the skill
+// can be re-imported from a stored URL source. ok is false for manual skills,
+// runtime_local skills, unparseable config, or a URL source missing its
+// source_url.
+func parseUpdatableSkillOrigin(config []byte) (updatableSkillOrigin, bool) {
+	if len(config) == 0 {
+		return updatableSkillOrigin{}, false
+	}
+	var wrapper struct {
+		Origin updatableSkillOrigin `json:"origin"`
+	}
+	if err := json.Unmarshal(config, &wrapper); err != nil {
+		return updatableSkillOrigin{}, false
+	}
+	o := wrapper.Origin
+	switch o.Type {
+	case "github", "skills_sh", "clawhub":
+		if strings.TrimSpace(o.SourceURL) != "" {
+			return o, true
+		}
+	}
+	return o, false
+}
+
 func (h *Handler) UpdateSkill(w http.ResponseWriter, r *http.Request) {
 	id := chi.URLParam(r, "id")
 	skill, ok := h.loadSkillForUser(w, r, id)
@@ -2159,6 +2192,21 @@ func (h *Handler) resolveImportSkillConflict(w http.ResponseWriter, r *http.Requ
 
 // --- Import handler ---
 
+// fetchImportedSkill dispatches to the per-source fetcher for a detected import
+// source. Shared by ImportSkill (hosted-URL body) and ReimportSkill (stored
+// provenance) so both go through exactly one fetch path.
+func fetchImportedSkill(ctx context.Context, client *http.Client, source importSource, normalized string) (*importedSkill, error) {
+	switch source {
+	case sourceClawHub:
+		return fetchFromClawHub(ctx, client, normalized)
+	case sourceSkillsSh:
+		return fetchFromSkillsSh(ctx, client, normalized)
+	case sourceGitHub:
+		return fetchFromGitHub(ctx, client, normalized)
+	}
+	return nil, fmt.Errorf("unsupported import source")
+}
+
 func (h *Handler) ImportSkill(w http.ResponseWriter, r *http.Request) {
 	workspaceID := h.resolveWorkspaceID(r)
 
@@ -2211,15 +2259,7 @@ func (h *Handler) ImportSkill(w http.ResponseWriter, r *http.Request) {
 	ctx, cancel := context.WithTimeout(r.Context(), importFetchTimeout)
 	defer cancel()
 
-	var imported *importedSkill
-	switch source {
-	case sourceClawHub:
-		imported, err = fetchFromClawHub(ctx, httpClient, normalized)
-	case sourceSkillsSh:
-		imported, err = fetchFromSkillsSh(ctx, httpClient, normalized)
-	case sourceGitHub:
-		imported, err = fetchFromGitHub(ctx, httpClient, normalized)
-	}
+	imported, err := fetchImportedSkill(ctx, httpClient, source, normalized)
 	if err != nil {
 		status, msg := importFetchErrorResponse(ctx, err)
 		writeError(w, status, msg)
@@ -2227,6 +2267,87 @@ func (h *Handler) ImportSkill(w http.ResponseWriter, r *http.Request) {
 	}
 
 	h.finishSkillImport(w, r, workspaceID, workspaceUUID, creatorUUID, creatorID, strategy, structuredResult, imported)
+}
+
+// ReimportSkill re-runs a skill's original URL import in place. The source URL
+// is read server-side from the skill's stored config.origin — the client never
+// supplies it — so a caller cannot repoint the update at an arbitrary URL, and a
+// locally renamed skill still updates (we target by id, not by name collision).
+// Creator-only, mirroring canOverwriteSkillByLocalImport.
+func (h *Handler) ReimportSkill(w http.ResponseWriter, r *http.Request) {
+	id := chi.URLParam(r, "id")
+	skill, ok := h.loadSkillForUser(w, r, id)
+	if !ok {
+		return
+	}
+
+	userID, ok := requireUserID(w, r)
+	if !ok {
+		return
+	}
+	if !canOverwriteSkillByLocalImport(userID, skill) {
+		writeError(w, http.StatusForbidden, "only the skill creator can update it from its source")
+		return
+	}
+
+	origin, ok := parseUpdatableSkillOrigin(skill.Config)
+	if !ok {
+		writeError(w, http.StatusUnprocessableEntity, "this skill was not imported from an updatable source")
+		return
+	}
+
+	source, normalized, err := detectImportSource(origin.SourceURL)
+	if err != nil {
+		writeError(w, http.StatusUnprocessableEntity, "stored source is no longer valid: "+err.Error())
+		return
+	}
+
+	httpClient := &http.Client{Timeout: 30 * time.Second}
+	ctx, cancel := context.WithTimeout(r.Context(), importFetchTimeout)
+	defer cancel()
+
+	imported, err := fetchImportedSkill(ctx, httpClient, source, normalized)
+	if err != nil {
+		status, msg := importFetchErrorResponse(ctx, err)
+		writeError(w, status, msg)
+		return
+	}
+
+	// Map the fetched bundle exactly as finishSkillImport does.
+	files := make([]CreateSkillFileRequest, 0, len(imported.files))
+	for _, f := range imported.files {
+		if !validateFilePath(f.path) {
+			continue
+		}
+		files = append(files, CreateSkillFileRequest{Path: f.path, Content: f.content})
+	}
+	config := map[string]any{}
+	if imported.origin != nil {
+		config["origin"] = imported.origin
+	}
+
+	// Overwrite in place, targeting THIS skill by id. ExpectedName = the skill's
+	// current name preserves identity and satisfies the overwrite name guard.
+	resp, err := h.overwriteSkillWithFiles(r.Context(), skillOverwriteInput{
+		WorkspaceID:   skill.WorkspaceID,
+		TargetSkillID: skill.ID,
+		UserID:        userID,
+		ExpectedName:  skill.Name,
+		Description:   imported.description,
+		Content:       imported.content,
+		Config:        config,
+		Files:         files,
+	})
+	if err != nil {
+		status, reason := skillImportOverwriteFailure(err)
+		writeError(w, status, reason)
+		return
+	}
+
+	workspaceID := uuidToString(skill.WorkspaceID)
+	actorType, actorID := h.resolveActor(r, userID, workspaceID)
+	h.publish(protocol.EventSkillUpdated, workspaceID, actorType, actorID, map[string]any{"skill": resp})
+	writeJSON(w, http.StatusOK, resp)
 }
 
 // importFetchTimeout bounds the total time spent fetching a skill's files from

--- a/server/internal/handler/skill.go
+++ b/server/internal/handler/skill.go
@@ -2273,20 +2273,21 @@ func (h *Handler) ImportSkill(w http.ResponseWriter, r *http.Request) {
 // is read server-side from the skill's stored config.origin — the client never
 // supplies it — so a caller cannot repoint the update at an arbitrary URL, and a
 // locally renamed skill still updates (we target by id, not by name collision).
-// Creator-only, mirroring canOverwriteSkillByLocalImport.
+// Authorized to anyone who may edit the skill (workspace owner/admin, or the
+// creator) via canManageSkill — the same "who can edit a skill" rule the UI
+// gates the action on.
 func (h *Handler) ReimportSkill(w http.ResponseWriter, r *http.Request) {
 	id := chi.URLParam(r, "id")
-	skill, ok := h.loadSkillForUser(w, r, id)
-	if !ok {
-		return
-	}
 
 	userID, ok := requireUserID(w, r)
 	if !ok {
 		return
 	}
-	if !canOverwriteSkillByLocalImport(userID, skill) {
-		writeError(w, http.StatusForbidden, "only the skill creator can update it from its source")
+	skill, ok := h.loadSkillForUser(w, r, id)
+	if !ok {
+		return
+	}
+	if !h.canManageSkill(w, r, skill) {
 		return
 	}
 
@@ -2337,6 +2338,9 @@ func (h *Handler) ReimportSkill(w http.ResponseWriter, r *http.Request) {
 		Content:       imported.content,
 		Config:        config,
 		Files:         files,
+		// Authorized above via canManageSkill (owner/admin/creator), so exempt
+		// this write from the shared overwrite's stricter creator-only re-check.
+		AllowWorkspaceManager: true,
 	})
 	if err != nil {
 		status, reason := skillImportOverwriteFailure(err)

--- a/server/internal/handler/skill.go
+++ b/server/internal/handler/skill.go
@@ -2118,6 +2118,8 @@ func skillImportOverwriteFailure(err error) (int, string) {
 		return http.StatusForbidden, "only the skill creator can overwrite this skill"
 	case errors.Is(err, errSkillOverwriteNameMismatch):
 		return http.StatusConflict, "target skill name no longer matches the imported skill"
+	case errors.Is(err, errSkillOverwriteStale):
+		return http.StatusConflict, "this skill was edited while the update was running; review the changes and try again"
 	default:
 		return http.StatusInternalServerError, "failed to overwrite skill: " + err.Error()
 	}
@@ -2338,9 +2340,13 @@ func (h *Handler) ReimportSkill(w http.ResponseWriter, r *http.Request) {
 		Content:       imported.content,
 		Config:        config,
 		Files:         files,
-		// Authorized above via canManageSkill (owner/admin/creator), so exempt
-		// this write from the shared overwrite's stricter creator-only re-check.
-		AllowWorkspaceManager: true,
+		// canManageSkill above is only the early reject. The write tx applies the
+		// same owner/admin/creator rule to membership it reads itself, because
+		// the fetch in between can run for importFetchTimeout.
+		Authz: overwriteAuthzCreatorOrManager,
+		// Same window, second hazard: an edit made while the fetch runs would be
+		// replaced without warning. Return 409 instead, so the user re-confirms.
+		ExpectedUpdatedAt: skill.UpdatedAt,
 	})
 	if err != nil {
 		status, reason := skillImportOverwriteFailure(err)

--- a/server/internal/handler/skill_create.go
+++ b/server/internal/handler/skill_create.go
@@ -116,6 +116,12 @@ type skillOverwriteInput struct {
 	Content      string
 	Config       any
 	Files        []CreateSkillFileRequest
+	// AllowWorkspaceManager lets a workspace owner/admin who is not the skill's
+	// creator overwrite it. The reimport path sets this because ReimportSkill
+	// already authorized the caller via canManageSkill (owner/admin/creator);
+	// the import-conflict overwrite path leaves it false to keep its stricter
+	// creator-only rule (see canOverwriteSkillByLocalImport).
+	AllowWorkspaceManager bool
 }
 
 // overwriteSkillWithFiles re-imports a bundle onto an existing skill in a single
@@ -157,7 +163,7 @@ func (h *Handler) overwriteSkillWithFiles(ctx context.Context, input skillOverwr
 		}
 		return SkillWithFilesResponse{}, err
 	}
-	if !canOverwriteSkillByLocalImport(input.UserID, existing) {
+	if !input.AllowWorkspaceManager && !canOverwriteSkillByLocalImport(input.UserID, existing) {
 		return SkillWithFilesResponse{}, errSkillOverwriteForbidden
 	}
 	// The overwrite is keyed on target_skill_id, but the conflict the user

--- a/server/internal/handler/skill_create.go
+++ b/server/internal/handler/skill_create.go
@@ -8,6 +8,7 @@ import (
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgtype"
 	skillpkg "github.com/multica-ai/multica/server/internal/skill"
+	"github.com/multica-ai/multica/server/internal/util"
 	db "github.com/multica-ai/multica/server/pkg/db/generated"
 )
 
@@ -101,12 +102,31 @@ var (
 	errSkillOverwriteNotFound     = errors.New("target skill not found")
 	errSkillOverwriteForbidden    = errors.New("not permitted to overwrite target skill")
 	errSkillOverwriteNameMismatch = errors.New("target skill name does not match the imported skill")
+	errSkillOverwriteStale        = errors.New("target skill changed since it was read")
+)
+
+// skillOverwriteAuthz names the permission rule overwriteSkillWithFiles
+// applies. It evaluates the rule inside the write transaction. Callers pass a
+// rule, not a verdict: the reimport path fetches the upstream bundle for up to
+// importFetchTimeout after its request-time check, and the caller can lose
+// access in that window.
+type skillOverwriteAuthz int
+
+const (
+	// overwriteAuthzCreatorOnly is the default. Only the creator may overwrite
+	// the skill (see canOverwriteSkillByLocalImport). Used by the local-import
+	// and import-conflict paths.
+	overwriteAuthzCreatorOnly skillOverwriteAuthz = iota
+	// overwriteAuthzCreatorOrManager matches canManageSkill. The caller must
+	// still be a workspace member, and be an owner/admin or the creator. Used
+	// by the reimport path.
+	overwriteAuthzCreatorOrManager
 )
 
 type skillOverwriteInput struct {
 	WorkspaceID   pgtype.UUID
 	TargetSkillID pgtype.UUID
-	UserID        string // re-checked against the skill creator inside the tx
+	UserID        string // re-checked against Authz inside the tx
 	// ExpectedName, when non-empty, must equal the target's current name. Guards
 	// against a client sending the wrong target_skill_id and overwriting a
 	// different skill than the one the conflict dialog showed the user. The
@@ -116,20 +136,62 @@ type skillOverwriteInput struct {
 	Content      string
 	Config       any
 	Files        []CreateSkillFileRequest
-	// AllowWorkspaceManager lets a workspace owner/admin who is not the skill's
-	// creator overwrite it. The reimport path sets this because ReimportSkill
-	// already authorized the caller via canManageSkill (owner/admin/creator);
-	// the import-conflict overwrite path leaves it false to keep its stricter
-	// creator-only rule (see canOverwriteSkillByLocalImport).
-	AllowWorkspaceManager bool
+	// Authz selects the permission rule re-evaluated inside the tx. The zero
+	// value is creator-only.
+	Authz skillOverwriteAuthz
+	// ExpectedUpdatedAt, when valid, must equal the target's current
+	// updated_at. Otherwise the overwrite fails with errSkillOverwriteStale.
+	// A caller that reads the skill, does slow work, then writes passes the
+	// value it read. An edit made in that window is then reported, not
+	// discarded. Leave it zero to skip the check.
+	ExpectedUpdatedAt pgtype.Timestamptz
 }
 
-// overwriteSkillWithFiles re-imports a bundle onto an existing skill in a single
-// transaction. It re-verifies, inside that tx, that the target still exists in
-// the workspace and that UserID may overwrite it (creator-only — see
-// canOverwriteSkillByLocalImport). A target deleted or a creator change between
-// the user's confirm and this write fails cleanly via errSkillOverwriteNotFound
-// / errSkillOverwriteForbidden rather than falling back to create.
+// authorizeSkillOverwrite applies input.Authz to state read through qtx. It
+// therefore sees the membership and skill row as of the write transaction, not
+// as of the request's opening checks.
+func authorizeSkillOverwrite(ctx context.Context, qtx *db.Queries, input skillOverwriteInput, existing db.Skill) error {
+	isCreator := canOverwriteSkillByLocalImport(input.UserID, existing)
+	if input.Authz == overwriteAuthzCreatorOnly {
+		if !isCreator {
+			return errSkillOverwriteForbidden
+		}
+		return nil
+	}
+
+	userUUID, err := util.ParseUUID(input.UserID)
+	if err != nil {
+		return errSkillOverwriteForbidden
+	}
+	member, err := qtx.GetMemberByUserAndWorkspace(ctx, db.GetMemberByUserAndWorkspaceParams{
+		UserID:      userUUID,
+		WorkspaceID: input.WorkspaceID,
+	})
+	if err != nil {
+		// No membership row: the caller left or was removed since the
+		// request-time check.
+		if errors.Is(err, pgx.ErrNoRows) {
+			return errSkillOverwriteForbidden
+		}
+		return err
+	}
+	if !roleAllowed(member.Role, "owner", "admin", "member") {
+		return errSkillOverwriteForbidden
+	}
+	if !roleAllowed(member.Role, "owner", "admin") && !isCreator {
+		return errSkillOverwriteForbidden
+	}
+	return nil
+}
+
+// overwriteSkillWithFiles re-imports a bundle onto an existing skill in one
+// transaction. It locks the target row and re-checks three things in that tx:
+// the target still exists in the workspace, UserID may overwrite it under
+// input.Authz (see authorizeSkillOverwrite), and it has not changed since
+// input.ExpectedUpdatedAt. A deleted target, a creator change, a role change,
+// or a concurrent edit fails with errSkillOverwriteNotFound,
+// errSkillOverwriteForbidden or errSkillOverwriteStale. Callers must not fall
+// back to create.
 //
 // Preserved: id, created_by, created_at, name, and agent_skill bindings (the
 // row identity and the binding table are never touched). Replaced: description,
@@ -153,7 +215,10 @@ func (h *Handler) overwriteSkillWithFiles(ctx context.Context, input skillOverwr
 
 	qtx := h.Queries.WithTx(tx)
 
-	existing, err := qtx.GetSkillInWorkspace(ctx, db.GetSkillInWorkspaceParams{
+	// FOR UPDATE locks the row for the rest of the tx. The checks below
+	// (permission, name, updated_at) therefore still hold at the UPDATE. Under
+	// READ COMMITTED a plain read would let a concurrent edit commit in between.
+	existing, err := qtx.GetSkillInWorkspaceForUpdate(ctx, db.GetSkillInWorkspaceForUpdateParams{
 		ID:          input.TargetSkillID,
 		WorkspaceID: input.WorkspaceID,
 	})
@@ -163,8 +228,16 @@ func (h *Handler) overwriteSkillWithFiles(ctx context.Context, input skillOverwr
 		}
 		return SkillWithFilesResponse{}, err
 	}
-	if !input.AllowWorkspaceManager && !canOverwriteSkillByLocalImport(input.UserID, existing) {
-		return SkillWithFilesResponse{}, errSkillOverwriteForbidden
+	if err := authorizeSkillOverwrite(ctx, qtx, input, existing); err != nil {
+		return SkillWithFilesResponse{}, err
+	}
+	// Compare-and-set against the row the caller read before its slow work.
+	// UpdateSkill replaces description, content and config outright. Without
+	// this check an edit made in that window disappears with no signal. That
+	// includes a change to the source URL in config.origin.
+	if input.ExpectedUpdatedAt.Valid &&
+		!existing.UpdatedAt.Time.Equal(input.ExpectedUpdatedAt.Time) {
+		return SkillWithFilesResponse{}, errSkillOverwriteStale
 	}
 	// The overwrite is keyed on target_skill_id, but the conflict the user
 	// confirmed was a same-name collision; reject if the target's name no longer

--- a/server/internal/handler/skill_reimport_test.go
+++ b/server/internal/handler/skill_reimport_test.go
@@ -5,7 +5,9 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"sync"
 	"testing"
+	"time"
 )
 
 // insertReimportSkill seeds a skill owned by testUserID with a clawhub origin
@@ -107,6 +109,50 @@ func withMockClawHubReimport(t *testing.T, slug, displayName, body string) {
 	})
 }
 
+// withGatedMockClawHubReimport is withMockClawHubReimport with the file
+// download held open. It returns a channel that closes once the handler enters
+// the download, plus a release channel the test closes to let it finish. A test
+// can then change DB state while the upstream fetch is in flight.
+func withGatedMockClawHubReimport(t *testing.T, slug, displayName, body string) (fetching <-chan struct{}, release chan<- struct{}) {
+	t.Helper()
+	reached := make(chan struct{})
+	gate := make(chan struct{})
+	var once sync.Once
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/v1/skills/" + slug:
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"skill": map[string]any{
+					"slug":        slug,
+					"displayName": displayName,
+					"summary":     "fresh summary",
+					"tags":        map[string]string{"latest": "2.0.0"},
+				},
+			})
+		case "/api/v1/skills/" + slug + "/versions/2.0.0":
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"version": map[string]any{
+					"version": "2.0.0",
+					"files":   []map[string]any{{"path": "SKILL.md", "size": len(body)}},
+				},
+			})
+		case "/api/v1/skills/" + slug + "/file":
+			once.Do(func() { close(reached) })
+			<-gate
+			_, _ = w.Write([]byte(body))
+		default:
+			t.Errorf("unexpected ClawHub path: %s", r.URL.String())
+		}
+	}))
+	prev := clawHubAPIBase
+	clawHubAPIBase = srv.URL + "/api/v1"
+	t.Cleanup(func() {
+		clawHubAPIBase = prev
+		srv.Close()
+	})
+	return reached, gate
+}
+
 func callReimport(t *testing.T, userID, skillID string) *httptest.ResponseRecorder {
 	t.Helper()
 	w := httptest.NewRecorder()
@@ -189,6 +235,105 @@ func TestReimportSkill_NonAdminMemberForbidden(t *testing.T) {
 	w := callReimport(t, memberID, id)
 	if w.Code != http.StatusForbidden {
 		t.Fatalf("status = %d, want 403: %s", w.Code, w.Body.String())
+	}
+}
+
+// The upstream fetch runs for up to importFetchTimeout between the
+// request-time permission check and the write. A caller who loses access in
+// that window must not land the overwrite. The write tx re-reads membership,
+// so revoking it mid-fetch returns 403 and leaves the skill untouched.
+func TestReimportSkill_RoleRevokedDuringFetchForbidden(t *testing.T) {
+	if testHandler == nil || testPool == nil {
+		t.Skip("handler test DB not configured")
+	}
+	slug := "review-helper"
+	// The workspace owner created the skill. The caller is a separate admin, so
+	// only their role authorizes them.
+	id := insertReimportSkillCreatedBy(t, slug, "# Old body\n", testUserID)
+	adminID := addWorkspaceMember(t, "admin")
+	var name string
+	if err := testPool.QueryRow(context.Background(), `SELECT name FROM skill WHERE id = $1`, id).Scan(&name); err != nil {
+		t.Fatalf("read name: %v", err)
+	}
+	fetching, release := withGatedMockClawHubReimport(t, slug, name, "# Fresh body\n")
+
+	done := make(chan *httptest.ResponseRecorder, 1)
+	go func() { done <- callReimport(t, adminID, id) }()
+
+	select {
+	case <-fetching:
+	case <-time.After(10 * time.Second):
+		t.Fatal("upstream fetch never started")
+	}
+	if _, err := testPool.Exec(context.Background(),
+		`DELETE FROM member WHERE workspace_id = $1 AND user_id = $2`, testWorkspaceID, adminID); err != nil {
+		t.Fatalf("revoke membership: %v", err)
+	}
+	close(release)
+
+	var w *httptest.ResponseRecorder
+	select {
+	case w = <-done:
+	case <-time.After(10 * time.Second):
+		t.Fatal("reimport never returned")
+	}
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("status = %d, want 403 after membership revoked mid-fetch: %s", w.Code, w.Body.String())
+	}
+	var content string
+	if err := testPool.QueryRow(context.Background(), `SELECT content FROM skill WHERE id = $1`, id).Scan(&content); err != nil {
+		t.Fatalf("read content: %v", err)
+	}
+	if content != "# Old body\n" {
+		t.Fatalf("content = %q, want the original body left unchanged", content)
+	}
+}
+
+// An edit that lands while the upstream fetch is in flight must survive. The
+// write tx compares updated_at against the row the request read, so the
+// overwrite fails with 409 and the edit stays.
+func TestReimportSkill_ConcurrentEditConflicts(t *testing.T) {
+	if testHandler == nil || testPool == nil {
+		t.Skip("handler test DB not configured")
+	}
+	slug := "review-helper"
+	id := insertReimportSkill(t, slug, "# Old body\n")
+	var name string
+	if err := testPool.QueryRow(context.Background(), `SELECT name FROM skill WHERE id = $1`, id).Scan(&name); err != nil {
+		t.Fatalf("read name: %v", err)
+	}
+	fetching, release := withGatedMockClawHubReimport(t, slug, name, "# Fresh body\n")
+
+	done := make(chan *httptest.ResponseRecorder, 1)
+	go func() { done <- callReimport(t, testUserID, id) }()
+
+	select {
+	case <-fetching:
+	case <-time.After(10 * time.Second):
+		t.Fatal("upstream fetch never started")
+	}
+	// Another member edits the body without renaming the skill.
+	if _, err := testPool.Exec(context.Background(),
+		`UPDATE skill SET content = $2, updated_at = now() WHERE id = $1`, id, "# Someone else's edit\n"); err != nil {
+		t.Fatalf("concurrent edit: %v", err)
+	}
+	close(release)
+
+	var w *httptest.ResponseRecorder
+	select {
+	case w = <-done:
+	case <-time.After(10 * time.Second):
+		t.Fatal("reimport never returned")
+	}
+	if w.Code != http.StatusConflict {
+		t.Fatalf("status = %d, want 409 after a concurrent edit: %s", w.Code, w.Body.String())
+	}
+	var content string
+	if err := testPool.QueryRow(context.Background(), `SELECT content FROM skill WHERE id = $1`, id).Scan(&content); err != nil {
+		t.Fatalf("read content: %v", err)
+	}
+	if content != "# Someone else's edit\n" {
+		t.Fatalf("content = %q, want the concurrent edit preserved", content)
 	}
 }
 

--- a/server/internal/handler/skill_reimport_test.go
+++ b/server/internal/handler/skill_reimport_test.go
@@ -12,6 +12,13 @@ import (
 // pointing at the given slug, plus an outdated body, and returns its id.
 func insertReimportSkill(t *testing.T, slug, content string) string {
 	t.Helper()
+	return insertReimportSkillCreatedBy(t, slug, content, testUserID)
+}
+
+// insertReimportSkillCreatedBy is insertReimportSkill with an explicit creator,
+// so tests can seed a skill owned by someone other than the caller.
+func insertReimportSkillCreatedBy(t *testing.T, slug, content, creatorID string) string {
+	t.Helper()
 	name := "reimport-" + t.Name()
 	config := `{"origin":{"type":"clawhub","source_url":"https://clawhub.ai/acme/` + slug + `","slug":"` + slug + `"}}`
 	var id string
@@ -19,7 +26,7 @@ func insertReimportSkill(t *testing.T, slug, content string) string {
 		INSERT INTO skill (workspace_id, name, description, content, config, created_by)
 		VALUES ($1, $2, $3, $4, $5::jsonb, $6)
 		RETURNING id
-	`, testWorkspaceID, name, "old description", content, config, testUserID).Scan(&id); err != nil {
+	`, testWorkspaceID, name, "old description", content, config, creatorID).Scan(&id); err != nil {
 		t.Fatalf("insert skill: %v", err)
 	}
 	t.Cleanup(func() {
@@ -27,6 +34,41 @@ func insertReimportSkill(t *testing.T, slug, content string) string {
 		testPool.Exec(context.Background(), `DELETE FROM skill WHERE id = $1`, id)
 	})
 	return id
+}
+
+// createTestUser inserts a real user row (the dev DB enforces the created_by /
+// member user_id foreign keys) with a unique email, and returns its id.
+func createTestUser(t *testing.T) string {
+	t.Helper()
+	var userID string
+	if err := testPool.QueryRow(context.Background(), `
+		INSERT INTO "user" (name, email)
+		VALUES ($1, gen_random_uuid()::text || '@test.local')
+		RETURNING id
+	`, "reimport-test-user").Scan(&userID); err != nil {
+		t.Fatalf("insert user: %v", err)
+	}
+	t.Cleanup(func() {
+		testPool.Exec(context.Background(), `DELETE FROM "user" WHERE id = $1`, userID)
+	})
+	return userID
+}
+
+// addWorkspaceMember seeds a real user as a member of testWorkspaceID with the
+// given role and returns its user id. Used to exercise role-based authorization.
+func addWorkspaceMember(t *testing.T, role string) string {
+	t.Helper()
+	userID := createTestUser(t)
+	if _, err := testPool.Exec(context.Background(), `
+		INSERT INTO member (workspace_id, user_id, role)
+		VALUES ($1, $2, $3)
+	`, testWorkspaceID, userID, role); err != nil {
+		t.Fatalf("insert member: %v", err)
+	}
+	t.Cleanup(func() {
+		testPool.Exec(context.Background(), `DELETE FROM member WHERE workspace_id = $1 AND user_id = $2`, testWorkspaceID, userID)
+	})
+	return userID
 }
 
 // withMockClawHubReimport stands up a mock ClawHub API for the given slug and
@@ -107,13 +149,44 @@ func TestReimportSkill_OverwritesFromSource(t *testing.T) {
 	}
 }
 
-func TestReimportSkill_NonCreatorForbidden(t *testing.T) {
+// A workspace owner/admin who is NOT the skill's creator may re-import it —
+// anyone who can edit a skill can update it from its source (canManageSkill).
+func TestReimportSkill_WorkspaceOwnerNonCreatorAllowed(t *testing.T) {
 	if testHandler == nil || testPool == nil {
 		t.Skip("handler test DB not configured")
 	}
-	id := insertReimportSkill(t, "review-helper", "# Old\n")
-	// A different (non-creator) user in the same workspace.
-	w := callReimport(t, "00000000-0000-0000-0000-0000000000ff", id)
+	slug := "review-helper"
+	// Skill created by someone else; testUserID is the workspace owner.
+	otherCreator := createTestUser(t)
+	id := insertReimportSkillCreatedBy(t, slug, "# Old body\n", otherCreator)
+	var name string
+	if err := testPool.QueryRow(context.Background(), `SELECT name FROM skill WHERE id = $1`, id).Scan(&name); err != nil {
+		t.Fatalf("read name: %v", err)
+	}
+	withMockClawHubReimport(t, slug, name, "# Fresh body\n")
+
+	w := callReimport(t, testUserID, id)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200 (owner may re-import a skill they didn't create): %s", w.Code, w.Body.String())
+	}
+	var resp SkillWithFilesResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if resp.Content != "# Fresh body\n" {
+		t.Fatalf("content = %q, want fresh body", resp.Content)
+	}
+}
+
+// A plain member who is neither an admin nor the creator cannot re-import —
+// they can't edit the skill, so they can't update it from source either (403).
+func TestReimportSkill_NonAdminMemberForbidden(t *testing.T) {
+	if testHandler == nil || testPool == nil {
+		t.Skip("handler test DB not configured")
+	}
+	id := insertReimportSkill(t, "review-helper", "# Old\n") // created by testUserID
+	memberID := addWorkspaceMember(t, "member")
+	w := callReimport(t, memberID, id)
 	if w.Code != http.StatusForbidden {
 		t.Fatalf("status = %d, want 403: %s", w.Code, w.Body.String())
 	}

--- a/server/internal/handler/skill_reimport_test.go
+++ b/server/internal/handler/skill_reimport_test.go
@@ -1,0 +1,132 @@
+package handler
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// insertReimportSkill seeds a skill owned by testUserID with a clawhub origin
+// pointing at the given slug, plus an outdated body, and returns its id.
+func insertReimportSkill(t *testing.T, slug, content string) string {
+	t.Helper()
+	name := "reimport-" + t.Name()
+	config := `{"origin":{"type":"clawhub","source_url":"https://clawhub.ai/acme/` + slug + `","slug":"` + slug + `"}}`
+	var id string
+	if err := testPool.QueryRow(context.Background(), `
+		INSERT INTO skill (workspace_id, name, description, content, config, created_by)
+		VALUES ($1, $2, $3, $4, $5::jsonb, $6)
+		RETURNING id
+	`, testWorkspaceID, name, "old description", content, config, testUserID).Scan(&id); err != nil {
+		t.Fatalf("insert skill: %v", err)
+	}
+	t.Cleanup(func() {
+		testPool.Exec(context.Background(), `DELETE FROM skill_file WHERE skill_id = $1`, id)
+		testPool.Exec(context.Background(), `DELETE FROM skill WHERE id = $1`, id)
+	})
+	return id
+}
+
+// withMockClawHubReimport stands up a mock ClawHub API for the given slug and
+// points clawHubAPIBase at it for the duration of the test.
+func withMockClawHubReimport(t *testing.T, slug, displayName, body string) {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/v1/skills/" + slug:
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"skill": map[string]any{
+					"slug":        slug,
+					"displayName": displayName,
+					"summary":     "fresh summary",
+					"tags":        map[string]string{"latest": "2.0.0"},
+				},
+			})
+		case "/api/v1/skills/" + slug + "/versions/2.0.0":
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"version": map[string]any{
+					"version": "2.0.0",
+					"files":   []map[string]any{{"path": "SKILL.md", "size": len(body)}},
+				},
+			})
+		case "/api/v1/skills/" + slug + "/file":
+			_, _ = w.Write([]byte(body))
+		default:
+			t.Fatalf("unexpected ClawHub path: %s", r.URL.String())
+		}
+	}))
+	prev := clawHubAPIBase
+	clawHubAPIBase = srv.URL + "/api/v1"
+	t.Cleanup(func() {
+		clawHubAPIBase = prev
+		srv.Close()
+	})
+}
+
+func callReimport(t *testing.T, userID, skillID string) *httptest.ResponseRecorder {
+	t.Helper()
+	w := httptest.NewRecorder()
+	req := newRequestAsUser(userID, http.MethodPost, "/api/skills/"+skillID+"/reimport", nil)
+	req = withURLParam(req, "id", skillID)
+	testHandler.ReimportSkill(w, req)
+	return w
+}
+
+func TestReimportSkill_OverwritesFromSource(t *testing.T) {
+	if testHandler == nil || testPool == nil {
+		t.Skip("handler test DB not configured")
+	}
+	slug := "review-helper"
+	id := insertReimportSkill(t, slug, "# Old body\n")
+	// The overwrite guard requires the target's name to equal the imported name,
+	// so the mock's displayName must match the seeded skill name.
+	var name string
+	if err := testPool.QueryRow(context.Background(), `SELECT name FROM skill WHERE id = $1`, id).Scan(&name); err != nil {
+		t.Fatalf("read name: %v", err)
+	}
+	withMockClawHubReimport(t, slug, name, "# Fresh body\n")
+
+	w := callReimport(t, testUserID, id)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200: %s", w.Code, w.Body.String())
+	}
+	var resp SkillWithFilesResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if resp.ID != id {
+		t.Fatalf("id changed: got %s want %s", resp.ID, id)
+	}
+	if resp.Content != "# Fresh body\n" {
+		t.Fatalf("content = %q, want fresh body", resp.Content)
+	}
+	if resp.Name != name {
+		t.Fatalf("name = %q, want preserved %q", resp.Name, name)
+	}
+}
+
+func TestReimportSkill_NonCreatorForbidden(t *testing.T) {
+	if testHandler == nil || testPool == nil {
+		t.Skip("handler test DB not configured")
+	}
+	id := insertReimportSkill(t, "review-helper", "# Old\n")
+	// A different (non-creator) user in the same workspace.
+	w := callReimport(t, "00000000-0000-0000-0000-0000000000ff", id)
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("status = %d, want 403: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestReimportSkill_ManualSkillNotUpdatable(t *testing.T) {
+	if testHandler == nil || testPool == nil {
+		t.Skip("handler test DB not configured")
+	}
+	// insertHandlerTestSkill seeds config '{}' (manual, no origin), created by testUserID.
+	id := insertHandlerTestSkill(t, "manual", "# Manual\n")
+	w := callReimport(t, testUserID, id)
+	if w.Code != http.StatusUnprocessableEntity {
+		t.Fatalf("status = %d, want 422: %s", w.Code, w.Body.String())
+	}
+}

--- a/server/pkg/db/generated/skill.sql.go
+++ b/server/pkg/db/generated/skill.sql.go
@@ -196,6 +196,38 @@ func (q *Queries) GetSkillInWorkspace(ctx context.Context, arg GetSkillInWorkspa
 	return i, err
 }
 
+const getSkillInWorkspaceForUpdate = `-- name: GetSkillInWorkspaceForUpdate :one
+SELECT id, workspace_id, name, description, content, config, created_by, created_at, updated_at FROM skill
+WHERE id = $1 AND workspace_id = $2
+FOR UPDATE
+`
+
+type GetSkillInWorkspaceForUpdateParams struct {
+	ID          pgtype.UUID `json:"id"`
+	WorkspaceID pgtype.UUID `json:"workspace_id"`
+}
+
+// Row-locking read used by the overwrite path. The lock turns the caller's
+// updated_at comparison into a real compare-and-set. Without it, under READ
+// COMMITTED, a concurrent edit can commit between the read and the UPDATE, and
+// the overwrite discards it.
+func (q *Queries) GetSkillInWorkspaceForUpdate(ctx context.Context, arg GetSkillInWorkspaceForUpdateParams) (Skill, error) {
+	row := q.db.QueryRow(ctx, getSkillInWorkspaceForUpdate, arg.ID, arg.WorkspaceID)
+	var i Skill
+	err := row.Scan(
+		&i.ID,
+		&i.WorkspaceID,
+		&i.Name,
+		&i.Description,
+		&i.Content,
+		&i.Config,
+		&i.CreatedBy,
+		&i.CreatedAt,
+		&i.UpdatedAt,
+	)
+	return i, err
+}
+
 const listAgentSkillNamesByAgentIDs = `-- name: ListAgentSkillNamesByAgentIDs :many
 SELECT ask.agent_id, s.name
 FROM agent_skill ask

--- a/server/pkg/db/queries/skill.sql
+++ b/server/pkg/db/queries/skill.sql
@@ -23,6 +23,15 @@ WHERE id = $1;
 SELECT * FROM skill
 WHERE id = $1 AND workspace_id = $2;
 
+-- name: GetSkillInWorkspaceForUpdate :one
+-- Row-locking read used by the overwrite path. The lock turns the caller's
+-- updated_at comparison into a real compare-and-set. Without it, under READ
+-- COMMITTED, a concurrent edit can commit between the read and the UPDATE, and
+-- the overwrite discards it.
+SELECT * FROM skill
+WHERE id = $1 AND workspace_id = $2
+FOR UPDATE;
+
 -- name: GetSkillByWorkspaceAndName :one
 -- Used by skill import and runtime-local skill discovery to reuse a workspace
 -- skill by name rather than violating UNIQUE(workspace_id, name).


### PR DESCRIPTION
# What

This PR adds the ability to trigger an "Update" of any skill that you imported from an external source, to re-import it and pull in any updates.

The new "Update" command is within the "..." action menu.

It also supports bulk operation the same way existing Skill bulk operations do.

## UI

<img width="1255" height="480" alt="image" src="https://github.com/user-attachments/assets/bbf1d7ab-6781-4c5f-a9de-e28ca2e8cac2" />

<img width="520" height="169" alt="image" src="https://github.com/user-attachments/assets/c3bf3d26-d837-4fbb-b630-d59ba6a91c57" />

<img width="494" height="237" alt="image" src="https://github.com/user-attachments/assets/47cb147d-a1b8-4982-92f9-9788cc0e7e03" />

---

# Why

I store almost all my skills in GitHub repositories, and when I make updates to those skills, having to delete and re-create the skill, then re-assign it to agents it was assigned to, is tedious and takes unnecessary effort. 

---

# Validation

Open the skills page in the web UI, and you can update any existing imported skills.

Unit tests added.

---

# E2E Scope

- Skills page.
