### PR TITLE
fix(daemon): reclaim superseded open-issue workdirs

### DIFF
--- a/CLI_AND_DAEMON.md
+++ b/CLI_AND_DAEMON.md
@@ -183,16 +183,17 @@ Daemon behavior is configured via flags or environment variables:
 | Workspaces root | — | `MULTICA_WORKSPACES_ROOT` | `~/multica_workspaces` |
 | GC enabled | — | `MULTICA_GC_ENABLED` | `true` (set `false`/`0` to disable) |
 | GC scan interval | — | `MULTICA_GC_INTERVAL` | `2h` |
-| GC TTL (done/cancelled issues) | — | `MULTICA_GC_TTL` | `24h` |
+| GC full-cleanup TTL | — | `MULTICA_GC_TTL` | `24h` |
 | GC orphan TTL (no `.gc_meta.json`) | — | `MULTICA_GC_ORPHAN_TTL` | `72h` |
 | GC artifact TTL (open issues) | — | `MULTICA_GC_ARTIFACT_TTL` | `12h` (set `0` to disable) |
 | GC artifact patterns | — | `MULTICA_GC_ARTIFACT_PATTERNS` | `node_modules,.next,.turbo` |
 
 #### Workspace garbage collection
 
-The daemon periodically scans `MULTICA_WORKSPACES_ROOT` and reclaims disk space in three modes:
+The daemon periodically scans `MULTICA_WORKSPACES_ROOT` and reclaims disk space in four modes:
 
 - **Full task cleanup** — when an issue's status is `done` or `cancelled` and has been idle for `MULTICA_GC_TTL`, the entire task directory is removed.
+- **Superseded workdir cleanup** — when an issue remains open, a completed task directory older than `MULTICA_GC_TTL` is removed if the server confirms it is no longer a resume candidate and no non-terminal task references it. The server protects the latest healthy resume workdir for every `(agent, issue)` pair, every workdir pinned by a `deferred`, `queued`, `dispatched`, `running`, or `waiting_local_directory` task, and the exact source workdir of a non-terminal manual rerun. If the server is too old to provide this authoritative protection set, or the lookup fails, the daemon fails closed and preserves the full task directory.
 - **Orphan cleanup** — task directories with no `.gc_meta.json` (e.g. left over from a daemon crash) are removed once they exceed `MULTICA_GC_ORPHAN_TTL`.
 - **Artifact-only cleanup** — when a task has been completed for at least `MULTICA_GC_ARTIFACT_TTL` but the issue is still open, regenerable build outputs whose directory basename matches `MULTICA_GC_ARTIFACT_PATTERNS` are removed. The daemon also reclaims the exact managed path `codex-home/.sandbox-bin`; old task metadata without `completed_at` becomes eligible for this managed-only cleanup after its `.gc_meta.json` file has been idle for `MULTICA_GC_ORPHAN_TTL`. The rest of the task (source, `.git`, `output/`, `logs/`, `.gc_meta.json`, Codex auth/config/session state) is preserved so the agent can resume it.
 

--- a/server/internal/daemon/client.go
+++ b/server/internal/daemon/client.go
@@ -600,8 +600,10 @@ func (c *Client) usesLegacyWorkspaceEndpoint() bool {
 
 // IssueGCStatus holds the minimal issue info returned by the GC check endpoint.
 type IssueGCStatus struct {
-	Status    string    `json:"status"`
-	UpdatedAt time.Time `json:"updated_at"`
+	Status                 string    `json:"status"`
+	UpdatedAt              time.Time `json:"updated_at"`
+	WorkdirProtectionKnown bool      `json:"workdir_protection_known"`
+	ProtectedWorkDirs      []string  `json:"protected_work_dirs"`
 }
 
 // IssueGCCheckResult is one explicit issue result from the workspace batch
@@ -609,11 +611,13 @@ type IssueGCStatus struct {
 // outside the requested workspace, preserving the server's anti-enumeration
 // contract. Err is only populated by the legacy per-issue fallback.
 type IssueGCCheckResult struct {
-	ID        string    `json:"id"`
-	Found     bool      `json:"found"`
-	Status    string    `json:"status,omitempty"`
-	UpdatedAt time.Time `json:"updated_at,omitempty"`
-	Err       error     `json:"-"`
+	ID                     string    `json:"id"`
+	Found                  bool      `json:"found"`
+	Status                 string    `json:"status,omitempty"`
+	UpdatedAt              time.Time `json:"updated_at,omitempty"`
+	WorkdirProtectionKnown bool      `json:"workdir_protection_known,omitempty"`
+	ProtectedWorkDirs      []string  `json:"protected_work_dirs,omitempty"`
+	Err                    error     `json:"-"`
 }
 
 type issueGCBatchResponse struct {
@@ -677,10 +681,12 @@ func (c *Client) getLegacyIssueGCChecks(ctx context.Context, issueIDs []string) 
 			continue
 		}
 		results[issueID] = IssueGCCheckResult{
-			ID:        issueID,
-			Found:     true,
-			Status:    status.Status,
-			UpdatedAt: status.UpdatedAt,
+			ID:                     issueID,
+			Found:                  true,
+			Status:                 status.Status,
+			UpdatedAt:              status.UpdatedAt,
+			WorkdirProtectionKnown: status.WorkdirProtectionKnown,
+			ProtectedWorkDirs:      status.ProtectedWorkDirs,
 		}
 	}
 	return results

--- a/server/internal/daemon/config.go
+++ b/server/internal/daemon/config.go
@@ -97,7 +97,7 @@ type Config struct {
 	MaxConcurrentTasks             int                   // max tasks running in parallel (default: 20)
 	GCEnabled                      bool                  // enable periodic workspace garbage collection (default: true)
 	GCInterval                     time.Duration         // how often the GC loop runs (default: 2h)
-	GCTTL                          time.Duration         // clean dirs whose issue is done/cancelled and updated_at < now()-TTL (default: 24h)
+	GCTTL                          time.Duration         // clean stale terminal-parent dirs and superseded open-issue dirs (default: 24h)
 	GCOrphanTTL                    time.Duration         // clean orphan dirs with no meta, or dirs whose issue gc-check returns 404, once they exceed this age (default: 72h). The 404 path uses the same TTL — a scoped-down token can't instantly wipe live workspaces.
 	GCArtifactTTL                  time.Duration         // when a task has been completed for at least this long but its issue is still open, drop regenerable artifacts (default: 12h, set 0 to disable)
 	GCArtifactPatterns             []string              // basename patterns whose subtrees are removed during artifact cleanup (default: node_modules, .next, .turbo)

--- a/server/internal/daemon/gc.go
+++ b/server/internal/daemon/gc.go
@@ -14,7 +14,8 @@ import (
 )
 
 // gcLoop periodically scans local workspace directories and removes those
-// whose issue is done/cancelled and hasn't been updated within the configured TTL.
+// whose parent is terminal or whose open-issue workdir is superseded beyond
+// the configured TTL.
 func (d *Daemon) gcLoop(ctx context.Context) {
 	if !d.cfg.GCEnabled {
 		d.logger.Info("gc: disabled")
@@ -50,7 +51,7 @@ func (d *Daemon) gcLoop(ctx context.Context) {
 
 // gcStats accumulates byte counts and per-pattern hit counts for one GC cycle.
 type gcStats struct {
-	cleaned         int            // whole task dirs removed (issue done/cancelled)
+	cleaned         int            // whole task dirs removed (terminal parent or superseded issue run)
 	orphaned        int            // whole task dirs removed (no meta / unreachable issue)
 	skipped         int            // task dirs left untouched
 	artifactDirs    int            // task dirs that had at least one artifact reclaimed
@@ -271,7 +272,7 @@ type gcAction int
 
 const (
 	gcActionSkip                  gcAction = iota
-	gcActionClean                          // issue is done/cancelled and stale
+	gcActionClean                          // terminal parent or superseded issue run is stale
 	gcActionOrphan                         // no meta or unknown issue and dir is old
 	gcActionCleanArtifacts                 // task completed long enough ago; drop regenerable artifacts only
 	gcActionCleanManagedArtifacts          // preserve the task and drop exact daemon-managed artifacts only
@@ -395,10 +396,12 @@ func (d *Daemon) gcDecisionIssue(ctx context.Context, taskDir string, meta *exec
 	}
 
 	return d.gcDecisionIssueResult(taskDir, meta, IssueGCCheckResult{
-		ID:        meta.IssueID,
-		Found:     true,
-		Status:    status.Status,
-		UpdatedAt: status.UpdatedAt,
+		ID:                     meta.IssueID,
+		Found:                  true,
+		Status:                 status.Status,
+		UpdatedAt:              status.UpdatedAt,
+		WorkdirProtectionKnown: status.WorkdirProtectionKnown,
+		ProtectedWorkDirs:      status.ProtectedWorkDirs,
 	})
 }
 
@@ -415,6 +418,19 @@ func (d *Daemon) gcDecisionIssueResult(taskDir string, meta *execenv.GCMeta, res
 			"issue", meta.IssueID,
 			"status", result.Status,
 			"updated_at", result.UpdatedAt.Format(time.RFC3339),
+		)
+		return gcActionClean
+	}
+
+	if issueAllowsSupersededWorkdirGC(result.Status) && result.WorkdirProtectionKnown && !meta.CompletedAt.IsZero() &&
+		time.Since(meta.CompletedAt) > d.cfg.GCTTL &&
+		!issueWorkDirProtected(taskDir, result.ProtectedWorkDirs) {
+		d.logger.Info("gc: superseded issue workdir eligible for cleanup",
+			"dir", filepath.Base(taskDir),
+			"kind", "issue",
+			"issue", meta.IssueID,
+			"status", result.Status,
+			"completed_at", meta.CompletedAt.Format(time.RFC3339),
 		)
 		return gcActionClean
 	}
@@ -449,6 +465,25 @@ func (d *Daemon) gcDecisionIssueResult(taskDir string, meta *execenv.GCMeta, res
 	}
 
 	return gcActionSkip
+}
+
+func issueAllowsSupersededWorkdirGC(status string) bool {
+	switch status {
+	case "backlog", "todo", "in_progress", "in_review", "blocked":
+		return true
+	default:
+		return false
+	}
+}
+
+func issueWorkDirProtected(taskDir string, protectedWorkDirs []string) bool {
+	candidate := filepath.Clean(filepath.Join(taskDir, "workdir"))
+	for _, protected := range protectedWorkDirs {
+		if strings.TrimSpace(protected) != "" && filepath.Clean(protected) == candidate {
+			return true
+		}
+	}
+	return false
 }
 
 func gcMetaFileAge(taskDir string) (time.Duration, bool) {

--- a/server/internal/daemon/gc_test.go
+++ b/server/internal/daemon/gc_test.go
@@ -365,6 +365,113 @@ func TestGCWorkspace_BatchesAndDeduplicatesIssueChecks(t *testing.T) {
 	}
 }
 
+func TestGCWorkspace_ReclaimsSupersededOpenIssueWorkdirButKeepsResumeCandidate(t *testing.T) {
+	issueID := "77777777-7777-7777-7777-777777777779"
+	protectedWorkDir := ""
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/daemon/workspaces/ws-superseded/issues/gc-check", func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(map[string]any{"issues": []map[string]any{
+			{
+				"id":                       issueID,
+				"found":                    true,
+				"status":                   "in_progress",
+				"updated_at":               time.Now(),
+				"workdir_protection_known": true,
+				"protected_work_dirs":      []string{protectedWorkDir},
+			},
+		}})
+	})
+
+	d := newGCTestDaemon(t, mux)
+	wsDir := filepath.Join(d.cfg.WorkspacesRoot, "ws-superseded")
+	oldDir := createTaskDir(t, d.cfg.WorkspacesRoot, "ws-superseded", "old-run", &execenv.GCMeta{
+		IssueID: issueID, WorkspaceID: "ws-superseded", CompletedAt: time.Now().Add(-10 * 24 * time.Hour),
+	})
+	protectedDir := createTaskDir(t, d.cfg.WorkspacesRoot, "ws-superseded", "latest-run", &execenv.GCMeta{
+		IssueID: issueID, WorkspaceID: "ws-superseded", CompletedAt: time.Now().Add(-10 * 24 * time.Hour),
+	})
+	protectedWorkDir = filepath.Join(protectedDir, "workdir")
+
+	stats := &gcStats{byPattern: map[string]int{}}
+	d.gcWorkspace(context.Background(), wsDir, stats)
+
+	if _, err := os.Stat(oldDir); !os.IsNotExist(err) {
+		t.Fatalf("superseded workdir must be reclaimed, stat err=%v", err)
+	}
+	if _, err := os.Stat(protectedDir); err != nil {
+		t.Fatalf("current resume candidate must remain: %v", err)
+	}
+	if stats.cleaned != 1 || stats.skipped != 1 {
+		t.Fatalf("stats = cleaned:%d skipped:%d, want 1/1", stats.cleaned, stats.skipped)
+	}
+}
+
+func TestGCWorkspace_OpenIssueWithoutProtectionKnowledgeFailsClosed(t *testing.T) {
+	issueID := "77777777-7777-7777-7777-777777777780"
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/daemon/workspaces/ws-unknown-protection/issues/gc-check", func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(map[string]any{"issues": []map[string]any{
+			{
+				"id":         issueID,
+				"found":      true,
+				"status":     "in_progress",
+				"updated_at": time.Now(),
+			},
+		}})
+	})
+
+	d := newGCTestDaemon(t, mux)
+	wsDir := filepath.Join(d.cfg.WorkspacesRoot, "ws-unknown-protection")
+	taskDir := createTaskDir(t, d.cfg.WorkspacesRoot, "ws-unknown-protection", "old-run", &execenv.GCMeta{
+		IssueID: issueID, WorkspaceID: "ws-unknown-protection", CompletedAt: time.Now().Add(-10 * 24 * time.Hour),
+	})
+
+	stats := &gcStats{byPattern: map[string]int{}}
+	d.gcWorkspace(context.Background(), wsDir, stats)
+
+	if _, err := os.Stat(taskDir); err != nil {
+		t.Fatalf("old server without authoritative protection must preserve task dir: %v", err)
+	}
+	if stats.cleaned != 0 || stats.skipped != 1 {
+		t.Fatalf("stats = cleaned:%d skipped:%d, want 0/1", stats.cleaned, stats.skipped)
+	}
+}
+
+func TestGCWorkspace_RecentTerminalIssueDoesNotUseSupersededCleanup(t *testing.T) {
+	issueID := "77777777-7777-7777-7777-777777777781"
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/daemon/workspaces/ws-recent-terminal/issues/gc-check", func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(map[string]any{"issues": []map[string]any{
+			{
+				"id":                       issueID,
+				"found":                    true,
+				"status":                   "done",
+				"updated_at":               time.Now(),
+				"workdir_protection_known": true,
+			},
+		}})
+	})
+
+	d := newGCTestDaemon(t, mux)
+	wsDir := filepath.Join(d.cfg.WorkspacesRoot, "ws-recent-terminal")
+	taskDir := createTaskDir(t, d.cfg.WorkspacesRoot, "ws-recent-terminal", "old-run", &execenv.GCMeta{
+		IssueID: issueID, WorkspaceID: "ws-recent-terminal", CompletedAt: time.Now().Add(-10 * 24 * time.Hour),
+	})
+
+	stats := &gcStats{byPattern: map[string]int{}}
+	d.gcWorkspace(context.Background(), wsDir, stats)
+
+	if _, err := os.Stat(taskDir); err != nil {
+		t.Fatalf("recently terminal issue must retain its task dir until issue TTL: %v", err)
+	}
+	if stats.cleaned != 0 || stats.skipped != 1 {
+		t.Fatalf("stats = cleaned:%d skipped:%d, want 0/1", stats.cleaned, stats.skipped)
+	}
+}
+
 func TestGCWorkspace_OldServerFallbackIsCached(t *testing.T) {
 	issueA := "77777777-7777-7777-7777-777777777773"
 	issueB := "77777777-7777-7777-7777-777777777774"

--- a/server/internal/handler/daemon.go
+++ b/server/internal/handler/daemon.go
@@ -3973,10 +3973,12 @@ type batchIssueGCCheckRequest struct {
 }
 
 type batchIssueGCCheckItem struct {
-	ID        string     `json:"id"`
-	Found     bool       `json:"found"`
-	Status    string     `json:"status,omitempty"`
-	UpdatedAt *time.Time `json:"updated_at,omitempty"`
+	ID                     string     `json:"id"`
+	Found                  bool       `json:"found"`
+	Status                 string     `json:"status,omitempty"`
+	UpdatedAt              *time.Time `json:"updated_at,omitempty"`
+	WorkdirProtectionKnown bool       `json:"workdir_protection_known,omitempty"`
+	ProtectedWorkDirs      []string   `json:"protected_work_dirs,omitempty"`
 }
 
 // BatchIssueGCCheck returns one explicit result for every requested issue ID.
@@ -4032,6 +4034,12 @@ func (h *Handler) BatchIssueGCCheck(w http.ResponseWriter, r *http.Request) {
 			rows[uuidToString(row.ID)] = row
 		}
 	}
+	protectedWorkDirs, err := h.listIssueGCProtectedWorkDirs(r.Context(), workspaceUUID, parsedIDs)
+	if err != nil {
+		slog.Warn("list issue GC protected workdirs failed", "workspace_id", workspaceID, "count", len(parsedIDs), "error", err)
+		writeError(w, http.StatusInternalServerError, "failed to check issue workdirs")
+		return
+	}
 
 	items := make([]batchIssueGCCheckItem, 0, len(req.IssueIDs))
 	for i, issueID := range req.IssueIDs {
@@ -4041,6 +4049,8 @@ func (h *Handler) BatchIssueGCCheck(w http.ResponseWriter, r *http.Request) {
 			item.Status = row.Status
 			updatedAt := row.UpdatedAt.Time
 			item.UpdatedAt = &updatedAt
+			item.WorkdirProtectionKnown = true
+			item.ProtectedWorkDirs = protectedWorkDirs[canonicalIDs[i]]
 		}
 		items = append(items, item)
 	}
@@ -4064,10 +4074,40 @@ func (h *Handler) GetIssueGCCheck(w http.ResponseWriter, r *http.Request) {
 	if !h.requireDaemonWorkspaceAccess(w, r, uuidToString(issue.WorkspaceID)) {
 		return
 	}
+	protectedWorkDirs, err := h.listIssueGCProtectedWorkDirs(r.Context(), issue.WorkspaceID, []pgtype.UUID{issueUUID})
+	if err != nil {
+		slog.Warn("list issue GC protected workdirs failed", "issue_id", issueID, "error", err)
+		writeError(w, http.StatusInternalServerError, "failed to check issue workdirs")
+		return
+	}
 	writeJSON(w, http.StatusOK, map[string]any{
-		"status":     issue.Status,
-		"updated_at": issue.UpdatedAt.Time,
+		"status":                   issue.Status,
+		"updated_at":               issue.UpdatedAt.Time,
+		"workdir_protection_known": true,
+		"protected_work_dirs":      protectedWorkDirs[uuidToString(issueUUID)],
 	})
+}
+
+func (h *Handler) listIssueGCProtectedWorkDirs(ctx context.Context, workspaceID pgtype.UUID, issueIDs []pgtype.UUID) (map[string][]string, error) {
+	protected := make(map[string][]string, len(issueIDs))
+	if len(issueIDs) == 0 {
+		return protected, nil
+	}
+	rows, err := h.Queries.ListIssueGCProtectedWorkDirs(ctx, db.ListIssueGCProtectedWorkDirsParams{
+		WorkspaceID: workspaceID,
+		IssueIds:    issueIDs,
+	})
+	if err != nil {
+		return nil, err
+	}
+	for _, row := range rows {
+		if !row.WorkDir.Valid || strings.TrimSpace(row.WorkDir.String) == "" {
+			continue
+		}
+		issueID := uuidToString(row.IssueID)
+		protected[issueID] = append(protected[issueID], row.WorkDir.String)
+	}
+	return protected, nil
 }
 
 // GetChatSessionGCCheck returns the status and updated_at of a chat session

--- a/server/internal/handler/daemon_test.go
+++ b/server/internal/handler/daemon_test.go
@@ -1332,8 +1332,8 @@ func TestGetIssueGCCheck_WithDaemonToken_CrossWorkspace(t *testing.T) {
 		t.Skip("database not available")
 	}
 
-	// Create an issue in the test workspace. The daemon GC endpoint returns
-	// only status + updated_at, so a "done" issue exercises the typical path.
+	// Create an issue in the test workspace. A "done" issue with no task rows
+	// exercises the known-empty workdir protection response.
 	var issueID string
 	err := testPool.QueryRow(context.Background(), `
 		INSERT INTO issue (workspace_id, title, status, priority, creator_id, creator_type)
@@ -1369,8 +1369,10 @@ func TestGetIssueGCCheck_WithDaemonToken_CrossWorkspace(t *testing.T) {
 	}
 
 	var resp struct {
-		Status    string `json:"status"`
-		UpdatedAt string `json:"updated_at"`
+		Status                 string   `json:"status"`
+		UpdatedAt              string   `json:"updated_at"`
+		WorkdirProtectionKnown bool     `json:"workdir_protection_known"`
+		ProtectedWorkDirs      []string `json:"protected_work_dirs"`
 	}
 	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
 		t.Fatalf("decode response: %v", err)
@@ -1380,6 +1382,9 @@ func TestGetIssueGCCheck_WithDaemonToken_CrossWorkspace(t *testing.T) {
 	}
 	if resp.UpdatedAt == "" {
 		t.Fatal("expected updated_at to be set")
+	}
+	if !resp.WorkdirProtectionKnown || len(resp.ProtectedWorkDirs) != 0 {
+		t.Fatalf("expected authoritative empty workdir protection, got %+v", resp)
 	}
 }
 
@@ -1412,10 +1417,11 @@ func TestBatchIssueGCCheck_WithDaemonToken(t *testing.T) {
 	}
 	var resp struct {
 		Issues []struct {
-			ID        string `json:"id"`
-			Found     bool   `json:"found"`
-			Status    string `json:"status"`
-			UpdatedAt string `json:"updated_at"`
+			ID                     string `json:"id"`
+			Found                  bool   `json:"found"`
+			Status                 string `json:"status"`
+			UpdatedAt              string `json:"updated_at"`
+			WorkdirProtectionKnown bool   `json:"workdir_protection_known"`
 		} `json:"issues"`
 	}
 	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
@@ -1424,7 +1430,7 @@ func TestBatchIssueGCCheck_WithDaemonToken(t *testing.T) {
 	if len(resp.Issues) != 2 {
 		t.Fatalf("issues length = %d, want 2", len(resp.Issues))
 	}
-	if got := resp.Issues[0]; got.ID != issueID || !got.Found || got.Status != "done" || got.UpdatedAt == "" {
+	if got := resp.Issues[0]; got.ID != issueID || !got.Found || got.Status != "done" || got.UpdatedAt == "" || !got.WorkdirProtectionKnown {
 		t.Fatalf("found issue result = %+v", got)
 	}
 	if got := resp.Issues[1]; got.ID != missingID || got.Found || got.Status != "" || got.UpdatedAt != "" {
@@ -1440,6 +1446,115 @@ func TestBatchIssueGCCheck_WithDaemonToken(t *testing.T) {
 	testHandler.BatchIssueGCCheck(w, req)
 	if w.Code != http.StatusNotFound {
 		t.Fatalf("cross-workspace batch: expected 404, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestBatchIssueGCCheck_ReturnsOnlyAuthoritativeProtectedWorkDirs(t *testing.T) {
+	if testHandler == nil {
+		t.Skip("database not available")
+	}
+
+	ctx := context.Background()
+	var agentID string
+	if err := testPool.QueryRow(ctx, `
+		SELECT id FROM agent WHERE workspace_id = $1 ORDER BY created_at LIMIT 1
+	`, testWorkspaceID).Scan(&agentID); err != nil {
+		t.Fatalf("setup: resolve agent: %v", err)
+	}
+
+	var issueID string
+	issueNumber := nextWorkspaceIssueNumber(t)
+	if err := testPool.QueryRow(ctx, `
+		INSERT INTO issue (workspace_id, title, status, priority, creator_id, creator_type, number)
+		VALUES ($1, 'batch-gc-protected-workdirs', 'in_progress', 'medium', $2, 'member', $3)
+		RETURNING id
+	`, testWorkspaceID, testUserID, issueNumber).Scan(&issueID); err != nil {
+		t.Fatalf("setup: create issue: %v", err)
+	}
+	var issueWithoutWorkDirID string
+	issueWithoutWorkDirNumber := nextWorkspaceIssueNumber(t)
+	if err := testPool.QueryRow(ctx, `
+		INSERT INTO issue (workspace_id, title, status, priority, creator_id, creator_type, number)
+		VALUES ($1, 'batch-gc-newest-resume-without-workdir', 'in_progress', 'medium', $2, 'member', $3)
+		RETURNING id
+	`, testWorkspaceID, testUserID, issueWithoutWorkDirNumber).Scan(&issueWithoutWorkDirID); err != nil {
+		t.Fatalf("setup: create no-workdir issue: %v", err)
+	}
+	t.Cleanup(func() {
+		testPool.Exec(context.Background(), `DELETE FROM agent_task_queue WHERE issue_id IN ($1, $2)`, issueID, issueWithoutWorkDirID)
+		testPool.Exec(context.Background(), `DELETE FROM issue WHERE id IN ($1, $2)`, issueID, issueWithoutWorkDirID)
+	})
+
+	if _, err := testPool.Exec(ctx, `
+		INSERT INTO agent_task_queue
+			(agent_id, runtime_id, issue_id, status, priority, started_at, completed_at, session_id, work_dir, error, retired_session_id)
+		VALUES
+			($1, $2, $3, 'completed', 0, now() - interval '6 hours', now() - interval '6 hours', 'gc-fallback-session', '/tmp/gc-fallback', NULL, NULL),
+			($1, $2, $3, 'completed', 0, now() - interval '5 hours', now() - interval '5 hours', 'gc-poisoned-session', '/tmp/gc-poisoned', NULL, NULL),
+			($1, $2, $3, 'failed',    0, now() - interval '4 hours', now() - interval '4 hours', 'gc-poisoned-session', '/tmp/gc-poisoned', '400 invalid_request_error', NULL),
+			($1, $2, $3, 'completed', 0, now() - interval '3 hours', now() - interval '3 hours', 'gc-retired-session', '/tmp/gc-retired', NULL, NULL),
+			($1, $2, $3, 'running',   0, now() - interval '1 hour',  NULL,                         NULL,                 '/tmp/gc-active', NULL, 'gc-retired-session'),
+			($1, $2, $3, 'deferred',  0, NULL,                         NULL,                         NULL,                 '/tmp/gc-deferred', NULL, NULL)
+	`, agentID, testRuntimeID, issueID); err != nil {
+		t.Fatalf("setup: create resume and active tasks: %v", err)
+	}
+
+	var rerunSourceID string
+	if err := testPool.QueryRow(ctx, `
+		INSERT INTO agent_task_queue
+			(agent_id, runtime_id, issue_id, status, priority, started_at, completed_at, work_dir)
+		VALUES ($1, $2, $3, 'completed', 0, now() - interval '2 hours', now() - interval '2 hours', '/tmp/gc-rerun-source')
+		RETURNING id
+	`, agentID, testRuntimeID, issueID).Scan(&rerunSourceID); err != nil {
+		t.Fatalf("setup: create rerun source: %v", err)
+	}
+	if _, err := testPool.Exec(ctx, `
+		INSERT INTO agent_task_queue
+			(agent_id, runtime_id, issue_id, status, priority, rerun_of_task_id, force_fresh_session)
+		VALUES ($1, $2, $3, 'queued', 0, $4, true)
+	`, agentID, testRuntimeID, issueID, rerunSourceID); err != nil {
+		t.Fatalf("setup: create active rerun: %v", err)
+	}
+	if _, err := testPool.Exec(ctx, `
+		INSERT INTO agent_task_queue
+			(agent_id, runtime_id, issue_id, status, priority, started_at, completed_at, session_id, work_dir)
+		VALUES
+			($1, $2, $3, 'completed', 0, now() - interval '2 hours', now() - interval '2 hours', 'gc-older-with-workdir', '/tmp/gc-must-not-fallback'),
+			($1, $2, $3, 'completed', 0, now() - interval '1 hour',  now() - interval '1 hour',  'gc-newest-without-workdir', NULL)
+	`, agentID, testRuntimeID, issueWithoutWorkDirID); err != nil {
+		t.Fatalf("setup: create no-workdir resume tasks: %v", err)
+	}
+
+	w := httptest.NewRecorder()
+	req := newDaemonTokenRequest("POST", "/api/daemon/workspaces/"+testWorkspaceID+"/issues/gc-check", map[string]any{
+		"issue_ids": []string{issueID, issueWithoutWorkDirID},
+	}, testWorkspaceID, "legit-daemon")
+	req = withURLParam(req, "workspaceId", testWorkspaceID)
+	testHandler.BatchIssueGCCheck(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("BatchIssueGCCheck: expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var resp struct {
+		Issues []struct {
+			ID                     string   `json:"id"`
+			WorkdirProtectionKnown bool     `json:"workdir_protection_known"`
+			ProtectedWorkDirs      []string `json:"protected_work_dirs"`
+		} `json:"issues"`
+	}
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if len(resp.Issues) != 2 || resp.Issues[0].ID != issueID || !resp.Issues[0].WorkdirProtectionKnown {
+		t.Fatalf("unexpected protection response: %+v", resp.Issues)
+	}
+	got := strings.Join(resp.Issues[0].ProtectedWorkDirs, ",")
+	want := strings.Join([]string{"/tmp/gc-active", "/tmp/gc-deferred", "/tmp/gc-fallback", "/tmp/gc-rerun-source"}, ",")
+	if got != want {
+		t.Fatalf("protected_work_dirs = %q, want %q", got, want)
+	}
+	if resp.Issues[1].ID != issueWithoutWorkDirID || !resp.Issues[1].WorkdirProtectionKnown || len(resp.Issues[1].ProtectedWorkDirs) != 0 {
+		t.Fatalf("newest resumable session without workdir must not protect an older workdir: %+v", resp.Issues[1])
 	}
 }
 

--- a/server/pkg/db/generated/agent.sql.go
+++ b/server/pkg/db/generated/agent.sql.go
@@ -3883,6 +3883,135 @@ func (q *Queries) ListChatFinalizeDeferredExpired(ctx context.Context, arg ListC
 	return items, nil
 }
 
+const listIssueGCProtectedWorkDirs = `-- name: ListIssueGCProtectedWorkDirs :many
+WITH requested_tasks AS (
+    SELECT
+        atq.id,
+        atq.agent_id,
+        atq.issue_id,
+        atq.status,
+        atq.dispatched_at,
+        atq.started_at,
+        atq.completed_at,
+        atq.error,
+        atq.created_at,
+        atq.session_id,
+        atq.work_dir,
+        atq.failure_reason,
+        atq.rerun_of_task_id,
+        atq.retired_session_id
+    FROM agent_task_queue atq
+    JOIN agent a ON a.id = atq.agent_id
+    WHERE a.workspace_id = $1
+      AND atq.issue_id = ANY($2::uuid[])
+), retired_sessions AS (
+    SELECT DISTINCT r.agent_id, r.issue_id, r.retired_session_id AS session_id
+    FROM requested_tasks r
+    WHERE r.retired_session_id IS NOT NULL
+), latest_per_session AS (
+    SELECT DISTINCT ON (t.agent_id, t.issue_id, t.session_id)
+        t.agent_id,
+        t.issue_id,
+        t.session_id,
+        t.work_dir,
+        t.status,
+        t.failure_reason,
+        t.error,
+        COALESCE(t.completed_at, t.started_at, t.dispatched_at, t.created_at) AS terminal_at
+    FROM requested_tasks t
+    WHERE t.session_id IS NOT NULL
+      AND t.status IN ('completed', 'failed')
+    ORDER BY t.agent_id, t.issue_id, t.session_id,
+             COALESCE(t.completed_at, t.started_at, t.dispatched_at, t.created_at) DESC
+), resume_candidates AS (
+    SELECT DISTINCT ON (l.agent_id, l.issue_id)
+        l.issue_id,
+        l.work_dir
+    FROM latest_per_session l
+    WHERE NOT EXISTS (
+          SELECT 1
+          FROM retired_sessions r
+          WHERE r.agent_id = l.agent_id
+            AND r.issue_id = l.issue_id
+            AND r.session_id = l.session_id
+      )
+      AND (
+        l.status = 'completed'
+        OR (
+          l.status = 'failed'
+          AND COALESCE(l.failure_reason, '') NOT IN ('iteration_limit', 'agent_fallback_message', 'api_invalid_request', 'codex_semantic_inactivity', 'agent_error.context_overflow')
+          AND NOT (COALESCE(l.error, '') ILIKE '%400%' AND COALESCE(l.error, '') ILIKE '%invalid_request_error%')
+          AND NOT (COALESCE(l.error, '') ILIKE '%image dimensions exceed max allowed size%' AND COALESCE(l.error, '') ILIKE '%image.source.base64.data%')
+          AND NOT (COALESCE(l.error, '') ~* 'must not be empty|must be non-?empty|must have non-?empty|non-?empty content|cannot be empty|should not be empty'
+                   AND COALESCE(l.error, '') ~* 'role[^a-z0-9]{0,2}assistant|assistant message|message at position|messages\.[0-9]|messages\[[0-9]')
+        )
+      )
+    ORDER BY l.agent_id, l.issue_id, l.terminal_at DESC
+), active_workdirs AS (
+    SELECT t.issue_id, t.work_dir
+    FROM requested_tasks t
+    WHERE t.status IN ('deferred', 'queued', 'dispatched', 'running', 'waiting_local_directory')
+      AND t.work_dir IS NOT NULL
+), active_rerun_sources AS (
+    SELECT source.issue_id, source.work_dir
+    FROM requested_tasks active
+    JOIN agent_task_queue source ON source.id = active.rerun_of_task_id
+    WHERE active.status IN ('deferred', 'queued', 'dispatched', 'running', 'waiting_local_directory')
+      AND source.issue_id = active.issue_id
+      AND source.work_dir IS NOT NULL
+)
+SELECT DISTINCT issue_id, work_dir
+FROM (
+    SELECT issue_id, work_dir FROM resume_candidates
+    UNION ALL
+    SELECT issue_id, work_dir FROM active_workdirs
+    UNION ALL
+    SELECT issue_id, work_dir FROM active_rerun_sources
+) protected
+ORDER BY issue_id, work_dir
+`
+
+type ListIssueGCProtectedWorkDirsParams struct {
+	WorkspaceID pgtype.UUID   `json:"workspace_id"`
+	IssueIds    []pgtype.UUID `json:"issue_ids"`
+}
+
+type ListIssueGCProtectedWorkDirsRow struct {
+	IssueID pgtype.UUID `json:"issue_id"`
+	WorkDir pgtype.Text `json:"work_dir"`
+}
+
+// Returns the workdirs that daemon GC must preserve for the requested issues.
+// This is server-owned because only the server can authoritatively apply the
+// same resume rules as GetLastTaskSession. The protected set contains:
+//  1. the current healthy resume candidate for every (agent, issue) pair;
+//  2. workdirs already pinned on non-terminal tasks; and
+//  3. exact source workdirs referenced by non-terminal manual reruns.
+//
+// Keep latest_per_session and its poison filters in sync with
+// GetLastTaskSession above. Returning only the protected set lets the daemon
+// reclaim older superseded env roots without treating every terminal task on
+// an open issue as disposable.
+func (q *Queries) ListIssueGCProtectedWorkDirs(ctx context.Context, arg ListIssueGCProtectedWorkDirsParams) ([]ListIssueGCProtectedWorkDirsRow, error) {
+	rows, err := q.db.Query(ctx, listIssueGCProtectedWorkDirs, arg.WorkspaceID, arg.IssueIds)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []ListIssueGCProtectedWorkDirsRow{}
+	for rows.Next() {
+		var i ListIssueGCProtectedWorkDirsRow
+		if err := rows.Scan(&i.IssueID, &i.WorkDir); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const listPendingTasksByRuntime = `-- name: ListPendingTasksByRuntime :many
 SELECT id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id, chat_session_id, autopilot_run_id, attempt, max_attempts, parent_task_id, failure_reason, trigger_summary, force_fresh_session, is_leader_task, wait_reason, initiator_user_id, handoff_note, prepare_lease_expires_at, squad_id, runtime_mcp_overlay, escalation_for_task_id, fire_at, originator_user_id, runtime_connected_apps, coalesced_comment_ids, delivered_comment_ids, chat_input_task_id, chat_finalize_deferred_at, originator_source, delegated_from_task_id, retry_of_task_id, rerun_of_task_id, rule_version_id, trigger_evidence_kind, trigger_evidence_ref_id, accountable_user_id, session_rollout_missing, retired_session_id, quick_actions_disabled, regenerate_quick_actions_for FROM agent_task_queue
 WHERE runtime_id = $1 AND status IN ('queued', 'dispatched')

--- a/server/pkg/db/queries/agent.sql
+++ b/server/pkg/db/queries/agent.sql
@@ -815,6 +815,104 @@ WHERE session_id NOT IN (SELECT session_id FROM retired_sessions)
 ORDER BY terminal_at DESC
 LIMIT 1;
 
+-- name: ListIssueGCProtectedWorkDirs :many
+-- Returns the workdirs that daemon GC must preserve for the requested issues.
+-- This is server-owned because only the server can authoritatively apply the
+-- same resume rules as GetLastTaskSession. The protected set contains:
+--   1. the current healthy resume candidate for every (agent, issue) pair;
+--   2. workdirs already pinned on non-terminal tasks; and
+--   3. exact source workdirs referenced by non-terminal manual reruns.
+--
+-- Keep latest_per_session and its poison filters in sync with
+-- GetLastTaskSession above. Returning only the protected set lets the daemon
+-- reclaim older superseded env roots without treating every terminal task on
+-- an open issue as disposable.
+WITH requested_tasks AS (
+    SELECT
+        atq.id,
+        atq.agent_id,
+        atq.issue_id,
+        atq.status,
+        atq.dispatched_at,
+        atq.started_at,
+        atq.completed_at,
+        atq.error,
+        atq.created_at,
+        atq.session_id,
+        atq.work_dir,
+        atq.failure_reason,
+        atq.rerun_of_task_id,
+        atq.retired_session_id
+    FROM agent_task_queue atq
+    JOIN agent a ON a.id = atq.agent_id
+    WHERE a.workspace_id = sqlc.arg('workspace_id')
+      AND atq.issue_id = ANY(sqlc.arg('issue_ids')::uuid[])
+), retired_sessions AS (
+    SELECT DISTINCT r.agent_id, r.issue_id, r.retired_session_id AS session_id
+    FROM requested_tasks r
+    WHERE r.retired_session_id IS NOT NULL
+), latest_per_session AS (
+    SELECT DISTINCT ON (t.agent_id, t.issue_id, t.session_id)
+        t.agent_id,
+        t.issue_id,
+        t.session_id,
+        t.work_dir,
+        t.status,
+        t.failure_reason,
+        t.error,
+        COALESCE(t.completed_at, t.started_at, t.dispatched_at, t.created_at) AS terminal_at
+    FROM requested_tasks t
+    WHERE t.session_id IS NOT NULL
+      AND t.status IN ('completed', 'failed')
+    ORDER BY t.agent_id, t.issue_id, t.session_id,
+             COALESCE(t.completed_at, t.started_at, t.dispatched_at, t.created_at) DESC
+), resume_candidates AS (
+    SELECT DISTINCT ON (l.agent_id, l.issue_id)
+        l.issue_id,
+        l.work_dir
+    FROM latest_per_session l
+    WHERE NOT EXISTS (
+          SELECT 1
+          FROM retired_sessions r
+          WHERE r.agent_id = l.agent_id
+            AND r.issue_id = l.issue_id
+            AND r.session_id = l.session_id
+      )
+      AND (
+        l.status = 'completed'
+        OR (
+          l.status = 'failed'
+          AND COALESCE(l.failure_reason, '') NOT IN ('iteration_limit', 'agent_fallback_message', 'api_invalid_request', 'codex_semantic_inactivity', 'agent_error.context_overflow')
+          AND NOT (COALESCE(l.error, '') ILIKE '%400%' AND COALESCE(l.error, '') ILIKE '%invalid_request_error%')
+          AND NOT (COALESCE(l.error, '') ILIKE '%image dimensions exceed max allowed size%' AND COALESCE(l.error, '') ILIKE '%image.source.base64.data%')
+          AND NOT (COALESCE(l.error, '') ~* 'must not be empty|must be non-?empty|must have non-?empty|non-?empty content|cannot be empty|should not be empty'
+                   AND COALESCE(l.error, '') ~* 'role[^a-z0-9]{0,2}assistant|assistant message|message at position|messages\.[0-9]|messages\[[0-9]')
+        )
+      )
+    ORDER BY l.agent_id, l.issue_id, l.terminal_at DESC
+), active_workdirs AS (
+    SELECT t.issue_id, t.work_dir
+    FROM requested_tasks t
+    WHERE t.status IN ('deferred', 'queued', 'dispatched', 'running', 'waiting_local_directory')
+      AND t.work_dir IS NOT NULL
+), active_rerun_sources AS (
+    SELECT source.issue_id, source.work_dir
+    FROM requested_tasks active
+    JOIN agent_task_queue source ON source.id = active.rerun_of_task_id
+    WHERE active.status IN ('deferred', 'queued', 'dispatched', 'running', 'waiting_local_directory')
+      AND source.issue_id = active.issue_id
+      AND source.work_dir IS NOT NULL
+)
+SELECT DISTINCT issue_id, work_dir
+FROM (
+    SELECT issue_id, work_dir FROM resume_candidates
+    UNION ALL
+    SELECT issue_id, work_dir FROM active_workdirs
+    UNION ALL
+    SELECT issue_id, work_dir FROM active_rerun_sources
+) protected
+ORDER BY issue_id, work_dir;
+
 -- name: GetLatestTaskRolloutMissing :one
 -- Reports whether the most recent terminal task for (agent_id, issue_id)
 -- withheld its Codex session because the rollout was missing (MUL-5305). When


### PR DESCRIPTION
## What does this PR do?

Bounds daemon-host disk growth for issues that stay open across many runs.

Today GC preserves every terminal task root while its issue is open, even though only the current healthy `(agent, issue)` resume candidate and workdirs referenced by non-terminal tasks can be reused. A single long-lived issue can therefore retain hundreds of full repository copies.

This change makes the server return an authoritative protected-workdir set and lets the daemon remove completed, TTL-expired task roots that are no longer protected. The daemon fails closed when the server is old or the protection lookup fails.

Thinking path:

1. Field evidence showed GC running normally but skipping hundreds of terminal roots on open issues.
2. A sampled open issue had 152 terminal runs and one workdir per historical run, while resume uses only the latest healthy session per `(agent, issue)`.
3. Resume authority belongs on the server because it owns poisoned/retired-session filtering, active tasks, and exact manual-rerun lineage.
4. The daemon keeps deletion containment and active env-root reservations, and only adds a server-authorized superseded branch after `MULTICA_GC_TTL`.

## Related Issue

Refs #1636

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Refactor / code improvement (no behavior change)
- [x] Documentation update
- [x] Tests (adding or improving test coverage)
- [ ] CI / infrastructure

## Changes Made

- Add an additive `workdir_protection_known` / `protected_work_dirs` contract to both daemon issue-GC endpoints.
- Protect the current healthy resume workdir per `(agent, issue)`, workdirs pinned by non-terminal tasks (including deferred tasks), and exact sources of non-terminal manual reruns.
- Reclaim only TTL-expired completed roots for explicitly open issue states when their `<taskDir>/workdir` is not protected.
- Preserve rolling compatibility: new server + old daemon ignores additive fields; new daemon + old server keeps full roots.
- Keep recently done/cancelled issues on their existing issue-updated-at TTL path.
- Document the fourth workspace GC mode and deployment behavior.

No database migration is required.

## How to Test

1. `go test -race ./internal/daemon`
2. `go test -race ./internal/handler`
3. `go vet ./internal/daemon ./internal/handler`
4. `go build ./cmd/server ./cmd/multica`
5. `go test ./...`

The affected packages, race tests, vet, and builds pass. The full suite passed except the pre-existing `internal/metrics` pg_sleep assertion on this local Homebrew PostgreSQL setup: the driver returns `context deadline exceeded` instead of the test-required `*pgconn.PgError`. Temp-database backfill tests pass when the local test role has the required `CREATEDB` privilege; that privilege was removed again after verification.

## Rollout / risk

Deploy server first, then daemons. Until both sides support the protection contract, open-issue full cleanup stays disabled. Deletion remains constrained to known task env roots and is rechecked against the daemon active-root reservation immediately before mutation. `local_directory` tasks retain the existing no-full-delete override.

A manual rerun of a terminal task older than the full-cleanup TTL remains best-effort: if its superseded workdir was reclaimed before the rerun was requested, the existing claim path starts fresh.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [ ] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] If this change affects the UI, I have included before/after screenshots (not applicable)
- [x] I have updated relevant documentation to reflect my changes
- [x] If I added a new runtime / coding tool / UI tab, I synced the change to landing copy and relevant docs (not applicable)
- [x] If this PR touches Chinese product copy, I checked it against the convention (not applicable)
- [x] I have considered and documented any risks above
- [x] I will address all reviewer comments before requesting merge

## AI Disclosure

**AI tool used:** OpenAI Codex

**Prompt / approach:** Diagnosed production daemon-host disk growth from live GC logs and workspace samples, minimized the retention rule to resume-authoritative state, added red/green daemon and database-backed handler regressions, then ran package, race, vet, build, and compatibility checks.

## Screenshots (optional)

Not applicable; no UI change.
