### PR TITLE
MUL-5617: fix(storage): disable request checksum in buffered S3 Upload

### DIFF
--- a/server/internal/storage/s3.go
+++ b/server/internal/storage/s3.go
@@ -281,7 +281,9 @@ func (s *S3Storage) Upload(ctx context.Context, key string, data []byte, content
 		ContentDisposition: aws.String(ContentDisposition(contentType, filename)),
 		CacheControl:       aws.String("max-age=432000,public"),
 		StorageClass:       s.storageClass(),
-	})
+	}, func(opts *s3.Options) {
+        opts.RequestChecksumCalculation = aws.RequestChecksumCalculationWhenRequired
+    })
 	if err != nil {
 		return "", fmt.Errorf("s3 PutObject: %w", err)
 	}

--- a/server/internal/storage/s3.go
+++ b/server/internal/storage/s3.go
@@ -282,8 +282,13 @@ func (s *S3Storage) Upload(ctx context.Context, key string, data []byte, content
 		CacheControl:       aws.String("max-age=432000,public"),
 		StorageClass:       s.storageClass(),
 	}, func(opts *s3.Options) {
-        opts.RequestChecksumCalculation = aws.RequestChecksumCalculationWhenRequired
-    })
+		// Avoid the optional trailing-checksum path for the same reason
+		// UploadStream does: it uses aws-chunked framing that S3-compatible
+		// backends handle unevenly (Aliyun OSS and Tencent COS reject it
+		// outright). The seekable body here is still covered by the real
+		// SigV4 payload hash, so integrity is unaffected.
+		opts.RequestChecksumCalculation = aws.RequestChecksumCalculationWhenRequired
+	})
 	if err != nil {
 		return "", fmt.Errorf("s3 PutObject: %w", err)
 	}

--- a/server/internal/storage/s3.go
+++ b/server/internal/storage/s3.go
@@ -136,11 +136,43 @@ func parseBoolEnv(raw string) (bool, error) {
 	}
 }
 
+// awsEndpointDomains are the parent domains AWS serves S3 from. VPC, dualstack
+// and FIPS hostnames all live under them, as does the China partition.
+var awsEndpointDomains = []string{"amazonaws.com", "amazonaws.com.cn"}
+
 // usesAWSEndpoint reports whether uploads go to real AWS S3 — either the
-// default endpoint or an explicitly configured AWS one, since VPC, dualstack
-// and FIPS hostnames all live under amazonaws.com.
+// default endpoint or an explicitly configured AWS one. The match is on the
+// host label boundary, so "notamazonaws.com" and "s3.amazonaws.com.evil.net"
+// are correctly treated as third-party endpoints.
 func (s *S3Storage) usesAWSEndpoint() bool {
-	return s.endpointURL == "" || strings.Contains(s.endpointURL, "amazonaws.com")
+	if s.endpointURL == "" {
+		return true
+	}
+	host := endpointHostname(s.endpointURL)
+	for _, domain := range awsEndpointDomains {
+		if host == domain || strings.HasSuffix(host, "."+domain) {
+			return true
+		}
+	}
+	return false
+}
+
+// endpointHostname extracts the comparable hostname from a configured
+// endpoint: lowercased, without the port, and without a trailing root dot.
+// A value written without a scheme is retried as an https URL, since
+// url.Parse otherwise reads the whole thing as a path.
+func endpointHostname(endpointURL string) string {
+	parsed, err := url.Parse(endpointURL)
+	if err != nil {
+		return ""
+	}
+	if parsed.Hostname() == "" {
+		parsed, err = url.Parse("https://" + endpointURL)
+		if err != nil {
+			return ""
+		}
+	}
+	return strings.TrimSuffix(strings.ToLower(parsed.Hostname()), ".")
 }
 
 // uploadChecksumOptions returns the per-request options for the buffered

--- a/server/internal/storage/s3.go
+++ b/server/internal/storage/s3.go
@@ -136,6 +136,33 @@ func parseBoolEnv(raw string) (bool, error) {
 	}
 }
 
+// usesAWSEndpoint reports whether uploads go to real AWS S3 — either the
+// default endpoint or an explicitly configured AWS one, since VPC, dualstack
+// and FIPS hostnames all live under amazonaws.com.
+func (s *S3Storage) usesAWSEndpoint() bool {
+	return s.endpointURL == "" || strings.Contains(s.endpointURL, "amazonaws.com")
+}
+
+// uploadChecksumOptions returns the per-request options for the buffered
+// upload path. The SDK defaults RequestChecksumCalculation to WhenSupported,
+// which sends the body as aws-chunked with a CRC32 trailer; Aliyun OSS and
+// Tencent COS do not implement that encoding and reject the request outright.
+//
+// Downgrading to WhenRequired drops the trailer, but it also drops the
+// client-side checksum entirely, so it is applied only to non-AWS endpoints.
+// Real AWS S3 accepts the trailer today, and buckets carrying a default Object
+// Lock retention actually require a checksum, so those requests are left
+// exactly as the SDK built them — including any AWS_REQUEST_CHECKSUM_CALCULATION
+// the operator configured.
+func (s *S3Storage) uploadChecksumOptions() []func(*s3.Options) {
+	if s.usesAWSEndpoint() {
+		return nil
+	}
+	return []func(*s3.Options){func(opts *s3.Options) {
+		opts.RequestChecksumCalculation = aws.RequestChecksumCalculationWhenRequired
+	}}
+}
+
 // storageClass returns the appropriate S3 storage class.
 // Custom endpoints (e.g. MinIO) only support STANDARD; real AWS defaults to INTELLIGENT_TIERING.
 func (s *S3Storage) storageClass() types.StorageClass {
@@ -281,14 +308,7 @@ func (s *S3Storage) Upload(ctx context.Context, key string, data []byte, content
 		ContentDisposition: aws.String(ContentDisposition(contentType, filename)),
 		CacheControl:       aws.String("max-age=432000,public"),
 		StorageClass:       s.storageClass(),
-	}, func(opts *s3.Options) {
-		// Avoid the optional trailing-checksum path for the same reason
-		// UploadStream does: it uses aws-chunked framing that S3-compatible
-		// backends handle unevenly (Aliyun OSS and Tencent COS reject it
-		// outright). The seekable body here is still covered by the real
-		// SigV4 payload hash, so integrity is unaffected.
-		opts.RequestChecksumCalculation = aws.RequestChecksumCalculationWhenRequired
-	})
+	}, s.uploadChecksumOptions()...)
 	if err != nil {
 		return "", fmt.Errorf("s3 PutObject: %w", err)
 	}

--- a/server/internal/storage/s3_test.go
+++ b/server/internal/storage/s3_test.go
@@ -76,6 +76,102 @@ func TestS3StorageUploadStreamRejectsUnknownLength(t *testing.T) {
 	}
 }
 
+func TestS3StorageUploadPathsAvoidChecksumTrailer(t *testing.T) {
+	type observedRequest struct {
+		contentSHA256 string
+		trailer       string
+		checksumCRC32 string
+		encoding      string
+		body          string
+	}
+
+	newRecordingServer := func(t *testing.T, observed chan<- observedRequest) *httptest.Server {
+		t.Helper()
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			body, err := io.ReadAll(r.Body)
+			if err != nil {
+				t.Errorf("read request body: %v", err)
+			}
+			observed <- observedRequest{
+				contentSHA256: r.Header.Get("X-Amz-Content-Sha256"),
+				trailer:       r.Header.Get("X-Amz-Trailer"),
+				checksumCRC32: r.Header.Get("X-Amz-Checksum-Crc32"),
+				encoding:      r.Header.Get("Content-Encoding"),
+				body:          string(body),
+			}
+			w.WriteHeader(http.StatusOK)
+		}))
+		t.Cleanup(server.Close)
+		return server
+	}
+
+	newStore := func(endpoint string) *S3Storage {
+		return &S3Storage{
+			client: s3.New(s3.Options{
+				Region:       "us-east-1",
+				Credentials:  aws.NewCredentialsCache(credentials.NewStaticCredentialsProvider("AKID", "SECRET", "")),
+				BaseEndpoint: aws.String(endpoint),
+				UsePathStyle: true,
+			}),
+			bucket:       "test-bucket",
+			region:       "us-east-1",
+			endpointURL:  endpoint,
+			usePathStyle: true,
+		}
+	}
+
+	// S3-compatible backends such as Aliyun OSS and Tencent COS reject
+	// aws-chunked framing outright, so neither upload path may emit a
+	// trailing checksum.
+	assertNoTrailer := func(t *testing.T, got observedRequest, payload string) {
+		t.Helper()
+		if got.contentSHA256 == "STREAMING-UNSIGNED-PAYLOAD-TRAILER" {
+			t.Fatalf("x-amz-content-sha256 = %q, want a non-chunked value", got.contentSHA256)
+		}
+		if got.trailer != "" {
+			t.Fatalf("x-amz-trailer = %q, want empty", got.trailer)
+		}
+		if got.checksumCRC32 != "" {
+			t.Fatalf("x-amz-checksum-crc32 = %q, want empty", got.checksumCRC32)
+		}
+		if strings.Contains(got.encoding, "aws-chunked") {
+			t.Fatalf("content-encoding = %q, want no aws-chunked framing", got.encoding)
+		}
+		if got.body != payload {
+			t.Fatalf("request body = %q, want %q", got.body, payload)
+		}
+	}
+
+	t.Run("buffered upload", func(t *testing.T) {
+		observed := make(chan observedRequest, 1)
+		server := newRecordingServer(t, observed)
+		payload := "buffered payload"
+
+		if _, err := newStore(server.URL).Upload(
+			context.Background(), "uploads/media.bin", []byte(payload),
+			"application/octet-stream", "media.bin",
+		); err != nil {
+			t.Fatalf("Upload: %v", err)
+		}
+		assertNoTrailer(t, <-observed, payload)
+	})
+
+	t.Run("streaming upload", func(t *testing.T) {
+		observed := make(chan observedRequest, 1)
+		server := newRecordingServer(t, observed)
+		payload := "streamed payload"
+		nonSeekable := io.LimitReader(strings.NewReader(payload), int64(len(payload)))
+
+		if _, err := newStore(server.URL).UploadStream(
+			context.Background(), "uploads/media.bin", nonSeekable, int64(len(payload)),
+			"application/octet-stream", "media.bin",
+		); err != nil {
+			t.Fatalf("UploadStream: %v", err)
+		}
+		assertNoTrailer(t, <-observed, payload)
+	})
+}
+
 func TestS3StorageKeyFromURL_CustomEndpointPreservesNestedKey(t *testing.T) {
 	s := &S3Storage{
 		bucket:      "test-bucket",

--- a/server/internal/storage/s3_test.go
+++ b/server/internal/storage/s3_test.go
@@ -191,6 +191,43 @@ func TestS3StorageUploadPathsAvoidChecksumTrailer(t *testing.T) {
 	})
 }
 
+// usesAWSEndpoint decides whether a request keeps the SDK's checksum trailer,
+// so a wrong answer either reintroduces the OSS/COS failure or strips the
+// checksum from an AWS bucket that requires one. Both directions have to hold
+// on the host label boundary.
+func TestS3StorageUsesAWSEndpoint(t *testing.T) {
+	for _, tc := range []struct {
+		endpointURL string
+		want        bool
+	}{
+		{"", true}, // unset: the SDK resolves the default AWS endpoint
+		{"https://s3.us-east-1.amazonaws.com", true},
+		{"https://S3.US-EAST-1.AMAZONAWS.COM", true},
+		{"https://bucket.s3.us-east-1.amazonaws.com:443", true},
+		{"https://bucket.s3.amazonaws.com.", true},
+		{"https://bucket.vpce-0abc-xyz.s3.us-east-1.vpce.amazonaws.com", true},
+		{"https://s3-fips.us-gov-west-1.amazonaws.com", true},
+		{"https://s3.dualstack.us-east-1.amazonaws.com", true},
+		{"https://s3.cn-north-1.amazonaws.com.cn", true},
+		{"s3.us-east-1.amazonaws.com", true}, // scheme-less but still AWS
+
+		{"https://oss-cn-shanghai-internal.aliyuncs.com", false},
+		{"https://cos.ap-shanghai.myqcloud.com", false},
+		{"https://notamazonaws.com", false},
+		{"https://s3.amazonaws.com.example.net", false},
+		{"https://minio.internal:9000?probe=amazonaws.com", false},
+		{"https://minio.internal:9000/amazonaws.com", false},
+		{"oss-cn-shanghai-internal.aliyuncs.com", false},
+	} {
+		t.Run(tc.endpointURL, func(t *testing.T) {
+			s := &S3Storage{endpointURL: tc.endpointURL}
+			if got := s.usesAWSEndpoint(); got != tc.want {
+				t.Fatalf("usesAWSEndpoint(%q) = %v, want %v", tc.endpointURL, got, tc.want)
+			}
+		})
+	}
+}
+
 // The OSS/COS workaround costs the request its client-side checksum, so it
 // must not reach AWS: real AWS S3 accepts the aws-chunked trailer, and buckets
 // carrying a default Object Lock retention require a checksum to be present.

--- a/server/internal/storage/s3_test.go
+++ b/server/internal/storage/s3_test.go
@@ -76,65 +76,73 @@ func TestS3StorageUploadStreamRejectsUnknownLength(t *testing.T) {
 	}
 }
 
-func TestS3StorageUploadPathsAvoidChecksumTrailer(t *testing.T) {
-	type observedRequest struct {
-		contentSHA256 string
-		trailer       string
-		checksumCRC32 string
-		encoding      string
-		body          string
-	}
+type observedChecksumRequest struct {
+	contentSHA256 string
+	trailer       string
+	checksumCRC32 string
+	encoding      string
+	body          string
+}
 
-	// TLS matters: the SDK only switches to a trailing checksum when the
-	// request is HTTPS (see the IsHTTPS gate in the checksum middleware), and
-	// production talks to OSS/S3 over HTTPS. A plain HTTP server would take the
-	// header-checksum branch instead and never reproduce the trailer.
-	newRecordingServer := func(t *testing.T, observed chan<- observedRequest) *httptest.Server {
-		t.Helper()
-		server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			body, err := io.ReadAll(r.Body)
-			if err != nil {
-				t.Errorf("read request body: %v", err)
-			}
-			observed <- observedRequest{
-				contentSHA256: r.Header.Get("X-Amz-Content-Sha256"),
-				trailer:       r.Header.Get("X-Amz-Trailer"),
-				checksumCRC32: r.Header.Get("X-Amz-Checksum-Crc32"),
-				encoding:      r.Header.Get("Content-Encoding"),
-				body:          string(body),
-			}
-			w.WriteHeader(http.StatusOK)
-		}))
-		t.Cleanup(server.Close)
-		return server
-	}
-
-	newStore := func(server *httptest.Server) *S3Storage {
-		return &S3Storage{
-			client: s3.New(s3.Options{
-				Region:       "us-east-1",
-				Credentials:  aws.NewCredentialsCache(credentials.NewStaticCredentialsProvider("AKID", "SECRET", "")),
-				BaseEndpoint: aws.String(server.URL),
-				UsePathStyle: true,
-				HTTPClient:   server.Client(),
-				// NewS3StorageFromEnv builds its client through
-				// config.LoadDefaultConfig, which resolves this to
-				// WhenSupported. s3.New leaves it unset, and an unset value
-				// emits no checksum at all — so without pinning the production
-				// default here the test passes even with the fix removed.
-				RequestChecksumCalculation: aws.RequestChecksumCalculationWhenSupported,
-			}),
-			bucket:       "test-bucket",
-			region:       "us-east-1",
-			endpointURL:  server.URL,
-			usePathStyle: true,
+// newChecksumRecordingServer records the checksum-relevant wire details of a
+// single upload. TLS matters: the SDK only switches to a trailing checksum when
+// the request is HTTPS (see the IsHTTPS gate in the checksum middleware), and
+// production talks to OSS/S3 over HTTPS. A plain HTTP server would take the
+// header-checksum branch instead and never reproduce the trailer.
+func newChecksumRecordingServer(t *testing.T, observed chan<- observedChecksumRequest) *httptest.Server {
+	t.Helper()
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Errorf("read request body: %v", err)
 		}
+		observed <- observedChecksumRequest{
+			contentSHA256: r.Header.Get("X-Amz-Content-Sha256"),
+			trailer:       r.Header.Get("X-Amz-Trailer"),
+			checksumCRC32: r.Header.Get("X-Amz-Checksum-Crc32"),
+			encoding:      r.Header.Get("Content-Encoding"),
+			body:          string(body),
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(server.Close)
+	return server
+}
+
+// newChecksumTestStore points a store at the recording server. endpointURL is
+// the field Upload branches on, so pass "" to exercise the default AWS shape
+// and server.URL to exercise an S3-compatible backend.
+func newChecksumTestStore(server *httptest.Server, endpointURL string) *S3Storage {
+	return &S3Storage{
+		client: s3.New(s3.Options{
+			Region:       "us-east-1",
+			Credentials:  aws.NewCredentialsCache(credentials.NewStaticCredentialsProvider("AKID", "SECRET", "")),
+			BaseEndpoint: aws.String(server.URL),
+			UsePathStyle: true,
+			HTTPClient:   server.Client(),
+			// NewS3StorageFromEnv builds its client through
+			// config.LoadDefaultConfig, which resolves this to
+			// WhenSupported. s3.New leaves it unset, and an unset value
+			// emits no checksum at all — so without pinning the production
+			// default here the test passes even with the fix removed.
+			RequestChecksumCalculation: aws.RequestChecksumCalculationWhenSupported,
+		}),
+		bucket:       "test-bucket",
+		region:       "us-east-1",
+		endpointURL:  endpointURL,
+		usePathStyle: true,
+	}
+}
+
+func TestS3StorageUploadPathsAvoidChecksumTrailer(t *testing.T) {
+	newStore := func(server *httptest.Server) *S3Storage {
+		return newChecksumTestStore(server, server.URL)
 	}
 
 	// S3-compatible backends such as Aliyun OSS and Tencent COS reject
 	// aws-chunked framing outright, so neither upload path may emit a
 	// trailing checksum.
-	assertNoTrailer := func(t *testing.T, got observedRequest, payload string) {
+	assertNoTrailer := func(t *testing.T, got observedChecksumRequest, payload string) {
 		t.Helper()
 		if got.contentSHA256 == "STREAMING-UNSIGNED-PAYLOAD-TRAILER" {
 			t.Fatalf("x-amz-content-sha256 = %q, want a non-chunked value", got.contentSHA256)
@@ -154,8 +162,8 @@ func TestS3StorageUploadPathsAvoidChecksumTrailer(t *testing.T) {
 	}
 
 	t.Run("buffered upload", func(t *testing.T) {
-		observed := make(chan observedRequest, 1)
-		server := newRecordingServer(t, observed)
+		observed := make(chan observedChecksumRequest, 1)
+		server := newChecksumRecordingServer(t, observed)
 		payload := "buffered payload"
 
 		if _, err := newStore(server).Upload(
@@ -168,8 +176,8 @@ func TestS3StorageUploadPathsAvoidChecksumTrailer(t *testing.T) {
 	})
 
 	t.Run("streaming upload", func(t *testing.T) {
-		observed := make(chan observedRequest, 1)
-		server := newRecordingServer(t, observed)
+		observed := make(chan observedChecksumRequest, 1)
+		server := newChecksumRecordingServer(t, observed)
 		payload := "streamed payload"
 		nonSeekable := io.LimitReader(strings.NewReader(payload), int64(len(payload)))
 
@@ -181,6 +189,40 @@ func TestS3StorageUploadPathsAvoidChecksumTrailer(t *testing.T) {
 		}
 		assertNoTrailer(t, <-observed, payload)
 	})
+}
+
+// The OSS/COS workaround costs the request its client-side checksum, so it
+// must not reach AWS: real AWS S3 accepts the aws-chunked trailer, and buckets
+// carrying a default Object Lock retention require a checksum to be present.
+// The store below is shaped the way NewS3StorageFromEnv leaves it when
+// AWS_ENDPOINT_URL is unset; the client is pointed at a local TLS server only
+// so the request can be observed.
+func TestS3StorageAWSUploadKeepsChecksumTrailer(t *testing.T) {
+	for _, endpointURL := range []string{
+		"",
+		"https://s3.us-east-1.amazonaws.com",
+	} {
+		t.Run("endpoint="+endpointURL, func(t *testing.T) {
+			observed := make(chan observedChecksumRequest, 1)
+			server := newChecksumRecordingServer(t, observed)
+			payload := "buffered payload"
+
+			if _, err := newChecksumTestStore(server, endpointURL).Upload(
+				context.Background(), "uploads/media.bin", []byte(payload),
+				"application/octet-stream", "media.bin",
+			); err != nil {
+				t.Fatalf("Upload: %v", err)
+			}
+
+			got := <-observed
+			if got.contentSHA256 != "STREAMING-UNSIGNED-PAYLOAD-TRAILER" {
+				t.Fatalf("x-amz-content-sha256 = %q, want the SDK default trailer flow", got.contentSHA256)
+			}
+			if !strings.HasPrefix(got.trailer, "x-amz-checksum-") {
+				t.Fatalf("x-amz-trailer = %q, want a checksum trailer", got.trailer)
+			}
+		})
+	}
 }
 
 func TestS3StorageKeyFromURL_CustomEndpointPreservesNestedKey(t *testing.T) {

--- a/server/internal/storage/s3_test.go
+++ b/server/internal/storage/s3_test.go
@@ -85,9 +85,13 @@ func TestS3StorageUploadPathsAvoidChecksumTrailer(t *testing.T) {
 		body          string
 	}
 
+	// TLS matters: the SDK only switches to a trailing checksum when the
+	// request is HTTPS (see the IsHTTPS gate in the checksum middleware), and
+	// production talks to OSS/S3 over HTTPS. A plain HTTP server would take the
+	// header-checksum branch instead and never reproduce the trailer.
 	newRecordingServer := func(t *testing.T, observed chan<- observedRequest) *httptest.Server {
 		t.Helper()
-		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			body, err := io.ReadAll(r.Body)
 			if err != nil {
 				t.Errorf("read request body: %v", err)
@@ -105,17 +109,24 @@ func TestS3StorageUploadPathsAvoidChecksumTrailer(t *testing.T) {
 		return server
 	}
 
-	newStore := func(endpoint string) *S3Storage {
+	newStore := func(server *httptest.Server) *S3Storage {
 		return &S3Storage{
 			client: s3.New(s3.Options{
 				Region:       "us-east-1",
 				Credentials:  aws.NewCredentialsCache(credentials.NewStaticCredentialsProvider("AKID", "SECRET", "")),
-				BaseEndpoint: aws.String(endpoint),
+				BaseEndpoint: aws.String(server.URL),
 				UsePathStyle: true,
+				HTTPClient:   server.Client(),
+				// NewS3StorageFromEnv builds its client through
+				// config.LoadDefaultConfig, which resolves this to
+				// WhenSupported. s3.New leaves it unset, and an unset value
+				// emits no checksum at all — so without pinning the production
+				// default here the test passes even with the fix removed.
+				RequestChecksumCalculation: aws.RequestChecksumCalculationWhenSupported,
 			}),
 			bucket:       "test-bucket",
 			region:       "us-east-1",
-			endpointURL:  endpoint,
+			endpointURL:  server.URL,
 			usePathStyle: true,
 		}
 	}
@@ -147,7 +158,7 @@ func TestS3StorageUploadPathsAvoidChecksumTrailer(t *testing.T) {
 		server := newRecordingServer(t, observed)
 		payload := "buffered payload"
 
-		if _, err := newStore(server.URL).Upload(
+		if _, err := newStore(server).Upload(
 			context.Background(), "uploads/media.bin", []byte(payload),
 			"application/octet-stream", "media.bin",
 		); err != nil {
@@ -162,7 +173,7 @@ func TestS3StorageUploadPathsAvoidChecksumTrailer(t *testing.T) {
 		payload := "streamed payload"
 		nonSeekable := io.LimitReader(strings.NewReader(payload), int64(len(payload)))
 
-		if _, err := newStore(server.URL).UploadStream(
+		if _, err := newStore(server).UploadStream(
 			context.Background(), "uploads/media.bin", nonSeekable, int64(len(payload)),
 			"application/octet-stream", "media.bin",
 		); err != nil {


### PR DESCRIPTION
## What does this PR do?

`server/internal/storage/s3.go` has two `PutObject` call sites. `UploadStream()` disables the AWS SDK's trailing-checksum path explicitly; `Upload()` — the buffered path behind `POST /api/upload-file` — passes no options at all.

Since the early-2025 AWS SDK releases, `RequestChecksumCalculation` defaults to `WhenSupported`, so `Upload()` emits a CRC32 checksum as an `aws-chunked` trailer. Aliyun OSS and Tencent COS do not implement that encoding and reject the request with HTTP 400, which breaks every attachment upload on those backends:

```
ERR file upload failed error="s3 PutObject: operation error S3: PutObject, https response error StatusCode: 400, api error NotImplemented: Aws MultiChunkedEncoding STREAMING-UNSIGNED-PAYLOAD-TRAILER is not supported."
ERR http request method=POST path=/api/upload-file status=500
```

This PR sets `RequestChecksumCalculation` to `WhenRequired` on `Upload()`, **but only for non-AWS endpoints**. Dropping the trailer also drops the client-side checksum entirely — on TLS the request goes out as `UNSIGNED-PAYLOAD` with no `x-amz-checksum-*` header — so applying it everywhere would change requests that work today, and AWS buckets with a default Object Lock retention require a checksum to be present. `Upload()` therefore branches on the configured endpoint:

- no `AWS_ENDPOINT_URL`, or an explicit `amazonaws.com` host → untouched; the client keeps whatever the SDK resolved, including any operator-set `AWS_REQUEST_CHECKSUM_CALCULATION`.
- any other S3-compatible endpoint → `WhenRequired`, so OSS/COS accept the request.

The unsigned-payload middleware `UploadStream()` also installs is deliberately **not** added here: `Upload()` passes `bytes.NewReader(data)`, which is seekable. Only the checksum option is needed.

## Related Issue

Closes #6260

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Refactor / code improvement (no behavior change)
- [ ] Documentation update
- [x] Tests (adding or improving test coverage)
- [ ] CI / infrastructure

## Changes Made

- `server/internal/storage/s3.go` — added `usesAWSEndpoint()` and `uploadChecksumOptions()`; `Upload()` spreads the latter, which is empty for AWS endpoints and sets `RequestChecksumCalculation: WhenRequired` for everything else.
- `server/internal/storage/s3_test.go` — `TestS3StorageUploadPathsAvoidChecksumTrailer` asserts neither upload path emits `STREAMING-UNSIGNED-PAYLOAD-TRAILER`, `x-amz-trailer`, `x-amz-checksum-crc32`, or `aws-chunked` framing against an S3-compatible endpoint. `TestS3StorageAWSUploadKeepsChecksumTrailer` pins the opposite property for the AWS path: the trailer must still be there.

## How to Test

1. Run both tests:
```
   cd server && go test ./internal/storage -run 'TestS3Storage(UploadPathsAvoidChecksumTrailer|AWSUploadKeepsChecksumTrailer)' -v
```
2. Mutation-check the pair. Making `uploadChecksumOptions()` always return `nil` (no fix) fails `buffered_upload` on the exact `STREAMING-UNSIGNED-PAYLOAD-TRAILER` value OSS rejects, while the AWS test still passes. Making it apply unconditionally (ignoring the endpoint) fails `TestS3StorageAWSUploadKeepsChecksumTrailer` on both endpoint variants, while the compatible-backend test still passes.
3. Full package suite:
```
   cd server && gofmt -l ./internal/storage && go vet ./internal/storage && go test ./internal/storage
```
4. End-to-end against a real backend: configure a self-hosted instance with an Aliyun OSS bucket (`S3_BUCKET`, `S3_REGION=cn-shanghai`, `AWS_ENDPOINT_URL=https://oss-cn-shanghai-internal.aliyuncs.com`, `S3_USE_PATH_STYLE=false`) and upload an attachment. Before this change the request returns 500; after it, the object is written and the attachment renders.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [x] I have updated relevant documentation to reflect my changes
- [x] If I added a new runtime / coding tool / UI tab, I synced the change to **landing copy** and **relevant docs**
- [x] If this PR touches Chinese product copy, I checked it against `conventions.zh.mdx`
- [x] I have considered and documented any risks above
- [x] I will address all reviewer comments before requesting merge

**Risks:** low, and scoped. Requests to real AWS S3 are byte-for-byte unchanged — the option is not applied on that path at all. S3-compatible endpoints (OSS, COS, R2, B2, MinIO) stop sending a client-side checksum on buffered uploads; TLS still protects the request in transit, and the object content, key, metadata, storage class and returned URL are unchanged. `UploadStream()` is not touched. No API, schema, or configuration surface changes.

## AI Disclosure

**AI tool used:** Claude

**Prompt / approach:** Started from the runtime error against Aliyun OSS and worked backwards. Ruled out addressing style (#4739 was already applied) and the SDK env-var workaround before diffing the two `PutObject` call sites in `s3.go`, which surfaced the missing option on `Upload()`. Used Claude to confirm the SDK's default checksum behaviour and module-version interaction, to decide that the unsigned-payload middleware was unnecessary for the seekable buffered path, and to draft the regression test in the style of the existing `httptest`-based cases in `s3_test.go`.

---

### Maintainer edits

Two follow-up commits were pushed to this branch by a maintainer rather than sent back as review rounds. Both were prepared with Claude. Summary, since they change claims the original description made:

- **`e31fc40`** — the regression test was passing for the wrong reason. It built its client with `s3.New(s3.Options{...})`, which leaves `RequestChecksumCalculation` unset, and unset emits no checksum at all, so the assertions held with or without the fix. Production resolves the field to `WhenSupported` via `config.LoadDefaultConfig`. The test now pins that default and serves over `httptest.NewTLSServer`, since the SDK only switches to a trailing checksum on HTTPS. Also ran `gofmt` on `s3.go`.
- **`e4d63e2`** — scoped the workaround to non-AWS endpoints, as described above, and removed an inaccurate comment claiming the seekable body stayed covered by a real SigV4 payload hash. Measured on the wire, both modes send `UNSIGNED-PAYLOAD` over TLS; the difference is only whether a CRC32 trailer accompanies it.

One correction to the original description, which claimed `AWS_REQUEST_CHECKSUM_CALCULATION=when_required` is ignored because the pinned `aws-sdk-go-v2/config` predates v1.29.0: it does not. `server/go.mod` is on `config v1.32.13`, and `s3.NewFromConfig` propagates the value. The variable had no effect in the reported deployment because `docker-compose.selfhost.yml` passes an explicit environment whitelist to the `backend` service, with no `env_file`, so it never reached the process. No SDK bump is needed; adding the variable to that whitelist is a separate, optional change.
