### PR TITLE
MUL-5625: WS-2867: bound daemon workspace cache growth

### DIFF
--- a/CLI_AND_DAEMON.md
+++ b/CLI_AND_DAEMON.md
@@ -190,13 +190,17 @@ Daemon behavior is configured via flags or environment variables:
 
 #### Workspace garbage collection
 
-The daemon periodically scans `MULTICA_WORKSPACES_ROOT` and reclaims disk space in three modes:
+On every task preparation or reuse, the daemon creates `.metadata_never_index` at `MULTICA_WORKSPACES_ROOT`. macOS Spotlight treats this empty marker as an instruction not to index the workspace tree; other platforms safely ignore it. The marker is self-healing and a write failure is non-fatal.
+
+Codex keeps its marketplace and plugin caches isolated under each task's `codex-home/.tmp` while the process is running. After the process exits, the daemon removes the exact managed paths `codex-home/.tmp` and `codex-home/.sandbox-bin` before reporting the terminal result. This applies to completed, failed, timed-out, and cancelled runs. It does not remove Codex sessions, auth/config, task logs, output, source work, or other user-created files.
+
+The daemon also periodically scans `MULTICA_WORKSPACES_ROOT` and reclaims disk space in three modes:
 
 - **Full task cleanup** — when an issue's status is `done` or `cancelled` and has been idle for `MULTICA_GC_TTL`, the entire task directory is removed.
 - **Orphan cleanup** — task directories with no `.gc_meta.json` (e.g. left over from a daemon crash) are removed once they exceed `MULTICA_GC_ORPHAN_TTL`.
-- **Artifact-only cleanup** — when a task has been completed for at least `MULTICA_GC_ARTIFACT_TTL` but the issue is still open, regenerable build outputs whose directory basename matches `MULTICA_GC_ARTIFACT_PATTERNS` are removed. The daemon also reclaims the exact managed path `codex-home/.sandbox-bin`; old task metadata without `completed_at` becomes eligible for this managed-only cleanup after its `.gc_meta.json` file has been idle for `MULTICA_GC_ORPHAN_TTL`. The rest of the task (source, `.git`, `output/`, `logs/`, `.gc_meta.json`, Codex auth/config/session state) is preserved so the agent can resume it.
+- **Artifact-only cleanup** — when a task has been completed for at least `MULTICA_GC_ARTIFACT_TTL` but the issue is still open, regenerable build outputs whose directory basename matches `MULTICA_GC_ARTIFACT_PATTERNS` are removed. The daemon also reclaims legacy copies of the exact managed paths `codex-home/.sandbox-bin` and `codex-home/.tmp`; old task metadata without `completed_at` becomes eligible for this managed-only cleanup after its `.gc_meta.json` file has been idle for `MULTICA_GC_ORPHAN_TTL`. The rest of the task (source, `.git`, `output/`, `logs/`, `.gc_meta.json`, Codex auth/config/session state) is preserved so the agent can resume it.
 
-Configured patterns are basename-only — entries containing `/` or `\` are silently dropped — and `.git` subtrees are never descended into. The managed Codex cache is matched by its exact relative path, so a repository's own `.sandbox-bin` is not removed unless an operator explicitly adds that basename to `MULTICA_GC_ARTIFACT_PATTERNS`. The default list (`node_modules`, `.next`, `.turbo`) is intentionally narrow; extend it per deployment if your repos consistently produce other regenerable directories (for example, `MULTICA_GC_ARTIFACT_PATTERNS=node_modules,.next,.turbo,target,__pycache__`). To disable artifact cleanup entirely, including the managed Codex cache, set `MULTICA_GC_ARTIFACT_TTL=0`.
+Configured patterns are basename-only — entries containing `/` or `\` are silently dropped — and `.git` subtrees are never descended into. Managed Codex caches are matched by exact relative path, so a repository's own `.sandbox-bin` or `.tmp` is not removed unless an operator explicitly adds that basename to `MULTICA_GC_ARTIFACT_PATTERNS`. The default list (`node_modules`, `.next`, `.turbo`) is intentionally narrow; extend it per deployment if your repos consistently produce other regenerable directories (for example, `MULTICA_GC_ARTIFACT_PATTERNS=node_modules,.next,.turbo,target,__pycache__`). Setting `MULTICA_GC_ARTIFACT_TTL=0` disables periodic artifact cleanup, but the immediate post-process cleanup of task-local Codex caches still runs.
 
 Agent-specific overrides:
 

--- a/docs/plans/2026-08-02-workspace-storage-lifecycle-design.md
+++ b/docs/plans/2026-08-02-workspace-storage-lifecycle-design.md
@@ -1,0 +1,119 @@
+# Workspace Storage Lifecycle Design
+
+## Problem
+
+Daemon-managed task roots are bounded by the existing lifecycle GC: terminal
+issues are removed after `MULTICA_GC_TTL`, missing metadata is treated as an
+orphan after `MULTICA_GC_ORPHAN_TTL`, and known build artifacts are removed
+from completed but open tasks after `MULTICA_GC_ARTIFACT_TTL`. Deleting every
+task root as soon as a process exits would break issue continuation, provider
+session resume, and user-authored output kept for review.
+
+The current disk incident has two narrower causes:
+
+1. Each isolated Codex home recreates `codex-home/.tmp`, even though its
+   observed contents are the same plugin and marketplace caches used by the
+   shared Codex home. On the affected host this directory is about 305 MiB per
+   Codex task.
+2. Workspace roots have no Spotlight exclusion marker, so every new task and
+   cache refresh is indexed.
+
+The 4.7 GiB `c37d6ffd` outlier is not a runtime cache. It is a five-minute
+LaunchAgent for WS-2512 that has produced 237 roughly 20 MiB observation runs
+without retention. The runtime must not silently delete that live,
+user-authored output while the parent issue is blocked.
+
+## Considered approaches
+
+### Delete the task root on process exit
+
+This gives the smallest footprint, but violates the existing continuation and
+resume contracts. It can also remove outputs that an issue still needs for
+review. Rejected.
+
+### Add an unconditional size cap for open issues
+
+This bounds storage without waiting for issue closure, but an LRU decision
+cannot distinguish disposable cache from durable work or an externally
+scheduled process rooted in the task directory. Rejected until the product has
+an explicit archive/retention contract for user output.
+
+### Reclaim known caches and retain lifecycle GC
+
+Keep the proven whole-root lifecycle, reclaim the known Codex runtime cache as
+soon as its process exits, teach artifact GC to reclaim legacy per-task copies,
+and exclude the workspace root from Spotlight. Selected because it removes the
+structural retained-per-run multiplier without deleting state whose durability
+is part of the task contract or exposing executable plugin caches across tasks.
+
+## Design
+
+### Ephemeral Codex runtime cache
+
+Codex marketplace checkouts contain executable plugin code. The repository's
+existing isolation contract explicitly forbids exposing those checkouts across
+task homes because one task could mutate code another task later executes.
+`codex-home/.tmp` therefore remains task-local while the Codex process runs.
+
+After the agent runner returns and its process has been reaped, but before the
+daemon reports task completion to the server, remove exact daemon-approved
+ephemeral paths including `<task>/codex-home/.tmp`. This ordering prevents a
+same-issue successor from being dispatched into the reused env root while
+cleanup is running. The directory contains regenerable marketplace/plugin
+data, not sessions, credentials, task output, or provider logs. Per-task SQLite
+logs and session state remain isolated.
+
+Add `codex-home/.tmp` to the exact daemon-managed artifact paths. Existing
+completed task roots therefore shed old regular-directory copies on the normal
+artifact-GC schedule. The existing no-symlink rule remains in force, so a
+tampered task root cannot redirect cleanup outside its sandbox.
+
+### Spotlight exclusion
+
+Create an empty `.metadata_never_index` file at each daemon workspaces root
+before populating a task. The marker is the macOS-native equivalent of a
+`.noindex` suffix and covers all current and future task directories under that
+root, including crash-orphaned directories. It is harmless on other operating
+systems and avoids platform-specific control flow in environment preparation.
+
+Preparation and reuse both self-heal the marker. Failure is logged and remains
+non-fatal: inability to optimize indexing must not prevent task execution.
+
+### Existing GC lifecycle
+
+No whole-root retention semantics change:
+
+- done/cancelled issue roots remain eligible after the configured 24-hour TTL;
+- crash/timeout roots without metadata remain eligible after the configured
+  72-hour orphan TTL;
+- completed open-issue roots retain work and session state while exact managed
+  caches and configured build artifacts are reclaimed after 12 hours;
+- active env-root reservations and symlink guardrails remain authoritative.
+
+## Error handling and safety
+
+- Immediate cache cleanup is best-effort and occurs only after the runner has
+  returned. A cleanup failure is logged and does not discard the task result.
+- A regular `.tmp` path is removed only after its agent process exits, or by
+  artifact GC after completion.
+- Artifact GC continues to validate containment and never follows links.
+- Spotlight marker creation touches only the configured daemon workspace root.
+- No existing host task directory is manually deleted as part of this change.
+
+## Verification
+
+Tests will cover:
+
+- task result reporting observes that exact managed caches have already been
+  removed, closing the same-issue successor race;
+- cancelled and failed runner outcomes also reclaim the cache when an env root
+  was successfully prepared;
+- the managed artifact catalog includes `codex-home/.tmp`;
+- legacy regular `.tmp` caches are counted and reclaimed while symlinks and
+  their targets are preserved;
+- fresh preparation and reuse create/self-heal `.metadata_never_index`;
+- disk-usage reporting advertises and accounts for the new managed path.
+
+Run the focused execenv, GC, and disk-usage suites, followed by the daemon
+package tests and repository formatting/static checks appropriate to the
+changed Go packages.

--- a/docs/superpowers/plans/2026-08-02-workspace-storage-lifecycle.md
+++ b/docs/superpowers/plans/2026-08-02-workspace-storage-lifecycle.md
@@ -1,0 +1,388 @@
+# Workspace Storage Lifecycle Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Bound the daemon's per-task Codex cache growth and stop Spotlight from indexing daemon workspace roots without deleting resumable sessions, logs, source work, or user output.
+
+**Architecture:** Keep the existing whole-root lifecycle GC and add `codex-home/.tmp` to the exact daemon-owned artifact catalog. Reclaim those exact artifacts in a `runTask` defer for Codex after the process exits and before `handleTask` can send a terminal callback; use the existing matcher so containment and symlink protections stay shared. Independently create a root-level `.metadata_never_index` marker during both fresh preparation and reuse.
+
+**Tech Stack:** Go, `os`/`path/filepath`, the daemon `execenv` package, existing GC artifact matcher, Go table tests.
+
+---
+
+## File structure
+
+- Create `server/internal/daemon/execenv/spotlight.go`: owns the root-level Spotlight marker name and idempotent creation helper.
+- Create `server/internal/daemon/execenv/spotlight_test.go`: unit tests marker creation plus Prepare/Reuse self-healing.
+- Modify `server/internal/daemon/execenv/execenv.go`: call the Spotlight helper on both environment entry paths, logging failures as non-fatal.
+- Modify `server/internal/daemon/execenv/reclaimable.go`: add the exact `codex-home/.tmp` path to the daemon-managed artifact catalog.
+- Modify `server/internal/daemon/gc.go`: add the provider-gated immediate cleanup wrapper used by `runTask`.
+- Modify `server/internal/daemon/daemon.go`: install the cleanup defer immediately after environment preparation/reuse succeeds.
+- Modify `server/internal/daemon/gc_test.go`: prove `.tmp` cleanup, preservation of durable Codex state, provider gating, and symlink safety.
+- Modify `server/internal/daemon/diskusage_test.go`: prove disk usage reports both exact managed paths and deduplicates basename matches.
+- Modify `CLI_AND_DAEMON.md`: document immediate Codex cache reclamation, legacy GC behavior, exact paths, and Spotlight exclusion.
+
+### Task 1: Add the Spotlight exclusion marker
+
+**Files:**
+
+- Create: `server/internal/daemon/execenv/spotlight.go`
+- Create: `server/internal/daemon/execenv/spotlight_test.go`
+- Modify: `server/internal/daemon/execenv/execenv.go:251-280,465-485`
+
+- [x] **Step 1: Write failing marker and lifecycle tests**
+
+Create tests that exercise the public behavior rather than macOS indexing internals:
+
+```go
+func TestEnsureSpotlightExclusion(t *testing.T) {
+	root := filepath.Join(t.TempDir(), "workspaces")
+	if err := EnsureSpotlightExclusion(root); err != nil {
+		t.Fatalf("EnsureSpotlightExclusion: %v", err)
+	}
+	marker := filepath.Join(root, SpotlightExclusionMarker)
+	info, err := os.Stat(marker)
+	if err != nil {
+		t.Fatalf("stat marker: %v", err)
+	}
+	if info.IsDir() || info.Size() != 0 {
+		t.Fatalf("marker info = dir:%v size:%d, want empty file", info.IsDir(), info.Size())
+	}
+	if err := EnsureSpotlightExclusion(root); err != nil {
+		t.Fatalf("idempotent EnsureSpotlightExclusion: %v", err)
+	}
+}
+
+func TestPrepare_WritesSpotlightExclusion(t *testing.T) {
+	root := t.TempDir()
+	env, err := Prepare(PrepareParams{
+		WorkspacesRoot: root,
+		WorkspaceID: "ws-spotlight-prepare",
+		TaskID: "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+		Task: TaskContextForEnv{IssueID: "issue-spotlight-prepare"},
+	}, testLogger())
+	if err != nil {
+		t.Fatalf("Prepare: %v", err)
+	}
+	defer env.Cleanup(true)
+	if _, err := os.Stat(filepath.Join(root, SpotlightExclusionMarker)); err != nil {
+		t.Fatalf("Prepare did not create Spotlight marker: %v", err)
+	}
+}
+
+func TestReuse_SelfHealsSpotlightExclusion(t *testing.T) {
+	root := t.TempDir()
+	env, err := Prepare(PrepareParams{
+		WorkspacesRoot: root,
+		WorkspaceID: "ws-spotlight-reuse",
+		TaskID: "bbbbbbbb-cccc-dddd-eeee-ffffffffffff",
+		Task: TaskContextForEnv{IssueID: "issue-spotlight-reuse"},
+	}, testLogger())
+	if err != nil {
+		t.Fatalf("Prepare: %v", err)
+	}
+	defer env.Cleanup(true)
+	marker := filepath.Join(root, SpotlightExclusionMarker)
+	if err := os.Remove(marker); err != nil {
+		t.Fatalf("remove marker: %v", err)
+	}
+	if got := Reuse(ReuseParams{WorkspacesRoot: root, WorkDir: env.WorkDir, Task: TaskContextForEnv{IssueID: "issue-spotlight-reuse"}}, testLogger()); got == nil {
+		t.Fatal("Reuse returned nil")
+	}
+	if _, err := os.Stat(marker); err != nil {
+		t.Fatalf("Reuse did not restore Spotlight marker: %v", err)
+	}
+}
+```
+
+- [x] **Step 2: Run the tests and verify the expected compile failure**
+
+Run:
+
+```bash
+cd server
+go test ./internal/daemon/execenv -run 'Test(EnsureSpotlightExclusion|Prepare_WritesSpotlightExclusion|Reuse_SelfHealsSpotlightExclusion)$'
+```
+
+Expected: FAIL because `EnsureSpotlightExclusion` and `SpotlightExclusionMarker` do not exist.
+
+- [x] **Step 3: Implement the minimal marker helper**
+
+Create `spotlight.go`:
+
+```go
+package execenv
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+const SpotlightExclusionMarker = ".metadata_never_index"
+
+func EnsureSpotlightExclusion(workspacesRoot string) error {
+	if workspacesRoot == "" {
+		return fmt.Errorf("execenv: workspaces root is required")
+	}
+	if err := os.MkdirAll(workspacesRoot, 0o755); err != nil {
+		return fmt.Errorf("create workspaces root for Spotlight marker: %w", err)
+	}
+	if err := os.WriteFile(filepath.Join(workspacesRoot, SpotlightExclusionMarker), nil, 0o644); err != nil {
+		return fmt.Errorf("write Spotlight exclusion marker: %w", err)
+	}
+	return nil
+}
+```
+
+Call it after `EnsureWorkspacesRootMarker` in both `Prepare` and non-empty-root `Reuse`:
+
+```go
+if err := EnsureSpotlightExclusion(params.WorkspacesRoot); err != nil && logger != nil {
+	logger.Warn("execenv: Spotlight exclusion marker not written", "error", err)
+}
+```
+
+- [x] **Step 4: Run the focused tests and package tests**
+
+Run:
+
+```bash
+cd server
+go test ./internal/daemon/execenv -run 'Test(EnsureSpotlightExclusion|Prepare_WritesSpotlightExclusion|Reuse_SelfHealsSpotlightExclusion)$'
+go test ./internal/daemon/execenv
+```
+
+Expected: PASS.
+
+- [x] **Step 5: Commit the Spotlight unit**
+
+```bash
+git add server/internal/daemon/execenv/spotlight.go server/internal/daemon/execenv/spotlight_test.go server/internal/daemon/execenv/execenv.go
+git commit -m "feat(daemon): exclude workspace roots from Spotlight"
+```
+
+### Task 2: Catalog and reclaim the Codex temporary cache
+
+**Files:**
+
+- Modify: `server/internal/daemon/execenv/reclaimable.go`
+- Modify: `server/internal/daemon/gc_test.go:446-508,870-945`
+- Modify: `server/internal/daemon/diskusage_test.go:207-242,407-454`
+
+- [x] **Step 1: Extend GC and disk-usage tests to require `.tmp`**
+
+In `TestGCWorkspace_ReclaimsLegacyCodexSandboxWithoutConfiguredPatterns`, seed `codex-home/.tmp/plugin/cache.bin`, expect both managed directories removed, and update stats to two directories and combined bytes. In `TestCleanTaskArtifacts_ManagedPathIsExactAndDeduplicated`, seed both exact Codex paths plus same-named directories under `workdir/repo`, then require only the exact paths to be removed unless the operator supplies the broad basename. Extend the symlink table with `codex-home/.tmp`.
+
+Update `TestScanDiskUsage_ManagedCodexSandboxIsExactAndDeduplicated` to seed 200 bytes under `.tmp`, expect 500 managed bytes, and require:
+
+```go
+wantManaged := "codex-home/.sandbox-bin,codex-home/.tmp"
+if got := strings.Join(report.ManagedArtifactSubpaths, ","); got != wantManaged {
+	// fail
+}
+```
+
+Apply the same managed-path expectation to `TestScanDiskUsageRoots_SumsAcrossRoots`.
+
+- [x] **Step 2: Run focused tests and verify failures**
+
+Run:
+
+```bash
+cd server
+go test ./internal/daemon -run 'Test(GCWorkspace_ReclaimsLegacyCodexSandboxWithoutConfiguredPatterns|CleanTaskArtifacts_ManagedPath|ScanDiskUsage_ManagedCodexSandboxIsExactAndDeduplicated|ScanDiskUsageRoots_SumsAcrossRoots)$'
+```
+
+Expected: FAIL because `.tmp` is not in `ManagedReclaimableArtifactSubpaths`.
+
+- [x] **Step 3: Add `.tmp` to the exact managed catalog**
+
+Change `reclaimable.go` to:
+
+```go
+const (
+	codexHomeDirName       = "codex-home"
+	codexSandboxBinDirName = ".sandbox-bin"
+	codexTempDirName       = ".tmp"
+)
+
+func ManagedReclaimableArtifactSubpaths() []string {
+	return []string{
+		filepath.Join(codexHomeDirName, codexSandboxBinDirName),
+		filepath.Join(codexHomeDirName, codexTempDirName),
+	}
+}
+```
+
+- [x] **Step 4: Run focused and package tests**
+
+Run:
+
+```bash
+cd server
+go test ./internal/daemon -run 'Test(GCWorkspace_ReclaimsLegacyCodexSandboxWithoutConfiguredPatterns|CleanTaskArtifacts_ManagedPath|ScanDiskUsage_ManagedCodexSandboxIsExactAndDeduplicated|ScanDiskUsageRoots_SumsAcrossRoots)$'
+go test ./internal/daemon
+```
+
+Expected: PASS, including preservation of auth, config, sessions, logs, output, and symlink targets.
+
+- [x] **Step 5: Commit the artifact catalog unit**
+
+```bash
+git add server/internal/daemon/execenv/reclaimable.go server/internal/daemon/gc_test.go server/internal/daemon/diskusage_test.go
+git commit -m "feat(daemon): manage Codex temporary caches"
+```
+
+### Task 3: Reclaim managed Codex artifacts at process exit
+
+**Files:**
+
+- Modify: `server/internal/daemon/gc.go:636-646`
+- Modify: `server/internal/daemon/daemon.go:4990-5040`
+- Modify: `server/internal/daemon/gc_test.go`
+- Modify: `server/internal/daemon/workdir_race_test.go`
+
+- [x] **Step 1: Write failing provider-gating and runTask-return tests**
+
+Add a helper test in `gc_test.go` that creates both managed paths and calls the desired wrapper:
+
+```go
+func TestReclaimTaskExitArtifacts_OnlyCodex(t *testing.T) {
+	tests := []struct {
+		provider string
+		wantGone bool
+	}{{"codex", true}, {"claude", false}}
+	for _, tc := range tests {
+		t.Run(tc.provider, func(t *testing.T) {
+			taskDir := t.TempDir()
+			writeFile(t, filepath.Join(taskDir, "codex-home/.tmp/cache.bin"), 10)
+			d := newGCTestDaemon(t, http.NewServeMux())
+			d.reclaimTaskExitArtifacts(tc.provider, taskDir, slog.Default())
+			_, err := os.Stat(filepath.Join(taskDir, "codex-home/.tmp"))
+			if tc.wantGone != os.IsNotExist(err) {
+				t.Fatalf("stat err=%v, wantGone=%v", err, tc.wantGone)
+			}
+		})
+	}
+}
+```
+
+Add a POSIX `runTask` regression fixture in `workdir_race_test.go` using a fake Codex app-server script. The script creates `$CODEX_HOME/.tmp/plugin/cache.bin` before emitting either a terminal success response or exiting non-zero. Invoke `runTask` and assert the cache is absent when it returns for both subtests. Also create `codex-home/sessions/keep.jsonl` and `logs/keep.log` from the script and require they remain, proving that task-exit cleanup is narrow. A Claude control subtest should leave a same-shaped directory untouched.
+
+- [x] **Step 2: Run focused tests and verify the expected failures**
+
+Run:
+
+```bash
+cd server
+go test ./internal/daemon -run 'Test(ReclaimTaskExitArtifacts_OnlyCodex|RunTask_ReclaimsCodexArtifactsBeforeReturn)$'
+```
+
+Expected: FAIL because `reclaimTaskExitArtifacts` is undefined and `runTask` does not install cleanup.
+
+- [x] **Step 3: Implement provider-gated best-effort cleanup**
+
+Add next to `cleanManagedTaskArtifacts`:
+
+```go
+func (d *Daemon) reclaimTaskExitArtifacts(provider, taskDir string, logger *slog.Logger) {
+	if provider != "codex" || taskDir == "" {
+		return
+	}
+	removed, bytes, _ := d.cleanManagedTaskArtifacts(taskDir)
+	if removed > 0 && logger != nil {
+		logger.Info("reclaimed managed task-exit artifacts", "directories", removed, "bytes", bytes)
+	}
+}
+```
+
+Immediately after `env` is known to be non-nil in `runTask`, before any subsequent early return, install:
+
+```go
+defer d.reclaimTaskExitArtifacts(provider, env.RootDir, taskLog)
+```
+
+Because Go evaluates the defer arguments immediately and executes it before `runTask` returns, every post-prepare success, failure, timeout, and cancellation path cleans the cache before `handleTask` can call `reportTaskResult`. Preparation failures do not run cleanup because no usable environment/process exists.
+
+- [x] **Step 4: Run focused tests and package tests**
+
+Run:
+
+```bash
+cd server
+go test ./internal/daemon -run 'Test(ReclaimTaskExitArtifacts_OnlyCodex|RunTask_ReclaimsCodexArtifactsBeforeReturn)$'
+go test ./internal/daemon
+```
+
+Expected: PASS.
+
+- [x] **Step 5: Commit the task-exit lifecycle unit**
+
+```bash
+git add server/internal/daemon/gc.go server/internal/daemon/daemon.go server/internal/daemon/gc_test.go server/internal/daemon/workdir_race_test.go
+git commit -m "feat(daemon): reclaim Codex caches at task exit"
+```
+
+### Task 4: Document and verify the complete lifecycle
+
+**Files:**
+
+- Modify: `CLI_AND_DAEMON.md:183-200`
+- Modify: `docs/superpowers/plans/2026-08-02-workspace-storage-lifecycle.md`
+
+- [x] **Step 1: Update operator documentation**
+
+Document these exact contracts:
+
+```text
+- Codex task processes retain isolated `.tmp` caches while running and the daemon
+  removes `codex-home/.tmp` plus `codex-home/.sandbox-bin` before reporting the
+  task terminal.
+- Artifact GC also reclaims legacy copies of both exact paths after the artifact
+  TTL; it does not broaden matching to repositories unless configured.
+- The daemon creates `.metadata_never_index` at the workspaces root and repairs
+  it on Prepare/Reuse to prevent Spotlight indexing on macOS.
+- Sessions, auth/config, workdir, output, logs, and user-created data are retained
+  under the existing issue/orphan lifecycle.
+```
+
+- [x] **Step 2: Format and run focused verification**
+
+Run:
+
+```bash
+gofmt -w server/internal/daemon/execenv/spotlight.go server/internal/daemon/execenv/spotlight_test.go server/internal/daemon/execenv/execenv.go server/internal/daemon/execenv/reclaimable.go server/internal/daemon/gc.go server/internal/daemon/daemon.go server/internal/daemon/gc_test.go server/internal/daemon/diskusage_test.go server/internal/daemon/workdir_race_test.go
+cd server
+go test ./internal/daemon/execenv ./internal/daemon
+```
+
+Expected: PASS.
+
+- [x] **Step 3: Run repository checks and inspect the diff**
+
+Run:
+
+```bash
+git diff --check
+git status --short
+git diff --stat
+```
+
+Expected: no whitespace errors; only the design, plan, code, tests, and daemon documentation for this issue are changed.
+
+- [x] **Step 4: Commit documentation and plan state**
+
+```bash
+git add CLI_AND_DAEMON.md docs/superpowers/plans/2026-08-02-workspace-storage-lifecycle.md
+git commit -m "docs: explain bounded workspace storage lifecycle"
+```
+
+- [ ] **Step 5: Push and open the linked pull request**
+
+```bash
+git push -u origin agent/cto-codex/3962c1ca-1785685966
+gh pr create --title "WS-2867: bound daemon workspace cache growth" --body-file ./pr-body.md
+```
+
+The PR body must include `Closes WS-2867`, a concise summary, the two Go package test command, and the `c37d6ffd` outlier note explaining that its live `data/runs` application retention remains intentionally untouched.

--- a/docs/superpowers/plans/2026-08-02-workspace-storage-lifecycle.md
+++ b/docs/superpowers/plans/2026-08-02-workspace-storage-lifecycle.md
@@ -378,7 +378,7 @@ git add CLI_AND_DAEMON.md docs/superpowers/plans/2026-08-02-workspace-storage-li
 git commit -m "docs: explain bounded workspace storage lifecycle"
 ```
 
-- [ ] **Step 5: Push and open the linked pull request**
+- [x] **Step 5: Push and open the linked pull request**
 
 ```bash
 git push -u origin agent/cto-codex/3962c1ca-1785685966

--- a/server/internal/daemon/daemon.go
+++ b/server/internal/daemon/daemon.go
@@ -5033,6 +5033,13 @@ func (d *Daemon) runTask(ctx context.Context, task Task, provider string, slot i
 		d.markActiveEnvRoot(env.RootDir)
 		defer d.unmarkActiveEnvRoot(env.RootDir)
 	}
+	// Codex marketplace/plugin caches must stay task-local while executable
+	// code is running, then become disposable as soon as the process exits.
+	// Register this after every active-root release defer so cleanup runs first:
+	// the root stays reserved until managed artifacts are gone. This applies to
+	// success, failure, timeout, and cancellation before handleTask can report a
+	// terminal result and dispatch a same-issue successor into this environment.
+	defer d.reclaimTaskExitArtifacts(provider, env.RootDir, taskLog)
 	taskTempDir, err := ensureTaskTempDir(env.RootDir, task.WorkspaceID, task.ID)
 	if err != nil {
 		return TaskResult{}, fmt.Errorf("prepare task temp dir: %w", err)

--- a/server/internal/daemon/diskusage_test.go
+++ b/server/internal/daemon/diskusage_test.go
@@ -211,28 +211,30 @@ func TestScanDiskUsage_ManagedCodexSandboxIsExactAndDeduplicated(t *testing.T) {
 	wsID := "mmmmmmmm-mmmm-mmmm-mmmm-mmmmmmmmmmmm"
 	taskDir := filepath.Join(root, wsID, "tttttttt")
 	writeFile(t, filepath.Join(taskDir, "codex-home/.sandbox-bin/codex.exe"), 300)
+	writeFile(t, filepath.Join(taskDir, "codex-home/.tmp/plugin/cache.bin"), 200)
 	writeFile(t, filepath.Join(taskDir, "workdir/repo/.sandbox-bin/cache"), 400)
+	writeFile(t, filepath.Join(taskDir, "workdir/repo/.tmp/cache"), 500)
 
 	report, err := ScanDiskUsage(root, nil)
 	if err != nil {
 		t.Fatalf("ScanDiskUsage managed-only: %v", err)
 	}
-	if got := report.Tasks[0].SizeBytes; got != 700 {
-		t.Fatalf("size_bytes=%d, want 700", got)
+	if got := report.Tasks[0].SizeBytes; got != 1400 {
+		t.Fatalf("size_bytes=%d, want 1400", got)
 	}
-	if got := report.Tasks[0].ArtifactSizeBytes; got != 300 {
-		t.Fatalf("artifact_size_bytes=%d, want exact managed 300", got)
+	if got := report.Tasks[0].ArtifactSizeBytes; got != 500 {
+		t.Fatalf("artifact_size_bytes=%d, want exact managed 500", got)
 	}
-	if got := strings.Join(report.ManagedArtifactSubpaths, ","); got != "codex-home/.sandbox-bin" {
-		t.Fatalf("managed artifact paths=%q, want codex-home/.sandbox-bin", got)
+	if got := strings.Join(report.ManagedArtifactSubpaths, ","); got != "codex-home/.sandbox-bin,codex-home/.tmp" {
+		t.Fatalf("managed artifact paths=%q, want both exact Codex cache paths", got)
 	}
 
-	report, err = ScanDiskUsage(root, []string{".sandbox-bin"})
+	report, err = ScanDiskUsage(root, []string{".sandbox-bin", ".tmp"})
 	if err != nil {
 		t.Fatalf("ScanDiskUsage broad basename: %v", err)
 	}
-	if got := report.Tasks[0].ArtifactSizeBytes; got != 700 {
-		t.Fatalf("artifact_size_bytes=%d, want 700 without double counting", got)
+	if got := report.Tasks[0].ArtifactSizeBytes; got != 1400 {
+		t.Fatalf("artifact_size_bytes=%d, want 1400 without double counting", got)
 	}
 }
 
@@ -447,8 +449,8 @@ func TestScanDiskUsageRoots_SumsAcrossRoots(t *testing.T) {
 	if agg.TotalWorkspaceCount != 2 {
 		t.Fatalf("TotalWorkspaceCount = %d, want 2", agg.TotalWorkspaceCount)
 	}
-	if got := strings.Join(agg.ManagedArtifactSubpaths, ","); got != "codex-home/.sandbox-bin" {
-		t.Fatalf("managed artifact paths=%q, want codex-home/.sandbox-bin", got)
+	if got := strings.Join(agg.ManagedArtifactSubpaths, ","); got != "codex-home/.sandbox-bin,codex-home/.tmp" {
+		t.Fatalf("managed artifact paths=%q, want both exact Codex cache paths", got)
 	}
 }
 

--- a/server/internal/daemon/execenv/execenv.go
+++ b/server/internal/daemon/execenv/execenv.go
@@ -270,6 +270,9 @@ func Prepare(params PrepareParams, logger *slog.Logger) (*Environment, error) {
 	if err := EnsureWorkspacesRootMarker(params.WorkspacesRoot); err != nil && logger != nil {
 		logger.Warn("execenv: workspaces root marker not written; fail-closed guard limited to the task workdir", "error", err)
 	}
+	if err := EnsureSpotlightExclusion(params.WorkspacesRoot); err != nil && logger != nil {
+		logger.Warn("execenv: Spotlight exclusion marker not written", "error", err)
+	}
 
 	// Remove existing env if present (defensive — task IDs are unique).
 	if _, err := os.Stat(envRoot); err == nil {
@@ -475,6 +478,9 @@ func Reuse(params ReuseParams, logger *slog.Logger) *Environment {
 	if params.WorkspacesRoot != "" {
 		if err := EnsureWorkspacesRootMarker(params.WorkspacesRoot); err != nil && logger != nil {
 			logger.Warn("execenv: workspaces root marker not written on reuse; fail-closed guard limited to the task workdir", "error", err)
+		}
+		if err := EnsureSpotlightExclusion(params.WorkspacesRoot); err != nil && logger != nil {
+			logger.Warn("execenv: Spotlight exclusion marker not written on reuse", "error", err)
 		}
 	}
 

--- a/server/internal/daemon/execenv/reclaimable.go
+++ b/server/internal/daemon/execenv/reclaimable.go
@@ -5,6 +5,7 @@ import "path/filepath"
 const (
 	codexHomeDirName       = "codex-home"
 	codexSandboxBinDirName = ".sandbox-bin"
+	codexTempDirName       = ".tmp"
 )
 
 // ManagedReclaimableArtifactSubpaths returns daemon-owned, regenerable
@@ -12,5 +13,8 @@ const (
 // relative paths rather than basenames: a repository may legitimately contain
 // a directory with the same leaf name.
 func ManagedReclaimableArtifactSubpaths() []string {
-	return []string{filepath.Join(codexHomeDirName, codexSandboxBinDirName)}
+	return []string{
+		filepath.Join(codexHomeDirName, codexSandboxBinDirName),
+		filepath.Join(codexHomeDirName, codexTempDirName),
+	}
 }

--- a/server/internal/daemon/execenv/spotlight.go
+++ b/server/internal/daemon/execenv/spotlight.go
@@ -1,0 +1,27 @@
+package execenv
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// SpotlightExclusionMarker is the macOS marker that prevents indexing of a
+// directory tree. Other platforms safely ignore the empty file.
+const SpotlightExclusionMarker = ".metadata_never_index"
+
+// EnsureSpotlightExclusion creates or refreshes the marker at the daemon's
+// workspaces root. Callers treat failures as non-fatal because indexing is an
+// optimization and must never prevent task execution.
+func EnsureSpotlightExclusion(workspacesRoot string) error {
+	if workspacesRoot == "" {
+		return fmt.Errorf("execenv: workspaces root is required")
+	}
+	if err := os.MkdirAll(workspacesRoot, 0o755); err != nil {
+		return fmt.Errorf("create workspaces root for Spotlight marker: %w", err)
+	}
+	if err := os.WriteFile(filepath.Join(workspacesRoot, SpotlightExclusionMarker), nil, 0o644); err != nil {
+		return fmt.Errorf("write Spotlight exclusion marker: %w", err)
+	}
+	return nil
+}

--- a/server/internal/daemon/execenv/spotlight_test.go
+++ b/server/internal/daemon/execenv/spotlight_test.go
@@ -1,0 +1,74 @@
+package execenv
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestEnsureSpotlightExclusion(t *testing.T) {
+	root := filepath.Join(t.TempDir(), "workspaces")
+	if err := EnsureSpotlightExclusion(root); err != nil {
+		t.Fatalf("EnsureSpotlightExclusion: %v", err)
+	}
+
+	marker := filepath.Join(root, SpotlightExclusionMarker)
+	info, err := os.Stat(marker)
+	if err != nil {
+		t.Fatalf("stat marker: %v", err)
+	}
+	if info.IsDir() || info.Size() != 0 {
+		t.Fatalf("marker info = dir:%v size:%d, want empty file", info.IsDir(), info.Size())
+	}
+
+	if err := EnsureSpotlightExclusion(root); err != nil {
+		t.Fatalf("idempotent EnsureSpotlightExclusion: %v", err)
+	}
+}
+
+func TestPrepare_WritesSpotlightExclusion(t *testing.T) {
+	root := t.TempDir()
+	env, err := Prepare(PrepareParams{
+		WorkspacesRoot: root,
+		WorkspaceID:    "ws-spotlight-prepare",
+		TaskID:         "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+		Task:           TaskContextForEnv{IssueID: "issue-spotlight-prepare"},
+	}, testLogger())
+	if err != nil {
+		t.Fatalf("Prepare: %v", err)
+	}
+	defer env.Cleanup(true)
+
+	if _, err := os.Stat(filepath.Join(root, SpotlightExclusionMarker)); err != nil {
+		t.Fatalf("Prepare did not create Spotlight marker: %v", err)
+	}
+}
+
+func TestReuse_SelfHealsSpotlightExclusion(t *testing.T) {
+	root := t.TempDir()
+	env, err := Prepare(PrepareParams{
+		WorkspacesRoot: root,
+		WorkspaceID:    "ws-spotlight-reuse",
+		TaskID:         "bbbbbbbb-cccc-dddd-eeee-ffffffffffff",
+		Task:           TaskContextForEnv{IssueID: "issue-spotlight-reuse"},
+	}, testLogger())
+	if err != nil {
+		t.Fatalf("Prepare: %v", err)
+	}
+	defer env.Cleanup(true)
+
+	marker := filepath.Join(root, SpotlightExclusionMarker)
+	if err := os.Remove(marker); err != nil {
+		t.Fatalf("remove marker: %v", err)
+	}
+	if reused := Reuse(ReuseParams{
+		WorkspacesRoot: root,
+		WorkDir:        env.WorkDir,
+		Task:           TaskContextForEnv{IssueID: "issue-spotlight-reuse"},
+	}, testLogger()); reused == nil {
+		t.Fatal("Reuse returned nil")
+	}
+	if _, err := os.Stat(marker); err != nil {
+		t.Fatalf("Reuse did not restore Spotlight marker: %v", err)
+	}
+}

--- a/server/internal/daemon/gc.go
+++ b/server/internal/daemon/gc.go
@@ -3,6 +3,7 @@ package daemon
 import (
 	"context"
 	"errors"
+	"log/slog"
 	"net/http"
 	"os"
 	"os/exec"
@@ -638,6 +639,19 @@ func (d *Daemon) cleanTaskArtifacts(taskDir string, patterns []string) (removed 
 
 func (d *Daemon) cleanManagedTaskArtifacts(taskDir string) (removed int, bytes int64, perPattern map[string]int) {
 	return d.cleanTaskArtifactsMatching(taskDir, newArtifactMatcher(nil, execenv.ManagedReclaimableArtifactSubpaths()))
+}
+
+// reclaimTaskExitArtifacts removes only exact daemon-owned Codex artifacts
+// after the provider process has exited. Other providers are left untouched,
+// even if their task root happens to contain a matching path.
+func (d *Daemon) reclaimTaskExitArtifacts(provider, taskDir string, logger *slog.Logger) {
+	if provider != "codex" || taskDir == "" {
+		return
+	}
+	removed, bytes, _ := d.cleanManagedTaskArtifacts(taskDir)
+	if removed > 0 && logger != nil {
+		logger.Info("reclaimed managed task-exit artifacts", "directories", removed, "bytes", bytes)
+	}
 }
 
 func (d *Daemon) cleanTaskArtifactsMatching(taskDir string, matcher artifactMatcher) (removed int, bytes int64, perPattern map[string]int) {

--- a/server/internal/daemon/gc_test.go
+++ b/server/internal/daemon/gc_test.go
@@ -958,6 +958,32 @@ func TestCleanTaskArtifacts_ManagedPathDoesNotFollowSymlinks(t *testing.T) {
 	}
 }
 
+func TestReclaimTaskExitArtifacts_OnlyCodex(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		provider string
+		wantGone bool
+	}{
+		{provider: "codex", wantGone: true},
+		{provider: "claude", wantGone: false},
+	} {
+		t.Run(tc.provider, func(t *testing.T) {
+			t.Parallel()
+			taskDir := t.TempDir()
+			writeFile(t, filepath.Join(taskDir, "codex-home/.tmp/cache.bin"), 10)
+
+			d := newGCTestDaemon(t, http.NewServeMux())
+			d.reclaimTaskExitArtifacts(tc.provider, taskDir, slog.Default())
+
+			_, err := os.Stat(filepath.Join(taskDir, "codex-home/.tmp"))
+			if gotGone := os.IsNotExist(err); gotGone != tc.wantGone {
+				t.Fatalf("cache gone=%v (stat err=%v), want %v", gotGone, err, tc.wantGone)
+			}
+		})
+	}
+}
+
 func TestActiveEnvRootRefcount(t *testing.T) {
 	t.Parallel()
 

--- a/server/internal/daemon/gc_test.go
+++ b/server/internal/daemon/gc_test.go
@@ -467,6 +467,7 @@ func TestGCWorkspace_ReclaimsLegacyCodexSandboxWithoutConfiguredPatterns(t *test
 	// A tiny representative file keeps the regression fast; the reported
 	// Windows executable is about 325 MiB but has identical GC semantics.
 	writeFile(t, filepath.Join(taskDir, "codex-home/.sandbox-bin/codex.exe"), 325)
+	writeFile(t, filepath.Join(taskDir, "codex-home/.tmp/plugin/cache.bin"), 205)
 	for _, rel := range []string{
 		"codex-home/auth.json",
 		"codex-home/config.toml",
@@ -474,6 +475,7 @@ func TestGCWorkspace_ReclaimsLegacyCodexSandboxWithoutConfiguredPatterns(t *test
 		"output/result.txt",
 		"logs/task.log",
 		"workdir/repo/.sandbox-bin/user-owned",
+		"workdir/repo/.tmp/user-owned",
 	} {
 		writeFile(t, filepath.Join(taskDir, filepath.FromSlash(rel)), 10)
 	}
@@ -484,6 +486,9 @@ func TestGCWorkspace_ReclaimsLegacyCodexSandboxWithoutConfiguredPatterns(t *test
 	if _, err := os.Stat(filepath.Join(taskDir, "codex-home/.sandbox-bin")); !os.IsNotExist(err) {
 		t.Fatalf("managed Codex sandbox should be removed, stat err=%v", err)
 	}
+	if _, err := os.Stat(filepath.Join(taskDir, "codex-home/.tmp")); !os.IsNotExist(err) {
+		t.Fatalf("managed Codex temporary cache should be removed, stat err=%v", err)
+	}
 	for _, rel := range []string{
 		"codex-home/auth.json",
 		"codex-home/config.toml",
@@ -491,18 +496,20 @@ func TestGCWorkspace_ReclaimsLegacyCodexSandboxWithoutConfiguredPatterns(t *test
 		"output/result.txt",
 		"logs/task.log",
 		"workdir/repo/.sandbox-bin/user-owned",
+		"workdir/repo/.tmp/user-owned",
 		".gc_meta.json",
 	} {
 		if _, err := os.Stat(filepath.Join(taskDir, filepath.FromSlash(rel))); err != nil {
 			t.Errorf("expected %s to be preserved: %v", rel, err)
 		}
 	}
-	managedPattern := managedArtifactPatternPrefix + "codex-home/.sandbox-bin"
-	if stats.artifactDirs != 1 || stats.artifactRemoved != 1 || stats.bytesReclaimed != 325 || stats.skipped != 1 {
+	sandboxPattern := managedArtifactPatternPrefix + "codex-home/.sandbox-bin"
+	tempPattern := managedArtifactPatternPrefix + "codex-home/.tmp"
+	if stats.artifactDirs != 1 || stats.artifactRemoved != 2 || stats.bytesReclaimed != 530 || stats.skipped != 1 {
 		t.Fatalf("unexpected managed cleanup stats: %+v", stats)
 	}
-	if stats.byPattern[managedPattern] != 1 {
-		t.Fatalf("managed pattern stats = %+v, want %q=1", stats.byPattern, managedPattern)
+	if stats.byPattern[sandboxPattern] != 1 || stats.byPattern[tempPattern] != 1 {
+		t.Fatalf("managed pattern stats = %+v, want %q=1 and %q=1", stats.byPattern, sandboxPattern, tempPattern)
 	}
 }
 
@@ -875,17 +882,20 @@ func TestCleanTaskArtifacts_ManagedPathIsExactAndDeduplicated(t *testing.T) {
 	t.Run("managed only", func(t *testing.T) {
 		taskDir := t.TempDir()
 		writeFile(t, filepath.Join(taskDir, "codex-home/.sandbox-bin/codex.exe"), 300)
+		writeFile(t, filepath.Join(taskDir, "codex-home/.tmp/plugin/cache.bin"), 200)
 		writeFile(t, filepath.Join(taskDir, "workdir/repo/.sandbox-bin/keep"), 400)
+		writeFile(t, filepath.Join(taskDir, "workdir/repo/.tmp/keep"), 500)
 		writeFile(t, filepath.Join(taskDir, "codex-home/auth.json"), 10)
 
 		removed, bytes, perPattern := d.cleanTaskArtifacts(taskDir, nil)
-		if removed != 1 || bytes != 300 {
-			t.Fatalf("removed=%d bytes=%d, want 1/300", removed, bytes)
+		if removed != 2 || bytes != 500 {
+			t.Fatalf("removed=%d bytes=%d, want 2/500", removed, bytes)
 		}
-		if perPattern[managedArtifactPatternPrefix+"codex-home/.sandbox-bin"] != 1 {
+		if perPattern[managedArtifactPatternPrefix+"codex-home/.sandbox-bin"] != 1 ||
+			perPattern[managedArtifactPatternPrefix+"codex-home/.tmp"] != 1 {
 			t.Fatalf("unexpected per-pattern stats: %+v", perPattern)
 		}
-		for _, rel := range []string{"workdir/repo/.sandbox-bin/keep", "codex-home/auth.json"} {
+		for _, rel := range []string{"workdir/repo/.sandbox-bin/keep", "workdir/repo/.tmp/keep", "codex-home/auth.json"} {
 			if _, err := os.Stat(filepath.Join(taskDir, filepath.FromSlash(rel))); err != nil {
 				t.Errorf("expected %s to be preserved: %v", rel, err)
 			}
@@ -895,13 +905,17 @@ func TestCleanTaskArtifacts_ManagedPathIsExactAndDeduplicated(t *testing.T) {
 	t.Run("explicit broad basename", func(t *testing.T) {
 		taskDir := t.TempDir()
 		writeFile(t, filepath.Join(taskDir, "codex-home/.sandbox-bin/codex.exe"), 300)
+		writeFile(t, filepath.Join(taskDir, "codex-home/.tmp/plugin/cache.bin"), 200)
 		writeFile(t, filepath.Join(taskDir, "workdir/repo/.sandbox-bin/cache"), 400)
+		writeFile(t, filepath.Join(taskDir, "workdir/repo/.tmp/cache"), 500)
 
-		removed, bytes, perPattern := d.cleanTaskArtifacts(taskDir, []string{".sandbox-bin"})
-		if removed != 2 || bytes != 700 {
-			t.Fatalf("removed=%d bytes=%d, want 2/700 without double counting", removed, bytes)
+		removed, bytes, perPattern := d.cleanTaskArtifacts(taskDir, []string{".sandbox-bin", ".tmp"})
+		if removed != 4 || bytes != 1400 {
+			t.Fatalf("removed=%d bytes=%d, want 4/1400 without double counting", removed, bytes)
 		}
-		if perPattern[managedArtifactPatternPrefix+"codex-home/.sandbox-bin"] != 1 || perPattern[".sandbox-bin"] != 1 {
+		if perPattern[managedArtifactPatternPrefix+"codex-home/.sandbox-bin"] != 1 ||
+			perPattern[managedArtifactPatternPrefix+"codex-home/.tmp"] != 1 ||
+			perPattern[".sandbox-bin"] != 1 || perPattern[".tmp"] != 1 {
 			t.Fatalf("unexpected per-pattern stats: %+v", perPattern)
 		}
 	})
@@ -917,6 +931,7 @@ func TestCleanTaskArtifacts_ManagedPathDoesNotFollowSymlinks(t *testing.T) {
 		linkPath string
 	}{
 		{name: "leaf", linkPath: "codex-home/.sandbox-bin"},
+		{name: "temp leaf", linkPath: "codex-home/.tmp"},
 		{name: "parent", linkPath: "codex-home"},
 	} {
 		t.Run(tc.name, func(t *testing.T) {

--- a/server/internal/daemon/workdir_race_test.go
+++ b/server/internal/daemon/workdir_race_test.go
@@ -273,55 +273,59 @@ printf '%s\n' '{"type":"result","subtype":"success","is_error":false,"session_id
 }
 
 func TestRunTask_ReclaimsCodexArtifactsBeforeReturn(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("shell-script Codex fixture is POSIX-only")
-	}
-
 	fakeBin := filepath.Join(t.TempDir(), "codex")
-	script := `#!/bin/sh
-mkdir -p "$CODEX_HOME/.tmp/plugin" "$CODEX_HOME/.sandbox-bin" "$CODEX_HOME/sessions/2026/08/03"
-printf cache > "$CODEX_HOME/.tmp/plugin/cache.bin"
-printf sandbox > "$CODEX_HOME/.sandbox-bin/codex"
-printf session > "$CODEX_HOME/sessions/keep.jsonl"
-printf rollout > "$CODEX_HOME/sessions/2026/08/03/rollout-2026-08-03T00-00-00-thr-cleanup.jsonl"
-printf log > "$CODEX_HOME/../logs/keep.log"
-IFS= read -r _
-printf '%s\n' '{"jsonrpc":"2.0","id":1,"result":{}}'
-IFS= read -r _
-IFS= read -r _
-printf '%s\n' '{"jsonrpc":"2.0","id":2,"result":{"thread":{"id":"thr-cleanup"}}}'
-IFS= read -r _
-printf '%s\n' '{"jsonrpc":"2.0","id":3,"result":{}}'
-printf '%s\n' '{"jsonrpc":"2.0","method":"turn/started","params":{"threadId":"thr-cleanup","turn":{"id":"turn-cleanup"}}}'
-case "$FIXTURE_STATUS" in
-  completed)
-    printf '%s\n' '{"jsonrpc":"2.0","method":"item/completed","params":{"threadId":"thr-cleanup","item":{"type":"agentMessage","id":"msg-cleanup","text":"done"}}}'
-    printf '%s\n' '{"jsonrpc":"2.0","method":"turn/completed","params":{"threadId":"thr-cleanup","turn":{"id":"turn-cleanup","status":"completed"}}}'
-    ;;
-  cancelled)
-    printf '%s\n' '{"jsonrpc":"2.0","method":"turn/completed","params":{"threadId":"thr-cleanup","turn":{"id":"turn-cleanup","status":"cancelled"}}}'
-    ;;
-  failed)
-    printf '%s\n' '{"jsonrpc":"2.0","method":"turn/completed","params":{"threadId":"thr-cleanup","turn":{"id":"turn-cleanup","status":"failed","error":{"message":"fixture failure"}}}}'
-    ;;
-esac
-sleep 2
-`
-	if err := os.WriteFile(fakeBin, []byte(script), 0o755); err != nil {
+	if err := os.WriteFile(fakeBin, []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
 		t.Fatalf("write fake Codex: %v", err)
 	}
-	if err := os.Chmod(fakeBin, 0o755); err != nil {
-		t.Fatalf("chmod fake Codex: %v", err)
-	}
 
-	for _, status := range []string{"completed", "cancelled", "failed"} {
-		t.Run(status, func(t *testing.T) {
+	for _, tc := range []struct {
+		name              string
+		startStatus       int
+		cancelBeforeStart bool
+		completeEarly     bool
+		wantErr           bool
+	}{
+		{name: "completed", startStatus: http.StatusOK, completeEarly: true},
+		{name: "failed", startStatus: http.StatusBadRequest, wantErr: true},
+		{name: "cancelled", startStatus: http.StatusOK, cancelBeforeStart: true, wantErr: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
 			workspacesRoot := t.TempDir()
-			workspaceID := "ws-codex-cleanup-" + status
-			taskID := "task-codex-cleanup-" + status
-			envRoot := execenv.PredictRootDir(workspacesRoot, workspaceID, taskID)
+			workspaceID := "ws-codex-cleanup-" + tc.name
+			taskID := "task-codex-cleanup-" + tc.name
+			envRoot := filepath.Join(workspacesRoot, workspaceID, "prior-task")
+			workDir := filepath.Join(envRoot, "workdir")
+			for _, rel := range []string{
+				"workdir",
+				"codex-home/.tmp/plugin",
+				"codex-home/.sandbox-bin",
+				"codex-home/sessions",
+				"logs",
+			} {
+				if err := os.MkdirAll(filepath.Join(envRoot, filepath.FromSlash(rel)), 0o755); err != nil {
+					t.Fatalf("mkdir %s: %v", rel, err)
+				}
+			}
+			for rel, body := range map[string]string{
+				"codex-home/.tmp/plugin/cache.bin": "cache",
+				"codex-home/.sandbox-bin/codex":    "sandbox",
+				"codex-home/sessions/keep.jsonl":   "session",
+				"logs/keep.log":                    "log",
+			} {
+				if err := os.WriteFile(filepath.Join(envRoot, filepath.FromSlash(rel)), []byte(body), 0o644); err != nil {
+					t.Fatalf("seed %s: %v", rel, err)
+				}
+			}
 
-			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			var startSawCache atomic.Bool
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if strings.HasSuffix(r.URL.Path, "/start") {
+					if _, err := os.Stat(filepath.Join(envRoot, "codex-home/.tmp/plugin/cache.bin")); err == nil {
+						startSawCache.Store(true)
+					}
+					w.WriteHeader(tc.startStatus)
+					return
+				}
 				w.WriteHeader(http.StatusOK)
 			}))
 			t.Cleanup(srv.Close)
@@ -334,7 +338,6 @@ sleep 2
 				activeEnvRoots: make(map[string]int),
 				cfg: Config{
 					WorkspacesRoot: workspacesRoot,
-					AgentTimeout:   30 * time.Second,
 					ServerBaseURL:  srv.URL,
 					Agents: map[string]AgentEntry{
 						"codex": {Path: fakeBin},
@@ -345,23 +348,33 @@ sleep 2
 				ID:                taskID,
 				WorkspaceID:       workspaceID,
 				RuntimeID:         "rt-1",
+				PriorWorkDir:      workDir,
 				QuickCreatePrompt: "exercise task-exit cleanup",
 				AuthToken:         "mat_codex_cleanup",
-				Agent: &AgentData{
-					Name:      "cleanup-agent",
-					CustomEnv: map[string]string{"FIXTURE_STATUS": status},
-				},
+				Agent:             &AgentData{Name: "cleanup-agent"},
+			}
+			if tc.completeEarly {
+				task.RegenerateQuickActionsFor = "obsolete-task"
+			}
+			runCtx := context.Background()
+			if tc.cancelBeforeStart {
+				var cancel context.CancelFunc
+				runCtx, cancel = context.WithCancel(runCtx)
+				cancel()
 			}
 
-			result, err := d.runTask(context.Background(), task, "codex", 0, d.logger)
-			if err != nil {
+			result, err := d.runTask(runCtx, task, "codex", 0, d.logger)
+			if tc.wantErr && err == nil {
+				t.Fatal("runTask returned nil error")
+			}
+			if !tc.wantErr && err != nil {
 				t.Fatalf("runTask: %v", err)
 			}
-			if status == "completed" && result.Status != "completed" {
-				t.Fatalf("result status=%q comment=%q failure_reason=%q, want completed", result.Status, result.Comment, result.FailureReason)
+			if tc.completeEarly && result.Status != "completed" {
+				t.Fatalf("result status=%q, want completed", result.Status)
 			}
-			if status != "completed" && result.Status != status && result.Status != "blocked" {
-				t.Fatalf("result status=%q, want %s or blocked", result.Status, status)
+			if !tc.cancelBeforeStart && !startSawCache.Load() {
+				t.Fatal("managed cache was absent before StartTask; test did not exercise task-exit cleanup")
 			}
 
 			for _, rel := range []string{"codex-home/.tmp", "codex-home/.sandbox-bin"} {

--- a/server/internal/daemon/workdir_race_test.go
+++ b/server/internal/daemon/workdir_race_test.go
@@ -272,6 +272,112 @@ printf '%s\n' '{"type":"result","subtype":"success","is_error":false,"session_id
 	}
 }
 
+func TestRunTask_ReclaimsCodexArtifactsBeforeReturn(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell-script Codex fixture is POSIX-only")
+	}
+
+	fakeBin := filepath.Join(t.TempDir(), "codex")
+	script := `#!/bin/sh
+mkdir -p "$CODEX_HOME/.tmp/plugin" "$CODEX_HOME/.sandbox-bin" "$CODEX_HOME/sessions/2026/08/03"
+printf cache > "$CODEX_HOME/.tmp/plugin/cache.bin"
+printf sandbox > "$CODEX_HOME/.sandbox-bin/codex"
+printf session > "$CODEX_HOME/sessions/keep.jsonl"
+printf rollout > "$CODEX_HOME/sessions/2026/08/03/rollout-2026-08-03T00-00-00-thr-cleanup.jsonl"
+printf log > "$CODEX_HOME/../logs/keep.log"
+IFS= read -r _
+printf '%s\n' '{"jsonrpc":"2.0","id":1,"result":{}}'
+IFS= read -r _
+IFS= read -r _
+printf '%s\n' '{"jsonrpc":"2.0","id":2,"result":{"thread":{"id":"thr-cleanup"}}}'
+IFS= read -r _
+printf '%s\n' '{"jsonrpc":"2.0","id":3,"result":{}}'
+printf '%s\n' '{"jsonrpc":"2.0","method":"turn/started","params":{"threadId":"thr-cleanup","turn":{"id":"turn-cleanup"}}}'
+case "$FIXTURE_STATUS" in
+  completed)
+    printf '%s\n' '{"jsonrpc":"2.0","method":"item/completed","params":{"threadId":"thr-cleanup","item":{"type":"agentMessage","id":"msg-cleanup","text":"done"}}}'
+    printf '%s\n' '{"jsonrpc":"2.0","method":"turn/completed","params":{"threadId":"thr-cleanup","turn":{"id":"turn-cleanup","status":"completed"}}}'
+    ;;
+  cancelled)
+    printf '%s\n' '{"jsonrpc":"2.0","method":"turn/completed","params":{"threadId":"thr-cleanup","turn":{"id":"turn-cleanup","status":"cancelled"}}}'
+    ;;
+  failed)
+    printf '%s\n' '{"jsonrpc":"2.0","method":"turn/completed","params":{"threadId":"thr-cleanup","turn":{"id":"turn-cleanup","status":"failed","error":{"message":"fixture failure"}}}}'
+    ;;
+esac
+sleep 2
+`
+	if err := os.WriteFile(fakeBin, []byte(script), 0o755); err != nil {
+		t.Fatalf("write fake Codex: %v", err)
+	}
+	if err := os.Chmod(fakeBin, 0o755); err != nil {
+		t.Fatalf("chmod fake Codex: %v", err)
+	}
+
+	for _, status := range []string{"completed", "cancelled", "failed"} {
+		t.Run(status, func(t *testing.T) {
+			workspacesRoot := t.TempDir()
+			workspaceID := "ws-codex-cleanup-" + status
+			taskID := "task-codex-cleanup-" + status
+			envRoot := execenv.PredictRootDir(workspacesRoot, workspaceID, taskID)
+
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(http.StatusOK)
+			}))
+			t.Cleanup(srv.Close)
+
+			d := &Daemon{
+				client:         NewClient(srv.URL),
+				logger:         slog.New(slog.NewTextHandler(io.Discard, nil)),
+				workspaces:     make(map[string]*workspaceState),
+				runtimeIndex:   map[string]Runtime{"rt-1": {ID: "rt-1", Provider: "codex"}},
+				activeEnvRoots: make(map[string]int),
+				cfg: Config{
+					WorkspacesRoot: workspacesRoot,
+					AgentTimeout:   30 * time.Second,
+					ServerBaseURL:  srv.URL,
+					Agents: map[string]AgentEntry{
+						"codex": {Path: fakeBin},
+					},
+				},
+			}
+			task := Task{
+				ID:                taskID,
+				WorkspaceID:       workspaceID,
+				RuntimeID:         "rt-1",
+				QuickCreatePrompt: "exercise task-exit cleanup",
+				AuthToken:         "mat_codex_cleanup",
+				Agent: &AgentData{
+					Name:      "cleanup-agent",
+					CustomEnv: map[string]string{"FIXTURE_STATUS": status},
+				},
+			}
+
+			result, err := d.runTask(context.Background(), task, "codex", 0, d.logger)
+			if err != nil {
+				t.Fatalf("runTask: %v", err)
+			}
+			if status == "completed" && result.Status != "completed" {
+				t.Fatalf("result status=%q comment=%q failure_reason=%q, want completed", result.Status, result.Comment, result.FailureReason)
+			}
+			if status != "completed" && result.Status != status && result.Status != "blocked" {
+				t.Fatalf("result status=%q, want %s or blocked", result.Status, status)
+			}
+
+			for _, rel := range []string{"codex-home/.tmp", "codex-home/.sandbox-bin"} {
+				if _, err := os.Stat(filepath.Join(envRoot, filepath.FromSlash(rel))); !os.IsNotExist(err) {
+					t.Fatalf("managed artifact %s still exists when runTask returned: %v", rel, err)
+				}
+			}
+			for _, rel := range []string{"codex-home/sessions/keep.jsonl", "logs/keep.log"} {
+				if _, err := os.Stat(filepath.Join(envRoot, filepath.FromSlash(rel))); err != nil {
+					t.Fatalf("durable task file %s was removed: %v", rel, err)
+				}
+			}
+		})
+	}
+}
+
 func TestRunTask_ExtendsPrepareLeaseDuringStartTask(t *testing.T) {
 	oldRefresh := taskPrepareLeaseRefresh
 	oldTimeout := taskPrepareLeaseTimeout


### PR DESCRIPTION
## Summary

- create and self-heal `.metadata_never_index` at daemon workspace roots
- treat `codex-home/.tmp` as an exact managed artifact alongside `.sandbox-bin`
- reclaim task-local Codex caches after the provider exits and before terminal reporting, while retaining sessions, logs, workdir, output, auth, and config
- extend GC/disk-usage coverage and document the resulting lifecycle

## Safety and scope

- cleanup continues to reject symlinks and preserves same-named directories inside user repositories unless operators explicitly configure broad basename matching
- whole task roots retain the existing issue/orphan TTL behavior, so issue continuation and session resume are unchanged
- the live `c37d6ffd` / WS-2512 `data/runs` outlier is application-owned scheduled output, not runtime cache; this PR intentionally does not delete it or add a generic size cap

## Test plan

- [x] `go test -count=1 -parallel=2 ./internal/daemon/execenv ./internal/daemon`
- [x] `git diff --check origin/main...HEAD`

Closes WS-2867
