### PR TITLE
feat(ui): add @reui/onboarding-3 block and wire up the @reui registry

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -181,6 +181,7 @@ Root-level reminders:
 ## UI Rules
 
 - Prefer shadcn/Base UI components over custom implementations. Add them with `pnpm ui:add <component>` from the repo root.
+- The `@reui` registry (Pro) is configured in `packages/ui/components.json`. It needs `REUI_LICENSE_KEY` exported in your shell or set in `packages/ui/.env.local` (gitignored); add items with `pnpm ui:add @reui/<name>`. Answer `n` to overwrite prompts so local component customizations survive.
 - Use design tokens and semantic classes; avoid hardcoded colors.
 - Do not introduce extra local state unless the design requires it.
 - Handle overflow, long text, scrolling, alignment, and spacing deliberately.

--- a/packages/ui/components.json
+++ b/packages/ui/components.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://ui.shadcn.com/schema.json",
   "style": "base-nova",
-  "rsc": false,
+  "rsc": true,
   "tsx": true,
   "tailwind": {
     "config": "",
@@ -17,5 +17,13 @@
     "hooks": "@multica/ui/hooks",
     "lib": "@multica/ui/lib",
     "utils": "@multica/ui/lib/utils"
+  },
+  "registries": {
+    "@reui": {
+      "url": "https://reui.io/r/base-nova/{name}.json",
+      "headers": {
+        "Authorization": "Bearer ${REUI_LICENSE_KEY}"
+      }
+    }
   }
 }

--- a/packages/ui/components/blocks/onboarding-3/components/data.tsx
+++ b/packages/ui/components/blocks/onboarding-3/components/data.tsx
@@ -1,0 +1,463 @@
+import type { ReactNode } from "react"
+import {
+  AdvertisimentIcon,
+  AiMagicIcon,
+  Facebook02Icon,
+  GoogleIcon,
+  InstagramIcon,
+  Linkedin01Icon,
+  Mail01Icon,
+  MoreHorizontalCircle01Icon,
+  NewTwitterIcon,
+  PodcastIcon,
+  RedditIcon,
+  UserMultiple02Icon,
+  YoutubeIcon,
+} from "@hugeicons/core-free-icons"
+import { HugeiconsIcon } from "@hugeicons/react"
+import { TargetIcon, GitBranchIcon, PaletteIcon, CodeIcon, RocketIcon, Settings2Icon, LayersIcon, UsersIcon, ArrowLeftRightIcon, SparklesIcon } from "lucide-react"
+
+export type OnboardingStep = {
+  id: string
+  value: number
+  label: string
+  title: string
+  description: string
+  optional?: boolean
+}
+
+export type OnboardingChoice<TValue extends string = string> = {
+  value: TValue
+  label: string
+  description: string
+  icon?: ReactNode
+  recommended?: boolean
+}
+
+export type RoleValue =
+  | "product"
+  | "engineering"
+  | "design"
+  | "developer"
+  | "founder"
+  | "operations"
+
+export type TeamSizeValue =
+  | "solo"
+  | "small"
+  | "team"
+  | "department"
+  | "midmarket"
+  | "company"
+  | "enterprise"
+  | "global"
+
+export type DiscoverySourceValue =
+  | "google"
+  | "linkedin"
+  | "facebook"
+  | "instagram"
+  | "reddit"
+  | "x"
+  | "youtube"
+  | "podcast"
+  | "newsletter"
+  | "friend"
+  | "ai"
+  | "outside"
+  | "other"
+
+export type GoalValue =
+  | "roadmaps"
+  | "sprints"
+  | "projects"
+  | "migration"
+  | "explore"
+
+export type InviteRoleValue = "guest" | "member" | "admin"
+
+export type InviteRow = {
+  id: string
+  email: string
+  role: InviteRoleValue
+}
+
+// Non-empty tuple so step lookups can fall back to index 0 under
+// noUncheckedIndexedAccess.
+export const ONBOARDING_STEPS: readonly [OnboardingStep, ...OnboardingStep[]] = [
+  {
+    id: "profile",
+    value: 1,
+    label: "Profile",
+    title: "Set up your profile",
+    description: "Add the details teammates will see across the workspace.",
+  },
+  {
+    id: "role",
+    value: 2,
+    label: "Role",
+    title: "Choose your role",
+    description: "Starter views will match your daily work.",
+  },
+  {
+    id: "source",
+    value: 3,
+    label: "Source",
+    title: "How did you hear about us?",
+    description:
+      "Tell us where ReUI first showed up for you. This step is optional.",
+    optional: true,
+  },
+  {
+    id: "workspace",
+    value: 4,
+    label: "Workspace",
+    title: "Create your workspace",
+    description: "Name the shared space your team will use first.",
+  },
+  {
+    id: "goals",
+    value: 5,
+    label: "Goals",
+    title: "Choose your first goals",
+    description: "Pick the workflows this workspace should support.",
+  },
+  {
+    id: "invite",
+    value: 6,
+    label: "Invite",
+    title: "Invite teammates",
+    description: "Add the people who should join this workspace.",
+    optional: true,
+  },
+]
+
+export const DISCOVERY_SOURCE_OPTIONS: OnboardingChoice<DiscoverySourceValue>[] =
+  [
+    {
+      value: "google",
+      label: "Google",
+      description: "Search or ads.",
+      icon: (
+        <HugeiconsIcon
+          icon={GoogleIcon}
+          className="size-4"
+          aria-hidden="true"
+        />
+      ),
+    },
+    {
+      value: "linkedin",
+      label: "LinkedIn",
+      description: "A professional post or share.",
+      icon: (
+        <HugeiconsIcon
+          icon={Linkedin01Icon}
+          className="size-4"
+          aria-hidden="true"
+        />
+      ),
+    },
+    {
+      value: "facebook",
+      label: "Facebook",
+      description: "A Facebook post or group mention.",
+      icon: (
+        <HugeiconsIcon
+          icon={Facebook02Icon}
+          className="size-4"
+          aria-hidden="true"
+        />
+      ),
+    },
+    {
+      value: "instagram",
+      label: "Instagram",
+      description: "A story, post, or creator share.",
+      icon: (
+        <HugeiconsIcon
+          icon={InstagramIcon}
+          className="size-4"
+          aria-hidden="true"
+        />
+      ),
+    },
+    {
+      value: "reddit",
+      label: "Reddit",
+      description: "A thread, review, or recommendation.",
+      icon: (
+        <HugeiconsIcon
+          icon={RedditIcon}
+          className="size-4"
+          aria-hidden="true"
+        />
+      ),
+    },
+    {
+      value: "x",
+      label: "X.com",
+      description: "A post or discussion on X.",
+      icon: (
+        <HugeiconsIcon
+          icon={NewTwitterIcon}
+          className="size-4"
+          aria-hidden="true"
+        />
+      ),
+    },
+    {
+      value: "youtube",
+      label: "YouTube",
+      description: "A demo, review, or walkthrough.",
+      icon: (
+        <HugeiconsIcon
+          icon={YoutubeIcon}
+          className="size-4"
+          aria-hidden="true"
+        />
+      ),
+    },
+    {
+      value: "podcast",
+      label: "Podcast",
+      description: "A show or interview.",
+      icon: (
+        <HugeiconsIcon
+          icon={PodcastIcon}
+          className="size-4"
+          aria-hidden="true"
+        />
+      ),
+    },
+    {
+      value: "newsletter",
+      label: "Newsletter",
+      description: "An email roundup.",
+      icon: (
+        <HugeiconsIcon
+          icon={Mail01Icon}
+          className="size-4"
+          aria-hidden="true"
+        />
+      ),
+    },
+    {
+      value: "friend",
+      label: "Friend / coworker",
+      description: "A teammate or peer recommended it.",
+      icon: (
+        <HugeiconsIcon
+          icon={UserMultiple02Icon}
+          className="size-4"
+          aria-hidden="true"
+        />
+      ),
+    },
+    {
+      value: "ai",
+      label: "AI assistant",
+      description: "Suggested during research.",
+      icon: (
+        <HugeiconsIcon
+          icon={AiMagicIcon}
+          className="size-4"
+          aria-hidden="true"
+        />
+      ),
+    },
+    {
+      value: "outside",
+      label: "Billboard / outside",
+      description: "Conference, billboard, or offline mention.",
+      icon: (
+        <HugeiconsIcon
+          icon={AdvertisimentIcon}
+          className="size-4"
+          aria-hidden="true"
+        />
+      ),
+    },
+    {
+      value: "other",
+      label: "Other",
+      description: "Something else.",
+      icon: (
+        <HugeiconsIcon
+          icon={MoreHorizontalCircle01Icon}
+          className="size-4"
+          aria-hidden="true"
+        />
+      ),
+    },
+  ]
+
+export const ROLE_OPTIONS: OnboardingChoice<RoleValue>[] = [
+  {
+    value: "product",
+    label: "Product Manager",
+    description: "Plan roadmaps and align releases.",
+    icon: (
+      <TargetIcon aria-hidden="true" />
+    ),
+  },
+  {
+    value: "engineering",
+    label: "Engineering Manager",
+    description: "Coordinate cycles, dependencies, and reviews.",
+    icon: (
+      <GitBranchIcon aria-hidden="true" />
+    ),
+  },
+  {
+    value: "design",
+    label: "Designer",
+    description: "Shape specs, decisions, and handoff.",
+    icon: (
+      <PaletteIcon aria-hidden="true" />
+    ),
+  },
+  {
+    value: "developer",
+    label: "Developer",
+    description: "Track issues, reviews, and implementation.",
+    icon: (
+      <CodeIcon aria-hidden="true" />
+    ),
+    recommended: true,
+  },
+  {
+    value: "founder",
+    label: "Founder or Executive",
+    description: "Keep launches and priorities in view.",
+    icon: (
+      <RocketIcon aria-hidden="true" />
+    ),
+  },
+  {
+    value: "operations",
+    label: "Operations Manager",
+    description: "Standardize ownership and handoffs.",
+    icon: (
+      <Settings2Icon aria-hidden="true" />
+    ),
+  },
+]
+
+export const TEAM_SIZE_OPTIONS: OnboardingChoice<TeamSizeValue>[] = [
+  {
+    value: "solo",
+    label: "Just myself",
+    description: "Personal setup.",
+  },
+  {
+    value: "small",
+    label: "2-10",
+    description: "Small team.",
+  },
+  {
+    value: "team",
+    label: "11-50",
+    description: "Growing team.",
+    recommended: true,
+  },
+  {
+    value: "department",
+    label: "51-200",
+    description: "Department.",
+  },
+  {
+    value: "midmarket",
+    label: "201-500",
+    description: "Mid-market team.",
+  },
+  {
+    value: "company",
+    label: "501-1,000",
+    description: "Company.",
+  },
+  {
+    value: "enterprise",
+    label: "1,001-5,000",
+    description: "Enterprise.",
+  },
+  {
+    value: "global",
+    label: "5,000+",
+    description: "Global organization.",
+  },
+]
+
+export const GOAL_OPTIONS: OnboardingChoice<GoalValue>[] = [
+  {
+    value: "roadmaps",
+    label: "Product roadmaps",
+    description: "Connect goals, projects, and releases.",
+    icon: (
+      <LayersIcon aria-hidden="true" />
+    ),
+  },
+  {
+    value: "sprints",
+    label: "Engineering sprints",
+    description: "Keep issues, cycles, and reviews moving.",
+    icon: (
+      <CodeIcon aria-hidden="true" />
+    ),
+  },
+  {
+    value: "projects",
+    label: "Cross-functional projects",
+    description: "Give each team one source of truth.",
+    icon: (
+      <UsersIcon aria-hidden="true" />
+    ),
+  },
+  {
+    value: "migration",
+    label: "Replace our current tool",
+    description: "Use familiar fields and migration defaults.",
+    icon: (
+      <ArrowLeftRightIcon aria-hidden="true" />
+    ),
+  },
+  {
+    value: "explore",
+    label: "Just exploring",
+    description: "Start with sample data and lighter setup.",
+    icon: (
+      <SparklesIcon aria-hidden="true" />
+    ),
+  },
+]
+
+export const INVITE_ROLE_OPTIONS: OnboardingChoice<InviteRoleValue>[] = [
+  {
+    value: "guest",
+    label: "Guest",
+    description: "Can view invited projects.",
+  },
+  {
+    value: "member",
+    label: "Member",
+    description: "Can create and update work.",
+  },
+  {
+    value: "admin",
+    label: "Admin",
+    description: "Can manage workspace settings.",
+  },
+]
+
+export const DEFAULT_INVITES: InviteRow[] = [
+  {
+    id: "invite-1",
+    email: "maya@northstar.dev",
+    role: "admin",
+  },
+  {
+    id: "invite-2",
+    email: "kai@northstar.dev",
+    role: "member",
+  },
+]

--- a/packages/ui/components/blocks/onboarding-3/components/dot-sphere.tsx
+++ b/packages/ui/components/blocks/onboarding-3/components/dot-sphere.tsx
@@ -1,0 +1,399 @@
+"use client"
+
+import { useEffect, useRef } from "react"
+
+import { cn } from "@multica/ui/lib/utils"
+
+interface DotSphereProps {
+  className?: string
+  dotGap?: number
+  motion?: "travel" | "wave"
+  sphereCount?: number
+  sphereRadius?: number | `${number}%`
+  dotRadiusMax?: number
+  speed?: number
+  bgColor?: string
+  dotColor?: string
+  followMouse?: boolean
+}
+
+interface Point {
+  x: number
+  y: number
+}
+
+interface DotSphereState {
+  center: Point
+  anchor: Point
+  from: Point
+  to: Point
+  progress: number
+  radius: number
+  radiusScale: number
+  dotRadiusMax: number
+  dotScale: number
+  speed: number
+  color: string
+  opacity: number
+}
+
+interface SpherePath {
+  from: Point
+  to: Point
+}
+
+interface SphereProfile {
+  phase: number
+  radius: number
+  dot: number
+  speed: number
+}
+
+const DOT_SPHERE_COLOR = "rgba(129, 140, 248, 0.5)"
+
+// Declared as non-empty tuples so index 0 stays a safe fallback under
+// noUncheckedIndexedAccess when these are cycled by sphere index.
+const SPHERE_PATHS: readonly [SpherePath, ...SpherePath[]] = [
+  {
+    from: { x: -0.28, y: 0.18 },
+    to: { x: 1.28, y: 0.78 },
+  },
+  {
+    from: { x: 1.28, y: 0.82 },
+    to: { x: -0.28, y: 0.22 },
+  },
+  {
+    from: { x: 0.18, y: 1.24 },
+    to: { x: 0.82, y: -0.24 },
+  },
+]
+
+const WAVE_SPHERE_ANCHORS: readonly [Point, ...Point[]] = [
+  { x: 0.28, y: 0.08 },
+  { x: 0.76, y: 0.28 },
+  { x: 0.38, y: 0.5 },
+  { x: 0.78, y: 0.72 },
+  { x: 0.34, y: 0.93 },
+]
+
+const SPHERE_PROFILES: readonly [SphereProfile, ...SphereProfile[]] = [
+  { phase: 0, radius: 1, dot: 1, speed: 1 },
+  { phase: 0.2, radius: 0.94, dot: 0.96, speed: 1 },
+  { phase: 0.4, radius: 1, dot: 1, speed: 1 },
+  { phase: 0.6, radius: 0.94, dot: 0.96, speed: 1 },
+  { phase: 0.8, radius: 0.9, dot: 0.94, speed: 1 },
+]
+
+function clamp(value: number, min: number, max: number) {
+  return Math.min(Math.max(value, min), max)
+}
+
+function lerp(start: number, end: number, amount: number) {
+  return start + (end - start) * amount
+}
+
+function easeInOutSine(value: number) {
+  return 0.5 - Math.cos(value * Math.PI) * 0.5
+}
+
+function smoothstep(edge0: number, edge1: number, value: number) {
+  const t = clamp((value - edge0) / (edge1 - edge0), 0, 1)
+
+  return t * t * (3 - 2 * t)
+}
+
+function getTravelOpacity(progress: number) {
+  const fadeIn = smoothstep(0.03, 0.24, progress)
+  const fadeOut = 1 - smoothstep(0.76, 0.97, progress)
+
+  return Math.min(fadeIn, fadeOut)
+}
+
+function getWaveOpacity(progress: number) {
+  const pulse = (1 - Math.cos(progress * Math.PI * 2)) * 0.5
+
+  return 0.16 + Math.pow(pulse, 1.28) * 0.84
+}
+
+function resolveSphereRadius(
+  radius: NonNullable<DotSphereProps["sphereRadius"]>,
+  windowSize: { w: number; h: number }
+) {
+  if (typeof radius === "number") {
+    return radius
+  }
+
+  const percent = Number.parseFloat(radius)
+
+  if (Number.isNaN(percent)) {
+    return Math.max(windowSize.w, windowSize.h)
+  }
+
+  return Math.max(windowSize.w, windowSize.h) * (percent / 100)
+}
+
+export function DotSphere({
+  className,
+  dotGap = 20,
+  motion = "travel",
+  sphereCount = 3,
+  sphereRadius = 200,
+  dotRadiusMax = 3,
+  speed = 0.18,
+  bgColor = "oklch(0.145 0 0)",
+  dotColor = DOT_SPHERE_COLOR,
+  followMouse = false,
+}: DotSphereProps) {
+  const canvasRef = useRef<HTMLCanvasElement | null>(null)
+  const stateRef = useRef({
+    windowSize: { w: 0, h: 0 },
+    circleNumber: { x: 0, y: 0 },
+    posStart: { x: 0, y: 0 },
+    spheres: [] as DotSphereState[],
+    animationId: 0,
+  })
+
+  useEffect(() => {
+    const canvas = canvasRef.current
+
+    if (!canvas) {
+      return
+    }
+
+    const ctx = canvas.getContext("2d")
+
+    if (!ctx) {
+      return
+    }
+
+    const canvasElement = canvas
+    const context = ctx
+    const state = stateRef.current
+    const prefersReducedMotion = window.matchMedia(
+      "(prefers-reduced-motion: reduce)"
+    ).matches
+
+    state.spheres = createSpheres()
+
+    function createSpheres() {
+      const count = Math.max(1, sphereCount)
+
+      return Array.from({ length: count }, (_, index) => {
+        const path = SPHERE_PATHS[index % SPHERE_PATHS.length] ?? SPHERE_PATHS[0]
+        const anchor =
+          WAVE_SPHERE_ANCHORS[index % WAVE_SPHERE_ANCHORS.length] ??
+          WAVE_SPHERE_ANCHORS[0]
+        const profile =
+          SPHERE_PROFILES[index % SPHERE_PROFILES.length] ?? SPHERE_PROFILES[0]
+
+        return {
+          center: { x: 0, y: 0 },
+          anchor,
+          from: path.from,
+          to: path.to,
+          progress: profile.phase,
+          radius: 0,
+          radiusScale: profile.radius,
+          dotRadiusMax: 0,
+          dotScale: profile.dot,
+          speed: speed * profile.speed,
+          color: dotColor,
+          opacity: 0,
+        }
+      })
+    }
+
+    function setDotParams() {
+      state.circleNumber = {
+        x: Math.floor(state.windowSize.w / dotGap) + 2,
+        y: Math.floor(state.windowSize.h / dotGap) + 1,
+      }
+
+      state.posStart = {
+        x: Math.round(
+          (state.windowSize.w - (state.circleNumber.x - 1) * dotGap) / 2
+        ),
+        y: Math.round(
+          (state.windowSize.h - (state.circleNumber.y - 1) * dotGap) / 2
+        ),
+      }
+    }
+
+    function updateSpherePosition(sphere: DotSphereState) {
+      if (motion === "wave") {
+        sphere.center.x = sphere.anchor.x * state.windowSize.w
+        sphere.center.y = sphere.anchor.y * state.windowSize.h
+        sphere.opacity = getWaveOpacity(sphere.progress)
+        return
+      }
+
+      const easedProgress = easeInOutSine(sphere.progress)
+
+      sphere.center.x =
+        lerp(sphere.from.x, sphere.to.x, easedProgress) * state.windowSize.w
+      sphere.center.y =
+        lerp(sphere.from.y, sphere.to.y, easedProgress) * state.windowSize.h
+      sphere.opacity = getTravelOpacity(sphere.progress)
+    }
+
+    function handleResize() {
+      const bounds = canvasElement.getBoundingClientRect()
+      const dpr = Math.min(window.devicePixelRatio || 1, 2)
+      const width = Math.max(1, Math.floor(bounds.width))
+      const height = Math.max(1, Math.floor(bounds.height))
+
+      state.windowSize = { w: width, h: height }
+      canvasElement.width = Math.floor(width * dpr)
+      canvasElement.height = Math.floor(height * dpr)
+      context.setTransform(dpr, 0, 0, dpr, 0, 0)
+
+      setDotParams()
+      state.spheres.forEach((sphere) => {
+        sphere.radius =
+          resolveSphereRadius(sphereRadius, state.windowSize) *
+          sphere.radiusScale
+        sphere.dotRadiusMax = dotRadiusMax * sphere.dotScale
+        updateSpherePosition(sphere)
+      })
+    }
+
+    function getDistance(
+      x: number,
+      y: number,
+      center: { x: number; y: number }
+    ) {
+      const distanceX = x - center.x
+      const distanceY = y - center.y
+
+      return Math.sqrt(distanceX * distanceX + distanceY * distanceY)
+    }
+
+    function getAlpha(distance: number, radius: number) {
+      return 1 - distance / radius
+    }
+
+    function getRadius(alpha: number, radiusMax: number) {
+      return radiusMax * alpha
+    }
+
+    function drawDots() {
+      context.beginPath()
+      context.fillStyle = bgColor
+      context.rect(0, 0, state.windowSize.w, state.windowSize.h)
+      context.fill()
+      context.closePath()
+      context.globalCompositeOperation = "lighter"
+
+      state.spheres.forEach((sphere) => {
+        if (sphere.opacity <= 0.01) {
+          return
+        }
+
+        for (let i = 0; i < state.circleNumber.x; i++) {
+          for (let j = 0; j < state.circleNumber.y; j++) {
+            const gapX = j % 2 === 0 ? -dotGap / 2 : 0
+            const x = state.posStart.x + gapX + i * dotGap
+            const y = state.posStart.y + j * dotGap
+            const distance = getDistance(x, y, sphere.center)
+
+            if (distance <= sphere.radius) {
+              const alpha = getAlpha(distance, sphere.radius)
+              const radius = getRadius(alpha, sphere.dotRadiusMax)
+
+              context.save()
+              context.globalAlpha = alpha * sphere.opacity
+              context.beginPath()
+              context.fillStyle = sphere.color
+              context.arc(x, y, radius, 0, 2 * Math.PI, false)
+              context.fill()
+              context.closePath()
+              context.restore()
+            }
+          }
+        }
+      })
+
+      context.globalCompositeOperation = "source-over"
+    }
+
+    function moveSpheres(event: MouseEvent | null) {
+      const bounds = event ? canvasElement.getBoundingClientRect() : null
+
+      state.spheres.forEach((sphere, index) => {
+        if (event && followMouse && index === 0 && bounds) {
+          sphere.center.x = event.clientX - bounds.left
+          sphere.center.y = event.clientY - bounds.top
+          sphere.opacity = 1
+          return
+        }
+
+        if (followMouse && index === 0) {
+          return
+        }
+
+        sphere.progress =
+          (sphere.progress +
+            sphere.speed * (motion === "wave" ? 0.0021 : 0.0035)) %
+          1
+        updateSpherePosition(sphere)
+      })
+    }
+
+    function render() {
+      if (!prefersReducedMotion) {
+        moveSpheres(null)
+      }
+
+      drawDots()
+    }
+
+    function draw() {
+      state.animationId = window.requestAnimationFrame(draw)
+      render()
+    }
+
+    function handleMouseMove(event: MouseEvent) {
+      if (followMouse) {
+        moveSpheres(event)
+      }
+    }
+
+    const resizeObserver = new ResizeObserver(handleResize)
+
+    resizeObserver.observe(canvasElement)
+    handleResize()
+    render()
+
+    if (!prefersReducedMotion) {
+      draw()
+    }
+
+    if (followMouse) {
+      window.addEventListener("mousemove", handleMouseMove)
+    }
+
+    return () => {
+      resizeObserver.disconnect()
+      window.removeEventListener("mousemove", handleMouseMove)
+      window.cancelAnimationFrame(state.animationId)
+    }
+  }, [
+    dotGap,
+    motion,
+    sphereCount,
+    sphereRadius,
+    dotRadiusMax,
+    speed,
+    bgColor,
+    dotColor,
+    followMouse,
+  ])
+
+  return (
+    <canvas
+      ref={canvasRef}
+      data-slot="dot-sphere"
+      className={cn("absolute inset-0 h-full w-full", className)}
+    />
+  )
+}

--- a/packages/ui/components/blocks/onboarding-3/components/image-upload-field.tsx
+++ b/packages/ui/components/blocks/onboarding-3/components/image-upload-field.tsx
@@ -1,0 +1,100 @@
+"use client"
+
+import { useFileUpload } from "@multica/ui/hooks/use-file-upload"
+
+import {
+  Avatar,
+  AvatarFallback,
+  AvatarImage,
+} from "@multica/ui/components/ui/avatar"
+import { Button } from "@multica/ui/components/ui/button"
+import { UserCircle } from "lucide-react"
+
+interface ImageUploadFieldProps {
+  inputId?: string
+  defaultImage?: string
+  alt?: string
+  description?: string
+  uploadLabel?: string
+  replaceLabel?: string
+}
+
+export function ImageUploadField({
+  inputId,
+  defaultImage,
+  alt = "Uploaded image",
+  description,
+  uploadLabel = "Upload photo",
+  replaceLabel = "Replace photo",
+}: ImageUploadFieldProps) {
+  const [{ files }, { removeFile, openFileDialog, getInputProps }] =
+    useFileUpload({
+      accept: "image/*",
+    })
+
+  const currentFile = files[0] ?? null
+  const previewUrl = currentFile?.preview ?? defaultImage ?? null
+  const fileName = currentFile?.file.name
+  const hasImage = Boolean(previewUrl)
+
+  const handleCancelUpload = () => {
+    if (!currentFile) {
+      return
+    }
+
+    removeFile(currentFile.id)
+  }
+
+  return (
+    <div className="flex items-center gap-3">
+      <Avatar className="size-12 border">
+        {previewUrl ? (
+          <AvatarImage src={previewUrl} alt={fileName ?? alt} />
+        ) : null}
+        <AvatarFallback className="bg-muted text-muted-foreground">
+          <UserCircle aria-hidden="true" className="size-5 opacity-60" />
+        </AvatarFallback>
+      </Avatar>
+
+      <div className="flex min-w-0 flex-col gap-1.5">
+        <div className="flex flex-wrap items-center gap-2">
+          <div className="relative inline-flex">
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              onClick={openFileDialog}
+              aria-haspopup="dialog"
+            >
+              {hasImage ? replaceLabel : uploadLabel}
+            </Button>
+            <input
+              {...getInputProps({ id: inputId })}
+              className="hidden"
+              aria-hidden="true"
+              tabIndex={-1}
+            />
+          </div>
+
+          {currentFile ? (
+            <Button
+              type="button"
+              variant="ghost"
+              size="sm"
+              onClick={handleCancelUpload}
+              className="text-muted-foreground hover:text-foreground"
+            >
+              Cancel
+            </Button>
+          ) : null}
+        </div>
+
+        {description ? (
+          <p className="text-muted-foreground text-caption">
+            {description}
+          </p>
+        ) : null}
+      </div>
+    </div>
+  )
+}

--- a/packages/ui/components/blocks/onboarding-3/components/onboarding-logo.tsx
+++ b/packages/ui/components/blocks/onboarding-3/components/onboarding-logo.tsx
@@ -1,0 +1,34 @@
+import { cn } from "@multica/ui/lib/utils"
+import { Item, ItemMedia } from "@multica/ui/components/ui/item"
+
+export function OnboardingLogo({ className }: { className?: string }) {
+  return (
+    <div className={cn("inline-flex items-center gap-2", className)}>
+      <Item
+        className="bg-primary text-primary-foreground flex size-7 shrink-0 items-center justify-center p-1.5"
+        aria-hidden="true"
+      >
+        <ItemMedia variant="icon" className="size-auto">
+          <svg
+            width="50"
+            height="50"
+            viewBox="25.668 25.1352 49.6644 50"
+            fill="none"
+            xmlns="http://www.w3.org/2000/svg"
+            className="size-[0.95rem]"
+          >
+            <circle cx="70.634" cy="29.8334" r="4.69799" fill="currentColor" />
+            <path
+              fillRule="evenodd"
+              clipRule="evenodd"
+              d="M25.668 57.0144V29.8332C25.668 27.2386 27.7713 25.1352 30.366 25.1352C32.9606 25.1352 35.0639 27.2386 35.0639 29.8332V57.0144C35.0639 61.833 38.9702 65.7392 43.7888 65.7392H57.2116C62.0302 65.7392 65.9364 61.833 65.9364 57.0144V43.7258C65.9364 41.1312 68.0398 39.0278 70.6344 39.0278C73.229 39.0278 75.3324 41.1312 75.3324 43.7258V57.0144C75.3324 67.0222 67.2194 75.1352 57.2116 75.1352H43.7888C33.7809 75.1352 25.668 67.0222 25.668 57.0144Z"
+              fill="currentColor"
+            />
+          </svg>
+        </ItemMedia>
+      </Item>
+
+      <span className="text-body-lg font-medium">ReUI</span>
+    </div>
+  )
+}

--- a/packages/ui/components/blocks/onboarding-3/components/onboarding-stepper.tsx
+++ b/packages/ui/components/blocks/onboarding-3/components/onboarding-stepper.tsx
@@ -1,0 +1,87 @@
+import {
+  Stepper,
+  StepperDescription,
+  StepperIndicator,
+  StepperItem,
+  StepperNav,
+  StepperSeparator,
+  StepperTitle,
+  StepperTrigger,
+} from "@multica/ui/components/reui/stepper"
+import type { OnboardingStep } from "./data"
+import { CheckIcon } from "lucide-react"
+
+const SIDEBAR_STEP_DESCRIPTIONS: Record<string, string> = {
+  profile: "Identity and timezone.",
+  role: "Role and use case.",
+  source: "Discovery source.",
+  workspace: "Workspace details.",
+  goals: "First workflows.",
+  invite: "Optional teammates.",
+}
+
+export function OnboardingStepper({
+  currentStep,
+  isComplete,
+  onStepChange,
+  steps,
+}: {
+  currentStep: number
+  isComplete: boolean
+  onStepChange: (step: number) => void
+  steps: readonly OnboardingStep[]
+}) {
+  return (
+    <Stepper
+      value={currentStep}
+      onValueChange={onStepChange}
+      orientation="vertical"
+      className="flex w-full flex-col items-start justify-center gap-0"
+      indicators={{
+        completed: (
+          <CheckIcon className="size-3" aria-hidden="true" />
+        ),
+      }}
+    >
+      <StepperNav aria-label="Onboarding progress" className="w-full">
+        {steps.map((step) => {
+          const description =
+            SIDEBAR_STEP_DESCRIPTIONS[step.id] ?? step.description
+
+          return (
+            <StepperItem
+              key={step.id}
+              step={step.value}
+              completed={isComplete || currentStep > step.value}
+              className="relative items-start not-last:flex-1"
+            >
+              <StepperTrigger className="w-full items-start gap-3 pb-5 text-left last:pb-0">
+                <StepperIndicator className="mt-0.5 size-4 bg-transparent text-transparent ring-1 ring-white/35 data-[state=active]:bg-transparent data-[state=active]:ring-white/65 data-[state=completed]:bg-white data-[state=completed]:text-slate-950 data-[state=completed]:ring-white/75">
+                  {step.value === currentStep && !isComplete ? (
+                    <span
+                      className="block size-1.5 rounded-full bg-white"
+                      aria-hidden="true"
+                    />
+                  ) : (
+                    <span className="sr-only">{step.value}</span>
+                  )}
+                </StepperIndicator>
+                <div className="min-w-0 flex-1 text-left">
+                  <StepperTitle className="!text-label !leading-4 text-white data-[state=completed]:text-white/88 data-[state=inactive]:text-white/72">
+                    {step.label}
+                  </StepperTitle>
+                  <StepperDescription className="mt-0.5 max-w-none !text-caption !leading-4 text-white/50 data-[state=active]:text-white/60">
+                    {description}
+                  </StepperDescription>
+                </div>
+              </StepperTrigger>
+              {step.value < steps.length ? (
+                <StepperSeparator className="absolute top-6 bottom-1 left-2 -order-1 m-0 !h-[calc(100%-1.75rem)] w-px -translate-x-1/2 bg-white/20 group-data-[state=completed]/step:bg-white/55" />
+              ) : null}
+            </StepperItem>
+          )
+        })}
+      </StepperNav>
+    </Stepper>
+  )
+}

--- a/packages/ui/components/blocks/onboarding-3/components/onboarding.tsx
+++ b/packages/ui/components/blocks/onboarding-3/components/onboarding.tsx
@@ -1,0 +1,966 @@
+"use client"
+
+import { useState, type CSSProperties, type FormEvent } from "react"
+import { IconStack } from "@multica/ui/components/reui/icon-stack"
+
+import { cn } from "@multica/ui/lib/utils"
+import { Button } from "@multica/ui/components/ui/button"
+import { Checkbox } from "@multica/ui/components/ui/checkbox"
+import {
+  Combobox,
+  ComboboxCollection,
+  ComboboxContent,
+  ComboboxEmpty,
+  ComboboxGroup,
+  ComboboxInput,
+  ComboboxItem,
+  ComboboxLabel,
+  ComboboxList,
+  ComboboxSeparator,
+} from "@multica/ui/components/ui/combobox"
+import {
+  Field,
+  FieldContent,
+  FieldDescription,
+  FieldGroup,
+  FieldLabel,
+  FieldLegend,
+  FieldSet,
+} from "@multica/ui/components/ui/field"
+import { Input } from "@multica/ui/components/ui/input"
+import { Item, ItemGroup, ItemMedia } from "@multica/ui/components/ui/item"
+import {
+  RadioGroup,
+  RadioGroupItem,
+} from "@multica/ui/components/ui/radio-group"
+import {
+  Select,
+  SelectContent,
+  SelectGroup,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@multica/ui/components/ui/select"
+import { Spinner } from "@multica/ui/components/ui/spinner"
+import { Switch } from "@multica/ui/components/ui/switch"
+import {
+  DEFAULT_INVITES,
+  DISCOVERY_SOURCE_OPTIONS,
+  GOAL_OPTIONS,
+  INVITE_ROLE_OPTIONS,
+  ONBOARDING_STEPS,
+  ROLE_OPTIONS,
+  TEAM_SIZE_OPTIONS,
+  type DiscoverySourceValue,
+  type GoalValue,
+  type InviteRoleValue,
+  type InviteRow,
+  type RoleValue,
+  type TeamSizeValue,
+} from "./data"
+import { DotSphere } from "./dot-sphere"
+import { ImageUploadField } from "./image-upload-field"
+import { OnboardingLogo } from "./onboarding-logo"
+import { OnboardingStepper } from "./onboarding-stepper"
+import { CheckIcon, PlusIcon, CircleCheckIcon, ArrowLeftIcon, RocketIcon } from "lucide-react"
+
+const TOTAL_STEPS = ONBOARDING_STEPS.length
+const TIMEZONE_GROUPS = [
+  {
+    value: "Americas",
+    items: [
+      "(GMT-5) New York",
+      "(GMT-8) Los Angeles",
+      "(GMT-6) Chicago",
+      "(GMT-5) Toronto",
+      "(GMT-8) Vancouver",
+      "(GMT-3) Sao Paulo",
+    ],
+  },
+  {
+    value: "Europe",
+    items: [
+      "(GMT+0) London",
+      "(GMT+1) Paris",
+      "(GMT+1) Berlin",
+      "(GMT+1) Rome",
+      "(GMT+1) Madrid",
+      "(GMT+1) Amsterdam",
+    ],
+  },
+  {
+    value: "Asia/Pacific",
+    items: [
+      "(GMT+9) Tokyo",
+      "(GMT+8) Shanghai",
+      "(GMT+8) Singapore",
+      "(GMT+4) Dubai",
+      "(GMT+11) Sydney",
+      "(GMT+9) Seoul",
+    ],
+  },
+]
+
+function getInviteRoleLabel(role: InviteRoleValue) {
+  return (
+    INVITE_ROLE_OPTIONS.find((option) => option.value === role)?.label ?? role
+  )
+}
+
+function StepHeading({
+  title,
+  description,
+}: {
+  title: string
+  description: string
+}) {
+  return (
+    <div className="flex max-w-[30rem] flex-col gap-1.5" aria-live="polite">
+      <h1 className="text-foreground text-title-lg font-semibold text-balance sm:text-display-sm">
+        {title}
+      </h1>
+      <p className="text-muted-foreground text-body text-pretty">
+        {description}
+      </p>
+    </div>
+  )
+}
+
+function ProfileStep({
+  fullName,
+  jobTitle,
+  marketingOptIn,
+  onFullNameChange,
+  onJobTitleChange,
+  onMarketingOptInChange,
+}: {
+  fullName: string
+  jobTitle: string
+  marketingOptIn: boolean
+  onFullNameChange: (name: string) => void
+  onJobTitleChange: (title: string) => void
+  onMarketingOptInChange: (checked: boolean) => void
+}) {
+  return (
+    <FieldSet>
+      <FieldLegend className="sr-only">Profile details</FieldLegend>
+      <FieldGroup className="gap-4">
+        <Field>
+          <ImageUploadField
+            inputId="onboarding-3-profile-photo"
+            alt="Sam Rivera"
+            uploadLabel="Upload photo"
+            replaceLabel="Replace photo"
+            description="PNG or JPG, at least 400 x 400 px, up to 10 MB."
+          />
+        </Field>
+
+        <FieldGroup className="gap-4">
+          <Field className="gap-2">
+            <FieldLabel htmlFor="onboarding-3-name">
+              Full name <span className="text-destructive">*</span>
+            </FieldLabel>
+            <Input
+              id="onboarding-3-name"
+              value={fullName}
+              onChange={(event) => onFullNameChange(event.target.value)}
+              autoComplete="name"
+            />
+          </Field>
+
+          <Field className="gap-2">
+            <FieldLabel htmlFor="onboarding-3-title">Job title</FieldLabel>
+            <Input
+              id="onboarding-3-title"
+              value={jobTitle}
+              onChange={(event) => onJobTitleChange(event.target.value)}
+              autoComplete="organization-title"
+            />
+          </Field>
+
+          <Field className="gap-2">
+            <FieldLabel htmlFor="onboarding-3-timezone">Timezone</FieldLabel>
+            <Combobox items={TIMEZONE_GROUPS}>
+              <ComboboxInput
+                id="onboarding-3-timezone"
+                placeholder="Select a timezone"
+                className="w-full"
+              />
+              <ComboboxContent className="w-(--anchor-width) min-w-(--anchor-width)">
+                <ComboboxEmpty>No timezones found.</ComboboxEmpty>
+                <ComboboxList>
+                  {(group) => (
+                    <ComboboxGroup key={group.value} items={group.items}>
+                      <ComboboxLabel>{group.value}</ComboboxLabel>
+                      <ComboboxCollection>
+                        {(item) => (
+                          <ComboboxItem key={item} value={item}>
+                            {item}
+                          </ComboboxItem>
+                        )}
+                      </ComboboxCollection>
+                      <ComboboxSeparator className="group-last/combobox-group:hidden" />
+                    </ComboboxGroup>
+                  )}
+                </ComboboxList>
+              </ComboboxContent>
+            </Combobox>
+          </Field>
+        </FieldGroup>
+
+        <Field orientation="horizontal" className="gap-2.5">
+          <Checkbox
+            id="onboarding-3-marketing"
+            checked={marketingOptIn}
+            onCheckedChange={(checked) =>
+              onMarketingOptInChange(checked === true)
+            }
+          />
+          <FieldLabel
+            htmlFor="onboarding-3-marketing"
+            className="text-muted-foreground font-normal"
+          >
+            Send me product updates and workspace tips.
+          </FieldLabel>
+        </Field>
+      </FieldGroup>
+    </FieldSet>
+  )
+}
+
+function RoleStep({
+  role,
+  onRoleChange,
+}: {
+  role: RoleValue
+  onRoleChange: (role: RoleValue) => void
+}) {
+  return (
+    <FieldSet className="gap-3">
+      <FieldLegend variant="label">Select one</FieldLegend>
+      <RadioGroup
+        value={role}
+        onValueChange={(value) => onRoleChange(value as RoleValue)}
+        aria-label="Select your role"
+      >
+        <ItemGroup className="gap-2">
+          {ROLE_OPTIONS.map((option) => {
+            const fieldId = `onboarding-3-role-${option.value}`
+
+            return (
+              <Item key={option.value} variant="outline" size="sm">
+                <Field orientation="horizontal" className="w-full gap-3">
+                  <RadioGroupItem id={fieldId} value={option.value} />
+                  <FieldLabel
+                    htmlFor={fieldId}
+                    className="items-center leading-none"
+                  >
+                    <span className="truncate font-medium">{option.label}</span>
+                  </FieldLabel>
+                </Field>
+              </Item>
+            )
+          })}
+        </ItemGroup>
+      </RadioGroup>
+    </FieldSet>
+  )
+}
+
+function SourceStep({
+  source,
+  otherSource,
+  onSourceChange,
+  onOtherSourceChange,
+}: {
+  source: DiscoverySourceValue | ""
+  otherSource: string
+  onSourceChange: (source: DiscoverySourceValue) => void
+  onOtherSourceChange: (source: string) => void
+}) {
+  return (
+    <FieldSet className="gap-4">
+      <FieldLegend className="sr-only">Discovery source</FieldLegend>
+      <FieldGroup
+        className="flex-row flex-wrap gap-2"
+        aria-label="How did you hear about us?"
+      >
+        {DISCOVERY_SOURCE_OPTIONS.map((option) => {
+          const selected = option.value === source
+
+          return (
+            <Button
+              key={option.value}
+              type="button"
+              variant="outline"
+              size="lg"
+              aria-pressed={selected}
+              className={cn(selected && "border-primary/30 bg-primary/5")}
+              onClick={() => onSourceChange(option.value)}
+            >
+              <span
+                className={cn(
+                  "text-muted-foreground flex shrink-0 items-center [&_svg]:size-4",
+                  selected && "text-primary"
+                )}
+              >
+                {option.icon}
+              </span>
+              <span>{option.label}</span>
+              {selected ? (
+                <CheckIcon className="size-4 shrink-0" aria-hidden="true" />
+              ) : null}
+            </Button>
+          )
+        })}
+      </FieldGroup>
+
+      {source === "other" ? (
+        <Field className="max-w-sm gap-2">
+          <FieldLabel htmlFor="onboarding-3-source-other-text">
+            Where did you hear about ReUI?
+          </FieldLabel>
+          <Input
+            id="onboarding-3-source-other-text"
+            value={otherSource}
+            onChange={(event) => onOtherSourceChange(event.target.value)}
+            placeholder="Type the source"
+            autoComplete="off"
+          />
+        </Field>
+      ) : null}
+    </FieldSet>
+  )
+}
+
+function WorkspaceStep({
+  workspaceName,
+  workspaceSlug,
+  teamSize,
+  onWorkspaceNameChange,
+  onWorkspaceSlugChange,
+  onTeamSizeChange,
+}: {
+  workspaceName: string
+  workspaceSlug: string
+  teamSize: TeamSizeValue
+  onWorkspaceNameChange: (value: string) => void
+  onWorkspaceSlugChange: (value: string) => void
+  onTeamSizeChange: (value: TeamSizeValue) => void
+}) {
+  return (
+    <FieldSet>
+      <FieldLegend className="sr-only">Workspace setup</FieldLegend>
+      <FieldGroup className="gap-5">
+        <FieldGroup className="gap-4">
+          <Field className="gap-2">
+            <FieldLabel htmlFor="onboarding-3-workspace">
+              Workspace name <span className="text-destructive">*</span>
+            </FieldLabel>
+            <Input
+              id="onboarding-3-workspace"
+              value={workspaceName}
+              onChange={(event) => onWorkspaceNameChange(event.target.value)}
+              autoComplete="organization"
+            />
+          </Field>
+
+          <Field className="gap-2">
+            <FieldLabel htmlFor="onboarding-3-url">
+              Workspace URL <span className="text-destructive">*</span>
+            </FieldLabel>
+            <Input
+              id="onboarding-3-url"
+              value={workspaceSlug}
+              onChange={(event) => onWorkspaceSlugChange(event.target.value)}
+              autoComplete="off"
+            />
+            <FieldDescription>
+              Your workspace will open at app.reui.dev/
+              {workspaceSlug.trim() || "workspace"}.
+            </FieldDescription>
+          </Field>
+        </FieldGroup>
+
+        <FieldSet className="gap-5">
+          <FieldLegend variant="label" className="mb-4">
+            How many people will use this workspace?
+          </FieldLegend>
+          <FieldGroup
+            className="flex-row flex-wrap gap-2"
+            aria-label="Workspace team size"
+          >
+            {TEAM_SIZE_OPTIONS.map((option) => {
+              const selected = option.value === teamSize
+
+              return (
+                <Button
+                  key={option.value}
+                  type="button"
+                  variant="outline"
+                  aria-pressed={selected}
+                  className={cn(
+                    "relative overflow-visible px-5",
+                    selected && "border-primary/30 bg-primary/5"
+                  )}
+                  onClick={() => onTeamSizeChange(option.value)}
+                >
+                  <span>{option.label}</span>
+                  {selected ? (
+                    <Item
+                      render={<span />}
+                      className="bg-primary text-primary-foreground ring-background absolute -top-2 -right-2 flex size-5 items-center justify-center rounded-full p-0 ring-2"
+                    >
+                      <ItemMedia variant="icon" className="size-auto">
+                        <CheckIcon className="size-3" aria-hidden="true" />
+                      </ItemMedia>
+                    </Item>
+                  ) : null}
+                </Button>
+              )
+            })}
+          </FieldGroup>
+        </FieldSet>
+      </FieldGroup>
+    </FieldSet>
+  )
+}
+
+function GoalsStep({
+  goals,
+  onGoalToggle,
+}: {
+  goals: GoalValue[]
+  onGoalToggle: (goal: GoalValue, checked: boolean) => void
+}) {
+  return (
+    <FieldSet className="gap-3">
+      <FieldLegend variant="label">Select one or more</FieldLegend>
+      <ItemGroup className="gap-2">
+        {GOAL_OPTIONS.map((option) => {
+          const selected = goals.includes(option.value)
+          const fieldId = `onboarding-3-goal-${option.value}`
+
+          return (
+            <Item key={option.value} variant="outline" size="sm">
+              <Field orientation="horizontal" className="w-full gap-3">
+                <Checkbox
+                  id={fieldId}
+                  checked={selected}
+                  onCheckedChange={(checked) =>
+                    onGoalToggle(option.value, checked === true)
+                  }
+                />
+                <FieldLabel
+                  htmlFor={fieldId}
+                  className="items-center leading-none"
+                >
+                  <span className="truncate font-medium">{option.label}</span>
+                </FieldLabel>
+              </Field>
+            </Item>
+          )
+        })}
+      </ItemGroup>
+    </FieldSet>
+  )
+}
+
+function InviteRoleSelect({
+  id,
+  value,
+  onValueChange,
+}: {
+  id: string
+  value: InviteRoleValue
+  onValueChange: (value: InviteRoleValue) => void
+}) {
+  return (
+    <Select
+      items={INVITE_ROLE_OPTIONS}
+      value={value}
+      onValueChange={(nextValue) =>
+        nextValue && onValueChange(nextValue as InviteRoleValue)
+      }
+    >
+      <SelectTrigger id={id} className="w-full">
+        <SelectValue>
+          {(item: InviteRoleValue) => getInviteRoleLabel(item)}
+        </SelectValue>
+      </SelectTrigger>
+      <SelectContent
+        align="start"
+        alignItemWithTrigger={false}
+        className="w-64 min-w-(--anchor-width)"
+      >
+        <SelectGroup>
+          {INVITE_ROLE_OPTIONS.map((option) => (
+            <SelectItem key={option.value} value={option.value}>
+              <span className="flex min-w-0 flex-col items-start gap-px">
+                <span className="font-medium">{option.label}</span>
+                <small className="text-muted-foreground line-clamp-1 text-caption">
+                  {option.description}
+                </small>
+              </span>
+            </SelectItem>
+          ))}
+        </SelectGroup>
+      </SelectContent>
+    </Select>
+  )
+}
+
+function InviteStep({
+  invites,
+  sendInviteDigest,
+  onAddInvite,
+  onInviteEmailChange,
+  onInviteRoleChange,
+  onSendInviteDigestChange,
+}: {
+  invites: InviteRow[]
+  sendInviteDigest: boolean
+  onAddInvite: () => void
+  onInviteEmailChange: (inviteId: string, email: string) => void
+  onInviteRoleChange: (inviteId: string, role: InviteRoleValue) => void
+  onSendInviteDigestChange: (checked: boolean) => void
+}) {
+  return (
+    <FieldSet>
+      <FieldLegend className="sr-only">Invite teammates</FieldLegend>
+      <FieldGroup className="gap-5">
+        <div className="grid gap-3">
+          <div className="text-muted-foreground hidden grid-cols-[minmax(0,1fr)_9rem] gap-3 px-1 text-caption font-medium sm:grid">
+            <span>Email</span>
+            <span>Role</span>
+          </div>
+          {invites.map((invite, index) => {
+            const emailId = `onboarding-3-invite-email-${invite.id}`
+            const roleId = `onboarding-3-invite-role-${invite.id}`
+
+            return (
+              <div
+                key={invite.id}
+                className="grid grid-cols-1 gap-3 sm:grid-cols-[minmax(0,1fr)_9rem]"
+              >
+                <Field>
+                  <FieldLabel htmlFor={emailId} className="sr-only">
+                    Invitee {index + 1} email
+                  </FieldLabel>
+                  <Input
+                    id={emailId}
+                    type="email"
+                    value={invite.email}
+                    onChange={(event) =>
+                      onInviteEmailChange(invite.id, event.target.value)
+                    }
+                    placeholder="teammate@company.com"
+                    autoComplete="email"
+                  />
+                </Field>
+                <Field>
+                  <FieldLabel htmlFor={roleId} className="sr-only">
+                    Invitee {index + 1} role
+                  </FieldLabel>
+                  <InviteRoleSelect
+                    id={roleId}
+                    value={invite.role}
+                    onValueChange={(role) =>
+                      onInviteRoleChange(invite.id, role)
+                    }
+                  />
+                </Field>
+              </div>
+            )
+          })}
+          <div className="flex justify-end">
+            <Button
+              type="button"
+              variant="link"
+              className="h-auto w-fit px-1"
+              onClick={onAddInvite}
+            >
+              <PlusIcon aria-hidden="true" data-icon="inline-start" />
+              Add another
+            </Button>
+          </div>
+        </div>
+
+        <Field orientation="horizontal" className="gap-3">
+          <FieldContent className="gap-0.5">
+            <FieldLabel htmlFor="onboarding-3-send-digest">
+              Send invitation summary
+            </FieldLabel>
+            <FieldDescription>Include workspace details.</FieldDescription>
+          </FieldContent>
+          <Switch
+            id="onboarding-3-send-digest"
+            checked={sendInviteDigest}
+            onCheckedChange={onSendInviteDigestChange}
+          />
+        </Field>
+      </FieldGroup>
+    </FieldSet>
+  )
+}
+
+function SuccessStep({
+  workspaceName,
+  onReviewSetup,
+}: {
+  workspaceName: string
+  onReviewSetup: () => void
+}) {
+  const displayName = workspaceName.trim() || "Workspace"
+
+  return (
+    <div className="mx-auto flex w-full max-w-sm flex-1 flex-col">
+      <div className="flex flex-1 flex-col justify-center">
+        <div
+          className="mx-auto flex h-28 w-full items-center justify-center"
+          aria-hidden="true"
+        >
+          <IconStack
+            className="text-primary h-24 w-22"
+            style={
+              {
+                "--icon-stack-content-x": "70%",
+                "--icon-stack-content-y": "57%",
+              } as CSSProperties
+            }
+          >
+            <CircleCheckIcon className="text-primary size-5" strokeWidth="1.8" aria-hidden="true" />
+          </IconStack>
+        </div>
+
+        <div className="mx-auto mt-3 max-w-sm text-center">
+          <h1 className="text-foreground text-display-sm font-semibold tracking-tight">
+            {displayName} is ready
+          </h1>
+          <p className="text-muted-foreground mt-2 text-body leading-6">
+            Your workspace is set up and ready for the first project.
+          </p>
+        </div>
+      </div>
+
+      <div className="mt-auto flex flex-col gap-2 pt-8">
+        <Button type="button" className="w-full">
+          Open {displayName}
+        </Button>
+        <Button
+          type="button"
+          variant="ghost"
+          className="w-full"
+          onClick={onReviewSetup}
+        >
+          Review setup
+        </Button>
+      </div>
+    </div>
+  )
+}
+
+function OnboardingSidebar({
+  currentStep,
+  isComplete,
+  canGoBack,
+  onBack,
+  onStepChange,
+}: {
+  currentStep: number
+  isComplete: boolean
+  canGoBack: boolean
+  onBack: () => void
+  onStepChange: (step: number) => void
+}) {
+  return (
+    <aside className="relative z-10 flex min-h-[25rem] w-full shrink-0 px-4 py-4 sm:px-5 sm:py-5 lg:min-h-svh lg:w-[22rem] lg:px-5 lg:py-5">
+      <div className="dark bg-background text-foreground ring-border relative isolate flex min-h-full w-full overflow-hidden rounded-2xl px-5 py-5 ring-1">
+        <div
+          aria-hidden="true"
+          className="bg-background pointer-events-none absolute inset-0 overflow-hidden"
+        >
+          <DotSphere
+            dotGap={19}
+            motion="wave"
+            sphereCount={5}
+            sphereRadius="20%"
+            dotRadiusMax={1.9}
+            speed={0.4}
+          />
+        </div>
+
+        <div className="relative flex min-h-full w-full flex-col">
+          <header className="flex min-h-9 items-center justify-between gap-3">
+            <OnboardingLogo className="[&_span]:text-slate-50 [&>div]:bg-slate-50 [&>div]:text-slate-950" />
+            {canGoBack ? (
+              <Button
+                type="button"
+                variant="ghost"
+                size="icon-sm"
+                className="text-white/65 hover:bg-white/10 hover:text-white"
+                onClick={onBack}
+                aria-label="Back to previous step"
+              >
+                <ArrowLeftIcon aria-hidden="true" />
+              </Button>
+            ) : null}
+          </header>
+
+          <div className="flex flex-1 items-center justify-center px-2 py-10 sm:px-3 sm:py-12 lg:px-2 lg:py-16">
+            <OnboardingStepper
+              currentStep={currentStep}
+              isComplete={isComplete}
+              onStepChange={onStepChange}
+              steps={ONBOARDING_STEPS}
+            />
+          </div>
+
+          <footer className="flex min-h-8 shrink-0 items-end justify-between gap-4 text-caption">
+            <button
+              type="button"
+              className="rounded-sm text-left text-white/60 hover:text-white focus-visible:ring-2 focus-visible:ring-white/45 focus-visible:outline-none"
+            >
+              Terms of Service
+            </button>
+            <button
+              type="button"
+              className="rounded-sm text-right text-white/60 hover:text-white focus-visible:ring-2 focus-visible:ring-white/45 focus-visible:outline-none"
+            >
+              Help Center
+            </button>
+          </footer>
+        </div>
+      </div>
+    </aside>
+  )
+}
+
+export function Onboarding() {
+  const [currentStep, setCurrentStep] = useState(1)
+  const [fullName, setFullName] = useState("Sam Rivera")
+  const [jobTitle, setJobTitle] = useState("Product Lead")
+  const [marketingOptIn, setMarketingOptIn] = useState(true)
+  const [role, setRole] = useState<RoleValue>("developer")
+  const [discoverySource, setDiscoverySource] =
+    useState<DiscoverySourceValue>("linkedin")
+  const [discoveryOther, setDiscoveryOther] = useState("")
+  const [workspaceName, setWorkspaceName] = useState("ReUI Labs")
+  const [workspaceSlug, setWorkspaceSlug] = useState("northstar")
+  const [teamSize, setTeamSize] = useState<TeamSizeValue>("team")
+  const [goals, setGoals] = useState<GoalValue[]>(["roadmaps", "sprints"])
+  const [invites, setInvites] = useState<InviteRow[]>(DEFAULT_INVITES)
+  const [sendInviteDigest, setSendInviteDigest] = useState(true)
+  const [isSubmitting, setIsSubmitting] = useState(false)
+  const [isComplete, setIsComplete] = useState(false)
+
+  const currentStepMeta = ONBOARDING_STEPS[currentStep - 1] ?? ONBOARDING_STEPS[0]
+  const isFinalStep = currentStep === TOTAL_STEPS
+  const canSkip = currentStep > 1 && currentStep < TOTAL_STEPS
+  const canContinue =
+    (currentStepMeta.id !== "profile" || fullName.trim().length > 0) &&
+    (currentStepMeta.id !== "workspace" ||
+      (workspaceName.trim().length > 0 && workspaceSlug.trim().length > 0)) &&
+    (currentStepMeta.id !== "goals" || goals.length > 0)
+
+  function goToStep(step: number) {
+    setIsComplete(false)
+    setCurrentStep(Math.min(Math.max(step, 1), TOTAL_STEPS))
+  }
+
+  function handleGoalToggle(goal: GoalValue, checked: boolean) {
+    setGoals((currentGoals) => {
+      if (checked) {
+        return currentGoals.includes(goal)
+          ? currentGoals
+          : [...currentGoals, goal]
+      }
+
+      return currentGoals.filter((currentGoal) => currentGoal !== goal)
+    })
+  }
+
+  function handleAddInvite() {
+    setInvites((currentInvites) => [
+      ...currentInvites,
+      {
+        id: `invite-${currentInvites.length + 1}`,
+        email: "",
+        role: "member",
+      },
+    ])
+  }
+
+  function handleInviteEmailChange(inviteId: string, email: string) {
+    setInvites((currentInvites) =>
+      currentInvites.map((invite) =>
+        invite.id === inviteId ? { ...invite, email } : invite
+      )
+    )
+  }
+
+  function handleInviteRoleChange(inviteId: string, nextRole: InviteRoleValue) {
+    setInvites((currentInvites) =>
+      currentInvites.map((invite) =>
+        invite.id === inviteId ? { ...invite, role: nextRole } : invite
+      )
+    )
+  }
+
+  function completeOnboarding() {
+    if (isSubmitting) {
+      return
+    }
+
+    setIsSubmitting(true)
+
+    window.setTimeout(() => {
+      setIsSubmitting(false)
+      setIsComplete(true)
+    }, 700)
+  }
+
+  function handleSkip() {
+    if (!canSkip) {
+      return
+    }
+
+    goToStep(currentStep + 1)
+  }
+
+  function handleStepNavigation(step: number) {
+    if (isComplete || step <= currentStep) {
+      goToStep(step)
+    }
+  }
+
+  function handleSubmit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault()
+
+    if (!canContinue) {
+      return
+    }
+
+    if (!isFinalStep) {
+      goToStep(currentStep + 1)
+      return
+    }
+
+    completeOnboarding()
+  }
+
+  return (
+    <main className="text-foreground bg-background relative isolate flex min-h-svh w-full flex-col lg:flex-row">
+      <OnboardingSidebar
+        currentStep={currentStep}
+        isComplete={isComplete}
+        canGoBack={!isComplete && currentStep > 1}
+        onBack={() => goToStep(currentStep - 1)}
+        onStepChange={handleStepNavigation}
+      />
+
+      <section className="relative z-10 flex min-w-0 flex-1 items-center justify-center px-6 py-8 sm:px-10 lg:px-14 lg:py-10">
+        <div className="flex min-h-[34rem] w-full max-w-[28rem] flex-col sm:min-h-[36rem]">
+          {isComplete ? (
+            <SuccessStep
+              workspaceName={workspaceName}
+              onReviewSetup={() => {
+                setIsComplete(false)
+                setCurrentStep(TOTAL_STEPS)
+              }}
+            />
+          ) : (
+            <form
+              className="flex min-h-[inherit] flex-col"
+              onSubmit={handleSubmit}
+            >
+              <div className="flex flex-col gap-8 pt-2 sm:pt-6">
+                <StepHeading
+                  title={currentStepMeta.title}
+                  description={currentStepMeta.description}
+                />
+
+                {currentStepMeta.id === "profile" ? (
+                  <ProfileStep
+                    fullName={fullName}
+                    jobTitle={jobTitle}
+                    marketingOptIn={marketingOptIn}
+                    onFullNameChange={setFullName}
+                    onJobTitleChange={setJobTitle}
+                    onMarketingOptInChange={setMarketingOptIn}
+                  />
+                ) : null}
+
+                {currentStepMeta.id === "role" ? (
+                  <RoleStep role={role} onRoleChange={setRole} />
+                ) : null}
+
+                {currentStepMeta.id === "source" ? (
+                  <SourceStep
+                    source={discoverySource}
+                    otherSource={discoveryOther}
+                    onSourceChange={setDiscoverySource}
+                    onOtherSourceChange={setDiscoveryOther}
+                  />
+                ) : null}
+
+                {currentStepMeta.id === "workspace" ? (
+                  <WorkspaceStep
+                    workspaceName={workspaceName}
+                    workspaceSlug={workspaceSlug}
+                    teamSize={teamSize}
+                    onWorkspaceNameChange={setWorkspaceName}
+                    onWorkspaceSlugChange={setWorkspaceSlug}
+                    onTeamSizeChange={setTeamSize}
+                  />
+                ) : null}
+
+                {currentStepMeta.id === "goals" ? (
+                  <GoalsStep goals={goals} onGoalToggle={handleGoalToggle} />
+                ) : null}
+
+                {currentStepMeta.id === "invite" ? (
+                  <InviteStep
+                    invites={invites}
+                    sendInviteDigest={sendInviteDigest}
+                    onAddInvite={handleAddInvite}
+                    onInviteEmailChange={handleInviteEmailChange}
+                    onInviteRoleChange={handleInviteRoleChange}
+                    onSendInviteDigestChange={setSendInviteDigest}
+                  />
+                ) : null}
+              </div>
+
+              <div className="mt-auto flex flex-col gap-2 pt-10 pb-2">
+                <Button
+                  type="submit"
+                  className="w-full"
+                  disabled={!canContinue || isSubmitting}
+                >
+                  {isSubmitting ? (
+                    <Spinner data-icon="inline-start" aria-hidden="true" />
+                  ) : isFinalStep ? (
+                    <RocketIcon aria-hidden="true" data-icon="inline-start" />
+                  ) : null}
+                  {isFinalStep ? "Create workspace" : "Continue"}
+                </Button>
+
+                {canSkip ? (
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    className="w-full"
+                    disabled={isSubmitting}
+                    onClick={handleSkip}
+                  >
+                    Skip
+                  </Button>
+                ) : null}
+              </div>
+            </form>
+          )}
+        </div>
+      </section>
+    </main>
+  )
+}

--- a/packages/ui/components/blocks/onboarding-3/page.tsx
+++ b/packages/ui/components/blocks/onboarding-3/page.tsx
@@ -1,0 +1,5 @@
+import { Onboarding } from "./components/onboarding"
+
+export function Page() {
+  return <Onboarding />
+}

--- a/packages/ui/components/reui/icon-stack.tsx
+++ b/packages/ui/components/reui/icon-stack.tsx
@@ -1,0 +1,90 @@
+import { cn } from "@multica/ui/lib/utils"
+
+type IconStackProps = React.ComponentProps<"div">
+
+function IconStack({ className, children, style, ...props }: IconStackProps) {
+  return (
+    <div
+      data-slot="icon-stack"
+      className={cn(
+        "text-foreground **:data-[slot=icon-stack-layer]:fill-background relative h-20 w-18",
+        className
+      )}
+      style={
+        {
+          "--icon-stack-content-x": "71%",
+          "--icon-stack-content-y": "58%",
+          ...style,
+        } as React.CSSProperties
+      }
+      {...props}
+    >
+      <svg
+        aria-hidden="true"
+        viewBox="0 0 72 81"
+        fill="none"
+        className="h-full w-full overflow-visible"
+      >
+        <ellipse
+          cx="36"
+          cy="76"
+          rx="30"
+          ry="7"
+          fill="currentColor"
+          fillOpacity="0.055"
+          className="blur-[4px]"
+        />
+
+        <IconStackLayer opacity="0.4" />
+        <IconStackLayer opacity="0.6" x={13.65} y={6.04} />
+        <IconStackLayer opacity="0.8" x={27.32} y={12.08} active />
+      </svg>
+
+      {children ? (
+        <div
+          data-slot="icon-stack-content"
+          className="text-muted-foreground pointer-events-none absolute top-[var(--icon-stack-content-y)] left-[var(--icon-stack-content-x)] flex -translate-x-1/2 -translate-y-1/2 scale-x-90 -skew-y-26 items-center justify-center"
+        >
+          {children}
+        </div>
+      ) : null}
+    </div>
+  )
+}
+
+function IconStackLayer({
+  active = false,
+  opacity,
+  x = 0,
+  y = 0,
+}: {
+  active?: boolean
+  opacity: string
+  x?: number
+  y?: number
+}) {
+  return (
+    <g opacity={opacity} transform={`translate(${x} ${y})`}>
+      <path
+        data-slot="icon-stack-layer"
+        d="M42.2538 2.046C41.4408 1.6325 40.3965 1.6677 39.2612 2.2424L7.9616 18.1934C5.3895 19.5039 3.301 23.1064 3.301 26.2322V64.3226C3.301 66.0677 3.9458 67.2943 4.962 67.8199L1.8363 66.229C0.8201 65.7104 0.1753 64.4771 0.1753 62.732V24.6412C0.1753 21.5085 2.2638 17.913 4.8359 16.6024L36.1355 0.6515C37.2778 0.0698 38.322 0.0416 39.128 0.4551L42.2538 2.046Z"
+        stroke="currentColor"
+        strokeOpacity={active ? "0.3" : "0.2"}
+        strokeWidth="0.5"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+      <path
+        data-slot="icon-stack-layer"
+        d="M42.2545 2.0456C43.2707 2.5643 43.9155 3.7979 43.9155 5.543V43.6337C43.9155 46.7665 41.827 50.3616 39.2549 51.6722L7.9554 67.6235C6.813 68.2052 5.7687 68.2331 4.9628 67.8196C3.9465 67.301 3.3018 66.0673 3.3018 64.3222V26.2318C3.3018 23.0991 5.3903 19.5036 7.9624 18.193L39.2619 2.2421C40.4043 1.6604 41.4486 1.6321 42.2545 2.0456Z"
+        stroke="currentColor"
+        strokeOpacity={active ? "0.3" : "0.2"}
+        strokeWidth="0.5"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </g>
+  )
+}
+
+export { IconStack, type IconStackProps }

--- a/packages/ui/components/reui/stepper.tsx
+++ b/packages/ui/components/reui/stepper.tsx
@@ -1,0 +1,472 @@
+"use client"
+
+import type { HTMLAttributes, ReactElement } from "react"
+import {
+  Children,
+  createContext,
+  isValidElement,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react"
+import { mergeProps } from "@base-ui/react/merge-props"
+import { useRender } from "@base-ui/react/use-render"
+
+import { cn } from "@multica/ui/lib/utils"
+
+// Types
+type StepperOrientation = "horizontal" | "vertical"
+type StepState = "active" | "completed" | "inactive" | "loading"
+type StepIndicators = {
+  active?: React.ReactNode
+  completed?: React.ReactNode
+  inactive?: React.ReactNode
+  loading?: React.ReactNode
+}
+
+interface StepperContextValue {
+  activeStep: number
+  setActiveStep: (step: number) => void
+  stepsCount: number
+  orientation: StepperOrientation
+  registerTrigger: (node: HTMLButtonElement | null) => void
+  triggerNodes: HTMLButtonElement[]
+  focusNext: (currentIdx: number) => void
+  focusPrev: (currentIdx: number) => void
+  focusFirst: () => void
+  focusLast: () => void
+  indicators: StepIndicators
+}
+
+interface StepItemContextValue {
+  step: number
+  state: StepState
+  isDisabled: boolean
+  isLoading: boolean
+}
+
+const StepperContext = createContext<StepperContextValue | undefined>(undefined)
+const StepItemContext = createContext<StepItemContextValue | undefined>(
+  undefined
+)
+
+function useStepper() {
+  const ctx = useContext(StepperContext)
+  if (!ctx) throw new Error("useStepper must be used within a Stepper")
+  return ctx
+}
+
+function useStepItem() {
+  const ctx = useContext(StepItemContext)
+  if (!ctx) throw new Error("useStepItem must be used within a StepperItem")
+  return ctx
+}
+
+interface StepperProps extends HTMLAttributes<HTMLDivElement> {
+  defaultValue?: number
+  value?: number
+  onValueChange?: (value: number) => void
+  orientation?: StepperOrientation
+  indicators?: StepIndicators
+}
+
+function Stepper({
+  defaultValue = 1,
+  value,
+  onValueChange,
+  orientation = "horizontal",
+  className,
+  children,
+  indicators = {},
+  ...props
+}: StepperProps) {
+  const [activeStep, setActiveStep] = useState(defaultValue)
+  const [triggerNodes, setTriggerNodes] = useState<HTMLButtonElement[]>([])
+
+  // Register/unregister triggers
+  const registerTrigger = useCallback((node: HTMLButtonElement | null) => {
+    setTriggerNodes((prev) => {
+      if (node && !prev.includes(node)) {
+        return [...prev, node]
+      } else if (!node && prev.includes(node!)) {
+        return prev.filter((n) => n !== node)
+      } else {
+        return prev
+      }
+    })
+  }, [])
+
+  const handleSetActiveStep = useCallback(
+    (step: number) => {
+      if (value === undefined) {
+        setActiveStep(step)
+      }
+      onValueChange?.(step)
+    },
+    [value, onValueChange]
+  )
+
+  const currentStep = value ?? activeStep
+
+  // Keyboard navigation logic
+  const focusTrigger = (idx: number) => {
+    if (triggerNodes[idx]) triggerNodes[idx].focus()
+  }
+  const focusNext = (currentIdx: number) =>
+    focusTrigger((currentIdx + 1) % triggerNodes.length)
+  const focusPrev = (currentIdx: number) =>
+    focusTrigger((currentIdx - 1 + triggerNodes.length) % triggerNodes.length)
+  const focusFirst = () => focusTrigger(0)
+  const focusLast = () => focusTrigger(triggerNodes.length - 1)
+
+  // Context value
+  const contextValue = useMemo<StepperContextValue>(
+    () => ({
+      activeStep: currentStep,
+      setActiveStep: handleSetActiveStep,
+      stepsCount: Children.toArray(children).filter(
+        (child): child is ReactElement =>
+          isValidElement(child) &&
+          (child.type as { displayName?: string }).displayName === "StepperItem"
+      ).length,
+      orientation,
+      registerTrigger,
+      focusNext,
+      focusPrev,
+      focusFirst,
+      focusLast,
+      triggerNodes,
+      indicators,
+    }),
+    [
+      currentStep,
+      handleSetActiveStep,
+      children,
+      orientation,
+      registerTrigger,
+      triggerNodes,
+    ]
+  )
+
+  return (
+    <StepperContext.Provider value={contextValue}>
+      <div
+        role="tablist"
+        aria-orientation={orientation}
+        data-slot="stepper"
+        className={cn("w-full", className)}
+        data-orientation={orientation}
+        {...props}
+      >
+        {children}
+      </div>
+    </StepperContext.Provider>
+  )
+}
+
+interface StepperItemProps extends React.HTMLAttributes<HTMLDivElement> {
+  step: number
+  completed?: boolean
+  disabled?: boolean
+  loading?: boolean
+}
+
+function StepperItem({
+  step,
+  completed = false,
+  disabled = false,
+  loading = false,
+  className,
+  children,
+  ...props
+}: StepperItemProps) {
+  const { activeStep } = useStepper()
+
+  const state: StepState =
+    completed || step < activeStep
+      ? "completed"
+      : activeStep === step
+        ? "active"
+        : "inactive"
+
+  const isLoading = loading && step === activeStep
+
+  return (
+    <StepItemContext.Provider
+      value={{ step, state, isDisabled: disabled, isLoading }}
+    >
+      <div
+        data-slot="stepper-item"
+        className={cn(
+          "group/step flex items-center justify-center not-last:flex-1 group-data-[orientation=horizontal]/stepper-nav:flex-row group-data-[orientation=vertical]/stepper-nav:flex-col",
+          className
+        )}
+        data-state={state}
+        {...(isLoading ? { "data-loading": true } : {})}
+        {...props}
+      >
+        {children}
+      </div>
+    </StepItemContext.Provider>
+  )
+}
+
+type StepperTriggerProps = useRender.ComponentProps<"button">
+
+function StepperTrigger({
+  className,
+  children,
+  tabIndex,
+  render,
+  ...props
+}: StepperTriggerProps) {
+  const { state, isLoading } = useStepItem()
+  const stepperCtx = useStepper()
+  const {
+    setActiveStep,
+    activeStep,
+    registerTrigger,
+    triggerNodes,
+    focusNext,
+    focusPrev,
+    focusFirst,
+    focusLast,
+  } = stepperCtx
+  const { step, isDisabled } = useStepItem()
+  const isSelected = activeStep === step
+  const id = `stepper-tab-${step}`
+  const panelId = `stepper-panel-${step}`
+
+  // Register this trigger for keyboard navigation
+  const btnRef = useRef<HTMLButtonElement>(null)
+  useEffect(() => {
+    if (btnRef.current) {
+      registerTrigger(btnRef.current)
+    }
+  }, [btnRef.current])
+
+  // Find our index among triggers for navigation
+  const myIdx = useMemo(
+    () =>
+      triggerNodes.findIndex((n: HTMLButtonElement) => n === btnRef.current),
+    [triggerNodes, btnRef.current]
+  )
+
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLButtonElement>) => {
+    switch (e.key) {
+      case "ArrowRight":
+      case "ArrowDown":
+        e.preventDefault()
+        if (myIdx !== -1 && focusNext) focusNext(myIdx)
+        break
+      case "ArrowLeft":
+      case "ArrowUp":
+        e.preventDefault()
+        if (myIdx !== -1 && focusPrev) focusPrev(myIdx)
+        break
+      case "Home":
+        e.preventDefault()
+        if (focusFirst) focusFirst()
+        break
+      case "End":
+        e.preventDefault()
+        if (focusLast) focusLast()
+        break
+      case "Enter":
+      case " ":
+        e.preventDefault()
+        setActiveStep(step)
+        break
+    }
+  }
+
+  const defaultProps = {
+    role: "tab",
+    id,
+    "aria-selected": isSelected,
+    "aria-controls": panelId,
+    tabIndex: typeof tabIndex === "number" ? tabIndex : isSelected ? 0 : -1,
+    "data-slot": "stepper-trigger",
+    "data-state": state,
+    "data-loading": isLoading,
+    className: cn(
+      "focus-visible:border-ring focus-visible:ring-ring/50 inline-flex cursor-pointer items-center outline-none focus-visible:z-10 focus-visible:ring-3 disabled:pointer-events-none disabled:opacity-60",
+      "gap-2.5 rounded-full",
+      className
+    ),
+    onClick: () => setActiveStep(step),
+    onKeyDown: handleKeyDown,
+    disabled: isDisabled,
+    children,
+  }
+
+  return useRender({
+    defaultTagName: "button",
+    render,
+    ref: btnRef,
+    props: mergeProps<"button">(defaultProps, props),
+  })
+}
+
+function StepperIndicator({
+  children,
+  className,
+}: React.ComponentProps<"div">) {
+  const { state, isLoading } = useStepItem()
+  const { indicators } = useStepper()
+
+  return (
+    <div
+      data-slot="stepper-indicator"
+      data-state={state}
+      className={cn(
+        "border-background bg-accent text-accent-foreground data-[state=completed]:bg-primary data-[state=completed]:text-primary-foreground data-[state=active]:bg-primary data-[state=active]:text-primary-foreground relative flex size-6 shrink-0 items-center justify-center overflow-hidden",
+        "rounded-full text-caption",
+        className
+      )}
+    >
+      <div className="absolute">
+        {indicators &&
+        ((isLoading && indicators.loading) ||
+          (state === "completed" && indicators.completed) ||
+          (state === "active" && indicators.active) ||
+          (state === "inactive" && indicators.inactive))
+          ? (isLoading && indicators.loading) ||
+            (state === "completed" && indicators.completed) ||
+            (state === "active" && indicators.active) ||
+            (state === "inactive" && indicators.inactive)
+          : children}
+      </div>
+    </div>
+  )
+}
+
+function StepperSeparator({ className }: React.ComponentProps<"div">) {
+  const { state } = useStepItem()
+
+  return (
+    <div
+      data-slot="stepper-separator"
+      data-state={state}
+      className={cn(
+        "bg-muted rounded-sm m-0.5 group-data-[orientation=horizontal]/stepper-nav:h-0.5 group-data-[orientation=horizontal]/stepper-nav:flex-1 group-data-[orientation=vertical]/stepper-nav:h-12 group-data-[orientation=vertical]/stepper-nav:w-0.5",
+        className
+      )}
+    />
+  )
+}
+
+function StepperTitle({ children, className }: React.ComponentProps<"h3">) {
+  const { state } = useStepItem()
+
+  return (
+    <h3
+      data-slot="stepper-title"
+      data-state={state}
+      className={cn("text-body leading-none font-medium", className)}
+    >
+      {children}
+    </h3>
+  )
+}
+
+function StepperDescription({
+  children,
+  className,
+}: React.ComponentProps<"div">) {
+  const { state } = useStepItem()
+
+  return (
+    <div
+      data-slot="stepper-description"
+      data-state={state}
+      className={cn("text-muted-foreground text-body", className)}
+    >
+      {children}
+    </div>
+  )
+}
+
+function StepperNav({ children, className }: React.ComponentProps<"nav">) {
+  const { activeStep, orientation } = useStepper()
+
+  return (
+    <nav
+      data-slot="stepper-nav"
+      data-state={activeStep}
+      data-orientation={orientation}
+      className={cn(
+        "group/stepper-nav inline-flex data-[orientation=horizontal]:w-full data-[orientation=horizontal]:flex-row data-[orientation=vertical]:flex-col",
+        className
+      )}
+    >
+      {children}
+    </nav>
+  )
+}
+
+function StepperPanel({ children, className }: React.ComponentProps<"div">) {
+  const { activeStep } = useStepper()
+
+  return (
+    <div
+      data-slot="stepper-panel"
+      data-state={activeStep}
+      className={cn("w-full", className)}
+    >
+      {children}
+    </div>
+  )
+}
+
+interface StepperContentProps extends React.ComponentProps<"div"> {
+  value: number
+  forceMount?: boolean
+}
+
+function StepperContent({
+  value,
+  forceMount,
+  children,
+  className,
+}: StepperContentProps) {
+  const { activeStep } = useStepper()
+  const isActive = value === activeStep
+
+  if (!forceMount && !isActive) {
+    return null
+  }
+
+  return (
+    <div
+      data-slot="stepper-content"
+      data-state={activeStep}
+      className={cn("w-full", className, !isActive && forceMount && "hidden")}
+      hidden={!isActive && forceMount}
+    >
+      {children}
+    </div>
+  )
+}
+
+export {
+  useStepper,
+  useStepItem,
+  Stepper,
+  StepperItem,
+  StepperTrigger,
+  StepperIndicator,
+  StepperSeparator,
+  StepperTitle,
+  StepperDescription,
+  StepperPanel,
+  StepperContent,
+  StepperNav,
+  type StepperProps,
+  type StepperItemProps,
+  type StepperTriggerProps,
+  type StepperContentProps,
+}

--- a/packages/ui/hooks/use-file-upload.ts
+++ b/packages/ui/hooks/use-file-upload.ts
@@ -1,0 +1,423 @@
+"use client"
+
+import type React from "react"
+import {
+  useCallback,
+  useRef,
+  useState,
+  type ChangeEvent,
+  type DragEvent,
+  type InputHTMLAttributes,
+} from "react"
+
+export type FileMetadata = {
+  name: string
+  size: number
+  type: string
+  url: string
+  id: string
+}
+
+export type FileWithPreview = {
+  file: File | FileMetadata
+  id: string
+  preview?: string
+}
+
+export type FileUploadOptions = {
+  maxFiles?: number // Only used when multiple is true, defaults to Infinity
+  maxSize?: number // in bytes
+  accept?: string
+  multiple?: boolean // Defaults to false
+  initialFiles?: FileMetadata[]
+  onFilesChange?: (files: FileWithPreview[]) => void // Callback when files change
+  onFilesAdded?: (addedFiles: FileWithPreview[]) => void // Callback when new files are added
+  onError?: (errors: string[]) => void
+}
+
+export type FileUploadState = {
+  files: FileWithPreview[]
+  isDragging: boolean
+  errors: string[]
+}
+
+export type FileUploadActions = {
+  addFiles: (files: FileList | File[]) => void
+  removeFile: (id: string) => void
+  clearFiles: () => void
+  clearErrors: () => void
+  handleDragEnter: (e: DragEvent<HTMLElement>) => void
+  handleDragLeave: (e: DragEvent<HTMLElement>) => void
+  handleDragOver: (e: DragEvent<HTMLElement>) => void
+  handleDrop: (e: DragEvent<HTMLElement>) => void
+  handleFileChange: (e: ChangeEvent<HTMLInputElement>) => void
+  openFileDialog: () => void
+  getInputProps: (
+    props?: InputHTMLAttributes<HTMLInputElement>
+  ) => InputHTMLAttributes<HTMLInputElement> & {
+    ref: React.Ref<HTMLInputElement>
+  }
+}
+
+export const useFileUpload = (
+  options: FileUploadOptions = {}
+): [FileUploadState, FileUploadActions] => {
+  const {
+    maxFiles = Number.POSITIVE_INFINITY,
+    maxSize = Number.POSITIVE_INFINITY,
+    accept = "*",
+    multiple = false,
+    initialFiles = [],
+    onFilesChange,
+    onFilesAdded,
+    onError,
+  } = options
+
+  const [state, setState] = useState<FileUploadState>({
+    files: initialFiles.map((file) => ({
+      file,
+      id: file.id,
+      preview: file.url,
+    })),
+    isDragging: false,
+    errors: [],
+  })
+
+  const inputRef = useRef<HTMLInputElement>(null)
+
+  const validateFile = useCallback(
+    (file: File | FileMetadata): string | null => {
+      if (file instanceof File) {
+        if (file.size > maxSize) {
+          return `File "${file.name}" exceeds the maximum size of ${formatBytes(maxSize)}.`
+        }
+      } else {
+        if (file.size > maxSize) {
+          return `File "${file.name}" exceeds the maximum size of ${formatBytes(maxSize)}.`
+        }
+      }
+
+      if (accept !== "*") {
+        const acceptedTypes = accept.split(",").map((type) => type.trim())
+        const fileType = file instanceof File ? file.type || "" : file.type
+        const fileExtension = `.${file instanceof File ? file.name.split(".").pop() : file.name.split(".").pop()}`
+
+        const isAccepted = acceptedTypes.some((type) => {
+          if (type.startsWith(".")) {
+            return fileExtension.toLowerCase() === type.toLowerCase()
+          }
+          if (type.endsWith("/*")) {
+            const baseType = type.split("/")[0]
+            return fileType.startsWith(`${baseType}/`)
+          }
+          return fileType === type
+        })
+
+        if (!isAccepted) {
+          return `File "${file instanceof File ? file.name : file.name}" is not an accepted file type.`
+        }
+      }
+
+      return null
+    },
+    [accept, maxSize]
+  )
+
+  const createPreview = useCallback(
+    (file: File | FileMetadata): string | undefined => {
+      if (file instanceof File) {
+        return URL.createObjectURL(file)
+      }
+      return file.url
+    },
+    []
+  )
+
+  const generateUniqueId = useCallback((file: File | FileMetadata): string => {
+    if (file instanceof File) {
+      return `${file.name}-${Date.now()}-${Math.random().toString(36).substring(2, 9)}`
+    }
+    return file.id
+  }, [])
+
+  const clearFiles = useCallback(() => {
+    setState((prev) => {
+      // Clean up object URLs
+      for (const file of prev.files) {
+        if (
+          file.preview &&
+          file.file instanceof File &&
+          file.file.type.startsWith("image/")
+        ) {
+          URL.revokeObjectURL(file.preview)
+        }
+      }
+
+      if (inputRef.current) {
+        inputRef.current.value = ""
+      }
+
+      const newState = {
+        ...prev,
+        files: [],
+        errors: [],
+      }
+
+      onFilesChange?.(newState.files)
+      return newState
+    })
+  }, [onFilesChange])
+
+  const addFiles = useCallback(
+    (newFiles: FileList | File[]) => {
+      if (!newFiles || newFiles.length === 0) return
+
+      const newFilesArray = Array.from(newFiles)
+      const errors: string[] = []
+
+      // Clear existing errors when new files are uploaded
+      setState((prev) => ({ ...prev, errors: [] }))
+
+      // In single file mode, clear existing files first
+      if (!multiple) {
+        clearFiles()
+      }
+
+      // Check if adding these files would exceed maxFiles (only in multiple mode)
+      if (
+        multiple &&
+        maxFiles !== Number.POSITIVE_INFINITY &&
+        state.files.length + newFilesArray.length > maxFiles
+      ) {
+        errors.push(`You can only upload a maximum of ${maxFiles} files.`)
+        onError?.(errors)
+        setState((prev) => ({ ...prev, errors }))
+        return
+      }
+
+      const validFiles: FileWithPreview[] = []
+
+      for (const file of newFilesArray) {
+        // Only check for duplicates if multiple files are allowed
+        if (multiple) {
+          const isDuplicate = state.files.some(
+            (existingFile) =>
+              existingFile.file.name === file.name &&
+              existingFile.file.size === file.size
+          )
+
+          // Skip duplicate files silently
+          if (isDuplicate) {
+            return
+          }
+        }
+
+        // Check file size
+        if (file.size > maxSize) {
+          errors.push(
+            multiple
+              ? `Some files exceed the maximum size of ${formatBytes(maxSize)}.`
+              : `File exceeds the maximum size of ${formatBytes(maxSize)}.`
+          )
+          continue
+        }
+
+        const error = validateFile(file)
+        if (error) {
+          errors.push(error)
+        } else {
+          validFiles.push({
+            file,
+            id: generateUniqueId(file),
+            preview: createPreview(file),
+          })
+        }
+      }
+
+      // Only update state if we have valid files to add
+      if (validFiles.length > 0) {
+        // Call the onFilesAdded callback with the newly added valid files
+        onFilesAdded?.(validFiles)
+
+        setState((prev) => {
+          const newFiles = !multiple
+            ? validFiles
+            : [...prev.files, ...validFiles]
+          onFilesChange?.(newFiles)
+          return {
+            ...prev,
+            files: newFiles,
+            errors,
+          }
+        })
+      } else if (errors.length > 0) {
+        onError?.(errors)
+        setState((prev) => ({
+          ...prev,
+          errors,
+        }))
+      }
+
+      // Reset input value after handling files
+      if (inputRef.current) {
+        inputRef.current.value = ""
+      }
+    },
+    [
+      state.files,
+      maxFiles,
+      multiple,
+      maxSize,
+      validateFile,
+      createPreview,
+      generateUniqueId,
+      clearFiles,
+      onFilesChange,
+      onFilesAdded,
+    ]
+  )
+
+  const removeFile = useCallback(
+    (id: string) => {
+      setState((prev) => {
+        const fileToRemove = prev.files.find((file) => file.id === id)
+        if (
+          fileToRemove &&
+          fileToRemove.preview &&
+          fileToRemove.file instanceof File &&
+          fileToRemove.file.type.startsWith("image/")
+        ) {
+          URL.revokeObjectURL(fileToRemove.preview)
+        }
+
+        const newFiles = prev.files.filter((file) => file.id !== id)
+        onFilesChange?.(newFiles)
+
+        return {
+          ...prev,
+          files: newFiles,
+          errors: [],
+        }
+      })
+    },
+    [onFilesChange]
+  )
+
+  const clearErrors = useCallback(() => {
+    setState((prev) => ({
+      ...prev,
+      errors: [],
+    }))
+  }, [])
+
+  const handleDragEnter = useCallback((e: DragEvent<HTMLElement>) => {
+    e.preventDefault()
+    e.stopPropagation()
+    setState((prev) => ({ ...prev, isDragging: true }))
+  }, [])
+
+  const handleDragLeave = useCallback((e: DragEvent<HTMLElement>) => {
+    e.preventDefault()
+    e.stopPropagation()
+
+    if (e.currentTarget.contains(e.relatedTarget as Node)) {
+      return
+    }
+
+    setState((prev) => ({ ...prev, isDragging: false }))
+  }, [])
+
+  const handleDragOver = useCallback((e: DragEvent<HTMLElement>) => {
+    e.preventDefault()
+    e.stopPropagation()
+  }, [])
+
+  const handleDrop = useCallback(
+    (e: DragEvent<HTMLElement>) => {
+      e.preventDefault()
+      e.stopPropagation()
+      setState((prev) => ({ ...prev, isDragging: false }))
+
+      // Don't process files if the input is disabled
+      if (inputRef.current?.disabled) {
+        return
+      }
+
+      if (e.dataTransfer.files && e.dataTransfer.files.length > 0) {
+        // In single file mode, only use the first file
+        if (!multiple) {
+          const file = e.dataTransfer.files[0]
+          if (file) {
+            addFiles([file])
+          }
+        } else {
+          addFiles(e.dataTransfer.files)
+        }
+      }
+    },
+    [addFiles, multiple]
+  )
+
+  const handleFileChange = useCallback(
+    (e: ChangeEvent<HTMLInputElement>) => {
+      if (e.target.files && e.target.files.length > 0) {
+        addFiles(e.target.files)
+      }
+    },
+    [addFiles]
+  )
+
+  const openFileDialog = useCallback(() => {
+    if (inputRef.current) {
+      inputRef.current.click()
+    }
+  }, [])
+
+  const getInputProps = useCallback(
+    (props: InputHTMLAttributes<HTMLInputElement> = {}) => {
+      return {
+        ...props,
+        type: "file" as const,
+        onChange: handleFileChange,
+        accept: props.accept || accept,
+        multiple: props.multiple !== undefined ? props.multiple : multiple,
+        ref: inputRef,
+      }
+    },
+    [accept, multiple, handleFileChange]
+  )
+
+  return [
+    state,
+    {
+      addFiles,
+      removeFile,
+      clearFiles,
+      clearErrors,
+      handleDragEnter,
+      handleDragLeave,
+      handleDragOver,
+      handleDrop,
+      handleFileChange,
+      openFileDialog,
+      getInputProps,
+    },
+  ]
+}
+
+// Helper function to format bytes to human-readable format
+export const formatBytes = (bytes: number, decimals = 2): string => {
+  if (bytes === 0) return "0 Bytes"
+
+  const k = 1024
+  const dm = decimals < 0 ? 0 : decimals
+  const sizes = ["Bytes", "KB", "MB", "GB", "TB", "PB", "EB", "ZB", "YB"]
+
+  // Clamp so sizes beyond YB still resolve to a unit instead of undefined.
+  const i = Math.min(
+    Math.floor(Math.log(bytes) / Math.log(k)),
+    sizes.length - 1
+  )
+
+  return Number.parseFloat((bytes / k ** i).toFixed(dm)) + (sizes[i] ?? "Bytes")
+}

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -10,6 +10,8 @@
   "exports": {
     "./components/ui/*": "./components/ui/*.tsx",
     "./components/common/*": "./components/common/*.tsx",
+    "./components/reui/*": "./components/reui/*.tsx",
+    "./components/blocks/*": "./components/blocks/*.tsx",
     "./markdown": "./markdown/index.ts",
     "./markdown/*": "./markdown/*.tsx",
     "./markdown/linkify": "./markdown/linkify.ts",
@@ -29,6 +31,8 @@
   "dependencies": {
     "@base-ui/react": "^1.3.0",
     "@emoji-mart/data": "^1.2.1",
+    "@hugeicons/core-free-icons": "^4.2.3",
+    "@hugeicons/react": "^1.1.9",
     "@number-flow/react": "^0.6.1",
     "@tanstack/react-table": "catalog:",
     "@tanstack/react-virtual": "catalog:",
@@ -39,8 +43,8 @@
     "embla-carousel-react": "^8.6.0",
     "emoji-mart": "^5.6.0",
     "input-otp": "^1.4.2",
-    "linkify-it": "^5.0.0",
     "katex": "catalog:",
+    "linkify-it": "^5.0.0",
     "lucide-react": "catalog:",
     "motion": "^12.38.0",
     "next-themes": "^0.4.6",

--- a/packages/ui/tsconfig.json
+++ b/packages/ui/tsconfig.json
@@ -6,7 +6,9 @@
     "paths": {
       "@/lib/utils": ["./lib/utils.ts"],
       "@/hooks/*": ["./hooks/*"],
-      "@/components/ui/*": ["./components/ui/*"]
+      "@/components/ui/*": ["./components/ui/*"],
+      "@multica/ui/components": ["./components"],
+      "@multica/ui/lib": ["./lib"]
     }
   },
   "include": ["**/*.ts", "**/*.tsx"],

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -835,6 +835,12 @@ importers:
       '@emoji-mart/data':
         specifier: ^1.2.1
         version: 1.2.1
+      '@hugeicons/core-free-icons':
+        specifier: ^4.2.3
+        version: 4.2.3
+      '@hugeicons/react':
+        specifier: ^1.1.9
+        version: 1.1.9(react@19.2.3)
       '@number-flow/react':
         specifier: ^0.6.1
         version: 0.6.1(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
@@ -2340,6 +2346,14 @@ packages:
     engines: {node: '>=18.14.1'}
     peerDependencies:
       hono: ^4
+
+  '@hugeicons/core-free-icons@4.2.3':
+    resolution: {integrity: sha512-fpiU0qFZkv4ABi23xJ2m4qNr0BBfuIaYjPboN8WDA6aj9D+OzXa7eykxKOpACZRuGbDz1U9S5DsNx1d5KNnsgA==}
+
+  '@hugeicons/react@1.1.9':
+    resolution: {integrity: sha512-O+lWSWjbijoAvMCxn4K2bQWCGN5+mP1y5j+X99j23mXMj+s0X25fs71T6t9YJLaBodwmZdaewD27dzS/PiboQw==}
+    peerDependencies:
+      react: '>=16.0.0'
 
   '@humanfs/core@0.19.1':
     resolution: {integrity: sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==}
@@ -12191,6 +12205,12 @@ snapshots:
   '@hono/node-server@1.19.11(hono@4.12.8)':
     dependencies:
       hono: 4.12.8
+
+  '@hugeicons/core-free-icons@4.2.3': {}
+
+  '@hugeicons/react@1.1.9(react@19.2.3)':
+    dependencies:
+      react: 19.2.3
 
   '@humanfs/core@0.19.1': {}
 


### PR DESCRIPTION
Tests the ReUI install flow end-to-end and lands the block it produced. Ref MUL-5628.

The flow works, but not out of the box — three repo-config gaps blocked it and the vendored output needed conformance fixes before it would compile here.

## What the install did

`pnpm dlx shadcn@latest add @reui/onboarding-3` from `packages/ui`, answering `n` to every overwrite prompt so local component customizations survive. It created 7 block files plus `@reui/stepper`, `@reui/icon-stack`, and `use-file-upload`, and skipped the 15 base components (`avatar`, `button`, `field`, `combobox`, `select`, …) that already exist here — none were modified.

Import rewriting worked cleanly: `@/components/ui/button` → `@multica/ui/components/ui/button`. The registry's internal `@/app/(create)/components/icon-placeholder` placeholder resolved into real `lucide-react` imports from our `iconLibrary` setting. `@hugeicons/*` is a genuine new dependency — it supplies the brand icons (Google, LinkedIn, Reddit, YouTube) for the discovery-source step that lucide doesn't ship.

## Registry setup

- Registered the authenticated `@reui` registry in `packages/ui/components.json`.
- **tsconfig paths for the bare `components` / `lib` aliases.** The first install failed outright: `Could not resolve the following aliases: components, lib`. shadcn resolves `components.json` aliases through workspace package exports and tsconfig paths, and `@multica/ui/components` / `@multica/ui/lib` matched neither (we export `./components/ui/*` and `./lib/utils`, but nothing at those roots). This blocks *any* registry item targeting those roots, not just this block.
- **Flipped `rsc` to `true`.** With it `false`, shadcn strips `"use client"` on the way in. The first run silently landed `onboarding.tsx` and `dot-sphere.tsx` — both `useState`/`useRef`/canvas components — without the directive, which breaks them under the App Router. 44 of the 60 existing components in this package already carry it, so `rsc: false` was stale config.
- Exported `./components/reui/*` and `./components/blocks/*` so the installed files resolve for consumers.

## Conformance fixes on the vendored output

The block does not compile against this repo's settings as shipped:

- **`noUncheckedIndexedAccess`** — 20 errors. Fixed with non-empty tuple types for the cycled sphere/step constants (`readonly [T, ...T[]]`, so index 0 is a sound fallback), a guarded drop-file path, and a clamped unit index in `formatBytes`, which previously returned `"1.5undefined"` for sizes past YB.
- **`Select` requires `items`** — our local `select.tsx` deliberately makes it required ("Base UI renders the raw value unless Root receives an items label map"). The block passed a `SelectValue` function child instead.
- **Type scale** — `apps/web/app/type-scale.test.ts` flagged 15 off-scale sizes (`text-xs`, `text-sm`, `text-2xl`, `text-[0.8125rem]`, …). Moved onto the role-named steps, dropping `leading-*` utilities that became redundant once the token supplied the same line-height.

## Verification

- `pnpm typecheck` — 6/6 pass
- `pnpm lint` — 0 errors. 4 `react-hooks/exhaustive-deps` warnings remain inside the vendored `stepper.tsx` / `use-file-upload.ts`; left as upstream ships them so future re-installs stay a clean diff.
- `pnpm test` — `web` 22/22 (including the type-scale, text-contrast, and brand-variant guards), `desktop` 47/47, `docs` 4/4. The 8 `@multica/core` failures and the `views` `sidebar-resize` failure reproduce on a clean tree without this branch — pre-existing, unrelated.
- Rendered the block in jsdom to confirm the first step mounts. That was a throwaway check, not committed: the block is reference UI, and a test pinning vendored demo code would cost more than it protects.

## Notes for review

- The block is **not routed or imported by the product** — it lands as reference UI under `packages/ui/components/blocks/`.
- That placement is the CLI default and keeps the install reproducible, but it sits against the `packages/ui` = "atomic UI components only" rule in CLAUDE.md. If you'd rather this live in `packages/views/`, say so and I'll move it — it would mean hand-relocating on every re-install.
- `REUI_LICENSE_KEY` is a Pro credential. It stays in `packages/ui/.env.local` (already covered by the `.env*` gitignore) or your shell; nothing secret is committed. Documented in the CLAUDE.md UI Rules section.
