### PR TITLE
fix(daemon): honour HTTP(S)_PROXY when dialing the wakeup WebSocket

### DIFF
--- a/server/internal/daemon/wakeup.go
+++ b/server/internal/daemon/wakeup.go
@@ -119,7 +119,18 @@ func (d *Daemon) runTaskWakeupConnection(ctx context.Context, runtimeIDs []strin
 	// this WS connection gets identical capability gating (MUL-4257).
 	headers.Set("X-Client-Capabilities", daemonClientCapabilities())
 
-	dialer := websocket.Dialer{HandshakeTimeout: 10 * time.Second}
+	// A hand-built websocket.Dialer has Proxy == nil, which gorilla reads as
+	// "dial direct" — unlike websocket.DefaultDialer, it does not fall back to
+	// the environment. On a machine that only reaches the internet through a
+	// corporate egress proxy the handshake then always fails and the daemon
+	// silently degrades to HTTP polling. gorilla rewrites wss:// to https://
+	// before consulting Proxy, so HTTPS_PROXY applies to this dial. With no
+	// proxy variables set, ProxyFromEnvironment returns nil and the connection
+	// is direct, exactly as before.
+	dialer := websocket.Dialer{
+		HandshakeTimeout: 10 * time.Second,
+		Proxy:            http.ProxyFromEnvironment,
+	}
 	conn, _, err := dialer.DialContext(ctx, wsURL, headers)
 	if err != nil {
 		return 0, err

--- a/server/internal/daemon/wakeup_proxy_test.go
+++ b/server/internal/daemon/wakeup_proxy_test.go
@@ -1,0 +1,115 @@
+package daemon
+
+import (
+	"bufio"
+	"context"
+	"io"
+	"log/slog"
+	"net"
+	"os"
+	"os/exec"
+	"strings"
+	"testing"
+	"time"
+)
+
+const (
+	// The child process re-runs this same test with the proxy environment in
+	// place; the marker tells it which half of the test to execute.
+	wakeupProxyChildEnv = "MULTICA_TEST_WAKEUP_PROXY_CHILD"
+
+	// A non-loopback, permanently unresolvable host. Loopback targets are the
+	// wrong choice here: net/http's proxy resolver bypasses proxies for
+	// localhost/127.0.0.1, so a loopback target would be dialled direct even
+	// with the proxy wired up correctly.
+	wakeupProxyTargetHost = "wakeup.example.invalid"
+)
+
+// TestTaskWakeupDialUsesEnvironmentProxy pins that the daemon's wakeup
+// WebSocket honours HTTPS_PROXY. Without it, a daemon behind a corporate
+// egress proxy can never open the control connection and silently degrades to
+// HTTP polling.
+//
+// The test runs the dial in a child process because net/http resolves the
+// proxy environment exactly once per process (envProxyOnce) and caches the
+// result: by the time this test runs inside the package suite, some earlier
+// test has already primed that cache with "no proxy", and t.Setenv can no
+// longer influence it. A fresh process reads the environment we hand it.
+func TestTaskWakeupDialUsesEnvironmentProxy(t *testing.T) {
+	if os.Getenv(wakeupProxyChildEnv) == "1" {
+		dialWakeupThroughEnvProxy(t)
+		return
+	}
+
+	// Stand-in CONNECT proxy: one line of the request is all we need to know
+	// whether the dial was routed through it.
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	defer ln.Close()
+
+	requestLine := make(chan string, 1)
+	go func() {
+		conn, err := ln.Accept()
+		if err != nil {
+			return
+		}
+		defer conn.Close()
+		line, err := bufio.NewReader(conn).ReadString('\n')
+		if err != nil {
+			return
+		}
+		requestLine <- strings.TrimSpace(line)
+	}()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, os.Args[0], "-test.run=^TestTaskWakeupDialUsesEnvironmentProxy$", "-test.v")
+	cmd.Env = append(environWithoutProxyVars(),
+		wakeupProxyChildEnv+"=1",
+		"HTTPS_PROXY=http://"+ln.Addr().String(),
+	)
+	out, runErr := cmd.CombinedOutput()
+
+	select {
+	case line := <-requestLine:
+		want := "CONNECT " + wakeupProxyTargetHost + ":443"
+		if !strings.HasPrefix(line, want) {
+			t.Fatalf("proxy received %q, want a request line starting with %q\nchild output:\n%s", line, want, out)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatalf("proxy received no CONNECT: the wakeup dial ignored HTTPS_PROXY (child exit: %v)\nchild output:\n%s", runErr, out)
+	}
+}
+
+// dialWakeupThroughEnvProxy is the child half: drive the real connection path
+// at a wss:// target and let it fail. The fake proxy hangs up after the
+// request line, so the handshake never completes — the parent asserts on what
+// the proxy saw, not on the outcome here.
+func dialWakeupThroughEnvProxy(t *testing.T) {
+	d := New(Config{
+		ServerBaseURL:  "https://" + wakeupProxyTargetHost,
+		WorkspacesRoot: t.TempDir(),
+	}, slog.New(slog.NewTextHandler(io.Discard, nil)))
+
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+	defer cancel()
+
+	_, err := d.runTaskWakeupConnection(ctx, nil, make(chan taskWakeup, 1), make(chan struct{}))
+	t.Logf("wakeup dial returned: %v", err)
+}
+
+// environWithoutProxyVars copies the environment minus every *_PROXY setting,
+// so a developer's own proxy configuration cannot decide the result.
+func environWithoutProxyVars() []string {
+	env := make([]string, 0, len(os.Environ()))
+	for _, kv := range os.Environ() {
+		key, _, ok := strings.Cut(kv, "=")
+		if ok && strings.HasSuffix(strings.ToLower(key), "_proxy") {
+			continue
+		}
+		env = append(env, kv)
+	}
+	return env
+}


### PR DESCRIPTION
On a machine whose only route to the internet is a corporate egress proxy, the daemon's task-wakeup WebSocket can never connect. `runTaskWakeupConnection` builds its dialer by hand, and a zero-value `websocket.Dialer` has `Proxy == nil`, which gorilla reads as "dial direct" — unlike `websocket.DefaultDialer`, it never consults the environment. The failure is silent, too: the loop logs "task wakeup websocket unavailable; polling fallback remains active" at debug level and nothing ever mentions a proxy, so the daemon just runs permanently degraded — task pickup waits on the 30s HTTP poll instead of a server push, and the WS-first claim path (MUL-4257) falls back to HTTP on every task.

Every `net/http` call in the process honours `HTTPS_PROXY` through `DefaultTransport`, so this one connection behaving differently is genuinely hard to diagnose from the outside.

The fix is one line — set `Proxy: http.ProxyFromEnvironment` — plus a comment. gorilla rewrites `wss://` to `https://` before consulting `Proxy`, so `HTTPS_PROXY` applies to this dial. With no proxy variables set, `ProxyFromEnvironment` returns nil and the dial is byte-for-byte what it was before; `NO_PROXY` is honoured the same way it is everywhere else in the process.

A note on the regression test, because its shape is unusual: it drives the real `runTaskWakeupConnection` dial through a fake CONNECT proxy, but it has to re-exec itself into a child process. `net/http` caches the proxy environment once per process (`envProxyOnce`), and other daemon tests have already burned that cache by the time this test runs — a plain `t.Setenv` version passes in isolation and fails with the package. The child gets a scrubbed environment with only the fake proxy set, so the cache semantics are correct regardless of test order or `-shuffle`. The target host is deliberately non-loopback, since Go's proxy rules bypass proxies for localhost. The test fails on `main` (the proxy never sees a CONNECT) and passes with the fix; it is also clean under `-race`.

`go build ./...`, `go vet`, and the wakeup/WS/heartbeat tests are green. One pre-existing failure in the package (`TestProbeAgentCLIs_QoderResolvesViaLoginShell`) fails identically on a clean `main` checkout on this machine — it picks up a locally installed qoder CLI — and is unrelated.

This is the last hand-built dialer in the tree; the lark connector already falls back to the environment at dial time (#4165). Follow-up to the note at the end of my review on #5833.

cc @Bohan-J — one line of production code, hopefully quick.
