### PR TITLE
fix(mobile): chat layout collapses after returning from background

### DIFF
--- a/apps/mobile/app/(app)/[workspace]/(tabs)/chat.tsx
+++ b/apps/mobile/app/(app)/[workspace]/(tabs)/chat.tsx
@@ -33,10 +33,9 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
   Alert,
-  KeyboardAvoidingView,
-  Platform,
   View,
 } from "react-native";
+import { KeyboardAvoidingView } from "react-native-keyboard-controller";
 import { router } from "expo-router";
 import { useFocusEffect, useIsFocused } from "@react-navigation/native";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
@@ -461,8 +460,15 @@ export default function ChatTab() {
         }
       />
       {availability === "none" ? <NoAgentBanner /> : null}
+      {/*
+       * Use the keyboard-controller implementation already mounted by the
+       * root KeyboardProvider. Unlike RN's event-driven KAV, its padding is
+       * derived from the native keyboard state, so a keyboard dismissal that
+       * occurs while the app is backgrounded cannot leave stale bottom
+       * padding and collapse this flex layout when the app resumes.
+       */}
       <KeyboardAvoidingView
-        behavior={Platform.OS === "ios" ? "padding" : undefined}
+        behavior="padding"
         className="flex-1"
       >
         <ChatMessageList


### PR DESCRIPTION
## Summary

Fix the mobile Chat layout that can collapse after the app returns from the background while a multiline draft has the keyboard open.

The affected screen used React Native's event-driven `KeyboardAvoidingView`. When iOS dismissed the keyboard while JavaScript was inactive, the final `keyboardWillHide` event could be missed or not applied, leaving a large bottom padding on resume. That stale padding consumed the container height: the message list's `flex: 1` area collapsed toward zero and the composer was pushed upward and compressed.

Chat now uses the `KeyboardAvoidingView` from `react-native-keyboard-controller`. The root `KeyboardProvider` is already mounted, so this introduces no dependency. Its padding derives from native keyboard state rather than delivery of JavaScript keyboard events, so a background dismissal cannot leave the stale offset behind.

## Reproduction

1. Open Chat and type enough text to expand the composer.
2. Without sending, switch to another app or return to the home screen while the keyboard is open.
3. Return to the app.

Before this change, the composer could collapse below the header with overlapping text and toolbar controls while the message list became blank.

| Before | After |
| --- | --- |
| ![Collapsed composer and blank message list](https://raw.githubusercontent.com/LiaoyuanNing/multica/3d127a36e28c5d31ee0cae133d91b59dd29c1b57/docs/assets/chat-layout-before.jpeg) | ![Normal composer and message list](https://raw.githubusercontent.com/LiaoyuanNing/multica/3d127a36e28c5d31ee0cae133d91b59dd29c1b57/docs/assets/chat-layout-after.jpeg) |

## Scope and follow-up

This is deliberately Chat-only: it fixes the reported expanded-composer layout without changing unrelated form screens. `new-issue.tsx`, `search.tsx`, `project/new.tsx`, `issue/[id]/edit.tsx`, `login.tsx`, and `verify.tsx` use the same React Native `KeyboardAvoidingView` pattern, so they may have the same failure mode; they have not been individually verified. A follow-up could standardize those screens if maintainers want the wider change.

## Validation

- `pnpm --filter @multica/mobile typecheck`
- `pnpm --filter @multica/mobile lint` (passes with 7 pre-existing warnings)
- `pnpm --filter @multica/mobile test` (42 tests passed)
- Verified the three-step recovery path on a physical device with TestFlight build 5 of a self-hosted internal build.
