### PR TITLE
fix(mobile): recover from zombie WebSocket connections

### DIFF
--- a/apps/mobile/data/realtime/ws-client.test.ts
+++ b/apps/mobile/data/realtime/ws-client.test.ts
@@ -1,0 +1,93 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { WSClient } from "./ws-client";
+
+class MockWebSocket {
+  static readonly CONNECTING = 0;
+  static readonly OPEN = 1;
+  static readonly CLOSING = 2;
+  static readonly CLOSED = 3;
+  static instances: MockWebSocket[] = [];
+
+  readyState = MockWebSocket.CONNECTING;
+  onopen: (() => void) | null = null;
+  onmessage: ((event: { data: string }) => void) | null = null;
+  onerror: (() => void) | null = null;
+  onclose: (() => void) | null = null;
+  readonly sent: string[] = [];
+
+  constructor(readonly url: string) {
+    MockWebSocket.instances.push(this);
+  }
+
+  open() {
+    this.readyState = MockWebSocket.OPEN;
+    this.onopen?.();
+  }
+
+  receive(frame: unknown) {
+    this.onmessage?.({ data: JSON.stringify(frame) });
+  }
+
+  send(frame: string) {
+    this.sent.push(frame);
+  }
+
+  close() {
+    this.readyState = MockWebSocket.CLOSED;
+    this.onclose?.();
+  }
+}
+
+function connectAuthenticatedClient() {
+  const client = new WSClient({
+    url: "wss://example.test/ws",
+    token: "token",
+    workspaceSlug: "workspace",
+  });
+  client.connect();
+  const socket = MockWebSocket.instances[0];
+  socket.open();
+  socket.receive({ type: "auth_ack" });
+  return { client, socket };
+}
+
+describe("WSClient application heartbeat", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.stubGlobal("WebSocket", MockWebSocket);
+    MockWebSocket.instances = [];
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it("reconnects a stale OPEN socket through the jittered backoff path", () => {
+    vi.spyOn(Math, "random").mockReturnValue(0);
+    const { client, socket } = connectAuthenticatedClient();
+
+    expect(socket.sent.map((frame) => JSON.parse(frame))).toEqual([
+      { type: "auth", payload: { token: "token" } },
+      { type: "ping" },
+    ]);
+
+    // No pong arrives even though the JS-visible readyState remains OPEN.
+    vi.advanceTimersByTime(10_000);
+    vi.advanceTimersByTime(1);
+
+    expect(MockWebSocket.instances).toHaveLength(2);
+    client.disconnect();
+  });
+
+  it("keeps a healthy socket connected when its pong arrives", () => {
+    const { client, socket } = connectAuthenticatedClient();
+    socket.receive({ type: "pong" });
+
+    vi.advanceTimersByTime(10_000);
+
+    expect(MockWebSocket.instances).toHaveLength(1);
+    client.disconnect();
+  });
+});

--- a/apps/mobile/data/realtime/ws-client.ts
+++ b/apps/mobile/data/realtime/ws-client.ts
@@ -63,6 +63,14 @@ const RECONNECT_BASE_MS = 1_000;
 const RECONNECT_CAP_MS = 30_000;
 const RECONNECT_MAX_EXPONENT = 6; // 1s → 64s ceiling, capped at 30s
 
+// React Native does not surface WebSocket control Ping/Pong frames to
+// JavaScript. The server sends control pings, but an iOS/NAT half-open socket
+// can still look OPEN here forever. Its `/ws` handler also supports text
+// {type:"ping"} → {type:"pong"}, which gives the mobile transport an
+// observable liveness check without changing the protocol.
+const HEARTBEAT_INTERVAL_MS = 25_000;
+const HEARTBEAT_TIMEOUT_MS = 10_000;
+
 /**
  * Lifecycle state — drives whether onclose schedules a reconnect:
  *   idle    — never connected, or fully disconnected. No reconnect on close.
@@ -77,6 +85,9 @@ export class WSClient {
   private state: State = "idle";
   private reconnectAttempt = 0;
   private reconnectTimer: ReturnType<typeof setTimeout> | null = null;
+  private heartbeatTimer: ReturnType<typeof setInterval> | null = null;
+  private pongTimer: ReturnType<typeof setTimeout> | null = null;
+  private awaitingPong = false;
   private hasConnectedBefore = false;
 
   private readonly handlers = new Map<WSEventType, Set<EventHandler>>();
@@ -218,6 +229,10 @@ export class WSClient {
         this.onAuthenticated();
         return;
       }
+      if (type === "pong") {
+        this.onPong();
+        return;
+      }
       if (!type) {
         // Server-side error frames have shape {error: "..."}; log and drop.
         // Reconnect loop is bounded by auth-store's 401 handler eventually
@@ -247,6 +262,7 @@ export class WSClient {
       if (!wasOurs) return;
 
       this.ws = null;
+      this.clearHeartbeat();
       this.logger.warn("[ws] socket closed");
       if (this.state === "active") this.scheduleReconnect();
     };
@@ -255,6 +271,7 @@ export class WSClient {
   private onAuthenticated() {
     this.reconnectAttempt = 0;
     this.logger.info("[ws] authenticated");
+    this.startHeartbeat();
     if (this.hasConnectedBefore) {
       for (const cb of this.onReconnectCallbacks) {
         try {
@@ -292,7 +309,76 @@ export class WSClient {
     }
   }
 
+  /**
+   * An application-level heartbeat is deliberately scoped to authenticated,
+   * foreground sockets. A missed pong is treated like any other disconnect:
+   * close the stale socket and feed recovery through the existing exponential
+   * backoff + full-jitter scheduler rather than immediately redialing.
+   */
+  private startHeartbeat() {
+    this.clearHeartbeat();
+    this.sendHeartbeat();
+    this.heartbeatTimer = setInterval(
+      () => this.sendHeartbeat(),
+      HEARTBEAT_INTERVAL_MS,
+    );
+  }
+
+  private sendHeartbeat() {
+    if (this.state !== "active" || this.ws?.readyState !== WebSocket.OPEN) {
+      return;
+    }
+
+    this.awaitingPong = true;
+    try {
+      // `ping`/`pong` are transport frames rather than business events, so
+      // they intentionally stay outside WSEventType / WSMessage.
+      this.ws.send(JSON.stringify({ type: "ping" }));
+    } catch {
+      this.reconnectAfterHeartbeatFailure();
+      return;
+    }
+
+    this.pongTimer = setTimeout(() => {
+      if (this.awaitingPong) {
+        this.logger.warn("[ws] heartbeat timed out");
+        this.reconnectAfterHeartbeatFailure();
+      }
+    }, HEARTBEAT_TIMEOUT_MS);
+  }
+
+  private onPong() {
+    if (!this.awaitingPong) return;
+    this.awaitingPong = false;
+    if (this.pongTimer) {
+      clearTimeout(this.pongTimer);
+      this.pongTimer = null;
+    }
+    this.logger.debug("[ws] heartbeat pong");
+  }
+
+  private reconnectAfterHeartbeatFailure() {
+    if (this.state !== "active") return;
+    this.teardownSocket();
+    // Do not use forceReconnect(): health failures must retain the normal
+    // exponential-backoff + full-jitter protection used by onclose.
+    this.scheduleReconnect();
+  }
+
+  private clearHeartbeat() {
+    if (this.heartbeatTimer) {
+      clearInterval(this.heartbeatTimer);
+      this.heartbeatTimer = null;
+    }
+    if (this.pongTimer) {
+      clearTimeout(this.pongTimer);
+      this.pongTimer = null;
+    }
+    this.awaitingPong = false;
+  }
+
   private teardownSocket() {
+    this.clearHeartbeat();
     if (!this.ws) return;
     const ws = this.ws;
     // Detach BEFORE close — onclose firing after teardown would re-enter


### PR DESCRIPTION
## Summary

- Add an observable application-level ping/pong heartbeat after mobile WebSocket authentication.
- Route missed heartbeats through the existing exponential-backoff and full-jitter reconnect path.
- Cover stale OPEN and healthy pong paths with Node-safe Vitest tests.

## Validation

- Mobile Vitest: 44 passed.
- Mobile TypeScript check: passed.
- Mobile lint: passed with 7 pre-existing warnings and no errors.

The existing /ws server endpoint already accepts a client text ping and returns pong; no server protocol change is required.
