### PR TITLE
fix(daemon): provision config-referenced Codex instruction files into task home

### DIFF
--- a/server/internal/daemon/execenv/codex_home.go
+++ b/server/internal/daemon/execenv/codex_home.go
@@ -947,6 +947,11 @@ func syncCodexReferencedFile(codexHome, sharedHome, key, configValue string) err
 // fails here (symlink, or a different directory at that path), and a swap after
 // it cannot matter, because everything downstream uses this handle rather than
 // the path.
+//
+// Scope: this covers the config-referenced copies below. The earlier steps of
+// prepareCodexHomeWithOpts still address the task home by path, so "the whole
+// prepare is safe against a symlinked task home" is not yet true — that
+// conversion is tracked in MUL-5647.
 func openVerifiedCodexHomeRoot(codexHome, key string) (*os.Root, error) {
 	root, err := os.OpenRoot(codexHome)
 	if err != nil {

--- a/server/internal/daemon/execenv/codex_home.go
+++ b/server/internal/daemon/execenv/codex_home.go
@@ -246,8 +246,8 @@ func prepareCodexHomeWithOpts(codexHome string, opts CodexHomeOptions, logger *s
 		logger.Warn("execenv: codex-home sanitize config failed", "error", err)
 	}
 
-	if err := syncCodexModelCatalog(codexHome, sharedHome); err != nil {
-		return fmt.Errorf("sync codex model_catalog_json: %w", err)
+	if err := syncCodexReferencedFiles(codexHome, sharedHome); err != nil {
+		return fmt.Errorf("sync codex config file references: %w", err)
 	}
 
 	// Seed the shared model cache only for a fresh task home. On reuse, keep a
@@ -821,7 +821,21 @@ func linkCodexRollout(src, dst string) error {
 	return os.Symlink(src, dst)
 }
 
-func syncCodexModelCatalog(codexHome, sharedHome string) error {
+// syncCodexReferencedFiles materialises every file the copied config.toml
+// points at inside the per-task CODEX_HOME.
+//
+// config.toml is copied verbatim, so its path-valued keys survive the move to
+// the task home while the files they name do not. Codex resolves a relative
+// value against CODEX_HOME, which is now the task home, so an unmaterialised
+// reference makes Codex fail while loading its configuration — before the task
+// prompt is ever delivered (MUL-5623 / #6271: `failed to read model
+// instructions file <task-home>/gpt-unrestricted.md`).
+//
+// Only the keys listed below are followed. Copying every path a config could
+// mention would turn any user config into a channel for pulling arbitrary host
+// files into a task sandbox, and copying the whole shared home would drag
+// auth.json and the machine's session history along with it.
+func syncCodexReferencedFiles(codexHome, sharedHome string) error {
 	configPath := filepath.Join(codexHome, "config.toml")
 	data, err := os.ReadFile(configPath)
 	if os.IsNotExist(err) {
@@ -833,43 +847,78 @@ func syncCodexModelCatalog(codexHome, sharedHome string) error {
 
 	var cfg struct {
 		ModelCatalogJSON string `toml:"model_catalog_json"`
+		// Replacement for Codex's built-in instructions.
+		// experimental_instructions_file is the deprecated alias Codex still
+		// accepts, so configs written before the rename need it too.
+		ModelInstructionsFile        string `toml:"model_instructions_file"`
+		ExperimentalInstructionsFile string `toml:"experimental_instructions_file"`
 	}
 	if err := toml.Unmarshal(data, &cfg); err != nil {
 		return fmt.Errorf("parse %s: %w", configPath, err)
 	}
-	catalogPath := strings.TrimSpace(cfg.ModelCatalogJSON)
-	if catalogPath == "" {
+
+	for _, ref := range []struct{ key, path string }{
+		{"model_catalog_json", cfg.ModelCatalogJSON},
+		{"model_instructions_file", cfg.ModelInstructionsFile},
+		{"experimental_instructions_file", cfg.ExperimentalInstructionsFile},
+	} {
+		if err := syncCodexReferencedFile(codexHome, sharedHome, ref.key, ref.path); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// syncCodexReferencedFile copies one config-referenced file from the shared
+// Codex home into the task home at the same relative location, so the copied
+// config.toml keeps resolving under the relocated CODEX_HOME.
+//
+// Absolute and ~-rooted values are left alone: they address the same host the
+// task runs on, so Codex reads them directly and copying would only risk
+// serving a stale snapshot. A relative value must stay inside the task home
+// (filepath.IsLocal) — a `..` escape would otherwise let config.toml name any
+// file on the host and have the daemon copy it into the task environment.
+//
+// The copy is refreshed on every prepare, so reusing a task home picks up an
+// edited source instead of keeping a stale instruction file.
+func syncCodexReferencedFile(codexHome, sharedHome, key, configValue string) error {
+	referencedPath := strings.TrimSpace(configValue)
+	if referencedPath == "" {
 		return nil
 	}
 
-	src, err := resolveCodexConfigPath(catalogPath, sharedHome)
+	src, err := resolveCodexConfigPath(referencedPath, sharedHome, key)
 	if err != nil {
 		return err
 	}
-	if _, err := os.Stat(src); err != nil {
-		return fmt.Errorf("model_catalog_json %q resolved to missing file %s: %w", catalogPath, src, err)
+	info, err := os.Stat(src)
+	if err != nil {
+		return fmt.Errorf("%s %q resolved to missing file %s: %w", key, referencedPath, src, err)
 	}
 
-	if filepath.IsAbs(catalogPath) || strings.HasPrefix(catalogPath, "~") {
+	if filepath.IsAbs(referencedPath) || strings.HasPrefix(referencedPath, "~") {
 		return nil
 	}
-	cleanCatalogPath := filepath.Clean(catalogPath)
-	if !filepath.IsLocal(cleanCatalogPath) {
-		return fmt.Errorf("model_catalog_json %q must be a local relative path or an absolute path", catalogPath)
+	if !info.Mode().IsRegular() {
+		return fmt.Errorf("%s %q resolved to %s, which is not a regular file", key, referencedPath, src)
 	}
-	dst := filepath.Join(codexHome, cleanCatalogPath)
+	cleanReferencedPath := filepath.Clean(referencedPath)
+	if !filepath.IsLocal(cleanReferencedPath) {
+		return fmt.Errorf("%s %q must be a local relative path or an absolute path", key, referencedPath)
+	}
+	dst := filepath.Join(codexHome, cleanReferencedPath)
 	if err := os.MkdirAll(filepath.Dir(dst), 0o755); err != nil {
-		return fmt.Errorf("create model catalog directory %s: %w", filepath.Dir(dst), err)
+		return fmt.Errorf("create %s directory %s: %w", key, filepath.Dir(dst), err)
 	}
 	if _, err := os.Lstat(dst); err == nil {
 		if err := os.Remove(dst); err != nil {
-			return fmt.Errorf("remove stale model catalog %s: %w", dst, err)
+			return fmt.Errorf("remove stale %s copy %s: %w", key, dst, err)
 		}
 	} else if !os.IsNotExist(err) {
-		return fmt.Errorf("stat model catalog %s: %w", dst, err)
+		return fmt.Errorf("stat %s copy %s: %w", key, dst, err)
 	}
 	if err := copyFile(src, dst); err != nil {
-		return fmt.Errorf("copy model_catalog_json %s to %s: %w", src, dst, err)
+		return fmt.Errorf("copy %s %s to %s: %w", key, src, dst, err)
 	}
 	return nil
 }
@@ -972,7 +1021,7 @@ func codexModelsCacheConfigFingerprint(sharedHome string) (string, error) {
 		}
 		catalogPath := strings.TrimSpace(cfg.ModelCatalogJSON)
 		if catalogPath != "" {
-			resolved, err := resolveCodexConfigPath(catalogPath, sharedHome)
+			resolved, err := resolveCodexConfigPath(catalogPath, sharedHome, "model_catalog_json")
 			if err != nil {
 				return "", err
 			}
@@ -1030,19 +1079,25 @@ func writeCodexModelsCacheBinding(path, fingerprint string) error {
 	return nil
 }
 
-func resolveCodexConfigPath(configPath, sharedHome string) (string, error) {
+// resolveCodexConfigPath maps a path-valued config.toml entry to its source
+// file on this host. key is the config key the path came from and only shapes
+// the diagnostics, so an operator reading a failure knows which setting to fix.
+// A relative path resolves against the shared Codex home — that is the
+// directory the config was copied from, and the base Codex itself would have
+// used before the per-task home relocated CODEX_HOME.
+func resolveCodexConfigPath(configPath, sharedHome, key string) (string, error) {
 	if filepath.IsAbs(configPath) {
 		return filepath.Clean(configPath), nil
 	}
 	if strings.HasPrefix(configPath, "~/") || strings.HasPrefix(configPath, `~\`) {
 		home, err := os.UserHomeDir()
 		if err != nil {
-			return "", fmt.Errorf("resolve model_catalog_json %q: user home: %w", configPath, err)
+			return "", fmt.Errorf("resolve %s %q: user home: %w", key, configPath, err)
 		}
 		return filepath.Join(home, configPath[2:]), nil
 	}
 	if strings.HasPrefix(configPath, "~") {
-		return "", fmt.Errorf("model_catalog_json %q uses unsupported ~user expansion", configPath)
+		return "", fmt.Errorf("%s %q uses unsupported ~user expansion", key, configPath)
 	}
 	return filepath.Join(sharedHome, filepath.Clean(configPath)), nil
 }

--- a/server/internal/daemon/execenv/codex_home.go
+++ b/server/internal/daemon/execenv/codex_home.go
@@ -875,12 +875,24 @@ func syncCodexReferencedFiles(codexHome, sharedHome string) error {
 //
 // Absolute and ~-rooted values are left alone: they address the same host the
 // task runs on, so Codex reads them directly and copying would only risk
-// serving a stale snapshot. A relative value must stay inside the task home
-// (filepath.IsLocal) — a `..` escape would otherwise let config.toml name any
-// file on the host and have the daemon copy it into the task environment.
+// serving a stale snapshot.
+//
+// Destination writes are root-scoped to codexHome (see
+// materialiseInCodexHome): filepath.IsLocal only proves the config string has no
+// lexical `..`, and a reused task home is writable by the task that used it, so
+// nothing but a root-scoped mkdir/remove/write can guarantee the daemon stays
+// inside the task home.
+//
+// The source side deliberately keeps ordinary path semantics: the relative path
+// resolves inside the shared Codex home and symlinks there are followed. That
+// directory is the user's own configuration, the file is only ever read, and a
+// task on this host can already read anything the daemon user can — so a
+// symlink out of ~/.codex grants no access the task did not already have.
 //
 // The copy is refreshed on every prepare, so reusing a task home picks up an
-// edited source instead of keeping a stale instruction file.
+// edited source instead of keeping a stale instruction file. A copy whose key
+// was later removed or repointed stays behind unreferenced; Codex never reads it
+// because the config no longer names it.
 func syncCodexReferencedFile(codexHome, sharedHome, key, configValue string) error {
 	referencedPath := strings.TrimSpace(configValue)
 	if referencedPath == "" {
@@ -892,8 +904,14 @@ func syncCodexReferencedFile(codexHome, sharedHome, key, configValue string) err
 		return err
 	}
 	info, err := os.Stat(src)
-	if err != nil {
+	if os.IsNotExist(err) {
 		return fmt.Errorf("%s %q resolved to missing file %s: %w", key, referencedPath, src, err)
+	}
+	if err != nil {
+		// Not a confident absence — a permission or IO failure must not be
+		// reported as "the file isn't there", which sends operators looking for
+		// the wrong problem.
+		return fmt.Errorf("%s %q: cannot stat source %s: %w", key, referencedPath, src, err)
 	}
 
 	if filepath.IsAbs(referencedPath) || strings.HasPrefix(referencedPath, "~") {
@@ -906,19 +924,67 @@ func syncCodexReferencedFile(codexHome, sharedHome, key, configValue string) err
 	if !filepath.IsLocal(cleanReferencedPath) {
 		return fmt.Errorf("%s %q must be a local relative path or an absolute path", key, referencedPath)
 	}
-	dst := filepath.Join(codexHome, cleanReferencedPath)
-	if err := os.MkdirAll(filepath.Dir(dst), 0o755); err != nil {
-		return fmt.Errorf("create %s directory %s: %w", key, filepath.Dir(dst), err)
+	return materialiseInCodexHome(codexHome, cleanReferencedPath, src, key)
+}
+
+// materialiseInCodexHome writes src to relPath inside codexHome using
+// root-scoped operations, so no symlink below the task home can redirect the
+// daemon's mkdir, remove, or write outside it.
+//
+// This matters because a task home is reused: a prepare can run against a
+// directory a previous task already wrote to. Without the root, a task that
+// replaced an intermediate directory of its own home with a link to somewhere
+// else would have the daemon delete and overwrite the link target on the next
+// prepare. os.Root still allows links that stay inside the task home, which is
+// harmless, and rejects the ones that leave it.
+func materialiseInCodexHome(codexHome, relPath, src, key string) error {
+	// os.OpenRoot resolves codexHome itself before confining anything below it,
+	// so a codexHome that is a link would silently move the root elsewhere.
+	homeInfo, err := os.Lstat(codexHome)
+	if err != nil {
+		return fmt.Errorf("stat codex home %s: %w", codexHome, err)
 	}
-	if _, err := os.Lstat(dst); err == nil {
-		if err := os.Remove(dst); err != nil {
-			return fmt.Errorf("remove stale %s copy %s: %w", key, dst, err)
+	if homeInfo.Mode()&os.ModeSymlink != 0 {
+		return fmt.Errorf("codex home %s is a symlink; refusing to write %s through it", codexHome, key)
+	}
+	root, err := os.OpenRoot(codexHome)
+	if err != nil {
+		return fmt.Errorf("open codex home %s: %w", codexHome, err)
+	}
+	defer root.Close()
+
+	if dir := filepath.Dir(relPath); dir != "." {
+		if err := root.MkdirAll(dir, 0o755); err != nil {
+			return fmt.Errorf("create %s directory %s: %w", key, dir, err)
+		}
+	}
+	if _, err := root.Lstat(relPath); err == nil {
+		if err := root.Remove(relPath); err != nil {
+			return fmt.Errorf("remove stale %s copy %s: %w", key, relPath, err)
 		}
 	} else if !os.IsNotExist(err) {
-		return fmt.Errorf("stat %s copy %s: %w", key, dst, err)
+		return fmt.Errorf("stat %s copy %s: %w", key, relPath, err)
 	}
-	if err := copyFile(src, dst); err != nil {
-		return fmt.Errorf("copy %s %s to %s: %w", key, src, dst, err)
+
+	in, err := os.Open(src)
+	if err != nil {
+		return fmt.Errorf("open %s %s: %w", key, src, err)
+	}
+	defer in.Close()
+
+	out, err := root.OpenFile(relPath, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o644)
+	if err != nil {
+		return fmt.Errorf("create %s copy %s: %w", key, relPath, err)
+	}
+	defer out.Close()
+
+	if _, err := io.Copy(out, in); err != nil {
+		return fmt.Errorf("copy %s %s to %s: %w", key, src, relPath, err)
+	}
+	// Close explicitly so a deferred write-back failure cannot be swallowed; the
+	// deferred Close then no-ops.
+	if err := out.Close(); err != nil {
+		return fmt.Errorf("close %s copy %s: %w", key, relPath, err)
 	}
 	return nil
 }

--- a/server/internal/daemon/execenv/codex_home.go
+++ b/server/internal/daemon/execenv/codex_home.go
@@ -927,6 +927,60 @@ func syncCodexReferencedFile(codexHome, sharedHome, key, configValue string) err
 	return materialiseInCodexHome(codexHome, cleanReferencedPath, src, key)
 }
 
+// openVerifiedCodexHomeRoot opens codexHome as a confinement root and only
+// returns it once the opened directory is proven to still BE codexHome.
+//
+// Checking the path first and opening it second is not enough: os.OpenRoot
+// resolves the path it is given, so a directory swapped for a link to somewhere
+// else between the check and the open yields a root that is happily confined —
+// to the wrong tree. Every subsequent root-scoped write would then land outside
+// the task home without ever "escaping" its root.
+//
+// That window is not hypothetical here. Task homes are reused, and on Windows
+// only the direct Codex process is terminated — descendant cleanup cannot be
+// confirmed (see server/pkg/agent/proc_windows.go) — so a leftover process that
+// knows its old CODEX_HOME can still act on it. Any local process can create the
+// same window on other platforms.
+//
+// So the identity check is bound to the handle instead of the path: compare the
+// opened directory against a no-follow stat of codexHome. A swap before the open
+// fails here (symlink, or a different directory at that path), and a swap after
+// it cannot matter, because everything downstream uses this handle rather than
+// the path.
+func openVerifiedCodexHomeRoot(codexHome, key string) (*os.Root, error) {
+	root, err := os.OpenRoot(codexHome)
+	if err != nil {
+		return nil, fmt.Errorf("open codex home %s: %w", codexHome, err)
+	}
+	if err := verifyCodexHomeRoot(root, codexHome, key); err != nil {
+		root.Close()
+		return nil, err
+	}
+	return root, nil
+}
+
+// verifyCodexHomeRoot proves that root is the directory codexHome names right
+// now: not reached through a symlink, and the same directory os.Lstat sees at
+// that path. It is separate from openVerifiedCodexHomeRoot so the swap case can
+// be tested deterministically instead of by racing.
+func verifyCodexHomeRoot(root *os.Root, codexHome, key string) error {
+	opened, err := root.Stat(".")
+	if err != nil {
+		return fmt.Errorf("stat opened codex home %s: %w", codexHome, err)
+	}
+	current, err := os.Lstat(codexHome)
+	if err != nil {
+		return fmt.Errorf("stat codex home %s: %w", codexHome, err)
+	}
+	if current.Mode()&os.ModeSymlink != 0 {
+		return fmt.Errorf("codex home %s is a symlink; refusing to write %s through it", codexHome, key)
+	}
+	if !os.SameFile(opened, current) {
+		return fmt.Errorf("codex home %s was replaced while opening it; refusing to write %s through it", codexHome, key)
+	}
+	return nil
+}
+
 // materialiseInCodexHome writes src to relPath inside codexHome using
 // root-scoped operations, so no symlink below the task home can redirect the
 // daemon's mkdir, remove, or write outside it.
@@ -936,20 +990,12 @@ func syncCodexReferencedFile(codexHome, sharedHome, key, configValue string) err
 // replaced an intermediate directory of its own home with a link to somewhere
 // else would have the daemon delete and overwrite the link target on the next
 // prepare. os.Root still allows links that stay inside the task home, which is
-// harmless, and rejects the ones that leave it.
+// harmless, and rejects the ones that leave it. The root itself is
+// identity-checked by openVerifiedCodexHomeRoot.
 func materialiseInCodexHome(codexHome, relPath, src, key string) error {
-	// os.OpenRoot resolves codexHome itself before confining anything below it,
-	// so a codexHome that is a link would silently move the root elsewhere.
-	homeInfo, err := os.Lstat(codexHome)
+	root, err := openVerifiedCodexHomeRoot(codexHome, key)
 	if err != nil {
-		return fmt.Errorf("stat codex home %s: %w", codexHome, err)
-	}
-	if homeInfo.Mode()&os.ModeSymlink != 0 {
-		return fmt.Errorf("codex home %s is a symlink; refusing to write %s through it", codexHome, key)
-	}
-	root, err := os.OpenRoot(codexHome)
-	if err != nil {
-		return fmt.Errorf("open codex home %s: %w", codexHome, err)
+		return err
 	}
 	defer root.Close()
 

--- a/server/internal/daemon/execenv/execenv_test.go
+++ b/server/internal/daemon/execenv/execenv_test.go
@@ -3,6 +3,7 @@ package execenv
 import (
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
 	"log/slog"
 	"os"
@@ -2438,6 +2439,173 @@ func TestPrepareCodexHomeReportsMissingModelCatalogPath(t *testing.T) {
 		if !strings.Contains(err.Error(), want) {
 			t.Fatalf("error %q missing %q", err, want)
 		}
+	}
+}
+
+// Regression test for MUL-5623 / #6271 — a user-level
+// `model_instructions_file = "./gpt-unrestricted.md"` survived the copy into the
+// per-task CODEX_HOME while the file it names did not, so Codex failed loading
+// its configuration before the task prompt was delivered.
+func TestPrepareCodexHomeCopiesRelativeModelInstructionsFile(t *testing.T) {
+	// Cannot use t.Parallel() with t.Setenv.
+
+	sharedHome := t.TempDir()
+	if err := os.WriteFile(filepath.Join(sharedHome, "config.toml"), []byte(`model_instructions_file = "./gpt-unrestricted.md"`), 0o644); err != nil {
+		t.Fatalf("write shared config.toml: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(sharedHome, "gpt-unrestricted.md"), []byte("Be direct."), 0o644); err != nil {
+		t.Fatalf("write shared instructions: %v", err)
+	}
+	t.Setenv("CODEX_HOME", sharedHome)
+
+	codexHome := filepath.Join(t.TempDir(), "codex-home")
+	if err := prepareCodexHome(codexHome, testLogger()); err != nil {
+		t.Fatalf("prepareCodexHome failed: %v", err)
+	}
+
+	data, err := os.ReadFile(filepath.Join(codexHome, "gpt-unrestricted.md"))
+	if err != nil {
+		t.Fatalf("read per-task instructions: %v", err)
+	}
+	if string(data) != "Be direct." {
+		t.Errorf("per-task instructions = %q", data)
+	}
+
+	// The copy must be isolated: a task editing its instructions cannot reach
+	// back into the user's real Codex home.
+	if err := os.WriteFile(filepath.Join(codexHome, "gpt-unrestricted.md"), []byte("tampered"), 0o644); err != nil {
+		t.Fatalf("rewrite per-task instructions: %v", err)
+	}
+	shared, err := os.ReadFile(filepath.Join(sharedHome, "gpt-unrestricted.md"))
+	if err != nil {
+		t.Fatalf("read shared instructions: %v", err)
+	}
+	if string(shared) != "Be direct." {
+		t.Errorf("shared instructions mutated by task: %q", shared)
+	}
+}
+
+// A nested reference must land at the same relative location inside the task
+// home. The path is built with filepath.Join so Windows exercises its own
+// separator, and the TOML literal string keeps that backslash verbatim.
+func TestPrepareCodexHomeCopiesNestedDeprecatedInstructionsFile(t *testing.T) {
+	// Cannot use t.Parallel() with t.Setenv.
+
+	sharedHome := t.TempDir()
+	rel := filepath.Join("prompts", "unrestricted.md")
+	if err := os.WriteFile(filepath.Join(sharedHome, "config.toml"), []byte(fmt.Sprintf("experimental_instructions_file = '%s'", rel)), 0o644); err != nil {
+		t.Fatalf("write shared config.toml: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Join(sharedHome, "prompts"), 0o755); err != nil {
+		t.Fatalf("create shared prompts dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(sharedHome, rel), []byte("Nested."), 0o644); err != nil {
+		t.Fatalf("write shared instructions: %v", err)
+	}
+	t.Setenv("CODEX_HOME", sharedHome)
+
+	codexHome := filepath.Join(t.TempDir(), "codex-home")
+	if err := prepareCodexHome(codexHome, testLogger()); err != nil {
+		t.Fatalf("prepareCodexHome failed: %v", err)
+	}
+
+	data, err := os.ReadFile(filepath.Join(codexHome, rel))
+	if err != nil {
+		t.Fatalf("read per-task instructions: %v", err)
+	}
+	if string(data) != "Nested." {
+		t.Errorf("per-task instructions = %q", data)
+	}
+}
+
+// A missing source must fail while preparing the environment, with a diagnostic
+// naming the key and both paths — not as an opaque `os error 2` from Codex's own
+// configuration loading, after the task has already been launched.
+func TestPrepareCodexHomeReportsMissingModelInstructionsFile(t *testing.T) {
+	// Cannot use t.Parallel() with t.Setenv.
+
+	sharedHome := t.TempDir()
+	if err := os.WriteFile(filepath.Join(sharedHome, "config.toml"), []byte(`model_instructions_file = "missing-instructions.md"`), 0o644); err != nil {
+		t.Fatalf("write shared config.toml: %v", err)
+	}
+	t.Setenv("CODEX_HOME", sharedHome)
+
+	codexHome := filepath.Join(t.TempDir(), "codex-home")
+	err := prepareCodexHome(codexHome, testLogger())
+	if err == nil {
+		t.Fatal("expected prepareCodexHome to fail for missing model instructions file")
+	}
+	for _, want := range []string{"model_instructions_file", "missing-instructions.md", filepath.Join(sharedHome, "missing-instructions.md")} {
+		if !strings.Contains(err.Error(), want) {
+			t.Fatalf("error %q missing %q", err, want)
+		}
+	}
+}
+
+// A relative reference that escapes the task home is rejected rather than
+// copied: honoring it would let any user config name an arbitrary host file and
+// have the daemon materialise it inside the task environment.
+func TestPrepareCodexHomeRejectsEscapingModelInstructionsFile(t *testing.T) {
+	// Cannot use t.Parallel() with t.Setenv.
+
+	root := t.TempDir()
+	sharedHome := filepath.Join(root, "shared")
+	if err := os.MkdirAll(sharedHome, 0o755); err != nil {
+		t.Fatalf("create shared home: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(sharedHome, "config.toml"), []byte(`model_instructions_file = "../secrets.md"`), 0o644); err != nil {
+		t.Fatalf("write shared config.toml: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "secrets.md"), []byte("secret"), 0o644); err != nil {
+		t.Fatalf("write escaping source: %v", err)
+	}
+	t.Setenv("CODEX_HOME", sharedHome)
+
+	codexHome := filepath.Join(t.TempDir(), "codex-home")
+	err := prepareCodexHome(codexHome, testLogger())
+	if err == nil {
+		t.Fatal("expected prepareCodexHome to reject an escaping model instructions path")
+	}
+	if !strings.Contains(err.Error(), "model_instructions_file") {
+		t.Fatalf("error %q does not name the offending key", err)
+	}
+	if _, statErr := os.Stat(filepath.Join(filepath.Dir(codexHome), "secrets.md")); !os.IsNotExist(statErr) {
+		t.Fatalf("escaping source was materialised outside the task home: %v", statErr)
+	}
+}
+
+// A reused task home must reflect the user's current instructions instead of
+// serving the snapshot an earlier run copied.
+func TestPrepareCodexHomeRefreshesModelInstructionsFileOnReuse(t *testing.T) {
+	// Cannot use t.Parallel() with t.Setenv.
+
+	sharedHome := t.TempDir()
+	if err := os.WriteFile(filepath.Join(sharedHome, "config.toml"), []byte(`model_instructions_file = "instructions-override.md"`), 0o644); err != nil {
+		t.Fatalf("write shared config.toml: %v", err)
+	}
+	source := filepath.Join(sharedHome, "instructions-override.md")
+	if err := os.WriteFile(source, []byte("first"), 0o644); err != nil {
+		t.Fatalf("write shared instructions: %v", err)
+	}
+	t.Setenv("CODEX_HOME", sharedHome)
+
+	codexHome := filepath.Join(t.TempDir(), "codex-home")
+	if err := prepareCodexHome(codexHome, testLogger()); err != nil {
+		t.Fatalf("first prepareCodexHome failed: %v", err)
+	}
+	if err := os.WriteFile(source, []byte("second"), 0o644); err != nil {
+		t.Fatalf("update shared instructions: %v", err)
+	}
+	if err := prepareCodexHome(codexHome, testLogger()); err != nil {
+		t.Fatalf("second prepareCodexHome failed: %v", err)
+	}
+
+	data, err := os.ReadFile(filepath.Join(codexHome, "instructions-override.md"))
+	if err != nil {
+		t.Fatalf("read per-task instructions: %v", err)
+	}
+	if string(data) != "second" {
+		t.Errorf("per-task instructions = %q, want the refreshed source", data)
 	}
 }
 

--- a/server/internal/daemon/execenv/execenv_test.go
+++ b/server/internal/daemon/execenv/execenv_test.go
@@ -2609,6 +2609,121 @@ func TestPrepareCodexHomeRefreshesModelInstructionsFileOnReuse(t *testing.T) {
 	}
 }
 
+// A reused task home is writable by the task that ran in it, so an intermediate
+// directory of the copy destination can be a symlink by the time the next
+// prepare runs. Root-scoped writes must refuse to follow it out of the task
+// home instead of deleting and overwriting the link target.
+func TestPrepareCodexHomeRefusesSymlinkedInstructionsParentOnReuse(t *testing.T) {
+	// Cannot use t.Parallel() with t.Setenv.
+
+	sharedHome := t.TempDir()
+	rel := filepath.Join("prompts", "unrestricted.md")
+	if err := os.WriteFile(filepath.Join(sharedHome, "config.toml"), []byte(fmt.Sprintf("model_instructions_file = '%s'", rel)), 0o644); err != nil {
+		t.Fatalf("write shared config.toml: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Join(sharedHome, "prompts"), 0o755); err != nil {
+		t.Fatalf("create shared prompts dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(sharedHome, rel), []byte("from shared home"), 0o644); err != nil {
+		t.Fatalf("write shared instructions: %v", err)
+	}
+	t.Setenv("CODEX_HOME", sharedHome)
+
+	codexHome := filepath.Join(t.TempDir(), "codex-home")
+	if err := prepareCodexHome(codexHome, testLogger()); err != nil {
+		t.Fatalf("first prepareCodexHome failed: %v", err)
+	}
+
+	// Stand in for what a task can do to its own home between prepares.
+	outside := t.TempDir()
+	sentinel := filepath.Join(outside, "unrestricted.md")
+	if err := os.WriteFile(sentinel, []byte("outside the task home"), 0o644); err != nil {
+		t.Fatalf("write sentinel: %v", err)
+	}
+	taskParent := filepath.Join(codexHome, "prompts")
+	if err := os.RemoveAll(taskParent); err != nil {
+		t.Fatalf("remove task prompts dir: %v", err)
+	}
+	if err := os.Symlink(outside, taskParent); err != nil {
+		t.Skipf("symlinks unsupported on this host: %v", err)
+	}
+
+	err := prepareCodexHome(codexHome, testLogger())
+	if err == nil {
+		t.Fatal("expected prepareCodexHome to refuse writing through a symlinked parent")
+	}
+	if !strings.Contains(err.Error(), "model_instructions_file") {
+		t.Fatalf("error %q does not name the offending key", err)
+	}
+
+	data, readErr := os.ReadFile(sentinel)
+	if readErr != nil {
+		t.Fatalf("sentinel outside the task home was removed: %v", readErr)
+	}
+	if string(data) != "outside the task home" {
+		t.Errorf("sentinel outside the task home was overwritten: %q", data)
+	}
+}
+
+// The destination file itself can also be a symlink on reuse. Removing it must
+// unlink the symlink, never write through it into the link target.
+func TestPrepareCodexHomeReplacesSymlinkedInstructionsCopyOnReuse(t *testing.T) {
+	// Cannot use t.Parallel() with t.Setenv.
+
+	sharedHome := t.TempDir()
+	if err := os.WriteFile(filepath.Join(sharedHome, "config.toml"), []byte(`model_instructions_file = "gpt-unrestricted.md"`), 0o644); err != nil {
+		t.Fatalf("write shared config.toml: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(sharedHome, "gpt-unrestricted.md"), []byte("from shared home"), 0o644); err != nil {
+		t.Fatalf("write shared instructions: %v", err)
+	}
+	t.Setenv("CODEX_HOME", sharedHome)
+
+	codexHome := filepath.Join(t.TempDir(), "codex-home")
+	if err := prepareCodexHome(codexHome, testLogger()); err != nil {
+		t.Fatalf("first prepareCodexHome failed: %v", err)
+	}
+
+	outside := t.TempDir()
+	sentinel := filepath.Join(outside, "sentinel.md")
+	if err := os.WriteFile(sentinel, []byte("outside the task home"), 0o644); err != nil {
+		t.Fatalf("write sentinel: %v", err)
+	}
+	taskCopy := filepath.Join(codexHome, "gpt-unrestricted.md")
+	if err := os.Remove(taskCopy); err != nil {
+		t.Fatalf("remove task copy: %v", err)
+	}
+	if err := os.Symlink(sentinel, taskCopy); err != nil {
+		t.Skipf("symlinks unsupported on this host: %v", err)
+	}
+
+	if err := prepareCodexHome(codexHome, testLogger()); err != nil {
+		t.Fatalf("second prepareCodexHome failed: %v", err)
+	}
+
+	data, err := os.ReadFile(sentinel)
+	if err != nil {
+		t.Fatalf("sentinel outside the task home was removed: %v", err)
+	}
+	if string(data) != "outside the task home" {
+		t.Errorf("sentinel outside the task home was overwritten: %q", data)
+	}
+	info, err := os.Lstat(taskCopy)
+	if err != nil {
+		t.Fatalf("lstat task copy: %v", err)
+	}
+	if info.Mode()&os.ModeSymlink != 0 {
+		t.Error("task copy is still a symlink")
+	}
+	copied, err := os.ReadFile(taskCopy)
+	if err != nil {
+		t.Fatalf("read task copy: %v", err)
+	}
+	if string(copied) != "from shared home" {
+		t.Errorf("task copy = %q", copied)
+	}
+}
+
 // Regression test for #1753 — Codex Desktop writes plugin-backed
 // `[[skills.config]]` entries without a `path` field, and the CLI's TOML
 // parser rejects them with `missing field path`. prepareCodexHome must drop

--- a/server/internal/daemon/execenv/execenv_test.go
+++ b/server/internal/daemon/execenv/execenv_test.go
@@ -2724,6 +2724,57 @@ func TestPrepareCodexHomeReplacesSymlinkedInstructionsCopyOnReuse(t *testing.T) 
 	}
 }
 
+// Repointing the key provisions the new target; the previous copy stays behind
+// unreferenced. Codex never reads it because the copied config no longer names
+// it — this test pins that documented contract so a future change to it is
+// deliberate.
+func TestPrepareCodexHomeLeavesRepointedInstructionsCopyBehind(t *testing.T) {
+	// Cannot use t.Parallel() with t.Setenv.
+
+	sharedHome := t.TempDir()
+	sharedConfig := filepath.Join(sharedHome, "config.toml")
+	if err := os.WriteFile(sharedConfig, []byte(`model_instructions_file = "old.md"`), 0o644); err != nil {
+		t.Fatalf("write shared config.toml: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(sharedHome, "old.md"), []byte("old"), 0o644); err != nil {
+		t.Fatalf("write old instructions: %v", err)
+	}
+	t.Setenv("CODEX_HOME", sharedHome)
+
+	codexHome := filepath.Join(t.TempDir(), "codex-home")
+	if err := prepareCodexHome(codexHome, testLogger()); err != nil {
+		t.Fatalf("first prepareCodexHome failed: %v", err)
+	}
+
+	if err := os.WriteFile(sharedConfig, []byte(`model_instructions_file = "new.md"`), 0o644); err != nil {
+		t.Fatalf("repoint shared config.toml: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(sharedHome, "new.md"), []byte("new"), 0o644); err != nil {
+		t.Fatalf("write new instructions: %v", err)
+	}
+	if err := prepareCodexHome(codexHome, testLogger()); err != nil {
+		t.Fatalf("second prepareCodexHome failed: %v", err)
+	}
+
+	data, err := os.ReadFile(filepath.Join(codexHome, "new.md"))
+	if err != nil {
+		t.Fatalf("read repointed instructions: %v", err)
+	}
+	if string(data) != "new" {
+		t.Errorf("repointed instructions = %q", data)
+	}
+	config, err := os.ReadFile(filepath.Join(codexHome, "config.toml"))
+	if err != nil {
+		t.Fatalf("read per-task config.toml: %v", err)
+	}
+	if !strings.Contains(string(config), `model_instructions_file = "new.md"`) {
+		t.Errorf("per-task config.toml still points at the old target: %s", config)
+	}
+	if _, err := os.Stat(filepath.Join(codexHome, "old.md")); err != nil {
+		t.Errorf("unreferenced old copy unexpectedly cleaned up: %v", err)
+	}
+}
+
 // Regression test for #1753 — Codex Desktop writes plugin-backed
 // `[[skills.config]]` entries without a `path` field, and the CLI's TOML
 // parser rejects them with `missing field path`. prepareCodexHome must drop

--- a/server/internal/daemon/execenv/execenv_test.go
+++ b/server/internal/daemon/execenv/execenv_test.go
@@ -2775,6 +2775,114 @@ func TestPrepareCodexHomeLeavesRepointedInstructionsCopyBehind(t *testing.T) {
 	}
 }
 
+// The root of the copy — the task home itself — must be identity-checked too. A
+// path-based check followed by a path-based open leaves a window where the
+// directory is swapped for a link and every "confined" write lands in the wrong
+// tree. These two tests drive the check directly so the swap is deterministic
+// rather than raced.
+func TestVerifyCodexHomeRootRejectsSwappedDirectory(t *testing.T) {
+	t.Parallel()
+
+	base := t.TempDir()
+	codexHome := filepath.Join(base, "codex-home")
+	if err := os.Mkdir(codexHome, 0o755); err != nil {
+		t.Fatalf("create codex home: %v", err)
+	}
+	root, err := os.OpenRoot(codexHome)
+	if err != nil {
+		t.Fatalf("open codex home root: %v", err)
+	}
+	defer root.Close()
+
+	// Same path, different directory — what a swap looks like after the open.
+	if err := os.Rename(codexHome, filepath.Join(base, "moved-aside")); err != nil {
+		t.Fatalf("move original codex home: %v", err)
+	}
+	if err := os.Mkdir(codexHome, 0o755); err != nil {
+		t.Fatalf("recreate codex home: %v", err)
+	}
+
+	err = verifyCodexHomeRoot(root, codexHome, "model_instructions_file")
+	if err == nil {
+		t.Fatal("expected verifyCodexHomeRoot to reject a swapped codex home")
+	}
+	if !strings.Contains(err.Error(), "replaced") {
+		t.Fatalf("error %q does not report the replacement", err)
+	}
+}
+
+func TestVerifyCodexHomeRootRejectsSymlinkedHome(t *testing.T) {
+	t.Parallel()
+
+	base := t.TempDir()
+	codexHome := filepath.Join(base, "codex-home")
+	if err := os.Mkdir(codexHome, 0o755); err != nil {
+		t.Fatalf("create codex home: %v", err)
+	}
+	root, err := os.OpenRoot(codexHome)
+	if err != nil {
+		t.Fatalf("open codex home root: %v", err)
+	}
+	defer root.Close()
+
+	outside := t.TempDir()
+	if err := os.Rename(codexHome, filepath.Join(base, "moved-aside")); err != nil {
+		t.Fatalf("move original codex home: %v", err)
+	}
+	if err := os.Symlink(outside, codexHome); err != nil {
+		t.Skipf("symlinks unsupported on this host: %v", err)
+	}
+
+	err = verifyCodexHomeRoot(root, codexHome, "model_instructions_file")
+	if err == nil {
+		t.Fatal("expected verifyCodexHomeRoot to reject a symlinked codex home")
+	}
+	if !strings.Contains(err.Error(), "symlink") {
+		t.Fatalf("error %q does not report the symlink", err)
+	}
+}
+
+// End to end: a task home that is already a link to an outside directory must
+// fail the copy instead of provisioning through the link.
+func TestPrepareCodexHomeRefusesSymlinkedCodexHome(t *testing.T) {
+	// Cannot use t.Parallel() with t.Setenv.
+
+	sharedHome := t.TempDir()
+	if err := os.WriteFile(filepath.Join(sharedHome, "config.toml"), []byte(`model_instructions_file = "gpt-unrestricted.md"`), 0o644); err != nil {
+		t.Fatalf("write shared config.toml: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(sharedHome, "gpt-unrestricted.md"), []byte("from shared home"), 0o644); err != nil {
+		t.Fatalf("write shared instructions: %v", err)
+	}
+	t.Setenv("CODEX_HOME", sharedHome)
+
+	outside := t.TempDir()
+	sentinel := filepath.Join(outside, "gpt-unrestricted.md")
+	if err := os.WriteFile(sentinel, []byte("outside the task home"), 0o644); err != nil {
+		t.Fatalf("write sentinel: %v", err)
+	}
+	codexHome := filepath.Join(t.TempDir(), "codex-home")
+	if err := os.Symlink(outside, codexHome); err != nil {
+		t.Skipf("symlinks unsupported on this host: %v", err)
+	}
+
+	err := prepareCodexHome(codexHome, testLogger())
+	if err == nil {
+		t.Fatal("expected prepareCodexHome to refuse a symlinked codex home")
+	}
+	if !strings.Contains(err.Error(), "model_instructions_file") {
+		t.Fatalf("error %q does not name the offending key", err)
+	}
+
+	data, readErr := os.ReadFile(sentinel)
+	if readErr != nil {
+		t.Fatalf("sentinel outside the task home was removed: %v", readErr)
+	}
+	if string(data) != "outside the task home" {
+		t.Errorf("sentinel outside the task home was overwritten: %q", data)
+	}
+}
+
 // Regression test for #1753 — Codex Desktop writes plugin-backed
 // `[[skills.config]]` entries without a `path` field, and the CLI's TOML
 // parser rejects them with `missing field path`. prepareCodexHome must drop

--- a/server/internal/daemon/execenv/execenv_test.go
+++ b/server/internal/daemon/execenv/execenv_test.go
@@ -2842,9 +2842,15 @@ func TestVerifyCodexHomeRootRejectsSymlinkedHome(t *testing.T) {
 	}
 }
 
-// End to end: a task home that is already a link to an outside directory must
-// fail the copy instead of provisioning through the link.
-func TestPrepareCodexHomeRefusesSymlinkedCodexHome(t *testing.T) {
+// End to end, scoped to the write this change owns: when the task home is
+// already a link to an outside directory, the referenced-file copy must fail
+// instead of provisioning through the link.
+//
+// Deliberately not asserted: that nothing at all lands in the link target.
+// Earlier steps in prepareCodexHomeWithOpts (config.toml, sessions/, plugin
+// cache) still address codexHome by path and run before this check, so making
+// the whole prepare root-handle safe is a separate, larger change (MUL-5647).
+func TestPrepareCodexHomeRefusesReferencedFileWriteThroughSymlinkedCodexHome(t *testing.T) {
 	// Cannot use t.Parallel() with t.Setenv.
 
 	sharedHome := t.TempDir()


### PR DESCRIPTION
Fixes #6271
Fixes MUL-5623

## Background

A per-task `CODEX_HOME` copies the user's `config.toml` verbatim, so a `model_instructions_file = "./gpt-unrestricted.md"` reference survives the move while the file it names does not. Codex resolves the relative value against `CODEX_HOME` — now the task home — and fails while loading its configuration, before the task prompt is ever delivered:

```
failed to load configuration: failed to read model instructions file <task-codex-home>/gpt-unrestricted.md: The system cannot find the file. (os error 2) (code=-32600)
```

That error text is what pins the resolution base to `CODEX_HOME`, so provisioning the file at the same relative path inside the task home is enough — no rewriting of config values needed.

## Change

`syncCodexModelCatalog` already did exactly the right thing for `model_catalog_json`. This generalizes it into `syncCodexReferencedFiles` + `syncCodexReferencedFile(codexHome, sharedHome, key, value)` driven by a small table of path-valued config keys, and adds `model_instructions_file` plus the deprecated `experimental_instructions_file` alias Codex still accepts (older configs use it, and skipping it would fix only half the reports).

Per-key semantics:

- absolute / `~` values are left alone — same host, Codex reads them directly, and copying would only risk a stale snapshot;
- relative values must pass `filepath.IsLocal`, so a lexical `..` escape is rejected;
- destination mkdir / stale-copy removal / write go through a **verified `os.Root` handle** for the task home (see below);
- the copy is refreshed on every prepare, so a reused task home reflects an edited source instead of stale instructions;
- a missing source fails during environment preparation with a diagnostic naming the key, instead of an opaque `os error 2` after the task has launched; a stat failure that is *not* a confident absence (permission, IO) is reported as such rather than as "missing file".

Deliberately not done: no copying of the whole shared Codex home (that would drag `auth.json` and the machine's session history into every task), and no blanket "copy every path a config mentions" (that turns any user config into a channel for host files). The key table stays explicit. `skills.config[].path` is out of scope because `codex_skill_strip.go` already removes those entries from the copied config.

Source-side symlink policy is documented in the code and intentionally permissive: the relative path resolves inside the user's own `~/.codex` and links there are followed. The file is only read, and a task on this host can already read anything the daemon user can, so a link out of the shared home grants no access the task did not already have.

## Task-home write safety (review rounds 2 and 3)

`filepath.IsLocal` only validates the config string; it says nothing about the real destination path. A task home is reused, and the task that ran in it can replace an intermediate directory of the destination with a link elsewhere, which made the next prepare's `MkdirAll` / `Remove` / write follow that link **outside** the task home. Checking the path with `os.Lstat` and then opening it with `os.OpenRoot` was not enough either: `OpenRoot` re-resolves the path it is given, so a directory swapped between check and open yields a root that is properly confined — to the wrong tree.

Final shape: open the root first, then prove identity against the handle — `root.Stat(".")` compared with a no-follow `os.Lstat(codexHome)` via `os.SameFile`, with an outright reject when that path is a symlink. A swap before the open fails the check; a swap after it cannot matter, because every operation downstream uses the handle rather than the path. `verifyCodexHomeRoot` is split out so the swap case is tested deterministically instead of raced. The pre-existing `model_catalog_json` path shares the helper, so its identical gap closes too.

Negative-verified, not assumed: with the pre-fix plain-`os` write path the symlinked-parent test fails and the external sentinel is silently overwritten; with `os.SameFile` short-circuited the swap test fails. Both pass on the final code.

Out of scope and tracked separately in **MUL-5647**: the earlier steps of `prepareCodexHomeWithOpts` (`config.toml` copy, `sessions/`, plugin cache) still address the task home by path, so "the whole prepare is safe against a symlinked task home" is not yet true. The end-to-end test name and the code comments say so explicitly rather than implying broader coverage.

## Verification

```
gofmt -l   # clean for both changed files
go vet ./internal/daemon/execenv/
go build ./internal/daemon/...
go test ./internal/daemon/... -count=1   # daemon, daemon/execenv, daemon/repocache all ok
```

Eleven regression tests: relative reference copied and isolated from the shared source; nested reference via the deprecated alias, path built with `filepath.Join` so Windows exercises its own separator; missing source reported at prepare time with key + both paths; `../secrets.md` rejected and not materialised; reused task home refreshed after the source changes; symlinked destination *parent* refused on reuse with the outside sentinel byte-identical; symlinked destination *file* unlinked rather than written through; repointed key provisions the new target and leaves the old copy unreferenced (documented contract); task-home directory swapped after open rejected; task-home path replaced by a symlink rejected; end-to-end refusal of the referenced-file write through a symlinked task home.

Not verified: a live Windows Codex `thread/start` against a real 0.144.x binary — no Windows host in this environment. `os.Root` / `os.SameFile` behaviour on Windows is exercised by the `windows-execenv` CI job.
