### PR TITLE
MUL-5648: docs(cli): `issue search` searches comments too, and its number match ignores the prefix

### DIFF
--- a/server/cmd/multica/cmd_issue.go
+++ b/server/cmd/multica/cmd_issue.go
@@ -355,9 +355,14 @@ var issueSearchCmd = &cobra.Command{
 	Use:   "search <query>",
 	Short: "Search issues by title, description, or comments",
 	Long: "Search issues in the current workspace. The query is matched against issue\n" +
-		"titles, descriptions and comment bodies; a numeric query also matches an\n" +
-		"issue by its number. Comment bodies are searched too, so a conclusion that\n" +
-		"only ever landed in a comment thread is still findable here.\n\n" +
+		"titles, descriptions and comment bodies. Comment bodies are searched too,\n" +
+		"so a conclusion that only ever landed in a comment thread is still findable\n" +
+		"here.\n\n" +
+		"A bare number matches the issue with that number, and so does anything\n" +
+		"shaped like an identifier: \"AGE-412\" is equivalent to \"412\". The prefix is\n" +
+		"not validated, so \"MUL-412\" and \"ZZZ-412\" match local issue 412 just the\n" +
+		"same. Number matches rank first, so pasting an identifier from another\n" +
+		"tracker can put an unrelated local issue at the top of the results.\n\n" +
 		"Each result carries a match_source of \"title\", \"description\" or \"comment\",\n" +
 		"shown in the MATCH column and returned by --output json. It reports the\n" +
 		"strongest field that matched, and \"comment\" is also the fallback for a\n" +

--- a/server/cmd/multica/cmd_issue.go
+++ b/server/cmd/multica/cmd_issue.go
@@ -359,10 +359,13 @@ var issueSearchCmd = &cobra.Command{
 		"so a conclusion that only ever landed in a comment thread is still findable\n" +
 		"here.\n\n" +
 		"A bare number matches the issue with that number, and so does anything\n" +
-		"shaped like an identifier: \"AGE-412\" is equivalent to \"412\". The prefix is\n" +
-		"not validated, so \"MUL-412\" and \"ZZZ-412\" match local issue 412 just the\n" +
-		"same. Number matches rank first, so pasting an identifier from another\n" +
-		"tracker can put an unrelated local issue at the top of the results.\n\n" +
+		"shaped like an identifier: \"AGE-412\" and \"412\" both match issue 412. The\n" +
+		"number match is the same either way, but the text search still uses the\n" +
+		"query as written, so \"412\" also matches text containing \"1412\" while\n" +
+		"\"AGE-412\" does not. The prefix is not validated, so \"MUL-412\" and\n" +
+		"\"ZZZ-412\" match local issue 412 just the same. Number matches rank\n" +
+		"first, so pasting an identifier from another tracker can put an\n" +
+		"unrelated local issue at the top of the results.\n\n" +
 		"Each result carries a match_source of \"title\", \"description\" or \"comment\",\n" +
 		"shown in the MATCH column and returned by --output json. It reports the\n" +
 		"strongest field that matched, and \"comment\" is also the fallback for a\n" +

--- a/server/cmd/multica/cmd_issue.go
+++ b/server/cmd/multica/cmd_issue.go
@@ -353,9 +353,17 @@ var issueCancelTaskCmd = &cobra.Command{
 
 var issueSearchCmd = &cobra.Command{
 	Use:   "search <query>",
-	Short: "Search issues by title or description",
-	Args:  cobra.ExactArgs(1),
-	RunE:  runIssueSearch,
+	Short: "Search issues by title, description, or comments",
+	Long: "Search issues in the current workspace. The query is matched against issue\n" +
+		"titles, descriptions and comment bodies; a numeric query also matches an\n" +
+		"issue by its number. Comment bodies are searched too, so a conclusion that\n" +
+		"only ever landed in a comment thread is still findable here.\n\n" +
+		"Each result carries a match_source of \"title\", \"description\" or \"comment\",\n" +
+		"shown in the MATCH column and returned by --output json. It reports the\n" +
+		"strongest field that matched, and \"comment\" is also the fallback for a\n" +
+		"number-only match, so treat it as a display hint rather than a filter.",
+	Args: cobra.ExactArgs(1),
+	RunE: runIssueSearch,
 }
 
 var validIssueStatuses = []string{


### PR DESCRIPTION
## Problem

`multica issue search --help` says:

> Search issues by title or description

The server has always searched comment bodies too. `buildSearchQuery` in `server/internal/handler/issue.go` ORs an `EXISTS (SELECT 1 FROM comment c WHERE c.issue_id = i.id AND LOWER(c.content) LIKE ...)` into the WHERE clause, ranks comment hits at tiers 7/8, and returns `match_source: "comment"` for them.

This is not a rare path. On a real 400-issue workspace, a 20-query sample of `issue search` returned:

| match_source | hits | share |
|---|---:|---:|
| comment | 102 | 52.0% |
| description | 69 | 35.2% |
| title | 25 | 12.8% |

Repro against any workspace with discussion history:

```bash
multica issue search "iOS TestFlight" --include-closed --limit 20 --output json \
  | jq -r '.issues[] | "\(.identifier) \(.match_source)"'
```

More than half the hits come from a source the help text says isn't searched. Readers who trust it conclude a decision recorded in a comment thread can't be found via search, and fall back to paging through whole comment histories instead — slower and more expensive.

## Change

Docs only, one command's help text. `Short` becomes `Search issues by title, description, or comments`, and a new `Long` states the actual match surface plus two behaviors that are easy to get wrong.

**1. `match_source` is a hint, not a filter.** The expression is a `CASE` that falls through to `'comment'`, so a hit that matched only by issue number is also reported as `comment`, with an empty snippet:

```
$ multica issue search "407" --include-closed --output json \
    | jq -r '.issues[0] | "\(.identifier) \(.match_source) sniplen=\(.matched_snippet|length)"'
AGE-407 comment sniplen=0
```

That issue has no comments. The help now says to read `match_source` as a display hint for the strongest matching field — which is how the web and mobile clients already treat it (both render description and comment snippets regardless of its value).

**2. Identifier-shaped queries ignore the prefix.** `parseQueryNumber` accepts a bare number *or* `(?i)^[a-z]+-(\d+)$`, and never validates the prefix against the current workspace:

```
$ multica issue search "MUL-411" --include-closed   # workspace prefix is AGE
rank 1: AGE-411   match_source=comment   sniplen=0
$ multica issue search "ZZZ-411" --include-closed
rank 1: AGE-411   match_source=comment   sniplen=0
```

A number match is rank tier 0, so an id pasted from another tracker puts an unrelated local issue at the *top* of the results. External ids show up routinely in docs and code comments, so this produces a confident wrong answer rather than an empty one. The previous wording said only "a numeric query", which read as bare-digits-only and hid it.

Both are documented, not changed. The loose prefix match is plausibly deliberate — paste an id from anywhere and still find something — and tightening it is a product decision, not a bug fix.

## Verification

```
$ gofmt -l server/cmd/multica/cmd_issue.go     # clean
$ go build ./...                                # ok
$ go test ./cmd/multica/                        # ok  1.314s
$ ./multica issue search --help
Search issues in the current workspace. The query is matched against issue
titles, descriptions and comment bodies. Comment bodies are searched too,
so a conclusion that only ever landed in a comment thread is still findable
here.

A bare number matches the issue with that number, and so does anything
shaped like an identifier: "AGE-412" is equivalent to "412". The prefix is
not validated, so "MUL-412" and "ZZZ-412" match local issue 412 just the
same. Number matches rank first, so pasting an identifier from another
tracker can put an unrelated local issue at the top of the results.

Each result carries a match_source of "title", "description" or "comment",
shown in the MATCH column and returned by --output json. It reports the
strongest field that matched, and "comment" is also the fallback for a
number-only match, so treat it as a display hint rather than a filter.
```

No behavior change — deliberately. Comment search is the correct behavior; only the documentation was wrong.
