### PR TITLE
MUL-5547: fix(daemon): detect Volta-managed CLIs

### DIFF
--- a/server/internal/daemon/agent_path_selfheal_test.go
+++ b/server/internal/daemon/agent_path_selfheal_test.go
@@ -2,6 +2,7 @@ package daemon
 
 import (
 	"context"
+	"github.com/multica-ai/multica/server/pkg/agent"
 	"log/slog"
 	"os"
 	"path/filepath"
@@ -28,7 +29,7 @@ func newSelfHealTestDaemon() *Daemon {
 func stubDetectVersionFromPath(t *testing.T) {
 	t.Helper()
 	orig := detectAgentVersion
-	detectAgentVersion = func(_ context.Context, path string, _ []string) (string, error) {
+	detectAgentVersion = func(_ context.Context, path string, _ agent.ExecEnv) (string, error) {
 		return filepath.Base(filepath.Dir(filepath.Dir(path))), nil
 	}
 	t.Cleanup(func() { detectAgentVersion = orig })

--- a/server/internal/daemon/agent_path_selfheal_test.go
+++ b/server/internal/daemon/agent_path_selfheal_test.go
@@ -28,7 +28,7 @@ func newSelfHealTestDaemon() *Daemon {
 func stubDetectVersionFromPath(t *testing.T) {
 	t.Helper()
 	orig := detectAgentVersion
-	detectAgentVersion = func(_ context.Context, path string) (string, error) {
+	detectAgentVersion = func(_ context.Context, path string, _ []string) (string, error) {
 		return filepath.Base(filepath.Dir(filepath.Dir(path))), nil
 	}
 	t.Cleanup(func() { detectAgentVersion = orig })

--- a/server/internal/daemon/agents_probe.go
+++ b/server/internal/daemon/agents_probe.go
@@ -111,10 +111,12 @@ var probeAgentCLIs = func() map[string]AgentEntry {
 		cmd := envOrDefault(envVar, defaultCmd)
 		if resolved, err := resolveAgentExecutable(cmd); err == nil {
 			return AgentEntry{
-				Path:    resolved.Path,
-				Env:     resolved.Env,
-				Command: cmd,
-				Model:   strings.TrimSpace(os.Getenv(modelEnv)),
+				Path:         resolved.Path,
+				Env:          resolved.Env,
+				EnvStampPath: resolved.StampPath,
+				EnvStampHash: resolved.StampHash,
+				Command:      cmd,
+				Model:        strings.TrimSpace(os.Getenv(modelEnv)),
 			}, true
 		}
 		// The shell fallback only rescues bare command names. An operator
@@ -133,10 +135,12 @@ var probeAgentCLIs = func() map[string]AgentEntry {
 			// hold — the inconsistency #6183's fix is supposed to remove.
 			resolved := canonicalExecutable(path)
 			return AgentEntry{
-				Path:    resolved.Path,
-				Env:     resolved.Env,
-				Command: cmd,
-				Model:   strings.TrimSpace(os.Getenv(modelEnv)),
+				Path:         resolved.Path,
+				Env:          resolved.Env,
+				EnvStampPath: resolved.StampPath,
+				EnvStampHash: resolved.StampHash,
+				Command:      cmd,
+				Model:        strings.TrimSpace(os.Getenv(modelEnv)),
 			}, true
 		}
 		if defaultCmd == "codex" && cmd == defaultCmd {

--- a/server/internal/daemon/agents_probe.go
+++ b/server/internal/daemon/agents_probe.go
@@ -109,11 +109,12 @@ var probeAgentCLIs = func() map[string]AgentEntry {
 	getShellResolved := cachedShellResolvedAgents
 	probe := func(envVar, defaultCmd, modelEnv string) (AgentEntry, bool) {
 		cmd := envOrDefault(envVar, defaultCmd)
-		if path, err := resolveAgentExecutablePath(cmd); err == nil {
+		if resolved, err := resolveAgentExecutable(cmd); err == nil {
 			return AgentEntry{
-				Path:    path,
-				Command: cmd,
-				Model:   strings.TrimSpace(os.Getenv(modelEnv)),
+				Path:     resolved.Path,
+				PathDirs: resolved.PathDirs,
+				Command:  cmd,
+				Model:    strings.TrimSpace(os.Getenv(modelEnv)),
 			}, true
 		}
 		// The shell fallback only rescues bare command names. An operator
@@ -124,10 +125,18 @@ var probeAgentCLIs = func() map[string]AgentEntry {
 			return AgentEntry{}, false
 		}
 		if path, ok := getShellResolved()[cmd]; ok {
+			// The login-shell script only canonicalizes the *directory* and
+			// keeps the file name, so a Volta alias arrives here still pointing
+			// at the shared shim. Run it through the same resolution the
+			// LookPath leg uses, or a GUI-launched daemon (the case this
+			// fallback exists for) would pin an alias the version gate cannot
+			// hold — the inconsistency #6183's fix is supposed to remove.
+			resolved := canonicalExecutable(path)
 			return AgentEntry{
-				Path:    path,
-				Command: cmd,
-				Model:   strings.TrimSpace(os.Getenv(modelEnv)),
+				Path:     resolved.Path,
+				PathDirs: resolved.PathDirs,
+				Command:  cmd,
+				Model:    strings.TrimSpace(os.Getenv(modelEnv)),
 			}, true
 		}
 		if defaultCmd == "codex" && cmd == defaultCmd {

--- a/server/internal/daemon/agents_probe.go
+++ b/server/internal/daemon/agents_probe.go
@@ -111,10 +111,10 @@ var probeAgentCLIs = func() map[string]AgentEntry {
 		cmd := envOrDefault(envVar, defaultCmd)
 		if resolved, err := resolveAgentExecutable(cmd); err == nil {
 			return AgentEntry{
-				Path:     resolved.Path,
-				PathDirs: resolved.PathDirs,
-				Command:  cmd,
-				Model:    strings.TrimSpace(os.Getenv(modelEnv)),
+				Path:    resolved.Path,
+				Env:     resolved.Env,
+				Command: cmd,
+				Model:   strings.TrimSpace(os.Getenv(modelEnv)),
 			}, true
 		}
 		// The shell fallback only rescues bare command names. An operator
@@ -133,10 +133,10 @@ var probeAgentCLIs = func() map[string]AgentEntry {
 			// hold — the inconsistency #6183's fix is supposed to remove.
 			resolved := canonicalExecutable(path)
 			return AgentEntry{
-				Path:     resolved.Path,
-				PathDirs: resolved.PathDirs,
-				Command:  cmd,
-				Model:    strings.TrimSpace(os.Getenv(modelEnv)),
+				Path:    resolved.Path,
+				Env:     resolved.Env,
+				Command: cmd,
+				Model:   strings.TrimSpace(os.Getenv(modelEnv)),
 			}, true
 		}
 		if defaultCmd == "codex" && cmd == defaultCmd {

--- a/server/internal/daemon/agents_probe_volta_real_test.go
+++ b/server/internal/daemon/agents_probe_volta_real_test.go
@@ -12,25 +12,30 @@ import (
 )
 
 // Opt-in integration coverage for #6183 against a REAL Volta installation.
-// The fixture-based tests in agents_probe_volta_test.go model Volta's shim
-// behavior; these prove the model matches the real thing, which is the one gap
-// a fixture cannot close by construction.
+// The fixture tests in agents_probe_volta_test.go model Volta's shim behavior;
+// these prove the model matches the real thing, which is the one gap a fixture
+// cannot close by construction.
 //
-// Skipped unless MULTICA_VERIFY_VOLTA_HOME points at a Volta home (the
-// directory containing bin/volta-shim), so CI and ordinary `go test` runs are
-// unaffected. To run it:
+// Skipped unless MULTICA_VERIFY_VOLTA_HOME points at a Volta home (the directory
+// containing bin/volta-shim), so CI and ordinary `go test` runs are unaffected:
 //
 //	export VOLTA_HOME=/tmp/volta-check
-//	curl -fsSL https://get.volta.sh | bash -s -- --skip-setup   # --skip-setup: no profile edits
+//	curl -fsSL https://get.volta.sh | bash -s -- --skip-setup   # no profile edits
 //	export PATH="$VOLTA_HOME/bin:$PATH"
 //	volta install node
 //	volta install @anthropic-ai/claude-code @openai/codex
 //	MULTICA_VERIFY_VOLTA_HOME="$VOLTA_HOME" go test ./internal/daemon -run TestRealVolta -v
 //
 // Verified on macOS arm64 with Volta 2.0.2, claude-code 2.1.220, codex 0.146.0.
+// Note those two differ in a way that matters: claude ships a native binary,
+// while codex is a `#!/usr/bin/env node` script — which is why resolution has to
+// carry Volta's Node platform and not just a path.
 
-// requireRealVolta skips unless a real Volta home is configured, and points the
-// resolution environment at it.
+// requireRealVolta skips unless a real Volta home is configured.
+//
+// Deliberately does NOT put Volta's bin dir on PATH. Doing so hides the whole
+// point of item 3: the shim dir contains a `node` shim, so a package script would
+// find node by accident and the missing execution environment would go unnoticed.
 func requireRealVolta(t *testing.T) (voltaHome, binDir string) {
 	t.Helper()
 	voltaHome = strings.TrimSpace(os.Getenv("MULTICA_VERIFY_VOLTA_HOME"))
@@ -41,20 +46,24 @@ func requireRealVolta(t *testing.T) (voltaHome, binDir string) {
 	if _, err := os.Stat(filepath.Join(binDir, voltaShimName)); err != nil {
 		t.Fatalf("no %s in %s: %v", voltaShimName, binDir, err)
 	}
-	// The daemon inherits VOLTA_HOME from its environment; a default ~/.volta
-	// install needs nothing set. /usr/bin stays on PATH because the real CLIs
-	// are `#!/usr/bin/env node` scripts.
+	// The daemon inherits VOLTA_HOME; a default ~/.volta install needs nothing.
 	t.Setenv("VOLTA_HOME", voltaHome)
-	t.Setenv("PATH", binDir+string(os.PathListSeparator)+"/usr/bin"+string(os.PathListSeparator)+"/bin")
 	resetVoltaResolveCache(t)
 	return voltaHome, binDir
 }
 
-// TestRealVolta_PlainSymlinkResolutionIsUnrunnable is the counterfactual: it
-// pins why plain canonicalization cannot be used for a Volta alias. Every
-// managed command collapses onto one volta-shim, which refuses to run.
+// systemOnlyPath is a PATH with no node and no Volta on it, modelling the
+// GUI-launched daemon this fix has to work under.
+func systemOnlyPath() string {
+	return "/usr/bin" + string(os.PathListSeparator) + "/bin"
+}
+
+// TestRealVolta_PlainSymlinkResolutionIsUnrunnable is the counterfactual: plain
+// canonicalization collapses every managed command onto one volta-shim, which
+// refuses to run.
 func TestRealVolta_PlainSymlinkResolutionIsUnrunnable(t *testing.T) {
 	_, binDir := requireRealVolta(t)
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+systemOnlyPath())
 
 	alias := filepath.Join(binDir, "claude")
 	collapsed, err := filepath.EvalSymlinks(alias)
@@ -70,10 +79,14 @@ func TestRealVolta_PlainSymlinkResolutionIsUnrunnable(t *testing.T) {
 	}
 }
 
-// TestRealVolta_ResolvesConcreteBinary asserts the daemon pins exactly what
-// Volta itself reports, so the path we gate is the path we launch.
-func TestRealVolta_ResolvesConcreteBinary(t *testing.T) {
+// TestRealVolta_ResolvesConcreteBinaryWithEnvironment asserts the daemon pins
+// what Volta itself reports AND carries an environment that makes it runnable
+// from a PATH that has no node at all.
+func TestRealVolta_ResolvesConcreteBinaryWithEnvironment(t *testing.T) {
 	_, binDir := requireRealVolta(t)
+	// Volta's own bin dir is on PATH only so LookPath can find the alias; the
+	// version probe's environment is what the resolution supplies.
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+systemOnlyPath())
 
 	for _, command := range []string{"claude", "codex"} {
 		out, err := exec.Command(filepath.Join(binDir, "volta"), "which", command).Output()
@@ -82,28 +95,67 @@ func TestRealVolta_ResolvesConcreteBinary(t *testing.T) {
 		}
 		want := strings.TrimSpace(string(out))
 
-		got, err := resolveAgentExecutablePath(command)
+		resolved, err := resolveAgentExecutable(command)
 		if err != nil {
-			t.Fatalf("%s: resolveAgentExecutablePath: %v", command, err)
+			t.Fatalf("%s: resolveAgentExecutable: %v", command, err)
 		}
-		if got != want {
-			t.Errorf("%s path = %q, want the `volta which` answer %q", command, got, want)
+		if resolved.Path != want {
+			t.Errorf("%s path = %q, want the `volta which` answer %q", command, resolved.Path, want)
+		}
+		if len(resolved.PathDirs) == 0 {
+			t.Errorf("%s carries no PATH dirs; a node-script package bin would be unrunnable", command)
 		}
 
-		version, err := agent.DetectVersion(context.Background(), got)
+		version, err := agent.DetectVersionWithPathDirs(context.Background(), resolved.Path, resolved.PathDirs)
 		if err != nil {
-			t.Fatalf("%s: DetectVersion(%q): %v", command, got, err)
+			t.Fatalf("%s: DetectVersionWithPathDirs(%q): %v", command, resolved.Path, err)
 		}
 		if err := agent.CheckMinVersion(command, version); err != nil {
 			t.Errorf("%s version %q failed the real min-version gate: %v", command, version, err)
 		}
+		t.Logf("%s -> %s (version %q, pathDirs %v)", command, resolved.Path, version, resolved.PathDirs)
+	}
+}
+
+// TestRealVolta_ResolvedEnvironmentIsRequired proves the carried environment is
+// load-bearing on a real install rather than decorative: at least one of the real
+// CLIs must fail without it. codex 0.146.0 is a `#!/usr/bin/env node` script and
+// does; claude ships a native binary and does not, so this asserts on the set.
+func TestRealVolta_ResolvedEnvironmentIsRequired(t *testing.T) {
+	_, binDir := requireRealVolta(t)
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+systemOnlyPath())
+
+	needsEnv := 0
+	for _, command := range []string{"claude", "codex"} {
+		resolved, err := resolveAgentExecutable(command)
+		if err != nil {
+			t.Fatalf("%s: resolveAgentExecutable: %v", command, err)
+		}
+		// Bare PATH, no node, no Volta: what a GUI-launched daemon looks like.
+		t.Setenv("PATH", systemOnlyPath())
+		_, withoutEnv := agent.DetectVersion(context.Background(), resolved.Path)
+		_, withEnv := agent.DetectVersionWithPathDirs(context.Background(), resolved.Path, resolved.PathDirs)
+		t.Setenv("PATH", binDir+string(os.PathListSeparator)+systemOnlyPath())
+
+		if withEnv != nil {
+			t.Errorf("%s failed even with the resolved environment: %v", command, withEnv)
+		}
+		if withoutEnv != nil {
+			needsEnv++
+			t.Logf("%s requires the resolved environment (without it: %v)", command, withoutEnv)
+		}
+	}
+	if needsEnv == 0 {
+		t.Error("no real CLI required the resolved environment; if the installed packages " +
+			"are all native binaries this check cannot prove anything — install a node-script CLI (codex)")
 	}
 }
 
 // TestRealVolta_RegistersRuntimes is the user-visible outcome from the report:
 // Volta-managed CLIs must reach the registration payload.
 func TestRealVolta_RegistersRuntimes(t *testing.T) {
-	requireRealVolta(t)
+	_, binDir := requireRealVolta(t)
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+systemOnlyPath())
 	isolateAgentDiscovery(t)
 
 	d := freshDaemon("")
@@ -113,6 +165,7 @@ func TestRealVolta_RegistersRuntimes(t *testing.T) {
 	for _, rt := range d.detectBuiltinRuntimes(context.Background()) {
 		registered[rt["type"]] = rt["version"]
 	}
+	t.Logf("registered: %#v", registered)
 	for _, command := range []string{"claude", "codex"} {
 		if _, ok := registered[command]; !ok {
 			t.Errorf("%s missing from the registration payload; skipped reasons: %#v",

--- a/server/internal/daemon/agents_probe_volta_real_test.go
+++ b/server/internal/daemon/agents_probe_volta_real_test.go
@@ -1,0 +1,122 @@
+package daemon
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/multica-ai/multica/server/pkg/agent"
+)
+
+// Opt-in integration coverage for #6183 against a REAL Volta installation.
+// The fixture-based tests in agents_probe_volta_test.go model Volta's shim
+// behavior; these prove the model matches the real thing, which is the one gap
+// a fixture cannot close by construction.
+//
+// Skipped unless MULTICA_VERIFY_VOLTA_HOME points at a Volta home (the
+// directory containing bin/volta-shim), so CI and ordinary `go test` runs are
+// unaffected. To run it:
+//
+//	export VOLTA_HOME=/tmp/volta-check
+//	curl -fsSL https://get.volta.sh | bash -s -- --skip-setup   # --skip-setup: no profile edits
+//	export PATH="$VOLTA_HOME/bin:$PATH"
+//	volta install node
+//	volta install @anthropic-ai/claude-code @openai/codex
+//	MULTICA_VERIFY_VOLTA_HOME="$VOLTA_HOME" go test ./internal/daemon -run TestRealVolta -v
+//
+// Verified on macOS arm64 with Volta 2.0.2, claude-code 2.1.220, codex 0.146.0.
+
+// requireRealVolta skips unless a real Volta home is configured, and points the
+// resolution environment at it.
+func requireRealVolta(t *testing.T) (voltaHome, binDir string) {
+	t.Helper()
+	voltaHome = strings.TrimSpace(os.Getenv("MULTICA_VERIFY_VOLTA_HOME"))
+	if voltaHome == "" {
+		t.Skip("set MULTICA_VERIFY_VOLTA_HOME to a Volta home to run the real-Volta checks")
+	}
+	binDir = filepath.Join(voltaHome, "bin")
+	if _, err := os.Stat(filepath.Join(binDir, voltaShimName)); err != nil {
+		t.Fatalf("no %s in %s: %v", voltaShimName, binDir, err)
+	}
+	// The daemon inherits VOLTA_HOME from its environment; a default ~/.volta
+	// install needs nothing set. /usr/bin stays on PATH because the real CLIs
+	// are `#!/usr/bin/env node` scripts.
+	t.Setenv("VOLTA_HOME", voltaHome)
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+"/usr/bin"+string(os.PathListSeparator)+"/bin")
+	resetVoltaResolveCache(t)
+	return voltaHome, binDir
+}
+
+// TestRealVolta_PlainSymlinkResolutionIsUnrunnable is the counterfactual: it
+// pins why plain canonicalization cannot be used for a Volta alias. Every
+// managed command collapses onto one volta-shim, which refuses to run.
+func TestRealVolta_PlainSymlinkResolutionIsUnrunnable(t *testing.T) {
+	_, binDir := requireRealVolta(t)
+
+	alias := filepath.Join(binDir, "claude")
+	collapsed, err := filepath.EvalSymlinks(alias)
+	if err != nil {
+		t.Fatalf("EvalSymlinks(%q): %v", alias, err)
+	}
+	if filepath.Base(collapsed) != voltaShimName {
+		t.Fatalf("expected %q to collapse onto %s, got %q", alias, voltaShimName, collapsed)
+	}
+	if _, err := agent.DetectVersion(context.Background(), collapsed); err == nil {
+		t.Fatal("collapsed shim path unexpectedly answered --version; " +
+			"the whole exception exists because it exits 126")
+	}
+}
+
+// TestRealVolta_ResolvesConcreteBinary asserts the daemon pins exactly what
+// Volta itself reports, so the path we gate is the path we launch.
+func TestRealVolta_ResolvesConcreteBinary(t *testing.T) {
+	_, binDir := requireRealVolta(t)
+
+	for _, command := range []string{"claude", "codex"} {
+		out, err := exec.Command(filepath.Join(binDir, "volta"), "which", command).Output()
+		if err != nil {
+			t.Fatalf("volta which %s: %v", command, err)
+		}
+		want := strings.TrimSpace(string(out))
+
+		got, err := resolveAgentExecutablePath(command)
+		if err != nil {
+			t.Fatalf("%s: resolveAgentExecutablePath: %v", command, err)
+		}
+		if got != want {
+			t.Errorf("%s path = %q, want the `volta which` answer %q", command, got, want)
+		}
+
+		version, err := agent.DetectVersion(context.Background(), got)
+		if err != nil {
+			t.Fatalf("%s: DetectVersion(%q): %v", command, got, err)
+		}
+		if err := agent.CheckMinVersion(command, version); err != nil {
+			t.Errorf("%s version %q failed the real min-version gate: %v", command, version, err)
+		}
+	}
+}
+
+// TestRealVolta_RegistersRuntimes is the user-visible outcome from the report:
+// Volta-managed CLIs must reach the registration payload.
+func TestRealVolta_RegistersRuntimes(t *testing.T) {
+	requireRealVolta(t)
+	isolateAgentDiscovery(t)
+
+	d := freshDaemon("")
+	d.cfg.Agents = probeAgentCLIs()
+
+	registered := map[string]string{}
+	for _, rt := range d.detectBuiltinRuntimes(context.Background()) {
+		registered[rt["type"]] = rt["version"]
+	}
+	for _, command := range []string{"claude", "codex"} {
+		if _, ok := registered[command]; !ok {
+			t.Errorf("%s missing from the registration payload; skipped reasons: %#v",
+				command, d.skippedAgentsSnapshot())
+		}
+	}
+}

--- a/server/internal/daemon/agents_probe_volta_real_test.go
+++ b/server/internal/daemon/agents_probe_volta_real_test.go
@@ -46,8 +46,12 @@ func requireRealVolta(t *testing.T) (voltaHome, binDir string) {
 	if _, err := os.Stat(filepath.Join(binDir, voltaShimName)); err != nil {
 		t.Fatalf("no %s in %s: %v", voltaShimName, binDir, err)
 	}
-	// The daemon inherits VOLTA_HOME; a default ~/.volta install needs nothing.
-	t.Setenv("VOLTA_HOME", voltaHome)
+	// Deliberately does NOT export VOLTA_HOME. A GUI-launched daemon never
+	// inherits it, and setting it here would bypass the very scenario the report
+	// describes: resolution has to derive the home from the alias path. For a
+	// non-default install (as used here) an unset VOLTA_HOME would otherwise send
+	// Volta looking in ~/.volta.
+	unsetEnvForTest(t, "VOLTA_HOME")
 	resetVoltaResolveCache(t)
 	return voltaHome, binDir
 }
@@ -83,13 +87,16 @@ func TestRealVolta_PlainSymlinkResolutionIsUnrunnable(t *testing.T) {
 // what Volta itself reports AND carries an environment that makes it runnable
 // from a PATH that has no node at all.
 func TestRealVolta_ResolvesConcreteBinaryWithEnvironment(t *testing.T) {
-	_, binDir := requireRealVolta(t)
+	voltaHome, binDir := requireRealVolta(t)
 	// Volta's own bin dir is on PATH only so LookPath can find the alias; the
 	// version probe's environment is what the resolution supplies.
 	t.Setenv("PATH", binDir+string(os.PathListSeparator)+systemOnlyPath())
 
 	for _, command := range []string{"claude", "codex"} {
-		out, err := exec.Command(filepath.Join(binDir, "volta"), "which", command).Output()
+		ground := exec.Command(filepath.Join(binDir, "volta"), "which", command)
+		ground.Dir = string(os.PathSeparator)
+		ground.Env = append(os.Environ(), "VOLTA_HOME="+voltaHome)
+		out, err := ground.Output()
 		if err != nil {
 			t.Fatalf("volta which %s: %v", command, err)
 		}
@@ -102,18 +109,18 @@ func TestRealVolta_ResolvesConcreteBinaryWithEnvironment(t *testing.T) {
 		if resolved.Path != want {
 			t.Errorf("%s path = %q, want the `volta which` answer %q", command, resolved.Path, want)
 		}
-		if len(resolved.PathDirs) == 0 {
+		if len(resolved.Env.PrefixPaths["PATH"]) == 0 {
 			t.Errorf("%s carries no PATH dirs; a node-script package bin would be unrunnable", command)
 		}
 
-		version, err := agent.DetectVersionWithPathDirs(context.Background(), resolved.Path, resolved.PathDirs)
+		version, err := agent.DetectVersionWithEnv(context.Background(), resolved.Path, resolved.Env)
 		if err != nil {
-			t.Fatalf("%s: DetectVersionWithPathDirs(%q): %v", command, resolved.Path, err)
+			t.Fatalf("%s: DetectVersionWithEnv(%q): %v", command, resolved.Path, err)
 		}
 		if err := agent.CheckMinVersion(command, version); err != nil {
 			t.Errorf("%s version %q failed the real min-version gate: %v", command, version, err)
 		}
-		t.Logf("%s -> %s (version %q, pathDirs %v)", command, resolved.Path, version, resolved.PathDirs)
+		t.Logf("%s -> %s (version %q, pathDirs %v)", command, resolved.Path, version, resolved.Env.PrefixPaths["PATH"])
 	}
 }
 
@@ -134,7 +141,7 @@ func TestRealVolta_ResolvedEnvironmentIsRequired(t *testing.T) {
 		// Bare PATH, no node, no Volta: what a GUI-launched daemon looks like.
 		t.Setenv("PATH", systemOnlyPath())
 		_, withoutEnv := agent.DetectVersion(context.Background(), resolved.Path)
-		_, withEnv := agent.DetectVersionWithPathDirs(context.Background(), resolved.Path, resolved.PathDirs)
+		_, withEnv := agent.DetectVersionWithEnv(context.Background(), resolved.Path, resolved.Env)
 		t.Setenv("PATH", binDir+string(os.PathListSeparator)+systemOnlyPath())
 
 		if withEnv != nil {

--- a/server/internal/daemon/agents_probe_volta_test.go
+++ b/server/internal/daemon/agents_probe_volta_test.go
@@ -245,6 +245,17 @@ func unsetEnvForTest(t *testing.T, name string) {
 	}
 }
 
+// entryFor turns a resolution into the AgentEntry shape the daemon caches.
+func entryFor(resolved resolvedExecutable) AgentEntry {
+	return AgentEntry{
+		Path:         resolved.Path,
+		Env:          resolved.Env,
+		EnvStampPath: resolved.StampPath,
+		EnvStampHash: resolved.StampHash,
+		Command:      "claude",
+	}
+}
+
 func resetVoltaResolveCache(t *testing.T) {
 	t.Helper()
 	clear := func() {
@@ -463,11 +474,17 @@ func TestVoltaResolve_BudgetResetsAfterCooldown(t *testing.T) {
 	resetVoltaResolveCache(t)
 
 	origRun, origCooldown, origBudget := runVolta, voltaFailureCooldown, voltaResolveBudget
+	origMiss := voltaCommandMissCooldown
 	t.Cleanup(func() {
 		runVolta, voltaFailureCooldown, voltaResolveBudget = origRun, origCooldown, origBudget
+		voltaCommandMissCooldown = origMiss
 	})
 	voltaFailureCooldown = 20 * time.Millisecond
 	voltaResolveBudget = 60 * time.Millisecond
+	// Shortened so the PER-COMMAND negative cache is not what suppresses the
+	// retries: this test is about the installation budget resetting, and the
+	// per-command gate would otherwise mask it.
+	voltaCommandMissCooldown = 5 * time.Millisecond
 
 	var mu sync.Mutex
 	calls := 0
@@ -508,11 +525,18 @@ func TestVoltaResolve_BoundsTotalCostWhenVoltaHangs(t *testing.T) {
 	resetVoltaResolveCache(t)
 
 	origRun, origTimeout, origWait := runVolta, voltaResolveTimeout, voltaResolveWaitDelay
+	origBudget := voltaResolveBudget
 	t.Cleanup(func() {
 		runVolta, voltaResolveTimeout, voltaResolveWaitDelay = origRun, origTimeout, origWait
+		voltaResolveBudget = origBudget
 	})
 	voltaResolveTimeout = 100 * time.Millisecond
 	voltaResolveWaitDelay = 50 * time.Millisecond
+	// Scaled to the production ratio: one timed-out query costs
+	// timeout+waitDelay, and the budget admits a second attempt before tripping
+	// the installation cooldown (real values: ~6s per failure against an 8s
+	// budget). So a hung install costs at most two timeouts, never one per command.
+	voltaResolveBudget = 200 * time.Millisecond
 
 	var mu sync.Mutex
 	calls := 0
@@ -539,9 +563,10 @@ func TestVoltaResolve_BoundsTotalCostWhenVoltaHangs(t *testing.T) {
 	mu.Lock()
 	got := calls
 	mu.Unlock()
-	if got != 1 {
-		t.Errorf("`volta` was invoked %d times for %d commands, want 1; a broken install must "+
-			"be asked once per cooldown, not once per command", got, len(commands))
+	if got > 2 {
+		t.Errorf("`volta` was invoked %d times for %d commands, want at most 2; a hung install "+
+			"must trip the installation cooldown once the budget is spent, not pay a timeout "+
+			"per command", got, len(commands))
 	}
 	singleCall := voltaResolveTimeout + voltaResolveWaitDelay
 	if additive := time.Duration(len(commands)) * singleCall; elapsed >= additive {
@@ -965,7 +990,7 @@ func TestVoltaPlatformDirs_RestoresFullPlatform(t *testing.T) {
 	managers := map[string]string{"npm": "10.2.0", "pnpm": "9.1.0", "yarn": "4.1.0"}
 	f := newVoltaFixture(t, voltaFixtureOpts{commands: []string{"claude"}, managers: managers})
 
-	dirs, ok := voltaPlatformDirs(f.home, "claude")
+	dirs, _, ok := voltaPlatformDirs(f.home, "claude")
 	if !ok {
 		t.Fatal("voltaPlatformDirs failed")
 	}
@@ -991,7 +1016,7 @@ func TestVoltaPlatformDirs_NodeOnlyWhenNoManagersPinned(t *testing.T) {
 	skipIfNoPOSIXShell(t)
 	f := newVoltaFixture(t, voltaFixtureOpts{commands: []string{"claude"}})
 
-	dirs, ok := voltaPlatformDirs(f.home, "claude")
+	dirs, _, ok := voltaPlatformDirs(f.home, "claude")
 	if !ok {
 		t.Fatal("voltaPlatformDirs failed")
 	}
@@ -1080,9 +1105,14 @@ func TestVoltaResolve_InstallationLevelBudget(t *testing.T) {
 	skipIfNoPOSIXShell(t)
 	resetVoltaResolveCache(t)
 
-	origRun, origTimeout := runVolta, voltaResolveTimeout
-	t.Cleanup(func() { runVolta, voltaResolveTimeout = origRun, origTimeout })
+	origRun, origTimeout, origBudget := runVolta, voltaResolveTimeout, voltaResolveBudget
+	t.Cleanup(func() {
+		runVolta, voltaResolveTimeout, voltaResolveBudget = origRun, origTimeout, origBudget
+	})
 	voltaResolveTimeout = 80 * time.Millisecond
+	// One timed-out query already spends the budget, so the installation cooldown
+	// opens immediately and the other commands must not query at all.
+	voltaResolveBudget = 50 * time.Millisecond
 
 	var mu sync.Mutex
 	calls := 0
@@ -1132,7 +1162,7 @@ func TestAgentEntryLaunchable_RequiresEnvironmentDirs(t *testing.T) {
 	if !ok {
 		t.Fatal("resolution failed")
 	}
-	if !agentEntryLaunchable(resolved.Path, resolved.Env) {
+	if !agentEntryLaunchable(entryFor(resolved)) {
 		t.Fatal("fresh resolution reported not launchable")
 	}
 
@@ -1143,7 +1173,7 @@ func TestAgentEntryLaunchable_RequiresEnvironmentDirs(t *testing.T) {
 	if !agentExecutablePresent(resolved.Path) {
 		t.Fatal("fixture removed the CLI too; the test would not prove anything")
 	}
-	if agentEntryLaunchable(resolved.Path, resolved.Env) {
+	if agentEntryLaunchable(entryFor(resolved)) {
 		t.Error("entry still considered launchable after its bound Node image was pruned; " +
 			"tasks would keep launching with a PATH that points nowhere")
 	}
@@ -1209,5 +1239,217 @@ func TestLayerTaskEnvironment_ResolvedEnvSurvivesCustomEnv(t *testing.T) {
 	wantPath := "/volta/tools/image/node/20.11.0/bin" + sep + "/usr/bin"
 	if agentEnv["PATH"] != wantPath {
 		t.Errorf("PATH = %q, want %q", agentEnv["PATH"], wantPath)
+	}
+}
+
+// rebindFixture rewrites a command's bin config to point at a different Node,
+// modelling `volta install <pkg>` against a newer default while the previous Node
+// image stays on disk for other tools.
+func rebindFixture(t *testing.T, f voltaFixture, command, newNode string) {
+	t.Helper()
+	mkdirs(t, f.nodeDir(newNode))
+	writeScript(t, filepath.Join(f.nodeDir(newNode), "node"), "#!/bin/sh\nexit 0\n")
+	writeVoltaConfigFile(t, voltaBinConfigPath(f.home, command),
+		voltaBinConfigJSON(command, newNode, nil))
+}
+
+// TestVoltaResolve_DetectsRebindToDifferentNode covers the rebind case: nothing is
+// missing after `volta install` picks a new Node — the old image is still there for
+// other tools — so only the bin config's contents reveal the change.
+func TestVoltaResolve_DetectsRebindToDifferentNode(t *testing.T) {
+	skipIfNoPOSIXShell(t)
+	resetVoltaResolveCache(t)
+
+	f := newVoltaFixture(t, voltaFixtureOpts{commands: []string{"claude"}})
+	t.Setenv("PATH", systemPath(f.binDir()))
+
+	first, ok := voltaResolve(f.alias("claude"), f.shim(), "claude")
+	if !ok {
+		t.Fatal("initial resolution failed")
+	}
+	if got := first.Env.PrefixPaths["PATH"][0]; got != f.boundNodeDir() {
+		t.Fatalf("initial PATH dir = %q, want %q", got, f.boundNodeDir())
+	}
+
+	const newNode = "22.5.0"
+	rebindFixture(t, f, "claude", newNode)
+	// The previously bound image is deliberately left in place: every directory the
+	// cached resolution refers to still exists.
+	if !dirExists(f.boundNodeDir()) {
+		t.Fatal("fixture removed the old node image; the test would not prove anything")
+	}
+
+	second, ok := voltaResolve(f.alias("claude"), f.shim(), "claude")
+	if !ok {
+		t.Fatal("resolution after rebind failed")
+	}
+	if want := f.nodeDir(newNode); second.Env.PrefixPaths["PATH"][0] != want {
+		t.Errorf("PATH dir after rebind = %q, want %q; the cache only checked that "+
+			"directories exist, so a rebind was invisible and the superseded toolchain "+
+			"was served forever", second.Env.PrefixPaths["PATH"][0], want)
+	}
+}
+
+// TestAgentEntryLaunchable_DetectsRebind is the daemon-cache half of the same
+// problem: a pinned AgentEntry must stop being launchable when its inputs change.
+func TestAgentEntryLaunchable_DetectsRebind(t *testing.T) {
+	skipIfNoPOSIXShell(t)
+	resetVoltaResolveCache(t)
+
+	f := newVoltaFixture(t, voltaFixtureOpts{commands: []string{"claude"}})
+	t.Setenv("PATH", systemPath(f.binDir()))
+
+	resolved, ok := voltaResolve(f.alias("claude"), f.shim(), "claude")
+	if !ok {
+		t.Fatal("resolution failed")
+	}
+	entry := entryFor(resolved)
+	if !agentEntryLaunchable(entry) {
+		t.Fatal("fresh entry reported not launchable")
+	}
+
+	rebindFixture(t, f, "claude", "22.5.0")
+	if !agentExecutablePresent(entry.Path) || !execEnvDirsPresent(entry.Env) {
+		t.Fatal("fixture invalidated the path or dirs; the test must isolate the rebind")
+	}
+	if agentEntryLaunchable(entry) {
+		t.Error("entry still launchable after a rebind; nothing is missing on disk, so only " +
+			"the config fingerprint can reveal it and tasks would keep the old toolchain")
+	}
+}
+
+// TestVoltaResolve_CommandMissDoesNotFreezeInstallation covers the breaker split. A
+// command with no bin config fails fast and cheaply; that says nothing about the
+// installation, so healthy commands must keep resolving. Previously ANY failure set
+// one shared flag and froze every command for the full cooldown — which also made
+// the spend budget unreachable.
+func TestVoltaResolve_CommandMissDoesNotFreezeInstallation(t *testing.T) {
+	skipIfNoPOSIXShell(t)
+	resetVoltaResolveCache(t)
+
+	f := newVoltaFixture(t, voltaFixtureOpts{commands: []string{"claude", "codex"}})
+	t.Setenv("PATH", systemPath(f.binDir()))
+
+	// claude is not resolvable: no bound platform.
+	if err := os.Remove(voltaBinConfigPath(f.home, "claude")); err != nil {
+		t.Fatalf("remove bin config: %v", err)
+	}
+	if _, ok := voltaResolve(f.alias("claude"), f.shim(), "claude"); ok {
+		t.Fatal("claude unexpectedly resolved without a bin config")
+	}
+
+	// codex is perfectly healthy and must not be collateral damage.
+	resolved, ok := voltaResolve(f.alias("codex"), f.shim(), "codex")
+	if !ok {
+		t.Fatal("codex was refused after an unrelated command's fast failure; a " +
+			"command-specific miss must not open an installation-wide cooldown")
+	}
+	if want := f.concrete("codex"); resolved.Path != want {
+		t.Errorf("codex path = %q, want %q", resolved.Path, want)
+	}
+}
+
+// TestVoltaResolve_CommandMissIsNegativelyCached keeps the other half honest: the
+// failing command itself must not be retried on every single call.
+func TestVoltaResolve_CommandMissIsNegativelyCached(t *testing.T) {
+	skipIfNoPOSIXShell(t)
+	resetVoltaResolveCache(t)
+
+	origRun := runVolta
+	t.Cleanup(func() { runVolta = origRun })
+
+	f := newVoltaFixture(t, voltaFixtureOpts{commands: []string{"claude"}})
+	t.Setenv("PATH", systemPath(f.binDir()))
+	if err := os.Remove(voltaBinConfigPath(f.home, "claude")); err != nil {
+		t.Fatalf("remove bin config: %v", err)
+	}
+
+	var mu sync.Mutex
+	calls := 0
+	runVolta = func(voltaBin, voltaHome string, args ...string) (string, bool) {
+		mu.Lock()
+		calls++
+		mu.Unlock()
+		return origRun(voltaBin, voltaHome, args...)
+	}
+
+	for i := 0; i < 3; i++ {
+		if _, ok := voltaResolve(f.alias("claude"), f.shim(), "claude"); ok {
+			t.Fatalf("attempt %d unexpectedly resolved", i+1)
+		}
+	}
+	mu.Lock()
+	got := calls
+	mu.Unlock()
+	if got != 1 {
+		t.Errorf("`volta` was invoked %d times for 3 attempts at one unresolvable command, "+
+			"want 1; the per-command negative cache is not working", got)
+	}
+}
+
+// TestCustomProfileEntry_DoesNotInheritBuiltinEnvironment covers the custom runtime
+// leak: swapping only Path left the built-in provider's resolved environment in
+// place, so a custom Codex-family script ran under Volta's Node platform for the
+// BUILT-IN codex — wrong PATH and NODE_PATH.
+func TestCustomProfileEntry_DoesNotInheritBuiltinEnvironment(t *testing.T) {
+	builtin := AgentEntry{
+		Path:         "/volta/tools/image/packages/codex/bin/codex",
+		Command:      "codex",
+		Model:        "gpt-5-codex",
+		Env:          agent.ExecEnv{PrefixPaths: map[string][]string{"PATH": {"/volta/node/24/bin"}}},
+		EnvStampPath: "/volta/tools/user/bins/codex.json",
+		EnvStampHash: "deadbeef",
+	}
+	custom := customProfileAgentEntry(builtin, "/opt/custom/my-codex")
+
+	if custom.Path != "/opt/custom/my-codex" {
+		t.Errorf("Path = %q, want the custom command", custom.Path)
+	}
+	if !custom.Env.IsZero() {
+		t.Errorf("custom profile inherited the built-in environment %v; its script would run "+
+			"under the wrong Node/PATH/NODE_PATH", custom.Env.PrefixPaths)
+	}
+	if custom.EnvStampPath != "" || custom.EnvStampHash != "" {
+		t.Error("custom profile inherited the built-in resolution stamp")
+	}
+	if custom.Model != builtin.Model {
+		t.Errorf("Model = %q, want it preserved (%q)", custom.Model, builtin.Model)
+	}
+}
+
+// TestResolveAgentEntry_ReplacesEntryAfterRebind is the plumbing half of the rebind
+// fix: a pinned entry whose binding changed must be re-resolved and replaced, not
+// handed back because its files happen to still exist.
+func TestResolveAgentEntry_ReplacesEntryAfterRebind(t *testing.T) {
+	skipIfNoPOSIXShell(t)
+	resetVoltaResolveCache(t)
+
+	f := newVoltaFixture(t, voltaFixtureOpts{commands: []string{"claude"}})
+	t.Setenv("PATH", systemPath(f.binDir()))
+	origDetect := detectAgentVersion
+	t.Cleanup(func() { detectAgentVersion = origDetect })
+	detectAgentVersion = func(_ context.Context, _ string, _ agent.ExecEnv) (string, error) {
+		return "2.1.0", nil
+	}
+
+	resolved, ok := voltaResolve(f.alias("claude"), f.shim(), "claude")
+	if !ok {
+		t.Fatal("initial resolution failed")
+	}
+	pinned := entryFor(resolved)
+
+	const newNode = "22.5.0"
+	rebindFixture(t, f, "claude", newNode)
+
+	d := freshDaemon("")
+	got, _ := d.resolveAgentEntry(context.Background(), "claude", pinned)
+
+	dirs := got.Env.PrefixPaths["PATH"]
+	if len(dirs) == 0 {
+		t.Fatal("re-resolved entry carries no PATH dirs")
+	}
+	if want := f.nodeDir(newNode); dirs[0] != want {
+		t.Errorf("entry PATH dir = %q, want the rebound Node %q; resolveAgentEntry kept the "+
+			"superseded binding", dirs[0], want)
 	}
 }

--- a/server/internal/daemon/agents_probe_volta_test.go
+++ b/server/internal/daemon/agents_probe_volta_test.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -45,8 +46,6 @@ type voltaFixtureOpts struct {
 	commands []string
 	// omitVolta models an install whose `volta` binary cannot be run.
 	omitVolta bool
-	// hang makes every `volta` invocation block, modelling a wedged install.
-	hang bool
 	// projectDir, when set, makes `volta which` answer with a project-local
 	// binary whenever it is invoked from inside that directory — which is what
 	// real Volta does (upstream src/command/which.rs prefers the project bin).
@@ -115,10 +114,6 @@ exec %q/"$n" "$@"
 // `which node`, prints nothing and exits non-zero otherwise, like upstream.
 func voltaFixtureScript(f voltaFixture, opts voltaFixtureOpts) string {
 	var body string
-	if opts.hang {
-		// Blocks forever so a test can measure how the caller bounds the cost.
-		return "#!/bin/sh\nwhile :; do sleep 1; done\n"
-	}
 	if opts.projectDir != "" {
 		// Project-local preference: only triggered when invoked from inside the
 		// project, which is exactly the cwd sensitivity the caller must avoid.
@@ -406,16 +401,39 @@ func TestVoltaResolve_IgnoresProjectDirectory(t *testing.T) {
 // TestVoltaResolve_BoundsTotalCostWhenVoltaHangs covers review item 4. A wedged
 // Volta install used to cost one full timeout PER command, so a machine with
 // several Volta-managed CLIs stalled startup for the sum of them.
+//
+// The invocation count is the real invariant ("ask a broken install once, not
+// once per command"), so it is asserted directly rather than inferred from wall
+// clock. runVolta is stubbed instead of hanging a real subprocess: a killed child
+// reports its side effects asynchronously, which made a file-based counter race
+// with the kill and read one call behind.
 func TestVoltaResolve_BoundsTotalCostWhenVoltaHangs(t *testing.T) {
 	skipIfNoPOSIXShell(t)
 	resetVoltaResolveCache(t)
 
-	origTimeout := voltaResolveTimeout
-	t.Cleanup(func() { voltaResolveTimeout = origTimeout })
-	voltaResolveTimeout = 300 * time.Millisecond
+	origTimeout, origWait := voltaResolveTimeout, voltaResolveWaitDelay
+	origRun := runVolta
+	t.Cleanup(func() {
+		voltaResolveTimeout, voltaResolveWaitDelay = origTimeout, origWait
+		runVolta = origRun
+	})
+	voltaResolveTimeout = 100 * time.Millisecond
+	voltaResolveWaitDelay = 50 * time.Millisecond
+
+	var mu sync.Mutex
+	calls := 0
+	// Models a wedged install: every invocation burns the whole per-call budget
+	// (timeout + the wait for a hung child's pipes) and then fails.
+	runVolta = func(string, ...string) (string, bool) {
+		mu.Lock()
+		calls++
+		mu.Unlock()
+		time.Sleep(voltaResolveTimeout + voltaResolveWaitDelay)
+		return "", false
+	}
 
 	commands := []string{"claude", "codex", "pi"}
-	f := newVoltaFixture(t, voltaFixtureOpts{commands: commands, hang: true})
+	f := newVoltaFixture(t, voltaFixtureOpts{commands: commands})
 	t.Setenv("PATH", pathWithout(f.binDir))
 
 	start := time.Now()
@@ -426,11 +444,68 @@ func TestVoltaResolve_BoundsTotalCostWhenVoltaHangs(t *testing.T) {
 	}
 	elapsed := time.Since(start)
 
-	// Additive behavior would be len(commands) x timeout. Allow one timeout plus
-	// slack: after the first failure the cooldown must short-circuit the rest.
-	if budget := 2 * voltaResolveTimeout; elapsed > budget {
-		t.Errorf("resolving %d hung aliases took %v (> %v); the per-command timeout is "+
-			"still additive and can stall daemon startup", len(commands), elapsed, budget)
+	mu.Lock()
+	got := calls
+	mu.Unlock()
+	if got != 1 {
+		t.Errorf("`volta` was invoked %d times for %d commands, want 1; a broken install "+
+			"must be asked once per cooldown, not once per command", got, len(commands))
+	}
+
+	singleCall := voltaResolveTimeout + voltaResolveWaitDelay
+	if additive := time.Duration(len(commands)) * singleCall; elapsed >= additive {
+		t.Errorf("resolving %d hung aliases took %v, at least the additive bound %v; "+
+			"the per-command timeout can still stall daemon startup", len(commands), elapsed, additive)
+	}
+}
+
+// TestVoltaResolve_FailureCooldownExpires is the other half of the circuit
+// breaker: a temporarily broken install must be retried once the cooldown is up,
+// not written off for the daemon's lifetime.
+func TestVoltaResolve_FailureCooldownExpires(t *testing.T) {
+	skipIfNoPOSIXShell(t)
+	resetVoltaResolveCache(t)
+
+	origRun, origCooldown := runVolta, voltaFailureCooldown
+	t.Cleanup(func() { runVolta, voltaFailureCooldown = origRun, origCooldown })
+	voltaFailureCooldown = 20 * time.Millisecond
+
+	var mu sync.Mutex
+	calls := 0
+	runVolta = func(string, ...string) (string, bool) {
+		mu.Lock()
+		defer mu.Unlock()
+		calls++
+		return "", false
+	}
+
+	f := newVoltaFixture(t, voltaFixtureOpts{commands: []string{"claude"}})
+	t.Setenv("PATH", pathWithout(f.binDir))
+
+	if _, ok := voltaResolve(f.shim(), "claude"); ok {
+		t.Fatal("unexpectedly resolved")
+	}
+	// Inside the cooldown: no new invocation.
+	if _, ok := voltaResolve(f.shim(), "claude"); ok {
+		t.Fatal("unexpectedly resolved")
+	}
+	mu.Lock()
+	during := calls
+	mu.Unlock()
+	if during != 1 {
+		t.Errorf("invocations inside the cooldown = %d, want 1", during)
+	}
+
+	time.Sleep(2 * voltaFailureCooldown)
+	if _, ok := voltaResolve(f.shim(), "claude"); ok {
+		t.Fatal("unexpectedly resolved")
+	}
+	mu.Lock()
+	after := calls
+	mu.Unlock()
+	if after != 2 {
+		t.Errorf("invocations after the cooldown expired = %d, want 2; a transient failure "+
+			"must not disable Volta resolution permanently", after)
 	}
 }
 

--- a/server/internal/daemon/agents_probe_volta_test.go
+++ b/server/internal/daemon/agents_probe_volta_test.go
@@ -2,6 +2,7 @@ package daemon
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -11,38 +12,96 @@ import (
 )
 
 // Volta installs one trampoline binary and symlinks every managed command to
-// it, dispatching on the name it was invoked as (#6183). These tests pin down
-// that the daemon keeps that name, because resolving the symlink collapses
-// claude/codex/pi onto the same volta-shim path and the shim then exits 126.
+// it, dispatching on the name it was invoked as (#6183). Resolving that symlink
+// collapses claude/codex/pi onto the same volta-shim path and the shim then
+// exits 126, so the daemon asks Volta for the concrete binary instead. These
+// tests cover that resolution, the registration it has to survive, and the
+// blast radius of the exception.
 
-// voltaShimBody is a stand-in for Volta's trampoline: it reports a version only
-// when invoked under a managed command's name and exits 126 otherwise, exactly
-// like the real shim. It uses ${0##*/} rather than basename(1) so the fixture
-// keeps working under the restricted PATHs these tests set.
-const voltaShimBody = `#!/bin/sh
-case "${0##*/}" in
-  claude) echo "1.2.3 (Claude Code)" ;;
-  codex) echo "codex-cli 0.140.0" ;;
-  pi) echo "pi 0.9.0" ;;
-  *) echo "volta error: no tool selected" >&2; exit 126 ;;
-esac
-`
+// voltaFixture is a ~/.volta lookalike.
+type voltaFixture struct {
+	binDir   string // the shim dir: volta, volta-shim, and one symlink per command
+	imageDir string // where the concrete per-tool binaries live
+}
 
-// newVoltaBinDir builds a ~/.volta/bin lookalike: one volta-shim plus an alias
-// symlink per command name. It returns the directory.
-func newVoltaBinDir(t *testing.T, names ...string) string {
+func (f voltaFixture) alias(command string) string    { return filepath.Join(f.binDir, command) }
+func (f voltaFixture) shim() string                   { return filepath.Join(f.binDir, voltaShimName) }
+func (f voltaFixture) concrete(command string) string { return filepath.Join(f.imageDir, command) }
+
+// voltaFixtureVersions are the versions the concrete fixture binaries report.
+// They must clear agent.MinVersions (claude >= 2.0.0, codex >= 0.100.0) or the
+// registration-level test below would prove nothing: the provider would be
+// dropped by the min-version gate rather than by the bug under test.
+var voltaFixtureVersions = map[string]string{
+	"claude": "2.1.0 (Claude Code)",
+	"codex":  "codex-cli 0.140.0",
+	"pi":     "pi 0.9.0",
+}
+
+// newVoltaFixture builds the shim dir, the concrete binaries, a faithful
+// argv[0]-dispatching volta-shim, and a `volta` that answers `which`.
+//
+// withVolta=false omits the `volta` binary, modelling an install where the
+// daemon cannot ask Volta for the concrete path.
+func newVoltaFixture(t *testing.T, withVolta bool, commands ...string) voltaFixture {
 	t.Helper()
-	dir := t.TempDir()
-	shim := filepath.Join(dir, voltaShimName)
-	if err := os.WriteFile(shim, []byte(voltaShimBody), 0o755); err != nil {
-		t.Fatalf("write volta-shim: %v", err)
+	root := t.TempDir()
+	f := voltaFixture{
+		binDir:   filepath.Join(root, "bin"),
+		imageDir: filepath.Join(root, "image"),
 	}
-	for _, name := range names {
-		if err := os.Symlink(shim, filepath.Join(dir, name)); err != nil {
-			t.Fatalf("symlink %s -> volta-shim: %v", name, err)
+	for _, dir := range []string{f.binDir, f.imageDir} {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", dir, err)
 		}
 	}
-	return dir
+
+	for _, command := range commands {
+		version, ok := voltaFixtureVersions[command]
+		if !ok {
+			t.Fatalf("no fixture version defined for %q", command)
+		}
+		writeScript(t, f.concrete(command), fmt.Sprintf("#!/bin/sh\necho %q\n", version))
+	}
+
+	// Faithful shim: refuses to run under its own name exactly like upstream
+	// (ErrorKind::RunShimDirectly -> exit 126), and otherwise dispatches on
+	// argv[0]. Uses ${0##*/} instead of basename(1) so it survives the
+	// restricted PATHs these tests set.
+	writeScript(t, f.shim(), fmt.Sprintf(`#!/bin/sh
+n=${0##*/}
+if [ "$n" = %q ]; then
+  echo "volta error: 'volta-shim' should not be called directly" >&2
+  exit 126
+fi
+exec %q/"$n" "$@"
+`, voltaShimName, f.imageDir))
+
+	for _, command := range commands {
+		if err := os.Symlink(f.shim(), f.alias(command)); err != nil {
+			t.Fatalf("symlink %s -> volta-shim: %v", command, err)
+		}
+	}
+
+	if withVolta {
+		// `volta which <tool>` prints the concrete path on stdout and exits
+		// non-zero without output when it cannot resolve, as upstream does.
+		writeScript(t, filepath.Join(f.binDir, "volta"), fmt.Sprintf(`#!/bin/sh
+if [ "$1" = "which" ] && [ -n "$2" ]; then
+  p=%q/"$2"
+  if [ -x "$p" ]; then echo "$p"; exit 0; fi
+fi
+exit 1
+`, f.imageDir))
+	}
+	return f
+}
+
+func writeScript(t *testing.T, path, body string) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte(body), 0o755); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
 }
 
 func skipIfNoPOSIXShell(t *testing.T) {
@@ -55,126 +114,228 @@ func skipIfNoPOSIXShell(t *testing.T) {
 	}
 }
 
-// TestResolveAgentExecutablePath_KeepsVoltaAliasName is the direct regression
-// test for #6183: all three reported commands must stay distinguishable and
-// must still answer --version after resolution.
-func TestResolveAgentExecutablePath_KeepsVoltaAliasName(t *testing.T) {
-	skipIfNoPOSIXShell(t)
-
-	names := []string{"claude", "codex", "pi"}
-	voltaBin := newVoltaBinDir(t, names...)
-	t.Setenv("PATH", voltaBin)
-
-	wantVersion := map[string]string{
-		"claude": "1.2.3 (Claude Code)",
-		"codex":  "codex-cli 0.140.0",
-		"pi":     "pi 0.9.0",
-	}
-	seen := map[string]string{}
-	for _, name := range names {
-		got, err := resolveAgentExecutablePath(name)
-		if err != nil {
-			t.Fatalf("%s: resolveAgentExecutablePath: %v", name, err)
-		}
-		if base := filepath.Base(got); base != name {
-			t.Errorf("%s resolved to %q (basename %q); the Volta shim picks its tool from "+
-				"argv[0], so collapsing the alias makes the command unrunnable", name, got, base)
-		}
-		if prev, dup := seen[filepath.Base(got)]; dup {
-			t.Errorf("%s and this path collide: %q", prev, got)
-		}
-		seen[filepath.Base(got)] = name
-
-		version, err := agent.DetectVersion(context.Background(), got)
-		if err != nil {
-			t.Fatalf("%s: DetectVersion(%q): %v (this is the exit-126 failure from #6183)", name, got, err)
-		}
-		if version != wantVersion[name] {
-			t.Errorf("%s version = %q, want %q", name, version, wantVersion[name])
-		}
-	}
-}
-
-// TestProbeAgentCLIs_DiscoversVoltaManagedCLIs covers the same fix one level up,
-// at the discovery entry point the daemon actually calls, and asserts the three
-// providers get three distinct paths rather than one shared shim.
-func TestProbeAgentCLIs_DiscoversVoltaManagedCLIs(t *testing.T) {
-	skipIfNoPOSIXShell(t)
-
-	voltaBin := newVoltaBinDir(t, "claude", "codex", "pi")
-	t.Setenv("PATH", voltaBin)
-
-	// Keep discovery hermetic: no login-shell fork, no Codex Desktop bundle.
+// isolateAgentDiscovery keeps probeAgentCLIs hermetic: no login-shell fork and
+// no Codex Desktop bundle fallback, so the only thing that can resolve is the
+// fixture on PATH.
+func isolateAgentDiscovery(t *testing.T) {
+	t.Helper()
 	origShell := resolveAgentsViaLoginShell
 	t.Cleanup(func() { resolveAgentsViaLoginShell = origShell })
 	resolveAgentsViaLoginShell = func([]string) map[string]string { return nil }
 	resetShellResolveCacheForTest(t)
+
 	origBundle := codexDesktopAppBundlePaths
 	t.Cleanup(func() { codexDesktopAppBundlePaths = origBundle })
 	codexDesktopAppBundlePaths = func() []string { return nil }
+}
+
+// resetVoltaResolveCache clears the process-wide `volta which` cache so tests
+// cannot observe each other's answers.
+func resetVoltaResolveCache(t *testing.T) {
+	t.Helper()
+	clear := func() {
+		voltaResolveMu.Lock()
+		defer voltaResolveMu.Unlock()
+		voltaResolveCache = map[string]string{}
+	}
+	clear()
+	t.Cleanup(clear)
+}
+
+// TestResolveAgentExecutablePath_PinsVoltaConcreteBinary is the primary
+// regression test for #6183. The pinned path must be the concrete binary, so
+// that the path we version-check is the path we later execute.
+func TestResolveAgentExecutablePath_PinsVoltaConcreteBinary(t *testing.T) {
+	skipIfNoPOSIXShell(t)
+	resetVoltaResolveCache(t)
+
+	commands := []string{"claude", "codex", "pi"}
+	f := newVoltaFixture(t, true, commands...)
+	t.Setenv("PATH", f.binDir)
+
+	for _, command := range commands {
+		got, err := resolveAgentExecutablePath(command)
+		if err != nil {
+			t.Fatalf("%s: resolveAgentExecutablePath: %v", command, err)
+		}
+		if got == f.shim() {
+			t.Fatalf("%s pinned the shared shim %q; the version probe exits 126 there (#6183)", command, got)
+		}
+		if got == f.alias(command) {
+			t.Errorf("%s pinned the Volta alias %q; that path dispatches per working directory, "+
+				"so the gated version would not be the executed version", command, got)
+		}
+		if want := f.concrete(command); got != want {
+			t.Errorf("%s path = %q, want the concrete binary %q", command, got, want)
+		}
+
+		version, err := agent.DetectVersion(context.Background(), got)
+		if err != nil {
+			t.Fatalf("%s: DetectVersion(%q): %v", command, got, err)
+		}
+		if version != voltaFixtureVersions[command] {
+			t.Errorf("%s version = %q, want %q", command, version, voltaFixtureVersions[command])
+		}
+	}
+}
+
+// TestProbeAgentCLIs_DiscoversVoltaManagedCLIs covers the discovery entry point
+// the daemon actually calls and asserts the three providers get three distinct
+// concrete paths rather than one shared shim.
+func TestProbeAgentCLIs_DiscoversVoltaManagedCLIs(t *testing.T) {
+	skipIfNoPOSIXShell(t)
+	resetVoltaResolveCache(t)
+
+	commands := []string{"claude", "codex", "pi"}
+	f := newVoltaFixture(t, true, commands...)
+	t.Setenv("PATH", f.binDir)
+	isolateAgentDiscovery(t)
 
 	agents := probeAgentCLIs()
 
-	paths := map[string]string{}
-	for _, provider := range []string{"claude", "codex", "pi"} {
-		entry, ok := agents[provider]
+	seen := map[string]string{}
+	for _, command := range commands {
+		entry, ok := agents[command]
 		if !ok {
-			t.Fatalf("%s not discovered from a Volta install: %#v", provider, agents)
+			t.Fatalf("%s not discovered from a Volta install: %#v", command, agents)
 		}
-		if base := filepath.Base(entry.Path); base != provider {
-			t.Errorf("%s path = %q, want the alias basename %q", provider, entry.Path, provider)
+		if want := f.concrete(command); entry.Path != want {
+			t.Errorf("%s path = %q, want %q", command, entry.Path, want)
 		}
-		if prev, dup := paths[entry.Path]; dup {
-			t.Errorf("%s and %s share one path %q; the shim cannot tell them apart", prev, provider, entry.Path)
+		if prev, dup := seen[entry.Path]; dup {
+			t.Errorf("%s and %s share one path %q", prev, command, entry.Path)
 		}
-		paths[entry.Path] = provider
+		seen[entry.Path] = command
 	}
 }
 
-// TestCanonicalExecutablePath_NonVoltaSymlinkStillCanonicalized guards the blast
-// radius of the fix. Ordinary symlinks must keep collapsing to the real file —
-// that is what pins agents against PATH drift and powers the MUL-4486 self-heal.
-func TestCanonicalExecutablePath_NonVoltaSymlinkStillCanonicalized(t *testing.T) {
+// TestDetectBuiltinRuntimes_RegistersVoltaManagedCLIs is the end-result test:
+// availability alone was never the user-visible outcome. This runs the real
+// version probe and the real minimum-version gate over a Volta install and
+// asserts all three providers reach the registration payload.
+func TestDetectBuiltinRuntimes_RegistersVoltaManagedCLIs(t *testing.T) {
 	skipIfNoPOSIXShell(t)
+	resetVoltaResolveCache(t)
 
-	realDir := t.TempDir()
-	realBin := filepath.Join(realDir, "claude-0.9.9")
-	if err := os.WriteFile(realBin, []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
-		t.Fatalf("write real binary: %v", err)
-	}
-	binDir := t.TempDir()
-	alias := filepath.Join(binDir, "claude")
-	if err := os.Symlink(realBin, alias); err != nil {
-		t.Fatalf("symlink: %v", err)
-	}
+	commands := []string{"claude", "codex", "pi"}
+	f := newVoltaFixture(t, true, commands...)
+	t.Setenv("PATH", f.binDir)
+	isolateAgentDiscovery(t)
 
-	got := canonicalExecutablePath(alias)
-	if filepath.Base(got) != "claude-0.9.9" {
-		t.Errorf("canonicalExecutablePath(%q) = %q, want the real versioned binary; "+
-			"non-Volta symlinks must still be resolved", alias, got)
+	// Deliberately no detectAgentVersion / checkAgentMinVersion stubs: the point
+	// is that the real gate accepts what discovery pinned.
+	d := freshDaemon("")
+	d.cfg.Agents = probeAgentCLIs()
+
+	runtimes := d.detectBuiltinRuntimes(context.Background())
+
+	registered := map[string]string{}
+	for _, rt := range runtimes {
+		registered[rt["type"]] = rt["version"]
+	}
+	for _, command := range commands {
+		version, ok := registered[command]
+		if !ok {
+			t.Errorf("%s missing from the registration payload; skipped reasons: %#v",
+				command, d.skippedAgentsSnapshot())
+			continue
+		}
+		if version != voltaFixtureVersions[command] {
+			t.Errorf("%s registered version = %q, want %q", command, version, voltaFixtureVersions[command])
+		}
 	}
 }
 
-// TestCanonicalExecutablePath_ExplicitShimPathStaysCanonical documents the edge
-// case: a path pointed straight at volta-shim carries no dispatch name, so there
-// is nothing to preserve and it must not get special treatment.
-func TestCanonicalExecutablePath_ExplicitShimPathStaysCanonical(t *testing.T) {
+// TestResolveAgentExecutablePath_FailsClosedWithoutVoltaResolution pins the
+// deliberate failure mode: with no way to ask Volta for the concrete binary we
+// must NOT fall back to the alias, because that path is only version-checkable
+// under conditions we cannot reproduce at launch. Staying unregistered is the
+// correct outcome; MULTICA_*_PATH remains the escape hatch.
+func TestResolveAgentExecutablePath_FailsClosedWithoutVoltaResolution(t *testing.T) {
 	skipIfNoPOSIXShell(t)
+	resetVoltaResolveCache(t)
 
-	voltaBin := newVoltaBinDir(t)
-	shim := filepath.Join(voltaBin, voltaShimName)
+	f := newVoltaFixture(t, false, "claude")
+	t.Setenv("PATH", f.binDir)
 
-	got := canonicalExecutablePath(shim)
-	if filepath.Base(got) != voltaShimName {
-		t.Errorf("canonicalExecutablePath(%q) = %q, want it to stay volta-shim", shim, got)
+	got, err := resolveAgentExecutablePath("claude")
+	if err != nil {
+		t.Fatalf("resolveAgentExecutablePath: %v", err)
+	}
+	if got == f.alias("claude") {
+		t.Fatalf("fell back to the alias %q; that reintroduces an ungated launch path", got)
+	}
+	// The shim path itself is still canonicalized, so compare against the
+	// resolved form (on macOS /tmp is a symlink to /private/tmp).
+	wantShim, err := filepath.EvalSymlinks(f.shim())
+	if err != nil {
+		t.Fatalf("EvalSymlinks: %v", err)
+	}
+	if got != wantShim {
+		t.Errorf("path = %q, want the canonicalized shim %q", got, wantShim)
+	}
+	if _, err := agent.DetectVersion(context.Background(), got); err == nil {
+		t.Error("expected version detection to fail, so the provider stays unregistered")
 	}
 }
 
-// TestResolveAgentExecutablePath_VoltaAliasShadowedByHooks proves the fix reaches
-// the ~/.multica/hooks branch too: that branch has its own canonicalize call, so
-// a hooks-shadowed Volta command must both skip the wrapper and keep its alias.
+// TestVoltaConcreteExecutable_ReresolvesAfterBinaryReplaced covers the cache's
+// revalidation-by-existence: when Volta swaps the underlying tool and the old
+// concrete path disappears, the next resolution must not keep serving it.
+func TestVoltaConcreteExecutable_ReresolvesAfterBinaryReplaced(t *testing.T) {
+	skipIfNoPOSIXShell(t)
+	resetVoltaResolveCache(t)
+
+	f := newVoltaFixture(t, true, "claude")
+	t.Setenv("PATH", f.binDir)
+
+	first, ok := voltaConcreteExecutable(f.shim(), "claude")
+	if !ok {
+		t.Fatal("initial resolution failed")
+	}
+
+	// Cached answer is reused while it is still runnable.
+	if again, ok := voltaConcreteExecutable(f.shim(), "claude"); !ok || again != first {
+		t.Fatalf("cached resolution = (%q, %v), want (%q, true)", again, ok, first)
+	}
+
+	// Volta replaces the tool: the old path is gone and `volta which` now
+	// answers with a different one.
+	if err := os.Remove(first); err != nil {
+		t.Fatalf("remove concrete binary: %v", err)
+	}
+	newImage := filepath.Join(t.TempDir(), "image")
+	if err := os.MkdirAll(newImage, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	writeScript(t, filepath.Join(newImage, "claude"), "#!/bin/sh\necho \"3.0.0 (Claude Code)\"\n")
+	writeScript(t, filepath.Join(f.binDir, "volta"), fmt.Sprintf(`#!/bin/sh
+if [ "$1" = "which" ] && [ -n "$2" ]; then
+  p=%q/"$2"
+  if [ -x "$p" ]; then echo "$p"; exit 0; fi
+fi
+exit 1
+`, newImage))
+
+	second, ok := voltaConcreteExecutable(f.shim(), "claude")
+	if !ok {
+		t.Fatal("re-resolution failed after the pinned binary disappeared")
+	}
+	if second == first {
+		t.Errorf("still serving the removed path %q", first)
+	}
+	if want := filepath.Join(newImage, "claude"); second != want {
+		t.Errorf("re-resolved path = %q, want %q", second, want)
+	}
+}
+
+// TestResolveAgentExecutablePath_VoltaAliasShadowedByHooks proves the fix
+// reaches the ~/.multica/hooks branch, which canonicalizes independently: a
+// hooks-shadowed Volta command must skip the recursive wrapper AND still land on
+// the concrete binary.
 func TestResolveAgentExecutablePath_VoltaAliasShadowedByHooks(t *testing.T) {
 	skipIfNoPOSIXShell(t)
+	resetVoltaResolveCache(t)
 
 	home := t.TempDir()
 	t.Setenv("HOME", home)
@@ -182,15 +343,10 @@ func TestResolveAgentExecutablePath_VoltaAliasShadowedByHooks(t *testing.T) {
 	if err := os.MkdirAll(hooksDir, 0o755); err != nil {
 		t.Fatalf("create hooks dir: %v", err)
 	}
-	// A previously generated wrapper that re-execs the same command name; the
-	// daemon must never pin or launch this.
-	if err := os.WriteFile(filepath.Join(hooksDir, "claude"),
-		[]byte("#!/bin/sh\nexec claude \"$@\"\n"), 0o755); err != nil {
-		t.Fatalf("write hook wrapper: %v", err)
-	}
+	writeScript(t, filepath.Join(hooksDir, "claude"), "#!/bin/sh\nexec claude \"$@\"\n")
 
-	voltaBin := newVoltaBinDir(t, "claude")
-	t.Setenv("PATH", hooksDir+string(os.PathListSeparator)+voltaBin)
+	f := newVoltaFixture(t, true, "claude")
+	t.Setenv("PATH", hooksDir+string(os.PathListSeparator)+f.binDir)
 
 	got, err := resolveAgentExecutablePath("claude")
 	if err != nil {
@@ -199,20 +355,73 @@ func TestResolveAgentExecutablePath_VoltaAliasShadowedByHooks(t *testing.T) {
 	if filepath.Dir(got) == hooksDir {
 		t.Fatalf("resolved into the hooks dir (%q); the wrapper would recurse", got)
 	}
-	if filepath.Base(got) != "claude" {
-		t.Errorf("path = %q, want the Volta alias basename claude", got)
-	}
-	// The version answer is what proves we landed on the Volta alias and not
-	// the recursive wrapper.
-	version, err := agent.DetectVersion(context.Background(), got)
-	if err != nil {
-		t.Fatalf("DetectVersion(%q): %v", got, err)
-	}
-	if version != "1.2.3 (Claude Code)" {
-		t.Errorf("version = %q, want the Volta-managed claude version", version)
+	if want := f.concrete("claude"); got != want {
+		t.Errorf("path = %q, want the concrete binary %q", got, want)
 	}
 }
 
+// TestCanonicalExecutablePath_NonVoltaSymlinkStillCanonicalized guards the blast
+// radius: ordinary symlinks must keep collapsing to the real file, which is what
+// pins agents against PATH drift and powers the MUL-4486 self-heal.
+func TestCanonicalExecutablePath_NonVoltaSymlinkStillCanonicalized(t *testing.T) {
+	skipIfNoPOSIXShell(t)
+
+	realDir := t.TempDir()
+	realBin := filepath.Join(realDir, "claude-0.9.9")
+	writeScript(t, realBin, "#!/bin/sh\nexit 0\n")
+	alias := filepath.Join(t.TempDir(), "claude")
+	if err := os.Symlink(realBin, alias); err != nil {
+		t.Fatalf("symlink: %v", err)
+	}
+
+	if got := canonicalExecutablePath(alias); filepath.Base(got) != "claude-0.9.9" {
+		t.Errorf("canonicalExecutablePath(%q) = %q, want the real versioned binary; "+
+			"non-Volta symlinks must still be resolved", alias, got)
+	}
+}
+
+// TestCanonicalExecutablePath_SymlinkedParentDirIsCanonicalized covers the other
+// half of canonicalization: a symlinked *directory* on the way to the binary
+// must also be collapsed, so a moving prefix dir cannot redirect a pinned path.
+func TestCanonicalExecutablePath_SymlinkedParentDirIsCanonicalized(t *testing.T) {
+	skipIfNoPOSIXShell(t)
+
+	root := t.TempDir()
+	realDir := filepath.Join(root, "versions", "20.1.0", "bin")
+	if err := os.MkdirAll(realDir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	writeScript(t, filepath.Join(realDir, "claude"), "#!/bin/sh\nexit 0\n")
+	linkDir := filepath.Join(root, "current")
+	if err := os.Symlink(realDir, linkDir); err != nil {
+		t.Fatalf("symlink dir: %v", err)
+	}
+
+	got := canonicalExecutablePath(filepath.Join(linkDir, "claude"))
+	wantDir, err := filepath.EvalSymlinks(realDir)
+	if err != nil {
+		t.Fatalf("EvalSymlinks: %v", err)
+	}
+	if want := filepath.Join(wantDir, "claude"); got != want {
+		t.Errorf("canonicalExecutablePath through a symlinked dir = %q, want %q", got, want)
+	}
+}
+
+// TestCanonicalExecutablePath_ExplicitShimPathStaysCanonical documents the edge
+// case: a path pointed straight at volta-shim carries no dispatch name, so there
+// is nothing to resolve and it must not get special treatment.
+func TestCanonicalExecutablePath_ExplicitShimPathStaysCanonical(t *testing.T) {
+	skipIfNoPOSIXShell(t)
+	resetVoltaResolveCache(t)
+
+	f := newVoltaFixture(t, true)
+	if got := canonicalExecutablePath(f.shim()); filepath.Base(got) != voltaShimName {
+		t.Errorf("canonicalExecutablePath(%q) = %q, want it to stay volta-shim", f.shim(), got)
+	}
+}
+
+// TestIsVoltaShimPath keeps the PATH-pinning exception minimal: only Volta's
+// actual shim names may opt out of plain symlink resolution.
 func TestIsVoltaShimPath(t *testing.T) {
 	for _, tc := range []struct {
 		path string
@@ -220,10 +429,14 @@ func TestIsVoltaShimPath(t *testing.T) {
 	}{
 		{filepath.Join("/home/u/.volta/bin", "volta-shim"), true},
 		{filepath.Join("/home/u/.volta/bin", "volta-shim.exe"), true},
-		{filepath.Join("C:\\", "volta", "VOLTA-SHIM.EXE"), true},
+		// Near misses: an extension-insensitive match would swallow these.
+		{filepath.Join("/home/u/.volta/bin", "volta-shim.bak"), false},
+		{filepath.Join("/home/u/.volta/bin", "volta-shim.wrapper"), false},
+		{filepath.Join("/home/u/.volta/bin", "volta-shim.exe.bak"), false},
+		{filepath.Join("/usr/local/bin", "volta-shim-wrapper"), false},
+		{filepath.Join("/usr/local/bin", "my-volta-shim"), false},
 		{filepath.Join("/home/u/.volta/bin", "claude"), false},
 		{filepath.Join("/usr/local/bin", "volta"), false},
-		{filepath.Join("/usr/local/bin", "volta-shim-wrapper"), false},
 		{"", false},
 	} {
 		if got := isVoltaShimPath(tc.path); got != tc.want {

--- a/server/internal/daemon/agents_probe_volta_test.go
+++ b/server/internal/daemon/agents_probe_volta_test.go
@@ -15,27 +15,39 @@ import (
 	"github.com/multica-ai/multica/server/pkg/agent"
 )
 
-// Volta installs one trampoline binary and symlinks every managed command to
-// it, dispatching on the name it was invoked as (#6183). Resolving that symlink
-// collapses claude/codex/pi onto the same volta-shim path and the shim then
-// exits 126, so the daemon asks Volta for the concrete binary instead — plus the
-// Node platform directory that binary needs to run.
+// Volta installs one trampoline binary and symlinks every managed command to it,
+// dispatching on the name it was invoked as (#6183). Resolving that symlink
+// collapses claude/codex/pi onto the same volta-shim path and the shim then exits
+// 126, so the daemon asks Volta for the concrete binary instead — together with
+// the execution context Volta itself would supply: the Node platform bound to the
+// package at install time, plus the shared NODE_PATH.
 
-// voltaFixture is a ~/.volta lookalike.
+// voltaFixture mirrors a real Volta layout, including the Homebrew-style split
+// where the binaries (volta, volta-shim) live outside $VOLTA_HOME.
 type voltaFixture struct {
-	binDir   string // shim dir: volta, volta-shim, one symlink per command
-	imageDir string // concrete per-tool binaries
-	nodeDir  string // Volta's Node platform bin dir
+	home       string // $VOLTA_HOME
+	installDir string // holds volta + volta-shim
+	boundNode  string // node version recorded in each bin config
+	otherNode  string // a different, "current default" node
 }
 
-func (f voltaFixture) alias(command string) string    { return filepath.Join(f.binDir, command) }
-func (f voltaFixture) shim() string                   { return filepath.Join(f.binDir, voltaShimName) }
-func (f voltaFixture) concrete(command string) string { return filepath.Join(f.imageDir, command) }
+func (f voltaFixture) binDir() string          { return filepath.Join(f.home, "bin") }
+func (f voltaFixture) alias(cmd string) string { return filepath.Join(f.binDir(), cmd) }
+func (f voltaFixture) shim() string            { return filepath.Join(f.installDir, voltaShimName) }
+func (f voltaFixture) voltaBin() string        { return filepath.Join(f.installDir, "volta") }
+func (f voltaFixture) concrete(cmd string) string {
+	return filepath.Join(f.home, "tools", "image", "packages", cmd, "bin", cmd)
+}
+func (f voltaFixture) nodeDir(version string) string {
+	return filepath.Join(f.home, "tools", "image", "node", version, "bin")
+}
+func (f voltaFixture) boundNodeDir() string { return f.nodeDir(f.boundNode) }
+func (f voltaFixture) sharedLibDir() string {
+	return filepath.Join(f.home, "tools", "shared")
+}
 
-// voltaFixtureVersions are the versions the concrete fixture binaries report.
-// They must clear agent.MinVersions (claude >= 2.0.0, codex >= 0.100.0) or the
-// registration-level tests would prove nothing: the provider would be dropped by
-// the min-version gate rather than by the bug under test.
+// voltaFixtureVersions must clear agent.MinVersions (claude >= 2.0.0,
+// codex >= 0.100.0) or the registration-level tests prove nothing.
 var voltaFixtureVersions = map[string]string{
 	"claude": "2.1.0 (Claude Code)",
 	"codex":  "codex-cli 0.140.0",
@@ -46,79 +58,83 @@ type voltaFixtureOpts struct {
 	commands []string
 	// omitVolta models an install whose `volta` binary cannot be run.
 	omitVolta bool
+	// omitBinConfig drops the bin config, so the bound Node cannot be determined.
+	omitBinConfig bool
 	// projectDir, when set, makes `volta which` answer with a project-local
-	// binary whenever it is invoked from inside that directory — which is what
-	// real Volta does (upstream src/command/which.rs prefers the project bin).
+	// binary when invoked from inside that directory, as real Volta does.
 	projectDir string
 }
 
-// newVoltaFixture builds the shim dir, concrete binaries, a Node platform dir, a
-// faithful argv[0]-dispatching volta-shim, and a `volta` answering `which`.
-//
-// Every concrete tool here needs `node` on PATH, mirroring the real install
-// where package bins are `#!/usr/bin/env node` scripts (verified against
-// @openai/codex 0.146.0). `node` exists ONLY in the Node platform dir, so a
-// resolution that forgets to carry that dir produces an unrunnable path.
 func newVoltaFixture(t *testing.T, opts voltaFixtureOpts) voltaFixture {
 	t.Helper()
 	root := t.TempDir()
 	f := voltaFixture{
-		binDir:   filepath.Join(root, "bin"),
-		imageDir: filepath.Join(root, "image"),
-		nodeDir:  filepath.Join(root, "node-image", "bin"),
+		home:       filepath.Join(root, "home"),
+		installDir: filepath.Join(root, "install"),
+		boundNode:  "20.11.0",
+		otherNode:  "24.18.1",
 	}
-	for _, dir := range []string{f.binDir, f.imageDir, f.nodeDir} {
-		if err := os.MkdirAll(dir, 0o755); err != nil {
-			t.Fatalf("mkdir %s: %v", dir, err)
-		}
-	}
-	writeScript(t, filepath.Join(f.nodeDir, "node"), "#!/bin/sh\nexit 0\n")
+	mkdirs(t, f.binDir(), f.installDir, f.sharedLibDir(),
+		f.nodeDir(f.boundNode), f.nodeDir(f.otherNode),
+		filepath.Join(f.home, "tools", "user", "bins"))
 
-	for _, command := range opts.commands {
-		version, ok := voltaFixtureVersions[command]
+	// Only the bound Node carries a working `node`; the "default" one is a decoy
+	// that fails, so a resolution using it cannot pass unnoticed.
+	writeScript(t, filepath.Join(f.nodeDir(f.boundNode), "node"), "#!/bin/sh\nexit 0\n")
+	writeScript(t, filepath.Join(f.nodeDir(f.otherNode), "node"),
+		"#!/bin/sh\necho 'wrong node: this is the current default, not the bound one' >&2\nexit 1\n")
+
+	for _, cmd := range opts.commands {
+		version, ok := voltaFixtureVersions[cmd]
 		if !ok {
-			t.Fatalf("no fixture version defined for %q", command)
+			t.Fatalf("no fixture version defined for %q", cmd)
 		}
-		writeScript(t, f.concrete(command), fmt.Sprintf(`#!/bin/sh
-command -v node >/dev/null 2>&1 || { echo "env: node: No such file or directory" >&2; exit 127; }
+		mkdirs(t, filepath.Dir(f.concrete(cmd)))
+		// Mirrors a real package bin: a node script, so it is unrunnable without
+		// the Node platform Volta bound to it. Verified against @openai/codex
+		// 0.146.0, which is `#!/usr/bin/env node`.
+		writeScript(t, f.concrete(cmd), fmt.Sprintf(`#!/bin/sh
+node --check-marker >/dev/null 2>&1 || { echo "env: node: No such file or directory" >&2; exit 127; }
 echo %q
 `, version))
+		if !opts.omitBinConfig {
+			writeVoltaConfigFile(t, filepath.Join(f.home, "tools", "user", "bins", cmd+".json"), fmt.Sprintf(
+				`{"name":%q,"package":%q,"version":"1.0.0","platform":{"node":%q,"npm":null,"pnpm":null,"yarn":null},"manager":"Npm"}`,
+				cmd, cmd, f.boundNode))
+		}
 	}
 
-	// Faithful shim: refuses to run under its own name exactly like upstream
-	// (ErrorKind::RunShimDirectly -> exit 126), and otherwise dispatches on
-	// argv[0]. Uses ${0##*/} instead of basename(1) so it survives the
-	// restricted PATHs these tests set.
+	// Faithful shim: refuses to run under its own name (upstream
+	// ErrorKind::RunShimDirectly -> exit 126) and otherwise dispatches on argv[0].
 	writeScript(t, f.shim(), fmt.Sprintf(`#!/bin/sh
 n=${0##*/}
 if [ "$n" = %q ]; then
   echo "volta error: 'volta-shim' should not be called directly" >&2
   exit 126
 fi
-exec %q/"$n" "$@"
-`, voltaShimName, f.imageDir))
+exec %q/tools/image/packages/"$n"/bin/"$n" "$@"
+`, voltaShimName, f.home))
 
-	for _, command := range opts.commands {
-		if err := os.Symlink(f.shim(), f.alias(command)); err != nil {
-			t.Fatalf("symlink %s -> volta-shim: %v", command, err)
+	for _, cmd := range opts.commands {
+		if err := os.Symlink(f.shim(), f.alias(cmd)); err != nil {
+			t.Fatalf("symlink %s: %v", cmd, err)
 		}
 	}
-
 	if !opts.omitVolta {
-		writeScript(t, filepath.Join(f.binDir, "volta"), voltaFixtureScript(f, opts))
+		writeScript(t, f.voltaBin(), voltaFixtureScript(f, opts))
 	}
 	return f
 }
 
-// voltaFixtureScript renders the fake `volta`. It answers `which <tool>` and
-// `which node`, prints nothing and exits non-zero otherwise, like upstream.
+// voltaFixtureScript renders the fake `volta`. It resolves everything relative to
+// $VOLTA_HOME and fails without it, so a caller that does not pass the right home
+// cannot silently get the right answer. `which node` deliberately reports the
+// *current default* Node, which is not the one a bound package must run under.
 func voltaFixtureScript(f voltaFixture, opts voltaFixtureOpts) string {
-	var body string
+	var project string
 	if opts.projectDir != "" {
-		// Project-local preference: only triggered when invoked from inside the
-		// project, which is exactly the cwd sensitivity the caller must avoid.
-		body = fmt.Sprintf(`
-case "$PWD" in
+		project = fmt.Sprintf(`
+case "$(pwd -P)" in
   %q*)
     if [ "$1" = "which" ] && [ -n "$2" ]; then
       p=%q/"$2"
@@ -129,21 +145,38 @@ esac
 `, opts.projectDir, filepath.Join(opts.projectDir, "node_modules", ".bin"))
 	}
 	return fmt.Sprintf(`#!/bin/sh
+[ -n "$VOLTA_HOME" ] || { echo "volta: VOLTA_HOME not set" >&2; exit 1; }
 %s
 if [ "$1" = "which" ] && [ "$2" = "node" ]; then
-  echo %q; exit 0
+  echo "$VOLTA_HOME/tools/image/node/%s/bin/node"; exit 0
 fi
 if [ "$1" = "which" ] && [ -n "$2" ]; then
-  p=%q/"$2"
+  p="$VOLTA_HOME/tools/image/packages/$2/bin/$2"
   if [ -x "$p" ]; then echo "$p"; exit 0; fi
 fi
 exit 1
-`, body, filepath.Join(f.nodeDir, "node"), f.imageDir)
+`, project, f.otherNode)
+}
+
+func mkdirs(t *testing.T, dirs ...string) {
+	t.Helper()
+	for _, d := range dirs {
+		if err := os.MkdirAll(d, 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", d, err)
+		}
+	}
 }
 
 func writeScript(t *testing.T, path, body string) {
 	t.Helper()
 	if err := os.WriteFile(path, []byte(body), 0o755); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+}
+
+func writeVoltaConfigFile(t *testing.T, path, body string) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
 		t.Fatalf("write %s: %v", path, err)
 	}
 }
@@ -158,9 +191,6 @@ func skipIfNoPOSIXShell(t *testing.T) {
 	}
 }
 
-// isolateAgentDiscovery keeps probeAgentCLIs hermetic: no login-shell fork and
-// no Codex Desktop bundle fallback, so the only thing that can resolve is the
-// fixture on PATH.
 func isolateAgentDiscovery(t *testing.T) {
 	t.Helper()
 	origShell := resolveAgentsViaLoginShell
@@ -173,9 +203,18 @@ func isolateAgentDiscovery(t *testing.T) {
 	codexDesktopAppBundlePaths = func() []string { return nil }
 }
 
-// resetVoltaResolveCache clears the process-wide Volta resolution state (cached
-// answers, failure cooldown and spend budget) so tests cannot observe each
-// other's results.
+// unsetEnvForTest removes a variable for the duration of the test and restores
+// the original afterwards. t.Setenv with an empty string is NOT equivalent: the
+// variable stays present-but-empty, and a real Volta then treats its home as a
+// relative path and writes layout files into the working directory.
+func unsetEnvForTest(t *testing.T, name string) {
+	t.Helper()
+	t.Setenv(name, "") // registers restoration of the original value
+	if err := os.Unsetenv(name); err != nil {
+		t.Fatalf("unset %s: %v", name, err)
+	}
+}
+
 func resetVoltaResolveCache(t *testing.T) {
 	t.Helper()
 	clear := func() {
@@ -187,114 +226,405 @@ func resetVoltaResolveCache(t *testing.T) {
 	t.Cleanup(clear)
 }
 
-// runVoltaFromDir runs the fixture `volta` with an explicit working directory,
-// so a test can confirm the fixture is genuinely cwd-sensitive before asserting
-// that production code is not.
-func runVoltaFromDir(t *testing.T, voltaBin, dir string, args ...string) (string, bool) {
+// systemPath is a PATH with neither Volta nor any node on it: what a
+// GUI-launched daemon sees.
+func systemPath(extra ...string) string {
+	return strings.Join(append(append([]string{}, extra...), "/usr/bin", "/bin"),
+		string(os.PathListSeparator))
+}
+
+// probeVersion runs the pinned executable under its resolved environment.
+func probeVersion(t *testing.T, resolved resolvedExecutable) (string, error) {
 	t.Helper()
-	cmd := exec.Command(voltaBin, args...)
-	cmd.Dir = dir
-	out, err := cmd.Output()
-	if err != nil {
-		return "", false
-	}
-	return strings.TrimSpace(string(out)), true
+	return agent.DetectVersionWithEnv(context.Background(), resolved.Path, resolved.Env)
 }
 
-// pathWithout returns a PATH containing only dirs (plus /bin and /usr/bin for
-// the shell itself), deliberately excluding Volta's Node platform dir.
-func pathWithout(dirs ...string) string {
-	all := append([]string{}, dirs...)
-	all = append(all, "/usr/bin", "/bin")
-	out := ""
-	for _, d := range all {
-		if out != "" {
-			out += string(os.PathListSeparator)
-		}
-		out += d
-	}
-	return out
-}
-
-// TestResolveAgentExecutablePath_PinsVoltaConcreteBinary is the primary
-// regression test for #6183: the pinned path must be the concrete binary, so the
-// path we version-check is the path we later execute.
-func TestResolveAgentExecutablePath_PinsVoltaConcreteBinary(t *testing.T) {
+// TestResolveAgentExecutable_PinsConcreteBinaryWithBoundNode is the primary
+// regression test for #6183 plus the environment requirement: the pinned path must
+// be the concrete binary, and it must carry the Node platform Volta bound to the
+// package at install time — NOT the current default Node.
+func TestResolveAgentExecutable_PinsConcreteBinaryWithBoundNode(t *testing.T) {
 	skipIfNoPOSIXShell(t)
 	resetVoltaResolveCache(t)
 
 	commands := []string{"claude", "codex", "pi"}
 	f := newVoltaFixture(t, voltaFixtureOpts{commands: commands})
-	t.Setenv("PATH", pathWithout(f.binDir))
+	t.Setenv("PATH", systemPath(f.binDir()))
 
-	for _, command := range commands {
-		resolved, err := resolveAgentExecutable(command)
+	for _, cmd := range commands {
+		resolved, err := resolveAgentExecutable(cmd)
 		if err != nil {
-			t.Fatalf("%s: resolveAgentExecutable: %v", command, err)
+			t.Fatalf("%s: resolveAgentExecutable: %v", cmd, err)
 		}
 		if resolved.Path == f.shim() {
-			t.Fatalf("%s pinned the shared shim; the version probe exits 126 there (#6183)", command)
+			t.Fatalf("%s pinned the shared shim; the version probe exits 126 there (#6183)", cmd)
 		}
-		if resolved.Path == f.alias(command) {
-			t.Errorf("%s pinned the Volta alias %q; that path dispatches per working "+
-				"directory, so the gated version would not be the executed version", command, resolved.Path)
+		if resolved.Path == f.alias(cmd) {
+			t.Errorf("%s pinned the Volta alias; that dispatches per working directory", cmd)
 		}
-		if want := f.concrete(command); resolved.Path != want {
-			t.Errorf("%s path = %q, want the concrete binary %q", command, resolved.Path, want)
+		if want := f.concrete(cmd); resolved.Path != want {
+			t.Errorf("%s path = %q, want %q", cmd, resolved.Path, want)
 		}
 
-		version, err := agent.DetectVersionWithPathDirs(context.Background(), resolved.Path, resolved.PathDirs)
-		if err != nil {
-			t.Fatalf("%s: DetectVersionWithPathDirs(%q): %v", command, resolved.Path, err)
+		pathDirs := resolved.Env.PrefixPaths["PATH"]
+		if len(pathDirs) == 0 || pathDirs[0] != f.boundNodeDir() {
+			t.Errorf("%s PATH dirs = %v, want the install-time bound Node %q; using the "+
+				"current default Node means switching defaults silently changes which "+
+				"Node a previously installed CLI runs under", cmd, pathDirs, f.boundNodeDir())
 		}
-		if version != voltaFixtureVersions[command] {
-			t.Errorf("%s version = %q, want %q", command, version, voltaFixtureVersions[command])
+		if nodePath := resolved.Env.PrefixPaths["NODE_PATH"]; len(nodePath) == 0 || nodePath[0] != f.sharedLibDir() {
+			t.Errorf("%s NODE_PATH = %v, want Volta's shared lib dir %q so a global bin can "+
+				"require other global libs", cmd, nodePath, f.sharedLibDir())
+		}
+
+		version, err := probeVersion(t, resolved)
+		if err != nil {
+			t.Fatalf("%s: version probe under the resolved env: %v", cmd, err)
+		}
+		if version != voltaFixtureVersions[cmd] {
+			t.Errorf("%s version = %q, want %q", cmd, version, voltaFixtureVersions[cmd])
 		}
 	}
 }
 
-// TestResolveAgentExecutable_CarriesVoltaNodePlatform covers review item 3: the
-// concrete binary is a node script, so the resolution must also hand back the
-// Node platform dir. Without it the pinned path is unrunnable under a PATH that
-// has no node — the GUI-launched case — and the version probe and the task
-// launch could disagree about which node runs the CLI.
-func TestResolveAgentExecutable_CarriesVoltaNodePlatform(t *testing.T) {
+// TestResolveAgentExecutable_EnvironmentIsRequired proves the carried environment
+// is load-bearing: without it the pinned path is not runnable at all.
+func TestResolveAgentExecutable_EnvironmentIsRequired(t *testing.T) {
 	skipIfNoPOSIXShell(t)
 	resetVoltaResolveCache(t)
 
 	f := newVoltaFixture(t, voltaFixtureOpts{commands: []string{"codex"}})
-	// Note: no node anywhere on PATH, only inside Volta's platform dir.
-	t.Setenv("PATH", pathWithout(f.binDir))
+	t.Setenv("PATH", systemPath(f.binDir()))
 
 	resolved, err := resolveAgentExecutable("codex")
 	if err != nil {
 		t.Fatalf("resolveAgentExecutable: %v", err)
 	}
-	if len(resolved.PathDirs) == 0 {
-		t.Fatal("resolution returned no PATH dirs; a node-script package binary cannot run without Volta's Node platform")
+	if _, err := probeVersion(t, resolved); err != nil {
+		t.Errorf("probe with the resolved environment failed: %v", err)
 	}
-	if resolved.PathDirs[0] != f.nodeDir {
-		t.Errorf("PathDirs[0] = %q, want Volta's node dir %q", resolved.PathDirs[0], f.nodeDir)
-	}
-
-	// With the environment: runnable.
-	if _, err := agent.DetectVersionWithPathDirs(context.Background(), resolved.Path, resolved.PathDirs); err != nil {
-		t.Errorf("version probe with the resolved environment failed: %v", err)
-	}
-	// Without it: not runnable. This is what makes carrying the dirs necessary
-	// rather than cosmetic.
 	if _, err := agent.DetectVersion(context.Background(), resolved.Path); err == nil {
-		t.Error("version probe without the resolved environment unexpectedly succeeded; " +
-			"the fixture no longer models the `#!/usr/bin/env node` dependency")
+		t.Error("probe WITHOUT the resolved environment unexpectedly succeeded; the fixture " +
+			"no longer models the `#!/usr/bin/env node` dependency")
 	}
 }
 
-// TestProbeAgentCLIs_ShellFallbackResolvesVoltaAlias covers review item 1. A
-// GUI-launched daemon does not see Volta on its own PATH and falls back to the
-// login shell, whose script preserves the file name — so the alias arrives here
-// still pointing at the shared shim. That leg must apply the same resolution as
-// the LookPath leg, otherwise Desktop users keep the ungated alias.
-func TestProbeAgentCLIs_ShellFallbackResolvesVoltaAlias(t *testing.T) {
+// TestVoltaResolve_UsesDerivedVoltaHomeNotAmbient covers the GUI daemon with a
+// custom VOLTA_HOME. The daemon does not inherit the user's VOLTA_HOME, and Volta
+// reads all package data relative to it, so resolution must derive the home from
+// the alias instead of trusting (or defaulting) the environment.
+func TestVoltaResolve_UsesDerivedVoltaHomeNotAmbient(t *testing.T) {
+	skipIfNoPOSIXShell(t)
+	resetVoltaResolveCache(t)
+
+	f := newVoltaFixture(t, voltaFixtureOpts{commands: []string{"claude"}})
+	t.Setenv("PATH", systemPath(f.binDir()))
+
+	// The daemon's environment knows nothing about this install: no VOLTA_HOME at
+	// all (GUI launch), which is what the original report ran into.
+	unsetEnvForTest(t, "VOLTA_HOME")
+	resolved, ok := voltaResolve(f.alias("claude"), f.shim(), "claude")
+	if !ok {
+		t.Fatal("resolution failed with no VOLTA_HOME in the environment; a GUI-launched " +
+			"daemon never inherits it, so the home must come from the alias path")
+	}
+	if want := f.concrete("claude"); resolved.Path != want {
+		t.Errorf("path = %q, want %q", resolved.Path, want)
+	}
+
+	// And a *wrong* inherited value must not win either.
+	resetVoltaResolveCache(t)
+	decoy := t.TempDir()
+	t.Setenv("VOLTA_HOME", decoy)
+	resolved, ok = voltaResolve(f.alias("claude"), f.shim(), "claude")
+	if !ok {
+		t.Fatal("resolution failed with a decoy VOLTA_HOME set")
+	}
+	if strings.HasPrefix(resolved.Path, decoy) {
+		t.Errorf("resolved into the decoy home %q; the ambient VOLTA_HOME overrode the "+
+			"install the alias actually belongs to", decoy)
+	}
+	if want := f.concrete("claude"); resolved.Path != want {
+		t.Errorf("path = %q, want %q", resolved.Path, want)
+	}
+}
+
+func TestVoltaHomeFromAlias(t *testing.T) {
+	skipIfNoPOSIXShell(t)
+	f := newVoltaFixture(t, voltaFixtureOpts{commands: []string{"claude"}})
+
+	got, ok := voltaHomeFromAlias(f.alias("claude"))
+	if !ok {
+		t.Fatal("could not derive VOLTA_HOME from the alias")
+	}
+	if got != f.home {
+		t.Errorf("voltaHomeFromAlias = %q, want %q", got, f.home)
+	}
+
+	// A non-Volta symlink yields nothing rather than a wrong guess.
+	other := filepath.Join(t.TempDir(), "claude")
+	target := filepath.Join(t.TempDir(), "real")
+	writeScript(t, target, "#!/bin/sh\nexit 0\n")
+	if err := os.Symlink(target, other); err != nil {
+		t.Fatal(err)
+	}
+	if home, ok := voltaHomeFromAlias(other); ok {
+		t.Errorf("derived %q from a non-Volta symlink; want no answer", home)
+	}
+}
+
+// TestVoltaResolve_FailsClosedWithoutBoundNode covers the partial-answer case: if
+// the bound Node cannot be determined we cannot reproduce Volta's environment, so
+// the resolution must fail rather than cache a path with an empty environment.
+func TestVoltaResolve_FailsClosedWithoutBoundNode(t *testing.T) {
+	skipIfNoPOSIXShell(t)
+	resetVoltaResolveCache(t)
+
+	f := newVoltaFixture(t, voltaFixtureOpts{commands: []string{"claude"}, omitBinConfig: true})
+	t.Setenv("PATH", systemPath(f.binDir()))
+
+	if resolved, ok := voltaResolve(f.alias("claude"), f.shim(), "claude"); ok {
+		t.Fatalf("resolved without a bound Node (%+v); an incomplete environment must not "+
+			"be cached or launched", resolved)
+	}
+	// And the overall resolution must not silently fall back to the alias.
+	got, err := resolveAgentExecutablePath("claude")
+	if err != nil {
+		t.Fatalf("resolveAgentExecutablePath: %v", err)
+	}
+	if got == f.alias("claude") {
+		t.Errorf("fell back to the alias %q", got)
+	}
+}
+
+// TestVoltaResolve_RevalidatesWhenNodeImageRemoved makes cache validity cover the
+// whole resolution, not just the tool path: if the Node image is deleted (a Volta
+// upgrade prunes old images) the cached entry is unrunnable and must be dropped.
+func TestVoltaResolve_RevalidatesWhenNodeImageRemoved(t *testing.T) {
+	skipIfNoPOSIXShell(t)
+	resetVoltaResolveCache(t)
+
+	f := newVoltaFixture(t, voltaFixtureOpts{commands: []string{"claude"}})
+	t.Setenv("PATH", systemPath(f.binDir()))
+
+	first, ok := voltaResolve(f.alias("claude"), f.shim(), "claude")
+	if !ok {
+		t.Fatal("initial resolution failed")
+	}
+	if !voltaResolutionUsable(first) {
+		t.Fatal("fresh resolution reported unusable")
+	}
+
+	if err := os.RemoveAll(filepath.Dir(f.boundNodeDir())); err != nil {
+		t.Fatalf("remove node image: %v", err)
+	}
+	if voltaResolutionUsable(first) {
+		t.Error("cached resolution still considered usable after its Node image was removed; " +
+			"validity must cover the environment, not only the tool path")
+	}
+}
+
+// TestVoltaResolve_BudgetResetsAfterCooldown is the recovery case: the spend
+// budget bounds one breaker window, not the process lifetime. Repeated slow
+// failures separated by expired cooldowns must each get a fresh attempt, or Volta
+// resolution latches off for good after a couple of transient outages.
+func TestVoltaResolve_BudgetResetsAfterCooldown(t *testing.T) {
+	skipIfNoPOSIXShell(t)
+	resetVoltaResolveCache(t)
+
+	origRun, origCooldown, origBudget := runVolta, voltaFailureCooldown, voltaResolveBudget
+	t.Cleanup(func() {
+		runVolta, voltaFailureCooldown, voltaResolveBudget = origRun, origCooldown, origBudget
+	})
+	voltaFailureCooldown = 20 * time.Millisecond
+	voltaResolveBudget = 60 * time.Millisecond
+
+	var mu sync.Mutex
+	calls := 0
+	// Each attempt costs most of the budget, so two of them exceed it.
+	runVolta = func(string, string, ...string) (string, bool) {
+		mu.Lock()
+		calls++
+		mu.Unlock()
+		time.Sleep(40 * time.Millisecond)
+		return "", false
+	}
+
+	f := newVoltaFixture(t, voltaFixtureOpts{commands: []string{"claude"}})
+	t.Setenv("PATH", systemPath(f.binDir()))
+
+	for i := 0; i < 3; i++ {
+		if i > 0 {
+			time.Sleep(2 * voltaFailureCooldown)
+		}
+		if _, ok := voltaResolve(f.alias("claude"), f.shim(), "claude"); ok {
+			t.Fatalf("attempt %d unexpectedly resolved", i+1)
+		}
+	}
+
+	mu.Lock()
+	got := calls
+	mu.Unlock()
+	if got != 3 {
+		t.Errorf("`volta` was invoked %d times across 3 expired cooldowns, want 3; the spend "+
+			"budget is accumulating across windows and permanently trips the breaker", got)
+	}
+}
+
+// TestVoltaResolve_BoundsTotalCostWhenVoltaHangs covers the additive-timeout
+// problem: a wedged install used to cost one full timeout PER command.
+func TestVoltaResolve_BoundsTotalCostWhenVoltaHangs(t *testing.T) {
+	skipIfNoPOSIXShell(t)
+	resetVoltaResolveCache(t)
+
+	origRun, origTimeout, origWait := runVolta, voltaResolveTimeout, voltaResolveWaitDelay
+	t.Cleanup(func() {
+		runVolta, voltaResolveTimeout, voltaResolveWaitDelay = origRun, origTimeout, origWait
+	})
+	voltaResolveTimeout = 100 * time.Millisecond
+	voltaResolveWaitDelay = 50 * time.Millisecond
+
+	var mu sync.Mutex
+	calls := 0
+	runVolta = func(string, string, ...string) (string, bool) {
+		mu.Lock()
+		calls++
+		mu.Unlock()
+		time.Sleep(voltaResolveTimeout + voltaResolveWaitDelay)
+		return "", false
+	}
+
+	commands := []string{"claude", "codex", "pi"}
+	f := newVoltaFixture(t, voltaFixtureOpts{commands: commands})
+	t.Setenv("PATH", systemPath(f.binDir()))
+
+	start := time.Now()
+	for _, cmd := range commands {
+		if _, ok := voltaResolve(f.alias(cmd), f.shim(), cmd); ok {
+			t.Fatalf("%s unexpectedly resolved against a hung volta", cmd)
+		}
+	}
+	elapsed := time.Since(start)
+
+	mu.Lock()
+	got := calls
+	mu.Unlock()
+	if got != 1 {
+		t.Errorf("`volta` was invoked %d times for %d commands, want 1; a broken install must "+
+			"be asked once per cooldown, not once per command", got, len(commands))
+	}
+	singleCall := voltaResolveTimeout + voltaResolveWaitDelay
+	if additive := time.Duration(len(commands)) * singleCall; elapsed >= additive {
+		t.Errorf("resolving %d hung aliases took %v, at least the additive bound %v",
+			len(commands), elapsed, additive)
+	}
+}
+
+// TestVoltaResolve_CoalescesConcurrentResolutions covers the in-flight merge:
+// releasing the lock for the subprocess must not let N concurrent callers each
+// spawn their own `volta`.
+func TestVoltaResolve_CoalescesConcurrentResolutions(t *testing.T) {
+	skipIfNoPOSIXShell(t)
+	resetVoltaResolveCache(t)
+
+	origRun := runVolta
+	t.Cleanup(func() { runVolta = origRun })
+
+	f := newVoltaFixture(t, voltaFixtureOpts{commands: []string{"claude"}})
+	t.Setenv("PATH", systemPath(f.binDir()))
+
+	var mu sync.Mutex
+	calls := 0
+	runVolta = func(voltaBin, voltaHome string, args ...string) (string, bool) {
+		mu.Lock()
+		calls++
+		mu.Unlock()
+		time.Sleep(30 * time.Millisecond)
+		return origRun(voltaBin, voltaHome, args...)
+	}
+
+	const concurrency = 8
+	var wg sync.WaitGroup
+	results := make([]resolvedExecutable, concurrency)
+	oks := make([]bool, concurrency)
+	for i := 0; i < concurrency; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			results[i], oks[i] = voltaResolve(f.alias("claude"), f.shim(), "claude")
+		}(i)
+	}
+	wg.Wait()
+
+	for i, ok := range oks {
+		if !ok {
+			t.Fatalf("goroutine %d failed to resolve", i)
+		}
+		if results[i].Path != results[0].Path {
+			t.Errorf("goroutine %d resolved %q, want %q", i, results[i].Path, results[0].Path)
+		}
+	}
+	mu.Lock()
+	got := calls
+	mu.Unlock()
+	// One `volta which` for the tool. Without coalescing every goroutine spawns
+	// its own, which is what the released lock would otherwise allow.
+	if got > 1 {
+		t.Errorf("`volta` was invoked %d times for %d concurrent resolutions of the same "+
+			"command, want 1", got, concurrency)
+	}
+}
+
+// TestVoltaResolve_IgnoresProjectDirectory covers the working-directory
+// sensitivity: Volta resolves a project-local binary before the user default, so
+// asking it from wherever the daemon started would pin one project's dependency as
+// the machine-wide runtime.
+func TestVoltaResolve_IgnoresProjectDirectory(t *testing.T) {
+	skipIfNoPOSIXShell(t)
+	resetVoltaResolveCache(t)
+
+	projectDir := t.TempDir()
+	projectBin := filepath.Join(projectDir, "node_modules", ".bin")
+	mkdirs(t, projectBin)
+	writeScript(t, filepath.Join(projectBin, "claude"), "#!/bin/sh\necho \"0.0.1 (project local)\"\n")
+
+	physicalProject, err := filepath.EvalSymlinks(projectDir)
+	if err != nil {
+		t.Fatalf("EvalSymlinks(%q): %v", projectDir, err)
+	}
+	f := newVoltaFixture(t, voltaFixtureOpts{commands: []string{"claude"}, projectDir: physicalProject})
+	t.Setenv("PATH", systemPath(f.binDir()))
+
+	// Sanity: the fixture really is cwd-sensitive, so this test can fail.
+	cmd := exec.Command(f.voltaBin(), "which", "claude")
+	cmd.Dir = projectDir
+	cmd.Env = append(os.Environ(), "VOLTA_HOME="+f.home)
+	out, err := cmd.Output()
+	if err != nil {
+		t.Fatalf("fixture volta failed inside the project dir: %v", err)
+	}
+	physicalProjectBin := filepath.Join(physicalProject, "node_modules", ".bin", "claude")
+	if got := strings.TrimSpace(string(out)); got != physicalProjectBin {
+		t.Fatalf("fixture is not cwd-sensitive: got %q, want %q", got, physicalProjectBin)
+	}
+
+	t.Chdir(projectDir)
+	resolved, ok := voltaResolve(f.alias("claude"), f.shim(), "claude")
+	if !ok {
+		t.Fatal("voltaResolve failed")
+	}
+	if resolved.Path == physicalProjectBin {
+		t.Errorf("resolved the project-local binary; a daemon started inside a JS project " +
+			"would pin that project's dependency as the machine runtime")
+	}
+	if want := f.concrete("claude"); resolved.Path != want {
+		t.Errorf("path = %q, want the default toolchain binary %q", resolved.Path, want)
+	}
+}
+
+// TestProbeAgentCLIs_ShellFallbackCarriesEnvironment covers the GUI/login-shell
+// leg: it must apply the same resolution, environment included.
+func TestProbeAgentCLIs_ShellFallbackCarriesEnvironment(t *testing.T) {
 	skipIfNoPOSIXShell(t)
 	resetVoltaResolveCache(t)
 
@@ -321,16 +651,16 @@ func TestProbeAgentCLIs_ShellFallbackResolvesVoltaAlias(t *testing.T) {
 		t.Fatalf("shell fallback pinned the Volta alias %q; the GUI path bypassed resolution", entry.Path)
 	}
 	if want := f.concrete("claude"); entry.Path != want {
-		t.Errorf("path = %q, want the concrete binary %q", entry.Path, want)
+		t.Errorf("path = %q, want %q", entry.Path, want)
 	}
-	if len(entry.PathDirs) == 0 || entry.PathDirs[0] != f.nodeDir {
-		t.Errorf("PathDirs = %v, want Volta's node dir %q", entry.PathDirs, f.nodeDir)
+	if dirs := entry.Env.PrefixPaths["PATH"]; len(dirs) == 0 || dirs[0] != f.boundNodeDir() {
+		t.Errorf("PATH dirs = %v, want the bound Node %q", dirs, f.boundNodeDir())
 	}
 }
 
-// TestReresolveAgentCommand_ShellFallbackResolvesVoltaAlias is item 1 for the
+// TestReresolveAgentCommand_ShellFallbackCarriesEnvironment is the same for the
 // self-heal path, which has its own shell branch.
-func TestReresolveAgentCommand_ShellFallbackResolvesVoltaAlias(t *testing.T) {
+func TestReresolveAgentCommand_ShellFallbackCarriesEnvironment(t *testing.T) {
 	skipIfNoPOSIXShell(t)
 	resetVoltaResolveCache(t)
 
@@ -347,183 +677,26 @@ func TestReresolveAgentCommand_ShellFallbackResolvesVoltaAlias(t *testing.T) {
 	if !ok {
 		t.Fatal("reresolveAgentCommand did not resolve claude")
 	}
-	if resolved.Path == f.alias("claude") {
-		t.Fatalf("self-heal pinned the Volta alias %q", resolved.Path)
-	}
 	if want := f.concrete("claude"); resolved.Path != want {
 		t.Errorf("path = %q, want %q", resolved.Path, want)
 	}
-}
-
-// TestVoltaResolve_IgnoresProjectDirectory covers review item 2. Volta resolves a
-// project-local binary before the user default, so asking it from whatever
-// directory the daemon happens to be started in would pin one project's
-// dependency as the machine-wide runtime.
-func TestVoltaResolve_IgnoresProjectDirectory(t *testing.T) {
-	skipIfNoPOSIXShell(t)
-	resetVoltaResolveCache(t)
-
-	projectDir := t.TempDir()
-	projectBin := filepath.Join(projectDir, "node_modules", ".bin")
-	if err := os.MkdirAll(projectBin, 0o755); err != nil {
-		t.Fatalf("mkdir: %v", err)
-	}
-	writeScript(t, filepath.Join(projectBin, "claude"), "#!/bin/sh\necho \"0.0.1 (project local)\"\n")
-
-	f := newVoltaFixture(t, voltaFixtureOpts{
-		commands:   []string{"claude"},
-		projectDir: projectDir,
-	})
-	t.Setenv("PATH", pathWithout(f.binDir))
-
-	// Sanity: the fixture really is cwd-sensitive, so this test can fail.
-	if out, ok := runVoltaFromDir(t, filepath.Join(f.binDir, "volta"), projectDir, "which", "claude"); !ok {
-		t.Fatalf("fixture volta failed inside the project dir")
-	} else if out != filepath.Join(projectBin, "claude") {
-		t.Fatalf("fixture is not cwd-sensitive: got %q", out)
-	}
-
-	// Run the daemon's resolution with the process cwd inside the project.
-	t.Chdir(projectDir)
-
-	resolved, ok := voltaResolve(f.shim(), "claude")
-	if !ok {
-		t.Fatal("voltaResolve failed")
-	}
-	if got := resolved.Path; got == filepath.Join(projectBin, "claude") {
-		t.Errorf("resolved the project-local binary %q; a daemon started inside a JS "+
-			"project would pin that project's dependency as the machine runtime", got)
-	} else if want := f.concrete("claude"); got != want {
-		t.Errorf("path = %q, want the default toolchain binary %q", got, want)
-	}
-}
-
-// TestVoltaResolve_BoundsTotalCostWhenVoltaHangs covers review item 4. A wedged
-// Volta install used to cost one full timeout PER command, so a machine with
-// several Volta-managed CLIs stalled startup for the sum of them.
-//
-// The invocation count is the real invariant ("ask a broken install once, not
-// once per command"), so it is asserted directly rather than inferred from wall
-// clock. runVolta is stubbed instead of hanging a real subprocess: a killed child
-// reports its side effects asynchronously, which made a file-based counter race
-// with the kill and read one call behind.
-func TestVoltaResolve_BoundsTotalCostWhenVoltaHangs(t *testing.T) {
-	skipIfNoPOSIXShell(t)
-	resetVoltaResolveCache(t)
-
-	origTimeout, origWait := voltaResolveTimeout, voltaResolveWaitDelay
-	origRun := runVolta
-	t.Cleanup(func() {
-		voltaResolveTimeout, voltaResolveWaitDelay = origTimeout, origWait
-		runVolta = origRun
-	})
-	voltaResolveTimeout = 100 * time.Millisecond
-	voltaResolveWaitDelay = 50 * time.Millisecond
-
-	var mu sync.Mutex
-	calls := 0
-	// Models a wedged install: every invocation burns the whole per-call budget
-	// (timeout + the wait for a hung child's pipes) and then fails.
-	runVolta = func(string, ...string) (string, bool) {
-		mu.Lock()
-		calls++
-		mu.Unlock()
-		time.Sleep(voltaResolveTimeout + voltaResolveWaitDelay)
-		return "", false
-	}
-
-	commands := []string{"claude", "codex", "pi"}
-	f := newVoltaFixture(t, voltaFixtureOpts{commands: commands})
-	t.Setenv("PATH", pathWithout(f.binDir))
-
-	start := time.Now()
-	for _, command := range commands {
-		if _, ok := voltaResolve(f.shim(), command); ok {
-			t.Fatalf("%s unexpectedly resolved against a hung volta", command)
-		}
-	}
-	elapsed := time.Since(start)
-
-	mu.Lock()
-	got := calls
-	mu.Unlock()
-	if got != 1 {
-		t.Errorf("`volta` was invoked %d times for %d commands, want 1; a broken install "+
-			"must be asked once per cooldown, not once per command", got, len(commands))
-	}
-
-	singleCall := voltaResolveTimeout + voltaResolveWaitDelay
-	if additive := time.Duration(len(commands)) * singleCall; elapsed >= additive {
-		t.Errorf("resolving %d hung aliases took %v, at least the additive bound %v; "+
-			"the per-command timeout can still stall daemon startup", len(commands), elapsed, additive)
-	}
-}
-
-// TestVoltaResolve_FailureCooldownExpires is the other half of the circuit
-// breaker: a temporarily broken install must be retried once the cooldown is up,
-// not written off for the daemon's lifetime.
-func TestVoltaResolve_FailureCooldownExpires(t *testing.T) {
-	skipIfNoPOSIXShell(t)
-	resetVoltaResolveCache(t)
-
-	origRun, origCooldown := runVolta, voltaFailureCooldown
-	t.Cleanup(func() { runVolta, voltaFailureCooldown = origRun, origCooldown })
-	voltaFailureCooldown = 20 * time.Millisecond
-
-	var mu sync.Mutex
-	calls := 0
-	runVolta = func(string, ...string) (string, bool) {
-		mu.Lock()
-		defer mu.Unlock()
-		calls++
-		return "", false
-	}
-
-	f := newVoltaFixture(t, voltaFixtureOpts{commands: []string{"claude"}})
-	t.Setenv("PATH", pathWithout(f.binDir))
-
-	if _, ok := voltaResolve(f.shim(), "claude"); ok {
-		t.Fatal("unexpectedly resolved")
-	}
-	// Inside the cooldown: no new invocation.
-	if _, ok := voltaResolve(f.shim(), "claude"); ok {
-		t.Fatal("unexpectedly resolved")
-	}
-	mu.Lock()
-	during := calls
-	mu.Unlock()
-	if during != 1 {
-		t.Errorf("invocations inside the cooldown = %d, want 1", during)
-	}
-
-	time.Sleep(2 * voltaFailureCooldown)
-	if _, ok := voltaResolve(f.shim(), "claude"); ok {
-		t.Fatal("unexpectedly resolved")
-	}
-	mu.Lock()
-	after := calls
-	mu.Unlock()
-	if after != 2 {
-		t.Errorf("invocations after the cooldown expired = %d, want 2; a transient failure "+
-			"must not disable Volta resolution permanently", after)
+	if resolved.Env.IsZero() {
+		t.Error("self-heal dropped the execution environment")
 	}
 }
 
 // TestDetectBuiltinRuntimes_RegistersVoltaManagedCLIs is the end-result test:
-// availability alone was never the user-visible outcome. This runs the real
-// version probe and the real minimum-version gate over a Volta install and
-// asserts all three providers reach the registration payload.
+// through the real version probe and the real minimum-version gate, under a PATH
+// that has no node of its own.
 func TestDetectBuiltinRuntimes_RegistersVoltaManagedCLIs(t *testing.T) {
 	skipIfNoPOSIXShell(t)
 	resetVoltaResolveCache(t)
 
 	commands := []string{"claude", "codex", "pi"}
 	f := newVoltaFixture(t, voltaFixtureOpts{commands: commands})
-	t.Setenv("PATH", pathWithout(f.binDir))
+	t.Setenv("PATH", systemPath(f.binDir()))
 	isolateAgentDiscovery(t)
 
-	// Deliberately no detectAgentVersion / checkAgentMinVersion stubs: the point
-	// is that the real gate accepts what discovery pinned.
 	d := freshDaemon("")
 	d.cfg.Agents = probeAgentCLIs()
 
@@ -531,58 +704,56 @@ func TestDetectBuiltinRuntimes_RegistersVoltaManagedCLIs(t *testing.T) {
 	for _, rt := range d.detectBuiltinRuntimes(context.Background()) {
 		registered[rt["type"]] = rt["version"]
 	}
-	for _, command := range commands {
-		version, ok := registered[command]
+	for _, cmd := range commands {
+		version, ok := registered[cmd]
 		if !ok {
 			t.Errorf("%s missing from the registration payload; skipped reasons: %#v",
-				command, d.skippedAgentsSnapshot())
+				cmd, d.skippedAgentsSnapshot())
 			continue
 		}
-		if version != voltaFixtureVersions[command] {
-			t.Errorf("%s registered version = %q, want %q", command, version, voltaFixtureVersions[command])
+		if version != voltaFixtureVersions[cmd] {
+			t.Errorf("%s registered version = %q, want %q", cmd, version, voltaFixtureVersions[cmd])
 		}
 	}
 }
 
-// TestProbeAgentCLIs_DiscoversVoltaManagedCLIs covers the discovery entry point
-// and asserts the three providers get three distinct concrete paths.
+// TestProbeAgentCLIs_DiscoversVoltaManagedCLIs asserts the providers get distinct
+// concrete paths rather than one shared shim.
 func TestProbeAgentCLIs_DiscoversVoltaManagedCLIs(t *testing.T) {
 	skipIfNoPOSIXShell(t)
 	resetVoltaResolveCache(t)
 
 	commands := []string{"claude", "codex", "pi"}
 	f := newVoltaFixture(t, voltaFixtureOpts{commands: commands})
-	t.Setenv("PATH", pathWithout(f.binDir))
+	t.Setenv("PATH", systemPath(f.binDir()))
 	isolateAgentDiscovery(t)
 
 	agents := probeAgentCLIs()
 	seen := map[string]string{}
-	for _, command := range commands {
-		entry, ok := agents[command]
+	for _, cmd := range commands {
+		entry, ok := agents[cmd]
 		if !ok {
-			t.Fatalf("%s not discovered from a Volta install: %#v", command, agents)
+			t.Fatalf("%s not discovered: %#v", cmd, agents)
 		}
-		if want := f.concrete(command); entry.Path != want {
-			t.Errorf("%s path = %q, want %q", command, entry.Path, want)
+		if want := f.concrete(cmd); entry.Path != want {
+			t.Errorf("%s path = %q, want %q", cmd, entry.Path, want)
 		}
 		if prev, dup := seen[entry.Path]; dup {
-			t.Errorf("%s and %s share one path %q", prev, command, entry.Path)
+			t.Errorf("%s and %s share one path %q", prev, cmd, entry.Path)
 		}
-		seen[entry.Path] = command
+		seen[entry.Path] = cmd
 	}
 }
 
 // TestResolveAgentExecutablePath_FailsClosedWithoutVoltaResolution pins the
 // deliberate failure mode: with no way to ask Volta we must NOT fall back to the
-// alias, because that path is only version-checkable under conditions we cannot
-// reproduce at launch. Staying unregistered is correct; MULTICA_*_PATH remains
-// the escape hatch.
+// alias, whose environment we cannot reproduce at launch.
 func TestResolveAgentExecutablePath_FailsClosedWithoutVoltaResolution(t *testing.T) {
 	skipIfNoPOSIXShell(t)
 	resetVoltaResolveCache(t)
 
 	f := newVoltaFixture(t, voltaFixtureOpts{commands: []string{"claude"}, omitVolta: true})
-	t.Setenv("PATH", pathWithout(f.binDir))
+	t.Setenv("PATH", systemPath(f.binDir()))
 
 	got, err := resolveAgentExecutablePath("claude")
 	if err != nil {
@@ -603,71 +774,43 @@ func TestResolveAgentExecutablePath_FailsClosedWithoutVoltaResolution(t *testing
 	}
 }
 
-// TestVoltaResolve_ReresolvesAfterBinaryReplaced covers the cache's
-// revalidation-by-existence: when Volta swaps the underlying tool and the old
-// concrete path disappears, the next resolution must not keep serving it.
+// TestVoltaResolve_ReresolvesAfterBinaryReplaced covers revalidation by existence.
 func TestVoltaResolve_ReresolvesAfterBinaryReplaced(t *testing.T) {
 	skipIfNoPOSIXShell(t)
 	resetVoltaResolveCache(t)
 
 	f := newVoltaFixture(t, voltaFixtureOpts{commands: []string{"claude"}})
-	t.Setenv("PATH", pathWithout(f.binDir))
+	t.Setenv("PATH", systemPath(f.binDir()))
 
-	first, ok := voltaResolve(f.shim(), "claude")
+	first, ok := voltaResolve(f.alias("claude"), f.shim(), "claude")
 	if !ok {
 		t.Fatal("initial resolution failed")
 	}
-	if again, ok := voltaResolve(f.shim(), "claude"); !ok || again.Path != first.Path {
+	if again, ok := voltaResolve(f.alias("claude"), f.shim(), "claude"); !ok || again.Path != first.Path {
 		t.Fatalf("cached resolution = (%q, %v), want (%q, true)", again.Path, ok, first.Path)
 	}
-
 	if err := os.Remove(first.Path); err != nil {
 		t.Fatalf("remove concrete binary: %v", err)
 	}
-	newImage := filepath.Join(t.TempDir(), "image")
-	if err := os.MkdirAll(newImage, 0o755); err != nil {
-		t.Fatalf("mkdir: %v", err)
-	}
-	writeScript(t, filepath.Join(newImage, "claude"), "#!/bin/sh\necho \"3.0.0 (Claude Code)\"\n")
-	writeScript(t, filepath.Join(f.binDir, "volta"), fmt.Sprintf(`#!/bin/sh
-if [ "$1" = "which" ] && [ "$2" = "node" ]; then echo %q; exit 0; fi
-if [ "$1" = "which" ] && [ -n "$2" ]; then
-  p=%q/"$2"
-  if [ -x "$p" ]; then echo "$p"; exit 0; fi
-fi
-exit 1
-`, filepath.Join(f.nodeDir, "node"), newImage))
-
-	second, ok := voltaResolve(f.shim(), "claude")
-	if !ok {
-		t.Fatal("re-resolution failed after the pinned binary disappeared")
-	}
-	if second.Path == first.Path {
-		t.Errorf("still serving the removed path %q", first.Path)
-	}
-	if want := filepath.Join(newImage, "claude"); second.Path != want {
-		t.Errorf("re-resolved path = %q, want %q", second.Path, want)
+	if voltaResolutionUsable(first) {
+		t.Error("cached resolution still usable after the binary was removed")
 	}
 }
 
-// TestResolveAgentExecutablePath_VoltaAliasShadowedByHooks proves the fix reaches
-// the ~/.multica/hooks branch, which canonicalizes independently: a
-// hooks-shadowed Volta command must skip the recursive wrapper AND still land on
-// the concrete binary.
-func TestResolveAgentExecutablePath_VoltaAliasShadowedByHooks(t *testing.T) {
+// TestResolveAgentExecutable_VoltaAliasShadowedByHooks proves the fix reaches the
+// ~/.multica/hooks branch, which canonicalizes independently.
+func TestResolveAgentExecutable_VoltaAliasShadowedByHooks(t *testing.T) {
 	skipIfNoPOSIXShell(t)
 	resetVoltaResolveCache(t)
 
 	home := t.TempDir()
 	t.Setenv("HOME", home)
 	hooksDir := filepath.Join(home, ".multica", "hooks")
-	if err := os.MkdirAll(hooksDir, 0o755); err != nil {
-		t.Fatalf("create hooks dir: %v", err)
-	}
+	mkdirs(t, hooksDir)
 	writeScript(t, filepath.Join(hooksDir, "claude"), "#!/bin/sh\nexec claude \"$@\"\n")
 
 	f := newVoltaFixture(t, voltaFixtureOpts{commands: []string{"claude"}})
-	t.Setenv("PATH", pathWithout(hooksDir, f.binDir))
+	t.Setenv("PATH", systemPath(hooksDir, f.binDir()))
 
 	resolved, err := resolveAgentExecutable("claude")
 	if err != nil {
@@ -677,54 +820,47 @@ func TestResolveAgentExecutablePath_VoltaAliasShadowedByHooks(t *testing.T) {
 		t.Fatalf("resolved into the hooks dir (%q); the wrapper would recurse", resolved.Path)
 	}
 	if want := f.concrete("claude"); resolved.Path != want {
-		t.Errorf("path = %q, want the concrete binary %q", resolved.Path, want)
+		t.Errorf("path = %q, want %q", resolved.Path, want)
 	}
-	if len(resolved.PathDirs) == 0 {
-		t.Error("hooks branch dropped the Volta Node platform dir")
+	if resolved.Env.IsZero() {
+		t.Error("hooks branch dropped the execution environment")
 	}
 }
 
 // TestCanonicalExecutablePath_NonVoltaSymlinkStillCanonicalized guards the blast
-// radius: ordinary symlinks must keep collapsing to the real file, which is what
-// pins agents against PATH drift and powers the MUL-4486 self-heal.
+// radius: ordinary symlinks must keep collapsing to the real file.
 func TestCanonicalExecutablePath_NonVoltaSymlinkStillCanonicalized(t *testing.T) {
 	skipIfNoPOSIXShell(t)
 
-	realDir := t.TempDir()
-	realBin := filepath.Join(realDir, "claude-0.9.9")
+	realBin := filepath.Join(t.TempDir(), "claude-0.9.9")
 	writeScript(t, realBin, "#!/bin/sh\nexit 0\n")
 	alias := filepath.Join(t.TempDir(), "claude")
 	if err := os.Symlink(realBin, alias); err != nil {
-		t.Fatalf("symlink: %v", err)
+		t.Fatal(err)
 	}
-
 	if got := canonicalExecutablePath(alias); filepath.Base(got) != "claude-0.9.9" {
-		t.Errorf("canonicalExecutablePath(%q) = %q, want the real versioned binary; "+
-			"non-Volta symlinks must still be resolved", alias, got)
+		t.Errorf("canonicalExecutablePath(%q) = %q, want the real versioned binary", alias, got)
 	}
 }
 
 // TestCanonicalExecutablePath_SymlinkedParentDirIsCanonicalized covers the other
-// half of canonicalization: a symlinked *directory* on the way to the binary
-// must also be collapsed, so a moving prefix dir cannot redirect a pinned path.
+// half of canonicalization: a symlinked directory must be collapsed too.
 func TestCanonicalExecutablePath_SymlinkedParentDirIsCanonicalized(t *testing.T) {
 	skipIfNoPOSIXShell(t)
 
 	root := t.TempDir()
 	realDir := filepath.Join(root, "versions", "20.1.0", "bin")
-	if err := os.MkdirAll(realDir, 0o755); err != nil {
-		t.Fatalf("mkdir: %v", err)
-	}
+	mkdirs(t, realDir)
 	writeScript(t, filepath.Join(realDir, "claude"), "#!/bin/sh\nexit 0\n")
 	linkDir := filepath.Join(root, "current")
 	if err := os.Symlink(realDir, linkDir); err != nil {
-		t.Fatalf("symlink dir: %v", err)
+		t.Fatal(err)
 	}
 
 	got := canonicalExecutablePath(filepath.Join(linkDir, "claude"))
 	wantDir, err := filepath.EvalSymlinks(realDir)
 	if err != nil {
-		t.Fatalf("EvalSymlinks: %v", err)
+		t.Fatal(err)
 	}
 	if want := filepath.Join(wantDir, "claude"); got != want {
 		t.Errorf("canonicalExecutablePath through a symlinked dir = %q, want %q", got, want)
@@ -732,8 +868,7 @@ func TestCanonicalExecutablePath_SymlinkedParentDirIsCanonicalized(t *testing.T)
 }
 
 // TestCanonicalExecutablePath_ExplicitShimPathStaysCanonical documents the edge
-// case: a path pointed straight at volta-shim carries no dispatch name, so there
-// is nothing to resolve and it must not get special treatment.
+// case: a path pointed straight at volta-shim has no dispatch name to recover.
 func TestCanonicalExecutablePath_ExplicitShimPathStaysCanonical(t *testing.T) {
 	skipIfNoPOSIXShell(t)
 	resetVoltaResolveCache(t)
@@ -744,8 +879,8 @@ func TestCanonicalExecutablePath_ExplicitShimPathStaysCanonical(t *testing.T) {
 	}
 }
 
-// TestIsVoltaShimPath keeps the PATH-pinning exception minimal: only Volta's
-// actual shim names may opt out of plain symlink resolution.
+// TestIsVoltaShimPath keeps the exception minimal: only Volta's actual shim names
+// may opt out of plain symlink resolution.
 func TestIsVoltaShimPath(t *testing.T) {
 	for _, tc := range []struct {
 		path string
@@ -753,7 +888,6 @@ func TestIsVoltaShimPath(t *testing.T) {
 	}{
 		{filepath.Join("/home/u/.volta/bin", "volta-shim"), true},
 		{filepath.Join("/home/u/.volta/bin", "volta-shim.exe"), true},
-		// Near misses: an extension-insensitive match would swallow these.
 		{filepath.Join("/home/u/.volta/bin", "volta-shim.bak"), false},
 		{filepath.Join("/home/u/.volta/bin", "volta-shim.wrapper"), false},
 		{filepath.Join("/home/u/.volta/bin", "volta-shim.exe.bak"), false},
@@ -769,9 +903,6 @@ func TestIsVoltaShimPath(t *testing.T) {
 	}
 }
 
-// TestVoltaNonProjectDir keeps the deterministic working directory an ancestor
-// nothing can shadow: any directory with a package.json above it would let Volta
-// pick a project tool.
 func TestVoltaNonProjectDir(t *testing.T) {
 	got := voltaNonProjectDir(filepath.Join("/home", "u", ".volta", "bin", "volta"))
 	if runtime.GOOS != "windows" && got != "/" {
@@ -779,5 +910,18 @@ func TestVoltaNonProjectDir(t *testing.T) {
 	}
 	if got == "" {
 		t.Error("voltaNonProjectDir returned an empty directory")
+	}
+}
+
+func TestEnvWithVoltaHome(t *testing.T) {
+	got := envWithVoltaHome([]string{"PATH=/bin", "VOLTA_HOME=/old", "FOO=bar"}, "/new")
+	var seen []string
+	for _, kv := range got {
+		if strings.HasPrefix(kv, "VOLTA_HOME=") {
+			seen = append(seen, kv)
+		}
+	}
+	if len(seen) != 1 || seen[0] != "VOLTA_HOME=/new" {
+		t.Errorf("VOLTA_HOME entries = %v, want exactly [VOLTA_HOME=/new]", seen)
 	}
 }

--- a/server/internal/daemon/agents_probe_volta_test.go
+++ b/server/internal/daemon/agents_probe_volta_test.go
@@ -1,0 +1,233 @@
+package daemon
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/multica-ai/multica/server/pkg/agent"
+)
+
+// Volta installs one trampoline binary and symlinks every managed command to
+// it, dispatching on the name it was invoked as (#6183). These tests pin down
+// that the daemon keeps that name, because resolving the symlink collapses
+// claude/codex/pi onto the same volta-shim path and the shim then exits 126.
+
+// voltaShimBody is a stand-in for Volta's trampoline: it reports a version only
+// when invoked under a managed command's name and exits 126 otherwise, exactly
+// like the real shim. It uses ${0##*/} rather than basename(1) so the fixture
+// keeps working under the restricted PATHs these tests set.
+const voltaShimBody = `#!/bin/sh
+case "${0##*/}" in
+  claude) echo "1.2.3 (Claude Code)" ;;
+  codex) echo "codex-cli 0.140.0" ;;
+  pi) echo "pi 0.9.0" ;;
+  *) echo "volta error: no tool selected" >&2; exit 126 ;;
+esac
+`
+
+// newVoltaBinDir builds a ~/.volta/bin lookalike: one volta-shim plus an alias
+// symlink per command name. It returns the directory.
+func newVoltaBinDir(t *testing.T, names ...string) string {
+	t.Helper()
+	dir := t.TempDir()
+	shim := filepath.Join(dir, voltaShimName)
+	if err := os.WriteFile(shim, []byte(voltaShimBody), 0o755); err != nil {
+		t.Fatalf("write volta-shim: %v", err)
+	}
+	for _, name := range names {
+		if err := os.Symlink(shim, filepath.Join(dir, name)); err != nil {
+			t.Fatalf("symlink %s -> volta-shim: %v", name, err)
+		}
+	}
+	return dir
+}
+
+func skipIfNoPOSIXShell(t *testing.T) {
+	t.Helper()
+	if runtime.GOOS == "windows" {
+		t.Skip("POSIX shim fixture needs a /bin/sh")
+	}
+	if _, err := os.Stat("/bin/sh"); err != nil {
+		t.Skipf("no /bin/sh available: %v", err)
+	}
+}
+
+// TestResolveAgentExecutablePath_KeepsVoltaAliasName is the direct regression
+// test for #6183: all three reported commands must stay distinguishable and
+// must still answer --version after resolution.
+func TestResolveAgentExecutablePath_KeepsVoltaAliasName(t *testing.T) {
+	skipIfNoPOSIXShell(t)
+
+	names := []string{"claude", "codex", "pi"}
+	voltaBin := newVoltaBinDir(t, names...)
+	t.Setenv("PATH", voltaBin)
+
+	wantVersion := map[string]string{
+		"claude": "1.2.3 (Claude Code)",
+		"codex":  "codex-cli 0.140.0",
+		"pi":     "pi 0.9.0",
+	}
+	seen := map[string]string{}
+	for _, name := range names {
+		got, err := resolveAgentExecutablePath(name)
+		if err != nil {
+			t.Fatalf("%s: resolveAgentExecutablePath: %v", name, err)
+		}
+		if base := filepath.Base(got); base != name {
+			t.Errorf("%s resolved to %q (basename %q); the Volta shim picks its tool from "+
+				"argv[0], so collapsing the alias makes the command unrunnable", name, got, base)
+		}
+		if prev, dup := seen[filepath.Base(got)]; dup {
+			t.Errorf("%s and this path collide: %q", prev, got)
+		}
+		seen[filepath.Base(got)] = name
+
+		version, err := agent.DetectVersion(context.Background(), got)
+		if err != nil {
+			t.Fatalf("%s: DetectVersion(%q): %v (this is the exit-126 failure from #6183)", name, got, err)
+		}
+		if version != wantVersion[name] {
+			t.Errorf("%s version = %q, want %q", name, version, wantVersion[name])
+		}
+	}
+}
+
+// TestProbeAgentCLIs_DiscoversVoltaManagedCLIs covers the same fix one level up,
+// at the discovery entry point the daemon actually calls, and asserts the three
+// providers get three distinct paths rather than one shared shim.
+func TestProbeAgentCLIs_DiscoversVoltaManagedCLIs(t *testing.T) {
+	skipIfNoPOSIXShell(t)
+
+	voltaBin := newVoltaBinDir(t, "claude", "codex", "pi")
+	t.Setenv("PATH", voltaBin)
+
+	// Keep discovery hermetic: no login-shell fork, no Codex Desktop bundle.
+	origShell := resolveAgentsViaLoginShell
+	t.Cleanup(func() { resolveAgentsViaLoginShell = origShell })
+	resolveAgentsViaLoginShell = func([]string) map[string]string { return nil }
+	resetShellResolveCacheForTest(t)
+	origBundle := codexDesktopAppBundlePaths
+	t.Cleanup(func() { codexDesktopAppBundlePaths = origBundle })
+	codexDesktopAppBundlePaths = func() []string { return nil }
+
+	agents := probeAgentCLIs()
+
+	paths := map[string]string{}
+	for _, provider := range []string{"claude", "codex", "pi"} {
+		entry, ok := agents[provider]
+		if !ok {
+			t.Fatalf("%s not discovered from a Volta install: %#v", provider, agents)
+		}
+		if base := filepath.Base(entry.Path); base != provider {
+			t.Errorf("%s path = %q, want the alias basename %q", provider, entry.Path, provider)
+		}
+		if prev, dup := paths[entry.Path]; dup {
+			t.Errorf("%s and %s share one path %q; the shim cannot tell them apart", prev, provider, entry.Path)
+		}
+		paths[entry.Path] = provider
+	}
+}
+
+// TestCanonicalExecutablePath_NonVoltaSymlinkStillCanonicalized guards the blast
+// radius of the fix. Ordinary symlinks must keep collapsing to the real file —
+// that is what pins agents against PATH drift and powers the MUL-4486 self-heal.
+func TestCanonicalExecutablePath_NonVoltaSymlinkStillCanonicalized(t *testing.T) {
+	skipIfNoPOSIXShell(t)
+
+	realDir := t.TempDir()
+	realBin := filepath.Join(realDir, "claude-0.9.9")
+	if err := os.WriteFile(realBin, []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
+		t.Fatalf("write real binary: %v", err)
+	}
+	binDir := t.TempDir()
+	alias := filepath.Join(binDir, "claude")
+	if err := os.Symlink(realBin, alias); err != nil {
+		t.Fatalf("symlink: %v", err)
+	}
+
+	got := canonicalExecutablePath(alias)
+	if filepath.Base(got) != "claude-0.9.9" {
+		t.Errorf("canonicalExecutablePath(%q) = %q, want the real versioned binary; "+
+			"non-Volta symlinks must still be resolved", alias, got)
+	}
+}
+
+// TestCanonicalExecutablePath_ExplicitShimPathStaysCanonical documents the edge
+// case: a path pointed straight at volta-shim carries no dispatch name, so there
+// is nothing to preserve and it must not get special treatment.
+func TestCanonicalExecutablePath_ExplicitShimPathStaysCanonical(t *testing.T) {
+	skipIfNoPOSIXShell(t)
+
+	voltaBin := newVoltaBinDir(t)
+	shim := filepath.Join(voltaBin, voltaShimName)
+
+	got := canonicalExecutablePath(shim)
+	if filepath.Base(got) != voltaShimName {
+		t.Errorf("canonicalExecutablePath(%q) = %q, want it to stay volta-shim", shim, got)
+	}
+}
+
+// TestResolveAgentExecutablePath_VoltaAliasShadowedByHooks proves the fix reaches
+// the ~/.multica/hooks branch too: that branch has its own canonicalize call, so
+// a hooks-shadowed Volta command must both skip the wrapper and keep its alias.
+func TestResolveAgentExecutablePath_VoltaAliasShadowedByHooks(t *testing.T) {
+	skipIfNoPOSIXShell(t)
+
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	hooksDir := filepath.Join(home, ".multica", "hooks")
+	if err := os.MkdirAll(hooksDir, 0o755); err != nil {
+		t.Fatalf("create hooks dir: %v", err)
+	}
+	// A previously generated wrapper that re-execs the same command name; the
+	// daemon must never pin or launch this.
+	if err := os.WriteFile(filepath.Join(hooksDir, "claude"),
+		[]byte("#!/bin/sh\nexec claude \"$@\"\n"), 0o755); err != nil {
+		t.Fatalf("write hook wrapper: %v", err)
+	}
+
+	voltaBin := newVoltaBinDir(t, "claude")
+	t.Setenv("PATH", hooksDir+string(os.PathListSeparator)+voltaBin)
+
+	got, err := resolveAgentExecutablePath("claude")
+	if err != nil {
+		t.Fatalf("resolveAgentExecutablePath: %v", err)
+	}
+	if filepath.Dir(got) == hooksDir {
+		t.Fatalf("resolved into the hooks dir (%q); the wrapper would recurse", got)
+	}
+	if filepath.Base(got) != "claude" {
+		t.Errorf("path = %q, want the Volta alias basename claude", got)
+	}
+	// The version answer is what proves we landed on the Volta alias and not
+	// the recursive wrapper.
+	version, err := agent.DetectVersion(context.Background(), got)
+	if err != nil {
+		t.Fatalf("DetectVersion(%q): %v", got, err)
+	}
+	if version != "1.2.3 (Claude Code)" {
+		t.Errorf("version = %q, want the Volta-managed claude version", version)
+	}
+}
+
+func TestIsVoltaShimPath(t *testing.T) {
+	for _, tc := range []struct {
+		path string
+		want bool
+	}{
+		{filepath.Join("/home/u/.volta/bin", "volta-shim"), true},
+		{filepath.Join("/home/u/.volta/bin", "volta-shim.exe"), true},
+		{filepath.Join("C:\\", "volta", "VOLTA-SHIM.EXE"), true},
+		{filepath.Join("/home/u/.volta/bin", "claude"), false},
+		{filepath.Join("/usr/local/bin", "volta"), false},
+		{filepath.Join("/usr/local/bin", "volta-shim-wrapper"), false},
+		{"", false},
+	} {
+		if got := isVoltaShimPath(tc.path); got != tc.want {
+			t.Errorf("isVoltaShimPath(%q) = %v, want %v", tc.path, got, tc.want)
+		}
+	}
+}

--- a/server/internal/daemon/agents_probe_volta_test.go
+++ b/server/internal/daemon/agents_probe_volta_test.go
@@ -42,6 +42,9 @@ func (f voltaFixture) nodeDir(version string) string {
 	return filepath.Join(f.home, "tools", "image", "node", version, "bin")
 }
 func (f voltaFixture) boundNodeDir() string { return f.nodeDir(f.boundNode) }
+func (f voltaFixture) managerDir(tool, version string) string {
+	return filepath.Join(f.home, "tools", "image", tool, version, "bin")
+}
 func (f voltaFixture) sharedLibDir() string {
 	return filepath.Join(f.home, "tools", "shared")
 }
@@ -63,6 +66,13 @@ type voltaFixtureOpts struct {
 	// projectDir, when set, makes `volta which` answer with a project-local
 	// binary when invoked from inside that directory, as real Volta does.
 	projectDir string
+	// managers pins package-manager versions in the bin config, as
+	// `volta install` records them when the platform has custom ones.
+	managers map[string]string
+	// reuseInstall points the shims at an existing install dir instead of a new
+	// one, modelling a Homebrew setup where several VOLTA_HOMEs share one
+	// volta/volta-shim pair.
+	reuseInstall string
 }
 
 func newVoltaFixture(t *testing.T, opts voltaFixtureOpts) voltaFixture {
@@ -74,6 +84,9 @@ func newVoltaFixture(t *testing.T, opts voltaFixtureOpts) voltaFixture {
 		boundNode:  "20.11.0",
 		otherNode:  "24.18.1",
 	}
+	if opts.reuseInstall != "" {
+		f.installDir = opts.reuseInstall
+	}
 	mkdirs(t, f.binDir(), f.installDir, f.sharedLibDir(),
 		f.nodeDir(f.boundNode), f.nodeDir(f.otherNode),
 		filepath.Join(f.home, "tools", "user", "bins"))
@@ -81,6 +94,11 @@ func newVoltaFixture(t *testing.T, opts voltaFixtureOpts) voltaFixture {
 	// Only the bound Node carries a working `node`; the "default" one is a decoy
 	// that fails, so a resolution using it cannot pass unnoticed.
 	writeScript(t, filepath.Join(f.nodeDir(f.boundNode), "node"), "#!/bin/sh\nexit 0\n")
+	for tool, version := range opts.managers {
+		dir := f.managerDir(tool, version)
+		mkdirs(t, dir)
+		writeScript(t, filepath.Join(dir, tool), "#!/bin/sh\nexit 0\n")
+	}
 	writeScript(t, filepath.Join(f.nodeDir(f.otherNode), "node"),
 		"#!/bin/sh\necho 'wrong node: this is the current default, not the bound one' >&2\nexit 1\n")
 
@@ -98,9 +116,8 @@ node --check-marker >/dev/null 2>&1 || { echo "env: node: No such file or direct
 echo %q
 `, version))
 		if !opts.omitBinConfig {
-			writeVoltaConfigFile(t, filepath.Join(f.home, "tools", "user", "bins", cmd+".json"), fmt.Sprintf(
-				`{"name":%q,"package":%q,"version":"1.0.0","platform":{"node":%q,"npm":null,"pnpm":null,"yarn":null},"manager":"Npm"}`,
-				cmd, cmd, f.boundNode))
+			writeVoltaConfigFile(t, filepath.Join(f.home, "tools", "user", "bins", cmd+".json"),
+				voltaBinConfigJSON(cmd, f.boundNode, opts.managers))
 		}
 	}
 
@@ -156,6 +173,19 @@ if [ "$1" = "which" ] && [ -n "$2" ]; then
 fi
 exit 1
 `, project, f.otherNode)
+}
+
+// voltaBinConfigJSON renders a bin config, pinning package managers when given.
+func voltaBinConfigJSON(cmd, node string, managers map[string]string) string {
+	field := func(tool string) string {
+		if v, ok := managers[tool]; ok && v != "" {
+			return fmt.Sprintf("%q", v)
+		}
+		return "null"
+	}
+	return fmt.Sprintf(
+		`{"name":%q,"package":%q,"version":"1.0.0","platform":{"node":%q,"npm":%s,"pnpm":%s,"yarn":%s},"manager":"Npm"}`,
+		cmd, cmd, node, field("npm"), field("pnpm"), field("yarn"))
 }
 
 func mkdirs(t *testing.T, dirs ...string) {
@@ -923,5 +953,261 @@ func TestEnvWithVoltaHome(t *testing.T) {
 	}
 	if len(seen) != 1 || seen[0] != "VOLTA_HOME=/new" {
 		t.Errorf("VOLTA_HOME entries = %v, want exactly [VOLTA_HOME=/new]", seen)
+	}
+}
+
+// TestVoltaPlatformDirs_RestoresFullPlatform covers the whole bound platform, not
+// just Node. Volta puts npm, then pnpm, then yarn, and Node LAST, so a custom npm
+// wins over the one bundled with Node (upstream Image::bins).
+func TestVoltaPlatformDirs_RestoresFullPlatform(t *testing.T) {
+	skipIfNoPOSIXShell(t)
+
+	managers := map[string]string{"npm": "10.2.0", "pnpm": "9.1.0", "yarn": "4.1.0"}
+	f := newVoltaFixture(t, voltaFixtureOpts{commands: []string{"claude"}, managers: managers})
+
+	dirs, ok := voltaPlatformDirs(f.home, "claude")
+	if !ok {
+		t.Fatal("voltaPlatformDirs failed")
+	}
+	want := []string{
+		f.managerDir("npm", "10.2.0"),
+		f.managerDir("pnpm", "9.1.0"),
+		f.managerDir("yarn", "4.1.0"),
+		f.boundNodeDir(),
+	}
+	if len(dirs) != len(want) {
+		t.Fatalf("dirs = %v, want %v", dirs, want)
+	}
+	for i := range want {
+		if dirs[i] != want[i] {
+			t.Errorf("dirs[%d] = %q, want %q (Volta order is npm, pnpm, yarn, node-last)",
+				i, dirs[i], want[i])
+		}
+	}
+}
+
+// TestVoltaPlatformDirs_NodeOnlyWhenNoManagersPinned keeps the common case simple.
+func TestVoltaPlatformDirs_NodeOnlyWhenNoManagersPinned(t *testing.T) {
+	skipIfNoPOSIXShell(t)
+	f := newVoltaFixture(t, voltaFixtureOpts{commands: []string{"claude"}})
+
+	dirs, ok := voltaPlatformDirs(f.home, "claude")
+	if !ok {
+		t.Fatal("voltaPlatformDirs failed")
+	}
+	if len(dirs) != 1 || dirs[0] != f.boundNodeDir() {
+		t.Errorf("dirs = %v, want just the bound Node %q", dirs, f.boundNodeDir())
+	}
+}
+
+// TestVoltaResolve_StateIsolatedPerVoltaHome covers the Homebrew shape: several
+// VOLTA_HOMEs share one volta/volta-shim pair, so state keyed on the binary alone
+// let one home serve another's tool paths and environment.
+func TestVoltaResolve_StateIsolatedPerVoltaHome(t *testing.T) {
+	skipIfNoPOSIXShell(t)
+	resetVoltaResolveCache(t)
+
+	homeA := newVoltaFixture(t, voltaFixtureOpts{commands: []string{"claude"}})
+	// Same install dir, different home: exactly what `brew install volta` plus a
+	// per-user VOLTA_HOME produces.
+	homeB := newVoltaFixture(t, voltaFixtureOpts{
+		commands:     []string{"claude"},
+		reuseInstall: homeA.installDir,
+	})
+	if homeA.installDir != homeB.installDir {
+		t.Fatalf("fixtures do not share an install dir: %q vs %q", homeA.installDir, homeB.installDir)
+	}
+	if homeA.home == homeB.home {
+		t.Fatal("fixtures share a home; the test cannot distinguish them")
+	}
+
+	resolvedA, ok := voltaResolve(homeA.alias("claude"), homeA.shim(), "claude")
+	if !ok {
+		t.Fatal("home A resolution failed")
+	}
+	resolvedB, ok := voltaResolve(homeB.alias("claude"), homeB.shim(), "claude")
+	if !ok {
+		t.Fatal("home B resolution failed")
+	}
+
+	if resolvedB.Path == resolvedA.Path {
+		t.Errorf("home B reused home A's tool path %q; Volta state must be keyed by "+
+			"VOLTA_HOME, not just the shared volta binary", resolvedA.Path)
+	}
+	if want := homeB.concrete("claude"); resolvedB.Path != want {
+		t.Errorf("home B path = %q, want %q", resolvedB.Path, want)
+	}
+	if dirs := resolvedB.Env.PrefixPaths["PATH"]; len(dirs) == 0 || dirs[0] != homeB.boundNodeDir() {
+		t.Errorf("home B PATH dirs = %v, want its own bound Node %q", dirs, homeB.boundNodeDir())
+	}
+}
+
+// TestVoltaResolve_SlowSuccessesDoNotTripBreaker is the recovery case for the
+// budget: it must count only failures. Charging successful queries to it let a
+// couple of slow-but-working resolutions exhaust the budget, and because success
+// clears failedAt no cooldown could ever reset it — every later uncached command
+// was refused for the life of the process.
+func TestVoltaResolve_SlowSuccessesDoNotTripBreaker(t *testing.T) {
+	skipIfNoPOSIXShell(t)
+	resetVoltaResolveCache(t)
+
+	origRun, origBudget := runVolta, voltaResolveBudget
+	t.Cleanup(func() { runVolta, voltaResolveBudget = origRun, origBudget })
+	voltaResolveBudget = 60 * time.Millisecond
+
+	commands := []string{"claude", "codex", "pi"}
+	f := newVoltaFixture(t, voltaFixtureOpts{commands: commands})
+	t.Setenv("PATH", systemPath(f.binDir()))
+
+	// Every query succeeds but is slow enough that two exceed the budget.
+	runVolta = func(voltaBin, voltaHome string, args ...string) (string, bool) {
+		time.Sleep(40 * time.Millisecond)
+		return origRun(voltaBin, voltaHome, args...)
+	}
+
+	for i, cmd := range commands {
+		if _, ok := voltaResolve(f.alias(cmd), f.shim(), cmd); !ok {
+			t.Fatalf("%s (request %d) was refused; slow but SUCCESSFUL resolutions must not "+
+				"consume the failure budget, or the breaker latches permanently", cmd, i+1)
+		}
+	}
+}
+
+// TestVoltaResolve_InstallationLevelBudget checks the gate is per installation:
+// concurrent resolutions of *different* commands against a broken install must not
+// each pay a full timeout.
+func TestVoltaResolve_InstallationLevelBudget(t *testing.T) {
+	skipIfNoPOSIXShell(t)
+	resetVoltaResolveCache(t)
+
+	origRun, origTimeout := runVolta, voltaResolveTimeout
+	t.Cleanup(func() { runVolta, voltaResolveTimeout = origRun, origTimeout })
+	voltaResolveTimeout = 80 * time.Millisecond
+
+	var mu sync.Mutex
+	calls := 0
+	runVolta = func(string, string, ...string) (string, bool) {
+		mu.Lock()
+		calls++
+		mu.Unlock()
+		time.Sleep(voltaResolveTimeout)
+		return "", false
+	}
+
+	commands := []string{"claude", "codex", "pi"}
+	f := newVoltaFixture(t, voltaFixtureOpts{commands: commands})
+	t.Setenv("PATH", systemPath(f.binDir()))
+
+	var wg sync.WaitGroup
+	for _, cmd := range commands {
+		wg.Add(1)
+		go func(cmd string) {
+			defer wg.Done()
+			voltaResolve(f.alias(cmd), f.shim(), cmd)
+		}(cmd)
+	}
+	wg.Wait()
+
+	mu.Lock()
+	got := calls
+	mu.Unlock()
+	if got > 1 {
+		t.Errorf("`volta` was invoked %d times for %d concurrent commands against a broken "+
+			"install, want 1; the budget must gate the installation, not each command",
+			got, len(commands))
+	}
+}
+
+// TestAgentEntryLaunchable_RequiresEnvironmentDirs covers the self-heal gap: a
+// Volta upgrade that prunes the old Node image leaves the CLI file in place, so
+// checking only the executable kept handing tasks a broken toolchain forever.
+func TestAgentEntryLaunchable_RequiresEnvironmentDirs(t *testing.T) {
+	skipIfNoPOSIXShell(t)
+	resetVoltaResolveCache(t)
+
+	f := newVoltaFixture(t, voltaFixtureOpts{commands: []string{"claude"}})
+	t.Setenv("PATH", systemPath(f.binDir()))
+
+	resolved, ok := voltaResolve(f.alias("claude"), f.shim(), "claude")
+	if !ok {
+		t.Fatal("resolution failed")
+	}
+	if !agentEntryLaunchable(resolved.Path, resolved.Env) {
+		t.Fatal("fresh resolution reported not launchable")
+	}
+
+	// The CLI file survives; only its toolchain is pruned.
+	if err := os.RemoveAll(filepath.Dir(f.boundNodeDir())); err != nil {
+		t.Fatalf("remove node image: %v", err)
+	}
+	if !agentExecutablePresent(resolved.Path) {
+		t.Fatal("fixture removed the CLI too; the test would not prove anything")
+	}
+	if agentEntryLaunchable(resolved.Path, resolved.Env) {
+		t.Error("entry still considered launchable after its bound Node image was pruned; " +
+			"tasks would keep launching with a PATH that points nowhere")
+	}
+}
+
+// TestResolveAgentEntry_ReresolvesWhenEnvironmentGoesStale is the daemon-level
+// half of the same fix: resolveAgentEntry must not hand back a cached entry
+// whose environment no longer exists.
+func TestResolveAgentEntry_ReresolvesWhenEnvironmentGoesStale(t *testing.T) {
+	skipIfNoPOSIXShell(t)
+	resetVoltaResolveCache(t)
+
+	f := newVoltaFixture(t, voltaFixtureOpts{commands: []string{"claude"}})
+	t.Setenv("PATH", systemPath(f.binDir()))
+	// A version that clears claude's real minimum, so the self-heal can complete
+	// and we observe the re-resolved environment rather than an aborted heal.
+	origDetect := detectAgentVersion
+	t.Cleanup(func() { detectAgentVersion = origDetect })
+	detectAgentVersion = func(_ context.Context, _ string, _ agent.ExecEnv) (string, error) {
+		return "2.1.0", nil
+	}
+
+	resolved, ok := voltaResolve(f.alias("claude"), f.shim(), "claude")
+	if !ok {
+		t.Fatal("resolution failed")
+	}
+	staleEnv := agent.ExecEnv{PrefixPaths: map[string][]string{
+		"PATH": {filepath.Join(t.TempDir(), "pruned-node", "bin")},
+	}}
+
+	d := freshDaemon("")
+	entry := AgentEntry{Path: resolved.Path, Command: "claude", Env: staleEnv}
+	got, _ := d.resolveAgentEntry(context.Background(), "claude", entry)
+
+	if len(got.Env.PrefixPaths["PATH"]) > 0 &&
+		got.Env.PrefixPaths["PATH"][0] == staleEnv.PrefixPaths["PATH"][0] {
+		t.Error("resolveAgentEntry returned the entry with its stale environment; it must " +
+			"re-resolve when the environment's directories are gone")
+	}
+}
+
+// TestLayerTaskEnvironment_ResolvedEnvSurvivesCustomEnv is the ordering contract
+// for item 6. custom_env may set NODE_PATH (unlike PATH, it is not blocked), so
+// the resolved execution environment has to be applied afterwards or the Volta
+// shared-modules prefix is silently wiped and a package binary loses its modules.
+func TestLayerTaskEnvironment_ResolvedEnvSurvivesCustomEnv(t *testing.T) {
+	sep := string(os.PathListSeparator)
+	execEnv := agent.ExecEnv{PrefixPaths: map[string][]string{
+		"PATH":      {"/volta/tools/image/node/20.11.0/bin"},
+		"NODE_PATH": {"/volta/tools/shared"},
+	}}
+	agentEnv := map[string]string{"PATH": "/usr/bin"}
+	customEnv := map[string]string{"NODE_PATH": "/user/modules"}
+
+	layerTaskEnvironment(agentEnv, customEnv, "", execEnv, nil)
+
+	wantNodePath := "/volta/tools/shared" + sep + "/user/modules"
+	if agentEnv["NODE_PATH"] != wantNodePath {
+		t.Errorf("NODE_PATH = %q, want %q; the resolved environment must be applied after "+
+			"custom_env so its prefix survives while the user's value is kept",
+			agentEnv["NODE_PATH"], wantNodePath)
+	}
+	wantPath := "/volta/tools/image/node/20.11.0/bin" + sep + "/usr/bin"
+	if agentEnv["PATH"] != wantPath {
+		t.Errorf("PATH = %q, want %q", agentEnv["PATH"], wantPath)
 	}
 }

--- a/server/internal/daemon/agents_probe_volta_test.go
+++ b/server/internal/daemon/agents_probe_volta_test.go
@@ -4,9 +4,12 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"runtime"
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/multica-ai/multica/server/pkg/agent"
 )
@@ -14,14 +17,14 @@ import (
 // Volta installs one trampoline binary and symlinks every managed command to
 // it, dispatching on the name it was invoked as (#6183). Resolving that symlink
 // collapses claude/codex/pi onto the same volta-shim path and the shim then
-// exits 126, so the daemon asks Volta for the concrete binary instead. These
-// tests cover that resolution, the registration it has to survive, and the
-// blast radius of the exception.
+// exits 126, so the daemon asks Volta for the concrete binary instead — plus the
+// Node platform directory that binary needs to run.
 
 // voltaFixture is a ~/.volta lookalike.
 type voltaFixture struct {
-	binDir   string // the shim dir: volta, volta-shim, and one symlink per command
-	imageDir string // where the concrete per-tool binaries live
+	binDir   string // shim dir: volta, volta-shim, one symlink per command
+	imageDir string // concrete per-tool binaries
+	nodeDir  string // Volta's Node platform bin dir
 }
 
 func (f voltaFixture) alias(command string) string    { return filepath.Join(f.binDir, command) }
@@ -30,38 +33,57 @@ func (f voltaFixture) concrete(command string) string { return filepath.Join(f.i
 
 // voltaFixtureVersions are the versions the concrete fixture binaries report.
 // They must clear agent.MinVersions (claude >= 2.0.0, codex >= 0.100.0) or the
-// registration-level test below would prove nothing: the provider would be
-// dropped by the min-version gate rather than by the bug under test.
+// registration-level tests would prove nothing: the provider would be dropped by
+// the min-version gate rather than by the bug under test.
 var voltaFixtureVersions = map[string]string{
 	"claude": "2.1.0 (Claude Code)",
 	"codex":  "codex-cli 0.140.0",
 	"pi":     "pi 0.9.0",
 }
 
-// newVoltaFixture builds the shim dir, the concrete binaries, a faithful
-// argv[0]-dispatching volta-shim, and a `volta` that answers `which`.
+type voltaFixtureOpts struct {
+	commands []string
+	// omitVolta models an install whose `volta` binary cannot be run.
+	omitVolta bool
+	// hang makes every `volta` invocation block, modelling a wedged install.
+	hang bool
+	// projectDir, when set, makes `volta which` answer with a project-local
+	// binary whenever it is invoked from inside that directory — which is what
+	// real Volta does (upstream src/command/which.rs prefers the project bin).
+	projectDir string
+}
+
+// newVoltaFixture builds the shim dir, concrete binaries, a Node platform dir, a
+// faithful argv[0]-dispatching volta-shim, and a `volta` answering `which`.
 //
-// withVolta=false omits the `volta` binary, modelling an install where the
-// daemon cannot ask Volta for the concrete path.
-func newVoltaFixture(t *testing.T, withVolta bool, commands ...string) voltaFixture {
+// Every concrete tool here needs `node` on PATH, mirroring the real install
+// where package bins are `#!/usr/bin/env node` scripts (verified against
+// @openai/codex 0.146.0). `node` exists ONLY in the Node platform dir, so a
+// resolution that forgets to carry that dir produces an unrunnable path.
+func newVoltaFixture(t *testing.T, opts voltaFixtureOpts) voltaFixture {
 	t.Helper()
 	root := t.TempDir()
 	f := voltaFixture{
 		binDir:   filepath.Join(root, "bin"),
 		imageDir: filepath.Join(root, "image"),
+		nodeDir:  filepath.Join(root, "node-image", "bin"),
 	}
-	for _, dir := range []string{f.binDir, f.imageDir} {
+	for _, dir := range []string{f.binDir, f.imageDir, f.nodeDir} {
 		if err := os.MkdirAll(dir, 0o755); err != nil {
 			t.Fatalf("mkdir %s: %v", dir, err)
 		}
 	}
+	writeScript(t, filepath.Join(f.nodeDir, "node"), "#!/bin/sh\nexit 0\n")
 
-	for _, command := range commands {
+	for _, command := range opts.commands {
 		version, ok := voltaFixtureVersions[command]
 		if !ok {
 			t.Fatalf("no fixture version defined for %q", command)
 		}
-		writeScript(t, f.concrete(command), fmt.Sprintf("#!/bin/sh\necho %q\n", version))
+		writeScript(t, f.concrete(command), fmt.Sprintf(`#!/bin/sh
+command -v node >/dev/null 2>&1 || { echo "env: node: No such file or directory" >&2; exit 127; }
+echo %q
+`, version))
 	}
 
 	// Faithful shim: refuses to run under its own name exactly like upstream
@@ -77,24 +99,51 @@ fi
 exec %q/"$n" "$@"
 `, voltaShimName, f.imageDir))
 
-	for _, command := range commands {
+	for _, command := range opts.commands {
 		if err := os.Symlink(f.shim(), f.alias(command)); err != nil {
 			t.Fatalf("symlink %s -> volta-shim: %v", command, err)
 		}
 	}
 
-	if withVolta {
-		// `volta which <tool>` prints the concrete path on stdout and exits
-		// non-zero without output when it cannot resolve, as upstream does.
-		writeScript(t, filepath.Join(f.binDir, "volta"), fmt.Sprintf(`#!/bin/sh
+	if !opts.omitVolta {
+		writeScript(t, filepath.Join(f.binDir, "volta"), voltaFixtureScript(f, opts))
+	}
+	return f
+}
+
+// voltaFixtureScript renders the fake `volta`. It answers `which <tool>` and
+// `which node`, prints nothing and exits non-zero otherwise, like upstream.
+func voltaFixtureScript(f voltaFixture, opts voltaFixtureOpts) string {
+	var body string
+	if opts.hang {
+		// Blocks forever so a test can measure how the caller bounds the cost.
+		return "#!/bin/sh\nwhile :; do sleep 1; done\n"
+	}
+	if opts.projectDir != "" {
+		// Project-local preference: only triggered when invoked from inside the
+		// project, which is exactly the cwd sensitivity the caller must avoid.
+		body = fmt.Sprintf(`
+case "$PWD" in
+  %q*)
+    if [ "$1" = "which" ] && [ -n "$2" ]; then
+      p=%q/"$2"
+      if [ -x "$p" ]; then echo "$p"; exit 0; fi
+    fi
+    ;;
+esac
+`, opts.projectDir, filepath.Join(opts.projectDir, "node_modules", ".bin"))
+	}
+	return fmt.Sprintf(`#!/bin/sh
+%s
+if [ "$1" = "which" ] && [ "$2" = "node" ]; then
+  echo %q; exit 0
+fi
 if [ "$1" = "which" ] && [ -n "$2" ]; then
   p=%q/"$2"
   if [ -x "$p" ]; then echo "$p"; exit 0; fi
 fi
 exit 1
-`, f.imageDir))
-	}
-	return f
+`, body, filepath.Join(f.nodeDir, "node"), f.imageDir)
 }
 
 func writeScript(t *testing.T, path, body string) {
@@ -129,49 +178,79 @@ func isolateAgentDiscovery(t *testing.T) {
 	codexDesktopAppBundlePaths = func() []string { return nil }
 }
 
-// resetVoltaResolveCache clears the process-wide `volta which` cache so tests
-// cannot observe each other's answers.
+// resetVoltaResolveCache clears the process-wide Volta resolution state (cached
+// answers, failure cooldown and spend budget) so tests cannot observe each
+// other's results.
 func resetVoltaResolveCache(t *testing.T) {
 	t.Helper()
 	clear := func() {
-		voltaResolveMu.Lock()
-		defer voltaResolveMu.Unlock()
-		voltaResolveCache = map[string]string{}
+		voltaMu.Lock()
+		defer voltaMu.Unlock()
+		voltaStates = map[string]*voltaInstallState{}
 	}
 	clear()
 	t.Cleanup(clear)
 }
 
+// runVoltaFromDir runs the fixture `volta` with an explicit working directory,
+// so a test can confirm the fixture is genuinely cwd-sensitive before asserting
+// that production code is not.
+func runVoltaFromDir(t *testing.T, voltaBin, dir string, args ...string) (string, bool) {
+	t.Helper()
+	cmd := exec.Command(voltaBin, args...)
+	cmd.Dir = dir
+	out, err := cmd.Output()
+	if err != nil {
+		return "", false
+	}
+	return strings.TrimSpace(string(out)), true
+}
+
+// pathWithout returns a PATH containing only dirs (plus /bin and /usr/bin for
+// the shell itself), deliberately excluding Volta's Node platform dir.
+func pathWithout(dirs ...string) string {
+	all := append([]string{}, dirs...)
+	all = append(all, "/usr/bin", "/bin")
+	out := ""
+	for _, d := range all {
+		if out != "" {
+			out += string(os.PathListSeparator)
+		}
+		out += d
+	}
+	return out
+}
+
 // TestResolveAgentExecutablePath_PinsVoltaConcreteBinary is the primary
-// regression test for #6183. The pinned path must be the concrete binary, so
-// that the path we version-check is the path we later execute.
+// regression test for #6183: the pinned path must be the concrete binary, so the
+// path we version-check is the path we later execute.
 func TestResolveAgentExecutablePath_PinsVoltaConcreteBinary(t *testing.T) {
 	skipIfNoPOSIXShell(t)
 	resetVoltaResolveCache(t)
 
 	commands := []string{"claude", "codex", "pi"}
-	f := newVoltaFixture(t, true, commands...)
-	t.Setenv("PATH", f.binDir)
+	f := newVoltaFixture(t, voltaFixtureOpts{commands: commands})
+	t.Setenv("PATH", pathWithout(f.binDir))
 
 	for _, command := range commands {
-		got, err := resolveAgentExecutablePath(command)
+		resolved, err := resolveAgentExecutable(command)
 		if err != nil {
-			t.Fatalf("%s: resolveAgentExecutablePath: %v", command, err)
+			t.Fatalf("%s: resolveAgentExecutable: %v", command, err)
 		}
-		if got == f.shim() {
-			t.Fatalf("%s pinned the shared shim %q; the version probe exits 126 there (#6183)", command, got)
+		if resolved.Path == f.shim() {
+			t.Fatalf("%s pinned the shared shim; the version probe exits 126 there (#6183)", command)
 		}
-		if got == f.alias(command) {
-			t.Errorf("%s pinned the Volta alias %q; that path dispatches per working directory, "+
-				"so the gated version would not be the executed version", command, got)
+		if resolved.Path == f.alias(command) {
+			t.Errorf("%s pinned the Volta alias %q; that path dispatches per working "+
+				"directory, so the gated version would not be the executed version", command, resolved.Path)
 		}
-		if want := f.concrete(command); got != want {
-			t.Errorf("%s path = %q, want the concrete binary %q", command, got, want)
+		if want := f.concrete(command); resolved.Path != want {
+			t.Errorf("%s path = %q, want the concrete binary %q", command, resolved.Path, want)
 		}
 
-		version, err := agent.DetectVersion(context.Background(), got)
+		version, err := agent.DetectVersionWithPathDirs(context.Background(), resolved.Path, resolved.PathDirs)
 		if err != nil {
-			t.Fatalf("%s: DetectVersion(%q): %v", command, got, err)
+			t.Fatalf("%s: DetectVersionWithPathDirs(%q): %v", command, resolved.Path, err)
 		}
 		if version != voltaFixtureVersions[command] {
 			t.Errorf("%s version = %q, want %q", command, version, voltaFixtureVersions[command])
@@ -179,20 +258,229 @@ func TestResolveAgentExecutablePath_PinsVoltaConcreteBinary(t *testing.T) {
 	}
 }
 
+// TestResolveAgentExecutable_CarriesVoltaNodePlatform covers review item 3: the
+// concrete binary is a node script, so the resolution must also hand back the
+// Node platform dir. Without it the pinned path is unrunnable under a PATH that
+// has no node — the GUI-launched case — and the version probe and the task
+// launch could disagree about which node runs the CLI.
+func TestResolveAgentExecutable_CarriesVoltaNodePlatform(t *testing.T) {
+	skipIfNoPOSIXShell(t)
+	resetVoltaResolveCache(t)
+
+	f := newVoltaFixture(t, voltaFixtureOpts{commands: []string{"codex"}})
+	// Note: no node anywhere on PATH, only inside Volta's platform dir.
+	t.Setenv("PATH", pathWithout(f.binDir))
+
+	resolved, err := resolveAgentExecutable("codex")
+	if err != nil {
+		t.Fatalf("resolveAgentExecutable: %v", err)
+	}
+	if len(resolved.PathDirs) == 0 {
+		t.Fatal("resolution returned no PATH dirs; a node-script package binary cannot run without Volta's Node platform")
+	}
+	if resolved.PathDirs[0] != f.nodeDir {
+		t.Errorf("PathDirs[0] = %q, want Volta's node dir %q", resolved.PathDirs[0], f.nodeDir)
+	}
+
+	// With the environment: runnable.
+	if _, err := agent.DetectVersionWithPathDirs(context.Background(), resolved.Path, resolved.PathDirs); err != nil {
+		t.Errorf("version probe with the resolved environment failed: %v", err)
+	}
+	// Without it: not runnable. This is what makes carrying the dirs necessary
+	// rather than cosmetic.
+	if _, err := agent.DetectVersion(context.Background(), resolved.Path); err == nil {
+		t.Error("version probe without the resolved environment unexpectedly succeeded; " +
+			"the fixture no longer models the `#!/usr/bin/env node` dependency")
+	}
+}
+
+// TestProbeAgentCLIs_ShellFallbackResolvesVoltaAlias covers review item 1. A
+// GUI-launched daemon does not see Volta on its own PATH and falls back to the
+// login shell, whose script preserves the file name — so the alias arrives here
+// still pointing at the shared shim. That leg must apply the same resolution as
+// the LookPath leg, otherwise Desktop users keep the ungated alias.
+func TestProbeAgentCLIs_ShellFallbackResolvesVoltaAlias(t *testing.T) {
+	skipIfNoPOSIXShell(t)
+	resetVoltaResolveCache(t)
+
+	f := newVoltaFixture(t, voltaFixtureOpts{commands: []string{"claude"}})
+	// Empty PATH: the LookPath leg must miss so the shell fallback is the only
+	// way claude can resolve, exactly as on a GUI-launched daemon.
+	t.Setenv("PATH", "")
+
+	origShell := resolveAgentsViaLoginShell
+	t.Cleanup(func() { resolveAgentsViaLoginShell = origShell })
+	resolveAgentsViaLoginShell = func([]string) map[string]string {
+		return map[string]string{"claude": f.alias("claude")}
+	}
+	resetShellResolveCacheForTest(t)
+	origBundle := codexDesktopAppBundlePaths
+	t.Cleanup(func() { codexDesktopAppBundlePaths = origBundle })
+	codexDesktopAppBundlePaths = func() []string { return nil }
+
+	entry, ok := probeAgentCLIs()["claude"]
+	if !ok {
+		t.Fatal("claude not discovered via the login-shell fallback")
+	}
+	if entry.Path == f.alias("claude") {
+		t.Fatalf("shell fallback pinned the Volta alias %q; the GUI path bypassed resolution", entry.Path)
+	}
+	if want := f.concrete("claude"); entry.Path != want {
+		t.Errorf("path = %q, want the concrete binary %q", entry.Path, want)
+	}
+	if len(entry.PathDirs) == 0 || entry.PathDirs[0] != f.nodeDir {
+		t.Errorf("PathDirs = %v, want Volta's node dir %q", entry.PathDirs, f.nodeDir)
+	}
+}
+
+// TestReresolveAgentCommand_ShellFallbackResolvesVoltaAlias is item 1 for the
+// self-heal path, which has its own shell branch.
+func TestReresolveAgentCommand_ShellFallbackResolvesVoltaAlias(t *testing.T) {
+	skipIfNoPOSIXShell(t)
+	resetVoltaResolveCache(t)
+
+	f := newVoltaFixture(t, voltaFixtureOpts{commands: []string{"claude"}})
+	t.Setenv("PATH", "")
+
+	origShell := resolveAgentsViaLoginShell
+	t.Cleanup(func() { resolveAgentsViaLoginShell = origShell })
+	resolveAgentsViaLoginShell = func([]string) map[string]string {
+		return map[string]string{"claude": f.alias("claude")}
+	}
+
+	resolved, ok := reresolveAgentCommand("claude")
+	if !ok {
+		t.Fatal("reresolveAgentCommand did not resolve claude")
+	}
+	if resolved.Path == f.alias("claude") {
+		t.Fatalf("self-heal pinned the Volta alias %q", resolved.Path)
+	}
+	if want := f.concrete("claude"); resolved.Path != want {
+		t.Errorf("path = %q, want %q", resolved.Path, want)
+	}
+}
+
+// TestVoltaResolve_IgnoresProjectDirectory covers review item 2. Volta resolves a
+// project-local binary before the user default, so asking it from whatever
+// directory the daemon happens to be started in would pin one project's
+// dependency as the machine-wide runtime.
+func TestVoltaResolve_IgnoresProjectDirectory(t *testing.T) {
+	skipIfNoPOSIXShell(t)
+	resetVoltaResolveCache(t)
+
+	projectDir := t.TempDir()
+	projectBin := filepath.Join(projectDir, "node_modules", ".bin")
+	if err := os.MkdirAll(projectBin, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	writeScript(t, filepath.Join(projectBin, "claude"), "#!/bin/sh\necho \"0.0.1 (project local)\"\n")
+
+	f := newVoltaFixture(t, voltaFixtureOpts{
+		commands:   []string{"claude"},
+		projectDir: projectDir,
+	})
+	t.Setenv("PATH", pathWithout(f.binDir))
+
+	// Sanity: the fixture really is cwd-sensitive, so this test can fail.
+	if out, ok := runVoltaFromDir(t, filepath.Join(f.binDir, "volta"), projectDir, "which", "claude"); !ok {
+		t.Fatalf("fixture volta failed inside the project dir")
+	} else if out != filepath.Join(projectBin, "claude") {
+		t.Fatalf("fixture is not cwd-sensitive: got %q", out)
+	}
+
+	// Run the daemon's resolution with the process cwd inside the project.
+	t.Chdir(projectDir)
+
+	resolved, ok := voltaResolve(f.shim(), "claude")
+	if !ok {
+		t.Fatal("voltaResolve failed")
+	}
+	if got := resolved.Path; got == filepath.Join(projectBin, "claude") {
+		t.Errorf("resolved the project-local binary %q; a daemon started inside a JS "+
+			"project would pin that project's dependency as the machine runtime", got)
+	} else if want := f.concrete("claude"); got != want {
+		t.Errorf("path = %q, want the default toolchain binary %q", got, want)
+	}
+}
+
+// TestVoltaResolve_BoundsTotalCostWhenVoltaHangs covers review item 4. A wedged
+// Volta install used to cost one full timeout PER command, so a machine with
+// several Volta-managed CLIs stalled startup for the sum of them.
+func TestVoltaResolve_BoundsTotalCostWhenVoltaHangs(t *testing.T) {
+	skipIfNoPOSIXShell(t)
+	resetVoltaResolveCache(t)
+
+	origTimeout := voltaResolveTimeout
+	t.Cleanup(func() { voltaResolveTimeout = origTimeout })
+	voltaResolveTimeout = 300 * time.Millisecond
+
+	commands := []string{"claude", "codex", "pi"}
+	f := newVoltaFixture(t, voltaFixtureOpts{commands: commands, hang: true})
+	t.Setenv("PATH", pathWithout(f.binDir))
+
+	start := time.Now()
+	for _, command := range commands {
+		if _, ok := voltaResolve(f.shim(), command); ok {
+			t.Fatalf("%s unexpectedly resolved against a hung volta", command)
+		}
+	}
+	elapsed := time.Since(start)
+
+	// Additive behavior would be len(commands) x timeout. Allow one timeout plus
+	// slack: after the first failure the cooldown must short-circuit the rest.
+	if budget := 2 * voltaResolveTimeout; elapsed > budget {
+		t.Errorf("resolving %d hung aliases took %v (> %v); the per-command timeout is "+
+			"still additive and can stall daemon startup", len(commands), elapsed, budget)
+	}
+}
+
+// TestDetectBuiltinRuntimes_RegistersVoltaManagedCLIs is the end-result test:
+// availability alone was never the user-visible outcome. This runs the real
+// version probe and the real minimum-version gate over a Volta install and
+// asserts all three providers reach the registration payload.
+func TestDetectBuiltinRuntimes_RegistersVoltaManagedCLIs(t *testing.T) {
+	skipIfNoPOSIXShell(t)
+	resetVoltaResolveCache(t)
+
+	commands := []string{"claude", "codex", "pi"}
+	f := newVoltaFixture(t, voltaFixtureOpts{commands: commands})
+	t.Setenv("PATH", pathWithout(f.binDir))
+	isolateAgentDiscovery(t)
+
+	// Deliberately no detectAgentVersion / checkAgentMinVersion stubs: the point
+	// is that the real gate accepts what discovery pinned.
+	d := freshDaemon("")
+	d.cfg.Agents = probeAgentCLIs()
+
+	registered := map[string]string{}
+	for _, rt := range d.detectBuiltinRuntimes(context.Background()) {
+		registered[rt["type"]] = rt["version"]
+	}
+	for _, command := range commands {
+		version, ok := registered[command]
+		if !ok {
+			t.Errorf("%s missing from the registration payload; skipped reasons: %#v",
+				command, d.skippedAgentsSnapshot())
+			continue
+		}
+		if version != voltaFixtureVersions[command] {
+			t.Errorf("%s registered version = %q, want %q", command, version, voltaFixtureVersions[command])
+		}
+	}
+}
+
 // TestProbeAgentCLIs_DiscoversVoltaManagedCLIs covers the discovery entry point
-// the daemon actually calls and asserts the three providers get three distinct
-// concrete paths rather than one shared shim.
+// and asserts the three providers get three distinct concrete paths.
 func TestProbeAgentCLIs_DiscoversVoltaManagedCLIs(t *testing.T) {
 	skipIfNoPOSIXShell(t)
 	resetVoltaResolveCache(t)
 
 	commands := []string{"claude", "codex", "pi"}
-	f := newVoltaFixture(t, true, commands...)
-	t.Setenv("PATH", f.binDir)
+	f := newVoltaFixture(t, voltaFixtureOpts{commands: commands})
+	t.Setenv("PATH", pathWithout(f.binDir))
 	isolateAgentDiscovery(t)
 
 	agents := probeAgentCLIs()
-
 	seen := map[string]string{}
 	for _, command := range commands {
 		entry, ok := agents[command]
@@ -209,54 +497,17 @@ func TestProbeAgentCLIs_DiscoversVoltaManagedCLIs(t *testing.T) {
 	}
 }
 
-// TestDetectBuiltinRuntimes_RegistersVoltaManagedCLIs is the end-result test:
-// availability alone was never the user-visible outcome. This runs the real
-// version probe and the real minimum-version gate over a Volta install and
-// asserts all three providers reach the registration payload.
-func TestDetectBuiltinRuntimes_RegistersVoltaManagedCLIs(t *testing.T) {
-	skipIfNoPOSIXShell(t)
-	resetVoltaResolveCache(t)
-
-	commands := []string{"claude", "codex", "pi"}
-	f := newVoltaFixture(t, true, commands...)
-	t.Setenv("PATH", f.binDir)
-	isolateAgentDiscovery(t)
-
-	// Deliberately no detectAgentVersion / checkAgentMinVersion stubs: the point
-	// is that the real gate accepts what discovery pinned.
-	d := freshDaemon("")
-	d.cfg.Agents = probeAgentCLIs()
-
-	runtimes := d.detectBuiltinRuntimes(context.Background())
-
-	registered := map[string]string{}
-	for _, rt := range runtimes {
-		registered[rt["type"]] = rt["version"]
-	}
-	for _, command := range commands {
-		version, ok := registered[command]
-		if !ok {
-			t.Errorf("%s missing from the registration payload; skipped reasons: %#v",
-				command, d.skippedAgentsSnapshot())
-			continue
-		}
-		if version != voltaFixtureVersions[command] {
-			t.Errorf("%s registered version = %q, want %q", command, version, voltaFixtureVersions[command])
-		}
-	}
-}
-
 // TestResolveAgentExecutablePath_FailsClosedWithoutVoltaResolution pins the
-// deliberate failure mode: with no way to ask Volta for the concrete binary we
-// must NOT fall back to the alias, because that path is only version-checkable
-// under conditions we cannot reproduce at launch. Staying unregistered is the
-// correct outcome; MULTICA_*_PATH remains the escape hatch.
+// deliberate failure mode: with no way to ask Volta we must NOT fall back to the
+// alias, because that path is only version-checkable under conditions we cannot
+// reproduce at launch. Staying unregistered is correct; MULTICA_*_PATH remains
+// the escape hatch.
 func TestResolveAgentExecutablePath_FailsClosedWithoutVoltaResolution(t *testing.T) {
 	skipIfNoPOSIXShell(t)
 	resetVoltaResolveCache(t)
 
-	f := newVoltaFixture(t, false, "claude")
-	t.Setenv("PATH", f.binDir)
+	f := newVoltaFixture(t, voltaFixtureOpts{commands: []string{"claude"}, omitVolta: true})
+	t.Setenv("PATH", pathWithout(f.binDir))
 
 	got, err := resolveAgentExecutablePath("claude")
 	if err != nil {
@@ -265,8 +516,6 @@ func TestResolveAgentExecutablePath_FailsClosedWithoutVoltaResolution(t *testing
 	if got == f.alias("claude") {
 		t.Fatalf("fell back to the alias %q; that reintroduces an ungated launch path", got)
 	}
-	// The shim path itself is still canonicalized, so compare against the
-	// resolved form (on macOS /tmp is a symlink to /private/tmp).
 	wantShim, err := filepath.EvalSymlinks(f.shim())
 	if err != nil {
 		t.Fatalf("EvalSymlinks: %v", err)
@@ -279,29 +528,25 @@ func TestResolveAgentExecutablePath_FailsClosedWithoutVoltaResolution(t *testing
 	}
 }
 
-// TestVoltaConcreteExecutable_ReresolvesAfterBinaryReplaced covers the cache's
+// TestVoltaResolve_ReresolvesAfterBinaryReplaced covers the cache's
 // revalidation-by-existence: when Volta swaps the underlying tool and the old
 // concrete path disappears, the next resolution must not keep serving it.
-func TestVoltaConcreteExecutable_ReresolvesAfterBinaryReplaced(t *testing.T) {
+func TestVoltaResolve_ReresolvesAfterBinaryReplaced(t *testing.T) {
 	skipIfNoPOSIXShell(t)
 	resetVoltaResolveCache(t)
 
-	f := newVoltaFixture(t, true, "claude")
-	t.Setenv("PATH", f.binDir)
+	f := newVoltaFixture(t, voltaFixtureOpts{commands: []string{"claude"}})
+	t.Setenv("PATH", pathWithout(f.binDir))
 
-	first, ok := voltaConcreteExecutable(f.shim(), "claude")
+	first, ok := voltaResolve(f.shim(), "claude")
 	if !ok {
 		t.Fatal("initial resolution failed")
 	}
-
-	// Cached answer is reused while it is still runnable.
-	if again, ok := voltaConcreteExecutable(f.shim(), "claude"); !ok || again != first {
-		t.Fatalf("cached resolution = (%q, %v), want (%q, true)", again, ok, first)
+	if again, ok := voltaResolve(f.shim(), "claude"); !ok || again.Path != first.Path {
+		t.Fatalf("cached resolution = (%q, %v), want (%q, true)", again.Path, ok, first.Path)
 	}
 
-	// Volta replaces the tool: the old path is gone and `volta which` now
-	// answers with a different one.
-	if err := os.Remove(first); err != nil {
+	if err := os.Remove(first.Path); err != nil {
 		t.Fatalf("remove concrete binary: %v", err)
 	}
 	newImage := filepath.Join(t.TempDir(), "image")
@@ -310,27 +555,28 @@ func TestVoltaConcreteExecutable_ReresolvesAfterBinaryReplaced(t *testing.T) {
 	}
 	writeScript(t, filepath.Join(newImage, "claude"), "#!/bin/sh\necho \"3.0.0 (Claude Code)\"\n")
 	writeScript(t, filepath.Join(f.binDir, "volta"), fmt.Sprintf(`#!/bin/sh
+if [ "$1" = "which" ] && [ "$2" = "node" ]; then echo %q; exit 0; fi
 if [ "$1" = "which" ] && [ -n "$2" ]; then
   p=%q/"$2"
   if [ -x "$p" ]; then echo "$p"; exit 0; fi
 fi
 exit 1
-`, newImage))
+`, filepath.Join(f.nodeDir, "node"), newImage))
 
-	second, ok := voltaConcreteExecutable(f.shim(), "claude")
+	second, ok := voltaResolve(f.shim(), "claude")
 	if !ok {
 		t.Fatal("re-resolution failed after the pinned binary disappeared")
 	}
-	if second == first {
-		t.Errorf("still serving the removed path %q", first)
+	if second.Path == first.Path {
+		t.Errorf("still serving the removed path %q", first.Path)
 	}
-	if want := filepath.Join(newImage, "claude"); second != want {
-		t.Errorf("re-resolved path = %q, want %q", second, want)
+	if want := filepath.Join(newImage, "claude"); second.Path != want {
+		t.Errorf("re-resolved path = %q, want %q", second.Path, want)
 	}
 }
 
-// TestResolveAgentExecutablePath_VoltaAliasShadowedByHooks proves the fix
-// reaches the ~/.multica/hooks branch, which canonicalizes independently: a
+// TestResolveAgentExecutablePath_VoltaAliasShadowedByHooks proves the fix reaches
+// the ~/.multica/hooks branch, which canonicalizes independently: a
 // hooks-shadowed Volta command must skip the recursive wrapper AND still land on
 // the concrete binary.
 func TestResolveAgentExecutablePath_VoltaAliasShadowedByHooks(t *testing.T) {
@@ -345,18 +591,21 @@ func TestResolveAgentExecutablePath_VoltaAliasShadowedByHooks(t *testing.T) {
 	}
 	writeScript(t, filepath.Join(hooksDir, "claude"), "#!/bin/sh\nexec claude \"$@\"\n")
 
-	f := newVoltaFixture(t, true, "claude")
-	t.Setenv("PATH", hooksDir+string(os.PathListSeparator)+f.binDir)
+	f := newVoltaFixture(t, voltaFixtureOpts{commands: []string{"claude"}})
+	t.Setenv("PATH", pathWithout(hooksDir, f.binDir))
 
-	got, err := resolveAgentExecutablePath("claude")
+	resolved, err := resolveAgentExecutable("claude")
 	if err != nil {
-		t.Fatalf("resolveAgentExecutablePath: %v", err)
+		t.Fatalf("resolveAgentExecutable: %v", err)
 	}
-	if filepath.Dir(got) == hooksDir {
-		t.Fatalf("resolved into the hooks dir (%q); the wrapper would recurse", got)
+	if filepath.Dir(resolved.Path) == hooksDir {
+		t.Fatalf("resolved into the hooks dir (%q); the wrapper would recurse", resolved.Path)
 	}
-	if want := f.concrete("claude"); got != want {
-		t.Errorf("path = %q, want the concrete binary %q", got, want)
+	if want := f.concrete("claude"); resolved.Path != want {
+		t.Errorf("path = %q, want the concrete binary %q", resolved.Path, want)
+	}
+	if len(resolved.PathDirs) == 0 {
+		t.Error("hooks branch dropped the Volta Node platform dir")
 	}
 }
 
@@ -414,7 +663,7 @@ func TestCanonicalExecutablePath_ExplicitShimPathStaysCanonical(t *testing.T) {
 	skipIfNoPOSIXShell(t)
 	resetVoltaResolveCache(t)
 
-	f := newVoltaFixture(t, true)
+	f := newVoltaFixture(t, voltaFixtureOpts{})
 	if got := canonicalExecutablePath(f.shim()); filepath.Base(got) != voltaShimName {
 		t.Errorf("canonicalExecutablePath(%q) = %q, want it to stay volta-shim", f.shim(), got)
 	}
@@ -442,5 +691,18 @@ func TestIsVoltaShimPath(t *testing.T) {
 		if got := isVoltaShimPath(tc.path); got != tc.want {
 			t.Errorf("isVoltaShimPath(%q) = %v, want %v", tc.path, got, tc.want)
 		}
+	}
+}
+
+// TestVoltaNonProjectDir keeps the deterministic working directory an ancestor
+// nothing can shadow: any directory with a package.json above it would let Volta
+// pick a project tool.
+func TestVoltaNonProjectDir(t *testing.T) {
+	got := voltaNonProjectDir(filepath.Join("/home", "u", ".volta", "bin", "volta"))
+	if runtime.GOOS != "windows" && got != "/" {
+		t.Errorf("voltaNonProjectDir = %q, want the filesystem root", got)
+	}
+	if got == "" {
+		t.Error("voltaNonProjectDir returned an empty directory")
 	}
 }

--- a/server/internal/daemon/config.go
+++ b/server/internal/daemon/config.go
@@ -2,6 +2,7 @@ package daemon
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"log/slog"
 	"net/url"
@@ -14,8 +15,10 @@ import (
 	"time"
 
 	"github.com/mattn/go-shellwords"
+	"golang.org/x/sync/singleflight"
 
 	"github.com/multica-ai/multica/server/internal/cli"
+	"github.com/multica-ai/multica/server/pkg/agent"
 )
 
 const (
@@ -721,19 +724,18 @@ func samePathDir(a, b string) bool {
 	return absA == absB
 }
 
-// resolvedExecutable is a pinned executable together with the PATH entries it
-// needs in order to run. The two travel as one result on purpose: Volta package
-// binaries are frequently `#!/usr/bin/env node` scripts, and Volta normally
-// supplies the Node platform bound to that package when it launches them
-// (upstream volta-core/src/run/binary.rs). Pinning only the path would leave the
-// version probe and the task launch to find *some* node on their own — a
-// different one per working directory, or none at all under a GUI-stripped PATH.
-// Keeping them together is what makes the gated version and the executed
-// version the same thing.
+// resolvedExecutable is a pinned executable together with the environment it
+// needs in order to run. The two travel as one result on purpose: a Volta-managed
+// global package binary is typically a `#!/usr/bin/env node` script, and Volta
+// supplies the Node platform bound to that package plus a NODE_PATH pointing at
+// its shared global lib dir when it launches one (upstream
+// volta-core/src/run/binary.rs). Pinning only the path would leave every consumer
+// to find some node on its own — a different one per directory, or none at all
+// under a GUI-stripped PATH — so the version the daemon gates on would not be
+// produced under the environment the CLI actually runs in.
 type resolvedExecutable struct {
 	Path string
-	// PathDirs are prepended to PATH, highest priority first.
-	PathDirs []string
+	Env  agent.ExecEnv
 }
 
 // voltaShimName is the basename of the single trampoline binary Volta installs
@@ -751,19 +753,19 @@ var (
 	// holding our stdout, and cmd.Output() blocks in Wait() until that pipe
 	// closes, so the real worst case for one call is timeout + this.
 	voltaResolveWaitDelay = time.Second
-	// voltaResolveBudget caps the TOTAL time one Volta install may cost across
-	// all commands before we stop asking it. Without this, N alias lookups
-	// against a wedged install each paid the per-call timeout and the startup
-	// probe stalled for N × timeout.
+	// voltaResolveBudget caps the time one Volta install may cost inside a single
+	// breaker window. Without it, N alias lookups against a wedged install each
+	// paid the per-call timeout and the startup probe stalled for N × timeout.
 	voltaResolveBudget = 8 * time.Second
 	// voltaFailureCooldown is how long a failing install is left alone. It turns
 	// "every command pays the timeout, every discovery tick" into "one command
-	// pays it, once per cooldown".
+	// pays it, once per cooldown". When it expires the budget resets too, so a
+	// transient outage can never latch the breaker open permanently.
 	voltaFailureCooldown = 5 * time.Minute
 )
 
 // canonicalExecutable resolves path to the concrete executable to pin plus the
-// PATH entries required to run it.
+// environment required to run it.
 //
 // Symlinks are collapsed so version-manager prefix dirs and other indirection
 // settle onto one stable path we can pin.
@@ -777,16 +779,16 @@ var (
 // exits 126 for any Volta error, which is the symptom reported in #6183. Volta
 // documents the same hazard from its own side in volta-cli/volta#579.
 //
-// So for a Volta alias we ask Volta itself for the concrete binary and pin that,
-// together with the Node platform directory it needs. Keeping the alias instead
-// and letting the shim dispatch would break the {path, version} invariant the
-// rest of the daemon relies on: the shim resolves per working directory, so the
-// version verified at registration would not be the version a task executes and
-// the minimum-version gate could be bypassed.
+// So for a Volta alias we ask Volta itself for the concrete binary and pin that
+// together with its execution context. Keeping the alias instead and letting the
+// shim dispatch would break the {path, version} invariant the rest of the daemon
+// relies on: the shim resolves per working directory, so the version verified at
+// registration would not be the version a task executes.
 //
 // Failing to resolve is deliberate: we return the shim path, version detection
-// fails as before, and the provider stays unregistered rather than being
-// launched through an ungated path. MULTICA_*_PATH remains the manual override.
+// fails as before, and the provider stays unregistered rather than being launched
+// through a path whose environment we could not reproduce. MULTICA_*_PATH remains
+// the manual override.
 func canonicalExecutable(path string) resolvedExecutable {
 	abs, err := filepath.Abs(path)
 	if err != nil {
@@ -797,7 +799,7 @@ func canonicalExecutable(path string) resolvedExecutable {
 		return resolvedExecutable{Path: abs}
 	}
 	if isVoltaShimPath(real) && !isVoltaShimPath(abs) {
-		if resolved, ok := voltaResolve(real, filepath.Base(abs)); ok {
+		if resolved, ok := voltaResolve(abs, real, filepath.Base(abs)); ok {
 			return resolved
 		}
 	}
@@ -825,22 +827,112 @@ func isVoltaShimPath(path string) bool {
 	return false
 }
 
+// voltaHomeFromAlias derives $VOLTA_HOME from a shim alias path.
+//
+// This must not be read from the daemon's environment. A GUI-launched daemon does
+// not inherit the user's VOLTA_HOME, and Volta locates all package data relative
+// to it (falling back to ~/.volta), so an inherited-or-default value would make
+// `volta` report on a different installation than the alias we actually found.
+// The layout pins the answer instead: shims live in $VOLTA_HOME/bin
+// (volta-layout: `"bin": shim_dir`), so the parent of the directory holding the
+// alias is $VOLTA_HOME. Note this is the *home*, which for a Homebrew install is
+// a different tree from where the volta binaries live.
+//
+// The symlink chain is walked one hop at a time rather than fully resolved,
+// because only the link that points AT the shim is guaranteed to sit in
+// $VOLTA_HOME/bin; an unrelated wrapper earlier in the chain would not.
+func voltaHomeFromAlias(aliasPath string) (string, bool) {
+	const maxHops = 16
+	current := aliasPath
+	for i := 0; i < maxHops; i++ {
+		target, err := os.Readlink(current)
+		if err != nil {
+			return "", false
+		}
+		if !filepath.IsAbs(target) {
+			target = filepath.Join(filepath.Dir(current), target)
+		}
+		if isVoltaShimPath(target) {
+			shimDir := filepath.Dir(current)
+			home := filepath.Dir(shimDir)
+			if home == "" || home == shimDir {
+				return "", false
+			}
+			return home, true
+		}
+		current = target
+	}
+	return "", false
+}
+
+// voltaBinConfig is the subset of $VOLTA_HOME/tools/user/bins/<name>.json the
+// daemon needs. Volta records the platform a global package was installed
+// against and uses exactly that when launching it (binary.rs
+// DefaultBinary::from_config reads bin_config.platform.node), so the *current
+// default* Node is not a substitute: switching the default must not change which
+// Node a previously installed CLI runs under.
+type voltaBinConfig struct {
+	Platform struct {
+		Node string `json:"node"`
+	} `json:"platform"`
+}
+
+// voltaBoundNodeDir returns the bin directory of the Node that Volta bound to
+// command at install time.
+func voltaBoundNodeDir(voltaHome, command string) (string, bool) {
+	raw, err := os.ReadFile(filepath.Join(voltaHome, "tools", "user", "bins", command+".json"))
+	if err != nil {
+		return "", false
+	}
+	var cfg voltaBinConfig
+	if err := json.Unmarshal(raw, &cfg); err != nil {
+		return "", false
+	}
+	version := strings.TrimSpace(cfg.Platform.Node)
+	if version == "" {
+		return "", false
+	}
+	imageDir := filepath.Join(voltaHome, "tools", "image", "node", version)
+	// Unix keeps the executables in <image>/bin; Windows puts them at the root of
+	// the image directory.
+	if binDir := filepath.Join(imageDir, "bin"); dirExists(binDir) {
+		return binDir, true
+	}
+	if dirExists(imageDir) {
+		return imageDir, true
+	}
+	return "", false
+}
+
+// voltaSharedLibDir is what Volta prefixes onto NODE_PATH so a global binary can
+// `require` other global libs (binary.rs shared_module_path ->
+// volta_home().shared_lib_root()).
+func voltaSharedLibDir(voltaHome string) string {
+	return filepath.Join(voltaHome, "tools", "shared")
+}
+
+func dirExists(path string) bool {
+	info, err := os.Stat(path)
+	return err == nil && info.IsDir()
+}
+
 type voltaInstallState struct {
 	tools    map[string]resolvedExecutable // command -> resolution
-	nodeDir  string                        // Node platform dir, "" if unknown
-	nodeDone bool
-	spent    time.Duration // cumulative cost, against voltaResolveBudget
-	failedAt time.Time     // last failure, for the cooldown
+	spent    time.Duration                 // cost inside the current breaker window
+	failedAt time.Time                     // last failure, for the cooldown
 }
 
 var (
 	voltaMu     sync.Mutex
 	voltaStates = map[string]*voltaInstallState{}
+	// voltaGroup coalesces concurrent resolutions. Without it two tasks healing
+	// the same provider could both pass the budget check and each pay a timeout.
+	voltaGroup singleflight.Group
 )
 
 // voltaExecutable returns the `volta` binary that belongs to shimPath. Both are
 // VoltaInstall entries, so they live in the same directory; we invoke it by
-// absolute path because the daemon may not have Volta's bin dir on PATH at all.
+// absolute path because the daemon may not have Volta's bin dir on PATH.
 func voltaExecutable(shimPath string) string {
 	voltaBin := filepath.Join(filepath.Dir(shimPath), "volta")
 	if runtime.GOOS == "windows" {
@@ -865,17 +957,23 @@ func voltaNonProjectDir(voltaBin string) string {
 	return string(os.PathSeparator)
 }
 
-// voltaResolve asks Volta for the concrete binary behind command, plus the Node
-// platform directory needed to run it, and caches the answer.
+// voltaResolve asks Volta for the concrete binary behind command and builds the
+// execution context it needs. It returns false unless BOTH are available: a path
+// without its environment is not reliably runnable, so a partial answer must
+// never be cached or launched.
 //
 // Answers are revalidated by existence rather than a TTL: probeAgentCLIs re-runs
 // on every discovery tick, and a steady-state daemon must not fork `volta`
-// forever. When Volta replaces the binary and the cached path disappears, the
-// entry is dropped and re-resolved, which dovetails with the MUL-4486 self-heal.
-func voltaResolve(shimPath, command string) (resolvedExecutable, bool) {
+// forever. When Volta replaces the binary or the Node image is removed, the entry
+// is dropped and re-resolved, which dovetails with the MUL-4486 self-heal.
+func voltaResolve(aliasPath, shimPath, command string) (resolvedExecutable, bool) {
 	// command comes from a filesystem basename; keep it to the same bare-name
 	// shape the shell resolver enforces so nothing flag-like reaches argv.
 	if !isSafeAgentName(command) {
+		return resolvedExecutable{}, false
+	}
+	voltaHome, ok := voltaHomeFromAlias(aliasPath)
+	if !ok {
 		return resolvedExecutable{}, false
 	}
 	voltaBin := voltaExecutable(shimPath)
@@ -887,25 +985,27 @@ func voltaResolve(shimPath, command string) (resolvedExecutable, bool) {
 		voltaStates[voltaBin] = state
 	}
 	if cached, ok := state.tools[command]; ok {
-		if isExecutableFile(cached.Path) {
+		if voltaResolutionUsable(cached) {
 			voltaMu.Unlock()
 			return cached, true
 		}
 		delete(state.tools, command)
 	}
-	// Circuit breaker: a wedged or broken install is asked once per cooldown,
-	// not once per command and not on every tick.
-	if !state.failedAt.IsZero() && time.Since(state.failedAt) < voltaFailureCooldown {
-		voltaMu.Unlock()
-		return resolvedExecutable{}, false
+	// Circuit breaker. A cooldown that has expired also resets the spend budget:
+	// the budget bounds one window, not the process lifetime, so a couple of slow
+	// failures can never disable Volta resolution for good.
+	if !state.failedAt.IsZero() {
+		if time.Since(state.failedAt) < voltaFailureCooldown {
+			voltaMu.Unlock()
+			return resolvedExecutable{}, false
+		}
+		state.failedAt = time.Time{}
+		state.spent = 0
 	}
 	if state.spent >= voltaResolveBudget {
 		voltaMu.Unlock()
 		return resolvedExecutable{}, false
 	}
-	nodeDir, nodeDone := state.nodeDir, state.nodeDone
-	// Released for the subprocess below: holding it would serialize every
-	// command behind one timeout and make the stall additive.
 	voltaMu.Unlock()
 
 	if !isExecutableFile(voltaBin) {
@@ -915,36 +1015,75 @@ func voltaResolve(shimPath, command string) (resolvedExecutable, bool) {
 		return resolvedExecutable{}, false
 	}
 
-	started := time.Now()
-	toolPath, toolOK := voltaWhich(voltaBin, command)
-	if toolOK && !nodeDone {
-		// One extra call per install, not per command: the Node platform dir is
-		// what makes an `env node` package script runnable.
-		nodeDir, _ = voltaNodeDir(voltaBin)
-		nodeDone = true
-	}
-	elapsed := time.Since(started)
+	// Coalesce concurrent work per (install, command): the first caller pays,
+	// the rest share its answer instead of each spawning a `volta`.
+	key := voltaBin + "\x00" + command
+	v, _, _ := voltaGroup.Do(key, func() (any, error) {
+		started := time.Now()
+		resolved, ok := voltaResolveUncached(voltaBin, voltaHome, command)
+		elapsed := time.Since(started)
 
-	voltaMu.Lock()
-	defer voltaMu.Unlock()
-	state.spent += elapsed
-	state.nodeDir, state.nodeDone = nodeDir, nodeDone
-	if !toolOK {
-		state.failedAt = time.Now()
+		voltaMu.Lock()
+		defer voltaMu.Unlock()
+		state.spent += elapsed
+		if !ok {
+			state.failedAt = time.Now()
+			return resolvedExecutable{}, nil
+		}
+		state.failedAt = time.Time{}
+		state.tools[command] = resolved
+		return resolved, nil
+	})
+	resolved, _ := v.(resolvedExecutable)
+	return resolved, resolved.Path != ""
+}
+
+// voltaResolveUncached performs the actual queries. Both halves must succeed.
+func voltaResolveUncached(voltaBin, voltaHome, command string) (resolvedExecutable, bool) {
+	toolPath, ok := voltaWhich(voltaBin, voltaHome, command)
+	if !ok {
 		return resolvedExecutable{}, false
 	}
-	state.failedAt = time.Time{}
-	resolved := resolvedExecutable{Path: toolPath}
-	if nodeDir != "" {
-		resolved.PathDirs = []string{nodeDir}
+	nodeDir, ok := voltaBoundNodeDir(voltaHome, command)
+	if !ok {
+		// Fail closed: without the bound Node we cannot reproduce the
+		// environment Volta itself would use, so the version we verify would not
+		// be the version that runs.
+		return resolvedExecutable{}, false
 	}
-	state.tools[command] = resolved
-	return resolved, true
+	return resolvedExecutable{
+		Path: toolPath,
+		Env: agent.ExecEnv{PrefixPaths: map[string][]string{
+			"PATH":      {nodeDir},
+			"NODE_PATH": {voltaSharedLibDir(voltaHome)},
+		}},
+	}, true
+}
+
+// voltaResolutionUsable reports whether a cached resolution is still runnable —
+// the tool AND every directory its environment depends on.
+func voltaResolutionUsable(resolved resolvedExecutable) bool {
+	if !isExecutableFile(resolved.Path) {
+		return false
+	}
+	for name, dirs := range resolved.Env.PrefixPaths {
+		if name != "PATH" {
+			// Only PATH entries have to exist to run; NODE_PATH is advisory and
+			// its shared dir is created lazily by Volta.
+			continue
+		}
+		for _, dir := range dirs {
+			if !dirExists(dir) {
+				return false
+			}
+		}
+	}
+	return true
 }
 
 // voltaWhich runs `volta which <command>` and returns the concrete path.
-func voltaWhich(voltaBin, command string) (string, bool) {
-	out, ok := runVolta(voltaBin, "which", command)
+func voltaWhich(voltaBin, voltaHome, command string) (string, bool) {
+	out, ok := runVolta(voltaBin, voltaHome, "which", command)
 	if !ok {
 		return "", false
 	}
@@ -960,26 +1099,17 @@ func voltaWhich(voltaBin, command string) (string, bool) {
 	return out, true
 }
 
-// voltaNodeDir returns the directory of the Node that Volta runs package
-// binaries with. Resolved through the same public `volta which` interface (in
-// the same non-project directory) so it is the default toolchain's Node rather
-// than whatever a project pins.
-func voltaNodeDir(voltaBin string) (string, bool) {
-	nodePath, ok := voltaWhich(voltaBin, "node")
-	if !ok {
-		return "", false
-	}
-	return filepath.Dir(nodePath), true
-}
-
-// runVolta invokes the Volta CLI and returns its trimmed stdout. A var so tests
-// can exercise the caching/cooldown logic without a real subprocess, following
-// the same seam pattern as resolveAgentsViaLoginShell and detectAgentVersion.
-var runVolta = func(voltaBin string, args ...string) (string, bool) {
+// runVolta invokes the Volta CLI and returns its trimmed stdout. VOLTA_HOME is
+// set explicitly (never inherited) so the answer describes the installation the
+// alias belongs to. A var so tests can exercise the caching/cooldown logic
+// without a real subprocess, following the same seam pattern as
+// resolveAgentsViaLoginShell and detectAgentVersion.
+var runVolta = func(voltaBin, voltaHome string, args ...string) (string, bool) {
 	ctx, cancel := context.WithTimeout(context.Background(), voltaResolveTimeout)
 	defer cancel()
 	cmd := exec.CommandContext(ctx, voltaBin, args...)
 	cmd.Dir = voltaNonProjectDir(voltaBin)
+	cmd.Env = envWithVoltaHome(os.Environ(), voltaHome)
 	// Volta prints results on stdout and diagnostics on stderr; Output()
 	// captures only stdout. WaitDelay keeps a hung child from outliving ctx.
 	cmd.WaitDelay = voltaResolveWaitDelay
@@ -988,6 +1118,18 @@ var runVolta = func(voltaBin string, args ...string) (string, bool) {
 		return "", false
 	}
 	return strings.TrimSpace(string(out)), true
+}
+
+// envWithVoltaHome returns environ with VOLTA_HOME replaced by home.
+func envWithVoltaHome(environ []string, home string) []string {
+	out := make([]string, 0, len(environ)+1)
+	for _, kv := range environ {
+		if name, _, ok := strings.Cut(kv, "="); ok && name == "VOLTA_HOME" {
+			continue
+		}
+		out = append(out, kv)
+	}
+	return append(out, "VOLTA_HOME="+home)
 }
 
 func isExecutableFile(path string) bool {

--- a/server/internal/daemon/config.go
+++ b/server/internal/daemon/config.go
@@ -746,6 +746,11 @@ const voltaShimName = "volta-shim"
 var (
 	// voltaResolveTimeout bounds a single `volta` invocation.
 	voltaResolveTimeout = 5 * time.Second
+	// voltaResolveWaitDelay is how long after the context fires we wait for a
+	// wedged child's pipes to close. A hung shell can leave grandchildren
+	// holding our stdout, and cmd.Output() blocks in Wait() until that pipe
+	// closes, so the real worst case for one call is timeout + this.
+	voltaResolveWaitDelay = time.Second
 	// voltaResolveBudget caps the TOTAL time one Volta install may cost across
 	// all commands before we stop asking it. Without this, N alias lookups
 	// against a wedged install each paid the per-call timeout and the startup
@@ -967,14 +972,17 @@ func voltaNodeDir(voltaBin string) (string, bool) {
 	return filepath.Dir(nodePath), true
 }
 
-func runVolta(voltaBin string, args ...string) (string, bool) {
+// runVolta invokes the Volta CLI and returns its trimmed stdout. A var so tests
+// can exercise the caching/cooldown logic without a real subprocess, following
+// the same seam pattern as resolveAgentsViaLoginShell and detectAgentVersion.
+var runVolta = func(voltaBin string, args ...string) (string, bool) {
 	ctx, cancel := context.WithTimeout(context.Background(), voltaResolveTimeout)
 	defer cancel()
 	cmd := exec.CommandContext(ctx, voltaBin, args...)
 	cmd.Dir = voltaNonProjectDir(voltaBin)
 	// Volta prints results on stdout and diagnostics on stderr; Output()
 	// captures only stdout. WaitDelay keeps a hung child from outliving ctx.
-	cmd.WaitDelay = time.Second
+	cmd.WaitDelay = voltaResolveWaitDelay
 	out, err := cmd.Output()
 	if err != nil {
 		return "", false

--- a/server/internal/daemon/config.go
+++ b/server/internal/daemon/config.go
@@ -8,7 +8,9 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/mattn/go-shellwords"
@@ -712,27 +714,36 @@ func samePathDir(a, b string) bool {
 // (volta-core/src/shim.rs, unix create()).
 const voltaShimName = "volta-shim"
 
+// voltaResolveTimeout bounds the `volta which` call below. Resolution runs on
+// the startup/discovery path, so a wedged Volta install must not stall the
+// daemon: on timeout we fail closed and the provider simply stays unregistered.
+var voltaResolveTimeout = 5 * time.Second
+
 // canonicalExecutablePath collapses path to the real file behind any symlinks,
 // so version-manager prefix dirs and other indirection settle onto one stable
 // path we can pin.
 //
-// Exception: argv[0]-dispatching trampolines. Volta decides which tool to run
-// from the name it was invoked as — volta-core/src/run/mod.rs get_tool_name()
-// takes file_name() of argv[0] — so resolving `~/.volta/bin/claude` to
-// volta-shim throws away the only input that selects the tool. Upstream then
-// fails the call outright (get_executor: `Some("volta-shim") =>
-// Err(ErrorKind::RunShimDirectly)`), and volta-shim's main exits 126 for any
-// Volta error, which is the exact symptom reported in #6183. Volta itself
-// documents this hazard in volta-cli/volta#579: fully resolving the symlink
-// before exec "loses the information about what tool was actually called".
+// Volta needs a detour. It points every command it manages at one shared
+// volta-shim and picks the tool from the name it was invoked as — upstream
+// get_tool_name() takes file_name() of argv[0] (volta-core/src/run/mod.rs) — so
+// resolving `~/.volta/bin/claude` to volta-shim throws away the only input that
+// selects the tool. Upstream then refuses the call outright (get_executor:
+// `Some("volta-shim") => Err(ErrorKind::RunShimDirectly)`) and volta-shim's main
+// exits 126 for any Volta error, which is the symptom reported in #6183. Volta
+// documents the same hazard from its own side in volta-cli/volta#579.
 //
-// For those we keep the caller's alias path, which is also the stable one: the
-// alias survives `volta install` upgrades that replace the versioned binary
-// underneath it.
+// So for a Volta alias we ask Volta itself for the concrete binary and pin that.
+// The tempting alternative — keep the alias path and let the shim dispatch —
+// breaks the {path, version} invariant the rest of the daemon relies on: the
+// shim resolves per current directory (`volta which` prefers a project-local
+// bin, src/command/which.rs), so the version verified at registration would not
+// be the version a task executes, and the minimum-version gate could be
+// bypassed. Pinning the concrete path keeps Volta installs on exactly the same
+// footing as every other install method.
 //
-// This stays deliberately narrow. Skipping symlink resolution in general would
-// regress the PATH-drift pinning, the ~/.multica/hooks recursion guard, and the
-// MUL-4486 self-heal that all depend on collapsing to a real path.
+// Failing to resolve is deliberate: we return the shim path, version detection
+// fails as before, and the provider stays unregistered rather than being
+// launched through an ungated path. MULTICA_*_PATH remains the manual override.
 func canonicalExecutablePath(path string) string {
 	abs, err := filepath.Abs(path)
 	if err != nil {
@@ -742,27 +753,92 @@ func canonicalExecutablePath(path string) string {
 	if err != nil {
 		return abs
 	}
-	// Only when the alias name differs from the shim's own name is there a
-	// dispatch name to preserve; an explicit path straight at volta-shim has
-	// nothing to keep and stays canonicalized.
 	if isVoltaShimPath(real) && !isVoltaShimPath(abs) {
-		return abs
+		if concrete, ok := voltaConcreteExecutable(real, filepath.Base(abs)); ok {
+			return concrete
+		}
 	}
 	return real
 }
 
-// isVoltaShimPath reports whether path's basename is Volta's shared shim. The
-// extension is trimmed and the compare is case-insensitive, mirroring Volta's
-// own normalization on Windows (run/mod.rs tool_name_from_file_name lowercases
-// and strips ".exe"). In practice only the Unix layout reaches here, since
-// Windows shims are .cmd scripts rather than symlinks.
+// isVoltaShimPath reports whether path is Volta's shared shim. The accepted
+// names are exact — an extension-insensitive match would also swallow
+// neighbours like volta-shim.bak or volta-shim.wrapper, and this exception
+// exists to be as narrow as possible.
 func isVoltaShimPath(path string) bool {
 	if path == "" {
 		return false
 	}
-	base := filepath.Base(path)
-	base = strings.TrimSuffix(base, filepath.Ext(base))
-	return strings.EqualFold(base, voltaShimName)
+	switch filepath.Base(path) {
+	case voltaShimName, voltaShimName + ".exe":
+		return true
+	}
+	return false
+}
+
+var (
+	voltaResolveMu    sync.Mutex
+	voltaResolveCache = map[string]string{}
+)
+
+// voltaConcreteExecutable asks Volta for the real binary behind command and
+// returns it only when the answer is an absolute, currently runnable path.
+//
+// `volta` lives in the same directory as volta-shim (both are VoltaInstall
+// entries), so we invoke it by absolute path instead of trusting PATH — the
+// daemon may not have Volta's bin dir at all.
+//
+// Answers are cached process-wide and revalidated by existence rather than a
+// TTL: probeAgentCLIs re-runs on every discovery tick, and a steady-state
+// daemon must not fork `volta which` forever. When Volta replaces the binary
+// and the cached path disappears, the entry is dropped and re-resolved, which
+// dovetails with the MUL-4486 self-heal.
+func voltaConcreteExecutable(shimPath, command string) (string, bool) {
+	// command comes from a filesystem basename; keep it to the same bare-name
+	// shape the shell resolver enforces so nothing flag-like reaches argv.
+	if !isSafeAgentName(command) {
+		return "", false
+	}
+	voltaBin := filepath.Join(filepath.Dir(shimPath), "volta")
+	if runtime.GOOS == "windows" {
+		voltaBin += ".exe"
+	}
+	cacheKey := voltaBin + "\x00" + command
+
+	voltaResolveMu.Lock()
+	defer voltaResolveMu.Unlock()
+	if cached, ok := voltaResolveCache[cacheKey]; ok {
+		if isExecutableFile(cached) {
+			return cached, true
+		}
+		delete(voltaResolveCache, cacheKey)
+	}
+	if !isExecutableFile(voltaBin) {
+		return "", false
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), voltaResolveTimeout)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, voltaBin, "which", command)
+	// Volta prints the path on stdout and diagnostics on stderr; Output()
+	// captures only stdout. WaitDelay keeps a hung child from outliving ctx.
+	cmd.WaitDelay = time.Second
+	out, err := cmd.Output()
+	if err != nil {
+		return "", false
+	}
+	// `volta which` prints nothing and exits non-zero when it cannot find the
+	// binary, so anything that is not a single absolute runnable path is a miss
+	// rather than something we should pin.
+	resolved := strings.TrimSpace(string(out))
+	if resolved == "" || strings.ContainsAny(resolved, "\r\n") || !filepath.IsAbs(resolved) {
+		return "", false
+	}
+	if !isExecutableFile(resolved) {
+		return "", false
+	}
+	voltaResolveCache[cacheKey] = resolved
+	return resolved, true
 }
 
 func isExecutableFile(path string) bool {

--- a/server/internal/daemon/config.go
+++ b/server/internal/daemon/config.go
@@ -2,6 +2,8 @@ package daemon
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"log/slog"
@@ -651,11 +653,18 @@ func agentExecutablePresent(path string) bool {
 // old Node image leaves the CLI file in place, so a cached entry stayed
 // "present" while its PATH pointed at a directory that no longer existed —
 // every task then launched with a broken toolchain and nothing ever re-resolved.
-func agentEntryLaunchable(path string, env agent.ExecEnv) bool {
-	if !agentExecutablePresent(path) {
+// A rebind to a different Node is the same class of problem with nothing missing
+// at all, which is why the resolution inputs are fingerprinted too.
+func agentEntryLaunchable(entry AgentEntry) bool {
+	if !agentExecutablePresent(entry.Path) {
 		return false
 	}
-	return execEnvDirsPresent(env)
+	if !execEnvDirsPresent(entry.Env) {
+		return false
+	}
+	// Same reason as voltaResolutionUsable: a Volta rebind leaves every directory
+	// in place, so only the config fingerprint reveals it.
+	return resolutionStampValid(entry.EnvStampPath, entry.EnvStampHash)
 }
 
 // execEnvDirsPresent reports whether the PATH directories an ExecEnv depends on
@@ -768,6 +777,14 @@ func samePathDir(a, b string) bool {
 type resolvedExecutable struct {
 	Path string
 	Env  agent.ExecEnv
+	// StampPath / StampHash fingerprint the file whose CONTENTS determined the
+	// environment — Volta's bin config for this command. Existence checks alone
+	// cannot see a rebind: `volta install pkg` against a newer Node rewrites the
+	// config while the previous Node image often stays on disk for other tools, so
+	// every directory still exists and a path-only validity check keeps serving the
+	// superseded toolchain forever.
+	StampPath string
+	StampHash string
 }
 
 // voltaShimName is the basename of the single trampoline binary Volta installs
@@ -789,7 +806,11 @@ var (
 	// breaker window. Without it, N alias lookups against a wedged install each
 	// paid the per-call timeout and the startup probe stalled for N × timeout.
 	voltaResolveBudget = 8 * time.Second
-	// voltaFailureCooldown is how long a failing install is left alone. It turns
+	// voltaCommandMissCooldown is how long a single command's failure suppresses
+	// retries of THAT command. Short, because such a miss is cheap to retest and a
+	// user who installs the tool should be picked up promptly.
+	voltaCommandMissCooldown = time.Minute
+	// voltaFailureCooldown is how long an EXPENSIVE-failing install is left alone. It turns
 	// "every command pays the timeout, every discovery tick" into "one command
 	// pays it, once per cooldown". When it expires the budget resets too, so a
 	// transient outage can never latch the breaker open permanently.
@@ -926,18 +947,19 @@ type voltaBinConfig struct {
 // image is missing is skipped rather than failing the whole resolution — an absent
 // directory on PATH has no effect on execution, and skipping it keeps validity
 // checks honest about what actually has to exist.
-func voltaPlatformDirs(voltaHome, command string) ([]string, bool) {
-	raw, err := os.ReadFile(filepath.Join(voltaHome, "tools", "user", "bins", command+".json"))
+func voltaPlatformDirs(voltaHome, command string) ([]string, string, bool) {
+	configPath := voltaBinConfigPath(voltaHome, command)
+	raw, err := os.ReadFile(configPath)
 	if err != nil {
-		return nil, false
+		return nil, "", false
 	}
 	var cfg voltaBinConfig
 	if err := json.Unmarshal(raw, &cfg); err != nil {
-		return nil, false
+		return nil, "", false
 	}
 	nodeVersion := strings.TrimSpace(cfg.Platform.Node)
 	if nodeVersion == "" {
-		return nil, false
+		return nil, "", false
 	}
 
 	var dirs []string
@@ -958,9 +980,32 @@ func voltaPlatformDirs(voltaHome, command string) ([]string, bool) {
 	}
 	nodeDir, ok := voltaImageBinDir(voltaHome, "node", nodeVersion)
 	if !ok {
-		return nil, false
+		return nil, "", false
 	}
-	return append(dirs, nodeDir), true
+	return append(dirs, nodeDir), hashBytes(raw), true
+}
+
+// voltaBinConfigPath is where Volta records the platform bound to a command.
+func voltaBinConfigPath(voltaHome, command string) string {
+	return filepath.Join(voltaHome, "tools", "user", "bins", command+".json")
+}
+
+func hashBytes(raw []byte) string {
+	sum := sha256.Sum256(raw)
+	return hex.EncodeToString(sum[:])
+}
+
+// resolutionStampValid reports whether the file that determined an environment
+// still has the same contents. A missing stamp means "nothing to check".
+func resolutionStampValid(stampPath, stampHash string) bool {
+	if stampPath == "" {
+		return true
+	}
+	raw, err := os.ReadFile(stampPath)
+	if err != nil {
+		return false
+	}
+	return hashBytes(raw) == stampHash
 }
 
 // voltaImageBinDir locates the executables for one toolchain image. Unix keeps
@@ -990,16 +1035,20 @@ func dirExists(path string) bool {
 
 type voltaInstallState struct {
 	tools map[string]resolvedExecutable // command -> resolution
-	// failureSpend accumulates ONLY failed or timed-out query time, inside the
-	// current breaker window. Counting successful queries too let a couple of slow
-	// but WORKING resolutions exhaust the budget; since success also clears
-	// failedAt, no cooldown could then fire and every later uncached command was
-	// refused for the life of the process.
+	// misses is a per-COMMAND negative cache. A command that simply is not
+	// Volta-managed (no bin config) fails fast and cheaply, and must only stop
+	// retries of ITSELF — it says nothing about the installation's health.
+	misses map[string]time.Time
+	// failureSpend is how much time failures have burned in the current window.
+	// Only when it reaches voltaResolveBudget does the whole installation go into
+	// cooldown, because that is the signal that querying Volta is EXPENSIVE (hung
+	// or timing out), not merely unsuccessful.
 	failureSpend time.Duration
-	failedAt     time.Time
+	// installCooldownUntil suppresses every command for this installation. Set
+	// only by an exhausted budget.
+	installCooldownUntil time.Time
 	// queryMu serializes this installation's queries so the budget is enforced per
-	// installation rather than per command: without it several commands pass the
-	// budget check concurrently and each pays a full timeout.
+	// installation rather than per command.
 	queryMu sync.Mutex
 }
 
@@ -1030,7 +1079,10 @@ func voltaInstallStateFor(key string) *voltaInstallState {
 	defer voltaMu.Unlock()
 	state := voltaStates[key]
 	if state == nil {
-		state = &voltaInstallState{tools: map[string]resolvedExecutable{}}
+		state = &voltaInstallState{
+			tools:  map[string]resolvedExecutable{},
+			misses: map[string]time.Time{},
+		}
 		voltaStates[key] = state
 	}
 	return state
@@ -1089,11 +1141,11 @@ func voltaResolve(aliasPath, shimPath, command string) (resolvedExecutable, bool
 	if cached, ok := voltaCachedTool(state, command); ok {
 		return cached, true
 	}
-	if !voltaBreakerAllows(state) {
+	if !voltaBreakerAllows(state, command) {
 		return resolvedExecutable{}, false
 	}
 	if !isExecutableFile(voltaBin) {
-		voltaNoteFailure(state, 0)
+		voltaNoteFailure(state, command, 0)
 		return resolvedExecutable{}, false
 	}
 
@@ -1108,14 +1160,14 @@ func voltaResolve(aliasPath, shimPath, command string) (resolvedExecutable, bool
 		if cached, ok := voltaCachedTool(state, command); ok {
 			return cached, nil
 		}
-		if !voltaBreakerAllows(state) {
+		if !voltaBreakerAllows(state, command) {
 			return resolvedExecutable{}, nil
 		}
 
 		started := time.Now()
 		resolved, ok := voltaResolveUncached(voltaBin, voltaHome, command)
 		if !ok {
-			voltaNoteFailure(state, time.Since(started))
+			voltaNoteFailure(state, command, time.Since(started))
 			return resolvedExecutable{}, nil
 		}
 		voltaNoteSuccess(state, command, resolved)
@@ -1140,29 +1192,48 @@ func voltaCachedTool(state *voltaInstallState, command string) (resolvedExecutab
 	return resolvedExecutable{}, false
 }
 
-// voltaBreakerAllows reports whether this installation may be queried now.
+// voltaBreakerAllows reports whether command may be queried now.
 //
-// The budget bounds ONE cooldown window and counts only failures, so neither a
-// run of slow-but-working resolutions nor a transient outage can latch the
-// breaker permanently: an expired cooldown clears both halves.
-func voltaBreakerAllows(state *voltaInstallState) bool {
+// Two independent gates, deliberately:
+//
+//   - A per-command negative cache. Most failures are command-specific and cheap
+//     (the command is simply not Volta-managed, so there is no bin config). Those
+//     must not stop other commands: previously any failure set one shared flag and
+//     a single fast miss froze every healthy command on the installation for the
+//     full cooldown, which also made the spend budget unreachable dead code.
+//   - An installation-wide cooldown, entered only when failures have actually
+//     burned the time budget. That is the case worth suppressing globally, because
+//     it means each further query costs a timeout.
+func voltaBreakerAllows(state *voltaInstallState, command string) bool {
 	voltaMu.Lock()
 	defer voltaMu.Unlock()
-	if !state.failedAt.IsZero() {
-		if time.Since(state.failedAt) < voltaFailureCooldown {
+	if !state.installCooldownUntil.IsZero() {
+		if time.Now().Before(state.installCooldownUntil) {
 			return false
 		}
-		state.failedAt = time.Time{}
+		// Cooldown served: start a fresh window.
+		state.installCooldownUntil = time.Time{}
 		state.failureSpend = 0
 	}
-	return state.failureSpend < voltaResolveBudget
+	if last, ok := state.misses[command]; ok {
+		if time.Since(last) < voltaCommandMissCooldown {
+			return false
+		}
+		delete(state.misses, command)
+	}
+	return true
 }
 
-func voltaNoteFailure(state *voltaInstallState, elapsed time.Duration) {
+func voltaNoteFailure(state *voltaInstallState, command string, elapsed time.Duration) {
 	voltaMu.Lock()
 	defer voltaMu.Unlock()
+	state.misses[command] = time.Now()
 	state.failureSpend += elapsed
-	state.failedAt = time.Now()
+	if state.failureSpend >= voltaResolveBudget {
+		// Expensive failures: suppress the whole installation for a cooldown so N
+		// commands cannot each pay a timeout.
+		state.installCooldownUntil = time.Now().Add(voltaFailureCooldown)
+	}
 }
 
 // voltaNoteSuccess records a working resolution. A success proves the install is
@@ -1171,8 +1242,9 @@ func voltaNoteFailure(state *voltaInstallState, elapsed time.Duration) {
 func voltaNoteSuccess(state *voltaInstallState, command string, resolved resolvedExecutable) {
 	voltaMu.Lock()
 	defer voltaMu.Unlock()
-	state.failedAt = time.Time{}
+	delete(state.misses, command)
 	state.failureSpend = 0
+	state.installCooldownUntil = time.Time{}
 	state.tools[command] = resolved
 }
 
@@ -1182,7 +1254,7 @@ func voltaResolveUncached(voltaBin, voltaHome, command string) (resolvedExecutab
 	if !ok {
 		return resolvedExecutable{}, false
 	}
-	platformDirs, ok := voltaPlatformDirs(voltaHome, command)
+	platformDirs, stampHash, ok := voltaPlatformDirs(voltaHome, command)
 	if !ok {
 		// Fail closed: without the bound platform we cannot reproduce the
 		// environment Volta itself would use, so the version we verify would not
@@ -1195,6 +1267,8 @@ func voltaResolveUncached(voltaBin, voltaHome, command string) (resolvedExecutab
 			"PATH":      platformDirs,
 			"NODE_PATH": {voltaSharedLibDir(voltaHome)},
 		}},
+		StampPath: voltaBinConfigPath(voltaHome, command),
+		StampHash: stampHash,
 	}, true
 }
 
@@ -1202,6 +1276,11 @@ func voltaResolveUncached(voltaBin, voltaHome, command string) (resolvedExecutab
 // the tool AND every directory its environment depends on.
 func voltaResolutionUsable(resolved resolvedExecutable) bool {
 	if !isExecutableFile(resolved.Path) {
+		return false
+	}
+	// A rebind rewrites the bin config; without this the old binding survives for
+	// as long as its image happens to stay on disk.
+	if !resolutionStampValid(resolved.StampPath, resolved.StampHash) {
 		return false
 	}
 	for name, dirs := range resolved.Env.PrefixPaths {

--- a/server/internal/daemon/config.go
+++ b/server/internal/daemon/config.go
@@ -705,15 +705,53 @@ func samePathDir(a, b string) bool {
 	return absA == absB
 }
 
+// voltaShimName is the basename of the single trampoline binary Volta installs
+// in ~/.volta/bin and symlinks EVERY managed command to (claude, codex, pi, ...).
+const voltaShimName = "volta-shim"
+
+// canonicalExecutablePath collapses path to the real file behind any symlinks,
+// so version-manager prefix dirs and other indirection settle onto one stable
+// path we can pin.
+//
+// Exception: argv[0]-dispatching trampolines. Volta points every command it
+// manages at one shared volta-shim and decides which tool to run from the name
+// it was invoked as, so resolving `~/.volta/bin/claude` to `volta-shim` throws
+// away the only input that selects the tool — the shim then exits 126 and the
+// runtime never registers (#6183). For those we keep the caller's alias path,
+// which is also the stable one: the alias survives `volta install` upgrades
+// that replace the versioned binary underneath it.
+//
+// This stays deliberately narrow. Skipping symlink resolution in general would
+// regress the PATH-drift pinning, the ~/.multica/hooks recursion guard, and the
+// MUL-4486 self-heal that all depend on collapsing to a real path.
 func canonicalExecutablePath(path string) string {
 	abs, err := filepath.Abs(path)
 	if err != nil {
 		return path
 	}
-	if real, err := filepath.EvalSymlinks(abs); err == nil {
-		return real
+	real, err := filepath.EvalSymlinks(abs)
+	if err != nil {
+		return abs
 	}
-	return abs
+	// Only when the alias name differs from the shim's own name is there a
+	// dispatch name to preserve; an explicit path straight at volta-shim has
+	// nothing to keep and stays canonicalized.
+	if isVoltaShimPath(real) && !isVoltaShimPath(abs) {
+		return abs
+	}
+	return real
+}
+
+// isVoltaShimPath reports whether path's basename is Volta's shared shim. The
+// extension is trimmed so volta-shim.exe matches on Windows, and the compare is
+// case-insensitive because macOS and Windows filesystems usually are.
+func isVoltaShimPath(path string) bool {
+	if path == "" {
+		return false
+	}
+	base := filepath.Base(path)
+	base = strings.TrimSuffix(base, filepath.Ext(base))
+	return strings.EqualFold(base, voltaShimName)
 }
 
 func isExecutableFile(path string) bool {

--- a/server/internal/daemon/config.go
+++ b/server/internal/daemon/config.go
@@ -599,20 +599,32 @@ func shellArgsFromEnv(name string) ([]string, error) {
 // When ~/.multica/hooks shadows a real agent binary, skip that hooks directory:
 // previously generated hook wrappers can execute the same command name and
 // recurse forever if the daemon records or launches the wrapper.
-func resolveAgentExecutablePath(cmd string) (string, error) {
+//
+// The returned PATH entries must be prepended to the environment of BOTH the
+// version probe and the task launch — see resolvedExecutable.
+func resolveAgentExecutable(cmd string) (resolvedExecutable, error) {
 	resolved, err := exec.LookPath(cmd)
 	if err != nil {
-		return "", err
+		return resolvedExecutable{}, err
 	}
 	if strings.ContainsAny(cmd, "/\\") {
-		return resolved, nil
+		// An operator-pinned absolute/relative path is taken literally: it is
+		// not canonicalized today and must keep that contract.
+		return resolvedExecutable{Path: resolved}, nil
 	}
 	if isInMulticaHooksDir(resolved) {
 		if unshadowed, err := lookPathExcludingMulticaHooks(cmd); err == nil {
 			return unshadowed, nil
 		}
 	}
-	return canonicalExecutablePath(resolved), nil
+	return canonicalExecutable(resolved), nil
+}
+
+// resolveAgentExecutablePath is the path-only form, for callers that do not
+// launch the result (and for tests asserting the pinned path).
+func resolveAgentExecutablePath(cmd string) (string, error) {
+	resolved, err := resolveAgentExecutable(cmd)
+	return resolved.Path, err
 }
 
 // agentExecutablePresent reports whether path currently resolves to a runnable
@@ -629,19 +641,19 @@ func agentExecutablePresent(path string) bool {
 }
 
 // reresolveAgentCommand re-runs the startup resolution for a single agent
-// command name, returning the freshly resolved absolute path. It mirrors the
+// command name, returning the freshly resolved executable. It mirrors the
 // probe() order in LoadConfig: exec.LookPath (with the ~/.multica/hooks
-// exclusion preserved via resolveAgentExecutablePath) first, then the login
+// exclusion preserved via resolveAgentExecutable) first, then the login
 // shell fallback for a bare command name a GUI-launched daemon can't see on
 // its own PATH. It is only called on the miss path — when a previously pinned
 // path has disappeared — so the login-shell cost is paid rarely, never on a
 // normal launch.
-func reresolveAgentCommand(cmd string) (string, bool) {
+func reresolveAgentCommand(cmd string) (resolvedExecutable, bool) {
 	if cmd == "" {
-		return "", false
+		return resolvedExecutable{}, false
 	}
-	if path, err := resolveAgentExecutablePath(cmd); err == nil {
-		return path, true
+	if resolved, err := resolveAgentExecutable(cmd); err == nil {
+		return resolved, true
 	}
 	// A bare command name the daemon's own PATH can't see: retry via the
 	// user's login shell, exactly as the startup probe does for
@@ -650,13 +662,15 @@ func reresolveAgentCommand(cmd string) (string, bool) {
 	// stay a hard miss rather than silently resolve a different binary.
 	if !strings.ContainsAny(cmd, "/\\") {
 		if path, ok := resolveAgentsViaLoginShell([]string{cmd})[cmd]; ok {
-			return path, true
+			// Same reason as the probe's shell leg: the script preserves the
+			// file name, so a Volta alias still needs the real resolution.
+			return canonicalExecutable(path), true
 		}
 	}
-	return "", false
+	return resolvedExecutable{}, false
 }
 
-func lookPathExcludingMulticaHooks(cmd string) (string, error) {
+func lookPathExcludingMulticaHooks(cmd string) (resolvedExecutable, error) {
 	for _, dir := range filepath.SplitList(os.Getenv("PATH")) {
 		if dir == "" {
 			dir = "."
@@ -666,10 +680,10 @@ func lookPathExcludingMulticaHooks(cmd string) (string, error) {
 		}
 		candidate := filepath.Join(dir, cmd)
 		if isExecutableFile(candidate) {
-			return canonicalExecutablePath(candidate), nil
+			return canonicalExecutable(candidate), nil
 		}
 	}
-	return "", exec.ErrNotFound
+	return resolvedExecutable{}, exec.ErrNotFound
 }
 
 func isInMulticaHooksDir(path string) bool {
@@ -707,6 +721,21 @@ func samePathDir(a, b string) bool {
 	return absA == absB
 }
 
+// resolvedExecutable is a pinned executable together with the PATH entries it
+// needs in order to run. The two travel as one result on purpose: Volta package
+// binaries are frequently `#!/usr/bin/env node` scripts, and Volta normally
+// supplies the Node platform bound to that package when it launches them
+// (upstream volta-core/src/run/binary.rs). Pinning only the path would leave the
+// version probe and the task launch to find *some* node on their own — a
+// different one per working directory, or none at all under a GUI-stripped PATH.
+// Keeping them together is what makes the gated version and the executed
+// version the same thing.
+type resolvedExecutable struct {
+	Path string
+	// PathDirs are prepended to PATH, highest priority first.
+	PathDirs []string
+}
+
 // voltaShimName is the basename of the single trampoline binary Volta installs
 // and symlinks EVERY managed command to (claude, codex, pi, ...). Upstream names
 // it "volta-shim[.exe]" (volta-layout/src/v1.rs, VoltaInstall.shim_executable),
@@ -714,14 +743,25 @@ func samePathDir(a, b string) bool {
 // (volta-core/src/shim.rs, unix create()).
 const voltaShimName = "volta-shim"
 
-// voltaResolveTimeout bounds the `volta which` call below. Resolution runs on
-// the startup/discovery path, so a wedged Volta install must not stall the
-// daemon: on timeout we fail closed and the provider simply stays unregistered.
-var voltaResolveTimeout = 5 * time.Second
+var (
+	// voltaResolveTimeout bounds a single `volta` invocation.
+	voltaResolveTimeout = 5 * time.Second
+	// voltaResolveBudget caps the TOTAL time one Volta install may cost across
+	// all commands before we stop asking it. Without this, N alias lookups
+	// against a wedged install each paid the per-call timeout and the startup
+	// probe stalled for N × timeout.
+	voltaResolveBudget = 8 * time.Second
+	// voltaFailureCooldown is how long a failing install is left alone. It turns
+	// "every command pays the timeout, every discovery tick" into "one command
+	// pays it, once per cooldown".
+	voltaFailureCooldown = 5 * time.Minute
+)
 
-// canonicalExecutablePath collapses path to the real file behind any symlinks,
-// so version-manager prefix dirs and other indirection settle onto one stable
-// path we can pin.
+// canonicalExecutable resolves path to the concrete executable to pin plus the
+// PATH entries required to run it.
+//
+// Symlinks are collapsed so version-manager prefix dirs and other indirection
+// settle onto one stable path we can pin.
 //
 // Volta needs a detour. It points every command it manages at one shared
 // volta-shim and picks the tool from the name it was invoked as — upstream
@@ -732,33 +772,37 @@ var voltaResolveTimeout = 5 * time.Second
 // exits 126 for any Volta error, which is the symptom reported in #6183. Volta
 // documents the same hazard from its own side in volta-cli/volta#579.
 //
-// So for a Volta alias we ask Volta itself for the concrete binary and pin that.
-// The tempting alternative — keep the alias path and let the shim dispatch —
-// breaks the {path, version} invariant the rest of the daemon relies on: the
-// shim resolves per current directory (`volta which` prefers a project-local
-// bin, src/command/which.rs), so the version verified at registration would not
-// be the version a task executes, and the minimum-version gate could be
-// bypassed. Pinning the concrete path keeps Volta installs on exactly the same
-// footing as every other install method.
+// So for a Volta alias we ask Volta itself for the concrete binary and pin that,
+// together with the Node platform directory it needs. Keeping the alias instead
+// and letting the shim dispatch would break the {path, version} invariant the
+// rest of the daemon relies on: the shim resolves per working directory, so the
+// version verified at registration would not be the version a task executes and
+// the minimum-version gate could be bypassed.
 //
 // Failing to resolve is deliberate: we return the shim path, version detection
 // fails as before, and the provider stays unregistered rather than being
 // launched through an ungated path. MULTICA_*_PATH remains the manual override.
-func canonicalExecutablePath(path string) string {
+func canonicalExecutable(path string) resolvedExecutable {
 	abs, err := filepath.Abs(path)
 	if err != nil {
-		return path
+		return resolvedExecutable{Path: path}
 	}
 	real, err := filepath.EvalSymlinks(abs)
 	if err != nil {
-		return abs
+		return resolvedExecutable{Path: abs}
 	}
 	if isVoltaShimPath(real) && !isVoltaShimPath(abs) {
-		if concrete, ok := voltaConcreteExecutable(real, filepath.Base(abs)); ok {
-			return concrete
+		if resolved, ok := voltaResolve(real, filepath.Base(abs)); ok {
+			return resolved
 		}
 	}
-	return real
+	return resolvedExecutable{Path: real}
+}
+
+// canonicalExecutablePath is the path-only form of canonicalExecutable, for
+// callers that pin a path without launching it.
+func canonicalExecutablePath(path string) string {
+	return canonicalExecutable(path).Path
 }
 
 // isVoltaShimPath reports whether path is Volta's shared shim. The accepted
@@ -776,69 +820,166 @@ func isVoltaShimPath(path string) bool {
 	return false
 }
 
+type voltaInstallState struct {
+	tools    map[string]resolvedExecutable // command -> resolution
+	nodeDir  string                        // Node platform dir, "" if unknown
+	nodeDone bool
+	spent    time.Duration // cumulative cost, against voltaResolveBudget
+	failedAt time.Time     // last failure, for the cooldown
+}
+
 var (
-	voltaResolveMu    sync.Mutex
-	voltaResolveCache = map[string]string{}
+	voltaMu     sync.Mutex
+	voltaStates = map[string]*voltaInstallState{}
 )
 
-// voltaConcreteExecutable asks Volta for the real binary behind command and
-// returns it only when the answer is an absolute, currently runnable path.
-//
-// `volta` lives in the same directory as volta-shim (both are VoltaInstall
-// entries), so we invoke it by absolute path instead of trusting PATH — the
-// daemon may not have Volta's bin dir at all.
-//
-// Answers are cached process-wide and revalidated by existence rather than a
-// TTL: probeAgentCLIs re-runs on every discovery tick, and a steady-state
-// daemon must not fork `volta which` forever. When Volta replaces the binary
-// and the cached path disappears, the entry is dropped and re-resolved, which
-// dovetails with the MUL-4486 self-heal.
-func voltaConcreteExecutable(shimPath, command string) (string, bool) {
-	// command comes from a filesystem basename; keep it to the same bare-name
-	// shape the shell resolver enforces so nothing flag-like reaches argv.
-	if !isSafeAgentName(command) {
-		return "", false
-	}
+// voltaExecutable returns the `volta` binary that belongs to shimPath. Both are
+// VoltaInstall entries, so they live in the same directory; we invoke it by
+// absolute path because the daemon may not have Volta's bin dir on PATH at all.
+func voltaExecutable(shimPath string) string {
 	voltaBin := filepath.Join(filepath.Dir(shimPath), "volta")
 	if runtime.GOOS == "windows" {
 		voltaBin += ".exe"
 	}
-	cacheKey := voltaBin + "\x00" + command
+	return voltaBin
+}
 
-	voltaResolveMu.Lock()
-	defer voltaResolveMu.Unlock()
-	if cached, ok := voltaResolveCache[cacheKey]; ok {
-		if isExecutableFile(cached) {
+// voltaNonProjectDir is where `volta` is invoked. Volta resolves a *project*
+// tool before the user default — upstream src/command/which.rs prefers
+// session.project().find_bin() — by walking up from the working directory
+// looking for a package.json. Inheriting the daemon's directory would therefore
+// let a daemon started inside a JS project pin that project's node_modules
+// binary as the machine-wide runtime. The filesystem root is the only directory
+// with no ancestor that could hold a package.json.
+func voltaNonProjectDir(voltaBin string) string {
+	if runtime.GOOS == "windows" {
+		if vol := filepath.VolumeName(voltaBin); vol != "" {
+			return vol + string(os.PathSeparator)
+		}
+	}
+	return string(os.PathSeparator)
+}
+
+// voltaResolve asks Volta for the concrete binary behind command, plus the Node
+// platform directory needed to run it, and caches the answer.
+//
+// Answers are revalidated by existence rather than a TTL: probeAgentCLIs re-runs
+// on every discovery tick, and a steady-state daemon must not fork `volta`
+// forever. When Volta replaces the binary and the cached path disappears, the
+// entry is dropped and re-resolved, which dovetails with the MUL-4486 self-heal.
+func voltaResolve(shimPath, command string) (resolvedExecutable, bool) {
+	// command comes from a filesystem basename; keep it to the same bare-name
+	// shape the shell resolver enforces so nothing flag-like reaches argv.
+	if !isSafeAgentName(command) {
+		return resolvedExecutable{}, false
+	}
+	voltaBin := voltaExecutable(shimPath)
+
+	voltaMu.Lock()
+	state := voltaStates[voltaBin]
+	if state == nil {
+		state = &voltaInstallState{tools: map[string]resolvedExecutable{}}
+		voltaStates[voltaBin] = state
+	}
+	if cached, ok := state.tools[command]; ok {
+		if isExecutableFile(cached.Path) {
+			voltaMu.Unlock()
 			return cached, true
 		}
-		delete(voltaResolveCache, cacheKey)
+		delete(state.tools, command)
 	}
+	// Circuit breaker: a wedged or broken install is asked once per cooldown,
+	// not once per command and not on every tick.
+	if !state.failedAt.IsZero() && time.Since(state.failedAt) < voltaFailureCooldown {
+		voltaMu.Unlock()
+		return resolvedExecutable{}, false
+	}
+	if state.spent >= voltaResolveBudget {
+		voltaMu.Unlock()
+		return resolvedExecutable{}, false
+	}
+	nodeDir, nodeDone := state.nodeDir, state.nodeDone
+	// Released for the subprocess below: holding it would serialize every
+	// command behind one timeout and make the stall additive.
+	voltaMu.Unlock()
+
 	if !isExecutableFile(voltaBin) {
-		return "", false
+		voltaMu.Lock()
+		state.failedAt = time.Now()
+		voltaMu.Unlock()
+		return resolvedExecutable{}, false
 	}
 
+	started := time.Now()
+	toolPath, toolOK := voltaWhich(voltaBin, command)
+	if toolOK && !nodeDone {
+		// One extra call per install, not per command: the Node platform dir is
+		// what makes an `env node` package script runnable.
+		nodeDir, _ = voltaNodeDir(voltaBin)
+		nodeDone = true
+	}
+	elapsed := time.Since(started)
+
+	voltaMu.Lock()
+	defer voltaMu.Unlock()
+	state.spent += elapsed
+	state.nodeDir, state.nodeDone = nodeDir, nodeDone
+	if !toolOK {
+		state.failedAt = time.Now()
+		return resolvedExecutable{}, false
+	}
+	state.failedAt = time.Time{}
+	resolved := resolvedExecutable{Path: toolPath}
+	if nodeDir != "" {
+		resolved.PathDirs = []string{nodeDir}
+	}
+	state.tools[command] = resolved
+	return resolved, true
+}
+
+// voltaWhich runs `volta which <command>` and returns the concrete path.
+func voltaWhich(voltaBin, command string) (string, bool) {
+	out, ok := runVolta(voltaBin, "which", command)
+	if !ok {
+		return "", false
+	}
+	// `volta which` prints nothing and exits non-zero when it cannot find the
+	// binary, so anything that is not a single absolute runnable path is a miss
+	// rather than something we should pin.
+	if out == "" || strings.ContainsAny(out, "\r\n") || !filepath.IsAbs(out) {
+		return "", false
+	}
+	if !isExecutableFile(out) {
+		return "", false
+	}
+	return out, true
+}
+
+// voltaNodeDir returns the directory of the Node that Volta runs package
+// binaries with. Resolved through the same public `volta which` interface (in
+// the same non-project directory) so it is the default toolchain's Node rather
+// than whatever a project pins.
+func voltaNodeDir(voltaBin string) (string, bool) {
+	nodePath, ok := voltaWhich(voltaBin, "node")
+	if !ok {
+		return "", false
+	}
+	return filepath.Dir(nodePath), true
+}
+
+func runVolta(voltaBin string, args ...string) (string, bool) {
 	ctx, cancel := context.WithTimeout(context.Background(), voltaResolveTimeout)
 	defer cancel()
-	cmd := exec.CommandContext(ctx, voltaBin, "which", command)
-	// Volta prints the path on stdout and diagnostics on stderr; Output()
+	cmd := exec.CommandContext(ctx, voltaBin, args...)
+	cmd.Dir = voltaNonProjectDir(voltaBin)
+	// Volta prints results on stdout and diagnostics on stderr; Output()
 	// captures only stdout. WaitDelay keeps a hung child from outliving ctx.
 	cmd.WaitDelay = time.Second
 	out, err := cmd.Output()
 	if err != nil {
 		return "", false
 	}
-	// `volta which` prints nothing and exits non-zero when it cannot find the
-	// binary, so anything that is not a single absolute runnable path is a miss
-	// rather than something we should pin.
-	resolved := strings.TrimSpace(string(out))
-	if resolved == "" || strings.ContainsAny(resolved, "\r\n") || !filepath.IsAbs(resolved) {
-		return "", false
-	}
-	if !isExecutableFile(resolved) {
-		return "", false
-	}
-	voltaResolveCache[cacheKey] = resolved
-	return resolved, true
+	return strings.TrimSpace(string(out)), true
 }
 
 func isExecutableFile(path string) bool {

--- a/server/internal/daemon/config.go
+++ b/server/internal/daemon/config.go
@@ -643,6 +643,38 @@ func agentExecutablePresent(path string) bool {
 	return err == nil
 }
 
+// agentEntryLaunchable reports whether entry can be launched exactly as it
+// stands: the executable resolves AND every directory its resolved environment
+// depends on still exists.
+//
+// Checking only the executable was not enough. A Volta upgrade that prunes the
+// old Node image leaves the CLI file in place, so a cached entry stayed
+// "present" while its PATH pointed at a directory that no longer existed —
+// every task then launched with a broken toolchain and nothing ever re-resolved.
+func agentEntryLaunchable(path string, env agent.ExecEnv) bool {
+	if !agentExecutablePresent(path) {
+		return false
+	}
+	return execEnvDirsPresent(env)
+}
+
+// execEnvDirsPresent reports whether the PATH directories an ExecEnv depends on
+// exist. NODE_PATH is advisory (Volta creates its shared dir lazily), so it is
+// not required.
+func execEnvDirsPresent(env agent.ExecEnv) bool {
+	for name, dirs := range env.PrefixPaths {
+		if name != "PATH" {
+			continue
+		}
+		for _, dir := range dirs {
+			if !dirExists(dir) {
+				return false
+			}
+		}
+	}
+	return true
+}
+
 // reresolveAgentCommand re-runs the startup resolution for a single agent
 // command name, returning the freshly resolved executable. It mirrors the
 // probe() order in LoadConfig: exec.LookPath (with the ~/.multica/hooks
@@ -868,33 +900,73 @@ func voltaHomeFromAlias(aliasPath string) (string, bool) {
 // voltaBinConfig is the subset of $VOLTA_HOME/tools/user/bins/<name>.json the
 // daemon needs. Volta records the platform a global package was installed
 // against and uses exactly that when launching it (binary.rs
-// DefaultBinary::from_config reads bin_config.platform.node), so the *current
-// default* Node is not a substitute: switching the default must not change which
-// Node a previously installed CLI runs under.
+// DefaultBinary::from_config), so the *current default* toolchain is not a
+// substitute: switching defaults must not change what a previously installed CLI
+// runs under.
 type voltaBinConfig struct {
 	Platform struct {
-		Node string `json:"node"`
+		Node string  `json:"node"`
+		Npm  *string `json:"npm"`
+		Pnpm *string `json:"pnpm"`
+		Yarn *string `json:"yarn"`
 	} `json:"platform"`
 }
 
-// voltaBoundNodeDir returns the bin directory of the Node that Volta bound to
-// command at install time.
-func voltaBoundNodeDir(voltaHome, command string) (string, bool) {
+// voltaPlatformDirs returns the PATH entries Volta puts in front for command, in
+// Volta's own order.
+//
+// Upstream Image::bins() pushes npm, then pnpm, then yarn, and Node LAST —
+// deliberately, "so that any custom version of npm will be earlier in the PATH"
+// (volta-core/src/platform/image.rs). Reproducing only Node would leave an agent
+// bound to a custom npm/pnpm/yarn unable to find it, or silently using the system
+// one.
+//
+// The Node image is required: it is what makes an `#!/usr/bin/env node` package
+// script runnable, and it anchors cache validity. A pinned package manager whose
+// image is missing is skipped rather than failing the whole resolution — an absent
+// directory on PATH has no effect on execution, and skipping it keeps validity
+// checks honest about what actually has to exist.
+func voltaPlatformDirs(voltaHome, command string) ([]string, bool) {
 	raw, err := os.ReadFile(filepath.Join(voltaHome, "tools", "user", "bins", command+".json"))
 	if err != nil {
-		return "", false
+		return nil, false
 	}
 	var cfg voltaBinConfig
 	if err := json.Unmarshal(raw, &cfg); err != nil {
-		return "", false
+		return nil, false
 	}
-	version := strings.TrimSpace(cfg.Platform.Node)
-	if version == "" {
-		return "", false
+	nodeVersion := strings.TrimSpace(cfg.Platform.Node)
+	if nodeVersion == "" {
+		return nil, false
 	}
-	imageDir := filepath.Join(voltaHome, "tools", "image", "node", version)
-	// Unix keeps the executables in <image>/bin; Windows puts them at the root of
-	// the image directory.
+
+	var dirs []string
+	for _, mgr := range []struct {
+		name    string
+		version *string
+	}{
+		{"npm", cfg.Platform.Npm},
+		{"pnpm", cfg.Platform.Pnpm},
+		{"yarn", cfg.Platform.Yarn},
+	} {
+		if mgr.version == nil || strings.TrimSpace(*mgr.version) == "" {
+			continue
+		}
+		if dir, ok := voltaImageBinDir(voltaHome, mgr.name, strings.TrimSpace(*mgr.version)); ok {
+			dirs = append(dirs, dir)
+		}
+	}
+	nodeDir, ok := voltaImageBinDir(voltaHome, "node", nodeVersion)
+	if !ok {
+		return nil, false
+	}
+	return append(dirs, nodeDir), true
+}
+
+// voltaImageBinDir locates the executables for one toolchain image. Unix keeps
+// them in <image>/bin; Windows puts them at the image root.
+func voltaImageBinDir(voltaHome, tool, version string) (string, bool) {
+	imageDir := filepath.Join(voltaHome, "tools", "image", tool, version)
 	if binDir := filepath.Join(imageDir, "bin"); dirExists(binDir) {
 		return binDir, true
 	}
@@ -917,18 +989,52 @@ func dirExists(path string) bool {
 }
 
 type voltaInstallState struct {
-	tools    map[string]resolvedExecutable // command -> resolution
-	spent    time.Duration                 // cost inside the current breaker window
-	failedAt time.Time                     // last failure, for the cooldown
+	tools map[string]resolvedExecutable // command -> resolution
+	// failureSpend accumulates ONLY failed or timed-out query time, inside the
+	// current breaker window. Counting successful queries too let a couple of slow
+	// but WORKING resolutions exhaust the budget; since success also clears
+	// failedAt, no cooldown could then fire and every later uncached command was
+	// refused for the life of the process.
+	failureSpend time.Duration
+	failedAt     time.Time
+	// queryMu serializes this installation's queries so the budget is enforced per
+	// installation rather than per command: without it several commands pass the
+	// budget check concurrently and each pays a full timeout.
+	queryMu sync.Mutex
 }
 
 var (
 	voltaMu     sync.Mutex
 	voltaStates = map[string]*voltaInstallState{}
-	// voltaGroup coalesces concurrent resolutions. Without it two tasks healing
-	// the same provider could both pass the budget check and each pay a timeout.
+	// voltaGroup coalesces identical concurrent resolutions.
 	voltaGroup singleflight.Group
 )
+
+// voltaStateKey identifies one Volta *installation*. It must include the home: a
+// Homebrew-style setup has several VOLTA_HOMEs sharing one volta-shim/volta pair,
+// so keying on the binary alone would let home B serve home A's cached tool paths
+// and environment. Symlinks are collapsed so two spellings of one home agree.
+func voltaStateKey(voltaHome, voltaBin string) string {
+	return canonicalDirKey(voltaHome) + "\x00" + canonicalDirKey(voltaBin)
+}
+
+func canonicalDirKey(path string) string {
+	if resolved, err := filepath.EvalSymlinks(path); err == nil {
+		return resolved
+	}
+	return filepath.Clean(path)
+}
+
+func voltaInstallStateFor(key string) *voltaInstallState {
+	voltaMu.Lock()
+	defer voltaMu.Unlock()
+	state := voltaStates[key]
+	if state == nil {
+		state = &voltaInstallState{tools: map[string]resolvedExecutable{}}
+		voltaStates[key] = state
+	}
+	return state
+}
 
 // voltaExecutable returns the `volta` binary that belongs to shimPath. Both are
 // VoltaInstall entries, so they live in the same directory; we invoke it by
@@ -977,65 +1083,97 @@ func voltaResolve(aliasPath, shimPath, command string) (resolvedExecutable, bool
 		return resolvedExecutable{}, false
 	}
 	voltaBin := voltaExecutable(shimPath)
+	stateKey := voltaStateKey(voltaHome, voltaBin)
+	state := voltaInstallStateFor(stateKey)
 
-	voltaMu.Lock()
-	state := voltaStates[voltaBin]
-	if state == nil {
-		state = &voltaInstallState{tools: map[string]resolvedExecutable{}}
-		voltaStates[voltaBin] = state
+	if cached, ok := voltaCachedTool(state, command); ok {
+		return cached, true
 	}
-	if cached, ok := state.tools[command]; ok {
-		if voltaResolutionUsable(cached) {
-			voltaMu.Unlock()
-			return cached, true
-		}
-		delete(state.tools, command)
-	}
-	// Circuit breaker. A cooldown that has expired also resets the spend budget:
-	// the budget bounds one window, not the process lifetime, so a couple of slow
-	// failures can never disable Volta resolution for good.
-	if !state.failedAt.IsZero() {
-		if time.Since(state.failedAt) < voltaFailureCooldown {
-			voltaMu.Unlock()
-			return resolvedExecutable{}, false
-		}
-		state.failedAt = time.Time{}
-		state.spent = 0
-	}
-	if state.spent >= voltaResolveBudget {
-		voltaMu.Unlock()
+	if !voltaBreakerAllows(state) {
 		return resolvedExecutable{}, false
 	}
-	voltaMu.Unlock()
-
 	if !isExecutableFile(voltaBin) {
-		voltaMu.Lock()
-		state.failedAt = time.Now()
-		voltaMu.Unlock()
+		voltaNoteFailure(state, 0)
 		return resolvedExecutable{}, false
 	}
 
-	// Coalesce concurrent work per (install, command): the first caller pays,
-	// the rest share its answer instead of each spawning a `volta`.
-	key := voltaBin + "\x00" + command
-	v, _, _ := voltaGroup.Do(key, func() (any, error) {
-		started := time.Now()
-		resolved, ok := voltaResolveUncached(voltaBin, voltaHome, command)
-		elapsed := time.Since(started)
+	// Coalesce identical concurrent requests, then serialize per installation so
+	// the budget below is an installation-wide bound rather than a per-command one.
+	v, _, _ := voltaGroup.Do(stateKey+"\x00"+command, func() (any, error) {
+		state.queryMu.Lock()
+		defer state.queryMu.Unlock()
 
-		voltaMu.Lock()
-		defer voltaMu.Unlock()
-		state.spent += elapsed
-		if !ok {
-			state.failedAt = time.Now()
+		// Re-check under the gate: a predecessor may have answered this command,
+		// or burned the budget, while we waited.
+		if cached, ok := voltaCachedTool(state, command); ok {
+			return cached, nil
+		}
+		if !voltaBreakerAllows(state) {
 			return resolvedExecutable{}, nil
 		}
-		state.failedAt = time.Time{}
-		state.tools[command] = resolved
+
+		started := time.Now()
+		resolved, ok := voltaResolveUncached(voltaBin, voltaHome, command)
+		if !ok {
+			voltaNoteFailure(state, time.Since(started))
+			return resolvedExecutable{}, nil
+		}
+		voltaNoteSuccess(state, command, resolved)
 		return resolved, nil
 	})
 	resolved, _ := v.(resolvedExecutable)
 	return resolved, resolved.Path != ""
+}
+
+// voltaCachedTool returns a cached resolution that is still runnable.
+func voltaCachedTool(state *voltaInstallState, command string) (resolvedExecutable, bool) {
+	voltaMu.Lock()
+	defer voltaMu.Unlock()
+	cached, ok := state.tools[command]
+	if !ok {
+		return resolvedExecutable{}, false
+	}
+	if voltaResolutionUsable(cached) {
+		return cached, true
+	}
+	delete(state.tools, command)
+	return resolvedExecutable{}, false
+}
+
+// voltaBreakerAllows reports whether this installation may be queried now.
+//
+// The budget bounds ONE cooldown window and counts only failures, so neither a
+// run of slow-but-working resolutions nor a transient outage can latch the
+// breaker permanently: an expired cooldown clears both halves.
+func voltaBreakerAllows(state *voltaInstallState) bool {
+	voltaMu.Lock()
+	defer voltaMu.Unlock()
+	if !state.failedAt.IsZero() {
+		if time.Since(state.failedAt) < voltaFailureCooldown {
+			return false
+		}
+		state.failedAt = time.Time{}
+		state.failureSpend = 0
+	}
+	return state.failureSpend < voltaResolveBudget
+}
+
+func voltaNoteFailure(state *voltaInstallState, elapsed time.Duration) {
+	voltaMu.Lock()
+	defer voltaMu.Unlock()
+	state.failureSpend += elapsed
+	state.failedAt = time.Now()
+}
+
+// voltaNoteSuccess records a working resolution. A success proves the install is
+// healthy, so it also clears the failure budget — and it deliberately does NOT
+// add its own duration to it.
+func voltaNoteSuccess(state *voltaInstallState, command string, resolved resolvedExecutable) {
+	voltaMu.Lock()
+	defer voltaMu.Unlock()
+	state.failedAt = time.Time{}
+	state.failureSpend = 0
+	state.tools[command] = resolved
 }
 
 // voltaResolveUncached performs the actual queries. Both halves must succeed.
@@ -1044,9 +1182,9 @@ func voltaResolveUncached(voltaBin, voltaHome, command string) (resolvedExecutab
 	if !ok {
 		return resolvedExecutable{}, false
 	}
-	nodeDir, ok := voltaBoundNodeDir(voltaHome, command)
+	platformDirs, ok := voltaPlatformDirs(voltaHome, command)
 	if !ok {
-		// Fail closed: without the bound Node we cannot reproduce the
+		// Fail closed: without the bound platform we cannot reproduce the
 		// environment Volta itself would use, so the version we verify would not
 		// be the version that runs.
 		return resolvedExecutable{}, false
@@ -1054,7 +1192,7 @@ func voltaResolveUncached(voltaBin, voltaHome, command string) (resolvedExecutab
 	return resolvedExecutable{
 		Path: toolPath,
 		Env: agent.ExecEnv{PrefixPaths: map[string][]string{
-			"PATH":      {nodeDir},
+			"PATH":      platformDirs,
 			"NODE_PATH": {voltaSharedLibDir(voltaHome)},
 		}},
 	}, true

--- a/server/internal/daemon/config.go
+++ b/server/internal/daemon/config.go
@@ -706,20 +706,29 @@ func samePathDir(a, b string) bool {
 }
 
 // voltaShimName is the basename of the single trampoline binary Volta installs
-// in ~/.volta/bin and symlinks EVERY managed command to (claude, codex, pi, ...).
+// and symlinks EVERY managed command to (claude, codex, pi, ...). Upstream names
+// it "volta-shim[.exe]" (volta-layout/src/v1.rs, VoltaInstall.shim_executable),
+// and on Unix each shim in $VOLTA_HOME/bin is a symlink to it
+// (volta-core/src/shim.rs, unix create()).
 const voltaShimName = "volta-shim"
 
 // canonicalExecutablePath collapses path to the real file behind any symlinks,
 // so version-manager prefix dirs and other indirection settle onto one stable
 // path we can pin.
 //
-// Exception: argv[0]-dispatching trampolines. Volta points every command it
-// manages at one shared volta-shim and decides which tool to run from the name
-// it was invoked as, so resolving `~/.volta/bin/claude` to `volta-shim` throws
-// away the only input that selects the tool — the shim then exits 126 and the
-// runtime never registers (#6183). For those we keep the caller's alias path,
-// which is also the stable one: the alias survives `volta install` upgrades
-// that replace the versioned binary underneath it.
+// Exception: argv[0]-dispatching trampolines. Volta decides which tool to run
+// from the name it was invoked as — volta-core/src/run/mod.rs get_tool_name()
+// takes file_name() of argv[0] — so resolving `~/.volta/bin/claude` to
+// volta-shim throws away the only input that selects the tool. Upstream then
+// fails the call outright (get_executor: `Some("volta-shim") =>
+// Err(ErrorKind::RunShimDirectly)`), and volta-shim's main exits 126 for any
+// Volta error, which is the exact symptom reported in #6183. Volta itself
+// documents this hazard in volta-cli/volta#579: fully resolving the symlink
+// before exec "loses the information about what tool was actually called".
+//
+// For those we keep the caller's alias path, which is also the stable one: the
+// alias survives `volta install` upgrades that replace the versioned binary
+// underneath it.
 //
 // This stays deliberately narrow. Skipping symlink resolution in general would
 // regress the PATH-drift pinning, the ~/.multica/hooks recursion guard, and the
@@ -743,8 +752,10 @@ func canonicalExecutablePath(path string) string {
 }
 
 // isVoltaShimPath reports whether path's basename is Volta's shared shim. The
-// extension is trimmed so volta-shim.exe matches on Windows, and the compare is
-// case-insensitive because macOS and Windows filesystems usually are.
+// extension is trimmed and the compare is case-insensitive, mirroring Volta's
+// own normalization on Windows (run/mod.rs tool_name_from_file_name lowercases
+// and strips ".exe"). In practice only the Unix layout reaches here, since
+// Windows shims are .cmd scripts rather than symlinks.
 func isVoltaShimPath(path string) bool {
 	if path == "" {
 		return false

--- a/server/internal/daemon/daemon.go
+++ b/server/internal/daemon/daemon.go
@@ -505,8 +505,11 @@ type healedAgent struct {
 	path    string
 	version string
 	// env travels with path/version so a reader that adopts the healed path also
-	// gets the environment that path was verified under.
-	env agent.ExecEnv
+	// gets the environment that path was verified under, and the stamp lets a later
+	// reader notice that the inputs behind that environment have changed.
+	env       agent.ExecEnv
+	stampPath string
+	stampHash string
 }
 
 // resolveAgentEntry returns entry with a usable executable path plus the CLI
@@ -553,13 +556,17 @@ func (d *Daemon) resolveAgentEntry(ctx context.Context, provider string, entry A
 	d.resolvedPathsMu.RLock()
 	healed, ok := d.resolvedPaths[provider]
 	d.resolvedPathsMu.RUnlock()
-	if ok && agentEntryLaunchable(healed.path, healed.env) {
-		entry.Path = healed.path
-		entry.Env = healed.env
-		return entry, healed.version
+	if ok {
+		healedEntry := entry
+		healedEntry.Path = healed.path
+		healedEntry.Env = healed.env
+		healedEntry.EnvStampPath, healedEntry.EnvStampHash = healed.stampPath, healed.stampHash
+		if agentEntryLaunchable(healedEntry) {
+			return healedEntry, healed.version
+		}
 	}
 
-	if agentEntryLaunchable(entry.Path, entry.Env) {
+	if agentEntryLaunchable(entry) {
 		return entry, d.agentVersion(provider)
 	}
 
@@ -624,7 +631,8 @@ func (d *Daemon) healAgentPath(ctx context.Context, provider, command string) he
 		return healedAgent{}
 	}
 
-	adopted := healedAgent{path: newPath.Path, version: version, env: newPath.Env}
+	adopted := healedAgent{path: newPath.Path, version: version, env: newPath.Env,
+		stampPath: newPath.StampPath, stampHash: newPath.StampHash}
 	// Publish path + version atomically: any reader that sees the new path in
 	// resolveAgentEntry gets the matching version out of the same struct value.
 	d.resolvedPathsMu.Lock()
@@ -4772,7 +4780,7 @@ func (d *Daemon) runTask(ctx context.Context, task Task, provider string, slot i
 	// codex is never launched under the previous version's policy (MUL-4486).
 	var resolvedVersion string
 	if customSpec, isCustom := d.customProfileLaunchForRuntime(task.RuntimeID); isCustom {
-		entry.Path = customSpec.path
+		entry = customProfileAgentEntry(entry, customSpec.path)
 		resolvedVersion = customSpec.version
 		profileFixedArgs = customSpec.fixedArgs
 		ok = true
@@ -6607,6 +6615,23 @@ func isBlockedEnvKey(key string) bool {
 		return true
 	}
 	return false
+}
+
+// customProfileAgentEntry builds the entry a custom runtime profile launches with,
+// from the built-in provider entry it replaces.
+//
+// Only Path used to be swapped, which left the built-in provider's resolved
+// execution environment attached. On a host running both a Volta-managed codex and
+// a Codex-family custom profile, the custom script was then launched under Volta's
+// Node platform for the BUILT-IN codex — wrong PATH and NODE_PATH. A custom command
+// is an unrelated executable, so it starts with no resolved environment; Command is
+// cleared too, since the built-in command name must never drive a re-resolve of a
+// custom path.
+func customProfileAgentEntry(builtin AgentEntry, path string) AgentEntry {
+	return AgentEntry{
+		Path:  path,
+		Model: builtin.Model,
+	}
 }
 
 // layerTaskEnvironment assembles the task environment: the agent's custom_env

--- a/server/internal/daemon/daemon.go
+++ b/server/internal/daemon/daemon.go
@@ -187,7 +187,7 @@ var (
 	// real agent helpers so tests can run the registration path without
 	// shelling out to a real CLI. Mirrors the pattern used for the brew
 	// helpers above.
-	detectAgentVersion   = agent.DetectVersion
+	detectAgentVersion   = agent.DetectVersionWithPathDirs
 	checkAgentMinVersion = agent.CheckMinVersion
 
 	// lookPath is an indirection over exec.LookPath so registration tests can
@@ -504,6 +504,9 @@ func (d *Daemon) agentVersion(provider string) string {
 type healedAgent struct {
 	path    string
 	version string
+	// pathDirs travels with path/version so a reader that adopts the healed
+	// path also gets the environment that path was verified under.
+	pathDirs []string
 }
 
 // resolveAgentEntry returns entry with a usable executable path plus the CLI
@@ -552,6 +555,7 @@ func (d *Daemon) resolveAgentEntry(ctx context.Context, provider string, entry A
 	d.resolvedPathsMu.RUnlock()
 	if ok && agentExecutablePresent(healed.path) {
 		entry.Path = healed.path
+		entry.PathDirs = healed.pathDirs
 		return entry, healed.version
 	}
 
@@ -575,6 +579,7 @@ func (d *Daemon) resolveAgentEntry(ctx context.Context, provider string, entry A
 		return entry, d.agentVersion(provider)
 	}
 	entry.Path = healed.path
+	entry.PathDirs = healed.pathDirs
 	return entry, healed.version
 }
 
@@ -607,19 +612,19 @@ func (d *Daemon) healAgentPath(ctx context.Context, provider, command string) he
 	// older or broken install must not be launched under the daemon's stale
 	// version policy, and must not slip past the minimum-version gate that the
 	// registration path applies (MUL-4486 review).
-	version, err := detectAgentVersion(ctx, newPath)
+	version, err := detectAgentVersion(ctx, newPath.Path, newPath.PathDirs)
 	if err != nil {
 		d.logger.Warn("re-resolved agent executable failed version detection; keeping pinned path",
-			"provider", provider, "command", command, "new_path", newPath, "error", err)
+			"provider", provider, "command", command, "new_path", newPath.Path, "error", err)
 		return healedAgent{}
 	}
 	if err := checkAgentMinVersion(provider, version); err != nil {
 		d.logger.Warn("re-resolved agent executable is below the minimum supported version; not adopting it",
-			"provider", provider, "command", command, "new_path", newPath, "version", version, "error", err)
+			"provider", provider, "command", command, "new_path", newPath.Path, "version", version, "error", err)
 		return healedAgent{}
 	}
 
-	adopted := healedAgent{path: newPath, version: version}
+	adopted := healedAgent{path: newPath.Path, version: version, pathDirs: newPath.PathDirs}
 	// Publish path + version atomically: any reader that sees the new path in
 	// resolveAgentEntry gets the matching version out of the same struct value.
 	d.resolvedPathsMu.Lock()
@@ -1455,7 +1460,7 @@ func (d *Daemon) probeBuiltinRuntime(ctx context.Context, name string, entry Age
 		// fixes: the upgrade that removed the old path may not have published
 		// the new one yet on the first attempt.
 		resolved, _ := d.resolveAgentEntry(ctx, name, entry)
-		version, err := detectAgentVersion(ctx, resolved.Path)
+		version, err := detectAgentVersion(ctx, resolved.Path, resolved.PathDirs)
 		if err != nil {
 			lastErr = err
 			if time.Since(startedAt) >= runtimeVersionProbeRetryWindow {
@@ -1805,7 +1810,9 @@ func (d *Daemon) appendProfileRuntimes(ctx context.Context, workspaceID string, 
 			resolved = r
 		}
 		// Best-effort version detection; an empty version is acceptable.
-		version, verErr := detectAgentVersion(ctx, resolved)
+		// Custom runtime profiles carry an absolute command path and no
+		// resolution-supplied environment.
+		version, verErr := detectAgentVersion(ctx, resolved, nil)
 		if verErr != nil {
 			d.logger.Debug("custom runtime profile: version probe failed (registering with empty version)",
 				"workspace_id", workspaceID, "profile_id", profile.ID, "path", resolved, "error", verErr)
@@ -5168,6 +5175,12 @@ func (d *Daemon) runTask(ctx context.Context, task Task, provider string, slot i
 		binDir := filepath.Dir(selfBin)
 		agentEnv["PATH"] = binDir + string(os.PathListSeparator) + os.Getenv("PATH")
 	}
+	// Apply the PATH entries that came out of executable resolution, so the task
+	// runs the CLI in the same environment its version was verified under. For a
+	// Volta package binary this is the Node platform Volta bound to it; without
+	// it an `#!/usr/bin/env node` script would pick up whatever node the task's
+	// directory happens to resolve, or none at all.
+	agent.PrependPathDirs(agentEnv, entry.PathDirs)
 	// Point Codex to the per-task CODEX_HOME so it discovers skills natively
 	// without polluting the system ~/.codex/skills/.
 	if env.CodexHome != "" {

--- a/server/internal/daemon/daemon.go
+++ b/server/internal/daemon/daemon.go
@@ -187,7 +187,7 @@ var (
 	// real agent helpers so tests can run the registration path without
 	// shelling out to a real CLI. Mirrors the pattern used for the brew
 	// helpers above.
-	detectAgentVersion   = agent.DetectVersionWithPathDirs
+	detectAgentVersion   = agent.DetectVersionWithEnv
 	checkAgentMinVersion = agent.CheckMinVersion
 
 	// lookPath is an indirection over exec.LookPath so registration tests can
@@ -504,9 +504,9 @@ func (d *Daemon) agentVersion(provider string) string {
 type healedAgent struct {
 	path    string
 	version string
-	// pathDirs travels with path/version so a reader that adopts the healed
-	// path also gets the environment that path was verified under.
-	pathDirs []string
+	// env travels with path/version so a reader that adopts the healed path also
+	// gets the environment that path was verified under.
+	env agent.ExecEnv
 }
 
 // resolveAgentEntry returns entry with a usable executable path plus the CLI
@@ -555,7 +555,7 @@ func (d *Daemon) resolveAgentEntry(ctx context.Context, provider string, entry A
 	d.resolvedPathsMu.RUnlock()
 	if ok && agentExecutablePresent(healed.path) {
 		entry.Path = healed.path
-		entry.PathDirs = healed.pathDirs
+		entry.Env = healed.env
 		return entry, healed.version
 	}
 
@@ -579,7 +579,7 @@ func (d *Daemon) resolveAgentEntry(ctx context.Context, provider string, entry A
 		return entry, d.agentVersion(provider)
 	}
 	entry.Path = healed.path
-	entry.PathDirs = healed.pathDirs
+	entry.Env = healed.env
 	return entry, healed.version
 }
 
@@ -612,7 +612,7 @@ func (d *Daemon) healAgentPath(ctx context.Context, provider, command string) he
 	// older or broken install must not be launched under the daemon's stale
 	// version policy, and must not slip past the minimum-version gate that the
 	// registration path applies (MUL-4486 review).
-	version, err := detectAgentVersion(ctx, newPath.Path, newPath.PathDirs)
+	version, err := detectAgentVersion(ctx, newPath.Path, newPath.Env)
 	if err != nil {
 		d.logger.Warn("re-resolved agent executable failed version detection; keeping pinned path",
 			"provider", provider, "command", command, "new_path", newPath.Path, "error", err)
@@ -624,7 +624,7 @@ func (d *Daemon) healAgentPath(ctx context.Context, provider, command string) he
 		return healedAgent{}
 	}
 
-	adopted := healedAgent{path: newPath.Path, version: version, pathDirs: newPath.PathDirs}
+	adopted := healedAgent{path: newPath.Path, version: version, env: newPath.Env}
 	// Publish path + version atomically: any reader that sees the new path in
 	// resolveAgentEntry gets the matching version out of the same struct value.
 	d.resolvedPathsMu.Lock()
@@ -1460,7 +1460,7 @@ func (d *Daemon) probeBuiltinRuntime(ctx context.Context, name string, entry Age
 		// fixes: the upgrade that removed the old path may not have published
 		// the new one yet on the first attempt.
 		resolved, _ := d.resolveAgentEntry(ctx, name, entry)
-		version, err := detectAgentVersion(ctx, resolved.Path, resolved.PathDirs)
+		version, err := detectAgentVersion(ctx, resolved.Path, resolved.Env)
 		if err != nil {
 			lastErr = err
 			if time.Since(startedAt) >= runtimeVersionProbeRetryWindow {
@@ -1812,7 +1812,7 @@ func (d *Daemon) appendProfileRuntimes(ctx context.Context, workspaceID string, 
 		// Best-effort version detection; an empty version is acceptable.
 		// Custom runtime profiles carry an absolute command path and no
 		// resolution-supplied environment.
-		version, verErr := detectAgentVersion(ctx, resolved, nil)
+		version, verErr := detectAgentVersion(ctx, resolved, agent.ExecEnv{})
 		if verErr != nil {
 			d.logger.Debug("custom runtime profile: version probe failed (registering with empty version)",
 				"workspace_id", workspaceID, "profile_id", profile.ID, "path", resolved, "error", verErr)
@@ -2929,7 +2929,7 @@ func (d *Daemon) handleModelList(ctx context.Context, rt Runtime, requestID stri
 	// Self-heal a pinned executable path an in-place upgrade deleted (MUL-4486).
 	entry, _ = d.resolveAgentEntry(ctx, rt.Provider, entry)
 
-	catalog, err := agent.ListModels(ctx, rt.Provider, entry.Path)
+	catalog, err := agent.ListModelsWithEnv(ctx, rt.Provider, entry.Path, entry.Env)
 	if err != nil {
 		d.reportModelListResult(ctx, rt, requestID, map[string]any{
 			"status": "failed",
@@ -5180,7 +5180,7 @@ func (d *Daemon) runTask(ctx context.Context, task Task, provider string, slot i
 	// Volta package binary this is the Node platform Volta bound to it; without
 	// it an `#!/usr/bin/env node` script would pick up whatever node the task's
 	// directory happens to resolve, or none at all.
-	agent.PrependPathDirs(agentEnv, entry.PathDirs)
+	entry.Env.ApplyToMap(agentEnv)
 	// Point Codex to the per-task CODEX_HOME so it discovers skills natively
 	// without polluting the system ~/.codex/skills/.
 	if env.CodexHome != "" {
@@ -5296,7 +5296,7 @@ func (d *Daemon) runTask(ctx context.Context, task Task, provider string, slot i
 	// through so a transient discovery failure does not silently disable a
 	// previously valid user choice.
 	if serviceTier != "" {
-		ok, err := agent.ValidateServiceTier(ctx, provider, entry.Path, model, serviceTier)
+		ok, err := agent.ValidateServiceTierWithEnv(ctx, provider, entry.Path, model, serviceTier, entry.Env)
 		if err != nil {
 			taskLog.Warn("service_tier: catalog lookup failed; passing through",
 				"provider", provider,
@@ -5325,7 +5325,7 @@ func (d *Daemon) runTask(ctx context.Context, task Task, provider string, slot i
 	// level here. Discovery errors fail open for resolved models: if we can't
 	// list models, we keep the persisted level and let the CLI object.
 	if thinkingLevel != "" {
-		ok, err := agent.ValidateThinkingLevel(ctx, provider, entry.Path, model, thinkingLevel)
+		ok, err := agent.ValidateThinkingLevelWithEnv(ctx, provider, entry.Path, model, thinkingLevel, entry.Env)
 		if err != nil {
 			taskLog.Warn("thinking_level: catalog lookup failed; passing through",
 				"provider", provider,

--- a/server/internal/daemon/daemon.go
+++ b/server/internal/daemon/daemon.go
@@ -553,13 +553,13 @@ func (d *Daemon) resolveAgentEntry(ctx context.Context, provider string, entry A
 	d.resolvedPathsMu.RLock()
 	healed, ok := d.resolvedPaths[provider]
 	d.resolvedPathsMu.RUnlock()
-	if ok && agentExecutablePresent(healed.path) {
+	if ok && agentEntryLaunchable(healed.path, healed.env) {
 		entry.Path = healed.path
 		entry.Env = healed.env
 		return entry, healed.version
 	}
 
-	if agentExecutablePresent(entry.Path) {
+	if agentEntryLaunchable(entry.Path, entry.Env) {
 		return entry, d.agentVersion(provider)
 	}
 
@@ -5175,12 +5175,6 @@ func (d *Daemon) runTask(ctx context.Context, task Task, provider string, slot i
 		binDir := filepath.Dir(selfBin)
 		agentEnv["PATH"] = binDir + string(os.PathListSeparator) + os.Getenv("PATH")
 	}
-	// Apply the PATH entries that came out of executable resolution, so the task
-	// runs the CLI in the same environment its version was verified under. For a
-	// Volta package binary this is the Node platform Volta bound to it; without
-	// it an `#!/usr/bin/env node` script would pick up whatever node the task's
-	// directory happens to resolve, or none at all.
-	entry.Env.ApplyToMap(agentEnv)
 	// Point Codex to the per-task CODEX_HOME so it discovers skills natively
 	// without polluting the system ~/.codex/skills/.
 	if env.CodexHome != "" {
@@ -5225,7 +5219,7 @@ func (d *Daemon) runTask(ctx context.Context, task Task, provider string, slot i
 	if task.Agent != nil {
 		agentCustomEnv = task.Agent.CustomEnv
 	}
-	layerCustomEnvAndHermesHome(agentEnv, agentCustomEnv, env.HermesHome, d.logger)
+	layerTaskEnvironment(agentEnv, agentCustomEnv, env.HermesHome, entry.Env, d.logger)
 	if err := configureCodexTaskShellEnvironment(provider, env.CodexHome, os.Environ(), agentEnv, agentCustomEnv, d.logger); err != nil {
 		return TaskResult{}, err
 	}
@@ -6613,6 +6607,21 @@ func isBlockedEnvKey(key string) bool {
 		return true
 	}
 	return false
+}
+
+// layerTaskEnvironment assembles the task environment: the agent's custom_env
+// first, then the execution environment that came out of path resolution.
+//
+// The order is the contract. ExecEnv *prefixes* list-shaped variables, so applying
+// it last both guarantees the toolchain wins and preserves whatever the user set:
+// a custom NODE_PATH ends up after Volta's shared lib dir instead of replacing it.
+// Applied before custom_env, a user-supplied NODE_PATH would overwrite the prefix
+// outright and an `#!/usr/bin/env node` package binary would lose the modules
+// Volta puts there. (PATH is already blocked from custom_env, but NODE_PATH is
+// not, which is exactly the case this ordering protects.)
+func layerTaskEnvironment(agentEnv, customEnv map[string]string, overlayHome string, execEnv agent.ExecEnv, logger *slog.Logger) {
+	layerCustomEnvAndHermesHome(agentEnv, customEnv, overlayHome, logger)
+	execEnv.ApplyToMap(agentEnv)
 }
 
 // layerCustomEnvAndHermesHome applies the agent's custom_env onto the child env

--- a/server/internal/daemon/runtime_gone_test.go
+++ b/server/internal/daemon/runtime_gone_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"github.com/multica-ai/multica/server/pkg/agent"
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
@@ -45,7 +46,7 @@ func stubAgentVersion(t *testing.T) func() {
 	t.Helper()
 	origDetect := detectAgentVersion
 	origCheck := checkAgentMinVersion
-	detectAgentVersion = func(_ context.Context, _ string, _ []string) (string, error) {
+	detectAgentVersion = func(_ context.Context, _ string, _ agent.ExecEnv) (string, error) {
 		return "9.9.9", nil
 	}
 	checkAgentMinVersion = func(_, _ string) error { return nil }

--- a/server/internal/daemon/runtime_gone_test.go
+++ b/server/internal/daemon/runtime_gone_test.go
@@ -45,7 +45,7 @@ func stubAgentVersion(t *testing.T) func() {
 	t.Helper()
 	origDetect := detectAgentVersion
 	origCheck := checkAgentMinVersion
-	detectAgentVersion = func(_ context.Context, _ string) (string, error) {
+	detectAgentVersion = func(_ context.Context, _ string, _ []string) (string, error) {
 		return "9.9.9", nil
 	}
 	checkAgentMinVersion = func(_, _ string) error { return nil }

--- a/server/internal/daemon/runtime_probe_batch_test.go
+++ b/server/internal/daemon/runtime_probe_batch_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"github.com/multica-ai/multica/server/pkg/agent"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -151,7 +152,7 @@ func newBatchFixture(t *testing.T) *batchFixture {
 		detectAgentVersion = origDetect
 		checkAgentMinVersion = origCheck
 	})
-	detectAgentVersion = func(_ context.Context, path string, _ []string) (string, error) {
+	detectAgentVersion = func(_ context.Context, path string, _ agent.ExecEnv) (string, error) {
 		fx.mu.Lock()
 		fx.probes[path]++
 		attempt := fx.probes[path]
@@ -522,7 +523,7 @@ func countingVersionProbe(t *testing.T, answer func(path string) (string, error)
 		checkAgentMinVersion = origCheck
 	})
 	var probes atomic.Int32
-	detectAgentVersion = func(_ context.Context, path string, _ []string) (string, error) {
+	detectAgentVersion = func(_ context.Context, path string, _ agent.ExecEnv) (string, error) {
 		probes.Add(1)
 		return answer(path)
 	}

--- a/server/internal/daemon/runtime_probe_batch_test.go
+++ b/server/internal/daemon/runtime_probe_batch_test.go
@@ -151,7 +151,7 @@ func newBatchFixture(t *testing.T) *batchFixture {
 		detectAgentVersion = origDetect
 		checkAgentMinVersion = origCheck
 	})
-	detectAgentVersion = func(_ context.Context, path string) (string, error) {
+	detectAgentVersion = func(_ context.Context, path string, _ []string) (string, error) {
 		fx.mu.Lock()
 		fx.probes[path]++
 		attempt := fx.probes[path]
@@ -522,7 +522,7 @@ func countingVersionProbe(t *testing.T, answer func(path string) (string, error)
 		checkAgentMinVersion = origCheck
 	})
 	var probes atomic.Int32
-	detectAgentVersion = func(_ context.Context, path string) (string, error) {
+	detectAgentVersion = func(_ context.Context, path string, _ []string) (string, error) {
 		probes.Add(1)
 		return answer(path)
 	}

--- a/server/internal/daemon/runtime_probe_concurrency_test.go
+++ b/server/internal/daemon/runtime_probe_concurrency_test.go
@@ -22,7 +22,7 @@ func TestDetectBuiltinRuntimes_ProbesRunConcurrently(t *testing.T) {
 
 	const probeBlock = 100 * time.Millisecond
 	var inFlight, maxInFlight int32
-	detectAgentVersion = func(_ context.Context, _ string) (string, error) {
+	detectAgentVersion = func(_ context.Context, _ string, _ []string) (string, error) {
 		cur := atomic.AddInt32(&inFlight, 1)
 		for {
 			prev := atomic.LoadInt32(&maxInFlight)
@@ -83,7 +83,7 @@ func TestDetectBuiltinRuntimes_SkipsFailedProbes(t *testing.T) {
 		checkAgentMinVersion = origCheck
 	})
 
-	detectAgentVersion = func(_ context.Context, path string) (string, error) {
+	detectAgentVersion = func(_ context.Context, path string, _ []string) (string, error) {
 		if path == "/broken" {
 			return "", context.DeadlineExceeded
 		}

--- a/server/internal/daemon/runtime_probe_concurrency_test.go
+++ b/server/internal/daemon/runtime_probe_concurrency_test.go
@@ -2,6 +2,7 @@ package daemon
 
 import (
 	"context"
+	"github.com/multica-ai/multica/server/pkg/agent"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -22,7 +23,7 @@ func TestDetectBuiltinRuntimes_ProbesRunConcurrently(t *testing.T) {
 
 	const probeBlock = 100 * time.Millisecond
 	var inFlight, maxInFlight int32
-	detectAgentVersion = func(_ context.Context, _ string, _ []string) (string, error) {
+	detectAgentVersion = func(_ context.Context, _ string, _ agent.ExecEnv) (string, error) {
 		cur := atomic.AddInt32(&inFlight, 1)
 		for {
 			prev := atomic.LoadInt32(&maxInFlight)
@@ -83,7 +84,7 @@ func TestDetectBuiltinRuntimes_SkipsFailedProbes(t *testing.T) {
 		checkAgentMinVersion = origCheck
 	})
 
-	detectAgentVersion = func(_ context.Context, path string, _ []string) (string, error) {
+	detectAgentVersion = func(_ context.Context, path string, _ agent.ExecEnv) (string, error) {
 		if path == "/broken" {
 			return "", context.DeadlineExceeded
 		}

--- a/server/internal/daemon/types.go
+++ b/server/internal/daemon/types.go
@@ -18,6 +18,14 @@ type AgentEntry struct {
 	// Daemon.resolveAgentEntry and MUL-4486.
 	Command string
 	Model   string // model override (optional)
+	// PathDirs are directories that must be prepended to PATH for this
+	// executable to run, produced by the same resolution step that produced
+	// Path. Volta package binaries are the motivating case: they are often
+	// `#!/usr/bin/env node` scripts that only work with the Node platform Volta
+	// bound to the package. Both the registration version probe and the task
+	// launch apply these, so the gated version is the executed version.
+	// Empty for the ordinary case.
+	PathDirs []string
 }
 
 // Runtime represents a registered daemon runtime.

--- a/server/internal/daemon/types.go
+++ b/server/internal/daemon/types.go
@@ -1,5 +1,7 @@
 package daemon
 
+import "github.com/multica-ai/multica/server/pkg/agent"
+
 import (
 	"encoding/json"
 
@@ -18,14 +20,14 @@ type AgentEntry struct {
 	// Daemon.resolveAgentEntry and MUL-4486.
 	Command string
 	Model   string // model override (optional)
-	// PathDirs are directories that must be prepended to PATH for this
-	// executable to run, produced by the same resolution step that produced
-	// Path. Volta package binaries are the motivating case: they are often
-	// `#!/usr/bin/env node` scripts that only work with the Node platform Volta
-	// bound to the package. Both the registration version probe and the task
-	// launch apply these, so the gated version is the executed version.
-	// Empty for the ordinary case.
-	PathDirs []string
+	// Env is the environment this executable needs in order to run, produced by
+	// the same resolution step that produced Path. Volta package binaries are the
+	// motivating case: they are often `#!/usr/bin/env node` scripts that only work
+	// with the Node platform Volta bound to the package plus its shared NODE_PATH.
+	// Every consumer that executes the CLI — the registration version probe, model
+	// discovery, the service-tier/thinking validators and the task launch — applies
+	// it, so the gated version is the executed version. Zero for the ordinary case.
+	Env agent.ExecEnv
 }
 
 // Runtime represents a registered daemon runtime.

--- a/server/internal/daemon/types.go
+++ b/server/internal/daemon/types.go
@@ -28,6 +28,12 @@ type AgentEntry struct {
 	// discovery, the service-tier/thinking validators and the task launch — applies
 	// it, so the gated version is the executed version. Zero for the ordinary case.
 	Env agent.ExecEnv
+	// EnvStampPath / EnvStampHash fingerprint the file whose contents produced Env
+	// (Volta's bin config). They let a cached entry notice a REBIND — a package
+	// reinstalled against a different Node — which no existence check can see
+	// because the previous toolchain image usually remains on disk.
+	EnvStampPath string
+	EnvStampHash string
 }
 
 // Runtime represents a registered daemon runtime.

--- a/server/pkg/agent/agent.go
+++ b/server/pkg/agent/agent.go
@@ -10,6 +10,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"log/slog"
+	"os"
+	"strings"
 	"time"
 )
 
@@ -342,6 +344,55 @@ func New(agentType string, cfg Config) (Backend, error) {
 // DetectVersion runs the agent CLI with --version and returns the output.
 func DetectVersion(ctx context.Context, executablePath string) (string, error) {
 	return detectCLIVersion(ctx, executablePath)
+}
+
+// DetectVersionWithPathDirs is DetectVersion with pathDirs prepended to PATH,
+// for executables that only run under a specific toolchain directory (a Volta
+// package binary needs the Node platform Volta bound to it). Callers pass the
+// same dirs they will use at launch so the gated version is the executed one.
+func DetectVersionWithPathDirs(ctx context.Context, executablePath string, pathDirs []string) (string, error) {
+	return detectCLIVersionWithPathDirs(ctx, executablePath, pathDirs)
+}
+
+// PrependPathDirs returns env with dirs prepended to its PATH entry, preserving
+// the rest of the environment. Exported so the daemon builds task environments
+// the same way the version probe does.
+func PrependPathDirs(env map[string]string, dirs []string) {
+	if len(dirs) == 0 {
+		return
+	}
+	joined := strings.Join(dirs, string(os.PathListSeparator))
+	existing := env["PATH"]
+	if existing == "" {
+		existing = os.Getenv("PATH")
+	}
+	if existing == "" {
+		env["PATH"] = joined
+		return
+	}
+	env["PATH"] = joined + string(os.PathListSeparator) + existing
+}
+
+// envWithPathDirs returns a copy of environ with dirs prepended to PATH.
+func envWithPathDirs(environ []string, dirs []string) []string {
+	if len(dirs) == 0 {
+		return environ
+	}
+	joined := strings.Join(dirs, string(os.PathListSeparator))
+	out := make([]string, 0, len(environ)+1)
+	replaced := false
+	for _, kv := range environ {
+		if name, value, ok := strings.Cut(kv, "="); ok && strings.EqualFold(name, "PATH") {
+			out = append(out, name+"="+joined+string(os.PathListSeparator)+value)
+			replaced = true
+			continue
+		}
+		out = append(out, kv)
+	}
+	if !replaced {
+		out = append(out, "PATH="+joined)
+	}
+	return out
 }
 
 // launchHeaders maps each supported agent type to the user-visible skeleton

--- a/server/pkg/agent/agent.go
+++ b/server/pkg/agent/agent.go
@@ -10,8 +10,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"log/slog"
-	"os"
-	"strings"
 	"time"
 )
 
@@ -346,53 +344,13 @@ func DetectVersion(ctx context.Context, executablePath string) (string, error) {
 	return detectCLIVersion(ctx, executablePath)
 }
 
-// DetectVersionWithPathDirs is DetectVersion with pathDirs prepended to PATH,
-// for executables that only run under a specific toolchain directory (a Volta
-// package binary needs the Node platform Volta bound to it). Callers pass the
-// same dirs they will use at launch so the gated version is the executed one.
-func DetectVersionWithPathDirs(ctx context.Context, executablePath string, pathDirs []string) (string, error) {
-	return detectCLIVersionWithPathDirs(ctx, executablePath, pathDirs)
-}
-
-// PrependPathDirs returns env with dirs prepended to its PATH entry, preserving
-// the rest of the environment. Exported so the daemon builds task environments
-// the same way the version probe does.
-func PrependPathDirs(env map[string]string, dirs []string) {
-	if len(dirs) == 0 {
-		return
-	}
-	joined := strings.Join(dirs, string(os.PathListSeparator))
-	existing := env["PATH"]
-	if existing == "" {
-		existing = os.Getenv("PATH")
-	}
-	if existing == "" {
-		env["PATH"] = joined
-		return
-	}
-	env["PATH"] = joined + string(os.PathListSeparator) + existing
-}
-
-// envWithPathDirs returns a copy of environ with dirs prepended to PATH.
-func envWithPathDirs(environ []string, dirs []string) []string {
-	if len(dirs) == 0 {
-		return environ
-	}
-	joined := strings.Join(dirs, string(os.PathListSeparator))
-	out := make([]string, 0, len(environ)+1)
-	replaced := false
-	for _, kv := range environ {
-		if name, value, ok := strings.Cut(kv, "="); ok && strings.EqualFold(name, "PATH") {
-			out = append(out, name+"="+joined+string(os.PathListSeparator)+value)
-			replaced = true
-			continue
-		}
-		out = append(out, kv)
-	}
-	if !replaced {
-		out = append(out, "PATH="+joined)
-	}
-	return out
+// DetectVersionWithEnv is DetectVersion with an execution environment applied,
+// for executables that only run under a specific toolchain (a Volta package
+// binary needs the Node platform Volta bound to it plus its shared NODE_PATH).
+// Callers pass the same ExecEnv they will use at launch so the gated version is
+// the executed one.
+func DetectVersionWithEnv(ctx context.Context, executablePath string, env ExecEnv) (string, error) {
+	return detectCLIVersionWithEnv(ctx, executablePath, env)
 }
 
 // launchHeaders maps each supported agent type to the user-visible skeleton

--- a/server/pkg/agent/claude.go
+++ b/server/pkg/agent/claude.go
@@ -1058,10 +1058,22 @@ func cleanupMcpConfigTemp(path string) {
 var detectVersionTimeout = 10 * time.Second
 
 func detectCLIVersion(ctx context.Context, execPath string) (string, error) {
+	return detectCLIVersionWithPathDirs(ctx, execPath, nil)
+}
+
+// detectCLIVersionWithPathDirs runs `<execPath> --version` with pathDirs
+// prepended to PATH. The probe must use the same environment the task launch
+// will, or the version this gates on is not the version that ends up running:
+// a Volta package binary is often a `#!/usr/bin/env node` script that resolves
+// a different node — or no node at all — under a different PATH.
+func detectCLIVersionWithPathDirs(ctx context.Context, execPath string, pathDirs []string) (string, error) {
 	ctx, cancel := context.WithTimeout(ctx, detectVersionTimeout)
 	defer cancel()
 
 	cmd := exec.CommandContext(ctx, execPath, "--version")
+	if len(pathDirs) > 0 {
+		cmd.Env = envWithPathDirs(os.Environ(), pathDirs)
+	}
 	hideAgentWindow(cmd)
 	// exec.CommandContext only kills the direct child on timeout. A broken CLI
 	// (node/bun shim) can leave grandchildren that inherited and still hold our

--- a/server/pkg/agent/claude.go
+++ b/server/pkg/agent/claude.go
@@ -1058,22 +1058,19 @@ func cleanupMcpConfigTemp(path string) {
 var detectVersionTimeout = 10 * time.Second
 
 func detectCLIVersion(ctx context.Context, execPath string) (string, error) {
-	return detectCLIVersionWithPathDirs(ctx, execPath, nil)
+	return detectCLIVersionWithEnv(ctx, execPath, ExecEnv{})
 }
 
-// detectCLIVersionWithPathDirs runs `<execPath> --version` with pathDirs
-// prepended to PATH. The probe must use the same environment the task launch
-// will, or the version this gates on is not the version that ends up running:
-// a Volta package binary is often a `#!/usr/bin/env node` script that resolves
-// a different node — or no node at all — under a different PATH.
-func detectCLIVersionWithPathDirs(ctx context.Context, execPath string, pathDirs []string) (string, error) {
+// detectCLIVersionWithEnv runs `<execPath> --version` under env. The probe must
+// use the same environment the task launch will, or the version this gates on is
+// not the version that ends up running: a Volta package binary is often a
+// `#!/usr/bin/env node` script that resolves a different node — or no node at
+// all — under a different environment.
+func detectCLIVersionWithEnv(ctx context.Context, execPath string, env ExecEnv) (string, error) {
 	ctx, cancel := context.WithTimeout(ctx, detectVersionTimeout)
 	defer cancel()
 
-	cmd := exec.CommandContext(ctx, execPath, "--version")
-	if len(pathDirs) > 0 {
-		cmd.Env = envWithPathDirs(os.Environ(), pathDirs)
-	}
+	cmd := env.command(ctx, execPath, "--version")
 	hideAgentWindow(cmd)
 	// exec.CommandContext only kills the direct child on timeout. A broken CLI
 	// (node/bun shim) can leave grandchildren that inherited and still hold our

--- a/server/pkg/agent/codebuddy_discovery_fallback_test.go
+++ b/server/pkg/agent/codebuddy_discovery_fallback_test.go
@@ -85,7 +85,7 @@ func TestDiscoverCodebuddyModelsFromACP(t *testing.T) {
 	resetCodebuddyDiscoveryCaches(t)
 	path := writeCodebuddyACPStub(t, codebuddyACPSessionResult)
 
-	catalog, err := discoverCodebuddyModels(context.Background(), path)
+	catalog, err := discoverCodebuddyModels(context.Background(), path, ExecEnv{})
 	if err != nil {
 		t.Fatalf("discoverCodebuddyModels: %v", err)
 	}
@@ -184,7 +184,7 @@ func TestDiscoverCodebuddyModelsACPEffort(t *testing.T) {
 	resetCodebuddyDiscoveryCaches(t)
 	path := writeCodebuddyACPStub(t, codebuddyACPSessionResult)
 
-	catalog, err := discoverCodebuddyModels(context.Background(), path)
+	catalog, err := discoverCodebuddyModels(context.Background(), path, ExecEnv{})
 	if err != nil {
 		t.Fatalf("discoverCodebuddyModels: %v", err)
 	}
@@ -252,7 +252,7 @@ func TestDiscoverCodebuddyModelsFallsBackOnACPFailure(t *testing.T) {
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			resetCodebuddyDiscoveryCaches(t)
-			catalog, err := discoverCodebuddyModels(context.Background(), tc.path(t))
+			catalog, err := discoverCodebuddyModels(context.Background(), tc.path(t), ExecEnv{})
 			if err != nil {
 				t.Fatalf("discoverCodebuddyModels: %v", err)
 			}

--- a/server/pkg/agent/deveco_models.go
+++ b/server/pkg/agent/deveco_models.go
@@ -17,7 +17,7 @@ import (
 // the DevEco Code CLI and parses `provider/model` rows. Discovery failures
 // (binary missing, non-zero exit, unparseable output) silently yield an empty
 // list so model selection degrades to manual entry rather than blocking.
-func discoverDevecoModels(ctx context.Context, executablePath string) ([]Model, error) {
+func discoverDevecoModels(ctx context.Context, executablePath string, env ExecEnv) ([]Model, error) {
 	if executablePath == "" {
 		executablePath = "deveco"
 	}
@@ -28,7 +28,7 @@ func discoverDevecoModels(ctx context.Context, executablePath string) ([]Model, 
 	// run; allow a generous timeout so the picker isn't empty on a cold start.
 	runCtx, cancel := context.WithTimeout(ctx, 15*time.Second)
 	defer cancel()
-	cmd := exec.CommandContext(runCtx, executablePath, "models")
+	cmd := env.command(runCtx, executablePath, "models")
 	hideAgentWindow(cmd)
 	out, _ := cmd.Output()
 	models := parseDevecoModels(string(out))

--- a/server/pkg/agent/execenv.go
+++ b/server/pkg/agent/execenv.go
@@ -1,0 +1,160 @@
+package agent
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"runtime"
+	"sort"
+	"strings"
+)
+
+// isWindows is split out so the env-name casing rule is testable as a value.
+var isWindows = runtime.GOOS == "windows"
+
+// ExecEnv is extra environment an agent CLI needs in order to run, produced by
+// the same resolution step that produced its path.
+//
+// It exists because a pinned path is not always self-sufficient. A Volta-managed
+// global package binary is typically a `#!/usr/bin/env node` script, and Volta
+// supplies both the Node platform bound to that package and a NODE_PATH pointing
+// at its shared global lib directory when it launches one (upstream
+// volta-core/src/run/binary.rs: the DefaultBinary command carries the bound
+// platform's PATH and `command.env("NODE_PATH", shared_module_path())`).
+// Reproducing only the path would run the CLI under whatever Node the ambient
+// environment happens to offer — or none at all.
+//
+// Every consumer that executes an agent CLI must apply the same ExecEnv, so the
+// version the daemon gates on is produced under the environment the CLI actually
+// runs in. The zero value is a no-op.
+type ExecEnv struct {
+	// PrefixPaths maps an environment variable name (PATH, NODE_PATH) to
+	// directories prefixed onto its existing list-shaped value, highest
+	// priority first.
+	PrefixPaths map[string][]string
+}
+
+// IsZero reports whether e would change nothing.
+func (e ExecEnv) IsZero() bool {
+	for _, dirs := range e.PrefixPaths {
+		if len(dirs) > 0 {
+			return false
+		}
+	}
+	return true
+}
+
+// sortedNames returns the variable names in deterministic order.
+func (e ExecEnv) sortedNames() []string {
+	names := make([]string, 0, len(e.PrefixPaths))
+	for name, dirs := range e.PrefixPaths {
+		if len(dirs) > 0 {
+			names = append(names, name)
+		}
+	}
+	sort.Strings(names)
+	return names
+}
+
+// CacheKey is a stable fingerprint, so a cache keyed on an executable also
+// distinguishes the environment it is executed under.
+func (e ExecEnv) CacheKey() string {
+	if e.IsZero() {
+		return ""
+	}
+	var b strings.Builder
+	for _, name := range e.sortedNames() {
+		b.WriteString(name)
+		b.WriteByte('=')
+		b.WriteString(strings.Join(e.PrefixPaths[name], string(os.PathListSeparator)))
+		b.WriteByte(';')
+	}
+	return b.String()
+}
+
+// ApplyToEnviron returns environ with every prefix applied. environ is not
+// modified.
+func (e ExecEnv) ApplyToEnviron(environ []string) []string {
+	if e.IsZero() {
+		return environ
+	}
+	current := make(map[string]string, len(environ))
+	order := make([]string, 0, len(environ))
+	for _, kv := range environ {
+		name, value, ok := strings.Cut(kv, "=")
+		if !ok {
+			continue
+		}
+		key := envKey(name)
+		if _, seen := current[key]; !seen {
+			order = append(order, name)
+		}
+		current[key] = value
+	}
+	// Track the original casing so an existing PATH/Path entry is replaced in
+	// place rather than duplicated (Windows is case-insensitive here).
+	nameFor := map[string]string{}
+	for _, name := range order {
+		nameFor[envKey(name)] = name
+	}
+
+	for _, name := range e.sortedNames() {
+		key := envKey(name)
+		joined := strings.Join(e.PrefixPaths[name], string(os.PathListSeparator))
+		if existing := current[key]; existing != "" {
+			current[key] = joined + string(os.PathListSeparator) + existing
+		} else {
+			current[key] = joined
+		}
+		if _, ok := nameFor[key]; !ok {
+			nameFor[key] = name
+			order = append(order, name)
+		}
+	}
+
+	out := make([]string, 0, len(order))
+	for _, name := range order {
+		key := envKey(name)
+		out = append(out, nameFor[key]+"="+current[key])
+	}
+	return out
+}
+
+// ApplyToMap applies every prefix to a name->value map, falling back to the
+// process environment for a variable the map does not carry yet. Used for task
+// environments, which are assembled as maps.
+func (e ExecEnv) ApplyToMap(env map[string]string) {
+	if e.IsZero() || env == nil {
+		return
+	}
+	for _, name := range e.sortedNames() {
+		joined := strings.Join(e.PrefixPaths[name], string(os.PathListSeparator))
+		existing, ok := env[name]
+		if !ok || existing == "" {
+			existing = os.Getenv(name)
+		}
+		if existing == "" {
+			env[name] = joined
+			continue
+		}
+		env[name] = joined + string(os.PathListSeparator) + existing
+	}
+}
+
+// command builds an exec.Cmd for path with this environment applied.
+func (e ExecEnv) command(ctx context.Context, path string, args ...string) *exec.Cmd {
+	cmd := exec.CommandContext(ctx, path, args...)
+	if !e.IsZero() {
+		cmd.Env = e.ApplyToEnviron(os.Environ())
+	}
+	return cmd
+}
+
+// envKey normalizes an environment variable name for lookup. Case-insensitive on
+// Windows, exact elsewhere.
+func envKey(name string) string {
+	if isWindows {
+		return strings.ToUpper(name)
+	}
+	return name
+}

--- a/server/pkg/agent/execenv_test.go
+++ b/server/pkg/agent/execenv_test.go
@@ -208,24 +208,72 @@ func TestListModelsWithEnv_UsesEnvironment(t *testing.T) {
 	}
 }
 
-// TestValidatorsWithEnv_ThreadEnvironment covers the service-tier and thinking
-// validators. They fail open on discovery errors, so this asserts they reach the
-// CLI under the supplied environment rather than asserting a verdict.
-func TestValidatorsWithEnv_ThreadEnvironment(t *testing.T) {
+// TestValidatorsWithEnv_ReachListModelsWithEnv covers the service-tier and
+// thinking validators, which called the env-less ListModels and so silently
+// dropped the toolchain for every Volta-managed CLI.
+//
+// The verdict is not a usable signal (a provider may simply not support the
+// value), so this asserts on the discovery cache: the entry the validator
+// populates must be keyed with the environment's fingerprint. With the env-less
+// call it would land under a key that has no fingerprint at all.
+func TestValidatorsWithEnv_ReachListModelsWithEnv(t *testing.T) {
 	skipIfNoPOSIXShell(t)
-	cli, env := newEnvDependentCLI(t, "echo '{}'\n")
+	cli, env := newEnvDependentCLI(t, "echo 'anthropic claude-sonnet-4'\n")
 	t.Setenv("PATH", "/usr/bin:/bin")
 
-	// Exercised for plumbing, not verdict: the point is that passing an ExecEnv
-	// is possible and does not change the no-env behavior contract.
-	if _, err := ValidateServiceTierWithEnv(context.Background(), "codex", cli, "gpt-5", "flex", env); err != nil {
+	resetModelCacheForTest()
+	if _, err := ValidateThinkingLevelWithEnv(context.Background(), "pi", cli,
+		"anthropic/claude-sonnet-4", "high", env); err != nil {
+		t.Fatalf("ValidateThinkingLevelWithEnv: %v", err)
+	}
+	wantKey := discoveryCacheKey("pi", cli, env)
+	if !modelCacheHasKey(wantKey) {
+		t.Errorf("thinking validator did not populate the cache under the env-aware key %q "+
+			"(keys present: %v); it is still calling the env-less ListModels",
+			wantKey, modelCacheKeys())
+	}
+
+	// ValidateServiceTier only consults a catalog for codex (it short-circuits for
+	// every other provider), and a codex fallback catalog is deliberately not
+	// cached — so assert the negative instead: nothing may be cached under a key
+	// that lacks the environment fingerprint.
+	resetModelCacheForTest()
+	if _, err := ValidateServiceTierWithEnv(context.Background(), "codex", cli,
+		"gpt-5-codex", "flex", env); err != nil {
 		t.Logf("ValidateServiceTierWithEnv error (fails open by design): %v", err)
 	}
-	if _, err := ValidateThinkingLevelWithEnv(context.Background(), "codex", cli, "gpt-5", "high", env); err != nil {
-		t.Logf("ValidateThinkingLevelWithEnv error (fails open by design): %v", err)
+	for _, key := range modelCacheKeys() {
+		if !strings.Contains(key, env.CacheKey()) {
+			t.Errorf("service-tier validator cached %q, which lacks the environment "+
+				"fingerprint %q; it is still calling the env-less ListModels", key, env.CacheKey())
+		}
 	}
+
 	// The zero-env wrappers must remain callable for every existing caller.
 	if _, err := ValidateServiceTier(context.Background(), "codex", cli, "gpt-5", "flex"); err != nil {
 		t.Logf("ValidateServiceTier error (fails open by design): %v", err)
 	}
+}
+
+func resetModelCacheForTest() {
+	modelCacheMu.Lock()
+	defer modelCacheMu.Unlock()
+	modelCache = map[string]modelCacheEntry{}
+}
+
+func modelCacheHasKey(key string) bool {
+	modelCacheMu.Lock()
+	defer modelCacheMu.Unlock()
+	_, ok := modelCache[key]
+	return ok
+}
+
+func modelCacheKeys() []string {
+	modelCacheMu.Lock()
+	defer modelCacheMu.Unlock()
+	keys := make([]string, 0, len(modelCache))
+	for k := range modelCache {
+		keys = append(keys, k)
+	}
+	return keys
 }

--- a/server/pkg/agent/execenv_test.go
+++ b/server/pkg/agent/execenv_test.go
@@ -1,0 +1,231 @@
+package agent
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+// ExecEnv exists so a resolved executable travels with the environment it needs.
+// These tests pin the mechanism (prefix semantics, cache-key distinctness) and
+// prove the environment actually reaches the subprocess of a consumer that
+// launches the CLI.
+
+func skipIfNoPOSIXShell(t *testing.T) {
+	t.Helper()
+	if runtime.GOOS == "windows" {
+		t.Skip("fixture needs a POSIX shell")
+	}
+	if _, err := os.Stat("/bin/sh"); err != nil {
+		t.Skipf("no /bin/sh: %v", err)
+	}
+}
+
+func TestExecEnv_ZeroValueIsNoOp(t *testing.T) {
+	var e ExecEnv
+	if !e.IsZero() {
+		t.Error("zero ExecEnv should be a no-op")
+	}
+	if got := e.CacheKey(); got != "" {
+		t.Errorf("CacheKey = %q, want empty", got)
+	}
+	environ := []string{"PATH=/bin", "FOO=bar"}
+	if got := e.ApplyToEnviron(environ); len(got) != 2 {
+		t.Errorf("ApplyToEnviron changed a no-op environment: %v", got)
+	}
+	// An ExecEnv whose lists are all empty is still a no-op.
+	empty := ExecEnv{PrefixPaths: map[string][]string{"PATH": {}}}
+	if !empty.IsZero() {
+		t.Error("ExecEnv with empty lists should be a no-op")
+	}
+}
+
+func TestExecEnv_ApplyToEnvironPrefixes(t *testing.T) {
+	sep := string(os.PathListSeparator)
+	e := ExecEnv{PrefixPaths: map[string][]string{
+		"PATH":      {"/node/bin"},
+		"NODE_PATH": {"/shared"},
+	}}
+	got := e.ApplyToEnviron([]string{"PATH=/usr/bin" + sep + "/bin", "FOO=bar"})
+
+	vals := map[string]string{}
+	for _, kv := range got {
+		if name, value, ok := strings.Cut(kv, "="); ok {
+			if _, dup := vals[name]; dup {
+				t.Errorf("duplicate entry for %s in %v", name, got)
+			}
+			vals[name] = value
+		}
+	}
+	if want := "/node/bin" + sep + "/usr/bin" + sep + "/bin"; vals["PATH"] != want {
+		t.Errorf("PATH = %q, want %q (prefix, existing value preserved)", vals["PATH"], want)
+	}
+	if vals["NODE_PATH"] != "/shared" {
+		t.Errorf("NODE_PATH = %q, want /shared when previously unset", vals["NODE_PATH"])
+	}
+	if vals["FOO"] != "bar" {
+		t.Errorf("unrelated var lost: %v", vals)
+	}
+}
+
+func TestExecEnv_ApplyToMapPrefixes(t *testing.T) {
+	sep := string(os.PathListSeparator)
+	e := ExecEnv{PrefixPaths: map[string][]string{"PATH": {"/node/bin"}}}
+
+	env := map[string]string{"PATH": "/existing"}
+	e.ApplyToMap(env)
+	if want := "/node/bin" + sep + "/existing"; env["PATH"] != want {
+		t.Errorf("PATH = %q, want %q", env["PATH"], want)
+	}
+
+	// A map that does not carry PATH yet falls back to the process value, so the
+	// task environment does not lose the inherited PATH.
+	t.Setenv("PATH", "/from-process")
+	env2 := map[string]string{}
+	e.ApplyToMap(env2)
+	if want := "/node/bin" + sep + "/from-process"; env2["PATH"] != want {
+		t.Errorf("PATH = %q, want %q", env2["PATH"], want)
+	}
+}
+
+func TestExecEnv_CacheKeyDistinguishesEnvironments(t *testing.T) {
+	a := ExecEnv{PrefixPaths: map[string][]string{"PATH": {"/node/20/bin"}}}
+	b := ExecEnv{PrefixPaths: map[string][]string{"PATH": {"/node/24/bin"}}}
+	if a.CacheKey() == b.CacheKey() {
+		t.Error("two different Node platforms share a cache key")
+	}
+	// Stable across map iteration order.
+	multi1 := ExecEnv{PrefixPaths: map[string][]string{"PATH": {"/a"}, "NODE_PATH": {"/b"}}}
+	multi2 := ExecEnv{PrefixPaths: map[string][]string{"NODE_PATH": {"/b"}, "PATH": {"/a"}}}
+	if multi1.CacheKey() != multi2.CacheKey() {
+		t.Errorf("cache key is not order-stable: %q vs %q", multi1.CacheKey(), multi2.CacheKey())
+	}
+}
+
+// TestDiscoveryCacheKey_IncludesEnv is the review's "environment must be part of
+// the discovery cache key": otherwise the same binary under two different
+// toolchains would share one cached catalog.
+func TestDiscoveryCacheKey_IncludesEnv(t *testing.T) {
+	base := discoveryCacheKey("codex", "/bin/codex", ExecEnv{})
+	withEnv := discoveryCacheKey("codex", "/bin/codex",
+		ExecEnv{PrefixPaths: map[string][]string{"PATH": {"/node/20/bin"}}})
+	other := discoveryCacheKey("codex", "/bin/codex",
+		ExecEnv{PrefixPaths: map[string][]string{"PATH": {"/node/24/bin"}}})
+
+	if base == withEnv {
+		t.Error("cache key ignores the execution environment")
+	}
+	if withEnv == other {
+		t.Error("cache key does not distinguish two execution environments")
+	}
+}
+
+// newEnvDependentCLI writes a fake CLI that only works when a marker executable
+// is reachable on PATH, mirroring a Volta package binary that needs the Node
+// platform Volta bound to it. It returns the CLI path and the ExecEnv that makes
+// it runnable.
+func newEnvDependentCLI(t *testing.T, stdout string) (string, ExecEnv) {
+	t.Helper()
+	root := t.TempDir()
+	envDir := filepath.Join(root, "toolchain", "bin")
+	if err := os.MkdirAll(envDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(envDir, "fixture-node"), []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	cli := filepath.Join(root, "cli")
+	body := "#!/bin/sh\ncommand -v fixture-node >/dev/null 2>&1 || { echo 'env: node: No such file or directory' >&2; exit 127; }\n" + stdout
+	if err := os.WriteFile(cli, []byte(body), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	return cli, ExecEnv{PrefixPaths: map[string][]string{"PATH": {envDir}}}
+}
+
+// TestExecEnv_ReachesSubprocess proves the environment is actually applied at the
+// exec boundary, not merely carried around.
+func TestExecEnv_ReachesSubprocess(t *testing.T) {
+	skipIfNoPOSIXShell(t)
+	cli, env := newEnvDependentCLI(t, "echo ok\n")
+	t.Setenv("PATH", "/usr/bin:/bin")
+
+	if out, err := env.command(context.Background(), cli).Output(); err != nil {
+		t.Errorf("with the environment applied: %v", err)
+	} else if strings.TrimSpace(string(out)) != "ok" {
+		t.Errorf("stdout = %q, want ok", out)
+	}
+	if _, err := (ExecEnv{}).command(context.Background(), cli).Output(); err == nil {
+		t.Error("without the environment the fixture should fail; it no longer models the dependency")
+	}
+}
+
+// TestDetectVersionWithEnv_UsesEnvironment covers the registration probe.
+func TestDetectVersionWithEnv_UsesEnvironment(t *testing.T) {
+	skipIfNoPOSIXShell(t)
+	cli, env := newEnvDependentCLI(t, "echo '1.2.3'\n")
+	t.Setenv("PATH", "/usr/bin:/bin")
+
+	if v, err := DetectVersionWithEnv(context.Background(), cli, env); err != nil {
+		t.Errorf("DetectVersionWithEnv: %v", err)
+	} else if v != "1.2.3" {
+		t.Errorf("version = %q, want 1.2.3", v)
+	}
+	if _, err := DetectVersion(context.Background(), cli); err == nil {
+		t.Error("DetectVersion without the environment should fail")
+	}
+}
+
+// TestListModelsWithEnv_UsesEnvironment is the review's item 2 for model
+// discovery: a Volta-managed CLI is unrunnable unless ListModels applies the same
+// environment, and pi's discovery shells out to the CLI.
+func TestListModelsWithEnv_UsesEnvironment(t *testing.T) {
+	skipIfNoPOSIXShell(t)
+	// pi discovery runs `<cli> --list-models` and parses `provider model` lines.
+	// It degrades to an empty catalog when the process cannot run, so the model
+	// count is what distinguishes "ran" from "could not run".
+	cli, env := newEnvDependentCLI(t, "echo 'anthropic claude-sonnet-4'\n")
+	t.Setenv("PATH", "/usr/bin:/bin")
+
+	withEnv, err := discoverPiModels(context.Background(), cli, env)
+	if err != nil {
+		t.Fatalf("discovery with the environment: %v", err)
+	}
+	if len(withEnv) == 0 {
+		t.Error("discovery with the environment found no models; ListModels did not apply it, " +
+			"so a Volta-managed CLI would come back with an empty catalog")
+	}
+
+	without, err := discoverPiModels(context.Background(), cli, ExecEnv{})
+	if err != nil {
+		t.Fatalf("discovery without the environment: %v", err)
+	}
+	if len(without) != 0 {
+		t.Errorf("discovery without the environment found %d models; the fixture no longer "+
+			"models the toolchain dependency", len(without))
+	}
+}
+
+// TestValidatorsWithEnv_ThreadEnvironment covers the service-tier and thinking
+// validators. They fail open on discovery errors, so this asserts they reach the
+// CLI under the supplied environment rather than asserting a verdict.
+func TestValidatorsWithEnv_ThreadEnvironment(t *testing.T) {
+	skipIfNoPOSIXShell(t)
+	cli, env := newEnvDependentCLI(t, "echo '{}'\n")
+	t.Setenv("PATH", "/usr/bin:/bin")
+
+	// Exercised for plumbing, not verdict: the point is that passing an ExecEnv
+	// is possible and does not change the no-env behavior contract.
+	if _, err := ValidateServiceTierWithEnv(context.Background(), "codex", cli, "gpt-5", "flex", env); err != nil {
+		t.Logf("ValidateServiceTierWithEnv error (fails open by design): %v", err)
+	}
+	if _, err := ValidateThinkingLevelWithEnv(context.Background(), "codex", cli, "gpt-5", "high", env); err != nil {
+		t.Logf("ValidateThinkingLevelWithEnv error (fails open by design): %v", err)
+	}
+	// The zero-env wrappers must remain callable for every existing caller.
+	if _, err := ValidateServiceTier(context.Background(), "codex", cli, "gpt-5", "flex"); err != nil {
+		t.Logf("ValidateServiceTier error (fails open by design): %v", err)
+	}
+}

--- a/server/pkg/agent/grok_test.go
+++ b/server/pkg/agent/grok_test.go
@@ -743,7 +743,7 @@ func TestDiscoverGrokModelsWaitsForAdvertisedAuth(t *testing.T) {
 	t.Setenv("GROK_AUTH_METHODS", "api")
 	t.Setenv("XAI_API_KEY", "test-only-key")
 
-	catalog, err := discoverGrokModels(context.Background(), fakePath)
+	catalog, err := discoverGrokModels(context.Background(), fakePath, ExecEnv{})
 	if err != nil {
 		t.Fatalf("discover grok models: %v", err)
 	}
@@ -789,7 +789,7 @@ func TestDiscoverGrokModelsStopsOnAuthFailures(t *testing.T) {
 			t.Setenv("GROK_AUTH_FAIL", tc.authFail)
 			t.Setenv("XAI_API_KEY", "")
 
-			catalog, err := discoverGrokModels(context.Background(), fakePath)
+			catalog, err := discoverGrokModels(context.Background(), fakePath, ExecEnv{})
 			if err != nil {
 				t.Fatalf("discover grok models: %v", err)
 			}

--- a/server/pkg/agent/models.go
+++ b/server/pkg/agent/models.go
@@ -150,38 +150,38 @@ func ListModelsWithEnv(ctx context.Context, providerType, executablePath string,
 		// agy 1.0.6 added a `--model` flag plus an `agy models` catalog
 		// command (MUL-3125). Enumerate it on demand like the other
 		// dynamic-discovery backends.
-		return cachedDiscovery(providerType, func() (Catalog, error) {
+		return cachedDiscovery(discoveryCacheKey(providerType, executablePath, env), func() (Catalog, error) {
 			return discovered(discoverAntigravityModels(ctx, executablePath, env))
 		})
 	case "traecli":
 		// Official TRAE CLI is ACP-native: it returns its model catalog from
 		// session/new. Enumerate it on demand like the other ACP backends
 		// (requires a logged-in traecli; falls back to manual entry on error).
-		return cachedDiscovery(providerType, func() (Catalog, error) {
+		return cachedDiscovery(discoveryCacheKey(providerType, executablePath, env), func() (Catalog, error) {
 			return discovered(discoverTraecliModels(ctx, executablePath, env))
 		})
 	case "cursor":
-		return cachedDiscovery(providerType, func() (Catalog, error) {
+		return cachedDiscovery(discoveryCacheKey(providerType, executablePath, env), func() (Catalog, error) {
 			return discoverCursorModels(ctx, executablePath, env)
 		})
 	case "copilot":
-		return cachedDiscovery(providerType, func() (Catalog, error) {
+		return cachedDiscovery(discoveryCacheKey(providerType, executablePath, env), func() (Catalog, error) {
 			return discoverCopilotModels(ctx, executablePath, env)
 		})
 	case "hermes":
-		return cachedDiscovery(providerType, func() (Catalog, error) {
+		return cachedDiscovery(discoveryCacheKey(providerType, executablePath, env), func() (Catalog, error) {
 			return discovered(discoverHermesModels(ctx, executablePath, env))
 		})
 	case "kimi":
-		return cachedDiscovery(providerType, func() (Catalog, error) {
+		return cachedDiscovery(discoveryCacheKey(providerType, executablePath, env), func() (Catalog, error) {
 			return discovered(discoverKimiModels(ctx, executablePath, env))
 		})
 	case "kiro":
-		return cachedDiscovery(providerType, func() (Catalog, error) {
+		return cachedDiscovery(discoveryCacheKey(providerType, executablePath, env), func() (Catalog, error) {
 			return discovered(discoverKiroModels(ctx, executablePath, env))
 		})
 	case "qoder", "qoderclicn":
-		return cachedDiscovery(providerType, func() (Catalog, error) {
+		return cachedDiscovery(discoveryCacheKey(providerType, executablePath, env), func() (Catalog, error) {
 			return discovered(discoverQoderModels(ctx, executablePath, qoderDefaultBinary(providerType), env))
 		})
 	case "opencode":
@@ -193,18 +193,18 @@ func ListModelsWithEnv(ctx context.Context, providerType, executablePath string,
 			return discovered(discoverDevecoModels(ctx, executablePath, env))
 		})
 	case "pi":
-		return cachedDiscovery(providerType, func() (Catalog, error) {
+		return cachedDiscovery(discoveryCacheKey(providerType, executablePath, env), func() (Catalog, error) {
 			return discovered(discoverPiModels(ctx, executablePath, env))
 		})
 	case "openclaw":
-		return cachedDiscovery(providerType, func() (Catalog, error) {
+		return cachedDiscovery(discoveryCacheKey(providerType, executablePath, env), func() (Catalog, error) {
 			return discovered(discoverOpenclawAgents(ctx, executablePath, env))
 		})
 	case "codebuddy":
 		// discoverCodebuddyModels owns the thinking annotation too, so the one
 		// `--help` capture feeds both catalogs. Annotating out here would run
 		// the command a second time (MUL-5549).
-		return cachedDiscovery(providerType, func() (Catalog, error) {
+		return cachedDiscovery(discoveryCacheKey(providerType, executablePath, env), func() (Catalog, error) {
 			return discoverCodebuddyModels(ctx, executablePath, env)
 		})
 	case "qwen":
@@ -216,7 +216,7 @@ func ListModelsWithEnv(ctx context.Context, providerType, executablePath string,
 		// xAI Grok Build is ACP-native (`grok agent stdio`); model catalog
 		// comes from session/new. Falls back to a small static list so the
 		// UI picker stays usable offline / unauthenticated.
-		return cachedDiscovery(providerType, func() (Catalog, error) {
+		return cachedDiscovery(discoveryCacheKey(providerType, executablePath, env), func() (Catalog, error) {
 			return discoverGrokModels(ctx, executablePath, env)
 		})
 	default:
@@ -983,6 +983,16 @@ type acpDiscoveryProvider struct {
 // `models.availableModels` / `models.currentModelId`, or under the
 // newer `configOptions` list. Provider-specific `launchArgs` select
 // ACP mode (e.g. `acp` vs `--acp`).
+// acpChildEnv builds the environment for an ACP discovery subprocess: the
+// resolved execution environment first, then the provider's own additions on top.
+//
+// This used to assign os.Environ() outright, which discarded the ExecEnv the
+// command was built with — so a Volta-managed CLI lost the toolchain it needs and
+// ACP discovery failed while every other provider worked.
+func acpChildEnv(env ExecEnv, extra []string) []string {
+	return append(env.ApplyToEnviron(os.Environ()), extra...)
+}
+
 func discoverACPModels(ctx context.Context, executablePath string, p acpDiscoveryProvider, env ExecEnv) ([]Model, error) {
 	fail := func(stage string, err error) ([]Model, error) {
 		if p.strictErrors {
@@ -1005,7 +1015,7 @@ func discoverACPModels(ctx context.Context, executablePath string, p acpDiscover
 	}
 	cmd := env.command(runCtx, executablePath, cmdArgs...)
 	hideAgentWindow(cmd)
-	childEnv := append(os.Environ(), p.extraEnv...)
+	childEnv := acpChildEnv(env, p.extraEnv)
 	cmd.Env = childEnv
 	stdin, err := cmd.StdinPipe()
 	if err != nil {

--- a/server/pkg/agent/models.go
+++ b/server/pkg/agent/models.go
@@ -128,77 +128,84 @@ const modelCacheTTL = 60 * time.Second
 // executablePath lets the caller point at a non-default binary; pass
 // "" to use the provider's default name on PATH.
 func ListModels(ctx context.Context, providerType, executablePath string) (Catalog, error) {
+	return ListModelsWithEnv(ctx, providerType, executablePath, ExecEnv{})
+}
+
+// ListModelsWithEnv is ListModels with the execution environment produced by
+// path resolution. Volta-managed CLIs are unrunnable without it, and the
+// discovery cache is keyed on it so two environments cannot share one entry.
+func ListModelsWithEnv(ctx context.Context, providerType, executablePath string, env ExecEnv) (Catalog, error) {
 	switch providerType {
 	case "claude":
 		models := claudeStaticModels()
-		annotateClaudeThinking(ctx, models, executablePath)
+		annotateClaudeThinking(ctx, models, executablePath, env)
 		// Claude's catalog is static by design, not by failure: there is no
 		// discovery step to fall back from, so this is authoritative.
 		return Catalog{Models: models}, nil
 	case "codex":
-		return cachedDiscovery(discoveryCacheKey(providerType, executablePath), func() (Catalog, error) {
-			return discovered(discoverCodexModels(ctx, executablePath), nil)
+		return cachedDiscovery(discoveryCacheKey(providerType, executablePath, env), func() (Catalog, error) {
+			return discovered(discoverCodexModels(ctx, executablePath, env), nil)
 		})
 	case "antigravity":
 		// agy 1.0.6 added a `--model` flag plus an `agy models` catalog
 		// command (MUL-3125). Enumerate it on demand like the other
 		// dynamic-discovery backends.
 		return cachedDiscovery(providerType, func() (Catalog, error) {
-			return discovered(discoverAntigravityModels(ctx, executablePath))
+			return discovered(discoverAntigravityModels(ctx, executablePath, env))
 		})
 	case "traecli":
 		// Official TRAE CLI is ACP-native: it returns its model catalog from
 		// session/new. Enumerate it on demand like the other ACP backends
 		// (requires a logged-in traecli; falls back to manual entry on error).
 		return cachedDiscovery(providerType, func() (Catalog, error) {
-			return discovered(discoverTraecliModels(ctx, executablePath))
+			return discovered(discoverTraecliModels(ctx, executablePath, env))
 		})
 	case "cursor":
 		return cachedDiscovery(providerType, func() (Catalog, error) {
-			return discoverCursorModels(ctx, executablePath)
+			return discoverCursorModels(ctx, executablePath, env)
 		})
 	case "copilot":
 		return cachedDiscovery(providerType, func() (Catalog, error) {
-			return discoverCopilotModels(ctx, executablePath)
+			return discoverCopilotModels(ctx, executablePath, env)
 		})
 	case "hermes":
 		return cachedDiscovery(providerType, func() (Catalog, error) {
-			return discovered(discoverHermesModels(ctx, executablePath))
+			return discovered(discoverHermesModels(ctx, executablePath, env))
 		})
 	case "kimi":
 		return cachedDiscovery(providerType, func() (Catalog, error) {
-			return discovered(discoverKimiModels(ctx, executablePath))
+			return discovered(discoverKimiModels(ctx, executablePath, env))
 		})
 	case "kiro":
 		return cachedDiscovery(providerType, func() (Catalog, error) {
-			return discovered(discoverKiroModels(ctx, executablePath))
+			return discovered(discoverKiroModels(ctx, executablePath, env))
 		})
 	case "qoder", "qoderclicn":
 		return cachedDiscovery(providerType, func() (Catalog, error) {
-			return discovered(discoverQoderModels(ctx, executablePath, qoderDefaultBinary(providerType)))
+			return discovered(discoverQoderModels(ctx, executablePath, qoderDefaultBinary(providerType), env))
 		})
 	case "opencode":
-		return cachedDiscovery(discoveryCacheKey(providerType, executablePath), func() (Catalog, error) {
-			return discovered(discoverOpenCodeModels(ctx, executablePath))
+		return cachedDiscovery(discoveryCacheKey(providerType, executablePath, env), func() (Catalog, error) {
+			return discovered(discoverOpenCodeModels(ctx, executablePath, env))
 		})
 	case "deveco":
-		return cachedDiscovery(discoveryCacheKey(providerType, executablePath), func() (Catalog, error) {
-			return discovered(discoverDevecoModels(ctx, executablePath))
+		return cachedDiscovery(discoveryCacheKey(providerType, executablePath, env), func() (Catalog, error) {
+			return discovered(discoverDevecoModels(ctx, executablePath, env))
 		})
 	case "pi":
 		return cachedDiscovery(providerType, func() (Catalog, error) {
-			return discovered(discoverPiModels(ctx, executablePath))
+			return discovered(discoverPiModels(ctx, executablePath, env))
 		})
 	case "openclaw":
 		return cachedDiscovery(providerType, func() (Catalog, error) {
-			return discovered(discoverOpenclawAgents(ctx, executablePath))
+			return discovered(discoverOpenclawAgents(ctx, executablePath, env))
 		})
 	case "codebuddy":
 		// discoverCodebuddyModels owns the thinking annotation too, so the one
 		// `--help` capture feeds both catalogs. Annotating out here would run
 		// the command a second time (MUL-5549).
 		return cachedDiscovery(providerType, func() (Catalog, error) {
-			return discoverCodebuddyModels(ctx, executablePath)
+			return discoverCodebuddyModels(ctx, executablePath, env)
 		})
 	case "qwen":
 		// Qwen Code has no account-independent headless model catalog. An
@@ -210,7 +217,7 @@ func ListModels(ctx context.Context, providerType, executablePath string) (Catal
 		// comes from session/new. Falls back to a small static list so the
 		// UI picker stays usable offline / unauthenticated.
 		return cachedDiscovery(providerType, func() (Catalog, error) {
-			return discoverGrokModels(ctx, executablePath)
+			return discoverGrokModels(ctx, executablePath, env)
 		})
 	default:
 		return Catalog{}, fmt.Errorf("unknown agent type: %q", providerType)
@@ -330,11 +337,11 @@ func cachedDiscovery(key string, fn func() (Catalog, error)) (Catalog, error) {
 	return catalog, nil
 }
 
-func discoveryCacheKey(providerType, executablePath string) string {
+func discoveryCacheKey(providerType, executablePath string, env ExecEnv) string {
 	if executablePath == "" {
-		return providerType
+		return providerType + "\x00" + env.CacheKey()
 	}
-	return providerType + ":" + executablePath
+	return providerType + ":" + executablePath + "\x00" + env.CacheKey()
 }
 
 // ── Static catalogs ──
@@ -418,13 +425,13 @@ func codexStaticModels() []Model {
 // and parses the model catalog traecli returns from session/new (same shape as
 // Kiro/Qoder). The official TRAE CLI must be logged in for the catalog to be
 // non-empty; on any failure the caller falls back to the manual-entry field.
-func discoverTraecliModels(ctx context.Context, executablePath string) ([]Model, error) {
+func discoverTraecliModels(ctx context.Context, executablePath string, env ExecEnv) ([]Model, error) {
 	return discoverACPModels(ctx, executablePath, acpDiscoveryProvider{
 		defaultBin:   "traecli",
 		clientName:   "multica-model-discovery",
 		tmpdirPrefix: "multica-traecli-discovery-",
 		acpArgs:      []string{"acp", "serve", "--yolo"},
-	})
+	}, env)
 }
 
 // cursorStaticModels is a minimal fallback used when
@@ -522,7 +529,7 @@ func isOpenAIReasoningSeriesID(id string) bool {
 // provider-specific reasoning-effort surface.
 // On any failure (CLI missing, parse error, timeout) we fall back to
 // an empty list so the creatable UI still works.
-func discoverOpenCodeModels(ctx context.Context, executablePath string) ([]Model, error) {
+func discoverOpenCodeModels(ctx context.Context, executablePath string, env ExecEnv) ([]Model, error) {
 	if executablePath == "" {
 		executablePath = "opencode"
 	}
@@ -535,7 +542,7 @@ func discoverOpenCodeModels(ctx context.Context, executablePath string) ([]Model
 	// the model picker was empty. See multica-ai/multica#3627.
 	runCtx, cancel := context.WithTimeout(ctx, 15*time.Second)
 	defer cancel()
-	cmd := exec.CommandContext(runCtx, executablePath, "models", "--verbose")
+	cmd := env.command(runCtx, executablePath, "models", "--verbose")
 	hideAgentWindow(cmd)
 	// Parse whatever the verbose command printed, even on a non-zero exit — a
 	// stale config entry can make `opencode models` exit non-zero while still
@@ -546,7 +553,7 @@ func discoverOpenCodeModels(ctx context.Context, executablePath string) ([]Model
 		// Verbose yielded nothing usable (unsupported flag, error text, or an
 		// empty list). Retry the plain command, which omits the per-model JSON
 		// but still prints the IDs.
-		cmd = exec.CommandContext(runCtx, executablePath, "models")
+		cmd = env.command(runCtx, executablePath, "models")
 		hideAgentWindow(cmd)
 		out, _ = cmd.Output()
 		models = parseOpenCodeModels(string(out))
@@ -733,7 +740,7 @@ func openCodeThinkingLevelsFromVariants(variants map[string]opencodeModelVariant
 // discoverPiModels runs `pi --list-models` and parses its output.
 // Older pi versions print the list to stderr; newer versions use
 // stdout. We capture both and parse whichever is non-empty.
-func discoverPiModels(ctx context.Context, executablePath string) ([]Model, error) {
+func discoverPiModels(ctx context.Context, executablePath string, env ExecEnv) ([]Model, error) {
 	if executablePath == "" {
 		executablePath = "pi"
 	}
@@ -748,7 +755,7 @@ func discoverPiModels(ctx context.Context, executablePath string) ([]Model, erro
 	// the opencode discovery cap (see #3729, same class as #3627).
 	runCtx, cancel := context.WithTimeout(ctx, 15*time.Second)
 	defer cancel()
-	cmd := exec.CommandContext(runCtx, executablePath, "--list-models")
+	cmd := env.command(runCtx, executablePath, "--list-models")
 	hideAgentWindow(cmd)
 	var stderr strings.Builder
 	cmd.Stderr = &stderr
@@ -854,13 +861,13 @@ func isPiDiscoveryNoise(line string) bool {
 // Failure modes (hermes missing, no credentials, config resolution
 // error) all return an empty list so the UI falls back to the
 // creatable manual-entry input instead of blocking the form.
-func discoverHermesModels(ctx context.Context, executablePath string) ([]Model, error) {
+func discoverHermesModels(ctx context.Context, executablePath string, env ExecEnv) ([]Model, error) {
 	return discoverACPModels(ctx, executablePath, acpDiscoveryProvider{
 		defaultBin:   "hermes",
 		clientName:   "multica-model-discovery",
 		extraEnv:     []string{"HERMES_YOLO_MODE=1"},
 		tmpdirPrefix: "multica-hermes-discovery-",
-	})
+	}, env)
 }
 
 // discoverKimiModels spins up a throwaway `kimi acp` process and
@@ -872,22 +879,22 @@ func discoverHermesModels(ctx context.Context, executablePath string) ([]Model, 
 //
 // Failure modes (kimi missing, not logged in, config error) all
 // return an empty list so the UI falls back to manual entry.
-func discoverKimiModels(ctx context.Context, executablePath string) ([]Model, error) {
+func discoverKimiModels(ctx context.Context, executablePath string, env ExecEnv) ([]Model, error) {
 	return discoverACPModels(ctx, executablePath, acpDiscoveryProvider{
 		defaultBin:   "kimi",
 		clientName:   "multica-model-discovery",
 		tmpdirPrefix: "multica-kimi-discovery-",
-	})
+	}, env)
 }
 
 // discoverKiroModels spins up a throwaway `kiro-cli acp` process and parses
 // the models block Kiro returns from session/new.
-func discoverKiroModels(ctx context.Context, executablePath string) ([]Model, error) {
+func discoverKiroModels(ctx context.Context, executablePath string, env ExecEnv) ([]Model, error) {
 	return discoverACPModels(ctx, executablePath, acpDiscoveryProvider{
 		defaultBin:   "kiro-cli",
 		clientName:   "multica-model-discovery",
 		tmpdirPrefix: "multica-kiro-discovery-",
-	})
+	}, env)
 }
 
 // discoverCopilotModels spins up `copilot --acp` and reads the
@@ -909,13 +916,13 @@ func discoverKiroModels(ctx context.Context, executablePath string) ([]Model, er
 // drives `initialize` + `session/new`, neither of which triggers
 // a tool-permission prompt — the model catalog is part of the
 // session/new response itself.
-func discoverCopilotModels(ctx context.Context, executablePath string) (Catalog, error) {
+func discoverCopilotModels(ctx context.Context, executablePath string, env ExecEnv) (Catalog, error) {
 	models, err := discoverACPModels(ctx, executablePath, acpDiscoveryProvider{
 		defaultBin:   "copilot",
 		clientName:   "multica-model-discovery",
 		tmpdirPrefix: "multica-copilot-discovery-",
 		acpArgs:      []string{"--acp"},
-	})
+	}, env)
 	if err != nil || len(models) == 0 {
 		return Catalog{Models: copilotStaticModels(), Fallback: true}, nil
 	}
@@ -929,13 +936,13 @@ func discoverCopilotModels(ctx context.Context, executablePath string) (Catalog,
 
 // discoverQoderModels spins up a Qoder CLI binary with `--yolo --acp` and
 // parses models from session/new.
-func discoverQoderModels(ctx context.Context, executablePath, defaultBin string) ([]Model, error) {
+func discoverQoderModels(ctx context.Context, executablePath, defaultBin string, env ExecEnv) ([]Model, error) {
 	return discoverACPModels(ctx, executablePath, acpDiscoveryProvider{
 		defaultBin:   defaultBin,
 		clientName:   "multica-model-discovery",
 		acpArgs:      []string{"--yolo", "--acp"},
 		tmpdirPrefix: "multica-qoder-discovery-",
-	})
+	}, env)
 }
 
 // acpDiscoveryProvider configures how discoverACPModels launches an
@@ -976,7 +983,7 @@ type acpDiscoveryProvider struct {
 // `models.availableModels` / `models.currentModelId`, or under the
 // newer `configOptions` list. Provider-specific `launchArgs` select
 // ACP mode (e.g. `acp` vs `--acp`).
-func discoverACPModels(ctx context.Context, executablePath string, p acpDiscoveryProvider) ([]Model, error) {
+func discoverACPModels(ctx context.Context, executablePath string, p acpDiscoveryProvider, env ExecEnv) ([]Model, error) {
 	fail := func(stage string, err error) ([]Model, error) {
 		if p.strictErrors {
 			return nil, fmt.Errorf("ACP model discovery %s failed: %w", stage, err)
@@ -996,7 +1003,7 @@ func discoverACPModels(ctx context.Context, executablePath string, p acpDiscover
 	if len(cmdArgs) == 0 {
 		cmdArgs = []string{"acp"}
 	}
-	cmd := exec.CommandContext(runCtx, executablePath, cmdArgs...)
+	cmd := env.command(runCtx, executablePath, cmdArgs...)
 	hideAgentWindow(cmd)
 	childEnv := append(os.Environ(), p.extraEnv...)
 	cmd.Env = childEnv
@@ -1351,7 +1358,7 @@ func acpModelLabel(name, modelID string) string {
 // catalog instead; agent.model stays unset and agy resolves its own
 // default. cachedDiscovery never caches empty results, so this retries on
 // the next request once the cause clears.
-func discoverAntigravityModels(ctx context.Context, executablePath string) ([]Model, error) {
+func discoverAntigravityModels(ctx context.Context, executablePath string, env ExecEnv) ([]Model, error) {
 	if executablePath == "" {
 		executablePath = "agy"
 	}
@@ -1362,7 +1369,7 @@ func discoverAntigravityModels(ctx context.Context, executablePath string) ([]Mo
 	// short cap is plenty; keep it generous enough to absorb cold starts.
 	runCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
 	defer cancel()
-	cmd := exec.CommandContext(runCtx, executablePath, "models")
+	cmd := env.command(runCtx, executablePath, "models")
 	hideAgentWindow(cmd)
 	out, err := cmd.Output()
 	if err != nil && len(out) == 0 {
@@ -1398,7 +1405,7 @@ func parseAntigravityModels(output string) []Model {
 // discoverGrokModels spins up `grok agent --always-approve stdio` and parses
 // the model catalog from session/new (same shape as Kiro/Qoder/Trae). Requires
 // an authenticated Grok CLI; on any failure falls back to grokStaticModels.
-func discoverGrokModels(ctx context.Context, executablePath string) (Catalog, error) {
+func discoverGrokModels(ctx context.Context, executablePath string, env ExecEnv) (Catalog, error) {
 	// Match the daemon's runtime launch: `--no-auto-update` (global) so a
 	// background update check can't stall discovery. Auth is selected only
 	// after initialize returns the methods this installed CLI actually offers.
@@ -1411,7 +1418,7 @@ func discoverGrokModels(ctx context.Context, executablePath string) (Catalog, er
 			return selectGrokAuthMethod(extractACPAuthMethods(initResult), envHasNonEmpty(childEnv, "XAI_API_KEY"))
 		},
 		strictErrors: true,
-	})
+	}, env)
 	if err != nil || len(models) == 0 {
 		if err != nil {
 			slog.Debug("grok model discovery fell back to static catalog", "error", err)
@@ -1461,7 +1468,7 @@ func annotateGrokThinking(models []Model) {
 // suffixes) — static baking would be obsolete within weeks. On any
 // failure we fall back to the minimal static catalog so the UI
 // stays usable when cursor-agent isn't installed on the daemon host.
-func discoverCursorModels(ctx context.Context, executablePath string) (Catalog, error) {
+func discoverCursorModels(ctx context.Context, executablePath string, env ExecEnv) (Catalog, error) {
 	if executablePath == "" {
 		executablePath = "cursor-agent"
 	}
@@ -1473,7 +1480,7 @@ func discoverCursorModels(ctx context.Context, executablePath string) (Catalog, 
 	// time out and fall back to the minimal static list. See #3729.
 	runCtx, cancel := context.WithTimeout(ctx, 15*time.Second)
 	defer cancel()
-	cmd := exec.CommandContext(runCtx, executablePath, "--list-models")
+	cmd := env.command(runCtx, executablePath, "--list-models")
 	hideAgentWindow(cmd)
 	out, err := cmd.Output()
 	if err != nil && len(out) == 0 {
@@ -1553,7 +1560,7 @@ func parseCursorModels(output string) []Model {
 // headers. On any ambiguity we return an empty list and let the
 // creatable dropdown handle manual entry — a silently-wrong
 // enumeration would be worse than none.
-func discoverOpenclawAgents(ctx context.Context, executablePath string) ([]Model, error) {
+func discoverOpenclawAgents(ctx context.Context, executablePath string, env ExecEnv) ([]Model, error) {
 	if executablePath == "" {
 		executablePath = "openclaw"
 	}
@@ -1570,7 +1577,7 @@ func discoverOpenclawAgents(ctx context.Context, executablePath string) ([]Model
 		{"agents", "list", "--output", "json"},
 		{"agents", "list", "-o", "json"},
 	} {
-		cmd := exec.CommandContext(runCtx, executablePath, jsonArgs...)
+		cmd := env.command(runCtx, executablePath, jsonArgs...)
 		hideAgentWindow(cmd)
 		out, err := cmd.Output()
 		if err != nil && len(out) == 0 {
@@ -1584,7 +1591,7 @@ func discoverOpenclawAgents(ctx context.Context, executablePath string) ([]Model
 	// Text fallback. Be strict — the default output is a decorated
 	// banner with box-drawing and section headers, and picking up
 	// the wrong tokens produces nonsense entries like "Identity:".
-	cmd := exec.CommandContext(runCtx, executablePath, "agents", "list")
+	cmd := env.command(runCtx, executablePath, "agents", "list")
 	hideAgentWindow(cmd)
 	out, err := cmd.Output()
 	if err != nil && len(out) == 0 {
@@ -1748,7 +1755,7 @@ func isOpenclawIdentifier(s string) bool {
 // Falls back to the static catalog (marked Fallback, so it can never be cached
 // as authoritative) when the handshake fails — including the not-logged-in case,
 // where session/new may legitimately refuse.
-func discoverCodebuddyModels(ctx context.Context, executablePath string) (Catalog, error) {
+func discoverCodebuddyModels(ctx context.Context, executablePath string, env ExecEnv) (Catalog, error) {
 	models, err := discoverACPModels(ctx, executablePath, acpDiscoveryProvider{
 		defaultBin:   "codebuddy",
 		clientName:   "multica-model-discovery",
@@ -1756,7 +1763,7 @@ func discoverCodebuddyModels(ctx context.Context, executablePath string) (Catalo
 		acpArgs:      []string{"--acp"},
 		strictErrors: true,
 		annotate:     annotateCodebuddyThinkingFromACP,
-	})
+	}, env)
 	if err != nil || len(models) == 0 {
 		if err != nil {
 			slog.Debug("codebuddy model discovery fell back to static catalog", "error", err)

--- a/server/pkg/agent/models_test.go
+++ b/server/pkg/agent/models_test.go
@@ -581,7 +581,7 @@ exit 1
 `
 	writeTestExecutable(t, fake, []byte(script))
 
-	models, err := discoverOpenCodeModels(context.Background(), fake)
+	models, err := discoverOpenCodeModels(context.Background(), fake, ExecEnv{})
 	if err != nil {
 		t.Fatalf("discoverOpenCodeModels: %v", err)
 	}
@@ -744,7 +744,7 @@ func TestDiscoverPiModelsNonZeroExit(t *testing.T) {
 			fakePath := filepath.Join(t.TempDir(), "pi")
 			writeTestExecutable(t, fakePath, []byte(tc.script))
 
-			models, err := discoverPiModels(context.Background(), fakePath)
+			models, err := discoverPiModels(context.Background(), fakePath, ExecEnv{})
 			if err != nil {
 				t.Fatalf("discoverPiModels: %v", err)
 			}
@@ -779,7 +779,7 @@ func TestDiscoverOpenCodeModelsFallsBackOnVerboseNoise(t *testing.T) {
 	fakePath := filepath.Join(t.TempDir(), "opencode")
 	writeTestExecutable(t, fakePath, []byte(script))
 
-	models, err := discoverOpenCodeModels(context.Background(), fakePath)
+	models, err := discoverOpenCodeModels(context.Background(), fakePath, ExecEnv{})
 	if err != nil {
 		t.Fatalf("discoverOpenCodeModels: %v", err)
 	}

--- a/server/pkg/agent/thinking.go
+++ b/server/pkg/agent/thinking.go
@@ -642,7 +642,7 @@ func ValidateThinkingLevelWithEnv(ctx context.Context, providerType, executableP
 	if model == "" && providerType == "codex" {
 		return false, nil
 	}
-	catalog, err := ListModels(ctx, providerType, executablePath)
+	catalog, err := ListModelsWithEnv(ctx, providerType, executablePath, env)
 	if err != nil {
 		return false, err
 	}
@@ -700,7 +700,7 @@ func ValidateServiceTierWithEnv(ctx context.Context, providerType, executablePat
 	if providerType != "codex" || model == "" {
 		return false, nil
 	}
-	catalog, err := ListModels(ctx, providerType, executablePath)
+	catalog, err := ListModelsWithEnv(ctx, providerType, executablePath, env)
 	if err != nil {
 		return false, err
 	}

--- a/server/pkg/agent/thinking.go
+++ b/server/pkg/agent/thinking.go
@@ -3,7 +3,6 @@ package agent
 import (
 	"context"
 	"encoding/json"
-	"os/exec"
 	"regexp"
 	"strings"
 	"sync"
@@ -130,8 +129,8 @@ var claudeStaticEffortFullSuperset = []string{"low", "medium", "high", "xhigh", 
 // through claudeModelEffortAllow. Errors are silently absorbed so a
 // missing CLI doesn't break model listing — the UI just hides the
 // picker for that model.
-func annotateClaudeThinking(ctx context.Context, models []Model, executablePath string) {
-	mapping := loadClaudeThinkingByModel(ctx, executablePath)
+func annotateClaudeThinking(ctx context.Context, models []Model, executablePath string, env ExecEnv) {
+	mapping := loadClaudeThinkingByModel(ctx, executablePath, env)
 	for i := range models {
 		if t, ok := mapping[models[i].ID]; ok && t != nil {
 			models[i].Thinking = t
@@ -139,17 +138,17 @@ func annotateClaudeThinking(ctx context.Context, models []Model, executablePath 
 	}
 }
 
-func loadClaudeThinkingByModel(ctx context.Context, executablePath string) map[string]*ModelThinking {
+func loadClaudeThinkingByModel(ctx context.Context, executablePath string, env ExecEnv) map[string]*ModelThinking {
 	if executablePath == "" {
 		executablePath = "claude"
 	}
-	version, _ := DetectVersion(ctx, executablePath)
+	version, _ := DetectVersionWithEnv(ctx, executablePath, env)
 	key := thinkingCacheKey{provider: "claude", executablePath: executablePath, cliVersion: version}
 	if cached, ok := thinkingCacheGet(key); ok {
 		return cached
 	}
 
-	superset := claudeEffortSuperset(ctx, executablePath)
+	superset := claudeEffortSuperset(ctx, executablePath, env)
 	result := map[string]*ModelThinking{}
 	for _, m := range claudeStaticModels() {
 		allow := claudeModelEffortAllow[m.ID]
@@ -170,8 +169,8 @@ func loadClaudeThinkingByModel(ctx context.Context, executablePath string) map[s
 // the help output can't be captured at all it returns the static
 // fallback rather than nothing so callers can still render a usable
 // picker.
-func claudeEffortSuperset(ctx context.Context, executablePath string) []string {
-	cmd := exec.CommandContext(ctx, executablePath, "--help")
+func claudeEffortSuperset(ctx context.Context, executablePath string, env ExecEnv) []string {
+	cmd := env.command(ctx, executablePath, "--help")
 	hideAgentWindow(cmd)
 	out, err := cmd.CombinedOutput()
 	if err != nil {
@@ -311,16 +310,16 @@ type codexDebugServiceTier struct {
 // catalog, including reasoning metadata. Version detection happens before the
 // debug command so old binaries do not log a predictable "unknown command"
 // failure on every cache refresh.
-func discoverCodexModels(ctx context.Context, executablePath string) []Model {
+func discoverCodexModels(ctx context.Context, executablePath string, env ExecEnv) []Model {
 	if executablePath == "" {
 		executablePath = "codex"
 	}
-	version, err := DetectVersion(ctx, executablePath)
+	version, err := DetectVersionWithEnv(ctx, executablePath, env)
 	if err != nil || !codexSupportsDebugModels(version) {
 		return codexStaticModels()
 	}
 
-	raw, err := runCodexDebugModels(ctx, executablePath)
+	raw, err := runCodexDebugModels(ctx, executablePath, env)
 	if err != nil {
 		return codexStaticModels()
 	}
@@ -351,8 +350,8 @@ func codexSupportsDebugModels(version string) bool {
 // in thinking_test.go.
 var codexDebugModelsArgs = []string{"debug", "models", "--bundled"}
 
-func runCodexDebugModels(ctx context.Context, executablePath string) ([]byte, error) {
-	cmd := exec.CommandContext(ctx, executablePath, codexDebugModelsArgs...)
+func runCodexDebugModels(ctx context.Context, executablePath string, env ExecEnv) ([]byte, error) {
+	cmd := env.command(ctx, executablePath, codexDebugModelsArgs...)
 	hideAgentWindow(cmd)
 	return cmd.Output()
 }
@@ -627,6 +626,12 @@ func parseACPCodebuddyEffort(raw json.RawMessage) (levels []string, defaultLevel
 // daemon's pre-execution guard and the server's UpdateAgent gate can
 // share the same source of truth.
 func ValidateThinkingLevel(ctx context.Context, providerType, executablePath, model, value string) (bool, error) {
+	return ValidateThinkingLevelWithEnv(ctx, providerType, executablePath, model, value, ExecEnv{})
+}
+
+// ValidateThinkingLevelWithEnv is ValidateThinkingLevel with the execution
+// environment produced by path resolution.
+func ValidateThinkingLevelWithEnv(ctx context.Context, providerType, executablePath, model, value string, env ExecEnv) (bool, error) {
 	if value == "" {
 		return true, nil
 	}
@@ -683,6 +688,12 @@ func ValidateThinkingLevel(ctx context.Context, providerType, executablePath, mo
 // means "inherit runtime configuration". An empty Codex model fails closed:
 // its effective model comes from config.toml and may not support the tier.
 func ValidateServiceTier(ctx context.Context, providerType, executablePath, model, value string) (bool, error) {
+	return ValidateServiceTierWithEnv(ctx, providerType, executablePath, model, value, ExecEnv{})
+}
+
+// ValidateServiceTierWithEnv is ValidateServiceTier with the execution
+// environment produced by path resolution.
+func ValidateServiceTierWithEnv(ctx context.Context, providerType, executablePath, model, value string, env ExecEnv) (bool, error) {
 	if value == "" {
 		return true, nil
 	}

--- a/server/pkg/agent/thinking_test.go
+++ b/server/pkg/agent/thinking_test.go
@@ -179,7 +179,7 @@ func TestRunCodexDebugModels_ArgvSeenByBinary(t *testing.T) {
 	// Linux ETXTBSY when we exec the file (Go #22315).
 	writeTestExecutable(t, fake, []byte(script))
 
-	raw, err := runCodexDebugModels(context.Background(), fake)
+	raw, err := runCodexDebugModels(context.Background(), fake, ExecEnv{})
 	if err != nil {
 		t.Fatalf("runCodexDebugModels: %v (output=%q)", err, raw)
 	}
@@ -310,7 +310,7 @@ echo '{"models":[{"slug":"runtime-model","display_name":"Runtime Model","visibil
 `
 		writeTestExecutable(t, fake, []byte(script))
 
-		got := discoverCodexModels(context.Background(), fake)
+		got := discoverCodexModels(context.Background(), fake, ExecEnv{})
 		if len(got) != 1 || got[0].ID != "runtime-model" || got[0].Thinking == nil || !hasThinkingLevel(got[0].Thinking, "high") {
 			t.Fatalf("expected runtime catalog, got %+v", got)
 		}
@@ -324,7 +324,7 @@ echo '{"models":[{"slug":"runtime-model","display_name":"Runtime Model","visibil
 			"exit 99\n"
 		writeTestExecutable(t, fake, []byte(script))
 
-		got := discoverCodexModels(context.Background(), fake)
+		got := discoverCodexModels(context.Background(), fake, ExecEnv{})
 		if len(got) == 0 || got[0].ID != "gpt-5.6-sol" {
 			t.Fatalf("expected static fallback, got %+v", got)
 		}
@@ -338,7 +338,7 @@ echo '{"models":[{"slug":"runtime-model","display_name":"Runtime Model","visibil
 			"exit 1\n"
 		writeTestExecutable(t, fake, []byte(script))
 
-		got := discoverCodexModels(context.Background(), fake)
+		got := discoverCodexModels(context.Background(), fake, ExecEnv{})
 		if len(got) == 0 || got[0].ID != "gpt-5.6-sol" || got[0].Thinking == nil {
 			t.Fatalf("expected model + thinking fallback, got %+v", got)
 		}


### PR DESCRIPTION
Fixes #6183. Multica issue: MUL-5547.

## Background

Volta installs a single `volta-shim` trampoline and symlinks **every** managed command to it, choosing which tool to run from the name it was invoked as. Upstream `get_tool_name()` takes `file_name()` of `argv[0]` (`volta-core/src/run/mod.rs`), and `get_executor()` refuses the shim under its own name (`Some("volta-shim") => Err(ErrorKind::RunShimDirectly)`); `volta-shim`'s `main` then exits 126 for any Volta error.

`resolveAgentExecutablePath` canonicalized bare command names through `filepath.EvalSymlinks`, collapsing `claude`/`codex`/`pi` onto that one shim path and discarding the tool selector. Result: version detection fails and none of them register.

```
WRN skip registering runtime name=claude error="detect version for ~/.volta/bin/volta-shim: exit status 126"
WRN skip registering runtime name=codex  error="detect version for ~/.volta/bin/volta-shim: exit status 126"
WRN skip registering runtime name=pi     error="detect version for ~/.volta/bin/volta-shim: exit status 126"
```

The pinned path also feeds `agent.Config.ExecutablePath`, so this broke task launches too, not just registration — the fix belongs at path resolution rather than in the version probe.

## Core logic

When a symlink resolves to `volta-shim`, ask Volta for the concrete binary (`volta which <command>`) and pin that.

`volta` is invoked by absolute path from the same directory as `volta-shim` (both are `VoltaInstall` entries) rather than via PATH, since the daemon may not have Volta's bin dir at all. Answers are cached process-wide and revalidated by existence, so a steady-state daemon does not fork a subprocess on every discovery tick and a replaced binary is re-resolved.

**Why pin the concrete path instead of keeping the alias.** Keeping `~/.volta/bin/claude` and letting the shim dispatch looks more faithful to Volta, but it breaks the `{path, version}` invariant the rest of the daemon relies on. The shim resolves per working directory — `volta which` itself prefers a project-local bin (`src/command/which.rs`) — so the version verified at registration would not necessarily be the version a task executes, and the minimum-version gate could be bypassed. Nor does the daemon re-probe often enough to paper over it: the refresh loop skips `convergeRuntimeRegistrations` entirely when no provider is missing, and `resolveAgentEntry` returns the cached version whenever the pinned path still exists — which an alias always does. Pinning the concrete path puts Volta installs on exactly the same footing as Homebrew or npm-global installs, and is what the reporter's own verified `MULTICA_*_PATH="$(volta which claude)"` workaround does.

**Fail-closed.** If Volta cannot be asked, we keep the shim path: version detection fails and the provider stays unregistered rather than being launched through an ungated path. `MULTICA_*_PATH` remains the manual override. There is a test for this.

**Scope.** `isVoltaShimPath` accepts only `volta-shim` and `volta-shim.exe` — exact names, so neighbours like `volta-shim.bak` or `volta-shim.wrapper` cannot opt out of symlink resolution. Nothing returns unresolved parent directories, so directory canonicalization and the PATH-drift guarantee stay intact. The exception lives in the shared `canonicalExecutablePath` helper, which also covers the `~/.multica/hooks` unshadowing branch (it canonicalizes independently) and the `reresolveAgentCommand` / MUL-4486 self-heal path.

## Testing

`server/internal/daemon/agents_probe_volta_test.go` uses a faithful fixture: an `argv[0]`-dispatching shim that exits 126 under its own name, plus a `volta` that answers `which`. Fixture versions clear `agent.MinVersions` (claude ≥ 2.0.0, codex ≥ 0.100.0) so registration is actually reachable.

- `TestDetectBuiltinRuntimes_RegistersVoltaManagedCLIs` — the end-result test, through the **real** version probe and **real** min-version gate, asserting claude/codex/pi all reach the registration payload.
- `TestResolveAgentExecutablePath_PinsVoltaConcreteBinary` — pins the concrete binary; explicitly not the shim and not the alias.
- `TestProbeAgentCLIs_DiscoversVoltaManagedCLIs` — three distinct concrete paths at the discovery entry point.
- `TestResolveAgentExecutablePath_FailsClosedWithoutVoltaResolution` — no fallback to the alias.
- `TestVoltaConcreteExecutable_ReresolvesAfterBinaryReplaced` — cache revalidation after Volta swaps the binary.
- `TestResolveAgentExecutablePath_VoltaAliasShadowedByHooks` — hooks wrapper skipped and concrete binary still pinned.
- `TestCanonicalExecutablePath_NonVoltaSymlinkStillCanonicalized` / `_SymlinkedParentDirIsCanonicalized` — blast-radius guards for files and parent dirs.
- `TestCanonicalExecutablePath_ExplicitShimPathStaysCanonical`, `TestIsVoltaShimPath` — edge cases and near-miss names.

Confirmed the regression tests genuinely fail without the fix (behavior branch neutralized), with the reporter's exact error — including at registration level:

```
claude missing from the registration payload; skipped reasons: map[string]string{
  "claude":"version detection failed: detect version for .../volta-shim: exit status 126", ...}
```

Full runs, all green: `go build ./...`, `go test ./internal/daemon/... -count=1` (daemon, execenv, repocache), `go test ./pkg/agent/ -count=1`, `go vet ./internal/daemon/`, `gofmt` clean on touched files, `git diff --check` clean.

## Remaining risk

- **Verified against a real Volta install.** macOS arm64, Volta 2.0.2 (the reporter's version), claude-code 2.1.220, codex 0.146.0. `volta-shim --version` exits 126 with Volta's "should not be called directly" error; with the fix disabled `detectBuiltinRuntimes` registers nothing and reports both providers as `version detection failed: detect version for .../volta-shim: exit status 126`, matching the reporter's log; with the fix both resolve to exactly what `volta which` reports and reach the registration payload. Captured as an opt-in test (`TestRealVolta_*`, gated on `MULTICA_VERIFY_VOLTA_HOME`, skipped in CI).
- `volta which` is a subprocess on the discovery path. It is bounded by a 5s timeout with `WaitDelay`, only runs when a shim is actually detected, and is cached; failure is fail-closed.
- The concrete path is resolved from the daemon's working directory, so it reflects Volta's **default** toolchain rather than any project-local override. That is the deterministic behavior the version gate requires, and it matches the documented workaround.
- If a user sets a custom `VOLTA_HOME` that the daemon does not inherit, `volta which` resolves against the default location; that is the same environment-inheritance class the login-shell PATH fallback already handles, and it fails closed.
- Backend-only; no schema, API, or config surface touched. Revert is a branch rollback.

