### PR TITLE
docs(license): state that free public hosting still needs a commercial license (MUL-5558)

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -25,8 +25,19 @@ together and what must be delivered when you redistribute.
       - This restriction applies to offering Multica (in whole or
         substantial part) as a SaaS platform, a managed service, or as
         an integrated component within another commercial offering.
+      - Providing a hosted service to third parties is restricted whether
+        or not you charge for it. A publicly accessible instance operated
+        for users outside your own organization requires a commercial
+        license even when it is offered free of charge, carries no
+        advertising, and sells no paid tier.
       - Internal use within a single organization (including multiple
         workspaces) does not require a commercial license.
+      - Distributing the source code itself, including publishing a fork
+        under an open-source license, is not a hosted service and does not
+        require a commercial license. It remains subject to conditions (b)
+        and (c), and it does not grant your downstream recipients any
+        right to operate a hosted service; each operator needs its own
+        commercial license.
 
    b. Branding and copyright information: Unless the producer has granted
       you a written branding waiver, you may not remove or modify the

--- a/LICENSE
+++ b/LICENSE
@@ -32,12 +32,14 @@ together and what must be delivered when you redistribute.
         advertising, and sells no paid tier.
       - Internal use within a single organization (including multiple
         workspaces) does not require a commercial license.
-      - Distributing the source code itself, including publishing a fork
-        under an open-source license, is not a hosted service and does not
-        require a commercial license. It remains subject to conditions (b)
-        and (c), and it does not grant your downstream recipients any
-        right to operate a hosted service; each operator needs its own
-        commercial license.
+      - Making the source code available, including publishing the source
+        code of a fork in a public repository, is not itself a hosted
+        service and does not require a commercial license. Any such
+        distribution remains subject to all applicable terms of this
+        Multica License, including conditions (b) and (c) below and
+        condition 3. Source distribution does not grant recipients the
+        right to operate a hosted service; each operator must obtain its
+        own commercial license.
 
    b. Branding and copyright information: Unless the producer has granted
       you a written branding waiver, you may not remove or modify the


### PR DESCRIPTION
## What

Adds two bullets under LICENSE condition 1a (no other changes):

1. **Free public hosting is still restricted.** Providing a hosted service to third parties requires a commercial license whether or not a fee is charged — free of charge, ad-free, no paid tier does not exempt it.
2. **Source distribution is not hosting.** Making the source code available — including publishing a fork's source in a public repository — is not itself a hosted service and needs no commercial license. Any such distribution remains subject to all applicable terms of the Multica License (including conditions (b), (c), and 3), and it conveys no hosting right downstream — each operator must obtain its own commercial license.

## Why

A downstream fork (Rollica) asked whether a completely free, ad-free public instance counts as a "hosted service to third parties" under 1a. The question is evidence the ambiguity is real: 1a's operative sentence carries no commerciality qualifier, but clause 1's preamble frames the section around commercial use, so both readings are arguable.

Free hosting is precisely the substitution risk 1a exists to price — a free public instance substitutes for the hosted product at the top of the funnel, and "free" is a revocable business-model claim. The second bullet is the same question from the other side: it keeps the fork-friendly design intact while closing the "launder hosting rights through a fork" path.

Discussion and sign-off: MUL-5558.

## Notes

- This ports the net content of commit `ae73ad1e3` — stranded on the already-merged #6197 branch (`agent/j/e2bb8fc5`), whose LICENSE/NOTICE predate the #6206 restructure — onto the current Multica License text. Verified the stale branch's only net-new content vs `main` is these two bullets; its NOTICE delta is pure staleness and is not ported.
- `README.md` / `README.zh-CN.md` license summaries already state the hosting restriction without a fee qualifier, so no sync is needed.
- Per condition 2a this applies to future releases only; snapshots already published keep the ambiguous text.

- Review fix (per Elon's review on MUL-5558): the bullet originally said "including publishing a fork under an open-source license", which could be read as permitting relicensing the fork as a whole — an OSD-compliant license cannot carry the hosting restriction, contradicting condition 3(d). Reworded to describe the act (publishing the fork's source) and to reference "all applicable terms of this Multica License" instead of enumerating only (b)/(c).
