### PR TITLE
MUL-5620: fix(daemon): close the repo-eviction liveness window and stop GC walking internal caches

### DIFF
--- a/server/internal/daemon/daemon.go
+++ b/server/internal/daemon/daemon.go
@@ -1914,8 +1914,13 @@ func (d *Daemon) workspaceRepoAllowed(workspaceID, repoURL string) bool {
 	return false
 }
 
-// liveRepoBarePaths returns the bare cache directories that some watched
-// workspace still claims, so the GC can refuse to evict them.
+// repoBarePathIsLive reports whether some watched workspace still claims the
+// repo cached at barePath, so the GC can refuse to evict it.
+//
+// Answering per-path rather than materializing the whole set lets the GC ask
+// again immediately before it deletes. A snapshot taken once per cycle goes
+// stale while the caller runs git and filesystem work on each repo in turn,
+// which is exactly the window in which a workspace can re-attach one.
 //
 // It mirrors workspaceRepoAllowed by unioning both sources: allowedRepoURLs
 // (workspace-level bindings) and taskRepoURLs (project repos the server
@@ -1927,22 +1932,25 @@ func (d *Daemon) workspaceRepoAllowed(workspaceID, repoURL string) bool {
 // for each workspace's repo list during GC — would make a transient API
 // failure look like "nothing is attached", and this set is what protects
 // caches from deletion.
-func (d *Daemon) liveRepoBarePaths() map[string]struct{} {
-	live := map[string]struct{}{}
-	if d.repoCache == nil {
-		return live
+func (d *Daemon) repoBarePathIsLive(barePath string) bool {
+	if d.repoCache == nil || barePath == "" {
+		return false
 	}
 	d.mu.Lock()
 	defer d.mu.Unlock()
 	for workspaceID, ws := range d.workspaces {
 		for url := range ws.allowedRepoURLs {
-			live[d.repoCache.BarePath(workspaceID, url)] = struct{}{}
+			if d.repoCache.BarePath(workspaceID, url) == barePath {
+				return true
+			}
 		}
 		for url := range ws.taskRepoURLs {
-			live[d.repoCache.BarePath(workspaceID, url)] = struct{}{}
+			if d.repoCache.BarePath(workspaceID, url) == barePath {
+				return true
+			}
 		}
 	}
-	return live
+	return false
 }
 
 func (d *Daemon) workspaceLastRepoSyncErr(workspaceID string) string {

--- a/server/internal/daemon/gc.go
+++ b/server/internal/daemon/gc.go
@@ -868,15 +868,20 @@ func (d *Daemon) evictRepoCacheLocked(barePath string, stats *gcStats) {
 		return
 	}
 
+	// Measure before the final check, not after. dirSize walks every file in
+	// the repo, which on a multi-GiB cache takes long enough for a workspace to
+	// re-attach underneath us — putting it between the check and the delete
+	// would reopen most of the window this check exists to close.
+	bytes := dirSize(barePath)
+
 	// Ask again immediately before deleting. The checks above run git and walk
 	// the filesystem, and a workspace can re-attach this repo while they do;
 	// re-reading in-memory state costs one mutex and no network, and shrinks
-	// the window from "the whole .repos walk" to these few statements.
+	// the window from "the whole .repos walk" to these two adjacent statements.
 	if d.repoBarePathIsLive(barePath) {
 		return
 	}
 
-	bytes := dirSize(barePath)
 	if err := os.RemoveAll(barePath); err != nil {
 		d.logger.Warn("gc: repo cache remove failed", "repo", barePath, "error", err)
 		return

--- a/server/internal/daemon/gc.go
+++ b/server/internal/daemon/gc.go
@@ -82,7 +82,14 @@ func (d *Daemon) runGC(ctx context.Context) {
 
 	stats := &gcStats{byPattern: map[string]int{}}
 	for _, wsEntry := range entries {
-		if !wsEntry.IsDir() || wsEntry.Name() == reposDirName {
+		// Skip every daemon-internal dot directory, not just .repos. A
+		// workspace directory is always a UUID, so a dot-prefixed entry is one
+		// of our own caches. Walking .skill-cache as if it were a workspace
+		// made its `v1` directory look like a task dir with no .gc_meta.json,
+		// so the orphan path would delete the entire bundle cache once its
+		// mtime went 72h without a new bundle. That reclaimed a few hundred KB
+		// and cost a full re-download.
+		if !wsEntry.IsDir() || strings.HasPrefix(wsEntry.Name(), ".") {
 			continue
 		}
 		wsDir := filepath.Join(root, wsEntry.Name())
@@ -746,7 +753,6 @@ func (d *Daemon) pruneRepoWorktrees(workspacesRoot string, stats *gcStats) {
 		return
 	}
 
-	live := d.liveRepoBarePaths()
 	for _, wsEntry := range wsEntries {
 		if !wsEntry.IsDir() {
 			continue
@@ -764,7 +770,7 @@ func (d *Daemon) pruneRepoWorktrees(workspacesRoot string, stats *gcStats) {
 			if !isBareRepo(barePath) {
 				continue
 			}
-			d.maintainRepoCache(barePath, live, stats)
+			d.maintainRepoCache(barePath, stats)
 		}
 		// Drop the per-workspace directory once its last repo is gone.
 		if remaining, err := os.ReadDir(wsRepoDir); err == nil && len(remaining) == 0 {
@@ -773,10 +779,10 @@ func (d *Daemon) pruneRepoWorktrees(workspacesRoot string, stats *gcStats) {
 	}
 }
 
-func (d *Daemon) maintainRepoCache(barePath string, live map[string]struct{}, stats *gcStats) {
+func (d *Daemon) maintainRepoCache(barePath string, stats *gcStats) {
 	d.withRepoLock(barePath, func() {
 		d.pruneWorktreeLocked(barePath)
-		d.evictRepoCacheLocked(barePath, live, stats)
+		d.evictRepoCacheLocked(barePath, stats)
 	})
 }
 
@@ -830,11 +836,13 @@ func (d *Daemon) withRepoLock(barePath string, fn func()) {
 // Evicting wrongly costs time, not correctness: the next task that needs the
 // repo takes the cache-miss path in ensureRepoReady, which re-syncs and
 // re-clones on demand.
-func (d *Daemon) evictRepoCacheLocked(barePath string, live map[string]struct{}, stats *gcStats) {
+func (d *Daemon) evictRepoCacheLocked(barePath string, stats *gcStats) {
 	if d.cfg.GCRepoTTL <= 0 {
 		return
 	}
-	if _, attached := live[barePath]; attached {
+	// Cheap early-out so an attached repo — the common case — never pays for
+	// the git and filesystem work below.
+	if d.repoBarePathIsLive(barePath) {
 		return
 	}
 
@@ -857,6 +865,14 @@ func (d *Daemon) evictRepoCacheLocked(barePath string, live map[string]struct{},
 	}
 	idle := time.Since(lastUsed)
 	if idle <= d.cfg.GCRepoTTL {
+		return
+	}
+
+	// Ask again immediately before deleting. The checks above run git and walk
+	// the filesystem, and a workspace can re-attach this repo while they do;
+	// re-reading in-memory state costs one mutex and no network, and shrinks
+	// the window from "the whole .repos walk" to these few statements.
+	if d.repoBarePathIsLive(barePath) {
 		return
 	}
 

--- a/server/internal/daemon/gc_repo_evict_test.go
+++ b/server/internal/daemon/gc_repo_evict_test.go
@@ -222,3 +222,77 @@ func TestLinkedWorktreeCount(t *testing.T) {
 		t.Errorf("linked worktrees = %d, want 2", count)
 	}
 }
+
+// TestRunGCLeavesDaemonInternalCachesAlone is the fix for the traversal split
+// between the GC and disk-usage. `.skill-cache` is not a workspace, but the GC
+// used to walk it as one: its `v1` directory then looked like a task dir with
+// no .gc_meta.json, so the orphan path deleted the whole bundle cache once its
+// mtime went GCOrphanTTL without a new bundle — reclaiming a few hundred KB in
+// exchange for a full re-download.
+func TestRunGCLeavesDaemonInternalCachesAlone(t *testing.T) {
+	d := newGCTestDaemon(t, http.NewServeMux())
+
+	skillCache := filepath.Join(d.cfg.WorkspacesRoot, ".skill-cache", "v1")
+	bundle := filepath.Join(skillCache, "ws", "source", "skill-id", "hash")
+	if err := os.MkdirAll(bundle, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(bundle, "bundle.json"), []byte("{}"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	// Older than GCOrphanTTL, which is what used to make it eligible.
+	old := time.Now().Add(-90 * 24 * time.Hour)
+	if err := os.Chtimes(skillCache, old, old); err != nil {
+		t.Fatal(err)
+	}
+
+	d.runGC(t.Context())
+
+	if _, err := os.Stat(filepath.Join(bundle, "bundle.json")); err != nil {
+		t.Fatalf("skill bundle cache must survive the GC walk: %v", err)
+	}
+}
+
+// TestRepoBarePathIsLiveCoversBothURLSets pins the union that keeps project
+// repos safe. taskRepoURLs holds repos the server surfaced through a task
+// claim; they never appear in GetWorkspaceRepos, so checking only
+// allowedRepoURLs would evict caches that tasks are actively checking out.
+func TestRepoBarePathIsLiveCoversBothURLSets(t *testing.T) {
+	d := newGCTestDaemon(t, http.NewServeMux())
+
+	const wsID = "11111111-1111-1111-1111-111111111111"
+	const workspaceRepo = "https://example.com/acme/workspace-repo.git"
+	const taskRepo = "https://example.com/acme/task-repo.git"
+	const strangerRepo = "https://example.com/acme/stranger.git"
+
+	d.mu.Lock()
+	d.workspaces[wsID] = &workspaceState{
+		workspaceID:     wsID,
+		allowedRepoURLs: map[string]struct{}{workspaceRepo: {}},
+		taskRepoURLs:    map[string]struct{}{taskRepo: {}},
+	}
+	d.mu.Unlock()
+
+	for _, tc := range []struct {
+		name string
+		url  string
+		want bool
+	}{
+		{"workspace-level binding", workspaceRepo, true},
+		{"task-surfaced project repo", taskRepo, true},
+		{"repo no workspace claims", strangerRepo, false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got := d.repoBarePathIsLive(d.repoCache.BarePath(wsID, tc.url))
+			if got != tc.want {
+				t.Errorf("repoBarePathIsLive(%s) = %v, want %v", tc.name, got, tc.want)
+			}
+		})
+	}
+
+	// Same URL under a workspace this daemon does not watch is not live.
+	other := d.repoCache.BarePath("22222222-2222-2222-2222-222222222222", workspaceRepo)
+	if d.repoBarePathIsLive(other) {
+		t.Error("a repo under an unwatched workspace must not count as live")
+	}
+}


### PR DESCRIPTION
Follow-up to #6297, addressing the two actionable non-blocking observations from its review.

## 1. Repo eviction consulted a stale liveness snapshot

`liveRepoBarePaths()` was computed once at the start of the `.repos` walk, then consulted per repo — after running `git worktree prune`, a worktree count, and a stamp read on each one in turn. A workspace re-attaching a repo inside that window could still see its cache evicted.

Replaced the snapshot with a per-path query (`repoBarePathIsLive`) and ask twice: once as a cheap early-out so an attached repo — the common case — never pays for the git work, and again immediately before `RemoveAll`. Re-reading in-memory state costs one mutex and no network.

**This narrows the race, it does not eliminate it.** Attachment updates `workspaceState` without taking the repo lock, so a sufficiently unlucky interleaving remains possible. It stays benign for two reasons already in the design: a freshly attached repo has no last-used stamp and takes the backfill-and-skip path, and a wrong eviction costs one re-clone through `ensureRepoReady` rather than a failure.

Not separately unit-tested, deliberately: forcing an attachment between two adjacent statements needs a test-only hook, and the user-visible guarantee (attached repos are never evicted) is already covered. What is newly tested is `repoBarePathIsLive` itself, including that it unions `taskRepoURLs` alongside `allowedRepoURLs` — the set that holds project repos surfaced through a task claim, which never appear in `GetWorkspaceRepos`.

## 2. GC walked `.skill-cache` as if it were a workspace

`runGC` skipped only `.repos`, so it descended into `.skill-cache`. Its `v1` directory then looked like a task directory with no `.gc_meta.json`, and the orphan path deleted the **entire bundle cache** once `v1`'s mtime went `GCOrphanTTL` (72h) without a new bundle. A few hundred KB reclaimed in exchange for a full re-download of every cached skill bundle.

`runGC` now skips every dot-directory, matching what `ScanDiskUsage` already does. Workspace directories are always UUIDs, so a dot-prefixed entry is one of our own caches.

This leaves the skill cache with no lifecycle at all — which is the right trade at its current size (552 KB on my machine, 307 KB on the reporter's in #6265). Deleting it wholesale on an unrelated TTL was strictly worse than not managing it. Giving it a real lifecycle is separate work if it ever grows.

I mutation-checked this one: reverting the skip makes `TestRunGCLeavesDaemonInternalCachesAlone` fail with the bundle actually deleted, confirming both that the bug was real and that the test has teeth.

## Not changed

The third observation — `repoCacheSize` measuring any second-level directory while eviction only handles `isBareRepo` ones, so a corrupted non-bare leftover is measured forever but never reclaimed — is left as is on purpose. Measuring more widely than we delete is the right asymmetry for a visibility feature: the leftover stays visible rather than silently uncounted, and widening eviction to non-bare directories would mean deleting things we cannot positively identify. The review flagged it for the record rather than as a defect, and I agree with that reading.

## Verification

`gofmt` clean on the touched files, `go vet ./internal/daemon/... ./cmd/multica` clean, `go test ./internal/daemon/...` (daemon, execenv, repocache) and the `cmd/multica` disk-usage tests all pass.
