### PR TITLE
MUL-5648: docs(cli): tighten the `issue search` help text

### DIFF
--- a/server/cmd/multica/cmd_issue.go
+++ b/server/cmd/multica/cmd_issue.go
@@ -354,22 +354,17 @@ var issueCancelTaskCmd = &cobra.Command{
 var issueSearchCmd = &cobra.Command{
 	Use:   "search <query>",
 	Short: "Search issues by title, description, or comments",
-	Long: "Search issues in the current workspace. The query is matched against issue\n" +
-		"titles, descriptions and comment bodies. Comment bodies are searched too,\n" +
-		"so a conclusion that only ever landed in a comment thread is still findable\n" +
-		"here.\n\n" +
-		"A bare number matches the issue with that number, and so does anything\n" +
-		"shaped like an identifier: \"AGE-412\" and \"412\" both match issue 412. The\n" +
-		"number match is the same either way, but the text search still uses the\n" +
-		"query as written, so \"412\" also matches text containing \"1412\" while\n" +
-		"\"AGE-412\" does not. The prefix is not validated, so \"MUL-412\" and\n" +
-		"\"ZZZ-412\" match local issue 412 just the same. Number matches rank\n" +
-		"first, so pasting an identifier from another tracker can put an\n" +
-		"unrelated local issue at the top of the results.\n\n" +
-		"Each result carries a match_source of \"title\", \"description\" or \"comment\",\n" +
-		"shown in the MATCH column and returned by --output json. It reports the\n" +
-		"strongest field that matched, and \"comment\" is also the fallback for a\n" +
-		"number-only match, so treat it as a display hint rather than a filter.",
+	Long: "Search issues in the current workspace. The query matches issue titles,\n" +
+		"descriptions, and comment bodies, so a conclusion that only lives in a\n" +
+		"comment thread is still findable.\n\n" +
+		"A bare number or an identifier-shaped query (\"412\", \"AGE-412\") matches\n" +
+		"the issue with that number. The prefix is not validated, and number\n" +
+		"matches rank first, so pasting an identifier from another tracker can\n" +
+		"put an unrelated local issue at the top of the results.\n\n" +
+		"The MATCH column (match_source in --output json) reports the strongest\n" +
+		"field that matched — title, description, or comment — and falls back to\n" +
+		"\"comment\" for a number-only hit. Treat it as a display hint, not a\n" +
+		"filter.",
 	Args: cobra.ExactArgs(1),
 	RunE: runIssueSearch,
 }


### PR DESCRIPTION
## Problem

Follow-up to #6293, which was correct but verbose. The `Long` it added runs 19 lines of prose — the longest `Long` in `cmd_issue.go` (the next longest, `issue reorder`, is 10, and most of that is a flag list).

That text has exactly two jobs: correct the belief that comments aren't searched, and warn that an identifier pasted from another tracker matches a local issue by number alone. Each paragraph carried a sentence that didn't serve either job:

1. **Paragraph 1 said the same thing twice** — it listed comment bodies in the match surface, then added "Comment bodies are searched too".
2. **Paragraph 2 spent 3 of its 8 lines on LIKE-pattern set theory** — that `"412"` also matches text containing `"1412"` while `"AGE-412"` doesn't. That landed as a review fix for an earlier `"AGE-412" is equivalent to "412"` overclaim. The overclaim was real, but the right repair is to stop asserting equivalence, not to append a proof. That precision is reviewer-grade, not user-grade.
3. **Paragraph 3 led with the implementation detail** (that `comment` is the fallback for a number-only match) before the part the reader can act on.

`--help` is read in about five seconds. Length is a cost paid on every read.

## Change

Docs only, one `Long` string. 19 lines → 11, no fact dropped.

```
Search issues in the current workspace. The query matches issue titles,
descriptions, and comment bodies, so a conclusion that only lives in a
comment thread is still findable.

A bare number or an identifier-shaped query ("412", "AGE-412") matches
the issue with that number. The prefix is not validated, and number
matches rank first, so pasting an identifier from another tracker can
put an unrelated local issue at the top of the results.

The MATCH column (match_source in --output json) reports the strongest
field that matched — title, description, or comment — and falls back to
"comment" for a number-only hit. Treat it as a display hint, not a
filter.
```

Both original corrections survive. The equivalence problem doesn't return, because the new text never asserts equivalence — it says both forms match issue 412 and stops.

One deliberate keep: the `"comment"`-for-a-number-only-hit clause. It reads like a droppable implementation detail, but without it "reports the strongest field that matched" is plainly wrong for a number-only hit — nothing matched textually, yet `match_source` still says `comment`. Cutting it would trade verbosity for the same class of inaccuracy #6293 set out to fix.

## Verification

```
$ gofmt -l server/cmd/multica/cmd_issue.go            # clean
$ go vet ./cmd/multica/ ./internal/handler/           # clean
$ go build ./cmd/multica                              # ok
$ go test ./internal/handler/ -run TestBuildSearchQuery   # ok (9/9)
$ ./multica issue search --help                       # renders as above
```

No behavior change: the only edit is a static string. Claims re-checked against `buildSearchQuery` and `parseQueryNumber` in `server/internal/handler/issue.go` — comment bodies in the WHERE `EXISTS`, `(?i)^[a-z]+-(\d+)$` keeping only the digits, number match at rank tier 0, and `match_source`'s trailing `ELSE 'comment'`.

MUL-5648
