### PR TITLE
MUL-5652: fix(agent): accumulate CacheWriteTokens in ACP backend promptDone handlers

### DIFF
--- a/server/pkg/agent/grok.go
+++ b/server/pkg/agent/grok.go
@@ -450,15 +450,14 @@ func (b *grokBackend) Execute(ctx context.Context, prompt string, opts ExecOptio
 					effectiveModel = pr.modelID
 				}
 				c.usageMu.Lock()
-				c.usage.InputTokens += pr.usage.InputTokens
-				c.usage.OutputTokens += pr.usage.OutputTokens
-				c.usage.CacheReadTokens += pr.usage.CacheReadTokens
-				c.usage.CacheWriteTokens += pr.usage.CacheWriteTokens
+				mergeACPTokenCountsMax(&c.usage, pr.usage)
 				// xAI prices the turn itself and reports the result here.
 				// Carrying it through is the only way the ≥200K long-context
 				// surcharge reaches the bill — token counts alone cannot
 				// reconstruct which tier a request hit.
-				c.usage.CostUSDTicks += pr.usage.CostUSDTicks
+				if pr.usage.CostUSDTicks > c.usage.CostUSDTicks {
+					c.usage.CostUSDTicks = pr.usage.CostUSDTicks
+				}
 				c.usageMu.Unlock()
 			default:
 			}

--- a/server/pkg/agent/grok.go
+++ b/server/pkg/agent/grok.go
@@ -449,15 +449,10 @@ func (b *grokBackend) Execute(ctx context.Context, prompt string, opts ExecOptio
 				if effectiveModel == "" {
 					effectiveModel = pr.modelID
 				}
+				// The shared merge also preserves xAI's authoritative cost for
+				// long-context turns, which token counts alone cannot reconstruct.
 				c.usageMu.Lock()
-				mergeACPTokenCountsMax(&c.usage, pr.usage)
-				// xAI prices the turn itself and reports the result here.
-				// Carrying it through is the only way the ≥200K long-context
-				// surcharge reaches the bill — token counts alone cannot
-				// reconstruct which tier a request hit.
-				if pr.usage.CostUSDTicks > c.usage.CostUSDTicks {
-					c.usage.CostUSDTicks = pr.usage.CostUSDTicks
-				}
+				mergeACPUsageSnapshot(&c.usage, &c.usageTotalTokens, pr.usage, pr.usageTotalTokens)
 				c.usageMu.Unlock()
 			default:
 			}

--- a/server/pkg/agent/grok.go
+++ b/server/pkg/agent/grok.go
@@ -453,6 +453,7 @@ func (b *grokBackend) Execute(ctx context.Context, prompt string, opts ExecOptio
 				c.usage.InputTokens += pr.usage.InputTokens
 				c.usage.OutputTokens += pr.usage.OutputTokens
 				c.usage.CacheReadTokens += pr.usage.CacheReadTokens
+				c.usage.CacheWriteTokens += pr.usage.CacheWriteTokens
 				// xAI prices the turn itself and reports the result here.
 				// Carrying it through is the only way the ≥200K long-context
 				// surcharge reaches the bill — token counts alone cannot

--- a/server/pkg/agent/grok_test.go
+++ b/server/pkg/agent/grok_test.go
@@ -109,7 +109,7 @@ while IFS= read -r line; do
       if [ -n "$GROK_USAGE" ]; then
         # Match live Grok Build ACP (0.2.x): metering lives under result._meta,
         # not a top-level usage field or sessionUpdate=usage_update.
-        printf '{"jsonrpc":"2.0","id":%s,"result":{"stopReason":"end_turn","_meta":{"sessionId":"ses_new","modelId":"grok-4.5","inputTokens":120,"outputTokens":30,"cachedReadTokens":20,"usage":{"inputTokens":120,"outputTokens":30,"totalTokens":150,"cachedReadTokens":20,"modelCalls":1,"costUsdTicks":98765}}}}\n' "$id"
+        printf '{"jsonrpc":"2.0","id":%s,"result":{"stopReason":"end_turn","_meta":{"sessionId":"ses_new","modelId":"grok-4.5","inputTokens":120,"outputTokens":30,"cachedReadTokens":20,"cacheWriteTokens":8,"usage":{"inputTokens":120,"outputTokens":30,"totalTokens":150,"cachedReadTokens":20,"cacheWriteTokens":8,"modelCalls":1,"costUsdTicks":98765}}}}\n' "$id"
       else
         printf '{"jsonrpc":"2.0","id":%s,"result":{"stopReason":"end_turn"}}\n' "$id"
       fi
@@ -616,6 +616,9 @@ func TestGrokPropagatesMCPAndUsage(t *testing.T) {
 	if usage.InputTokens != 100 || usage.OutputTokens != 30 || usage.CacheReadTokens != 20 {
 		t.Fatalf("unexpected usage: %+v", usage)
 	}
+	if usage.CacheWriteTokens != 8 {
+		t.Fatalf("CacheWriteTokens = %d, want 8", usage.CacheWriteTokens)
+	}
 	// xAI's own price for the turn has to survive the whole backend, not just
 	// the parser: it is the only figure carrying the ≥200K prompt surcharge,
 	// and everything downstream falls back to a rate-table guess without it.
@@ -669,6 +672,9 @@ func TestGrokAttributesUsageOnResumeWithoutConfiguredModel(t *testing.T) {
 	}
 	if usage.InputTokens != 100 || usage.OutputTokens != 30 || usage.CacheReadTokens != 20 {
 		t.Fatalf("unexpected usage: %+v", usage)
+	}
+	if usage.CacheWriteTokens != 8 {
+		t.Fatalf("CacheWriteTokens = %d, want 8", usage.CacheWriteTokens)
 	}
 }
 

--- a/server/pkg/agent/grok_test.go
+++ b/server/pkg/agent/grok_test.go
@@ -107,9 +107,11 @@ while IFS= read -r line; do
       printf '{"jsonrpc":"2.0","method":"session/update","params":{"sessionId":"ses_new","update":{"sessionUpdate":"tool_call_update","toolCallId":"tc-1","status":"completed","name":"Shell","output":"hi\\n"}}}\n'
       printf '{"jsonrpc":"2.0","method":"session/update","params":{"sessionId":"ses_new","update":{"sessionUpdate":"agent_message_chunk","content":{"type":"text","text":"pong"}}}}\n'
       if [ -n "$GROK_USAGE" ]; then
-        # Match live Grok Build ACP (0.2.x): metering lives under result._meta,
-        # not a top-level usage field or sessionUpdate=usage_update.
-        printf '{"jsonrpc":"2.0","id":%s,"result":{"stopReason":"end_turn","_meta":{"sessionId":"ses_new","modelId":"grok-4.5","inputTokens":120,"outputTokens":30,"cachedReadTokens":20,"cacheWriteTokens":8,"usage":{"inputTokens":120,"outputTokens":30,"totalTokens":150,"cachedReadTokens":20,"cacheWriteTokens":8,"modelCalls":1,"costUsdTicks":98765}}}}\n' "$id"
+        # Grok Build ACP (0.2.x) puts metering under result._meta rather than a
+        # top-level usage field or usage_update. The cache-write extension is
+        # synthetic, so keep its four token buckets mutually exclusive and
+        # totalTokens self-consistent: 100 + 30 + 20 + 8 = 158.
+        printf '{"jsonrpc":"2.0","id":%s,"result":{"stopReason":"end_turn","_meta":{"sessionId":"ses_new","modelId":"grok-4.5","inputTokens":100,"outputTokens":30,"cachedReadTokens":20,"cacheWriteTokens":8,"usage":{"inputTokens":100,"outputTokens":30,"totalTokens":158,"cachedReadTokens":20,"cacheWriteTokens":8,"modelCalls":1,"costUsdTicks":98765}}}}\n' "$id"
       else
         printf '{"jsonrpc":"2.0","id":%s,"result":{"stopReason":"end_turn"}}\n' "$id"
       fi
@@ -610,9 +612,8 @@ func TestGrokPropagatesMCPAndUsage(t *testing.T) {
 	if !ok {
 		t.Fatalf("usage missing grok-4.5 key: %+v", result.Usage)
 	}
-	// The fixture's totalTokens (150) equals input + output, so its 20 cached
-	// reads sit inside inputTokens and are billed once: input is stored as the
-	// uncached remainder 120 - 20 = 100.
+	// The fixture uses mutually exclusive counters whose sum matches
+	// totalTokens, so no bucket is charged twice.
 	if usage.InputTokens != 100 || usage.OutputTokens != 30 || usage.CacheReadTokens != 20 {
 		t.Fatalf("unexpected usage: %+v", usage)
 	}

--- a/server/pkg/agent/hermes.go
+++ b/server/pkg/agent/hermes.go
@@ -558,10 +558,10 @@ func (b *hermesBackend) Execute(ctx context.Context, prompt string, opts ExecOpt
 					finalError = "hermes cancelled the prompt"
 				}
 				// Prompt responses and usage_update notifications can carry the
-				// same cumulative counters. Take the larger value from either path
+				// same cumulative counters. Reconcile whole normalized snapshots
 				// so a runtime that emits both is charged exactly once.
 				c.usageMu.Lock()
-				mergeACPTokenCountsMax(&c.usage, pr.usage)
+				mergeACPUsageSnapshot(&c.usage, &c.usageTotalTokens, pr.usage, pr.usageTotalTokens)
 				c.usageMu.Unlock()
 			default:
 			}
@@ -741,8 +741,9 @@ func waitForHermesPipeDrain(readerDone, stderrDone <-chan struct{}, timeout time
 // ── hermesClient: ACP JSON-RPC 2.0 transport ──
 
 type hermesPromptResult struct {
-	stopReason string
-	usage      TokenUsage
+	stopReason       string
+	usage            TokenUsage
+	usageTotalTokens int64
 	// modelID is the model the agent actually billed this turn against, as
 	// reported on `result._meta.modelId`. Empty for agents that don't report
 	// it. Backends use it to attribute usage when the session handshake
@@ -777,8 +778,9 @@ type hermesClient struct {
 	toolMu       sync.Mutex
 	pendingTools map[string]*pendingToolCall
 
-	usageMu sync.Mutex
-	usage   TokenUsage
+	usageMu          sync.Mutex
+	usage            TokenUsage
+	usageTotalTokens int64
 }
 
 // pendingToolCall buffers state for a tool call while its arguments
@@ -1213,7 +1215,9 @@ func (c *hermesClient) extractPromptResult(data json.RawMessage) {
 		modelID:    parseACPModelIDFromMeta(resp.Meta),
 	}
 	if len(resp.Usage) > 0 && string(resp.Usage) != "null" {
-		pr.usage = parseACPTokenUsage(resp.Usage)
+		snapshot := parseACPTokenUsageSnapshot(resp.Usage)
+		pr.usage = snapshot.usage
+		pr.usageTotalTokens = snapshot.totalTokens
 	}
 	// Prefer the standard top-level ACP `usage` field when present. Some
 	// agents (notably xAI Grok Build) put per-turn metering only under
@@ -1221,8 +1225,9 @@ func (c *hermesClient) extractPromptResult(data json.RawMessage) {
 	// `_meta` itself. Without this fallback, tasks complete with an empty
 	// usage map and Multica's Usage/cost dashboards stay at zero.
 	if !acpTokenUsagePresent(pr.usage) {
-		if metaUsage := parseACPTokenUsageFromMeta(resp.Meta); acpTokenUsagePresent(metaUsage) {
-			pr.usage = metaUsage
+		if metaUsage := parseACPTokenUsageSnapshotFromMeta(resp.Meta); acpTokenUsagePresent(metaUsage.usage) {
+			pr.usage = metaUsage.usage
+			pr.usageTotalTokens = metaUsage.totalTokens
 		}
 	}
 
@@ -1236,28 +1241,28 @@ func acpTokenUsagePresent(u TokenUsage) bool {
 	return u.InputTokens > 0 || u.OutputTokens > 0 || u.CacheReadTokens > 0 || u.CacheWriteTokens > 0
 }
 
-// parseACPTokenUsageFromMeta extracts token usage from an ACP result `_meta`
-// object. Grok Build returns shapes like:
+// parseACPTokenUsageSnapshotFromMeta extracts token usage from an ACP result
+// `_meta` object. Grok Build returns shapes like:
 //
 //	{"inputTokens":…,"outputTokens":…,"cachedReadTokens":…,"usage":{…}}
 //
 // Prefer the nested `usage` object when it carries counters; otherwise parse
 // the flat `_meta` fields with the same alias rules as top-level usage.
-func parseACPTokenUsageFromMeta(meta json.RawMessage) TokenUsage {
+func parseACPTokenUsageSnapshotFromMeta(meta json.RawMessage) acpTokenUsageSnapshot {
 	if len(meta) == 0 || string(meta) == "null" {
-		return TokenUsage{}
+		return acpTokenUsageSnapshot{}
 	}
 	var envelope struct {
 		Usage json.RawMessage `json:"usage"`
 	}
 	if err := json.Unmarshal(meta, &envelope); err == nil {
 		if len(envelope.Usage) > 0 && string(envelope.Usage) != "null" {
-			if u := parseACPTokenUsage(envelope.Usage); acpTokenUsagePresent(u) {
-				return u
+			if snapshot := parseACPTokenUsageSnapshot(envelope.Usage); acpTokenUsagePresent(snapshot.usage) {
+				return snapshot
 			}
 		}
 	}
-	return parseACPTokenUsage(meta)
+	return parseACPTokenUsageSnapshot(meta)
 }
 
 // parseACPModelIDFromMeta pulls the model id off an ACP result `_meta`
@@ -1740,42 +1745,65 @@ func (c *hermesClient) handleUsageUpdate(data json.RawMessage) {
 	if err := json.Unmarshal(data, &msg); err != nil {
 		return
 	}
-	usage := parseACPTokenUsage(msg.Usage)
+	usage := parseACPTokenUsageSnapshot(msg.Usage)
 
 	c.usageMu.Lock()
-	mergeACPTokenCountsMax(&c.usage, usage)
-	if usage.CostUSDTicks > c.usage.CostUSDTicks {
-		c.usage.CostUSDTicks = usage.CostUSDTicks
-	}
+	mergeACPUsageSnapshot(&c.usage, &c.usageTotalTokens, usage.usage, usage.totalTokens)
 	c.usageMu.Unlock()
 }
 
-// mergeACPTokenCountsMax merges cumulative counters reported through ACP's
-// usage_update and PromptResponse paths. Runtimes may emit the same snapshot
-// through both, so adding them would double-charge one turn. Per-field maxima
-// also preserve a richer later snapshot when one path omits a counter.
-func mergeACPTokenCountsMax(dst *TokenUsage, next TokenUsage) {
-	if next.InputTokens > dst.InputTokens {
-		dst.InputTokens = next.InputTokens
+// mergeACPUsageSnapshot reconciles cumulative usage reported through ACP's
+// usage_update and PromptResponse paths. A snapshot with totalTokens is
+// self-describing and has already been normalized into mutually exclusive
+// token buckets, so keep its counters together instead of mixing them with an
+// ambiguous snapshot that may still include cached tokens in inputTokens.
+// Among self-describing snapshots the largest cumulative total wins; without
+// one, per-field maxima retain the most complete available counters. Provider
+// cost is cumulative too and always uses the largest reported value.
+func mergeACPUsageSnapshot(dst *TokenUsage, dstTotalTokens *int64, next TokenUsage, nextTotalTokens int64) {
+	if nextTotalTokens > 0 {
+		if *dstTotalTokens == 0 || nextTotalTokens >= *dstTotalTokens {
+			dst.InputTokens = next.InputTokens
+			dst.OutputTokens = next.OutputTokens
+			dst.CacheReadTokens = next.CacheReadTokens
+			dst.CacheWriteTokens = next.CacheWriteTokens
+			*dstTotalTokens = nextTotalTokens
+		}
+	} else if *dstTotalTokens == 0 {
+		if next.InputTokens > dst.InputTokens {
+			dst.InputTokens = next.InputTokens
+		}
+		if next.OutputTokens > dst.OutputTokens {
+			dst.OutputTokens = next.OutputTokens
+		}
+		if next.CacheReadTokens > dst.CacheReadTokens {
+			dst.CacheReadTokens = next.CacheReadTokens
+		}
+		if next.CacheWriteTokens > dst.CacheWriteTokens {
+			dst.CacheWriteTokens = next.CacheWriteTokens
+		}
 	}
-	if next.OutputTokens > dst.OutputTokens {
-		dst.OutputTokens = next.OutputTokens
-	}
-	if next.CacheReadTokens > dst.CacheReadTokens {
-		dst.CacheReadTokens = next.CacheReadTokens
-	}
-	if next.CacheWriteTokens > dst.CacheWriteTokens {
-		dst.CacheWriteTokens = next.CacheWriteTokens
+	if next.CostUSDTicks > dst.CostUSDTicks {
+		dst.CostUSDTicks = next.CostUSDTicks
 	}
 }
 
 func parseACPTokenUsage(data json.RawMessage) TokenUsage {
+	return parseACPTokenUsageSnapshot(data).usage
+}
+
+type acpTokenUsageSnapshot struct {
+	usage       TokenUsage
+	totalTokens int64
+}
+
+func parseACPTokenUsageSnapshot(data json.RawMessage) acpTokenUsageSnapshot {
 	if len(data) == 0 || string(data) == "null" {
-		return TokenUsage{}
+		return acpTokenUsageSnapshot{}
 	}
 	var fields map[string]json.RawMessage
 	if err := json.Unmarshal(data, &fields); err != nil {
-		return TokenUsage{}
+		return acpTokenUsageSnapshot{}
 	}
 	usage := TokenUsage{
 		InputTokens:  acpUsageInt64(fields, "inputTokens", "input_tokens"),
@@ -1798,7 +1826,11 @@ func parseACPTokenUsage(data json.RawMessage) TokenUsage {
 		// counts (see TokenUsage.CostUSDTicks).
 		CostUSDTicks: acpUsageInt64(fields, "costUsdTicks", "cost_usd_ticks"),
 	}
-	return excludeACPCachedInput(usage, acpUsageInt64(fields, "totalTokens", "total_tokens"))
+	totalTokens := acpUsageInt64(fields, "totalTokens", "total_tokens")
+	return acpTokenUsageSnapshot{
+		usage:       excludeACPCachedInput(usage, totalTokens),
+		totalTokens: totalTokens,
+	}
 }
 
 // excludeACPCachedInput re-buckets a usage record whose `inputTokens` already

--- a/server/pkg/agent/hermes.go
+++ b/server/pkg/agent/hermes.go
@@ -562,6 +562,7 @@ func (b *hermesBackend) Execute(ctx context.Context, prompt string, opts ExecOpt
 				c.usage.InputTokens += pr.usage.InputTokens
 				c.usage.OutputTokens += pr.usage.OutputTokens
 				c.usage.CacheReadTokens += pr.usage.CacheReadTokens
+				c.usage.CacheWriteTokens += pr.usage.CacheWriteTokens
 				c.usageMu.Unlock()
 			default:
 			}

--- a/server/pkg/agent/hermes.go
+++ b/server/pkg/agent/hermes.go
@@ -557,12 +557,11 @@ func (b *hermesBackend) Execute(ctx context.Context, prompt string, opts ExecOpt
 					finalStatus = "aborted"
 					finalError = "hermes cancelled the prompt"
 				}
-				// Merge usage from the PromptResponse.
+				// Prompt responses and usage_update notifications can carry the
+				// same cumulative counters. Take the larger value from either path
+				// so a runtime that emits both is charged exactly once.
 				c.usageMu.Lock()
-				c.usage.InputTokens += pr.usage.InputTokens
-				c.usage.OutputTokens += pr.usage.OutputTokens
-				c.usage.CacheReadTokens += pr.usage.CacheReadTokens
-				c.usage.CacheWriteTokens += pr.usage.CacheWriteTokens
+				mergeACPTokenCountsMax(&c.usage, pr.usage)
 				c.usageMu.Unlock()
 			default:
 			}
@@ -1744,23 +1743,30 @@ func (c *hermesClient) handleUsageUpdate(data json.RawMessage) {
 	usage := parseACPTokenUsage(msg.Usage)
 
 	c.usageMu.Lock()
-	// Usage updates from ACP are cumulative snapshots, so take the latest.
-	if usage.InputTokens > c.usage.InputTokens {
-		c.usage.InputTokens = usage.InputTokens
-	}
-	if usage.OutputTokens > c.usage.OutputTokens {
-		c.usage.OutputTokens = usage.OutputTokens
-	}
-	if usage.CacheReadTokens > c.usage.CacheReadTokens {
-		c.usage.CacheReadTokens = usage.CacheReadTokens
-	}
-	if usage.CacheWriteTokens > c.usage.CacheWriteTokens {
-		c.usage.CacheWriteTokens = usage.CacheWriteTokens
-	}
+	mergeACPTokenCountsMax(&c.usage, usage)
 	if usage.CostUSDTicks > c.usage.CostUSDTicks {
 		c.usage.CostUSDTicks = usage.CostUSDTicks
 	}
 	c.usageMu.Unlock()
+}
+
+// mergeACPTokenCountsMax merges cumulative counters reported through ACP's
+// usage_update and PromptResponse paths. Runtimes may emit the same snapshot
+// through both, so adding them would double-charge one turn. Per-field maxima
+// also preserve a richer later snapshot when one path omits a counter.
+func mergeACPTokenCountsMax(dst *TokenUsage, next TokenUsage) {
+	if next.InputTokens > dst.InputTokens {
+		dst.InputTokens = next.InputTokens
+	}
+	if next.OutputTokens > dst.OutputTokens {
+		dst.OutputTokens = next.OutputTokens
+	}
+	if next.CacheReadTokens > dst.CacheReadTokens {
+		dst.CacheReadTokens = next.CacheReadTokens
+	}
+	if next.CacheWriteTokens > dst.CacheWriteTokens {
+		dst.CacheWriteTokens = next.CacheWriteTokens
+	}
 }
 
 func parseACPTokenUsage(data json.RawMessage) TokenUsage {

--- a/server/pkg/agent/hermes_test.go
+++ b/server/pkg/agent/hermes_test.go
@@ -1241,6 +1241,13 @@ func TestParseACPTokenUsageCachedInputBucketing(t *testing.T) {
 			want: TokenUsage{InputTokens: 100, OutputTokens: 20, CacheReadTokens: 30},
 		},
 		{
+			// Cache writes are a separate bucket too. When all four buckets sum
+			// to totalTokens, inputTokens is already the uncached remainder.
+			name: "exclusive cache read and write buckets are left alone",
+			raw:  `{"inputTokens":100,"outputTokens":30,"totalTokens":158,"cachedReadTokens":20,"cacheWriteTokens":8}`,
+			want: TokenUsage{InputTokens: 100, OutputTokens: 30, CacheReadTokens: 20, CacheWriteTokens: 8},
+		},
+		{
 			// No totalTokens: nothing in the payload describes the overlap, so
 			// the counters are persisted as reported.
 			name: "missing totalTokens keeps counters as reported",
@@ -2257,6 +2264,9 @@ while IFS= read -r line; do
       ;;
     *'"method":"session/prompt"'*)
       printf '{"jsonrpc":"2.0","method":"session/update","params":{"sessionId":"ses_cw","update":{"sessionUpdate":"agent_message_chunk","content":{"type":"text","text":"done"}}}}\n'
+      if [ -n "$HERMES_USAGE_UPDATE" ]; then
+        printf '{"jsonrpc":"2.0","method":"session/update","params":{"sessionId":"ses_cw","update":{"sessionUpdate":"usage_update","usage":{"inputTokens":200,"outputTokens":50,"cacheReadTokens":30,"cacheWriteTokens":15}}}}\n'
+      fi
       printf '{"jsonrpc":"2.0","id":%s,"result":{"stopReason":"end_turn","usage":{"inputTokens":200,"outputTokens":50,"cacheReadTokens":30,"cacheWriteTokens":15}}}\n' "$id"
       exit 0
       ;;
@@ -2272,11 +2282,33 @@ done
 // parseACPTokenUsage correctly parsed it from the wire.
 func TestHermesBackendAccumulatesCacheWriteTokens(t *testing.T) {
 	t.Parallel()
+	usage := runHermesCacheWriteUsage(t, nil)
+	want := TokenUsage{InputTokens: 200, OutputTokens: 50, CacheReadTokens: 30, CacheWriteTokens: 15}
+	if usage != want {
+		t.Fatalf("usage = %+v, want %+v", usage, want)
+	}
+}
+
+// TestHermesBackendDeduplicatesUsageUpdateAndPromptResult pins the merge
+// semantics when an ACP runtime reports the same cumulative counters through
+// both supported usage paths. Each counter must be charged once, regardless
+// of which frame the stdout reader observes first.
+func TestHermesBackendDeduplicatesUsageUpdateAndPromptResult(t *testing.T) {
+	t.Parallel()
+	usage := runHermesCacheWriteUsage(t, map[string]string{"HERMES_USAGE_UPDATE": "1"})
+	want := TokenUsage{InputTokens: 200, OutputTokens: 50, CacheReadTokens: 30, CacheWriteTokens: 15}
+	if usage != want {
+		t.Fatalf("usage = %+v, want %+v", usage, want)
+	}
+}
+
+func runHermesCacheWriteUsage(t *testing.T, env map[string]string) TokenUsage {
+	t.Helper()
 
 	fakePath := filepath.Join(t.TempDir(), "hermes")
 	writeTestExecutable(t, fakePath, []byte(fakeHermesACPCacheWriteUsageScript()))
 
-	backend, err := New("hermes", Config{ExecutablePath: fakePath, Logger: slog.Default()})
+	backend, err := New("hermes", Config{ExecutablePath: fakePath, Logger: slog.Default(), Env: env})
 	if err != nil {
 		t.Fatalf("new hermes backend: %v", err)
 	}
@@ -2307,21 +2339,11 @@ func TestHermesBackendAccumulatesCacheWriteTokens(t *testing.T) {
 		if !ok {
 			t.Fatalf("expected usage under test-model, got %+v", result.Usage)
 		}
-		if usage.InputTokens != 200 {
-			t.Errorf("InputTokens = %d, want 200", usage.InputTokens)
-		}
-		if usage.OutputTokens != 50 {
-			t.Errorf("OutputTokens = %d, want 50", usage.OutputTokens)
-		}
-		if usage.CacheReadTokens != 30 {
-			t.Errorf("CacheReadTokens = %d, want 30", usage.CacheReadTokens)
-		}
-		if usage.CacheWriteTokens != 15 {
-			t.Errorf("CacheWriteTokens = %d, want 15", usage.CacheWriteTokens)
-		}
+		return usage
 	case <-time.After(10 * time.Second):
 		t.Fatal("timeout waiting for result")
 	}
+	return TokenUsage{}
 }
 
 // fakeHermesACPRateLimitScript impersonates hermes for the GitHub

--- a/server/pkg/agent/hermes_test.go
+++ b/server/pkg/agent/hermes_test.go
@@ -1569,6 +1569,58 @@ func TestHermesClientHandleUsageUpdateCumulative(t *testing.T) {
 	}
 }
 
+func TestMergeACPUsageSnapshotPrefersSelfDescribingRecords(t *testing.T) {
+	t.Parallel()
+
+	var usage TokenUsage
+	var totalTokens int64
+
+	// Start with an ambiguous snapshot whose input may include cached reads.
+	mergeACPUsageSnapshot(&usage, &totalTokens, TokenUsage{
+		InputTokens:     120,
+		OutputTokens:    30,
+		CacheReadTokens: 20,
+		CostUSDTicks:    800,
+	}, 0)
+
+	// An equivalent self-describing snapshot has already been normalized by
+	// parseACPTokenUsageSnapshot, so its mutually exclusive buckets replace the
+	// ambiguous counters as a whole.
+	mergeACPUsageSnapshot(&usage, &totalTokens, TokenUsage{
+		InputTokens:     100,
+		OutputTokens:    30,
+		CacheReadTokens: 20,
+		CostUSDTicks:    900,
+	}, 150)
+	want := TokenUsage{InputTokens: 100, OutputTokens: 30, CacheReadTokens: 20, CostUSDTicks: 900}
+	if usage != want || totalTokens != 150 {
+		t.Fatalf("after normalized snapshot: usage=%+v total=%d, want usage=%+v total=150", usage, totalTokens, want)
+	}
+
+	// A later ambiguous duplicate cannot reintroduce overlapping buckets, but
+	// a newer provider cost still wins independently.
+	mergeACPUsageSnapshot(&usage, &totalTokens, TokenUsage{
+		InputTokens:     120,
+		OutputTokens:    30,
+		CacheReadTokens: 20,
+		CostUSDTicks:    1000,
+	}, 0)
+	want.CostUSDTicks = 1000
+	if usage != want || totalTokens != 150 {
+		t.Fatalf("after ambiguous duplicate: usage=%+v total=%d, want usage=%+v total=150", usage, totalTokens, want)
+	}
+
+	// Older cumulative totals cannot roll the selected token record back.
+	mergeACPUsageSnapshot(&usage, &totalTokens, TokenUsage{
+		InputTokens:     90,
+		OutputTokens:    25,
+		CacheReadTokens: 15,
+	}, 130)
+	if usage != want || totalTokens != 150 {
+		t.Fatalf("after older normalized snapshot: usage=%+v total=%d, want usage=%+v total=150", usage, totalTokens, want)
+	}
+}
+
 // ── extractPromptResult ──
 
 func TestHermesClientExtractPromptResult(t *testing.T) {
@@ -1676,6 +1728,9 @@ func TestHermesClientExtractPromptResultMetaUsage(t *testing.T) {
 	}
 	if got.usage.CacheReadTokens != 10880 {
 		t.Errorf("cacheReadTokens: got %d, want 10880", got.usage.CacheReadTokens)
+	}
+	if got.usageTotalTokens != 12958 {
+		t.Errorf("usageTotalTokens: got %d, want 12958", got.usageTotalTokens)
 	}
 	// The turn stamps the model it billed against. A resumed session has no
 	// other source for this (session/load reports no model id), so losing it
@@ -2264,6 +2319,11 @@ while IFS= read -r line; do
       ;;
     *'"method":"session/prompt"'*)
       printf '{"jsonrpc":"2.0","method":"session/update","params":{"sessionId":"ses_cw","update":{"sessionUpdate":"agent_message_chunk","content":{"type":"text","text":"done"}}}}\n'
+      if [ -n "$HERMES_MIXED_NORMALIZATION" ]; then
+        printf '{"jsonrpc":"2.0","method":"session/update","params":{"sessionId":"ses_cw","update":{"sessionUpdate":"usage_update","usage":{"inputTokens":120,"outputTokens":30,"cacheReadTokens":20}}}}\n'
+        printf '{"jsonrpc":"2.0","id":%s,"result":{"stopReason":"end_turn","usage":{"inputTokens":120,"outputTokens":30,"totalTokens":150,"cacheReadTokens":20}}}\n' "$id"
+        exit 0
+      fi
       if [ -n "$HERMES_USAGE_UPDATE" ]; then
         printf '{"jsonrpc":"2.0","method":"session/update","params":{"sessionId":"ses_cw","update":{"sessionUpdate":"usage_update","usage":{"inputTokens":200,"outputTokens":50,"cacheReadTokens":30,"cacheWriteTokens":15}}}}\n'
       fi
@@ -2297,6 +2357,21 @@ func TestHermesBackendDeduplicatesUsageUpdateAndPromptResult(t *testing.T) {
 	t.Parallel()
 	usage := runHermesCacheWriteUsage(t, map[string]string{"HERMES_USAGE_UPDATE": "1"})
 	want := TokenUsage{InputTokens: 200, OutputTokens: 50, CacheReadTokens: 30, CacheWriteTokens: 15}
+	if usage != want {
+		t.Fatalf("usage = %+v, want %+v", usage, want)
+	}
+}
+
+// TestHermesBackendPrefersNormalizedPromptUsage covers two equivalent
+// cumulative snapshots with different information quality: usage_update omits
+// totalTokens, while the terminal PromptResponse includes it and proves cached
+// reads are contained in inputTokens. The normalized terminal record must win
+// as a whole; mixing per-field maxima would leave input at 120 and charge 170
+// tokens instead of the provider-reported total of 150.
+func TestHermesBackendPrefersNormalizedPromptUsage(t *testing.T) {
+	t.Parallel()
+	usage := runHermesCacheWriteUsage(t, map[string]string{"HERMES_MIXED_NORMALIZATION": "1"})
+	want := TokenUsage{InputTokens: 100, OutputTokens: 30, CacheReadTokens: 20}
 	if usage != want {
 		t.Fatalf("usage = %+v, want %+v", usage, want)
 	}

--- a/server/pkg/agent/hermes_test.go
+++ b/server/pkg/agent/hermes_test.go
@@ -2240,6 +2240,90 @@ func TestHermesBackendAttributesUsageToACPDefaultModel(t *testing.T) {
 	}
 }
 
+// fakeHermesACPCacheWriteUsageScript returns a fake ACP script that reports
+// cacheWriteTokens in the prompt result usage. This exercises the promptDone
+// accumulation path — the only source of usage data when the runtime does not
+// emit usage_update notifications.
+func fakeHermesACPCacheWriteUsageScript() string {
+	return `#!/bin/sh
+while IFS= read -r line; do
+  id=$(printf '%s' "$line" | sed -n 's/.*"id":\([0-9]*\).*/\1/p')
+  case "$line" in
+    *'"method":"initialize"'*)
+      printf '{"jsonrpc":"2.0","id":%s,"result":{"protocolVersion":1,"agentCapabilities":{}}}\n' "$id"
+      ;;
+    *'"method":"session/new"'*)
+      printf '{"jsonrpc":"2.0","id":%s,"result":{"sessionId":"ses_cw","models":{"currentModelId":"test-model","availableModels":[{"modelId":"test-model","name":"Test"}]}}}\n' "$id"
+      ;;
+    *'"method":"session/prompt"'*)
+      printf '{"jsonrpc":"2.0","method":"session/update","params":{"sessionId":"ses_cw","update":{"sessionUpdate":"agent_message_chunk","content":{"type":"text","text":"done"}}}}\n'
+      printf '{"jsonrpc":"2.0","id":%s,"result":{"stopReason":"end_turn","usage":{"inputTokens":200,"outputTokens":50,"cacheReadTokens":30,"cacheWriteTokens":15}}}\n' "$id"
+      exit 0
+      ;;
+  esac
+done
+`
+}
+
+// TestHermesBackendAccumulatesCacheWriteTokens verifies that
+// CacheWriteTokens from the promptDone (turn_end/result) usage is
+// accumulated into the final Result.Usage. Prior to the fix, this field
+// was silently dropped by the promptDone handler even though
+// parseACPTokenUsage correctly parsed it from the wire.
+func TestHermesBackendAccumulatesCacheWriteTokens(t *testing.T) {
+	t.Parallel()
+
+	fakePath := filepath.Join(t.TempDir(), "hermes")
+	writeTestExecutable(t, fakePath, []byte(fakeHermesACPCacheWriteUsageScript()))
+
+	backend, err := New("hermes", Config{ExecutablePath: fakePath, Logger: slog.Default()})
+	if err != nil {
+		t.Fatalf("new hermes backend: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	session, err := backend.Execute(ctx, "prompt-ignored", ExecOptions{
+		Timeout: 5 * time.Second,
+	})
+	if err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	go func() {
+		for range session.Messages {
+		}
+	}()
+
+	select {
+	case result, ok := <-session.Result:
+		if !ok {
+			t.Fatal("result channel closed without a value")
+		}
+		if result.Status != "completed" {
+			t.Fatalf("expected completed, got %q: %s", result.Status, result.Error)
+		}
+		usage, ok := result.Usage["test-model"]
+		if !ok {
+			t.Fatalf("expected usage under test-model, got %+v", result.Usage)
+		}
+		if usage.InputTokens != 200 {
+			t.Errorf("InputTokens = %d, want 200", usage.InputTokens)
+		}
+		if usage.OutputTokens != 50 {
+			t.Errorf("OutputTokens = %d, want 50", usage.OutputTokens)
+		}
+		if usage.CacheReadTokens != 30 {
+			t.Errorf("CacheReadTokens = %d, want 30", usage.CacheReadTokens)
+		}
+		if usage.CacheWriteTokens != 15 {
+			t.Errorf("CacheWriteTokens = %d, want 15", usage.CacheWriteTokens)
+		}
+	case <-time.After(10 * time.Second):
+		t.Fatal("timeout waiting for result")
+	}
+}
+
 // fakeHermesACPRateLimitScript impersonates hermes for the GitHub
 // multica#1952 scenario: the upstream LLM returns HTTP 429 (rate
 // limited / no credit), hermes retries internally and ultimately

--- a/server/pkg/agent/kimi.go
+++ b/server/pkg/agent/kimi.go
@@ -374,10 +374,7 @@ func (b *kimiBackend) Execute(ctx context.Context, prompt string, opts ExecOptio
 					finalError = "kimi cancelled the prompt"
 				}
 				c.usageMu.Lock()
-				c.usage.InputTokens += pr.usage.InputTokens
-				c.usage.OutputTokens += pr.usage.OutputTokens
-				c.usage.CacheReadTokens += pr.usage.CacheReadTokens
-				c.usage.CacheWriteTokens += pr.usage.CacheWriteTokens
+				mergeACPTokenCountsMax(&c.usage, pr.usage)
 				c.usageMu.Unlock()
 			default:
 			}

--- a/server/pkg/agent/kimi.go
+++ b/server/pkg/agent/kimi.go
@@ -376,6 +376,8 @@ func (b *kimiBackend) Execute(ctx context.Context, prompt string, opts ExecOptio
 				c.usageMu.Lock()
 				c.usage.InputTokens += pr.usage.InputTokens
 				c.usage.OutputTokens += pr.usage.OutputTokens
+				c.usage.CacheReadTokens += pr.usage.CacheReadTokens
+				c.usage.CacheWriteTokens += pr.usage.CacheWriteTokens
 				c.usageMu.Unlock()
 			default:
 			}

--- a/server/pkg/agent/kimi.go
+++ b/server/pkg/agent/kimi.go
@@ -374,7 +374,7 @@ func (b *kimiBackend) Execute(ctx context.Context, prompt string, opts ExecOptio
 					finalError = "kimi cancelled the prompt"
 				}
 				c.usageMu.Lock()
-				mergeACPTokenCountsMax(&c.usage, pr.usage)
+				mergeACPUsageSnapshot(&c.usage, &c.usageTotalTokens, pr.usage, pr.usageTotalTokens)
 				c.usageMu.Unlock()
 			default:
 			}

--- a/server/pkg/agent/kimi_test.go
+++ b/server/pkg/agent/kimi_test.go
@@ -176,7 +176,7 @@ while IFS= read -r line; do
       ;;
     *'"method":"session/prompt"'*)
       printf '{"jsonrpc":"2.0","method":"session/update","params":{"sessionId":"ses_fake","update":{"sessionUpdate":"agent_message_chunk","content":{"type":"text","text":"pong"}}}}\n'
-      printf '{"jsonrpc":"2.0","id":%s,"result":{"stopReason":"end_turn"}}\n' "$id"
+      printf '{"jsonrpc":"2.0","id":%s,"result":{"stopReason":"end_turn","usage":{"inputTokens":200,"outputTokens":50,"cacheReadTokens":30,"cacheWriteTokens":15}}}\n' "$id"
       if [ -n "$KIMI_LATE_CHUNK" ]; then
         sleep 0.05
         printf '{"jsonrpc":"2.0","method":"session/update","params":{"sessionId":"ses_fake","update":{"sessionUpdate":"agent_message_chunk","content":{"type":"text","text":" tail"}}}}\n'
@@ -493,5 +493,35 @@ func TestKimiBackendDropsHistoryReplayOnResume(t *testing.T) {
 		if m.Type == MessageText && strings.Contains(m.Content, "old history") {
 			t.Fatalf("history replay leaked into message stream: %+v", m)
 		}
+	}
+}
+
+func TestKimiBackendAccumulatesPromptResultUsage(t *testing.T) {
+	t.Parallel()
+
+	fakePath := filepath.Join(t.TempDir(), "kimi")
+	writeTestExecutable(t, fakePath, []byte(fakeKimiACPPromptScript()))
+
+	backend, err := New("kimi", Config{ExecutablePath: fakePath, Logger: slog.Default()})
+	if err != nil {
+		t.Fatalf("new kimi backend: %v", err)
+	}
+
+	session, err := backend.Execute(context.Background(), "task", ExecOptions{Timeout: 5 * time.Second})
+	if err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	go func() {
+		for range session.Messages {
+		}
+	}()
+
+	result := <-session.Result
+	if result.Status != "completed" {
+		t.Fatalf("expected completed, got status=%q error=%q", result.Status, result.Error)
+	}
+	want := TokenUsage{InputTokens: 200, OutputTokens: 50, CacheReadTokens: 30, CacheWriteTokens: 15}
+	if usage := result.Usage["unknown"]; usage != want {
+		t.Fatalf("usage = %+v, want %+v", usage, want)
 	}
 }

--- a/server/pkg/agent/kiro.go
+++ b/server/pkg/agent/kiro.go
@@ -435,10 +435,7 @@ func (b *kiroBackend) Execute(ctx context.Context, prompt string, opts ExecOptio
 					finalError = "kiro cancelled the prompt"
 				}
 				c.usageMu.Lock()
-				c.usage.InputTokens += pr.usage.InputTokens
-				c.usage.OutputTokens += pr.usage.OutputTokens
-				c.usage.CacheReadTokens += pr.usage.CacheReadTokens
-				c.usage.CacheWriteTokens += pr.usage.CacheWriteTokens
+				mergeACPTokenCountsMax(&c.usage, pr.usage)
 				c.usageMu.Unlock()
 			default:
 			}

--- a/server/pkg/agent/kiro.go
+++ b/server/pkg/agent/kiro.go
@@ -435,7 +435,7 @@ func (b *kiroBackend) Execute(ctx context.Context, prompt string, opts ExecOptio
 					finalError = "kiro cancelled the prompt"
 				}
 				c.usageMu.Lock()
-				mergeACPTokenCountsMax(&c.usage, pr.usage)
+				mergeACPUsageSnapshot(&c.usage, &c.usageTotalTokens, pr.usage, pr.usageTotalTokens)
 				c.usageMu.Unlock()
 			default:
 			}

--- a/server/pkg/agent/qoder.go
+++ b/server/pkg/agent/qoder.go
@@ -383,6 +383,7 @@ func (b *qoderBackend) Execute(ctx context.Context, prompt string, opts ExecOpti
 				c.usage.InputTokens += pr.usage.InputTokens
 				c.usage.OutputTokens += pr.usage.OutputTokens
 				c.usage.CacheReadTokens += pr.usage.CacheReadTokens
+				c.usage.CacheWriteTokens += pr.usage.CacheWriteTokens
 				c.usageMu.Unlock()
 			default:
 			}

--- a/server/pkg/agent/qoder.go
+++ b/server/pkg/agent/qoder.go
@@ -380,7 +380,7 @@ func (b *qoderBackend) Execute(ctx context.Context, prompt string, opts ExecOpti
 					finalError = "qoder cancelled the prompt"
 				}
 				c.usageMu.Lock()
-				mergeACPTokenCountsMax(&c.usage, pr.usage)
+				mergeACPUsageSnapshot(&c.usage, &c.usageTotalTokens, pr.usage, pr.usageTotalTokens)
 				c.usageMu.Unlock()
 			default:
 			}

--- a/server/pkg/agent/qoder.go
+++ b/server/pkg/agent/qoder.go
@@ -380,10 +380,7 @@ func (b *qoderBackend) Execute(ctx context.Context, prompt string, opts ExecOpti
 					finalError = "qoder cancelled the prompt"
 				}
 				c.usageMu.Lock()
-				c.usage.InputTokens += pr.usage.InputTokens
-				c.usage.OutputTokens += pr.usage.OutputTokens
-				c.usage.CacheReadTokens += pr.usage.CacheReadTokens
-				c.usage.CacheWriteTokens += pr.usage.CacheWriteTokens
+				mergeACPTokenCountsMax(&c.usage, pr.usage)
 				c.usageMu.Unlock()
 			default:
 			}

--- a/server/pkg/agent/traecli.go
+++ b/server/pkg/agent/traecli.go
@@ -380,10 +380,7 @@ func (b *traecliBackend) Execute(ctx context.Context, prompt string, opts ExecOp
 					finalError = "traecli cancelled the prompt"
 				}
 				c.usageMu.Lock()
-				c.usage.InputTokens += pr.usage.InputTokens
-				c.usage.OutputTokens += pr.usage.OutputTokens
-				c.usage.CacheReadTokens += pr.usage.CacheReadTokens
-				c.usage.CacheWriteTokens += pr.usage.CacheWriteTokens
+				mergeACPTokenCountsMax(&c.usage, pr.usage)
 				c.usageMu.Unlock()
 			default:
 			}

--- a/server/pkg/agent/traecli.go
+++ b/server/pkg/agent/traecli.go
@@ -383,6 +383,7 @@ func (b *traecliBackend) Execute(ctx context.Context, prompt string, opts ExecOp
 				c.usage.InputTokens += pr.usage.InputTokens
 				c.usage.OutputTokens += pr.usage.OutputTokens
 				c.usage.CacheReadTokens += pr.usage.CacheReadTokens
+				c.usage.CacheWriteTokens += pr.usage.CacheWriteTokens
 				c.usageMu.Unlock()
 			default:
 			}

--- a/server/pkg/agent/traecli.go
+++ b/server/pkg/agent/traecli.go
@@ -380,7 +380,7 @@ func (b *traecliBackend) Execute(ctx context.Context, prompt string, opts ExecOp
 					finalError = "traecli cancelled the prompt"
 				}
 				c.usageMu.Lock()
-				mergeACPTokenCountsMax(&c.usage, pr.usage)
+				mergeACPUsageSnapshot(&c.usage, &c.usageTotalTokens, pr.usage, pr.usageTotalTokens)
 				c.usageMu.Unlock()
 			default:
 			}


### PR DESCRIPTION
## Summary

- Fix missing `CacheWriteTokens` accumulation in the `promptDone` usage handler for 5 ACP backends (hermes, grok, kimi, qoder, traecli)
- Fix missing `CacheReadTokens` accumulation in kimi's `promptDone` handler
- Add unit test `TestHermesBackendAccumulatesCacheWriteTokens` that exercises the promptDone-only path and asserts all cache token fields survive to `Result.Usage`
- Extend grok test fixture to include `cacheWriteTokens` and add assertions

## Problem

`parseACPTokenUsage` correctly parses `cacheWriteTokens` from the ACP wire format, but the per-backend `promptDone` handler only accumulated a subset of the parsed fields into `c.usage`. When the runtime does not send `usage_update` notifications (e.g. Grok Build reports usage only in `result._meta`), this is the sole data source — causing `CacheWriteTokens` to be permanently zero in `Result.Usage`.

The downstream pricing layer (`metrics/business.go`) computes `tokenCostUSD(cacheWriteTokens, CacheWritePerM)` — with zero tokens in, the cost is $0 regardless of the per-million rate ($6.25 for Anthropic Opus, $2.00 for xAI Grok, etc.).

## Fix

Add the missing `c.usage.CacheWriteTokens += pr.usage.CacheWriteTokens` line in each backend's promptDone select branch, aligning with the kiro backend which was already correct.

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./pkg/agent/ -run "TestHermesBackendAccumulatesCacheWriteTokens"` — new test passes
- [x] `go test ./pkg/agent/ -run "TestGrokPropagatesMCPAndUsage|TestGrokAttributesUsageOnResumeWithoutConfiguredModel"` — updated assertions pass
- [x] `go test ./pkg/agent/ -run "TestHermes|TestGrok|TestKimi|TestKiro|TestQoder|TestTraecli"` — all ACP backend tests pass
- [x] Verified the new test FAILS without the fix (`CacheWriteTokens = 0, want 15`)