### PR TITLE
MUL-5657 fix(agent): add missing streamingCurrentTurn gate to kimi ACP backend

### DIFF
--- a/server/pkg/agent/kimi.go
+++ b/server/pkg/agent/kimi.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"os/exec"
 	"strings"
+	"sync/atomic"
 	"time"
 )
 
@@ -119,6 +120,12 @@ func (b *kimiBackend) Execute(ctx context.Context, prompt string, opts ExecOptio
 	// agent_message_chunk type; the tracker keeps only the post-tool-call block
 	// for Result.Output while retaining the full text for error detection.
 	var deliverable acpDeliverableTracker
+	// streamingCurrentTurn gates all session updates so that history replay
+	// (Kimi sends full prior-turn transcripts on session/resume, and may
+	// flush queued chunks before our session/prompt response streams) is
+	// dropped instead of duplicating the previous answer into output. We
+	// flip it to true only after session/prompt is sent.
+	var streamingCurrentTurn atomic.Bool
 
 	promptDone := make(chan hermesPromptResult, 1)
 	activity := make(chan struct{}, 1)
@@ -129,6 +136,9 @@ func (b *kimiBackend) Execute(ctx context.Context, prompt string, opts ExecOptio
 		stdin:        stdin,
 		pending:      make(map[int]*pendingRPC),
 		pendingTools: make(map[string]*pendingToolCall),
+		acceptNotification: func(string) bool {
+			return streamingCurrentTurn.Load()
+		},
 		onActivity: func() {
 			select {
 			case activity <- struct{}{}:
@@ -136,6 +146,9 @@ func (b *kimiBackend) Execute(ctx context.Context, prompt string, opts ExecOptio
 			}
 		},
 		onMessage: func(msg Message) {
+			if !streamingCurrentTurn.Load() {
+				return
+			}
 			// hermesClient.handleToolCallStart has already mapped
 			// the raw ACP title via hermesToolNameFromTitle — which
 			// covers lowercase hermes-style titles ("read:", "patch
@@ -151,6 +164,9 @@ func (b *kimiBackend) Execute(ctx context.Context, prompt string, opts ExecOptio
 			trySend(msgCh, msg)
 		},
 		onPromptDone: func(result hermesPromptResult) {
+			if !streamingCurrentTurn.Load() {
+				return
+			}
 			select {
 			case promptDone <- result:
 			default:
@@ -318,6 +334,7 @@ func (b *kimiBackend) Execute(ctx context.Context, prompt string, opts ExecOptio
 		}
 
 		// 5. Send the prompt and wait for PromptResponse.
+		streamingCurrentTurn.Store(true)
 		_, err = c.request(runCtx, "session/prompt", map[string]any{
 			"sessionId": sessionID,
 			"prompt": []map[string]any{
@@ -375,6 +392,7 @@ func (b *kimiBackend) Execute(ctx context.Context, prompt string, opts ExecOptio
 		// Ensure the stderr copier has drained before consulting the
 		// provider-error sniffer; see hermes.go for the failure mode.
 		<-stderrDone
+		streamingCurrentTurn.Store(false)
 
 		finalOutput, providerErrorOutput := deliverable.result()
 

--- a/server/pkg/agent/kimi_test.go
+++ b/server/pkg/agent/kimi_test.go
@@ -406,3 +406,92 @@ func TestKimiDrainsNotificationsAfterPromptResponse(t *testing.T) {
 		t.Fatalf("late output was truncated: %q", result.Output)
 	}
 }
+
+// fakeKimiACPResumeHistoryReplayScript impersonates kimi acp during session
+// resume: after session/resume responds it emits a history-replay notification
+// (the way a real Kimi CLI replays prior turns when loadSession:true). Then on
+// session/prompt it emits a new chunk with the actual answer. The gate must
+// ensure the history chunk never reaches output.
+func fakeKimiACPResumeHistoryReplayScript() string {
+	return `#!/bin/sh
+while IFS= read -r line; do
+  id=$(printf '%s' "$line" | sed -n 's/.*"id":\([0-9]*\).*/\1/p')
+  case "$line" in
+    *'"method":"initialize"'*)
+      printf '{"jsonrpc":"2.0","id":%s,"result":{"protocolVersion":1,"agentCapabilities":{"loadSession":true}}}\n' "$id"
+      ;;
+    *'"method":"session/resume"'*)
+      # Emit history replay BEFORE responding — this is what real Kimi does.
+      printf '{"jsonrpc":"2.0","method":"session/update","params":{"sessionId":"ses_resumed","update":{"sessionUpdate":"agent_message_chunk","content":{"type":"text","text":"old history from previous turn"}}}}\n'
+      printf '{"jsonrpc":"2.0","id":%s,"result":{"sessionId":"ses_resumed"}}\n' "$id"
+      ;;
+    *'"method":"session/prompt"'*)
+      printf '{"jsonrpc":"2.0","method":"session/update","params":{"sessionId":"ses_resumed","update":{"sessionUpdate":"agent_message_chunk","content":{"type":"text","text":"fresh answer"}}}}\n'
+      printf '{"jsonrpc":"2.0","id":%s,"result":{"stopReason":"end_turn"}}\n' "$id"
+      exit 0
+      ;;
+  esac
+done
+`
+}
+
+// TestKimiBackendDropsHistoryReplayOnResume pins the streaming gate: when a
+// Kimi session is resumed, the runtime may replay prior-turn transcripts as
+// ACP notifications before the client sends session/prompt. Without the
+// streamingCurrentTurn gate those replayed messages would be appended to the
+// message channel and contaminate Result.Output with the previous answer.
+func TestKimiBackendDropsHistoryReplayOnResume(t *testing.T) {
+	t.Parallel()
+
+	fakePath := filepath.Join(t.TempDir(), "kimi")
+	writeTestExecutable(t, fakePath, []byte(fakeKimiACPResumeHistoryReplayScript()))
+
+	backend, err := New("kimi", Config{ExecutablePath: fakePath, Logger: slog.Default()})
+	if err != nil {
+		t.Fatalf("new kimi backend: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	session, err := backend.Execute(ctx, "do something new", ExecOptions{
+		Timeout:         5 * time.Second,
+		ResumeSessionID: "ses_resumed",
+	})
+	if err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+
+	var messages []Message
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		for m := range session.Messages {
+			messages = append(messages, m)
+		}
+	}()
+
+	result := <-session.Result
+	<-done
+
+	if result.Status != "completed" {
+		t.Fatalf("expected completed, got status=%q error=%q", result.Status, result.Error)
+	}
+	if result.SessionID != "ses_resumed" {
+		t.Errorf("expected session id ses_resumed, got %q", result.SessionID)
+	}
+	// The gate must block the history replay chunk.
+	if strings.Contains(result.Output, "old history") {
+		t.Fatalf("history replay leaked into Result.Output: %q", result.Output)
+	}
+	// The current-turn answer must pass through.
+	if !strings.Contains(result.Output, "fresh answer") {
+		t.Fatalf("expected current-turn output to contain 'fresh answer', got %q", result.Output)
+	}
+	// Also verify the message channel didn't receive the history chunk.
+	for _, m := range messages {
+		if m.Type == MessageText && strings.Contains(m.Content, "old history") {
+			t.Fatalf("history replay leaked into message stream: %+v", m)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

- Add `streamingCurrentTurn` gate to kimi backend, matching hermes/grok/traecli/kiro/qoder
- Without the gate, session resume replays prior-turn history into output and message stream
- Add `TestKimiBackendDropsHistoryReplayOnResume` regression test

## Problem

When a Kimi session is resumed (`session/resume`), the ACP runtime replays prior-turn transcripts as `session/update` notifications before the client sends `session/prompt`. All other ACP backends gate these notifications with a `streamingCurrentTurn` atomic.Bool that is only flipped to `true` after `session/prompt` is sent — but kimi.go was missing this gate entirely.

The result: on resume, the previous answer is duplicated into `Result.Output` and streamed to the UI alongside the new answer.

## Root Cause

The gate was introduced in PR #2024 (2026-05-03) for hermes only. Kimi already existed at that time but was not patched. Subsequent backends (grok #5285, traecli #4724) were written after the fix and included the gate from the start.

## Fix

Add the identical gate pattern (6 touch points):
1. `var streamingCurrentTurn atomic.Bool`
2. `acceptNotification` callback → `return streamingCurrentTurn.Load()`
3. `onMessage` gate → `if !streamingCurrentTurn.Load() { return }`
4. `onPromptDone` gate → `if !streamingCurrentTurn.Load() { return }`
5. `streamingCurrentTurn.Store(true)` before `session/prompt`
6. `streamingCurrentTurn.Store(false)` after drain

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./pkg/agent/ -run TestKimi -count=1` — all 7 kimi tests pass (including new one)
- [x] New test verifies: history replay blocked from Output AND message stream; current-turn answer passes through; session ID preserved
- [x] Verified the new test FAILS without the fix (history leaks into output)