### PR TITLE
fix(skills): select files on click, add Edit to the row menu (MUL-5654)

### DIFF
--- a/packages/views/locales/en/skills.json
+++ b/packages/views/locales/en/skills.json
@@ -206,6 +206,7 @@
       "add_file": "New file",
       "mode_aria": "File view",
       "mode_preview": "Preview",
+      "mode_edit": "Edit",
       "mode_raw": "Plain text"
     }
   },
@@ -328,6 +329,7 @@
     "no_files": "No files",
     "actions": {
       "label": "Actions for {{path}}",
+      "edit": "Edit",
       "rename": "Rename",
       "delete": "Delete"
     }

--- a/packages/views/locales/ja/skills.json
+++ b/packages/views/locales/ja/skills.json
@@ -194,6 +194,7 @@
       "add_file": "新規ファイル",
       "mode_aria": "ファイル表示",
       "mode_preview": "プレビュー",
+      "mode_edit": "編集",
       "mode_raw": "プレーンテキスト"
     }
   },
@@ -315,6 +316,7 @@
     "no_files": "ファイルなし",
     "actions": {
       "label": "{{path}} の操作",
+      "edit": "編集",
       "rename": "名前を変更",
       "delete": "削除"
     }

--- a/packages/views/locales/ko/skills.json
+++ b/packages/views/locales/ko/skills.json
@@ -194,6 +194,7 @@
       "add_file": "새 파일",
       "mode_aria": "파일 보기",
       "mode_preview": "미리보기",
+      "mode_edit": "편집",
       "mode_raw": "일반 텍스트"
     }
   },
@@ -315,6 +316,7 @@
     "no_files": "파일 없음",
     "actions": {
       "label": "{{path}} 작업",
+      "edit": "편집",
       "rename": "이름 변경",
       "delete": "삭제"
     }

--- a/packages/views/locales/zh-Hans/skills.json
+++ b/packages/views/locales/zh-Hans/skills.json
@@ -194,6 +194,7 @@
       "add_file": "新建文件",
       "mode_aria": "文件视图",
       "mode_preview": "预览",
+      "mode_edit": "编辑",
       "mode_raw": "纯文本"
     }
   },
@@ -315,6 +316,7 @@
     "no_files": "无文件",
     "actions": {
       "label": "{{path}} 的操作",
+      "edit": "编辑",
       "rename": "重命名",
       "delete": "删除"
     }

--- a/packages/views/skills/components/file-tree.test.tsx
+++ b/packages/views/skills/components/file-tree.test.tsx
@@ -13,6 +13,7 @@ const PATHS = ["SKILL.md", "references/api.md", "notes.txt"];
 
 function makeActions(overrides: Partial<FileTreeActions> = {}): FileTreeActions {
   return {
+    onEdit: vi.fn(),
     validatePath: () => "",
     onRename: vi.fn(),
     onDelete: vi.fn(),
@@ -30,7 +31,7 @@ describe("FileTree row actions", () => {
     expect(screen.queryByRole("button", { name: /notes\.txt/ })).toBeNull();
   });
 
-  it("withholds them from the reserved file, which owns the skill's content", async () => {
+  it("withholds rename and delete from the reserved file, but not edit", async () => {
     await renderWithI18n(
       <FileTree
         filePaths={PATHS}
@@ -40,11 +41,57 @@ describe("FileTree row actions", () => {
       />,
     );
 
+    await userEvent.click(screen.getByRole("button", { name: /SKILL\.md/ }));
+
     // Deleting or renaming SKILL.md is refused by the server, so the row must
-    // not present it as available.
-    const rows = screen.getAllByRole("tab");
-    const skillMd = rows.find((row) => row.textContent === "SKILL.md")!;
-    expect(skillMd.parentElement!.querySelector("[aria-label]")).toBeNull();
+    // not present either as available. Editing it is ordinary, so the row
+    // keeps that one rather than losing the menu wholesale.
+    expect(
+      await screen.findByRole("menuitem", { name: /编辑|Edit/ }),
+    ).toBeInTheDocument();
+    expect(screen.queryByRole("menuitem", { name: /重命名|Rename/ })).toBeNull();
+    expect(screen.queryByRole("menuitem", { name: /删除|Delete/ })).toBeNull();
+  });
+
+  it("edits the row acted on", async () => {
+    const onEdit = vi.fn();
+    await renderWithI18n(
+      <FileTree
+        filePaths={PATHS}
+        selectedPath="SKILL.md"
+        onSelect={vi.fn()}
+        actions={makeActions({ onEdit })}
+      />,
+    );
+
+    await userEvent.click(screen.getByRole("button", { name: /notes\.txt/ }));
+    await userEvent.click(
+      await screen.findByRole("menuitem", { name: /编辑|Edit/ }),
+    );
+
+    expect(onEdit).toHaveBeenCalledWith("notes.txt");
+  });
+
+  it("keeps the menu trigger's widened hit area inside the trigger", async () => {
+    await renderWithI18n(
+      <FileTree
+        filePaths={PATHS}
+        selectedPath="SKILL.md"
+        onSelect={vi.fn()}
+        actions={makeActions()}
+      />,
+    );
+
+    // MUL-5654: the trigger widens its hit area with an absolutely positioned
+    // `after:-inset-1`. Drop `relative` and that pseudo-element resolves
+    // against the row instead, covering it end to end and swallowing every
+    // click on the file name — the row stops selecting and opens this menu.
+    // jsdom has no layout or hit testing, so the class pairing is the part a
+    // unit test can hold; the behaviour itself needs a real browser.
+    // The name button carries role="tab", so a "button" match is the trigger.
+    const trigger = screen.getByRole("button", { name: /notes\.txt/ });
+    expect(trigger.className).toContain("after:absolute");
+    expect(trigger.className).toContain("relative");
   });
 
   it("deletes the row acted on, not whichever file happens to be open", async () => {

--- a/packages/views/skills/components/file-tree.tsx
+++ b/packages/views/skills/components/file-tree.tsx
@@ -10,6 +10,7 @@ import {
   FolderOpen,
   MoreHorizontal,
   Pencil,
+  PencilLine,
   Trash2,
 } from "lucide-react";
 import { Input } from "@multica/ui/components/ui/input";
@@ -23,11 +24,16 @@ import { cn } from "@multica/ui/lib/utils";
 import { useT } from "../../i18n";
 
 /**
- * What a row may offer beyond selection. Absent for read-only viewers and for
- * the reserved primary file, so the tree never shows an action it would then
- * have to refuse.
+ * What a row may offer beyond selection. Absent for read-only viewers, so the
+ * tree never shows an action it would then have to refuse.
+ *
+ * `reservedPath` narrows the menu rather than removing it: the primary file
+ * cannot be renamed or deleted, but it is edited like any other row, so it
+ * keeps the edit entry and loses the other two.
  */
 export interface FileTreeActions {
+  /** Open the row's file in the editor, caret already in it. */
+  onEdit: (path: string) => void;
   /** Returns an error message, or "" when the path is free to use. */
   validatePath: (path: string, existing: string[]) => string;
   onRename: (from: string, to: string) => void;
@@ -159,7 +165,11 @@ function TreeNodeItem({
   }
 
   const Icon = getFileIcon(node.name);
-  const editable = !!actions && node.path !== actions.reservedPath;
+  // Two different questions: whether the row has a menu at all (any row does,
+  // once the viewer may edit), and whether that menu may offer rename/delete
+  // (the reserved primary file may not).
+  const hasMenu = !!actions;
+  const canModify = !!actions && node.path !== actions.reservedPath;
 
   if (renaming && actions) {
     return (
@@ -185,7 +195,7 @@ function TreeNodeItem({
       // anchors to that button rather than the cursor, which keeps one menu
       // per row instead of a context-menu root beside a dropdown root.
       onContextMenu={
-        editable
+        hasMenu
           ? (event) => {
               event.preventDefault();
               menuButtonRef.current?.click();
@@ -209,7 +219,7 @@ function TreeNodeItem({
         <Icon className="h-3.5 w-3.5 shrink-0" />
         <span className="truncate">{node.name}</span>
       </button>
-      {editable && (
+      {actions && (
         <DropdownMenu>
           <DropdownMenuTrigger
             render={
@@ -222,7 +232,17 @@ function TreeNodeItem({
                 // Hidden until the row is hovered or something inside it holds
                 // focus, so a rail of ten files is not a rail of ten buttons.
                 // after:-inset-1 widens the hit area past the 20px glyph.
-                className="mr-1 shrink-0 rounded p-0.5 text-faint-foreground opacity-0 transition-opacity after:absolute after:-inset-1 hover:text-foreground group-hover/row:opacity-100 focus-visible:opacity-100 aria-expanded:opacity-100"
+                //
+                // `relative` is load-bearing, not decoration: it makes THIS
+                // button the containing block for that ::after. Without it the
+                // pseudo-element resolves against the row (the nearest
+                // positioned ancestor), so the invisible hit area covered the
+                // whole row and — being absolutely positioned, hence painted
+                // above the in-flow name button — swallowed every click on the
+                // file name. Selecting a supporting file opened this menu
+                // instead (MUL-5654). opacity-0 does not opt out of hit
+                // testing, so the row was unclickable even before hover.
+                className="relative mr-1 shrink-0 rounded p-0.5 text-faint-foreground opacity-0 transition-opacity after:absolute after:-inset-1 hover:text-foreground group-hover/row:opacity-100 focus-visible:opacity-100 aria-expanded:opacity-100"
                 onClick={(event) => event.stopPropagation()}
               >
                 <MoreHorizontal className="h-3.5 w-3.5" />
@@ -230,17 +250,25 @@ function TreeNodeItem({
             }
           />
           <DropdownMenuContent align="end" className="w-36">
-            <DropdownMenuItem onClick={() => setRenaming(true)}>
-              <Pencil />
-              {t(($) => $.file_tree.actions.rename)}
+            <DropdownMenuItem onClick={() => actions.onEdit(node.path)}>
+              <PencilLine />
+              {t(($) => $.file_tree.actions.edit)}
             </DropdownMenuItem>
-            <DropdownMenuItem
-              variant="destructive"
-              onClick={() => actions.onDelete(node.path)}
-            >
-              <Trash2 />
-              {t(($) => $.file_tree.actions.delete)}
-            </DropdownMenuItem>
+            {canModify && (
+              <>
+                <DropdownMenuItem onClick={() => setRenaming(true)}>
+                  <Pencil />
+                  {t(($) => $.file_tree.actions.rename)}
+                </DropdownMenuItem>
+                <DropdownMenuItem
+                  variant="destructive"
+                  onClick={() => actions.onDelete(node.path)}
+                >
+                  <Trash2 />
+                  {t(($) => $.file_tree.actions.delete)}
+                </DropdownMenuItem>
+              </>
+            )}
           </DropdownMenuContent>
         </DropdownMenu>
       )}

--- a/packages/views/skills/components/file-viewer.tsx
+++ b/packages/views/skills/components/file-viewer.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useMemo } from "react";
+import { useEffect, useMemo, useRef } from "react";
 import { Textarea } from "@multica/ui/components/ui/textarea";
 import { parseFrontmatter } from "@multica/core/skills/frontmatter";
 import { RichContent } from "../../rich-content";
@@ -30,21 +30,44 @@ export function FileViewer({
   content,
   mode,
   readOnly,
+  autoFocus,
   onChange,
+  onFocusHandled,
 }: {
   path: string;
   content: string;
   mode: FileMode;
   readOnly: boolean;
+  /** Set by "Edit": put the caret in this file's editor once it renders. */
+  autoFocus?: boolean;
   onChange: (content: string) => void;
+  /** Called once the caret has landed, so the request is not replayed. */
+  onFocusHandled?: () => void;
 }) {
   const { t } = useT("skills");
   const isMd = isMarkdownPath(path);
+  const editorRef = useRef<HTMLTextAreaElement>(null);
 
   const body = useMemo(
     () => (isMd ? parseFrontmatter(content).body : content),
     [content, isMd],
   );
+
+  // The caller flips the mode to raw in the same update that raises this flag,
+  // so by the time the effect runs the textarea below is mounted. Focusing
+  // through a request the page owns — rather than `autoFocus` on the element —
+  // is what makes "Edit" work on the file that is ALREADY open: that path
+  // changes no key, mounts nothing, and would never re-run a mount-only focus.
+  useEffect(() => {
+    if (autoFocus !== true) return;
+    const el = editorRef.current;
+    if (!el) return;
+    el.focus();
+    // Caret at the top. Jumping to the end of a multi-thousand-character
+    // reference file would scroll away the content the user just clicked.
+    el.setSelectionRange(0, 0);
+    onFocusHandled?.();
+  }, [autoFocus, onFocusHandled]);
 
   // Non-markdown files have nothing to preview; they are always raw.
   if (isMd && mode === "preview") {
@@ -64,6 +87,7 @@ export function FileViewer({
 
   return (
     <Textarea
+      ref={editorRef}
       value={content}
       readOnly={readOnly}
       onChange={(e) => onChange(e.target.value)}

--- a/packages/views/skills/components/skill-detail-page.test.tsx
+++ b/packages/views/skills/components/skill-detail-page.test.tsx
@@ -2,6 +2,7 @@
 
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { fireEvent, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import type { Skill } from "@multica/core/types";
 import { I18nProvider } from "@multica/core/i18n/react";
@@ -193,7 +194,7 @@ describe("SkillDetailPage file mode", () => {
   it("keeps plain-text mode when switching files", async () => {
     renderPage(new URLSearchParams("view=files"));
 
-    fireEvent.click(await screen.findByRole("button", { name: "Plain text" }));
+    fireEvent.click(await screen.findByRole("button", { name: "Edit" }));
     expect(screen.getByRole("textbox", { name: /SKILL\.md/ })).toBeTruthy();
 
     // Mode used to live inside FileViewer, which the per-path `key`
@@ -208,6 +209,69 @@ describe("SkillDetailPage file mode", () => {
     const preview = await screen.findByTestId("preview");
     expect(preview.textContent).toContain("# Interface Animations");
     expect(preview.textContent).not.toContain("name: aiforui-animations");
+  });
+});
+
+describe("SkillDetailPage edit action (MUL-5654)", () => {
+  /** Opens a file row's action menu the way the rail exposes it. */
+  async function openRowMenu(path: string | RegExp) {
+    // The file-name button carries role="tab", so a "button" match on the row
+    // is the trailing "..." trigger.
+    await userEvent.click(await screen.findByRole("button", { name: path }));
+  }
+
+  it("opens a supporting file in a focused editor", async () => {
+    renderPage(new URLSearchParams("view=files"));
+
+    await openRowMenu(/patterns\.md/);
+    await userEvent.click(
+      await screen.findByRole("menuitem", { name: "Edit" }),
+    );
+
+    // One gesture owes all three: the file is open, the pane is the editor
+    // rather than the preview, and the caret is already in it.
+    const editor = screen.getByRole("textbox", { name: /patterns\.md/ });
+    expect(screen.queryByTestId("preview")).toBeNull();
+    expect(document.activeElement).toBe(editor);
+  });
+
+  it("focuses the editor for the file that is already open", async () => {
+    renderPage(new URLSearchParams("view=files"));
+
+    // SKILL.md opens selected, so this path mounts nothing new. A mount-only
+    // autoFocus would silently do nothing here.
+    await openRowMenu(/SKILL\.md/);
+    await userEvent.click(
+      await screen.findByRole("menuitem", { name: "Edit" }),
+    );
+
+    expect(document.activeElement).toBe(
+      screen.getByRole("textbox", { name: /SKILL\.md/ }),
+    );
+  });
+
+  it("leaves the caret at the top rather than the end of the file", async () => {
+    renderPage(new URLSearchParams("view=files"));
+
+    await openRowMenu(/patterns\.md/);
+    await userEvent.click(
+      await screen.findByRole("menuitem", { name: "Edit" }),
+    );
+
+    const editor = screen.getByRole("textbox", {
+      name: /patterns\.md/,
+    }) as HTMLTextAreaElement;
+    expect([editor.selectionStart, editor.selectionEnd]).toEqual([0, 0]);
+  });
+
+  it("offers read-only viewers a plain-text view, not an edit they cannot make", async () => {
+    canEditRef.current = false;
+    renderPage(new URLSearchParams("view=files"));
+
+    expect(await screen.findByRole("button", { name: "Plain text" })).toBeTruthy();
+    expect(screen.queryByRole("button", { name: "Edit" })).toBeNull();
+    // No row menus either — the tree offers no action the page would refuse.
+    expect(screen.queryByRole("button", { name: /Actions for/ })).toBeNull();
   });
 });
 
@@ -240,7 +304,7 @@ describe("SkillDetailPage save pill", () => {
   it("counts a supporting-file edit as one changed file", async () => {
     renderPage(new URLSearchParams("view=files"));
     fireEvent.click(await screen.findByRole("tab", { name: "patterns.md" }));
-    fireEvent.click(screen.getByRole("button", { name: "Plain text" }));
+    fireEvent.click(screen.getByRole("button", { name: "Edit" }));
     fireEvent.change(screen.getByRole("textbox", { name: /patterns\.md/ }), {
       target: { value: "edited content" },
     });

--- a/packages/views/skills/components/skill-detail-page.tsx
+++ b/packages/views/skills/components/skill-detail-page.tsx
@@ -528,6 +528,7 @@ function FilesTab({
   mode,
   canEdit,
   addingFile,
+  focusEditor,
   onSelectPath,
   onModeChange,
   onStartAddFile,
@@ -535,7 +536,9 @@ function FilesTab({
   onCancelAddFile,
   onDeleteFile,
   onRenameFile,
+  onEditFile,
   onContentChange,
+  onFocusHandled,
 }: {
   filePaths: string[];
   selectedPath: string;
@@ -543,6 +546,7 @@ function FilesTab({
   mode: FileMode;
   canEdit: boolean;
   addingFile: boolean;
+  focusEditor: boolean;
   onSelectPath: (path: string) => void;
   onModeChange: (mode: FileMode) => void;
   onStartAddFile: () => void;
@@ -550,16 +554,20 @@ function FilesTab({
   onCancelAddFile: () => void;
   onDeleteFile: (path?: string) => void;
   onRenameFile: (from: string, to: string) => void;
+  onEditFile: (path: string) => void;
   onContentChange: (content: string) => void;
+  onFocusHandled: () => void;
 }) {
   const { t } = useT("skills");
   const validatePath = useValidateNewFilePath();
   const supportingPaths = filePaths.filter((p) => p !== SKILL_MD);
   const isMd = isMarkdownPath(selectedPath);
   // Absent for read-only viewers so the tree never offers an action it would
-  // then refuse. SKILL.md is excluded inside the tree by reservedPath.
+  // then refuse. Both rails get the same object: SKILL.md keeps Edit and loses
+  // rename/delete, which the tree derives from reservedPath.
   const treeActions = canEdit
     ? {
+        onEdit: onEditFile,
         validatePath,
         onRename: onRenameFile,
         onDelete: onDeleteFile,
@@ -582,6 +590,7 @@ function FilesTab({
           {t(($) => $.detail.files.main)}
         </p>
         <FileTree
+          actions={treeActions}
           filePaths={[SKILL_MD]}
           selectedPath={selectedPath}
           onSelect={onSelectPath}
@@ -633,6 +642,11 @@ function FilesTab({
           </span>
           <div className="ml-auto flex shrink-0 items-center gap-1">
             {isMd && (
+              // The second segment is named for what it does for THIS viewer:
+              // "Edit" when the pane it opens accepts typing, "Plain text"
+              // when the same pane is read-only. Same mode either way — only
+              // the promise differs, and offering an edit the page would
+              // refuse is the thing this rail is careful not to do.
               <div
                 role="group"
                 aria-label={t(($) => $.detail.files.mode_aria)}
@@ -653,7 +667,9 @@ function FilesTab({
                   >
                     {value === "preview"
                       ? t(($) => $.detail.files.mode_preview)
-                      : t(($) => $.detail.files.mode_raw)}
+                      : canEdit
+                        ? t(($) => $.detail.files.mode_edit)
+                        : t(($) => $.detail.files.mode_raw)}
                   </button>
                 ))}
               </div>
@@ -687,7 +703,9 @@ function FilesTab({
             content={selectedContent}
             mode={mode}
             readOnly={!canEdit}
+            autoFocus={focusEditor}
             onChange={onContentChange}
+            onFocusHandled={onFocusHandled}
           />
         </div>
       </section>
@@ -756,6 +774,10 @@ export function SkillDetailPage({ skillId }: { skillId: string }) {
   // and survives switching files. It used to live inside FileViewer, which the
   // per-file `key` remounted — every file switch silently snapped back.
   const [fileMode, setFileMode] = useState<FileMode>("preview");
+  // Which file's editor is waiting for the caret. A path rather than a boolean
+  // so a request raised for one row cannot land in another row's editor if the
+  // selection moves before the effect runs.
+  const [focusPath, setFocusPath] = useState<string | null>(null);
 
   const urlView = navigation.searchParams.get("view");
   const [activeView, setActiveView] = useState<DetailView>(() =>
@@ -988,6 +1010,22 @@ export function SkillDetailPage({ skillId }: { skillId: string }) {
     setFiles((prev) => prev.filter((f) => f.path !== path));
     if (path === selectedPath) setSelectedPath(SKILL_MD);
   };
+
+  // "Edit" from a row menu is one gesture that owes three things: the file is
+  // open, the pane is the editor rather than the preview, and the caret is in
+  // it. Doing fewer would leave the user another click away from typing, which
+  // is the whole reason the entry exists.
+  const handleEditFile = useCallback(
+    (path: string) => {
+      if (!canEdit) return;
+      setSelectedPath(path);
+      setFileMode("raw");
+      setFocusPath(path);
+    },
+    [canEdit],
+  );
+
+  const handleFocusHandled = useCallback(() => setFocusPath(null), []);
 
   const handleRenameFile = (from: string, to: string) => {
     if (from === SKILL_MD) return;
@@ -1229,6 +1267,7 @@ export function SkillDetailPage({ skillId }: { skillId: string }) {
             mode={fileMode}
             canEdit={canEdit}
             addingFile={addingFile}
+            focusEditor={focusPath === selectedPath}
             onSelectPath={setSelectedPath}
             onModeChange={setFileMode}
             onStartAddFile={() => setAddingFile(true)}
@@ -1236,7 +1275,9 @@ export function SkillDetailPage({ skillId }: { skillId: string }) {
             onCancelAddFile={() => setAddingFile(false)}
             onDeleteFile={handleDeleteFile}
             onRenameFile={handleRenameFile}
+            onEditFile={handleEditFile}
             onContentChange={handleFileContentChange}
+            onFocusHandled={handleFocusHandled}
           />
         )}
       </div>


### PR DESCRIPTION
Fixes MUL-5654.

## The bug

Clicking a supporting file in the skill file rail never selected it — it opened the row's action menu instead. Only `SKILL.md` could be opened, which is why the issue started life as "只有 SKILL.md 能编辑".

The row's `…` trigger widens its hit area with `after:absolute after:-inset-1`, but the button itself was not positioned. The pseudo-element therefore resolved against the nearest positioned ancestor — the row — and covered it end to end. Absolutely positioned, it painted above the in-flow name button and swallowed every click on the file name; `opacity-0` does not opt an element out of hit testing, so the row was dead even before hover. `SKILL.md` renders in a rail without actions, so it had no overlay and stayed clickable.

Every other widened hit area in the repo (`slider.tsx`, `switch.tsx`, `checkbox.tsx`, `radio-group.tsx`) sits on an element that is itself `relative`; this one was the outlier.

## Changes

1. `relative` on the menu trigger, so the `::after` is bounded by the button. Rows select on click again.
2. The raw segment of the view toggle reads **Edit** for viewers who may edit. It stays **Plain text** for read-only viewers rather than promising an edit the page would refuse.
3. The row menu gains an **Edit** entry: it opens the file, switches the pane from preview to the editor, and puts the caret at the top of it. Works for the file that is already open too — that path mounts nothing, so focus is driven by a request the page owns rather than by mount-time `autoFocus`.
4. `SKILL.md` keeps the Edit entry and still withholds rename/delete: `reservedPath` now narrows the menu instead of removing it.

New i18n keys `detail.files.mode_edit` and `file_tree.actions.edit` in all four locales.

## Verification

- `pnpm exec vitest run` in `packages/views` — 3521 passed (300 files), including locale parity.
- New unit tests: Edit opens a focused editor for a supporting file and for the already-open file; the caret lands at offset 0; read-only viewers get "Plain text" and no row menus; `SKILL.md` offers Edit but neither rename nor delete; a class-pairing guard on the trigger (`relative` + `after:absolute`).
- `pnpm typecheck` — 6/6 tasks pass. `eslint packages/views/skills` — clean.
- Real-browser check (headless Chromium, classes read out of the component and compiled with the project's Tailwind): before the fix `elementFromPoint` over the file name returned the menu trigger and the click landed there; after it, the name button receives clicks on the name and on empty row space, while the glyph and ~4px around it still hit the menu — the widened target the class was there to provide is preserved.

jsdom has no layout or hit testing, which is why the original 51-test suite stayed green through this bug; the unit test added here can only hold the class pairing, so the behavioural check is the browser probe above.

## Note for review

Giving `SKILL.md` a (single-entry) row menu is a small scope addition beyond the literal bug — it comes from the "右键也可以有编辑选项" part of the request. If you would rather the main file keep a bare row, dropping it is a two-line revert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
