### PR TITLE
LOOP-735: seed workspace list before auth gate opens

### DIFF
--- a/packages/core/platform/auth-initializer.test.tsx
+++ b/packages/core/platform/auth-initializer.test.tsx
@@ -1,0 +1,112 @@
+// @vitest-environment jsdom
+
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { cleanup, render, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { setApiInstance } from "../api";
+import type { ApiClient } from "../api/client";
+import { createAuthStore, registerAuthStore } from "../auth";
+import type { StorageAdapter, User, Workspace } from "../types";
+import { workspaceKeys } from "../workspace/queries";
+import { AuthInitializer } from "./auth-initializer";
+
+const user = {
+  id: "u1",
+  name: "Alice",
+  email: "alice@example.com",
+  avatar_url: null,
+  onboarded_at: "2026-01-01T00:00:00Z",
+  onboarding_questionnaire: {},
+  starter_content_state: "imported",
+  language: null,
+  profile_description: "",
+  timezone: null,
+  created_at: "2026-01-01T00:00:00Z",
+  updated_at: "2026-01-01T00:00:00Z",
+} satisfies User;
+
+const workspaces = [
+  {
+    id: "ws-1",
+    name: "Loop",
+    slug: "loop",
+    description: null,
+    context: null,
+    settings: {},
+    repos: [],
+    issue_prefix: "LOOP",
+    avatar_url: null,
+    created_at: "2026-01-01T00:00:00Z",
+    updated_at: "2026-01-01T00:00:00Z",
+  },
+] satisfies Workspace[];
+
+function storage(initial: Record<string, string> = {}): StorageAdapter {
+  const data = { ...initial };
+  return {
+    getItem: (key) => data[key] ?? null,
+    setItem: (key, value) => {
+      data[key] = value;
+    },
+    removeItem: (key) => {
+      delete data[key];
+    },
+  };
+}
+
+function api(): ApiClient {
+  return {
+    getConfig: vi.fn().mockRejectedValue(new Error("skip config")),
+    getMe: vi.fn().mockResolvedValue(user),
+    listWorkspaces: vi.fn().mockResolvedValue(workspaces),
+    setToken: vi.fn(),
+  } as unknown as ApiClient;
+}
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("AuthInitializer", () => {
+  it.each([
+    ["cookie", true, {}],
+    ["token", false, { multica_token: "token" }],
+  ] as const)(
+    "seeds workspace list before opening the auth gate in %s mode",
+    async (_mode, cookieAuth, initialStorage) => {
+      const queryClient = new QueryClient({
+        defaultOptions: { queries: { retry: false } },
+      });
+      const fakeApi = api();
+      const fakeStorage = storage(initialStorage);
+      setApiInstance(fakeApi);
+      registerAuthStore(
+        createAuthStore({
+          api: fakeApi,
+          storage: fakeStorage,
+          cookieAuth,
+        }),
+      );
+
+      const onLogin = vi.fn(() => {
+        expect(queryClient.getQueryData(workspaceKeys.list())).toEqual(
+          workspaces,
+        );
+      });
+
+      render(
+        <QueryClientProvider client={queryClient}>
+          <AuthInitializer
+            cookieAuth={cookieAuth}
+            storage={fakeStorage}
+            onLogin={onLogin}
+          >
+            <div />
+          </AuthInitializer>
+        </QueryClientProvider>,
+      );
+
+      await waitFor(() => expect(onLogin).toHaveBeenCalledTimes(1));
+    },
+  );
+});

--- a/packages/core/platform/auth-initializer.tsx
+++ b/packages/core/platform/auth-initializer.tsx
@@ -106,8 +106,8 @@ export function AuthInitializer({
       // selection here.
       Promise.all([api.getMe(), api.listWorkspaces()])
         .then(([user, wsList]) => {
-          onAuthSuccess(user);
           qc.setQueryData(workspaceKeys.list(), wsList);
+          onAuthSuccess(user);
         })
         .catch((err) => {
           logger.error("cookie auth init failed", err);
@@ -128,10 +128,10 @@ export function AuthInitializer({
 
     Promise.all([api.getMe(), api.listWorkspaces()])
       .then(([user, wsList]) => {
-        onAuthSuccess(user);
         // Seed React Query cache so the URL-driven layout can resolve the
         // slug without a second fetch.
         qc.setQueryData(workspaceKeys.list(), wsList);
+        onAuthSuccess(user);
       })
       .catch((err) => {
         logger.error("auth init failed", err);


### PR DESCRIPTION
## Root Cause

On hard refresh, `AuthInitializer` called `onAuthSuccess(user)` before seeding `workspaceKeys.list()` in React Query. `onAuthSuccess` opens the auth gate by setting the user and `isLoading=false`, so the dashboard shell could render the workspace switcher before the workspace list cache was repopulated.

## Fix

- Seed `workspaceKeys.list()` before opening the auth gate in both cookie and token auth initialization paths.
- Add a jsdom regression test that asserts the workspace list is already in the query cache when `onLogin` fires.

## Verification

- `pnpm --dir packages/core exec vitest run platform/auth-initializer.test.tsx`
- `pnpm --dir packages/views exec vitest run layout/app-sidebar.test.tsx workspace/no-access-page.test.tsx`
- `pnpm --filter @multica/core typecheck`
- `pnpm --filter @multica/views typecheck`
- `git diff --check`
- Real Chrome verification on `/loop735-a-648088/issues`: hard refresh and F5 both kept the workspace switcher populated with `Loop 735 A 648088` and `Loop 735 B 648088`.

## Notes

- Requested base branch `test` is not present in `multica-ai/multica` (`git ls-remote --heads origin test` returned empty; GitHub branch API returned 404), so this PR targets `main`.
- Workspace dropdown audit: the dashboard switcher is the shared `AppSidebar`; other `workspaceListOptions()` consumers found are redirects, onboarding/invite flows, no-access fallback, or cache updates. The shared switcher and no-access fallback tests passed.
