### PR TITLE
feat(mobile): enable basic native iPad support

### DIFF
--- a/apps/mobile/app.config.ts
+++ b/apps/mobile/app.config.ts
@@ -31,7 +31,11 @@ export default ({ config }: ConfigContext): ExpoConfig => {
     // iOS icon size from this single PNG.
     icon: "./assets/icon.png",
     ios: {
-      supportsTablet: false,
+      // Keep the existing iPhone portrait policy while letting Expo generate
+      // the iPad-specific orientation declarations and device family. iPad
+      // then remains free to rotate between its native portrait and landscape
+      // layouts without widening the phone form factor's behavior.
+      supportsTablet: true,
       // Per-variant bundle id overrides exist for one reason: an Apple ID
       // can only sign bundle prefixes it owns, so contributors not on the
       // Multica Apple Developer team (and external users self-building a

--- a/apps/mobile/app/(app)/[workspace]/(tabs)/_layout.tsx
+++ b/apps/mobile/app/(app)/[workspace]/(tabs)/_layout.tsx
@@ -43,6 +43,12 @@ const BADGE_STYLE = {
   backgroundColor: THEME.light.brand,
 };
 
+// Phone scenes keep their full available width. On iPad, capping the shared
+// tab scene preserves the existing single-column interaction model and keeps
+// prose, issue rows, and the chat timeline readable in landscape. This is a
+// layout-only constraint: each tab still owns the same navigation and data.
+const TABLET_CONTENT_MAX_WIDTH = 760;
+
 export default function TabsLayout() {
   const { colorScheme } = useColorScheme();
   const t = THEME[colorScheme];
@@ -72,6 +78,11 @@ export default function TabsLayout() {
           tabBarInactiveTintColor: t.mutedForeground,
           tabBarStyle: { backgroundColor: t.background },
           tabBarLabelStyle: { fontSize: 11 },
+          sceneStyle: {
+            width: "100%",
+            maxWidth: TABLET_CONTENT_MAX_WIDTH,
+            alignSelf: "center",
+          },
         }}
       >
         <Tabs.Screen


### PR DESCRIPTION
## What does this PR do?

Enables **basic native iPad support** for the mobile app. Today `ios.supportsTablet: false` installs the app in iPhone compatibility mode on iPad. This change opts into the iPad device family and preserves the existing single-column tab model with a centered 760pt maximum content width.

This is intentionally not a complete iPad experience. In landscape, the centered single column leaves side whitespace; that is a readability trade-off to avoid stretching phone-designed prose, issue rows, and chat timelines across the full iPad width. It does not add split view or master-detail navigation.

iPhone behavior remains unchanged: the existing app orientation is still portrait, so iPhone cannot enter the wide landscape case, and all iPhone portrait scene widths remain below the 760pt cap.

`supportsTablet: false` may be an intentional product choice. This is offered as a scoped option for maintainers to evaluate, not as a claim that upstream must adopt it. Keeping the current setting is a valid outcome.

## Related Issue

Closes #6328

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Refactor / code improvement (no behavior change)
- [ ] Documentation update
- [ ] Tests (adding or improving test coverage)
- [ ] CI / infrastructure

## Changes Made

- `apps/mobile/app.config.ts`: changes `ios.supportsTablet` to `true`; Expo then generates the iPad device family and iPad orientation declarations while retaining the existing iPhone portrait policy.
- `apps/mobile/app/(app)/[workspace]/(tabs)/_layout.tsx`: constrains every tab scene to a maximum 760pt width and centers it, without changing routes, navigation, or data behavior.

## How to Test

1. Build the mobile app and install it on an iPad; confirm it opens as a native iPad app rather than in iPhone compatibility mode.
2. On an iPad mini, check 744pt portrait and 1133pt landscape across Inbox, My Issues, Chat, agent/session picker, and More. Confirm content stays one readable centered column without overflow.
3. On an iPhone, verify the unchanged portrait Inbox and Chat layouts.
4. Run `pnpm --filter @multica/mobile test`, `pnpm --filter @multica/mobile typecheck`, and `pnpm --filter @multica/mobile lint`.

Internal validation: an iPad mini (A17 Pro) accepted TestFlight build 8 at both 744pt portrait and 1133pt landscape.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have run tests locally and they pass
- [ ] I have added or updated tests where applicable — this is Expo configuration plus a shared layout constraint; device behavior was validated on an iPad mini.
- [ ] If this change affects the UI, I have included before/after screenshots — no screenshots are attached; acceptance covered real-device portrait and landscape behavior.
- [x] I have updated relevant documentation to reflect my changes — source comments document the iPhone invariant and intentional single-column constraint.
- [ ] If I added a new runtime / coding tool / UI tab, I synced the change to **landing copy** (`apps/web/features/landing/i18n/`) and **relevant docs** (`apps/docs/content/docs/`)
- [ ] If this PR touches Chinese product copy, I checked it against `apps/docs/content/docs/developers/conventions.zh.mdx` (terminology, mixed-rule for `task` / `issue` / `skill`)
- [x] I have considered and documented any risks above
- [x] I will address all reviewer comments before requesting merge

Local results: 8 test files / 45 tests passed; typecheck passed; lint completed with 0 errors and 7 pre-existing warnings outside these files. `expo config --type prebuild` confirmed `orientation: "portrait"` and `ios.supportsTablet: true`.

## AI Disclosure

**AI tool used:** Codex (Multica Dev-iOS agent)

**Prompt / approach:** Investigated why the app used iPhone compatibility mode on iPad, traced it to the Expo iOS tablet setting, and chose the smallest readable single-column adaptation. The change was verified in a clean upstream worktree and on an iPad mini internal build; the PR documents its scope and leaves the product decision to maintainers.

## Screenshots (optional)

Not attached. The real-device acceptance focused on native iPad presentation, readable landscape width, and unchanged iPhone behavior; the landscape whitespace described above is intentional.
