### PR TITLE
fix(server): read the chat's channel from its binding instead of guessing

### DIFF
--- a/server/internal/handler/daemon.go
+++ b/server/internal/handler/daemon.go
@@ -21,7 +21,6 @@ import (
 	"github.com/multica-ai/multica/server/internal/analytics"
 	"github.com/multica-ai/multica/server/internal/auth"
 	"github.com/multica-ai/multica/server/internal/daemonws"
-	"github.com/multica-ai/multica/server/internal/integrations/channel"
 	"github.com/multica-ai/multica/server/internal/integrations/slack"
 	obsmetrics "github.com/multica-ai/multica/server/internal/metrics"
 	"github.com/multica-ai/multica/server/internal/middleware"
@@ -2123,35 +2122,30 @@ func (h *Handler) buildClaimedTaskResponse(r *http.Request, task *db.AgentTaskQu
 			// is operating inside an IM conversation and not the Multica web app
 			// (MUL-3871). Empty for a web-only chat session.
 			//
-			// Every registered channel type is probed, not just Slack: a Feishu
-			// session writes the same channel_chat_session_binding row under
-			// channel_type='feishu' (lark/channel_store.go), so the Slack-only
-			// lookup used to report a Feishu chat as web-backed. Downstream that
-			// mis-flag made the brief inject `multica attachment upload` guidance
-			// into a conversation that cannot carry attachments at all (MUL-4899).
+			// The binding is read WITHOUT naming a channel. Every channel writes
+			// the same channel_chat_session_binding row and differs only in
+			// channel_type, and UNIQUE (chat_session_id) allows at most one, so
+			// the row itself is the answer. Enumerating candidate channels here
+			// was the bug twice over: the Slack-only lookup reported a Feishu
+			// chat as web-backed (MUL-4899), and the {slack, feishu} list that
+			// replaced it did the same to WeCom. Downstream that mis-flag makes
+			// the brief inject `multica attachment upload` guidance into a
+			// conversation that cannot carry attachments at all.
 			//
 			// ChatInThread stays Slack-only on purpose. It selects between
 			// `multica chat history` and `multica chat thread`, and those two
 			// endpoints are hardwired to h.SlackHistory (chat_history.go) — there
-			// is no Feishu history reader, so the flag has nothing to select
-			// between on any other channel and must not imply one exists.
-			for _, channelType := range []channel.Type{slack.TypeSlack, channel.TypeFeishu} {
-				binding, berr := h.Queries.GetChannelChatSessionBindingBySession(r.Context(), db.GetChannelChatSessionBindingBySessionParams{
-					ChatSessionID: cs.ID,
-					ChannelType:   string(channelType),
-				})
-				if berr != nil {
-					continue
-				}
-				resp.ChatChannelType = string(channelType)
-				if channelType == slack.TypeSlack {
+			// is no history reader on any other channel, so the flag has nothing
+			// to select between there and must not imply one exists.
+			if binding, berr := h.Queries.GetChannelChatSessionBindingBySessionAny(r.Context(), cs.ID); berr == nil {
+				resp.ChatChannelType = binding.ChannelType
+				if binding.ChannelType == string(slack.TypeSlack) {
 					// The latest trigger was a thread reply iff its reply-target
 					// thread (last_thread_id) differs from its own message id (a
 					// top-level @mention records its own ts as both).
 					resp.ChatInThread = binding.LastThreadID.Valid && binding.LastThreadID.String != "" &&
 						binding.LastThreadID.String != binding.LastMessageID.String
 				}
-				break
 			}
 			// A web chat can opt into the same durable project context as an
 			// issue-bound task. Revalidate the soft reference in this workspace at

--- a/server/internal/handler/daemon_claim_channel_type_test.go
+++ b/server/internal/handler/daemon_claim_channel_type_test.go
@@ -119,6 +119,34 @@ func TestClaim_SlackBoundSessionStillReportsThreadState(t *testing.T) {
 	}
 }
 
+// A channel whose adapter the claim handler does not name must still be
+// reported. The lookup enumerated a fixed {slack, feishu} list, so every
+// channel added after it — WeCom is the first — claimed as a web chat and
+// inherited the web chat's `multica attachment upload` guidance, the exact
+// MUL-4899 failure the fixed list was supposed to have ended.
+//
+// The list is what is under test here, not WeCom: the binding row shape is
+// identical for every channel, so a handler that reads the row instead of
+// guessing the channel_type cannot regress the next one either.
+func TestClaim_UnlistedChannelBoundSessionReportsChannelType(t *testing.T) {
+	if testHandler == nil {
+		t.Skip("database not available")
+	}
+	ctx := context.Background()
+	agentID, sessionID, runtimeID, _ := setupDirectChatSession(t, ctx, "wecom-backed chat")
+	seedChannelBinding(t, ctx, agentID, sessionID, "wecom", "msg-1", "thread-9")
+	insertChannelChatTask(t, ctx, agentID, runtimeID, sessionID)
+	requeueTaskForClaim(t, ctx, sessionID)
+
+	channelType, inThread := claimChatChannelFields(t, runtimeID)
+	if channelType != "wecom" {
+		t.Errorf("chat_channel_type = %q, want %q — a channel the handler does not name must not look like a web chat", channelType, "wecom")
+	}
+	if inThread {
+		t.Error("chat_in_thread must stay false off Slack: it selects between two Slack-only read commands")
+	}
+}
+
 func TestClaim_UnboundSessionReportsNoChannelType(t *testing.T) {
 	if testHandler == nil {
 		t.Skip("database not available")

--- a/server/pkg/db/generated/channel.sql.go
+++ b/server/pkg/db/generated/channel.sql.go
@@ -800,6 +800,35 @@ func (q *Queries) GetChannelChatSessionBindingBySession(ctx context.Context, arg
 	return i, err
 }
 
+const getChannelChatSessionBindingBySessionAny = `-- name: GetChannelChatSessionBindingBySessionAny :one
+SELECT id, chat_session_id, installation_id, channel_type, channel_chat_id, chat_type, last_message_id, last_thread_id, config, created_at FROM channel_chat_session_binding
+WHERE chat_session_id = $1
+`
+
+// Channel-agnostic reverse lookup: which channel, if any, is behind this
+// chat_session? UNIQUE (chat_session_id) guarantees at most one row, so a
+// caller that only needs to READ the binding never has to name the channel it
+// is hoping for — and therefore cannot go blind on a channel added later.
+// The channel_type-scoped variant above stays for the outbound senders, which
+// are per-platform by construction and must not deliver into a foreign one.
+func (q *Queries) GetChannelChatSessionBindingBySessionAny(ctx context.Context, chatSessionID pgtype.UUID) (ChannelChatSessionBinding, error) {
+	row := q.db.QueryRow(ctx, getChannelChatSessionBindingBySessionAny, chatSessionID)
+	var i ChannelChatSessionBinding
+	err := row.Scan(
+		&i.ID,
+		&i.ChatSessionID,
+		&i.InstallationID,
+		&i.ChannelType,
+		&i.ChannelChatID,
+		&i.ChatType,
+		&i.LastMessageID,
+		&i.LastThreadID,
+		&i.Config,
+		&i.CreatedAt,
+	)
+	return i, err
+}
+
 const getChannelInstallation = `-- name: GetChannelInstallation :one
 SELECT id, workspace_id, agent_id, channel_type, config, status, ws_lease_token, ws_lease_expires_at, installer_user_id, installed_at, created_at, updated_at FROM channel_installation
 WHERE id = $1 AND channel_type = $2

--- a/server/pkg/db/queries/channel.sql
+++ b/server/pkg/db/queries/channel.sql
@@ -446,6 +446,16 @@ SELECT * FROM channel_chat_session_binding
 WHERE chat_session_id = sqlc.arg('chat_session_id')
   AND channel_type = sqlc.arg('channel_type');
 
+-- name: GetChannelChatSessionBindingBySessionAny :one
+-- Channel-agnostic reverse lookup: which channel, if any, is behind this
+-- chat_session? UNIQUE (chat_session_id) guarantees at most one row, so a
+-- caller that only needs to READ the binding never has to name the channel it
+-- is hoping for — and therefore cannot go blind on a channel added later.
+-- The channel_type-scoped variant above stays for the outbound senders, which
+-- are per-platform by construction and must not deliver into a foreign one.
+SELECT * FROM channel_chat_session_binding
+WHERE chat_session_id = $1;
+
 -- name: UpdateChannelChatSessionBindingReplyTarget :exec
 -- Records the most recent inbound trigger message + thread so the decoupled
 -- outbound patcher can thread its reply back into the originating topic.


### PR DESCRIPTION
A chat claim works out `chat_channel_type` by trying the binding lookup once per channel it knows the name of. That list was Slack alone, then `{Slack, Feishu}` after MUL-4899. A channel added later falls off the end and claims as a web chat — so the runtime brief tells the agent to deliver files with `multica attachment upload` into a conversation that cannot carry an attachment. That is exactly the failure MUL-4899 fixed, reintroduced by the shape of the fix: every new channel has to remember to add its name here, and nothing fails loudly when it doesn't.

I hit this building a WeCom adapter (#5833's smart-bot path), but the bug isn't WeCom-specific — it's the next channel, whichever one that is.

The row already holds the answer. Every channel writes the same `channel_chat_session_binding` and differs only in `channel_type`, and `UNIQUE (chat_session_id)` allows at most one per session. So this reads the row by session id and takes `channel_type` off what comes back, instead of guessing names:

```go
binding, berr := h.Queries.GetChannelChatSessionBindingBySessionAny(r.Context(), cs.ID)
if berr == nil {
    resp.ChatChannelType = binding.ChannelType
    ...
}
```

Two things deliberately unchanged:

- **`chat_in_thread` stays Slack-only**, now keyed on the row's own `channel_type` rather than on which loop iteration found it. The two commands it picks between are hardwired to the Slack history reader, and no other channel has one.
- **The `channel_type`-scoped query stays** for the outbound senders. Those are per-platform by construction and must never deliver into a foreign channel; only the claim path wants "whichever channel this session belongs to".

The new query is additive (`sqlc generate` produces 29 new lines, nothing else moves). Test covers a binding whose `channel_type` is outside the old hardcoded set — it fails on `main` and passes here.

`go build ./...`, `go vet ./...` and the handler suite are green.

cc @Bohan-J — small and self-contained.
