### PR TITLE
fix(channel): defer bare fresh commands

### DIFF
--- a/server/internal/integrations/channel/engine/resolvers.go
+++ b/server/internal/integrations/channel/engine/resolvers.go
@@ -58,6 +58,9 @@ type Result struct {
 	IssueNumber     int32
 	IssueIdentifier string
 	IssueTitle      string
+	// runScheduled reports whether this ingest scheduled a normal chat run.
+	// It is Router-internal state: repliers must continue to use Outcome.
+	runScheduled bool
 }
 
 // ResolvedInstallation is the channel-agnostic installation context the Router

--- a/server/internal/integrations/channel/engine/router.go
+++ b/server/internal/integrations/channel/engine/router.go
@@ -56,7 +56,7 @@ type Router struct {
 	logger *slog.Logger
 
 	pendingFreshMu sync.Mutex
-	pendingFresh   map[string]bool
+	pendingFresh   map[string]time.Time
 }
 
 // Config tunes the Router. Zero values default.
@@ -108,7 +108,7 @@ func NewRouter(issues IssueCreator, tasks TaskEnqueuer, reader SessionReader, cf
 		mediaCancel:  mediaCancel,
 		mediaSem:     make(chan struct{}, cfg.MediaConcurrency),
 		logger:       cfg.Logger,
-		pendingFresh: make(map[string]bool),
+		pendingFresh: make(map[string]time.Time),
 		mediaQueues:  make(map[string]*mediaQueueEntry),
 	}
 }
@@ -187,12 +187,16 @@ func (r *Router) Handle(ctx context.Context, msg channel.InboundMessage) error {
 	}
 
 	// /new is a channel-wide product command, not an adapter capability. Parse
-	// it here so every adapter that delivers it as message text gets the same
-	// fresh-session behavior. Feishu already strips /new before its context
-	// enricher runs and sets ForceFresh; the guard preserves that enriched body.
-	if !msg.ForceFresh {
-		if body, ok := ParseFreshSessionCommand(msg.CommandText); ok {
-			msg.ForceFresh = true
+	// the original command source here even when an adapter already set
+	// ForceFresh, so bare-command classification stays identical across
+	// platforms. Only rewrite Text when the adapter has not already stripped
+	// the directive; Feishu enriches that stripped body before it reaches us.
+	bareFresh := false
+	if body, ok := ParseFreshSessionCommand(msg.CommandText); ok {
+		adapterAlreadyStripped := msg.ForceFresh
+		msg.ForceFresh = true
+		bareFresh = body == ""
+		if !adapterAlreadyStripped {
 			msg.Text = body
 		}
 	}
@@ -205,7 +209,7 @@ func (r *Router) Handle(ctx context.Context, msg channel.InboundMessage) error {
 		return ErrNoResolverSet
 	}
 
-	res, inst, err := r.dispatch(ctx, set, msg)
+	res, inst, err := r.dispatch(ctx, set, msg, bareFresh)
 	if err != nil {
 		r.logger.Error("channel router: dispatch error",
 			"channel_type", string(msg.Source.ChannelType),
@@ -223,7 +227,7 @@ func (r *Router) Handle(ctx context.Context, msg channel.InboundMessage) error {
 
 	// Typing indicator on ingest, detached so the reaction HTTP call never
 	// blocks the connector ACK path.
-	if res.Outcome == OutcomeIngested && set.Typing != nil {
+	if res.Outcome == OutcomeIngested && res.runScheduled && set.Typing != nil {
 		go func() {
 			tctx, cancel := context.WithTimeout(context.Background(), r.replyTimeout)
 			defer cancel()
@@ -236,7 +240,7 @@ func (r *Router) Handle(ctx context.Context, msg channel.InboundMessage) error {
 
 // dispatch runs the pipeline and returns the typed result plus the resolved
 // installation (needed by the outbound side). Mirrors lark.Dispatcher.Handle.
-func (r *Router) dispatch(ctx context.Context, set ResolverSet, msg channel.InboundMessage) (Result, ResolvedInstallation, error) {
+func (r *Router) dispatch(ctx context.Context, set ResolverSet, msg channel.InboundMessage, bareFresh bool) (Result, ResolvedInstallation, error) {
 	// 1. Route to installation. The adapter maps the platform routing key
 	//    (carried on the message) to its installation row. These drop
 	//    branches run BEFORE the dedup claim because they have no valid
@@ -271,7 +275,7 @@ func (r *Router) dispatch(ctx context.Context, set ResolverSet, msg channel.Inbo
 		claimed = true
 	}
 
-	res, finalize, err := r.processClaimed(ctx, set, msg, inst, claimToken)
+	res, finalize, err := r.processClaimed(ctx, set, msg, inst, claimToken, bareFresh)
 
 	if claimed {
 		r.applyFinalize(ctx, set, inst.ID, msg.MessageID, claimToken, finalize)
@@ -295,7 +299,7 @@ const (
 
 // processClaimed runs the post-dedup pipeline. Mirrors
 // lark.Dispatcher.processClaimed; see its boundary contract per step.
-func (r *Router) processClaimed(ctx context.Context, set ResolverSet, msg channel.InboundMessage, inst ResolvedInstallation, claimToken pgtype.UUID) (Result, dedupFinalize, error) {
+func (r *Router) processClaimed(ctx context.Context, set ResolverSet, msg channel.InboundMessage, inst ResolvedInstallation, claimToken pgtype.UUID, bareFresh bool) (Result, dedupFinalize, error) {
 	// 3. Group-mention filter (group chats only), before identity so an
 	//    unbound user's idle group chatter never spams a binding card.
 	if msg.Source.ChatType == channel.ChatTypeGroup && !msg.AddressedToBot {
@@ -337,6 +341,18 @@ func (r *Router) processClaimed(ctx context.Context, set ResolverSet, msg channe
 	if err != nil {
 		// Single tx; an error rolled it back, nothing landed. Release.
 		return Result{}, finalizeRelease, fmt.Errorf("ensure chat session: %w", err)
+	}
+	if bareFresh {
+		// ForceFresh is a task-dispatch property. A bare command has no useful
+		// task to dispatch, so remember the intent and apply it to the next real
+		// message instead of writing or running an empty turn.
+		r.markPendingFresh(keyForSession(sessionID))
+		return Result{
+			Outcome:        OutcomeIngested,
+			InstallationID: inst.ID,
+			ChatSessionID:  sessionID,
+			Sender:         msg.Source.SenderID,
+		}, finalizeMark, nil
 	}
 	// 6. Append message + in-tx dedup Mark — the durable transition point.
 	// The media budget is persisted only when the message actually carries
@@ -410,6 +426,7 @@ func (r *Router) processClaimed(ctx context.Context, set ResolverSet, msg channe
 	//    session creator (group sessions are creator=installer). Latest sender
 	//    in a window wins (MUL-2645).
 	r.scheduleRun(set, inst, msg, sessionID, identity.UserID)
+	res.runScheduled = true
 	if resolveMedia {
 		r.enqueueMedia(set, inst, identity, appendRes.MessageID, msg, sessionID, localMediaDeadline)
 	}
@@ -548,7 +565,7 @@ func (r *Router) scheduleRun(set ResolverSet, inst ResolvedInstallation, msg cha
 	key := keyForSession(sessionID)
 	fresh := msg.ForceFresh
 	if r.batcher == nil {
-		r.flushChatRun(set, inst, msg, sessionID, initiatorUserID, fresh)
+		r.flushChatRun(set, inst, msg, sessionID, initiatorUserID, r.takePendingFresh(key, fresh))
 		return
 	}
 	if fresh {
@@ -573,12 +590,21 @@ func (r *Router) flushChatRun(set ResolverSet, inst ResolvedInstallation, msg ch
 
 	session, err := r.reader.GetChatSession(ctx, sessionID)
 	if err != nil {
+		if forceFresh {
+			r.markPendingFresh(keyForSession(sessionID))
+		}
 		r.logger.Error("channel router: flush reload chat session failed",
 			"chat_session_id", uuidString(sessionID), "err", err.Error())
 		r.clearTyping(ctx, set, sessionID)
 		return
 	}
 	if _, err := r.tasks.EnqueueChatTask(ctx, session, initiatorUserID, forceFresh); err != nil {
+		if forceFresh {
+			// ForceFresh belongs to the first successfully queued run, not the
+			// first attempt. Preserve it across offline, archived, or transient
+			// enqueue failures so the next real message cannot resume old context.
+			r.markPendingFresh(keyForSession(sessionID))
+		}
 		// No task was enqueued, so no task lifecycle event will ever publish and
 		// the platform's bus-driven typing clear can never fire. Clear the
 		// indicator here (before any notice) so the "processing" reaction does
@@ -608,16 +634,28 @@ func (r *Router) clearTyping(ctx context.Context, set ResolverSet, sessionID pgt
 func (r *Router) markPendingFresh(key string) {
 	r.pendingFreshMu.Lock()
 	defer r.pendingFreshMu.Unlock()
-	r.pendingFresh[key] = true
+	now := time.Now()
+	cutoff := now.Add(-pendingFreshTTL)
+	for pendingKey, markedAt := range r.pendingFresh {
+		if markedAt.Before(cutoff) {
+			delete(r.pendingFresh, pendingKey)
+		}
+	}
+	r.pendingFresh[key] = now
 }
 
 func (r *Router) takePendingFresh(key string, fallback bool) bool {
 	r.pendingFreshMu.Lock()
 	defer r.pendingFreshMu.Unlock()
-	fresh := fallback || r.pendingFresh[key]
+	markedAt, ok := r.pendingFresh[key]
 	delete(r.pendingFresh, key)
-	return fresh
+	return fallback || (ok && time.Since(markedAt) <= pendingFreshTTL)
 }
+
+// Bare fresh intent is in-memory plumbing between the command and the next
+// real message. Bound it so abandoned sessions cannot grow the Router map
+// forever. A process restart has the same reset-loss boundary.
+const pendingFreshTTL = 24 * time.Hour
 
 // emitFlushReply delivers an offline/archived notice for a flushed run.
 func (r *Router) emitFlushReply(ctx context.Context, set ResolverSet, inst ResolvedInstallation, msg channel.InboundMessage, sessionID pgtype.UUID, outcome Outcome) {

--- a/server/internal/integrations/channel/engine/router_test.go
+++ b/server/internal/integrations/channel/engine/router_test.go
@@ -986,12 +986,107 @@ func TestRouter_AdapterFreshBodyIsNotParsedAgain(t *testing.T) {
 	msg := p2pMessage(t)
 	msg.ForceFresh = true
 	msg.Text = "<recent_context>\n/new from history\n</recent_context>\n\ncurrent prompt"
+	msg.CommandText = "/new current prompt"
 
 	if err := h.router.Handle(context.Background(), msg); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	if got := h.binder.lastAppend.Message.Text; got != msg.Text {
 		t.Fatalf("adapter-enriched body changed: got %q want %q", got, msg.Text)
+	}
+}
+
+func TestRouter_BareFreshSkipsEmptyTurnAndForcesNextRealMessage(t *testing.T) {
+	h := newHarness(t)
+	h.media.noMedia = true
+
+	reset := p2pMessage(t)
+	reset.Text = "/new"
+	if err := h.router.Handle(context.Background(), reset); err != nil {
+		t.Fatalf("bare fresh Handle: %v", err)
+	}
+	if h.binder.appendedParams().Message.MessageID != "" {
+		t.Fatal("bare fresh must not append an empty user message")
+	}
+	if h.tasks.wasCalled() {
+		t.Fatal("bare fresh must not schedule an empty agent run")
+	}
+	if h.typing.calls() != 0 {
+		t.Fatal("bare fresh must not start a typing indicator without a run")
+	}
+	if h.dedup.marks() != 1 {
+		t.Fatalf("bare fresh dedup marks = %d, want 1", h.dedup.marks())
+	}
+
+	next := p2pMessage(t)
+	next.MessageID = "om-2"
+	next.Text = "start the new topic"
+	if err := h.router.Handle(context.Background(), next); err != nil {
+		t.Fatalf("next Handle: %v", err)
+	}
+	if !h.tasks.freshArg() {
+		t.Fatal("the next real message must consume the pending ForceFresh intent")
+	}
+
+	again := p2pMessage(t)
+	again.MessageID = "om-3"
+	if err := h.router.Handle(context.Background(), again); err != nil {
+		t.Fatalf("again Handle: %v", err)
+	}
+	if h.tasks.freshArg() {
+		t.Fatal("the pending ForceFresh intent must be consumed exactly once")
+	}
+}
+
+func TestRouter_AdapterBareFreshUsesOriginalCommandText(t *testing.T) {
+	h := newHarness(t)
+	h.media.noMedia = true
+
+	reset := p2pMessage(t)
+	reset.Text = "<recent_context>old topic</recent_context>"
+	reset.CommandText = "/new"
+	reset.ForceFresh = true
+	if err := h.router.Handle(context.Background(), reset); err != nil {
+		t.Fatalf("bare fresh Handle: %v", err)
+	}
+	if h.binder.appendedParams().Message.MessageID != "" {
+		t.Fatal("adapter-enriched bare fresh must not append a user message")
+	}
+	if h.tasks.wasCalled() {
+		t.Fatal("adapter-enriched bare fresh must not schedule an empty agent run")
+	}
+}
+
+func TestRouter_BareFreshSurvivesFailedEnqueue(t *testing.T) {
+	h := newHarness(t)
+	h.media.noMedia = true
+
+	reset := p2pMessage(t)
+	reset.Text = "/new"
+	if err := h.router.Handle(context.Background(), reset); err != nil {
+		t.Fatalf("bare fresh Handle: %v", err)
+	}
+
+	h.tasks.err = service.ErrChatTaskAgentNoRuntime
+	failed := p2pMessage(t)
+	failed.MessageID = "om-2"
+	failed.Text = "first attempt while offline"
+	if err := h.router.Handle(context.Background(), failed); err != nil {
+		t.Fatalf("failed enqueue Handle: %v", err)
+	}
+	if !h.tasks.freshArg() {
+		t.Fatal("failed enqueue must still receive the pending ForceFresh intent")
+	}
+
+	h.tasks.err = nil
+	next := p2pMessage(t)
+	next.MessageID = "om-3"
+	next.Text = "retry after runtime is available"
+	if err := h.router.Handle(context.Background(), next); err != nil {
+		t.Fatalf("retry Handle: %v", err)
+	}
+	if !h.tasks.freshArg() {
+		t.Fatal("pending ForceFresh intent must survive until a run queues")
 	}
 }
 


### PR DESCRIPTION
## What does this PR do?

Fixes the shared channel Router so a bare `/new` command records fresh-session intent without appending an empty user turn or scheduling an empty agent run. The next real message in the same chat session consumes that intent exactly once and starts a fresh agent session.

The root cause was that shared `/new` parsing stripped the command to an empty body but still sent the message through the normal append, typing, and run-scheduling path. The fix keeps classification and pending state inside the shared Router, so existing Slack and Feishu/Lark adapters inherit the same behavior without platform-specific changes.

The pending intent reuses the Router's existing in-process fresh/debounce ownership. It is bounded to 24 hours; like the existing debounce state, it is intentionally not durable across a hard process restart.

## Related Issue

Closes #6336

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Refactor / code improvement (no behavior change)
- [ ] Documentation update
- [x] Tests (adding or improving test coverage)
- [ ] CI / infrastructure

## Changes Made

- Classify a bare `/new` from the original `CommandText` inside the shared Router, including Feishu/Lark's pre-stripped and enriched path.
- Complete installation, identity, session, and dedup handling, then skip empty message persistence, typing, media handling, and task scheduling.
- Apply the pending fresh intent to the next successfully queued real message exactly once, retaining it across enqueue failures.
- Bound abandoned in-memory fresh intents with a 24-hour TTL.
- Keep the new control state private to the engine; no Slack, Lark, or future adapter contract is added.

## How to Test

1. Send a bare `/new` through Slack or Feishu/Lark and confirm no empty chat message, typing indicator, or agent task is created.
2. Send a normal follow-up in the same conversation and confirm its queued task has `force_fresh_session=true`.
3. Send another normal message and confirm fresh intent is not applied again.
4. Make the first follow-up enqueue fail, retry with another message, and confirm the fresh intent survives until a run is successfully queued.

Automated verification:

```text
go test ./internal/integrations/channel/... ./internal/integrations/lark/... ./internal/integrations/slack/...
```

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [ ] I have updated relevant documentation to reflect my changes
- [ ] If I added a new runtime / coding tool / UI tab, I synced the change to **landing copy** (`apps/web/features/landing/i18n/`) and **relevant docs** (`apps/docs/content/docs/`)
- [ ] If this PR touches Chinese product copy, I checked it against `apps/docs/content/docs/developers/conventions.zh.mdx` (terminology, mixed-rule for `task` / `issue` / `skill`)
- [x] I have considered and documented any risks above
- [x] I will address all reviewer comments before requesting merge

The screenshot, documentation, landing-copy, and Chinese-copy checklist items are not applicable because this is a server-only behavior fix with no user-facing copy or UI changes.

## AI Disclosure

**AI tool used:** OpenAI Codex

**Prompt / approach:**
Reviewed the change from the shared channel Router outward: command classification, dedup, session resolution, append/run/typing side effects, debounce state, enqueue failure, and both existing Slack and Feishu/Lark adapter mappings. Removed adapter-facing fields that were not required for the fix and verified the affected Go packages.

## Screenshots (optional)

Not applicable; no UI changes.
