### PR TITLE
MUL-5685: fix agent builder composer clearing and conversation routing

### DIFF
--- a/apps/desktop/src/renderer/src/pages/ai-builder-session-page.tsx
+++ b/apps/desktop/src/renderer/src/pages/ai-builder-session-page.tsx
@@ -1,0 +1,8 @@
+import { useParams } from "react-router-dom";
+import { AiBuilderSessionPage as SharedAiBuilderSessionPage } from "@multica/views/agents";
+
+export function AiBuilderSessionPage() {
+  const { sessionId } = useParams<{ sessionId: string }>();
+  if (!sessionId) return null;
+  return <SharedAiBuilderSessionPage sessionId={sessionId} />;
+}

--- a/apps/desktop/src/renderer/src/routes.tsx
+++ b/apps/desktop/src/renderer/src/routes.tsx
@@ -6,6 +6,7 @@ import { ProjectDetailPage } from "./pages/project-detail-page";
 import { AutopilotDetailPage } from "./pages/autopilot-detail-page";
 import { SkillDetailPage } from "./pages/skill-detail-page";
 import { AgentDetailPage } from "./pages/agent-detail-page";
+import { AiBuilderSessionPage } from "./pages/ai-builder-session-page";
 import { MemberDetailPage } from "./pages/member-detail-page";
 import {
   RuntimeDetailPage,
@@ -196,6 +197,11 @@ export const appRoutes: RouteObject[] = [
           {
             path: "agents/new/ai",
             element: <AiCreateAgentPage />,
+            handle: { title: "Create Agent" },
+          },
+          {
+            path: "agents/new/ai/:sessionId",
+            element: <AiBuilderSessionPage />,
             handle: { title: "Create Agent" },
           },
           {

--- a/apps/web/app/[workspaceSlug]/(dashboard)/agents/new/ai/[sessionId]/page.tsx
+++ b/apps/web/app/[workspaceSlug]/(dashboard)/agents/new/ai/[sessionId]/page.tsx
@@ -1,0 +1,13 @@
+"use client";
+
+import { use } from "react";
+import { AiBuilderSessionPage } from "@multica/views/agents";
+
+export default function NewAgentAiSessionRoute({
+  params,
+}: {
+  params: Promise<{ sessionId: string }>;
+}) {
+  const { sessionId } = use(params);
+  return <AiBuilderSessionPage sessionId={sessionId} />;
+}

--- a/packages/core/diagnostics/diagnostic-context.ts
+++ b/packages/core/diagnostics/diagnostic-context.ts
@@ -63,6 +63,7 @@ const WORKSPACE_ROUTES: readonly RoutePattern[] = [
   ["agents", "new"],
   ["agents", "new", "manual"],
   ["agents", "new", "ai"],
+  ["agents", "new", "ai", ":sessionId"],
   ["agents", ":id"],
   ["members", ":id"],
   ["squads"],

--- a/packages/core/paths/paths.test.ts
+++ b/packages/core/paths/paths.test.ts
@@ -14,6 +14,8 @@ describe("paths.workspace(slug)", () => {
     expect(ws.autopilotDetail("a1")).toBe("/acme/autopilots/a1");
     expect(ws.agents()).toBe("/acme/agents");
     expect(ws.newAgent()).toBe("/acme/agents/new");
+    expect(ws.newAgentAi()).toBe("/acme/agents/new/ai");
+    expect(ws.newAgentAiSession("sess_1")).toBe("/acme/agents/new/ai/sess_1");
     expect(ws.memberDetail("u1")).toBe("/acme/members/u1");
     expect(ws.inbox()).toBe("/acme/inbox");
     expect(ws.myIssues()).toBe("/acme/my-issues");

--- a/packages/core/paths/paths.ts
+++ b/packages/core/paths/paths.ts
@@ -31,6 +31,11 @@ function workspaceScoped(slug: string) {
     // half-filled form survives a refresh and can be linked to directly.
     newAgentManual: () => `${ws}/agents/new/manual`,
     newAgentAi: () => `${ws}/agents/new/ai`,
+    // One creation conversation. It is a durable object, not a step of the
+    // route above: it survives leaving the studio and is resumed later, so it
+    // owns an address instead of being a query param on the "start one" screen.
+    newAgentAiSession: (sessionId: string) =>
+      `${ws}/agents/new/ai/${encode(sessionId)}`,
     agentDetail: (id: string) => `${ws}/agents/${encode(id)}`,
     memberDetail: (id: string) => `${ws}/members/${encode(id)}`,
     squads: () => `${ws}/squads`,

--- a/packages/views/agents/create/ai-builder-session-page.tsx
+++ b/packages/views/agents/create/ai-builder-session-page.tsx
@@ -1,0 +1,86 @@
+"use client";
+
+import { useCallback, useState } from "react";
+import { useQuery } from "@tanstack/react-query";
+import { agentBuilderSessionListOptions } from "@multica/core/agents";
+import { useWorkspaceId } from "@multica/core/hooks";
+import { useWorkspacePaths } from "@multica/core/paths";
+import { useNavigation } from "../../navigation";
+import { useT } from "../../i18n";
+import { BuilderWorkspace } from "./builder-workspace";
+import { AgentCreateChip, AgentCreateShell } from "./create-shell";
+import { withSquadParam } from "./squad-param";
+
+/**
+ * One creation conversation, addressed by its own session id.
+ *
+ * The id is in the path, not in component state or a query param, because this
+ * conversation outlives the screen that started it: leaving the studio no
+ * longer deletes it (#6307), so a refresh, a back/forward, a reopened tab and a
+ * direct link all have to land back in the same chat.
+ */
+export function AiBuilderSessionPage({ sessionId }: { sessionId: string }) {
+  const { t } = useT("agents");
+  const wsId = useWorkspaceId();
+  const paths = useWorkspacePaths();
+  const navigation = useNavigation();
+  const squadId = navigation.searchParams.get("squad");
+  // The runtime this conversation was just started on. It cannot be read back
+  // for the first turn — a conversation joins the list only once it has a
+  // message or a saved configuration — so the starting screen hands it over in
+  // the URL. Absent on every later visit, by which point the list answers.
+  const startedRuntimeId = navigation.searchParams.get("runtime") ?? "";
+
+  const builderSessions = useQuery(agentBuilderSessionListOptions(wsId));
+  const sessions = builderSessions.data ?? [];
+  const sessionSettled = builderSessions.isSuccess || builderSessions.isError;
+  const session = sessions.find((row) => row.session_id === sessionId);
+
+  // Only the open conversation knows which runtime it settled on.
+  const [runtimeLabel, setRuntimeLabel] = useState<string | null>(null);
+
+  // The conversation is gone — discarded here, deleted from another tab, or a
+  // link that outlived it. Replace rather than push: the address no longer
+  // resolves, so it must not stay on the stack for a back to land on.
+  const leave = useCallback(
+    () => navigation.replace(withSquadParam(paths.newAgentAi(), squadId)),
+    [navigation, paths, squadId],
+  );
+
+  return (
+    <AgentCreateShell
+      title={
+        squadId
+          ? t(($) => $.creation_studio.squad_title)
+          : t(($) => $.creation_studio.title)
+      }
+      step={t(($) => $.creation_studio.step_ai)}
+      onBack={() => navigation.push(paths.newAgent())}
+      chips={
+        <>
+          <AgentCreateChip>
+            {t(($) => $.creation_studio.modes.ai.title)}
+          </AgentCreateChip>
+          {runtimeLabel ? (
+            <AgentCreateChip>{runtimeLabel}</AgentCreateChip>
+          ) : null}
+        </>
+      }
+    >
+      <BuilderWorkspace
+        // Switching conversations remounts everything below: the draft, the
+        // applied-message marker and the composer all belong to one
+        // conversation, and a remount is the only reset that cannot forget a
+        // field.
+        key={sessionId}
+        sessionId={sessionId}
+        squadId={squadId}
+        session={session}
+        sessionSettled={sessionSettled}
+        fallbackRuntimeId={startedRuntimeId}
+        onDiscarded={leave}
+        onRuntimeLabel={setRuntimeLabel}
+      />
+    </AgentCreateShell>
+  );
+}

--- a/packages/views/agents/create/ai-create-agent-page.tsx
+++ b/packages/views/agents/create/ai-create-agent-page.tsx
@@ -10,21 +10,23 @@ import type { RuntimeDevice } from "@multica/core/types";
 import { useNavigation } from "../../navigation";
 import { useT } from "../../i18n";
 import { BuilderSetupPanel } from "./builder-setup-panel";
-import { BuilderWorkspace } from "./builder-workspace";
 import { AgentCreateChip, AgentCreateShell } from "./create-shell";
 import { createPathWithParams } from "./squad-param";
 
 /**
- * Conversational agent creation.
+ * Starting a conversational agent creation: pick where it will run.
  *
- * The route holds the conversation list and the identity of the open one; each
- * conversation's own state lives in {@link BuilderWorkspace}, mounted under a
- * `key` so switching is a remount rather than a reset every future field would
- * have to remember to join.
+ * This route is the ACTION — one screen, one job. The conversation it produces
+ * is a durable object and lives at its own address (ai-builder-session-page),
+ * because it is left and resumed rather than completed in one sitting. Both
+ * used to share this route, switched on a `?session=` param, which made the
+ * route render two unrelated screens and left the conversation — the thing
+ * with a lifetime — as a modifier on the thing without one.
  *
- * `?session=` is what makes a conversation addressable — a refresh, a
- * back/forward, and a reopened tab all land back in the same chat instead of
- * silently starting a new one.
+ * Entering a conversation REPLACES this entry. The runtime choice is consumed
+ * the moment the session exists — it is frozen onto the hidden carrier agent
+ * and cannot be revisited from here — so leaving it on the history stack would
+ * only offer to start a second conversation on the way back.
  */
 export function AiCreateAgentPage() {
   const { t } = useT("agents");
@@ -32,45 +34,25 @@ export function AiCreateAgentPage() {
   const paths = useWorkspacePaths();
   const navigation = useNavigation();
   const squadId = navigation.searchParams.get("squad");
-  const sessionId = navigation.searchParams.get("session") ?? "";
 
   const builderSessions = useQuery(agentBuilderSessionListOptions(wsId));
   const sessions = builderSessions.data ?? [];
-  const sessionSettled = builderSessions.isSuccess || builderSessions.isError;
-  const openSession = sessions.find(
-    (session) => session.session_id === sessionId,
-  );
 
-  // The chip has to say something before the list answers, and only the open
-  // pane knows which runtime it settled on.
+  // The chip has to say something before a runtime is settled on.
   const [runtimeLabel, setRuntimeLabel] = useState<string | null>(null);
-  // The runtime a just-started conversation was created with. It cannot be read
-  // back yet — a conversation joins the list only once it has a message — and
-  // without it the first turn would render against the first runtime in the
-  // list instead of the one the user picked.
-  const [startedRuntimeId, setStartedRuntimeId] = useState("");
-
-  const handleSetupRuntimeLabel = useCallback(
+  const handleRuntimeLabel = useCallback(
     (runtime: RuntimeDevice | null) =>
       setRuntimeLabel(runtime ? runtimeDisplayLabel(runtime) : null),
     [],
   );
 
   const open = useCallback(
-    (nextSessionId: string) =>
+    (sessionId: string, runtimeId: string | null) =>
       navigation.replace(
-        createPathWithParams(paths.newAgentAi(), {
+        createPathWithParams(paths.newAgentAiSession(sessionId), {
           squad: squadId,
-          session: nextSessionId,
+          runtime: runtimeId,
         }),
-      ),
-    [navigation, paths, squadId],
-  );
-
-  const closeSession = useCallback(
-    () =>
-      navigation.replace(
-        createPathWithParams(paths.newAgentAi(), { squad: squadId }),
       ),
     [navigation, paths, squadId],
   );
@@ -95,35 +77,14 @@ export function AiCreateAgentPage() {
         </>
       }
     >
-      {sessionId ? (
-        <BuilderWorkspace
-          // Switching conversations remounts everything below: the draft, the
-          // applied-message marker and the composer all belong to one
-          // conversation, and a remount is the only reset that cannot forget a
-          // field.
-          key={sessionId}
-          sessionId={sessionId}
-          squadId={squadId}
-          session={openSession}
-          sessionSettled={sessionSettled}
-          fallbackRuntimeId={startedRuntimeId}
-          onDiscarded={closeSession}
-          onRuntimeLabel={setRuntimeLabel}
-        />
-      ) : (
-        <BuilderSetupPanel
-          sessions={sessions}
-          onResume={(nextSessionId) => {
-            setStartedRuntimeId("");
-            open(nextSessionId);
-          }}
-          onStarted={(nextSessionId, runtimeId) => {
-            setStartedRuntimeId(runtimeId);
-            open(nextSessionId);
-          }}
-          onRuntimeLabel={handleSetupRuntimeLabel}
-        />
-      )}
+      <BuilderSetupPanel
+        sessions={sessions}
+        // Resuming carries no runtime seed: a listed conversation reports its
+        // own, which is the truthful answer after a runtime switch.
+        onResume={(sessionId) => open(sessionId, null)}
+        onStarted={(sessionId, runtimeId) => open(sessionId, runtimeId)}
+        onRuntimeLabel={handleRuntimeLabel}
+      />
     </AgentCreateShell>
   );
 }

--- a/packages/views/agents/create/builder-conversation.tsx
+++ b/packages/views/agents/create/builder-conversation.tsx
@@ -146,7 +146,9 @@ export function BuilderConversation({
     | { task_id?: string; status?: string; created_at?: string }
     | undefined;
   runtimeOnline: boolean;
-  onSend: (content: string) => Promise<boolean>;
+  /** `commitInput` is the composer's clear; the owner runs it as soon as the
+   *  server accepts the message. The prompt buttons below send without one. */
+  onSend: (content: string, commitInput?: () => void) => Promise<boolean>;
   onStop: () => void;
   restoreDraftRequest: BuilderRestore | null;
   onRestoreDraftApplied: () => void;
@@ -235,7 +237,9 @@ export function BuilderConversation({
       ) : null}
 
       <ChatInput
-        onSend={(content) => onSend(content)}
+        onSend={(content, _attachmentIds, commitInput) =>
+          onSend(content, commitInput)
+        }
         onStop={onStop}
         isRunning={pending}
         disabled={!runtimeOnline}

--- a/packages/views/agents/create/index.ts
+++ b/packages/views/agents/create/index.ts
@@ -1,6 +1,7 @@
-// The three route entry points. Everything else in this folder is internal to
-// the flow and already imported by path — re-exporting it here only created a
+// The route entry points. Everything else in this folder is internal to the
+// flow and already imported by path — re-exporting it here only created a
 // second name for the same thing and a list to keep in sync.
 export { ChooseCreateMethodPage } from "./choose-create-method-page";
 export { ManualCreateAgentPage } from "./manual-create-agent-page";
 export { AiCreateAgentPage } from "./ai-create-agent-page";
+export { AiBuilderSessionPage } from "./ai-builder-session-page";

--- a/packages/views/agents/create/squad-param.ts
+++ b/packages/views/agents/create/squad-param.ts
@@ -3,17 +3,21 @@
  * between screens.
  *
  * `squad` is the reason the flow was opened at all, so it rides along from the
- * chooser into whichever method the user picks. `session` addresses one builder
- * conversation, so a refresh, a back/forward, or a reopened tab lands back in
- * the same chat instead of starting a new one.
+ * chooser into whichever method the user picks.
+ *
+ * `runtime` is a seed, not an identity: a conversation joins the sessions list
+ * only once it holds a message or a saved configuration, so for the first turn
+ * the runtime the user just picked cannot be read back from anywhere. It rides
+ * in the URL rather than in component state so a refresh on that first turn
+ * still knows where the conversation runs.
  */
 export function createPathWithParams(
   path: string,
-  params: { squad?: string | null; session?: string | null },
+  params: { squad?: string | null; runtime?: string | null },
 ): string {
   const query = new URLSearchParams();
   if (params.squad) query.set("squad", params.squad);
-  if (params.session) query.set("session", params.session);
+  if (params.runtime) query.set("runtime", params.runtime);
   const suffix = query.toString();
   return suffix ? `${path}?${suffix}` : path;
 }

--- a/packages/views/agents/create/use-builder-session.ts
+++ b/packages/views/agents/create/use-builder-session.ts
@@ -207,7 +207,22 @@ export function useBuilderSession(options: {
     }
   };
 
-  const send = async (content: string): Promise<boolean> => {
+  /**
+   * Sends one turn.
+   *
+   * `commitInput` is the composer's clear (MUL-5181): it runs the moment the
+   * server has accepted the message and the caches render it, NOT after the
+   * reconciling invalidations settle. Awaiting those held the user's text in
+   * the box for three more round-trips while their message was already on
+   * screen. Same ordering as the main chat's handleSend.
+   *
+   * Optional because the empty-state prompt buttons call this directly, with
+   * no composer to clear.
+   */
+  const send = async (
+    content: string,
+    commitInput?: () => void,
+  ): Promise<boolean> => {
     const text = content.trim();
     // switchingRuntime blocks the send while a rebind is in flight: the server
     // serialises the two anyway, but letting the message through would mean the
@@ -240,13 +255,13 @@ export function useBuilderSession(options: {
         status: "queued",
         created_at: createdAt,
       });
-      await Promise.all([
-        qc.invalidateQueries({ queryKey: chatKeys.messages(sessionId) }),
-        qc.invalidateQueries({ queryKey: chatKeys.pendingTask(sessionId) }),
-        // The first turn is what makes a brand-new conversation listable at
-        // all, and every later one moves it to the top with a new preview.
-        invalidateDraftList(),
-      ]);
+      // Accepted and rendered — release the composer before reconciling.
+      commitInput?.();
+      void qc.invalidateQueries({ queryKey: chatKeys.messages(sessionId) });
+      void qc.invalidateQueries({ queryKey: chatKeys.pendingTask(sessionId) });
+      // The first turn is what makes a brand-new conversation listable at
+      // all, and every later one moves it to the top with a new preview.
+      void invalidateDraftList();
       return true;
     } catch (err) {
       setError(

--- a/packages/views/agents/index.ts
+++ b/packages/views/agents/index.ts
@@ -3,4 +3,5 @@ export {
   ChooseCreateMethodPage,
   ManualCreateAgentPage,
   AiCreateAgentPage,
+  AiBuilderSessionPage,
 } from "./create";


### PR DESCRIPTION
Two follow-ups to the Agent Creation Studio rewrite (#6307). Both are about the same thing: a screen that was assembled from shared parts but wired to its own rules.

## 1. The composer kept the user's text after sending

Send a message in the builder and it posts, renders in the transcript — and the text stays in the box.

The composer itself is the shared one, on the MUL-5181 contract: `ChatInput` hands the owner a `commitInput` callback and clears the draft when the owner's send resolves. The chat controller calls it the moment the POST is accepted and lets the invalidations reconcile in the background.

This owner did neither. It ignored `commitInput` entirely and then resolved late — after awaiting three cache invalidations (messages, pendingTask, drafts list) that ran *after* the message had already been written into the caches and put on screen. So the clear was gated behind that many extra round-trips while the user was already looking at their sent message.

Worse in the tail: `ChatInput` has a stale-submit guard that declines to clear a draft edited during the send, so it cannot wipe work typed while a request was in flight. That guard is sized for a window of one round-trip. Stretched across three, a user who keeps typing trips it, and the already-sent text is stranded in the box for good.

`send` now takes `commitInput` and runs it as soon as the server accepts and the caches render the message. Same ordering as `use-chat-controller`'s `handleSend`. The parameter is optional because the empty-state prompt buttons call `send` directly, with no composer to clear.

## 2. One route served two unrelated screens

`/{ws}/agents/new/ai` rendered the runtime picker without `?session=` and the conversation with it.

That inverts what the two things are:

- **The runtime pick is a step.** It is consumed the instant the session exists — the runtime is frozen onto the hidden carrier agent and cannot be revisited from that screen.
- **The conversation is a durable object.** Since #6307 stopped deleting it on navigation, it is left and resumed across sittings. It is the thing that needs an address — and it had the address of a modifier on the step.

Split into one route per screen:

```
/{ws}/agents/new/ai              start one
/{ws}/agents/new/ai/{sessionId}  one conversation
```

Behavior is deliberately unchanged. Starting still REPLACES the picker's history entry, so a back cannot land on a consumed step; back still leaves to the method chooser; a discarded conversation still replaces its own entry rather than leaving a dead address on the stack.

### A latent bug goes with it

The runtime a just-started conversation runs on lived in React state on the shared page. It has to live somewhere, because a conversation joins the sessions list only once it holds a message or a saved configuration — for the first turn there is nothing to read it back from. Component state does not survive a refresh, so refreshing on that first turn dropped the seed and left the runtime picker locked.

It now rides in `?runtime=` on the conversation URL: a seed for exactly that gap, absent on every later visit once the list can answer. A param carrying data, not a param deciding which screen renders.

## Verification

- `pnpm typecheck` — 6/6 workspaces
- `packages/core` paths tests — 78 passed (added coverage for `newAgentAiSession`)
- `packages/views` agents tests — 221 passed

Not yet exercised by hand in a running app.

🤖 Generated with [Claude Code](https://claude.com/claude-code)