### PR TITLE
LOOP-771: guard inherited provider homes in execenv

### DIFF
--- a/apps/docs/content/docs/daemon-runtimes.mdx
+++ b/apps/docs/content/docs/daemon-runtimes.mdx
@@ -48,6 +48,17 @@ On startup, the daemon detects supported AI coding tools on `PATH` and registers
 
 The daemon needs at least one built-in supported AI coding tool detected before it will start. Install methods and executable names are in [Install AI coding tools](/install-agent-runtime).
 
+### Launch environment hygiene
+
+If you start the daemon from a shell or service runbook, clear only provider home selectors that can pin every task to stale task-local state:
+
+```bash
+test -n "${MLAMP_API_KEY:-}" || { echo "MLAMP_API_KEY is missing"; exit 1; }
+env -u CODEX_HOME -u HERMES_HOME -u OPENCLAW_HOME -u OPENCLAW_CONFIG_PATH multica daemon start
+```
+
+Do not start from a broadly scrubbed environment unless you explicitly re-inject required credentials and gateway variables. Scrubbing `*_HOME` should not remove `MLAMP_API_KEY` or other deployment-specific variables the detected tools need.
+
 ## Dispatch and online status
 
 Once registered, a runtime keeps a persistent connection. When a new task enters the queue, the server notifies the matching daemon; the daemon also polls periodically as a backstop after connection interruptions. So when a runtime is online with spare capacity, tasks usually start immediately.

--- a/server/internal/daemon/daemon.go
+++ b/server/internal/daemon/daemon.go
@@ -4994,7 +4994,7 @@ func (d *Daemon) runTask(ctx context.Context, task Task, provider string, slot i
 	var hermesEnv map[string]string
 	if provider == "hermes" {
 		sel := agent.ParseHermesProfileArgs(agentCustomArgs)
-		res := execenv.ResolveHermesProfile(agentEnvOverrides["HERMES_HOME"], sel.Name, sel.Found, sel.Inline)
+		res := execenv.ResolveHermesProfileWithWorkspacesRoot(agentEnvOverrides["HERMES_HOME"], sel.Name, sel.Found, sel.Inline, d.cfg.WorkspacesRoot)
 		if res.Err != nil {
 			return TaskResult{}, fmt.Errorf("resolve hermes profile: %w", res.Err)
 		}
@@ -5011,7 +5011,11 @@ func (d *Daemon) runTask(ctx context.Context, task Task, provider string, slot i
 	// store's stale (pre-remount) mtime cannot reclaim it out from under a resume
 	// of a long-idle issue (MUL-4424). No-op for non-Codex tasks / no stable key.
 	if provider == "codex" {
-		if store := execenv.CodexSessionStorePath(d.cfg.Profile, task.AgentID, task.IssueID); store != "" {
+		store, err := execenv.CodexSessionStorePath(d.cfg.Profile, task.AgentID, task.IssueID, d.cfg.WorkspacesRoot)
+		if err != nil {
+			return TaskResult{}, fmt.Errorf("resolve codex session store: %w", err)
+		}
+		if store != "" {
 			d.markActiveCodexStore(store)
 			defer d.unmarkActiveCodexStore(store)
 		}

--- a/server/internal/daemon/execenv/codex_home.go
+++ b/server/internal/daemon/execenv/codex_home.go
@@ -46,6 +46,11 @@ var codexModelsCacheConfigFiles = []string{
 // CodexHomeOptions carries optional inputs for prepareCodexHomeWithOpts that
 // affect the generated per-task config.toml.
 type CodexHomeOptions struct {
+	// WorkspacesRoot is the daemon-owned root for task envs. When the daemon
+	// process inherited CODEX_HOME from a prior task and that path points under
+	// this root, the shared-home resolver fails closed instead of seeding every
+	// task from another task's isolated home.
+	WorkspacesRoot string
 	// CodexVersion is the detected Codex CLI version (e.g. "0.121.0"). Empty
 	// means unknown; on macOS, unknown is treated as "probably broken" so the
 	// daemon falls back to danger-full-access for network access. See
@@ -189,7 +194,10 @@ func classifyPerTaskWindowsSandbox(configFile string, configSyncErr error, share
 // config files are copied (isolated). The per-task config.toml gets a
 // daemon-managed sandbox block picked by codexSandboxPolicyFor.
 func prepareCodexHomeWithOpts(codexHome string, opts CodexHomeOptions, logger *slog.Logger) error {
-	sharedHome := resolveSharedCodexHome()
+	sharedHome, err := resolveSharedCodexHome(opts.WorkspacesRoot)
+	if err != nil {
+		return err
+	}
 	freshHome := false
 	if _, err := os.Lstat(codexHome); os.IsNotExist(err) {
 		freshHome = true
@@ -229,11 +237,14 @@ func prepareCodexHomeWithOpts(codexHome string, opts CodexHomeOptions, logger *s
 	for _, name := range codexCopiedFiles {
 		src := filepath.Join(sharedHome, name)
 		dst := filepath.Join(codexHome, name)
-		if err := syncCopiedFile(src, dst); err != nil {
+		srcMissing, err := syncCopiedFile(src, dst)
+		if err != nil {
 			logger.Warn("execenv: codex-home sync failed", "file", name, "error", err)
 			if name == "config.toml" {
 				configSyncErr = err
 			}
+		} else if srcMissing && name == "config.toml" && strings.TrimSpace(os.Getenv("CODEX_HOME")) != "" {
+			logger.Warn("execenv: inherited CODEX_HOME has no config.toml; Codex may fall back to its native default provider", "shared_home", sharedHome)
 		}
 	}
 	// Drop `[[skills.config]]` entries inherited from the user's
@@ -310,20 +321,46 @@ func prepareCodexHomeWithOpts(codexHome string, opts CodexHomeOptions, logger *s
 	return nil
 }
 
-// resolveSharedCodexHome returns the path to the user's shared Codex home.
-// Checks $CODEX_HOME first, falls back to ~/.codex.
-func resolveSharedCodexHome() string {
-	if v := os.Getenv("CODEX_HOME"); v != "" {
-		abs, err := filepath.Abs(v)
-		if err == nil {
-			return abs
-		}
+// resolveSharedCodexHome returns the path to the user's shared Codex home. It
+// checks inherited $CODEX_HOME first, then falls back to ~/.codex. Inherited
+// CODEX_HOME is guarded because a daemon launched from a task shell must not
+// seed every task from that task-scoped home.
+func resolveSharedCodexHome(workspacesRoot string) (string, error) {
+	if v := os.Getenv("CODEX_HOME"); strings.TrimSpace(v) != "" {
+		return resolveAndGuardProviderConfigPath("codex", "CODEX_HOME", v, workspacesRoot, codexSharedHomeProviderConfig)
 	}
 	home, err := os.UserHomeDir()
 	if err != nil {
-		return filepath.Join(os.TempDir(), ".codex") // last resort fallback
+		return filepath.Join(os.TempDir(), ".codex"), nil // last resort fallback
 	}
-	return filepath.Join(home, ".codex")
+	return filepath.Join(home, ".codex"), nil
+}
+
+func codexSharedHomeProviderConfig(home string) error {
+	data, err := os.ReadFile(filepath.Join(home, "config.toml"))
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return fmt.Errorf("read config.toml: %w", err)
+	}
+	cfg := map[string]any{}
+	if err := toml.Unmarshal(data, &cfg); err != nil {
+		return fmt.Errorf("parse config.toml: %w", err)
+	}
+	for _, key := range []string{
+		"sandbox_mode",
+		"sandbox_workspace_write",
+		"shell_environment_policy",
+		"features",
+		"memories",
+	} {
+		delete(cfg, key)
+	}
+	if len(cfg) == 0 {
+		return fmt.Errorf("config.toml has no user provider/config settings beyond daemon-managed defaults")
+	}
+	return nil
 }
 
 // codexSessionStateGlobs are the session-derived SQLite state Codex builds
@@ -446,11 +483,18 @@ func sanitizeCodexPathSegment(s string) string {
 // the remove are effectively atomic, closing the stat->remove race a plain
 // point-in-time active check leaves open. nil disables the guard (tests): every
 // idle store is removed.
-func PruneCodexSessionStores(profile string, retention time.Duration, now time.Time, reserve func(storeDir string) (commit func(), ok bool), logger *slog.Logger) (removed int, bytesFreed int64) {
+func PruneCodexSessionStores(profile, workspacesRoot string, retention time.Duration, now time.Time, reserve func(storeDir string) (commit func(), ok bool), logger *slog.Logger) (removed int, bytesFreed int64) {
 	if retention <= 0 {
 		return 0, 0
 	}
-	root := filepath.Join(resolveSharedCodexHome(), codexSessionStoreRoot, codexSessionStoreNamespace(profile))
+	sharedHome, err := resolveSharedCodexHome(workspacesRoot)
+	if err != nil {
+		if logger != nil {
+			logger.Warn("execenv: skip codex session store prune; shared CODEX_HOME is unusable", "error", err)
+		}
+		return 0, 0
+	}
+	root := filepath.Join(sharedHome, codexSessionStoreRoot, codexSessionStoreNamespace(profile))
 	agents, err := os.ReadDir(root)
 	if err != nil {
 		return 0, 0 // not created yet, or unreadable — nothing to prune
@@ -670,12 +714,16 @@ func touchCodexSessionStore(storeDir string, logger *slog.Logger) {
 // key. The daemon marks this path in-use for the duration of a task so
 // PruneCodexSessionStores never reclaims a store mid-mount, closing the
 // stat→remove race the mtime refresh alone cannot (MUL-4424).
-func CodexSessionStorePath(profile, agentID, issueID string) string {
+func CodexSessionStorePath(profile, agentID, issueID, workspacesRoot string) (string, error) {
 	key := codexSessionStoreKey(profile, agentID, issueID)
 	if key == "" {
-		return ""
+		return "", nil
 	}
-	return codexSessionStoreDir(resolveSharedCodexHome(), key)
+	sharedHome, err := resolveSharedCodexHome(workspacesRoot)
+	if err != nil {
+		return "", err
+	}
+	return codexSessionStoreDir(sharedHome, key), nil
 }
 
 // sameCodexPath reports whether two filesystem paths refer to the same location,
@@ -1338,23 +1386,23 @@ func logCodexAuthState(authPath string, logger *slog.Logger) {
 // exists in the shared config. For config.json / instructions.md there is
 // no daemon-managed default, so they simply disappear in lockstep with the
 // shared source.
-func syncCopiedFile(src, dst string) error {
+func syncCopiedFile(src, dst string) (bool, error) {
 	_, srcErr := os.Stat(src)
 	srcMissing := os.IsNotExist(srcErr)
 	if srcErr != nil && !srcMissing {
-		return fmt.Errorf("stat src %s: %w", src, srcErr)
+		return false, fmt.Errorf("stat src %s: %w", src, srcErr)
 	}
 
 	if _, err := os.Lstat(dst); err == nil {
 		if err := os.Remove(dst); err != nil {
-			return fmt.Errorf("remove stale dst %s: %w", dst, err)
+			return false, fmt.Errorf("remove stale dst %s: %w", dst, err)
 		}
 	}
 
 	if srcMissing {
-		return nil
+		return true, nil
 	}
-	return copyFile(src, dst)
+	return false, copyFile(src, dst)
 }
 
 // seedCopiedFile copies src only when dst has no task-local regular file.

--- a/server/internal/daemon/execenv/codex_home.go
+++ b/server/internal/daemon/execenv/codex_home.go
@@ -96,7 +96,7 @@ type CodexHomeOptions struct {
 // so the sandbox block it writes is stable regardless of the host running the
 // test.
 func prepareCodexHome(codexHome string, logger *slog.Logger) error {
-	return prepareCodexHomeWithOpts(codexHome, CodexHomeOptions{GOOS: "linux"}, logger)
+	return prepareCodexHomeWithOpts(codexHome, CodexHomeOptions{WorkspacesRoot: filepath.Join(codexHome, "workspaces-root"), GOOS: "linux"}, logger)
 }
 
 // sharedConfigPresence is the tri-state existence of the shared
@@ -327,7 +327,7 @@ func prepareCodexHomeWithOpts(codexHome string, opts CodexHomeOptions, logger *s
 // seed every task from that task-scoped home.
 func resolveSharedCodexHome(workspacesRoot string) (string, error) {
 	if v := os.Getenv("CODEX_HOME"); strings.TrimSpace(v) != "" {
-		return resolveAndGuardProviderConfigPath("codex", "CODEX_HOME", v, workspacesRoot, codexSharedHomeProviderConfig)
+		return resolveAndGuardProviderConfigPath("codex", "CODEX_HOME", v, workspacesRoot)
 	}
 	home, err := os.UserHomeDir()
 	if err != nil {
@@ -336,31 +336,42 @@ func resolveSharedCodexHome(workspacesRoot string) (string, error) {
 	return filepath.Join(home, ".codex"), nil
 }
 
-func codexSharedHomeProviderConfig(home string) error {
-	data, err := os.ReadFile(filepath.Join(home, "config.toml"))
+func ensureCodexProviderConfigUsable(codexHome string) error {
+	configPath := filepath.Join(codexHome, "config.toml")
+	data, err := os.ReadFile(configPath)
 	if err != nil {
 		if os.IsNotExist(err) {
-			return nil
+			return fmt.Errorf("config.toml is missing model_provider")
 		}
 		return fmt.Errorf("read config.toml: %w", err)
 	}
-	cfg := map[string]any{}
+	var cfg struct {
+		ModelProvider  string                    `toml:"model_provider"`
+		ModelProviders map[string]map[string]any `toml:"model_providers"`
+	}
 	if err := toml.Unmarshal(data, &cfg); err != nil {
 		return fmt.Errorf("parse config.toml: %w", err)
 	}
-	for _, key := range []string{
-		"sandbox_mode",
-		"sandbox_workspace_write",
-		"shell_environment_policy",
-		"features",
-		"memories",
-	} {
-		delete(cfg, key)
+	provider := strings.TrimSpace(cfg.ModelProvider)
+	if provider == "" {
+		return fmt.Errorf("config.toml is missing model_provider")
 	}
-	if len(cfg) == 0 {
-		return fmt.Errorf("config.toml has no user provider/config settings beyond daemon-managed defaults")
+	if _, ok := cfg.ModelProviders[provider]; ok {
+		return nil
 	}
-	return nil
+	if isBuiltInCodexModelProvider(provider) {
+		if _, err := os.Stat(filepath.Join(codexHome, "auth.json")); err == nil {
+			return nil
+		} else if !os.IsNotExist(err) {
+			return fmt.Errorf("stat auth.json for built-in provider %q: %w", provider, err)
+		}
+		return fmt.Errorf("config.toml selects built-in model_provider %q but auth.json is missing", provider)
+	}
+	return fmt.Errorf("config.toml selects model_provider %q but [model_providers.%s] is missing", provider, provider)
+}
+
+func isBuiltInCodexModelProvider(provider string) bool {
+	return provider == "openai"
 }
 
 // codexSessionStateGlobs are the session-derived SQLite state Codex builds

--- a/server/internal/daemon/execenv/codex_home.go
+++ b/server/internal/daemon/execenv/codex_home.go
@@ -318,6 +318,10 @@ func prepareCodexHomeWithOpts(codexHome string, opts CodexHomeOptions, logger *s
 		logger.Warn("execenv: codex-home ensure memory config failed", "error", err)
 	}
 
+	if err := ensureCodexProviderSeedingPreserved(codexHome, sharedHome, logger); err != nil {
+		return err
+	}
+
 	return nil
 }
 
@@ -336,42 +340,42 @@ func resolveSharedCodexHome(workspacesRoot string) (string, error) {
 	return filepath.Join(home, ".codex"), nil
 }
 
-func ensureCodexProviderConfigUsable(codexHome string) error {
-	configPath := filepath.Join(codexHome, "config.toml")
-	data, err := os.ReadFile(configPath)
+func ensureCodexProviderSeedingPreserved(codexHome, sharedHome string, logger *slog.Logger) error {
+	sharedProvider, err := codexConfigModelProvider(sharedHome)
 	if err != nil {
-		if os.IsNotExist(err) {
-			return fmt.Errorf("config.toml is missing model_provider")
-		}
-		return fmt.Errorf("read config.toml: %w", err)
+		return fmt.Errorf("inspect shared codex provider config: %w", err)
 	}
-	var cfg struct {
-		ModelProvider  string                    `toml:"model_provider"`
-		ModelProviders map[string]map[string]any `toml:"model_providers"`
+	taskProvider, err := codexConfigModelProvider(codexHome)
+	if err != nil {
+		return fmt.Errorf("inspect task codex provider config: %w", err)
 	}
-	if err := toml.Unmarshal(data, &cfg); err != nil {
-		return fmt.Errorf("parse config.toml: %w", err)
+	if sharedProvider != "" && taskProvider == "" {
+		return fmt.Errorf("codex config lost model_provider %q while seeding from shared home %s", sharedProvider, sharedHome)
 	}
-	provider := strings.TrimSpace(cfg.ModelProvider)
-	if provider == "" {
-		return fmt.Errorf("config.toml is missing model_provider")
+	if sharedProvider != "" && taskProvider != sharedProvider {
+		return fmt.Errorf("codex config changed model_provider from %q to %q while seeding from shared home %s", sharedProvider, taskProvider, sharedHome)
 	}
-	if _, ok := cfg.ModelProviders[provider]; ok {
-		return nil
+	if sharedProvider == "" && taskProvider == "" && logger != nil {
+		logger.Warn("execenv: codex config has no model_provider; allowing Codex native default provider", "shared_home", sharedHome, "codex_home", codexHome)
 	}
-	if isBuiltInCodexModelProvider(provider) {
-		if _, err := os.Stat(filepath.Join(codexHome, "auth.json")); err == nil {
-			return nil
-		} else if !os.IsNotExist(err) {
-			return fmt.Errorf("stat auth.json for built-in provider %q: %w", provider, err)
-		}
-		return fmt.Errorf("config.toml selects built-in model_provider %q but auth.json is missing", provider)
-	}
-	return fmt.Errorf("config.toml selects model_provider %q but [model_providers.%s] is missing", provider, provider)
+	return nil
 }
 
-func isBuiltInCodexModelProvider(provider string) bool {
-	return provider == "openai"
+func codexConfigModelProvider(home string) (string, error) {
+	data, err := os.ReadFile(filepath.Join(home, "config.toml"))
+	if err != nil {
+		if os.IsNotExist(err) {
+			return "", nil
+		}
+		return "", fmt.Errorf("read config.toml: %w", err)
+	}
+	var cfg struct {
+		ModelProvider string `toml:"model_provider"`
+	}
+	if err := toml.Unmarshal(data, &cfg); err != nil {
+		return "", fmt.Errorf("parse config.toml: %w", err)
+	}
+	return strings.TrimSpace(cfg.ModelProvider), nil
 }
 
 // codexSessionStateGlobs are the session-derived SQLite state Codex builds

--- a/server/internal/daemon/execenv/codex_home_sessions_test.go
+++ b/server/internal/daemon/execenv/codex_home_sessions_test.go
@@ -482,7 +482,7 @@ func TestPruneCodexSessionStores(t *testing.T) {
 	// Age only the stale store's whole tree well past retention.
 	chtimesTree(t, staleStore, now.Add(-30*24*time.Hour))
 
-	removed, bytes := PruneCodexSessionStores("", retention, now, nil, testLogger())
+	removed, bytes := PruneCodexSessionStores("", "", retention, now, nil, testLogger())
 	if removed != 1 {
 		t.Fatalf("removed = %d, want 1 (only the store idle past retention)", removed)
 	}
@@ -498,7 +498,7 @@ func TestPruneCodexSessionStores(t *testing.T) {
 
 	// retention <= 0 disables pruning even for an aged store.
 	chtimesTree(t, freshStore, now.Add(-30*24*time.Hour))
-	if removed, _ := PruneCodexSessionStores("", 0, now, nil, testLogger()); removed != 0 {
+	if removed, _ := PruneCodexSessionStores("", "", 0, now, nil, testLogger()); removed != 0 {
 		t.Errorf("retention<=0 must disable pruning, removed=%d", removed)
 	}
 	assertPresent(t, freshStore)
@@ -530,7 +530,7 @@ func TestPruneCodexSessionStores_ReopenedStoreNotReclaimed(t *testing.T) {
 	}
 
 	// A GC cycle now — before the resumed turn writes anything — must keep it.
-	if removed, _ := PruneCodexSessionStores("", 14*24*time.Hour, time.Now(), nil, testLogger()); removed != 0 {
+	if removed, _ := PruneCodexSessionStores("", "", 14*24*time.Hour, time.Now(), nil, testLogger()); removed != 0 {
 		t.Fatalf("removed = %d, want 0 (a just-reopened store must survive GC)", removed)
 	}
 	assertPresent(t, storeDir)
@@ -558,13 +558,13 @@ func TestPruneCodexSessionStores_ActiveStoreNotReclaimed(t *testing.T) {
 		}
 		return func() {}, true
 	}
-	if removed, _ := PruneCodexSessionStores("", 14*24*time.Hour, time.Now(), held, testLogger()); removed != 0 {
+	if removed, _ := PruneCodexSessionStores("", "", 14*24*time.Hour, time.Now(), held, testLogger()); removed != 0 {
 		t.Fatalf("removed = %d, want 0 (a reserved/in-use store must never be reclaimed)", removed)
 	}
 	assertPresent(t, storeDir)
 
 	// Once reservable, the same idle store is reclaimed.
-	if removed, _ := PruneCodexSessionStores("", 14*24*time.Hour, time.Now(), nil, testLogger()); removed != 1 {
+	if removed, _ := PruneCodexSessionStores("", "", 14*24*time.Hour, time.Now(), nil, testLogger()); removed != 1 {
 		t.Fatalf("removed = %d, want 1 (idle store reclaimed when reservable)", removed)
 	}
 	assertAbsent(t, storeDir)
@@ -585,13 +585,13 @@ func TestPruneCodexSessionStores_IsolatesProfiles(t *testing.T) {
 
 	// The production (default) daemon prunes — it must NOT touch staging's store,
 	// even with no guard, because staging is a different namespace it never scans.
-	if removed, _ := PruneCodexSessionStores("", 14*24*time.Hour, time.Now(), nil, testLogger()); removed != 0 {
+	if removed, _ := PruneCodexSessionStores("", "", 14*24*time.Hour, time.Now(), nil, testLogger()); removed != 0 {
 		t.Fatalf("removed = %d, want 0 — another profile's store must be out of scope", removed)
 	}
 	assertPresent(t, stagingStore)
 
 	// The staging daemon prunes its own namespace → reclaims its idle store.
-	if removed, _ := PruneCodexSessionStores("staging", 14*24*time.Hour, time.Now(), nil, testLogger()); removed != 1 {
+	if removed, _ := PruneCodexSessionStores("staging", "", 14*24*time.Hour, time.Now(), nil, testLogger()); removed != 1 {
 		t.Fatalf("removed = %d, want 1 — the owning profile reclaims its idle store", removed)
 	}
 	assertAbsent(t, stagingStore)
@@ -657,14 +657,14 @@ func TestPruneCodexSessionStores_NoCrossProfileCollision(t *testing.T) {
 		chtimesTree(t, storeB, time.Now().Add(-30*24*time.Hour))
 
 		// Pruning profile a reclaims a's store only — b's must survive.
-		if removed, _ := PruneCodexSessionStores(a, 14*24*time.Hour, time.Now(), nil, testLogger()); removed != 1 {
+		if removed, _ := PruneCodexSessionStores(a, "", 14*24*time.Hour, time.Now(), nil, testLogger()); removed != 1 {
 			t.Fatalf("prune %q removed=%d, want 1", a, removed)
 		}
 		assertAbsent(t, storeA)
 		assertPresent(t, storeB)
 
 		// Then pruning profile b reclaims b's store.
-		if removed, _ := PruneCodexSessionStores(b, 14*24*time.Hour, time.Now(), nil, testLogger()); removed != 1 {
+		if removed, _ := PruneCodexSessionStores(b, "", 14*24*time.Hour, time.Now(), nil, testLogger()); removed != 1 {
 			t.Fatalf("prune %q removed=%d, want 1", b, removed)
 		}
 		assertAbsent(t, storeB)
@@ -683,7 +683,7 @@ func TestPruneCodexSessionStores_RemovesEmptyAgentDir(t *testing.T) {
 
 	now := time.Now()
 	chtimesTree(t, onlyStore, now.Add(-30*24*time.Hour))
-	if removed, _ := PruneCodexSessionStores("", 14*24*time.Hour, now, nil, testLogger()); removed != 1 {
+	if removed, _ := PruneCodexSessionStores("", "", 14*24*time.Hour, now, nil, testLogger()); removed != 1 {
 		t.Fatalf("removed = %d, want 1", removed)
 	}
 	assertAbsent(t, filepath.Join(storeRoot, "agent-lonely"))

--- a/server/internal/daemon/execenv/codex_home_sessions_test.go
+++ b/server/internal/daemon/execenv/codex_home_sessions_test.go
@@ -482,7 +482,7 @@ func TestPruneCodexSessionStores(t *testing.T) {
 	// Age only the stale store's whole tree well past retention.
 	chtimesTree(t, staleStore, now.Add(-30*24*time.Hour))
 
-	removed, bytes := PruneCodexSessionStores("", "", retention, now, nil, testLogger())
+	removed, bytes := PruneCodexSessionStores("", t.TempDir(), retention, now, nil, testLogger())
 	if removed != 1 {
 		t.Fatalf("removed = %d, want 1 (only the store idle past retention)", removed)
 	}
@@ -498,7 +498,7 @@ func TestPruneCodexSessionStores(t *testing.T) {
 
 	// retention <= 0 disables pruning even for an aged store.
 	chtimesTree(t, freshStore, now.Add(-30*24*time.Hour))
-	if removed, _ := PruneCodexSessionStores("", "", 0, now, nil, testLogger()); removed != 0 {
+	if removed, _ := PruneCodexSessionStores("", t.TempDir(), 0, now, nil, testLogger()); removed != 0 {
 		t.Errorf("retention<=0 must disable pruning, removed=%d", removed)
 	}
 	assertPresent(t, freshStore)
@@ -530,7 +530,7 @@ func TestPruneCodexSessionStores_ReopenedStoreNotReclaimed(t *testing.T) {
 	}
 
 	// A GC cycle now — before the resumed turn writes anything — must keep it.
-	if removed, _ := PruneCodexSessionStores("", "", 14*24*time.Hour, time.Now(), nil, testLogger()); removed != 0 {
+	if removed, _ := PruneCodexSessionStores("", t.TempDir(), 14*24*time.Hour, time.Now(), nil, testLogger()); removed != 0 {
 		t.Fatalf("removed = %d, want 0 (a just-reopened store must survive GC)", removed)
 	}
 	assertPresent(t, storeDir)
@@ -558,13 +558,13 @@ func TestPruneCodexSessionStores_ActiveStoreNotReclaimed(t *testing.T) {
 		}
 		return func() {}, true
 	}
-	if removed, _ := PruneCodexSessionStores("", "", 14*24*time.Hour, time.Now(), held, testLogger()); removed != 0 {
+	if removed, _ := PruneCodexSessionStores("", t.TempDir(), 14*24*time.Hour, time.Now(), held, testLogger()); removed != 0 {
 		t.Fatalf("removed = %d, want 0 (a reserved/in-use store must never be reclaimed)", removed)
 	}
 	assertPresent(t, storeDir)
 
 	// Once reservable, the same idle store is reclaimed.
-	if removed, _ := PruneCodexSessionStores("", "", 14*24*time.Hour, time.Now(), nil, testLogger()); removed != 1 {
+	if removed, _ := PruneCodexSessionStores("", t.TempDir(), 14*24*time.Hour, time.Now(), nil, testLogger()); removed != 1 {
 		t.Fatalf("removed = %d, want 1 (idle store reclaimed when reservable)", removed)
 	}
 	assertAbsent(t, storeDir)
@@ -585,13 +585,13 @@ func TestPruneCodexSessionStores_IsolatesProfiles(t *testing.T) {
 
 	// The production (default) daemon prunes — it must NOT touch staging's store,
 	// even with no guard, because staging is a different namespace it never scans.
-	if removed, _ := PruneCodexSessionStores("", "", 14*24*time.Hour, time.Now(), nil, testLogger()); removed != 0 {
+	if removed, _ := PruneCodexSessionStores("", t.TempDir(), 14*24*time.Hour, time.Now(), nil, testLogger()); removed != 0 {
 		t.Fatalf("removed = %d, want 0 — another profile's store must be out of scope", removed)
 	}
 	assertPresent(t, stagingStore)
 
 	// The staging daemon prunes its own namespace → reclaims its idle store.
-	if removed, _ := PruneCodexSessionStores("staging", "", 14*24*time.Hour, time.Now(), nil, testLogger()); removed != 1 {
+	if removed, _ := PruneCodexSessionStores("staging", t.TempDir(), 14*24*time.Hour, time.Now(), nil, testLogger()); removed != 1 {
 		t.Fatalf("removed = %d, want 1 — the owning profile reclaims its idle store", removed)
 	}
 	assertAbsent(t, stagingStore)
@@ -657,14 +657,14 @@ func TestPruneCodexSessionStores_NoCrossProfileCollision(t *testing.T) {
 		chtimesTree(t, storeB, time.Now().Add(-30*24*time.Hour))
 
 		// Pruning profile a reclaims a's store only — b's must survive.
-		if removed, _ := PruneCodexSessionStores(a, "", 14*24*time.Hour, time.Now(), nil, testLogger()); removed != 1 {
+		if removed, _ := PruneCodexSessionStores(a, t.TempDir(), 14*24*time.Hour, time.Now(), nil, testLogger()); removed != 1 {
 			t.Fatalf("prune %q removed=%d, want 1", a, removed)
 		}
 		assertAbsent(t, storeA)
 		assertPresent(t, storeB)
 
 		// Then pruning profile b reclaims b's store.
-		if removed, _ := PruneCodexSessionStores(b, "", 14*24*time.Hour, time.Now(), nil, testLogger()); removed != 1 {
+		if removed, _ := PruneCodexSessionStores(b, t.TempDir(), 14*24*time.Hour, time.Now(), nil, testLogger()); removed != 1 {
 			t.Fatalf("prune %q removed=%d, want 1", b, removed)
 		}
 		assertAbsent(t, storeB)
@@ -683,7 +683,7 @@ func TestPruneCodexSessionStores_RemovesEmptyAgentDir(t *testing.T) {
 
 	now := time.Now()
 	chtimesTree(t, onlyStore, now.Add(-30*24*time.Hour))
-	if removed, _ := PruneCodexSessionStores("", "", 14*24*time.Hour, now, nil, testLogger()); removed != 1 {
+	if removed, _ := PruneCodexSessionStores("", t.TempDir(), 14*24*time.Hour, now, nil, testLogger()); removed != 1 {
 		t.Fatalf("removed = %d, want 1", removed)
 	}
 	assertAbsent(t, filepath.Join(storeRoot, "agent-lonely"))

--- a/server/internal/daemon/execenv/codex_real_home_test.go
+++ b/server/internal/daemon/execenv/codex_real_home_test.go
@@ -24,10 +24,12 @@ func TestPrepareCodexKeepsRealHomeAndScopesOnlyCodexHome(t *testing.T) {
 	// Cannot use t.Parallel() with t.Setenv.
 
 	sharedHome := t.TempDir()
+	writeCodexTestProviderConfig(t, sharedHome, "")
 	t.Setenv("CODEX_HOME", sharedHome)
 
+	workspacesRoot := t.TempDir()
 	env, err := Prepare(PrepareParams{
-		WorkspacesRoot: t.TempDir(),
+		WorkspacesRoot: workspacesRoot,
 		WorkspaceID:    "ws-codex-real-home",
 		TaskID:         "b1c2d3e4-f5a6-7890-bcde-f01234567890",
 		AgentName:      "Codex Agent",
@@ -60,10 +62,12 @@ func TestReuseCodexToleratesLegacyTaskHome(t *testing.T) {
 	// Cannot use t.Parallel() with t.Setenv.
 
 	sharedHome := t.TempDir()
+	writeCodexTestProviderConfig(t, sharedHome, "")
 	t.Setenv("CODEX_HOME", sharedHome)
 
+	workspacesRoot := t.TempDir()
 	env, err := Prepare(PrepareParams{
-		WorkspacesRoot: t.TempDir(),
+		WorkspacesRoot: workspacesRoot,
 		WorkspaceID:    "ws-codex-legacy-home",
 		TaskID:         "c1d2e3f4-a5b6-7890-cdef-012345678901",
 		AgentName:      "Codex Agent",
@@ -85,9 +89,10 @@ func TestReuseCodexToleratesLegacyTaskHome(t *testing.T) {
 	}
 
 	reused := Reuse(ReuseParams{
-		WorkDir:  env.WorkDir,
-		Provider: "codex",
-		Task:     TaskContextForEnv{IssueID: "legacy-home-test"},
+		WorkspacesRoot: workspacesRoot,
+		WorkDir:        env.WorkDir,
+		Provider:       "codex",
+		Task:           TaskContextForEnv{IssueID: "legacy-home-test"},
 	}, testLogger())
 	if reused == nil {
 		t.Fatal("Reuse returned nil on an env root carrying a legacy task home")

--- a/server/internal/daemon/execenv/codex_user_skills.go
+++ b/server/internal/daemon/execenv/codex_user_skills.go
@@ -23,8 +23,12 @@ import (
 // Per-skill failures are logged and skipped — a single broken user skill
 // must not prevent the task from running. Returning an error is reserved for
 // failures that prevent listing the shared skills directory at all.
-func seedUserCodexSkills(codexHome string, workspaceSkills []SkillContextForEnv, logger *slog.Logger) error {
-	sharedSkillsDir := filepath.Join(resolveSharedCodexHome(), "skills")
+func seedUserCodexSkills(codexHome, workspacesRoot string, workspaceSkills []SkillContextForEnv, logger *slog.Logger) error {
+	sharedHome, err := resolveSharedCodexHome(workspacesRoot)
+	if err != nil {
+		return err
+	}
+	sharedSkillsDir := filepath.Join(sharedHome, "skills")
 
 	info, err := os.Stat(sharedSkillsDir)
 	if err != nil {

--- a/server/internal/daemon/execenv/execenv.go
+++ b/server/internal/daemon/execenv/execenv.go
@@ -336,10 +336,10 @@ func Prepare(params PrepareParams, logger *slog.Logger) (*Environment, error) {
 	// For Codex, set up a per-task CODEX_HOME seeded from ~/.codex/ with skills.
 	if params.Provider == "codex" {
 		codexHome := filepath.Join(envRoot, codexHomeDirName)
-		if err := prepareCodexHomeWithOpts(codexHome, CodexHomeOptions{CodexVersion: params.CodexVersion, IsLocalDirectory: params.LocalWorkDir != "", SessionStoreKey: codexSessionStoreKey(params.Profile, params.Task.AgentID, params.Task.IssueID), CodexCustomArgs: params.CodexCustomArgs}, logger); err != nil {
+		if err := prepareCodexHomeWithOpts(codexHome, CodexHomeOptions{WorkspacesRoot: params.WorkspacesRoot, CodexVersion: params.CodexVersion, IsLocalDirectory: params.LocalWorkDir != "", SessionStoreKey: codexSessionStoreKey(params.Profile, params.Task.AgentID, params.Task.IssueID), CodexCustomArgs: params.CodexCustomArgs}, logger); err != nil {
 			return nil, fmt.Errorf("execenv: prepare codex-home: %w", err)
 		}
-		if err := hydrateCodexSkills(codexHome, params.Task.AgentSkills, params.Task.DisabledRuntimeSkills, logger); err != nil {
+		if err := hydrateCodexSkills(codexHome, params.WorkspacesRoot, params.Task.AgentSkills, params.Task.DisabledRuntimeSkills, logger); err != nil {
 			return nil, fmt.Errorf("execenv: hydrate codex skills: %w", err)
 		}
 		env.CodexHome = codexHome
@@ -392,9 +392,10 @@ func Prepare(params PrepareParams, logger *slog.Logger) (*Environment, error) {
 	// OpenClaw without the agents / providers / API keys it expects.
 	if params.Provider == "openclaw" {
 		result, err := prepareOpenclawConfig(envRoot, workDir, OpenclawConfigPrep{
-			OpenclawBin: params.OpenclawBin,
-			McpConfig:   params.McpConfig,
-			Gateway:     params.OpenclawGateway,
+			OpenclawBin:    params.OpenclawBin,
+			WorkspacesRoot: params.WorkspacesRoot,
+			McpConfig:      params.McpConfig,
+			Gateway:        params.OpenclawGateway,
 		})
 		if err != nil {
 			return nil, fmt.Errorf("execenv: prepare openclaw config: %w", err)
@@ -552,11 +553,11 @@ func Reuse(params ReuseParams, logger *slog.Logger) *Environment {
 	// config (especially sandbox/network access) is up to date.
 	if params.Provider == "codex" {
 		codexHome := filepath.Join(env.RootDir, codexHomeDirName)
-		if err := prepareCodexHomeWithOpts(codexHome, CodexHomeOptions{CodexVersion: params.CodexVersion, ResumeSessionID: params.ResumeSessionID, IsLocalDirectory: params.LocalDirectory, SessionStoreKey: codexSessionStoreKey(params.Profile, params.Task.AgentID, params.Task.IssueID), CodexCustomArgs: params.CodexCustomArgs}, logger); err != nil {
+		if err := prepareCodexHomeWithOpts(codexHome, CodexHomeOptions{WorkspacesRoot: params.WorkspacesRoot, CodexVersion: params.CodexVersion, ResumeSessionID: params.ResumeSessionID, IsLocalDirectory: params.LocalDirectory, SessionStoreKey: codexSessionStoreKey(params.Profile, params.Task.AgentID, params.Task.IssueID), CodexCustomArgs: params.CodexCustomArgs}, logger); err != nil {
 			logger.Warn("execenv: refresh codex-home failed", "error", err)
 		} else {
 			env.CodexHome = codexHome
-			if err := hydrateCodexSkills(codexHome, params.Task.AgentSkills, params.Task.DisabledRuntimeSkills, logger); err != nil {
+			if err := hydrateCodexSkills(codexHome, params.WorkspacesRoot, params.Task.AgentSkills, params.Task.DisabledRuntimeSkills, logger); err != nil {
 				logger.Warn("execenv: refresh codex skills failed", "error", err)
 			}
 		}
@@ -623,9 +624,10 @@ func Reuse(params ReuseParams, logger *slog.Logger) *Environment {
 	// without the registered agents.
 	if params.Provider == "openclaw" {
 		result, err := prepareOpenclawConfig(env.RootDir, params.WorkDir, OpenclawConfigPrep{
-			OpenclawBin: params.OpenclawBin,
-			McpConfig:   params.McpConfig,
-			Gateway:     params.OpenclawGateway,
+			OpenclawBin:    params.OpenclawBin,
+			WorkspacesRoot: params.WorkspacesRoot,
+			McpConfig:      params.McpConfig,
+			Gateway:        params.OpenclawGateway,
 		})
 		if err != nil {
 			logger.Warn("execenv: refresh openclaw config failed", "error", err)
@@ -659,12 +661,12 @@ func Reuse(params ReuseParams, logger *slog.Logger) *Environment {
 // user's real ~/.codex/. Other runtimes leave HOME untouched and discover
 // user-level skills natively (see context.go for the workdir-local paths
 // they use for workspace skills).
-func hydrateCodexSkills(codexHome string, workspaceSkills []SkillContextForEnv, disabledRuntimeSkills []RuntimeSkillRefForEnv, logger *slog.Logger) error {
+func hydrateCodexSkills(codexHome, workspacesRoot string, workspaceSkills []SkillContextForEnv, disabledRuntimeSkills []RuntimeSkillRefForEnv, logger *slog.Logger) error {
 	skillsDir := filepath.Join(codexHome, "skills")
 	if err := os.RemoveAll(skillsDir); err != nil {
 		return fmt.Errorf("clear codex skills dir: %w", err)
 	}
-	if err := seedUserCodexSkills(codexHome, workspaceSkills, logger); err != nil {
+	if err := seedUserCodexSkills(codexHome, workspacesRoot, workspaceSkills, logger); err != nil {
 		logger.Warn("execenv: seed user codex skills failed", "error", err)
 	}
 	if len(workspaceSkills) > 0 {

--- a/server/internal/daemon/execenv/execenv.go
+++ b/server/internal/daemon/execenv/execenv.go
@@ -342,9 +342,6 @@ func Prepare(params PrepareParams, logger *slog.Logger) (*Environment, error) {
 		if err := hydrateCodexSkills(codexHome, params.WorkspacesRoot, params.Task.AgentSkills, params.Task.DisabledRuntimeSkills, logger); err != nil {
 			return nil, fmt.Errorf("execenv: hydrate codex skills: %w", err)
 		}
-		if err := ensureCodexProviderConfigUsable(codexHome); err != nil {
-			return nil, fmt.Errorf("execenv: codex provider config unusable: %w", err)
-		}
 		env.CodexHome = codexHome
 	}
 
@@ -562,10 +559,6 @@ func Reuse(params ReuseParams, logger *slog.Logger) *Environment {
 		}
 		if err := hydrateCodexSkills(codexHome, params.WorkspacesRoot, params.Task.AgentSkills, params.Task.DisabledRuntimeSkills, logger); err != nil {
 			logger.Warn("execenv: refresh codex skills failed; forcing fresh prepare", "error", err)
-			return nil
-		}
-		if err := ensureCodexProviderConfigUsable(codexHome); err != nil {
-			logger.Warn("execenv: codex provider config unusable after reuse refresh; forcing fresh prepare", "error", err)
 			return nil
 		}
 		env.CodexHome = codexHome

--- a/server/internal/daemon/execenv/execenv.go
+++ b/server/internal/daemon/execenv/execenv.go
@@ -342,6 +342,9 @@ func Prepare(params PrepareParams, logger *slog.Logger) (*Environment, error) {
 		if err := hydrateCodexSkills(codexHome, params.WorkspacesRoot, params.Task.AgentSkills, params.Task.DisabledRuntimeSkills, logger); err != nil {
 			return nil, fmt.Errorf("execenv: hydrate codex skills: %w", err)
 		}
+		if err := ensureCodexProviderConfigUsable(codexHome); err != nil {
+			return nil, fmt.Errorf("execenv: codex provider config unusable: %w", err)
+		}
 		env.CodexHome = codexHome
 	}
 
@@ -554,13 +557,18 @@ func Reuse(params ReuseParams, logger *slog.Logger) *Environment {
 	if params.Provider == "codex" {
 		codexHome := filepath.Join(env.RootDir, codexHomeDirName)
 		if err := prepareCodexHomeWithOpts(codexHome, CodexHomeOptions{WorkspacesRoot: params.WorkspacesRoot, CodexVersion: params.CodexVersion, ResumeSessionID: params.ResumeSessionID, IsLocalDirectory: params.LocalDirectory, SessionStoreKey: codexSessionStoreKey(params.Profile, params.Task.AgentID, params.Task.IssueID), CodexCustomArgs: params.CodexCustomArgs}, logger); err != nil {
-			logger.Warn("execenv: refresh codex-home failed", "error", err)
-		} else {
-			env.CodexHome = codexHome
-			if err := hydrateCodexSkills(codexHome, params.WorkspacesRoot, params.Task.AgentSkills, params.Task.DisabledRuntimeSkills, logger); err != nil {
-				logger.Warn("execenv: refresh codex skills failed", "error", err)
-			}
+			logger.Warn("execenv: refresh codex-home failed; forcing fresh prepare", "error", err)
+			return nil
 		}
+		if err := hydrateCodexSkills(codexHome, params.WorkspacesRoot, params.Task.AgentSkills, params.Task.DisabledRuntimeSkills, logger); err != nil {
+			logger.Warn("execenv: refresh codex skills failed; forcing fresh prepare", "error", err)
+			return nil
+		}
+		if err := ensureCodexProviderConfigUsable(codexHome); err != nil {
+			logger.Warn("execenv: codex provider config unusable after reuse refresh; forcing fresh prepare", "error", err)
+			return nil
+		}
+		env.CodexHome = codexHome
 	}
 
 	if params.Provider == "claude" && env.RootDir != "" {

--- a/server/internal/daemon/execenv/execenv_test.go
+++ b/server/internal/daemon/execenv/execenv_test.go
@@ -21,6 +21,31 @@ func discardLogger() *slog.Logger {
 	return slog.New(slog.NewTextHandler(io.Discard, nil))
 }
 
+func codexTestProviderConfig(extra string) string {
+	config := `model_provider = "test-provider"
+`
+	if strings.TrimSpace(extra) != "" {
+		config += "\n" + extra + "\n"
+	}
+	return config + `
+
+[model_providers.test-provider]
+name = "Test"
+base_url = "https://example.invalid/v1"
+env_key = "TEST_API_KEY"
+`
+}
+
+func writeCodexTestProviderConfig(t *testing.T, home string, extra string) {
+	t.Helper()
+	if err := os.MkdirAll(home, 0o755); err != nil {
+		t.Fatalf("mkdir codex home: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(home, "config.toml"), []byte(codexTestProviderConfig(extra)), 0o644); err != nil {
+		t.Fatalf("write codex config.toml: %v", err)
+	}
+}
+
 func TestShortID(t *testing.T) {
 	t.Parallel()
 	tests := []struct {
@@ -2973,6 +2998,7 @@ func TestPrepareCodexHomeSkipsMissingFiles(t *testing.T) {
 
 	// Empty shared home — no files to seed.
 	sharedHome := t.TempDir()
+	writeCodexTestProviderConfig(t, sharedHome, "")
 	t.Setenv("CODEX_HOME", sharedHome)
 
 	codexHome := filepath.Join(t.TempDir(), "codex-home")
@@ -3842,7 +3868,7 @@ func TestPrepareCodexHomeFailsClosedWhenSandboxWriteFails(t *testing.T) {
 
 	// Shared home the user has since pointed at a native Windows sandbox.
 	sharedHome := t.TempDir()
-	if err := os.WriteFile(filepath.Join(sharedHome, "config.toml"), []byte("windows.sandbox = \"unelevated\"\n"), 0o644); err != nil {
+	if err := os.WriteFile(filepath.Join(sharedHome, "config.toml"), []byte(codexTestProviderConfig("windows.sandbox = \"unelevated\"\n")), 0o644); err != nil {
 		t.Fatal(err)
 	}
 	t.Setenv("CODEX_HOME", sharedHome)
@@ -3868,7 +3894,7 @@ func TestPrepareCodexHomeFailsClosedWhenSandboxWriteFails(t *testing.T) {
 		_ = os.Chmod(configPath, 0o644)
 	})
 
-	err := prepareCodexHomeWithOpts(codexHome, CodexHomeOptions{GOOS: "windows", CodexVersion: "0.144.5"}, testLogger())
+	err := prepareCodexHomeWithOpts(codexHome, CodexHomeOptions{WorkspacesRoot: filepath.Join(codexHome, "workspaces-root"), GOOS: "windows", CodexVersion: "0.144.5"}, testLogger())
 	if err == nil {
 		t.Fatal("expected prepareCodexHomeWithOpts to fail closed when the sandbox block cannot be written, got nil")
 	}
@@ -3896,6 +3922,7 @@ func TestPrepareCodexHomeWritesManagedSandboxBlock(t *testing.T) {
 
 	// Empty shared home — no config.toml to copy.
 	sharedHome := t.TempDir()
+	writeCodexTestProviderConfig(t, sharedHome, "")
 	t.Setenv("CODEX_HOME", sharedHome)
 
 	codexHome := filepath.Join(t.TempDir(), "codex-home")
@@ -3925,6 +3952,7 @@ func TestReuseRestoresCodexHome(t *testing.T) {
 	// Cannot use t.Parallel() with t.Setenv.
 
 	sharedHome := t.TempDir()
+	writeCodexTestProviderConfig(t, sharedHome, "")
 	t.Setenv("CODEX_HOME", sharedHome)
 
 	workspacesRoot := t.TempDir()
@@ -3948,7 +3976,7 @@ func TestReuseRestoresCodexHome(t *testing.T) {
 	}
 
 	// Reuse should restore CodexHome.
-	reused := Reuse(ReuseParams{WorkDir: env.WorkDir, Provider: "codex", Task: TaskContextForEnv{IssueID: "reuse-test"}}, testLogger())
+	reused := Reuse(ReuseParams{WorkspacesRoot: workspacesRoot, WorkDir: env.WorkDir, Provider: "codex", Task: TaskContextForEnv{IssueID: "reuse-test"}}, testLogger())
 	if reused == nil {
 		t.Fatal("Reuse returned nil")
 	}
@@ -3971,6 +3999,7 @@ func TestReuseRestoresCodexPluginCache(t *testing.T) {
 	// Cannot use t.Parallel() with t.Setenv.
 
 	sharedHome := t.TempDir()
+	writeCodexTestProviderConfig(t, sharedHome, "")
 	sharedPluginCache := filepath.Join(sharedHome, "plugins", "cache")
 	if err := os.MkdirAll(filepath.Join(sharedPluginCache, "superpowers"), 0o755); err != nil {
 		t.Fatalf("create shared plugin cache: %v", err)
@@ -3998,7 +4027,7 @@ func TestReuseRestoresCodexPluginCache(t *testing.T) {
 		t.Fatalf("remove codex plugins dir: %v", err)
 	}
 
-	reused := Reuse(ReuseParams{WorkDir: env.WorkDir, Provider: "codex", Task: TaskContextForEnv{IssueID: "reuse-plugin-test"}}, testLogger())
+	reused := Reuse(ReuseParams{WorkspacesRoot: workspacesRoot, WorkDir: env.WorkDir, Provider: "codex", Task: TaskContextForEnv{IssueID: "reuse-plugin-test"}}, testLogger())
 	if reused == nil {
 		t.Fatal("Reuse returned nil")
 	}
@@ -4016,10 +4045,12 @@ func TestReusePreservesTaskLocalModelsCacheWhenSharedMissing(t *testing.T) {
 	// Cannot use t.Parallel() with t.Setenv.
 
 	sharedHome := t.TempDir()
+	writeCodexTestProviderConfig(t, sharedHome, "")
 	t.Setenv("CODEX_HOME", sharedHome)
 
+	workspacesRoot := t.TempDir()
 	env, err := Prepare(PrepareParams{
-		WorkspacesRoot: t.TempDir(),
+		WorkspacesRoot: workspacesRoot,
 		WorkspaceID:    "ws-codex-model-cache-missing",
 		TaskID:         "b5f6a7b8-c9d0-1234-efab-567890123456",
 		AgentName:      "Codex Agent",
@@ -4037,9 +4068,10 @@ func TestReusePreservesTaskLocalModelsCacheWhenSharedMissing(t *testing.T) {
 	}
 
 	reused := Reuse(ReuseParams{
-		WorkDir:  env.WorkDir,
-		Provider: "codex",
-		Task:     TaskContextForEnv{IssueID: "reuse-model-cache-missing"},
+		WorkspacesRoot: workspacesRoot,
+		WorkDir:        env.WorkDir,
+		Provider:       "codex",
+		Task:           TaskContextForEnv{IssueID: "reuse-model-cache-missing"},
 	}, testLogger())
 	if reused == nil {
 		t.Fatal("Reuse returned nil")
@@ -4058,13 +4090,15 @@ func TestReusePreservesTaskLocalModelsCacheOverStaleSharedSnapshot(t *testing.T)
 	// Cannot use t.Parallel() with t.Setenv.
 
 	sharedHome := t.TempDir()
+	writeCodexTestProviderConfig(t, sharedHome, "")
 	if err := os.WriteFile(filepath.Join(sharedHome, "models_cache.json"), []byte(`{"source":"shared"}`), 0o644); err != nil {
 		t.Fatalf("write shared models cache: %v", err)
 	}
 	t.Setenv("CODEX_HOME", sharedHome)
 
+	workspacesRoot := t.TempDir()
 	env, err := Prepare(PrepareParams{
-		WorkspacesRoot: t.TempDir(),
+		WorkspacesRoot: workspacesRoot,
 		WorkspaceID:    "ws-codex-model-cache-stale",
 		TaskID:         "c5f6a7b8-c9d0-1234-efab-567890123456",
 		AgentName:      "Codex Agent",
@@ -4082,9 +4116,10 @@ func TestReusePreservesTaskLocalModelsCacheOverStaleSharedSnapshot(t *testing.T)
 	}
 
 	reused := Reuse(ReuseParams{
-		WorkDir:  env.WorkDir,
-		Provider: "codex",
-		Task:     TaskContextForEnv{IssueID: "reuse-model-cache-stale"},
+		WorkspacesRoot: workspacesRoot,
+		WorkDir:        env.WorkDir,
+		Provider:       "codex",
+		Task:           TaskContextForEnv{IssueID: "reuse-model-cache-stale"},
 	}, testLogger())
 	if reused == nil {
 		t.Fatal("Reuse returned nil")
@@ -4104,7 +4139,13 @@ func TestReuseInvalidatesTaskLocalModelsCacheWhenProviderConfigChanges(t *testin
 
 	sharedHome := t.TempDir()
 	configPath := filepath.Join(sharedHome, "config.toml")
-	if err := os.WriteFile(configPath, []byte(`model_provider = "provider-a"`), 0o644); err != nil {
+	if err := os.WriteFile(configPath, []byte(`model_provider = "provider-a"
+
+[model_providers.provider-a]
+name = "Provider A"
+base_url = "https://provider-a.example.invalid/v1"
+env_key = "PROVIDER_A_API_KEY"
+`), 0o644); err != nil {
 		t.Fatalf("write provider A config: %v", err)
 	}
 	sharedCache := filepath.Join(sharedHome, "models_cache.json")
@@ -4113,8 +4154,9 @@ func TestReuseInvalidatesTaskLocalModelsCacheWhenProviderConfigChanges(t *testin
 	}
 	t.Setenv("CODEX_HOME", sharedHome)
 
+	workspacesRoot := t.TempDir()
 	env, err := Prepare(PrepareParams{
-		WorkspacesRoot: t.TempDir(),
+		WorkspacesRoot: workspacesRoot,
 		WorkspaceID:    "ws-codex-model-cache-provider-change",
 		TaskID:         "d5f6a7b8-c9d0-1234-efab-567890123456",
 		AgentName:      "Codex Agent",
@@ -4130,7 +4172,13 @@ func TestReuseInvalidatesTaskLocalModelsCacheWhenProviderConfigChanges(t *testin
 	if err := os.WriteFile(modelsCache, []byte(`{"source":"task-a"}`), 0o644); err != nil {
 		t.Fatalf("refresh provider A task cache: %v", err)
 	}
-	if err := os.WriteFile(configPath, []byte(`model_provider = "provider-b"`), 0o644); err != nil {
+	if err := os.WriteFile(configPath, []byte(`model_provider = "provider-b"
+
+[model_providers.provider-b]
+name = "Provider B"
+base_url = "https://provider-b.example.invalid/v1"
+env_key = "PROVIDER_B_API_KEY"
+`), 0o644); err != nil {
 		t.Fatalf("write provider B config: %v", err)
 	}
 	// Even a changed shared snapshot is not safe to copy: Codex's cache format
@@ -4140,9 +4188,10 @@ func TestReuseInvalidatesTaskLocalModelsCacheWhenProviderConfigChanges(t *testin
 	}
 
 	reused := Reuse(ReuseParams{
-		WorkDir:  env.WorkDir,
-		Provider: "codex",
-		Task:     TaskContextForEnv{IssueID: "reuse-model-cache-provider-change"},
+		WorkspacesRoot: workspacesRoot,
+		WorkDir:        env.WorkDir,
+		Provider:       "codex",
+		Task:           TaskContextForEnv{IssueID: "reuse-model-cache-provider-change"},
 	}, testLogger())
 	if reused == nil {
 		t.Fatal("Reuse returned nil")
@@ -4164,9 +4213,10 @@ func TestReuseInvalidatesTaskLocalModelsCacheWhenProviderConfigChanges(t *testin
 		t.Fatalf("write provider B task cache: %v", err)
 	}
 	if Reuse(ReuseParams{
-		WorkDir:  env.WorkDir,
-		Provider: "codex",
-		Task:     TaskContextForEnv{IssueID: "reuse-model-cache-provider-change"},
+		WorkspacesRoot: workspacesRoot,
+		WorkDir:        env.WorkDir,
+		Provider:       "codex",
+		Task:           TaskContextForEnv{IssueID: "reuse-model-cache-provider-change"},
 	}, testLogger()) == nil {
 		t.Fatal("second Reuse returned nil")
 	}
@@ -4183,7 +4233,7 @@ func TestReuseInvalidatesTaskLocalModelsCacheWhenModelCatalogChanges(t *testing.
 	// Cannot use t.Parallel() with t.Setenv.
 
 	sharedHome := t.TempDir()
-	if err := os.WriteFile(filepath.Join(sharedHome, "config.toml"), []byte(`model_catalog_json = "catalog.json"`), 0o644); err != nil {
+	if err := os.WriteFile(filepath.Join(sharedHome, "config.toml"), []byte(codexTestProviderConfig(`model_catalog_json = "catalog.json"`)), 0o644); err != nil {
 		t.Fatalf("write model catalog config: %v", err)
 	}
 	catalogPath := filepath.Join(sharedHome, "catalog.json")
@@ -4195,8 +4245,9 @@ func TestReuseInvalidatesTaskLocalModelsCacheWhenModelCatalogChanges(t *testing.
 	}
 	t.Setenv("CODEX_HOME", sharedHome)
 
+	workspacesRoot := t.TempDir()
 	env, err := Prepare(PrepareParams{
-		WorkspacesRoot: t.TempDir(),
+		WorkspacesRoot: workspacesRoot,
 		WorkspaceID:    "ws-codex-model-catalog-change",
 		TaskID:         "e5f6a7b8-c9d0-1234-efab-567890123456",
 		AgentName:      "Codex Agent",
@@ -4217,9 +4268,10 @@ func TestReuseInvalidatesTaskLocalModelsCacheWhenModelCatalogChanges(t *testing.
 	}
 
 	reused := Reuse(ReuseParams{
-		WorkDir:  env.WorkDir,
-		Provider: "codex",
-		Task:     TaskContextForEnv{IssueID: "reuse-model-catalog-change"},
+		WorkspacesRoot: workspacesRoot,
+		WorkDir:        env.WorkDir,
+		Provider:       "codex",
+		Task:           TaskContextForEnv{IssueID: "reuse-model-catalog-change"},
 	}, testLogger())
 	if reused == nil {
 		t.Fatal("Reuse returned nil")
@@ -4240,13 +4292,20 @@ func TestReuseInvalidatesUnboundLegacyModelsCache(t *testing.T) {
 	// Cannot use t.Parallel() with t.Setenv.
 
 	sharedHome := t.TempDir()
-	if err := os.WriteFile(filepath.Join(sharedHome, "config.toml"), []byte(`model_provider = "provider-a"`), 0o644); err != nil {
+	if err := os.WriteFile(filepath.Join(sharedHome, "config.toml"), []byte(`model_provider = "provider-a"
+
+[model_providers.provider-a]
+name = "Provider A"
+base_url = "https://provider-a.example.invalid/v1"
+env_key = "PROVIDER_A_API_KEY"
+`), 0o644); err != nil {
 		t.Fatalf("write provider config: %v", err)
 	}
 	t.Setenv("CODEX_HOME", sharedHome)
 
+	workspacesRoot := t.TempDir()
 	env, err := Prepare(PrepareParams{
-		WorkspacesRoot: t.TempDir(),
+		WorkspacesRoot: workspacesRoot,
 		WorkspaceID:    "ws-codex-model-cache-legacy",
 		TaskID:         "f5f6a7b8-c9d0-1234-efab-567890123456",
 		AgentName:      "Codex Agent",
@@ -4267,9 +4326,10 @@ func TestReuseInvalidatesUnboundLegacyModelsCache(t *testing.T) {
 	}
 
 	if Reuse(ReuseParams{
-		WorkDir:  env.WorkDir,
-		Provider: "codex",
-		Task:     TaskContextForEnv{IssueID: "reuse-model-cache-legacy"},
+		WorkspacesRoot: workspacesRoot,
+		WorkDir:        env.WorkDir,
+		Provider:       "codex",
+		Task:           TaskContextForEnv{IssueID: "reuse-model-cache-legacy"},
 	}, testLogger()) == nil {
 		t.Fatal("Reuse returned nil")
 	}
@@ -4286,9 +4346,10 @@ func TestReuseInvalidatesUnboundLegacyModelsCache(t *testing.T) {
 		t.Fatalf("write shared cache: %v", err)
 	}
 	if Reuse(ReuseParams{
-		WorkDir:  env.WorkDir,
-		Provider: "codex",
-		Task:     TaskContextForEnv{IssueID: "reuse-model-cache-legacy"},
+		WorkspacesRoot: workspacesRoot,
+		WorkDir:        env.WorkDir,
+		Provider:       "codex",
+		Task:           TaskContextForEnv{IssueID: "reuse-model-cache-legacy"},
 	}, testLogger()) == nil {
 		t.Fatal("second Reuse returned nil")
 	}
@@ -4301,6 +4362,7 @@ func TestReuseWritesMissingCodexWorkspaceSkills(t *testing.T) {
 	// Cannot use t.Parallel() with t.Setenv.
 
 	sharedHome := t.TempDir()
+	writeCodexTestProviderConfig(t, sharedHome, "")
 	t.Setenv("CODEX_HOME", sharedHome)
 
 	workspacesRoot := t.TempDir()
@@ -4321,7 +4383,7 @@ func TestReuseWritesMissingCodexWorkspaceSkills(t *testing.T) {
 		t.Fatalf("remove codex skills dir: %v", err)
 	}
 
-	reused := Reuse(ReuseParams{WorkDir: env.WorkDir, Provider: "codex", Task: TaskContextForEnv{
+	reused := Reuse(ReuseParams{WorkspacesRoot: workspacesRoot, WorkDir: env.WorkDir, Provider: "codex", Task: TaskContextForEnv{
 		IssueID: "reuse-skill-test",
 		AgentSkills: []SkillContextForEnv{
 			{
@@ -4355,6 +4417,7 @@ func TestReuseUpdatesCodexWorkspaceSkills(t *testing.T) {
 	// Cannot use t.Parallel() with t.Setenv.
 
 	sharedHome := t.TempDir()
+	writeCodexTestProviderConfig(t, sharedHome, "")
 	t.Setenv("CODEX_HOME", sharedHome)
 
 	workspacesRoot := t.TempDir()
@@ -4380,7 +4443,7 @@ func TestReuseUpdatesCodexWorkspaceSkills(t *testing.T) {
 	}
 	defer env.Cleanup(true)
 
-	reused := Reuse(ReuseParams{WorkDir: env.WorkDir, Provider: "codex", Task: TaskContextForEnv{
+	reused := Reuse(ReuseParams{WorkspacesRoot: workspacesRoot, WorkDir: env.WorkDir, Provider: "codex", Task: TaskContextForEnv{
 		IssueID: "reuse-skill-update-test",
 		AgentSkills: []SkillContextForEnv{
 			{
@@ -4418,6 +4481,7 @@ func TestPrepareCodexSeedsUserSkills(t *testing.T) {
 	// Cannot use t.Parallel() with t.Setenv.
 
 	sharedHome := t.TempDir()
+	writeCodexTestProviderConfig(t, sharedHome, "")
 	t.Setenv("CODEX_HOME", sharedHome)
 
 	// Lay out two user-installed skills with both a SKILL.md and a
@@ -4483,6 +4547,7 @@ func TestPrepareCodexWorkspaceSkillBeatsUserSkillOnConflict(t *testing.T) {
 	// Cannot use t.Parallel() with t.Setenv.
 
 	sharedHome := t.TempDir()
+	writeCodexTestProviderConfig(t, sharedHome, "")
 	t.Setenv("CODEX_HOME", sharedHome)
 
 	userSkillDir := filepath.Join(sharedHome, "skills", "writing")
@@ -4535,6 +4600,7 @@ func TestPrepareCodexNoUserSkillsDir(t *testing.T) {
 	// Cannot use t.Parallel() with t.Setenv.
 
 	sharedHome := t.TempDir()
+	writeCodexTestProviderConfig(t, sharedHome, "")
 	t.Setenv("CODEX_HOME", sharedHome)
 
 	env, err := Prepare(PrepareParams{
@@ -4565,6 +4631,7 @@ func TestPrepareCodexResolvesUserSkillSymlinks(t *testing.T) {
 	// Cannot use t.Parallel() with t.Setenv.
 
 	sharedHome := t.TempDir()
+	writeCodexTestProviderConfig(t, sharedHome, "")
 	t.Setenv("CODEX_HOME", sharedHome)
 
 	installerRoot := filepath.Join(t.TempDir(), "installer", "lark-mail")
@@ -4619,6 +4686,7 @@ func TestReuseSeedsUserSkillUpdates(t *testing.T) {
 	// Cannot use t.Parallel() with t.Setenv.
 
 	sharedHome := t.TempDir()
+	writeCodexTestProviderConfig(t, sharedHome, "")
 	t.Setenv("CODEX_HOME", sharedHome)
 
 	userSkill := filepath.Join(sharedHome, "skills", "summarize")
@@ -4647,7 +4715,7 @@ func TestReuseSeedsUserSkillUpdates(t *testing.T) {
 		t.Fatalf("update user SKILL.md: %v", err)
 	}
 
-	reused := Reuse(ReuseParams{WorkDir: env.WorkDir, Provider: "codex", Task: TaskContextForEnv{
+	reused := Reuse(ReuseParams{WorkspacesRoot: workspacesRoot, WorkDir: env.WorkDir, Provider: "codex", Task: TaskContextForEnv{
 		IssueID: "user-skill-reuse-test",
 	}}, testLogger())
 	if reused == nil {
@@ -4671,6 +4739,7 @@ func TestReuseClearsUserSkillResidueOnWorkspaceConflict(t *testing.T) {
 	// Cannot use t.Parallel() with t.Setenv.
 
 	sharedHome := t.TempDir()
+	writeCodexTestProviderConfig(t, sharedHome, "")
 	t.Setenv("CODEX_HOME", sharedHome)
 
 	userSkillDir := filepath.Join(sharedHome, "skills", "writing")
@@ -4684,8 +4753,9 @@ func TestReuseClearsUserSkillResidueOnWorkspaceConflict(t *testing.T) {
 		t.Fatalf("seed user support file: %v", err)
 	}
 
+	workspacesRoot := t.TempDir()
 	env, err := Prepare(PrepareParams{
-		WorkspacesRoot: t.TempDir(),
+		WorkspacesRoot: workspacesRoot,
 		WorkspaceID:    "ws-reuse-conflict",
 		TaskID:         "c1d2e3f4-a5b6-7890-abcd-123456789012",
 		AgentName:      "Codex Agent",
@@ -4702,7 +4772,7 @@ func TestReuseClearsUserSkillResidueOnWorkspaceConflict(t *testing.T) {
 		t.Fatalf("user support file should be seeded in round 1: %v", err)
 	}
 
-	reused := Reuse(ReuseParams{WorkDir: env.WorkDir, Provider: "codex", Task: TaskContextForEnv{
+	reused := Reuse(ReuseParams{WorkspacesRoot: workspacesRoot, WorkDir: env.WorkDir, Provider: "codex", Task: TaskContextForEnv{
 		IssueID: "reuse-conflict-test",
 		AgentSkills: []SkillContextForEnv{
 			{Name: "Writing", Content: "workspace writing"},
@@ -4732,6 +4802,7 @@ func TestReuseClearsRemovedUserSkill(t *testing.T) {
 	// Cannot use t.Parallel() with t.Setenv.
 
 	sharedHome := t.TempDir()
+	writeCodexTestProviderConfig(t, sharedHome, "")
 	t.Setenv("CODEX_HOME", sharedHome)
 
 	userSkill := filepath.Join(sharedHome, "skills", "deprecated")
@@ -4742,8 +4813,9 @@ func TestReuseClearsRemovedUserSkill(t *testing.T) {
 		t.Fatalf("seed user SKILL.md: %v", err)
 	}
 
+	workspacesRoot := t.TempDir()
 	env, err := Prepare(PrepareParams{
-		WorkspacesRoot: t.TempDir(),
+		WorkspacesRoot: workspacesRoot,
 		WorkspaceID:    "ws-reuse-remove",
 		TaskID:         "d2e3f4a5-b6c7-8901-abcd-234567890123",
 		AgentName:      "Codex Agent",
@@ -4764,7 +4836,7 @@ func TestReuseClearsRemovedUserSkill(t *testing.T) {
 		t.Fatalf("remove user skill: %v", err)
 	}
 
-	reused := Reuse(ReuseParams{WorkDir: env.WorkDir, Provider: "codex", Task: TaskContextForEnv{
+	reused := Reuse(ReuseParams{WorkspacesRoot: workspacesRoot, WorkDir: env.WorkDir, Provider: "codex", Task: TaskContextForEnv{
 		IssueID: "reuse-remove-test",
 	}}, testLogger())
 	if reused == nil {

--- a/server/internal/daemon/execenv/hermes_home.go
+++ b/server/internal/daemon/execenv/hermes_home.go
@@ -256,46 +256,7 @@ func guardInheritedHermesHome(res HermesProfileResolution, inherited bool, works
 		res.Err = err
 		return res
 	}
-	if err := hermesSourceHomeProviderConfig(res.SourceHome); err != nil {
-		res.Err = fmt.Errorf("hermes: inherited HERMES_HOME is not usable (%s): %w", res.SourceHome, err)
-	}
 	return res
-}
-
-func hermesSourceHomeProviderConfig(home string) error {
-	data, err := os.ReadFile(filepath.Join(home, "config.yaml"))
-	if err != nil {
-		if os.IsNotExist(err) {
-			return nil
-		}
-		return fmt.Errorf("read config.yaml: %w", err)
-	}
-	var doc yaml.Node
-	if err := yaml.Unmarshal(data, &doc); err != nil {
-		return fmt.Errorf("parse config.yaml: %w", err)
-	}
-	if yamlDocumentHasAnyTopLevelKey(&doc, "model", "provider", "providers", "api_key") {
-		return nil
-	}
-	return fmt.Errorf("config.yaml has no model/provider settings")
-}
-
-func yamlDocumentHasAnyTopLevelKey(doc *yaml.Node, keys ...string) bool {
-	if doc == nil || doc.Kind != yaml.DocumentNode || len(doc.Content) == 0 {
-		return false
-	}
-	root := doc.Content[0]
-	if root.Kind != yaml.MappingNode {
-		return false
-	}
-	for i := 0; i+1 < len(root.Content); i += 2 {
-		for _, key := range keys {
-			if root.Content[i].Value == key {
-				return true
-			}
-		}
-	}
-	return false
 }
 
 // hermesRootFromHome reproduces hermes_constants.get_default_hermes_root: the

--- a/server/internal/daemon/execenv/hermes_home.go
+++ b/server/internal/daemon/execenv/hermes_home.go
@@ -203,9 +203,15 @@ type HermesProfileResolution struct {
 // a value matched; inline distinguishes the `--profile=<value>` form, whose empty
 // value must hard-fail rather than fall back to the default.
 func ResolveHermesProfile(customEnvHome, name string, found, inline bool) HermesProfileResolution {
+	return ResolveHermesProfileWithWorkspacesRoot(customEnvHome, name, found, inline, "")
+}
+
+func ResolveHermesProfileWithWorkspacesRoot(customEnvHome, name string, found, inline bool, workspacesRoot string) HermesProfileResolution {
 	base := strings.TrimSpace(customEnvHome)
+	inheritedHome := false
 	if base == "" {
 		base = strings.TrimSpace(os.Getenv("HERMES_HOME"))
+		inheritedHome = base != ""
 	}
 	if base == "" {
 		base = platformDefaultHermesHome()
@@ -220,7 +226,7 @@ func ResolveHermesProfile(customEnvHome, name string, found, inline bool) Hermes
 		// Step 1.5: trust an already-profile-scoped HERMES_HOME (immediate parent
 		// dir named "profiles") without consulting active_profile.
 		if base != "" && filepath.Base(filepath.Dir(base)) == "profiles" {
-			return HermesProfileResolution{SourceHome: base, MustExist: true}
+			return guardInheritedHermesHome(HermesProfileResolution{SourceHome: base, MustExist: true}, inheritedHome, workspacesRoot)
 		}
 		// Step 2: honor the sticky <root>/active_profile. (The container-only
 		// HERMES_S6_SUPERVISED_CHILD exception in Hermes does not apply to a
@@ -228,7 +234,7 @@ func ResolveHermesProfile(customEnvHome, name string, found, inline bool) Hermes
 		// root/default) is the source.
 		profile = readHermesActiveProfile(root)
 		if profile == "" {
-			return HermesProfileResolution{SourceHome: base}
+			return guardInheritedHermesHome(HermesProfileResolution{SourceHome: base}, inheritedHome, workspacesRoot)
 		}
 	}
 
@@ -239,7 +245,53 @@ func ResolveHermesProfile(customEnvHome, name string, found, inline bool) Hermes
 	if err != nil {
 		return HermesProfileResolution{Err: err}
 	}
-	return HermesProfileResolution{SourceHome: home, MustExist: mustExist}
+	return guardInheritedHermesHome(HermesProfileResolution{SourceHome: home, MustExist: mustExist}, inheritedHome, workspacesRoot)
+}
+
+func guardInheritedHermesHome(res HermesProfileResolution, inherited bool, workspacesRoot string) HermesProfileResolution {
+	if !inherited || res.Err != nil {
+		return res
+	}
+	if _, err := resolveAndGuardProviderConfigPath("hermes", "HERMES_HOME", res.SourceHome, workspacesRoot, hermesSourceHomeProviderConfig); err != nil {
+		res.Err = err
+	}
+	return res
+}
+
+func hermesSourceHomeProviderConfig(home string) error {
+	data, err := os.ReadFile(filepath.Join(home, "config.yaml"))
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return fmt.Errorf("read config.yaml: %w", err)
+	}
+	var doc yaml.Node
+	if err := yaml.Unmarshal(data, &doc); err != nil {
+		return fmt.Errorf("parse config.yaml: %w", err)
+	}
+	if yamlDocumentHasAnyTopLevelKey(&doc, "model", "provider", "providers", "api_key") {
+		return nil
+	}
+	return fmt.Errorf("config.yaml has no model/provider settings")
+}
+
+func yamlDocumentHasAnyTopLevelKey(doc *yaml.Node, keys ...string) bool {
+	if doc == nil || doc.Kind != yaml.DocumentNode || len(doc.Content) == 0 {
+		return false
+	}
+	root := doc.Content[0]
+	if root.Kind != yaml.MappingNode {
+		return false
+	}
+	for i := 0; i+1 < len(root.Content); i += 2 {
+		for _, key := range keys {
+			if root.Content[i].Value == key {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 // hermesRootFromHome reproduces hermes_constants.get_default_hermes_root: the

--- a/server/internal/daemon/execenv/hermes_home.go
+++ b/server/internal/daemon/execenv/hermes_home.go
@@ -252,8 +252,12 @@ func guardInheritedHermesHome(res HermesProfileResolution, inherited bool, works
 	if !inherited || res.Err != nil {
 		return res
 	}
-	if _, err := resolveAndGuardProviderConfigPath("hermes", "HERMES_HOME", res.SourceHome, workspacesRoot, hermesSourceHomeProviderConfig); err != nil {
+	if _, err := resolveAndGuardProviderConfigPath("hermes", "HERMES_HOME", res.SourceHome, workspacesRoot); err != nil {
 		res.Err = err
+		return res
+	}
+	if err := hermesSourceHomeProviderConfig(res.SourceHome); err != nil {
+		res.Err = fmt.Errorf("hermes: inherited HERMES_HOME is not usable (%s): %w", res.SourceHome, err)
 	}
 	return res
 }

--- a/server/internal/daemon/execenv/isolation_unix_test.go
+++ b/server/internal/daemon/execenv/isolation_unix_test.go
@@ -21,6 +21,7 @@ import (
 func TestPrepareIsolated_PermanentFIFOBlockThenImmediateRetry(t *testing.T) {
 	sharedCodexHome := t.TempDir()
 	t.Setenv("CODEX_HOME", sharedCodexHome)
+	writeCodexTestProviderConfig(t, sharedCodexHome, "")
 	fifo := filepath.Join(sharedCodexHome, "config.json")
 	if err := syscall.Mkfifo(fifo, 0o600); err != nil {
 		t.Fatalf("create config FIFO: %v", err)

--- a/server/internal/daemon/execenv/openclaw_config.go
+++ b/server/internal/daemon/execenv/openclaw_config.go
@@ -59,6 +59,9 @@ type OpenclawConfigPrep struct {
 	// OpenclawBin is the openclaw CLI binary to invoke for config introspection.
 	// Empty means resolve "openclaw" from PATH at exec time.
 	OpenclawBin string
+	// WorkspacesRoot is the daemon-owned root for task envs. Active OpenClaw
+	// config paths under it are rejected as inherited per-task pollution.
+	WorkspacesRoot string
 	// Timeout sets the context deadline for each CLI invocation — not a
 	// guaranteed cap on how long the call takes; see openclawCLITimeout. Zero
 	// falls back to openclawCLITimeout.
@@ -209,6 +212,12 @@ func prepareOpenclawConfig(envRoot, workDir string, opts OpenclawConfigPrep) (Op
 	activePath, exists, err := openclawActiveConfigPath(bin, timeout)
 	if err != nil {
 		return OpenclawConfigResult{}, fmt.Errorf("locate openclaw active config: %w", err)
+	}
+	if activePath != "" {
+		activePath, err = resolveAndGuardProviderConfigPath("openclaw", "active config path", activePath, opts.WorkspacesRoot, nil)
+		if err != nil {
+			return OpenclawConfigResult{}, err
+		}
 	}
 
 	var resolvedList []any

--- a/server/internal/daemon/execenv/openclaw_config.go
+++ b/server/internal/daemon/execenv/openclaw_config.go
@@ -214,7 +214,10 @@ func prepareOpenclawConfig(envRoot, workDir string, opts OpenclawConfigPrep) (Op
 		return OpenclawConfigResult{}, fmt.Errorf("locate openclaw active config: %w", err)
 	}
 	if activePath != "" {
-		activePath, err = resolveAndGuardProviderConfigPath("openclaw", "active config path", activePath, opts.WorkspacesRoot, nil)
+		// OpenClaw config usability is checked by its CLI calls below; this
+		// guard only prevents inherited active config paths from selecting
+		// task-scoped state under the daemon workspaces root.
+		activePath, err = resolveAndGuardProviderConfigPath("openclaw", "active config path", activePath, opts.WorkspacesRoot)
 		if err != nil {
 			return OpenclawConfigResult{}, err
 		}

--- a/server/internal/daemon/execenv/openclaw_config_test.go
+++ b/server/internal/daemon/execenv/openclaw_config_test.go
@@ -47,6 +47,11 @@ func installOpenclawStub(t *testing.T, responses map[string]openclawResponse) *o
 	return stub
 }
 
+func openclawTestPrep(t *testing.T, stub *openclawCLIStub) OpenclawConfigPrep {
+	t.Helper()
+	return OpenclawConfigPrep{OpenclawBin: stub.bin, WorkspacesRoot: t.TempDir()}
+}
+
 func (s *openclawCLIStub) exec(_ context.Context, bin string, args ...string) (string, error) {
 	s.calls = append(s.calls, openclawCall{bin: bin, args: append([]string(nil), args...)})
 	key := strings.Join(args, " ")
@@ -116,7 +121,7 @@ func TestPrepareOpenclawConfigDelegatesParsingToCLI(t *testing.T) {
 		]`},
 	})
 
-	result, err := prepareOpenclawConfig(envRoot, workDir, OpenclawConfigPrep{OpenclawBin: stub.bin})
+	result, err := prepareOpenclawConfig(envRoot, workDir, openclawTestPrep(t, stub))
 	if err != nil {
 		t.Fatalf("prepareOpenclawConfig: %v", err)
 	}
@@ -187,7 +192,7 @@ func TestPrepareOpenclawConfigFailsClosedOnCLIError(t *testing.T) {
 		"config file": {err: errors.New("exec: openclaw: no such file or directory")},
 	})
 
-	_, err := prepareOpenclawConfig(envRoot, workDir, OpenclawConfigPrep{OpenclawBin: stub.bin})
+	_, err := prepareOpenclawConfig(envRoot, workDir, openclawTestPrep(t, stub))
 	if err == nil {
 		t.Fatal("prepareOpenclawConfig succeeded on CLI failure; expected fail closed")
 	}
@@ -228,7 +233,7 @@ func TestPrepareOpenclawConfigFallsBackWhenConfigFileUnsupported(t *testing.T) {
 		]`},
 	})
 
-	result, err := prepareOpenclawConfig(envRoot, workDir, OpenclawConfigPrep{OpenclawBin: stub.bin})
+	result, err := prepareOpenclawConfig(envRoot, workDir, openclawTestPrep(t, stub))
 	if err != nil {
 		t.Fatalf("prepareOpenclawConfig: %v", err)
 	}
@@ -496,7 +501,7 @@ func TestPrepareOpenclawConfigFailsClosedOnMalformedAgentsList(t *testing.T) {
 		"config get agents.list --json": {stdout: "<<<garbage>>>"},
 	})
 
-	_, err := prepareOpenclawConfig(envRoot, workDir, OpenclawConfigPrep{OpenclawBin: stub.bin})
+	_, err := prepareOpenclawConfig(envRoot, workDir, openclawTestPrep(t, stub))
 	if err == nil {
 		t.Fatal("prepareOpenclawConfig succeeded on malformed agents.list output; expected fail closed")
 	}
@@ -531,7 +536,7 @@ func TestPrepareOpenclawConfigKeyMissingTreatedAsEmpty(t *testing.T) {
 		"agents list --json": {stdout: "null"},
 	})
 
-	result, err := prepareOpenclawConfig(envRoot, workDir, OpenclawConfigPrep{OpenclawBin: stub.bin})
+	result, err := prepareOpenclawConfig(envRoot, workDir, openclawTestPrep(t, stub))
 	if err != nil {
 		t.Fatalf("prepareOpenclawConfig: %v", err)
 	}
@@ -565,7 +570,7 @@ func TestPrepareOpenclawConfigFreshInstallNoOnDiskConfig(t *testing.T) {
 		// the stub will fail "unexpected args" if it is.
 	})
 
-	result, err := prepareOpenclawConfig(envRoot, workDir, OpenclawConfigPrep{OpenclawBin: stub.bin})
+	result, err := prepareOpenclawConfig(envRoot, workDir, openclawTestPrep(t, stub))
 	if err != nil {
 		t.Fatalf("prepareOpenclawConfig: %v", err)
 	}
@@ -610,7 +615,7 @@ func TestPrepareOpenclawConfigExpandsTilde(t *testing.T) {
 		"config get agents.list --json": {stdout: "null"},
 	})
 
-	result, err := prepareOpenclawConfig(envRoot, workDir, OpenclawConfigPrep{OpenclawBin: stub.bin})
+	result, err := prepareOpenclawConfig(envRoot, workDir, openclawTestPrep(t, stub))
 	if err != nil {
 		t.Fatalf("prepareOpenclawConfig: %v", err)
 	}
@@ -670,7 +675,7 @@ func TestPrepareOpenclawConfigParsesPathFromUITerminalOutput(t *testing.T) {
 		"config get agents.list --json": {stdout: "null"},
 	})
 
-	result, err := prepareOpenclawConfig(envRoot, workDir, OpenclawConfigPrep{OpenclawBin: stub.bin})
+	result, err := prepareOpenclawConfig(envRoot, workDir, openclawTestPrep(t, stub))
 	if err != nil {
 		t.Fatalf("prepareOpenclawConfig: %v", err)
 	}
@@ -722,7 +727,7 @@ func TestPrepareOpenclawConfigWrapperLoadableUnderIncludeConfinement(t *testing.
 		"config get agents.list --json": {stdout: "null"},
 	})
 
-	result, err := prepareOpenclawConfig(envRoot, workDir, OpenclawConfigPrep{OpenclawBin: stub.bin})
+	result, err := prepareOpenclawConfig(envRoot, workDir, openclawTestPrep(t, stub))
 	if err != nil {
 		t.Fatalf("prepareOpenclawConfig: %v", err)
 	}
@@ -803,8 +808,9 @@ func TestPrepareOpenclawConfigStrictReplacesUserMcpServers(t *testing.T) {
 	}`)
 
 	result, err := prepareOpenclawConfig(envRoot, workDir, OpenclawConfigPrep{
-		OpenclawBin: stub.bin,
-		McpConfig:   mcpConfig,
+		OpenclawBin:    stub.bin,
+		WorkspacesRoot: t.TempDir(),
+		McpConfig:      mcpConfig,
 	})
 	if err != nil {
 		t.Fatalf("prepareOpenclawConfig: %v", err)
@@ -906,8 +912,9 @@ func TestPrepareOpenclawConfigStrictPreservesNonServerMcpKeys(t *testing.T) {
 	mcpConfig := json.RawMessage(`{"mcpServers": {"managed_only": {"command": "uvx", "args": ["m"]}}}`)
 
 	result, err := prepareOpenclawConfig(envRoot, workDir, OpenclawConfigPrep{
-		OpenclawBin: stub.bin,
-		McpConfig:   mcpConfig,
+		OpenclawBin:    stub.bin,
+		WorkspacesRoot: t.TempDir(),
+		McpConfig:      mcpConfig,
 	})
 	if err != nil {
 		t.Fatalf("prepareOpenclawConfig: %v", err)
@@ -969,8 +976,9 @@ func TestPrepareOpenclawConfigStrictEmptyManagedSetDropsUserMcp(t *testing.T) {
 				"config get agents.list --json": {stdout: "null"},
 			})
 			result, err := prepareOpenclawConfig(envRoot, workDir, OpenclawConfigPrep{
-				OpenclawBin: stub.bin,
-				McpConfig:   raw,
+				OpenclawBin:    stub.bin,
+				WorkspacesRoot: t.TempDir(),
+				McpConfig:      raw,
 			})
 			if err != nil {
 				t.Fatalf("prepareOpenclawConfig: %v", err)
@@ -1030,8 +1038,9 @@ func TestPrepareOpenclawConfigNullMcpConfigKeepsUserInclude(t *testing.T) {
 				// not call it (would burn an extra CLI roundtrip per task).
 			})
 			result, err := prepareOpenclawConfig(envRoot, workDir, OpenclawConfigPrep{
-				OpenclawBin: stub.bin,
-				McpConfig:   raw,
+				OpenclawBin:    stub.bin,
+				WorkspacesRoot: t.TempDir(),
+				McpConfig:      raw,
 			})
 			if err != nil {
 				t.Fatalf("prepareOpenclawConfig: %v", err)
@@ -1072,8 +1081,9 @@ func TestPrepareOpenclawConfigManagedSetFreshInstall(t *testing.T) {
 	mcpConfig := json.RawMessage(`{"mcpServers": {"context7": {"command": "uvx", "args": ["context7-mcp"]}}}`)
 
 	result, err := prepareOpenclawConfig(envRoot, workDir, OpenclawConfigPrep{
-		OpenclawBin: stub.bin,
-		McpConfig:   mcpConfig,
+		OpenclawBin:    stub.bin,
+		WorkspacesRoot: t.TempDir(),
+		McpConfig:      mcpConfig,
 	})
 	if err != nil {
 		t.Fatalf("prepareOpenclawConfig: %v", err)
@@ -1123,8 +1133,9 @@ func TestPrepareOpenclawConfigFailsClosedOnResolvedConfigError(t *testing.T) {
 	mcpConfig := json.RawMessage(`{"mcpServers": {"context7": {"command": "uvx"}}}`)
 
 	_, err := prepareOpenclawConfig(envRoot, workDir, OpenclawConfigPrep{
-		OpenclawBin: stub.bin,
-		McpConfig:   mcpConfig,
+		OpenclawBin:    stub.bin,
+		WorkspacesRoot: t.TempDir(),
+		McpConfig:      mcpConfig,
 	})
 	if err == nil {
 		t.Fatal("prepareOpenclawConfig succeeded when `config get --json` errored; expected fail closed")
@@ -1169,8 +1180,9 @@ func TestPrepareOpenclawConfigFailsClosedOnMalformedMcpConfig(t *testing.T) {
 				"config get agents.list --json": {stdout: "null"},
 			})
 			_, err := prepareOpenclawConfig(envRoot, workDir, OpenclawConfigPrep{
-				OpenclawBin: stub.bin,
-				McpConfig:   raw,
+				OpenclawBin:    stub.bin,
+				WorkspacesRoot: t.TempDir(),
+				McpConfig:      raw,
 			})
 			if err == nil {
 				t.Fatalf("prepareOpenclawConfig succeeded on %s; expected fail closed", name)
@@ -1210,7 +1222,7 @@ func TestPrepareOpenclawSkillWriteMatchesScanPath(t *testing.T) {
 		{Name: "Local Dev", Content: "Spin up the local dev env."},
 	}
 
-	result, err := prepareOpenclawConfig(envRoot, workDir, OpenclawConfigPrep{OpenclawBin: stub.bin})
+	result, err := prepareOpenclawConfig(envRoot, workDir, openclawTestPrep(t, stub))
 	if err != nil {
 		t.Fatalf("prepareOpenclawConfig: %v", err)
 	}
@@ -1530,7 +1542,7 @@ func TestPrepareOpenclawConfigNewSchemaOmitsAgentsList(t *testing.T) {
 		"agents list --json": {stdout: registry},
 	})
 
-	result, err := prepareOpenclawConfig(envRoot, workDir, OpenclawConfigPrep{OpenclawBin: stub.bin})
+	result, err := prepareOpenclawConfig(envRoot, workDir, openclawTestPrep(t, stub))
 	if err != nil {
 		t.Fatalf("prepareOpenclawConfig: %v", err)
 	}
@@ -1564,7 +1576,7 @@ func TestPrepareOpenclawConfigNewSchemaEmptyRegistry(t *testing.T) {
 		"agents list --json":            {stdout: "[]"},
 	})
 
-	result, err := prepareOpenclawConfig(envRoot, workDir, OpenclawConfigPrep{OpenclawBin: stub.bin})
+	result, err := prepareOpenclawConfig(envRoot, workDir, openclawTestPrep(t, stub))
 	if err != nil {
 		t.Fatalf("prepareOpenclawConfig: %v", err)
 	}

--- a/server/internal/daemon/execenv/provider_config_guard.go
+++ b/server/internal/daemon/execenv/provider_config_guard.go
@@ -2,13 +2,12 @@ package execenv
 
 import (
 	"fmt"
+	"os"
 	"path/filepath"
 	"strings"
 )
 
-type providerConfigCheck func(path string) error
-
-func resolveAndGuardProviderConfigPath(provider, source, rawPath, workspacesRoot string, check providerConfigCheck) (string, error) {
+func resolveAndGuardProviderConfigPath(provider, source, rawPath, workspacesRoot string) (string, error) {
 	path := strings.TrimSpace(rawPath)
 	if path == "" {
 		return "", fmt.Errorf("%s: %s is empty", provider, source)
@@ -17,29 +16,47 @@ func resolveAndGuardProviderConfigPath(provider, source, rawPath, workspacesRoot
 	if err != nil {
 		return "", fmt.Errorf("%s: resolve %s: %w", provider, source, err)
 	}
-	if pathIsUnder(abs, workspacesRoot) {
-		return "", fmt.Errorf("%s: inherited %s points inside Multica workspaces root (%s); refusing task-scoped provider state as shared config", provider, source, abs)
+	under, err := pathIsUnder(abs, workspacesRoot)
+	if err != nil {
+		return "", fmt.Errorf("%s: guard %s: %w", provider, source, err)
 	}
-	if check != nil {
-		if err := check(abs); err != nil {
-			return "", fmt.Errorf("%s: inherited %s is not usable (%s): %w", provider, source, abs, err)
-		}
+	if under {
+		return "", fmt.Errorf("%s: inherited %s points inside Multica workspaces root (%s); refusing task-scoped provider state as shared config", provider, source, abs)
 	}
 	return abs, nil
 }
 
-func pathIsUnder(path, root string) bool {
+func pathIsUnder(path, root string) (bool, error) {
 	root = strings.TrimSpace(root)
 	if root == "" {
-		return false
+		return false, fmt.Errorf("workspaces root is empty")
 	}
 	absRoot, err := filepath.Abs(root)
 	if err != nil {
-		return false
+		return false, fmt.Errorf("resolve workspaces root: %w", err)
 	}
-	rel, err := filepath.Rel(absRoot, path)
+	resolvedRoot := filepath.Clean(resolvePathBestEffort(absRoot))
+	resolvedPath := filepath.Clean(resolvePathBestEffort(path))
+	if isPathUnder(resolvedRoot, resolvedPath) {
+		return true, nil
+	}
+	return pathHasSameFileAncestor(path, absRoot) || pathHasSameFileAncestor(resolvedPath, resolvedRoot), nil
+}
+
+func pathHasSameFileAncestor(path, root string) bool {
+	rootInfo, err := os.Stat(root)
 	if err != nil {
 		return false
 	}
-	return rel == "." || (rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator)))
+	dir := path
+	for {
+		if info, err := os.Stat(dir); err == nil && os.SameFile(info, rootInfo) {
+			return true
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			return false
+		}
+		dir = parent
+	}
 }

--- a/server/internal/daemon/execenv/provider_config_guard.go
+++ b/server/internal/daemon/execenv/provider_config_guard.go
@@ -1,0 +1,45 @@
+package execenv
+
+import (
+	"fmt"
+	"path/filepath"
+	"strings"
+)
+
+type providerConfigCheck func(path string) error
+
+func resolveAndGuardProviderConfigPath(provider, source, rawPath, workspacesRoot string, check providerConfigCheck) (string, error) {
+	path := strings.TrimSpace(rawPath)
+	if path == "" {
+		return "", fmt.Errorf("%s: %s is empty", provider, source)
+	}
+	abs, err := filepath.Abs(path)
+	if err != nil {
+		return "", fmt.Errorf("%s: resolve %s: %w", provider, source, err)
+	}
+	if pathIsUnder(abs, workspacesRoot) {
+		return "", fmt.Errorf("%s: inherited %s points inside Multica workspaces root (%s); refusing task-scoped provider state as shared config", provider, source, abs)
+	}
+	if check != nil {
+		if err := check(abs); err != nil {
+			return "", fmt.Errorf("%s: inherited %s is not usable (%s): %w", provider, source, abs, err)
+		}
+	}
+	return abs, nil
+}
+
+func pathIsUnder(path, root string) bool {
+	root = strings.TrimSpace(root)
+	if root == "" {
+		return false
+	}
+	absRoot, err := filepath.Abs(root)
+	if err != nil {
+		return false
+	}
+	rel, err := filepath.Rel(absRoot, path)
+	if err != nil {
+		return false
+	}
+	return rel == "." || (rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator)))
+}

--- a/server/internal/daemon/execenv/provider_config_guard_test.go
+++ b/server/internal/daemon/execenv/provider_config_guard_test.go
@@ -172,70 +172,87 @@ func TestHermesExplicitHomeBypassesInheritedGuard(t *testing.T) {
 	}
 }
 
-func TestCodexInheritedHomeWithProviderlessConfigFailsClosed(t *testing.T) {
+func TestCodexInheritedProviderlessHomeCanUseNativeDefaultProvider(t *testing.T) {
 	sharedHome := t.TempDir()
 	mustWrite(t, filepath.Join(sharedHome, "config.toml"), "model = \"gpt-5-codex\"\napproval_policy = \"never\"\n")
 	t.Setenv("CODEX_HOME", sharedHome)
+	t.Setenv("OPENAI_API_KEY", "test-key")
 
-	_, err := Prepare(PrepareParams{
+	env, err := Prepare(PrepareParams{
 		WorkspacesRoot: t.TempDir(),
 		WorkspaceID:    "ws-providerless-codex",
 		TaskID:         "11111111-2222-3333-4444-555555555555",
 		Provider:       "codex",
 		Task:           TaskContextForEnv{IssueID: "providerless-codex"},
 	}, slog.New(slog.NewTextHandler(io.Discard, nil)))
-	if err == nil {
-		t.Fatal("Prepare succeeded with providerless inherited CODEX_HOME; expected fail closed")
+	if err != nil {
+		t.Fatalf("Prepare failed for providerless inherited CODEX_HOME that can use Codex's native default provider: %v", err)
 	}
-	if !strings.Contains(err.Error(), "model_provider") {
-		t.Fatalf("error = %v, want model_provider detail", err)
+	defer env.Cleanup(true)
+	if env.CodexHome == "" {
+		t.Fatal("Prepare did not set CodexHome")
 	}
 }
 
-func TestCodexDefaultHomeWithProviderlessConfigFailsClosed(t *testing.T) {
+func TestCodexDefaultProviderlessHomeCanUseNativeDefaultProvider(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("CODEX_HOME", "")
 	t.Setenv("HOME", home)
 	t.Setenv("USERPROFILE", home)
+	t.Setenv("OPENAI_API_KEY", "test-key")
 	mustWrite(t, filepath.Join(home, ".codex", "config.toml"), "model = \"gpt-5-codex\"\napproval_policy = \"never\"\n")
 
-	_, err := Prepare(PrepareParams{
+	env, err := Prepare(PrepareParams{
 		WorkspacesRoot: t.TempDir(),
 		WorkspaceID:    "ws-default-providerless-codex",
 		TaskID:         "21111111-2222-3333-4444-555555555555",
 		Provider:       "codex",
 		Task:           TaskContextForEnv{IssueID: "default-providerless-codex"},
 	}, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	if err != nil {
+		t.Fatalf("Prepare failed for providerless default ~/.codex that can use Codex's native default provider: %v", err)
+	}
+	defer env.Cleanup(true)
+	if env.CodexHome == "" {
+		t.Fatal("Prepare did not set CodexHome")
+	}
+}
+
+func TestCodexProviderModelProviderLostDuringSeedingFailsClosed(t *testing.T) {
+	sharedHome := t.TempDir()
+	codexHome := t.TempDir()
+	writeCodexTestProviderConfig(t, sharedHome, "")
+	mustWrite(t, filepath.Join(codexHome, "config.toml"), "model = \"gpt-5-codex\"\napproval_policy = \"never\"\n")
+
+	err := ensureCodexProviderSeedingPreserved(codexHome, sharedHome, slog.New(slog.NewTextHandler(io.Discard, nil)))
 	if err == nil {
-		t.Fatal("Prepare succeeded with providerless default ~/.codex; expected fail closed")
+		t.Fatal("provider seeding check succeeded after model_provider was lost; expected fail closed")
 	}
 	if !strings.Contains(err.Error(), "model_provider") {
 		t.Fatalf("error = %v, want model_provider detail", err)
 	}
 }
 
-func TestHermesInheritedHomeProviderlessConfigFailsClosed(t *testing.T) {
+func TestHermesInheritedProviderlessHomeCanUseNativeDefaults(t *testing.T) {
 	sharedHome := t.TempDir()
 	workspacesRoot := t.TempDir()
 	mustWrite(t, filepath.Join(sharedHome, "config.yaml"), "skills: {}\n")
 	t.Setenv("HERMES_HOME", sharedHome)
 
 	res := ResolveHermesProfileWithWorkspacesRoot("", "", false, false, workspacesRoot)
-	if res.Err == nil {
-		t.Fatal("ResolveHermesProfile succeeded with providerless inherited HERMES_HOME; expected fail closed")
+	if res.Err != nil {
+		t.Fatalf("ResolveHermesProfile failed for providerless inherited HERMES_HOME that can use Hermes defaults: %v", res.Err)
 	}
-	if !strings.Contains(res.Err.Error(), "model/provider") {
-		t.Fatalf("error = %v, want model/provider detail", res.Err)
-	}
-	if strings.Contains(res.Err.Error(), "workspaces root") {
-		t.Fatalf("error = %v, hermes provider check test should not be satisfied by containment", res.Err)
+	if res.SourceHome != sharedHome {
+		t.Fatalf("SourceHome = %q, want %q", res.SourceHome, sharedHome)
 	}
 }
 
-func TestReuseCodexProviderConfigFailureForcesFreshPrepare(t *testing.T) {
+func TestReuseCodexProviderlessConfigCanUseNativeDefaultProvider(t *testing.T) {
 	sharedHome := t.TempDir()
 	writeCodexTestProviderConfig(t, sharedHome, "")
 	t.Setenv("CODEX_HOME", sharedHome)
+	t.Setenv("OPENAI_API_KEY", "test-key")
 	workspacesRoot := t.TempDir()
 
 	env, err := Prepare(PrepareParams{
@@ -258,7 +275,7 @@ func TestReuseCodexProviderConfigFailureForcesFreshPrepare(t *testing.T) {
 		Provider:       "codex",
 		Task:           TaskContextForEnv{IssueID: "reuse-provider-fail"},
 	}, slog.New(slog.NewTextHandler(io.Discard, nil)))
-	if reused != nil {
-		t.Fatal("Reuse succeeded with unusable codex provider config; expected nil to force fresh Prepare")
+	if reused == nil {
+		t.Fatal("Reuse returned nil for providerless Codex config that can use Codex's native default provider")
 	}
 }

--- a/server/internal/daemon/execenv/provider_config_guard_test.go
+++ b/server/internal/daemon/execenv/provider_config_guard_test.go
@@ -67,6 +67,98 @@ func TestInheritedProviderEnvUnderWorkspacesRootFailsClosed(t *testing.T) {
 	})
 }
 
+func TestInheritedProviderPathGuardHandlesNonLexicalWorkspacePaths(t *testing.T) {
+	t.Run("empty root fails closed", func(t *testing.T) {
+		sharedHome := t.TempDir()
+		t.Setenv("CODEX_HOME", sharedHome)
+
+		_, err := resolveSharedCodexHome("")
+		if err == nil {
+			t.Fatal("resolveSharedCodexHome succeeded with empty workspaces root; expected fail closed")
+		}
+		if !strings.Contains(err.Error(), "workspaces root is empty") {
+			t.Fatalf("error = %v, want empty root detail", err)
+		}
+	})
+
+	t.Run("symlink into workspaces root fails closed", func(t *testing.T) {
+		workspacesRoot := t.TempDir()
+		dirtyHome := filepath.Join(workspacesRoot, "ws", "task", codexHomeDirName)
+		mustWrite(t, filepath.Join(dirtyHome, "config.toml"), "sandbox_mode = \"danger-full-access\"\n")
+		link := filepath.Join(t.TempDir(), "codex-link")
+		if err := os.Symlink(dirtyHome, link); err != nil {
+			t.Skipf("symlink unavailable: %v", err)
+		}
+		t.Setenv("CODEX_HOME", link)
+
+		_, err := resolveSharedCodexHome(workspacesRoot)
+		if err == nil {
+			t.Fatal("resolveSharedCodexHome succeeded through symlink into workspaces root; expected fail closed")
+		}
+		if !strings.Contains(err.Error(), "workspaces root") {
+			t.Fatalf("error = %v, want workspaces root detail", err)
+		}
+	})
+
+	t.Run("case-insensitive spelling fails closed", func(t *testing.T) {
+		workspacesRoot := t.TempDir()
+		dirtyHome := filepath.Join(workspacesRoot, "ws", "task", codexHomeDirName)
+		mustWrite(t, filepath.Join(dirtyHome, "config.toml"), "sandbox_mode = \"danger-full-access\"\n")
+		upperHome := strings.ToUpper(dirtyHome)
+		if upperHome == dirtyHome {
+			t.Skip("path has no lowercase bytes to exercise case folding")
+		}
+		gotInfo, err := os.Stat(upperHome)
+		if err != nil {
+			t.Skipf("filesystem is case-sensitive for %s: %v", upperHome, err)
+		}
+		wantInfo, err := os.Stat(dirtyHome)
+		if err != nil {
+			t.Fatalf("stat dirty home: %v", err)
+		}
+		if !os.SameFile(gotInfo, wantInfo) {
+			t.Skip("uppercase spelling does not resolve to the same file")
+		}
+		t.Setenv("CODEX_HOME", upperHome)
+
+		_, err = resolveSharedCodexHome(workspacesRoot)
+		if err == nil {
+			t.Fatal("resolveSharedCodexHome succeeded with case-only path variant; expected fail closed")
+		}
+		if !strings.Contains(err.Error(), "workspaces root") {
+			t.Fatalf("error = %v, want workspaces root detail", err)
+		}
+	})
+
+	t.Run("relative path from cwd fails closed", func(t *testing.T) {
+		cwd := t.TempDir()
+		workspacesRoot := filepath.Join(cwd, "root")
+		dirtyHome := filepath.Join(workspacesRoot, "ws", "task", codexHomeDirName)
+		mustWrite(t, filepath.Join(dirtyHome, "config.toml"), "sandbox_mode = \"danger-full-access\"\n")
+		rel, err := filepath.Rel(cwd, dirtyHome)
+		if err != nil {
+			t.Fatalf("rel: %v", err)
+		}
+		oldwd, err := os.Getwd()
+		if err != nil {
+			t.Fatalf("getwd: %v", err)
+		}
+		if err := os.Chdir(cwd); err != nil {
+			t.Fatalf("chdir: %v", err)
+		}
+		t.Cleanup(func() { _ = os.Chdir(oldwd) })
+		t.Setenv("CODEX_HOME", rel)
+
+		_, err = resolveSharedCodexHome(workspacesRoot)
+		if err == nil {
+			t.Fatal("resolveSharedCodexHome succeeded with relative path into workspaces root; expected fail closed")
+		}
+		if !strings.Contains(err.Error(), "workspaces root") {
+			t.Fatalf("error = %v, want workspaces root detail", err)
+		}
+	})
+}
+
 func TestHermesExplicitHomeBypassesInheritedGuard(t *testing.T) {
 	workspacesRoot := t.TempDir()
 	explicitTaskHome := filepath.Join(workspacesRoot, "ws", "task", "hermes-home")
@@ -82,7 +174,7 @@ func TestHermesExplicitHomeBypassesInheritedGuard(t *testing.T) {
 
 func TestCodexInheritedHomeWithProviderlessConfigFailsClosed(t *testing.T) {
 	sharedHome := t.TempDir()
-	mustWrite(t, filepath.Join(sharedHome, "config.toml"), "# only daemon-managed defaults\nsandbox_mode = \"danger-full-access\"\n")
+	mustWrite(t, filepath.Join(sharedHome, "config.toml"), "model = \"gpt-5-codex\"\napproval_policy = \"never\"\n")
 	t.Setenv("CODEX_HOME", sharedHome)
 
 	_, err := Prepare(PrepareParams{
@@ -95,7 +187,78 @@ func TestCodexInheritedHomeWithProviderlessConfigFailsClosed(t *testing.T) {
 	if err == nil {
 		t.Fatal("Prepare succeeded with providerless inherited CODEX_HOME; expected fail closed")
 	}
-	if !strings.Contains(err.Error(), "provider/config") {
-		t.Fatalf("error = %v, want provider/config detail", err)
+	if !strings.Contains(err.Error(), "model_provider") {
+		t.Fatalf("error = %v, want model_provider detail", err)
+	}
+}
+
+func TestCodexDefaultHomeWithProviderlessConfigFailsClosed(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("CODEX_HOME", "")
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	mustWrite(t, filepath.Join(home, ".codex", "config.toml"), "model = \"gpt-5-codex\"\napproval_policy = \"never\"\n")
+
+	_, err := Prepare(PrepareParams{
+		WorkspacesRoot: t.TempDir(),
+		WorkspaceID:    "ws-default-providerless-codex",
+		TaskID:         "21111111-2222-3333-4444-555555555555",
+		Provider:       "codex",
+		Task:           TaskContextForEnv{IssueID: "default-providerless-codex"},
+	}, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	if err == nil {
+		t.Fatal("Prepare succeeded with providerless default ~/.codex; expected fail closed")
+	}
+	if !strings.Contains(err.Error(), "model_provider") {
+		t.Fatalf("error = %v, want model_provider detail", err)
+	}
+}
+
+func TestHermesInheritedHomeProviderlessConfigFailsClosed(t *testing.T) {
+	sharedHome := t.TempDir()
+	workspacesRoot := t.TempDir()
+	mustWrite(t, filepath.Join(sharedHome, "config.yaml"), "skills: {}\n")
+	t.Setenv("HERMES_HOME", sharedHome)
+
+	res := ResolveHermesProfileWithWorkspacesRoot("", "", false, false, workspacesRoot)
+	if res.Err == nil {
+		t.Fatal("ResolveHermesProfile succeeded with providerless inherited HERMES_HOME; expected fail closed")
+	}
+	if !strings.Contains(res.Err.Error(), "model/provider") {
+		t.Fatalf("error = %v, want model/provider detail", res.Err)
+	}
+	if strings.Contains(res.Err.Error(), "workspaces root") {
+		t.Fatalf("error = %v, hermes provider check test should not be satisfied by containment", res.Err)
+	}
+}
+
+func TestReuseCodexProviderConfigFailureForcesFreshPrepare(t *testing.T) {
+	sharedHome := t.TempDir()
+	writeCodexTestProviderConfig(t, sharedHome, "")
+	t.Setenv("CODEX_HOME", sharedHome)
+	workspacesRoot := t.TempDir()
+
+	env, err := Prepare(PrepareParams{
+		WorkspacesRoot: workspacesRoot,
+		WorkspaceID:    "ws-codex-reuse-provider-fail",
+		TaskID:         "31111111-2222-3333-4444-555555555555",
+		Provider:       "codex",
+		Task:           TaskContextForEnv{IssueID: "reuse-provider-fail"},
+	}, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	if err != nil {
+		t.Fatalf("Prepare failed: %v", err)
+	}
+	defer env.Cleanup(true)
+
+	mustWrite(t, filepath.Join(sharedHome, "config.toml"), "model = \"gpt-5-codex\"\napproval_policy = \"never\"\n")
+
+	reused := Reuse(ReuseParams{
+		WorkspacesRoot: workspacesRoot,
+		WorkDir:        env.WorkDir,
+		Provider:       "codex",
+		Task:           TaskContextForEnv{IssueID: "reuse-provider-fail"},
+	}, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	if reused != nil {
+		t.Fatal("Reuse succeeded with unusable codex provider config; expected nil to force fresh Prepare")
 	}
 }

--- a/server/internal/daemon/execenv/provider_config_guard_test.go
+++ b/server/internal/daemon/execenv/provider_config_guard_test.go
@@ -1,0 +1,101 @@
+package execenv
+
+import (
+	"io"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestInheritedProviderEnvUnderWorkspacesRootFailsClosed(t *testing.T) {
+	workspacesRoot := t.TempDir()
+
+	t.Run("codex", func(t *testing.T) {
+		dirtyHome := filepath.Join(workspacesRoot, "ws", "task", codexHomeDirName)
+		mustWrite(t, filepath.Join(dirtyHome, "config.toml"), "sandbox_mode = \"danger-full-access\"\n")
+		t.Setenv("CODEX_HOME", dirtyHome)
+
+		_, err := resolveSharedCodexHome(workspacesRoot)
+		if err == nil {
+			t.Fatal("resolveSharedCodexHome succeeded with inherited per-task CODEX_HOME; expected fail closed")
+		}
+		if !strings.Contains(err.Error(), "CODEX_HOME") || !strings.Contains(err.Error(), "workspaces root") {
+			t.Fatalf("error = %v, want CODEX_HOME/workspaces root detail", err)
+		}
+	})
+
+	t.Run("hermes", func(t *testing.T) {
+		dirtyHome := filepath.Join(workspacesRoot, "ws", "task", "hermes-home")
+		mustWrite(t, filepath.Join(dirtyHome, "config.yaml"), "skills: {}\n")
+		t.Setenv("HERMES_HOME", dirtyHome)
+
+		res := ResolveHermesProfileWithWorkspacesRoot("", "", false, false, workspacesRoot)
+		if res.Err == nil {
+			t.Fatal("ResolveHermesProfile succeeded with inherited per-task HERMES_HOME; expected fail closed")
+		}
+		if !strings.Contains(res.Err.Error(), "HERMES_HOME") || !strings.Contains(res.Err.Error(), "workspaces root") {
+			t.Fatalf("error = %v, want HERMES_HOME/workspaces root detail", res.Err)
+		}
+	})
+
+	t.Run("openclaw", func(t *testing.T) {
+		envRoot := t.TempDir()
+		workDir := filepath.Join(envRoot, "workdir")
+		if err := os.MkdirAll(workDir, 0o755); err != nil {
+			t.Fatalf("mkdir workdir: %v", err)
+		}
+		dirtyConfig := filepath.Join(workspacesRoot, "ws", "task", "openclaw-config.json")
+		stub := installOpenclawStub(t, map[string]openclawResponse{
+			"config file": {stdout: dirtyConfig},
+		})
+
+		_, err := prepareOpenclawConfig(envRoot, workDir, OpenclawConfigPrep{
+			OpenclawBin:    stub.bin,
+			WorkspacesRoot: workspacesRoot,
+		})
+		if err == nil {
+			t.Fatal("prepareOpenclawConfig succeeded with inherited per-task active config; expected fail closed")
+		}
+		if !strings.Contains(err.Error(), "openclaw") || !strings.Contains(err.Error(), "workspaces root") {
+			t.Fatalf("error = %v, want openclaw/workspaces root detail", err)
+		}
+		if _, statErr := os.Stat(filepath.Join(envRoot, openclawConfigFile)); !os.IsNotExist(statErr) {
+			t.Fatalf("wrapper config should not be written after fail-fast, stat err = %v", statErr)
+		}
+	})
+}
+
+func TestHermesExplicitHomeBypassesInheritedGuard(t *testing.T) {
+	workspacesRoot := t.TempDir()
+	explicitTaskHome := filepath.Join(workspacesRoot, "ws", "task", "hermes-home")
+
+	res := ResolveHermesProfileWithWorkspacesRoot(explicitTaskHome, "", false, false, workspacesRoot)
+	if res.Err != nil {
+		t.Fatalf("explicit Hermes home should not be treated as inherited process env: %v", res.Err)
+	}
+	if res.SourceHome != explicitTaskHome {
+		t.Fatalf("SourceHome = %q, want %q", res.SourceHome, explicitTaskHome)
+	}
+}
+
+func TestCodexInheritedHomeWithProviderlessConfigFailsClosed(t *testing.T) {
+	sharedHome := t.TempDir()
+	mustWrite(t, filepath.Join(sharedHome, "config.toml"), "# only daemon-managed defaults\nsandbox_mode = \"danger-full-access\"\n")
+	t.Setenv("CODEX_HOME", sharedHome)
+
+	_, err := Prepare(PrepareParams{
+		WorkspacesRoot: t.TempDir(),
+		WorkspaceID:    "ws-providerless-codex",
+		TaskID:         "11111111-2222-3333-4444-555555555555",
+		Provider:       "codex",
+		Task:           TaskContextForEnv{IssueID: "providerless-codex"},
+	}, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	if err == nil {
+		t.Fatal("Prepare succeeded with providerless inherited CODEX_HOME; expected fail closed")
+	}
+	if !strings.Contains(err.Error(), "provider/config") {
+		t.Fatalf("error = %v, want provider/config detail", err)
+	}
+}

--- a/server/internal/daemon/gc.go
+++ b/server/internal/daemon/gc.go
@@ -104,7 +104,7 @@ func (d *Daemon) runGC(ctx context.Context) {
 	// Reclaim per-issue Codex session stores idle past their TTL. These live
 	// under the shared ~/.codex home (outside WorkspacesRoot) so resume survives
 	// the task GC, which means they need their own bounded lifecycle (MUL-4424).
-	if storesRemoved, storeBytes := execenv.PruneCodexSessionStores(d.cfg.Profile, d.cfg.GCCodexSessionTTL, time.Now(), d.reserveCodexStoreForDeletion, d.logger); storesRemoved > 0 {
+	if storesRemoved, storeBytes := execenv.PruneCodexSessionStores(d.cfg.Profile, d.cfg.WorkspacesRoot, d.cfg.GCCodexSessionTTL, time.Now(), d.reserveCodexStoreForDeletion, d.logger); storesRemoved > 0 {
 		stats.storesReclaimed += storesRemoved
 		stats.bytesReclaimed += storeBytes
 	}

--- a/server/pkg/agent/codex.go
+++ b/server/pkg/agent/codex.go
@@ -21,6 +21,7 @@ import (
 	"time"
 
 	"github.com/multica-ai/multica/server/pkg/redact"
+	"github.com/pelletier/go-toml/v2"
 )
 
 // codexBlockedArgs are flags hardcoded by the daemon that must not be
@@ -748,6 +749,9 @@ func (b *codexBackend) Execute(ctx context.Context, prompt string, opts ExecOpti
 	go func() {
 		defer close(msgCh)
 		defer close(resCh)
+		sendResult := func(result Result) {
+			resCh <- b.annotateCodexProviderlessDefaultFailure(result)
+		}
 		session := firstSession
 		attemptOpts := opts
 		for attempt := 1; attempt <= 2; attempt++ {
@@ -755,7 +759,7 @@ func (b *codexBackend) Execute(ctx context.Context, prompt string, opts ExecOpti
 				var err error
 				session, err = b.executeOnce(ctx, prompt, attemptOpts, attempt)
 				if err != nil {
-					resCh <- Result{Status: "failed", Error: err.Error()}
+					sendResult(Result{Status: "failed", Error: err.Error()})
 					return
 				}
 			}
@@ -788,7 +792,7 @@ func (b *codexBackend) Execute(ctx context.Context, prompt string, opts ExecOpti
 			result, ok := <-session.Result
 			if !ok {
 				flushHeldPins()
-				resCh <- Result{Status: "failed", Error: "codex attempt closed without result"}
+				sendResult(Result{Status: "failed", Error: "codex attempt closed without result"})
 				return
 			}
 			retryReason := ""
@@ -800,7 +804,7 @@ func (b *codexBackend) Execute(ctx context.Context, prompt string, opts ExecOpti
 			}
 			if retryReason == "" || attempt == 2 {
 				flushHeldPins()
-				resCh <- result
+				sendResult(result)
 				return
 			}
 			// The model catalog refresh reaches the network, so give the
@@ -827,7 +831,7 @@ func (b *codexBackend) Execute(ctx context.Context, prompt string, opts ExecOpti
 			select {
 			case <-ctx.Done():
 				flushHeldPins()
-				resCh <- result
+				sendResult(result)
 				return
 			case <-time.After(backoff):
 			}
@@ -835,6 +839,36 @@ func (b *codexBackend) Execute(ctx context.Context, prompt string, opts ExecOpti
 	}()
 
 	return &Session{Messages: msgCh, Result: resCh}, nil
+}
+
+func (b *codexBackend) annotateCodexProviderlessDefaultFailure(result Result) Result {
+	if result.Status == "completed" || strings.TrimSpace(result.Error) == "" {
+		return result
+	}
+	codexHome := strings.TrimSpace(b.cfg.Env["CODEX_HOME"])
+	if codexHome == "" || strings.Contains(result.Error, "Codex config note:") {
+		return result
+	}
+	provider, ok := codexConfigModelProviderForDiagnostic(filepath.Join(codexHome, "config.toml"))
+	if !ok || provider != "" {
+		return result
+	}
+	result.Error += "\n\nCodex config note: CODEX_HOME/config.toml has no model_provider; this task was allowed to use Codex's native default provider/environment credentials."
+	return result
+}
+
+func codexConfigModelProviderForDiagnostic(configPath string) (string, bool) {
+	data, err := os.ReadFile(configPath)
+	if err != nil {
+		return "", false
+	}
+	var cfg struct {
+		ModelProvider string `toml:"model_provider"`
+	}
+	if err := toml.Unmarshal(data, &cfg); err != nil {
+		return "", false
+	}
+	return strings.TrimSpace(cfg.ModelProvider), true
 }
 
 func (b *codexBackend) executeOnce(ctx context.Context, prompt string, opts ExecOptions, attempt int) (*Session, error) {

--- a/server/pkg/agent/codex_test.go
+++ b/server/pkg/agent/codex_test.go
@@ -41,6 +41,24 @@ func newTestCodexClient(t *testing.T) (*codexClient, *fakeStdin, []Message) {
 	return c, fs, messages
 }
 
+func TestCodexProviderlessDefaultFailureAnnotation(t *testing.T) {
+	codexHome := t.TempDir()
+	if err := os.WriteFile(filepath.Join(codexHome, "config.toml"), []byte("model = \"gpt-5-codex\"\n"), 0o644); err != nil {
+		t.Fatalf("write config.toml: %v", err)
+	}
+	backend := &codexBackend{cfg: Config{Env: map[string]string{"CODEX_HOME": codexHome}}}
+
+	result := backend.annotateCodexProviderlessDefaultFailure(Result{Status: "failed", Error: "missing api key"})
+	if !strings.Contains(result.Error, "Codex config note: CODEX_HOME/config.toml has no model_provider") {
+		t.Fatalf("annotated error = %q, want providerless config note", result.Error)
+	}
+
+	completed := backend.annotateCodexProviderlessDefaultFailure(Result{Status: "completed", Error: "ignored"})
+	if strings.Contains(completed.Error, "Codex config note:") {
+		t.Fatalf("completed result should not be annotated: %q", completed.Error)
+	}
+}
+
 type fakeStdin struct {
 	mu   sync.Mutex
 	data []byte


### PR DESCRIPTION
## Summary

- Keeps one shared execenv containment guard for inherited provider config paths: resolve the path, fail closed when `WorkspacesRoot` is empty, and reject paths that resolve under the daemon workspaces root, including symlink, case-only, and `/var` alias variants.
- Splits provider/config content from path containment:
  - Codex now hard-fails only when the shared source had `model_provider` and the generated per-task config lost or changed it during seeding.
  - Codex shared homes without `model_provider` are allowed to use Codex's native default provider/environment credentials; if Codex later fails, the task-visible error includes a config note.
  - Hermes inherited `HERMES_HOME` is guarded for path provenance only; Hermes-native provider/default behavior is left to Hermes.
  - OpenClaw inherited active config paths are guarded for containment only; provider/config usability stays delegated to existing CLI reads.
- Wires containment through current inherited-home/config resolvers:
  - Codex: inherited `CODEX_HOME`, shared home seeding, user skill seeding, and session store prune path resolution.
  - Hermes: process-inherited `HERMES_HOME`; explicit task/custom env home still bypasses the inherited-env guard.
  - OpenClaw: inherited active config path before writing the task wrapper.
- Updates daemon launch docs to scrub only provider home selectors and assert required vars such as `MLAMP_API_KEY` remain present.

## Notes

- GC/prune now depends only on containment, not provider usability; it can still resolve a providerless shared home for cleanup.
- Reuse returns nil only for refresh/prep failures that require a fresh `Prepare`; providerless default Codex config no longer blocks reuse.
- LOOP-771 extra view (a): kept the early WorkspacesRoot containment guard because a task-scoped home under the daemon workspaces root is provably reverse pollution before provider probing.
- LOOP-771 extra view (b): `syncCopiedFile` still reports a missing copied source to the caller; when the source had no `model_provider`, the daemon logs a warning and lets Codex's native default-provider behavior run.
- MUL-5578 / MUL-4424 isolation is preserved: this guards daemon-process inherited resolver inputs. The daemon still explicitly exports per-task `CODEX_HOME`, Hermes overlay `HERMES_HOME`, and per-task `OPENCLAW_CONFIG_PATH` to child tasks after execenv preparation.

## Tests

- `go test ./internal/daemon/execenv -count=1`
- `go test ./pkg/agent -run 'TestCodexProviderlessDefaultFailureAnnotation|TestCodex' -count=1`
- `go test ./internal/daemon/... -count=1`
- `go test ./pkg/agent -count=1`
- `git diff --check`
