### PR TITLE
MUL-5694: confirm the assignment dialog with the send chord

### DIFF
--- a/packages/views/modals/run-confirm.test.tsx
+++ b/packages/views/modals/run-confirm.test.tsx
@@ -1,5 +1,10 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import {
+  configureShortcutPlatform,
+  createShortcutChord,
+  useShortcutStore,
+} from "@multica/core/shortcuts";
 import { RunConfirmModal } from "./run-confirm";
 
 // --- Warm agent / squad / runtime caches (prefetched in the real app) --------
@@ -85,7 +90,10 @@ vi.mock("../i18n", () => ({
 // Keep the ui primitives as light DOM so the logic is what's under test.
 vi.mock("@multica/ui/components/ui/dialog", () => ({
   Dialog: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
-  DialogContent: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  // Keeps the real Popup's prop passthrough, which the send chord binds to.
+  DialogContent: ({ children, ...props }: React.HTMLAttributes<HTMLDivElement>) => (
+    <div data-testid="dialog-content" {...props}>{children}</div>
+  ),
   DialogHeader: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
   DialogFooter: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
   DialogTitle: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
@@ -115,7 +123,20 @@ beforeEach(() => {
   cache.agents = [{ id: "agent-1", runtime_id: "runtime-1" }];
   cache.runtimes = [{ id: "runtime-1", metadata: { cli_version: "0.4.0" } }];
   cache.squads = [{ id: "squad-1", leader_id: "agent-1" }];
+  // The real shortcut store drives both the submit chord and the keycap hint,
+  // and jsdom's platform follows the host OS — pin it so the chord is ⌘+Enter
+  // everywhere, not Ctrl+Enter on a Linux CI runner.
+  configureShortcutPlatform("macos");
+  useShortcutStore.setState({ overrides: {} });
 });
+
+afterEach(() => {
+  configureShortcutPlatform(null);
+  useShortcutStore.setState({ overrides: {} });
+});
+
+const confirmButton = () => screen.getByRole("button", { name: "Confirm assignment" });
+const noteBox = () => screen.getByPlaceholderText("scope...");
 
 const single = {
   issueIds: ["issue-1"],
@@ -129,16 +150,16 @@ describe("RunConfirmModal", () => {
     // The MUL-5010 core: opening the dialog fires nothing and blocks nothing.
     const { container } = render(<RunConfirmModal onClose={vi.fn()} data={single} />);
     expect(screen.queryByTestId("spinner")).not.toBeInTheDocument();
-    expect(screen.getByPlaceholderText("scope...")).not.toBeDisabled();
-    expect(screen.getByText("Confirm assignment")).not.toBeDisabled();
+    expect(noteBox()).not.toBeDisabled();
+    expect(confirmButton()).not.toBeDisabled();
     // Headline reads across elements — the assignee name is bolded in place.
     expect(container.textContent).toContain("assign to Walt");
   });
 
   it("single assign sends the assignee change with the handoff note", async () => {
     render(<RunConfirmModal onClose={vi.fn()} data={single} />);
-    fireEvent.change(screen.getByPlaceholderText("scope..."), { target: { value: "only login" } });
-    fireEvent.click(screen.getByText("Confirm assignment"));
+    fireEvent.change(noteBox(), { target: { value: "only login" } });
+    fireEvent.click(confirmButton());
     await waitFor(() => expect(mockUpdate).toHaveBeenCalledTimes(1));
     expect(mockUpdate).toHaveBeenCalledWith({
       id: "issue-1",
@@ -154,7 +175,7 @@ describe("RunConfirmModal", () => {
     // run surface through the issue's normal updates, so submit adds no toast.
     const onClose = vi.fn();
     render(<RunConfirmModal onClose={onClose} data={single} />);
-    fireEvent.click(screen.getByText("Confirm assignment"));
+    fireEvent.click(confirmButton());
     await waitFor(() => expect(onClose).toHaveBeenCalled());
     expect(mockToast.success).not.toHaveBeenCalled();
     expect(mockToast.error).not.toHaveBeenCalled();
@@ -162,7 +183,7 @@ describe("RunConfirmModal", () => {
 
   it("'暂不开始' sends suppress_run and no handoff note", async () => {
     render(<RunConfirmModal onClose={vi.fn()} data={single} />);
-    fireEvent.change(screen.getByPlaceholderText("scope..."), { target: { value: "ignored" } });
+    fireEvent.change(noteBox(), { target: { value: "ignored" } });
     fireEvent.click(screen.getByText("Don't start yet"));
     await waitFor(() => expect(mockUpdate).toHaveBeenCalledTimes(1));
     const payload = mockUpdate.mock.calls[0]![0];
@@ -174,7 +195,7 @@ describe("RunConfirmModal", () => {
   it("disables the note box when the agent's runtime is too old", () => {
     cache.runtimes = [{ id: "runtime-1", metadata: { cli_version: "0.2.21" } }];
     render(<RunConfirmModal onClose={vi.fn()} data={single} />);
-    expect(screen.getByPlaceholderText("scope...")).toBeDisabled();
+    expect(noteBox()).toBeDisabled();
     expect(screen.getByText("runtime too old")).toBeInTheDocument();
   });
 
@@ -188,7 +209,7 @@ describe("RunConfirmModal", () => {
         data={{ ...single, assigneeType: "squad", assigneeId: "squad-1" }}
       />,
     );
-    expect(screen.getByPlaceholderText("scope...")).toBeDisabled();
+    expect(noteBox()).toBeDisabled();
     expect(screen.getByText("runtime too old")).toBeInTheDocument();
   });
 
@@ -197,7 +218,7 @@ describe("RunConfirmModal", () => {
     // unresolvable target must not produce a spurious warning.
     cache.agents = [];
     render(<RunConfirmModal onClose={vi.fn()} data={single} />);
-    expect(screen.getByPlaceholderText("scope...")).not.toBeDisabled();
+    expect(noteBox()).not.toBeDisabled();
     expect(screen.queryByText("runtime too old")).not.toBeInTheDocument();
   });
 
@@ -206,7 +227,7 @@ describe("RunConfirmModal", () => {
       <RunConfirmModal onClose={vi.fn()} data={{ ...single, issueIds: ["i1", "i2"] }} />,
     );
     expect(container.textContent).toContain("assign 2 to Walt");
-    fireEvent.click(screen.getByText("Confirm assignment"));
+    fireEvent.click(confirmButton());
     await waitFor(() => expect(mockBatch).toHaveBeenCalledTimes(1));
     expect(mockBatch).toHaveBeenCalledWith({
       ids: ["i1", "i2"],
@@ -216,11 +237,82 @@ describe("RunConfirmModal", () => {
     expect(mockToast.success).not.toHaveBeenCalled();
   });
 
+  // --- Send chord (MUL-5694) ------------------------------------------------
+  // The note box is where the caret starts, so the dialog has to submit from
+  // the keyboard there, the same way the issue composer creates.
+
+  it("confirms on the send chord typed in the note box", async () => {
+    const onClose = vi.fn();
+    render(<RunConfirmModal onClose={onClose} data={single} />);
+    fireEvent.change(noteBox(), { target: { value: "only login" } });
+    fireEvent.keyDown(noteBox(), { key: "Enter", metaKey: true });
+    await waitFor(() => expect(mockUpdate).toHaveBeenCalledTimes(1));
+    expect(mockUpdate).toHaveBeenCalledWith({
+      id: "issue-1",
+      assignee_type: "agent",
+      assignee_id: "agent-1",
+      handoff_note: "only login",
+    });
+    await waitFor(() => expect(onClose).toHaveBeenCalled());
+  });
+
+  it("leaves a focused button to its own activation instead of double-writing", () => {
+    // The browser already clicks a focused button on Enter; confirming here as
+    // well would fire two writes — and on "Don't start yet" they would disagree.
+    render(<RunConfirmModal onClose={vi.fn()} data={single} />);
+    fireEvent.keyDown(screen.getByText("Don't start yet"), { key: "Enter", metaKey: true });
+    fireEvent.keyDown(confirmButton(), { key: "Enter", metaKey: true });
+    expect(mockUpdate).not.toHaveBeenCalled();
+  });
+
+  it("still confirms when the note box is disabled by an old runtime", async () => {
+    // The chord is bound on the dialog, not the note box, so the keycap the
+    // confirm button advertises keeps working when the note cannot be typed.
+    cache.runtimes = [{ id: "runtime-1", metadata: { cli_version: "0.2.21" } }];
+    render(<RunConfirmModal onClose={vi.fn()} data={single} />);
+    fireEvent.keyDown(screen.getByTestId("dialog-content"), { key: "Enter", metaKey: true });
+    await waitFor(() => expect(mockUpdate).toHaveBeenCalledTimes(1));
+    expect(mockUpdate.mock.calls[0]![0].handoff_note).toBeUndefined();
+  });
+
+  it("leaves plain Enter alone so the note stays multi-line", () => {
+    render(<RunConfirmModal onClose={vi.fn()} data={single} />);
+    fireEvent.keyDown(noteBox(), { key: "Enter" });
+    expect(mockUpdate).not.toHaveBeenCalled();
+  });
+
+  it("submits once for a held chord, and never for an IME's committing Enter", async () => {
+    render(<RunConfirmModal onClose={vi.fn()} data={single} />);
+    fireEvent.keyDown(noteBox(), { key: "Enter", metaKey: true, isComposing: true });
+    fireEvent.keyDown(noteBox(), { key: "Enter", metaKey: true, repeat: true });
+    expect(mockUpdate).not.toHaveBeenCalled();
+    fireEvent.keyDown(noteBox(), { key: "Enter", metaKey: true });
+    await waitFor(() => expect(mockUpdate).toHaveBeenCalledTimes(1));
+  });
+
+  it("follows a remapped send chord instead of hardcoding ⌘+Enter", async () => {
+    useShortcutStore.setState({ overrides: { send: createShortcutChord("Enter") } });
+    render(<RunConfirmModal onClose={vi.fn()} data={single} />);
+    fireEvent.keyDown(noteBox(), { key: "Enter", metaKey: true });
+    expect(mockUpdate).not.toHaveBeenCalled();
+    fireEvent.keyDown(noteBox(), { key: "Enter" });
+    await waitFor(() => expect(mockUpdate).toHaveBeenCalledTimes(1));
+  });
+
+  it("shows the chord on the confirm button without renaming it", () => {
+    render(<RunConfirmModal onClose={vi.fn()} data={single} />);
+    // Decorative: discoverable next to the label, absent from the a11y name —
+    // `confirmButton()` resolving by that exact name is the assertion.
+    expect(
+      confirmButton().querySelector('[data-slot="shortcut-keycaps"]'),
+    ).toBeInTheDocument();
+  });
+
   it("keeps the dialog open and surfaces the error when the write fails", async () => {
     const onClose = vi.fn();
     mockUpdate.mockRejectedValue(new Error("boom"));
     render(<RunConfirmModal onClose={onClose} data={single} />);
-    fireEvent.click(screen.getByText("Confirm assignment"));
+    fireEvent.click(confirmButton());
     await waitFor(() => expect(mockToast.error).toHaveBeenCalledWith("boom"));
     expect(onClose).not.toHaveBeenCalled();
     expect(mockToast.success).not.toHaveBeenCalled();

--- a/packages/views/modals/run-confirm.test.tsx
+++ b/packages/views/modals/run-confirm.test.tsx
@@ -256,23 +256,28 @@ describe("RunConfirmModal", () => {
     await waitFor(() => expect(onClose).toHaveBeenCalled());
   });
 
-  it("leaves a focused button to its own activation instead of double-writing", () => {
-    // The browser already clicks a focused button on Enter; confirming here as
-    // well would fire two writes — and on "Don't start yet" they would disagree.
-    render(<RunConfirmModal onClose={vi.fn()} data={single} />);
-    fireEvent.keyDown(screen.getByText("Don't start yet"), { key: "Enter", metaKey: true });
-    fireEvent.keyDown(confirmButton(), { key: "Enter", metaKey: true });
-    expect(mockUpdate).not.toHaveBeenCalled();
-  });
-
-  it("still confirms when the note box is disabled by an old runtime", async () => {
-    // The chord is bound on the dialog, not the note box, so the keycap the
-    // confirm button advertises keeps working when the note cannot be typed.
+  it("confirms from a focused footer button, which the chord cannot activate", async () => {
+    // Chromium fires no click for ⌘/Ctrl+Enter on a focused button, so without
+    // the dialog handling it there the chord is simply dead. The dialog focuses
+    // its first tabbable child, so this is where an old runtime leaves the user.
     cache.runtimes = [{ id: "runtime-1", metadata: { cli_version: "0.2.21" } }];
     render(<RunConfirmModal onClose={vi.fn()} data={single} />);
-    fireEvent.keyDown(screen.getByTestId("dialog-content"), { key: "Enter", metaKey: true });
+    fireEvent.keyDown(screen.getByText("Don't start yet"), { key: "Enter", metaKey: true });
     await waitFor(() => expect(mockUpdate).toHaveBeenCalledTimes(1));
-    expect(mockUpdate.mock.calls[0]![0].handoff_note).toBeUndefined();
+    // The primary action, not the button the caret happened to sit on.
+    const payload = mockUpdate.mock.calls[0]![0];
+    expect(payload.suppress_run).toBeUndefined();
+    expect(payload.handoff_note).toBeUndefined();
+  });
+
+  it("yields to a focused button when send is remapped to plain Enter", () => {
+    // A bare Enter DOES activate a focused button, so confirming here as well
+    // would double-write — and on "Don't start yet" the two would disagree.
+    useShortcutStore.setState({ overrides: { send: createShortcutChord("Enter") } });
+    render(<RunConfirmModal onClose={vi.fn()} data={single} />);
+    fireEvent.keyDown(screen.getByText("Don't start yet"), { key: "Enter" });
+    fireEvent.keyDown(confirmButton(), { key: "Enter" });
+    expect(mockUpdate).not.toHaveBeenCalled();
   });
 
   it("leaves plain Enter alone so the note stays multi-line", () => {

--- a/packages/views/modals/run-confirm.tsx
+++ b/packages/views/modals/run-confirm.tsx
@@ -20,7 +20,7 @@ import { useActorName } from "@multica/core/workspace/hooks";
 import { useWorkspaceId } from "@multica/core/hooks";
 import { agentListOptions, squadListOptions } from "@multica/core/workspace/queries";
 import { runtimeListOptions, readRuntimeCliVersion, handoffSupported } from "@multica/core/runtimes";
-import { useShortcut, shortcutMatchesEvent } from "@multica/core/shortcuts";
+import { useShortcut, shortcutMatchesEvent, isPlainShortcut } from "@multica/core/shortcuts";
 import { isImeComposing } from "@multica/core/utils";
 import { ShortcutKeycaps } from "../common/shortcut-keycaps";
 import { useT } from "../i18n";
@@ -172,20 +172,27 @@ export function RunConfirmModal({
    * The configured `send` chord confirms the assignment, the same chord that
    * creates from the issue composer (MUL-5694).
    *
-   * Bound on the dialog rather than on the note box so the keycap the confirm
-   * button advertises does not depend on the note being typable: the chord
-   * still confirms when an old runtime disables the box, or when focus is on
-   * the popup itself. A focused button is the one exception, below.
+   * Bound on the dialog, not on the note box, because the chord means "run the
+   * primary action" no matter which control has focus — and the note box is
+   * not always where focus is. An old runtime disables it, which hands initial
+   * focus to the footer instead, and that is precisely where the keycap on the
+   * confirm button would otherwise be advertising a dead key.
    */
   const onDialogKeyDown = (e: React.KeyboardEvent) => {
     // A held chord submits once, and the Enter that commits an IME
     // composition is the user picking a candidate, never a confirmation.
     if (e.defaultPrevented || e.repeat || isImeComposing(e)) return;
     if (!shortcutMatchesEvent(sendShortcut, e.nativeEvent)) return;
-    // A focused button already activates itself on Enter, so confirming here
-    // too would fire two writes — and on "Don't start yet" they would even
-    // disagree about suppress_run.
-    if (e.target instanceof HTMLElement && e.target.closest("button")) return;
+    // Only a BARE Enter activates a focused button (Chromium fires no click
+    // for ⌘/Ctrl+Enter), so a `send` remapped to plain Enter is the one case
+    // where confirming here too would double-write — and on "Don't start yet"
+    // the two writes would disagree about suppress_run. Every chord form
+    // reaches the footer as a dead key without us, so it must not be skipped.
+    const activatesFocusedButton =
+      isPlainShortcut(sendShortcut, "Enter") &&
+      e.target instanceof HTMLElement &&
+      e.target.closest("button") !== null;
+    if (activatesFocusedButton) return;
     e.preventDefault();
     void submit(false);
   };

--- a/packages/views/modals/run-confirm.tsx
+++ b/packages/views/modals/run-confirm.tsx
@@ -20,6 +20,9 @@ import { useActorName } from "@multica/core/workspace/hooks";
 import { useWorkspaceId } from "@multica/core/hooks";
 import { agentListOptions, squadListOptions } from "@multica/core/workspace/queries";
 import { runtimeListOptions, readRuntimeCliVersion, handoffSupported } from "@multica/core/runtimes";
+import { useShortcut, shortcutMatchesEvent } from "@multica/core/shortcuts";
+import { isImeComposing } from "@multica/core/utils";
+import { ShortcutKeycaps } from "../common/shortcut-keycaps";
 import { useT } from "../i18n";
 
 const MAX_HANDOFF_NOTE = 2000;
@@ -79,6 +82,7 @@ export function RunConfirmModal({
 }) {
   const { t } = useT("modals");
   const { getActorName } = useActorName();
+  const sendShortcut = useShortcut("send");
   const d = (data ?? {}) as RunConfirmData;
   const issueIds = d.issueIds ?? [];
 
@@ -164,6 +168,28 @@ export function RunConfirmModal({
     }
   };
 
+  /**
+   * The configured `send` chord confirms the assignment, the same chord that
+   * creates from the issue composer (MUL-5694).
+   *
+   * Bound on the dialog rather than on the note box so the keycap the confirm
+   * button advertises does not depend on the note being typable: the chord
+   * still confirms when an old runtime disables the box, or when focus is on
+   * the popup itself. A focused button is the one exception, below.
+   */
+  const onDialogKeyDown = (e: React.KeyboardEvent) => {
+    // A held chord submits once, and the Enter that commits an IME
+    // composition is the user picking a candidate, never a confirmation.
+    if (e.defaultPrevented || e.repeat || isImeComposing(e)) return;
+    if (!shortcutMatchesEvent(sendShortcut, e.nativeEvent)) return;
+    // A focused button already activates itself on Enter, so confirming here
+    // too would fire two writes — and on "Don't start yet" they would even
+    // disagree about suppress_run.
+    if (e.target instanceof HTMLElement && e.target.closest("button")) return;
+    e.preventDefault();
+    void submit(false);
+  };
+
   // States the action, not a prediction: the assignment is certain, the run is
   // conditional, so the copy names no run count.
   const headline: ReactNode = boldName(
@@ -179,7 +205,7 @@ export function RunConfirmModal({
 
   return (
     <Dialog open onOpenChange={(v) => { if (!v && !submitting) onClose(); }}>
-      <DialogContent>
+      <DialogContent onKeyDown={onDialogKeyDown}>
         <DialogHeader>
           <DialogTitle>{t(($) => $.run_confirm.title_assign)}</DialogTitle>
           <DialogDescription>{headline}</DialogDescription>
@@ -212,7 +238,24 @@ export function RunConfirmModal({
             {pendingAction === "suppress" ? <Spinner className="size-4" /> : t(($) => $.run_confirm.dont_start)}
           </Button>
           <Button type="button" disabled={submitting} onClick={() => submit(false)}>
-            {pendingAction === "go" ? <Spinner className="size-4" /> : t(($) => $.run_confirm.confirm_assign)}
+            {pendingAction === "go" ? (
+              <Spinner className="size-4" />
+            ) : (
+              <>
+                {t(($) => $.run_confirm.confirm_assign)}
+                {/* Decorative: the accessible name stays "Confirm assignment",
+                    not "Confirm assignment Command Enter". Absent when `send`
+                    is unbound. */}
+                {sendShortcut ? (
+                  <ShortcutKeycaps
+                    shortcut={sendShortcut}
+                    decorative
+                    className="ml-1"
+                    keyClassName="border-background/30 bg-background/15 text-primary-foreground shadow-none"
+                  />
+                ) : null}
+              </>
+            )}
           </Button>
         </DialogFooter>
       </DialogContent>


### PR DESCRIPTION
## Summary

The "Confirm assignment?" dialog could only be completed with the mouse — the handoff note takes the caret when the dialog opens, but no key finished the form.

It now submits on the configured `send` shortcut (⌘+Enter on macOS, Ctrl+Enter elsewhere, and whatever the user remapped it to), matching the issue create modal, and the confirm button shows the keycap so the shortcut is discoverable.

Details:

- The handler is bound on the dialog rather than on the note box, because the chord means "run the primary action" wherever focus is — and the note box is not always where focus is. An old runtime disables it, which hands initial focus to the footer instead.
- A focused button is yielded to **only when `send` is remapped to plain Enter**. Verified in Chromium: a focused `<button>` fires a click for a bare Enter, but only a keydown for ⌘/Ctrl+Enter. So a bare Enter is the single case where confirming here too would double-write — and on "Don't start yet" the two writes would disagree about `suppress_run`. Every chord form reaches the footer as a dead key without the dialog handling it, so it must not be skipped.
- Held chords (`repeat`) and the Enter that commits an IME composition never submit.
- The keycap is decorative, so the button's accessible name stays "Confirm assignment".

## Testing

- `packages/views` — full suite, 301 files / 3492 tests pass. `run-confirm.test.tsx` now has 16 cases, 7 of them covering the shortcut: submit from the note box, submit from a focused footer button (the old-runtime path, asserting the primary action rather than `suppress_run`), yielding to a focused button under a plain-Enter remap, plain Enter left alone under the default binding, held/IME Enter ignored, a remapped chord followed instead of a hardcoded ⌘+Enter, and the decorative keycap.
- The footer-button regression test was checked against the pre-fix guard: it fails there and passes with the fix, so it is not a false positive.
- `pnpm typecheck` and `pnpm lint` pass (lint reports only pre-existing warnings, 0 errors).

MUL-5694
