### PR TITLE
fix(server): remove the last language seeds from the LLM prompts (MUL-5689)

### DIFF
--- a/server/internal/handler/chat_title.go
+++ b/server/internal/handler/chat_title.go
@@ -23,16 +23,23 @@ const chatTitleGenTimeout = 20 * time.Second
 // chatTitleSystemPrompt instructs the model to condense the opening of a
 // conversation into a short, language-matched title. The rules mirror the
 // acceptance criteria in MUL-4295: no quotes, no trailing punctuation, no
-// "标题：" / "Title:" prefix, follow the conversation's language. sanitizeChatTitle
-// re-applies these rules defensively in case the model ignores them.
+// label prefix, follow the conversation's language. sanitizeChatTitle re-applies
+// these rules defensively in case the model ignores them.
+//
+// This text names no language and contains no CJK, deliberately. A prompt that
+// spells out a specific language — even only as a formatting example — reads as
+// permission to answer in it, which is how quick actions ended up emitting
+// Chinese pills for English conversations (MUL-5689). The label prefixes this
+// used to enumerate are still stripped for real by chatTitleLabelPrefixes,
+// which is where that guarantee belongs.
 const chatTitleSystemPrompt = `You write a very short title that summarizes the topic of a chat conversation, given the user's opening message.
 
 Rules:
 - Output ONLY the title text — nothing else, no explanation.
 - Keep it short: a few words, ideally under 8, never a full sentence.
-- Write the title in the SAME language as the user's message (Chinese input → Chinese title, English input → English title).
+- Write the title in the SAME language as the user's message, and in no other.
 - Do NOT wrap the title in quotes or brackets.
-- Do NOT prefix it with "Title:", "标题：", or similar.
+- Do NOT prefix it with a label such as "Title:", in any language.
 - Do NOT end with a period or any trailing punctuation.`
 
 // maybeGenerateChatTitleAsync kicks off best-effort LLM title generation for a

--- a/server/internal/service/chat_quick_actions_generate.go
+++ b/server/internal/service/chat_quick_actions_generate.go
@@ -137,8 +137,8 @@ Field rules:
 - "primary": true on exactly one suggestion, the single most likely next step.
   false on all others.
 
-Language: the user message ends with a LANGUAGE RULE line. It is authoritative;
-follow it exactly.
+Language: the user message contains a LANGUAGE RULE line near the end. It is
+authoritative; follow it exactly.
 
 Output JSON only, exactly this shape:
 {"actions":[{"label":"...","prompt":"...","primary":true}]}
@@ -156,7 +156,7 @@ No prose, no markdown, no code fences.`
 //
 // Everything else is named and excluded explicitly, because each one has been
 // observed to pull the output the wrong way (MUL-5689): the agent may reply in
-// another language, these instructions are English, and ALREADY SUGGESTED
+// another language, the system prompt is English, and ALREADY SUGGESTED
 // replays the previous turn's labels — which is what made one bad pass stick,
 // each Chinese label seeding the next round.
 //
@@ -168,7 +168,7 @@ No prose, no markdown, no code fences.`
 // to infer), it reads an earlier Korean turn over the latest Japanese one, and
 // a kana sentence carrying enough English identifiers classifies as Latin, at
 // which point a "never emit CJK" clause forbids the user's own script.
-const chatQuickActionsLanguageRule = `LANGUAGE RULE: Write every "label" and "prompt" in the same language as the most recent [user] message above. Ignore the agent's reply, older messages, these instructions, and ALREADY SUGGESTED when choosing the language. If there is no [user] message, use the latest [agent] message.`
+const chatQuickActionsLanguageRule = `LANGUAGE RULE: Write every "label" and "prompt" in the same language as the most recent [user] message above. Ignore the agent's reply, older messages, the system instructions, and ALREADY SUGGESTED when choosing the language. If there is no [user] message, use the latest [agent] message.`
 
 // GenerateChatQuickActionsForTask runs one suggestion pass for a completed chat
 // turn and attaches the result to that turn's assistant row, broadcasting

--- a/server/internal/service/chat_quick_actions_generate_test.go
+++ b/server/internal/service/chat_quick_actions_generate_test.go
@@ -210,7 +210,7 @@ func TestRenderChatQuickActionsContextClosesWithTheLanguageRule(t *testing.T) {
 	if !strings.Contains(out, "same language as the most recent [user] message") {
 		t.Fatalf("rule must anchor on the most recent user turn:\n%s", out)
 	}
-	for _, disowned := range []string{"agent's reply", "older messages", "these instructions", "ALREADY SUGGESTED"} {
+	for _, disowned := range []string{"agent's reply", "older messages", "the system instructions", "ALREADY SUGGESTED"} {
 		if !strings.Contains(chatQuickActionsLanguageRule, disowned) {
 			t.Fatalf("rule must explicitly exclude %q: %s", disowned, chatQuickActionsLanguageRule)
 		}


### PR DESCRIPTION
Follow-up to #6345 (MUL-5689), which fixed chat quick actions drifting out of the user's language. Two loose ends from that PR, both text-only, no behavior or schema change.

## 1. Two inaccuracies in the quick-actions language rule

Raised in review on #6345 and marked non-blocking there; deferred so that merge stayed unblocked.

**`these instructions` was self-referential.** The `LANGUAGE RULE` is itself an instruction, so telling the model to *"ignore … these instructions when choosing the language"* left it ambiguous whether the rule was disowning itself. It means the system prompt, so it now says `the system instructions`.

**The system prompt claimed the user message "ends with" the rule.** It does not — the task line (`Produce the follow-up suggestions for the latest agent reply.`) follows it. Reworded to *"contains a LANGUAGE RULE line near the end"*, which is what the renderer actually emits. The rule's position is unchanged: still after the conversation and after the replayed `ALREADY SUGGESTED` labels, which is the part that does the work.

## 2. The Chinese seed in the chat-title prompt

Found while auditing every LLM prompt in the server for CJK content — the question that produced this was *"do any of our prompts contain Chinese?"*. There are exactly two prompts, and `chatTitleSystemPrompt` was carrying Chinese in two places:

```go
- Write the title in the SAME language as the user's message (Chinese input → Chinese title, English input → English title).
- Do NOT prefix it with "Title:", "标题：", or similar.
```

One rule names a language outright; the other embeds a `标题：` literal as a formatting counter-example. This is the same defect that produced MUL-5689 — a prompt that spells out a specific language, *even only as an example of what not to do*, reads as permission to answer in it.

Nothing is lost by dropping the `标题：` example: `chatTitleLabelPrefixes` already strips `标题` / `题目` / `主题` along with the English forms from the model's output. That is where the guarantee actually lives, and it stays exactly as it was — the prompt was only restating it.

This is preventive. Unlike #6345 there is no user report of wrong-language chat titles, and no efficacy measurement here — the argument is that the identical seed in the identical position caused a confirmed bug in the sibling prompt.

## Verification

- `go build ./...`, `go vet ./internal/service/ ./internal/handler/`, `gofmt` on all three touched files — clean.
- `go test ./internal/service/ -run ChatQuickActions -count=1` — pass. The existing test that asserts the rule names each distractor was updated to the new wording, so it still pins the contract rather than the old string.
- `go test ./internal/handler/ -run SanitizeChatTitle -count=1` — pass, all 20 subtests including `chinese_label_prefix`, confirming the prefix-stripping guarantee survives the prompt edit.
- The `./internal/handler/` package has 12 files gofmt flags as unformatted; that is pre-existing on `main` and none of them are touched here.

MUL-5689
