### PR TITLE
fix(views): stop offering CLI updates for unparseable versions (MUL-5676)

### DIFF
--- a/packages/views/locales/en/runtimes.json
+++ b/packages/views/locales/en/runtimes.json
@@ -255,6 +255,8 @@
     "managed_by_desktop_title": "The CLI binary is managed by Multica Desktop — update Desktop to upgrade the CLI.",
     "read_only": "Read-only",
     "read_only_title": "Only runtime owners and workspace admins can update the CLI.",
+    "local_build": "Local build",
+    "local_build_title": "This runtime reports a non-release version, so Multica cannot tell whether an upgrade is available. Update it from the machine itself.",
     "latest": "Latest",
     "available": "available",
     "action": "Update",

--- a/packages/views/locales/ja/runtimes.json
+++ b/packages/views/locales/ja/runtimes.json
@@ -243,6 +243,8 @@
     "managed_by_desktop_title": "CLI バイナリは Multica Desktop で管理されています。CLI をアップグレードするには Desktop を更新してください。",
     "read_only": "読み取り専用",
     "read_only_title": "CLI を更新できるのは、ランタイムの所有者とワークスペース管理者のみです。",
+    "local_build": "ローカルビルド",
+    "local_build_title": "このランタイムはリリース版ではないバージョンを報告しているため、Multica はアップグレードの有無を判断できません。マシン上で直接更新してください。",
     "latest": "最新",
     "available": "利用可能",
     "action": "更新",

--- a/packages/views/locales/ko/runtimes.json
+++ b/packages/views/locales/ko/runtimes.json
@@ -243,6 +243,8 @@
     "managed_by_desktop_title": "CLI 바이너리는 Multica Desktop에서 관리합니다. CLI를 업그레이드하려면 Desktop을 업데이트하세요.",
     "read_only": "읽기 전용",
     "read_only_title": "런타임 소유자와 워크스페이스 관리자만 CLI를 업데이트할 수 있습니다.",
+    "local_build": "로컬 빌드",
+    "local_build_title": "이 런타임은 릴리스 버전이 아닌 버전을 보고하므로 Multica가 업그레이드 가능 여부를 판단할 수 없습니다. 머신에서 직접 업데이트하세요.",
     "latest": "최신",
     "available": "사용 가능",
     "action": "업데이트",

--- a/packages/views/locales/zh-Hans/runtimes.json
+++ b/packages/views/locales/zh-Hans/runtimes.json
@@ -243,6 +243,8 @@
     "managed_by_desktop_title": "CLI 二进制由 Multica 桌面端管理 —— 升级桌面端即可升级 CLI。",
     "read_only": "只读",
     "read_only_title": "只有运行时所有者和工作区管理员可以更新 CLI。",
+    "local_build": "本地构建",
+    "local_build_title": "该运行时报告的不是发布版本，Multica 无法判断是否有可升级的版本。请在这台机器上自行更新。",
     "latest": "最新",
     "available": "可用",
     "action": "更新",

--- a/packages/views/runtimes/components/update-section.test.tsx
+++ b/packages/views/runtimes/components/update-section.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { cleanup, render, screen } from "@testing-library/react";
 import { I18nProvider } from "@multica/core/i18n/react";
 import enCommon from "../../locales/en/common.json";
@@ -96,5 +96,77 @@ describe("UpdateSection read-only status", () => {
     expect(
       screen.queryByRole("button", { name: "Update" }),
     ).not.toBeInTheDocument();
+  });
+});
+
+// A daemon built from source reports either the ldflags default ("dev") or a
+// `git describe` string. Neither can be ordered against a release tag, so the
+// UI must not claim an upgrade is available — a manual update is legitimate
+// precisely because a human made an informed decision, and that decision has to
+// rest on something we actually parsed.
+describe("UpdateSection non-release versions", () => {
+  const LATEST = "v0.4.20";
+
+  // fetchLatestVersion memoizes the GitHub tag in module scope for 10 minutes,
+  // so without advancing the clock every case here would silently reuse the tag
+  // an earlier test cached rather than its own.
+  let clock = Date.now();
+
+  beforeEach(() => {
+    clock += 60 * 60 * 1000;
+    vi.spyOn(Date, "now").mockReturnValue(clock);
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({ tag_name: LATEST }),
+      }),
+    );
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  const NON_RELEASE_VERSIONS = [
+    "dev",
+    "v0.4.17-12-gabc1234",
+    "v0.4.17-dirty",
+    "v0.4.17-rc1",
+    "v0.4",
+  ];
+
+  for (const currentVersion of NON_RELEASE_VERSIONS) {
+    it(`offers no update and claims no state for "${currentVersion}"`, async () => {
+      renderSection({ runtimeId: "runtime-1", currentVersion });
+
+      expect(await screen.findByText("Local build")).toBeInTheDocument();
+      expect(
+        screen.queryByRole("button", { name: "Update" }),
+      ).not.toBeInTheDocument();
+      expect(screen.queryByText("available")).not.toBeInTheDocument();
+      // "Latest" would be just as unfounded as "update available".
+      expect(screen.queryByText("Latest")).not.toBeInTheDocument();
+    });
+  }
+
+  it("still offers the update on a release version behind the latest", async () => {
+    renderSection({ runtimeId: "runtime-1", currentVersion: "v0.4.17" });
+
+    expect(
+      await screen.findByRole("button", { name: "Update" }),
+    ).toBeInTheDocument();
+    expect(screen.getByText("available")).toBeInTheDocument();
+    expect(screen.queryByText("Local build")).not.toBeInTheDocument();
+  });
+
+  it("reports a release version on the latest tag as Latest", async () => {
+    renderSection({ runtimeId: "runtime-1", currentVersion: LATEST });
+
+    expect(await screen.findByText("Latest")).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: "Update" }),
+    ).not.toBeInTheDocument();
+    expect(screen.queryByText("Local build")).not.toBeInTheDocument();
   });
 });

--- a/packages/views/runtimes/components/update-section.tsx
+++ b/packages/views/runtimes/components/update-section.tsx
@@ -37,15 +37,42 @@ async function fetchLatestVersion(): Promise<string | null> {
   }
 }
 
-function stripV(v: string): string {
-  return v.replace(/^v/, "");
+/**
+ * Parses a released CLI version ("v0.4.17" / "0.4.17") into comparable parts,
+ * or null when the string is not a release version.
+ *
+ * A daemon built from source reports a `git describe` string
+ * ("v0.4.17-12-gabc1234") or the ldflags default ("dev"), and neither can be
+ * ordered against a release tag. This mirrors `IsReleaseVersion` in
+ * server/internal/cli/update.go, which is how the daemon's own auto-update
+ * loop decides the same question.
+ */
+function parseReleaseVersion(v: string): number[] | null {
+  const parts = v.trim().replace(/^v/, "").split(".");
+  if (parts.length !== 3) return null;
+  const parsed: number[] = [];
+  for (const part of parts) {
+    if (!/^\d+$/.test(part)) return null;
+    parsed.push(Number(part));
+  }
+  return parsed;
 }
 
+/**
+ * True when `latest` is strictly newer than `current`.
+ *
+ * An unparseable version on either side compares as "no update available".
+ * Number("dev") is NaN, and every NaN comparison is false, so the old
+ * component-wise scan fell through to the next component and reported an
+ * upgrade for a version string it had never actually read — inviting the
+ * operator to replace a locally built binary on the strength of a claim we
+ * could not make.
+ */
 function isNewer(latest: string, current: string): boolean {
-  const l = stripV(latest).split(".").map(Number);
-  const c = stripV(current).split(".").map(Number);
-  for (let i = 0; i < Math.max(l.length, c.length); i++) {
-    const lv = l[i] ?? 0;
+  const l = parseReleaseVersion(latest);
+  const c = parseReleaseVersion(current);
+  if (!l || !c) return false;
+  for (const [i, lv] of l.entries()) {
     const cv = c[i] ?? 0;
     if (lv > cv) return true;
     if (lv < cv) return false;
@@ -176,6 +203,13 @@ export function UpdateSection({
     latestVersion &&
     isNewer(latestVersion, currentVersion);
 
+  // A source build cannot be ordered against a release tag, so neither
+  // "update available" nor "Latest" is a claim we can make. Say that, rather
+  // than defaulting to "Latest" and telling the operator their local binary is
+  // up to date when we never parsed its version.
+  const isLocalBuild =
+    !!currentVersion && parseReleaseVersion(currentVersion) === null;
+
   const config = status ? statusConfig[status] : null;
   const Icon = config?.icon;
   const isActive = status === "pending" || status === "running";
@@ -197,12 +231,25 @@ export function UpdateSection({
           </span>
         ) : (
           <>
-            {!hasUpdate && currentVersion && latestVersion && !status && (
-              <span className="inline-flex items-center gap-1 text-caption text-success">
-                <Check className="h-3 w-3" />
-                {t(($) => $.update.latest)}
+            {isLocalBuild && !status && (
+              <span
+                className="inline-flex items-center gap-1 text-caption text-muted-foreground"
+                title={t(($) => $.update.local_build_title)}
+              >
+                {t(($) => $.update.local_build)}
               </span>
             )}
+
+            {!isLocalBuild &&
+              !hasUpdate &&
+              currentVersion &&
+              latestVersion &&
+              !status && (
+                <span className="inline-flex items-center gap-1 text-caption text-success">
+                  <Check className="h-3 w-3" />
+                  {t(($) => $.update.latest)}
+                </span>
+              )}
 
             {hasUpdate && !status && (
               <>


### PR DESCRIPTION
Related to #6332 (reported the surrounding area; the behaviour change requested there was declined separately — this PR does not close it).

## Summary

The runtimes page offered a CLI upgrade for daemons whose version it could not parse.

`isNewer()` compared versions component-wise after `Number()`. `Number("dev")` is `NaN`, every `NaN` comparison is false, so the scan fell through to the next component instead of stopping — and a build reporting the ldflags default `dev` matched `isNewer("v0.4.20", "dev") === true`. The page then rendered "dev → v0.4.20 available" plus an Update button, for a version string it had never actually read.

A `git describe` version (`v0.4.17-12-gabc1234`) hit the opposite branch of the same flaw and hid the button. Same class of source build, opposite behaviour, neither one designed.

| current version | before | after |
| --- | --- | --- |
| `v0.4.17` (release, behind) | Update offered | Update offered |
| `v0.4.20` (release, current) | "Latest" | "Latest" |
| `dev` | **Update offered** | "Local build" |
| `v0.4.17-12-gabc1234` | "Latest" | "Local build" |
| `v0.4.17-rc1`, `v0.4.17-dirty`, `v0.4` | "Latest" | "Local build" |

## Changes

**Parse strictly.** `parseReleaseVersion()` requires exactly three all-digit components, mirroring `IsReleaseVersion` in `server/internal/cli/update.go` — which is how the daemon's own auto-update loop answers this same question. An unparseable version on either side now compares as "no update available".

**Don't swap one false claim for another.** With only the parsing fix, a `dev` build would fall through to the "✓ Latest" badge — just as unfounded, and arguably worse, since it tells the operator their local binary is up to date. Non-release versions now get a neutral muted "Local build" label with a tooltip, following the existing "Managed by Desktop" pattern in this component. New i18n keys added to all four bundles (en / zh-Hans / ja / ko).

A server-triggered update is legitimate precisely because a human made an informed decision. That decision has to rest on something we actually parsed.

## Scope note

This is deliberately **not** a change to who may trigger an update or when. `disable_auto_update` governs the daemon's periodic self-update poll; a maintainer clicking Update is a manual action of a different class and is unaffected here. This PR only makes the information that click is based on true.

Discovered while triaging #6332, which raises a separate (and declined) question about the server-triggered path.

## Verification

- `pnpm exec vitest run runtimes/ locales/` in `packages/views` — 334 passed
- `pnpm typecheck` — 6/6 tasks pass
- `pnpm lint` — 0 errors, no warnings in the changed files

Tests were confirmed to fail against the unfixed component: all 5 non-release cases fail, the 2 release-version regression guards pass. The locale parity test covers the new keys across all four bundles.

Test note: `fetchLatestVersion` memoizes the GitHub tag in module scope for 10 minutes, so the new cases stub `Date.now()` forward to avoid silently reusing a tag cached by an earlier test — without it, a case asserting on `v0.4.20` was actually running against `v0.4.0`.

