### PR TITLE
refactor(daemon): slim Issue Metadata to its judgment core, defer discipline to the skill (MUL-5442)

### DIFF
--- a/server/internal/daemon/execenv/execenv_test.go
+++ b/server/internal/daemon/execenv/execenv_test.go
@@ -5624,10 +5624,17 @@ func TestInjectRuntimeConfigIssueMetadataSectionScope(t *testing.T) {
 			"decision",
 			// Safety boundaries — these are the negative rules that
 			// keep metadata from rotting into a second description /
-			// log dump. Pinned as one sentence since MUL-5442 merged the
-			// ban list into the Write-on-exit bullet.
-			"Never pin secrets, tokens, or API keys, logs or comment summaries, or runtime bookkeeping",
-			"single-run details belong in the result comment",
+			// log dump. Pinned as separate semantic anchors (not one
+			// sentence) so the phrasing can be rewritten without CI churn,
+			// while dropping any single ban — or the bookkeeping examples
+			// that define that category's boundary — still fails (MUL-5442
+			// review).
+			"secrets/tokens/API keys",
+			"logs/comment summaries",
+			"runtime bookkeeping such as",
+			"attempts, run timestamps, or agent IDs",
+			"single-run details",
+			"belong in the result comment",
 			"snake_case ASCII",
 		},
 	}

--- a/server/internal/daemon/execenv/execenv_test.go
+++ b/server/internal/daemon/execenv/execenv_test.go
@@ -5606,8 +5606,9 @@ func TestInjectRuntimeConfigIssueMetadataSectionScope(t *testing.T) {
 			"## Issue Metadata",
 			"high-signal scratchpad",
 			"**Read on entry.**",
+			// MUL-5442: the What-NOT-to-pin heading merged into Write on
+			// exit; the negative rules below still pin the full ban list.
 			"**Write on exit.**",
-			"**What NOT to pin.**",
 			"**Recommended keys**",
 			// Recommended-key list — both lea's killer-use-case keys
 			// (pr_number, pipeline_status) and the broader set from
@@ -5623,10 +5624,10 @@ func TestInjectRuntimeConfigIssueMetadataSectionScope(t *testing.T) {
 			"decision",
 			// Safety boundaries — these are the negative rules that
 			// keep metadata from rotting into a second description /
-			// log dump.
-			"No secrets, tokens, or API keys",
-			"No logs",
-			"runtime bookkeeping",
+			// log dump. Pinned as one sentence since MUL-5442 merged the
+			// ban list into the Write-on-exit bullet.
+			"Never pin secrets, tokens, or API keys, logs or comment summaries, or runtime bookkeeping",
+			"single-run details belong in the result comment",
 			"snake_case ASCII",
 		},
 	}

--- a/server/internal/daemon/execenv/execenv_test.go
+++ b/server/internal/daemon/execenv/execenv_test.go
@@ -5604,38 +5604,22 @@ func TestInjectRuntimeConfigIssueMetadataSectionScope(t *testing.T) {
 	withSection := wantSection{
 		present: []string{
 			"## Issue Metadata",
-			"high-signal scratchpad",
 			"**Read on entry.**",
-			// MUL-5442: the What-NOT-to-pin heading merged into Write on
-			// exit; the negative rules below still pin the full ban list.
 			"**Write on exit.**",
-			"**Recommended keys**",
-			// Recommended-key list — both lea's killer-use-case keys
-			// (pr_number, pipeline_status) and the broader set from
-			// review must be named so the workspace converges on shared
-			// vocabulary.
-			"pr_url",
-			"pr_number",
-			"pipeline_status",
-			"deploy_url",
-			"external_issue_url",
-			"waiting_on",
-			"blocked_reason",
-			"decision",
-			// Safety boundaries — these are the negative rules that
-			// keep metadata from rotting into a second description /
-			// log dump. Pinned as separate semantic anchors (not one
-			// sentence) so the phrasing can be rewritten without CI churn,
-			// while dropping any single ban — or the bookkeeping examples
-			// that define that category's boundary — still fails (MUL-5442
-			// review).
-			"secrets/tokens/API keys",
-			"logs/comment summaries",
-			"runtime bookkeeping such as",
-			"attempts, run timestamps, or agent IDs",
-			"single-run details",
-			"belong in the result comment",
-			"snake_case ASCII",
+			"Hints, not truth",
+			// MUL-5442: the brief keeps only what the interface cannot
+			// express — the read stance, the re-read bar, and the two
+			// write-time boundaries (secrets, length). The full ban list
+			// and the key-naming conventions live in the
+			// multica-working-on-issues skill, pinned by
+			// TestWorkingOnIssuesSkillCoversIssueLoopContracts so this
+			// pointer cannot dangle. The recommended-keys block was
+			// removed outright: metadata is deliberately free-form custom
+			// state (owner decision on MUL-5442), not a vocabulary the
+			// platform curates in every brief.
+			"never secrets or long content",
+			"multica issue metadata delete",
+			"the `multica-working-on-issues` skill",
 		},
 	}
 	withoutSection := wantSection{

--- a/server/internal/daemon/execenv/runtime_config_sections.go
+++ b/server/internal/daemon/execenv/runtime_config_sections.go
@@ -368,10 +368,9 @@ func writeProjectContext(b *strings.Builder, ctx TaskContextForEnv) {
 // helper does not re-check.
 func writeIssueMetadata(b *strings.Builder) {
 	b.WriteString("## Issue Metadata\n\n")
-	b.WriteString("`metadata` is a small per-issue KV bag — a high-signal scratchpad for facts future runs will re-read (PR URL, deploy URL, current blocker). Most runs pin **zero** new keys; that is the expected case.\n\n")
+	b.WriteString("`metadata` is a small per-issue KV bag — custom key-value state your workflow wants future runs on this issue to re-read. Most runs write nothing.\n\n")
 	b.WriteString("- **Read on entry.** Hints, not truth: latest comment / code wins on conflict. Empty `{}` is normal.\n")
-	b.WriteString("- **Write on exit.** Pin only what is materially important to this issue AND likely to be re-read by a future run; overwrite or `multica issue metadata delete` stale keys. Never pin secrets/tokens/API keys; logs/comment summaries; runtime bookkeeping such as attempts, run timestamps, or agent IDs; or other single-run details — those belong in the result comment.\n")
-	b.WriteString("- **Recommended keys** (snake_case ASCII, reuse these names): `pr_url`, `pr_number`, `pipeline_status`, `deploy_url`, `external_issue_url`, `waiting_on`, `blocked_reason`, `decision`.\n\n")
+	b.WriteString("- **Write on exit.** Only what a future run will actually re-read — short values, never secrets or long content. Overwrite or `multica issue metadata delete` stale keys. Full write discipline: the `multica-working-on-issues` skill.\n\n")
 }
 
 // writeInstructionPrecedence emits the "Agent Identity wins over the issue

--- a/server/internal/daemon/execenv/runtime_config_sections.go
+++ b/server/internal/daemon/execenv/runtime_config_sections.go
@@ -370,7 +370,7 @@ func writeIssueMetadata(b *strings.Builder) {
 	b.WriteString("## Issue Metadata\n\n")
 	b.WriteString("`metadata` is a small per-issue KV bag — a high-signal scratchpad for facts future runs will re-read (PR URL, deploy URL, current blocker). Most runs pin **zero** new keys; that is the expected case.\n\n")
 	b.WriteString("- **Read on entry.** Hints, not truth: latest comment / code wins on conflict. Empty `{}` is normal.\n")
-	b.WriteString("- **Write on exit.** Pin only what is materially important to this issue AND likely to be re-read by a future run; overwrite or `multica issue metadata delete` stale keys. Never pin secrets, tokens, or API keys, logs or comment summaries, or runtime bookkeeping — single-run details belong in the result comment.\n")
+	b.WriteString("- **Write on exit.** Pin only what is materially important to this issue AND likely to be re-read by a future run; overwrite or `multica issue metadata delete` stale keys. Never pin secrets/tokens/API keys; logs/comment summaries; runtime bookkeeping such as attempts, run timestamps, or agent IDs; or other single-run details — those belong in the result comment.\n")
 	b.WriteString("- **Recommended keys** (snake_case ASCII, reuse these names): `pr_url`, `pr_number`, `pipeline_status`, `deploy_url`, `external_issue_url`, `waiting_on`, `blocked_reason`, `decision`.\n\n")
 }
 

--- a/server/internal/daemon/execenv/runtime_config_sections.go
+++ b/server/internal/daemon/execenv/runtime_config_sections.go
@@ -368,11 +368,10 @@ func writeProjectContext(b *strings.Builder, ctx TaskContextForEnv) {
 // helper does not re-check.
 func writeIssueMetadata(b *strings.Builder) {
 	b.WriteString("## Issue Metadata\n\n")
-	b.WriteString("`metadata` is a small KV bag per issue — a high-signal scratchpad for facts future runs on this same issue will read more than once (PR URL, deploy URL, current blocker). Most runs pin **zero** new keys; that is the expected case.\n\n")
-	b.WriteString("- **Read on entry.** Metadata is hints, not truth: latest comment / code wins on conflict. Empty `{}` is normal.\n")
-	b.WriteString("- **Write on exit.** Pin only if BOTH: (a) materially important to this issue, AND (b) a future run is likely to re-read it. Otherwise leave the bag alone. Stale keys: overwrite with the new value or `multica issue metadata delete`.\n")
-	b.WriteString("- **What NOT to pin.** No secrets, tokens, or API keys. No logs or comment summaries. No runtime bookkeeping (attempts, run timestamps, agent ids). No single-run details — those belong in the result comment.\n")
-	b.WriteString("- **Recommended keys** (use snake_case ASCII; reuse these names so queries stay consistent): `pr_url`, `pr_number`, `pipeline_status`, `deploy_url`, `external_issue_url`, `waiting_on`, `blocked_reason`, `decision`.\n\n")
+	b.WriteString("`metadata` is a small per-issue KV bag — a high-signal scratchpad for facts future runs will re-read (PR URL, deploy URL, current blocker). Most runs pin **zero** new keys; that is the expected case.\n\n")
+	b.WriteString("- **Read on entry.** Hints, not truth: latest comment / code wins on conflict. Empty `{}` is normal.\n")
+	b.WriteString("- **Write on exit.** Pin only what is materially important to this issue AND likely to be re-read by a future run; overwrite or `multica issue metadata delete` stale keys. Never pin secrets, tokens, or API keys, logs or comment summaries, or runtime bookkeeping — single-run details belong in the result comment.\n")
+	b.WriteString("- **Recommended keys** (snake_case ASCII, reuse these names): `pr_url`, `pr_number`, `pipeline_status`, `deploy_url`, `external_issue_url`, `waiting_on`, `blocked_reason`, `decision`.\n\n")
 }
 
 // writeInstructionPrecedence emits the "Agent Identity wins over the issue

--- a/server/internal/service/builtin_skills/multica-working-on-issues/SKILL.md
+++ b/server/internal/service/builtin_skills/multica-working-on-issues/SKILL.md
@@ -172,7 +172,7 @@ multica issue property unset <issue-id> --name Environment
   If a needed property does not exist, propose it in a comment instead.
 - Property vs metadata: if the value is workflow state a human should see and
   filter by, and a definition exists, prefer the property. Metadata stays the
-  free-form scratchpad for run state (`pr_url`, `waiting_on`, ...).
+  free-form bag for durable custom issue state.
 
 ## Status changes have server side effects
 

--- a/server/internal/service/builtin_skills/multica-working-on-issues/SKILL.md
+++ b/server/internal/service/builtin_skills/multica-working-on-issues/SKILL.md
@@ -127,29 +127,21 @@ not observe a routable issue key in the PR title/body/branch — or the only mat
 was a bare body mention, which links as `reference_only` and is hidden from this
 list (see the reference-only rule above).
 
-## Metadata: high-signal keys only
+## Metadata: durable custom state
 
-Metadata is durable issue state. Reading metadata is safe. Writing a metadata key
-is a state mutation and should be tied to an explicit task requirement to record
-that state for later readers or runs.
+Metadata is a free-form KV bag of durable issue state. Reading metadata is safe.
+Writing a metadata key is a state mutation and should be tied to an explicit
+task requirement to record that state for later readers or runs. Keys are
+whatever your workflow needs — the platform curates no vocabulary; pick short
+snake_case names and reuse them consistently within your workspace.
 
-High-signal keys (reuse these names so queries stay consistent):
-
-- `pr_url`
-- `pr_number`
-- `pipeline_status`
-- `deploy_url`
-- `external_issue_url`
-- `waiting_on`
-- `blocked_reason`
-- `decision`
-
-Never store secrets, tokens, or API keys in metadata. Not metadata: logs,
-summaries, files touched, timestamps, attempt counts, agent ids, investigation
-notes — those belong in the result comment.
+Never store secrets, tokens, or API keys in metadata.
+Not metadata: logs or summaries; runtime bookkeeping such as timestamps,
+attempt counts, or agent IDs; or other single-run details such as
+files touched and investigation notes — those belong in the result comment.
 
 ```bash
-multica issue metadata set <issue-id> --key pr_url --value <url>
+multica issue metadata set <issue-id> --key <key> --value <value>
 multica issue metadata delete <issue-id> --key <stale-key>
 ```
 

--- a/server/internal/service/builtin_skills/multica-working-on-issues/SKILL.md
+++ b/server/internal/service/builtin_skills/multica-working-on-issues/SKILL.md
@@ -144,8 +144,9 @@ High-signal keys (reuse these names so queries stay consistent):
 - `blocked_reason`
 - `decision`
 
-Not metadata: logs, summaries, files touched, timestamps, attempt counts,
-investigation notes. Those belong in the result comment.
+Never store secrets, tokens, or API keys in metadata. Not metadata: logs,
+summaries, files touched, timestamps, attempt counts, agent ids, investigation
+notes — those belong in the result comment.
 
 ```bash
 multica issue metadata set <issue-id> --key pr_url --value <url>

--- a/server/internal/service/builtin_skills_test.go
+++ b/server/internal/service/builtin_skills_test.go
@@ -243,6 +243,14 @@ func TestWorkingOnIssuesSkillCoversIssueLoopContracts(t *testing.T) {
 		"`--stage <N>`",
 		"when a whole stage finishes",
 		"multica issue status <child-id> todo",
+		// MUL-5442: the brief's Issue Metadata section defers the full
+		// write discipline here. These anchors are the relocated bans —
+		// each one used to be pinned in the brief and must not leave the
+		// skill while the brief still points at it.
+		"Never store secrets, tokens, or API keys",
+		"Not metadata: logs,",
+		"attempt counts, agent ids",
+		"belong in the result comment",
 	}
 	for _, want := range mustContain {
 		if !strings.Contains(body, want) {

--- a/server/internal/service/builtin_skills_test.go
+++ b/server/internal/service/builtin_skills_test.go
@@ -244,13 +244,20 @@ func TestWorkingOnIssuesSkillCoversIssueLoopContracts(t *testing.T) {
 		"when a whole stage finishes",
 		"multica issue status <child-id> todo",
 		// MUL-5442: the brief's Issue Metadata section defers the full
-		// write discipline here. These anchors are the relocated bans —
-		// each one used to be pinned in the brief and must not leave the
-		// skill while the brief still points at it.
+		// write discipline here. Every relocated ban is anchored
+		// individually — both defining categories AND each example —
+		// so no single item or category boundary can be dropped while
+		// the brief still points at this skill (round-3 review).
 		"Never store secrets, tokens, or API keys",
-		"Not metadata: logs,",
-		"attempt counts, agent ids",
+		"Not metadata: logs or summaries",
+		"bookkeeping such as timestamps",
+		"attempt counts, or agent IDs",
+		"other single-run details",
+		"files touched and investigation notes",
 		"belong in the result comment",
+		// Owner ruling: metadata is deliberately free-form custom state;
+		// the platform curates no key vocabulary.
+		"the platform curates no vocabulary",
 	}
 	for _, want := range mustContain {
 		if !strings.Contains(body, want) {
@@ -259,6 +266,11 @@ func TestWorkingOnIssuesSkillCoversIssueLoopContracts(t *testing.T) {
 	}
 
 	mustNotContain := []string{
+		// A curated key list is the "recommended fields" concept the owner
+		// ruled out on MUL-5442 — it must not creep back into the skill
+		// that loads exactly when an agent is about to write metadata.
+		"High-signal keys",
+		"reuse these names so queries stay consistent",
 		"Start from the trigger, not from memory",
 		"multica issue get <issue-id> --output json",
 		"multica issue metadata list <issue-id> --output json",

--- a/server/internal/service/builtin_skills_test.go
+++ b/server/internal/service/builtin_skills_test.go
@@ -234,7 +234,10 @@ func TestWorkingOnIssuesSkillCoversIssueLoopContracts(t *testing.T) {
 		"include the PR URL when a PR exists",
 		"Closes MUL-2759",
 		"--status backlog",
-		"pr_url",
+		// The only sanctioned pr_url reference is the negative compatibility
+		// warning about pre-existing data — not a write recommendation
+		// (MUL-5442 owner ruling: no curated key vocabulary).
+		"`pr_url` metadata (which can be",
 		"references/working-on-issues-source-map.md",
 		// MUL-5442: the brief's Sub-issue Creation section is now a one-line
 		// map pointing here. These anchors are the demoted playbook — if they
@@ -271,6 +274,8 @@ func TestWorkingOnIssuesSkillCoversIssueLoopContracts(t *testing.T) {
 		// that loads exactly when an agent is about to write metadata.
 		"High-signal keys",
 		"reuse these names so queries stay consistent",
+		"scratchpad for run state",
+		"(`pr_url`, `waiting_on`",
 		"Start from the trigger, not from memory",
 		"multica issue get <issue-id> --output json",
 		"multica issue metadata list <issue-id> --output json",


### PR DESCRIPTION
Part of MUL-5442. Three rounds, following the owner's direction as it sharpened:

1. **Fold the ban-list heading into the write rule** (−202B) — Elon's review restored the three runtime-bookkeeping boundary examples (+52B) and converted the whole-sentence pin to semantic anchors.
2. **This round (owner decision)**: metadata is deliberately **free-form custom key-value state** — the recommended-keys block never matched the feature's intent and is removed outright. The full write discipline defers to the `multica-working-on-issues` skill (progressive disclosure), which already carried a near-complete copy and now gains the two bans it lacked (**secrets/tokens/API keys**, **agent ids**) so every relocated rule keeps a tested home.

## Measured

| | bytes |
|---|---:|
| Issue Metadata section at round start | 1,024 |
| after round 1 + review fix | 874 |
| **now** | **505** |
| brief total | 16,099 → **15,579 (−520)** |

The brief keeps only what the interface cannot express: read-as-hints stance, the will-a-future-run-re-read-it bar, and the two write-time boundaries (never secrets, never long content) plus the skill pointer.

## Pin accounting

- Brief side: slimmed to the surviving semantics + the skill pointer (anti-dangling).
- Skill side: `TestWorkingOnIssuesSkillCoversIssueLoopContracts` gains the relocated ban anchors (secrets, Not-metadata list, attempt counts/agent ids, result-comment redirect) — the bans cannot leave the skill while the brief points at it.
- Nothing deleted without a tested home.

## Verification

`go test ./internal/daemon/... -count=1` green, skill/builtin template tests green (including strict-YAML and body-budget checks on the edited SKILL.md), `go build ./...` clean.