### PR TITLE
MUL-5686: fix(chat): resume the cancelled turn's session instead of starting cold

### DIFF
--- a/server/internal/handler/daemon_claim_cancelled_session_test.go
+++ b/server/internal/handler/daemon_claim_cancelled_session_test.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/go-chi/chi/v5"
 	"github.com/jackc/pgx/v5"
-	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/jackc/pgx/v5/pgtype"
 
 	"github.com/multica-ai/multica/server/internal/service"
@@ -731,22 +730,22 @@ func TestCancelTask_ConcurrentWithChatSessionDelete(t *testing.T) {
 		deleteErr := make(chan error, 1)
 		go func() {
 			<-start
-			_, err := testHandler.TaskService.CancelTaskWithResult(context.Background(), parseUUID(taskID),
+			callCtx, cancel := raceCtx()
+			defer cancel()
+			_, err := testHandler.TaskService.CancelTaskWithResult(callCtx, parseUUID(taskID),
 				service.CancelTaskOptions{ClientSupportsDraftRestore: true})
 			cancelErr <- err
 		}()
 		go func() {
 			<-start
-			deleteErr <- deleteChatSessionLikeHandler(context.Background(), chatSessionID)
+			callCtx, cancel := raceCtx()
+			defer cancel()
+			deleteErr <- deleteChatSessionLikeHandler(callCtx, chatSessionID)
 		}()
 		close(start)
 
-		if err := <-cancelErr; err != nil && isDeadlock(err) {
-			t.Fatalf("iteration %d: cancel deadlocked against chat delete: %v", i, err)
-		}
-		if err := <-deleteErr; err != nil && isDeadlock(err) {
-			t.Fatalf("iteration %d: chat delete deadlocked against cancel: %v", i, err)
-		}
+		assertRaceSucceeded(t, i, "cancel", <-cancelErr)
+		assertRaceSucceeded(t, i, "chat delete", <-deleteErr)
 
 		testPool.Exec(ctx, `DELETE FROM agent_task_queue WHERE id = $1`, taskID)
 		testPool.Exec(ctx, `DELETE FROM chat_session WHERE id = $1`, chatSessionID)
@@ -865,12 +864,16 @@ func TestCancelAndPin_ConcurrentWithTerminalReport(t *testing.T) {
 		{
 			name: "cancel-vs-complete",
 			first: func(taskID string) error {
-				_, err := testHandler.TaskService.CancelTaskWithResult(context.Background(), parseUUID(taskID),
+				callCtx, cancel := raceCtx()
+				defer cancel()
+				_, err := testHandler.TaskService.CancelTaskWithResult(callCtx, parseUUID(taskID),
 					service.CancelTaskOptions{ClientSupportsDraftRestore: true})
 				return err
 			},
 			other: func(taskID string) error {
-				_, err := testHandler.TaskService.CompleteTask(context.Background(), parseUUID(taskID),
+				callCtx, cancel := raceCtx()
+				defer cancel()
+				_, err := testHandler.TaskService.CompleteTask(callCtx, parseUUID(taskID),
 					[]byte(`"done"`), "turn2-session", "/tmp/turn2-workdir", false, "")
 				return err
 			},
@@ -882,17 +885,25 @@ func TestCancelAndPin_ConcurrentWithTerminalReport(t *testing.T) {
 				req := newDaemonTokenRequest(http.MethodPost, "/api/daemon/tasks/"+taskID+"/session",
 					map[string]any{"session_id": "turn2-session", "work_dir": "/tmp/turn2-workdir"},
 					testWorkspaceID, daemonID)
+				reqCtx, cancel := context.WithTimeout(req.Context(), raceTimeout)
+				defer cancel()
 				rctx := chi.NewRouteContext()
 				rctx.URLParams.Add("taskId", taskID)
-				req = req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, rctx))
+				req = req.WithContext(context.WithValue(reqCtx, chi.RouteCtxKey, rctx))
 				testHandler.PinTaskSession(w, req)
+				// Any non-204 fails, deliberately: a pin that loses a deadlock is
+				// reported by the handler as a plain 500, so a check that only
+				// recognised *pgconn.PgError(40P01) would skip the very failure
+				// this test exists to catch.
 				if w.Code != http.StatusNoContent {
 					return errors.New("pin failed: " + w.Body.String())
 				}
 				return nil
 			},
 			other: func(taskID string) error {
-				_, err := testHandler.TaskService.FailTask(context.Background(), parseUUID(taskID),
+				callCtx, cancel := raceCtx()
+				defer cancel()
+				_, err := testHandler.TaskService.FailTask(callCtx, parseUUID(taskID),
 					"boom", "turn3-session", "/tmp/turn3-workdir", "agent_error", false, "")
 				return err
 			},
@@ -932,12 +943,8 @@ func TestCancelAndPin_ConcurrentWithTerminalReport(t *testing.T) {
 				go func() { <-start; otherErr <- c.other(taskID) }()
 				close(start)
 
-				if err := <-firstErr; err != nil && isDeadlock(err) {
-					t.Fatalf("iteration %d: deadlock: %v", i, err)
-				}
-				if err := <-otherErr; err != nil && isDeadlock(err) {
-					t.Fatalf("iteration %d: deadlock: %v", i, err)
-				}
+				assertRaceSucceeded(t, i, "first", <-firstErr)
+				assertRaceSucceeded(t, i, "other", <-otherErr)
 
 				testPool.Exec(ctx, `DELETE FROM agent_task_queue WHERE chat_session_id = $1`, chatSessionID)
 				testPool.Exec(ctx, `DELETE FROM chat_session WHERE id = $1`, chatSessionID)
@@ -970,9 +977,20 @@ func deleteChatSessionLikeHandler(ctx context.Context, chatSessionID string) err
 	return tx.Commit(ctx)
 }
 
-func isDeadlock(err error) bool {
-	var pgErr *pgconn.PgError
-	return errors.As(err, &pgErr) && pgErr.Code == "40P01"
+// assertRaceSucceeded fails on anything except the one benign outcome these
+// races have: whoever moved the task to a terminal state first leaves the loser
+// matching no row (pgx.ErrNoRows).
+//
+// Deliberately NOT a 40P01-only check. A deadlock victim inside an HTTP handler
+// is reported as a plain 500 with no *pgconn.PgError to unwrap, so matching the
+// SQLSTATE alone would silently pass exactly the failure these tests exist to
+// catch. Anything unexpected is a failure, and the error text says what it was.
+func assertRaceSucceeded(t *testing.T, iteration int, label string, err error) {
+	t.Helper()
+	if err == nil || errors.Is(err, pgx.ErrNoRows) {
+		return
+	}
+	t.Fatalf("iteration %d: %s failed: %v", iteration, label, err)
 }
 
 // beginWarmedTx opens a transaction that is safe to hold a row lock in for the
@@ -1017,11 +1035,13 @@ func beginWarmedTx(t *testing.T, ctx context.Context) pgx.Tx {
 	return tx
 }
 
-// raceCtx bounds a racing call so a stalled connection surfaces as a test
-// failure with a real message instead of wedging the package until the
-// 10-minute timeout. Far above the sub-second these paths actually take.
+// raceTimeout bounds every racing call below so a stalled connection surfaces
+// as a test failure with a real message instead of wedging the package until
+// the 10-minute timeout. Far above the sub-second these paths actually take.
+const raceTimeout = 30 * time.Second
+
 func raceCtx() (context.Context, context.CancelFunc) {
-	return context.WithTimeout(context.Background(), 30*time.Second)
+	return context.WithTimeout(context.Background(), raceTimeout)
 }
 
 // pinTaskSessionViaAPI drives the real daemon endpoint so the test covers the

--- a/server/internal/handler/daemon_claim_cancelled_session_test.go
+++ b/server/internal/handler/daemon_claim_cancelled_session_test.go
@@ -2,12 +2,15 @@ package handler
 
 import (
 	"context"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"testing"
 	"time"
 
 	"github.com/go-chi/chi/v5"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/jackc/pgx/v5/pgtype"
 
 	"github.com/multica-ai/multica/server/internal/service"
@@ -504,6 +507,293 @@ func TestPinTaskSession_LateCancelledPinYieldsToNewerTurn(t *testing.T) {
 	if pointer != "turn3-session" {
 		t.Fatalf("chat_session.session_id = %q, want turn3-session (a straggler pin must not rewind a newer turn)", pointer)
 	}
+}
+
+// TestPinTaskSession_PointerAdvanceIsAtomicWithPin is the pin-path mirror of
+// TestCancelTask_PointerAdvanceIsAtomicWithStatusFlip: landing the session on
+// the task row and advancing the chat pointer must be one commit, or a
+// follow-up claimed in between still resumes the previous turn.
+func TestPinTaskSession_PointerAdvanceIsAtomicWithPin(t *testing.T) {
+	if testHandler == nil {
+		t.Skip("database not available")
+	}
+
+	ctx := context.Background()
+	agentID, runtimeID, daemonID := createRuntimeGuardAgent(t, ctx)
+
+	var chatSessionID string
+	if err := testPool.QueryRow(ctx, `
+		INSERT INTO chat_session (
+			workspace_id, agent_id, creator_id, title,
+			session_id, work_dir, runtime_id
+		)
+		VALUES ($1, $2, $3, 'pin atomicity', 'turn1-session', '/tmp/turn1-workdir', $4)
+		RETURNING id
+	`, testWorkspaceID, agentID, testUserID, runtimeID).Scan(&chatSessionID); err != nil {
+		t.Fatalf("setup: create chat session: %v", err)
+	}
+	t.Cleanup(func() { testPool.Exec(ctx, `DELETE FROM chat_session WHERE id = $1`, chatSessionID) })
+
+	var taskID string
+	if err := testPool.QueryRow(ctx, `
+		INSERT INTO agent_task_queue (
+			agent_id, runtime_id, chat_session_id,
+			status, priority, started_at, completed_at
+		)
+		VALUES ($1, $2, $3, 'cancelled', 0, now(), now())
+		RETURNING id
+	`, agentID, runtimeID, chatSessionID).Scan(&taskID); err != nil {
+		t.Fatalf("setup: create cancelled chat task: %v", err)
+	}
+	t.Cleanup(func() { testPool.Exec(ctx, `DELETE FROM agent_task_queue WHERE id = $1`, taskID) })
+
+	if _, err := testPool.Exec(ctx, `
+		INSERT INTO agent_task_queue (agent_id, runtime_id, chat_session_id, status, priority)
+		VALUES ($1, $2, $3, 'queued', 0)
+	`, agentID, runtimeID, chatSessionID); err != nil {
+		t.Fatalf("setup: create queued follow-up: %v", err)
+	}
+
+	conn, err := testPool.Acquire(ctx)
+	if err != nil {
+		t.Fatalf("acquire blocking conn: %v", err)
+	}
+	defer conn.Release()
+	blockTx, err := conn.Begin(ctx)
+	if err != nil {
+		t.Fatalf("begin blocking tx: %v", err)
+	}
+	if _, err := blockTx.Exec(ctx, `SELECT id FROM chat_session WHERE id = $1 FOR UPDATE`, chatSessionID); err != nil {
+		t.Fatalf("lock chat session: %v", err)
+	}
+
+	pinDone := make(chan int, 1)
+	go func() {
+		w := httptest.NewRecorder()
+		req := newDaemonTokenRequest(http.MethodPost, "/api/daemon/tasks/"+taskID+"/session",
+			map[string]any{"session_id": "turn2-session", "work_dir": "/tmp/turn2-workdir"},
+			testWorkspaceID, daemonID)
+		rctx := chi.NewRouteContext()
+		rctx.URLParams.Add("taskId", taskID)
+		req = req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, rctx))
+		testHandler.PinTaskSession(w, req)
+		pinDone <- w.Code
+	}()
+
+	// Blocked on the chat row: the task row must not be carrying the new
+	// session yet, or a follow-up could claim the gap and resume turn1.
+	time.Sleep(300 * time.Millisecond)
+	var pinnedSoFar *string
+	if err := testPool.QueryRow(ctx, `SELECT session_id FROM agent_task_queue WHERE id = $1`, taskID).Scan(&pinnedSoFar); err != nil {
+		t.Fatalf("read task session: %v", err)
+	}
+	if pinnedSoFar != nil {
+		t.Fatalf("task carried session %q while the pointer advance was still blocked", *pinnedSoFar)
+	}
+
+	if err := blockTx.Rollback(ctx); err != nil {
+		t.Fatalf("release chat session lock: %v", err)
+	}
+	if code := <-pinDone; code != http.StatusNoContent {
+		t.Fatalf("PinTaskSession: expected 204, got %d", code)
+	}
+
+	task := claimTaskForRuntimeGuard(t, runtimeID, daemonID)
+	if task.PriorSessionID != "turn2-session" {
+		t.Fatalf("PriorSessionID = %q, want turn2-session", task.PriorSessionID)
+	}
+}
+
+// TestCancelTask_TakesChatSessionLockBeforeTask pins the lock order the repo
+// documents (chat_session -> agent_task_queue, see LockChatSessionForTask).
+// DeleteChatSession locks the session and then cascades into agent_task_queue;
+// a cancel that took the task row first and only then reached for the session
+// deadlocks against it — PostgreSQL aborts one side with 40P01 and runInTx has
+// no deadlock retry.
+//
+// With the session held from another connection, a cancel must be waiting for
+// the SESSION, having taken no lock on the task row yet — which a FOR UPDATE
+// NOWAIT probe can prove.
+func TestCancelTask_TakesChatSessionLockBeforeTask(t *testing.T) {
+	if testHandler == nil {
+		t.Skip("database not available")
+	}
+
+	ctx := context.Background()
+	agentID, runtimeID, _ := createRuntimeGuardAgent(t, ctx)
+
+	var chatSessionID string
+	if err := testPool.QueryRow(ctx, `
+		INSERT INTO chat_session (
+			workspace_id, agent_id, creator_id, title,
+			session_id, work_dir, runtime_id
+		)
+		VALUES ($1, $2, $3, 'cancel lock order', 'turn1-session', '/tmp/turn1-workdir', $4)
+		RETURNING id
+	`, testWorkspaceID, agentID, testUserID, runtimeID).Scan(&chatSessionID); err != nil {
+		t.Fatalf("setup: create chat session: %v", err)
+	}
+	t.Cleanup(func() { testPool.Exec(ctx, `DELETE FROM chat_session WHERE id = $1`, chatSessionID) })
+
+	var taskID string
+	if err := testPool.QueryRow(ctx, `
+		INSERT INTO agent_task_queue (
+			agent_id, runtime_id, chat_session_id,
+			status, priority, started_at, session_id, work_dir
+		)
+		VALUES ($1, $2, $3, 'running', 0, now(), 'turn2-session', '/tmp/turn2-workdir')
+		RETURNING id
+	`, agentID, runtimeID, chatSessionID).Scan(&taskID); err != nil {
+		t.Fatalf("setup: create running chat task: %v", err)
+	}
+	t.Cleanup(func() { testPool.Exec(ctx, `DELETE FROM agent_task_queue WHERE id = $1`, taskID) })
+
+	// Stand in for DeleteChatSession's first statement.
+	deleter, err := testPool.Acquire(ctx)
+	if err != nil {
+		t.Fatalf("acquire deleter conn: %v", err)
+	}
+	defer deleter.Release()
+	deleterTx, err := deleter.Begin(ctx)
+	if err != nil {
+		t.Fatalf("begin deleter tx: %v", err)
+	}
+	if _, err := deleterTx.Exec(ctx, `SELECT id FROM chat_session WHERE id = $1 FOR UPDATE`, chatSessionID); err != nil {
+		t.Fatalf("lock chat session: %v", err)
+	}
+
+	cancelDone := make(chan error, 1)
+	go func() {
+		_, err := testHandler.TaskService.CancelTaskWithResult(context.Background(), parseUUID(taskID),
+			service.CancelTaskOptions{ClientSupportsDraftRestore: true})
+		cancelDone <- err
+	}()
+	time.Sleep(300 * time.Millisecond)
+
+	// The deleter's next step would be cancelling the session's tasks. If the
+	// cancel already holds that row, the two are in a cycle.
+	probe, err := testPool.Acquire(ctx)
+	if err != nil {
+		t.Fatalf("acquire probe conn: %v", err)
+	}
+	defer probe.Release()
+	probeTx, err := probe.Begin(ctx)
+	if err != nil {
+		t.Fatalf("begin probe tx: %v", err)
+	}
+	var probed string
+	if err := probeTx.QueryRow(ctx,
+		`SELECT id FROM agent_task_queue WHERE id = $1 FOR UPDATE NOWAIT`, taskID,
+	).Scan(&probed); err != nil {
+		probeTx.Rollback(ctx)
+		deleterTx.Rollback(ctx)
+		<-cancelDone
+		t.Fatalf("cancel holds the task row while waiting for the chat session — inverted lock order deadlocks against DeleteChatSession: %v", err)
+	}
+	if err := probeTx.Rollback(ctx); err != nil {
+		t.Fatalf("release probe: %v", err)
+	}
+
+	if err := deleterTx.Rollback(ctx); err != nil {
+		t.Fatalf("release chat session lock: %v", err)
+	}
+	if err := <-cancelDone; err != nil {
+		t.Fatalf("cancel task: %v", err)
+	}
+	if got := taskStatus(t, taskID); got != "cancelled" {
+		t.Fatalf("task status = %q, want cancelled", got)
+	}
+}
+
+// TestCancelTask_ConcurrentWithChatSessionDelete runs the two paths against
+// each other for real: whoever wins, neither may come back with a deadlock.
+func TestCancelTask_ConcurrentWithChatSessionDelete(t *testing.T) {
+	if testHandler == nil {
+		t.Skip("database not available")
+	}
+
+	ctx := context.Background()
+	agentID, runtimeID, _ := createRuntimeGuardAgent(t, ctx)
+
+	for i := 0; i < 12; i++ {
+		var chatSessionID string
+		if err := testPool.QueryRow(ctx, `
+			INSERT INTO chat_session (
+				workspace_id, agent_id, creator_id, title,
+				session_id, work_dir, runtime_id
+			)
+			VALUES ($1, $2, $3, 'cancel vs delete', 'turn1-session', '/tmp/turn1-workdir', $4)
+			RETURNING id
+		`, testWorkspaceID, agentID, testUserID, runtimeID).Scan(&chatSessionID); err != nil {
+			t.Fatalf("setup: create chat session: %v", err)
+		}
+
+		var taskID string
+		if err := testPool.QueryRow(ctx, `
+			INSERT INTO agent_task_queue (
+				agent_id, runtime_id, chat_session_id,
+				status, priority, started_at, session_id, work_dir
+			)
+			VALUES ($1, $2, $3, 'running', 0, now(), 'turn2-session', '/tmp/turn2-workdir')
+			RETURNING id
+		`, agentID, runtimeID, chatSessionID).Scan(&taskID); err != nil {
+			t.Fatalf("setup: create running chat task: %v", err)
+		}
+
+		start := make(chan struct{})
+		cancelErr := make(chan error, 1)
+		deleteErr := make(chan error, 1)
+		go func() {
+			<-start
+			_, err := testHandler.TaskService.CancelTaskWithResult(context.Background(), parseUUID(taskID),
+				service.CancelTaskOptions{ClientSupportsDraftRestore: true})
+			cancelErr <- err
+		}()
+		go func() {
+			<-start
+			deleteErr <- deleteChatSessionLikeHandler(context.Background(), chatSessionID)
+		}()
+		close(start)
+
+		if err := <-cancelErr; err != nil && isDeadlock(err) {
+			t.Fatalf("iteration %d: cancel deadlocked against chat delete: %v", i, err)
+		}
+		if err := <-deleteErr; err != nil && isDeadlock(err) {
+			t.Fatalf("iteration %d: chat delete deadlocked against cancel: %v", i, err)
+		}
+
+		testPool.Exec(ctx, `DELETE FROM agent_task_queue WHERE id = $1`, taskID)
+		testPool.Exec(ctx, `DELETE FROM chat_session WHERE id = $1`, chatSessionID)
+	}
+}
+
+// deleteChatSessionLikeHandler replays DeleteChatSession's locking protocol
+// (lock the session, then cascade into agent_task_queue) so the concurrency
+// test exercises the real order without going through HTTP auth.
+func deleteChatSessionLikeHandler(ctx context.Context, chatSessionID string) error {
+	tx, err := testHandler.TxStarter.Begin(ctx)
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback(ctx)
+	qtx := testHandler.Queries.WithTx(tx)
+
+	id := parseUUID(chatSessionID)
+	if _, err := qtx.LockChatSessionForDelete(ctx, id); err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil
+		}
+		return err
+	}
+	if _, err := qtx.CancelAgentTasksByChatSession(ctx, id); err != nil {
+		return err
+	}
+	return tx.Commit(ctx)
+}
+
+func isDeadlock(err error) bool {
+	var pgErr *pgconn.PgError
+	return errors.As(err, &pgErr) && pgErr.Code == "40P01"
 }
 
 // pinTaskSessionViaAPI drives the real daemon endpoint so the test covers the

--- a/server/internal/handler/daemon_claim_cancelled_session_test.go
+++ b/server/internal/handler/daemon_claim_cancelled_session_test.go
@@ -338,29 +338,29 @@ func TestCancelTask_PointerAdvanceIsAtomicWithStatusFlip(t *testing.T) {
 	}
 
 	// Hold the chat row from another connection so the pointer write blocks.
-	conn, err := testPool.Acquire(ctx)
-	if err != nil {
-		t.Fatalf("acquire blocking conn: %v", err)
-	}
-	defer conn.Release()
-	blockTx, err := conn.Begin(ctx)
-	if err != nil {
-		t.Fatalf("begin blocking tx: %v", err)
-	}
+	blockTx := beginWarmedTx(t, ctx)
 	if _, err := blockTx.Exec(ctx, `SELECT id FROM chat_session WHERE id = $1 FOR UPDATE`, chatSessionID); err != nil {
 		t.Fatalf("lock chat session: %v", err)
 	}
 
 	cancelDone := make(chan error, 1)
 	go func() {
-		_, err := testHandler.TaskService.CancelTaskWithResult(context.Background(), parseUUID(taskID),
+		callCtx, cancel := raceCtx()
+		defer cancel()
+		_, err := testHandler.TaskService.CancelTaskWithResult(callCtx, parseUUID(taskID),
 			service.CancelTaskOptions{ClientSupportsDraftRestore: true})
 		cancelDone <- err
 	}()
 
 	// While the pointer write is blocked, the cancellation must not be visible.
+	// Read on the holding transaction: it is READ COMMITTED, so it still sees
+	// whatever the cancel has committed, and it needs no new lock to do so.
 	time.Sleep(300 * time.Millisecond)
-	if got := taskStatus(t, taskID); got == "cancelled" {
+	var statusDuringBlock string
+	if err := blockTx.QueryRow(ctx, `SELECT status FROM agent_task_queue WHERE id = $1`, taskID).Scan(&statusDuringBlock); err != nil {
+		t.Fatalf("read task status: %v", err)
+	}
+	if statusDuringBlock == "cancelled" {
 		t.Fatalf("task became cancelled while the pointer advance was still blocked: a follow-up claimed in this gap resumes the stale session")
 	}
 
@@ -554,15 +554,7 @@ func TestPinTaskSession_PointerAdvanceIsAtomicWithPin(t *testing.T) {
 		t.Fatalf("setup: create queued follow-up: %v", err)
 	}
 
-	conn, err := testPool.Acquire(ctx)
-	if err != nil {
-		t.Fatalf("acquire blocking conn: %v", err)
-	}
-	defer conn.Release()
-	blockTx, err := conn.Begin(ctx)
-	if err != nil {
-		t.Fatalf("begin blocking tx: %v", err)
-	}
+	blockTx := beginWarmedTx(t, ctx)
 	if _, err := blockTx.Exec(ctx, `SELECT id FROM chat_session WHERE id = $1 FOR UPDATE`, chatSessionID); err != nil {
 		t.Fatalf("lock chat session: %v", err)
 	}
@@ -573,18 +565,23 @@ func TestPinTaskSession_PointerAdvanceIsAtomicWithPin(t *testing.T) {
 		req := newDaemonTokenRequest(http.MethodPost, "/api/daemon/tasks/"+taskID+"/session",
 			map[string]any{"session_id": "turn2-session", "work_dir": "/tmp/turn2-workdir"},
 			testWorkspaceID, daemonID)
+		// Derive from the request's own context so the daemon identity survives;
+		// the timeout only bounds a stall.
+		reqCtx, cancel := context.WithTimeout(req.Context(), 30*time.Second)
+		defer cancel()
 		rctx := chi.NewRouteContext()
 		rctx.URLParams.Add("taskId", taskID)
-		req = req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, rctx))
+		req = req.WithContext(context.WithValue(reqCtx, chi.RouteCtxKey, rctx))
 		testHandler.PinTaskSession(w, req)
 		pinDone <- w.Code
 	}()
 
 	// Blocked on the chat row: the task row must not be carrying the new
-	// session yet, or a follow-up could claim the gap and resume turn1.
+	// session yet, or a follow-up could claim the gap and resume turn1. Read on
+	// the holding transaction so this needs no new table lock.
 	time.Sleep(300 * time.Millisecond)
 	var pinnedSoFar *string
-	if err := testPool.QueryRow(ctx, `SELECT session_id FROM agent_task_queue WHERE id = $1`, taskID).Scan(&pinnedSoFar); err != nil {
+	if err := blockTx.QueryRow(ctx, `SELECT session_id FROM agent_task_queue WHERE id = $1`, taskID).Scan(&pinnedSoFar); err != nil {
 		t.Fatalf("read task session: %v", err)
 	}
 	if pinnedSoFar != nil {
@@ -648,23 +645,21 @@ func TestCancelTask_TakesChatSessionLockBeforeTask(t *testing.T) {
 	}
 	t.Cleanup(func() { testPool.Exec(ctx, `DELETE FROM agent_task_queue WHERE id = $1`, taskID) })
 
+	// Both transactions are opened and warmed BEFORE anything is locked: a
+	// connection taken mid-hold can queue behind a sibling package's DDL.
+	deleterTx := beginWarmedTx(t, ctx)
+	probeTx := beginWarmedTx(t, ctx)
+
 	// Stand in for DeleteChatSession's first statement.
-	deleter, err := testPool.Acquire(ctx)
-	if err != nil {
-		t.Fatalf("acquire deleter conn: %v", err)
-	}
-	defer deleter.Release()
-	deleterTx, err := deleter.Begin(ctx)
-	if err != nil {
-		t.Fatalf("begin deleter tx: %v", err)
-	}
 	if _, err := deleterTx.Exec(ctx, `SELECT id FROM chat_session WHERE id = $1 FOR UPDATE`, chatSessionID); err != nil {
 		t.Fatalf("lock chat session: %v", err)
 	}
 
 	cancelDone := make(chan error, 1)
 	go func() {
-		_, err := testHandler.TaskService.CancelTaskWithResult(context.Background(), parseUUID(taskID),
+		callCtx, cancel := raceCtx()
+		defer cancel()
+		_, err := testHandler.TaskService.CancelTaskWithResult(callCtx, parseUUID(taskID),
 			service.CancelTaskOptions{ClientSupportsDraftRestore: true})
 		cancelDone <- err
 	}()
@@ -672,15 +667,6 @@ func TestCancelTask_TakesChatSessionLockBeforeTask(t *testing.T) {
 
 	// The deleter's next step would be cancelling the session's tasks. If the
 	// cancel already holds that row, the two are in a cycle.
-	probe, err := testPool.Acquire(ctx)
-	if err != nil {
-		t.Fatalf("acquire probe conn: %v", err)
-	}
-	defer probe.Release()
-	probeTx, err := probe.Begin(ctx)
-	if err != nil {
-		t.Fatalf("begin probe tx: %v", err)
-	}
 	var probed string
 	if err := probeTx.QueryRow(ctx,
 		`SELECT id FROM agent_task_queue WHERE id = $1 FOR UPDATE NOWAIT`, taskID,
@@ -767,6 +753,199 @@ func TestCancelTask_ConcurrentWithChatSessionDelete(t *testing.T) {
 	}
 }
 
+// TestTerminalReports_TakeChatSessionLockBeforeTask extends the lock-order
+// invariant to the terminal reports. Cancel and the pin take chat_session
+// first; CompleteTask / FailTask writing the task row first is the other half
+// of the same crossing pair, and the daemon issues its pin from a goroutine
+// independent of the report, so the two really do overlap.
+//
+// Same proof as the cancel case: with the session held elsewhere, the report
+// must be waiting on the SESSION and holding no lock on the task row.
+func TestTerminalReports_TakeChatSessionLockBeforeTask(t *testing.T) {
+	if testHandler == nil {
+		t.Skip("database not available")
+	}
+
+	report := map[string]func(taskID string) error{
+		"complete": func(taskID string) error {
+			callCtx, cancel := raceCtx()
+			defer cancel()
+			_, err := testHandler.TaskService.CompleteTask(callCtx, parseUUID(taskID),
+				[]byte(`"done"`), "turn2-session", "/tmp/turn2-workdir", false, "")
+			return err
+		},
+		"fail": func(taskID string) error {
+			callCtx, cancel := raceCtx()
+			defer cancel()
+			_, err := testHandler.TaskService.FailTask(callCtx, parseUUID(taskID),
+				"boom", "turn2-session", "/tmp/turn2-workdir", "agent_error", false, "")
+			return err
+		},
+	}
+
+	for name, run := range report {
+		t.Run(name, func(t *testing.T) {
+			ctx := context.Background()
+			agentID, runtimeID, _ := createRuntimeGuardAgent(t, ctx)
+
+			var chatSessionID string
+			if err := testPool.QueryRow(ctx, `
+				INSERT INTO chat_session (
+					workspace_id, agent_id, creator_id, title,
+					session_id, work_dir, runtime_id
+				)
+				VALUES ($1, $2, $3, 'report lock order', 'turn1-session', '/tmp/turn1-workdir', $4)
+				RETURNING id
+			`, testWorkspaceID, agentID, testUserID, runtimeID).Scan(&chatSessionID); err != nil {
+				t.Fatalf("setup: create chat session: %v", err)
+			}
+			t.Cleanup(func() { testPool.Exec(ctx, `DELETE FROM chat_session WHERE id = $1`, chatSessionID) })
+
+			var taskID string
+			if err := testPool.QueryRow(ctx, `
+				INSERT INTO agent_task_queue (
+					agent_id, runtime_id, chat_session_id, status, priority, started_at
+				)
+				VALUES ($1, $2, $3, 'running', 0, now())
+				RETURNING id
+			`, agentID, runtimeID, chatSessionID).Scan(&taskID); err != nil {
+				t.Fatalf("setup: create running chat task: %v", err)
+			}
+			t.Cleanup(func() { testPool.Exec(ctx, `DELETE FROM agent_task_queue WHERE id = $1`, taskID) })
+
+			// Opened and warmed before anything is locked; see beginWarmedTx.
+			holderTx := beginWarmedTx(t, ctx)
+			probeTx := beginWarmedTx(t, ctx)
+
+			if _, err := holderTx.Exec(ctx, `SELECT id FROM chat_session WHERE id = $1 FOR UPDATE`, chatSessionID); err != nil {
+				t.Fatalf("lock chat session: %v", err)
+			}
+
+			reportDone := make(chan error, 1)
+			go func() { reportDone <- run(taskID) }()
+			time.Sleep(300 * time.Millisecond)
+
+			var probed string
+			if err := probeTx.QueryRow(ctx,
+				`SELECT id FROM agent_task_queue WHERE id = $1 FOR UPDATE NOWAIT`, taskID,
+			).Scan(&probed); err != nil {
+				probeTx.Rollback(ctx)
+				holderTx.Rollback(ctx)
+				<-reportDone
+				t.Fatalf("%s holds the task row while waiting for the chat session — inverted lock order deadlocks against cancel/pin: %v", name, err)
+			}
+			probeTx.Rollback(ctx)
+
+			if err := holderTx.Rollback(ctx); err != nil {
+				t.Fatalf("release chat session lock: %v", err)
+			}
+			if err := <-reportDone; err != nil {
+				t.Fatalf("%s task: %v", name, err)
+			}
+		})
+	}
+}
+
+// TestCancelAndPin_ConcurrentWithTerminalReport runs the crossing pairs for
+// real. Whoever wins, neither side may come back with a deadlock.
+func TestCancelAndPin_ConcurrentWithTerminalReport(t *testing.T) {
+	if testHandler == nil {
+		t.Skip("database not available")
+	}
+
+	ctx := context.Background()
+	agentID, runtimeID, daemonID := createRuntimeGuardAgent(t, ctx)
+
+	// cancel vs complete, and the daemon's independent pin goroutine vs fail.
+	contenders := []struct {
+		name  string
+		first func(taskID string) error
+		other func(taskID string) error
+	}{
+		{
+			name: "cancel-vs-complete",
+			first: func(taskID string) error {
+				_, err := testHandler.TaskService.CancelTaskWithResult(context.Background(), parseUUID(taskID),
+					service.CancelTaskOptions{ClientSupportsDraftRestore: true})
+				return err
+			},
+			other: func(taskID string) error {
+				_, err := testHandler.TaskService.CompleteTask(context.Background(), parseUUID(taskID),
+					[]byte(`"done"`), "turn2-session", "/tmp/turn2-workdir", false, "")
+				return err
+			},
+		},
+		{
+			name: "pin-vs-fail",
+			first: func(taskID string) error {
+				w := httptest.NewRecorder()
+				req := newDaemonTokenRequest(http.MethodPost, "/api/daemon/tasks/"+taskID+"/session",
+					map[string]any{"session_id": "turn2-session", "work_dir": "/tmp/turn2-workdir"},
+					testWorkspaceID, daemonID)
+				rctx := chi.NewRouteContext()
+				rctx.URLParams.Add("taskId", taskID)
+				req = req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, rctx))
+				testHandler.PinTaskSession(w, req)
+				if w.Code != http.StatusNoContent {
+					return errors.New("pin failed: " + w.Body.String())
+				}
+				return nil
+			},
+			other: func(taskID string) error {
+				_, err := testHandler.TaskService.FailTask(context.Background(), parseUUID(taskID),
+					"boom", "turn3-session", "/tmp/turn3-workdir", "agent_error", false, "")
+				return err
+			},
+		},
+	}
+
+	for _, c := range contenders {
+		t.Run(c.name, func(t *testing.T) {
+			for i := 0; i < 12; i++ {
+				var chatSessionID string
+				if err := testPool.QueryRow(ctx, `
+					INSERT INTO chat_session (
+						workspace_id, agent_id, creator_id, title,
+						session_id, work_dir, runtime_id
+					)
+					VALUES ($1, $2, $3, 'race', 'turn1-session', '/tmp/turn1-workdir', $4)
+					RETURNING id
+				`, testWorkspaceID, agentID, testUserID, runtimeID).Scan(&chatSessionID); err != nil {
+					t.Fatalf("setup: create chat session: %v", err)
+				}
+
+				var taskID string
+				if err := testPool.QueryRow(ctx, `
+					INSERT INTO agent_task_queue (
+						agent_id, runtime_id, chat_session_id, status, priority, started_at
+					)
+					VALUES ($1, $2, $3, 'running', 0, now())
+					RETURNING id
+				`, agentID, runtimeID, chatSessionID).Scan(&taskID); err != nil {
+					t.Fatalf("setup: create running chat task: %v", err)
+				}
+
+				start := make(chan struct{})
+				firstErr := make(chan error, 1)
+				otherErr := make(chan error, 1)
+				go func() { <-start; firstErr <- c.first(taskID) }()
+				go func() { <-start; otherErr <- c.other(taskID) }()
+				close(start)
+
+				if err := <-firstErr; err != nil && isDeadlock(err) {
+					t.Fatalf("iteration %d: deadlock: %v", i, err)
+				}
+				if err := <-otherErr; err != nil && isDeadlock(err) {
+					t.Fatalf("iteration %d: deadlock: %v", i, err)
+				}
+
+				testPool.Exec(ctx, `DELETE FROM agent_task_queue WHERE chat_session_id = $1`, chatSessionID)
+				testPool.Exec(ctx, `DELETE FROM chat_session WHERE id = $1`, chatSessionID)
+			}
+		})
+	}
+}
+
 // deleteChatSessionLikeHandler replays DeleteChatSession's locking protocol
 // (lock the session, then cascade into agent_task_queue) so the concurrency
 // test exercises the real order without going through HTTP auth.
@@ -794,6 +973,55 @@ func deleteChatSessionLikeHandler(ctx context.Context, chatSessionID string) err
 func isDeadlock(err error) bool {
 	var pgErr *pgconn.PgError
 	return errors.As(err, &pgErr) && pgErr.Code == "40P01"
+}
+
+// beginWarmedTx opens a transaction that is safe to hold a row lock in for the
+// length of a test.
+//
+// The tests below block a writer by holding a row, then read other rows to
+// observe what the writer has and has not committed. Doing those reads on a
+// FRESH pooled connection is what made them hang: the whole suite shares one
+// database, a sibling package can queue DDL (ACCESS EXCLUSIVE) against these
+// tables at any moment, and once that request is pending every later
+// ACCESS SHARE request queues behind it — including ours, while we are still
+// holding the row the DDL is waiting for. Nothing here is a cycle PostgreSQL
+// can break, so the package sat until the 10-minute test timeout.
+//
+// Taking both table locks up front means this transaction never asks for a new
+// one while holding a row, and the reads then ride the same connection.
+func beginWarmedTx(t *testing.T, ctx context.Context) pgx.Tx {
+	t.Helper()
+
+	conn, err := testPool.Acquire(ctx)
+	if err != nil {
+		t.Fatalf("acquire conn: %v", err)
+	}
+	tx, err := conn.Begin(ctx)
+	if err != nil {
+		conn.Release()
+		t.Fatalf("begin tx: %v", err)
+	}
+	t.Cleanup(func() {
+		// Both are no-ops when the test already released them explicitly.
+		tx.Rollback(context.Background())
+		conn.Release()
+	})
+	for _, warm := range []string{
+		`SELECT 1 FROM chat_session LIMIT 1`,
+		`SELECT 1 FROM agent_task_queue LIMIT 1`,
+	} {
+		if _, err := tx.Exec(ctx, warm); err != nil {
+			t.Fatalf("warm table locks: %v", err)
+		}
+	}
+	return tx
+}
+
+// raceCtx bounds a racing call so a stalled connection surfaces as a test
+// failure with a real message instead of wedging the package until the
+// 10-minute timeout. Far above the sub-second these paths actually take.
+func raceCtx() (context.Context, context.CancelFunc) {
+	return context.WithTimeout(context.Background(), 30*time.Second)
 }
 
 // pinTaskSessionViaAPI drives the real daemon endpoint so the test covers the

--- a/server/internal/handler/daemon_claim_cancelled_session_test.go
+++ b/server/internal/handler/daemon_claim_cancelled_session_test.go
@@ -2,8 +2,12 @@ package handler
 
 import (
 	"context"
+	"net/http"
+	"net/http/httptest"
 	"testing"
+	"time"
 
+	"github.com/go-chi/chi/v5"
 	"github.com/jackc/pgx/v5/pgtype"
 
 	"github.com/multica-ai/multica/server/internal/service"
@@ -276,6 +280,247 @@ func TestCancelTask_KeepsChatPointerWhenNoSessionEstablished(t *testing.T) {
 	}
 	if sessionID != "turn1-session" {
 		t.Fatalf("chat_session.session_id = %q, want turn1-session (a session-less cancel must not touch the pointer)", sessionID)
+	}
+}
+
+// TestCancelTask_PointerAdvanceIsAtomicWithStatusFlip is the adversarial case:
+// a follow-up is already queued when the user cancels. If the status flip
+// committed before the pointer advance, that follow-up could be claimed in the
+// gap and resume the PREVIOUS turn's session — the exact failure this change
+// exists to remove.
+//
+// The chat row is locked from another connection so the pointer write blocks
+// mid-cancel; while it is blocked, no other connection may observe the task as
+// cancelled.
+func TestCancelTask_PointerAdvanceIsAtomicWithStatusFlip(t *testing.T) {
+	if testHandler == nil {
+		t.Skip("database not available")
+	}
+
+	ctx := context.Background()
+	agentID, runtimeID, daemonID := createRuntimeGuardAgent(t, ctx)
+
+	var chatSessionID string
+	if err := testPool.QueryRow(ctx, `
+		INSERT INTO chat_session (
+			workspace_id, agent_id, creator_id, title,
+			session_id, work_dir, runtime_id
+		)
+		VALUES ($1, $2, $3, 'cancel atomicity', 'turn1-session', '/tmp/turn1-workdir', $4)
+		RETURNING id
+	`, testWorkspaceID, agentID, testUserID, runtimeID).Scan(&chatSessionID); err != nil {
+		t.Fatalf("setup: create chat session: %v", err)
+	}
+	t.Cleanup(func() { testPool.Exec(ctx, `DELETE FROM chat_session WHERE id = $1`, chatSessionID) })
+
+	var taskID string
+	if err := testPool.QueryRow(ctx, `
+		INSERT INTO agent_task_queue (
+			agent_id, runtime_id, chat_session_id,
+			status, priority, started_at, session_id, work_dir
+		)
+		VALUES ($1, $2, $3, 'running', 0, now(), 'turn2-session', '/tmp/turn2-workdir')
+		RETURNING id
+	`, agentID, runtimeID, chatSessionID).Scan(&taskID); err != nil {
+		t.Fatalf("setup: create running chat task: %v", err)
+	}
+	t.Cleanup(func() { testPool.Exec(ctx, `DELETE FROM agent_task_queue WHERE id = $1`, taskID) })
+
+	// The follow-up the user queued while the turn was still running.
+	if _, err := testPool.Exec(ctx, `
+		INSERT INTO agent_task_queue (agent_id, runtime_id, chat_session_id, status, priority)
+		VALUES ($1, $2, $3, 'queued', 0)
+	`, agentID, runtimeID, chatSessionID); err != nil {
+		t.Fatalf("setup: create queued follow-up: %v", err)
+	}
+
+	// Hold the chat row from another connection so the pointer write blocks.
+	conn, err := testPool.Acquire(ctx)
+	if err != nil {
+		t.Fatalf("acquire blocking conn: %v", err)
+	}
+	defer conn.Release()
+	blockTx, err := conn.Begin(ctx)
+	if err != nil {
+		t.Fatalf("begin blocking tx: %v", err)
+	}
+	if _, err := blockTx.Exec(ctx, `SELECT id FROM chat_session WHERE id = $1 FOR UPDATE`, chatSessionID); err != nil {
+		t.Fatalf("lock chat session: %v", err)
+	}
+
+	cancelDone := make(chan error, 1)
+	go func() {
+		_, err := testHandler.TaskService.CancelTaskWithResult(context.Background(), parseUUID(taskID),
+			service.CancelTaskOptions{ClientSupportsDraftRestore: true})
+		cancelDone <- err
+	}()
+
+	// While the pointer write is blocked, the cancellation must not be visible.
+	time.Sleep(300 * time.Millisecond)
+	if got := taskStatus(t, taskID); got == "cancelled" {
+		t.Fatalf("task became cancelled while the pointer advance was still blocked: a follow-up claimed in this gap resumes the stale session")
+	}
+
+	if err := blockTx.Rollback(ctx); err != nil {
+		t.Fatalf("release chat session lock: %v", err)
+	}
+	if err := <-cancelDone; err != nil {
+		t.Fatalf("cancel task: %v", err)
+	}
+
+	var pointer string
+	if err := testPool.QueryRow(ctx, `SELECT session_id FROM chat_session WHERE id = $1`, chatSessionID).Scan(&pointer); err != nil {
+		t.Fatalf("read chat session pointer: %v", err)
+	}
+	if pointer != "turn2-session" {
+		t.Fatalf("chat_session.session_id = %q, want turn2-session", pointer)
+	}
+	if got := taskStatus(t, taskID); got != "cancelled" {
+		t.Fatalf("task status = %q, want cancelled", got)
+	}
+
+	// The queued follow-up now claims onto the cancelled turn's session.
+	task := claimTaskForRuntimeGuard(t, runtimeID, daemonID)
+	if task.PriorSessionID != "turn2-session" {
+		t.Fatalf("PriorSessionID = %q, want turn2-session", task.PriorSessionID)
+	}
+}
+
+// TestPinTaskSession_LateCancelledPinAdvancesChatPointer covers the other
+// ordering: the cancel wins the race and finds no session to publish (a Codex
+// pin is still waiting on its rollout), then the pin lands on the cancelled row.
+// Filling the task row is not enough — an existing chat pointer shadows it, so
+// the follow-up would still resume the previous turn.
+func TestPinTaskSession_LateCancelledPinAdvancesChatPointer(t *testing.T) {
+	if testHandler == nil {
+		t.Skip("database not available")
+	}
+
+	ctx := context.Background()
+	agentID, runtimeID, daemonID := createRuntimeGuardAgent(t, ctx)
+
+	var chatSessionID string
+	if err := testPool.QueryRow(ctx, `
+		INSERT INTO chat_session (
+			workspace_id, agent_id, creator_id, title,
+			session_id, work_dir, runtime_id
+		)
+		VALUES ($1, $2, $3, 'late pin', 'turn1-session', '/tmp/turn1-workdir', $4)
+		RETURNING id
+	`, testWorkspaceID, agentID, testUserID, runtimeID).Scan(&chatSessionID); err != nil {
+		t.Fatalf("setup: create chat session: %v", err)
+	}
+	t.Cleanup(func() { testPool.Exec(ctx, `DELETE FROM chat_session WHERE id = $1`, chatSessionID) })
+
+	// Cancelled before the backend revealed its session.
+	var taskID string
+	if err := testPool.QueryRow(ctx, `
+		INSERT INTO agent_task_queue (
+			agent_id, runtime_id, chat_session_id,
+			status, priority, started_at, completed_at
+		)
+		VALUES ($1, $2, $3, 'cancelled', 0, now(), now())
+		RETURNING id
+	`, agentID, runtimeID, chatSessionID).Scan(&taskID); err != nil {
+		t.Fatalf("setup: create cancelled chat task: %v", err)
+	}
+	t.Cleanup(func() { testPool.Exec(ctx, `DELETE FROM agent_task_queue WHERE id = $1`, taskID) })
+
+	pinTaskSessionViaAPI(t, taskID, daemonID, "turn2-session", "/tmp/turn2-workdir")
+
+	if _, err := testPool.Exec(ctx, `
+		INSERT INTO agent_task_queue (agent_id, runtime_id, chat_session_id, status, priority)
+		VALUES ($1, $2, $3, 'queued', 0)
+	`, agentID, runtimeID, chatSessionID); err != nil {
+		t.Fatalf("setup: create follow-up chat task: %v", err)
+	}
+
+	task := claimTaskForRuntimeGuard(t, runtimeID, daemonID)
+	if task.PriorSessionID != "turn2-session" {
+		t.Fatalf("PriorSessionID = %q, want turn2-session (a late pin must not stay shadowed by the previous turn's pointer)", task.PriorSessionID)
+	}
+	if task.PriorWorkDir != "/tmp/turn2-workdir" {
+		t.Fatalf("PriorWorkDir = %q, want /tmp/turn2-workdir", task.PriorWorkDir)
+	}
+}
+
+// TestPinTaskSession_LateCancelledPinYieldsToNewerTurn is the guard on the
+// path above: once a NEWER turn has recorded a session of its own, a straggler
+// pin for the cancelled turn must not drag the conversation backwards.
+func TestPinTaskSession_LateCancelledPinYieldsToNewerTurn(t *testing.T) {
+	if testHandler == nil {
+		t.Skip("database not available")
+	}
+
+	ctx := context.Background()
+	agentID, runtimeID, daemonID := createRuntimeGuardAgent(t, ctx)
+
+	var chatSessionID string
+	if err := testPool.QueryRow(ctx, `
+		INSERT INTO chat_session (
+			workspace_id, agent_id, creator_id, title,
+			session_id, work_dir, runtime_id
+		)
+		VALUES ($1, $2, $3, 'late pin yields', 'turn3-session', '/tmp/turn3-workdir', $4)
+		RETURNING id
+	`, testWorkspaceID, agentID, testUserID, runtimeID).Scan(&chatSessionID); err != nil {
+		t.Fatalf("setup: create chat session: %v", err)
+	}
+	t.Cleanup(func() { testPool.Exec(ctx, `DELETE FROM chat_session WHERE id = $1`, chatSessionID) })
+
+	var cancelledID string
+	if err := testPool.QueryRow(ctx, `
+		INSERT INTO agent_task_queue (
+			agent_id, runtime_id, chat_session_id,
+			status, priority, created_at, started_at, completed_at
+		)
+		VALUES ($1, $2, $3, 'cancelled', 0, now() - interval '10 minutes',
+		        now() - interval '10 minutes', now() - interval '9 minutes')
+		RETURNING id
+	`, agentID, runtimeID, chatSessionID).Scan(&cancelledID); err != nil {
+		t.Fatalf("setup: create cancelled chat task: %v", err)
+	}
+	t.Cleanup(func() { testPool.Exec(ctx, `DELETE FROM agent_task_queue WHERE id = $1`, cancelledID) })
+
+	// A newer turn already ran to completion and owns the pointer.
+	if _, err := testPool.Exec(ctx, `
+		INSERT INTO agent_task_queue (
+			agent_id, runtime_id, chat_session_id,
+			status, priority, created_at, started_at, completed_at, session_id, work_dir
+		)
+		VALUES ($1, $2, $3, 'completed', 0, now() - interval '2 minutes',
+		        now() - interval '2 minutes', now() - interval '1 minutes',
+		        'turn3-session', '/tmp/turn3-workdir')
+	`, agentID, runtimeID, chatSessionID); err != nil {
+		t.Fatalf("setup: create newer completed task: %v", err)
+	}
+
+	pinTaskSessionViaAPI(t, cancelledID, daemonID, "turn2-session", "/tmp/turn2-workdir")
+
+	var pointer string
+	if err := testPool.QueryRow(ctx, `SELECT session_id FROM chat_session WHERE id = $1`, chatSessionID).Scan(&pointer); err != nil {
+		t.Fatalf("read chat session pointer: %v", err)
+	}
+	if pointer != "turn3-session" {
+		t.Fatalf("chat_session.session_id = %q, want turn3-session (a straggler pin must not rewind a newer turn)", pointer)
+	}
+}
+
+// pinTaskSessionViaAPI drives the real daemon endpoint so the test covers the
+// handler wiring, not just the query.
+func pinTaskSessionViaAPI(t *testing.T, taskID, daemonID, sessionID, workDir string) {
+	t.Helper()
+
+	w := httptest.NewRecorder()
+	req := newDaemonTokenRequest(http.MethodPost, "/api/daemon/tasks/"+taskID+"/session",
+		map[string]any{"session_id": sessionID, "work_dir": workDir}, testWorkspaceID, daemonID)
+	rctx := chi.NewRouteContext()
+	rctx.URLParams.Add("taskId", taskID)
+	req = req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, rctx))
+
+	testHandler.PinTaskSession(w, req)
+	if w.Code != http.StatusNoContent {
+		t.Fatalf("PinTaskSession: expected 204, got %d: %s", w.Code, w.Body.String())
 	}
 }
 

--- a/server/internal/handler/daemon_claim_cancelled_session_test.go
+++ b/server/internal/handler/daemon_claim_cancelled_session_test.go
@@ -1,0 +1,351 @@
+package handler
+
+import (
+	"context"
+	"testing"
+
+	"github.com/jackc/pgx/v5/pgtype"
+
+	"github.com/multica-ai/multica/server/internal/service"
+	db "github.com/multica-ai/multica/server/pkg/db/generated"
+)
+
+// GH #6340: a user stops a chat turn the agent had already started answering,
+// then sends the next message and the agent replies with no memory of the
+// conversation.
+//
+// The cancelled turn's provider session is real — the daemon pinned it onto the
+// task row mid-flight and cancellation keeps it there — but nothing on the
+// cancel path could hand it back: the resume lookups only considered
+// 'completed' / 'failed' rows, and the chat-level resume pointer is written by
+// CompleteTask / FailTask, neither of which runs for a cancelled task. These
+// tests pin both halves, plus the guards that must survive them.
+
+// TestClaimTask_ChatResumesCancelledTurnSession is the reported scenario at its
+// worst: the FIRST turn of a chat is cancelled, so there is no earlier session
+// to fall back to and the next turn used to start completely cold.
+func TestClaimTask_ChatResumesCancelledTurnSession(t *testing.T) {
+	if testHandler == nil {
+		t.Skip("database not available")
+	}
+
+	ctx := context.Background()
+	agentID, runtimeID, daemonID := createRuntimeGuardAgent(t, ctx)
+
+	// A brand-new chat: no resume pointer of its own yet.
+	var chatSessionID string
+	if err := testPool.QueryRow(ctx, `
+		INSERT INTO chat_session (workspace_id, agent_id, creator_id, title)
+		VALUES ($1, $2, $3, 'cancelled first turn')
+		RETURNING id
+	`, testWorkspaceID, agentID, testUserID).Scan(&chatSessionID); err != nil {
+		t.Fatalf("setup: create chat session: %v", err)
+	}
+	t.Cleanup(func() { testPool.Exec(ctx, `DELETE FROM chat_session WHERE id = $1`, chatSessionID) })
+
+	if _, err := testPool.Exec(ctx, `
+		INSERT INTO agent_task_queue (
+			agent_id, runtime_id, chat_session_id,
+			status, priority, started_at, completed_at, session_id, work_dir
+		)
+		VALUES ($1, $2, $3, 'cancelled', 0, now(), now(), 'cancelled-turn-session', '/tmp/cancelled-turn-workdir')
+	`, agentID, runtimeID, chatSessionID); err != nil {
+		t.Fatalf("setup: create cancelled chat task: %v", err)
+	}
+	if _, err := testPool.Exec(ctx, `
+		INSERT INTO agent_task_queue (agent_id, runtime_id, chat_session_id, status, priority)
+		VALUES ($1, $2, $3, 'queued', 0)
+	`, agentID, runtimeID, chatSessionID); err != nil {
+		t.Fatalf("setup: create follow-up chat task: %v", err)
+	}
+
+	task := claimTaskForRuntimeGuard(t, runtimeID, daemonID)
+	if task.PriorSessionID != "cancelled-turn-session" {
+		t.Fatalf("PriorSessionID = %q, want cancelled-turn-session (the cancelled turn's context must carry over)", task.PriorSessionID)
+	}
+	if task.PriorWorkDir != "/tmp/cancelled-turn-workdir" {
+		t.Fatalf("PriorWorkDir = %q, want /tmp/cancelled-turn-workdir", task.PriorWorkDir)
+	}
+}
+
+// TestClaimTask_ChatCancelledSessionStaysExcludedWhenRetired pins the guard the
+// change must not weaken: a session some run deliberately abandoned stays
+// unreachable even when a cancelled row still points at it.
+func TestClaimTask_ChatCancelledSessionStaysExcludedWhenRetired(t *testing.T) {
+	if testHandler == nil {
+		t.Skip("database not available")
+	}
+
+	ctx := context.Background()
+	agentID, runtimeID, daemonID := createRuntimeGuardAgent(t, ctx)
+
+	var chatSessionID string
+	if err := testPool.QueryRow(ctx, `
+		INSERT INTO chat_session (workspace_id, agent_id, creator_id, title)
+		VALUES ($1, $2, $3, 'cancelled retired turn')
+		RETURNING id
+	`, testWorkspaceID, agentID, testUserID).Scan(&chatSessionID); err != nil {
+		t.Fatalf("setup: create chat session: %v", err)
+	}
+	t.Cleanup(func() { testPool.Exec(ctx, `DELETE FROM chat_session WHERE id = $1`, chatSessionID) })
+
+	if _, err := testPool.Exec(ctx, `
+		INSERT INTO agent_task_queue (
+			agent_id, runtime_id, chat_session_id,
+			status, priority, started_at, completed_at, session_id, work_dir
+		)
+		VALUES ($1, $2, $3, 'cancelled', 0, now() - interval '5 minutes', now() - interval '4 minutes',
+		        'retired-cancelled-session', '/tmp/retired-cancelled-workdir')
+	`, agentID, runtimeID, chatSessionID); err != nil {
+		t.Fatalf("setup: create cancelled chat task: %v", err)
+	}
+	// A later run resumed that session, could not use it, and retired it.
+	if _, err := testPool.Exec(ctx, `
+		INSERT INTO agent_task_queue (
+			agent_id, runtime_id, chat_session_id,
+			status, priority, started_at, completed_at, retired_session_id
+		)
+		VALUES ($1, $2, $3, 'completed', 0, now() - interval '2 minutes', now() - interval '1 minutes',
+		        'retired-cancelled-session')
+	`, agentID, runtimeID, chatSessionID); err != nil {
+		t.Fatalf("setup: create retiring chat task: %v", err)
+	}
+	if _, err := testPool.Exec(ctx, `
+		INSERT INTO agent_task_queue (agent_id, runtime_id, chat_session_id, status, priority)
+		VALUES ($1, $2, $3, 'queued', 0)
+	`, agentID, runtimeID, chatSessionID); err != nil {
+		t.Fatalf("setup: create follow-up chat task: %v", err)
+	}
+
+	task := claimTaskForRuntimeGuard(t, runtimeID, daemonID)
+	if task.PriorSessionID != "" {
+		t.Fatalf("PriorSessionID = %q, want empty (a retired session stays retired even when a cancelled row names it)", task.PriorSessionID)
+	}
+}
+
+// TestClaimTask_IssueResumesCancelledTaskSession is the issue-side half: stop a
+// run, comment again, and the follow-up keeps the stopped run's context.
+func TestClaimTask_IssueResumesCancelledTaskSession(t *testing.T) {
+	if testHandler == nil {
+		t.Skip("database not available")
+	}
+
+	ctx := context.Background()
+	agentID, runtimeID, daemonID := createRuntimeGuardAgent(t, ctx)
+
+	var issueID string
+	if err := testPool.QueryRow(ctx, `
+		INSERT INTO issue (workspace_id, title, status, priority, creator_id, creator_type, number, position)
+		VALUES ($1, 'cancelled issue run fixture', 'in_progress', 'none', $2, 'member', 86340, 0)
+		RETURNING id
+	`, testWorkspaceID, testUserID).Scan(&issueID); err != nil {
+		t.Fatalf("setup: create issue: %v", err)
+	}
+	t.Cleanup(func() { testPool.Exec(ctx, `DELETE FROM issue WHERE id = $1`, issueID) })
+
+	if _, err := testPool.Exec(ctx, `
+		INSERT INTO agent_task_queue (
+			agent_id, runtime_id, issue_id,
+			status, priority, started_at, completed_at, session_id, work_dir
+		)
+		VALUES ($1, $2, $3, 'cancelled', 0, now(), now(), 'cancelled-issue-session', '/tmp/cancelled-issue-workdir')
+	`, agentID, runtimeID, issueID); err != nil {
+		t.Fatalf("setup: create cancelled issue task: %v", err)
+	}
+	if _, err := testPool.Exec(ctx, `
+		INSERT INTO agent_task_queue (agent_id, runtime_id, issue_id, status, priority)
+		VALUES ($1, $2, $3, 'queued', 0)
+	`, agentID, runtimeID, issueID); err != nil {
+		t.Fatalf("setup: create follow-up issue task: %v", err)
+	}
+
+	task := claimTaskForRuntimeGuard(t, runtimeID, daemonID)
+	if task.PriorSessionID != "cancelled-issue-session" {
+		t.Fatalf("PriorSessionID = %q, want cancelled-issue-session", task.PriorSessionID)
+	}
+	if task.PriorWorkDir != "/tmp/cancelled-issue-workdir" {
+		t.Fatalf("PriorWorkDir = %q, want /tmp/cancelled-issue-workdir", task.PriorWorkDir)
+	}
+}
+
+// TestCancelTask_AdvancesChatSessionResumePointer covers the pointer half. The
+// claim handler reads chat_session.session_id FIRST, so on a chat that already
+// has history a stale pointer would still rewind past the cancelled turn on any
+// provider that mints a new session id per resume.
+func TestCancelTask_AdvancesChatSessionResumePointer(t *testing.T) {
+	if testHandler == nil {
+		t.Skip("database not available")
+	}
+
+	ctx := context.Background()
+	agentID, runtimeID, _ := createRuntimeGuardAgent(t, ctx)
+
+	var chatSessionID string
+	if err := testPool.QueryRow(ctx, `
+		INSERT INTO chat_session (
+			workspace_id, agent_id, creator_id, title,
+			session_id, work_dir, runtime_id
+		)
+		VALUES ($1, $2, $3, 'cancel advances pointer', 'turn1-session', '/tmp/turn1-workdir', $4)
+		RETURNING id
+	`, testWorkspaceID, agentID, testUserID, runtimeID).Scan(&chatSessionID); err != nil {
+		t.Fatalf("setup: create chat session: %v", err)
+	}
+	t.Cleanup(func() { testPool.Exec(ctx, `DELETE FROM chat_session WHERE id = $1`, chatSessionID) })
+
+	// Turn 2 is running and has already pinned its own session id.
+	var taskID string
+	if err := testPool.QueryRow(ctx, `
+		INSERT INTO agent_task_queue (
+			agent_id, runtime_id, chat_session_id,
+			status, priority, started_at, session_id, work_dir
+		)
+		VALUES ($1, $2, $3, 'running', 0, now(), 'turn2-session', '/tmp/turn2-workdir')
+		RETURNING id
+	`, agentID, runtimeID, chatSessionID).Scan(&taskID); err != nil {
+		t.Fatalf("setup: create running chat task: %v", err)
+	}
+	t.Cleanup(func() { testPool.Exec(ctx, `DELETE FROM agent_task_queue WHERE id = $1`, taskID) })
+
+	if _, err := testHandler.TaskService.CancelTaskWithResult(ctx, parseUUID(taskID),
+		service.CancelTaskOptions{ClientSupportsDraftRestore: true}); err != nil {
+		t.Fatalf("cancel task: %v", err)
+	}
+
+	var sessionID, workDir, pointerRuntimeID string
+	if err := testPool.QueryRow(ctx, `
+		SELECT session_id, work_dir, runtime_id FROM chat_session WHERE id = $1
+	`, chatSessionID).Scan(&sessionID, &workDir, &pointerRuntimeID); err != nil {
+		t.Fatalf("read chat session pointer: %v", err)
+	}
+	if sessionID != "turn2-session" {
+		t.Fatalf("chat_session.session_id = %q, want turn2-session (the cancelled turn owns the newest session)", sessionID)
+	}
+	if workDir != "/tmp/turn2-workdir" {
+		t.Fatalf("chat_session.work_dir = %q, want /tmp/turn2-workdir", workDir)
+	}
+	if pointerRuntimeID != runtimeID {
+		t.Fatalf("chat_session.runtime_id = %q, want %q (the claim guard only honours its own runtime's pointer)", pointerRuntimeID, runtimeID)
+	}
+}
+
+// TestCancelTask_KeepsChatPointerWhenNoSessionEstablished guards the other
+// direction: a turn cancelled before the backend revealed a session must leave
+// the existing pointer alone rather than blanking the chat's memory.
+func TestCancelTask_KeepsChatPointerWhenNoSessionEstablished(t *testing.T) {
+	if testHandler == nil {
+		t.Skip("database not available")
+	}
+
+	ctx := context.Background()
+	agentID, runtimeID, _ := createRuntimeGuardAgent(t, ctx)
+
+	var chatSessionID string
+	if err := testPool.QueryRow(ctx, `
+		INSERT INTO chat_session (
+			workspace_id, agent_id, creator_id, title,
+			session_id, work_dir, runtime_id
+		)
+		VALUES ($1, $2, $3, 'cancel keeps pointer', 'turn1-session', '/tmp/turn1-workdir', $4)
+		RETURNING id
+	`, testWorkspaceID, agentID, testUserID, runtimeID).Scan(&chatSessionID); err != nil {
+		t.Fatalf("setup: create chat session: %v", err)
+	}
+	t.Cleanup(func() { testPool.Exec(ctx, `DELETE FROM chat_session WHERE id = $1`, chatSessionID) })
+
+	var taskID string
+	if err := testPool.QueryRow(ctx, `
+		INSERT INTO agent_task_queue (agent_id, runtime_id, chat_session_id, status, priority, started_at)
+		VALUES ($1, $2, $3, 'running', 0, now())
+		RETURNING id
+	`, agentID, runtimeID, chatSessionID).Scan(&taskID); err != nil {
+		t.Fatalf("setup: create running chat task: %v", err)
+	}
+	t.Cleanup(func() { testPool.Exec(ctx, `DELETE FROM agent_task_queue WHERE id = $1`, taskID) })
+
+	if _, err := testHandler.TaskService.CancelTaskWithResult(ctx, parseUUID(taskID),
+		service.CancelTaskOptions{ClientSupportsDraftRestore: true}); err != nil {
+		t.Fatalf("cancel task: %v", err)
+	}
+
+	var sessionID string
+	if err := testPool.QueryRow(ctx, `
+		SELECT session_id FROM chat_session WHERE id = $1
+	`, chatSessionID).Scan(&sessionID); err != nil {
+		t.Fatalf("read chat session pointer: %v", err)
+	}
+	if sessionID != "turn1-session" {
+		t.Fatalf("chat_session.session_id = %q, want turn1-session (a session-less cancel must not touch the pointer)", sessionID)
+	}
+}
+
+// TestPinTaskSession_LateCancelledPin covers the mid-flight pin racing the
+// cancel: it may fill an EMPTY session slot on the row it belongs to, but must
+// never overwrite a session a terminal report already recorded.
+func TestPinTaskSession_LateCancelledPin(t *testing.T) {
+	if testHandler == nil {
+		t.Skip("database not available")
+	}
+
+	ctx := context.Background()
+	agentID, runtimeID, _ := createRuntimeGuardAgent(t, ctx)
+
+	newTask := func(status, sessionID string) string {
+		t.Helper()
+		var id string
+		var session any
+		if sessionID != "" {
+			session = sessionID
+		}
+		if err := testPool.QueryRow(ctx, `
+			INSERT INTO agent_task_queue (
+				agent_id, runtime_id, status, priority, started_at, completed_at, session_id
+			)
+			VALUES ($1, $2, $3, 0, now(), now(), $4)
+			RETURNING id
+		`, agentID, runtimeID, status, session).Scan(&id); err != nil {
+			t.Fatalf("setup: create %s task: %v", status, err)
+		}
+		t.Cleanup(func() { testPool.Exec(context.Background(), `DELETE FROM agent_task_queue WHERE id = $1`, id) })
+		return id
+	}
+	readSession := func(taskID string) string {
+		t.Helper()
+		var sessionID *string
+		if err := testPool.QueryRow(ctx, `SELECT session_id FROM agent_task_queue WHERE id = $1`, taskID).Scan(&sessionID); err != nil {
+			t.Fatalf("read task session: %v", err)
+		}
+		if sessionID == nil {
+			return ""
+		}
+		return *sessionID
+	}
+
+	pin := func(taskID, sessionID string) {
+		t.Helper()
+		if err := testHandler.Queries.UpdateAgentTaskSession(ctx, db.UpdateAgentTaskSessionParams{
+			ID:        parseUUID(taskID),
+			SessionID: pgtype.Text{String: sessionID, Valid: true},
+		}); err != nil {
+			t.Fatalf("pin session: %v", err)
+		}
+	}
+
+	cancelledEmpty := newTask("cancelled", "")
+	pin(cancelledEmpty, "late-pinned-session")
+	if got := readSession(cancelledEmpty); got != "late-pinned-session" {
+		t.Fatalf("cancelled task session_id = %q, want late-pinned-session", got)
+	}
+
+	cancelledPinned := newTask("cancelled", "pinned-session")
+	pin(cancelledPinned, "straggler-session")
+	if got := readSession(cancelledPinned); got != "pinned-session" {
+		t.Fatalf("cancelled task session_id = %q, want pinned-session (an occupied slot is never overwritten)", got)
+	}
+
+	completed := newTask("completed", "reported-session")
+	pin(completed, "straggler-session")
+	if got := readSession(completed); got != "reported-session" {
+		t.Fatalf("completed task session_id = %q, want reported-session (a terminal report must win)", got)
+	}
+}

--- a/server/internal/handler/task_lifecycle.go
+++ b/server/internal/handler/task_lifecycle.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 
 	"github.com/go-chi/chi/v5"
+	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgtype"
 	"github.com/multica-ai/multica/server/internal/service"
 	db "github.com/multica-ai/multica/server/pkg/db/generated"
@@ -89,23 +90,52 @@ func (h *Handler) PinTaskSession(w http.ResponseWriter, r *http.Request) {
 	if req.WorkDir != "" {
 		params.WorkDir = pgtype.Text{String: req.WorkDir, Valid: true}
 	}
-	if err := h.Queries.UpdateAgentTaskSession(r.Context(), params); err != nil {
-		slog.Warn("pin-session failed", "task_id", taskID, "error", err)
-		writeError(w, http.StatusInternalServerError, "pin session failed")
-		return
-	}
 	// The pin can arrive after the user has already cancelled the run — it is
 	// asynchronous, and for Codex it waits for the rollout to reach the store.
 	// The cancel transaction then found no session to publish, so the chat's
 	// resume pointer is still on the previous turn and would shadow the session
-	// this pin just recorded (the claim handler reads the pointer before the
-	// GetLastChatTaskSession fallback). Advancing here closes that half of
-	// GH #6340; the statement itself re-reads the row, ignores anything that is
-	// not a cancelled chat task, and refuses to move the pointer when a newer
-	// turn already owns a session — so a straggler pin cannot drag the
-	// conversation backwards. Best-effort: the pin itself already succeeded.
-	if err := h.Queries.AdvanceCancelledChatSessionPointer(r.Context(), parseUUID(taskID)); err != nil {
+	// this pin is about to record (the claim handler reads the pointer before
+	// the GetLastChatTaskSession fallback). Advancing it here closes that half
+	// of GH #6340.
+	//
+	// Both writes commit together. Landing the session on the task row first and
+	// the pointer second leaves the same window the cancel path had: the row
+	// already names the new session while the pointer still names the previous
+	// turn, and a follow-up claimed in between resumes the older one. The lock
+	// comes first for the same reason it does in CancelTaskWithResult —
+	// chat_session -> agent_task_queue is the global order, and ErrNoRows simply
+	// means there is no session to lock or advance.
+	tx, err := h.TxStarter.Begin(r.Context())
+	if err != nil {
+		slog.Warn("pin-session failed to start tx", "task_id", taskID, "error", err)
+		writeError(w, http.StatusInternalServerError, "pin session failed")
+		return
+	}
+	defer tx.Rollback(r.Context())
+	qtx := h.Queries.WithTx(tx)
+
+	if _, err := qtx.LockChatSessionForTask(r.Context(), params.ID); err != nil && !errors.Is(err, pgx.ErrNoRows) {
+		slog.Warn("pin-session failed to lock chat session", "task_id", taskID, "error", err)
+		writeError(w, http.StatusInternalServerError, "pin session failed")
+		return
+	}
+	if err := qtx.UpdateAgentTaskSession(r.Context(), params); err != nil {
+		slog.Warn("pin-session failed", "task_id", taskID, "error", err)
+		writeError(w, http.StatusInternalServerError, "pin session failed")
+		return
+	}
+	// The statement re-reads the row, ignores anything that is not a cancelled
+	// chat task, and refuses to move the pointer when a newer turn already owns
+	// a session — so a straggler pin cannot drag the conversation backwards.
+	if err := qtx.AdvanceCancelledChatSessionPointer(r.Context(), params.ID); err != nil {
 		slog.Warn("advance cancelled chat session pointer failed", "task_id", taskID, "error", err)
+		writeError(w, http.StatusInternalServerError, "pin session failed")
+		return
+	}
+	if err := tx.Commit(r.Context()); err != nil {
+		slog.Warn("pin-session commit failed", "task_id", taskID, "error", err)
+		writeError(w, http.StatusInternalServerError, "pin session failed")
+		return
 	}
 	w.WriteHeader(http.StatusNoContent)
 }

--- a/server/internal/handler/task_lifecycle.go
+++ b/server/internal/handler/task_lifecycle.go
@@ -94,6 +94,19 @@ func (h *Handler) PinTaskSession(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusInternalServerError, "pin session failed")
 		return
 	}
+	// The pin can arrive after the user has already cancelled the run — it is
+	// asynchronous, and for Codex it waits for the rollout to reach the store.
+	// The cancel transaction then found no session to publish, so the chat's
+	// resume pointer is still on the previous turn and would shadow the session
+	// this pin just recorded (the claim handler reads the pointer before the
+	// GetLastChatTaskSession fallback). Advancing here closes that half of
+	// GH #6340; the statement itself re-reads the row, ignores anything that is
+	// not a cancelled chat task, and refuses to move the pointer when a newer
+	// turn already owns a session — so a straggler pin cannot drag the
+	// conversation backwards. Best-effort: the pin itself already succeeded.
+	if err := h.Queries.AdvanceCancelledChatSessionPointer(r.Context(), parseUUID(taskID)); err != nil {
+		slog.Warn("advance cancelled chat session pointer failed", "task_id", taskID, "error", err)
+	}
 	w.WriteHeader(http.StatusNoContent)
 }
 

--- a/server/internal/service/task.go
+++ b/server/internal/service/task.go
@@ -1986,15 +1986,8 @@ func (s *TaskService) CancelTaskWithResult(ctx context.Context, taskID pgtype.UU
 	// concurrently rather than a stale in-memory copy.
 	var task db.AgentTaskQueue
 	err := s.runInTx(ctx, func(qtx *db.Queries) error {
-		// chat_session -> agent_task_queue is the global lock order (see
-		// LockChatSessionForTask in chat.sql), and adding the pointer write gave
-		// this transaction two rows to hold instead of one. Taking the session
-		// first is what keeps it from deadlocking against DeleteChatSession,
-		// which locks the session and then cascades into agent_task_queue.
-		// ErrNoRows means there is no session to lock — a non-chat task, or one
-		// whose session was already deleted — and nothing to advance later.
-		if _, err := qtx.LockChatSessionForTask(ctx, taskID); err != nil && !errors.Is(err, pgx.ErrNoRows) {
-			return fmt.Errorf("lock chat session for cancel: %w", err)
+		if err := lockChatSessionForTaskWrite(ctx, qtx, taskID); err != nil {
+			return err
 		}
 		cancelled, err := qtx.CancelAgentTask(ctx, taskID)
 		if err != nil {
@@ -2034,6 +2027,32 @@ func (s *TaskService) CancelTaskWithResult(ctx context.Context, taskID pgtype.UU
 	}, nil
 }
 
+// lockChatSessionForTaskWrite takes the chat_session row a task belongs to. It
+// must be the FIRST statement of any transaction that ends up holding both that
+// session row and the task's own row, which is every terminal-state path a chat
+// task has: complete, fail, cancel, the cancelled-turn finalize, and the
+// daemon's mid-flight pin.
+//
+// chat_session -> agent_task_queue is the repo-wide order (see
+// LockChatSessionForTask in chat.sql). DeleteChatSession and
+// FinalizeDeferredCancelledChat already took it; the terminal reports did not,
+// because they only ever wrote the task row first and the session second and
+// nothing else contended for both. Once the cancel and pin paths started
+// holding the session row too, "task first" and "session first" existed side by
+// side and any crossing pair could deadlock — PostgreSQL aborts one with 40P01
+// and runInTx has no retry. There is no per-path fix for that: either every
+// writer agrees or none of them are safe.
+//
+// ErrNoRows means there is nothing to lock — a non-chat task, or one whose
+// session was already deleted (the FK NULLs the column) — and the caller then
+// has no session write to protect either.
+func lockChatSessionForTaskWrite(ctx context.Context, qtx *db.Queries, taskID pgtype.UUID) error {
+	if _, err := qtx.LockChatSessionForTask(ctx, taskID); err != nil && !errors.Is(err, pgx.ErrNoRows) {
+		return fmt.Errorf("lock chat session for task write: %w", err)
+	}
+	return nil
+}
+
 // chatInputOwnerID resolves the id the task's user-message input batch is
 // keyed on: chat_input_task_id when set (auto-retry clones inherit their
 // parent's, so provenance checks reach the parent's sealed messages), falling
@@ -2051,6 +2070,12 @@ func (s *TaskService) finalizeCancelledChatMessage(ctx context.Context, task db.
 	}
 	var cancelled *CancelledChatMessageResult
 	if err := s.runInTx(ctx, func(qtx *db.Queries) error {
+		// Same protocol as every other terminal path: this transaction marks the
+		// task row and then writes chat_message rows, whose FK takes a KEY SHARE
+		// lock on the session — two rows again, so it takes the session first.
+		if err := lockChatSessionForTaskWrite(ctx, qtx, task.ID); err != nil {
+			return err
+		}
 		messages, err := qtx.ListTaskMessages(ctx, task.ID)
 		if err != nil {
 			return fmt.Errorf("list cancelled chat task messages: %w", err)
@@ -2902,6 +2927,9 @@ func (s *TaskService) CompleteTask(ctx context.Context, taskID pgtype.UUID, resu
 	// only after the transaction commits.
 	var chatAssistantMsg *db.ChatMessage
 	if err := s.runInTx(ctx, func(qtx *db.Queries) error {
+		if err := lockChatSessionForTaskWrite(ctx, qtx, taskID); err != nil {
+			return err
+		}
 		t, err := qtx.CompleteAgentTask(ctx, db.CompleteAgentTaskParams{
 			ID:                    taskID,
 			Result:                result,
@@ -3339,6 +3367,9 @@ func (s *TaskService) FailTask(ctx context.Context, taskID pgtype.UUID, errMsg, 
 	var task db.AgentTaskQueue
 	var retried *db.AgentTaskQueue
 	if err := s.runInTx(ctx, func(qtx *db.Queries) error {
+		if err := lockChatSessionForTaskWrite(ctx, qtx, taskID); err != nil {
+			return err
+		}
 		t, err := qtx.FailAgentTask(ctx, db.FailAgentTaskParams{
 			ID:                    taskID,
 			Error:                 pgtype.Text{String: errMsg, Valid: true},

--- a/server/internal/service/task.go
+++ b/server/internal/service/task.go
@@ -1990,6 +1990,7 @@ func (s *TaskService) CancelTaskWithResult(ctx context.Context, taskID pgtype.UU
 
 	slog.Info("task cancelled", "task_id", util.UUIDToString(task.ID), "issue_id", util.UUIDToString(task.IssueID))
 	s.captureTaskCancelled(ctx, task)
+	s.recordCancelledChatSessionPointer(ctx, task)
 	cancelledChatMessage := s.finalizeCancelledChatMessage(ctx, task, opts)
 
 	// Reconcile agent status
@@ -2003,6 +2004,49 @@ func (s *TaskService) CancelTaskWithResult(ctx context.Context, taskID pgtype.UU
 		Task:                 task,
 		CancelledChatMessage: cancelledChatMessage,
 	}, nil
+}
+
+// recordCancelledChatSessionPointer moves the chat's resume pointer onto the
+// session the cancelled turn was running (GH #6340).
+//
+// Cancellation is the one terminal state that never reports back: the daemon
+// discards its result and only sends a cancel-ack, so neither CompleteTask nor
+// FailTask — the only writers of chat_session.session_id — ever runs. The turn's
+// session survives on the task row (the daemon pinned it mid-flight) and
+// GetLastChatTaskSession now finds it, but that fallback is only consulted when
+// the pointer is EMPTY. On a chat that already has history the stale pointer
+// wins, and for any provider that mints a new session id per resume that means
+// rewinding to the previous turn and dropping the cancelled exchange — which the
+// user can still see in the transcript.
+//
+// Writing here rather than in the deferred finalize path is deliberate: this
+// runs while the cancelled task is still the newest turn on the session, so it
+// cannot land after a later turn's terminal write and un-advance the pointer.
+// It also means the empty-transcript judgment (#5219) has not been made yet, so
+// this cannot distinguish "cancelled with a partial reply" from "cancelled
+// before the first token" — and should not try to. Both leave the same
+// transcript on the provider side, and pointing at it is still strictly closer
+// to the conversation than rewinding to the turn before.
+//
+// runtime_id moves with the session because the claim handler only honours a
+// pointer its own runtime produced; a row without one cannot say which runtime
+// the session belongs to, so it is left alone rather than pairing a new session
+// with a stale runtime.
+func (s *TaskService) recordCancelledChatSessionPointer(ctx context.Context, task db.AgentTaskQueue) {
+	if !task.ChatSessionID.Valid || !task.SessionID.Valid || task.SessionID.String == "" || !task.RuntimeID.Valid {
+		return
+	}
+	if err := s.Queries.UpdateChatSessionSession(ctx, db.UpdateChatSessionSessionParams{
+		ID:        task.ChatSessionID,
+		SessionID: task.SessionID,
+		WorkDir:   task.WorkDir,
+		RuntimeID: task.RuntimeID,
+	}); err != nil {
+		slog.Warn("failed to record cancelled chat session pointer",
+			"task_id", util.UUIDToString(task.ID),
+			"chat_session_id", util.UUIDToString(task.ChatSessionID),
+			"error", err)
+	}
 }
 
 // chatInputOwnerID resolves the id the task's user-message input batch is

--- a/server/internal/service/task.go
+++ b/server/internal/service/task.go
@@ -1976,7 +1976,26 @@ func (s *TaskService) CancelTask(ctx context.Context, taskID pgtype.UUID) (*db.A
 // CancelTaskWithResult cancels a single task and returns any chat-specific
 // cleanup result needed by user-facing callers.
 func (s *TaskService) CancelTaskWithResult(ctx context.Context, taskID pgtype.UUID, opts CancelTaskOptions) (*CancelTaskResult, error) {
-	task, err := s.Queries.CancelAgentTask(ctx, taskID)
+	// The status flip and the chat resume-pointer advance commit together. Split
+	// across two statements, the `cancelled` status becomes visible to every
+	// other connection while the pointer still names the PREVIOUS turn's
+	// session — and a follow-up the user had already queued can be claimed in
+	// that gap and resume the older session, which is the bug this change is
+	// supposed to remove (GH #6340). AdvanceCancelledChatSessionPointer reads
+	// the row this transaction just wrote, so it also sees a session pinned
+	// concurrently rather than a stale in-memory copy.
+	var task db.AgentTaskQueue
+	err := s.runInTx(ctx, func(qtx *db.Queries) error {
+		cancelled, err := qtx.CancelAgentTask(ctx, taskID)
+		if err != nil {
+			return err
+		}
+		task = cancelled
+		if !cancelled.ChatSessionID.Valid {
+			return nil
+		}
+		return qtx.AdvanceCancelledChatSessionPointer(ctx, cancelled.ID)
+	})
 	if errors.Is(err, pgx.ErrNoRows) {
 		existing, err := s.Queries.GetAgentTask(ctx, taskID)
 		if err != nil {
@@ -1990,7 +2009,6 @@ func (s *TaskService) CancelTaskWithResult(ctx context.Context, taskID pgtype.UU
 
 	slog.Info("task cancelled", "task_id", util.UUIDToString(task.ID), "issue_id", util.UUIDToString(task.IssueID))
 	s.captureTaskCancelled(ctx, task)
-	s.recordCancelledChatSessionPointer(ctx, task)
 	cancelledChatMessage := s.finalizeCancelledChatMessage(ctx, task, opts)
 
 	// Reconcile agent status
@@ -2004,49 +2022,6 @@ func (s *TaskService) CancelTaskWithResult(ctx context.Context, taskID pgtype.UU
 		Task:                 task,
 		CancelledChatMessage: cancelledChatMessage,
 	}, nil
-}
-
-// recordCancelledChatSessionPointer moves the chat's resume pointer onto the
-// session the cancelled turn was running (GH #6340).
-//
-// Cancellation is the one terminal state that never reports back: the daemon
-// discards its result and only sends a cancel-ack, so neither CompleteTask nor
-// FailTask — the only writers of chat_session.session_id — ever runs. The turn's
-// session survives on the task row (the daemon pinned it mid-flight) and
-// GetLastChatTaskSession now finds it, but that fallback is only consulted when
-// the pointer is EMPTY. On a chat that already has history the stale pointer
-// wins, and for any provider that mints a new session id per resume that means
-// rewinding to the previous turn and dropping the cancelled exchange — which the
-// user can still see in the transcript.
-//
-// Writing here rather than in the deferred finalize path is deliberate: this
-// runs while the cancelled task is still the newest turn on the session, so it
-// cannot land after a later turn's terminal write and un-advance the pointer.
-// It also means the empty-transcript judgment (#5219) has not been made yet, so
-// this cannot distinguish "cancelled with a partial reply" from "cancelled
-// before the first token" — and should not try to. Both leave the same
-// transcript on the provider side, and pointing at it is still strictly closer
-// to the conversation than rewinding to the turn before.
-//
-// runtime_id moves with the session because the claim handler only honours a
-// pointer its own runtime produced; a row without one cannot say which runtime
-// the session belongs to, so it is left alone rather than pairing a new session
-// with a stale runtime.
-func (s *TaskService) recordCancelledChatSessionPointer(ctx context.Context, task db.AgentTaskQueue) {
-	if !task.ChatSessionID.Valid || !task.SessionID.Valid || task.SessionID.String == "" || !task.RuntimeID.Valid {
-		return
-	}
-	if err := s.Queries.UpdateChatSessionSession(ctx, db.UpdateChatSessionSessionParams{
-		ID:        task.ChatSessionID,
-		SessionID: task.SessionID,
-		WorkDir:   task.WorkDir,
-		RuntimeID: task.RuntimeID,
-	}); err != nil {
-		slog.Warn("failed to record cancelled chat session pointer",
-			"task_id", util.UUIDToString(task.ID),
-			"chat_session_id", util.UUIDToString(task.ChatSessionID),
-			"error", err)
-	}
 }
 
 // chatInputOwnerID resolves the id the task's user-message input batch is

--- a/server/internal/service/task.go
+++ b/server/internal/service/task.go
@@ -1986,6 +1986,16 @@ func (s *TaskService) CancelTaskWithResult(ctx context.Context, taskID pgtype.UU
 	// concurrently rather than a stale in-memory copy.
 	var task db.AgentTaskQueue
 	err := s.runInTx(ctx, func(qtx *db.Queries) error {
+		// chat_session -> agent_task_queue is the global lock order (see
+		// LockChatSessionForTask in chat.sql), and adding the pointer write gave
+		// this transaction two rows to hold instead of one. Taking the session
+		// first is what keeps it from deadlocking against DeleteChatSession,
+		// which locks the session and then cascades into agent_task_queue.
+		// ErrNoRows means there is no session to lock — a non-chat task, or one
+		// whose session was already deleted — and nothing to advance later.
+		if _, err := qtx.LockChatSessionForTask(ctx, taskID); err != nil && !errors.Is(err, pgx.ErrNoRows) {
+			return fmt.Errorf("lock chat session for cancel: %w", err)
+		}
 		cancelled, err := qtx.CancelAgentTask(ctx, taskID)
 		if err != nil {
 			return err

--- a/server/pkg/db/generated/agent.sql.go
+++ b/server/pkg/db/generated/agent.sql.go
@@ -2868,13 +2868,13 @@ WITH retired_sessions AS (
     FROM agent_task_queue t
     WHERE t.agent_id = $1 AND t.issue_id = $2
       AND t.session_id IS NOT NULL
-      AND t.status IN ('completed', 'failed')
+      AND t.status IN ('completed', 'failed', 'cancelled')
     ORDER BY t.session_id, COALESCE(t.completed_at, t.started_at, t.dispatched_at, t.created_at) DESC
 )
 SELECT session_id, work_dir, runtime_id FROM latest_per_session
 WHERE session_id NOT IN (SELECT session_id FROM retired_sessions)
   AND (
-    status = 'completed'
+    status IN ('completed', 'cancelled')
     OR (
       status = 'failed'
       AND COALESCE(failure_reason, '') NOT IN ('iteration_limit', 'agent_fallback_message', 'api_invalid_request', 'codex_semantic_inactivity', 'agent_error.context_overflow')
@@ -2901,13 +2901,21 @@ type GetLastTaskSessionRow struct {
 
 // Returns the session_id and work_dir from the most recent task for a given
 // (agent_id, issue_id) pair, used for session resumption on the auto-retry
-// path. We accept both 'completed' and 'failed' tasks: a failed task may
-// have established a real agent session before crashing (orphaned by a
+// path. We accept 'completed', 'failed' AND 'cancelled' tasks: a failed task
+// may have established a real agent session before crashing (orphaned by a
 // daemon restart, runtime offline, or sweeper timeout), and the daemon pins
 // the resume pointer mid-flight via UpdateAgentTaskSession. Without this,
 // an auto-retry of a mid-run failure would silently start a fresh
 // conversation and lose the in-flight context — exactly what MUL-1128's B
 // branch is meant to fix.
+//
+// A cancelled task is in exactly the same position, and excluding it was the
+// issue-side half of GH #6340: the pinned session is real (the provider emitted
+// it), the user stopped the run rather than the provider rejecting it, and
+// cancellation records no failure_reason/error for the poison filters below to
+// match on. So a stop-then-comment-again sequence keeps its context instead of
+// silently starting cold. A user who wants a clean slate has manual rerun,
+// which never takes this path (see below).
 //
 // Manual rerun (TaskService.RerunIssue) does NOT take this path. The claim
 // handler branches on rerun_of_task_id FIRST and resolves the session/workdir
@@ -6055,7 +6063,11 @@ const updateAgentTaskSession = `-- name: UpdateAgentTaskSession :exec
 UPDATE agent_task_queue
 SET session_id = COALESCE($2, session_id),
     work_dir  = COALESCE($3, work_dir)
-WHERE id = $1 AND status IN ('dispatched', 'running')
+WHERE id = $1
+  AND (
+    status IN ('dispatched', 'running')
+    OR (status = 'cancelled' AND session_id IS NULL)
+  )
 `
 
 type UpdateAgentTaskSessionParams struct {
@@ -6068,6 +6080,15 @@ type UpdateAgentTaskSessionParams struct {
 // session_id/work_dir on the task row. No-op if the task is no longer
 // in dispatched/running. waiting_local_directory tasks have no session yet
 // so this query intentionally skips them.
+//
+// A row the user just cancelled accepts the pin too, but only while its
+// session slot is still empty (GH #6340). The pin is asynchronous — for Codex
+// it waits for the rollout to reach the store — so a cancel landing in that
+// window used to drop the session id for good, and the cancelled turn's
+// context with it. Filling an EMPTY slot on the run's own row is exactly what
+// the mid-flight pin is for; the `session_id IS NULL` guard is what keeps this
+// from being an overwrite, and completed/failed rows stay untouchable so a
+// straggler goroutine can never contradict a terminal report.
 func (q *Queries) UpdateAgentTaskSession(ctx context.Context, arg UpdateAgentTaskSessionParams) error {
 	_, err := q.db.Exec(ctx, updateAgentTaskSession, arg.ID, arg.SessionID, arg.WorkDir)
 	return err

--- a/server/pkg/db/generated/chat.sql.go
+++ b/server/pkg/db/generated/chat.sql.go
@@ -702,13 +702,13 @@ WITH retired_sessions AS (
     FROM agent_task_queue t
     WHERE t.chat_session_id = $1
       AND t.session_id IS NOT NULL
-      AND t.status IN ('completed', 'failed')
+      AND t.status IN ('completed', 'failed', 'cancelled')
     ORDER BY t.session_id, t.completed_at DESC
 )
 SELECT session_id, work_dir, runtime_id FROM latest_per_session
 WHERE session_id NOT IN (SELECT session_id FROM retired_sessions)
   AND (
-    status = 'completed'
+    status IN ('completed', 'cancelled')
     OR (
       status = 'failed'
       AND COALESCE(failure_reason, '') NOT IN ('iteration_limit', 'agent_fallback_message', 'api_invalid_request', 'codex_semantic_inactivity', 'agent_error.context_overflow')
@@ -728,13 +728,25 @@ type GetLastChatTaskSessionRow struct {
 }
 
 // Returns the most recent task in this chat session that managed to record a
-// session_id. Includes both completed and failed tasks: even a failed task
-// may have established a real agent session before failing, and we'd rather
-// resume there than start over and lose conversation memory. Used as a
-// fallback when chat_session.session_id is NULL. Resume-unsafe failures are
-// excluded because replaying those sessions deterministically reproduces the
-// same terminal state. Keep this list in sync with resumeUnsafeFailureReason
-// and GetLastTaskSession.
+// session_id. Includes completed, failed AND cancelled tasks: each of them may
+// have established a real agent session, and we'd rather resume there than
+// start over and lose conversation memory. Used as a fallback when
+// chat_session.session_id is NULL. Resume-unsafe failures are excluded because
+// replaying those sessions deterministically reproduces the same terminal
+// state. Keep this list in sync with resumeUnsafeFailureReason and
+// GetLastTaskSession.
+//
+// 'cancelled' is resumable and its absence was GH #6340: the user stops a turn
+// the agent had already started answering, and the next message starts from
+// nothing. A cancelled row only carries a session_id because the daemon pinned
+// one mid-flight (UpdateAgentTaskSession), which means the provider really did
+// emit that session — either the resume loaded or it opened a fresh one. The
+// user interrupted it; the provider did not reject it, so it is no more
+// suspect than a completed one. Cancellation records no failure_reason/error,
+// so the poison filters below have nothing to match and cancelled rows pass
+// them the way completed rows do. The remaining risk — a transcript killed
+// mid-tool-call that the provider later refuses — is caught downstream by
+// taskfailure.UnresumableHistory and retires the session on the next turn.
 //
 // The regex pair mirrors GetLastTaskSession's provider-agnostic guard for an
 // empty message baked into the conversation history: both must match, and
@@ -1030,6 +1042,7 @@ type ListAgentBuilderSessionsByCreatorRow struct {
 // neither is also wrong: a session opened and abandoned untouched is not a
 // draft, and would put an empty row in front of the user on every accidental
 // entry into the flow.
+//
 // The stored draft rides along instead of needing its own fetch: the studio
 // renders this list beside the conversation it is switching between, so the
 // configuration for the row the user picks has to be in hand at click time.

--- a/server/pkg/db/generated/chat.sql.go
+++ b/server/pkg/db/generated/chat.sql.go
@@ -11,6 +11,55 @@ import (
 	"github.com/jackc/pgx/v5/pgtype"
 )
 
+const advanceCancelledChatSessionPointer = `-- name: AdvanceCancelledChatSessionPointer :exec
+UPDATE chat_session cs
+SET session_id = t.session_id,
+    runtime_id = t.runtime_id,
+    work_dir   = COALESCE(t.work_dir, cs.work_dir),
+    updated_at = now()
+FROM agent_task_queue t
+WHERE t.id = $1
+  AND t.chat_session_id = cs.id
+  AND t.status = 'cancelled'
+  AND t.session_id IS NOT NULL
+  AND t.runtime_id IS NOT NULL
+  AND NOT EXISTS (
+      SELECT 1 FROM agent_task_queue newer
+      WHERE newer.chat_session_id = t.chat_session_id
+        AND newer.id <> t.id
+        AND newer.session_id IS NOT NULL
+        AND newer.created_at > t.created_at
+  )
+`
+
+// Moves a chat's resume pointer onto the session a CANCELLED task recorded
+// (GH #6340).
+//
+// Cancellation is the one terminal state that never reports back: the daemon
+// discards its result and only sends a cancel-ack, so neither CompleteTask nor
+// FailTask — the only other writers of chat_session.session_id — ever runs. The
+// claim handler reads this pointer BEFORE falling back to
+// GetLastChatTaskSession, so on a chat that already has history a pointer left
+// on the previous turn shadows the cancelled turn's session no matter what the
+// fallback would have found.
+//
+// Two callers, one statement, because both are races the other cannot cover:
+// the cancel path runs it inside the status-flip transaction (so no follow-up
+// can observe `cancelled` while the pointer still names the older session), and
+// the pin path runs it after a mid-flight pin lands on an already-cancelled row
+// (Codex waits for its rollout, so the pin routinely arrives after the cancel —
+// at which point the cancel path saw no session to publish).
+//
+// Everything it decides on is read from the task row inside the statement, so
+// neither caller can act on a stale in-memory copy. The NOT EXISTS guard is what
+// makes the late pin safe: a NEWER task on this chat that already recorded a
+// session owns the pointer, and a straggler must not drag the conversation
+// backwards onto the turn the user interrupted.
+func (q *Queries) AdvanceCancelledChatSessionPointer(ctx context.Context, taskID pgtype.UUID) error {
+	_, err := q.db.Exec(ctx, advanceCancelledChatSessionPointer, taskID)
+	return err
+}
+
 const chatSessionHasUserMessage = `-- name: ChatSessionHasUserMessage :one
 SELECT EXISTS (
     SELECT 1 FROM chat_message

--- a/server/pkg/db/queries/agent.sql
+++ b/server/pkg/db/queries/agent.sql
@@ -728,13 +728,21 @@ RETURNING *;
 -- name: GetLastTaskSession :one
 -- Returns the session_id and work_dir from the most recent task for a given
 -- (agent_id, issue_id) pair, used for session resumption on the auto-retry
--- path. We accept both 'completed' and 'failed' tasks: a failed task may
--- have established a real agent session before crashing (orphaned by a
+-- path. We accept 'completed', 'failed' AND 'cancelled' tasks: a failed task
+-- may have established a real agent session before crashing (orphaned by a
 -- daemon restart, runtime offline, or sweeper timeout), and the daemon pins
 -- the resume pointer mid-flight via UpdateAgentTaskSession. Without this,
 -- an auto-retry of a mid-run failure would silently start a fresh
 -- conversation and lose the in-flight context — exactly what MUL-1128's B
 -- branch is meant to fix.
+--
+-- A cancelled task is in exactly the same position, and excluding it was the
+-- issue-side half of GH #6340: the pinned session is real (the provider emitted
+-- it), the user stopped the run rather than the provider rejecting it, and
+-- cancellation records no failure_reason/error for the poison filters below to
+-- match on. So a stop-then-comment-again sequence keeps its context instead of
+-- silently starting cold. A user who wants a clean slate has manual rerun,
+-- which never takes this path (see below).
 --
 -- Manual rerun (TaskService.RerunIssue) does NOT take this path. The claim
 -- handler branches on rerun_of_task_id FIRST and resolves the session/workdir
@@ -820,13 +828,13 @@ WITH retired_sessions AS (
     FROM agent_task_queue t
     WHERE t.agent_id = $1 AND t.issue_id = $2
       AND t.session_id IS NOT NULL
-      AND t.status IN ('completed', 'failed')
+      AND t.status IN ('completed', 'failed', 'cancelled')
     ORDER BY t.session_id, COALESCE(t.completed_at, t.started_at, t.dispatched_at, t.created_at) DESC
 )
 SELECT session_id, work_dir, runtime_id FROM latest_per_session
 WHERE session_id NOT IN (SELECT session_id FROM retired_sessions)
   AND (
-    status = 'completed'
+    status IN ('completed', 'cancelled')
     OR (
       status = 'failed'
       AND COALESCE(failure_reason, '') NOT IN ('iteration_limit', 'agent_fallback_message', 'api_invalid_request', 'codex_semantic_inactivity', 'agent_error.context_overflow')
@@ -911,10 +919,23 @@ RETURNING *;
 -- session_id/work_dir on the task row. No-op if the task is no longer
 -- in dispatched/running. waiting_local_directory tasks have no session yet
 -- so this query intentionally skips them.
+--
+-- A row the user just cancelled accepts the pin too, but only while its
+-- session slot is still empty (GH #6340). The pin is asynchronous — for Codex
+-- it waits for the rollout to reach the store — so a cancel landing in that
+-- window used to drop the session id for good, and the cancelled turn's
+-- context with it. Filling an EMPTY slot on the run's own row is exactly what
+-- the mid-flight pin is for; the `session_id IS NULL` guard is what keeps this
+-- from being an overwrite, and completed/failed rows stay untouchable so a
+-- straggler goroutine can never contradict a terminal report.
 UPDATE agent_task_queue
 SET session_id = COALESCE(sqlc.narg('session_id'), session_id),
     work_dir  = COALESCE(sqlc.narg('work_dir'), work_dir)
-WHERE id = $1 AND status IN ('dispatched', 'running');
+WHERE id = $1
+  AND (
+    status IN ('dispatched', 'running')
+    OR (status = 'cancelled' AND session_id IS NULL)
+  );
 
 -- name: RecoverOrphanedTasksForRuntime :many
 -- Called by the daemon at startup. Atomically fails any dispatched/running/

--- a/server/pkg/db/queries/chat.sql
+++ b/server/pkg/db/queries/chat.sql
@@ -464,13 +464,25 @@ RETURNING *;
 
 -- name: GetLastChatTaskSession :one
 -- Returns the most recent task in this chat session that managed to record a
--- session_id. Includes both completed and failed tasks: even a failed task
--- may have established a real agent session before failing, and we'd rather
--- resume there than start over and lose conversation memory. Used as a
--- fallback when chat_session.session_id is NULL. Resume-unsafe failures are
--- excluded because replaying those sessions deterministically reproduces the
--- same terminal state. Keep this list in sync with resumeUnsafeFailureReason
--- and GetLastTaskSession.
+-- session_id. Includes completed, failed AND cancelled tasks: each of them may
+-- have established a real agent session, and we'd rather resume there than
+-- start over and lose conversation memory. Used as a fallback when
+-- chat_session.session_id is NULL. Resume-unsafe failures are excluded because
+-- replaying those sessions deterministically reproduces the same terminal
+-- state. Keep this list in sync with resumeUnsafeFailureReason and
+-- GetLastTaskSession.
+--
+-- 'cancelled' is resumable and its absence was GH #6340: the user stops a turn
+-- the agent had already started answering, and the next message starts from
+-- nothing. A cancelled row only carries a session_id because the daemon pinned
+-- one mid-flight (UpdateAgentTaskSession), which means the provider really did
+-- emit that session — either the resume loaded or it opened a fresh one. The
+-- user interrupted it; the provider did not reject it, so it is no more
+-- suspect than a completed one. Cancellation records no failure_reason/error,
+-- so the poison filters below have nothing to match and cancelled rows pass
+-- them the way completed rows do. The remaining risk — a transcript killed
+-- mid-tool-call that the provider later refuses — is caught downstream by
+-- taskfailure.UnresumableHistory and retires the session on the next turn.
 --
 -- The regex pair mirrors GetLastTaskSession's provider-agnostic guard for an
 -- empty message baked into the conversation history: both must match, and
@@ -496,13 +508,13 @@ WITH retired_sessions AS (
     FROM agent_task_queue t
     WHERE t.chat_session_id = $1
       AND t.session_id IS NOT NULL
-      AND t.status IN ('completed', 'failed')
+      AND t.status IN ('completed', 'failed', 'cancelled')
     ORDER BY t.session_id, t.completed_at DESC
 )
 SELECT session_id, work_dir, runtime_id FROM latest_per_session
 WHERE session_id NOT IN (SELECT session_id FROM retired_sessions)
   AND (
-    status = 'completed'
+    status IN ('completed', 'cancelled')
     OR (
       status = 'failed'
       AND COALESCE(failure_reason, '') NOT IN ('iteration_limit', 'agent_fallback_message', 'api_invalid_request', 'codex_semantic_inactivity', 'agent_error.context_overflow')

--- a/server/pkg/db/queries/chat.sql
+++ b/server/pkg/db/queries/chat.sql
@@ -219,6 +219,49 @@ WHERE id = sqlc.arg('id')
   AND session_id = sqlc.arg('session_id')
   AND runtime_id = sqlc.arg('runtime_id');
 
+-- name: AdvanceCancelledChatSessionPointer :exec
+-- Moves a chat's resume pointer onto the session a CANCELLED task recorded
+-- (GH #6340).
+--
+-- Cancellation is the one terminal state that never reports back: the daemon
+-- discards its result and only sends a cancel-ack, so neither CompleteTask nor
+-- FailTask — the only other writers of chat_session.session_id — ever runs. The
+-- claim handler reads this pointer BEFORE falling back to
+-- GetLastChatTaskSession, so on a chat that already has history a pointer left
+-- on the previous turn shadows the cancelled turn's session no matter what the
+-- fallback would have found.
+--
+-- Two callers, one statement, because both are races the other cannot cover:
+-- the cancel path runs it inside the status-flip transaction (so no follow-up
+-- can observe `cancelled` while the pointer still names the older session), and
+-- the pin path runs it after a mid-flight pin lands on an already-cancelled row
+-- (Codex waits for its rollout, so the pin routinely arrives after the cancel —
+-- at which point the cancel path saw no session to publish).
+--
+-- Everything it decides on is read from the task row inside the statement, so
+-- neither caller can act on a stale in-memory copy. The NOT EXISTS guard is what
+-- makes the late pin safe: a NEWER task on this chat that already recorded a
+-- session owns the pointer, and a straggler must not drag the conversation
+-- backwards onto the turn the user interrupted.
+UPDATE chat_session cs
+SET session_id = t.session_id,
+    runtime_id = t.runtime_id,
+    work_dir   = COALESCE(t.work_dir, cs.work_dir),
+    updated_at = now()
+FROM agent_task_queue t
+WHERE t.id = sqlc.arg('task_id')
+  AND t.chat_session_id = cs.id
+  AND t.status = 'cancelled'
+  AND t.session_id IS NOT NULL
+  AND t.runtime_id IS NOT NULL
+  AND NOT EXISTS (
+      SELECT 1 FROM agent_task_queue newer
+      WHERE newer.chat_session_id = t.chat_session_id
+        AND newer.id <> t.id
+        AND newer.session_id IS NOT NULL
+        AND newer.created_at > t.created_at
+  );
+
 -- name: LockChatSessionForDelete :one
 -- Acquires an exclusive (FOR UPDATE) row lock on chat_session(id). Used by
 -- the delete path so that a concurrent SendChatMessage cannot enqueue a new


### PR DESCRIPTION
Fixes #6340. Multica issue: MUL-5686.

## The bug

Stop a chat turn the agent has already started answering, send the next message, and the agent replies with no memory of the conversation.

The cancelled turn's provider session is real and recorded — the daemon pins it onto the task row mid-flight (`PinTaskSession` → `UpdateAgentTaskSession`) and the cancel queries keep it — but nothing could hand it back:

1. `GetLastChatTaskSession` / `GetLastTaskSession` only considered `status IN ('completed', 'failed')`, so a cancelled row's session was invisible to resume resolution.
2. `chat_session.session_id` is written only by `CompleteTask` / `FailTask`, and a cancelled task reaches neither — the daemon discards its result and sends a cancel-ack. On a chat whose **first** turn was cancelled the pointer therefore stayed `NULL`, and `buildChatPrompt` injects only the current user message, so the next turn ran with zero context. That is the reported symptom.

The issue side had the same hole: stop a run, comment again, and the follow-up starts cold.

This is not a regression of the v0.4.2 cancellation fix (#5246) — that one covered transcript flush / finalization ordering and never touched the resume pointer.

## The change

- **Both resume lookups accept `cancelled`.** A cancelled row only carries a session id because the provider emitted one, so the transcript exists; the user interrupted the run, the provider did not reject it. Cancellation records no `failure_reason` / `error`, so the poison filters have nothing to match and cancelled rows pass them the way completed rows do.
- **The chat-level pointer advances at cancel time.** The claim handler reads `chat_session.session_id` first, so on a chat that already has history a stale pointer would still rewind past the cancelled turn on any provider that mints a new session id per resume. Written synchronously in `CancelTaskWithResult` (not the deferred finalize) so it cannot land after a later turn's terminal write.
- **The mid-flight pin may fill an EMPTY session slot on a just-cancelled row.** The pin is asynchronous — for Codex it waits for the rollout to reach the store — so a cancel landing in that window used to drop the session id for good. Occupied slots and `completed` / `failed` rows stay untouchable, so a straggler goroutine can never contradict a terminal report.

Unchanged: retired sessions, the per-session-latest poisoning judgment (GH #5975), the resume-unsafe failure filters (GH #6066), the Codex rollout-present guard (MUL-5305), and manual rerun, which resolves from its exact source task and never takes this path. A transcript killed mid-tool-call that the provider later refuses is still caught by `taskfailure.UnresumableHistory`, which retires the session and starts the next turn fresh with a disclosed context gap.

No migration: neither partial index on `agent_task_queue` (231 / 233) serves these queries.

## Verification

New tests in `server/internal/handler/daemon_claim_cancelled_session_test.go`, all driven through the real claim / cancel paths:

| Test | Pins |
| --- | --- |
| `TestClaimTask_ChatResumesCancelledTurnSession` | the reported scenario — first turn cancelled, follow-up resumes it |
| `TestClaimTask_IssueResumesCancelledTaskSession` | the issue-side half |
| `TestCancelTask_AdvancesChatSessionResumePointer` | the pointer moves onto the cancelled turn's session + runtime |
| `TestCancelTask_KeepsChatPointerWhenNoSessionEstablished` | a session-less cancel must not touch the pointer |
| `TestClaimTask_ChatCancelledSessionStaysExcludedWhenRetired` | a retired session stays retired even when a cancelled row names it |
| `TestPinTaskSession_LateCancelledPin` | empty slot accepts the late pin; occupied and completed rows do not |

The four behavioral tests fail on `main` (`prior_session_id=""`, pointer stuck at the previous turn) and pass with this change; the two guard tests pass both ways by design.

`go test ./internal/handler/... ./internal/service/... ./internal/daemon/...` is green locally. `./cmd/multica` has 94 failures in my environment both with and without this change (ambient `MULTICA_*` env vars leak into the CLI config-resolution tests) — untouched by this PR.

## Not covered

Whether a specific provider's transcript is replayable after its process is SIGTERM/SIGKILLed is a provider property, verified here only through the existing unresumable-history recovery path rather than against a live CLI.
