### PR TITLE
chore(ui): configure the @reui registry for shadcn installs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -181,6 +181,8 @@ Root-level reminders:
 ## UI Rules
 
 - Prefer shadcn/Base UI components over custom implementations. Add them with `pnpm ui:add <component>` from the repo root.
+- The Pro `@reui` registry is configured in `packages/ui/components.json`; add items with `pnpm ui:add @reui/<name>` and answer `n` to every overwrite prompt so local component customizations survive. It reads `REUI_LICENSE_KEY` from the environment — agents get it from their Multica agent environment, humans export it in their own shell. Never write the key into a repo file.
+- ReUI ships source, not a dependency: route the vendored output to our layout (new primitives to `packages/ui/components/ui/`, compositions to `packages/views/<domain>/`) and rewrite it to our conventions before committing.
 - Use design tokens and semantic classes; avoid hardcoded colors.
 - Do not introduce extra local state unless the design requires it.
 - Handle overflow, long text, scrolling, alignment, and spacing deliberately.

--- a/packages/ui/components.json
+++ b/packages/ui/components.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://ui.shadcn.com/schema.json",
   "style": "base-nova",
-  "rsc": false,
+  "rsc": true,
   "tsx": true,
   "tailwind": {
     "config": "",
@@ -17,5 +17,13 @@
     "hooks": "@multica/ui/hooks",
     "lib": "@multica/ui/lib",
     "utils": "@multica/ui/lib/utils"
+  },
+  "registries": {
+    "@reui": {
+      "url": "https://reui.io/r/base-nova/{name}.json",
+      "headers": {
+        "Authorization": "Bearer ${REUI_LICENSE_KEY}"
+      }
+    }
   }
 }

--- a/packages/ui/tsconfig.json
+++ b/packages/ui/tsconfig.json
@@ -6,7 +6,9 @@
     "paths": {
       "@/lib/utils": ["./lib/utils.ts"],
       "@/hooks/*": ["./hooks/*"],
-      "@/components/ui/*": ["./components/ui/*"]
+      "@/components/ui/*": ["./components/ui/*"],
+      "@multica/ui/components": ["./components"],
+      "@multica/ui/lib": ["./lib"]
     }
   },
   "include": ["**/*.ts", "**/*.tsx"],


### PR DESCRIPTION
Makes `@reui` installable. Config only — three files, no vendored code, no new dependencies.

Replaces the config half of #6277, which also carried the `onboarding-3` block it was testing with. That block is unrouted reference UI sitting under `packages/ui/components/blocks/`, against the "atomic UI components only" rule; it needs its own decision and shouldn't hold up the config everyone else is blocked on.

## What is here

- **`components.json` → registry entry.** Authenticated `@reui` registry at `https://reui.io/r/base-nova/{name}.json`, key read from `${REUI_LICENSE_KEY}` in the environment. Nothing secret is committed.
- **`components.json` → `rsc: true`.** With it `false`, shadcn strips `"use client"` on the way in and the block lands looking fine but broken under the App Router. 44 of the 60 components already in this package carry the directive, so `rsc: false` was stale.
- **`tsconfig.json` → the bare `components` / `lib` alias paths.** Without these, every install fails outright with `Could not resolve the following aliases: components, lib`. shadcn resolves `components.json` aliases through package exports and tsconfig paths, and `@multica/ui/components` / `@multica/ui/lib` matched neither.
- **`CLAUDE.md`** — how to add an item, and that ReUI ships source rather than a dependency, so vendored output gets routed to our layout and rewritten before it is committed.

## What #6277 had that this drops

- The `onboarding-3` block, `components/reui/*`, and `use-file-upload` — vendored code, separate decision.
- `@hugeicons/*` and the lockfile churn — those came with the block, not the registry.
- `exports` entries for `./components/reui/*` and `./components/blocks/*` — they point at directories that do not exist on a clean tree, and they enshrine the vendor's layout. Exports get added per install, for the directories that install actually lands in.

The license-key doc line also changed: the key now comes from the agent environment (or your own shell), not `packages/ui/.env.local`. A Pro credential does not belong in a repo file, gitignored or not.

## Verification

Installed `@reui/stats-1` on this branch and reverted it — that is the check that matters, since the alias failure was an install-time error:

- No alias error; 5 files created, imports rewritten to `@multica/ui/components/reui/badge` and friends.
- `button` / `dropdown-menu` / `separator` skipped, unmodified — the `n` answers held.
- `"use client"` survived on the client component, confirming the `rsc` flip.
- Registry auth resolved from the environment on a Pro item (`stats-1` is 401 without a key).

`pnpm typecheck` 6/6, `pnpm lint` 0 errors (16 pre-existing warnings, none in these files). No test run: this branch adds no TypeScript.

Ref MUL-5701.
