### PR TITLE
MUL-5666: cap picker pill width and standardize clear rows

### DIFF
--- a/packages/core/issues/config/index.ts
+++ b/packages/core/issues/config/index.ts
@@ -1,2 +1,2 @@
 export { STATUS_ORDER, ALL_STATUSES, STATUS_CONFIG } from "./status";
-export { PRIORITY_ORDER, PRIORITY_CONFIG } from "./priority";
+export { PRIORITY_ORDER, PRIORITY_DISPLAY_ORDER, PRIORITY_CONFIG } from "./priority";

--- a/packages/core/issues/config/priority.ts
+++ b/packages/core/issues/config/priority.ts
@@ -1,11 +1,32 @@
 import type { IssuePriority } from "../../types";
 
+/**
+ * Severity order, high to low. This is the **sort rank** — `sortIssues` turns
+ * the array index into the comparison weight — so "none" must stay last.
+ * Never reorder this to change how a menu reads; use
+ * {@link PRIORITY_DISPLAY_ORDER} for that.
+ */
 export const PRIORITY_ORDER: IssuePriority[] = [
   "urgent",
   "high",
   "medium",
   "low",
   "none",
+];
+
+/**
+ * Order every user-facing priority list renders in: the empty value first,
+ * then severity descending. Leading with "No priority" follows the convention
+ * every other picker in the app uses — the first row is always the empty
+ * value (unassigned / no project / no stage), so the eye finds "clear this
+ * field" in the same place regardless of which pill was opened.
+ */
+export const PRIORITY_DISPLAY_ORDER: IssuePriority[] = [
+  "none",
+  "urgent",
+  "high",
+  "medium",
+  "low",
 ];
 
 export const PRIORITY_CONFIG: Record<

--- a/packages/views/chat/components/chat-input.tsx
+++ b/packages/views/chat/components/chat-input.tsx
@@ -607,7 +607,7 @@ export function ChatInput({
                     disabled={!projectSelectionEnabled}
                     aria-label={t(($) => $.input.change_project_context)}
                     title={t(($) => $.input.change_project_context)}
-                    className="flex h-6 max-w-56 items-center gap-1.5 rounded-full border border-surface-border bg-surface-raised px-2 pr-7 text-caption font-medium text-foreground transition-colors hover:bg-accent/60"
+                    className="flex h-6 max-w-56 items-center gap-1.5 rounded-full border border-surface-border bg-surface-raised px-2 text-caption font-medium text-foreground transition-colors hover:bg-accent/60"
                   />
                 }
               />

--- a/packages/views/common/date-only-picker.tsx
+++ b/packages/views/common/date-only-picker.tsx
@@ -7,13 +7,13 @@ import {
   formatDateOnly,
   isPastDateOnly,
 } from "@multica/core/issues/date";
+import { Check } from "lucide-react";
 import { Calendar } from "@multica/ui/components/ui/calendar";
 import {
   Popover,
   PopoverTrigger,
   PopoverContent,
 } from "@multica/ui/components/ui/popover";
-import { Button } from "@multica/ui/components/ui/button";
 import { DeferredPopup } from "./deferred-popup";
 
 /**
@@ -32,8 +32,8 @@ interface DateOnlyPickerProps {
   icon: React.ReactNode;
   /** Placeholder label shown when no date is set. */
   placeholder: string;
-  /** Label for the "clear date" action inside the popover. */
-  clearLabel: string;
+  /** Label of the empty-value row at the top of the popover ("No due date"). */
+  emptyLabel: string;
   /** Paint the value with `text-destructive` when it is in the past (due dates). */
   highlightOverdue?: boolean;
   /** Fully custom trigger contents (replaces the icon + date/placeholder). */
@@ -111,7 +111,7 @@ function DateOnlyPickerImpl({
   onChange,
   icon,
   placeholder,
-  clearLabel,
+  emptyLabel,
   highlightOverdue = false,
   trigger: customTrigger,
   triggerRender,
@@ -141,6 +141,24 @@ function DateOnlyPickerImpl({
         )}
       </PopoverTrigger>
       <PopoverContent className="w-auto p-0" align={align}>
+        {/* Empty value first, above the calendar — the same position every
+            list-backed picker puts it in, so clearing a field is always the
+            top row no matter which pill was opened. Unlike a footer button it
+            is also a selectable value: it carries the checkmark when the
+            field is empty. */}
+        <button
+          type="button"
+          onClick={() => {
+            onChange(null);
+            setOpen(false);
+          }}
+          className="flex w-full items-center gap-3 border-b px-3 py-2 text-left text-body transition-colors hover:bg-accent"
+        >
+          <span className="flex min-w-0 flex-1 items-center gap-2 text-muted-foreground">
+            {emptyLabel}
+          </span>
+          <Check className={`h-3.5 w-3.5 shrink-0 text-muted-foreground ${date ? "invisible" : ""}`} />
+        </button>
         <Calendar
           mode="single"
           selected={date}
@@ -149,21 +167,6 @@ function DateOnlyPickerImpl({
             setOpen(false);
           }}
         />
-        {date && (
-          <div className="border-t px-3 py-2">
-            <Button
-              variant="ghost"
-              size="xs"
-              onClick={() => {
-                onChange(null);
-                setOpen(false);
-              }}
-              className="text-muted-foreground hover:text-foreground"
-            >
-              {clearLabel}
-            </Button>
-          </div>
-        )}
       </PopoverContent>
     </Popover>
   );

--- a/packages/views/common/pill-button.tsx
+++ b/packages/views/common/pill-button.tsx
@@ -12,6 +12,15 @@ export function PillButton({
       type="button"
       className={cn(
         "inline-flex items-center gap-1.5 rounded-full border px-2.5 py-1 text-caption",
+        // Hard width cap. Pills carry user-generated text (project title,
+        // assignee name, label names), and the create toolbars are flex-wrap
+        // rows — an uncapped pill stretches until it owns the whole line and
+        // pushes every sibling to the next one. 14rem matches the chat
+        // composer's project pill. `min-w-0` + `overflow-hidden` let the
+        // inner `truncate` spans actually shrink (a flex item only drops
+        // `min-width: auto` once its overflow is hidden); leading icons are
+        // `shrink-0`, so the text yields first.
+        "min-w-0 max-w-56 overflow-hidden",
         "hover:bg-accent/60 transition-colors cursor-pointer",
         "data-popup-open:bg-accent data-popup-open:text-accent-foreground",
         "disabled:cursor-not-allowed disabled:hover:bg-transparent",

--- a/packages/views/issues/actions/issue-actions-menu-items.tsx
+++ b/packages/views/issues/actions/issue-actions-menu-items.tsx
@@ -24,7 +24,7 @@ import { todayDateOnly, addDaysDateOnly } from "@multica/core/issues/date";
 import { api } from "@multica/core/api";
 import {
   ALL_STATUSES,
-  PRIORITY_ORDER,
+  PRIORITY_DISPLAY_ORDER,
   PRIORITY_CONFIG,
 } from "@multica/core/issues/config";
 import { issueKeys } from "@multica/core/issues/queries";
@@ -174,7 +174,7 @@ export function IssueActionsMenuItems({
           {t(($) => $.actions.priority)}
         </P.SubTrigger>
         <P.SubContent>
-          {PRIORITY_ORDER.map((p) => (
+          {PRIORITY_DISPLAY_ORDER.map((p) => (
             <P.Item key={p} onClick={() => updateField({ priority: p })}>
               <span
                 className={`inline-flex items-center gap-1 rounded px-1.5 py-0.5 text-caption font-medium ${PRIORITY_CONFIG[p].badgeBg} ${PRIORITY_CONFIG[p].badgeText}`}

--- a/packages/views/issues/components/issue-detail.test.tsx
+++ b/packages/views/issues/components/issue-detail.test.tsx
@@ -316,6 +316,7 @@ vi.mock("@multica/core/issues/config", () => ({
     cancelled: { label: "Cancelled", iconColor: "text-muted-foreground", hoverBg: "hover:bg-accent" },
   },
   PRIORITY_ORDER: ["urgent", "high", "medium", "low", "none"],
+  PRIORITY_DISPLAY_ORDER: ["none", "urgent", "high", "medium", "low"],
   PRIORITY_CONFIG: {
     urgent: { label: "Urgent", bars: 4, color: "text-destructive", badgeBg: "bg-destructive/10", badgeText: "text-destructive" },
     high: { label: "High", bars: 3, color: "text-warning", badgeBg: "bg-warning/10", badgeText: "text-warning" },

--- a/packages/views/issues/components/issues-cold-load-loop.test.tsx
+++ b/packages/views/issues/components/issues-cold-load-loop.test.tsx
@@ -82,6 +82,7 @@ vi.mock("@multica/core/issues/config", () => ({
     cancelled: { label: "Cancelled", iconColor: "text-muted-foreground", hoverBg: "hover:bg-accent" },
   },
   PRIORITY_ORDER: ["urgent", "high", "medium", "low", "none"],
+  PRIORITY_DISPLAY_ORDER: ["none", "urgent", "high", "medium", "low"],
   PRIORITY_CONFIG: {
     urgent: { label: "Urgent", bars: 4, color: "text-destructive" },
     high: { label: "High", bars: 3, color: "text-warning" },

--- a/packages/views/issues/components/issues-header.tsx
+++ b/packages/views/issues/components/issues-header.tsx
@@ -50,7 +50,7 @@ import { Calendar } from "@multica/ui/components/ui/calendar";
 import { Switch } from "@multica/ui/components/ui/switch";
 import {
   ALL_STATUSES,
-  PRIORITY_ORDER,
+  PRIORITY_DISPLAY_ORDER,
 } from "@multica/core/issues/config";
 import { StatusIcon, PriorityIcon } from ".";
 import { useQuery } from "@tanstack/react-query";
@@ -1190,7 +1190,7 @@ export function IssueDisplayControls({
                 )}
               </DropdownMenuSubTrigger>
               <DropdownMenuSubContent className="w-auto min-w-44">
-                {PRIORITY_ORDER.map((p) => {
+                {PRIORITY_DISPLAY_ORDER.map((p) => {
                   const checked = priorityFilters.includes(p);
                   const count = counts.priority.get(p) ?? 0;
                   return (

--- a/packages/views/issues/components/issues-page.test.tsx
+++ b/packages/views/issues/components/issues-page.test.tsx
@@ -280,6 +280,7 @@ vi.mock("@multica/core/issues/config", () => ({
     cancelled: { label: "Cancelled", iconColor: "text-muted-foreground", hoverBg: "hover:bg-accent" },
   },
   PRIORITY_ORDER: ["urgent", "high", "medium", "low", "none"],
+  PRIORITY_DISPLAY_ORDER: ["none", "urgent", "high", "medium", "low"],
   PRIORITY_CONFIG: {
     urgent: { label: "Urgent", bars: 4, color: "text-destructive" },
     high: { label: "High", bars: 3, color: "text-warning" },

--- a/packages/views/issues/components/pickers/assignee-picker.keyboard.test.tsx
+++ b/packages/views/issues/components/pickers/assignee-picker.keyboard.test.tsx
@@ -1,0 +1,93 @@
+// Keyboard behaviour of the assignee picker's search box. Uses the REAL
+// PropertyPicker / Base UI Popover — the regression under test lives in
+// PropertyPicker's highlight bookkeeping, so mocking it would test nothing.
+//
+// Regression: the "Unassigned" row is pinned as the picker's first row, which
+// also makes it the first `data-picker-item`. PropertyPicker used to reset the
+// highlight to index 0 on every keystroke, so typing a name and pressing Enter
+// unassigned the issue instead of assigning it to the person being searched
+// for. The empty row is now excluded from the search-result Enter default while
+// staying reachable by arrow key.
+import { describe, expect, it, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { I18nProvider } from "@multica/core/i18n/react";
+import enIssues from "../../../locales/en/issues.json";
+import { AssigneePicker } from "./assignee-picker";
+
+const MEMBERS = [
+  { user_id: "user-1", name: "Ada Lovelace", role: "member" },
+  { user_id: "user-2", name: "Grace Hopper", role: "member" },
+];
+
+vi.mock("@tanstack/react-query", () => ({
+  useQuery: ({ queryKey }: { queryKey: string[] }) => {
+    if (queryKey[0] === "members") return { data: MEMBERS };
+    return { data: [] };
+  },
+}));
+
+vi.mock("@multica/core/hooks", () => ({ useWorkspaceId: () => "workspace-1" }));
+vi.mock("@multica/core/auth", () => ({ useAuthStore: () => ({ id: "user-1" }) }));
+vi.mock("@multica/core/agents", () => ({ isAgentRuntimeBound: () => true }));
+vi.mock("@multica/core/permissions", () => ({
+  canAssignAgentToIssue: () => ({ allowed: true }),
+}));
+vi.mock("@multica/core/workspace/hooks", () => ({
+  useActorName: () => ({ getActorName: () => "Ada Lovelace" }),
+}));
+vi.mock("@multica/core/workspace/queries", () => ({
+  memberListOptions: () => ({ queryKey: ["members"] }),
+  agentListOptions: () => ({ queryKey: ["agents"] }),
+  squadListOptions: () => ({ queryKey: ["squads"] }),
+  assigneeFrequencyOptions: () => ({ queryKey: ["frequency"] }),
+}));
+vi.mock("../../../common/actor-avatar", () => ({
+  ActorAvatar: () => <span data-testid="actor-avatar" />,
+}));
+
+const SEARCH_PLACEHOLDER = "Assign to...";
+
+function renderPicker(onUpdate: () => void) {
+  return render(
+    <I18nProvider locale="en" resources={{ en: { issues: enIssues } }}>
+      {/* Controlled open: the picker is the subject, its trigger is not. */}
+      <AssigneePicker
+        assigneeType={null}
+        assigneeId={null}
+        onUpdate={onUpdate}
+        open
+        onOpenChange={() => {}}
+      />
+    </I18nProvider>,
+  );
+}
+
+describe("AssigneePicker search keyboard defaults", () => {
+  it("assigns the first match on Enter instead of unassigning", async () => {
+    const user = userEvent.setup();
+    const onUpdate = vi.fn();
+
+    renderPicker(onUpdate);
+
+    await user.type(await screen.findByPlaceholderText(SEARCH_PLACEHOLDER), "grace");
+    await user.keyboard("{Enter}");
+
+    expect(onUpdate).toHaveBeenCalledWith({
+      assignee_type: "member",
+      assignee_id: "user-2",
+    });
+  });
+
+  it("leaves Enter inert when the query matches nobody", async () => {
+    const user = userEvent.setup();
+    const onUpdate = vi.fn();
+
+    renderPicker(onUpdate);
+
+    await user.type(await screen.findByPlaceholderText(SEARCH_PLACEHOLDER), "zzzznomatch");
+    await user.keyboard("{Enter}");
+
+    expect(onUpdate).not.toHaveBeenCalled();
+  });
+});

--- a/packages/views/issues/components/pickers/assignee-picker.tsx
+++ b/packages/views/issues/components/pickers/assignee-picker.tsx
@@ -175,19 +175,19 @@ function AssigneePickerImpl({
         )
       }
     >
-      {/* Unassigned option — hidden when search is active */}
-      {!query && (
-        <PickerItem
-          selected={!mixed && !assigneeType && !assigneeId}
-          onClick={() => {
-            onUpdate({ assignee_type: null, assignee_id: null });
-            setOpen(false);
-          }}
-        >
-          <UserMinus className="h-3.5 w-3.5 text-muted-foreground" />
-          <span className="text-muted-foreground">{t(($) => $.pickers.assignee.trigger_unassigned)}</span>
-        </PickerItem>
-      )}
+      {/* Unassigned — always the first row, search active or not. Every
+          picker in the app puts the empty value there, so "clear this field"
+          never moves. */}
+      <PickerItem
+        selected={!mixed && !assigneeType && !assigneeId}
+        onClick={() => {
+          onUpdate({ assignee_type: null, assignee_id: null });
+          setOpen(false);
+        }}
+      >
+        <UserMinus className="h-3.5 w-3.5 text-muted-foreground" />
+        <span className="text-muted-foreground">{t(($) => $.pickers.assignee.trigger_unassigned)}</span>
+      </PickerItem>
 
       {/* Members */}
       {filteredMembers.length > 0 && (

--- a/packages/views/issues/components/pickers/assignee-picker.tsx
+++ b/packages/views/issues/components/pickers/assignee-picker.tsx
@@ -179,6 +179,7 @@ function AssigneePickerImpl({
           picker in the app puts the empty value there, so "clear this field"
           never moves. */}
       <PickerItem
+        emptyValue
         selected={!mixed && !assigneeType && !assigneeId}
         onClick={() => {
           onUpdate({ assignee_type: null, assignee_id: null });

--- a/packages/views/issues/components/pickers/custom-property-picker.tsx
+++ b/packages/views/issues/components/pickers/custom-property-picker.tsx
@@ -128,6 +128,7 @@ export function CustomPropertyValueInput({
   // checkmark when the property is unset.
   const emptyRow = (
     <PickerItem
+      emptyValue
       selected={!hasValue}
       onClick={() => {
         clear();

--- a/packages/views/issues/components/pickers/custom-property-picker.tsx
+++ b/packages/views/issues/components/pickers/custom-property-picker.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import { CalendarDays, ExternalLink } from "lucide-react";
+import { CalendarDays, Check, ExternalLink } from "lucide-react";
 import { toast } from "sonner";
 import type { Issue, IssueProperty, IssuePropertyValue } from "@multica/core/types";
 import {
@@ -123,19 +123,20 @@ export function CustomPropertyValueInput({
     </span>
   );
 
-  const clearFooter = hasValue ? (
-    <Button
-      variant="ghost"
-      size="xs"
+  // Empty value as the first row, not a footer button — the position every
+  // other picker uses for "no value", and being a real row it can carry the
+  // checkmark when the property is unset.
+  const emptyRow = (
+    <PickerItem
+      selected={!hasValue}
       onClick={() => {
         clear();
         setOpen(false);
       }}
-      className="w-full justify-start text-muted-foreground hover:text-foreground"
     >
-      {t(($) => $.pickers.custom_property.clear_action)}
-    </Button>
-  ) : undefined;
+      <span className="text-muted-foreground">{t(($) => $.pickers.custom_property.none)}</span>
+    </PickerItem>
+  );
 
   // Archived (or unknown-type) definitions: read-only display; the only
   // offered action is Clear so stale values can still be cleaned up.
@@ -153,8 +154,8 @@ export function CustomPropertyValueInput({
         align="start"
         trigger={valueTrigger}
         triggerRender={triggerRender}
-        footer={clearFooter}
       >
+        {emptyRow}
         <p className="px-2 py-1.5 text-caption text-muted-foreground">
           {t(($) => $.pickers.custom_property.archived_hint)}
         </p>
@@ -173,8 +174,8 @@ export function CustomPropertyValueInput({
           searchable={options.length > 7}
           trigger={valueTrigger}
           triggerRender={triggerRender}
-          footer={clearFooter}
         >
+          {emptyRow}
           {options.map((option) => (
             <PickerItem
               key={option.id}
@@ -209,8 +210,8 @@ export function CustomPropertyValueInput({
           searchable={options.length > 7}
           trigger={valueTrigger}
           triggerRender={triggerRender}
-          footer={clearFooter}
         >
+          {emptyRow}
           {options.map((option) => (
             <PickerItem
               key={option.id}
@@ -235,6 +236,20 @@ export function CustomPropertyValueInput({
             {valueTrigger}
           </PopoverTrigger>
           <PopoverContent className="w-auto p-0" align="start">
+            {/* Empty value above the calendar — same position as DateOnlyPicker. */}
+            <button
+              type="button"
+              onClick={() => {
+                clear();
+                setOpen(false);
+              }}
+              className="flex w-full items-center gap-3 border-b px-3 py-2 text-left text-body transition-colors hover:bg-accent"
+            >
+              <span className="flex min-w-0 flex-1 items-center gap-2 text-muted-foreground">
+                {t(($) => $.pickers.custom_property.none)}
+              </span>
+              <Check className={`h-3.5 w-3.5 shrink-0 text-muted-foreground ${date ? "invisible" : ""}`} />
+            </button>
             <Calendar
               mode="single"
               selected={date}
@@ -244,21 +259,6 @@ export function CustomPropertyValueInput({
                 setOpen(false);
               }}
             />
-            {date && (
-              <div className="border-t px-3 py-2">
-                <Button
-                  variant="ghost"
-                  size="xs"
-                  onClick={() => {
-                    clear();
-                    setOpen(false);
-                  }}
-                  className="text-muted-foreground hover:text-foreground"
-                >
-                  {t(($) => $.pickers.custom_property.clear_action)}
-                </Button>
-              </div>
-            )}
           </PopoverContent>
         </Popover>
       );
@@ -271,8 +271,8 @@ export function CustomPropertyValueInput({
           align="start"
           trigger={valueTrigger}
           triggerRender={triggerRender}
-          footer={clearFooter}
         >
+          {emptyRow}
           <PickerItem
             selected={value === true}
             onClick={() => {

--- a/packages/views/issues/components/pickers/due-date-picker.tsx
+++ b/packages/views/issues/components/pickers/due-date-picker.tsx
@@ -33,7 +33,7 @@ export function DueDatePicker({
       onChange={(v) => onUpdate({ due_date: v })}
       icon={<CalendarDays className="h-3.5 w-3.5 text-muted-foreground" />}
       placeholder={t(($) => $.pickers.due_date.trigger_label)}
-      clearLabel={t(($) => $.pickers.due_date.clear_action)}
+      emptyLabel={t(($) => $.pickers.due_date.none)}
       highlightOverdue
       trigger={trigger}
       triggerRender={triggerRender}

--- a/packages/views/issues/components/pickers/priority-picker.tsx
+++ b/packages/views/issues/components/pickers/priority-picker.tsx
@@ -2,7 +2,7 @@
 
 import { useState } from "react";
 import type { IssuePriority, UpdateIssueRequest } from "@multica/core/types";
-import { PRIORITY_ORDER, PRIORITY_CONFIG } from "@multica/core/issues/config";
+import { PRIORITY_DISPLAY_ORDER, PRIORITY_CONFIG } from "@multica/core/issues/config";
 import { PriorityIcon } from "../priority-icon";
 import { DeferredPopup } from "../../../common/deferred-popup";
 import { PropertyPicker, PickerItem, PICKER_TRIGGER_CLASS } from "./property-picker";
@@ -88,7 +88,8 @@ function PriorityPickerImpl({
         ) : null)
       }
     >
-      {PRIORITY_ORDER.map((p) => {
+      {/* "No priority" leads — see PRIORITY_DISPLAY_ORDER. */}
+      {PRIORITY_DISPLAY_ORDER.map((p) => {
         const c = PRIORITY_CONFIG[p];
         return (
           <PickerItem

--- a/packages/views/issues/components/pickers/property-picker.tsx
+++ b/packages/views/issues/components/pickers/property-picker.tsx
@@ -17,6 +17,15 @@ import { useT } from "../../../i18n";
 
 const HIGHLIGHT_CLASS = "bg-accent";
 const ITEM_SELECTOR = "button[data-picker-item]:not(:disabled)";
+/**
+ * Marks the fixed empty-value row ("No project", "Unassigned", …). The row is
+ * pinned first for the eye, but it is not a search result — typing a query and
+ * pressing Enter must commit the first real match, never clear the field.
+ */
+const EMPTY_ITEM_ATTR = "data-picker-empty";
+
+const isEmptyItem = (el: HTMLButtonElement | undefined) =>
+  el?.hasAttribute(EMPTY_ITEM_ATTR) === true;
 
 /**
  * Default class of the picker popover trigger. Shared with the deferred
@@ -93,6 +102,21 @@ export function PropertyPicker({
     );
   }, []);
 
+  // Typing re-highlights the first *real* match. The index can't be computed
+  // in the input's onChange handler — the filtered list hasn't rendered yet —
+  // so the keystroke raises a flag and this effect resolves it against the
+  // fresh DOM. Guarding on the flag keeps arrow keys free to walk back onto
+  // the empty row: only a keystroke moves the highlight off it.
+  const pendingSearchHighlight = useRef(false);
+  useEffect(() => {
+    if (!pendingSearchHighlight.current) return;
+    pendingSearchHighlight.current = false;
+    const items = getItems();
+    // -1 when the query matches nothing (only the empty row is left), which
+    // leaves Enter inert instead of clearing the field.
+    setHighlightedIndex(items.findIndex((item) => !isEmptyItem(item)));
+  }, [children, getItems]);
+
   // Apply/remove highlight class via DOM when index changes
   useEffect(() => {
     const items = getItems();
@@ -145,8 +169,10 @@ export function PropertyPicker({
         e.preventDefault();
         if (highlightedIndex >= 0 && highlightedIndex < items.length) {
           items[highlightedIndex]?.click();
-        } else if (items.length === 1) {
-          // Auto-select when only one result
+        } else if (items.length === 1 && !isEmptyItem(items[0])) {
+          // Auto-select when only one result. The empty row is excluded: a
+          // query with no matches leaves it as the sole item, and Enter there
+          // would clear the field the user was trying to search in.
           items[0]?.click();
         }
       }
@@ -181,7 +207,7 @@ export function PropertyPicker({
               value={query}
               onChange={(e) => {
                 setQuery(e.target.value);
-                setHighlightedIndex(0);
+                pendingSearchHighlight.current = true;
                 onSearchChange?.(e.target.value);
               }}
               onKeyDown={handleKeyDown}
@@ -209,12 +235,23 @@ export function PickerItem({
   onClick,
   hoverClassName,
   tooltip,
+  emptyValue = false,
   children,
 }: {
   selected: boolean;
   disabled?: boolean;
   onClick: () => void;
   hoverClassName?: string;
+  /**
+   * Marks this row as the field's fixed empty value ("No project",
+   * "Unassigned", "No stage"). Such a row is pinned first for the eye but
+   * excluded from search-result keyboard defaults, so typing a query and
+   * pressing Enter commits the first real match instead of clearing the
+   * field. Arrow keys can still reach it. Set this on rows that write
+   * null/undefined — not on a real enum member that happens to read as
+   * "none" (issue priority), which is a value like any other.
+   */
+  emptyValue?: boolean;
   /** Design-system tooltip for the row — useful when truncated content needs
    *  the full string, or when the row carries metadata that doesn't fit on
    *  a single line. Wrapped in a real Tooltip component (200ms delay,
@@ -226,6 +263,7 @@ export function PickerItem({
     <button
       type="button"
       data-picker-item
+      {...(emptyValue ? { [EMPTY_ITEM_ATTR]: "" } : {})}
       disabled={disabled}
       onClick={onClick}
       className={`flex w-full items-center gap-3 rounded-md px-2 py-1.5 text-left text-body ${disabled ? "opacity-50 cursor-not-allowed" : hoverClassName ?? "hover:bg-accent"} transition-colors`}

--- a/packages/views/issues/components/pickers/stage-picker.tsx
+++ b/packages/views/issues/components/pickers/stage-picker.tsx
@@ -78,6 +78,7 @@ export function StagePicker({
       {/* "No stage" — always the first row, matching every other picker. Keeps
           the value rows' icon column so the labels line up. */}
       <PickerItem
+        emptyValue
         selected={stage == null}
         onClick={() => {
           onUpdate({ stage: null });

--- a/packages/views/issues/components/pickers/stage-picker.tsx
+++ b/packages/views/issues/components/pickers/stage-picker.tsx
@@ -75,6 +75,8 @@ export function StagePicker({
         )
       }
     >
+      {/* "No stage" — always the first row, matching every other picker. Keeps
+          the value rows' icon column so the labels line up. */}
       <PickerItem
         selected={stage == null}
         onClick={() => {
@@ -82,7 +84,10 @@ export function StagePicker({
           setOpen(false);
         }}
       >
-        <span className="truncate text-caption text-muted-foreground">{t(($) => $.stage.none)}</span>
+        <span className="inline-flex items-center gap-1.5 text-caption text-muted-foreground">
+          <Milestone className="h-3 w-3 shrink-0" />
+          <span className="truncate">{t(($) => $.stage.none)}</span>
+        </span>
       </PickerItem>
       {options.map((s) => (
         <PickerItem

--- a/packages/views/issues/components/pickers/start-date-picker.tsx
+++ b/packages/views/issues/components/pickers/start-date-picker.tsx
@@ -33,7 +33,7 @@ export function StartDatePicker({
       onChange={(v) => onUpdate({ start_date: v })}
       icon={<CalendarClock className="h-3.5 w-3.5 text-muted-foreground" />}
       placeholder={t(($) => $.pickers.start_date.trigger_label)}
-      clearLabel={t(($) => $.pickers.start_date.clear_action)}
+      emptyLabel={t(($) => $.pickers.start_date.none)}
       trigger={trigger}
       triggerRender={triggerRender}
       open={open}

--- a/packages/views/issues/components/swimlane-view.test.tsx
+++ b/packages/views/issues/components/swimlane-view.test.tsx
@@ -112,6 +112,7 @@ vi.mock("@multica/core/issues/config", () => ({
     cancelled: { label: "Cancelled", iconColor: "text-muted-foreground", hoverBg: "hover:bg-accent" },
   },
   PRIORITY_ORDER: ["urgent", "high", "medium", "low", "none"],
+  PRIORITY_DISPLAY_ORDER: ["none", "urgent", "high", "medium", "low"],
   PRIORITY_CONFIG: {
     urgent: { label: "Urgent", bars: 4, color: "text-destructive" },
     high: { label: "High", bars: 3, color: "text-warning" },

--- a/packages/views/labels/label-chip.tsx
+++ b/packages/views/labels/label-chip.tsx
@@ -56,7 +56,11 @@ export function LabelChip({ label, onRemove, className, fullName }: LabelChipPro
   const nameClass = fullName ? "break-all" : "truncate max-w-[12rem]";
   return (
     <span
-      className={`inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-caption font-medium ${className ?? ""}`}
+      // `min-w-0` lets the chip shrink when it is a flex item in a width-capped
+      // container (the create toolbar's label pill). Without it the chip keeps
+      // its content width and the parent clips it mid-shape; with it the inner
+      // name truncates and the chip keeps its rounded ends.
+      className={`inline-flex min-w-0 items-center gap-1 rounded-full px-2 py-0.5 text-caption font-medium ${className ?? ""}`}
       style={{ backgroundColor: label.color, color: textColor }}
       // aria-label exposes the full name to screen readers when the span
       // visually truncates. title stays for sighted hover-tooltip.

--- a/packages/views/locales/en/issues.json
+++ b/packages/views/locales/en/issues.json
@@ -584,7 +584,7 @@
   "pickers": {
     "custom_property": {
       "empty": "Empty",
-      "clear_action": "Clear",
+      "none": "No value",
       "true_label": "Yes",
       "false_label": "No",
       "value_placeholder": "Enter value…",
@@ -606,11 +606,11 @@
     },
     "start_date": {
       "trigger_label": "Start date",
-      "clear_action": "Clear date"
+      "none": "No start date"
     },
     "due_date": {
       "trigger_label": "Due date",
-      "clear_action": "Clear date"
+      "none": "No due date"
     },
     "label": {
       "trigger_label": "Add label",

--- a/packages/views/locales/en/projects.json
+++ b/packages/views/locales/en/projects.json
@@ -70,7 +70,8 @@
     "section_description": "Description",
     "prop_start_date": "Start date",
     "prop_due_date": "Due date",
-    "clear_date": "Clear date",
+    "no_start_date": "No start date",
+    "no_due_date": "No due date",
     "description_placeholder": "Add description...",
     "description_hint": "Shared with agents as context for every task in this project.",
     "empty_issues_title": "No issues linked",
@@ -126,7 +127,6 @@
   },
   "picker": {
     "no_project": "No project",
-    "remove": "Remove from project",
     "empty": "No projects yet",
     "search_placeholder": "Search projects..."
   },

--- a/packages/views/locales/ja/issues.json
+++ b/packages/views/locales/ja/issues.json
@@ -559,7 +559,7 @@
   "pickers": {
     "custom_property": {
       "empty": "空",
-      "clear_action": "クリア",
+      "none": "値なし",
       "true_label": "はい",
       "false_label": "いいえ",
       "value_placeholder": "値を入力…",
@@ -581,11 +581,11 @@
     },
     "start_date": {
       "trigger_label": "開始日",
-      "clear_action": "日付をクリア"
+      "none": "開始日なし"
     },
     "due_date": {
       "trigger_label": "期限",
-      "clear_action": "日付をクリア"
+      "none": "期限なし"
     },
     "label": {
       "trigger_label": "ラベルを追加",

--- a/packages/views/locales/ja/projects.json
+++ b/packages/views/locales/ja/projects.json
@@ -69,7 +69,8 @@
     "section_description": "説明",
     "prop_start_date": "開始日",
     "prop_due_date": "期限",
-    "clear_date": "日付をクリア",
+    "no_start_date": "開始日なし",
+    "no_due_date": "期限なし",
     "description_placeholder": "説明を追加...",
     "description_hint": "このプロジェクトのすべてのタスクで、コンテキストとしてエージェントに共有されます。",
     "empty_issues_title": "リンクされたイシューはありません",
@@ -125,7 +126,6 @@
   },
   "picker": {
     "no_project": "プロジェクトなし",
-    "remove": "プロジェクトから削除",
     "empty": "プロジェクトはまだありません",
     "search_placeholder": "プロジェクトを検索..."
   },

--- a/packages/views/locales/ko/issues.json
+++ b/packages/views/locales/ko/issues.json
@@ -559,7 +559,7 @@
   "pickers": {
     "custom_property": {
       "empty": "비어 있음",
-      "clear_action": "지우기",
+      "none": "값 없음",
       "true_label": "예",
       "false_label": "아니요",
       "value_placeholder": "값 입력…",
@@ -581,11 +581,11 @@
     },
     "start_date": {
       "trigger_label": "시작일",
-      "clear_action": "날짜 지우기"
+      "none": "시작일 없음"
     },
     "due_date": {
       "trigger_label": "마감일",
-      "clear_action": "날짜 지우기"
+      "none": "마감일 없음"
     },
     "label": {
       "trigger_label": "라벨 추가",

--- a/packages/views/locales/ko/projects.json
+++ b/packages/views/locales/ko/projects.json
@@ -69,7 +69,8 @@
     "section_description": "설명",
     "prop_start_date": "시작일",
     "prop_due_date": "마감일",
-    "clear_date": "날짜 지우기",
+    "no_start_date": "시작일 없음",
+    "no_due_date": "마감일 없음",
     "description_placeholder": "설명 추가...",
     "description_hint": "이 프로젝트의 모든 작업에서 컨텍스트로 에이전트에게 공유됩니다.",
     "empty_issues_title": "연결된 이슈가 없습니다",
@@ -125,7 +126,6 @@
   },
   "picker": {
     "no_project": "프로젝트 없음",
-    "remove": "프로젝트에서 제거",
     "empty": "아직 프로젝트가 없습니다",
     "search_placeholder": "프로젝트 검색..."
   },

--- a/packages/views/locales/zh-Hans/issues.json
+++ b/packages/views/locales/zh-Hans/issues.json
@@ -559,7 +559,7 @@
   "pickers": {
     "custom_property": {
       "empty": "空",
-      "clear_action": "清除",
+      "none": "无值",
       "true_label": "是",
       "false_label": "否",
       "value_placeholder": "输入值…",
@@ -581,11 +581,11 @@
     },
     "start_date": {
       "trigger_label": "开始日期",
-      "clear_action": "清除日期"
+      "none": "无开始日期"
     },
     "due_date": {
       "trigger_label": "截止日期",
-      "clear_action": "清除日期"
+      "none": "无截止日期"
     },
     "label": {
       "trigger_label": "添加标签",

--- a/packages/views/locales/zh-Hans/projects.json
+++ b/packages/views/locales/zh-Hans/projects.json
@@ -69,7 +69,8 @@
     "section_description": "描述",
     "prop_start_date": "开始日期",
     "prop_due_date": "截止日期",
-    "clear_date": "清除日期",
+    "no_start_date": "无开始日期",
+    "no_due_date": "无截止日期",
     "description_placeholder": "添加描述...",
     "description_hint": "会作为项目上下文提供给智能体，应用于该项目下的每个任务。",
     "empty_issues_title": "还没有关联的 issue",
@@ -125,7 +126,6 @@
   },
   "picker": {
     "no_project": "无项目",
-    "remove": "从项目移除",
     "empty": "还没有项目",
     "search_placeholder": "搜索项目..."
   },

--- a/packages/views/modals/create-project.tsx
+++ b/packages/views/modals/create-project.tsx
@@ -448,7 +448,7 @@ export function CreateProjectModal({ onClose }: { onClose: () => void }) {
                   {leadType && leadId ? (
                     <>
                       <ActorAvatar actorType={leadType} actorId={leadId} size="sm" showStatusDot />
-                      <span>{leadLabel}</span>
+                      <span className="truncate">{leadLabel}</span>
                     </>
                   ) : (
                     <span className="text-muted-foreground">{t(($) => $.create_project.lead)}</span>

--- a/packages/views/projects/components/project-date-pickers.test.tsx
+++ b/packages/views/projects/components/project-date-pickers.test.tsx
@@ -18,14 +18,14 @@ describe("ProjectStartDatePicker", () => {
     expect(screen.getByText("Mar 1")).toBeInTheDocument();
   });
 
-  it("emits start_date: null when the date is cleared", async () => {
+  it("emits start_date: null from the empty row above the calendar", async () => {
     const onUpdate = vi.fn();
     const user = userEvent.setup();
     renderWithI18n(
       <ProjectStartDatePicker startDate="2026-03-01" onUpdate={onUpdate} />,
     );
     await user.click(screen.getByText("Mar 1")); // open popover
-    await user.click(screen.getByRole("button", { name: "Clear date" }));
+    await user.click(screen.getByRole("button", { name: "No start date" }));
     expect(onUpdate).toHaveBeenCalledWith({ start_date: null });
   });
 });
@@ -41,14 +41,14 @@ describe("ProjectDueDatePicker", () => {
     expect(screen.getByText("Mar 1")).toBeInTheDocument();
   });
 
-  it("emits due_date: null when the date is cleared", async () => {
+  it("emits due_date: null from the empty row above the calendar", async () => {
     const onUpdate = vi.fn();
     const user = userEvent.setup();
     renderWithI18n(
       <ProjectDueDatePicker dueDate="2026-03-01" onUpdate={onUpdate} />,
     );
     await user.click(screen.getByText("Mar 1")); // open popover
-    await user.click(screen.getByRole("button", { name: "Clear date" }));
+    await user.click(screen.getByRole("button", { name: "No due date" }));
     expect(onUpdate).toHaveBeenCalledWith({ due_date: null });
   });
 });

--- a/packages/views/projects/components/project-due-date-picker.tsx
+++ b/packages/views/projects/components/project-due-date-picker.tsx
@@ -34,7 +34,7 @@ export function ProjectDueDatePicker({
       onChange={(v) => onUpdate({ due_date: v })}
       icon={<CalendarDays className="h-3.5 w-3.5 text-muted-foreground" />}
       placeholder={t(($) => $.detail.prop_due_date)}
-      clearLabel={t(($) => $.detail.clear_date)}
+      emptyLabel={t(($) => $.detail.no_due_date)}
       highlightOverdue
       triggerRender={triggerRender}
       align={align}

--- a/packages/views/projects/components/project-picker.open-state.test.tsx
+++ b/packages/views/projects/components/project-picker.open-state.test.tsx
@@ -148,6 +148,57 @@ describe("ProjectPicker search", () => {
     expect(screen.queryByRole("button", { name: /mobile web/i })).not.toBeInTheDocument();
   });
 
+  // Regression: the empty value is pinned as the first row, which also made it
+  // the first `data-picker-item`. PropertyPicker used to reset the highlight to
+  // index 0 on every keystroke, so typing a query and pressing Enter committed
+  // the empty row — clearing the field the user was searching in instead of
+  // picking the match they were looking at.
+  it("commits the first match on Enter, not the empty row", async () => {
+    const user = userEvent.setup();
+    const onUpdate = vi.fn();
+
+    render(<CreateDialogHarness onUpdate={onUpdate} />);
+
+    await user.click(screen.getByRole("button", { name: /no project/i }));
+    await user.type(await screen.findByPlaceholderText("Search projects..."), "mobile");
+    await user.keyboard("{Enter}");
+
+    expect(onUpdate).toHaveBeenCalledWith({ project_id: "project-2" });
+    expect(onUpdate).not.toHaveBeenCalledWith({ project_id: null });
+  });
+
+  it("leaves Enter inert when the query matches nothing", async () => {
+    // The empty row survives every filter, so a no-match query leaves it as
+    // the sole item. The single-item auto-select must not fire on it.
+    const user = userEvent.setup();
+    const onUpdate = vi.fn();
+
+    render(<CreateDialogHarness onUpdate={onUpdate} />);
+
+    await user.click(screen.getByRole("button", { name: /no project/i }));
+    await user.type(await screen.findByPlaceholderText("Search projects..."), "zzzznomatch");
+    await user.keyboard("{Enter}");
+
+    expect(onUpdate).not.toHaveBeenCalled();
+  });
+
+  it("still reaches the empty row by arrow key while searching", async () => {
+    // Skipping it as the Enter default must not make it unreachable.
+    // jsdom has no layout, so scrollIntoView isn't defined at all — assign it
+    // rather than spy on it (vi.spyOn requires an existing property).
+    HTMLElement.prototype.scrollIntoView = vi.fn();
+    const user = userEvent.setup();
+    const onUpdate = vi.fn();
+
+    render(<CreateDialogHarness onUpdate={onUpdate} />);
+
+    await user.click(screen.getByRole("button", { name: /no project/i }));
+    await user.type(await screen.findByPlaceholderText("Search projects..."), "mobile");
+    await user.keyboard("{ArrowUp}{Enter}");
+
+    expect(onUpdate).toHaveBeenCalledWith({ project_id: null });
+  });
+
   // Regression: selecting a row closes the popover by calling `setOpen(false)`
   // directly, which never routes through PropertyPicker's own open-change
   // handler — the only place that used to reset the query. The stale search

--- a/packages/views/projects/components/project-picker.test.tsx
+++ b/packages/views/projects/components/project-picker.test.tsx
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
-import { fireEvent, render, screen } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { I18nProvider } from "@multica/core/i18n/react";
 import enProjects from "../../locales/en/projects.json";
@@ -9,7 +9,10 @@ import { PillButton } from "../../common/pill-button";
 
 vi.mock("@tanstack/react-query", () => ({
   useQuery: () => ({
-    data: [{ id: "project-1", title: "Launch Command Center", icon: null }],
+    data: [
+      { id: "project-1", title: "Launch Command Center", icon: null },
+      { id: "project-2", title: "Mobile Web", icon: null },
+    ],
   }),
 }));
 
@@ -25,89 +28,112 @@ vi.mock("./project-icon", () => ({
   ProjectIcon: () => <span data-testid="project-icon" />,
 }));
 
-// Real PropertyPicker (Popover) — do not mock it: the inline clear control is
-// rendered by ProjectPicker outside the popover, so it is present without
-// opening the picker.
+function withI18n(children: React.ReactNode) {
+  return (
+    <I18nProvider locale="en" resources={{ en: { projects: enProjects, issues: enIssues } }}>
+      {children}
+    </I18nProvider>
+  );
+}
+
+// Real PropertyPicker (Popover) — do not mock it: clearing now lives inside
+// the popover, so the tests have to actually open it.
 function renderPicker(props: Partial<React.ComponentProps<typeof ProjectPicker>> = {}) {
   return render(
-    <I18nProvider locale="en" resources={{ en: { projects: enProjects, issues: enIssues } }}>
+    withI18n(
       <ProjectPicker
         projectId="project-1"
         onUpdate={props.onUpdate ?? vi.fn()}
         triggerRender={<PillButton />}
         {...props}
-      />
-    </I18nProvider>,
+      />,
+    ),
   );
 }
 
-function findInlineClear() {
-  return screen
-    .getAllByRole("button", { name: "Remove from project" })
-    .find((button) => button.className.includes("group-hover/project:opacity-100"));
-}
+const SEARCH_PLACEHOLDER = "Search projects...";
 
 describe("ProjectPicker", () => {
-  it("shows a hover clear action for the selected project", async () => {
+  it("renders the trigger alone — the pill carries no inline clear control", () => {
+    // Regression: the clear × used to be an absolutely-positioned sibling
+    // overlaying the trigger, and only the picker's own default trigger
+    // reserved right padding for it. Every caller passing `triggerRender`
+    // (create dialog pill, table cell, autopilot card) had the × painted on
+    // top of the project name. Clearing belongs in the popover instead, which
+    // is also where the other property pickers put it.
+    renderPicker();
+
+    expect(screen.getAllByRole("button")).toHaveLength(1);
+    expect(screen.getByRole("button", { name: /launch command center/i })).toBeInTheDocument();
+  });
+
+  it("clears the selection from the No project row", async () => {
     const user = userEvent.setup();
     const onUpdate = vi.fn();
 
     renderPicker({ onUpdate });
 
-    const clear = findInlineClear();
-    expect(clear).toBeDefined();
-    expect(clear!.className).toContain("group-hover/project:opacity-100");
-    expect(clear!.className).toContain("size-3.5");
-    expect(clear!.className).toContain("hover:bg-muted-foreground/20");
-    expect(clear!.className).not.toContain("bg-background/95");
-    expect(clear!.className).not.toContain("inset-y-0");
-    expect(clear!.className).not.toContain("w-7");
+    await user.click(screen.getByRole("button", { name: /launch command center/i }));
+    await user.click(await screen.findByRole("button", { name: /no project/i }));
 
-    await user.click(clear!);
     expect(onUpdate).toHaveBeenCalledWith({ project_id: null });
   });
 
-  it("clears via keyboard activation when enabled", async () => {
-    // Other callers (issue/create/autopilot) rely on the clear control staying
-    // reachable by keyboard, not just hover. Enabling must not regress that.
+  it("keeps the empty row first while searching", async () => {
+    // The empty value is the fixed first row of every picker in the app — a
+    // typed query must not move or hide it, or "clear this field" lands
+    // somewhere different depending on what the user typed.
     const user = userEvent.setup();
     const onUpdate = vi.fn();
 
     renderPicker({ onUpdate });
 
-    const clear = findInlineClear();
-    expect(clear).toBeDefined();
-    expect(clear).not.toBeDisabled();
+    await user.click(screen.getByRole("button", { name: /launch command center/i }));
+    await user.type(await screen.findByPlaceholderText(SEARCH_PLACEHOLDER), "zzzznomatch");
 
-    clear!.focus();
-    expect(clear).toHaveFocus();
-    await user.keyboard("{Enter}");
+    await user.click(screen.getByRole("button", { name: /no project/i }));
     expect(onUpdate).toHaveBeenCalledWith({ project_id: null });
   });
 
-  it("locks the inline clear control against pointer and keyboard when disabled", () => {
-    // Regression (MUL-5150): the outer wrapper's `pointer-events-none` only
-    // blocks the mouse. The inline clear button stayed in the tab order, so a
-    // keyboard user could Tab to it and press Enter to detach the project while
-    // a chat send was in flight — retargeting the lazily-created session. The
-    // explicit `disabled` capability must remove it from the tab order and make
-    // both pointer and keyboard activation inert.
+  it("keeps the empty row ahead of the filtered matches", async () => {
+    const user = userEvent.setup();
+
+    renderPicker({ projectId: null });
+
+    // Unset, the trigger adopts the "No project" label too, so both it and
+    // the row match — before and after typing.
+    await user.click(screen.getByRole("button", { name: /no project/i }));
+    expect(screen.getAllByRole("button", { name: /no project/i })).toHaveLength(2);
+
+    await user.type(await screen.findByPlaceholderText(SEARCH_PLACEHOLDER), "mobile");
+    expect(screen.getAllByRole("button", { name: /no project/i })).toHaveLength(2);
+    expect(screen.getByRole("button", { name: /mobile web/i })).toBeInTheDocument();
+  });
+
+  it("locks every mutation path when disabled", async () => {
+    // Regression (MUL-5150): a keyboard user could Tab to the inline clear
+    // button and detach the project while a chat send was in flight,
+    // retargeting the lazily-created session. With clearing moved into the
+    // popover, `disabled` has a single path to close — the popover.
+    const user = userEvent.setup();
     const onUpdate = vi.fn();
 
-    renderPicker({ onUpdate, disabled: true });
+    const { unmount } = render(
+      withI18n(<ProjectPicker projectId="project-1" onUpdate={onUpdate} disabled />),
+    );
 
-    const clear = findInlineClear();
-    expect(clear).toBeDefined();
-    expect(clear).toBeDisabled();
+    const trigger = screen.getByRole("button", { name: /launch command center/i });
+    expect(trigger).toBeDisabled();
 
-    // A disabled control cannot receive focus, so it is not tabbable.
-    clear!.focus();
-    expect(clear).not.toHaveFocus();
+    await user.click(trigger);
+    expect(screen.queryByPlaceholderText(SEARCH_PLACEHOLDER)).not.toBeInTheDocument();
+    expect(onUpdate).not.toHaveBeenCalled();
 
-    // Neither keyboard activation nor a direct click may mutate the selection.
-    fireEvent.keyDown(clear!, { key: "Enter" });
-    fireEvent.keyDown(clear!, { key: " " });
-    fireEvent.click(clear!);
+    // The lock also wins over a controlled `open` — a caller that freezes the
+    // picker mid-send cannot leave it hanging open with a live clear row.
+    unmount();
+    render(withI18n(<ProjectPicker projectId="project-1" onUpdate={onUpdate} disabled open />));
+    expect(screen.queryByPlaceholderText(SEARCH_PLACEHOLDER)).not.toBeInTheDocument();
     expect(onUpdate).not.toHaveBeenCalled();
   });
 });

--- a/packages/views/projects/components/project-picker.tsx
+++ b/packages/views/projects/components/project-picker.tsx
@@ -99,6 +99,7 @@ export function ProjectPicker({
             only clear entry now that the pill carries no inline ×. Mirrors
             the unassigned row in the assignee picker. */}
         <PickerItem
+          emptyValue
           selected={!projectId}
           onClick={() => {
             onUpdate({ project_id: null });

--- a/packages/views/projects/components/project-picker.tsx
+++ b/packages/views/projects/components/project-picker.tsx
@@ -1,12 +1,11 @@
 "use client";
 
 import { useState } from "react";
-import { FolderKanban, X } from "lucide-react";
+import { FolderKanban } from "lucide-react";
 import { useQuery } from "@tanstack/react-query";
 import { projectListOptions } from "@multica/core/projects/queries";
 import { useWorkspaceId } from "@multica/core/hooks";
 import type { UpdateIssueRequest } from "@multica/core/types";
-import { cn } from "@multica/ui/lib/utils";
 import { ProjectIcon } from "./project-icon";
 import {
   PropertyPicker,
@@ -36,12 +35,11 @@ export function ProjectPicker({
   defaultOpen?: boolean;
   open?: boolean;
   onOpenChange?: (open: boolean) => void;
-  /** Read-only lock. When true the trigger, the menu, and the inline clear
-   *  button are all disabled and out of the tab order, so no project-context
-   *  mutation can fire — pointer OR keyboard. Callers that must freeze the
-   *  selection during a transient window (an in-flight chat send) pass this;
-   *  every other caller keeps the default hover/keyboard clear behavior since
-   *  it defaults to false. */
+  /** Read-only lock. When true the trigger is disabled and out of the tab
+   *  order and the menu can never open, so no project-context mutation can
+   *  fire — pointer OR keyboard. Clearing lives inside the menu, so locking
+   *  the menu locks clearing too. Callers that must freeze the selection
+   *  during a transient window (an in-flight chat send) pass this. */
   disabled?: boolean;
 }) {
   const { t } = useT("projects");
@@ -66,19 +64,14 @@ export function ProjectPicker({
     (p) => p.title.toLowerCase().includes(query) || matchesPinyin(p.title, query),
   );
 
-  // Default trigger built as a `triggerRender` so it can reserve right padding
-  // for the inline clear button. Callers that bring their own trigger (chat
-  // pill, autopilot card, table cell) take over the trigger entirely.
+  // Callers that bring their own trigger (create pill, chat pill, autopilot
+  // card, table cell) take over the trigger entirely.
   const resolvedTriggerRender = triggerRender ?? (
-    <button
-      type="button"
-      disabled={disabled}
-      className={cn(PICKER_TRIGGER_CLASS, current && "pr-5")}
-    />
+    <button type="button" disabled={disabled} className={PICKER_TRIGGER_CLASS} />
   );
 
   return (
-    <div className="group/project relative inline-flex min-w-0">
+    <div className="inline-flex min-w-0">
       <PropertyPicker
         open={open}
         onOpenChange={setOpen}
@@ -102,20 +95,19 @@ export function ProjectPicker({
           )
         }
       >
-        {/* "No project" clear row — hidden while searching, mirrors the
-            unassigned row in the assignee picker. */}
-        {!query && projects.length > 0 && (
-          <PickerItem
-            selected={!projectId}
-            onClick={() => {
-              onUpdate({ project_id: null });
-              setOpen(false);
-            }}
-          >
-            <FolderKanban className="h-3.5 w-3.5 text-muted-foreground" />
-            <span className="text-muted-foreground">{t(($) => $.picker.no_project)}</span>
-          </PickerItem>
-        )}
+        {/* "No project" — always the first row, search active or not, and the
+            only clear entry now that the pill carries no inline ×. Mirrors
+            the unassigned row in the assignee picker. */}
+        <PickerItem
+          selected={!projectId}
+          onClick={() => {
+            onUpdate({ project_id: null });
+            setOpen(false);
+          }}
+        >
+          <FolderKanban className="h-3.5 w-3.5 text-muted-foreground" />
+          <span className="text-muted-foreground">{t(($) => $.picker.no_project)}</span>
+        </PickerItem>
 
         {filtered.map((p) => (
           <PickerItem
@@ -136,22 +128,6 @@ export function ProjectPicker({
         )}
         {projects.length > 0 && filtered.length === 0 && query && <PickerEmpty />}
       </PropertyPicker>
-
-      {current && (
-        <button
-          type="button"
-          disabled={disabled}
-          aria-label={t(($) => $.picker.remove)}
-          onClick={(event) => {
-            event.preventDefault();
-            event.stopPropagation();
-            onUpdate({ project_id: null });
-          }}
-          className="pointer-events-none absolute right-1 top-1/2 flex size-3.5 -translate-y-1/2 items-center justify-center rounded-sm text-muted-foreground opacity-0 transition-[background-color,color,opacity] hover:bg-muted-foreground/20 hover:text-foreground focus-visible:ring-1 focus-visible:ring-ring focus-visible:outline-none group-hover/project:pointer-events-auto group-hover/project:opacity-100 focus-visible:pointer-events-auto focus-visible:opacity-100 disabled:pointer-events-none disabled:opacity-0 disabled:group-hover/project:opacity-0"
-        >
-          <X className="size-2.5" />
-        </button>
-      )}
     </div>
   );
 }

--- a/packages/views/projects/components/project-start-date-picker.tsx
+++ b/packages/views/projects/components/project-start-date-picker.tsx
@@ -36,7 +36,7 @@ export function ProjectStartDatePicker({
       onChange={(v) => onUpdate({ start_date: v })}
       icon={<CalendarClock className="h-3.5 w-3.5 text-muted-foreground" />}
       placeholder={t(($) => $.detail.prop_start_date)}
-      clearLabel={t(($) => $.detail.clear_date)}
+      emptyLabel={t(($) => $.detail.no_start_date)}
       triggerRender={triggerRender}
       align={align}
       open={open}


### PR DESCRIPTION
## Why

Two problems, same root: the property pills had no shared contract.

**Clearing a field was in a different place per picker.** Assignee / project / stage led with an empty row; priority put "No priority" last; the date and custom-property popovers hid a Clear button in a footer; and the project pill carried a hover-only overlay × on top of its row.

That × was also broken. It was an absolutely-positioned sibling of the trigger, and only the picker's *own default* trigger reserved right padding for it — so every caller passing `triggerRender` (create dialog, table cell, autopilot card) had the × painted directly over the project name. Three of five callers got the implicit padding contract wrong.

**Nothing capped a pill's width.** Pills carry user-generated text and the create toolbars are `flex-wrap` rows, so one long project title stretched its pill across the whole line and pushed every sibling to the next one.

## What changed

**The empty value is always the popover's first row.**

| Picker | Before | After |
|---|---|---|
| Project | overlay × + row hidden while searching | row only, always first |
| Assignee | row hidden while searching | always first |
| Priority | "No priority" last | first (see below) |
| Start / due date | footer Clear button | row above the calendar |
| Custom property | footer Clear button | first row |
| Stage | first row, no icon | first row, icon column aligned |

Priority needed the constant split: `PRIORITY_ORDER` doubles as the **sort rank** (`sortIssues` uses the array index as the comparison weight), so it keeps `none` last. The new `PRIORITY_DISPLAY_ORDER` leads with it and drives the picker, the actions menu, and the filter dropdown.

Copy follows position — rows read as nouns (No project / Unassigned / No due date / No value), retiring the verb-form `clear_action` and `clear_date` keys across all four locales.

**Pill width is capped once, at the shared `PillButton`:** `min-w-0 max-w-56 overflow-hidden`. The `min-w-0` + `overflow-hidden` pair is what makes the inner `truncate` spans work at all — a flex item only drops `min-width: auto` once its overflow is hidden, which is why those spans never truncated before. Two call sites needed a follow-up the cap exposed: the create-project lead pill had no `truncate`, and `LabelChip` had no `min-w-0` (so the label pill clipped a chip mid-shape instead of shrinking it).

## Notes for review

- **`disabled` on ProjectPicker is now enforced in one place.** MUL-5150 hardened it because a keyboard user could Tab to the inline × and detach the project mid chat-send. With clearing inside the popover, `disabled` only has to keep the popover shut — covered by a test that also asserts a controlled `open` can't force it open.
- **Clicking an empty row when the field is already empty** is now reachable and fires a no-op write. This matches what every list-backed picker already did, and the server documents `properties - key` as a no-op for the absent-key case, so there is no error path.
- **Mobile is deliberately untouched** (iOS isn't being iterated on right now). It keeps severity-descending priority order and still hides the empty row while searching. Both are ordering/visibility only — the options themselves exist on both clients, so the semantic parity rules in `apps/mobile/CLAUDE.md` (enums, counts, permissions) still hold.

## Open question, not addressed here

Multi-select fields are now inconsistent with each other: custom `multi_select` has an empty row that clears **all** selected options in one click, while labels has no such entry and clears one chip at a time. Either labels gains one or the custom one goes — I lean toward removing it, since a clear-all shouldn't be easier to hit than unchecking. Happy to follow up either way.

## Verification

- `packages/views` — 301 files / 3496 tests pass
- `packages/core` — 114 files / 1234 tests pass
- `pnpm typecheck` — clean
- `pnpm lint` — 0 errors (16 pre-existing warnings in untouched files)

Not run: Playwright e2e, Go tests (no backend change), mobile checks (no mobile change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)