### PR TITLE
MUL-5704: fix truncated zh Discord label in the sidebar footer

### DIFF
--- a/packages/views/layout/join-discord-card.tsx
+++ b/packages/views/layout/join-discord-card.tsx
@@ -19,10 +19,17 @@ import { useT } from "../i18n";
  *
  * No external-link arrow, unlike the Help menu's outbound items: sharing one
  * 224px strip with the help trigger leaves 128px for the label, and the arrow
- * plus the dismiss button together overflow that in en (109px) and zh (125px).
- * The dismiss affordance wins because it is a user-facing capability and the
- * arrow is only a hint — the Discord mark already signals the destination.
- * `flex-1 min-w-0` makes the label truncate rather than push the trigger off.
+ * plus the dismiss button together overflow that in the widest locale (en,
+ * 109px). The dismiss affordance wins because it is a user-facing capability
+ * and the arrow is only a hint — the Discord mark already signals the
+ * destination. `flex-1 min-w-0` makes the label truncate rather than push the
+ * trigger off.
+ *
+ * That 128px is the budget at the DEFAULT 256px sidebar, and the sidebar is
+ * user-resizable down to 200px — every 1px of drag takes 1px from the label.
+ * So a title that merely fits at 256px still truncates for anyone who has
+ * narrowed their sidebar; keep every locale's title comfortably under budget,
+ * not just under it (MUL-5704).
  */
 export function JoinDiscordCard() {
   const { t } = useT("layout");

--- a/packages/views/locales/zh-Hans/layout.json
+++ b/packages/views/locales/zh-Hans/layout.json
@@ -55,7 +55,7 @@
     "configure_group": "配置",
     "unread_overflow": "99+",
     "discord_card": {
-      "title": "加入我们的 Discord",
+      "title": "加入 Discord",
       "dismiss": "关闭"
     }
   }


### PR DESCRIPTION
Closes MUL-5704

The Chinese sidebar entry rendered as `加入我们的 Dis...`.

## Cause

The footer strip in `packages/views/layout/app-sidebar.tsx` gives the label a fixed budget:

```
sidebar width − 16 (inset p-2) − 16 (footer p-2) − 28 (help trigger) − 4 (gap)
              − 8 (pl) − 32 (pr-8 dismiss reserve) − 16 (icon) − 8 (gap)
            = sidebar width − 128
```

At the default 256px sidebar that is **128px**. Measured in Chromium at 14px with the real `--font-sans` chain (Inter → PingFang SC):

| locale | title | width |
| --- | --- | --- |
| ja | `Discord に参加` | 96.8px |
| ko | `Discord 참여하기` | 103.3px |
| en | `Join our Discord` | 108.8px |
| **zh-Hans** | **`加入我们的 Discord`** | **124.8px** |

zh fit only by 3.2px — and the sidebar is user-resizable down to 200px, persisted in `localStorage`. Any user who has narrowed theirs loses the tail. The reported screenshot is a ~232px sidebar: a 104px budget, which truncates at exactly `加入我们的 Dis...`.

## Fix

Drop the possessive. ja and ko already omit it (`Discord に参加`, `Discord 참여하기`), so zh was the outlier — and `apps/docs/content/docs/developers/conventions.mdx` § *Chinese voice and style* names `我们的` explicitly as translation-ese to avoid:

> **Concise and direct.** Avoid translation-ese: "对于 X 来说"、"作为 X"、"我们的"。

`加入 Discord` measures 82.8px — 45px of headroom at the default width, and it still fits well below it. The single space around the Latin word follows the word-combination rule.

The doc comment on `JoinDiscordCard` carried a now-stale per-locale width and did not mention that the budget shrinks with the resizable sidebar, which is what made a merely-fitting title regress. Both corrected.

## Verification

- `vitest run` in `packages/views` — locale parity + layout suites, 185 passed
- `tsc --noEmit` (`@multica/views`) — clean
- `eslint` on the changed component — clean
- Layout re-measured in headless Chromium before and after, at 232px and 256px sidebars
