### PR TITLE
feat(agents): add directory-based agents that run in a user-specified directory

### DIFF
--- a/packages/core/types/agent.ts
+++ b/packages/core/types/agent.ts
@@ -480,6 +480,13 @@ export interface Agent {
    * account defaults remain authoritative.
    */
   service_tier?: string;
+  /**
+   * Absolute path of the directory this directory-based agent's tasks run in
+   * (the directory is the whole agent — its CLAUDE.md / skills / MCP config
+   * come from there). Empty/undefined means a normal agent using the standard
+   * per-task workdir (or a project-level local_directory when attached).
+   */
+  local_directory?: string | null;
   owner_id: string | null;
   skills: AgentSkillSummary[];
   /** Runtime-local skills this agent must not inherit. Older servers omit it. */
@@ -549,6 +556,10 @@ export interface CreateAgentRequest {
   thinking_level?: string;
   /** Optional Codex service-tier catalog ID. See `Agent.service_tier`. */
   service_tier?: string;
+  /** Absolute path for a directory-based agent: the agent's tasks run in this
+   *  directory instead of a per-task workdir. Empty/omitted creates a normal
+   *  agent. */
+  local_directory?: string;
   /** Optional template slug used by the onboarding agent picker. Surfaced
    *  as the `template` property on the `agent_created` PostHog event. */
   template?: string;

--- a/packages/views/agents/components/agent-creation-studio.execution.test.tsx
+++ b/packages/views/agents/components/agent-creation-studio.execution.test.tsx
@@ -78,6 +78,7 @@ const baseDraft: AgentDraft = {
   model: "gpt-5.6-sol",
   thinkingLevel: "",
   serviceTier: "",
+  localDirectory: "",
   skillIds: new Set(),
   permissionScope: "private",
   memberIds: new Set(),

--- a/packages/views/agents/components/agent-creation-studio.test.ts
+++ b/packages/views/agents/components/agent-creation-studio.test.ts
@@ -38,6 +38,7 @@ vi.mock("../../i18n", () => ({
           modes: {
             blank: { title: string; description: string };
             ai: { title: string; description: string };
+            directory: { title: string; description: string };
           };
           create_and_open: string;
           create_and_add: string;
@@ -65,6 +66,10 @@ vi.mock("../../i18n", () => ({
             ai: {
               title: "Build with AI",
               description: "Describe the outcome you want.",
+            },
+            directory: {
+              title: "From a local directory",
+              description: "The directory is the agent.",
             },
           },
           create_and_open: "Create and open",
@@ -195,6 +200,7 @@ const draft = (): AgentDraft => ({
   model: "model-1",
   thinkingLevel: "",
   serviceTier: "",
+  localDirectory: "",
   skillIds: new Set(["skill-1"]),
   permissionScope: "private",
   memberIds: new Set(),
@@ -207,11 +213,13 @@ describe("Agent creation studio mode chooser", () => {
       createElement(ModeChooser, {
         onBlank: vi.fn(),
         onAI: vi.fn(),
+        onDirectory: vi.fn(),
       }),
     );
 
     expect(screen.getByText("Start blank")).toBeInTheDocument();
     expect(screen.getByText("Build with AI")).toBeInTheDocument();
+    expect(screen.getByText("From a local directory")).toBeInTheDocument();
   });
 });
 

--- a/packages/views/agents/components/agent-creation-studio.tsx
+++ b/packages/views/agents/components/agent-creation-studio.tsx
@@ -9,6 +9,7 @@ import {
   Check,
   ChevronRight,
   FileText,
+  Folder,
   Loader2,
   MessageSquare,
   Search,
@@ -81,8 +82,9 @@ import { ServiceTierSettingField } from "./inspector/service-tier-setting-field"
 import { ThinkingSettingField } from "./inspector/thinking-prop-row";
 import { RuntimePicker, isRuntimeUsableForUser } from "./runtime-picker";
 import { SkillMultiSelect } from "./skill-multi-select";
+import { LocalDirectoryPicker } from "./local-directory-picker";
 
-type StudioMode = "choose" | "templates" | "blank" | "template" | "ai";
+type StudioMode = "choose" | "templates" | "blank" | "template" | "directory" | "ai";
 type StudioScreenKey =
   | "choose"
   | "templates"
@@ -96,7 +98,7 @@ export function getAgentCreationScreenKey(
   mode: StudioMode,
   builderSessionId: string,
 ): StudioScreenKey {
-  if (mode === "blank" || mode === "template") return "configure";
+  if (mode === "blank" || mode === "template" || mode === "directory") return "configure";
   if (mode === "ai") return builderSessionId ? "ai-builder" : "ai-setup";
   return mode;
 }
@@ -112,6 +114,8 @@ export interface AgentDraft {
   thinkingLevel: string;
   /** Runtime-native execution tier (Codex Speed), scoped to `model`. */
   serviceTier: string;
+  /** Absolute local directory for a directory-based agent ("" = normal agent). */
+  localDirectory: string;
   skillIds: Set<string>;
   permissionScope: PermissionScope;
   memberIds: Set<string>;
@@ -198,6 +202,7 @@ const EMPTY_DRAFT: AgentDraft = {
   model: "",
   thinkingLevel: "",
   serviceTier: "",
+  localDirectory: "",
   skillIds: new Set(),
   permissionScope: "private",
   memberIds: new Set(),
@@ -471,6 +476,7 @@ export function AgentCreationStudio() {
     draft.teamIds.size === 0;
   const canCreate =
     draft.name.trim().length > 0 &&
+    (mode !== "directory" || draft.localDirectory.trim().length > 0) &&
     selectedRuntime != null &&
     isRuntimeUsableForUser(selectedRuntime, currentUser?.id ?? null) &&
     isDraftDescriptionWithinLimit(draft.description) &&
@@ -552,6 +558,16 @@ export function AgentCreationStudio() {
   const chooseAI = () => {
     setTransitionDirection(1);
     setMode("ai");
+  };
+
+  const chooseDirectory = () => {
+    setSourceTemplate(null);
+    setDraft((current) => ({
+      ...EMPTY_DRAFT,
+      runtimeId: current.runtimeId || usableRuntimes[0]?.id || "",
+    }));
+    setTransitionDirection(1);
+    setMode("directory");
   };
 
   const applyTemplate = () => {
@@ -856,7 +872,12 @@ export function AgentCreationStudio() {
         {mode !== "choose" && mode !== "templates" && (
           <div className="ml-auto hidden items-center gap-2 text-caption text-muted-foreground sm:flex">
             <span className="rounded-full bg-muted px-2 py-1">
-              {sourceTemplate?.name ?? (mode === "ai" ? t(($) => $.creation_studio.modes.ai.title) : t(($) => $.creation_studio.modes.blank.title))}
+              {sourceTemplate?.name ??
+                (mode === "ai"
+                  ? t(($) => $.creation_studio.modes.ai.title)
+                  : mode === "directory"
+                    ? t(($) => $.creation_studio.modes.directory.title)
+                    : t(($) => $.creation_studio.modes.blank.title))}
             </span>
             {selectedRuntime && (
               <span className="rounded-full bg-muted px-2 py-1">
@@ -885,6 +906,7 @@ export function AgentCreationStudio() {
         <ModeChooser
           onBlank={chooseBlank}
           onAI={chooseAI}
+          onDirectory={chooseDirectory}
         />
       )}
 
@@ -902,7 +924,7 @@ export function AgentCreationStudio() {
         />
       )}
 
-      {(mode === "blank" || mode === "template") && (
+      {(mode === "blank" || mode === "template" || mode === "directory") && (
         <div className="min-h-0 flex-1 overflow-y-auto">
           <div className="mx-auto w-full max-w-4xl px-5 py-8 sm:px-8">
             {duplicateAgent && (
@@ -924,6 +946,7 @@ export function AgentCreationStudio() {
               currentUserId={currentUser?.id ?? null}
               nameError={nameError}
               onNameChange={updateAgentName}
+              directoryMode={mode === "directory"}
             />
           </div>
           <StudioFooter
@@ -1018,9 +1041,11 @@ export function AgentCreationStudio() {
 export function ModeChooser({
   onBlank,
   onAI,
+  onDirectory,
 }: {
   onBlank: () => void;
   onAI: () => void;
+  onDirectory: () => void;
 }) {
   const { t } = useT("agents");
   const modes = [
@@ -1036,6 +1061,12 @@ export function ModeChooser({
       description: t(($) => $.creation_studio.modes.ai.description),
       action: onAI,
       recommended: true,
+    },
+    {
+      icon: Folder,
+      title: t(($) => $.creation_studio.modes.directory.title),
+      description: t(($) => $.creation_studio.modes.directory.description),
+      action: onDirectory,
     },
   ];
   return (
@@ -1195,6 +1226,7 @@ function ConfigurationPanel({
   onRuntimeSelect,
   runtimeSwitchPending = false,
   runtimeSwitchInFlight = false,
+  directoryMode = false,
 }: {
   draft: AgentDraft;
   onChange: (draft: AgentDraft) => void;
@@ -1213,6 +1245,10 @@ function ConfigurationPanel({
   runtimeSwitchPending?: boolean;
   /** A rebind request is in flight. */
   runtimeSwitchInFlight?: boolean;
+  /** Directory-based agent: the Behavior section becomes a local-directory
+   *  picker instead of instructions + skill selection (the directory IS the
+   *  agent's behavior). */
+  directoryMode?: boolean;
 }) {
   const { t } = useT("agents");
   const selectedRuntime = runtimes.find((runtime) => runtime.id === draft.runtimeId) ?? null;
@@ -1293,32 +1329,45 @@ function ConfigurationPanel({
 
       <SettingsSection
         title={t(($) => $.creation_studio.sections.behavior)}
-        description={t(($) => $.creation_studio.sections.behavior_hint)}
+        description={
+          directoryMode
+            ? t(($) => $.creation_studio.sections.directory_hint)
+            : t(($) => $.creation_studio.sections.behavior_hint)
+        }
       >
         <SettingsCard>
-          <DraftFieldRow
-            compact
-            label={t(($) => $.create_dialog.instructions.label)}
-            htmlFor="agent-create-instructions"
-          >
-            <Textarea
-              id="agent-create-instructions"
-              name="agent-instructions"
-              autoComplete="off"
-              aria-label={t(($) => $.create_dialog.instructions.label)}
-              value={draft.instructions}
-              onChange={(event) => set("instructions", event.target.value)}
-              placeholder={t(($) => $.create_dialog.instructions.editor_placeholder)}
-              rows={compact ? 9 : 12}
-              className="min-h-44 resize-y font-mono text-label leading-6"
+          {directoryMode ? (
+            <LocalDirectoryPicker
+              value={draft.localDirectory}
+              onChange={(dir) => set("localDirectory", dir)}
             />
-          </DraftFieldRow>
-          <div className="px-4 py-4">
-            <SkillMultiSelect
-              selectedIds={draft.skillIds}
-              onChange={(ids) => set("skillIds", ids)}
-            />
-          </div>
+          ) : (
+            <>
+              <DraftFieldRow
+                compact
+                label={t(($) => $.create_dialog.instructions.label)}
+                htmlFor="agent-create-instructions"
+              >
+                <Textarea
+                  id="agent-create-instructions"
+                  name="agent-instructions"
+                  autoComplete="off"
+                  aria-label={t(($) => $.create_dialog.instructions.label)}
+                  value={draft.instructions}
+                  onChange={(event) => set("instructions", event.target.value)}
+                  placeholder={t(($) => $.create_dialog.instructions.editor_placeholder)}
+                  rows={compact ? 9 : 12}
+                  className="min-h-44 resize-y font-mono text-label leading-6"
+                />
+              </DraftFieldRow>
+              <div className="px-4 py-4">
+                <SkillMultiSelect
+                  selectedIds={draft.skillIds}
+                  onChange={(ids) => set("skillIds", ids)}
+                />
+              </div>
+            </>
+          )}
         </SettingsCard>
       </SettingsSection>
 
@@ -1938,6 +1987,7 @@ export function buildCreateAgentRequest(options: {
     model: draft.model.trim() || undefined,
     thinking_level: draft.thinkingLevel.trim() || undefined,
     service_tier: draft.serviceTier.trim() || undefined,
+    local_directory: draft.localDirectory.trim() || undefined,
     permission_mode:
       draft.permissionScope === "private" ? "private" : "public_to",
     invocation_targets: buildInvocationTargets(draft),

--- a/packages/views/agents/components/agent-overview-pane.tsx
+++ b/packages/views/agents/components/agent-overview-pane.tsx
@@ -184,14 +184,23 @@ export function AgentOverviewPane({
       !!currentUserId &&
       !!agent.owner_id &&
       agent.owner_id === currentUserId;
+    // Directory-based agent: behavior & capabilities come from the bound
+    // directory (its CLAUDE.md / skills / MCP config), so instructions and
+    // skills are hidden — editing them here would be meaningless. Other
+    // capability tabs (MCP config, integrations) stay visible.
+    const isDirectoryBased = !!agent.local_directory;
 
     return CAPABILITY_TABS.filter((tab) => {
+      if (isDirectoryBased && (tab.id === "instructions" || tab.id === "skills")) {
+        return false;
+      }
       if (tab.id === "mcp_config") return showMcp;
       if (tab.id === "composio_mcp") return showComposioMcp;
       if (tab.id === "integrations") return integrationsConfigured;
       return true;
     });
   }, [
+    agent.local_directory,
     agent.owner_id,
     composioMCPAppsEnabled,
     currentUserId,

--- a/packages/views/agents/components/local-directory-picker.tsx
+++ b/packages/views/agents/components/local-directory-picker.tsx
@@ -1,0 +1,121 @@
+import { useState } from "react";
+import { AlertTriangle, Check, FolderOpen, Loader2 } from "lucide-react";
+import { Button } from "@multica/ui/components/ui/button";
+import { Input } from "@multica/ui/components/ui/input";
+import { useT } from "../../i18n";
+import {
+  isDesktopShell,
+  pickDirectory,
+  validateLocalDirectory,
+} from "../../platform/local-directory";
+
+/**
+ * Local-directory picker for directory-based agents.
+ *
+ * Desktop (Electron) shell: a "Browse" button opens the native directory
+ * chooser via `desktopAPI.pickDirectory`. Web has no filesystem access, so it
+ * falls back to a manual absolute-path input — the daemon validates the path
+ * at claim time. Both surfaces offer a Validate button when the API is
+ * available (desktop only).
+ */
+export function LocalDirectoryPicker({
+  value,
+  onChange,
+}: {
+  value: string;
+  onChange: (path: string) => void;
+}) {
+  const { t } = useT("agents");
+  const desktop = isDesktopShell();
+  const [validating, setValidating] = useState(false);
+  const [valid, setValid] = useState<boolean | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const handlePick = async () => {
+    const res = await pickDirectory();
+    if (res.ok && res.path) {
+      onChange(res.path);
+      setValid(null);
+      setError(null);
+    }
+  };
+
+  const handleValidate = async () => {
+    const path = value.trim();
+    if (!path) {
+      setValid(false);
+      setError(t(($) => $.creation_studio.directory_required));
+      return;
+    }
+    setValidating(true);
+    const res = await validateLocalDirectory(path);
+    setValidating(false);
+    if (res.ok) {
+      setValid(true);
+      setError(null);
+    } else {
+      setValid(false);
+      setError(
+        res.reason === "unsupported"
+          ? t(($) => $.creation_studio.directory_unsupported)
+          : t(($) => $.creation_studio.directory_invalid),
+      );
+    }
+  };
+
+  const updatePath = (path: string) => {
+    onChange(path);
+    setValid(null);
+    setError(null);
+  };
+
+  return (
+    <div className="flex flex-col gap-3 px-4 py-4">
+      <div className="flex flex-wrap items-center gap-2">
+        <Input
+          value={value}
+          onChange={(e) => updatePath(e.target.value)}
+          placeholder={t(($) => $.creation_studio.directory_placeholder)}
+          aria-label={t(($) => $.creation_studio.directory_label)}
+          className="min-w-64 flex-1 font-mono text-label"
+        />
+        {desktop && (
+          <Button type="button" variant="outline" onClick={handlePick}>
+            <FolderOpen className="size-4" />
+            {t(($) => $.creation_studio.directory_browse)}
+          </Button>
+        )}
+        <Button
+          type="button"
+          variant="secondary"
+          onClick={handleValidate}
+          disabled={validating}
+        >
+          {validating ? (
+            <Loader2 className="size-4 animate-spin" />
+          ) : (
+            <Check className="size-4" />
+          )}
+          {t(($) => $.creation_studio.directory_validate)}
+        </Button>
+      </div>
+      {!desktop && (
+        <p className="text-caption leading-5 text-muted-foreground">
+          {t(($) => $.creation_studio.directory_web_hint)}
+        </p>
+      )}
+      {error && (
+        <p className="flex items-center gap-1.5 text-caption text-destructive">
+          <AlertTriangle className="size-3.5" />
+          {error}
+        </p>
+      )}
+      {valid === true && (
+        <p className="flex items-center gap-1.5 text-caption text-emerald-600">
+          <Check className="size-3.5" />
+          {t(($) => $.creation_studio.directory_valid)}
+        </p>
+      )}
+    </div>
+  );
+}

--- a/packages/views/locales/en/agents.json
+++ b/packages/views/locales/en/agents.json
@@ -300,6 +300,10 @@
       "ai": {
         "title": "Build with AI",
         "description": "Describe the outcome you want. An Agent Builder will ask focused questions and prepare a live draft."
+      },
+      "directory": {
+        "title": "From a local directory",
+        "description": "The directory is the agent: it already holds the skills, MCP config and instructions (CLAUDE.md) the agent runs with."
       }
     },
     "templates": {
@@ -319,7 +323,8 @@
       "execution": "Execution",
       "execution_hint": "Choose where the agent runs, and optionally override the runtime's default model, thinking level and speed.",
       "access": "Access",
-      "access_hint": "Control who can start runs with this agent. You can change this later."
+      "access_hint": "Control who can start runs with this agent. You can change this later.",
+      "directory_hint": "Pick the local directory the agent runs in. Its CLAUDE.md / skills / MCP config are the agent's whole behavior."
     },
     "thinking_label": "Thinking",
     "speed_label": "Speed",
@@ -371,7 +376,16 @@
     "creating": "Creating agent…",
     "create_failed": "Could not create the agent.",
     "name_conflict": "An agent with this name already exists.",
-    "created": "{{name}} was created"
+    "created": "{{name}} was created",
+    "directory_label": "Local directory",
+    "directory_placeholder": "/absolute/path/to/your-agent-directory",
+    "directory_browse": "Browse",
+    "directory_validate": "Validate",
+    "directory_web_hint": "Enter the absolute path. It is validated on the machine that runs your agents.",
+    "directory_required": "Please enter an absolute directory path.",
+    "directory_invalid": "This path is not a valid readable/writable directory on the agent machine.",
+    "directory_unsupported": "Validation isn't available in this view; the path is checked when a task runs.",
+    "directory_valid": "Directory verified."
   },
   "create_dialog": {
     "title_create": "Create Agent",

--- a/packages/views/locales/ja/agents.json
+++ b/packages/views/locales/ja/agents.json
@@ -759,6 +759,10 @@
       "ai": {
         "title": "AI で作成",
         "description": "期待する成果を説明すると、Agent Builder が重要な質問を行い、下書きをリアルタイムで作成します。"
+      },
+      "directory": {
+        "title": "ローカルディレクトリから作成",
+        "description": "ディレクトリがそのままエージェントです。CLAUDE.md・スキル・MCP 設定を既に含むディレクトリで実行します。"
       }
     },
     "templates": {
@@ -778,7 +782,8 @@
       "execution": "実行環境",
       "execution_hint": "エージェントを実行する場所を選び、必要に応じてランタイムの既定モデル・思考レベル・速度を変更します。",
       "access": "アクセス",
-      "access_hint": "このエージェントを実行できるユーザーを設定します。後から変更できます。"
+      "access_hint": "このエージェントを実行できるユーザーを設定します。後から変更できます。",
+      "directory_hint": "エージェントが実行するローカルディレクトリを選びます。CLAUDE.md / skills / MCP 設定がそのまま動作になります。"
     },
     "thinking_label": "思考",
     "speed_label": "速度",
@@ -830,7 +835,16 @@
     "creating": "エージェントを作成中…",
     "create_failed": "エージェントを作成できませんでした。",
     "name_conflict": "同じ名前のエージェントがすでに存在します。",
-    "created": "{{name}} を作成しました"
+    "created": "{{name}} を作成しました",
+    "directory_label": "ローカルディレクトリ",
+    "directory_placeholder": "/絶対/パス/エージェント用ディレクトリ",
+    "directory_browse": "参照",
+    "directory_validate": "検証",
+    "directory_web_hint": "絶対パスを入力してください。実行時にエージェントを動かすマシンで検証されます。",
+    "directory_required": "絶対ディレクトリパスを入力してください。",
+    "directory_invalid": "このパスはエージェントマシン上で有効な読み書き可能なディレクトリではありません。",
+    "directory_unsupported": "この画面では検証できません。タスク実行時にチェックされます。",
+    "directory_valid": "ディレクトリ検証済み。"
   },
   "actions": {
     "selected_other": "{{count}} 件選択中",

--- a/packages/views/locales/ko/agents.json
+++ b/packages/views/locales/ko/agents.json
@@ -759,6 +759,10 @@
       "ai": {
         "title": "AI로 만들기",
         "description": "원하는 결과를 설명하면 Agent Builder가 핵심 질문을 하고 실시간 초안을 준비합니다."
+      },
+      "directory": {
+        "title": "로컬 디렉터리에서 생성",
+        "description": "디렉터리가 곧 에이전트입니다. CLAUDE.md·스킬·MCP 설정을 이미 담은 디렉터리에서 실행합니다."
       }
     },
     "templates": {
@@ -778,7 +782,8 @@
       "execution": "실행",
       "execution_hint": "에이전트를 실행할 위치를 선택하고 필요하면 런타임 기본 모델, 추론 수준, 속도를 변경하세요.",
       "access": "접근 권한",
-      "access_hint": "이 에이전트를 실행할 수 있는 사용자를 설정합니다. 나중에 변경할 수 있습니다."
+      "access_hint": "이 에이전트를 실행할 수 있는 사용자를 설정합니다. 나중에 변경할 수 있습니다.",
+      "directory_hint": "에이전트가 실행될 로컬 디렉터리를 선택합니다. 그 안의 CLAUDE.md / skills / MCP 설정이 곧 동작 방식입니다."
     },
     "thinking_label": "추론",
     "speed_label": "속도",
@@ -830,7 +835,16 @@
     "creating": "에이전트 만드는 중…",
     "create_failed": "에이전트를 만들지 못했습니다.",
     "name_conflict": "같은 이름의 에이전트가 이미 있습니다.",
-    "created": "{{name}}을(를) 만들었습니다"
+    "created": "{{name}}을(를) 만들었습니다",
+    "directory_label": "로컬 디렉터리",
+    "directory_placeholder": "/절대/경로/에이전트-디렉터리",
+    "directory_browse": "찾아보기",
+    "directory_validate": "검증",
+    "directory_web_hint": "절대 경로를 입력하세요. 작업 실행 시 에이전트를 실행하는 머신에서 검증됩니다.",
+    "directory_required": "절대 디렉터리 경로를 입력하세요.",
+    "directory_invalid": "이 경로는 에이전트 머신에서 유효한 읽기/쓰기 가능 디렉터리가 아닙니다.",
+    "directory_unsupported": "이 화면에서는 검증할 수 없습니다. 작업 실행 시 확인됩니다.",
+    "directory_valid": "디렉터리 검증됨."
   },
   "actions": {
     "selected_other": "{{count}}개 선택됨",

--- a/packages/views/locales/zh-Hans/agents.json
+++ b/packages/views/locales/zh-Hans/agents.json
@@ -291,6 +291,10 @@
       "ai": {
         "title": "通过 AI 创建",
         "description": "描述你想要的结果。Agent Builder 会提出关键问题并实时生成草稿。"
+      },
+      "directory": {
+        "title": "从本地目录新建",
+        "description": "目录就是智能体本身：其中已有的 CLAUDE.md、skills、MCP 配置就是该智能体的全部能力，无需在平台内重复配置。"
       }
     },
     "templates": {
@@ -310,7 +314,8 @@
       "execution": "运行方式",
       "execution_hint": "选择智能体使用的运行时，也可以覆盖运行时的默认模型、思考等级和速度。",
       "access": "访问权限",
-      "access_hint": "控制谁可以运行此智能体，创建后仍可修改。"
+      "access_hint": "控制谁可以运行此智能体，创建后仍可修改。",
+      "directory_hint": "选择智能体运行时的本地目录。目录里的 CLAUDE.md / skills / MCP 配置就是它的全部行为。"
     },
     "thinking_label": "思考",
     "speed_label": "速度",
@@ -362,7 +367,16 @@
     "creating": "正在创建…",
     "create_failed": "无法创建智能体。",
     "name_conflict": "工作区中已存在同名智能体。",
-    "created": "已创建 {{name}}"
+    "created": "已创建 {{name}}",
+    "directory_label": "本地目录",
+    "directory_placeholder": "/绝对/路径/你的智能体目录",
+    "directory_browse": "浏览",
+    "directory_validate": "校验",
+    "directory_web_hint": "输入绝对路径，任务运行时会在运行 agent 的机器上校验该路径。",
+    "directory_required": "请输入绝对目录路径。",
+    "directory_invalid": "该路径在 agent 机器上不是有效的可读/可写目录。",
+    "directory_unsupported": "当前视图无法校验，路径将在任务运行时检查。",
+    "directory_valid": "目录校验通过。"
   },
   "create_dialog": {
     "title_create": "创建智能体",

--- a/server/internal/daemon/local_directory.go
+++ b/server/internal/daemon/local_directory.go
@@ -45,6 +45,25 @@ type localDirectoryAssignment struct {
 // child issues or comments, but should not bind to the user's repo worktree or
 // hold the path mutex while downstream workers are ready to write.
 func localDirectoryAssignmentForTask(task Task, daemonID string) (*localDirectoryAssignment, error) {
+	// Directory-based agent: the agent's own local_directory wins over any
+	// project-level local_directory resource. The path is bound to this daemon
+	// through the agent's runtime — claim routing guarantees the daemon owns
+	// that runtime — so no daemon_id match is needed here.
+	if task.Agent != nil && strings.TrimSpace(task.Agent.LocalDirectory) != "" {
+		absPath, err := normalizeLocalPath(task.Agent.LocalDirectory)
+		if err != nil {
+			return nil, err
+		}
+		realPath, err := resolveRealPath(absPath)
+		if err != nil {
+			return nil, err
+		}
+		return &localDirectoryAssignment{
+			Ref:      localDirectoryRef{LocalPath: absPath, DaemonID: daemonID, Label: "agent"},
+			AbsPath:  absPath,
+			RealPath: realPath,
+		}, nil
+	}
 	if task.IsLeaderTask {
 		return nil, nil
 	}

--- a/server/internal/daemon/types.go
+++ b/server/internal/daemon/types.go
@@ -179,6 +179,9 @@ type AgentData struct {
 	Model                 string                     `json:"model,omitempty"`
 	ThinkingLevel         string                     `json:"thinking_level,omitempty"`
 	ServiceTier           string                     `json:"service_tier,omitempty"`
+	// LocalDirectory is the absolute path this directory-based agent's tasks
+	// run in (empty = standard per-task workdir / project local_directory).
+	LocalDirectory        string                     `json:"local_directory,omitempty"`
 	DisabledRuntimeSkills []DisabledRuntimeSkillData `json:"disabled_runtime_skills,omitempty"`
 	// RuntimeConfig is the per-provider runtime_config JSON as stored on
 	// the agent record, forwarded verbatim by the claim endpoint. The

--- a/server/internal/handler/agent.go
+++ b/server/internal/handler/agent.go
@@ -85,6 +85,10 @@ type AgentResponse struct {
 	// ServiceTier is the runtime-native Codex execution tier persisted for
 	// this agent (empty = inherit local Codex configuration).
 	ServiceTier string `json:"service_tier"`
+	// LocalDirectory is the absolute path of the directory this agent's tasks
+	// run in (directory-based agent). Empty means the agent uses the standard
+	// per-task workdir (or a project-level local_directory when attached).
+	LocalDirectory string `json:"local_directory"`
 	// ComposioToolkitAllowlist is the subset of Composio toolkit slugs this
 	// agent is allowed to mount as MCP at task dispatch — for ANY run that
 	// passes the agent's invocation permission, using the agent OWNER's
@@ -187,6 +191,7 @@ func (h *Handler) agentToResponse(a db.Agent) AgentResponse {
 		Model:                    a.Model.String,
 		ThinkingLevel:            a.ThinkingLevel.String,
 		ServiceTier:              a.ServiceTier.String,
+		LocalDirectory:           a.LocalDirectory.String,
 		ComposioToolkitAllowlist: composioAllowlist,
 		OwnerID:                  uuidToPtr(a.OwnerID),
 		Skills:                   []AgentSkillSummary{},
@@ -589,6 +594,7 @@ type TaskAgentData struct {
 	Model                 string                      `json:"model,omitempty"`
 	ThinkingLevel         string                      `json:"thinking_level,omitempty"`
 	ServiceTier           string                      `json:"service_tier,omitempty"`
+	LocalDirectory        string                      `json:"local_directory,omitempty"`
 	DisabledRuntimeSkills []DisabledRuntimeSkill      `json:"disabled_runtime_skills,omitempty"`
 	// RuntimeConfig is the agent's saved runtime_config JSON as-is. The
 	// daemon decodes it per-provider — e.g. the openclaw backend reads
@@ -962,6 +968,9 @@ type CreateAgentRequest struct {
 	Model              string                     `json:"model"`
 	ThinkingLevel      string                     `json:"thinking_level"`
 	ServiceTier        string                     `json:"service_tier"`
+	// LocalDirectory is the absolute path the agent's tasks run in
+	// (directory-based agent). Empty creates a normal agent.
+	LocalDirectory string `json:"local_directory"`
 	// ComposioToolkitAllowlist seeds the per-task overlay gate (MUL-3869). On
 	// create only the calling user can be the owner, so we accept the field
 	// unconditionally here; the cross-owner permission gate lives on PUT.
@@ -1074,6 +1083,11 @@ func (h *Handler) CreateAgent(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	if err := validateLocalDirectory(req.LocalDirectory); err != nil {
+		writeError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+
 	// thinking_level validation: fixed-enum providers reject unknown literals;
 	// dynamic-catalog providers (Codex/OpenCode) reject malformed tokens here.
 	// Per-model gaps are enforced by the daemon at execution time (MUL-2339):
@@ -1178,6 +1192,7 @@ func (h *Handler) CreateAgent(w http.ResponseWriter, r *http.Request) {
 		Model:                    pgtype.Text{String: req.Model, Valid: req.Model != ""},
 		ThinkingLevel:            pgtype.Text{String: req.ThinkingLevel, Valid: req.ThinkingLevel != ""},
 		ServiceTier:              pgtype.Text{String: req.ServiceTier, Valid: req.ServiceTier != ""},
+		LocalDirectory:           pgtype.Text{String: req.LocalDirectory, Valid: req.LocalDirectory != ""},
 		ComposioToolkitAllowlist: allowlist,
 	})
 	if err != nil {
@@ -1337,6 +1352,10 @@ type UpdateAgentRequest struct {
 	// ServiceTier follows the same tri-state contract as ThinkingLevel:
 	// omitted preserves, empty clears, and non-empty sets a Codex catalog ID.
 	ServiceTier *string `json:"service_tier"`
+	// LocalDirectory follows the tri-state contract: omitted preserves,
+	// empty string clears (agent reverts to the standard per-task workdir),
+	// non-empty absolute path sets the directory-based run root.
+	LocalDirectory *string `json:"local_directory"`
 	// ComposioToolkitAllowlist is a tri-state, same pattern as
 	// thinking_level, mcp_config:
 	//   - field omitted → no change (column preserved as-is)
@@ -1793,6 +1812,30 @@ func (h *Handler) UpdateAgent(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
+	// local_directory handling. Tri-state semantics, mirroring mcp_config:
+	//   - field omitted → preserve (COALESCE narg)
+	//   - field present as JSON null → explicit clear (ClearAgentLocalDirectory)
+	//   - field present as "" → explicit clear
+	//   - field present as an absolute path → set (directory-based agent)
+	// A nil *string is the same wire shape as omitted, so the decode-time raw
+	// fields map disambiguates "sent as null" from "not sent at all".
+	shouldClearLocalDirectory := false
+	rawLocalDirectory, hasLocalDirectory := rawFields["local_directory"]
+	if hasLocalDirectory && bytes.Equal(bytes.TrimSpace(rawLocalDirectory), []byte("null")) {
+		shouldClearLocalDirectory = true
+	} else if hasLocalDirectory && req.LocalDirectory != nil {
+		value := *req.LocalDirectory
+		if value == "" {
+			shouldClearLocalDirectory = true
+		} else {
+			if err := validateLocalDirectory(value); err != nil {
+				writeError(w, http.StatusBadRequest, err.Error())
+				return
+			}
+			params.LocalDirectory = pgtype.Text{String: value, Valid: true}
+		}
+	}
+
 	// composio_toolkit_allowlist handling (MUL-3869). Tri-state semantics
 	// mirror thinking_level (see above): omitted → no change, null →
 	// ClearAgentComposioToolkitAllowlist, slice → wholesale replace.
@@ -1884,6 +1927,14 @@ func (h *Handler) UpdateAgent(w http.ResponseWriter, r *http.Request) {
 		if err != nil {
 			slog.Warn("clear agent composio_toolkit_allowlist failed", append(logger.RequestAttrs(r), "error", err, "agent_id", id)...)
 			writeError(w, http.StatusInternalServerError, "failed to clear composio_toolkit_allowlist: "+err.Error())
+			return
+		}
+	}
+	if shouldClearLocalDirectory {
+		updated, err = h.Queries.ClearAgentLocalDirectory(r.Context(), updated.ID)
+		if err != nil {
+			slog.Warn("clear agent local_directory failed", append(logger.RequestAttrs(r), "error", err, "agent_id", id)...)
+			writeError(w, http.StatusInternalServerError, "failed to clear local_directory: "+err.Error())
 			return
 		}
 	}

--- a/server/internal/handler/agent_test.go
+++ b/server/internal/handler/agent_test.go
@@ -1613,3 +1613,90 @@ func insertHandlerTestTask(t *testing.T, agentID string) string {
 // Defence-in-depth: spot-check that the package compiles a small
 // fmt.Sprintf so accidental imports stay tidy.
 var _ = fmt.Sprintf
+
+func TestCreateAgent_StoresLocalDirectory(t *testing.T) {
+	if testHandler == nil {
+		t.Skip("database not available")
+	}
+	t.Cleanup(func() {
+		testPool.Exec(context.Background(),
+			`DELETE FROM agent WHERE workspace_id = $1 AND name = $2`,
+			testWorkspaceID, "local-dir-agent")
+	})
+
+	body := map[string]any{
+		"name":            "local-dir-agent",
+		"runtime_id":      testRuntimeID,
+		"visibility":      "private",
+		"local_directory": "/abs/path/agent-dir",
+	}
+	w := httptest.NewRecorder()
+	testHandler.CreateAgent(w, newRequest(http.MethodPost, "/api/agents", body))
+	if w.Code != http.StatusCreated {
+		t.Fatalf("CreateAgent: expected 201, got %d: %s", w.Code, w.Body.String())
+	}
+	var resp map[string]any
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if got, _ := resp["local_directory"].(string); got != "/abs/path/agent-dir" {
+		t.Fatalf("expected local_directory in response, got %q", got)
+	}
+}
+
+func TestCreateAgent_RejectsRelativeLocalDirectory(t *testing.T) {
+	if testHandler == nil {
+		t.Skip("database not available")
+	}
+	body := map[string]any{
+		"name":            "local-dir-relative",
+		"runtime_id":      testRuntimeID,
+		"visibility":      "private",
+		"local_directory": "relative/path",
+	}
+	w := httptest.NewRecorder()
+	testHandler.CreateAgent(w, newRequest(http.MethodPost, "/api/agents", body))
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 for relative local_directory, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestUpdateAgent_LocalDirectoryTriState(t *testing.T) {
+	if testHandler == nil {
+		t.Skip("database not available")
+	}
+	id := createHandlerTestAgent(t, "local-dir-update", nil)
+	t.Cleanup(func() {
+		testPool.Exec(context.Background(), `DELETE FROM agent WHERE id = $1`, id)
+	})
+
+	// Set an absolute path.
+	w := httptest.NewRecorder()
+	testHandler.UpdateAgent(w, withURLParam(
+		newRequest(http.MethodPatch, "/api/agents/"+id, map[string]any{"local_directory": "/abs/update"}), "id", id))
+	if w.Code != http.StatusOK {
+		t.Fatalf("set local_directory: expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	var resp map[string]any
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if got, _ := resp["local_directory"].(string); got != "/abs/update" {
+		t.Fatalf("expected local_directory after set, got %q", got)
+	}
+
+	// Clear via JSON null.
+	w2 := httptest.NewRecorder()
+	testHandler.UpdateAgent(w2, withURLParam(
+		newRequest(http.MethodPatch, "/api/agents/"+id, map[string]any{"local_directory": nil}), "id", id))
+	if w2.Code != http.StatusOK {
+		t.Fatalf("clear local_directory: expected 200, got %d: %s", w2.Code, w2.Body.String())
+	}
+	var resp2 map[string]any
+	if err := json.NewDecoder(w2.Body).Decode(&resp2); err != nil {
+		t.Fatalf("decode clear response: %v", err)
+	}
+	if got, _ := resp2["local_directory"].(string); got != "" {
+		t.Fatalf("expected empty local_directory after clear, got %q", got)
+	}
+}

--- a/server/internal/handler/agent_validation.go
+++ b/server/internal/handler/agent_validation.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"path/filepath"
 
 	"github.com/multica-ai/multica/server/internal/agentconfig"
 )
@@ -22,4 +23,18 @@ func defaultAndValidateAgentMaxConcurrentTasks(rawFields map[string]json.RawMess
 		return nil
 	}
 	return validateAgentMaxConcurrentTasks(*value)
+}
+
+// validateLocalDirectory checks a directory-based agent's local_directory:
+// empty is valid (a normal agent), non-empty must be an absolute path. The
+// path's existence / readability is validated by the daemon at claim time,
+// not here — the browser cannot see the daemon machine's filesystem.
+func validateLocalDirectory(path string) error {
+	if path == "" {
+		return nil
+	}
+	if !filepath.IsAbs(path) {
+		return fmt.Errorf("local_directory must be an absolute path")
+	}
+	return nil
 }

--- a/server/internal/handler/daemon.go
+++ b/server/internal/handler/daemon.go
@@ -1694,6 +1694,7 @@ func (h *Handler) buildClaimedTaskResponse(r *http.Request, task *db.AgentTaskQu
 			Model:                 agent.Model.String,
 			ThinkingLevel:         agent.ThinkingLevel.String,
 			ServiceTier:           agent.ServiceTier.String,
+			LocalDirectory:        agent.LocalDirectory.String,
 			RuntimeConfig:         runtimeConfig,
 			DisabledRuntimeSkills: disabledRuntimeSkillsFor(agent.DisabledRuntimeSkills, runtimeID, runtime.Provider),
 		}

--- a/server/migrations/252_agent_local_directory.down.sql
+++ b/server/migrations/252_agent_local_directory.down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE agent DROP COLUMN local_directory;

--- a/server/migrations/252_agent_local_directory.up.sql
+++ b/server/migrations/252_agent_local_directory.up.sql
@@ -1,0 +1,5 @@
+-- Directory-based agents: a directory is the whole agent (its CLAUDE.md /
+-- skills / MCP config come from that directory). Stores the absolute path the
+-- agent's tasks run in. NULL means the agent uses the standard per-task envRoot
+-- workdir (or the project-level local_directory when one is attached).
+ALTER TABLE agent ADD COLUMN local_directory TEXT;

--- a/server/pkg/db/generated/agent.sql.go
+++ b/server/pkg/db/generated/agent.sql.go
@@ -14,7 +14,7 @@ import (
 const archiveAgent = `-- name: ArchiveAgent :one
 UPDATE agent SET archived_at = now(), archived_by = $2, updated_at = now()
 WHERE id = $1
-RETURNING id, workspace_id, name, avatar_url, runtime_mode, runtime_config, visibility, status, max_concurrent_tasks, owner_id, created_at, updated_at, description, runtime_id, instructions, archived_at, archived_by, custom_env, custom_args, mcp_config, model, thinking_level, composio_toolkit_allowlist, permission_mode, kind, system_key, disabled_runtime_skills, service_tier
+RETURNING id, workspace_id, name, avatar_url, runtime_mode, runtime_config, visibility, status, max_concurrent_tasks, owner_id, created_at, updated_at, description, runtime_id, instructions, archived_at, archived_by, custom_env, custom_args, mcp_config, model, thinking_level, composio_toolkit_allowlist, permission_mode, kind, system_key, disabled_runtime_skills, service_tier, local_directory
 `
 
 type ArchiveAgentParams struct {
@@ -54,6 +54,7 @@ func (q *Queries) ArchiveAgent(ctx context.Context, arg ArchiveAgentParams) (Age
 		&i.SystemKey,
 		&i.DisabledRuntimeSkills,
 		&i.ServiceTier,
+		&i.LocalDirectory,
 	)
 	return i, err
 }
@@ -62,7 +63,7 @@ const archiveAgentsByIDs = `-- name: ArchiveAgentsByIDs :many
 UPDATE agent
 SET archived_at = now(), archived_by = $1, updated_at = now()
 WHERE id = ANY($2::uuid[]) AND archived_at IS NULL
-RETURNING id, workspace_id, name, avatar_url, runtime_mode, runtime_config, visibility, status, max_concurrent_tasks, owner_id, created_at, updated_at, description, runtime_id, instructions, archived_at, archived_by, custom_env, custom_args, mcp_config, model, thinking_level, composio_toolkit_allowlist, permission_mode, kind, system_key, disabled_runtime_skills, service_tier
+RETURNING id, workspace_id, name, avatar_url, runtime_mode, runtime_config, visibility, status, max_concurrent_tasks, owner_id, created_at, updated_at, description, runtime_id, instructions, archived_at, archived_by, custom_env, custom_args, mcp_config, model, thinking_level, composio_toolkit_allowlist, permission_mode, kind, system_key, disabled_runtime_skills, service_tier, local_directory
 `
 
 type ArchiveAgentsByIDsParams struct {
@@ -116,6 +117,7 @@ func (q *Queries) ArchiveAgentsByIDs(ctx context.Context, arg ArchiveAgentsByIDs
 			&i.SystemKey,
 			&i.DisabledRuntimeSkills,
 			&i.ServiceTier,
+			&i.LocalDirectory,
 		); err != nil {
 			return nil, err
 		}
@@ -131,7 +133,7 @@ const archiveAgentsByRuntime = `-- name: ArchiveAgentsByRuntime :many
 UPDATE agent
 SET archived_at = now(), archived_by = $1, updated_at = now()
 WHERE runtime_id = ANY($2::uuid[]) AND archived_at IS NULL
-RETURNING id, workspace_id, name, avatar_url, runtime_mode, runtime_config, visibility, status, max_concurrent_tasks, owner_id, created_at, updated_at, description, runtime_id, instructions, archived_at, archived_by, custom_env, custom_args, mcp_config, model, thinking_level, composio_toolkit_allowlist, permission_mode, kind, system_key, disabled_runtime_skills, service_tier
+RETURNING id, workspace_id, name, avatar_url, runtime_mode, runtime_config, visibility, status, max_concurrent_tasks, owner_id, created_at, updated_at, description, runtime_id, instructions, archived_at, archived_by, custom_env, custom_args, mcp_config, model, thinking_level, composio_toolkit_allowlist, permission_mode, kind, system_key, disabled_runtime_skills, service_tier, local_directory
 `
 
 type ArchiveAgentsByRuntimeParams struct {
@@ -181,6 +183,7 @@ func (q *Queries) ArchiveAgentsByRuntime(ctx context.Context, arg ArchiveAgentsB
 			&i.SystemKey,
 			&i.DisabledRuntimeSkills,
 			&i.ServiceTier,
+			&i.LocalDirectory,
 		); err != nil {
 			return nil, err
 		}
@@ -1083,7 +1086,7 @@ func (q *Queries) ClaimChatFinalizeDeferred(ctx context.Context, id pgtype.UUID)
 const clearAgentComposioToolkitAllowlist = `-- name: ClearAgentComposioToolkitAllowlist :one
 UPDATE agent SET composio_toolkit_allowlist = NULL, updated_at = now()
 WHERE id = $1
-RETURNING id, workspace_id, name, avatar_url, runtime_mode, runtime_config, visibility, status, max_concurrent_tasks, owner_id, created_at, updated_at, description, runtime_id, instructions, archived_at, archived_by, custom_env, custom_args, mcp_config, model, thinking_level, composio_toolkit_allowlist, permission_mode, kind, system_key, disabled_runtime_skills, service_tier
+RETURNING id, workspace_id, name, avatar_url, runtime_mode, runtime_config, visibility, status, max_concurrent_tasks, owner_id, created_at, updated_at, description, runtime_id, instructions, archived_at, archived_by, custom_env, custom_args, mcp_config, model, thinking_level, composio_toolkit_allowlist, permission_mode, kind, system_key, disabled_runtime_skills, service_tier, local_directory
 `
 
 // Explicit NULL-clear for composio_toolkit_allowlist. The COALESCE-based
@@ -1124,6 +1127,53 @@ func (q *Queries) ClearAgentComposioToolkitAllowlist(ctx context.Context, id pgt
 		&i.SystemKey,
 		&i.DisabledRuntimeSkills,
 		&i.ServiceTier,
+		&i.LocalDirectory,
+	)
+	return i, err
+}
+
+const clearAgentLocalDirectory = `-- name: ClearAgentLocalDirectory :one
+UPDATE agent SET local_directory = NULL, updated_at = now()
+WHERE id = $1
+RETURNING id, workspace_id, name, avatar_url, runtime_mode, runtime_config, visibility, status, max_concurrent_tasks, owner_id, created_at, updated_at, description, runtime_id, instructions, archived_at, archived_by, custom_env, custom_args, mcp_config, model, thinking_level, composio_toolkit_allowlist, permission_mode, kind, system_key, disabled_runtime_skills, service_tier, local_directory
+`
+
+// Explicit NULL-clear for local_directory. The COALESCE-based UpdateAgent
+// cannot set the column back to NULL, so reverting a directory-based agent to
+// the standard per-task workdir routes through this dedicated query.
+func (q *Queries) ClearAgentLocalDirectory(ctx context.Context, id pgtype.UUID) (Agent, error) {
+	row := q.db.QueryRow(ctx, clearAgentLocalDirectory, id)
+	var i Agent
+	err := row.Scan(
+		&i.ID,
+		&i.WorkspaceID,
+		&i.Name,
+		&i.AvatarUrl,
+		&i.RuntimeMode,
+		&i.RuntimeConfig,
+		&i.Visibility,
+		&i.Status,
+		&i.MaxConcurrentTasks,
+		&i.OwnerID,
+		&i.CreatedAt,
+		&i.UpdatedAt,
+		&i.Description,
+		&i.RuntimeID,
+		&i.Instructions,
+		&i.ArchivedAt,
+		&i.ArchivedBy,
+		&i.CustomEnv,
+		&i.CustomArgs,
+		&i.McpConfig,
+		&i.Model,
+		&i.ThinkingLevel,
+		&i.ComposioToolkitAllowlist,
+		&i.PermissionMode,
+		&i.Kind,
+		&i.SystemKey,
+		&i.DisabledRuntimeSkills,
+		&i.ServiceTier,
+		&i.LocalDirectory,
 	)
 	return i, err
 }
@@ -1131,7 +1181,7 @@ func (q *Queries) ClearAgentComposioToolkitAllowlist(ctx context.Context, id pgt
 const clearAgentMcpConfig = `-- name: ClearAgentMcpConfig :one
 UPDATE agent SET mcp_config = NULL, updated_at = now()
 WHERE id = $1
-RETURNING id, workspace_id, name, avatar_url, runtime_mode, runtime_config, visibility, status, max_concurrent_tasks, owner_id, created_at, updated_at, description, runtime_id, instructions, archived_at, archived_by, custom_env, custom_args, mcp_config, model, thinking_level, composio_toolkit_allowlist, permission_mode, kind, system_key, disabled_runtime_skills, service_tier
+RETURNING id, workspace_id, name, avatar_url, runtime_mode, runtime_config, visibility, status, max_concurrent_tasks, owner_id, created_at, updated_at, description, runtime_id, instructions, archived_at, archived_by, custom_env, custom_args, mcp_config, model, thinking_level, composio_toolkit_allowlist, permission_mode, kind, system_key, disabled_runtime_skills, service_tier, local_directory
 `
 
 func (q *Queries) ClearAgentMcpConfig(ctx context.Context, id pgtype.UUID) (Agent, error) {
@@ -1166,6 +1216,7 @@ func (q *Queries) ClearAgentMcpConfig(ctx context.Context, id pgtype.UUID) (Agen
 		&i.SystemKey,
 		&i.DisabledRuntimeSkills,
 		&i.ServiceTier,
+		&i.LocalDirectory,
 	)
 	return i, err
 }
@@ -1173,7 +1224,7 @@ func (q *Queries) ClearAgentMcpConfig(ctx context.Context, id pgtype.UUID) (Agen
 const clearAgentServiceTier = `-- name: ClearAgentServiceTier :one
 UPDATE agent SET service_tier = NULL, updated_at = now()
 WHERE id = $1
-RETURNING id, workspace_id, name, avatar_url, runtime_mode, runtime_config, visibility, status, max_concurrent_tasks, owner_id, created_at, updated_at, description, runtime_id, instructions, archived_at, archived_by, custom_env, custom_args, mcp_config, model, thinking_level, composio_toolkit_allowlist, permission_mode, kind, system_key, disabled_runtime_skills, service_tier
+RETURNING id, workspace_id, name, avatar_url, runtime_mode, runtime_config, visibility, status, max_concurrent_tasks, owner_id, created_at, updated_at, description, runtime_id, instructions, archived_at, archived_by, custom_env, custom_args, mcp_config, model, thinking_level, composio_toolkit_allowlist, permission_mode, kind, system_key, disabled_runtime_skills, service_tier, local_directory
 `
 
 // Explicit NULL-clear for service_tier. COALESCE-based UpdateAgent cannot
@@ -1210,6 +1261,7 @@ func (q *Queries) ClearAgentServiceTier(ctx context.Context, id pgtype.UUID) (Ag
 		&i.SystemKey,
 		&i.DisabledRuntimeSkills,
 		&i.ServiceTier,
+		&i.LocalDirectory,
 	)
 	return i, err
 }
@@ -1217,7 +1269,7 @@ func (q *Queries) ClearAgentServiceTier(ctx context.Context, id pgtype.UUID) (Ag
 const clearAgentThinkingLevel = `-- name: ClearAgentThinkingLevel :one
 UPDATE agent SET thinking_level = NULL, updated_at = now()
 WHERE id = $1
-RETURNING id, workspace_id, name, avatar_url, runtime_mode, runtime_config, visibility, status, max_concurrent_tasks, owner_id, created_at, updated_at, description, runtime_id, instructions, archived_at, archived_by, custom_env, custom_args, mcp_config, model, thinking_level, composio_toolkit_allowlist, permission_mode, kind, system_key, disabled_runtime_skills, service_tier
+RETURNING id, workspace_id, name, avatar_url, runtime_mode, runtime_config, visibility, status, max_concurrent_tasks, owner_id, created_at, updated_at, description, runtime_id, instructions, archived_at, archived_by, custom_env, custom_args, mcp_config, model, thinking_level, composio_toolkit_allowlist, permission_mode, kind, system_key, disabled_runtime_skills, service_tier, local_directory
 `
 
 // Explicit NULL-clear for thinking_level. COALESCE-based UpdateAgent cannot
@@ -1255,6 +1307,7 @@ func (q *Queries) ClearAgentThinkingLevel(ctx context.Context, id pgtype.UUID) (
 		&i.SystemKey,
 		&i.DisabledRuntimeSkills,
 		&i.ServiceTier,
+		&i.LocalDirectory,
 	)
 	return i, err
 }
@@ -1374,17 +1427,17 @@ INSERT INTO agent (
     workspace_id, name, description, avatar_url, runtime_mode,
     runtime_config, runtime_id, visibility, max_concurrent_tasks, owner_id,
     instructions, custom_env, custom_args, mcp_config, model, thinking_level,
-    service_tier,
+    service_tier, local_directory,
     composio_toolkit_allowlist, permission_mode
 ) VALUES (
     $1, $2, $3, $4, $5,
     $6, $7, $8, $9, $10,
     $11, $12, $13, $14, $15, $16,
-    $17,
-    $18::text[],
-    COALESCE($19, 'private')
+    $17, $18,
+    $19::text[],
+    COALESCE($20, 'private')
 )
-RETURNING id, workspace_id, name, avatar_url, runtime_mode, runtime_config, visibility, status, max_concurrent_tasks, owner_id, created_at, updated_at, description, runtime_id, instructions, archived_at, archived_by, custom_env, custom_args, mcp_config, model, thinking_level, composio_toolkit_allowlist, permission_mode, kind, system_key, disabled_runtime_skills, service_tier
+RETURNING id, workspace_id, name, avatar_url, runtime_mode, runtime_config, visibility, status, max_concurrent_tasks, owner_id, created_at, updated_at, description, runtime_id, instructions, archived_at, archived_by, custom_env, custom_args, mcp_config, model, thinking_level, composio_toolkit_allowlist, permission_mode, kind, system_key, disabled_runtime_skills, service_tier, local_directory
 `
 
 type CreateAgentParams struct {
@@ -1405,6 +1458,7 @@ type CreateAgentParams struct {
 	Model                    pgtype.Text `json:"model"`
 	ThinkingLevel            pgtype.Text `json:"thinking_level"`
 	ServiceTier              pgtype.Text `json:"service_tier"`
+	LocalDirectory           pgtype.Text `json:"local_directory"`
 	ComposioToolkitAllowlist []string    `json:"composio_toolkit_allowlist"`
 	PermissionMode           interface{} `json:"permission_mode"`
 }
@@ -1428,6 +1482,7 @@ func (q *Queries) CreateAgent(ctx context.Context, arg CreateAgentParams) (Agent
 		arg.Model,
 		arg.ThinkingLevel,
 		arg.ServiceTier,
+		arg.LocalDirectory,
 		arg.ComposioToolkitAllowlist,
 		arg.PermissionMode,
 	)
@@ -1461,6 +1516,7 @@ func (q *Queries) CreateAgent(ctx context.Context, arg CreateAgentParams) (Agent
 		&i.SystemKey,
 		&i.DisabledRuntimeSkills,
 		&i.ServiceTier,
+		&i.LocalDirectory,
 	)
 	return i, err
 }
@@ -1475,7 +1531,7 @@ INSERT INTO agent (
     'private', 'private', 1, $5, $6,
     '{}'::jsonb, '[]'::jsonb, $7, 'system', $8
 )
-RETURNING id, workspace_id, name, avatar_url, runtime_mode, runtime_config, visibility, status, max_concurrent_tasks, owner_id, created_at, updated_at, description, runtime_id, instructions, archived_at, archived_by, custom_env, custom_args, mcp_config, model, thinking_level, composio_toolkit_allowlist, permission_mode, kind, system_key, disabled_runtime_skills, service_tier
+RETURNING id, workspace_id, name, avatar_url, runtime_mode, runtime_config, visibility, status, max_concurrent_tasks, owner_id, created_at, updated_at, description, runtime_id, instructions, archived_at, archived_by, custom_env, custom_args, mcp_config, model, thinking_level, composio_toolkit_allowlist, permission_mode, kind, system_key, disabled_runtime_skills, service_tier, local_directory
 `
 
 type CreateAgentBuilderParams struct {
@@ -1534,6 +1590,7 @@ func (q *Queries) CreateAgentBuilder(ctx context.Context, arg CreateAgentBuilder
 		&i.SystemKey,
 		&i.DisabledRuntimeSkills,
 		&i.ServiceTier,
+		&i.LocalDirectory,
 	)
 	return i, err
 }
@@ -2542,7 +2599,7 @@ func (q *Queries) FailStaleTasks(ctx context.Context, arg FailStaleTasksParams) 
 }
 
 const getAgent = `-- name: GetAgent :one
-SELECT id, workspace_id, name, avatar_url, runtime_mode, runtime_config, visibility, status, max_concurrent_tasks, owner_id, created_at, updated_at, description, runtime_id, instructions, archived_at, archived_by, custom_env, custom_args, mcp_config, model, thinking_level, composio_toolkit_allowlist, permission_mode, kind, system_key, disabled_runtime_skills, service_tier FROM agent
+SELECT id, workspace_id, name, avatar_url, runtime_mode, runtime_config, visibility, status, max_concurrent_tasks, owner_id, created_at, updated_at, description, runtime_id, instructions, archived_at, archived_by, custom_env, custom_args, mcp_config, model, thinking_level, composio_toolkit_allowlist, permission_mode, kind, system_key, disabled_runtime_skills, service_tier, local_directory FROM agent
 WHERE id = $1
 `
 
@@ -2578,12 +2635,13 @@ func (q *Queries) GetAgent(ctx context.Context, id pgtype.UUID) (Agent, error) {
 		&i.SystemKey,
 		&i.DisabledRuntimeSkills,
 		&i.ServiceTier,
+		&i.LocalDirectory,
 	)
 	return i, err
 }
 
 const getAgentForClaimUpdate = `-- name: GetAgentForClaimUpdate :one
-SELECT id, workspace_id, name, avatar_url, runtime_mode, runtime_config, visibility, status, max_concurrent_tasks, owner_id, created_at, updated_at, description, runtime_id, instructions, archived_at, archived_by, custom_env, custom_args, mcp_config, model, thinking_level, composio_toolkit_allowlist, permission_mode, kind, system_key, disabled_runtime_skills, service_tier FROM agent
+SELECT id, workspace_id, name, avatar_url, runtime_mode, runtime_config, visibility, status, max_concurrent_tasks, owner_id, created_at, updated_at, description, runtime_id, instructions, archived_at, archived_by, custom_env, custom_args, mcp_config, model, thinking_level, composio_toolkit_allowlist, permission_mode, kind, system_key, disabled_runtime_skills, service_tier, local_directory FROM agent
 WHERE id = $1
 FOR UPDATE
 `
@@ -2620,12 +2678,13 @@ func (q *Queries) GetAgentForClaimUpdate(ctx context.Context, id pgtype.UUID) (A
 		&i.SystemKey,
 		&i.DisabledRuntimeSkills,
 		&i.ServiceTier,
+		&i.LocalDirectory,
 	)
 	return i, err
 }
 
 const getAgentForUpdate = `-- name: GetAgentForUpdate :one
-SELECT id, workspace_id, name, avatar_url, runtime_mode, runtime_config, visibility, status, max_concurrent_tasks, owner_id, created_at, updated_at, description, runtime_id, instructions, archived_at, archived_by, custom_env, custom_args, mcp_config, model, thinking_level, composio_toolkit_allowlist, permission_mode, kind, system_key, disabled_runtime_skills, service_tier FROM agent
+SELECT id, workspace_id, name, avatar_url, runtime_mode, runtime_config, visibility, status, max_concurrent_tasks, owner_id, created_at, updated_at, description, runtime_id, instructions, archived_at, archived_by, custom_env, custom_args, mcp_config, model, thinking_level, composio_toolkit_allowlist, permission_mode, kind, system_key, disabled_runtime_skills, service_tier, local_directory FROM agent
 WHERE id = $1
 FOR UPDATE
 `
@@ -2664,12 +2723,13 @@ func (q *Queries) GetAgentForUpdate(ctx context.Context, id pgtype.UUID) (Agent,
 		&i.SystemKey,
 		&i.DisabledRuntimeSkills,
 		&i.ServiceTier,
+		&i.LocalDirectory,
 	)
 	return i, err
 }
 
 const getAgentInWorkspace = `-- name: GetAgentInWorkspace :one
-SELECT id, workspace_id, name, avatar_url, runtime_mode, runtime_config, visibility, status, max_concurrent_tasks, owner_id, created_at, updated_at, description, runtime_id, instructions, archived_at, archived_by, custom_env, custom_args, mcp_config, model, thinking_level, composio_toolkit_allowlist, permission_mode, kind, system_key, disabled_runtime_skills, service_tier FROM agent
+SELECT id, workspace_id, name, avatar_url, runtime_mode, runtime_config, visibility, status, max_concurrent_tasks, owner_id, created_at, updated_at, description, runtime_id, instructions, archived_at, archived_by, custom_env, custom_args, mcp_config, model, thinking_level, composio_toolkit_allowlist, permission_mode, kind, system_key, disabled_runtime_skills, service_tier, local_directory FROM agent
 WHERE id = $1 AND workspace_id = $2 AND kind = 'user'
 `
 
@@ -2710,6 +2770,7 @@ func (q *Queries) GetAgentInWorkspace(ctx context.Context, arg GetAgentInWorkspa
 		&i.SystemKey,
 		&i.DisabledRuntimeSkills,
 		&i.ServiceTier,
+		&i.LocalDirectory,
 	)
 	return i, err
 }
@@ -3335,7 +3396,7 @@ func (q *Queries) LinkTaskToIssue(ctx context.Context, arg LinkTaskToIssueParams
 }
 
 const listActiveAgentsByRuntime = `-- name: ListActiveAgentsByRuntime :many
-SELECT id, workspace_id, name, avatar_url, runtime_mode, runtime_config, visibility, status, max_concurrent_tasks, owner_id, created_at, updated_at, description, runtime_id, instructions, archived_at, archived_by, custom_env, custom_args, mcp_config, model, thinking_level, composio_toolkit_allowlist, permission_mode, kind, system_key, disabled_runtime_skills, service_tier FROM agent
+SELECT id, workspace_id, name, avatar_url, runtime_mode, runtime_config, visibility, status, max_concurrent_tasks, owner_id, created_at, updated_at, description, runtime_id, instructions, archived_at, archived_by, custom_env, custom_args, mcp_config, model, thinking_level, composio_toolkit_allowlist, permission_mode, kind, system_key, disabled_runtime_skills, service_tier, local_directory FROM agent
 WHERE runtime_id = $1 AND archived_at IS NULL AND kind = 'user'
 ORDER BY name ASC
 `
@@ -3384,6 +3445,7 @@ func (q *Queries) ListActiveAgentsByRuntime(ctx context.Context, runtimeID pgtyp
 			&i.SystemKey,
 			&i.DisabledRuntimeSkills,
 			&i.ServiceTier,
+			&i.LocalDirectory,
 		); err != nil {
 			return nil, err
 		}
@@ -3396,7 +3458,7 @@ func (q *Queries) ListActiveAgentsByRuntime(ctx context.Context, runtimeID pgtyp
 }
 
 const listActiveAgentsByRuntimeForUpdate = `-- name: ListActiveAgentsByRuntimeForUpdate :many
-SELECT id, workspace_id, name, avatar_url, runtime_mode, runtime_config, visibility, status, max_concurrent_tasks, owner_id, created_at, updated_at, description, runtime_id, instructions, archived_at, archived_by, custom_env, custom_args, mcp_config, model, thinking_level, composio_toolkit_allowlist, permission_mode, kind, system_key, disabled_runtime_skills, service_tier FROM agent
+SELECT id, workspace_id, name, avatar_url, runtime_mode, runtime_config, visibility, status, max_concurrent_tasks, owner_id, created_at, updated_at, description, runtime_id, instructions, archived_at, archived_by, custom_env, custom_args, mcp_config, model, thinking_level, composio_toolkit_allowlist, permission_mode, kind, system_key, disabled_runtime_skills, service_tier, local_directory FROM agent
 WHERE runtime_id = $1 AND archived_at IS NULL AND kind = 'user'
 ORDER BY name ASC
 FOR UPDATE
@@ -3447,6 +3509,7 @@ func (q *Queries) ListActiveAgentsByRuntimeForUpdate(ctx context.Context, runtim
 			&i.SystemKey,
 			&i.DisabledRuntimeSkills,
 			&i.ServiceTier,
+			&i.LocalDirectory,
 		); err != nil {
 			return nil, err
 		}
@@ -3620,7 +3683,7 @@ func (q *Queries) ListAgentTasks(ctx context.Context, agentID pgtype.UUID) ([]Ag
 }
 
 const listAgents = `-- name: ListAgents :many
-SELECT id, workspace_id, name, avatar_url, runtime_mode, runtime_config, visibility, status, max_concurrent_tasks, owner_id, created_at, updated_at, description, runtime_id, instructions, archived_at, archived_by, custom_env, custom_args, mcp_config, model, thinking_level, composio_toolkit_allowlist, permission_mode, kind, system_key, disabled_runtime_skills, service_tier FROM agent
+SELECT id, workspace_id, name, avatar_url, runtime_mode, runtime_config, visibility, status, max_concurrent_tasks, owner_id, created_at, updated_at, description, runtime_id, instructions, archived_at, archived_by, custom_env, custom_args, mcp_config, model, thinking_level, composio_toolkit_allowlist, permission_mode, kind, system_key, disabled_runtime_skills, service_tier, local_directory FROM agent
 WHERE workspace_id = $1 AND archived_at IS NULL AND kind = 'user'
 ORDER BY created_at ASC
 `
@@ -3663,6 +3726,7 @@ func (q *Queries) ListAgents(ctx context.Context, workspaceID pgtype.UUID) ([]Ag
 			&i.SystemKey,
 			&i.DisabledRuntimeSkills,
 			&i.ServiceTier,
+			&i.LocalDirectory,
 		); err != nil {
 			return nil, err
 		}
@@ -3675,7 +3739,7 @@ func (q *Queries) ListAgents(ctx context.Context, workspaceID pgtype.UUID) ([]Ag
 }
 
 const listAllAgents = `-- name: ListAllAgents :many
-SELECT id, workspace_id, name, avatar_url, runtime_mode, runtime_config, visibility, status, max_concurrent_tasks, owner_id, created_at, updated_at, description, runtime_id, instructions, archived_at, archived_by, custom_env, custom_args, mcp_config, model, thinking_level, composio_toolkit_allowlist, permission_mode, kind, system_key, disabled_runtime_skills, service_tier FROM agent
+SELECT id, workspace_id, name, avatar_url, runtime_mode, runtime_config, visibility, status, max_concurrent_tasks, owner_id, created_at, updated_at, description, runtime_id, instructions, archived_at, archived_by, custom_env, custom_args, mcp_config, model, thinking_level, composio_toolkit_allowlist, permission_mode, kind, system_key, disabled_runtime_skills, service_tier, local_directory FROM agent
 WHERE workspace_id = $1 AND kind = 'user'
 ORDER BY created_at ASC
 `
@@ -3718,6 +3782,7 @@ func (q *Queries) ListAllAgents(ctx context.Context, workspaceID pgtype.UUID) ([
 			&i.SystemKey,
 			&i.DisabledRuntimeSkills,
 			&i.ServiceTier,
+			&i.LocalDirectory,
 		); err != nil {
 			return nil, err
 		}
@@ -3730,7 +3795,7 @@ func (q *Queries) ListAllAgents(ctx context.Context, workspaceID pgtype.UUID) ([
 }
 
 const listAllAgentsAnyKind = `-- name: ListAllAgentsAnyKind :many
-SELECT id, workspace_id, name, avatar_url, runtime_mode, runtime_config, visibility, status, max_concurrent_tasks, owner_id, created_at, updated_at, description, runtime_id, instructions, archived_at, archived_by, custom_env, custom_args, mcp_config, model, thinking_level, composio_toolkit_allowlist, permission_mode, kind, system_key, disabled_runtime_skills, service_tier FROM agent
+SELECT id, workspace_id, name, avatar_url, runtime_mode, runtime_config, visibility, status, max_concurrent_tasks, owner_id, created_at, updated_at, description, runtime_id, instructions, archived_at, archived_by, custom_env, custom_args, mcp_config, model, thinking_level, composio_toolkit_allowlist, permission_mode, kind, system_key, disabled_runtime_skills, service_tier, local_directory FROM agent
 WHERE workspace_id = $1
 ORDER BY created_at ASC
 `
@@ -3783,6 +3848,7 @@ func (q *Queries) ListAllAgentsAnyKind(ctx context.Context, workspaceID pgtype.U
 			&i.SystemKey,
 			&i.DisabledRuntimeSkills,
 			&i.ServiceTier,
+			&i.LocalDirectory,
 		); err != nil {
 			return nil, err
 		}
@@ -4213,7 +4279,7 @@ func (q *Queries) ListTasksByIssue(ctx context.Context, issueID pgtype.UUID) ([]
 }
 
 const listUserAgentsByRuntimeForUpdate = `-- name: ListUserAgentsByRuntimeForUpdate :many
-SELECT id, workspace_id, name, avatar_url, runtime_mode, runtime_config, visibility, status, max_concurrent_tasks, owner_id, created_at, updated_at, description, runtime_id, instructions, archived_at, archived_by, custom_env, custom_args, mcp_config, model, thinking_level, composio_toolkit_allowlist, permission_mode, kind, system_key, disabled_runtime_skills, service_tier FROM agent
+SELECT id, workspace_id, name, avatar_url, runtime_mode, runtime_config, visibility, status, max_concurrent_tasks, owner_id, created_at, updated_at, description, runtime_id, instructions, archived_at, archived_by, custom_env, custom_args, mcp_config, model, thinking_level, composio_toolkit_allowlist, permission_mode, kind, system_key, disabled_runtime_skills, service_tier, local_directory FROM agent
 WHERE runtime_id = $1 AND kind = 'user'
 ORDER BY id
 FOR UPDATE
@@ -4262,6 +4328,7 @@ func (q *Queries) ListUserAgentsByRuntimeForUpdate(ctx context.Context, runtimeI
 			&i.SystemKey,
 			&i.DisabledRuntimeSkills,
 			&i.ServiceTier,
+			&i.LocalDirectory,
 		); err != nil {
 			return nil, err
 		}
@@ -4567,7 +4634,7 @@ func (q *Queries) ListWorkspaceWorkingAgents(ctx context.Context, arg ListWorksp
 }
 
 const lockAgentForAutopilotAssignment = `-- name: LockAgentForAutopilotAssignment :one
-SELECT id, workspace_id, name, avatar_url, runtime_mode, runtime_config, visibility, status, max_concurrent_tasks, owner_id, created_at, updated_at, description, runtime_id, instructions, archived_at, archived_by, custom_env, custom_args, mcp_config, model, thinking_level, composio_toolkit_allowlist, permission_mode, kind, system_key, disabled_runtime_skills, service_tier FROM agent
+SELECT id, workspace_id, name, avatar_url, runtime_mode, runtime_config, visibility, status, max_concurrent_tasks, owner_id, created_at, updated_at, description, runtime_id, instructions, archived_at, archived_by, custom_env, custom_args, mcp_config, model, thinking_level, composio_toolkit_allowlist, permission_mode, kind, system_key, disabled_runtime_skills, service_tier, local_directory FROM agent
 WHERE id = $1 AND workspace_id = $2 AND kind = 'user'
 FOR SHARE
 `
@@ -4618,6 +4685,7 @@ func (q *Queries) LockAgentForAutopilotAssignment(ctx context.Context, arg LockA
 		&i.SystemKey,
 		&i.DisabledRuntimeSkills,
 		&i.ServiceTier,
+		&i.LocalDirectory,
 	)
 	return i, err
 }
@@ -5076,7 +5144,7 @@ SET runtime_id = $1,
     model = $3,
     updated_at = now()
 WHERE id = $4 AND kind = 'system' AND system_key LIKE 'agent_builder:%'
-RETURNING id, workspace_id, name, avatar_url, runtime_mode, runtime_config, visibility, status, max_concurrent_tasks, owner_id, created_at, updated_at, description, runtime_id, instructions, archived_at, archived_by, custom_env, custom_args, mcp_config, model, thinking_level, composio_toolkit_allowlist, permission_mode, kind, system_key, disabled_runtime_skills, service_tier
+RETURNING id, workspace_id, name, avatar_url, runtime_mode, runtime_config, visibility, status, max_concurrent_tasks, owner_id, created_at, updated_at, description, runtime_id, instructions, archived_at, archived_by, custom_env, custom_args, mcp_config, model, thinking_level, composio_toolkit_allowlist, permission_mode, kind, system_key, disabled_runtime_skills, service_tier, local_directory
 `
 
 type RebindAgentBuilderRuntimeParams struct {
@@ -5139,6 +5207,7 @@ func (q *Queries) RebindAgentBuilderRuntime(ctx context.Context, arg RebindAgent
 		&i.SystemKey,
 		&i.DisabledRuntimeSkills,
 		&i.ServiceTier,
+		&i.LocalDirectory,
 	)
 	return i, err
 }
@@ -5438,7 +5507,7 @@ SET status = CASE WHEN EXISTS (
 ) THEN 'working' ELSE 'idle' END,
     updated_at = now()
 WHERE a.id = $1
-RETURNING id, workspace_id, name, avatar_url, runtime_mode, runtime_config, visibility, status, max_concurrent_tasks, owner_id, created_at, updated_at, description, runtime_id, instructions, archived_at, archived_by, custom_env, custom_args, mcp_config, model, thinking_level, composio_toolkit_allowlist, permission_mode, kind, system_key, disabled_runtime_skills, service_tier
+RETURNING id, workspace_id, name, avatar_url, runtime_mode, runtime_config, visibility, status, max_concurrent_tasks, owner_id, created_at, updated_at, description, runtime_id, instructions, archived_at, archived_by, custom_env, custom_args, mcp_config, model, thinking_level, composio_toolkit_allowlist, permission_mode, kind, system_key, disabled_runtime_skills, service_tier, local_directory
 `
 
 func (q *Queries) RefreshAgentStatusFromTasks(ctx context.Context, id pgtype.UUID) (Agent, error) {
@@ -5473,6 +5542,7 @@ func (q *Queries) RefreshAgentStatusFromTasks(ctx context.Context, id pgtype.UUI
 		&i.SystemKey,
 		&i.DisabledRuntimeSkills,
 		&i.ServiceTier,
+		&i.LocalDirectory,
 	)
 	return i, err
 }
@@ -5633,7 +5703,7 @@ func (q *Queries) RequeueAgentTaskAfterClaimFailure(ctx context.Context, arg Req
 const restoreAgent = `-- name: RestoreAgent :one
 UPDATE agent SET archived_at = NULL, archived_by = NULL, updated_at = now()
 WHERE id = $1
-RETURNING id, workspace_id, name, avatar_url, runtime_mode, runtime_config, visibility, status, max_concurrent_tasks, owner_id, created_at, updated_at, description, runtime_id, instructions, archived_at, archived_by, custom_env, custom_args, mcp_config, model, thinking_level, composio_toolkit_allowlist, permission_mode, kind, system_key, disabled_runtime_skills, service_tier
+RETURNING id, workspace_id, name, avatar_url, runtime_mode, runtime_config, visibility, status, max_concurrent_tasks, owner_id, created_at, updated_at, description, runtime_id, instructions, archived_at, archived_by, custom_env, custom_args, mcp_config, model, thinking_level, composio_toolkit_allowlist, permission_mode, kind, system_key, disabled_runtime_skills, service_tier, local_directory
 `
 
 func (q *Queries) RestoreAgent(ctx context.Context, id pgtype.UUID) (Agent, error) {
@@ -5668,6 +5738,7 @@ func (q *Queries) RestoreAgent(ctx context.Context, id pgtype.UUID) (Agent, erro
 		&i.SystemKey,
 		&i.DisabledRuntimeSkills,
 		&i.ServiceTier,
+		&i.LocalDirectory,
 	)
 	return i, err
 }
@@ -5813,10 +5884,11 @@ UPDATE agent SET
     model = COALESCE($16, model),
     thinking_level = COALESCE($17, thinking_level),
     service_tier = COALESCE($18, service_tier),
-    composio_toolkit_allowlist = COALESCE($19::text[], composio_toolkit_allowlist),
+    local_directory = COALESCE($19, local_directory),
+    composio_toolkit_allowlist = COALESCE($20::text[], composio_toolkit_allowlist),
     updated_at = now()
 WHERE id = $1
-RETURNING id, workspace_id, name, avatar_url, runtime_mode, runtime_config, visibility, status, max_concurrent_tasks, owner_id, created_at, updated_at, description, runtime_id, instructions, archived_at, archived_by, custom_env, custom_args, mcp_config, model, thinking_level, composio_toolkit_allowlist, permission_mode, kind, system_key, disabled_runtime_skills, service_tier
+RETURNING id, workspace_id, name, avatar_url, runtime_mode, runtime_config, visibility, status, max_concurrent_tasks, owner_id, created_at, updated_at, description, runtime_id, instructions, archived_at, archived_by, custom_env, custom_args, mcp_config, model, thinking_level, composio_toolkit_allowlist, permission_mode, kind, system_key, disabled_runtime_skills, service_tier, local_directory
 `
 
 type UpdateAgentParams struct {
@@ -5838,6 +5910,7 @@ type UpdateAgentParams struct {
 	Model                    pgtype.Text `json:"model"`
 	ThinkingLevel            pgtype.Text `json:"thinking_level"`
 	ServiceTier              pgtype.Text `json:"service_tier"`
+	LocalDirectory           pgtype.Text `json:"local_directory"`
 	ComposioToolkitAllowlist []string    `json:"composio_toolkit_allowlist"`
 }
 
@@ -5867,6 +5940,7 @@ func (q *Queries) UpdateAgent(ctx context.Context, arg UpdateAgentParams) (Agent
 		arg.Model,
 		arg.ThinkingLevel,
 		arg.ServiceTier,
+		arg.LocalDirectory,
 		arg.ComposioToolkitAllowlist,
 	)
 	var i Agent
@@ -5899,6 +5973,7 @@ func (q *Queries) UpdateAgent(ctx context.Context, arg UpdateAgentParams) (Agent
 		&i.SystemKey,
 		&i.DisabledRuntimeSkills,
 		&i.ServiceTier,
+		&i.LocalDirectory,
 	)
 	return i, err
 }
@@ -5907,7 +5982,7 @@ const updateAgentCustomEnv = `-- name: UpdateAgentCustomEnv :one
 UPDATE agent
 SET custom_env = $2, updated_at = now()
 WHERE id = $1
-RETURNING id, workspace_id, name, avatar_url, runtime_mode, runtime_config, visibility, status, max_concurrent_tasks, owner_id, created_at, updated_at, description, runtime_id, instructions, archived_at, archived_by, custom_env, custom_args, mcp_config, model, thinking_level, composio_toolkit_allowlist, permission_mode, kind, system_key, disabled_runtime_skills, service_tier
+RETURNING id, workspace_id, name, avatar_url, runtime_mode, runtime_config, visibility, status, max_concurrent_tasks, owner_id, created_at, updated_at, description, runtime_id, instructions, archived_at, archived_by, custom_env, custom_args, mcp_config, model, thinking_level, composio_toolkit_allowlist, permission_mode, kind, system_key, disabled_runtime_skills, service_tier, local_directory
 `
 
 type UpdateAgentCustomEnvParams struct {
@@ -5952,6 +6027,7 @@ func (q *Queries) UpdateAgentCustomEnv(ctx context.Context, arg UpdateAgentCusto
 		&i.SystemKey,
 		&i.DisabledRuntimeSkills,
 		&i.ServiceTier,
+		&i.LocalDirectory,
 	)
 	return i, err
 }
@@ -5960,7 +6036,7 @@ const updateAgentDisabledRuntimeSkills = `-- name: UpdateAgentDisabledRuntimeSki
 UPDATE agent
 SET disabled_runtime_skills = $2, updated_at = now()
 WHERE id = $1
-RETURNING id, workspace_id, name, avatar_url, runtime_mode, runtime_config, visibility, status, max_concurrent_tasks, owner_id, created_at, updated_at, description, runtime_id, instructions, archived_at, archived_by, custom_env, custom_args, mcp_config, model, thinking_level, composio_toolkit_allowlist, permission_mode, kind, system_key, disabled_runtime_skills, service_tier
+RETURNING id, workspace_id, name, avatar_url, runtime_mode, runtime_config, visibility, status, max_concurrent_tasks, owner_id, created_at, updated_at, description, runtime_id, instructions, archived_at, archived_by, custom_env, custom_args, mcp_config, model, thinking_level, composio_toolkit_allowlist, permission_mode, kind, system_key, disabled_runtime_skills, service_tier, local_directory
 `
 
 type UpdateAgentDisabledRuntimeSkillsParams struct {
@@ -6000,6 +6076,7 @@ func (q *Queries) UpdateAgentDisabledRuntimeSkills(ctx context.Context, arg Upda
 		&i.SystemKey,
 		&i.DisabledRuntimeSkills,
 		&i.ServiceTier,
+		&i.LocalDirectory,
 	)
 	return i, err
 }
@@ -6007,7 +6084,7 @@ func (q *Queries) UpdateAgentDisabledRuntimeSkills(ctx context.Context, arg Upda
 const updateAgentStatus = `-- name: UpdateAgentStatus :one
 UPDATE agent SET status = $2, updated_at = now()
 WHERE id = $1
-RETURNING id, workspace_id, name, avatar_url, runtime_mode, runtime_config, visibility, status, max_concurrent_tasks, owner_id, created_at, updated_at, description, runtime_id, instructions, archived_at, archived_by, custom_env, custom_args, mcp_config, model, thinking_level, composio_toolkit_allowlist, permission_mode, kind, system_key, disabled_runtime_skills, service_tier
+RETURNING id, workspace_id, name, avatar_url, runtime_mode, runtime_config, visibility, status, max_concurrent_tasks, owner_id, created_at, updated_at, description, runtime_id, instructions, archived_at, archived_by, custom_env, custom_args, mcp_config, model, thinking_level, composio_toolkit_allowlist, permission_mode, kind, system_key, disabled_runtime_skills, service_tier, local_directory
 `
 
 type UpdateAgentStatusParams struct {
@@ -6047,6 +6124,7 @@ func (q *Queries) UpdateAgentStatus(ctx context.Context, arg UpdateAgentStatusPa
 		&i.SystemKey,
 		&i.DisabledRuntimeSkills,
 		&i.ServiceTier,
+		&i.LocalDirectory,
 	)
 	return i, err
 }

--- a/server/pkg/db/generated/models.go
+++ b/server/pkg/db/generated/models.go
@@ -52,6 +52,7 @@ type Agent struct {
 	SystemKey             pgtype.Text `json:"system_key"`
 	DisabledRuntimeSkills []byte      `json:"disabled_runtime_skills"`
 	ServiceTier           pgtype.Text `json:"service_tier"`
+	LocalDirectory        pgtype.Text `json:"local_directory"`
 }
 
 // Allow-list of who may invoke a public_to agent (MUL-3963). One row per (agent, target_type, target); targets stack and canInvokeAgent OR-matches. workspace rows store the agent workspace_id in target_id; member rows store the user id; team rows are reserved and inert in V1. Rows only matter when agent.permission_mode = public_to. No DB foreign keys: agent_id / created_by / member target_id relationships are maintained in the application layer (see migration comment).

--- a/server/pkg/db/generated/runtime.sql.go
+++ b/server/pkg/db/generated/runtime.sql.go
@@ -992,7 +992,7 @@ const unbindUserAgentsFromRuntime = `-- name: UnbindUserAgentsFromRuntime :many
 UPDATE agent
 SET runtime_id = NULL, updated_at = now()
 WHERE runtime_id = $1 AND kind = 'user'
-RETURNING id, workspace_id, name, avatar_url, runtime_mode, runtime_config, visibility, status, max_concurrent_tasks, owner_id, created_at, updated_at, description, runtime_id, instructions, archived_at, archived_by, custom_env, custom_args, mcp_config, model, thinking_level, composio_toolkit_allowlist, permission_mode, kind, system_key, disabled_runtime_skills, service_tier
+RETURNING id, workspace_id, name, avatar_url, runtime_mode, runtime_config, visibility, status, max_concurrent_tasks, owner_id, created_at, updated_at, description, runtime_id, instructions, archived_at, archived_by, custom_env, custom_args, mcp_config, model, thinking_level, composio_toolkit_allowlist, permission_mode, kind, system_key, disabled_runtime_skills, service_tier, local_directory
 `
 
 // MUL-5559: the runtime-delete replacement for archive-then-hard-delete. Every
@@ -1043,6 +1043,7 @@ func (q *Queries) UnbindUserAgentsFromRuntime(ctx context.Context, runtimeID pgt
 			&i.SystemKey,
 			&i.DisabledRuntimeSkills,
 			&i.ServiceTier,
+			&i.LocalDirectory,
 		); err != nil {
 			return nil, err
 		}

--- a/server/pkg/db/queries/agent.sql
+++ b/server/pkg/db/queries/agent.sql
@@ -57,13 +57,13 @@ INSERT INTO agent (
     workspace_id, name, description, avatar_url, runtime_mode,
     runtime_config, runtime_id, visibility, max_concurrent_tasks, owner_id,
     instructions, custom_env, custom_args, mcp_config, model, thinking_level,
-    service_tier,
+    service_tier, local_directory,
     composio_toolkit_allowlist, permission_mode
 ) VALUES (
     $1, $2, $3, $4, $5,
     $6, $7, $8, $9, $10,
     $11, $12, $13, $14, $15, $16,
-    $17,
+    $17, sqlc.narg('local_directory'),
     sqlc.narg('composio_toolkit_allowlist')::text[],
     COALESCE(sqlc.narg('permission_mode'), 'private')
 )
@@ -142,6 +142,7 @@ UPDATE agent SET
     model = COALESCE(sqlc.narg('model'), model),
     thinking_level = COALESCE(sqlc.narg('thinking_level'), thinking_level),
     service_tier = COALESCE(sqlc.narg('service_tier'), service_tier),
+    local_directory = COALESCE(sqlc.narg('local_directory'), local_directory),
     composio_toolkit_allowlist = COALESCE(sqlc.narg('composio_toolkit_allowlist')::text[], composio_toolkit_allowlist),
     updated_at = now()
 WHERE id = $1
@@ -175,6 +176,14 @@ RETURNING *;
 
 -- name: ClearAgentMcpConfig :one
 UPDATE agent SET mcp_config = NULL, updated_at = now()
+WHERE id = $1
+RETURNING *;
+
+-- name: ClearAgentLocalDirectory :one
+-- Explicit NULL-clear for local_directory. The COALESCE-based UpdateAgent
+-- cannot set the column back to NULL, so reverting a directory-based agent to
+-- the standard per-task workdir routes through this dedicated query.
+UPDATE agent SET local_directory = NULL, updated_at = now()
 WHERE id = $1
 RETURNING *;
 


### PR DESCRIPTION
## Summary

Adds **directory-based agents**: create an agent bound to a local directory, and the agent's tasks run in that directory — its `CLAUDE.md` / skills / MCP config **are** the agent's whole behavior. This serves the workflow where a user already maintains a complete agent in a directory and wants to publish it to Multica without re-configuring prompts and skills.

## Changes

- **DB / sqlc**: `agent.local_directory` column (migration 252) + `CreateAgent` / `UpdateAgent` / `ClearAgentLocalDirectory` queries
- **API**: `CreateAgentRequest` / `UpdateAgentRequest` / `AgentResponse` carry `local_directory` (tri-state update: omitted preserves, `null`/`""` clears, absolute path sets; relative paths rejected 400)
- **Frontend**: creation studio gains a "From a local directory" mode card; the behavior section becomes a local-directory picker (native chooser on desktop, path input on web) and instructions/skills are hidden; the agent detail page hides behavior/capabilities tabs for directory agents; 4-locale i18n copy
- **Daemon**: task execution uses `agent.local_directory` as the agent CLI's `cwd`, reusing `validateLocalPath` / `LocalPathLocker`, taking **precedence over** the project-level `local_directory`

## Design notes

- Directory-based agents are bound to the runtime/daemon that owns the directory (claim routing already guarantees this).
- The Multica runtime brief is still injected via the marker-block append (`writeRuntimeConfigFile`), so the user's own `CLAUDE.md` is never clobbered.
- Same-directory tasks are serialized by the existing path mutex, like project-level `local_directory`.

## Testing

- New handler tests: `TestCreateAgent_StoresLocalDirectory`, `TestCreateAgent_RejectsRelativeLocalDirectory`, `TestUpdateAgent_LocalDirectoryTriState`
- `go vet` + `go test ./internal/handler ./internal/daemon ./internal/service` — all pass
- Frontend: `pnpm typecheck` (core/views/web) + `vitest run agents/` (239 tests) — all pass
- Manual E2E: created a directory agent → dispatched an issue → daemon ran `claude` with `cwd` = the directory (verified via `pwd`), task completed
