### PR TITLE
MUL-5708 fix(taskfailure): classify response-side context-window overflow

### DIFF
--- a/server/internal/service/task_complete_race_test.go
+++ b/server/internal/service/task_complete_race_test.go
@@ -324,3 +324,40 @@ func TestSkillBundleFailureFromLegacyDaemonRetries(t *testing.T) {
 		t.Errorf("a skill-bundle failure reported by a current daemon must be retried; got reason %q", current)
 	}
 }
+
+// TestContextOverflowFromLegacyDaemonRetiresSession is the mixed-version
+// regression for GH #6360. It walks the chain FailTask runs for a task an
+// un-upgraded daemon just failed on a response-side context overflow, and
+// asserts the user-visible outcome: the conversation is retired, so the next
+// comment on that issue starts from a fresh session.
+//
+// Higher stakes than the skill-bundle case above. There, a stale label costs
+// one missed retry; here the catchall is on no resume blacklist, so the
+// over-full session stays pinned as the (agent, issue) resume pointer and
+// EVERY later comment replays the same overflow — one un-upgraded host means a
+// permanently stuck issue until it updates.
+func TestContextOverflowFromLegacyDaemonRetiresSession(t *testing.T) {
+	// Verbatim from Claude Code 2.1.x: the turn is not rejected with a 400,
+	// the response comes back with stop_reason model_context_window_exceeded.
+	const overflowErr = "API Error: The model has reached its context window limit."
+
+	legacyReason := taskfailure.ReasonAgentUnknown.String()
+	if ResumeUnsafeFailure(legacyReason, overflowErr) {
+		t.Fatal("precondition: the raw catchall must be resume-safe, or this test proves nothing")
+	}
+
+	normalized := taskfailure.NormalizeDaemonReason(legacyReason, overflowErr).String()
+	if normalized != taskfailure.ReasonAgentContextOverflow.String() {
+		t.Fatalf("normalized reason = %q, want %q", normalized, taskfailure.ReasonAgentContextOverflow)
+	}
+	if !ResumeUnsafeFailure(normalized, overflowErr) {
+		t.Errorf("an overflow reported by an old daemon must retire the session; got reason %q", normalized)
+	}
+
+	// A current daemon supplies the reason itself and must reach the same
+	// outcome — the two versions converge rather than diverging by client.
+	current := taskfailure.NormalizeDaemonReason(taskfailure.ReasonAgentContextOverflow.String(), overflowErr).String()
+	if !ResumeUnsafeFailure(current, overflowErr) {
+		t.Errorf("an overflow reported by a current daemon must retire the session; got reason %q", current)
+	}
+}

--- a/server/pkg/taskfailure/classify.go
+++ b/server/pkg/taskfailure/classify.go
@@ -80,6 +80,20 @@ func Classify(rawError string) Reason {
 		"maximum context",
 		"prompt is too long",
 		"context size has been exceeded",
+		// Overflow reported on the RESPONSE rather than as a 400 on the
+		// request: the provider accepts the call and ends the turn with
+		// stop_reason "model_context_window_exceeded", which Claude Code
+		// 2.1.x surfaces verbatim as "API Error: The model has reached its
+		// context window limit." (GH #6360). It carries neither "token" nor
+		// any of the phrases above, so it used to land in
+		// agent_error.unknown — a reason the resume blacklists do not cover,
+		// which left the over-full session pinned as the resume pointer and
+		// made every later comment on that issue replay the same overflow.
+		// Both wordings are matched so a backend forwarding the raw stop
+		// reason classifies the same way as one forwarding the CLI's copy.
+		"context window limit",
+		"model_context_window_exceeded",
+		// Mirror these substrings into the MUL-1949 offline backfill SQL.
 	),
 		// SQL had `%token%limit%` — ILIKE wildcard between tokens. We
 		// approximate with both substrings present, which catches

--- a/server/pkg/taskfailure/classify.go
+++ b/server/pkg/taskfailure/classify.go
@@ -80,21 +80,8 @@ func Classify(rawError string) Reason {
 		"maximum context",
 		"prompt is too long",
 		"context size has been exceeded",
-		// Overflow reported on the RESPONSE rather than as a 400 on the
-		// request: the provider accepts the call and ends the turn with
-		// stop_reason "model_context_window_exceeded", which Claude Code
-		// 2.1.x surfaces verbatim as "API Error: The model has reached its
-		// context window limit." (GH #6360). It carries neither "token" nor
-		// any of the phrases above, so it used to land in
-		// agent_error.unknown — a reason the resume blacklists do not cover,
-		// which left the over-full session pinned as the resume pointer and
-		// made every later comment on that issue replay the same overflow.
-		// Both wordings are matched so a backend forwarding the raw stop
-		// reason classifies the same way as one forwarding the CLI's copy.
-		"context window limit",
-		"model_context_window_exceeded",
-		// Mirror these substrings into the MUL-1949 offline backfill SQL.
 	),
+		containsAny(lower, contextWindowExceededWitnesses...),
 		// SQL had `%token%limit%` — ILIKE wildcard between tokens. We
 		// approximate with both substrings present, which catches
 		// "token limit", "tokens per minute limit", etc., without the
@@ -268,6 +255,27 @@ func Classify(rawError string) Reason {
 	return ReasonAgentUnknown
 }
 
+// contextWindowExceededWitnesses are the two wordings for an overflow reported
+// on the RESPONSE rather than as a 400 on the request: the provider accepts the
+// call and ends the turn with stop_reason "model_context_window_exceeded", which
+// Claude Code 2.1.x surfaces verbatim as "API Error: The model has reached its
+// context window limit." (GH #6360). Both are matched so a backend forwarding
+// the raw stop reason classifies the same way as one forwarding the CLI's copy.
+//
+// Neither carries "token" nor any of rule 1's other phrases, so before this the
+// failure landed in agent_error.unknown — a reason no resume blacklist covers,
+// which left the over-full session pinned as the resume pointer and made every
+// later comment on that issue replay the same overflow.
+//
+// Each is an unambiguous witness on its own, which is what lets
+// NormalizeDaemonReason reuse them to upgrade an older daemon's catchall
+// server-side. Matched against pre-lowercased text.
+// Mirror these substrings into the MUL-1949 offline backfill SQL.
+var contextWindowExceededWitnesses = []string{
+	"context window limit",
+	"model_context_window_exceeded",
+}
+
 // legacySkillBundlePrefix is the exact wrapper a pre-MUL-5370 daemon put on a
 // failed skill-bundle download. It is an unambiguous witness: no other code
 // path ever produced it, and a current daemon writes "skill bundle
@@ -286,6 +294,22 @@ var legacySkillBundleReasons = map[string]bool{
 	"agent_error":                      true,
 }
 
+// legacyContextOverflowReasons are the buckets an older daemon lands the
+// response-side context overflow in: agent_error.unknown from its own
+// classifier (its rule 1 predates contextWindowExceededWitnesses) and the
+// pre-MUL-1949 coarse agent_error.
+//
+// Deliberately narrower than legacySkillBundleReasons. A refined reason means
+// the old daemon matched an earlier rule on the same text — process_failure on
+// a crash marker, provider_network on a stream cut — and that says more about
+// what actually ended the run than a witness appearing somewhere in the same
+// blob does. Upgrading those would discard information; leaving them alone
+// costs at most the pre-existing behaviour.
+var legacyContextOverflowReasons = map[string]bool{
+	string(ReasonAgentUnknown): true,
+	"agent_error":              true,
+}
+
 // NormalizeDaemonReason upgrades a failure_reason reported by an older daemon
 // onto the taxonomy this server understands, using the raw error text as the
 // witness. It returns the reason unchanged when nothing applies.
@@ -298,13 +322,25 @@ var legacySkillBundleReasons = map[string]bool{
 // generic copy. Recognising the wire shape an old daemon produces closes that
 // gap the moment the server deploys.
 //
-// This is a boundary compatibility shim, not internal fallback logic: it can
-// be deleted once no daemon old enough to emit legacySkillBundlePrefix is
-// still reporting.
+// This is a boundary compatibility shim, not internal fallback logic: each rule
+// can be deleted once no daemon old enough to produce its wire shape is still
+// reporting.
 func NormalizeDaemonReason(reason, rawError string) Reason {
 	if legacySkillBundleReasons[reason] &&
 		strings.HasPrefix(strings.TrimSpace(rawError), legacySkillBundlePrefix) {
 		return ReasonSkillBundleUnavailable
+	}
+	// GH #6360: the same mixed-version gap, on a failure where waiting for
+	// every host to update is more expensive. A daemon whose rule 1 predates
+	// contextWindowExceededWitnesses reports the catchall, and the catchall is
+	// on no resume blacklist — so the over-full session stays pinned as the
+	// resume pointer and every later comment on that issue replays the same
+	// overflow. One un-upgraded host means a permanently stuck (agent, issue)
+	// pair, not just a missing label; upgrading here retires the session the
+	// moment the server deploys.
+	if legacyContextOverflowReasons[reason] &&
+		containsAny(strings.ToLower(rawError), contextWindowExceededWitnesses...) {
+		return ReasonAgentContextOverflow
 	}
 	return Reason(reason)
 }

--- a/server/pkg/taskfailure/classify_test.go
+++ b/server/pkg/taskfailure/classify_test.go
@@ -40,6 +40,11 @@ func TestClassifyRules(t *testing.T) {
 		{"prompt is too long", "API Error: prompt is too long: 250000 tokens > 200000 maximum", ReasonAgentContextOverflow},
 		{"context size has been exceeded", "context size has been exceeded; consider /compact", ReasonAgentContextOverflow},
 		{"token limit", "Hit the token limit for this conversation", ReasonAgentContextOverflow},
+		// GH #6360, verbatim from Claude Code 2.1.x. The turn is not
+		// rejected with a 400 — the response comes back with stop_reason
+		// "model_context_window_exceeded" and the CLI prints this line.
+		{"claude code context window limit", "API Error: The model has reached its context window limit.", ReasonAgentContextOverflow},
+		{"raw stop reason", `{"stop_reason":"model_context_window_exceeded"}`, ReasonAgentContextOverflow},
 
 		// 2. Missing config.
 		{"missing env var", "Missing environment variable: `MIFY_API_KEY`.", ReasonAgentMissingConfig},

--- a/server/pkg/taskfailure/classify_test.go
+++ b/server/pkg/taskfailure/classify_test.go
@@ -357,6 +357,58 @@ func TestNormalizeDaemonReason(t *testing.T) {
 			raw:    legacyErr,
 			want:   Reason(""),
 		},
+
+		// --- GH #6360: response-side context overflow. An un-upgraded daemon
+		// classifies the wordings below as the catchall, which is on no resume
+		// blacklist — so without this the over-full session stays pinned and
+		// every later comment on the issue replays the same overflow.
+		{
+			name:   "old daemon catchall on the claude code wording is upgraded",
+			reason: string(ReasonAgentUnknown),
+			raw:    "API Error: The model has reached its context window limit.",
+			want:   ReasonAgentContextOverflow,
+		},
+		{
+			name:   "old daemon catchall on the raw stop reason is upgraded",
+			reason: string(ReasonAgentUnknown),
+			raw:    `{"stop_reason":"model_context_window_exceeded"}`,
+			want:   ReasonAgentContextOverflow,
+		},
+		{
+			name:   "pre-MUL-1949 coarse reason on the overflow is upgraded",
+			reason: "agent_error",
+			raw:    "API Error: The model has reached its context window limit.",
+			want:   ReasonAgentContextOverflow,
+		},
+		{
+			// The witness is matched case-insensitively, like Classify's.
+			name:   "witness casing does not defeat the upgrade",
+			reason: string(ReasonAgentUnknown),
+			raw:    "API ERROR: THE MODEL HAS REACHED ITS CONTEXT WINDOW LIMIT.",
+			want:   ReasonAgentContextOverflow,
+		},
+		{
+			// A current daemon already classified it; nothing to do.
+			name:   "current daemon overflow reason passes through",
+			reason: string(ReasonAgentContextOverflow),
+			raw:    "API Error: The model has reached its context window limit.",
+			want:   ReasonAgentContextOverflow,
+		},
+		{
+			// A refined reason means the old daemon matched an earlier rule on
+			// this same text. That is a stronger statement about what ended the
+			// run than the witness is, so it is left alone.
+			name:   "refined reason with the overflow witness is left alone",
+			reason: string(ReasonAgentProcessFailure),
+			raw:    "claude exited with error: exit status 1: The model has reached its context window limit.",
+			want:   ReasonAgentProcessFailure,
+		},
+		{
+			name:   "catchall without an overflow witness is left alone",
+			reason: string(ReasonAgentUnknown),
+			raw:    "API Error: the model is overloaded",
+			want:   ReasonAgentUnknown,
+		},
 	}
 
 	for _, tc := range cases {


### PR DESCRIPTION
Fixes #6360. Multica issue: MUL-5708.

## The problem

The report is "repeated comments on one issue eventually fail with `API Error: The model has reached its context window limit.`" — read as "auto-compaction doesn't work". Auto-compaction does work; what fails is the classification of the error, and that is what makes the failure permanent.

Multica resumes the same agent session for every turn on an `(agent, issue)` pair (`GetLastTaskSession` → `claude --resume <id>`), so a long-running issue accumulates one ever-growing transcript. The platform already has the remedy for an overflow: `agent_error.context_overflow` is on every resume blacklist (`resumeUnsafeFailureReason`, `GetLastTaskSession`, `GetLastChatTaskSession`), so an overflowing session is retired and the next turn starts clean.

It never fires, because this overflow does not arrive in a shape the classifier recognises. Rule 1 was written for the request-side rejection:

```
API Error: 400 {"type":"error","error":{"type":"invalid_request_error",
                "message":"prompt is too long: 213000 tokens > 200000 maximum"}}
```

Claude Code 2.1.x reports it on the **response** instead: the call is accepted and the turn ends with `stop_reason: "model_context_window_exceeded"`, which the CLI prints as `API Error: The model has reached its context window limit.` (the two live side by side with the `max_tokens` branch in the 2.1.221 binary, under `tengu_context_window_exceeded`).

That string contains none of rule 1's phrases and no `token`, so:

```
Classify("API Error: The model has reached its context window limit.")
  -> agent_error.unknown        (verified against main)
```

`agent_error.unknown` is on no blacklist, so the over-full session stays pinned as the resume pointer. The next comment resumes the same transcript, overflows again, and the `(agent, issue)` pair is stuck — the same bricking shape as #5975 / #6066 / #5760, reached through a different wording. It also mislabels the failure: the user sees "unknown", not "context overflow".

## The change

**Daemon side** — two substrings added to rule 1: the CLI's copy and the raw stop reason, so a backend forwarding either classifies the same way. The reason it produces is already wired into the retirement path, so nothing downstream needs touching.

**Server side** — installed daemons update on their own cadence and `FailTask` only re-classifies when the caller supplied no reason, so a daemon still running the old rule 1 keeps reporting the catchall. `NormalizeDaemonReason` now recognises the same two witnesses on `agent_error.unknown` / the pre-MUL-1949 coarse `agent_error`, next to the MUL-5370 skill-bundle rule it mirrors, so the retirement lands the moment the server deploys rather than when the last host updates. Both halves read one shared `contextWindowExceededWitnesses` var so they cannot drift apart.

That accepted legacy set is deliberately narrower than the skill-bundle rule's — no `provider_network`, no `process_failure`. A refined reason means the old daemon matched an *earlier* rule on the same text (a crash marker, a stream cut), which says more about what actually ended the run than a witness appearing somewhere in the same blob. The common shape carries no crash marker anyway: `finalizeStreamResult` gates its "exited with error: exit status N" branch on `status == "completed"`, so a result-is-error turn reports the CLI's text alone.

After this, the overflowing turn retires its session and the next comment on the issue starts fresh. One turn is still lost at the boundary — the transcript is over the window before the turn begins, so nothing can be salvaged in-place — but the issue is no longer permanently stuck.

## Relationship to #6228

Complementary, not overlapping. #6228 concludes "this session is dead" from behaviour (two consecutive non-transient failures) and would eventually bound this case too, at the cost of a second wasted run and an `unknown` label. This makes the first overflow self-heal and attribute correctly. If #6228 lands first this still applies; if it lands second, this keeps the common case off the breaker.

## Verification

- `go test ./pkg/taskfailure/...` — pass. New: two `Classify` cases pinned to the verbatim 2.1.x string and the raw stop reason, and seven `NormalizeDaemonReason` cases (both witnesses upgraded from the catchall, the coarse `agent_error` upgraded, case-insensitivity, current-daemon pass-through, and the two negatives — a refined reason left alone, a catchall without a witness left alone).
- `go test ./internal/service -run '^(TestTaskFailureClassifiers|TestSkillBundleFailureFromLegacyDaemonRetries|TestContextOverflowFromLegacyDaemonRetiresSession)$'` — pass. The new test is the end-to-end property, mirroring the MUL-5370 one: it walks the chain `FailTask` runs for a task an un-upgraded daemon just failed and asserts `ResumeUnsafeFailure` flips to true, with the raw catchall pinned as a precondition so it cannot silently stop proving anything.
- `go test ./internal/daemon/...` — pass (3 packages), the consumer of `Classify` on the failure path.
- `go build ./...`, `go vet ./pkg/taskfailure/...`, `gofmt` clean.
- Source of the error string confirmed against the installed Claude Code 2.1.221 binary rather than inferred from the report.

Not covered here: rows a not-yet-upgraded daemon **already wrote** as `agent_error.unknown`. The resume queries' error-text guard only matches the Anthropic 400 shape, so those keep their pointer until #6228's breaker retires them.
