### PR TITLE
fix(issues): make the unsubscribe menu items actually unsubscribe (MUL-5710)

### DIFF
--- a/packages/views/issues/components/issue-detail.test.tsx
+++ b/packages/views/issues/components/issue-detail.test.tsx
@@ -1,5 +1,5 @@
 import { forwardRef, useEffect, useRef, useState, useImperativeHandle } from "react";
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import type { Issue, Label, TimelineEntry } from "@multica/core/types";
@@ -272,6 +272,7 @@ const mockApiObj = vi.hoisted(() => ({
   listIssueSubscribers: vi.fn().mockResolvedValue([]),
   subscribeToIssue: vi.fn().mockResolvedValue(undefined),
   unsubscribeFromIssue: vi.fn().mockResolvedValue(undefined),
+  unsubscribeFromIssueSubtree: vi.fn().mockResolvedValue(undefined),
   getActiveTasksForIssue: vi.fn().mockResolvedValue({ tasks: [] }),
   listTasksByIssue: vi.fn().mockResolvedValue([]),
   rerunIssue: vi.fn(),
@@ -1675,6 +1676,75 @@ describe("IssueDetail (shared)", () => {
       const due = screen.getByText("Jan 1");
       expect(due.closest("span")?.className).not.toContain("text-destructive");
       expect(due.closest("span")?.className).toContain("text-muted-foreground");
+    });
+  });
+
+  // Deliberately drives the real Base UI DropdownMenu rather than a stub: the
+  // bug these tests pin (MUL-5710) was a handler wired to `onSelect`, which
+  // typechecks because Menu.Item's props extend the whole div attribute set,
+  // then lands on the DOM as the native text-selection event and never fires.
+  // Only the real menu reproduces that; any hand-rolled mock hides it.
+  describe("unsubscribe menu", () => {
+    const subscribedAsMember = [
+      {
+        issue_id: "issue-1",
+        user_type: "member" as const,
+        user_id: "user-1",
+        reason: "manual" as const,
+        created_at: "2026-01-01T00:00:00Z",
+      },
+    ];
+
+    beforeEach(() => {
+      mockApiObj.listIssueSubscribers.mockResolvedValue(subscribedAsMember);
+    });
+
+    // Base UI portals the popup onto document.body; RTL unmounts it, but wipe
+    // the body too so a leftover portal can't duplicate menu item names.
+    afterEach(() => {
+      document.body.innerHTML = "";
+    });
+
+    async function openUnsubscribeMenu() {
+      renderIssueDetail();
+      fireEvent.click(await screen.findByText("Unsubscribe"));
+      return screen.findByRole("menu");
+    }
+
+    it("unsubscribes the current member when the single-issue item is clicked", async () => {
+      await openUnsubscribeMenu();
+
+      fireEvent.click(
+        screen.getByRole("menuitem", { name: "Unsubscribe from this issue" }),
+      );
+
+      await waitFor(() =>
+        expect(mockApiObj.unsubscribeFromIssue).toHaveBeenCalledWith(
+          "issue-1",
+          "user-1",
+          "member",
+        ),
+      );
+      expect(mockApiObj.unsubscribeFromIssueSubtree).not.toHaveBeenCalled();
+    });
+
+    it("unsubscribes from the whole subtree when the subtree item is clicked", async () => {
+      await openUnsubscribeMenu();
+
+      fireEvent.click(
+        screen.getByRole("menuitem", {
+          name: "Unsubscribe from this issue and its sub-issues",
+        }),
+      );
+
+      await waitFor(() =>
+        expect(mockApiObj.unsubscribeFromIssueSubtree).toHaveBeenCalledWith(
+          "issue-1",
+          "user-1",
+          "member",
+        ),
+      );
+      expect(mockApiObj.unsubscribeFromIssue).not.toHaveBeenCalled();
     });
   });
 });

--- a/packages/views/issues/components/issue-detail.tsx
+++ b/packages/views/issues/components/issue-detail.tsx
@@ -2651,11 +2651,17 @@ export function IssueDetail({ issueId, onDelete, onDone, defaultSidebarOpen = tr
                     <DropdownMenuTrigger className="text-caption text-muted-foreground hover:text-foreground transition-colors">
                       {t(($) => $.detail.unsubscribe)}
                     </DropdownMenuTrigger>
+                    {/* onClick, not onSelect: Base UI's Menu.Item exposes no
+                        onSelect (that is the Radix spelling), and because its
+                        props extend the full div attribute set, an onSelect
+                        typechecks and silently lands on the DOM node as the
+                        native text-selection event — the handler never runs
+                        (MUL-5710). */}
                     <DropdownMenuContent align="end">
-                      <DropdownMenuItem onSelect={handleToggleSubscribe}>
+                      <DropdownMenuItem onClick={handleToggleSubscribe}>
                         {t(($) => $.detail.unsubscribe_this)}
                       </DropdownMenuItem>
-                      <DropdownMenuItem onSelect={handleUnsubscribeSubtree}>
+                      <DropdownMenuItem onClick={handleUnsubscribeSubtree}>
                         {t(($) => $.detail.unsubscribe_subtree)}
                       </DropdownMenuItem>
                     </DropdownMenuContent>


### PR DESCRIPTION
Fixes MUL-5710 — the "Unsubscribe" dropdown in issue detail did nothing when clicked.

## Root cause

Both items wired their handler to `onSelect`:

```tsx
<DropdownMenuItem onSelect={handleToggleSubscribe}>
```

`onSelect` is the Radix spelling. Our `DropdownMenuItem` renders Base UI's `Menu.Item` (`packages/ui/components/ui/dropdown-menu.tsx`), whose only callback is `onClick` — `onSelect` appears zero times in `MenuItem.js` / `useMenuItem.js`, so the runtime never reads it.

It typechecks because `MenuItem.Props` extends `BaseUIComponentProps<'div', State>`, i.e. the entire div attribute set, and React's `onSelect` (the native text-selection event) is part of that. So the prop silently landed on the DOM node and fired only on text selection. Clicking closed the menu and did nothing.

Introduced in #6209 (MUL-5483), which replaced a working `<button onClick={handleToggleSubscribe}>` with this dropdown.

## Fix

Both items use `onClick`. Base UI's `closeOnClick` defaults to `true`, so the menu still closes on click — no extra handling needed.

The hook (`use-issue-subscribers.ts`) was never at fault, which is why its unit tests stayed green: they cover the hook, not this wiring.

## Tests

Two regression tests on the real Base UI menu — open the dropdown, click each item, assert `unsubscribeFromIssue` / `unsubscribeFromIssueSubtree` fire with `("issue-1", "user-1", "member")`.

They deliberately do **not** stub `DropdownMenu`. A stub can't reproduce a bug whose whole mechanism is Base UI's prop contract, and several existing suites do stub it — worth calling out in review.

Verified red-then-green: both tests fail on the unfixed component (handler never fires), pass with the fix.

## Verification

- `pnpm typecheck` — 6/6 pass
- `pnpm lint` — 0 errors (16 pre-existing warnings, none in touched files)
- `packages/views` full suite — 302 files, 3514 tests, all pass

## Blast radius

Repo-wide sweep: these were the only two places passing `onSelect` to a Base UI menu item. Every other `onSelect` belongs to a custom component's own prop API (`inbox-list.tsx`, `PropertyIconPicker`) and is correct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
