### PR TITLE
MUL-5715: fix(runtimes): distinguish runtime and machine names

### DIFF
--- a/packages/views/runtimes/components/runtime-detail-visibility.test.tsx
+++ b/packages/views/runtimes/components/runtime-detail-visibility.test.tsx
@@ -1,6 +1,7 @@
 // @vitest-environment jsdom
 
 import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { ComponentProps, ReactNode } from "react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import type { AgentRuntime, RuntimeProfile } from "@multica/core/types";
@@ -129,7 +130,7 @@ vi.mock("../../agents/presence", () => ({
 }));
 vi.mock("../../common/actor-avatar", () => ({ ActorAvatar: () => null }));
 vi.mock("../../navigation", () => ({
-  AppLink: () => null,
+  AppLink: ({ children }: { children: ReactNode }) => <>{children}</>,
   useNavigation: () => ({ push: vi.fn(), replace: vi.fn() }),
 }));
 
@@ -174,12 +175,18 @@ function makeProfile(overrides: Partial<RuntimeProfile> = {}): RuntimeProfile {
   };
 }
 
-function renderDetail(runtime: AgentRuntime) {
+function renderDetail(
+  runtime: AgentRuntime,
+  props: Pick<
+    ComponentProps<typeof RuntimeDetail>,
+    "machineHref" | "machineLabel"
+  > = {},
+) {
   const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
   return render(
     <I18nProvider locale="en" resources={TEST_RESOURCES}>
       <QueryClientProvider client={qc}>
-        <RuntimeDetail runtime={runtime} />
+        <RuntimeDetail runtime={runtime} {...props} />
       </QueryClientProvider>
     </I18nProvider>,
   );
@@ -216,6 +223,33 @@ describe("RuntimeDetail visibility section", () => {
     expect(
       screen.queryByRole("button", { name: "Update" }),
     ).not.toBeInTheDocument();
+  });
+
+  it("uses the provider name when the runtime alias is the machine name", () => {
+    renderDetail(
+      makeRuntime({
+        name: "Pi (Studio Mac)",
+        custom_name: "Studio Mac",
+        provider: "pi",
+      }),
+      { machineHref: "/runtimes/local:daemon-1", machineLabel: "Studio Mac" },
+    );
+
+    expect(screen.getAllByText("Pi")).toHaveLength(2);
+    expect(screen.getByRole("banner")).toHaveTextContent("Studio Mac");
+  });
+
+  it("preserves a runtime-specific alias that differs from the machine name", () => {
+    renderDetail(
+      makeRuntime({
+        name: "Pi (Studio Mac)",
+        custom_name: "Research Pi",
+        provider: "pi",
+      }),
+      { machineHref: "/runtimes/local:daemon-1", machineLabel: "Studio Mac" },
+    );
+
+    expect(screen.getAllByText("Research Pi")).toHaveLength(2);
   });
 
   it("flips visibility to public when the owner clicks the Public choice", async () => {

--- a/packages/views/runtimes/components/runtime-detail.tsx
+++ b/packages/views/runtimes/components/runtime-detail.tsx
@@ -45,6 +45,7 @@ import { ProviderLogo } from "./provider-logo";
 import { UsageSection } from "./usage-section";
 import { DeleteRuntimeDialog } from "./delete-runtime-dialog";
 import { DeleteRuntimeProfileDialog } from "./delete-runtime-profile-dialog";
+import { runtimeRowLabel } from "./runtime-machines";
 import { useT, useTimeAgo } from "../../i18n";
 
 function getCliVersion(metadata: Record<string, unknown>): string | null {
@@ -147,6 +148,9 @@ export function RuntimeDetail({
   const lastSeen = runtime.last_seen_at
     ? timeAgo(runtime.last_seen_at)
     : t(($) => $.detail.never_seen);
+  const runtimeName = machineLabel
+    ? runtimeRowLabel(runtime, machineLabel)
+    : runtimeDisplayName(runtime);
 
   return (
     <div className="flex h-full flex-col">
@@ -159,7 +163,7 @@ export function RuntimeDetail({
         ]}
         leaf={
           <span className="truncate font-mono text-caption text-foreground">
-            {runtimeDisplayName(runtime)}
+            {runtimeName}
           </span>
         }
         actions={
@@ -182,6 +186,7 @@ export function RuntimeDetail({
           <div className="min-w-0 space-y-5">
             <HeroCard
               runtime={runtime}
+              runtimeName={runtimeName}
               health={health}
               lastSeen={lastSeen}
               ownerMember={ownerMember}
@@ -245,6 +250,7 @@ function parseDeviceInfo(raw: string): { hostname: string; runtime?: string } {
 
 function HeroCard({
   runtime,
+  runtimeName,
   health,
   lastSeen,
   ownerMember,
@@ -252,6 +258,7 @@ function HeroCard({
   daemonShort,
 }: {
   runtime: AgentRuntime;
+  runtimeName: string;
   health: ReturnType<typeof deriveRuntimeHealth>;
   lastSeen: string;
   ownerMember: MemberWithUser | null;
@@ -273,7 +280,7 @@ function HeroCard({
         <div className="min-w-0 flex-1">
           <div className="flex flex-wrap items-center gap-x-3 gap-y-1">
             <h2 className="truncate text-title-sm font-semibold tracking-tight">
-              {runtimeDisplayName(runtime)}
+              {runtimeName}
             </h2>
             <HealthBadge health={health} />
             <span className="text-caption text-muted-foreground">


### PR DESCRIPTION
## Summary

- use the machine-aware runtime label in the runtime detail breadcrumb and hero title
- avoid repeating the machine name when a runtime inherits the machine-level alias
- preserve explicit per-runtime aliases and standalone detail behavior

## Test plan

- pnpm exec vitest run runtimes/components/runtime-detail-visibility.test.tsx runtimes/components/runtime-machines.test.ts
- pnpm typecheck
- pnpm exec eslint runtimes/components/runtime-detail.tsx runtimes/components/runtime-detail-visibility.test.tsx
