### PR TITLE
test(views): cover invitation page states

### DIFF
--- a/packages/views/invite/invite-page.test.tsx
+++ b/packages/views/invite/invite-page.test.tsx
@@ -1,0 +1,168 @@
+import type { ReactElement, ReactNode } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import "@testing-library/jest-dom/vitest";
+import { I18nProvider } from "@multica/core/i18n/react";
+import enCommon from "../locales/en/common.json";
+import enInvite from "../locales/en/invite.json";
+
+const mockGetInvitation = vi.hoisted(() => vi.fn());
+const mockAcceptInvitation = vi.hoisted(() => vi.fn());
+const mockDeclineInvitation = vi.hoisted(() => vi.fn());
+const mockMarkOnboardingComplete = vi.hoisted(() => vi.fn());
+const mockRefreshMe = vi.hoisted(() => vi.fn());
+const mockPush = vi.hoisted(() => vi.fn());
+const mockLogout = vi.hoisted(() => vi.fn());
+const mockInvalidateQueries = vi.hoisted(() => vi.fn());
+const mockFetchQuery = vi.hoisted(() => vi.fn());
+
+vi.mock("@tanstack/react-query", () => ({
+  useQuery: ({ queryKey, queryFn }: { queryKey: string[]; queryFn: () => unknown }) => {
+    if (queryKey[0] === "invitation") {
+      return { data: mockGetInvitation(), isLoading: false, error: null };
+    }
+    return { data: [], isLoading: false, error: null, queryFn };
+  },
+  useQueryClient: () => ({
+    fetchQuery: mockFetchQuery,
+    invalidateQueries: mockInvalidateQueries,
+  }),
+}));
+
+vi.mock("@multica/core/api", () => ({
+  api: {
+    getInvitation: mockGetInvitation,
+    acceptInvitation: mockAcceptInvitation,
+    declineInvitation: mockDeclineInvitation,
+    markOnboardingComplete: mockMarkOnboardingComplete,
+  },
+}));
+
+vi.mock("@multica/core/auth", () => ({
+  useAuthStore: {
+    getState: () => ({ refreshMe: mockRefreshMe }),
+  },
+}));
+
+vi.mock("@multica/core/workspace/queries", () => ({
+  workspaceKeys: { myInvitations: () => ["workspaces", "invitations"] },
+  workspaceListOptions: () => ({ queryKey: ["workspaces", "list"] }),
+}));
+
+vi.mock("@multica/core/paths", () => ({
+  paths: {
+    workspace: (slug: string) => ({ issues: () => `/${slug}/issues` }),
+  },
+  resolvePostAuthDestination: () => "/onboarding",
+  useHasOnboarded: () => true,
+}));
+
+vi.mock("../navigation", () => ({
+  useNavigation: () => ({ push: mockPush }),
+}));
+
+vi.mock("../auth", () => ({
+  useLogout: () => mockLogout,
+}));
+
+vi.mock("../platform", () => ({
+  DragStrip: () => null,
+}));
+
+import { InvitePage } from "./invite-page";
+
+const TEST_RESOURCES = {
+  en: { common: enCommon, invite: enInvite },
+};
+
+function I18nWrapper({ children }: { children: ReactNode }) {
+  return (
+    <I18nProvider locale="en" resources={TEST_RESOURCES}>
+      {children}
+    </I18nProvider>
+  );
+}
+
+function renderInvite(ui: ReactElement) {
+  return render(ui, { wrapper: I18nWrapper });
+}
+
+const PENDING_INVITATION = {
+  workspace_id: "workspace-1",
+  workspace_name: "Acme",
+  inviter_name: "Ada Lovelace",
+  inviter_email: "ada@example.com",
+  role: "member",
+  status: "pending",
+};
+
+describe("InvitePage", () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetInvitation.mockReturnValue(PENDING_INVITATION);
+    mockAcceptInvitation.mockResolvedValue(undefined);
+    mockDeclineInvitation.mockResolvedValue(undefined);
+    mockMarkOnboardingComplete.mockResolvedValue(undefined);
+    mockRefreshMe.mockResolvedValue(undefined);
+    mockFetchQuery.mockResolvedValue([]);
+  });
+
+  it("shows a pending invitation with the available actions", () => {
+    renderInvite(<InvitePage invitationId="invite-1" />);
+
+    expect(screen.getByRole("heading", { name: "Join Acme" })).toBeInTheDocument();
+    expect(screen.getByText("Ada Lovelace")).toBeInTheDocument();
+    expect(screen.getByText("invited you to join as a member.")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Decline" })).toBeEnabled();
+    expect(screen.getByRole("button", { name: "Accept & Join" })).toBeEnabled();
+  });
+
+  it("declines the invitation and shows the confirmation state", async () => {
+    renderInvite(<InvitePage invitationId="invite-1" />);
+    const user = userEvent.setup();
+
+    await user.click(screen.getByRole("button", { name: "Decline" }));
+
+    await waitFor(() => {
+      expect(mockDeclineInvitation).toHaveBeenCalledWith("invite-1");
+      expect(screen.getByRole("heading", { name: "Invitation declined" })).toBeInTheDocument();
+    });
+    expect(mockInvalidateQueries).toHaveBeenCalledWith({
+      queryKey: ["workspaces", "invitations"],
+    });
+  });
+
+  it("reports an accept failure without leaving the invitation page", async () => {
+    mockAcceptInvitation.mockRejectedValueOnce(new Error("Invitation expired"));
+    renderInvite(<InvitePage invitationId="invite-1" />);
+    const user = userEvent.setup();
+
+    await user.click(screen.getByRole("button", { name: "Accept & Join" }));
+
+    await waitFor(() => {
+      expect(screen.getByText("Invitation expired")).toBeInTheDocument();
+    });
+    expect(mockMarkOnboardingComplete).not.toHaveBeenCalled();
+    expect(mockPush).not.toHaveBeenCalled();
+  });
+
+  it("shows the already accepted state without mutation actions", () => {
+    mockGetInvitation.mockReturnValue({
+      ...PENDING_INVITATION,
+      status: "accepted",
+    });
+
+    renderInvite(<InvitePage invitationId="invite-1" />);
+
+    expect(
+      screen.getByText("This invitation has already been accepted."),
+    ).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Decline" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Accept & Join" })).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
Cover pending, completed, and failed invitation actions so shared web and desktop behavior remains guarded.

## What does this PR do?

Adds component-level regression coverage for the shared `InvitePage`, used by Web and desktop invitation flows. This PR protects the pending, completed, and failed-action states without changing production behavior.

## Related Issue

No related issue. This is a targeted test-coverage contribution for an untested shared view.

Closes #

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Refactor / code improvement (no behavior change)
- [ ] Documentation update
- [x] Tests (adding or improving test coverage)
- [ ] CI / infrastructure

## Changes Made

- Added `packages/views/invite/invite-page.test.tsx`.
- Covered pending invitation rendering and available actions.
- Covered successful invitation decline and invitation-cache invalidation.
- Covered failed invitation acceptance, ensuring the error renders without navigation.
- Covered already-accepted invitations, ensuring mutation actions are hidden.

## How to Test

1. Run:

   ```bash
   pnpm exec vitest run packages/views/invite/invite-page.test.tsx --environment jsdom --maxWorkers=1
   ```

2. Confirm all four `InvitePage` tests pass.
3. Review coverage for pending, declined, failed acceptance, and already-accepted states.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [ ] I have updated relevant documentation to reflect my changes
- [ ] If I added a new runtime / coding tool / UI tab, I synced the change to **landing copy** (`apps/web/features/landing/i18n/`) and **relevant docs** (`apps/docs/content/docs/`)
- [ ] If this PR touches Chinese product copy, I checked it against `apps/docs/content/docs/developers/conventions.zh.mdx` (terminology, mixed-rule for `task` / `issue` / `skill`)
- [x] I have considered and documented any risks above
- [x] I will address all reviewer comments before requesting merge

## Risks

This change only adds tests and mocks external dependencies. It does not alter production code or API behavior.

Package-level typecheck is currently blocked by an unrelated existing error in `packages/views/editor/extensions/slash-command-suggestion.test.tsx`.

## AI Disclosure

**AI tool used:** Cursor

**Prompt / approach:**

Used Cursor to inspect untested shared views, selected `InvitePage`, reviewed existing `packages/views` test patterns, and added focused Vitest/Testing Library coverage for key invitation states. The generated tests were run locally and adjusted until passing.

## Screenshots (optional)

Not applicable; this PR adds automated tests only.