### PR TITLE
refactor(daemon): rewrite Background Task Safety to its judgment form (MUL-5442)

### DIFF
--- a/server/internal/daemon/execenv/execenv_test.go
+++ b/server/internal/daemon/execenv/execenv_test.go
@@ -989,58 +989,37 @@ func TestInjectRuntimeConfigBackgroundTaskSafetyProviderAgnostic(t *testing.T) {
 			s := string(data)
 			for _, want := range []string{
 				"## Background Task Safety",
-				// The orphan rule is scoped to run-owned work — an unscoped
-				// "anything still running" would sweep in external systems
-				// (GitHub Actions) the section later says NOT to wait for.
+				// MUL-5442 judgment rewrite (owner-authorized pin renegotiation): the
+				// section now states the one platform fact, the external-systems/CI
+				// boundary with its single exception, and the review-locked
+				// persistent-service contract. Enforcement-detail pins that only
+				// restated derivations of the platform fact were retired with the
+				// prose ("Do NOT end your turn while background tasks", the
+				// tool-promise enumeration, "does not cover tests, builds, CI
+				// polling", "any sleep / retry loop that polls check status", ...).
+				// What stays pinned: the fact, each boundary, each exception, and
+				// the handoff triple — the things an agent cannot infer.
 				"any run-owned work still active is orphaned",
-				"Do NOT end your turn while background tasks",
-				"wait for a future notification/reminder",
-				"run the work synchronously instead",
-				// Hardened pins (MUL-4140): the mechanism that slipped
-				// through in MUL-4091 was a turn ending cleanly with a
-				// "standing by, I'll report when CI finishes" message and
-				// no follow-up wakeup. These pins forbid that shape.
+				"no background-completion wakeup",
+				"whatever a tool response promises",
 				"Never background-and-yield",
-				"foreground tool call that blocks",
-				// MUL-5274: persistent local services are allowed only as
-				// an explicit, verified handoff with a cleanup handle.
+				"foreground tool calls that block",
+				"run unobservable work synchronously",
+				"standing by",
+				"are not run-owned: do not wait",
+				"do not run `gh pr checks --watch`",
+				"GitHub Actions after a successful push",
+				"NOT your delivery acceptance criteria",
+				"CI running: <PR link>",
+				"The one exception",
+				"ONE foreground blocking call (`gh pr checks <pr> --watch`)",
 				"persistent service handoff",
 				"running service itself is the requested deliverable",
-				// MUL-5442: pin the handoff concepts, not the operational
-				// phrasing — but the cleanup handle must stay general (a
-				// supervisor/profile-managed service has no single stable PID)
-				// and the user-facing reply must keep the full URL/logs/stop
-				// triple (durable logs alone are unobservable if the user is
-				// never told where they are).
 				"durable logs",
 				"cleanup handle such as PID/profile",
 				"verify readiness",
 				"URL, logs, and stop instructions",
 				"survival as best-effort, not guaranteed",
-				"does not cover tests, builds, CI polling",
-				"are not agent-owned background tasks",
-				"GitHub Actions after a successful push",
-				"Do not wait for them by default",
-				// MUL-5223: the conceptual boundary above was read as
-				// compatible with `gh pr checks --watch` (a blocking
-				// foreground call) whenever the repo required green CI to
-				// merge. These pins name the banned tool shapes, deny
-				// merge requirements as acceptance criteria, and supply
-				// the replacement hand-off phrasing.
-				"do NOT run `gh pr checks --watch`",
-				"any sleep / retry loop that polls check status",
-				"NOT your delivery acceptance criteria",
-				"CI running: <PR link>",
-				// The ban must stay scoped: an explicitly requested CI
-				// result is still reachable, and the section must name
-				// the one executable way to collect it. Without these
-				// pins the ban could be re-absolutised and the exception
-				// would become unfollowable.
-				"unless the explicit exception below applies",
-				"The one exception",
-				"ONE foreground blocking call (`gh pr checks <pr> --watch`)",
-				"running in the background so you can keep working",
-				"standing by",
 			} {
 				if !strings.Contains(s, want) {
 					t.Errorf("%s missing background task safety text %q\n---\n%s", tc.file, want, s)

--- a/server/internal/daemon/execenv/execenv_test.go
+++ b/server/internal/daemon/execenv/execenv_test.go
@@ -1007,7 +1007,9 @@ func TestInjectRuntimeConfigBackgroundTaskSafetyProviderAgnostic(t *testing.T) {
 				"run unobservable work synchronously",
 				"standing by",
 				"are not run-owned: do not wait",
-				"do not run `gh pr checks --watch`",
+				// The full compound ban, not its first item — MUL-5223 made this a
+				// non-derivable boundary, so no member may be silently dropped.
+				"do not run `gh pr checks --watch`, `gh run watch`, or sleep/retry polls",
 				"GitHub Actions after a successful push",
 				"NOT your delivery acceptance criteria",
 				"CI running: <PR link>",
@@ -1024,6 +1026,12 @@ func TestInjectRuntimeConfigBackgroundTaskSafetyProviderAgnostic(t *testing.T) {
 				if !strings.Contains(s, want) {
 					t.Errorf("%s missing background task safety text %q\n---\n%s", tc.file, want, s)
 				}
+			}
+			// Exactly one exception: substring pins cannot see a duplicated
+			// "The one exception" clause (a second, wider-scope copy slipped
+			// in during the MUL-5442 rewrite and every pin stayed green).
+			if got := strings.Count(s, "The one exception"); got != 1 {
+				t.Errorf("%s must state the CI exception exactly once, got %d\n---\n%s", tc.file, got, s)
 			}
 			// `gh run watch` may only appear as a banned command, never as
 			// the section's example of how to wait properly.

--- a/server/internal/daemon/execenv/runtime_config_kind_test.go
+++ b/server/internal/daemon/execenv/runtime_config_kind_test.go
@@ -269,41 +269,34 @@ func TestBackgroundTaskSafetySlimHardPins(t *testing.T) {
 
 	for _, want := range []string{
 		"## Background Task Safety",
-		"Do NOT end your turn while background tasks",
-		"wait for a future notification/reminder",
-		"run the work synchronously instead",
+		// MUL-5442 judgment rewrite (owner-authorized pin renegotiation): the
+		// section now states the one platform fact, the external-systems/CI
+		// boundary with its single exception, and the review-locked
+		// persistent-service contract. Enforcement-detail pins that only
+		// restated derivations of the platform fact were retired with the
+		// prose. What stays pinned: the fact, each boundary, each exception,
+		// and the handoff triple — the things an agent cannot infer.
+		"any run-owned work still active is orphaned",
+		"no background-completion wakeup",
+		"whatever a tool response promises",
 		"Never background-and-yield",
-		"foreground tool call that blocks",
-		// MUL-5274: an explicitly requested persistent local service is a
-		// completed handoff, not unfinished run-owned work. Pin the narrow
-		// exception and its readiness / cleanup / honesty requirements.
+		"foreground tool calls that block",
+		"run unobservable work synchronously",
+		"standing by",
+		"are not run-owned: do not wait",
+		"do not run `gh pr checks --watch`",
+		"GitHub Actions after a successful push",
+		"NOT your delivery acceptance criteria",
+		"CI running: <PR link>",
+		"The one exception",
+		"ONE foreground blocking call (`gh pr checks <pr> --watch`)",
 		"persistent service handoff",
 		"running service itself is the requested deliverable",
-		// MUL-5442: pin the handoff concepts, not the operational phrasing.
-		// The cleanup handle stays general and the user-facing reply keeps the
-		// full URL/logs/stop triple (see the execenv_test.go pins).
 		"durable logs",
 		"cleanup handle such as PID/profile",
 		"verify readiness",
 		"URL, logs, and stop instructions",
 		"survival as best-effort, not guaranteed",
-		"does not cover tests, builds, CI polling",
-		"are not agent-owned background tasks",
-		"GitHub Actions after a successful push",
-		"Do not wait for them by default",
-		// MUL-5223 pins: named tool-shape bans, merge requirements
-		// denied as acceptance criteria, replacement hand-off phrasing,
-		// and the scoped escape hatch that keeps an explicitly requested
-		// CI result both permitted and executable.
-		"do NOT run `gh pr checks --watch`",
-		"any sleep / retry loop that polls check status",
-		"NOT your delivery acceptance criteria",
-		"CI running: <PR link>",
-		"unless the explicit exception below applies",
-		"The one exception",
-		"ONE foreground blocking call (`gh pr checks <pr> --watch`)",
-		"running in the background so you can keep working",
-		"standing by",
 	} {
 		if !strings.Contains(out, want) {
 			t.Errorf("slim Background Task Safety missing hardened pin %q\n---\n%s", want, out)

--- a/server/internal/daemon/execenv/runtime_config_kind_test.go
+++ b/server/internal/daemon/execenv/runtime_config_kind_test.go
@@ -284,7 +284,9 @@ func TestBackgroundTaskSafetySlimHardPins(t *testing.T) {
 		"run unobservable work synchronously",
 		"standing by",
 		"are not run-owned: do not wait",
-		"do not run `gh pr checks --watch`",
+		// The full compound ban, not its first item — MUL-5223 made this a
+		// non-derivable boundary, so no member may be silently dropped.
+		"do not run `gh pr checks --watch`, `gh run watch`, or sleep/retry polls",
 		"GitHub Actions after a successful push",
 		"NOT your delivery acceptance criteria",
 		"CI running: <PR link>",
@@ -301,6 +303,11 @@ func TestBackgroundTaskSafetySlimHardPins(t *testing.T) {
 		if !strings.Contains(out, want) {
 			t.Errorf("slim Background Task Safety missing hardened pin %q\n---\n%s", want, out)
 		}
+	}
+	// Exactly one exception (see the execenv provider-agnostic test for
+	// the incident this guards).
+	if got := strings.Count(out, "The one exception"); got != 1 {
+		t.Errorf("slim brief must state the CI exception exactly once, got %d\n---\n%s", got, out)
 	}
 	// `gh run watch` may only appear as a banned command, never as the
 	// section's example of how to wait properly.

--- a/server/internal/daemon/execenv/runtime_config_sections.go
+++ b/server/internal/daemon/execenv/runtime_config_sections.go
@@ -94,16 +94,25 @@ func writeHeader(b *strings.Builder) {
 // The sign-off ban now leads rather than closes the list; it still applies to
 // the whole section because the opening bullet scopes it to ending a turn at
 // all, not to any one later bullet.
+//
+// MUL-5442 stage 2 (owner-authorized judgment rewrite): the section now
+// carries three paragraphs — the platform fact everything derives from
+// (turn exit = task terminal, no wakeup), the external-systems/CI boundary
+// with its single exception, and the persistent-service handoff contract.
+// Enforcement details that frontier models derive from the fact were
+// deliberately dropped: the run-owned work enumeration, the tool-promise
+// enumeration, the wait/collect split rule, the persistent-service scope
+// bullet, the auto-merge and snapshot elaborations. The incident history
+// above (MUL-5223, MUL-5274, MUL-4091) remains the WHY for what stays:
+// the named --watch ban and merge-gate denial survive because MUL-5223
+// proved the principle alone did not stop CI-watching, and the handoff
+// paragraph is review-locked verbatim (URL/logs/stop triple, general
+// cleanup handle) — do not reword it without a fresh review decision.
 func writeBackgroundTaskSafetySlim(b *strings.Builder) {
 	b.WriteString("## Background Task Safety\n\n")
-	b.WriteString("Multica marks the task terminal the moment your top-level turn exits — any run-owned work still active is orphaned, its result lost, and the final comment you meant to post never sends. There is no background-completion wakeup here.\n\n")
-	b.WriteString("- Do NOT end your turn while background tasks or other run-owned work is active — async subagents, background shells, and detached tool calls included. Never background-and-yield: no future notification or wakeup will arrive to resume you. A tool response that says to wait for a future notification/reminder, or that it is running in the background so you can keep working, does not change that — block before exiting. If you can't observe a result, run the work synchronously instead, and never end a turn with a \"standing by\" / \"I'll report back when X finishes\" message: it becomes your final output.\n")
-	b.WriteString("- When a required result from run-owned work must be collected, wait synchronously inside one foreground tool call that blocks to completion (e.g. a blocking test or build command); never split \"start the wait\" and \"collect the result\" across turns.\n")
-	b.WriteString("- A user explicitly asking for a local service to stay available after the turn is a persistent service handoff, not background-and-yield — allowed only when the running service itself is the requested deliverable. Detach its lifecycle from this run first (durable logs, a recorded cleanup handle such as PID/profile), verify readiness, and reply with the URL, logs, and stop instructions. Without a supervisor, describe survival as best-effort, not guaranteed.\n")
-	b.WriteString("- The persistent-service exception does not cover tests, builds, CI polling, monitors, or any other work whose completion the agent still owes; those remain run-owned, and the CI-specific rules below still apply.\n")
-	b.WriteString("- External systems triggered by a completed action — for example GitHub Actions after a successful push — are not agent-owned background tasks. Do not wait for them by default; report them as pending and finish the handoff.\n")
-	b.WriteString("- Concretely, after a push or a PR create, unless the explicit exception below applies: do NOT run `gh pr checks --watch`, `gh run watch`, or any sleep / retry loop that polls check status (`gh pr merge --auto` is fine — it returns immediately). Take at most ONE non-blocking status snapshot (e.g. `gh pr checks <pr>`) and deliver what you have: \"Local tests pass; CI running: <PR link>\". A PR whose CI is still in flight is a complete hand-off.\n")
-	b.WriteString("- A repo's merge requirements — \"CI must be green before merge\", required reviews, branch protection — are GitHub's merge gate, NOT your delivery acceptance criteria, and do not license a wait.\n")
+	b.WriteString("Multica marks the task terminal the moment your top-level turn exits — any run-owned work still active is orphaned, its result lost, and the final comment you meant to post never sends. There is no background-completion wakeup, whatever a tool response promises. Never background-and-yield: collect required results inside foreground tool calls that block to completion, run unobservable work synchronously, and never end a turn \"standing by\" for something to finish — that message becomes your final output.\n\n")
+	b.WriteString("External systems triggered by your completed actions — CI, GitHub Actions after a successful push — are not run-owned: do not wait for them, and do not run `gh pr checks --watch`, `gh run watch`, or sleep/retry polls. A repo's merge gate (\"CI must be green before merge\") is NOT your delivery acceptance criteria. Deliver what you have — \"Local tests pass; CI running: <PR link>\" is a complete hand-off. The one exception: when the trigger comment or the issue's acceptance criteria explicitly ask for the CI result, collect it as ONE foreground blocking call (`gh pr checks <pr> --watch`) inside this same turn.\n\n")
+	b.WriteString("A user explicitly asking for a local service to stay available after the turn is a persistent service handoff, not background-and-yield — allowed only when the running service itself is the requested deliverable. Detach its lifecycle from this run first (durable logs, a recorded cleanup handle such as PID/profile), verify readiness, and reply with the URL, logs, and stop instructions. Without a supervisor, describe survival as best-effort, not guaranteed.\n")
 	b.WriteString("- The one exception: when the trigger comment or the issue's acceptance criteria explicitly ask you for the CI result, that result IS the deliverable — wait for it as ONE foreground blocking call (`gh pr checks <pr> --watch`) inside this same turn and report the outcome. Nothing else re-opens this door.\n\n")
 }
 

--- a/server/internal/daemon/execenv/runtime_config_sections.go
+++ b/server/internal/daemon/execenv/runtime_config_sections.go
@@ -30,8 +30,10 @@ import (
 //  2. Per-section prose compression — Available Commands, Issue
 //     Body Formatting, Metadata, Mentions, Sub-issue Creation,
 //     Comment Formatting, Always Use CLI, Background Task Safety, Task Initiator,
-//     Repositories, Output are all tightened. Every test-asserted phrase
-//     stays.
+//     Repositories, Output are all tightened. Test-asserted phrases either
+//     survive verbatim or are renegotiated to new semantic anchors in the
+//     same PR (MUL-5442 established that discipline); no assertion is
+//     dropped without a replacement.
 //
 // Background Task Safety is emitted by `writeBackgroundTaskSafetySlim`
 // below.
@@ -42,13 +44,13 @@ func writeHeader(b *strings.Builder) {
 	b.WriteString("You are a coding agent in the Multica platform. Use the `multica` CLI to interact with the platform.\n\n")
 }
 
-// writeBackgroundTaskSafetySlim emits the Background Task Safety section.
-// Drops the verbose preamble but keeps the same hard behaviour pins the
-// tests assert:
-// "Do NOT end your turn while background tasks", "wait for a future
-// notification/reminder", "run the work synchronously instead", the
-// no-background-and-yield rule, the external-work boundary, and the
-// no-"standing by" sign-off rule.
+// writeBackgroundTaskSafetySlim emits the Background Task Safety section
+// in its judgment form (MUL-5442): three paragraphs — the platform fact
+// everything else derives from (turn exit is task-terminal, no wakeup
+// exists, never background-and-yield), the external-systems/CI boundary
+// with its single explicit-ask exception, and the persistent-service
+// handoff contract. The pinned anchors the tests assert are the fact,
+// each boundary, both exceptions, and the handoff triple.
 //
 // MUL-5223: the external-work boundary alone did not stop agents from
 // blocking on CI. Two holes are closed here. First, the boundary was
@@ -76,44 +78,29 @@ func writeHeader(b *strings.Builder) {
 // handoff contract (lifecycle independence, durable logs, cleanup handle);
 // how to detach is the Local Dev Environment skill's concern, not the brief's.
 //
-// Bullet order is deliberate: run-owned rules first, then the persistent
-// service handoff and its negative boundary, then the external-systems / CI
-// cluster. The former boundary sentence "The rules above apply only to work
-// owned by the current run" was dropped in the MUL-5274 review: with the
-// handoff exception inserted above it, "the rules above" would have swept in
-// work that is precisely no longer run-owned. The external-systems bullet
-// carries the boundary on its own ("are not agent-owned background tasks").
-// Within the CI cluster the exception bullet must stay below the ban bullet —
-// the ban forward-references "the explicit exception below".
+// Paragraph order: the CI exception lives INSIDE the boundary paragraph
+// (one "The one exception" occurrence, count-guarded in the tests), and the
+// persistent-service paragraph closes the section. A former scoping sentence
+// ("The rules above apply only to work owned by the current run") stays
+// dropped: the boundary paragraph carries its own scope ("are not
+// run-owned").
 //
-// MUL-5442 folds four bullets that restated one rule from different angles
-// (end-of-turn ban, untrustworthy tool promises, unobservable results, the
-// "standing by" sign-off) into the leading bullet. They were four views of
-// "the turn ending is the deadline", and separating them cost bytes without
-// adding a distinct behaviour. Every pinned phrase is carried over verbatim.
-// The sign-off ban now leads rather than closes the list; it still applies to
-// the whole section because the opening bullet scopes it to ending a turn at
-// all, not to any one later bullet.
-//
-// MUL-5442 stage 2 (owner-authorized judgment rewrite): the section now
-// carries three paragraphs — the platform fact everything derives from
-// (turn exit = task terminal, no wakeup), the external-systems/CI boundary
-// with its single exception, and the persistent-service handoff contract.
-// Enforcement details that frontier models derive from the fact were
-// deliberately dropped: the run-owned work enumeration, the tool-promise
-// enumeration, the wait/collect split rule, the persistent-service scope
-// bullet, the auto-merge and snapshot elaborations. The incident history
-// above (MUL-5223, MUL-5274, MUL-4091) remains the WHY for what stays:
-// the named --watch ban and merge-gate denial survive because MUL-5223
-// proved the principle alone did not stop CI-watching, and the handoff
-// paragraph is review-locked verbatim (URL/logs/stop triple, general
-// cleanup handle) — do not reword it without a fresh review decision.
+// MUL-5442 stage 2 (owner-authorized judgment rewrite): enforcement details
+// a frontier model derives from the platform fact were deliberately dropped
+// — the run-owned work enumeration, the tool-promise enumeration, the
+// wait/collect split rule, the persistent-service scope bullet, the
+// auto-merge and snapshot elaborations. Their pins were retired in the same
+// change. The incident history above (MUL-5223, MUL-5274, MUL-4091) remains
+// the WHY for what stays: the named --watch/watch/poll ban and merge-gate
+// denial survive because MUL-5223 proved the principle alone did not stop
+// CI-watching, and the handoff paragraph is review-locked verbatim
+// (URL/logs/stop triple, general cleanup handle) — do not reword it without
+// a fresh review decision.
 func writeBackgroundTaskSafetySlim(b *strings.Builder) {
 	b.WriteString("## Background Task Safety\n\n")
 	b.WriteString("Multica marks the task terminal the moment your top-level turn exits — any run-owned work still active is orphaned, its result lost, and the final comment you meant to post never sends. There is no background-completion wakeup, whatever a tool response promises. Never background-and-yield: collect required results inside foreground tool calls that block to completion, run unobservable work synchronously, and never end a turn \"standing by\" for something to finish — that message becomes your final output.\n\n")
 	b.WriteString("External systems triggered by your completed actions — CI, GitHub Actions after a successful push — are not run-owned: do not wait for them, and do not run `gh pr checks --watch`, `gh run watch`, or sleep/retry polls. A repo's merge gate (\"CI must be green before merge\") is NOT your delivery acceptance criteria. Deliver what you have — \"Local tests pass; CI running: <PR link>\" is a complete hand-off. The one exception: when the trigger comment or the issue's acceptance criteria explicitly ask for the CI result, collect it as ONE foreground blocking call (`gh pr checks <pr> --watch`) inside this same turn.\n\n")
-	b.WriteString("A user explicitly asking for a local service to stay available after the turn is a persistent service handoff, not background-and-yield — allowed only when the running service itself is the requested deliverable. Detach its lifecycle from this run first (durable logs, a recorded cleanup handle such as PID/profile), verify readiness, and reply with the URL, logs, and stop instructions. Without a supervisor, describe survival as best-effort, not guaranteed.\n")
-	b.WriteString("- The one exception: when the trigger comment or the issue's acceptance criteria explicitly ask you for the CI result, that result IS the deliverable — wait for it as ONE foreground blocking call (`gh pr checks <pr> --watch`) inside this same turn and report the outcome. Nothing else re-opens this door.\n\n")
+	b.WriteString("A user explicitly asking for a local service to stay available after the turn is a persistent service handoff, not background-and-yield — allowed only when the running service itself is the requested deliverable. Detach its lifecycle from this run first (durable logs, a recorded cleanup handle such as PID/profile), verify readiness, and reply with the URL, logs, and stop instructions. Without a supervisor, describe survival as best-effort, not guaranteed.\n\n")
 }
 
 // writeAgentIdentity emits the Agent Identity heading and (optionally) the


### PR DESCRIPTION
Stage 2, section 1 — judgment-form rewrite (owner-authorized pin renegotiation), plus Elon's three review fixes.

## Measured (standard issue fixture)

| | bytes |
|---|---:|
| main (post #6365) | 14,725 |
| this PR | **13,374** |
| Background Task Safety | 2,980 → **1,624 (−1,356 / −45.5%)** |

Campaign cumulative: 19,231 → 13,374 (**−30.5%**). The section lands BELOW the plan's original 1,700 target — the review round found a duplicated CI-exception clause worth 307B that substring pins could not see.

## The section now

Three paragraphs: (1) the platform fact everything derives from — turn exit is task-terminal, no wakeup, never background-and-yield — with its three consequences stated once; (2) the external-systems/CI boundary: not run-owned, the full named watch/poll ban (kept: MUL-5223 proved the principle alone did not stop CI-watching), merge-gate ≠ acceptance criteria, the hand-off phrasing, and the single explicit-ask exception (count-guarded to exactly one occurrence); (3) the review-locked persistent-service handoff contract, verbatim.

Dropped as derivable: run-owned work enumeration, tool-promise enumeration, wait/collect split rule, persistent-service scope bullet, auto-merge/snapshot elaborations. Incident history lives in the Go doc comment (rewritten this round to match the three-paragraph model).

## Pins

21 semantic anchors per test list (fact, boundaries, exceptions, handoff triple) + the compound ban pinned as its full clause + the exactly-one-exception count guard. Retired pins are named in test comments with rationale.

## Verification

`go test ./internal/daemon/... -count=1` green · `go build` / `go vet` / `gofmt -l` clean · ByteIdentical guards pass.