### PR TITLE
refactor(daemon): per-turn message slimming — OPT-1 UUID dedup + OPT-2 initiator prose (MUL-5721)

### DIFF
--- a/server/internal/daemon/execenv/execenv_test.go
+++ b/server/internal/daemon/execenv/execenv_test.go
@@ -5265,6 +5265,7 @@ func TestTaskInitiatorBlockMember(t *testing.T) {
 		"is who you are answering",
 		"apply any per-person privacy or access rules",
 		"credentials stay scoped to the runtime owner",
+		"attribution does not change what you may read or write",
 		"do not assume the initiator can see everything you can",
 	} {
 		if !strings.Contains(block, want) {

--- a/server/internal/daemon/execenv/execenv_test.go
+++ b/server/internal/daemon/execenv/execenv_test.go
@@ -5442,7 +5442,6 @@ func TestInjectRuntimeConfigBriefOmitsResumedThreadAnchor(t *testing.T) {
 	for _, want := range []string{
 		"triggering comment is already included above",
 		"No other new comments on this issue since your last run",
-		"active thread anchor `thread-root-1` and triggering comment ID `" + triggerID + "`",
 		"If your reply depends on thread context",
 		"do not rely only on resumed session memory",
 		"multica issue comment list " + issueID + " --thread thread-root-1 --tail 30 --output json",
@@ -5450,6 +5449,11 @@ func TestInjectRuntimeConfigBriefOmitsResumedThreadAnchor(t *testing.T) {
 		if !strings.Contains(hint, want) {
 			t.Errorf("resumed hint missing %q\n---\n%s", want, hint)
 		}
+	}
+	// The anchor-restating sentence is gone (MUL-5721 OPT-1): the read command
+	// carries the thread anchor and the reply cookbook carries the trigger id.
+	if strings.Contains(hint, "active thread anchor") {
+		t.Errorf("resumed hint must not restate anchors outside the commands, got:\n%s", hint)
 	}
 }
 

--- a/server/internal/daemon/execenv/execenv_test.go
+++ b/server/internal/daemon/execenv/execenv_test.go
@@ -5262,8 +5262,10 @@ func TestTaskInitiatorBlockMember(t *testing.T) {
 	for _, want := range []string{
 		"## Task Initiator",
 		"initiated by **Bohan** (bohan@example.com), a member of this workspace",
+		"is who you are answering",
 		"apply any per-person privacy or access rules",
 		"credentials stay scoped to the runtime owner",
+		"do not assume the initiator can see everything you can",
 	} {
 		if !strings.Contains(block, want) {
 			t.Errorf("expected initiator block to contain %q\n---\n%s", want, block)

--- a/server/internal/daemon/execenv/reply_instructions.go
+++ b/server/internal/daemon/execenv/reply_instructions.go
@@ -14,9 +14,8 @@ import "fmt"
 // thread. The issue-wide `--since` catch-up is kept as an explicit
 // "only if you need it" fallback.
 //
-// Both the per-turn prompt (daemon.buildCommentPrompt) and the CLAUDE.md
-// workflow (InjectRuntimeConfig) call this so the two surfaces cannot drift
-// (hard requirement from PR #2816).
+// Since MUL-5377 the per-turn prompt (daemon.buildCommentPrompt) is the only
+// caller — the brief must not carry per-run routing state.
 //
 // Renders nothing on cold start (no prior run → newCommentsSince empty) or when
 // there are no new comments (newCommentCount <= 0) or issueID is empty. In those
@@ -29,16 +28,18 @@ func BuildNewCommentsHint(issueID, triggerCommentID, triggerThreadID, newComment
 	threadID := activeThreadID(triggerThreadID, triggerCommentID)
 	// When we know the triggering thread, steer the agent to read THAT thread
 	// first rather than blindly pulling every new comment issue-wide. The
-	// issue-wide --since catch-up is demoted to an only-if-needed fallback.
+	// issue-wide --since catch-up is demoted to an only-if-needed fallback,
+	// phrased as a rerun of the thread command minus `--thread` instead of a
+	// second full command: the duplicate restated the issue UUID and anchor
+	// for no routing value (MUL-5721 OPT-1).
 	if threadID != "" {
 		return fmt.Sprintf(
 			"%d new comment(s) on this issue since your last run — don't read them all blindly. "+
 				"Start with the thread your triggering comment is in: "+
 				"`multica issue comment list %s --thread %s --since %s --output json` "+
 				"(swap `--since` for `--tail 30` if you need the full thread, not just the delta). "+
-				"Only if you need context from the other threads, catch up issue-wide: "+
-				"`multica issue comment list %s --since %s --output json`.\n\n",
-			newCommentCount, issueID, threadID, newCommentsSince, issueID, newCommentsSince,
+				"Only if you need context from the other threads, rerun it without `--thread` for the issue-wide catch-up.\n\n",
+			newCommentCount, issueID, threadID, newCommentsSince,
 		)
 	}
 	// Defensive: comment triggers always carry a trigger id, but if one is
@@ -64,14 +65,16 @@ func BuildResumedCommentsHint(issueID, triggerCommentID, triggerThreadID string)
 	if issueID == "" || threadID == "" {
 		return ""
 	}
+	// No standalone anchor-restating sentence here (MUL-5721 OPT-1): the read
+	// command below already carries the thread anchor, and the trigger comment
+	// id reaches the agent as the reply cookbook's `--parent` value.
 	return fmt.Sprintf(
 		"You're resuming the prior session, and the triggering comment is already included above. "+
 			"No other new comments on this issue since your last run. "+
-			"Use the active thread anchor `%s` and triggering comment ID `%s`. "+
 			"If your reply depends on thread context, do not rely only on resumed session memory — "+
 			"first pull the triggering conversation with: "+
 			"`multica issue comment list %s --thread %s --tail 30 --output json`.\n\n",
-		threadID, triggerCommentID, issueID, threadID,
+		issueID, threadID,
 	)
 }
 
@@ -87,23 +90,24 @@ func BuildResumedCommentsHint(issueID, triggerCommentID, triggerThreadID string)
 // `## Available Commands` (MUL-5372). Per-turn hints name only the reads they
 // actually want the agent to run.
 //
-// Both surfaces call this so the cold fallback cannot drift between them (same
-// single-source rule as BuildNewCommentsHint, PR #2816). Returns "" when there
-// is no triggering comment to thread from, so the caller can keep a final plain
-// fallback.
+// Since MUL-5377 the per-turn prompt is the only caller (same as
+// BuildNewCommentsHint). Returns "" when there is no triggering comment to
+// thread from, so the caller can keep a final plain fallback.
 func BuildColdCommentsHint(issueID, triggerCommentID, triggerThreadID string) string {
 	threadID := activeThreadID(triggerThreadID, triggerCommentID)
 	if issueID == "" || threadID == "" {
 		return ""
 	}
+	// The roots scan is phrased as a flag swap on the thread command above, not
+	// a second full command: the duplicate restated the issue UUID for no
+	// routing value (MUL-5721 OPT-1).
 	return fmt.Sprintf(
 		"Read the triggering conversation first: "+
 			"`multica issue comment list %s --thread %s --tail 30 --output json` "+
 			"(that thread's root + its 30 newest replies). "+
-			"Need cross-thread background? Scan the other threads cheaply with "+
-			"`multica issue comment list %s --roots-only --summary --output json` and expand only "+
-			"what looks relevant.\n\n",
-		issueID, threadID, issueID,
+			"Need cross-thread background? Rerun with `--roots-only --summary` replacing `--thread ... --tail 30` "+
+			"to scan the other threads cheaply, and expand only what looks relevant.\n\n",
+		issueID, threadID,
 	)
 }
 

--- a/server/internal/daemon/execenv/runtime_config_sections.go
+++ b/server/internal/daemon/execenv/runtime_config_sections.go
@@ -180,7 +180,7 @@ func BuildTaskInitiatorBlock(initiatorType, initiatorName, initiatorEmail string
 	} else {
 		fmt.Fprintf(&b, "This task was initiated by **%s**, a member of this workspace.\n\n", safeInitiator)
 	}
-	b.WriteString("The initiator — not the runtime owner — is who you are answering: apply any per-person privacy or access rules your instructions define. Your Multica credentials stay scoped to the runtime owner; do not assume the initiator can see everything you can.\n\n")
+	b.WriteString("The initiator — not the runtime owner — is who you are answering: apply any per-person privacy or access rules your instructions define. Your Multica credentials stay scoped to the runtime owner, and initiator attribution does not change what you may read or write; do not assume the initiator can see everything you can.\n\n")
 	return b.String()
 }
 

--- a/server/internal/daemon/execenv/runtime_config_sections.go
+++ b/server/internal/daemon/execenv/runtime_config_sections.go
@@ -180,7 +180,7 @@ func BuildTaskInitiatorBlock(initiatorType, initiatorName, initiatorEmail string
 	} else {
 		fmt.Fprintf(&b, "This task was initiated by **%s**, a member of this workspace.\n\n", safeInitiator)
 	}
-	b.WriteString("Attribute this request to that person and apply any per-person privacy or access rules your instructions define — in a workspace many people can reach, the initiator (not the runtime owner) is who you are answering. Your Multica credentials stay scoped to the runtime owner, so this attribution does not widen what you can read or write — do not assume the initiator can see everything you can.\n\n")
+	b.WriteString("The initiator — not the runtime owner — is who you are answering: apply any per-person privacy or access rules your instructions define. Your Multica credentials stay scoped to the runtime owner; do not assume the initiator can see everything you can.\n\n")
 	return b.String()
 }
 

--- a/server/internal/daemon/execenv/runtime_config_test.go
+++ b/server/internal/daemon/execenv/runtime_config_test.go
@@ -275,7 +275,6 @@ func TestResumedCommentsHintSkipsDefaultThreadRead(t *testing.T) {
 	for _, want := range []string{
 		"triggering comment is already included above",
 		"No other new comments on this issue since your last run",
-		"active thread anchor `thread-root-1` and triggering comment ID `trigger-1`",
 		"If your reply depends on thread context",
 		"do not rely only on resumed session memory",
 		"multica issue comment list " + issueID + " --thread thread-root-1 --tail 30 --output json",
@@ -283,6 +282,11 @@ func TestResumedCommentsHintSkipsDefaultThreadRead(t *testing.T) {
 		if !strings.Contains(hint, want) {
 			t.Errorf("resumed/no-delta hint missing %q\n--- output ---\n%s", want, hint)
 		}
+	}
+	// The anchor-restating sentence is gone (MUL-5721 OPT-1): the read command
+	// carries the thread anchor and the reply cookbook carries the trigger id.
+	if strings.Contains(hint, "active thread anchor") {
+		t.Errorf("resumed/no-delta hint must not restate anchors outside the commands, got:\n%s", hint)
 	}
 	if strings.Contains(hint, "scoped to the triggering thread") {
 		t.Errorf("resumed/no-delta hint must not claim the delta is thread-scoped, got:\n%s", hint)

--- a/server/internal/daemon/prompt_test.go
+++ b/server/internal/daemon/prompt_test.go
@@ -717,9 +717,14 @@ func TestBuildPromptNewCommentsHint(t *testing.T) {
 	if !strings.Contains(out, "--tail 30") {
 		t.Errorf("hint must offer the full-thread (--tail 30) option, got:\n%s", out)
 	}
-	// Issue-wide catch-up is demoted to an only-if-needed fallback.
-	if !strings.Contains(out, "multica issue comment list "+issueID+" --since "+since+" --output json") {
-		t.Errorf("hint must keep the issue-wide --since catch-up as a fallback, got:\n%s", out)
+	// Issue-wide catch-up is demoted to an only-if-needed fallback, phrased as
+	// a rerun of the thread command minus `--thread` (MUL-5721 OPT-1) instead
+	// of a second full command that restated the UUID and anchor.
+	if !strings.Contains(out, "rerun it without `--thread` for the issue-wide catch-up") {
+		t.Errorf("hint must keep the issue-wide catch-up fallback, got:\n%s", out)
+	}
+	if strings.Contains(out, "multica issue comment list "+issueID+" --since "+since+" --output json") {
+		t.Errorf("warm hint must not render a second full issue-wide command (MUL-5721 OPT-1), got:\n%s", out)
 	}
 	// The old cursor-heavy paragraph must be gone.
 	if strings.Contains(out, "Next reply cursor") || strings.Contains(out, "--before-id") {
@@ -752,9 +757,14 @@ func TestBuildPromptColdStartThreadRead(t *testing.T) {
 	// MUL-5372: cross-thread background is a cheap roots scan. The hint names
 	// only the reads it wants run — `--recent` and its saturation trap are
 	// documented once in the brief's `## Available Commands`, so restating the
-	// flag surface here would put reference text on every cold turn.
-	if !strings.Contains(out, "multica issue comment list "+issueID+" --roots-only --summary --output json") {
+	// flag surface here would put reference text on every cold turn. The scan
+	// is phrased as a flag swap on the thread command, not a second full
+	// command restating the UUID (MUL-5721 OPT-1).
+	if !strings.Contains(out, "Rerun with `--roots-only --summary` replacing `--thread ... --tail 30`") {
 		t.Errorf("cold start should offer the cheap roots scan for cross-thread background, got:\n%s", out)
+	}
+	if strings.Contains(out, "multica issue comment list "+issueID+" --roots-only --summary --output json") {
+		t.Errorf("cold hint must not render a second full command for the roots scan (MUL-5721 OPT-1), got:\n%s", out)
 	}
 	if strings.Contains(out, "--recent") {
 		t.Errorf("cold start hint should not restate the --recent surface, got:\n%s", out)
@@ -782,7 +792,6 @@ func TestBuildPromptResumedNoDeltaDoesNotForceThreadRead(t *testing.T) {
 	for _, want := range []string{
 		"triggering comment is already included above",
 		"No other new comments on this issue since your last run",
-		"active thread anchor `thread-root-1` and triggering comment ID `trigger-1`",
 		"If your reply depends on thread context",
 		"do not rely only on resumed session memory",
 		"multica issue comment list " + issueID + " --thread thread-root-1 --tail 30 --output json",
@@ -790,6 +799,11 @@ func TestBuildPromptResumedNoDeltaDoesNotForceThreadRead(t *testing.T) {
 		if !strings.Contains(out, want) {
 			t.Errorf("resumed/no-delta prompt missing %q\n--- output ---\n%s", want, out)
 		}
+	}
+	// The anchor-restating sentence is gone (MUL-5721 OPT-1): the read command
+	// carries the thread anchor and the reply cookbook carries the trigger id.
+	if strings.Contains(out, "active thread anchor") {
+		t.Errorf("resumed/no-delta prompt must not restate anchors outside the commands, got:\n%s", out)
 	}
 	// The stale thread-scoped wording (since-delta used to be thread-scoped)
 	// must not reappear.


### PR DESCRIPTION
Per-turn message slimming, phase 1 of the MUL-5721 plan: the two low-risk items (OPT-1 UUID dedup, OPT-2 Task Initiator prose). Measurement report and pin inventory: MUL-5721.

## What changes for the agent

Nothing operationally. Every command the agent is told to run first (issue get, thread-first read, reply cookbook with its concrete `--parent`) keeps its full, copy-pasteable form. What disappears is repetition:

- **Warm hint**: the issue-wide catch-up was a second full `comment list <uuid> --since <ts>` command differing from the thread-first command only by dropping `--thread`. It is now phrased as exactly that flag drop.
- **Cold hint**: same for the roots scan (`--roots-only --summary` replacing `--thread ... --tail 30`).
- **Resumed hint**: the sentence restating the thread anchor and trigger id is gone — the read command carries the anchor, the reply cookbook carries the trigger id as `--parent`.
- **Task Initiator**: the 400 B attribution paragraph loses its two derivable restatements; every rule survives (per-person privacy/access rules, initiator-not-owner attribution, credential scoping, visibility asymmetry), both MUL-2645 pinned phrases verbatim.

## Measured (fixture: 36 B UUIDs, 100 B ref body; same harness as the MUL-5721 report)

| | before | after | Δ |
|---|---:|---:|---:|
| Reply warm (B1) | 1,824 | 1,750 | −74 |
| Reply resumed (B2) | 1,820 | 1,686 | −134 |
| Reply cold (B3) | 1,698 | 1,665 | −33 |
| Task Initiator block | 513 | 370 | −143 |
| **Typical reply turn (B1 + initiator)** | **2,338** | **2,121** | **−217 (−9.3%)** |

Ownership prompt: unchanged (828 B). UUID renders on B2 drop from 8 to 6; B1/B3 from 7 to 6.

**Estimate vs actual, disclosed up front:** the MUL-5721 report projected −440~490 B for OPT-1+OPT-2. Actual is −217 B. The gap is deliberate: the report's OPT-1 ceiling assumed deduping down to one issue UUID total, which would placeholder-ize executable commands (the issue-get line and the reply cookbook) — that is OPT-1b (examples→interface), classified high-risk and NOT in this PR. OPT-2 keeps the two pinned phrases plus the visibility rule verbatim rather than hitting the ~220 B block target by cutting contract material.

## Invariants (nothing below changed)

- Reply cookbook: full `comment add <issue> --parent <trigger> --content-file` command, "do NOT reuse --parent", `\n`-escape rule, Windows variant.
- Hint routing semantics: thread-first read, "blindly" demotion of bulk reads, cold/warm/resumed selection logic, all builder signatures.
- Task Initiator: heading, fact line (name/email/member-vs-agent forms), both MUL-2645 pins.
- Brief (CLAUDE.md): byte-identical — these builders render only into the per-turn message since MUL-5377 (two stale "both surfaces call this" doc comments corrected as part of this change).

## Pin changes

- Removed asserts: the three dropped duplicates (issue-wide command, roots-scan command, anchor sentence ×3 test sites).
- Added denies: each dropped duplicate now has a must-NOT-render assertion so it cannot silently return.
- Added anchors: `rerun it without --thread for the issue-wide catch-up`, `Rerun with --roots-only --summary replacing --thread ... --tail 30`, and two previously unpinned initiator rules (`is who you are answering`, `do not assume the initiator can see everything you can`).

Two commits = two independent revert units (hints / initiator).

## Verification

- `go build ./...` clean; `go test ./internal/daemon/... -count=1` all green; `gofmt -l` clean on all touched files.
- Byte measurements reproduced with the MUL-5721 harness on this branch (harness not committed).
