### PR TITLE
fix(agent): raise the agent stream scanner cap to 32 MiB and share it (MUL-5722)

### DIFF
--- a/server/pkg/agent/antigravity.go
+++ b/server/pkg/agent/antigravity.go
@@ -1,7 +1,6 @@
 package agent
 
 import (
-	"bufio"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -125,8 +124,7 @@ func (b *antigravityBackend) Execute(ctx context.Context, prompt string, opts Ex
 		finalStatus := "completed"
 		var finalError string
 
-		scanner := bufio.NewScanner(stdout)
-		scanner.Buffer(make([]byte, 0, 1024*1024), 10*1024*1024)
+		scanner := newAgentStreamScanner(stdout)
 
 		trySend(msgCh, Message{Type: MessageStatus, Status: "running"})
 
@@ -353,8 +351,7 @@ func readAntigravityTranscriptOutput(logPath, conversationID string) string {
 	defer f.Close()
 
 	var parts []string
-	scanner := bufio.NewScanner(f)
-	scanner.Buffer(make([]byte, 0, 1024*1024), 10*1024*1024)
+	scanner := newAgentStreamScanner(f)
 	for scanner.Scan() {
 		line := scanner.Bytes()
 		if len(line) == 0 {

--- a/server/pkg/agent/claude.go
+++ b/server/pkg/agent/claude.go
@@ -1,7 +1,6 @@
 package agent
 
 import (
-	"bufio"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -213,8 +212,7 @@ func (b *claudeBackend) Execute(ctx context.Context, prompt string, opts ExecOpt
 			_ = stdout.Close()
 		}()
 
-		scanner := bufio.NewScanner(stdout)
-		scanner.Buffer(make([]byte, 0, 1024*1024), 10*1024*1024)
+		scanner := newAgentStreamScanner(stdout)
 
 		for scanner.Scan() {
 			line := strings.TrimSpace(scanner.Text())

--- a/server/pkg/agent/codebuddy.go
+++ b/server/pkg/agent/codebuddy.go
@@ -1,7 +1,6 @@
 package agent
 
 import (
-	"bufio"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -196,8 +195,7 @@ func (b *codebuddyBackend) Execute(ctx context.Context, prompt string, opts Exec
 			_ = stdout.Close()
 		}()
 
-		scanner := bufio.NewScanner(stdout)
-		scanner.Buffer(make([]byte, 0, 1024*1024), 10*1024*1024)
+		scanner := newAgentStreamScanner(stdout)
 
 		for scanner.Scan() {
 			line := strings.TrimSpace(scanner.Text())

--- a/server/pkg/agent/codex.go
+++ b/server/pkg/agent/codex.go
@@ -1085,8 +1085,7 @@ func (b *codexBackend) executeOnce(ctx context.Context, prompt string, opts Exec
 	readerDone := make(chan struct{})
 	go func() {
 		defer close(readerDone)
-		scanner := bufio.NewScanner(stdout)
-		scanner.Buffer(make([]byte, 0, 1024*1024), 10*1024*1024)
+		scanner := newAgentStreamScanner(stdout)
 		for scanner.Scan() {
 			line := strings.TrimSpace(scanner.Text())
 			if line == "" {

--- a/server/pkg/agent/codex_test.go
+++ b/server/pkg/agent/codex_test.go
@@ -3133,8 +3133,8 @@ func TestCodexExecuteCleansUpWhenScannerOverflowsOnResume(t *testing.T) {
 	}
 
 	// Regression for GH#4520. On `thread/resume`, the fake codex emits a
-	// single stdout line larger than the daemon's bufio.Scanner cap (10 MB),
-	// which trips "bufio.Scanner: token too long" in the reader goroutine.
+	// single stdout line larger than agentStreamMaxLineBytes, which trips
+	// "bufio.Scanner: token too long" in the reader goroutine.
 	// Pre-fix, drainAndWait then hung forever on cmd.Wait(): the reader had
 	// stopped consuming the pipe, codex was blocked writing into a full
 	// stdout buffer, stdin.Close never unblocked codex, and the deferred
@@ -3155,12 +3155,13 @@ func TestCodexExecuteCleansUpWhenScannerOverflowsOnResume(t *testing.T) {
 		`read line`+"\n"+
 		`echo '{"jsonrpc":"2.0","id":1,"result":{}}'`+"\n"+
 		`read line`+"\n"+
-		// Emit a > 10 MB single line with no embedded newline. printf
+		// Emit a single line past the cap with no embedded newline. printf
 		// avoids the trailing newline echo would add; head + tr generates
-		// the bulk payload in pure POSIX shell. The scanner errors out at
-		// 10 MB even though we write 11 MB.
+		// the bulk payload in pure POSIX shell. The size is derived from
+		// the production constant so raising the cap cannot silently turn
+		// this regression test into a no-op.
 		`printf '{"jsonrpc":"2.0","id":2,"result":{"big":"'`+"\n"+
-		`head -c 11000000 /dev/zero | tr '\0' 'x'`+"\n"+
+		fmt.Sprintf(`head -c %d /dev/zero | tr '\0' 'x'`, agentStreamMaxLineBytes+1024*1024)+"\n"+
 		`printf '"}}\n'`+"\n"+
 		// Hold the process open without reading more stdin. Pre-fix this
 		// hangs cmd.Wait() because codex never sees stdin EOF (it isn't

--- a/server/pkg/agent/copilot.go
+++ b/server/pkg/agent/copilot.go
@@ -1,7 +1,6 @@
 package agent
 
 import (
-	"bufio"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -395,8 +394,7 @@ func (b *copilotBackend) Execute(ctx context.Context, prompt string, opts ExecOp
 			_ = stdout.Close()
 		}()
 
-		scanner := bufio.NewScanner(stdout)
-		scanner.Buffer(make([]byte, 0, 1024*1024), 10*1024*1024)
+		scanner := newAgentStreamScanner(stdout)
 
 		for scanner.Scan() {
 			line := strings.TrimSpace(scanner.Text())

--- a/server/pkg/agent/cursor.go
+++ b/server/pkg/agent/cursor.go
@@ -1,7 +1,6 @@
 package agent
 
 import (
-	"bufio"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -141,8 +140,7 @@ func (b *cursorBackend) Execute(ctx context.Context, prompt string, opts ExecOpt
 		hasResultUsage := false
 		var thinking cursorThinkingStream
 
-		scanner := bufio.NewScanner(stdout)
-		scanner.Buffer(make([]byte, 0, 1024*1024), 10*1024*1024)
+		scanner := newAgentStreamScanner(stdout)
 
 		for scanner.Scan() {
 			raw := scanner.Text()

--- a/server/pkg/agent/cursor_execute_unix_test.go
+++ b/server/pkg/agent/cursor_execute_unix_test.go
@@ -3,6 +3,7 @@
 package agent
 
 import (
+	"fmt"
 	"log/slog"
 	"os"
 	"path/filepath"
@@ -186,11 +187,14 @@ exit 1
 }
 
 func TestCursorExecuteReportsScannerOverflow(t *testing.T) {
-	script := `#!/bin/sh
-printf '%s\n' '{"type":"system","subtype":"init","session_id":"sess-overflow"}'
-dd if=/dev/zero bs=1048576 count=11 2>/dev/null | tr '\000' x
+	// The oversized event is sized from agentStreamMaxLineBytes so raising
+	// the shared cap cannot silently turn this into a plain oversized-line
+	// pass that never reaches the overflow branch.
+	script := fmt.Sprintf(`#!/bin/sh
+printf '%%s\n' '{"type":"system","subtype":"init","session_id":"sess-overflow"}'
+dd if=/dev/zero bs=1048576 count=%d 2>/dev/null | tr '\000' x
 printf '\n'
-`
+`, agentStreamMaxLineBytes/(1024*1024)+1)
 	result := executeFakeCursor(t, script)
 
 	if result.Status != "failed" {

--- a/server/pkg/agent/deveco.go
+++ b/server/pkg/agent/deveco.go
@@ -27,7 +27,6 @@ package agent
 //     (see packages/core/agents/mcp-support.ts).
 
 import (
-	"bufio"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -313,8 +312,7 @@ func (b *devecoBackend) processEvents(r io.Reader, ch chan<- Message) devecoEven
 	finalStatus := "completed"
 	var finalError string
 
-	scanner := bufio.NewScanner(r)
-	scanner.Buffer(make([]byte, 0, 1024*1024), 10*1024*1024)
+	scanner := newAgentStreamScanner(r)
 
 	for scanner.Scan() {
 		line := strings.TrimSpace(scanner.Text())

--- a/server/pkg/agent/grok.go
+++ b/server/pkg/agent/grok.go
@@ -1,7 +1,6 @@
 package agent
 
 import (
-	"bufio"
 	"context"
 	"fmt"
 	"io"
@@ -239,8 +238,7 @@ func (b *grokBackend) Execute(ctx context.Context, prompt string, opts ExecOptio
 	readerDone := make(chan struct{})
 	go func() {
 		defer close(readerDone)
-		scanner := bufio.NewScanner(stdout)
-		scanner.Buffer(make([]byte, 0, 1024*1024), 10*1024*1024)
+		scanner := newAgentStreamScanner(stdout)
 		for scanner.Scan() {
 			line := strings.TrimSpace(scanner.Text())
 			if line == "" {

--- a/server/pkg/agent/hermes.go
+++ b/server/pkg/agent/hermes.go
@@ -1,7 +1,6 @@
 package agent
 
 import (
-	"bufio"
 	"bytes"
 	"context"
 	"encoding/json"
@@ -315,8 +314,7 @@ func (b *hermesBackend) Execute(ctx context.Context, prompt string, opts ExecOpt
 	readerDone := make(chan struct{})
 	go func() {
 		defer close(readerDone)
-		scanner := bufio.NewScanner(stdout)
-		scanner.Buffer(make([]byte, 0, 1024*1024), 10*1024*1024)
+		scanner := newAgentStreamScanner(stdout)
 		for scanner.Scan() {
 			line := strings.TrimSpace(scanner.Text())
 			if line == "" {

--- a/server/pkg/agent/kimi.go
+++ b/server/pkg/agent/kimi.go
@@ -1,7 +1,6 @@
 package agent
 
 import (
-	"bufio"
 	"context"
 	"fmt"
 	"io"
@@ -178,8 +177,7 @@ func (b *kimiBackend) Execute(ctx context.Context, prompt string, opts ExecOptio
 	readerDone := make(chan struct{})
 	go func() {
 		defer close(readerDone)
-		scanner := bufio.NewScanner(stdout)
-		scanner.Buffer(make([]byte, 0, 1024*1024), 10*1024*1024)
+		scanner := newAgentStreamScanner(stdout)
 		for scanner.Scan() {
 			line := strings.TrimSpace(scanner.Text())
 			if line == "" {

--- a/server/pkg/agent/kiro.go
+++ b/server/pkg/agent/kiro.go
@@ -1,7 +1,6 @@
 package agent
 
 import (
-	"bufio"
 	"context"
 	"errors"
 	"fmt"
@@ -205,8 +204,7 @@ func (b *kiroBackend) Execute(ctx context.Context, prompt string, opts ExecOptio
 	readerDone := make(chan struct{})
 	go func() {
 		defer close(readerDone)
-		scanner := bufio.NewScanner(stdout)
-		scanner.Buffer(make([]byte, 0, 1024*1024), 10*1024*1024)
+		scanner := newAgentStreamScanner(stdout)
 		for scanner.Scan() {
 			line := strings.TrimSpace(scanner.Text())
 			if line == "" {

--- a/server/pkg/agent/openclaw.go
+++ b/server/pkg/agent/openclaw.go
@@ -1,7 +1,6 @@
 package agent
 
 import (
-	"bufio"
 	"bytes"
 	"context"
 	"encoding/json"
@@ -405,8 +404,7 @@ func (b *openclawBackend) processOutput(r io.Reader, ch chan<- Message) openclaw
 	// backend on this code path emits real NDJSON streams and needs live
 	// progress updates, we'll need to split the fast path off a streaming
 	// reader instead of io.ReadAll.
-	scanner := bufio.NewScanner(bytes.NewReader(buf))
-	scanner.Buffer(make([]byte, 0, 1024*1024), 10*1024*1024)
+	scanner := newAgentStreamScanner(bytes.NewReader(buf))
 
 	var output strings.Builder
 	var sessionID string

--- a/server/pkg/agent/opencode.go
+++ b/server/pkg/agent/opencode.go
@@ -1,7 +1,6 @@
 package agent
 
 import (
-	"bufio"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -305,8 +304,7 @@ func (b *opencodeBackend) processEvents(r io.Reader, ch chan<- Message) eventRes
 	stepHasContinuationTool := false // current step has a local tool result OpenCode must feed back
 	awaitingContinuation := false    // the last step_finish still required another step
 
-	scanner := bufio.NewScanner(r)
-	scanner.Buffer(make([]byte, 0, 1024*1024), 10*1024*1024)
+	scanner := newAgentStreamScanner(r)
 
 	for scanner.Scan() {
 		line := strings.TrimSpace(scanner.Text())

--- a/server/pkg/agent/pi.go
+++ b/server/pkg/agent/pi.go
@@ -1,7 +1,6 @@
 package agent
 
 import (
-	"bufio"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -262,10 +261,9 @@ func (b *piBackend) Execute(ctx context.Context, prompt string, opts ExecOptions
 		var finalError string
 		usage := make(map[string]TokenUsage)
 
-		scanner := bufio.NewScanner(stdout)
 		// Pi message_update events can be large (they embed the full message
-		// partial on each delta), so give the scanner generous headroom.
-		scanner.Buffer(make([]byte, 0, 1024*1024), 32*1024*1024)
+		// partial on each delta); the shared stream bound covers that.
+		scanner := newAgentStreamScanner(stdout)
 		var textBuffer strings.Builder
 
 		for scanner.Scan() {

--- a/server/pkg/agent/qoder.go
+++ b/server/pkg/agent/qoder.go
@@ -1,7 +1,6 @@
 package agent
 
 import (
-	"bufio"
 	"context"
 	"fmt"
 	"io"
@@ -196,8 +195,7 @@ func (b *qoderBackend) Execute(ctx context.Context, prompt string, opts ExecOpti
 	readerDone := make(chan struct{})
 	go func() {
 		defer close(readerDone)
-		scanner := bufio.NewScanner(stdout)
-		scanner.Buffer(make([]byte, 0, 1024*1024), 10*1024*1024)
+		scanner := newAgentStreamScanner(stdout)
 		for scanner.Scan() {
 			line := strings.TrimSpace(scanner.Text())
 			if line == "" {

--- a/server/pkg/agent/qwen.go
+++ b/server/pkg/agent/qwen.go
@@ -1,7 +1,6 @@
 package agent
 
 import (
-	"bufio"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -139,8 +138,7 @@ func (b *qwenBackend) Execute(ctx context.Context, prompt string, opts ExecOptio
 			_ = stdout.Close()
 		}()
 
-		scanner := bufio.NewScanner(stdout)
-		scanner.Buffer(make([]byte, 0, 1024*1024), 10*1024*1024)
+		scanner := newAgentStreamScanner(stdout)
 		for scanner.Scan() {
 			line := strings.TrimSpace(scanner.Text())
 			if line == "" {

--- a/server/pkg/agent/qwenpaw.go
+++ b/server/pkg/agent/qwenpaw.go
@@ -1,7 +1,6 @@
 package agent
 
 import (
-	"bufio"
 	"context"
 	"fmt"
 	"io"
@@ -156,8 +155,7 @@ func (b *qwenpawBackend) Execute(ctx context.Context, prompt string, opts ExecOp
 	readerDone := make(chan struct{})
 	go func() {
 		defer close(readerDone)
-		scanner := bufio.NewScanner(stdout)
-		scanner.Buffer(make([]byte, 0, 1024*1024), 10*1024*1024)
+		scanner := newAgentStreamScanner(stdout)
 		for scanner.Scan() {
 			line := strings.TrimSpace(scanner.Text())
 			if line == "" {

--- a/server/pkg/agent/stream_json_final_output_test.go
+++ b/server/pkg/agent/stream_json_final_output_test.go
@@ -3,6 +3,7 @@ package agent
 import (
 	"bytes"
 	"context"
+	"fmt"
 	"log/slog"
 	"path/filepath"
 	"runtime"
@@ -173,9 +174,15 @@ printf '%s\n' '{"type":"user","message":{"role":"user","content":[{"type":"tool_
 		},
 		{
 			name: "scanner error fails closed",
-			// The production scanner caps a single event at 10 MiB. A larger
-			// token produces bufio.ErrTooLong while the child still exits 0.
-			scriptBody: `dd if=/dev/zero bs=1048576 count=11 2>/dev/null | tr '\000' x; printf '\n'` + "\n",
+			// The production scanner caps a single event at
+			// agentStreamMaxLineBytes. A larger token produces
+			// bufio.ErrTooLong while the child still exits 0. The count is
+			// derived from the constant so raising the cap cannot silently
+			// turn this case into a plain-oversized-line pass.
+			scriptBody: fmt.Sprintf(
+				`dd if=/dev/zero bs=1048576 count=%d 2>/dev/null | tr '\000' x; printf '\n'`,
+				agentStreamMaxLineBytes/(1024*1024)+1,
+			) + "\n",
 			wantStatus: "failed",
 			wantOutput: "",
 			wantError:  "stdout read error",

--- a/server/pkg/agent/stream_scanner.go
+++ b/server/pkg/agent/stream_scanner.go
@@ -1,0 +1,36 @@
+package agent
+
+import (
+	"bufio"
+	"io"
+)
+
+// agentStreamMaxLineBytes bounds a single line read from an agent CLI's
+// event stream. Agent transports are line-delimited JSON, and one line can
+// carry a whole conversation: Codex app-server serializes an entire thread
+// into the single `thread/resume` response, and providers that re-send a
+// growing message partial on every delta (Pi) or embed a large tool result
+// in one event grow the same way. Crossing this bound makes scanner.Scan()
+// return false with bufio.ErrTooLong, which the backends can only report as
+// a transport failure — the session itself is fine, we just cannot read it.
+//
+// 32 MiB was picked as the follow-up to GH#4520, where the previous 10 MiB
+// bound broke `thread/resume` for long Codex threads (MUL-5722). It is
+// headroom, not a guarantee: a thread can still outgrow any fixed cap, so
+// the recovery path matters more than the number.
+const agentStreamMaxLineBytes = 32 * 1024 * 1024
+
+// agentStreamInitialBufferBytes is the scanner's starting allocation. Lines
+// above it still grow up to agentStreamMaxLineBytes; this only decides how
+// much is reserved before the first grow, so ordinary events never realloc.
+const agentStreamInitialBufferBytes = 1024 * 1024
+
+// newAgentStreamScanner returns a bufio.Scanner sized for agent event
+// streams. Every backend reading a line-delimited agent transport must go
+// through this constructor: the bound used to be copy-pasted per backend and
+// silently drifted, which is how GH#4520's fix reached only one of them.
+func newAgentStreamScanner(r io.Reader) *bufio.Scanner {
+	scanner := bufio.NewScanner(r)
+	scanner.Buffer(make([]byte, 0, agentStreamInitialBufferBytes), agentStreamMaxLineBytes)
+	return scanner
+}

--- a/server/pkg/agent/stream_scanner_test.go
+++ b/server/pkg/agent/stream_scanner_test.go
@@ -1,0 +1,60 @@
+package agent
+
+import (
+	"bufio"
+	"bytes"
+	"errors"
+	"strings"
+	"testing"
+)
+
+// TestAgentStreamScannerReadsPastOldTenMiBCap is the regression for MUL-5722 /
+// GH#4520: Codex serializes a whole thread into the single `thread/resume`
+// response line, and the previous 10 MiB bound turned any thread past that
+// size into a permanent "bufio.Scanner: token too long" resume failure.
+func TestAgentStreamScannerReadsPastOldTenMiBCap(t *testing.T) {
+	t.Parallel()
+
+	const oldCap = 10 * 1024 * 1024
+	if agentStreamMaxLineBytes <= oldCap {
+		t.Fatalf("agentStreamMaxLineBytes must exceed the old %d-byte cap, got %d",
+			oldCap, agentStreamMaxLineBytes)
+	}
+
+	line := strings.Repeat("x", oldCap+1024*1024)
+	scanner := newAgentStreamScanner(strings.NewReader(line + "\n"))
+
+	if !scanner.Scan() {
+		t.Fatalf("expected a %d-byte line to scan, got err=%v", len(line), scanner.Err())
+	}
+	if got := len(scanner.Bytes()); got != len(line) {
+		t.Fatalf("expected %d bytes, got %d", len(line), got)
+	}
+	if err := scanner.Err(); err != nil {
+		t.Fatalf("unexpected scanner error: %v", err)
+	}
+}
+
+// TestAgentStreamScannerStillFailsClosedAboveCap keeps the bound a bound: the
+// backends' overflow handling (fail the turn rather than silently truncate an
+// event) depends on Scan reporting bufio.ErrTooLong, so raising the cap must
+// not mean removing it.
+func TestAgentStreamScannerStillFailsClosedAboveCap(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+	buf.Grow(agentStreamMaxLineBytes + 2)
+	for i := 0; i < agentStreamMaxLineBytes+1; i++ {
+		buf.WriteByte('x')
+	}
+	buf.WriteByte('\n')
+
+	scanner := newAgentStreamScanner(&buf)
+
+	if scanner.Scan() {
+		t.Fatalf("expected an over-cap line to fail, scanned %d bytes", len(scanner.Bytes()))
+	}
+	if err := scanner.Err(); !errors.Is(err, bufio.ErrTooLong) {
+		t.Fatalf("expected bufio.ErrTooLong, got %v", err)
+	}
+}

--- a/server/pkg/agent/traecli.go
+++ b/server/pkg/agent/traecli.go
@@ -1,7 +1,6 @@
 package agent
 
 import (
-	"bufio"
 	"context"
 	"fmt"
 	"io"
@@ -205,8 +204,7 @@ func (b *traecliBackend) Execute(ctx context.Context, prompt string, opts ExecOp
 	readerDone := make(chan struct{})
 	go func() {
 		defer close(readerDone)
-		scanner := bufio.NewScanner(stdout)
-		scanner.Buffer(make([]byte, 0, 1024*1024), 10*1024*1024)
+		scanner := newAgentStreamScanner(stdout)
 		for scanner.Scan() {
 			line := strings.TrimSpace(scanner.Text())
 			if line == "" {


### PR DESCRIPTION
## Problem

Codex app-server serializes an **entire thread into the single `thread/resume` response line**. Once a thread grows past the reader's 10 MiB `bufio.Scanner` cap (`server/pkg/agent/codex.go`), `scanner.Scan()` returns false with `bufio.ErrTooLong`, the reader goroutine calls `markProcessExited`, and the in-flight resume RPC fails with:

```
codex thread/resume failed: codex process exited: bufio.Scanner: token too long
```

The user-visible symptom is "session resume 一直失败，上下文过长" — the direction is right, but what overflows is our own buffer, not the model's context window.

**It never recovers on its own.** The error classifies as `agent_error.process_failure`, which is not in the resume-unsafe blacklist, so the session pointer survives; it is not in `retryableReasons`, so nothing retries; the `thread/start` fallback is blocked because `errCodexProcessExited` counts as a transport error; and `shouldRetryWithFreshSession` bails early because codex never sets `ResumeRejected`. Every subsequent turn resumes the same oversized thread and hits the same wall.

This is **GH#4520 recurring**. #4563 (closed it on 2026-06-25) fixed the hang and the orphan process so the daemon could at least emit a failed result, but the two follow-ups listed at close time were never done — the first being exactly "raise the remaining 10 MiB scanner cap to 32 MiB and extract it into a shared constant so backends stop drifting".

## Change

- New `server/pkg/agent/stream_scanner.go`: `agentStreamMaxLineBytes = 32 MiB` plus a `newAgentStreamScanner(io.Reader)` constructor.
- All 18 line-delimited agent transports now go through that constructor: codex, claude, codebuddy, copilot, cursor, deveco, grok, hermes, kimi, kiro, openclaw, opencode, pi, qoder, qwen, qwenpaw, traecli, antigravity (×2).

The cap was copy-pasted per backend and **had already drifted** — pi was at 32 MiB, all seventeen others at 10 MiB. That drift is precisely why #4563's fix only ever reached one backend, so a constructor rather than a bare constant: there is now no way to open a stream scanner and forget the bound.

Untouched on purpose: the 1 MiB / 4 MiB scanners for model listing and codex session-file parsing. Those are a different class with different inputs, not the execution transport.

## Scope — this is the containment layer only

Layer 1 of the three in MUL-5722. It moves the cliff; it does not remove it. A thread can outgrow any fixed cap, and the recovery path is still missing:

- overflow is still reported as a transport error, so the `thread/start` fallback stays blocked;
- codex still never sets `ResumeRejected`, so the daemon's fresh-session retry still does not fire.

Worth noting for whoever picks up layer 2: after an overflow the reader goroutine is dead and codex is blocked writing into an unread stdout pipe, so **the fallback cannot reuse that process** — it has to go through a fresh one. Setting `Result.ResumeRejected` on `bufio.ErrTooLong` is the cheapest way in, since it is the positive evidence `shouldRetryWithFreshSession` already asks for, and the retry restarts the process for free.

QwenPaw (#5986) merged to main after this branch was cut and brought its own 10 MiB scanner with it. Rebased onto main and folded it in — caught in review, and a good demonstration of the drift this PR is about: a bare constant would not have stopped a new backend from re-introducing the old cap either. The constructor at least makes the shared path the obvious one to reach for.

## Verification

Ran locally:

- `go test ./server/pkg/agent/` — full package green (~139s), re-run after the rebase.
- `go test ./server/internal/daemon/... ./server/pkg/taskfailure/...` — green.
- `go build ./...`, `go vet ./...`, `gofmt -l` — clean.

Three existing tests deliberately overflow the scanner and were asserting against the old 10 MiB bound with hardcoded 11 MB payloads — they would have silently stopped testing the overflow branch:

- `TestCodexExecuteCleansUpWhenScannerOverflowsOnResume`
- `TestStreamJSONBackendsFinalOutputBoundaries/{claude,codebuddy}/scanner_error_fails_closed`
- `TestCursorExecuteReportsScannerOverflow`

All three now size their payload from `agentStreamMaxLineBytes`, so a future cap change cannot quietly turn them into no-ops.

New `stream_scanner_test.go` covers both directions: a line in the old-failing 10–32 MiB range now scans, and a line above the new cap still fails closed with `bufio.ErrTooLong` (the backends' overflow handling depends on that error still being reported — raising a bound must not mean removing it).

