### PR TITLE
feat(server): tell a chat agent which room it is in and who else can read it

### DIFF
--- a/server/internal/daemon/daemon.go
+++ b/server/internal/daemon/daemon.go
@@ -4871,6 +4871,7 @@ func (d *Daemon) runTask(ctx context.Context, task Task, provider string, slot i
 		ProjectResources:                 convertProjectResourcesForEnv(task.ProjectResources),
 		ChatSessionID:                    task.ChatSessionID,
 		ChatChannelType:                  task.ChatChannelType,
+		ChatType:                         task.ChatType,
 		AutopilotRunID:                   task.AutopilotRunID,
 		AutopilotID:                      task.AutopilotID,
 		AutopilotTitle:                   task.AutopilotTitle,

--- a/server/internal/daemon/execenv/channel_type.go
+++ b/server/internal/daemon/execenv/channel_type.go
@@ -9,12 +9,60 @@ package execenv
 // server already serialized to JSON, and must not pull the server-side
 // integration packages (integrations/slack, integrations/lark) into its own
 // build just to read one discriminator. The canonical definitions live with
-// their adapters — slack.TypeSlack and channel.TypeFeishu — and both sides
-// agree on the wire strings below.
+// their adapters — slack.TypeSlack, channel.TypeFeishu, wecom.TypeWecom — and
+// both sides agree on the wire strings below.
 const (
 	ChannelTypeSlack  = "slack"
 	ChannelTypeFeishu = "feishu"
+	ChannelTypeWecom  = "wecom"
 )
+
+// Room-shape discriminators, mirroring channel_chat_session_binding.chat_type
+// (channel.ChatTypeP2P / channel.ChatTypeGroup). Every adapter persists this
+// column, so the shape of a conversation is known off one read whatever the
+// platform. Empty means the server did not report one — a web chat, which has
+// no binding row, or a server predating the field.
+const (
+	ChatTypeP2P   = "p2p"
+	ChatTypeGroup = "group"
+)
+
+// ChatAudience is what a run is allowed to say about who can read its replies.
+// Three states, because "unknown" is not "private": a web chat carries no
+// binding row at all and is 1:1 by construction, but an IM channel whose shape
+// the server did not report could be a room of any size, and the one thing the
+// copy must not then do is promise a privacy the conversation may not have.
+//
+// Both the brief's chat-mode line and the per-turn chat prompt open by naming
+// the audience, and they must not contradict each other or `## Conversation
+// Channel`. Routing all three through this keeps them from drifting.
+type ChatAudience int
+
+const (
+	// ChatAudienceDirect — one reader, provably: an explicit p2p binding, or a
+	// web chat that has no channel behind it.
+	ChatAudienceDirect ChatAudience = iota
+	// ChatAudienceGroup — a room shared by people the run has not been shown.
+	ChatAudienceGroup
+	// ChatAudienceUnknown — an IM channel whose shape did not arrive: a daemon
+	// newer than the server it claims from, or a binding deleted between
+	// enqueue and claim. Assert nothing about the audience.
+	ChatAudienceUnknown
+)
+
+// AudienceOf classifies a claim's (chat_channel_type, chat_type) pair.
+func AudienceOf(channelType, chatType string) ChatAudience {
+	switch {
+	case chatType == ChatTypeGroup:
+		return ChatAudienceGroup
+	case chatType == ChatTypeP2P:
+		return ChatAudienceDirect
+	case channelType == "":
+		return ChatAudienceDirect
+	default:
+		return ChatAudienceUnknown
+	}
+}
 
 // ChannelDisplayName renders a chat_channel_type for prompt / brief copy.
 // Unknown types fall through to the raw discriminator rather than a generic
@@ -26,6 +74,8 @@ func ChannelDisplayName(channelType string) string {
 		return "Slack"
 	case ChannelTypeFeishu:
 		return "Feishu/Lark"
+	case ChannelTypeWecom:
+		return "WeCom"
 	default:
 		return channelType
 	}

--- a/server/internal/daemon/execenv/execenv.go
+++ b/server/internal/daemon/execenv/execenv.go
@@ -126,13 +126,23 @@ type TaskContextForEnv struct {
 	ProjectResources              []ProjectResourceForEnv // resources attached to the project
 	ChatSessionID                 string                  // non-empty for chat tasks
 	// ChatChannelType is the IM platform behind a chat session ("slack",
-	// "feishu"); empty for a web/mobile chat. The brief reads it for DELIVERY
-	// policy only: any non-empty value means the reply leaves Multica for an
+	// "feishu", "wecom"); empty for a web/mobile chat. Two brief sections read
+	// it. DELIVERY: any non-empty value means the reply leaves Multica for an
 	// external channel, so `multica attachment upload` cannot deliver a file and
-	// the Output section says text-only instead (MUL-4899). The orthogonal
-	// history-command policy is Slack-only and lives in the per-turn chat prompt
-	// (daemon/prompt.go) — the server has no Feishu history reader.
-	ChatChannelType         string
+	// the Output section says text-only instead (MUL-4899). CHANNEL CONTEXT:
+	// `## Conversation Channel` names the platform, and pairs it with ChatType
+	// below. The orthogonal history-command policy is Slack-only and lives in
+	// the per-turn chat prompt (daemon/prompt.go) — the server has no history
+	// reader for any other channel.
+	ChatChannelType string
+	// ChatType is the room shape behind a channel chat session — "group" when
+	// the chat_session is shared by a whole room, "p2p" for a 1:1 with the bot.
+	// Read from channel_chat_session_binding.chat_type, which every adapter
+	// writes, so this is channel-agnostic. Empty for a web chat (no binding
+	// row) or an older server. The brief's `## Conversation Channel` section
+	// reads it to tell the agent who else can read its replies; without it the
+	// brief described every chat run as a private 1:1.
+	ChatType                string
 	AutopilotRunID          string // non-empty for autopilot run_only tasks
 	AutopilotID             string
 	AutopilotTitle          string

--- a/server/internal/daemon/execenv/runtime_config_channel_context_test.go
+++ b/server/internal/daemon/execenv/runtime_config_channel_context_test.go
@@ -1,0 +1,226 @@
+package execenv
+
+import (
+	"strings"
+	"testing"
+)
+
+// The `## Conversation Channel` contract.
+//
+// A chat_session behind Feishu, Slack or WeCom may be a GROUP room shared by
+// many people, and the brief used to describe every chat run as "A user is
+// messaging you directly in a chat window". An agent told it is in a private
+// 1:1 has no reason to weigh who else is reading, so the one input an operator
+// needs in order to write "do not repeat customer detail in a shared room"
+// was missing from the runtime.
+//
+// What the block does and does not do is the point of these tests: it states
+// the room's shape and stops. Deciding what may be said in front of that
+// audience belongs to the operator's agent instructions, so no rule of that
+// kind may appear here.
+
+// chatCtx builds a chat-kind context for a given channel and room shape.
+func chatCtx(channelType, chatType string) TaskContextForEnv {
+	return TaskContextForEnv{
+		ChatSessionID:   "c-1",
+		ChatChannelType: channelType,
+		ChatType:        chatType,
+		AgentID:         "eve-1",
+		AgentName:       "Eve",
+	}
+}
+
+// everyChannel is every IM the brief can name. The block is channel-agnostic
+// by construction — it reads chat_type, which every adapter persists on the
+// same channel_chat_session_binding column — and this table is what keeps a
+// future channel from having to be special-cased in.
+func everyChannel() map[string]string {
+	return map[string]string{
+		ChannelTypeSlack:  "Slack",
+		ChannelTypeFeishu: "Feishu/Lark",
+		ChannelTypeWecom:  "WeCom",
+	}
+}
+
+func TestBriefConversationChannel_GroupChatNamesTheAudience(t *testing.T) {
+	t.Parallel()
+
+	want := []string{
+		"## Conversation Channel",
+		// The fact the agent cannot infer: more than one reader.
+		"everyone in the room receives every reply you send",
+		"did not write the message you are answering",
+		"Nothing you send here is private to the person asking",
+		// In a shared room the asker changes per message, so the agent must
+		// not read the runtime owner as the person it is answering.
+		"`## Task Initiator`",
+		"`## Requesting User`",
+	}
+
+	for channelType, display := range everyChannel() {
+		out := buildMetaSkillContent("claude", chatCtx(channelType, ChatTypeGroup))
+		for _, phrase := range want {
+			if !strings.Contains(out, phrase) {
+				t.Errorf("channel=%s: group brief is missing %q\n---\n%s", channelType, phrase, out)
+			}
+		}
+		if !strings.Contains(out, display) {
+			t.Errorf("channel=%s: brief must name the platform as %q", channelType, display)
+		}
+	}
+}
+
+func TestBriefConversationChannel_DirectChatSaysSoAndClaimsNoAudience(t *testing.T) {
+	t.Parallel()
+
+	for channelType := range everyChannel() {
+		out := buildMetaSkillContent("claude", chatCtx(channelType, ChatTypeP2P))
+		if !strings.Contains(out, "## Conversation Channel") {
+			t.Errorf("channel=%s: direct chat still needs the channel block — it names the platform", channelType)
+		}
+		if !strings.Contains(out, "only the person you are replying to") {
+			t.Errorf("channel=%s: direct brief must say the reply reaches one person\n---\n%s", channelType, out)
+		}
+		if strings.Contains(out, "everyone in the room") {
+			t.Errorf("channel=%s: direct brief must not describe a shared room", channelType)
+		}
+	}
+}
+
+// Degradation, two steps. No channel at all (web chat) renders nothing. A
+// channel with no known room shape — an older server sends chat_channel_type
+// but no chat_type — names the platform and asserts no audience: guessing
+// "direct" is the wrong-picture failure this block exists to end.
+func TestBriefConversationChannel_DegradesWhenFactsAreMissing(t *testing.T) {
+	t.Parallel()
+
+	web := buildMetaSkillContent("claude", chatCtx("", ""))
+	if strings.Contains(web, "## Conversation Channel") {
+		t.Errorf("a web chat has no channel facts and must render no channel block\n---\n%s", web)
+	}
+
+	shapeless := buildMetaSkillContent("claude", chatCtx(ChannelTypeFeishu, ""))
+	if !strings.Contains(shapeless, "## Conversation Channel") {
+		t.Error("a known channel with unknown room shape must still name the platform")
+	}
+	// Including the chat-mode line, which is read BEFORE this block and used to
+	// restate the claim the block had just declined to make.
+	for _, phrase := range []string{"everyone in the room", "only the person you are replying to", "messaging you directly"} {
+		if strings.Contains(shapeless, phrase) {
+			t.Errorf("unknown room shape must claim no audience, found %q\n---\n%s", phrase, shapeless)
+		}
+	}
+}
+
+// The brief opens with the chat-mode line and only later reaches `##
+// Conversation Channel`. Whatever the second says about the audience, the
+// first must not have already contradicted it — it is what the agent reads
+// first, so a wrong claim there survives a correct one below.
+func TestBriefChatModeLineAgreesWithTheChannelBlock(t *testing.T) {
+	t.Parallel()
+
+	cases := map[string]struct {
+		ctx      TaskContextForEnv
+		mustNot  []string
+		mustHave string
+	}{
+		"group room": {
+			ctx:      chatCtx(ChannelTypeFeishu, ChatTypeGroup),
+			mustNot:  []string{"messaging you directly"},
+			mustHave: "one participant in a group conversation",
+		},
+		"known 1:1": {
+			ctx:      chatCtx(ChannelTypeSlack, ChatTypeP2P),
+			mustHave: "messaging you directly",
+		},
+		// The case the two-step degradation is for: a daemon claiming from a
+		// server that does not send chat_type yet, or a binding deleted between
+		// enqueue and claim. Neither privacy nor an audience may be asserted.
+		"channel with no reported shape": {
+			ctx:     chatCtx(ChannelTypeWecom, ""),
+			mustNot: []string{"messaging you directly", "everyone in the room"},
+		},
+		// A web chat has no binding row by construction, so absent shape here
+		// really does mean one reader. It keeps the original wording.
+		"web chat": {
+			ctx:      chatCtx("", ""),
+			mustHave: "messaging you directly",
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			out := buildMetaSkillContent("claude", tc.ctx)
+			for _, phrase := range tc.mustNot {
+				if strings.Contains(out, phrase) {
+					t.Errorf("%s: brief must not say %q\n---\n%s", name, phrase, out)
+				}
+			}
+			if tc.mustHave != "" && !strings.Contains(out, tc.mustHave) {
+				t.Errorf("%s: brief should say %q\n---\n%s", name, tc.mustHave, out)
+			}
+		})
+	}
+}
+
+func TestBriefConversationChannel_ChatKindOnly(t *testing.T) {
+	t.Parallel()
+
+	// Every non-chat kind, each carrying channel fields it has no business
+	// rendering — the kind gate, not the data, is what must hold.
+	others := map[string]TaskContextForEnv{
+		"comment":     {IssueID: "i-1", TriggerCommentID: "tc-1", ChatChannelType: ChannelTypeFeishu, ChatType: ChatTypeGroup},
+		"assignment":  {IssueID: "i-1", ChatChannelType: ChannelTypeFeishu, ChatType: ChatTypeGroup},
+		"autopilot":   {AutopilotRunID: "r-1", ChatChannelType: ChannelTypeFeishu, ChatType: ChatTypeGroup},
+		"quickcreate": {QuickCreatePrompt: "p", ChatChannelType: ChannelTypeFeishu, ChatType: ChatTypeGroup},
+	}
+	for name, ctx := range others {
+		ctx.AgentID, ctx.AgentName = "eve-1", "Eve"
+		if out := buildMetaSkillContent("claude", ctx); strings.Contains(out, "## Conversation Channel") {
+			t.Errorf("kind=%s: the channel block is chat-only", name)
+		}
+	}
+}
+
+// The block reports the room; it does not police what is said in it. An
+// operator writes that policy in agent instructions, and a rule baked in here
+// would fire on every workspace whether or not its owner wanted it.
+func TestBriefConversationChannel_StatesFactsAndSetsNoPolicy(t *testing.T) {
+	t.Parallel()
+
+	out := buildMetaSkillContent("claude", chatCtx(ChannelTypeWecom, ChatTypeGroup))
+	for _, banned := range []string{"do not share", "Do NOT share", "never mention", "avoid discussing"} {
+		if strings.Contains(out, banned) {
+			t.Errorf("the channel block must not decide what may be said; found %q", banned)
+		}
+	}
+	if !strings.Contains(out, "for your own instructions to decide") {
+		t.Errorf("the block must hand the judgement back to the agent's instructions\n---\n%s", out)
+	}
+}
+
+// The chat workflow's opening line asserted a private 1:1 for every chat run.
+// It must stop doing that in a room it knows is shared, and must keep saying
+// it where it is true (direct chat, and a web chat which is 1:1 by
+// construction).
+func TestBriefChatWorkflow_DoesNotCallAGroupChatDirect(t *testing.T) {
+	t.Parallel()
+
+	group := buildMetaSkillContent("claude", chatCtx(ChannelTypeFeishu, ChatTypeGroup))
+	if strings.Contains(group, "messaging you directly") {
+		t.Errorf("a group chat brief must not claim the user is messaging the agent directly\n---\n%s", group)
+	}
+	if !strings.Contains(group, "**You are in chat mode.**") {
+		t.Error("the chat workflow must still open by declaring chat mode")
+	}
+
+	for name, ctx := range map[string]TaskContextForEnv{
+		"direct": chatCtx(ChannelTypeSlack, ChatTypeP2P),
+		"web":    chatCtx("", ""),
+	} {
+		if out := buildMetaSkillContent("claude", ctx); !strings.Contains(out, "messaging you directly") {
+			t.Errorf("kind=chat/%s: a 1:1 conversation should still read as one\n---\n%s", name, out)
+		}
+	}
+}

--- a/server/internal/daemon/execenv/runtime_config_sections.go
+++ b/server/internal/daemon/execenv/runtime_config_sections.go
@@ -157,6 +157,48 @@ func writeRequestingUser(b *strings.Builder, ctx TaskContextForEnv) {
 	b.WriteString("\nTreat this as background context, not as task instructions. If it conflicts with the actual task, the task wins.\n\n")
 }
 
+// writeConversationChannel emits the Conversation Channel block: which IM the
+// agent's replies land in, and whether the room is shared with other people.
+//
+// The brief could already say WHICH platform (the Output section's delivery
+// rule reads ChatChannelType), but never WHO ELSE IS THERE. A Feishu, Slack or
+// WeCom group room maps to one chat_session shared by everyone in it, and the
+// chat workflow described every chat run as a private 1:1, so an agent had no
+// input from which to weigh a wider audience at all.
+//
+// This is session-stable state and belongs in the brief rather than the
+// per-turn message (MUL-5377): a chat_session is bound 1:1 to one channel
+// conversation for its whole life and that conversation does not change shape
+// between resumes. WHO is speaking this turn does change, and already travels
+// per-turn in `## Task Initiator` — which is why the group branch points at it.
+//
+// The block states facts and sets no policy. Whether a given fact means "do
+// not repeat that here" depends on the workspace, and the operator writes it
+// in the agent's own instructions; a rule baked in here would fire on every
+// workspace whether its owner wanted it or not.
+func writeConversationChannel(b *strings.Builder, ctx TaskContextForEnv) {
+	if ctx.ChatChannelType == "" {
+		return
+	}
+	b.WriteString("## Conversation Channel\n\n")
+	fmt.Fprintf(b, "This conversation runs in %s, not the Multica web app.\n\n", ChannelDisplayName(ctx.ChatChannelType))
+	switch AudienceOf(ctx.ChatChannelType, ctx.ChatType) {
+	case ChatAudienceGroup:
+		b.WriteString("**Group chat: everyone in the room receives every reply you send.** That includes people who did not write the message you are answering. Multica does not hand you the room's member list, so the audience may be wider than the names you have seen. Nothing you send here is private to the person asking.\n\n")
+		b.WriteString("Who is asking also changes from message to message: this turn's `## Task Initiator` names them. `## Requesting User` does not — that is the person whose credentials you run with, and they need not be in this room at all.\n\n")
+	case ChatAudienceDirect:
+		b.WriteString("**Direct one-to-one chat: only the person you are replying to receives what you send.**\n\n")
+	default:
+		// Channel known, room shape not — a server predating chat_type on the
+		// claim, or a binding deleted between enqueue and claim. Name the
+		// platform and stop: assuming "direct" is exactly the wrong picture
+		// this section exists to correct. writeWorkflowChat and buildChatPrompt
+		// read the same AudienceOf, so neither puts the claim back later.
+		return
+	}
+	b.WriteString("Treat that as a fact about who can read your output. What may be said in front of that audience is for your own instructions to decide.\n\n")
+}
+
 // BuildTaskInitiatorBlock renders the Task Initiator block for the per-turn
 // user message. Both MUL-2645 test-pinned phrases ("apply any per-person
 // privacy or access rules" and "credentials stay scoped to the runtime
@@ -412,8 +454,27 @@ func writeWorkflowHeader(b *strings.Builder) {
 // post-completion suggestion pass (chat_suggest.go), because an optional
 // formatting instruction in this brief proved unreliable across providers and
 // long conversations.
-func writeWorkflowChat(b *strings.Builder) {
-	b.WriteString("**You are in chat mode.** A user is messaging you directly in a chat window.\n\n")
+//
+// The opening line used to assert "A user is messaging you directly" for every
+// chat run. On a channel group session that is false — one chat_session serves
+// a whole room — and it is the first thing the agent reads, so it overrode any
+// later hint that other people are present. It now only claims a private 1:1
+// where the server says there is one; a web chat reports no room shape and is
+// 1:1 by construction, so it keeps the original wording. The audience detail
+// stays in `## Conversation Channel` (writeConversationChannel) rather than
+// being restated here.
+func writeWorkflowChat(b *strings.Builder, ctx TaskContextForEnv) {
+	switch AudienceOf(ctx.ChatChannelType, ctx.ChatType) {
+	case ChatAudienceGroup:
+		b.WriteString("**You are in chat mode.** You are one participant in a group conversation, answering a message addressed to you.\n\n")
+	case ChatAudienceUnknown:
+		// `## Conversation Channel` has just declined to say who is present,
+		// on purpose. Restating "messaging you directly" here would put the
+		// claim back two sections later, and this line is read first.
+		b.WriteString("**You are in chat mode.** You are answering a message in a chat conversation.\n\n")
+	default:
+		b.WriteString("**You are in chat mode.** A user is messaging you directly in a chat window.\n\n")
+	}
 	b.WriteString("- Respond conversationally and helpfully to the user's message\n")
 	b.WriteString("- You have full access to the `multica` CLI to look up issues, workspace info, members, agents, etc.\n")
 	b.WriteString("- If asked about issues, use `multica issue list --output json` or `multica issue get <id> --output json`\n")
@@ -707,6 +768,7 @@ func writeOutput(b *strings.Builder, kind taskKind, ctx TaskContextForEnv) {
 //
 //	Section               | comment | assign | autopilot | quick_create | chat
 //	----------------------+---------+--------+-----------+--------------+------
+//	Conversation Channel  |    —    |   —    |     —     |      —       |  △
 //	Available Commands    |   full  |  full  |   full    |   minimal    | full
 //	Issue Body Formatting |    ✓    |   ✓    |     ✓     |      ✓       |  ✓
 //	Comment Formatting    |    ✓    |   ✓    |     —     |      —       |  —
@@ -735,6 +797,13 @@ func buildMetaSkillContentSlim(provider string, ctx TaskContextForEnv) string {
 	writeBackgroundTaskSafetySlim(&b)
 	writeAgentIdentity(&b, ctx)
 	writeRequestingUser(&b, ctx)
+	// Sits next to Requesting User because it answers the same question from
+	// the other side: that section says who the agent acts FOR, this one says
+	// who can READ the answer. Chat-only — no other kind has a conversation
+	// to describe — and it elides itself when the claim carried no channel.
+	if kind == kindChat {
+		writeConversationChannel(&b, ctx)
+	}
 	writeWorkspaceContext(&b, ctx)
 
 	switch kind {
@@ -766,7 +835,7 @@ func buildMetaSkillContentSlim(provider string, ctx TaskContextForEnv) string {
 	writeWorkflowHeader(&b)
 	switch kind {
 	case kindChat:
-		writeWorkflowChat(&b)
+		writeWorkflowChat(&b, ctx)
 	case kindQuickCreate:
 		writeWorkflowQuickCreate(&b)
 	case kindAutopilotRunOnly:

--- a/server/internal/daemon/prompt.go
+++ b/server/internal/daemon/prompt.go
@@ -422,7 +422,23 @@ func buildChatPrompt(task Task) string {
 
 	var b strings.Builder
 	b.WriteString("You are running as a chat assistant for a Multica workspace.\n")
-	b.WriteString("A user is chatting with you directly. Respond to their message.\n\n")
+	// "directly" is only true of a 1:1. A channel group room maps to ONE
+	// chat_session shared by everyone in it, so on a group turn this line used
+	// to assert a private conversation that does not exist — and it is the
+	// second thing the agent reads. The room's shape and who else can read the
+	// reply are stated once, in the brief's `## Conversation Channel`; this
+	// line only has to stop contradicting it. A web chat reports no shape and
+	// is 1:1 by construction, so it keeps the original wording; a channel whose
+	// shape did not arrive is not the same case and claims no audience at all
+	// (AudienceOf).
+	switch execenv.AudienceOf(task.ChatChannelType, task.ChatType) {
+	case execenv.ChatAudienceGroup:
+		b.WriteString("You are in a group conversation and someone has addressed you. Respond to their message.\n\n")
+	case execenv.ChatAudienceUnknown:
+		b.WriteString("Someone has addressed you in a chat conversation. Respond to their message.\n\n")
+	default:
+		b.WriteString("A user is chatting with you directly. Respond to their message.\n\n")
+	}
 	// Channel awareness (MUL-3871). When the session is backed by an IM channel,
 	// the agent must KNOW it is operating inside that channel — otherwise an ask
 	// like "what did you just talk about" sends it to read Multica instead of the

--- a/server/internal/daemon/prompt_test.go
+++ b/server/internal/daemon/prompt_test.go
@@ -489,6 +489,55 @@ func TestBuildChatPromptFeishuIgnoresChatInThread(t *testing.T) {
 	}
 }
 
+// The per-turn chat prompt's opening line said "A user is chatting with you
+// directly" for every chat run, the same claim the runtime brief made. In a
+// Feishu / Slack / WeCom group room one chat_session serves everyone in it, so
+// on a group turn the prompt asserted a private 1:1 that does not exist.
+func TestBuildChatPromptGroupTurnIsNotCalledDirect(t *testing.T) {
+	for _, channelType := range []string{execenv.ChannelTypeSlack, execenv.ChannelTypeFeishu, execenv.ChannelTypeWecom} {
+		out := buildChatPrompt(Task{
+			ChatSessionID:   "sess-1",
+			ChatChannelType: channelType,
+			ChatType:        execenv.ChatTypeGroup,
+			ChatMessage:     "hi",
+		})
+		if strings.Contains(out, "chatting with you directly") {
+			t.Errorf("channel=%s: a group turn must not be framed as a direct chat\n--- output ---\n%s", channelType, out)
+		}
+		if !strings.Contains(out, "Respond to their message") {
+			t.Errorf("channel=%s: the prompt must still say what to do this turn", channelType)
+		}
+	}
+
+	// A 1:1 — and a web chat, which reports no room shape and is 1:1 by
+	// construction — keeps the original framing.
+	for name, task := range map[string]Task{
+		"direct": {ChatSessionID: "s", ChatChannelType: execenv.ChannelTypeFeishu, ChatType: execenv.ChatTypeP2P, ChatMessage: "hi"},
+		"web":    {ChatSessionID: "s", ChatMessage: "hi"},
+	} {
+		if out := buildChatPrompt(task); !strings.Contains(out, "chatting with you directly") {
+			t.Errorf("%s: a 1:1 conversation should still read as one\n--- output ---\n%s", name, out)
+		}
+	}
+
+	// A channel whose room shape did not arrive is neither of the two above:
+	// the brief has just declined to name an audience for it, and this line
+	// must not put the claim back. Reachable whenever the daemon is newer than
+	// the server it claims from, or the binding was deleted between enqueue and
+	// claim.
+	shapeless := buildChatPrompt(Task{
+		ChatSessionID:   "s",
+		ChatChannelType: execenv.ChannelTypeWecom,
+		ChatMessage:     "hi",
+	})
+	if strings.Contains(shapeless, "chatting with you directly") {
+		t.Errorf("an unreported room shape must not be framed as a direct chat\n--- output ---\n%s", shapeless)
+	}
+	if !strings.Contains(shapeless, "Respond to their message") {
+		t.Errorf("the prompt must still say what to do this turn\n--- output ---\n%s", shapeless)
+	}
+}
+
 func TestBuildChatPromptAgentIntro(t *testing.T) {
 	// The proactive self-introduction chat (MUL-4230) has no user message: the
 	// prompt must tell the agent to open the conversation itself, and must NOT

--- a/server/internal/daemon/types.go
+++ b/server/internal/daemon/types.go
@@ -90,6 +90,7 @@ type Task struct {
 	NewCommentsSince              string                 `json:"new_comments_since,omitempty"`               // RFC3339 anchor (last run's started_at) the count is measured from; empty on cold start
 	ChatSessionID                 string                 `json:"chat_session_id,omitempty"`                  // non-empty for chat tasks
 	ChatChannelType               string                 `json:"chat_channel_type,omitempty"`                // "slack" when the chat session is backed by an IM channel; empty for a web-only chat. Drives the channel-awareness block in the prompt
+	ChatType                      string                 `json:"chat_type,omitempty"`                        // "group" when the channel conversation is a shared room, "p2p" for a 1:1 with the bot. Empty for a web chat or an old server; the brief's `## Conversation Channel` block then claims no audience rather than guessing 1:1
 	ChatInThread                  bool                   `json:"chat_in_thread,omitempty"`                   // true when the latest @mention was a thread reply; selects which read command the prompt tells the agent to start with
 	ChatMessage                   string                 `json:"chat_message,omitempty"`                     // user message content for chat tasks
 	ChatMessageAttachments        []ChatAttachmentMeta   `json:"chat_message_attachments,omitempty"`         // attachments linked to the chat message; agent uses these to `multica attachment download <id>`

--- a/server/internal/handler/agent.go
+++ b/server/internal/handler/agent.go
@@ -346,6 +346,7 @@ type AgentTaskResponse struct {
 	NewCommentsSince         string                 `json:"new_comments_since,omitempty"`          // RFC3339 anchor (last run's started_at) the count is measured from; omitempty so old daemons ignore it
 	ChatSessionID            string                 `json:"chat_session_id,omitempty"`             // non-empty for chat tasks
 	ChatChannelType          string                 `json:"chat_channel_type,omitempty"`           // "slack" when the chat session is backed by an IM channel; empty for a web-only chat. Makes the agent channel-aware (read history from the channel, not Multica)
+	ChatType                 string                 `json:"chat_type,omitempty"`                   // channel_chat_session_binding.chat_type — "group" for a shared room, "p2p" for a 1:1 with the bot. Lets the brief tell the agent who else can read its replies; empty for a web-only chat
 	ChatInThread             bool                   `json:"chat_in_thread,omitempty"`              // true when the latest @mention was a thread reply; tells the agent to start with `multica chat thread` vs `multica chat history`
 	ChatMessage              string                 `json:"chat_message,omitempty"`                // user message for chat tasks
 	ChatMessageAttachments   []ChatAttachmentMeta   `json:"chat_message_attachments,omitempty"`    // attachments on the user message — agent calls `multica attachment download <id>` per entry

--- a/server/internal/handler/daemon.go
+++ b/server/internal/handler/daemon.go
@@ -2137,8 +2137,17 @@ func (h *Handler) buildClaimedTaskResponse(r *http.Request, task *db.AgentTaskQu
 			// endpoints are hardwired to h.SlackHistory (chat_history.go) — there
 			// is no history reader on any other channel, so the flag has nothing
 			// to select between there and must not imply one exists.
+			//
+			// chat_type rides along on the same row. It is what lets the
+			// runtime brief tell the agent whether this chat_session is a room
+			// shared by many people or a 1:1 with the bot; the brief used to
+			// describe every chat run as a private 1:1 whatever the room. The
+			// shared session service writes the column for every channel
+			// (channel/engine/session.go), so no channel needs naming here
+			// either.
 			if binding, berr := h.Queries.GetChannelChatSessionBindingBySessionAny(r.Context(), cs.ID); berr == nil {
 				resp.ChatChannelType = binding.ChannelType
+				resp.ChatType = binding.ChatType
 				if binding.ChannelType == string(slack.TypeSlack) {
 					// The latest trigger was a thread reply iff its reply-target
 					// thread (last_thread_id) differs from its own message id (a

--- a/server/internal/handler/daemon_claim_channel_type_test.go
+++ b/server/internal/handler/daemon_claim_channel_type_test.go
@@ -23,12 +23,20 @@ import (
 // hardwired to h.SlackHistory (chat_history.go). There is no Feishu reader, so
 // the flag has nothing to select between and must not imply one exists.
 
-// seedChannelBinding binds sessionID to an IM channel of channelType, creating
-// the installation the binding requires. This is the row shape both the Slack
-// binder (slack/binding.go) and the Feishu store (lark/channel_store.go) write —
-// identical but for channel_type, which is exactly why the claim lookup must not
-// hardcode one value.
+// seedChannelBinding binds sessionID to a group room on an IM channel of
+// channelType, creating the installation the binding requires. This is the row
+// shape both the Slack binder (slack/binding.go) and the Feishu store
+// (lark/channel_store.go) write — identical but for channel_type, which is
+// exactly why the claim lookup must not hardcode one value.
 func seedChannelBinding(t *testing.T, ctx context.Context, agentID, sessionID, channelType, lastMessageID, lastThreadID string) {
+	t.Helper()
+	seedChannelBindingOfChatType(t, ctx, agentID, sessionID, channelType, "group", lastMessageID, lastThreadID)
+}
+
+// seedChannelBindingOfChatType is seedChannelBinding with the room shape
+// (p2p / group) chosen by the caller — the column the claim must report so the
+// runtime brief can tell the agent whether anyone else is reading.
+func seedChannelBindingOfChatType(t *testing.T, ctx context.Context, agentID, sessionID, channelType, chatType, lastMessageID, lastThreadID string) {
 	t.Helper()
 	var installationID string
 	if err := testPool.QueryRow(ctx, `
@@ -41,8 +49,8 @@ func seedChannelBinding(t *testing.T, ctx context.Context, agentID, sessionID, c
 	if _, err := testPool.Exec(ctx, `
 		INSERT INTO channel_chat_session_binding
 			(chat_session_id, installation_id, channel_type, channel_chat_id, chat_type, last_message_id, last_thread_id)
-		VALUES ($1, $2, $3, $4, 'group', $5, $6)
-	`, sessionID, installationID, channelType, "C-TEST-"+channelType, lastMessageID, lastThreadID); err != nil {
+		VALUES ($1, $2, $3, $4, $5, $6, $7)
+	`, sessionID, installationID, channelType, "C-TEST-"+channelType, chatType, lastMessageID, lastThreadID); err != nil {
 		t.Fatalf("seed %s binding: %v", channelType, err)
 	}
 	t.Cleanup(func() {
@@ -51,9 +59,16 @@ func seedChannelBinding(t *testing.T, ctx context.Context, agentID, sessionID, c
 	})
 }
 
+// claimedChatChannel is the channel-awareness slice of a claim response.
+type claimedChatChannel struct {
+	ChannelType string `json:"chat_channel_type"`
+	ChatType    string `json:"chat_type"`
+	InThread    bool   `json:"chat_in_thread"`
+}
+
 // claimChatChannelFields claims the queued task for runtimeID and returns the
 // channel-awareness fields the daemon reads off the claim response.
-func claimChatChannelFields(t *testing.T, runtimeID string) (channelType string, inThread bool) {
+func claimChatChannelFields(t *testing.T, runtimeID string) claimedChatChannel {
 	t.Helper()
 	w := httptest.NewRecorder()
 	req := newDaemonTokenRequest("POST", "/api/daemon/runtimes/"+runtimeID+"/tasks/claim", nil,
@@ -65,10 +80,7 @@ func claimChatChannelFields(t *testing.T, runtimeID string) (channelType string,
 		t.Fatalf("ClaimTaskByRuntime: expected 200, got %d: %s", w.Code, w.Body.String())
 	}
 	var resp struct {
-		Task *struct {
-			ChatChannelType string `json:"chat_channel_type"`
-			ChatInThread    bool   `json:"chat_in_thread"`
-		} `json:"task"`
+		Task *claimedChatChannel `json:"task"`
 	}
 	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
 		t.Fatalf("decode claim response: %v", err)
@@ -76,7 +88,7 @@ func claimChatChannelFields(t *testing.T, runtimeID string) (channelType string,
 	if resp.Task == nil {
 		t.Fatal("expected a claimed task")
 	}
-	return resp.Task.ChatChannelType, resp.Task.ChatInThread
+	return *resp.Task
 }
 
 func TestClaim_FeishuBoundSessionReportsChannelType(t *testing.T) {
@@ -91,11 +103,11 @@ func TestClaim_FeishuBoundSessionReportsChannelType(t *testing.T) {
 	insertChannelChatTask(t, ctx, agentID, runtimeID, sessionID)
 	requeueTaskForClaim(t, ctx, sessionID)
 
-	channelType, inThread := claimChatChannelFields(t, runtimeID)
-	if channelType != "feishu" {
-		t.Errorf("chat_channel_type = %q, want %q — a Feishu session must not look like a web chat", channelType, "feishu")
+	claimed := claimChatChannelFields(t, runtimeID)
+	if claimed.ChannelType != "feishu" {
+		t.Errorf("chat_channel_type = %q, want %q — a Feishu session must not look like a web chat", claimed.ChannelType, "feishu")
 	}
-	if inThread {
+	if claimed.InThread {
 		t.Error("chat_in_thread must stay false on Feishu: it selects between two Slack-only read commands")
 	}
 }
@@ -110,11 +122,11 @@ func TestClaim_SlackBoundSessionStillReportsThreadState(t *testing.T) {
 	insertChannelChatTask(t, ctx, agentID, runtimeID, sessionID)
 	requeueTaskForClaim(t, ctx, sessionID)
 
-	channelType, inThread := claimChatChannelFields(t, runtimeID)
-	if channelType != "slack" {
-		t.Errorf("chat_channel_type = %q, want %q", channelType, "slack")
+	claimed := claimChatChannelFields(t, runtimeID)
+	if claimed.ChannelType != "slack" {
+		t.Errorf("chat_channel_type = %q, want %q", claimed.ChannelType, "slack")
 	}
-	if !inThread {
+	if !claimed.InThread {
 		t.Error("chat_in_thread should be true when last_thread_id differs from last_message_id")
 	}
 }
@@ -138,11 +150,11 @@ func TestClaim_UnlistedChannelBoundSessionReportsChannelType(t *testing.T) {
 	insertChannelChatTask(t, ctx, agentID, runtimeID, sessionID)
 	requeueTaskForClaim(t, ctx, sessionID)
 
-	channelType, inThread := claimChatChannelFields(t, runtimeID)
-	if channelType != "wecom" {
-		t.Errorf("chat_channel_type = %q, want %q — a channel the handler does not name must not look like a web chat", channelType, "wecom")
+	claimed := claimChatChannelFields(t, runtimeID)
+	if claimed.ChannelType != "wecom" {
+		t.Errorf("chat_channel_type = %q, want %q — a channel the handler does not name must not look like a web chat", claimed.ChannelType, "wecom")
 	}
-	if inThread {
+	if claimed.InThread {
 		t.Error("chat_in_thread must stay false off Slack: it selects between two Slack-only read commands")
 	}
 }
@@ -156,12 +168,70 @@ func TestClaim_UnboundSessionReportsNoChannelType(t *testing.T) {
 	insertChannelChatTask(t, ctx, agentID, runtimeID, sessionID)
 	requeueTaskForClaim(t, ctx, sessionID)
 
-	channelType, inThread := claimChatChannelFields(t, runtimeID)
-	if channelType != "" {
-		t.Errorf("chat_channel_type = %q, want empty for a web-only session", channelType)
+	claimed := claimChatChannelFields(t, runtimeID)
+	if claimed.ChannelType != "" {
+		t.Errorf("chat_channel_type = %q, want empty for a web-only session", claimed.ChannelType)
 	}
-	if inThread {
+	if claimed.InThread {
 		t.Error("chat_in_thread must be false for a web-only session")
+	}
+}
+
+// The room shape rides the same binding row as the channel type and must reach
+// the daemon with it. Without it the runtime brief has no way to know that one
+// chat_session is a room shared by many people, and it described every chat run
+// as a private 1:1 — the agent then had no input from which to weigh a wider
+// audience. Asserted per channel because the column is written by the shared
+// session service for all of them (channel/engine/session.go).
+func TestClaim_BoundSessionReportsRoomShape(t *testing.T) {
+	if testHandler == nil {
+		t.Skip("database not available")
+	}
+	ctx := context.Background()
+
+	for _, tc := range []struct {
+		channelType string
+		chatType    string
+	}{
+		{"slack", "group"},
+		{"slack", "p2p"},
+		{"feishu", "group"},
+		{"feishu", "p2p"},
+		{"wecom", "group"},
+		{"wecom", "p2p"},
+	} {
+		name := tc.channelType + "/" + tc.chatType
+		t.Run(name, func(t *testing.T) {
+			agentID, sessionID, runtimeID, _ := setupDirectChatSession(t, ctx, name+" chat")
+			seedChannelBindingOfChatType(t, ctx, agentID, sessionID, tc.channelType, tc.chatType, "msg-1", "msg-1")
+			insertChannelChatTask(t, ctx, agentID, runtimeID, sessionID)
+			requeueTaskForClaim(t, ctx, sessionID)
+
+			claimed := claimChatChannelFields(t, runtimeID)
+			if claimed.ChannelType != tc.channelType {
+				t.Errorf("chat_channel_type = %q, want %q", claimed.ChannelType, tc.channelType)
+			}
+			if claimed.ChatType != tc.chatType {
+				t.Errorf("chat_type = %q, want %q — the brief cannot describe a room it is not told about", claimed.ChatType, tc.chatType)
+			}
+		})
+	}
+}
+
+// A web chat has no binding row, so there is no room shape to report. It must
+// come back empty rather than defaulting to "p2p": the brief treats an unknown
+// shape as "claim no audience", and a guessed default would defeat that.
+func TestClaim_UnboundSessionReportsNoRoomShape(t *testing.T) {
+	if testHandler == nil {
+		t.Skip("database not available")
+	}
+	ctx := context.Background()
+	agentID, sessionID, runtimeID, _ := setupDirectChatSession(t, ctx, "web chat shape")
+	insertChannelChatTask(t, ctx, agentID, runtimeID, sessionID)
+	requeueTaskForClaim(t, ctx, sessionID)
+
+	if claimed := claimChatChannelFields(t, runtimeID); claimed.ChatType != "" {
+		t.Errorf("chat_type = %q, want empty for a web-only session", claimed.ChatType)
 	}
 }
 


### PR DESCRIPTION
The runtime brief opens every chat run with "A user is messaging you directly in a chat window", and `buildChatPrompt` repeats it on line two. On Feishu, Slack and whatever channel comes next, a group room maps to ONE `chat_session` shared by everyone in it — so on a group turn both lines assert a private conversation that does not exist. Nothing else in the run says otherwise, so an operator who wants "don't repeat customer detail in a shared room" has no fact to write the rule against: the agent cannot tell the two cases apart.

The fact is already durable, and already on the row this claim reads. Every adapter writes the room shape to `channel_chat_session_binding.chat_type` through the shared session service, and #6330 taught the claim handler to read that row by session id. This carries one more column off it:

```go
if binding, berr := h.Queries.GetChannelChatSessionBindingBySessionAny(r.Context(), cs.ID); berr == nil {
    resp.ChatChannelType = binding.ChannelType
    resp.ChatType = binding.ChatType
```

No migration, no new query, no channel named in the handler.

The new `## Conversation Channel` section sits beside `## Requesting User` — that one says who the agent acts for, this one says who can read the answer. In a group it points at `## Task Initiator` for the asker, because in a shared room the asker changes per message and is not the runtime owner named above it.

It states facts and sets no policy. What may be said in front of a given audience varies by workspace and belongs in the operator's own agent instructions; a rule baked in here would fire on workspaces that never asked for it.

**Session-stable, so it lives in the brief** rather than the per-turn message (MUL-5377): a `chat_session` is bound to one conversation for its whole life and that conversation does not change shape between resumes. Who is speaking does change, and already travels per-turn in `## Task Initiator`.

**Degradation is two-step.** No channel at all — a web chat — renders nothing, and `buildChatPrompt` keeps its original wording, since a web chat is 1:1 by construction. A known channel whose shape the server did not report renders the platform and asserts no audience: defaulting to "direct" is exactly the wrong picture this section exists to correct.

One thing to call out: this adds `ChannelTypeWecom` and a `"WeCom"` display name — note 1 from your #6330 review. Two lines, touching nothing else, but if you'd rather it rode with the adapter I'll drop it from here.

`go build ./...`, `go vet ./...` and `gofmt` are clean; `internal/daemon/...`, `internal/handler` and `internal/integrations/channel/...` are green. Tests cover both room shapes, the unreported-shape fallback, the no-channel case, and the prompt's group/direct branch.

cc @Bohan-J
