### PR TITLE
test(core): cover label query failure paths

### DIFF
--- a/packages/core/labels/queries.test.ts
+++ b/packages/core/labels/queries.test.ts
@@ -1,0 +1,126 @@
+import { QueryClient } from "@tanstack/react-query";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { setApiInstance } from "../api";
+import type { ApiClient } from "../api/client";
+import type { IssueLabelsResponse, Label, ListLabelsResponse } from "../types";
+import {
+  issueLabelsOptions,
+  labelKeys,
+  labelListOptions,
+  resourceLabelsOptions,
+} from "./queries";
+
+const WS_ID = "ws-1";
+const ISSUE_ID = "issue-1";
+
+const label: Label = {
+  id: "label-1",
+  workspace_id: WS_ID,
+  name: "bug",
+  color: "#ef4444",
+  created_at: "2026-01-01T00:00:00Z",
+  updated_at: "2026-01-01T00:00:00Z",
+};
+
+describe("labelKeys", () => {
+  it("keeps list and resource caches scoped to their workspace and resource type", () => {
+    expect(labelKeys.list(WS_ID)).toEqual(["labels", WS_ID, "list", "issue"]);
+    expect(labelKeys.list(WS_ID, "skill")).toEqual([
+      "labels",
+      WS_ID,
+      "list",
+      "skill",
+    ]);
+    expect(labelKeys.byIssue(WS_ID, ISSUE_ID)).toEqual([
+      "labels",
+      WS_ID,
+      "issue",
+      ISSUE_ID,
+    ]);
+    expect(labelKeys.byResource(WS_ID, "agent", "agent-1")).toEqual([
+      "labels",
+      WS_ID,
+      "agent",
+      "agent-1",
+    ]);
+    expect(labelKeys.list("ws-2")).not.toEqual(labelKeys.list(WS_ID));
+  });
+});
+
+describe("label query options", () => {
+  let qc: QueryClient;
+
+  beforeEach(() => {
+    qc = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+  });
+
+  afterEach(() => {
+    qc.clear();
+    vi.restoreAllMocks();
+  });
+
+  it("fetches the label list and selects its labels", async () => {
+    const response: ListLabelsResponse = { labels: [label], total: 1 };
+    const listLabels = vi.fn().mockResolvedValue(response);
+    setApiInstance({ listLabels } as unknown as ApiClient);
+    const options = labelListOptions(WS_ID);
+
+    await expect(qc.fetchQuery(options)).resolves.toEqual(response);
+    expect(listLabels).toHaveBeenCalledWith("issue");
+    expect(options.select?.(response)).toEqual([label]);
+  });
+
+  it("forwards a non-default resource type to the label list request", async () => {
+    const response: ListLabelsResponse = { labels: [label], total: 1 };
+    const listLabels = vi.fn().mockResolvedValue(response);
+    setApiInstance({ listLabels } as unknown as ApiClient);
+
+    await qc.fetchQuery(labelListOptions(WS_ID, "skill"));
+
+    expect(listLabels).toHaveBeenCalledWith("skill");
+  });
+
+  it("propagates label list request failures without caching data", async () => {
+    const error = new Error("failed to list labels");
+    const listLabels = vi.fn().mockRejectedValue(error);
+    setApiInstance({ listLabels } as unknown as ApiClient);
+    const options = labelListOptions(WS_ID);
+
+    await expect(qc.fetchQuery(options)).rejects.toBe(error);
+    expect(qc.getQueryData(options.queryKey)).toBeUndefined();
+  });
+
+  it("fetches labels for the requested issue and selects its labels", async () => {
+    const response: IssueLabelsResponse = { labels: [label] };
+    const listLabelsForIssue = vi.fn().mockResolvedValue(response);
+    setApiInstance({ listLabelsForIssue } as unknown as ApiClient);
+    const options = issueLabelsOptions(WS_ID, ISSUE_ID);
+
+    await expect(qc.fetchQuery(options)).resolves.toEqual(response);
+    expect(listLabelsForIssue).toHaveBeenCalledWith(ISSUE_ID);
+    expect(options.select?.(response)).toEqual([label]);
+  });
+
+  it("disables issue label requests until an issue id exists", () => {
+    expect(issueLabelsOptions(WS_ID, "").enabled).toBe(false);
+    expect(issueLabelsOptions(WS_ID, ISSUE_ID).enabled).toBe(true);
+  });
+
+  it("disables generic resource requests until a resource id exists", () => {
+    expect(resourceLabelsOptions(WS_ID, "agent", "").enabled).toBe(false);
+    expect(resourceLabelsOptions(WS_ID, "agent", "agent-1").enabled).toBe(true);
+  });
+
+  it("propagates issue label request failures without caching data", async () => {
+    const error = new Error("failed to list issue labels");
+    const listLabelsForIssue = vi.fn().mockRejectedValue(error);
+    setApiInstance({ listLabelsForIssue } as unknown as ApiClient);
+    const options = issueLabelsOptions(WS_ID, ISSUE_ID);
+
+    await expect(qc.fetchQuery(options)).rejects.toBe(error);
+    expect(qc.getQueryData(options.queryKey)).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## What does this PR do?

Adds focused test coverage for `packages/core/labels/queries.ts`.

The tests verify scoped query keys, request parameter forwarding, query enablement, response selection, and error propagation without caching failed responses.

This is a test-only change with no production behavior changes.

## Related Issue

No related issue. This addresses an identified test coverage gap in `packages/core/labels/`.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Refactor / code improvement (no behavior change)
- [ ] Documentation update
- [x] Tests (adding or improving test coverage)
- [ ] CI / infrastructure

## Changes Made

- Added `packages/core/labels/queries.test.ts`.
- Covered workspace- and resource-scoped query keys.
- Verified resource types are forwarded to the API.
- Verified queries remain disabled until a resource ID exists.
- Verified response selection.
- Verified request errors propagate without caching successful data.

## How to Test

1. Run the focused test:

   ```bash
   pnpm --filter @multica/core exec vitest run labels/queries.test.ts
   ```

2. Run the core package type check:

   ```bash
   pnpm --filter @multica/core typecheck
   ```

3. Run ESLint:

   ```bash
   pnpm --filter @multica/core exec eslint labels/queries.test.ts
   ```

Expected result: all 8 tests pass, with no TypeScript or ESLint errors.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [ ] I have updated relevant documentation to reflect my changes
- [ ] If I added a new runtime / coding tool / UI tab, I synced the change to **landing copy** (`apps/web/features/landing/i18n/`) and **relevant docs** (`apps/docs/content/docs/`)
- [ ] If this PR touches Chinese product copy, I checked it against `apps/docs/content/docs/developers/conventions.zh.mdx`
- [x] I have considered and documented any risks above
- [x] I will address all reviewer comments before requesting merge

### Thinking Path and Risks

The labels query module had no dedicated query tests, while label mutation behavior already had focused coverage. I limited the contribution to the missing query layer and followed existing `packages/core` testing patterns using a real `QueryClient` with a fake API instance.

The risk is minimal because this PR changes only tests.

## AI Disclosure

**AI tool used:** Cursor

**Prompt / approach:**

I asked Cursor to identify a small test coverage gap in `packages/core/labels/` and add pure query logic and request failure-path tests. The changes were reviewed against the current label query API and verified with focused Vitest, TypeScript, and ESLint checks.

## Screenshots (optional)

Not applicable. This PR does not affect the UI.