### PR TITLE
test(views): cover project detail deletion flow

### DIFF
--- a/packages/views/projects/components/project-detail.test.tsx
+++ b/packages/views/projects/components/project-detail.test.tsx
@@ -1,0 +1,332 @@
+import React from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import type { Project } from "@multica/core/types";
+import { renderWithI18n } from "../../test/i18n";
+import { NavigationProvider, type NavigationAdapter } from "../../navigation";
+import { ProjectDetail } from "./project-detail";
+
+const mocks = vi.hoisted(() => ({
+  role: "admin",
+  deleteProject: vi.fn(),
+  push: vi.fn(),
+  recordVisit: vi.fn(),
+  toastSuccess: vi.fn(),
+}));
+
+vi.mock("@tanstack/react-query", () => ({
+  useQuery: (options: { queryKey?: readonly unknown[] }) => {
+    switch (options.queryKey?.[0]) {
+      case "project-detail":
+        return { data: PROJECT, isLoading: false };
+      case "members":
+        return {
+          data: [{ user_id: "user-1", name: "User One", role: mocks.role }],
+          isLoading: false,
+        };
+      case "agents":
+      case "pins":
+        return { data: [], isLoading: false };
+      default:
+        return { data: undefined, isLoading: false };
+    }
+  },
+}));
+
+vi.mock("@multica/core/projects/queries", () => ({
+  projectDetailOptions: () => ({ queryKey: ["project-detail"] }),
+}));
+
+vi.mock("@multica/core/projects/mutations", () => ({
+  useUpdateProject: () => ({ mutate: vi.fn() }),
+  useDeleteProject: () => ({ mutate: mocks.deleteProject }),
+}));
+
+vi.mock("@multica/core/pins", () => ({
+  pinListOptions: () => ({ queryKey: ["pins"] }),
+  useCreatePin: () => ({ mutate: vi.fn() }),
+  useDeletePin: () => ({ mutate: vi.fn() }),
+}));
+
+vi.mock("@multica/core/workspace/queries", () => ({
+  memberListOptions: () => ({ queryKey: ["members"] }),
+  agentListOptions: () => ({ queryKey: ["agents"] }),
+}));
+
+vi.mock("@multica/core/hooks", () => ({
+  useWorkspaceId: () => "workspace-1",
+}));
+
+vi.mock("@multica/core/auth", () => ({
+  useAuthStore: (selector: (state: { user: { id: string } }) => unknown) =>
+    selector({ user: { id: "user-1" } }),
+}));
+
+vi.mock("@multica/core/chat", () => ({
+  useRecentContextStore: (
+    selector: (state: { recordVisit: typeof mocks.recordVisit }) => unknown,
+  ) => selector({ recordVisit: mocks.recordVisit }),
+}));
+
+vi.mock("@multica/core/paths", () => ({
+  useWorkspacePaths: () => ({
+    projects: () => "/test-workspace/projects",
+  }),
+}));
+
+vi.mock("@multica/core/workspace/hooks", () => ({
+  useActorName: () => ({ getActorName: () => "User One" }),
+}));
+
+vi.mock("sonner", () => ({
+  toast: { success: mocks.toastSuccess },
+}));
+
+vi.mock("react-resizable-panels", () => ({
+  useDefaultLayout: () => ({
+    defaultLayout: undefined,
+    onLayoutChanged: vi.fn(),
+  }),
+  usePanelRef: () => ({
+    current: {
+      isCollapsed: () => false,
+      expand: vi.fn(),
+      collapse: vi.fn(),
+    },
+  }),
+}));
+
+vi.mock("@multica/ui/hooks/use-mobile", () => ({
+  useIsMobile: () => false,
+}));
+
+vi.mock("@multica/ui/components/common/emoji-picker", () => ({
+  EmojiPicker: () => null,
+}));
+
+vi.mock("@multica/ui/components/ui/resizable", () => ({
+  ResizablePanelGroup: ({ children }: { children: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
+  ResizablePanel: ({ children }: { children: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
+  ResizableHandle: () => null,
+}));
+
+vi.mock("@multica/ui/components/ui/dropdown-menu", () => ({
+  DropdownMenu: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  DropdownMenuTrigger: ({ render }: { render: React.ReactNode }) => <>{render}</>,
+  DropdownMenuContent: ({ children }: { children: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
+  DropdownMenuItem: ({
+    children,
+    onClick,
+  }: {
+    children: React.ReactNode;
+    onClick?: () => void;
+  }) => (
+    <button type="button" onClick={onClick}>
+      {children}
+    </button>
+  ),
+  DropdownMenuSeparator: () => <hr />,
+}));
+
+vi.mock("@multica/ui/components/ui/popover", () => ({
+  Popover: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  PopoverTrigger: ({ render }: { render: React.ReactNode }) => <>{render}</>,
+  PopoverContent: ({ children }: { children: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
+}));
+
+vi.mock("@multica/ui/components/ui/tooltip", () => ({
+  Tooltip: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  TooltipTrigger: ({ render }: { render: React.ReactNode }) => <>{render}</>,
+  TooltipContent: ({ children }: { children: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
+}));
+
+vi.mock("@multica/ui/components/ui/sheet", () => ({
+  Sheet: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  SheetContent: ({ children }: { children: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
+}));
+
+vi.mock("@multica/ui/components/ui/alert-dialog", () => ({
+  AlertDialog: ({
+    open,
+    children,
+  }: {
+    open: boolean;
+    children: React.ReactNode;
+  }) => (open ? <div role="alertdialog">{children}</div> : null),
+  AlertDialogContent: ({ children }: { children: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
+  AlertDialogHeader: ({ children }: { children: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
+  AlertDialogTitle: ({ children }: { children: React.ReactNode }) => (
+    <h2>{children}</h2>
+  ),
+  AlertDialogDescription: ({ children }: { children: React.ReactNode }) => (
+    <p>{children}</p>
+  ),
+  AlertDialogFooter: ({ children }: { children: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
+  AlertDialogCancel: ({ children }: { children: React.ReactNode }) => (
+    <button type="button">{children}</button>
+  ),
+  AlertDialogAction: ({
+    children,
+    onClick,
+  }: {
+    children: React.ReactNode;
+    onClick?: () => void;
+  }) => (
+    <button type="button" onClick={onClick}>
+      {children}
+    </button>
+  ),
+}));
+
+vi.mock("../../editor", () => ({
+  TitleEditor: ({ defaultValue }: { defaultValue: string }) => (
+    <div>{defaultValue}</div>
+  ),
+  ContentEditor: () => null,
+}));
+
+vi.mock("../../common/actor-avatar", () => ({
+  ActorAvatar: () => null,
+}));
+
+vi.mock("../../issues/components/priority-icon", () => ({
+  PriorityIcon: () => null,
+}));
+
+vi.mock("./project-resources-section", () => ({
+  ProjectResourcesSection: () => null,
+}));
+
+vi.mock("./project-start-date-picker", () => ({
+  ProjectStartDatePicker: () => null,
+}));
+
+vi.mock("./project-due-date-picker", () => ({
+  ProjectDueDatePicker: () => null,
+}));
+
+vi.mock("../../issues/surface/issue-surface", () => ({
+  IssueSurface: () => null,
+}));
+
+vi.mock("../../layout/breadcrumb-header", () => ({
+  BreadcrumbHeader: ({ actions }: { actions: React.ReactNode }) => (
+    <header>{actions}</header>
+  ),
+}));
+
+vi.mock("../../layout/animated-right-sidebar", () => ({
+  AnimatedRightSidebar: ({ children }: { children: React.ReactNode }) => (
+    <aside>{children}</aside>
+  ),
+  getAnimatedRightSidebarInitialOpen: () => true,
+  rightSidebarPanelMotionProps: {},
+  useAnimatedRightSidebarState: () => ({
+    open: true,
+    visualOpen: true,
+    motionEnabled: false,
+    beginToggle: vi.fn(),
+    handleResize: vi.fn(),
+  }),
+}));
+
+const PROJECT: Project = {
+  id: "project-1",
+  workspace_id: "workspace-1",
+  title: "Launch Plan",
+  description: null,
+  icon: null,
+  status: "in_progress",
+  priority: "high",
+  lead_type: null,
+  lead_id: null,
+  start_date: null,
+  due_date: null,
+  created_at: "2026-06-01T00:00:00Z",
+  updated_at: "2026-06-01T00:00:00Z",
+  issue_count: 3,
+  done_count: 1,
+  resource_count: 0,
+};
+
+function renderProjectDetail() {
+  const adapter: NavigationAdapter = {
+    push: mocks.push,
+    replace: vi.fn(),
+    back: vi.fn(),
+    pathname: "/test-workspace/projects/project-1",
+    searchParams: new URLSearchParams(),
+    getShareableUrl: (path) => path,
+  };
+
+  renderWithI18n(
+    <NavigationProvider value={adapter}>
+      <ProjectDetail projectId={PROJECT.id} />
+    </NavigationProvider>,
+  );
+}
+
+beforeEach(() => {
+  mocks.role = "admin";
+  mocks.deleteProject.mockReset();
+  mocks.push.mockReset();
+  mocks.recordVisit.mockReset();
+  mocks.toastSuccess.mockReset();
+});
+
+describe("ProjectDetail project deletion", () => {
+  it("requires confirmation and navigates only after deletion succeeds", async () => {
+    const user = userEvent.setup();
+    renderProjectDetail();
+
+    await user.click(screen.getByRole("button", { name: "Delete project" }));
+
+    expect(screen.getByRole("alertdialog")).toBeInTheDocument();
+    expect(mocks.deleteProject).not.toHaveBeenCalled();
+
+    await user.click(screen.getByRole("button", { name: "Delete" }));
+
+    expect(mocks.deleteProject).toHaveBeenCalledWith(
+      PROJECT.id,
+      expect.objectContaining({ onSuccess: expect.any(Function) }),
+    );
+    expect(mocks.push).not.toHaveBeenCalled();
+
+    const options = mocks.deleteProject.mock.calls[0]?.[1] as {
+      onSuccess: () => void;
+    };
+    options.onSuccess();
+
+    expect(mocks.toastSuccess).toHaveBeenCalledWith("Project deleted");
+    expect(mocks.push).toHaveBeenCalledWith("/test-workspace/projects");
+  });
+
+  it("does not offer project deletion to regular members", () => {
+    mocks.role = "member";
+
+    renderProjectDetail();
+
+    expect(
+      screen.queryByRole("button", { name: "Delete project" }),
+    ).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## What does this PR do?

Adds component coverage for the project deletion flow in `ProjectDetail`.

The tests verify that only workspace administrators can delete a project, deletion requires confirmation, and navigation occurs only after the deletion succeeds.

## Related Issue

No related issue. This PR addresses an identified component test gap.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Refactor / code improvement (no behavior change)
- [ ] Documentation update
- [x] Tests (adding or improving test coverage)
- [ ] CI / infrastructure

## Changes Made

- Added `packages/views/projects/components/project-detail.test.tsx`.
- Verified regular members cannot access the delete action.
- Verified administrators must confirm deletion.
- Verified the mutation receives the current project ID.
- Verified navigation and success feedback occur only after deletion succeeds.

## How to Test

1. Run:
   ```bash
   pnpm --filter @multica/views exec vitest run projects/components/project-detail.test.tsx
   ```
2. Confirm both tests pass.
3. Run:
   ```bash
   pnpm --filter @multica/views exec eslint projects/components/project-detail.test.tsx
   ```

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [ ] I have updated relevant documentation to reflect my changes
- [ ] If I added a new runtime / coding tool / UI tab, I synced the change to **landing copy** (`apps/web/features/landing/i18n/`) and **relevant docs** (`apps/docs/content/docs/`)
- [ ] If this PR touches Chinese product copy, I checked it against `apps/docs/content/docs/developers/conventions.zh.mdx` (terminology, mixed-rule for `task` / `issue` / `skill`)
- [x] I have considered and documented any risks above
- [x] I will address all reviewer comments before requesting merge

This is a test-only change and does not affect runtime behavior. Screenshots and documentation updates are not applicable.

The focused tests and ESLint check pass. The package-wide typecheck is currently blocked by unrelated existing dependency and test typing errors.

## AI Disclosure

**AI tool used:** Cursor

**Prompt / approach:**

I asked Cursor to identify and cover a critical user behavior in `ProjectDetail`. The implementation focused on the permission, confirmation, mutation, and success-navigation boundaries of project deletion. Cursor helped inspect repository conventions, implement isolated component mocks, and run focused verification.

## Screenshots (optional)

Not applicable; this PR does not change the UI.