### PR TITLE
fix preserve colliding QwenPaw skills

### DIFF
--- a/server/internal/daemon/execenv/qwenpaw_workspace.go
+++ b/server/internal/daemon/execenv/qwenpaw_workspace.go
@@ -58,13 +58,10 @@ func prepareQwenpawWorkspace(qwenpawWorkspace string, workspaceSkills []SkillCon
 	}
 
 	skillNames := make([]string, 0, len(workspaceSkills))
-	for _, skill := range workspaceSkills {
-		slug := sanitizeSkillName(skill.Name)
+	slugs := resolveSkillSlugs(workspaceSkills)
+	for i, skill := range workspaceSkills {
+		slug := slugs[i]
 		skillDir := filepath.Join(skillsDir, slug)
-
-		// No collision guard needed: we just removed the entire skills dir
-		// above, so every slug is available. The per-task workspace is
-		// daemon-owned and never coexists with user files.
 
 		if err := os.MkdirAll(skillDir, 0o755); err != nil {
 			return fmt.Errorf("create skill dir for %q: %w", skill.Name, err)
@@ -98,9 +95,9 @@ func prepareQwenpawWorkspace(qwenpawWorkspace string, workspaceSkills []SkillCon
 	skills := make(map[string]any, len(skillNames))
 	for _, slug := range skillNames {
 		skills[slug] = map[string]any{
-			"enabled":   true,
-			"channels":  []string{"all"},
-			"source":    "customized",
+			"enabled":  true,
+			"channels": []string{"all"},
+			"source":   "customized",
 			"metadata": map[string]any{
 				"name":        slug,
 				"description": "",

--- a/server/internal/daemon/execenv/qwenpaw_workspace_test.go
+++ b/server/internal/daemon/execenv/qwenpaw_workspace_test.go
@@ -96,6 +96,67 @@ func TestPrepareQwenpawWorkspace(t *testing.T) {
 	}
 }
 
+func TestPrepareQwenpawWorkspacePreservesCollidingSkillSlugs(t *testing.T) {
+	t.Parallel()
+
+	workspaceDir := t.TempDir()
+	skills := []SkillContextForEnv{
+		{Name: "A B", Content: "# First\n\nfirst skill body"},
+		{Name: "A-B", Content: "# Second\n\nsecond skill body"},
+	}
+
+	if err := prepareQwenpawWorkspace(workspaceDir, skills, testLogger()); err != nil {
+		t.Fatalf("prepareQwenpawWorkspace failed: %v", err)
+	}
+
+	expectedSkills := map[string]string{
+		"a-b":         "first skill body",
+		"a-b-multica": "second skill body",
+	}
+	for slug, wantBody := range expectedSkills {
+		data, err := os.ReadFile(filepath.Join(workspaceDir, "skills", slug, "SKILL.md"))
+		if err != nil {
+			t.Fatalf("read SKILL.md for %q: %v", slug, err)
+		}
+		body := string(data)
+		if !frontmatterNameIs(body, slug) {
+			t.Errorf("SKILL.md for %q does not use its directory slug in frontmatter", slug)
+		}
+		if !strings.Contains(body, wantBody) {
+			t.Errorf("SKILL.md for %q does not contain %q", slug, wantBody)
+		}
+	}
+
+	data, err := os.ReadFile(filepath.Join(workspaceDir, "skill.json"))
+	if err != nil {
+		t.Fatalf("read skill.json: %v", err)
+	}
+	var manifest map[string]any
+	if err := json.Unmarshal(data, &manifest); err != nil {
+		t.Fatalf("unmarshal skill.json: %v", err)
+	}
+	skillsMap, ok := manifest["skills"].(map[string]any)
+	if !ok {
+		t.Fatal("skills is not a map")
+	}
+	if len(skillsMap) != len(expectedSkills) {
+		t.Fatalf("manifest has %d skills, want %d", len(skillsMap), len(expectedSkills))
+	}
+	for slug := range expectedSkills {
+		entry, ok := skillsMap[slug].(map[string]any)
+		if !ok {
+			t.Fatalf("skill entry %q is not a map", slug)
+		}
+		metadata, ok := entry["metadata"].(map[string]any)
+		if !ok {
+			t.Fatalf("metadata for %q is not a map", slug)
+		}
+		if metadata["name"] != slug {
+			t.Errorf("metadata name for %q = %v, want %q", slug, metadata["name"], slug)
+		}
+	}
+}
+
 // TestPrepareQwenpawWorkspaceEmpty verifies that an empty skills list creates
 // the workspace directory but removes any existing skills dir and manifest.
 func TestPrepareQwenpawWorkspaceEmpty(t *testing.T) {
@@ -269,7 +330,7 @@ func TestPrepareQwenpawWorkspaceReplace(t *testing.T) {
 	for _, slug := range []string{"bug-finder", "review-helper"} {
 		dir := filepath.Join(skillsDir, slug)
 		if _, err := os.Stat(dir); err != nil {
-				t.Fatalf("new skill dir %q should exist: %v", slug, err)
+			t.Fatalf("new skill dir %q should exist: %v", slug, err)
 		}
 		// Verify no collision suffix
 		if _, err := os.Stat(filepath.Join(skillsDir, slug+"-multica")); !os.IsNotExist(err) {


### PR DESCRIPTION
## Root cause

`prepareQwenpawWorkspace` derived each directory and manifest key directly from `sanitizeSkillName`. Because that normalization is not injective, names such as `A B` and `A-B` both became `a-b`, allowing the later skill to overwrite the earlier one.

## Changes

- Allocate deterministic, collision-free slugs with the existing `resolveSkillSlugs` helper before writing QwenPaw skills.
- Use that single allocation for directories, generated frontmatter, and `skill.json` keys and metadata.
- Add a regression test proving both colliding skills and their distinct contents are preserved.

## Verification

- `go test ./internal/daemon/execenv -run '^TestPrepareQwenpawWorkspace' -count=1`
- `go test ./internal/daemon/execenv -count=1`
- `go test ./pkg/agent -run '^TestQwenpaw' -count=1`
- `go vet ./internal/daemon/execenv`
- `git diff --check`
- Diff size: 70 additions + 12 deletions = 82 lines

Container- or cluster-backed integration/E2E tests were not run locally and remain for existing CI.

## Risk and rollback

Risk is limited to QwenPaw workspaces with colliding normalized skill names. Non-colliding skills keep their existing slugs. Roll back by reverting commit `8eb0ab19b`.

Closes OSS-11
Related finding: OSS-7
