### PR TITLE
fix(chat): keep a user's own message in the transcript (MUL-5711)

### DIFF
--- a/packages/core/realtime/use-realtime-sync.test.ts
+++ b/packages/core/realtime/use-realtime-sync.test.ts
@@ -14,6 +14,7 @@ import { workspaceKeys } from "../workspace/queries";
 import type {
   ChatDonePayload,
   ChatMessage,
+  ChatMessageEventPayload,
   ChatPendingTask,
   ChatMessagesPage,
   ChatSession,
@@ -23,6 +24,7 @@ import type {
 import {
   applyChatCancelFinalizedToCache,
   applyChatDoneToCache,
+  applyChatMessageToCache,
   applyChatQuickActionsToCache,
   applyChatSessionUpdatedToCache,
   applyWorkspaceUpdatedToCache,
@@ -988,9 +990,16 @@ describe("chat quick-actions supplement flow", () => {
       task_id: taskId,
       created_at: "2026-05-13T05:00:02Z",
     };
+    const actions = [{ label: "Next", prompt: "Do the next thing", primary: true }];
     // Settled post-chat:done state: assistant present, no actions yet.
     const staleRows = [userMessage(), assistant];
     qc.setQueryData<ChatMessage[]>(messagesKey, staleRows);
+
+    // Server truth, which the supplement's own broadcast lags: the daemon
+    // persists the actions BEFORE publishing chat:quick_actions
+    // (SupplementChatQuickActions), so a request issued after the event reads
+    // them back while the in-flight one predates them.
+    let serverRows = staleRows;
 
     // An active observer (a mounted chat screen) whose refetch we hold open, so
     // it is genuinely in flight when the supplement lands.
@@ -998,9 +1007,11 @@ describe("chat quick-actions supplement flow", () => {
     const observer = new QueryObserver<ChatMessage[]>(qc, {
       queryKey: messagesKey,
       queryFn: () =>
-        new Promise<ChatMessage[]>((resolve) => {
-          releaseRefetch = resolve;
-        }),
+        releaseRefetch
+          ? Promise.resolve(serverRows)
+          : new Promise<ChatMessage[]>((resolve) => {
+              releaseRefetch = resolve;
+            }),
       staleTime: Infinity,
       gcTime: Infinity,
       retry: false,
@@ -1014,7 +1025,7 @@ describe("chat quick-actions supplement flow", () => {
       expect(typeof releaseRefetch).toBe("function");
     });
 
-    const actions = [{ label: "Next", prompt: "Do the next thing", primary: true }];
+    serverRows = [userMessage(), { ...assistant, quick_actions: actions }];
     await applyChatQuickActionsToCache(qc, {
       chat_session_id: sessionId,
       task_id: taskId,
@@ -1032,5 +1043,153 @@ describe("chat quick-actions supplement flow", () => {
       actions,
     );
     unsub();
+  });
+
+  // Regression (MUL-5711): cancelQueries defaults to revert:true, so the
+  // cancel above ALSO rolls the cache back to the pre-fetch snapshot. Rows that
+  // only the cancelled response carried — a peer's user message, anything that
+  // landed while this surface was unmounted — must come back, which is what the
+  // re-invalidate after the patch is for. Without it the hole is permanent:
+  // both caches are staleTime: Infinity and nothing else re-fetches.
+  it("re-syncs after the cancel so rows only the cancelled refetch carried are not lost", async () => {
+    const qc = createQueryClient();
+    const assistant: ChatMessage = {
+      id: "msg-assistant",
+      chat_session_id: sessionId,
+      role: "assistant",
+      content: "done",
+      task_id: taskId,
+      created_at: "2026-05-13T05:00:02Z",
+    };
+    // This client never wrote the peer's prompt locally — only the in-flight
+    // refetch carries it.
+    const peerPrompt: ChatMessage = {
+      id: "msg-peer",
+      chat_session_id: sessionId,
+      role: "user",
+      content: "sent from another window",
+      task_id: taskId,
+      created_at: "2026-05-13T05:00:01Z",
+    };
+    const actions = [{ label: "Next", prompt: "Do the next thing", primary: true }];
+    qc.setQueryData<ChatMessage[]>(messagesKey, [assistant]);
+
+    let serverRows: ChatMessage[] = [peerPrompt, assistant];
+    let releaseRefetch: ((rows: ChatMessage[]) => void) | undefined;
+    const observer = new QueryObserver<ChatMessage[]>(qc, {
+      queryKey: messagesKey,
+      queryFn: () =>
+        releaseRefetch
+          ? Promise.resolve(serverRows)
+          : new Promise<ChatMessage[]>((resolve) => {
+              releaseRefetch = resolve;
+            }),
+      staleTime: Infinity,
+      gcTime: Infinity,
+      retry: false,
+    });
+    const unsub = observer.subscribe(() => {});
+
+    void qc.invalidateQueries({ queryKey: messagesKey });
+    await vi.waitFor(() => {
+      expect(qc.getQueryState(messagesKey)?.fetchStatus).toBe("fetching");
+      expect(typeof releaseRefetch).toBe("function");
+    });
+
+    serverRows = [peerPrompt, { ...assistant, quick_actions: actions }];
+    await applyChatQuickActionsToCache(qc, {
+      chat_session_id: sessionId,
+      task_id: taskId,
+      message_id: "msg-assistant",
+      quick_actions: actions,
+    });
+    releaseRefetch?.([peerPrompt, assistant]);
+
+    await vi.waitFor(() => {
+      const rows = qc.getQueryData<ChatMessage[]>(messagesKey);
+      expect(rows?.map((m) => m.id)).toEqual(["msg-peer", "msg-assistant"]);
+      expect(rows?.at(-1)?.quick_actions).toEqual(actions);
+    });
+    unsub();
+  });
+});
+
+describe("applyChatMessageToCache", () => {
+  function messagePayload(
+    overrides: Partial<ChatMessageEventPayload> = {},
+  ): ChatMessageEventPayload {
+    return {
+      chat_session_id: sessionId,
+      message_id: "msg-user-2",
+      role: "user",
+      content: "second prompt",
+      task_id: taskId,
+      created_at: "2026-05-13T05:00:05Z",
+      ...overrides,
+    };
+  }
+
+  it("inserts the user message into both caches without waiting for a refetch", () => {
+    const qc = createQueryClient();
+    qc.setQueryData<ChatMessage[]>(messagesKey, [userMessage()]);
+    qc.setQueryData<InfiniteData<ChatMessagesPage>>(chatKeys.messagesPage(sessionId), {
+      pages: [{ messages: [userMessage()], limit: 50, has_more: false, next_cursor: null }],
+      pageParams: [null],
+    });
+
+    applyChatMessageToCache(qc, messagePayload());
+
+    const flat = qc.getQueryData<ChatMessage[]>(messagesKey);
+    expect(flat?.map((m) => m.id)).toEqual(["msg-user", "msg-user-2"]);
+    expect(flat?.at(-1)).toMatchObject({
+      role: "user",
+      content: "second prompt",
+      task_id: taskId,
+      created_at: "2026-05-13T05:00:05Z",
+    });
+    const pages = qc.getQueryData<InfiniteData<ChatMessagesPage>>(
+      chatKeys.messagesPage(sessionId),
+    );
+    expect(pages?.pages[0]?.messages.map((m) => m.id)).toEqual(["msg-user", "msg-user-2"]);
+  });
+
+  it("is idempotent against the sender's own optimistic write and reconnect replay", () => {
+    const qc = createQueryClient();
+    // The sender's own row is richer than the event (it carries attachments the
+    // payload has no field for), so the dedup must keep it rather than replace.
+    const alreadySent: ChatMessage = {
+      id: "msg-user-2",
+      chat_session_id: sessionId,
+      role: "user",
+      content: "locally written",
+      task_id: taskId,
+      created_at: "2026-05-13T05:00:05Z",
+    };
+    qc.setQueryData<ChatMessage[]>(messagesKey, [alreadySent]);
+
+    applyChatMessageToCache(qc, messagePayload());
+    applyChatMessageToCache(qc, messagePayload());
+
+    const rows = qc.getQueryData<ChatMessage[]>(messagesKey);
+    expect(rows).toHaveLength(1);
+    expect(rows?.[0]?.content).toBe("locally written");
+  });
+
+  it("leaves assistant turns to chat:done, which carries the richer row", () => {
+    const qc = createQueryClient();
+    qc.setQueryData<ChatMessage[]>(messagesKey, [userMessage()]);
+
+    applyChatMessageToCache(
+      qc,
+      messagePayload({ message_id: "msg-assistant", role: "assistant", content: "done" }),
+    );
+
+    expect(qc.getQueryData<ChatMessage[]>(messagesKey)).toHaveLength(1);
+  });
+
+  it("does not seed an unfetched cache — the first fetch owns it", () => {
+    const qc = createQueryClient();
+    applyChatMessageToCache(qc, messagePayload());
+    expect(qc.getQueryData<ChatMessage[]>(messagesKey)).toBeUndefined();
   });
 });

--- a/packages/core/realtime/use-realtime-sync.ts
+++ b/packages/core/realtime/use-realtime-sync.ts
@@ -96,6 +96,7 @@ import type {
   ChatQuickActionsFailureState,
   ChatCancelFinalizedPayload,
   ChatMessage,
+  ChatMessageEventPayload,
   ChatPendingTask,
   ChatMessagesPage,
   ChatSession,
@@ -133,6 +134,60 @@ export function refetchPendingChatAggregate(
 ) {
   if (!wsId) return;
   qc.invalidateQueries({ queryKey: chatKeys.pendingTasks(wsId) });
+}
+
+/**
+ * Apply a chat:message event: insert the turn's USER message into both message
+ * caches, then reconcile authoritatively (MUL-5711).
+ *
+ * The inline insert is what `chat:done` has always done for the assistant reply,
+ * and its absence here was the whole bug: a user message reached the transcript
+ * ONLY through the refetch this handler triggers, so any client that did not
+ * write it locally (a second window/device, a send whose HTTP response errored
+ * after the server committed, a surface mounting mid-flight) lost the message
+ * whenever that refetch was dropped — most reliably by the chat:quick_actions
+ * cancel below. Both caches are `staleTime: Infinity`, so nothing re-fetched
+ * afterwards and the prompt stayed missing until a remount.
+ *
+ * Only `role: "user"` is inserted. The event has exactly one producer today
+ * (SendChatMessage), and an assistant row fabricated from this payload would
+ * carry no elapsed_ms / message_kind / quick_actions AND would make
+ * applyChatDoneToCache's id dedup skip the richer row it is about to write.
+ *
+ * The invalidate is kept: this payload has no `attachments`, so the reconciling
+ * refetch is what fills them in for clients that did not send the message.
+ */
+export function applyChatMessageToCache(
+  qc: QueryClient,
+  payload: ChatMessageEventPayload,
+) {
+  const sessionId = payload.chat_session_id;
+  if (payload.role === "user" && payload.message_id) {
+    const message: ChatMessage = {
+      id: payload.message_id,
+      chat_session_id: sessionId,
+      role: "user",
+      content: payload.content ?? "",
+      task_id: payload.task_id ?? null,
+      created_at: payload.created_at ?? new Date().toISOString(),
+    };
+    qc.setQueryData<ChatMessage[] | undefined>(
+      chatKeys.messages(sessionId),
+      (old) => {
+        if (!old) return old; // first fetch will pick it up
+        // Idempotent against the sender's own optimistic write and against
+        // reconnect replay.
+        if (old.some((m) => m.id === message.id)) return old;
+        return [...old, message];
+      },
+    );
+    qc.setQueryData<InfiniteData<ChatMessagesPage> | undefined>(
+      chatKeys.messagesPage(sessionId),
+      (old) => patchLatestChatMessagePage(old, message),
+    );
+  }
+  invalidateChatMessageQueries(qc, sessionId);
+  qc.invalidateQueries({ queryKey: chatKeys.pendingTask(sessionId) });
 }
 
 export function applyChatDoneToCache(
@@ -245,6 +300,16 @@ export async function applyChatQuickActionsToCache(
             }
           : old,
     );
+    // Re-sync after the cancel (MUL-5711). cancelQueries defaults to
+    // `revert: true`, so the cancelled refetch is not merely ignored — the cache
+    // is rolled back to the snapshot taken when it STARTED, and rows that only
+    // that response carried (a peer's user message, anything that landed while
+    // this surface was unmounted) are dropped. With `staleTime: Infinity` and no
+    // further trigger, the hole survived until a remount. Re-invalidating costs
+    // one request per supplement and cannot lose the pills: the server persists
+    // the actions BEFORE broadcasting this event (SupplementChatQuickActions),
+    // so the refetch this schedules reads them back.
+    invalidateChatMessageQueries(qc, sessionId);
   }
   // Resolve the marker only when it belongs to THIS message: a late
   // supplement for turn N must not clear the marker turn N+1's chat:done
@@ -1237,10 +1302,14 @@ export function useRealtimeSync(
     };
 
     const unsubChatMessage = ws.on("chat:message", (p) => {
-      const payload = p as { chat_session_id: string };
-      chatWsLogger.info("chat:message (global)", { chat_session_id: payload.chat_session_id });
-      invalidateChatMessageQueries(qc, payload.chat_session_id);
-      qc.invalidateQueries({ queryKey: chatKeys.pendingTask(payload.chat_session_id) });
+      const payload = p as ChatMessageEventPayload;
+      chatWsLogger.info("chat:message (global)", {
+        chat_session_id: payload.chat_session_id,
+        role: payload.role,
+      });
+      // Inline-insert the user turn before invalidating, so the prompt does not
+      // depend on the refetch surviving (MUL-5711) — same shape as chat:done.
+      applyChatMessageToCache(qc, payload);
       // NOTE: intentionally does NOT touch the pending aggregate. chat:message
       // fires per streamed message with no status; the aggregate is maintained
       // by the task lifecycle handlers below (MUL-4159).

--- a/packages/views/chat/components/chat-message-list.tsx
+++ b/packages/views/chat/components/chat-message-list.tsx
@@ -242,7 +242,12 @@ export function ChatMessageList({
     return items;
   }, [messages, hasLive, pendingTaskId]);
 
-  const firstIndex = renderItems.length > 0 ? firstItemIndex : 0;
+  // Passed straight through. Zeroing it while the list is momentarily empty
+  // (a pending task holds this list mounted before its messages land) made the
+  // next render raise it by the whole base, which react-virtuoso reads as
+  // "drop that many rows off the head" and which wrecks its size bookkeeping —
+  // the caller keeps this value stable instead (MUL-5711).
+  const firstIndex = firstItemIndex;
 
   const listContext: ChatListContext = {
     isFetchingOlderMessages,

--- a/packages/views/chat/components/chat-window.tsx
+++ b/packages/views/chat/components/chat-window.tsx
@@ -59,6 +59,7 @@ import { useQuickActionsPendingTimeout } from "@multica/core/chat/use-quick-acti
 import { useQuickActionsFailureToast } from "./use-quick-actions-failure-toast";
 import { removeChatMessageFromCaches } from "@multica/core/realtime";
 import { useChatDraftRestore } from "./use-chat-draft-restore";
+import { useChatFirstItemIndex } from "./use-chat-first-item-index";
 import { useChatInputFocus } from "./use-chat-input-focus";
 import { ChatMessageList, ChatMessageSkeleton } from "./chat-message-list";
 import { ChatInput } from "./chat-input";
@@ -77,7 +78,6 @@ import { useT } from "../../i18n";
 
 const uiLogger = createLogger("chat.ui");
 const apiLogger = createLogger("chat.api");
-const CHAT_VIRTUOSO_INITIAL_FIRST_ITEM_INDEX = 1_000_000;
 
 function appendChatMessageToLatestPageCache(
   qc: ReturnType<typeof useQueryClient>,
@@ -152,15 +152,12 @@ export function ChatWindow() {
   // When no active session, always show empty — don't use stale cache.
   // Page 0 contains the latest chronological window; later cursor pages are
   // older chronological windows. Reverse pages so older fetched pages render
-  // above the initial latest page. The Virtuoso firstItemIndex is client-owned:
-  // it starts from a large stable base and only subtracts the count of loaded
-  // prepended rows, so concurrent server inserts cannot drift the scroll anchor.
+  // above the initial latest page. The Virtuoso firstItemIndex is client-owned
+  // and anchored to a loaded message, so appends and page-window slides cannot
+  // drift the scroll anchor — see useChatFirstItemIndex (MUL-5711).
   const messagePages = activeSessionId ? rawMessagePages?.pages ?? [] : [];
   const messages = [...messagePages].reverse().flatMap((page) => page.messages);
-  const olderMessageCount = messagePages.slice(1).reduce((sum, page) => sum + page.messages.length, 0);
-  const firstItemIndex = messages.length > 0
-    ? CHAT_VIRTUOSO_INITIAL_FIRST_ITEM_INDEX - olderMessageCount
-    : 0;
+  const firstItemIndex = useChatFirstItemIndex(activeSessionId, messages);
   // Skeleton only shows for an un-cached session fetch. Cached switches
   // return data synchronously — no flash. `enabled: false` (new chat)
   // keeps isLoading false so the starter prompts aren't hidden.

--- a/packages/views/chat/components/use-chat-controller.ts
+++ b/packages/views/chat/components/use-chat-controller.ts
@@ -36,6 +36,7 @@ import {
 import { useChatStore } from "@multica/core/chat";
 import { removeChatMessageFromCaches } from "@multica/core/realtime";
 import { useChatDraftRestore } from "./use-chat-draft-restore";
+import { useChatFirstItemIndex } from "./use-chat-first-item-index";
 import { useChatProjectContextSupport } from "./use-chat-project-context-support";
 import { createLogger } from "@multica/core/logger";
 import type {
@@ -150,7 +151,6 @@ export function hasInFlightPendingTask(
   const pending = qc.getQueryData<ChatPendingTask>(chatKeys.pendingTask(sessionId));
   return Boolean(pending?.task_id);
 }
-const CHAT_VIRTUOSO_INITIAL_FIRST_ITEM_INDEX = 1_000_000;
 
 function appendChatMessageToLatestPageCache(
   qc: ReturnType<typeof useQueryClient>,
@@ -230,13 +230,10 @@ export function useChatController(opts?: { isActive?: boolean }) {
 
   const messagePages = activeSessionId ? rawMessagePages?.pages ?? [] : [];
   const messages = [...messagePages].reverse().flatMap((page) => page.messages);
-  const olderMessageCount = messagePages
-    .slice(1)
-    .reduce((sum, page) => sum + page.messages.length, 0);
-  const firstItemIndex =
-    messages.length > 0
-      ? CHAT_VIRTUOSO_INITIAL_FIRST_ITEM_INDEX - olderMessageCount
-      : 0;
+  // Absolute row numbering is anchored to a loaded message rather than derived
+  // from page sizes — the newest page is a sliding 50-message window, so page
+  // counts move on every turn without anything being prepended (MUL-5711).
+  const firstItemIndex = useChatFirstItemIndex(activeSessionId, messages);
   const showSkeleton = !!activeSessionId && messagesLoading;
 
   const { data: pendingTask } = useQuery(

--- a/packages/views/chat/components/use-chat-first-item-index.test.ts
+++ b/packages/views/chat/components/use-chat-first-item-index.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, it } from "vitest";
+import {
+  CHAT_VIRTUOSO_INITIAL_FIRST_ITEM_INDEX as BASE,
+  nextChatFirstItemIndex,
+  type ChatFirstItemIndexAnchor,
+} from "./use-chat-first-item-index";
+
+const sessionId = "session-1";
+
+function rows(...ids: string[]) {
+  return ids.map((id) => ({ id }));
+}
+
+/** Feed successive message lists through the reducer like React would. */
+function run(lists: { id: string }[][], session: string | null = sessionId) {
+  let anchor: ChatFirstItemIndexAnchor | null = null;
+  return lists.map((messages) => {
+    const next = nextChatFirstItemIndex(anchor, session, messages);
+    anchor = next.anchor;
+    return next.firstItemIndex;
+  });
+}
+
+describe("nextChatFirstItemIndex", () => {
+  it("starts at the base for the first non-empty render", () => {
+    expect(run([rows("m1", "m2", "m3")])).toEqual([BASE]);
+  });
+
+  it("drops by exactly the number of rows prepended by a load-older page", () => {
+    const [first, second] = run([
+      rows("m11", "m12"),
+      rows("m1", "m2", "m3", "m11", "m12"),
+    ]);
+    expect(first).toBe(BASE);
+    expect(second).toBe(BASE - 3);
+  });
+
+  // Regression (MUL-5711): a turn appends two messages to the newest page, which
+  // is a fixed-size window — two older messages spill into the next page and the
+  // old "count everything but the newest page" derivation fell by 2 per turn,
+  // telling react-virtuoso rows had been prepended when only appends happened.
+  it("does not move when a turn appends and the page window slides", () => {
+    const loaded = rows("m1", "m2", "m11", "m12");
+    const afterTurn = rows("m1", "m2", "m11", "m12", "m13", "m14");
+    expect(run([loaded, afterTurn])).toEqual([BASE, BASE]);
+  });
+
+  it("survives repeated turns without drifting", () => {
+    const lists = [rows("m1", "m2")];
+    for (let turn = 0; turn < 5; turn++) {
+      const last = lists[lists.length - 1]!;
+      lists.push([...last, { id: `u${turn}` }, { id: `a${turn}` }]);
+    }
+    expect(new Set(run(lists))).toEqual(new Set([BASE]));
+  });
+
+  // Regression (MUL-5711): the list stays mounted with zero messages while a
+  // pending task holds it open. Re-basing to 0 there made the next render RAISE
+  // the index by the whole base, which react-virtuoso reads as "drop that many
+  // rows off the head".
+  it("never raises the index when the list is momentarily empty", () => {
+    const values = run([
+      rows("m1", "m2", "m11"),
+      rows("m1", "m2", "m11", "m12"),
+      [],
+      rows("m1", "m2", "m11", "m12", "m13"),
+    ]);
+    expect(values).toEqual([BASE, BASE, BASE, BASE]);
+  });
+
+  it("holds the last value when a session opens empty", () => {
+    expect(run([[], rows("m1")])).toEqual([BASE, BASE]);
+  });
+
+  it("re-bases when the session changes", () => {
+    let anchor: ChatFirstItemIndexAnchor | null = null;
+    ({ anchor } = nextChatFirstItemIndex(anchor, sessionId, rows("m1", "m2")));
+    ({ anchor } = nextChatFirstItemIndex(anchor, sessionId, rows("m0", "m1", "m2")));
+    const other = nextChatFirstItemIndex(anchor, "session-2", rows("x1", "x2"));
+    expect(other.firstItemIndex).toBe(BASE);
+    expect(other.anchor).toMatchObject({ sessionId: "session-2", anchorId: "x1" });
+  });
+
+  it("re-anchors without moving when the anchored message is deleted", () => {
+    const values = run([
+      rows("m1", "m2", "m3"),
+      rows("m0", "m1", "m2", "m3"), // prepended older page → BASE - 1
+      rows("m2", "m3"), // m0/m1 gone (cancelled turn restored to the composer)
+      rows("m2", "m3", "m4"),
+    ]);
+    expect(values).toEqual([BASE, BASE - 1, BASE - 1, BASE - 1]);
+  });
+
+  it("returns the base and no anchor without a session", () => {
+    const result = nextChatFirstItemIndex(null, null, rows("m1"));
+    expect(result).toEqual({ firstItemIndex: BASE, anchor: null });
+  });
+
+  it("keeps the anchor object stable when nothing moved", () => {
+    const first = nextChatFirstItemIndex(null, sessionId, rows("m1", "m2"));
+    const second = nextChatFirstItemIndex(first.anchor, sessionId, rows("m1", "m2", "m3"));
+    expect(second.anchor).toBe(first.anchor);
+  });
+});

--- a/packages/views/chat/components/use-chat-first-item-index.ts
+++ b/packages/views/chat/components/use-chat-first-item-index.ts
@@ -1,0 +1,126 @@
+"use client";
+
+import { useRef } from "react";
+
+/**
+ * Absolute index Virtuoso assigns to the oldest message of a freshly opened
+ * session. High enough that every later "load older" prepend can subtract from
+ * it without ever reaching zero (react-virtuoso rejects a negative
+ * `firstItemIndex`).
+ */
+export const CHAT_VIRTUOSO_INITIAL_FIRST_ITEM_INDEX = 1_000_000;
+
+/**
+ * Pins one loaded message to a fixed absolute index so the rest of the list can
+ * be numbered relative to it across refetches.
+ */
+export interface ChatFirstItemIndexAnchor {
+  sessionId: string;
+  /** Message whose absolute index is held fixed. */
+  anchorId: string;
+  /** That message's absolute Virtuoso index. */
+  anchorIndex: number;
+  /** Last emitted value — the absolute index of `messages[0]`. */
+  firstItemIndex: number;
+}
+
+/**
+ * Compute the next `firstItemIndex` for a chat message list (MUL-5711).
+ *
+ * react-virtuoso reads this prop as "the absolute index of `data[0]`" and
+ * diffs it between renders: a DECREASE means rows were prepended, an INCREASE
+ * means rows were dropped off the head. Both branches shift its size/anchor
+ * bookkeeping, so a value that moves for any other reason mis-attributes row
+ * heights and jumps the scroll position.
+ *
+ * The previous derivation — `BASE - (messages in every page but the newest)` —
+ * moved for another reason on every single turn. The newest page is a fixed
+ * 50-message window: two new messages push two older ones out of it and into
+ * the next page (TanStack re-derives each page cursor on refetch), so the
+ * "older" count grew by 2 per turn and the index fell by 2 while nothing was
+ * prepended. It could also jump by the whole BASE when the list mounted empty
+ * (a pending task holds the list open) and the first messages arrived after.
+ *
+ * Anchoring fixes both: an already-loaded message keeps its absolute index for
+ * the life of the session, so the value moves only when rows really do enter or
+ * leave the head of the list.
+ */
+export function nextChatFirstItemIndex(
+  anchor: ChatFirstItemIndexAnchor | null,
+  sessionId: string | null,
+  messages: readonly { id: string }[],
+): { firstItemIndex: number; anchor: ChatFirstItemIndexAnchor | null } {
+  if (!sessionId) {
+    return { firstItemIndex: CHAT_VIRTUOSO_INITIAL_FIRST_ITEM_INDEX, anchor: null };
+  }
+
+  const current = anchor?.sessionId === sessionId ? anchor : null;
+
+  const head = messages[0];
+  if (!head) {
+    // Empty list: hold the last emitted value. Re-basing to BASE here is what
+    // made the index jump upward once the first messages landed.
+    return {
+      firstItemIndex: current?.firstItemIndex ?? CHAT_VIRTUOSO_INITIAL_FIRST_ITEM_INDEX,
+      anchor: current,
+    };
+  }
+
+  if (!current) {
+    // First non-empty render for this session: the oldest loaded message
+    // defines the origin.
+    return {
+      firstItemIndex: CHAT_VIRTUOSO_INITIAL_FIRST_ITEM_INDEX,
+      anchor: {
+        sessionId,
+        anchorId: head.id,
+        anchorIndex: CHAT_VIRTUOSO_INITIAL_FIRST_ITEM_INDEX,
+        firstItemIndex: CHAT_VIRTUOSO_INITIAL_FIRST_ITEM_INDEX,
+      },
+    };
+  }
+
+  const position = messages.findIndex((m) => m.id === current.anchorId);
+  if (position < 0) {
+    // The anchor is gone (deleted turn, or it fell out of the loaded window).
+    // Re-anchor on the current head WITHOUT moving the index: a spurious move
+    // is exactly what this helper exists to prevent, and the alternative — a
+    // guessed offset — would shift every row's recorded height.
+    return {
+      firstItemIndex: current.firstItemIndex,
+      anchor: { ...current, anchorId: head.id, anchorIndex: current.firstItemIndex },
+    };
+  }
+
+  // `position` rows now sit above the anchor, so data[0] is that many indexes
+  // ahead of it. Appends leave this untouched; a real prepend lowers it by
+  // exactly the number of rows prepended.
+  const firstItemIndex = current.anchorIndex - position;
+  return {
+    firstItemIndex,
+    anchor: current.firstItemIndex === firstItemIndex ? current : { ...current, firstItemIndex },
+  };
+}
+
+/**
+ * React binding for {@link nextChatFirstItemIndex}. Both chat surfaces (the tab
+ * and the floating window) render the same Virtuoso list, so the numbering rule
+ * lives here rather than being derived twice.
+ *
+ * The ref is written during render on purpose: the value has to be available to
+ * the same render that consumes it, and the computation is idempotent — running
+ * it twice with the same inputs (StrictMode) yields the same anchor and index.
+ */
+export function useChatFirstItemIndex(
+  sessionId: string | null,
+  messages: readonly { id: string }[],
+): number {
+  const anchorRef = useRef<ChatFirstItemIndexAnchor | null>(null);
+  const { firstItemIndex, anchor } = nextChatFirstItemIndex(
+    anchorRef.current,
+    sessionId,
+    messages,
+  );
+  anchorRef.current = anchor;
+  return firstItemIndex;
+}


### PR DESCRIPTION
Fixes MUL-5711.

## The bug

A human's own chat message is the only row in the transcript that **no WebSocket handler ever writes into the cache**.

`chat:message` carries the whole message — `message_id`, `role`, `content`, `task_id`, `created_at` (`server/internal/handler/chat.go`, `ChatMessageEventPayload`) — but the handler read only `chat_session_id` and invalidated. So the user's prompt reached the UI **solely** through the refetch that invalidate scheduled, while the agent's reply is inline-inserted by `chat:done` and is never at risk. That asymmetry is exactly the reported symptom: the reply renders, the prompt that produced it is missing, and a refresh brings it back because the row was always in the database.

The refetch is then thrown away by the quick-actions supplement: `applyChatQuickActionsToCache` cancels the in-flight messages fetch before patching, and `cancelQueries` defaults to `revert: true` — so the cache is *rolled back* to the snapshot taken when that fetch started, not merely left alone. Both message caches are `staleTime: Infinity` and nothing re-fetched afterwards, so the hole survived until a remount.

## What changed

**1. `chat:message` inline-inserts the user turn** (`applyChatMessageToCache`), mirroring `chat:done`, then invalidates as before.

- Only `role: "user"`. `SendChatMessage` is the event's one producer, and an assistant row fabricated from this payload would carry no `elapsed_ms` / `message_kind` / `quick_actions` **and** would make `applyChatDoneToCache`'s id dedup skip the richer row it is about to write.
- The invalidate stays: this payload has no `attachments`, so the reconciling refetch is what fills them in for clients that did not send the message.
- Idempotent by `message_id`, so the sender's own optimistic row wins and reconnect replay is a no-op.

**2. `chat:quick_actions` re-invalidates after its cancel+patch.** One request per supplement, and it cannot lose the pills: `SupplementChatQuickActions` persists the actions *before* publishing the event, so the refetch this schedules reads them back.

**3. `firstItemIndex` is anchored to a loaded message** (`useChatFirstItemIndex`) instead of derived from page sizes.

The newest page is a fixed 50-message window and TanStack re-derives each page cursor on refetch, so every turn pushed two older messages into the next page — the old `BASE - (messages in every page but the newest)` fell by 2 per turn, telling react-virtuoso rows had been **prepended** when only appends happened. It could also jump by the whole base when the list mounted empty (a pending task holds it open), which react-virtuoso reads as "drop that many rows off the head" and which wrecks its size bookkeeping. Anchoring means the value moves only when rows really enter or leave the head. Both chat surfaces now share the rule instead of deriving it twice.

## Verification

- `pnpm typecheck` — 6/6 tasks pass
- `pnpm lint` — no new problems (16 pre-existing warnings, none in the touched files)
- `pnpm test` — core 1239 tests, views 3541 tests, all pass
- Red/green: the new quick-actions regression test fails with the re-invalidate removed and passes with it.

New tests: 5 for `applyChatMessageToCache` (insert into both caches, idempotence vs. the local write, assistant turns left to `chat:done`, no seeding of an unfetched cache), 1 for the post-cancel re-sync, and 10 for the anchored index (per-turn stability, load-older prepends, momentarily-empty list, session switch, deleted anchor).

Not covered here: the browser-level confirmation that the scroll no longer jumps. The index arithmetic is unit-tested, but the visual result needs a real layout engine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
