### PR TITLE
feat(comment): add ask_user_question structured question comments

### DIFF
--- a/packages/core/api/client.ts
+++ b/packages/core/api/client.ts
@@ -1032,6 +1032,32 @@ export class ApiClient {
     return this.fetch(`/api/comments/${commentId}/resolve`, { method: "DELETE" });
   }
 
+  /** Record the target user's response to an ask_user_question comment.
+   *  For "submitted", pass exactly one of the selection shapes: `selectedIndex`
+   *  (single), `selectedIndices` (multi), and/or `customText` (the "Other"
+   *  free-text). "ignored" needs no selection. Matches the sibling comment
+   *  mutations (createComment/updateComment/resolveComment) in returning the
+   *  updated Comment via the shared fetch path. */
+  async answerAskUserQuestion(
+    commentId: string,
+    state: "submitted" | "ignored",
+    selection?: {
+      selectedIndex?: number;
+      selectedIndices?: number[];
+      customText?: string;
+    },
+  ): Promise<Comment> {
+    return this.fetch(`/api/comments/${commentId}/answer`, {
+      method: "POST",
+      body: JSON.stringify({
+        state,
+        ...(selection?.selectedIndex !== undefined ? { selected_index: selection.selectedIndex } : {}),
+        ...(selection?.selectedIndices !== undefined ? { selected_indices: selection.selectedIndices } : {}),
+        ...(selection?.customText !== undefined ? { custom_text: selection.customText } : {}),
+      }),
+    });
+  }
+
   async addReaction(commentId: string, emoji: string): Promise<Reaction> {
     return this.fetch(`/api/comments/${commentId}/reactions`, {
       method: "POST",

--- a/packages/core/api/schemas.test.ts
+++ b/packages/core/api/schemas.test.ts
@@ -1107,3 +1107,129 @@ describe("RuntimeModelListRequestSchema", () => {
     );
   });
 });
+
+describe("ask_user_question metadata schema drift", () => {
+  const base = {
+    type: "comment",
+    id: "c1",
+    actor_type: "agent",
+    actor_id: "a1",
+    created_at: "2026-01-01T00:00:00Z",
+    comment_type: "ask_user_question",
+  };
+
+  it("parses a well-formed ask_user_question metadata payload", () => {
+    const parsed = TimelineEntriesSchema.parse([
+      {
+        ...base,
+        metadata: {
+          ask_user_question: {
+            target_user: "u1",
+            source_user: "a1",
+            question: "Which cache?",
+            options: [
+              { label: "Redis", description: "distributed" },
+              { label: "Local", description: "single-node" },
+            ],
+            answer: { state: "submitted", selected_index: 0, answered_at: "2026-01-01T01:00:00Z" },
+          },
+        },
+      },
+    ]);
+    const aq = parsed[0]?.metadata?.ask_user_question;
+    expect(aq?.question).toBe("Which cache?");
+    expect(aq?.options).toHaveLength(2);
+    expect(aq?.answer?.selected_index).toBe(0);
+  });
+
+  it("downgrades gracefully when metadata is missing (ordinary comment)", () => {
+    const parsed = TimelineEntriesSchema.parse([{ ...base, comment_type: "comment" }]);
+    expect(parsed[0]?.metadata).toBeUndefined();
+  });
+
+  it("does not throw when options is null and defaults it to []", () => {
+    const parsed = TimelineEntriesSchema.parse([
+      {
+        ...base,
+        metadata: {
+          ask_user_question: {
+            target_user: "u1",
+            question: "Q?",
+            options: null,
+          },
+        },
+      },
+    ]);
+    expect(parsed[0]?.metadata?.ask_user_question?.options).toEqual([]);
+  });
+
+  it("does not throw on a partial option missing description", () => {
+    const parsed = TimelineEntriesSchema.parse([
+      {
+        ...base,
+        metadata: {
+          ask_user_question: {
+            target_user: "u1",
+            question: "Q?",
+            options: [{ label: "only-label" }],
+          },
+        },
+      },
+    ]);
+    const opt = parsed[0]?.metadata?.ask_user_question?.options?.[0];
+    expect(opt?.label).toBe("only-label");
+    expect(opt?.description).toBe("");
+  });
+});
+
+describe("ask_user_question multi-select + custom fields", () => {
+  const base = {
+    type: "comment", id: "c1", actor_type: "agent", actor_id: "a1",
+    created_at: "2026-01-01T00:00:00Z", comment_type: "ask_user_question",
+  };
+
+  it("parses multi_select / allow_custom + selected_indices + custom_text", () => {
+    const parsed = TimelineEntriesSchema.parse([
+      {
+        ...base,
+        metadata: {
+          ask_user_question: {
+            target_user: "u1", source_user: "a1", question: "Q?",
+            options: [{ label: "A", description: "a" }, { label: "B", description: "b" }],
+            multi_select: true,
+            allow_custom: true,
+            answer: {
+              state: "submitted",
+              selected_indices: [0, 1],
+              custom_text: "mine",
+              answered_at: "2026-01-01T01:00:00Z",
+            },
+          },
+        },
+      },
+    ]);
+    const aq = parsed[0]?.metadata?.ask_user_question;
+    expect(aq?.multi_select).toBe(true);
+    expect(aq?.allow_custom).toBe(true);
+    expect(aq?.answer?.selected_indices).toEqual([0, 1]);
+    expect(aq?.answer?.custom_text).toBe("mine");
+  });
+
+  it("defaults multi_select / allow_custom to undefined when absent (legacy single)", () => {
+    const parsed = TimelineEntriesSchema.parse([
+      {
+        ...base,
+        metadata: {
+          ask_user_question: {
+            target_user: "u1", question: "Q?",
+            options: [{ label: "A", description: "a" }],
+            answer: { state: "submitted", selected_index: 0, answered_at: "x" },
+          },
+        },
+      },
+    ]);
+    const aq = parsed[0]?.metadata?.ask_user_question;
+    expect(aq?.multi_select).toBeUndefined();
+    expect(aq?.answer?.selected_index).toBe(0);
+  });
+});

--- a/packages/core/api/schemas.ts
+++ b/packages/core/api/schemas.ts
@@ -404,6 +404,42 @@ const AttachmentSchema = z.object({
   id: z.string(),
 }).loose();
 
+// ask_user_question payload carried on comment.metadata. Lenient on shape
+// (.loose + optional) so a malformed or partial payload from a drifted server
+// downgrades gracefully instead of crashing the timeline parse — the render
+// layer nil-guards every field.
+const AskUserQuestionOptionSchema = z.object({
+  label: z.string().default(""),
+  description: z.string().default(""),
+}).loose();
+
+const CommentMetadataSchema = z.object({
+  ask_user_question: z.object({
+    target_user: z.string().default(""),
+    source_user: z.string().default(""),
+    question: z.string().default(""),
+    // Coerce null/undefined → [] so a drifted server sending options:null
+    // degrades to an empty list instead of throwing the whole timeline parse.
+    options: z.preprocess(
+      (v) => (Array.isArray(v) ? v : []),
+      z.array(AskUserQuestionOptionSchema).default([]),
+    ),
+    multi_select: z.boolean().optional(),
+    allow_custom: z.boolean().optional(),
+    answer: z
+      .object({
+        state: z.string().default(""),
+        selected_index: z.number().optional(),
+        selected_indices: z.array(z.number()).optional(),
+        custom_text: z.string().optional(),
+        answered_at: z.string().default(""),
+      })
+      .loose()
+      .nullable()
+      .optional(),
+  }).loose().optional(),
+}).loose();
+
 const ChatQuickActionSchema = z.object({
   label: z.string(),
   prompt: z.string(),
@@ -498,6 +534,7 @@ const TimelineEntrySchema = z.object({
   parent_id: z.string().nullable().optional(),
   updated_at: z.string().optional(),
   comment_type: z.string().optional(),
+  metadata: CommentMetadataSchema.nullable().optional(),
   reactions: z.array(ReactionSchema).optional(),
   attachments: z.array(AttachmentSchema).optional(),
   source_task_id: z.string().nullable().optional(),
@@ -588,6 +625,7 @@ export const CommentSchema = z.object({
   content: z.string(),
   type: z.string(),
   parent_id: z.string().nullable(),
+  metadata: CommentMetadataSchema.nullable().optional(),
   reactions: z.array(ReactionSchema).default([]),
   attachments: z.array(AttachmentSchema).default([]),
   created_at: z.string(),

--- a/packages/core/issues/mutations.ts
+++ b/packages/core/issues/mutations.ts
@@ -1155,3 +1155,32 @@ export function useUnsubscribeFromIssueSubtree(issueId: string) {
     },
   });
 }
+
+// ---------------------------------------------------------------------------
+// ask_user_question answers
+// ---------------------------------------------------------------------------
+
+export interface AnswerAskUserQuestionVars {
+  commentId: string;
+  state: "submitted" | "ignored";
+  selectedIndex?: number;
+  selectedIndices?: number[];
+  customText?: string;
+}
+
+/** Records the target user's answer to an ask_user_question comment. The
+ *  server updates the comment in place and (on submit) posts a reply that
+ *  re-triggers the source agent; the resulting comment:updated / comment:created
+ *  WS events refresh the timeline, so this only invalidates on settle as a
+ *  fallback. */
+export function useAnswerAskUserQuestion(issueId: string) {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationKey: ["answerAskUserQuestion", issueId] as const,
+    mutationFn: ({ commentId, state, selectedIndex, selectedIndices, customText }: AnswerAskUserQuestionVars) =>
+      api.answerAskUserQuestion(commentId, state, { selectedIndex, selectedIndices, customText }),
+    onSettled: () => {
+      qc.invalidateQueries({ queryKey: issueKeys.timeline(issueId) });
+    },
+  });
+}

--- a/packages/core/types/activity.ts
+++ b/packages/core/types/activity.ts
@@ -1,4 +1,4 @@
-import type { CommentAuthorType, Reaction } from "./comment";
+import type { CommentAuthorType, CommentMetadata, Reaction } from "./comment";
 import type { Attachment } from "./attachment";
 
 export interface AssigneeFrequencyEntry {
@@ -21,6 +21,9 @@ export interface TimelineEntry {
   parent_id?: string | null;
   updated_at?: string;
   comment_type?: string;
+  /** Structured payload for typed comments (currently ask_user_question).
+   *  Omitted for ordinary comments and activities. */
+  metadata?: CommentMetadata | null;
   /** Set only on comments a quick action produced (MUL-5465). Unforgeable. */
   quick_action_id?: string | null;
   reactions?: Reaction[];

--- a/packages/core/types/comment.ts
+++ b/packages/core/types/comment.ts
@@ -1,9 +1,48 @@
-export type CommentType = "comment" | "status_change" | "progress_update" | "system";
+export type CommentType = "comment" | "status_change" | "progress_update" | "system" | "ask_user_question";
 
 // `system` is used by platform-generated rows (e.g. the parent-issue
 // child-done notification, MUL-2538). System rows carry a zero UUID for
 // author_id; render paths should branch on author_type rather than the UUID.
 export type CommentAuthorType = "member" | "agent" | "system";
+
+/** One selectable choice in an ask_user_question comment. `label` is the short
+ *  headline (rendered on top), `description` the longer explanation (below). */
+export interface AskUserQuestionOption {
+  label: string;
+  description: string;
+}
+
+/** Written once the target user responds. Absent until then. Selection is
+ *  recorded per mode: `selected_index` (single, also legacy rows),
+ *  `selected_indices` (multi), `custom_text` (the auto "Other" free-text). */
+export interface AskUserQuestionAnswer {
+  state: "submitted" | "ignored";
+  selected_index?: number;
+  selected_indices?: number[];
+  custom_text?: string;
+  answered_at: string;
+}
+
+/** Structured payload for an ask_user_question comment, stored under
+ *  comment.metadata.ask_user_question. */
+export interface AskUserQuestionMeta {
+  /** user_id of the human being asked; only this user may answer. */
+  target_user: string;
+  /** agent id that asked (= comment author); the confirmation reply @mentions it. */
+  source_user: string;
+  question: string;
+  options: AskUserQuestionOption[];
+  /** Allow picking multiple options (checkbox). Default false = single (radio). */
+  multi_select?: boolean;
+  /** Append an auto "Other" choice with a free-text input. Default false. */
+  allow_custom?: boolean;
+  answer?: AskUserQuestionAnswer | null;
+}
+
+/** Decoded comment.metadata. Only ask_user_question is modeled today. */
+export interface CommentMetadata {
+  ask_user_question?: AskUserQuestionMeta;
+}
 
 export interface Reaction {
   id: string;
@@ -22,6 +61,7 @@ export interface Comment {
   content: string;
   type: CommentType;
   parent_id: string | null;
+  metadata?: CommentMetadata | null;
   reactions: Reaction[];
   attachments: import("./attachment").Attachment[];
   created_at: string;

--- a/packages/core/types/index.ts
+++ b/packages/core/types/index.ts
@@ -83,7 +83,7 @@ export { RUNTIME_PROFILE_PROTOCOL_FAMILIES } from "./agent";
 export type { Workspace, WorkspaceRepo, Member, MemberRole, User, MemberWithUser, Invitation } from "./workspace";
 export type { InboxItem, InboxSeverity, InboxItemType, InboxWorkspaceUnread } from "./inbox";
 export type { NotificationGroupKey, NotificationGroupValue, NotificationPreferences, NotificationPreferenceResponse } from "./notification-preference";
-export type { Comment, CommentType, CommentAuthorType, CommentTriggerPreview, CommentTriggerPreviewAgent, CommentTriggerSource, CommentTriggerOutcome, CommentTriggerStatus, Reaction } from "./comment";
+export type { Comment, CommentType, CommentAuthorType, CommentMetadata, AskUserQuestionMeta, AskUserQuestionOption, AskUserQuestionAnswer, CommentTriggerPreview, CommentTriggerPreviewAgent, CommentTriggerSource, CommentTriggerOutcome, CommentTriggerStatus, Reaction } from "./comment";
 export type { Label, LabelResourceType, CreateLabelRequest, UpdateLabelRequest, ListLabelsResponse, IssueLabelsResponse, ResourceLabelsResponse } from "./label";
 export type { IssueProperty, IssuePropertyType, IssuePropertyOption, IssuePropertyConfig, IssuePropertyValue, IssuePropertyValues, CreatePropertyRequest, UpdatePropertyRequest, ListPropertiesResponse, IssuePropertiesResponse } from "./property";
 export { ISSUE_PROPERTY_TYPES, isKnownPropertyType } from "./property";

--- a/packages/views/issues/components/ask-user-question-card.test.tsx
+++ b/packages/views/issues/components/ask-user-question-card.test.tsx
@@ -1,0 +1,181 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import type { ReactElement } from "react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { I18nProvider } from "@multica/core/i18n/react";
+import type { AskUserQuestionMeta } from "@multica/core/types";
+import enIssues from "../../locales/en/issues.json";
+
+const TEST_RESOURCES = { en: { issues: enIssues } };
+
+const { mutateMock } = vi.hoisted(() => ({ mutateMock: vi.fn() }));
+
+vi.mock("@multica/core/issues/mutations", () => ({
+  useAnswerAskUserQuestion: () => ({ mutate: mutateMock, isPending: false }),
+}));
+
+vi.mock("@multica/core/workspace/hooks", () => ({
+  useActorName: () => ({
+    getActorName: (_type: string, id: string) => (id === "u-target" ? "Alice" : id),
+  }),
+}));
+
+import { AskUserQuestionCard } from "./ask-user-question-card";
+
+function meta(overrides: Partial<AskUserQuestionMeta> = {}): AskUserQuestionMeta {
+  return {
+    target_user: "u-target",
+    source_user: "a-agent",
+    question: "Which cache?",
+    options: [
+      { label: "Redis", description: "distributed" },
+      { label: "Local", description: "single-node" },
+    ],
+    answer: null,
+    ...overrides,
+  };
+}
+
+function renderCard(ui: ReactElement) {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false, gcTime: 0 } } });
+  return render(
+    <I18nProvider locale="en" resources={TEST_RESOURCES}>
+      <QueryClientProvider client={qc}>{ui}</QueryClientProvider>
+    </I18nProvider>,
+  );
+}
+
+beforeEach(() => vi.clearAllMocks());
+afterEach(() => vi.restoreAllMocks());
+
+describe("AskUserQuestionCard", () => {
+  it("shows Confirm/Ignore for the target user and submits the selected option", () => {
+    renderCard(
+      <AskUserQuestionCard
+        issueId="i1"
+        commentId="c1"
+        meta={meta()}
+        currentUserId="u-target"
+      />,
+    );
+    // Question + both option labels render.
+    expect(screen.getByText("Which cache?")).toBeTruthy();
+    expect(screen.getByText("Redis")).toBeTruthy();
+    expect(screen.getByText("Local")).toBeTruthy();
+
+    // Confirm is disabled until a selection is made.
+    const confirm = screen.getByText("Confirm").closest("button")!;
+    expect(confirm.disabled).toBe(true);
+
+    // Select the second option, then confirm.
+    fireEvent.click(screen.getByText("Local"));
+    fireEvent.click(screen.getByText("Confirm").closest("button")!);
+    expect(mutateMock).toHaveBeenCalledTimes(1);
+    expect(mutateMock.mock.calls[0]![0]).toMatchObject({
+      commentId: "c1",
+      state: "submitted",
+      selectedIndex: 1,
+    });
+  });
+
+  it("ignores without a selection", () => {
+    renderCard(
+      <AskUserQuestionCard issueId="i1" commentId="c1" meta={meta()} currentUserId="u-target" />,
+    );
+    fireEvent.click(screen.getByText("Ignore").closest("button")!);
+    expect(mutateMock.mock.calls[0]![0]).toMatchObject({ commentId: "c1", state: "ignored" });
+  });
+
+  it("is read-only for a non-target user (no action buttons)", () => {
+    renderCard(
+      <AskUserQuestionCard issueId="i1" commentId="c1" meta={meta()} currentUserId="someone-else" />,
+    );
+    expect(screen.queryByText("Confirm")).toBeNull();
+    expect(screen.queryByText("Ignore")).toBeNull();
+    // Question still visible in read-only mode.
+    expect(screen.getByText("Which cache?")).toBeTruthy();
+  });
+
+  it("renders the terminal 'Selected' chip and no buttons once submitted", () => {
+    renderCard(
+      <AskUserQuestionCard
+        issueId="i1"
+        commentId="c1"
+        meta={meta({ answer: { state: "submitted", selected_index: 0, answered_at: "2026-01-01T00:00:00Z" } })}
+        currentUserId="u-target"
+      />,
+    );
+    expect(screen.getByText("Selected")).toBeTruthy();
+    expect(screen.queryByText("Confirm")).toBeNull();
+    expect(screen.queryByText("Ignore")).toBeNull();
+  });
+
+  it("renders the terminal 'Ignored' chip once ignored", () => {
+    renderCard(
+      <AskUserQuestionCard
+        issueId="i1"
+        commentId="c1"
+        meta={meta({ answer: { state: "ignored", answered_at: "2026-01-01T00:00:00Z" } })}
+        currentUserId="u-target"
+      />,
+    );
+    expect(screen.getByText("Ignored")).toBeTruthy();
+    expect(screen.queryByText("Confirm")).toBeNull();
+  });
+  it("multi-select: checks several options and submits selectedIndices", () => {
+    renderCard(
+      <AskUserQuestionCard
+        issueId="i1"
+        commentId="c1"
+        meta={meta({ multi_select: true })}
+        currentUserId="u-target"
+      />,
+    );
+    fireEvent.click(screen.getByText("Redis"));
+    fireEvent.click(screen.getByText("Local"));
+    fireEvent.click(screen.getByText("Confirm").closest("button")!);
+    expect(mutateMock.mock.calls[0]![0]).toMatchObject({
+      commentId: "c1",
+      state: "submitted",
+      selectedIndices: [0, 1],
+    });
+  });
+
+  it("allow_custom: picking Other reveals input and submits customText", () => {
+    renderCard(
+      <AskUserQuestionCard
+        issueId="i1"
+        commentId="c1"
+        meta={meta({ allow_custom: true })}
+        currentUserId="u-target"
+      />,
+    );
+    // "Other" row present; selecting it reveals the text input.
+    fireEvent.click(screen.getByText("Other"));
+    const input = document.querySelector('input[type="text"]') as HTMLInputElement;
+    expect(input).toBeTruthy();
+    fireEvent.change(input, { target: { value: "my custom answer" } });
+    fireEvent.click(screen.getByText("Confirm").closest("button")!);
+    expect(mutateMock.mock.calls[0]![0]).toMatchObject({
+      commentId: "c1",
+      state: "submitted",
+      customText: "my custom answer",
+    });
+  });
+
+  it("multi-select terminal: shows all chosen labels ticked", () => {
+    renderCard(
+      <AskUserQuestionCard
+        issueId="i1"
+        commentId="c1"
+        meta={meta({
+          multi_select: true,
+          answer: { state: "submitted", selected_indices: [0, 1], answered_at: "2026-01-01T00:00:00Z" },
+        })}
+        currentUserId="u-target"
+      />,
+    );
+    expect(screen.getByText("Selected")).toBeTruthy();
+    expect(screen.queryByText("Confirm")).toBeNull();
+  });
+});

--- a/packages/views/issues/components/ask-user-question-card.tsx
+++ b/packages/views/issues/components/ask-user-question-card.tsx
@@ -1,0 +1,343 @@
+"use client";
+
+import { memo, useState } from "react";
+import { CheckCircle2, XCircle } from "lucide-react";
+import { toast } from "sonner";
+import { RadioGroup, RadioGroupItem } from "@multica/ui/components/ui/radio-group";
+import { Checkbox } from "@multica/ui/components/ui/checkbox";
+import { Button } from "@multica/ui/components/ui/button";
+import { cn } from "@multica/ui/lib/utils";
+import { useActorName } from "@multica/core/workspace/hooks";
+import { useAnswerAskUserQuestion } from "@multica/core/issues/mutations";
+import type { AskUserQuestionMeta } from "@multica/core/types";
+import { useT } from "../../i18n";
+
+interface AskUserQuestionCardProps {
+  issueId: string;
+  commentId: string;
+  meta: AskUserQuestionMeta;
+  /** user_id of the currently signed-in member (undefined for agents). */
+  currentUserId?: string;
+  className?: string;
+}
+
+/**
+ * Renders an ask_user_question comment as the fixed four-layer card:
+ *   1. @target_user prompt line
+ *   2. the question text
+ *   3. an option list — radio (single) or checkbox (multi_select); when
+ *      allow_custom is on, an auto "Other" row reveals a free-text input
+ *   4. Confirm / Ignore buttons (or a terminal "Selected" / "Ignored" chip)
+ *
+ * Only the target_user may act; everyone else sees a read-only view. Once the
+ * answer is recorded (via the answer endpoint → comment:updated WS event), the
+ * card re-renders in its terminal state: options greyed, chosen ones ticked,
+ * custom text shown, and the buttons replaced by a disabled chip.
+ */
+function AskUserQuestionCardImpl({
+  issueId,
+  commentId,
+  meta,
+  currentUserId,
+  className,
+}: AskUserQuestionCardProps) {
+  const { t } = useT("issues");
+  const { getActorName } = useActorName();
+  const answer = useAnswerAskUserQuestion(issueId);
+
+  const options = meta.options ?? [];
+  const multi = meta.multi_select === true;
+  const allowCustom = meta.allow_custom === true;
+  const existingAnswer = meta.answer ?? null;
+  const isAnswered = existingAnswer != null;
+  const isSubmitted = existingAnswer?.state === "submitted";
+  const isIgnored = existingAnswer?.state === "ignored";
+
+  // Only the target user may interact, and only while unanswered.
+  const canAct = !isAnswered && !!currentUserId && currentUserId === meta.target_user;
+
+  // Live selection state (pre-submit). Multi uses a Set; single uses one index.
+  const [selectedSet, setSelectedSet] = useState<Set<number>>(new Set());
+  const [singleSel, setSingleSel] = useState<number | null>(null);
+  const [customChecked, setCustomChecked] = useState(false);
+  const [customText, setCustomText] = useState("");
+
+  const targetName = getActorName("member", meta.target_user);
+
+  // --- Answered (terminal) selection, for greying + tick rendering ---
+  const answeredIdxSet = new Set<number>([
+    ...(existingAnswer?.selected_index != null ? [existingAnswer.selected_index] : []),
+    ...(existingAnswer?.selected_indices ?? []),
+  ]);
+  const answeredCustom = existingAnswer?.custom_text ?? "";
+
+  const isOptionChecked = (i: number): boolean => {
+    if (isSubmitted) return answeredIdxSet.has(i);
+    return multi ? selectedSet.has(i) : singleSel === i;
+  };
+
+  const toggleOption = (i: number) => {
+    if (!canAct) return;
+    if (multi) {
+      setSelectedSet((prev) => {
+        const next = new Set(prev);
+        if (next.has(i)) next.delete(i);
+        else next.add(i);
+        return next;
+      });
+    } else {
+      setSingleSel(i);
+      // Single-select: picking a real option clears the custom choice.
+      setCustomChecked(false);
+    }
+  };
+
+  const toggleCustom = () => {
+    if (!canAct) return;
+    if (multi) {
+      setCustomChecked((v) => !v);
+    } else {
+      // Single-select "Other": mutually exclusive with option choice.
+      setCustomChecked(true);
+      setSingleSel(null);
+    }
+  };
+
+  // Whether the current live selection is submittable.
+  const hasSelection =
+    (multi ? selectedSet.size > 0 : singleSel != null) ||
+    (allowCustom && customChecked && customText.trim() !== "");
+
+  const submit = () => {
+    if (!hasSelection) return;
+    const vars: {
+      commentId: string;
+      state: "submitted";
+      selectedIndex?: number;
+      selectedIndices?: number[];
+      customText?: string;
+    } = { commentId, state: "submitted" };
+
+    if (multi) {
+      vars.selectedIndices = [...selectedSet].sort((a, b) => a - b);
+    } else if (singleSel != null) {
+      vars.selectedIndex = singleSel;
+    }
+    if (allowCustom && customChecked && customText.trim() !== "") {
+      vars.customText = customText.trim();
+    }
+
+    answer.mutate(vars, {
+      onError: (err) =>
+        toast.error(
+          err instanceof Error && err.message
+            ? err.message
+            : t(($) => $.ask_user_question.submit_failed),
+        ),
+    });
+  };
+
+  const ignore = () => {
+    answer.mutate(
+      { commentId, state: "ignored" },
+      {
+        onError: (err) =>
+          toast.error(
+            err instanceof Error && err.message
+              ? err.message
+              : t(($) => $.ask_user_question.ignore_failed),
+          ),
+      },
+    );
+  };
+
+  // Shared row renderer for a preset option (radio or checkbox control).
+  const renderOptionRow = (i: number) => {
+    const opt = options[i]!;
+    const checked = isOptionChecked(i);
+    const dimmed = isSubmitted && !checked;
+    const id = `${commentId}-opt-${i}`;
+    return (
+      <div
+        key={id}
+        role="button"
+        tabIndex={canAct ? 0 : -1}
+        onClick={() => toggleOption(i)}
+        onKeyDown={(e) => {
+          if (canAct && (e.key === "Enter" || e.key === " ")) {
+            e.preventDefault();
+            toggleOption(i);
+          }
+        }}
+        className={cn(
+          "flex items-start gap-2 rounded-md border border-border/60 bg-background px-2.5 py-2 outline-none",
+          canAct && "cursor-pointer hover:bg-muted/50 focus-visible:ring-2 focus-visible:ring-ring",
+          dimmed && "opacity-50",
+        )}
+      >
+        {multi ? (
+          <Checkbox checked={checked} disabled={!canAct} className="mt-0.5 pointer-events-none" />
+        ) : (
+          <RadioGroupItem id={id} value={String(i)} className="mt-0.5 pointer-events-none" />
+        )}
+        <div className="min-w-0 flex-1">
+          <div className="text-body font-medium leading-snug">{opt.label}</div>
+          <div className="text-caption text-muted-foreground leading-snug">{opt.description}</div>
+        </div>
+      </div>
+    );
+  };
+
+  // The "Other" custom row (only when allow_custom).
+  const customIsChecked = isSubmitted ? answeredCustom !== "" : customChecked;
+  const renderCustomRow = () => {
+    const dimmed = isSubmitted && !customIsChecked;
+    return (
+      <div
+        className={cn(
+          "rounded-md border border-border/60 bg-background px-2.5 py-2",
+          dimmed && "opacity-50",
+        )}
+      >
+        <div
+          role="button"
+          tabIndex={canAct ? 0 : -1}
+          onClick={toggleCustom}
+          onKeyDown={(e) => {
+            if (canAct && (e.key === "Enter" || e.key === " ")) {
+              e.preventDefault();
+              toggleCustom();
+            }
+          }}
+          className={cn(
+            "flex items-start gap-2 outline-none",
+            canAct && "cursor-pointer focus-visible:ring-2 focus-visible:ring-ring",
+          )}
+        >
+          {multi ? (
+            <Checkbox checked={customIsChecked} disabled={!canAct} className="mt-0.5 pointer-events-none" />
+          ) : (
+            <RadioGroupItem
+              id={`${commentId}-opt-custom`}
+              value="__custom__"
+              className="mt-0.5 pointer-events-none"
+            />
+          )}
+          <div className="min-w-0 flex-1 text-body font-medium leading-snug">
+            {t(($) => $.ask_user_question.other)}
+          </div>
+        </div>
+        {/* Submitted terminal: show the stored text. Editing: show the input. */}
+        {isSubmitted && answeredCustom !== "" && (
+          <div className="mt-1.5 pl-6 text-body text-muted-foreground">{answeredCustom}</div>
+        )}
+        {canAct && customChecked && (
+          <div className="mt-1.5 pl-6">
+            {/* Plain <input> (not the Base UI <Input>): this is a simple free-text
+                field with no Field integration, and Base UI's input event wrapping
+                swallows synthetic change events (breaks tests + programmatic fills). */}
+            <input
+              type="text"
+              value={customText}
+              onChange={(e) => setCustomText(e.target.value)}
+              placeholder={t(($) => $.ask_user_question.custom_placeholder)}
+              onClick={(e) => e.stopPropagation()}
+              className="h-8 w-full rounded-md border border-input bg-background px-2.5 text-body outline-none focus-visible:border-ring focus-visible:ring-2 focus-visible:ring-ring/50"
+            />
+          </div>
+        )}
+      </div>
+    );
+  };
+
+  const optionList = (
+    <div className="mt-3 space-y-2">
+      {options.map((_, i) => renderOptionRow(i))}
+      {allowCustom && renderCustomRow()}
+    </div>
+  );
+
+  return (
+    <div className={cn("rounded-md border border-border bg-muted/30 p-3", className)}>
+      {/* Layer 1 — @target prompt */}
+      <p className="text-body">
+        <span className="font-semibold text-primary">@{targetName}</span>
+        {t(($) => $.ask_user_question.prompt)}
+        {multi && (
+          <span className="ml-1 text-caption text-muted-foreground">
+            {t(($) => $.ask_user_question.multi_hint)}
+          </span>
+        )}
+      </p>
+
+      {/* Layer 2 — question */}
+      <p className="mt-2 text-body font-medium text-foreground">{meta.question}</p>
+
+      {/* Layer 3 — options. Radio needs the RadioGroup wrapper; checkbox does not.
+          The RadioGroup is kept always-controlled with a stable string value
+          ("" when nothing is picked) to avoid Base UI's uncontrolled→controlled
+          warning. Actual tick state is driven by isOptionChecked per row, so the
+          value here only needs to be a consistent non-undefined string. */}
+      {multi ? (
+        optionList
+      ) : (
+        <RadioGroup
+          value={
+            (isSubmitted
+              ? existingAnswer?.selected_index != null
+                ? String(existingAnswer.selected_index)
+                : answeredCustom !== ""
+                  ? "__custom__"
+                  : ""
+              : customChecked
+                ? "__custom__"
+                : singleSel != null
+                  ? String(singleSel)
+                  : "")
+          }
+          disabled={!canAct}
+        >
+          {optionList}
+        </RadioGroup>
+      )}
+
+      {/* Layer 4 — actions / terminal state */}
+      <div className="mt-3 flex items-center gap-2">
+        {isSubmitted && (
+          <span className="inline-flex items-center gap-1 rounded-md bg-muted px-2.5 py-1 text-caption font-medium text-muted-foreground">
+            <CheckCircle2 className="size-3.5" />
+            {t(($) => $.ask_user_question.submitted)}
+          </span>
+        )}
+        {isIgnored && (
+          <span className="inline-flex items-center gap-1 rounded-md bg-muted px-2.5 py-1 text-caption font-medium text-muted-foreground">
+            <XCircle className="size-3.5" />
+            {t(($) => $.ask_user_question.ignored)}
+          </span>
+        )}
+        {canAct && (
+          <>
+            <Button
+              size="sm"
+              variant="outline"
+              disabled={!hasSelection || answer.isPending}
+              onClick={submit}
+            >
+              {t(($) => $.ask_user_question.submit)}
+            </Button>
+            <Button
+              size="sm"
+              variant="ghost"
+              disabled={answer.isPending}
+              onClick={ignore}
+            >
+              {t(($) => $.ask_user_question.ignore)}
+            </Button>
+          </>
+        )}
+      </div>
+    </div>
+  );
+}
+
+export const AskUserQuestionCard = memo(AskUserQuestionCardImpl);

--- a/packages/views/issues/components/comment-card.tsx
+++ b/packages/views/issues/components/comment-card.tsx
@@ -35,6 +35,7 @@ import { FileUploadButton } from "@multica/ui/components/common/file-upload-butt
 import { api, dispatchReasonCode } from "@multica/core/api";
 import { ReplyInput } from "./reply-input";
 import { CommentTriggerChips } from "./comment-trigger-chips";
+import { AskUserQuestionCard } from "./ask-user-question-card";
 import { useCommentTriggerPreview } from "../hooks/use-comment-trigger-preview";
 import type { TimelineEntry, Attachment } from "@multica/core/types";
 import { contentReferencesAttachment } from "@multica/core/types";
@@ -725,10 +726,23 @@ function CommentRow({
         </div>
       ) : (
         <>
-          <div className="pl-12 pr-4 pt-1 text-body leading-relaxed text-foreground">
-            <ReadonlyContent content={entry.content ?? ""} attachments={entry.attachments} />
-          </div>
-          <AttachmentList attachments={entry.attachments} content={entry.content} className="mt-1.5 pl-12 pr-4" />
+          {entry.comment_type === "ask_user_question" && entry.metadata?.ask_user_question ? (
+            <div className="mt-1.5 pl-12 pr-4">
+              <AskUserQuestionCard
+                issueId={issueId}
+                commentId={entry.id}
+                meta={entry.metadata.ask_user_question}
+                currentUserId={currentUserId}
+              />
+            </div>
+          ) : (
+            <>
+              <div className="pl-12 pr-4 pt-1 text-body leading-relaxed text-foreground">
+                <ReadonlyContent content={entry.content ?? ""} attachments={entry.attachments} />
+              </div>
+              <AttachmentList attachments={entry.attachments} content={entry.content} className="mt-1.5 pl-12 pr-4" />
+            </>
+          )}
           {retryableAgentFailureComment(entry) && (
             <TaskCommentRetryButton
               issueId={issueId}
@@ -1041,10 +1055,23 @@ function CommentCardImpl({
               </div>
             ) : (
               <>
-                <div className="pl-10 text-body leading-relaxed text-foreground">
-                  <ReadonlyContent content={entry.content ?? ""} attachments={entry.attachments} />
-                </div>
-                <AttachmentList attachments={entry.attachments} content={entry.content} className="mt-1.5 pl-10" />
+                {entry.comment_type === "ask_user_question" && entry.metadata?.ask_user_question ? (
+                  <div className="mt-1.5 pl-10">
+                    <AskUserQuestionCard
+                      issueId={issueId}
+                      commentId={entry.id}
+                      meta={entry.metadata.ask_user_question}
+                      currentUserId={currentUserId}
+                    />
+                  </div>
+                ) : (
+                  <>
+                    <div className="pl-10 text-body leading-relaxed text-foreground">
+                      <ReadonlyContent content={entry.content ?? ""} attachments={entry.attachments} />
+                    </div>
+                    <AttachmentList attachments={entry.attachments} content={entry.content} className="mt-1.5 pl-10" />
+                  </>
+                )}
                 {retryableAgentFailureComment(entry) && (
                   <TaskCommentRetryButton
                     issueId={issueId}

--- a/packages/views/locales/en/issues.json
+++ b/packages/views/locales/en/issues.json
@@ -653,5 +653,17 @@
     "row_backlog_hint": "keeps the agent paused",
     "row_todo_label": "Todo",
     "row_todo_hint": "starts the agent"
+  },
+  "ask_user_question": {
+    "prompt": "Please make a selection for the question below:",
+    "submit": "Confirm",
+    "ignore": "Ignore",
+    "submitted": "Selected",
+    "ignored": "Ignored",
+    "submit_failed": "Failed to submit selection",
+    "ignore_failed": "Failed to ignore",
+    "other": "Other",
+    "custom_placeholder": "Enter your answer…",
+    "multi_hint": "(multiple choice)"
   }
 }

--- a/packages/views/locales/ja/issues.json
+++ b/packages/views/locales/ja/issues.json
@@ -628,5 +628,17 @@
     "row_backlog_hint": "エージェントを一時停止のままにします",
     "row_todo_label": "未着手",
     "row_todo_hint": "エージェントを開始します"
+  },
+  "ask_user_question": {
+    "prompt": "以下の質問について選択してください:",
+    "submit": "確認",
+    "ignore": "無視",
+    "submitted": "選択済み",
+    "ignored": "無視しました",
+    "submit_failed": "選択の送信に失敗しました",
+    "ignore_failed": "無視に失敗しました",
+    "other": "その他",
+    "custom_placeholder": "回答を入力…",
+    "multi_hint": "(複数選択可)"
   }
 }

--- a/packages/views/locales/ko/issues.json
+++ b/packages/views/locales/ko/issues.json
@@ -628,5 +628,17 @@
     "row_backlog_hint": "에이전트를 대기 상태로 유지",
     "row_todo_label": "할 일",
     "row_todo_hint": "에이전트 시작"
+  },
+  "ask_user_question": {
+    "prompt": "아래 질문에 대해 선택해 주세요:",
+    "submit": "확인",
+    "ignore": "무시",
+    "submitted": "선택됨",
+    "ignored": "무시함",
+    "submit_failed": "선택 제출에 실패했습니다",
+    "ignore_failed": "무시에 실패했습니다",
+    "other": "기타",
+    "custom_placeholder": "답변을 입력하세요…",
+    "multi_hint": "(복수 선택 가능)"
   }
 }

--- a/packages/views/locales/zh-Hans/issues.json
+++ b/packages/views/locales/zh-Hans/issues.json
@@ -628,5 +628,17 @@
     "row_backlog_hint": "智能体保持暂停",
     "row_todo_label": "Todo",
     "row_todo_hint": "启动智能体"
+  },
+  "ask_user_question": {
+    "prompt": "以下问题请做选择:",
+    "submit": "确认提交",
+    "ignore": "忽略",
+    "submitted": "已选择",
+    "ignored": "已忽略",
+    "submit_failed": "提交选择失败",
+    "ignore_failed": "忽略失败",
+    "other": "其他",
+    "custom_placeholder": "请输入…",
+    "multi_hint": "(可多选)"
   }
 }

--- a/server/cmd/multica/cmd_issue.go
+++ b/server/cmd/multica/cmd_issue.go
@@ -555,6 +555,17 @@ func init() {
 	issueCommentAddCmd.Flags().StringSlice("attachment", nil, "File path(s) to attach (can be specified multiple times)")
 	issueCommentAddCmd.Flags().String("output", "json", "Output format: table or json")
 
+	// ask_user_question: an agent poses a structured multiple-choice question at
+	// a specific human, rendered as a selectable card. Keep the flag list and
+	// JSON shape in sync with buildAskUserQuestionMeta below and the server
+	// handler validation (comment_ask_user_question.go).
+	issueCommentAddCmd.Flags().String("type", "", "Comment type. Use 'ask_user_question' to post a structured question (requires --target-user, --question, --options-json)")
+	issueCommentAddCmd.Flags().String("target-user", "", "For --type ask_user_question: the human being asked (user UUID, name, or email)")
+	issueCommentAddCmd.Flags().String("question", "", "For --type ask_user_question: the question text shown to the target user")
+	issueCommentAddCmd.Flags().String("options-json", "", "For --type ask_user_question: JSON array of options, e.g. '[{\"label\":\"A\",\"description\":\"...\"}]'")
+	issueCommentAddCmd.Flags().Bool("multi-select", false, "For --type ask_user_question: allow the user to pick multiple options (default single-select)")
+	issueCommentAddCmd.Flags().Bool("allow-custom", false, "For --type ask_user_question: append an 'Other' choice with a free-text input")
+
 	// issue comment resolve/unresolve
 	issueCommentResolveCmd.Flags().String("output", "json", "Output format: table or json")
 	issueCommentUnresolveCmd.Flags().String("output", "json", "Output format: table or json")
@@ -1929,16 +1940,24 @@ func runIssueCommentList(cmd *cobra.Command, args []string) error {
 }
 
 func runIssueCommentAdd(cmd *cobra.Command, args []string) error {
+	commentType, _ := cmd.Flags().GetString("type")
+	isAskUserQuestion := commentType == "ask_user_question"
+
 	content, hasContent, err := resolveTextFlag(cmd, "content")
 	if err != nil {
 		return err
 	}
-	if !hasContent {
+	// For ask_user_question, content is optional — a human-readable fallback is
+	// generated from the question + options below. For every other type content
+	// is required as before.
+	if !hasContent && !isAskUserQuestion {
 		return fmt.Errorf("--content, --content-stdin, or --content-file is required")
 	}
-	if err := guardLocalPathLinks(content, "comment body",
-		"Deliver the file itself with `multica issue comment add <issue-id> --attachment <path>` (repeatable) and drop the link."); err != nil {
-		return err
+	if hasContent {
+		if err := guardLocalPathLinks(content, "comment body",
+			"Deliver the file itself with `multica issue comment add <issue-id> --attachment <path>` (repeatable) and drop the link."); err != nil {
+			return err
+		}
 	}
 
 	client, err := newAPIClient(cmd)
@@ -1961,6 +1980,20 @@ func runIssueCommentAdd(cmd *cobra.Command, args []string) error {
 	}
 	issueID := issueRef.ID
 
+	// Build the ask_user_question metadata + fallback content up front so a bad
+	// payload fails before we upload any attachments.
+	var askMeta map[string]any
+	if isAskUserQuestion {
+		meta, fallback, buildErr := buildAskUserQuestionMeta(ctx, client, cmd)
+		if buildErr != nil {
+			return buildErr
+		}
+		askMeta = meta
+		if !hasContent {
+			content = fallback
+		}
+	}
+
 	// Validate and read ALL attachments before uploading any. URLs are skipped
 	// with a warning — `--attachment` only accepts local file paths. Reading
 	// everything up front means a later invalid path (external / symlink escape
@@ -1982,6 +2015,12 @@ func runIssueCommentAdd(cmd *cobra.Command, args []string) error {
 	}
 
 	body := map[string]any{"content": content}
+	if commentType != "" {
+		body["type"] = commentType
+	}
+	if askMeta != nil {
+		body["metadata"] = askMeta
+	}
 	if parentID, _ := cmd.Flags().GetString("parent"); parentID != "" {
 		body["parent_id"] = parentID
 	}
@@ -2000,6 +2039,122 @@ func runIssueCommentAdd(cmd *cobra.Command, args []string) error {
 		return nil
 	}
 	return cli.PrintJSON(os.Stdout, result)
+}
+
+// askUserQuestionOption mirrors the server's option shape for --options-json.
+type askUserQuestionOption struct {
+	Label       string `json:"label"`
+	Description string `json:"description"`
+}
+
+// buildAskUserQuestionMeta validates the ask_user_question flags and returns the
+// metadata payload (for body["metadata"]) plus a human-readable Markdown
+// fallback used as content when --content is not supplied. source_user is set
+// server-side from the authenticated agent, so it is not included here.
+func buildAskUserQuestionMeta(ctx context.Context, client *cli.APIClient, cmd *cobra.Command) (map[string]any, string, error) {
+	targetInput, _ := cmd.Flags().GetString("target-user")
+	question, _ := cmd.Flags().GetString("question")
+	optionsJSON, _ := cmd.Flags().GetString("options-json")
+
+	if strings.TrimSpace(targetInput) == "" {
+		return nil, "", fmt.Errorf("--target-user is required for --type ask_user_question")
+	}
+	if strings.TrimSpace(question) == "" {
+		return nil, "", fmt.Errorf("--question is required for --type ask_user_question")
+	}
+	if strings.TrimSpace(optionsJSON) == "" {
+		return nil, "", fmt.Errorf("--options-json is required for --type ask_user_question")
+	}
+
+	var options []askUserQuestionOption
+	if err := json.Unmarshal([]byte(optionsJSON), &options); err != nil {
+		return nil, "", fmt.Errorf("invalid --options-json: %w", err)
+	}
+	if len(options) == 0 {
+		return nil, "", fmt.Errorf("--options-json must contain at least one option")
+	}
+	for i, o := range options {
+		if strings.TrimSpace(o.Label) == "" {
+			return nil, "", fmt.Errorf("option %d: label is required", i)
+		}
+		if strings.TrimSpace(o.Description) == "" {
+			return nil, "", fmt.Errorf("option %d: description is required", i)
+		}
+	}
+
+	targetUserID, err := resolveMemberUserID(ctx, client, targetInput)
+	if err != nil {
+		return nil, "", err
+	}
+
+	multiSelect, _ := cmd.Flags().GetBool("multi-select")
+	allowCustom, _ := cmd.Flags().GetBool("allow-custom")
+
+	meta := map[string]any{
+		"ask_user_question": map[string]any{
+			"target_user":  targetUserID,
+			"question":     question,
+			"options":      options,
+			"multi_select": multiSelect,
+			"allow_custom": allowCustom,
+		},
+	}
+
+	// Human-readable fallback so clients that don't understand the type (mobile,
+	// old builds) still show the question and options.
+	var b strings.Builder
+	hint := ""
+	if multiSelect && allowCustom {
+		hint = "(多选,可自定义)"
+	} else if multiSelect {
+		hint = "(多选)"
+	} else if allowCustom {
+		hint = "(可自定义)"
+	}
+	fmt.Fprintf(&b, "**%s**%s\n", question, hint)
+	for _, o := range options {
+		fmt.Fprintf(&b, "- **%s** — %s\n", o.Label, o.Description)
+	}
+	if allowCustom {
+		fmt.Fprintf(&b, "- **其他** — 自定义输入\n")
+	}
+	return meta, b.String(), nil
+}
+
+// resolveMemberUserID resolves a --target-user input (user UUID, name, or email)
+// to a workspace member's user_id. A valid UUID is returned as-is; otherwise the
+// workspace member list is fetched and matched case-insensitively on name/email.
+func resolveMemberUserID(ctx context.Context, client *cli.APIClient, input string) (string, error) {
+	input = strings.TrimSpace(input)
+	if _, err := util.ParseUUID(input); err == nil {
+		return input, nil
+	}
+	if client.WorkspaceID == "" {
+		return "", fmt.Errorf("cannot resolve --target-user %q: no workspace selected", input)
+	}
+	var members []struct {
+		UserID string `json:"user_id"`
+		Name   string `json:"name"`
+		Email  string `json:"email"`
+	}
+	if err := client.GetJSON(ctx, "/api/workspaces/"+url.PathEscape(client.WorkspaceID)+"/members", &members); err != nil {
+		return "", fmt.Errorf("list members to resolve --target-user: %w", err)
+	}
+	lower := strings.ToLower(input)
+	var matches []string
+	for _, m := range members {
+		if strings.ToLower(m.Name) == lower || strings.ToLower(m.Email) == lower {
+			matches = append(matches, m.UserID)
+		}
+	}
+	switch len(matches) {
+	case 0:
+		return "", fmt.Errorf("no workspace member matches --target-user %q", input)
+	case 1:
+		return matches[0], nil
+	default:
+		return "", fmt.Errorf("--target-user %q is ambiguous (%d members match); pass a user UUID instead", input, len(matches))
+	}
 }
 
 func runIssueCommentDelete(cmd *cobra.Command, args []string) error {

--- a/server/cmd/multica/cmd_issue_ask_user_question_test.go
+++ b/server/cmd/multica/cmd_issue_ask_user_question_test.go
@@ -1,0 +1,132 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+// askCmd builds a throwaway command carrying the ask_user_question flags that
+// buildAskUserQuestionMeta reads.
+func askCmd() *cobra.Command {
+	c := &cobra.Command{Use: "test"}
+	c.Flags().String("target-user", "", "")
+	c.Flags().String("question", "", "")
+	c.Flags().String("options-json", "", "")
+	c.Flags().Bool("multi-select", false, "")
+	c.Flags().Bool("allow-custom", false, "")
+	return c
+}
+
+func TestBuildAskUserQuestionMeta_Valid(t *testing.T) {
+	c := askCmd()
+	// A UUID target-user short-circuits member resolution, so no client needed.
+	_ = c.Flags().Set("target-user", "f31a2be0-0f7d-46b5-abf4-b8ff65846261")
+	_ = c.Flags().Set("question", "Which cache?")
+	_ = c.Flags().Set("options-json", `[{"label":"Redis","description":"distributed"},{"label":"Local","description":"single-node"}]`)
+
+	meta, fallback, err := buildAskUserQuestionMeta(context.Background(), nil, c)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	aq, ok := meta["ask_user_question"].(map[string]any)
+	if !ok {
+		t.Fatalf("missing ask_user_question key: %#v", meta)
+	}
+	if aq["target_user"] != "f31a2be0-0f7d-46b5-abf4-b8ff65846261" {
+		t.Errorf("target_user: got %v", aq["target_user"])
+	}
+	if aq["question"] != "Which cache?" {
+		t.Errorf("question: got %v", aq["question"])
+	}
+	// source_user must NOT be set client-side (server fills it from the author).
+	if _, present := aq["source_user"]; present {
+		t.Errorf("source_user must not be set by CLI")
+	}
+	// Options must round-trip.
+	b, _ := json.Marshal(aq["options"])
+	if !strings.Contains(string(b), "Redis") || !strings.Contains(string(b), "single-node") {
+		t.Errorf("options not preserved: %s", b)
+	}
+	// Fallback markdown must mention both labels for old-client degradation.
+	if !strings.Contains(fallback, "Redis") || !strings.Contains(fallback, "Local") {
+		t.Errorf("fallback markdown missing labels: %q", fallback)
+	}
+}
+
+func TestBuildAskUserQuestionMeta_Errors(t *testing.T) {
+	cases := []struct {
+		name        string
+		target      string
+		question    string
+		optionsJSON string
+		wantErr     string
+	}{
+		{"missing target", "", "q", `[{"label":"a","description":"b"}]`, "target-user"},
+		{"missing question", "f31a2be0-0f7d-46b5-abf4-b8ff65846261", "", `[{"label":"a","description":"b"}]`, "question"},
+		{"missing options", "f31a2be0-0f7d-46b5-abf4-b8ff65846261", "q", "", "options-json"},
+		{"bad json", "f31a2be0-0f7d-46b5-abf4-b8ff65846261", "q", `not json`, "invalid --options-json"},
+		{"empty options", "f31a2be0-0f7d-46b5-abf4-b8ff65846261", "q", `[]`, "at least one option"},
+		{"option missing label", "f31a2be0-0f7d-46b5-abf4-b8ff65846261", "q", `[{"description":"b"}]`, "label is required"},
+		{"option missing description", "f31a2be0-0f7d-46b5-abf4-b8ff65846261", "q", `[{"label":"a"}]`, "description is required"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			c := askCmd()
+			_ = c.Flags().Set("target-user", tc.target)
+			_ = c.Flags().Set("question", tc.question)
+			_ = c.Flags().Set("options-json", tc.optionsJSON)
+			_, _, err := buildAskUserQuestionMeta(context.Background(), nil, c)
+			if err == nil {
+				t.Fatalf("expected error containing %q, got nil", tc.wantErr)
+			}
+			if !strings.Contains(err.Error(), tc.wantErr) {
+				t.Errorf("error %q does not contain %q", err.Error(), tc.wantErr)
+			}
+		})
+	}
+}
+
+func TestBuildAskUserQuestionMeta_MultiSelectAndCustom(t *testing.T) {
+	c := askCmd()
+	_ = c.Flags().Set("target-user", "f31a2be0-0f7d-46b5-abf4-b8ff65846261")
+	_ = c.Flags().Set("question", "Pick some")
+	_ = c.Flags().Set("options-json", `[{"label":"A","description":"a"},{"label":"B","description":"b"}]`)
+	_ = c.Flags().Set("multi-select", "true")
+	_ = c.Flags().Set("allow-custom", "true")
+
+	meta, fallback, err := buildAskUserQuestionMeta(context.Background(), nil, c)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	aq := meta["ask_user_question"].(map[string]any)
+	if aq["multi_select"] != true {
+		t.Errorf("multi_select: got %v", aq["multi_select"])
+	}
+	if aq["allow_custom"] != true {
+		t.Errorf("allow_custom: got %v", aq["allow_custom"])
+	}
+	// Fallback markdown should mention multi + custom hint and an "其他" row.
+	if !strings.Contains(fallback, "多选") || !strings.Contains(fallback, "其他") {
+		t.Errorf("fallback missing multi/custom markers: %q", fallback)
+	}
+}
+
+func TestBuildAskUserQuestionMeta_DefaultsFalse(t *testing.T) {
+	c := askCmd()
+	_ = c.Flags().Set("target-user", "f31a2be0-0f7d-46b5-abf4-b8ff65846261")
+	_ = c.Flags().Set("question", "Q")
+	_ = c.Flags().Set("options-json", `[{"label":"A","description":"a"}]`)
+
+	meta, _, err := buildAskUserQuestionMeta(context.Background(), nil, c)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	aq := meta["ask_user_question"].(map[string]any)
+	if aq["multi_select"] != false || aq["allow_custom"] != false {
+		t.Errorf("defaults should be false: multi=%v custom=%v", aq["multi_select"], aq["allow_custom"])
+	}
+}

--- a/server/cmd/server/router.go
+++ b/server/cmd/server/router.go
@@ -1294,6 +1294,7 @@ func NewRouterWithOptions(pool *pgxpool.Pool, hub *realtime.Hub, bus *events.Bus
 				r.Delete("/resolve", h.UnresolveComment)
 				r.Post("/reactions", h.AddReaction)
 				r.Delete("/reactions", h.RemoveReaction)
+				r.Post("/answer", h.AnswerAskUserQuestion)
 			})
 
 			// Agents

--- a/server/internal/daemon/execenv/reply_instructions.go
+++ b/server/internal/daemon/execenv/reply_instructions.go
@@ -271,3 +271,36 @@ func BuildMultiThreadCommentReplyInstructions(issueID string, targets []ThreadRe
 		len(targets), len(targets), targetLines, cookbook,
 	)
 }
+
+// BuildAskUserQuestionHint teaches the agent to ask the human a *structured*
+// question — rendered as a selectable card in the UI — instead of asking in
+// prose and hoping the user replies in a parseable way. Injected on both the
+// comment-triggered and assignment-triggered prompts so the agent always knows
+// the option exists.
+//
+// The card is created via `issue comment add --type ask_user_question`. Keep the
+// flag list and JSON shape in sync with server/cmd/multica/cmd_issue.go
+// (buildAskUserQuestionMeta) and the server handler validation.
+func BuildAskUserQuestionHint(issueID string) string {
+	return fmt.Sprintf(
+		"## Asking the user a question\n\n"+
+			"When you need the user to make a CHOICE or DECISION (pick an option, approve/reject, "+
+			"resolve ambiguity), do NOT ask in a plain prose comment. Post a structured question "+
+			"that renders as a selectable card the user can click to answer:\n\n"+
+			"    multica issue comment add %s --type ask_user_question \\\n"+
+			"      --target-user <the person's name / email / user UUID> \\\n"+
+			"      --question \"What should I do about X?\" \\\n"+
+			"      --options-json '[{\"label\":\"Option A\",\"description\":\"what it means\"},{\"label\":\"Option B\",\"description\":\"...\"}]'\n\n"+
+			"Flags:\n"+
+			"- `--target-user` (required): who must answer. Usually the user who asked you (see the "+
+			"triggering comment's author) — resolve them by name, email, or user UUID.\n"+
+			"- `--options-json` (required): 2+ options, each with a `label` (short) and `description` (why).\n"+
+			"- `--multi-select` (optional): let the user pick more than one option.\n"+
+			"- `--allow-custom` (optional): add an \"Other\" choice with a free-text box for answers "+
+			"outside your presets.\n\n"+
+			"After the user answers, a reply comment (`我选择【...】`) is posted back to you automatically, "+
+			"which re-triggers you to continue. Prefer this over prose questions whenever the answer is a "+
+			"choice — it is unambiguous and the user can respond in one click.\n\n",
+		issueID,
+	)
+}

--- a/server/internal/daemon/prompt.go
+++ b/server/internal/daemon/prompt.go
@@ -105,6 +105,7 @@ func buildPromptBody(task Task, provider string) string {
 	}
 	fmt.Fprintf(&b, "Start by running `multica issue get %s --output json` to understand your task, then complete it.\n", task.IssueID)
 	fmt.Fprintf(&b, "For comment history, follow the rule in your runtime workflow file (assignment-triggered tasks treat the read as mandatory). Scan the threads first with `multica issue comment list %s --roots-only --summary --output json`, then expand only what matters with `--thread <thread-id> --tail 30`. For `--since` incremental polling, pagination, and folding, see `multica issue comment list --help`.\n", task.IssueID)
+	b.WriteString(execenv.BuildAskUserQuestionHint(task.IssueID))
 	return b.String()
 }
 
@@ -343,6 +344,7 @@ func buildCommentPrompt(task Task, provider string) string {
 	} else {
 		b.WriteString(execenv.BuildCommentReplyInstructions(provider, task.IssueID, task.TriggerCommentID))
 	}
+	b.WriteString(execenv.BuildAskUserQuestionHint(task.IssueID))
 	return b.String()
 }
 

--- a/server/internal/daemon/prompt_test.go
+++ b/server/internal/daemon/prompt_test.go
@@ -1302,3 +1302,39 @@ func TestBriefModeRouterMatchesPromptMarkers(t *testing.T) {
 		t.Error("brief still routes on the prompt's opening line; it must route on the explicit marker")
 	}
 }
+
+// TestAskUserQuestionHintInjected verifies both the comment-triggered and the
+// assignment-triggered prompts teach the agent to ask structured questions via
+// `--type ask_user_question` rather than in prose.
+func TestAskUserQuestionHintInjected(t *testing.T) {
+	issue := "11111111-1111-1111-1111-111111111111"
+	mustContain := []string{
+		"--type ask_user_question",
+		"--target-user",
+		"--options-json",
+		"--multi-select",
+		"--allow-custom",
+	}
+
+	t.Run("comment-triggered", func(t *testing.T) {
+		out := BuildPrompt(Task{
+			IssueID:               issue,
+			TriggerCommentID:      "22222222-2222-2222-2222-222222222222",
+			TriggerCommentContent: "please decide X",
+		}, "claude")
+		for _, s := range mustContain {
+			if !strings.Contains(out, s) {
+				t.Errorf("comment prompt missing %q", s)
+			}
+		}
+	})
+
+	t.Run("assignment-triggered", func(t *testing.T) {
+		out := BuildPrompt(Task{IssueID: issue}, "claude")
+		for _, s := range mustContain {
+			if !strings.Contains(out, s) {
+				t.Errorf("assignment prompt missing %q", s)
+			}
+		}
+	})
+}

--- a/server/internal/handler/activity.go
+++ b/server/internal/handler/activity.go
@@ -38,6 +38,9 @@ type TimelineEntry struct {
 	ResolvedByType *string              `json:"resolved_by_type,omitempty"`
 	ResolvedByID   *string              `json:"resolved_by_id,omitempty"`
 	SourceTaskID   *string              `json:"source_task_id,omitempty"`
+	// Metadata carries the structured payload for typed comments (currently
+	// ask_user_question). Omitted for ordinary comments and activities.
+	Metadata *CommentMetadata `json:"metadata,omitempty"`
 }
 
 // timelineHardCap bounds the per-issue timeline payload. Sized as a defensive
@@ -277,6 +280,12 @@ func (h *Handler) commentsToEntries(r *http.Request, comments []db.Comment) []Ti
 		commentType := c.Type
 		updatedAt := timestampToString(c.UpdatedAt)
 		cid := uuidToString(c.ID)
+		// Surface structured metadata only when it carries a known payload, so
+		// ordinary comments keep their existing timeline shape.
+		var metadata *CommentMetadata
+		if m := parseCommentMetadata(c.Metadata); m.AskUserQuestion != nil {
+			metadata = &m
+		}
 		out[i] = TimelineEntry{
 			Type:           "comment",
 			ID:             cid,
@@ -294,6 +303,7 @@ func (h *Handler) commentsToEntries(r *http.Request, comments []db.Comment) []Ti
 			ResolvedByType: textToPtr(c.ResolvedByType),
 			ResolvedByID:   uuidToPtr(c.ResolvedByID),
 			SourceTaskID:   uuidToPtr(c.SourceTaskID),
+			Metadata:       metadata,
 		}
 	}
 	return out

--- a/server/internal/handler/comment.go
+++ b/server/internal/handler/comment.go
@@ -44,6 +44,10 @@ type CommentResponse struct {
 	QuickActionID *string              `json:"quick_action_id,omitempty"`
 	Reactions     []ReactionResponse   `json:"reactions"`
 	Attachments   []AttachmentResponse `json:"attachments"`
+	// Metadata carries structured payloads keyed by type. For
+	// ask_user_question comments it holds the question/options/answer object.
+	// Omitted when empty so ordinary comments keep their existing response shape.
+	Metadata *CommentMetadata `json:"metadata,omitempty"`
 	// Orientation stats — populated only on the roots_only path and omitted in
 	// every other mode, so the default response shape stays byte-identical for
 	// existing callers. ReplyCount is the number of descendants in the thread;
@@ -94,6 +98,12 @@ func commentToResponse(c db.Comment, reactions []ReactionResponse, attachments [
 	if attachments == nil {
 		attachments = []AttachmentResponse{}
 	}
+	// Surface the structured metadata only when it carries a known payload, so
+	// ordinary comments keep their existing response shape (metadata omitted).
+	var metadata *CommentMetadata
+	if m := parseCommentMetadata(c.Metadata); m.AskUserQuestion != nil {
+		metadata = &m
+	}
 	return CommentResponse{
 		ID:             uuidToString(c.ID),
 		IssueID:        uuidToString(c.IssueID),
@@ -111,6 +121,7 @@ func commentToResponse(c db.Comment, reactions []ReactionResponse, attachments [
 		QuickActionID:  uuidToPtr(c.QuickActionID),
 		Reactions:      reactions,
 		Attachments:    attachments,
+		Metadata:       metadata,
 	}
 }
 
@@ -1450,11 +1461,15 @@ func keepRootConnected(byID map[string]db.Comment) []db.Comment {
 }
 
 type CreateCommentRequest struct {
-	Content          string   `json:"content"`
-	Type             string   `json:"type"`
-	ParentID         *string  `json:"parent_id"`
-	AttachmentIDs    []string `json:"attachment_ids"`
-	SuppressAgentIDs []string `json:"suppress_agent_ids"`
+	Content          string          `json:"content"`
+	Type             string          `json:"type"`
+	ParentID         *string         `json:"parent_id"`
+	AttachmentIDs    []string        `json:"attachment_ids"`
+	SuppressAgentIDs []string        `json:"suppress_agent_ids"`
+	// Metadata carries the structured payload for typed comments. For
+	// ask_user_question it holds the question/options/target_user object;
+	// ignored for ordinary comments.
+	Metadata json.RawMessage `json:"metadata"`
 }
 
 type CommentTriggerPreviewRequest struct {
@@ -1775,6 +1790,44 @@ func (h *Handler) CreateComment(w http.ResponseWriter, r *http.Request) {
 	// Determine author identity: agent (via X-Agent-ID header) or member.
 	authorType, authorID := h.resolveActor(r, userID, uuidToString(issue.WorkspaceID))
 
+	// ask_user_question: an agent poses a structured multiple-choice question at
+	// a specific human. Validate the payload, force source_user to the resolved
+	// author (never trust a client-supplied value), and store it in metadata.
+	// metadata defaults to '{}' for ordinary comments — the column is NOT NULL.
+	metadataBytes := []byte("{}")
+	if req.Type == commentMetadataKey {
+		if authorType != "agent" {
+			writeError(w, http.StatusBadRequest, "ask_user_question comments must be posted by an agent")
+			return
+		}
+		parsed := parseCommentMetadata(req.Metadata)
+		if err := validateAskUserQuestionMeta(parsed.AskUserQuestion); err != nil {
+			writeError(w, http.StatusBadRequest, err.Error())
+			return
+		}
+		// target_user must be a real member of this workspace.
+		targetUUID, err := util.ParseUUID(parsed.AskUserQuestion.TargetUser)
+		if err != nil {
+			writeError(w, http.StatusBadRequest, "target_user is not a valid user id")
+			return
+		}
+		if _, err := h.Queries.GetMemberByUserAndWorkspace(r.Context(), db.GetMemberByUserAndWorkspaceParams{
+			UserID:      targetUUID,
+			WorkspaceID: issue.WorkspaceID,
+		}); err != nil {
+			writeError(w, http.StatusBadRequest, "target_user is not a member of this workspace")
+			return
+		}
+		parsed.AskUserQuestion.SourceUser = authorID
+		parsed.AskUserQuestion.Answer = nil
+		encoded, err := json.Marshal(parsed)
+		if err != nil {
+			writeError(w, http.StatusInternalServerError, "failed to encode metadata")
+			return
+		}
+		metadataBytes = encoded
+	}
+
 	// Defense against resumed-session drift: when an agent posts from inside a
 	// comment-triggered task AND the comment is being posted on that same
 	// issue, the parent_id must exactly match the task's trigger comment.
@@ -1870,6 +1923,7 @@ func (h *Handler) CreateComment(w http.ResponseWriter, r *http.Request) {
 		Type:         req.Type,
 		ParentID:     parentID,
 		SourceTaskID: sourceTaskID,
+		Metadata:     metadataBytes,
 	})
 	if err != nil {
 		slog.Warn("create comment failed", append(logger.RequestAttrs(r), "error", err, "issue_id", issueID)...)
@@ -1923,6 +1977,11 @@ func (h *Handler) CreateComment(w http.ResponseWriter, r *http.Request) {
 var clientAuthorableCommentTypes = map[string]struct{}{
 	"comment":         {},
 	"progress_update": {},
+	// ask_user_question is agent-only in practice: CreateComment rejects it
+	// unless the resolved author is an agent. It is listed here so the type
+	// passes the authorable-type gate; the agent-only + payload validation
+	// happens in the ask_user_question block below.
+	"ask_user_question": {},
 }
 
 func isClientAuthorableCommentType(t string) bool {

--- a/server/internal/handler/comment_ask_user_question.go
+++ b/server/internal/handler/comment_ask_user_question.go
@@ -1,0 +1,364 @@
+package handler
+
+import (
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/multica-ai/multica/server/internal/logger"
+	"github.com/multica-ai/multica/server/internal/util"
+	db "github.com/multica-ai/multica/server/pkg/db/generated"
+	"github.com/multica-ai/multica/server/pkg/protocol"
+)
+
+// commentMetadataKey is the top-level key under comment.metadata that holds the
+// ask_user_question payload. Keeping it namespaced leaves room for other
+// structured comment types to store their own payloads alongside it later.
+const commentMetadataKey = "ask_user_question"
+
+const maxAskUserQuestionOptions = 20
+
+// AskUserQuestionOption is one selectable choice. label is the short headline
+// (rendered on top), description is the longer explanation (rendered below).
+type AskUserQuestionOption struct {
+	Label       string `json:"label"`
+	Description string `json:"description"`
+}
+
+// AskUserQuestionAnswer is written once the target user confirms or ignores.
+// It is nil until then.
+//
+// Selection is recorded in one of three ways depending on the question mode:
+//   - single-select: SelectedIndex (kept for backward compat with old rows)
+//   - multi-select:  SelectedIndices
+//   - custom input:  CustomText (when the user picked the auto-appended "Other")
+// A multi-select + allow_custom question may set both SelectedIndices and CustomText.
+type AskUserQuestionAnswer struct {
+	State           string `json:"state"` // "submitted" | "ignored"
+	SelectedIndex   *int   `json:"selected_index,omitempty"`
+	SelectedIndices []int  `json:"selected_indices,omitempty"`
+	CustomText      string `json:"custom_text,omitempty"`
+	AnsweredAt      string `json:"answered_at"`
+}
+
+// AskUserQuestionMeta is the full structured payload stored under
+// comment.metadata.ask_user_question for an ask_user_question comment.
+type AskUserQuestionMeta struct {
+	// TargetUser is the user_id of the human being asked. Only this user may
+	// answer (enforced in AnswerAskUserQuestion).
+	TargetUser string `json:"target_user"`
+	// SourceUser is the agent id that asked the question (= comment author).
+	// The confirmation reply @mentions this agent so it can continue.
+	SourceUser string                  `json:"source_user"`
+	Question   string                  `json:"question"`
+	Options    []AskUserQuestionOption `json:"options"`
+	// MultiSelect lets the user pick more than one option (checkbox semantics).
+	// Default false = single-select (radio). Mirrors the SDK's per-question
+	// multiSelect flag.
+	MultiSelect bool `json:"multi_select,omitempty"`
+	// AllowCustom appends an auto "Other" choice that reveals a free-text input,
+	// mirroring the SDK's auto-provided Other option. Default false.
+	AllowCustom bool                   `json:"allow_custom,omitempty"`
+	Answer      *AskUserQuestionAnswer `json:"answer,omitempty"`
+}
+
+// CommentMetadata is the decoded shape of comment.metadata. Only the
+// ask_user_question key is modeled today; unknown keys are ignored on decode
+// and dropped on re-encode, which is acceptable because the column is only
+// written by this handler.
+type CommentMetadata struct {
+	AskUserQuestion *AskUserQuestionMeta `json:"ask_user_question,omitempty"`
+}
+
+// parseCommentMetadata decodes the raw JSONB bytes into CommentMetadata.
+// Returns an empty (non-nil-safe) struct on empty/invalid input so callers can
+// branch on AskUserQuestion == nil without a separate error path.
+func parseCommentMetadata(raw []byte) CommentMetadata {
+	var m CommentMetadata
+	if len(raw) == 0 {
+		return m
+	}
+	if err := json.Unmarshal(raw, &m); err != nil {
+		return CommentMetadata{}
+	}
+	return m
+}
+
+// validateAskUserQuestionMeta checks the inbound payload for a new
+// ask_user_question comment. answer must be absent on create.
+func validateAskUserQuestionMeta(m *AskUserQuestionMeta) error {
+	if m == nil {
+		return fmt.Errorf("ask_user_question payload is required")
+	}
+	if strings.TrimSpace(m.TargetUser) == "" {
+		return fmt.Errorf("target_user is required")
+	}
+	if strings.TrimSpace(m.Question) == "" {
+		return fmt.Errorf("question is required")
+	}
+	if len(m.Options) == 0 {
+		return fmt.Errorf("at least one option is required")
+	}
+	if len(m.Options) > maxAskUserQuestionOptions {
+		return fmt.Errorf("too many options (max %d)", maxAskUserQuestionOptions)
+	}
+	for i, o := range m.Options {
+		if strings.TrimSpace(o.Label) == "" {
+			return fmt.Errorf("option %d: label is required", i)
+		}
+		if strings.TrimSpace(o.Description) == "" {
+			return fmt.Errorf("option %d: description is required", i)
+		}
+	}
+	return nil
+}
+
+// AnswerAskUserQuestionRequest is the body for POST /api/comments/{id}/answer.
+type AnswerAskUserQuestionRequest struct {
+	State           string `json:"state"` // "submitted" | "ignored"
+	SelectedIndex   *int   `json:"selected_index"`
+	SelectedIndices []int  `json:"selected_indices"`
+	CustomText      string `json:"custom_text"`
+}
+
+// AnswerAskUserQuestion records the target user's response to an
+// ask_user_question comment. Only the target_user may answer (403 otherwise),
+// and only once (409 on re-answer). On "submitted" it also posts a reply that
+// @mentions the source agent so it resumes work.
+func (h *Handler) AnswerAskUserQuestion(w http.ResponseWriter, r *http.Request) {
+	commentID := chi.URLParam(r, "commentId")
+
+	userID, ok := requireUserID(w, r)
+	if !ok {
+		return
+	}
+
+	workspaceID := h.resolveWorkspaceID(r)
+	commentUUID, ok := parseUUIDOrBadRequest(w, commentID, "comment id")
+	if !ok {
+		return
+	}
+	wsUUID, ok := parseUUIDOrBadRequest(w, workspaceID, "workspace id")
+	if !ok {
+		return
+	}
+
+	comment, err := h.Queries.GetCommentInWorkspace(r.Context(), db.GetCommentInWorkspaceParams{
+		ID:          commentUUID,
+		WorkspaceID: wsUUID,
+	})
+	if err != nil {
+		writeError(w, http.StatusNotFound, "comment not found")
+		return
+	}
+	if comment.Type != commentMetadataKey {
+		writeError(w, http.StatusBadRequest, "comment is not an ask_user_question")
+		return
+	}
+
+	meta := parseCommentMetadata(comment.Metadata)
+	if meta.AskUserQuestion == nil {
+		writeError(w, http.StatusBadRequest, "comment has no ask_user_question payload")
+		return
+	}
+	aq := meta.AskUserQuestion
+
+	// Only the target user may answer. resolveActor's member actorID is the
+	// user_id, which is what target_user stores.
+	actorType, actorID := h.resolveActor(r, userID, workspaceID)
+	if actorType != "member" || actorID != aq.TargetUser {
+		writeError(w, http.StatusForbidden, "only the target user may answer this question")
+		return
+	}
+
+	// Idempotency: reject a second answer so the confirmation reply (and its
+	// agent trigger) fires at most once.
+	if aq.Answer != nil {
+		writeError(w, http.StatusConflict, "question already answered")
+		return
+	}
+
+	var req AnswerAskUserQuestionRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid request body")
+		return
+	}
+	if req.State != "submitted" && req.State != "ignored" {
+		writeError(w, http.StatusBadRequest, "state must be 'submitted' or 'ignored'")
+		return
+	}
+	answer := AskUserQuestionAnswer{
+		State:      req.State,
+		AnsweredAt: time.Now().UTC().Format(time.RFC3339),
+	}
+	if req.State == "submitted" {
+		// Validate + record the selection according to the question's mode.
+		customText := strings.TrimSpace(req.CustomText)
+		if customText != "" && !aq.AllowCustom {
+			writeError(w, http.StatusBadRequest, "custom_text is not allowed for this question")
+			return
+		}
+		validIdx := func(i int) bool { return i >= 0 && i < len(aq.Options) }
+
+		if aq.MultiSelect {
+			// De-dup + range-check the selected indices.
+			seen := map[int]bool{}
+			var idxs []int
+			for _, i := range req.SelectedIndices {
+				if !validIdx(i) {
+					writeError(w, http.StatusBadRequest, "selected_indices out of range")
+					return
+				}
+				if !seen[i] {
+					seen[i] = true
+					idxs = append(idxs, i)
+				}
+			}
+			// At least one signal required: a picked option OR custom text.
+			if len(idxs) == 0 && customText == "" {
+				writeError(w, http.StatusBadRequest, "select at least one option")
+				return
+			}
+			answer.SelectedIndices = idxs
+			answer.CustomText = customText
+		} else {
+			// Single-select. A custom-only answer (no option index) is allowed
+			// when allow_custom is on; otherwise selected_index is required.
+			if req.SelectedIndex != nil {
+				if !validIdx(*req.SelectedIndex) {
+					writeError(w, http.StatusBadRequest, "selected_index out of range")
+					return
+				}
+				answer.SelectedIndex = req.SelectedIndex
+			} else if customText == "" {
+				writeError(w, http.StatusBadRequest, "selected_index is required when state is 'submitted'")
+				return
+			}
+			answer.CustomText = customText
+		}
+	}
+
+	answerJSON, err := json.Marshal(answer)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to encode answer")
+		return
+	}
+
+	updated, err := h.Queries.UpdateCommentAnswer(r.Context(), db.UpdateCommentAnswerParams{
+		ID:          comment.ID,
+		WorkspaceID: wsUUID,
+		Answer:      answerJSON,
+	})
+	if err != nil {
+		slog.Warn("update comment answer failed", append(logger.RequestAttrs(r), "error", err, "comment_id", commentID)...)
+		writeError(w, http.StatusInternalServerError, "failed to record answer")
+		return
+	}
+
+	// Broadcast the updated comment so every client flips the card to its
+	// terminal state in place (no new event type needed).
+	grouped := h.groupReactions(r, []pgtype.UUID{updated.ID})
+	groupedAtt := h.groupAttachments(r, []pgtype.UUID{updated.ID})
+	resp := commentToResponse(updated, grouped[uuidToString(updated.ID)], groupedAtt[uuidToString(updated.ID)])
+
+	var issueTitle, issueStatus string
+	if issue, err := h.Queries.GetIssue(r.Context(), updated.IssueID); err == nil {
+		issueTitle = issue.Title
+		issueStatus = issue.Status
+	}
+	h.publish(protocol.EventCommentUpdated, workspaceID, actorType, actorID, map[string]any{
+		"comment":      resp,
+		"issue_id":     uuidToString(updated.IssueID),
+		"issue_title":  issueTitle,
+		"issue_status": issueStatus,
+	})
+
+	// On submit, post a reply that @mentions the source agent so it continues.
+	if req.State == "submitted" {
+		h.postAskUserQuestionReply(r, updated, aq, &answer, actorID)
+	}
+
+	writeJSON(w, http.StatusOK, resp)
+}
+
+// buildSelectedSummary renders the human-readable selection for the reply
+// text, unifying single-select / multi-select / custom-input. Examples:
+//   single:          "Redis"
+//   multi:           "Redis、Local"
+//   multi + custom:  "Redis、其他:自定义方案"
+//   custom only:     "其他:自定义方案"
+func buildSelectedSummary(aq *AskUserQuestionMeta, answer *AskUserQuestionAnswer) string {
+	labelAt := func(i int) string {
+		if i >= 0 && i < len(aq.Options) {
+			return aq.Options[i].Label
+		}
+		return ""
+	}
+	var parts []string
+	if answer.SelectedIndex != nil {
+		if l := labelAt(*answer.SelectedIndex); l != "" {
+			parts = append(parts, l)
+		}
+	}
+	for _, i := range answer.SelectedIndices {
+		if l := labelAt(i); l != "" {
+			parts = append(parts, l)
+		}
+	}
+	if strings.TrimSpace(answer.CustomText) != "" {
+		parts = append(parts, "其他:"+strings.TrimSpace(answer.CustomText))
+	}
+	return strings.Join(parts, "、")
+}
+
+// postAskUserQuestionReply creates the member reply that confirms the choice and
+// @mentions the source agent, which re-triggers the agent via the normal
+// comment-mention path. Best-effort: a failure here is logged but does not fail
+// the answer (the answer itself already committed).
+func (h *Handler) postAskUserQuestionReply(r *http.Request, parent db.Comment, aq *AskUserQuestionMeta, answer *AskUserQuestionAnswer, memberUserID string) {
+	agentMention := aq.SourceUser
+	if agentUUID, err := util.ParseUUID(aq.SourceUser); err == nil {
+		if agent, err := h.Queries.GetAgent(r.Context(), agentUUID); err == nil {
+			agentMention = fmt.Sprintf("[@%s](mention://agent/%s)", agent.Name, aq.SourceUser)
+		}
+	}
+	content := fmt.Sprintf("问题:【%s】我选择【%s】,请继续 %s", aq.Question, buildSelectedSummary(aq, answer), agentMention)
+
+	reply, err := h.Queries.CreateComment(r.Context(), db.CreateCommentParams{
+		IssueID:     parent.IssueID,
+		WorkspaceID: parent.WorkspaceID,
+		AuthorType:  "member",
+		AuthorID:    parseUUID(memberUserID),
+		Content:     content,
+		Type:        "comment",
+		ParentID:    parent.ID,
+		Metadata:    []byte("{}"),
+	})
+	if err != nil {
+		slog.Warn("post ask_user_question reply failed", append(logger.RequestAttrs(r), "error", err, "comment_id", uuidToString(parent.ID))...)
+		return
+	}
+
+	resp := commentToResponse(reply, nil, nil)
+	workspaceID := uuidToString(parent.WorkspaceID)
+	issue, issueErr := h.Queries.GetIssue(r.Context(), parent.IssueID)
+	if issueErr == nil {
+		h.publish(protocol.EventCommentCreated, workspaceID, "member", memberUserID, map[string]any{
+			"comment":             resp,
+			"issue_title":         issue.Title,
+			"issue_assignee_type": textToPtr(issue.AssigneeType),
+			"issue_assignee_id":   uuidToPtr(issue.AssigneeID),
+			"issue_status":        issue.Status,
+		})
+		// Trigger the mentioned source agent to resume, mirroring the normal
+		// comment path's mention-driven enqueue. The member confirming is the
+		// originator; there is no autopilot delegation and no agents to
+		// suppress on this member-authored reply.
+		h.triggerTasksForComment(r.Context(), issue, reply, &parent, "member", memberUserID, memberUserID, "", nil)
+	}
+}

--- a/server/internal/handler/comment_ask_user_question_test.go
+++ b/server/internal/handler/comment_ask_user_question_test.go
@@ -1,0 +1,251 @@
+package handler
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// seedAskUserQuestion inserts an issue + a single-select ask_user_question
+// comment authored by a synthetic agent. Returns issueID, commentID.
+func seedAskUserQuestion(t *testing.T, targetUserID string) (string, string) {
+	return seedAskUserQuestionOpts(t, targetUserID, false, false)
+}
+
+// seedAskUserQuestionOpts is seedAskUserQuestion with explicit multi_select /
+// allow_custom flags.
+func seedAskUserQuestionOpts(t *testing.T, targetUserID string, multiSelect, allowCustom bool) (string, string) {
+	t.Helper()
+	ctx := context.Background()
+
+	var issueID string
+	if err := testPool.QueryRow(ctx, `
+		INSERT INTO issue (workspace_id, creator_type, creator_id, title)
+		VALUES ($1, 'member', $2, $3)
+		RETURNING id
+	`, testWorkspaceID, testUserID, "ask_user_question fixture").Scan(&issueID); err != nil {
+		t.Fatalf("create issue: %v", err)
+	}
+	t.Cleanup(func() {
+		testPool.Exec(context.Background(), `DELETE FROM issue WHERE id = $1`, issueID)
+	})
+
+	// source_user is a synthetic agent id — the answer path only formats it into
+	// the reply mention (falling back to the raw id when the agent is absent),
+	// so it does not need to be a real agent row for this test.
+	meta := map[string]any{
+		"ask_user_question": map[string]any{
+			"target_user": targetUserID,
+			"source_user": "33333333-3333-3333-3333-333333333333",
+			"question":    "Which cache?",
+			"options": []map[string]any{
+				{"label": "Redis", "description": "distributed"},
+				{"label": "Local", "description": "single-node"},
+			},
+			"multi_select": multiSelect,
+			"allow_custom": allowCustom,
+		},
+	}
+	metaJSON, _ := json.Marshal(meta)
+
+	var commentID string
+	if err := testPool.QueryRow(ctx, `
+		INSERT INTO comment (issue_id, workspace_id, author_type, author_id, content, type, metadata)
+		VALUES ($1, $2, 'agent', $3, $4, 'ask_user_question', $5)
+		RETURNING id
+	`, issueID, testWorkspaceID, "33333333-3333-3333-3333-333333333333",
+		"**Which cache?**", metaJSON).Scan(&commentID); err != nil {
+		t.Fatalf("insert ask_user_question comment: %v", err)
+	}
+	return issueID, commentID
+}
+
+func answerReq(t *testing.T, userID, commentID string, body any) *httptest.ResponseRecorder {
+	t.Helper()
+	w := httptest.NewRecorder()
+	req := newRequestAs(userID, "POST", "/api/comments/"+commentID+"/answer", body)
+	req = withURLParam(req, "commentId", commentID)
+	testHandler.AnswerAskUserQuestion(w, req)
+	return w
+}
+
+// TestAnswerAskUserQuestion_SubmittedByTarget: the target user submits a valid
+// selection → 200, metadata records the answer, and a confirmation reply is
+// posted that mentions the source agent.
+func TestAnswerAskUserQuestion_SubmittedByTarget(t *testing.T) {
+	if testHandler == nil || testPool == nil {
+		t.Skip("database not available")
+	}
+	issueID, commentID := seedAskUserQuestion(t, testUserID)
+
+	idx := 1
+	w := answerReq(t, testUserID, commentID, map[string]any{"state": "submitted", "selected_index": idx})
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var resp CommentResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if resp.Metadata == nil || resp.Metadata.AskUserQuestion == nil || resp.Metadata.AskUserQuestion.Answer == nil {
+		t.Fatalf("expected answer recorded in metadata, got %+v", resp.Metadata)
+	}
+	ans := resp.Metadata.AskUserQuestion.Answer
+	if ans.State != "submitted" || ans.SelectedIndex == nil || *ans.SelectedIndex != 1 {
+		t.Fatalf("unexpected answer: %+v", ans)
+	}
+
+	// A confirmation reply must have been posted, parented at the question.
+	var replyCount int
+	if err := testPool.QueryRow(context.Background(),
+		`SELECT count(*) FROM comment WHERE issue_id = $1 AND parent_id = $2 AND type = 'comment'`,
+		issueID, commentID).Scan(&replyCount); err != nil {
+		t.Fatalf("count replies: %v", err)
+	}
+	if replyCount != 1 {
+		t.Fatalf("expected exactly 1 confirmation reply, got %d", replyCount)
+	}
+}
+
+// TestAnswerAskUserQuestion_ForbiddenForNonTarget: a member who is not the
+// target user gets 403 and no answer is recorded.
+func TestAnswerAskUserQuestion_ForbiddenForNonTarget(t *testing.T) {
+	if testHandler == nil || testPool == nil {
+		t.Skip("database not available")
+	}
+	// Target is a different user; the request is made as testUserID.
+	otherUserID := "22222222-2222-2222-2222-222222222222"
+	_, commentID := seedAskUserQuestion(t, otherUserID)
+
+	w := answerReq(t, testUserID, commentID, map[string]any{"state": "submitted", "selected_index": 0})
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("expected 403, got %d: %s", w.Code, w.Body.String())
+	}
+
+	// Metadata must still have no answer.
+	c, err := testHandler.Queries.GetComment(context.Background(), parseUUID(commentID))
+	if err != nil {
+		t.Fatalf("get comment: %v", err)
+	}
+	if m := parseCommentMetadata(c.Metadata); m.AskUserQuestion != nil && m.AskUserQuestion.Answer != nil {
+		t.Fatalf("answer should not be recorded on 403")
+	}
+}
+
+// TestAnswerAskUserQuestion_IgnoredThenReanswerRejected: ignoring records the
+// terminal state and a subsequent answer is rejected (409, idempotent).
+func TestAnswerAskUserQuestion_IgnoredThenReanswerRejected(t *testing.T) {
+	if testHandler == nil || testPool == nil {
+		t.Skip("database not available")
+	}
+	_, commentID := seedAskUserQuestion(t, testUserID)
+
+	w := answerReq(t, testUserID, commentID, map[string]any{"state": "ignored"})
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200 on ignore, got %d: %s", w.Code, w.Body.String())
+	}
+
+	// Second answer must be rejected.
+	w2 := answerReq(t, testUserID, commentID, map[string]any{"state": "submitted", "selected_index": 0})
+	if w2.Code != http.StatusConflict {
+		t.Fatalf("expected 409 on re-answer, got %d: %s", w2.Code, w2.Body.String())
+	}
+}
+
+// TestAnswerAskUserQuestion_MultiSelect: a multi_select question accepts
+// selected_indices and the reply lists all chosen labels.
+func TestAnswerAskUserQuestion_MultiSelect(t *testing.T) {
+	if testHandler == nil || testPool == nil {
+		t.Skip("database not available")
+	}
+	issueID, commentID := seedAskUserQuestionOpts(t, testUserID, true, false)
+
+	w := answerReq(t, testUserID, commentID, map[string]any{
+		"state":            "submitted",
+		"selected_indices": []int{0, 1},
+	})
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	var resp CommentResponse
+	json.Unmarshal(w.Body.Bytes(), &resp)
+	ans := resp.Metadata.AskUserQuestion.Answer
+	if ans == nil || len(ans.SelectedIndices) != 2 {
+		t.Fatalf("expected 2 selected indices, got %+v", ans)
+	}
+
+	// The confirmation reply must mention both labels.
+	var replyContent string
+	if err := testPool.QueryRow(context.Background(),
+		`SELECT content FROM comment WHERE issue_id=$1 AND parent_id=$2 AND type='comment'`,
+		issueID, commentID).Scan(&replyContent); err != nil {
+		t.Fatalf("load reply: %v", err)
+	}
+	if !strings.Contains(replyContent, "Redis") || !strings.Contains(replyContent, "Local") {
+		t.Fatalf("reply should list both labels, got %q", replyContent)
+	}
+}
+
+// TestAnswerAskUserQuestion_CustomText: allow_custom question accepts custom_text.
+func TestAnswerAskUserQuestion_CustomText(t *testing.T) {
+	if testHandler == nil || testPool == nil {
+		t.Skip("database not available")
+	}
+	issueID, commentID := seedAskUserQuestionOpts(t, testUserID, false, true)
+
+	w := answerReq(t, testUserID, commentID, map[string]any{
+		"state":       "submitted",
+		"custom_text": "my own answer",
+	})
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	var resp CommentResponse
+	json.Unmarshal(w.Body.Bytes(), &resp)
+	if resp.Metadata.AskUserQuestion.Answer.CustomText != "my own answer" {
+		t.Fatalf("custom_text not recorded: %+v", resp.Metadata.AskUserQuestion.Answer)
+	}
+	var replyContent string
+	testPool.QueryRow(context.Background(),
+		`SELECT content FROM comment WHERE issue_id=$1 AND parent_id=$2 AND type='comment'`,
+		issueID, commentID).Scan(&replyContent)
+	if !strings.Contains(replyContent, "my own answer") {
+		t.Fatalf("reply should contain custom text, got %q", replyContent)
+	}
+}
+
+// TestAnswerAskUserQuestion_CustomTextRejectedWhenDisallowed: custom_text on a
+// question without allow_custom → 400.
+func TestAnswerAskUserQuestion_CustomTextRejectedWhenDisallowed(t *testing.T) {
+	if testHandler == nil || testPool == nil {
+		t.Skip("database not available")
+	}
+	_, commentID := seedAskUserQuestionOpts(t, testUserID, false, false)
+	w := answerReq(t, testUserID, commentID, map[string]any{
+		"state":       "submitted",
+		"custom_text": "nope",
+	})
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+// TestAnswerAskUserQuestion_MultiSelectEmptyRejected: multi_select with no
+// selection and no custom → 400.
+func TestAnswerAskUserQuestion_MultiSelectEmptyRejected(t *testing.T) {
+	if testHandler == nil || testPool == nil {
+		t.Skip("database not available")
+	}
+	_, commentID := seedAskUserQuestionOpts(t, testUserID, true, false)
+	w := answerReq(t, testUserID, commentID, map[string]any{
+		"state":            "submitted",
+		"selected_indices": []int{},
+	})
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d: %s", w.Code, w.Body.String())
+	}
+}

--- a/server/internal/handler/comment_touch_issue_test.go
+++ b/server/internal/handler/comment_touch_issue_test.go
@@ -84,6 +84,7 @@ func TestCreateComment_WorkspaceMismatchPersistsNothing(t *testing.T) {
 		AuthorID:    parseUUID(testUserID),
 		Content:     "should never persist",
 		Type:        "comment",
+		Metadata:    []byte("{}"),
 	})
 	if !errors.Is(err, pgx.ErrNoRows) {
 		t.Fatalf("expected pgx.ErrNoRows on workspace mismatch, got %v", err)

--- a/server/internal/handler/issue_child_done.go
+++ b/server/internal/handler/issue_child_done.go
@@ -308,6 +308,7 @@ func (h *Handler) postChildDoneComment(ctx context.Context, parent, completed db
 		Content:     content,
 		Type:        "system",
 		ParentID:    pgtype.UUID{Valid: false},
+		Metadata:    []byte("{}"),
 	})
 	if err != nil {
 		slog.Warn("child done: create system comment failed",

--- a/server/internal/handler/quick_action.go
+++ b/server/internal/handler/quick_action.go
@@ -897,6 +897,7 @@ func (h *Handler) RunQuickAction(w http.ResponseWriter, r *http.Request) {
 		// forgeable and would also have cost a CHECK rebuild on a hot table.
 		Type:          "comment",
 		QuickActionID: qa.ID,
+		Metadata:      []byte("{}"),
 	})
 	if err != nil {
 		slog.Warn("quick action comment create failed", append(logger.RequestAttrs(r), "error", err, "quick_action_id", uuidToString(qa.ID))...)

--- a/server/internal/service/task.go
+++ b/server/internal/service/task.go
@@ -4615,6 +4615,7 @@ func (s *TaskService) createAgentComment(ctx context.Context, issueID, agentID p
 		Type:         commentType,
 		ParentID:     parentID,
 		SourceTaskID: sourceTaskID,
+		Metadata:     []byte("{}"),
 	})
 	if err != nil {
 		return

--- a/server/migrations/254_comment_ask_user_question.down.sql
+++ b/server/migrations/254_comment_ask_user_question.down.sql
@@ -1,0 +1,9 @@
+-- Revert 253: drop the metadata column and its CHECKs, and restore the
+-- original 4-value type CHECK.
+ALTER TABLE comment DROP CONSTRAINT IF EXISTS comment_metadata_size_limit;
+ALTER TABLE comment DROP CONSTRAINT IF EXISTS comment_metadata_is_object;
+ALTER TABLE comment DROP COLUMN IF EXISTS metadata;
+
+ALTER TABLE comment DROP CONSTRAINT IF EXISTS comment_type_check;
+ALTER TABLE comment ADD CONSTRAINT comment_type_check
+    CHECK (type IN ('comment', 'status_change', 'progress_update', 'system'));

--- a/server/migrations/254_comment_ask_user_question.up.sql
+++ b/server/migrations/254_comment_ask_user_question.up.sql
@@ -1,0 +1,24 @@
+-- Adds the `ask_user_question` comment type: an agent posts a structured
+-- multiple-choice question at a specific human (target_user); that user picks
+-- one option and confirms, which posts a reply back to the agent (source_user)
+-- so it can continue. The structured payload (question, options, answer state)
+-- lives in a new comment.metadata JSONB column; content still holds a
+-- human-readable Markdown fallback so old clients / mobile degrade gracefully.
+
+-- 1) Extend the type CHECK. The base constraint is the unnamed inline CHECK
+--    from 001_init.up.sql, which Postgres names `comment_type_check`.
+ALTER TABLE comment DROP CONSTRAINT IF EXISTS comment_type_check;
+ALTER TABLE comment ADD CONSTRAINT comment_type_check
+    CHECK (type IN ('comment', 'status_change', 'progress_update', 'system', 'ask_user_question'));
+
+-- 2) Structured payload column. Mirrors the issue.metadata shape: JSONB
+--    NOT NULL DEFAULT '{}', object-only, size-capped. Handler-level validation
+--    enforces the ask_user_question schema; these CHECKs are defense-in-depth
+--    against direct SQL / migrations that bypass the API.
+ALTER TABLE comment ADD COLUMN metadata JSONB NOT NULL DEFAULT '{}'::jsonb;
+
+ALTER TABLE comment ADD CONSTRAINT comment_metadata_is_object
+    CHECK (jsonb_typeof(metadata) = 'object');
+
+ALTER TABLE comment ADD CONSTRAINT comment_metadata_size_limit
+    CHECK (pg_column_size(metadata) <= 8192);

--- a/server/pkg/db/generated/comment.sql.go
+++ b/server/pkg/db/generated/comment.sql.go
@@ -45,7 +45,7 @@ UPDATE comment SET
 WHERE comment.id IN (SELECT id FROM descendants)
   AND comment.id <> $1
   AND comment.resolved_at IS NOT NULL
-RETURNING id, issue_id, author_type, author_id, content, type, created_at, updated_at, parent_id, workspace_id, resolved_at, resolved_by_type, resolved_by_id, source_task_id, quick_action_id
+RETURNING id, issue_id, author_type, author_id, content, type, created_at, updated_at, parent_id, workspace_id, resolved_at, resolved_by_type, resolved_by_id, source_task_id, quick_action_id, metadata
 `
 
 type ClearOtherThreadResolutionsParams struct {
@@ -89,6 +89,7 @@ func (q *Queries) ClearOtherThreadResolutions(ctx context.Context, arg ClearOthe
 			&i.ResolvedByID,
 			&i.SourceTaskID,
 			&i.QuickActionID,
+			&i.Metadata,
 		); err != nil {
 			return nil, err
 		}
@@ -158,13 +159,13 @@ func (q *Queries) CountNewCommentsSince(ctx context.Context, arg CountNewComment
 const createComment = `-- name: CreateComment :one
 WITH touched_issue AS (
     UPDATE issue SET updated_at = now()
-    WHERE issue.id = $8 AND issue.workspace_id = $9
+    WHERE issue.id = $9 AND issue.workspace_id = $10
     RETURNING issue.id, issue.workspace_id
 )
-INSERT INTO comment (issue_id, workspace_id, author_type, author_id, content, type, parent_id, source_task_id, quick_action_id)
-SELECT ti.id, ti.workspace_id, $1, $2, $3, $4, $5, $6, $7
+INSERT INTO comment (issue_id, workspace_id, author_type, author_id, content, type, parent_id, source_task_id, quick_action_id, metadata)
+SELECT ti.id, ti.workspace_id, $1, $2, $3, $4, $5, $6, $7, $8
 FROM touched_issue ti
-RETURNING id, issue_id, author_type, author_id, content, type, created_at, updated_at, parent_id, workspace_id, resolved_at, resolved_by_type, resolved_by_id, source_task_id, quick_action_id
+RETURNING id, issue_id, author_type, author_id, content, type, created_at, updated_at, parent_id, workspace_id, resolved_at, resolved_by_type, resolved_by_id, source_task_id, quick_action_id, metadata
 `
 
 type CreateCommentParams struct {
@@ -175,6 +176,7 @@ type CreateCommentParams struct {
 	ParentID      pgtype.UUID `json:"parent_id"`
 	SourceTaskID  pgtype.UUID `json:"source_task_id"`
 	QuickActionID pgtype.UUID `json:"quick_action_id"`
+	Metadata      []byte      `json:"metadata"`
 	IssueID       pgtype.UUID `json:"issue_id"`
 	WorkspaceID   pgtype.UUID `json:"workspace_id"`
 }
@@ -195,6 +197,9 @@ type CreateCommentParams struct {
 // Centralizing this here means every comment entrypoint inherits both
 // guarantees regardless of what a caller passes. The "Updated date" sort and
 // the daemon GC TTL both read updated_at, so this consistency is load-bearing.
+// metadata defaults to '{}' via the column default, but the INSERT lists it
+// explicitly, so every Go caller MUST pass a non-nil value (use []byte("{}")
+// for a plain comment). Passing nil sends SQL NULL and violates NOT NULL.
 func (q *Queries) CreateComment(ctx context.Context, arg CreateCommentParams) (Comment, error) {
 	row := q.db.QueryRow(ctx, createComment,
 		arg.AuthorType,
@@ -204,6 +209,7 @@ func (q *Queries) CreateComment(ctx context.Context, arg CreateCommentParams) (C
 		arg.ParentID,
 		arg.SourceTaskID,
 		arg.QuickActionID,
+		arg.Metadata,
 		arg.IssueID,
 		arg.WorkspaceID,
 	)
@@ -224,6 +230,7 @@ func (q *Queries) CreateComment(ctx context.Context, arg CreateCommentParams) (C
 		&i.ResolvedByID,
 		&i.SourceTaskID,
 		&i.QuickActionID,
+		&i.Metadata,
 	)
 	return i, err
 }
@@ -244,7 +251,7 @@ func (q *Queries) DeleteComment(ctx context.Context, arg DeleteCommentParams) er
 }
 
 const getComment = `-- name: GetComment :one
-SELECT id, issue_id, author_type, author_id, content, type, created_at, updated_at, parent_id, workspace_id, resolved_at, resolved_by_type, resolved_by_id, source_task_id, quick_action_id FROM comment
+SELECT id, issue_id, author_type, author_id, content, type, created_at, updated_at, parent_id, workspace_id, resolved_at, resolved_by_type, resolved_by_id, source_task_id, quick_action_id, metadata FROM comment
 WHERE id = $1
 `
 
@@ -267,12 +274,13 @@ func (q *Queries) GetComment(ctx context.Context, id pgtype.UUID) (Comment, erro
 		&i.ResolvedByID,
 		&i.SourceTaskID,
 		&i.QuickActionID,
+		&i.Metadata,
 	)
 	return i, err
 }
 
 const getCommentInWorkspace = `-- name: GetCommentInWorkspace :one
-SELECT id, issue_id, author_type, author_id, content, type, created_at, updated_at, parent_id, workspace_id, resolved_at, resolved_by_type, resolved_by_id, source_task_id, quick_action_id FROM comment
+SELECT id, issue_id, author_type, author_id, content, type, created_at, updated_at, parent_id, workspace_id, resolved_at, resolved_by_type, resolved_by_id, source_task_id, quick_action_id, metadata FROM comment
 WHERE id = $1 AND workspace_id = $2
 `
 
@@ -300,12 +308,13 @@ func (q *Queries) GetCommentInWorkspace(ctx context.Context, arg GetCommentInWor
 		&i.ResolvedByID,
 		&i.SourceTaskID,
 		&i.QuickActionID,
+		&i.Metadata,
 	)
 	return i, err
 }
 
 const getLatestMemberCommentForIssueSince = `-- name: GetLatestMemberCommentForIssueSince :one
-SELECT id, issue_id, author_type, author_id, content, type, created_at, updated_at, parent_id, workspace_id, resolved_at, resolved_by_type, resolved_by_id, source_task_id, quick_action_id FROM comment
+SELECT id, issue_id, author_type, author_id, content, type, created_at, updated_at, parent_id, workspace_id, resolved_at, resolved_by_type, resolved_by_id, source_task_id, quick_action_id, metadata FROM comment
 WHERE issue_id = $1
   AND author_type = 'member'
   AND created_at > $2
@@ -346,6 +355,7 @@ func (q *Queries) GetLatestMemberCommentForIssueSince(ctx context.Context, arg G
 		&i.ResolvedByID,
 		&i.SourceTaskID,
 		&i.QuickActionID,
+		&i.Metadata,
 	)
 	return i, err
 }
@@ -360,7 +370,7 @@ WITH RECURSIVE root_of AS (
     FROM comment p
     JOIN root_of r ON p.id = r.parent_id
 )
-SELECT c.id, c.issue_id, c.author_type, c.author_id, c.content, c.type, c.created_at, c.updated_at, c.parent_id, c.workspace_id, c.resolved_at, c.resolved_by_type, c.resolved_by_id, c.source_task_id, c.quick_action_id FROM comment c
+SELECT c.id, c.issue_id, c.author_type, c.author_id, c.content, c.type, c.created_at, c.updated_at, c.parent_id, c.workspace_id, c.resolved_at, c.resolved_by_type, c.resolved_by_id, c.source_task_id, c.quick_action_id, c.metadata FROM comment c
 WHERE c.id = (SELECT id FROM root_of WHERE parent_id IS NULL LIMIT 1)
 `
 
@@ -393,6 +403,7 @@ func (q *Queries) GetThreadRoot(ctx context.Context, arg GetThreadRootParams) (C
 		&i.ResolvedByID,
 		&i.SourceTaskID,
 		&i.QuickActionID,
+		&i.Metadata,
 	)
 	return i, err
 }
@@ -441,7 +452,7 @@ func (q *Queries) HasAgentRepliedInThread(ctx context.Context, arg HasAgentRepli
 }
 
 const listChildCommentsForParents = `-- name: ListChildCommentsForParents :many
-SELECT id, issue_id, author_type, author_id, content, type, created_at, updated_at, parent_id, workspace_id, resolved_at, resolved_by_type, resolved_by_id, source_task_id, quick_action_id FROM comment
+SELECT id, issue_id, author_type, author_id, content, type, created_at, updated_at, parent_id, workspace_id, resolved_at, resolved_by_type, resolved_by_id, source_task_id, quick_action_id, metadata FROM comment
 WHERE parent_id = ANY($1::uuid[])
   AND issue_id = $2
   AND workspace_id = $3
@@ -500,6 +511,7 @@ func (q *Queries) ListChildCommentsForParents(ctx context.Context, arg ListChild
 			&i.ResolvedByID,
 			&i.SourceTaskID,
 			&i.QuickActionID,
+			&i.Metadata,
 		); err != nil {
 			return nil, err
 		}
@@ -512,7 +524,7 @@ func (q *Queries) ListChildCommentsForParents(ctx context.Context, arg ListChild
 }
 
 const listCommentsByIDsForIssue = `-- name: ListCommentsByIDsForIssue :many
-SELECT id, issue_id, author_type, author_id, content, type, created_at, updated_at, parent_id, workspace_id, resolved_at, resolved_by_type, resolved_by_id, source_task_id, quick_action_id FROM comment
+SELECT id, issue_id, author_type, author_id, content, type, created_at, updated_at, parent_id, workspace_id, resolved_at, resolved_by_type, resolved_by_id, source_task_id, quick_action_id, metadata FROM comment
 WHERE id = ANY($1::uuid[])
   AND issue_id = $2
   AND workspace_id = $3
@@ -559,6 +571,7 @@ func (q *Queries) ListCommentsByIDsForIssue(ctx context.Context, arg ListComment
 			&i.ResolvedByID,
 			&i.SourceTaskID,
 			&i.QuickActionID,
+			&i.Metadata,
 		); err != nil {
 			return nil, err
 		}
@@ -571,8 +584,8 @@ func (q *Queries) ListCommentsByIDsForIssue(ctx context.Context, arg ListComment
 }
 
 const listCommentsForIssue = `-- name: ListCommentsForIssue :many
-SELECT id, issue_id, author_type, author_id, content, type, created_at, updated_at, parent_id, workspace_id, resolved_at, resolved_by_type, resolved_by_id, source_task_id, quick_action_id FROM (
-    SELECT id, issue_id, author_type, author_id, content, type, created_at, updated_at, parent_id, workspace_id, resolved_at, resolved_by_type, resolved_by_id, source_task_id, quick_action_id FROM comment
+SELECT id, issue_id, author_type, author_id, content, type, created_at, updated_at, parent_id, workspace_id, resolved_at, resolved_by_type, resolved_by_id, source_task_id, quick_action_id, metadata FROM (
+    SELECT id, issue_id, author_type, author_id, content, type, created_at, updated_at, parent_id, workspace_id, resolved_at, resolved_by_type, resolved_by_id, source_task_id, quick_action_id, metadata FROM comment
     WHERE issue_id = $1 AND workspace_id = $2
     ORDER BY created_at DESC, id DESC
     LIMIT $3
@@ -628,6 +641,7 @@ func (q *Queries) ListCommentsForIssue(ctx context.Context, arg ListCommentsForI
 			&i.ResolvedByID,
 			&i.SourceTaskID,
 			&i.QuickActionID,
+			&i.Metadata,
 		); err != nil {
 			return nil, err
 		}
@@ -640,7 +654,7 @@ func (q *Queries) ListCommentsForIssue(ctx context.Context, arg ListCommentsForI
 }
 
 const listCommentsSinceForIssue = `-- name: ListCommentsSinceForIssue :many
-SELECT id, issue_id, author_type, author_id, content, type, created_at, updated_at, parent_id, workspace_id, resolved_at, resolved_by_type, resolved_by_id, source_task_id, quick_action_id FROM comment
+SELECT id, issue_id, author_type, author_id, content, type, created_at, updated_at, parent_id, workspace_id, resolved_at, resolved_by_type, resolved_by_id, source_task_id, quick_action_id, metadata FROM comment
 WHERE issue_id = $1 AND workspace_id = $2 AND created_at > $3
 ORDER BY created_at ASC, id ASC
 LIMIT $4
@@ -685,6 +699,7 @@ func (q *Queries) ListCommentsSinceForIssue(ctx context.Context, arg ListComment
 			&i.ResolvedByID,
 			&i.SourceTaskID,
 			&i.QuickActionID,
+			&i.Metadata,
 		); err != nil {
 			return nil, err
 		}
@@ -842,7 +857,7 @@ func (q *Queries) ListRecentThreadCommentsForIssue(ctx context.Context, arg List
 }
 
 const listReconcilableCommentsForIssueSince = `-- name: ListReconcilableCommentsForIssueSince :many
-SELECT id, issue_id, author_type, author_id, content, type, created_at, updated_at, parent_id, workspace_id, resolved_at, resolved_by_type, resolved_by_id, source_task_id, quick_action_id FROM comment
+SELECT id, issue_id, author_type, author_id, content, type, created_at, updated_at, parent_id, workspace_id, resolved_at, resolved_by_type, resolved_by_id, source_task_id, quick_action_id, metadata FROM comment
 WHERE issue_id = $1
   AND author_type IN ('member', 'agent')
   AND (
@@ -910,6 +925,7 @@ func (q *Queries) ListReconcilableCommentsForIssueSince(ctx context.Context, arg
 			&i.ResolvedByID,
 			&i.SourceTaskID,
 			&i.QuickActionID,
+			&i.Metadata,
 		); err != nil {
 			return nil, err
 		}
@@ -1312,7 +1328,7 @@ UPDATE comment SET
     resolved_by_id = COALESCE(resolved_by_id, $3),
     updated_at = CASE WHEN resolved_at IS NULL THEN now() ELSE updated_at END
 WHERE id = $1
-RETURNING id, issue_id, author_type, author_id, content, type, created_at, updated_at, parent_id, workspace_id, resolved_at, resolved_by_type, resolved_by_id, source_task_id, quick_action_id
+RETURNING id, issue_id, author_type, author_id, content, type, created_at, updated_at, parent_id, workspace_id, resolved_at, resolved_by_type, resolved_by_id, source_task_id, quick_action_id, metadata
 `
 
 type ResolveCommentParams struct {
@@ -1342,6 +1358,7 @@ func (q *Queries) ResolveComment(ctx context.Context, arg ResolveCommentParams) 
 		&i.ResolvedByID,
 		&i.SourceTaskID,
 		&i.QuickActionID,
+		&i.Metadata,
 	)
 	return i, err
 }
@@ -1353,7 +1370,7 @@ UPDATE comment SET
     resolved_by_id = NULL,
     updated_at = CASE WHEN resolved_at IS NOT NULL THEN now() ELSE updated_at END
 WHERE id = $1
-RETURNING id, issue_id, author_type, author_id, content, type, created_at, updated_at, parent_id, workspace_id, resolved_at, resolved_by_type, resolved_by_id, source_task_id, quick_action_id
+RETURNING id, issue_id, author_type, author_id, content, type, created_at, updated_at, parent_id, workspace_id, resolved_at, resolved_by_type, resolved_by_id, source_task_id, quick_action_id, metadata
 `
 
 // Idempotent: a no-op clear (already unresolved) just returns the row.
@@ -1376,6 +1393,7 @@ func (q *Queries) UnresolveComment(ctx context.Context, id pgtype.UUID) (Comment
 		&i.ResolvedByID,
 		&i.SourceTaskID,
 		&i.QuickActionID,
+		&i.Metadata,
 	)
 	return i, err
 }
@@ -1386,7 +1404,7 @@ UPDATE comment SET
     source_task_id = $3,
     updated_at = now()
 WHERE id = $1
-RETURNING id, issue_id, author_type, author_id, content, type, created_at, updated_at, parent_id, workspace_id, resolved_at, resolved_by_type, resolved_by_id, source_task_id, quick_action_id
+RETURNING id, issue_id, author_type, author_id, content, type, created_at, updated_at, parent_id, workspace_id, resolved_at, resolved_by_type, resolved_by_id, source_task_id, quick_action_id, metadata
 `
 
 type UpdateCommentParams struct {
@@ -1414,6 +1432,50 @@ func (q *Queries) UpdateComment(ctx context.Context, arg UpdateCommentParams) (C
 		&i.ResolvedByID,
 		&i.SourceTaskID,
 		&i.QuickActionID,
+		&i.Metadata,
+	)
+	return i, err
+}
+
+const updateCommentAnswer = `-- name: UpdateCommentAnswer :one
+UPDATE comment SET
+    metadata = jsonb_set(metadata, '{ask_user_question,answer}', $3::jsonb, true),
+    updated_at = now()
+WHERE id = $1 AND workspace_id = $2
+RETURNING id, issue_id, author_type, author_id, content, type, created_at, updated_at, parent_id, workspace_id, resolved_at, resolved_by_type, resolved_by_id, source_task_id, quick_action_id, metadata
+`
+
+type UpdateCommentAnswerParams struct {
+	ID          pgtype.UUID `json:"id"`
+	WorkspaceID pgtype.UUID `json:"workspace_id"`
+	Answer      []byte      `json:"answer"`
+}
+
+// Records the answer for an ask_user_question comment by setting the
+// metadata.ask_user_question.answer object. Uses jsonb_set so the rest of the
+// payload (question, options, target_user, source_user) is preserved. The
+// handler is responsible for idempotency (rejecting if an answer already
+// exists) — this query unconditionally overwrites.
+func (q *Queries) UpdateCommentAnswer(ctx context.Context, arg UpdateCommentAnswerParams) (Comment, error) {
+	row := q.db.QueryRow(ctx, updateCommentAnswer, arg.ID, arg.WorkspaceID, arg.Answer)
+	var i Comment
+	err := row.Scan(
+		&i.ID,
+		&i.IssueID,
+		&i.AuthorType,
+		&i.AuthorID,
+		&i.Content,
+		&i.Type,
+		&i.CreatedAt,
+		&i.UpdatedAt,
+		&i.ParentID,
+		&i.WorkspaceID,
+		&i.ResolvedAt,
+		&i.ResolvedByType,
+		&i.ResolvedByID,
+		&i.SourceTaskID,
+		&i.QuickActionID,
+		&i.Metadata,
 	)
 	return i, err
 }

--- a/server/pkg/db/generated/models.go
+++ b/server/pkg/db/generated/models.go
@@ -458,6 +458,7 @@ type Comment struct {
 	ResolvedByID   pgtype.UUID        `json:"resolved_by_id"`
 	SourceTaskID   pgtype.UUID        `json:"source_task_id"`
 	QuickActionID  pgtype.UUID        `json:"quick_action_id"`
+	Metadata       []byte             `json:"metadata"`
 }
 
 type CommentReaction struct {

--- a/server/pkg/db/queries/comment.sql
+++ b/server/pkg/db/queries/comment.sql
@@ -430,8 +430,11 @@ WITH touched_issue AS (
     WHERE issue.id = sqlc.arg(issue_id) AND issue.workspace_id = sqlc.arg(workspace_id)
     RETURNING issue.id, issue.workspace_id
 )
-INSERT INTO comment (issue_id, workspace_id, author_type, author_id, content, type, parent_id, source_task_id, quick_action_id)
-SELECT ti.id, ti.workspace_id, sqlc.arg(author_type), sqlc.arg(author_id), sqlc.arg(content), sqlc.arg(type), sqlc.narg(parent_id), sqlc.narg(source_task_id), sqlc.narg(quick_action_id)
+-- metadata defaults to '{}' via the column default, but the INSERT lists it
+-- explicitly, so every Go caller MUST pass a non-nil value (use []byte("{}")
+-- for a plain comment). Passing nil sends SQL NULL and violates NOT NULL.
+INSERT INTO comment (issue_id, workspace_id, author_type, author_id, content, type, parent_id, source_task_id, quick_action_id, metadata)
+SELECT ti.id, ti.workspace_id, sqlc.arg(author_type), sqlc.arg(author_id), sqlc.arg(content), sqlc.arg(type), sqlc.narg(parent_id), sqlc.narg(source_task_id), sqlc.narg(quick_action_id), sqlc.arg(metadata)
 FROM touched_issue ti
 RETURNING *;
 
@@ -441,6 +444,18 @@ UPDATE comment SET
     source_task_id = sqlc.narg(source_task_id),
     updated_at = now()
 WHERE id = $1
+RETURNING *;
+
+-- name: UpdateCommentAnswer :one
+-- Records the answer for an ask_user_question comment by setting the
+-- metadata.ask_user_question.answer object. Uses jsonb_set so the rest of the
+-- payload (question, options, target_user, source_user) is preserved. The
+-- handler is responsible for idempotency (rejecting if an answer already
+-- exists) — this query unconditionally overwrites.
+UPDATE comment SET
+    metadata = jsonb_set(metadata, '{ask_user_question,answer}', @answer::jsonb, true),
+    updated_at = now()
+WHERE id = $1 AND workspace_id = $2
 RETURNING *;
 
 -- name: HasAgentCommentedSince :one


### PR DESCRIPTION
---
Port the ask_user_question feature: an agent posts a structured multiple-choice question at a specific human, rendered as a selectable card. The target user picks an option (single/multi/custom) and confirms, which records the answer and posts a reply @mentioning the source agent so it resumes.

- DB: migration 253 adds comment.metadata JSONB + extends type CHECK; CreateComment carries metadata, new UpdateCommentAnswer query (regenerated via sqlc, not hand-edited)
- server: AnswerAskUserQuestion handler + POST /api/comments/{id}/answer, CreateComment validates the payload (agent-only, target must be a workspace member), CommentResponse/TimelineEntry expose metadata
- daemon/CLI: BuildAskUserQuestionHint injected into both prompt paths; issue comment add --type ask_user_question with --target-user / --question / --options-json / --multi-select / --allow-custom
- frontend: AskUserQuestionCard, comment-card wiring (root + reply), types + zod schemas (drift-tolerant) + client method + mutation hook, i18n for en/zh-Hans/ja/ko
- tests: handler, CLI, prompt hint, schema drift, card component

What does this PR do?

Adds a new ask_user_question comment type so an agent can ask a human a structured decision instead of a free-prose question. When an agent needs the user to make a choice (pick an option, approve/reject, resolve ambiguity), it posts a question aimed at a specific workspace member; the UI renders it as a selectable card. The target user picks one or more options (or types a custom answer), confirms, and the server records the answer and auto-posts a reply that @mentions the source agent — which re-triggers the agent through the normal mention path so it resumes with an unambiguous answer.

The problem it solves: prose questions are ambiguous and easy for the user to miss or answer in a form the agent can't parse. A structured card makes the ask explicit, one-click to answer, and the answer round-trips back to the agent deterministically.

The approach keeps the structured payload in a new comment.metadata JSONB column (namespaced under an ask_user_question key) with a human-readable Markdown fallback in content, so old/mobile clients that don't understand the type still show the question and options and degrade gracefully.

Related Issue

<!-- Link the issue this PR addresses. If no issue exists, consider creating one first. -->

Closes #

Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Refactor / code improvement (no behavior change)
- [ ] Documentation update
- [ ] Tests (adding or improving test coverage)
- [ ] CI / infrastructure

Changes Made

DB
- server/migrations/253_comment_ask_user_question.up.sql / .down.sql — add comment.metadata JSONB NOT NULL DEFAULT '{}' (object-only, size-capped) and extend comment_type_check with ask_user_question
- server/pkg/db/queries/comment.sql — CreateComment now carries metadata; new UpdateCommentAnswer query using jsonb_set to writeer/pkg/db/generated/{comment.sql.go,models.go} via make sqlc (not hand-edited)

Server
- server/internal/handler/comment_ask_user_question.go (new) — AnswerAskUserQuestion handler + payload types/validation + confirmation-reply that re-triggers the source agent
- server/internal/handler/comment.go — CreateComment validates ask_user_question (agent-only author, target_user must be a worksed to the resolved author, answer must be absent on create); CommentResponse exposes metadata
- server/internal/handler/activity.go — TimelineEntry exposes metadata
- server/cmd/server/router.go — POST /api/comments/{commentId}/answer
- server/internal/handler/{issue_child_done,quick_action}.go, server/internal/service/task.go — pass metadata: {} on their CreateComment calls (column is NOT NULL)

Daemon / CLI
- server/internal/daemon/execenv/reply_instructions.go — new BuildAskUserQuestionHint
- server/internal/daemon/prompt.go — inject the hint into both the assignment and comment prompt paths
- server/cmd/multica/cmd_issue.go — issue comment add --type ask_user_question with --target-user / --question / --options-json stom, plus target-user resolution (UUID / name / email)

Frontend
- packages/views/issues/components/ask-user-question-card.tsx (new) + comment-card wiring (root + reply render paths)
- packages/core/types/{comment,activity,index}.ts — types
- packages/core/api/schemas.ts — drift-tolerant zod schemas on CommentSchema + TimelineEntrySchema
- packages/core/api/client.ts — answerAskUserQuestion method; packages/core/issues/mutations.ts — useAnswerAskUserQuestion hook
- packages/views/locales/{en,zh-Hans,ja,ko}/issues.json — i18n

Tests
- Go: handler (comment_ask_user_question_test.go), CLI (cmd_issue_ask_user_question_test.go), prompt-hint injection
- TS: schema drift (schemas.test.ts), card component (ask-user-question-card.test.tsx)

How to Test

1. DB: make migrate-up (applies 253), then make sqlc is a no-op if generated code is in sync.
2. Backend: cd server && go build ./... && go vet ./... && go test ./internal/handler/ ./cmd/multica/ ./internal/daemon/ — all g
3. Frontend: pnpm typecheck && pnpm lint, then pnpm --filter @multica/core test and pnpm --filter @multica/views exec vitest run issues/components/ask-user-question-card.test.tsx.
4. End-to-end (manual): as an agent, run multica issue comment add <issue> --type ask_user_question --target-user <name|email|uuid> --question "Which cache?" --options-json '[{"label":"Redis","description":"distributed"},{"label":"Local","description":"single-node"}]'. Open the issue as the target user → a selectable card renders → pick an option and confirm → a reply comment (我选择【…】) is posted @mentioning the agent, which re-triggers it. Verify a non-target user gets 403 and a second answer gets 409.

Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [ ] I have updated relevant documentation to reflect my changes
- [ ] If I added a new runtime / coding tool / UI tab, I synced the change to landing copy (apps/web/features/landing/i18n/) andtent/docs/)
- [x] If this PR touches Chinese product copy, I checked it against apps/docs/content/docs/developers/conventions.zh.mdx (terminissue / skill)
- [x] I have considered and documented any risks above
- [ ] I will address all reviewer comments before requesting merge

AI Disclosure

AI tool used: Claude Code

Prompt / approach: Ported the feature from an internal fork onto the current upstream main. Because the fork branched from a much older upstream point, the work was done as a per-file incremental port rather than a file copy: two Explore agents first mapped every touched file and classified new-vs-modified, then each change was re-applied on top of main's current shape (e.g. adapting to the drifted triggereping the DB layer as a proper migration + make sqlc regen instead of the fork's hand-edited generated code). Verified with fullbackend build/vet/test and frontend typecheck/lint/test before opening.