### PR TITLE
feat(runtime): fail over provider-limit retries

### DIFF
--- a/server/internal/handler/daemon.go
+++ b/server/internal/handler/daemon.go
@@ -1635,6 +1635,31 @@ type claimBuildFailure struct {
 func (h *Handler) buildClaimedTaskResponse(r *http.Request, task *db.AgentTaskQueue, runtime db.AgentRuntime, runtimeID, runtimeWorkspaceID string) (resp AgentTaskResponse, deliveredCommentIDs []pgtype.UUID, agentSkillCount, builtinSkillCount int, failure *claimBuildFailure) {
 	// Build response with fresh agent data (name + skills + custom_env + custom_args).
 	resp = taskToResponse(*task, runtimeWorkspaceID)
+	// Automatic retries resume from their exact parent, including when a
+	// provider-limit failover routed the child to another account on the same
+	// daemon. Resolve this before the issue/chat fallback lookups so a parallel
+	// task can never replace the intended continuation source.
+	retryResumeResolved := false
+	if task.RetryOfTaskID.Valid {
+		retryResumeResolved = true
+		if src, err := h.Queries.GetAgentTask(r.Context(), task.RetryOfTaskID); err == nil {
+			if src.WorkDir.Valid {
+				resp.PriorWorkDir = src.WorkDir.String
+			}
+			compatible := src.RuntimeID == task.RuntimeID
+			if !compatible {
+				if sourceRuntime, rerr := h.Queries.GetAgentRuntime(r.Context(), src.RuntimeID); rerr == nil {
+					compatible = service.RuntimeResumeCompatible(sourceRuntime, runtime)
+				}
+			}
+			if compatible && !service.ResumeUnsafeFailure(src.FailureReason.String, src.Error.String) && src.SessionID.Valid {
+				resp.PriorSessionID = src.SessionID.String
+			}
+			if src.SessionRolloutMissing {
+				resp.PriorSessionResumeUnavailable = true
+			}
+		}
+	}
 	supportsCoalescedComments := requestHasClientCapability(r, protocol.DaemonCapabilityCoalescedCommentsV1)
 	// Empty-but-non-nil so pgx persists '{}' rather than NULL for tasks without
 	// comment input. Comment tasks replace this with the ids actually embedded
@@ -2064,7 +2089,7 @@ func (h *Handler) buildClaimedTaskResponse(r *http.Request, task *db.AgentTaskQu
 					resp.PriorSessionResumeUnavailable = true
 				}
 			}
-		} else if !task.ForceFreshSession {
+		} else if !retryResumeResolved && !task.ForceFreshSession {
 			// Non-rerun follow-up on the same issue: resume the most recent
 			// (agent, issue) session so the agent keeps the issue's conversation
 			// context across turns. The "Focus on THIS comment" guard in
@@ -2199,7 +2224,7 @@ func (h *Handler) buildClaimedTaskResponse(r *http.Request, task *db.AgentTaskQu
 					resp.Repos = repos
 				}
 			}
-			if !task.ForceFreshSession {
+			if !retryResumeResolved && !task.ForceFreshSession {
 				// Resume chat sessions only when the stored pointer was produced
 				// by the same runtime as the claiming task. When the chat_session
 				// pointer is missing (legacy NULL runtime_id), stale (last task

--- a/server/internal/handler/daemon_test.go
+++ b/server/internal/handler/daemon_test.go
@@ -3654,6 +3654,69 @@ func TestClaimTask_ManualRetryReusesWorkdir(t *testing.T) {
 	})
 }
 
+func TestClaimTask_AutoRetryResumesAcrossCompatibleRuntime(t *testing.T) {
+	if testHandler == nil {
+		t.Skip("database not available")
+	}
+	ctx := context.Background()
+
+	agentID, sourceRuntimeID, daemonID := createRuntimeGuardAgent(t, ctx)
+	profileID := insertRuntimeProfileFixture(t, ctx, "Failover Runtime", "opencode", "opencode-failover")
+	var targetRuntimeID string
+	if err := testPool.QueryRow(ctx, `
+		INSERT INTO agent_runtime (
+			workspace_id, daemon_id, name, runtime_mode, provider, status,
+			device_info, metadata, owner_id, profile_id, last_seen_at
+		)
+		VALUES ($1, $2, 'Failover Runtime', 'local', 'opencode', 'online',
+		       'failover fixture', '{}'::jsonb, $3, $4, now())
+		RETURNING id
+	`, testWorkspaceID, daemonID, testUserID, profileID).Scan(&targetRuntimeID); err != nil {
+		t.Fatalf("setup: create compatible failover runtime: %v", err)
+	}
+	t.Cleanup(func() { testPool.Exec(ctx, `DELETE FROM agent_runtime WHERE id = $1`, targetRuntimeID) })
+
+	var issueID string
+	if err := testPool.QueryRow(ctx, `
+		INSERT INTO issue (workspace_id, title, status, priority, creator_id, creator_type, number, position)
+		VALUES ($1, 'runtime failover retry fixture', 'in_progress', 'none', $2, 'member', 81220, 0)
+		RETURNING id
+	`, testWorkspaceID, testUserID).Scan(&issueID); err != nil {
+		t.Fatalf("setup: create issue: %v", err)
+	}
+	t.Cleanup(func() { testPool.Exec(ctx, `DELETE FROM issue WHERE id = $1`, issueID) })
+
+	var sourceTaskID string
+	if err := testPool.QueryRow(ctx, `
+		INSERT INTO agent_task_queue (
+			agent_id, runtime_id, issue_id, status, priority, attempt, max_attempts,
+			failure_reason, error, session_id, work_dir
+		)
+		VALUES ($1, $2, $3, 'failed', 0, 1, 2,
+		        'agent_error.provider_quota_limit', 'session limit', 'failover-session', '/tmp/failover-workdir')
+		RETURNING id
+	`, agentID, sourceRuntimeID, issueID).Scan(&sourceTaskID); err != nil {
+		t.Fatalf("setup: create source task: %v", err)
+	}
+	if _, err := testPool.Exec(ctx, `
+		INSERT INTO agent_task_queue (
+			agent_id, runtime_id, issue_id, status, priority, attempt, max_attempts,
+			parent_task_id, retry_of_task_id
+		)
+		VALUES ($1, $2, $3, 'queued', 0, 2, 2, $4, $4)
+	`, agentID, targetRuntimeID, issueID, sourceTaskID); err != nil {
+		t.Fatalf("setup: create failover retry: %v", err)
+	}
+
+	task := claimTaskForRuntimeGuard(t, targetRuntimeID, daemonID)
+	if task.PriorWorkDir != "/tmp/failover-workdir" {
+		t.Fatalf("PriorWorkDir = %q, want source workdir", task.PriorWorkDir)
+	}
+	if task.PriorSessionID != "failover-session" {
+		t.Fatalf("PriorSessionID = %q, want exact source session", task.PriorSessionID)
+	}
+}
+
 func TestClaimTask_ChatPriorSessionRuntimeGuard(t *testing.T) {
 	if testHandler == nil {
 		t.Skip("database not available")

--- a/server/internal/service/builtin_skills/multica-creating-agents/SKILL.md
+++ b/server/internal/service/builtin_skills/multica-creating-agents/SKILL.md
@@ -122,7 +122,7 @@ multica agent copy <source-agent-id> --runtime-id <target> --model <model>  # cr
 | `thinking_level` | `agent.thinking_level` (nullable) | provider-level enum; unknown literal → 400 | daemon; empty = runtime default |
 | `service_tier` | `agent.service_tier` (nullable) | Codex-only safe token; other providers reject; exact model/tier pair checked by daemon | daemon → Codex app-server; empty = local Codex config |
 | `custom_args` | `agent.custom_args` (JSON array) | JSON shape checked CLI-side; server stores as-is | daemon (extra CLI switches); defaults to `[]` |
-| `runtime_config` | `agent.runtime_config` (JSON) | JSON shape checked CLI-side; server stores as-is | runtime-specific config; defaults to `{}` |
+| `runtime_config` | `agent.runtime_config` (JSON) | JSON shape checked CLI-side; server stores as-is | runtime-specific config and server-side failover policy; defaults to `{}` |
 | `custom_env` | `agent.custom_env` (JSON object) | — | daemon (process env); see Env & secrets |
 | `mcp_config` | `agent.mcp_config` (raw JSON) | CLI checks it is a JSON object or `null`; server stores as-is. At create, literal `null` is dropped (no-op); at update, `null` clears the column | daemon → provider (provider-specific MCP handling); redacted on read |
 | `visibility` | `agent.visibility` | — | access control; defaults to `private`; gates who can read/route a private agent (e.g. a private squad leader) — NOT the runtime prompt |
@@ -135,6 +135,21 @@ Other defaults when omitted: `runtime_config` → `{}`, `custom_env` → `{}`,
 (all materialized server-side before the insert). `custom_args`/`runtime_config`
 are typed `[]string`/`any` and marshaled as-is — the JSON-shape rejection
 happens in the CLI, not the create handler.
+
+To opt into provider-limit failover, set an ordered list of alternate runtime
+ids in `runtime_config`:
+
+```json
+{"failover":{"runtime_ids":["<alternate-runtime-uuid>"]}}
+```
+
+The server uses this list only after a provider quota/session/rate-limit
+failure. It creates a bounded retry child on the first online candidate that
+shares the source runtime's workspace, owner, daemon, and provider; other
+failures retain their existing retry behavior. The agent's default runtime is
+not mutated. Cross-runtime continuation reuses the exact failed task's workdir
+and, when resume-safe, its provider session. This is resumptive failover after
+the provider returns a limit error, not live process migration.
 
 The 1–50 concurrency range applies consistently to manual create, update, and
 the create-from-template HTTP path. On create paths, an omitted field defaults

--- a/server/internal/service/builtin_skills/multica-creating-agents/references/creating-agents-source-map.md
+++ b/server/internal/service/builtin_skills/multica-creating-agents/references/creating-agents-source-map.md
@@ -70,6 +70,7 @@ only.
 | `thinking_level` provider-level validation | 896–903 | `!agent.IsKnownThinkingValue(runtime.Provider, req.ThinkingLevel)` → 400; fixed providers use an enum, Codex/OpenCode use safe-token syntax, and per-model gaps are deferred to daemon (MUL-2339) |
 | `service_tier` provider-level validation | `agent.go` create/update paths | Non-empty values are Codex-only safe tokens; exact per-model support is daemon-owned |
 | Defaults: `{}` config/env, `[]` args | 688–701 | `RuntimeConfig`→`{}`, `CustomEnv`→`{}`, `CustomArgs`→`[]` when nil, before insert |
+| Provider-limit failover config | `internal/service/task_failover.go`; `internal/service/task.go`; `internal/handler/daemon.go` | `runtime_config.failover.runtime_ids` selects the first online same-workspace/owner/daemon/provider alternate; retry child overrides `runtime_id` and resumes from its exact parent |
 | `visibility` default | 635–636 | `if req.Visibility == "" { req.Visibility = "private" }` — access-control field, not the runtime prompt |
 | `max_concurrent_tasks` create/default validation | `agent.go`; `agent_validation.go`; `internal/agentconfig/concurrency.go` | Shared 1–50 validator; a missing or explicit `null` field defaults to 6, while an explicitly supplied numeric 0/out-of-range value returns 400 |
 | `max_concurrent_tasks` update validation | 1660–1666 | Omission preserves the existing value; a supplied value outside 1–50 returns 400 before persistence |

--- a/server/internal/service/retry_deferred_test.go
+++ b/server/internal/service/retry_deferred_test.go
@@ -21,13 +21,22 @@ func TestCreateRetryTaskFireAtControlsDeferral(t *testing.T) {
 	pool := newResolveOriginatorPool(t)
 	ctx := context.Background()
 	q := db.New(pool)
-	_, _, agentID, issueID := seedAttributionFixture(t, pool)
+	workspaceID, userID, agentID, issueID := seedAttributionFixture(t, pool)
 
 	// agent_task_queue.runtime_id is NOT NULL; reuse the fixture agent's runtime.
 	var runtimeID string
 	if err := pool.QueryRow(ctx, `SELECT runtime_id::text FROM agent WHERE id = $1`, agentID).Scan(&runtimeID); err != nil {
 		t.Fatalf("read agent runtime: %v", err)
 	}
+	var alternateRuntimeID string
+	if err := pool.QueryRow(ctx, `
+		INSERT INTO agent_runtime (workspace_id, name, runtime_mode, provider, status, device_info, metadata, owner_id)
+		VALUES ($1, 'retry alternate', 'cloud', 'claude', 'online', '', '{}'::jsonb, $2)
+		RETURNING id
+	`, workspaceID, userID).Scan(&alternateRuntimeID); err != nil {
+		t.Fatalf("insert alternate runtime: %v", err)
+	}
+	t.Cleanup(func() { pool.Exec(context.Background(), `DELETE FROM agent_runtime WHERE id = $1`, alternateRuntimeID) })
 
 	// Parent: a provider_network failure on its second attempt — the point at
 	// which the schedule wants the next (final) retry deferred.
@@ -50,16 +59,18 @@ func TestCreateRetryTaskFireAtControlsDeferral(t *testing.T) {
 		wantStatus      string
 		wantFireAt      bool
 		wantMaxAttempts int32
+		runtimeID       pgtype.UUID
+		wantRuntimeID   string
 	}{
 		// Final tier: deferred, and the effective budget (3) written into the row
 		// so it self-describes as attempt=3/max_attempts=3, not attempt=3/max=2.
-		{"deferred final tier persists budget", pgtype.Timestamptz{Time: time.Now().Add(5 * time.Second), Valid: true}, pgtype.Int4{Int32: 3, Valid: true}, "deferred", true, 3},
+		{"deferred final tier persists budget", pgtype.Timestamptz{Time: time.Now().Add(5 * time.Second), Valid: true}, pgtype.Int4{Int32: 3, Valid: true}, "deferred", true, 3, pgtype.UUID{}, runtimeID},
 		// NULL max_attempts inherits the parent's column (COALESCE fallback).
-		{"queued immediate tier inherits budget", pgtype.Timestamptz{}, pgtype.Int4{}, "queued", false, 2},
+		{"queued immediate tier can override runtime", pgtype.Timestamptz{}, pgtype.Int4{}, "queued", false, 2, util.MustParseUUID(alternateRuntimeID), alternateRuntimeID},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			child, err := q.CreateRetryTask(ctx, db.CreateRetryTaskParams{ID: parentID, FireAt: tc.fireAt, MaxAttempts: tc.maxAttempts})
+			child, err := q.CreateRetryTask(ctx, db.CreateRetryTaskParams{ID: parentID, RuntimeID: tc.runtimeID, FireAt: tc.fireAt, MaxAttempts: tc.maxAttempts})
 			if err != nil {
 				t.Fatalf("CreateRetryTask: %v", err)
 			}
@@ -76,6 +87,9 @@ func TestCreateRetryTaskFireAtControlsDeferral(t *testing.T) {
 			}
 			if child.MaxAttempts != tc.wantMaxAttempts {
 				t.Errorf("max_attempts = %d, want %d", child.MaxAttempts, tc.wantMaxAttempts)
+			}
+			if got := util.UUIDToString(child.RuntimeID); got != tc.wantRuntimeID {
+				t.Errorf("runtime_id = %s, want %s", got, tc.wantRuntimeID)
 			}
 			// provider_network is resume-safe: the retry must continue the session.
 			if child.ForceFreshSession {

--- a/server/internal/service/task.go
+++ b/server/internal/service/task.go
@@ -3335,6 +3335,7 @@ func (s *TaskService) FailTask(ctx context.Context, taskID pgtype.UUID, errMsg, 
 		retryOverlay     runtimeMCPOverlayData
 		retryFireAt      pgtype.Timestamptz
 		retryMaxAttempts pgtype.Int4
+		retryRuntimeID   pgtype.UUID
 	)
 	if retryableReasons[failureReason] {
 		if parent, perr := s.Queries.GetAgentTask(ctx, taskID); perr != nil {
@@ -3342,6 +3343,7 @@ func (s *TaskService) FailTask(ctx context.Context, taskID pgtype.UUID, errMsg, 
 				"task_id", util.UUIDToString(taskID), "error", perr)
 		} else if retryEligible(failureReason, parent) {
 			wantRetry = true
+			retryRuntimeID = parent.RuntimeID
 			// Persist the reason-aware effective budget into the child so the
 			// retry chain self-describes (e.g. provider_network → max_attempts=3),
 			// rather than leaking a contradictory attempt=N/max_attempts=2 row.
@@ -3358,8 +3360,28 @@ func (s *TaskService) FailTask(ctx context.Context, taskID pgtype.UUID, errMsg, 
 				slog.Warn("fail task auto-retry: load agent for overlay failed",
 					"task_id", util.UUIDToString(taskID),
 					"agent_id", util.UUIDToString(parent.AgentID), "error", aerr)
+				if isFailoverOnlyRetryReason(failureReason) {
+					wantRetry = false
+				}
 			} else {
 				retryOverlay = s.buildRuntimeMCPOverlay(ctx, parent.OriginatorUserID, agent)
+				if isFailoverOnlyRetryReason(failureReason) {
+					target, ok, ferr := s.configuredFailoverRuntime(ctx, agent, parent.RuntimeID)
+					switch {
+					case ferr != nil:
+						slog.Warn("fail task auto-retry: resolve failover runtime failed",
+							"task_id", util.UUIDToString(taskID), "error", ferr)
+						wantRetry = false
+					case !ok:
+						slog.Info("fail task auto-retry skipped: no compatible failover runtime",
+							"task_id", util.UUIDToString(taskID),
+							"runtime_id", util.UUIDToString(parent.RuntimeID),
+							"reason", failureReason)
+						wantRetry = false
+					default:
+						retryRuntimeID = target
+					}
+				}
 			}
 		}
 	}
@@ -3453,6 +3475,7 @@ func (s *TaskService) FailTask(ctx context.Context, taskID pgtype.UUID, errMsg, 
 		if wantRetry {
 			child, cerr := qtx.CreateRetryTask(ctx, db.CreateRetryTaskParams{
 				ID:                   taskID,
+				RuntimeID:            retryRuntimeID,
 				FireAt:               retryFireAt,
 				MaxAttempts:          retryMaxAttempts,
 				RuntimeMcpOverlay:    retryOverlay.Overlay,
@@ -3505,6 +3528,8 @@ func (s *TaskService) FailTask(ctx context.Context, taskID pgtype.UUID, errMsg, 
 			"parent_task_id", util.UUIDToString(task.ID),
 			"child_task_id", util.UUIDToString(retried.ID),
 			"reason", failureReason,
+			"source_runtime_id", util.UUIDToString(task.RuntimeID),
+			"target_runtime_id", util.UUIDToString(retried.RuntimeID),
 			"attempt", retried.Attempt,
 			"max_attempts", retried.MaxAttempts,
 			"status", retried.Status,
@@ -3567,7 +3592,12 @@ func (s *TaskService) FailTask(ctx context.Context, taskID pgtype.UUID, errMsg, 
 // etc.) are intentionally excluded — those are real problems that the user
 // should see, not infrastructure flakiness.
 //
-// The one agent_error.* exception is provider_network: a mid-stream provider
+// Provider network is a same-runtime retry for transient stream cuts. Provider
+// quota and capacity reasons are retryable only when runtime_config names a
+// compatible alternate runtime; they are never retried against the exhausted
+// account.
+//
+// provider_network is a mid-stream provider
 // disconnect (e.g. Claude Code's "API Error: Connection closed mid-response")
 // is transient infrastructure flakiness, not an agent decision. Unattended
 // issue runs otherwise terminate on it, while interactive chat only survives
@@ -3584,8 +3614,10 @@ var retryableReasons = map[string]bool{
 	"runtime_recovery":          true,
 	"timeout":                   true,
 	"codex_semantic_inactivity": true,
-	string(taskfailure.ReasonAgentProviderNetwork):   true,
-	string(taskfailure.ReasonSkillBundleUnavailable): true,
+	string(taskfailure.ReasonAgentProviderNetwork):             true,
+	string(taskfailure.ReasonAgentProviderQuotaLimit):          true,
+	string(taskfailure.ReasonAgentProviderCapacityOrRateLimit): true,
+	string(taskfailure.ReasonSkillBundleUnavailable):           true,
 }
 
 // Transient provider stream cuts (provider_network) get a bespoke three-tier
@@ -3675,11 +3707,12 @@ func ResumeUnsafeFailure(failureReason, errorText string) bool {
 	return taskfailure.UnresumableHistory(errorText)
 }
 
-// retryEligible reports whether a failed task qualifies for an automatic retry
-// attempt: an infrastructure-shaped failure_reason, remaining attempt budget,
-// not an autopilot run, and linked to an issue or chat session. Shared by
-// FailTask's in-transaction retry and the orphan sweeper's MaybeRetryFailedTask
-// so both agree on which failures re-run.
+// retryEligible reports whether a failed task passes the common automatic
+// retry gates: an allowed failure_reason, remaining attempt budget, not an
+// autopilot run, and linked to an issue or chat session. Provider-limit reasons
+// must additionally resolve a configured alternate runtime before callers
+// create a child. Shared by FailTask's in-transaction retry and the orphan
+// sweeper's MaybeRetryFailedTask so both agree on the common gates.
 func retryEligible(failureReason string, t db.AgentTaskQueue) bool {
 	return retryableReasons[failureReason] &&
 		t.Attempt < retryAttemptCeiling(failureReason, t.MaxAttempts) &&
@@ -3730,6 +3763,7 @@ func (s *TaskService) MaybeRetryFailedTask(ctx context.Context, parent db.AgentT
 	}
 
 	var runtimeMCPOverlay runtimeMCPOverlayData
+	retryRuntimeID := parent.RuntimeID
 	agent, agentErr := s.Queries.GetAgent(ctx, parent.AgentID)
 	if agentErr != nil {
 		// Best-effort: failing to resolve the agent for the overlay is not
@@ -3740,8 +3774,27 @@ func (s *TaskService) MaybeRetryFailedTask(ctx context.Context, parent db.AgentT
 			"agent_id", util.UUIDToString(parent.AgentID),
 			"error", agentErr,
 		)
+		if isFailoverOnlyRetryReason(reason) {
+			return nil, nil
+		}
 	} else {
 		runtimeMCPOverlay = s.buildRuntimeMCPOverlay(ctx, parent.OriginatorUserID, agent)
+		if isFailoverOnlyRetryReason(reason) {
+			target, ok, err := s.configuredFailoverRuntime(ctx, agent, parent.RuntimeID)
+			if err != nil {
+				slog.Warn("task auto-retry: resolve failover runtime failed",
+					"parent_task_id", util.UUIDToString(parent.ID), "error", err)
+				return nil, err
+			}
+			if !ok {
+				slog.Info("task auto-retry skipped: no compatible failover runtime",
+					"parent_task_id", util.UUIDToString(parent.ID),
+					"runtime_id", util.UUIDToString(parent.RuntimeID),
+					"reason", reason)
+				return nil, nil
+			}
+			retryRuntimeID = target
+		}
 	}
 	// Mirror FailTask's in-tx backoff + effective-budget persistence: defer the
 	// final provider_network attempt ~5s via fire_at (zero delay leaves fire_at
@@ -3753,6 +3806,7 @@ func (s *TaskService) MaybeRetryFailedTask(ctx context.Context, parent db.AgentT
 	}
 	child, err := s.Queries.CreateRetryTask(ctx, db.CreateRetryTaskParams{
 		ID:                   parent.ID,
+		RuntimeID:            retryRuntimeID,
 		FireAt:               retryFireAt,
 		MaxAttempts:          pgtype.Int4{Int32: retryAttemptCeiling(reason, parent.MaxAttempts), Valid: true},
 		RuntimeMcpOverlay:    runtimeMCPOverlay.Overlay,
@@ -3770,6 +3824,8 @@ func (s *TaskService) MaybeRetryFailedTask(ctx context.Context, parent db.AgentT
 		"parent_task_id", util.UUIDToString(parent.ID),
 		"child_task_id", util.UUIDToString(child.ID),
 		"reason", reason,
+		"source_runtime_id", util.UUIDToString(parent.RuntimeID),
+		"target_runtime_id", util.UUIDToString(child.RuntimeID),
 		"attempt", child.Attempt,
 		"max_attempts", child.MaxAttempts,
 		"status", child.Status,

--- a/server/internal/service/task_failover.go
+++ b/server/internal/service/task_failover.go
@@ -1,0 +1,94 @@
+package service
+
+import (
+	"context"
+	"encoding/json"
+
+	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/multica-ai/multica/server/internal/util"
+	db "github.com/multica-ai/multica/server/pkg/db/generated"
+	"github.com/multica-ai/multica/server/pkg/taskfailure"
+)
+
+type agentRuntimeFailoverConfig struct {
+	Failover struct {
+		RuntimeIDs []string `json:"runtime_ids"`
+	} `json:"failover"`
+}
+
+func configuredFailoverRuntimeIDs(raw []byte) []pgtype.UUID {
+	var cfg agentRuntimeFailoverConfig
+	if len(raw) == 0 || json.Unmarshal(raw, &cfg) != nil {
+		return nil
+	}
+
+	ids := make([]pgtype.UUID, 0, len(cfg.Failover.RuntimeIDs))
+	seen := make(map[[16]byte]struct{}, len(cfg.Failover.RuntimeIDs))
+	for _, rawID := range cfg.Failover.RuntimeIDs {
+		id, err := util.ParseUUID(rawID)
+		if err != nil {
+			continue
+		}
+		if _, duplicate := seen[id.Bytes]; duplicate {
+			continue
+		}
+		seen[id.Bytes] = struct{}{}
+		ids = append(ids, id)
+	}
+	return ids
+}
+
+// RuntimeResumeCompatible limits cross-runtime continuation to another account
+// served by the same daemon and provider. That guarantees a shared filesystem
+// for workdir reuse while preventing session ids from crossing workspace,
+// provider, machine, or Multica-owner boundaries.
+func RuntimeResumeCompatible(source, target db.AgentRuntime) bool {
+	return source.WorkspaceID.Valid && source.WorkspaceID == target.WorkspaceID &&
+		source.OwnerID.Valid && source.OwnerID == target.OwnerID &&
+		source.DaemonID.Valid && source.DaemonID == target.DaemonID &&
+		source.Provider != "" && source.Provider == target.Provider
+}
+
+func isFailoverOnlyRetryReason(reason string) bool {
+	return reason == string(taskfailure.ReasonAgentProviderQuotaLimit) ||
+		reason == string(taskfailure.ReasonAgentProviderCapacityOrRateLimit)
+}
+
+func selectConfiguredFailoverRuntime(currentID pgtype.UUID, configured []pgtype.UUID, runtimes []db.AgentRuntime) (pgtype.UUID, bool) {
+	byID := make(map[[16]byte]db.AgentRuntime, len(runtimes))
+	for _, runtime := range runtimes {
+		if runtime.ID.Valid {
+			byID[runtime.ID.Bytes] = runtime
+		}
+	}
+	source, ok := byID[currentID.Bytes]
+	if !currentID.Valid || !ok {
+		return pgtype.UUID{}, false
+	}
+	for _, candidateID := range configured {
+		if !candidateID.Valid || candidateID == currentID {
+			continue
+		}
+		candidate, ok := byID[candidateID.Bytes]
+		if ok && candidate.Status == "online" && RuntimeResumeCompatible(source, candidate) {
+			return candidate.ID, true
+		}
+	}
+	return pgtype.UUID{}, false
+}
+
+func (s *TaskService) configuredFailoverRuntime(ctx context.Context, agent db.Agent, currentID pgtype.UUID) (pgtype.UUID, bool, error) {
+	configured := configuredFailoverRuntimeIDs(agent.RuntimeConfig)
+	if len(configured) == 0 {
+		return pgtype.UUID{}, false, nil
+	}
+	ids := make([]pgtype.UUID, 0, len(configured)+1)
+	ids = append(ids, currentID)
+	ids = append(ids, configured...)
+	runtimes, err := s.Queries.GetAgentRuntimes(ctx, ids)
+	if err != nil {
+		return pgtype.UUID{}, false, err
+	}
+	target, ok := selectConfiguredFailoverRuntime(currentID, configured, runtimes)
+	return target, ok, nil
+}

--- a/server/internal/service/task_failover_test.go
+++ b/server/internal/service/task_failover_test.go
@@ -1,0 +1,81 @@
+package service
+
+import (
+	"testing"
+
+	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/multica-ai/multica/server/internal/util"
+	db "github.com/multica-ai/multica/server/pkg/db/generated"
+)
+
+func failoverRuntime(id, workspace, owner, daemon, provider, status string) db.AgentRuntime {
+	return db.AgentRuntime{
+		ID:          util.MustParseUUID(id),
+		WorkspaceID: util.MustParseUUID(workspace),
+		OwnerID:     util.MustParseUUID(owner),
+		DaemonID:    pgtype.Text{String: daemon, Valid: true},
+		Provider:    provider,
+		Status:      status,
+	}
+}
+
+func TestConfiguredFailoverRuntimeIDs(t *testing.T) {
+	const first = "10000000-0000-0000-0000-000000000001"
+	const second = "10000000-0000-0000-0000-000000000002"
+
+	got := configuredFailoverRuntimeIDs([]byte(`{"failover":{"runtime_ids":["` + first + `","bad","` + first + `","` + second + `"]}}`))
+	if len(got) != 2 {
+		t.Fatalf("got %d ids, want 2", len(got))
+	}
+	if got[0] != util.MustParseUUID(first) || got[1] != util.MustParseUUID(second) {
+		t.Fatalf("ids = %v, want valid unique ids in configured order", got)
+	}
+	if got := configuredFailoverRuntimeIDs([]byte(`{"failover":`)); got != nil {
+		t.Fatalf("malformed config returned %v, want nil", got)
+	}
+}
+
+func TestSelectConfiguredFailoverRuntime(t *testing.T) {
+	const (
+		workspace = "20000000-0000-0000-0000-000000000001"
+		owner     = "30000000-0000-0000-0000-000000000001"
+		sourceID  = "40000000-0000-0000-0000-000000000001"
+		offlineID = "40000000-0000-0000-0000-000000000002"
+		wrongID   = "40000000-0000-0000-0000-000000000003"
+		targetID  = "40000000-0000-0000-0000-000000000004"
+	)
+
+	source := failoverRuntime(sourceID, workspace, owner, "daemon-a", "claude", "online")
+	offline := failoverRuntime(offlineID, workspace, owner, "daemon-a", "claude", "offline")
+	wrongDaemon := failoverRuntime(wrongID, workspace, owner, "daemon-b", "claude", "online")
+	target := failoverRuntime(targetID, workspace, owner, "daemon-a", "claude", "online")
+
+	configured := []pgtype.UUID{offline.ID, wrongDaemon.ID, target.ID}
+	got, ok := selectConfiguredFailoverRuntime(source.ID, configured, []db.AgentRuntime{target, wrongDaemon, source, offline})
+	if !ok || got != target.ID {
+		t.Fatalf("selected (%v, %v), want online compatible target %s", got, ok, targetID)
+	}
+
+	wrongProvider := target
+	wrongProvider.Provider = "codex"
+	if RuntimeResumeCompatible(source, wrongProvider) {
+		t.Fatal("different providers must not be resume-compatible")
+	}
+	wrongOwner := target
+	wrongOwner.OwnerID = util.MustParseUUID("30000000-0000-0000-0000-000000000002")
+	if RuntimeResumeCompatible(source, wrongOwner) {
+		t.Fatal("different owners must not be resume-compatible")
+	}
+}
+
+func TestProviderLimitReasonsRequireFailover(t *testing.T) {
+	if !isFailoverOnlyRetryReason("agent_error.provider_quota_limit") {
+		t.Fatal("quota limit must use alternate-runtime retry")
+	}
+	if !isFailoverOnlyRetryReason("agent_error.provider_capacity_or_rate_limit") {
+		t.Fatal("capacity limit must use alternate-runtime retry")
+	}
+	if isFailoverOnlyRetryReason("agent_error.provider_network") {
+		t.Fatal("network errors keep the existing same-runtime retry path")
+	}
+}

--- a/server/pkg/db/generated/agent.sql.go
+++ b/server/pkg/db/generated/agent.sql.go
@@ -1935,23 +1935,23 @@ INSERT INTO agent_task_queue (
     chat_input_task_id, fire_at
 )
 SELECT
-    p.agent_id, p.runtime_id, p.issue_id, p.chat_session_id, p.autopilot_run_id,
-    CASE WHEN $2::timestamptz IS NOT NULL THEN 'deferred' ELSE 'queued' END,
+    p.agent_id, COALESCE($2::uuid, p.runtime_id), p.issue_id, p.chat_session_id, p.autopilot_run_id,
+    CASE WHEN $3::timestamptz IS NOT NULL THEN 'deferred' ELSE 'queued' END,
     CASE WHEN p.chat_session_id IS NOT NULL THEN GREATEST(p.priority, 3) ELSE p.priority END,
     p.trigger_comment_id, p.coalesced_comment_ids, p.trigger_summary, p.context,
     CASE WHEN p.failure_reason IS NOT DISTINCT FROM 'codex_semantic_inactivity' THEN NULL ELSE p.session_id END,
     CASE WHEN p.failure_reason IS NOT DISTINCT FROM 'codex_semantic_inactivity' THEN NULL ELSE p.work_dir END,
-    p.attempt + 1, COALESCE($3::int, p.max_attempts), p.id,
+    p.attempt + 1, COALESCE($4::int, p.max_attempts), p.id,
     p.failure_reason IS NOT DISTINCT FROM 'codex_semantic_inactivity',
     p.is_leader_task,
     p.squad_id,
     p.originator_user_id,
     p.accountable_user_id,
-    $4,
     $5,
+    $6,
     p.originator_source, p.delegated_from_task_id, p.rule_version_id,
     p.trigger_evidence_kind, p.trigger_evidence_ref_id, p.id,
-    p.chat_input_task_id, $2
+    p.chat_input_task_id, $3
 FROM agent_task_queue p
 WHERE p.id = $1
 RETURNING id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id, chat_session_id, autopilot_run_id, attempt, max_attempts, parent_task_id, failure_reason, trigger_summary, force_fresh_session, is_leader_task, wait_reason, initiator_user_id, handoff_note, prepare_lease_expires_at, squad_id, runtime_mcp_overlay, escalation_for_task_id, fire_at, originator_user_id, runtime_connected_apps, coalesced_comment_ids, delivered_comment_ids, chat_input_task_id, chat_finalize_deferred_at, originator_source, delegated_from_task_id, retry_of_task_id, rerun_of_task_id, rule_version_id, trigger_evidence_kind, trigger_evidence_ref_id, accountable_user_id, session_rollout_missing, retired_session_id, quick_actions_disabled, regenerate_quick_actions_for
@@ -1959,6 +1959,7 @@ RETURNING id, agent_id, issue_id, status, priority, dispatched_at, started_at, c
 
 type CreateRetryTaskParams struct {
 	ID                   pgtype.UUID        `json:"id"`
+	RuntimeID            pgtype.UUID        `json:"runtime_id"`
 	FireAt               pgtype.Timestamptz `json:"fire_at"`
 	MaxAttempts          pgtype.Int4        `json:"max_attempts"`
 	RuntimeMcpOverlay    []byte             `json:"runtime_mcp_overlay"`
@@ -2017,9 +2018,13 @@ type CreateRetryTaskParams struct {
 // attempt=3, max_attempts=3 rather than leaking attempt=3, max_attempts=2 to the
 // task API (MUL-4910). The Go retryAttemptCeiling already refuses to raise a
 // disabled (max_attempts<=1) task, so this only ever widens, never revives.
+// runtime_id overrides the parent's runtime when non-NULL. Provider-limit
+// failover uses this to route only the retry child to a compatible alternate
+// account without mutating the agent's default runtime for unrelated tasks.
 func (q *Queries) CreateRetryTask(ctx context.Context, arg CreateRetryTaskParams) (AgentTaskQueue, error) {
 	row := q.db.QueryRow(ctx, createRetryTask,
 		arg.ID,
+		arg.RuntimeID,
 		arg.FireAt,
 		arg.MaxAttempts,
 		arg.RuntimeMcpOverlay,

--- a/server/pkg/db/queries/agent.sql
+++ b/server/pkg/db/queries/agent.sql
@@ -427,6 +427,9 @@ WHERE id = $1 AND issue_id IS NULL;
 -- attempt=3, max_attempts=3 rather than leaking attempt=3, max_attempts=2 to the
 -- task API (MUL-4910). The Go retryAttemptCeiling already refuses to raise a
 -- disabled (max_attempts<=1) task, so this only ever widens, never revives.
+-- runtime_id overrides the parent's runtime when non-NULL. Provider-limit
+-- failover uses this to route only the retry child to a compatible alternate
+-- account without mutating the agent's default runtime for unrelated tasks.
 INSERT INTO agent_task_queue (
     agent_id, runtime_id, issue_id, chat_session_id, autopilot_run_id,
     status, priority, trigger_comment_id, coalesced_comment_ids, trigger_summary, context,
@@ -438,7 +441,7 @@ INSERT INTO agent_task_queue (
     chat_input_task_id, fire_at
 )
 SELECT
-    p.agent_id, p.runtime_id, p.issue_id, p.chat_session_id, p.autopilot_run_id,
+    p.agent_id, COALESCE(sqlc.narg(runtime_id)::uuid, p.runtime_id), p.issue_id, p.chat_session_id, p.autopilot_run_id,
     CASE WHEN sqlc.narg(fire_at)::timestamptz IS NOT NULL THEN 'deferred' ELSE 'queued' END,
     CASE WHEN p.chat_session_id IS NOT NULL THEN GREATEST(p.priority, 3) ELSE p.priority END,
     p.trigger_comment_id, p.coalesced_comment_ids, p.trigger_summary, p.context,

--- a/server/pkg/taskfailure/classify.go
+++ b/server/pkg/taskfailure/classify.go
@@ -127,11 +127,13 @@ func Classify(rawError string) Reason {
 			"balance is too low",
 			"monthly usage limit",
 			"usage limit",
+			"you've hit your session limit",
 			"you've hit your limit",
 			// Curly apostrophe variant: providers and copy-pasted error
 			// strings sometimes use U+2019 instead of ASCII '. SQL ILIKE
 			// would not match the curly form either, so this is a small
 			// in-flight improvement on top of the SQL classifier.
+			"you\u2019ve hit your session limit",
 			"you\u2019ve hit your limit",
 			"credits",
 			"quota",
@@ -310,21 +312,28 @@ var legacyContextOverflowReasons = map[string]bool{
 	"agent_error":              true,
 }
 
+var legacyProviderQuotaReasons = map[string]bool{
+	string(ReasonAgentUnknown): true,
+	"agent_error":              true,
+}
+
 // NormalizeDaemonReason upgrades a failure_reason reported by an older daemon
 // onto the taxonomy this server understands, using the raw error text as the
 // witness. It returns the reason unchanged when nothing applies.
 //
-// Why this exists (MUL-5370): installed daemons upgrade on their own cadence,
-// so a fix that only labels a failure correctly on the daemon side reaches
-// nobody until every host updates. The daemon reports a non-empty reason, so
-// FailTask's "classify when empty" guard does not fire, and the server would
-// persist the stale label — no auto-retry, and the chat bubble falls back to
-// generic copy. Recognising the wire shape an old daemon produces closes that
-// gap the moment the server deploys.
+// Why this exists (MUL-5370 and provider-limit failover): installed daemons
+// upgrade on their own cadence, so a fix that only labels a failure correctly
+// on the daemon side reaches nobody until every host updates. The daemon
+// reports a non-empty reason, so FailTask's "classify when empty" guard does
+// not fire, and the server would persist the stale label. Recognising the wire
+// shape an old daemon produces closes that gap when the server deploys.
 //
-// This is a boundary compatibility shim, not internal fallback logic: each rule
-// can be deleted once no daemon old enough to produce its wire shape is still
-// reporting.
+// This is a boundary compatibility shim, not internal fallback logic. Each
+// rule is deliberately narrow and only upgrades legacy catchalls backed by an
+// unambiguous witness. A daemon's more specific reason always wins.
+// The quota branch is deliberately narrow: only legacy catchalls are upgraded,
+// and only to the quota bucket backed by an unambiguous current classifier
+// result. A daemon's more specific reason always wins.
 func NormalizeDaemonReason(reason, rawError string) Reason {
 	if legacySkillBundleReasons[reason] &&
 		strings.HasPrefix(strings.TrimSpace(rawError), legacySkillBundlePrefix) {
@@ -341,6 +350,12 @@ func NormalizeDaemonReason(reason, rawError string) Reason {
 	if legacyContextOverflowReasons[reason] &&
 		containsAny(strings.ToLower(rawError), contextWindowExceededWitnesses...) {
 		return ReasonAgentContextOverflow
+	}
+	if legacyProviderQuotaReasons[reason] {
+		classified := Classify(rawError)
+		if classified == ReasonAgentProviderQuotaLimit {
+			return classified
+		}
 	}
 	return Reason(reason)
 }

--- a/server/pkg/taskfailure/classify_test.go
+++ b/server/pkg/taskfailure/classify_test.go
@@ -73,6 +73,8 @@ func TestClassifyRules(t *testing.T) {
 		{"balance is too low", "balance is too low to make this request", ReasonAgentProviderQuotaLimit},
 		{"monthly usage limit", "You've hit your org's monthly usage limit", ReasonAgentProviderQuotaLimit},
 		{"usage limit", "Account exceeded the daily usage limit", ReasonAgentProviderQuotaLimit},
+		{"session limit ascii", "You've hit your session limit · resets 2pm (Asia/Seoul)", ReasonAgentProviderQuotaLimit},
+		{"session limit curly", "You\u2019ve hit your session limit · resets 2pm", ReasonAgentProviderQuotaLimit},
 		{"hit your limit ascii", "you've hit your limit; upgrade to continue", ReasonAgentProviderQuotaLimit},
 		{"hit your limit curly", "you\u2019ve hit your limit", ReasonAgentProviderQuotaLimit},
 		{"credits", "Your account has 0 credits remaining", ReasonAgentProviderQuotaLimit},
@@ -322,6 +324,12 @@ func TestNormalizeDaemonReason(t *testing.T) {
 			reason: string(ReasonAgentUnknown),
 			raw:    "  " + legacyErr,
 			want:   ReasonSkillBundleUnavailable,
+		},
+		{
+			name:   "old daemon session-limit catchall is upgraded",
+			reason: string(ReasonAgentUnknown),
+			raw:    "You've hit your session limit · resets 2pm (Asia/Seoul)",
+			want:   ReasonAgentProviderQuotaLimit,
 		},
 		{
 			// A current daemon already sends the right reason and a different

--- a/server/pkg/taskfailure/failure.go
+++ b/server/pkg/taskfailure/failure.go
@@ -122,8 +122,9 @@ const (
 	ReasonAgentProviderAuthOrAccess Reason = "agent_error.provider_auth_or_access"
 
 	// ReasonAgentProviderQuotaLimit: 402, insufficient_balance,
-	// monthly usage limit, credits exhausted. Not retryable until the
-	// account is topped up.
+	// monthly/session usage limit, credits exhausted. Retryable only when the
+	// agent has a compatible alternate runtime configured; retrying the same
+	// provider account would only consume another attempt.
 	ReasonAgentProviderQuotaLimit Reason = "agent_error.provider_quota_limit"
 
 	// ReasonAgentProviderCapacityOrRateLimit: 429 / 529, rate-limited,


### PR DESCRIPTION
## Summary

- classify Claude session-limit responses as provider quota failures, including mixed-version daemon catchalls
- route quota/rate-limit retry children to the first configured online runtime with the same workspace, owner, daemon, and provider
- resume automatic retries from their exact failed parent across compatible runtimes, preserving workdir and resumable session context
- document `runtime_config.failover.runtime_ids` and keep retries bounded by the existing attempt budget

## Verification

- `go test ./pkg/taskfailure ./internal/service ./internal/handler`
- `go test ./...` passes all relevant packages; the existing `TestCodexExecuteSemanticInactivityAllowsContinuousMessages` timing test fails at its 72 ms timeout and reproduces unchanged on `origin/main`
- database-backed integration cases are included but skip locally without `DATABASE_URL`; CI should exercise them
