### PR TITLE
MUL-5713: fix mobile issue detail spacing

### DIFF
--- a/packages/ui/styles/base.css
+++ b/packages/ui/styles/base.css
@@ -3,14 +3,31 @@
  * ============================================================================= */
 
 /* The chat launcher overlays the dashboard's bottom-right corner on every
- * workspace page, so a page-level bar that runs to that corner has to stop
- * short of it. Named rather than spelled out at each site: the intent is
- * legible, every site that yields to the launcher is findable by this class,
- * and the distance stays derived from the launcher's own geometry. Centred
- * floating toolbars and dialog footers do not need it — nothing else reaches
- * that corner. */
+ * workspace page, so anything that runs to that corner has to stop short of
+ * it. Named rather than spelled out at each site: the intent is legible, every
+ * site that yields to the launcher is findable by these classes, and the
+ * distance stays derived from the launcher's own geometry.
+ *
+ * Which one to reach for depends on how the site approaches the corner:
+ *  - a full-width bar arrives from the left     -> pe-chat-launcher
+ *  - scrollable content ends there              -> pb-chat-launcher
+ *  - a centred overlay grows into it            -> above-chat-launcher
+ *
+ * A centred toolbar (`left-1/2 -translate-x-1/2`) cannot use the padding
+ * variants: inline padding widens it symmetrically, so it reaches just as far
+ * right as before. It has to clear the launcher vertically instead. On a wide
+ * viewport a centred toolbar never gets near the corner, so its clearance is
+ * usually applied under a `max-md:` variant. */
 @utility pe-chat-launcher {
   padding-inline-end: var(--chat-launcher-clearance);
+}
+
+@utility pb-chat-launcher {
+  padding-bottom: var(--chat-launcher-clearance);
+}
+
+@utility above-chat-launcher {
+  bottom: calc(var(--chat-launcher-clearance) + var(--chat-launcher-inset));
 }
 
 /* Shiki dual themes: CSS-only light/dark switching via CSS variables */

--- a/packages/views/agents/components/agent-batch-toolbar.tsx
+++ b/packages/views/agents/components/agent-batch-toolbar.tsx
@@ -140,7 +140,7 @@ export function AgentBatchToolbar({
         {rows.length > 0 && (
           <div
             key="agent-batch-toolbar"
-            className="absolute bottom-6 left-1/2 z-50 -translate-x-1/2"
+            className="absolute bottom-6 left-1/2 z-50 -translate-x-1/2 max-md:above-chat-launcher"
           >
             <motion.div
               className="flex items-center gap-1 rounded-lg border bg-background px-2 py-1.5 shadow-lg"

--- a/packages/views/autopilots/components/autopilot-list-actions.tsx
+++ b/packages/views/autopilots/components/autopilot-list-actions.tsx
@@ -224,7 +224,7 @@ export function AutopilotBatchToolbar({
     <>
       {/* Anchored to the page root (relative), NOT the viewport — see the
           skills batch toolbar for the rationale. */}
-      <div className="absolute bottom-6 left-1/2 z-50 flex -translate-x-1/2 items-center gap-1 rounded-lg border bg-background px-2 py-1.5 shadow-lg">
+      <div className="absolute bottom-6 left-1/2 z-50 flex -translate-x-1/2 items-center gap-1 rounded-lg border bg-background px-2 py-1.5 shadow-lg max-md:above-chat-launcher">
         <div className="mr-1 flex items-center gap-1.5 border-r pl-1 pr-2">
           <span className="text-body font-medium">
             {t(($) => $.actions.selected, { count: rows.length })}

--- a/packages/views/inbox/components/inbox-page.test.tsx
+++ b/packages/views/inbox/components/inbox-page.test.tsx
@@ -261,6 +261,33 @@ describe("InboxPage", () => {
     expect(replace).toHaveBeenCalledWith("/acme/inbox?issue=issue-3");
   });
 
+  // `InboxItem.issue_id` is nullable: a quick-create outcome is a notification,
+  // not an issue, so `IssueDetail` never renders for it — and `IssueDetail` is
+  // what carries the way back in its own header on a phone. This branch has to
+  // supply its own bar or opening one of these is a dead end.
+  it("keeps a way back to the list for a notification with no issue", () => {
+    reset();
+    listData.active = [
+      item({ id: "inbox-note", issue_id: null, type: "quick_create_failed" }),
+    ];
+
+    render(<InboxPage />);
+    fireEvent.click(screen.getByTestId("row"));
+
+    // Mobile swaps the list out for the detail, so the row is gone…
+    expect(screen.queryByTestId("row")).toBeNull();
+
+    // …and the only thing that can bring it back is the bar this branch adds.
+    // Located structurally: the test's `useT` returns one string for every key,
+    // so every button in this detail shares an accessible name.
+    const back = document.querySelector<HTMLButtonElement>(".h-12.border-b button");
+    expect(back).not.toBeNull();
+
+    fireEvent.click(back!);
+
+    expect(screen.getByTestId("row")).toBeInTheDocument();
+  });
+
   it("marks the opened notification read", () => {
     reset();
     listData.active = [

--- a/packages/views/inbox/components/inbox-page.tsx
+++ b/packages/views/inbox/components/inbox-page.tsx
@@ -482,18 +482,57 @@ export function InboxPage() {
     </>
   );
 
+  // Phone only: the detail fills the screen there, so the trip back to the list
+  // has to live inside it. On desktop the list is still on screen in the left
+  // panel and needs no back control at all.
+  //
+  // The detail owns the whole phone screen in four states — loaded, loading,
+  // not-found and crashed — so this control is threaded into all four below.
+  // Miss one and that state strands the reader with no way out.
+  const mobileBackAction = isMobile ? (
+    <Button
+      variant="ghost"
+      size="sm"
+      onClick={() => setSelectedKey("")}
+      className="-ml-2 shrink-0 gap-1.5 text-muted-foreground"
+    >
+      <ArrowLeft className="h-4 w-4" />
+      {/* Back goes to the list the user came FROM, so the label has to
+          name it — "Inbox" here would be a lie about the destination. */}
+      {isArchivedView ? t(($) => $.list.archived_title) : t(($) => $.page.back)}
+    </Button>
+  ) : undefined;
+
+  const mobileBackBar = mobileBackAction ? (
+    <div className="flex h-12 shrink-0 items-center gap-2 border-b px-4">{mobileBackAction}</div>
+  ) : null;
+
   const detailContent = selected?.issue_id ? (
     // Key by issue_id (not inbox-item id): a new comment/reaction generates a
     // new inbox notification for the same issue, and the dedup helper picks the
     // newest one — keying on its id would remount IssueDetail on every event,
     // wiping the comment composer draft and resetting scroll position.
-    <ErrorBoundary resetKeys={[selected.issue_id]}>
+    <ErrorBoundary
+      resetKeys={[selected.issue_id]}
+      // The default fallback is a bare message card. On a phone it would be the
+      // only thing on screen, so it has to carry the way back too — the bar is
+      // the point here, the message is whatever the boundary caught.
+      fallback={mobileBackAction ? ({ error }) => (
+        <div className="flex flex-1 min-h-0 flex-col">
+          {mobileBackBar}
+          <div className="flex flex-1 min-h-0 items-center justify-center px-4 text-center text-body text-muted-foreground">
+            {error.message}
+          </div>
+        </div>
+      ) : undefined}
+    >
       <IssueDetail
         key={selected.issue_id}
         issueId={selected.issue_id}
         defaultSidebarOpen={false}
         layoutId="multica_inbox_issue_detail_layout"
         highlightCommentId={selected.details?.comment_id ?? undefined}
+        leadingAction={mobileBackAction}
         onDelete={() => {
           // Issue deletion CASCADE-deletes the inbox item server-side, and the
           // issue:deleted WS event prunes it from the inbox cache. Just clear
@@ -597,28 +636,22 @@ export function InboxPage() {
       );
     }
 
-    // Mobile: show detail full-screen when an item is selected
+    // Mobile: show detail full-screen when an item is selected.
+    //
+    // No scroll container and no back bar of our own: `IssueDetail` owns both.
+    // Wrapping it in an `overflow-y-auto` used to collapse its inner scroller
+    // to content height, which took its header (and the done/pin/more/sidebar
+    // actions in it) out of the pinned position, made `position: sticky`
+    // inside it a no-op, and pointed both scroll restoration and the timeline
+    // virtualizer at an element that never scrolls. This wrapper only has to
+    // give the detail a definite height to fill.
     if (selected) {
       return (
         <div className="flex flex-1 flex-col min-h-0">
-          <div className="flex h-12 shrink-0 items-center border-b px-2">
-            <Button
-              variant="ghost"
-              size="sm"
-              onClick={() => setSelectedKey("")}
-              className="gap-1.5 text-muted-foreground"
-            >
-              <ArrowLeft className="h-4 w-4" />
-              {/* Back goes to the list the user came FROM, so the label has to
-                  name it — "Inbox" here would be a lie about the destination. */}
-              {isArchivedView
-                ? t(($) => $.list.archived_title)
-                : t(($) => $.page.back)}
-            </Button>
-          </div>
-          <div className="flex-1 min-h-0 overflow-y-auto">
-            {detailContent}
-          </div>
+          {/* `InboxItem.issue_id` is nullable, so `detailContent` can be null
+              for a selected row. Without the bar that is a blank screen with
+              no way back. */}
+          {detailContent ?? mobileBackBar}
         </div>
       );
     }

--- a/packages/views/inbox/components/inbox-page.tsx
+++ b/packages/views/inbox/components/inbox-page.tsx
@@ -636,22 +636,29 @@ export function InboxPage() {
       );
     }
 
-    // Mobile: show detail full-screen when an item is selected.
-    //
-    // No scroll container and no back bar of our own: `IssueDetail` owns both.
-    // Wrapping it in an `overflow-y-auto` used to collapse its inner scroller
-    // to content height, which took its header (and the done/pin/more/sidebar
-    // actions in it) out of the pinned position, made `position: sticky`
-    // inside it a no-op, and pointed both scroll restoration and the timeline
-    // virtualizer at an element that never scrolls. This wrapper only has to
-    // give the detail a definite height to fill.
+    // Mobile: show detail full-screen when an item is selected. The two kinds
+    // of selection get their chrome from different places, so they render
+    // differently — `InboxItem.issue_id` is nullable and a null one is a plain
+    // notification (a failed quick-create, say), not an issue.
+    if (selected?.issue_id) {
+      // No scroll container and no back bar of our own: `IssueDetail` owns
+      // both, and takes the way back through `leadingAction`. Wrapping it in
+      // an `overflow-y-auto` used to collapse its inner scroller to content
+      // height, which took its header (and the done/pin/more/sidebar actions
+      // in it) out of the pinned position, made `position: sticky` inside it a
+      // no-op, and pointed both scroll restoration and the timeline
+      // virtualizer at an element that never scrolls. This wrapper only has to
+      // give the detail a definite height to fill.
+      return <div className="flex flex-1 flex-col min-h-0">{detailContent}</div>;
+    }
+
     if (selected) {
+      // A notification body is a plain block with no header to host a leading
+      // slot and no scroller of its own, so this branch keeps supplying both.
       return (
         <div className="flex flex-1 flex-col min-h-0">
-          {/* `InboxItem.issue_id` is nullable, so `detailContent` can be null
-              for a selected row. Without the bar that is a blank screen with
-              no way back. */}
-          {detailContent ?? mobileBackBar}
+          {mobileBackBar}
+          <div className="flex-1 min-h-0 overflow-y-auto">{detailContent}</div>
         </div>
       );
     }

--- a/packages/views/issues/components/batch-action-toolbar.tsx
+++ b/packages/views/issues/components/batch-action-toolbar.tsx
@@ -174,7 +174,7 @@ export function BatchActionToolbar({
             className={cn(
               "z-50",
               placement === "fixed-bottom"
-                ? "fixed bottom-6 left-1/2 -translate-x-1/2"
+                ? "fixed bottom-6 left-1/2 -translate-x-1/2 max-md:above-chat-launcher"
                 : "mb-2 w-fit",
             )}
           >

--- a/packages/views/issues/components/comment-composers.test.tsx
+++ b/packages/views/issues/components/comment-composers.test.tsx
@@ -265,6 +265,9 @@ beforeEach(() => {
   insertMarkdownBehavior.succeed = true;
   localStorage.clear();
   useCommentComposerStore.setState({ sticky: true });
+  // The composer's pinning (and the height cap that follows it) is viewport
+  // dependent, so a narrow-viewport test must not leak into the next one.
+  Object.defineProperty(window, "innerWidth", { configurable: true, value: 1280 });
   // The draft store is a module singleton — a draft left by a previous test
   // (e.g. the failed-send case) would trip the composers' draft-direct-mount
   // path and hide the shell the next test expects.
@@ -1092,6 +1095,18 @@ describe("sticky composer preference", () => {
 
   it("lets the editor grow when the preference is off", () => {
     useCommentComposerStore.setState({ sticky: false });
+    renderCommentInput();
+
+    activateComposer("comment-composer-shell");
+    expect(screen.getByTestId("editor").parentElement?.className).not.toContain("max-h-[40vh]");
+  });
+
+  // The cap only earns its keep while the composer is pinned: it stops a long
+  // draft from swallowing the timeline it floats over. Below the mobile
+  // breakpoint nothing is pinned (see `useStickyComposer`), so a capped
+  // composer would just be a scroll-inside-a-scroll for no reason.
+  it("lets the editor grow below the mobile breakpoint, where nothing is pinned", () => {
+    Object.defineProperty(window, "innerWidth", { configurable: true, value: 390 });
     renderCommentInput();
 
     activateComposer("comment-composer-shell");

--- a/packages/views/issues/components/comment-input.tsx
+++ b/packages/views/issues/components/comment-input.tsx
@@ -7,12 +7,13 @@ import { FileUploadButton } from "@multica/ui/components/common/file-upload-butt
 import { SubmitButton } from "@multica/ui/components/common/submit-button";
 import { contentReferencesAttachment } from "@multica/core/types";
 import { formatShortcut, useShortcut } from "@multica/core/shortcuts";
-import { useCommentComposerStore, useCommentDraftStore } from "@multica/core/issues/stores";
+import { useCommentDraftStore } from "@multica/core/issues/stores";
 import { useT } from "../../i18n";
 import { CommentTriggerChips } from "./comment-trigger-chips";
 import { useCommentTriggerPreview } from "../hooks/use-comment-trigger-preview";
 import { useCommentUploads } from "./use-comment-uploads";
 import { useQuickActionMenu } from "../hooks/use-quick-action-menu";
+import { useStickyComposer } from "../hooks/use-sticky-composer";
 
 interface CommentInputProps {
   issueId: string;
@@ -70,8 +71,9 @@ function CommentInput({ issueId, onSubmit }: CommentInputProps) {
     onDrop: lazy.uploadOrQueue,
   });
   // Sticky preference (Settings → Preferences): issue-detail pins this
-  // composer to the bottom of the scroll viewport when enabled.
-  const sticky = useCommentComposerStore((s) => s.sticky);
+  // composer to the bottom of the scroll viewport when enabled. Shared with
+  // the host so the height cap below can never outlive the pinning.
+  const sticky = useStickyComposer();
 
   // Draft persistence. Hydrate from store on mount via `defaultValue` above
   // (ContentEditorRef has no setContent, so this is the only injection point).

--- a/packages/views/issues/components/issue-detail.test.tsx
+++ b/packages/views/issues/components/issue-detail.test.tsx
@@ -849,6 +849,46 @@ describe("IssueDetail (shared)", () => {
     expect(screen.queryByText("Properties")).not.toBeInTheDocument();
   });
 
+  it("pins the comment composer to the scroll viewport on a wide screen", async () => {
+    const { container } = renderIssueDetail();
+
+    await waitFor(() => {
+      expect(screen.getByText("Implement authentication")).toBeInTheDocument();
+    });
+
+    // `bottom-0` is unique to the composer wrapper — the sticky affordances
+    // inside the timeline (comment headers, resolve bars) all pin to `top-0`.
+    expect(container.querySelector(".sticky.bottom-0")).not.toBeNull();
+  });
+
+  it("lets the composer ride the end of the timeline on mobile", async () => {
+    // A pinned composer on a phone sits on the chat launcher's corner at every
+    // scroll position, and the part it covers is its own send button.
+    mockViewport.isMobile = true;
+
+    const { container } = renderIssueDetail();
+
+    await waitFor(() => {
+      expect(screen.getByText("Implement authentication")).toBeInTheDocument();
+    });
+
+    expect(container.querySelector(".sticky.bottom-0")).toBeNull();
+  });
+
+  it("reserves the chat launcher's corner at the end of the mobile scroll", async () => {
+    mockViewport.isMobile = true;
+
+    const { container } = renderIssueDetail();
+
+    await waitFor(() => {
+      expect(screen.getByText("Implement authentication")).toBeInTheDocument();
+    });
+
+    // Unpinned, the composer lands in that corner once the reader reaches the
+    // bottom, so the column has to end above the launcher rather than under it.
+    expect(container.querySelector(".max-md\\:pb-chat-launcher")).not.toBeNull();
+  });
+
   it("hides metadata content from the sidebar and shows a button when the bag has keys", async () => {
     // Metadata is agent-facing; the sidebar only exposes a button that opens
     // the raw JSON on demand. Keys are NOT rendered inline anywhere.

--- a/packages/views/issues/components/issue-detail.tsx
+++ b/packages/views/issues/components/issue-detail.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect, useCallback, useMemo, useRef, Fragment } from "react";
+import { useState, useEffect, useCallback, useMemo, useRef, Fragment, type ReactNode } from "react";
 import { Virtuoso, type VirtuosoHandle } from "react-virtuoso";
 import { useDefaultLayout, usePanelRef } from "react-resizable-panels";
 import { AppLink, useBackOrReplace } from "../../navigation";
@@ -91,7 +91,6 @@ import { propertyListOptions } from "@multica/core/properties";
 import { memberListOptions, agentListOptions } from "@multica/core/workspace/queries";
 import {
   selectExpandedResolved,
-  useCommentComposerStore,
   useRecentIssuesStore,
   useResolvedExpandStore,
   useSubIssueDisplayStore,
@@ -114,6 +113,7 @@ import { matchesPinyin } from "../../editor/extensions/pinyin-match";
 import { useT } from "../../i18n";
 import { useIssueDetailScrollRestore } from "../hooks/use-issue-detail-scroll-restore";
 import { useInPageFind } from "../hooks/use-in-page-find";
+import { useStickyComposer } from "../hooks/use-sticky-composer";
 import { FindBar } from "./find-bar";
 import {
   AnimatedRightSidebar,
@@ -920,6 +920,14 @@ interface IssueDetailProps {
   layoutId?: string;
   /** When set, the issue detail will auto-scroll to this comment and briefly highlight it. */
   highlightCommentId?: string;
+  /**
+   * Far-left header slot, replacing the mobile sidebar trigger. A host that
+   * embeds this detail one level deep (the inbox, on a phone) passes its own
+   * "back" control here instead of stacking a second 48px bar above us — the
+   * breadcrumb this header already renders names the issue's container, not
+   * the surface the reader arrived from, so only the host can spell that trip.
+   */
+  leadingAction?: ReactNode;
 }
 
 // ---------------------------------------------------------------------------
@@ -932,20 +940,37 @@ interface IssueDetailProps {
  * so mounts a second observer on the already-failed query, which refetches it
  * and restarts the resolve/remount cycle indefinitely.
  */
-export function IssueNotFound({ showBackLink = true }: { showBackLink?: boolean }) {
+export function IssueNotFound({
+  showBackLink = true,
+  leading,
+}: {
+  showBackLink?: boolean;
+  /**
+   * Host-supplied way back, mirrored from `IssueDetailProps.leadingAction`. A
+   * host that hands its whole screen to this component (the inbox, on a phone)
+   * has no bar of its own left, so this state has to carry the trip back or
+   * there is none.
+   */
+  leading?: ReactNode;
+}) {
   const { t } = useT("issues");
   const backOrReplace = useBackOrReplace();
   const paths = useWorkspacePaths();
 
   return (
-    <div className="flex flex-1 min-h-0 flex-col items-center justify-center gap-3 text-body text-muted-foreground">
-      <p>{t(($) => $.detail.not_found)}</p>
-      {showBackLink && (
-        <Button variant="outline" size="sm" onClick={() => backOrReplace(paths.issues())}>
-          <ChevronLeft className="mr-1 h-3.5 w-3.5" />
-          {t(($) => $.detail.back)}
-        </Button>
+    <div className="flex flex-1 min-h-0 flex-col">
+      {leading && (
+        <div className="flex h-12 shrink-0 items-center gap-2 border-b px-4">{leading}</div>
       )}
+      <div className="flex flex-1 min-h-0 flex-col items-center justify-center gap-3 text-body text-muted-foreground">
+        <p>{t(($) => $.detail.not_found)}</p>
+        {showBackLink && (
+          <Button variant="outline" size="sm" onClick={() => backOrReplace(paths.issues())}>
+            <ChevronLeft className="mr-1 h-3.5 w-3.5" />
+            {t(($) => $.detail.back)}
+          </Button>
+        )}
+      </div>
     </div>
   );
 }
@@ -959,19 +984,28 @@ export function IssueNotFound({ showBackLink = true }: { showBackLink?: boolean 
  * an identifier URL to its issue — the two waits are indistinguishable to the
  * user, and rendering the same skeleton keeps them that way.
  */
-export function IssueDetailSkeleton() {
+export function IssueDetailSkeleton({ leading }: { leading?: ReactNode } = {}) {
   return (
     <div className="flex flex-1 min-h-0 flex-col">
+      {/* The way back is real from the first frame, not once the issue lands:
+          a host that gave up its own bar for `leadingAction` has nothing else
+          to offer while this skeleton owns the screen. */}
       <div className="flex h-12 shrink-0 items-center gap-2 border-b px-4">
-        <Skeleton className="h-4 w-16" />
-        <Skeleton className="h-4 w-4" />
-        <Skeleton className="h-4 w-24" />
+        {leading ?? (
+          <>
+            <Skeleton className="h-4 w-16" />
+            <Skeleton className="h-4 w-4" />
+            <Skeleton className="h-4 w-24" />
+          </>
+        )}
       </div>
       <div className="flex flex-1 min-h-0">
         {/* Same scrollbar-gutter as the loaded scroller below, so the skeleton
             column doesn't shift sideways when real content mounts. */}
         <div className="flex-1 overflow-y-auto [scrollbar-gutter:stable_both-edges]">
-          <div className="mx-auto w-full max-w-4xl px-8 py-8 space-y-6">
+          {/* Gutters match the loaded column exactly (see its comment), so the
+              skeleton doesn't reflow sideways when real content mounts. */}
+          <div className="mx-auto w-full max-w-4xl px-4 py-6 space-y-6 md:px-8 md:py-8">
             <Skeleton className="h-8 w-3/4" />
             <div className="space-y-2">
               <Skeleton className="h-4 w-full" />
@@ -1015,7 +1049,7 @@ export function IssueDetailSkeleton() {
 // IssueDetail
 // ---------------------------------------------------------------------------
 
-export function IssueDetail({ issueId, onDelete, onDone, defaultSidebarOpen = true, layoutId = "multica_issue_detail_layout", highlightCommentId }: IssueDetailProps) {
+export function IssueDetail({ issueId, onDelete, onDone, defaultSidebarOpen = true, layoutId = "multica_issue_detail_layout", highlightCommentId, leadingAction }: IssueDetailProps) {
   const { t } = useT("issues");
   const timeAgo = useTimeAgo();
   const id = issueId;
@@ -1113,8 +1147,9 @@ export function IssueDetail({ issueId, onDelete, onDone, defaultSidebarOpen = tr
     [restoreScrollRef],
   );
   const [highlightedId, setHighlightedId] = useState<string | null>(null);
-  // User preference: pin the bottom comment bar to the scroll viewport.
-  const stickyComposer = useCommentComposerStore((s) => s.sticky);
+  // User preference: pin the bottom comment bar to the scroll viewport. Off
+  // below `md` regardless of the preference — see the hook.
+  const stickyComposer = useStickyComposer();
 
   // Per-session: which resolved threads the user has temporarily expanded.
   // Not persisted (matches Linear) — reload collapses everything back to bars.
@@ -1840,11 +1875,11 @@ export function IssueDetail({ issueId, onDelete, onDone, defaultSidebarOpen = tr
   });
 
   if (loading) {
-    return <IssueDetailSkeleton />;
+    return <IssueDetailSkeleton leading={leadingAction} />;
   }
 
   if (!issue) {
-    return <IssueNotFound showBackLink={!onDelete} />;
+    return <IssueNotFound showBackLink={!onDelete} leading={leadingAction} />;
   }
 
   const sidebarContent = (
@@ -2305,6 +2340,7 @@ export function IssueDetail({ issueId, onDelete, onDone, defaultSidebarOpen = tr
           />
         )}
         <BreadcrumbHeader
+          leading={leadingAction}
           segments={breadcrumbSegments}
           leaf={
             <AppLink
@@ -2414,7 +2450,13 @@ export function IssueDetail({ issueId, onDelete, onDone, defaultSidebarOpen = tr
           data-tab-scroll-root
           className="relative flex-1 overflow-y-auto [scrollbar-gutter:stable_both-edges]"
         >
-        <div className="mx-auto w-full max-w-4xl px-8 py-8">
+        {/* Gutters: 32px is a comfortable reading margin on a desktop column
+            but eats 16% of a 393px phone, so below `md` they drop to 16px.
+            `max-md:pb-chat-launcher` reserves the launcher's corner at the end
+            of the scroll: below `md` the composer is not pinned (see
+            `useStickyComposer`), so it lands here — right where the launcher
+            floats — once the reader scrolls to the bottom. */}
+        <div className="mx-auto w-full max-w-4xl px-4 py-6 max-md:pb-chat-launcher md:px-8 md:py-8">
           {titleLazy.active && (
             <div className={titleLazy.ready ? undefined : "hidden"}>
               <TitleEditor

--- a/packages/views/issues/hooks/index.ts
+++ b/packages/views/issues/hooks/index.ts
@@ -4,3 +4,4 @@ export { useIssueSubscribers } from "./use-issue-subscribers";
 export { useIssueDetailScrollRestore } from "./use-issue-detail-scroll-restore";
 export { useInPageFind } from "./use-in-page-find";
 export { useResolveIssueIdentifier } from "./use-resolve-issue-identifier";
+export { useStickyComposer } from "./use-sticky-composer";

--- a/packages/views/issues/hooks/use-sticky-composer.test.tsx
+++ b/packages/views/issues/hooks/use-sticky-composer.test.tsx
@@ -1,0 +1,70 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { renderHook } from "@testing-library/react";
+import { useCommentComposerStore } from "@multica/core/issues/stores";
+import { useStickyComposer } from "./use-sticky-composer";
+
+// `useIsMobile` reads `window.innerWidth` against a 768px breakpoint, so the
+// viewport is the only thing these tests need to move.
+const DESKTOP_WIDTH = 1280;
+const PHONE_WIDTH = 390;
+
+function setViewportWidth(width: number) {
+  Object.defineProperty(window, "innerWidth", { configurable: true, value: width });
+}
+
+describe("useStickyComposer", () => {
+  beforeEach(() => {
+    useCommentComposerStore.setState({ sticky: true });
+    setViewportWidth(DESKTOP_WIDTH);
+  });
+
+  afterEach(() => {
+    useCommentComposerStore.setState({ sticky: true });
+    setViewportWidth(DESKTOP_WIDTH);
+  });
+
+  it("pins the composer when the preference is on and the viewport has room", () => {
+    const { result } = renderHook(() => useStickyComposer());
+
+    expect(result.current).toBe(true);
+  });
+
+  it("does not pin when the preference is off", () => {
+    useCommentComposerStore.setState({ sticky: false });
+
+    const { result } = renderHook(() => useStickyComposer());
+
+    expect(result.current).toBe(false);
+  });
+
+  it("does not pin below the mobile breakpoint even with the preference on", () => {
+    setViewportWidth(PHONE_WIDTH);
+
+    const { result } = renderHook(() => useStickyComposer());
+
+    expect(result.current).toBe(false);
+  });
+
+  it("still pins at exactly the breakpoint — 768px is not a phone", () => {
+    setViewportWidth(768);
+
+    const { result } = renderHook(() => useStickyComposer());
+
+    expect(result.current).toBe(true);
+  });
+
+  // The narrow-screen override is a rendering decision, not a settings change.
+  // Rewriting the stored preference would silently unpin the composer on the
+  // desktop too, the next time that user opened an issue there.
+  it("leaves the stored preference alone, so a wider viewport pins again", () => {
+    setViewportWidth(PHONE_WIDTH);
+    renderHook(() => useStickyComposer());
+
+    expect(useCommentComposerStore.getState().sticky).toBe(true);
+
+    setViewportWidth(DESKTOP_WIDTH);
+    const { result } = renderHook(() => useStickyComposer());
+
+    expect(result.current).toBe(true);
+  });
+});

--- a/packages/views/issues/hooks/use-sticky-composer.ts
+++ b/packages/views/issues/hooks/use-sticky-composer.ts
@@ -1,0 +1,29 @@
+"use client";
+
+import { useIsMobile } from "@multica/ui/hooks/use-mobile";
+import { useCommentComposerStore } from "@multica/core/issues/stores";
+
+/**
+ * Whether the bottom comment composer is pinned to the scroll viewport.
+ *
+ * The stored preference (Settings → Preferences) is the user's answer for a
+ * screen with room to spare. A narrow viewport is not that screen:
+ *
+ *  - The chat launcher owns the bottom-right corner of every workspace page
+ *    (see `--chat-launcher-clearance`). A pinned composer sits under it at
+ *    every scroll position, and the part it covers is the send button.
+ *  - Pinned, the composer costs ~15% of a phone viewport permanently, on a
+ *    surface people mostly read rather than write on.
+ *
+ * Below `md` the composer therefore rides the end of the timeline, which is
+ * where a phone reader scrolls to comment anyway. The preference is not
+ * rewritten — it still applies the moment the viewport is wide enough.
+ *
+ * Both the composer and its host read this, so the pinning and the 40vh height
+ * cap that only makes sense while pinned can never disagree.
+ */
+export function useStickyComposer(): boolean {
+  const preferred = useCommentComposerStore((s) => s.sticky);
+  const isMobile = useIsMobile();
+  return preferred && !isMobile;
+}

--- a/packages/views/layout/app-sidebar.test.tsx
+++ b/packages/views/layout/app-sidebar.test.tsx
@@ -3,8 +3,9 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { ApiError } from "@multica/core/api";
 import { AppSidebar } from "./app-sidebar";
 
-const { appForeground, chatSessions, chatStore, detail, deletePin, inboxItems, navigation, pins, summary, workspaces } = vi.hoisted(() => ({
+const { appForeground, chatSessions, chatStore, detail, deletePin, inboxItems, navigation, pins, sidebarState, summary, workspaces } = vi.hoisted(() => ({
   appForeground: { current: true },
+  sidebarState: { setOpenMobile: vi.fn() },
   chatSessions: { current: [] as { id?: string; unread_count?: number }[] },
   chatStore: { current: { activeSessionId: null as string | null, isOpen: false } },
   detail: { current: { isPending: false, isError: false, data: null as unknown, error: null as unknown } },
@@ -67,6 +68,7 @@ vi.mock("@multica/ui/components/ui/sidebar", () => ({
   ),
   SidebarMenuItem: ({ children }: { children: React.ReactNode }) => <>{children}</>,
   SidebarRail: () => null,
+  useSidebar: () => ({ setOpenMobile: sidebarState.setOpenMobile }),
 }));
 vi.mock("@multica/ui/components/ui/dropdown-menu", () => ({
   DropdownMenu: ({ children }: { children: React.ReactNode }) => <>{children}</>,
@@ -231,6 +233,36 @@ describe("PinRow", () => {
       "true",
     );
     expect(container.querySelector('button[data-href="/acme/issues"]')).not.toHaveAttribute("data-active");
+  });
+});
+
+// On a phone the sidebar is a Sheet laid over the page, so a nav tap that
+// leaves it open renders the destination underneath and reads as a dead tap.
+describe("mobile sheet dismissal", () => {
+  beforeEach(() => {
+    sidebarState.setOpenMobile.mockClear();
+    navigation.current = { pathname: "/acme/issues" };
+  });
+
+  it("dismisses the sheet once the route changes", () => {
+    const { rerender } = render(<AppSidebar />);
+    sidebarState.setOpenMobile.mockClear();
+
+    navigation.current = { pathname: "/acme/inbox" };
+    rerender(<AppSidebar />);
+
+    expect(sidebarState.setOpenMobile).toHaveBeenCalledWith(false);
+  });
+
+  // Closing on `pathname` rather than per-link keeps every route out of the
+  // sidebar covered at once — nav groups, pins, and the switcher's own push.
+  it("does not re-dismiss while the route holds still", () => {
+    const { rerender } = render(<AppSidebar />);
+    sidebarState.setOpenMobile.mockClear();
+
+    rerender(<AppSidebar />);
+
+    expect(sidebarState.setOpenMobile).not.toHaveBeenCalled();
   });
 });
 

--- a/packages/views/layout/app-sidebar.tsx
+++ b/packages/views/layout/app-sidebar.tsx
@@ -45,6 +45,7 @@ import {
   SidebarMenuButton,
   SidebarMenuItem,
   SidebarRail,
+  useSidebar,
 } from "@multica/ui/components/ui/sidebar";
 import {
   DropdownMenu,
@@ -359,6 +360,18 @@ export function AppSidebar({ topSlot, searchSlot, headerClassName, headerStyle }
   const { data: workspaces = EMPTY_WORKSPACES } = useQuery(workspaceListOptions());
   const { data: myInvitations = EMPTY_INVITATIONS } = useQuery(myInvitationListOptions());
   const workspaceCreationDisabled = useConfigStore((s) => s.workspaceCreationDisabled);
+
+  // On a phone the sidebar is a Sheet covering the page, so navigating out of
+  // it has to dismiss it — otherwise the destination renders underneath and the
+  // tap reads as "nothing happened". Closing on `pathname` rather than on each
+  // link's onClick covers every route out of here at once: the nav groups, the
+  // pinned items, the workspace switcher's programmatic push, and anything
+  // added later. `setOpenMobile` is a no-op on desktop, where the sheet is not
+  // the sidebar's rendering at all.
+  const { setOpenMobile } = useSidebar();
+  useEffect(() => {
+    setOpenMobile(false);
+  }, [pathname, setOpenMobile]);
 
   const wsId = workspace?.id;
   const { data: inboxItems = EMPTY_INBOX } = useQuery({

--- a/packages/views/layout/breadcrumb-header.tsx
+++ b/packages/views/layout/breadcrumb-header.tsx
@@ -30,6 +30,8 @@ interface BreadcrumbHeaderProps {
   leaf: ReactNode;
   /** Right-side actions. Wrapped in a `shrink-0` flex row; omit for none. */
   actions?: ReactNode;
+  /** Far-left slot; replaces the mobile sidebar trigger. See `PageHeader`. */
+  leading?: ReactNode;
   className?: string;
 }
 
@@ -41,9 +43,9 @@ interface BreadcrumbHeaderProps {
  * The mental model is identical everywhere: the leading crumbs are the thing's
  * real containers and clicking one navigates up to it.
  */
-export function BreadcrumbHeader({ segments, leaf, actions, className }: BreadcrumbHeaderProps) {
+export function BreadcrumbHeader({ segments, leaf, actions, leading, className }: BreadcrumbHeaderProps) {
   return (
-    <PageHeader className={cn("gap-2 bg-background text-body", className)}>
+    <PageHeader leading={leading} className={cn("gap-2 bg-background text-body", className)}>
       <div className="flex flex-1 items-center gap-1.5 min-w-0">
         {segments.map((segment) => (
           <Fragment key={segment.href}>

--- a/packages/views/layout/page-header.tsx
+++ b/packages/views/layout/page-header.tsx
@@ -11,13 +11,23 @@ function MobileSidebarTrigger() {
 
 interface PageHeaderProps {
   children: React.ReactNode;
+  /**
+   * Replaces the mobile sidebar trigger at the far left.
+   *
+   * For a surface a phone reaches by drilling in rather than by navigating —
+   * the inbox's issue detail — "go back" is the leading affordance that
+   * matters, and the sidebar is still one step away behind it. Rendering both
+   * would spend two of the header's 48px on navigation chrome and leave the
+   * title nothing to truncate into.
+   */
+  leading?: React.ReactNode;
   className?: string;
 }
 
-export function PageHeader({ children, className }: PageHeaderProps) {
+export function PageHeader({ children, leading, className }: PageHeaderProps) {
   return (
     <header className={cn("flex h-12 shrink-0 items-center border-b px-4", className)}>
-      <MobileSidebarTrigger />
+      {leading ?? <MobileSidebarTrigger />}
       {children}
     </header>
   );

--- a/packages/views/projects/components/projects-page.tsx
+++ b/packages/views/projects/components/projects-page.tsx
@@ -698,7 +698,7 @@ function ProjectBatchToolbar({
 
   return (
     <>
-      <div className="absolute bottom-6 left-1/2 z-50 flex -translate-x-1/2 items-center gap-1 rounded-lg border bg-background px-2 py-1.5 shadow-lg">
+      <div className="absolute bottom-6 left-1/2 z-50 flex -translate-x-1/2 items-center gap-1 rounded-lg border bg-background px-2 py-1.5 shadow-lg max-md:above-chat-launcher">
         <div className="mr-1 flex items-center gap-1.5 border-r pl-1 pr-2">
           <span className="text-body font-medium">
             {t(($) => $.page.selected, { count: rows.length })}

--- a/packages/views/skills/components/skill-detail-page.tsx
+++ b/packages/views/skills/components/skill-detail-page.tsx
@@ -1289,7 +1289,7 @@ export function SkillDetailPage({ skillId }: { skillId: string }) {
         <div
           role="status"
           aria-live="polite"
-          className="absolute bottom-6 left-1/2 z-50 flex -translate-x-1/2 animate-in items-center gap-1 rounded-lg border bg-background px-2 py-1.5 fade-in slide-in-from-bottom-2 shadow-lg"
+          className="absolute bottom-6 left-1/2 z-50 flex -translate-x-1/2 animate-in items-center gap-1 rounded-lg border bg-background px-2 py-1.5 fade-in slide-in-from-bottom-2 shadow-lg max-md:above-chat-launcher"
         >
           <div className="mr-1 flex items-center border-r pl-1 pr-2">
             <span className="whitespace-nowrap text-caption text-muted-foreground">

--- a/packages/views/skills/components/skill-list-actions.tsx
+++ b/packages/views/skills/components/skill-list-actions.tsx
@@ -618,7 +618,7 @@ export function SkillBatchToolbar({
           sidebar/split pane open, viewport-centering sits visibly off the
           list's own center. Same rule for every future list page's batch
           toolbar. */}
-      <div className="absolute bottom-6 left-1/2 z-50 flex -translate-x-1/2 items-center gap-1 rounded-lg border bg-background px-2 py-1.5 shadow-lg">
+      <div className="absolute bottom-6 left-1/2 z-50 flex -translate-x-1/2 items-center gap-1 rounded-lg border bg-background px-2 py-1.5 shadow-lg max-md:above-chat-launcher">
         <div className="mr-1 flex items-center gap-1.5 border-r pl-1 pr-2">
           <span className="text-body font-medium">
             {t(($) => $.actions.selected, { count: rows.length })}


### PR DESCRIPTION
Issue detail reads as cramped on a phone. Three separate things each take a slice of a 393px screen, and none of the three was ever decided for that width — each is a desktop default that nobody re-asked on mobile.

## What was spending the space

**Gutters that never shrink.** `issue-detail.tsx` renders its content column at `px-8 py-8` at every width. On a desktop column that is a comfortable reading margin. On a 393px phone it is 64px — **16% of the screen** — spent on nothing.

**A composer pinned to the viewport.** `sticky` is a stored preference (Settings → Preferences), and the answer it stores was given by a user sitting at a wide screen. Applied to a phone it costs ~15% of the viewport at *every* scroll position, on a surface people mostly read rather than write on — and it parks the composer under the chat launcher, so the launcher covers the composer's own send button. `stickyComposer` had no breakpoint at all: `issue-detail.tsx` read the preference and used it directly.

**The launcher's corner, claimed by nobody.** `tokens.css:137` already declares the contract:

> the chat launcher … that corner **is not available to page content**. …anything reaching that corner — a footer's action buttons, a floating toolbar — reserves `--chat-launcher-clearance`

Exactly one site in the repo honoured it (`create-agent-footer.tsx`). Everything else reaching that corner just overlapped the button.

## What this changes

**Gutters** drop to `px-4 py-6` below `md`, unchanged above it. The skeleton matches so the column does not reflow sideways when real content mounts.

**Pinning** moves behind `useStickyComposer()` (new), which returns the preference AND-ed with "the viewport has room". Both `issue-detail.tsx` and `comment-input.tsx` read it, so the pinning and the `max-h-[40vh]` cap that only makes sense *while* pinned can no longer disagree — previously they were two independent reads of the same store. The stored preference is not rewritten: widening the window pins again immediately.

**The corner** gets two utilities alongside the existing `pe-chat-launcher`, one per remaining way of arriving at it:

| approach | utility |
| --- | --- |
| a full-width bar arrives from the left | `pe-chat-launcher` (existing) |
| scrollable content ends there | `pb-chat-launcher` |
| a centred overlay grows into it | `above-chat-launcher` |

The third exists because a centred toolbar (`left-1/2 -translate-x-1/2`) **cannot** use the padding variants — inline padding widens it symmetrically, so it reaches exactly as far right as before. It has to clear the launcher vertically. Applied to the issue-detail column plus the six centred floating toolbars (issues + agents batch actions, autopilots, projects, skills list, skill detail).

## Two mobile bugs found on the way

**1. Inbox nested a second scroller.** `inbox-page.tsx` wrapped `IssueDetail` in its own `overflow-y-auto`. `IssueDetail`'s root is `h-full` inside a `flex-1` wrapper — but that wrapper's parent was a *block*, so `flex-1` was inert, the height resolved to `auto`, and the detail's own `flex-1 overflow-y-auto` scroller grew to content height and never overflowed. Four things broke together:

- its header — and the done/pin/more/sidebar actions in it — scrolled away instead of staying pinned
- `position: sticky` inside it became a no-op (sticky resolves against the nearest *scrolling* ancestor, and that ancestor no longer scrolled)
- `data-tab-scroll-root`, which scroll restoration targets, pointed at an element that never scrolls
- the timeline virtualizer read the wrong scroll parent

Only the inbox path was affected; `/issues/[id]` mounts under `SidebarInset`, which is a flex column, so its chain resolved correctly.

Removing the wrapper alone would have surfaced the detail's header *underneath* the inbox's own back bar — two stacked 48px bars, 96px of a ~700px viewport, in a PR about saving space. So the back control moves into the detail's header instead, through a `leading` slot on `PageHeader` that replaces the mobile sidebar trigger. One bar, not two.

**2. The sidebar never closed itself.** On a phone the sidebar is a Sheet laid over the page, and `app-sidebar.tsx` never called `setOpenMobile`. Tapping a nav item navigated *underneath* the still-open sheet, which reads as a dead tap. It now dismisses on `pathname` — one place, covering the nav groups, the pinned items and the workspace switcher's programmatic push, plus anything added later.

## One thing worth a reviewer's eye

`IssueDetail` owns the entire phone screen in **four** states, not one — loaded, loading (`IssueDetailSkeleton`), not-found (`IssueNotFound`, which the inbox renders with `showBackLink={false}` because it passes `onDelete`), and crashed (the inbox's own `ErrorBoundary`). Once the inbox gives up its own bar, a slot honoured in only the first state strands the reader on the other three with no way back and no sidebar trigger either.

So `leadingAction` is threaded through all four, and a fifth gap is closed alongside: `InboxItem.issue_id` is `string | null`, so `detailContent` can be `null` for a selected row — previously that showed the bar over an empty area, and after removing the bar it would have been a blank screen.

This was caught in self-review, not by a test — the render path is a state the tests do not currently reach. Worth a skeptical second look.

## Tests

- `use-sticky-composer.test.tsx` (new, 5): preference on/off, below the breakpoint, exactly *at* 768px, and that the stored preference survives a narrow render
- `issue-detail.test.tsx` (+3): composer pinned on a wide screen, not pinned on mobile, launcher clearance present on the mobile column
- `comment-composers.test.tsx` (+1): the height cap follows the pinning below the breakpoint, plus a viewport reset in `beforeEach` so narrow tests cannot leak
- `app-sidebar.test.tsx` (+2): the sheet dismisses when the route changes, and does not re-fire while it holds still

## Verification

- `packages/views` full suite — 303 files, 3542 tests, all pass
- `pnpm typecheck` — 6/6 pass
- `eslint` on every touched file — clean

## Blast radius

Frontend only, no backend or API change. `PageHeader` gains an optional prop with an unchanged default, so the 22 pages that render it are untouched. `apps/mobile` shares none of this. The sidebar dismissal is the widest change — it fires on every route change on every platform, but `setOpenMobile` is inert on desktop, where the sheet is not how the sidebar renders.

## Known and deliberately not fixed

- **Desktop windows between roughly 768px and 1000px.** There, `max-w-4xl` nearly fills `SidebarInset`, so a pinned composer's bottom-right corner still reaches the launcher. Out of scope for a mobile PR, and fixing it properly wants a container query rather than a viewport breakpoint.
- **Soft keyboard.** Reasoning from the layout says the launcher is `absolute` inside an `h-svh` shell, so the keyboard covers it rather than pushing it up onto the composer. That is static analysis, not a device test — worth one check on real hardware.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
