### PR TITLE
docs(desktop): distinguish Desktop desktop.json from the CLI config (MUL-5737)

### DIFF
--- a/apps/docs/content/docs/desktop-app.ja.mdx
+++ b/apps/docs/content/docs/desktop-app.ja.mdx
@@ -78,6 +78,8 @@ Desktop はデフォルトで Multica Cloud に接続します。セルフホス
 | Linux | `/home/<you>/.multica/desktop.json` |
 | Windows | `C:\Users\<you>\.multica\desktop.json` |
 
+これらはデフォルトの場所です。ホームディレクトリを移動またはリダイレクトしている場合は、実際のパスを使ってください。
+
 ```json
 {
   "schemaVersion": 1,
@@ -124,7 +126,7 @@ Desktop が接続できるのは、ブラウザと実行マシンの両方から
 
 Windows では、エディタの 2 つのデフォルト動作が Desktop の読めないファイルを気づかないうちに作ってしまいます:
 
-- **メモ帳は `.txt` を付け足します。** `desktop.json` として保存したつもりでも実際には `desktop.json.txt` になることがあり、Desktop はファイルが見つからないものとして扱います。エクスプローラーでファイル名拡張子の表示を有効にするか、保存ダイアログで*すべてのファイル*を選んでください。`dir %USERPROFILE%\.multica` で確認すると、ちょうど `desktop.json` だけが表示されるはずです。
+- **メモ帳は `.txt` を付け足します。** `desktop.json` として保存したつもりでも実際には `desktop.json.txt` になることがあり、Desktop はファイルが見つからないものとして扱います。エクスプローラーでファイル名拡張子の表示を有効にするか、保存ダイアログで*すべてのファイル*を選んでください。実際のファイル名を確認するには、PowerShell で `Get-ChildItem "$env:USERPROFILE\.multica" -Filter "desktop.json*"` を実行します。`Name` 列がちょうど `desktop.json` になっている必要があります。
 - **PowerShell のリダイレクトは UTF-16 や BOM 付きで書き込みます。** `> desktop.json` や `Out-File` はパースできないエンコーディングを生成することがあり、設定エラーとして現れます。
 
 どちらも避けるには、PowerShell で一度に作成します:

--- a/apps/docs/content/docs/desktop-app.ja.mdx
+++ b/apps/docs/content/docs/desktop-app.ja.mdx
@@ -70,7 +70,13 @@ Desktop はワークスペースごとにタブを保存します。たとえば
 
 ## セルフホストインスタンスへの接続
 
-Desktop はデフォルトで Multica Cloud に接続します。セルフホストインスタンスに接続するには、ホームディレクトリに `~/.multica/desktop.json` を作成します:
+Desktop はデフォルトで Multica Cloud に接続します。セルフホストインスタンスに接続するには、ホームディレクトリの `.multica` の中に `desktop.json` を作成します:
+
+| プラットフォーム | パス |
+| --- | --- |
+| macOS | `/Users/<you>/.multica/desktop.json` |
+| Linux | `/home/<you>/.multica/desktop.json` |
+| Windows | `C:\Users\<you>\.multica\desktop.json` |
 
 ```json
 {
@@ -78,6 +84,10 @@ Desktop はデフォルトで Multica Cloud に接続します。セルフホス
   "apiUrl": "https://api.example.com"
 }
 ```
+
+<Callout type="warning">
+これは CLI の `~/.multica/config.json` と**別のファイル**で、キー名も異なります: CLI は `server_url`、Desktop は `apiUrl` を使います。Desktop は CLI の設定を読みません。`~/.multica/profiles/desktop-<host>/` の下に専用の daemon プロファイルを管理します。`config.json` を編集しても、Desktop の接続先は変わりません。
+</Callout>
 
 `apiUrl` はバックエンドの公開アドレスです。必須で、`http` または `https` を使う必要があります。残りの 2 つのアドレスは省略でき、Desktop が自動で導出します:
 
@@ -99,11 +109,37 @@ Desktop はデフォルトで Multica Cloud に接続します。セルフホス
 }
 ```
 
-保存後に Desktop を再起動します。ファイルが存在するのに JSON、バージョン、URL のいずれかが無効な場合、アプリは設定エラーを表示し、自動では Cloud にフォールバックしません。そのファイルを削除して再起動すれば、デフォルトの Cloud 設定に戻ります。
+保存後に Desktop を再起動します。この設定は起動時に一度だけ読み込まれます。2 つの失敗の現れ方は異なるため、これが切り分けの手がかりになります:
+
+- **ファイルが見つからない**（ディレクトリが違う、またはファイル名が `desktop.json` ではない）: Desktop はデフォルトの Cloud 設定を使い、エラーは表示しません。つまり Desktop が Cloud のアドレスを表示したままで設定エラーも出ない場合、ファイルは Desktop が探している場所にありません。
+- **ファイルは見つかったが無効**（JSON、バージョン、URL のいずれかに問題がある）: Desktop は設定エラーを表示し、自動では Cloud にフォールバックしません。
+
+そのファイルを削除して再起動すれば、デフォルトの Cloud 設定に戻ります。
 
 <Callout type="warning">
 Desktop が接続できるのは、ブラウザと実行マシンの両方から到達できるアドレスだけです。リモートのセルフホストインスタンスが HTTPS を使っていない、または WebSocket をプロキシしていない場合、Desktop は接続を確立できません。完全な設定は[セルフホストクイックスタート](/self-host-quickstart#3-アクセス方法を選ぶ)を参照してください。
 </Callout>
+
+### Windows: ファイル名とエンコーディングを確認する
+
+Windows では、エディタの 2 つのデフォルト動作が Desktop の読めないファイルを気づかないうちに作ってしまいます:
+
+- **メモ帳は `.txt` を付け足します。** `desktop.json` として保存したつもりでも実際には `desktop.json.txt` になることがあり、Desktop はファイルが見つからないものとして扱います。エクスプローラーでファイル名拡張子の表示を有効にするか、保存ダイアログで*すべてのファイル*を選んでください。`dir %USERPROFILE%\.multica` で確認すると、ちょうど `desktop.json` だけが表示されるはずです。
+- **PowerShell のリダイレクトは UTF-16 や BOM 付きで書き込みます。** `> desktop.json` や `Out-File` はパースできないエンコーディングを生成することがあり、設定エラーとして現れます。
+
+どちらも避けるには、PowerShell で一度に作成します:
+
+```powershell
+$dir = "$env:USERPROFILE\.multica"
+New-Item -ItemType Directory -Force $dir | Out-Null
+$json = @'
+{
+  "schemaVersion": 1,
+  "apiUrl": "https://api.example.com"
+}
+'@
+[System.IO.File]::WriteAllText("$dir\desktop.json", $json)
+```
 
 ## Windows Defender が Multica をウイルスとして検出する
 

--- a/apps/docs/content/docs/desktop-app.ko.mdx
+++ b/apps/docs/content/docs/desktop-app.ko.mdx
@@ -78,6 +78,8 @@ Desktop은 기본적으로 Multica Cloud에 연결됩니다. 자체 호스팅 �
 | Linux | `/home/<사용자>/.multica/desktop.json` |
 | Windows | `C:\Users\<사용자>\.multica\desktop.json` |
 
+위 경로는 기본 위치입니다. 홈 디렉터리를 옮겼거나 리디렉션한 경우에는 실제 경로를 사용하세요.
+
 ```json
 {
   "schemaVersion": 1,
@@ -124,7 +126,7 @@ Desktop은 브라우저와 실행 컴퓨터에서 모두 접근할 수 있는 �
 
 Windows에서는 편집기의 두 가지 기본 동작 때문에 Desktop이 사용할 수 없는 파일이 조용히 만들어집니다.
 
-- **메모장이 `.txt`를 덧붙입니다.** `desktop.json`으로 저장해도 실제로는 `desktop.json.txt`가 될 수 있으며, Desktop은 이를 파일이 없는 것으로 처리합니다. 파일 탐색기에서 파일 확장명 표시를 켜거나 저장 대화 상자에서 *모든 파일*을 선택하세요. `dir %USERPROFILE%\.multica`로 확인하면 정확히 `desktop.json`만 표시되어야 합니다.
+- **메모장이 `.txt`를 덧붙입니다.** `desktop.json`으로 저장해도 실제로는 `desktop.json.txt`가 될 수 있으며, Desktop은 이를 파일이 없는 것으로 처리합니다. 파일 탐색기에서 파일 확장명 표시를 켜거나 저장 대화 상자에서 *모든 파일*을 선택하세요. 실제 파일 이름을 확인하려면 PowerShell에서 `Get-ChildItem "$env:USERPROFILE\.multica" -Filter "desktop.json*"`를 실행하세요. `Name` 열이 정확히 `desktop.json`이어야 합니다.
 - **PowerShell 리디렉션은 UTF-16이나 BOM을 씁니다.** `> desktop.json`과 `Out-File`은 파싱할 수 없는 인코딩을 만들 수 있으며, 설정 오류로 나타납니다.
 
 두 가지를 모두 피하려면 PowerShell에서 한 번에 파일을 만듭니다.

--- a/apps/docs/content/docs/desktop-app.ko.mdx
+++ b/apps/docs/content/docs/desktop-app.ko.mdx
@@ -70,7 +70,13 @@ Desktop 설정에서 실행 상태와 로그를 확인할 수 있습니다. 도�
 
 ## 자체 호스팅 인스턴스 연결
 
-Desktop은 기본적으로 Multica Cloud에 연결됩니다. 자체 호스팅 인스턴스에 연결하려면 사용자 디렉터리에 `~/.multica/desktop.json`을 만듭니다.
+Desktop은 기본적으로 Multica Cloud에 연결됩니다. 자체 호스팅 인스턴스에 연결하려면 사용자 디렉터리의 `.multica` 안에 `desktop.json`을 만듭니다.
+
+| 플랫폼 | 경로 |
+| --- | --- |
+| macOS | `/Users/<사용자>/.multica/desktop.json` |
+| Linux | `/home/<사용자>/.multica/desktop.json` |
+| Windows | `C:\Users\<사용자>\.multica\desktop.json` |
 
 ```json
 {
@@ -78,6 +84,10 @@ Desktop은 기본적으로 Multica Cloud에 연결됩니다. 자체 호스팅 �
   "apiUrl": "https://api.example.com"
 }
 ```
+
+<Callout type="warning">
+이 파일은 CLI의 `~/.multica/config.json`과 **다른 파일**이며 키 이름도 다릅니다. CLI는 `server_url`을, Desktop은 `apiUrl`을 사용합니다. Desktop은 CLI 설정을 읽지 않고 `~/.multica/profiles/desktop-<host>/` 아래에 별도의 daemon 프로필을 관리합니다. `config.json`을 수정해도 Desktop이 연결하는 서버는 바뀌지 않습니다.
+</Callout>
 
 `apiUrl`은 backend의 공개 주소로 필수이며 `http` 또는 `https`를 사용해야 합니다. 다음 두 주소는 생략할 수 있으며 Desktop이 자동으로 추론합니다.
 
@@ -99,11 +109,37 @@ Desktop은 기본적으로 Multica Cloud에 연결됩니다. 자체 호스팅 �
 }
 ```
 
-저장한 뒤 Desktop을 다시 시작합니다. 설정 파일이 존재하지만 JSON, 버전, URL이 유효하지 않으면 앱에 설정 오류가 표시되고 Cloud에 자동 연결되지 않습니다. 해당 파일을 삭제하고 다시 시작하면 기본 Cloud 설정으로 돌아갑니다.
+저장한 뒤 Desktop을 다시 시작합니다. 이 설정은 시작할 때 한 번만 읽습니다. 두 가지 실패는 다르게 나타나므로 이를 보고 빠르게 구분할 수 있습니다.
+
+- **파일을 찾지 못한 경우**(디렉터리가 다르거나 파일 이름이 `desktop.json`이 아닌 경우): Desktop은 기본 Cloud 설정을 사용하고 오류를 표시하지 않습니다. 따라서 Desktop이 여전히 Cloud 주소를 표시하고 설정 오류도 없다면, 파일이 Desktop이 찾는 위치에 없다는 뜻입니다.
+- **파일은 찾았지만 유효하지 않은 경우**(JSON, 버전, URL에 문제가 있는 경우): Desktop에 설정 오류가 표시되며 Cloud로 자동 폴백하지 않습니다.
+
+해당 파일을 삭제하고 다시 시작하면 기본 Cloud 설정으로 돌아갑니다.
 
 <Callout type="warning">
 Desktop은 브라우저와 실행 컴퓨터에서 모두 접근할 수 있는 주소에만 연결할 수 있습니다. 원격 자체 호스팅 인스턴스에 HTTPS가 없거나 WebSocket 프록시가 설정되지 않으면 Desktop이 연결되지 않습니다. 전체 설정은 [자체 호스팅 빠른 시작](/self-host-quickstart#3-접근-방식-선택)을 참고하세요.
 </Callout>
+
+### Windows: 파일 이름과 인코딩 확인
+
+Windows에서는 편집기의 두 가지 기본 동작 때문에 Desktop이 사용할 수 없는 파일이 조용히 만들어집니다.
+
+- **메모장이 `.txt`를 덧붙입니다.** `desktop.json`으로 저장해도 실제로는 `desktop.json.txt`가 될 수 있으며, Desktop은 이를 파일이 없는 것으로 처리합니다. 파일 탐색기에서 파일 확장명 표시를 켜거나 저장 대화 상자에서 *모든 파일*을 선택하세요. `dir %USERPROFILE%\.multica`로 확인하면 정확히 `desktop.json`만 표시되어야 합니다.
+- **PowerShell 리디렉션은 UTF-16이나 BOM을 씁니다.** `> desktop.json`과 `Out-File`은 파싱할 수 없는 인코딩을 만들 수 있으며, 설정 오류로 나타납니다.
+
+두 가지를 모두 피하려면 PowerShell에서 한 번에 파일을 만듭니다.
+
+```powershell
+$dir = "$env:USERPROFILE\.multica"
+New-Item -ItemType Directory -Force $dir | Out-Null
+$json = @'
+{
+  "schemaVersion": 1,
+  "apiUrl": "https://api.example.com"
+}
+'@
+[System.IO.File]::WriteAllText("$dir\desktop.json", $json)
+```
 
 ## Windows Defender가 Multica를 바이러스로 탐지하는 경우
 

--- a/apps/docs/content/docs/desktop-app.mdx
+++ b/apps/docs/content/docs/desktop-app.mdx
@@ -78,6 +78,8 @@ Desktop connects to Multica Cloud by default. To connect to a self-hosted instan
 | Linux | `/home/<you>/.multica/desktop.json` |
 | Windows | `C:\Users\<you>\.multica\desktop.json` |
 
+These are the default locations — if your home directory has been moved or redirected, use its actual path.
+
 ```json
 {
   "schemaVersion": 1,
@@ -124,7 +126,7 @@ Desktop can only connect to addresses reachable from both the browser and the ex
 
 Two Windows editor defaults silently produce a file Desktop can't use:
 
-- **Notepad appends `.txt`.** Saving as `desktop.json` can produce `desktop.json.txt`, which Desktop treats as not found. Turn on file name extensions in Explorer, or pick *All files* in the save dialog. Verify with `dir %USERPROFILE%\.multica` — it should list exactly `desktop.json`.
+- **Notepad appends `.txt`.** Saving as `desktop.json` can produce `desktop.json.txt`, which Desktop treats as not found. Turn on file name extensions in Explorer, or pick *All files* in the save dialog. To see the real filename, run `Get-ChildItem "$env:USERPROFILE\.multica" -Filter "desktop.json*"` in PowerShell — the `Name` column must read exactly `desktop.json`.
 - **PowerShell redirection writes UTF-16 or a BOM.** `> desktop.json` and `Out-File` can produce an encoding that fails to parse, which surfaces as a configuration error.
 
 To avoid both, create the file from PowerShell in one step:

--- a/apps/docs/content/docs/desktop-app.mdx
+++ b/apps/docs/content/docs/desktop-app.mdx
@@ -70,7 +70,13 @@ Updates are distributed per OS and CPU architecture:
 
 ## Connecting to a self-hosted instance
 
-Desktop connects to Multica Cloud by default. To connect to a self-hosted instance, create `~/.multica/desktop.json` in your home directory:
+Desktop connects to Multica Cloud by default. To connect to a self-hosted instance, create `desktop.json` inside the `.multica` directory of your home directory:
+
+| Platform | Path |
+| --- | --- |
+| macOS | `/Users/<you>/.multica/desktop.json` |
+| Linux | `/home/<you>/.multica/desktop.json` |
+| Windows | `C:\Users\<you>\.multica\desktop.json` |
 
 ```json
 {
@@ -78,6 +84,10 @@ Desktop connects to Multica Cloud by default. To connect to a self-hosted instan
   "apiUrl": "https://api.example.com"
 }
 ```
+
+<Callout type="warning">
+This is **not** the CLI's `~/.multica/config.json`, and the key names differ: the CLI uses `server_url`, Desktop uses `apiUrl`. Desktop never reads the CLI's config — it manages a separate daemon profile under `~/.multica/profiles/desktop-<host>/`. Editing `config.json` does not change which server Desktop connects to.
+</Callout>
 
 `apiUrl` is the backend's public address; it is required and must use `http` or `https`. The other two URLs can be omitted — Desktop derives them automatically:
 
@@ -99,11 +109,37 @@ Usually `apiUrl` alone is enough. Override explicitly only when the derivation d
 }
 ```
 
-Restart Desktop after saving. If the file exists but the JSON, version, or URLs are invalid, the app shows a configuration error and does not fall back to Cloud automatically. Delete the file and restart to return to the default Cloud configuration.
+Restart Desktop after saving — the file is read once at startup. The two failure modes look different, which is the fastest way to tell them apart:
+
+- **File not found** (wrong directory, or a filename that isn't exactly `desktop.json`) — Desktop uses the default Cloud configuration and shows no error. So if Desktop still reports a Cloud address and no configuration error, the file is not where Desktop is looking.
+- **File found but invalid** JSON, version, or URLs — Desktop shows a configuration error and does not fall back to Cloud.
+
+Delete the file and restart to return to the default Cloud configuration.
 
 <Callout type="warning">
 Desktop can only connect to addresses reachable from both the browser and the executing machine. If a remote self-hosted instance doesn't use HTTPS or doesn't proxy WebSocket, Desktop can't establish a connection; see the [self-host quickstart](/self-host-quickstart#3-choose-how-to-access) for the full configuration.
 </Callout>
+
+### Windows: check the filename and encoding
+
+Two Windows editor defaults silently produce a file Desktop can't use:
+
+- **Notepad appends `.txt`.** Saving as `desktop.json` can produce `desktop.json.txt`, which Desktop treats as not found. Turn on file name extensions in Explorer, or pick *All files* in the save dialog. Verify with `dir %USERPROFILE%\.multica` — it should list exactly `desktop.json`.
+- **PowerShell redirection writes UTF-16 or a BOM.** `> desktop.json` and `Out-File` can produce an encoding that fails to parse, which surfaces as a configuration error.
+
+To avoid both, create the file from PowerShell in one step:
+
+```powershell
+$dir = "$env:USERPROFILE\.multica"
+New-Item -ItemType Directory -Force $dir | Out-Null
+$json = @'
+{
+  "schemaVersion": 1,
+  "apiUrl": "https://api.example.com"
+}
+'@
+[System.IO.File]::WriteAllText("$dir\desktop.json", $json)
+```
 
 ## Windows Defender flags Multica as a virus
 

--- a/apps/docs/content/docs/desktop-app.zh.mdx
+++ b/apps/docs/content/docs/desktop-app.zh.mdx
@@ -78,6 +78,8 @@ Desktop 默认连接 Multica Cloud。连接自托管实例时，在用户目录�
 | Linux | `/home/<你>/.multica/desktop.json` |
 | Windows | `C:\Users\<你>\.multica\desktop.json` |
 
+以上是默认位置。用户目录被迁移或重定向过的话，用实际路径。
+
 ```json
 {
   "schemaVersion": 1,
@@ -124,7 +126,7 @@ Desktop 只能连接浏览器和执行电脑都能访问的地址。远程自托
 
 Windows 上两个编辑器默认行为会悄悄生成 Desktop 用不了的文件：
 
-- **记事本会补 `.txt` 后缀**。存成 `desktop.json` 可能实际得到 `desktop.json.txt`，Desktop 会当作没找到。在资源管理器里打开文件扩展名显示，或在保存对话框里选*所有文件*。用 `dir %USERPROFILE%\.multica` 确认，列出的应该正好是 `desktop.json`。
+- **记事本会补 `.txt` 后缀**。存成 `desktop.json` 可能实际得到 `desktop.json.txt`，Desktop 会当作没找到。在资源管理器里打开文件扩展名显示，或在保存对话框里选*所有文件*。想确认真实文件名，在 PowerShell 里运行 `Get-ChildItem "$env:USERPROFILE\.multica" -Filter "desktop.json*"`，`Name` 一列必须正好是 `desktop.json`。
 - **PowerShell 重定向会写成 UTF-16 或带 BOM**。`> desktop.json` 和 `Out-File` 可能生成无法解析的编码，表现为配置错误。
 
 用 PowerShell 一步创建可以同时避开这两个坑：

--- a/apps/docs/content/docs/desktop-app.zh.mdx
+++ b/apps/docs/content/docs/desktop-app.zh.mdx
@@ -70,7 +70,13 @@ Desktop 会为每个工作区单独保存标签页。例如，你在工作区 A 
 
 ## 连接自托管实例
 
-Desktop 默认连接 Multica Cloud。连接自托管实例时，在用户目录创建 `~/.multica/desktop.json`：
+Desktop 默认连接 Multica Cloud。连接自托管实例时，在用户目录的 `.multica` 下创建 `desktop.json`：
+
+| 平台 | 路径 |
+| --- | --- |
+| macOS | `/Users/<你>/.multica/desktop.json` |
+| Linux | `/home/<你>/.multica/desktop.json` |
+| Windows | `C:\Users\<你>\.multica\desktop.json` |
 
 ```json
 {
@@ -78,6 +84,10 @@ Desktop 默认连接 Multica Cloud。连接自托管实例时，在用户目录�
   "apiUrl": "https://api.example.com"
 }
 ```
+
+<Callout type="warning">
+这个文件**不是** CLI 的 `~/.multica/config.json`，字段名也不同：CLI 用 `server_url`，Desktop 用 `apiUrl`。Desktop 不会读取 CLI 的配置，它在 `~/.multica/profiles/desktop-<host>/` 下管理独立的 daemon profile。改 `config.json` 不会影响 Desktop 连接哪个服务。
+</Callout>
 
 `apiUrl` 是 backend 的公开地址，必须填写，且必须使用 `http` 或 `https`。另外两个地址可以省略，Desktop 会自动推导：
 
@@ -99,11 +109,37 @@ Desktop 默认连接 Multica Cloud。连接自托管实例时，在用户目录�
 }
 ```
 
-保存后重启 Desktop。配置文件存在但 JSON、版本或 URL 无效时，应用会显示配置错误，不会自动连接 Cloud。删除该文件并重启即可恢复默认的 Cloud 配置。
+保存后重启 Desktop，配置只在启动时读取一次。两种失败的表现不同，据此可以快速区分：
+
+- **文件没找到**（目录不对，或文件名不是 `desktop.json`）：Desktop 使用默认的 Cloud 配置，不报错。所以如果 Desktop 仍然显示 Cloud 地址且没有任何配置错误，说明文件不在 Desktop 查找的位置。
+- **文件找到但无效**（JSON、版本或 URL 有问题）：Desktop 显示配置错误，不会自动回退到 Cloud。
+
+删除该文件并重启即可恢复默认的 Cloud 配置。
 
 <Callout type="warning">
 Desktop 只能连接浏览器和执行电脑都能访问的地址。远程自托管实例未使用 HTTPS 或未代理 WebSocket 时，Desktop 无法建立连接；完整配置见[自托管快速上手](/self-host-quickstart#3-选择访问方式)。
 </Callout>
+
+### Windows：检查文件名和编码
+
+Windows 上两个编辑器默认行为会悄悄生成 Desktop 用不了的文件：
+
+- **记事本会补 `.txt` 后缀**。存成 `desktop.json` 可能实际得到 `desktop.json.txt`，Desktop 会当作没找到。在资源管理器里打开文件扩展名显示，或在保存对话框里选*所有文件*。用 `dir %USERPROFILE%\.multica` 确认，列出的应该正好是 `desktop.json`。
+- **PowerShell 重定向会写成 UTF-16 或带 BOM**。`> desktop.json` 和 `Out-File` 可能生成无法解析的编码，表现为配置错误。
+
+用 PowerShell 一步创建可以同时避开这两个坑：
+
+```powershell
+$dir = "$env:USERPROFILE\.multica"
+New-Item -ItemType Directory -Force $dir | Out-Null
+$json = @'
+{
+  "schemaVersion": 1,
+  "apiUrl": "https://api.example.com"
+}
+'@
+[System.IO.File]::WriteAllText("$dir\desktop.json", $json)
+```
 
 ## Windows Defender 把 Multica 报成病毒
 


### PR DESCRIPTION
## Summary

Docs fix for the confusion reported in #6399: a user self-hosting on Windows edited the CLI's `~/.multica/config.json`, set `server_url`, and found Desktop still connecting to Cloud.

That's working as designed — Desktop only reads `~/.multica/desktop.json` and the key is `apiUrl`, not `server_url` (`apps/desktop/src/main/runtime-config-loader.ts:44`, `apps/desktop/src/shared/runtime-config.ts:72`). But nothing in the docs said so, and the failure is silent: a missing `desktop.json` falls back to Cloud with no error (`runtime-config-loader.ts:31-33`), so the user gets no signal that they edited the wrong file.

Four gaps in `## Connecting to a self-hosted instance`, all fixed here:

1. **No Windows path.** The doc only said `~/.multica/desktop.json`. Windows appeared in that page for installers, update feeds, and Defender false positives — never for this. Now a per-platform table, including `C:\Users\<you>\.multica\desktop.json`.
2. **No distinction from the CLI config.** Added a callout: different file, different key names (`server_url` vs `apiUrl`), and Desktop keeps its own daemon profile under `~/.multica/profiles/desktop-<host>/`, so editing `config.json` does nothing.
3. **Missing-file behaviour undocumented.** The doc described only the *invalid* file case ("shows a configuration error"). The *missing* case — silent Cloud fallback — was absent, and that's the one users actually hit. Both are now documented as a diagnostic pair: no error at all means the file isn't where Desktop looks.
4. **Windows filename/encoding traps.** Notepad saving `desktop.json.txt` (reads as missing → silent fallback) and PowerShell redirection writing UTF-16/BOM (reads as invalid → config error). Added a PowerShell snippet using `[System.IO.File]::WriteAllText`, which writes UTF-8 without BOM on both Windows PowerShell 5.1 and PowerShell 7.

Docs-only — no behaviour change. All four locales (en/zh/ja/ko) updated symmetrically and stay line-aligned.

## Verification

- `pnpm typecheck` in `apps/docs` — passes.
- `pnpm test` in `apps/docs` — 17/17 pass.
- `pnpm build` — MDX compiles successfully (`✓ Compiled successfully`). The build then fails prerendering `/404` with `<Html> should not be imported outside of pages/_document`. **This is pre-existing on `main`** — I confirmed it reproduces identically with my changes stashed, so it is not introduced by this PR.
- Verified every claim in the new copy against the source rather than the old docs: the config path, the required `apiUrl`, the `wsUrl`/`appUrl` derivation, the ENOENT-vs-invalid split, and the `desktop-<host>` profile naming.

## Not in scope

The silent Cloud fallback on a missing `desktop.json` is a real UX problem — the user gets no feedback that the file wasn't found. This PR only documents it; making Desktop surface it is a separate change.
