### PR TITLE
fix(chat): preserve follow-up transcript order (MUL-5751)

### DIFF
--- a/server/internal/handler/chat_input_ownership_test.go
+++ b/server/internal/handler/chat_input_ownership_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"net/url"
 	"strings"
 	"testing"
 
@@ -68,6 +69,18 @@ func completeResult(t *testing.T, output string) []byte {
 	return b
 }
 
+func assertChatTranscriptContents(t *testing.T, messages []db.ChatMessage, want []string) {
+	t.Helper()
+	if len(messages) != len(want) {
+		t.Fatalf("transcript length = %d, want %d: %+v", len(messages), len(want), messages)
+	}
+	for i, content := range want {
+		if messages[i].Content != content {
+			t.Fatalf("transcript[%d] = %q, want %q; transcript=%+v", i, messages[i].Content, content, messages)
+		}
+	}
+}
+
 // TestDirectChat_TaskOwnsItsOwnInputBatch is the core input-boundary contract
 // (MUL-4351): each direct send owns exactly the user message it created. When
 // U1→T1 and U2→T2 are both queued, T1's claim must deliver ONLY U1 (never
@@ -103,6 +116,185 @@ func TestDirectChat_TaskOwnsItsOwnInputBatch(t *testing.T) {
 	claimed2 := claimTaskForRuntimeGuard(t, runtimeID, daemonID)
 	if claimed2.ChatMessage != "还有青岛" {
 		t.Fatalf("second claim must deliver ONLY the second owned message; got %q", claimed2.ChatMessage)
+	}
+}
+
+// TestDirectChat_ClaimKeepsQueuedTurnsPairedWithReplies covers the follow-up
+// transcript regression from MUL-5751. The queued user rows are persisted
+// before the first assistant reply, but each row must enter the transcript
+// only when its own task is claimed, after the preceding reply. The same
+// server-authoritative order must drive both the legacy full list and every
+// cursor page.
+func TestDirectChat_ClaimKeepsQueuedTurnsPairedWithReplies(t *testing.T) {
+	if testHandler == nil {
+		t.Skip("database not available")
+	}
+	ctx := context.Background()
+	agentID, sessionID, runtimeID, daemonID := setupDirectChatSession(t, ctx, "queued transcript order")
+
+	t1 := sendDirectChat(t, ctx, agentID, sessionID, "user A")
+	t2 := sendDirectChat(t, ctx, agentID, sessionID, "user B")
+	t3 := sendDirectChat(t, ctx, agentID, sessionID, "user C")
+
+	claimTaskForRuntimeGuard(t, runtimeID, daemonID)
+	markTaskRunning(t, ctx, t1)
+	if _, err := testHandler.TaskService.CompleteTask(ctx, parseUUID(t1), completeResult(t, "assistant A"), "", "", false, ""); err != nil {
+		t.Fatalf("complete turn A: %v", err)
+	}
+
+	queuedBeforeClaim, err := testHandler.Queries.GetAgentTask(ctx, parseUUID(t2))
+	if err != nil {
+		t.Fatalf("load queued turn B: %v", err)
+	}
+	claimTaskForRuntimeGuard(t, runtimeID, daemonID)
+	claimedAfter, err := testHandler.Queries.GetAgentTask(ctx, parseUUID(t2))
+	if err != nil {
+		t.Fatalf("load claimed turn B: %v", err)
+	}
+	if !claimedAfter.CreatedAt.Time.Equal(queuedBeforeClaim.CreatedAt.Time) {
+		t.Fatalf("claim changed task queue created_at from %s to %s", queuedBeforeClaim.CreatedAt.Time, claimedAfter.CreatedAt.Time)
+	}
+
+	transcript, err := testHandler.Queries.ListChatMessages(ctx, parseUUID(sessionID))
+	if err != nil {
+		t.Fatalf("list transcript after claiming B: %v", err)
+	}
+	assertChatTranscriptContents(t, transcript, []string{"user A", "assistant A", "user B"})
+
+	// Lost claim responses are re-delivered from dispatched without creating a
+	// new transcript turn. Refreshing dispatched_at must not move user B again.
+	inputBeforeReclaim, err := testHandler.Queries.ListChatInputMessages(ctx, parseUUID(t2))
+	if err != nil || len(inputBeforeReclaim) != 1 {
+		t.Fatalf("load B input before reclaim: messages=%+v err=%v", inputBeforeReclaim, err)
+	}
+	if _, err := testPool.Exec(ctx, `
+		UPDATE agent_task_queue
+		SET dispatched_at = now() - interval '1 hour',
+		    prepare_lease_expires_at = now() - interval '1 minute'
+		WHERE id = $1
+	`, t2); err != nil {
+		t.Fatalf("age B dispatch for reclaim: %v", err)
+	}
+	reclaimed, err := testHandler.Queries.ReclaimStaleDispatchedTaskForRuntime(ctx, db.ReclaimStaleDispatchedTaskForRuntimeParams{
+		RuntimeID:         parseUUID(runtimeID),
+		ClaimRecoverySecs: 0,
+		PrepareLeaseSecs:  60,
+	})
+	if err != nil {
+		t.Fatalf("reclaim B dispatch: %v", err)
+	}
+	if uuidToString(reclaimed.ID) != t2 {
+		t.Fatalf("reclaimed task = %s, want %s", uuidToString(reclaimed.ID), t2)
+	}
+	inputAfterReclaim, err := testHandler.Queries.ListChatInputMessages(ctx, parseUUID(t2))
+	if err != nil || len(inputAfterReclaim) != 1 {
+		t.Fatalf("load B input after reclaim: messages=%+v err=%v", inputAfterReclaim, err)
+	}
+	if !inputAfterReclaim[0].CreatedAt.Time.Equal(inputBeforeReclaim[0].CreatedAt.Time) {
+		t.Fatalf("stale reclaim moved B from %s to %s", inputBeforeReclaim[0].CreatedAt.Time, inputAfterReclaim[0].CreatedAt.Time)
+	}
+
+	markTaskRunning(t, ctx, t2)
+	if _, err := testHandler.TaskService.CompleteTask(ctx, parseUUID(t2), completeResult(t, "assistant B"), "", "", false, ""); err != nil {
+		t.Fatalf("complete turn B: %v", err)
+	}
+	claimTaskForRuntimeGuard(t, runtimeID, daemonID)
+	transcript, err = testHandler.Queries.ListChatMessages(ctx, parseUUID(sessionID))
+	if err != nil {
+		t.Fatalf("list transcript after claiming C: %v", err)
+	}
+	assertChatTranscriptContents(t, transcript, []string{"user A", "assistant A", "user B", "assistant B", "user C"})
+
+	markTaskRunning(t, ctx, t3)
+	if _, err := testHandler.TaskService.CompleteTask(ctx, parseUUID(t3), completeResult(t, "assistant C"), "", "", false, ""); err != nil {
+		t.Fatalf("complete turn C: %v", err)
+	}
+	transcript, err = testHandler.Queries.ListChatMessages(ctx, parseUUID(sessionID))
+	if err != nil {
+		t.Fatalf("list completed transcript: %v", err)
+	}
+	want := []string{"user A", "assistant A", "user B", "assistant B", "user C", "assistant C"}
+	assertChatTranscriptContents(t, transcript, want)
+
+	// Rebuild the same transcript from two-message cursor pages, detecting both
+	// missing rows and duplicate ids while crossing every turn boundary.
+	var before *ChatMessagesCursorResponse
+	var paged []string
+	seen := map[string]bool{}
+	for {
+		params := url.Values{"limit": {"2"}}
+		if before != nil {
+			params.Set("before_created_at", before.CreatedAt)
+			params.Set("before_id", before.ID)
+		}
+		page := fetchChatMessagesPageForTest(t, sessionID, params)
+		contents := make([]string, 0, len(page.Messages))
+		for _, message := range page.Messages {
+			if seen[message.ID] {
+				t.Fatalf("cursor pagination returned duplicate message %s", message.ID)
+			}
+			seen[message.ID] = true
+			contents = append(contents, message.Content)
+		}
+		paged = append(contents, paged...)
+		if !page.HasMore {
+			break
+		}
+		if page.NextCursor == nil {
+			t.Fatal("page has_more without next_cursor")
+		}
+		before = page.NextCursor
+	}
+	if len(paged) != len(want) {
+		t.Fatalf("paged transcript length = %d, want %d: %v", len(paged), len(want), paged)
+	}
+	for i, content := range want {
+		if paged[i] != content {
+			t.Fatalf("paged transcript[%d] = %q, want %q; transcript=%v", i, paged[i], content, paged)
+		}
+	}
+}
+
+// Retry tasks inherit the original chat_input_task_id and must never make the
+// already-visible root user turn look new again when the child is claimed.
+func TestDirectChat_RetryClaimDoesNotMoveOriginalInput(t *testing.T) {
+	if testHandler == nil {
+		t.Skip("database not available")
+	}
+	ctx := context.Background()
+	agentID, sessionID, _, _ := setupDirectChatSession(t, ctx, "retry transcript order")
+	rootID := sendDirectChat(t, ctx, agentID, sessionID, "retry me")
+	inputBefore, err := testHandler.Queries.ListChatInputMessages(ctx, parseUUID(rootID))
+	if err != nil || len(inputBefore) != 1 {
+		t.Fatalf("load root input: messages=%+v err=%v", inputBefore, err)
+	}
+	if _, err := testPool.Exec(ctx, `
+		UPDATE agent_task_queue
+		SET status = 'failed', failure_reason = 'agent_error', completed_at = now()
+		WHERE id = $1
+	`, rootID); err != nil {
+		t.Fatalf("fail root task: %v", err)
+	}
+	retry, err := testHandler.Queries.CreateRetryTask(ctx, db.CreateRetryTaskParams{ID: parseUUID(rootID)})
+	if err != nil {
+		t.Fatalf("create retry task: %v", err)
+	}
+	if !retry.ChatInputTaskID.Valid || uuidToString(retry.ChatInputTaskID) != rootID {
+		t.Fatalf("retry input owner = %s, want root %s", uuidToString(retry.ChatInputTaskID), rootID)
+	}
+	claimed, err := testHandler.TaskService.ClaimTask(ctx, parseUUID(agentID))
+	if err != nil || claimed == nil {
+		t.Fatalf("claim retry task: task=%+v err=%v", claimed, err)
+	}
+	if uuidToString(claimed.ID) != uuidToString(retry.ID) {
+		t.Fatalf("claimed task = %s, want retry %s", uuidToString(claimed.ID), uuidToString(retry.ID))
+	}
+	inputAfter, err := testHandler.Queries.ListChatInputMessages(ctx, parseUUID(rootID))
+	if err != nil || len(inputAfter) != 1 {
+		t.Fatalf("reload root input: messages=%+v err=%v", inputAfter, err)
+	}
+	if !inputAfter[0].CreatedAt.Time.Equal(inputBefore[0].CreatedAt.Time) {
+		t.Fatalf("retry claim moved root input from %s to %s", inputBefore[0].CreatedAt.Time, inputAfter[0].CreatedAt.Time)
 	}
 }
 

--- a/server/internal/service/task.go
+++ b/server/internal/service/task.go
@@ -2541,6 +2541,23 @@ func (s *TaskService) ClaimTask(ctx context.Context, agentID pgtype.UUID) (*db.A
 			return fmt.Errorf("claim task: %w", err)
 		}
 
+		// A task-owned direct-chat user row is written when the user enqueues
+		// it, but stays hidden until this queued -> dispatched transition. Move
+		// its transcript timestamp inside the same transaction as the claim so
+		// every full-list and cursor reader observes either hidden+queued or
+		// visible+reanchored, never an intermediate state. Retry children keep
+		// the root input owner and stale-dispatch reclaim uses a separate query,
+		// so neither path can move an already-visible user turn again.
+		if task.ChatSessionID.Valid && task.ChatInputTaskID == task.ID {
+			if err := qtx.ReanchorClaimedDirectChatInput(ctx, db.ReanchorClaimedDirectChatInputParams{
+				DispatchedAt: task.DispatchedAt,
+				TaskID:       task.ID,
+			}); err != nil {
+				outcome = "error_reanchor_chat_input"
+				return fmt.Errorf("reanchor claimed direct chat input: %w", err)
+			}
+		}
+
 		claimedTask := task
 		claimed = &claimedTask
 		return nil

--- a/server/pkg/db/generated/chat.sql.go
+++ b/server/pkg/db/generated/chat.sql.go
@@ -2060,6 +2060,60 @@ func (q *Queries) PromoteChannelChatTasksIfMediaReady(ctx context.Context, chatS
 	return items, nil
 }
 
+const reanchorClaimedDirectChatInput = `-- name: ReanchorClaimedDirectChatInput :exec
+UPDATE chat_message AS claimed_input
+SET created_at = GREATEST(
+    $1::timestamptz,
+    COALESCE((
+        SELECT prior.created_at + interval '1 microsecond'
+        FROM chat_message AS prior
+        WHERE prior.chat_session_id = claimed_input.chat_session_id
+          AND prior.id != claimed_input.id
+          AND NOT (
+            prior.role = 'user'
+            AND EXISTS (
+              SELECT 1
+              FROM agent_task_queue AS queued_task
+              WHERE queued_task.chat_session_id = prior.chat_session_id
+                AND queued_task.status = 'queued'
+                AND queued_task.id = prior.task_id
+            )
+          )
+        ORDER BY prior.created_at DESC, prior.id DESC
+        LIMIT 1
+    ), $1::timestamptz)
+)
+WHERE claimed_input.task_id = $2
+  AND claimed_input.role = 'user'
+  AND NOT claimed_input.channel_ingested
+`
+
+type ReanchorClaimedDirectChatInputParams struct {
+	DispatchedAt pgtype.Timestamptz `json:"dispatched_at"`
+	TaskID       pgtype.UUID        `json:"task_id"`
+}
+
+// A direct follow-up is persisted at enqueue time but hidden from the settled
+// transcript while its task remains queued. When that task is claimed, move
+// the user row to the claim boundary so it becomes visible after the previous
+// assistant outcome instead of jumping back to its original enqueue time.
+//
+// The task's own created_at remains immutable and continues to drive queue
+// FIFO, wait duration, and elapsed time. Only the message timestamp changes,
+// preserving the existing public ordering/cursor contract for older clients.
+// Add one microsecond when the DB clock ties the latest visible row so UUID
+// ordering can never put the new user turn before the previous assistant row.
+//
+// channel_ingested excludes sealed Slack/Lark batches, which can own multiple
+// user rows and must preserve their original provider order. Retry children
+// are excluded by the caller because their chat_input_task_id names the root
+// task rather than themselves. Stale dispatched reclaim bypasses this query,
+// so re-delivery does not move an already-visible turn.
+func (q *Queries) ReanchorClaimedDirectChatInput(ctx context.Context, arg ReanchorClaimedDirectChatInputParams) error {
+	_, err := q.db.Exec(ctx, reanchorClaimedDirectChatInput, arg.DispatchedAt, arg.TaskID)
+	return err
+}
+
 const setChatMessageQuickActionsByTask = `-- name: SetChatMessageQuickActionsByTask :one
 UPDATE chat_message
 SET quick_actions = $2

--- a/server/pkg/db/queries/chat.sql
+++ b/server/pkg/db/queries/chat.sql
@@ -484,6 +484,49 @@ SELECT * FROM chat_message
 WHERE task_id = $1 AND role = 'user'
 ORDER BY created_at ASC, id ASC;
 
+-- name: ReanchorClaimedDirectChatInput :exec
+-- A direct follow-up is persisted at enqueue time but hidden from the settled
+-- transcript while its task remains queued. When that task is claimed, move
+-- the user row to the claim boundary so it becomes visible after the previous
+-- assistant outcome instead of jumping back to its original enqueue time.
+--
+-- The task's own created_at remains immutable and continues to drive queue
+-- FIFO, wait duration, and elapsed time. Only the message timestamp changes,
+-- preserving the existing public ordering/cursor contract for older clients.
+-- Add one microsecond when the DB clock ties the latest visible row so UUID
+-- ordering can never put the new user turn before the previous assistant row.
+--
+-- channel_ingested excludes sealed Slack/Lark batches, which can own multiple
+-- user rows and must preserve their original provider order. Retry children
+-- are excluded by the caller because their chat_input_task_id names the root
+-- task rather than themselves. Stale dispatched reclaim bypasses this query,
+-- so re-delivery does not move an already-visible turn.
+UPDATE chat_message AS claimed_input
+SET created_at = GREATEST(
+    @dispatched_at::timestamptz,
+    COALESCE((
+        SELECT prior.created_at + interval '1 microsecond'
+        FROM chat_message AS prior
+        WHERE prior.chat_session_id = claimed_input.chat_session_id
+          AND prior.id != claimed_input.id
+          AND NOT (
+            prior.role = 'user'
+            AND EXISTS (
+              SELECT 1
+              FROM agent_task_queue AS queued_task
+              WHERE queued_task.chat_session_id = prior.chat_session_id
+                AND queued_task.status = 'queued'
+                AND queued_task.id = prior.task_id
+            )
+          )
+        ORDER BY prior.created_at DESC, prior.id DESC
+        LIMIT 1
+    ), @dispatched_at::timestamptz)
+)
+WHERE claimed_input.task_id = @task_id
+  AND claimed_input.role = 'user'
+  AND NOT claimed_input.channel_ingested;
+
 -- name: ListChatMessagesPage :many
 SELECT message.* FROM chat_message AS message
 WHERE message.chat_session_id = $1


### PR DESCRIPTION
## What does this PR do?

修复 follow-up queue 解隐藏后的 transcript 错序。

direct-chat user message 仍在 enqueue 时持久化并在 `queued` 阶段隐藏；当 task 原子地从 `queued` claim 为 `dispatched` 时，将该 user row 的 transcript `created_at` 重锚到上一条可见消息之后。`agent_task_queue.created_at` 完全不变，继续作为 FIFO、等待时长和 elapsed time 的来源。

选择沿用现有 `created_at` 排序键，是为了让 legacy full-list、现有 `(created_at, id)` cursor 和旧 Desktop 客户端无需协议或 schema 升级就获得一致顺序。仅在原始 direct-chat task 首次 claim 时执行；channel batch、retry child 和 stale-dispatch reclaim 都不会移动已有 turn。

回滚不需要 migration：代码回滚后，已重锚的消息仍保持有效顺序。

## Related Issue

Closes MUL-5751

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Refactor / code improvement (no behavior change)
- [ ] Documentation update
- [x] Tests (adding or improving test coverage)
- [ ] CI / infrastructure

## Changes Made

- 在 `ClaimTask` 的现有事务中原子重锚 newly-visible direct-chat input。
- 保留 task queue 时间语义，并排除 channel、retry 与 stale reclaim 路径。
- 新增 DB-backed 回归：连续 enqueue A/B/C，验证 full-list 与两条一页的 cursor pagination 均严格一问一答，无重复或漏行。
- 覆盖 task `created_at` 不变、stale reclaim 幂等、retry child 不移动 root input。

## How to Test

1. `DATABASE_URL='postgres://multica:multica@localhost:5432/multica_multica_755?sslmode=disable' go test -p 1 ./internal/service ./internal/handler ./pkg/db/generated -count=1`
2. `DATABASE_URL='postgres://multica:multica@localhost:5432/multica_multica_755?sslmode=disable' go test -race ./internal/handler -run 'TestDirectChat_(ClaimKeepsQueuedTurnsPairedWithReplies|RetryClaimDoesNotMoveOriginalInput)$' -count=1`
3. `go vet ./internal/service ./internal/handler ./pkg/db/generated`
4. `pnpm --filter @multica/core exec vitest run realtime/use-realtime-sync-ws-instance.test.tsx -t 'invalidates per-chat-session caches|refetches the transcript when a queued prompt starts running'`

以上均通过。额外运行全量 `@multica/core` 测试时，当前本机 Node 25 环境有 8 个既有 `localStorage` 环境失败；本 PR 相关的 dispatch/reconnect 3 个测试单独通过，CI 使用仓库指定的 Node 22。

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] If this change affects the UI, I have included before/after screenshots（不适用：服务端排序修复）
- [x] I have updated relevant documentation to reflect my changes（不适用：无用户文档变化）
- [x] If I added a new runtime / coding tool / UI tab, I synced the change to **landing copy** (`apps/web/features/landing/i18n/`) and **relevant docs** (`apps/docs/content/docs/`)（不适用）
- [x] If this PR touches Chinese product copy, I checked it against `apps/docs/content/docs/developers/conventions.zh.mdx`（不适用：无产品文案）
- [x] I have considered and documented any risks above
- [x] I will address all reviewer comments before requesting merge

## AI Disclosure

**AI tool used:** Multica Agent (Codex)

**Prompt / approach:** 从 MUL-5751 的合并后复现与根因出发，先补充在 main 上失败的 DB-backed 测试，再在现有 claim 事务内实现最小修复，并验证 full-list、cursor、reclaim、retry 以及客户端 dispatch/reconnect cache invalidation。

## Screenshots (optional)

不适用；行为由 DB-backed transcript/cursor 回归测试覆盖。
