### PR TITLE
MUL-5756: 更新 Reasonix runtime 的 logo

### DIFF
--- a/packages/views/runtimes/components/provider-logo.test.tsx
+++ b/packages/views/runtimes/components/provider-logo.test.tsx
@@ -3,13 +3,19 @@ import { describe, expect, it } from "vitest";
 import { ProviderLogo } from "./provider-logo";
 
 describe("ProviderLogo", () => {
-  it("renders the dedicated Reasonix mark", () => {
+  it("renders the official Reasonix logo", () => {
     const { container } = render(
       <ProviderLogo provider="reasonix" className="runtime-logo" />,
     );
 
-    const logo = container.querySelector('svg[aria-label="Reasonix"]');
-    expect(logo?.querySelector('path[fill="#0153E5"]')).not.toBeNull();
+    const logo = container.querySelector('img[alt="Reasonix"]');
+    const logoSrc = logo?.getAttribute("src") ?? "";
+    const logoSvg = atob(logoSrc.split(",")[1] ?? "");
+
+    expect(logoSrc).toMatch(/^data:image\/svg\+xml;base64,/);
+    expect(logoSvg).toContain('viewBox="0 0 64 64"');
+    expect(logoSvg).toContain('stop-color="#4f9dff"');
+    expect(logoSvg).toContain('stop-color="#c46bff"');
     expect(logo?.classList.contains("runtime-logo")).toBe(true);
   });
 

--- a/packages/views/runtimes/components/provider-logo.test.tsx
+++ b/packages/views/runtimes/components/provider-logo.test.tsx
@@ -1,21 +1,25 @@
+import { readFileSync } from "node:fs";
 import { render } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
 import { ProviderLogo } from "./provider-logo";
 
 describe("ProviderLogo", () => {
+  it("keeps the official Reasonix artwork", () => {
+    const logoSvg = readFileSync("runtimes/components/reasonix-logo.svg", "utf8");
+
+    expect(logoSvg).toContain('viewBox="0 0 64 64"');
+    expect(logoSvg).toContain('stop-color="#4f9dff"');
+    expect(logoSvg).toContain('stop-color="#c46bff"');
+  });
+
   it("renders the official Reasonix logo", () => {
     const { container } = render(
       <ProviderLogo provider="reasonix" className="runtime-logo" />,
     );
 
     const logo = container.querySelector('img[alt="Reasonix"]');
-    const logoSrc = logo?.getAttribute("src") ?? "";
-    const logoSvg = atob(logoSrc.split(",")[1] ?? "");
 
-    expect(logoSrc).toMatch(/^data:image\/svg\+xml;base64,/);
-    expect(logoSvg).toContain('viewBox="0 0 64 64"');
-    expect(logoSvg).toContain('stop-color="#4f9dff"');
-    expect(logoSvg).toContain('stop-color="#c46bff"');
+    expect(logo?.getAttribute("src")).toBeTruthy();
     expect(logo?.classList.contains("runtime-logo")).toBe(true);
   });
 

--- a/packages/views/runtimes/components/provider-logo.tsx
+++ b/packages/views/runtimes/components/provider-logo.tsx
@@ -3,6 +3,12 @@ import { Monitor } from "lucide-react";
 import qwenLogo from "./qwen-logo.svg";
 import reasonixLogo from "./reasonix-logo.svg";
 
+// Next.js exposes static imports as objects while Vite exposes URL strings.
+// Normalize both shapes here so shared provider logos work in web and desktop.
+function staticAssetSrc(asset: string | { src: string }): string {
+  return typeof asset === "string" ? asset : asset.src;
+}
+
 // Claude (Anthropic) — official mark, sourced from Bootstrap Icons (bi-claude)
 function ClaudeLogo({ className }: { className: string }) {
   return (
@@ -185,10 +191,7 @@ function KimiLogo({ className }: { className: string }) {
 }
 
 // Reasonix — official logo served at https://reasonix.io/logo.svg.
-const reasonixLogoSrc: string = (() => {
-  const asset = reasonixLogo as unknown;
-  return typeof asset === "string" ? asset : (asset as { src: string }).src;
-})();
+const reasonixLogoSrc = staticAssetSrc(reasonixLogo);
 
 function ReasonixLogo({ className }: { className: string }) {
   return <img src={reasonixLogoSrc} alt="Reasonix" className={className} />;
@@ -215,16 +218,9 @@ function QoderLogo({ className }: { className: string }) {
   );
 }
 
-// Antigravity (Google) — official mark, shipped as a PNG asset next to
-// this file. Different bundlers type the PNG import differently — Next.js
-// gives a StaticImageData object (.src), electron-vite + plain vite give
-// a string. Normalise via unknown so neither side's narrower type wins
-// and breaks the other's typecheck.
+// Antigravity (Google) — official mark, shipped as a PNG asset next to this file.
 import antigravityLogo from "./antigravity-logo.png";
-const antigravityLogoSrc: string = (() => {
-  const asset = antigravityLogo as unknown;
-  return typeof asset === "string" ? asset : (asset as { src: string }).src;
-})();
+const antigravityLogoSrc = staticAssetSrc(antigravityLogo);
 
 function AntigravityLogo({ className }: { className: string }) {
   return <img src={antigravityLogoSrc} alt="Antigravity" className={className} />;
@@ -297,10 +293,7 @@ function GrokLogo({ className }: { className: string }) {
 
 // Qwen Code — official SVG copied verbatim from QwenLM/qwen-code's desktop
 // brand assets (packages/desktop/apps/electron/resources/brands/qwen-code/icon.svg).
-const qwenLogoSrc: string = (() => {
-  const asset = qwenLogo as unknown;
-  return typeof asset === "string" ? asset : (asset as { src: string }).src;
-})();
+const qwenLogoSrc = staticAssetSrc(qwenLogo);
 
 function QwenLogo({ className }: { className: string }) {
   return <img src={qwenLogoSrc} alt="" aria-hidden className={className} />;

--- a/packages/views/runtimes/components/provider-logo.tsx
+++ b/packages/views/runtimes/components/provider-logo.tsx
@@ -1,6 +1,7 @@
 import { useId } from "react";
 import { Monitor } from "lucide-react";
 import qwenLogo from "./qwen-logo.svg";
+import reasonixLogo from "./reasonix-logo.svg";
 
 // Claude (Anthropic) — official mark, sourced from Bootstrap Icons (bi-claude)
 function ClaudeLogo({ className }: { className: string }) {
@@ -183,25 +184,14 @@ function KimiLogo({ className }: { className: string }) {
   );
 }
 
-// Reasonix — official symbol from DeepSeek-Reasonix's logo-symbol.svg.
+// Reasonix — official logo served at https://reasonix.io/logo.svg.
+const reasonixLogoSrc: string = (() => {
+  const asset = reasonixLogo as unknown;
+  return typeof asset === "string" ? asset : (asset as { src: string }).src;
+})();
+
 function ReasonixLogo({ className }: { className: string }) {
-  return (
-    <svg viewBox="245 70 235 245" className={className} role="img" aria-label="Reasonix">
-      <path
-        fill="#0153E5"
-        d="M369.75 185.3c2.09 1.76 4.98 2.41 7.95 1.06 1.18-.54 1.96-1.91 1.47-3.25-3.92-10.71-14.97-18.54-19.38-12.48-.54.74-.52 1.7-.11 2.29.32.47.97.57 1.82.4 2.68-.56 6.02 1.31 5.7 4.3-.33 3.12.3 5.79 2.56 7.69Z"
-      />
-      <path
-        fill="#0153E5"
-        d="M434.28 204.78c10.12-11.32 16.46-25.01 18.67-40.07 5.04-32.93-11.31-63.01-42.11-75.75-10.83-4.35-21.95-6.2-33.76-6.09l-114.5.03v219.42l56.29-.04v-77.17c-1.86-.69-3.15-1.27-3.15-1.27-12.24-5.59-21.6-15.29-26.74-27.44-6.56-15.51-4.54-32.9 5.78-46.12 10.28-12.84 24.31-16.92 40.41-14.67 5.95.83 12.3-6.15 24.4-4.81.81.09 1.63.7 1.71 1.18.28 1.65-4.4 2.54-4.4 7.05 0 1.9.85 4.1 2.65 5.36 6.17 4.33 11.51 9.19 17.1 14.22 2.72 2.44 11.93 9.31 14.27 3.72 1.37-3.26 2.27-6.68 3.18-10.15.45-1.72-.5-2.74-1.89-3.56-9.5-5.63-13.08-17.35-9.37-27.74.36-1 1.29-1.49 2.08-1.52 3.19-.14 1.49 5.78 9.38 8.21 7.49 2.31 7.71 8.53 11.35 6.05 8.48-5.78 11.54-1.05 19.41-8.46.81-.76 2.2-.82 3.04-.23.52.36.97 1.29.93 2.38-.23 6.26-2.67 12.24-6.95 16.84-8.09 8.69-14.89 4.53-15.33 10.62-1.29 17.86-7.13 35.69-19.81 48.66-.41.42-.65 1.01-.58 1.41.07.42.57.83 1.12 1.01l10.68 3.63c1.51.51 2.6 1.87 2.41 3.31-.17 1.26-1.17 2.37-2.61 2.85-7.84 2.59-16.26 2.14-24.24-.27-10.56 8.89-23.54 13.48-37.68 12.93l20.53 28.34 33.49 45.73 66.85-.09-56.68-76.53c13.19-3.89 24.78-10.87 34.07-20.94Z"
-      />
-      <circle fill="#0153E5" cx="362.14" cy="177.19" r="1.58" />
-      <path
-        fill="#0153E5"
-        d="M300.31 167.85c-3.53.43-5.65 2.96-5.31 6.74 2.39 26.35 26.7 47.92 53.94 42.72 5.8-1.11 11.08-3.41 15.36-7.74-9.27-7.98-13.79-16.12-21.41-24.13-10.91-11.47-26.43-19.54-42.58-17.59Z"
-      />
-    </svg>
-  );
+  return <img src={reasonixLogoSrc} alt="Reasonix" className={className} />;
 }
 
 // Qoder (QoderCLI) — official logo from qoder-color.svg

--- a/packages/views/runtimes/components/reasonix-logo.svg
+++ b/packages/views/runtimes/components/reasonix-logo.svg
@@ -1,0 +1,11 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <defs>
+    <linearGradient id="g" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#4f9dff"/>
+      <stop offset=".55" stop-color="#7a6bff"/>
+      <stop offset="1" stop-color="#c46bff"/>
+    </linearGradient>
+  </defs>
+  <rect width="64" height="64" rx="15" fill="url(#g)"/>
+  <text x="32" y="46" font-family="Inter,Segoe UI,Arial,sans-serif" font-size="42" font-weight="800" fill="#fff" text-anchor="middle">R</text>
+</svg>


### PR DESCRIPTION
## 变更

- 将 Reasonix runtime logo 替换为 `https://reasonix.io/logo.svg` 提供的官方资源
- 将 SVG 作为本地静态资源打包，避免运行时依赖外部请求
- 更新 ProviderLogo 回归测试，校验官方渐变 logo 与样式透传

## 验证

- `pnpm --filter @multica/views exec vitest run runtimes/components/provider-logo.test.tsx`
- `pnpm --filter @multica/views typecheck`
- `pnpm --filter @multica/views exec eslint runtimes/components/provider-logo.tsx runtimes/components/provider-logo.test.tsx`
- `pnpm --filter @multica/web typecheck`
- `pnpm --filter @multica/desktop typecheck`
- `pnpm --filter @multica/web build`
- `pnpm --filter @multica/desktop build`
- `git diff --check`

补充：全量 `@multica/views` 测试中仅 `layout/sidebar-resize.test.tsx` 的 1 个用例失败；在干净的 `origin/main` worktree 上单独运行同样失败，确认不是本 PR 引入。

Closes MUL-5756
