### PR TITLE
fix(editor): MUL-5752 follow-ups — header sequence navigation, snap re-fit

### DIFF
--- a/packages/views/editor/attachment-preview-modal.tsx
+++ b/packages/views/editor/attachment-preview-modal.tsx
@@ -565,6 +565,33 @@ function PreviewPanel({
           </span>
         </div>
         <div className="ml-auto flex items-center gap-1">
+          {/* Navigation leads the action cluster, arrows off the image
+              (they covered exactly the content being looked at) and the
+              counter between the arrows it describes. min-w keeps the
+              arrows from shifting as digit counts change. */}
+          {sequence && (
+            <div className="mr-1 flex shrink-0 items-center gap-0.5">
+              <SequenceButton
+                side="prev"
+                label={t(($) => $.image.previous)}
+                onClick={sequence.onPrev}
+              />
+              <span
+                className="min-w-10 select-none text-center text-caption tabular-nums text-muted-foreground"
+                aria-live="polite"
+              >
+                {t(($) => $.image.sequence_position, {
+                  index: sequence.index + 1,
+                  total: sequence.total,
+                })}
+              </span>
+              <SequenceButton
+                side="next"
+                label={t(($) => $.image.next)}
+                onClick={sequence.onNext}
+              />
+            </div>
+          )}
           {/* Standalone preview keeps the original gate — no controls until
               the image is measured, and none at all for content that has no
               intrinsic size to drive. In a sequence they stay mounted
@@ -635,32 +662,6 @@ function PreviewPanel({
             onDownload={onDownload}
           />
         )}
-        {sequence && (
-          <>
-            <SequenceButton
-              side="prev"
-              label={t(($) => $.image.previous)}
-              onClick={sequence.onPrev}
-            />
-            <SequenceButton
-              side="next"
-              label={t(($) => $.image.next)}
-              onClick={sequence.onNext}
-            />
-            {/* Position lives with the navigation it describes, not in the
-                header's action cluster — same bottom-counter shape as the
-                mobile lightbox. */}
-            <span
-              className="pointer-events-none absolute bottom-3 left-1/2 z-10 -translate-x-1/2 select-none rounded-full bg-background/80 px-2.5 py-1 text-caption tabular-nums text-foreground shadow-sm backdrop-blur-sm"
-              aria-live="polite"
-            >
-              {t(($) => $.image.sequence_position, {
-                index: sequence.index + 1,
-                total: sequence.total,
-              })}
-            </span>
-          </>
-        )}
       </div>
     </>
   );
@@ -670,10 +671,12 @@ function PreviewPanel({
 // Sequence controls
 // ---------------------------------------------------------------------------
 
-// Edge-anchored chevrons, the shape every image viewer uses. `onClick`
+// Header chevrons in the same idiom as the download/close buttons. `onClick`
 // undefined means "boundary reached": the button stays mounted but disabled,
 // so the reader can see they are at one end instead of the control vanishing
-// and shifting nothing into its place.
+// and shifting the counter into its place. `enabled:hover` so the disabled
+// state gets no hover feedback (and no pointer-events-none — a disabled
+// control should still catch the cursor and read as "nothing here").
 function SequenceButton({
   side,
   label,
@@ -687,22 +690,13 @@ function SequenceButton({
   return (
     <button
       type="button"
-      className={cn(
-        "absolute top-1/2 z-10 -translate-y-1/2 rounded-full bg-background/80 p-2 text-foreground shadow-sm backdrop-blur-sm transition-opacity",
-        // No disabled:pointer-events-none (the shadcn default): this button
-        // floats over the zoom canvas, and letting a disabled boundary arrow
-        // pass pointer events through would show the canvas's grab cursor —
-        // "draggable here" — exactly where the UI means "nothing to click".
-        // The disabled attribute already blocks activation.
-        "enabled:hover:bg-background disabled:opacity-30",
-        side === "prev" ? "left-3" : "right-3",
-      )}
+      className="rounded-md p-1.5 text-muted-foreground transition-colors enabled:hover:bg-secondary enabled:hover:text-foreground disabled:opacity-30"
       title={label}
       aria-label={label}
       disabled={!onClick}
       onClick={onClick}
     >
-      <Icon className="size-5" />
+      <Icon className="size-4" />
     </button>
   );
 }

--- a/packages/views/editor/hooks/use-zoom-canvas.ts
+++ b/packages/views/editor/hooks/use-zoom-canvas.ts
@@ -153,22 +153,29 @@ export function useZoomCanvas({
     return () => observer.disconnect();
   }, [viewportNode]);
 
-  // Fit once, on first open. Deliberately not re-fitting on later viewport
-  // changes: a theme switch re-renders the content at the same size, and
-  // silently snapping the user's zoom back to fit would lose their place.
-  useEffect(() => {
+  // Fit once, on first open — a layout effect, so the first painted frame is
+  // already fitted. Deliberately not re-fitting on later viewport changes: a
+  // theme switch re-renders the content at the same size, and silently
+  // snapping the user's zoom back to fit would lose their place.
+  useLayoutEffect(() => {
     if (!ready || hasFittedRef.current) return;
     hasFittedRef.current = true;
     setTransform(computeFitTransform(contentSize, viewport));
   }, [ready, contentSize, viewport]);
 
-  // Genuinely different content (new natural size) starts fresh.
+  // Genuinely different content (new natural size) starts fresh. Also a
+  // layout effect, and never eased: swapping to another image (sequence
+  // navigation) is content replacement, not a camera move on the same
+  // content. The new frame must paint already fitted — a plain effect would
+  // paint it once under the previous image's pan/zoom, and a leftover
+  // `isAnimated` from the last discrete control would ease the correction.
   const contentKey = `${contentSize.width}x${contentSize.height}`;
   const previousContentKeyRef = useRef(contentKey);
-  useEffect(() => {
+  useLayoutEffect(() => {
     if (previousContentKeyRef.current === contentKey) return;
     previousContentKeyRef.current = contentKey;
     if (!ready) return;
+    setIsAnimated(false);
     setTransform(computeFitTransform(contentSize, viewport));
   }, [contentKey, ready, contentSize, viewport]);
 


### PR DESCRIPTION
Follow-ups to MUL-5752 (#6424) that were pushed after the squash merge and never landed. Two commits, cherry-picked as-is.

## Navigation moves into the header action cluster

The edge-anchored chevrons floated over the image and covered exactly the content being looked at (and the bottom counter pill covered more). The prev / `3 / 7` / next cluster now leads the header's right-side actions, in the same button idiom as download/close: `p-1.5` rounded, disabled arrows stay mounted at reduced opacity with no hover feedback, `min-w` on the counter so the arrows don't shift as digit counts change.

## New canvas content paints pre-fitted, without easing

Regression exposed by the flashless-navigation change in #6424: the preview panel now persists across sequence navigation, so the zoom canvas state survives image swaps. Two artifacts followed:

- The re-fit on a natural-size change ran in a plain `useEffect`, so the next image painted one frame under the previous image's pan/zoom before being corrected.
- `isAnimated` was never reset on content change — after any discrete zoom (buttons, `+`/`-`/`0`, double-click, arrow pan), the leftover flag made every subsequent swap ease its re-fit over 150ms, which read as a paging animation.

The re-fit (and the fit-on-open) now run in `useLayoutEffect` and clear `isAnimated`: swapping to another image is content replacement, not a camera move, so the new frame appears already fitted. Discrete zoom on the same content keeps its easing; drag/wheel keep tracking 1:1.

## Verification

- `packages/views` tests for every zoom-canvas consumer (attachment-preview-modal, image-sequence-context, mermaid-viewer, mermaid-diagram, readonly-content): 144/144 green locally on these exact diffs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
