### PR TITLE
fix(desktop): return to the last visited tab on close (MUL-5665)

### DIFF
--- a/apps/desktop/src/renderer/src/stores/tab-store.test.ts
+++ b/apps/desktop/src/renderer/src/stores/tab-store.test.ts
@@ -518,6 +518,170 @@ describe("bulk tab closing", () => {
   });
 });
 
+describe("closeTab activation order (MUL-5665)", () => {
+  // Tabs are appended at the end of the strip, so the tab you opened from a
+  // list is rarely that list's neighbour. Landing on a positional neighbour
+  // dropped users on a page they hadn't looked at in a while.
+  it("activates the last visited tab, not the positional neighbour", () => {
+    const store = useTabStore.getState();
+    store.switchWorkspace("acme");
+    const issuesId = useTabStore.getState().byWorkspace.acme.tabs[0].id;
+    store.addTab("/acme/projects", "Projects");
+    const agentsId = store.addTab("/acme/agents", "Agents");
+
+    store.setActiveTab(issuesId);
+    store.setActiveTab(agentsId);
+    store.closeTab(agentsId);
+
+    const group = useTabStore.getState().byWorkspace.acme;
+    expect(group.activeTabId).toBe(issuesId); // positional would give Projects
+    expect(group.recentTabIds).toEqual([]);
+  });
+
+  it("walks back through the visit history as tabs keep closing", () => {
+    const store = useTabStore.getState();
+    store.switchWorkspace("acme");
+    const issuesId = useTabStore.getState().byWorkspace.acme.tabs[0].id;
+    const projectsId = store.addTab("/acme/projects", "Projects");
+    const agentsId = store.addTab("/acme/agents", "Agents");
+    const settingsId = store.addTab("/acme/settings", "Settings");
+
+    store.setActiveTab(projectsId);
+    store.setActiveTab(agentsId);
+    store.setActiveTab(settingsId);
+    expect(useTabStore.getState().byWorkspace.acme.recentTabIds).toEqual([
+      agentsId,
+      projectsId,
+      issuesId,
+    ]);
+
+    store.closeTab(settingsId);
+    expect(useTabStore.getState().byWorkspace.acme.activeTabId).toBe(agentsId);
+    store.closeTab(agentsId);
+    expect(useTabStore.getState().byWorkspace.acme.activeTabId).toBe(projectsId);
+    store.closeTab(projectsId);
+    expect(useTabStore.getState().byWorkspace.acme.activeTabId).toBe(issuesId);
+  });
+
+  it("counts a revisit once — the most recent visit wins", () => {
+    const store = useTabStore.getState();
+    store.switchWorkspace("acme");
+    const issuesId = useTabStore.getState().byWorkspace.acme.tabs[0].id;
+    const projectsId = store.addTab("/acme/projects", "Projects");
+    const agentsId = store.addTab("/acme/agents", "Agents");
+
+    store.setActiveTab(projectsId); // recent: [issues]
+    store.setActiveTab(issuesId); // recent: [projects]
+    store.setActiveTab(agentsId); // recent: [issues, projects]
+
+    expect(useTabStore.getState().byWorkspace.acme.recentTabIds).toEqual([
+      issuesId,
+      projectsId,
+    ]);
+    store.closeTab(agentsId);
+    expect(useTabStore.getState().byWorkspace.acme.activeTabId).toBe(issuesId);
+  });
+
+  it("drops a closed background tab from the visit history", () => {
+    const store = useTabStore.getState();
+    store.switchWorkspace("acme");
+    const issuesId = useTabStore.getState().byWorkspace.acme.tabs[0].id;
+    const projectsId = store.addTab("/acme/projects", "Projects");
+    const agentsId = store.addTab("/acme/agents", "Agents");
+
+    store.setActiveTab(projectsId);
+    store.setActiveTab(agentsId); // recent: [projects, issues]
+
+    store.closeTab(projectsId); // not the active tab
+    const group = useTabStore.getState().byWorkspace.acme;
+    expect(group.activeTabId).toBe(agentsId); // untouched
+    expect(group.recentTabIds).toEqual([issuesId]);
+
+    store.closeTab(agentsId);
+    expect(useTabStore.getState().byWorkspace.acme.activeTabId).toBe(issuesId);
+  });
+
+  it("falls back to the positional neighbour when no other tab was ever visited", () => {
+    const store = useTabStore.getState();
+    store.switchWorkspace("acme");
+    const issuesId = useTabStore.getState().byWorkspace.acme.tabs[0].id;
+    const projectsId = store.addTab("/acme/projects", "Projects");
+    store.addTab("/acme/agents", "Agents");
+
+    // addTab never activates, so the active tab has no visit history behind it.
+    store.closeTab(issuesId);
+
+    expect(useTabStore.getState().byWorkspace.acme.activeTabId).toBe(projectsId);
+  });
+
+  it("opening a tab in a new tab and closing it returns to the opener", () => {
+    const store = useTabStore.getState();
+    store.switchWorkspace("acme");
+    const issuesId = useTabStore.getState().byWorkspace.acme.tabs[0].id;
+    store.addTab("/acme/projects", "Projects");
+    const detailId = store.openTab("/acme/issues/bug-42", "Bug 42", {
+      activate: true,
+    });
+
+    store.closeTab(detailId);
+
+    expect(useTabStore.getState().byWorkspace.acme.activeTabId).toBe(issuesId);
+  });
+
+  it("closeOtherTabs keeps only surviving tabs in the visit history", () => {
+    const store = useTabStore.getState();
+    store.switchWorkspace("acme");
+    const issuesId = useTabStore.getState().byWorkspace.acme.tabs[0].id;
+    const projectsId = store.addTab("/acme/projects", "Projects");
+    const agentsId = store.addTab("/acme/agents", "Agents");
+    store.togglePin(issuesId);
+    store.setActiveTab(issuesId);
+    store.setActiveTab(projectsId);
+    store.setActiveTab(agentsId); // recent: [projects, issues]
+
+    store.closeOtherTabs(agentsId);
+
+    const group = useTabStore.getState().byWorkspace.acme;
+    expect(group.tabs.map((t) => t.id)).toEqual([issuesId, agentsId]);
+    expect(group.recentTabIds).toEqual([issuesId]); // projects is gone
+    expect(group.activeTabId).toBe(agentsId);
+  });
+
+  it("keeps each workspace's visit history to itself", () => {
+    const store = useTabStore.getState();
+    store.switchWorkspace("acme");
+    const acmeIssuesId = useTabStore.getState().byWorkspace.acme.tabs[0].id;
+    const acmeProjectsId = store.addTab("/acme/projects", "Projects");
+    store.setActiveTab(acmeProjectsId);
+
+    store.switchWorkspace("butter");
+    const butterIssuesId = useTabStore.getState().byWorkspace.butter.tabs[0].id;
+    const butterAgentsId = store.addTab("/butter/agents", "Agents");
+    store.setActiveTab(butterAgentsId);
+    store.closeTab(butterAgentsId);
+
+    const state = useTabStore.getState();
+    expect(state.byWorkspace.butter.activeTabId).toBe(butterIssuesId);
+    expect(state.byWorkspace.acme.recentTabIds).toEqual([acmeIssuesId]);
+  });
+
+  it("reseeding the last tab of a workspace starts a fresh visit history", () => {
+    const store = useTabStore.getState();
+    store.switchWorkspace("acme");
+    const issuesId = useTabStore.getState().byWorkspace.acme.tabs[0].id;
+    const projectsId = store.addTab("/acme/projects", "Projects");
+    store.setActiveTab(projectsId);
+    store.closeTab(issuesId);
+
+    store.closeTab(projectsId); // last tab — reseeds the default
+
+    const group = useTabStore.getState().byWorkspace.acme;
+    expect(group.tabs).toHaveLength(1);
+    expect(group.recentTabIds).toEqual([]);
+    expect(group.activeTabId).toBe(group.tabs[0].id);
+  });
+});
+
 describe("togglePin", () => {
   it("flips a tab's pinned state", () => {
     const store = useTabStore.getState();
@@ -762,5 +926,57 @@ describe("mergePersistedTabs (rehydration, MUL-4370)", () => {
     const tab = rehydrate(persistedTab("/acme/squads"));
     expect(tab).not.toHaveProperty("icon");
     expect(tab.url).toBe("/acme/squads");
+  });
+
+  function rehydrateGroup(
+    activeTabId: string,
+    urls: Record<string, string>,
+    recentTabIds?: unknown,
+  ): WorkspaceTabGroup {
+    return mergePersistedTabs(
+      {
+        activeWorkspaceSlug: "acme",
+        byWorkspace: {
+          acme: {
+            activeTabId,
+            recentTabIds,
+            tabs: Object.entries(urls).map(([id, url]) =>
+              persistedTab(url, { id }),
+            ),
+          },
+        },
+      },
+      emptyState(),
+    ).byWorkspace.acme;
+  }
+
+  it("restores the MRU order so the first close after a restart still returns there", () => {
+    const group = rehydrateGroup(
+      "t3",
+      { t1: "/acme/issues", t2: "/acme/projects", t3: "/acme/agents" },
+      ["t1", "t2"],
+    );
+    expect(group.recentTabIds).toEqual(["t1", "t2"]);
+
+    useTabStore.setState({
+      activeWorkspaceSlug: "acme",
+      byWorkspace: { acme: group },
+    });
+    useTabStore.getState().closeTab("t3");
+    expect(useTabStore.getState().byWorkspace.acme.activeTabId).toBe("t1");
+  });
+
+  it("sanitizes an MRU order carrying dropped, duplicate, or active tab ids", () => {
+    const group = rehydrateGroup(
+      "t2",
+      { t1: "/acme/issues", t2: "/acme/projects" },
+      ["gone", "t1", "t1", "t2", 7],
+    );
+    expect(group.recentTabIds).toEqual(["t1"]);
+  });
+
+  it("defaults the MRU order to empty for payloads written before it existed", () => {
+    const group = rehydrateGroup("t1", { t1: "/acme/issues" });
+    expect(group.recentTabIds).toEqual([]);
   });
 });

--- a/apps/desktop/src/renderer/src/stores/tab-store.ts
+++ b/apps/desktop/src/renderer/src/stores/tab-store.ts
@@ -78,6 +78,18 @@ export interface WorkspaceTabGroup {
   tabs: TabSession[];
   /** Must be a valid tab.id in `tabs`; the empty-tabs state is transient only. */
   activeTabId: string;
+  /**
+   * Previously visited tabs of this group, most recent first. Never contains
+   * `activeTabId`, never contains an id that is no longer in `tabs`.
+   *
+   * This is the group's MRU (most-recently-used) order, and it exists for one
+   * question: where do we land when the active tab goes away? Closing a tab
+   * returns to the tab you were last looking at (MUL-5665), not to a
+   * positional neighbour — opening a detail tab from a list, then closing it,
+   * must put you back on that list even when the tab bar appended the new tab
+   * far away from it.
+   */
+  recentTabIds: string[];
 }
 
 interface TabStore {
@@ -134,6 +146,10 @@ interface TabStore {
    * only know the tab id, not the owning workspace). If this is the last
    * tab in its workspace, reseed a default tab so the invariant
    * "every live workspace has at least one tab" holds.
+   *
+   * Closing the ACTIVE tab activates the group's most recently visited
+   * surviving tab (`recentTabIds`), falling back to the positional neighbour
+   * only when that order is empty.
    */
   closeTab: (tabId: string) => void;
   /** Close every other unpinned tab in the target tab's workspace. */
@@ -176,8 +192,8 @@ interface TabStore {
   /**
    * Close the active tab. The always-safe escape from a route-level crash:
    * unlike reloadActiveTab (remounts the same crashing URL), closing
-   * destroys the crashing session entirely and falls back to a sibling tab
-   * (or a reseeded default if it was the last tab).
+   * destroys the crashing session entirely and falls back to the last tab
+   * you were on (or a reseeded default if it was the last tab).
    */
   closeActiveTab: () => void;
   /**
@@ -336,6 +352,53 @@ function defaultTabFor(slug: string): TabSession {
 // Group helpers
 // ---------------------------------------------------------------------------
 
+/**
+ * Build a group with its MRU order reconciled against the new (tabs,
+ * activeTabId) pair. Every write that changes which tab is active or which
+ * tabs exist goes through here, so `recentTabIds` cannot drift from `tabs`.
+ *
+ * `prev` is the group being replaced: when the active tab changes, the
+ * outgoing tab becomes the most recent visit. Pass null when seeding a brand
+ * new group (nothing has been visited yet).
+ */
+function reconcileGroup(
+  prev: WorkspaceTabGroup | null,
+  tabs: TabSession[],
+  activeTabId: string,
+): WorkspaceTabGroup {
+  const live = new Set(tabs.map((t) => t.id));
+  const carried =
+    prev && prev.activeTabId !== activeTabId
+      ? [prev.activeTabId, ...prev.recentTabIds]
+      : (prev?.recentTabIds ?? []);
+
+  const recentTabIds: string[] = [];
+  for (const id of carried) {
+    if (id === activeTabId) continue;
+    if (!live.has(id)) continue; // closed tabs leave the MRU order
+    if (recentTabIds.includes(id)) continue;
+    recentTabIds.push(id);
+  }
+  return { tabs, activeTabId, recentTabIds };
+}
+
+/**
+ * Which tab to activate when the active tab closes: the most recently
+ * visited surviving tab. Falls back to the positional neighbour when the MRU
+ * order has nothing live left — the tab was never left and returned to, or
+ * the group was rehydrated from a build that persisted no MRU order.
+ */
+function nextActiveAfterClose(
+  group: WorkspaceTabGroup,
+  nextTabs: TabSession[],
+  closedIndex: number,
+): string {
+  const survivors = new Set(nextTabs.map((t) => t.id));
+  const recent = group.recentTabIds.find((id) => survivors.has(id));
+  if (recent) return recent;
+  return nextTabs[Math.min(closedIndex, nextTabs.length - 1)].id;
+}
+
 function findTabLocation(
   byWorkspace: Record<string, WorkspaceTabGroup>,
   tabId: string,
@@ -368,7 +431,7 @@ function buildCloseOtherTabsResult(
 
   return {
     ...byWorkspace,
-    [slug]: { tabs: nextTabs, activeTabId: nextActiveTabId },
+    [slug]: reconcileGroup(group, nextTabs, nextActiveTabId),
   };
 }
 
@@ -403,7 +466,7 @@ export const useTabStore = create<TabStore>()(
             activeWorkspaceSlug: slug,
             byWorkspace: {
               ...byWorkspace,
-              [slug]: { tabs: [tab], activeTabId: tab.id },
+              [slug]: reconcileGroup(null, [tab], tab.id),
             },
           });
           return;
@@ -421,7 +484,7 @@ export const useTabStore = create<TabStore>()(
                 activeWorkspaceSlug: slug,
                 byWorkspace: {
                   ...byWorkspace,
-                  [slug]: { ...existing, activeTabId: match.id },
+                  [slug]: reconcileGroup(existing, existing.tabs, match.id),
                 },
               });
               return;
@@ -431,10 +494,11 @@ export const useTabStore = create<TabStore>()(
               activeWorkspaceSlug: slug,
               byWorkspace: {
                 ...byWorkspace,
-                [slug]: {
-                  tabs: [...existing.tabs, tab],
-                  activeTabId: tab.id,
-                },
+                [slug]: reconcileGroup(
+                  existing,
+                  [...existing.tabs, tab],
+                  tab.id,
+                ),
               },
             });
             return;
@@ -460,7 +524,11 @@ export const useTabStore = create<TabStore>()(
           set({
             byWorkspace: {
               ...byWorkspace,
-              [activeWorkspaceSlug]: { ...group, activeTabId: existing.id },
+              [activeWorkspaceSlug]: reconcileGroup(
+                group,
+                group.tabs,
+                existing.id,
+              ),
             },
           });
           return existing.id;
@@ -470,10 +538,11 @@ export const useTabStore = create<TabStore>()(
         set({
           byWorkspace: {
             ...byWorkspace,
-            [activeWorkspaceSlug]: {
-              tabs: [...group.tabs, tab],
-              activeTabId: opts?.activate === true ? tab.id : group.activeTabId,
-            },
+            [activeWorkspaceSlug]: reconcileGroup(
+              group,
+              [...group.tabs, tab],
+              opts?.activate === true ? tab.id : group.activeTabId,
+            ),
           },
         });
         return tab.id;
@@ -490,10 +559,11 @@ export const useTabStore = create<TabStore>()(
         set({
           byWorkspace: {
             ...byWorkspace,
-            [activeWorkspaceSlug]: {
-              tabs: [...group.tabs, tab],
-              activeTabId: group.activeTabId,
-            },
+            [activeWorkspaceSlug]: reconcileGroup(
+              group,
+              [...group.tabs, tab],
+              group.activeTabId,
+            ),
           },
         });
         return tab.id;
@@ -513,7 +583,7 @@ export const useTabStore = create<TabStore>()(
           set({
             byWorkspace: {
               ...byWorkspace,
-              [slug]: { tabs: [fresh], activeTabId: fresh.id },
+              [slug]: reconcileGroup(null, [fresh], fresh.id),
             },
           });
           return;
@@ -522,13 +592,13 @@ export const useTabStore = create<TabStore>()(
         const nextTabs = group.tabs.filter((t) => t.id !== tabId);
         const nextActiveTabId =
           group.activeTabId === tabId
-            ? nextTabs[Math.min(index, nextTabs.length - 1)].id
+            ? nextActiveAfterClose(group, nextTabs, index)
             : group.activeTabId;
 
         set({
           byWorkspace: {
             ...byWorkspace,
-            [slug]: { tabs: nextTabs, activeTabId: nextActiveTabId },
+            [slug]: reconcileGroup(group, nextTabs, nextActiveTabId),
           },
         });
       },
@@ -550,7 +620,7 @@ export const useTabStore = create<TabStore>()(
           activeWorkspaceSlug: slug,
           byWorkspace: {
             ...byWorkspace,
-            [slug]: { ...group, activeTabId: tabId },
+            [slug]: reconcileGroup(group, group.tabs, tabId),
           },
         });
       },
@@ -774,10 +844,11 @@ export const useTabStore = create<TabStore>()(
           const fallbackSlug = validSlugs.values().next().value;
           if (fallbackSlug) {
             const fresh = defaultTabFor(fallbackSlug);
-            nextByWorkspace[fallbackSlug] = {
-              tabs: [fresh],
-              activeTabId: fresh.id,
-            };
+            nextByWorkspace[fallbackSlug] = reconcileGroup(
+              null,
+              [fresh],
+              fresh.id,
+            );
             nextActive = fallbackSlug;
             changed = true;
           }
@@ -826,6 +897,10 @@ export const useTabStore = create<TabStore>()(
             slug,
             {
               activeTabId: group.activeTabId,
+              // Persisted so the first close after a restart still lands on
+              // the tab you were last looking at rather than falling back to
+              // the positional neighbour.
+              recentTabIds: group.recentTabIds,
               tabs: group.tabs.map((t) => ({
                 id: t.id,
                 url: t.url,
@@ -913,7 +988,19 @@ export function mergePersistedTabs<T extends PersistedTabState>(
     const activeTabId = tabs.some((t) => t.id === pGroup.activeTabId)
       ? pGroup.activeTabId
       : tabs[0].id;
-    byWorkspace[slug] = { tabs, activeTabId };
+    // reconcileGroup filters the persisted MRU order down to live tab ids
+    // (tabs dropped just above), drops the active tab from it, and dedupes.
+    byWorkspace[slug] = reconcileGroup(
+      {
+        tabs,
+        activeTabId,
+        recentTabIds: Array.isArray(pGroup.recentTabIds)
+          ? pGroup.recentTabIds.filter((id) => typeof id === "string")
+          : [],
+      },
+      tabs,
+      activeTabId,
+    );
   }
 
   const activeWorkspaceSlug =
@@ -1026,6 +1113,13 @@ interface V4PersistedTab {
 interface V4PersistedGroup {
   tabs: V4PersistedTab[];
   activeTabId: string;
+  /**
+   * MRU activation order. Optional: payloads written before MUL-5665 don't
+   * have it, and an absent order simply means the first close of that group
+   * falls back to the positional neighbour. Re-validated on rehydration, so
+   * a stale id from a hand-edited payload can never become the active tab.
+   */
+  recentTabIds?: string[];
 }
 
 interface V4Persisted {


### PR DESCRIPTION
Closing the active tab activated a positional neighbour (`tabs[min(index, len-1)]`). Since new tabs are appended at the end of the strip, the neighbour is rarely the tab you came from — open an issue from the issues list, close it, and you land on whatever tab happens to sit next to it.

Tab groups now carry an MRU activation order. Closing the active tab activates the most recently visited surviving tab instead.

## Changes

- `WorkspaceTabGroup` gains `recentTabIds: string[]` — previously visited tabs, most recent first, never containing the active tab or a closed tab.
- `closeTab` picks the first surviving id from that order, falling back to the old positional neighbour only when the order is empty (a tab that was never left and returned to, or state persisted by an older build).
- Every write that changes a group's tabs or active tab goes through a single `reconcileGroup` helper, so the order can't drift from `tabs`.
- The order is persisted alongside the tabs, so the first close after a restart behaves the same. Rehydration re-validates it against live tab ids — a stale or hand-edited id can never become the active tab. No persist version bump: an absent field just means "no MRU order yet".

`closeOtherTabs` and the last-tab reseed path go through the same helper, so a closed tab never lingers in the order.

## Verification

- 11 new store tests covering: last-visited activation, walking back through several closes, revisits collapsing to one entry, closing a background tab, positional fallback, open-in-new-tab → close → back to opener, `closeOtherTabs`, per-workspace isolation, reseed, and persisted-order rehydration (including stale/duplicate/non-string ids).
- `pnpm test` in `apps/desktop` — 499 passed.
- `pnpm typecheck`, `pnpm exec eslint` on the changed files — clean.
