### PR TITLE
docs: wrap bare {{count}} in code spans to unbreak the Vercel docs build

### DIFF
--- a/apps/docs/content/docs/developers/conventions.mdx
+++ b/apps/docs/content/docs/developers/conventions.mdx
@@ -132,7 +132,7 @@ What does not move:
 - **API / DB fields** stay `issue` / `task` / `skill` everywhere: `issue_status`, `task_id`, `skill_uuid`.
 - **Code references and literal commands** stay English: `multica issue ...`, the `/issue` Slack and Lark slash command.
 - **`skill`** keeps lowercase English in Chinese text — a Multica-specific concept with no established Chinese term; titles may capitalize as `Skills`.
-- **`issue` in the "problem" sense** (runtime health) is a plain noun, not the entity: "{{count}} issues" on a machine card is `{{count}} 个异常`, not `任务`.
+- **`issue` in the "problem" sense** (runtime health) is a plain noun, not the entity: `{{count}} issues` on a machine card is `{{count}} 个异常`, not `任务`.
 
 **Why `issue` is translated while `skill` is not**: users file and read issues all day, and "issue" has no meaning in Chinese, Japanese, or Korean outside of dev jargon. The everyday task word is what people already say for this. `skill` is a Multica-specific concept where no local word carries the meaning.
 

--- a/apps/docs/content/docs/developers/conventions.zh.mdx
+++ b/apps/docs/content/docs/developers/conventions.zh.mdx
@@ -132,7 +132,7 @@ Multica 的产品名词分两类：
 - **API / DB 字段**永远是 `issue` / `task` / `skill`：`issue_status`、`task_id`、`skill_uuid`。
 - **代码引用和字面命令**保持英文：`multica issue ...`、Slack 与飞书的 `/issue` 斜杠命令。
 - **`skill`** 在中文里仍用小写英文 —— Multica 特有概念，没有公认中文译法；标题可大写为 `Skills`。
-- **表示「问题」的 issue** 不是这个实体：机器卡片上的 "{{count}} issues" 是 `{{count}} 个异常`，不是 `任务`。
+- **表示「问题」的 issue** 不是这个实体：机器卡片上的 `{{count}} issues` 是 `{{count}} 个异常`，不是 `任务`。
 
 **为什么 `issue` 要译，而 `skill` 不译**：用户每天都在提任务、看任务，而 "issue" 这个词在中文、日文、韩文里除了开发圈黑话之外没有含义，当地人本来就用「任务」在说这件事。`skill` 则是 Multica 特有概念，没有哪个中文词能承载它的意思。
 


### PR DESCRIPTION
Every `multica-docs` Vercel deployment (production and rebased previews) has failed since e3bf9ccd4 (#6362, merged today 15:25 CST). This unbreaks it — a two-character fix per language.

## Root cause

#6362 added one prose line to `conventions.mdx` / `conventions.zh.mdx` (line 135 in both) containing a bare `"{{count}} issues"` outside a code span. MDX parses `{...}` as a JSX expression, and `{{count}}` happens to be valid JavaScript (an object literal with shorthand `count`), so **compilation passes** — but rendering evaluates the undefined `count` binding and throws `ReferenceError: count is not defined`, killing the page's static generation and the whole build.

Every other `{{count}}` on these pages sits inside a code fence or backticks; these two were the only bare ones.

## Why nothing caught it

- GitHub CI builds and tests with `--filter='!@multica/docs'` — the docs app is only ever built by Vercel.
- The error class is invisible to compile-only checks: it fails at render, not at parse.

Evidence: docs production deploys succeeded through 3a2847410 (15:10 CST) and have failed on every commit since e3bf9ccd4 (15:25 CST); the failing line reproduces `count is not defined` under `@mdx-js/mdx` `evaluate`, and both files render clean with this fix applied.

## Fix

Wrap the two occurrences in backticks, matching the neighbouring lines' style. Verified locally: both full pages compile and render through MDX (frontmatter stripped, GFM enabled); the pre-fix versions fail with the exact production error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
