### PR TITLE
MUL-5764 fix(daemon): preserve quick-create Codex session handoff

### DIFF
--- a/server/internal/daemon/config.go
+++ b/server/internal/daemon/config.go
@@ -68,7 +68,7 @@ const (
 	DefaultGCTTL                          = 24 * time.Hour      // 1 day — AI-coding issues rarely stay open long
 	DefaultGCOrphanTTL                    = 72 * time.Hour      // 3 days — orphans with no meta (crashes, pre-GC leftovers)
 	DefaultGCArtifactTTL                  = 12 * time.Hour      // 12h — drop regenerable artifacts on completed but still-open issues
-	DefaultGCCodexSessionTTL              = 14 * 24 * time.Hour // 14 days — reclaim per-issue Codex session stores untouched this long
+	DefaultGCCodexSessionTTL              = 14 * 24 * time.Hour // 14 days — reclaim scoped Codex session stores untouched this long, including orphaned quick-create scopes
 	DefaultGCRepoTTL                      = 30 * 24 * time.Hour // 30 days — evict a bare repo cache no task has checked out this long
 	DefaultAutoUpdateCheckInterval        = 6 * time.Hour       // how often the daemon polls GitHub for a newer CLI release
 )
@@ -103,7 +103,7 @@ type Config struct {
 	GCArtifactTTL                  time.Duration         // when a task has been completed for at least this long but its issue is still open, drop regenerable artifacts (default: 12h, set 0 to disable)
 	GCArtifactPatterns             []string              // basename patterns whose subtrees are removed during artifact cleanup (default: node_modules, .next, .turbo)
 	GCRepoTTL                      time.Duration         // evict a cached bare repo under .repos once no task has created a worktree from it for this long, it has no worktrees left, and it is no longer attached to any watched workspace (default: 30d, set 0 to disable)
-	GCCodexSessionTTL              time.Duration         // reclaim a per-issue Codex session store (~/.codex/multica-sessions/<agent>/<issue>) untouched for at least this long, so a done/abandoned issue's conversation history does not accumulate forever (default: 14d, set 0 to disable)
+	GCCodexSessionTTL              time.Duration         // reclaim a scoped Codex session store (~/.codex/multica-sessions/<profile-namespace>/<agent>/<scope>) untouched for at least this long; quick-create scopes are qc_<origin_task_id> and map through issue.origin_id (default: 14d, set 0 to disable)
 	AutoUpdateEnabled              bool                  // periodically check for a newer CLI release and self-update when idle (default: true on Multica Cloud, false on self-host)
 	AutoUpdateCheckInterval        time.Duration         // how often the auto-update loop polls for a new release (default: 6h)
 	PollInterval                   time.Duration

--- a/server/internal/daemon/daemon.go
+++ b/server/internal/daemon/daemon.go
@@ -5007,12 +5007,14 @@ func (d *Daemon) runTask(ctx context.Context, task Task, provider string, slot i
 		}
 		hermesEnv["HERMES_HOME"] = res.SourceHome
 	}
-	// Guard this task's per-issue Codex session store from the GC for the whole
+	// Guard this task's scoped Codex session store from the GC for the whole
 	// task, starting before Prepare/Reuse mounts it — so a prune that samples the
 	// store's stale (pre-remount) mtime cannot reclaim it out from under a resume
-	// of a long-idle issue (MUL-4424). No-op for non-Codex tasks / no stable key.
+	// of a long-idle conversation (MUL-4424). No-op for non-Codex tasks / no
+	// stable key.
+	sessionStoreScope := execenv.ResolveCodexSessionStoreScope(task.SessionStoreScope, task.IssueID)
 	if provider == "codex" {
-		if store := execenv.CodexSessionStorePath(d.cfg.Profile, task.AgentID, task.IssueID); store != "" {
+		if store := execenv.CodexSessionStorePath(d.cfg.Profile, task.AgentID, sessionStoreScope); store != "" {
 			d.markActiveCodexStore(store)
 			defer d.unmarkActiveCodexStore(store)
 		}
@@ -5022,6 +5024,7 @@ func (d *Daemon) runTask(ctx context.Context, task Task, provider string, slot i
 		env, err = d.reuseExecutionEnvironment(prepareCtx, execenv.ReuseParams{
 			WorkspacesRoot:        d.cfg.WorkspacesRoot,
 			Profile:               d.cfg.Profile,
+			SessionStoreScope:     sessionStoreScope,
 			WorkDir:               task.PriorWorkDir,
 			Provider:              provider,
 			CodexVersion:          codexVersion,
@@ -5045,6 +5048,7 @@ func (d *Daemon) runTask(ctx context.Context, task Task, provider string, slot i
 		prepParams := execenv.PrepareParams{
 			WorkspacesRoot:        d.cfg.WorkspacesRoot,
 			Profile:               d.cfg.Profile,
+			SessionStoreScope:     sessionStoreScope,
 			WorkspaceID:           task.WorkspaceID,
 			TaskID:                task.ID,
 			AgentName:             agentName,

--- a/server/internal/daemon/execenv/codex_home.go
+++ b/server/internal/daemon/execenv/codex_home.go
@@ -391,9 +391,8 @@ func codexSessionStoreNamespace(profile string) string {
 
 // ResolveCodexSessionStoreScope chooses the server-provided stable scope when
 // it is a safe single directory segment, otherwise preserving the legacy
-// issue-id scope. The daemon resolves once and passes that exact value to both
-// the active-store GC guard and mount preparation, so they cannot disagree
-// about which store is in use.
+// issue-id scope. Both the active-store GC guard and mount preparation call
+// this resolver so they cannot disagree about which store is in use.
 //
 // A quick-created issue intentionally keeps qc_<origin_task_id> as its on-disk
 // scope instead of being renamed to the issue id: that stable name avoids
@@ -402,17 +401,6 @@ func codexSessionStoreNamespace(profile string) string {
 func ResolveCodexSessionStoreScope(explicitScope, issueID string) string {
 	if ValidCodexSessionStoreScope(explicitScope) {
 		return explicitScope
-	}
-	return issueID
-}
-
-// effectiveCodexSessionStoreScope preserves the issue-id default for direct
-// execenv callers that predate SessionStoreScope. Runtime tasks pass the value
-// already validated by ResolveCodexSessionStoreScope; resolving the wire value
-// is deliberately owned by the daemon boundary, not repeated during mount.
-func effectiveCodexSessionStoreScope(resolvedScope, issueID string) string {
-	if resolvedScope != "" {
-		return resolvedScope
 	}
 	return issueID
 }

--- a/server/internal/daemon/execenv/codex_home.go
+++ b/server/internal/daemon/execenv/codex_home.go
@@ -56,7 +56,7 @@ type CodexHomeOptions struct {
 	// both macOS and Linux paths deterministically.
 	GOOS string
 	// ResumeSessionID is the Codex thread/session ID this run intends to
-	// resume, when any. It is consulted when populating the per-issue session
+	// resume, when any. It is consulted when populating the scoped session
 	// store (local_directory tasks) or migrating a legacy per-task home whose
 	// sessions/ still symlinks the shared ~/.codex/sessions: the single rollout
 	// for this ID is exposed so thread/resume can find it without pulling the
@@ -66,11 +66,12 @@ type CodexHomeOptions struct {
 	// IsLocalDirectory marks a local_directory task — one running in the user's
 	// own project directory. These tasks get a fresh codex-home per task ID (the
 	// daemon never reuses their workdir), so their sessions/ is pointed at the
-	// per-issue store (SessionStoreKey) that survives across task IDs and holds
-	// ONLY this issue's rollouts — never the machine's whole ~/.codex/sessions.
+	// stable store (SessionStoreKey) that survives across task IDs and holds
+	// ONLY this conversation scope's rollouts — never the machine's whole
+	// ~/.codex/sessions.
 	// See prepareCodexSessionsDir (MUL-4424).
 	IsLocalDirectory bool
-	// SessionStoreKey is a stable, per-(agent, issue) relative path segment that
+	// SessionStoreKey is a stable, per-(agent, scope) relative path segment that
 	// identifies this task's persistent Codex sessions store. It survives across
 	// task IDs (unlike the task-scoped envRoot the GC reclaims) so a follow-up
 	// run resumes the same thread. Empty when no stable key is available (e.g. a
@@ -388,21 +389,39 @@ func codexSessionStoreNamespace(profile string) string {
 	return "p_" + hex.EncodeToString(sum[:])
 }
 
-// codexSessionStoreKey builds the per-(profile, agent, issue) key for a task's
-// persistent Codex sessions store. The agent/issue IDs are server-issued UUIDs;
+// ResolveCodexSessionStoreScope chooses the server-provided stable scope when
+// it is a safe single directory segment, otherwise preserving the legacy
+// issue-id scope. Both the active-store GC guard and mount preparation call
+// this resolver so they cannot disagree about which store is in use.
+func ResolveCodexSessionStoreScope(explicitScope, issueID string) string {
+	if ValidCodexSessionStoreScope(explicitScope) {
+		return explicitScope
+	}
+	return issueID
+}
+
+// ValidCodexSessionStoreScope reports whether scope is already one safe path
+// segment. The daemon rejects malformed wire values instead of silently
+// normalizing two distinct scopes into the same directory.
+func ValidCodexSessionStoreScope(scope string) bool {
+	return scope != "" && len(scope) <= 255 && sanitizeCodexPathSegment(scope) == scope
+}
+
+// codexSessionStoreKey builds the per-(profile, agent, scope) key for a task's
+// persistent Codex sessions store. The agent/scope values are server-issued;
 // all three segments are sanitized to bare path segments defensively so a
 // malformed value can never escape the store root. Returns "" when there is no
-// issue to key on (the store is issue-scoped), leaving sessions/ task-local.
-func codexSessionStoreKey(profile, agentID, issueID string) string {
-	issue := sanitizeCodexPathSegment(issueID)
-	if issue == "" {
+// stable scope, leaving sessions/ task-local.
+func codexSessionStoreKey(profile, agentID, scopeID string) string {
+	scope := sanitizeCodexPathSegment(scopeID)
+	if scope == "" {
 		return ""
 	}
 	agent := sanitizeCodexPathSegment(agentID)
 	if agent == "" {
 		agent = "_"
 	}
-	return filepath.Join(codexSessionStoreNamespace(profile), agent, issue)
+	return filepath.Join(codexSessionStoreNamespace(profile), agent, scope)
 }
 
 // sanitizeCodexPathSegment reduces s to the characters a UUID uses (hex plus
@@ -419,19 +438,20 @@ func sanitizeCodexPathSegment(s string) string {
 	return b.String()
 }
 
-// PruneCodexSessionStores reclaims per-issue Codex session stores under the
+// PruneCodexSessionStores reclaims scoped Codex session stores under the
 // shared home's multica-sessions root that have not been touched within
 // retention, bounding the lifetime of the conversation history each one holds.
 //
 // The stores deliberately live outside the task-scoped envRoot the task GC
 // reclaims (so resume survives across task IDs), which means without this they
-// would accumulate forever — a done or abandoned issue's prompts and full
+// would accumulate forever — a done or abandoned conversation's prompts and full
 // rollouts (one reporter saw a single 1.5 GiB rollout) would never be freed, and
 // deleting the issue/agent/workspace would not remove them. A store's newest
 // mtime is its last activity: Codex writes/extends a rollout as the thread
 // advances, so an active or recently-resumed task keeps its store fresh and is
 // never reclaimed; a store idle past retention is removed, giving deleted issues
-// an eventual-reclamation guarantee. retention <= 0 disables pruning entirely.
+// and orphaned quick-create scopes an eventual-reclamation guarantee. retention
+// <= 0 disables pruning entirely.
 //
 // It scans ONLY the caller profile's namespace, so a daemon never reclaims a
 // store owned by another profile-daemon sharing the same ~/.codex — the
@@ -665,13 +685,13 @@ func touchCodexSessionStore(storeDir string, logger *slog.Logger) {
 	}
 }
 
-// CodexSessionStorePath returns the per-issue Codex session store directory for
-// (profile, agentID, issueID) on the shared home, or "" when there is no stable
+// CodexSessionStorePath returns the Codex session store directory for
+// (profile, agentID, scopeID) on the shared home, or "" when there is no stable
 // key. The daemon marks this path in-use for the duration of a task so
 // PruneCodexSessionStores never reclaims a store mid-mount, closing the
 // stat→remove race the mtime refresh alone cannot (MUL-4424).
-func CodexSessionStorePath(profile, agentID, issueID string) string {
-	key := codexSessionStoreKey(profile, agentID, issueID)
+func CodexSessionStorePath(profile, agentID, scopeID string) string {
+	key := codexSessionStoreKey(profile, agentID, scopeID)
 	if key == "" {
 		return ""
 	}

--- a/server/internal/daemon/execenv/codex_home.go
+++ b/server/internal/daemon/execenv/codex_home.go
@@ -391,11 +391,28 @@ func codexSessionStoreNamespace(profile string) string {
 
 // ResolveCodexSessionStoreScope chooses the server-provided stable scope when
 // it is a safe single directory segment, otherwise preserving the legacy
-// issue-id scope. Both the active-store GC guard and mount preparation call
-// this resolver so they cannot disagree about which store is in use.
+// issue-id scope. The daemon resolves once and passes that exact value to both
+// the active-store GC guard and mount preparation, so they cannot disagree
+// about which store is in use.
+//
+// A quick-created issue intentionally keeps qc_<origin_task_id> as its on-disk
+// scope instead of being renamed to the issue id: that stable name avoids
+// moving potentially large rollouts. Operators can map it back through
+// issue.origin_id.
 func ResolveCodexSessionStoreScope(explicitScope, issueID string) string {
 	if ValidCodexSessionStoreScope(explicitScope) {
 		return explicitScope
+	}
+	return issueID
+}
+
+// effectiveCodexSessionStoreScope preserves the issue-id default for direct
+// execenv callers that predate SessionStoreScope. Runtime tasks pass the value
+// already validated by ResolveCodexSessionStoreScope; resolving the wire value
+// is deliberately owned by the daemon boundary, not repeated during mount.
+func effectiveCodexSessionStoreScope(resolvedScope, issueID string) string {
+	if resolvedScope != "" {
+		return resolvedScope
 	}
 	return issueID
 }

--- a/server/internal/daemon/execenv/codex_home_sessions_test.go
+++ b/server/internal/daemon/execenv/codex_home_sessions_test.go
@@ -467,6 +467,42 @@ func TestPrepareCodexSessionsDir_QuickCreateHandoffAcrossIssueBoundary(t *testin
 	}
 }
 
+// Managed tasks reuse one CODEX_HOME with an authoritative real sessions
+// directory. A quick-create scope must remain inert on that path: changing from
+// no issue id to an issue id cannot hide the source rollout.
+func TestPrepareCodexSessionsDir_ManagedQuickCreateHandoffKeepsRollout(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	sharedHome := filepath.Join(root, "shared")
+	codexHome := filepath.Join(root, "managed-task", "codex-home")
+	if err := os.MkdirAll(codexHome, 0o755); err != nil {
+		t.Fatalf("mkdir codex home: %v", err)
+	}
+	const (
+		agentID = "agent-managed-quick-create"
+		issueID = "019f59d9-a6aa-7a53-b173-1eccc4b4c873"
+		scope   = "qc_019f59d9-a6aa-7a53-b173-1eccc4b4c874"
+		session = "019f59d9-a6aa-7a53-b173-1eccc4b4c875"
+	)
+	sourceKey := codexSessionStoreKey("", agentID, ResolveCodexSessionStoreScope(scope, ""))
+	if err := prepareCodexSessionsDir(codexHome, sharedHome, CodexHomeOptions{SessionStoreKey: sourceKey}, testLogger()); err != nil {
+		t.Fatalf("prepare source home: %v", err)
+	}
+	seedRolloutAt(t, filepath.Join(codexHome, "sessions", "2026", "08", "05", "rollout-2026-08-05T00-00-00-"+session+".jsonl"), 32)
+
+	issueKey := codexSessionStoreKey("", agentID, ResolveCodexSessionStoreScope(scope, issueID))
+	if err := prepareCodexSessionsDir(codexHome, sharedHome, CodexHomeOptions{SessionStoreKey: issueKey, ResumeSessionID: session}, testLogger()); err != nil {
+		t.Fatalf("prepare reused issue home: %v", err)
+	}
+	if !CodexResumeRolloutPresent(codexHome, session) {
+		t.Fatal("managed issue task cannot see quick-create source rollout")
+	}
+	if fi, err := os.Lstat(filepath.Join(codexHome, "sessions")); err != nil || !fi.IsDir() || fi.Mode()&os.ModeSymlink != 0 {
+		t.Fatalf("managed sessions must remain an authoritative real directory, fi=%v err=%v", fi, err)
+	}
+}
+
 // A managed home migrated on a prior reuse already links the per-issue store; a
 // subsequent reuse must treat that link as authoritative and not re-migrate it.
 func TestPrepareCodexSessionsDir_ReusedStoreLinkIsAuthoritative(t *testing.T) {
@@ -512,16 +548,18 @@ func TestPruneCodexSessionStores(t *testing.T) {
 	storeRoot := filepath.Join(home, codexSessionStoreRoot, codexSessionStoreNamespace(""))
 
 	freshStore := filepath.Join(storeRoot, "agent-1", "issue-fresh")
-	staleStore := filepath.Join(storeRoot, "agent-1", "issue-stale")
+	orphanQuickCreateStore := filepath.Join(storeRoot, "agent-1", "qc_019f59d9-a6aa-7a53-b173-1eccc4b4c874")
 	otherStore := filepath.Join(storeRoot, "agent-2", "issue-x")
 	seedRolloutAt(t, filepath.Join(freshStore, "2026", "07", "14", "rollout-2026-07-14T00-00-00-a.jsonl"), 16)
-	seedRolloutAt(t, filepath.Join(staleStore, "2026", "06", "01", "rollout-2026-06-01T00-00-00-b.jsonl"), 16)
+	seedRolloutAt(t, filepath.Join(orphanQuickCreateStore, "2026", "06", "01", "rollout-2026-06-01T00-00-00-b.jsonl"), 16)
 	seedRolloutAt(t, filepath.Join(otherStore, "2026", "07", "14", "rollout-2026-07-14T00-00-00-c.jsonl"), 16)
 
 	now := time.Now()
 	retention := 14 * 24 * time.Hour
-	// Age only the stale store's whole tree well past retention.
-	chtimesTree(t, staleStore, now.Add(-30*24*time.Hour))
+	// A failed quick-create can leave this scoped store without an issue. It is
+	// retained for the normal 14-day recovery window, then reclaimed like any
+	// other idle conversation store.
+	chtimesTree(t, orphanQuickCreateStore, now.Add(-30*24*time.Hour))
 
 	removed, bytes := PruneCodexSessionStores("", retention, now, nil, testLogger())
 	if removed != 1 {
@@ -530,9 +568,9 @@ func TestPruneCodexSessionStores(t *testing.T) {
 	if bytes <= 0 {
 		t.Errorf("bytesFreed = %d, want > 0", bytes)
 	}
-	// The stale store is gone; the fresh one and the other agent's store survive
-	// (per-issue isolation), and agent-1 stays because issue-fresh remains.
-	assertAbsent(t, staleStore)
+	// The orphan is gone; the fresh one and the other agent's store survive
+	// (per-scope isolation), and agent-1 stays because issue-fresh remains.
+	assertAbsent(t, orphanQuickCreateStore)
 	assertPresent(t, freshStore)
 	assertPresent(t, otherStore)
 	assertPresent(t, filepath.Join(storeRoot, "agent-1"))

--- a/server/internal/daemon/execenv/codex_home_sessions_test.go
+++ b/server/internal/daemon/execenv/codex_home_sessions_test.go
@@ -426,6 +426,47 @@ func TestPrepareCodexSessionsDir_LocalDirectoryResumeAcrossTaskIDs(t *testing.T)
 	}
 }
 
+// A quick-create source has no issue id, while the issue task it creates does.
+// The explicit origin scope must make both fresh local_directory homes mount
+// the same store so the second task can actually resolve the first rollout.
+func TestPrepareCodexSessionsDir_QuickCreateHandoffAcrossIssueBoundary(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	sharedHome := filepath.Join(root, "shared")
+	const (
+		agentID = "agent-quick-create"
+		issueID = "019f59d9-a6aa-7a53-b173-1eccc4b4c873"
+		scope   = "qc_019f59d9-a6aa-7a53-b173-1eccc4b4c874"
+		session = "019f59d9-a6aa-7a53-b173-1eccc4b4c875"
+	)
+	sourceKey := codexSessionStoreKey("", agentID, ResolveCodexSessionStoreScope(scope, ""))
+	issueKey := codexSessionStoreKey("", agentID, ResolveCodexSessionStoreScope(scope, issueID))
+	if sourceKey != issueKey {
+		t.Fatalf("quick-create handoff keys differ: source=%q issue=%q", sourceKey, issueKey)
+	}
+
+	sourceHome := filepath.Join(root, "source-task", "codex-home")
+	if err := os.MkdirAll(sourceHome, 0o755); err != nil {
+		t.Fatalf("mkdir source home: %v", err)
+	}
+	if err := prepareCodexSessionsDir(sourceHome, sharedHome, CodexHomeOptions{IsLocalDirectory: true, SessionStoreKey: sourceKey}, testLogger()); err != nil {
+		t.Fatalf("prepare source home: %v", err)
+	}
+	seedRolloutAt(t, filepath.Join(sourceHome, "sessions", "2026", "08", "05", "rollout-2026-08-05T00-00-00-"+session+".jsonl"), 32)
+
+	issueHome := filepath.Join(root, "issue-task", "codex-home")
+	if err := os.MkdirAll(issueHome, 0o755); err != nil {
+		t.Fatalf("mkdir issue home: %v", err)
+	}
+	if err := prepareCodexSessionsDir(issueHome, sharedHome, CodexHomeOptions{IsLocalDirectory: true, SessionStoreKey: issueKey, ResumeSessionID: session}, testLogger()); err != nil {
+		t.Fatalf("prepare issue home: %v", err)
+	}
+	if !CodexResumeRolloutPresent(issueHome, session) {
+		t.Fatal("first issue task cannot see quick-create source rollout")
+	}
+}
+
 // A managed home migrated on a prior reuse already links the per-issue store; a
 // subsequent reuse must treat that link as authoritative and not re-migrate it.
 func TestPrepareCodexSessionsDir_ReusedStoreLinkIsAuthoritative(t *testing.T) {
@@ -637,6 +678,37 @@ func TestCodexSessionStoreNamespace_FitsDirectorySegment(t *testing.T) {
 		if err := os.MkdirAll(filepath.Join(base, ns), 0o755); err != nil {
 			t.Errorf("namespace for profile (len %d) could not be created: %v", len(profile), err)
 		}
+	}
+}
+
+func TestResolveCodexSessionStoreScope(t *testing.T) {
+	t.Parallel()
+
+	const (
+		issueID = "019f59d9-a6aa-7a53-b173-1eccc4b4c873"
+		quickID = "qc_019f59d9-a6aa-7a53-b173-1eccc4b4c874"
+	)
+	for _, tc := range []struct {
+		name     string
+		explicit string
+		want     string
+	}{
+		{name: "quick-create scope", explicit: quickID, want: quickID},
+		{name: "old server omitted field", explicit: "", want: issueID},
+		{name: "path separator rejected", explicit: "qc_bad/scope", want: issueID},
+		{name: "punctuation rejected", explicit: "qc_bad:scope", want: issueID},
+		{name: "overlong segment rejected", explicit: strings.Repeat("q", 256), want: issueID},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := ResolveCodexSessionStoreScope(tc.explicit, issueID); got != tc.want {
+				t.Fatalf("ResolveCodexSessionStoreScope(%q, %q) = %q, want %q", tc.explicit, issueID, got, tc.want)
+			}
+		})
+	}
+
+	key := codexSessionStoreKey("", "agent-1", quickID)
+	if filepath.Base(key) != quickID {
+		t.Fatalf("quick-create scope must remain one exact path segment, key = %q", key)
 	}
 }
 

--- a/server/internal/daemon/execenv/execenv.go
+++ b/server/internal/daemon/execenv/execenv.go
@@ -40,12 +40,17 @@ type PrepareParams struct {
 	TaskID         string // task UUID — used for directory name
 	AgentName      string // for git branch naming only
 	// Profile is the daemon's profile name (empty = default). It namespaces the
-	// per-issue Codex session store so a second profile-daemon sharing the same
+	// scoped Codex session store so a second profile-daemon sharing the same
 	// ~/.codex cannot see or GC this daemon's stores (MUL-4424).
-	Profile      string
-	Provider     string // agent provider (determines runtime config and skill injection paths)
-	CodexVersion string // detected Codex CLI version (only used when Provider == "codex")
-	OpenclawBin  string // resolved openclaw CLI path (only used when Provider == "openclaw"); empty = look up on PATH
+	Profile string
+	// SessionStoreScope optionally overrides Task.IssueID as the stable Codex
+	// rollout-store scope. Quick-create handoffs use their origin task id so the
+	// source and created issue share one store. Empty preserves the issue-id
+	// behavior for old callers.
+	SessionStoreScope string
+	Provider          string // agent provider (determines runtime config and skill injection paths)
+	CodexVersion      string // detected Codex CLI version (only used when Provider == "codex")
+	OpenclawBin       string // resolved openclaw CLI path (only used when Provider == "openclaw"); empty = look up on PATH
 	// McpConfig is the agent's saved `mcp_config` JSON, forwarded to the
 	// provider-specific config preparer when that provider materialises MCP
 	// via a per-task config file. Cursor and OpenClaw consume it here; other
@@ -343,7 +348,7 @@ func Prepare(params PrepareParams, logger *slog.Logger) (*Environment, error) {
 	// For Codex, set up a per-task CODEX_HOME seeded from ~/.codex/ with skills.
 	if params.Provider == "codex" {
 		codexHome := filepath.Join(envRoot, codexHomeDirName)
-		if err := prepareCodexHomeWithOpts(codexHome, CodexHomeOptions{CodexVersion: params.CodexVersion, IsLocalDirectory: params.LocalWorkDir != "", SessionStoreKey: codexSessionStoreKey(params.Profile, params.Task.AgentID, params.Task.IssueID), CodexCustomArgs: params.CodexCustomArgs}, logger); err != nil {
+		if err := prepareCodexHomeWithOpts(codexHome, CodexHomeOptions{CodexVersion: params.CodexVersion, IsLocalDirectory: params.LocalWorkDir != "", SessionStoreKey: codexSessionStoreKey(params.Profile, params.Task.AgentID, ResolveCodexSessionStoreScope(params.SessionStoreScope, params.Task.IssueID)), CodexCustomArgs: params.CodexCustomArgs}, logger); err != nil {
 			return nil, fmt.Errorf("execenv: prepare codex-home: %w", err)
 		}
 		if err := hydrateCodexSkills(codexHome, params.Task.AgentSkills, params.Task.DisabledRuntimeSkills, logger); err != nil {
@@ -452,9 +457,11 @@ type ReuseParams struct {
 	// agent picks up any runtime_config changes saved since the prior run.
 	OpenclawGateway OpenclawGatewayPin
 	// Profile is the daemon's profile name (empty = default), mirroring
-	// PrepareParams.Profile so a reused task keys its per-issue Codex session
+	// PrepareParams.Profile so a reused task keys its scoped Codex session
 	// store into the same profile namespace (MUL-4424).
 	Profile string
+	// SessionStoreScope mirrors PrepareParams.SessionStoreScope on reuse.
+	SessionStoreScope string
 	// LocalDirectory is true when the reused WorkDir is a user-supplied
 	// directory (the local_directory flow). The flag is propagated into
 	// the returned Environment so downstream callers (notably the GC
@@ -566,7 +573,7 @@ func Reuse(params ReuseParams, logger *slog.Logger) *Environment {
 	// config (especially sandbox/network access) is up to date.
 	if params.Provider == "codex" {
 		codexHome := filepath.Join(env.RootDir, codexHomeDirName)
-		if err := prepareCodexHomeWithOpts(codexHome, CodexHomeOptions{CodexVersion: params.CodexVersion, ResumeSessionID: params.ResumeSessionID, IsLocalDirectory: params.LocalDirectory, SessionStoreKey: codexSessionStoreKey(params.Profile, params.Task.AgentID, params.Task.IssueID), CodexCustomArgs: params.CodexCustomArgs}, logger); err != nil {
+		if err := prepareCodexHomeWithOpts(codexHome, CodexHomeOptions{CodexVersion: params.CodexVersion, ResumeSessionID: params.ResumeSessionID, IsLocalDirectory: params.LocalDirectory, SessionStoreKey: codexSessionStoreKey(params.Profile, params.Task.AgentID, ResolveCodexSessionStoreScope(params.SessionStoreScope, params.Task.IssueID)), CodexCustomArgs: params.CodexCustomArgs}, logger); err != nil {
 			logger.Warn("execenv: refresh codex-home failed", "error", err)
 		} else {
 			env.CodexHome = codexHome

--- a/server/internal/daemon/execenv/execenv.go
+++ b/server/internal/daemon/execenv/execenv.go
@@ -43,10 +43,10 @@ type PrepareParams struct {
 	// scoped Codex session store so a second profile-daemon sharing the same
 	// ~/.codex cannot see or GC this daemon's stores (MUL-4424).
 	Profile string
-	// SessionStoreScope is the stable Codex rollout-store scope resolved by the
-	// daemon task boundary. Quick-create handoffs use their origin task id so the
+	// SessionStoreScope optionally overrides Task.IssueID as the stable Codex
+	// rollout-store scope. Quick-create handoffs use their origin task id so the
 	// source and created issue share one store. Empty preserves the issue-id
-	// behavior for old/direct callers.
+	// behavior for old callers.
 	SessionStoreScope string
 	Provider          string // agent provider (determines runtime config and skill injection paths)
 	CodexVersion      string // detected Codex CLI version (only used when Provider == "codex")
@@ -348,7 +348,7 @@ func Prepare(params PrepareParams, logger *slog.Logger) (*Environment, error) {
 	// For Codex, set up a per-task CODEX_HOME seeded from ~/.codex/ with skills.
 	if params.Provider == "codex" {
 		codexHome := filepath.Join(envRoot, codexHomeDirName)
-		if err := prepareCodexHomeWithOpts(codexHome, CodexHomeOptions{CodexVersion: params.CodexVersion, IsLocalDirectory: params.LocalWorkDir != "", SessionStoreKey: codexSessionStoreKey(params.Profile, params.Task.AgentID, effectiveCodexSessionStoreScope(params.SessionStoreScope, params.Task.IssueID)), CodexCustomArgs: params.CodexCustomArgs}, logger); err != nil {
+		if err := prepareCodexHomeWithOpts(codexHome, CodexHomeOptions{CodexVersion: params.CodexVersion, IsLocalDirectory: params.LocalWorkDir != "", SessionStoreKey: codexSessionStoreKey(params.Profile, params.Task.AgentID, ResolveCodexSessionStoreScope(params.SessionStoreScope, params.Task.IssueID)), CodexCustomArgs: params.CodexCustomArgs}, logger); err != nil {
 			return nil, fmt.Errorf("execenv: prepare codex-home: %w", err)
 		}
 		if err := hydrateCodexSkills(codexHome, params.Task.AgentSkills, params.Task.DisabledRuntimeSkills, logger); err != nil {
@@ -573,7 +573,7 @@ func Reuse(params ReuseParams, logger *slog.Logger) *Environment {
 	// config (especially sandbox/network access) is up to date.
 	if params.Provider == "codex" {
 		codexHome := filepath.Join(env.RootDir, codexHomeDirName)
-		if err := prepareCodexHomeWithOpts(codexHome, CodexHomeOptions{CodexVersion: params.CodexVersion, ResumeSessionID: params.ResumeSessionID, IsLocalDirectory: params.LocalDirectory, SessionStoreKey: codexSessionStoreKey(params.Profile, params.Task.AgentID, effectiveCodexSessionStoreScope(params.SessionStoreScope, params.Task.IssueID)), CodexCustomArgs: params.CodexCustomArgs}, logger); err != nil {
+		if err := prepareCodexHomeWithOpts(codexHome, CodexHomeOptions{CodexVersion: params.CodexVersion, ResumeSessionID: params.ResumeSessionID, IsLocalDirectory: params.LocalDirectory, SessionStoreKey: codexSessionStoreKey(params.Profile, params.Task.AgentID, ResolveCodexSessionStoreScope(params.SessionStoreScope, params.Task.IssueID)), CodexCustomArgs: params.CodexCustomArgs}, logger); err != nil {
 			logger.Warn("execenv: refresh codex-home failed", "error", err)
 		} else {
 			env.CodexHome = codexHome

--- a/server/internal/daemon/execenv/execenv.go
+++ b/server/internal/daemon/execenv/execenv.go
@@ -43,10 +43,10 @@ type PrepareParams struct {
 	// scoped Codex session store so a second profile-daemon sharing the same
 	// ~/.codex cannot see or GC this daemon's stores (MUL-4424).
 	Profile string
-	// SessionStoreScope optionally overrides Task.IssueID as the stable Codex
-	// rollout-store scope. Quick-create handoffs use their origin task id so the
+	// SessionStoreScope is the stable Codex rollout-store scope resolved by the
+	// daemon task boundary. Quick-create handoffs use their origin task id so the
 	// source and created issue share one store. Empty preserves the issue-id
-	// behavior for old callers.
+	// behavior for old/direct callers.
 	SessionStoreScope string
 	Provider          string // agent provider (determines runtime config and skill injection paths)
 	CodexVersion      string // detected Codex CLI version (only used when Provider == "codex")
@@ -348,7 +348,7 @@ func Prepare(params PrepareParams, logger *slog.Logger) (*Environment, error) {
 	// For Codex, set up a per-task CODEX_HOME seeded from ~/.codex/ with skills.
 	if params.Provider == "codex" {
 		codexHome := filepath.Join(envRoot, codexHomeDirName)
-		if err := prepareCodexHomeWithOpts(codexHome, CodexHomeOptions{CodexVersion: params.CodexVersion, IsLocalDirectory: params.LocalWorkDir != "", SessionStoreKey: codexSessionStoreKey(params.Profile, params.Task.AgentID, ResolveCodexSessionStoreScope(params.SessionStoreScope, params.Task.IssueID)), CodexCustomArgs: params.CodexCustomArgs}, logger); err != nil {
+		if err := prepareCodexHomeWithOpts(codexHome, CodexHomeOptions{CodexVersion: params.CodexVersion, IsLocalDirectory: params.LocalWorkDir != "", SessionStoreKey: codexSessionStoreKey(params.Profile, params.Task.AgentID, effectiveCodexSessionStoreScope(params.SessionStoreScope, params.Task.IssueID)), CodexCustomArgs: params.CodexCustomArgs}, logger); err != nil {
 			return nil, fmt.Errorf("execenv: prepare codex-home: %w", err)
 		}
 		if err := hydrateCodexSkills(codexHome, params.Task.AgentSkills, params.Task.DisabledRuntimeSkills, logger); err != nil {
@@ -573,7 +573,7 @@ func Reuse(params ReuseParams, logger *slog.Logger) *Environment {
 	// config (especially sandbox/network access) is up to date.
 	if params.Provider == "codex" {
 		codexHome := filepath.Join(env.RootDir, codexHomeDirName)
-		if err := prepareCodexHomeWithOpts(codexHome, CodexHomeOptions{CodexVersion: params.CodexVersion, ResumeSessionID: params.ResumeSessionID, IsLocalDirectory: params.LocalDirectory, SessionStoreKey: codexSessionStoreKey(params.Profile, params.Task.AgentID, ResolveCodexSessionStoreScope(params.SessionStoreScope, params.Task.IssueID)), CodexCustomArgs: params.CodexCustomArgs}, logger); err != nil {
+		if err := prepareCodexHomeWithOpts(codexHome, CodexHomeOptions{CodexVersion: params.CodexVersion, ResumeSessionID: params.ResumeSessionID, IsLocalDirectory: params.LocalDirectory, SessionStoreKey: codexSessionStoreKey(params.Profile, params.Task.AgentID, effectiveCodexSessionStoreScope(params.SessionStoreScope, params.Task.IssueID)), CodexCustomArgs: params.CodexCustomArgs}, logger); err != nil {
 			logger.Warn("execenv: refresh codex-home failed", "error", err)
 		} else {
 			env.CodexHome = codexHome

--- a/server/internal/daemon/leader_workdir_reuse_test.go
+++ b/server/internal/daemon/leader_workdir_reuse_test.go
@@ -99,24 +99,6 @@ func TestShouldReusePriorWorkdirNonLeaderReusesUnchanged(t *testing.T) {
 	}
 }
 
-// A managed-runtime quick-create handoff continues to use the existing workdir
-// reuse path. The new scoped Codex store is only material to local_directory;
-// it must not turn managed follow-ups into fresh environments.
-func TestShouldReusePriorWorkdirQuickCreateManaged(t *testing.T) {
-	t.Parallel()
-
-	root := t.TempDir()
-	prior := filepath.Join(root, "managed", "quick-create", "workdir")
-	task := leaderReuseTestTask("task-quick-create-managed")
-	task.IsLeaderTask = false
-	task.SessionStoreScope = "qc_019f59d9-a6aa-7a53-b173-1eccc4b4c874"
-	task.PriorSessionID = "quick-create-session"
-	task.PriorWorkDir = prior
-	if !shouldReusePriorWorkdir(task, nil, root) {
-		t.Fatal("managed quick-create follow-up must reuse its prior workdir")
-	}
-}
-
 // TestShouldReusePriorWorkdirSquadLeaderAcceptsManagedProvenance is the unit
 // positive: managed shape + matching Prepare-time provenance + matching marker.
 func TestShouldReusePriorWorkdirSquadLeaderAcceptsManagedProvenance(t *testing.T) {

--- a/server/internal/daemon/leader_workdir_reuse_test.go
+++ b/server/internal/daemon/leader_workdir_reuse_test.go
@@ -99,6 +99,24 @@ func TestShouldReusePriorWorkdirNonLeaderReusesUnchanged(t *testing.T) {
 	}
 }
 
+// A managed-runtime quick-create handoff continues to use the existing workdir
+// reuse path. The new scoped Codex store is only material to local_directory;
+// it must not turn managed follow-ups into fresh environments.
+func TestShouldReusePriorWorkdirQuickCreateManaged(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	prior := filepath.Join(root, "managed", "quick-create", "workdir")
+	task := leaderReuseTestTask("task-quick-create-managed")
+	task.IsLeaderTask = false
+	task.SessionStoreScope = "qc_019f59d9-a6aa-7a53-b173-1eccc4b4c874"
+	task.PriorSessionID = "quick-create-session"
+	task.PriorWorkDir = prior
+	if !shouldReusePriorWorkdir(task, nil, root) {
+		t.Fatal("managed quick-create follow-up must reuse its prior workdir")
+	}
+}
+
 // TestShouldReusePriorWorkdirSquadLeaderAcceptsManagedProvenance is the unit
 // positive: managed shape + matching Prepare-time provenance + matching marker.
 func TestShouldReusePriorWorkdirSquadLeaderAcceptsManagedProvenance(t *testing.T) {

--- a/server/internal/daemon/types.go
+++ b/server/internal/daemon/types.go
@@ -78,6 +78,7 @@ type Task struct {
 	IsLeaderTask                  bool                   `json:"is_leader_task,omitempty"`                   // true when executing in the squad-leader coordinator role
 	PriorSessionID                string                 `json:"prior_session_id,omitempty"`                 // Claude session ID from a previous task on this issue
 	PriorWorkDir                  string                 `json:"prior_work_dir,omitempty"`                   // work_dir from a previous task on this issue
+	SessionStoreScope             string                 `json:"session_store_scope,omitempty"`              // optional stable Codex rollout-store scope; absent on old servers, then IssueID remains the fallback
 	PriorSessionResumeUnavailable bool                   `json:"prior_session_resume_unavailable,omitempty"` // MUL-5305: server signals a more recent Codex session was withheld (rollout missing) and PriorSessionID (if any) is an older fallback; the run must disclose the continuity gap even if that older session resumes cleanly. Absent/false on old servers.
 	TriggerCommentID              string                 `json:"trigger_comment_id,omitempty"`               // comment that triggered this task
 	CoalescedCommentIDs           []string               `json:"coalesced_comment_ids,omitempty"`            // MUL-4195: earlier comments folded into this run while it was still queued; the agent must address these in addition to the (newest) triggering comment. Empty for old servers / non-merged runs

--- a/server/internal/handler/agent.go
+++ b/server/internal/handler/agent.go
@@ -315,6 +315,11 @@ type AgentTaskResponse struct {
 	CreatedAt          string                `json:"created_at"`
 	PriorSessionID     string                `json:"prior_session_id,omitempty"` // session ID from a previous task on same issue
 	PriorWorkDir       string                `json:"prior_work_dir,omitempty"`   // work_dir from a previous task on same issue
+	// SessionStoreScope is an optional stable filesystem scope for Codex
+	// rollouts. Quick-create handoffs use the origin task id so the no-issue
+	// source task and the first issue task mount the same persistent store.
+	// Older daemons ignore it; newer daemons fall back to IssueID when absent.
+	SessionStoreScope string `json:"session_store_scope,omitempty"`
 	// PriorSessionResumeUnavailable is set when a more recent Codex session was
 	// withheld because its rollout was missing (MUL-5305); PriorSessionID (if
 	// any) is then an older fallback. The daemon surfaces the continuity gap in

--- a/server/internal/handler/daemon.go
+++ b/server/internal/handler/daemon.go
@@ -1625,6 +1625,24 @@ type claimBuildFailure struct {
 	message string
 }
 
+const quickCreateSessionStorePrefix = "qc_"
+
+func quickCreateSessionStoreScope(originTaskID pgtype.UUID) string {
+	if !originTaskID.Valid {
+		return ""
+	}
+	return quickCreateSessionStorePrefix + uuidToString(originTaskID)
+}
+
+func quickCreateOriginIsTerminal(status string) bool {
+	switch status {
+	case "completed", "failed", "cancelled":
+		return true
+	default:
+		return false
+	}
+}
+
 // buildClaimedTaskResponse assembles the full daemon claim payload for a
 // single already-claimed task and computes the exact comment ids embedded in
 // it (deliveredCommentIDs). Shared by the per-runtime handler
@@ -1753,10 +1771,22 @@ func (h *Handler) buildClaimedTaskResponse(r *http.Request, task *db.AgentTaskQu
 	// project explicitly attached its repos, those are the authoritative set
 	// for issues inside that project. When the project has no github_repo
 	// resources (or no project at all), we fall back to the workspace repos.
+	var quickCreateOrigin *db.AgentTaskQueue
 	if task.IssueID.Valid {
 		if issue, err := h.Queries.GetIssue(r.Context(), task.IssueID); err == nil {
 			resp.WorkspaceID = uuidToString(issue.WorkspaceID)
 			resp.ThreadName = issue.Title
+			if issue.OriginType.Valid && issue.OriginType.String == service.QuickCreateContextType && issue.OriginID.Valid {
+				resp.SessionStoreScope = quickCreateSessionStoreScope(issue.OriginID)
+				// The origin id is server-stamped, but re-check the carrier agent
+				// before using its session. An issue reassigned to another agent
+				// keeps the same opaque scope under a DIFFERENT agent directory and
+				// starts fresh; it must never inherit the creator's conversation.
+				if origin, originErr := h.Queries.GetAgentTask(r.Context(), issue.OriginID); originErr == nil && origin.AgentID == task.AgentID {
+					originCopy := origin
+					quickCreateOrigin = &originCopy
+				}
+			}
 
 			// Squad-leader briefing injection: keyed off the task being a
 			// leader-task (is_leader_task) carrying a squad_id — NOT off the
@@ -2071,15 +2101,37 @@ func (h *Handler) buildClaimedTaskResponse(r *http.Request, task *db.AgentTaskQu
 			// context across turns. The "Focus on THIS comment" guard in
 			// prompt.go defends against inheriting the prior turn's "Done."
 			// marker, and GetLastTaskSession already excludes poisoned sessions.
+			priorFound := false
 			if prior, err := h.Queries.GetLastTaskSession(r.Context(), db.GetLastTaskSessionParams{
 				AgentID: task.AgentID,
 				IssueID: task.IssueID,
 			}); err == nil && prior.SessionID.Valid {
+				priorFound = true
 				if prior.RuntimeID == task.RuntimeID {
 					resp.PriorSessionID = prior.SessionID.String
 				}
 				if prior.WorkDir.Valid {
 					resp.PriorWorkDir = prior.WorkDir.String
+				}
+			}
+			// The quick-create completion path links its task to the new issue
+			// after the terminal write. A first issue claim can land in that small
+			// window, so fall back to the issue's exact origin row instead of
+			// relying only on the (agent, issue) lookup. The bounded claim delay
+			// keeps active origins out of this path; the terminal check is defense
+			// in depth and makes a timed-out delay degrade to a fresh session.
+			if !priorFound && quickCreateOrigin != nil && quickCreateOriginIsTerminal(quickCreateOrigin.Status) {
+				src := *quickCreateOrigin
+				if src.SessionRolloutMissing {
+					resp.PriorSessionResumeUnavailable = true
+				}
+				if !service.ResumeUnsafeFailure(src.FailureReason.String, src.Error.String) && src.SessionID.Valid {
+					if src.WorkDir.Valid {
+						resp.PriorWorkDir = src.WorkDir.String
+					}
+					if src.RuntimeID == task.RuntimeID {
+						resp.PriorSessionID = src.SessionID.String
+					}
 				}
 			}
 			// MUL-5305: if the most recent terminal task withheld its Codex
@@ -2371,6 +2423,7 @@ func (h *Handler) buildClaimedTaskResponse(r *http.Request, task *db.AgentTaskQu
 		var qc service.QuickCreateContext
 		if json.Unmarshal(task.Context, &qc) == nil && qc.Type == service.QuickCreateContextType {
 			hasQuickCreate = true
+			resp.SessionStoreScope = quickCreateSessionStoreScope(task.ID)
 			resp.QuickCreatePrompt = qc.Prompt
 			resp.QuickCreatePriority = qc.Priority
 			resp.QuickCreateDueDate = qc.DueDate

--- a/server/internal/handler/daemon_test.go
+++ b/server/internal/handler/daemon_test.go
@@ -4065,6 +4065,39 @@ func TestClaimTask_QuickCreateHandoffWaitIsBounded(t *testing.T) {
 		t.Fatalf("active handoff claimed task %s before wait bound", uuidToString(claimed.ID))
 	}
 
+	// The delayed handoff is filtered before ORDER BY/LIMIT, so a lower-priority
+	// unrelated task for the same agent must still run instead of sitting behind
+	// the handoff at the head of the queue.
+	var unrelatedIssueID string
+	if err := testPool.QueryRow(ctx, `
+		INSERT INTO issue (
+			workspace_id, title, creator_type, creator_id,
+			assignee_type, assignee_id, priority, number
+		)
+		VALUES (
+			$1, 'Unrelated task behind quick-create handoff', 'agent', $2,
+			'agent', $2, 'low',
+			(SELECT COALESCE(MAX(number), 0) + 1 FROM issue WHERE workspace_id = $1)
+		)
+		RETURNING id
+	`, testWorkspaceID, fixture.agentID).Scan(&unrelatedIssueID); err != nil {
+		t.Fatalf("setup: create unrelated issue: %v", err)
+	}
+	t.Cleanup(func() { testPool.Exec(ctx, `DELETE FROM issue WHERE id = $1`, unrelatedIssueID) })
+
+	var unrelatedTaskID string
+	if err := testPool.QueryRow(ctx, `
+		INSERT INTO agent_task_queue (agent_id, runtime_id, issue_id, status, priority)
+		VALUES ($1, $2, $3, 'queued', 0)
+		RETURNING id
+	`, fixture.agentID, fixture.runtimeID, unrelatedIssueID).Scan(&unrelatedTaskID); err != nil {
+		t.Fatalf("setup: create unrelated queued task: %v", err)
+	}
+	unrelated := claimTaskForRuntimeGuard(t, fixture.runtimeID, fixture.daemonID)
+	if unrelated.ID != unrelatedTaskID {
+		t.Fatalf("claimed task = %q, want unrelated task %q while handoff waits", unrelated.ID, unrelatedTaskID)
+	}
+
 	if _, err := testPool.Exec(ctx, `
 		UPDATE agent_task_queue SET created_at = now() - interval '10 minutes' WHERE id = $1
 	`, fixture.issueTaskID); err != nil {

--- a/server/internal/handler/daemon_test.go
+++ b/server/internal/handler/daemon_test.go
@@ -3146,8 +3146,10 @@ func TestCompleteTask_AssignmentTriggered_DoesNotSuppressTrivialDoneOutput(t *te
 }
 
 type claimRuntimeGuardTask struct {
+	ID                       string   `json:"id"`
 	PriorSessionID           string   `json:"prior_session_id"`
 	PriorWorkDir             string   `json:"prior_work_dir"`
+	SessionStoreScope        string   `json:"session_store_scope"`
 	ChatMessage              string   `json:"chat_message"`
 	ThreadName               string   `json:"thread_name"`
 	QuickCreateAttachmentIDs []string `json:"quick_create_attachment_ids"`
@@ -3920,10 +3922,12 @@ func TestClaimTask_QuickCreatePopulatesThreadName(t *testing.T) {
 		"attachment_ids": []string{attachmentID},
 	})
 
-	if _, err := testPool.Exec(ctx, `
+	var sourceTaskID string
+	if err := testPool.QueryRow(ctx, `
 		INSERT INTO agent_task_queue (agent_id, runtime_id, status, priority, context)
 		VALUES ($1, $2, 'queued', 2, $3)
-	`, agentID, runtimeID, quickContext); err != nil {
+		RETURNING id
+	`, agentID, runtimeID, quickContext).Scan(&sourceTaskID); err != nil {
 		t.Fatalf("setup: create quick-create task: %v", err)
 	}
 
@@ -3936,6 +3940,145 @@ func TestClaimTask_QuickCreatePopulatesThreadName(t *testing.T) {
 	}
 	if task.QuickCreatePriority != "high" || task.QuickCreateDueDate != "2026-08-01" {
 		t.Fatalf("quick-create fields = {%q, %q}, want {high, 2026-08-01}", task.QuickCreatePriority, task.QuickCreateDueDate)
+	}
+	if task.SessionStoreScope != "qc_"+sourceTaskID {
+		t.Fatalf("quick-create source session_store_scope = %q, want %q", task.SessionStoreScope, "qc_"+sourceTaskID)
+	}
+}
+
+type quickCreateHandoffFixture struct {
+	agentID     string
+	runtimeID   string
+	daemonID    string
+	originID    string
+	issueID     string
+	issueTaskID string
+}
+
+func createQuickCreateHandoffFixture(t *testing.T, ctx context.Context, originStatus string) quickCreateHandoffFixture {
+	t.Helper()
+
+	agentID, runtimeID, daemonID := createRuntimeGuardAgent(t, ctx)
+	quickContext, _ := json.Marshal(map[string]any{
+		"type":         "quick_create",
+		"prompt":       "create the handoff issue",
+		"requester_id": testUserID,
+		"workspace_id": testWorkspaceID,
+	})
+
+	var originID string
+	if err := testPool.QueryRow(ctx, `
+		INSERT INTO agent_task_queue (
+			agent_id, runtime_id, status, priority, context, started_at
+		)
+		VALUES ($1, $2, $3, 2, $4, CASE WHEN $3 = 'running' THEN now() ELSE NULL END)
+		RETURNING id
+	`, agentID, runtimeID, originStatus, quickContext).Scan(&originID); err != nil {
+		t.Fatalf("setup: create quick-create origin: %v", err)
+	}
+	if originStatus == "completed" {
+		if _, err := testPool.Exec(ctx, `
+			UPDATE agent_task_queue
+			SET started_at = now(), completed_at = now(),
+			    session_id = 'quick-create-session', work_dir = '/tmp/quick-create-origin'
+			WHERE id = $1
+		`, originID); err != nil {
+			t.Fatalf("setup: complete quick-create origin: %v", err)
+		}
+	}
+
+	var issueID string
+	if err := testPool.QueryRow(ctx, `
+		INSERT INTO issue (
+			workspace_id, title, creator_type, creator_id,
+			assignee_type, assignee_id, priority, number, origin_type, origin_id
+		)
+		VALUES (
+			$1, 'Quick-create handoff fixture', 'agent', $2,
+			'agent', $2, 'medium',
+			(SELECT COALESCE(MAX(number), 0) + 1 FROM issue WHERE workspace_id = $1),
+			'quick_create', $3
+		)
+		RETURNING id
+	`, testWorkspaceID, agentID, originID).Scan(&issueID); err != nil {
+		t.Fatalf("setup: create quick-created issue: %v", err)
+	}
+	t.Cleanup(func() { testPool.Exec(ctx, `DELETE FROM issue WHERE id = $1`, issueID) })
+
+	var issueTaskID string
+	if err := testPool.QueryRow(ctx, `
+		INSERT INTO agent_task_queue (agent_id, runtime_id, issue_id, status, priority)
+		VALUES ($1, $2, $3, 'queued', 2)
+		RETURNING id
+	`, agentID, runtimeID, issueID).Scan(&issueTaskID); err != nil {
+		t.Fatalf("setup: create first issue task: %v", err)
+	}
+
+	return quickCreateHandoffFixture{
+		agentID: agentID, runtimeID: runtimeID, daemonID: daemonID,
+		originID: originID, issueID: issueID, issueTaskID: issueTaskID,
+	}
+}
+
+// The quick-create completion transaction writes the terminal task before it
+// links that task to the newly created issue. The issue's immutable origin id
+// must bridge this tiny window so the first issue claim still resumes both the
+// provider session and the local_directory rollout store.
+func TestClaimTask_QuickCreateHandoffUsesOriginBeforeIssueLink(t *testing.T) {
+	if testHandler == nil {
+		t.Skip("database not available")
+	}
+
+	ctx := context.Background()
+	fixture := createQuickCreateHandoffFixture(t, ctx, "completed")
+	task := claimTaskForRuntimeGuard(t, fixture.runtimeID, fixture.daemonID)
+
+	if task.ID != fixture.issueTaskID {
+		t.Fatalf("claimed task = %q, want issue task %q", task.ID, fixture.issueTaskID)
+	}
+	if task.SessionStoreScope != "qc_"+fixture.originID {
+		t.Fatalf("session_store_scope = %q, want %q", task.SessionStoreScope, "qc_"+fixture.originID)
+	}
+	if task.PriorSessionID != "quick-create-session" {
+		t.Fatalf("prior_session_id = %q, want quick-create-session", task.PriorSessionID)
+	}
+	if task.PriorWorkDir != "/tmp/quick-create-origin" {
+		t.Fatalf("prior_work_dir = %q, want /tmp/quick-create-origin", task.PriorWorkDir)
+	}
+}
+
+// Active origins are soft-ordered ahead of their first issue task. The bound
+// is deliberate: if an origin wedges, the issue becomes claimable after the
+// handoff window and starts cold rather than remaining blocked forever.
+func TestClaimTask_QuickCreateHandoffWaitIsBounded(t *testing.T) {
+	if testHandler == nil {
+		t.Skip("database not available")
+	}
+
+	ctx := context.Background()
+	fixture := createQuickCreateHandoffFixture(t, ctx, "running")
+	claimed, err := testHandler.TaskService.ClaimTaskForRuntime(ctx, parseUUID(fixture.runtimeID))
+	if err != nil {
+		t.Fatalf("claim during active handoff: %v", err)
+	}
+	if claimed != nil {
+		t.Fatalf("active handoff claimed task %s before wait bound", uuidToString(claimed.ID))
+	}
+
+	if _, err := testPool.Exec(ctx, `
+		UPDATE agent_task_queue SET created_at = now() - interval '10 minutes' WHERE id = $1
+	`, fixture.issueTaskID); err != nil {
+		t.Fatalf("age issue task past handoff bound: %v", err)
+	}
+	task := claimTaskForRuntimeGuard(t, fixture.runtimeID, fixture.daemonID)
+	if task.ID != fixture.issueTaskID {
+		t.Fatalf("claimed task = %q, want aged issue task %q", task.ID, fixture.issueTaskID)
+	}
+	if task.SessionStoreScope != "qc_"+fixture.originID {
+		t.Fatalf("session_store_scope = %q, want %q", task.SessionStoreScope, "qc_"+fixture.originID)
+	}
+	if task.PriorSessionID != "" || task.PriorWorkDir != "" {
+		t.Fatalf("timed-out active origin must fall back cold, got session=%q workdir=%q", task.PriorSessionID, task.PriorWorkDir)
 	}
 }
 

--- a/server/internal/service/task.go
+++ b/server/internal/service/task.go
@@ -166,6 +166,11 @@ const (
 	// stretching this global crash-recovery window.
 	claimResponseRecoveryWindow = 90 * time.Second
 	prepareLeaseDuration        = 45 * time.Second
+	// quickCreateHandoffWait bounds the soft ordering between a quick-create
+	// origin and the first task of the issue it creates. While the origin is
+	// active, the queued issue task is skipped and retried by the daemon's normal
+	// poll loop; after this window it becomes claimable and safely starts fresh.
+	quickCreateHandoffWait = 2 * time.Minute
 )
 
 // buildCommentTriggerSummary fetches the comment content and truncates
@@ -2540,8 +2545,9 @@ func (s *TaskService) ClaimTask(ctx context.Context, agentID pgtype.UUID) (*db.A
 
 		t0 = time.Now()
 		task, err := qtx.ClaimAgentTask(ctx, db.ClaimAgentTaskParams{
-			AgentID:          agentID,
-			PrepareLeaseSecs: prepareLeaseDuration.Seconds(),
+			AgentID:                    agentID,
+			PrepareLeaseSecs:           prepareLeaseDuration.Seconds(),
+			QuickCreateHandoffWaitSecs: quickCreateHandoffWait.Seconds(),
 		})
 		claimAgentMs = time.Since(t0).Milliseconds()
 		if err != nil {

--- a/server/pkg/db/generated/agent.sql.go
+++ b/server/pkg/db/generated/agent.sql.go
@@ -1092,6 +1092,22 @@ SET status = 'dispatched',
 WHERE id = (
     SELECT atq.id FROM agent_task_queue atq
     WHERE atq.agent_id = $1 AND atq.status = 'queued'
+      -- Soft-order the first task of a quick-created issue behind its exact
+      -- origin task. The age bound prevents an orphaned/stuck origin from
+      -- blocking the issue forever; after it expires the task claims cold.
+      AND (
+          atq.created_at <= now() - make_interval(secs => $3::double precision)
+          OR NOT EXISTS (
+              SELECT 1
+              FROM issue handoff_issue
+              JOIN agent_task_queue origin ON origin.id = handoff_issue.origin_id
+              WHERE handoff_issue.id = atq.issue_id
+                AND handoff_issue.origin_type = 'quick_create'
+                AND origin.agent_id = atq.agent_id
+                AND origin.runtime_id = atq.runtime_id
+                AND origin.status IN ('queued', 'dispatched', 'running', 'waiting_local_directory')
+          )
+      )
       AND NOT EXISTS (
           SELECT 1 FROM agent_task_queue active
           WHERE active.agent_id = atq.agent_id
@@ -1117,8 +1133,9 @@ RETURNING id, agent_id, issue_id, status, priority, dispatched_at, started_at, c
 `
 
 type ClaimAgentTaskParams struct {
-	AgentID          pgtype.UUID `json:"agent_id"`
-	PrepareLeaseSecs float64     `json:"prepare_lease_secs"`
+	AgentID                    pgtype.UUID `json:"agent_id"`
+	PrepareLeaseSecs           float64     `json:"prepare_lease_secs"`
+	QuickCreateHandoffWaitSecs float64     `json:"quick_create_handoff_wait_secs"`
 }
 
 // Claims the next queued task for an agent, enforcing per-(issue, agent) serialization:
@@ -1131,7 +1148,7 @@ type ClaimAgentTaskParams struct {
 // otherwise a user mashing the create button could fire concurrent quick-creates
 // whose completion lookup would race over "most recent issue by this agent".
 func (q *Queries) ClaimAgentTask(ctx context.Context, arg ClaimAgentTaskParams) (AgentTaskQueue, error) {
-	row := q.db.QueryRow(ctx, claimAgentTask, arg.AgentID, arg.PrepareLeaseSecs)
+	row := q.db.QueryRow(ctx, claimAgentTask, arg.AgentID, arg.PrepareLeaseSecs, arg.QuickCreateHandoffWaitSecs)
 	var i AgentTaskQueue
 	err := row.Scan(
 		&i.ID,

--- a/server/pkg/db/queries/agent.sql
+++ b/server/pkg/db/queries/agent.sql
@@ -546,6 +546,22 @@ SET status = 'dispatched',
 WHERE id = (
     SELECT atq.id FROM agent_task_queue atq
     WHERE atq.agent_id = $1 AND atq.status = 'queued'
+      -- Soft-order the first task of a quick-created issue behind its exact
+      -- origin task. The age bound prevents an orphaned/stuck origin from
+      -- blocking the issue forever; after it expires the task claims cold.
+      AND (
+          atq.created_at <= now() - make_interval(secs => @quick_create_handoff_wait_secs::double precision)
+          OR NOT EXISTS (
+              SELECT 1
+              FROM issue handoff_issue
+              JOIN agent_task_queue origin ON origin.id = handoff_issue.origin_id
+              WHERE handoff_issue.id = atq.issue_id
+                AND handoff_issue.origin_type = 'quick_create'
+                AND origin.agent_id = atq.agent_id
+                AND origin.runtime_id = atq.runtime_id
+                AND origin.status IN ('queued', 'dispatched', 'running', 'waiting_local_directory')
+          )
+      )
       AND NOT EXISTS (
           SELECT 1 FROM agent_task_queue active
           WHERE active.agent_id = atq.agent_id


### PR DESCRIPTION
## Summary

- give a quick-create source task and its created issue a shared, filesystem-safe `qc_<origin_task_id>` Codex session-store scope
- soft-order the first issue task behind an active origin with a two-minute bound, then safely fall back to a fresh session
- recover the origin session during the completion/link race and use one scope resolver for both the mount and GC active-store guard

## Compatibility and safety

- the wire field is optional; mixed server/daemon versions retain the previous issue-ID fallback
- stores remain isolated by profile and agent, and reassignment never reuses another agent's session
- no schema migration; orphaned quick-create stores remain covered by the existing TTL GC

## Tests

- `go test -race ./internal/service ./internal/handler ./internal/daemon/...`
- added local-directory rollout handoff, bounded claim wait, path validation, race fallback, and managed-runtime regression coverage

Closes MUL-5764
Fixes #6427
