### PR TITLE
fix(chat): decouple the follow-up queue card from the composer chrome

### DIFF
--- a/packages/views/chat/chat-page.tsx
+++ b/packages/views/chat/chat-page.tsx
@@ -315,7 +315,6 @@ export function ChatPage() {
         onStop={c.handleStop}
         isRunning={!!c.pendingTaskId}
         allowSubmitWhileRunning={c.pendingTask?.supports_queue === true}
-        hasQueue={queuedTasks.length > 0}
         disabled={
           c.isSessionArchived || c.isAgentArchived || !c.isAgentRuntimeBound
         }

--- a/packages/views/chat/components/chat-input.test.tsx
+++ b/packages/views/chat/components/chat-input.test.tsx
@@ -663,21 +663,14 @@ describe("ChatInput project context", () => {
     expect(screen.queryByRole("button", { name: "Queue message" })).not.toBeInTheDocument();
   });
 
-  it("raises and rounds the composer above an attached queue", () => {
-    const { container } = renderInput({ hasQueue: true });
-
-    expect(container.firstElementChild).toHaveClass("relative", "z-10");
-    expect(container.querySelector('[data-slot="chat-input-surface"]')).toHaveClass(
-      "rounded-4xl",
-      "shadow-[var(--menu-shadow)]",
-    );
-  });
-
-  it("keeps the default composer chrome without an attached queue", () => {
-    const { container } = renderInput({ hasQueue: false });
+  it("keeps the composer chrome independent of the queue", () => {
+    // The follow-up queue tucks its bottom edge under the composer, which
+    // therefore ALWAYS paints on top (static z-10) — but the queue's presence
+    // must never restyle the input surface itself.
+    const { container } = renderInput();
     const surface = container.querySelector('[data-slot="chat-input-surface"]');
 
-    expect(container.firstElementChild).not.toHaveClass("relative", "z-10");
+    expect(container.firstElementChild).toHaveClass("relative", "z-10");
     expect(surface).toHaveClass("rounded-lg");
     expect(surface).not.toHaveClass(
       "rounded-4xl",

--- a/packages/views/chat/components/chat-input.tsx
+++ b/packages/views/chat/components/chat-input.tsx
@@ -89,11 +89,6 @@ interface ChatInputProps {
   isRunning?: boolean;
   /** Enabled only after the server explicitly advertises follow-up queues. */
   allowSubmitWhileRunning?: boolean;
-  /**
-   * Visually stacks the composer above the ChatGPT-style follow-up queue.
-   * Must use the same queued-task array and non-empty condition as ChatQueue.
-   */
-  hasQueue?: boolean;
   disabled?: boolean;
   /** True when the user has no agent available — disables the editor and
    *  surfaces a distinct placeholder. Kept separate from `disabled` so
@@ -142,7 +137,6 @@ export function ChatInput({
   onStop,
   isRunning,
   allowSubmitWhileRunning,
-  hasQueue,
   disabled,
   noAgent,
   agentArchived,
@@ -575,7 +569,10 @@ export function ChatInput({
         // spilling out of it.
         "flex max-h-[50%] min-h-0 flex-col pb-3 pt-0",
         CHAT_GUTTER,
-        hasQueue && "relative z-10",
+        // Static elevation, NOT queue-conditional: ChatQueue tucks its bottom
+        // edge under this surface (z-0 + negative margin on its side), and the
+        // composer simply always paints on top. Its own chrome never varies.
+        "relative z-10",
         // Outer wrapper carries the disabled cursor. Inner card sets
         // pointer-events-none, which suppresses hover (and therefore
         // any cursor of its own) — splitting the two layers lets hover
@@ -594,9 +591,6 @@ export function ChatInput({
           // then resolve to none).
           CHAT_COLUMN,
           "relative flex min-h-16 max-h-96 flex-col rounded-lg border border-surface-border bg-surface pb-9 transition-[border-color,box-shadow] focus-within:border-brand focus-within:ring-2 focus-within:ring-ring/20",
-          // The attached composer is the foreground card, so it intentionally
-          // uses a stronger shadow than ChatQueue's rear surface shadow.
-          hasQueue && "rounded-4xl shadow-[var(--menu-shadow)]",
           // Visual + interaction lock when there's no agent. We don't
           // toggle ContentEditor's editable mode (Tiptap can't switch
           // cleanly post-mount, and the prop has been removed); instead

--- a/packages/views/chat/components/chat-queue.test.tsx
+++ b/packages/views/chat/components/chat-queue.test.tsx
@@ -103,7 +103,7 @@ describe("ChatQueue", () => {
     }));
 
     const scroller = actions.container.querySelector('[data-slot="chat-queue-list"]');
-    expect(scroller).toHaveClass("max-h-48");
+    expect(scroller).toHaveClass("max-h-40");
 
     const clearTrigger = screen.getAllByLabelText("More queue actions")[0]!;
     fireEvent.click(clearTrigger);

--- a/packages/views/chat/components/chat-queue.test.tsx
+++ b/packages/views/chat/components/chat-queue.test.tsx
@@ -39,7 +39,7 @@ function renderQueue(headStatus = "running") {
 }
 
 describe("ChatQueue", () => {
-  it("matches the ChatGPT desktop queue chrome without a separate header", () => {
+  it("renders a standalone queue card without a separate header", () => {
     const { container } = renderQueue();
 
     expect(screen.getByRole("region", { name: "2 queued messages" })).toBeInTheDocument();
@@ -53,12 +53,14 @@ describe("ChatQueue", () => {
 
     const shell = container.querySelector('[data-slot="chat-queue-shell"]');
     const queue = container.querySelector('[data-slot="chat-queue"]');
-    expect(shell).toHaveClass("-mb-8");
+    // Tucked stack, owned entirely by the queue: it slides under the composer
+    // (negative margin + z-0) while the composer's chrome stays untouched.
+    expect(shell).toHaveClass("z-0", "-mb-3");
     expect(queue).toHaveClass(
-      "rounded-4xl",
+      "rounded-lg",
       "border-surface-border",
       "bg-surface",
-      "pb-10",
+      "pb-4",
     );
     expect(container.querySelectorAll('[data-slot="chat-queue-row"]')).toHaveLength(2);
     expect(container.querySelectorAll('[data-slot="chat-queue-item-icon"]')).toHaveLength(2);

--- a/packages/views/chat/components/chat-queue.tsx
+++ b/packages/views/chat/components/chat-queue.tsx
@@ -60,135 +60,145 @@ export function ChatQueue({
   return (
     <div
       data-slot="chat-queue-shell"
-      className={cn(CHAT_GUTTER, "relative z-0 -mb-8")}
+      // Tucked under the composer: the negative margin slides this card's
+      // bottom edge behind the (opaque, always z-10) composer surface, so the
+      // queue reads as emerging from behind the input. z-0 keeps it there even
+      // while the entrance animation's opacity/transform spawns a stacking
+      // context. The composer's own chrome never changes.
+      className={cn(CHAT_GUTTER, "relative z-0 -mb-3")}
       aria-live="polite"
       aria-busy={busyAction !== null}
     >
-      <section
-        data-slot="chat-queue"
-        aria-label={t(($) => $.queue.title, { count: tasks.length })}
-        className={cn(
-          CHAT_COLUMN,
-          // This is the rear card in the attached stack. The composer uses
-          // the stronger menu shadow so it reads as the foreground surface.
-          "overflow-hidden rounded-4xl border border-surface-border bg-surface pb-10 shadow-[var(--surface-shadow)]",
-        )}
-      >
-        <div
-          data-slot="chat-queue-list"
-          className="max-h-48 overflow-y-auto px-4 pt-3"
+      <div className={CHAT_COLUMN}>
+        <section
+          data-slot="chat-queue"
+          aria-label={t(($) => $.queue.title, { count: tasks.length })}
+          className={cn(
+            // Quiet secondary surface: border only, no shadow, so the composer
+            // below stays the visually dominant card. pb-4 = the 12px hidden
+            // behind the composer plus a visible 4px breathing room above it.
+            // mx-3 pulls the rear card in from the composer's edges so the
+            // stack reads as two distinct layers.
+            "mx-3 overflow-hidden rounded-lg border border-surface-border bg-surface pb-4",
+            "animate-in fade-in slide-in-from-bottom-2 duration-300",
+          )}
         >
-          {tasks.map((task) => {
-            const sendNowKey = `send-now:${task.task_id}`;
-            const editKey = `edit:${task.task_id}`;
-            const removeKey = `remove:${task.task_id}`;
-            const clearKey = `clear:${task.task_id}`;
-            return (
-              <div
-                key={task.task_id}
-                data-slot="chat-queue-row"
-                className="flex min-h-12 min-w-0 items-center gap-3 rounded-xl px-1 py-1 text-body"
-              >
-                <ListEnd
-                  data-slot="chat-queue-item-icon"
-                  className="size-5 shrink-0 text-faint-foreground"
-                  aria-hidden="true"
-                />
-                <span className="min-w-0 flex-1 truncate">
-                  {task.content?.trim() || t(($) => $.queue.fallback)}
-                </span>
-                <div className="flex shrink-0 items-center gap-0.5">
-                  <span
-                    className="shrink-0"
-                    title={t(($) =>
-                      canSendNow ? $.queue.steer : $.queue.steer_unavailable
-                    )}
-                  >
+          <div
+            data-slot="chat-queue-list"
+            className="max-h-40 overflow-y-auto px-2 py-1"
+          >
+            {tasks.map((task) => {
+              const sendNowKey = `send-now:${task.task_id}`;
+              const editKey = `edit:${task.task_id}`;
+              const removeKey = `remove:${task.task_id}`;
+              const clearKey = `clear:${task.task_id}`;
+              return (
+                <div
+                  key={task.task_id}
+                  data-slot="chat-queue-row"
+                  className="flex min-h-7 min-w-0 items-center gap-2 rounded-md px-1.5 py-0.5 text-caption animate-in fade-in duration-200"
+                >
+                  <ListEnd
+                    data-slot="chat-queue-item-icon"
+                    className="size-3.5 shrink-0 text-faint-foreground"
+                    aria-hidden="true"
+                  />
+                  <span className="min-w-0 flex-1 truncate text-muted-foreground">
+                    {task.content?.trim() || t(($) => $.queue.fallback)}
+                  </span>
+                  <div className="flex shrink-0 items-center gap-0.5">
+                    <span
+                      className="shrink-0"
+                      title={t(($) =>
+                        canSendNow ? $.queue.steer : $.queue.steer_unavailable
+                      )}
+                    >
+                      <Button
+                        variant="ghost"
+                        size="xs"
+                        className="px-1.5 font-normal text-muted-foreground"
+                        disabled={busyAction !== null || !canSendNow}
+                        aria-label={t(($) =>
+                          canSendNow
+                            ? $.queue.steer
+                            : $.queue.steer_unavailable
+                        )}
+                        onClick={() => void run(sendNowKey, () => onSendNow(task.task_id))}
+                      >
+                        {busyAction === sendNowKey ? (
+                          <Loader2 className="animate-spin" aria-hidden="true" />
+                        ) : (
+                          <CornerDownRight aria-hidden="true" />
+                        )}
+                        {t(($) => $.queue.steer)}
+                      </Button>
+                    </span>
                     <Button
                       variant="ghost"
-                      size="sm"
-                      className="gap-1.5 px-2 font-normal text-muted-foreground"
-                      disabled={busyAction !== null || !canSendNow}
-                      aria-label={t(($) =>
-                        canSendNow
-                          ? $.queue.steer
-                          : $.queue.steer_unavailable
-                      )}
-                      onClick={() => void run(sendNowKey, () => onSendNow(task.task_id))}
+                      size="icon-xs"
+                      className="shrink-0 text-muted-foreground"
+                      disabled={busyAction !== null}
+                      title={t(($) => $.queue.remove)}
+                      aria-label={t(($) => $.queue.remove)}
+                      onClick={() => void run(removeKey, () => onRemove(task.task_id))}
                     >
-                      {busyAction === sendNowKey ? (
+                      {busyAction === removeKey ? (
                         <Loader2 className="animate-spin" aria-hidden="true" />
                       ) : (
-                        <CornerDownRight aria-hidden="true" />
-                      )}
-                      {t(($) => $.queue.steer)}
-                    </Button>
-                  </span>
-                  <Button
-                    variant="ghost"
-                    size="icon-sm"
-                    className="shrink-0 text-muted-foreground"
-                    disabled={busyAction !== null}
-                    title={t(($) => $.queue.remove)}
-                    aria-label={t(($) => $.queue.remove)}
-                    onClick={() => void run(removeKey, () => onRemove(task.task_id))}
-                  >
-                    {busyAction === removeKey ? (
-                      <Loader2 className="animate-spin" aria-hidden="true" />
-                    ) : (
-                      <Trash2 aria-hidden="true" />
-                    )}
-                  </Button>
-                  <DropdownMenu>
-                    <DropdownMenuTrigger
-                      render={
-                        <Button
-                          type="button"
-                          variant="ghost"
-                          size="icon-sm"
-                          className="shrink-0 text-muted-foreground"
-                          disabled={busyAction !== null}
-                          title={t(($) => $.queue.more)}
-                          aria-label={t(($) => $.queue.more)}
-                        />
-                      }
-                    >
-                      {busyAction === editKey || busyAction === clearKey ? (
-                        <Loader2 className="animate-spin" aria-hidden="true" />
-                      ) : (
-                        <Ellipsis aria-hidden="true" />
-                      )}
-                    </DropdownMenuTrigger>
-                    <DropdownMenuContent
-                      align="end"
-                      side="top"
-                      sideOffset={6}
-                      className="w-auto"
-                    >
-                      <DropdownMenuItem
-                        disabled={busyAction !== null}
-                        onClick={() => void run(editKey, () => onEdit(task.task_id))}
-                      >
-                        <Pencil aria-hidden="true" />
-                        {t(($) => $.queue.edit)}
-                      </DropdownMenuItem>
-                      <DropdownMenuSeparator />
-                      <DropdownMenuItem
-                        variant="destructive"
-                        disabled={busyAction !== null}
-                        onClick={() => void run(clearKey, onClear)}
-                      >
                         <Trash2 aria-hidden="true" />
-                        {t(($) => $.queue.clear)}
-                      </DropdownMenuItem>
-                    </DropdownMenuContent>
-                  </DropdownMenu>
+                      )}
+                    </Button>
+                    <DropdownMenu>
+                      <DropdownMenuTrigger
+                        render={
+                          <Button
+                            type="button"
+                            variant="ghost"
+                            size="icon-xs"
+                            className="shrink-0 text-muted-foreground"
+                            disabled={busyAction !== null}
+                            title={t(($) => $.queue.more)}
+                            aria-label={t(($) => $.queue.more)}
+                          />
+                        }
+                      >
+                        {busyAction === editKey || busyAction === clearKey ? (
+                          <Loader2 className="animate-spin" aria-hidden="true" />
+                        ) : (
+                          <Ellipsis aria-hidden="true" />
+                        )}
+                      </DropdownMenuTrigger>
+                      <DropdownMenuContent
+                        align="end"
+                        side="top"
+                        sideOffset={6}
+                        className="w-auto"
+                      >
+                        <DropdownMenuItem
+                          disabled={busyAction !== null}
+                          onClick={() => void run(editKey, () => onEdit(task.task_id))}
+                        >
+                          <Pencil aria-hidden="true" />
+                          {t(($) => $.queue.edit)}
+                        </DropdownMenuItem>
+                        <DropdownMenuSeparator />
+                        <DropdownMenuItem
+                          variant="destructive"
+                          disabled={busyAction !== null}
+                          onClick={() => void run(clearKey, onClear)}
+                        >
+                          <Trash2 aria-hidden="true" />
+                          {t(($) => $.queue.clear)}
+                        </DropdownMenuItem>
+                      </DropdownMenuContent>
+                    </DropdownMenu>
+                  </div>
                 </div>
-              </div>
-            );
-          })}
-        </div>
-      </section>
+              );
+            })}
+          </div>
+        </section>
+      </div>
     </div>
   );
 }

--- a/packages/views/chat/components/chat-window.tsx
+++ b/packages/views/chat/components/chat-window.tsx
@@ -914,7 +914,6 @@ export function ChatWindow() {
         onStop={handleStop}
         isRunning={!!pendingTaskId}
         allowSubmitWhileRunning={pendingTask?.supports_queue === true}
-        hasQueue={queuedTasks.length > 0}
         disabled={
           isSessionArchived || isAgentArchived || !activeAgentRuntimeBound
         }


### PR DESCRIPTION
## Problem

Since #6430 the follow-up queue and the composer were styled as one attached stack: when the queue appeared, a `hasQueue` prop flipped the composer from `rounded-lg` to `rounded-4xl` and swapped its shadow, so the input box visibly morphed the instant a message was queued (no `border-radius` transition either). The stacked look also depended on a three-way implicit contract spread across both components (`-mb-8` on the queue shell, `pb-10` on the queue card, conditional `z-10` + radius on the composer) that had to be kept in sync by hand.

## Change

**Composer chrome is now constant.** `ChatInput` no longer knows the queue exists: the `hasQueue` prop and both conditional class branches are gone. The only addition is a *static* `relative z-10` so the composer always paints on top — it never varies with queue state.

**The tucked stack is owned entirely by `ChatQueue`.** The card slides its own bottom edge under the composer (`z-0`, `-mb-3`, `pb-4`) and insets itself with `mx-3`, so the stack reads as a narrower rear layer emerging from behind the input. The column geometry contract (gutter outside, `CHAT_COLUMN` inside) is unchanged.

**Lighter, smaller queue chrome**, all existing tokens/idioms:
- rows: `min-h-12`/`text-body` → `min-h-7`/`text-caption`, muted text, `size-3.5` icon
- actions: `sm`/`icon-sm` buttons → `xs`/`icon-xs`
- card: border-only (no shadow) so the composer stays the dominant surface
- entrance: `animate-in fade-in slide-in-from-bottom-2` on the card, `fade-in` per row

## Tests

- `chat-input.test.tsx`: the two stacked-chrome tests are replaced by one pinning that the composer chrome is queue-independent (static `z-10`, `rounded-lg`, never `rounded-4xl`/menu-shadow).
- `chat-queue.test.tsx`: asserts the queue-owned tuck (`z-0 -mb-3`, `pb-4`, `rounded-lg`).

Verification not run per workflow — reviewer/CI covers `pnpm test` + `pnpm typecheck`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)