### PR TITLE
fix(agents): explain why a runtime refuses thinking_level (MUL-5770)

### DIFF
--- a/server/cmd/multica/cmd_agent.go
+++ b/server/cmd/multica/cmd_agent.go
@@ -163,7 +163,7 @@ func init() {
 	agentCreateCmd.Flags().String("runtime-id", "", "Runtime ID (required)")
 	agentCreateCmd.Flags().String("runtime-config", "", "Runtime config as JSON string")
 	agentCreateCmd.Flags().String("model", "", "Model identifier (e.g. claude-sonnet-4-6, openai/gpt-4o). Prefer this over passing --model in --custom-args.")
-	agentCreateCmd.Flags().String("thinking-level", "", "Reasoning/effort level for the agent's runtime (e.g. Claude: low|medium|high|xhigh|max; Codex values come from the runtime model catalog). The set is runtime/model-specific; malformed values are rejected server-side and the daemon validates the exact model/level pair. Empty = runtime default.")
+	agentCreateCmd.Flags().String("thinking-level", "", "Reasoning/effort level for the agent's runtime (e.g. Claude: low|medium|high|xhigh|max; Codex values come from the runtime model catalog). The set is runtime/model-specific; malformed values are rejected server-side and the daemon validates the exact model/level pair. Some runtimes (e.g. hermes) expose no reasoning control and reject every value. Empty = runtime default.")
 	agentCreateCmd.Flags().String("service-tier", "", "Codex execution service tier from the selected model's runtime catalog (e.g. priority, displayed as Fast). Empty = inherit local Codex configuration.")
 	agentCreateCmd.Flags().String("custom-args", "", "Custom CLI arguments as JSON array. For model selection prefer --model; some providers (codex app-server, openclaw) reject --model in custom_args.")
 	agentCreateCmd.Flags().String("custom-env", "", "Custom environment variables as JSON object, e.g. '{\"KEY\":\"value\"}'. Treated as secret material — never logged by the CLI, but values passed on the command line are visible to shell history and 'ps'; prefer --custom-env-stdin or --custom-env-file for real secrets. Pass '{}' to set an empty map.")
@@ -186,7 +186,7 @@ func init() {
 	agentUpdateCmd.Flags().String("runtime-id", "", "New runtime ID")
 	agentUpdateCmd.Flags().String("runtime-config", "", "New runtime config as JSON string")
 	agentUpdateCmd.Flags().String("model", "", "New model identifier. Pass an empty string to clear and fall back to the runtime default.")
-	agentUpdateCmd.Flags().String("thinking-level", "", "New reasoning/effort level for the agent's runtime (e.g. Claude: low|medium|high|xhigh|max; Codex values come from the runtime model catalog). The set is runtime/model-specific; malformed values are rejected server-side and the daemon validates the exact model/level pair. Pass an empty string to clear and fall back to the runtime default.")
+	agentUpdateCmd.Flags().String("thinking-level", "", "New reasoning/effort level for the agent's runtime (e.g. Claude: low|medium|high|xhigh|max; Codex values come from the runtime model catalog). The set is runtime/model-specific; malformed values are rejected server-side and the daemon validates the exact model/level pair. Some runtimes (e.g. hermes) expose no reasoning control and reject every value. Pass an empty string to clear and fall back to the runtime default.")
 	agentUpdateCmd.Flags().String("service-tier", "", "New Codex execution service tier from the selected model's runtime catalog. Pass an empty string to clear and inherit local Codex configuration.")
 	agentUpdateCmd.Flags().String("custom-args", "", "New custom CLI arguments as JSON array. For model selection prefer --model; some providers (codex app-server, openclaw) reject --model in custom_args.")
 	// custom_env is intentionally NOT part of `agent update`. Use

--- a/server/internal/handler/agent.go
+++ b/server/internal/handler/agent.go
@@ -1080,7 +1080,7 @@ func (h *Handler) CreateAgent(w http.ResponseWriter, r *http.Request) {
 	// Per-model gaps are enforced by the daemon at execution time (MUL-2339):
 	// combination-invalid values are logged and omitted from the invocation.
 	if !agent.IsKnownThinkingValue(runtime.Provider, req.ThinkingLevel) {
-		writeError(w, http.StatusBadRequest, fmt.Sprintf("thinking_level %q is not a recognised value for runtime %q", req.ThinkingLevel, runtime.Provider))
+		writeError(w, http.StatusBadRequest, thinkingLevelRejection(runtime.Provider, req.ThinkingLevel))
 		return
 	}
 	if !agent.IsKnownServiceTier(runtime.Provider, req.ServiceTier) {
@@ -1723,7 +1723,7 @@ func (h *Handler) UpdateAgent(w http.ResponseWriter, r *http.Request) {
 				}
 			}
 			if !agent.IsKnownThinkingValue(provider, value) {
-				writeError(w, http.StatusBadRequest, fmt.Sprintf("thinking_level %q is not a recognised value for runtime %q", value, provider))
+				writeError(w, http.StatusBadRequest, thinkingLevelRejection(provider, value))
 				return
 			}
 			params.ThinkingLevel = pgtype.Text{String: value, Valid: true}
@@ -1746,10 +1746,7 @@ func (h *Handler) UpdateAgent(w http.ResponseWriter, r *http.Request) {
 			}
 		}
 		if !agent.IsKnownThinkingValue(provider, existing.ThinkingLevel.String) {
-			writeError(w, http.StatusBadRequest, fmt.Sprintf(
-				"existing thinking_level %q is not valid for runtime %q; pass thinking_level=\"\" to clear or set a value valid for the new runtime",
-				existing.ThinkingLevel.String, provider,
-			))
+			writeError(w, http.StatusBadRequest, existingThinkingLevelRejection(provider, existing.ThinkingLevel.String))
 			return
 		}
 	}
@@ -1971,6 +1968,39 @@ func (h *Handler) resolveAgentProvider(r *http.Request, workspaceID pgtype.UUID,
 		return "", false
 	}
 	return rt.Provider, true
+}
+
+// thinkingLevelRejection explains why the target runtime will not take this
+// thinking_level. Two different failures used to share one sentence: a token
+// the runtime's catalog doesn't list, and a runtime with no reasoning control
+// at all. The second one made "high" look like a spelling mistake and sent
+// users hunting for a value that does not exist for that runtime (MUL-5770),
+// so it now names the capability gap instead.
+func thinkingLevelRejection(provider, value string) string {
+	if !agent.ThinkingControlSupported(provider) {
+		return fmt.Sprintf(
+			"runtime %q does not support a per-agent reasoning effort; leave thinking_level empty to use the runtime default",
+			provider,
+		)
+	}
+	return fmt.Sprintf("thinking_level %q is not a recognised value for runtime %q", value, provider)
+}
+
+// existingThinkingLevelRejection is thinkingLevelRejection for the carry-over
+// path, where the caller changed runtime without touching a level the new
+// runtime cannot take. Both branches point at the same escape hatch, so the
+// user does not have to guess that clearing is allowed.
+func existingThinkingLevelRejection(provider, value string) string {
+	if !agent.ThinkingControlSupported(provider) {
+		return fmt.Sprintf(
+			"runtime %q does not support a per-agent reasoning effort; pass thinking_level=\"\" to clear the existing %q",
+			provider, value,
+		)
+	}
+	return fmt.Sprintf(
+		"existing thinking_level %q is not valid for runtime %q; pass thinking_level=\"\" to clear or set a value valid for the new runtime",
+		value, provider,
+	)
 }
 
 func (h *Handler) ArchiveAgent(w http.ResponseWriter, r *http.Request) {

--- a/server/internal/handler/agent_thinking_test.go
+++ b/server/internal/handler/agent_thinking_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 )
 
@@ -471,6 +472,122 @@ func TestUpdateAgent_RuntimeSwitch_ClearsKnownIncompatibleModel(t *testing.T) {
 			t.Errorf("expected unknown custom model preserved, got %v", resp["model"])
 		}
 	})
+}
+
+// TestThinkingLevelRejectionCopy pins WHY a thinking_level was refused, not
+// just that it was. A runtime with no reasoning control must not be described
+// as receiving an unrecognised value: "high" is a fine effort token, and the
+// old shared sentence sent Hermes users looking for a spelling that cannot
+// exist (MUL-5770).
+func TestThinkingLevelRejectionCopy(t *testing.T) {
+	t.Parallel()
+
+	t.Run("runtime without reasoning control names the capability gap", func(t *testing.T) {
+		msg := thinkingLevelRejection("hermes", "high")
+		if !strings.Contains(msg, "does not support a per-agent reasoning effort") {
+			t.Errorf("expected a capability explanation, got %q", msg)
+		}
+		if strings.Contains(msg, "not a recognised value") {
+			t.Errorf("capability gap must not read as a bad token, got %q", msg)
+		}
+		if !strings.Contains(msg, `"hermes"`) {
+			t.Errorf("expected the runtime named in %q", msg)
+		}
+	})
+
+	t.Run("runtime with reasoning control names the value", func(t *testing.T) {
+		msg := thinkingLevelRejection("claude", "supersonic")
+		if !strings.Contains(msg, "not a recognised value") {
+			t.Errorf("expected a value-level explanation, got %q", msg)
+		}
+		if !strings.Contains(msg, `"supersonic"`) {
+			t.Errorf("expected the rejected token echoed in %q", msg)
+		}
+	})
+
+	t.Run("carry-over path always offers the clear escape hatch", func(t *testing.T) {
+		for _, provider := range []string{"hermes", "claude"} {
+			msg := existingThinkingLevelRejection(provider, "xhigh")
+			if !strings.Contains(msg, `thinking_level=""`) {
+				t.Errorf("provider %q: expected the clear instruction, got %q", provider, msg)
+			}
+		}
+		if msg := existingThinkingLevelRejection("hermes", "xhigh"); !strings.Contains(msg, "does not support a per-agent reasoning effort") {
+			t.Errorf("expected the capability explanation on the carry-over path, got %q", msg)
+		}
+	})
+}
+
+// TestCreateAgent_HermesRejectsThinkingLevel covers the reported flow
+// end-to-end: creating a Hermes agent with a reasoning effort 400s, and the
+// body explains that the runtime has no such control rather than blaming the
+// value. Empty stays valid — it means "runtime default".
+func TestCreateAgent_HermesRejectsThinkingLevel(t *testing.T) {
+	if testHandler == nil {
+		t.Skip("database not available")
+	}
+	hermesRuntimeID := createHermesProviderRuntime(t)
+	t.Cleanup(func() {
+		testPool.Exec(context.Background(),
+			`DELETE FROM agent WHERE workspace_id = $1 AND name LIKE 'hermes-thinking-%'`,
+			testWorkspaceID,
+		)
+	})
+
+	t.Run("effort value rejected with a capability message", func(t *testing.T) {
+		body := map[string]any{
+			"name":                 "hermes-thinking-high",
+			"runtime_id":           hermesRuntimeID,
+			"visibility":           "private",
+			"max_concurrent_tasks": 1,
+			"thinking_level":       "high",
+		}
+		w := httptest.NewRecorder()
+		testHandler.CreateAgent(w, newRequest(http.MethodPost, "/api/agents", body))
+		if w.Code != http.StatusBadRequest {
+			t.Fatalf("hermes thinking_level=high: expected 400, got %d: %s", w.Code, w.Body.String())
+		}
+		if !strings.Contains(w.Body.String(), "does not support a per-agent reasoning effort") {
+			t.Errorf("expected a capability explanation in the 400 body, got %s", w.Body.String())
+		}
+	})
+
+	t.Run("empty value still creates", func(t *testing.T) {
+		body := map[string]any{
+			"name":                 "hermes-thinking-empty",
+			"runtime_id":           hermesRuntimeID,
+			"visibility":           "private",
+			"max_concurrent_tasks": 1,
+			"thinking_level":       "",
+		}
+		w := httptest.NewRecorder()
+		testHandler.CreateAgent(w, newRequest(http.MethodPost, "/api/agents", body))
+		if w.Code != http.StatusCreated {
+			t.Fatalf("hermes empty thinking_level: expected 201, got %d: %s", w.Code, w.Body.String())
+		}
+	})
+}
+
+// createHermesProviderRuntime stands up a runtime row with provider "hermes",
+// the runtime whose ACP surface exposes no reasoning-effort control.
+func createHermesProviderRuntime(t *testing.T) string {
+	t.Helper()
+	var runtimeID string
+	err := testPool.QueryRow(context.Background(), `
+		INSERT INTO agent_runtime (
+			workspace_id, daemon_id, name, runtime_mode, provider, status,
+			device_info, metadata, last_seen_at, owner_id
+		)
+		VALUES ($1, NULL, $2, 'cloud', 'hermes', 'online', $3, '{}'::jsonb, now(), $4)
+		RETURNING id
+	`, testWorkspaceID, "Hermes Thinking Runtime", "Hermes thinking-level test runtime", testUserID).Scan(&runtimeID)
+	if err != nil {
+		t.Fatalf("create hermes runtime: %v", err)
+	}
+	t.Cleanup(func() {
+		testPool.Exec(context.Background(), `DELETE FROM agent_runtime WHERE id = $1`, runtimeID)
+	})
+	return runtimeID
 }
 
 // createCodexProviderRuntime mirrors createClaudeProviderRuntime but for

--- a/server/internal/service/builtin_skills/multica-creating-agents/SKILL.md
+++ b/server/internal/service/builtin_skills/multica-creating-agents/SKILL.md
@@ -119,7 +119,7 @@ multica agent copy <source-agent-id> --runtime-id <target> --model <model>  # cr
 | `avatar_url` | `agent.avatar_url` | none; an explicit non-empty value is preserved, while omitted/empty creates a random `emoji:<glyph>` avatar | catalog/listing UI only — NOT the runtime prompt |
 | `runtime_id` | `agent.runtime_id` (nullable) | required at create (400) + must resolve to a runtime in this workspace | selects runtime/provider; `NULL` means unbound — see below |
 | `model` | `agent.model` (nullable) | none beyond runtime support | daemon reads; empty = runtime default |
-| `thinking_level` | `agent.thinking_level` (nullable) | provider-level enum; unknown literal → 400 | daemon; empty = runtime default |
+| `thinking_level` | `agent.thinking_level` (nullable) | provider-level enum; unknown literal → 400. A runtime with no reasoning control (e.g. `hermes`) rejects EVERY non-empty value and says so — that 400 is a capability answer, not a bad token | daemon; empty = runtime default |
 | `service_tier` | `agent.service_tier` (nullable) | Codex-only safe token; other providers reject; exact model/tier pair checked by daemon | daemon → Codex app-server; empty = local Codex config |
 | `custom_args` | `agent.custom_args` (JSON array) | JSON shape checked CLI-side; server stores as-is | daemon (extra CLI switches); defaults to `[]` |
 | `runtime_config` | `agent.runtime_config` (JSON) | JSON shape checked CLI-side; server stores as-is | runtime-specific config; defaults to `{}` |

--- a/server/internal/service/builtin_skills/multica-creating-agents/references/creating-agents-source-map.md
+++ b/server/internal/service/builtin_skills/multica-creating-agents/references/creating-agents-source-map.md
@@ -68,6 +68,7 @@ only.
 | `runtime_id` required | 631–633 | `if req.RuntimeID == ""` → 400 "runtime_id is required" |
 | `runtime_id` must resolve in workspace | 642–658 | parsed + `GetAgentRuntimeForWorkspace`; unknown → 400 "invalid runtime_id" |
 | `thinking_level` provider-level validation | 896–903 | `!agent.IsKnownThinkingValue(runtime.Provider, req.ThinkingLevel)` → 400; fixed providers use an enum, Codex/OpenCode use safe-token syntax, and per-model gaps are deferred to daemon (MUL-2339) |
+| `thinking_level` rejection copy | `agent.go` `thinkingLevelRejection` / `existingThinkingLevelRejection` | Splits "runtime has no reasoning control" from "unrecognised token" so a runtime-capability 400 does not read as a typo; both carry-over branches point at `thinking_level=""` (MUL-5770) |
 | `service_tier` provider-level validation | `agent.go` create/update paths | Non-empty values are Codex-only safe tokens; exact per-model support is daemon-owned |
 | Defaults: `{}` config/env, `[]` args | 688–701 | `RuntimeConfig`→`{}`, `CustomEnv`→`{}`, `CustomArgs`→`[]` when nil, before insert |
 | `visibility` default | 635–636 | `if req.Visibility == "" { req.Visibility = "private" }` — access-control field, not the runtime prompt |
@@ -98,6 +99,7 @@ only.
 | Codex catalog projection | `thinking.go` `parseCodexModelCatalog` | Hidden models are excluded; visible model, reasoning, and `service_tiers` metadata are preserved |
 | Per-model thinking validation | `thinking.go` 547–640 | `ValidateThinkingLevel` accepts only values in the explicit model's `Thinking.SupportedLevels`; an empty Codex model fails closed because its effective `config.toml` model is unknown |
 | Dynamic Codex token gate | `thinking.go` 642–710 | Server persistence accepts syntactically safe Codex tokens so new catalog values do not require a Multica release; exact support remains a daemon-local per-model check |
+| Runtime reasoning capability | `thinking.go` `ThinkingControlSupported` | True for the fixed-enum providers plus Codex/OpenCode. False for runtimes with no effort dial on the surface the daemon drives — Hermes' ACP adapter never carries `reasoning_config` onto a session, so its CLI-level `agent.reasoning_effort` cannot be reached from Multica (verified against Hermes Agent v0.18.2, MUL-5770) |
 | Per-model service-tier validation | `thinking.go` `ValidateServiceTier` | Accepts only a tier advertised for the explicit Codex model; empty model fails closed because config.toml is unknown |
 | Daemon invalid-combination handling | `internal/daemon/daemon.go` 3860–3892 | Before execution, invalid `(provider, model, thinking_level)` combinations log a warning and omit the override rather than failing the task |
 

--- a/server/pkg/agent/hermes.go
+++ b/server/pkg/agent/hermes.go
@@ -156,6 +156,13 @@ func StripHermesProfileArgs(args []string, sel HermesProfileSelection) []string 
 // via the ACP (Agent Communication Protocol) JSON-RPC 2.0 over stdin/stdout.
 // This is the same pattern as Codex but with the ACP protocol instead of
 // the Codex-specific JSON-RPC methods.
+//
+// opts.ThinkingLevel is deliberately not consumed here: Hermes' ACP surface
+// has nowhere to put a reasoning effort (see ThinkingControlSupported in
+// thinking.go for the evidence and the version it was verified against), and
+// the server rejects the field for this provider before a task is ever
+// dispatched. Wire it up here — alongside the model selection below — once
+// Hermes' ACP adapter carries reasoning onto the session.
 type hermesBackend struct {
 	cfg Config
 }

--- a/server/pkg/agent/thinking.go
+++ b/server/pkg/agent/thinking.go
@@ -762,20 +762,63 @@ var providerThinkingEnums = map[string]map[string]bool{
 	},
 }
 
+// thinkingDynamicCatalogProviders are the runtimes whose effort vocabulary is
+// owned by a daemon-local model catalog instead of a fixed enum above. The
+// server accepts any well-formed token for them and lets the daemon's
+// per-model check decide before execution.
+var thinkingDynamicCatalogProviders = map[string]bool{
+	"codex":    true,
+	"opencode": true,
+}
+
+// ThinkingControlSupported reports whether Multica can deliver a per-agent
+// reasoning effort to this runtime at all. False means the answer to any
+// thinking_level is "no", regardless of the token: the runtime exposes no
+// effort dial on the surface the daemon speaks to it over, so there is nothing
+// to inject and nothing a different spelling would fix.
+//
+// Hermes is the instructive case (MUL-5770). The Hermes CLI does support
+// reasoning effort — `agent.reasoning_effort` in `<HERMES_HOME>/config.yaml`,
+// checked against its own `minimal|low|medium|high|xhigh|max|ultra` set — but
+// Multica drives Hermes over ACP (`hermes acp`), and its ACP adapter does not
+// carry that setting onto the session:
+//   - `session/new` advertises `models` and `modes` only, no `configOptions`,
+//     so there is no effort catalog to discover;
+//   - `session/set_config_option` records the value on the session and never
+//     applies it;
+//   - `acp_adapter/session.py::_make_agent` constructs the agent without
+//     `reasoning_config`, so every ACP session runs at the transport default.
+//
+// Verified against Hermes Agent v0.18.2. Because the config file is read by
+// the CLI/gateway paths but not the ACP one, writing an effort into a per-task
+// HERMES_HOME would be just as inert as accepting the value here — which is
+// why this is a capability gap to report, not a value to pass through. Revisit
+// when Hermes' ACP surface exposes reasoning; the picker then follows from the
+// discovered catalog like every other runtime's.
+func ThinkingControlSupported(providerType string) bool {
+	if thinkingDynamicCatalogProviders[providerType] {
+		return true
+	}
+	_, ok := providerThinkingEnums[providerType]
+	return ok
+}
+
 // IsKnownThinkingValue reports whether `value` is a recognised effort
 // token for the given provider. Empty string is always accepted (means
-// "use runtime default"). Unknown providers (no thinking concept) accept
+// "use runtime default"). Providers with no reasoning control accept
 // only empty; Codex and OpenCode accept well-formed tokens here because their
 // daemon-local catalogs perform the exact per-model check before execution.
 //
 // This is the cheap synchronous gate the server uses on CreateAgent /
 // UpdateAgent. Unlike ValidateThinkingLevel it does NOT consult the live
-// catalog or per-model subset.
+// catalog or per-model subset. Callers that surface a rejection to a user
+// should ask ThinkingControlSupported first so the message says "this runtime
+// has no reasoning control" instead of implying a bad token.
 func IsKnownThinkingValue(providerType, value string) bool {
 	if value == "" {
 		return true
 	}
-	if providerType == "codex" || providerType == "opencode" {
+	if thinkingDynamicCatalogProviders[providerType] {
 		return isValidDynamicThinkingValue(value)
 	}
 	enum, ok := providerThinkingEnums[providerType]

--- a/server/pkg/agent/thinking_test.go
+++ b/server/pkg/agent/thinking_test.go
@@ -468,7 +468,7 @@ func TestIsKnownThinkingValue(t *testing.T) {
 		{"opencode", ".hidden", false},   // reject suspicious / malformed names server-side
 		{"opencode", "bad value", false}, // spaces are not valid variant names
 		{"hermes", "", true},
-		{"hermes", "low", false}, // hermes has no thinking concept
+		{"hermes", "low", false}, // hermes' ACP surface exposes no effort dial
 		{"grok", "", true},
 		{"grok", "low", true},
 		{"grok", "medium", true},
@@ -483,6 +483,52 @@ func TestIsKnownThinkingValue(t *testing.T) {
 		if got := IsKnownThinkingValue(tc.provider, tc.value); got != tc.want {
 			t.Errorf("IsKnownThinkingValue(%q, %q) = %v, want %v",
 				tc.provider, tc.value, got, tc.want)
+		}
+	}
+}
+
+// TestThinkingControlSupported pins which runtimes Multica can actually hand a
+// per-agent effort to. The distinction drives the API's rejection copy, so a
+// provider must not drift into "supported" without a real injection path.
+func TestThinkingControlSupported(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		provider string
+		want     bool
+	}{
+		{"claude", true},
+		{"codebuddy", true},
+		{"grok", true},
+		{"codex", true},    // dynamic catalog, validated per model by the daemon
+		{"opencode", true}, // dynamic variant names from opencode.json
+		{"hermes", false},  // ACP adapter drops reasoning entirely (MUL-5770)
+		{"kimi", false},
+		{"qwenpaw", false},
+		{"", false},
+		{"not-a-runtime", false},
+	}
+	for _, tc := range tests {
+		if got := ThinkingControlSupported(tc.provider); got != tc.want {
+			t.Errorf("ThinkingControlSupported(%q) = %v, want %v", tc.provider, got, tc.want)
+		}
+	}
+}
+
+// TestThinkingControlSupportedMatchesTokenGate keeps the capability predicate
+// and the value gate from disagreeing: if a provider accepts any non-empty
+// token it must report the capability, and if it reports none it must accept
+// nothing but the empty "runtime default" sentinel. Otherwise the API can
+// reject a level while claiming the runtime supports one, or vice versa.
+func TestThinkingControlSupportedMatchesTokenGate(t *testing.T) {
+	t.Parallel()
+	providers := []string{"claude", "codebuddy", "grok", "codex", "opencode", "hermes", "kimi", "cursor"}
+	// "medium" is in every fixed enum and is a well-formed dynamic token, so a
+	// provider with any reasoning control accepts it.
+	for _, provider := range providers {
+		accepts := IsKnownThinkingValue(provider, "medium")
+		if got := ThinkingControlSupported(provider); got != accepts {
+			t.Errorf("provider %q: ThinkingControlSupported = %v but IsKnownThinkingValue(%q, \"medium\") = %v",
+				provider, got, provider, accepts)
 		}
 	}
 }


### PR DESCRIPTION
## Summary

Setting a reasoning effort on a Hermes agent fails with:

```
thinking_level "high" is not a recognised value for runtime "hermes"
```

That reads like a bad token. It is not — `high` is a perfectly good effort
level, and no other spelling would work either: Hermes exposes no reasoning
control on the surface Multica drives it over, so the correct answer is a
capability answer.

This PR makes the API say that, and records the evidence so nobody re-derives
it. It does **not** change which values are accepted for any runtime.

- `agent.ThinkingControlSupported(provider)` — new capability predicate, built
  from the sets that already decide the token gate (fixed enums + the dynamic
  Codex/OpenCode catalogs), so the two cannot drift.
- `CreateAgent` / `UpdateAgent` now answer "runtime `X` does not support a
  per-agent reasoning effort" for runtimes with no dial, and keep the existing
  "not a recognised value" copy for runtimes that have one. The runtime-switch
  carry-over branch points at `thinking_level=""` in both cases.
- `--thinking-level` help on `agent create` / `agent update` mentions the
  constraint up front, with matching updates to the `multica-creating-agents`
  skill and its source map.

## Why Hermes has no dial

Investigated against **Hermes Agent v0.18.2** (the reported runtime). Hermes'
CLI *does* support reasoning effort (`agent.reasoning_effort` in
`<HERMES_HOME>/config.yaml`, over `minimal|low|medium|high|xhigh|max|ultra`),
but Multica drives Hermes over ACP (`hermes acp`) and that adapter drops it:

- `session/new` advertises `models` and `modes` only — no `configOptions`, so
  there is no effort catalog to discover (confirmed with a live
  `initialize` + `session/new` handshake).
- `session/set_config_option` stores the value on the session and never
  applies it.
- `acp_adapter/session.py::_make_agent` builds the agent without
  `reasoning_config`, so `AIAgent.reasoning_config` is `None` for every ACP
  session and `agent/transports/codex.py` falls back to `effort="medium"`.

Consequence worth flagging: the "global Hermes setting" that gets suggested as
a workaround does not reach ACP sessions either. Verified by constructing the
agent the way the ACP adapter does — config reports `medium`, the agent reports
`reasoning_config = None`.

So the per-agent pass-through cannot be built on our side today. It needs
Hermes' ACP adapter to carry reasoning onto the session; once it does, the
picker follows from the discovered catalog like every other runtime's.
`hermes.go` carries a pointer to that follow-up at the exact spot it would be
wired.

## Verification

- `go test ./pkg/agent -count=1` — pass (includes the new
  `TestThinkingControlSupported` and the gate-consistency test).
- `go test ./internal/handler -run 'TestThinkingLevelRejectionCopy|TestCreateAgent_HermesRejectsThinkingLevel'` — pass.
- `go build ./...`, `go vet ./internal/handler ./pkg/agent`, `gofmt` — clean.
- Pre-existing, unrelated local failures (identical on a clean tree, verified by
  stashing): handler create-path tests 500 on this box because the local dev DB
  predates the `agent.service_tier` column, and `./cmd/multica` refuses to run
  inside an agent task context.
