### PR TITLE
fix(issues): keep the usage dialog's content inside the dialog (MUL-5762)

### DIFF
--- a/packages/views/issues/components/issue-usage-dialog.test.tsx
+++ b/packages/views/issues/components/issue-usage-dialog.test.tsx
@@ -1,0 +1,122 @@
+// @vitest-environment jsdom
+
+import { cleanup, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { AgentTask, TaskUsage } from "@multica/core/types";
+import { renderWithI18n } from "../../test/i18n";
+
+vi.mock("../../common/actor-avatar", () => ({
+  ActorAvatar: () => <span data-testid="actor-avatar" />,
+}));
+
+import { IssueUsageDialog } from "./issue-usage-dialog";
+
+function makeTask(overrides: Partial<AgentTask> = {}): AgentTask {
+  return {
+    id: "task-1",
+    agent_id: "agent-1",
+    runtime_id: "runtime-1",
+    issue_id: "issue-1",
+    status: "completed",
+    priority: 0,
+    dispatched_at: null,
+    started_at: "2026-08-05T08:00:00Z",
+    completed_at: "2026-08-05T08:11:00Z",
+    result: null,
+    error: null,
+    created_at: "2026-08-05T08:00:00Z",
+    trigger_summary: "Initial run",
+    ...overrides,
+  };
+}
+
+function usage(overrides: Partial<TaskUsage> = {}): TaskUsage {
+  return {
+    provider: "anthropic",
+    model: "claude-opus-5",
+    input_tokens: 1_000,
+    output_tokens: 1_000,
+    cache_read_tokens: 1_000,
+    cache_write_tokens: 0,
+    ...overrides,
+  };
+}
+
+function open(tasks: AgentTask[]) {
+  renderWithI18n(
+    <IssueUsageDialog open onOpenChange={() => {}} identifier="ACM-1" tasks={tasks} />,
+  );
+}
+
+beforeEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+afterEach(cleanup);
+
+describe("IssueUsageDialog", () => {
+  it("floors the cache hit rate instead of rounding it up to 100%", () => {
+    // 99.55% — rounding would print "100% hit rate" and claim every token came
+    // from cache on an issue that plainly read some fresh input.
+    open([
+      makeTask({
+        usage: [usage({ input_tokens: 573_500, cache_read_tokens: 126_000_000 })],
+      }),
+    ]);
+
+    expect(screen.getByText(/99% hit rate/)).toBeInTheDocument();
+    expect(screen.queryByText(/100% hit rate/)).not.toBeInTheDocument();
+  });
+
+  it("still says 100% when the hit rate really is 100%", () => {
+    open([
+      makeTask({ usage: [usage({ input_tokens: 0, cache_read_tokens: 1_000 })] }),
+    ]);
+
+    expect(screen.getByText(/100% hit rate/)).toBeInTheDocument();
+  });
+
+  it("keeps the full model list reachable when the cell truncates", () => {
+    // A run that spilled across models carries ids long enough to set the
+    // table's width on their own; the cell is capped, so the untruncated list
+    // has to survive somewhere.
+    const models = "claude-haiku-4-5-20251001, claude-opus-5[1m]";
+    open([
+      makeTask({
+        usage: [
+          usage({ model: "claude-haiku-4-5-20251001" }),
+          usage({ model: "claude-opus-5[1m]" }),
+        ],
+      }),
+    ]);
+
+    expect(screen.getByTitle(models)).toBeInTheDocument();
+  });
+
+  it("gives every terminal run a status a screen reader can read", () => {
+    // The status glyph is aria-hidden, so without the paired label a failed
+    // run and a completed one are indistinguishable to assistive tech.
+    open([
+      makeTask({ id: "t-ok", usage: [usage()] }),
+      makeTask({ id: "t-bad", status: "failed", usage: [usage()] }),
+    ]);
+
+    expect(screen.getByText("Completed")).toBeInTheDocument();
+    expect(screen.getByText("Failed")).toBeInTheDocument();
+  });
+
+  it("lets the run table scroll rather than widening the dialog", () => {
+    // jsdom has no layout engine, so the overflow itself is verified in a
+    // browser. What is pinned here is the contract that produced the bug: the
+    // scroll container must be able to shrink below its content. Drop
+    // `min-w-0` and the box grows to the table's min-content width instead of
+    // clipping, which is what pushed the table outside the dialog.
+    open([makeTask({ usage: [usage()] })]);
+
+    const table = screen.getByRole("table");
+    const scroller = table.parentElement;
+    expect(scroller?.className).toContain("overflow-auto");
+    expect(scroller?.className).toContain("min-w-0");
+  });
+});

--- a/packages/views/issues/components/issue-usage-dialog.tsx
+++ b/packages/views/issues/components/issue-usage-dialog.tsx
@@ -84,17 +84,24 @@ export function IssueUsageDialog({
     [priced, pricings],
   );
 
+  // Floor, not round: on a cache-heavy issue 99.55% rounds to "100% hit rate",
+  // which claims every single token came from cache. Flooring only ever says
+  // 100% when it is actually 100%, and one percentage point of pessimism is
+  // cheaper than an impossible-looking number.
   const cacheHitRate =
     total && total.input + total.cacheRead > 0
-      ? Math.round((total.cacheRead / (total.input + total.cacheRead)) * 100)
+      ? Math.floor((total.cacheRead / (total.input + total.cacheRead)) * 100)
       : 0;
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
       {/* DialogContent's base is `sm:max-w-sm`, which the same-specificity
           `max-w-4xl` does not beat — the table then overflows the box instead
-          of the box growing. `!` wins it, matching the transcript dialog. */}
-      <DialogContent className="!max-w-4xl !w-[calc(100vw-4rem)]">
+          of the box growing. `!` wins it, matching the transcript dialog.
+          5xl rather than 4xl because nine columns plus the token bar need
+          ~920px: at 4xl the Cost column — the one people open this for —
+          landed outside the scroll viewport. */}
+      <DialogContent className="!max-w-5xl !w-[calc(100vw-4rem)]">
         <DialogHeader>
           <DialogTitle>{t(($) => $.usage_detail.title)}</DialogTitle>
           <DialogDescription>
@@ -110,7 +117,13 @@ export function IssueUsageDialog({
             {t(($) => $.usage_detail.empty)}
           </p>
         ) : (
-          <div className="flex flex-col gap-5">
+          /* `min-w-0`: DialogContent is a grid, and a grid item defaults to
+             `min-width: auto` — it sizes to its content's minimum rather than
+             to the track. Without this the wide run table pushes this column
+             past the dialog's own max-width, and every sibling (KPI cards,
+             by-agent bars, footnotes) stretches with it and paints outside
+             the box. */
+          <div className="flex min-w-0 flex-col gap-5">
             <div className="grid grid-cols-3 divide-x rounded-lg border bg-card">
               <KpiCard
                 label={t(($) => $.usage_detail.kpi_cost)}
@@ -268,7 +281,12 @@ function RunTable({ tasks, total }: { tasks: AgentTask[]; total: TaskUsageSummar
     // Nine columns of numbers have a floor width; on a narrow window they
     // scroll sideways rather than squeezing the trigger text to nothing or
     // pushing the totals outside the dialog.
-    <div className="max-h-[45vh] overflow-auto">
+    //
+    // `min-w-0` is what makes `overflow-auto` actually clip: as a flex item
+    // this box defaults to `min-width: auto`, so it grows to the table's
+    // min-content width and never scrolls. Removing it puts the table back
+    // outside the dialog.
+    <div className="max-h-[45vh] min-w-0 overflow-auto">
       <table className="w-full min-w-[46rem]">
         <thead className="sticky top-0 bg-popover">
           <tr className="text-micro text-muted-foreground [&>th]:whitespace-nowrap [&>th]:px-2 [&>th]:pb-1.5 [&>th]:text-right [&>th]:font-normal">
@@ -340,8 +358,17 @@ function RunRow({ task, maxTokens }: { task: AgentTask; maxTokens: number }) {
           )}
         </div>
       </td>
-      <td className="text-micro text-muted-foreground">
-        {summary.models.join(", ") || "—"}
+      {/* A run that spilled across models lists them all, and real model ids
+          are long (`claude-haiku-4-5-20251001, claude-opus-5[1m]`). Left
+          uncapped that single cell sets the table's width and forces every
+          other issue's dialog to scroll sideways, so cap it and keep the full
+          list in the title. `whitespace-nowrap` comes from the row, so the
+          cell needs its own width bound for `truncate` to have anything to
+          truncate against. */}
+      <td className="max-w-[11rem] text-micro text-muted-foreground">
+        <span className="block truncate" title={summary.models.join(", ")}>
+          {summary.models.join(", ") || "—"}
+        </span>
       </td>
       <td className="text-muted-foreground">{duration || "—"}</td>
       <td>{formatTokens(summary.input)}</td>


### PR DESCRIPTION
Follow-up to #6440. Reported with a screenshot on MUL-5762.

## What was broken

On a real issue the breakdown painted **outside its own dialog** — the KPI cards, the by-agent bars and the entire run table rendered over the page behind it, and the Cost column was off the right edge with no way to reach it.

## Cause

`DialogContent` is a `grid`; the scroll wrapper was a plain flex item. Both default to `min-width: auto`, so they size to their content's min-content width rather than to the track. `overflow-auto` therefore had nothing to clip — the box grew to **1032px inside an 896px dialog** and every sibling stretched with it.

Measured in the browser before the fix:

```
dialog box:     896px
scrollWidth:   1048px
scroller:      1032px wide, scrollWidth 1032  ← never scrolled, just grew
worst overflow: 152px past the dialog's right edge
```

`min-w-0` on the content column and on the scroller is what lets the table scroll instead of pushing.

## Two things made the table wide enough to trigger it

- **The Model cell was uncapped.** A run that spilled across models prints both ids in full (`claude-haiku-4-5-20251001, claude-opus-5[1m]`) — one such run set the width for the entire table, so every *other* issue's dialog inherited the overflow. Now capped and truncated, with the full list in the `title`.
- **`max-w-4xl` was too narrow.** Nine columns plus the token bar need ~920px. At 4xl the Cost column landed outside the scroll viewport even after the clipping was fixed. 5xl fits the whole table with no scrolling at ≥1100px; below that it scrolls, which is the honest outcome for a dialog that cannot exceed the window.

## Also

Cache hit rate now **floors** instead of rounding. 99.55% was printing "100% hit rate", which claims every token came from cache on an issue that plainly read fresh input.

## Verification

Browser-measured at three viewport widths, on the same data that reproduced it:

| viewport | dialog | escapes outside dialog | Cost column |
| --- | --- | --- | --- |
| 1440 | 1024px | 0px | visible, no scroll needed |
| 1100 | 1024px | 0px | visible, no scroll needed |
| 900 | 836px | 0px | reachable by scrolling |

jsdom has no layout engine, so the overflow itself cannot be unit-tested. The new tests pin the contract that produced the bug — the scroller must be able to shrink below its content — plus the truncation, hit-rate and screen-reader-label behaviours. I verified all of them fail when their fix is reverted.

`pnpm typecheck` clean, `pnpm lint` 0 errors, views 3643 passed. The one `sidebar-resize` failure is pre-existing on `main`.
