### PR TITLE
fix(mentions): route synthesized agent comments

### DIFF
--- a/server/internal/handler/comment.go
+++ b/server/internal/handler/comment.go
@@ -1930,6 +1930,32 @@ func isClientAuthorableCommentType(t string) bool {
 	return ok
 }
 
+// triggerSynthesizedAgentComment routes explicit mentions from the fallback
+// comment TaskService creates when an agent finishes without posting a live
+// comment. It deliberately reuses the normal comment trigger engine instead
+// of enqueueing from the service layer, preserving invoke authorization,
+// attribution, squad resolution, pending-task folding, and blocked outcomes.
+func (h *Handler) triggerSynthesizedAgentComment(ctx context.Context, issue db.Issue, comment db.Comment) {
+	if comment.Type != "comment" || comment.AuthorType != "agent" {
+		return
+	}
+
+	var parentComment *db.Comment
+	if comment.ParentID.Valid {
+		if parent, err := h.Queries.GetCommentInWorkspace(ctx, db.GetCommentInWorkspaceParams{
+			ID:          comment.ParentID,
+			WorkspaceID: issue.WorkspaceID,
+		}); err == nil {
+			parentComment = &parent
+		}
+	}
+
+	authorID := uuidToString(comment.AuthorID)
+	originatorUserID := uuidToString(h.TaskService.ResolveOriginatorFromTriggerComment(ctx, issue.WorkspaceID, comment.ID))
+	delegationAuthority := h.autopilotDelegationAuthorityFromComment(ctx, issue, comment)
+	h.triggerTasksForComment(ctx, issue, comment, parentComment, comment.AuthorType, authorID, originatorUserID, delegationAuthority, nil)
+}
+
 // noteCommentPrefix marks a comment as a human-only note. A comment whose first
 // whitespace-delimited token is this prefix (case-insensitive) is stored like
 // any other comment but never triggers an agent.

--- a/server/internal/handler/handler.go
+++ b/server/internal/handler/handler.go
@@ -370,6 +370,7 @@ func New(queries *db.Queries, txStarter txStarter, hub *realtime.Hub, bus *event
 		slog.Warn("github: PR snapshot pipeline disabled (invalid App private key)", "err", err)
 	}
 	h.PRRefresh = ghsnapshot.NewManager(ghClient, queries, txStarter, h.broadcastPRSnapshotApplied)
+	taskSvc.AgentCommentCreated = h.triggerSynthesizedAgentComment
 
 	return h
 }

--- a/server/internal/handler/squad_no_action_test.go
+++ b/server/internal/handler/squad_no_action_test.go
@@ -14,6 +14,7 @@ import (
 type runningSquadLeaderTaskFixture struct {
 	IssueID          string
 	LeaderID         string
+	OtherID          string
 	TaskID           string
 	TriggerCommentID string
 }
@@ -59,6 +60,7 @@ func newRunningSquadLeaderTaskFixture(t *testing.T) runningSquadLeaderTaskFixtur
 	return runningSquadLeaderTaskFixture{
 		IssueID:          issueID,
 		LeaderID:         fx.LeaderID,
+		OtherID:          fx.OtherID,
 		TaskID:           taskID,
 		TriggerCommentID: triggerCommentID,
 	}
@@ -158,6 +160,28 @@ func TestCompleteTask_SquadLeaderActionStillSynthesizesComment(t *testing.T) {
 
 	if got := countAgentCommentsForIssue(t, fx.IssueID, fx.LeaderID); got != 1 {
 		t.Fatalf("expected action completion to synthesize one comment, got %d", got)
+	}
+}
+
+func TestCompleteTask_SynthesizedMentionEnqueuesTarget(t *testing.T) {
+	if testHandler == nil || testPool == nil {
+		t.Skip("database not available")
+	}
+
+	fx := newRunningSquadLeaderTaskFixture(t)
+	recordSquadLeaderEvaluationForTask(t, fx, "action")
+
+	completeRunningTask(t, fx, "Please [@Worker](mention://agent/"+fx.OtherID+") take the implementation.")
+
+	var queued int
+	if err := testPool.QueryRow(context.Background(), `
+		SELECT count(*) FROM agent_task_queue
+		WHERE issue_id = $1 AND agent_id = $2 AND status = 'queued' AND is_leader_task = FALSE
+	`, fx.IssueID, fx.OtherID).Scan(&queued); err != nil {
+		t.Fatalf("count worker tasks: %v", err)
+	}
+	if queued != 1 {
+		t.Fatalf("expected synthesized @agent mention to enqueue one worker task, got %d", queued)
 	}
 }
 

--- a/server/internal/service/builtin_skills/multica-mentioning/references/mentioning-source-map.md
+++ b/server/internal/service/builtin_skills/multica-mentioning/references/mentioning-source-map.md
@@ -35,6 +35,7 @@ a pointer.
 | `computeMentionedAgentCommentTriggers` builds the mention trigger set; `enqueueCommentAgentTriggers` is the shared enqueue helper | `server/internal/handler/comment.go:1381-1467,1124-1157` |
 | Comment creation runs `triggerTasksForComment`, which computes triggers, applies suppressions, then enqueues | `server/internal/handler/comment.go:1069,1092-1098` |
 | Comment edit re-triggering also runs `triggerTasksForComment` after cancelling old tasks for the edited comment | `server/internal/handler/comment.go:1577-1594` |
+| Task completion fallback comments reuse `triggerTasksForComment`, so an explicit mention emitted only in final output is routed with the same authorization, attribution, squad, coalescing, deferred, and blocked-outcome behavior as a live comment | `server/internal/service/task.go` (search `AgentCommentCreated`); `server/internal/handler/handler.go` (search `triggerSynthesizedAgentComment`); `server/internal/handler/comment.go` (search `func (h *Handler) triggerSynthesizedAgentComment`) |
 | `squad` branch: resolve squad in workspace, read `LeaderID`, add the leader trigger | `server/internal/handler/comment.go:1397-1435` |
 | `squad` → shared enqueue helper calls `EnqueueTaskForSquadLeader` | `server/internal/handler/comment.go:1141-1147` |
 | Everything not `agent` after the squad branch is skipped: `if m.Type != "agent" { continue }` | `server/internal/handler/comment.go:1437-1439` |

--- a/server/internal/service/task.go
+++ b/server/internal/service/task.go
@@ -40,6 +40,12 @@ type TaskService struct {
 	Analytics analytics.Client
 	Metrics   *obsmetrics.BusinessMetrics
 	Wakeup    TaskWakeupNotifier
+	// AgentCommentCreated is invoked after a synthesized issue comment is
+	// persisted. The HTTP handler wires this hook to the same mention trigger
+	// engine used by live comments, so a handoff emitted only in a task's final
+	// output is not silently dropped. Nil keeps standalone service tests and
+	// non-HTTP callers backward-compatible.
+	AgentCommentCreated func(context.Context, db.Issue, db.Comment)
 	// FeatureFlags is the server-side toggle router. Nil is valid and returns
 	// each call site's default.
 	FeatureFlags *featureflag.Service
@@ -4867,6 +4873,9 @@ func (s *TaskService) createAgentComment(ctx context.Context, issueID, agentID p
 		},
 	})
 	s.AutoUnresolveThreadOnReply(ctx, rootComment, util.UUIDToString(issue.WorkspaceID), "agent", util.UUIDToString(agentID))
+	if comment.Type == "comment" && s.AgentCommentCreated != nil {
+		s.AgentCommentCreated(ctx, issue, comment)
+	}
 }
 
 // AutoUnresolveThreadOnReply clears resolved_at on the thread root when a


### PR DESCRIPTION
## Summary
- route mentions from synthesized task-completion comments through the normal comment trigger engine
- preserve current invoke authorization, attribution, squad resolution, pending-task folding, and blocked outcomes
- add a regression test proving a synthesized agent mention enqueues the target
- document the fallback path in the built-in mentioning source map

## Why
When an agent finishes without posting a live comment, CompleteTask synthesizes a comment from final output. That persisted the handoff text but previously skipped mention routing, so the UI could show a delegation that never ran. This addresses #2702.

#2963 identified the same gap, but enqueues directly from TaskService. Current main has additional authorization, attribution, coalescing/deferred, and blocked-outcome behavior in the handler trigger engine. This change calls that existing engine instead of duplicating its logic.

## Tests
- go test ./internal/service -count=1
- go test -v ./internal/handler -run TestCompleteTask_SynthesizedMentionEnqueuesTarget\|TestCompleteTask_SquadLeaderActionStillSynthesizesComment -count=1 (isolated migrated PostgreSQL)
- git diff --check