### PR TITLE
MUL-5782: fix(daemon): preserve runtime config on write failure

### DIFF
--- a/server/internal/daemon/execenv/runtime_config.go
+++ b/server/internal/daemon/execenv/runtime_config.go
@@ -236,10 +236,20 @@ func writeRuntimeConfigFile(path, brief string) error {
 
 	existing, err := os.ReadFile(path)
 	if errors.Is(err, fs.ErrNotExist) {
-		return os.WriteFile(path, []byte(block), 0o644)
+		// A dangling symlink also reports ErrNotExist through ReadFile. Do not
+		// replace that user-owned link with a regular file; there is no existing
+		// target we can atomically replace.
+		if info, lerr := os.Lstat(path); lerr == nil && info.Mode()&os.ModeSymlink != 0 {
+			return fmt.Errorf("runtime config %s is a dangling symlink", path)
+		}
+		return writeRuntimeConfigFileAtomic(path, []byte(block), 0o644)
 	}
 	if err != nil {
 		return fmt.Errorf("read existing runtime config %s: %w", path, err)
+	}
+	writePath, perm, err := existingRuntimeConfigWriteTarget(path)
+	if err != nil {
+		return err
 	}
 
 	existingStr := string(existing)
@@ -250,7 +260,7 @@ func writeRuntimeConfigFile(path, brief string) error {
 		// The managed separator (if any) lives in existingStr[:start] and
 		// is preserved untouched.
 		newContent := existingStr[:start] + block + existingStr[end:]
-		return os.WriteFile(path, []byte(newContent), 0o644)
+		return writeRuntimeConfigFileAtomic(writePath, []byte(newContent), perm)
 	}
 
 	// No marker block present. Append the fixed managed separator followed
@@ -258,7 +268,84 @@ func writeRuntimeConfigFile(path, brief string) error {
 	// that already end in two or more newlines — so the byte boundary
 	// between user content and the managed region is deterministic, which
 	// is what lets Cleanup roll back to the user's exact original bytes.
-	return os.WriteFile(path, []byte(existingStr+runtimeManagedSeparator+block), 0o644)
+	return writeRuntimeConfigFileAtomic(writePath, []byte(existingStr+runtimeManagedSeparator+block), perm)
+}
+
+// existingRuntimeConfigWriteTarget returns the regular file that an existing
+// runtime-config path names, plus its current permission bits. Resolving a
+// symlink before the atomic rename preserves the user's link itself; renaming
+// directly onto path would silently replace it with a regular file.
+func existingRuntimeConfigWriteTarget(path string) (string, fs.FileMode, error) {
+	info, err := os.Stat(path)
+	if err != nil {
+		return "", 0, fmt.Errorf("stat existing runtime config %s: %w", path, err)
+	}
+	writePath := path
+	linkInfo, err := os.Lstat(path)
+	if err != nil {
+		return "", 0, fmt.Errorf("lstat existing runtime config %s: %w", path, err)
+	}
+	if linkInfo.Mode()&os.ModeSymlink != 0 {
+		writePath, err = filepath.EvalSymlinks(path)
+		if err != nil {
+			return "", 0, fmt.Errorf("resolve runtime config symlink %s: %w", path, err)
+		}
+	}
+	return writePath, info.Mode().Perm(), nil
+}
+
+// writeRuntimeConfigFileAtomic stages data in the destination directory and
+// renames it into place only after the complete payload has been written,
+// chmodded, synced, and closed. A direct os.WriteFile opens an existing target
+// with O_TRUNC, so a disk-full or short-write error can return after destroying
+// the user's CLAUDE.md / AGENTS.md. With same-directory staging, every failure
+// before Rename leaves the original file byte-identical.
+func writeRuntimeConfigFileAtomic(path string, data []byte, perm fs.FileMode) error {
+	return writeRuntimeConfigFileAtomicWith(path, data, perm, func(file *os.File, payload []byte) error {
+		_, err := file.Write(payload)
+		return err
+	})
+}
+
+// writeRuntimeConfigFileAtomicWith exposes only the staging write operation so
+// tests can inject a deterministic partial-write failure on every platform.
+// Production always enters through writeRuntimeConfigFileAtomic above.
+func writeRuntimeConfigFileAtomicWith(path string, data []byte, perm fs.FileMode, write func(*os.File, []byte) error) error {
+	tmp, err := os.CreateTemp(filepath.Dir(path), "."+filepath.Base(path)+".multica-*.tmp")
+	if err != nil {
+		return fmt.Errorf("create temp runtime config for %s: %w", path, err)
+	}
+	tmpPath := tmp.Name()
+	closed := false
+	committed := false
+	defer func() {
+		if !closed {
+			_ = tmp.Close()
+		}
+		if !committed {
+			_ = os.Remove(tmpPath)
+		}
+	}()
+
+	if err := write(tmp, data); err != nil {
+		return fmt.Errorf("write temp runtime config for %s: %w", path, err)
+	}
+	if err := tmp.Chmod(perm); err != nil {
+		return fmt.Errorf("chmod temp runtime config for %s: %w", path, err)
+	}
+	if err := tmp.Sync(); err != nil {
+		return fmt.Errorf("sync temp runtime config for %s: %w", path, err)
+	}
+	if err := tmp.Close(); err != nil {
+		closed = true
+		return fmt.Errorf("close temp runtime config for %s: %w", path, err)
+	}
+	closed = true
+	if err := replaceRuntimeConfigFile(tmpPath, path); err != nil {
+		return fmt.Errorf("replace runtime config %s: %w", path, err)
+	}
+	committed = true
+	return nil
 }
 
 // locateMarkerBlock finds the [start, end) byte range of the Multica marker
@@ -367,6 +454,9 @@ func CleanupRuntimeConfig(workDir, provider string) error {
 	if !hadManagedSeparator && remainder == "" {
 		// Inject created the file (no managed separator → block was the
 		// only content). Restore the missing-file state.
+		if info, err := os.Lstat(path); err == nil && info.Mode()&os.ModeSymlink != 0 {
+			return fmt.Errorf("runtime config %s is a symlink without a managed separator; refusing to remove it", path)
+		}
 		if err := os.Remove(path); err != nil && !errors.Is(err, fs.ErrNotExist) {
 			return fmt.Errorf("remove runtime config %s: %w", path, err)
 		}
@@ -377,7 +467,11 @@ func CleanupRuntimeConfig(workDir, provider string) error {
 	// without any normalisation. An empty `remainder` here means the
 	// user's original file was empty; we still write it (zero-byte file)
 	// so the file's existence is preserved.
-	return os.WriteFile(path, []byte(remainder), 0o644)
+	writePath, perm, err := existingRuntimeConfigWriteTarget(path)
+	if err != nil {
+		return err
+	}
+	return writeRuntimeConfigFileAtomic(writePath, []byte(remainder), perm)
 }
 
 // buildMetaSkillContent generates the meta skill markdown that teaches the

--- a/server/internal/daemon/execenv/runtime_config.go
+++ b/server/internal/daemon/execenv/runtime_config.go
@@ -242,13 +242,18 @@ func writeRuntimeConfigFile(path, brief string) error {
 		if info, lerr := os.Lstat(path); lerr == nil && info.Mode()&os.ModeSymlink != 0 {
 			return fmt.Errorf("runtime config %s is a dangling symlink", path)
 		}
-		return writeRuntimeConfigFileAtomic(path, []byte(block), 0o644)
+		// CreateTemp starts at 0600, and keeping that private mode avoids
+		// bypassing a restrictive process umask with a later chmod to 0644.
+		return writeRuntimeConfigFileAtomic(path, []byte(block), 0o600)
 	}
 	if err != nil {
 		return fmt.Errorf("read existing runtime config %s: %w", path, err)
 	}
 	writePath, perm, err := existingRuntimeConfigWriteTarget(path)
 	if err != nil {
+		return err
+	}
+	if err := requireRuntimeConfigWritable(writePath); err != nil {
 		return err
 	}
 
@@ -291,15 +296,36 @@ func existingRuntimeConfigWriteTarget(path string) (string, fs.FileMode, error) 
 			return "", 0, fmt.Errorf("resolve runtime config symlink %s: %w", path, err)
 		}
 	}
-	return writePath, info.Mode().Perm(), nil
+	if !info.Mode().IsRegular() {
+		return "", 0, fmt.Errorf("runtime config %s resolves to non-regular file type %s", path, info.Mode().Type())
+	}
+	if err := validateRuntimeConfigReplacementTarget(writePath, info); err != nil {
+		return "", 0, err
+	}
+	return writePath, info.Mode(), nil
+}
+
+// requireRuntimeConfigWritable preserves the permission gate of the previous
+// os.WriteFile path without truncating the target. Checking mode bits alone is
+// insufficient because ACLs and the effective user also participate in the
+// operating system's access decision.
+func requireRuntimeConfigWritable(path string) error {
+	file, err := os.OpenFile(path, os.O_WRONLY, 0)
+	if err != nil {
+		return fmt.Errorf("open existing runtime config %s for writing: %w", path, err)
+	}
+	if err := file.Close(); err != nil {
+		return fmt.Errorf("close writable runtime config %s: %w", path, err)
+	}
+	return nil
 }
 
 // writeRuntimeConfigFileAtomic stages data in the destination directory and
-// renames it into place only after the complete payload has been written,
-// chmodded, synced, and closed. A direct os.WriteFile opens an existing target
-// with O_TRUNC, so a disk-full or short-write error can return after destroying
-// the user's CLAUDE.md / AGENTS.md. With same-directory staging, every failure
-// before Rename leaves the original file byte-identical.
+// commits it with the platform's atomic replacement only after the complete
+// payload has been written, its metadata prepared, synced, and closed. A direct
+// os.WriteFile opens an existing target with O_TRUNC, so a disk-full or
+// short-write error can return after destroying the user's CLAUDE.md /
+// AGENTS.md. Every pre-commit failure leaves the original byte-identical.
 func writeRuntimeConfigFileAtomic(path string, data []byte, perm fs.FileMode) error {
 	return writeRuntimeConfigFileAtomicWith(path, data, perm, func(file *os.File, payload []byte) error {
 		_, err := file.Write(payload)
@@ -311,6 +337,13 @@ func writeRuntimeConfigFileAtomic(path string, data []byte, perm fs.FileMode) er
 // tests can inject a deterministic partial-write failure on every platform.
 // Production always enters through writeRuntimeConfigFileAtomic above.
 func writeRuntimeConfigFileAtomicWith(path string, data []byte, perm fs.FileMode, write func(*os.File, []byte) error) error {
+	metadataSource := ""
+	if _, err := os.Lstat(path); err == nil {
+		metadataSource = path
+	} else if !errors.Is(err, fs.ErrNotExist) {
+		return fmt.Errorf("inspect runtime config metadata source %s: %w", path, err)
+	}
+
 	tmp, err := os.CreateTemp(filepath.Dir(path), "."+filepath.Base(path)+".multica-*.tmp")
 	if err != nil {
 		return fmt.Errorf("create temp runtime config for %s: %w", path, err)
@@ -330,8 +363,8 @@ func writeRuntimeConfigFileAtomicWith(path string, data []byte, perm fs.FileMode
 	if err := write(tmp, data); err != nil {
 		return fmt.Errorf("write temp runtime config for %s: %w", path, err)
 	}
-	if err := tmp.Chmod(perm); err != nil {
-		return fmt.Errorf("chmod temp runtime config for %s: %w", path, err)
+	if err := preserveRuntimeConfigFileMetadata(tmp, metadataSource, perm); err != nil {
+		return fmt.Errorf("preserve runtime config metadata for %s: %w", path, err)
 	}
 	if err := tmp.Sync(); err != nil {
 		return fmt.Errorf("sync temp runtime config for %s: %w", path, err)
@@ -469,6 +502,9 @@ func CleanupRuntimeConfig(workDir, provider string) error {
 	// so the file's existence is preserved.
 	writePath, perm, err := existingRuntimeConfigWriteTarget(path)
 	if err != nil {
+		return err
+	}
+	if err := requireRuntimeConfigWritable(writePath); err != nil {
 		return err
 	}
 	return writeRuntimeConfigFileAtomic(writePath, []byte(remainder), perm)

--- a/server/internal/daemon/execenv/runtime_config_fault_linux_test.go
+++ b/server/internal/daemon/execenv/runtime_config_fault_linux_test.go
@@ -1,0 +1,105 @@
+//go:build linux
+
+package execenv
+
+import (
+	"bytes"
+	"os"
+	"os/signal"
+	"path/filepath"
+	"strings"
+	"syscall"
+	"testing"
+)
+
+// TestWriteRuntimeConfigFilePartialWriteFailurePreservesOriginal is the
+// end-to-end regression for a torn os.WriteFile. RLIMIT_FSIZE makes the staging
+// write fail after 64 bytes: the production call must return that error without
+// truncating the existing user-owned file. The old direct os.WriteFile
+// implementation leaves path as a 64-byte prefix and fails this test.
+func TestWriteRuntimeConfigFilePartialWriteFailurePreservesOriginal(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "AGENTS.md")
+	original := []byte("# User-owned AGENTS.md\n\nThese bytes must survive a failed Multica runtime-brief write.\n")
+	if err := os.WriteFile(path, original, 0o644); err != nil {
+		t.Fatalf("seed original: %v", err)
+	}
+
+	err := withRuntimeConfigFileSizeLimit(t, 64, func() error {
+		return writeRuntimeConfigFile(path, strings.Repeat("load-bearing runtime instruction\n", 1024))
+	})
+	if err == nil {
+		t.Fatal("write unexpectedly succeeded under a 64-byte file-size limit")
+	}
+
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read target after failed write: %v", err)
+	}
+	if !bytes.Equal(got, original) {
+		t.Fatalf("failed runtime-config write changed user file\n got: %q\nwant: %q", got, original)
+	}
+}
+
+func TestCleanupRuntimeConfigPartialWriteFailurePreservesInjectedFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "AGENTS.md")
+	original := []byte("# User-owned AGENTS.md\n\nThese bytes must survive a failed Multica runtime-brief cleanup.\n")
+	if err := os.WriteFile(path, original, 0o644); err != nil {
+		t.Fatalf("seed original: %v", err)
+	}
+	if err := writeRuntimeConfigFile(path, "runtime brief"); err != nil {
+		t.Fatalf("seed injected file: %v", err)
+	}
+	injected, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read injected file: %v", err)
+	}
+
+	err = withRuntimeConfigFileSizeLimit(t, 64, func() error {
+		return CleanupRuntimeConfig(dir, "codex")
+	})
+	if err == nil {
+		t.Fatal("cleanup unexpectedly succeeded under a 64-byte file-size limit")
+	}
+
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read target after failed cleanup: %v", err)
+	}
+	if !bytes.Equal(got, injected) {
+		t.Fatalf("failed runtime-config cleanup changed injected file\n got: %q\nwant: %q", got, injected)
+	}
+}
+
+func withRuntimeConfigFileSizeLimit(t *testing.T, limit uint64, fn func() error) error {
+	t.Helper()
+	var oldLimit syscall.Rlimit
+	if err := syscall.Getrlimit(syscall.RLIMIT_FSIZE, &oldLimit); err != nil {
+		t.Fatalf("get RLIMIT_FSIZE: %v", err)
+	}
+	if oldLimit.Max < limit {
+		t.Skipf("RLIMIT_FSIZE hard limit %d is below requested limit %d", oldLimit.Max, limit)
+	}
+	limited := oldLimit
+	limited.Cur = limit
+	if err := syscall.Setrlimit(syscall.RLIMIT_FSIZE, &limited); err != nil {
+		t.Fatalf("set RLIMIT_FSIZE: %v", err)
+	}
+	signal.Ignore(syscall.SIGXFSZ)
+	restored := false
+	defer func() {
+		if !restored {
+			_ = syscall.Setrlimit(syscall.RLIMIT_FSIZE, &oldLimit)
+			signal.Reset(syscall.SIGXFSZ)
+		}
+	}()
+
+	err := fn()
+	if restoreErr := syscall.Setrlimit(syscall.RLIMIT_FSIZE, &oldLimit); restoreErr != nil {
+		t.Fatalf("restore RLIMIT_FSIZE: %v", restoreErr)
+	}
+	signal.Reset(syscall.SIGXFSZ)
+	restored = true
+	return err
+}

--- a/server/internal/daemon/execenv/runtime_config_fault_linux_test.go
+++ b/server/internal/daemon/execenv/runtime_config_fault_linux_test.go
@@ -5,11 +5,17 @@ package execenv
 import (
 	"bytes"
 	"os"
+	"os/exec"
 	"os/signal"
 	"path/filepath"
 	"strings"
 	"syscall"
 	"testing"
+)
+
+const (
+	runtimeConfigFaultHelperModeEnv = "MULTICA_RUNTIME_CONFIG_FAULT_HELPER_MODE"
+	runtimeConfigFaultHelperPathEnv = "MULTICA_RUNTIME_CONFIG_FAULT_HELPER_PATH"
 )
 
 // TestWriteRuntimeConfigFilePartialWriteFailurePreservesOriginal is the
@@ -18,6 +24,11 @@ import (
 // truncating the existing user-owned file. The old direct os.WriteFile
 // implementation leaves path as a 64-byte prefix and fails this test.
 func TestWriteRuntimeConfigFilePartialWriteFailurePreservesOriginal(t *testing.T) {
+	if os.Getenv(runtimeConfigFaultHelperModeEnv) == "write" {
+		runRuntimeConfigFaultHelper(t, "write")
+		return
+	}
+
 	dir := t.TempDir()
 	path := filepath.Join(dir, "AGENTS.md")
 	original := []byte("# User-owned AGENTS.md\n\nThese bytes must survive a failed Multica runtime-brief write.\n")
@@ -25,12 +36,7 @@ func TestWriteRuntimeConfigFilePartialWriteFailurePreservesOriginal(t *testing.T
 		t.Fatalf("seed original: %v", err)
 	}
 
-	err := withRuntimeConfigFileSizeLimit(t, 64, func() error {
-		return writeRuntimeConfigFile(path, strings.Repeat("load-bearing runtime instruction\n", 1024))
-	})
-	if err == nil {
-		t.Fatal("write unexpectedly succeeded under a 64-byte file-size limit")
-	}
+	runRuntimeConfigFaultSubprocess(t, "write", path)
 
 	got, err := os.ReadFile(path)
 	if err != nil {
@@ -42,6 +48,11 @@ func TestWriteRuntimeConfigFilePartialWriteFailurePreservesOriginal(t *testing.T
 }
 
 func TestCleanupRuntimeConfigPartialWriteFailurePreservesInjectedFile(t *testing.T) {
+	if os.Getenv(runtimeConfigFaultHelperModeEnv) == "cleanup" {
+		runRuntimeConfigFaultHelper(t, "cleanup")
+		return
+	}
+
 	dir := t.TempDir()
 	path := filepath.Join(dir, "AGENTS.md")
 	original := []byte("# User-owned AGENTS.md\n\nThese bytes must survive a failed Multica runtime-brief cleanup.\n")
@@ -56,12 +67,7 @@ func TestCleanupRuntimeConfigPartialWriteFailurePreservesInjectedFile(t *testing
 		t.Fatalf("read injected file: %v", err)
 	}
 
-	err = withRuntimeConfigFileSizeLimit(t, 64, func() error {
-		return CleanupRuntimeConfig(dir, "codex")
-	})
-	if err == nil {
-		t.Fatal("cleanup unexpectedly succeeded under a 64-byte file-size limit")
-	}
+	runRuntimeConfigFaultSubprocess(t, "cleanup", path)
 
 	got, err := os.ReadFile(path)
 	if err != nil {
@@ -69,6 +75,44 @@ func TestCleanupRuntimeConfigPartialWriteFailurePreservesInjectedFile(t *testing
 	}
 	if !bytes.Equal(got, injected) {
 		t.Fatalf("failed runtime-config cleanup changed injected file\n got: %q\nwant: %q", got, injected)
+	}
+}
+
+// runRuntimeConfigFaultSubprocess keeps the process-wide RLIMIT_FSIZE away
+// from the parent go test process. In particular, cmd intentionally omits
+// -test.testlogfile: otherwise Go's test-cache recorder can try to write while
+// the 64-byte limit is active and fail the package after every test has passed.
+func runRuntimeConfigFaultSubprocess(t *testing.T, mode, path string) {
+	t.Helper()
+	cmd := exec.Command(os.Args[0], "-test.run=^"+t.Name()+"$")
+	cmd.Env = append(os.Environ(),
+		runtimeConfigFaultHelperModeEnv+"="+mode,
+		runtimeConfigFaultHelperPathEnv+"="+path,
+	)
+	if output, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("runtime-config fault helper failed: %v\n%s", err, output)
+	}
+}
+
+func runRuntimeConfigFaultHelper(t *testing.T, mode string) {
+	t.Helper()
+	path := os.Getenv(runtimeConfigFaultHelperPathEnv)
+	if path == "" {
+		t.Fatal("runtime-config fault helper path is empty")
+	}
+
+	err := withRuntimeConfigFileSizeLimit(t, 64, func() error {
+		switch mode {
+		case "write":
+			return writeRuntimeConfigFile(path, strings.Repeat("load-bearing runtime instruction\n", 1024))
+		case "cleanup":
+			return CleanupRuntimeConfig(filepath.Dir(path), "codex")
+		default:
+			return nil
+		}
+	})
+	if err == nil {
+		t.Fatalf("%s unexpectedly succeeded under a 64-byte file-size limit", mode)
 	}
 }
 

--- a/server/internal/daemon/execenv/runtime_config_metadata_darwin.go
+++ b/server/internal/daemon/execenv/runtime_config_metadata_darwin.go
@@ -1,0 +1,44 @@
+package execenv
+
+import (
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+
+	"golang.org/x/sys/unix"
+)
+
+// Existing-file metadata stays attached to the target inode because Darwin's
+// exchangedata replacement swaps only file contents. Missing files retain the
+// deliberately private 0600 mode.
+func preserveRuntimeConfigFileMetadata(staged *os.File, sourcePath string, mode fs.FileMode) error {
+	if sourcePath == "" {
+		return staged.Chmod(mode)
+	}
+	// exchangedata swaps every data fork. Seed the staged file with the
+	// original resource fork so the target receives an identical fork while
+	// its ACLs, xattrs, flags, owner, and inode stay attached in place.
+	const resourceFork = "com.apple.ResourceFork"
+	for {
+		size, err := unix.Getxattr(sourcePath, resourceFork, nil)
+		if errors.Is(err, unix.ENOATTR) {
+			return nil
+		}
+		if err != nil {
+			return fmt.Errorf("inspect resource fork: %w", err)
+		}
+		value := make([]byte, size)
+		n, err := unix.Getxattr(sourcePath, resourceFork, value)
+		if err == unix.ERANGE {
+			continue
+		}
+		if err != nil {
+			return fmt.Errorf("read resource fork: %w", err)
+		}
+		if err := unix.Setxattr(staged.Name(), resourceFork, value[:n], 0); err != nil {
+			return fmt.Errorf("copy resource fork: %w", err)
+		}
+		return nil
+	}
+}

--- a/server/internal/daemon/execenv/runtime_config_metadata_darwin_test.go
+++ b/server/internal/daemon/execenv/runtime_config_metadata_darwin_test.go
@@ -1,0 +1,39 @@
+package execenv
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"golang.org/x/sys/unix"
+)
+
+func TestRuntimeConfigRoundTripPreservesDarwinResourceFork(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "AGENTS.md")
+	if err := os.WriteFile(path, []byte("user instructions\n"), 0o644); err != nil {
+		t.Fatalf("seed runtime config: %v", err)
+	}
+	const resourceFork = "com.apple.ResourceFork"
+	want := []byte("user-owned resource fork")
+	if err := unix.Setxattr(path, resourceFork, want, 0); err != nil {
+		t.Skipf("resource forks unavailable: %v", err)
+	}
+
+	if err := writeRuntimeConfigFile(path, "runtime brief"); err != nil {
+		t.Fatalf("inject runtime config: %v", err)
+	}
+	if err := CleanupRuntimeConfig(dir, "codex"); err != nil {
+		t.Fatalf("cleanup runtime config: %v", err)
+	}
+
+	got := make([]byte, len(want))
+	n, err := unix.Getxattr(path, resourceFork, got)
+	if err != nil {
+		t.Fatalf("read resource fork after round trip: %v", err)
+	}
+	if !bytes.Equal(got[:n], want) {
+		t.Fatalf("resource fork after round trip = %q, want %q", got[:n], want)
+	}
+}

--- a/server/internal/daemon/execenv/runtime_config_metadata_other.go
+++ b/server/internal/daemon/execenv/runtime_config_metadata_other.go
@@ -1,0 +1,16 @@
+//go:build !linux && !darwin && !windows
+
+package execenv
+
+import (
+	"fmt"
+	"io/fs"
+	"os"
+)
+
+func preserveRuntimeConfigFileMetadata(staged *os.File, sourcePath string, mode fs.FileMode) error {
+	if sourcePath != "" {
+		return fmt.Errorf("metadata-preserving runtime config replacement is unsupported on this platform")
+	}
+	return staged.Chmod(mode)
+}

--- a/server/internal/daemon/execenv/runtime_config_metadata_unix.go
+++ b/server/internal/daemon/execenv/runtime_config_metadata_unix.go
@@ -1,0 +1,140 @@
+//go:build linux
+
+package execenv
+
+import (
+	"bytes"
+	"fmt"
+	"io/fs"
+	"os"
+
+	"golang.org/x/sys/unix"
+)
+
+// preserveRuntimeConfigFileMetadata clones the inode metadata that an atomic
+// rename would otherwise discard. Ownership is applied before mode bits
+// because chown can clear set-ID bits; extended attributes are copied exactly,
+// including POSIX ACLs where the filesystem exposes them as xattrs.
+func preserveRuntimeConfigFileMetadata(staged *os.File, sourcePath string, mode fs.FileMode) error {
+	if sourcePath == "" {
+		return staged.Chmod(mode)
+	}
+
+	source, err := os.Open(sourcePath)
+	if err != nil {
+		return fmt.Errorf("open metadata source: %w", err)
+	}
+	defer source.Close()
+
+	var sourceStat unix.Stat_t
+	if err := unix.Fstat(int(source.Fd()), &sourceStat); err != nil {
+		return fmt.Errorf("stat metadata source: %w", err)
+	}
+	var stagedStat unix.Stat_t
+	if err := unix.Fstat(int(staged.Fd()), &stagedStat); err != nil {
+		return fmt.Errorf("stat staged file: %w", err)
+	}
+	if stagedStat.Uid != sourceStat.Uid || stagedStat.Gid != sourceStat.Gid {
+		if err := unix.Fchown(int(staged.Fd()), int(sourceStat.Uid), int(sourceStat.Gid)); err != nil {
+			return fmt.Errorf("copy owner and group: %w", err)
+		}
+	}
+	if err := unix.Fchmod(int(staged.Fd()), uint32(sourceStat.Mode)&0o7777); err != nil {
+		return fmt.Errorf("copy file mode: %w", err)
+	}
+
+	sourceAttrs, err := readRuntimeConfigXattrs(int(source.Fd()))
+	if err != nil {
+		return fmt.Errorf("read source extended attributes: %w", err)
+	}
+	stagedAttrs, err := listRuntimeConfigXattrs(int(staged.Fd()))
+	if err != nil {
+		return fmt.Errorf("list staged extended attributes: %w", err)
+	}
+	for _, name := range stagedAttrs {
+		if _, keep := sourceAttrs[name]; keep {
+			continue
+		}
+		if err := unix.Fremovexattr(int(staged.Fd()), name); err != nil {
+			return fmt.Errorf("remove inherited extended attribute %q: %w", name, err)
+		}
+	}
+	for name, value := range sourceAttrs {
+		if err := unix.Fsetxattr(int(staged.Fd()), name, value, 0); err != nil {
+			return fmt.Errorf("copy extended attribute %q: %w", name, err)
+		}
+	}
+
+	if err := unix.Fstat(int(staged.Fd()), &stagedStat); err != nil {
+		return fmt.Errorf("verify staged metadata: %w", err)
+	}
+	if stagedStat.Uid != sourceStat.Uid || stagedStat.Gid != sourceStat.Gid {
+		return fmt.Errorf("staged owner/group = %d:%d, want %d:%d", stagedStat.Uid, stagedStat.Gid, sourceStat.Uid, sourceStat.Gid)
+	}
+	if got, want := uint32(stagedStat.Mode)&0o7777, uint32(sourceStat.Mode)&0o7777; got != want {
+		return fmt.Errorf("staged mode = %04o, want %04o", got, want)
+	}
+	return nil
+}
+
+func readRuntimeConfigXattrs(fd int) (map[string][]byte, error) {
+	names, err := listRuntimeConfigXattrs(fd)
+	if err != nil {
+		return nil, err
+	}
+	attrs := make(map[string][]byte, len(names))
+	for _, name := range names {
+		value, err := readRuntimeConfigXattr(fd, name)
+		if err != nil {
+			return nil, fmt.Errorf("read %q: %w", name, err)
+		}
+		attrs[name] = value
+	}
+	return attrs, nil
+}
+
+func listRuntimeConfigXattrs(fd int) ([]string, error) {
+	for {
+		size, err := unix.Flistxattr(fd, nil)
+		if err != nil {
+			return nil, err
+		}
+		if size == 0 {
+			return nil, nil
+		}
+		buf := make([]byte, size)
+		n, err := unix.Flistxattr(fd, buf)
+		if err == unix.ERANGE {
+			continue
+		}
+		if err != nil {
+			return nil, err
+		}
+		parts := bytes.Split(bytes.TrimRight(buf[:n], "\x00"), []byte{0})
+		names := make([]string, 0, len(parts))
+		for _, part := range parts {
+			if len(part) != 0 {
+				names = append(names, string(part))
+			}
+		}
+		return names, nil
+	}
+}
+
+func readRuntimeConfigXattr(fd int, name string) ([]byte, error) {
+	for {
+		size, err := unix.Fgetxattr(fd, name, nil)
+		if err != nil {
+			return nil, err
+		}
+		value := make([]byte, size)
+		n, err := unix.Fgetxattr(fd, name, value)
+		if err == unix.ERANGE {
+			continue
+		}
+		if err != nil {
+			return nil, err
+		}
+		return value[:n], nil
+	}
+}

--- a/server/internal/daemon/execenv/runtime_config_metadata_unix_test.go
+++ b/server/internal/daemon/execenv/runtime_config_metadata_unix_test.go
@@ -1,0 +1,185 @@
+//go:build linux || darwin
+
+package execenv
+
+import (
+	"bytes"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"syscall"
+	"testing"
+
+	"golang.org/x/sys/unix"
+)
+
+const (
+	runtimeConfigUmaskHelperEnv     = "MULTICA_RUNTIME_CONFIG_UMASK_HELPER"
+	runtimeConfigUmaskHelperPathEnv = "MULTICA_RUNTIME_CONFIG_UMASK_HELPER_PATH"
+)
+
+func TestWriteRuntimeConfigFileRejectsReadOnlyTarget(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "AGENTS.md")
+	original := []byte("user-owned read-only instructions\n")
+	if err := os.WriteFile(path, original, 0o444); err != nil {
+		t.Fatalf("seed read-only target: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(path, 0o644) })
+
+	probe, err := os.OpenFile(path, os.O_WRONLY, 0)
+	if err == nil {
+		_ = probe.Close()
+		t.Skip("current user can write a 0444 file; permission gate cannot be asserted")
+	}
+	if err := writeRuntimeConfigFile(path, "runtime brief"); err == nil {
+		t.Fatal("write unexpectedly replaced a read-only target")
+	}
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read target after rejection: %v", err)
+	}
+	if !bytes.Equal(got, original) {
+		t.Fatalf("read-only target changed\n got: %q\nwant: %q", got, original)
+	}
+}
+
+func TestCleanupRuntimeConfigRejectsReadOnlyTarget(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "AGENTS.md")
+	if err := os.WriteFile(path, []byte("user instructions\n"), 0o644); err != nil {
+		t.Fatalf("seed cleanup target: %v", err)
+	}
+	if err := writeRuntimeConfigFile(path, "runtime brief"); err != nil {
+		t.Fatalf("inject runtime config: %v", err)
+	}
+	injected, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read injected target: %v", err)
+	}
+	if err := os.Chmod(path, 0o444); err != nil {
+		t.Fatalf("make injected target read-only: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(path, 0o644) })
+
+	probe, err := os.OpenFile(path, os.O_WRONLY, 0)
+	if err == nil {
+		_ = probe.Close()
+		t.Skip("current user can write a 0444 file; permission gate cannot be asserted")
+	}
+	if err := CleanupRuntimeConfig(dir, "codex"); err == nil {
+		t.Fatal("cleanup unexpectedly replaced a read-only target")
+	}
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read target after rejected cleanup: %v", err)
+	}
+	if !bytes.Equal(got, injected) {
+		t.Fatalf("read-only target changed during rejected cleanup\n got: %q\nwant: %q", got, injected)
+	}
+}
+
+func TestWriteRuntimeConfigFileRejectsMultipleHardLinks(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "AGENTS.md")
+	alias := filepath.Join(dir, "shared-instructions.md")
+	original := []byte("hard-linked user instructions\n")
+	if err := os.WriteFile(path, original, 0o644); err != nil {
+		t.Fatalf("seed hard-linked target: %v", err)
+	}
+	if err := os.Link(path, alias); err != nil {
+		t.Skipf("hard links unavailable: %v", err)
+	}
+
+	if err := writeRuntimeConfigFile(path, "runtime brief"); err == nil {
+		t.Fatal("write unexpectedly replaced one entry of a multiple-hard-link file")
+	}
+	for _, candidate := range []string{path, alias} {
+		got, err := os.ReadFile(candidate)
+		if err != nil {
+			t.Fatalf("read %s after rejection: %v", candidate, err)
+		}
+		if !bytes.Equal(got, original) {
+			t.Fatalf("hard-linked target %s changed\n got: %q\nwant: %q", candidate, got, original)
+		}
+	}
+}
+
+func TestWriteRuntimeConfigFilePreservesUnixMetadata(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "AGENTS.md")
+	original := []byte("user instructions\n")
+	if err := os.WriteFile(path, original, 0o640); err != nil {
+		t.Fatalf("seed metadata target: %v", err)
+	}
+
+	attrName := "user.multica.runtime-config-test"
+	if runtime.GOOS == "darwin" {
+		attrName = "com.multica.runtime-config-test"
+	}
+	attrValue := []byte("preserve-me")
+	if err := unix.Setxattr(path, attrName, attrValue, 0); err != nil {
+		t.Skipf("extended attributes unavailable: %v", err)
+	}
+	beforeInfo, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat metadata target: %v", err)
+	}
+	beforeStat := beforeInfo.Sys().(*syscall.Stat_t)
+
+	if err := writeRuntimeConfigFile(path, "runtime brief"); err != nil {
+		t.Fatalf("inject runtime config: %v", err)
+	}
+	if err := CleanupRuntimeConfig(dir, "codex"); err != nil {
+		t.Fatalf("cleanup runtime config: %v", err)
+	}
+
+	afterInfo, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat after round trip: %v", err)
+	}
+	afterStat := afterInfo.Sys().(*syscall.Stat_t)
+	if beforeStat.Uid != afterStat.Uid || beforeStat.Gid != afterStat.Gid {
+		t.Fatalf("owner/group changed from %d:%d to %d:%d", beforeStat.Uid, beforeStat.Gid, afterStat.Uid, afterStat.Gid)
+	}
+	if got, want := afterInfo.Mode().Perm(), beforeInfo.Mode().Perm(); got != want {
+		t.Fatalf("mode after round trip = %04o, want %04o", got, want)
+	}
+	gotAttr := make([]byte, len(attrValue))
+	n, err := unix.Getxattr(path, attrName, gotAttr)
+	if err != nil {
+		t.Fatalf("read preserved extended attribute: %v", err)
+	}
+	if !bytes.Equal(gotAttr[:n], attrValue) {
+		t.Fatalf("extended attribute after round trip = %q, want %q", gotAttr[:n], attrValue)
+	}
+}
+
+func TestWriteMissingRuntimeConfigUsesPrivatePermissions(t *testing.T) {
+	if os.Getenv(runtimeConfigUmaskHelperEnv) == "1" {
+		oldUmask := syscall.Umask(0o077)
+		defer syscall.Umask(oldUmask)
+		if err := writeRuntimeConfigFile(os.Getenv(runtimeConfigUmaskHelperPathEnv), "runtime brief"); err != nil {
+			t.Fatalf("write missing runtime config: %v", err)
+		}
+		return
+	}
+
+	path := filepath.Join(t.TempDir(), "AGENTS.md")
+	cmd := exec.Command(os.Args[0], "-test.run=^TestWriteMissingRuntimeConfigUsesPrivatePermissions$")
+	cmd.Env = append(os.Environ(),
+		runtimeConfigUmaskHelperEnv+"=1",
+		runtimeConfigUmaskHelperPathEnv+"="+path,
+	)
+	if output, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("restrictive-umask helper failed: %v\n%s", err, output)
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat newly created runtime config: %v", err)
+	}
+	if got := info.Mode().Perm(); got != 0o600 {
+		t.Fatalf("new runtime config mode = %04o, want private 0600", got)
+	}
+}

--- a/server/internal/daemon/execenv/runtime_config_replace_darwin.go
+++ b/server/internal/daemon/execenv/runtime_config_replace_darwin.go
@@ -1,0 +1,34 @@
+package execenv
+
+import (
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+
+	"golang.org/x/sys/unix"
+)
+
+// replaceRuntimeConfigFile uses exchangedata for an existing target. Darwin
+// swaps all data forks atomically while leaving ownership, mode, ACLs, xattrs,
+// flags, and object identity attached to the original inode. That is the native
+// safe-save primitive and avoids trying to reconstruct protected ACL metadata.
+func replaceRuntimeConfigFile(stagedPath, targetPath string) error {
+	if _, err := os.Lstat(targetPath); errors.Is(err, fs.ErrNotExist) {
+		return os.Rename(stagedPath, targetPath)
+	} else if err != nil {
+		return fmt.Errorf("stat replace target: %w", err)
+	}
+
+	if err := unix.Exchangedata(stagedPath, targetPath, 0); err != nil {
+		return fmt.Errorf("exchange staged runtime config data: %w", err)
+	}
+	if err := os.Remove(stagedPath); err != nil {
+		removeErr := fmt.Errorf("remove exchanged runtime config staging file: %w", err)
+		if rollbackErr := unix.Exchangedata(stagedPath, targetPath, 0); rollbackErr != nil {
+			return errors.Join(removeErr, fmt.Errorf("restore original runtime config data: %w", rollbackErr))
+		}
+		return removeErr
+	}
+	return nil
+}

--- a/server/internal/daemon/execenv/runtime_config_replace_other.go
+++ b/server/internal/daemon/execenv/runtime_config_replace_other.go
@@ -1,4 +1,4 @@
-//go:build !windows
+//go:build !windows && !darwin
 
 package execenv
 

--- a/server/internal/daemon/execenv/runtime_config_replace_other.go
+++ b/server/internal/daemon/execenv/runtime_config_replace_other.go
@@ -1,0 +1,9 @@
+//go:build !windows
+
+package execenv
+
+import "os"
+
+func replaceRuntimeConfigFile(stagedPath, targetPath string) error {
+	return os.Rename(stagedPath, targetPath)
+}

--- a/server/internal/daemon/execenv/runtime_config_replace_windows.go
+++ b/server/internal/daemon/execenv/runtime_config_replace_windows.go
@@ -6,6 +6,7 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
+	"strings"
 	"syscall"
 	"unsafe"
 
@@ -13,6 +14,20 @@ import (
 )
 
 var replaceFileW = windows.NewLazySystemDLL("kernel32.dll").NewProc("ReplaceFileW")
+
+func validateRuntimeConfigReplacementTarget(string, fs.FileInfo) error {
+	return nil
+}
+
+// preserveRuntimeConfigFileMetadata leaves existing-file metadata to
+// ReplaceFileW, which transfers the target's ACL and filesystem attributes to
+// the staged inode. Missing files retain the deliberately private 0600 mode.
+func preserveRuntimeConfigFileMetadata(staged *os.File, sourcePath string, mode fs.FileMode) error {
+	if sourcePath == "" {
+		return staged.Chmod(mode)
+	}
+	return nil
+}
 
 // replaceRuntimeConfigFile uses ReplaceFileW for an existing target instead
 // of Go's MoveFileEx-based os.Rename. ReplaceFileW carries the replaced file's
@@ -40,15 +55,28 @@ func replaceRuntimeConfigFile(stagedPath, targetPath string) error {
 		return fmt.Errorf("release replacement backup reservation: %w", err)
 	}
 
-	targetPtr, err := windows.UTF16PtrFromString(targetPath)
+	extendedTargetPath, err := extendedLengthWindowsPath(targetPath)
+	if err != nil {
+		return fmt.Errorf("normalize replace target: %w", err)
+	}
+	extendedStagedPath, err := extendedLengthWindowsPath(stagedPath)
+	if err != nil {
+		return fmt.Errorf("normalize staged replacement: %w", err)
+	}
+	extendedBackupPath, err := extendedLengthWindowsPath(backupPath)
+	if err != nil {
+		return fmt.Errorf("normalize replacement backup: %w", err)
+	}
+
+	targetPtr, err := windows.UTF16PtrFromString(extendedTargetPath)
 	if err != nil {
 		return fmt.Errorf("encode replace target: %w", err)
 	}
-	stagedPtr, err := windows.UTF16PtrFromString(stagedPath)
+	stagedPtr, err := windows.UTF16PtrFromString(extendedStagedPath)
 	if err != nil {
 		return fmt.Errorf("encode staged replacement: %w", err)
 	}
-	backupPtr, err := windows.UTF16PtrFromString(backupPath)
+	backupPtr, err := windows.UTF16PtrFromString(extendedBackupPath)
 	if err != nil {
 		return fmt.Errorf("encode replacement backup: %w", err)
 	}
@@ -80,4 +108,23 @@ func replaceRuntimeConfigFile(stagedPath, targetPath string) error {
 		return fmt.Errorf("remove committed replacement backup %s: %w", backupPath, err)
 	}
 	return nil
+}
+
+// extendedLengthWindowsPath gives raw Win32 APIs the same long-path support
+// that Go's os package applies internally. ReplaceFileW otherwise receives an
+// ordinary absolute path and can fail once the existing target exceeds
+// MAX_PATH in a process without a long-path-aware manifest.
+func extendedLengthWindowsPath(path string) (string, error) {
+	if strings.HasPrefix(path, `\\?\`) {
+		return path, nil
+	}
+	abs, err := filepath.Abs(path)
+	if err != nil {
+		return "", err
+	}
+	abs = filepath.Clean(abs)
+	if strings.HasPrefix(abs, `\\`) {
+		return `\\?\UNC\` + strings.TrimPrefix(abs, `\\`), nil
+	}
+	return `\\?\` + abs, nil
 }

--- a/server/internal/daemon/execenv/runtime_config_replace_windows.go
+++ b/server/internal/daemon/execenv/runtime_config_replace_windows.go
@@ -1,0 +1,83 @@
+package execenv
+
+import (
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"syscall"
+	"unsafe"
+
+	"golang.org/x/sys/windows"
+)
+
+var replaceFileW = windows.NewLazySystemDLL("kernel32.dll").NewProc("ReplaceFileW")
+
+// replaceRuntimeConfigFile uses ReplaceFileW for an existing target instead
+// of Go's MoveFileEx-based os.Rename. ReplaceFileW carries the replaced file's
+// ACLs, encryption, compression, named streams, and other attributes onto the
+// staged replacement; MoveFileEx would silently replace them with metadata
+// inherited by the temp file. A same-directory backup lets us restore the
+// original if ReplaceFileW encounters one of its partial-move error states.
+func replaceRuntimeConfigFile(stagedPath, targetPath string) error {
+	if _, err := os.Lstat(targetPath); errors.Is(err, fs.ErrNotExist) {
+		return os.Rename(stagedPath, targetPath)
+	} else if err != nil {
+		return fmt.Errorf("stat replace target: %w", err)
+	}
+
+	backup, err := os.CreateTemp(filepath.Dir(targetPath), "."+filepath.Base(targetPath)+".multica-backup-*.tmp")
+	if err != nil {
+		return fmt.Errorf("reserve replacement backup: %w", err)
+	}
+	backupPath := backup.Name()
+	if err := backup.Close(); err != nil {
+		_ = os.Remove(backupPath)
+		return fmt.Errorf("close replacement backup reservation: %w", err)
+	}
+	if err := os.Remove(backupPath); err != nil {
+		return fmt.Errorf("release replacement backup reservation: %w", err)
+	}
+
+	targetPtr, err := windows.UTF16PtrFromString(targetPath)
+	if err != nil {
+		return fmt.Errorf("encode replace target: %w", err)
+	}
+	stagedPtr, err := windows.UTF16PtrFromString(stagedPath)
+	if err != nil {
+		return fmt.Errorf("encode staged replacement: %w", err)
+	}
+	backupPtr, err := windows.UTF16PtrFromString(backupPath)
+	if err != nil {
+		return fmt.Errorf("encode replacement backup: %w", err)
+	}
+
+	r1, _, callErr := replaceFileW.Call(
+		uintptr(unsafe.Pointer(targetPtr)),
+		uintptr(unsafe.Pointer(stagedPtr)),
+		uintptr(unsafe.Pointer(backupPtr)),
+		0,
+		0,
+		0,
+	)
+	if r1 == 0 {
+		if callErr == windows.ERROR_SUCCESS {
+			callErr = syscall.EINVAL
+		}
+		replaceErr := os.NewSyscallError("ReplaceFileW", callErr)
+		if _, backupErr := os.Lstat(backupPath); backupErr == nil {
+			if restoreErr := os.Rename(backupPath, targetPath); restoreErr != nil {
+				return errors.Join(replaceErr, fmt.Errorf("restore original runtime config from %s: %w", backupPath, restoreErr))
+			}
+		} else if !errors.Is(backupErr, fs.ErrNotExist) {
+			return errors.Join(replaceErr, fmt.Errorf("inspect replacement backup %s: %w", backupPath, backupErr))
+		}
+		return replaceErr
+	}
+
+	if err := os.Remove(backupPath); err != nil && !errors.Is(err, fs.ErrNotExist) {
+		return fmt.Errorf("remove committed replacement backup %s: %w", backupPath, err)
+	}
+	return nil
+}

--- a/server/internal/daemon/execenv/runtime_config_replace_windows_test.go
+++ b/server/internal/daemon/execenv/runtime_config_replace_windows_test.go
@@ -1,0 +1,67 @@
+package execenv
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"golang.org/x/sys/windows"
+)
+
+func TestWriteRuntimeConfigFilePreservesWindowsDACL(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "AGENTS.md")
+	if err := os.WriteFile(path, []byte("user rules\n"), 0o644); err != nil {
+		t.Fatalf("seed runtime config: %v", err)
+	}
+
+	user, err := windows.GetCurrentProcessToken().GetTokenUser()
+	if err != nil {
+		t.Fatalf("get current token user: %v", err)
+	}
+	acl, err := windows.ACLFromEntries([]windows.EXPLICIT_ACCESS{{
+		AccessPermissions: windows.GENERIC_ALL,
+		AccessMode:        windows.GRANT_ACCESS,
+		Inheritance:       windows.NO_INHERITANCE,
+		Trustee: windows.TRUSTEE{
+			TrusteeForm:  windows.TRUSTEE_IS_SID,
+			TrusteeType:  windows.TRUSTEE_IS_USER,
+			TrusteeValue: windows.TrusteeValueFromSID(user.User.Sid),
+		},
+	}}, nil)
+	if err != nil {
+		t.Fatalf("build protected DACL: %v", err)
+	}
+	if err := windows.SetNamedSecurityInfo(
+		path,
+		windows.SE_FILE_OBJECT,
+		windows.DACL_SECURITY_INFORMATION|windows.PROTECTED_DACL_SECURITY_INFORMATION,
+		nil,
+		nil,
+		acl,
+		nil,
+	); err != nil {
+		t.Fatalf("set protected DACL: %v", err)
+	}
+	before := runtimeConfigDACLString(t, path)
+
+	if err := writeRuntimeConfigFile(path, "runtime brief"); err != nil {
+		t.Fatalf("inject runtime config: %v", err)
+	}
+	if after := runtimeConfigDACLString(t, path); after != before {
+		t.Fatalf("Windows DACL changed during atomic replacement\nbefore: %s\n after: %s", before, after)
+	}
+}
+
+func runtimeConfigDACLString(t *testing.T, path string) string {
+	t.Helper()
+	descriptor, err := windows.GetNamedSecurityInfo(
+		path,
+		windows.SE_FILE_OBJECT,
+		windows.DACL_SECURITY_INFORMATION|windows.PROTECTED_DACL_SECURITY_INFORMATION,
+	)
+	if err != nil {
+		t.Fatalf("get DACL for %s: %v", path, err)
+	}
+	return descriptor.String()
+}

--- a/server/internal/daemon/execenv/runtime_config_replace_windows_test.go
+++ b/server/internal/daemon/execenv/runtime_config_replace_windows_test.go
@@ -3,6 +3,7 @@ package execenv
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"golang.org/x/sys/windows"
@@ -50,6 +51,38 @@ func TestWriteRuntimeConfigFilePreservesWindowsDACL(t *testing.T) {
 	}
 	if after := runtimeConfigDACLString(t, path); after != before {
 		t.Fatalf("Windows DACL changed during atomic replacement\nbefore: %s\n after: %s", before, after)
+	}
+}
+
+func TestRuntimeConfigRoundTripSupportsExistingWindowsLongPath(t *testing.T) {
+	dir := t.TempDir()
+	for len(filepath.Join(dir, "AGENTS.md")) <= 280 {
+		dir = filepath.Join(dir, strings.Repeat("nested", 6))
+	}
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("create long-path directory: %v", err)
+	}
+	path := filepath.Join(dir, "AGENTS.md")
+	if len(path) <= 260 {
+		t.Fatalf("test path length = %d, want > 260: %s", len(path), path)
+	}
+	original := []byte("user instructions at a long Windows path\n")
+	if err := os.WriteFile(path, original, 0o644); err != nil {
+		t.Fatalf("seed long-path runtime config: %v", err)
+	}
+
+	if err := writeRuntimeConfigFile(path, "runtime brief"); err != nil {
+		t.Fatalf("inject at long path: %v", err)
+	}
+	if err := CleanupRuntimeConfig(dir, "codex"); err != nil {
+		t.Fatalf("cleanup at long path: %v", err)
+	}
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read long-path target after round trip: %v", err)
+	}
+	if string(got) != string(original) {
+		t.Fatalf("long-path round trip changed user content\n got: %q\nwant: %q", got, original)
 	}
 }
 

--- a/server/internal/daemon/execenv/runtime_config_test.go
+++ b/server/internal/daemon/execenv/runtime_config_test.go
@@ -1,9 +1,11 @@
 package execenv
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strconv"
 	"strings"
 	"testing"
@@ -866,6 +868,100 @@ func TestWriteRuntimeConfigFileIsIdempotent(t *testing.T) {
 	}
 	if !strings.HasPrefix(s, userContent) {
 		t.Errorf("user content must remain intact at the top of the file, got:\n%s", s)
+	}
+}
+
+func TestWriteRuntimeConfigFileAtomicFailurePreservesOriginal(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "AGENTS.md")
+	original := []byte("# User AGENTS.md\n\nThese bytes must survive a failed staging write.\n")
+	if err := os.WriteFile(path, original, 0o644); err != nil {
+		t.Fatalf("seed original: %v", err)
+	}
+
+	injectedErr := errors.New("injected partial-write failure")
+	err := writeRuntimeConfigFileAtomicWith(path, []byte("replacement that must never land"), 0o644, func(file *os.File, payload []byte) error {
+		if _, err := file.Write(payload[:8]); err != nil {
+			return err
+		}
+		return injectedErr
+	})
+	if !errors.Is(err, injectedErr) {
+		t.Fatalf("write error = %v, want injected error", err)
+	}
+
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read target after failed write: %v", err)
+	}
+	if string(got) != string(original) {
+		t.Fatalf("failed staging write changed user file\n got: %q\nwant: %q", got, original)
+	}
+	temps, err := filepath.Glob(filepath.Join(dir, ".AGENTS.md.multica-*.tmp"))
+	if err != nil {
+		t.Fatalf("glob staging files: %v", err)
+	}
+	if len(temps) != 0 {
+		t.Fatalf("failed staging write left temp files: %v", temps)
+	}
+}
+
+func TestWriteRuntimeConfigFilePreservesExistingSymlink(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	target := filepath.Join(dir, "shared-instructions.md")
+	link := filepath.Join(dir, "AGENTS.md")
+	const original = "# Shared instructions\n"
+	if err := os.WriteFile(target, []byte(original), 0o644); err != nil {
+		t.Fatalf("seed symlink target: %v", err)
+	}
+	if err := os.Symlink(target, link); err != nil {
+		t.Skipf("symlink unavailable on this platform: %v", err)
+	}
+
+	if err := writeRuntimeConfigFile(link, "runtime brief"); err != nil {
+		t.Fatalf("write through symlink: %v", err)
+	}
+	info, err := os.Lstat(link)
+	if err != nil {
+		t.Fatalf("lstat link: %v", err)
+	}
+	if info.Mode()&os.ModeSymlink == 0 {
+		t.Fatal("runtime config write replaced the user's symlink")
+	}
+	got, err := os.ReadFile(target)
+	if err != nil {
+		t.Fatalf("read symlink target: %v", err)
+	}
+	if !strings.HasPrefix(string(got), original) || !strings.Contains(string(got), "runtime brief") {
+		t.Fatalf("symlink target did not receive preserved user content plus brief:\n%s", got)
+	}
+}
+
+func TestWriteRuntimeConfigFilePreservesPermissions(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Windows does not expose Unix permission bits consistently")
+	}
+	t.Parallel()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "AGENTS.md")
+	if err := os.WriteFile(path, []byte("user rules\n"), 0o600); err != nil {
+		t.Fatalf("seed restricted file: %v", err)
+	}
+
+	if err := writeRuntimeConfigFile(path, "runtime brief"); err != nil {
+		t.Fatalf("inject: %v", err)
+	}
+	if err := CleanupRuntimeConfig(dir, "codex"); err != nil {
+		t.Fatalf("cleanup: %v", err)
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat after round trip: %v", err)
+	}
+	if got := info.Mode().Perm(); got != 0o600 {
+		t.Fatalf("permissions after atomic inject+cleanup = %04o, want 0600", got)
 	}
 }
 

--- a/server/internal/daemon/execenv/runtime_config_validate_other.go
+++ b/server/internal/daemon/execenv/runtime_config_validate_other.go
@@ -1,0 +1,44 @@
+//go:build !windows
+
+package execenv
+
+import (
+	"fmt"
+	"io/fs"
+	"reflect"
+)
+
+// validateRuntimeConfigReplacementTarget rejects multiple-hard-link files.
+// Replacing only one directory entry would otherwise detach it from the
+// user-owned inode, so cleanup could not restore the original identity.
+// Stat_t.Nlink varies in integer width across Unix targets, hence the small
+// reflective adapter here.
+func validateRuntimeConfigReplacementTarget(path string, info fs.FileInfo) error {
+	stat := reflect.ValueOf(info.Sys())
+	if stat.Kind() == reflect.Pointer {
+		if stat.IsNil() {
+			return fmt.Errorf("inspect runtime config %s link count: missing stat data", path)
+		}
+		stat = stat.Elem()
+	}
+	nlink := stat.FieldByName("Nlink")
+	if !nlink.IsValid() {
+		return fmt.Errorf("inspect runtime config %s link count: unsupported stat data", path)
+	}
+	var count uint64
+	switch nlink.Kind() {
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+		count = nlink.Uint()
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		if nlink.Int() < 0 {
+			return fmt.Errorf("inspect runtime config %s link count: invalid value %d", path, nlink.Int())
+		}
+		count = uint64(nlink.Int())
+	default:
+		return fmt.Errorf("inspect runtime config %s link count: unsupported field type %s", path, nlink.Kind())
+	}
+	if count != 1 {
+		return fmt.Errorf("runtime config %s has %d hard links; refusing atomic replacement", path, count)
+	}
+	return nil
+}


### PR DESCRIPTION
## What does this PR do?

Prevents failed runtime-config writes from truncating user-owned provider instruction files such as `CLAUDE.md`, `AGENTS.md`, `CODEBUDDY.md`, and `QWEN.md`.

`os.WriteFile` opens existing files with `O_TRUNC`. If a subsequent write fails partway through, it returns an error but leaves the original file empty or partially overwritten.

This change stages the complete replacement in the destination directory and only replaces the target after the temporary file has been successfully written, chmodded, synced, and closed. The cleanup path uses the same mechanism.

This PR deliberately does not change:

- the daemon's existing non-fatal runtime-config error policy;
- conflict handling for concurrent user edits.

Those are separate product and concurrency concerns.

## Related Issue

Tracked in Multica: MUL-5782.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Refactor / code improvement (no behavior change)
- [ ] Documentation update
- [x] Tests (adding or improving test coverage)
- [ ] CI / infrastructure

## Changes Made

- Stage runtime-config writes in a same-directory temporary file.
- Preserve the original target when writing, syncing, closing, or replacement fails.
- Apply the same protection to `CleanupRuntimeConfig`.
- Preserve existing Unix permission bits and user-owned symlinks.
- Use `ReplaceFileW` on Windows so replacement preserves the target DACL and metadata.
- Add a deterministic cross-platform partial-write regression test.
- Add Linux kernel-level regression tests using `RLIMIT_FSIZE`.
- Add a Windows DACL preservation regression test.

## How to Test

On Debian/Linux:

```bash
GOTOOLCHAIN=auto go test ./internal/daemon/execenv \
  -run '^(TestWriteRuntimeConfigFilePartialWriteFailurePreservesOriginal|TestCleanupRuntimeConfigPartialWriteFailurePreservesInjectedFile)$' \
  -count=1 -v

GOTOOLCHAIN=auto go test ./internal/daemon/execenv -count=1
```

Observed on Debian:

- Both kernel-level partial-write regression tests pass.
- The complete `internal/daemon/execenv` package passes.

On Windows:

```powershell
go test ./internal/daemon/execenv `
  -run "Test(WriteRuntimeConfigFile|InjectRuntimeConfigPreservesUserContent|CleanupRuntimeConfig)" `
  -count=1
```

The targeted runtime-config suite, including Windows DACL preservation, passes.

The Linux regression uses `RLIMIT_FSIZE` to produce a deterministic partial write after 64 bytes. It does not claim to reproduce an actual `ENOSPC` filesystem; it exercises the same destructive sequence relevant to the bug: the destination is opened and truncated, then the write fails before the full payload is stored.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] If this change affects the UI, I have included before/after screenshots
- [x] I have updated relevant documentation to reflect my changes
- [x] If I added a new runtime / coding tool / UI tab, I synced the change to **landing copy** (`apps/web/features/landing/i18n/`) and **relevant docs** (`apps/docs/content/docs/`)
- [x] If this PR touches Chinese product copy, I checked it against `apps/docs/content/docs/developers/conventions.zh.mdx` (terminology, mixed-rule for `task` / `issue` / `skill`)
- [x] I have considered and documented any risks above
- [x] I will address all reviewer comments before requesting merge

## AI Disclosure

<!-- Most PRs involve AI coding tools — that's totally fine! We're curious about your process. -->

**AI tool used:** Codex Cli

**Prompt / approach:**
Please help me analyze whether Multica AI in the project directory causes destructive changes to user files during build and runtime. For example, does it silently fail to write to files that fail to write?


## Screenshots (optional)

<!-- If applicable, add screenshots showing the change in action. -->