### PR TITLE
MUL-5787: tighten the mobile issue-detail gutters to 12px

### DIFF
--- a/packages/views/issues/components/issue-detail.test.tsx
+++ b/packages/views/issues/components/issue-detail.test.tsx
@@ -666,6 +666,38 @@ describe("IssueDetail (shared)", () => {
     ).toBe(true);
   });
 
+  it("gives the skeleton the same horizontal gutters as the loaded column", async () => {
+    // The skeleton is the loaded column's stand-in, so a gutter change has to
+    // land on both or the column jumps sideways at the moment the issue
+    // arrives. Horizontal only: the loaded column also reserves the chat
+    // launcher's corner at its bottom, which the skeleton has no scroll to
+    // reach.
+    const horizontalGutters = (el: Element | null) =>
+      (el?.className ?? "")
+        .split(/\s+/)
+        .filter((cls) => /(^|:)px-/.test(cls))
+        .sort();
+
+    mockApiObj.getIssue.mockReturnValue(new Promise(() => {}));
+    const loadingRender = renderIssueDetail();
+    const skeletonGutters = horizontalGutters(
+      loadingRender.container.querySelector(".max-w-4xl"),
+    );
+    loadingRender.unmount();
+
+    mockApiObj.getIssue.mockResolvedValue(mockIssue);
+    const { container } = renderIssueDetail();
+    await waitFor(() => {
+      expect(screen.getByText("Implement authentication")).toBeInTheDocument();
+    });
+
+    // Non-empty guard: without it a renamed column class passes vacuously.
+    expect(skeletonGutters.length).toBeGreaterThan(0);
+    expect(skeletonGutters).toEqual(
+      horizontalGutters(container.querySelector(".max-w-4xl")),
+    );
+  });
+
   it("renders comment bodies without Base UI collapsible panels", async () => {
     const { container } = renderIssueDetail();
 

--- a/packages/views/issues/components/issue-detail.tsx
+++ b/packages/views/issues/components/issue-detail.tsx
@@ -1003,7 +1003,7 @@ export function IssueDetailSkeleton({ leading }: { leading?: ReactNode } = {}) {
         <div className="flex-1 overflow-y-auto [scrollbar-gutter:stable_both-edges]">
           {/* Gutters match the loaded column exactly (see its comment), so the
               skeleton doesn't reflow sideways when real content mounts. */}
-          <div className="mx-auto w-full max-w-4xl px-4 py-6 space-y-6 md:px-8 md:py-8">
+          <div className="mx-auto w-full max-w-4xl px-3 py-6 space-y-6 md:px-8 md:py-8">
             <Skeleton className="h-8 w-3/4" />
             <div className="space-y-2">
               <Skeleton className="h-4 w-full" />
@@ -2528,12 +2528,12 @@ export function IssueDetail({ issueId, onDelete, onDone, defaultSidebarOpen = tr
           className="relative flex-1 overflow-y-auto [scrollbar-gutter:stable_both-edges]"
         >
         {/* Gutters: 32px is a comfortable reading margin on a desktop column
-            but eats 16% of a 393px phone, so below `md` they drop to 16px.
+            but eats 16% of a 393px phone, so below `md` they drop to 12px.
             `max-md:pb-chat-launcher` reserves the launcher's corner at the end
             of the scroll: below `md` the composer is not pinned (see
             `useStickyComposer`), so it lands here — right where the launcher
             floats — once the reader scrolls to the bottom. */}
-        <div className="mx-auto w-full max-w-4xl px-4 py-6 max-md:pb-chat-launcher md:px-8 md:py-8">
+        <div className="mx-auto w-full max-w-4xl px-3 py-6 max-md:pb-chat-launcher md:px-8 md:py-8">
           {titleLazy.active && (
             <div className={titleLazy.ready ? undefined : "hidden"}>
               <TitleEditor


### PR DESCRIPTION
Follow-up to #6415, which set the mobile issue-detail gutters to `px-4`. On the phone that is still a wider margin than the column needs — 16px on a 393px screen is 8% of the width spent on nothing, and this is a reading surface whose longest lines (code, identifiers, pasted URLs) are the first thing to wrap. Below `md` the content column gutters go to 12px.

Both gutter sites move together: the loaded column and `IssueDetailSkeleton`. The skeleton exists to hold the column's shape while the issue loads, so a gutter landing on only one of them reflows the column sideways at the moment real content mounts — the exact thing #6415 matched them to prevent. That match was a comment; it is now a test, since a follow-up touching one site is how it breaks. The test compares horizontal gutters only — the loaded column also reserves the chat launcher's corner at its bottom, which the skeleton has no scroll to reach.

Vertical padding is unchanged, and nothing above `md` moves.

**One thing worth a designer's eye:** the header bar (`PageHeader`, `px-4` at every width) does not follow, so on a phone the breadcrumb now starts 4px outside the title below it. `PageHeader` is shared by every page in the app, so moving it is a decision about the whole mobile layout rather than about this column — left alone deliberately. Happy to take it in a follow-up if the offset reads wrong on device.

## Verification

- `packages/views` typecheck — clean.
- `issue-detail.test.tsx` — 58 passed, including the new gutter-match test. Verified it fails when only one site changes (`expected [ 'md:px-8', 'px-4' ] to deeply equal [ 'md:px-8', 'px-3' ]`).
- Full `packages/views` suite — 3644 passed, 1 failed: `layout/sidebar-resize.test.tsx`, which fails identically on a clean `main` checkout. Pre-existing, unrelated.
- ESLint on both changed files — clean.

Not verified on a real device; this is a Tailwind class change with no render-time logic.
