### PR TITLE
chore(daemon): halve the local version-probe frequency to 10 minutes (MUL-3269)

### DIFF
--- a/server/internal/daemon/agents_refresh.go
+++ b/server/internal/daemon/agents_refresh.go
@@ -27,7 +27,20 @@ var agentConvergeMaxBackoff = 30 * time.Minute
 // of codex/claude is picked up without a restart. A round is one `--version`
 // fork per installed CLI, fanned out and machine-level — it does not scale with
 // workspace count or runtime count. Overridable for tests.
-var agentVersionRefreshInterval = 5 * time.Minute
+//
+// This is the one local probe whose cost grows with the host (one fork per
+// installed CLI) and which executes third-party binaries, some of whose
+// wrappers have visible side effects when run — so it is the one worth
+// lengthening if background probing needs to get cheaper.
+//
+// It is not lengthened further than selfReloadCheckInterval, though, because
+// the round does more than refresh a displayed version string: it also keys
+// version-sensitive launch policy, and it is what confirms a CLI has dropped
+// below its minimum supported version and must stop being given work. The
+// interval is therefore also the window in which an unsupported CLI keeps
+// claiming tasks, which is why this tracks the reload check rather than being
+// pushed out on cost grounds alone.
+var agentVersionRefreshInterval = 10 * time.Minute
 
 // agentDiscoveryLoop keeps the registered runtime set converged on the agent
 // CLIs actually installed on this machine, so a CLI installed while the daemon

--- a/server/internal/daemon/auto_update.go
+++ b/server/internal/daemon/auto_update.go
@@ -73,7 +73,17 @@ var autoUpdateInitialDelay = 2 * time.Minute
 // re-exec. One fork/exec per tick, machine-level (not per workspace, not per
 // runtime), so the cost is fixed no matter how big the daemon's workload is.
 // Overridable for tests.
-var selfReloadCheckInterval = 5 * time.Minute
+//
+// The value bounds how long a user waits after replacing the binary themselves,
+// not how often we ship: the "is there a new release" question belongs to
+// DefaultAutoUpdateCheckInterval, and only that one should track release
+// cadence. It also compounds, because a tick that lands while the daemon is
+// busy defers to the next one rather than interrupting a task — so the wait is
+// really "the first tick that is both due and idle". Ten minutes keeps the
+// average wait around five and the multiplier tolerable on a busy host; an hour
+// would not, and would put us back in sight of the "I upgraded and nothing
+// happened" problem this check exists to remove.
+var selfReloadCheckInterval = 10 * time.Minute
 
 // selfReloadProbeTimeout bounds the `--version` fork/exec. Generous: the point
 // of the timeout is to stop a wedged binary from parking the loop goroutine,


### PR DESCRIPTION
## Summary

Both of the daemon's local version probes ran every 5 minutes. This halves the frequency to 10 minutes. The remote GitHub poll is unchanged at 6 hours.

| | Asks | Was | Now |
|---|---|---|---|
| `selfReloadCheckInterval` | has the `multica` binary on this disk changed? | 5 min | **10 min** |
| `agentVersionRefreshInterval` | has an agent CLI upgraded in place? | 5 min | **10 min** |
| `DefaultAutoUpdateCheckInterval` | does a newer release exist upstream? | 6 h | 6 h (unchanged) |

That split is the substance of the change. Only the remote poll asks whether a new release exists, so only it should track release cadence. The two local probes ask whether the binary on this machine has *already* changed — bounded by how long a user is willing to wait after acting themselves, not by how often we ship.

## Why 10 and not longer

Neither probe has caused a measured problem; this is tightening background work that a user never asked for, not fixing a regression. But 10 is the floor for both:

- **`selfReloadCheckInterval` compounds.** A tick that lands while the daemon is busy defers to the next one rather than interrupting a task, so the real wait is "the first tick that is both due *and* idle" — interval × N on a busy host. At 10 min the average wait is ~5 min and the multiplier stays tolerable. At an hour it would not, and we'd be back within sight of the "I upgraded and nothing happened" problem the check exists to remove.
- **`agentVersionRefreshInterval` gates the below-minimum verdict.** The round does more than refresh a displayed version string — it keys version-sensitive launch policy and is what confirms a CLI has dropped below its minimum supported version and must stop being given work. Its interval is therefore also the window in which an unsupported CLI keeps claiming tasks. Cost alone shouldn't push it out, which is why it tracks the reload check rather than going further.

Of the two, this one is where cost actually scales — one fork per *installed* CLI, and it executes third-party binaries whose wrappers can have visible side effects when run. Both comments now record that reasoning so the next person tuning these knows which clock they're touching.

## Not included

No env/config knob. There's no evidence yet that anyone needs to tune these per-host, and a permanent config surface costs documentation, tests, and support. Worth revisiting if real `--version` overhead data or user reports show up.

## Tests

Both are `var`s that tests override with millisecond values, so no test needed updating and none pins the default.

- `go build ./...` — pass
- `go vet ./internal/daemon` — clean
- `go test -count=1 ./internal/daemon` — pass
- `gofmt` clean on both files

Context: follow-up to #4096 (MUL-3269).
