### PR TITLE
refactor(daemon): compress the agent-trigger warning to its per-turn fact (MUL-5442)

### DIFF
--- a/server/internal/daemon/daemon_test.go
+++ b/server/internal/daemon/daemon_test.go
@@ -1078,6 +1078,12 @@ func TestBuildPromptCommentTriggeredByAgent(t *testing.T) {
 
 	for _, want := range []string{
 		"Another agent (Atlas)",
+		// MUL-5442 #6484 review: the compressed block's SHAPE is the
+		// behaviour — pin the canonical pointer and both outcome arms as
+		// sequential relations, not just the closing anchors.
+		"Apply the reply-warranted rule and mention discipline from your brief",
+		"produced real work → post the result as a normal reply",
+		"no work and only an acknowledgment / thanks / sign-off → exit with no output",
 		"do not @mention the other agent as a sign-off",
 		"Silence is the preferred way",
 	} {

--- a/server/internal/daemon/execenv/execenv_test.go
+++ b/server/internal/daemon/execenv/execenv_test.go
@@ -5010,6 +5010,11 @@ func TestInjectRuntimeConfigMentionLoopHardening(t *testing.T) {
 			// the work-produced arm and the silent-exit arm must each
 			// survive compression, not just the bullet's heading.
 			"produced actual work",
+			// The work-category boundary: investigation-only and answer-only
+			// turns COUNT as deliverable work. The per-turn agent-trigger
+			// block points here for this definition (MUL-5442 #6484 review) —
+			// dropping any category silently un-defines the pointer target.
+			"investigation, a fix, or an answer to a real question",
 			"pure acknowledgment / thanks / sign-off",
 			"do NOT reply",
 			"Silence is a valid and preferred way",

--- a/server/internal/daemon/execenv/runtime_config_sections.go
+++ b/server/internal/daemon/execenv/runtime_config_sections.go
@@ -566,7 +566,7 @@ func writeWorkflowIssue(b *strings.Builder, ctx TaskContextForEnv) {
 
 	b.WriteString("**Reply mode only — respond to the comment in the user message**\n\n")
 	b.WriteString("- Respond to THAT specific comment; take its id from the user message, never from this file or from an earlier turn.\n")
-	b.WriteString("- **Decide whether a reply is warranted.** If you produced actual work this turn, post the result via step 5. If the triggering comment was a pure acknowledgment / thanks / sign-off from another agent AND you produced no work, do NOT reply — not even a 'No reply needed' comment; exit with no output. Silence is a valid and preferred way to end agent-to-agent conversations.\n")
+	b.WriteString("- **Decide whether a reply is warranted.** If you produced actual work this turn (investigation, a fix, or an answer to a real question all count), post the result via step 5. If the triggering comment was a pure acknowledgment / thanks / sign-off from another agent AND you produced no work, do NOT reply — not even a 'No reply needed' comment; exit with no output. Silence is a valid and preferred way to end agent-to-agent conversations.\n")
 	if ctx.IsSquadLeader {
 		b.WriteString("- **Squad leader rule:** If your evaluation outcome is `no_action`, call `multica squad activity <issue-id> no_action --reason \"...\"` and then EXIT IMMEDIATELY. DO NOT post any comment whose only purpose is to announce that you are taking no action, exiting silently, or acknowledging another agent. A comment like \"No action needed\" or \"Exiting silently\" is noise — the `squad activity` call already records your decision in the timeline.\n")
 	}

--- a/server/internal/daemon/prompt.go
+++ b/server/internal/daemon/prompt.go
@@ -331,7 +331,7 @@ func buildCommentPrompt(task Task, provider string) string {
 				task.IssueID)
 		}
 		if task.TriggerAuthorType == "agent" {
-			b.WriteString("⚠️ The triggering comment was posted by another agent. Decide whether a reply is warranted. If you produced actual work this turn (investigated, fixed something, answered a real question), post the result as a normal reply — that is NOT a noise comment, and the standard rule that final results must be delivered via comment still applies. If the triggering comment was a pure acknowledgment, thanks, or sign-off AND you produced no work this turn, do NOT reply — and do NOT post a comment saying 'No reply needed' or similar. Simply exit with no output. Silence is the preferred way to end agent-to-agent threads. If you do reply, do not @mention the other agent as a sign-off (that re-triggers them and starts a loop).\n\n")
+			b.WriteString("⚠️ This trigger comment is from another agent. Apply the reply-warranted rule and mention discipline from your brief: produced real work → post the result as a normal reply; pure acknowledgment / thanks / sign-off and no work → exit with no output. Silence is the preferred way to end agent-to-agent threads; do not @mention the other agent as a sign-off (that re-triggers them).\n\n")
 		}
 		if task.Agent != nil && strings.Contains(task.Agent.Instructions, "## Squad Operating Protocol") {
 			fmt.Fprintf(&b, "⚠️ **Squad leader no_action rule:** If you decide no action is needed, call `multica squad activity %s no_action --reason \"...\"` and EXIT. DO NOT post any comment — not even one that says \"no action needed\" or \"exiting silently\". The squad activity call records your decision; a comment is redundant noise.\n\n", task.IssueID)

--- a/server/internal/daemon/prompt.go
+++ b/server/internal/daemon/prompt.go
@@ -331,7 +331,7 @@ func buildCommentPrompt(task Task, provider string) string {
 				task.IssueID)
 		}
 		if task.TriggerAuthorType == "agent" {
-			b.WriteString("⚠️ This trigger comment is from another agent. Apply the reply-warranted rule and mention discipline from your brief: produced real work → post the result as a normal reply; pure acknowledgment / thanks / sign-off and no work → exit with no output. Silence is the preferred way to end agent-to-agent threads; do not @mention the other agent as a sign-off (that re-triggers them).\n\n")
+			b.WriteString("⚠️ This trigger comment is from another agent. Apply the reply-warranted rule and mention discipline from your brief: produced real work → post the result as a normal reply; no work and only an acknowledgment / thanks / sign-off → exit with no output. Silence is the preferred way to end agent-to-agent threads; do not @mention the other agent as a sign-off (that re-triggers them).\n\n")
 		}
 		if task.Agent != nil && strings.Contains(task.Agent.Instructions, "## Squad Operating Protocol") {
 			fmt.Fprintf(&b, "⚠️ **Squad leader no_action rule:** If you decide no action is needed, call `multica squad activity %s no_action --reason \"...\"` and EXIT. DO NOT post any comment — not even one that says \"no action needed\" or \"exiting silently\". The squad activity call records your decision; a comment is redundant noise.\n\n", task.IssueID)


### PR DESCRIPTION
Pool-2 item 1 from the future-todos analysis. Compresses the per-turn agent-trigger warning block and migrates the work-category definition it relied on into the cached brief. Four files: the per-turn string (`prompt.go`), the brief canonical (`runtime_config_sections.go`), and two new pin sets (`daemon_test.go`, `execenv_test.go`).

## Measured

| | bytes |
|---|---:|
| agent-trigger warning block (trailing newlines excluded) | 728 → **390 (−338 per agent-triggered turn)** |
| cached brief (real-UUID fixture) | 12,701 → **12,767 (+66 one-time)** |

Net uncached-byte win over N agent-triggered turns: `338×N − 66`. The block rides the uncacheable per-turn channel and fires on every agent-to-agent turn — collaboration-heavy issues (like MUL-5442 itself) pay it dozens of times per session. (Review history: the initial compressed commit measured 387; the conjunction-scoping rewording from review added 3.)

## The judgment split

The per-turn FACT is only which trigger this is (another agent). The full discipline lives — and is pinned — in the brief: the reply-warranted rule with both outcome arms (Reply-mode block), the 'No reply needed' noise ban (same), and the sign-off-mention ban (Mentions). The compressed block states the fact, both outcome arms in short form, and points at the brief.

One semantic did NOT originally live in the brief: the work-category boundary (investigation-only and answer-only turns count as deliverable work) existed solely in the deleted parenthetical — review caught the dangling pointer. It now lives in the brief's canonical reply-warranted line ("investigation, a fix, or an answer to a real question all count"), the +66 above, so the per-turn channel never pays for it again.

## Verification

`go test ./internal/daemon/... -count=1` green · `go build` clean. Test changes (from review, not zero): `execenv_test.go` pins the category clause in the anti-loop block; `daemon_test.go` pins the compressed block's shape as sequential relations — the canonical-pointer sentence, the work arm with its consequence, and the no-work arm with its consequence. Prior anti-loop anchors ('Silence is the preferred way', 'do not @mention the other agent as a sign-off') survive verbatim; the member-trigger leak guard is untouched.
