### PR TITLE
fix(desktop): never fall back to the user's default CLI profile (MUL-5737)

### DIFF
--- a/apps/desktop/src/main/daemon-manager.ts
+++ b/apps/desktop/src/main/daemon-manager.ts
@@ -25,6 +25,17 @@ import { daemonStatusAlive } from "../shared/daemon-types";
 import { ensureManagedCli, managedCliPath } from "./cli-bootstrap";
 import { decideVersionAction } from "./version-decision";
 import {
+  DEFAULT_HEALTH_PORT,
+  deriveProfileName,
+  healthPortForProfile,
+  isResolvedProfile,
+  profileArgs,
+  profileConfigPath,
+  profileDir,
+  profileLogPath,
+  profileUserIdPath,
+} from "./daemon-profile";
+import {
   daemonLifecycleUnreachable,
   isDaemonExternallyManaged,
   normalizeHostOS,
@@ -35,7 +46,6 @@ import {
   type AuthProbeResult,
 } from "./daemon-auth-probe";
 
-const DEFAULT_HEALTH_PORT = 19514;
 const POLL_INTERVAL_MS = 5_000;
 const PREFS_PATH = join(homedir(), ".multica", "desktop_prefs.json");
 const LOG_TAIL_RETRY_MS = 2_000;
@@ -89,36 +99,6 @@ let authExpired = false;
 // may try to write concurrently; chaining them avoids interleaved writes
 // corrupting the JSON.
 let configWriteChain: Promise<void> = Promise.resolve();
-
-// Keep the Go impl in sync: server/cmd/multica/cmd_daemon.go healthPortForProfile.
-function healthPortForProfile(profile: string): number {
-  if (!profile) return DEFAULT_HEALTH_PORT;
-  let sum = 0;
-  for (const b of Buffer.from(profile, "utf-8")) sum += b;
-  return DEFAULT_HEALTH_PORT + 1 + (sum % 1000);
-}
-
-function profileDir(profile: string): string {
-  return profile
-    ? join(homedir(), ".multica", "profiles", profile)
-    : join(homedir(), ".multica");
-}
-
-function profileConfigPath(profile: string): string {
-  return join(profileDir(profile), "config.json");
-}
-
-function profileLogPath(profile: string): string {
-  return join(profileDir(profile), "daemon.log");
-}
-
-// Sidecar file that records which Multica user the cached PAT in config.json
-// was minted for. The Go CLI/daemon never read or write this file, so it
-// survives Go-side config rewrites. Used to detect user switches and mint a
-// fresh PAT instead of reusing a token that belongs to a previous user.
-function profileUserIdPath(profile: string): string {
-  return join(profileDir(profile), ".desktop-user-id");
-}
 
 async function readProfileUserId(profile: string): Promise<string | null> {
   try {
@@ -229,19 +209,6 @@ async function probeTokenValidity(profile: string): Promise<AuthProbeResult> {
   }
 }
 
-// Desktop owns a dedicated CLI profile named after the target API host, so it
-// never reads or writes the user's hand-configured profiles. Profile dir:
-//   ~/.multica/profiles/desktop-<host>/
-function deriveProfileName(targetUrl: string): string {
-  try {
-    const url = new URL(targetUrl);
-    const host = url.host.replace(/:/g, "-").toLowerCase();
-    return `desktop-${host}`;
-  } catch {
-    return "desktop";
-  }
-}
-
 async function readProfileConfig(
   profile: string,
 ): Promise<Record<string, unknown>> {
@@ -275,9 +242,11 @@ async function writeProfileConfig(
  * Returns the Desktop-owned profile for the current target API URL. Creates
  * the profile's config.json on demand with `server_url` pinned to the target.
  *
- * This function never falls back to the default profile, and never touches a
- * profile whose name doesn't start with `desktop-`, so the user's manually
- * configured CLI profiles are untouched.
+ * Until the renderer reports its `apiUrl` there is no such profile, and the
+ * returned name is empty. That empty name is a "not resolved yet" marker, not
+ * a usable profile: `daemon-profile.ts` refuses to turn it into a path or a
+ * `--profile` argument, so no caller can silently act on the user's default
+ * CLI profile at `~/.multica/`.
  */
 async function resolveActiveProfile(): Promise<ActiveProfile> {
   const target = targetApiBaseUrl;
@@ -297,8 +266,12 @@ async function resolveActiveProfile(): Promise<ActiveProfile> {
 
 async function ensureActiveProfile(): Promise<ActiveProfile> {
   if (activeProfile) return activeProfile;
-  activeProfile = await resolveActiveProfile();
-  return activeProfile;
+  const resolved = await resolveActiveProfile();
+  // Never cache the unresolved placeholder: the target URL arrives over IPC
+  // shortly after startup, and a cached empty name would otherwise persist
+  // until something happened to invalidate it.
+  if (isResolvedProfile(resolved.name)) activeProfile = resolved;
+  return resolved;
 }
 
 function invalidateActiveProfile(): void {
@@ -673,6 +646,12 @@ async function syncToken(
   userId: string,
 ): Promise<void> {
   const active = await ensureActiveProfile();
+  if (!isResolvedProfile(active.name)) {
+    // No Desktop-owned profile yet — writing here would land the token and
+    // server_url in the user's default CLI config. The renderer re-runs this
+    // once the target URL is set.
+    throw new Error("daemon profile is not resolved yet; token sync skipped");
+  }
   const config = await readProfileConfig(active.name);
   const previousUserId = await readProfileUserId(active.name);
   const userChanged = Boolean(previousUserId) && previousUserId !== userId;
@@ -742,6 +721,9 @@ async function savePrefs(prefs: DaemonPrefs): Promise<void> {
 
 async function clearToken(): Promise<void> {
   const active = await ensureActiveProfile();
+  // Nothing of ours to clear yet, and the default CLI profile is not ours to
+  // strip a token from.
+  if (!isResolvedProfile(active.name)) return;
   const config = await readProfileConfig(active.name);
   if ("token" in config) {
     delete config.token;
@@ -810,10 +792,6 @@ async function withGuard<T>(fn: () => Promise<T>): Promise<T | { success: false;
   }
 }
 
-function profileArgs(active: ActiveProfile): string[] {
-  return active.name ? ["--profile", active.name] : [];
-}
-
 function successfulRuntimeProbe(
   providers: string[],
   daemonRunning: boolean,
@@ -846,10 +824,11 @@ async function probeLocalRuntimes(): Promise<LocalRuntimeProbe> {
   const bin = await resolveCliBinary();
   if (!bin) return { probeResult: "error" };
   const active = await ensureActiveProfile();
+  if (!isResolvedProfile(active.name)) return { probeResult: "error" };
   return new Promise((resolve) => {
     execFile(
       bin,
-      ["daemon", "probe-runtimes", ...profileArgs(active)],
+      ["daemon", "probe-runtimes", ...profileArgs(active.name)],
       { timeout: 15_000, env: desktopSpawnEnv(), maxBuffer: 64 * 1024 },
       (error, stdout) => {
         if (error) {
@@ -914,6 +893,9 @@ async function startDaemon(): Promise<{ success: boolean; error?: string }> {
   if (!bin) return { success: false, error: "multica CLI is not installed" };
 
   const active = await ensureActiveProfile();
+  if (!isResolvedProfile(active.name)) {
+    return { success: false, error: "Waiting for the service address" };
+  }
   const existing = await fetchHealthAtPort(active.port);
   if (daemonStatusAlive(existing?.status)) {
     // A daemon is already up ("running") or booting ("starting") on this port —
@@ -930,7 +912,7 @@ async function startDaemon(): Promise<{ success: boolean; error?: string }> {
   authExpired = false;
   sendStatus({ state: "starting" });
 
-  const args = ["daemon", "start", ...profileArgs(active)];
+  const args = ["daemon", "start", ...profileArgs(active.name)];
 
   return new Promise((resolve) => {
     execFile(
@@ -984,13 +966,14 @@ async function stopDaemon(): Promise<{ success: boolean; error?: string }> {
   if (!bin) return { success: false, error: "multica CLI is not installed" };
 
   const active = await ensureActiveProfile();
+  if (!isResolvedProfile(active.name)) return { success: true };
   currentState = "stopping";
   // An explicit stop is a clean reset — drop any pending auth-failure verdict.
   authExpired = false;
   startingSince = null;
   sendStatus({ state: "stopping" });
 
-  const args = ["daemon", "stop", ...profileArgs(active)];
+  const args = ["daemon", "stop", ...profileArgs(active.name)];
 
   return new Promise((resolve) => {
     execFile(bin, args, { timeout: 15_000 }, (err) => {
@@ -1090,8 +1073,13 @@ function startLogTail(win: BrowserWindow, retryCount = 0): void {
   stopLogTail();
 
   void ensureActiveProfile().then(async (active) => {
-    const logPath = profileLogPath(active.name);
-    if (!existsSync(logPath)) {
+    // Before the renderer reports its apiUrl there is no Desktop-owned profile
+    // yet, and therefore no log file of ours to tail. Retry rather than reach
+    // for the default profile's log.
+    const logPath = isResolvedProfile(active.name)
+      ? profileLogPath(active.name)
+      : null;
+    if (!logPath || !existsSync(logPath)) {
       if (retryCount < LOG_TAIL_MAX_RETRIES) {
         setTimeout(() => startLogTail(win, retryCount + 1), LOG_TAIL_RETRY_MS);
       }
@@ -1233,8 +1221,10 @@ export function setupDaemonManager(
   // (full history, complex search, copy-to-clipboard at scale).
   ipcMain.handle("daemon:open-log-file", async () => {
     const active = await ensureActiveProfile();
-    const logPath = profileLogPath(active.name);
-    if (!existsSync(logPath)) {
+    const logPath = isResolvedProfile(active.name)
+      ? profileLogPath(active.name)
+      : null;
+    if (!logPath || !existsSync(logPath)) {
       return { success: false, error: "Log file not found yet" };
     }
     // shell.openPath returns "" on success, error string on failure.

--- a/apps/desktop/src/main/daemon-manager.ts
+++ b/apps/desktop/src/main/daemon-manager.ts
@@ -25,10 +25,8 @@ import { daemonStatusAlive } from "../shared/daemon-types";
 import { ensureManagedCli, managedCliPath } from "./cli-bootstrap";
 import { decideVersionAction } from "./version-decision";
 import {
-  DEFAULT_HEALTH_PORT,
   deriveProfileName,
   healthPortForProfile,
-  isResolvedProfile,
   profileArgs,
   profileConfigPath,
   profileDir,
@@ -65,8 +63,10 @@ const DAEMON_START_EXEC_TIMEOUT_MS = 60_000;
 
 const DEFAULT_PREFS: DaemonPrefs = { autoStart: true, autoStop: false };
 
+// Always a resolved Desktop-owned profile. "Not resolved yet" is represented by
+// `null` at every call site, never by an empty name — see daemon-profile.ts.
 interface ActiveProfile {
-  name: string; // "" = default profile
+  name: string;
   port: number;
 }
 
@@ -242,15 +242,14 @@ async function writeProfileConfig(
  * Returns the Desktop-owned profile for the current target API URL. Creates
  * the profile's config.json on demand with `server_url` pinned to the target.
  *
- * Until the renderer reports its `apiUrl` there is no such profile, and the
- * returned name is empty. That empty name is a "not resolved yet" marker, not
- * a usable profile: `daemon-profile.ts` refuses to turn it into a path or a
- * `--profile` argument, so no caller can silently act on the user's default
- * CLI profile at `~/.multica/`.
+ * Returns `null` until the renderer reports its `apiUrl`. There is no profile
+ * to act on in that window, and callers must do nothing rather than reach for
+ * the user's default CLI profile at `~/.multica/` — neither its files nor its
+ * health port.
  */
-async function resolveActiveProfile(): Promise<ActiveProfile> {
+async function resolveActiveProfile(): Promise<ActiveProfile | null> {
   const target = targetApiBaseUrl;
-  if (!target) return { name: "", port: DEFAULT_HEALTH_PORT };
+  if (!target) return null;
 
   const name = deriveProfileName(target);
   const cfg = await readProfileConfig(name);
@@ -264,14 +263,13 @@ async function resolveActiveProfile(): Promise<ActiveProfile> {
   return { name, port: healthPortForProfile(name) };
 }
 
-async function ensureActiveProfile(): Promise<ActiveProfile> {
+async function ensureActiveProfile(): Promise<ActiveProfile | null> {
   if (activeProfile) return activeProfile;
-  const resolved = await resolveActiveProfile();
-  // Never cache the unresolved placeholder: the target URL arrives over IPC
-  // shortly after startup, and a cached empty name would otherwise persist
-  // until something happened to invalidate it.
-  if (isResolvedProfile(resolved.name)) activeProfile = resolved;
-  return resolved;
+  // Only a resolved profile is cached; the target URL arrives over IPC shortly
+  // after startup, and caching "unresolved" would persist until something
+  // happened to invalidate it.
+  activeProfile = await resolveActiveProfile();
+  return activeProfile;
 }
 
 function invalidateActiveProfile(): void {
@@ -287,6 +285,10 @@ async function fetchHealth(): Promise<DaemonStatus> {
   }
 
   const active = await ensureActiveProfile();
+  // No profile yet means no daemon of ours to probe. Reporting "stopped" is the
+  // honest answer; probing the default port would surface the user's own CLI
+  // daemon as if it were Desktop's.
+  if (!active) return { state: "stopped" };
   const data = await fetchHealthAtPort(active.port);
 
   if (!data || data.status !== "running") {
@@ -550,6 +552,7 @@ async function ensureRunningDaemonVersionMatches(): Promise<
   "restarted" | "deferred" | "ok" | "not_running"
 > {
   const active = await ensureActiveProfile();
+  if (!active) return "not_running";
   const running = await fetchHealthAtPort(active.port);
 
   // Don't try to version-match a daemon we can't restart (e.g. WSL2). Treat it
@@ -646,10 +649,10 @@ async function syncToken(
   userId: string,
 ): Promise<void> {
   const active = await ensureActiveProfile();
-  if (!isResolvedProfile(active.name)) {
-    // No Desktop-owned profile yet — writing here would land the token and
-    // server_url in the user's default CLI config. The renderer re-runs this
-    // once the target URL is set.
+  if (!active) {
+    // Writing here would land the token and server_url in the user's default
+    // CLI config. The renderer awaits setTargetApiUrl before calling this, so
+    // reaching this branch is a real error rather than a normal startup race.
     throw new Error("daemon profile is not resolved yet; token sync skipped");
   }
   const config = await readProfileConfig(active.name);
@@ -723,7 +726,7 @@ async function clearToken(): Promise<void> {
   const active = await ensureActiveProfile();
   // Nothing of ours to clear yet, and the default CLI profile is not ours to
   // strip a token from.
-  if (!isResolvedProfile(active.name)) return;
+  if (!active) return;
   const config = await readProfileConfig(active.name);
   if ("token" in config) {
     delete config.token;
@@ -824,7 +827,7 @@ async function probeLocalRuntimes(): Promise<LocalRuntimeProbe> {
   const bin = await resolveCliBinary();
   if (!bin) return { probeResult: "error" };
   const active = await ensureActiveProfile();
-  if (!isResolvedProfile(active.name)) return { probeResult: "error" };
+  if (!active) return { probeResult: "error" };
   return new Promise((resolve) => {
     execFile(
       bin,
@@ -893,7 +896,7 @@ async function startDaemon(): Promise<{ success: boolean; error?: string }> {
   if (!bin) return { success: false, error: "multica CLI is not installed" };
 
   const active = await ensureActiveProfile();
-  if (!isResolvedProfile(active.name)) {
+  if (!active) {
     return { success: false, error: "Waiting for the service address" };
   }
   const existing = await fetchHealthAtPort(active.port);
@@ -946,6 +949,7 @@ async function startDaemon(): Promise<{ success: boolean; error?: string }> {
  */
 async function lifecycleBlockedByForeignDaemon(): Promise<boolean> {
   const active = await ensureActiveProfile();
+  if (!active) return false;
   return daemonLifecycleUnreachable(
     async () => (await fetchHealthAtPort(active.port))?.os,
     normalizeHostOS(process.platform),
@@ -966,7 +970,7 @@ async function stopDaemon(): Promise<{ success: boolean; error?: string }> {
   if (!bin) return { success: false, error: "multica CLI is not installed" };
 
   const active = await ensureActiveProfile();
-  if (!isResolvedProfile(active.name)) return { success: true };
+  if (!active) return { success: true };
   currentState = "stopping";
   // An explicit stop is a clean reset — drop any pending auth-failure verdict.
   authExpired = false;
@@ -1076,9 +1080,7 @@ function startLogTail(win: BrowserWindow, retryCount = 0): void {
     // Before the renderer reports its apiUrl there is no Desktop-owned profile
     // yet, and therefore no log file of ours to tail. Retry rather than reach
     // for the default profile's log.
-    const logPath = isResolvedProfile(active.name)
-      ? profileLogPath(active.name)
-      : null;
+    const logPath = active ? profileLogPath(active.name) : null;
     if (!logPath || !existsSync(logPath)) {
       if (retryCount < LOG_TAIL_MAX_RETRIES) {
         setTimeout(() => startLogTail(win, retryCount + 1), LOG_TAIL_RETRY_MS);
@@ -1221,9 +1223,7 @@ export function setupDaemonManager(
   // (full history, complex search, copy-to-clipboard at scale).
   ipcMain.handle("daemon:open-log-file", async () => {
     const active = await ensureActiveProfile();
-    const logPath = isResolvedProfile(active.name)
-      ? profileLogPath(active.name)
-      : null;
+    const logPath = active ? profileLogPath(active.name) : null;
     if (!logPath || !existsSync(logPath)) {
       return { success: false, error: "Log file not found yet" };
     }

--- a/apps/desktop/src/main/daemon-profile.test.ts
+++ b/apps/desktop/src/main/daemon-profile.test.ts
@@ -6,7 +6,6 @@ import {
   DEFAULT_HEALTH_PORT,
   deriveProfileName,
   healthPortForProfile,
-  isResolvedProfile,
   profileArgs,
   profileConfigPath,
   profileDir,
@@ -83,20 +82,22 @@ describe("profileArgs", () => {
 });
 
 describe("healthPortForProfile", () => {
-  it("keeps the default port for the unresolved profile", () => {
-    expect(healthPortForProfile("")).toBe(DEFAULT_HEALTH_PORT);
+  // Regression: this returned 19514 — the default profile's port — for an
+  // unresolved profile, so Desktop would probe the user's own CLI daemon and
+  // report it as its own. #6399.
+  it("refuses to hand out a port for an unresolved profile", () => {
+    expect(() => healthPortForProfile("")).toThrow(/unresolved/);
+  });
+
+  it("never derives the default profile's port", () => {
+    for (const name of ["desktop-api.multica.ai", "desktop", "x", "a".repeat(50)]) {
+      expect(healthPortForProfile(name)).not.toBe(DEFAULT_HEALTH_PORT);
+    }
   });
 
   it("derives a stable per-profile port above the default", () => {
     const port = healthPortForProfile("desktop-api.multica.ai");
     expect(port).toBeGreaterThan(DEFAULT_HEALTH_PORT);
     expect(port).toBe(healthPortForProfile("desktop-api.multica.ai"));
-  });
-});
-
-describe("isResolvedProfile", () => {
-  it("treats only a non-empty name as resolved", () => {
-    expect(isResolvedProfile("")).toBe(false);
-    expect(isResolvedProfile("desktop-api.multica.ai")).toBe(true);
   });
 });

--- a/apps/desktop/src/main/daemon-profile.test.ts
+++ b/apps/desktop/src/main/daemon-profile.test.ts
@@ -1,0 +1,102 @@
+import { homedir } from "os";
+import { join } from "path";
+import { describe, expect, it } from "vitest";
+
+import {
+  DEFAULT_HEALTH_PORT,
+  deriveProfileName,
+  healthPortForProfile,
+  isResolvedProfile,
+  profileArgs,
+  profileConfigPath,
+  profileDir,
+  profileLogPath,
+  profileUserIdPath,
+} from "./daemon-profile";
+
+const MULTICA_DIR = join(homedir(), ".multica");
+const DEFAULT_CLI_CONFIG = join(MULTICA_DIR, "config.json");
+
+describe("deriveProfileName", () => {
+  it("names the profile after the target host", () => {
+    expect(deriveProfileName("https://api.multica.ai")).toBe(
+      "desktop-api.multica.ai",
+    );
+  });
+
+  it("replaces the port colon so the name is path-safe", () => {
+    expect(deriveProfileName("http://localhost:8080")).toBe(
+      "desktop-localhost-8080",
+    );
+  });
+
+  it("falls back to a fixed name on an unparseable URL", () => {
+    expect(deriveProfileName("not a url")).toBe("desktop");
+  });
+});
+
+describe("profile paths", () => {
+  it("always resolves under profiles/<name>", () => {
+    const dir = join(MULTICA_DIR, "profiles", "desktop-api.multica.ai");
+    expect(profileDir("desktop-api.multica.ai")).toBe(dir);
+    expect(profileConfigPath("desktop-api.multica.ai")).toBe(
+      join(dir, "config.json"),
+    );
+    expect(profileLogPath("desktop-api.multica.ai")).toBe(
+      join(dir, "daemon.log"),
+    );
+    expect(profileUserIdPath("desktop-api.multica.ai")).toBe(
+      join(dir, ".desktop-user-id"),
+    );
+  });
+
+  // Regression: an unresolved profile used to resolve to ~/.multica, so Desktop
+  // could overwrite server_url and token in the user's own CLI config. #6399.
+  it("refuses to build a path for an unresolved profile", () => {
+    expect(() => profileDir("")).toThrow(/unresolved/);
+    expect(() => profileConfigPath("")).toThrow(/unresolved/);
+    expect(() => profileLogPath("")).toThrow(/unresolved/);
+    expect(() => profileUserIdPath("")).toThrow(/unresolved/);
+  });
+
+  it("never yields the default CLI config path for any input", () => {
+    for (const name of ["desktop-api.multica.ai", "desktop", "x"]) {
+      expect(profileConfigPath(name)).not.toBe(DEFAULT_CLI_CONFIG);
+    }
+    expect(() => profileConfigPath("")).toThrow();
+  });
+});
+
+describe("profileArgs", () => {
+  it("selects the Desktop-owned profile", () => {
+    expect(profileArgs("desktop-api.multica.ai")).toEqual([
+      "--profile",
+      "desktop-api.multica.ai",
+    ]);
+  });
+
+  // Regression: this returned [] for an unresolved profile, so the bundled CLI
+  // ran against the user's default profile instead of Desktop's. #6399.
+  it("refuses to spawn the CLI without a profile flag", () => {
+    expect(() => profileArgs("")).toThrow(/unresolved/);
+  });
+});
+
+describe("healthPortForProfile", () => {
+  it("keeps the default port for the unresolved profile", () => {
+    expect(healthPortForProfile("")).toBe(DEFAULT_HEALTH_PORT);
+  });
+
+  it("derives a stable per-profile port above the default", () => {
+    const port = healthPortForProfile("desktop-api.multica.ai");
+    expect(port).toBeGreaterThan(DEFAULT_HEALTH_PORT);
+    expect(port).toBe(healthPortForProfile("desktop-api.multica.ai"));
+  });
+});
+
+describe("isResolvedProfile", () => {
+  it("treats only a non-empty name as resolved", () => {
+    expect(isResolvedProfile("")).toBe(false);
+    expect(isResolvedProfile("desktop-api.multica.ai")).toBe(true);
+  });
+});

--- a/apps/desktop/src/main/daemon-profile.ts
+++ b/apps/desktop/src/main/daemon-profile.ts
@@ -1,0 +1,79 @@
+import { homedir } from "os";
+import { join } from "path";
+
+// Keep the Go impl in sync: server/cmd/multica/cmd_daemon.go healthPortForProfile.
+export const DEFAULT_HEALTH_PORT = 19514;
+
+/**
+ * Empty string is the "target API URL not known yet" state, which exists
+ * between main-process startup and the renderer reporting its `apiUrl`.
+ *
+ * It is NOT a profile name. Desktop owns only `~/.multica/profiles/desktop-<host>/`;
+ * the default profile at `~/.multica/` belongs to the user's terminal CLI and
+ * must never be read, written, or passed to the bundled CLI. Resolving an empty
+ * name to that directory silently rewrote the user's own `server_url` and
+ * `token`, so every path that could reach the filesystem fails loudly instead.
+ * See #6399.
+ */
+export function assertResolvedProfile(profile: string): void {
+  if (!profile) {
+    throw new Error(
+      "daemon profile is unresolved — refusing to fall back to the default CLI profile",
+    );
+  }
+}
+
+export function isResolvedProfile(profile: string): boolean {
+  return Boolean(profile);
+}
+
+// Desktop owns a dedicated CLI profile named after the target API host, so it
+// never reads or writes the user's hand-configured profiles. Profile dir:
+//   ~/.multica/profiles/desktop-<host>/
+export function deriveProfileName(targetUrl: string): string {
+  try {
+    const url = new URL(targetUrl);
+    const host = url.host.replace(/:/g, "-").toLowerCase();
+    return `desktop-${host}`;
+  } catch {
+    return "desktop";
+  }
+}
+
+export function healthPortForProfile(profile: string): number {
+  if (!profile) return DEFAULT_HEALTH_PORT;
+  let sum = 0;
+  for (const b of Buffer.from(profile, "utf-8")) sum += b;
+  return DEFAULT_HEALTH_PORT + 1 + (sum % 1000);
+}
+
+export function profileDir(profile: string): string {
+  assertResolvedProfile(profile);
+  return join(homedir(), ".multica", "profiles", profile);
+}
+
+export function profileConfigPath(profile: string): string {
+  return join(profileDir(profile), "config.json");
+}
+
+export function profileLogPath(profile: string): string {
+  return join(profileDir(profile), "daemon.log");
+}
+
+// Sidecar file that records which Multica user the cached PAT in config.json
+// was minted for. The Go CLI/daemon never read or write this file, so it
+// survives Go-side config rewrites. Used to detect user switches and mint a
+// fresh PAT instead of reusing a token that belongs to a previous user.
+export function profileUserIdPath(profile: string): string {
+  return join(profileDir(profile), ".desktop-user-id");
+}
+
+/**
+ * CLI args selecting the Desktop-owned profile. An unresolved profile must
+ * never produce an empty arg list: the bundled CLI would then act on the
+ * user's default profile at `~/.multica/config.json`.
+ */
+export function profileArgs(profile: string): string[] {
+  assertResolvedProfile(profile);
+  return ["--profile", profile];
+}

--- a/apps/desktop/src/main/daemon-profile.ts
+++ b/apps/desktop/src/main/daemon-profile.ts
@@ -5,15 +5,14 @@ import { join } from "path";
 export const DEFAULT_HEALTH_PORT = 19514;
 
 /**
- * Empty string is the "target API URL not known yet" state, which exists
- * between main-process startup and the renderer reporting its `apiUrl`.
+ * Desktop owns only `~/.multica/profiles/desktop-<host>/`. The default profile
+ * at `~/.multica/` — config, daemon log, and health port 19514 — belongs to the
+ * user's terminal CLI and must never be read, written, probed, or passed to the
+ * bundled CLI.
  *
- * It is NOT a profile name. Desktop owns only `~/.multica/profiles/desktop-<host>/`;
- * the default profile at `~/.multica/` belongs to the user's terminal CLI and
- * must never be read, written, or passed to the bundled CLI. Resolving an empty
- * name to that directory silently rewrote the user's own `server_url` and
- * `token`, so every path that could reach the filesystem fails loudly instead.
- * See #6399.
+ * Callers signal "target API URL not known yet" with `null`, never with an
+ * empty name, so there is no value that can quietly resolve to the default
+ * profile. This guard is the backstop for that. See #6399.
  */
 export function assertResolvedProfile(profile: string): void {
   if (!profile) {
@@ -21,10 +20,6 @@ export function assertResolvedProfile(profile: string): void {
       "daemon profile is unresolved — refusing to fall back to the default CLI profile",
     );
   }
-}
-
-export function isResolvedProfile(profile: string): boolean {
-  return Boolean(profile);
 }
 
 // Desktop owns a dedicated CLI profile named after the target API host, so it
@@ -40,8 +35,13 @@ export function deriveProfileName(targetUrl: string): string {
   }
 }
 
+/**
+ * Port 19514 itself is the default profile's, so an unresolved profile must
+ * never produce one: probing it would report the user's own CLI daemon as
+ * Desktop's, and lifecycle commands would act on it.
+ */
 export function healthPortForProfile(profile: string): number {
-  if (!profile) return DEFAULT_HEALTH_PORT;
+  assertResolvedProfile(profile);
   let sum = 0;
   for (const b of Buffer.from(profile, "utf-8")) sum += b;
   return DEFAULT_HEALTH_PORT + 1 + (sum % 1000);

--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -18,6 +18,7 @@ import { IssueWindow } from "./components/issue-window";
 import { useTabStore } from "./stores/tab-store";
 import { useWindowOverlayStore } from "./stores/window-overlay-store";
 import { useDaemonIPCBridge } from "./platform/daemon-ipc-bridge";
+import { syncDaemonOnLogin } from "./platform/daemon-login-sync";
 import { createDesktopLocaleAdapter } from "./platform/i18n-adapter";
 import { captureEvent } from "@multica/core/analytics";
 import { RESOURCES } from "@multica/views/locales";
@@ -168,21 +169,26 @@ function AppContent() {
     });
   }, [qc]);
 
-  // Sync token and start the daemon whenever the user logs in.
+  // Sync token and start the daemon whenever the user logs in. The ordering
+  // inside syncDaemonOnLogin is load-bearing — see that module.
   useEffect(() => {
-    if (!user) return;
+    if (!user || !runtimeConfig) return;
     const token = localStorage.getItem("multica_token");
     if (!token) return;
     const userId = user.id;
     (async () => {
       try {
-        await window.daemonAPI.syncToken(token, userId);
-        await window.daemonAPI.autoStart();
+        await syncDaemonOnLogin(
+          window.daemonAPI,
+          runtimeConfig.apiUrl,
+          token,
+          userId,
+        );
       } catch (err) {
         console.error("Failed to sync daemon on login", err);
       }
     })();
-  }, [user]);
+  }, [user, runtimeConfig]);
 
   // When a user who started the session with zero workspaces creates their
   // first one, restart the daemon so it picks up the new workspace

--- a/apps/desktop/src/renderer/src/platform/daemon-login-sync.test.ts
+++ b/apps/desktop/src/renderer/src/platform/daemon-login-sync.test.ts
@@ -1,0 +1,78 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  syncDaemonOnLogin,
+  type DaemonLoginSyncAPI,
+} from "./daemon-login-sync";
+
+const calls: string[] = [];
+
+function makeApi(overrides: Partial<DaemonLoginSyncAPI> = {}): DaemonLoginSyncAPI {
+  return {
+    setTargetApiUrl: vi.fn(async () => {
+      calls.push("setTargetApiUrl");
+    }),
+    syncToken: vi.fn(async () => {
+      calls.push("syncToken");
+    }),
+    autoStart: vi.fn(async () => {
+      calls.push("autoStart");
+    }),
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  calls.length = 0;
+  vi.clearAllMocks();
+});
+
+describe("syncDaemonOnLogin", () => {
+  // Regression: syncToken used to race a separate effect's setTargetApiUrl.
+  // Arriving first meant main had no resolved profile and wrote the token to
+  // the user's default CLI profile. #6399.
+  it("pushes the target URL before syncing the token", async () => {
+    const api = makeApi();
+    await syncDaemonOnLogin(api, "https://api.example.com", "tok", "user-1");
+
+    expect(calls).toEqual(["setTargetApiUrl", "syncToken", "autoStart"]);
+    expect(api.setTargetApiUrl).toHaveBeenCalledWith("https://api.example.com");
+    expect(api.syncToken).toHaveBeenCalledWith("tok", "user-1");
+  });
+
+  it("awaits the target URL rather than firing it off", async () => {
+    let released: (() => void) | undefined;
+    const api = makeApi({
+      setTargetApiUrl: vi.fn(
+        () =>
+          new Promise<void>((resolve) => {
+            released = () => {
+              calls.push("setTargetApiUrl");
+              resolve();
+            };
+          }),
+      ),
+    });
+
+    const pending = syncDaemonOnLogin(api, "https://api.example.com", "t", "u");
+    await Promise.resolve();
+    expect(api.syncToken).not.toHaveBeenCalled();
+
+    released?.();
+    await pending;
+    expect(calls).toEqual(["setTargetApiUrl", "syncToken", "autoStart"]);
+  });
+
+  it("does not start the daemon when the token sync fails", async () => {
+    const api = makeApi({
+      syncToken: vi.fn(async () => {
+        throw new Error("daemon profile is not resolved yet");
+      }),
+    });
+
+    await expect(
+      syncDaemonOnLogin(api, "https://api.example.com", "t", "u"),
+    ).rejects.toThrow(/not resolved/);
+    expect(api.autoStart).not.toHaveBeenCalled();
+  });
+});

--- a/apps/desktop/src/renderer/src/platform/daemon-login-sync.ts
+++ b/apps/desktop/src/renderer/src/platform/daemon-login-sync.ts
@@ -1,0 +1,30 @@
+/**
+ * Bring the local daemon up for a freshly signed-in user.
+ *
+ * The order matters and is the reason this is a function rather than three
+ * inline awaits. Desktop's daemon profile is derived from the target API URL,
+ * so until the main process has that URL there is no Desktop-owned profile —
+ * and main now refuses to write the token at all rather than fall back to the
+ * user's default CLI profile at `~/.multica/` (#6399).
+ *
+ * That refusal has no retry of its own: the login effect re-runs on `user`, not
+ * on the target URL. So the URL must be pushed and awaited here, before the
+ * token sync, instead of racing a separate effect's IPC message. Re-sending it
+ * is cheap — the main-process handler ignores an unchanged value.
+ */
+export interface DaemonLoginSyncAPI {
+  setTargetApiUrl: (url: string) => Promise<void>;
+  syncToken: (token: string, userId: string) => Promise<void>;
+  autoStart: () => Promise<unknown>;
+}
+
+export async function syncDaemonOnLogin(
+  api: DaemonLoginSyncAPI,
+  apiUrl: string,
+  token: string,
+  userId: string,
+): Promise<void> {
+  await api.setTargetApiUrl(apiUrl);
+  await api.syncToken(token, userId);
+  await api.autoStart();
+}


### PR DESCRIPTION
## Summary

Desktop could act on the user's **default CLI profile** (`~/.multica/`) instead of its own (`~/.multica/profiles/desktop-<host>/`).

Desktop derives its daemon profile from the API URL, which the renderer sends to the main process over IPC shortly after startup. Until that arrives there is no profile — and that state was represented by an **empty profile name**, which quietly resolved to the default profile the terminal CLI owns:

```ts
function profileDir(profile: string): string {
  return profile
    ? join(homedir(), ".multica", "profiles", profile)
    : join(homedir(), ".multica");   // <- the user's own CLI profile
}
```

Three ways that reached the user's environment, all silent:

1. **Config overwrite** — `syncToken()` writes `config.token` and `config.server_url`, then `writeProfileConfig(active.name, config)`. With an empty name that writes `~/.multica/config.json`, replacing a self-hosted `server_url` and adding a `mul_...` token.
2. **CLI invoked without `--profile`** — `profileArgs()` returned `[]` for an empty name, so `daemon start` / `daemon stop` / `daemon probe-runtimes` ran the bundled CLI against the default profile.
3. **Health port collision** — `healthPortForProfile("")` returned `19514`, which *is* the default profile's port. `fetchHealth`, the version-match check and the lifecycle preflight probed it before any guard ran, so a user's own CLI daemon could be reported as Desktop's, and `probeLocalRuntimes()` would return that daemon's runtimes.

`resolveActiveProfile`'s docstring already promised none of this could happen, and `apps/docs/content/docs/desktop-app.mdx:55` repeats that promise to users. Nothing enforced it, and there was no test.

This is **not Windows-specific**. None of the three vectors branches on platform; any machine running both Desktop and the terminal CLI is exposed. It simply surfaced on Windows first.

## Approach

**Delete the empty-string sentinel rather than guard it.** `resolveActiveProfile()` and `ensureActiveProfile()` now return `ActiveProfile | null`, so "no profile yet" carries neither a path nor a port, and TypeScript forces all ten call sites to handle it:

- `fetchHealth` reports `stopped` (honest: we have no daemon of our own yet) instead of probing 19514;
- `ensureRunningDaemonVersionMatches` returns `not_running`, `lifecycleBlockedByForeignDaemon` returns `false`;
- `startDaemon` returns a "waiting for the service address" error, `stopDaemon` is a no-op success, `probeLocalRuntimes` returns `error`;
- log tailing retries; `clearToken` returns; `syncToken` throws rather than write.

`daemon-profile.ts` holds the path/port/args helpers and asserts a resolved profile as a backstop, so the default profile is unreachable from anywhere by construction.

**Login ordering.** `syncToken`'s fail-closed branch had no recovery: the login effect only depends on `user`, and the URL was pushed by a *separate* effect, so a bad interleaving would have left the daemon offline until the next login. The sequence is now `platform/daemon-login-sync.ts` (same shape as the existing `daemon-reauth.ts`), which awaits `setTargetApiUrl` → `syncToken` → `autoStart`, with the effect depending on `runtimeConfig`. Ordering is explicit and tested rather than left to IPC arrival order.

Enforcing the invariant makes the existing doc sentence true rather than aspirational, so no doc change is needed.

## Behaviour change / risk

- **No migration.** Profile directory, naming, and the port derivation for resolved profiles are unchanged. Desktop-only users see no functional difference.
- **First login may wait marginally longer.** `setTargetApiUrl`'s handler runs `pollOnce()`, whose local health request has a 2s ceiling; it is now awaited before token sync. In practice a localhost connection-refused returns immediately — the bound only matters if something is answering oddly on that port.
- **A brief honest `stopped`.** Before the URL arrives the UI may show `stopped` rather than borrowing a CLI daemon's `running`. That corrects a wrong state rather than removing one.
- **Deliberately removed coupling.** Anyone relying on Desktop to observe or control the *default* CLI daemon loses that. It was never a supported behaviour — the code contract and the docs both promise isolation.
- Untouched: PAT reuse, restart-on-user-switch, auto-start/stop, WSL2 external-daemon detection, log paths. No persisted-format, API, or deployment-order changes; rollback needs no migration.

## Scope

This came out of #6399, where a self-hosting Windows user reports his `~/.multica/config.json` `server_url` reverting to `https://api.multica.ai`. The defect fixed here would produce exactly that symptom, but the reporter hasn't yet confirmed which file is being rewritten, so this is `Refs`, not `Fixes` — a confirmed isolation hole closed on its own merits, not a verified root-cause fix for that report.

The separate silent Cloud fallback when `desktop.json` is missing (no feedback that the file wasn't found) is **not** addressed here and is worth tracking separately.

## Verification

- `pnpm typecheck` in `apps/desktop` — passes (node + web).
- `pnpm vitest run` in `apps/desktop` — 440 tests across 44 files pass.
- `pnpm lint` — no new problems; the single warning is pre-existing in `tab-content.tsx`.
- New tests cover each regression directly: an unresolved profile must not yield a path, a `--profile` arg list, or a port; no resolved profile name may ever derive port 19514; and the login sequence must push the URL, actually await it, and not auto-start when token sync fails.
- No heavyweight Electron main-process mock was introduced — the repo has no precedent for it, and making the unresolved state unrepresentable removes the class of bug the integration test would have chased.
