### PR TITLE
fix(daemon): discover models from the custom runtime profile's own binary (MUL-5789)

### DIFF
--- a/server/internal/daemon/daemon.go
+++ b/server/internal/daemon/daemon.go
@@ -190,6 +190,11 @@ var (
 	detectAgentVersion   = agent.DetectVersion
 	checkAgentMinVersion = agent.CheckMinVersion
 
+	// listModels is an indirection over agent.ListModels so model-discovery
+	// tests can assert which executable path the daemon enumerates without
+	// shelling out to a real CLI. Mirrors the detectAgentVersion hook above.
+	listModels = agent.ListModels
+
 	// lookPath is an indirection over exec.LookPath so registration tests can
 	// resolve custom runtime-profile commands without manipulating the
 	// process PATH. Mirrors the detectAgentVersion hook above.
@@ -3646,18 +3651,33 @@ func (d *Daemon) handlePendingWorkHint(runtimeID, kind string) {
 func (d *Daemon) handleModelList(ctx context.Context, rt Runtime, requestID string) {
 	d.logger.Info("model list requested", "runtime_id", rt.ID, "request_id", requestID, "provider", rt.Provider)
 
-	entry, ok := d.agents()[rt.Provider]
-	if !ok {
+	// Discovery must enumerate the binary this runtime will actually execute,
+	// otherwise the picker advertises a catalog the launched CLI never agreed
+	// to (MUL-5789). Mirror runTask's resolution order: a custom runtime
+	// profile (MUL-3284) owns the executable path, and such a runtime can live
+	// on a host with NO built-in agent of the same protocol family installed —
+	// so a custom runtime must never fail on the built-in lookup. A custom
+	// path is also never re-resolved: like runTask, we don't second-guess a
+	// path the profile pinned.
+	var execPath string
+	if customSpec, isCustom := d.customProfileLaunchForRuntime(rt.ID); isCustom {
+		execPath = customSpec.path
+		d.logger.Info("model list uses custom runtime profile command",
+			"runtime_id", rt.ID, "provider", rt.Provider, "command_path", execPath)
+	} else if entry, ok := d.agents()[rt.Provider]; ok {
+		// Built-in provider: self-heal a pinned executable path an in-place
+		// upgrade deleted (MUL-4486).
+		entry, _ = d.resolveAgentEntry(ctx, rt.Provider, entry)
+		execPath = entry.Path
+	} else {
 		d.reportModelListResult(ctx, rt, requestID, map[string]any{
 			"status": "failed",
 			"error":  fmt.Sprintf("no agent configured for provider %q", rt.Provider),
 		})
 		return
 	}
-	// Self-heal a pinned executable path an in-place upgrade deleted (MUL-4486).
-	entry, _ = d.resolveAgentEntry(ctx, rt.Provider, entry)
 
-	catalog, err := agent.ListModels(ctx, rt.Provider, entry.Path)
+	catalog, err := listModels(ctx, rt.Provider, execPath)
 	if err != nil {
 		d.reportModelListResult(ctx, rt, requestID, map[string]any{
 			"status": "failed",
@@ -3668,7 +3688,7 @@ func (d *Daemon) handleModelList(ctx context.Context, rt Runtime, requestID stri
 	models := catalog.Models
 	if catalog.Fallback {
 		d.logger.Warn("model discovery fell back to a static catalog; reporting it as non-authoritative",
-			"runtime_id", rt.ID, "provider", rt.Provider, "path", entry.Path, "count", len(models))
+			"runtime_id", rt.ID, "provider", rt.Provider, "path", execPath, "count", len(models))
 	}
 
 	// Wire format matches handler.ModelEntry. Use a struct (not

--- a/server/internal/daemon/model_list_binary_test.go
+++ b/server/internal/daemon/model_list_binary_test.go
@@ -1,0 +1,221 @@
+package daemon
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+
+	"github.com/multica-ai/multica/server/pkg/agent"
+)
+
+// modelListFixture stands up a Daemon whose model-list report is captured and
+// whose agent.ListModels call is stubbed, so a test can assert exactly which
+// executable path model discovery enumerated without shelling out to a CLI.
+type modelListFixture struct {
+	daemon *Daemon
+
+	mu             sync.Mutex
+	listedProvider string
+	listedPath     string
+	listCalls      int
+	report         map[string]any
+}
+
+func newModelListFixture(t *testing.T) *modelListFixture {
+	t.Helper()
+	withFastLocalSkillReportBackoffs(t)
+
+	fx := &modelListFixture{}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var body map[string]any
+		_ = json.NewDecoder(r.Body).Decode(&body)
+		fx.mu.Lock()
+		fx.report = body
+		fx.mu.Unlock()
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"status":"ok"}`))
+	}))
+	t.Cleanup(srv.Close)
+
+	d := freshDaemon(srv.URL)
+	d.profileLaunchSpecs = make(map[string]profileLaunchSpec)
+	fx.daemon = d
+
+	orig := listModels
+	listModels = func(_ context.Context, provider, execPath string) (agent.Catalog, error) {
+		fx.mu.Lock()
+		fx.listedProvider = provider
+		fx.listedPath = execPath
+		fx.listCalls++
+		fx.mu.Unlock()
+		return agent.Catalog{Models: []agent.Model{{ID: "m-1", Label: "M 1"}}}, nil
+	}
+	t.Cleanup(func() { listModels = orig })
+
+	return fx
+}
+
+func (fx *modelListFixture) snapshot() (provider, path string, calls int, report map[string]any) {
+	fx.mu.Lock()
+	defer fx.mu.Unlock()
+	return fx.listedProvider, fx.listedPath, fx.listCalls, fx.report
+}
+
+// fakeExecutable writes an executable file the daemon's exec.LookPath-based
+// presence check accepts. Tests must never resolve a user-installed agent CLI,
+// so every built-in AgentEntry.Path in this file points at one of these.
+func fakeExecutable(t *testing.T, name string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), name)
+	if err := os.WriteFile(path, []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
+		t.Fatalf("write fake executable: %v", err)
+	}
+	return path
+}
+
+// TestHandleModelList_CustomProfileEnumeratesProfileBinary pins the core of
+// MUL-5789: a profile-backed runtime must have its models discovered from the
+// binary the profile pinned, not from the built-in CLI of the same protocol
+// family that happens to also be installed. Enumerating the built-in advertises
+// a catalog the launched binary never agreed to.
+func TestHandleModelList_CustomProfileEnumeratesProfileBinary(t *testing.T) {
+	fx := newModelListFixture(t)
+	d := fx.daemon
+
+	builtinPath := fakeExecutable(t, "hermes")
+	d.cfg.Agents = map[string]AgentEntry{"hermes": {Path: builtinPath}}
+	d.runtimeIndex["rt-custom"] = Runtime{ID: "rt-custom", Provider: "hermes", ProfileID: "prof-1"}
+	d.profileLaunchSpecs["prof-1"] = profileLaunchSpec{path: "/usr/local/bin/jcode", version: "1.2.3"}
+
+	d.handleModelList(context.Background(), d.runtimeIndex["rt-custom"], "req-1")
+
+	provider, path, calls, report := fx.snapshot()
+	if calls != 1 {
+		t.Fatalf("expected exactly 1 discovery call, got %d", calls)
+	}
+	if provider != "hermes" {
+		t.Fatalf("discovery provider = %q, want the protocol family %q", provider, "hermes")
+	}
+	if path != "/usr/local/bin/jcode" {
+		t.Fatalf("discovery path = %q, want the profile's command path", path)
+	}
+	if got := report["status"]; got != "completed" {
+		t.Fatalf("report status = %v, want completed (report: %v)", got, report)
+	}
+}
+
+// TestHandleModelList_CustomProfileWithoutBuiltinAgent is the reported failure
+// (GitHub #6466): a host that has only the custom command installed — no
+// built-in CLI of the same protocol family — used to answer the model list with
+// `no agent configured for provider`, leaving the picker empty even though the
+// same runtime executes tasks fine.
+func TestHandleModelList_CustomProfileWithoutBuiltinAgent(t *testing.T) {
+	fx := newModelListFixture(t)
+	d := fx.daemon
+
+	// No built-in agents at all on this host.
+	d.cfg.Agents = map[string]AgentEntry{}
+	d.runtimeIndex["rt-custom"] = Runtime{ID: "rt-custom", Provider: "hermes", ProfileID: "prof-1"}
+	d.profileLaunchSpecs["prof-1"] = profileLaunchSpec{path: "/usr/local/bin/jcode"}
+
+	d.handleModelList(context.Background(), d.runtimeIndex["rt-custom"], "req-1")
+
+	_, path, calls, report := fx.snapshot()
+	if calls != 1 {
+		t.Fatalf("expected discovery to run, got %d calls (report: %v)", calls, report)
+	}
+	if path != "/usr/local/bin/jcode" {
+		t.Fatalf("discovery path = %q, want the profile's command path", path)
+	}
+	if got := report["status"]; got != "completed" {
+		t.Fatalf("report status = %v, want completed (report: %v)", got, report)
+	}
+	if _, hasErr := report["error"]; hasErr {
+		t.Fatalf("report carried an error: %v", report)
+	}
+}
+
+// TestHandleModelList_BuiltinRuntimeUnaffected pins that the built-in path is
+// untouched, including when unrelated profile launch specs exist on the same
+// daemon. A built-in runtime has no ProfileID, so it must keep resolving
+// through the provider's agent entry.
+func TestHandleModelList_BuiltinRuntimeUnaffected(t *testing.T) {
+	fx := newModelListFixture(t)
+	d := fx.daemon
+
+	builtinPath := fakeExecutable(t, "codex")
+	d.cfg.Agents = map[string]AgentEntry{"codex": {Path: builtinPath}}
+	d.runtimeIndex["rt-builtin"] = Runtime{ID: "rt-builtin", Provider: "codex"}
+	// A custom profile for a different runtime must not leak into this lookup.
+	d.runtimeIndex["rt-custom"] = Runtime{ID: "rt-custom", Provider: "codex", ProfileID: "prof-1"}
+	d.profileLaunchSpecs["prof-1"] = profileLaunchSpec{path: "/opt/bin/company-codex"}
+
+	d.handleModelList(context.Background(), d.runtimeIndex["rt-builtin"], "req-1")
+
+	_, path, calls, report := fx.snapshot()
+	if calls != 1 {
+		t.Fatalf("expected exactly 1 discovery call, got %d", calls)
+	}
+	if path != builtinPath {
+		t.Fatalf("discovery path = %q, want the built-in entry path %q", path, builtinPath)
+	}
+	if got := report["status"]; got != "completed" {
+		t.Fatalf("report status = %v, want completed (report: %v)", got, report)
+	}
+}
+
+// TestHandleModelList_NoProfileAndNoBuiltinStillFails pins that the failure
+// message survives for the case it was actually written for: a built-in runtime
+// whose provider has no agent entry on this host.
+func TestHandleModelList_NoProfileAndNoBuiltinStillFails(t *testing.T) {
+	fx := newModelListFixture(t)
+	d := fx.daemon
+
+	d.cfg.Agents = map[string]AgentEntry{}
+	d.runtimeIndex["rt-builtin"] = Runtime{ID: "rt-builtin", Provider: "codex"}
+
+	d.handleModelList(context.Background(), d.runtimeIndex["rt-builtin"], "req-1")
+
+	_, _, calls, report := fx.snapshot()
+	if calls != 0 {
+		t.Fatalf("expected no discovery call, got %d", calls)
+	}
+	if got := report["status"]; got != "failed" {
+		t.Fatalf("report status = %v, want failed (report: %v)", got, report)
+	}
+	if got, want := report["error"], `no agent configured for provider "codex"`; got != want {
+		t.Fatalf("report error = %v, want %q", got, want)
+	}
+}
+
+// TestHandleModelList_UnresolvedProfileFallsBackToBuiltin covers the profile
+// whose command never resolved on this host (registration skipped it, so there
+// is no launch spec). Discovery must not invent a path — it falls through to
+// the built-in entry, matching customProfileLaunchForRuntime's contract.
+func TestHandleModelList_UnresolvedProfileFallsBackToBuiltin(t *testing.T) {
+	fx := newModelListFixture(t)
+	d := fx.daemon
+
+	builtinPath := fakeExecutable(t, "hermes")
+	d.cfg.Agents = map[string]AgentEntry{"hermes": {Path: builtinPath}}
+	d.runtimeIndex["rt-custom"] = Runtime{ID: "rt-custom", Provider: "hermes", ProfileID: "prof-missing"}
+
+	d.handleModelList(context.Background(), d.runtimeIndex["rt-custom"], "req-1")
+
+	_, path, calls, report := fx.snapshot()
+	if calls != 1 {
+		t.Fatalf("expected exactly 1 discovery call, got %d", calls)
+	}
+	if path != builtinPath {
+		t.Fatalf("discovery path = %q, want the built-in fallback %q", path, builtinPath)
+	}
+	if got := report["status"]; got != "completed" {
+		t.Fatalf("report status = %v, want completed (report: %v)", got, report)
+	}
+}

--- a/server/pkg/agent/model_discovery_cache_key_test.go
+++ b/server/pkg/agent/model_discovery_cache_key_test.go
@@ -1,0 +1,71 @@
+package agent
+
+import "testing"
+
+// TestDiscoveryCacheKeyScopesByExecutable pins the key shape: an empty path
+// keeps the bare provider key (what a built-in on PATH resolves to), and two
+// executables of the same protocol family never collapse onto one key.
+func TestDiscoveryCacheKeyScopesByExecutable(t *testing.T) {
+	if got, want := discoveryCacheKey("hermes", ""), "hermes"; got != want {
+		t.Fatalf("discoveryCacheKey(hermes, \"\") = %q, want %q", got, want)
+	}
+	builtin := discoveryCacheKey("hermes", "/usr/local/bin/hermes")
+	custom := discoveryCacheKey("hermes", "/usr/local/bin/jcode")
+	if builtin == custom {
+		t.Fatalf("same key %q for two different executables", builtin)
+	}
+	if builtin == "hermes" || custom == "hermes" {
+		t.Fatalf("a path-scoped key must differ from the bare provider key: %q / %q", builtin, custom)
+	}
+}
+
+// TestCachedDiscoveryDoesNotShareMemoAcrossExecutables is the reason the key
+// carries the path (MUL-5789). A host can run a built-in runtime and a custom
+// runtime profile of the same protocol family at once — the reporter's own
+// `MULTICA_HERMES_PATH` workaround produces exactly that pair. With a
+// provider-only key the first discovery to land would answer for both for the
+// full TTL, reintroducing the catalog/binary mismatch the daemon-side fix
+// removes.
+func TestCachedDiscoveryDoesNotShareMemoAcrossExecutables(t *testing.T) {
+	builtinKey := discoveryCacheKey("hermes", "/usr/local/bin/hermes")
+	customKey := discoveryCacheKey("hermes", "/usr/local/bin/jcode")
+	reset := func() {
+		modelCacheMu.Lock()
+		delete(modelCache, builtinKey)
+		delete(modelCache, customKey)
+		modelCacheMu.Unlock()
+	}
+	reset()
+	t.Cleanup(reset)
+
+	discover := func(id string, calls *int) func() (Catalog, error) {
+		return func() (Catalog, error) {
+			*calls++
+			return Catalog{Models: []Model{{ID: id}}}, nil
+		}
+	}
+
+	var builtinCalls, customCalls int
+	if _, err := cachedDiscovery(builtinKey, discover("hermes-model", &builtinCalls)); err != nil {
+		t.Fatalf("cachedDiscovery(builtin): %v", err)
+	}
+
+	got, err := cachedDiscovery(customKey, discover("jcode-model", &customCalls))
+	if err != nil {
+		t.Fatalf("cachedDiscovery(custom): %v", err)
+	}
+	if customCalls != 1 {
+		t.Fatalf("custom executable must run its own discovery, got %d calls", customCalls)
+	}
+	if len(got.Models) != 1 || got.Models[0].ID != "jcode-model" {
+		t.Fatalf("custom key served the built-in catalog: %+v", got.Models)
+	}
+
+	// The built-in entry is still memoized under its own key.
+	if _, err := cachedDiscovery(builtinKey, discover("hermes-model", &builtinCalls)); err != nil {
+		t.Fatalf("cachedDiscovery(builtin, second): %v", err)
+	}
+	if builtinCalls != 1 {
+		t.Fatalf("built-in discovery should have been served from cache, got %d calls", builtinCalls)
+	}
+}

--- a/server/pkg/agent/models.go
+++ b/server/pkg/agent/models.go
@@ -864,14 +864,36 @@ func parsePiModels(output string) []Model {
 // pattern message is also matched on its own. These are prose, not
 // `provider model` rows; without skipping them the field splitter coins bogus
 // models like `No/models`. See #3729.
+//
+// A pi-family custom runtime profile (MUL-3284) can point at a fork that has
+// no `--list-models` at all. Those exit non-zero printing usage text —
+//
+//	Error: unknown flag: --list-models
+//	Run `omp --help` for available flags.
+//
+// — and the second line has no diagnostic prefix, so it used to be coined into
+// a `Run/`omp` model. Usage hints are matched on their own markers (backtick-
+// quoted commands, `--help`, `usage:`, unknown flag/command) so the picker
+// comes back empty and the UI falls back to manual entry instead of offering
+// garbage IDs. Deliberately narrow: catalog rows are `provider/model` or
+// `provider model …` tokens, none of which carry these markers. The parse-on-
+// non-zero-exit behaviour from #3729 is untouched — older pi really does print
+// its catalog to stderr while exiting non-zero. See #4482.
 func isPiDiscoveryNoise(line string) bool {
 	lower := strings.ToLower(line)
 	if strings.Contains(lower, "no models match pattern") {
 		return true
 	}
-	return strings.HasPrefix(lower, "warning:") ||
+	if strings.HasPrefix(lower, "warning:") ||
 		strings.HasPrefix(lower, "error:") ||
-		strings.HasPrefix(lower, "info:")
+		strings.HasPrefix(lower, "info:") {
+		return true
+	}
+	return strings.Contains(line, "`") ||
+		strings.Contains(lower, "--help") ||
+		strings.Contains(lower, "usage:") ||
+		strings.Contains(lower, "unknown flag") ||
+		strings.Contains(lower, "unknown command")
 }
 
 // discoverHermesModels spins up a throwaway `hermes acp` process,

--- a/server/pkg/agent/models.go
+++ b/server/pkg/agent/models.go
@@ -143,42 +143,42 @@ func ListModels(ctx context.Context, providerType, executablePath string) (Catal
 		// agy 1.0.6 added a `--model` flag plus an `agy models` catalog
 		// command (MUL-3125). Enumerate it on demand like the other
 		// dynamic-discovery backends.
-		return cachedDiscovery(providerType, func() (Catalog, error) {
+		return cachedDiscovery(discoveryCacheKey(providerType, executablePath), func() (Catalog, error) {
 			return discovered(discoverAntigravityModels(ctx, executablePath))
 		})
 	case "traecli":
 		// Official TRAE CLI is ACP-native: it returns its model catalog from
 		// session/new. Enumerate it on demand like the other ACP backends
 		// (requires a logged-in traecli; falls back to manual entry on error).
-		return cachedDiscovery(providerType, func() (Catalog, error) {
+		return cachedDiscovery(discoveryCacheKey(providerType, executablePath), func() (Catalog, error) {
 			return discovered(discoverTraecliModels(ctx, executablePath))
 		})
 	case "cursor":
-		return cachedDiscovery(providerType, func() (Catalog, error) {
+		return cachedDiscovery(discoveryCacheKey(providerType, executablePath), func() (Catalog, error) {
 			return discoverCursorModels(ctx, executablePath)
 		})
 	case "copilot":
-		return cachedDiscovery(providerType, func() (Catalog, error) {
+		return cachedDiscovery(discoveryCacheKey(providerType, executablePath), func() (Catalog, error) {
 			return discoverCopilotModels(ctx, executablePath)
 		})
 	case "hermes":
-		return cachedDiscovery(providerType, func() (Catalog, error) {
+		return cachedDiscovery(discoveryCacheKey(providerType, executablePath), func() (Catalog, error) {
 			return discovered(discoverHermesModels(ctx, executablePath))
 		})
 	case "kimi":
-		return cachedDiscovery(providerType, func() (Catalog, error) {
+		return cachedDiscovery(discoveryCacheKey(providerType, executablePath), func() (Catalog, error) {
 			return discovered(discoverKimiModels(ctx, executablePath))
 		})
 	case "reasonix":
-		return cachedDiscovery(providerType, func() (Catalog, error) {
+		return cachedDiscovery(discoveryCacheKey(providerType, executablePath), func() (Catalog, error) {
 			return discovered(discoverReasonixModels(ctx, executablePath))
 		})
 	case "kiro":
-		return cachedDiscovery(providerType, func() (Catalog, error) {
+		return cachedDiscovery(discoveryCacheKey(providerType, executablePath), func() (Catalog, error) {
 			return discovered(discoverKiroModels(ctx, executablePath))
 		})
 	case "qoder", "qoderclicn":
-		return cachedDiscovery(providerType, func() (Catalog, error) {
+		return cachedDiscovery(discoveryCacheKey(providerType, executablePath), func() (Catalog, error) {
 			return discovered(discoverQoderModels(ctx, executablePath, qoderDefaultBinary(providerType)))
 		})
 	case "opencode":
@@ -190,18 +190,18 @@ func ListModels(ctx context.Context, providerType, executablePath string) (Catal
 			return discovered(discoverDevecoModels(ctx, executablePath))
 		})
 	case "pi":
-		return cachedDiscovery(providerType, func() (Catalog, error) {
+		return cachedDiscovery(discoveryCacheKey(providerType, executablePath), func() (Catalog, error) {
 			return discovered(discoverPiModels(ctx, executablePath))
 		})
 	case "openclaw":
-		return cachedDiscovery(providerType, func() (Catalog, error) {
+		return cachedDiscovery(discoveryCacheKey(providerType, executablePath), func() (Catalog, error) {
 			return discovered(discoverOpenclawAgents(ctx, executablePath))
 		})
 	case "codebuddy":
 		// discoverCodebuddyModels owns the thinking annotation too, so the one
 		// `--help` capture feeds both catalogs. Annotating out here would run
 		// the command a second time (MUL-5549).
-		return cachedDiscovery(providerType, func() (Catalog, error) {
+		return cachedDiscovery(discoveryCacheKey(providerType, executablePath), func() (Catalog, error) {
 			return discoverCodebuddyModels(ctx, executablePath)
 		})
 	case "qwen":
@@ -221,7 +221,7 @@ func ListModels(ctx context.Context, providerType, executablePath string) (Catal
 		// xAI Grok Build is ACP-native (`grok agent stdio`); model catalog
 		// comes from session/new. Falls back to a small static list so the
 		// UI picker stays usable offline / unauthenticated.
-		return cachedDiscovery(providerType, func() (Catalog, error) {
+		return cachedDiscovery(discoveryCacheKey(providerType, executablePath), func() (Catalog, error) {
 			return discoverGrokModels(ctx, executablePath)
 		})
 	default:
@@ -315,9 +315,9 @@ func modelHasKnownPrefix(model string) bool {
 }
 
 // cachedDiscovery invokes fn and caches the result for modelCacheTTL.
-// The cache is keyed on providerType only; callers that need to
-// distinguish discovery by host/user should include that in the key
-// if we ever introduce such a mode.
+// Callers build the key with discoveryCacheKey so two runtimes of the same
+// protocol family never share one memo entry when they enumerate different
+// binaries.
 func cachedDiscovery(key string, fn func() (Catalog, error)) (Catalog, error) {
 	modelCacheMu.Lock()
 	if entry, ok := modelCache[key]; ok && time.Now().Before(entry.expiresAt) {
@@ -353,6 +353,13 @@ func cachedDiscovery(key string, fn func() (Catalog, error)) (Catalog, error) {
 	return catalog, nil
 }
 
+// discoveryCacheKey scopes a discovery memo to the binary it enumerated.
+// A custom runtime profile (MUL-3284) runs a different executable under a
+// built-in protocol family, so a provider-only key would let a built-in
+// runtime and a same-family profile runtime on one host serve each other's
+// catalog for the TTL — the same mismatch the daemon's path resolution
+// fixes, reintroduced at the cache layer (MUL-5789). An empty path keeps
+// the bare provider key, which is what a built-in on PATH resolves to.
 func discoveryCacheKey(providerType, executablePath string) string {
 	if executablePath == "" {
 		return providerType

--- a/server/pkg/agent/models_test.go
+++ b/server/pkg/agent/models_test.go
@@ -688,6 +688,41 @@ bareword-only-line
 	}
 }
 
+// TestParsePiModelsSkipsForkUsageHints pins the second half of GitHub #4482: a
+// pi-family custom runtime profile can point at a fork with no `--list-models`,
+// which exits printing usage text. Those lines carry no diagnostic prefix, so
+// the field splitter used to coin them into models like `Run/`omp`. An empty
+// catalog is the correct answer — the UI falls back to manual entry, which is
+// strictly better than offering IDs the CLI will reject.
+func TestParsePiModelsSkipsForkUsageHints(t *testing.T) {
+	input := "Error: unknown flag: --list-models\n" +
+		"Run `omp --help` for available flags.\n" +
+		"Usage: omp [command]\n" +
+		"unknown command \"models\" for \"omp\"\n"
+
+	if models := parsePiModels(input); len(models) != 0 {
+		t.Fatalf("expected usage text to yield no models, got %+v", models)
+	}
+}
+
+// TestParsePiModelsKeepsCatalogAlongsideUsageHints pins that the widened noise
+// filter only drops the prose: a real catalog printed next to a usage hint
+// still parses. Without this the #3729 behaviour (catalog on a non-zero exit)
+// could be silently traded away for the #4482 fix.
+func TestParsePiModelsKeepsCatalogAlongsideUsageHints(t *testing.T) {
+	input := "Run `omp --help` for available flags.\n" +
+		"provider  model    context\n" +
+		"opencode  glm-4.7  202.8K\n"
+
+	models := parsePiModels(input)
+	if len(models) != 1 {
+		t.Fatalf("expected 1 model, got %d: %+v", len(models), models)
+	}
+	if models[0].ID != "opencode/glm-4.7" {
+		t.Errorf("unexpected model: %+v", models[0])
+	}
+}
+
 // TestDiscoverPiModelsNonZeroExit verifies that discoverPiModels still returns
 // the resolvable catalog when `pi --list-models` exits non-zero. Pi exits
 // non-zero (and warns) when an agent config references stale provider/model


### PR DESCRIPTION
Fixes #6466. Fixes #4482. Fixes MUL-5789. Fixes MUL-5471.

Supersedes #6112 and #4499 — both were opened against a tree that has since moved (`ListModels` now returns `Catalog`, and three protocol families were added), so this is a fresh implementation on current `main` rather than a rebase of either.

## Background

`handleModelList` resolved the executable from `d.agents()[rt.Provider]`, which holds built-in CLIs only. `runTask` launches the custom runtime profile's own command (MUL-3284). The two paths disagreed:

- A host with **only** the custom command installed answered the model list with `no agent configured for provider "hermes"` — the picker was empty even though the same runtime executed tasks fine. That's the reported failure: a `protocol_family=hermes, command_name=jcode` profile on a host with no `hermes`.
- A host with **both** installed enumerated the built-in binary and executed the profile's, so the picker could advertise models the launched CLI rejects.

Note that this isn't a "we don't know what models a custom runtime has" problem: `protocol_family` is validated against `agent.SupportedTypes` at profile creation and again at daemon registration, so every profile inherits a known family's discovery routine, and 17 of the 20 families read their catalog out of the binary itself (ACP `session/new`, `--list-models`, `models`). Pointing discovery at the right binary is the whole fix.

## Changes

**1. `handleModelList` mirrors `runTask`'s resolution order** — profile path first, built-in entry (with its MUL-4486 self-heal) otherwise, and the existing failure kept for the case it was written for: a built-in runtime whose provider has no agent entry on this host. A custom path is never re-resolved, matching `runTask` — we don't second-guess a path the profile pinned.

**2. The 60s discovery memo is scoped to the executable.** Only codex / opencode / deveco keyed on the path; every other family keyed on the provider name alone, so a built-in runtime and a same-family profile runtime on one host shared one entry — the same catalog/binary mismatch, reintroduced at the cache layer. All 16 dynamic-discovery branches now use `discoveryCacheKey`; an empty path still maps to the bare provider key. This matters for the reporter's own workaround (`MULTICA_HERMES_PATH=/usr/local/bin/jcode`), which produces exactly that built-in + profile pair.

**3. pi's parser no longer coins usage text into models** (the second half of #4482). A pi-family profile pointing at a fork with no `--list-models` gets:

```
Error: unknown flag: --list-models
Run `omp --help` for available flags.
```

The second line has no diagnostic prefix, so the field splitter turned it into a `` Run/`omp `` model. `isPiDiscoveryNoise` now also matches backtick-quoted commands, `--help`, `usage:`, and unknown flag/command. Deliberately narrow: a real `provider model …` row printed alongside a usage hint still parses, so #3729's "catalog on a non-zero exit" behaviour is untouched. An empty catalog is the right answer here — the UI falls back to manual entry.

## Not in scope

- **`fixed_args` and discovery** — tracked in MUL-5807. Only the claude / codex / antigravity / codebuddy / qwen backends actually read `opts.ExtraArgs`, which is where a profile's `fixed_args` are injected; the ACP families (hermes included) ignore them at launch today. So the reported jcode case has no discovery/execution argument divergence, and only codex / antigravity / codebuddy can diverge at all. If discovery ever starts passing launch args, `discoveryCacheKey` has to grow with it — a path-only key would let two profiles that share a binary but differ in `fixed_args` collide, which is this PR's bug again along a new axis.
- **Families whose catalog isn't discoverable from the binary** — `claude` (static Anthropic list), `qwen` / `qwenpaw` (deliberately empty). A claude-family custom profile will get an authoritative-looking static list that its binary may not accept. Pre-existing, and a separate decision about how to mark such a catalog non-authoritative.

## Verification

Run locally on macOS:

- `go build ./...`, `go vet ./internal/daemon/ ./pkg/agent/`, `gofmt` clean (`internal/daemon/execenv/git.go` is flagged on `main` already, untouched here).
- `go test ./internal/daemon/... ./pkg/agent/ -count=1` — all green.
- New `server/internal/daemon/model_list_binary_test.go`: profile runtime enumerates the profile's path even with a built-in of the same family present; custom-only host reports `completed` instead of `no agent configured`; built-in runtime unaffected by an unrelated profile spec; no-profile-no-builtin still fails with the original message; a profile whose command never resolved falls back to the built-in rather than inventing a path. `agent.ListModels` is stubbed through a new package-var indirection (same pattern as `detectAgentVersion`), and built-in entries point at test-created fake executables, so no user-installed CLI is resolved or executed.
- New `server/pkg/agent/model_discovery_cache_key_test.go`: two executables of one family don't share a memo, and each key still caches on its own.
- New pi parser tests: usage text yields no models; a catalog printed next to a usage hint still parses.

Not reproduced on real hardware — I don't have a host with a jcode/omp install, so the end-to-end picker behaviour from #6466's repro steps is still worth one manual pass on staging.

