### PR TITLE
fix(issues): keep the execution log header on one line (MUL-5804)

### DIFF
--- a/packages/views/issues/components/execution-log-section.test.tsx
+++ b/packages/views/issues/components/execution-log-section.test.tsx
@@ -27,9 +27,16 @@ vi.mock("./terminate-task-confirm-dialog", () => ({
   TerminateTaskConfirmDialog: () => null,
 }));
 
-import { ActiveTaskRow, TaskCommentCoverage, IssueUsageTotal } from "./execution-log-section";
+import {
+  ActiveTaskRow,
+  ExecutionLogSection,
+  TaskCommentCoverage,
+  IssueUsageTotal,
+} from "./execution-log-section";
 import type { TaskUsage } from "@multica/core/types";
-import { act } from "@testing-library/react";
+import { act, within } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { issueKeys } from "@multica/core/issues/queries";
 import { useCustomPricingStore } from "@multica/core/runtimes/custom-pricing-store";
 
 function makeTask(overrides: Partial<AgentTask> = {}): AgentTask {
@@ -251,6 +258,103 @@ describe("per-run token usage", () => {
     // And no em dash either — mid-run, "no figure yet" is not a claim worth
     // making next to a ticking timer.
     expect(screen.queryByText("—")).not.toBeInTheDocument();
+  });
+});
+
+// The sidebar this section lives in is a resizable panel — 260px minimum,
+// 320px default, 420px maximum — so the header's three items (section label,
+// active-run count, issue total) have to hold a width the component does not
+// choose. They stopped holding it once the total moved into the header: at the
+// 260px minimum the row has 227px and the full header wants ~238px, and the
+// label was the only item that could give. It gave by breaking "Execution log"
+// across two lines (MUL-5804). These tests pin the contract that replaced that:
+// one line always, and a width tier that drops the token figure whole.
+describe("execution log header geometry", () => {
+  function renderSection(tasks: AgentTask[]) {
+    // Seed the cache instead of mocking the API: the query is fresh for 30s,
+    // so `listTasksByIssue` is never reached and the section renders its real
+    // header markup.
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+    queryClient.setQueryData(issueKeys.tasks("issue-1"), tasks);
+    return renderWithI18n(
+      <QueryClientProvider client={queryClient}>
+        <ExecutionLogSection issueId="issue-1" identifier="MUL-1" />
+      </QueryClientProvider>,
+    );
+  }
+
+  function headerOf(): HTMLElement {
+    const label = screen.getByText("Execution log");
+    const header = label.closest("div");
+    if (!header) throw new Error("header row not found");
+    return header;
+  }
+
+  const completed = makeTask({
+    status: "completed",
+    completed_at: "2026-06-08T08:04:00Z",
+    usage: [usageSlice()],
+  });
+
+  it("keeps the section label on one line", () => {
+    renderSection([completed]);
+
+    const label = screen.getByText("Execution log");
+    // The label is the only header item allowed to shrink, so it is the one
+    // that must carry nowrap + ellipsis. A heading that reflows mid-phrase
+    // reads as broken; an ellipsis reads as a narrow column.
+    expect(label.className).toContain("truncate");
+    expect(label.closest("button")?.className).toContain("whitespace-nowrap");
+  });
+
+  it("tiers on the sidebar's width, not the viewport's", () => {
+    const { container } = renderSection([completed]);
+
+    // Two sidebars of different widths can be open in one window (desktop
+    // split panes, the mobile sheet), so a `lg:` variant would tier this
+    // header on a width that has nothing to do with the panel it sits in.
+    const root = container.firstElementChild as HTMLElement;
+    expect(root.className).toContain("@container/execution-log");
+    for (const el of headerOf().querySelectorAll("*")) {
+      // classList, not className: the chevron is an SVG, whose className is an
+      // SVGAnimatedString.
+      for (const cls of el.classList) {
+        expect(cls).not.toMatch(/^(sm|md|lg|xl|2xl):/);
+      }
+    }
+  });
+
+  it("drops the token figure whole rather than clipping a number", () => {
+    const { unmount } = renderSection([completed]);
+    let header = within(headerOf());
+
+    // Below the tier the tokens and their separator leave together and the
+    // cost stays — never a clipped "$2.0…", which would read as a different
+    // figure than the issue actually spent.
+    const cost = header.getByText("$2.00");
+    expect(header.getByText("892K").className).toContain(
+      "@max-[14rem]/execution-log:hidden",
+    );
+    expect(header.getByText("·").className).toContain(
+      "@max-[14rem]/execution-log:hidden",
+    );
+    expect(cost.className).not.toContain("hidden");
+    // And the pill itself never truncates — that is what would clip a digit.
+    const pill = cost.closest("button");
+    expect(pill?.className).toContain("shrink-0");
+    expect(pill?.className).not.toContain("truncate");
+
+    // An active run puts the count chip in the same row, which is the shape
+    // that actually runs out of width — so it tiers earlier. At rest the total
+    // fits the 260px minimum whole and should not be tiered away with it.
+    unmount();
+    renderSection([completed, makeTask({ status: "running" })]);
+    header = within(headerOf());
+    expect(header.getByText("892K").className).toContain(
+      "@max-[16rem]/execution-log:hidden",
+    );
   });
 });
 

--- a/packages/views/issues/components/execution-log-section.tsx
+++ b/packages/views/issues/components/execution-log-section.tsx
@@ -124,7 +124,11 @@ export function ExecutionLogSection({ issueId, identifier }: ExecutionLogSection
   if (activeTasks.length === 0 && pastTasks.length === 0) return null;
 
   return (
-    <div>
+    // `@container/execution-log`: the header's three items only fit side by
+    // side above a certain width, and the width that decides it is the
+    // sidebar's — a resizable 260–420px panel — not the viewport's. See
+    // IssueUsageTotal for the tier this container drives.
+    <div className="@container/execution-log">
       {/* Header is two independent targets, not one: the label + chevron
           collapse the section, the total on the right opens the usage
           breakdown. Nesting a button inside a button is invalid HTML, so they
@@ -132,12 +136,19 @@ export function ExecutionLogSection({ issueId, identifier }: ExecutionLogSection
       <div className="mb-2 flex w-full items-center gap-1">
         <button
           type="button"
-          className={`flex min-w-0 items-center gap-1 rounded-md px-2 py-1 text-caption font-medium transition-colors hover:bg-accent/70 ${
+          className={`flex min-w-0 items-center gap-1 whitespace-nowrap rounded-md px-2 py-1 text-caption font-medium transition-colors hover:bg-accent/70 ${
             open ? "" : "text-muted-foreground hover:text-foreground"
           }`}
           onClick={() => setOpen(!open)}
         >
-          {t(($) => $.execution_log.section)}
+          {/* The section label is the one item here that may shrink, so it
+              carries the nowrap + ellipsis pair. Without it the squeezed
+              button broke "Execution log" across two lines (MUL-5804) — a
+              section heading that reflows is a layout bug, not a narrow
+              column. The tier below keeps the ellipsis from ever showing at
+              the panel's 260px minimum; it is the backstop for a longer
+              translation, not the everyday state. */}
+          <span className="truncate">{t(($) => $.execution_log.section)}</span>
           <ChevronRight
             className={`!size-3 shrink-0 stroke-[2.5] text-muted-foreground transition-transform ${
               open ? "rotate-90" : ""
@@ -211,6 +222,14 @@ export function ExecutionLogSection({ issueId, identifier }: ExecutionLogSection
 // Renders nothing when no run on the issue has recorded usage — an issue whose
 // runs all predate usage reporting gets its old header back rather than a
 // "0 · $0.00" that would read as "this was free".
+//
+// Narrow sections drop the token figure and keep the cost. Something has to
+// give at the narrow end — the header's full form needs ~246px next to the
+// active-run chip and the sidebar's 260px minimum leaves 228px — and the token
+// count is the piece whose absence costs least: the cost answers "what has
+// this issue spent", and the exact token split is a click away in the dialog
+// this opens. It is a figure that yields, never a figure's digits: a clipped
+// "$31.1…" would read as a different number than the issue actually spent.
 export function IssueUsageTotal({
   tasks,
   alone,
@@ -232,6 +251,17 @@ export function IssueUsageTotal({
   );
   if (!total) return null;
 
+  // Two thresholds because the header has two shapes, and the tier should cost
+  // the reader a figure only where the row genuinely runs out: beside the
+  // active-run chip the full form needs ~246px, alone ~218px. Written as whole
+  // literal classes — Tailwind scans source text, so a composed string would
+  // generate neither. `@max-…` (rather than showing at `@min-…`) is what makes
+  // a host that renders this outside the section's `@container` degrade to the
+  // full form instead of silently losing the tokens forever.
+  const narrowTier = alone
+    ? "@max-[14rem]/execution-log:hidden"
+    : "@max-[16rem]/execution-log:hidden";
+
   return (
     <Tooltip>
       <TooltipTrigger
@@ -240,8 +270,10 @@ export function IssueUsageTotal({
           alone ? "ml-auto" : ""
         }`}
       >
-        <span className="font-medium">{formatTokens(total.tokens)}</span>
-        <span className="text-faint-foreground">·</span>
+        <span className={`font-medium ${narrowTier}`}>
+          {formatTokens(total.tokens)}
+        </span>
+        <span className={`text-faint-foreground ${narrowTier}`}>·</span>
         <span className="text-muted-foreground">{formatUsd(total.cost)}</span>
       </TooltipTrigger>
       <TooltipContent>{t(($) => $.execution_log.usage_total_tooltip)}</TooltipContent>


### PR DESCRIPTION
Fixes MUL-5804.

The issue sidebar is a resizable panel — 260px minimum, 320px default — and the execution-log header has carried three items since the issue total moved into it: the section label, the active-run count, and `24.6M · $31.18`. At the 260px minimum the row has 227px of content and that form wants ~238px, so the label — the only item that could shrink — broke "Execution log" across two lines.

## What changed

- **The label never wraps.** `whitespace-nowrap` on the button, `truncate` on the label. The ellipsis is a backstop for a longer translation, not the everyday state.
- **The header tiers on its own width, not the viewport's.** `@container/execution-log` on the section root — two sidebars of different widths can be open in one window (desktop split panes, the mobile sheet).
- **Below the tier the total drops its token figure and keeps the cost.** A figure yields, never a figure's digits: a clipped `$31.1…` would read as a number the issue never spent, and the token split is one click away in the dialog the total opens. Two thresholds, because the row has two shapes — 16rem beside the active-run chip (~246px of content), 14rem without it (~218px) — so an issue at rest keeps its whole total at every width the panel can reach.

## Verification

- Widths measured in Chromium against the real 12px caption step, across 260 / 272 / 280 / 288 / 320 / 420 panels, both header shapes, with wide-number fixtures (`2400M · $1234`, a two-digit run count): no wrap, no clipped label, no overflow at any of them. The two-line break reproduces on the pre-fix markup at 260px (and at 272px with the wider numbers) and is gone after.
- Three new tests in `execution-log-section.test.tsx` pin the contract: label on one line, no viewport variants in the header, and the token figure dropping whole at the tier that matches the row's shape.
- `pnpm exec vitest run issues` in `packages/views` (635 pass), `pnpm typecheck`, `eslint` on both changed files (only the pre-existing `pricings` dependency warning).
