### PR TITLE
MUL-5783: make upload limits configurable end to end

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -59,6 +59,10 @@ MULTICA_APP_URL=${FRONTEND_ORIGIN}
 # avoid Host / X-Forwarded-Host spoofing when a self-hosted reverse proxy
 # is not hardened.
 MULTICA_PUBLIC_URL=
+# Maximum size of one uploaded file. Accepts bytes or KB/MB/GB and
+# KiB/MiB/GiB suffixes, up to 1 GiB. Clients discover the effective value
+# from /api/config after the backend restarts.
+MULTICA_MAX_UPLOAD_SIZE=100MiB
 # Optional delay after SIGTERM/SIGINT before the existing graceful shutdown
 # begins. Accepts a non-negative Go duration such as 300s or 5m. Empty or 0
 # preserves the default behavior and starts shutdown immediately. The platform

--- a/SELF_HOSTING_ADVANCED.md
+++ b/SELF_HOSTING_ADVANCED.md
@@ -93,6 +93,7 @@ For file uploads and attachments, configure S3 and (optionally) CloudFront:
 | `S3_BUCKET` | Bucket name only (e.g. `my-bucket`). Do **not** include the `.s3.<region>.amazonaws.com` suffix — the server constructs the public URL from `S3_BUCKET` + `S3_REGION` |
 | `S3_REGION` | AWS region (default: `us-west-2`). Must match the bucket's actual region — used for both SDK signing and public URLs |
 | `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` | Static credentials. When both are unset, the AWS SDK default credential chain is used |
+| `MULTICA_MAX_UPLOAD_SIZE` | Maximum size of one file (default `100MiB`, maximum `1GiB`). Accepts bytes or `KB`/`MB`/`GB` and `KiB`/`MiB`/`GiB` suffixes. Web and mobile clients discover the effective value at runtime. |
 | `AWS_ENDPOINT_URL` | Custom S3-compatible endpoint (e.g. MinIO, R2, B2). Setting this defaults to path-style URLs for backward compatibility |
 | `S3_USE_PATH_STYLE` | Optional S3 addressing mode. Leave empty for the default (`true` when `AWS_ENDPOINT_URL` is set, `false` for AWS S3). Set `false` for S3-compatible providers that require virtual-hosted-style URLs |
 | `ATTACHMENT_DOWNLOAD_MODE` | Attachment download behavior: `auto` (default), `cloudfront`, `presign`, or `proxy`. Use `proxy` for private buckets behind Docker/VPC-only endpoints such as `http://rustfs:9000`. Avatars follow the same policy — see below |
@@ -100,6 +101,13 @@ For file uploads and attachments, configure S3 and (optionally) CloudFront:
 | `CLOUDFRONT_DOMAIN` | CloudFront distribution domain — when set, public URLs use this host instead of the S3 host |
 | `CLOUDFRONT_KEY_PAIR_ID` | CloudFront key pair ID for signed URLs |
 | `CLOUDFRONT_PRIVATE_KEY` | CloudFront private key (PEM format) |
+
+If Multica is behind nginx, Traefik, Caddy, a cloud load balancer, or another
+ingress, configure that layer to accept at least `MULTICA_MAX_UPLOAD_SIZE` plus
+1 MiB for multipart framing. An upstream proxy can reject the request before
+Multica sees it; its default body limit is independent of this setting. For
+nginx ingress and the default limit, for example, set
+`nginx.ingress.kubernetes.io/proxy-body-size: "101m"`.
 
 #### Avatars on a private bucket
 

--- a/apps/docs/content/docs/environment-variables.mdx
+++ b/apps/docs/content/docs/environment-variables.mdx
@@ -39,6 +39,7 @@ Do not use the default `JWT_SECRET` in production, and do not set `MULTICA_DEV_V
 | `AUTH_TOKEN_TTL` | `720h` (30 days) | Lifetime of browser JWTs and cookies; accepts a Go duration or a positive integer of seconds |
 | `LOG_LEVEL` | application default | Log level |
 | `MULTICA_SHUTDOWN_HOLD_DURATION` | `0` | How long to wait after a termination signal before graceful shutdown begins |
+| `MULTICA_MAX_UPLOAD_SIZE` | `100MiB` | Maximum size of one uploaded file; accepts bytes or `KB`/`MB`/`GB` and `KiB`/`MiB`/`GiB`, up to `1GiB` |
 
 When setting a shutdown hold on Kubernetes, `terminationGracePeriodSeconds` must exceed the hold plus the time the actual shutdown needs.
 
@@ -121,6 +122,11 @@ When `S3_BUCKET` is unset, Multica uses local disk.
 | `ATTACHMENT_DOWNLOAD_URL_TTL` | `30m` | Lifetime of signed download URLs |
 
 Use `ATTACHMENT_DOWNLOAD_MODE=proxy` when the endpoint — an internal MinIO, for example — is not reachable from the browser.
+
+Your reverse proxy or ingress body limit must be at least
+`MULTICA_MAX_UPLOAD_SIZE` plus 1 MiB for multipart framing. Otherwise that
+layer returns its own payload-too-large response before Multica can apply or
+report the configured limit.
 
 ### Local disk
 

--- a/apps/mobile/app/_layout.tsx
+++ b/apps/mobile/app/_layout.tsx
@@ -31,6 +31,7 @@ function AuthInitializer({ children }: { children: React.ReactNode }) {
   const signingOutRef = useRef(false);
 
   useEffect(() => {
+    const controller = new AbortController();
     // Wire 401 handling onto the shared ApiClient singleton. Must be set
     // before any request fires — initialize() below kicks off the first
     // getMe() call, so do this synchronously first.
@@ -51,7 +52,11 @@ function AuthInitializer({ children }: { children: React.ReactNode }) {
         })();
       },
     });
+    void api.loadConfig({ signal: controller.signal }).catch(() => {
+      // Older/offline servers keep the 100 MiB compatibility fallback.
+    });
     initialize();
+    return () => controller.abort();
   }, [initialize, qc]);
 
   return <>{children}</>;

--- a/apps/mobile/components/composer/message-composer.tsx
+++ b/apps/mobile/components/composer/message-composer.tsx
@@ -52,7 +52,7 @@ import { router, type Href } from "expo-router";
 import * as Haptics from "expo-haptics";
 import * as ImagePicker from "expo-image-picker";
 import * as DocumentPicker from "expo-document-picker";
-import { api, MAX_FILE_SIZE } from "@/data/api";
+import { api } from "@/data/api";
 import { useMentionDraftStore } from "@/data/stores/mention-draft-store";
 import { useColorScheme } from "@/lib/use-color-scheme";
 import { stripMarkdown } from "@/lib/strip-markdown";
@@ -346,8 +346,11 @@ export function MessageComposer({
     if (picker.canceled) return;
     const picked = picker.assets[0];
     if (!picked) return;
-    if (picked.fileSize != null && picked.fileSize > MAX_FILE_SIZE) {
-      Alert.alert("File too large", "Files must be smaller than 100 MB.");
+    if (picked.fileSize != null && picked.fileSize > api.uploadSizeLimitBytes) {
+      Alert.alert(
+        "File too large",
+        `Files must be no larger than ${api.uploadSizeLimitLabel}.`,
+      );
       return;
     }
     const filename = picked.fileName ?? `image-${Date.now()}.jpg`;
@@ -379,8 +382,11 @@ export function MessageComposer({
     if (picker.canceled) return;
     const picked = picker.assets[0];
     if (!picked) return;
-    if (picked.size != null && picked.size > MAX_FILE_SIZE) {
-      Alert.alert("File too large", "Files must be smaller than 100 MB.");
+    if (picked.size != null && picked.size > api.uploadSizeLimitBytes) {
+      Alert.alert(
+        "File too large",
+        `Files must be no larger than ${api.uploadSizeLimitLabel}.`,
+      );
       return;
     }
     const mimeType = picked.mimeType ?? "application/octet-stream";

--- a/apps/mobile/components/editor/use-file-attach.ts
+++ b/apps/mobile/components/editor/use-file-attach.ts
@@ -20,7 +20,7 @@ import { useCallback, useState } from "react";
 import { Alert } from "react-native";
 import * as ImagePicker from "expo-image-picker";
 import * as DocumentPicker from "expo-document-picker";
-import { api, MAX_FILE_SIZE, type FileAsset } from "@/data/api";
+import { api, type FileAsset } from "@/data/api";
 
 export interface FileAttachResult {
   /** Attachment id from the server. Callers MUST carry this to the mutation
@@ -50,10 +50,10 @@ export function useFileAttach() {
       asset: PickedAsset,
       ctx?: UploadContext,
     ): Promise<FileAttachResult | null> => {
-      if (asset.size != null && asset.size > MAX_FILE_SIZE) {
+      if (asset.size != null && asset.size > api.uploadSizeLimitBytes) {
         Alert.alert(
           "File too large",
-          "Files must be smaller than 100 MB.",
+          `Files must be no larger than ${api.uploadSizeLimitLabel}.`,
         );
         return null;
       }

--- a/apps/mobile/data/api.ts
+++ b/apps/mobile/data/api.ts
@@ -58,12 +58,15 @@ import type {
   Workspace,
 } from "@multica/core/types";
 import {
+  AppConfigSchema,
+  EMPTY_APP_CONFIG,
   EMPTY_LIST_ISSUES_RESPONSE,
   EMPTY_TIMELINE_ENTRIES,
   IssueSchema,
   ListIssuesResponseSchema,
   TimelineEntriesSchema,
 } from "@multica/core/api/schemas";
+import type { AppConfigResponse } from "@multica/core/api/schemas";
 import {
   ActiveTasksResponseSchema,
   AgentListSchema,
@@ -146,9 +149,16 @@ export interface FileAsset {
   type: string;
 }
 
-/** Web mirrors this from `packages/core/constants/upload.ts`. Mobile keeps
- *  its own copy per the `mirror, don't import` rule in apps/mobile/CLAUDE.md. */
-const MAX_FILE_SIZE = 100 * 1024 * 1024;
+/** Compatibility fallback for servers older than max_upload_size_bytes. */
+const DEFAULT_MAX_FILE_SIZE = 100 * 1024 * 1024;
+
+function formatFileSizeLimit(bytes: number): string {
+  const gib = 1024 * 1024 * 1024;
+  const mib = 1024 * 1024;
+  if (bytes % gib === 0) return `${bytes / gib} GiB`;
+  if (bytes % mib === 0) return `${bytes / mib} MiB`;
+  return `${bytes.toLocaleString()} bytes`;
+}
 
 /** Hard ceiling for every HTTP request. Mobile-specific because iOS may
  *  suspend a backgrounded network task without ever resolving/rejecting
@@ -180,6 +190,15 @@ export interface ApiClientOptions {
 class ApiClient {
   private token: string | null = null;
   private options: ApiClientOptions = {};
+  private maxUploadSizeBytes = DEFAULT_MAX_FILE_SIZE;
+
+  get uploadSizeLimitBytes(): number {
+    return this.maxUploadSizeBytes;
+  }
+
+  get uploadSizeLimitLabel(): string {
+    return formatFileSizeLimit(this.maxUploadSizeBytes);
+  }
 
   setToken(token: string | null) {
     this.token = token;
@@ -335,6 +354,17 @@ class ApiClient {
     return parseWithFallback(raw, schema, fallback, {
       endpoint: opts?.endpoint ?? path,
     });
+  }
+
+  async loadConfig(opts?: { signal?: AbortSignal }): Promise<AppConfigResponse> {
+    const config = await this.fetchValidated(
+      "/api/config",
+      AppConfigSchema,
+      EMPTY_APP_CONFIG,
+      { signal: opts?.signal, endpoint: "GET /api/config" },
+    );
+    this.maxUploadSizeBytes = config.max_upload_size_bytes;
+    return config;
   }
 
   /** Same as fetchValidated but supports any HTTP method + body. Used by
@@ -1238,9 +1268,11 @@ class ApiClient {
         body = undefined;
       }
       const message =
-        (body && typeof body === "object" && "message" in body
-          ? String((body as { message: unknown }).message)
-          : null) ?? `Upload failed: ${res.status}`;
+        (body && typeof body === "object" && "error" in body
+          ? String((body as { error: unknown }).error)
+          : body && typeof body === "object" && "message" in body
+            ? String((body as { message: unknown }).message)
+            : null) ?? `Upload failed: ${res.status}`;
       console.error(`[api] ← ${res.status} ${path}`, {
         rid,
         duration: `${duration}ms`,
@@ -1271,7 +1303,5 @@ class ApiClient {
     return parsed.data;
   }
 }
-
-export { MAX_FILE_SIZE };
 
 export const api = new ApiClient();

--- a/apps/web/app/api/upload-file/route.ts
+++ b/apps/web/app/api/upload-file/route.ts
@@ -1,0 +1,8 @@
+import { proxyUpload } from "@/platform/upload-proxy";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+export async function POST(request: Request): Promise<Response> {
+  return proxyUpload(request);
+}

--- a/apps/web/platform/upload-proxy.test.ts
+++ b/apps/web/platform/upload-proxy.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it, vi } from "vitest";
+import { proxyUpload } from "./upload-proxy";
+
+describe("proxyUpload", () => {
+  it("forwards the multipart stream and preserves the backend response", async () => {
+    const body = new ReadableStream({
+      start(controller) {
+        controller.enqueue(new TextEncoder().encode("multipart bytes"));
+        controller.close();
+      },
+    });
+    const request = new Request("https://app.test/api/upload-file?draft=1", {
+      method: "POST",
+      headers: {
+        authorization: "Bearer token",
+        "content-type": "multipart/form-data; boundary=test",
+        "content-length": "15",
+        "x-workspace-slug": "acme",
+      },
+      body,
+      duplex: "half",
+    } as RequestInit & { duplex: "half" });
+    const fetchImpl = vi.fn(async (_input: string | URL | Request, init?: RequestInit) => {
+      expect(init?.body).toBe(body);
+      expect(new Headers(init?.headers).get("authorization")).toBe("Bearer token");
+      expect(new Headers(init?.headers).get("x-workspace-slug")).toBe("acme");
+      expect(new Headers(init?.headers).has("content-length")).toBe(false);
+      return new Response("uploaded", {
+        status: 201,
+        headers: { "x-upload-id": "att-1" },
+      });
+    });
+
+    const response = await proxyUpload(
+      request,
+      { NODE_ENV: "production", REMOTE_API_URL: "http://backend:8080/base" },
+      fetchImpl,
+    );
+
+    expect(fetchImpl).toHaveBeenCalledOnce();
+    expect(String(fetchImpl.mock.calls[0]?.[0])).toBe(
+      "http://backend:8080/base/api/upload-file?draft=1",
+    );
+    expect(response.status).toBe(201);
+    expect(response.headers.get("x-upload-id")).toBe("att-1");
+    await expect(response.text()).resolves.toBe("uploaded");
+  });
+
+  it("returns 503 when the production backend is not configured", async () => {
+    const response = await proxyUpload(
+      new Request("https://app.test/api/upload-file", { method: "POST" }),
+      { NODE_ENV: "production" },
+    );
+
+    expect(response.status).toBe(503);
+    await expect(response.json()).resolves.toMatchObject({
+      error: "file upload backend is not configured",
+    });
+  });
+
+  it("turns upstream network errors into a stable 502", async () => {
+    const fetchImpl = vi.fn(async () => {
+      throw new Error("connection refused");
+    });
+    const response = await proxyUpload(
+      new Request("https://app.test/api/upload-file", { method: "POST" }),
+      { NODE_ENV: "production", REMOTE_API_URL: "http://backend:8080" },
+      fetchImpl,
+    );
+
+    expect(response.status).toBe(502);
+  });
+});

--- a/apps/web/platform/upload-proxy.ts
+++ b/apps/web/platform/upload-proxy.ts
@@ -1,0 +1,79 @@
+import {
+  resolveDevRemoteApiUrl,
+  resolveRemoteApiUrl,
+} from "../config/runtime-urls";
+
+type RuntimeEnv = Record<string, string | undefined>;
+type FetchLike = (input: string | URL | Request, init?: RequestInit) => Promise<Response>;
+
+const HOP_BY_HOP_HEADERS = [
+  "connection",
+  "host",
+  "keep-alive",
+  "proxy-authenticate",
+  "proxy-authorization",
+  "proxy-connection",
+  "te",
+  "trailer",
+  "transfer-encoding",
+  "upgrade",
+];
+
+function forwardedHeaders(source: Headers, request: boolean): Headers {
+  const headers = new Headers(source);
+  for (const name of HOP_BY_HOP_HEADERS) headers.delete(name);
+  // The outgoing fetch selects chunked transfer encoding for the stream. A
+  // stale browser-supplied length would make intermediaries mis-frame it.
+  if (request) headers.delete("content-length");
+  return headers;
+}
+
+function uploadOrigin(env: RuntimeEnv): string | undefined {
+  return env.NODE_ENV === "development"
+    ? resolveDevRemoteApiUrl(env)
+    : resolveRemoteApiUrl(env);
+}
+
+/** Forward the browser multipart body without materializing it in Next.js. */
+export async function proxyUpload(
+  request: Request,
+  env: RuntimeEnv = process.env,
+  fetchImpl: FetchLike = fetch,
+): Promise<Response> {
+  const origin = uploadOrigin(env);
+  if (!origin) {
+    return Response.json(
+      { error: "file upload backend is not configured" },
+      { status: 503 },
+    );
+  }
+
+  const incomingURL = new URL(request.url);
+  const upstreamURL = new URL(origin);
+  upstreamURL.pathname = `${upstreamURL.pathname.replace(/\/+$/, "")}/api/upload-file`;
+  upstreamURL.search = incomingURL.search;
+
+  try {
+    // Node's fetch requires duplex for streaming request bodies. It is an
+    // Undici extension that is intentionally kept local to this boundary.
+    const init: RequestInit & { duplex: "half" } = {
+      method: "POST",
+      headers: forwardedHeaders(request.headers, true),
+      body: request.body,
+      redirect: "manual",
+      signal: request.signal,
+      duplex: "half",
+    };
+    const upstream = await fetchImpl(upstreamURL, init);
+    return new Response(upstream.body, {
+      status: upstream.status,
+      statusText: upstream.statusText,
+      headers: forwardedHeaders(upstream.headers, false),
+    });
+  } catch (error) {
+    console.error("upload proxy request failed", {
+      error: error instanceof Error ? error.message : String(error),
+    });
+    return Response.json({ error: "file upload backend unavailable" }, { status: 502 });
+  }
+}

--- a/apps/web/proxy.test.ts
+++ b/apps/web/proxy.test.ts
@@ -1,7 +1,8 @@
 import { describe, expect, it } from "vitest";
 import { NextRequest } from "next/server";
+import { unstable_doesMiddlewareMatch } from "next/experimental/testing/server";
 import { MULTICA_LOCALE_HEADER } from "./lib/locale-routing";
-import { proxy } from "./proxy";
+import { config, proxy } from "./proxy";
 
 function makeRequest(
   path: string,
@@ -120,6 +121,23 @@ describe("proxy legacy workspace route redirects", () => {
 });
 
 describe("proxy runtime upstream rewrites", () => {
+  it("leaves upload-file to the streaming route handler", () => {
+    expect(
+      unstable_doesMiddlewareMatch({
+        config,
+        nextConfig: {},
+        url: "https://app.multica.test/api/upload-file",
+      }),
+    ).toBe(false);
+    expect(
+      unstable_doesMiddlewareMatch({
+        config,
+        nextConfig: {},
+        url: "https://app.multica.test/api/config",
+      }),
+    ).toBe(true);
+  });
+
   it("does not rewrite API requests when no runtime API origin is configured", () => {
     withoutRuntimeUpstreams(() => {
       const res = proxy(makeRequest("/api/config?x=1"));

--- a/apps/web/proxy.ts
+++ b/apps/web/proxy.ts
@@ -110,7 +110,10 @@ export const config = {
   // proxy routes whose upstream origins are resolved from process.env at
   // request time instead of being baked into next.config.js at build time.
   matcher: [
-    "/api/:path*",
+    // Uploads use an App Router handler that forwards the request body as a
+    // stream. Keeping this path out of Proxy avoids Next buffering the whole
+    // multipart request before the backend can read it.
+    "/api/((?!upload-file(?:/|$)).*)",
     "/auth/:path*",
     "/uploads/:path*",
     "/docs/:path*",

--- a/deploy/helm/multica/templates/configmap.yaml
+++ b/deploy/helm/multica/templates/configmap.yaml
@@ -25,6 +25,7 @@ data:
   CLOUDFRONT_DOMAIN: {{ .Values.backend.config.cloudfrontDomain | quote }}
   CLOUDFRONT_KEY_PAIR_ID: {{ .Values.backend.config.cloudfrontKeyPairId | quote }}
   LOCAL_UPLOAD_BASE_URL: {{ .Values.backend.config.localUploadBaseUrl | quote }}
+  MULTICA_MAX_UPLOAD_SIZE: {{ .Values.backend.config.maxUploadSize | quote }}
 
   {{- if not .Values.postgres.external.enabled }}
   # --- PostgreSQL (consumed by the backend to build DATABASE_URL) ---

--- a/deploy/helm/multica/values.yaml
+++ b/deploy/helm/multica/values.yaml
@@ -136,6 +136,9 @@ backend:
     cloudfrontDomain: ""
     cloudfrontKeyPairId: ""
     localUploadBaseUrl: http://api.multica.dev.lan
+    # Per-file upload limit. Keep the ingress body limit at least 1 MiB higher
+    # to allow for multipart framing.
+    maxUploadSize: 100MiB
   resources:
     requests:
       cpu: 100m
@@ -187,6 +190,9 @@ frontend:
 ingress:
   enabled: true
   className: traefik
+  # Controller-specific example for the default 100 MiB file limit:
+  # annotations:
+  #   nginx.ingress.kubernetes.io/proxy-body-size: "101m"
   annotations: {}
   frontend:
     host: multica.dev.lan

--- a/docker-compose.selfhost.yml
+++ b/docker-compose.selfhost.yml
@@ -110,6 +110,7 @@ services:
       # intentionally NOT used to derive this value, to avoid Host /
       # X-Forwarded-Host spoofing on misconfigured proxies.
       MULTICA_PUBLIC_URL: ${MULTICA_PUBLIC_URL:-}
+      MULTICA_MAX_UPLOAD_SIZE: ${MULTICA_MAX_UPLOAD_SIZE:-100MiB}
       # Comma-separated CIDRs whose source IP is allowed to set
       # X-Forwarded-For / X-Real-IP for the webhook per-IP rate limiter.
       # Empty default = headers ignored, RemoteAddr used. Set e.g.

--- a/packages/core/api/client.test.ts
+++ b/packages/core/api/client.test.ts
@@ -1631,6 +1631,31 @@ describe("ApiClient", () => {
       ).rejects.toMatchObject({ name: "AbortError" });
     });
 
+    it("preserves a structured 413 upload response", async () => {
+      const body = {
+        error: "file exceeds configured upload limit",
+        code: "file_too_large",
+        max_size_bytes: 10,
+      };
+      vi.stubGlobal(
+        "fetch",
+        vi.fn().mockResolvedValue(
+          new Response(JSON.stringify(body), {
+            status: 413,
+            statusText: "Payload Too Large",
+            headers: { "Content-Type": "application/json" },
+          }),
+        ),
+      );
+
+      const error = await new ApiClient("https://api.example.test")
+        .uploadFile(new File(["too large"], "large.bin"))
+        .catch((err: unknown) => err);
+
+      expect(error).toBeInstanceOf(ApiError);
+      expect(error).toMatchObject({ status: 413, body });
+    });
+
     it("sendChatMessage serialises attachment_ids onto the JSON body when present", async () => {
       const fetchMock = vi.fn().mockResolvedValue(
         new Response(JSON.stringify({ message_id: "m1", task_id: "t1", created_at: "2026-08-01T00:00:00Z" }), {

--- a/packages/core/api/client.ts
+++ b/packages/core/api/client.ts
@@ -485,16 +485,6 @@ export class ApiClient {
     this.options.onUnauthorized?.();
   }
 
-  private async parseErrorMessage(res: Response, fallback: string): Promise<string> {
-    try {
-      const data = await res.json() as { error?: string };
-      if (typeof data.error === "string" && data.error) return data.error;
-    } catch {
-      // Ignore non-JSON error bodies.
-    }
-    return fallback;
-  }
-
   // Reads the response body once for both human-readable error message and
   // structured fields. The Response stream can only be consumed once, so
   // both pieces have to come from a single read.
@@ -2269,9 +2259,12 @@ export class ApiClient {
 
     if (!res.ok) {
       if (res.status === 401) this.handleUnauthorized();
-      const message = await this.parseErrorMessage(res, `Upload failed: ${res.status}`);
+      const { message, body } = await this.parseErrorBody(
+        res,
+        `Upload failed: ${res.status}`,
+      );
       this.logger.error(`← ${res.status} /api/upload-file`, { rid, duration: `${Date.now() - start}ms`, error: message });
-      throw new Error(message);
+      throw new ApiError(message, res.status, res.statusText, body);
     }
 
     this.logger.info(`← ${res.status} /api/upload-file`, { rid, duration: `${Date.now() - start}ms` });

--- a/packages/core/api/schemas.test.ts
+++ b/packages/core/api/schemas.test.ts
@@ -805,6 +805,17 @@ describe("dashboard + runtime usage schema drift", () => {
 });
 
 describe("AppConfigSchema cdn_signed drift", () => {
+  it("defaults malformed or missing upload limits to 100 MiB", () => {
+    expect(AppConfigSchema.parse({}).max_upload_size_bytes).toBe(100 * 1024 * 1024);
+    expect(
+      AppConfigSchema.parse({ max_upload_size_bytes: "unlimited" })
+        .max_upload_size_bytes,
+    ).toBe(100 * 1024 * 1024);
+    expect(AppConfigSchema.parse({ max_upload_size_bytes: 256 << 20 }).max_upload_size_bytes).toBe(
+      256 << 20,
+    );
+  });
+
   it("defaults cdn_signed to false when the server omits it (pre-MUL-3254 servers)", () => {
     const parsed = AppConfigSchema.parse({ cdn_domain: "cdn.example.com" });
     expect(parsed.cdn_signed).toBe(false);

--- a/packages/core/api/schemas.ts
+++ b/packages/core/api/schemas.ts
@@ -342,6 +342,7 @@ export const EMPTY_ISSUE_PROPERTIES_RESPONSE: IssuePropertiesResponse = {
 
 export interface AppConfigResponse {
   cdn_domain: string;
+  max_upload_size_bytes: number;
   // True when the CDN domain serves private content via time-bounded signed
   // URLs (CloudFront signing) — raw storage URLs on that domain are NOT
   // publicly fetchable and must not be used as native media sources
@@ -535,6 +536,16 @@ const FeatureFlagsSchema = z.preprocess(
 
 export const AppConfigSchema = z.object({
   cdn_domain: z.string().default(""),
+  max_upload_size_bytes: z.preprocess(
+    (value) =>
+      typeof value === "number" &&
+      Number.isSafeInteger(value) &&
+      value > 0 &&
+      value <= 1024 * 1024 * 1024
+        ? value
+        : undefined,
+    z.number().default(100 * 1024 * 1024),
+  ),
   cdn_signed: BooleanWithDefaultSchema(false),
   allow_signup: BooleanWithDefaultSchema(true),
   google_client_id: OptionalStringSchema,
@@ -551,6 +562,7 @@ export const AppConfigSchema = z.object({
 
 export const EMPTY_APP_CONFIG: AppConfigResponse = {
   cdn_domain: "",
+  max_upload_size_bytes: 100 * 1024 * 1024,
   cdn_signed: false,
   allow_signup: true,
   google_client_id: "",

--- a/packages/core/config/index.ts
+++ b/packages/core/config/index.ts
@@ -25,6 +25,7 @@ interface ConfigState {
   // self-hosted operators can confirm what's deployed. Empty for dev builds
   // or servers older than this feature.
   serverVersion: string;
+  maxUploadSizeBytes: number;
   setCdnConfig: (config: { cdnDomain: string; cdnSigned?: boolean }) => void;
   setAuthConfig: (config: {
     allowSignup: boolean;
@@ -38,6 +39,7 @@ interface ConfigState {
   }) => void;
   setFeatureFlags: (flags?: Record<string, boolean>) => void;
   setServerVersion: (version?: string) => void;
+  setMaxUploadSizeBytes: (bytes: number) => void;
 }
 
 export const configStore = createStore<ConfigState>((set) => ({
@@ -51,6 +53,7 @@ export const configStore = createStore<ConfigState>((set) => ({
   vcsIntegrationAvailable: false,
   featureFlags: {},
   serverVersion: "",
+  maxUploadSizeBytes: 100 * 1024 * 1024,
   setCdnConfig: ({ cdnDomain, cdnSigned = false }) => set({ cdnDomain, cdnSigned }),
   setAuthConfig: ({
     allowSignup,
@@ -62,6 +65,7 @@ export const configStore = createStore<ConfigState>((set) => ({
     set({ daemonServerUrl, daemonAppUrl }),
   setFeatureFlags: (flags = {}) => set({ featureFlags: { ...flags } }),
   setServerVersion: (version = "") => set({ serverVersion: version }),
+  setMaxUploadSizeBytes: (maxUploadSizeBytes) => set({ maxUploadSizeBytes }),
 }));
 
 export function useConfigStore(): ConfigState;

--- a/packages/core/constants/upload.ts
+++ b/packages/core/constants/upload.ts
@@ -1,1 +1,22 @@
-export const MAX_FILE_SIZE = 100 * 1024 * 1024; // 100 MB
+export const DEFAULT_MAX_FILE_SIZE = 100 * 1024 * 1024;
+
+let maxFileSize = DEFAULT_MAX_FILE_SIZE;
+
+export function setMaxFileSize(bytes: number | undefined): void {
+  maxFileSize =
+    typeof bytes === "number" && Number.isSafeInteger(bytes) && bytes > 0
+      ? bytes
+      : DEFAULT_MAX_FILE_SIZE;
+}
+
+export function getMaxFileSize(): number {
+  return maxFileSize;
+}
+
+export function formatFileSizeLimit(bytes: number): string {
+  const gib = 1024 * 1024 * 1024;
+  const mib = 1024 * 1024;
+  if (bytes % gib === 0) return `${bytes / gib} GiB`;
+  if (bytes % mib === 0) return `${bytes / mib} MiB`;
+  return `${bytes.toLocaleString()} bytes`;
+}

--- a/packages/core/hooks/use-file-upload.test.ts
+++ b/packages/core/hooks/use-file-upload.test.ts
@@ -1,11 +1,17 @@
 /**
  * @vitest-environment jsdom
  */
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { renderHook, act } from "@testing-library/react";
 import type { ApiClient } from "../api/client";
 import type { Attachment } from "../types";
 import { useFileUpload, type UploadResult } from "./use-file-upload";
+import {
+  DEFAULT_MAX_FILE_SIZE,
+  setMaxFileSize,
+} from "../constants/upload";
+
+afterEach(() => setMaxFileSize(DEFAULT_MAX_FILE_SIZE));
 
 // MUL-3192 — verifies that the URL chosen for markdown persistence is
 // a durable, server-supplied absolute URL when available, and falls
@@ -96,7 +102,21 @@ describe("useFileUpload — markdownLink picks the durable URL with three-layer 
       act(async () => {
         await result.current.upload(huge);
       }),
-    ).rejects.toThrow(/100 MB/);
+    ).rejects.toThrow(/100 MiB/);
+    expect(api.uploadFile as ReturnType<typeof vi.fn>).not.toHaveBeenCalled();
+  });
+
+  it("uses the upload limit advertised by the server", async () => {
+    const api = makeApi(makeAttachment());
+    setMaxFileSize(3);
+    const file = new File(["four"], "small.bin");
+
+    const { result } = renderHook(() => useFileUpload(api));
+    await expect(
+      act(async () => {
+        await result.current.upload(file);
+      }),
+    ).rejects.toThrow(/3 bytes/);
     expect(api.uploadFile as ReturnType<typeof vi.fn>).not.toHaveBeenCalled();
   });
 });

--- a/packages/core/hooks/use-file-upload.ts
+++ b/packages/core/hooks/use-file-upload.ts
@@ -4,7 +4,7 @@ import { useState, useCallback } from "react";
 import type { ApiClient } from "../api/client";
 import type { Attachment } from "../types";
 import { attachmentDownloadPath } from "../types/attachment-url";
-import { MAX_FILE_SIZE } from "../constants/upload";
+import { formatFileSizeLimit, getMaxFileSize } from "../constants/upload";
 
 // Carries the full Attachment so editors that need preview metadata
 // (`content_type`, `download_url`) get it directly. Two URL fields are
@@ -115,8 +115,9 @@ export function useFileUpload(
 
   const upload = useCallback(
     async (file: File, ctx?: UploadContext): Promise<UploadResult | null> => {
-      if (file.size > MAX_FILE_SIZE) {
-        throw new Error("File exceeds 100 MB limit");
+      const maxFileSize = getMaxFileSize();
+      if (file.size > maxFileSize) {
+        throw new Error(`File exceeds ${formatFileSizeLimit(maxFileSize)} limit`);
       }
 
       setInFlight((n) => n + 1);

--- a/packages/core/platform/auth-initializer.tsx
+++ b/packages/core/platform/auth-initializer.tsx
@@ -18,6 +18,7 @@ import { setCurrentWorkspace } from "./workspace-storage";
 import type { ClientIdentity } from "./types";
 import type { StorageAdapter } from "../types/storage";
 import type { User } from "../types";
+import { setMaxFileSize } from "../constants/upload";
 
 const logger = createLogger("auth");
 
@@ -49,6 +50,8 @@ export function AuthInitializer({
     api
       .getConfig()
       .then((cfg) => {
+        setMaxFileSize(cfg.max_upload_size_bytes);
+        configStore.getState().setMaxUploadSizeBytes(cfg.max_upload_size_bytes);
         if (cfg.cdn_domain) {
           configStore.getState().setCdnConfig({
             cdnDomain: cfg.cdn_domain,

--- a/packages/views/editor/use-coordinated-uploads.ts
+++ b/packages/views/editor/use-coordinated-uploads.ts
@@ -55,7 +55,10 @@ import {
   type UploadContext,
   type UploadResult,
 } from "@multica/core/hooks/use-file-upload";
-import { MAX_FILE_SIZE } from "@multica/core/constants/upload";
+import {
+  formatFileSizeLimit,
+  getMaxFileSize,
+} from "@multica/core/constants/upload";
 import { useT } from "../i18n";
 import type { UploadGate } from "./use-upload-gate";
 import type { ContentEditorRef } from "./content-editor";
@@ -392,10 +395,11 @@ export function useCoordinatedUploads(
 
       const pastedText = pastedTextSource(file);
 
-      if (file.size > MAX_FILE_SIZE) {
+      const maxFileSize = getMaxFileSize();
+      if (file.size > maxFileSize) {
         // Never enters the coordinator, and never enters the draft either —
         // see the settle handler below for why a failure leaves no placeholder.
-        const reason = "File exceeds 100 MB limit";
+        const reason = `File exceeds ${formatFileSizeLimit(maxFileSize)} limit`;
         if (pastedText !== undefined) {
           // A paste has no on-disk copy to re-attach from, so the text goes
           // back into the composer instead of being lost with the upload.

--- a/server/cmd/multica/cmd_attachment.go
+++ b/server/cmd/multica/cmd_attachment.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"time"
 
@@ -151,12 +152,6 @@ func runAttachmentDownload(cmd *cobra.Command, args []string) error {
 		filename = args[0]
 	}
 
-	// Download the file content.
-	data, err := client.DownloadFile(ctx, downloadURL)
-	if err != nil {
-		return fmt.Errorf("download file: %w", err)
-	}
-
 	// Write to the output directory, creating it if needed so `-o` works
 	// against a directory that does not exist yet (the help example's
 	// `-o ./attachments` in a clean workdir).
@@ -167,9 +162,34 @@ func runAttachmentDownload(cmd *cobra.Command, args []string) error {
 		}
 	}
 	destPath := filepath.Join(outputDir, filename)
+	sizeText := strVal(att, "size_bytes")
+	sizeBytes, err := strconv.ParseInt(sizeText, 10, 64)
+	if err != nil || sizeBytes < 0 {
+		return fmt.Errorf("attachment has invalid size_bytes %q", sizeText)
+	}
+	tempFile, err := os.CreateTemp(outputDir, ".multica-download-*")
+	if err != nil {
+		return fmt.Errorf("create temporary download: %w", err)
+	}
+	tempPath := tempFile.Name()
+	defer os.Remove(tempPath)
 
-	if err := os.WriteFile(destPath, data, 0o644); err != nil {
-		return fmt.Errorf("write file: %w", err)
+	written, downloadErr := client.DownloadFileTo(ctx, downloadURL, tempFile, sizeBytes)
+	closeErr := tempFile.Close()
+	if downloadErr != nil {
+		return fmt.Errorf("download file: %w", downloadErr)
+	}
+	if closeErr != nil {
+		return fmt.Errorf("close downloaded file: %w", closeErr)
+	}
+	if written != sizeBytes {
+		return fmt.Errorf("download size mismatch: got %d bytes, expected %d", written, sizeBytes)
+	}
+	if err := os.Chmod(tempPath, 0o644); err != nil {
+		return fmt.Errorf("set downloaded file permissions: %w", err)
+	}
+	if err := os.Rename(tempPath, destPath); err != nil {
+		return fmt.Errorf("move downloaded file into place: %w", err)
 	}
 
 	// Print the absolute path so agents can reference the file.
@@ -184,6 +204,6 @@ func runAttachmentDownload(cmd *cobra.Command, args []string) error {
 		"id":       strVal(att, "id"),
 		"filename": filename,
 		"path":     abs,
-		"size":     strVal(att, "size_bytes"),
+		"size":     sizeText,
 	})
 }

--- a/server/cmd/server/router.go
+++ b/server/cmd/server/router.go
@@ -143,6 +143,18 @@ func parseTrustedProxies(raw string) []netip.Prefix {
 	return out
 }
 
+func configuredMaxUploadSize(raw string) int64 {
+	size, err := handler.ParseMaxUploadSize(raw)
+	if err != nil {
+		slog.Warn("invalid MULTICA_MAX_UPLOAD_SIZE, using default",
+			"value", raw,
+			"default_bytes", handler.DefaultMaxUploadSizeBytes,
+			"error", err)
+		return handler.DefaultMaxUploadSizeBytes
+	}
+	return size
+}
+
 // normalizeServerVersion maps the unstamped "dev" default (main.go's
 // `version` var, unchanged when the binary wasn't built with
 // -X main.version=<tag>) to an empty string. handler.Config.ServerVersion
@@ -213,6 +225,7 @@ func NewRouterWithOptions(pool *pgxpool.Pool, hub *realtime.Hub, bus *events.Bus
 	origins := allowedOrigins()
 
 	signupConfig := handler.Config{
+		MaxUploadSizeBytes:       configuredMaxUploadSize(os.Getenv("MULTICA_MAX_UPLOAD_SIZE")),
 		AllowSignup:              os.Getenv("ALLOW_SIGNUP") != "false",
 		AllowedEmails:            splitAndTrim(os.Getenv("ALLOWED_EMAILS")),
 		AllowedEmailDomains:      splitAndTrim(os.Getenv("ALLOWED_EMAIL_DOMAINS")),

--- a/server/internal/cli/client.go
+++ b/server/internal/cli/client.go
@@ -671,7 +671,9 @@ func (c *APIClient) ImportSkillFile(ctx context.Context, fileData []byte, filena
 
 // DownloadFile downloads a file from the given URL and returns the response body.
 // This is used for downloading attachments via their signed download_url.
-// Downloads are limited to 100 MB to match the upload size limit.
+// This legacy in-memory helper is capped at 100 MiB and returns an explicit
+// error instead of truncating. File-oriented callers should use
+// DownloadFileTo with the attachment's advertised size.
 //
 // The URL may be absolute (a signed CloudFront/S3 URL) or relative
 // (a server-relative path like "/api/attachments/{id}/download" or
@@ -680,17 +682,28 @@ func (c *APIClient) ImportSkillFile(ctx context.Context, fileData []byte, filena
 // BaseURL and sent with the standard auth headers; absolute URLs are
 // used as-is so that their query-string signatures are not disturbed.
 func (c *APIClient) DownloadFile(ctx context.Context, downloadURL string) ([]byte, error) {
+	var body bytes.Buffer
+	const maxDownloadSize = 100 << 20
+	if _, err := c.DownloadFileTo(ctx, downloadURL, &body, maxDownloadSize); err != nil {
+		return nil, err
+	}
+	return body.Bytes(), nil
+}
+
+// DownloadFileTo streams a download into dst and fails explicitly if the body
+// exceeds maxBytes. A negative maxBytes means no client-side cap.
+func (c *APIClient) DownloadFileTo(ctx context.Context, downloadURL string, dst io.Writer, maxBytes int64) (int64, error) {
 	isRelative := !strings.HasPrefix(downloadURL, "http://") && !strings.HasPrefix(downloadURL, "https://")
 	if isRelative {
 		if c.BaseURL == "" {
-			return nil, fmt.Errorf("download URL %q is relative but client has no BaseURL", downloadURL)
+			return 0, fmt.Errorf("download URL %q is relative but client has no BaseURL", downloadURL)
 		}
 		downloadURL = c.BaseURL + downloadURL
 	}
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, downloadURL, nil)
 	if err != nil {
-		return nil, err
+		return 0, err
 	}
 	if isRelative {
 		c.setHeaders(req)
@@ -699,16 +712,26 @@ func (c *APIClient) DownloadFile(ctx context.Context, downloadURL string) ([]byt
 	resp, err := c.HTTPClient.Do(req)
 	err = wrapTransport(req, err)
 	if err != nil {
-		return nil, err
+		return 0, err
 	}
 	defer resp.Body.Close()
 
 	if resp.StatusCode >= 400 {
-		return nil, newHTTPError(http.MethodGet, downloadURL, resp)
+		return 0, newHTTPError(http.MethodGet, downloadURL, resp)
 	}
 
-	const maxDownloadSize = 100 << 20 // 100 MB
-	return io.ReadAll(io.LimitReader(resp.Body, maxDownloadSize))
+	reader := io.Reader(resp.Body)
+	if maxBytes >= 0 {
+		reader = io.LimitReader(resp.Body, maxBytes+1)
+	}
+	written, err := io.Copy(dst, reader)
+	if err != nil {
+		return written, err
+	}
+	if maxBytes >= 0 && written > maxBytes {
+		return written, fmt.Errorf("download exceeds %d-byte limit", maxBytes)
+	}
+	return written, nil
 }
 
 // HealthCheck hits the /health endpoint and returns the response body.

--- a/server/internal/cli/client_test.go
+++ b/server/internal/cli/client_test.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -279,6 +280,26 @@ func TestDownloadFile(t *testing.T) {
 			t.Fatal("expected error, got nil")
 		}
 	})
+}
+
+func TestDownloadFileToRejectsOversizeBodyWithoutSilentTruncation(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		io.WriteString(w, "12345")
+	}))
+	defer srv.Close()
+
+	client := NewAPIClient(srv.URL, "", "")
+	var dst bytes.Buffer
+	written, err := client.DownloadFileTo(context.Background(), srv.URL, &dst, 4)
+	if err == nil {
+		t.Fatal("expected oversize error")
+	}
+	if written != 5 {
+		t.Fatalf("written = %d, want 5 bytes observed", written)
+	}
+	if !strings.Contains(err.Error(), "exceeds 4-byte limit") {
+		t.Fatalf("unexpected error: %v", err)
+	}
 }
 
 func TestUploadFileWithURL(t *testing.T) {

--- a/server/internal/handler/config.go
+++ b/server/internal/handler/config.go
@@ -12,6 +12,9 @@ import (
 
 type AppConfig struct {
 	CdnDomain string `json:"cdn_domain"`
+	// MaxUploadSizeBytes is safe public capability metadata. Clients use it
+	// for preflight validation; the server remains authoritative.
+	MaxUploadSizeBytes int64 `json:"max_upload_size_bytes"`
 	// CdnSigned tells clients that the CDN domain above serves PRIVATE
 	// content through time-bounded signed URLs (CloudFront signing is
 	// enabled). When true, a raw storage URL on the CDN domain is NOT
@@ -76,6 +79,7 @@ func (h *Handler) GetConfig(w http.ResponseWriter, r *http.Request) {
 		AllowSignup:               os.Getenv("ALLOW_SIGNUP") != "false",
 		GoogleClientID:            os.Getenv("GOOGLE_CLIENT_ID"),
 		WorkspaceCreationDisabled: os.Getenv("DISABLE_WORKSPACE_CREATION") == "true",
+		MaxUploadSizeBytes:        h.maxUploadSizeBytes(),
 	}
 	if h.Storage != nil {
 		config.CdnDomain = h.Storage.CdnDomain()

--- a/server/internal/handler/config_test.go
+++ b/server/internal/handler/config_test.go
@@ -9,6 +9,24 @@ import (
 	"github.com/multica-ai/multica/server/internal/auth"
 )
 
+func TestGetConfigExposesMaxUploadSize(t *testing.T) {
+	h := &Handler{cfg: Config{MaxUploadSizeBytes: 256 << 20}}
+	req := httptest.NewRequest(http.MethodGet, "/api/config", nil)
+	w := httptest.NewRecorder()
+
+	h.GetConfig(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("GetConfig: expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	var cfg AppConfig
+	if err := json.Unmarshal(w.Body.Bytes(), &cfg); err != nil {
+		t.Fatalf("decode config: %v", err)
+	}
+	if cfg.MaxUploadSizeBytes != 256<<20 {
+		t.Fatalf("max_upload_size_bytes = %d, want %d", cfg.MaxUploadSizeBytes, 256<<20)
+	}
+}
+
 func TestGetConfigReportsCdnSignedMode(t *testing.T) {
 	origStorage := testHandler.Storage
 	origSigner := testHandler.CFSigner

--- a/server/internal/handler/file.go
+++ b/server/internal/handler/file.go
@@ -2,6 +2,7 @@ package handler
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"log/slog"
@@ -30,8 +31,6 @@ var extContentTypes = map[string]string{
 	".json": "application/json",
 	".wasm": "application/wasm",
 }
-
-const maxUploadSize = 100 << 20 // 100 MB
 
 const defaultAttachmentDownloadURLTTL = 30 * time.Minute
 
@@ -378,11 +377,27 @@ func (h *Handler) UploadFile(w http.ResponseWriter, r *http.Request) {
 	}
 
 	workspaceID := h.resolveWorkspaceID(r)
+	var uploaderType, uploaderID string
+	if workspaceID != "" {
+		// Reject unauthorized workspace uploads before reading any attacker-
+		// controlled body bytes.
+		if _, err := h.getWorkspaceMember(r.Context(), userID, workspaceID); err != nil {
+			writeError(w, http.StatusForbidden, "not a member of this workspace")
+			return
+		}
+		uploaderType, uploaderID = h.resolveActor(r, userID, workspaceID)
+	}
 
-	r.Body = http.MaxBytesReader(w, r.Body, maxUploadSize)
+	maxFileSize := h.maxUploadSizeBytes()
+	r.Body = http.MaxBytesReader(w, r.Body, maxFileSize+multipartEnvelopeBytes)
 
-	if err := r.ParseMultipartForm(maxUploadSize); err != nil {
-		writeError(w, http.StatusBadRequest, "file too large or invalid multipart form")
+	if err := r.ParseMultipartForm(multipartMemoryBytes); err != nil {
+		var maxBytesErr *http.MaxBytesError
+		if errors.As(err, &maxBytesErr) {
+			writeUploadTooLarge(w, maxFileSize)
+			return
+		}
+		writeError(w, http.StatusBadRequest, "invalid multipart form")
 		return
 	}
 	defer r.MultipartForm.RemoveAll()
@@ -393,6 +408,10 @@ func (h *Handler) UploadFile(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	defer file.Close()
+	if header.Size > maxFileSize {
+		writeUploadTooLarge(w, maxFileSize)
+		return
+	}
 
 	// Sniff actual content type from file bytes instead of trusting the client header.
 	buf := make([]byte, 512)
@@ -409,12 +428,6 @@ func (h *Handler) UploadFile(w http.ResponseWriter, r *http.Request) {
 	// Seek back so the full file is uploaded.
 	if _, err := file.Seek(0, io.SeekStart); err != nil {
 		writeError(w, http.StatusInternalServerError, "failed to read file")
-		return
-	}
-
-	data, err := io.ReadAll(file)
-	if err != nil {
-		writeError(w, http.StatusBadRequest, "failed to read file")
 		return
 	}
 
@@ -435,13 +448,6 @@ func (h *Handler) UploadFile(w http.ResponseWriter, r *http.Request) {
 
 	// If workspace context is available, validate membership before uploading.
 	if workspaceID != "" {
-		if _, err := h.getWorkspaceMember(r.Context(), userID, workspaceID); err != nil {
-			writeError(w, http.StatusForbidden, "not a member of this workspace")
-			return
-		}
-
-		uploaderType, uploaderID := h.resolveActor(r, userID, workspaceID)
-
 		params := db.CreateAttachmentParams{
 			ID:           pgtype.UUID{Bytes: id, Valid: true},
 			WorkspaceID:  parseUUID(workspaceID),
@@ -449,7 +455,7 @@ func (h *Handler) UploadFile(w http.ResponseWriter, r *http.Request) {
 			UploaderID:   parseUUID(uploaderID),
 			Filename:     header.Filename,
 			ContentType:  contentType,
-			SizeBytes:    int64(len(data)),
+			SizeBytes:    header.Size,
 		}
 
 		if issueID := r.FormValue("issue_id"); issueID != "" {
@@ -546,7 +552,7 @@ func (h *Handler) UploadFile(w http.ResponseWriter, r *http.Request) {
 			params.ChatSessionID = task.ChatSessionID
 		}
 
-		link, err := h.Storage.Upload(r.Context(), key, data, contentType, header.Filename)
+		link, err := h.uploadFileContents(r.Context(), key, file, header.Size, contentType, header.Filename)
 		if err != nil {
 			slog.Error("file upload failed", "error", err)
 			writeError(w, http.StatusInternalServerError, "upload failed")
@@ -573,7 +579,7 @@ func (h *Handler) UploadFile(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// No workspace context (e.g. avatar upload) — upload directly.
-	link, err := h.Storage.Upload(r.Context(), key, data, contentType, header.Filename)
+	link, err := h.uploadFileContents(r.Context(), key, file, header.Size, contentType, header.Filename)
 	if err != nil {
 		slog.Error("file upload failed", "error", err)
 		writeError(w, http.StatusInternalServerError, "upload failed")
@@ -583,6 +589,23 @@ func (h *Handler) UploadFile(w http.ResponseWriter, r *http.Request) {
 		"id":       id.String(),
 		"url":      link,
 		"filename": header.Filename,
+	})
+}
+
+func (h *Handler) uploadFileContents(ctx context.Context, key string, file io.Reader, sizeBytes int64, contentType, filename string) (string, error) {
+	if sizeBytes > 0 {
+		return h.Storage.UploadStream(ctx, key, file, sizeBytes, contentType, filename)
+	}
+
+	// The S3 streaming uploader requires a positive content length.
+	return h.Storage.Upload(ctx, key, nil, contentType, filename)
+}
+
+func writeUploadTooLarge(w http.ResponseWriter, maxBytes int64) {
+	writeJSON(w, http.StatusRequestEntityTooLarge, map[string]any{
+		"error":          fmt.Sprintf("file exceeds configured upload limit of %d bytes", maxBytes),
+		"code":           "file_too_large",
+		"max_size_bytes": maxBytes,
 	})
 }
 

--- a/server/internal/handler/file_test.go
+++ b/server/internal/handler/file_test.go
@@ -57,6 +57,7 @@ type mockStorage struct {
 	files               map[string][]byte
 	presignCalls        []string
 	presignDispositions []string
+	streamUploads       int
 }
 
 func (m *mockStorage) Upload(_ context.Context, key string, data []byte, _ string, _ string) (string, error) {
@@ -67,6 +68,17 @@ func (m *mockStorage) Upload(_ context.Context, key string, data []byte, _ strin
 	}
 	m.files[key] = append([]byte(nil), data...)
 	return fmt.Sprintf("https://cdn.example.com/%s", key), nil
+}
+
+func (m *mockStorage) UploadStream(ctx context.Context, key string, data io.Reader, _ int64, contentType string, filename string) (string, error) {
+	contents, err := io.ReadAll(data)
+	if err != nil {
+		return "", err
+	}
+	m.mu.Lock()
+	m.streamUploads++
+	m.mu.Unlock()
+	return m.Upload(ctx, key, contents, contentType, filename)
 }
 
 func (m *mockStorage) Delete(_ context.Context, key string) {
@@ -208,7 +220,8 @@ func (m *failingMockStorage) GetReader(_ context.Context, key string) (io.ReadCl
 
 func TestUploadFileForeignWorkspace(t *testing.T) {
 	origStorage := testHandler.Storage
-	testHandler.Storage = &mockStorage{}
+	store := &mockStorage{}
+	testHandler.Storage = store
 	defer func() { testHandler.Storage = origStorage }()
 
 	var body bytes.Buffer
@@ -230,6 +243,94 @@ func TestUploadFileForeignWorkspace(t *testing.T) {
 	testHandler.UploadFile(w, req)
 	if w.Code != http.StatusForbidden {
 		t.Fatalf("UploadFile with foreign workspace: expected 403, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+type countingReadCloser struct {
+	io.Reader
+	reads int
+}
+
+func (r *countingReadCloser) Read(p []byte) (int, error) {
+	r.reads++
+	return r.Reader.Read(p)
+}
+
+func (*countingReadCloser) Close() error { return nil }
+
+func TestUploadFileRejectsForeignWorkspaceBeforeReadingBody(t *testing.T) {
+	origStorage := testHandler.Storage
+	testHandler.Storage = &mockStorage{}
+	t.Cleanup(func() { testHandler.Storage = origStorage })
+
+	body := &countingReadCloser{Reader: strings.NewReader("untrusted body")}
+	req := httptest.NewRequest(http.MethodPost, "/api/upload-file", nil)
+	req.Body = body
+	req.Header.Set("Content-Type", "multipart/form-data; boundary=test")
+	req.Header.Set("X-User-ID", testUserID)
+	req.Header.Set("X-Workspace-ID", "00000000-0000-0000-0000-000000000099")
+
+	w := httptest.NewRecorder()
+	testHandler.UploadFile(w, req)
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("status = %d, want 403: %s", w.Code, w.Body.String())
+	}
+	if body.reads != 0 {
+		t.Fatalf("unauthorized request body was read %d time(s)", body.reads)
+	}
+}
+
+func TestUploadFileConfiguredLimit(t *testing.T) {
+	origStorage := testHandler.Storage
+	origCfg := testHandler.cfg
+	store := &mockStorage{}
+	testHandler.Storage = store
+	testHandler.cfg.MaxUploadSizeBytes = 10
+	t.Cleanup(func() {
+		testHandler.Storage = origStorage
+		testHandler.cfg = origCfg
+	})
+
+	request := func(contents string) *http.Request {
+		t.Helper()
+		var body bytes.Buffer
+		writer := multipart.NewWriter(&body)
+		part, err := writer.CreateFormFile("file", "limit.txt")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if _, err := part.Write([]byte(contents)); err != nil {
+			t.Fatal(err)
+		}
+		if err := writer.Close(); err != nil {
+			t.Fatal(err)
+		}
+		req := httptest.NewRequest(http.MethodPost, "/api/upload-file", &body)
+		req.Header.Set("Content-Type", writer.FormDataContentType())
+		req.Header.Set("X-User-ID", testUserID)
+		return req
+	}
+
+	w := httptest.NewRecorder()
+	testHandler.UploadFile(w, request("0123456789"))
+	if w.Code != http.StatusOK {
+		t.Fatalf("exact limit: status = %d, want 200: %s", w.Code, w.Body.String())
+	}
+	if store.streamUploads != 1 {
+		t.Fatalf("stream uploads = %d, want 1", store.streamUploads)
+	}
+
+	w = httptest.NewRecorder()
+	testHandler.UploadFile(w, request("01234567890"))
+	if w.Code != http.StatusRequestEntityTooLarge {
+		t.Fatalf("over limit: status = %d, want 413: %s", w.Code, w.Body.String())
+	}
+	var response map[string]any
+	if err := json.Unmarshal(w.Body.Bytes(), &response); err != nil {
+		t.Fatalf("decode 413: %v", err)
+	}
+	if response["code"] != "file_too_large" || response["max_size_bytes"] != float64(10) {
+		t.Fatalf("unexpected 413 response: %#v", response)
 	}
 }
 

--- a/server/internal/handler/handler.go
+++ b/server/internal/handler/handler.go
@@ -59,6 +59,9 @@ type dbExecutor interface {
 }
 
 type Config struct {
+	// MaxUploadSizeBytes is the per-file upload limit exposed through
+	// /api/config. It is populated from MULTICA_MAX_UPLOAD_SIZE.
+	MaxUploadSizeBytes  int64
 	AllowSignup         bool
 	AllowedEmails       []string
 	AllowedEmailDomains []string
@@ -300,6 +303,9 @@ func New(queries *db.Queries, txStarter txStarter, hub *realtime.Hub, bus *event
 	}
 	if cfg.AttachmentDownloadURLTTL <= 0 {
 		cfg.AttachmentDownloadURLTTL = defaultAttachmentDownloadURLTTL
+	}
+	if cfg.MaxUploadSizeBytes <= 0 {
+		cfg.MaxUploadSizeBytes = DefaultMaxUploadSizeBytes
 	}
 
 	var daemonHub *daemonws.Hub

--- a/server/internal/handler/upload_size.go
+++ b/server/internal/handler/upload_size.go
@@ -1,0 +1,63 @@
+package handler
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+const (
+	DefaultMaxUploadSizeBytes      int64 = 100 << 20
+	MaxConfigurableUploadSizeBytes int64 = 1 << 30
+	multipartMemoryBytes           int64 = 8 << 20
+	multipartEnvelopeBytes         int64 = 1 << 20
+)
+
+// ParseMaxUploadSize parses an integer byte count or a binary size suffix.
+// MB/GB are treated as MiB/GiB for compatibility with common self-hosted
+// configuration conventions. Values above 1 GiB are rejected so a typo
+// cannot turn a public multipart endpoint into an unbounded resource sink.
+func ParseMaxUploadSize(raw string) (int64, error) {
+	value := strings.TrimSpace(raw)
+	if value == "" {
+		return DefaultMaxUploadSizeBytes, nil
+	}
+
+	i := 0
+	for i < len(value) && value[i] >= '0' && value[i] <= '9' {
+		i++
+	}
+	if i == 0 {
+		return 0, fmt.Errorf("must start with a positive integer")
+	}
+	n, err := strconv.ParseInt(value[:i], 10, 64)
+	if err != nil || n <= 0 {
+		return 0, fmt.Errorf("must be a positive integer")
+	}
+
+	suffix := strings.ToLower(strings.TrimSpace(value[i:]))
+	multiplier := int64(1)
+	switch suffix {
+	case "", "b":
+	case "k", "kb", "kib":
+		multiplier = 1 << 10
+	case "m", "mb", "mib":
+		multiplier = 1 << 20
+	case "g", "gb", "gib":
+		multiplier = 1 << 30
+	default:
+		return 0, fmt.Errorf("unsupported size suffix %q", suffix)
+	}
+
+	if n > MaxConfigurableUploadSizeBytes/multiplier {
+		return 0, fmt.Errorf("must not exceed 1 GiB")
+	}
+	return n * multiplier, nil
+}
+
+func (h *Handler) maxUploadSizeBytes() int64 {
+	if h.cfg.MaxUploadSizeBytes > 0 {
+		return h.cfg.MaxUploadSizeBytes
+	}
+	return DefaultMaxUploadSizeBytes
+}

--- a/server/internal/handler/upload_size_test.go
+++ b/server/internal/handler/upload_size_test.go
@@ -1,0 +1,38 @@
+package handler
+
+import "testing"
+
+func TestParseMaxUploadSize(t *testing.T) {
+	tests := []struct {
+		name string
+		raw  string
+		want int64
+	}{
+		{name: "default", raw: "", want: DefaultMaxUploadSizeBytes},
+		{name: "bytes", raw: "4096", want: 4096},
+		{name: "megabytes", raw: "250MB", want: 250 << 20},
+		{name: "mebibytes with whitespace", raw: " 64 MiB ", want: 64 << 20},
+		{name: "maximum", raw: "1GiB", want: MaxConfigurableUploadSizeBytes},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ParseMaxUploadSize(tt.raw)
+			if err != nil {
+				t.Fatalf("ParseMaxUploadSize(%q): %v", tt.raw, err)
+			}
+			if got != tt.want {
+				t.Fatalf("ParseMaxUploadSize(%q) = %d, want %d", tt.raw, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestParseMaxUploadSizeRejectsUnsafeValues(t *testing.T) {
+	for _, raw := range []string{"0", "-1", "10.5MB", "100watts", "2GiB"} {
+		t.Run(raw, func(t *testing.T) {
+			if _, err := ParseMaxUploadSize(raw); err == nil {
+				t.Fatalf("ParseMaxUploadSize(%q) unexpectedly succeeded", raw)
+			}
+		})
+	}
+}

--- a/server/internal/storage/storage.go
+++ b/server/internal/storage/storage.go
@@ -8,6 +8,7 @@ import (
 
 type Storage interface {
 	Upload(ctx context.Context, key string, data []byte, contentType string, filename string) (string, error)
+	UploadStream(ctx context.Context, key string, data io.Reader, sizeBytes int64, contentType string, filename string) (string, error)
 	Delete(ctx context.Context, key string)
 	// DeleteObject is Delete with the error surfaced — the channel-media
 	// reconciler schedules retries on failure instead of assuming success.


### PR DESCRIPTION
## Summary

- route `/api/upload-file` through a dedicated streaming App Router handler so Next Proxy no longer truncates self-hosted uploads at 10 MiB
- add `MULTICA_MAX_UPLOAD_SIZE` (default 100 MiB, hard maximum 1 GiB), expose the effective limit through `/api/config`, stream parsed files into storage, authorize workspace membership before reading the body, and return structured 413 responses
- make Web and Mobile preflight checks consume the server capability, preserve structured upload errors, and make CLI attachment downloads stream without silent 100 MiB truncation
- wire the setting into Docker Compose and Helm defaults and document reverse-proxy/ingress body-limit requirements

## Safety and compatibility

- no database or persisted-format migration
- no global increase to Next's proxy buffering limit
- multipart memory stays fixed at 8 MiB; larger files spool and then stream to storage
- invalid configuration logs a warning and safely falls back to 100 MiB
- older servers and clients retain the previous 100 MiB behavior

## Validation

- `pnpm --filter @multica/web build`
- Web test suite; focused Core upload/config tests (161); Mobile test suite (55)
- Core, Views, Web, Mobile, and Docs typechecks
- Core, Views, Web, and Mobile lint (pre-existing warnings only)
- focused Go handler/CLI tests and `go test ./... -run '^$'`
- `docker compose -f docker-compose.selfhost.yml config --quiet`
- Helm `values.yaml` parsed successfully (the local environment does not have the `helm` binary)

Local full-suite notes: the Core suite has eight unrelated Node 26 `localStorage` failures, and the backend integration suite is blocked by an existing local test database missing current migration columns. All tests covering this change pass.

Fixes #6461
Closes MUL-5783
