### PR TITLE
feat(views): mobile comment rails + full-screen keyboard-aware chat

### DIFF
--- a/packages/views/chat/components/chat-window.tsx
+++ b/packages/views/chat/components/chat-window.tsx
@@ -68,6 +68,8 @@ import { ChatQueue } from "./chat-queue";
 import { ChatResizeHandles } from "./chat-resize-handles";
 import { useChatContextItems } from "./use-chat-context-items";
 import { useChatResize } from "./use-chat-resize";
+import { useVisualViewportKeyboard } from "./use-visual-viewport-keyboard";
+import { useIsMobile } from "@multica/ui/hooks/use-mobile";
 import {
   hasInFlightPendingTask,
   isStillOnComposeTarget,
@@ -738,14 +740,65 @@ export function ChatWindow() {
 
   const isVisible = isOpen && (isExpanded || boundsReady);
 
+  // Small screens drop the floating-card form entirely — a 90%-of-375px
+  // "window" is all chrome and no content, so the panel goes full-screen
+  // (Lark/IM-style) and the resize/expand affordances disappear with it.
+  const isMobile = useIsMobile();
+
   // `@container`: the window is user-resizable from 360px to 90% of the
   // viewport, so the chat body's gutter (CHAT_GUTTER) has to key off the
   // window's own width, not the page behind it.
-  const containerClass = "absolute bottom-2 right-2 z-50 flex flex-col overflow-hidden rounded-xl bg-surface-raised shadow-[var(--floating-shadow)] ring-1 ring-surface-border @container";
+  const containerClass = cn(
+    "absolute z-50 flex flex-col overflow-hidden bg-surface-raised @container",
+    isMobile
+      ? "inset-x-0"
+      : "right-2 rounded-xl shadow-[var(--floating-shadow)] ring-1 ring-surface-border",
+  );
+  // Soft keyboards shrink only the *visual* viewport — the layout viewport
+  // (and this panel's bottom-anchored parent) keeps its full height, so
+  // without correction the panel's lower half, composer included, sits
+  // behind the keyboard while iOS pans the page and chops the panel's top
+  // instead. While the keyboard is up, pin the panel to the visual
+  // viewport: bottom glued to its bottom edge (occludedBottom tracks any
+  // pan), height/maxHeight bounded by the visible strip, so the composer
+  // rides the keyboard's top edge.
+  //
+  // Every branch writes the SAME style keys with explicit values: motion.div
+  // applies styles imperatively and never unsets a key that merely
+  // disappears from the style prop, so a conditional spread here would
+  // leave the keyboard geometry stuck on the DOM after the keyboard closes.
+  const keyboard = useVisualViewportKeyboard();
   const containerStyle: React.CSSProperties = {
     transformOrigin: "bottom right",
     pointerEvents: isOpen ? "auto" : "none",
+    ...(isMobile
+      ? {
+          // Full-screen panel anchored to the visible bottom edge;
+          // width/height live in the motion animate below.
+          top: "auto",
+          bottom: keyboard ? keyboard.occludedBottom : 0,
+          maxHeight: "none",
+        }
+      : {
+          // Floating card; only the anchor and the height cap live here.
+          top: "auto",
+          bottom: keyboard ? keyboard.occludedBottom + 8 : 8,
+          maxHeight: keyboard ? keyboard.viewportHeight - 16 : "none",
+        }),
   };
+
+  // Width/height are ALWAYS owned by motion, in both modes: useIsMobile
+  // resolves after the first client render, and a key that merely vanishes
+  // from `animate` keeps its last DOM value — a phone's first frame would
+  // otherwise leave the desktop card's inline width stuck on the
+  // full-screen panel. Mixed units (px <-> "100%") skip interpolation and
+  // jump, which is the behavior we want for keyboard snaps anyway.
+  const motionSize = isMobile
+    ? {
+        width: "100%",
+        height: keyboard ? keyboard.viewportHeight : "100%",
+      }
+    : { width: renderWidth, height: renderHeight };
 
   const contextItems = useChatContextItems(wsId);
   const queuedTasks = pendingTask?.queued_tasks ?? [];
@@ -755,12 +808,11 @@ export function ChatWindow() {
       ref={windowRef}
       className={containerClass}
       style={containerStyle}
-      initial={{ opacity: 0, scale: 0.95, width: renderWidth, height: renderHeight }}
+      initial={{ opacity: 0, scale: 0.95, ...motionSize }}
       animate={{
         opacity: isVisible ? 1 : 0,
         scale: isVisible ? 1 : 0.95,
-        width: renderWidth,
-        height: renderHeight,
+        ...motionSize,
       }}
       transition={{
         width: isDragging ? { duration: 0 } : { type: "spring", duration: 0.3, bounce: 0 },
@@ -769,7 +821,7 @@ export function ChatWindow() {
         scale: { type: "spring", duration: 0.2, bounce: 0 },
       }}
     >
-      <ChatResizeHandles onDragStart={startDrag} />
+      {!isMobile && <ChatResizeHandles onDragStart={startDrag} />}
       {/* Header — ⊕ new + session dropdown | window tools */}
       <div className="flex items-center justify-between border-b px-4 py-2.5 gap-2">
         <div className="flex items-center gap-1 min-w-0">
@@ -798,23 +850,25 @@ export function ChatWindow() {
           />
         </div>
         <div className="flex items-center gap-0.5 shrink-0">
-          <Tooltip>
-            <TooltipTrigger
-              render={
-                <Button
-                  variant="ghost"
-                  size="icon-sm"
-                  className="text-muted-foreground"
-                  onClick={toggleExpand}
-                />
-              }
-            >
-              {isExpanded || isAtMax ? <Minimize2 /> : <Maximize2 />}
-            </TooltipTrigger>
-            <TooltipContent side="top">
-              {isExpanded || isAtMax ? t(($) => $.window.restore_tooltip) : t(($) => $.window.expand_tooltip)}
-            </TooltipContent>
-          </Tooltip>
+          {!isMobile && (
+            <Tooltip>
+              <TooltipTrigger
+                render={
+                  <Button
+                    variant="ghost"
+                    size="icon-sm"
+                    className="text-muted-foreground"
+                    onClick={toggleExpand}
+                  />
+                }
+              >
+                {isExpanded || isAtMax ? <Minimize2 /> : <Maximize2 />}
+              </TooltipTrigger>
+              <TooltipContent side="top">
+                {isExpanded || isAtMax ? t(($) => $.window.restore_tooltip) : t(($) => $.window.expand_tooltip)}
+              </TooltipContent>
+            </Tooltip>
+          )}
           <Tooltip>
             <TooltipTrigger
               render={
@@ -1667,7 +1721,7 @@ function EmptyState({
   // presume the user already knows what chat is for.
   if (!hasSessions) {
     return (
-      <div className="flex flex-1 flex-col items-center justify-center gap-3 px-6 py-8">
+      <div className="flex min-h-0 flex-1 flex-col items-center justify-center-safe gap-3 overflow-y-auto px-6 py-8">
         <div className="text-center space-y-3">
           <h3 className="text-title-sm font-semibold">
             {t(($) => $.empty_state.first_time_title)}
@@ -1689,7 +1743,7 @@ function EmptyState({
 
   // Returning user: starter prompts are the fastest path back to action.
   return (
-    <div className="flex flex-1 flex-col items-center justify-center gap-5 px-6 py-8">
+    <div className="flex min-h-0 flex-1 flex-col items-center justify-center-safe gap-5 overflow-y-auto px-6 py-8">
       <div className="text-center space-y-1">
         <h3 className="text-title-sm font-semibold">
           {agentName

--- a/packages/views/chat/components/use-visual-viewport-keyboard.test.ts
+++ b/packages/views/chat/components/use-visual-viewport-keyboard.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { act, renderHook } from "@testing-library/react";
+import { useVisualViewportKeyboard } from "./use-visual-viewport-keyboard";
+
+class FakeVisualViewport extends EventTarget {
+  height: number;
+  offsetTop = 0;
+  scale = 1;
+  constructor(height: number) {
+    super();
+    this.height = height;
+  }
+  resize(next: Partial<Pick<FakeVisualViewport, "height" | "offsetTop" | "scale">>) {
+    Object.assign(this, next);
+    this.dispatchEvent(new Event("resize"));
+  }
+}
+
+describe("useVisualViewportKeyboard", () => {
+  let vv: FakeVisualViewport;
+
+  beforeEach(() => {
+    // iOS Safari shrinks window.innerHeight together with the visual
+    // viewport when the keyboard opens, so the hook must key off the stable
+    // documentElement.clientHeight. Model that worst case: innerHeight
+    // always mirrors the visual viewport height.
+    Object.defineProperty(document.documentElement, "clientHeight", {
+      configurable: true,
+      value: 800,
+    });
+    vv = new FakeVisualViewport(800);
+    Object.defineProperty(window, "innerHeight", {
+      configurable: true,
+      get: () => vv.height,
+    });
+    Object.defineProperty(window, "visualViewport", {
+      configurable: true,
+      value: vv,
+    });
+  });
+
+  afterEach(() => {
+    Reflect.deleteProperty(document.documentElement, "clientHeight");
+    Reflect.deleteProperty(window, "innerHeight");
+    Reflect.deleteProperty(window, "visualViewport");
+  });
+
+  it("reports null while the visual viewport matches the layout viewport", () => {
+    const { result } = renderHook(() => useVisualViewportKeyboard());
+    expect(result.current).toBeNull();
+  });
+
+  it("ignores small browser-chrome height changes below the keyboard threshold", () => {
+    const { result } = renderHook(() => useVisualViewportKeyboard());
+    act(() => vv.resize({ height: 740 }));
+    expect(result.current).toBeNull();
+  });
+
+  it("reports geometry when the keyboard shrinks the visual viewport", () => {
+    const { result } = renderHook(() => useVisualViewportKeyboard());
+    act(() => vv.resize({ height: 500 }));
+    expect(result.current).toEqual({ occludedBottom: 300, viewportHeight: 500 });
+  });
+
+  it("keeps viewportHeight while a pan moves the occluded bottom", () => {
+    const { result } = renderHook(() => useVisualViewportKeyboard());
+    act(() => vv.resize({ height: 500, offsetTop: 120 }));
+    expect(result.current).toEqual({ occludedBottom: 180, viewportHeight: 500 });
+  });
+
+  it("still reports the keyboard after a full iOS pan (occludedBottom 0)", () => {
+    const { result } = renderHook(() => useVisualViewportKeyboard());
+    act(() => vv.resize({ height: 500, offsetTop: 300 }));
+    expect(result.current).toEqual({ occludedBottom: 0, viewportHeight: 500 });
+  });
+
+  it("returns to null when the keyboard closes", () => {
+    const { result } = renderHook(() => useVisualViewportKeyboard());
+    act(() => vv.resize({ height: 500 }));
+    act(() => vv.resize({ height: 800, offsetTop: 0 }));
+    expect(result.current).toBeNull();
+  });
+
+  it("ignores pinch-zoom (scale != 1)", () => {
+    const { result } = renderHook(() => useVisualViewportKeyboard());
+    act(() => vv.resize({ height: 400, scale: 2 }));
+    expect(result.current).toBeNull();
+  });
+
+  it("supports browsers without visualViewport", () => {
+    Reflect.deleteProperty(window, "visualViewport");
+    const { result } = renderHook(() => useVisualViewportKeyboard());
+    expect(result.current).toBeNull();
+  });
+});

--- a/packages/views/chat/components/use-visual-viewport-keyboard.ts
+++ b/packages/views/chat/components/use-visual-viewport-keyboard.ts
@@ -1,0 +1,80 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+/** Geometry of the visual viewport while the mobile soft keyboard is up. */
+export interface VisualViewportKeyboard {
+  /**
+   * Distance (px) from the LAYOUT viewport's bottom edge up to the visual
+   * viewport's bottom edge. A bottom-anchored overlay offset by this much
+   * sits exactly on the visible bottom edge, wherever the browser has
+   * panned the page.
+   */
+  occludedBottom: number;
+  /** Visible height (px) — the tallest an overlay can be and stay on screen. */
+  viewportHeight: number;
+}
+
+/**
+ * iOS Safari's chrome expanding/collapsing also shrinks the visual viewport
+ * by a few tens of px; only gaps at least this tall are treated as a
+ * keyboard. Every mobile keyboard is well above this.
+ */
+const KEYBOARD_MIN_PX = 100;
+
+/**
+ * Reports visual-viewport geometry while the soft keyboard is open, null
+ * otherwise (desktop, keyboard closed, pinch-zoomed, or no API).
+ *
+ * Mobile browsers do not shrink the layout viewport when the keyboard opens —
+ * they shrink the *visual* viewport and, on iOS, pan it to keep the caret
+ * visible. A bottom-anchored overlay therefore needs BOTH numbers: the pan
+ * makes "distance to the visible bottom" differ from the keyboard's height,
+ * and the shrunken height bounds how tall the overlay may stay.
+ *
+ * The layout height baseline must be documentElement.clientHeight, not
+ * window.innerHeight: iOS Safari shrinks innerHeight together with the
+ * visual viewport when the keyboard opens (observed 547 -> 385 on iOS
+ * 17.5), which would make an innerHeight-based keyboard measure read near
+ * zero exactly when the keyboard is up.
+ */
+export function useVisualViewportKeyboard(): VisualViewportKeyboard | null {
+  const [keyboard, setKeyboard] = useState<VisualViewportKeyboard | null>(null);
+
+  useEffect(() => {
+    const vv = window.visualViewport;
+    if (!vv) return;
+
+    const update = () => {
+      const zoomed = Math.abs(vv.scale - 1) > 0.01;
+      const layoutHeight = document.documentElement.clientHeight;
+      const keyboardHeight = layoutHeight - vv.height;
+      const next: VisualViewportKeyboard | null =
+        zoomed || keyboardHeight < KEYBOARD_MIN_PX
+          ? null
+          : {
+              occludedBottom: Math.max(
+                0,
+                Math.round(layoutHeight - vv.height - vv.offsetTop),
+              ),
+              viewportHeight: Math.round(vv.height),
+            };
+      setKeyboard((prev) =>
+        prev?.occludedBottom === next?.occludedBottom &&
+        prev?.viewportHeight === next?.viewportHeight
+          ? prev
+          : next,
+      );
+    };
+
+    update();
+    vv.addEventListener("resize", update);
+    vv.addEventListener("scroll", update);
+    return () => {
+      vv.removeEventListener("resize", update);
+      vv.removeEventListener("scroll", update);
+    };
+  }, []);
+
+  return keyboard;
+}

--- a/packages/views/issues/components/comment-card.tsx
+++ b/packages/views/issues/components/comment-card.tsx
@@ -551,7 +551,7 @@ function CommentRow({
           highlight state while it occludes the body scrolling underneath. */}
       <StickyHeaderShell
         highlighted={isHighlighted}
-        className="flex items-center gap-2.5 px-4 pt-1 pb-1.5"
+        className="flex items-center gap-2.5 px-4 max-md:px-3 pt-1 pb-1.5"
       >
         <ActorAvatar actorType={entry.actor_type} actorId={entry.actor_id} size="md" enableHoverCard showStatusDot />
         <span className="cursor-pointer text-body font-medium">
@@ -641,7 +641,7 @@ function CommentRow({
       {edit.editing ? (
         <div
           {...edit.dropZoneProps}
-          className="relative pl-12 pr-4 pt-1"
+          className="relative pl-12 pr-4 max-md:pl-3 max-md:pr-3 pt-1"
           onKeyDown={(e) => { if (e.key === "Escape") edit.cancelEdit(); }}
         >
           <div className="text-body leading-relaxed">
@@ -709,15 +709,15 @@ function CommentRow({
         </div>
       ) : (
         <>
-          <div className="pl-12 pr-4 pt-1 text-body leading-relaxed text-foreground">
+          <div className="pl-12 pr-4 max-md:pl-3 max-md:pr-3 pt-1 text-body leading-relaxed text-foreground">
             <ReadonlyContent content={entry.content ?? ""} attachments={entry.attachments} />
           </div>
-          <AttachmentList attachments={entry.attachments} content={entry.content} className="mt-1.5 pl-12 pr-4" />
+          <AttachmentList attachments={entry.attachments} content={entry.content} className="mt-1.5 pl-12 pr-4 max-md:pl-3 max-md:pr-3" />
           {retryableAgentFailureComment(entry) && (
             <TaskCommentRetryButton
               issueId={issueId}
               taskId={entry.source_task_id}
-              className="mt-2 pl-12 pr-4"
+              className="mt-2 pl-12 pr-4 max-md:pl-3 max-md:pr-3"
             />
           )}
           <ReactionBar
@@ -725,7 +725,7 @@ function CommentRow({
             currentUserId={currentUserId}
             onToggle={(emoji) => onToggleReaction(entry.id, emoji)}
             getActorName={getActorName}
-            className="mt-1.5 pl-12 pr-4"
+            className="mt-1.5 pl-12 pr-4 max-md:pl-3 max-md:pr-3"
           />
         </>
       )}
@@ -823,7 +823,7 @@ function CommentCardImpl({
         <button
           type="button"
           onClick={onCollapseResolved}
-          className="sticky top-0 z-20 flex w-full items-center gap-2.5 border-b border-border/50 bg-muted px-4 py-2.5 text-left text-body text-muted-foreground transition-colors cursor-pointer hover:bg-accent hover:text-accent-foreground"
+          className="sticky top-0 z-20 flex w-full items-center gap-2.5 border-b border-border/50 bg-muted px-4 max-md:px-3 py-2.5 text-left text-body text-muted-foreground transition-colors cursor-pointer hover:bg-accent hover:text-accent-foreground"
           aria-label={t(($) => $.comment.resolve.collapse)}
         >
           <ListChevronsDownUp className="h-3.5 w-3.5" />
@@ -841,7 +841,7 @@ function CommentCardImpl({
           <StickyHeaderShell
             sticky={stickyHeader}
             highlighted={isHighlighted}
-            className="px-4 py-3"
+            className="px-4 max-md:px-3 py-3"
           >
             <div className="flex items-center gap-2.5">
               <button
@@ -953,11 +953,11 @@ function CommentCardImpl({
             probes computed styles to detect animations, forcing a style
             recalculation across long issue-detail documents. */}
         {open && (
-          <div id={`comment-body-${entry.id}`} className="px-4 pt-1 pb-3">
+          <div id={`comment-body-${entry.id}`} className="px-4 max-md:px-3 pt-1 pb-3">
             {edit.editing ? (
               <div
                 {...edit.dropZoneProps}
-                className="relative pl-10"
+                className="relative pl-10 max-md:pl-0"
                 onKeyDown={(e) => { if (e.key === "Escape") edit.cancelEdit(); }}
               >
                 <div className="text-body leading-relaxed">
@@ -1025,15 +1025,15 @@ function CommentCardImpl({
               </div>
             ) : (
               <>
-                <div className="pl-10 text-body leading-relaxed text-foreground">
+                <div className="pl-10 max-md:pl-0 text-body leading-relaxed text-foreground">
                   <ReadonlyContent content={entry.content ?? ""} attachments={entry.attachments} />
                 </div>
-                <AttachmentList attachments={entry.attachments} content={entry.content} className="mt-1.5 pl-10" />
+                <AttachmentList attachments={entry.attachments} content={entry.content} className="mt-1.5 pl-10 max-md:pl-0" />
                 {retryableAgentFailureComment(entry) && (
                   <TaskCommentRetryButton
                     issueId={issueId}
                     taskId={entry.source_task_id}
-                    className="mt-2 pl-10"
+                    className="mt-2 pl-10 max-md:pl-0"
                   />
                 )}
                 <ReactionBar
@@ -1041,7 +1041,7 @@ function CommentCardImpl({
                   currentUserId={currentUserId}
                   onToggle={(emoji) => onToggleReaction(entry.id, emoji)}
                   getActorName={getActorName}
-                  className="mt-1.5 pl-10"
+                  className="mt-1.5 pl-10 max-md:pl-0"
                 />
               </>
             )}
@@ -1058,7 +1058,7 @@ function CommentCardImpl({
             <>
               {/* reply-mode folded: other replies behind a bar, resolution pinned below */}
               {foldedReplies.length > 0 && (
-                <div className="border-t border-border/50 px-4 py-2.5">
+                <div className="border-t border-border/50 px-4 max-md:px-3 py-2.5">
                   <CommentsFoldBar
                     replies={foldedReplies}
                     onExpand={() => onResolvedExpandChange?.(entry.id, true)}
@@ -1095,7 +1095,7 @@ function CommentCardImpl({
                 <button
                   type="button"
                   onClick={() => onResolvedExpandChange(entry.id, false)}
-                  className="sticky top-0 z-20 flex w-full items-center gap-2.5 border-t border-border/50 bg-muted px-4 py-2.5 text-left text-body text-muted-foreground transition-colors cursor-pointer hover:bg-accent hover:text-accent-foreground"
+                  className="sticky top-0 z-20 flex w-full items-center gap-2.5 border-t border-border/50 bg-muted px-4 max-md:px-3 py-2.5 text-left text-body text-muted-foreground transition-colors cursor-pointer hover:bg-accent hover:text-accent-foreground"
                   aria-label={t(($) => $.comment.resolve.collapse)}
                 >
                   <ListChevronsDownUp className="h-3.5 w-3.5" />
@@ -1128,7 +1128,7 @@ function CommentCardImpl({
               ))}
 
               {/* Reply input */}
-              <div className="border-t border-border/50 px-4 py-2.5">
+              <div className="border-t border-border/50 px-4 max-md:px-3 py-2.5">
                 <ReplyInput
                   issueId={issueId}
                   parentId={entry.id}

--- a/packages/views/issues/components/issue-detail.tsx
+++ b/packages/views/issues/components/issue-detail.tsx
@@ -507,7 +507,7 @@ function ActivityBlock({
   if (!expanded) {
     const count = entries.length;
     return (
-      <div className="pb-3 px-4">
+      <div className="pb-3 px-4 max-md:px-3">
         <button
           type="button"
           onClick={onToggle}
@@ -533,7 +533,7 @@ function ActivityBlock({
   // fold the whole block back to a single count line.
   const showHeader = hiddenOlderCount === 0;
   return (
-    <div className="pb-3 px-4 flex flex-col gap-3">
+    <div className="pb-3 px-4 max-md:px-3 flex flex-col gap-3">
       {showHeader && (
         <button
           type="button"
@@ -1003,7 +1003,7 @@ export function IssueDetailSkeleton({ leading }: { leading?: ReactNode } = {}) {
         <div className="flex-1 overflow-y-auto [scrollbar-gutter:stable_both-edges]">
           {/* Gutters match the loaded column exactly (see its comment), so the
               skeleton doesn't reflow sideways when real content mounts. */}
-          <div className="mx-auto w-full max-w-4xl px-4 py-6 space-y-6 md:px-8 md:py-8">
+          <div className="mx-auto w-full max-w-4xl px-3 py-6 space-y-6 md:px-8 md:py-8">
             <Skeleton className="h-8 w-3/4" />
             <div className="space-y-2">
               <Skeleton className="h-4 w-full" />
@@ -2528,12 +2528,12 @@ export function IssueDetail({ issueId, onDelete, onDone, defaultSidebarOpen = tr
           className="relative flex-1 overflow-y-auto [scrollbar-gutter:stable_both-edges]"
         >
         {/* Gutters: 32px is a comfortable reading margin on a desktop column
-            but eats 16% of a 393px phone, so below `md` they drop to 16px.
+            but eats 16% of a 393px phone, so below `md` they drop to 12px.
             `max-md:pb-chat-launcher` reserves the launcher's corner at the end
             of the scroll: below `md` the composer is not pinned (see
             `useStickyComposer`), so it lands here — right where the launcher
             floats — once the reader scrolls to the bottom. */}
-        <div className="mx-auto w-full max-w-4xl px-4 py-6 max-md:pb-chat-launcher md:px-8 md:py-8">
+        <div className="mx-auto w-full max-w-4xl px-3 py-6 max-md:pb-chat-launcher md:px-8 md:py-8">
           {titleLazy.active && (
             <div className={titleLazy.ready ? undefined : "hidden"}>
               <TitleEditor


### PR DESCRIPTION
## Summary

Two mobile-web (<768px) adaptations driven by real-device feedback (Tim's Discord report + iPhone SE simulator verification):

### Issue comment rails
- Card interior horizontal padding 16 -> 12px across every band (headers, body, fold bars, footers) so the inner rail moves as one.
- The 40px avatar hanging indent on root comment bodies is removed on mobile; replies drop their `pl-12` the same way — body text goes full-width under the header, GitHub-mobile-style.
- Page container and ActivityBlock gutters tighten 16 -> 12px.
- Net: comment text width on iPhone SE grows 269 -> 325px (+21%). Desktop is untouched.

### Full-screen keyboard-aware chat
- On small screens the floating chat card becomes a full-screen panel (Lark/IM-style); resize handles and the expand control are not rendered there. Desktop keeps the floating card unchanged.
- New `useVisualViewportKeyboard` hook reports visual-viewport geometry while the soft keyboard is up. The panel pins its bottom to the visible edge (`occludedBottom` tracks iOS pans) and bounds its height to the visible strip, so the composer rides the keyboard's top edge instead of hiding behind it.
- Two behaviors measured on iOS 17.5 and baked into the implementation:
  - iOS Safari shrinks `window.innerHeight` together with the visual viewport when the keyboard opens, so the layout baseline is `documentElement.clientHeight`.
  - `motion.div` never unsets style/animate keys that vanish between renders; both keyboard branches therefore write the same style keys, and width/height stay motion-owned in both form factors.
- EmptyState gets `min-h-0` + scroll + safe centering so the composer can never be pushed out of the panel at small heights.

## Verification

- `useVisualViewportKeyboard` unit tests (8) model the iOS innerHeight behavior; chat component suite 167/167 green; `pnpm typecheck` clean in the touched packages.
- Manually verified in the iPhone SE (iOS 17.5) simulator: open full-screen -> keyboard up (panel snaps above keyboard, header visible) -> keyboard down (panel restores full-screen) -> minimize back to FAB.

🤖 Generated with [Claude Code](https://claude.com/claude-code)