### PR TITLE
MUL-5802: pair failed OpenCode tool results

### DIFF
--- a/server/pkg/agent/deveco.go
+++ b/server/pkg/agent/deveco.go
@@ -377,8 +377,8 @@ func (b *devecoBackend) handleTextEvent(event devecoEvent, ch chan<- Message, ou
 }
 
 // handleToolUseEvent processes "tool_use" events. A single tool_use event
-// contains both the call and result in part.state when the tool has completed
-// (state.status == "completed").
+// contains both the call and result in part.state when the tool reaches a
+// terminal state (state.status is "completed" or "error").
 func (b *devecoBackend) handleToolUseEvent(event devecoEvent, ch chan<- Message) {
 	var input map[string]any
 	if event.Part.State != nil && event.Part.State.Input != nil {
@@ -392,8 +392,15 @@ func (b *devecoBackend) handleToolUseEvent(event devecoEvent, ch chan<- Message)
 		Input:  input,
 	})
 
-	if event.Part.State != nil && event.Part.State.Status == "completed" {
-		outputStr := extractDevecoToolOutput(event.Part.State.Output)
+	// Pair every terminal tool-use with a tool-result. The daemon uses this
+	// pair to track in-flight tools, so dropping error results would leave its
+	// counter permanently elevated and suppress the normal idle watchdog.
+	state := event.Part.State
+	if state != nil && (state.Status == "completed" || state.Status == "error") {
+		outputStr := extractDevecoToolOutput(state.Output)
+		if state.Status == "error" && state.Error != "" {
+			outputStr = state.Error
+		}
 		trySend(ch, Message{
 			Type:   MessageToolResult,
 			Tool:   event.Part.Tool,
@@ -488,6 +495,7 @@ type devecoToolState struct {
 	Status string          `json:"status,omitempty"`
 	Input  json.RawMessage `json:"input,omitempty"`
 	Output any             `json:"output,omitempty"`
+	Error  string          `json:"error,omitempty"`
 }
 
 // devecoError represents an error event from deveco.

--- a/server/pkg/agent/deveco_test.go
+++ b/server/pkg/agent/deveco_test.go
@@ -208,6 +208,46 @@ func TestDevecoProcessEventsHappyPath(t *testing.T) {
 	}
 }
 
+func TestDevecoProcessEventsToolErrorEmitsResult(t *testing.T) {
+	t.Parallel()
+
+	b := &devecoBackend{cfg: Config{Logger: slog.Default()}}
+	ch := make(chan Message, 256)
+
+	lines := strings.Join([]string{
+		`{"type":"step_start","timestamp":1000,"sessionID":"ses_toolerr","part":{"type":"step-start"}}`,
+		`{"type":"tool_use","timestamp":1001,"sessionID":"ses_toolerr","part":{"type":"tool","tool":"read","callID":"functions.read:1","state":{"status":"error","input":{"filePath":"/missing.md"},"error":"File not found: /missing.md"}}}`,
+		`{"type":"step_finish","timestamp":1002,"sessionID":"ses_toolerr","part":{"type":"step-finish"}}`,
+	}, "\n")
+
+	result := b.processEvents(strings.NewReader(lines), ch)
+	if result.status != "completed" {
+		t.Errorf("status: got %q, want %q", result.status, "completed")
+	}
+
+	close(ch)
+	var toolUses, toolResults int
+	var failedToolResult Message
+	for msg := range ch {
+		switch msg.Type {
+		case MessageToolUse:
+			toolUses++
+		case MessageToolResult:
+			toolResults++
+			failedToolResult = msg
+		}
+	}
+	if toolUses != 1 || toolResults != 1 {
+		t.Fatalf("tool messages are not paired: tool_use=%d tool_result=%d", toolUses, toolResults)
+	}
+	if failedToolResult.CallID != "functions.read:1" {
+		t.Errorf("failed tool callID: got %q", failedToolResult.CallID)
+	}
+	if failedToolResult.Output != "File not found: /missing.md" {
+		t.Errorf("failed tool output: got %q", failedToolResult.Output)
+	}
+}
+
 func TestDevecoProcessEventsErrorCausesFailedStatus(t *testing.T) {
 	t.Parallel()
 

--- a/server/pkg/agent/opencode.go
+++ b/server/pkg/agent/opencode.go
@@ -399,7 +399,7 @@ func (b *opencodeBackend) handleTextEvent(event opencodeEvent, ch chan<- Message
 
 // handleToolUseEvent processes "tool_use" events from opencode. A single
 // tool_use event contains both the call and result in part.state when the
-// tool has completed (state.status == "completed").
+// tool reaches a terminal state (state.status is "completed" or "error").
 func (b *opencodeBackend) handleToolUseEvent(event opencodeEvent, ch chan<- Message) {
 	// Extract input from state.input (the tool invocation parameters).
 	var input map[string]any
@@ -415,9 +415,15 @@ func (b *opencodeBackend) handleToolUseEvent(event opencodeEvent, ch chan<- Mess
 		Input:  input,
 	})
 
-	// If the tool has completed, also emit a tool-result message.
-	if event.Part.State != nil && event.Part.State.Status == "completed" {
-		outputStr := extractToolOutput(event.Part.State.Output)
+	// Pair every terminal tool-use with a tool-result. The daemon uses this
+	// pair to track in-flight tools, so dropping error results would leave its
+	// counter permanently elevated and suppress the normal idle watchdog.
+	state := event.Part.State
+	if state != nil && (state.Status == "completed" || state.Status == "error") {
+		outputStr := extractToolOutput(state.Output)
+		if state.Status == "error" && state.Error != "" {
+			outputStr = state.Error
+		}
 		trySend(ch, Message{
 			Type:   MessageToolResult,
 			Tool:   event.Part.Tool,
@@ -578,6 +584,7 @@ type opencodeToolState struct {
 	Status string          `json:"status,omitempty"`
 	Input  json.RawMessage `json:"input,omitempty"`
 	Output any             `json:"output,omitempty"`
+	Error  string          `json:"error,omitempty"`
 }
 
 // opencodeError represents an error event from opencode.

--- a/server/pkg/agent/opencode_test.go
+++ b/server/pkg/agent/opencode_test.go
@@ -982,6 +982,33 @@ func TestOpencodeProcessEventsToolErrorThenCleanFinish(t *testing.T) {
 	}
 
 	close(ch)
+	var msgs []Message
+	for msg := range ch {
+		msgs = append(msgs, msg)
+	}
+
+	var toolUses, toolResults int
+	var failedToolResult *Message
+	for i := range msgs {
+		switch msgs[i].Type {
+		case MessageToolUse:
+			toolUses++
+		case MessageToolResult:
+			toolResults++
+			if msgs[i].CallID == "functions.read:1" {
+				failedToolResult = &msgs[i]
+			}
+		}
+	}
+	if toolUses != 2 || toolResults != 2 {
+		t.Fatalf("tool messages are not paired: tool_use=%d tool_result=%d (%+v)", toolUses, toolResults, msgs)
+	}
+	if failedToolResult == nil {
+		t.Fatal("missing tool_result for failed read tool")
+	}
+	if failedToolResult.Output != "File not found: /nonexistent-path-xyz/also-missing.md" {
+		t.Errorf("failed tool output: got %q", failedToolResult.Output)
+	}
 }
 
 // ── Windows native-binary resolution tests ──


### PR DESCRIPTION
## Summary

- emit a matching `tool_result` when OpenCode reports a terminal tool error
- preserve `state.error` as the failed tool's result output
- apply the same fix to the DevEco fork and cover both wire formats with regressions

This keeps the daemon's in-flight tool counter balanced so a recovered tool error cannot suppress the normal idle watchdog for the rest of the run.

## Verification

- `go test ./pkg/agent -run 'Test(Opencode|Deveco)' -count=1`
- `go test ./internal/daemon -run 'TestExecuteAndDrain_IdleWatchdog_(FiresOnStuckInFlightTool|FiresAfterToolResultIfBackendStaysSilent|PerRunOverrideStillUsesToolWindow)$' -count=1`
- `go vet ./pkg/agent`
- `git diff --check`

Fixes #6480
Closes MUL-5802
