### PR TITLE
docs(dingtalk): note community-maintained support status

### DIFF
--- a/apps/docs/content/docs/dingtalk-bot-integration.ja.mdx
+++ b/apps/docs/content/docs/dingtalk-bot-integration.ja.mdx
@@ -7,6 +7,8 @@ import { Callout } from "fumadocs-ui/components/callout";
 
 任意の[エージェント](/agents)を DingTalk Bot に接続すれば、チームは DingTalk の中から直接それを使えます——Bot に DM したり、グループで @ メンションしたり、スクリーンショットを送ったり、`/issue` と入力してアプリを開かずに [Multica イシュー](/issues)を起票したりできます。
 
+DingTalk 連携はコミュニティによってメンテナンスされています。毎リリースに同梱されますが、公式のサポート SLA は付きません。問題があれば [GitHub issues](https://github.com/multica-ai/multica/issues) に報告してください。
+
 DingTalk は**自分のアプリを持ち込む（BYO: bring-your-own-app）**モデルを採用しています。ワークスペースの admin が DingTalk アプリを作成し、それに Stream モードのロボットを追加して、その認証情報を Multica に貼り付けます。エージェントごとに**専用の** DingTalk アプリを持つため、同じ組織内で複数のエージェントがそれぞれ別個に @ メンションできる異なる Bot を持てます。（これは紐づけがスキャンしてインストールするフローである [Lark](/lark-bot-integration) とは異なります。）
 
 セットアップ全体は以下のとおりで、所要時間は約 5 分です。最終的に、Multica に貼り付ける 2 つの認証情報が得られます。

--- a/apps/docs/content/docs/dingtalk-bot-integration.ko.mdx
+++ b/apps/docs/content/docs/dingtalk-bot-integration.ko.mdx
@@ -7,6 +7,8 @@ import { Callout } from "fumadocs-ui/components/callout";
 
 아무 [에이전트](/agents)나 DingTalk 봇에 연결하면, 팀이 DingTalk 안에서 바로 그 에이전트와 함께 일할 수 있습니다 — 봇에게 DM을 보내거나, 그룹에서 `@`로 멘션하거나, 스크린샷을 보내거나, `/issue`를 입력해 앱을 열지 않고도 [Multica 이슈](/issues)를 생성하세요.
 
+DingTalk 연동은 커뮤니티가 유지관리합니다. 매 릴리스에 포함되지만 공식 지원 SLA는 제공되지 않습니다. 문제가 있으면 [GitHub issues](https://github.com/multica-ai/multica/issues)에 보고해 주세요.
+
 DingTalk은 **자체 앱 사용(BYO)** 모델을 따릅니다: 워크스페이스 admin이 DingTalk 앱을 만들고, 거기에 Stream 모드 로봇을 추가한 다음, 그 자격 증명을 Multica에 붙여넣습니다. 각 에이전트가 **자체** DingTalk 앱을 갖습니다 — 그래서 하나의 조직 안에서 여러 에이전트가 각각 별개로 `@`로 멘션할 수 있는 봇을 가질 수 있습니다. (바인딩이 스캔하여 설치하는 방식인 [Lark](/lark-bot-integration)와는 다릅니다.)
 
 전체 설정은 아래에 있으며 약 5분이 걸립니다. 마지막에는 Multica에 붙여넣을 두 개의 자격 증명을 얻게 됩니다:

--- a/apps/docs/content/docs/dingtalk-bot-integration.mdx
+++ b/apps/docs/content/docs/dingtalk-bot-integration.mdx
@@ -7,6 +7,8 @@ import { Callout } from "fumadocs-ui/components/callout";
 
 Connect any [agent](/agents) to a DingTalk bot and your team can work with it from inside DingTalk — DM the bot, @-mention it in a group, send it screenshots, or type `/issue` to file a [Multica issue](/issues) without opening the app.
 
+DingTalk support is community-maintained: it ships in every release, but it carries no official support SLA. Report problems in [GitHub issues](https://github.com/multica-ai/multica/issues).
+
 DingTalk uses a **bring-your-own-app (BYO)** model: a workspace admin creates a DingTalk app, adds a Stream-mode robot to it, and pastes its credentials into Multica. Each agent gets **its own** DingTalk app — so several agents can each have a distinct, separately @-mentionable bot in the same organization. (This differs from [Lark](/lark-bot-integration), where binding is a scan-to-install flow.)
 
 The whole setup is below and takes about five minutes. You'll end up with two credentials to paste into Multica:

--- a/apps/docs/content/docs/dingtalk-bot-integration.zh.mdx
+++ b/apps/docs/content/docs/dingtalk-bot-integration.zh.mdx
@@ -7,6 +7,8 @@ import { Callout } from "fumadocs-ui/components/callout";
 
 把任意[智能体](/agents)接入一个钉钉 Bot，团队就能在钉钉里直接使用它——私聊 Bot、在群里 @ 它、发截图给它，或者输入 `/issue` 直接创建一个 [Multica issue](/issues)，不用打开应用。
 
+钉钉集成由社区维护：每个版本都会随包发布，但不附带官方支持 SLA。遇到问题请提到 [GitHub issues](https://github.com/multica-ai/multica/issues)。
+
 钉钉走的是**自带应用（bring-your-own-app，BYO）**模式：workspace 管理员创建一个钉钉 app，给它加一个 Stream 模式的机器人，再把它的凭证粘贴进 Multica。每个智能体都有**它自己的**钉钉 app——所以多个智能体可以在同一个组织里各自拥有一个独立、可单独 @ 的 Bot。（这一点和 [Lark](/lark-bot-integration) 不同，Lark 的绑定是扫码安装流程。）
 
 整个设置流程在下面，大约五分钟。最后你会得到两个凭证粘贴进 Multica：

--- a/server/internal/integrations/dingtalk/config.go
+++ b/server/internal/integrations/dingtalk/config.go
@@ -12,6 +12,17 @@
 // static bot token, DingTalk outbound needs a short-lived access_token minted
 // from AppKey/AppSecret, so the outbound path caches it like Feishu's
 // tenant_access_token (token.go).
+//
+// Maintenance: this package is COMMUNITY-MAINTAINED. @yyclaw contributed it and
+// is its code owner — the first stop for DingTalk-specific bugs and behavior
+// questions, on a best-effort volunteer basis. The Multica team keeps this
+// package compiling and its tests green through shared-layer refactors, but
+// does not use DingTalk and cannot verify behavior against the real platform;
+// that part depends on the code owner. If the integration breaks in a way that
+// cannot be fixed without real DingTalk access and no fix lands for a few
+// releases, it may be deprecated rather than left quietly broken. Changing the
+// shared channel engine? Keep this adapter building — and loop in the code
+// owner for anything that changes DingTalk-visible behavior.
 package dingtalk
 
 import (


### PR DESCRIPTION
## What does this PR do?

Follow-up to #4829. We told @yyclaw the DingTalk integration would be documented as community-maintained. This makes good on that, putting each piece of information where its audience actually is.

**Docs** (`apps/docs/content/docs/dingtalk-bot-integration.{mdx,zh,ja,ko}`) — one line under the intro:

> DingTalk support is community-maintained: it ships in every release, but it carries no official support SLA. Report problems in [GitHub issues](...).

That's the part a docs reader needs — it changes whether you build a team workflow on this integration. The maintainer's name is deliberately *not* here: someone setting up a bot doesn't need to know who wrote the adapter, and a full ownership notice at the top of a setup guide is noise for the people reading it.

**Code** (`server/internal/integrations/dingtalk`) — the full contract in the package comment: who the code owner is, what the team does and doesn't commit to, the deprecation rule, and a note to loop in the code owner for DingTalk-visible behavior changes. That's aimed at whoever is refactoring the shared channel engine, which is exactly who needs it.

Attribution for the contributor lives where it's durable anyway: commit authorship, the merged PR, and the code-owner line in the package.

## Not included

A `.github/CODEOWNERS` entry. GitHub only honors CODEOWNERS for accounts with write access, so an entry for an outside contributor generates no review requests — a comment that looks like a mechanism. Making it real means granting repo access (triage suffices), which is a separate decision.

## Type of Change

- [x] Documentation update

## How to Test

1. `pnpm --filter docs dev`, open `/dingtalk-bot-integration` plus the `zh` / `ja` / `ko` variants; the line reads as normal prose under the intro.
2. `go doc ./server/internal/integrations/dingtalk` shows the maintenance note.

## Verification

- `go build ./...`, `go vet ./internal/integrations/dingtalk`, `gofmt -l` clean
- `go test ./internal/integrations/dingtalk` passes
- Callout tags still balanced in all four locale files (the component is still used elsewhere on the page, so the import stays live)

No behavior change; docs and comments only.