### PR TITLE
refactor(daemon): make the cached brief role-independent — squad briefing rides the per-turn channel (MUL-5811)

### DIFF
--- a/server/internal/daemon/daemon.go
+++ b/server/internal/daemon/daemon.go
@@ -5640,7 +5640,7 @@ func (d *Daemon) runTask(ctx context.Context, task Task, provider string, slot i
 		PriorSessionResumeUnavailable:    task.PriorSessionResumeUnavailable,
 		AgentID:                          agentID,
 		AgentName:                        agentName,
-		AgentInstructions:                instructions,
+		AgentInstructions:                stableAgentInstructions(instructions),
 		AgentSkills:                      convertSkillsForEnv(skills),
 		DisabledRuntimeSkills:            convertDisabledRuntimeSkillsForEnv(task.Agent, task.RuntimeID, provider),
 		Repos:                            convertReposForEnv(task.Repos),
@@ -7624,4 +7624,15 @@ func defaultArgsForProvider(cfg Config, provider string) []string {
 		return nil
 	}
 	return append([]string(nil), args...)
+}
+
+// stableAgentInstructions returns the role-independent half of the agent's
+// instructions for the cached brief. The server appends the per-task squad
+// leader briefing to Instructions on leader tasks; passing it through would
+// flip the brief's bytes between leader and worker turns of the same agent
+// (MUL-5442 #6493 review). The briefing itself rides the per-turn prompt
+// (BuildPrompt).
+func stableAgentInstructions(instructions string) string {
+	stable, _ := execenv.SplitSquadBriefing(instructions)
+	return stable
 }

--- a/server/internal/daemon/daemon_test.go
+++ b/server/internal/daemon/daemon_test.go
@@ -1169,9 +1169,17 @@ func TestBuildPromptSquadLeaderNoActionProhibition(t *testing.T) {
 	}, "claude")
 
 	for _, want := range []string{
-		"Squad leader no_action rule",
+		"Squad leader rules for this turn",
+		"no_action rule:",
 		"DO NOT post any comment",
 		"multica squad activity",
+		// Relocated from the brief (MUL-5442 #6493 review): leadership is a
+		// per-task role, so the status-ownership grant and the leader-only
+		// CLI surface ride this per-turn block now.
+		"Own the parent issue status",
+		"without waiting to be asked",
+		"guest leader",
+		"multica squad member set-role",
 	} {
 		if !strings.Contains(prompt, want) {
 			t.Fatalf("squad leader prompt missing %q\n---\n%s", want, prompt)
@@ -1191,7 +1199,7 @@ func TestBuildPromptSquadLeaderNoActionProhibition(t *testing.T) {
 		},
 	}, "claude")
 
-	if strings.Contains(nonLeaderPrompt, "Squad leader no_action rule") {
+	if strings.Contains(nonLeaderPrompt, "no_action rule:") {
 		t.Fatalf("non-squad-leader prompt should NOT contain squad leader rule\n---\n%s", nonLeaderPrompt)
 	}
 }
@@ -5024,6 +5032,8 @@ func TestFreshSessionMayHelp(t *testing.T) {
 	const hermesAuth = "hermes provider error: \"Could not resolve authentication method. Expected either api_key or auth_token to be set. Or for one of the X-Api-Key or Authorization headers to be explicitly omitted\""
 	if !freshSessionMayHelp(hermesAuth) {
 		t.Fatalf("freshSessionMayHelp(auth-resolution error) = false; a fresh session cures this failure, it must report session-fixable")
+	}
+}
 
 // TestBuildPromptSquadLeaderReplyCommandCarvesOutNoAction renders the COMPLETE
 // leader prompt and pins the exception's scope relation (MUL-5442 #6493
@@ -5046,7 +5056,10 @@ func TestBuildPromptSquadLeaderReplyCommandCarvesOutNoAction(t *testing.T) {
 		},
 	}, "claude")
 
-	if !strings.Contains(prompt, "Squad leader no_action rule") {
+	if !strings.Contains(prompt, "Squad leader rules for this turn") {
+		t.Fatalf("leader prompt missing the leader rules block\n---\n%s", prompt)
+	}
+	if !strings.Contains(prompt, "no_action rule:") {
 		t.Fatalf("leader prompt missing the no_action rule\n---\n%s", prompt)
 	}
 	if !strings.Contains(prompt, "Unless your outcome is `no_action`, post your reply as a comment") {
@@ -5054,5 +5067,90 @@ func TestBuildPromptSquadLeaderReplyCommandCarvesOutNoAction(t *testing.T) {
 	}
 	if strings.Contains(prompt, "Post your reply as a comment") {
 		t.Fatalf("leader prompt still carries the unconditional reply imperative\n---\n%s", prompt)
+	}
+}
+
+// TestBuildPromptSquadLeaderAssignmentKeepsParentInProgress carries the
+// dispatch-status contract that used to live in the brief (MUL-5442 #6493
+// review): leadership is a per-task role, so the keep-parent-in_progress
+// rule rides the leader's assignment per-turn block. The brief tells
+// everyone "When done, run in_review"; for a dispatch turn that is exactly
+// wrong, so the override must appear in every leader assignment prompt —
+// and never in an ordinary agent's.
+func TestBuildPromptSquadLeaderAssignmentKeepsParentInProgress(t *testing.T) {
+	t.Parallel()
+
+	leaderTask := Task{
+		IssueID: "issue-1",
+		Agent: &AgentData{
+			Name:         "Lead",
+			Instructions: "Some instructions\n\n## Squad Operating Protocol\n\nYou are the LEADER...",
+		},
+	}
+	prompt := BuildPrompt(leaderTask, "claude")
+	for _, want := range []string{
+		"Squad leader rules for this turn",
+		"leave the parent issue `in_progress`",
+		"do NOT move it to `in_review` or `done` on this turn",
+		"only then, if the overall goal is met, move the parent to `in_review`",
+		"multica squad activity",
+	} {
+		if !strings.Contains(prompt, want) {
+			t.Fatalf("leader assignment prompt missing %q\n---\n%s", want, prompt)
+		}
+	}
+
+	ordinary := BuildPrompt(Task{
+		IssueID: "issue-1",
+		Agent:   &AgentData{Name: "Reg", Instructions: "You are a regular agent."},
+	}, "claude")
+	if strings.Contains(ordinary, "Squad leader rules") {
+		t.Fatalf("ordinary assignment prompt leaked the leader block\n---\n%s", ordinary)
+	}
+}
+
+// TestBuildPromptSquadLeaderMultiThreadCarvesOutNoAction renders the
+// complete leader prompt on the cross-thread fan-out path (MUL-5442 #6493
+// review round 2): the multi-thread imperative fires AFTER the no_action
+// rule, so it must carry the same carve-out as the single-thread cookbook —
+// a bare "Post ONE reply per thread" in a leader prompt re-opens the
+// contradiction. The ordinary fan-out output keeps the unconditional form.
+func TestBuildPromptSquadLeaderMultiThreadCarvesOutNoAction(t *testing.T) {
+	t.Parallel()
+
+	leaderTask := Task{
+		IssueID:               "issue-1",
+		TriggerCommentID:      "comment-9",
+		TriggerThreadID:       "thread-B",
+		TriggerCommentContent: "second update",
+		TriggerAuthorType:     "agent",
+		TriggerAuthorName:     "Worker",
+		CoalescedComments: []CoalescedCommentData{
+			{ID: "comment-8", ThreadID: "thread-A", Content: "first update"},
+		},
+		Agent: &AgentData{
+			Name:         "Lead",
+			Instructions: "Some instructions\n\n## Squad Operating Protocol\n\nYou are the LEADER...",
+		},
+	}
+	prompt := BuildPrompt(leaderTask, "claude")
+	if !strings.Contains(prompt, "no_action rule:") {
+		t.Fatalf("leader multi-thread prompt missing the no_action rule\n---\n%s", prompt)
+	}
+	if !strings.Contains(prompt, "Unless your outcome is `no_action`, post ONE reply per thread") {
+		t.Fatalf("leader multi-thread prompt missing the carve-out imperative\n---\n%s", prompt)
+	}
+	if strings.Contains(prompt, ". Post ONE reply per thread") {
+		t.Fatalf("leader multi-thread prompt still carries the unconditional imperative\n---\n%s", prompt)
+	}
+
+	ordinaryTask := leaderTask
+	ordinaryTask.Agent = &AgentData{Name: "Reg", Instructions: "You are a regular agent."}
+	ordinary := BuildPrompt(ordinaryTask, "claude")
+	if !strings.Contains(ordinary, ". Post ONE reply per thread") {
+		t.Fatalf("ordinary multi-thread prompt missing the unconditional imperative\n---\n%s", ordinary)
+	}
+	if strings.Contains(ordinary, "Unless your outcome is") {
+		t.Fatalf("ordinary multi-thread prompt leaked the leader carve-out\n---\n%s", ordinary)
 	}
 }

--- a/server/internal/daemon/daemon_test.go
+++ b/server/internal/daemon/daemon_test.go
@@ -1089,6 +1089,9 @@ func TestBuildPromptCommentTriggeredByAgent(t *testing.T) {
 		"do not @mention the other agent as a sign-off",
 		"reply is warranted",
 		"exit with no output",
+		// The conditional reply framing was the door the retired rule
+		// walked through — guard it shut (MUL-5442 #6493 review).
+		"If you decide to reply",
 	} {
 		if strings.Contains(prompt, banned) {
 			t.Fatalf("per-turn prompt still carries retired no-reply warning %q\n---\n%s", banned, prompt)
@@ -5021,5 +5024,35 @@ func TestFreshSessionMayHelp(t *testing.T) {
 	const hermesAuth = "hermes provider error: \"Could not resolve authentication method. Expected either api_key or auth_token to be set. Or for one of the X-Api-Key or Authorization headers to be explicitly omitted\""
 	if !freshSessionMayHelp(hermesAuth) {
 		t.Fatalf("freshSessionMayHelp(auth-resolution error) = false; a fresh session cures this failure, it must report session-fixable")
+
+// TestBuildPromptSquadLeaderReplyCommandCarvesOutNoAction renders the COMPLETE
+// leader prompt and pins the exception's scope relation (MUL-5442 #6493
+// review): the no_action rule and the reply imperative appear in the same
+// prompt, so the imperative must carry the carve-out itself — a bare
+// unconditional "Post your reply as a comment" anywhere in a leader prompt
+// re-opens the contradiction the carve-out exists to close.
+func TestBuildPromptSquadLeaderReplyCommandCarvesOutNoAction(t *testing.T) {
+	t.Parallel()
+
+	prompt := BuildPrompt(Task{
+		IssueID:               "issue-1",
+		TriggerCommentID:      "comment-1",
+		TriggerCommentContent: "team update posted",
+		TriggerAuthorType:     "member",
+		TriggerAuthorName:     "Bohan",
+		Agent: &AgentData{
+			Name:         "Lead",
+			Instructions: "Some instructions\n\n## Squad Operating Protocol\n\nYou are the LEADER...",
+		},
+	}, "claude")
+
+	if !strings.Contains(prompt, "Squad leader no_action rule") {
+		t.Fatalf("leader prompt missing the no_action rule\n---\n%s", prompt)
+	}
+	if !strings.Contains(prompt, "Unless your outcome is `no_action`, post your reply as a comment") {
+		t.Fatalf("leader prompt missing the carve-out reply imperative\n---\n%s", prompt)
+	}
+	if strings.Contains(prompt, "Post your reply as a comment") {
+		t.Fatalf("leader prompt still carries the unconditional reply imperative\n---\n%s", prompt)
 	}
 }

--- a/server/internal/daemon/daemon_test.go
+++ b/server/internal/daemon/daemon_test.go
@@ -5137,8 +5137,24 @@ func TestBuildPromptSquadLeaderMultiThreadCarvesOutNoAction(t *testing.T) {
 	if !strings.Contains(prompt, "no_action rule:") {
 		t.Fatalf("leader multi-thread prompt missing the no_action rule\n---\n%s", prompt)
 	}
-	if !strings.Contains(prompt, "Unless your outcome is `no_action`, post ONE reply per thread") {
-		t.Fatalf("leader multi-thread prompt missing the carve-out imperative\n---\n%s", prompt)
+	// #6493 round 3: the scope sentence must govern the ENTIRE fan-out —
+	// assert it precedes every later obligation, not just the first verb.
+	scope := strings.Index(prompt, "skip this ENTIRE fan-out block")
+	if scope < 0 {
+		t.Fatalf("leader multi-thread prompt missing the whole-block scope sentence\n---\n%s", prompt)
+	}
+	for _, obligation := range []string{
+		"multiple replies are required and correct",
+		"Post the replies in the order listed below",
+		"For EACH thread above",
+	} {
+		idx := strings.Index(prompt, obligation)
+		if idx < 0 {
+			t.Fatalf("leader multi-thread prompt missing obligation %q\n---\n%s", obligation, prompt)
+		}
+		if idx < scope {
+			t.Fatalf("obligation %q precedes the no_action scope sentence — it escapes the carve-out\n---\n%s", obligation, prompt)
+		}
 	}
 	if strings.Contains(prompt, ". Post ONE reply per thread") {
 		t.Fatalf("leader multi-thread prompt still carries the unconditional imperative\n---\n%s", prompt)
@@ -5152,5 +5168,74 @@ func TestBuildPromptSquadLeaderMultiThreadCarvesOutNoAction(t *testing.T) {
 	}
 	if strings.Contains(ordinary, "Unless your outcome is") {
 		t.Fatalf("ordinary multi-thread prompt leaked the leader carve-out\n---\n%s", ordinary)
+	}
+}
+
+// TestStableAgentInstructionsStripsSquadBriefing pins the daemon half of the
+// #6493 round-3 invariant with the handler's real join shape: the brief
+// receives only the stable half of Instructions, so a leader turn and a
+// worker turn of the same agent hand execenv byte-identical instructions.
+func TestStableAgentInstructionsStripsSquadBriefing(t *testing.T) {
+	t.Parallel()
+
+	const stable = "Think from first principles."
+	briefing := "## Squad Operating Protocol\n\nYou are the LEADER.\n\n## Squad Roster\n\n- Leader (you): Eve\n"
+	if got := stableAgentInstructions(stable + "\n\n" + briefing); got != stable {
+		t.Fatalf("leader-task instructions not reduced to the stable half: %q", got)
+	}
+	if got := stableAgentInstructions(stable); got != stable {
+		t.Fatalf("worker-task instructions must pass through: %q", got)
+	}
+	if got := stableAgentInstructions(briefing); got != "" {
+		t.Fatalf("briefing-only instructions must reduce to empty: %q", got)
+	}
+}
+
+// TestBuildPromptCarriesSquadBriefing pins the other half: the briefing
+// stripped from the brief must arrive in the per-turn prompt on every leader
+// prompt shape — comment-triggered (including the old-server empty-body
+// form, #6493 round 3) and assignment-triggered.
+func TestBuildPromptCarriesSquadBriefing(t *testing.T) {
+	t.Parallel()
+
+	instructions := "Some instructions\n\n## Squad Operating Protocol\n\nYou are the LEADER.\n\n## Squad Roster\n\n- Leader (you): Eve\n"
+	shapes := []struct {
+		name string
+		task Task
+	}{
+		{"comment", Task{
+			IssueID: "issue-1", TriggerCommentID: "comment-1",
+			TriggerCommentContent: "status?", TriggerAuthorType: "member",
+			Agent: &AgentData{Name: "Lead", Instructions: instructions},
+		}},
+		{"comment-empty-body-old-server", Task{
+			IssueID: "issue-1", TriggerCommentID: "comment-1",
+			Agent: &AgentData{Name: "Lead", Instructions: instructions},
+		}},
+		{"assignment", Task{
+			IssueID: "issue-1",
+			Agent:   &AgentData{Name: "Lead", Instructions: instructions},
+		}},
+	}
+	for _, shape := range shapes {
+		prompt := BuildPrompt(shape.task, "claude")
+		for _, want := range []string{
+			"## Squad Operating Protocol",
+			"## Squad Roster",
+			"Squad leader rules for this turn",
+		} {
+			if !strings.Contains(prompt, want) {
+				t.Fatalf("%s: leader prompt missing %q\n---\n%s", shape.name, want, prompt)
+			}
+		}
+	}
+
+	ordinary := BuildPrompt(Task{
+		IssueID: "issue-1", TriggerCommentID: "comment-1",
+		TriggerCommentContent: "status?", TriggerAuthorType: "member",
+		Agent: &AgentData{Name: "Reg", Instructions: "You are a regular agent."},
+	}, "claude")
+	if strings.Contains(ordinary, "## Squad Operating Protocol") {
+		t.Fatalf("ordinary prompt leaked a squad briefing\n---\n%s", ordinary)
 	}
 }

--- a/server/internal/daemon/daemon_test.go
+++ b/server/internal/daemon/daemon_test.go
@@ -1042,11 +1042,10 @@ func TestBuildPromptCommentTriggered(t *testing.T) {
 		commentID,
 		"multica issue comment add " + issueID + " --parent " + commentID,
 		"do NOT reuse --parent values from previous turns",
-		// Silence-as-valid-exit for agent-to-agent loops depends on the
-		// reply command being framed conditionally rather than as a hard
-		// requirement. Guard the phrasing so the conflict with the new
-		// workflow (MUL-1323) doesn't come back.
-		"If you decide to reply",
+		// MUL-5442 (2026-08-06): with the generic no-reply rule retired,
+		// the reply command is framed as a plain imperative again — the
+		// squad leader's `no_action` block states its own exception.
+		"Post your reply as a comment",
 	} {
 		if !strings.Contains(prompt, want) {
 			t.Fatalf("prompt missing %q\n---\n%s", want, prompt)
@@ -1059,11 +1058,17 @@ func TestBuildPromptCommentTriggered(t *testing.T) {
 	}
 }
 
-// TestBuildPromptCommentTriggeredByAgent covers the agent-to-agent mention
-// loop signal injected into the per-turn prompt (MUL-1323 / GH#1576). When
-// the triggering comment was posted by another agent, the prompt must name
-// the author, warn against sign-off @mentions, and point at silence as a
-// valid exit.
+// TestBuildPromptCommentTriggeredByAgent covers the trigger-attribution
+// line for agent-authored triggers, and guards the RETIREMENT of the
+// generic no-reply warning block that used to follow it (MUL-1323 /
+// GH#1576). Retired by MUL-5442 owner decision (2026-08-06): an agent
+// comment cannot wake an ordinary agent without an explicit @mention
+// (computeCommentAgentTriggers routes agent-authored comments only via
+// mentions, plus the squad-leader wake), so loop prevention belongs to the
+// mention discipline in the brief's `## Mentions`, and recorded silence
+// stays squad-leader-only (`no_action`). Retired pins, now negative
+// guards: "do not @mention the other agent as a sign-off", "Silence is
+// the preferred way".
 func TestBuildPromptCommentTriggeredByAgent(t *testing.T) {
 	t.Parallel()
 
@@ -1076,13 +1081,17 @@ func TestBuildPromptCommentTriggeredByAgent(t *testing.T) {
 		Agent:                 &AgentData{Name: "Test"},
 	}, "claude")
 
-	for _, want := range []string{
-		"Another agent (Atlas)",
-		"do not @mention the other agent as a sign-off",
+	if !strings.Contains(prompt, "Another agent (Atlas)") {
+		t.Fatalf("prompt missing trigger attribution\n---\n%s", prompt)
+	}
+	for _, banned := range []string{
 		"Silence is the preferred way",
+		"do not @mention the other agent as a sign-off",
+		"reply is warranted",
+		"exit with no output",
 	} {
-		if !strings.Contains(prompt, want) {
-			t.Fatalf("prompt missing %q\n---\n%s", want, prompt)
+		if strings.Contains(prompt, banned) {
+			t.Fatalf("per-turn prompt still carries retired no-reply warning %q\n---\n%s", banned, prompt)
 		}
 	}
 }
@@ -1108,15 +1117,16 @@ func TestBuildPromptCommentTriggeredByMember(t *testing.T) {
 	if strings.Contains(prompt, "Another agent") {
 		t.Fatalf("member-triggered prompt should not claim the author was another agent")
 	}
-	// Must NOT use the old "You MUST respond" language — that conflicts with
-	// the agent-to-agent silence-as-valid-exit workflow. Even on human-authored
-	// triggers, the reply command is framed conditionally for a single
-	// consistent rule across turn types.
+	// Must NOT use the old "You MUST respond" language: the reply command is
+	// shared across turn types, and a squad leader's `no_action` exit — the
+	// one silent path left after MUL-5442 retired the generic no-reply rule —
+	// must not be shouted over by the per-turn channel. The unconditional
+	// one-comment contract for ordinary agents lives in the brief.
 	if strings.Contains(prompt, "MUST respond") {
 		t.Fatalf("prompt should not contain unconditional \"MUST respond\" language\n---\n%s", prompt)
 	}
-	if !strings.Contains(prompt, "If you decide to reply") {
-		t.Fatalf("prompt should frame the reply command conditionally\n---\n%s", prompt)
+	if !strings.Contains(prompt, "Post your reply as a comment") {
+		t.Fatalf("prompt should carry the imperative reply command\n---\n%s", prompt)
 	}
 }
 

--- a/server/internal/daemon/execenv/execenv.go
+++ b/server/internal/daemon/execenv/execenv.go
@@ -141,7 +141,12 @@ type TaskContextForEnv struct {
 	AutopilotTriggerPayload string
 	QuickCreatePrompt       string // non-empty for quick-create tasks
 	HandoffNote             string // assignment handoff instruction; rendered into issue_context.md (MUL-3375)
-	IsSquadLeader           bool   // true when the agent is acting as a squad leader (may exit silently on no_action)
+	// IsSquadLeader is true when THIS TASK runs the agent as a squad leader.
+	// It is a per-task role, not agent configuration — the brief builder must
+	// never branch on it (leader rules ride the per-turn channel; #6493
+	// review), and the byte-identity test toggles it to prove the brief
+	// ignores it.
+	IsSquadLeader bool
 	// WorkspaceContext is the workspace-level system prompt (workspace.context
 	// in the DB). Rendered into the brief as `## Workspace Context` when
 	// non-empty so every agent in the workspace sees the same shared context,

--- a/server/internal/daemon/execenv/execenv_test.go
+++ b/server/internal/daemon/execenv/execenv_test.go
@@ -4995,28 +4995,37 @@ func TestInjectRuntimeConfigMentionLoopHardening(t *testing.T) {
 		}
 	})
 
-	t.Run("workflow-carries-silence-as-exit-and-no-signoff-mention", func(t *testing.T) {
+	t.Run("workflow-reply-is-unconditional-and-no-signoff-mention", func(t *testing.T) {
 		t.Parallel()
 		s := readClaudeMD(t, commentTriggerCtx)
-		// The anti-loop signal must reach the brief; lock in the key phrases so
-		// it can't decay back into pure prose again. The reply-warranted rules
-		// live in the Reply mode block, while the no-sign-off-mention rule is
-		// mention policy and lives in `## Mentions` (MUL-5442) — these
-		// assertions are file-wide on purpose, so the signal is pinned without
-		// pinning which section carries it.
+		// MUL-5442 owner decision (2026-08-06): the generic no-reply rule is
+		// retired. It never carried the loop prevention — agent comments
+		// trigger nothing without an explicit @mention (the sole implicit
+		// wake is the squad-leader path), so the mention discipline pinned in
+		// the Mentions subtest above is the real defense. Ordinary agents are
+		// back on the unconditional one-comment-per-run contract; recorded
+		// silence via `no_action` remains squad-leader-only. Retired pins,
+		// replaced by the negative guards below so the apparatus cannot creep
+		// back: "Decide whether a reply is warranted", "produced actual
+		// work", "pure acknowledgment / thanks / sign-off", "do NOT reply",
+		// "Silence is a valid and preferred way".
 		for _, want := range []string{
-			"Decide whether a reply is warranted",
-			// Both outcomes pinned individually (MUL-5442 stage-1 review):
-			// the work-produced arm and the silent-exit arm must each
-			// survive compression, not just the bullet's heading.
-			"produced actual work",
-			"pure acknowledgment / thanks / sign-off",
-			"do NOT reply",
-			"Silence is a valid and preferred way",
+			"Posting your reply as a comment is mandatory",
+			"Do any requested work first",
 			"Never @mention the agent you are replying to as a thank-you or sign-off",
 		} {
 			if !strings.Contains(s, want) {
 				t.Errorf("comment-triggered CLAUDE.md missing %q", want)
+			}
+		}
+		for _, banned := range []string{
+			"Decide whether a reply is warranted",
+			"exit with no output",
+			"Silence is a valid and preferred way",
+			"conditional on the reply rule",
+		} {
+			if strings.Contains(s, banned) {
+				t.Errorf("comment-triggered CLAUDE.md still carries retired no-reply text %q", banned)
 			}
 		}
 	})

--- a/server/internal/daemon/execenv/execenv_test.go
+++ b/server/internal/daemon/execenv/execenv_test.go
@@ -5023,6 +5023,17 @@ func TestInjectRuntimeConfigMentionLoopHardening(t *testing.T) {
 			"exit with no output",
 			"Silence is a valid and preferred way",
 			"conditional on the reply rule",
+			// #6493 review: the ledger named five retired pins but only
+			// guarded two — the missing three let the old apparatus
+			// coexist with the new sentences. Ordinary-agent scope only:
+			// the leader's no_action bullet says "DO NOT post any
+			// comment", which none of these match.
+			"produced actual work",
+			"pure acknowledgment / thanks / sign-off",
+			"do NOT reply",
+			// Leader-leak guard: the carve-out imperative is
+			// leader-brief-only.
+			"Unless your outcome is",
 		} {
 			if strings.Contains(s, banned) {
 				t.Errorf("comment-triggered CLAUDE.md still carries retired no-reply text %q", banned)
@@ -5054,15 +5065,24 @@ func TestInjectRuntimeConfigSquadLeaderCommentTriggeredNoAction(t *testing.T) {
 	}
 	s := string(data)
 
-	// The comment-triggered workflow must contain the squad leader no_action rule.
+	// The comment-triggered workflow must contain the squad leader no_action
+	// rule, and the reply imperative must carry the no_action carve-out so a
+	// later bullet never contradicts it (MUL-5442 #6493 review).
 	for _, want := range []string{
 		"Squad leader rule",
 		"DO NOT post any comment",
 		"multica squad activity",
+		"Unless your outcome is `no_action` (Squad leader rule above), posting your reply as a comment is mandatory",
 	} {
 		if !strings.Contains(s, want) {
 			t.Errorf("squad leader comment-triggered CLAUDE.md missing %q", want)
 		}
+	}
+	// Capital-P form = the ordinary unconditional bullet; the leader brief
+	// must carry only the carve-out variant (its lowercase "posting your
+	// reply as a comment is mandatory" tail is expected and legal).
+	if strings.Contains(s, "Posting your reply as a comment is mandatory") {
+		t.Errorf("squad leader CLAUDE.md still carries the unconditional reply bullet")
 	}
 
 	// The Output section must use strong prohibition language.

--- a/server/internal/daemon/execenv/execenv_test.go
+++ b/server/internal/daemon/execenv/execenv_test.go
@@ -1095,12 +1095,15 @@ func TestInjectRuntimeConfigAvailableCommandsCoreOnly(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to read leader AGENTS.md: %v", err)
 	}
-	for _, want := range []string{
+	// #6493 review: Squad maintenance moved to the per-turn leader block —
+	// leadership is per-task role, so leader-only CLI surface can no longer
+	// ride the cached brief. Negative guard against regression.
+	for _, banned := range []string{
 		"### Squad maintenance",
 		"multica squad member set-role <squad-id>",
 	} {
-		if !strings.Contains(string(leader), want) {
-			t.Errorf("squad-leader AGENTS.md missing %q\n---\n%s", want, leader)
+		if strings.Contains(string(leader), banned) {
+			t.Errorf("AGENTS.md must not carry leader-only CLI surface %q\n---\n%s", banned, leader)
 		}
 	}
 
@@ -5050,63 +5053,47 @@ func TestInjectRuntimeConfigMentionLoopHardening(t *testing.T) {
 func TestInjectRuntimeConfigSquadLeaderCommentTriggeredNoAction(t *testing.T) {
 	t.Parallel()
 
-	dir := t.TempDir()
-	ctx := TaskContextForEnv{
-		IssueID:          "issue-1",
-		TriggerCommentID: "comment-1",
-		IsSquadLeader:    true,
-	}
-	if _, err := InjectRuntimeConfig(dir, "claude", ctx); err != nil {
-		t.Fatalf("InjectRuntimeConfig failed: %v", err)
-	}
-	data, err := os.ReadFile(filepath.Join(dir, "CLAUDE.md"))
-	if err != nil {
-		t.Fatalf("read CLAUDE.md: %v", err)
-	}
-	s := string(data)
-
-	// The comment-triggered workflow must contain the squad leader no_action
-	// rule, and the reply imperative must carry the no_action carve-out so a
-	// later bullet never contradicts it (MUL-5442 #6493 review).
-	for _, want := range []string{
-		"Squad leader rule",
-		"DO NOT post any comment",
-		"multica squad activity",
-		"Unless your outcome is `no_action` (Squad leader rule above), posting your reply as a comment is mandatory",
-	} {
-		if !strings.Contains(s, want) {
-			t.Errorf("squad leader comment-triggered CLAUDE.md missing %q", want)
+	// MUL-5442 #6493 review: leadership is a per-task role, so the leader
+	// no_action rule, the reply carve-out, and the Output exception all left
+	// the brief for the per-turn channel (daemon/prompt.go). The injected
+	// CLAUDE.md must now be byte-identical across roles, and no leader
+	// wording may remain. Retired brief pins, relocated to per-turn tests:
+	// "Squad leader rule", "DO NOT post any comment", "multica squad
+	// activity", "Unless your outcome is `no_action` (Squad leader rule
+	// above), posting your reply as a comment is mandatory", "you MUST exit
+	// without posting any comment".
+	render := func(t *testing.T, leader bool) string {
+		t.Helper()
+		dir := t.TempDir()
+		ctx := TaskContextForEnv{
+			IssueID:          "issue-1",
+			TriggerCommentID: "comment-1",
+			IsSquadLeader:    leader,
 		}
-	}
-	// Capital-P form = the ordinary unconditional bullet; the leader brief
-	// must carry only the carve-out variant (its lowercase "posting your
-	// reply as a comment is mandatory" tail is expected and legal).
-	if strings.Contains(s, "Posting your reply as a comment is mandatory") {
-		t.Errorf("squad leader CLAUDE.md still carries the unconditional reply bullet")
-	}
-
-	// The Output section must use strong prohibition language.
-	if !strings.Contains(s, "you MUST exit without posting any comment") {
-		t.Errorf("Output section missing strong prohibition for squad leader no_action")
+		if _, err := InjectRuntimeConfig(dir, "claude", ctx); err != nil {
+			t.Fatalf("InjectRuntimeConfig failed: %v", err)
+		}
+		data, err := os.ReadFile(filepath.Join(dir, "CLAUDE.md"))
+		if err != nil {
+			t.Fatalf("read CLAUDE.md: %v", err)
+		}
+		return string(data)
 	}
 
-	// Non-squad-leader should NOT have the squad leader rule in comment-triggered path.
-	dir2 := t.TempDir()
-	ctx2 := TaskContextForEnv{
-		IssueID:          "issue-1",
-		TriggerCommentID: "comment-1",
-		IsSquadLeader:    false,
+	leader := render(t, true)
+	ordinary := render(t, false)
+	if leader != ordinary {
+		t.Errorf("CLAUDE.md must render byte-identically across roles; leader render diverges")
 	}
-	if _, err := InjectRuntimeConfig(dir2, "claude", ctx2); err != nil {
-		t.Fatalf("InjectRuntimeConfig failed: %v", err)
-	}
-	data2, err := os.ReadFile(filepath.Join(dir2, "CLAUDE.md"))
-	if err != nil {
-		t.Fatalf("read CLAUDE.md: %v", err)
-	}
-	s2 := string(data2)
-	if strings.Contains(s2, "Squad leader rule") {
-		t.Errorf("non-squad-leader CLAUDE.md should NOT contain squad leader rule")
+	for _, banned := range []string{
+		"Squad leader rule",
+		"multica squad activity",
+		"no_action",
+		"Unless your outcome is",
+	} {
+		if strings.Contains(leader, banned) {
+			t.Errorf("CLAUDE.md still carries leader-only wording %q", banned)
+		}
 	}
 }
 

--- a/server/internal/daemon/execenv/execenv_test.go
+++ b/server/internal/daemon/execenv/execenv_test.go
@@ -6038,3 +6038,56 @@ func TestEnvironmentCleanupStandardModeRemovesWorkdir(t *testing.T) {
 		t.Fatalf("output/ removed by partial cleanup: %v", err)
 	}
 }
+
+// TestSplitSquadBriefingBriefEquality pins the #6493 round-3 invariant with
+// handler-shaped inputs: the server appends the squad briefing to
+// Instructions as `stable + "\n\n" + briefing` (or briefing alone when the
+// stable part is empty), and the brief rendered from the split stable half
+// must be byte-identical to the brief a worker turn renders from the plain
+// instructions. Toggling ctx.IsSquadLeader alone cannot catch this — the
+// production difference arrives through AgentInstructions.
+func TestSplitSquadBriefingBriefEquality(t *testing.T) {
+	t.Parallel()
+
+	const stableInstr = "Think from first principles."
+	briefingText := SquadBriefingMarker + "\n\nYou are the LEADER.\n\n## Squad Roster\n\n- Leader (you): Eve\n- Worker: Bob\n"
+
+	for _, tc := range []struct {
+		name     string
+		combined string
+	}{
+		{"appended", stableInstr + "\n\n" + briefingText},
+		{"briefing-only", briefingText},
+		{"trailing-newline-stable", stableInstr + "\n" + "\n\n" + briefingText},
+	} {
+		stable, briefing := SplitSquadBriefing(tc.combined)
+		if briefing == "" {
+			t.Fatalf("%s: briefing not detected", tc.name)
+		}
+		wantStable, _ := SplitSquadBriefing(stableInstr)
+		if tc.name == "briefing-only" {
+			wantStable = ""
+		}
+		if stable != wantStable {
+			t.Fatalf("%s: stable half %q != plain %q", tc.name, stable, wantStable)
+		}
+
+		leaderCtx := TaskContextForEnv{
+			IssueID: "issue-1", TriggerCommentID: "comment-1",
+			AgentName: "Eve", AgentID: "agent-1",
+			AgentInstructions: stable,
+			IsSquadLeader:     true,
+		}
+		workerCtx := leaderCtx
+		workerCtx.AgentInstructions = wantStable
+		workerCtx.IsSquadLeader = false
+		if buildMetaSkillContent("claude", leaderCtx) != buildMetaSkillContent("claude", workerCtx) {
+			t.Fatalf("%s: brief diverges between leader and worker renders", tc.name)
+		}
+	}
+
+	stable, briefing := SplitSquadBriefing(stableInstr)
+	if briefing != "" || stable != stableInstr {
+		t.Fatalf("no-marker input must pass through: stable=%q briefing=%q", stable, briefing)
+	}
+}

--- a/server/internal/daemon/execenv/git.go
+++ b/server/internal/daemon/execenv/git.go
@@ -9,7 +9,6 @@ import (
 	"regexp"
 	"strings"
 	"time"
-
 )
 
 // detectGitRepo checks if dir is inside a git repository (regular or bare).
@@ -111,7 +110,7 @@ func removeGitWorktree(gitRoot, worktreePath, branchName string, logger *slog.Lo
 	// Delete the branch (best-effort).
 	if branchName != "" {
 		cmd = exec.Command("git", "-C", gitRoot, "branch", "-D", branchName)
-	
+
 		if out, err := cmd.CombinedOutput(); err != nil {
 			logger.Warn("execenv: git branch delete failed", "branch", branchName, "output", strings.TrimSpace(string(out)), "error", err)
 		}

--- a/server/internal/daemon/execenv/reply_instructions.go
+++ b/server/internal/daemon/execenv/reply_instructions.go
@@ -236,7 +236,7 @@ type ThreadReplyTarget struct {
 // before this instruction is emitted, so a per-thread fan-out cannot split it.
 //
 // Returns "" for fewer than two targets; callers keep the single-parent path.
-func BuildMultiThreadCommentReplyInstructions(issueID string, targets []ThreadReplyTarget) string {
+func BuildMultiThreadCommentReplyInstructions(issueID string, targets []ThreadReplyTarget, squadLeader bool) string {
 	if issueID == "" || len(targets) < 2 {
 		return ""
 	}
@@ -270,8 +270,15 @@ func BuildMultiThreadCommentReplyInstructions(issueID string, targets []ThreadRe
 		)
 	}
 
+	// Same carve-out as the single-thread cookbook (MUL-5442 #6493 review):
+	// the leader's no_action exit must not be contradicted by this later
+	// imperative; ordinary agents keep the unconditional form byte-for-byte.
+	lead := "This run coalesced comments from %d DISTINCT threads. Post ONE reply per thread"
+	if squadLeader {
+		lead = "This run coalesced comments from %d DISTINCT threads. Unless your outcome is `no_action`, post ONE reply per thread"
+	}
 	return fmt.Sprintf(
-		"This run coalesced comments from %d DISTINCT threads. Post ONE reply per thread — %d replies in total — each threaded under its own conversation. This OVERRIDES the general \"post exactly one comment per run\" guidance: for THIS run multiple replies are required and correct. Do NOT merge separate threads into a single comment, and do NOT post more than one reply in the same thread.\n\n"+
+		lead+" — %d replies in total — each threaded under its own conversation. This OVERRIDES the general \"post exactly one comment per run\" guidance: for THIS run multiple replies are required and correct. Do NOT merge separate threads into a single comment, and do NOT post more than one reply in the same thread.\n\n"+
 			"Post the replies in the order listed below — OLDEST thread first, the newest (triggering) thread LAST — so they land in chronological order. Do NOT answer the newest/triggering comment first.\n\n"+
 			"Reply targets, in the order to post them (use the exact `--parent` for each — do NOT reuse `--parent` values from previous turns in this session):\n"+
 			"%s\n"+

--- a/server/internal/daemon/execenv/reply_instructions.go
+++ b/server/internal/daemon/execenv/reply_instructions.go
@@ -270,12 +270,15 @@ func BuildMultiThreadCommentReplyInstructions(issueID string, targets []ThreadRe
 		)
 	}
 
-	// Same carve-out as the single-thread cookbook (MUL-5442 #6493 review):
-	// the leader's no_action exit must not be contradicted by this later
-	// imperative; ordinary agents keep the unconditional form byte-for-byte.
+	// Same carve-out as the single-thread cookbook (MUL-5442 #6493 review,
+	// round 3): the scope sentence must govern the ENTIRE fan-out block —
+	// every obligation below ("multiple replies are required", the posting
+	// order, the per-thread cookbook) sits under the "Otherwise" — not just
+	// the first verb. Ordinary agents keep the unconditional form
+	// byte-for-byte.
 	lead := "This run coalesced comments from %d DISTINCT threads. Post ONE reply per thread"
 	if squadLeader {
-		lead = "This run coalesced comments from %d DISTINCT threads. Unless your outcome is `no_action`, post ONE reply per thread"
+		lead = "This run coalesced comments from %d DISTINCT threads. **If your outcome is `no_action`, skip this ENTIRE fan-out block — post no replies at all and exit via `multica squad activity` as your leader rules direct; everything below applies only otherwise.** Otherwise, post ONE reply per thread"
 	}
 	return fmt.Sprintf(
 		lead+" — %d replies in total — each threaded under its own conversation. This OVERRIDES the general \"post exactly one comment per run\" guidance: for THIS run multiple replies are required and correct. Do NOT merge separate threads into a single comment, and do NOT post more than one reply in the same thread.\n\n"+

--- a/server/internal/daemon/execenv/reply_instructions.go
+++ b/server/internal/daemon/execenv/reply_instructions.go
@@ -185,7 +185,7 @@ func BuildCommentReplyInstructions(provider, issueID, triggerCommentID string) s
 func buildCommentReplyInstructionsSlim(provider, issueID, triggerCommentID string) string {
 	if runtimeGOOS == "windows" {
 		return fmt.Sprintf(
-			"If you decide to reply, post it as a comment — always use the trigger comment ID below, "+
+			"Post your reply as a comment — always use the trigger comment ID below, "+
 				"do NOT reuse --parent values from previous turns in this session.\n\n"+
 				"Write the body file first — never pipe via `--content-stdin` (PowerShell drops non-ASCII; full rules: ## Comment Formatting above):\n\n"+
 				"    multica issue comment add %s --parent %s --content-file ./reply.md\n"+
@@ -195,7 +195,7 @@ func buildCommentReplyInstructionsSlim(provider, issueID, triggerCommentID strin
 		)
 	}
 	return fmt.Sprintf(
-		"If you decide to reply, post it as a comment — always use the trigger comment ID below, "+
+		"Post your reply as a comment — always use the trigger comment ID below, "+
 			"do NOT reuse --parent values from previous turns in this session.\n\n"+
 			"Write the body file first (rules: ## Comment Formatting above — MUL-2904 / #4182):\n\n"+
 			"    multica issue comment add %s --parent %s --content-file ./reply.md\n"+

--- a/server/internal/daemon/execenv/reply_instructions.go
+++ b/server/internal/daemon/execenv/reply_instructions.go
@@ -162,11 +162,11 @@ func activeThreadID(triggerThreadID, triggerCommentID string) string {
 //
 // provider is retained for caller symmetry and future per-provider tweaks; the
 // guardrail itself is intentionally identical across providers and hosts.
-func BuildCommentReplyInstructions(provider, issueID, triggerCommentID string) string {
+func BuildCommentReplyInstructions(provider, issueID, triggerCommentID string, squadLeader bool) string {
 	if triggerCommentID == "" {
 		return ""
 	}
-	return buildCommentReplyInstructionsSlim(provider, issueID, triggerCommentID)
+	return buildCommentReplyInstructionsSlim(provider, issueID, triggerCommentID, squadLeader)
 }
 
 // buildCommentReplyInstructionsSlim is the compressed reply-instructions
@@ -182,10 +182,18 @@ func BuildCommentReplyInstructions(provider, issueID, triggerCommentID string) s
 // canonical `## Comment Formatting` section the same brief carries, so
 // repeating it inline at every comment-triggered step 7 would be
 // duplication, not signal.
-func buildCommentReplyInstructionsSlim(provider, issueID, triggerCommentID string) string {
+func buildCommentReplyInstructionsSlim(provider, issueID, triggerCommentID string, squadLeader bool) string {
+	// The squad leader's `no_action` exit (recorded via `squad activity`) is
+	// the one path where posting no comment is correct — the imperative must
+	// carry its own carve-out so a later line never contradicts the
+	// no_action rule injected above it (MUL-5442 #6493 review).
+	lead := "Post your reply as a comment — always use the trigger comment ID below, "
+	if squadLeader {
+		lead = "Unless your outcome is `no_action`, post your reply as a comment — always use the trigger comment ID below, "
+	}
 	if runtimeGOOS == "windows" {
 		return fmt.Sprintf(
-			"Post your reply as a comment — always use the trigger comment ID below, "+
+			lead+
 				"do NOT reuse --parent values from previous turns in this session.\n\n"+
 				"Write the body file first — never pipe via `--content-stdin` (PowerShell drops non-ASCII; full rules: ## Comment Formatting above):\n\n"+
 				"    multica issue comment add %s --parent %s --content-file ./reply.md\n"+
@@ -195,7 +203,7 @@ func buildCommentReplyInstructionsSlim(provider, issueID, triggerCommentID strin
 		)
 	}
 	return fmt.Sprintf(
-		"Post your reply as a comment — always use the trigger comment ID below, "+
+		lead+
 			"do NOT reuse --parent values from previous turns in this session.\n\n"+
 			"Write the body file first (rules: ## Comment Formatting above — MUL-2904 / #4182):\n\n"+
 			"    multica issue comment add %s --parent %s --content-file ./reply.md\n"+

--- a/server/internal/daemon/execenv/reply_instructions_test.go
+++ b/server/internal/daemon/execenv/reply_instructions_test.go
@@ -94,7 +94,7 @@ func TestBuildCommentReplyInstructionsNonCodexLinux(t *testing.T) {
 					"#4182",
 					"rm ./reply.md",
 					"do NOT reuse --parent values from previous turns",
-					"If you decide to reply",
+					"Post your reply as a comment",
 				} {
 					if !strings.Contains(got, want) {
 						t.Errorf("%s reply instructions missing %q\n---\n%s", name, want, got)

--- a/server/internal/daemon/execenv/reply_instructions_test.go
+++ b/server/internal/daemon/execenv/reply_instructions_test.go
@@ -26,7 +26,7 @@ func TestBuildCommentReplyInstructionsCodexLinux(t *testing.T) {
 	issueID := "11111111-1111-1111-1111-111111111111"
 	triggerID := "22222222-2222-2222-2222-222222222222"
 
-	got := BuildCommentReplyInstructions("codex", issueID, triggerID)
+	got := BuildCommentReplyInstructions("codex", issueID, triggerID, false)
 
 	for _, want := range []string{
 		"multica issue comment add " + issueID + " --parent " + triggerID + " --content-file ./reply.md",
@@ -82,7 +82,7 @@ func TestBuildCommentReplyInstructionsNonCodexLinux(t *testing.T) {
 			name := provider + "/" + host
 			t.Run(name, func(t *testing.T) {
 				runtimeGOOS = host
-				got := BuildCommentReplyInstructions(provider, issueID, triggerID)
+				got := BuildCommentReplyInstructions(provider, issueID, triggerID, false)
 
 				for _, want := range []string{
 					"multica issue comment add " + issueID + " --parent " + triggerID + " --content-file ./reply.md",
@@ -138,7 +138,7 @@ func TestBuildCommentReplyInstructionsWindowsUsesContentFile(t *testing.T) {
 
 	for _, provider := range []string{"codex", "claude", "opencode", "openclaw", "hermes", "kimi", "reasonix", "kiro", "cursor"} {
 		t.Run(provider+"/windows", func(t *testing.T) {
-			got := BuildCommentReplyInstructions(provider, issueID, triggerID)
+			got := BuildCommentReplyInstructions(provider, issueID, triggerID, false)
 			for _, want := range []string{
 				"multica issue comment add " + issueID + " --parent " + triggerID + " --content-file",
 				// MUL-5442 cross-channel dedup: the $OutputEncoding trap's
@@ -171,7 +171,7 @@ func TestBuildCommentReplyInstructionsEmptyWhenNoTrigger(t *testing.T) {
 	t.Parallel()
 
 	for _, provider := range []string{"codex", "claude", "opencode"} {
-		if got := BuildCommentReplyInstructions(provider, "issue-id", ""); got != "" {
+		if got := BuildCommentReplyInstructions(provider, "issue-id", "", false); got != "" {
 			t.Fatalf("expected empty string when triggerCommentID is empty for %s, got %q", provider, got)
 		}
 	}
@@ -240,7 +240,7 @@ func TestWindowsCommentReplyInstructionsHaveNoStdin(t *testing.T) {
 
 	for _, provider := range []string{"claude", "codex", "opencode"} {
 		t.Run(provider, func(t *testing.T) {
-			s := BuildCommentReplyInstructions(provider, issueID, triggerID)
+			s := BuildCommentReplyInstructions(provider, issueID, triggerID, false)
 			for _, want := range []string{
 				"multica issue comment add " + issueID + " --parent " + triggerID + " --content-file",
 				"--content-file",
@@ -320,5 +320,30 @@ func TestInjectRuntimeConfigWindowsAssignmentBriefStaysFileOnly(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+// TestBuildCommentReplyInstructionsSquadLeaderCarveOut pins that the squad
+// leader variant scopes the reply imperative with the `no_action` exception
+// (MUL-5442 #6493 review): the leader's only silent path must not be
+// contradicted by a later unconditional "Post your reply" line, and the
+// ordinary variant must never carry the leader carve-out.
+func TestBuildCommentReplyInstructionsSquadLeaderCarveOut(t *testing.T) {
+	t.Parallel()
+
+	leader := BuildCommentReplyInstructions("claude", "issue-1", "comment-1", true)
+	if !strings.Contains(leader, "Unless your outcome is `no_action`, post your reply as a comment") {
+		t.Errorf("leader reply instructions missing the no_action carve-out\n---\n%s", leader)
+	}
+	if strings.Contains(leader, "Post your reply as a comment") {
+		t.Errorf("leader reply instructions still carry the unconditional imperative\n---\n%s", leader)
+	}
+
+	ordinary := BuildCommentReplyInstructions("claude", "issue-1", "comment-1", false)
+	if !strings.Contains(ordinary, "Post your reply as a comment") {
+		t.Errorf("ordinary reply instructions missing the imperative\n---\n%s", ordinary)
+	}
+	if strings.Contains(ordinary, "Unless your outcome is") {
+		t.Errorf("ordinary reply instructions leaked the leader carve-out\n---\n%s", ordinary)
 	}
 }

--- a/server/internal/daemon/execenv/runtime_config_sections.go
+++ b/server/internal/daemon/execenv/runtime_config_sections.go
@@ -105,6 +105,28 @@ func writeBackgroundTaskSafetySlim(b *strings.Builder) {
 
 // writeAgentIdentity emits the Agent Identity heading and (optionally) the
 // agent's instructions body.
+// SquadBriefingMarker opens the per-task squad leader briefing the server
+// appends to Agent.Instructions for leader tasks (handler
+// buildSquadLeaderBriefing). It is both the leadership check and the split
+// point for SplitSquadBriefing.
+const SquadBriefingMarker = "## Squad Operating Protocol"
+
+// SplitSquadBriefing separates an agent's stable instructions from the
+// per-task squad leader briefing. Leadership is a per-task role — the same
+// agent flips leader/worker between turns while session resume keys on
+// (agent_id, issue_id) — so the briefing must never reach the cached brief
+// (MUL-5377; MUL-5442 #6493 review): the stable part feeds the brief, the
+// briefing rides the per-turn prompt. The stable part is
+// trailing-newline-normalized on BOTH paths so a leader turn's stable half
+// is byte-identical to a worker turn's whole.
+func SplitSquadBriefing(instructions string) (stable, briefing string) {
+	i := strings.Index(instructions, SquadBriefingMarker)
+	if i < 0 {
+		return strings.TrimRight(instructions, "\n"), ""
+	}
+	return strings.TrimRight(instructions[:i], "\n"), instructions[i:]
+}
+
 func writeAgentIdentity(b *strings.Builder, ctx TaskContextForEnv) {
 	if ctx.AgentName != "" || ctx.AgentID != "" {
 		b.WriteString("## Agent Identity\n\n")
@@ -550,7 +572,11 @@ func writeWorkflowIssue(b *strings.Builder, ctx TaskContextForEnv) {
 
 	b.WriteString("**Ownership mode only — you own the issue status this run** (skip any status call below that your Agent Identity forbids)\n\n")
 	b.WriteString("- Before step 4, run `multica issue status <issue-id> in_progress`.\n")
-	b.WriteString("- When done, run `multica issue status <issue-id> in_review`.\n")
+	// No runnable in_review command shape here: the brief is role-independent
+	// and also reaches guest squad leaders, whose combined instructions must
+	// never carry one (squad_parent_status_contract_test). The syntax lives
+	// in ## Available Commands.
+	b.WriteString("- When done, set the issue status to `in_review` (syntax: `## Available Commands`).\n")
 	b.WriteString("- If blocked, run `multica issue status <issue-id> blocked`, and post a comment explaining the blocker unless your Agent Identity forbids issue comments.\n\n")
 
 	b.WriteString("**Reply mode only — respond to the comment in the user message**\n\n")

--- a/server/internal/daemon/execenv/runtime_config_sections.go
+++ b/server/internal/daemon/execenv/runtime_config_sections.go
@@ -268,15 +268,6 @@ func writeAvailableCommands(b *strings.Builder, ctx TaskContextForEnv) {
 	b.WriteString("- `multica issue metadata set <issue-id> --key <k> --value <v> [--type string|number|bool]` — pin or overwrite a key.\n")
 	b.WriteString("- `multica issue metadata delete <issue-id> --key <k>` — remove a key.\n")
 	b.WriteString("- `multica repo checkout <url> [--ref <branch-or-sha>]` — repository checkout on a dedicated branch.\n\n")
-	// Squad maintenance is squad-leader surface: an agent that leads no squad
-	// has no squad to change roles in, so this shipped to every run as dead
-	// weight (MUL-5442). IsSquadLeader is agent configuration, not per-run
-	// state, so gating on it keeps the brief byte-stable across runs of one
-	// session (MUL-5377) — the same reason the workflow already branches on it.
-	if ctx.IsSquadLeader {
-		b.WriteString("### Squad maintenance\n")
-		b.WriteString("- `multica squad member set-role <squad-id> --member-id <id> --member-type <agent|member> --role <role> [--output json]` — change role in place (use this instead of remove+add).\n\n")
-	}
 }
 
 // writeAvailableCommandsQuickCreate emits a minimal Available Commands
@@ -538,8 +529,14 @@ func writeWorkflowAutopilot(b *strings.Builder, ctx TaskContextForEnv) {
 // a re-trigger (member update / stage barrier) confirms the overall goal
 // is met; see the Squad Operating Protocol and child-done system comments.
 //
-// ctx.IsSquadLeader is agent configuration, not per-run state, so branching
-// on it does not break byte-stability across runs of one session.
+// The brief must NOT branch on ctx.IsSquadLeader: leadership is a PER-TASK
+// role, not agent configuration — the handler appends the Squad Operating
+// Protocol to Agent.Instructions only for leader tasks, and the same agent
+// can be leader one turn and worker the next while session resume keys on
+// (agent_id, issue_id) with no role isolation. A role branch here would make
+// the cached brief flip bytes between turns (MUL-5377; #6493 review). All
+// leader-specific rules ride the per-turn channel (prompt.go), which is
+// role-aware via the task's instructions.
 func writeWorkflowIssue(b *strings.Builder, ctx TaskContextForEnv) {
 	b.WriteString("**Turn mode.** The per-turn user message names this run's mode on a line of its own: `Turn mode: Reply.` (respond to the comment that message carries — it brings the triggering comment's id and your `--parent` value) or `Turn mode: Ownership.` (an assignment or status change started this run). Steps 1–6 are shared; then **apply exactly one mode block, the one the user message named** — they differ on issue status. No mode line → Reply mode, do not change the issue status.\n\n")
 
@@ -548,50 +545,19 @@ func writeWorkflowIssue(b *strings.Builder, ctx TaskContextForEnv) {
 	b.WriteString("2. Read the metadata bag (`multica issue metadata list`) — best-effort, empty `{}` and CLI failures are normal. What to look for: `## Issue Metadata`.\n")
 	b.WriteString("3. Catch up on the comment history — this is mandatory, not optional — in two bounded reads, never one bulk pull: scan every thread cheaply (`--roots-only --summary`), then expand only the threads that matter (`--thread <id> --tail 30`). Earlier comments often carry context the issue body lacks. Skipping this step is the most common cause of agents acting on stale or incomplete instructions — so always run the scan, even when the trigger looks self-contained. In Reply mode the per-turn user message names the thread to expand first; the scan is how you decide whether any OTHER thread is also relevant.\n")
 	b.WriteString("4. Complete the task within your Agent Identity boundaries (`## Instruction Precedence` lists the actions Agent Identity can forbid). If your role is delegation-only, perform the allowed delegation work and stop once that outcome is delivered.\n")
-	if ctx.IsSquadLeader {
-		b.WriteString("5. **Post your final results as a comment** (unless your outcome is `no_action` — in that case, calling `multica squad activity <issue-id> no_action --reason \"...\"` alone is sufficient; you MUST exit without posting any comment. DO NOT post a comment announcing no_action or saying you are exiting silently): post it with `multica issue comment add` using the platform-correct non-inline mode from ## Comment Formatting (never inline `--content`). Your results are only visible to the user if posted via this CLI call; text in your terminal or run logs is NOT delivered.\n")
-	} else {
-		b.WriteString("5. **Post your final results as a comment — this step is mandatory**: post it with `multica issue comment add` using the platform-correct non-inline mode from ## Comment Formatting (never inline `--content`). `## Output` states why this call is the only delivery channel.\n")
-	}
+	b.WriteString("5. **Post your final results as a comment — this step is mandatory**: post it with `multica issue comment add` using the platform-correct non-inline mode from ## Comment Formatting (never inline `--content`). `## Output` states why this call is the only delivery channel.\n")
 	b.WriteString("6. Before exiting, pin or clear a metadata key via `multica issue metadata set`/`delete` only if it clears the bar in `## Issue Metadata`. Most runs write nothing here — that is the expected outcome, not a gap. When in doubt, do not write.\n\n")
 
 	b.WriteString("**Ownership mode only — you own the issue status this run** (skip any status call below that your Agent Identity forbids)\n\n")
 	b.WriteString("- Before step 4, run `multica issue status <issue-id> in_progress`.\n")
-	if ctx.IsSquadLeader {
-		b.WriteString("- After this initial dispatch, leave the parent issue `in_progress` — do NOT move it to `in_review` or `done` on this turn. Dispatching members is not completion. You will be re-triggered when members post updates or a stage closes; only then, if the overall goal is met, move the parent to `in_review`.\n")
-	} else {
-		b.WriteString("- When done, run `multica issue status <issue-id> in_review`.\n")
-	}
+	b.WriteString("- When done, run `multica issue status <issue-id> in_review`.\n")
 	b.WriteString("- If blocked, run `multica issue status <issue-id> blocked`, and post a comment explaining the blocker unless your Agent Identity forbids issue comments.\n\n")
 
 	b.WriteString("**Reply mode only — respond to the comment in the user message**\n\n")
 	b.WriteString("- Respond to THAT specific comment; take its id from the user message, never from this file or from an earlier turn.\n")
-	if ctx.IsSquadLeader {
-		b.WriteString("- **Squad leader rule:** If your evaluation outcome is `no_action`, call `multica squad activity <issue-id> no_action --reason \"...\"` and then EXIT IMMEDIATELY. DO NOT post any comment whose only purpose is to announce that you are taking no action, exiting silently, or acknowledging another agent. A comment like \"No action needed\" or \"Exiting silently\" is noise — the `squad activity` call already records your decision in the timeline.\n")
-	}
 	b.WriteString("- Do any requested work first, then **decide whether to include any `@mention` link.** The default is NO mention; `## Mentions` states when one is warranted.\n")
-	if ctx.IsSquadLeader {
-		b.WriteString("- **Unless your outcome is `no_action` (Squad leader rule above), posting your reply as a comment is mandatory** (`## Output`). Use the `--parent` value the per-turn user message gives you for this turn; do NOT reuse a `--parent` from an earlier turn in this session. When that message lists more than one thread to answer, post one reply per thread instead of merging them.\n")
-	} else {
-		b.WriteString("- **Posting your reply as a comment is mandatory** (`## Output`). Use the `--parent` value the per-turn user message gives you for this turn; do NOT reuse a `--parent` from an earlier turn in this session. When that message lists more than one thread to answer, post one reply per thread instead of merging them.\n")
-	}
-	if ctx.IsSquadLeader {
-		// The default rule below and the Squad Operating Protocol's
-		// "Own the parent issue status" responsibility would otherwise
-		// contradict each other on the squad's most common shape:
-		// @mention dispatch with no child issues, where the member's
-		// delivery comment never "explicitly asks" for a status change and
-		// no child-done system comment exists to carry that ask. Naming the
-		// protocol section as the exception resolves it in one direction.
-		//
-		// The exception is safe to state unconditionally here because the
-		// grant only exists in the instructions when the server determined
-		// this issue is assigned to this squad (see buildSquadLeaderBriefing);
-		// a guest leader gets the opposite text and this stays a no-op.
-		b.WriteString("- Do NOT change the issue status unless the comment explicitly asks for it — **or** a section in your instructions explicitly grants you ownership of this issue's status (the Squad Operating Protocol's \"Own the parent issue status\" responsibility). That section only appears when this issue is assigned to your squad; when it is there, treat it as a standing instruction and move the parent to `in_review` on the turn you confirm the overall goal is met, without waiting to be asked. When it is absent, the rule above is absolute. **The Ownership-mode status steps above do not apply in Reply mode.**\n\n")
-	} else {
-		b.WriteString("- Do NOT change the issue status unless the comment explicitly asks for it. **The Ownership-mode status steps above do not apply in Reply mode.**\n\n")
-	}
+	b.WriteString("- **Posting your reply as a comment is mandatory** (`## Output`). Use the `--parent` value the per-turn user message gives you for this turn; do NOT reuse a `--parent` from an earlier turn in this session. When that message lists more than one thread to answer, post one reply per thread instead of merging them.\n")
+	b.WriteString("- Do NOT change the issue status unless the comment explicitly asks for it. **The Ownership-mode status steps above do not apply in Reply mode.**\n\n")
 }
 
 // writeSubIssueCreation emits the Sub-issue Creation section.
@@ -714,11 +680,7 @@ func writeOutput(b *strings.Builder, kind taskKind, ctx TaskContextForEnv) {
 			b.WriteString("**Delivering files here:** run `multica attachment upload <local-path>` — it binds the file to your reply and it renders as an attachment card. That command is the ONLY way a file reaches the user; a path written into your reply text is not.\n")
 		}
 	default:
-		if ctx.IsSquadLeader {
-			b.WriteString("⚠️ **Final results MUST be delivered via `multica issue comment add`** — unless your outcome is `no_action`. When you evaluate a trigger and decide no action is needed, calling `multica squad activity <issue-id> no_action --reason \"...\"` alone is sufficient; you MUST exit without posting any comment. DO NOT post a comment that announces no_action, acknowledges another agent, or says you are exiting silently — such comments are noise. For all other outcomes (`action`, `failed`), a comment is still mandatory.\n\n")
-		} else {
-			b.WriteString("⚠️ **Final results MUST be delivered via `multica issue comment add`.** The user does NOT see your terminal output or run logs — only comments on the issue.\n\n")
-		}
+		b.WriteString("⚠️ **Final results MUST be delivered via `multica issue comment add`.** The user does NOT see your terminal output or run logs — only comments on the issue.\n\n")
 		b.WriteString("**Post exactly ONE comment per run — your final result, before this turn exits.** Do NOT post progress updates or plans along the way.\n\n")
 		b.WriteString("Keep comments concise and natural — state the outcome, not the process.\n\n")
 		b.WriteString("**Delivering files here:** pass `--attachment <path>` to `multica issue comment add` (repeatable) — the only way a screenshot or artifact reaches the reader.\n")

--- a/server/internal/daemon/execenv/runtime_config_sections.go
+++ b/server/internal/daemon/execenv/runtime_config_sections.go
@@ -551,7 +551,7 @@ func writeWorkflowIssue(b *strings.Builder, ctx TaskContextForEnv) {
 	if ctx.IsSquadLeader {
 		b.WriteString("5. **Post your final results as a comment** (unless your outcome is `no_action` — in that case, calling `multica squad activity <issue-id> no_action --reason \"...\"` alone is sufficient; you MUST exit without posting any comment. DO NOT post a comment announcing no_action or saying you are exiting silently): post it with `multica issue comment add` using the platform-correct non-inline mode from ## Comment Formatting (never inline `--content`). Your results are only visible to the user if posted via this CLI call; text in your terminal or run logs is NOT delivered.\n")
 	} else {
-		b.WriteString("5. **Post your final results as a comment — this step is mandatory**: post it with `multica issue comment add` using the platform-correct non-inline mode from ## Comment Formatting (never inline `--content`). `## Output` states why this call is the only delivery channel. In Reply mode this step is conditional on the reply rule below.\n")
+		b.WriteString("5. **Post your final results as a comment — this step is mandatory**: post it with `multica issue comment add` using the platform-correct non-inline mode from ## Comment Formatting (never inline `--content`). `## Output` states why this call is the only delivery channel.\n")
 	}
 	b.WriteString("6. Before exiting, pin or clear a metadata key via `multica issue metadata set`/`delete` only if it clears the bar in `## Issue Metadata`. Most runs write nothing here — that is the expected outcome, not a gap. When in doubt, do not write.\n\n")
 
@@ -566,12 +566,11 @@ func writeWorkflowIssue(b *strings.Builder, ctx TaskContextForEnv) {
 
 	b.WriteString("**Reply mode only — respond to the comment in the user message**\n\n")
 	b.WriteString("- Respond to THAT specific comment; take its id from the user message, never from this file or from an earlier turn.\n")
-	b.WriteString("- **Decide whether a reply is warranted.** If you produced actual work this turn, post the result via step 5. If the triggering comment was a pure acknowledgment / thanks / sign-off from another agent AND you produced no work, do NOT reply — not even a 'No reply needed' comment; exit with no output. Silence is a valid and preferred way to end agent-to-agent conversations.\n")
 	if ctx.IsSquadLeader {
 		b.WriteString("- **Squad leader rule:** If your evaluation outcome is `no_action`, call `multica squad activity <issue-id> no_action --reason \"...\"` and then EXIT IMMEDIATELY. DO NOT post any comment whose only purpose is to announce that you are taking no action, exiting silently, or acknowledging another agent. A comment like \"No action needed\" or \"Exiting silently\" is noise — the `squad activity` call already records your decision in the timeline.\n")
 	}
-	b.WriteString("- If a reply IS warranted: do any requested work first, then **decide whether to include any `@mention` link.** The default is NO mention; `## Mentions` states when one is warranted.\n")
-	b.WriteString("- **If you reply, posting it as a comment is mandatory** (`## Output`). Use the `--parent` value the per-turn user message gives you for this turn; do NOT reuse a `--parent` from an earlier turn in this session. When that message lists more than one thread to answer, post one reply per thread instead of merging them.\n")
+	b.WriteString("- Do any requested work first, then **decide whether to include any `@mention` link.** The default is NO mention; `## Mentions` states when one is warranted.\n")
+	b.WriteString("- **Posting your reply as a comment is mandatory** (`## Output`). Use the `--parent` value the per-turn user message gives you for this turn; do NOT reuse a `--parent` from an earlier turn in this session. When that message lists more than one thread to answer, post one reply per thread instead of merging them.\n")
 	if ctx.IsSquadLeader {
 		// The default rule below and the Squad Operating Protocol's
 		// "Own the parent issue status" responsibility would otherwise

--- a/server/internal/daemon/execenv/runtime_config_sections.go
+++ b/server/internal/daemon/execenv/runtime_config_sections.go
@@ -570,7 +570,11 @@ func writeWorkflowIssue(b *strings.Builder, ctx TaskContextForEnv) {
 		b.WriteString("- **Squad leader rule:** If your evaluation outcome is `no_action`, call `multica squad activity <issue-id> no_action --reason \"...\"` and then EXIT IMMEDIATELY. DO NOT post any comment whose only purpose is to announce that you are taking no action, exiting silently, or acknowledging another agent. A comment like \"No action needed\" or \"Exiting silently\" is noise — the `squad activity` call already records your decision in the timeline.\n")
 	}
 	b.WriteString("- Do any requested work first, then **decide whether to include any `@mention` link.** The default is NO mention; `## Mentions` states when one is warranted.\n")
-	b.WriteString("- **Posting your reply as a comment is mandatory** (`## Output`). Use the `--parent` value the per-turn user message gives you for this turn; do NOT reuse a `--parent` from an earlier turn in this session. When that message lists more than one thread to answer, post one reply per thread instead of merging them.\n")
+	if ctx.IsSquadLeader {
+		b.WriteString("- **Unless your outcome is `no_action` (Squad leader rule above), posting your reply as a comment is mandatory** (`## Output`). Use the `--parent` value the per-turn user message gives you for this turn; do NOT reuse a `--parent` from an earlier turn in this session. When that message lists more than one thread to answer, post one reply per thread instead of merging them.\n")
+	} else {
+		b.WriteString("- **Posting your reply as a comment is mandatory** (`## Output`). Use the `--parent` value the per-turn user message gives you for this turn; do NOT reuse a `--parent` from an earlier turn in this session. When that message lists more than one thread to answer, post one reply per thread instead of merging them.\n")
+	}
 	if ctx.IsSquadLeader {
 		// The default rule below and the Squad Operating Protocol's
 		// "Own the parent issue status" responsibility would otherwise

--- a/server/internal/daemon/execenv/runtime_config_test.go
+++ b/server/internal/daemon/execenv/runtime_config_test.go
@@ -1561,7 +1561,7 @@ func TestMultiThreadReplyInstructionsFanOut(t *testing.T) {
 // Single-thread reply cookbook moved to the per-turn prompt (MUL-5377).
 func TestSingleThreadReplyInstructionsKeepSingleParent(t *testing.T) {
 	t.Parallel()
-	out := BuildCommentReplyInstructions("claude", "55555555-6666-7777-8888-999999999999", "c3")
+	out := BuildCommentReplyInstructions("claude", "55555555-6666-7777-8888-999999999999", "c3", false)
 
 	if strings.Contains(out, "DISTINCT threads") {
 		t.Errorf("single/same-thread instructions must not emit the multi-thread fan-out block, got:\n%s", out)

--- a/server/internal/daemon/execenv/runtime_config_test.go
+++ b/server/internal/daemon/execenv/runtime_config_test.go
@@ -354,7 +354,9 @@ func TestIssueWorkflowHonorsAgentIdentity(t *testing.T) {
 		// Step 4 keeps only what the enumeration cannot express: a
 		// delegation-only role stops once the delegation is delivered.
 		"If your role is delegation-only, perform the allowed delegation work and stop once that outcome is delivered",
-		"When done, run `multica issue status <issue-id> in_review`.",
+		// #6493 round 3: no runnable in_review shape in the brief — it also
+		// reaches guest leaders (squad_parent_status_contract_test).
+		"When done, set the issue status to `in_review` (syntax: `## Available Commands`).",
 		"If blocked, run `multica issue status <issue-id> blocked`, and post a comment explaining the blocker unless your Agent Identity forbids issue comments.",
 	} {
 		if !strings.Contains(out, want) {
@@ -392,7 +394,7 @@ func TestIssueBriefIsRoleIndependent(t *testing.T) {
 	if got := buildMetaSkillContent("claude", leader); got != ordinary {
 		t.Errorf("issue brief must be byte-identical across roles; leader render diverges\n---\n%s", got)
 	}
-	if !strings.Contains(ordinary, "When done, run `multica issue status <issue-id> in_review`.") {
+	if !strings.Contains(ordinary, "When done, set the issue status to `in_review` (syntax: `## Available Commands`).") {
 		t.Errorf("issue brief missing the ordinary completion step\n---\n%s", ordinary)
 	}
 }

--- a/server/internal/daemon/execenv/runtime_config_test.go
+++ b/server/internal/daemon/execenv/runtime_config_test.go
@@ -169,36 +169,30 @@ func TestCommentTriggeredProtocolDoesNotForceInReview(t *testing.T) {
 	}
 }
 
-// A squad leader on a comment-triggered turn gets the same guardrail plus a
-// named exception. Without it the guardrail and the Squad Operating Protocol's
-// "Own the parent issue status" responsibility contradict each other on the
-// @mention-dispatch shape, where the member's delivery comment never asks for
-// a status change and no child-done system comment exists to ask on its
-// behalf — so the parent would sit in in_progress forever.
-func TestCommentTriggeredSquadLeaderDefersToStatusOwnershipGrant(t *testing.T) {
+// TestCommentTriggeredBriefIsRoleIndependent replaces the old
+// squad-leader status-grant brief test (MUL-5442 #6493 review). Leadership
+// is a PER-TASK role, so the brief must render byte-identically for leader
+// and worker turns of the same agent — the status-ownership grant, the
+// no_action rule, and every other leader rule now ride the per-turn channel
+// (daemon/prompt.go, TestBuildPromptSquadLeaderNoActionProhibition).
+// Retired brief pins, all relocated to per-turn tests: "Own the parent
+// issue status", "only appears when this issue is assigned to your squad",
+// "without waiting to be asked", "When it is absent, the rule above is
+// absolute.".
+func TestCommentTriggeredBriefIsRoleIndependent(t *testing.T) {
 	t.Parallel()
-	out := buildMetaSkillContent("claude", TaskContextForEnv{
+	base := TaskContextForEnv{
 		IssueID:          "55555555-6666-7777-8888-999999999999",
 		TriggerCommentID: "66666666-7777-8888-9999-aaaaaaaaaaaa",
-		IsSquadLeader:    true,
-	})
-
-	for _, want := range []string{
-		"Do NOT change the issue status unless the comment explicitly asks for it",
-		`Squad Operating Protocol's "Own the parent issue status"`,
-		"only appears when this issue is assigned to your squad",
-		"without waiting to be asked",
-		"When it is absent, the rule above is absolute.",
-	} {
-		if !strings.Contains(out, want) {
-			t.Errorf("squad-leader comment brief missing %q\n---\n%s", want, out)
-		}
 	}
-
-	// The unqualified sentence must be gone: its presence alongside the grant
-	// is the contradiction this branch exists to remove.
-	if strings.Contains(out, "explicitly asks for it\n") {
-		t.Errorf("squad-leader comment brief still ends the guardrail unqualified\n---\n%s", out)
+	leader := base
+	leader.IsSquadLeader = true
+	ordinary := buildMetaSkillContent("claude", base)
+	if got := buildMetaSkillContent("claude", leader); got != ordinary {
+		t.Errorf("comment-triggered brief must be byte-identical across roles; leader render diverges\n---\n%s", got)
+	}
+	if strings.Contains(ordinary, "Own the parent issue status") {
+		t.Errorf("brief must not carry the squad status grant (per-turn content):\n%s", ordinary)
 	}
 }
 
@@ -379,32 +373,27 @@ func TestIssueWorkflowHonorsAgentIdentity(t *testing.T) {
 	}
 }
 
-// Squad-leader briefs must open the parent with in_progress, but must not
-// treat the first dispatch turn as completion (no unconditional in_review).
-func TestSquadLeaderIssueWorkflowKeepsParentInProgress(t *testing.T) {
+// TestIssueBriefIsRoleIndependent replaces the old squad-leader dispatch
+// brief test (MUL-5442 #6493 review): the keep-parent-in_progress dispatch
+// rule is per-task role content and now rides the leader's assignment
+// per-turn block (daemon/prompt.go,
+// TestBuildPromptSquadLeaderAssignmentKeepsParentInProgress). The brief
+// renders the ordinary Ownership-mode step for everyone and must be
+// byte-identical across roles. Retired brief pins, relocated per-turn:
+// "After this initial dispatch, leave the parent issue `in_progress`",
+// "do NOT move it to `in_review` or `done` on this turn", "only then, if
+// the overall goal is met, move the parent to `in_review`".
+func TestIssueBriefIsRoleIndependent(t *testing.T) {
 	t.Parallel()
-	const issueID = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
-	out := buildMetaSkillContent("claude", TaskContextForEnv{
-		IssueID:       issueID,
-		IsSquadLeader: true,
-	})
-
-	for _, want := range []string{
-		"Before step 4, run `multica issue status <issue-id> in_progress`.",
-		"After this initial dispatch, leave the parent issue `in_progress`",
-		// The guest-leader contract test (handler side) bans any runnable
-		// in_review command shape from reaching a guest — the dispatch rule
-		// therefore states the prohibition without a command form.
-		"do NOT move it to `in_review` or `done` on this turn",
-		"only then, if the overall goal is met, move the parent to `in_review`",
-	} {
-		if !strings.Contains(out, want) {
-			t.Errorf("squad-leader issue brief missing %q\n---\n%s", want, out)
-		}
+	base := TaskContextForEnv{IssueID: "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"}
+	leader := base
+	leader.IsSquadLeader = true
+	ordinary := buildMetaSkillContent("claude", base)
+	if got := buildMetaSkillContent("claude", leader); got != ordinary {
+		t.Errorf("issue brief must be byte-identical across roles; leader render diverges\n---\n%s", got)
 	}
-
-	if strings.Contains(out, "When done, run `multica issue status <issue-id> in_review`") {
-		t.Errorf("squad-leader issue brief must not contain the ordinary-agent completion step\n---\n%s", out)
+	if !strings.Contains(ordinary, "When done, run `multica issue status <issue-id> in_review`.") {
+		t.Errorf("issue brief missing the ordinary completion step\n---\n%s", ordinary)
 	}
 }
 
@@ -1549,7 +1538,7 @@ func TestMultiThreadReplyInstructionsFanOut(t *testing.T) {
 		{ThreadID: "c1", ParentID: "c1"},
 		{ThreadID: "c2", ParentID: "c2"},
 		{ThreadID: "c3", ParentID: "c3"},
-	})
+	}, false)
 
 	for _, want := range []string{"3 DISTINCT threads", "Post ONE reply per thread", "--parent c1", "--parent c2", "--parent c3"} {
 		if !strings.Contains(out, want) {
@@ -1639,6 +1628,14 @@ func TestInjectRuntimeConfigByteIdenticalAcrossTriggers(t *testing.T) {
 			c.InitiatorType = "agent"
 			c.InitiatorID = "agent-9"
 			c.InitiatorName = "GPT-Boy"
+		}},
+		// Leadership is a per-task role (#6493 review): the same agent can
+		// be leader one turn and worker the next while session resume keys
+		// on (agent_id, issue_id). This variant is what makes the test
+		// actually verify the role-independence invariant.
+		{"leader-role-task", func(c *TaskContextForEnv) {
+			c.TriggerCommentID = "comment-6"
+			c.IsSquadLeader = true
 		}},
 		{"connected-apps", func(c *TaskContextForEnv) {
 			c.ConnectedApps = []runtimeapps.ConnectedApp{{

--- a/server/internal/daemon/prompt.go
+++ b/server/internal/daemon/prompt.go
@@ -330,9 +330,6 @@ func buildCommentPrompt(task Task, provider string) string {
 			fmt.Fprintf(&b, "Fetch each id you still need directly: `multica issue comment list %s --thread <comment-id> --tail 30 --output json`. `--thread` accepts a reply id, not just a thread root, so you do not need to know which thread the comment lives in. If it is older than those 30 replies, page back with the `Next reply cursor` values (`--before` / `--before-id`) until it appears. Do not finish this turn until every id above is accounted for.\n\n",
 				task.IssueID)
 		}
-		if task.TriggerAuthorType == "agent" {
-			b.WriteString("⚠️ The triggering comment was posted by another agent. Decide whether a reply is warranted. If you produced actual work this turn (investigated, fixed something, answered a real question), post the result as a normal reply — that is NOT a noise comment, and the standard rule that final results must be delivered via comment still applies. If the triggering comment was a pure acknowledgment, thanks, or sign-off AND you produced no work this turn, do NOT reply — and do NOT post a comment saying 'No reply needed' or similar. Simply exit with no output. Silence is the preferred way to end agent-to-agent threads. If you do reply, do not @mention the other agent as a sign-off (that re-triggers them and starts a loop).\n\n")
-		}
 		if task.Agent != nil && strings.Contains(task.Agent.Instructions, "## Squad Operating Protocol") {
 			fmt.Fprintf(&b, "⚠️ **Squad leader no_action rule:** If you decide no action is needed, call `multica squad activity %s no_action --reason \"...\"` and EXIT. DO NOT post any comment — not even one that says \"no action needed\" or \"exiting silently\". The squad activity call records your decision; a comment is redundant noise.\n\n", task.IssueID)
 		}

--- a/server/internal/daemon/prompt.go
+++ b/server/internal/daemon/prompt.go
@@ -96,6 +96,23 @@ func BuildPrompt(task Task, provider string) string {
 		}
 		body += blocks
 	}
+	// The per-task squad leader briefing (Protocol + Roster + Squad
+	// Instructions) is stripped from the cached brief by
+	// stableAgentInstructions and delivered here instead, on every prompt
+	// shape (#6493 review round 3) — losing it would cost the leader its
+	// entire protocol, and letting it reach the brief flips cached bytes
+	// between leader and worker turns.
+	if task.Agent != nil {
+		if _, briefing := execenv.SplitSquadBriefing(task.Agent.Instructions); briefing != "" {
+			if !strings.HasSuffix(body, "\n\n") {
+				body += "\n"
+			}
+			body += briefing
+			if !strings.HasSuffix(body, "\n") {
+				body += "\n"
+			}
+		}
+	}
 	return body
 }
 
@@ -341,19 +358,23 @@ func buildCommentPrompt(task Task, provider string) string {
 			fmt.Fprintf(&b, "Fetch each id you still need directly: `multica issue comment list %s --thread <comment-id> --tail 30 --output json`. `--thread` accepts a reply id, not just a thread root, so you do not need to know which thread the comment lives in. If it is older than those 30 replies, page back with the `Next reply cursor` values (`--before` / `--before-id`) until it appears. Do not finish this turn until every id above is accounted for.\n\n",
 				task.IssueID)
 		}
-		if taskIsSquadLeader(task) {
-			// Leadership is a per-task role (the handler appends the Squad
-			// Operating Protocol only to leader tasks), so every
-			// leader-specific rule rides this uncacheable channel — the
-			// cached brief must stay byte-identical across role flips
-			// (MUL-5377; MUL-5442 #6493 review). These rules land AFTER the
-			// brief in context order, and each names the general rule it
-			// overrides, so the exception always follows the rule.
-			fmt.Fprintf(&b, "⚠️ **Squad leader rules for this turn** — your instructions carry the Squad Operating Protocol; where these conflict with the brief's general rules, these rules win:\n\n"+
-				"- **no_action rule:** If you decide no action is needed, call `multica squad activity %s no_action --reason \"...\"` and EXIT with no comment — the one exception to the brief's mandatory-reply and one-comment-per-run rules. DO NOT post any comment announcing no_action, acknowledging another agent, or saying you are exiting silently; the `squad activity` call already records your decision.\n"+
-				"- **Parent status:** if the protocol's \"Own the parent issue status\" responsibility appears in your instructions, treat it as a standing grant — move the parent to `in_review` on the turn you confirm the overall goal is met, without waiting to be asked. If that section is absent (guest leader), the brief's do-not-change-status rule is absolute.\n"+
-				"- **Squad maintenance:** `multica squad member set-role <squad-id> --member-id <id> --member-type <agent|member> --role <role>` changes a member's role in place (use it instead of remove+add).\n\n", task.IssueID)
-		}
+	}
+	// The leader block sits OUTSIDE the TriggerCommentContent conditional:
+	// older servers may send the trigger id without a body (#6493 review
+	// round 3), and an empty body must not cost a leader its no_action,
+	// status-grant, and maintenance rules.
+	if taskIsSquadLeader(task) {
+		// Leadership is a per-task role (the handler appends the Squad
+		// Operating Protocol only to leader tasks), so every leader-specific
+		// rule rides this uncacheable channel — the cached brief must stay
+		// byte-identical across role flips (MUL-5377; MUL-5442 #6493
+		// review). These rules land AFTER the brief in context order, and
+		// each names the general rule it overrides, so the exception always
+		// follows the rule.
+		fmt.Fprintf(&b, "⚠️ **Squad leader rules for this turn** — your instructions carry the Squad Operating Protocol; where these conflict with the brief's general rules, these rules win:\n\n"+
+			"- **no_action rule:** If you decide no action is needed, call `multica squad activity %s no_action --reason \"...\"` and EXIT with no comment — the one exception to the brief's mandatory-reply and one-comment-per-run rules. DO NOT post any comment announcing no_action, acknowledging another agent, or saying you are exiting silently; the `squad activity` call already records your decision.\n"+
+			"- **Parent status:** if the protocol's \"Own the parent issue status\" responsibility appears in your instructions, treat it as a standing grant — move the parent to `in_review` on the turn you confirm the overall goal is met, without waiting to be asked. If that section is absent (guest leader), the brief's do-not-change-status rule is absolute.\n"+
+			"- **Squad maintenance:** `multica squad member set-role <squad-id> --member-id <id> --member-type <agent|member> --role <role>` changes a member's role in place (use it instead of remove+add).\n\n", task.IssueID)
 	}
 	fmt.Fprintf(&b, "Start by running `multica issue get %s --output json` to understand your task, then decide how to proceed.\n\n", task.IssueID)
 	// Comment-reading pointer. Warm path with new comments: issue-wide
@@ -624,9 +645,12 @@ func buildAutopilotPrompt(task Task) string {
 	return b.String()
 }
 
-// taskIsSquadLeader mirrors the check gating the per-turn no_action block:
-// leadership is agent configuration (the Squad Operating Protocol section in
-// the agent's instructions), never per-run state.
+// taskIsSquadLeader reports whether THIS TASK runs the agent as a squad
+// leader. Leadership is a per-task role, not agent configuration: the server
+// appends the squad briefing to Instructions only when the task's
+// is_leader_task is set, and the same agent can be leader one turn and
+// worker the next. Everything gated on this must ride the per-turn channel,
+// never the cached brief (#6493 review).
 func taskIsSquadLeader(task Task) bool {
-	return task.Agent != nil && strings.Contains(task.Agent.Instructions, "## Squad Operating Protocol")
+	return task.Agent != nil && strings.Contains(task.Agent.Instructions, execenv.SquadBriefingMarker)
 }

--- a/server/internal/daemon/prompt.go
+++ b/server/internal/daemon/prompt.go
@@ -330,7 +330,7 @@ func buildCommentPrompt(task Task, provider string) string {
 			fmt.Fprintf(&b, "Fetch each id you still need directly: `multica issue comment list %s --thread <comment-id> --tail 30 --output json`. `--thread` accepts a reply id, not just a thread root, so you do not need to know which thread the comment lives in. If it is older than those 30 replies, page back with the `Next reply cursor` values (`--before` / `--before-id`) until it appears. Do not finish this turn until every id above is accounted for.\n\n",
 				task.IssueID)
 		}
-		if task.Agent != nil && strings.Contains(task.Agent.Instructions, "## Squad Operating Protocol") {
+		if taskIsSquadLeader(task) {
 			fmt.Fprintf(&b, "⚠️ **Squad leader no_action rule:** If you decide no action is needed, call `multica squad activity %s no_action --reason \"...\"` and EXIT. DO NOT post any comment — not even one that says \"no action needed\" or \"exiting silently\". The squad activity call records your decision; a comment is redundant noise.\n\n", task.IssueID)
 		}
 	}
@@ -358,7 +358,7 @@ func buildCommentPrompt(task Task, provider string) string {
 	if targets := commentReplyThreads(task); len(targets) >= 2 {
 		b.WriteString(execenv.BuildMultiThreadCommentReplyInstructions(task.IssueID, targets))
 	} else {
-		b.WriteString(execenv.BuildCommentReplyInstructions(provider, task.IssueID, task.TriggerCommentID))
+		b.WriteString(execenv.BuildCommentReplyInstructions(provider, task.IssueID, task.TriggerCommentID, taskIsSquadLeader(task)))
 	}
 	return b.String()
 }
@@ -601,4 +601,11 @@ func buildAutopilotPrompt(task Task) string {
 	// emission point, and a second hand-maintained per-turn copy is exactly
 	// how the two surfaces drifted into conflict before (MUL-5696).
 	return b.String()
+}
+
+// taskIsSquadLeader mirrors the check gating the per-turn no_action block:
+// leadership is agent configuration (the Squad Operating Protocol section in
+// the agent's instructions), never per-run state.
+func taskIsSquadLeader(task Task) bool {
+	return task.Agent != nil && strings.Contains(task.Agent.Instructions, "## Squad Operating Protocol")
 }

--- a/server/internal/daemon/prompt.go
+++ b/server/internal/daemon/prompt.go
@@ -123,6 +123,17 @@ func buildPromptBody(task Task, provider string) string {
 		b.WriteString("You were handed this issue with a handoff note. Treat it as the assigner's scoping instruction for this run; follow it before doing anything broader, and do not reply to it as if it were a comment:\n\n")
 		fmt.Fprintf(&b, "> %s\n\n", task.HandoffNote)
 	}
+	if taskIsSquadLeader(task) {
+		// Same channel rule as the comment path: leader content is per-task
+		// role state and must never reach the cached brief. The brief's
+		// Ownership-mode block says "When done, run in_review" — for a
+		// dispatch turn that is exactly wrong, so the override must ride
+		// every leader assignment prompt.
+		fmt.Fprintf(&b, "⚠️ **Squad leader rules for this turn** — where these conflict with the brief's general rules, these rules win:\n\n"+
+			"- After dispatching members, leave the parent issue `in_progress` — do NOT move it to `in_review` or `done` on this turn; dispatching members is not completion. You will be re-triggered when members post updates or a stage closes; only then, if the overall goal is met, move the parent to `in_review`.\n"+
+			"- If your outcome is `no_action` (nothing to dispatch), call `multica squad activity %s no_action --reason \"...\"` and exit without posting a comment — the one exception to the brief's mandatory-comment rule.\n"+
+			"- **Squad maintenance:** `multica squad member set-role <squad-id> --member-id <id> --member-type <agent|member> --role <role>` changes a member's role in place (use it instead of remove+add).\n\n", task.IssueID)
+	}
 	fmt.Fprintf(&b, "Start by running `multica issue get %s --output json` to understand your task, then complete it.\n", task.IssueID)
 	fmt.Fprintf(&b, "For comment history, follow the rule in your runtime workflow file (assignment-triggered tasks treat the read as mandatory). Scan the threads first with `multica issue comment list %s --roots-only --summary --output json`, then expand only what matters with `--thread <thread-id> --tail 30`. For `--since` incremental polling, pagination, and folding, see `multica issue comment list --help`.\n", task.IssueID)
 	return b.String()
@@ -331,7 +342,17 @@ func buildCommentPrompt(task Task, provider string) string {
 				task.IssueID)
 		}
 		if taskIsSquadLeader(task) {
-			fmt.Fprintf(&b, "⚠️ **Squad leader no_action rule:** If you decide no action is needed, call `multica squad activity %s no_action --reason \"...\"` and EXIT. DO NOT post any comment — not even one that says \"no action needed\" or \"exiting silently\". The squad activity call records your decision; a comment is redundant noise.\n\n", task.IssueID)
+			// Leadership is a per-task role (the handler appends the Squad
+			// Operating Protocol only to leader tasks), so every
+			// leader-specific rule rides this uncacheable channel — the
+			// cached brief must stay byte-identical across role flips
+			// (MUL-5377; MUL-5442 #6493 review). These rules land AFTER the
+			// brief in context order, and each names the general rule it
+			// overrides, so the exception always follows the rule.
+			fmt.Fprintf(&b, "⚠️ **Squad leader rules for this turn** — your instructions carry the Squad Operating Protocol; where these conflict with the brief's general rules, these rules win:\n\n"+
+				"- **no_action rule:** If you decide no action is needed, call `multica squad activity %s no_action --reason \"...\"` and EXIT with no comment — the one exception to the brief's mandatory-reply and one-comment-per-run rules. DO NOT post any comment announcing no_action, acknowledging another agent, or saying you are exiting silently; the `squad activity` call already records your decision.\n"+
+				"- **Parent status:** if the protocol's \"Own the parent issue status\" responsibility appears in your instructions, treat it as a standing grant — move the parent to `in_review` on the turn you confirm the overall goal is met, without waiting to be asked. If that section is absent (guest leader), the brief's do-not-change-status rule is absolute.\n"+
+				"- **Squad maintenance:** `multica squad member set-role <squad-id> --member-id <id> --member-type <agent|member> --role <role>` changes a member's role in place (use it instead of remove+add).\n\n", task.IssueID)
 		}
 	}
 	fmt.Fprintf(&b, "Start by running `multica issue get %s --output json` to understand your task, then decide how to proceed.\n\n", task.IssueID)
@@ -356,7 +377,7 @@ func buildCommentPrompt(task Task, provider string) string {
 	// group upstream, so they keep the ordinary single-parent path below and can
 	// never be split into duplicate replies.
 	if targets := commentReplyThreads(task); len(targets) >= 2 {
-		b.WriteString(execenv.BuildMultiThreadCommentReplyInstructions(task.IssueID, targets))
+		b.WriteString(execenv.BuildMultiThreadCommentReplyInstructions(task.IssueID, targets, taskIsSquadLeader(task)))
 	} else {
 		b.WriteString(execenv.BuildCommentReplyInstructions(provider, task.IssueID, task.TriggerCommentID, taskIsSquadLeader(task)))
 	}

--- a/server/internal/daemon/prompt_test.go
+++ b/server/internal/daemon/prompt_test.go
@@ -254,7 +254,7 @@ func TestBuildPromptSquadLeaderNoActionForMemberTrigger(t *testing.T) {
 		},
 	}
 	out := BuildPrompt(task, "claude")
-	if !strings.Contains(out, "Squad leader no_action rule") {
+	if !strings.Contains(out, "no_action rule:") {
 		t.Errorf("buildCommentPrompt must inject squad leader no_action rule for member-triggered comments, got:\n%s", out)
 	}
 	if !strings.Contains(out, "DO NOT post any comment") {
@@ -276,7 +276,7 @@ func TestBuildPromptSquadLeaderNoActionForAgentTrigger(t *testing.T) {
 		},
 	}
 	out := BuildPrompt(task, "claude")
-	if !strings.Contains(out, "Squad leader no_action rule") {
+	if !strings.Contains(out, "no_action rule:") {
 		t.Errorf("buildCommentPrompt must inject squad leader no_action rule for agent-triggered comments, got:\n%s", out)
 	}
 }
@@ -736,7 +736,7 @@ func TestBuildPromptNonSquadLeaderNoRule(t *testing.T) {
 		},
 	}
 	out := BuildPrompt(task, "claude")
-	if strings.Contains(out, "Squad leader no_action rule") {
+	if strings.Contains(out, "no_action rule:") {
 		t.Errorf("buildCommentPrompt must NOT inject squad leader no_action rule for non-squad-leader agents, got:\n%s", out)
 	}
 }

--- a/server/internal/handler/squad_parent_status_contract_test.go
+++ b/server/internal/handler/squad_parent_status_contract_test.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/multica-ai/multica/server/internal/daemon"
 	"github.com/multica-ai/multica/server/internal/daemon/execenv"
 )
 
@@ -22,16 +23,47 @@ import (
 // So each test assembles both halves for one real scenario and asserts the
 // combined instruction set points one way.
 
-// leaderCommentRuntimeBrief renders the CLAUDE.md a squad leader receives on a
-// comment-triggered turn.
-func leaderCommentRuntimeBrief(t *testing.T, instructions string) string {
+// leaderCommentSurfaces renders BOTH surfaces a squad leader receives on a
+// comment-triggered turn, the way the daemon actually assembles them since
+// MUL-5442 #6493 round 3: the cached brief gets only the STABLE half of the
+// instructions (the briefing is split off so the brief stays byte-identical
+// across leader/worker turns), and the per-turn prompt carries the full
+// briefing plus the leader rules block.
+func leaderCommentSurfaces(t *testing.T, instructions string) (brief, prompt string) {
+	t.Helper()
+	stable, _ := execenv.SplitSquadBriefing(instructions)
+	dir := t.TempDir()
+	if _, err := execenv.InjectRuntimeConfig(dir, "claude", execenv.TaskContextForEnv{
+		IssueID:           "issue-1",
+		TriggerCommentID:  "comment-1",
+		AgentInstructions: stable,
+		IsSquadLeader:     true,
+	}); err != nil {
+		t.Fatalf("InjectRuntimeConfig: %v", err)
+	}
+	data, err := os.ReadFile(filepath.Join(dir, "CLAUDE.md"))
+	if err != nil {
+		t.Fatalf("read CLAUDE.md: %v", err)
+	}
+	prompt = daemon.BuildPrompt(daemon.Task{
+		IssueID:               "issue-1",
+		TriggerCommentID:      "comment-1",
+		TriggerCommentContent: "done — all subtasks finished",
+		TriggerAuthorType:     "member",
+		Agent:                 &daemon.AgentData{Name: "Lead", Instructions: instructions},
+	}, "claude")
+	return string(data), prompt
+}
+
+// workerRuntimeBrief renders the CLAUDE.md the same agent receives on a
+// non-leader turn (plain instructions, no briefing appended).
+func workerRuntimeBrief(t *testing.T, stableInstructions string) string {
 	t.Helper()
 	dir := t.TempDir()
 	if _, err := execenv.InjectRuntimeConfig(dir, "claude", execenv.TaskContextForEnv{
 		IssueID:           "issue-1",
 		TriggerCommentID:  "comment-1",
-		AgentInstructions: instructions,
-		IsSquadLeader:     true,
+		AgentInstructions: stableInstructions,
 	}); err != nil {
 		t.Fatalf("InjectRuntimeConfig: %v", err)
 	}
@@ -53,33 +85,38 @@ func TestSquadAssignedLeaderCanWrapUpOnCommentTurn(t *testing.T) {
 
 	// The issue is assigned to this squad → the server grants status ownership.
 	briefing := buildSquadLeaderBriefing(ctx, testHandler.Queries, squad, true)
-	brief := leaderCommentRuntimeBrief(t, briefing)
+	stableInstr := "Coordinate the team."
+	combinedInstr := stableInstr + "\n\n" + briefing
+	brief, prompt := leaderCommentSurfaces(t, combinedInstr)
 
 	if !strings.Contains(briefing, "Own the parent issue status") {
 		t.Fatalf("squad-assigned briefing must grant status ownership:\n%s", briefing)
 	}
 
-	// The runtime brief must not restate the prohibition in its absolute form,
-	// which is what contradicted the grant. The absolute sentence ends right
-	// after "explicitly asks for it"; the leader variant continues past it.
-	if strings.Contains(brief, "explicitly asks for it\n") {
-		t.Error("leader runtime brief still carries the unqualified no-status-change rule, " +
-			"which contradicts the Own-the-parent-issue-status grant")
+	// MUL-5442 #6493 round 3: the brief is role-independent — byte-identical
+	// to the worker-turn render — so the grant carve-out and the briefing
+	// itself must arrive via the per-turn prompt instead.
+	if worker := workerRuntimeBrief(t, stableInstr); brief != worker {
+		t.Error("leader-turn brief diverges from the worker-turn brief — the squad briefing leaked into the cached surface")
 	}
 	for _, want := range []string{
 		// The carve-out must name the granting section, not gesture at it —
 		// the leader has to be able to tell whether it applies to this turn.
-		`Squad Operating Protocol's "Own the parent issue status"`,
-		"only appears when this issue is assigned to your squad",
+		`"Own the parent issue status"`,
+		"treat it as a standing grant",
 		"without waiting to be asked",
+		// The full briefing itself rides the prompt.
+		"## Squad Operating Protocol",
 	} {
-		if !strings.Contains(brief, want) {
-			t.Errorf("leader runtime brief missing %q\n--- brief ---\n%s", want, brief)
+		if !strings.Contains(prompt, want) {
+			t.Errorf("leader per-turn prompt missing %q\n--- prompt ---\n%s", want, prompt)
 		}
 	}
 
-	// End to end: both halves must agree that in_review is reachable here.
-	combined := briefing + "\n" + brief
+	// End to end: the surfaces the leader actually sees must agree that
+	// in_review is reachable here (the wrap-up command arrives with the
+	// briefing inside the prompt).
+	combined := brief + "\n" + prompt
 	if !strings.Contains(combined, "multica issue status <issue-id> in_review") {
 		t.Error("combined instructions never tell the owning leader how to wrap up")
 	}
@@ -97,7 +134,7 @@ func TestGuestLeaderCannotChangeStatusOnCommentTurn(t *testing.T) {
 
 	// The issue is assigned to someone else → no status ownership.
 	briefing := buildSquadLeaderBriefing(ctx, testHandler.Queries, squad, false)
-	brief := leaderCommentRuntimeBrief(t, briefing)
+	brief, prompt := leaderCommentSurfaces(t, "Coordinate the team.\n\n"+briefing)
 
 	// The leader still gets the coordination context it was pulled in for —
 	// withholding status authority must not withhold the roster too.
@@ -117,7 +154,11 @@ func TestGuestLeaderCannotChangeStatusOnCommentTurn(t *testing.T) {
 	if strings.Contains(briefing, "Own the parent issue status") {
 		t.Errorf("guest leader must not receive the status-ownership grant:\n%s", briefing)
 	}
-	combined := briefing + "\n" + brief
+	// #6493 round 3: compose what the guest leader actually sees — the
+	// role-independent brief plus the per-turn prompt (which carries the
+	// guest briefing and the leader rules). No surface may hand it a
+	// runnable in_review command.
+	combined := brief + "\n" + prompt
 	if strings.Contains(combined, "multica issue status <issue-id> in_review") {
 		t.Error("combined instructions hand a guest leader an in_review command for " +
 			"an issue assigned to someone else")


### PR DESCRIPTION
> **Draft — stacks on #6493 (PR A).** Tracking and discussion: Multica sub-issue **MUL-5811**. The diff currently shows PR A's commits too; it narrows to the refactor once #6493 merges. Do not merge before the three round-4 must-fixes below are closed.

Split out of #6493 by owner decision: the cached brief was never role-independent — seven explicit `ctx.IsSquadLeader` branches plus the server-appended squad briefing (Protocol + Roster + Squad Instructions inside `Agent.Instructions`) flipped the brief's bytes whenever the same agent switched between leader and worker turns, invalidating the whole prompt-cache prefix each time (MUL-5377). `IsSquadLeader` is a per-task role, not agent configuration.

## Done in this WIP (leader==worker brief measured byte-identical under handler-shaped inputs)

- All seven brief role branches removed; the false "agent configuration" comments rewritten.
- `execenv.SplitSquadBriefing` + daemon `stableAgentInstructions`: stable instructions feed the brief; the briefing rides every leader prompt shape (comment, empty-body comment, assignment) via `BuildPrompt`; leader rules consolidated into two per-turn blocks, each naming the brief rule it overrides.
- Squad parent-status contract tests compose the surfaces a leader actually sees (role-independent brief + prompt carrying the briefing) with a brief-equality assertion; the brief's Ownership bullet drops the runnable `in_review` shape (guest-leader contract).
- ByteIdentical gains a leader variant; two role-independence tests with migration ledgers.

## Open before merge (review round-4 must-fixes → spec in MUL-5811)

1. Role determination must not hinge on the user-writable `## Squad Operating Protocol` heading (design decision pending: dedicated wire field vs private sentinel gated by `Task.IsLeaderTask` / `SquadID`), plus a negative regression for ordinary instructions containing the heading.
2. Splitter normalization must match the handler's join rules (`TrimSpace` empty semantics, CRLF, pure-whitespace) with handler-shaped equality cases.
3. Byte accounting with a real leader fixture: single-turn and multi-turn session cost of the briefing moving from cacheable to per-turn.
