### PR TITLE
MUL-5802: make OpenClaw EOF test deterministic

### DIFF
--- a/server/pkg/agent/openclaw_stdout_test.go
+++ b/server/pkg/agent/openclaw_stdout_test.go
@@ -272,31 +272,69 @@ func TestReadOpenclawStdoutDoesNotWaitForIdleGraceAtEOF(t *testing.T) {
 	}
 }
 
+// stagedOpenclawEOFReader returns an incomplete result first, then waits until
+// the test releases the final bytes. The final Read returns data and io.EOF
+// together, so completion and clean EOF are one deterministic observation
+// rather than two independently scheduled pipe operations.
+type stagedOpenclawEOFReader struct {
+	prefix        string
+	suffix        string
+	suffixRead    chan struct{}
+	releaseSuffix chan struct{}
+	readCount     int
+}
+
+func (r *stagedOpenclawEOFReader) Read(p []byte) (int, error) {
+	switch r.readCount {
+	case 0:
+		r.readCount++
+		return copy(p, r.prefix), nil
+	case 1:
+		r.readCount++
+		close(r.suffixRead)
+		<-r.releaseSuffix
+		return copy(p, r.suffix), io.EOF
+	default:
+		return 0, io.EOF
+	}
+}
+
 // TestReadOpenclawStdoutWaitsForCompleteResult pins the safety half of the
 // shortcut: idle output alone is not enough. Cutting off a partial buffer would
 // throw away work the agent has already done, which is worse than the hang this
 // change fixes.
 func TestReadOpenclawStdoutWaitsForCompleteResult(t *testing.T) {
-	pr, pw, err := os.Pipe()
-	if err != nil {
-		t.Fatalf("pipe: %v", err)
+	r := &stagedOpenclawEOFReader{
+		prefix:        `{"payloads":[{"text":"half`,
+		suffix:        `"}],"meta":{"durationMs":1}}`,
+		suffixRead:    make(chan struct{}),
+		releaseSuffix: make(chan struct{}),
 	}
-	defer pr.Close()
-
-	// A partial blob that cannot parse, followed by silence.
-	if _, err := pw.WriteString(`{"payloads":[{"text":"half`); err != nil {
-		t.Fatalf("write: %v", err)
-	}
+	released := false
+	t.Cleanup(func() {
+		if !released {
+			close(r.releaseSuffix)
+		}
+	})
 
 	type outcome struct {
 		cutShort bool
 		buf      string
+		err      error
 	}
 	done := make(chan outcome, 1)
 	go func() {
-		buf, cutShort, _ := readOpenclawStdout(pr, 200*time.Millisecond)
-		done <- outcome{cutShort: cutShort, buf: string(buf)}
+		buf, cutShort, err := readOpenclawStdout(r, 200*time.Millisecond)
+		done <- outcome{cutShort: cutShort, buf: string(buf), err: err}
 	}()
+
+	select {
+	case <-r.suffixRead:
+		// The incomplete prefix has been consumed and the reader is now
+		// deliberately silent until the test releases the suffix.
+	case <-time.After(5 * time.Second):
+		t.Fatal("readOpenclawStdout did not request the final bytes")
+	}
 
 	// Well past the idle grace: without the parse guard the reader would have
 	// returned cutShort by now.
@@ -309,14 +347,18 @@ func TestReadOpenclawStdoutWaitsForCompleteResult(t *testing.T) {
 	default:
 	}
 
-	// Completing the blob and closing gives the reader a clean EOF.
-	if _, err := pw.WriteString(`"}],"meta":{"durationMs":1}}`); err != nil {
-		t.Fatalf("write: %v", err)
-	}
-	pw.Close()
+	// Complete the blob and report EOF in the same Read. The old os.Pipe test
+	// performed a write and close separately, allowing the idle ticker to win
+	// after the bytes became parseable but before the read goroutine observed
+	// EOF on a loaded CI runner.
+	released = true
+	close(r.releaseSuffix)
 
 	select {
 	case got := <-done:
+		if got.err != nil {
+			t.Errorf("readOpenclawStdout: %v", got.err)
+		}
 		if got.cutShort {
 			t.Error("cutShort = true after a clean EOF, want false")
 		}


### PR DESCRIPTION
## Summary

- replace the timing-sensitive `os.Pipe` completion in `TestReadOpenclawStdoutWaitsForCompleteResult` with a staged, controllable reader
- return the final result bytes and `io.EOF` from the same read so loaded CI runners cannot observe a parseable buffer before clean EOF
- preserve the original assertion that an incomplete result must remain blocked beyond the idle grace

This is a test-only follow-up to the flaky backend failure in [CI run 31080675776](https://github.com/multica-ai/multica/actions/runs/31080675776/job/92548532621). Production OpenClaw behavior is unchanged.

## Verification

- `go test ./pkg/agent -run '^TestReadOpenclawStdoutWaitsForCompleteResult$' -count=50`
- `go test ./pkg/agent -run 'Test(ReadOpenclawStdout|Openclaw)' -count=1`
- `go test -race ./pkg/agent -run '^TestReadOpenclawStdoutWaitsForCompleteResult$' -count=1`
- `go test ./pkg/agent -count=1`
- `go vet ./pkg/agent`
- `git diff --check`

Follow-up to #6497 and MUL-5802.
