### PR TITLE
KAP-1466: reconcile uncertain daemon task starts

### DIFF
--- a/server/internal/daemon/client.go
+++ b/server/internal/daemon/client.go
@@ -321,32 +321,44 @@ func (c *Client) ExtendTaskPrepareLease(ctx context.Context, runtimeID, taskID s
 func (c *Client) StartTask(ctx context.Context, taskID string) error {
 	path := fmt.Sprintf("/api/daemon/tasks/%s/start", taskID)
 	var lastErr error
+	ambiguousAttempt := false
 	for attempt := 0; ; attempt++ {
+		// A prior transport error can commit after its first reconciliation.
+		// Re-read immediately before every retry POST, after any backoff, so a
+		// late dispatched -> running transition cannot race into a conflict.
+		if attempt > 0 {
+			started, err := c.reconcileStartTaskStatus(ctx, taskID, lastErr)
+			if err != nil {
+				return err
+			}
+			if started {
+				return nil
+			}
+		}
+
 		err := c.postJSON(ctx, path, map[string]any{}, nil)
 		if err == nil {
 			return nil
 		}
 		lastErr = err
 		if !isTransientError(err) {
+			if ambiguousAttempt {
+				return c.finalReconcileStartTask(ctx, taskID, err)
+			}
 			return err
 		}
+		ambiguousAttempt = true
 
 		// A transport error is ambiguous: the server may have committed the
 		// transition even when the daemon did not receive its response. Read
 		// the task state before considering another POST so this logical start
 		// never launches the agent twice.
-		status, statusErr := c.GetTaskStatus(ctx, taskID)
-		if statusErr != nil {
-			return fmt.Errorf("reconcile start task after %w: get task status: %w", err, statusErr)
+		started, reconcileErr := c.reconcileStartTaskStatus(ctx, taskID, err)
+		if reconcileErr != nil {
+			return reconcileErr
 		}
-		switch status {
-		case "running":
+		if started {
 			return nil
-		case "dispatched", "waiting_local_directory":
-			// The server has confirmed that no start committed, so retrying the
-			// same task ID is safe. The SQL transition only accepts these states.
-		default:
-			return fmt.Errorf("reconcile start task after %w: task status is %q", err, status)
 		}
 
 		if attempt >= len(startTaskRetrySchedule) {
@@ -356,6 +368,40 @@ func (c *Client) StartTask(ctx context.Context, taskID string) error {
 			return lastErr
 		}
 	}
+}
+
+// reconcileStartTaskStatus proves whether one ambiguous start attempt committed.
+// It reports started=true when the task is running; started=false is returned
+// only for states that the SQL StartAgentTask transition accepts. Every caller
+// that retries must invoke it immediately before its POST.
+func (c *Client) reconcileStartTaskStatus(ctx context.Context, taskID string, cause error) (bool, error) {
+	status, statusErr := c.GetTaskStatus(ctx, taskID)
+	if statusErr != nil {
+		return false, fmt.Errorf("reconcile start task after %w: get task status: %w", cause, statusErr)
+	}
+	switch status {
+	case "running":
+		return true, nil
+	case "dispatched", "waiting_local_directory":
+		return false, nil
+	default:
+		return false, fmt.Errorf("reconcile start task after %w: task status is %q", cause, status)
+	}
+}
+
+// finalReconcileStartTask closes the narrow race where the original ambiguous
+// POST commits after the retry's last GET but before the retry reaches the
+// server. Only an already-ambiguous logical start uses this fallback: an
+// ordinary permanent 4xx must remain an error.
+func (c *Client) finalReconcileStartTask(ctx context.Context, taskID string, startErr error) error {
+	status, statusErr := c.GetTaskStatus(ctx, taskID)
+	if statusErr != nil {
+		return fmt.Errorf("final reconcile start task after %w: get task status: %w", startErr, statusErr)
+	}
+	if status == "running" {
+		return nil
+	}
+	return startErr
 }
 
 // MarkTaskWaitingLocalDirectory parks a freshly-dispatched task in the

--- a/server/internal/daemon/client.go
+++ b/server/internal/daemon/client.go
@@ -319,7 +319,43 @@ func (c *Client) ExtendTaskPrepareLease(ctx context.Context, runtimeID, taskID s
 }
 
 func (c *Client) StartTask(ctx context.Context, taskID string) error {
-	return c.postJSON(ctx, fmt.Sprintf("/api/daemon/tasks/%s/start", taskID), map[string]any{}, nil)
+	path := fmt.Sprintf("/api/daemon/tasks/%s/start", taskID)
+	var lastErr error
+	for attempt := 0; ; attempt++ {
+		err := c.postJSON(ctx, path, map[string]any{}, nil)
+		if err == nil {
+			return nil
+		}
+		lastErr = err
+		if !isTransientError(err) {
+			return err
+		}
+
+		// A transport error is ambiguous: the server may have committed the
+		// transition even when the daemon did not receive its response. Read
+		// the task state before considering another POST so this logical start
+		// never launches the agent twice.
+		status, statusErr := c.GetTaskStatus(ctx, taskID)
+		if statusErr != nil {
+			return fmt.Errorf("reconcile start task after %w: get task status: %w", err, statusErr)
+		}
+		switch status {
+		case "running":
+			return nil
+		case "dispatched", "waiting_local_directory":
+			// The server has confirmed that no start committed, so retrying the
+			// same task ID is safe. The SQL transition only accepts these states.
+		default:
+			return fmt.Errorf("reconcile start task after %w: task status is %q", err, status)
+		}
+
+		if attempt >= len(startTaskRetrySchedule) {
+			return lastErr
+		}
+		if sleepErr := retrySleep(ctx, startTaskRetrySchedule[attempt]); sleepErr != nil {
+			return lastErr
+		}
+	}
 }
 
 // MarkTaskWaitingLocalDirectory parks a freshly-dispatched task in the
@@ -845,6 +881,15 @@ var defaultTerminalRetrySchedule = []time.Duration{
 var skillBundleResolveRetrySchedule = []time.Duration{
 	500 * time.Millisecond,
 	2 * time.Second,
+}
+
+// startTaskRetrySchedule bounds recovery for an uncertain task-start callback.
+// Each retry is preceded by GetTaskStatus: another POST is allowed only after
+// the server confirms the task is still not running. Two backoffs mean at most
+// three POST attempts for one logical task start.
+var startTaskRetrySchedule = []time.Duration{
+	250 * time.Millisecond,
+	time.Second,
 }
 
 // retrySleep is the sleep used between retry attempts. Pulled into a package

--- a/server/internal/daemon/client_test.go
+++ b/server/internal/daemon/client_test.go
@@ -412,8 +412,8 @@ func TestStartTask_RetriesTLSHandshakeTimeoutAfterConfirmedNotStarted(t *testing
 	if got := startCalls.Load(); got != 2 {
 		t.Fatalf("start calls = %d, want 2", got)
 	}
-	if got := statusCalls.Load(); got != 1 {
-		t.Fatalf("status calls = %d, want 1", got)
+	if got := statusCalls.Load(); got != 2 {
+		t.Fatalf("status calls = %d, want 2 (initial reconciliation plus pre-retry check)", got)
 	}
 }
 
@@ -480,7 +480,7 @@ func TestStartTask_ExhaustedTransientRetries(t *testing.T) {
 	if got, want := startCalls.Load(), int32(len(startTaskRetrySchedule)+1); got != want {
 		t.Fatalf("start calls = %d, want %d", got, want)
 	}
-	if got, want := statusCalls.Load(), int32(len(startTaskRetrySchedule)+1); got != want {
+	if got, want := statusCalls.Load(), int32(2*len(startTaskRetrySchedule)+1); got != want {
 		t.Fatalf("status calls = %d, want %d", got, want)
 	}
 }
@@ -563,6 +563,106 @@ func TestStartTask_DoesNotRetryWhenReconciliationIsUnknown(t *testing.T) {
 	}
 	if got := startCalls.Load(); got != 1 {
 		t.Fatalf("start calls = %d, want 1; unknown status must prevent another POST", got)
+	}
+	if got := statusCalls.Load(); got != 1 {
+		t.Fatalf("status calls = %d, want 1", got)
+	}
+}
+
+func TestStartTask_LateCommitAfterPreRetryReconcileReturnsSuccess(t *testing.T) {
+	oldSleep := retrySleep
+	defer func() { retrySleep = oldSleep }()
+
+	var startCalls, statusCalls atomic.Int32
+	status := "dispatched"
+	retrySleep = func(context.Context, time.Duration) error { return nil }
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/daemon/tasks/task-1/start":
+			if startCalls.Add(1) == 2 {
+				// The original ambiguous request commits after this retry's
+				// immediately-prior GET but before its POST reaches the server.
+				status = "running"
+				w.WriteHeader(http.StatusBadRequest)
+				return
+			}
+			w.WriteHeader(http.StatusBadGateway)
+		case "/api/daemon/tasks/task-1/status":
+			statusCalls.Add(1)
+			_, _ = w.Write([]byte(`{"status":"` + status + `"}`))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	c := NewClient(srv.URL)
+	if err := c.StartTask(context.Background(), "task-1"); err != nil {
+		t.Fatalf("StartTask: %v", err)
+	}
+	if got := startCalls.Load(); got != 2 {
+		t.Fatalf("start calls = %d, want 2", got)
+	}
+	if got := statusCalls.Load(); got != 3 {
+		t.Fatalf("status calls = %d, want 3 (initial, pre-retry, final)", got)
+	}
+}
+
+func TestStartTask_WaitingLocalDirectoryAllowsRetry(t *testing.T) {
+	defer noSleepRetry(t)()
+
+	var startCalls, statusCalls atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/daemon/tasks/task-1/start":
+			if startCalls.Add(1) == 1 {
+				w.WriteHeader(http.StatusBadGateway)
+				return
+			}
+			w.WriteHeader(http.StatusOK)
+		case "/api/daemon/tasks/task-1/status":
+			statusCalls.Add(1)
+			_, _ = w.Write([]byte(`{"status":"waiting_local_directory"}`))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	c := NewClient(srv.URL)
+	if err := c.StartTask(context.Background(), "task-1"); err != nil {
+		t.Fatalf("StartTask: %v", err)
+	}
+	if got := startCalls.Load(); got != 2 {
+		t.Fatalf("start calls = %d, want 2", got)
+	}
+	if got := statusCalls.Load(); got != 2 {
+		t.Fatalf("status calls = %d, want 2", got)
+	}
+}
+
+func TestStartTask_TerminalStatusPreventsRetry(t *testing.T) {
+	var startCalls, statusCalls atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/daemon/tasks/task-1/start":
+			startCalls.Add(1)
+			w.WriteHeader(http.StatusBadGateway)
+		case "/api/daemon/tasks/task-1/status":
+			statusCalls.Add(1)
+			_, _ = w.Write([]byte(`{"status":"completed"}`))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	c := NewClient(srv.URL)
+	if err := c.StartTask(context.Background(), "task-1"); err == nil {
+		t.Fatal("StartTask succeeded for terminal task")
+	}
+	if got := startCalls.Load(); got != 1 {
+		t.Fatalf("start calls = %d, want 1", got)
 	}
 	if got := statusCalls.Load(); got != 1 {
 		t.Fatalf("status calls = %d, want 1", got)

--- a/server/internal/daemon/client_test.go
+++ b/server/internal/daemon/client_test.go
@@ -375,6 +375,200 @@ func TestPostJSONWithRetry_CtxCancelStopsRetries(t *testing.T) {
 	}
 }
 
+func TestStartTask_RetriesTLSHandshakeTimeoutAfterConfirmedNotStarted(t *testing.T) {
+	defer noSleepRetry(t)()
+
+	var startCalls, statusCalls atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/daemon/tasks/task-1/start":
+			if startCalls.Add(1) == 1 {
+				// Simulate a TLS timeout before the request reaches the server.
+				hijacker, ok := w.(http.Hijacker)
+				if !ok {
+					t.Fatal("ResponseWriter does not implement Hijacker")
+				}
+				conn, _, err := hijacker.Hijack()
+				if err != nil {
+					t.Fatalf("hijack connection: %v", err)
+				}
+				_ = conn.Close()
+				return
+			}
+			w.WriteHeader(http.StatusOK)
+		case "/api/daemon/tasks/task-1/status":
+			statusCalls.Add(1)
+			_, _ = w.Write([]byte(`{"status":"dispatched"}`))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	c := NewClient(srv.URL)
+	if err := c.StartTask(context.Background(), "task-1"); err != nil {
+		t.Fatalf("StartTask: %v", err)
+	}
+	if got := startCalls.Load(); got != 2 {
+		t.Fatalf("start calls = %d, want 2", got)
+	}
+	if got := statusCalls.Load(); got != 1 {
+		t.Fatalf("status calls = %d, want 1", got)
+	}
+}
+
+func TestStartTask_AmbiguousTransportErrorAfterCommitDoesNotDuplicateStart(t *testing.T) {
+	var startCalls, statusCalls atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/daemon/tasks/task-1/start":
+			startCalls.Add(1)
+			// The server commits start but the response is lost.
+			hijacker, ok := w.(http.Hijacker)
+			if !ok {
+				t.Fatal("ResponseWriter does not implement Hijacker")
+			}
+			conn, _, err := hijacker.Hijack()
+			if err != nil {
+				t.Fatalf("hijack connection: %v", err)
+			}
+			_ = conn.Close()
+		case "/api/daemon/tasks/task-1/status":
+			statusCalls.Add(1)
+			_, _ = w.Write([]byte(`{"status":"running"}`))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	c := NewClient(srv.URL)
+	if err := c.StartTask(context.Background(), "task-1"); err != nil {
+		t.Fatalf("StartTask: %v", err)
+	}
+	if got := startCalls.Load(); got != 1 {
+		t.Fatalf("start calls = %d, want 1; running reconciliation must prevent a duplicate start", got)
+	}
+	if got := statusCalls.Load(); got != 1 {
+		t.Fatalf("status calls = %d, want 1", got)
+	}
+}
+
+func TestStartTask_ExhaustedTransientRetries(t *testing.T) {
+	defer noSleepRetry(t)()
+
+	var startCalls, statusCalls atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/daemon/tasks/task-1/start":
+			startCalls.Add(1)
+			w.WriteHeader(http.StatusBadGateway)
+		case "/api/daemon/tasks/task-1/status":
+			statusCalls.Add(1)
+			_, _ = w.Write([]byte(`{"status":"dispatched"}`))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	c := NewClient(srv.URL)
+	err := c.StartTask(context.Background(), "task-1")
+	if err == nil || !isTransientError(err) {
+		t.Fatalf("StartTask error = %v, want exhausted transient error", err)
+	}
+	if got, want := startCalls.Load(), int32(len(startTaskRetrySchedule)+1); got != want {
+		t.Fatalf("start calls = %d, want %d", got, want)
+	}
+	if got, want := statusCalls.Load(), int32(len(startTaskRetrySchedule)+1); got != want {
+		t.Fatalf("status calls = %d, want %d", got, want)
+	}
+}
+
+func TestStartTask_PermanentErrorDoesNotRetryOrReconcile(t *testing.T) {
+	var startCalls, statusCalls atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/daemon/tasks/task-1/start":
+			startCalls.Add(1)
+			w.WriteHeader(http.StatusForbidden)
+		case "/api/daemon/tasks/task-1/status":
+			statusCalls.Add(1)
+			_, _ = w.Write([]byte(`{"status":"dispatched"}`))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	c := NewClient(srv.URL)
+	if err := c.StartTask(context.Background(), "task-1"); err == nil {
+		t.Fatal("StartTask succeeded on permanent error")
+	}
+	if got := startCalls.Load(); got != 1 {
+		t.Fatalf("start calls = %d, want 1", got)
+	}
+	if got := statusCalls.Load(); got != 0 {
+		t.Fatalf("status calls = %d, want 0", got)
+	}
+}
+
+func TestStartTask_NormalPathDoesNotReconcile(t *testing.T) {
+	var startCalls, statusCalls atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/daemon/tasks/task-1/start":
+			startCalls.Add(1)
+			w.WriteHeader(http.StatusOK)
+		case "/api/daemon/tasks/task-1/status":
+			statusCalls.Add(1)
+			_, _ = w.Write([]byte(`{"status":"running"}`))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	c := NewClient(srv.URL)
+	if err := c.StartTask(context.Background(), "task-1"); err != nil {
+		t.Fatalf("StartTask: %v", err)
+	}
+	if got := startCalls.Load(); got != 1 {
+		t.Fatalf("start calls = %d, want 1", got)
+	}
+	if got := statusCalls.Load(); got != 0 {
+		t.Fatalf("status calls = %d, want 0", got)
+	}
+}
+
+func TestStartTask_DoesNotRetryWhenReconciliationIsUnknown(t *testing.T) {
+	var startCalls, statusCalls atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/daemon/tasks/task-1/start":
+			startCalls.Add(1)
+			w.WriteHeader(http.StatusBadGateway)
+		case "/api/daemon/tasks/task-1/status":
+			statusCalls.Add(1)
+			w.WriteHeader(http.StatusServiceUnavailable)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	c := NewClient(srv.URL)
+	if err := c.StartTask(context.Background(), "task-1"); err == nil {
+		t.Fatal("StartTask succeeded with unknown reconciliation state")
+	}
+	if got := startCalls.Load(); got != 1 {
+		t.Fatalf("start calls = %d, want 1; unknown status must prevent another POST", got)
+	}
+	if got := statusCalls.Load(); got != 1 {
+		t.Fatalf("status calls = %d, want 1", got)
+	}
+}
+
 func TestDefaultTerminalRetrySchedule_MatchesAgreedPlan(t *testing.T) {
 	// MUL-2780 settled on a 5-step exponential backoff (4s, 8s, 16s, 32s, 64s).
 	// Pin it so a future "tidy this up" refactor can't silently flatten or


### PR DESCRIPTION
## Summary
- reconcile transient task-start transport errors through read-after-error status checks
- retry only after the same task remains unstarted; accept `running` as the prior start succeeding
- add TLS/transport, ambiguous-commit, permanent-error, cap, and normal-path regression coverage

## Verification
- `cd server && go test ./internal/daemon -count=1`
- `cd server && go build ./cmd/multica`

Closes KAP-1466