### PR TITLE
fix(selfhost): pass LOCAL_UPLOAD_* through to the backend container

### DIFF
--- a/docker-compose.selfhost.yml
+++ b/docker-compose.selfhost.yml
@@ -86,6 +86,17 @@ services:
       S3_USE_PATH_STYLE: ${S3_USE_PATH_STYLE:-}
       AWS_ACCESS_KEY_ID: ${AWS_ACCESS_KEY_ID:-}
       AWS_SECRET_ACCESS_KEY: ${AWS_SECRET_ACCESS_KEY:-}
+      # LocalStorage backend, used when S3_BUCKET is unset. LOCAL_UPLOAD_DIR is
+      # the in-container upload root and must match the volume mounted above
+      # (backend_uploads:/app/data/uploads), so leave the default unless you
+      # also retarget the volume. LOCAL_UPLOAD_BASE_URL is the externally-
+      # reachable origin for those uploads; with it empty, attachment URLs fall
+      # back to the authenticated /api/attachments/{id}/download path, which
+      # browsers and <video>/<audio>/PDF views cannot load as plain resources
+      # — set it to the backend's public origin to mint unauthenticated
+      # {baseURL}/uploads/{key} URLs instead. See #6324.
+      LOCAL_UPLOAD_DIR: ${LOCAL_UPLOAD_DIR:-/app/data/uploads}
+      LOCAL_UPLOAD_BASE_URL: ${LOCAL_UPLOAD_BASE_URL:-}
       ATTACHMENT_DOWNLOAD_MODE: ${ATTACHMENT_DOWNLOAD_MODE:-auto}
       ATTACHMENT_DOWNLOAD_URL_TTL: ${ATTACHMENT_DOWNLOAD_URL_TTL:-30m}
       CLOUDFRONT_DOMAIN: ${CLOUDFRONT_DOMAIN:-}

--- a/scripts/selfhost-config.test.sh
+++ b/scripts/selfhost-config.test.sh
@@ -46,6 +46,15 @@ require_config "$config" 'published: "9100"'
 require_config "$config" 'FRONTEND_ORIGIN: http://localhost:3100'
 require_config "$config" 'GOOGLE_REDIRECT_URI: http://localhost:3100/auth/callback'
 require_config "$config" 'MULTICA_APP_URL: http://localhost:3100'
+# LocalStorage env vars must reach the backend container — .env.example
+# documents them and NewLocalStorageFromEnv reads them, so the compose file
+# must forward them or a self-hoster's LOCAL_UPLOAD_* settings are silently
+# ignored (regression for #6324, same class as the SMTP_FROM_EMAIL fix in
+# #5322). Assert the keys are present in the rendered config rather than a
+# specific value: LOCAL_UPLOAD_DIR comes from .env.example and
+# LOCAL_UPLOAD_BASE_URL is empty by default, and compose may quote either.
+require_config "$config" 'LOCAL_UPLOAD_DIR'
+require_config "$config" 'LOCAL_UPLOAD_BASE_URL'
 
 for script in scripts/dev.sh scripts/check.sh; do
   if ! grep -Fq '. scripts/local-env.sh' "$script"; then


### PR DESCRIPTION
## Summary

`docker-compose.selfhost.yml`'s `backend` service never forwarded `LOCAL_UPLOAD_DIR` or `LOCAL_UPLOAD_BASE_URL` to the container, even though both are documented in `.env.example` and read by `NewLocalStorageFromEnv` (`server/internal/storage/local.go:43-44`). An operator who set them in `.env` had them silently ignored: the container always fell back to the code defaults, so `LOCAL_UPLOAD_BASE_URL` stayed empty and attachment URLs degraded to the authenticated `/api/attachments/{id}/download` path that browsers, `<video>`/`<audio>`, and the PDF preview cannot load as plain resources.

## Change

- Forward both `LOCAL_UPLOAD_DIR` and `LOCAL_UPLOAD_BASE_URL` from the backend `environment` block, defaulting `LOCAL_UPLOAD_DIR` to `/app/data/uploads` so it matches the existing `backend_uploads:/app/data/uploads` volume mount when the operator leaves it unset. `LOCAL_UPLOAD_BASE_URL` stays empty by default to preserve current behaviour; setting it to the backend's public origin is what makes `LocalStorage` mint unauthenticated `{baseURL}/uploads/{key}` URLs instead.
- Add a regression assertion in `scripts/selfhost-config.test.sh` (`require_config LOCAL_UPLOAD_DIR` / `LOCAL_UPLOAD_BASE_URL`) so the vars stay wired into the compose file.

Same class as the `SMTP_FROM_EMAIL` forwarding (#5322 / MUL-4460) and the `MULTICA_SLACK_SECRET_KEY` forwarding (MUL-3897).

Fixes #6324
