### PR TITLE
refactor(daemon): converge multi-thread fan-out cookbook into Comment Formatting pointer (MUL-5825)

### DIFF
--- a/server/internal/daemon/daemon_test.go
+++ b/server/internal/daemon/daemon_test.go
@@ -5091,10 +5091,17 @@ func TestBuildPromptSquadLeaderMultiThreadCarvesOutNoAction(t *testing.T) {
 	if scope < 0 {
 		t.Fatalf("leader multi-thread prompt missing the whole-block scope sentence\n---\n%s", prompt)
 	}
+	// Obligation strings track the converged fan-out block (MUL-5825). Pin
+	// ledger: "Post the replies in the order listed below" → the order rule
+	// merged into the targets header ("OLDEST thread first"); "For EACH
+	// thread above" → the embedded cookbook collapsed to the
+	// `## Comment Formatting` pointer plus the per-thread file delta
+	// ("DISTINCT body file per thread"). The assertion shape is unchanged:
+	// every obligation must sit AFTER the no_action scope sentence.
 	for _, obligation := range []string{
 		"multiple replies are required and correct",
-		"Post the replies in the order listed below",
-		"For EACH thread above",
+		"OLDEST thread first",
+		"DISTINCT body file per thread",
 	} {
 		idx := strings.Index(prompt, obligation)
 		if idx < 0 {

--- a/server/internal/daemon/execenv/reply_instructions.go
+++ b/server/internal/daemon/execenv/reply_instructions.go
@@ -221,12 +221,12 @@ type ThreadReplyTarget struct {
 	ParentID string
 }
 
-// BuildMultiThreadCommentReplyInstructions is the reply cookbook for a run whose
-// coalesced comments span MORE THAN ONE root thread (MUL-4348). It deliberately
-// overrides the general "post exactly one comment per run" guidance for this
-// specific run: three unrelated questions raised in three separate threads must
-// land as three in-thread answers, not one merged blob posted under a single
-// thread (or as a stray root comment).
+// BuildMultiThreadCommentReplyInstructions is the reply fan-out block for a run
+// whose coalesced comments span MORE THAN ONE root thread (MUL-4348). It
+// deliberately overrides the general "post exactly one comment per run"
+// guidance for this specific run: three unrelated questions raised in three
+// separate threads must land as three in-thread answers, not one merged blob
+// posted under a single thread (or as a stray root comment).
 //
 // The grouping is computed server-side, so same-thread follow-ups never reach
 // here — they collapse to a single target upstream and take the ordinary
@@ -234,6 +234,18 @@ type ThreadReplyTarget struct {
 // exactly one reply per listed thread and never more than one reply in the same
 // thread: the "multiple @mentions in one thread" case is already consolidated
 // before this instruction is emitted, so a per-thread fan-out cannot split it.
+//
+// The block carries only what is multi-thread-SPECIFIC: the fan-out
+// announcement + override, the posting order, the per-thread `--parent`
+// targets, and the one mechanical delta (a DISTINCT body file per thread).
+// The posting mechanism itself — body file → `--content-file` → cleanup, the
+// inline/`--content-stdin` bans, the `\n`-escape rule, and the OS-specific
+// cleanup command — lives once in the brief's `## Comment Formatting`; this
+// block used to restate all of it plus two example command pairs, triple-
+// writing the same cookbook for ~1KB extra per multi-thread turn (MUL-5825).
+// Dropping the embedded commands also removes the only OS-dependent text, so
+// the block no longer branches on runtimeGOOS: `## Comment Formatting` keeps
+// the OS split.
 //
 // Returns "" for fewer than two targets; callers keep the single-parent path.
 func BuildMultiThreadCommentReplyInstructions(issueID string, targets []ThreadReplyTarget, squadLeader bool) string {
@@ -246,35 +258,11 @@ func BuildMultiThreadCommentReplyInstructions(issueID string, targets []ThreadRe
 		targetLines += fmt.Sprintf("%d. thread %s → reply with `--parent %s`\n", i+1, tgt.ThreadID, tgt.ParentID)
 	}
 
-	// File-hygiene guidance mirrors buildCommentReplyInstructionsSlim, but the
-	// agent must use a DISTINCT body file per thread so one reply's content can
-	// never leak into another's.
-	var cookbook string
-	if runtimeGOOS == "windows" {
-		cookbook = fmt.Sprintf(
-			"For EACH thread above, write that reply's body to its own UTF-8 file with your file-write tool, then post it with `--content-file` (do NOT use inline `--content` or a `--content-stdin` HEREDOC — see ## Comment Formatting above for why). Use a DISTINCT file per thread (never reuse one file) and remove each after posting:\n\n"+
-				"    multica issue comment add %s --parent <thread-1-parent> --content-file ./reply-1.md\n"+
-				"    Remove-Item ./reply-1.md\n"+
-				"    multica issue comment add %s --parent <thread-2-parent> --content-file ./reply-2.md\n"+
-				"    Remove-Item ./reply-2.md\n\n",
-			issueID, issueID,
-		)
-	} else {
-		cookbook = fmt.Sprintf(
-			"For EACH thread above, write that reply's body to its own UTF-8 file with your file-write tool, then post it with `--content-file` (do NOT use inline `--content` or a `--content-stdin` HEREDOC — see ## Comment Formatting above for why). Use a DISTINCT file per thread (never reuse one file) and remove each after posting:\n\n"+
-				"    multica issue comment add %s --parent <thread-1-parent> --content-file ./reply-1.md\n"+
-				"    rm ./reply-1.md\n"+
-				"    multica issue comment add %s --parent <thread-2-parent> --content-file ./reply-2.md\n"+
-				"    rm ./reply-2.md\n\n",
-			issueID, issueID,
-		)
-	}
-
 	// Same carve-out as the single-thread cookbook (MUL-5442 #6493 review):
 	// the leader's no_action exit must not be contradicted by this later
 	// imperative, and the scope sentence must govern the ENTIRE fan-out
 	// block — every obligation below ("multiple replies are required", the
-	// posting order, the per-thread cookbook) sits under the "Otherwise" —
+	// posting order, the per-thread file rule) sits under the "Otherwise" —
 	// not just the first verb. Ordinary agents keep the unconditional form
 	// byte-for-byte.
 	lead := "This run coalesced comments from %d DISTINCT threads. Post ONE reply per thread"
@@ -282,12 +270,10 @@ func BuildMultiThreadCommentReplyInstructions(issueID string, targets []ThreadRe
 		lead = "This run coalesced comments from %d DISTINCT threads. **If your outcome is `no_action`, skip this ENTIRE fan-out block — post no replies at all and exit via `multica squad activity` as your leader rules direct; everything below applies only otherwise.** Otherwise, post ONE reply per thread"
 	}
 	return fmt.Sprintf(
-		lead+" — %d replies in total — each threaded under its own conversation. This OVERRIDES the general \"post exactly one comment per run\" guidance: for THIS run multiple replies are required and correct. Do NOT merge separate threads into a single comment, and do NOT post more than one reply in the same thread.\n\n"+
-			"Post the replies in the order listed below — OLDEST thread first, the newest (triggering) thread LAST — so they land in chronological order. Do NOT answer the newest/triggering comment first.\n\n"+
-			"Reply targets, in the order to post them (use the exact `--parent` for each — do NOT reuse `--parent` values from previous turns in this session):\n"+
+		lead+" — %d in total. This OVERRIDES the \"post exactly one comment per run\" rule: for THIS run multiple replies are required and correct. Do NOT merge separate threads into one comment or post twice in the same thread.\n\n"+
+			"Reply targets, in posting order — OLDEST thread first, the newest (triggering) thread LAST. Use the exact `--parent` for each; never reuse a `--parent` from an earlier turn:\n"+
 			"%s\n"+
-			"%s"+
-			"Do NOT write literal `\\n` escapes to simulate line breaks; each file preserves real newlines.\n",
-		len(targets), len(targets), targetLines, cookbook,
+			"Write and post each reply exactly as `## Comment Formatting` above directs, with ONE multi-thread delta: use a DISTINCT body file per thread (./reply-1.md, ./reply-2.md, …) so one reply's content can never leak into another's.\n",
+		len(targets), len(targets), targetLines,
 	)
 }

--- a/server/internal/daemon/execenv/runtime_config_test.go
+++ b/server/internal/daemon/execenv/runtime_config_test.go
@@ -1551,9 +1551,66 @@ func TestMultiThreadReplyInstructionsFanOut(t *testing.T) {
 		{ThreadID: "c3", ParentID: "c3"},
 	}, false)
 
-	for _, want := range []string{"3 DISTINCT threads", "Post ONE reply per thread", "--parent c1", "--parent c2", "--parent c3"} {
+	for _, want := range []string{
+		"3 DISTINCT threads",
+		"Post ONE reply per thread",
+		"OVERRIDES",
+		"--parent c1", "--parent c2", "--parent c3",
+		"OLDEST thread first",
+		// MUL-5825: the posting mechanism is a pointer at the brief's
+		// canonical section plus the one multi-thread-specific delta.
+		"`## Comment Formatting`",
+		"DISTINCT body file per thread",
+		"never reuse a `--parent` from an earlier turn",
+	} {
 		if !strings.Contains(out, want) {
 			t.Errorf("cross-thread instructions must contain %q, got:\n%s", want, out)
+		}
+	}
+
+	// Pin ledger (MUL-5825): the embedded file-operations cookbook was
+	// retired in favour of the `## Comment Formatting` pointer above — it
+	// triple-wrote the mechanism already carried by the brief and the
+	// single-thread cookbook (~1KB per multi-thread turn). These strings are
+	// the retired machinery; none may reappear in the fan-out block:
+	for _, banned := range []string{
+		"For EACH thread above",                // old cookbook opener
+		"UTF-8 file with your file-write tool", // restated mechanism
+		"multica issue comment add",            // embedded example commands
+		"--content-stdin",                      // restated HEREDOC ban
+		"rm ./reply-",                          // unix cleanup example
+		"Remove-Item",                          // windows cleanup example
+		"Do NOT write literal",                 // restated \n-escape rule
+	} {
+		if strings.Contains(out, banned) {
+			t.Errorf("fan-out block re-grew retired cookbook text %q (mechanism lives in ## Comment Formatting — MUL-5825), got:\n%s", banned, out)
+		}
+	}
+}
+
+// TestMultiThreadReplyInstructionsOSInvariant pins that the fan-out block is
+// byte-identical across host OSes (MUL-5825). The only OS-dependent text was
+// the embedded cleanup command pair (`rm` vs `Remove-Item`), which left with
+// the cookbook; the OS split now lives solely in the brief's
+// `## Comment Formatting`. If this fails, OS-specific mechanism text crept
+// back into the block — move it to the brief instead.
+//
+// Not parallel: mutates the package-level runtimeGOOS.
+func TestMultiThreadReplyInstructionsOSInvariant(t *testing.T) {
+	saved := runtimeGOOS
+	t.Cleanup(func() { runtimeGOOS = saved })
+
+	targets := []ThreadReplyTarget{
+		{ThreadID: "c1", ParentID: "c1"},
+		{ThreadID: "c2", ParentID: "c2"},
+	}
+	for _, leader := range []bool{false, true} {
+		runtimeGOOS = "linux"
+		linux := BuildMultiThreadCommentReplyInstructions("55555555-6666-7777-8888-999999999999", targets, leader)
+		runtimeGOOS = "windows"
+		windows := BuildMultiThreadCommentReplyInstructions("55555555-6666-7777-8888-999999999999", targets, leader)
+		if linux != windows {
+			t.Errorf("fan-out block (leader=%v) must be OS-invariant\nlinux:\n%s\nwindows:\n%s", leader, linux, windows)
 		}
 	}
 }

--- a/server/internal/daemon/prompt_test.go
+++ b/server/internal/daemon/prompt_test.go
@@ -1156,6 +1156,16 @@ func TestBuildCommentPromptCrossThreadFansOutReplies(t *testing.T) {
 	if strings.Contains(out, "always use the trigger comment ID below") {
 		t.Errorf("cross-thread prompt must not emit the single-parent reply cookbook, got:\n%s", out)
 	}
+	// MUL-5825: the fan-out block points at the brief's `## Comment
+	// Formatting` for the posting mechanism instead of restating it, so the
+	// assembled cross-thread prompt carries no `comment add` example commands
+	// at all — the `--parent` targets plus the pointer are the whole recipe.
+	if strings.Contains(out, "multica issue comment add") {
+		t.Errorf("cross-thread prompt re-grew embedded comment-add commands (mechanism lives in ## Comment Formatting — MUL-5825), got:\n%s", out)
+	}
+	if !strings.Contains(out, "`## Comment Formatting`") {
+		t.Errorf("cross-thread prompt must point at the brief's Comment Formatting mechanism, got:\n%s", out)
+	}
 
 	// Chronological ordering (MUL-4348 test-round-2 problem #1): replies must be
 	// posted oldest thread first, the newest (triggering) thread last — so the


### PR DESCRIPTION
## Summary

MUL-5825 (split from MUL-5442): when a run coalesces comments from ≥2 root threads, the per-turn message emits the fan-out block from `BuildMultiThreadCommentReplyInstructions`. That block embedded a full file-operations cookbook — body file → `--content-file` → cleanup, the inline `--content` / `--content-stdin` HEREDOC bans, the `\n`-escape rule, and two complete example command pairs — triple-writing the mechanism already carried by the brief's `## Comment Formatting` and the single-thread cookbook.

The block now keeps only what is multi-thread-SPECIFIC and points at `## Comment Formatting` for the mechanism:

- fan-out announcement (N replies) + the OVERRIDE of the "post exactly one comment per run" rule
- posting order (OLDEST thread first, triggering thread LAST), merged into the targets header
- the per-thread `--parent` target list (+ the no-reuse-from-earlier-turns rule)
- the one mechanical delta: a DISTINCT body file per thread (`./reply-1.md`, `./reply-2.md`, …)
- the squad leader's whole-block `no_action` scope sentence, byte-for-byte the #6493 shape

Dropping the embedded example commands removes the only OS-dependent text (`rm` vs `Remove-Item`), so the windows/unix cookbook variants collapse and the block no longer branches on `runtimeGOOS` — the OS split lives solely in the brief's `## Comment Formatting`.

## Measured (before → after)

2-thread, 36-char-UUID fixture, measured on this branch's base and head:

| Variant | Before | After | Δ |
|---|---:|---:|---:|
| ordinary, linux/darwin | 1,657B | 919B | −738B |
| ordinary, windows | 1,675B | 919B | −756B |
| leader, linux/darwin | 1,870B | 1,132B | −738B |
| leader, windows | 1,888B | 1,132B | −756B |

Single-thread cookbook (untouched, for reference): 478B linux / 536B windows. The charter's ~650B target assumed trimming the announcement/override wording too; I kept those semantics essentially verbatim (they are the MUL-4348 behavioural core and carry existing pins), and the two UUID target lines are ~220B of irreducible payload — 919B is the floor without cutting semantics the charter says to preserve. Net per coalesced multi-thread turn: **≈ −740–760B**. Frequency note: only coalesced cross-thread runs emit this block — low-frequency, low-risk.

Cache impact: none. The block is per-turn only; the brief renders byte-identically before/after (`TestInjectRuntimeConfigByteIdenticalAcrossTriggers` and `TestPerRunCommentContextStaysOutOfBrief` unchanged and green).

## Pin discipline

Retained as-is:
- ordinary unconditional form: `. Post ONE reply per thread` present for ordinary, absent for leader; leader-leak guards on ordinary output (`daemon_test.go`)
- leader scope ordering: every obligation asserted to sit AFTER `skip this ENTIRE fan-out block` — assertion shape unchanged, obligation strings track the new text (ledger comment records the mapping: "Post the replies in the order listed below" → "OLDEST thread first"; "For EACH thread above" → "DISTINCT body file per thread")
- cross-thread end-to-end pins: `3 DISTINCT threads`, `OVERRIDES`, `OLDEST thread first`, `--parent c1/c2/c3` oldest-first index ordering, single-parent cookbook absence

New guards:
- negative guards on the retired cookbook text in the block test (`For EACH thread above`, `UTF-8 file with your file-write tool`, `multica issue comment add`, `--content-stdin`, `rm ./reply-`, `Remove-Item`, `Do NOT write literal`) with a ledger comment
- assembled-prompt guard: the cross-thread per-turn prompt carries NO `multica issue comment add` example command at all, and must carry the `## Comment Formatting` pointer
- `TestMultiThreadReplyInstructionsOSInvariant` (non-parallel, mutates `runtimeGOOS`): linux and windows renders byte-equal for both ordinary and leader — pins the windows/unix convergence

## Verification

- `go test ./internal/daemon/... -count=1` — all green (daemon 44.9s, execenv 5.9s, repocache 3.3s)
- `go vet ./internal/daemon/...`, `go build ./...`, `gofmt`, `git diff --check` — clean
- Before/after bytes measured with a throwaway test harness on the same fixture (not committed)
