### PR TITLE
MUL-5844 fix(agent): tolerate coarse Kimi wire log mtimes

### DIFF
--- a/server/pkg/agent/kimi.go
+++ b/server/pkg/agent/kimi.go
@@ -578,11 +578,15 @@ func scanKimiSessionUsage(scan kimiUsageScan) map[string]TokenUsage {
 	}
 
 	usage := make(map[string]TokenUsage)
+	// Some filesystems round mtimes down to whole seconds. Compare against a
+	// cutoff at the same precision so a log written during this turn is not
+	// discarded before its authoritative per-record timestamps are checked.
+	mtimeCutoff := scan.startTime.Truncate(time.Second)
 	for _, path := range kimiSessionWireLogs(root, scan.sessionID) {
-		// A wire log untouched since before the turn began belongs to an
-		// earlier run of a resumed session; billing it would re-charge
-		// tokens the previous task already reported.
-		if info, err := os.Stat(path); err != nil || info.ModTime().Before(scan.startTime) {
+		// A wire log clearly untouched since before the turn began belongs to
+		// an earlier run of a resumed session. The record-level filter below
+		// remains the authority at the turn boundary.
+		if info, err := os.Stat(path); err != nil || info.ModTime().Before(mtimeCutoff) {
 			continue
 		}
 		accumulateKimiWireUsage(usage, path, scan)

--- a/server/pkg/agent/kimi_test.go
+++ b/server/pkg/agent/kimi_test.go
@@ -829,10 +829,16 @@ func TestScanKimiSessionUsageSkipsPriorRunOnResume(t *testing.T) {
 
 	home := t.TempDir()
 	turnStart := time.Now()
-	writeKimiWireLog(t, home, "session_r", "main",
+	path := writeKimiWireLog(t, home, "session_r", "main",
 		kimiWireRecordLineAt(turnStart.Add(-time.Hour), 5000, 500, 9000, 0), // previous task
 		kimiWireRecordLineAt(turnStart.Add(time.Second), 120, 12, 340, 0),   // this task
 	)
+	// Keep this record-boundary test independent of filesystem timestamp
+	// precision. The untouched-log mtime gate is covered separately above.
+	touchedAt := turnStart.Add(time.Second)
+	if err := os.Chtimes(path, touchedAt, touchedAt); err != nil {
+		t.Fatalf("chtimes: %v", err)
+	}
 
 	usage := kimiScanTotal(kimiUsageScan{startTime: turnStart, kimiHome: home, sessionID: "session_r", resumed: true, fallbackModel: "unknown"})
 

--- a/server/pkg/agent/kimi_test.go
+++ b/server/pkg/agent/kimi_test.go
@@ -661,7 +661,7 @@ func TestScanKimiSessionUsageSkipsLogsUntouchedSinceStart(t *testing.T) {
 		t.Fatalf("chtimes: %v", err)
 	}
 
-	usage := kimiScanTotal(kimiUsageScan{startTime: time.Now().Add(-time.Minute), kimiHome: home, sessionID: "session_old", fallbackModel: "unknown"})
+	usage := kimiScanTotal(kimiUsageScan{startTime: time.Now().Add(-time.Minute), kimiHome: home, sessionID: "session_old", resumed: true, fallbackModel: "unknown"})
 	if acpTokenUsagePresent(usage) {
 		t.Fatalf("re-billed a log from before this turn: %+v", usage)
 	}
@@ -828,15 +828,16 @@ func TestScanKimiSessionUsageSkipsPriorRunOnResume(t *testing.T) {
 	t.Parallel()
 
 	home := t.TempDir()
-	turnStart := time.Now()
+	turnStart := time.Now().Truncate(time.Second).Add(500 * time.Millisecond)
 	path := writeKimiWireLog(t, home, "session_r", "main",
 		kimiWireRecordLineAt(turnStart.Add(-time.Hour), 5000, 500, 9000, 0), // previous task
 		kimiWireRecordLineAt(turnStart.Add(time.Second), 120, 12, 340, 0),   // this task
 	)
-	// Keep this record-boundary test independent of filesystem timestamp
-	// precision. The untouched-log mtime gate is covered separately above.
-	touchedAt := turnStart.Add(time.Second)
-	if err := os.Chtimes(path, touchedAt, touchedAt); err != nil {
+	// Simulate a filesystem that stores mtimes at one-second precision: the
+	// log was touched during this turn, but its rounded mtime precedes the
+	// sub-second turn boundary.
+	coarseMtime := turnStart.Truncate(time.Second)
+	if err := os.Chtimes(path, coarseMtime, coarseMtime); err != nil {
 		t.Fatalf("chtimes: %v", err)
 	}
 


### PR DESCRIPTION
## What does this PR do?

Prevents Kimi wire-log usage from being dropped when a filesystem rounds a freshly written log's mtime below the sub-second task start time.

`scanKimiSessionUsage` previously rejected the entire log before reading its records whenever `mtime < startTime`. This happened intermittently in GitHub Actions and returned all-zero usage. The same comparison is on the production billing fallback path, so stabilizing only the test would have hidden a real undercount risk.

The fix rounds the mtime cutoff to whole-second precision. The mtime check remains a fast path for logs that are clearly stale, while each `usage.record` timestamp remains authoritative for deciding whether a record belongs to the current turn. Production protocols and data formats are unchanged.

Observed in:

- upstream/main run: https://github.com/multica-ai/multica/actions/runs/31103837427
- unrelated PR run: https://github.com/multica-ai/multica/actions/runs/31136852047

## Related Issue

No issue filed; this is a focused follow-up to a verified upstream CI failure and production-path undercount risk.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Refactor / code improvement (no behavior change)
- [ ] Documentation update
- [x] Tests (adding or improving test coverage)
- [ ] CI / infrastructure

## Changes Made

- Update `server/pkg/agent/kimi.go` to compare wire-log mtimes against a whole-second cutoff before record-level filtering.
- Update `TestScanKimiSessionUsageSkipsPriorRunOnResume` to deterministically simulate a coarse filesystem mtime and verify current-turn usage is retained without rebilling the prior turn.
- Mark the untouched-log test as a resumed scan so its setup matches the production lifecycle it documents.

## How to Test

1. On the previous production implementation, run `go test ./pkg/agent -run '^TestScanKimiSessionUsageSkipsPriorRunOnResume$' -count=1` from `server/`; the regression test returns all-zero usage and fails.
2. On this branch, run `go test ./pkg/agent -run '^TestScanKimiSessionUsageSkipsPriorRunOnResume$' -count=500`.
3. Run `go test ./pkg/agent -run '^TestScanKimiSessionUsage' -count=100`.
4. Run `go test -race ./pkg/agent -run '^TestScanKimiSessionUsage' -count=20`.
5. Run `go test ./pkg/agent -run '^TestKimiBackendReportsUsageFromWireLog$' -count=50` and `go vet ./pkg/agent`.

Local results:

- Regression test against the prior implementation: failed with all-zero usage as expected.
- Target test, 500 repetitions: passed.
- Kimi usage scan test group, 100 repetitions: passed.
- Kimi usage scan test group under the race detector, 20 repetitions: passed.
- Wire-log backend integration test, 50 repetitions: passed.
- `go vet ./pkg/agent`: passed.
- A previous full `server/pkg/agent` run encountered unrelated pre-existing ACP timeout-test failures under local parallel load; the relevant tests above and the prior PR revision's GitHub Actions backend job passed.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have run the relevant tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] If this change affects the UI, I have included before/after screenshots (not applicable)
- [x] I have updated relevant documentation to reflect my changes (not applicable)
- [x] If I added a new runtime / coding tool / UI tab, I synced the change to landing copy and relevant docs (not applicable)
- [x] If this PR touches Chinese product copy, I checked it against the terminology conventions (not applicable)
- [x] I have considered and documented any risks above
- [x] I will address all reviewer comments before requesting merge

Risk is limited to scanning logs whose mtimes fall within the same whole second as the task start. Old timed records are still rejected by their per-record timestamps, and untimed records on resumed sessions are still dropped. The trade-off is at most an extra scan of a near-boundary log rather than silently losing current-turn usage.

## AI Disclosure

**AI tool used:** Codex

**Prompt / approach:** Investigated the failing GitHub Actions job, reproduced the all-zero result by setting a coarse mtime, traced the production fallback's ownership and duplicate-billing guards, then made the mtime optimization precision-aware while retaining record timestamps as the billing authority.

## Screenshots (optional)

Not applicable.
