### PR TITLE
docs(wecom): document WeCom as a channel and name its code owners (MUL-5226)

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ issue — so nobody reconstructs context, and nothing ships without a human sayi
 - **[Workspaces](https://multica.ai/docs/workspaces) →** Separate agents, issues, and settings per team.
 - **[Roles](https://multica.ai/docs/members-roles) and [access scopes](https://multica.ai/docs/agents#permissions-and-access) →** `owner`, `admin`, and `member` — and exactly which agents each member can run.
 - **[Security model](https://multica.ai/docs/security-model) →** What an agent can reach, and what it can't.
-- **[Slack, Lark, and DingTalk](https://multica.ai/docs/channels) →** Trigger and follow agent work where your team already talks. DingTalk is community-maintained.
+- **[Slack, Lark, DingTalk, and WeCom](https://multica.ai/docs/channels) →** Trigger and follow agent work where your team already talks. DingTalk and WeCom are community-maintained.
 - **[Web, desktop, and mobile](https://multica.ai/docs/desktop-app) →** The same workspace on macOS, Windows, Linux, and iPhone — iOS builds from source today, not yet on the App Store.
 - **[CLI and API](https://multica.ai/docs/cli) →** Every surface is scriptable. Agents drive Multica through the same CLI you do.
 

--- a/apps/docs/content/docs/channels.ja.mdx
+++ b/apps/docs/content/docs/channels.ja.mdx
@@ -1,27 +1,31 @@
 ---
 title: チャット連携
-description: Multica のエージェントを Feishu、Lark、Slack、DingTalk に接続し、チームが普段使っているチャットツールから利用する方法を説明します。
+description: Multica のエージェントを Feishu、Lark、Slack、DingTalk、WeCom に接続し、チームが普段使っているチャットツールから利用する方法を説明します。
 ---
 
 import { Callout } from "fumadocs-ui/components/callout";
 
 チャット連携を使うと、Multica を開かなくても、エージェントへの質問、グループチャットでの @メンション、チャット画面からのイシュー作成ができます。
 
-現在は Feishu/Lark、Slack、DingTalk に対応しています。セッション、ユーザー識別、実行の仕組みは共通ですが、インストール方法が異なります。
+現在は Feishu/Lark、Slack、DingTalk、WeCom に対応しています。セッション、ユーザー識別、実行の仕組みは共通ですが、インストール方法が異なります。
 
 ## プラットフォームを選ぶ
 
-| | Feishu / Lark | Slack | DingTalk |
-|---|---|---|---|
-| インストール | Multica で QR コードを生成し、Feishu でスキャンして認証 | Slack でアプリを作成し、2 つのトークンを Multica に入力 | 社内アプリと Stream モードのロボットを作成し、AppKey と AppSecret を Multica に入力 |
-| エージェントとの DM | 対応 | 対応 | 対応 |
-| グループまたはチャンネル | Bot を @メンションするとトリガー | Bot を @メンションするとトリガー | Bot を @メンションするとトリガー |
-| イシューの作成 | `/issue` メッセージコマンド。入力内容からそのまま作成 | `/issue` スラッシュコマンド。エージェントが説明を整理してから作成 | `/issue` メッセージコマンド。入力内容からそのまま作成 |
-| 接続方式 | プラットフォームの常時接続 | Socket Mode | Stream モード |
+| | Feishu / Lark | Slack | DingTalk | WeCom |
+|---|---|---|---|---|
+| インストール | Multica で QR コードを生成し、Feishu でスキャンして認証 | Slack でアプリを作成し、2 つのトークンを Multica に入力 | 社内アプリと Stream モードのロボットを作成し、AppKey と AppSecret を Multica に入力 | WeCom 管理コンソールで常時接続を有効にしたスマートボットを作成し、Bot ID と Secret を Multica に入力 |
+| エージェントとの DM | 対応 | 対応 | 対応 | 対応 |
+| グループまたはチャンネル | Bot を @メンションするとトリガー | Bot を @メンションするとトリガー | Bot を @メンションするとトリガー | Bot を @メンションするとトリガー |
+| イシューの作成 | `/issue` メッセージコマンド。入力内容からそのまま作成 | `/issue` スラッシュコマンド。エージェントが説明を整理してから作成 | `/issue` メッセージコマンド。入力内容からそのまま作成 | `/issue` メッセージコマンド。入力内容からそのまま作成 |
+| 接続方式 | プラットフォームの常時接続 | Socket Mode | Stream モード | プラットフォームの常時接続 |
 
 新規接続は現在、中国本土版の Feishu でのみ利用できます。既存の国際版 Lark 接続は、引き続き利用および管理できます。
 
 各 Bot は 1 つの Multica エージェントに紐づきます。同じチャットプラットフォームで複数のエージェントを使う場合は、エージェントごとに Bot を接続してください。
+
+DingTalk と WeCom はコミュニティメンテナンスです。各リリースに含まれますが、公式サポート SLA はありません。問題は [GitHub issues](https://github.com/multica-ai/multica/issues) で報告してください。
+
+WeCom が現在扱えるのはテキストメッセージのみです。音声、画像、ファイルのメッセージにはその旨の短い返信が返り、エージェントには渡されません。
 
 詳しい手順:
 
@@ -44,6 +48,7 @@ Bot を @メンションしていないチャンネルメッセージは、エ�
 - Feishu/Lark はチャットごとにセッションを分けます。同じチャットの後続メッセージは同じセッションを継続します。
 - Slack は DM をチャンネルごとに分けます。チャンネル内では、スレッドごとに独立したセッションが保持されます。
 - DingTalk は conversation ごとにセッションを分けます。DM とグループはそれぞれのセッションを継続します。
+- WeCom はチャットごとにセッションを分けます。DM とグループチャットはそれぞれのセッションを継続します。
 
 チャンネルで追加の依頼を送る場合も、Bot を再度 @メンションする必要があります。エージェントが受け取るのは自分宛てのメッセージだけで、チャンネルの履歴全体を自動的に読み取ることはありません。
 
@@ -71,9 +76,12 @@ Multica がエージェントを実行するのは、アカウント連携が完
 MULTICA_LARK_SECRET_KEY=<base64-encoded 32-byte key>
 MULTICA_SLACK_SECRET_KEY=<base64-encoded 32-byte key>
 MULTICA_DINGTALK_SECRET_KEY=<base64-encoded 32-byte key>
+MULTICA_WECOM_SECRET_KEY=<base64-encoded 32-byte key>
 ```
 
 これらのキーは、保存された Bot の認証情報を暗号化します。生成、保管、ローテーションの方法は[環境変数](/environment-variables)を参照してください。Multica Cloud ではすでに設定済みです。
+
+WeCom はさらにバックエンドを**単一レプリカ**で運用する必要があります。送信経路が 1 つのプロセスが保持する WebSocket だけのため、他のレプリカで生成された返信は破棄されます。レプリカ間の送信ルーティングが実装されるまで、WeCom を有効にしたバックエンドは多重化しないでください。
 
 ## 次のステップ
 

--- a/apps/docs/content/docs/channels.ko.mdx
+++ b/apps/docs/content/docs/channels.ko.mdx
@@ -1,27 +1,31 @@
 ---
 title: 채팅 연동
-description: Multica 에이전트를 Feishu, Lark, Slack 또는 DingTalk에 연결해 팀이 이미 사용하는 채팅 도구에서 활용합니다.
+description: Multica 에이전트를 Feishu, Lark, Slack, DingTalk 또는 WeCom에 연결해 팀이 이미 사용하는 채팅 도구에서 활용합니다.
 ---
 
 import { Callout } from "fumadocs-ui/components/callout";
 
 채팅 연동을 사용하면 팀이 Multica를 열지 않고도 에이전트에게 바로 질문하고, 그룹 채팅에서 @멘션하거나, 채팅 창에서 이슈를 만들 수 있습니다.
 
-현재 Feishu/Lark, Slack, DingTalk를 지원합니다. 같은 대화, 신원, 실행 메커니즘을 사용하지만 설치 방법은 다릅니다.
+현재 Feishu/Lark, Slack, DingTalk, WeCom을 지원합니다. 같은 대화, 신원, 실행 메커니즘을 사용하지만 설치 방법은 다릅니다.
 
 ## 플랫폼 선택
 
-| | Feishu / Lark | Slack | DingTalk |
-|---|---|---|---|
-| 설치 방법 | Multica에서 QR 코드를 만든 뒤 Feishu로 스캔해 승인 | Slack에서 app을 만든 뒤 두 token을 Multica에 입력 | 사내 app과 Stream 모드 로봇을 만든 뒤 AppKey와 AppSecret을 Multica에 입력 |
-| 에이전트와 DM | 지원 | 지원 | 지원 |
-| 그룹 채팅 또는 채널 | Bot을 @멘션하면 트리거 | Bot을 @멘션하면 트리거 | Bot을 @멘션하면 트리거 |
-| 이슈 만들기 | `/issue` 메시지 명령으로 입력 내용을 바로 생성 | `/issue` slash 명령으로 에이전트가 설명을 정리한 뒤 생성 | `/issue` 메시지 명령으로 입력 내용을 바로 생성 |
-| 연결 방식 | 플랫폼 장기 연결 | Socket Mode | Stream 모드 |
+| | Feishu / Lark | Slack | DingTalk | WeCom |
+|---|---|---|---|---|
+| 설치 방법 | Multica에서 QR 코드를 만든 뒤 Feishu로 스캔해 승인 | Slack에서 app을 만든 뒤 두 token을 Multica에 입력 | 사내 app과 Stream 모드 로봇을 만든 뒤 AppKey와 AppSecret을 Multica에 입력 | WeCom 관리자 콘솔에서 장기 연결을 켠 스마트 봇을 만든 뒤 Bot ID와 Secret을 Multica에 입력 |
+| 에이전트와 DM | 지원 | 지원 | 지원 | 지원 |
+| 그룹 채팅 또는 채널 | Bot을 @멘션하면 트리거 | Bot을 @멘션하면 트리거 | Bot을 @멘션하면 트리거 | Bot을 @멘션하면 트리거 |
+| 이슈 만들기 | `/issue` 메시지 명령으로 입력 내용을 바로 생성 | `/issue` slash 명령으로 에이전트가 설명을 정리한 뒤 생성 | `/issue` 메시지 명령으로 입력 내용을 바로 생성 | `/issue` 메시지 명령으로 입력 내용을 바로 생성 |
+| 연결 방식 | 플랫폼 장기 연결 | Socket Mode | Stream 모드 | 플랫폼 장기 연결 |
 
 새 연결은 현재 중국 본토 버전 Feishu에서만 만들 수 있습니다. 기존 국제 버전 Lark 연결은 계속 사용하고 관리할 수 있습니다.
 
 Bot 하나는 Multica 에이전트 하나에 연결됩니다. 같은 채팅 플랫폼에서 여러 에이전트를 사용하려면 각각 별도의 Bot을 연결해야 합니다.
+
+DingTalk과 WeCom은 커뮤니티에서 유지 관리합니다. 모든 릴리스에 포함되지만 공식 지원 SLA는 없습니다. 문제는 [GitHub issues](https://github.com/multica-ai/multica/issues)에 알려주세요.
+
+WeCom은 현재 텍스트 메시지만 처리합니다. 음성, 이미지, 파일 메시지에는 안내 문구만 회신하며 에이전트로 전달하지 않습니다.
 
 자세한 단계는 다음 문서를 참고하세요.
 
@@ -44,6 +48,7 @@ Bot을 @멘션하지 않은 채널 메시지는 에이전트를 트리거하지 
 - Feishu/Lark는 채팅별로 대화를 구분하며 같은 채팅의 후속 메시지는 기존 대화를 이어갑니다.
 - Slack DM은 채널별로 구분하고, 채널 안에서는 각 thread가 별도 대화를 저장합니다.
 - DingTalk는 conversation별로 대화를 구분하며 각 DM 또는 그룹이 자체 대화를 이어갑니다.
+- WeCom은 채팅별로 대화를 구분하며 각 DM 또는 그룹 채팅이 자체 대화를 이어갑니다.
 
 채널에서 후속 질문을 할 때도 Bot을 다시 @멘션해야 합니다. 에이전트는 자신에게 보낸 메시지만 받으며 전체 채널 기록을 자동으로 읽지 않습니다.
 
@@ -71,9 +76,12 @@ Bot을 @멘션하지 않은 채널 메시지는 에이전트를 트리거하지 
 MULTICA_LARK_SECRET_KEY=<base64로 인코딩한 32바이트 키>
 MULTICA_SLACK_SECRET_KEY=<base64로 인코딩한 32바이트 키>
 MULTICA_DINGTALK_SECRET_KEY=<base64로 인코딩한 32바이트 키>
+MULTICA_WECOM_SECRET_KEY=<base64로 인코딩한 32바이트 키>
 ```
 
 이 키는 Bot 자격 증명을 암호화해 저장하는 데 사용됩니다. 생성, 보관, 교체 방법은 [환경 변수](/environment-variables)를 참고하세요. Multica Cloud에는 이미 설정되어 있습니다.
+
+WeCom은 추가로 백엔드를 **단일 레플리카**로 운영해야 합니다. 발신 경로가 한 프로세스가 보유한 WebSocket뿐이어서 다른 레플리카에서 생성된 응답은 폐기됩니다. 레플리카 간 발신 라우팅이 구현되기 전까지 WeCom을 켠 백엔드는 다중화하지 마세요.
 
 ## 다음 단계
 

--- a/apps/docs/content/docs/channels.mdx
+++ b/apps/docs/content/docs/channels.mdx
@@ -1,27 +1,31 @@
 ---
 title: Chat integrations
-description: Connect Multica agents to Feishu, Lark, Slack, or DingTalk and use them from the chat tools your team already uses.
+description: Connect Multica agents to Feishu, Lark, Slack, DingTalk, or WeCom and use them from the chat tools your team already uses.
 ---
 
 import { Callout } from "fumadocs-ui/components/callout";
 
 Chat integrations let the team ask an agent questions, @-mention it in a group chat, or create issues from the chat window — without opening Multica.
 
-Feishu/Lark, Slack, and DingTalk are supported today. They share the same session, identity, and execution mechanics but install differently.
+Feishu/Lark, Slack, DingTalk, and WeCom are supported today. They share the same session, identity, and execution mechanics but install differently.
 
 ## Choose a platform
 
-| | Feishu / Lark | Slack | DingTalk |
-|---|---|---|---|
-| Installation | Generate a QR code in Multica and authorize by scanning it with Feishu | Create an app in Slack, then paste two tokens into Multica | Create an internal app and Stream-mode robot, then paste its AppKey and AppSecret into Multica |
-| DM the agent | Supported | Supported | Supported |
-| Groups or channels | Triggered by @-mentioning the Bot | Triggered by @-mentioning the Bot | Triggered by @-mentioning the Bot |
-| Create issues | `/issue` message command; creates the issue from your input as-is | `/issue` slash command; the agent writes up the description before creating | `/issue` message command; creates the issue from your input as-is |
-| Connection | Platform long connection | Socket Mode | Stream mode |
+| | Feishu / Lark | Slack | DingTalk | WeCom |
+|---|---|---|---|---|
+| Installation | Generate a QR code in Multica and authorize by scanning it with Feishu | Create an app in Slack, then paste two tokens into Multica | Create an internal app and Stream-mode robot, then paste its AppKey and AppSecret into Multica | Create a smart bot with the long connection enabled in the WeCom admin console, then paste its Bot ID and Secret into Multica |
+| DM the agent | Supported | Supported | Supported | Supported |
+| Groups or channels | Triggered by @-mentioning the Bot | Triggered by @-mentioning the Bot | Triggered by @-mentioning the Bot | Triggered by @-mentioning the Bot |
+| Create issues | `/issue` message command; creates the issue from your input as-is | `/issue` slash command; the agent writes up the description before creating | `/issue` message command; creates the issue from your input as-is | `/issue` message command; creates the issue from your input as-is |
+| Connection | Platform long connection | Socket Mode | Stream mode | Platform long connection |
 
 New connections are currently open only for mainland-China Feishu; existing international Lark connections keep working and can still be managed.
 
 Each Bot is bound to one Multica agent. To use several agents on the same chat platform, connect a separate Bot for each.
+
+DingTalk and WeCom are community-maintained: they ship in every release, but carry no official support SLA. Report problems in [GitHub issues](https://github.com/multica-ai/multica/issues).
+
+WeCom handles text messages today. Voice, image, and file messages get a short reply explaining that, and are not passed to the agent.
 
 Step-by-step guides:
 
@@ -44,6 +48,7 @@ Channel messages that don't @-mention the Bot never trigger the agent and are no
 - Feishu/Lark separates sessions by chat; later messages in the same chat continue the same session.
 - Slack separates DMs by channel; in a channel, each thread holds its own session.
 - DingTalk separates sessions by conversation; each DM or group continues its own session.
+- WeCom separates sessions by chat; each DM or group chat continues its own session.
 
 Follow-ups in a channel still need a fresh @-mention. The agent only receives messages addressed to it — it never reads the whole channel history automatically.
 
@@ -71,9 +76,12 @@ A self-hosted deployment must configure a 32-byte encryption key for each platfo
 MULTICA_LARK_SECRET_KEY=<base64-encoded 32-byte key>
 MULTICA_SLACK_SECRET_KEY=<base64-encoded 32-byte key>
 MULTICA_DINGTALK_SECRET_KEY=<base64-encoded 32-byte key>
+MULTICA_WECOM_SECRET_KEY=<base64-encoded 32-byte key>
 ```
 
 These keys encrypt stored Bot credentials. See [Environment variables](/environment-variables) for how to generate, store, and rotate them. Multica Cloud already has this configured.
+
+WeCom additionally requires a **single backend replica**: its only outbound path is the WebSocket held by one process, so replies produced on another replica are dropped. Run the WeCom-enabled backend unreplicated until cross-replica outbound routing lands.
 
 ## Next steps
 

--- a/apps/docs/content/docs/channels.zh.mdx
+++ b/apps/docs/content/docs/channels.zh.mdx
@@ -1,27 +1,31 @@
 ---
 title: 聊天集成
-description: 把 Multica 智能体接入飞书、Lark、Slack 或钉钉，在团队已有的聊天工具中使用。
+description: 把 Multica 智能体接入飞书、Lark、Slack、钉钉或企业微信，在团队已有的聊天工具中使用。
 ---
 
 import { Callout } from "fumadocs-ui/components/callout";
 
 聊天集成让团队不用打开 Multica，也能直接向智能体提问、在群聊中 @它，或从聊天窗口创建 issue。
 
-目前支持飞书/Lark、Slack 和钉钉。它们使用相同的会话、身份和执行机制，但安装方式不同。
+目前支持飞书/Lark、Slack、钉钉和企业微信。它们使用相同的会话、身份和执行机制，但安装方式不同。
 
 ## 选择平台
 
-| | 飞书 / Lark | Slack | 钉钉 |
-|---|---|---|---|
-| 安装方式 | 在 Multica 中生成二维码，用飞书扫码授权 | 在 Slack 创建 app，再把两个 token 填入 Multica | 创建企业内部应用和 Stream 模式机器人，再把 AppKey 与 AppSecret 填入 Multica |
-| 私聊智能体 | 支持 | 支持 | 支持 |
-| 群聊或频道 | @ Bot 后触发 | @ Bot 后触发 | @ Bot 后触发 |
-| 创建 issue | `/issue` 消息命令，按输入直接创建 | `/issue` slash 命令，智能体整理描述后创建 | `/issue` 消息命令，按输入直接创建 |
-| 连接方式 | 平台长连接 | Socket Mode | Stream 模式 |
+| | 飞书 / Lark | Slack | 钉钉 | 企业微信 |
+|---|---|---|---|---|
+| 安装方式 | 在 Multica 中生成二维码，用飞书扫码授权 | 在 Slack 创建 app，再把两个 token 填入 Multica | 创建企业内部应用和 Stream 模式机器人，再把 AppKey 与 AppSecret 填入 Multica | 在企业微信管理后台创建智能机器人并开启长连接，再把 Bot ID 与 Secret 填入 Multica |
+| 私聊智能体 | 支持 | 支持 | 支持 | 支持 |
+| 群聊或频道 | @ Bot 后触发 | @ Bot 后触发 | @ Bot 后触发 | @ Bot 后触发 |
+| 创建 issue | `/issue` 消息命令，按输入直接创建 | `/issue` slash 命令，智能体整理描述后创建 | `/issue` 消息命令，按输入直接创建 | `/issue` 消息命令，按输入直接创建 |
+| 连接方式 | 平台长连接 | Socket Mode | Stream 模式 | 平台长连接 |
 
 新连接目前只开放中国大陆版飞书；已有的国际版 Lark 连接仍可继续使用和管理。
 
 每个 Bot 绑定一个 Multica 智能体。需要在同一个聊天平台中使用多个智能体时，要分别连接多个 Bot。
+
+钉钉和企业微信由社区维护：随每个版本发布，但没有官方支持 SLA。遇到问题请提交 [GitHub issue](https://github.com/multica-ai/multica/issues)。
+
+企业微信目前只处理文字消息。语音、图片和文件消息会收到一句说明，不会转交给智能体。
 
 详细步骤：
 
@@ -44,6 +48,7 @@ import { Callout } from "fumadocs-ui/components/callout";
 - 飞书/Lark 按聊天区分会话；同一个聊天中的后续消息会继续原会话。
 - Slack 私聊按频道区分；频道中的每个 thread 分别保存一段会话。
 - 钉钉按 conversation 区分会话；每个单聊或群聊分别延续自己的会话。
+- 企业微信按聊天区分会话；每个单聊或群聊分别延续自己的会话。
 
 在频道中继续追问时仍需再次 @ Bot。智能体只收到发给自己的消息，不会自动读取整个频道的历史。
 
@@ -71,9 +76,12 @@ import { Callout } from "fumadocs-ui/components/callout";
 MULTICA_LARK_SECRET_KEY=<base64 编码的 32 字节密钥>
 MULTICA_SLACK_SECRET_KEY=<base64 编码的 32 字节密钥>
 MULTICA_DINGTALK_SECRET_KEY=<base64 编码的 32 字节密钥>
+MULTICA_WECOM_SECRET_KEY=<base64 编码的 32 字节密钥>
 ```
 
 这些密钥用于加密保存 Bot 凭据。生成、保存和轮换方法见[环境变量](/environment-variables)。Multica Cloud 已完成这项配置。
+
+企业微信还要求后端**只部署单个副本**：它的出站只有一条路径，即某个进程持有的 WebSocket，因此在其他副本上产生的回复会被丢弃。在跨副本出站路由实现之前，请不要对启用企业微信的后端做多副本部署。
 
 ## 接下来
 

--- a/server/internal/integrations/wecom/types.go
+++ b/server/internal/integrations/wecom/types.go
@@ -16,6 +16,23 @@
 // engine.Supervisor's WS lease, so the multi-replica invariant (at most one
 // active connection per installation across processes) already holds without
 // wecom-specific code.
+//
+// Maintenance: this package is COMMUNITY-MAINTAINED. @leroy-chen contributed it
+// and co-owns it with @seacen — they are the first stop for WeCom-specific bugs
+// and behavior questions, on a best-effort volunteer basis. The Multica team
+// keeps this package compiling and its tests green through shared-layer
+// refactors, but does not use WeCom and cannot verify behavior against the real
+// platform; that part depends on the code owners. If the integration breaks in a
+// way that cannot be fixed without real WeCom access and no fix lands for a few
+// releases, it may be deprecated rather than left quietly broken. Changing the
+// shared channel engine? Keep this adapter building — and loop in the code
+// owners for anything that changes WeCom-visible behavior.
+//
+// Known limits of the first version, both deliberate: inbound handling is
+// text-only (other message types get a short "text only" receipt), and outbound
+// delivery requires a SINGLE backend replica, because the only send path is the
+// in-process WebSocket in sendersRegistry while EventChatDone dispatches on the
+// in-process events.Bus. See SELF_HOSTING.md.
 package wecom
 
 import (


### PR DESCRIPTION
WeCom shipped in #5833 with **no user-facing documentation**. It wasn't on the channels page in any of the four locales, and it wasn't in the README — so a user had no way to learn how to create the bot, where `bot_id` / `secret` come from, or that the first version is text-only and expects a single backend replica.

This closes that gap for the parts we can write ourselves, and names the code owners.

## Changes

**`apps/docs/content/docs/channels.{mdx,zh,ja,ko}`** — WeCom added to the intro, the platform comparison table (installation, DM, groups, `/issue`, connection type), session isolation, and the self-hosting key block. Plus two limits that were previously documented nowhere user-facing:

- text-only inbound (voice/image/file get a short receipt and never reach the agent)
- single-replica backend, because the only outbound path is the in-process WebSocket while `EventChatDone` dispatches on the in-process bus

Also states plainly that DingTalk and WeCom are community-maintained with no official support SLA.

**`README.md`** — WeCom listed alongside the other channels.

**`server/internal/integrations/wecom/types.go`** — package maintenance header mirroring `dingtalk/config.go`: @leroy-chen and @seacen as co-owners, the community-maintained terms, the deprecation rule, and the note asking anyone changing the shared channel engine to keep this adapter building and to loop the owners in on WeCom-visible behavior changes.

## Deliberately not here

The step-by-step `/wecom-bot-integration` guide (×4 locales) is **not** included and not linked — a dangling link would be worse than none. It's tracked in #6550 for @leroy-chen and @seacen to write, since they work in the WeCom admin console daily and we don't. Once it lands, the guide links go into `channels.*` alongside the Feishu/Slack/DingTalk ones.

## Verification

`gofmt -l` clean, `go build ./internal/integrations/wecom/` passes, and all four channel tables verified to have consistent column counts. Doc prose only otherwise.

zh copy follows `developers/conventions.zh.mdx` — 企业微信 is kept as the Chinese product name (it never changed), full-width punctuation, spaces around Latin terms.

