### PR TITLE
[codex] add Weixin iLink protocol foundation

### DIFF
--- a/server/internal/integrations/weixin/client.go
+++ b/server/internal/integrations/weixin/client.go
@@ -1,0 +1,458 @@
+package weixin
+
+import (
+	"bytes"
+	"context"
+	cryptorand "crypto/rand"
+	"encoding/base64"
+	"encoding/binary"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+	"time"
+)
+
+const (
+	endpointGetQRCode   = "ilink/bot/get_bot_qrcode"
+	endpointQRStatus    = "ilink/bot/get_qrcode_status"
+	endpointGetUpdates  = "ilink/bot/getupdates"
+	endpointSendMessage = "ilink/bot/sendmessage"
+)
+
+// BaseURLPolicy decides whether an iLink API base URL is trusted. Production
+// callers should use the default policy. The seam exists so httptest servers
+// can exercise the client without weakening the production allowlist.
+type BaseURLPolicy func(*url.URL) bool
+
+// ClientOptions configures the iLink protocol client. Zero values select the
+// Tencent production endpoint and conservative timeouts.
+type ClientOptions struct {
+	BaseURL        string
+	ILinkAppID     string
+	ClientVersion  string
+	ChannelVersion string
+	BotAgent       string
+	RequestTimeout time.Duration
+	PollTimeout    time.Duration
+	AllowBaseURL   BaseURLPolicy
+}
+
+// Client implements the personal-WeChat iLink JSON/HTTP protocol. It owns no
+// credentials or receive cursor; both stay installation-scoped at the caller.
+type Client struct {
+	httpClient     *http.Client
+	baseURL        string
+	iLinkAppID     string
+	clientVersion  string
+	baseInfo       baseInfo
+	requestTimeout time.Duration
+	pollTimeout    time.Duration
+	allowBaseURL   BaseURLPolicy
+}
+
+// NewClient constructs a client and rejects an unsafe configured base URL
+// before any network request is possible.
+func NewClient(httpClient *http.Client, opts ClientOptions) (*Client, error) {
+	if httpClient == nil {
+		httpClient = &http.Client{}
+	}
+	if opts.BaseURL == "" {
+		opts.BaseURL = defaultBaseURL
+	}
+	if opts.ILinkAppID == "" {
+		opts.ILinkAppID = defaultILinkAppID
+	}
+	if opts.ClientVersion == "" {
+		opts.ClientVersion = defaultClientVersion
+	}
+	if opts.ChannelVersion == "" {
+		opts.ChannelVersion = defaultChannelVersion
+	}
+	if opts.BotAgent == "" {
+		opts.BotAgent = defaultBotAgent
+	}
+	if opts.RequestTimeout <= 0 {
+		opts.RequestTimeout = defaultRequestTimeout
+	}
+	if opts.PollTimeout <= 0 {
+		opts.PollTimeout = defaultPollTimeout
+	}
+	if opts.AllowBaseURL == nil {
+		opts.AllowBaseURL = allowTencentBaseURL
+	}
+
+	c := &Client{
+		httpClient:     httpClient,
+		iLinkAppID:     opts.ILinkAppID,
+		clientVersion:  opts.ClientVersion,
+		baseInfo:       baseInfo{ChannelVersion: opts.ChannelVersion, BotAgent: opts.BotAgent},
+		requestTimeout: opts.RequestTimeout,
+		pollTimeout:    opts.PollTimeout,
+		allowBaseURL:   opts.AllowBaseURL,
+	}
+	baseURL, err := c.validateBaseURL(opts.BaseURL)
+	if err != nil {
+		return nil, err
+	}
+	c.baseURL = baseURL
+	return c, nil
+}
+
+// allowTencentBaseURL is intentionally narrower than "*.qq.com". QR status,
+// API redirects, and media URLs are server-controlled input; accepting an
+// arbitrary returned host would turn the integration into an SSRF primitive.
+func allowTencentBaseURL(u *url.URL) bool {
+	if u == nil || u.Scheme != "https" {
+		return false
+	}
+	host := strings.ToLower(u.Hostname())
+	return host == "ilinkai.weixin.qq.com" || strings.HasSuffix(host, ".weixin.qq.com")
+}
+
+func (c *Client) validateBaseURL(raw string) (string, error) {
+	u, err := url.Parse(strings.TrimSpace(raw))
+	if err != nil {
+		return "", fmt.Errorf("weixin: parse base URL: %w", err)
+	}
+	if u.Scheme == "" || u.Host == "" || u.User != nil || u.RawQuery != "" || u.Fragment != "" {
+		return "", errors.New("weixin: invalid base URL")
+	}
+	if u.Scheme != "https" && u.Scheme != "http" {
+		return "", errors.New("weixin: base URL must use HTTP or HTTPS")
+	}
+	if u.Path != "" && u.Path != "/" {
+		return "", errors.New("weixin: base URL must not contain a path")
+	}
+	if c.allowBaseURL == nil || !c.allowBaseURL(u) {
+		return "", fmt.Errorf("weixin: untrusted base URL host %q", u.Hostname())
+	}
+	u.Path = ""
+	return strings.TrimRight(u.String(), "/"), nil
+}
+
+// RedirectBaseURL validates an IDC redirect_host and returns the HTTPS base
+// URL that can be supplied to PollQRCode. The host must not contain a scheme,
+// credentials, path, query, fragment, or port.
+func (c *Client) RedirectBaseURL(host string) (string, error) {
+	host = strings.TrimSpace(host)
+	if host == "" || strings.ContainsAny(host, "/?#@:") {
+		return "", errors.New("weixin: invalid QR redirect host")
+	}
+	return c.validateBaseURL("https://" + host)
+}
+
+// BeginQRCode starts a QR authorization session. The returned Code is an
+// opaque status-poll token; ImageContent is what the frontend renders.
+func (c *Client) BeginQRCode(ctx context.Context, localTokens []string) (QRCode, error) {
+	query := url.Values{"bot_type": []string{defaultBotType}}
+	var out QRCode
+	err := c.doJSON(ctx, request{
+		method:  http.MethodPost,
+		baseURL: c.baseURL,
+		path:    endpointGetQRCode,
+		query:   query,
+		body: map[string]any{
+			"local_token_list": localTokens,
+		},
+		timeout: c.requestTimeout,
+	}, &out)
+	if err != nil {
+		return QRCode{}, err
+	}
+	if strings.TrimSpace(out.Code) == "" || strings.TrimSpace(out.ImageContent) == "" {
+		return QRCode{}, errors.New("weixin: QR response is incomplete")
+	}
+	return out, nil
+}
+
+// PollQRCode performs one long-poll status request. verifyCode is included only
+// after the server reports need_verifycode. baseURL starts at the fixed Tencent
+// host and may change only through RedirectBaseURL.
+func (c *Client) PollQRCode(ctx context.Context, baseURL, code, verifyCode string) (QRStatus, error) {
+	if strings.TrimSpace(code) == "" {
+		return QRStatus{}, errors.New("weixin: QR code token is required")
+	}
+	if baseURL == "" {
+		baseURL = c.baseURL
+	}
+	validated, err := c.validateBaseURL(baseURL)
+	if err != nil {
+		return QRStatus{}, err
+	}
+	query := url.Values{"qrcode": []string{code}}
+	if verifyCode != "" {
+		query.Set("verify_code", verifyCode)
+	}
+	var out QRStatus
+	err = c.doJSON(ctx, request{
+		method:  http.MethodGet,
+		baseURL: validated,
+		path:    endpointQRStatus,
+		query:   query,
+		timeout: c.pollTimeout,
+	}, &out)
+	if err != nil {
+		if ctx.Err() == nil && errors.Is(err, context.DeadlineExceeded) {
+			return QRStatus{Status: "wait"}, nil
+		}
+		return QRStatus{}, err
+	}
+	if err := validateQRStatus(out); err != nil {
+		return QRStatus{}, err
+	}
+	if out.confirmed() {
+		accountBaseURL, err := c.validateBaseURL(out.BaseURL)
+		if err != nil {
+			return QRStatus{}, fmt.Errorf("weixin: rejected confirmed account base URL: %w", err)
+		}
+		out.BaseURL = accountBaseURL
+	}
+	if out.Status == "scaned_but_redirect" && out.RedirectHost != "" {
+		if _, err := c.RedirectBaseURL(out.RedirectHost); err != nil {
+			return QRStatus{}, fmt.Errorf("weixin: rejected QR redirect: %w", err)
+		}
+	}
+	return out, nil
+}
+
+// GetUpdates long-polls one installation. An internal client-side timeout is a
+// normal empty poll and returns the caller's cursor unchanged. Parent-context
+// cancellation remains an error so a supervised receive loop exits promptly.
+func (c *Client) GetUpdates(ctx context.Context, baseURL, token, cursor string, timeout time.Duration) (Updates, error) {
+	if strings.TrimSpace(token) == "" {
+		return Updates{}, errors.New("weixin: bot token is required")
+	}
+	validated, err := c.validateBaseURL(baseURL)
+	if err != nil {
+		return Updates{}, err
+	}
+	if timeout <= 0 {
+		timeout = c.pollTimeout
+	}
+	var out Updates
+	err = c.doJSON(ctx, request{
+		method:  http.MethodPost,
+		baseURL: validated,
+		path:    endpointGetUpdates,
+		body: getUpdatesRequest{
+			Cursor:   cursor,
+			BaseInfo: c.baseInfo,
+		},
+		token:   token,
+		timeout: timeout,
+	}, &out)
+	if err != nil {
+		if ctx.Err() == nil && errors.Is(err, context.DeadlineExceeded) {
+			return Updates{Cursor: cursor}, nil
+		}
+		return Updates{}, err
+	}
+	if out.Ret != 0 || out.ErrCode != 0 {
+		return Updates{}, &APIError{
+			Operation: "getupdates",
+			Ret:       out.Ret,
+			ErrCode:   out.ErrCode,
+			Message:   out.ErrorMessage,
+		}
+	}
+	return out, nil
+}
+
+// SendTextInput is one reply-driven personal-WeChat text delivery. ClientID may
+// be supplied by a durable outbound worker and must be reused when retrying an
+// ambiguous network failure.
+type SendTextInput struct {
+	BaseURL      string
+	Token        string
+	ToUserID     string
+	ContextToken string
+	Text         string
+	RunID        string
+	ClientID     string
+}
+
+// SendText posts one finished bot message and validates the protocol-level ret
+// field. An HTTP 200 with ret != 0 is a delivery failure.
+func (c *Client) SendText(ctx context.Context, in SendTextInput) (string, error) {
+	if strings.TrimSpace(in.Token) == "" {
+		return "", errors.New("weixin: bot token is required")
+	}
+	if strings.TrimSpace(in.ToUserID) == "" {
+		return "", errors.New("weixin: destination user is required")
+	}
+	if strings.TrimSpace(in.ContextToken) == "" {
+		return "", errors.New("weixin: context token is required")
+	}
+	if in.Text == "" {
+		return "", errors.New("weixin: outbound text is required")
+	}
+	validated, err := c.validateBaseURL(in.BaseURL)
+	if err != nil {
+		return "", err
+	}
+	clientID := in.ClientID
+	if clientID == "" {
+		clientID, err = randomClientID()
+		if err != nil {
+			return "", err
+		}
+	}
+	var out apiResponse
+	err = c.doJSON(ctx, request{
+		method:  http.MethodPost,
+		baseURL: validated,
+		path:    endpointSendMessage,
+		token:   in.Token,
+		timeout: c.requestTimeout,
+		body: sendMessageRequest{
+			Message: Message{
+				ToUserID:     in.ToUserID,
+				ClientID:     clientID,
+				MessageType:  messageTypeBot,
+				MessageState: messageStateFinish,
+				ContextToken: in.ContextToken,
+				RunID:        in.RunID,
+				Items: []MessageItem{{
+					Type: messageItemTypeText,
+					Text: &TextItem{Text: in.Text},
+				}},
+			},
+			BaseInfo: c.baseInfo,
+		},
+	}, &out)
+	if err != nil {
+		return clientID, err
+	}
+	if out.Ret != 0 || out.ErrCode != 0 {
+		return clientID, &APIError{
+			Operation: "sendmessage",
+			Ret:       out.Ret,
+			ErrCode:   out.ErrCode,
+			Message:   out.ErrorMessage,
+		}
+	}
+	return clientID, nil
+}
+
+type request struct {
+	method  string
+	baseURL string
+	path    string
+	query   url.Values
+	body    any
+	token   string
+	timeout time.Duration
+}
+
+func (c *Client) doJSON(parent context.Context, in request, out any) error {
+	if parent == nil {
+		return errors.New("weixin: nil request context")
+	}
+	endpoint, err := url.Parse(in.baseURL)
+	if err != nil {
+		return fmt.Errorf("weixin: parse request base URL: %w", err)
+	}
+	endpoint.Path = strings.TrimRight(endpoint.Path, "/") + "/" + strings.TrimLeft(in.path, "/")
+	endpoint.RawQuery = in.query.Encode()
+
+	var body io.Reader
+	if in.body != nil {
+		payload, err := json.Marshal(in.body)
+		if err != nil {
+			return fmt.Errorf("weixin: encode %s request: %w", in.path, err)
+		}
+		body = bytes.NewReader(payload)
+	}
+	ctx := parent
+	cancel := func() {}
+	if in.timeout > 0 {
+		ctx, cancel = context.WithTimeout(parent, in.timeout)
+	}
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, in.method, endpoint.String(), body)
+	if err != nil {
+		return fmt.Errorf("weixin: build %s request: %w", in.path, err)
+	}
+	req.Header.Set("iLink-App-Id", c.iLinkAppID)
+	req.Header.Set("iLink-App-ClientVersion", c.clientVersion)
+	if in.body != nil {
+		req.Header.Set("Content-Type", "application/json")
+		req.Header.Set("AuthorizationType", "ilink_bot_token")
+		req.Header.Set("X-WECHAT-UIN", randomWechatUIN())
+	}
+	if in.token != "" {
+		req.Header.Set("Authorization", "Bearer "+in.token)
+	}
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
+		return fmt.Errorf("weixin: %s request failed: %w", in.path, err)
+	}
+	defer resp.Body.Close()
+
+	payload, err := io.ReadAll(io.LimitReader(resp.Body, maxResponseBytes+1))
+	if err != nil {
+		return fmt.Errorf("weixin: read %s response: %w", in.path, err)
+	}
+	if len(payload) > maxResponseBytes {
+		return fmt.Errorf("weixin: %s response exceeds %d bytes", in.path, maxResponseBytes)
+	}
+	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
+		return fmt.Errorf("weixin: %s returned HTTP %d", in.path, resp.StatusCode)
+	}
+	if out == nil || len(bytes.TrimSpace(payload)) == 0 {
+		return nil
+	}
+	if err := json.Unmarshal(payload, out); err != nil {
+		return fmt.Errorf("weixin: decode %s response: %w", in.path, err)
+	}
+	return nil
+}
+
+// randomWechatUIN is base64(decimal(random uint32)), matching Tencent's
+// reference client. It is a request nonce, not a credential.
+func randomWechatUIN() string {
+	var b [4]byte
+	if _, err := cryptorand.Read(b[:]); err != nil {
+		return base64.StdEncoding.EncodeToString([]byte("0"))
+	}
+	v := binary.BigEndian.Uint32(b[:])
+	return base64.StdEncoding.EncodeToString([]byte(strconv.FormatUint(uint64(v), 10)))
+}
+
+func randomClientID() (string, error) {
+	var b [16]byte
+	if _, err := cryptorand.Read(b[:]); err != nil {
+		return "", fmt.Errorf("weixin: generate client id: %w", err)
+	}
+	return "multica-" + hex.EncodeToString(b[:]), nil
+}
+
+// ChunkText splits a reply on rune boundaries. The iLink reference adapter
+// uses 4,000 characters as its conservative text-message limit.
+func ChunkText(text string, maxRunes int) []string {
+	if maxRunes <= 0 {
+		maxRunes = 4000
+	}
+	runes := []rune(text)
+	if len(runes) <= maxRunes {
+		return []string{text}
+	}
+	out := make([]string, 0, (len(runes)+maxRunes-1)/maxRunes)
+	for len(runes) > 0 {
+		n := min(maxRunes, len(runes))
+		out = append(out, string(runes[:n]))
+		runes = runes[n:]
+	}
+	return out
+}

--- a/server/internal/integrations/weixin/client_test.go
+++ b/server/internal/integrations/weixin/client_test.go
@@ -1,0 +1,277 @@
+package weixin
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+)
+
+func testClient(t *testing.T, handler http.HandlerFunc) (*Client, *httptest.Server) {
+	t.Helper()
+	server := httptest.NewServer(handler)
+	t.Cleanup(server.Close)
+	client, err := NewClient(server.Client(), ClientOptions{
+		BaseURL:        server.URL,
+		ILinkAppID:     "bot",
+		ClientVersion:  "132102",
+		ChannelVersion: "test-version",
+		BotAgent:       "Multica/Test",
+		AllowBaseURL:   func(*url.URL) bool { return true },
+	})
+	if err != nil {
+		t.Fatalf("NewClient: %v", err)
+	}
+	return client, server
+}
+
+func TestBeginQRCodeUsesOfficialRequestShape(t *testing.T) {
+	client, _ := testClient(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Errorf("method = %s, want POST", r.Method)
+		}
+		if r.URL.Path != "/"+endpointGetQRCode {
+			t.Errorf("path = %q", r.URL.Path)
+		}
+		if got := r.URL.Query().Get("bot_type"); got != defaultBotType {
+			t.Errorf("bot_type = %q", got)
+		}
+		assertCommonHeaders(t, r, false)
+		var body struct {
+			LocalTokens []string `json:"local_token_list"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Errorf("decode request: %v", err)
+		}
+		if len(body.LocalTokens) != 1 || body.LocalTokens[0] != "old-token" {
+			t.Errorf("local_token_list = %#v", body.LocalTokens)
+		}
+		_ = json.NewEncoder(w).Encode(QRCode{Code: "opaque-code", ImageContent: "https://example.invalid/qr"})
+	})
+
+	got, err := client.BeginQRCode(context.Background(), []string{"old-token"})
+	if err != nil {
+		t.Fatalf("BeginQRCode: %v", err)
+	}
+	if got.Code != "opaque-code" || got.ImageContent != "https://example.invalid/qr" {
+		t.Fatalf("QRCode = %#v", got)
+	}
+}
+
+func TestPollQRCodeEscapesOpaqueValuesAndValidatesConfirmation(t *testing.T) {
+	client, server := testClient(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Errorf("method = %s, want GET", r.Method)
+		}
+		if r.URL.Query().Get("qrcode") != "opaque +/?" {
+			t.Errorf("qrcode = %q", r.URL.Query().Get("qrcode"))
+		}
+		if r.URL.Query().Get("verify_code") != "123 456" {
+			t.Errorf("verify_code = %q", r.URL.Query().Get("verify_code"))
+		}
+		assertCommonHeaders(t, r, true)
+		_ = json.NewEncoder(w).Encode(QRStatus{
+			Status:    "confirmed",
+			BotToken:  "secret",
+			BotID:     "bot@im.bot",
+			BaseURL:   defaultBaseURL,
+			ScannerID: "user@im.wechat",
+		})
+	})
+
+	got, err := client.PollQRCode(context.Background(), server.URL, "opaque +/?", "123 456")
+	if err != nil {
+		t.Fatalf("PollQRCode: %v", err)
+	}
+	if !got.confirmed() || got.BotID != "bot@im.bot" || got.ScannerID != "user@im.wechat" {
+		t.Fatalf("QRStatus = %#v", got)
+	}
+}
+
+func TestPollQRCodeRejectsIncompleteConfirmation(t *testing.T) {
+	client, server := testClient(t, func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(QRStatus{Status: "confirmed", BotID: "bot@im.bot"})
+	})
+	_, err := client.PollQRCode(context.Background(), server.URL, "code", "")
+	if err == nil || !strings.Contains(err.Error(), "bot_token") || !strings.Contains(err.Error(), "baseurl") {
+		t.Fatalf("error = %v", err)
+	}
+}
+
+func TestPollQRCodeTreatsInternalLongPollTimeoutAsWait(t *testing.T) {
+	client, server := testClient(t, func(w http.ResponseWriter, r *http.Request) {
+		time.Sleep(50 * time.Millisecond)
+		_, _ = w.Write([]byte(`{"status":"wait"}`))
+	})
+	client.pollTimeout = 10 * time.Millisecond
+	got, err := client.PollQRCode(context.Background(), server.URL, "code", "")
+	if err != nil {
+		t.Fatalf("PollQRCode: %v", err)
+	}
+	if got.Status != "wait" {
+		t.Fatalf("status = %#v", got)
+	}
+}
+
+func TestGetUpdatesAuthenticatesAndPreservesProtocolFields(t *testing.T) {
+	client, server := testClient(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/"+endpointGetUpdates {
+			t.Errorf("path = %q", r.URL.Path)
+		}
+		assertCommonHeaders(t, r, false)
+		if got := r.Header.Get("Authorization"); got != "Bearer token-value" {
+			t.Errorf("Authorization = %q", got)
+		}
+		var body getUpdatesRequest
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Errorf("decode request: %v", err)
+		}
+		if body.Cursor != "cursor-1" {
+			t.Errorf("cursor = %q", body.Cursor)
+		}
+		if body.BaseInfo.ChannelVersion != "test-version" || body.BaseInfo.BotAgent != "Multica/Test" {
+			t.Errorf("base_info = %#v", body.BaseInfo)
+		}
+		_, _ = w.Write([]byte(`{"ret":0,"get_updates_buf":"cursor-2","longpolling_timeout_ms":41000,"msgs":[{"message_id":42,"from_user_id":"u@im.wechat","to_user_id":"b@im.bot","message_type":1,"item_list":[{"type":1,"text_item":{"text":"hello"}}]}]}`))
+	})
+
+	got, err := client.GetUpdates(context.Background(), server.URL, "token-value", "cursor-1", time.Second)
+	if err != nil {
+		t.Fatalf("GetUpdates: %v", err)
+	}
+	if got.Cursor != "cursor-2" || got.LongPollMillis != 41000 || len(got.Messages) != 1 {
+		t.Fatalf("Updates = %#v", got)
+	}
+	if id := rawMessageID(got.Messages[0].MessageID); id != "42" {
+		t.Fatalf("message id = %q", id)
+	}
+}
+
+func TestGetUpdatesMapsStaleToken(t *testing.T) {
+	client, server := testClient(t, func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"ret":-14,"errcode":-14,"errmsg":"session timeout"}`))
+	})
+	_, err := client.GetUpdates(context.Background(), server.URL, "token", "", time.Second)
+	if !errors.Is(err, ErrReauthorizationRequired) {
+		t.Fatalf("error = %v, want ErrReauthorizationRequired", err)
+	}
+	var apiErr *APIError
+	if !errors.As(err, &apiErr) || apiErr.Operation != "getupdates" {
+		t.Fatalf("error = %#v, want APIError", err)
+	}
+}
+
+func TestGetUpdatesTreatsInternalLongPollTimeoutAsEmpty(t *testing.T) {
+	client, server := testClient(t, func(w http.ResponseWriter, r *http.Request) {
+		time.Sleep(50 * time.Millisecond)
+		_, _ = w.Write([]byte(`{"ret":0}`))
+	})
+	got, err := client.GetUpdates(context.Background(), server.URL, "token", "cursor-1", 10*time.Millisecond)
+	if err != nil {
+		t.Fatalf("GetUpdates: %v", err)
+	}
+	if got.Cursor != "cursor-1" || len(got.Messages) != 0 {
+		t.Fatalf("Updates = %#v", got)
+	}
+}
+
+func TestSendTextUsesStableClientIDAndChecksRet(t *testing.T) {
+	requests := 0
+	client, server := testClient(t, func(w http.ResponseWriter, r *http.Request) {
+		requests++
+		var body sendMessageRequest
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Errorf("decode request: %v", err)
+		}
+		msg := body.Message
+		if msg.ClientID != "stable-client-id" || msg.ToUserID != "u@im.wechat" || msg.ContextToken != "context-secret" {
+			t.Errorf("message = %#v", msg)
+		}
+		if msg.MessageType != messageTypeBot || msg.MessageState != messageStateFinish || len(msg.Items) != 1 || msg.Items[0].Text.Text != "reply" {
+			t.Errorf("message payload = %#v", msg)
+		}
+		if requests == 1 {
+			_, _ = w.Write([]byte(`{"ret":0}`))
+			return
+		}
+		_, _ = w.Write([]byte(`{"ret":-2,"errmsg":"bad context"}`))
+	})
+
+	in := SendTextInput{
+		BaseURL:      server.URL,
+		Token:        "token",
+		ToUserID:     "u@im.wechat",
+		ContextToken: "context-secret",
+		Text:         "reply",
+		ClientID:     "stable-client-id",
+	}
+	got, err := client.SendText(context.Background(), in)
+	if err != nil || got != "stable-client-id" {
+		t.Fatalf("SendText = (%q, %v)", got, err)
+	}
+	got, err = client.SendText(context.Background(), in)
+	if got != "stable-client-id" {
+		t.Fatalf("client id on failure = %q", got)
+	}
+	var apiErr *APIError
+	if !errors.As(err, &apiErr) || apiErr.Ret != -2 {
+		t.Fatalf("error = %#v", err)
+	}
+}
+
+func TestClientRejectsUntrustedBaseURL(t *testing.T) {
+	client, err := NewClient(nil, ClientOptions{})
+	if err != nil {
+		t.Fatalf("NewClient: %v", err)
+	}
+	_, err = client.GetUpdates(context.Background(), "https://attacker.example", "token", "", time.Second)
+	if err == nil || !strings.Contains(err.Error(), "untrusted") {
+		t.Fatalf("error = %v", err)
+	}
+	if _, err := client.RedirectBaseURL("evil.weixin.qq.com@attacker.example"); err == nil {
+		t.Fatal("RedirectBaseURL accepted userinfo-like host")
+	}
+}
+
+func TestChunkTextPreservesRuneBoundaries(t *testing.T) {
+	got := ChunkText("甲乙丙丁戊", 2)
+	want := []string{"甲乙", "丙丁", "戊"}
+	if len(got) != len(want) {
+		t.Fatalf("chunks = %#v", got)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("chunks = %#v", got)
+		}
+	}
+}
+
+func assertCommonHeaders(t *testing.T, r *http.Request, isGET bool) {
+	t.Helper()
+	if got := r.Header.Get("iLink-App-Id"); got != "bot" {
+		t.Errorf("iLink-App-Id = %q", got)
+	}
+	if got := r.Header.Get("iLink-App-ClientVersion"); got != "132102" {
+		t.Errorf("iLink-App-ClientVersion = %q", got)
+	}
+	if isGET {
+		if got := r.Header.Get("AuthorizationType"); got != "" {
+			t.Errorf("GET AuthorizationType = %q", got)
+		}
+		return
+	}
+	if got := r.Header.Get("AuthorizationType"); got != "ilink_bot_token" {
+		t.Errorf("AuthorizationType = %q", got)
+	}
+	uin := r.Header.Get("X-WECHAT-UIN")
+	decoded, err := base64.StdEncoding.DecodeString(uin)
+	if err != nil || len(decoded) == 0 {
+		t.Errorf("X-WECHAT-UIN = %q, err=%v", uin, err)
+	}
+}

--- a/server/internal/integrations/weixin/doc.go
+++ b/server/internal/integrations/weixin/doc.go
@@ -1,0 +1,19 @@
+// Package weixin contains the protocol foundation for personal WeChat direct
+// messages over Tencent's iLink bot API.
+//
+// Personal WeChat is deliberately a distinct channel type from WeCom
+// (Enterprise WeChat). The two products use unrelated authentication,
+// transport, identity, and reply-context protocols.
+//
+// This package currently owns only the protocol client, inbound normalization,
+// and cursor-safe receiver. Installation persistence, QR-session HTTP handlers,
+// channel-engine registration, and the EventChatDone outbound subscriber are
+// added in later slices so the security- and reliability-sensitive wire layer
+// can be reviewed independently first.
+package weixin
+
+import "github.com/multica-ai/multica/server/internal/integrations/channel"
+
+// TypeWeixin is the durable channel discriminator for personal WeChat iLink.
+// Do not reuse "wecom": that value already identifies Enterprise WeChat.
+const TypeWeixin channel.Type = "weixin"

--- a/server/internal/integrations/weixin/inbound.go
+++ b/server/internal/integrations/weixin/inbound.go
@@ -1,0 +1,170 @@
+package weixin
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/multica-ai/multica/server/internal/integrations/channel"
+)
+
+// InboundMetadata is the adapter-private portion of an inbound envelope. The
+// rotating context token is intentionally absent from normalized Source: it is
+// not cross-platform routing state. A future session binder will encrypt and
+// atomically persist this Raw value with the durable inbound message.
+type InboundMetadata struct {
+	BotID        string `json:"ilink_bot_id"`
+	ContextToken string `json:"context_token,omitempty"`
+	SessionID    string `json:"session_id,omitempty"`
+	Seq          int64  `json:"seq,omitempty"`
+}
+
+// DecodeInboundMetadata is the adapter-side inverse of the Raw encoding. It is
+// exported for the future session and outbound components; the shared Router
+// must continue treating Raw as opaque.
+func DecodeInboundMetadata(msg channel.InboundMessage) (InboundMetadata, error) {
+	if len(msg.Raw) == 0 {
+		return InboundMetadata{}, fmt.Errorf("weixin: inbound Raw is empty")
+	}
+	var out InboundMetadata
+	if err := json.Unmarshal(msg.Raw, &out); err != nil {
+		return InboundMetadata{}, fmt.Errorf("weixin: decode inbound Raw: %w", err)
+	}
+	return out, nil
+}
+
+// NormalizeInbound converts one completed, user-authored iLink direct message
+// into the channel engine's normalized envelope. It deliberately rejects bot
+// echoes, groups, generating messages, missing identities, and media-only
+// messages. Tencent's current reference channel declares direct chat only; a
+// group_id must not be silently treated as supported group chat.
+func NormalizeInbound(msg Message, installationBotID string) (channel.InboundMessage, bool) {
+	if msg.MessageType != messageTypeUser {
+		return channel.InboundMessage{}, false
+	}
+	if msg.MessageState != 0 && msg.MessageState != messageStateFinish {
+		return channel.InboundMessage{}, false
+	}
+	if strings.TrimSpace(msg.GroupID) != "" {
+		return channel.InboundMessage{}, false
+	}
+	senderID := strings.TrimSpace(msg.FromUserID)
+	botID := strings.TrimSpace(msg.ToUserID)
+	if botID == "" {
+		botID = strings.TrimSpace(installationBotID)
+	}
+	if senderID == "" || botID == "" {
+		return channel.InboundMessage{}, false
+	}
+
+	text := messageText(msg.Items)
+	if text == "" {
+		return channel.InboundMessage{}, false
+	}
+	messageID := stableMessageID(msg)
+	if messageID == "" {
+		return channel.InboundMessage{}, false
+	}
+
+	raw, err := json.Marshal(InboundMetadata{
+		BotID:        botID,
+		ContextToken: msg.ContextToken,
+		SessionID:    msg.SessionID,
+		Seq:          msg.Seq,
+	})
+	if err != nil {
+		return channel.InboundMessage{}, false
+	}
+
+	return channel.InboundMessage{
+		EventID:   messageID,
+		MessageID: messageID,
+		Source: channel.Source{
+			ChannelType: TypeWeixin,
+			ChatID:      senderID,
+			ChatType:    channel.ChatTypeP2P,
+			SenderID:    senderID,
+		},
+		Type:           channel.MsgTypeText,
+		Text:           text,
+		CommandText:    text,
+		AddressedToBot: true,
+		Raw:            raw,
+	}, true
+}
+
+func messageText(items []MessageItem) string {
+	parts := make([]string, 0, len(items))
+	for _, item := range items {
+		switch item.Type {
+		case messageItemTypeText:
+			if item.Text != nil && item.Text.Text != "" {
+				parts = append(parts, item.Text.Text)
+			}
+		case messageItemTypeVoice:
+			// Server-provided voice transcription is already text. The media
+			// bytes remain unsupported until the AES/SILK pipeline is hardened.
+			if item.Voice != nil && item.Voice.Text != "" {
+				parts = append(parts, item.Voice.Text)
+			}
+		}
+	}
+	return strings.Join(parts, "\n")
+}
+
+// stableMessageID prefers upstream identifiers and derives a deterministic
+// fallback only when they are absent. Random ids are forbidden because a
+// reconnect replay must hit channel_inbound_message_dedup.
+func stableMessageID(msg Message) string {
+	if id := rawMessageID(msg.MessageID); id != "" && id != "0" {
+		return id
+	}
+	for _, item := range msg.Items {
+		if id := strings.TrimSpace(item.MsgID); id != "" {
+			return id
+		}
+	}
+
+	h := sha256.New()
+	fmt.Fprintf(h, "%d\x00%s\x00%s\x00%s\x00%d\x00%s\x00%s",
+		msg.Seq,
+		msg.ClientID,
+		msg.FromUserID,
+		msg.ToUserID,
+		msg.CreateTimeMS,
+		msg.SessionID,
+		msg.ContextToken,
+	)
+	for _, item := range msg.Items {
+		fmt.Fprintf(h, "\x00%d\x00%s", item.Type, item.MsgID)
+		if item.Text != nil {
+			fmt.Fprintf(h, "\x00%s", item.Text.Text)
+		}
+		if item.Voice != nil {
+			fmt.Fprintf(h, "\x00%s", item.Voice.Text)
+		}
+	}
+	sum := h.Sum(nil)
+	return "derived-" + hex.EncodeToString(sum[:16])
+}
+
+func rawMessageID(raw json.RawMessage) string {
+	trimmed := strings.TrimSpace(string(raw))
+	if trimmed == "" || trimmed == "null" {
+		return ""
+	}
+	var text string
+	if err := json.Unmarshal(raw, &text); err == nil {
+		return strings.TrimSpace(text)
+	}
+	var number json.Number
+	if err := json.Unmarshal(raw, &number); err == nil {
+		if _, err := strconv.ParseInt(number.String(), 10, 64); err == nil {
+			return number.String()
+		}
+	}
+	return ""
+}

--- a/server/internal/integrations/weixin/inbound_test.go
+++ b/server/internal/integrations/weixin/inbound_test.go
@@ -1,0 +1,152 @@
+package weixin
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/multica-ai/multica/server/internal/integrations/channel"
+)
+
+func TestNormalizeInboundDirectText(t *testing.T) {
+	rawID := json.RawMessage(`12345`)
+	got, ok := NormalizeInbound(Message{
+		Seq:          7,
+		MessageID:    rawID,
+		FromUserID:   "user@im.wechat",
+		ToUserID:     "bot@im.bot",
+		SessionID:    "session-1",
+		MessageType:  messageTypeUser,
+		MessageState: messageStateFinish,
+		ContextToken: "context-secret",
+		Items: []MessageItem{
+			{Type: messageItemTypeText, Text: &TextItem{Text: "hello"}},
+			{Type: messageItemTypeText, Text: &TextItem{Text: "world"}},
+		},
+	}, "")
+	if !ok {
+		t.Fatal("NormalizeInbound rejected direct text")
+	}
+	if got.MessageID != "12345" || got.EventID != "12345" {
+		t.Errorf("ids = (%q, %q)", got.MessageID, got.EventID)
+	}
+	if got.Source.ChannelType != TypeWeixin || got.Source.ChatType != channel.ChatTypeP2P {
+		t.Errorf("source = %#v", got.Source)
+	}
+	if got.Source.ChatID != "user@im.wechat" || got.Source.SenderID != "user@im.wechat" {
+		t.Errorf("source = %#v", got.Source)
+	}
+	if got.Text != "hello\nworld" || got.CommandText != got.Text || got.Type != channel.MsgTypeText {
+		t.Errorf("message = %#v", got)
+	}
+	meta, err := DecodeInboundMetadata(got)
+	if err != nil {
+		t.Fatalf("DecodeInboundMetadata: %v", err)
+	}
+	if meta.BotID != "bot@im.bot" || meta.ContextToken != "context-secret" || meta.SessionID != "session-1" || meta.Seq != 7 {
+		t.Errorf("metadata = %#v", meta)
+	}
+}
+
+func TestNormalizeInboundUsesInstallationBotIDFallback(t *testing.T) {
+	got, ok := NormalizeInbound(Message{
+		MessageID:   json.RawMessage(`"string-id"`),
+		FromUserID:  "user@im.wechat",
+		MessageType: messageTypeUser,
+		Items:       []MessageItem{{Type: messageItemTypeText, Text: &TextItem{Text: "hi"}}},
+	}, "installed-bot@im.bot")
+	if !ok {
+		t.Fatal("NormalizeInbound rejected fallback bot id")
+	}
+	meta, err := DecodeInboundMetadata(got)
+	if err != nil || meta.BotID != "installed-bot@im.bot" {
+		t.Fatalf("metadata = %#v, err=%v", meta, err)
+	}
+}
+
+func TestNormalizeInboundUsesItemIDBeforeDeterministicFallback(t *testing.T) {
+	base := Message{
+		Seq:          9,
+		FromUserID:   "user@im.wechat",
+		ToUserID:     "bot@im.bot",
+		MessageType:  messageTypeUser,
+		CreateTimeMS: 123,
+		Items: []MessageItem{{
+			Type:  messageItemTypeText,
+			MsgID: "item-id",
+			Text:  &TextItem{Text: "hello"},
+		}},
+	}
+	got, ok := NormalizeInbound(base, "")
+	if !ok || got.MessageID != "item-id" {
+		t.Fatalf("message = %#v, ok=%v", got, ok)
+	}
+
+	base.Items[0].MsgID = ""
+	first, ok := NormalizeInbound(base, "")
+	if !ok || first.MessageID == "" {
+		t.Fatalf("fallback message = %#v, ok=%v", first, ok)
+	}
+	second, _ := NormalizeInbound(base, "")
+	if first.MessageID != second.MessageID {
+		t.Fatalf("fallback is unstable: %q != %q", first.MessageID, second.MessageID)
+	}
+	base.Items[0].Text.Text = "changed"
+	changed, _ := NormalizeInbound(base, "")
+	if changed.MessageID == first.MessageID {
+		t.Fatal("fallback id did not change with message content")
+	}
+}
+
+func TestNormalizeInboundAcceptsVoiceTranscriptAsText(t *testing.T) {
+	got, ok := NormalizeInbound(Message{
+		MessageID:   json.RawMessage(`1`),
+		FromUserID:  "user@im.wechat",
+		ToUserID:    "bot@im.bot",
+		MessageType: messageTypeUser,
+		Items: []MessageItem{{
+			Type:  messageItemTypeVoice,
+			Voice: &VoiceItem{Text: "transcribed words"},
+		}},
+	}, "")
+	if !ok || got.Text != "transcribed words" {
+		t.Fatalf("message = %#v, ok=%v", got, ok)
+	}
+}
+
+func TestNormalizeInboundRejectsUnsupportedTraffic(t *testing.T) {
+	valid := Message{
+		MessageID:   json.RawMessage(`1`),
+		FromUserID:  "user@im.wechat",
+		ToUserID:    "bot@im.bot",
+		MessageType: messageTypeUser,
+		Items:       []MessageItem{{Type: messageItemTypeText, Text: &TextItem{Text: "hello"}}},
+	}
+	tests := []struct {
+		name   string
+		mutate func(*Message)
+	}{
+		{"bot echo", func(m *Message) { m.MessageType = messageTypeBot }},
+		{"group", func(m *Message) { m.GroupID = "group-id" }},
+		{"generating", func(m *Message) { m.MessageState = 1 }},
+		{"missing sender", func(m *Message) { m.FromUserID = "" }},
+		{"media only", func(m *Message) { m.Items = []MessageItem{{Type: 2}} }},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			msg := valid
+			tt.mutate(&msg)
+			if got, ok := NormalizeInbound(msg, ""); ok {
+				t.Fatalf("accepted unsupported message: %#v", got)
+			}
+		})
+	}
+}
+
+func TestDecodeInboundMetadataRejectsMalformedRaw(t *testing.T) {
+	if _, err := DecodeInboundMetadata(channel.InboundMessage{}); err == nil {
+		t.Fatal("empty Raw was accepted")
+	}
+	if _, err := DecodeInboundMetadata(channel.InboundMessage{Raw: json.RawMessage(`{`)}); err == nil {
+		t.Fatal("malformed Raw was accepted")
+	}
+}

--- a/server/internal/integrations/weixin/protocol.go
+++ b/server/internal/integrations/weixin/protocol.go
@@ -1,0 +1,205 @@
+package weixin
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+)
+
+// The protocol structures mirror Tencent's maintained reference channel:
+// https://github.com/Tencent/openclaw-weixin/tree/main/src/api
+//
+// Keep them intentionally narrow. Unknown response fields are ignored by
+// encoding/json, which lets the adapter tolerate additive upstream changes
+// while contract tests catch changes to fields Multica actually depends on.
+
+const (
+	defaultBaseURL    = "https://ilinkai.weixin.qq.com"
+	defaultBotType    = "3"
+	defaultILinkAppID = "bot"
+	// The wire headers are pinned to the Tencent reference version whose
+	// fixtures this first client slice implements. Bump both values together
+	// when contract tests are updated against a newer reference release.
+	defaultChannelVersion = "2.4.6"
+	defaultClientVersion  = "132102" // 2<<16 | 4<<8 | 6
+	defaultBotAgent       = "Multica"
+	defaultRequestTimeout = 15 * time.Second
+	defaultPollTimeout    = 35 * time.Second
+	maxPollTimeout        = 60 * time.Second
+	minPollTimeout        = 5 * time.Second
+	maxResponseBytes      = 2 << 20
+)
+
+const (
+	messageTypeUser = 1
+	messageTypeBot  = 2
+
+	messageItemTypeText  = 1
+	messageItemTypeVoice = 3
+
+	messageStateFinish = 2
+)
+
+// ErrReauthorizationRequired means iLink rejected the bot session as stale.
+// The installation layer should mark the connection degraded and ask the user
+// to scan a fresh QR code instead of reconnecting forever.
+var ErrReauthorizationRequired = errors.New("weixin: reauthorization required")
+
+// APIError is a successful HTTP response whose iLink ret/errcode reports a
+// protocol failure. It never contains credentials or request payloads.
+type APIError struct {
+	Operation string
+	Ret       int
+	ErrCode   int
+	Message   string
+}
+
+func (e *APIError) Error() string {
+	code := e.ErrCode
+	if code == 0 {
+		code = e.Ret
+	}
+	if e.Message == "" {
+		return fmt.Sprintf("weixin: %s failed (code=%d)", e.Operation, code)
+	}
+	return fmt.Sprintf("weixin: %s failed (code=%d message=%q)", e.Operation, code, e.Message)
+}
+
+func (e *APIError) Unwrap() error {
+	if e.Ret == -14 || e.ErrCode == -14 {
+		return ErrReauthorizationRequired
+	}
+	return nil
+}
+
+type baseInfo struct {
+	ChannelVersion string `json:"channel_version,omitempty"`
+	BotAgent       string `json:"bot_agent,omitempty"`
+}
+
+// QRCode is the opaque polling token plus the content that the frontend should
+// render as a QR code. The opaque Code itself must never be rendered or logged.
+type QRCode struct {
+	Code         string `json:"qrcode"`
+	ImageContent string `json:"qrcode_img_content"`
+}
+
+// QRStatus is the complete state returned by get_qrcode_status. The caller
+// decides whether to request a verification code, follow an allowlisted
+// redirect, finish installation, or expire the local login session.
+type QRStatus struct {
+	Status       string `json:"status"`
+	BotToken     string `json:"bot_token,omitempty"`
+	BotID        string `json:"ilink_bot_id,omitempty"`
+	BaseURL      string `json:"baseurl,omitempty"`
+	ScannerID    string `json:"ilink_user_id,omitempty"`
+	RedirectHost string `json:"redirect_host,omitempty"`
+}
+
+func (s QRStatus) confirmed() bool {
+	return s.Status == "confirmed"
+}
+
+// MessageItem is one content item inside an iLink message. Media fields are
+// intentionally omitted from this first text slice; Voice.Text is retained so
+// a server-provided voice transcript can be treated as text without downloading
+// or decoding SILK audio.
+type MessageItem struct {
+	Type  int        `json:"type,omitempty"`
+	MsgID string     `json:"msg_id,omitempty"`
+	Text  *TextItem  `json:"text_item,omitempty"`
+	Voice *VoiceItem `json:"voice_item,omitempty"`
+}
+
+type TextItem struct {
+	Text string `json:"text,omitempty"`
+}
+
+type VoiceItem struct {
+	Text string `json:"text,omitempty"`
+}
+
+// Message mirrors the stable subset of WeixinMessage used for text routing.
+// MessageID stays json.RawMessage because upstream has emitted numeric ids and
+// fixtures from older bridges have used strings. stableMessageID accepts both.
+type Message struct {
+	Seq          int64           `json:"seq,omitempty"`
+	MessageID    json.RawMessage `json:"message_id,omitempty"`
+	FromUserID   string          `json:"from_user_id,omitempty"`
+	ToUserID     string          `json:"to_user_id,omitempty"`
+	ClientID     string          `json:"client_id,omitempty"`
+	CreateTimeMS int64           `json:"create_time_ms,omitempty"`
+	SessionID    string          `json:"session_id,omitempty"`
+	GroupID      string          `json:"group_id,omitempty"`
+	MessageType  int             `json:"message_type,omitempty"`
+	MessageState int             `json:"message_state,omitempty"`
+	Items        []MessageItem   `json:"item_list,omitempty"`
+	ContextToken string          `json:"context_token,omitempty"`
+	RunID        string          `json:"run_id,omitempty"`
+}
+
+type getUpdatesRequest struct {
+	Cursor   string   `json:"get_updates_buf"`
+	BaseInfo baseInfo `json:"base_info"`
+}
+
+// Updates is one long-poll response. Cursor is opaque and must be persisted
+// only after all Messages in the response are durably handled.
+type Updates struct {
+	Ret            int       `json:"ret,omitempty"`
+	ErrCode        int       `json:"errcode,omitempty"`
+	ErrorMessage   string    `json:"errmsg,omitempty"`
+	Messages       []Message `json:"msgs,omitempty"`
+	Cursor         string    `json:"get_updates_buf,omitempty"`
+	LongPollMillis int64     `json:"longpolling_timeout_ms,omitempty"`
+}
+
+func (u Updates) pollTimeout(fallback time.Duration) time.Duration {
+	if fallback <= 0 {
+		fallback = defaultPollTimeout
+	}
+	if u.LongPollMillis <= 0 {
+		return fallback
+	}
+	d := time.Duration(u.LongPollMillis) * time.Millisecond
+	if d < minPollTimeout {
+		return minPollTimeout
+	}
+	if d > maxPollTimeout {
+		return maxPollTimeout
+	}
+	return d
+}
+
+type sendMessageRequest struct {
+	Message  Message  `json:"msg"`
+	BaseInfo baseInfo `json:"base_info"`
+}
+
+type apiResponse struct {
+	Ret          int    `json:"ret,omitempty"`
+	ErrCode      int    `json:"errcode,omitempty"`
+	ErrorMessage string `json:"errmsg,omitempty"`
+}
+
+func validateQRStatus(status QRStatus) error {
+	if !status.confirmed() {
+		return nil
+	}
+	missing := make([]string, 0, 3)
+	if strings.TrimSpace(status.BotToken) == "" {
+		missing = append(missing, "bot_token")
+	}
+	if strings.TrimSpace(status.BotID) == "" {
+		missing = append(missing, "ilink_bot_id")
+	}
+	if strings.TrimSpace(status.BaseURL) == "" {
+		missing = append(missing, "baseurl")
+	}
+	if len(missing) > 0 {
+		return fmt.Errorf("weixin: confirmed QR response missing %s", strings.Join(missing, ", "))
+	}
+	return nil
+}

--- a/server/internal/integrations/weixin/receiver.go
+++ b/server/internal/integrations/weixin/receiver.go
@@ -1,0 +1,136 @@
+package weixin
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/multica-ai/multica/server/internal/integrations/channel"
+)
+
+// UpdatesClient is the receive-side slice of Client. The interface keeps the
+// cursor-ordering contract testable without a network server.
+type UpdatesClient interface {
+	GetUpdates(ctx context.Context, baseURL, token, cursor string, timeout time.Duration) (Updates, error)
+}
+
+var _ UpdatesClient = (*Client)(nil)
+
+// CursorStore persists the opaque get_updates_buf outside installation config.
+// Installation config is supervisor-fingerprinted; writing a cursor there after
+// every poll would continuously restart the channel connection.
+type CursorStore interface {
+	LoadCursor(ctx context.Context, installationKey string) (string, error)
+	SaveCursor(ctx context.Context, installationKey, cursor string) error
+}
+
+// ReceiverConfig is one installation's long-poll receive configuration.
+type ReceiverConfig struct {
+	InstallationKey string
+	BotID           string
+	BotToken        string
+	BaseURL         string
+	PollTimeout     time.Duration
+	Client          UpdatesClient
+	Cursors         CursorStore
+	Handler         channel.InboundHandler
+}
+
+// Receiver owns the getupdates loop for one installation. It processes messages
+// sequentially and advances the cursor only after the complete returned batch
+// has been accepted by the shared Router. A crash before cursor persistence
+// therefore causes safe replay rather than message loss; engine dedup absorbs
+// already-committed messages.
+type Receiver struct {
+	installationKey string
+	botID           string
+	botToken        string
+	baseURL         string
+	pollTimeout     time.Duration
+	client          UpdatesClient
+	cursors         CursorStore
+	handler         channel.InboundHandler
+}
+
+func NewReceiver(cfg ReceiverConfig) (*Receiver, error) {
+	if strings.TrimSpace(cfg.InstallationKey) == "" {
+		return nil, errors.New("weixin: receiver installation key is required")
+	}
+	if strings.TrimSpace(cfg.BotID) == "" {
+		return nil, errors.New("weixin: receiver bot id is required")
+	}
+	if strings.TrimSpace(cfg.BotToken) == "" {
+		return nil, errors.New("weixin: receiver bot token is required")
+	}
+	if strings.TrimSpace(cfg.BaseURL) == "" {
+		return nil, errors.New("weixin: receiver base URL is required")
+	}
+	if cfg.Client == nil {
+		return nil, errors.New("weixin: receiver client is required")
+	}
+	if cfg.Cursors == nil {
+		return nil, errors.New("weixin: receiver cursor store is required")
+	}
+	if cfg.Handler == nil {
+		return nil, errors.New("weixin: receiver inbound handler is required")
+	}
+	if cfg.PollTimeout <= 0 {
+		cfg.PollTimeout = defaultPollTimeout
+	}
+	return &Receiver{
+		installationKey: cfg.InstallationKey,
+		botID:           cfg.BotID,
+		botToken:        cfg.BotToken,
+		baseURL:         cfg.BaseURL,
+		pollTimeout:     cfg.PollTimeout,
+		client:          cfg.Client,
+		cursors:         cfg.Cursors,
+		handler:         cfg.Handler,
+	}, nil
+}
+
+// Run blocks until ctx is cancelled or an infrastructure/protocol failure asks
+// the supervisor to reconnect. Product-level drops remain the Router's concern.
+func (r *Receiver) Run(ctx context.Context) error {
+	cursor, err := r.cursors.LoadCursor(ctx, r.installationKey)
+	if err != nil {
+		return fmt.Errorf("weixin: load receive cursor: %w", err)
+	}
+	timeout := r.pollTimeout
+	for {
+		if ctx.Err() != nil {
+			return nil
+		}
+		updates, err := r.client.GetUpdates(ctx, r.baseURL, r.botToken, cursor, timeout)
+		if err != nil {
+			if ctx.Err() != nil {
+				return nil
+			}
+			return err
+		}
+		timeout = updates.pollTimeout(timeout)
+		for _, raw := range updates.Messages {
+			msg, ok := NormalizeInbound(raw, r.botID)
+			if !ok {
+				continue
+			}
+			if err := r.handler(ctx, msg); err != nil {
+				if ctx.Err() != nil {
+					return nil
+				}
+				return fmt.Errorf("weixin: handle inbound message %q: %w", msg.MessageID, err)
+			}
+		}
+		if updates.Cursor != "" && updates.Cursor != cursor {
+			if err := r.cursors.SaveCursor(ctx, r.installationKey, updates.Cursor); err != nil {
+				if ctx.Err() != nil {
+					return nil
+				}
+				return fmt.Errorf("weixin: save receive cursor: %w", err)
+			}
+			cursor = updates.Cursor
+		}
+	}
+}

--- a/server/internal/integrations/weixin/receiver_test.go
+++ b/server/internal/integrations/weixin/receiver_test.go
@@ -1,0 +1,271 @@
+package weixin
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/multica-ai/multica/server/internal/integrations/channel"
+)
+
+type pollCall struct {
+	baseURL string
+	token   string
+	cursor  string
+	timeout time.Duration
+}
+
+type fakeUpdatesClient struct {
+	calls []pollCall
+	fn    func(context.Context, int, pollCall) (Updates, error)
+}
+
+func (f *fakeUpdatesClient) GetUpdates(ctx context.Context, baseURL, token, cursor string, timeout time.Duration) (Updates, error) {
+	call := pollCall{baseURL: baseURL, token: token, cursor: cursor, timeout: timeout}
+	index := len(f.calls)
+	f.calls = append(f.calls, call)
+	return f.fn(ctx, index, call)
+}
+
+type fakeCursorStore struct {
+	initial  string
+	loadErr  error
+	saveErr  error
+	loadKeys []string
+	saves    []struct {
+		key    string
+		cursor string
+	}
+}
+
+func (f *fakeCursorStore) LoadCursor(_ context.Context, key string) (string, error) {
+	f.loadKeys = append(f.loadKeys, key)
+	return f.initial, f.loadErr
+}
+
+func (f *fakeCursorStore) SaveCursor(_ context.Context, key, cursor string) error {
+	f.saves = append(f.saves, struct {
+		key    string
+		cursor string
+	}{key: key, cursor: cursor})
+	return f.saveErr
+}
+
+func TestReceiverSavesCursorAfterCompleteBatch(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	client := &fakeUpdatesClient{}
+	client.fn = func(ctx context.Context, index int, call pollCall) (Updates, error) {
+		if index > 0 {
+			<-ctx.Done()
+			return Updates{}, ctx.Err()
+		}
+		return Updates{
+			Cursor: "cursor-2",
+			Messages: []Message{
+				testInboundMessage(1, "first"),
+				// Bot echoes are intentionally ignored but do not prevent the
+				// successfully handled batch cursor from advancing.
+				func() Message {
+					m := testInboundMessage(2, "echo")
+					m.MessageType = messageTypeBot
+					return m
+				}(),
+				testInboundMessage(3, "second"),
+			},
+		}, nil
+	}
+	cursors := &fakeCursorStore{initial: "cursor-1"}
+	var handled []string
+	receiver := mustReceiver(t, ReceiverConfig{
+		Client:  client,
+		Cursors: cursors,
+		Handler: func(_ context.Context, msg channel.InboundMessage) error {
+			handled = append(handled, msg.Text)
+			if len(handled) == 2 {
+				cancel()
+			}
+			return nil
+		},
+	})
+
+	if err := receiver.Run(ctx); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if fmt.Sprint(handled) != "[first second]" {
+		t.Fatalf("handled = %#v", handled)
+	}
+	if len(cursors.saves) != 1 || cursors.saves[0].cursor != "cursor-2" {
+		t.Fatalf("cursor saves = %#v", cursors.saves)
+	}
+	if len(client.calls) != 1 || client.calls[0].cursor != "cursor-1" {
+		t.Fatalf("poll calls = %#v", client.calls)
+	}
+}
+
+func TestReceiverDoesNotAdvanceCursorWhenHandlerFails(t *testing.T) {
+	wantErr := errors.New("database unavailable")
+	client := &fakeUpdatesClient{fn: func(context.Context, int, pollCall) (Updates, error) {
+		return Updates{Cursor: "cursor-2", Messages: []Message{testInboundMessage(1, "first")}}, nil
+	}}
+	cursors := &fakeCursorStore{initial: "cursor-1"}
+	receiver := mustReceiver(t, ReceiverConfig{
+		Client:  client,
+		Cursors: cursors,
+		Handler: func(context.Context, channel.InboundMessage) error { return wantErr },
+	})
+
+	err := receiver.Run(context.Background())
+	if !errors.Is(err, wantErr) {
+		t.Fatalf("Run error = %v", err)
+	}
+	if len(cursors.saves) != 0 {
+		t.Fatalf("cursor advanced after failed handler: %#v", cursors.saves)
+	}
+}
+
+func TestReceiverResumesAndClampsSuggestedTimeout(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	client := &fakeUpdatesClient{}
+	client.fn = func(ctx context.Context, index int, call pollCall) (Updates, error) {
+		if index == 0 {
+			return Updates{Cursor: "next", LongPollMillis: 1000}, nil
+		}
+		cancel()
+		return Updates{}, context.Canceled
+	}
+	cursors := &fakeCursorStore{initial: "resume"}
+	receiver := mustReceiver(t, ReceiverConfig{
+		Client:  client,
+		Cursors: cursors,
+		Handler: func(context.Context, channel.InboundMessage) error { return nil },
+	})
+
+	if err := receiver.Run(ctx); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if len(client.calls) != 2 {
+		t.Fatalf("poll calls = %#v", client.calls)
+	}
+	if client.calls[0].cursor != "resume" || client.calls[1].cursor != "next" {
+		t.Fatalf("poll cursors = %#v", client.calls)
+	}
+	if client.calls[1].timeout != minPollTimeout {
+		t.Fatalf("second timeout = %s, want %s", client.calls[1].timeout, minPollTimeout)
+	}
+	if len(cursors.saves) != 1 || cursors.saves[0].cursor != "next" {
+		t.Fatalf("cursor saves = %#v", cursors.saves)
+	}
+}
+
+func TestReceiverPropagatesReauthorizationAndStoreErrors(t *testing.T) {
+	t.Run("load", func(t *testing.T) {
+		wantErr := errors.New("load failed")
+		receiver := mustReceiver(t, ReceiverConfig{
+			Client:  &fakeUpdatesClient{fn: func(context.Context, int, pollCall) (Updates, error) { return Updates{}, nil }},
+			Cursors: &fakeCursorStore{loadErr: wantErr},
+			Handler: func(context.Context, channel.InboundMessage) error { return nil },
+		})
+		if err := receiver.Run(context.Background()); !errors.Is(err, wantErr) {
+			t.Fatalf("Run error = %v", err)
+		}
+	})
+
+	t.Run("save", func(t *testing.T) {
+		wantErr := errors.New("save failed")
+		receiver := mustReceiver(t, ReceiverConfig{
+			Client: &fakeUpdatesClient{fn: func(context.Context, int, pollCall) (Updates, error) {
+				return Updates{Cursor: "next"}, nil
+			}},
+			Cursors: &fakeCursorStore{saveErr: wantErr},
+			Handler: func(context.Context, channel.InboundMessage) error { return nil },
+		})
+		if err := receiver.Run(context.Background()); !errors.Is(err, wantErr) {
+			t.Fatalf("Run error = %v", err)
+		}
+	})
+
+	t.Run("stale token", func(t *testing.T) {
+		receiver := mustReceiver(t, ReceiverConfig{
+			Client: &fakeUpdatesClient{fn: func(context.Context, int, pollCall) (Updates, error) {
+				return Updates{}, ErrReauthorizationRequired
+			}},
+			Cursors: &fakeCursorStore{},
+			Handler: func(context.Context, channel.InboundMessage) error { return nil },
+		})
+		if err := receiver.Run(context.Background()); !errors.Is(err, ErrReauthorizationRequired) {
+			t.Fatalf("Run error = %v", err)
+		}
+	})
+}
+
+func TestNewReceiverValidatesDurableDependencies(t *testing.T) {
+	valid := ReceiverConfig{
+		InstallationKey: "installation-id",
+		BotID:           "bot@im.bot",
+		BotToken:        "token",
+		BaseURL:         defaultBaseURL,
+		Client: &fakeUpdatesClient{fn: func(context.Context, int, pollCall) (Updates, error) {
+			return Updates{}, nil
+		}},
+		Cursors: &fakeCursorStore{},
+		Handler: func(context.Context, channel.InboundMessage) error { return nil },
+	}
+	tests := []struct {
+		name   string
+		mutate func(*ReceiverConfig)
+	}{
+		{"installation key", func(c *ReceiverConfig) { c.InstallationKey = "" }},
+		{"bot id", func(c *ReceiverConfig) { c.BotID = "" }},
+		{"bot token", func(c *ReceiverConfig) { c.BotToken = "" }},
+		{"base URL", func(c *ReceiverConfig) { c.BaseURL = "" }},
+		{"client", func(c *ReceiverConfig) { c.Client = nil }},
+		{"cursor store", func(c *ReceiverConfig) { c.Cursors = nil }},
+		{"handler", func(c *ReceiverConfig) { c.Handler = nil }},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := valid
+			tt.mutate(&cfg)
+			if _, err := NewReceiver(cfg); err == nil {
+				t.Fatal("NewReceiver accepted invalid config")
+			}
+		})
+	}
+}
+
+func mustReceiver(t *testing.T, cfg ReceiverConfig) *Receiver {
+	t.Helper()
+	if cfg.InstallationKey == "" {
+		cfg.InstallationKey = "installation-id"
+	}
+	if cfg.BotID == "" {
+		cfg.BotID = "bot@im.bot"
+	}
+	if cfg.BotToken == "" {
+		cfg.BotToken = "token"
+	}
+	if cfg.BaseURL == "" {
+		cfg.BaseURL = defaultBaseURL
+	}
+	receiver, err := NewReceiver(cfg)
+	if err != nil {
+		t.Fatalf("NewReceiver: %v", err)
+	}
+	return receiver
+}
+
+func testInboundMessage(id int, text string) Message {
+	return Message{
+		MessageID:    json.RawMessage(fmt.Sprintf("%d", id)),
+		FromUserID:   "user@im.wechat",
+		ToUserID:     "bot@im.bot",
+		MessageType:  messageTypeUser,
+		MessageState: messageStateFinish,
+		Items:        []MessageItem{{Type: messageItemTypeText, Text: &TextItem{Text: text}}},
+	}
+}


### PR DESCRIPTION
## What does this PR do?

This draft PR adds the reviewable protocol foundation for **personal WeChat direct messages over Tencent iLink**. It intentionally does not register a user-visible channel yet: the goal of this first slice is to validate the security- and reliability-sensitive wire layer before installation persistence, channel-engine wiring, and UI make it production reachable.

Multica already has a generalized channel engine, but it has no current-main implementation of the personal-WeChat protocol. iLink also has two constraints that make a thin generic HTTP wrapper unsafe:

1. `get_updates_buf` is an opaque receive cursor. Persisting it before a complete batch is durably handled can lose messages, while keeping it only in memory makes restart behavior ambiguous.
2. Replies depend on a rotating inbound `context_token`, and server-controlled base URLs / QR redirects must not become arbitrary SSRF destinations.

This change isolates those constraints under `server/internal/integrations/weixin/` and follows Tencent's maintained `Tencent/openclaw-weixin` v2.4.6 reference protocol. It uses `weixin` as a distinct durable channel type so personal WeChat cannot be confused with the existing `wecom` Enterprise WeChat adapter.

The resulting user-visible behavior is deliberately unchanged in this PR. A follow-up can now build QR-session persistence, encrypted installation credentials and rotating context state, the `channel.Factory` / `ResolverSet`, outbound events, and management UI on a tested protocol boundary.

### Reliability and security decisions

- QR creation uses the current official POST shape; QR status supports verification-code and redirect states.
- Production base URLs are HTTPS-only and restricted to the Tencent `*.weixin.qq.com` boundary; returned account base URLs and redirect hosts are revalidated before use.
- Bot tokens and context tokens are never logged or included in HTTP error bodies.
- Authenticated requests include the iLink-specific headers and `base_info` compatibility fields.
- An HTTP 200 is not treated as delivery success when protocol `ret` / `errcode` is nonzero; `-14` maps to a typed reauthorization error.
- Direct user messages only are normalized. Bot echoes, group messages, incomplete streaming messages, and media-only messages are rejected instead of claiming unsupported capability.
- Upstream message ids are preferred; a deterministic fallback prevents reconnect replay from receiving random dedup ids.
- The receiver loads an external durable cursor and saves the next cursor only after every supported message in the batch has been accepted by the shared inbound handler.
- Outbound sends require a context token, validate protocol delivery, chunk Unicode on rune boundaries, and allow a durable worker to reuse the same client id on an ambiguous retry.

## Related Issue

Progresses #6548. This foundation is not sufficient to close the feature request.

Prior art: #5306 contains an earlier full-stack iLink attempt. That PR currently conflicts with main and predates the latest channel-engine work. This PR credits that exploration while taking a smaller current-main slice and aligning the protocol behavior with the maintained Tencent reference, direct-only scope, strict host validation, and durable-cursor contract.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Refactor / code improvement (no behavior change)
- [ ] Documentation update
- [x] Tests (adding or improving test coverage)
- [ ] CI / infrastructure

## Changes Made

- Added typed iLink QR, status, `getupdates`, and `sendmessage` protocol models in `server/internal/integrations/weixin/protocol.go`.
- Added a context-cancellable HTTP client with official headers, bounded responses/timeouts, typed API errors, compatibility-version pinning, and strict Tencent URL policy in `server/internal/integrations/weixin/client.go`.
- Added direct-message normalization, bot/group filtering, rotating context metadata, voice-transcript degradation, and stable inbound dedup ids in `server/internal/integrations/weixin/inbound.go`.
- Added a cursor-store-backed receiver that advances `get_updates_buf` only after complete batch handling in `server/internal/integrations/weixin/receiver.go`.
- Added unit, failure-path, timeout, URL-policy, protocol-shape, deterministic-id, cursor-ordering, and race coverage across the package.

## How to Test

From `server/`:

1. Run the focused race suite:

   ```bash
   go test -race -timeout 90s ./internal/integrations/weixin
   ```

2. Run vet for the new package:

   ```bash
   go vet ./internal/integrations/weixin
   ```

3. Run all integration-package tests:

   ```bash
   go test -timeout 10m ./internal/integrations/...
   ```

4. Compile every server package:

   ```bash
   go test -run '^$' -timeout 10m ./...
   ```

All four commands pass locally. `make test` was also attempted, but the local full-suite harness could not start its PostgreSQL container because the Docker/OrbStack daemon was offline; CI should exercise that container-backed path.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have run the relevant local tests and they pass
- [x] I have added or updated tests where applicable
- [x] UI is unchanged, so screenshots are not applicable to this slice
- [x] User-facing documentation is unchanged because the channel is not registered yet
- [x] No runtime, coding tool, or UI tab is added in this slice
- [x] No Chinese product copy is changed
- [x] I have considered and documented the risks above
- [x] I will address all reviewer comments before requesting merge

## AI Disclosure

**AI tool used:** OpenAI Codex

**Prompt / approach:**

Codex inspected issue #6548, the latest Multica channel engine and WeCom/DingTalk adapter patterns, Tencent's current `openclaw-weixin` protocol source, and prior PR #5306. It then implemented a deliberately narrow protocol-first slice on a fresh branch from current `main`, added failure-path and race tests, ran focused and broad Go verification, and documented the remaining production wiring rather than implying that the channel is already user-visible.

## Screenshots (optional)

Not applicable; this PR has no UI changes.
