### PR TITLE
MUL-5846 fix(agent): stop launching CodeBuddy with MCP disabled

### DIFF
--- a/server/internal/daemon/runtime_mcp.go
+++ b/server/internal/daemon/runtime_mcp.go
@@ -77,6 +77,138 @@ func mergeRuntimeAndAgentMcpConfig(provider string, agentConfig json.RawMessage)
 	return raw, nil
 }
 
+// codebuddyUserMcpConfigPath returns the user-scope MCP config file CodeBuddy
+// actually reads.
+//
+// CodeBuddy is a Claude Code fork but resolves its own config, so `~/.claude.json`
+// is never consulted. Its config directory is `$CODEBUDDY_CONFIG_DIR`, defaulting
+// to `~/.codebuddy`, and the user-scope MCP file is the FIRST of these that
+// exists — the list is a fallback chain, not a merge:
+//
+//	<configDir>/.mcp.json   (what `codebuddy mcp add --scope user` writes)
+//	<configDir>/mcp.json
+//	~/.codebuddy.json
+//
+// When none exist the first candidate is returned so the caller's read fails
+// with os.ErrNotExist and is treated as "no runtime servers", matching the
+// other providers. Verified against CodeBuddy 2.x by writing each file in turn
+// and reading back `codebuddy mcp list`.
+func codebuddyUserMcpConfigPath(home string) string {
+	configDir := strings.TrimSpace(os.Getenv("CODEBUDDY_CONFIG_DIR"))
+	if configDir == "" {
+		configDir = filepath.Join(home, ".codebuddy")
+	}
+	candidates := []string{
+		filepath.Join(configDir, ".mcp.json"),
+		filepath.Join(configDir, "mcp.json"),
+		filepath.Join(home, ".codebuddy.json"),
+	}
+	for _, candidate := range candidates {
+		if info, err := os.Stat(candidate); err == nil && !info.IsDir() {
+			return candidate
+		}
+	}
+	return candidates[0]
+}
+
+// unmarshalRuntimeMcpConfig decodes one runtime's config file. "jsonc" is JSON
+// with comments and trailing commas, which CodeBuddy accepts in its MCP files —
+// parsing those as strict JSON would drop every server behind a single `//`.
+func unmarshalRuntimeMcpConfig(raw []byte, format string) (map[string]any, error) {
+	var cfg map[string]any
+	switch format {
+	case "toml":
+		if err := toml.Unmarshal(raw, &cfg); err != nil {
+			return nil, fmt.Errorf("parse runtime MCP config: %w", err)
+		}
+	case "jsonc":
+		if err := json.Unmarshal(stripJSONC(raw), &cfg); err != nil {
+			return nil, fmt.Errorf("parse runtime MCP config: %w", err)
+		}
+	default:
+		if err := json.Unmarshal(raw, &cfg); err != nil {
+			return nil, fmt.Errorf("parse runtime MCP config: %w", err)
+		}
+	}
+	return cfg, nil
+}
+
+// stripJSONC rewrites JSONC into strict JSON: `//` and `/* */` comments become
+// spaces and trailing commas before `}` / `]` are dropped. String literals are
+// copied verbatim, so a `//` or a comma inside a command argument survives.
+// Comments are blanked rather than deleted so byte offsets in any parse error
+// still line up with the file the user wrote.
+func stripJSONC(raw []byte) []byte {
+	out := make([]byte, 0, len(raw))
+	// Offsets into out of commas that are still candidates for removal. Reset
+	// whenever a value follows, so only a genuinely trailing comma is dropped.
+	var pendingCommas []int
+	inString := false
+	escaped := false
+
+	for i := 0; i < len(raw); i++ {
+		c := raw[i]
+
+		if inString {
+			out = append(out, c)
+			switch {
+			case escaped:
+				escaped = false
+			case c == '\\':
+				escaped = true
+			case c == '"':
+				inString = false
+			}
+			continue
+		}
+
+		switch {
+		case c == '"':
+			inString = true
+			pendingCommas = pendingCommas[:0]
+			out = append(out, c)
+		case c == '/' && i+1 < len(raw) && raw[i+1] == '/':
+			for i < len(raw) && raw[i] != '\n' {
+				out = append(out, ' ')
+				i++
+			}
+			if i < len(raw) {
+				out = append(out, raw[i])
+			}
+		case c == '/' && i+1 < len(raw) && raw[i+1] == '*':
+			out = append(out, ' ', ' ')
+			i += 2
+			for i < len(raw) && !(raw[i] == '*' && i+1 < len(raw) && raw[i+1] == '/') {
+				if raw[i] == '\n' {
+					out = append(out, '\n')
+				} else {
+					out = append(out, ' ')
+				}
+				i++
+			}
+			if i < len(raw) {
+				out = append(out, ' ')
+				i++ // consume '*'; the loop's i++ consumes '/'
+			}
+		case c == ',':
+			pendingCommas = append(pendingCommas, len(out))
+			out = append(out, c)
+		case c == '}' || c == ']':
+			for _, at := range pendingCommas {
+				out[at] = ' '
+			}
+			pendingCommas = pendingCommas[:0]
+			out = append(out, c)
+		case c == ' ' || c == '\t' || c == '\n' || c == '\r':
+			out = append(out, c)
+		default:
+			pendingCommas = pendingCommas[:0]
+			out = append(out, c)
+		}
+	}
+	return out
+}
+
 // loadRuntimeMcpServerConfigs returns full, secret-bearing runtime MCP entries
 // for task-local merging. Callers must never send the result to the server or
 // logs; the public capabilities endpoint continues to use the redacted summary
@@ -92,11 +224,7 @@ func loadRuntimeMcpServerConfigs(provider string) (map[string]any, bool, error) 
 	case "claude":
 		path, key, format = filepath.Join(home, ".claude.json"), "mcpServers", "json"
 	case "codebuddy":
-		// CodeBuddy is a Claude Code fork but keeps its own config file and
-		// plugin root (`~/.codebuddy.json`, `~/.workbuddy/`). Reading Claude's
-		// file here leaked Claude's servers into CodeBuddy launches while
-		// dropping the ones CodeBuddy itself was configured with.
-		path, key, format = filepath.Join(home, ".codebuddy.json"), "mcpServers", "json"
+		path, key, format = codebuddyUserMcpConfigPath(home), "mcpServers", "jsonc"
 	case "codex":
 		codexHome := strings.TrimSpace(os.Getenv("CODEX_HOME"))
 		if codexHome == "" {
@@ -128,13 +256,9 @@ func loadRuntimeMcpServerConfigs(provider string) (map[string]any, bool, error) 
 	servers := map[string]any{}
 	raw, err := os.ReadFile(path)
 	if err == nil {
-		var cfg map[string]any
-		if format == "toml" {
-			if err := toml.Unmarshal(raw, &cfg); err != nil {
-				return nil, true, fmt.Errorf("parse runtime MCP config: %w", err)
-			}
-		} else if err := json.Unmarshal(raw, &cfg); err != nil {
-			return nil, true, fmt.Errorf("parse runtime MCP config: %w", err)
+		cfg, err := unmarshalRuntimeMcpConfig(raw, format)
+		if err != nil {
+			return nil, true, err
 		}
 		if configured, ok := nestedRuntimeMcpMap(cfg, key); ok {
 			for name, entry := range configured {
@@ -222,7 +346,7 @@ func listRuntimeLocalMcpServers(provider string) ([]runtimeLocalMcpServerSummary
 	case "claude":
 		path, key, source, format = filepath.Join(home, ".claude.json"), "mcpServers", "User config", "json"
 	case "codebuddy":
-		path, key, source, format = filepath.Join(home, ".codebuddy.json"), "mcpServers", "User config", "json"
+		path, key, source, format = codebuddyUserMcpConfigPath(home), "mcpServers", "User config", "jsonc"
 	case "kimi":
 		// Inventory only — kimi is deliberately absent from
 		// loadRuntimeMcpServerConfigs. `kimi acp` merges this file with the
@@ -264,13 +388,9 @@ func listRuntimeLocalMcpServers(provider string) ([]runtimeLocalMcpServerSummary
 	out := make([]runtimeLocalMcpServerSummary, 0)
 	raw, err := os.ReadFile(path)
 	if err == nil {
-		var cfg map[string]any
-		if format == "toml" {
-			if err := toml.Unmarshal(raw, &cfg); err != nil {
-				return nil, true, fmt.Errorf("parse runtime MCP config: %w", err)
-			}
-		} else if err := json.Unmarshal(raw, &cfg); err != nil {
-			return nil, true, fmt.Errorf("parse runtime MCP config: %w", err)
+		cfg, err := unmarshalRuntimeMcpConfig(raw, format)
+		if err != nil {
+			return nil, true, err
 		}
 		if servers, ok := nestedRuntimeMcpMap(cfg, key); ok {
 			out = append(out, runtimeMcpSummaries(servers, source)...)

--- a/server/internal/daemon/runtime_mcp.go
+++ b/server/internal/daemon/runtime_mcp.go
@@ -134,15 +134,24 @@ func unmarshalRuntimeMcpConfig(raw []byte, format string) (map[string]any, error
 }
 
 // stripJSONC rewrites JSONC into strict JSON: `//` and `/* */` comments become
-// spaces and trailing commas before `}` / `]` are dropped. String literals are
-// copied verbatim, so a `//` or a comma inside a command argument survives.
-// Comments are blanked rather than deleted so byte offsets in any parse error
-// still line up with the file the user wrote.
+// spaces and a single trailing comma before `}` / `]` is dropped. String
+// literals are copied verbatim, so a `//` or a comma inside a command argument
+// survives.
+//
+// Output is always the same length as the input — comments and the dropped
+// comma are blanked, never deleted — so a parse-error offset still points at
+// the byte the user actually wrote.
+//
+// Only the LAST comma before a closer is blanked, so genuinely malformed input
+// stays malformed: `[1,,,]` does not silently become `[1]`. This is a
+// pragmatic subset of JSONC covering what CodeBuddy's MCP files use in
+// practice; anything it cannot repair is reported as a parse error rather than
+// guessed at.
 func stripJSONC(raw []byte) []byte {
 	out := make([]byte, 0, len(raw))
-	// Offsets into out of commas that are still candidates for removal. Reset
-	// whenever a value follows, so only a genuinely trailing comma is dropped.
-	var pendingCommas []int
+	// Offset into out of the one comma still eligible for removal, or -1.
+	// Reset by any value token, so only a genuinely trailing comma is dropped.
+	lastComma := -1
 	inString := false
 	escaped := false
 
@@ -165,9 +174,10 @@ func stripJSONC(raw []byte) []byte {
 		switch {
 		case c == '"':
 			inString = true
-			pendingCommas = pendingCommas[:0]
+			lastComma = -1
 			out = append(out, c)
 		case c == '/' && i+1 < len(raw) && raw[i+1] == '/':
+			// Blank through end of line, preserving the newline itself.
 			for i < len(raw) && raw[i] != '\n' {
 				out = append(out, ' ')
 				i++
@@ -176,9 +186,15 @@ func stripJSONC(raw []byte) []byte {
 				out = append(out, raw[i])
 			}
 		case c == '/' && i+1 < len(raw) && raw[i+1] == '*':
-			out = append(out, ' ', ' ')
-			i += 2
-			for i < len(raw) && !(raw[i] == '*' && i+1 < len(raw) && raw[i+1] == '/') {
+			// Blank the whole comment, newlines included, so line numbers and
+			// the total byte count both survive. An unterminated comment
+			// blanks to EOF and the caller reports the resulting parse error.
+			for i < len(raw) {
+				if raw[i] == '*' && i+1 < len(raw) && raw[i+1] == '/' {
+					out = append(out, ' ', ' ')
+					i++ // consume '*'; the loop's i++ consumes '/'
+					break
+				}
 				if raw[i] == '\n' {
 					out = append(out, '\n')
 				} else {
@@ -186,23 +202,19 @@ func stripJSONC(raw []byte) []byte {
 				}
 				i++
 			}
-			if i < len(raw) {
-				out = append(out, ' ')
-				i++ // consume '*'; the loop's i++ consumes '/'
-			}
 		case c == ',':
-			pendingCommas = append(pendingCommas, len(out))
+			lastComma = len(out)
 			out = append(out, c)
 		case c == '}' || c == ']':
-			for _, at := range pendingCommas {
-				out[at] = ' '
+			if lastComma >= 0 {
+				out[lastComma] = ' '
 			}
-			pendingCommas = pendingCommas[:0]
+			lastComma = -1
 			out = append(out, c)
 		case c == ' ' || c == '\t' || c == '\n' || c == '\r':
 			out = append(out, c)
 		default:
-			pendingCommas = pendingCommas[:0]
+			lastComma = -1
 			out = append(out, c)
 		}
 	}
@@ -223,8 +235,12 @@ func loadRuntimeMcpServerConfigs(provider string) (map[string]any, bool, error) 
 	switch provider {
 	case "claude":
 		path, key, format = filepath.Join(home, ".claude.json"), "mcpServers", "json"
-	case "codebuddy":
-		path, key, format = codebuddyUserMcpConfigPath(home), "mcpServers", "jsonc"
+	// codebuddy is deliberately absent. CodeBuddy loads its own user, project
+	// and local scopes on every launch (codebuddy.go never passes
+	// --strict-mcp-config), and a managed entry already wins a same-name
+	// collision, so the daemon pre-merging them would only duplicate what the
+	// CLI does natively — while losing the scope precedence and the approval
+	// gate that protects project-scope servers.
 	case "codex":
 		codexHome := strings.TrimSpace(os.Getenv("CODEX_HOME"))
 		if codexHome == "" {

--- a/server/internal/daemon/runtime_mcp.go
+++ b/server/internal/daemon/runtime_mcp.go
@@ -3,6 +3,7 @@ package daemon
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -122,7 +123,11 @@ func unmarshalRuntimeMcpConfig(raw []byte, format string) (map[string]any, error
 			return nil, fmt.Errorf("parse runtime MCP config: %w", err)
 		}
 	case "jsonc":
-		if err := json.Unmarshal(stripJSONC(raw), &cfg); err != nil {
+		stripped, err := stripJSONC(raw)
+		if err != nil {
+			return nil, fmt.Errorf("parse runtime MCP config: %w", err)
+		}
+		if err := json.Unmarshal(stripped, &cfg); err != nil {
 			return nil, fmt.Errorf("parse runtime MCP config: %w", err)
 		}
 	default:
@@ -147,7 +152,13 @@ func unmarshalRuntimeMcpConfig(raw []byte, format string) (map[string]any, error
 // pragmatic subset of JSONC covering what CodeBuddy's MCP files use in
 // practice; anything it cannot repair is reported as a parse error rather than
 // guessed at.
-func stripJSONC(raw []byte) []byte {
+//
+// An unterminated `/*` is an error rather than a blank-to-EOF, so the Agent >
+// MCP tab cannot list servers out of a file CodeBuddy itself rejects. Verified:
+// the CLI reports "No MCP servers configured" for both an unterminated comment
+// and the `/*/` near-miss, where the opener's `*` must not double as the
+// closer's.
+func stripJSONC(raw []byte) ([]byte, error) {
 	out := make([]byte, 0, len(raw))
 	// Offset into out of the one comma still eligible for removal, or -1.
 	// Reset by any value token, so only a genuinely trailing comma is dropped.
@@ -186,13 +197,17 @@ func stripJSONC(raw []byte) []byte {
 				out = append(out, raw[i])
 			}
 		case c == '/' && i+1 < len(raw) && raw[i+1] == '*':
-			// Blank the whole comment, newlines included, so line numbers and
-			// the total byte count both survive. An unterminated comment
-			// blanks to EOF and the caller reports the resulting parse error.
+			// Consume the opener first so `/*/` cannot reuse its own `*` as the
+			// closer's, then blank the body, newlines included, so line numbers
+			// and the total byte count both survive.
+			out = append(out, ' ', ' ')
+			i += 2
+			closed := false
 			for i < len(raw) {
 				if raw[i] == '*' && i+1 < len(raw) && raw[i+1] == '/' {
 					out = append(out, ' ', ' ')
 					i++ // consume '*'; the loop's i++ consumes '/'
+					closed = true
 					break
 				}
 				if raw[i] == '\n' {
@@ -201,6 +216,9 @@ func stripJSONC(raw []byte) []byte {
 					out = append(out, ' ')
 				}
 				i++
+			}
+			if !closed {
+				return nil, errors.New("unterminated block comment")
 			}
 		case c == ',':
 			lastComma = len(out)
@@ -218,7 +236,7 @@ func stripJSONC(raw []byte) []byte {
 			out = append(out, c)
 		}
 	}
-	return out
+	return out, nil
 }
 
 // loadRuntimeMcpServerConfigs returns full, secret-bearing runtime MCP entries

--- a/server/internal/daemon/runtime_mcp.go
+++ b/server/internal/daemon/runtime_mcp.go
@@ -89,8 +89,14 @@ func loadRuntimeMcpServerConfigs(provider string) (map[string]any, bool, error) 
 
 	var path, key, format string
 	switch provider {
-	case "claude", "codebuddy":
+	case "claude":
 		path, key, format = filepath.Join(home, ".claude.json"), "mcpServers", "json"
+	case "codebuddy":
+		// CodeBuddy is a Claude Code fork but keeps its own config file and
+		// plugin root (`~/.codebuddy.json`, `~/.workbuddy/`). Reading Claude's
+		// file here leaked Claude's servers into CodeBuddy launches while
+		// dropping the ones CodeBuddy itself was configured with.
+		path, key, format = filepath.Join(home, ".codebuddy.json"), "mcpServers", "json"
 	case "codex":
 		codexHome := strings.TrimSpace(os.Getenv("CODEX_HOME"))
 		if codexHome == "" {
@@ -139,7 +145,7 @@ func loadRuntimeMcpServerConfigs(provider string) (map[string]any, bool, error) 
 		return nil, true, fmt.Errorf("read runtime MCP config: %w", err)
 	}
 
-	if provider == "claude" || provider == "codebuddy" {
+	if provider == "claude" {
 		// User configuration has the same precedence Claude uses: plugin
 		// servers only fill names not already defined by the user.
 		for name, entry := range loadClaudePluginMcpServerConfigs(home) {
@@ -213,8 +219,20 @@ func listRuntimeLocalMcpServers(provider string) ([]runtimeLocalMcpServerSummary
 	var path, key, source string
 	var format string
 	switch provider {
-	case "claude", "codebuddy":
+	case "claude":
 		path, key, source, format = filepath.Join(home, ".claude.json"), "mcpServers", "User config", "json"
+	case "codebuddy":
+		path, key, source, format = filepath.Join(home, ".codebuddy.json"), "mcpServers", "User config", "json"
+	case "kimi":
+		// Inventory only — kimi is deliberately absent from
+		// loadRuntimeMcpServerConfigs. `kimi acp` merges this file with the
+		// ephemeral `mcpServers` we send in session/new, so merging it in
+		// again would spawn every user server twice.
+		kimiHome := strings.TrimSpace(os.Getenv("KIMI_CODE_HOME"))
+		if kimiHome == "" {
+			kimiHome = filepath.Join(home, ".kimi-code")
+		}
+		path, key, source, format = filepath.Join(kimiHome, "mcp.json"), "mcpServers", "User config", "json"
 	case "codex":
 		codexHome := strings.TrimSpace(os.Getenv("CODEX_HOME"))
 		if codexHome == "" {
@@ -261,7 +279,7 @@ func listRuntimeLocalMcpServers(provider string) ([]runtimeLocalMcpServerSummary
 		return nil, true, fmt.Errorf("read runtime MCP config: %w", err)
 	}
 
-	if provider == "claude" || provider == "codebuddy" {
+	if provider == "claude" {
 		out = append(out, listClaudePluginMcpServers(home)...)
 	}
 

--- a/server/internal/daemon/runtime_mcp_test.go
+++ b/server/internal/daemon/runtime_mcp_test.go
@@ -2,6 +2,7 @@ package daemon
 
 import (
 	"encoding/json"
+	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
@@ -182,20 +183,79 @@ func TestMergeRuntimeAndAgentMcpConfigNullKeepsNativeInheritance(t *testing.T) {
 	}
 }
 
-// CodeBuddy is a Claude Code fork but keeps its own config file and plugin
-// root. Reading ~/.claude.json for it leaked Claude's servers into CodeBuddy
-// launches while dropping CodeBuddy's own (MUL-5846).
+// CodeBuddy resolves its own config: `$CODEBUDDY_CONFIG_DIR` (default
+// `~/.codebuddy`), user-scope MCP from the first existing of
+// `<configDir>/.mcp.json` -> `<configDir>/mcp.json` -> `~/.codebuddy.json`,
+// parsed as JSONC. `~/.claude.json` is never consulted (MUL-5846).
+func TestCodebuddyUserMcpConfigPathPrecedence(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("CODEBUDDY_CONFIG_DIR", "")
+	configDir := filepath.Join(home, ".codebuddy")
+	if err := os.MkdirAll(configDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	write := func(path string) {
+		if err := os.WriteFile(path, []byte(`{"mcpServers":{}}`), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	// Nothing on disk: the caller must still get a stable path so the read
+	// fails with ErrNotExist rather than the provider looking unsupported.
+	if got, want := codebuddyUserMcpConfigPath(home), filepath.Join(configDir, ".mcp.json"); got != want {
+		t.Fatalf("no files: got %q, want %q", got, want)
+	}
+
+	legacy := filepath.Join(home, ".codebuddy.json")
+	write(legacy)
+	if got := codebuddyUserMcpConfigPath(home); got != legacy {
+		t.Fatalf("legacy only: got %q, want %q", got, legacy)
+	}
+
+	plain := filepath.Join(configDir, "mcp.json")
+	write(plain)
+	if got := codebuddyUserMcpConfigPath(home); got != plain {
+		t.Fatalf("mcp.json must win over ~/.codebuddy.json: got %q", got)
+	}
+
+	dotted := filepath.Join(configDir, ".mcp.json")
+	write(dotted)
+	if got := codebuddyUserMcpConfigPath(home); got != dotted {
+		t.Fatalf(".mcp.json must win over mcp.json: got %q", got)
+	}
+}
+
+func TestCodebuddyUserMcpConfigPathHonorsConfigDirEnv(t *testing.T) {
+	home := t.TempDir()
+	configDir := t.TempDir()
+	t.Setenv("CODEBUDDY_CONFIG_DIR", configDir)
+	want := filepath.Join(configDir, ".mcp.json")
+	if err := os.WriteFile(want, []byte(`{"mcpServers":{}}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if got := codebuddyUserMcpConfigPath(home); got != want {
+		t.Fatalf("got %q, want %q", got, want)
+	}
+}
+
 func TestListRuntimeLocalMcpServersCodebuddyReadsItsOwnConfig(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)
+	t.Setenv("CODEBUDDY_CONFIG_DIR", "")
+	configDir := filepath.Join(home, ".codebuddy")
+	if err := os.MkdirAll(configDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
 	if err := os.WriteFile(filepath.Join(home, ".claude.json"), []byte(`{"mcpServers":{"claude-only":{"command":"claude-cmd"}}}`), 0o600); err != nil {
 		t.Fatal(err)
 	}
-	if err := os.WriteFile(filepath.Join(home, ".codebuddy.json"), []byte(`{"mcpServers":{"buddy":{"command":"buddy-cmd"}}}`), 0o600); err != nil {
+	// JSONC: a comment and a trailing comma must not lose the server.
+	jsonc := "{\n  // user scope\n  \"mcpServers\": {\n    \"buddy\": { \"command\": \"buddy-cmd\", },\n  },\n}\n"
+	if err := os.WriteFile(filepath.Join(configDir, ".mcp.json"), []byte(jsonc), 0o600); err != nil {
 		t.Fatal(err)
 	}
 	// A Claude plugin server must not be attributed to CodeBuddy either:
-	// CodeBuddy plugins live under ~/.workbuddy, not ~/.claude/plugins.
+	// CodeBuddy plugins live under <configDir>/plugins, not ~/.claude/plugins.
 	installPath := writeTestClaudePlugin(t, home, "paper-desktop@paper", "paper-desktop", true)
 	if err := os.WriteFile(filepath.Join(installPath, "mcp.json"), []byte(`{"mcpServers":{"paper":{"type":"http","url":"http://127.0.0.1:29979/mcp"}}}`), 0o600); err != nil {
 		t.Fatal(err)
@@ -210,17 +270,25 @@ func TestListRuntimeLocalMcpServersCodebuddyReadsItsOwnConfig(t *testing.T) {
 	}
 }
 
-func TestMergeRuntimeAndAgentMcpConfigCodebuddyReadsItsOwnConfig(t *testing.T) {
+func TestMergeRuntimeAndAgentMcpConfigCodebuddyMergesLocalAndManaged(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)
+	t.Setenv("CODEBUDDY_CONFIG_DIR", "")
+	configDir := filepath.Join(home, ".codebuddy")
+	if err := os.MkdirAll(configDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
 	if err := os.WriteFile(filepath.Join(home, ".claude.json"), []byte(`{"mcpServers":{"claude-only":{"command":"claude-cmd"}}}`), 0o600); err != nil {
 		t.Fatal(err)
 	}
-	if err := os.WriteFile(filepath.Join(home, ".codebuddy.json"), []byte(`{"mcpServers":{"buddy":{"command":"buddy-cmd"}}}`), 0o600); err != nil {
+	local := `{"mcpServers":{"local-only":{"command":"local-cmd"},"shared":{"command":"local-shared"}}}`
+	if err := os.WriteFile(filepath.Join(configDir, ".mcp.json"), []byte(local), 0o600); err != nil {
 		t.Fatal(err)
 	}
 
-	merged, err := mergeRuntimeAndAgentMcpConfig("codebuddy", json.RawMessage(`{"mcpServers":{"agent-only":{"command":"agent-cmd"}}}`))
+	// Adding one managed server must not disable the user's local ones: strict
+	// mode makes this merged document the whole world CodeBuddy sees.
+	merged, err := mergeRuntimeAndAgentMcpConfig("codebuddy", json.RawMessage(`{"mcpServers":{"shared":{"command":"agent-shared"},"agent-only":{"command":"agent-cmd"}}}`))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -230,14 +298,105 @@ func TestMergeRuntimeAndAgentMcpConfigCodebuddyReadsItsOwnConfig(t *testing.T) {
 	if err := json.Unmarshal(merged, &document); err != nil {
 		t.Fatal(err)
 	}
-	if len(document.McpServers) != 2 {
+	if len(document.McpServers) != 3 {
 		t.Fatalf("merged servers = %#v", document.McpServers)
 	}
 	if _, ok := document.McpServers["claude-only"]; ok {
 		t.Fatalf("Claude's servers must not leak into a CodeBuddy launch: %#v", document.McpServers)
 	}
-	if got := document.McpServers["buddy"]["command"]; got != "buddy-cmd" {
-		t.Fatalf("buddy command = %#v", got)
+	if got := document.McpServers["local-only"]["command"]; got != "local-cmd" {
+		t.Fatalf("local-only command = %#v", got)
+	}
+	if got := document.McpServers["shared"]["command"]; got != "agent-shared" {
+		t.Fatalf("agent must win on a same-name collision, got %#v", got)
+	}
+}
+
+// An explicitly empty managed object still opts into the merged, task-local
+// config — it means "no servers of my own", not "no MCP at all", so the
+// runtime's servers survive.
+func TestMergeRuntimeAndAgentMcpConfigCodebuddyExplicitEmptySet(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("CODEBUDDY_CONFIG_DIR", "")
+	configDir := filepath.Join(home, ".codebuddy")
+	if err := os.MkdirAll(configDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(configDir, ".mcp.json"), []byte(`{"mcpServers":{"local-only":{"command":"local-cmd"}}}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	merged, err := mergeRuntimeAndAgentMcpConfig("codebuddy", json.RawMessage(`{}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var document struct {
+		McpServers map[string]map[string]any `json:"mcpServers"`
+	}
+	if err := json.Unmarshal(merged, &document); err != nil {
+		t.Fatal(err)
+	}
+	if len(document.McpServers) != 1 || document.McpServers["local-only"]["command"] != "local-cmd" {
+		t.Fatalf("merged servers = %#v", document.McpServers)
+	}
+}
+
+// A JSON null keeps the provider's native inheritance path: no managed config
+// means codebuddy.go omits --strict-mcp-config and CodeBuddy resolves its own.
+func TestMergeRuntimeAndAgentMcpConfigCodebuddyNullIsPassthrough(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("CODEBUDDY_CONFIG_DIR", "")
+
+	merged, err := mergeRuntimeAndAgentMcpConfig("codebuddy", json.RawMessage(`null`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(merged) != "null" {
+		t.Fatalf("got %s, want null", merged)
+	}
+}
+
+func TestStripJSONC(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want map[string]any
+	}{
+		{"line comment", "{\n// hi\n\"a\":1\n}", map[string]any{"a": float64(1)}},
+		{"block comment", "{/* hi */\"a\":1}", map[string]any{"a": float64(1)}},
+		{"trailing comma object", `{"a":1,}`, map[string]any{"a": float64(1)}},
+		{"trailing comma nested", `{"a":{"b":1,},}`, map[string]any{"a": map[string]any{"b": float64(1)}}},
+		{
+			"comment-like text inside a string is preserved",
+			`{"a":"http://x//y, /* not a comment */"}`,
+			map[string]any{"a": "http://x//y, /* not a comment */"},
+		},
+		{"escaped quote in string", `{"a":"say \"//\" ok"}`, map[string]any{"a": `say "//" ok`}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var got map[string]any
+			if err := json.Unmarshal(stripJSONC([]byte(tc.in)), &got); err != nil {
+				t.Fatalf("unmarshal %q -> %q: %v", tc.in, stripJSONC([]byte(tc.in)), err)
+			}
+			if fmt.Sprintf("%v", got) != fmt.Sprintf("%v", tc.want) {
+				t.Fatalf("got %#v, want %#v", got, tc.want)
+			}
+		})
+	}
+}
+
+// A trailing comma that is NOT trailing must survive: blanking it would merge
+// two array elements into one.
+func TestStripJSONCKeepsSeparatorCommas(t *testing.T) {
+	var got []any
+	if err := json.Unmarshal(stripJSONC([]byte(`["a","b",]`)), &got); err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 2 || got[0] != "a" || got[1] != "b" {
+		t.Fatalf("got %#v, want [a b]", got)
 	}
 }
 

--- a/server/internal/daemon/runtime_mcp_test.go
+++ b/server/internal/daemon/runtime_mcp_test.go
@@ -181,3 +181,109 @@ func TestMergeRuntimeAndAgentMcpConfigNullKeepsNativeInheritance(t *testing.T) {
 		}
 	}
 }
+
+// CodeBuddy is a Claude Code fork but keeps its own config file and plugin
+// root. Reading ~/.claude.json for it leaked Claude's servers into CodeBuddy
+// launches while dropping CodeBuddy's own (MUL-5846).
+func TestListRuntimeLocalMcpServersCodebuddyReadsItsOwnConfig(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	if err := os.WriteFile(filepath.Join(home, ".claude.json"), []byte(`{"mcpServers":{"claude-only":{"command":"claude-cmd"}}}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(home, ".codebuddy.json"), []byte(`{"mcpServers":{"buddy":{"command":"buddy-cmd"}}}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	// A Claude plugin server must not be attributed to CodeBuddy either:
+	// CodeBuddy plugins live under ~/.workbuddy, not ~/.claude/plugins.
+	installPath := writeTestClaudePlugin(t, home, "paper-desktop@paper", "paper-desktop", true)
+	if err := os.WriteFile(filepath.Join(installPath, "mcp.json"), []byte(`{"mcpServers":{"paper":{"type":"http","url":"http://127.0.0.1:29979/mcp"}}}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	servers, supported, err := listRuntimeLocalMcpServers("codebuddy")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !supported || len(servers) != 1 || servers[0].Name != "buddy" {
+		t.Fatalf("supported=%v servers=%#v", supported, servers)
+	}
+}
+
+func TestMergeRuntimeAndAgentMcpConfigCodebuddyReadsItsOwnConfig(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	if err := os.WriteFile(filepath.Join(home, ".claude.json"), []byte(`{"mcpServers":{"claude-only":{"command":"claude-cmd"}}}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(home, ".codebuddy.json"), []byte(`{"mcpServers":{"buddy":{"command":"buddy-cmd"}}}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	merged, err := mergeRuntimeAndAgentMcpConfig("codebuddy", json.RawMessage(`{"mcpServers":{"agent-only":{"command":"agent-cmd"}}}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var document struct {
+		McpServers map[string]map[string]any `json:"mcpServers"`
+	}
+	if err := json.Unmarshal(merged, &document); err != nil {
+		t.Fatal(err)
+	}
+	if len(document.McpServers) != 2 {
+		t.Fatalf("merged servers = %#v", document.McpServers)
+	}
+	if _, ok := document.McpServers["claude-only"]; ok {
+		t.Fatalf("Claude's servers must not leak into a CodeBuddy launch: %#v", document.McpServers)
+	}
+	if got := document.McpServers["buddy"]["command"]; got != "buddy-cmd" {
+		t.Fatalf("buddy command = %#v", got)
+	}
+}
+
+func TestListRuntimeLocalMcpServersKimi(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("KIMI_CODE_HOME", "")
+	kimiHome := filepath.Join(home, ".kimi-code")
+	if err := os.MkdirAll(kimiHome, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(kimiHome, "mcp.json"), []byte(`{"mcpServers":{"paper":{"url":"https://paper.example/mcp"}}}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	servers, supported, err := listRuntimeLocalMcpServers("kimi")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !supported || len(servers) != 1 || servers[0].Name != "paper" {
+		t.Fatalf("supported=%v servers=%#v", supported, servers)
+	}
+}
+
+// kimi merges <KIMI_CODE_HOME>/mcp.json with the ephemeral `mcpServers` array
+// the ACP backend sends in session/new, and a duplicate name spawns the server
+// twice. So kimi is inventory-only: the task-local merge must leave the agent's
+// config untouched.
+func TestMergeRuntimeAndAgentMcpConfigKimiIsPassthrough(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("KIMI_CODE_HOME", "")
+	kimiHome := filepath.Join(home, ".kimi-code")
+	if err := os.MkdirAll(kimiHome, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(kimiHome, "mcp.json"), []byte(`{"mcpServers":{"paper":{"url":"https://paper.example/mcp"}}}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	agentConfig := json.RawMessage(`{"mcpServers":{"agent-only":{"command":"agent-cmd"}}}`)
+	merged, err := mergeRuntimeAndAgentMcpConfig("kimi", agentConfig)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(merged) != string(agentConfig) {
+		t.Fatalf("kimi merge must be a passthrough, got %s", merged)
+	}
+}

--- a/server/internal/daemon/runtime_mcp_test.go
+++ b/server/internal/daemon/runtime_mcp_test.go
@@ -270,52 +270,10 @@ func TestListRuntimeLocalMcpServersCodebuddyReadsItsOwnConfig(t *testing.T) {
 	}
 }
 
-func TestMergeRuntimeAndAgentMcpConfigCodebuddyMergesLocalAndManaged(t *testing.T) {
-	home := t.TempDir()
-	t.Setenv("HOME", home)
-	t.Setenv("CODEBUDDY_CONFIG_DIR", "")
-	configDir := filepath.Join(home, ".codebuddy")
-	if err := os.MkdirAll(configDir, 0o755); err != nil {
-		t.Fatal(err)
-	}
-	if err := os.WriteFile(filepath.Join(home, ".claude.json"), []byte(`{"mcpServers":{"claude-only":{"command":"claude-cmd"}}}`), 0o600); err != nil {
-		t.Fatal(err)
-	}
-	local := `{"mcpServers":{"local-only":{"command":"local-cmd"},"shared":{"command":"local-shared"}}}`
-	if err := os.WriteFile(filepath.Join(configDir, ".mcp.json"), []byte(local), 0o600); err != nil {
-		t.Fatal(err)
-	}
-
-	// Adding one managed server must not disable the user's local ones: strict
-	// mode makes this merged document the whole world CodeBuddy sees.
-	merged, err := mergeRuntimeAndAgentMcpConfig("codebuddy", json.RawMessage(`{"mcpServers":{"shared":{"command":"agent-shared"},"agent-only":{"command":"agent-cmd"}}}`))
-	if err != nil {
-		t.Fatal(err)
-	}
-	var document struct {
-		McpServers map[string]map[string]any `json:"mcpServers"`
-	}
-	if err := json.Unmarshal(merged, &document); err != nil {
-		t.Fatal(err)
-	}
-	if len(document.McpServers) != 3 {
-		t.Fatalf("merged servers = %#v", document.McpServers)
-	}
-	if _, ok := document.McpServers["claude-only"]; ok {
-		t.Fatalf("Claude's servers must not leak into a CodeBuddy launch: %#v", document.McpServers)
-	}
-	if got := document.McpServers["local-only"]["command"]; got != "local-cmd" {
-		t.Fatalf("local-only command = %#v", got)
-	}
-	if got := document.McpServers["shared"]["command"]; got != "agent-shared" {
-		t.Fatalf("agent must win on a same-name collision, got %#v", got)
-	}
-}
-
-// An explicitly empty managed object still opts into the merged, task-local
-// config — it means "no servers of my own", not "no MCP at all", so the
-// runtime's servers survive.
-func TestMergeRuntimeAndAgentMcpConfigCodebuddyExplicitEmptySet(t *testing.T) {
+// CodeBuddy loads its own user/project/local scopes on every launch, so the
+// daemon must NOT pre-merge them: doing so would duplicate the CLI's own work
+// while losing scope precedence and the project-scope approval gate.
+func TestMergeRuntimeAndAgentMcpConfigCodebuddyIsPassthrough(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)
 	t.Setenv("CODEBUDDY_CONFIG_DIR", "")
@@ -327,34 +285,13 @@ func TestMergeRuntimeAndAgentMcpConfigCodebuddyExplicitEmptySet(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	merged, err := mergeRuntimeAndAgentMcpConfig("codebuddy", json.RawMessage(`{}`))
+	agentConfig := json.RawMessage(`{"mcpServers":{"agent-only":{"command":"agent-cmd"}}}`)
+	merged, err := mergeRuntimeAndAgentMcpConfig("codebuddy", agentConfig)
 	if err != nil {
 		t.Fatal(err)
 	}
-	var document struct {
-		McpServers map[string]map[string]any `json:"mcpServers"`
-	}
-	if err := json.Unmarshal(merged, &document); err != nil {
-		t.Fatal(err)
-	}
-	if len(document.McpServers) != 1 || document.McpServers["local-only"]["command"] != "local-cmd" {
-		t.Fatalf("merged servers = %#v", document.McpServers)
-	}
-}
-
-// A JSON null keeps the provider's native inheritance path: no managed config
-// means codebuddy.go omits --strict-mcp-config and CodeBuddy resolves its own.
-func TestMergeRuntimeAndAgentMcpConfigCodebuddyNullIsPassthrough(t *testing.T) {
-	home := t.TempDir()
-	t.Setenv("HOME", home)
-	t.Setenv("CODEBUDDY_CONFIG_DIR", "")
-
-	merged, err := mergeRuntimeAndAgentMcpConfig("codebuddy", json.RawMessage(`null`))
-	if err != nil {
-		t.Fatal(err)
-	}
-	if string(merged) != "null" {
-		t.Fatalf("got %s, want null", merged)
+	if string(merged) != string(agentConfig) {
+		t.Fatalf("codebuddy merge must be a passthrough, got %s", merged)
 	}
 }
 
@@ -397,6 +334,33 @@ func TestStripJSONCKeepsSeparatorCommas(t *testing.T) {
 	}
 	if len(got) != 2 || got[0] != "a" || got[1] != "b" {
 		t.Fatalf("got %#v, want [a b]", got)
+	}
+}
+
+// Repairing only a genuine trailing comma keeps malformed input malformed —
+// a config the CLI would reject must not be silently accepted here.
+func TestStripJSONCLeavesMalformedInputInvalid(t *testing.T) {
+	for _, in := range []string{`[1,,,]`, `{"a":1,,}`, `[1,,2]`} {
+		var got any
+		if err := json.Unmarshal(stripJSONC([]byte(in)), &got); err == nil {
+			t.Fatalf("%q must stay invalid, got %#v", in, got)
+		}
+	}
+}
+
+// Comments and the dropped comma are blanked, never deleted, so a parse-error
+// offset still points at the byte the user wrote.
+func TestStripJSONCPreservesByteLength(t *testing.T) {
+	for _, in := range []string{
+		"{\n  // c\n  \"a\": 1,\n}\n",
+		`{/* block */"a":1,}`,
+		`{"a":"// not a comment"}`,
+		`{/* unterminated "a":1`,
+		"{}",
+	} {
+		if got, want := len(stripJSONC([]byte(in))), len(in); got != want {
+			t.Fatalf("%q: length %d, want %d (%q)", in, got, want, stripJSONC([]byte(in)))
+		}
 	}
 }
 

--- a/server/internal/daemon/runtime_mcp_test.go
+++ b/server/internal/daemon/runtime_mcp_test.go
@@ -314,9 +314,13 @@ func TestStripJSONC(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
+			stripped, err := stripJSONC([]byte(tc.in))
+			if err != nil {
+				t.Fatalf("stripJSONC %q: %v", tc.in, err)
+			}
 			var got map[string]any
-			if err := json.Unmarshal(stripJSONC([]byte(tc.in)), &got); err != nil {
-				t.Fatalf("unmarshal %q -> %q: %v", tc.in, stripJSONC([]byte(tc.in)), err)
+			if err := json.Unmarshal(stripped, &got); err != nil {
+				t.Fatalf("unmarshal %q -> %q: %v", tc.in, stripped, err)
 			}
 			if fmt.Sprintf("%v", got) != fmt.Sprintf("%v", tc.want) {
 				t.Fatalf("got %#v, want %#v", got, tc.want)
@@ -328,8 +332,12 @@ func TestStripJSONC(t *testing.T) {
 // A trailing comma that is NOT trailing must survive: blanking it would merge
 // two array elements into one.
 func TestStripJSONCKeepsSeparatorCommas(t *testing.T) {
+	stripped, err := stripJSONC([]byte(`["a","b",]`))
+	if err != nil {
+		t.Fatal(err)
+	}
 	var got []any
-	if err := json.Unmarshal(stripJSONC([]byte(`["a","b",]`)), &got); err != nil {
+	if err := json.Unmarshal(stripped, &got); err != nil {
 		t.Fatal(err)
 	}
 	if len(got) != 2 || got[0] != "a" || got[1] != "b" {
@@ -341,8 +349,12 @@ func TestStripJSONCKeepsSeparatorCommas(t *testing.T) {
 // a config the CLI would reject must not be silently accepted here.
 func TestStripJSONCLeavesMalformedInputInvalid(t *testing.T) {
 	for _, in := range []string{`[1,,,]`, `{"a":1,,}`, `[1,,2]`} {
+		stripped, err := stripJSONC([]byte(in))
+		if err != nil {
+			continue
+		}
 		var got any
-		if err := json.Unmarshal(stripJSONC([]byte(in)), &got); err == nil {
+		if err := json.Unmarshal(stripped, &got); err == nil {
 			t.Fatalf("%q must stay invalid, got %#v", in, got)
 		}
 	}
@@ -355,12 +367,56 @@ func TestStripJSONCPreservesByteLength(t *testing.T) {
 		"{\n  // c\n  \"a\": 1,\n}\n",
 		`{/* block */"a":1,}`,
 		`{"a":"// not a comment"}`,
-		`{/* unterminated "a":1`,
+		`{/**/"a":1}`,
 		"{}",
 	} {
-		if got, want := len(stripJSONC([]byte(in))), len(in); got != want {
-			t.Fatalf("%q: length %d, want %d (%q)", in, got, want, stripJSONC([]byte(in)))
+		stripped, err := stripJSONC([]byte(in))
+		if err != nil {
+			t.Fatalf("stripJSONC %q: %v", in, err)
 		}
+		if got, want := len(stripped), len(in); got != want {
+			t.Fatalf("%q: length %d, want %d (%q)", in, got, want, stripped)
+		}
+	}
+}
+
+// A file CodeBuddy itself rejects must not produce an inventory listing. The
+// CLI answers "No MCP servers configured" for both of these; blanking an
+// unterminated comment to EOF would instead have turned the first into valid
+// JSON, and letting the opener's `*` double as the closer's would have made
+// `/*/` a complete comment.
+func TestStripJSONCRejectsUnterminatedBlockComment(t *testing.T) {
+	cases := map[string]string{
+		"unterminated":              `{"mcpServers":{}} /* oops`,
+		"opener not closer":         `/*/ {"mcpServers":{}}`,
+		"unterminated after opener": `/*`,
+	}
+	for name, in := range cases {
+		t.Run(name, func(t *testing.T) {
+			if stripped, err := stripJSONC([]byte(in)); err == nil {
+				t.Fatalf("%q must fail to parse, got %q", in, stripped)
+			}
+		})
+	}
+}
+
+// The same input must reach the caller as a parse error, so the inventory
+// surfaces the problem rather than silently reporting zero servers.
+func TestListRuntimeLocalMcpServersCodebuddyRejectsUnterminatedComment(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("CODEBUDDY_CONFIG_DIR", "")
+	configDir := filepath.Join(home, ".codebuddy")
+	if err := os.MkdirAll(configDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	broken := `{"mcpServers":{"buddy":{"command":"buddy-cmd"}}} /* oops`
+	if err := os.WriteFile(filepath.Join(configDir, ".mcp.json"), []byte(broken), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, _, err := listRuntimeLocalMcpServers("codebuddy"); err == nil {
+		t.Fatal("expected a parse error for a config CodeBuddy itself rejects")
 	}
 }
 

--- a/server/pkg/agent/codebuddy.go
+++ b/server/pkg/agent/codebuddy.go
@@ -65,7 +65,8 @@ func buildCodebuddyArgs(opts ExecOptions, logger *slog.Logger) []string {
 		// pins CodeBuddy to it. With no managed config the flag MUST stay off —
 		// `--strict-mcp-config` means "only use servers from --mcp-config", so
 		// passing it without a config launched every CodeBuddy agent with zero
-		// MCP servers and silently ignored the user's own ~/.codebuddy.json.
+		// MCP servers and silently ignored the user's own CodeBuddy MCP
+		// config (see codebuddyUserMcpConfigPath for where that lives).
 		args = append(args, "--strict-mcp-config")
 	}
 	if opts.Model != "" {

--- a/server/pkg/agent/codebuddy.go
+++ b/server/pkg/agent/codebuddy.go
@@ -107,11 +107,15 @@ func (b *codebuddyBackend) Execute(ctx context.Context, prompt string, opts Exec
 
 	args := buildCodebuddyArgs(opts, b.cfg.Logger)
 
-	// If the caller provided an MCP config, write it to a temp file and pass
-	// --mcp-config <path> so the agent uses a controlled set of MCP servers.
-	// Gated on the same three-state check buildCodebuddyArgs uses for
-	// --strict-mcp-config, so the two never disagree: a JSON `null` means
-	// "inherit the runtime configuration", not "managed empty set".
+	// A managed agent config is written to a temp file and added with
+	// --mcp-config, which ADDS to whatever CodeBuddy loads from its own user,
+	// project and local scopes — buildCodebuddyArgs never passes
+	// --strict-mcp-config, so those stay on. A managed entry wins a same-name
+	// collision natively.
+	//
+	// Three-state, as everywhere else: a JSON `null` means "inherit the runtime
+	// configuration" and skips the flag entirely, while an explicitly empty
+	// object is a managed set that happens to contain no servers.
 	var mcpConfigPath string
 	var mcpFileCleanup func()
 	if hasManagedMcpConfig(opts.McpConfig) {

--- a/server/pkg/agent/codebuddy.go
+++ b/server/pkg/agent/codebuddy.go
@@ -41,7 +41,6 @@ func buildCodebuddyArgs(opts ExecOptions, logger *slog.Logger) []string {
 		"--output-format", "stream-json",
 		"--input-format", "stream-json",
 		"--verbose",
-		"--strict-mcp-config",
 		"--permission-mode", "bypassPermissions",
 		// CodeBuddy's interactive tools have no UI to render in under the
 		// daemon's headless stream-json transport. AskUserQuestion and
@@ -59,6 +58,15 @@ func buildCodebuddyArgs(opts ExecOptions, logger *slog.Logger) []string {
 		// (PermissionUtils.matchPermissionRules), so a comma-joined string
 		// would match nothing despite what the CLI's own help text claims.
 		"--disallowedTools", "AskUserQuestion", "EnterPlanMode", "ExitPlanMode",
+	}
+	if hasManagedMcpConfig(opts.McpConfig) {
+		// Same contract as claude.go: a saved agent-level config is
+		// authoritative (including an explicitly empty object) and strict mode
+		// pins CodeBuddy to it. With no managed config the flag MUST stay off —
+		// `--strict-mcp-config` means "only use servers from --mcp-config", so
+		// passing it without a config launched every CodeBuddy agent with zero
+		// MCP servers and silently ignored the user's own ~/.codebuddy.json.
+		args = append(args, "--strict-mcp-config")
 	}
 	if opts.Model != "" {
 		args = append(args, "--model", opts.Model)
@@ -96,9 +104,12 @@ func (b *codebuddyBackend) Execute(ctx context.Context, prompt string, opts Exec
 
 	// If the caller provided an MCP config, write it to a temp file and pass
 	// --mcp-config <path> so the agent uses a controlled set of MCP servers.
+	// Gated on the same three-state check buildCodebuddyArgs uses for
+	// --strict-mcp-config, so the two never disagree: a JSON `null` means
+	// "inherit the runtime configuration", not "managed empty set".
 	var mcpConfigPath string
 	var mcpFileCleanup func()
-	if len(opts.McpConfig) > 0 {
+	if hasManagedMcpConfig(opts.McpConfig) {
 		path, err := writeMcpConfigToTemp(opts.McpConfig)
 		if err != nil {
 			cancel()

--- a/server/pkg/agent/codebuddy.go
+++ b/server/pkg/agent/codebuddy.go
@@ -59,16 +59,20 @@ func buildCodebuddyArgs(opts ExecOptions, logger *slog.Logger) []string {
 		// would match nothing despite what the CLI's own help text claims.
 		"--disallowedTools", "AskUserQuestion", "EnterPlanMode", "ExitPlanMode",
 	}
-	if hasManagedMcpConfig(opts.McpConfig) {
-		// Same contract as claude.go: a saved agent-level config is
-		// authoritative (including an explicitly empty object) and strict mode
-		// pins CodeBuddy to it. With no managed config the flag MUST stay off —
-		// `--strict-mcp-config` means "only use servers from --mcp-config", so
-		// passing it without a config launched every CodeBuddy agent with zero
-		// MCP servers and silently ignored the user's own CodeBuddy MCP
-		// config (see codebuddyUserMcpConfigPath for where that lives).
-		args = append(args, "--strict-mcp-config")
-	}
+	// NOTE: --strict-mcp-config is deliberately never passed. It means "only
+	// use servers from --mcp-config", which drops CodeBuddy's user, project
+	// AND local scopes. Measured against CodeBuddy 2.x with one real MCP
+	// server registered per scope, using process spawns as the oracle:
+	//
+	//	--mcp-config only ....... managed + user + local  <- what we want
+	//	--mcp-config + strict ... managed only
+	//	strict only ............. nothing at all
+	//
+	// The union is also what mergeRuntimeAndAgentMcpConfig promises: adding
+	// one managed server must not disable the user's own. CodeBuddy applies
+	// it natively, and a managed entry already wins a same-name collision
+	// (verified), so the daemon does not pre-merge — see the codebuddy note
+	// in loadRuntimeMcpServerConfigs.
 	if opts.Model != "" {
 		args = append(args, "--model", opts.Model)
 	}

--- a/server/pkg/agent/codebuddy_test.go
+++ b/server/pkg/agent/codebuddy_test.go
@@ -26,7 +26,6 @@ func TestBuildCodebuddyArgs_Basic(t *testing.T) {
 		"--output-format", "stream-json",
 		"--input-format", "stream-json",
 		"--verbose",
-		"--strict-mcp-config",
 		"--permission-mode", "bypassPermissions",
 		"--disallowedTools", "AskUserQuestion", "EnterPlanMode", "ExitPlanMode",
 		"--model", "claude-sonnet-4-20250514",
@@ -40,6 +39,43 @@ func TestBuildCodebuddyArgs_Basic(t *testing.T) {
 	for i, want := range expected {
 		if args[i] != want {
 			t.Fatalf("args[%d] = %q, want %q\nfull args: %v", i, args[i], want, args)
+		}
+	}
+}
+
+// `--strict-mcp-config` means "only use servers from --mcp-config". Passing it
+// unconditionally launched every CodeBuddy agent without a Multica-managed
+// config with zero MCP servers, silently ignoring the user's own
+// ~/.codebuddy.json (MUL-5846).
+func TestBuildCodebuddyArgsOmitsStrictMCPWithoutManagedConfig(t *testing.T) {
+	t.Parallel()
+
+	for _, mcpConfig := range []json.RawMessage{nil, json.RawMessage("null"), json.RawMessage("  \n")} {
+		args := buildCodebuddyArgs(ExecOptions{McpConfig: mcpConfig}, slog.Default())
+		for _, arg := range args {
+			if arg == "--strict-mcp-config" {
+				t.Fatalf("mcp_config %q must inherit runtime MCP servers, got %v", string(mcpConfig), args)
+			}
+		}
+	}
+}
+
+func TestBuildCodebuddyArgsUsesStrictMCPForManagedConfig(t *testing.T) {
+	t.Parallel()
+
+	// An explicitly empty object is still a managed set: the agent asked for
+	// "no MCP servers", which strict mode is what enforces.
+	for _, mcpConfig := range []string{`{}`, `{"mcpServers":{"paper":{"command":"paper"}}}`} {
+		args := buildCodebuddyArgs(ExecOptions{McpConfig: json.RawMessage(mcpConfig)}, slog.Default())
+		found := false
+		for _, arg := range args {
+			if arg == "--strict-mcp-config" {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Fatalf("managed MCP config %q must enable strict mode, got %v", mcpConfig, args)
 		}
 	}
 }

--- a/server/pkg/agent/codebuddy_test.go
+++ b/server/pkg/agent/codebuddy_test.go
@@ -43,39 +43,25 @@ func TestBuildCodebuddyArgs_Basic(t *testing.T) {
 	}
 }
 
-// `--strict-mcp-config` means "only use servers from --mcp-config". Passing it
-// unconditionally launched every CodeBuddy agent without a Multica-managed
-// config with zero MCP servers, silently ignoring the user's own
-// ~/.codebuddy.json (MUL-5846).
-func TestBuildCodebuddyArgsOmitsStrictMCPWithoutManagedConfig(t *testing.T) {
+// --strict-mcp-config must never be passed, with or without a managed config.
+// It means "only use servers from --mcp-config" and drops CodeBuddy's user,
+// project and local scopes; measured against the real CLI, strict + a managed
+// config loaded ONLY the managed server, and strict alone loaded nothing at
+// all. The union is what mergeRuntimeAndAgentMcpConfig promises (MUL-5846).
+func TestBuildCodebuddyArgsNeverPassesStrictMCP(t *testing.T) {
 	t.Parallel()
 
-	for _, mcpConfig := range []json.RawMessage{nil, json.RawMessage("null"), json.RawMessage("  \n")} {
+	for _, mcpConfig := range []json.RawMessage{
+		nil,
+		json.RawMessage("null"),
+		json.RawMessage(`{}`),
+		json.RawMessage(`{"mcpServers":{"paper":{"command":"paper"}}}`),
+	} {
 		args := buildCodebuddyArgs(ExecOptions{McpConfig: mcpConfig}, slog.Default())
 		for _, arg := range args {
 			if arg == "--strict-mcp-config" {
-				t.Fatalf("mcp_config %q must inherit runtime MCP servers, got %v", string(mcpConfig), args)
+				t.Fatalf("mcp_config %q must not disable CodeBuddy's own MCP scopes, got %v", string(mcpConfig), args)
 			}
-		}
-	}
-}
-
-func TestBuildCodebuddyArgsUsesStrictMCPForManagedConfig(t *testing.T) {
-	t.Parallel()
-
-	// An explicitly empty object is still a managed set: the agent asked for
-	// "no MCP servers", which strict mode is what enforces.
-	for _, mcpConfig := range []string{`{}`, `{"mcpServers":{"paper":{"command":"paper"}}}`} {
-		args := buildCodebuddyArgs(ExecOptions{McpConfig: json.RawMessage(mcpConfig)}, slog.Default())
-		found := false
-		for _, arg := range args {
-			if arg == "--strict-mcp-config" {
-				found = true
-				break
-			}
-		}
-		if !found {
-			t.Fatalf("managed MCP config %q must enable strict mode, got %v", mcpConfig, args)
 		}
 	}
 }

--- a/server/pkg/agent/kimi_integration_test.go
+++ b/server/pkg/agent/kimi_integration_test.go
@@ -3,10 +3,15 @@
 package agent
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
+	"fmt"
 	"log/slog"
 	"os"
 	"os/exec"
+	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -87,4 +92,113 @@ func kimiSmokeModel() string {
 		return model
 	}
 	return ""
+}
+
+// TestKimiRealMcpConfigReachesSessionSmoke drives the real `kimi acp` binary
+// through this package's own backend with a Multica-shaped agent.mcp_config
+// and asserts the server is actually connected and callable.
+//
+// Users reported that MCP configured in Multica "never reaches kimi", pointing
+// at the bare `kimi acp` launch line as evidence (MUL-5846). That line carries
+// no MCP flags because the CLI has none — kimi takes MCP over ACP session/new
+// instead — so only an end-to-end run against the real binary can settle it.
+// The oracle is the MCP server process itself: it appends to a log when spawned
+// and returns a sentinel from its one tool, so neither a hand-written ACP
+// fixture nor the model's own description of its tools can fake a pass.
+func TestKimiRealMcpConfigReachesSessionSmoke(t *testing.T) {
+	requireRealAgentSmoke(t)
+	if testing.Short() {
+		t.Skip("skipping real-binary smoke test in -short mode")
+	}
+	if runtime.GOOS == "windows" {
+		t.Skip("shell-script MCP fixture is POSIX-only")
+	}
+	path, err := exec.LookPath("kimi")
+	if err != nil {
+		t.Skip("kimi not on PATH; skipping real-binary smoke test")
+	}
+	if version, err := exec.Command(path, "--version").CombinedOutput(); err == nil {
+		t.Logf("kimi CLI version: %s", strings.TrimSpace(string(version)))
+	}
+
+	dir := t.TempDir()
+	spawnLog := filepath.Join(dir, "spawned.log")
+	serverPath := filepath.Join(dir, "mcp-probe")
+	writeTestExecutable(t, serverPath, []byte(stdioMcpProbeScript(spawnLog)))
+
+	backend, err := New("kimi", Config{ExecutablePath: path, Logger: slog.Default()})
+	if err != nil {
+		t.Fatalf("new kimi backend: %v", err)
+	}
+
+	// Exactly the shape the daemon forwards from agent.mcp_config.
+	mcpConfig := fmt.Sprintf(`{"mcpServers":{"multicaprobe":{"command":%q,"args":[],"env":{}}}}`, serverPath)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 240*time.Second)
+	defer cancel()
+	session, err := backend.Execute(ctx,
+		"Call the multica_probe_ping tool and reply with exactly what it returned. Do nothing else.",
+		ExecOptions{
+			Timeout:   210 * time.Second,
+			Cwd:       dir,
+			Model:     kimiSmokeModel(),
+			McpConfig: json.RawMessage(mcpConfig),
+		})
+	if err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	go func() {
+		for range session.Messages {
+		}
+	}()
+
+	result := <-session.Result
+	t.Logf("status=%q error=%q output=%q", result.Status, result.Error, result.Output)
+
+	// Ground truth: did kimi actually start the MCP server we configured?
+	spawned, err := os.ReadFile(spawnLog)
+	t.Logf("MCP server saw:\n%s", spawned)
+	if err != nil || !bytes.Contains(spawned, []byte("SPAWNED")) {
+		t.Fatalf("MCP server was never started by kimi (log=%q err=%v) — the managed mcp_config did not reach the session", spawned, err)
+	}
+	if !bytes.Contains(spawned, []byte("tools/list")) {
+		t.Fatalf("kimi started the MCP server but never listed its tools: %q", spawned)
+	}
+	if !strings.Contains(result.Output, "MULTICA_MCP_OK") {
+		t.Fatalf("agent output does not contain the tool's sentinel: %q", result.Output)
+	}
+}
+
+// stdioMcpProbeScript returns a minimal POSIX-sh MCP stdio server. It records
+// every request it receives in spawnLog so the test can assert on the process
+// rather than on anything the model says.
+func stdioMcpProbeScript(spawnLog string) string {
+	return `#!/bin/sh
+LOG=` + fmt.Sprintf("%q", spawnLog) + `
+echo SPAWNED >> "$LOG"
+while IFS= read -r line; do
+  echo "$line" >> "$LOG"
+  id=` + "`" + `printf '%s' "$line" | sed -n 's/.*"id":\([0-9][0-9]*\).*/\1/p'` + "`" + `
+  case "$line" in
+    *'"method":"initialize"'*)
+      printf '{"jsonrpc":"2.0","id":%s,"result":{"protocolVersion":"2025-06-18","capabilities":{"tools":{"listChanged":false}},"serverInfo":{"name":"multica-probe","version":"1.0.0"}}}\n' "$id"
+      ;;
+    *'"method":"tools/list"'*)
+      printf '{"jsonrpc":"2.0","id":%s,"result":{"tools":[{"name":"multica_probe_ping","description":"Returns MULTICA_MCP_OK.","inputSchema":{"type":"object","properties":{},"additionalProperties":false}}]}}\n' "$id"
+      ;;
+    *'"method":"tools/call"'*)
+      printf '{"jsonrpc":"2.0","id":%s,"result":{"content":[{"type":"text","text":"MULTICA_MCP_OK"}],"isError":false}}\n' "$id"
+      ;;
+    *'"method":"resources/list"'*)
+      printf '{"jsonrpc":"2.0","id":%s,"result":{"resources":[]}}\n' "$id"
+      ;;
+    *'"method":"prompts/list"'*)
+      printf '{"jsonrpc":"2.0","id":%s,"result":{"prompts":[]}}\n' "$id"
+      ;;
+    *'"id"'*)
+      printf '{"jsonrpc":"2.0","id":%s,"error":{"code":-32601,"message":"method not found"}}\n' "$id"
+      ;;
+  esac
+done
+`
 }

--- a/server/pkg/agent/kimi_test.go
+++ b/server/pkg/agent/kimi_test.go
@@ -370,6 +370,57 @@ func TestKimiResumeIncludesMcpServers(t *testing.T) {
 	}
 }
 
+// TestKimiFreshSessionIncludesMcpServers is the session/new counterpart to the
+// resume test above: a fresh Kimi task must carry the managed MCP set too.
+// Kimi takes MCP over ACP rather than as a CLI flag, so a bare `kimi acp`
+// launch line is not evidence that the servers were dropped (MUL-5846) — this
+// pins the payload that actually carries them.
+func TestKimiFreshSessionIncludesMcpServers(t *testing.T) {
+	t.Parallel()
+
+	recordPath := filepath.Join(t.TempDir(), "frames.jsonl")
+	fakePath := filepath.Join(t.TempDir(), "kimi")
+	writeTestExecutable(t, fakePath, []byte(fakeACPRecordingScript(recordPath, "ses_new", `{}`)))
+
+	backend, err := New("kimi", Config{ExecutablePath: fakePath, Logger: slog.Default()})
+	if err != nil {
+		t.Fatalf("new kimi backend: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	session, err := backend.Execute(ctx, "prompt-ignored", ExecOptions{
+		Timeout:   5 * time.Second,
+		McpConfig: json.RawMessage(`{"mcpServers":{"fetch":{"command":"uvx","args":["mcp-server-fetch"]}}}`),
+	})
+	if err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	go func() {
+		for range session.Messages {
+		}
+	}()
+	select {
+	case <-session.Result:
+	case <-time.After(10 * time.Second):
+		t.Fatal("timeout waiting for result")
+	}
+
+	frame := findRecordedFrame(t, recordPath, "session/new")
+	params := frame["params"].(map[string]any)
+	servers, ok := params["mcpServers"].([]any)
+	if !ok {
+		t.Fatalf("session/new.mcpServers: got %T, want []any", params["mcpServers"])
+	}
+	if len(servers) != 1 {
+		t.Fatalf("session/new.mcpServers: got %d entries, want 1", len(servers))
+	}
+	entry := servers[0].(map[string]any)
+	if entry["name"] != "fetch" || entry["command"] != "uvx" {
+		t.Fatalf("session/new.mcpServers[0]: got %v, want {name:fetch,command:uvx,...}", entry)
+	}
+}
+
 // TestKimiDrainsNotificationsAfterPromptResponse pins the trailing-notification
 // drain. kimi ACP can emit a final session update just after the
 // session/prompt response returns; closing stdin and cancelling the context at


### PR DESCRIPTION
## Summary

Reported: kimicode and CodeBuddy don't get MCP applied at launch. Investigated both; CodeBuddy is genuinely broken, kimi is mostly fine with one discovery gap.

### CodeBuddy — MCP was disabled on every launch

`buildCodebuddyArgs` passed `--strict-mcp-config` unconditionally. Per CodeBuddy's own help, that flag means *"only use MCP servers from `--mcp-config`, ignoring all other MCP configurations"*. With no Multica-managed `mcp_config` (the default), the CLI was launched in strict mode with no config at all — so it ran with **zero** MCP servers and silently ignored whatever the user had configured in `~/.codebuddy.json`. `claude.go` already gates the flag on `hasManagedMcpConfig`; this does the same.

The `--mcp-config` temp file now uses that same three-state check instead of `len(opts.McpConfig) > 0`, so a JSON `null` ("inherit the runtime configuration") no longer counts as a managed set.

### CodeBuddy — wrong runtime config file

`runtime_mcp.go` treated `codebuddy` as an alias of `claude`, reading `~/.claude.json` plus Claude's plugin MCP servers. CodeBuddy is a fork but keeps its own config file and plugin root (`~/.codebuddy.json`, `~/.workbuddy/` — confirmed by `codebuddy mcp add` and the CLI bundle). The old mapping both leaked Claude's servers into CodeBuddy launches and dropped CodeBuddy's own.

### kimi — inventory gap only

MCP **does** reach `kimi acp`: it goes over ACP `session/new` `mcpServers`, not a CLI flag (`kimi acp` has no MCP flags at all), which is likely what the launch log looked like. Verified end-to-end that a managed server is connected and callable.

The real gap was that `runtime_mcp.go` had no `kimi` case, so the runtime probe reported `mcp_supported=false` and the Agent → MCP tab told users the runtime doesn't support MCP. Added `<KIMI_CODE_HOME>/mcp.json` to the inventory.

Kimi is deliberately **not** added to `loadRuntimeMcpServerConfigs` (the task-local merge): `kimi acp` already merges that file with the ephemeral list we send, and a duplicate server name spawns the server twice — both verified against kimi-code 0.33.0.

## Verification

Wrote a minimal stdio MCP server that logs when it is spawned and exposes one tool, then drove the real CLIs:

| Case | Result |
| --- | --- |
| CodeBuddy, old launch line (`--strict-mcp-config`, no `--mcp-config`) | `NO_MCP_TOOL`, server never spawned |
| CodeBuddy, new launch line (no managed config) | tool called, probe payload returned |
| kimi, `session/new` with `mcpServers` | tool listed and called |
| kimi, `<KIMI_CODE_HOME>/mcp.json` + empty ephemeral list | user server loaded |
| kimi, same name in both | **two** processes spawned |

Tests: `go test ./pkg/agent/ ./internal/daemon/... -count=1` — all pass. New coverage for the strict-mode gate, the CodeBuddy config path (both the inventory and the merge), the kimi inventory, and the kimi passthrough.

## Not covered

The other ACP providers (hermes, grok, kiro, qoder, qwenpaw, reasonix, traecli) also have no runtime-MCP inventory entry. Left alone — their config file locations weren't verified here.
