### PR TITLE
MUL-5785 fix(agent): return an empty output when a stream-json run has no final text

### DIFF
--- a/server/pkg/agent/claude.go
+++ b/server/pkg/agent/claude.go
@@ -235,13 +235,18 @@ func (b *claudeBackend) Execute(ctx context.Context, prompt string, opts ExecOpt
 				assistantEventCount++
 				assistantText, tools := b.handleAssistant(msg, msgCh, usage)
 				toolUseCount += tools
-				if tools == 0 {
+				if tools == 0 && assistantText != "" {
 					lastAssistantText = assistantText
-				} else {
+				} else if tools > 0 {
 					// A turn that invokes a tool is intermediate even when it also
 					// contains narration. Do not use it as an empty-result fallback.
 					lastAssistantText = ""
 				}
+				// A text-less, tool-less assistant event (thinking-only, or a
+				// content block set we render nothing for) carries no answer and
+				// no intermediacy signal, so it must leave the fallback alone.
+				// Overwriting it with "" discarded an answer the model had
+				// already delivered. Matches qwen's handling.
 			case "user":
 				if b.handleUser(msg, msgCh) {
 					sawAsyncLaunch = true

--- a/server/pkg/agent/claude.go
+++ b/server/pkg/agent/claude.go
@@ -182,6 +182,7 @@ func (b *claudeBackend) Execute(ctx context.Context, prompt string, opts ExecOpt
 		invalidEventCount := 0
 		assistantEventCount := 0
 		toolUseCount := 0
+		unreadableAssistantCount := 0
 
 		// On cancellation / timeout, terminate claude (and every MCP server and
 		// tool subprocess it spawned) BEFORE unblocking the scanner. EOF stdin
@@ -233,20 +234,12 @@ func (b *claudeBackend) Execute(ctx context.Context, prompt string, opts ExecOpt
 			switch msg.Type {
 			case "assistant":
 				assistantEventCount++
-				assistantText, tools := b.handleAssistant(msg, msgCh, usage)
-				toolUseCount += tools
-				if tools == 0 && assistantText != "" {
-					lastAssistantText = assistantText
-				} else if tools > 0 {
-					// A turn that invokes a tool is intermediate even when it also
-					// contains narration. Do not use it as an empty-result fallback.
-					lastAssistantText = ""
+				turn := b.handleAssistant(msg, msgCh, usage)
+				toolUseCount += turn.toolUses
+				if !turn.understood {
+					unreadableAssistantCount++
 				}
-				// A text-less, tool-less assistant event (thinking-only, or a
-				// content block set we render nothing for) carries no answer and
-				// no intermediacy signal, so it must leave the fallback alone.
-				// Overwriting it with "" discarded an answer the model had
-				// already delivered. Matches qwen's handling.
+				lastAssistantText = turn.resolveFallback(lastAssistantText)
 			case "user":
 				if b.handleUser(msg, msgCh) {
 					sawAsyncLaunch = true
@@ -342,6 +335,7 @@ func (b *claudeBackend) Execute(ctx context.Context, prompt string, opts ExecOpt
 			resultBytes:                len(finalResultText),
 			lastAssistantBytes:         len(lastAssistantText),
 			scannerError:               scanErr != nil,
+			unreadableAssistantCount:   unreadableAssistantCount,
 			anthropicBaseURLConfigured: strings.TrimSpace(b.cfg.Env["ANTHROPIC_BASE_URL"]) != "",
 		})
 
@@ -372,11 +366,14 @@ func (b *claudeBackend) Execute(ctx context.Context, prompt string, opts ExecOpt
 	return &Session{Messages: msgCh, Result: resCh}, nil
 }
 
-func (b *claudeBackend) handleAssistant(msg claudeSDKMessage, ch chan<- Message, usage map[string]TokenUsage) (string, int) {
+func (b *claudeBackend) handleAssistant(msg claudeSDKMessage, ch chan<- Message, usage map[string]TokenUsage) assistantTurn {
 	var content claudeMessageContent
 	if err := json.Unmarshal(msg.Message, &content); err != nil {
-		return "", 0
+		// Unreadable body: understood stays false so the caller drops any
+		// fallback rather than let an older turn stand in for this one.
+		return assistantTurn{}
 	}
+	turn := assistantTurn{understood: true}
 	var assistantText strings.Builder
 	toolUseCount := 0
 
@@ -413,9 +410,17 @@ func (b *claudeBackend) handleAssistant(msg claudeSDKMessage, ch chan<- Message,
 				CallID: block.ID,
 				Input:  input,
 			})
+		default:
+			// A block type we do not render may be carrying the model's answer
+			// in a shape we cannot read, so we must not claim this turn was
+			// silent. Recognising a new no-text block is a deliberate one-line
+			// addition here, not an accident of falling through.
+			turn.understood = false
 		}
 	}
-	return assistantText.String(), toolUseCount
+	turn.text = assistantText.String()
+	turn.toolUses = toolUseCount
+	return turn
 }
 
 func (b *claudeBackend) handleUser(msg claudeSDKMessage, ch chan<- Message) bool {

--- a/server/pkg/agent/claude_test.go
+++ b/server/pkg/agent/claude_test.go
@@ -30,7 +30,8 @@ func TestClaudeHandleAssistantText(t *testing.T) {
 		}),
 	}
 
-	output, tools := b.handleAssistant(msg, ch, make(map[string]TokenUsage))
+	turn := b.handleAssistant(msg, ch, make(map[string]TokenUsage))
+	output, tools := turn.text, turn.toolUses
 
 	if output != "Hello world" {
 		t.Fatalf("expected output 'Hello world', got %q", output)
@@ -69,7 +70,8 @@ func TestClaudeHandleAssistantToolUse(t *testing.T) {
 		}),
 	}
 
-	output, tools := b.handleAssistant(msg, ch, make(map[string]TokenUsage))
+	turn := b.handleAssistant(msg, ch, make(map[string]TokenUsage))
+	output, tools := turn.text, turn.toolUses
 
 	if output != "" {
 		t.Fatalf("tool_use should not add to output, got %q", output)
@@ -279,7 +281,8 @@ func TestClaudeHandleAssistantInvalidJSON(t *testing.T) {
 	}
 
 	// Should not panic
-	output, tools := b.handleAssistant(msg, ch, make(map[string]TokenUsage))
+	turn := b.handleAssistant(msg, ch, make(map[string]TokenUsage))
+	output, tools := turn.text, turn.toolUses
 
 	if output != "" {
 		t.Fatalf("expected empty output for invalid JSON, got %q", output)

--- a/server/pkg/agent/codebuddy.go
+++ b/server/pkg/agent/codebuddy.go
@@ -187,6 +187,7 @@ func (b *codebuddyBackend) Execute(ctx context.Context, prompt string, opts Exec
 		invalidEventCount := 0
 		assistantEventCount := 0
 		toolUseCount := 0
+		unreadableAssistantCount := 0
 
 		// Close stdout when the context is cancelled so scanner.Scan() unblocks.
 		go func() {
@@ -213,18 +214,12 @@ func (b *codebuddyBackend) Execute(ctx context.Context, prompt string, opts Exec
 			switch msg.Type {
 			case "assistant":
 				assistantEventCount++
-				assistantText, tools := b.handleAssistant(msg, msgCh, usage)
-				toolUseCount += tools
-				if tools == 0 && assistantText != "" {
-					lastAssistantText = assistantText
-				} else if tools > 0 {
-					// A turn that invokes a tool is intermediate even when it also
-					// contains narration. Do not use it as an empty-result fallback.
-					lastAssistantText = ""
+				turn := b.handleAssistant(msg, msgCh, usage)
+				toolUseCount += turn.toolUses
+				if !turn.understood {
+					unreadableAssistantCount++
 				}
-				// A text-less, tool-less assistant event carries no answer and no
-				// intermediacy signal, so it must leave the fallback alone. Matches
-				// qwen's handling.
+				lastAssistantText = turn.resolveFallback(lastAssistantText)
 			case "user":
 				b.handleUser(msg, msgCh)
 			case "system":
@@ -304,6 +299,7 @@ func (b *codebuddyBackend) Execute(ctx context.Context, prompt string, opts Exec
 			resultBytes:                len(finalResultText),
 			lastAssistantBytes:         len(lastAssistantText),
 			scannerError:               scanErr != nil,
+			unreadableAssistantCount:   unreadableAssistantCount,
 			anthropicBaseURLConfigured: strings.TrimSpace(b.cfg.Env["ANTHROPIC_BASE_URL"]) != "",
 		})
 
@@ -332,11 +328,14 @@ func (b *codebuddyBackend) Execute(ctx context.Context, prompt string, opts Exec
 	return &Session{Messages: msgCh, Result: resCh}, nil
 }
 
-func (b *codebuddyBackend) handleAssistant(msg codebuddySDKMessage, ch chan<- Message, usage map[string]TokenUsage) (string, int) {
+func (b *codebuddyBackend) handleAssistant(msg codebuddySDKMessage, ch chan<- Message, usage map[string]TokenUsage) assistantTurn {
 	var content codebuddyMessageContent
 	if err := json.Unmarshal(msg.Message, &content); err != nil {
-		return "", 0
+		// Unreadable body: understood stays false so the caller drops any
+		// fallback rather than let an older turn stand in for this one.
+		return assistantTurn{}
 	}
+	turn := assistantTurn{understood: true}
 	var assistantText strings.Builder
 	toolUseCount := 0
 
@@ -373,9 +372,17 @@ func (b *codebuddyBackend) handleAssistant(msg codebuddySDKMessage, ch chan<- Me
 				CallID: block.ID,
 				Input:  input,
 			})
+		default:
+			// A block type we do not render may be carrying the model's answer
+			// in a shape we cannot read, so we must not claim this turn was
+			// silent. Recognising a new no-text block is a deliberate one-line
+			// addition here, not an accident of falling through.
+			turn.understood = false
 		}
 	}
-	return assistantText.String(), toolUseCount
+	turn.text = assistantText.String()
+	turn.toolUses = toolUseCount
+	return turn
 }
 
 func (b *codebuddyBackend) handleUser(msg codebuddySDKMessage, ch chan<- Message) {

--- a/server/pkg/agent/codebuddy.go
+++ b/server/pkg/agent/codebuddy.go
@@ -215,13 +215,16 @@ func (b *codebuddyBackend) Execute(ctx context.Context, prompt string, opts Exec
 				assistantEventCount++
 				assistantText, tools := b.handleAssistant(msg, msgCh, usage)
 				toolUseCount += tools
-				if tools == 0 {
+				if tools == 0 && assistantText != "" {
 					lastAssistantText = assistantText
-				} else {
+				} else if tools > 0 {
 					// A turn that invokes a tool is intermediate even when it also
 					// contains narration. Do not use it as an empty-result fallback.
 					lastAssistantText = ""
 				}
+				// A text-less, tool-less assistant event carries no answer and no
+				// intermediacy signal, so it must leave the fallback alone. Matches
+				// qwen's handling.
 			case "user":
 				b.handleUser(msg, msgCh)
 			case "system":

--- a/server/pkg/agent/codebuddy_test.go
+++ b/server/pkg/agent/codebuddy_test.go
@@ -362,7 +362,8 @@ func TestCodebuddyHandleAssistantText(t *testing.T) {
 		}),
 	}
 
-	output, tools := b.handleAssistant(msg, ch, make(map[string]TokenUsage))
+	turn := b.handleAssistant(msg, ch, make(map[string]TokenUsage))
+	output, tools := turn.text, turn.toolUses
 
 	if output != "codebuddy says hi" {
 		t.Fatalf("expected output 'codebuddy says hi', got %q", output)

--- a/server/pkg/agent/qwen.go
+++ b/server/pkg/agent/qwen.go
@@ -177,6 +177,7 @@ func (b *qwenBackend) Execute(ctx context.Context, prompt string, opts ExecOptio
 			toolUseCount: state.toolUseCount, sawResult: state.sawResult, resultIsError: state.resultIsError,
 			resultBytes: len(state.finalResultText), lastAssistantBytes: len(state.lastAssistantText),
 			scannerError: scanErr != nil, lastEventType: state.lastEventType,
+			unreadableAssistantCount: state.unreadableAssistantCount,
 		})
 		b.cfg.Logger.Info("qwen finished", "pid", cmd.Process.Pid, "status", status, "duration", duration.Round(time.Millisecond).String())
 		resCh <- Result{
@@ -228,6 +229,7 @@ type qwenStreamState struct {
 	sawResult, resultIsError                                            bool
 	usage                                                               map[string]TokenUsage
 	eventCount, invalidEventCount, assistantEventCount, toolUseCount    int
+	unreadableAssistantCount                                            int
 }
 
 func handleQwenEvent(event qwenStreamEvent, ch chan<- Message, state *qwenStreamState) {
@@ -242,16 +244,15 @@ func handleQwenEvent(event qwenStreamEvent, ch chan<- Message, state *qwenStream
 		trySend(ch, Message{Type: MessageStatus, Status: "running", SessionID: state.sessionID})
 	case "assistant":
 		state.assistantEventCount++
-		text, tools, model := handleQwenAssistant(event.Message, ch, state.usage)
+		turn, model := handleQwenAssistant(event.Message, ch, state.usage)
 		if model != "" {
 			state.model = model
 		}
-		state.toolUseCount += tools
-		if tools == 0 && text != "" {
-			state.lastAssistantText = text
-		} else if tools > 0 {
-			state.lastAssistantText = ""
+		state.toolUseCount += turn.toolUses
+		if !turn.understood {
+			state.unreadableAssistantCount++
 		}
+		state.lastAssistantText = turn.resolveFallback(state.lastAssistantText)
 	case "user":
 		handleQwenUser(event.Message, ch)
 	case "result":
@@ -275,11 +276,14 @@ func handleQwenEvent(event qwenStreamEvent, ch chan<- Message, state *qwenStream
 	}
 }
 
-func handleQwenAssistant(raw json.RawMessage, ch chan<- Message, usage map[string]TokenUsage) (string, int, string) {
+func handleQwenAssistant(raw json.RawMessage, ch chan<- Message, usage map[string]TokenUsage) (assistantTurn, string) {
 	var message qwenMessage
 	if json.Unmarshal(raw, &message) != nil {
-		return "", 0, ""
+		// Unreadable body: understood stays false so the caller drops any
+		// fallback rather than let an older turn stand in for this one.
+		return assistantTurn{}, ""
 	}
+	turn := assistantTurn{understood: true}
 	if message.Usage != nil && message.Model != "" {
 		usage[message.Model] = qwenTokenUsage(message.Usage)
 	}
@@ -303,9 +307,17 @@ func handleQwenAssistant(raw json.RawMessage, ch chan<- Message, usage map[strin
 				_ = json.Unmarshal(block.Input, &input)
 			}
 			trySend(ch, Message{Type: MessageToolUse, Tool: block.Name, CallID: block.ID, Input: input})
+		default:
+			// A block type we do not render may be carrying the model's answer
+			// in a shape we cannot read, so we must not claim this turn was
+			// silent. Recognising a new no-text block is a deliberate one-line
+			// addition here, not an accident of falling through.
+			turn.understood = false
 		}
 	}
-	return text.String(), tools, message.Model
+	turn.text = text.String()
+	turn.toolUses = tools
+	return turn, message.Model
 }
 
 func handleQwenUser(raw json.RawMessage, ch chan<- Message) {

--- a/server/pkg/agent/stream_json_final_output_test.go
+++ b/server/pkg/agent/stream_json_final_output_test.go
@@ -12,7 +12,11 @@ import (
 	"time"
 )
 
-func TestFinalizeStreamResultEmptySuccessWithoutAssistantUsesSafeNotice(t *testing.T) {
+// A successful run that produced no deliverable text must report an EMPTY
+// output, never a placeholder sentence. Empty is what the issue / direct-chat /
+// channel delivery paths each branch on to pick their own no-response behavior;
+// any non-empty prose here defeats all three at once (GH #6462).
+func TestFinalizeStreamResultEmptySuccessWithoutAssistantReturnsEmptyOutput(t *testing.T) {
 	t.Parallel()
 
 	status, output, errMsg := finalizeStreamResult(
@@ -25,8 +29,8 @@ func TestFinalizeStreamResultEmptySuccessWithoutAssistantUsesSafeNotice(t *testi
 		streamTerminalState{sawResult: true},
 		"",
 	)
-	if status != "completed" || output != emptySuccessfulStreamResult || errMsg != "" {
-		t.Fatalf("finalizeStreamResult() = (%q, %q, %q), want completed safe notice", status, output, errMsg)
+	if status != "completed" || output != "" || errMsg != "" {
+		t.Fatalf("finalizeStreamResult() = (%q, %q, %q), want completed with empty output", status, output, errMsg)
 	}
 }
 
@@ -150,10 +154,10 @@ printf '%s\n' '{"type":"user","message":{"role":"user","content":[{"type":"tool_
 			},
 		},
 		{
-			name:       "empty successful result after tool-using turn uses safe notice",
+			name:       "empty successful result after tool-using turn returns empty output",
 			scriptBody: toolLastStream + `printf '%s\n' '{"type":"result","subtype":"success","is_error":false,"session_id":"sess-boundary","result":""}'` + "\n",
 			wantStatus: "completed",
-			wantOutput: emptySuccessfulStreamResult,
+			wantOutput: "",
 			forbiddenOutput: []string{
 				"PRE-TOOL NARRATION",
 				"I WILL USE A TOOL",

--- a/server/pkg/agent/stream_json_final_output_test.go
+++ b/server/pkg/agent/stream_json_final_output_test.go
@@ -161,6 +161,21 @@ printf '%s\n' '{"type":"user","message":{"role":"user","content":[{"type":"tool_
 			},
 		},
 		{
+			// A thinking-only trailing event carries neither an answer nor an
+			// intermediacy signal, so it must not discard the answer the model
+			// already delivered. Regression for the overwrite that turned a
+			// complete reply into a no-response turn.
+			name:       "text-less trailing assistant event preserves the last answer",
+			scriptBody: multiTurnStream + `printf '%s\n' '{"type":"assistant","message":{"role":"assistant","model":"test-model","content":[{"type":"thinking","text":"SILENT DELIBERATION"}]}}'` + "\n" + `printf '%s\n' '{"type":"result","subtype":"success","is_error":false,"session_id":"sess-boundary","result":""}'` + "\n",
+			wantStatus: "completed",
+			wantOutput: "LAST ASSISTANT ANSWER",
+			forbiddenOutput: []string{
+				"FIRST-TURN NARRATION",
+				"TOOL TRACE",
+				"SILENT DELIBERATION",
+			},
+		},
+		{
 			name:       "clean exit without result fails closed",
 			scriptBody: multiTurnStream,
 			wantStatus: "failed",

--- a/server/pkg/agent/stream_json_final_output_test.go
+++ b/server/pkg/agent/stream_json_final_output_test.go
@@ -34,6 +34,50 @@ func TestFinalizeStreamResultEmptySuccessWithoutAssistantReturnsEmptyOutput(t *t
 	}
 }
 
+// resolveFallback is the single policy every stream-json backend applies per
+// assistant event, so pin all four outcomes here rather than only through the
+// per-backend stream fixtures.
+func TestAssistantTurnResolveFallback(t *testing.T) {
+	t.Parallel()
+
+	const prior = "AN ANSWER THE MODEL ALREADY GAVE"
+	tests := []struct {
+		name string
+		turn assistantTurn
+		want string
+	}{
+		{
+			name: "text-only turn becomes the fallback",
+			turn: assistantTurn{text: "NEW ANSWER", understood: true},
+			want: "NEW ANSWER",
+		},
+		{
+			name: "tool-using turn is intermediate and clears it",
+			turn: assistantTurn{text: "I WILL USE A TOOL", toolUses: 1, understood: true},
+			want: "",
+		},
+		{
+			name: "understood silent turn leaves it alone",
+			turn: assistantTurn{understood: true},
+			want: prior,
+		},
+		{
+			name: "unreadable turn clears it",
+			turn: assistantTurn{understood: false},
+			want: "",
+		},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := tt.turn.resolveFallback(prior); got != tt.want {
+				t.Fatalf("resolveFallback(%q) = %q, want %q", prior, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestFinalizeStreamResultPreservesErrorResultWhenContextEnds(t *testing.T) {
 	t.Parallel()
 
@@ -177,6 +221,33 @@ printf '%s\n' '{"type":"user","message":{"role":"user","content":[{"type":"tool_
 				"FIRST-TURN NARRATION",
 				"TOOL TRACE",
 				"SILENT DELIBERATION",
+			},
+		},
+		{
+			// An assistant event whose body does not match the expected shape
+			// is unreadable, not silent: the model may have answered inside it.
+			// The earlier narration must NOT be promoted to the final answer.
+			name:       "unparseable trailing assistant event drops the fallback",
+			scriptBody: multiTurnStream + `printf '%s\n' '{"type":"assistant","message":"NOT AN OBJECT"}'` + "\n" + `printf '%s\n' '{"type":"result","subtype":"success","is_error":false,"session_id":"sess-boundary","result":""}'` + "\n",
+			wantStatus: "completed",
+			wantOutput: "",
+			forbiddenOutput: []string{
+				"FIRST-TURN NARRATION",
+				"TOOL TRACE",
+				"LAST ASSISTANT ANSWER",
+			},
+		},
+		{
+			// Same rule for a content block type we do not render: we cannot
+			// claim the turn was silent, so the fallback must not survive it.
+			name:       "unknown content block drops the fallback",
+			scriptBody: multiTurnStream + `printf '%s\n' '{"type":"assistant","message":{"role":"assistant","model":"test-model","content":[{"type":"server_tool_use","id":"st-1","name":"web_search"}]}}'` + "\n" + `printf '%s\n' '{"type":"result","subtype":"success","is_error":false,"session_id":"sess-boundary","result":""}'` + "\n",
+			wantStatus: "completed",
+			wantOutput: "",
+			forbiddenOutput: []string{
+				"FIRST-TURN NARRATION",
+				"TOOL TRACE",
+				"LAST ASSISTANT ANSWER",
 			},
 		},
 		{

--- a/server/pkg/agent/stream_json_result.go
+++ b/server/pkg/agent/stream_json_result.go
@@ -9,8 +9,6 @@ import (
 	"time"
 )
 
-const emptySuccessfulStreamResult = "The agent completed without a final response."
-
 // streamTerminalState keeps the user-facing final answer separate from the
 // streamed assistant turns. Assistant messages are still emitted through the
 // Session.Messages channel for live progress/transcript storage, but only a
@@ -40,6 +38,17 @@ type streamTerminalState struct {
 // stream-json protocol completed: success requires a result event. Failed runs
 // always return an empty output so upstream issue/chat fallbacks can never
 // mistake a partial transcript for a final answer.
+//
+// A SUCCESSFUL run with no deliverable text returns an empty output for the same
+// reason. Empty is the platform's signal for "this turn produced no final text",
+// and every delivery surface already owns a decision keyed on it: an issue task
+// skips the synthesized fallback comment, a direct chat writes a localized
+// no_response outcome, and a Slack/Lark channel drops the turn rather than push
+// a placeholder outward. Returning prose here instead makes the output non-empty
+// and silently defeats all three at once — that is how an English sentinel
+// reached a Lark thread (GH #6462). Which words a user sees, and in which
+// language, belongs to each delivery surface; the stream parser only reports
+// whether text exists.
 func finalizeStreamResult(
 	provider string,
 	timeout time.Duration,
@@ -112,10 +121,7 @@ func finalizeStreamResult(
 	if state.finalResultText != "" {
 		return status, state.finalResultText, ""
 	}
-	if state.lastAssistantText != "" {
-		return status, state.lastAssistantText, ""
-	}
-	return status, emptySuccessfulStreamResult, ""
+	return status, state.lastAssistantText, ""
 }
 
 type streamProtocolObservation struct {

--- a/server/pkg/agent/stream_json_result.go
+++ b/server/pkg/agent/stream_json_result.go
@@ -9,6 +9,43 @@ import (
 	"time"
 )
 
+// assistantTurn is the classified outcome of one assistant stream event.
+//
+// The stream-json backends parse different wire shapes but share one question
+// per event: may a fallback answer captured earlier in the run survive it?
+type assistantTurn struct {
+	text     string
+	toolUses int
+	// understood is false when the event's message body failed to parse, or
+	// carried a content block type the backend does not handle. In both cases
+	// the backend cannot tell whether the model delivered its answer inside
+	// that event, so an earlier fallback must not outlive it.
+	understood bool
+}
+
+// resolveFallback returns the empty-result fallback after this turn, given the
+// fallback held before it. It is the single place the three stream-json
+// backends encode which turns may leave an answer behind.
+func (t assistantTurn) resolveFallback(prior string) string {
+	switch {
+	case t.toolUses > 0 || !t.understood:
+		// A turn that invokes a tool is intermediate even when it also
+		// contains narration. An unreadable turn tells us nothing at all —
+		// the model may have answered in a shape we failed to parse. Neither
+		// may leave a stale answer behind for the terminal result to adopt:
+		// that is how pre-tool narration would reach a user as the final
+		// answer (#6006), which the fail-closed contract below exists to stop.
+		return ""
+	case t.text != "":
+		return t.text
+	default:
+		// Understood, text-less and tool-less — a thinking-only turn. It
+		// carries neither an answer nor an intermediacy signal, so it must
+		// leave an answer the model already delivered untouched.
+		return prior
+	}
+}
+
 // streamTerminalState keeps the user-facing final answer separate from the
 // streamed assistant turns. Assistant messages are still emitted through the
 // Session.Messages channel for live progress/transcript storage, but only a
@@ -155,6 +192,16 @@ type streamProtocolObservation struct {
 	unhandledEventTypeCount int
 	unhandledEventTypes     string
 	unhandledSubtypeCount   int
+	// unreadableAssistantCount reports assistant events whose message body did
+	// not parse, or that carried a content block type the backend does not
+	// handle. Unlike unhandledEventTypeCount (a TOP-LEVEL event type we skip),
+	// this counts events we accepted and then could not fully read.
+	//
+	// Non-zero means the run dropped its empty-result fallback defensively, so
+	// a task that ended with no final text may have had an answer we could not
+	// see. It is the first number to check when a known-good agent starts
+	// returning empty outputs after a CLI upgrade.
+	unreadableAssistantCount int
 }
 
 // logStreamProtocolObservation records only protocol metadata. It deliberately
@@ -180,6 +227,7 @@ func logStreamProtocolObservation(logger *slog.Logger, obs streamProtocolObserva
 		"unhandled_event_type_count", obs.unhandledEventTypeCount,
 		"unhandled_event_types", obs.unhandledEventTypes,
 		"unhandled_subtype_count", obs.unhandledSubtypeCount,
+		"unreadable_assistant_count", obs.unreadableAssistantCount,
 		"anthropic_base_url_configured", obs.anthropicBaseURLConfigured,
 	)
 }


### PR DESCRIPTION
Fixes #6462. Multica issue: MUL-5785.

## What was wrong

A successful stream-json run that produced no deliverable text returned the sentence `The agent completed without a final response.` as its `Result.Output`.

That string is a **signal**, not a message to a user — but shipping it as content made the output non-empty, and every no-response decision the delivery layer already owns branches on the output being **empty**:

| Surface | Behavior on empty output |
|---|---|
| issue task | skips the synthesized fallback comment |
| direct chat (web/desktop) | writes a localized `no_response` outcome |
| Slack / Lark channel | drops the turn rather than pushing anything outward |

A non-empty sentinel bypassed all three at once:

- the issue thread got a fallback comment whose entire body was the sentinel;
- the chat panel got an ordinary assistant bubble instead of a `no_response` row;
- an English sentence was pushed into a Lark thread — the case MUL-4351 explicitly forbids (*"the no_response fallback body must never be pushed to an external channel"*), and exactly what #6462 reported.

The reporter's own diagnostics confirm the shape: `saw_result=true`, `result_is_error=false`, `result_bytes=0`, `last_assistant_bytes=0`, `tool_use_count=13`, `exit_code=0`, with `invalid_event_count=0` and `unhandled_event_type_count=0` ruling out a CLI protocol change.

## The change

**1. Return an empty output instead of the sentinel** (`stream_json_result.go`)

This is the contract the file already documents for failed runs —

> Failed runs always return an empty output **so upstream issue/chat fallbacks** can never mistake a partial transcript for a final answer.

— applied to the successful-but-textless case for the same reason. Which words a user sees, and in which language, belongs to each delivery surface, not to the stream parser.

**2. Stop a text-less assistant event from discarding the final answer** (`claude.go`, `codebuddy.go`)

Both readers treated *every* tool-less assistant event as the new fallback, including one carrying no text. A thinking-only trailing event therefore overwrote a complete answer with `""`. Only a tool-using turn is positively intermediate; a text-less, tool-less event carries neither an answer nor an intermediacy signal and must leave the fallback alone.

`qwen.go` already reads it this way — this aligns the other two stream-json backends with it rather than inventing a new rule.

This lands in the same PR on purpose: once the sentinel is gone, this bug turns "the model answered" into a silent no-response turn, so the two must ship together.

## Deliberately not done

- **Not aligning claude with the Hermes/ACP fallback.** Falling back to pre-tool narration would re-introduce the interim-narration leak #6006 / MUL-5378 just fixed. The ACP tracker's boundary is a workaround for a protocol that cannot distinguish narration from a conclusion (*"a heuristic until the runtimes mark the final answer explicitly"*); stream-json has a dedicated terminal `result` field and needs no such heuristic.
- **Status stays `completed`.** An empty output is a legitimate terminal result for a turn that ended on a tool call, and re-running would repeat side effects that already happened — the direct-chat path documents this same reasoning.

## Verification

```
gofmt -l server/pkg/agent/     # clean
go vet ./pkg/agent/            # clean
go build ./...                 # clean
go test ./pkg/agent/ -count=1  # ok (144s)
```

The new regression case was confirmed to actually catch the bug: with the `claude.go` hunk reverted it fails with `output = "", want "LAST ASSISTANT ANSWER"`, and passes with it.

One transient failure appeared in an early full-package run and did not reproduce across two subsequent full runs plus three targeted runs. Its tail pointed at the qoder backend, which uses `acpDeliverableTracker` and never calls `finalizeStreamResult`, so it is outside the code this PR touches.

Test changes: two assertions flip from "expect the sentinel" to "expect empty" (locking in the new contract), plus one new boundary case covering the text-less trailing event across both `claude` and `codebuddy`.
