### PR TITLE
MUL-5855: feat(dev): add worktree database cleanup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,6 +51,9 @@ jobs:
               - 'scripts/generate-reserved-slugs.mjs'
               - 'server/internal/handler/reserved_slugs.json'
               - 'scripts/selfhost-config.test.sh'
+              - 'scripts/drop-database.sh'
+              - 'scripts/remove-worktree.sh'
+              - 'scripts/worktree-db.test.sh'
               - 'scripts/selfhost-wait.sh'
               # selfhost-config.test.sh asserts on the installers' side of
               # the port contract, so a change to either must run it.
@@ -148,6 +151,10 @@ jobs:
       - name: Test self-host env derivation
         if: ${{ needs.changes.outputs.frontend == 'true' }}
         run: bash scripts/selfhost-config.test.sh
+
+      - name: Test worktree database cleanup
+        if: ${{ needs.changes.outputs.frontend == 'true' }}
+        run: bash scripts/worktree-db.test.sh
 
       - name: Verify reserved-slugs.ts is up to date
         if: ${{ needs.changes.outputs.frontend == 'true' }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -79,6 +79,8 @@ Use the repo scripts as the source of truth. Common commands:
 make dev              # auto-setup and start the app
 make start            # start backend + frontend
 make stop             # stop app processes for this checkout
+make db-drop          # permanently drop this checkout's local database
+make remove-worktree WORKTREE=../path  # drop a linked worktree DB, then remove it
 make server           # run Go server only
 make daemon           # run local daemon
 make test             # Go tests

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -673,6 +673,8 @@ The command prints the selected database and environment file, then requires a
 `y/N` confirmation. It only operates on the local Docker PostgreSQL service,
 protects PostgreSQL system databases, and refuses to drop the default main
 database `multica` unless `ALLOW_MAIN_DB_DROP=1` is explicitly supplied.
+Declining the confirmation is a successful no-op; when called by
+`make remove-worktree`, it also leaves the worktree in place.
 
 If you want to wipe all local PostgreSQL data for this repo:
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -191,6 +191,25 @@ make stop-worktree    # stop
 make check-worktree   # verify
 ```
 
+### Removing a Worktree
+
+Git does not provide a `pre-worktree-remove` hook. Use the repository wrapper
+from another checkout so database cleanup happens before Git removes the
+worktree directory:
+
+```bash
+make remove-worktree WORKTREE=../multica-feature
+```
+
+The command refuses to remove the primary checkout, the current checkout, a
+locked worktree, or a worktree with uncommitted changes. If the target contains
+`.env.worktree`, it shows the database name and asks for `y/N` confirmation,
+drops that database, and only then runs `git worktree remove`. A worktree that
+was never set up has no `.env.worktree`, so database cleanup is skipped.
+
+Running `git worktree remove` directly bypasses this cleanup and can leave an
+orphaned local database.
+
 ## Running Main and Worktree at the Same Time
 
 This is a first-class workflow.
@@ -643,6 +662,17 @@ make start
 - only affects the current env's database; other worktree databases are untouched
 - refuses to run if `DATABASE_URL` points at a remote host
 - pass `ENV_FILE=.env.worktree` to target a specific worktree
+
+To permanently drop the current worktree database without recreating it:
+
+```bash
+make db-drop ENV_FILE=.env.worktree
+```
+
+The command prints the selected database and environment file, then requires a
+`y/N` confirmation. It only operates on the local Docker PostgreSQL service,
+protects PostgreSQL system databases, and refuses to drop the default main
+database `multica` unless `ALLOW_MAIN_DB_DROP=1` is explicitly supplied.
 
 If you want to wipe all local PostgreSQL data for this repo:
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help makehelp dev server daemon cli multica build test migrate-up migrate-down sqlc seed clean setup start stop check worktree-env setup-main start-main stop-main check-main setup-worktree start-worktree stop-worktree check-worktree db-up db-down db-reset selfhost selfhost-build selfhost-stop
+.PHONY: help makehelp dev server daemon cli multica build test migrate-up migrate-down sqlc seed clean setup start stop check worktree-env setup-main start-main stop-main check-main setup-worktree start-worktree stop-worktree check-worktree remove-worktree db-up db-down db-drop db-reset selfhost selfhost-build selfhost-stop
 
 MAIN_ENV_FILE ?= .env
 WORKTREE_ENV_FILE ?= .env.worktree
@@ -193,6 +193,10 @@ db-up: ## Start the shared PostgreSQL container used by main and worktrees
 db-down: ## Stop the shared PostgreSQL container without removing its Docker volume
 	@$(COMPOSE) down
 
+db-drop: ## Permanently drop the current env's local database after confirmation
+	$(REQUIRE_ENV)
+	@bash scripts/drop-database.sh "$(ENV_FILE)"
+
 # Drop + recreate the current env's database, then run all migrations.
 # Use for a clean slate in local dev. Only affects the DB named in
 # ENV_FILE (POSTGRES_DB); the shared postgres container and other
@@ -245,6 +249,9 @@ stop-worktree: ## Stop this worktree's backend and frontend processes
 
 check-worktree: ## Run the full verification pipeline for this worktree
 	@ENV_FILE=$(WORKTREE_ENV_FILE) bash scripts/check.sh
+
+remove-worktree: ## Drop a linked worktree's database, then remove it (WORKTREE=path)
+	@bash scripts/remove-worktree.sh "$(WORKTREE)"
 
 # ---------- Individual commands ----------
 ##@ Individual commands

--- a/Makefile
+++ b/Makefile
@@ -195,7 +195,9 @@ db-down: ## Stop the shared PostgreSQL container without removing its Docker vol
 
 db-drop: ## Permanently drop the current env's local database after confirmation
 	$(REQUIRE_ENV)
-	@bash scripts/drop-database.sh "$(ENV_FILE)"
+	@status=0; bash scripts/drop-database.sh "$(ENV_FILE)" || status=$$?; \
+		if [ "$$status" -eq 2 ]; then exit 0; fi; \
+		exit "$$status"
 
 # Drop + recreate the current env's database, then run all migrations.
 # Use for a clean slate in local dev. Only affects the DB named in

--- a/scripts/drop-database.sh
+++ b/scripts/drop-database.sh
@@ -63,7 +63,8 @@ case "$answer" in
   y | Y) ;;
   *)
     echo "Cancelled."
-    exit 1
+    # Callers distinguish an intentional cancellation from an execution error.
+    exit 2
     ;;
 esac
 

--- a/scripts/drop-database.sh
+++ b/scripts/drop-database.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+root_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+env_input="${1:-.env}"
+
+if [[ "$env_input" = /* ]]; then
+  env_file="$env_input"
+else
+  env_file="$PWD/$env_input"
+fi
+
+if [ ! -f "$env_file" ]; then
+  echo "Missing env file: $env_input" >&2
+  exit 1
+fi
+
+set -a
+# shellcheck disable=SC1090
+. "$env_file"
+set +a
+
+POSTGRES_DB="${POSTGRES_DB:-}"
+POSTGRES_USER="${POSTGRES_USER:-multica}"
+DATABASE_URL="${DATABASE_URL:-}"
+
+if [ -z "$POSTGRES_DB" ]; then
+  echo "Refusing to drop a database: POSTGRES_DB is empty in $env_input." >&2
+  exit 1
+fi
+
+case "$DATABASE_URL" in
+  "" | *@localhost:* | *@localhost/* | *@127.0.0.1:* | *@127.0.0.1/* | *@\[::1\]:* | *@\[::1\]/*) ;;
+  *)
+    echo "Refusing to drop database '$POSTGRES_DB': DATABASE_URL points at a remote host." >&2
+    exit 1
+    ;;
+esac
+
+case "$POSTGRES_DB" in
+  postgres | template0 | template1)
+    echo "Refusing to drop protected PostgreSQL database '$POSTGRES_DB'." >&2
+    exit 1
+    ;;
+  multica)
+    if [ "${ALLOW_MAIN_DB_DROP:-0}" != "1" ]; then
+      echo "Refusing to drop the default main database 'multica'." >&2
+      echo "Re-run with ALLOW_MAIN_DB_DROP=1 only if deleting the main checkout database is intentional." >&2
+      exit 1
+    fi
+    ;;
+esac
+
+echo "Database: $POSTGRES_DB"
+echo "Source:   $env_input"
+echo ""
+printf "Drop this database permanently? [y/N] "
+if ! IFS= read -r answer; then
+  answer=""
+fi
+
+case "$answer" in
+  y | Y) ;;
+  *)
+    echo "Cancelled."
+    exit 1
+    ;;
+esac
+
+cd "$root_dir"
+docker compose exec -T postgres \
+  dropdb \
+  --username "$POSTGRES_USER" \
+  --maintenance-db postgres \
+  --if-exists \
+  --force \
+  -- \
+  "$POSTGRES_DB"
+
+echo "Dropped database '$POSTGRES_DB'."

--- a/scripts/remove-worktree.sh
+++ b/scripts/remove-worktree.sh
@@ -22,7 +22,8 @@ if [ ! -d "$candidate" ]; then
 fi
 
 target="$(cd "$candidate" && pwd -P)"
-current="$(pwd -P)"
+current_root="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+current="$(cd "$current_root" && pwd -P)"
 primary=""
 registered=0
 locked=0

--- a/scripts/remove-worktree.sh
+++ b/scripts/remove-worktree.sh
@@ -76,7 +76,16 @@ fi
 
 worktree_env="$target/.env.worktree"
 if [ -f "$worktree_env" ]; then
-  make --no-print-directory -C "$script_dir/.." db-drop ENV_FILE="$worktree_env"
+  db_drop_status=0
+  bash "$script_dir/drop-database.sh" "$worktree_env" || db_drop_status=$?
+  case "$db_drop_status" in
+    0) ;;
+    2)
+      echo "Worktree was not removed."
+      exit 0
+      ;;
+    *) exit "$db_drop_status" ;;
+  esac
 else
   echo "No .env.worktree found; skipping database cleanup."
 fi

--- a/scripts/remove-worktree.sh
+++ b/scripts/remove-worktree.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+worktree_input="${1:-}"
+
+if [ -z "$worktree_input" ]; then
+  echo "Usage: make remove-worktree WORKTREE=/path/to/worktree" >&2
+  exit 1
+fi
+
+repo_root="$(git rev-parse --show-toplevel)"
+if [[ "$worktree_input" = /* ]]; then
+  candidate="$worktree_input"
+else
+  candidate="$PWD/$worktree_input"
+fi
+
+if [ ! -d "$candidate" ]; then
+  echo "Worktree directory does not exist: $worktree_input" >&2
+  exit 1
+fi
+
+target="$(cd "$candidate" && pwd -P)"
+current="$(pwd -P)"
+primary=""
+registered=0
+locked=0
+listed_path=""
+
+while IFS= read -r line || [ -n "$line" ]; do
+  case "$line" in
+    worktree\ *)
+      listed_path="${line#worktree }"
+      if [ -z "$primary" ]; then
+        primary="$listed_path"
+      fi
+      if [ "$listed_path" = "$target" ]; then
+        registered=1
+      fi
+      ;;
+    locked*)
+      if [ "$listed_path" = "$target" ]; then
+        locked=1
+      fi
+      ;;
+  esac
+done < <(git -C "$repo_root" worktree list --porcelain)
+
+if [ "$registered" != "1" ]; then
+  echo "Not a registered worktree of this repository: $target" >&2
+  exit 1
+fi
+
+if [ "$target" = "$primary" ]; then
+  echo "Refusing to remove the primary checkout: $target" >&2
+  exit 1
+fi
+
+if [ "$target" = "$current" ]; then
+  echo "Refusing to remove the current worktree from inside itself." >&2
+  echo "Run this command from another checkout." >&2
+  exit 1
+fi
+
+if [ "$locked" = "1" ]; then
+  echo "Refusing to remove locked worktree: $target" >&2
+  exit 1
+fi
+
+if [ -n "$(git -C "$target" status --porcelain --untracked-files=all)" ]; then
+  echo "Refusing to remove dirty worktree before its database is dropped: $target" >&2
+  echo "Commit, stash, or discard its changes first." >&2
+  exit 1
+fi
+
+worktree_env="$target/.env.worktree"
+if [ -f "$worktree_env" ]; then
+  make --no-print-directory -C "$script_dir/.." db-drop ENV_FILE="$worktree_env"
+else
+  echo "No .env.worktree found; skipping database cleanup."
+fi
+
+git -C "$repo_root" worktree remove "$target"
+echo "Removed worktree '$target'."

--- a/scripts/worktree-db.test.sh
+++ b/scripts/worktree-db.test.sh
@@ -124,7 +124,9 @@ git -C "$repo" config user.name "Worktree DB Test"
 git -C "$repo" config user.email "worktree-db-test@example.com"
 printf '.env.worktree\n' >"$repo/.gitignore"
 printf 'base\n' >"$repo/tracked.txt"
-git -C "$repo" add .gitignore tracked.txt
+mkdir -p "$repo/backend"
+printf 'nested\n' >"$repo/backend/tracked.txt"
+git -C "$repo" add .gitignore tracked.txt backend/tracked.txt
 git -C "$repo" commit -qm "test: initialize fixture"
 git -C "$repo" worktree add -q -b feature "$worktree"
 cat >"$worktree/.env.worktree" <<'EOF'
@@ -132,6 +134,19 @@ POSTGRES_DB=multica_worktree_456
 POSTGRES_USER=multica
 DATABASE_URL=postgres://multica:multica@localhost:5432/multica_worktree_456?sslmode=disable
 EOF
+
+: >"$docker_log"
+if printf 'y\n' | (cd "$worktree/backend" && PATH="$stub_dir:$PATH" DOCKER_LOG="$docker_log" \
+  bash "$root_dir/scripts/remove-worktree.sh" "$worktree") >"$output" 2>&1; then
+  fail "remove-worktree must refuse the current worktree from a nested directory"
+fi
+require_contains "$output" "Refusing to remove the current worktree from inside itself."
+if [ ! -d "$worktree" ]; then
+  fail "remove-worktree removed the current worktree from a nested directory"
+fi
+if [ -s "$docker_log" ]; then
+  fail "remove-worktree dropped the database before rejecting the current worktree"
+fi
 
 : >"$docker_log"
 if ! printf 'n\n' | (cd "$repo" && PATH="$stub_dir:$PATH" DOCKER_LOG="$docker_log" \

--- a/scripts/worktree-db.test.sh
+++ b/scripts/worktree-db.test.sh
@@ -1,0 +1,166 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+root_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+tmp_dir="$(mktemp -d)"
+trap 'rm -rf "$tmp_dir"' EXIT
+
+fail() {
+  echo "FAIL: $*" >&2
+  exit 1
+}
+
+require_contains() {
+  local file=$1
+  local expected=$2
+  if ! grep -Fq "$expected" "$file"; then
+    echo "Expected output to contain: $expected" >&2
+    echo "Observed:" >&2
+    cat "$file" >&2
+    exit 1
+  fi
+}
+
+stub_dir="$tmp_dir/bin"
+mkdir -p "$stub_dir"
+docker_log="$tmp_dir/docker.log"
+
+cat >"$stub_dir/docker" <<'STUB'
+#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "$*" >>"$DOCKER_LOG"
+STUB
+chmod +x "$stub_dir/docker"
+
+local_env="$tmp_dir/local.env"
+cat >"$local_env" <<'EOF'
+POSTGRES_DB=multica_feature_123
+POSTGRES_USER=multica
+DATABASE_URL=postgres://multica:multica@localhost:5432/multica_feature_123?sslmode=disable
+EOF
+
+output="$tmp_dir/output"
+: >"$docker_log"
+if printf 'n\n' | PATH="$stub_dir:$PATH" DOCKER_LOG="$docker_log" \
+  bash "$root_dir/scripts/drop-database.sh" "$local_env" >"$output" 2>&1; then
+  fail "db-drop must fail when confirmation is declined"
+fi
+require_contains "$output" "Drop this database permanently? [y/N] Cancelled."
+if [ -s "$docker_log" ]; then
+  fail "db-drop invoked Docker after confirmation was declined"
+fi
+
+: >"$docker_log"
+printf 'y\n' | PATH="$stub_dir:$PATH" DOCKER_LOG="$docker_log" \
+  bash "$root_dir/scripts/drop-database.sh" "$local_env" >"$output"
+require_contains "$docker_log" \
+  "compose exec -T postgres dropdb --username multica --maintenance-db postgres --if-exists --force -- multica_feature_123"
+require_contains "$output" "Dropped database 'multica_feature_123'."
+
+remote_env="$tmp_dir/remote.env"
+cat >"$remote_env" <<'EOF'
+POSTGRES_DB=production
+DATABASE_URL=postgres://user:password@db.example.com:5432/production
+EOF
+: >"$docker_log"
+if printf 'y\n' | PATH="$stub_dir:$PATH" DOCKER_LOG="$docker_log" \
+  bash "$root_dir/scripts/drop-database.sh" "$remote_env" >"$output" 2>&1; then
+  fail "db-drop must refuse a remote DATABASE_URL"
+fi
+require_contains "$output" "DATABASE_URL points at a remote host"
+if [ -s "$docker_log" ]; then
+  fail "db-drop invoked Docker for a remote DATABASE_URL"
+fi
+
+system_env="$tmp_dir/system.env"
+cat >"$system_env" <<'EOF'
+POSTGRES_DB=postgres
+DATABASE_URL=postgres://multica:multica@localhost:5432/postgres
+EOF
+if printf 'y\n' | PATH="$stub_dir:$PATH" DOCKER_LOG="$docker_log" \
+  bash "$root_dir/scripts/drop-database.sh" "$system_env" >"$output" 2>&1; then
+  fail "db-drop must protect PostgreSQL system databases"
+fi
+require_contains "$output" "Refusing to drop protected PostgreSQL database"
+
+main_env="$tmp_dir/main.env"
+cat >"$main_env" <<'EOF'
+POSTGRES_DB=multica
+DATABASE_URL=postgres://multica:multica@localhost:5432/multica
+EOF
+if printf 'y\n' | PATH="$stub_dir:$PATH" DOCKER_LOG="$docker_log" \
+  bash "$root_dir/scripts/drop-database.sh" "$main_env" >"$output" 2>&1; then
+  fail "db-drop must protect the default main database"
+fi
+require_contains "$output" "Refusing to drop the default main database"
+
+: >"$docker_log"
+if PATH="$stub_dir:$PATH" DOCKER_LOG="$docker_log" \
+  bash "$root_dir/scripts/drop-database.sh" "$local_env" </dev/null >"$output" 2>&1; then
+  fail "db-drop must cancel when confirmation input is unavailable"
+fi
+require_contains "$output" "Cancelled."
+if [ -s "$docker_log" ]; then
+  fail "db-drop invoked Docker without affirmative confirmation"
+fi
+
+repo="$tmp_dir/repo"
+worktree="$tmp_dir/worktree"
+git init -q -b main "$repo"
+git -C "$repo" config user.name "Worktree DB Test"
+git -C "$repo" config user.email "worktree-db-test@example.com"
+printf '.env.worktree\n' >"$repo/.gitignore"
+printf 'base\n' >"$repo/tracked.txt"
+git -C "$repo" add .gitignore tracked.txt
+git -C "$repo" commit -qm "test: initialize fixture"
+git -C "$repo" worktree add -q -b feature "$worktree"
+cat >"$worktree/.env.worktree" <<'EOF'
+POSTGRES_DB=multica_worktree_456
+POSTGRES_USER=multica
+DATABASE_URL=postgres://multica:multica@localhost:5432/multica_worktree_456?sslmode=disable
+EOF
+
+: >"$docker_log"
+if printf 'n\n' | (cd "$repo" && PATH="$stub_dir:$PATH" DOCKER_LOG="$docker_log" \
+  bash "$root_dir/scripts/remove-worktree.sh" "$worktree") >"$output" 2>&1; then
+  fail "remove-worktree must abort when database deletion is declined"
+fi
+if [ ! -d "$worktree" ]; then
+  fail "remove-worktree removed the worktree after database deletion was declined"
+fi
+
+printf 'y\n' | (cd "$repo" && PATH="$stub_dir:$PATH" DOCKER_LOG="$docker_log" \
+  bash "$root_dir/scripts/remove-worktree.sh" "$worktree") >"$output"
+if [ -e "$worktree" ]; then
+  fail "remove-worktree did not remove the worktree after database deletion"
+fi
+require_contains "$docker_log" \
+  "compose exec -T postgres dropdb --username multica --maintenance-db postgres --if-exists --force -- multica_worktree_456"
+
+dirty_worktree="$tmp_dir/dirty-worktree"
+git -C "$repo" worktree add -q -b dirty-feature "$dirty_worktree"
+printf 'dirty\n' >>"$dirty_worktree/tracked.txt"
+: >"$docker_log"
+if printf 'y\n' | (cd "$repo" && PATH="$stub_dir:$PATH" DOCKER_LOG="$docker_log" \
+  bash "$root_dir/scripts/remove-worktree.sh" "$dirty_worktree") >"$output" 2>&1; then
+  fail "remove-worktree must refuse a dirty worktree"
+fi
+require_contains "$output" "Refusing to remove dirty worktree"
+if [ -s "$docker_log" ]; then
+  fail "remove-worktree dropped the database before rejecting a dirty worktree"
+fi
+
+empty_worktree="$tmp_dir/empty-worktree"
+git -C "$repo" worktree add -q -b empty-feature "$empty_worktree"
+(cd "$repo" && bash "$root_dir/scripts/remove-worktree.sh" "$empty_worktree") >"$output"
+require_contains "$output" "No .env.worktree found; skipping database cleanup."
+if [ -e "$empty_worktree" ]; then
+  fail "remove-worktree did not remove a worktree without an env file"
+fi
+
+if (cd "$repo" && bash "$root_dir/scripts/remove-worktree.sh" "$repo") >"$output" 2>&1; then
+  fail "remove-worktree must refuse the primary checkout"
+fi
+require_contains "$output" "Refusing to remove the primary checkout"
+
+echo "worktree database cleanup tests passed"

--- a/scripts/worktree-db.test.sh
+++ b/scripts/worktree-db.test.sh
@@ -41,13 +41,24 @@ EOF
 
 output="$tmp_dir/output"
 : >"$docker_log"
-if printf 'n\n' | PATH="$stub_dir:$PATH" DOCKER_LOG="$docker_log" \
-  bash "$root_dir/scripts/drop-database.sh" "$local_env" >"$output" 2>&1; then
-  fail "db-drop must fail when confirmation is declined"
+cancel_status=0
+printf 'n\n' | PATH="$stub_dir:$PATH" DOCKER_LOG="$docker_log" \
+  bash "$root_dir/scripts/drop-database.sh" "$local_env" >"$output" 2>&1 || cancel_status=$?
+if [ "$cancel_status" -ne 2 ]; then
+  fail "db-drop cancellation status = $cancel_status, want 2"
 fi
 require_contains "$output" "Drop this database permanently? [y/N] Cancelled."
 if [ -s "$docker_log" ]; then
   fail "db-drop invoked Docker after confirmation was declined"
+fi
+
+if ! printf 'n\n' | PATH="$stub_dir:$PATH" DOCKER_LOG="$docker_log" \
+  make --no-print-directory -C "$root_dir" db-drop ENV_FILE="$local_env" >"$output" 2>&1; then
+  fail "make db-drop must treat an intentional cancellation as success"
+fi
+require_contains "$output" "Cancelled."
+if grep -Fq "Error" "$output"; then
+  fail "make db-drop printed a Make error after cancellation"
 fi
 
 : >"$docker_log"
@@ -95,9 +106,11 @@ fi
 require_contains "$output" "Refusing to drop the default main database"
 
 : >"$docker_log"
-if PATH="$stub_dir:$PATH" DOCKER_LOG="$docker_log" \
-  bash "$root_dir/scripts/drop-database.sh" "$local_env" </dev/null >"$output" 2>&1; then
-  fail "db-drop must cancel when confirmation input is unavailable"
+cancel_status=0
+PATH="$stub_dir:$PATH" DOCKER_LOG="$docker_log" \
+  bash "$root_dir/scripts/drop-database.sh" "$local_env" </dev/null >"$output" 2>&1 || cancel_status=$?
+if [ "$cancel_status" -ne 2 ]; then
+  fail "db-drop EOF cancellation status = $cancel_status, want 2"
 fi
 require_contains "$output" "Cancelled."
 if [ -s "$docker_log" ]; then
@@ -121,12 +134,16 @@ DATABASE_URL=postgres://multica:multica@localhost:5432/multica_worktree_456?sslm
 EOF
 
 : >"$docker_log"
-if printf 'n\n' | (cd "$repo" && PATH="$stub_dir:$PATH" DOCKER_LOG="$docker_log" \
+if ! printf 'n\n' | (cd "$repo" && PATH="$stub_dir:$PATH" DOCKER_LOG="$docker_log" \
   bash "$root_dir/scripts/remove-worktree.sh" "$worktree") >"$output" 2>&1; then
-  fail "remove-worktree must abort when database deletion is declined"
+  fail "remove-worktree must treat an intentional cancellation as success"
 fi
 if [ ! -d "$worktree" ]; then
   fail "remove-worktree removed the worktree after database deletion was declined"
+fi
+require_contains "$output" "Worktree was not removed."
+if grep -Fq "Error" "$output"; then
+  fail "remove-worktree printed an error after cancellation"
 fi
 
 printf 'y\n' | (cd "$repo" && PATH="$stub_dir:$PATH" DOCKER_LOG="$docker_log" \


### PR DESCRIPTION
## Summary

- add `make db-drop` with local-only validation, protected databases, and `y/N` confirmation
- add `make remove-worktree WORKTREE=...` to drop a linked worktree database before removing the worktree
- document Git's lack of a native `pre-worktree-remove` hook and wire shell regression coverage into CI

## Why

Worktree databases share a persistent PostgreSQL volume, but `git worktree remove` does not clean them up. Git does not expose a hook before worktree removal, so old databases accumulate unless contributors remember to delete them manually.

The new repository wrapper provides one explicit cleanup path and refuses unsafe targets before any destructive database operation.

## Safety

- refuses remote `DATABASE_URL` values
- protects PostgreSQL system databases and the default `multica` main database
- defaults confirmation to no
- refuses primary, current, locked, and dirty worktrees before dropping their database
- uses `dropdb --force --if-exists` with the database name passed as an argument

## Validation

- `bash scripts/worktree-db.test.sh`
- `bash scripts/selfhost-config.test.sh`
- `bash -n scripts/drop-database.sh scripts/remove-worktree.sh scripts/worktree-db.test.sh`
- `git diff --check`
