### PR TITLE
fix(server): stop broadcasting inbox:unread to the whole workspace (MUL-5603 PR 0)

### DIFF
--- a/server/cmd/server/listeners.go
+++ b/server/cmd/server/listeners.go
@@ -81,6 +81,7 @@ func registerListeners(bus *events.Bus, b realtime.Broadcaster) {
 	personalEvents := map[string]bool{
 		protocol.EventInboxNew:           true,
 		protocol.EventInboxRead:          true,
+		protocol.EventInboxUnread:        true,
 		protocol.EventInboxArchived:      true,
 		protocol.EventInboxUnarchived:    true,
 		protocol.EventInboxBatchRead:     true,
@@ -116,10 +117,19 @@ func registerListeners(bus *events.Bus, b realtime.Broadcaster) {
 		sendToRecipient(b, e, recipientID)
 	})
 
-	// inbox:read, inbox:archived, inbox:unarchived, inbox:batch-read,
-	// inbox:batch-archived — extract recipient from top-level payload
+	// inbox:read, inbox:unread, inbox:archived, inbox:unarchived,
+	// inbox:batch-read, inbox:batch-archived — extract recipient from top-level
+	// payload.
+	//
+	// inbox:unread was missing from both this list and personalEvents, so it
+	// fell through to the SubscribeAll workspace fanout below: marking one
+	// notification unread pushed that person's item_id and recipient_id to every
+	// connected member of the workspace, and made all of their clients
+	// invalidate an inbox that had not changed. It is personal state, like every
+	// other event here.
 	for _, eventType := range []string{
-		protocol.EventInboxRead, protocol.EventInboxArchived, protocol.EventInboxUnarchived,
+		protocol.EventInboxRead, protocol.EventInboxUnread,
+		protocol.EventInboxArchived, protocol.EventInboxUnarchived,
 		protocol.EventInboxBatchRead, protocol.EventInboxBatchArchived,
 	} {
 		bus.Subscribe(eventType, func(e events.Event) {

--- a/server/cmd/server/listeners_inbox_personal_test.go
+++ b/server/cmd/server/listeners_inbox_personal_test.go
@@ -1,0 +1,114 @@
+package main
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/multica-ai/multica/server/internal/events"
+	"github.com/multica-ai/multica/server/pkg/protocol"
+)
+
+// Inbox events are personal state. Every one of them must reach only its
+// recipient — never the workspace room, which every member of the workspace is
+// subscribed to.
+//
+// inbox:unread was the one that leaked: it was absent from both personalEvents
+// and the targeted-subscriber list, so SubscribeAll fanned it out to the whole
+// workspace. Marking a single notification unread therefore pushed that
+// person's item_id and recipient_id to every connected colleague and made all
+// of their clients invalidate an inbox that had not changed.
+func TestRegisterListeners_InboxEventsNeverReachTheWorkspaceRoom(t *testing.T) {
+	const (
+		workspaceID = "11111111-1111-4111-8111-111111111111"
+		recipientID = "22222222-2222-4222-8222-222222222222"
+		itemID      = "33333333-3333-4333-8333-333333333333"
+	)
+
+	cases := []struct {
+		name    string
+		event   string
+		payload map[string]any
+	}{
+		{"inbox:new", protocol.EventInboxNew, map[string]any{
+			"item": map[string]any{"id": itemID, "recipient_id": recipientID},
+		}},
+		{"inbox:read", protocol.EventInboxRead, map[string]any{
+			"item_id": itemID, "recipient_id": recipientID,
+		}},
+		{"inbox:unread", protocol.EventInboxUnread, map[string]any{
+			"item_id": itemID, "recipient_id": recipientID,
+		}},
+		{"inbox:archived", protocol.EventInboxArchived, map[string]any{
+			"item_id": itemID, "recipient_id": recipientID,
+		}},
+		{"inbox:unarchived", protocol.EventInboxUnarchived, map[string]any{
+			"item_id": itemID, "recipient_id": recipientID,
+		}},
+		{"inbox:batch-read", protocol.EventInboxBatchRead, map[string]any{
+			"recipient_id": recipientID, "count": 3,
+		}},
+		{"inbox:batch-archived", protocol.EventInboxBatchArchived, map[string]any{
+			"recipient_id": recipientID, "count": 3,
+		}},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			bus := events.New()
+			fake := &fakeBroadcaster{}
+			registerListeners(bus, fake)
+
+			bus.Publish(events.Event{
+				Type:        tc.event,
+				WorkspaceID: workspaceID,
+				ActorType:   "member",
+				ActorID:     recipientID,
+				Payload:     tc.payload,
+			})
+
+			if len(fake.workspaceCalls) != 0 {
+				t.Fatalf("%s was broadcast to the workspace room — it is personal state", tc.event)
+			}
+			if len(fake.scopeCalls) != 0 {
+				t.Fatalf("%s was broadcast to a scope room", tc.event)
+			}
+			if len(fake.userCalls) != 1 {
+				t.Fatalf("%s reached %d users, want exactly the recipient", tc.event, len(fake.userCalls))
+			}
+			if got := fake.userCalls[0].userID; got != recipientID {
+				t.Fatalf("%s was sent to %q, want the recipient %q", tc.event, got, recipientID)
+			}
+
+			// The recipient must still receive a well-formed frame — silencing
+			// the leak by dropping the event entirely would be its own bug.
+			var frame map[string]any
+			if err := json.Unmarshal(fake.userCalls[0].msg, &frame); err != nil {
+				t.Fatalf("%s frame is not valid JSON: %v", tc.event, err)
+			}
+			if frame["type"] != tc.event {
+				t.Fatalf("frame type = %v, want %s", frame["type"], tc.event)
+			}
+		})
+	}
+}
+
+// A missing recipient must drop the event rather than fall through to the
+// workspace fanout: an inbox event with nobody to deliver it to is a producer
+// bug, and broadcasting it would be the same leak by another route.
+func TestRegisterListeners_InboxEventWithoutRecipientIsDropped(t *testing.T) {
+	bus := events.New()
+	fake := &fakeBroadcaster{}
+	registerListeners(bus, fake)
+
+	bus.Publish(events.Event{
+		Type:        protocol.EventInboxUnread,
+		WorkspaceID: "11111111-1111-4111-8111-111111111111",
+		ActorType:   "member",
+		Payload:     map[string]any{"item_id": "33333333-3333-4333-8333-333333333333"},
+	})
+
+	if len(fake.userCalls) != 0 || len(fake.workspaceCalls) != 0 || len(fake.scopeCalls) != 0 {
+		t.Fatalf("an inbox event with no recipient must be dropped, got user=%d workspace=%d scope=%d",
+			len(fake.userCalls), len(fake.workspaceCalls), len(fake.scopeCalls))
+	}
+}


### PR DESCRIPTION
MUL-5603 · **PR 0** — the standalone fix the plan requires to land before the inbox refactor.

## The bug

`inbox:unread` is missing from both `personalEvents` and the targeted-subscriber
list in `registerListeners`, so it falls through to the `SubscribeAll` workspace
fanout. Marking one notification unread pushes that person's `item_id` and
`recipient_id` to **every connected member of the workspace**, and makes all of
their clients invalidate an inbox that has not changed.

The other six inbox events (`new`, `read`, `archived`, `unarchived`,
`batch-read`, `batch-archived`) are all routed to their recipient. This one was
simply never added when `MarkInboxUnread` shipped.

## The fix

Both halves are needed:

1. Add it to `personalEvents`, so `SubscribeAll` stops broadcasting it.
2. Add it to the loop that resolves `recipient_id` and sends only to that user.

Doing only (1) would silence the event — the recipient would stop receiving it
too.

## Tests

`TestRegisterListeners_InboxEventsNeverReachTheWorkspaceRoom` covers **all seven**
inbox events, not just the broken one. The invariant is "inbox events are
personal state"; pinning it per event is what stops the next one from being
added to the publisher without a route. It also asserts the recipient still gets
a well-formed frame, because silencing the leak by dropping the event would be
its own bug.

`TestRegisterListeners_InboxEventWithoutRecipientIsDropped` pins that a producer
bug (no recipient) drops the event rather than falling back to the workspace
fanout — that would be the same leak by another route.

Negative-verified: reverting either half of the fix fails the `inbox:unread`
case.

## Verification

```
go test ./cmd/server/         ok
go test ./internal/handler/   ok
go build ./... && go vet      clean
```

## Scope

Deliberately split out of the inbox refactor. This is a live privacy and
cache-churn bug on its own and should not wait behind a large change — the
MUL-5603 plan lists it as a separate PR that lands first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
