### PR TITLE
MUL-5759: fix analytics pickers and chart label clipping

### DIFF
--- a/packages/ui/components/ui/dropdown-menu.tsx
+++ b/packages/ui/components/ui/dropdown-menu.tsx
@@ -202,6 +202,11 @@ function DropdownMenuRadioItem({
   className,
   children,
   inset,
+  // Base UI defaults radio items to closeOnClick=false (tuned for menus where
+  // the user adjusts several options in one visit). Our radio menus are almost
+  // all single-select pickers, so selecting should dismiss; menus that mix a
+  // radio group with further actions opt back out with closeOnClick={false}.
+  closeOnClick = true,
   ...props
 }: MenuPrimitive.RadioItem.Props & {
   inset?: boolean
@@ -210,6 +215,7 @@ function DropdownMenuRadioItem({
     <MenuPrimitive.RadioItem
       data-slot="dropdown-menu-radio-item"
       data-inset={inset}
+      closeOnClick={closeOnClick}
       className={cn(
         "relative flex cursor-default items-center gap-1.5 rounded-md py-1 pr-8 pl-1.5 text-body outline-hidden select-none focus:bg-accent focus:text-accent-foreground data-inset:pl-7 data-disabled:pointer-events-none data-disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
         className

--- a/packages/ui/components/ui/number-flow.tsx
+++ b/packages/ui/components/ui/number-flow.tsx
@@ -70,6 +70,14 @@ type CompactNumberFlowProps = Omit<
   suffixCase?: "lower" | "upper"
 }
 
+const COMPACT_UNITS = [
+  { divisor: 1, upperSuffix: undefined, lowerSuffix: undefined },
+  { divisor: 1_000, upperSuffix: "K", lowerSuffix: "k" },
+  { divisor: 1_000_000, upperSuffix: "M", lowerSuffix: "m" },
+  { divisor: 1_000_000_000, upperSuffix: "B", lowerSuffix: "b" },
+  { divisor: 1_000_000_000_000, upperSuffix: "T", lowerSuffix: "t" },
+] as const
+
 function CompactNumberFlow({
   value,
   suffixCase = "upper",
@@ -78,25 +86,31 @@ function CompactNumberFlow({
   ...props
 }: CompactNumberFlowProps) {
   const magnitude = Math.abs(value)
-  const divisor =
-    magnitude >= 1_000_000 ? 1_000_000 : magnitude >= 1_000 ? 1_000 : 1
-  const scaledValue = value / divisor
+  let unitIndex = COMPACT_UNITS.findLastIndex(
+    ({ divisor }) => magnitude >= divisor,
+  )
+  unitIndex = Math.max(unitIndex, 0)
+
+  let unit = COMPACT_UNITS[unitIndex]!
+  let scaledValue = value / unit.divisor
+
+  if (
+    Math.abs(Number(scaledValue.toFixed(1))) >= 1_000 &&
+    unitIndex < COMPACT_UNITS.length - 1
+  ) {
+    unit = COMPACT_UNITS[unitIndex + 1]!
+    scaledValue = value / unit.divisor
+  }
+
+  const roundedValue = Number(scaledValue.toFixed(1))
   const fractionDigits =
-    divisor > 1 && Math.abs(scaledValue % 1) >= 0.05 ? 1 : 0
+    unit.divisor > 1 && !Number.isInteger(roundedValue) ? 1 : 0
   const suffix =
-    divisor === 1_000_000
-      ? suffixCase === "upper"
-        ? "M"
-        : "m"
-      : divisor === 1_000
-        ? suffixCase === "upper"
-          ? "K"
-          : "k"
-        : undefined
+    suffixCase === "upper" ? unit.upperSuffix : unit.lowerSuffix
   const format: NumberFlowFormat = {
     minimumFractionDigits: fractionDigits,
     maximumFractionDigits: fractionDigits,
-    useGrouping: divisor === 1,
+    useGrouping: unit.divisor === 1,
   }
   const formatted = new Intl.NumberFormat(locales, format).format(scaledValue)
 

--- a/packages/views/dashboard/components/dashboard-page.tsx
+++ b/packages/views/dashboard/components/dashboard-page.tsx
@@ -524,8 +524,7 @@ export function DashboardPage() {
 
       <div className="flex-1 overflow-y-auto">
         <div className="mx-auto max-w-6xl p-6">
-          <TabsContent value="usage" className="space-y-5">
-            <p className="text-caption text-muted-foreground">{t(($) => $.subtitle)}</p>
+          <TabsContent value="usage">
             {usageLoading ? (
               <DashboardSkeleton />
             ) : usageHasNoData ? (

--- a/packages/views/issues/components/issues-header.tsx
+++ b/packages/views/issues/components/issues-header.tsx
@@ -698,7 +698,10 @@ function DateSubContent({
         <DropdownMenuLabel>{t(($) => $.filters.date_field)}</DropdownMenuLabel>
         <DropdownMenuRadioGroup value={field} onValueChange={(next) => setFieldValue(next as IssueDateField)}>
           {(["created_at", "updated_at"] as const).map((option) => (
-            <DropdownMenuRadioItem key={option} value={option}>
+            // Picking the date field is a parameter for the presets below, not
+            // the final action — keep the menu open so the user can continue
+            // to a preset or the custom range.
+            <DropdownMenuRadioItem key={option} value={option} closeOnClick={false}>
               {t(($) => $.filters[DATE_FIELD_LABEL_KEY[option]])}
             </DropdownMenuRadioItem>
           ))}

--- a/packages/views/locales/en/usage.json
+++ b/packages/views/locales/en/usage.json
@@ -1,7 +1,6 @@
 {
   "title": "Analytics",
   "tab_usage": "Usage",
-  "subtitle": "Token spend and agent activity across this workspace.",
   "header": {
     "timezone_and_updated": "{{tz}} · updated {{time}}",
     "refresh": "Refresh"

--- a/packages/views/locales/ja/usage.json
+++ b/packages/views/locales/ja/usage.json
@@ -1,7 +1,6 @@
 {
   "title": "分析",
   "tab_usage": "使用量",
-  "subtitle": "このワークスペース全体のトークン消費とエージェントの活動です。",
   "header": {
     "timezone_and_updated": "{{tz}} · {{time}} 更新",
     "refresh": "更新"

--- a/packages/views/locales/ko/usage.json
+++ b/packages/views/locales/ko/usage.json
@@ -1,7 +1,6 @@
 {
   "title": "분석",
   "tab_usage": "사용량",
-  "subtitle": "이 워크스페이스의 토큰 비용과 에이전트 활동입니다.",
   "header": {
     "timezone_and_updated": "{{tz}} · {{time}} 업데이트",
     "refresh": "새로고침"

--- a/packages/views/locales/zh-Hans/usage.json
+++ b/packages/views/locales/zh-Hans/usage.json
@@ -1,7 +1,6 @@
 {
   "title": "统计",
   "tab_usage": "用量",
-  "subtitle": "查看当前 Workspace 的 token 消耗和智能体运行情况。",
   "header": {
     "timezone_and_updated": "{{tz}} · 更新于 {{time}}",
     "refresh": "刷新"

--- a/packages/views/runtimes/components/charts/daily-cost-chart.tsx
+++ b/packages/views/runtimes/components/charts/daily-cost-chart.tsx
@@ -50,7 +50,7 @@ export function DailyCostChart({ data }: { data: DailyCostStackData[] }) {
           axisLine={false}
           tickMargin={8}
           tickFormatter={(v: number) => `$${v}`}
-          width={50}
+          width="auto"
         />
         <ChartTooltip
           content={

--- a/packages/views/runtimes/components/charts/daily-errors-chart.tsx
+++ b/packages/views/runtimes/components/charts/daily-errors-chart.tsx
@@ -48,7 +48,7 @@ export function DailyErrorsChart({ data }: { data: DailyErrorsData[] }) {
           axisLine={false}
           tickMargin={8}
           allowDecimals={false}
-          width={40}
+          width="auto"
         />
         <ChartTooltip
           content={

--- a/packages/views/runtimes/components/charts/daily-tasks-chart.tsx
+++ b/packages/views/runtimes/components/charts/daily-tasks-chart.tsx
@@ -49,7 +49,7 @@ export function DailyTasksChart({ data }: { data: DailyTasksData[] }) {
           axisLine={false}
           tickMargin={8}
           allowDecimals={false}
-          width={40}
+          width="auto"
         />
         <ChartTooltip
           content={

--- a/packages/views/runtimes/components/charts/daily-time-chart.tsx
+++ b/packages/views/runtimes/components/charts/daily-time-chart.tsx
@@ -52,7 +52,7 @@ export function DailyTimeChart({
           axisLine={false}
           tickMargin={8}
           tickFormatter={(v: number) => formatY(v)}
-          width={56}
+          width="auto"
         />
         <ChartTooltip
           content={

--- a/packages/views/runtimes/components/charts/daily-tokens-chart.tsx
+++ b/packages/views/runtimes/components/charts/daily-tokens-chart.tsx
@@ -52,7 +52,7 @@ export function DailyTokensChart({ data }: { data: DailyTokenData[] }) {
           axisLine={false}
           tickMargin={8}
           tickFormatter={(v: number) => formatTokens(v)}
-          width={50}
+          width="auto"
         />
         <ChartTooltip
           content={

--- a/packages/views/runtimes/components/charts/weekly-cost-chart.tsx
+++ b/packages/views/runtimes/components/charts/weekly-cost-chart.tsx
@@ -43,7 +43,7 @@ export function WeeklyCostChart({ data }: { data: WeeklyCostStackData[] }) {
           axisLine={false}
           tickMargin={8}
           tickFormatter={(v: number) => `$${v}`}
-          width={50}
+          width="auto"
         />
         <ChartTooltip
           content={

--- a/packages/views/runtimes/components/charts/weekly-errors-chart.tsx
+++ b/packages/views/runtimes/components/charts/weekly-errors-chart.tsx
@@ -49,7 +49,7 @@ export function WeeklyErrorsChart({ data }: { data: WeeklyErrorsData[] }) {
           axisLine={false}
           tickMargin={8}
           allowDecimals={false}
-          width={40}
+          width="auto"
         />
         <ChartTooltip
           content={

--- a/packages/views/runtimes/components/charts/weekly-tasks-chart.tsx
+++ b/packages/views/runtimes/components/charts/weekly-tasks-chart.tsx
@@ -58,7 +58,7 @@ export function WeeklyTasksChart({ data }: { data: WeeklyTasksData[] }) {
           axisLine={false}
           tickMargin={8}
           allowDecimals={false}
-          width={40}
+          width="auto"
         />
         <ChartTooltip
           content={

--- a/packages/views/runtimes/components/charts/weekly-time-chart.tsx
+++ b/packages/views/runtimes/components/charts/weekly-time-chart.tsx
@@ -61,7 +61,7 @@ export function WeeklyTimeChart({
           axisLine={false}
           tickMargin={8}
           tickFormatter={(v: number) => formatY(v)}
-          width={56}
+          width="auto"
         />
         <ChartTooltip
           content={

--- a/packages/views/runtimes/components/charts/weekly-tokens-chart.tsx
+++ b/packages/views/runtimes/components/charts/weekly-tokens-chart.tsx
@@ -42,7 +42,7 @@ export function WeeklyTokensChart({ data }: { data: WeeklyTokenData[] }) {
           axisLine={false}
           tickMargin={8}
           tickFormatter={(v: number) => formatTokens(v)}
-          width={50}
+          width="auto"
         />
         <ChartTooltip
           content={

--- a/packages/views/runtimes/utils.test.ts
+++ b/packages/views/runtimes/utils.test.ts
@@ -10,6 +10,7 @@ import {
   computeCostInWindow,
   estimateCost,
   estimateCostBreakdown,
+  formatTokens,
   isModelPriced,
   isSelfHealingRuntime,
   sliceWindow,
@@ -1391,5 +1392,23 @@ describe("summarizeTaskUsageAcross", () => {
   it("is null only when no run has any usage", () => {
     expect(summarizeTaskUsageAcross([undefined, [], undefined])).toBeNull();
     expect(summarizeTaskUsageAcross([])).toBeNull();
+  });
+});
+
+describe("formatTokens", () => {
+  it("uses a compact unit ladder for large token counts", () => {
+    expect(formatTokens(999)).toBe("999");
+    expect(formatTokens(1_000)).toBe("1K");
+    expect(formatTokens(1_050)).toBe("1.1K");
+    expect(formatTokens(1_000_000)).toBe("1M");
+    expect(formatTokens(2_200_000_000)).toBe("2.2B");
+    expect(formatTokens(29_513_100_000)).toBe("29.5B");
+    expect(formatTokens(1_000_000_000_000)).toBe("1T");
+  });
+
+  it("promotes values that round across a unit boundary", () => {
+    expect(formatTokens(999_949)).toBe("999.9K");
+    expect(formatTokens(999_950)).toBe("1M");
+    expect(formatTokens(999_999_999)).toBe("1B");
   });
 });

--- a/packages/views/runtimes/utils.ts
+++ b/packages/views/runtimes/utils.ts
@@ -107,16 +107,37 @@ export function isVersionNewer(latest: string, current: string): boolean {
   return false;
 }
 
+const TOKEN_UNITS = [
+  { divisor: 1, suffix: "" },
+  { divisor: 1_000, suffix: "K" },
+  { divisor: 1_000_000, suffix: "M" },
+  { divisor: 1_000_000_000, suffix: "B" },
+  { divisor: 1_000_000_000_000, suffix: "T" },
+] as const;
+
 export function formatTokens(n: number): string {
-  if (n >= 1_000_000) {
-    const m = n / 1_000_000;
-    return m % 1 < 0.05 ? `${Math.round(m)}M` : `${m.toFixed(1)}M`;
+  const magnitude = Math.abs(n);
+  let unitIndex = TOKEN_UNITS.findLastIndex(
+    ({ divisor }) => magnitude >= divisor,
+  );
+  unitIndex = Math.max(unitIndex, 0);
+
+  if (unitIndex === 0) return n.toLocaleString();
+
+  let unit = TOKEN_UNITS[unitIndex]!;
+  let scaled = n / unit.divisor;
+
+  // Promote values that round across a unit boundary (999,999 -> 1M), so a
+  // compact label never renders as 1000K / 1000M and grows unnecessarily.
+  if (
+    Math.abs(Number(scaled.toFixed(1))) >= 1_000 &&
+    unitIndex < TOKEN_UNITS.length - 1
+  ) {
+    unit = TOKEN_UNITS[unitIndex + 1]!;
+    scaled = n / unit.divisor;
   }
-  if (n >= 1_000) {
-    const k = n / 1_000;
-    return k % 1 < 0.05 ? `${Math.round(k)}K` : `${k.toFixed(1)}K`;
-  }
-  return n.toLocaleString();
+
+  return `${Number(scaled.toFixed(1))}${unit.suffix}`;
 }
 
 // Cents below $100, whole dollars above — two decimals on a four-figure spend


### PR DESCRIPTION
## Summary

- make single-select dropdown radio items close after selection by default, while preserving the multi-step issue date filter behavior
- let every Analytics/Runtime Y axis measure its rendered tick labels instead of clipping them to fixed widths
- format large token totals with a complete K/M/B/T ladder, including boundary promotion such as 999.95K → 1M
- remove the redundant Usage tab subtitle and its unused translations

## Root cause

Base UI radio items default to keeping menus open, which does not match picker behavior. The shared charts also reserved fixed Y-axis widths sized for smaller runtime-level values, so workspace-level labels could cross the SVG boundary. Token compaction stopped at millions, making large totals unnecessarily wide.

## Impact

Analytics filters now dismiss immediately, large chart labels remain visible across all daily and weekly metrics, and workspace-scale token totals are shorter and easier to read.

## Validation

- `pnpm --filter @multica/views exec vitest run dashboard/components/dashboard-page.test.tsx runtimes/components/usage-section.test.tsx runtimes/utils.test.ts` — 112 tests passed
- `pnpm --filter @multica/views typecheck`
- `pnpm --filter @multica/ui typecheck`
- changed-file ESLint — 0 errors (5 pre-existing unused-disable warnings in `runtimes/utils.test.ts`)
- `git diff --check`
