### PR TITLE
MUL-5859 fix(dev): repair the local dev flow and collapse bootstrap into one command

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,7 +58,10 @@ jobs:
               - 'scripts/install.ps1'
               - 'scripts/check.sh'
               - 'scripts/dev.sh'
+              - 'scripts/dev-bootstrap.sh'
               - 'scripts/local-env.sh'
+              - 'scripts/port-guard.sh'
+              - 'scripts/port-guard.test.sh'
               - '.env.example'
               - 'docker-compose.selfhost.yml'
               - 'docker-compose.selfhost.build.yml'
@@ -148,6 +151,13 @@ jobs:
       - name: Test self-host env derivation
         if: ${{ needs.changes.outputs.frontend == 'true' }}
         run: bash scripts/selfhost-config.test.sh
+
+      # Pins the listener-only contract behind `make stop` and the `make dev`
+      # port preflight: a bare lsof lookup also matches CLIENTS of the port, so
+      # stopping the backend used to kill the daemon connected to it.
+      - name: Test port guard
+        if: ${{ needs.changes.outputs.frontend == 'true' }}
+        run: bash scripts/port-guard.test.sh
 
       - name: Verify reserved-slugs.ts is up to date
         if: ${{ needs.changes.outputs.frontend == 'true' }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -76,11 +76,13 @@ Mobile is independent. It may import types and pure functions from `@multica/cor
 Use the repo scripts as the source of truth. Common commands:
 
 ```bash
-make dev              # auto-setup and start the app
+make dev-bootstrap    # clean checkout -> logged-in, daemon-attached environment
+make dev-bootstrap-stop
+make dev              # auto-setup and start backend + frontend (foreground)
 make start            # start backend + frontend
-make stop             # stop app processes for this checkout
+make stop             # stop the backend/frontend LISTENERS for this checkout
 make server           # run Go server only
-make daemon           # run local daemon
+make daemon           # build server/bin/multica, then run a daemon command via ARGS
 make test             # Go tests
 make sqlc             # regenerate sqlc code after SQL changes
 pnpm install
@@ -95,6 +97,8 @@ pnpm ui:add badge     # shadcn/Base UI component into packages/ui
 ```
 
 Worktrees share one PostgreSQL container and get isolated DB names/ports via `.env.worktree`. `make dev` auto-detects this. For manual setup use `make worktree-env`, `make setup-worktree`, and `make start-worktree`. `pnpm dev:desktop` additionally self-isolates per worktree (its own renderer port + app name) automatically, independent of `.env.worktree`.
+
+Never start a daemon through `go run` (`make cli ARGS="daemon start"`). It records its own executable path and re-execs it for every task, and `go run` deletes that binary when the launcher exits — the daemon then fails every task with `no such file or directory`. `daemon start` refuses such a binary; use `make daemon ARGS="..."` or `make dev-bootstrap`, which build `server/bin/multica` first.
 
 CI runs Node 22, Go 1.26.1, and a `pgvector/pgvector:pg17` PostgreSQL service.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -115,6 +115,18 @@ FORCE=1 make worktree-env
 From any checkout (main or worktree):
 
 ```bash
+make dev-bootstrap
+```
+
+This takes a clean checkout all the way to a usable environment: everything
+`make dev` does, plus a logged-in user, a workspace, a CLI profile, and a
+running daemon — then prints the URL, the login, and how to stop it. Stop it
+with `make dev-bootstrap-stop`. See
+[Full-Stack Isolated Testing](#full-stack-isolated-testing) for the details.
+
+If you only want backend + frontend in the foreground:
+
+```bash
 make dev
 ```
 
@@ -123,6 +135,8 @@ This single command:
 - auto-detects whether you're in a main checkout or a worktree
 - creates the appropriate env file (`.env` or `.env.worktree`) if it doesn't exist
 - checks that prerequisites (Node.js, pnpm, Go, Docker) are installed
+- refuses to start if the backend or frontend port is already served, instead of
+  dying on the bind while the old instance keeps answering
 - installs JavaScript dependencies
 - ensures the shared PostgreSQL container is running
 - creates the application database if it does not exist
@@ -263,12 +277,20 @@ make start
 make stop
 make check
 make dev
+make dev-bootstrap
+make dev-bootstrap-stop
 make test
 make migrate-up
 make migrate-down
 ```
 
-These generic targets require a valid env file in the current directory.
+These generic targets require a valid env file in the current directory
+(`make dev` and `make dev-bootstrap` create one if it is missing).
+
+`make stop` terminates only the processes **listening** on this checkout's
+backend and frontend ports, with `TERM` before `KILL`. It does not touch clients
+of those ports — notably the local daemon, which holds a long-lived connection
+to the backend and used to be killed along with it.
 
 ## How Database Creation Works
 
@@ -318,8 +340,13 @@ Notes:
 Run the local daemon:
 
 ```bash
-make daemon
+make daemon                                    # restart --profile local
+make daemon ARGS="start --profile my-profile"  # any daemon subcommand
 ```
+
+`make daemon` builds `server/bin/multica` first and runs the daemon from that
+binary — never through `go run`. See
+[Why the daemon must not run through `go run`](#why-the-daemon-must-not-run-through-go-run).
 
 The daemon authenticates using the CLI's stored token (`multica login`).
 It registers runtimes for all watched workspaces from the CLI config.
@@ -365,114 +392,71 @@ allocation.
 
 ### Start the Isolated Environment
 
-Run all steps from the worktree root (where the Makefile is).
-
-#### 1. Start backend, frontend, and database
+From the checkout root:
 
 ```bash
-make dev
+make dev-bootstrap
 ```
 
-Wait for the backend to be healthy:
+That is the whole flow. It runs, in order, the twelve steps that used to be
+manual — and where the order matters, it is the reason this is a script:
 
-```bash
-PORT=$(grep '^PORT=' .env.worktree 2>/dev/null || grep '^PORT=' .env | head -1 | cut -d= -f2)
-PORT=${PORT:-8080}
-SERVER="http://localhost:${PORT}"
+1. pins a durable `TMPDIR` (an agent's `TMPDIR` is deleted when its run ends)
+2. generates `.env` / `.env.worktree` with this directory's ports and database
+3. sets `MULTICA_DEV_VERIFICATION_CODE=888888` **before** the first launch, so
+   there is no start → edit → restart detour
+4. refuses to continue if either port is already served (see Troubleshooting)
+5. creates the database against `DATABASE_URL` rather than `docker exec`, which
+   is what makes it work when a native PostgreSQL owns 5432
+6. starts backend + frontend detached, in their own process group
+7. waits for `/health` and verifies the answering process is the one it started
+8. `send-code` once, `verify-code` once (retries lock the code out), then mints
+   a personal access token
+9. creates the workspace and marks onboarding complete
+10. writes `~/.multica/profiles/<profile>/config.json`
+11. builds `server/bin/multica` and starts the daemon from that binary
+12. prints the URL, the login, the profile, the logs, and the stop command
 
-for i in $(seq 1 30); do
-  curl -sf "$SERVER/health" > /dev/null 2>&1 && break
-  sleep 2
-done
-```
+Re-running it against an existing environment is safe: the env file, database,
+workspace, and profile are reused.
 
-#### 2. Create a test user and token (automated auth)
+Overrides, if you need them: `MULTICA_DEV_EMAIL`, `MULTICA_DEV_WORKSPACE_NAME`,
+`MULTICA_DEV_WORKSPACE_SLUG`, `MULTICA_DEV_TMPDIR`.
 
-For deterministic local automation, set `MULTICA_DEV_VERIFICATION_CODE=888888`
-in your env file before starting the backend:
+#### Why the daemon must not run through `go run`
 
-```bash
-curl -s -X POST "$SERVER/auth/send-code" \
-  -H "Content-Type: application/json" \
-  -d '{"email": "dev@localhost"}'
+`make dev-bootstrap` builds `server/bin/multica` and starts the daemon from it,
+and `make daemon` does the same. This is not a preference.
 
-JWT=$(curl -s -X POST "$SERVER/auth/verify-code" \
-  -H "Content-Type: application/json" \
-  -d '{"email": "dev@localhost", "code": "888888"}' | jq -r '.token')
+The daemon records its own executable path at startup and re-execs it as the
+execution-environment preparation helper for **every task**. Under `go run` that
+path is a temp build which the toolchain deletes as soon as the `go run` parent
+exits — so the daemon starts, registers, heartbeats, and then fails every task
+with `fork/exec /…/go-build…/exe/multica: no such file or directory`. `daemon
+start` now refuses such a binary up front rather than deferring the failure.
 
-PAT=$(curl -s -X POST "$SERVER/api/tokens" \
-  -H "Authorization: Bearer $JWT" \
-  -H "Content-Type: application/json" \
-  -d '{"name": "auto-dev", "expires_in_days": 365}' | jq -r '.token')
-```
-
-#### 3. Create a workspace
-
-```bash
-WS=$(curl -s -X POST "$SERVER/api/workspaces" \
-  -H "Authorization: Bearer $PAT" \
-  -H "Content-Type: application/json" \
-  -d '{"name": "Dev", "slug": "dev"}' | jq -r '.id')
-```
-
-#### 4. Compute profile name and write CLI config
-
-```bash
-# Compute profile (see Dynamic Profile Naming above)
-WORKTREE_DIR="$(basename "$PWD")"
-SLUG="$(printf '%s' "$WORKTREE_DIR" | tr '[:upper:]' '[:lower:]' | sed 's/[^a-z0-9]/_/g; s/__*/_/g; s/^_//; s/_$//')"
-HASH="$(printf '%s' "$PWD" | cksum | awk '{print $1}')"
-OFFSET=$((HASH % 1000))
-PROFILE="dev-${SLUG}-${OFFSET}"
-
-FRONTEND_PORT=$(grep '^FRONTEND_PORT=' .env.worktree 2>/dev/null || grep '^FRONTEND_PORT=' .env | head -1 | cut -d= -f2)
-FRONTEND_PORT=${FRONTEND_PORT:-3000}
-
-CONFIG_DIR="$HOME/.multica/profiles/$PROFILE"
-mkdir -p "$CONFIG_DIR"
-
-cat > "$CONFIG_DIR/config.json" << EOF
-{
-  "server_url": "$SERVER",
-  "app_url": "http://localhost:${FRONTEND_PORT}",
-  "token": "$PAT",
-  "workspace_id": "$WS",
-  "watched_workspaces": [{"id": "$WS", "name": "Dev"}]
-}
-EOF
-```
-
-#### 5. Start the daemon from source
-
-```bash
-make cli ARGS="daemon start --profile $PROFILE"
-```
-
-The daemon runs from the current worktree's Go source, connecting to the
-local backend. Agent-executed `multica` commands automatically use the same
-binary (the daemon prepends its own directory to `PATH`).
+One-shot CLI commands through `make cli` (`go run`) are unaffected — nothing
+records a path that has to outlive the process.
 
 ### Stop the Isolated Environment
 
 ```bash
-# Compute profile (same formula)
-PROFILE="dev-$(printf '%s' "$(basename "$PWD")" | tr '[:upper:]' '[:lower:]' | sed 's/[^a-z0-9]/_/g; s/__*/_/g; s/^_//; s/_$//')-$(( $(printf '%s' "$PWD" | cksum | awk '{print $1}') % 1000 ))"
+make dev-bootstrap-stop
+```
 
-# 1. Stop daemon
-make cli ARGS="daemon stop --profile $PROFILE"
+Stops the daemon, the backend, and the frontend. PostgreSQL, the database, the
+workspace, and the CLI profile are deliberately left in place — they are what
+makes the next `make dev-bootstrap` fast.
 
-# 2. Stop backend + frontend
-make stop            # main checkout
-make stop-worktree   # worktree checkout
+`make stop` / `make stop-worktree` stop only the backend and frontend listeners
+and deliberately leave a running daemon alive.
 
-# 3. (Optional) Stop shared PostgreSQL
-make db-down
+For a full reset:
 
-# 4. (Optional) Clean build artifacts
-make clean
-
-# 5. (Optional) Remove profile config
-rm -rf "$HOME/.multica/profiles/$PROFILE"
+```bash
+make db-reset                                  # drop + recreate this env's database
+make clean                                     # build artifacts
+rm -rf "$HOME/.multica/profiles/<profile>"     # CLI profile (printed by bootstrap)
 ```
 
 ### Desktop App Local Testing
@@ -606,6 +590,34 @@ make worktree-env
 make setup-worktree
 make start-worktree
 ```
+
+### Port Already in Use
+
+`make dev` / `make dev-bootstrap` refuse to start when the backend or frontend
+port already has a listener, and print which process owns it and when it
+started. Take the message literally — this is the failure that used to be
+invisible: the new process dies on the bind, the **old** one keeps serving, and
+`/health` answers 200 throughout, so a "restart" looks successful while the
+previous build handles every request.
+
+```bash
+make stop            # main checkout
+make stop-worktree   # worktree checkout
+```
+
+### Am I Talking to the Process I Just Started?
+
+`GET /health` identifies the process that answered:
+
+```console
+$ curl -s http://localhost:8080/health
+{"status":"ok","commit":"d09019cd9","started_at":"2026-08-07T08:30:04Z","pid":35518}
+```
+
+If `started_at` predates your restart, you are talking to a leftover instance —
+a 200 alone never proves otherwise. `commit` is populated by `make dev`,
+`make start`, and `make build`; it stays `unknown` for a bare
+`go run ./cmd/server`.
 
 ### App Stops but PostgreSQL Keeps Running
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help makehelp dev server daemon cli multica build test migrate-up migrate-down sqlc seed clean setup start stop check worktree-env setup-main start-main stop-main check-main setup-worktree start-worktree stop-worktree check-worktree db-up db-down db-reset selfhost selfhost-build selfhost-stop
+.PHONY: help makehelp dev dev-bootstrap dev-bootstrap-stop server daemon cli multica multica-bin build test migrate-up migrate-down sqlc seed clean setup start stop check worktree-env setup-main start-main stop-main check-main setup-worktree start-worktree stop-worktree check-worktree db-up db-down db-reset selfhost selfhost-build selfhost-stop
 
 MAIN_ENV_FILE ?= .env
 WORKTREE_ENV_FILE ?= .env.worktree
@@ -70,7 +70,7 @@ endef
 ##@ Help
 
 help: ## Show available make targets and common local workflows
-	@awk 'BEGIN {FS = ":.*## "; printf "\nUsage:\n  make \033[36m<target>\033[0m\n\nQuick start:\n  \033[36mmake dev\033[0m          Bootstrap the current checkout and start everything\n  \033[36mmake check\033[0m        Run the full local verification pipeline\n\nCheckout modes:\n  Main checkout uses \033[36m.env\033[0m\n  Worktrees use \033[36m.env.worktree\033[0m (generate with \033[36mmake worktree-env\033[0m)\n\n"} \
+	@awk 'BEGIN {FS = ":.*## "; printf "\nUsage:\n  make \033[36m<target>\033[0m\n\nQuick start:\n  \033[36mmake dev-bootstrap\033[0m  Clean checkout to a logged-in, daemon-attached environment\n  \033[36mmake dev\033[0m            Start backend + frontend only, in the foreground\n  \033[36mmake check\033[0m          Run the full local verification pipeline\n\nCheckout modes:\n  Main checkout uses \033[36m.env\033[0m\n  Worktrees use \033[36m.env.worktree\033[0m (generate with \033[36mmake worktree-env\033[0m)\n\n"} \
 		/^##@/ {printf "\n\033[1m%s\033[0m\n", substr($$0, 5); next} \
 		/^[a-zA-Z0-9_.-]+:.*## / {printf "  \033[36m%-18s\033[0m %s\n", $$1, $$2}' $(MAKEFILE_LIST)
 
@@ -167,15 +167,19 @@ start: ## Start backend and frontend for the current checkout and run migrations
 	cd server && go run ./cmd/migrate up
 	@echo "Starting backend and frontend..."
 	@trap 'kill 0' EXIT; \
-		(cd server && go run ./cmd/server) & \
+		(cd server && go run -ldflags "-X main.commit=$(COMMIT)" ./cmd/server) & \
 		pnpm dev:web & \
 		wait
 
+# Stops LISTENERS only, and asks politely first. A bare `lsof -ti:PORT` also
+# matches every client connected to the port — the local daemon holds a
+# long-lived connection to the backend — so `kill -9` on that list took the
+# daemon down with the backend, silently. See scripts/port-guard.sh.
 stop: ## Stop backend and frontend processes for the current checkout
 	$(REQUIRE_ENV)
 	@echo "Stopping services..."
-	@-lsof -ti:$(PORT) | xargs kill -9 2>/dev/null
-	@-lsof -ti:$(FRONTEND_PORT) | xargs kill -9 2>/dev/null
+	@bash scripts/port-guard.sh stop $(PORT) backend
+	@bash scripts/port-guard.sh stop $(FRONTEND_PORT) frontend
 	@case "$(DATABASE_URL)" in \
 		""|*@localhost:*|*@localhost/*|*@127.0.0.1:*|*@127.0.0.1/*|*@\[::1\]:*|*@\[::1\]/*) \
 			echo "✓ App processes stopped. Shared PostgreSQL is still running on localhost:$(POSTGRES_PORT)." ;; \
@@ -252,14 +256,32 @@ check-worktree: ## Run the full verification pipeline for this worktree
 dev: ## Bootstrap this checkout end-to-end: create env if needed, ensure DB, migrate, start services
 	@bash scripts/dev.sh
 
+dev-bootstrap: ## Take this checkout to a logged-in, daemon-attached environment in one command
+	@bash scripts/dev-bootstrap.sh
+
+dev-bootstrap-stop: ## Stop everything `make dev-bootstrap` started (backend, frontend, daemon)
+	@bash scripts/dev-bootstrap.sh --stop
+
 server: ## Run only the Go server for the current checkout
 	$(REQUIRE_ENV)
 	@bash scripts/ensure-postgres.sh "$(ENV_FILE)"
 	cd server && go run ./cmd/server
 
-daemon: ## Restart the local agent daemon using the CLI's stored auth/session
-	@$(MAKE) multica MULTICA_ARGS="daemon restart --profile local"
+# The daemon must NOT run through `go run`. It records its own executable path
+# at startup and re-execs it for every task, and `go run` deletes that temp
+# binary as soon as the launcher exits — so a go-run daemon starts fine and then
+# fails every task with "no such file or directory". `daemon start` now refuses
+# such a binary outright; this target builds a real one first.
+DAEMON_ARGS ?= $(if $(strip $(MULTICA_ARGS)),$(MULTICA_ARGS),restart --profile local)
 
+daemon: multica-bin ## Run a daemon command from a built binary (ARGS, default: restart --profile local)
+	./server/bin/multica daemon $(DAEMON_ARGS)
+
+multica-bin: ## Build only the multica CLI into server/bin/multica
+	cd server && go build -ldflags "-X main.version=$(VERSION) -X main.commit=$(COMMIT) -X main.date=$(DATE)" -o bin/multica ./cmd/multica
+
+# One-shot CLI commands are fine through `go run` (~2.4s warm). Long-lived
+# daemon processes are not — use `make daemon ARGS="..."` for those.
 cli: ## Run the multica CLI with ARGS or MULTICA_ARGS from source
 	@$(MAKE) multica MULTICA_ARGS="$(MULTICA_ARGS)"
 
@@ -270,9 +292,8 @@ VERSION ?= $(shell git describe --tags --match 'v[0-9]*' --always --dirty 2>/dev
 COMMIT  ?= $(shell git rev-parse --short HEAD 2>/dev/null || echo unknown)
 DATE    ?= $(shell date -u '+%Y-%m-%dT%H:%M:%SZ')
 
-build: ## Build the server, CLI, and migrate binaries into server/bin
+build: multica-bin ## Build the server, CLI, and migrate binaries into server/bin
 	cd server && go build -ldflags "-X main.version=$(VERSION) -X main.commit=$(COMMIT)" -o bin/server ./cmd/server
-	cd server && go build -ldflags "-X main.version=$(VERSION) -X main.commit=$(COMMIT) -X main.date=$(DATE)" -o bin/multica ./cmd/multica
 	cd server && go build -o bin/migrate ./cmd/migrate
 
 test: ## Run Go tests after ensuring the target DB exists and migrations are applied

--- a/README.md
+++ b/README.md
@@ -222,11 +222,16 @@ Contributors: start with the [Contributing Guide](CONTRIBUTING.md).
 **Prerequisites:** [Node.js](https://nodejs.org/) v20+, [pnpm](https://pnpm.io/) v10.28+, [Go](https://go.dev/) v1.26+, [Docker](https://www.docker.com/)
 
 ```bash
-make dev
+make dev-bootstrap
 ```
 
-`make dev` auto-detects your environment (main checkout or worktree), creates the env file,
-installs dependencies, sets up the database, runs migrations, and starts every service.
+`make dev-bootstrap` takes a clean checkout to a running environment you can log into: it
+auto-detects main checkout vs worktree, creates the env file, installs dependencies, sets up
+the database, runs migrations, starts every service, logs a dev user in, creates a workspace,
+and starts the local daemon — then prints the URL, the login, and the stop command
+(`make dev-bootstrap-stop`).
+
+Use `make dev` instead when you want only the backend and frontend, in the foreground.
 
 See [CONTRIBUTING.md](CONTRIBUTING.md) for the full workflow, worktree support, testing, and
 troubleshooting. The iOS client lives in [`apps/mobile/`](apps/mobile/) — its

--- a/README.zh.md
+++ b/README.zh.md
@@ -215,11 +215,15 @@ Multica 不自带模型。它驱动的是你本来就装好、登录好的那些
 **环境要求：**[Node.js](https://nodejs.org/) v20+、[pnpm](https://pnpm.io/) v10.28+、[Go](https://go.dev/) v1.26+、[Docker](https://www.docker.com/)
 
 ```bash
-make dev
+make dev-bootstrap
 ```
 
-`make dev` 会自己认出你在主 checkout 还是 worktree 里，然后创建 env 文件、装依赖、初始化数据库、
-跑迁移，最后把所有服务拉起来。
+`make dev-bootstrap` 一条命令把一个干净的 checkout 变成能直接登录进去用的环境：自己认出你在主
+checkout 还是 worktree 里，创建 env 文件、装依赖、初始化数据库、跑迁移、拉起所有服务，再帮你登录
+一个开发账号、建好 workspace、启动本地 daemon，最后把访问地址、登录方式和停止命令
+（`make dev-bootstrap-stop`）打印出来。
+
+只想在前台跑后端和前端的话，用 `make dev`。
 
 完整的开发流程、worktree 支持、测试和问题排查见 [CONTRIBUTING.md](CONTRIBUTING.md)。
 iOS 客户端在 [`apps/mobile/`](apps/mobile/)，怎么编译装到自己 iPhone 上见它的

--- a/scripts/check.sh
+++ b/scripts/check.sh
@@ -73,6 +73,8 @@ wait_for_port() {
 # Step 0: Ensure DB
 # --------------------------------------------------------------------------
 echo "==> Using env file: $ENV_FILE"
+echo "==> Verifying port guard (listener-only stop/preflight)..."
+bash scripts/port-guard.test.sh || { EXIT_CODE=1; exit 1; }
 echo "==> Checking PostgreSQL..."
 bash scripts/ensure-postgres.sh "$ENV_FILE"
 

--- a/scripts/dev-bootstrap.sh
+++ b/scripts/dev-bootstrap.sh
@@ -1,0 +1,389 @@
+#!/usr/bin/env bash
+# One command from a clean checkout to a logged-in, daemon-attached environment.
+#
+# Replaces the ~12-step manual sequence (generate env → create DB → start →
+# wait → set verification code → restart → send-code → verify-code → PAT →
+# workspace → CLI profile → daemon), where getting the order wrong means
+# backtracking and some steps are not retryable. Everything here is mechanical,
+# so it belongs in a script rather than in a human's or an agent's head.
+#
+#   make dev-bootstrap        # start
+#   make dev-bootstrap-stop   # stop what it started
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$REPO_ROOT"
+
+DEV_EMAIL="${MULTICA_DEV_EMAIL:-dev@localhost}"
+WORKSPACE_NAME="${MULTICA_DEV_WORKSPACE_NAME:-Dev}"
+WORKSPACE_SLUG="${MULTICA_DEV_WORKSPACE_SLUG:-dev}"
+
+# The agent runtime exports these pointing at PRODUCTION, and MULTICA_SERVER_URL
+# silently outranks server_url in a saved profile config. Every long-lived child
+# below is launched without them so a local daemon cannot end up authenticating
+# its local token against the production API (which fails as a bare 401 and
+# looks like a product bug).
+CLEAN_ENV=(env
+  -u MULTICA_SERVER_URL -u MULTICA_TOKEN -u MULTICA_WORKSPACE_ID
+  -u MULTICA_DAEMON_PORT -u MULTICA_AGENT_ID -u MULTICA_AGENT_NAME
+  -u MULTICA_TASK_ID -u MULTICA_TASK_SLOT)
+
+usage() {
+  cat <<'EOF'
+Usage: scripts/dev-bootstrap.sh [--stop]
+
+  (no flags)  Bring up backend, frontend, database, login, workspace, and daemon.
+  --stop      Stop the backend, frontend, and daemon this script started.
+
+The database, the CLI profile, and the created workspace are left alone by
+--stop; they are what make a re-run fast.
+EOF
+}
+
+MODE=start
+case "${1:-}" in
+  "") ;;
+  --stop) MODE=stop ;;
+  -h | --help)
+    usage
+    exit 0
+    ;;
+  *)
+    usage >&2
+    exit 2
+    ;;
+esac
+
+step() { printf '\n\033[1m==> %s\033[0m\n' "$1"; }
+info() { printf '    %s\n' "$1"; }
+die() {
+  printf '\n\033[31m✗ %s\033[0m\n' "$1" >&2
+  exit 1
+}
+
+# ---------- Durable TMPDIR ----------
+# An agent runs with TMPDIR=/tmp/multica-task-<id>, which is deleted when the run
+# ends. Anything the Go toolchain builds there vanishes with it, so an
+# environment handed over by an agent outlives its creator only if TMPDIR does.
+# Humans inherit a fine TMPDIR already; pointing both at the same durable path
+# means neither has to know this exists.
+DEV_TMPDIR="${MULTICA_DEV_TMPDIR:-$HOME/.multica/dev-tmp}"
+mkdir -p "$DEV_TMPDIR"
+if [ "${TMPDIR:-}" != "$DEV_TMPDIR" ]; then
+  PREVIOUS_TMPDIR="${TMPDIR:-<unset>}"
+  export TMPDIR="$DEV_TMPDIR"
+  export TMP="$DEV_TMPDIR" TEMP="$DEV_TMPDIR"
+fi
+
+# ---------- Identity: env file, profile, ports, logs ----------
+if [ -f .git ] && [ ! -d .git ]; then
+  ENV_FILE=".env.worktree"
+  CHECKOUT_KIND="worktree"
+  STOP_TARGET="make stop-worktree"
+else
+  ENV_FILE=".env"
+  CHECKOUT_KIND="main checkout"
+  STOP_TARGET="make stop"
+fi
+
+# Same derivation as scripts/init-worktree-env.sh, so the profile lines up with
+# the ports and database that file allocates for this directory.
+SLUG="$(basename "$PWD" | tr '[:upper:]' '[:lower:]' | sed 's/[^a-z0-9]/_/g; s/__*/_/g; s/^_//; s/_$//')"
+[ -n "$SLUG" ] || SLUG="multica"
+OFFSET=$(($(printf '%s' "$PWD" | cksum | awk '{print $1}') % 1000))
+PROFILE="dev-${SLUG}-${OFFSET}"
+
+PROFILE_DIR="$HOME/.multica/profiles/$PROFILE"
+DEV_LOG="$PROFILE_DIR/dev.log"
+DEV_PID_FILE="$PROFILE_DIR/dev.pid"
+DAEMON_LOG="$PROFILE_DIR/daemon.log"
+MULTICA_BIN="server/bin/multica"
+
+load_env() {
+  [ -f "$ENV_FILE" ] || die "Missing $ENV_FILE — run scripts/dev-bootstrap.sh without --stop first."
+  set -a
+  # shellcheck disable=SC1090
+  . "$ENV_FILE"
+  set +a
+  # shellcheck disable=SC1091
+  . scripts/local-env.sh
+  SERVER="http://localhost:${PORT}"
+  FRONTEND="http://localhost:${FRONTEND_PORT}"
+}
+
+# ---------- Stop mode ----------
+if [ "$MODE" = stop ]; then
+  load_env
+  step "Stopping the daemon [$PROFILE]"
+  if [ -x "$MULTICA_BIN" ]; then
+    "${CLEAN_ENV[@]}" "$MULTICA_BIN" daemon stop --profile "$PROFILE" 2>&1 | sed 's/^/    /' || true
+  else
+    info "$MULTICA_BIN not built; skipping (nothing this script started can be running)."
+  fi
+
+  step "Stopping backend and frontend"
+  if [ -f "$DEV_PID_FILE" ]; then
+    dev_pid="$(cat "$DEV_PID_FILE")"
+    if kill -0 "$dev_pid" 2> /dev/null; then
+      # Negative PID targets the whole process group the launcher created, so
+      # `make` → dev.sh → go/pnpm all go down together.
+      kill -TERM -"$dev_pid" 2> /dev/null || kill -TERM "$dev_pid" 2> /dev/null || true
+      sleep 1
+    fi
+    rm -f "$DEV_PID_FILE"
+  fi
+  bash scripts/port-guard.sh stop "$PORT" backend
+  bash scripts/port-guard.sh stop "$FRONTEND_PORT" frontend
+
+  printf '\n\033[32m✓ Stopped.\033[0m PostgreSQL, the database, and the CLI profile were left in place.\n'
+  info "Full reset: make db-reset && rm -rf $PROFILE_DIR"
+  exit 0
+fi
+
+# ---------- 1. Prerequisites ----------
+step "1/9  Prerequisites"
+missing=()
+for tool in node pnpm go docker curl; do
+  command -v "$tool" > /dev/null 2>&1 || missing+=("$tool")
+done
+[ ${#missing[@]} -eq 0 ] || die "Missing prerequisites: ${missing[*]} (need Node.js v20+, pnpm v10.28+, Go v1.26+, Docker, curl)"
+info "node, pnpm, go, docker, curl found."
+if [ -n "${PREVIOUS_TMPDIR:-}" ]; then
+  info "TMPDIR pinned to $TMPDIR (was $PREVIOUS_TMPDIR)."
+fi
+
+# JSON reads go through node rather than jq: node is already a hard requirement,
+# jq is not.
+json_field() {
+  node -e '
+    let payload;
+    try { payload = JSON.parse(process.argv[1]); } catch { process.exit(1); }
+    const value = process.argv[2].split(".").reduce((acc, key) => (acc == null ? acc : acc[key]), payload);
+    if (value === undefined || value === null || value === "") process.exit(1);
+    process.stdout.write(String(value));
+  ' "$1" "$2" 2> /dev/null
+}
+
+# ---------- 2. Environment file ----------
+step "2/9  Environment file"
+if [ ! -f "$ENV_FILE" ]; then
+  if [ "$CHECKOUT_KIND" = worktree ]; then
+    info "Worktree detected — generating $ENV_FILE with unique ports and database."
+    bash scripts/init-worktree-env.sh "$ENV_FILE" > /dev/null
+  else
+    info "Creating $ENV_FILE from .env.example."
+    cp .env.example "$ENV_FILE"
+  fi
+fi
+
+# The fixed verification code has to be in place BEFORE the backend starts:
+# the handler reads the env var at request time, but the process only loads the
+# file once. Setting it here is what removes the "start, edit, restart" detour
+# from the manual flow.
+if ! grep -qE '^MULTICA_DEV_VERIFICATION_CODE=[0-9]{6}$' "$ENV_FILE"; then
+  if grep -q '^MULTICA_DEV_VERIFICATION_CODE=' "$ENV_FILE"; then
+    tmp_env="$(mktemp)"
+    sed 's/^MULTICA_DEV_VERIFICATION_CODE=.*/MULTICA_DEV_VERIFICATION_CODE=888888/' "$ENV_FILE" > "$tmp_env"
+    mv "$tmp_env" "$ENV_FILE"
+  else
+    printf '\nMULTICA_DEV_VERIFICATION_CODE=888888\n' >> "$ENV_FILE"
+  fi
+  info "Set MULTICA_DEV_VERIFICATION_CODE=888888 (ignored when APP_ENV=production)."
+fi
+
+load_env
+DEV_CODE="${MULTICA_DEV_VERIFICATION_CODE:-888888}"
+info "$ENV_FILE  ·  backend :$PORT  ·  frontend :$FRONTEND_PORT  ·  db ${POSTGRES_DB}"
+
+# ---------- 3. Ports ----------
+step "3/9  Ports"
+bash scripts/port-guard.sh require-free "$PORT" backend \
+  || die "Backend port $PORT is busy. Run 'make dev-bootstrap-stop' first."
+bash scripts/port-guard.sh require-free "$FRONTEND_PORT" frontend \
+  || die "Frontend port $FRONTEND_PORT is busy. Run 'make dev-bootstrap-stop' first."
+info "Ports $PORT and $FRONTEND_PORT are free."
+
+# ---------- 4. Database ----------
+step "4/9  Database"
+ADMIN_URL=""
+if command -v psql > /dev/null 2>&1 && [ -n "${DATABASE_URL:-}" ]; then
+  ADMIN_URL="$(node -e '
+    const url = new URL(process.argv[1]);
+    url.pathname = "/postgres";
+    process.stdout.write(url.toString());
+  ' "$DATABASE_URL")"
+fi
+
+# Create the database against DATABASE_URL, not `docker exec`. When a native
+# PostgreSQL already owns 5432 the container never binds the host port, so a
+# docker-exec create lands in a server the backend never talks to and migrations
+# then die with `database "..." does not exist`. Talking to whoever answers on
+# the port is correct either way.
+if [ -n "$ADMIN_URL" ] && psql "$ADMIN_URL" -tAc 'SELECT 1' > /dev/null 2>&1; then
+  info "PostgreSQL already answering on ${POSTGRES_PORT:-5432}; using it directly."
+else
+  bash scripts/ensure-postgres.sh "$ENV_FILE" | sed 's/^/    /'
+fi
+if [ -n "$ADMIN_URL" ] && psql "$ADMIN_URL" -tAc 'SELECT 1' > /dev/null 2>&1; then
+  if ! psql "$ADMIN_URL" -tAc "SELECT 1 FROM pg_database WHERE datname='${POSTGRES_DB}'" | grep -q 1; then
+    psql "$ADMIN_URL" -c "CREATE DATABASE \"${POSTGRES_DB}\"" > /dev/null
+    info "Created database ${POSTGRES_DB}."
+  fi
+fi
+info "Database ${POSTGRES_DB} ready."
+
+# ---------- 5. Backend + frontend ----------
+step "5/9  Backend and frontend"
+mkdir -p "$PROFILE_DIR"
+LAUNCHED_AT="$(node -e 'process.stdout.write(String(Math.floor(Date.now() / 1000)))')"
+: > "$DEV_LOG"
+
+# `set -m` puts the launcher in its own process group, so --stop can take the
+# whole tree down with one signal and dev.sh's own `trap 'kill 0'` can never
+# reach back into the caller's shell.
+(
+  set -m
+  nohup "${CLEAN_ENV[@]}" make dev > "$DEV_LOG" 2>&1 < /dev/null &
+  printf '%s\n' "$!" > "$DEV_PID_FILE"
+)
+DEV_PID="$(cat "$DEV_PID_FILE")"
+info "Launched (pid $DEV_PID) — installing deps and running migrations, this is the slow part."
+info "Log: $DEV_LOG"
+
+wait_for_backend() {
+  local waited=0
+  while [ "$waited" -lt 300 ]; do
+    if curl -sf "$SERVER/health" > /dev/null 2>&1; then
+      return 0
+    fi
+    if ! kill -0 "$DEV_PID" 2> /dev/null; then
+      return 1
+    fi
+    sleep 2
+    waited=$((waited + 2))
+  done
+  return 1
+}
+
+if ! wait_for_backend; then
+  tail -30 "$DEV_LOG" | sed 's/^/    /' >&2 || true
+  die "Backend never became healthy. Full log: $DEV_LOG"
+fi
+
+# Prove the answering process is the one we just started. This is what /health's
+# process identity is for: without it, a stale instance on the same port answers
+# 200 and the whole bootstrap silently configures the wrong server.
+HEALTH="$(curl -sf "$SERVER/health")"
+HEALTH_STARTED_AT="$(json_field "$HEALTH" started_at || true)"
+if [ -n "$HEALTH_STARTED_AT" ]; then
+  health_epoch="$(node -e 'process.stdout.write(String(Math.floor(Date.parse(process.argv[1]) / 1000)))' "$HEALTH_STARTED_AT")"
+  if [ "$health_epoch" -lt $((LAUNCHED_AT - 5)) ]; then
+    die "Something else is serving :$PORT — it started at $HEALTH_STARTED_AT, before this run. Stop it and retry."
+  fi
+fi
+info "Backend healthy at $SERVER (started $HEALTH_STARTED_AT)."
+
+# ---------- 6. Login ----------
+# send-code once, verify-code once: repeated verify attempts lock the code out
+# and start returning 400 even when it is correct, so a retry loop here is
+# self-defeating.
+step "6/9  Login as $DEV_EMAIL"
+curl -sf -X POST "$SERVER/auth/send-code" \
+  -H 'Content-Type: application/json' \
+  -d "{\"email\":\"${DEV_EMAIL}\"}" > /dev/null \
+  || die "send-code failed. Is MULTICA_DEV_VERIFICATION_CODE set and APP_ENV non-production?"
+
+VERIFY_RESPONSE="$(curl -sS -X POST "$SERVER/auth/verify-code" \
+  -H 'Content-Type: application/json' \
+  -d "{\"email\":\"${DEV_EMAIL}\",\"code\":\"${DEV_CODE}\"}")"
+JWT="$(json_field "$VERIFY_RESPONSE" token || true)"
+[ -n "$JWT" ] || die "verify-code failed: $VERIFY_RESPONSE
+Do not retry immediately — repeated attempts lock the code. Wait ~40s and re-run."
+
+PAT_RESPONSE="$(curl -sS -X POST "$SERVER/api/tokens" \
+  -H "Authorization: Bearer $JWT" \
+  -H 'Content-Type: application/json' \
+  -d '{"name":"dev-bootstrap","expires_in_days":365}')"
+PAT="$(json_field "$PAT_RESPONSE" token || true)"
+[ -n "$PAT" ] || die "Personal access token creation failed: $PAT_RESPONSE"
+info "Logged in and minted a personal access token."
+
+# ---------- 7. Workspace ----------
+step "7/9  Workspace"
+WS_RESPONSE="$(curl -sS -X POST "$SERVER/api/workspaces" \
+  -H "Authorization: Bearer $PAT" \
+  -H 'Content-Type: application/json' \
+  -d "{\"name\":\"${WORKSPACE_NAME}\",\"slug\":\"${WORKSPACE_SLUG}\"}")"
+WS="$(json_field "$WS_RESPONSE" id || true)"
+if [ -z "$WS" ]; then
+  # Re-run against an existing environment: the slug is already taken by the
+  # workspace this script created earlier.
+  WS="$(node -e '
+    let list;
+    try { list = JSON.parse(process.argv[1]); } catch { process.exit(1); }
+    const match = (Array.isArray(list) ? list : []).find(ws => ws.slug === process.argv[2]);
+    if (!match) process.exit(1);
+    process.stdout.write(match.id);
+  ' "$(curl -sS "$SERVER/api/workspaces" -H "Authorization: Bearer $PAT")" "$WORKSPACE_SLUG" 2> /dev/null || true)"
+fi
+[ -n "$WS" ] || die "Workspace creation failed: $WS_RESPONSE"
+
+# A fresh user has onboarded_at = NULL, so a browser login is bounced to
+# /onboarding. Flipping it here means the printed URL actually lands in the app.
+curl -sS -X POST "$SERVER/api/me/onboarding/complete" \
+  -H "Authorization: Bearer $PAT" -H "X-Workspace-ID: $WS" \
+  -H 'Content-Type: application/json' -d '{"exit":"existing"}' > /dev/null || true
+
+info "Workspace '${WORKSPACE_NAME}' (${WS})."
+
+# ---------- 8. CLI profile ----------
+step "8/9  CLI profile [$PROFILE]"
+mkdir -p "$PROFILE_DIR"
+cat > "$PROFILE_DIR/config.json" << EOF
+{
+  "server_url": "$SERVER",
+  "app_url": "$FRONTEND",
+  "token": "$PAT",
+  "workspace_id": "$WS"
+}
+EOF
+chmod 600 "$PROFILE_DIR/config.json"
+info "Wrote $PROFILE_DIR/config.json"
+
+# ---------- 9. Daemon ----------
+# Built, never `go run`: the daemon records its own executable path and re-execs
+# it for every task, and `go run` deletes that binary when the launcher exits.
+step "9/9  Daemon"
+info "Building $MULTICA_BIN (a go run daemon would fail every task later)."
+make multica-bin > /dev/null
+# A non-zero exit here is not automatically fatal (an already-running daemon
+# reports "already running"); the status probe below is the real gate.
+"${CLEAN_ENV[@]}" "$MULTICA_BIN" daemon start --profile "$PROFILE" 2>&1 | sed 's/^/    /' || true
+
+RUNTIME_STATUS="$("${CLEAN_ENV[@]}" "$MULTICA_BIN" daemon status --profile "$PROFILE" --output json 2>/dev/null || true)"
+DAEMON_STATE="$(json_field "$RUNTIME_STATUS" status || echo unknown)"
+if [ "$DAEMON_STATE" != running ]; then
+  die "Daemon is '$DAEMON_STATE' after start. Log: $DAEMON_LOG"
+fi
+
+# ---------- Summary ----------
+# There is no workspace index route, so point at a real surface: a bare
+# /<slug> 404s.
+APP_URL="$FRONTEND/$WORKSPACE_SLUG/issues"
+
+cat << EOF
+
+$(printf '\033[32m✓ Environment ready.\033[0m')
+
+  Open        $APP_URL
+  Sign in     ${DEV_EMAIL}  ·  code ${DEV_CODE}
+  Backend     $SERVER   (GET /health reports pid + started_at + commit)
+
+  Profile     $PROFILE
+  CLI         $MULTICA_BIN --profile $PROFILE <command>
+  Logs        $DEV_LOG
+              $DAEMON_LOG
+
+  Stop        make dev-bootstrap-stop
+              ($STOP_TARGET stops only backend + frontend, leaving the daemon up)
+EOF

--- a/scripts/dev.sh
+++ b/scripts/dev.sh
@@ -43,6 +43,14 @@ set +a
 # shellcheck disable=SC1091
 . scripts/local-env.sh
 
+# ---------- Port preflight ----------
+# Without this, starting over a running instance fails silently in the worst
+# possible way: the new processes die on the bind, the old ones keep serving,
+# and /health answers 200 the whole time — so the "restart" looks successful
+# while the previous build is still the one handling every request.
+bash scripts/port-guard.sh require-free "${PORT:-8080}" backend
+bash scripts/port-guard.sh require-free "${FRONTEND_PORT:-3000}" frontend
+
 # ---------- Install dependencies ----------
 if [ ! -d node_modules ]; then
   echo "==> Installing dependencies..."
@@ -63,6 +71,8 @@ echo "  Frontend: http://localhost:${FRONTEND_PORT:-3000}"
 echo ""
 
 trap 'kill 0' EXIT
-(cd server && go run ./cmd/server) &
+# Stamp the commit so /health can report which build is answering.
+COMMIT="$(git rev-parse --short HEAD 2> /dev/null || echo unknown)"
+(cd server && go run -ldflags "-X main.commit=${COMMIT}" ./cmd/server) &
 pnpm dev:web &
 wait

--- a/scripts/port-guard.sh
+++ b/scripts/port-guard.sh
@@ -1,0 +1,115 @@
+#!/usr/bin/env bash
+# Listener-only port helpers shared by `make stop`, scripts/dev.sh, and
+# scripts/dev-bootstrap.sh.
+#
+# The rule every command here enforces: only a process LISTENING on the port is
+# ours to inspect or stop. Bare `lsof -ti:PORT` also matches every client
+# connected to it — including the local daemon, which holds a long-lived
+# connection to the backend — so stopping the backend that way silently kills
+# the daemon too (its log just stops mid-heartbeat). `-sTCP:LISTEN` is the whole
+# fix, and it is why these calls live in one place instead of being inlined.
+#
+# Usage:
+#   port-guard.sh listeners <port>                 # print listening PIDs, one per line
+#   port-guard.sh require-free <port> [label]      # exit 1 if the port is taken
+#   port-guard.sh stop <port> [label]              # TERM, then KILL what is left
+set -euo pipefail
+
+# Prints the PIDs listening on a port, nothing else. Empty output (exit 0) means
+# the port is free, or that lsof is unavailable to tell us otherwise.
+port_listeners() {
+  local port=$1
+  command -v lsof > /dev/null 2>&1 || return 0
+  lsof -ti:"$port" -sTCP:LISTEN 2>/dev/null || true
+}
+
+# Describes who owns a port, for error messages: "1234 (node, started Thu ...)".
+port_owner_description() {
+  local pid=$1 proc_name started_at
+  proc_name="$(ps -o comm= -p "$pid" 2>/dev/null | tr -d ' ' || true)"
+  started_at="$(ps -o lstart= -p "$pid" 2>/dev/null | sed 's/^ *//' || true)"
+  if [ -n "$proc_name" ] && [ -n "$started_at" ]; then
+    echo "$pid ($proc_name, started $started_at)"
+  elif [ -n "$proc_name" ]; then
+    echo "$pid ($proc_name)"
+  else
+    echo "$pid"
+  fi
+}
+
+cmd_listeners() {
+  port_listeners "$1"
+}
+
+# Fails loudly when a port is already served. Without this a second `make dev`
+# dies on the bind while the OLD process keeps answering /health with 200, so
+# the restart looks healthy and you keep testing the pre-fix binary.
+cmd_require_free() {
+  local port=$1 label=${2:-service} pids pid
+  pids="$(port_listeners "$port")"
+  [ -n "$pids" ] || return 0
+
+  echo "✗ Port $port ($label) is already in use:" >&2
+  while IFS= read -r pid; do
+    [ -n "$pid" ] || continue
+    echo "    $(port_owner_description "$pid")" >&2
+  done <<< "$pids"
+  echo "" >&2
+  echo "  A second instance cannot bind it, and the process above would keep serving" >&2
+  echo "  requests — including a healthy /health — so the restart would look fine while" >&2
+  echo "  the old build stayed live. Stop it first:" >&2
+  echo "    make stop            # main checkout" >&2
+  echo "    make stop-worktree   # worktree checkout" >&2
+  return 1
+}
+
+# Stops only the listeners: TERM first so the process can shut down cleanly,
+# KILL only for whatever is still alive after the grace period.
+cmd_stop() {
+  local port=$1 label=${2:-service} pids pid
+  pids="$(port_listeners "$port")"
+  if [ -z "$pids" ]; then
+    echo "    $label (:$port) was not running."
+    return 0
+  fi
+
+  while IFS= read -r pid; do
+    [ -n "$pid" ] || continue
+    kill -TERM "$pid" 2> /dev/null || true
+  done <<< "$pids"
+
+  local waited=0
+  while [ "$waited" -lt 10 ]; do
+    [ -n "$(port_listeners "$port")" ] || break
+    sleep 0.5
+    waited=$((waited + 1))
+  done
+
+  local remaining
+  remaining="$(port_listeners "$port")"
+  if [ -n "$remaining" ]; then
+    while IFS= read -r pid; do
+      [ -n "$pid" ] || continue
+      kill -9 "$pid" 2> /dev/null || true
+    done <<< "$remaining"
+    echo "    $label (:$port) did not exit on TERM; killed."
+  else
+    echo "    $label (:$port) stopped."
+  fi
+}
+
+# Warn once rather than per lookup: without lsof every command below degrades to
+# "the port looks free", and a silent no-op stop is worse than a loud one.
+if ! command -v lsof > /dev/null 2>&1 && [ "${1:-}" != listeners ]; then
+  echo "note: lsof not found — cannot inspect port ownership; skipping this check." >&2
+fi
+
+case "${1:-}" in
+  listeners) shift; cmd_listeners "$@" ;;
+  require-free) shift; cmd_require_free "$@" ;;
+  stop) shift; cmd_stop "$@" ;;
+  *)
+    echo "Usage: port-guard.sh {listeners|require-free|stop} <port> [label]" >&2
+    exit 2
+    ;;
+esac

--- a/scripts/port-guard.test.sh
+++ b/scripts/port-guard.test.sh
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+# Verifies scripts/port-guard.sh against a real listener and a real connected
+# client. The client half is the regression this file exists for: `make stop`
+# used to run bare `lsof -ti:PORT`, which matches clients as well as the
+# listener, so stopping the backend also killed the daemon connected to it.
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT_DIR"
+
+GUARD="scripts/port-guard.sh"
+
+if ! command -v lsof > /dev/null 2>&1; then
+  echo "lsof unavailable — skipping port-guard tests."
+  exit 0
+fi
+
+PORT="${PORT_GUARD_TEST_PORT:-19741}"
+LISTENER_PID=""
+CLIENT_PID=""
+
+cleanup() {
+  [ -n "$CLIENT_PID" ] && kill -9 "$CLIENT_PID" 2> /dev/null || true
+  [ -n "$LISTENER_PID" ] && kill -9 "$LISTENER_PID" 2> /dev/null || true
+}
+trap cleanup EXIT
+
+fail() {
+  echo "✗ $1" >&2
+  exit 1
+}
+
+# node is already a hard prerequisite of the local dev flow (scripts/dev.sh), so
+# using it for the fixtures keeps this test dependency-free.
+node -e '
+  const net = require("net");
+  net.createServer(s => s.on("error", () => {})).listen(Number(process.argv[1]), "127.0.0.1");
+  setTimeout(() => process.exit(0), 60000);
+' "$PORT" &
+LISTENER_PID=$!
+# Drop the job from the table so bash does not print "Terminated" noise when the
+# fixture is stopped as part of the assertions below.
+disown "$LISTENER_PID" 2> /dev/null || true
+
+for _ in $(seq 1 40); do
+  [ -n "$(bash "$GUARD" listeners "$PORT")" ] && break
+  sleep 0.25
+done
+
+listeners="$(bash "$GUARD" listeners "$PORT")"
+[ -n "$listeners" ] || fail "listener on :$PORT never came up"
+
+# A client connected to the same port. Bare `lsof -ti:PORT` reports this PID
+# too; `listeners` must not.
+node -e '
+  const net = require("net");
+  const socket = net.connect(Number(process.argv[1]), "127.0.0.1");
+  socket.on("error", () => {});
+  setTimeout(() => process.exit(0), 60000);
+' "$PORT" &
+CLIENT_PID=$!
+disown "$CLIENT_PID" 2> /dev/null || true
+sleep 1
+
+if ! kill -0 "$CLIENT_PID" 2> /dev/null; then
+  fail "client fixture did not stay connected"
+fi
+
+# Prove the fixture reproduces the original hazard before asserting the fix:
+# the unfiltered lookup `make stop` used to run does match the client.
+if ! grep -Fxq "$CLIENT_PID" <<< "$(lsof -ti:"$PORT" 2>/dev/null || true)"; then
+  fail "unfiltered lsof did not see the client — fixture cannot prove the filter matters"
+fi
+
+if grep -Fxq "$CLIENT_PID" <<< "$(bash "$GUARD" listeners "$PORT")"; then
+  fail "listeners reported the connected client (pid $CLIENT_PID) — -sTCP:LISTEN is missing"
+fi
+
+if bash "$GUARD" require-free "$PORT" backend > /dev/null 2>&1; then
+  fail "require-free succeeded on an occupied port"
+fi
+
+require_free_output="$(bash "$GUARD" require-free "$PORT" backend 2>&1 || true)"
+grep -q "make stop" <<< "$require_free_output" \
+  || fail "require-free must tell the caller how to stop the running instance"
+
+bash "$GUARD" stop "$PORT" backend > /dev/null
+
+if kill -0 "$LISTENER_PID" 2> /dev/null; then
+  fail "stop left the listener (pid $LISTENER_PID) running"
+fi
+if ! kill -0 "$CLIENT_PID" 2> /dev/null; then
+  fail "stop killed the connected client (pid $CLIENT_PID) — this is the daemon-kill bug"
+fi
+
+bash "$GUARD" require-free "$PORT" backend > /dev/null \
+  || fail "require-free failed on a port that is now free"
+
+bash "$GUARD" stop "$PORT" backend | grep -q "was not running" \
+  || fail "stop on a free port should report that nothing was running"
+
+echo "✓ port-guard.sh: listener-only detection, stop, and preflight all behave."

--- a/server/cmd/multica/cmd_daemon.go
+++ b/server/cmd/multica/cmd_daemon.go
@@ -308,6 +308,31 @@ func requireDaemonAuth(profile string) error {
 	return nil
 }
 
+// requireDurableDaemonBinary rejects a daemon binary that the Go toolchain will
+// delete out from under the running daemon.
+//
+// The daemon records its own executable path at startup and re-execs it as the
+// execution-environment preparation helper for every task (see
+// daemon.defaultExecutionEnvironmentCommand). Launched through `go run`, that
+// path is a temp build that disappears as soon as the `go run` parent exits: the
+// daemon starts, registers, heartbeats — and then fails every task with
+// "fork/exec …/go-build…/exe/multica: no such file or directory", pointing
+// nowhere near the cause. Refuse at start, where the message can still explain
+// itself.
+func requireDurableDaemonBinary(exePath string) error {
+	if !selfexec.IsEphemeralBuild(exePath) {
+		return nil
+	}
+	return fmt.Errorf(
+		"daemon binary %s is a temporary `go run` build; Go deletes it when the launcher exits, "+
+			"so the daemon would start and then fail every task with \"no such file or directory\".\n"+
+			"Run the daemon from a built binary instead:\n"+
+			"  make daemon ARGS=\"start --profile <profile>\"   # builds server/bin/multica, then runs it\n"+
+			"  make multica-bin && server/bin/multica daemon start --profile <profile>",
+		exePath,
+	)
+}
+
 func runDaemonStart(cmd *cobra.Command, _ []string) error {
 	foreground, _ := cmd.Flags().GetBool("foreground")
 	if foreground {
@@ -341,6 +366,9 @@ func runDaemonBackground(cmd *cobra.Command) error {
 	exePath, err := daemonExecutable()
 	if err != nil {
 		return fmt.Errorf("resolve executable path: %w", err)
+	}
+	if err := requireDurableDaemonBinary(exePath); err != nil {
+		return err
 	}
 
 	// Build child args: daemon start --foreground + forwarded flags.
@@ -666,6 +694,16 @@ func buildDaemonStartArgs(cmd *cobra.Command) []string {
 
 func runDaemonForeground(cmd *cobra.Command) error {
 	util.EnsureHiddenConsole()
+
+	// Also checked before spawning a background child, but this process is the
+	// one that records the helper path, so it verifies its own binary too —
+	// `daemon start --foreground` and any launcher that skips the parent path
+	// get the same fail-at-start guarantee.
+	if exePath, err := daemonExecutable(); err == nil {
+		if err := requireDurableDaemonBinary(exePath); err != nil {
+			return err
+		}
+	}
 
 	profile := resolveProfile(cmd)
 

--- a/server/cmd/multica/cmd_daemon_test.go
+++ b/server/cmd/multica/cmd_daemon_test.go
@@ -417,6 +417,46 @@ func TestDaemonStartBackgroundReportsEarlyChildExit(t *testing.T) {
 	}
 }
 
+// TestDaemonStartRejectsEphemeralGoRunBinary pins the fail-at-start contract
+// for `make cli ARGS="daemon start"`-style launches, where the daemon binary is
+// a `go run` temp build. The daemon would come up fine and then fail every task
+// with "fork/exec …/go-build…/exe/multica: no such file or directory" once Go
+// deleted the build directory, so start must refuse while it can still say why.
+func TestDaemonStartRejectsEphemeralGoRunBinary(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	goRunBin := filepath.Join(t.TempDir(), "go-build2260624469", "b001", "exe", "multica")
+	orig := daemonExecutable
+	daemonExecutable = func() (string, error) { return goRunBin, nil }
+	t.Cleanup(func() { daemonExecutable = orig })
+
+	const profile = "go-run-test"
+	if err := cli.SaveCLIConfigForProfile(cli.CLIConfig{Token: "mul_fake"}, profile); err != nil {
+		t.Fatalf("SaveCLIConfigForProfile: %v", err)
+	}
+
+	cmd := &cobra.Command{Use: "start"}
+	cmd.Flags().Bool("foreground", false, "")
+	cmd.Flags().String("profile", "", "")
+	cmd.Flags().String("server-url", "", "")
+	if err := cmd.Flags().Set("profile", profile); err != nil {
+		t.Fatalf("set profile flag: %v", err)
+	}
+
+	err := runDaemonStart(cmd, nil)
+	if err == nil {
+		t.Fatal("runDaemonStart() = nil, want refusal for a `go run` build")
+	}
+	for _, want := range []string{"go run", goRunBin, "make daemon"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Fatalf("error = %q, want it to mention %q", err, want)
+		}
+	}
+	if _, statErr := os.Stat(daemonPIDPathForProfile(profile)); statErr == nil {
+		t.Fatal("start wrote a PID file; it must refuse before spawning anything")
+	}
+}
+
 // TestDaemonRestartUnauthenticatedFailsBeforeStopping pins the ordering that
 // makes `daemon restart` safe when the user is not logged in: the auth check
 // must run BEFORE the stop phase. Otherwise restart kills the running daemon

--- a/server/cmd/server/health.go
+++ b/server/cmd/server/health.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"net/http"
+	"os"
 	"strconv"
 	"sync"
 	"sync/atomic"
@@ -36,6 +37,7 @@ type serverHealth struct {
 	cacheTTL           time.Duration
 	refreshMu          sync.Mutex
 	cache              atomic.Pointer[cachedReadiness]
+	identity           liveResponse
 }
 
 type cachedReadiness struct {
@@ -44,8 +46,17 @@ type cachedReadiness struct {
 	expiresAt  time.Time
 }
 
+// liveResponse identifies the process that answered, not just that something
+// did. Without this, restarting over a still-running instance is invisible: the
+// new process dies on the bind, the OLD one keeps serving, and /health returns
+// 200 throughout — so a caller can "verify" a restart and then keep testing the
+// previous build. StartedAt and PID make that provable; Commit names the build
+// (it stays "unknown" unless the binary was linked with -X main.commit).
 type liveResponse struct {
-	Status string `json:"status"`
+	Status    string `json:"status"`
+	Commit    string `json:"commit,omitempty"`
+	StartedAt string `json:"started_at,omitempty"`
+	PID       int    `json:"pid,omitempty"`
 }
 
 type readinessResponse struct {
@@ -58,6 +69,10 @@ type readinessChecks struct {
 	Migrations string `json:"migrations"`
 }
 
+// processStartedAt is fixed at package init, so /health reports when THIS
+// process came up regardless of how long wiring took.
+var processStartedAt = time.Now()
+
 func newServerHealth(pool *pgxpool.Pool) *serverHealth {
 	requiredMigrations, err := migrations.AllVersions()
 	return &serverHealth{
@@ -65,11 +80,18 @@ func newServerHealth(pool *pgxpool.Pool) *serverHealth {
 		requiredMigrations: requiredMigrations,
 		initErr:            err,
 		cacheTTL:           readinessCacheTTL,
+		// Rendered once: /health is on the hot path of every probe.
+		identity: liveResponse{
+			Status:    "ok",
+			Commit:    commit,
+			StartedAt: processStartedAt.UTC().Format(time.RFC3339),
+			PID:       os.Getpid(),
+		},
 	}
 }
 
 func (h *serverHealth) liveHandler(w http.ResponseWriter, _ *http.Request) {
-	writeJSON(w, http.StatusOK, liveResponse{Status: "ok"})
+	writeJSON(w, http.StatusOK, h.identity)
 }
 
 func (h *serverHealth) readyHandler(w http.ResponseWriter, r *http.Request) {

--- a/server/cmd/server/integration_test.go
+++ b/server/cmd/server/integration_test.go
@@ -215,10 +215,20 @@ func TestHealth(t *testing.T) {
 		t.Fatalf("expected 200, got %d", resp.StatusCode)
 	}
 
-	var result map[string]string
-	json.NewDecoder(resp.Body).Decode(&result)
+	var result map[string]any
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		t.Fatalf("decode health response: %v", err)
+	}
 	if result["status"] != "ok" {
-		t.Fatalf("expected status ok, got %s", result["status"])
+		t.Fatalf("expected status ok, got %v", result["status"])
+	}
+	// Process identity: a caller must be able to tell WHICH process answered,
+	// otherwise a failed restart over a still-running instance reads as healthy.
+	if startedAt, _ := result["started_at"].(string); startedAt == "" {
+		t.Fatalf("expected started_at in health response, got %v", result)
+	}
+	if pid, _ := result["pid"].(float64); int(pid) != os.Getpid() {
+		t.Fatalf("expected pid %d in health response, got %v", os.Getpid(), result["pid"])
 	}
 }
 

--- a/server/internal/selfexec/selfexec.go
+++ b/server/internal/selfexec/selfexec.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 )
 
 // Resolve prefers the OS-reported executable path. Some launch environments
@@ -15,6 +16,42 @@ import (
 // current directory.
 func Resolve() (string, error) {
 	return resolveWith(os.Executable, os.Args)
+}
+
+// IsEphemeralBuild reports whether path sits under a `go run` build directory
+// (`<tmp>/go-build<random>/b001/exe/<name>`), which the Go toolchain deletes
+// when the launching `go run` exits. Binaries produced by `go build -o` or
+// installed by a package manager never do. Callers that record their own
+// executable path for a later re-exec need this: the recorded path resolves
+// cleanly and stops existing minutes later.
+//
+// Resolve cannot catch it on its own — while `go run` is alive, os.Executable
+// succeeds and the file is genuinely on disk, so the argv[0] fallback (which
+// only triggers on an os.Executable error) never runs.
+//
+// Both separators are split on regardless of GOOS, so a Windows path stays
+// classifiable when it is inspected from a test or a log on another platform.
+func IsEphemeralBuild(path string) bool {
+	segments := strings.FieldsFunc(path, func(r rune) bool { return r == '/' || r == '\\' })
+	for _, segment := range segments {
+		if isGoBuildTempDir(segment) {
+			return true
+		}
+	}
+	return false
+}
+
+// isGoBuildTempDir matches the directory name `go run` creates via
+// os.MkdirTemp("", "go-build"): the literal prefix plus the random digits
+// MkdirTemp appends. The bare name `go-build` is the persistent build cache
+// (GOCACHE) and is deliberately not matched.
+func isGoBuildTempDir(segment string) bool {
+	const prefix = "go-build"
+	digits, ok := strings.CutPrefix(segment, prefix)
+	if !ok || digits == "" {
+		return false
+	}
+	return strings.IndexFunc(digits, func(r rune) bool { return r < '0' || r > '9' }) < 0
 }
 
 func resolveWith(osExecutable func() (string, error), args []string) (string, error) {

--- a/server/internal/selfexec/selfexec_test.go
+++ b/server/internal/selfexec/selfexec_test.go
@@ -115,6 +115,30 @@ func TestResolveWithRejectsInvalidFallback(t *testing.T) {
 	}
 }
 
+func TestIsEphemeralBuild(t *testing.T) {
+	tests := []struct {
+		name string
+		path string
+		want bool
+	}{
+		{name: "go run build", path: "/tmp/go-build2260624469/b001/exe/multica", want: true},
+		{name: "go test build", path: "/var/folders/x/T/go-build123/b001/daemon.test", want: true},
+		{name: "agent scoped TMPDIR", path: "/tmp/multica-task-abc/go-build99/b001/exe/multica", want: true},
+		{name: "windows separators", path: `C:\Users\dev\AppData\Local\Temp\go-build42\b001\exe\multica.exe`, want: true},
+		{name: "repo build output", path: "/src/multica/server/bin/multica", want: false},
+		{name: "homebrew install", path: "/opt/homebrew/bin/multica", want: false},
+		{name: "build cache root", path: "/Users/dev/Library/Caches/go-build/ab/abc-d", want: false},
+		{name: "unrelated prefix", path: "/src/go-builder/bin/multica", want: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := IsEphemeralBuild(tt.path); got != tt.want {
+				t.Fatalf("IsEphemeralBuild(%q) = %v, want %v", tt.path, got, tt.want)
+			}
+		})
+	}
+}
+
 func writeTestExecutable(t *testing.T, dir, base string) string {
 	t.Helper()
 	if runtime.GOOS == "windows" {


### PR DESCRIPTION
Fixes the three local-dev defects reported in MUL-5859 and collapses the ~12-step bootstrap into one command.

## 1. `make daemon` produced a daemon that could not run any task

`make daemon` → `make multica` → `go run`. The daemon records its own executable path at startup and re-execs it as the execution-environment preparation helper for **every task**; `go run` deletes that temp binary when the launcher exits, so the daemon started, registered, heartbeat — then failed every task with `fork/exec …/go-build…/exe/multica: no such file or directory`.

- `make daemon` builds `server/bin/multica` and runs that. `ARGS` forwards any daemon subcommand (`make daemon ARGS="start --profile foo"`); bare `make daemon` still means `restart --profile local`.
- New `make multica-bin` builds only the CLI; `make build` reuses it.
- `daemon start` (background **and** `--foreground`) now refuses a `go run` binary at start, with a message that names the cause and the fix. `selfexec.IsEphemeralBuild` does the classification.

One-shot CLI commands through `make cli` are unaffected — nothing there records a path that must outlive the process.

## 2. `make stop` killed the daemon

`lsof -ti:PORT` matches every process holding a socket on the port, **including clients** — and the daemon holds a long-lived connection to the backend. Reproduced on a live environment: `lsof -ti:18453` → `35518 35606`, where 35606 was the daemon.

New `scripts/port-guard.sh` filters to `-sTCP:LISTEN` and sends `TERM` before escalating to `KILL`. `scripts/port-guard.test.sh` pins it against a real listener and a real connected client — including an assertion that the *unfiltered* lookup does see the client, so the test cannot pass vacuously. Wired into CI and `make check`.

## 3. Restarting over a running instance failed invisibly

The new process died on the bind, the old one kept serving, and `/health` answered 200 the whole time.

- `scripts/dev.sh` preflights both ports and names the owning process and its start time.
- `/health` now returns process identity:

  ```json
  {"status":"ok","commit":"d09019cd9","started_at":"2026-08-07T08:30:04Z","pid":35518}
  ```

  `commit` is stamped by `make dev` / `make start` / `make build`.

## 4. One command: `make dev-bootstrap`

Runs the whole sequence and prints the URL, login, profile, logs, and stop command. Problems 1–3 are avoided structurally inside it (built daemon binary, listener-only stop, port preflight), plus:

- pins a durable `TMPDIR` — an agent's `TMPDIR` is deleted when its run ends, so a handed-off environment did not survive its creator;
- writes `MULTICA_DEV_VERIFICATION_CODE` **before** first launch, removing the start → edit → restart detour;
- creates the database against `DATABASE_URL` rather than `docker exec`, which is what makes it work when a native PostgreSQL owns 5432;
- verifies the health response came from the process it just launched (using the new `started_at`);
- `send-code` once, `verify-code` once — retries lock the code out.

Re-running against an existing environment is safe. `make dev-bootstrap-stop` tears it down and leaves the database, workspace, and profile in place.

## Verification

Run end to end on a clean worktree checkout:

- `make dev-bootstrap` → **11.7s** to a logged-in, daemon-attached environment; daemon registered 9 runtimes across 1 workspace.
- Daemon executable resolved to `server/bin/multica` (durable), not a `go-build` temp path.
- `make cli ARGS="daemon start --profile …"` now fails at start with the actionable message.
- `make dev` over the running instance failed loudly and left the running backend healthy.
- `make stop-worktree` stopped both listeners; the daemon (pid 35606) survived and kept reporting `running`.
- `make dev-bootstrap-stop` left no listeners and no stray processes.
- `go test ./cmd/multica/... ./cmd/server/... ./internal/selfexec/... ./internal/daemon/...` — all pass (run from a clean checkout outside an agent workdir; inside one, unrelated packages trip the agent-task-context guard on both this branch and `main`).
- `bash scripts/port-guard.test.sh`, `bash scripts/selfhost-config.test.sh` — pass.

Not verified: executing a real agent task end to end, which would resolve and run a user-installed agent CLI. The task-time failure was ENOENT on the recorded helper path; that path is now durable and checked at start, and the check itself is unit-tested.

## Docs

`CONTRIBUTING.md` (quick start, isolated-environment flow, daemon section, two new troubleshooting entries), `README.md`, `README.zh.md`, `CLAUDE.md`. The `local-dev-environment` workspace skill is updated separately to match.
