### PR TITLE
MUL-5862: project pill quick-clear × + stop remembering the last project

### DIFF
--- a/packages/core/issues/stores/quick-create-store.test.ts
+++ b/packages/core/issues/stores/quick-create-store.test.ts
@@ -4,7 +4,6 @@ import { useQuickCreateStore } from "./quick-create-store";
 const RESET_STATE = {
   lastActorType: null,
   lastActorId: null,
-  lastProjectId: null,
   keepOpen: false,
 };
 
@@ -13,14 +12,13 @@ describe("quick create store", () => {
     useQuickCreateStore.setState(RESET_STATE);
   });
 
-  it("remembers the last project picked so frequent users skip the picker", () => {
-    const { setLastProjectId } = useQuickCreateStore.getState();
-
-    setLastProjectId("proj-1");
-    expect(useQuickCreateStore.getState().lastProjectId).toBe("proj-1");
-
-    setLastProjectId(null);
-    expect(useQuickCreateStore.getState().lastProjectId).toBeNull();
+  // The store remembers the actor and nothing else about the last create.
+  // Project is a property of the issue being filed, not a standing
+  // preference, so carrying it forward files the next issue somewhere the
+  // user never picked (MUL-5862).
+  it("does not carry any project memory", () => {
+    expect(useQuickCreateStore.getState()).not.toHaveProperty("lastProjectId");
+    expect(useQuickCreateStore.getState()).not.toHaveProperty("setLastProjectId");
   });
 
   it("remembers the last actor (agent or squad) and clears both fields together", () => {

--- a/packages/core/issues/stores/quick-create-store.ts
+++ b/packages/core/issues/stores/quick-create-store.ts
@@ -8,15 +8,21 @@ import { registerDraftCleanup } from "../../drafts/cleanup-registry";
 
 export type QuickCreateActorType = "agent" | "squad";
 
-// Per-workspace memory of the last actor (agent or squad) and project the
-// user picked in the Quick Create modal. Defaulted to those values on next
-// open so frequent users skip the pickers entirely — without this, anyone
-// targeting a single project ends up retyping "in project A" on every
-// prompt. Persisted with the workspace-aware StateStorage so switching
-// workspaces shows the right default automatically. Per-user scoping comes
-// for free from localStorage being browser-profile-local — matches how
-// draft-store / issues-scope-store / comment-collapse-store already
-// namespace themselves.
+// Per-workspace memory of the last actor (agent or squad) the user picked in
+// the Quick Create modal. Defaulted on next open so frequent users skip the
+// picker entirely. Persisted with the workspace-aware StateStorage so
+// switching workspaces shows the right default automatically. Per-user
+// scoping comes for free from localStorage being browser-profile-local —
+// matches how draft-store / issues-scope-store / comment-collapse-store
+// already namespace themselves.
+//
+// The last project is deliberately NOT remembered (MUL-5862). Actor and
+// project look symmetrical but aren't: an issue's target project is a
+// property of the issue being filed, not a standing preference, so carrying
+// the previous one forward guesses wrong as soon as the user moves on — and
+// silently files the next issue into a project they never picked. The two
+// seeds that survive both have the user's intent behind them: the project
+// page they opened the modal from, and their own unfinished draft.
 //
 // lastActorType + lastActorId replace the prior `lastAgentId` field once
 // squads became selectable. Users who had a persisted agent preference
@@ -26,13 +32,11 @@ export type QuickCreateActorType = "agent" | "squad";
 // The in-progress agent prompt no longer lives here — it moved into the
 // unified issue-create draft's `agent` slot (draft-store) so it shares one
 // lifecycle with the manual draft (MUL-5181). This store keeps only the
-// last-successful preferences (actor, project) and the shared keep-open toggle.
+// last-successful actor and the shared keep-open toggle.
 interface QuickCreateState {
   lastActorType: QuickCreateActorType | null;
   lastActorId: string | null;
   setLastActor: (type: QuickCreateActorType | null, id: string | null) => void;
-  lastProjectId: string | null;
-  setLastProjectId: (id: string | null) => void;
   keepOpen: boolean;
   setKeepOpen: (v: boolean) => void;
 }
@@ -43,8 +47,6 @@ export const useQuickCreateStore = create<QuickCreateState>()(
       lastActorType: null,
       lastActorId: null,
       setLastActor: (type, id) => set({ lastActorType: type, lastActorId: id }),
-      lastProjectId: null,
-      setLastProjectId: (id) => set({ lastProjectId: id }),
       keepOpen: false,
       setKeepOpen: (v) => set({ keepOpen: v }),
     }),
@@ -66,7 +68,6 @@ registerDraftCleanup({
     useQuickCreateStore.setState({
       lastActorType: null,
       lastActorId: null,
-      lastProjectId: null,
       keepOpen: false,
     }),
 });

--- a/packages/views/chat/components/chat-input.tsx
+++ b/packages/views/chat/components/chat-input.tsx
@@ -27,6 +27,7 @@ import { formatShortcut, useShortcut } from "@multica/core/shortcuts";
 import type { MentionItem } from "../../editor/extensions/mention-suggestion";
 import type { Attachment, Project } from "@multica/core/types";
 import { ProjectPicker } from "../../projects/components/project-picker";
+import { ClearablePillButton } from "../../common/pill-button";
 import { useT } from "../../i18n";
 
 const logger = createLogger("chat.ui");
@@ -614,12 +615,13 @@ export function ChatInput({
                 onUpdate={(updates) => onProjectChange?.(updates.project_id ?? null)}
                 disabled={!projectSelectionEnabled}
                 triggerRender={
-                  <button
-                    type="button"
+                  <ClearablePillButton
                     disabled={!projectSelectionEnabled}
                     aria-label={t(($) => $.input.change_project_context)}
                     title={t(($) => $.input.change_project_context)}
-                    className="flex h-6 max-w-56 items-center gap-1.5 rounded-full border border-surface-border bg-surface-raised px-2 text-caption font-medium text-foreground transition-colors hover:bg-accent/60"
+                    onClear={() => onProjectChange?.(null)}
+                    clearLabel={t(($) => $.input.remove_project_context)}
+                    className="h-6 border-surface-border bg-surface-raised font-medium text-foreground"
                   />
                 }
               />

--- a/packages/views/common/pill-button.tsx
+++ b/packages/views/common/pill-button.tsx
@@ -1,6 +1,21 @@
 "use client";
 
+import { X as XIcon } from "lucide-react";
 import { cn } from "@multica/ui/lib/utils";
+
+// Shared pill chrome. `PillButton` puts it on the button itself; the clearable
+// variant puts it on the shell that holds the trigger and the clear button, so
+// both read as the same object.
+//
+// Hard width cap: pills carry user-generated text (project title, assignee
+// name, label names), and the create toolbars are flex-wrap rows — an uncapped
+// pill stretches until it owns the whole line and pushes every sibling to the
+// next one. 14rem matches the chat composer's project pill. `min-w-0` +
+// `overflow-hidden` let the inner `truncate` spans actually shrink (a flex item
+// only drops `min-width: auto` once its overflow is hidden); leading icons are
+// `shrink-0`, so the text yields first.
+const PILL_CHROME =
+  "inline-flex items-center rounded-full border text-caption min-w-0 max-w-56 overflow-hidden transition-colors";
 
 export function PillButton({
   children,
@@ -11,17 +26,9 @@ export function PillButton({
     <button
       type="button"
       className={cn(
-        "inline-flex items-center gap-1.5 rounded-full border px-2.5 py-1 text-caption",
-        // Hard width cap. Pills carry user-generated text (project title,
-        // assignee name, label names), and the create toolbars are flex-wrap
-        // rows — an uncapped pill stretches until it owns the whole line and
-        // pushes every sibling to the next one. 14rem matches the chat
-        // composer's project pill. `min-w-0` + `overflow-hidden` let the
-        // inner `truncate` spans actually shrink (a flex item only drops
-        // `min-width: auto` once its overflow is hidden); leading icons are
-        // `shrink-0`, so the text yields first.
-        "min-w-0 max-w-56 overflow-hidden",
-        "hover:bg-accent/60 transition-colors cursor-pointer",
+        PILL_CHROME,
+        "gap-1.5 px-2.5 py-1",
+        "hover:bg-accent/60 cursor-pointer",
         "data-popup-open:bg-accent data-popup-open:text-accent-foreground",
         "disabled:cursor-not-allowed disabled:hover:bg-transparent",
         className,
@@ -30,5 +37,84 @@ export function PillButton({
     >
       {children}
     </button>
+  );
+}
+
+/**
+ * Pill trigger with a trailing quick-clear ×, for pills whose value can be
+ * dropped in one click (project context, parent link, …). Same chrome as
+ * `PillButton`, so a row can mix the two.
+ *
+ * Two sibling `<button>`s inside a plain shell — never a button nested in a
+ * button, and never the overlay × this replaces: that one was an absolutely
+ * positioned sibling of the trigger, so every caller had to reserve right
+ * padding for it and three of five didn't, painting the × over the value
+ * (MUL-5666).
+ *
+ * The root stays a `<span>` whether or not `onClear` is set. Presence of the
+ * clear action tracks "the field has a value", which flips in the same commit
+ * that closes the popover — swapping the root element type there would remount
+ * the popover's own trigger mid-close.
+ *
+ * Forwarded props (including the `ref`, `onClick` and `data-popup-open` that
+ * Base UI's `render` merges in) land on the inner trigger button, so the
+ * popover anchors to the trigger and the × stays outside its hit area.
+ */
+export function ClearablePillButton({
+  children,
+  className,
+  onClear,
+  clearLabel,
+  disabled,
+  ...props
+}: React.ButtonHTMLAttributes<HTMLButtonElement> & {
+  /** Omit to render a plain pill — the × appears only when there is a value
+   *  to drop. */
+  onClear?: (() => void) | undefined;
+  /** Accessible name for the × ("Clear project"). Required whenever
+   *  `onClear` is set: the button has no text. */
+  clearLabel?: string;
+}) {
+  // A disabled trigger disables clearing too: both are writes to the same
+  // field, and a read-only pill that can still be emptied is not read-only.
+  const clearable = !!onClear && !disabled;
+  return (
+    <span
+      className={cn(
+        PILL_CHROME,
+        !disabled && "hover:bg-accent/60",
+        // The open-state highlight lives on the trigger (Base UI stamps the
+        // attribute there), but it has to paint the whole pill.
+        "has-[[data-popup-open]]:bg-accent has-[[data-popup-open]]:text-accent-foreground",
+        className,
+      )}
+    >
+      <button
+        type="button"
+        disabled={disabled}
+        className={cn(
+          "flex min-w-0 items-center gap-1.5 overflow-hidden py-1 pl-2.5 cursor-pointer",
+          clearable ? "pr-1" : "pr-2.5",
+          "disabled:cursor-not-allowed",
+        )}
+        {...props}
+      >
+        {children}
+      </button>
+      {clearable && (
+        <button
+          type="button"
+          aria-label={clearLabel}
+          title={clearLabel}
+          onClick={(e) => {
+            e.stopPropagation();
+            onClear?.();
+          }}
+          className="flex shrink-0 items-center py-1 pl-0.5 pr-2 text-muted-foreground hover:text-foreground cursor-pointer"
+        >
+          <XIcon className="size-3" />
+        </button>
+      )}
+    </span>
   );
 }

--- a/packages/views/locales/en/projects.json
+++ b/packages/views/locales/en/projects.json
@@ -128,7 +128,8 @@
   "picker": {
     "no_project": "No project",
     "empty": "No projects yet",
-    "search_placeholder": "Search projects..."
+    "search_placeholder": "Search projects...",
+    "clear_aria": "Clear project"
   },
   "chip": {
     "fallback_label": "Project"

--- a/packages/views/locales/ja/projects.json
+++ b/packages/views/locales/ja/projects.json
@@ -127,7 +127,8 @@
   "picker": {
     "no_project": "プロジェクトなし",
     "empty": "プロジェクトはまだありません",
-    "search_placeholder": "プロジェクトを検索..."
+    "search_placeholder": "プロジェクトを検索...",
+    "clear_aria": "プロジェクトをクリア"
   },
   "chip": {
     "fallback_label": "プロジェクト"

--- a/packages/views/locales/ko/projects.json
+++ b/packages/views/locales/ko/projects.json
@@ -127,7 +127,8 @@
   "picker": {
     "no_project": "프로젝트 없음",
     "empty": "아직 프로젝트가 없습니다",
-    "search_placeholder": "프로젝트 검색..."
+    "search_placeholder": "프로젝트 검색...",
+    "clear_aria": "프로젝트 지우기"
   },
   "chip": {
     "fallback_label": "프로젝트"

--- a/packages/views/locales/zh-Hans/projects.json
+++ b/packages/views/locales/zh-Hans/projects.json
@@ -127,7 +127,8 @@
   "picker": {
     "no_project": "无项目",
     "empty": "还没有项目",
-    "search_placeholder": "搜索项目..."
+    "search_placeholder": "搜索项目...",
+    "clear_aria": "清除项目"
   },
   "chip": {
     "fallback_label": "项目"

--- a/packages/views/modals/create-issue.test.tsx
+++ b/packages/views/modals/create-issue.test.tsx
@@ -999,9 +999,6 @@ describe("CreateIssueModal", () => {
     expect(onSwitchMode.mock.calls[0]?.[0]).toBeNull();
   });
 
-  // Manual → agent must forward the picked project so the new modal pins to
-  // the same target. Without this the agent panel re-seeds from its own
-  // persisted `lastProjectId` and silently routes the issue to a stale one.
   // Reporter scenario: backend rejects same-titled create with a 409 +
   // structured duplicate body. The user should land on a duplicate toast
   // pointing at the existing issue, not a generic "create failed" message.

--- a/packages/views/modals/create-issue.tsx
+++ b/packages/views/modals/create-issue.tsx
@@ -81,7 +81,7 @@ import {
   parseWithFallback,
 } from "@multica/core/api";
 import { FileUploadButton } from "@multica/ui/components/common/file-upload-button";
-import { PillButton } from "../common/pill-button";
+import { ClearablePillButton, PillButton } from "../common/pill-button";
 import { ActorAvatar } from "../common/actor-avatar";
 import { PropertyIcon } from "../common/property-icon";
 import {
@@ -208,6 +208,7 @@ export function ManualCreatePanel({
 }) {
   const { t } = useT("modals");
   const { t: tEditor } = useT("editor");
+  const { t: tProjects } = useT("projects");
   const router = useNavigation();
   const p = useWorkspacePaths();
   const workspaceName = useCurrentWorkspace()?.name;
@@ -943,7 +944,12 @@ export function ManualCreatePanel({
                 <ProjectPicker
                   projectId={projectId ?? null}
                   onUpdate={(u) => updateProject(u.project_id ?? undefined)}
-                  triggerRender={<PillButton />}
+                  triggerRender={
+                    <ClearablePillButton
+                      onClear={projectId ? () => updateProject(undefined) : undefined}
+                      clearLabel={tProjects(($) => $.picker.clear_aria)}
+                    />
+                  }
                   align="start"
                   open={fieldPickerOpen === "project" ? true : undefined}
                   onOpenChange={(open) => setFieldPickerOpen(open ? "project" : null)}

--- a/packages/views/modals/quick-create-issue.test.tsx
+++ b/packages/views/modals/quick-create-issue.test.tsx
@@ -5,7 +5,6 @@ import userEvent from "@testing-library/user-event";
 
 const mockQuickCreateIssue = vi.hoisted(() => vi.fn());
 const mockSetLastActor = vi.hoisted(() => vi.fn());
-const mockSetLastProjectId = vi.hoisted(() => vi.fn());
 const mockSetQuickCreateFieldVisible = vi.hoisted(() => vi.fn());
 const mockSetKeepOpen = vi.hoisted(() => vi.fn());
 const mockSetLastMode = vi.hoisted(() => vi.fn());
@@ -58,10 +57,12 @@ const mockQuickCreateStore = {
   lastActorType: null as "agent" | "squad" | null,
   lastActorId: null as string | null,
   setLastActor: mockSetLastActor,
-  lastProjectId: null as string | null,
-  setLastProjectId: mockSetLastProjectId,
   keepOpen: false,
   setKeepOpen: mockSetKeepOpen,
+  // Not part of the store's interface any more (MUL-5862), but an older
+  // build persisted it and localStorage still hands it back on rehydrate.
+  // Kept here so the tests can prove the panel ignores it.
+  lastProjectId: null as string | null,
 };
 
 const mockCreateSettingsStore = {
@@ -545,9 +546,6 @@ describe("AgentCreatePanel", () => {
     });
 
     expect(mockSetLastActor).toHaveBeenCalledWith("agent", "agent-1");
-    // No project picked → persisted project preference is cleared so the
-    // store stays in sync with the actual outgoing request.
-    expect(mockSetLastProjectId).toHaveBeenCalledWith(null);
     // A successful create ends the whole unified draft.
     expect(mockClearDraft).toHaveBeenCalled();
     expect(mockSetLastMode).toHaveBeenCalledWith("agent");
@@ -787,22 +785,72 @@ describe("AgentCreatePanel", () => {
     expect(screen.queryByRole("button", { name: /Orphan Squad/ })).toBeNull();
   });
 
-  // If the user's persisted `lastProjectId` points at a project that has
-  // been deleted (or moved to another workspace), the modal must not keep
-  // submitting that dead UUID. Once the projects query resolves and the id
-  // is missing, we clear BOTH local state and the persisted preference;
-  // dropping only local state would leave the next open re-seeding the same
-  // dead value and trigger the server's `project not found` rejection.
-  it("clears a stale persisted project once the projects list resolves without it", async () => {
-    mockQuickCreateStore.lastProjectId = "deleted-proj";
+  // A successful create used to persist its project, so the NEXT open
+  // re-seeded the pill with it and quietly filed the following issue into the
+  // same place. The target project belongs to the issue being filed, not to
+  // the user as a standing preference — the actor is the only thing that
+  // carries over now (MUL-5862).
+  describe("project is not remembered across creates", () => {
+    it("ignores a lastProjectId left behind by an older build", () => {
+      mockQuickCreateStore.lastProjectId = "proj-1";
+      mockProjectsQuery.data = [{ id: "proj-1", title: "Web", icon: null }];
+      mockProjectsQuery.isSuccess = true;
+
+      renderPanel({ onClose: vi.fn(), isExpanded: false, setIsExpanded: vi.fn() });
+
+      // Seeding from it is exactly the removed behavior — the pill must be
+      // empty, and with no value there is nothing to clear.
+      expect(screen.getByTestId("project-picker")).toHaveTextContent("Project none");
+      expect(screen.queryByRole("button", { name: "Clear project" })).not.toBeInTheDocument();
+    });
+
+    it("still submits the project picked in this session", async () => {
+      // Guard against over-removal: dropping the memory must not drop the
+      // field from the outgoing request.
+      const user = userEvent.setup();
+      mockProjectsQuery.data = [{ id: "proj-1", title: "Web", icon: null }];
+      mockProjectsQuery.isSuccess = true;
+
+      renderPanel({ onClose: vi.fn(), isExpanded: false, setIsExpanded: vi.fn() });
+
+      await user.click(screen.getByRole("button", { name: /Bohan/ }));
+      await user.click(screen.getByTestId("project-picker"));
+      await user.type(
+        screen.getByPlaceholderText(
+          'Tell the agent what to do, e.g. "let Bohan fix the inbox loading slowness in the Web project"',
+        ),
+        "Ship it",
+      );
+      await user.click(screen.getByRole("button", { name: /^Create$/i }));
+
+      await waitFor(() => {
+        expect(mockQuickCreateIssue).toHaveBeenCalledWith(
+          expect.objectContaining({ project_id: "proj-1" }),
+        );
+      });
+      // The actor is still remembered — only the project memory is gone.
+      expect(mockSetLastActor).toHaveBeenCalledWith("agent", "agent-1");
+    });
+  });
+
+  // If the unfinished draft points at a project that has been deleted (or
+  // moved to another workspace), the modal must not keep submitting that dead
+  // UUID. Once the projects query resolves and the id is missing, we clear
+  // BOTH local state and the draft; dropping only local state would leave the
+  // next open re-seeding the same dead value and trigger the server's
+  // `project not found` rejection. The draft is now the only persisted copy —
+  // the last-create memory is gone (MUL-5862).
+  it("clears a stale drafted project once the projects list resolves without it", async () => {
+    mockIssueDraftStore.draft.shared.projectId = "deleted-proj";
     mockProjectsQuery.data = [];
     mockProjectsQuery.isSuccess = true;
 
     renderPanel({ onClose: vi.fn(), isExpanded: false, setIsExpanded: vi.fn() });
 
     await waitFor(() => {
-      expect(mockSetLastProjectId).toHaveBeenCalledWith(null);
+      expect(mockSetShared).toHaveBeenCalledWith({ projectId: undefined });
     });
+    expect(screen.getByTestId("project-picker")).toHaveTextContent("Project none");
   });
 
   // Dropping a project used to cost two clicks — open the popover, hit
@@ -819,7 +867,7 @@ describe("AgentCreatePanel", () => {
 
     it("clears local state and the shared draft in one click", async () => {
       const user = userEvent.setup();
-      mockQuickCreateStore.lastProjectId = "proj-1";
+      mockIssueDraftStore.draft.shared.projectId = "proj-1";
       mockProjectsQuery.data = [{ id: "proj-1", title: "Web", icon: null }];
       mockProjectsQuery.isSuccess = true;
 
@@ -836,16 +884,17 @@ describe("AgentCreatePanel", () => {
   });
 
   // Mirror case: while the query is still loading, we must NOT preemptively
-  // clear the persisted preference — that would wipe a perfectly valid
-  // selection on every open before the list ever renders.
-  it("keeps the persisted project while the projects list is still loading", () => {
-    mockQuickCreateStore.lastProjectId = "proj-1";
+  // clear the drafted project — that would wipe a perfectly valid selection
+  // on every open before the list ever renders.
+  it("keeps the drafted project while the projects list is still loading", () => {
+    mockIssueDraftStore.draft.shared.projectId = "proj-1";
     mockProjectsQuery.data = [];
     mockProjectsQuery.isSuccess = false;
 
     renderPanel({ onClose: vi.fn(), isExpanded: false, setIsExpanded: vi.fn() });
 
-    expect(mockSetLastProjectId).not.toHaveBeenCalled();
+    expect(mockSetShared).not.toHaveBeenCalled();
+    expect(screen.getByTestId("project-picker")).toHaveTextContent("Project proj-1");
   });
 
   // When the modal was opened from "Add sub issue" on an existing issue,

--- a/packages/views/modals/quick-create-issue.test.tsx
+++ b/packages/views/modals/quick-create-issue.test.tsx
@@ -211,15 +211,16 @@ vi.mock("../issues/components", () => ({
 }));
 
 vi.mock("../projects/components/project-picker", () => ({
-  ProjectPicker: ({ projectId, onUpdate }: any) => (
-    <button type="button" data-testid="project-picker" onClick={() => onUpdate({ project_id: "proj-1" })}>
-      Project {projectId ?? "none"}
-    </button>
+  ProjectPicker: ({ projectId, onUpdate, triggerRender }: any) => (
+    <>
+      <button type="button" data-testid="project-picker" onClick={() => onUpdate({ project_id: "proj-1" })}>
+        Project {projectId ?? "none"}
+      </button>
+      {/* The caller's own trigger renders too — the pill carries the
+          quick-clear ×, which belongs to this panel, not to the picker. */}
+      {triggerRender}
+    </>
   ),
-}));
-
-vi.mock("../common/pill-button", () => ({
-  PillButton: ({ children, ...props }: any) => <button type="button" {...props}>{children}</button>,
 }));
 
 vi.mock("@multica/ui/components/ui/dropdown-menu", () => ({
@@ -403,9 +404,12 @@ import { I18nProvider } from "@multica/core/i18n/react";
 import enCommon from "../locales/en/common.json";
 import enModals from "../locales/en/modals.json";
 import enEditor from "../locales/en/editor.json";
+import enProjects from "../locales/en/projects.json";
 import { AgentCreatePanel } from "./quick-create-issue";
 
-const TEST_RESOURCES = { en: { common: enCommon, modals: enModals, editor: enEditor } };
+const TEST_RESOURCES = {
+  en: { common: enCommon, modals: enModals, editor: enEditor, projects: enProjects },
+};
 
 function renderPanel(props: React.ComponentProps<typeof AgentCreatePanel>) {
   return render(
@@ -798,6 +802,36 @@ describe("AgentCreatePanel", () => {
 
     await waitFor(() => {
       expect(mockSetLastProjectId).toHaveBeenCalledWith(null);
+    });
+  });
+
+  // Dropping a project used to cost two clicks — open the popover, hit
+  // "No project" — because the pill had no clear affordance of its own
+  // (MUL-5862). The × is part of the pill, so it only exists once the field
+  // has a value to drop.
+  describe("project pill quick-clear", () => {
+    it("has no × while no project is selected", () => {
+      renderPanel({ onClose: vi.fn(), isExpanded: false, setIsExpanded: vi.fn() });
+
+      expect(screen.getByTestId("project-picker")).toHaveTextContent("Project none");
+      expect(screen.queryByRole("button", { name: "Clear project" })).not.toBeInTheDocument();
+    });
+
+    it("clears local state and the shared draft in one click", async () => {
+      const user = userEvent.setup();
+      mockQuickCreateStore.lastProjectId = "proj-1";
+      mockProjectsQuery.data = [{ id: "proj-1", title: "Web", icon: null }];
+      mockProjectsQuery.isSuccess = true;
+
+      renderPanel({ onClose: vi.fn(), isExpanded: false, setIsExpanded: vi.fn() });
+      expect(screen.getByTestId("project-picker")).toHaveTextContent("Project proj-1");
+
+      await user.click(screen.getByRole("button", { name: "Clear project" }));
+
+      expect(screen.getByTestId("project-picker")).toHaveTextContent("Project none");
+      expect(mockSetShared).toHaveBeenCalledWith({ projectId: undefined });
+      // The × retires with the value it cleared.
+      expect(screen.queryByRole("button", { name: "Clear project" })).not.toBeInTheDocument();
     });
   });
 

--- a/packages/views/modals/quick-create-issue.tsx
+++ b/packages/views/modals/quick-create-issue.tsx
@@ -56,7 +56,7 @@ import {
   type Squad,
 } from "@multica/core/types";
 import { ActorAvatar } from "../common/actor-avatar";
-import { PillButton } from "../common/pill-button";
+import { ClearablePillButton, PillButton } from "../common/pill-button";
 import { ProjectPicker } from "../projects/components/project-picker";
 import { DueDatePicker, PriorityIcon, PriorityPicker } from "../issues/components";
 import { canAssignAgent } from "../issues/components/pickers/assignee-picker";
@@ -115,6 +115,7 @@ export function AgentCreatePanel({
   setIsExpanded: (v: boolean) => void;
 }) {
   const { t } = useT("modals");
+  const { t: tProjects } = useT("projects");
   const sendShortcut = useShortcut("send");
   const workspaceName = useCurrentWorkspace()?.name;
   const workspacePaths = useWorkspacePaths();
@@ -266,6 +267,12 @@ export function AgentCreatePanel({
     (data?.due_date as string | undefined) ?? draft.shared.dueDate,
   );
   const [fieldPickerOpen, setFieldPickerOpen] = useState<QuickCreateField | null>(null);
+  // Local state + shared draft always move together, so both the picker rows
+  // and the pill's quick-clear go through here.
+  const commitProject = (next: string | null) => {
+    setProjectId(next);
+    setShared({ projectId: next ?? undefined });
+  };
 
   // Parent-issue context — seeded by `openCreateSubIssue` when the modal is
   // opened from the "Add sub issue" entry on an existing issue. We carry it
@@ -658,12 +665,13 @@ export function AgentCreatePanel({
             fieldPickerOpen === "project") && (
             <ProjectPicker
               projectId={projectId}
-              onUpdate={(u) => {
-                const next = u.project_id ?? null;
-                setProjectId(next);
-                setShared({ projectId: next ?? undefined });
-              }}
-              triggerRender={<PillButton />}
+              onUpdate={(u) => commitProject(u.project_id ?? null)}
+              triggerRender={
+                <ClearablePillButton
+                  onClear={projectId !== null ? () => commitProject(null) : undefined}
+                  clearLabel={tProjects(($) => $.picker.clear_aria)}
+                />
+              }
               align="start"
               open={fieldPickerOpen === "project" ? true : undefined}
               onOpenChange={(open) => setFieldPickerOpen(open ? "project" : null)}

--- a/packages/views/modals/quick-create-issue.tsx
+++ b/packages/views/modals/quick-create-issue.tsx
@@ -166,8 +166,6 @@ export function AgentCreatePanel({
   const lastActorType = useQuickCreateStore((s) => s.lastActorType);
   const lastActorId = useQuickCreateStore((s) => s.lastActorId);
   const setLastActor = useQuickCreateStore((s) => s.setLastActor);
-  const lastProjectId = useQuickCreateStore((s) => s.lastProjectId);
-  const setLastProjectId = useQuickCreateStore((s) => s.setLastProjectId);
   const visibleFields = useIssueCreateSettingsStore((s) => s.quickCreateFields);
   const keepOpen = useQuickCreateStore((s) => s.keepOpen);
   const setKeepOpen = useQuickCreateStore((s) => s.setKeepOpen);
@@ -250,14 +248,16 @@ export function AgentCreatePanel({
     return visibleSquads.find((s) => s.id === actor.id);
   }, [actor, visibleSquads]);
 
-  // Unfinished selections live in the shared issue-create draft. Last-successful
-  // actor/project values remain separate fallbacks, so closing a draft never
-  // overwrites the defaults established by an actual create.
+  // Unfinished selections live in the shared issue-create draft. The
+  // last-successful actor remains a separate fallback, so closing a draft
+  // never overwrites the default established by an actual create.
+  //
+  // Project has exactly two seeds, both carrying explicit user intent: the
+  // project page (or manual panel) the modal was opened from, and the user's
+  // own unfinished draft. It is deliberately NOT seeded from the last create
+  // — see quick-create-store (MUL-5862).
   const [projectId, setProjectId] = useState<string | null>(() => {
-    const seed =
-      (data?.project_id as string | undefined) ??
-      draft.shared.projectId ??
-      lastProjectId;
+    const seed = (data?.project_id as string | undefined) ?? draft.shared.projectId;
     return seed ?? null;
   });
   const [priority, setPriority] = useState<IssuePriority>(
@@ -287,9 +287,9 @@ export function AgentCreatePanel({
   // Stale-id sweep. Once the project list query has actually resolved
   // (`isSuccess` — distinct from "data is the empty default during loading"),
   // a `projectId` that isn't in the list means the project was deleted in
-  // another session. Clear local state, the unfinished draft, and the
-  // last-successful preference; dropping any persisted copy would make the
-  // next open re-seed and submit the same dead value.
+  // another session. Clear local state AND the unfinished draft — the draft
+  // is the only persisted copy left, and leaving it would make the next open
+  // re-seed and submit the same dead value.
   useEffect(() => {
     if (!projectsLoaded || projectId === null) return;
     if (projects.some((p) => p.id === projectId)) return;
@@ -297,16 +297,7 @@ export function AgentCreatePanel({
     if (draft.shared.projectId === projectId) {
       setShared({ projectId: undefined });
     }
-    if (lastProjectId === projectId) setLastProjectId(null);
-  }, [
-    projectsLoaded,
-    projects,
-    projectId,
-    draft.shared.projectId,
-    lastProjectId,
-    setShared,
-    setLastProjectId,
-  ]);
+  }, [projectsLoaded, projects, projectId, draft.shared.projectId, setShared]);
 
   // Mark the persisted draft's active mode so a later reopen and any reader of
   // the unified draft know which form is being edited.
@@ -426,7 +417,6 @@ export function AgentCreatePanel({
           ...(activeAttachmentIds.length > 0 ? { attachment_ids: activeAttachmentIds } : {}),
         });
         setLastActor(actor.type, actor.id);
-        setLastProjectId(projectId);
         setLastMode("agent");
         toast.success(t(($) => $.create_issue.agent.toast_sent), {
           duration: 4000,

--- a/packages/views/projects/components/project-picker.open-state.test.tsx
+++ b/packages/views/projects/components/project-picker.open-state.test.tsx
@@ -14,7 +14,7 @@ import { I18nProvider } from "@multica/core/i18n/react";
 import enProjects from "../../locales/en/projects.json";
 import enIssues from "../../locales/en/issues.json";
 import { ProjectPicker } from "./project-picker";
-import { PillButton } from "../../common/pill-button";
+import { ClearablePillButton, PillButton } from "../../common/pill-button";
 
 vi.mock("@tanstack/react-query", () => ({
   useQuery: () => ({
@@ -46,18 +46,25 @@ function withI18n(children: React.ReactNode) {
   );
 }
 
-/** Mirrors the create-issue dialog wiring from packages/views/modals/create-issue.tsx. */
+/** Mirrors the create-issue dialog wiring from packages/views/modals/create-issue.tsx,
+ *  including the clearable pill both create panels use. */
 function CreateDialogHarness({ onUpdate }: { onUpdate: (u: object) => void }) {
   const [fieldPickerOpen, setFieldPickerOpen] = useState<"project" | null>(null);
   const [projectId, setProjectId] = useState<string | null>(null);
+  const commit = (next: string | null) => {
+    onUpdate({ project_id: next });
+    setProjectId(next);
+  };
   return withI18n(
     <ProjectPicker
       projectId={projectId}
-      onUpdate={(u) => {
-        onUpdate(u);
-        setProjectId((u as { project_id?: string | null }).project_id ?? null);
-      }}
-      triggerRender={<PillButton />}
+      onUpdate={(u) => commit((u as { project_id?: string | null }).project_id ?? null)}
+      triggerRender={
+        <ClearablePillButton
+          onClear={projectId !== null ? () => commit(null) : undefined}
+          clearLabel="Clear project"
+        />
+      }
       align="start"
       open={fieldPickerOpen === "project" ? true : undefined}
       onOpenChange={(open) => setFieldPickerOpen(open ? "project" : null)}
@@ -103,6 +110,39 @@ describe("ProjectPicker open state under create-dialog wiring", () => {
     // Reopen from the (now selected) trigger and close by selecting again.
     await user.click(screen.getByRole("button", { name: /launch command center/i }));
     await user.click(await screen.findByRole("button", { name: /mobile web/i }));
+    await expectClosed();
+  });
+});
+
+// The pill's quick-clear (MUL-5862). It is a sibling button inside the pill
+// shell, not an overlay on the trigger — the overlay version this replaces
+// needed every caller to reserve right padding and three of five didn't
+// (MUL-5666). The trigger stays the popover's anchor, so pressing × must
+// clear the field WITHOUT opening the list.
+describe("ProjectPicker clearable pill", () => {
+  it("offers no × until a project is selected", async () => {
+    render(<CreateDialogHarness onUpdate={vi.fn()} />);
+
+    expect(screen.queryByRole("button", { name: "Clear project" })).not.toBeInTheDocument();
+  });
+
+  it("clears the selection in one click without opening the popover", async () => {
+    const user = userEvent.setup();
+    const onUpdate = vi.fn();
+
+    render(<CreateDialogHarness onUpdate={onUpdate} />);
+
+    await user.click(screen.getByRole("button", { name: /no project/i }));
+    await user.click(await screen.findByRole("button", { name: /mobile web/i }));
+    await expectClosed();
+
+    await user.click(screen.getByRole("button", { name: "Clear project" }));
+
+    expect(onUpdate).toHaveBeenLastCalledWith({ project_id: null });
+    // Trigger is back to the empty label, the × is gone, and the click never
+    // reached the trigger underneath it.
+    expect(screen.getByRole("button", { name: /no project/i })).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Clear project" })).not.toBeInTheDocument();
     await expectClosed();
   });
 });


### PR DESCRIPTION
Closes MUL-5862

本 PR 现在有两个提交，都来自这个 issue 的讨论。

---

## 1. `feat(views)`: 项目 pill 的快速清除 ×

**问题**

「通过智能体创建」里选完项目，pill 上没有任何取消入口 —— 想清掉得先点开下拉、再在列表里找到「无项目」。同一行的父任务 chip、子任务 chip 早就有 × 了，项目 pill 没有。

MUL-5666 当初拿掉项目 pill 的 × 是有道理的：那个 × 是 trigger 的绝对定位兄弟节点，需要每个调用方自己留出右内边距，五个调用方里三个没留，× 直接盖在项目名上。这次是把能力加回来，但不把那个约定加回来。

**做法**

`ClearablePillButton` —— 一个不可点的外壳，里面两个并排的 `<button>`：popover 触发器 + 清除按钮。不是 button 套 button，也不需要调用方配合内边距。

- Base UI 的 `render` 把 ref / onClick / data-popup-open 合并到**内层触发按钮**上，所以 popover 依然锚定 trigger，× 落在它的点击区之外；
- 展开态的高亮由外壳用 `has-[[data-popup-open]]` 接回来，整颗 pill 一起变色，和以前一致；
- 根节点无论有没有 `onClear` 都是 `<span>`。「有没有值可清」和「popover 关闭」是同一次提交里翻转的，这时候换根节点类型会把 popover 自己的 trigger 在关闭过程中卸载重挂。

接入三个 pill 形态的调用点：智能体创建、手动创建、Chat 输入框。属性行形态的调用点（任务详情侧栏、表格单元格）和自动驾驶的整行 select 保持原样 —— × 属于 chip，不属于属性行。

下拉里的「无项目」全部保留，键盘路径和其他 picker 完全不变。

---

## 2. `fix(quick-create)`: 不再记住上次创建的项目

**问题**

成功创建后会把项目持久化，下次打开用它回填 pill。actor 和 project 看起来对称，其实不是：找哪个智能体是一种长期偏好，而项目属于**这一条** issue。把它带到下一次是在猜，而且猜错时没有任何提示 —— 下一条 issue 就静默落进了用户没有选过的项目里。

**做法**

从 quick-create store 里整个删掉 `lastProjectId`，连同它的回填和创建成功时的写入。剩下两条回填路径都有明确的用户意图：打开弹窗时所在的项目页（或手动面板带过来的），以及用户自己没写完的草稿。

失效 id 的清扫逻辑继续对草稿生效 —— 草稿现在是唯一的持久副本，被删掉的项目依然不会活到下次打开再被当成死 UUID 提交。

无需迁移：老版本留在 localStorage 里的 `lastProjectId` 不会再被读，zustand/persist 下次写入时自然丢弃未知字段。因为这个残值对存量用户是真实存在的，专门加了一条回归测试钉住「不读它」。

---

## 验证

- `pnpm typecheck` —— 6 个包全过
- `pnpm --filter @multica/views test` —— 3737 passed；唯一失败的 `layout/sidebar-resize.test.tsx` 在干净的 main 上同样失败，与本 PR 无关
- `pnpm --filter @multica/core test` —— 1334 passed；失败的 8 条（projects/workspace mutations、realtime）在干净的 main 上同样失败，与本 PR 无关
- lint 0 error
- 新增回归测试：
  - `project-picker.open-state.test.tsx` 用真实 Base UI Popover 验证「点 × 清空且不展开列表」
  - `quick-create-issue.test.tsx` 验证 × 只在有值时出现、一次点击同时清掉本地 state 和共享草稿
  - `quick-create-issue.test.tsx` 验证残留的 `lastProjectId` 不再被回填（把旧的回填路径贴回去后这条会失败，确认它有效）
  - `quick-create-store.test.ts` 钉住 store 不再持有任何项目记忆
