### PR TITLE
fix(analytics): restore card spacing on the usage tab

### DIFF
--- a/packages/views/dashboard/components/dashboard-page.tsx
+++ b/packages/views/dashboard/components/dashboard-page.tsx
@@ -524,7 +524,7 @@ export function DashboardPage() {
 
       <div className="flex-1 overflow-y-auto">
         <div className="mx-auto max-w-6xl p-6">
-          <TabsContent value="usage">
+          <TabsContent value="usage" className="space-y-5">
             {usageLoading ? (
               <DashboardSkeleton />
             ) : usageHasNoData ? (


### PR DESCRIPTION
## Summary

#6564 removed the subtitle line on the Analytics usage tab and accidentally dropped the `space-y-5` class from the same `<TabsContent value="usage">` line, leaving the KPI row, usage trend card, and leaderboard stacked with no gap after data loads.

The loading skeleton and the Errors tab carry their own `space-y-5`, so only the loaded usage tab was affected. This restores the class.

🤖 Generated with [Claude Code](https://claude.com/claude-code)