### PR TITLE
fix(wecom): cap the request bodies both WeCom JSON endpoints read

### DIFF
--- a/server/internal/handler/handler.go
+++ b/server/internal/handler/handler.go
@@ -279,7 +279,7 @@ type Handler struct {
 	// to their real userid or email, so an explicit binding is required —
 	// see wecom/binding.go). Nil disables the redeem endpoint (returns 503)
 	// and the OutboundReplier's binding-prompt path.
-	WecomBindingTokens *wecom.BindingTokenService
+	WecomBindingTokens WecomBindingRedeemer
 	// LLM is the basic LLM API layer (MUL-4238): a thin wrapper over the
 	// OpenAI Go SDK backing server-internal one-shot LLM helpers such as chat
 	// title generation. The generic passthrough endpoints were removed in

--- a/server/internal/handler/wecom_web.go
+++ b/server/internal/handler/wecom_web.go
@@ -8,6 +8,7 @@ package handler
 // WebSocket long connection, so a public callback URL is not required.
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"log/slog"
@@ -15,11 +16,27 @@ import (
 	"strings"
 
 	"github.com/go-chi/chi/v5"
+	"github.com/jackc/pgx/v5/pgtype"
 
 	"github.com/multica-ai/multica/server/internal/integrations/wecom"
 	db "github.com/multica-ai/multica/server/pkg/db/generated"
 	"github.com/multica-ai/multica/server/pkg/protocol"
 )
+
+// wecomBodyLimit caps what either WeCom JSON endpoint will read. Both bodies
+// are a handful of short fields, and encoding/json materializes a string value
+// whole before Decode returns — so without a ceiling, one authenticated caller
+// POSTing a multi-gigabyte token string costs the API server that much RSS per
+// request.
+const wecomBodyLimit = 16 * 1024
+
+// WecomBindingRedeemer is the slice of wecom.BindingTokenService the redeem
+// endpoint drives. *wecom.BindingTokenService is the production value; the
+// interface exists so the body ceiling can be pinned in a test without a live
+// channel_binding_token table.
+type WecomBindingRedeemer interface {
+	RedeemAndBind(ctx context.Context, raw string, multicaUserID pgtype.UUID) (wecom.RedeemedBindingToken, error)
+}
 
 // WecomInstallationResponse is the wire shape for a wecom installation
 // row. The secret is NEVER included — it remains sealed on the row. BotID
@@ -140,6 +157,7 @@ func (h *Handler) RegisterWecomBYO(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	var body RegisterWecomBYORequest
+	r.Body = http.MaxBytesReader(w, r.Body, wecomBodyLimit)
 	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
 		writeError(w, http.StatusBadRequest, "invalid request body")
 		return
@@ -279,6 +297,7 @@ func (h *Handler) RedeemWecomBindingToken(w http.ResponseWriter, r *http.Request
 		return
 	}
 	var req RedeemWecomBindingTokenRequest
+	r.Body = http.MaxBytesReader(w, r.Body, wecomBodyLimit)
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 		writeError(w, http.StatusBadRequest, "invalid request body")
 		return

--- a/server/internal/handler/wecom_web_test.go
+++ b/server/internal/handler/wecom_web_test.go
@@ -1,0 +1,75 @@
+package handler
+
+// wecom_web_test.go — both WeCom JSON endpoints decoded an unbounded body.
+// encoding/json materializes a string value whole before Decode returns, so
+// one authenticated caller POSTing a multi-gigabyte token cost the API server
+// that much RSS per request.
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/jackc/pgx/v5/pgtype"
+
+	"github.com/multica-ai/multica/server/internal/integrations/wecom"
+)
+
+// fakeRedeemer records whether the handler ever got as far as the service.
+// A body the ceiling rejects must never reach it.
+type fakeRedeemer struct{ calls int }
+
+func (f *fakeRedeemer) RedeemAndBind(context.Context, string, pgtype.UUID) (wecom.RedeemedBindingToken, error) {
+	f.calls++
+	return wecom.RedeemedBindingToken{
+		WorkspaceID:    pgtype.UUID{Bytes: [16]byte{1}, Valid: true},
+		InstallationID: pgtype.UUID{Bytes: [16]byte{2}, Valid: true},
+		WecomUserID:    "T-alex",
+	}, nil
+}
+
+func redeemRequest(body string) *http.Request {
+	r := httptest.NewRequest(http.MethodPost, "/api/wecom/binding/redeem", strings.NewReader(body))
+	// requestUserID reads this header and nothing else, so the whole test
+	// runs without a database.
+	r.Header.Set("X-User-ID", "00000000-0000-0000-0000-000000000001")
+	return r
+}
+
+// TestRedeemWecomBindingTokenRefusesAnOversizedBody: the ceiling has to reject
+// before the decoder allocates, and before the token reaches the service.
+func TestRedeemWecomBindingTokenRefusesAnOversizedBody(t *testing.T) {
+	fake := &fakeRedeemer{}
+	h := &Handler{WecomBindingTokens: fake}
+
+	huge := `{"token":"` + strings.Repeat("A", wecomBodyLimit*2) + `"}`
+	w := httptest.NewRecorder()
+	h.RedeemWecomBindingToken(w, redeemRequest(huge))
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want %d", w.Code, http.StatusBadRequest)
+	}
+	if fake.calls != 0 {
+		t.Errorf("an oversized body reached the redeem service %d time(s), want 0", fake.calls)
+	}
+}
+
+// TestRedeemWecomBindingTokenAcceptsAnOrdinaryBody guards the other side: a
+// ceiling set too tight would break every real redemption, and this test is
+// what would catch that.
+func TestRedeemWecomBindingTokenAcceptsAnOrdinaryBody(t *testing.T) {
+	fake := &fakeRedeemer{}
+	h := &Handler{WecomBindingTokens: fake}
+
+	w := httptest.NewRecorder()
+	h.RedeemWecomBindingToken(w, redeemRequest(`{"token":"an-ordinary-32-byte-looking-token"}`))
+
+	if w.Code != http.StatusOK {
+		t.Errorf("status = %d, want %d (body: %s)", w.Code, http.StatusOK, w.Body.String())
+	}
+	if fake.calls != 1 {
+		t.Errorf("redeem service called %d time(s), want 1", fake.calls)
+	}
+}


### PR DESCRIPTION
## What

`RegisterWecomBYO` and `RedeemWecomBindingToken` both decode `r.Body` unbounded. `encoding/json` materializes a string value whole before `Decode` returns, so one authenticated caller POSTing a multi-gigabyte token string costs the API server that much RSS per request. No auth bypass involved — an ordinary member account reaches both endpoints.

Both bodies are now wrapped in `http.MaxBytesReader` at 16 KiB. Neither carries more than a handful of short fields: the redeem token is 32 bytes, and a bot id plus a long-connection secret is not close to the ceiling either.

## Tests

Two, and they need no database of their own — `requestUserID` reads only the `X-User-ID` header, so the redeem handler can be driven directly with a fake redeemer.

- an oversized body is refused with 400 **and never reaches the service**
- an ordinary body still gets through — this is what catches a ceiling set too tight

Deleting the two `MaxBytesReader` lines fails the first one:

```
wecom_web_test.go:52: status = 200, want 400
wecom_web_test.go:55: an oversized body reached the redeem service 1 time(s), want 0
```

## Note on the interface

`Handler.WecomBindingTokens` is retyped from `*wecom.BindingTokenService` to a small `WecomBindingRedeemer` interface so the test can supply that fake. Production wiring is unchanged — `*wecom.BindingTokenService` satisfies it, and `router.go` needed no edit.

## Related

`#6581` adds `wecom_install_web.go` with its own JSON decodes and no ceiling. If both land, `wecomBodyLimit` should be extended to those handlers too — happy to do that as a follow-up once it merges.