### PR TITLE
docs(wecom): follow the same page_description shape as Slack, Lark and DingTalk (MUL-5883)

### DIFF
--- a/packages/views/locales/en/settings.json
+++ b/packages/views/locales/en/settings.json
@@ -727,7 +727,7 @@
   },
   "wecom": {
     "section_title": "WeCom",
-    "page_description": "Connect each Multica Agent to its own WeCom smart bot. Members message the bot in WeCom and the Agent replies through a long WebSocket connection — no public callback URL is required.",
+    "page_description": "Connect each Multica Agent to its own WeCom (企业微信) smart bot. Members can DM the bot, @ it in groups, and type /issue to spin up a new Multica issue. The Agent replies over a long WebSocket connection, so no public callback URL is required.",
     "not_enabled_title": "WeCom integration not enabled",
     "not_enabled_description_prefix": "Set",
     "not_enabled_description_suffix": "on the server to enable WeCom smart-bot installations.",

--- a/packages/views/locales/ja/settings.json
+++ b/packages/views/locales/ja/settings.json
@@ -726,7 +726,7 @@
   },
   "wecom": {
     "section_title": "WeCom",
-    "page_description": "各 Multica エージェントを専用の WeCom スマートボットに接続します。WebSocket ロングコネクションで受信するため、公開コールバック URL は不要です。",
+    "page_description": "Multica の各エージェントを専用の WeCom（企业微信）スマートボットに接続します。メンバーはボットに DM を送り、グループで @ メンションし、/issue と入力して Multica の issue を作成できます。WebSocket ロングコネクションで応答するため、公開コールバック URL は不要です。",
     "not_enabled_title": "WeCom 連携が有効化されていません",
     "not_enabled_description_prefix": "サーバー側で",
     "not_enabled_description_suffix": "を設定すると WeCom スマートボットのインストールが有効になります。",

--- a/packages/views/locales/ja/settings.json
+++ b/packages/views/locales/ja/settings.json
@@ -726,7 +726,7 @@
   },
   "wecom": {
     "section_title": "WeCom",
-    "page_description": "Multica の各エージェントを専用の WeCom（企业微信）スマートボットに接続します。メンバーはボットに DM を送り、グループで @ メンションし、/issue と入力して Multica の issue を作成できます。WebSocket ロングコネクションで応答するため、公開コールバック URL は不要です。",
+    "page_description": "各 Multica エージェントを専用の WeCom (企业微信) スマートボットに接続します。メンバーはボットに DM を送り、グループで @ メンションし、/issue と入力して Multica タスクを作成できます。WebSocket ロングコネクションで応答するため、公開コールバック URL は不要です。",
     "not_enabled_title": "WeCom 連携が有効化されていません",
     "not_enabled_description_prefix": "サーバー側で",
     "not_enabled_description_suffix": "を設定すると WeCom スマートボットのインストールが有効になります。",

--- a/packages/views/locales/ko/settings.json
+++ b/packages/views/locales/ko/settings.json
@@ -831,7 +831,7 @@
   },
   "wecom": {
     "section_title": "WeCom",
-    "page_description": "각 Multica 에이전트를 전용 WeCom 스마트봇에 연결합니다. WebSocket 롱 커넥션으로 메시지를 받으므로 공개 콜백 URL이 필요 없어요.",
+    "page_description": "각 Multica 에이전트를 전용 WeCom(企业微信) 스마트 봇에 연결합니다. 멤버는 봇에게 DM을 보내고, 그룹에서 @ 멘션하고, /issue를 입력해 Multica issue를 만들 수 있어요. WebSocket 롱 커넥션으로 응답하므로 공개 콜백 URL이 필요 없어요.",
     "not_enabled_title": "WeCom 통합이 활성화되지 않았어요",
     "not_enabled_description_prefix": "서버에서",
     "not_enabled_description_suffix": "를 설정하면 WeCom 스마트봇 설치가 활성화돼요.",

--- a/packages/views/locales/ko/settings.json
+++ b/packages/views/locales/ko/settings.json
@@ -831,7 +831,7 @@
   },
   "wecom": {
     "section_title": "WeCom",
-    "page_description": "각 Multica 에이전트를 전용 WeCom(企业微信) 스마트 봇에 연결합니다. 멤버는 봇에게 DM을 보내고, 그룹에서 @ 멘션하고, /issue를 입력해 Multica issue를 만들 수 있어요. WebSocket 롱 커넥션으로 응답하므로 공개 콜백 URL이 필요 없어요.",
+    "page_description": "각 Multica 에이전트를 전용 WeCom(企业微信) 스마트봇에 연결합니다. 멤버는 봇에게 DM을 보내고, 그룹에서 @ 멘션하고, /issue를 입력해 Multica 태스크를 만들 수 있어요. WebSocket 롱 커넥션으로 응답하므로 공개 콜백 URL이 필요 없어요.",
     "not_enabled_title": "WeCom 통합이 활성화되지 않았어요",
     "not_enabled_description_prefix": "서버에서",
     "not_enabled_description_suffix": "를 설정하면 WeCom 스마트봇 설치가 활성화돼요.",

--- a/packages/views/locales/zh-Hans/settings.json
+++ b/packages/views/locales/zh-Hans/settings.json
@@ -726,7 +726,7 @@
   },
   "wecom": {
     "section_title": "企业微信",
-    "page_description": "将每个 Multica 智能体连接到专属的企业微信智能机器人。成员可私聊机器人、在群里 @ 它，或输入 /issue 直接创建 Multica issue。Agent 通过 WebSocket 长连接回复，无需公网回调地址。",
+    "page_description": "将每个 Multica 智能体连接到专属的企业微信智能机器人。成员可私聊机器人、在群里 @ 它，或输入 /issue 直接创建 Multica 任务。Agent 通过 WebSocket 长连接回复，无需公网回调地址。",
     "not_enabled_title": "企业微信集成未启用",
     "not_enabled_description_prefix": "在服务器上设置",
     "not_enabled_description_suffix": "以启用企业微信智能机器人的安装。",

--- a/packages/views/locales/zh-Hans/settings.json
+++ b/packages/views/locales/zh-Hans/settings.json
@@ -726,7 +726,7 @@
   },
   "wecom": {
     "section_title": "企业微信",
-    "page_description": "将每个 Multica 智能体连接到专属的企业微信智能机器人。成员在企业微信中与机器人对话，Agent 通过长连接实时回复——无需公网回调地址。",
+    "page_description": "将每个 Multica 智能体连接到专属的企业微信智能机器人。成员可私聊机器人、在群里 @ 它，或输入 /issue 直接创建 Multica issue。Agent 通过 WebSocket 长连接回复，无需公网回调地址。",
     "not_enabled_title": "企业微信集成未启用",
     "not_enabled_description_prefix": "在服务器上设置",
     "not_enabled_description_suffix": "以启用企业微信智能机器人的安装。",


### PR DESCRIPTION
## What

One string, four locales.

The four integration settings pages share one sentence shape — and WeCom is the only one that leaves it:

| | `page_description` (en) |
|---|---|
| **Slack** | Connect each Multica Agent to its own Slack bot. **Members can DM the bot, @mention it in a channel, and type /issue to spin up a new Multica issue.** |
| **Lark** | Connect each Multica Agent to a **Lark (飞书)** PersonalAgent Bot. **Members can DM the Bot, @ it in groups, and type /issue to spin up a new Multica issue.** |
| **DingTalk** | Connect each Multica Agent to its own DingTalk robot. **Members can DM the bot, @mention it in a group, and type /issue to spin up a new Multica issue.** |
| **WeCom** | Connect each Multica Agent to its own WeCom smart bot. Members message the bot in WeCom and the Agent replies through a long WebSocket connection — no public callback URL is required. |

The other three answer the question the admin is actually deciding on: what do members get. WeCom answers a deployment question instead — so the one page a WeCom admin lands on never mentions that members can DM the bot, @ it in a group, or type `/issue`.

Proposed:

> Connect each Multica Agent to its own WeCom (企业微信) smart bot. Members can DM the bot, @ it in groups, and type /issue to spin up a new Multica issue. The Agent replies over a long WebSocket connection, so no public callback URL is required.

The long-connection fact stays as a second sentence — it is genuinely useful and the other three have no equivalent to lose, so there is no reason to trade one for the other.

All four locales, each keeping its existing register (ja stays です・ます, ko stays 해요체).

## The parenthetical

Naming 企业微信 in the English string follows **Lark, which already writes `Lark (飞书)`** for the same reason: the admin console people copy the bot id out of is Chinese, and the parenthetical is what connects the page to the product in front of them.

## Why a separate PR

This one is about copy; #6585 fixes WeCom rendering as the same generic speech bubble glyph as Slack. Keeping them apart so a wording discussion doesn't hold up the icon.