### PR TITLE
fix(wecom): don't let a closing connection evict its own successor

### DIFF
--- a/server/internal/integrations/wecom/senders_registry.go
+++ b/server/internal/integrations/wecom/senders_registry.go
@@ -45,10 +45,26 @@ func (r *sendersRegistry) set(id pgtype.UUID, s *wsSender) {
 	r.byKey[util.UUIDToString(id)] = s
 }
 
-func (r *sendersRegistry) clear(id pgtype.UUID) {
+// clear removes this installation's entry, but only if s is still the sender
+// registered under it. A generation that is shutting down must not evict its
+// own successor: Connect installs on entry and clears on a defer, so when a
+// lease flips while the old socket is still draining, the two overlap and the
+// loser's defer runs after the winner's set. Deleting unconditionally there
+// leaves the registry empty while a healthy connection is up, and every
+// outbound push resolves to nil — the bot goes silent with nothing in the log
+// to say why, until the next reconnect happens to re-register.
+//
+// dingtalk_channel.go:74 guards the same handover with
+// `CompareAndSwap(c, nil)`; slack and lark have no registry at all because
+// their outbound is REST. WeCom was the one platform deleting unconditionally.
+func (r *sendersRegistry) clear(id pgtype.UUID, s *wsSender) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
-	delete(r.byKey, util.UUIDToString(id))
+	key := util.UUIDToString(id)
+	if cur, ok := r.byKey[key]; ok && cur != s {
+		return
+	}
+	delete(r.byKey, key)
 }
 
 // get returns the live wsSender for an installation, or nil when no

--- a/server/internal/integrations/wecom/senders_registry.go
+++ b/server/internal/integrations/wecom/senders_registry.go
@@ -2,9 +2,10 @@ package wecom
 
 // senders_registry.go — a small process-wide map from installation_id to
 // live wsSender. wecomChannel.Connect adds an entry on entry and clears it
-// on exit; OutboundReplier and wecomChannel.Send look up by installation
-// id to push aibot_send_msg over the same socket the inbound loop owns
-// (aibot has no REST outbound path; every write goes over the WebSocket).
+// on exit; OutboundReplier and Outbound look up by installation id to push
+// aibot_send_msg over the same socket the inbound loop owns (aibot has no
+// REST outbound path; every write goes over the WebSocket). wecomChannel.Send
+// is not a reader — it returns ErrSendNotSupported.
 //
 // Why a registry rather than storing the sender on wecomChannel:
 // OutboundReplier is created once at boot with the shared engine.Router

--- a/server/internal/integrations/wecom/senders_registry_test.go
+++ b/server/internal/integrations/wecom/senders_registry_test.go
@@ -1,0 +1,68 @@
+package wecom
+
+// senders_registry_test.go — Connect installs a sender on entry and clears it
+// on a defer. When a lease flips while the old socket is still draining, the
+// two generations overlap and the loser's defer runs AFTER the winner's set.
+// An unconditional delete there evicts a live connection.
+
+import (
+	"testing"
+
+	"github.com/jackc/pgx/v5/pgtype"
+)
+
+func registryUUID(b byte) pgtype.UUID { return pgtype.UUID{Bytes: [16]byte{b}, Valid: true} }
+
+// TestClearDoesNotEvictASuccessor is the handover: generation 2 takes the
+// installation over, then generation 1's deferred clear finally runs. The
+// registry must still hold generation 2.
+func TestClearDoesNotEvictASuccessor(t *testing.T) {
+	reg := newSendersRegistry()
+	id := registryUUID(1)
+
+	first := newWSSender(&recordingConn{}, nil)
+	second := newWSSender(&recordingConn{}, nil)
+
+	reg.set(id, first)
+	reg.set(id, second) // the lease moved; a new connection took over
+
+	reg.clear(id, first) // generation 1's defer, running late
+
+	got := reg.get(id)
+	if got == nil {
+		t.Fatal("the successor was evicted by its predecessor's deferred clear — every outbound push now resolves to nil and the bot is silent")
+	}
+	if got != second {
+		t.Fatalf("registry holds the wrong sender after handover")
+	}
+}
+
+// TestClearRemovesItsOwnSender is the ordinary path, and the reason the fence
+// cannot simply be "never delete": a connection that really is going away has
+// to leave, or the registry hands out a sender whose socket is dead.
+func TestClearRemovesItsOwnSender(t *testing.T) {
+	reg := newSendersRegistry()
+	id := registryUUID(1)
+
+	only := newWSSender(&recordingConn{}, nil)
+	reg.set(id, only)
+	reg.clear(id, only)
+
+	if got := reg.get(id); got != nil {
+		t.Fatal("a sender that owned the slot was not removed; outbound would be dispatched to a dead socket")
+	}
+}
+
+// TestClearOfAnUnknownInstallationIsANoop: a Connect that fails before set
+// still runs its defer.
+func TestClearOfAnUnknownInstallationIsANoop(t *testing.T) {
+	reg := newSendersRegistry()
+	live := newWSSender(&recordingConn{}, nil)
+	reg.set(registryUUID(1), live)
+
+	reg.clear(registryUUID(2), newWSSender(&recordingConn{}, nil))
+
+	if got := reg.get(registryUUID(1)); got != live {
+		t.Fatal("clearing an unrelated installation disturbed a live one")
+	}
+}

--- a/server/internal/integrations/wecom/wecom_channel.go
+++ b/server/internal/integrations/wecom/wecom_channel.go
@@ -167,7 +167,7 @@ func (c *wecomChannel) Connect(ctx context.Context) error {
 	// on exit so a stale sender for a dead connection is never dispatched to.
 	if c.senders != nil && c.installationID.Valid {
 		c.senders.set(c.installationID, sender)
-		defer c.senders.clear(c.installationID)
+		defer c.senders.clear(c.installationID, sender)
 	}
 
 	// Heartbeat — WeCom kills silent sockets past ~90s. We ping every 30s

--- a/server/internal/integrations/wecom/wecom_channel.go
+++ b/server/internal/integrations/wecom/wecom_channel.go
@@ -405,11 +405,10 @@ type ChannelDeps struct {
 	Credentials CredentialsResolver
 	Logger      *slog.Logger
 
-	// Senders is the package-level installation→wsSender registry. The
-	// OutboundReplier and the wecomChannel.Send path both look up the live
-	// wsSender through it. Boot passes ONE registry instance shared with
-	// the OutboundReplier constructor. Nil in tests that don't exercise
-	// outbound.
+	// Senders is the package-level installation→wsSender registry.
+	// OutboundReplier and Outbound both look up the live wsSender through
+	// it. Boot passes ONE registry instance shared with the OutboundReplier
+	// constructor. Nil in tests that don't exercise outbound.
 	Senders *sendersRegistry
 
 	// Dialer overrides the default gorilla dialer. Tests point it at an

--- a/server/internal/integrations/wecom/ws_sender.go
+++ b/server/internal/integrations/wecom/ws_sender.go
@@ -97,7 +97,7 @@ func (s *wsSender) write(frame map[string]any) error {
 // sendText pushes an aibot_send_msg (proactive push) with plain text to a
 // specific chat. Callers pass channel.ChatType so the aibot chat_type int
 // (1=single, 2=group) is decided at the wecom-side boundary, not the
-// engine's. Used by wecomChannel.Send and OutboundReplier.
+// engine's. Used by OutboundReplier and Outbound.
 func (s *wsSender) sendText(chatID string, chatTypeInt int, content string) error {
 	body, err := sendMsgTextBody(chatID, chatTypeInt, content)
 	if err != nil {


### PR DESCRIPTION
## What

`sendersRegistry.clear` deletes the installation's entry unconditionally. `Connect` installs the sender on entry and clears it on a `defer`, so when a lease flips while the old socket is still draining, the two generations overlap and the **loser's defer runs after the winner's `set`**.

The registry then holds nothing while a perfectly healthy connection is up. `OutboundReplier` and `wecomChannel.Send` both resolve through `get`, so every outbound push returns nil and the bot goes silent — with nothing in the log to explain it, because the losing generation did exactly what it was told. It stays that way until the next reconnect happens to re-register.

`clear` now takes the sender doing the clearing and only deletes if that sender still owns the slot.

## Precedent

This is the one platform that didn't fence it:

- **DingTalk** — `dingtalk_channel.go:74` guards the same handover with `defer c.slot.current.CompareAndSwap(c, nil)`
- **Slack / Lark** — no registry at all; `Disconnect` is a no-op because their outbound is REST
- **WeCom** — `delete(r.byKey, ...)`, unconditional

## Tests

Three, no database needed.

- a predecessor's late `clear` leaves the successor in place — **fails on the old code**: `the successor was evicted by its predecessor's deferred clear — every outbound push now resolves to nil and the bot is silent`
- a sender that *does* own the slot is still removed. The fence can't be "never delete", or outbound gets dispatched to a dead socket, and this test is what pins that
- clearing an unknown installation disturbs nothing

## Why it gets worse with #6581

Under that PR `queueSender.Send` resolves `s.senders.get(row.InstallationID)` per row and returns `DispositionRetry` on nil. So a stale clear stops being "replies vanish" and becomes "every queued row for this installation retries until the backoff gives up" — the same silence, now with the queue's retry budget burning behind it.