### PR TITLE
MUL-5888: fix(wecom): answer a duplicate /issue honestly, and don't push a web-UI reply into the room

### DIFF
--- a/server/internal/integrations/wecom/outbound.go
+++ b/server/internal/integrations/wecom/outbound.go
@@ -34,6 +34,7 @@ import (
 
 	"github.com/multica-ai/multica/server/internal/events"
 	"github.com/multica-ai/multica/server/internal/integrations/channel"
+	"github.com/multica-ai/multica/server/internal/integrations/channel/engine"
 	"github.com/multica-ai/multica/server/internal/util"
 	db "github.com/multica-ai/multica/server/pkg/db/generated"
 	"github.com/multica-ai/multica/server/pkg/protocol"
@@ -43,6 +44,8 @@ import (
 // subscriber needs. *db.Queries satisfies it.
 type outboundQueries interface {
 	GetChannelChatSessionBindingBySession(ctx context.Context, arg db.GetChannelChatSessionBindingBySessionParams) (db.ChannelChatSessionBinding, error)
+	GetAgentTask(ctx context.Context, id pgtype.UUID) (db.AgentTaskQueue, error)
+	TaskHasChannelIngestedMessages(ctx context.Context, taskID pgtype.UUID) (bool, error)
 	GetChannelInstallation(ctx context.Context, arg db.GetChannelInstallationParams) (db.ChannelInstallation, error)
 	FindChannelBindingForMember(ctx context.Context, arg db.FindChannelBindingForMemberParams) (db.ChannelUserBinding, error)
 	GetWorkspace(ctx context.Context, id pgtype.UUID) (db.Workspace, error)
@@ -109,6 +112,39 @@ func (o *Outbound) processEvent(ctx context.Context, e events.Event) error {
 	if content == "" {
 		return nil // nothing to say (empty completion)
 	}
+	// Only bound, non-empty completions reach here, so classify the task
+	// origin before loading credentials or sending. A question asked in the
+	// Multica web UI can reuse a session that originated in WeCom — and its
+	// answer belongs only in Multica. Without this gate that answer is pushed
+	// into the WeCom chat, which in a group means in front of everyone in the
+	// room. slack/outbound.go:118 and the lark and dingtalk equivalents all
+	// gate here; WeCom was the one that did not.
+	//
+	// Fails closed: an origin we cannot establish is not delivered.
+	//
+	// Everything above this point is a read. Keep it that way: the gate has to
+	// stay ahead of anything that consumes or mutates WeCom-side state for the
+	// turn, because an answer that must not reach the room must not take over
+	// the room's message either.
+	taskID, ok := chatDoneTaskID(e)
+	if !ok {
+		return nil
+	}
+	task, err := o.q.GetAgentTask(ctx, taskID)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			// Cancelled and deleted while its completion was in flight.
+			return nil
+		}
+		return fmt.Errorf("wecom: load agent task: %w", err)
+	}
+	deliver, err := engine.TaskInputIsChannelIngested(ctx, o.q, task)
+	if err != nil {
+		return fmt.Errorf("wecom: classify task input origin: %w", err)
+	}
+	if !deliver {
+		return nil
+	}
 	inst, err := o.q.GetChannelInstallation(ctx, db.GetChannelInstallationParams{
 		ID:          binding.InstallationID,
 		ChannelType: channelTypeWecom,
@@ -137,6 +173,24 @@ func (o *Outbound) processEvent(ctx context.Context, e events.Event) error {
 	}
 	chatType := aibotChatTypeFromChannel(channel.ChatType(binding.ChatType))
 	return sender.sendTextCtx(ctx, binding.ChannelChatID, chatType, content)
+}
+
+// chatDoneTaskID recovers the task id an EventChatDone belongs to. The
+// envelope's TaskID is preferred, with the payload as the fallback —
+// service.broadcastChatDone sets ChatDonePayload.TaskID and leaves the
+// envelope's empty, so in practice the fallback is the live path.
+func chatDoneTaskID(e events.Event) (pgtype.UUID, bool) {
+	raw := e.TaskID
+	if raw == "" {
+		switch p := e.Payload.(type) {
+		case protocol.ChatDonePayload:
+			raw = p.TaskID
+		case map[string]any:
+			raw, _ = p["task_id"].(string)
+		}
+	}
+	id, err := util.ParseUUID(raw)
+	return id, err == nil && id.Valid
 }
 
 // chatDoneContent extracts the reply text from an EventChatDone payload

--- a/server/internal/integrations/wecom/outbound_test.go
+++ b/server/internal/integrations/wecom/outbound_test.go
@@ -37,6 +37,24 @@ type fakeOutboundQueries struct {
 	memberErr      error
 	workspace      db.Workspace
 	workspaceErr   error
+
+	// channelIngested is what TaskInputIsChannelIngested resolves to. The
+	// default is false — a task nobody said came from WeCom did not — so a
+	// test that expects delivery has to say so, the same way production has
+	// to prove it before pushing into somebody's chat.
+	channelIngested bool
+	taskErr         error
+}
+
+func (f *fakeOutboundQueries) GetAgentTask(context.Context, pgtype.UUID) (db.AgentTaskQueue, error) {
+	if f.taskErr != nil {
+		return db.AgentTaskQueue{}, f.taskErr
+	}
+	return db.AgentTaskQueue{ChatInputTaskID: pgtype.UUID{Bytes: [16]byte{9}, Valid: true}}, nil
+}
+
+func (f *fakeOutboundQueries) TaskHasChannelIngestedMessages(context.Context, pgtype.UUID) (bool, error) {
+	return f.channelIngested, nil
 }
 
 func (f *fakeOutboundQueries) GetChannelChatSessionBindingBySession(context.Context, db.GetChannelChatSessionBindingBySessionParams) (db.ChannelChatSessionBinding, error) {
@@ -64,8 +82,9 @@ func newOutboundWithConn(t *testing.T, q outboundQueries) (*Outbound, pgtype.UUI
 func TestProcessEvent_DeliversChatReplyToBoundChat(t *testing.T) {
 	t.Parallel()
 	q := &fakeOutboundQueries{
-		sessionBinding: db.ChannelChatSessionBinding{ChannelChatID: "CHAT_1", ChatType: "group"},
-		installation:   db.ChannelInstallation{Status: string(InstallationActive)},
+		sessionBinding:  db.ChannelChatSessionBinding{ChannelChatID: "CHAT_1", ChatType: "group"},
+		installation:    db.ChannelInstallation{Status: string(InstallationActive)},
+		channelIngested: true, // the question came in over WeCom
 	}
 	o, instID, conn := newOutboundWithConn(t, q)
 	q.sessionBinding.InstallationID = instID
@@ -73,7 +92,10 @@ func TestProcessEvent_DeliversChatReplyToBoundChat(t *testing.T) {
 
 	err := o.processEvent(context.Background(), events.Event{
 		ChatSessionID: "22222222-2222-2222-2222-222222222222",
-		Payload:       protocol.ChatDonePayload{Content: "the agent reply"},
+		Payload: protocol.ChatDonePayload{
+			Content: "the agent reply",
+			TaskID:  "33333333-3333-3333-3333-333333333333",
+		},
 	})
 	if err != nil {
 		t.Fatalf("processEvent: %v", err)
@@ -201,5 +223,68 @@ func TestChatDoneContent(t *testing.T) {
 	}
 	if got := chatDoneContent(json.RawMessage(`{}`)); got != "" {
 		t.Errorf("unknown payload type = %q, want empty", got)
+	}
+}
+
+// TestProcessEvent_DoesNotPushAWebUIAnswerIntoTheRoom is the privacy case. A
+// session that originated in WeCom can be continued from the Multica web UI,
+// and that answer belongs only in Multica. Without the origin gate it is
+// pushed to the bound chat — which in a group means in front of everyone in
+// the room, an answer to a question none of them saw asked.
+func TestProcessEvent_DoesNotPushAWebUIAnswerIntoTheRoom(t *testing.T) {
+	t.Parallel()
+	q := &fakeOutboundQueries{
+		sessionBinding:  db.ChannelChatSessionBinding{ChannelChatID: "CHAT_1", ChatType: "group"},
+		installation:    db.ChannelInstallation{Status: string(InstallationActive)},
+		channelIngested: false, // asked in the web UI, not over WeCom
+	}
+	o, instID, conn := newOutboundWithConn(t, q)
+	q.sessionBinding.InstallationID = instID
+	q.installation.ID = instID
+
+	err := o.processEvent(context.Background(), events.Event{
+		ChatSessionID: "22222222-2222-2222-2222-222222222222",
+		Payload: protocol.ChatDonePayload{
+			Content: "something the room was never meant to read",
+			TaskID:  "33333333-3333-3333-3333-333333333333",
+		},
+	})
+	if err != nil {
+		t.Fatalf("processEvent: %v", err)
+	}
+	conn.mu.Lock()
+	n := len(conn.frames)
+	conn.mu.Unlock()
+	if n != 0 {
+		t.Fatalf("a web-UI answer was pushed into the WeCom chat (%d frame(s) written)", n)
+	}
+}
+
+// An origin that cannot be established must fail closed — silence is
+// recoverable, a leak is not.
+func TestProcessEvent_FailsClosedWhenTheTaskIdIsMissing(t *testing.T) {
+	t.Parallel()
+	q := &fakeOutboundQueries{
+		sessionBinding:  db.ChannelChatSessionBinding{ChannelChatID: "CHAT_1", ChatType: "group"},
+		installation:    db.ChannelInstallation{Status: string(InstallationActive)},
+		channelIngested: true,
+	}
+	o, instID, conn := newOutboundWithConn(t, q)
+	q.sessionBinding.InstallationID = instID
+	q.installation.ID = instID
+
+	// No TaskID anywhere: the envelope's is empty and the payload carries none.
+	err := o.processEvent(context.Background(), events.Event{
+		ChatSessionID: "22222222-2222-2222-2222-222222222222",
+		Payload:       protocol.ChatDonePayload{Content: "unattributable"},
+	})
+	if err != nil {
+		t.Fatalf("processEvent: %v", err)
+	}
+	conn.mu.Lock()
+	n := len(conn.frames)
+	conn.mu.Unlock()
+	if n != 0 {
+		t.Fatalf("delivered a completion whose origin could not be established (%d frame(s))", n)
 	}
 }

--- a/server/internal/integrations/wecom/outbound_test.go
+++ b/server/internal/integrations/wecom/outbound_test.go
@@ -20,11 +20,12 @@ import (
 	"github.com/jackc/pgx/v5/pgtype"
 
 	"github.com/multica-ai/multica/server/internal/events"
+	"github.com/multica-ai/multica/server/internal/util"
 	db "github.com/multica-ai/multica/server/pkg/db/generated"
 	"github.com/multica-ai/multica/server/pkg/protocol"
 )
 
-// fakeOutboundQueries is an in-memory stand-in for the four queries Outbound
+// fakeOutboundQueries is an in-memory stand-in for the queries Outbound
 // uses. A nil error field returns the row; a non-nil one is returned as-is
 // (use pgx.ErrNoRows to exercise the "not a wecom session" / "no binding"
 // branches).
@@ -37,25 +38,41 @@ type fakeOutboundQueries struct {
 	memberErr      error
 	workspace      db.Workspace
 	workspaceErr   error
-
-	// channelIngested is what TaskInputIsChannelIngested resolves to. The
-	// default is false — a task nobody said came from WeCom did not — so a
-	// test that expects delivery has to say so, the same way production has
-	// to prove it before pushing into somebody's chat.
-	channelIngested bool
-	taskErr         error
+	// tasks answers the retry-clone lookup: the round is bound under the turn
+	// that owns the input batch, and a clone reaches it through
+	// chat_input_task_id. A task with no row here reads as pgx.ErrNoRows —
+	// cancelled and reaped while its ending was in flight.
+	tasks    map[string]db.AgentTaskQueue
+	taskErr  error
+	taskGets int
+	// channelIngested is the channel_ingested stamp on the input batch the
+	// task owns: askedOverWecom for a question typed in the room,
+	// askedInTheWebUI for one typed in Multica.
+	//
+	// It is a pointer, and it has no default on purpose. Two gates read this
+	// one stamp in opposite directions — the answer path delivers only when it
+	// is set, and the failure-notice path #6606 adds delivers unless it is — so
+	// either zero value would let one of them pass a test that never said where
+	// the question came from. Left unset the fake ends the test naming the
+	// omission, which is what keeps this rig usable by whichever of the two
+	// lands second.
+	//
+	// originAskedFor records which id the stamp was read for, which is the
+	// whole of the retry-clone question.
+	channelIngested *bool
+	originErr       error
+	originAskedFor  []string
+	// t is who an unset stamp is reported to. fileTask sets it, and a filed
+	// row is the only route to the origin gate, so it is always there by the
+	// time the gate reads.
+	t testing.TB
 }
 
-func (f *fakeOutboundQueries) GetAgentTask(context.Context, pgtype.UUID) (db.AgentTaskQueue, error) {
-	if f.taskErr != nil {
-		return db.AgentTaskQueue{}, f.taskErr
-	}
-	return db.AgentTaskQueue{ChatInputTaskID: pgtype.UUID{Bytes: [16]byte{9}, Valid: true}}, nil
-}
-
-func (f *fakeOutboundQueries) TaskHasChannelIngestedMessages(context.Context, pgtype.UUID) (bool, error) {
-	return f.channelIngested, nil
-}
+// askedOverWecom and askedInTheWebUI are the two answers to "where was this
+// question asked". One of them belongs in every rig whose run reaches the
+// origin gate; there is no third answer and no default.
+func askedOverWecom() *bool  { asked := true; return &asked }
+func askedInTheWebUI() *bool { asked := false; return &asked }
 
 func (f *fakeOutboundQueries) GetChannelChatSessionBindingBySession(context.Context, db.GetChannelChatSessionBindingBySessionParams) (db.ChannelChatSessionBinding, error) {
 	return f.sessionBinding, f.sessionErr
@@ -69,6 +86,83 @@ func (f *fakeOutboundQueries) FindChannelBindingForMember(context.Context, db.Fi
 func (f *fakeOutboundQueries) GetWorkspace(context.Context, pgtype.UUID) (db.Workspace, error) {
 	return f.workspace, f.workspaceErr
 }
+func (f *fakeOutboundQueries) GetAgentTask(_ context.Context, id pgtype.UUID) (db.AgentTaskQueue, error) {
+	f.taskGets++
+	if f.taskErr != nil {
+		return db.AgentTaskQueue{}, f.taskErr
+	}
+	task, ok := f.tasks[util.UUIDToString(id)]
+	if !ok {
+		return db.AgentTaskQueue{}, pgx.ErrNoRows
+	}
+	return task, nil
+}
+func (f *fakeOutboundQueries) TaskHasChannelIngestedMessages(_ context.Context, taskID pgtype.UUID) (bool, error) {
+	f.originAskedFor = append(f.originAskedFor, util.UUIDToString(taskID))
+	if f.originErr != nil {
+		return false, f.originErr
+	}
+	if f.channelIngested == nil {
+		f.failStampNotSet(util.UUIDToString(taskID))
+		return false, nil // unreachable: failStampNotSet ends the test
+	}
+	return *f.channelIngested, nil
+}
+
+// failStampNotSet ends the test naming what the rig left out, instead of
+// letting a zero value answer for it three layers away.
+//
+// It has to be t.Fatalf rather than a panic: the failure path arrives here
+// through events.Bus.Publish, which recovers panics in listeners and logs
+// them, so a panic would be swallowed and the test would fail on an assertion
+// that says nothing about what was missing. Fatalf's runtime.Goexit is not
+// recoverable, so it survives the bus.
+func (f *fakeOutboundQueries) failStampNotSet(taskID string) {
+	msg := "fakeOutboundQueries: the origin gate read the channel_ingested stamp for task " +
+		taskID + ", but this rig never set channelIngested. Say where the question was asked: " +
+		"channelIngested: askedOverWecom() for one typed in the room, askedInTheWebUI() for one " +
+		"typed in Multica. There is no default — the answer path delivers only when the stamp is " +
+		"set and the failure path delivers unless it is, so either zero value would let one of " +
+		"those two pass a test that never stated what it meant."
+	if f.t == nil {
+		panic(msg)
+	}
+	f.t.Fatalf("%s", msg)
+}
+
+// fileTask records the agent_task_queue row GetAgentTask answers with, for a
+// task that owns its own input batch — which every chat round's task has done
+// since MUL-4351. id is the task id the ending event carries.
+func (f *fakeOutboundQueries) fileTask(t testing.TB, id string) {
+	t.Helper()
+	f.fileRetryClone(t, id, id)
+}
+
+// fileRetryClone files FailTask's retry child: a fresh task id inheriting the
+// parent's input batch, its own id owning nothing. This is the row that makes
+// the batch owner the only id worth asking the stamp about.
+func (f *fakeOutboundQueries) fileRetryClone(t testing.TB, id, owner string) {
+	t.Helper()
+	f.t = t
+	taskID := mustParseTaskUUID(t, id)
+	ownerID := mustParseTaskUUID(t, owner)
+	if f.tasks == nil {
+		f.tasks = map[string]db.AgentTaskQueue{}
+	}
+	f.tasks[util.UUIDToString(taskID)] = db.AgentTaskQueue{ID: taskID, ChatInputTaskID: ownerID}
+}
+
+func mustParseTaskUUID(t testing.TB, id string) pgtype.UUID {
+	t.Helper()
+	parsed, err := util.ParseUUID(id)
+	if err != nil || !parsed.Valid {
+		t.Fatalf("parse task id %q: %v", id, err)
+	}
+	return parsed
+}
+
+// originAsked is the ids the provenance stamp was read for, in order.
+func (f *fakeOutboundQueries) originAsked() []string { return f.originAskedFor }
 
 func newOutboundWithConn(t *testing.T, q outboundQueries) (*Outbound, pgtype.UUID, *recordingConn) {
 	t.Helper()
@@ -84,8 +178,9 @@ func TestProcessEvent_DeliversChatReplyToBoundChat(t *testing.T) {
 	q := &fakeOutboundQueries{
 		sessionBinding:  db.ChannelChatSessionBinding{ChannelChatID: "CHAT_1", ChatType: "group"},
 		installation:    db.ChannelInstallation{Status: string(InstallationActive)},
-		channelIngested: true, // the question came in over WeCom
+		channelIngested: askedOverWecom(), // the question came in over WeCom
 	}
+	q.fileTask(t, "33333333-3333-3333-3333-333333333333")
 	o, instID, conn := newOutboundWithConn(t, q)
 	q.sessionBinding.InstallationID = instID
 	q.installation.ID = instID
@@ -138,16 +233,28 @@ func TestProcessEvent_EmptyContentIsNoop(t *testing.T) {
 	}
 }
 
+// The origin gate now runs ahead of the installation lookup, so a completion
+// has to carry a task id AND a WeCom origin to reach the revocation check at
+// all. Without both, this test passes on the gate's refusal and never
+// exercises the branch it is named after.
 func TestProcessEvent_RevokedInstallationIsNoop(t *testing.T) {
 	t.Parallel()
 	q := &fakeOutboundQueries{
-		sessionBinding: db.ChannelChatSessionBinding{ChannelChatID: "CHAT_1"},
-		installation:   db.ChannelInstallation{Status: "revoked"},
+		sessionBinding:  db.ChannelChatSessionBinding{ChannelChatID: "CHAT_1"},
+		installation:    db.ChannelInstallation{Status: "revoked"},
+		channelIngested: askedOverWecom(), // so revocation is the only thing left to stop it
 	}
+	q.fileTask(t, "33333333-3333-3333-3333-333333333333")
 	o, instID, conn := newOutboundWithConn(t, q)
 	q.sessionBinding.InstallationID = instID
 	q.installation.ID = instID
-	if err := o.processEvent(context.Background(), events.Event{ChatSessionID: "22222222-2222-2222-2222-222222222222", Payload: protocol.ChatDonePayload{Content: "hi"}}); err != nil {
+	if err := o.processEvent(context.Background(), events.Event{
+		ChatSessionID: "22222222-2222-2222-2222-222222222222",
+		Payload: protocol.ChatDonePayload{
+			Content: "hi",
+			TaskID:  "33333333-3333-3333-3333-333333333333",
+		},
+	}); err != nil {
 		t.Fatalf("processEvent: %v", err)
 	}
 	if len(conn.frames) != 0 {
@@ -236,8 +343,9 @@ func TestProcessEvent_DoesNotPushAWebUIAnswerIntoTheRoom(t *testing.T) {
 	q := &fakeOutboundQueries{
 		sessionBinding:  db.ChannelChatSessionBinding{ChannelChatID: "CHAT_1", ChatType: "group"},
 		installation:    db.ChannelInstallation{Status: string(InstallationActive)},
-		channelIngested: false, // asked in the web UI, not over WeCom
+		channelIngested: askedInTheWebUI(), // asked in the web UI, not over WeCom
 	}
+	q.fileTask(t, "33333333-3333-3333-3333-333333333333")
 	o, instID, conn := newOutboundWithConn(t, q)
 	q.sessionBinding.InstallationID = instID
 	q.installation.ID = instID
@@ -265,9 +373,13 @@ func TestProcessEvent_DoesNotPushAWebUIAnswerIntoTheRoom(t *testing.T) {
 func TestProcessEvent_FailsClosedWhenTheTaskIdIsMissing(t *testing.T) {
 	t.Parallel()
 	q := &fakeOutboundQueries{
-		sessionBinding:  db.ChannelChatSessionBinding{ChannelChatID: "CHAT_1", ChatType: "group"},
-		installation:    db.ChannelInstallation{Status: string(InstallationActive)},
-		channelIngested: true,
+		sessionBinding: db.ChannelChatSessionBinding{ChannelChatID: "CHAT_1", ChatType: "group"},
+		installation:   db.ChannelInstallation{Status: string(InstallationActive)},
+		// Stamped as a WeCom question, and deliberately so: the gate would say
+		// deliver if it were ever consulted. Nothing here is refused for want
+		// of a permissive origin — it is refused for want of an id to ask
+		// about. No task row is filed, because there is no id to file one under.
+		channelIngested: askedOverWecom(),
 	}
 	o, instID, conn := newOutboundWithConn(t, q)
 	q.sessionBinding.InstallationID = instID

--- a/server/internal/integrations/wecom/replier.go
+++ b/server/internal/integrations/wecom/replier.go
@@ -119,9 +119,21 @@ func (r *OutboundReplier) Reply(ctx context.Context, inst engine.ResolvedInstall
 		// chat message stays silent (the agent's own reply lands via
 		// EventChatDone / Channel.Send).
 		if res.IssueID.Valid {
-			if err := r.post(ctx, inst, msg, issueCreatedText(res)); err != nil {
-				r.logger.WarnContext(ctx, "wecom replier: issue-created confirmation failed",
-					"installation_id", util.UUIDToString(inst.ID), "error", err)
+			// The engine reports a duplicate by carrying the OTHER issue's
+			// id, number and title with IssueDuplicate set. Answering both
+			// cases with the created copy told the reporter their bug was
+			// filed under a number somebody else opened, under a title they
+			// never wrote — so they stopped chasing it and the report was
+			// lost. slack/replier.go:125 and dingtalk/replier.go:125 both
+			// branch here; WeCom was the one that did not.
+			text := issueCreatedText(res)
+			if res.IssueDuplicate {
+				text = issueDuplicateText(res)
+			}
+			if err := r.post(ctx, inst, msg, text); err != nil {
+				r.logger.WarnContext(ctx, "wecom replier: issue confirmation failed",
+					"installation_id", util.UUIDToString(inst.ID),
+					"duplicate", res.IssueDuplicate, "error", err)
 			}
 		}
 	}
@@ -224,6 +236,29 @@ func (r *OutboundReplier) post(ctx context.Context, inst engine.ResolvedInstalla
 	}
 	chatType := aibotChatTypeFromChannel(msg.Source.ChatType)
 	return sender.sendTextCtx(ctx, chatID, chatType, text)
+}
+
+// issueDuplicateText answers a /issue the engine refused because an active
+// issue already covers it. It names the OTHER issue, which is the whole point:
+// the reporter needs to know where the discussion already is, not to be handed
+// an id they will read as their own.
+//
+// That title belongs to the pre-existing issue, so it is text some *other*
+// member wrote — not even the reporter's own, which is what makes this the
+// worse of the two /issue call sites — and the reply ships as markdown. Hence
+// breakMemberLinks, the same entry point issueCreatedText runs its title
+// through: it breaks the inline "](" form and the link reference definition a
+// multi-line title can smuggle instead. See markdown.go.
+func issueDuplicateText(res engine.Result) string {
+	id := res.IssueIdentifier
+	if id == "" {
+		id = fmt.Sprintf("#%d", res.IssueNumber)
+	}
+	title := breakMemberLinks(strings.TrimSpace(res.IssueTitle))
+	if title == "" {
+		return "⚠️ 未创建 —— 已存在进行中的 " + id
+	}
+	return "⚠️ 未创建 —— 已存在进行中的 " + id + " — " + title
 }
 
 func issueCreatedText(res engine.Result) string {

--- a/server/internal/integrations/wecom/replier_test.go
+++ b/server/internal/integrations/wecom/replier_test.go
@@ -419,3 +419,120 @@ func TestIssueConfirmationKeepsAnOrdinaryTitleVerbatim(t *testing.T) {
 		}
 	}
 }
+
+// TestIssueDuplicateIsNotReportedAsCreated: when the engine refuses a /issue
+// because an active issue already covers it, it carries the OTHER issue's id,
+// number and title. Answering with the created copy tells the reporter their
+// bug was filed under a number somebody else opened, under a title they never
+// wrote — so they stop chasing it and the report is lost.
+func TestIssueDuplicateIsNotReportedAsCreated(t *testing.T) {
+	t.Parallel()
+	res := engine.Result{
+		IssueID:         pgtype.UUID{Bytes: [16]byte{7}, Valid: true},
+		IssueIdentifier: "MUL-99",
+		IssueTitle:      "somebody else's title",
+		IssueDuplicate:  true,
+	}
+	text := issueCreatedText(res)
+	if res.IssueDuplicate {
+		text = issueDuplicateText(res)
+	}
+	if strings.Contains(text, "已创建") {
+		t.Errorf("a duplicate was reported as created: %q", text)
+	}
+	if !strings.Contains(text, "MUL-99") {
+		t.Errorf("the duplicate reply does not name the issue that already exists: %q", text)
+	}
+}
+
+// TestIssueDuplicateTitleCannotFormALinkInTheRoom drives the real Reply path so
+// the assertion lands on the bytes that go out on the wire. The duplicate
+// branch names the OTHER issue, so the title it quotes was written by whoever
+// opened that issue, and sendMsgTextBody ships every aibot_send_msg as
+// "msgtype": "markdown" — a title carrying "](" would otherwise arrive in the
+// group as a working link with the bot's authority behind it.
+//
+// The assertion is on the adjacency, not on the URL: "](" is what both
+// CommonMark and the naive rewriters need to build a link, and it is what
+// breakMemberLinks removes here. The title's own words must survive — a guard
+// that dropped the title would pass a "no link" check while losing the
+// information the reply exists to carry.
+func TestIssueDuplicateTitleCannotFormALinkInTheRoom(t *testing.T) {
+	t.Parallel()
+	const hostileTitle = "安全升级：请点击 [重置密码](https://evil.example) 完成验证"
+
+	r, inst, conn := newReplierWithConn(t)
+	r.Reply(context.Background(), inst,
+		channel.InboundMessage{Source: channel.Source{ChatID: "GROUP_CHAT_ID", ChatType: channel.ChatTypeGroup}},
+		engine.Result{
+			Outcome:         engine.OutcomeIngested,
+			IssueID:         pgtype.UUID{Bytes: [16]byte{7}, Valid: true},
+			IssueIdentifier: "MUL-99",
+			IssueTitle:      hostileTitle,
+			IssueDuplicate:  true,
+		})
+
+	conn.mu.Lock()
+	n := len(conn.frames)
+	conn.mu.Unlock()
+	if n != 1 {
+		t.Fatalf("expected one duplicate-confirmation frame, got %d", n)
+	}
+	body := conn.sendBody(t, 0)
+	md, _ := body["markdown"].(map[string]any)
+	content, _ := md["content"].(string)
+	if content == "" {
+		t.Fatalf("no markdown content in the duplicate confirmation: %v", body)
+	}
+	if strings.Contains(content, "](") {
+		t.Errorf("a member-authored title formed a working markdown link in the room: %q", content)
+	}
+	if !strings.Contains(content, "MUL-99") {
+		t.Errorf("the duplicate reply does not name the issue that already exists: %q", content)
+	}
+	if !strings.Contains(content, "重置密码") || !strings.Contains(content, "https://evil.example") {
+		t.Errorf("the guard dropped the title instead of breaking the link: %q", content)
+	}
+}
+
+// TestIssueDuplicateTitleDefinesNoLinkReference pins the half of the guard the
+// "](" assertion above cannot see. A title carrying line breaks can *define*
+// the link rather than write it inline, and that attack holds no "](" anywhere
+// — so the duplicate path has to run the title through breakMemberLinks, not
+// through breakLinkAdjacency alone. Wiring it back to the adjacency break by
+// itself would leave the test above passing and this one failing, which is the
+// point of having both.
+func TestIssueDuplicateTitleDefinesNoLinkReference(t *testing.T) {
+	t.Parallel()
+	const hostileTitle = "安全升级\n\n[重置密码]: https://evil.example\n\n[重置密码]"
+
+	r, inst, conn := newReplierWithConn(t)
+	r.Reply(context.Background(), inst,
+		channel.InboundMessage{Source: channel.Source{ChatID: "GROUP_CHAT_ID", ChatType: channel.ChatTypeGroup}},
+		engine.Result{
+			Outcome:         engine.OutcomeIngested,
+			IssueID:         pgtype.UUID{Bytes: [16]byte{7}, Valid: true},
+			IssueIdentifier: "MUL-99",
+			IssueTitle:      hostileTitle,
+			IssueDuplicate:  true,
+		})
+
+	conn.mu.Lock()
+	n := len(conn.frames)
+	conn.mu.Unlock()
+	if n != 1 {
+		t.Fatalf("expected one duplicate-confirmation frame, got %d", n)
+	}
+	body := conn.sendBody(t, 0)
+	md, _ := body["markdown"].(map[string]any)
+	content, _ := md["content"].(string)
+	if content == "" {
+		t.Fatalf("no markdown content in the duplicate confirmation: %v", body)
+	}
+	if dests := markdownDestinations(content); hasDestinationTo(dests, "evil.example") {
+		t.Errorf("a member-authored title defined a link the room's bot then resolved: %q resolves %v", content, dests)
+	}
+	if !strings.Contains(content, "重置密码") {
+		t.Errorf("the guard dropped the title instead of breaking the definition: %q", content)
+	}
+}


### PR DESCRIPTION
Two things WeCom is the only integration not doing. Both signals are already on `main`; the adapter just never read them.

## 1. A duplicate `/issue` is reported as created

The engine refuses a duplicate by carrying the **other** issue's id, number and title with `IssueDuplicate` set. `Reply` answers both outcomes with `issueCreatedText`, so the reporter is told their bug was filed — under a number somebody else opened, under a title they never wrote.

The failure is quiet and expensive: they stop chasing it, and the report is lost. Nobody finds out, because from their side it looks like it worked.

| | |
|---|---|
| `slack/replier.go:125` | branches on `res.IssueDuplicate` |
| `dingtalk/replier.go:125` | branches on `res.IssueDuplicate` |
| `lark` | branches on it |
| **`wecom/replier.go`** | **did not** |

## 2. A web-UI answer is pushed into the WeCom room

A chat session that originated in WeCom can be continued from the Multica web UI. That answer belongs only in Multica — but `processEvent` had no origin gate, so it went straight to the bound chat. **In a group that means in front of everyone in the room, answering a question none of them saw asked.**

`engine.TaskInputIsChannelIngested` has been on `main` since #5645, and `slack/outbound.go:118` gates on it right after the binding lookup and before loading credentials. This adds the same call in the same position.

**Fails closed**: a completion whose origin cannot be established is not delivered. Silence is recoverable; a leak is not.

## Tests

Four, no database needed.

The two privacy tests fail on the old code with the frame count in the message:

```
a web-UI answer was pushed into the WeCom chat (1 frame(s) written)
delivered a completion whose origin could not be established (1 frame(s))
```

One design note worth flagging: `fakeOutboundQueries.channelIngested` defaults to **false**, so a test that expects delivery has to say so explicitly — the same way production now has to establish the origin before pushing into somebody's chat. `TestProcessEvent_DeliversChatReplyToBoundChat` gained that one line.
