### PR TITLE
MUL-5890: fix(wecom): ask the engine whether it is an /issue command instead of mirroring it

### DIFF
--- a/server/internal/integrations/wecom/ws_frame.go
+++ b/server/internal/integrations/wecom/ws_frame.go
@@ -17,6 +17,7 @@ import (
 	"unicode"
 
 	"github.com/multica-ai/multica/server/internal/integrations/channel"
+	"github.com/multica-ai/multica/server/internal/integrations/channel/engine"
 )
 
 // Frame commands the client sends.
@@ -282,25 +283,22 @@ func stripLeadingMentions(s, botName string) string {
 	}
 }
 
-// isIssueCommand mirrors engine.ParseIssueCommand's front-of-body detection
-// without materializing the parsed struct — we only need the yes/no. A pure
-// /issue command starts at the first non-empty line, "/issue" as a whole
-// token, optionally followed by whitespace and the title.
+// isIssueCommand asks the engine's own parser instead of mirroring it. The
+// mirror had drifted: it trimmed with strings.TrimSpace, which strips every
+// Unicode space including U+3000 — the ideographic space a Chinese IME emits
+// in full-width mode — while engine.ParseIssueCommand trims only " \t".
+//
+// So a p2p line opening with U+3000 read as a command here and as prose there:
+// SkipAgentRun was set so no agent ran, and the parser declined so no issue was
+// filed. The sender got nothing back and no error anywhere said why. Group
+// messages reach this helper after their leading mentions are normalized, and
+// must use the same parser too.
+//
+// A mirror of a parser is a parser. Delegating costs one allocation on a path
+// that already does I/O, and removes the whole class.
 func isIssueCommand(body string) bool {
-	for _, raw := range strings.Split(body, "\n") {
-		line := strings.TrimSpace(raw)
-		if line == "" {
-			continue
-		}
-		if line == "/issue" {
-			return true
-		}
-		if strings.HasPrefix(line, "/issue ") || strings.HasPrefix(line, "/issue\t") {
-			return true
-		}
-		return false
-	}
-	return false
+	_, ok := engine.ParseIssueCommand(body)
+	return ok
 }
 
 // channelMsgType maps the raw aibot msg_type onto the normalized enum.

--- a/server/internal/integrations/wecom/ws_frame_test.go
+++ b/server/internal/integrations/wecom/ws_frame_test.go
@@ -164,3 +164,34 @@ func TestSendMsgTextBody_ShapeAndChatTypeValidation(t *testing.T) {
 		t.Error("chat_type 3 should be rejected (must be 1 or 2)")
 	}
 }
+
+// TestIssueCommandDetectionMatchesTheEngine: the adapter sets SkipAgentRun
+// from its own answer, and the engine files the issue from its own. Any input
+// they disagree on is a message that reaches nobody — no agent run because
+// this side said "command", no issue because that side said "prose".
+//
+// U+3000 is the case that mattered: it is what a Chinese IME emits for the
+// space bar in full-width mode, so it opens real messages.
+func TestIssueCommandDetectionMatchesTheEngine(t *testing.T) {
+	cases := []string{
+		"/issue the login redirect is broken",
+		"/issue",
+		"/issue\tthe title after a tab",
+		"  /issue leading halfwidth spaces",
+		"　/issue after an ideographic space",
+		"　　/issue after two",
+		"/issuewithoutspace",
+		"not a command at all",
+		"",
+		"\n\n/issue after blank lines",
+		"prose first\n/issue not at the front",
+		" /issue after a non-breaking space",
+	}
+	for _, body := range cases {
+		_, engineSays := engine.ParseIssueCommand(body)
+		if got := isIssueCommand(body); got != engineSays {
+			t.Errorf("isIssueCommand(%q) = %v but engine.ParseIssueCommand says %v — SkipAgentRun and the issue decision disagree, so this message reaches nobody",
+				body, got, engineSays)
+		}
+	}
+}


### PR DESCRIPTION
`isIssueCommand` reimplements `engine.ParseIssueCommand`'s front-of-body detection. The two have drifted:

| | trims |
|---|---|
| `wecom/ws_frame.go` | `strings.TrimSpace` — **every** Unicode space |
| `engine.ParseIssueCommand` | `strings.TrimLeft(line, " \t")` |

So a line opening with **U+3000** — the ideographic space a Chinese IME emits for the space bar in full-width mode, i.e. one people hit by accident every day — is read as a command here and as prose there:

- `SkipAgentRun` is set → no agent runs
- the parser declines → no issue is filed

The sender gets nothing back, and nothing in any log says why. U+00A0 behaves the same.

## Fix

Delegate:

```go
func isIssueCommand(body string) bool {
	_, ok := engine.ParseIssueCommand(body)
	return ok
}
```

One allocation on a path that already does network I/O, and the drift class is gone. main's own comment above the function calls it a mirror of the engine's detection — which is the argument for not keeping a second copy rather than for keeping it in sync by hand.

## Test

A table over twelve bodies asserting the adapter and the engine agree. On the old code three fail, and the message names the consequence rather than the mismatch:

```
isIssueCommand("　/issue after an ideographic space") = true but
engine.ParseIssueCommand says false — SkipAgentRun and the issue decision
disagree, so this message reaches nobody
```

The test is written against `engine.ParseIssueCommand` rather than a hardcoded expectation, so it keeps holding if the engine's own rules change.
