### PR TITLE
MUL-5893 fix(lark): three defensive fixes to stored media filenames

### DIFF
--- a/server/internal/integrations/lark/media_filename_test.go
+++ b/server/internal/integrations/lark/media_filename_test.go
@@ -1,0 +1,66 @@
+package lark
+
+// media_filename_test.go — the stored object's display name. Not a path
+// traversal (path.Base already resolves the path), but a name that reaches
+// Content-Disposition and anywhere the file is later re-saved.
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/multica-ai/multica/server/internal/integrations/channel"
+)
+
+func TestCleanFilenameRejectsDotOnlyNames(t *testing.T) {
+	for _, in := range []string{"..", "...", ".", "  ..  ", "../", "a/../.."} {
+		if got := cleanFilename(in); strings.Trim(got, ".") == "" && got != "" {
+			t.Errorf("cleanFilename(%q) = %q — a name made only of dots is not a filename", in, got)
+		}
+	}
+	// The ordinary cases must survive, or every upload loses its real name.
+	for in, want := range map[string]string{
+		"report.pdf":            "report.pdf",
+		"/tmp/report.pdf":       "report.pdf",
+		`C:\Users\a\report.pdf`: "report.pdf",
+		"../../etc/passwd":      "passwd",
+		"..hidden.txt":          "..hidden.txt",
+	} {
+		if got := cleanFilename(in); got != want {
+			t.Errorf("cleanFilename(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestMediaExtensionKnowsPDF(t *testing.T) {
+	if got := mediaExtension("application/pdf"); got != ".pdf" {
+		t.Errorf("mediaExtension(application/pdf) = %q, want .pdf — mime.ExtensionsByType reads /etc/mime.types, which a slim image does not ship", got)
+	}
+	if got := mediaExtension("application/pdf; charset=binary"); got != ".pdf" {
+		t.Errorf("parameterized content type = %q, want .pdf", got)
+	}
+}
+
+// Every resource on one message shares a MessageID, so without the index
+// three photos in one send produce three objects with the same name.
+func TestGeneratedMediaFilenamesAreDistinctWithinAMessage(t *testing.T) {
+	lm := InboundMessage{MessageID: "om_abc123"}
+	res := larkMediaResource{kind: channel.MsgTypeImage}
+	seen := map[string]int{}
+	for i := 0; i < 3; i++ {
+		name := mediaFilename(lm, res, DownloadedResourceStream{}, "image/png", i)
+		seen[name]++
+	}
+	if len(seen) != 3 {
+		t.Fatalf("three attachments produced %d distinct names (%v) — the later ones overwrite or confuse the earlier", len(seen), seen)
+	}
+}
+
+// A real filename from the platform still wins over the generated one, index
+// or not.
+func TestProvidedFilenameStillWins(t *testing.T) {
+	lm := InboundMessage{MessageID: "om_abc123"}
+	res := larkMediaResource{kind: channel.MsgTypeFile, filename: "quarterly.pdf"}
+	if got := mediaFilename(lm, res, DownloadedResourceStream{}, "application/pdf", 2); got != "quarterly.pdf" {
+		t.Errorf("mediaFilename = %q, want the platform's own name", got)
+	}
+}

--- a/server/internal/integrations/lark/media_ingest.go
+++ b/server/internal/integrations/lark/media_ingest.go
@@ -10,6 +10,7 @@ import (
 	"log/slog"
 	"mime"
 	"path"
+	"strconv"
 	"strings"
 
 	"github.com/jackc/pgx/v5/pgtype"
@@ -84,7 +85,7 @@ func (r *feishuMediaResolver) ResolveMedia(ctx context.Context, inst engine.Reso
 		r.logMediaWarn("lark media ingest skipped: credentials unavailable", lm, err)
 		return msg
 	}
-	for _, res := range resources {
+	for resIndex, res := range resources {
 		key := mediaObjectKey(inst, chatMessageID, res)
 		link := r.storage.ObjectURL(key)
 		// Persist the upload intent BEFORE any write can happen. Every
@@ -124,7 +125,7 @@ func (r *feishuMediaResolver) ResolveMedia(ctx context.Context, inst engine.Reso
 		if contentType == "" {
 			contentType = "application/octet-stream"
 		}
-		filename := mediaFilename(lm, res, got, contentType)
+		filename := mediaFilename(lm, res, got, contentType, resIndex)
 		uploadedBytes, err := r.uploadResource(ctx, key, got.Body, got.SizeBytes, contentType, filename)
 		if err != nil {
 			// The store may still be processing the PUT — deleting here
@@ -340,7 +341,11 @@ func mediaResourcesFromPost(lm InboundMessage) []larkMediaResource {
 	return out
 }
 
-func mediaFilename(lm InboundMessage, res larkMediaResource, got DownloadedResourceStream, contentType string) string {
+// mediaFilename picks a name for the stored object. index disambiguates the
+// generated form: every resource on one message shares a MessageID, so three
+// photos in one send used to produce three objects all named
+// "feishu-image-<msg>.jpg".
+func mediaFilename(lm InboundMessage, res larkMediaResource, got DownloadedResourceStream, contentType string, index int) string {
 	for _, candidate := range []string{got.Filename, res.filename} {
 		if name := cleanFilename(candidate); name != "" {
 			return name
@@ -353,7 +358,11 @@ func mediaFilename(lm InboundMessage, res larkMediaResource, got DownloadedResou
 	case channel.MsgTypeVideo:
 		prefix = "feishu-video"
 	}
-	return prefix + "-" + safePathSegment(lm.MessageID) + mediaExtension(contentType)
+	name := prefix + "-" + safePathSegment(lm.MessageID)
+	if index > 0 {
+		name += "-" + strconv.Itoa(index+1)
+	}
+	return name + mediaExtension(contentType)
 }
 
 func cleanFilename(name string) string {
@@ -362,7 +371,11 @@ func cleanFilename(name string) string {
 		return ""
 	}
 	name = path.Base(strings.ReplaceAll(name, "\\", "/"))
-	if name == "." || name == "/" {
+	// path.Base resolves a path, but it hands back ".." and "..." unchanged.
+	// A name made only of dots is not a filename; letting one through means
+	// the object's display name is ".." wherever it is later rendered or
+	// re-saved. Fall through to the generated name instead.
+	if strings.Trim(name, ".") == "" || name == "/" {
 		return ""
 	}
 	return name
@@ -383,6 +396,12 @@ func mediaExtension(contentType string) string {
 		return ".webp"
 	case "video/mp4":
 		return ".mp4"
+	case "application/pdf":
+		// mime.ExtensionsByType returns ExtensionsByType(".pdf") on most
+		// systems, but it reads /etc/mime.types — which a slim container
+		// image does not ship — so the common document type is pinned here
+		// rather than left to the host.
+		return ".pdf"
 	}
 	if exts, err := mime.ExtensionsByType(contentType); err == nil && len(exts) > 0 {
 		return exts[0]


### PR DESCRIPTION
Three small fixes to `lark/media_ingest.go`, found while auditing the WeCom adapter against this one.

**None is a path traversal** — `path.Base` already resolves the path before any of this runs. All three reach the stored object's *display name*, which surfaces in `Content-Disposition` and wherever the file is later re-saved.

| | Before | After |
|---|---|---|
| `cleanFilename("..")` | `".."` | falls through to the generated name |
| `mediaExtension("application/pdf")` | depends on the host's `/etc/mime.types` | `".pdf"` |
| 3 photos in one message | 3 objects all named `feishu-image-<msg>.jpg` | `…​.jpg`, `…​-2.jpg`, `…​-3.jpg` |

## Details

1. **`cleanFilename` returned `".."` and `"..."` unchanged.** `path.Base` resolves a path but hands a dot-only name straight back, and the guard only covered `"."` and `"/"`. `"..hidden.txt"` and `"../../etc/passwd"` → `"passwd"` behave exactly as before.

2. **No case for `application/pdf`**, so it fell through to `mime.ExtensionsByType` — which reads `/etc/mime.types`, a file slim container images do not ship. On those images a PDF was stored with **no extension at all**. Now pinned alongside the image and video types that were already pinned for the same reason.

3. **The generated filename omitted the attachment index.** Every resource on one message shares a `MessageID`, so a three-photo send produced three identically-named objects. A platform-provided filename still wins.

## Tests

Four. Reverting fixes 1 and 3 fails them:

```
cleanFilename("..") = ".." — a name made only of dots is not a filename
three attachments produced 1 distinct names (map[feishu-image-om_abc123.png:3])
```

**Fix 2 has no failing-first proof, and I want to be straight about that**: reverting it does *not* fail on a developer machine, because macOS and most distros ship `/etc/mime.types` and the fallback succeeds. That is precisely the condition the fix is for, so it cannot be reproduced locally. The test pins the behaviour going forward; it does not demonstrate the bug.
