### PR TITLE
fix(metrics): forbid installation_id as a metric label (MUL-5894)

### DIFF
--- a/server/internal/metrics/labels.go
+++ b/server/internal/metrics/labels.go
@@ -90,13 +90,19 @@ var businessMetricLabels = map[string][]string{
 
 var forbiddenMetricLabels = map[string]struct{}{
 	"workspace_id": {},
-	"user_id":      {},
-	"agent_id":     {},
-	"task_id":      {},
-	"issue_id":     {},
-	"runtime_id":   {},
-	"session_id":   {},
-	"ip":           {},
+	// installation_id is the same class as the rest: one series per channel
+	// installation, growing with tenants rather than with the deployment. It
+	// is also the natural thing to reach for in any channel metric — every
+	// adapter call site already carries one — which is what makes leaving it
+	// off this list a matter of time rather than of luck.
+	"installation_id": {},
+	"user_id":         {},
+	"agent_id":        {},
+	"task_id":         {},
+	"issue_id":        {},
+	"runtime_id":      {},
+	"session_id":      {},
+	"ip":              {},
 }
 
 var (

--- a/server/internal/metrics/labels_test.go
+++ b/server/internal/metrics/labels_test.go
@@ -41,3 +41,16 @@ func TestNormalizeLabelsCollapseUnknownValues(t *testing.T) {
 		t.Fatalf("NormalizeTaskSource unknown = %q, want other", got)
 	}
 }
+
+// TestForbiddenLabelsCoverChannelIdentifiers: the channel adapters (slack,
+// lark, dingtalk, wecom) all carry an installation id at every metric call
+// site, so it is the natural label to reach for. One series per installation
+// grows with tenants, not with the deployment — the same reason workspace_id
+// and session_id are on this list.
+func TestForbiddenLabelsCoverChannelIdentifiers(t *testing.T) {
+	for _, label := range []string{"installation_id", "workspace_id", "session_id"} {
+		if _, forbidden := forbiddenMetricLabels[label]; !forbidden {
+			t.Errorf("%s is not forbidden — a per-tenant identifier will eventually be used as a metric label and multiply the series count by the tenant count", label)
+		}
+	}
+}


### PR DESCRIPTION
`forbiddenMetricLabels` already blocks `workspace_id`, `session_id`, `task_id`, `agent_id`, `runtime_id` and `ip` — every identifier whose series count grows with **tenants** rather than with the deployment.

`installation_id` is the same class and was missing.

It is also the one most likely to be added by accident. The channel adapters (slack, lark, dingtalk, wecom) all carry an installation id at every metric call site, so it is right there whenever somebody adds a counter — leaving it off the list is a matter of time rather than of luck. And by the time it shows up, the series are already in the operator's Prometheus and cannot be taken back out of the retention window.

Found while auditing a WeCom metrics change that deliberately refuses this label in its doc comment. The refusal should be enforced by the guard, not by each author remembering.

## Test

Asserts the channel identifiers are all covered. Removing the entry:

```
installation_id is not forbidden — a per-tenant identifier will eventually be
used as a metric label and multiply the series count by the tenant count
```

No metric currently uses it, so nothing changes at runtime — this is the guard closing before the mistake, not after.