### PR TITLE
feat(wecom): make a refused handshake distinguishable from an unreachable one (MUL-5895)

### DIFF
--- a/server/internal/integrations/wecom/credential_probe.go
+++ b/server/internal/integrations/wecom/credential_probe.go
@@ -79,6 +79,37 @@ var rejectionErrCodes = map[int]struct{}{
 	40013: {}, // 不合法的CorpID — the identity half of the pair is not valid
 }
 
+// classifySubscribeAck turns a non-zero errcode on an aibot_subscribe ack into
+// one of the two sentinels above.
+//
+// Both readers of that ack go through here — this probe at install time, and
+// the channel's own handshake on every reconnect (wecom_channel.go). It is one
+// function rather than two copies of the same map lookup so the two cannot
+// give different answers to the same code: a 45009 throttle that is
+// "unverifiable, wait" at install time must not be "somebody go fix this
+// installation" on the connect path.
+//
+// log receives the codes we do not recognize; nil falls back to the default
+// logger.
+func classifySubscribeAck(log *slog.Logger, errCode int, errMsg string) error {
+	if _, rejected := rejectionErrCodes[errCode]; rejected {
+		// The one answer the admin can act on, and the only branch that
+		// blames their credentials.
+		return fmt.Errorf("%w (errcode %d: %s)", ErrCredentialsRejected, errCode, errMsg)
+	}
+	// Unknown non-zero: throttling, a platform-side failure, or a code WeCom
+	// added since. Fail closed rather than blame the secret. The raw pair is
+	// logged here so an operator can see it even if the caller only surfaces
+	// the sentinel, and carried on the error so the caller's own log line has
+	// it too.
+	if log == nil {
+		log = slog.Default()
+	}
+	log.Warn("wecom: unrecognized subscribe errcode, treating as unverifiable",
+		"errcode", errCode, "errmsg", errMsg)
+	return fmt.Errorf("%w (subscribe returned errcode %d: %s)", ErrCredentialsUnverifiable, errCode, errMsg)
+}
+
 // credentialProbeTimeout bounds the whole probe. It has to cover a dial and
 // one round trip and nothing else, and it is spent with the admin watching a
 // spinner, so it is short. Sized off the connection's own two constants
@@ -162,19 +193,7 @@ func (p *handshakeProbe) Probe(ctx context.Context, botID, secret string) error 
 			continue
 		}
 		if env.ErrCode != 0 {
-			if _, rejected := rejectionErrCodes[env.ErrCode]; rejected {
-				// The one answer the admin can act on, and the only branch
-				// that blames their credentials.
-				return fmt.Errorf("%w (errcode %d: %s)", ErrCredentialsRejected, env.ErrCode, env.ErrMsg)
-			}
-			// Unknown non-zero: throttling, a platform-side failure, or a code
-			// WeCom added since. Fail closed rather than blame the secret. The
-			// raw pair is logged here so an operator can see it even if the
-			// caller only surfaces the sentinel, and carried on the error so
-			// the handler's own log line has it too.
-			slog.Warn("wecom credential probe: unrecognized subscribe errcode, treating as unverifiable",
-				"errcode", env.ErrCode, "errmsg", env.ErrMsg)
-			return fmt.Errorf("%w (subscribe returned errcode %d: %s)", ErrCredentialsUnverifiable, env.ErrCode, env.ErrMsg)
+			return classifySubscribeAck(slog.Default(), env.ErrCode, env.ErrMsg)
 		}
 		return nil
 	}

--- a/server/internal/integrations/wecom/subscribe_error_test.go
+++ b/server/internal/integrations/wecom/subscribe_error_test.go
@@ -1,0 +1,113 @@
+package wecom
+
+// subscribe_error_test.go — a handshake the server refused and a handshake
+// that never reached the server call for opposite responses. One needs a
+// person to go fix the installation; the other usually fixes itself. Callers
+// (the Supervisor's logging today, a metrics split tomorrow) can only tell
+// them apart if the rejection is identifiable.
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log/slog"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/gorilla/websocket"
+)
+
+func TestSubscribeRejectionIsIdentifiable(t *testing.T) {
+	// The shape subscribe() produces on a non-zero errcode.
+	err := fmt.Errorf("%w: errcode=%d errmsg=%s", errSubscribeRejected, 40001, "invalid credential")
+	if !errors.Is(err, errSubscribeRejected) {
+		t.Fatal("a refused handshake is not identifiable, so it cannot be told apart from a network failure")
+	}
+	// The diagnosis must survive: the errcode is what names WHICH credential
+	// problem it is.
+	if got := err.Error(); got == "" || !contains(got, "40001") || !contains(got, "invalid credential") {
+		t.Errorf("error text lost the server's diagnosis: %q", got)
+	}
+}
+
+func TestTransportFailuresAreNotRejections(t *testing.T) {
+	for _, err := range []error{
+		&net.OpError{Op: "dial", Err: errors.New("connection refused")},
+		errors.New("wecom: subscribe read: i/o timeout"),
+		fmt.Errorf("wecom: send subscribe: %w", errors.New("broken pipe")),
+	} {
+		if errors.Is(err, errSubscribeRejected) {
+			t.Errorf("%v was classified as a credential rejection — an operator would go chase a tenant whose bot is fine", err)
+		}
+	}
+}
+
+func contains(s, sub string) bool {
+	for i := 0; i+len(sub) <= len(s); i++ {
+		if s[i:i+len(sub)] == sub {
+			return true
+		}
+	}
+	return false
+}
+
+// ackingConn answers the subscribe frame with a chosen errcode, echoing the
+// req_id the way the server does.
+type ackingConn struct {
+	errCode int
+	errMsg  string
+	sent    chan []byte
+	reqID   string
+}
+
+func (c *ackingConn) WriteMessage(_ int, data []byte) error {
+	var env frameEnvelope
+	if err := json.Unmarshal(data, &env); err != nil {
+		return err
+	}
+	c.reqID = env.Headers.ReqID
+	return nil
+}
+
+func (c *ackingConn) ReadMessage() (int, []byte, error) {
+	payload, err := json.Marshal(frameEnvelope{
+		Headers: frameHeaders{ReqID: c.reqID},
+		ErrCode: c.errCode,
+		ErrMsg:  c.errMsg,
+	})
+	if err != nil {
+		return 0, nil, err
+	}
+	return websocket.TextMessage, payload, nil
+}
+
+func (c *ackingConn) SetReadDeadline(time.Time) error  { return nil }
+func (c *ackingConn) SetWriteDeadline(time.Time) error { return nil }
+func (c *ackingConn) Close() error                     { return nil }
+
+// TestSubscribeWrapsAServerRefusal drives the real subscribe() so the test
+// fails if the wrapping is ever dropped — asserting on the sentinel alone
+// would keep passing while the caller could no longer identify a rejection.
+func TestSubscribeWrapsAServerRefusal(t *testing.T) {
+	conn := &ackingConn{errCode: 40001, errMsg: "invalid credential"}
+	c := &wecomChannel{botID: "bot-1", secret: "s"}
+
+	err := c.subscribe(context.Background(), conn, newWSSender(conn, nil), slog.Default())
+	if err == nil {
+		t.Fatal("a refused subscribe returned success")
+	}
+	if !errors.Is(err, errSubscribeRejected) {
+		t.Fatalf("subscribe() does not mark a server refusal as one: %v — the caller cannot tell it from a network failure", err)
+	}
+}
+
+// The other side: an accepted handshake must not be reported as a rejection.
+func TestSubscribeSucceedsOnZeroErrcode(t *testing.T) {
+	conn := &ackingConn{errCode: 0}
+	c := &wecomChannel{botID: "bot-1", secret: "s"}
+	if err := c.subscribe(context.Background(), conn, newWSSender(conn, nil), slog.Default()); err != nil {
+		t.Fatalf("an accepted subscribe failed: %v", err)
+	}
+}

--- a/server/internal/integrations/wecom/subscribe_error_test.go
+++ b/server/internal/integrations/wecom/subscribe_error_test.go
@@ -5,52 +5,31 @@ package wecom
 // person to go fix the installation; the other usually fixes itself. Callers
 // (the Supervisor's logging today, a metrics split tomorrow) can only tell
 // them apart if the rejection is identifiable.
+//
+// Every test here drives the real subscribe(). Building an error with
+// fmt.Errorf and then asserting errors.Is on it tests errors.Is, not the
+// production code: misclassifying a transport failure inside subscribe() would
+// leave such a test green.
 
 import (
 	"context"
 	"encoding/json"
 	"errors"
-	"fmt"
+	"io"
 	"log/slog"
 	"net"
+	"strconv"
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/gorilla/websocket"
 )
 
-func TestSubscribeRejectionIsIdentifiable(t *testing.T) {
-	// The shape subscribe() produces on a non-zero errcode.
-	err := fmt.Errorf("%w: errcode=%d errmsg=%s", errSubscribeRejected, 40001, "invalid credential")
-	if !errors.Is(err, errSubscribeRejected) {
-		t.Fatal("a refused handshake is not identifiable, so it cannot be told apart from a network failure")
-	}
-	// The diagnosis must survive: the errcode is what names WHICH credential
-	// problem it is.
-	if got := err.Error(); got == "" || !contains(got, "40001") || !contains(got, "invalid credential") {
-		t.Errorf("error text lost the server's diagnosis: %q", got)
-	}
-}
-
-func TestTransportFailuresAreNotRejections(t *testing.T) {
-	for _, err := range []error{
-		&net.OpError{Op: "dial", Err: errors.New("connection refused")},
-		errors.New("wecom: subscribe read: i/o timeout"),
-		fmt.Errorf("wecom: send subscribe: %w", errors.New("broken pipe")),
-	} {
-		if errors.Is(err, errSubscribeRejected) {
-			t.Errorf("%v was classified as a credential rejection — an operator would go chase a tenant whose bot is fine", err)
-		}
-	}
-}
-
-func contains(s, sub string) bool {
-	for i := 0; i+len(sub) <= len(s); i++ {
-		if s[i:i+len(sub)] == sub {
-			return true
-		}
-	}
-	return false
+// quietLogger keeps the unrecognized-errcode warning out of the test output;
+// the log is not what any of these assert on.
+func quietLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(io.Discard, nil))
 }
 
 // ackingConn answers the subscribe frame with a chosen errcode, echoing the
@@ -58,7 +37,6 @@ func contains(s, sub string) bool {
 type ackingConn struct {
 	errCode int
 	errMsg  string
-	sent    chan []byte
 	reqID   string
 }
 
@@ -87,27 +65,103 @@ func (c *ackingConn) SetReadDeadline(time.Time) error  { return nil }
 func (c *ackingConn) SetWriteDeadline(time.Time) error { return nil }
 func (c *ackingConn) Close() error                     { return nil }
 
-// TestSubscribeWrapsAServerRefusal drives the real subscribe() so the test
-// fails if the wrapping is ever dropped — asserting on the sentinel alone
-// would keep passing while the caller could no longer identify a rejection.
-func TestSubscribeWrapsAServerRefusal(t *testing.T) {
-	conn := &ackingConn{errCode: 40001, errMsg: "invalid credential"}
-	c := &wecomChannel{botID: "bot-1", secret: "s"}
+// failingConn is the transport half: the frame never goes out, or the ack
+// never comes back.
+type failingConn struct {
+	writeErr error
+	readErr  error
+}
 
-	err := c.subscribe(context.Background(), conn, newWSSender(conn, nil), slog.Default())
-	if err == nil {
-		t.Fatal("a refused subscribe returned success")
-	}
-	if !errors.Is(err, errSubscribeRejected) {
-		t.Fatalf("subscribe() does not mark a server refusal as one: %v — the caller cannot tell it from a network failure", err)
+func (c *failingConn) WriteMessage(int, []byte) error    { return c.writeErr }
+func (c *failingConn) ReadMessage() (int, []byte, error) { return 0, nil, c.readErr }
+func (c *failingConn) SetReadDeadline(time.Time) error   { return nil }
+func (c *failingConn) SetWriteDeadline(time.Time) error  { return nil }
+func (c *failingConn) Close() error                      { return nil }
+
+// TestSubscribeClassifiesAnAckLikeTheCredentialProbe pins the connect path to
+// the same verdicts the install-time probe gives the same errcodes
+// (credential_probe_test.go's table). The whole point of the split is that a
+// throttle is not a credential failure; a connect-vs-auth metric built on a
+// classification that disagreed with the probe's would page somebody about a
+// tenant whose bot is fine.
+func TestSubscribeClassifiesAnAckLikeTheCredentialProbe(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		errCode int
+		errMsg  string
+		want    error
+	}{
+		{name: "invalid secret is a rejection", errCode: 40001, errMsg: "invalid secret", want: ErrCredentialsRejected},
+		{name: "invalid corpid is a rejection", errCode: 40013, errMsg: "invalid corpid", want: ErrCredentialsRejected},
+		{name: "rate limited is not a rejection", errCode: 45009, errMsg: "api freq out of limit", want: ErrCredentialsUnverifiable},
+		{name: "concurrency limited is not a rejection", errCode: 45033, errMsg: "api concurrency out of limit", want: ErrCredentialsUnverifiable},
+		{name: "system error is not a rejection", errCode: -1, errMsg: "system busy", want: ErrCredentialsUnverifiable},
+		{name: "unknown code is not a rejection", errCode: 999999, errMsg: "something new", want: ErrCredentialsUnverifiable},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			conn := &ackingConn{errCode: tc.errCode, errMsg: tc.errMsg}
+			c := &wecomChannel{botID: "bot-1", secret: "s"}
+
+			err := c.subscribe(context.Background(), conn, newWSSender(conn, quietLogger()), quietLogger())
+			if err == nil {
+				t.Fatal("a refused subscribe returned success")
+			}
+			if !errors.Is(err, tc.want) {
+				t.Fatalf("subscribe() classified errcode %d as %v, want %v", tc.errCode, err, tc.want)
+			}
+			other := ErrCredentialsRejected
+			if tc.want == ErrCredentialsRejected {
+				other = ErrCredentialsUnverifiable
+			}
+			if errors.Is(err, other) {
+				t.Fatalf("subscribe() classified errcode %d as both answers at once: %v", tc.errCode, err)
+			}
+			// The diagnosis must survive: the errcode is what names WHICH
+			// problem it is.
+			if got := err.Error(); !strings.Contains(got, strconv.Itoa(tc.errCode)) || !strings.Contains(got, tc.errMsg) {
+				t.Errorf("error text lost the server's diagnosis: %q", got)
+			}
+		})
 	}
 }
 
-// The other side: an accepted handshake must not be reported as a rejection.
+// TestSubscribeTransportFailuresAreNotRejections is the other direction, and
+// it has to run subscribe() to hold: classifying a read failure as a rejection
+// inside subscribe() is exactly the drift this is here to catch.
+func TestSubscribeTransportFailuresAreNotRejections(t *testing.T) {
+	readFailed := errors.New("i/o timeout")
+	writeFailed := &net.OpError{Op: "write", Err: errors.New("broken pipe")}
+
+	for _, tc := range []struct {
+		name string
+		conn *failingConn
+		want error
+	}{
+		{name: "the ack never comes back", conn: &failingConn{readErr: readFailed}, want: readFailed},
+		{name: "the frame never goes out", conn: &failingConn{writeErr: writeFailed}, want: writeFailed},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			c := &wecomChannel{botID: "bot-1", secret: "s"}
+
+			err := c.subscribe(context.Background(), tc.conn, newWSSender(tc.conn, quietLogger()), quietLogger())
+			if err == nil {
+				t.Fatal("a transport failure returned success")
+			}
+			if !errors.Is(err, tc.want) {
+				t.Fatalf("subscribe() dropped the underlying transport error: %v", err)
+			}
+			if errors.Is(err, ErrCredentialsRejected) {
+				t.Errorf("subscribe() called a transport failure a credential rejection: %v — an operator would go chase a tenant whose bot is fine", err)
+			}
+		})
+	}
+}
+
+// The third case: an accepted handshake must not be reported as either.
 func TestSubscribeSucceedsOnZeroErrcode(t *testing.T) {
 	conn := &ackingConn{errCode: 0}
 	c := &wecomChannel{botID: "bot-1", secret: "s"}
-	if err := c.subscribe(context.Background(), conn, newWSSender(conn, nil), slog.Default()); err != nil {
+	if err := c.subscribe(context.Background(), conn, newWSSender(conn, quietLogger()), quietLogger()); err != nil {
 		t.Fatalf("an accepted subscribe failed: %v", err)
 	}
 }

--- a/server/internal/integrations/wecom/wecom_channel.go
+++ b/server/internal/integrations/wecom/wecom_channel.go
@@ -317,6 +317,15 @@ func (c *wecomChannel) Connect(ctx context.Context) (err error) {
 // not quietly discard the messages it could not reach.
 const callbackQueueDepth = 64
 
+// errSubscribeRejected marks a handshake the server refused on its merits —
+// bad credentials, a bot that no longer exists, a bot whose long connection is
+// off. It is separated from every other connection failure because only this
+// one needs a person: it repeats identically on every backoff until somebody
+// fixes the installation, while a dial failure or a timeout usually recovers
+// on its own. An operator watching one number cannot tell "our network
+// blipped" from "this tenant's bot has been broken since Tuesday".
+var errSubscribeRejected = errors.New("wecom: subscribe rejected")
+
 // subscribe sends the aibot_subscribe frame and waits (up to
 // subscribeTimeout) for the server's ack. The ack shape is a frame with
 // echoed headers.req_id + errcode; errcode == 0 means good, anything else
@@ -360,7 +369,7 @@ func (c *wecomChannel) subscribe(ctx context.Context, conn wsConn, sender *wsSen
 			continue
 		}
 		if env.ErrCode != 0 {
-			return fmt.Errorf("wecom: subscribe rejected errcode=%d errmsg=%s", env.ErrCode, env.ErrMsg)
+			return fmt.Errorf("%w: errcode=%d errmsg=%s", errSubscribeRejected, env.ErrCode, env.ErrMsg)
 		}
 		return nil
 	}

--- a/server/internal/integrations/wecom/wecom_channel.go
+++ b/server/internal/integrations/wecom/wecom_channel.go
@@ -317,19 +317,19 @@ func (c *wecomChannel) Connect(ctx context.Context) (err error) {
 // not quietly discard the messages it could not reach.
 const callbackQueueDepth = 64
 
-// errSubscribeRejected marks a handshake the server refused on its merits —
-// bad credentials, a bot that no longer exists, a bot whose long connection is
-// off. It is separated from every other connection failure because only this
-// one needs a person: it repeats identically on every backoff until somebody
-// fixes the installation, while a dial failure or a timeout usually recovers
-// on its own. An operator watching one number cannot tell "our network
-// blipped" from "this tenant's bot has been broken since Tuesday".
-var errSubscribeRejected = errors.New("wecom: subscribe rejected")
-
 // subscribe sends the aibot_subscribe frame and waits (up to
 // subscribeTimeout) for the server's ack. The ack shape is a frame with
-// echoed headers.req_id + errcode; errcode == 0 means good, anything else
-// is fatal (bad credentials / bot doesn't exist).
+// echoed headers.req_id + errcode; errcode == 0 means good.
+//
+// A non-zero errcode goes through classifySubscribeAck — the same function the
+// install-time credential probe uses on the same ack, so the two cannot answer
+// the same code differently. 40001 / 40013 come back as ErrCredentialsRejected:
+// the refusal that repeats identically on every backoff until somebody fixes
+// the installation. Every other non-zero code is ErrCredentialsUnverifiable,
+// because a throttle (45009, 45033) or a platform-side failure clears on its
+// own, and counting one as a credential failure would page an operator about a
+// tenant whose bot is fine. Both sentinels are exported, so channel/engine —
+// which is what receives this error out of Connect() — can branch on them.
 func (c *wecomChannel) subscribe(ctx context.Context, conn wsConn, sender *wsSender, log *slog.Logger) error {
 	reqID := newReqID()
 	if err := sender.write(map[string]any{
@@ -369,7 +369,7 @@ func (c *wecomChannel) subscribe(ctx context.Context, conn wsConn, sender *wsSen
 			continue
 		}
 		if env.ErrCode != 0 {
-			return fmt.Errorf("%w: errcode=%d errmsg=%s", errSubscribeRejected, env.ErrCode, env.ErrMsg)
+			return classifySubscribeAck(log, env.ErrCode, env.ErrMsg)
 		}
 		return nil
 	}


### PR DESCRIPTION
`subscribe()` returned a plain `fmt.Errorf` for a server refusal, so every caller sees one undifferentiated "connect failed".

The two cases need **opposite** operator responses:

| | behaviour | response |
|---|---|---|
| **refusal** — the bot id / secret pair is not valid | repeats identically on every backoff, forever | somebody has to go fix that installation |
| **everything else** — dial failed, timeout, TLS, a throttle, a platform-side failure | usually recovers on its own | wait |

Watching one number, an operator cannot tell *"our network blipped"* from *"this tenant's bot has been broken since Tuesday"* — and only the second has a user sitting in front of a bot that never answers.

## Where the classification comes from

`credential_probe.go` already answers this question about this ack, at install time: `rejectionErrCodes` is a whitelist of 40001 / 40013 and every other non-zero code fails closed to unverifiable, because WeCom only guarantees that 0 means success and the subscribe path is under frequency and concurrency protection (45009, 45033).

`subscribe()` now goes through `classifySubscribeAck`, which lives next to that whitelist and which the probe calls too. One function, so the connect path cannot answer a code differently from the install path — a 45009 that means "wait" at install time cannot mean "go fix this installation" on reconnect. It returns the exported `ErrCredentialsRejected` / `ErrCredentialsUnverifiable` pair, the same two `internal/handler/wecom_web.go` already branches on for the install path.

## Scope

Nothing branches on the classification yet. This is the piece a connect-vs-auth failure metric split needs, filed on its own because it is small, has no dependencies, and the classification is already useful to whoever reads the log.

One constraint for that follow-up: `channel/engine` is what receives this error out of `Connect()`, but it cannot branch on these sentinels — `wecom` already imports `channel/engine` (`binding.go`, `replier.go`, `ws_frame.go`, `installation.go`, `wecom_resolvers.go`), so the reverse import is a cycle. The metric has to be emitted in the WeCom layer — `classifySubscribeAck` is the one point both paths funnel through — or live above both, or `channel` needs a platform-neutral classification contract first.

## Tests

Every test drives the real `subscribe()` through a fake conn, so a misclassification inside `subscribe()` fails them.

- a table over the probe's own errcodes (40001, 40013, 45009, 45033, -1, 999999), asserting the connect path reaches the same verdict and never both at once
- a transport failure — a conn whose `ReadMessage` fails, and separately one whose `WriteMessage` fails — asserting it is not classified as a rejection
- a zero errcode still succeeds
