### PR TITLE
MUL-5901: feat(wecom): read voice notes, which WeCom already transcribes for us

### DIFF
--- a/server/internal/integrations/wecom/types.go
+++ b/server/internal/integrations/wecom/types.go
@@ -28,8 +28,10 @@
 // shared channel engine? Keep this adapter building — and loop in the code
 // owners for anything that changes WeCom-visible behavior.
 //
-// Known limits of the first version, both deliberate: inbound handling is
-// text-only (other message types get a short "text only" receipt), and outbound
+// Known limits of the first version, both deliberate: inbound handling takes
+// only what arrives as words — typed text, and the transcript WeCom returns
+// for a voice note — while the kinds carrying a downloadable payload get a
+// short "text only" receipt; and outbound
 // delivery requires a SINGLE backend replica, because the only send path is the
 // in-process WebSocket in sendersRegistry while EventChatDone dispatches on the
 // in-process events.Bus. See SELF_HOSTING.md.

--- a/server/internal/integrations/wecom/voice_test.go
+++ b/server/internal/integrations/wecom/voice_test.go
@@ -1,0 +1,67 @@
+package wecom
+
+// voice_test.go — WeCom runs speech recognition on its side and delivers the
+// transcript in voice.content. Answering a voice note with "I only handle
+// text" refuses a sentence we were already handed.
+
+import "testing"
+
+func TestVoiceTranscriptIsTreatedAsText(t *testing.T) {
+	mc := aibotMsgCallback{MsgType: "voice"}
+	mc.Voice.Content = "把登录跳转的 bug 记一下"
+
+	body, ok := mc.bodyText()
+	if !ok {
+		t.Fatal("a voice note with a transcript was refused — the sentence was already in hand")
+	}
+	if body != "把登录跳转的 bug 记一下" {
+		t.Errorf("body = %q, want the transcript", body)
+	}
+
+	msg := channelMessageFromCallback("bot-1", "", mc, "req-1")
+	if msg.Text != "把登录跳转的 bug 记一下" {
+		t.Errorf("InboundMessage.Text = %q, want the transcript", msg.Text)
+	}
+}
+
+// A spoken /issue is still a command.
+func TestSpokenIssueCommandIsACommand(t *testing.T) {
+	mc := aibotMsgCallback{MsgType: "voice"}
+	mc.Voice.Content = "/issue the login redirect is broken"
+	msg := channelMessageFromCallback("bot-1", "", mc, "req-1")
+	if !msg.SkipAgentRun {
+		t.Error("a spoken /issue did not register as a command")
+	}
+}
+
+// Recognition returns empty on background noise or a half-second press. An
+// empty body would reach the agent as a turn with nothing in it.
+func TestEmptyTranscriptIsNotIngested(t *testing.T) {
+	for _, content := range []string{"", "   ", "\t\n"} {
+		mc := aibotMsgCallback{MsgType: "voice"}
+		mc.Voice.Content = content
+		if _, ok := mc.bodyText(); ok {
+			t.Errorf("an empty transcript (%q) was ingested as a turn", content)
+		}
+	}
+}
+
+func TestTextIsUnaffected(t *testing.T) {
+	mc := aibotMsgCallback{MsgType: "text"}
+	mc.Text.Content = "typed as usual"
+	body, ok := mc.bodyText()
+	if !ok || body != "typed as usual" {
+		t.Errorf("bodyText() = (%q, %v), want the typed text", body, ok)
+	}
+}
+
+// The downloadable kinds still take the receipt path — reading a transcript
+// adds no media ingestion.
+func TestDownloadableKindsStillTakeTheReceiptPath(t *testing.T) {
+	for _, kind := range []string{"image", "file", "video", "mixed"} {
+		mc := aibotMsgCallback{MsgType: kind}
+		if _, ok := mc.bodyText(); ok {
+			t.Errorf("%s was routed as text", kind)
+		}
+	}
+}

--- a/server/internal/integrations/wecom/wecom_channel.go
+++ b/server/internal/integrations/wecom/wecom_channel.go
@@ -377,16 +377,26 @@ func (c *wecomChannel) dispatchFrame(ctx context.Context, env frameEnvelope, sen
 			log.Warn("wecom: bad aibot_msg_callback body", "error", err)
 			return nil
 		}
-		traceInbound(log, mc, mc.Text.Content)
+		// Trace the body the adapter will actually route, not the typed
+		// field: a voice note carries its words in voice.content, and an
+		// operator who turned tracing on to follow one would otherwise read
+		// len=0 next to a bot that answered.
+		body, routable := mc.bodyText()
+		traceInbound(log, mc, body)
 		msg := channelMessageFromCallback(c.botID, c.botDisplayName, mc, env.Headers.ReqID)
-		if mc.MsgType != "text" {
-			// Iteration 1 routes only text. Rather than drop other types
-			// (voice / image / file) silently — which reads as a broken bot —
+		// A voice note is a sentence that happened to be spoken: WeCom does
+		// the recognition and hands over the transcript, so it needs no
+		// download, no media key and no storage. Answering it with "I only
+		// handle text" was refusing content we already had in hand.
+		if !routable {
+			// Kinds that carry a downloadable payload (image / file / video /
+			// mixed), and a voice note whose recognition came back empty.
+			// Rather than drop them silently — which reads as a broken bot —
 			// answer the same chat with a one-line "text only" receipt, then
 			// stop. Media routing, and dedup'd receipts that never double-answer
 			// a WeCom delivery retry, are a follow-up. Best-effort: a send
 			// failure degrades to the prior silent drop.
-			log.Debug("wecom: non-text message, replying text-only", "msg_type", mc.MsgType, "msg_id", mc.MsgID)
+			log.Debug("wecom: unroutable message, replying text-only", "msg_type", mc.MsgType, "msg_id", mc.MsgID)
 			if err := sender.sendText(msg.Source.ChatID, aibotChatTypeFromChannel(msg.Source.ChatType), "抱歉，我目前只能处理文字消息。"); err != nil {
 				log.Debug("wecom: text-only receipt send failed", "error", err, "msg_id", mc.MsgID)
 			}

--- a/server/internal/integrations/wecom/ws_frame.go
+++ b/server/internal/integrations/wecom/ws_frame.go
@@ -83,8 +83,32 @@ type aibotMsgCallback struct {
 	Text    struct {
 		Content string `json:"content"`
 	} `json:"text"`
-	// Image / voice / file / video / mixed have their own fields; we do
-	// not surface them yet — MsgType=="text" is the only case we route.
+	// Voice carries the TRANSCRIPT, not audio. WeCom runs the speech
+	// recognition on its side and delivers only the result, so a voice note
+	// needs no download, no media key and no storage — it is a sentence that
+	// happened to be spoken. Not gated on chat type: whatever chat a voice
+	// note arrives from, the transcript is read the same way.
+	Voice struct {
+		Content string `json:"content"`
+	} `json:"voice"`
+	// Image / file / video / mixed have their own fields and carry a
+	// downloadable payload; they are not surfaced yet.
+}
+
+// bodyText is the message's text, whether it was typed or spoken. Recognition
+// comes back empty on background noise or a half-second press, and an empty
+// body would reach the agent as a turn with nothing in it — so an empty
+// transcript reports false and takes the receipt path instead.
+func (mc aibotMsgCallback) bodyText() (string, bool) {
+	switch strings.ToLower(mc.MsgType) {
+	case "text":
+		return mc.Text.Content, true
+	case "voice":
+		transcript := strings.TrimSpace(mc.Voice.Content)
+		return transcript, transcript != ""
+	default:
+		return "", false
+	}
 }
 
 // aibotEventCallback is the body of an aibot_event_callback frame. We only
@@ -127,9 +151,10 @@ type InboundMessage struct {
 	// SenderUserID is the userid of the person who typed the message.
 	SenderUserID string `json:"sender_user_id,omitempty"`
 
-	// Content is the human-readable text body when MsgType == "text";
-	// empty for media / events. The cross-platform envelope's Text field
-	// is populated from this.
+	// Content is the human-readable body of the message — what was typed
+	// for MsgType == "text", what WeCom's recognition returned for
+	// MsgType == "voice". Empty for the downloadable kinds and for events.
+	// The cross-platform envelope's Text field is populated from this.
 	Content string `json:"content,omitempty"`
 
 	// ReqID is the frame req_id the server sent this message with. We
@@ -155,6 +180,7 @@ type InboundMessage struct {
 // is used for one thing: recognising where the sender's @-mention ends. Empty
 // is fine and falls back to a whitespace heuristic; see stripLeadingMentions.
 func channelMessageFromCallback(botID, botDisplayName string, mc aibotMsgCallback, reqID string) channel.InboundMessage {
+	body, _ := mc.bodyText()
 	chatType := channel.ChatTypeP2P
 	if strings.EqualFold(mc.ChatType, "group") {
 		chatType = channel.ChatTypeGroup
@@ -177,9 +203,14 @@ func channelMessageFromCallback(botID, botDisplayName string, mc aibotMsgCallbac
 	// issue nobody asked for plus, via SkipAgentRun below, no answer at all.
 	// Passing the raw content through keeps p2p exactly where it was before
 	// CommandText was set here.
-	command := mc.Text.Content
+	//
+	// Read off bodyText, not Text.Content: a spoken "/issue …" carries the
+	// words in voice.content, and sourcing the command from the typed field
+	// would leave it empty — the engine would then fall back to Text, file the
+	// issue and, with SkipAgentRun false, run the agent over it as well.
+	command := body
 	if chatType == channel.ChatTypeGroup {
-		command = stripLeadingMentions(mc.Text.Content, botDisplayName)
+		command = stripLeadingMentions(body, botDisplayName)
 	}
 
 	wm := InboundMessage{
@@ -189,7 +220,7 @@ func channelMessageFromCallback(botID, botDisplayName string, mc aibotMsgCallbac
 		ChatType:     mc.ChatType,
 		ChatID:       chatID,
 		SenderUserID: senderID,
-		Content:      mc.Text.Content,
+		Content:      body,
 		ReqID:        reqID,
 	}
 	raw, _ := json.Marshal(wm)
@@ -198,7 +229,7 @@ func channelMessageFromCallback(botID, botDisplayName string, mc aibotMsgCallbac
 		EventID:        mc.MsgID,
 		MessageID:      mc.MsgID,
 		Type:           channelMsgType(mc.MsgType),
-		Text:           mc.Text.Content,
+		Text:           body,
 		AddressedToBot: true,
 		// The sender's own words, with a group's addressing removed. Command
 		// classification is shared (channel/message.go) and falls back to Text
@@ -315,11 +346,12 @@ func channelMsgType(wecomType string) channel.MsgType {
 	case "video":
 		return channel.MsgTypeVideo
 	default:
-		// Includes "mixed" (text + media): dispatchFrame only routes msgtype
-		// == "text", so anything else is answered with the text-only receipt
-		// and never reaches this normalization. Kept as Unknown rather than
-		// mapping "mixed" → Text, which was dead and implied mixed messages
-		// were routed as text when they are not.
+		// Includes "mixed" (text + media): dispatchFrame routes the kinds
+		// bodyText answers for — "text", and "voice" with a non-empty
+		// transcript — so anything else is answered with the text-only
+		// receipt and never reaches this normalization. Kept as Unknown
+		// rather than mapping "mixed" → Text, which was dead and implied
+		// mixed messages were routed as text when they are not.
 		return channel.MsgTypeUnknown
 	}
 }


### PR DESCRIPTION
A voice message currently gets:

> 抱歉，我目前只能处理文字消息。

But **WeCom runs the speech recognition on its side** and hands the result over in `voice.content`. No audio to download, no media key to handle, no storage to write — the adapter was refusing a sentence it was already holding.

Voice notes are how people talk to a bot on a phone: walking, in a car, hands full. On a mobile-first platform that is not an edge case, and the failure mode is the bot looking like it does not work.

## What it does

`bodyText()` answers "the message's text, typed or spoken", and the callback path reads it instead of `Text.Content` directly.

- an **empty transcript** (background noise, a half-second press) still takes the receipt path — an empty body would otherwise reach the agent as a turn with nothing in it
- a spoken **`/issue …`** is a command, because the parser reads the same body. That falls out of routing it as text rather than being special-cased
- **image / file / video / mixed are unchanged.** This adds no media ingestion — those genuinely need a download, a key and storage

Single chats only; WeCom does not deliver voice to a bot in a group (errcode 100719), which is noted on the field.

## Tests

Five. Reverting the routing fails two:

```
a voice note with a transcript was refused — the sentence was already in hand
a spoken /issue did not register as a command
```

The other three pin that empty transcripts are not ingested, that typed text is unaffected, and that the downloadable kinds still take the receipt path — so this cannot quietly grow into media handling later.