### PR TITLE
fix(wecom): a re-install must not silently drop config the dialog never asked for

### DIFF
--- a/server/internal/integrations/wecom/installation.go
+++ b/server/internal/integrations/wecom/installation.go
@@ -217,6 +217,21 @@ func (s *InstallationService) Upsert(ctx context.Context, p InstallationParams) 
 
 	// The row this upsert is about to overwrite, read on the tx handle so it is
 	// serialized with the write. Zero when this is a first install.
+	//
+	// It is read because UpsertChannelInstallation replaces `config` wholesale
+	// while the config holds more than the install dialog collects — the chat
+	// display name, and principal_user_id saying who the bot is operated on
+	// behalf of when an admin set it up for a colleague. Rebuilding the config
+	// from the request alone drops those, so a secret rotation through the
+	// Settings dialog would silently reassign the bot to whoever clicked the
+	// button, with nothing on screen and nothing in the log to say the setting
+	// had gone.
+	//
+	// Reading after the reclaim above is safe because the reclaim cannot take
+	// this row: its revoked branch explicitly excludes the caller's own
+	// (workspace, agent) pair, and its two orphan branches only fire for a
+	// missing workspace or agent, neither of which this install could have
+	// resolved to get here.
 	carried, err := currentInstallation(ctx, qtx.Queries, p.WorkspaceID, p.AgentID)
 	if err != nil {
 		return Installation{}, err
@@ -231,10 +246,15 @@ func (s *InstallationService) Upsert(ctx context.Context, p InstallationParams) 
 	if displayName == "" && carried.BotID == p.BotID {
 		displayName = carried.BotDisplayName
 	}
+	// The principal carries differently, and deliberately so: it is a property
+	// of the AGENT — who this agent's bot answers for — not of the credentials,
+	// so unlike the display name above it survives a re-install that swaps in a
+	// different bot as well as one that only rotates the secret.
 	cfg, err := encodeInstallConfig(Installation{
 		BotID:           p.BotID,
 		SecretEncrypted: sealed,
 		BotDisplayName:  displayName,
+		PrincipalUserID: carried.PrincipalUserID,
 	})
 	if err != nil {
 		return Installation{}, err
@@ -268,7 +288,9 @@ func (s *InstallationService) Upsert(ctx context.Context, p InstallationParams) 
 // There is no query keyed on that triple — the conflict key of the upsert is
 // not something any read path needed until now — so this filters the
 // workspace's wecom rows, of which there are a handful. Running it on the
-// caller's queries handle is what makes it serializable with the write.
+// caller's queries handle is what makes it serializable with the write;
+// dingtalk reads its current row inside the same transaction for the same
+// reason (dingtalk/install.go:188, GetDingTalkInstallationOwnerForUpdate).
 func currentInstallation(ctx context.Context, q *db.Queries, workspaceID, agentID pgtype.UUID) (Installation, error) {
 	rows, err := q.ListChannelInstallationsByWorkspace(ctx, db.ListChannelInstallationsByWorkspaceParams{
 		WorkspaceID: workspaceID,
@@ -278,9 +300,14 @@ func currentInstallation(ctx context.Context, q *db.Queries, workspaceID, agentI
 		return Installation{}, fmt.Errorf("wecom: read current installation: %w", err)
 	}
 	for _, row := range rows {
-		if row.AgentID == agentID {
-			return installationFromRow(row)
+		if row.AgentID != agentID {
+			continue
 		}
+		inst, err := installationFromRow(row)
+		if err != nil {
+			return Installation{}, fmt.Errorf("wecom: decode current installation %s: %w", row.ID.String(), err)
+		}
+		return inst, nil
 	}
 	return Installation{}, nil
 }

--- a/server/internal/integrations/wecom/installation_principal_test.go
+++ b/server/internal/integrations/wecom/installation_principal_test.go
@@ -1,0 +1,226 @@
+package wecom
+
+// installation_principal_test.go — guards config->>'principal_user_id' across a
+// re-install.
+//
+// Upsert replaces channel_installation.config wholesale, and the config carries
+// more than the install dialog collects. Everything the dialog does not ask for
+// has to be read off the current row and written back, or the next re-install
+// erases it. These tests drive InstallationService.Upsert — the only write path
+// to a wecom row — against a real migrated database, the same way
+// installation_reclaim_test.go does, and skip when none is reachable.
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/multica-ai/multica/server/internal/util/secretbox"
+	db "github.com/multica-ai/multica/server/pkg/db/generated"
+)
+
+const (
+	wcPrBotRotated = "bot_principal_rotated"
+	wcPrBotOther   = "bot_principal_other_agent"
+
+	// The colleague the bot is operated on behalf of — not the installer.
+	wcPrColleague = "5c09e200-0000-4000-8000-0000000000c1"
+)
+
+func cleanPrincipal(ctx context.Context, pool *pgxpool.Pool) {
+	apps := []string{wcPrBotRotated, wcPrBotOther}
+	_, _ = pool.Exec(ctx, `DELETE FROM channel_installation WHERE config->>'app_id' = ANY($1)`, apps)
+	_, _ = pool.Exec(ctx, `DELETE FROM workspace WHERE id = $1`, wcRclWS)
+}
+
+// setupPrincipal reuses the reclaim suite's workspace/agent fixtures and adds a
+// cleanup for this file's own bot ids: the (channel_type, app_id) index is
+// unique with no status condition, so a row left behind fails the next run.
+func setupPrincipal(t *testing.T) (context.Context, *pgxpool.Pool, *InstallationService, *secretbox.Box) {
+	t.Helper()
+	pool := reclaimTestDB(t)
+	ctx := context.Background()
+	cleanPrincipal(ctx, pool)
+	seedReclaimOwners(t, ctx, pool)
+	t.Cleanup(func() { cleanPrincipal(ctx, pool) })
+
+	box, err := secretbox.New(make([]byte, secretbox.KeySize))
+	if err != nil {
+		t.Fatalf("secretbox.New: %v", err)
+	}
+	// The probe is mandatory (see credential_probe.go) and the default one
+	// dials WeCom for real. These tests are about what the config JSONB keeps
+	// across a re-install, not about the proof of control, so they use the
+	// same always-succeeds fake as installation_reclaim_test.go.
+	svc, err := NewInstallationService(db.New(pool), pool, box, WithCredentialProbe(&fakeProbe{}))
+	if err != nil {
+		t.Fatalf("NewInstallationService: %v", err)
+	}
+	return ctx, pool, svc, box
+}
+
+// insertLegacyWecomInstall writes a row in exactly the config shape this
+// adapter produced before principal_user_id existed — no such key at all — so
+// the decode path is exercised against a real pre-change row rather than one
+// this build wrote.
+func insertLegacyWecomInstall(t *testing.T, ctx context.Context, pool *pgxpool.Pool, app, agent string) {
+	t.Helper()
+	if _, err := pool.Exec(ctx, `
+INSERT INTO channel_installation (workspace_id, agent_id, channel_type, config, installer_user_id, status)
+VALUES ($1, $2, 'wecom', jsonb_build_object('app_id', $3::text, 'bot_id', $3::text, 'secret_encrypted', 'b2xk'), $4, 'active')`,
+		wcRclWS, agent, app, wcRclInstall); err != nil {
+		t.Fatalf("insert legacy install app=%s: %v", app, err)
+	}
+}
+
+// setPrincipal is the only way a principal gets onto a row today: by hand.
+// There is no dialog field for it, which is exactly why losing it on a
+// re-install cannot be undone from the UI.
+func setPrincipal(t *testing.T, ctx context.Context, pool *pgxpool.Pool, app, userID string) {
+	t.Helper()
+	if _, err := pool.Exec(ctx, `
+UPDATE channel_installation SET config = config || jsonb_build_object('principal_user_id', $2::text)
+WHERE channel_type = 'wecom' AND config->>'app_id' = $1`, app, userID); err != nil {
+		t.Fatalf("set principal on %s: %v", app, err)
+	}
+}
+
+func principalInDB(t *testing.T, ctx context.Context, pool *pgxpool.Pool, app string) string {
+	t.Helper()
+	var got *string
+	if err := pool.QueryRow(ctx,
+		`SELECT config->>'principal_user_id' FROM channel_installation WHERE channel_type = 'wecom' AND config->>'app_id' = $1`,
+		app).Scan(&got); err != nil {
+		t.Fatalf("read principal for %s: %v", app, err)
+	}
+	if got == nil {
+		return ""
+	}
+	return *got
+}
+
+// Rotating a leaked secret must not reassign the bot.
+//
+// The admin opens Settings, pastes a fresh secret and saves. That call knows
+// nothing about principal_user_id — the dialog has no field for it — so
+// rebuilding the config from the request alone drops the key, and from the
+// next message on the bot belongs to whoever clicked the button. Nothing on
+// screen says so and nothing in the log does either.
+func TestUpsert_RotatingTheSecretKeepsThePrincipal(t *testing.T) {
+	ctx, pool, svc, box := setupPrincipal(t)
+
+	// A row that predates this field, then given a principal by hand.
+	insertLegacyWecomInstall(t, ctx, pool, wcPrBotRotated, wcRclAgentA)
+	setPrincipal(t, ctx, pool, wcPrBotRotated, wcPrColleague)
+
+	p := params(wcPrBotRotated, wcRclAgentA)
+	p.Secret = "rotated-secret"
+	again, err := svc.Upsert(ctx, p)
+	if err != nil {
+		t.Fatalf("rotating the secret: %v", err)
+	}
+
+	if again.PrincipalUserID != wcPrColleague {
+		t.Fatalf("principal = %q after a secret rotation, want it carried forward as %q — "+
+			"the bot silently changed hands to whoever pressed save",
+			again.PrincipalUserID, wcPrColleague)
+	}
+	if got := principalInDB(t, ctx, pool, wcPrBotRotated); got != wcPrColleague {
+		t.Fatalf("principal in the stored config = %q, want %q", got, wcPrColleague)
+	}
+
+	// And the rotation itself still landed: carrying the principal forward
+	// must not carry the old secret with it.
+	creds, err := (&SecretboxCredentialsResolver{Box: box}).Credentials(again)
+	if err != nil {
+		t.Fatalf("unseal the stored secret: %v", err)
+	}
+	if creds.Secret != "rotated-secret" {
+		t.Fatalf("stored secret = %q, want the rotated one — the rotation did not take", creds.Secret)
+	}
+}
+
+// A first install on one agent must not pick up another agent's principal.
+//
+// There is no query keyed on (workspace, agent, channel_type), so the
+// carry-forward reads the workspace's wecom rows and selects on agent_id. Get
+// that filter wrong and installing a bot for agent B hands it to whoever agent
+// A's bot answers for — a person the installing admin may not even know is
+// involved.
+func TestUpsert_FirstInstallDoesNotInheritAnotherAgentsPrincipal(t *testing.T) {
+	ctx, pool, svc, _ := setupPrincipal(t)
+
+	// Agent A already has a bot, operated on a colleague's behalf.
+	insertLegacyWecomInstall(t, ctx, pool, wcPrBotRotated, wcRclAgentA)
+	setPrincipal(t, ctx, pool, wcPrBotRotated, wcPrColleague)
+
+	// Agent B gets its first bot, installed by the admin for themselves.
+	fresh, err := svc.Upsert(ctx, params(wcPrBotOther, wcRclAgentB))
+	if err != nil {
+		t.Fatalf("first install on a second agent: %v", err)
+	}
+	if fresh.PrincipalUserID != "" {
+		t.Fatalf("principal = %q on a first install, want empty (the installer) — "+
+			"agent B's bot was handed to agent A's principal", fresh.PrincipalUserID)
+	}
+	if got := principalInDB(t, ctx, pool, wcPrBotOther); got != "" {
+		t.Fatalf("principal in the stored config = %q, want the key absent", got)
+	}
+	// Agent A is untouched by an install that was never about it.
+	if got := principalInDB(t, ctx, pool, wcPrBotRotated); got != wcPrColleague {
+		t.Fatalf("agent A's principal = %q after an unrelated install, want %q", got, wcPrColleague)
+	}
+}
+
+// The JSONB key is a compatibility surface: every row in the table was written
+// without it. omitempty is what keeps those rows — and every future install
+// that never sets a principal — encoding to the same bytes as before.
+//
+// No database needed; this is the encode/decode pair on its own.
+func TestInstallConfig_PrincipalKeyIsAbsentUntilSet(t *testing.T) {
+	// A config this build writes for an ordinary install carries no
+	// principal_user_id at all. Were it emitted as "", every re-install would
+	// rewrite rows with a key that means nothing, and any future reader that
+	// distinguishes unset from set loses the distinction on day one.
+	raw, err := encodeInstallConfig(Installation{BotID: "BOT-1", SecretEncrypted: []byte("sealed")})
+	if err != nil {
+		t.Fatalf("encodeInstallConfig: %v", err)
+	}
+	var keys map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &keys); err != nil {
+		t.Fatalf("unmarshal encoded config: %v", err)
+	}
+	if _, present := keys["principal_user_id"]; present {
+		t.Errorf("an install that sets no principal wrote principal_user_id anyway: %s", raw)
+	}
+
+	// A row written before this field existed still decodes, and reads as
+	// "the installer" rather than failing or losing its other fields.
+	legacy := []byte(`{"app_id":"BOT-1","bot_id":"BOT-1","secret_encrypted":"c2VhbGVk"}`)
+	inst, err := installationFromRow(db.ChannelInstallation{Config: legacy, Status: string(InstallationActive)})
+	if err != nil {
+		t.Fatalf("decoding a pre-change installation row: %v", err)
+	}
+	if inst.PrincipalUserID != "" {
+		t.Errorf("PrincipalUserID = %q on a pre-change row, want empty", inst.PrincipalUserID)
+	}
+	if inst.BotID != "BOT-1" || !bytes.Equal(inst.SecretEncrypted, []byte("sealed")) {
+		t.Errorf("pre-change row lost its other fields: bot=%q secret=%q", inst.BotID, inst.SecretEncrypted)
+	}
+
+	// And a principal that IS set round-trips.
+	raw, err = encodeInstallConfig(Installation{BotID: "BOT-1", PrincipalUserID: wcPrColleague})
+	if err != nil {
+		t.Fatalf("encodeInstallConfig with a principal: %v", err)
+	}
+	back, err := installationFromRow(db.ChannelInstallation{Config: raw})
+	if err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if back.PrincipalUserID != wcPrColleague {
+		t.Errorf("PrincipalUserID = %q, want it back as written (%q)", back.PrincipalUserID, wcPrColleague)
+	}
+}

--- a/server/internal/integrations/wecom/types.go
+++ b/server/internal/integrations/wecom/types.go
@@ -96,6 +96,18 @@ type Installation struct {
 	// stripLeadingMentions, which is correct for a single-word name and is
 	// what every existing installation gets.
 	BotDisplayName string
+
+	// PrincipalUserID names the Multica user this bot is operated on behalf
+	// of, for the case where an admin installs it for a colleague. Empty —
+	// which is every row that exists today — means the installer, and
+	// InstallerUserID above is what callers should read.
+	//
+	// Nothing sets it and nothing reads it for behaviour: it is carried, not
+	// consumed. Install preserves whatever the row already holds
+	// (installation.go), so whoever does start writing it does not also have
+	// to fix a re-install that silently drops it — which is the failure this
+	// field's handling exists to rule out, not the reading of it.
+	PrincipalUserID string
 }
 
 // InstallationCredentials is the plaintext-bearing view the WebSocket
@@ -120,6 +132,13 @@ type installConfig struct {
 	// existing row; absent means the whitespace heuristic, which is what the
 	// adapter did before this field existed.
 	BotDisplayName string `json:"bot_display_name,omitempty"`
+
+	// PrincipalUserID is optional, and absent on every row written before
+	// this field existed; absent means the installer. omitempty keeps it a
+	// key that only appears once somebody sets it, so an installation that
+	// never does encodes byte-for-byte the config it encoded before — no
+	// migration, and no rewrite of rows already in the table.
+	PrincipalUserID string `json:"principal_user_id,omitempty"`
 }
 
 // encodeInstallConfig marshals an Installation's config-bearing fields into
@@ -133,6 +152,7 @@ func encodeInstallConfig(inst Installation) ([]byte, error) {
 		BotID:           inst.BotID,
 		SecretEncrypted: inst.SecretEncrypted,
 		BotDisplayName:  inst.BotDisplayName,
+		PrincipalUserID: inst.PrincipalUserID,
 	})
 }
 
@@ -155,5 +175,6 @@ func installationFromRow(row db.ChannelInstallation) (Installation, error) {
 		BotID:           cfg.BotID,
 		SecretEncrypted: cfg.SecretEncrypted,
 		BotDisplayName:  cfg.BotDisplayName,
+		PrincipalUserID: cfg.PrincipalUserID,
 	}, nil
 }


### PR DESCRIPTION
## The defect

`InstallationService.Upsert` replaces `channel_installation.config` wholesale and rebuilt it from the install request alone:

```go
cfg, err := encodeInstallConfig(Installation{
    BotID:           p.BotID,
    SecretEncrypted: sealed,
})
```

Anything in that JSONB the install dialog does not collect is therefore erased by the next write to the row. Re-installing is not a rare event — the dialog is also how an admin rotates a secret, and that call carries the same bot id and the same agent id, so it lands on the existing row via `ON CONFLICT (workspace_id, agent_id, channel_type)`.

This PR adds the first config key that is not collected by the dialog, `config->>'principal_user_id'` — the Multica user the bot is operated on behalf of, for when an admin installs it for a colleague — and the carry-forward that keeps it.

## User-visible consequence

Without the carry-forward: an admin pastes a fresh secret into Settings after a leak and saves. The bot is now assigned to whoever pressed save. Nothing on screen says the setting changed and nothing in the log does either, and there is no dialog field for the principal, so it cannot be put back from the UI — the row has to be edited by hand.

That is why the field and the carry-forward are one PR rather than two. A setting that a routine secret rotation silently drops is worse than not having the setting.

## What is inert, and why it is here anyway

**Nothing reads `PrincipalUserID` yet.** The run-progress code that consumes it (deciding how much of a run the principal sees) is not upstream; it is part of a later chain. Until that lands this field is written, carried and read back, and no behavior depends on its value. Flagging that up front rather than leaving a reviewer to grep for the reader and find none.

It is not exposed on the wire: `WecomInstallationResponse` (`handler/wecom_web.go:27`) is an explicit DTO and was not touched, so the field does not appear in any API response.

## Compatibility

The persisted JSONB key is the compatibility surface, so it is `omitempty` and absent means the installer:

- an installation that never sets a principal encodes byte-for-byte the config it encoded before this change — no migration, no rewrite of rows already in the table;
- a row written before the field existed decodes with `PrincipalUserID == ""` and its other fields intact.

Both are asserted in `TestInstallConfig_PrincipalKeyIsAbsentUntilSet`, the second against a literal pre-change config blob rather than one this build wrote.

## Sibling precedent

DingTalk already reads the row it is about to replace from inside the install transaction, for the same serialization reason: `internal/integrations/dingtalk/install.go:188` (`GetDingTalkInstallationOwnerForUpdate`, on `qtx`, between the reclaim and the upsert). This PR does the same thing in the same place — read on the tx handle, after `ReclaimDeadChannelInstallationByAppID`, before `UpsertChannelInstallation`.

There is no query keyed on `(workspace_id, agent_id, channel_type)` — the upsert's conflict key was never something a read path needed — so `currentInstallation` filters the workspace's wecom rows, of which a workspace has a handful. The reclaim never removes this row (it spares the caller's own `(workspace, agent)` pair, per `ReclaimDeadChannelInstallationByAppID`'s contract), so reading after it is safe.

## Tests

Three new tests in `server/internal/integrations/wecom/installation_principal_test.go`. The two DB-backed ones extend the existing `installation_reclaim_test.go` rig — same workspace/agent fixtures, real migrated Postgres, skip when none is reachable.

Every one was reverse-verified: the fix was reverted, the test was confirmed to fail, and the fix restored. Actual output below.

**1. `TestUpsert_RotatingTheSecretKeepsThePrincipal`** — a row in the pre-change config shape, given a principal by hand, then a secret rotation through `Upsert`. Asserts the principal survives in both the returned value and the stored config, and that the rotation itself still landed (the stored blob unseals to the *new* secret, so carrying the principal forward does not carry the old secret with it).

Reverted the carry-forward (`PrincipalUserID: carried.PrincipalUserID` dropped from the encode):

```
--- FAIL: TestUpsert_RotatingTheSecretKeepsThePrincipal (0.07s)
    installation_principal_test.go:123: principal = "" after a secret rotation, want it carried forward as "5c09e200-0000-4000-8000-0000000000c1" — the bot silently changed hands to whoever pressed save
FAIL
```

**2. `TestUpsert_FirstInstallDoesNotInheritAnotherAgentsPrincipal`** — agent A has a bot with a principal; agent B gets its first bot. Asserts B's install carries no principal and A's row is untouched. This drives the `agent_id` filter in `currentInstallation`, which is the one place the workspace-scoped read could go wrong.

Reverted that filter (`if row.AgentID != agentID { continue }` removed):

```
--- FAIL: TestUpsert_FirstInstallDoesNotInheritAnotherAgentsPrincipal (0.05s)
    installation_principal_test.go:162: principal = "5c09e200-0000-4000-8000-0000000000c1" on a first install, want empty (the installer) — agent B's bot was handed to agent A's principal
FAIL
```

**3. `TestInstallConfig_PrincipalKeyIsAbsentUntilSet`** — no DB. The encode/decode pair: the key is absent until set, a pre-change row decodes, a set principal round-trips.

Reverted `omitempty` (`json:"principal_user_id"`):

```
--- FAIL: TestInstallConfig_PrincipalKeyIsAbsentUntilSet (0.00s)
    installation_principal_test.go:193: an install that sets no principal wrote principal_user_id anyway: {"app_id":"BOT-1","bot_id":"BOT-1","secret_encrypted":"c2VhbGVk","principal_user_id":""}
FAIL
```

## Verification

`go build ./...` and `go vet ./...` clean; `gofmt` clean.

Full `go test ./internal/...` against a migrated Postgres: green except `TestProbeAgentCLIs_QoderResolvesViaLoginShell` in `internal/daemon`, which fails identically on unmodified `main` on this machine (a real `qoderclicn` on `PATH` beats the test's fake) and is unrelated to this change.

```
ok  github.com/multica-ai/multica/server/internal/integrations/wecom
```
