### PR TITLE
feat(wecom): add the MULTICA_WECOM_TRACE operator switch (and stop it printing binding tokens)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -195,7 +195,11 @@ GOOGLE_REDIRECT_URI=${FRONTEND_ORIGIN}/auth/callback
 #                              smart-bot secret is never read, but user text
 #                              is not — turn it on deliberately and unset it
 #                              when the session ends. The backend logs a
-#                              warning on every boot while it is on.
+#                              warning on every boot while it is on. Read at
+#                              boot, so changing it needs a backend restart;
+#                              who can read the resulting logs and how long
+#                              they are kept is your log stack's business, see
+#                              SELF_HOSTING_ADVANCED.md → WeCom frame tracing.
 #
 # Per-installation credentials (bot_id, secret) are NOT env vars — they
 # live in the channel_installation table. Create an installation from the

--- a/.env.example
+++ b/.env.example
@@ -182,6 +182,21 @@ GOOGLE_REDIRECT_URI=${FRONTEND_ORIGIN}/auth/callback
 #                              and the wecom Web-UI endpoints return 503.
 #                              Generate with: openssl rand -base64 32
 #
+#   MULTICA_WECOM_TRACE        1 = log every frame this adapter reads and
+#                              writes, so a real-device session can be checked
+#                              against the server afterwards. Empty / anything
+#                              else = off, which is the right state outside a
+#                              debugging session.
+#                              This logs MESSAGE CONTENT: each traced frame
+#                              carries the first 120 runes of the message body
+#                              (runes, not bytes, so Chinese text is not cut
+#                              mid-character). Binding tokens and other
+#                              token=… query parameters are redacted, and the
+#                              smart-bot secret is never read, but user text
+#                              is not — turn it on deliberately and unset it
+#                              when the session ends. The backend logs a
+#                              warning on every boot while it is on.
+#
 # Per-installation credentials (bot_id, secret) are NOT env vars — they
 # live in the channel_installation table. Create an installation from the
 # WeCom settings tab in the app (Settings → Integrations → WeCom), which
@@ -195,6 +210,7 @@ GOOGLE_REDIRECT_URI=${FRONTEND_ORIGIN}/auth/callback
 # the lease are dropped and the user sees nothing. Until cross-replica outbound
 # routing lands, run the WeCom-enabled backend as a SINGLE replica.
 MULTICA_WECOM_SECRET_KEY=
+MULTICA_WECOM_TRACE=
 
 # S3 / CloudFront
 # S3_BUCKET — bucket NAME only (e.g. "my-bucket"). Do NOT include the

--- a/SELF_HOSTING_ADVANCED.md
+++ b/SELF_HOSTING_ADVANCED.md
@@ -162,6 +162,25 @@ rewrite configuration. Its backend fallback therefore accepts
 `BACKEND_PORT` → `API_PORT` → `SERVER_PORT` → `8080`, while an explicit
 `REMOTE_API_URL` or `NEXT_PUBLIC_API_URL` still takes priority.
 
+### WeCom frame tracing
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `MULTICA_WECOM_TRACE` | empty (off) | `1` records every WeCom frame the backend reads and writes, including the first 120 runes of each message body. Anything else is off. |
+
+Turn it on for a debugging session and unset it when the session ends. Before
+you do:
+
+- **It is read at boot, so changing it needs a backend restart** — `docker compose -f docker-compose.selfhost.yml up -d backend`. There is no runtime toggle. While it is on, the backend logs a warning on every startup saying so.
+- **Anyone who can read the backend's logs can read the traced message text.** That is a wider audience than the WeCom chat it came from: your `docker logs` / journald / log shipper, and whoever administers them. Binding tokens and other `token=…` parameters are redacted and the smart-bot secret is never read, but user message content is not.
+- **Retention is your log stack's, not the application's.** The backend writes to stderr and keeps nothing itself, so how long the traced text survives is whatever your Docker logging driver or shipper is set to. If that is "forever", decide about it before enabling rather than after.
+
+Each outbound frame produces two lines that share a `seq`: `dir=out` when it is
+about to be written, and `dir=out.done` with `ok=true` / `ok=false` once the
+socket has answered. `seq` is the frame's position in the write order, so the
+pair tells you what the server saw and in which order; an attempt with no
+matching outcome is a write that never returned.
+
 ### CLI / Daemon
 
 These are configured on each user's machine, not on the server:

--- a/SELF_HOSTING_ADVANCED.md
+++ b/SELF_HOSTING_ADVANCED.md
@@ -178,8 +178,13 @@ you do:
 Each outbound frame produces two lines that share a `seq`: `dir=out` when it is
 about to be written, and `dir=out.done` with `ok=true` / `ok=false` once the
 socket has answered. `seq` is the frame's position in the write order, so the
-pair tells you what the server saw and in which order; an attempt with no
+pair tells you what this backend sent and in which order; an attempt with no
 matching outcome is a write that never returned.
+
+`ok=true` means the frame reached the socket, not that WeCom accepted it. For
+the platform's verdict, match the frame's `req_id` against the `dir=in` line
+answering it and read that line's `errcode` — a frame can be written
+successfully and still be rejected there.
 
 ### CLI / Daemon
 

--- a/docker-compose.selfhost.yml
+++ b/docker-compose.selfhost.yml
@@ -146,6 +146,12 @@ services:
       # subscribe credentials at connection time, and to seal the secret when
       # an installation is created from the WeCom settings tab.
       MULTICA_WECOM_SECRET_KEY: ${MULTICA_WECOM_SECRET_KEY:-}
+      # 1 = log every inbound and outbound WeCom frame, including the first
+      # 120 runes of each message body, so a real-device session can be
+      # checked against the server afterwards. Off unless set; turn it on only
+      # for a debugging session and unset it when that session ends, because
+      # what it records is user message content.
+      MULTICA_WECOM_TRACE: ${MULTICA_WECOM_TRACE:-}
     restart: unless-stopped
 
   frontend:

--- a/server/cmd/server/router.go
+++ b/server/cmd/server/router.go
@@ -708,6 +708,15 @@ func NewRouterWithOptions(pool *pgxpool.Pool, hub *realtime.Hub, bus *events.Bus
 				// user in WeCom sees no response.
 				wecom.NewOutbound(queries, wecomSenders, slog.Default()).Register(bus)
 
+				// Frame tracing: off unless an operator asks for it. It
+				// records a bounded prefix of message text, so the fact that
+				// it is on has to be visible in the log it is writing into —
+				// otherwise a session gets left switched on and nobody
+				// notices message content accumulating.
+				if wecom.SetTrace(os.Getenv("MULTICA_WECOM_TRACE") == "1") {
+					slog.Warn("wecom: frame tracing ON — records message text; unset MULTICA_WECOM_TRACE when done")
+				}
+
 				slog.Info("wecom integration enabled (smart bot, long connection)")
 				// SINGLE-REPLICA CONSTRAINT: WeCom outbound (agent replies +
 				// inbox pushes) is delivered only by the replica holding each

--- a/server/internal/integrations/wecom/trace.go
+++ b/server/internal/integrations/wecom/trace.go
@@ -27,7 +27,7 @@ package wecom
 // prefix is capped rather than full, the cap counts runes so a Chinese
 // message is not cut mid-character, bearer tokens are redacted out of it, and
 // nothing here reads a credential field: the bot secret rides in the
-// aibot_subscribe body, which traceOut never descends into.
+// aibot_subscribe body, which traceOutFields never descends into.
 
 import (
 	"log/slog"
@@ -94,37 +94,117 @@ func tracePreview(s string) string {
 	return string(out)
 }
 
-// traceOut records a frame on its way to WeCom. Called from wsSender.write,
-// the one place that writes the socket, so nothing can be sent without
-// appearing here.
+// An outbound frame is recorded twice, as an attempt and an outcome sharing a
+// seq: "dir=out" when it is about to go on the wire, "dir=out.done" with
+// ok=true/false once SetWriteDeadline and WriteMessage have had their say.
+//
+// One line would not do. The trace exists to answer "did this frame actually
+// reach the wire?", and a single line written before the write cannot answer
+// it — a rejected frame and a delivered one look identical. A single line
+// written after the write answers it only for writes that return: a write
+// that hangs or a process killed mid-write leaves nothing at all, which is
+// the silent failure the switch exists to remove. Two lines let a reader pair
+// them by seq and see an attempt with no outcome for what it is.
+//
+// The pair is also why the seq exists rather than pairing on req_id alone: a
+// pong echoes the server's req_id, which may be empty or repeated, so req_id
+// is not a key. seq is assigned under the writer mutex and never goes on the
+// wire; it is the frame's position in the wire order.
+
+// Stages of one write, named on a failed outcome so a rejected frame is
+// distinguishable from one whose deadline could not even be set.
+const (
+	traceStageDeadline = "set_write_deadline"
+	traceStageWrite    = "write_message"
+)
+
+// outTrace is what tracing keeps about one outbound frame between extracting
+// its fields and emitting its two lines. A nil outTrace means this frame is
+// not being traced; both lines are governed by that single decision, so the
+// log can never hold an attempt whose outcome was suppressed by the switch
+// flipping halfway through a write.
+type outTrace struct {
+	attrs []any
+	cmd   string
+	reqID string
+}
+
+// traceOutFields extracts what tracing records about a frame on its way to
+// WeCom. wsSender.write calls it BEFORE taking the writer mutex: this is the
+// expensive half — a regexp redaction pass and a rune-by-rune cut over the
+// message body — and none of it needs to be serialized with the socket. Only
+// the emit does, and that is traceOutAttempt's job.
 //
 // It reads named fields rather than dumping the frame: the aibot_subscribe
 // body carries the smart-bot secret, and a wholesale dump would put it in the
 // log. Add a field here only after checking what every cmd puts under it.
-func traceOut(log *slog.Logger, frame map[string]any) {
+func traceOutFields(log *slog.Logger, frame map[string]any) *outTrace {
 	if !tracingOn() || log == nil {
-		return
+		return nil
 	}
-	attrs := []any{"dir", "out"}
+	t := &outTrace{}
 	if cmd, ok := frame["cmd"].(string); ok {
-		attrs = append(attrs, "cmd", cmd)
+		t.cmd = cmd
+		t.attrs = append(t.attrs, "cmd", cmd)
 	}
 	if h, ok := frame["headers"].(frameHeaders); ok && h.ReqID != "" {
-		attrs = append(attrs, "req_id", h.ReqID)
+		t.reqID = h.ReqID
+		t.attrs = append(t.attrs, "req_id", h.ReqID)
 	}
 	if body, ok := frame["body"].(map[string]any); ok {
 		if v, ok := body["chatid"].(string); ok {
-			attrs = append(attrs, "chatid", v)
+			t.attrs = append(t.attrs, "chatid", v)
 		}
 		if v, ok := body["chat_type"].(int); ok {
-			attrs = append(attrs, "chat_type", v)
+			t.attrs = append(t.attrs, "chat_type", v)
 		}
 		if v, ok := body["msgtype"].(string); ok {
-			attrs = append(attrs, "msgtype", v)
+			t.attrs = append(t.attrs, "msgtype", v)
 		}
 		if md, ok := body["markdown"].(map[string]string); ok {
-			attrs = append(attrs, "len", len(md["content"]), "text", tracePreview(md["content"]))
+			t.attrs = append(t.attrs, "len", len(md["content"]), "text", tracePreview(md["content"]))
 		}
+	}
+	return t
+}
+
+// traceOutAttempt records a frame at the moment it is about to be written.
+// wsSender.write calls it under the writer mutex, which is the point at which
+// concurrent senders — the ping loop, agent replies, inbox pushes — become
+// ordered. So the order of these lines is the order the frames reach
+// WriteMessage, by construction rather than by correlation.
+func traceOutAttempt(log *slog.Logger, seq uint64, t *outTrace) {
+	if t == nil {
+		return
+	}
+	attrs := make([]any, 0, len(t.attrs)+4)
+	attrs = append(attrs, "dir", "out", "seq", seq)
+	attrs = append(attrs, t.attrs...)
+	log.Info("wecom trace", attrs...)
+}
+
+// traceOutResult records what became of the attempt carrying the same seq.
+// Also under the writer mutex, so an attempt and its outcome are never split
+// by another goroutine's frame.
+//
+// The error text goes through tracePreview: it is the socket's words, not
+// ours, and everything else this file writes is bounded and redacted.
+func traceOutResult(log *slog.Logger, seq uint64, t *outTrace, stage string, err error) {
+	if t == nil {
+		return
+	}
+	attrs := make([]any, 0, 12)
+	attrs = append(attrs, "dir", "out.done", "seq", seq)
+	if t.cmd != "" {
+		attrs = append(attrs, "cmd", t.cmd)
+	}
+	if t.reqID != "" {
+		attrs = append(attrs, "req_id", t.reqID)
+	}
+	if err != nil {
+		attrs = append(attrs, "ok", false, "stage", stage, "error", tracePreview(err.Error()))
+	} else {
+		attrs = append(attrs, "ok", true)
 	}
 	log.Info("wecom trace", attrs...)
 }

--- a/server/internal/integrations/wecom/trace.go
+++ b/server/internal/integrations/wecom/trace.go
@@ -1,0 +1,182 @@
+package wecom
+
+// trace.go — an opt-in record of every frame this adapter reads and writes.
+//
+// Why it exists: nothing else in the package logs a frame. Failures log, and
+// only failures — a bad envelope, a non-zero server ack. A run that goes
+// wrong QUIETLY leaves no trace on the server at all: the reply addressed to
+// the room instead of the person, the command that was silently dropped, the
+// receipt that went out twice. Verifying those today needs someone to
+// describe what they saw on a phone, which is slow, lossy, and impossible for
+// anything about ordering or timing.
+//
+// With MULTICA_WECOM_TRACE=1 the server records enough to check a real-device
+// session afterwards: which way the frame went, what chat it was addressed
+// to, whether that chat is a room or a person, and what the server said back.
+//
+// Why not slog.Debug, which the siblings use for their per-frame lines
+// (slack_channel.go:162, lark/ws_connector.go:339): logger.parseLevel
+// defaults LOG_LEVEL to *debug*, so a Debug call is on in every deployment
+// that has not set LOG_LEVEL. Message text must not be logged by default, so
+// the switch has to be its own, and default to off.
+//
+// Off is the right state outside a test session. What this records includes a
+// bounded prefix of message text, because "which of the copy strings was
+// that" cannot be answered from lengths alone — so it is message content, in
+// a log, and it should be turned on deliberately and turned off after. The
+// prefix is capped rather than full, the cap counts runes so a Chinese
+// message is not cut mid-character, bearer tokens are redacted out of it, and
+// nothing here reads a credential field: the bot secret rides in the
+// aibot_subscribe body, which traceOut never descends into.
+
+import (
+	"log/slog"
+	"regexp"
+	"strings"
+	"sync/atomic"
+)
+
+// tracing is set once at boot and read on every frame.
+var tracing atomic.Bool
+
+// SetTrace turns frame tracing on or off. Called from the server wiring with
+// MULTICA_WECOM_TRACE; returns what it set so the caller can log it.
+func SetTrace(on bool) bool {
+	tracing.Store(on)
+	return on
+}
+
+// tracingOn reports whether frames are being recorded.
+func tracingOn() bool { return tracing.Load() }
+
+// tracePreviewRunes bounds what of a message body reaches the log. Long
+// enough to tell one copy string from another and to see which language it is
+// in; short enough that a transcript is not reconstructable from the log.
+const tracePreviewRunes = 120
+
+// tracePreview returns a bounded, single-line prefix of s with any bearer
+// token redacted. Newlines become spaces so one frame stays one log line, and
+// the cut is on a rune boundary.
+//
+// The redaction is not optional. OutboundReplier.sendBindingPrompt builds
+// "👋 请先绑定你的 Multica 账号，才能与我对话：\n" + appURL + "/wecom/bind?token=" +
+// a 43-character token, and with a normal MULTICA_APP_URL the token's last
+// character lands at rune 107-112 — inside the cap. Without this, turning
+// tracing on for a debugging session would log live binding credentials in
+// full. A binding token is a bearer credential (RedeemAndBind checks only
+// that the redeemer belongs to the token's workspace, and the bind page
+// redeems on load as whoever is signed in), so whoever could read the log
+// could bind that sender's WeCom identity to their own Multica account before
+// the user clicked their own link — the same hijack replier.go:150 already
+// guards against by refusing to post the link into a room.
+//
+// It matches on the query parameter rather than on the bind path, because
+// this is a package-level function with no access to the configured path
+// (OutboundReplier owns it, and BindingPath is configurable). A "token=" in a
+// URL is the shape worth hiding wherever it appears.
+func tracePreview(s string) string {
+	s = redactBearerTokens(s)
+	out := make([]rune, 0, tracePreviewRunes)
+	cut := false
+	for _, r := range s {
+		if len(out) == tracePreviewRunes {
+			cut = true
+			break
+		}
+		if r == '\n' || r == '\r' {
+			r = ' '
+		}
+		out = append(out, r)
+	}
+	if cut {
+		return string(out) + "…"
+	}
+	return string(out)
+}
+
+// traceOut records a frame on its way to WeCom. Called from wsSender.write,
+// the one place that writes the socket, so nothing can be sent without
+// appearing here.
+//
+// It reads named fields rather than dumping the frame: the aibot_subscribe
+// body carries the smart-bot secret, and a wholesale dump would put it in the
+// log. Add a field here only after checking what every cmd puts under it.
+func traceOut(log *slog.Logger, frame map[string]any) {
+	if !tracingOn() || log == nil {
+		return
+	}
+	attrs := []any{"dir", "out"}
+	if cmd, ok := frame["cmd"].(string); ok {
+		attrs = append(attrs, "cmd", cmd)
+	}
+	if h, ok := frame["headers"].(frameHeaders); ok && h.ReqID != "" {
+		attrs = append(attrs, "req_id", h.ReqID)
+	}
+	if body, ok := frame["body"].(map[string]any); ok {
+		if v, ok := body["chatid"].(string); ok {
+			attrs = append(attrs, "chatid", v)
+		}
+		if v, ok := body["chat_type"].(int); ok {
+			attrs = append(attrs, "chat_type", v)
+		}
+		if v, ok := body["msgtype"].(string); ok {
+			attrs = append(attrs, "msgtype", v)
+		}
+		if md, ok := body["markdown"].(map[string]string); ok {
+			attrs = append(attrs, "len", len(md["content"]), "text", tracePreview(md["content"]))
+		}
+	}
+	log.Info("wecom trace", attrs...)
+}
+
+// traceIn records a frame arriving from WeCom, including the server's verdict
+// on something we sent — an errcode here is how a silent failure becomes
+// visible. dispatchFrame only warns on a non-zero errcode for the anonymous
+// ack case, so without this a rejected aibot_send_msg is the only rejection
+// that shows up at all.
+func traceIn(log *slog.Logger, env frameEnvelope) {
+	if !tracingOn() || log == nil {
+		return
+	}
+	log.Info("wecom trace",
+		"dir", "in",
+		"cmd", env.Cmd,
+		"req_id", env.Headers.ReqID,
+		"errcode", env.ErrCode,
+		"errmsg", tracePreview(env.ErrMsg),
+	)
+}
+
+// traceInbound records a decoded user message: what the adapter believes
+// about who sent it and where it landed, which is exactly the pair that gets
+// confused (the room's id in one field, the person's in the other). traceIn
+// alone cannot show it — the callback body is still raw JSON at that point.
+func traceInbound(log *slog.Logger, mc aibotMsgCallback, text string) {
+	if !tracingOn() || log == nil {
+		return
+	}
+	log.Info("wecom trace",
+		"dir", "in.msg",
+		"msg_id", mc.MsgID,
+		"chatid", mc.ChatID,
+		"chat_type", mc.ChatType,
+		"sender", mc.From.UserID,
+		"msgtype", mc.MsgType,
+		"len", len(text),
+		"text", tracePreview(text),
+	)
+}
+
+// tokenParamPattern finds a token carried as a query parameter, whatever path
+// it sits on. Deliberately broad: an access_token or a code is no safer in a
+// log than a binding token.
+var tokenParamPattern = regexp.MustCompile(`(?i)\b((?:binding_token|access_token|token|code)=)([^\s&"'<>]+)`)
+
+// redactBearerTokens replaces the value of any token-shaped query parameter
+// with a fixed marker, keeping enough of the line to be worth logging.
+func redactBearerTokens(s string) string {
+	if !strings.Contains(s, "=") {
+		return s
+	}
+	return tokenParamPattern.ReplaceAllString(s, "${1}[redacted]")
+}

--- a/server/internal/integrations/wecom/trace_test.go
+++ b/server/internal/integrations/wecom/trace_test.go
@@ -1,0 +1,369 @@
+package wecom
+
+// trace_test.go — guards for the MULTICA_WECOM_TRACE operator switch. Three
+// things have to hold or the switch is not shippable: it records nothing at
+// all when off, it records enough to be worth turning on, and what it records
+// is never a credential.
+//
+// These tests do NOT call t.Parallel: `tracing` is a package-level atomic and
+// the assertions are about whether a log line exists. `go test` runs top-level
+// non-parallel tests one at a time, so they do not interleave with each other;
+// every one restores the switch on the way out.
+
+import (
+	"bytes"
+	"context"
+	"crypto/rand"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"log/slog"
+	"net/url"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+	"unicode/utf8"
+
+	"github.com/gorilla/websocket"
+
+	"github.com/multica-ai/multica/server/internal/integrations/channel"
+	"github.com/multica-ai/multica/server/internal/integrations/channel/engine"
+)
+
+// ---- capture helpers ----
+
+// syncBuf is an io.Writer safe for the Connect goroutine to write while the
+// test body reads.
+type syncBuf struct {
+	mu  sync.Mutex
+	buf bytes.Buffer
+}
+
+func (b *syncBuf) Write(p []byte) (int, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.Write(p)
+}
+
+func (b *syncBuf) String() string {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.String()
+}
+
+// capturingLogger returns a logger writing into a buffer the test can read.
+func capturingLogger() (*slog.Logger, *syncBuf) {
+	var b syncBuf
+	return slog.New(slog.NewTextHandler(&b, &slog.HandlerOptions{Level: slog.LevelDebug})), &b
+}
+
+// withTrace sets the switch for the duration of one test and restores it.
+func withTrace(t *testing.T, on bool) {
+	t.Helper()
+	prev := tracingOn()
+	SetTrace(on)
+	t.Cleanup(func() { SetTrace(prev) })
+}
+
+// productionShapedToken mints a token the same way BindingTokenService.Mint
+// does (32 random bytes, base64url, no padding → 43 characters), so the
+// redaction test is measured against the real credential shape rather than a
+// short placeholder that would fit under any cap.
+func productionShapedToken(t *testing.T) string {
+	t.Helper()
+	buf := make([]byte, 32)
+	if _, err := rand.Read(buf); err != nil {
+		t.Fatalf("rand: %v", err)
+	}
+	return base64.RawURLEncoding.EncodeToString(buf)
+}
+
+// callbackConn acks the subscribe frame, then delivers one aibot_msg_callback,
+// then drops the socket so Connect returns. It is the smallest script that
+// exercises every trace point: the subscribe write (traceOut), the subscribe
+// ack (traceIn in the handshake loop), the callback frame (traceIn in the read
+// loop), and the decoded message (traceInbound).
+type callbackConn struct {
+	mu       sync.Mutex
+	queue    [][]byte
+	acked    bool
+	callback []byte
+	closeOne sync.Once
+}
+
+func (c *callbackConn) WriteMessage(_ int, data []byte) error {
+	var env frameEnvelope
+	if err := json.Unmarshal(data, &env); err != nil {
+		return nil
+	}
+	if env.Cmd == cmdSubscribe {
+		ack, _ := json.Marshal(frameEnvelope{Headers: frameHeaders{ReqID: env.Headers.ReqID}})
+		c.mu.Lock()
+		c.queue = append(c.queue, ack)
+		c.mu.Unlock()
+	}
+	return nil
+}
+
+func (c *callbackConn) ReadMessage() (int, []byte, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if len(c.queue) > 0 {
+		next := c.queue[0]
+		c.queue = c.queue[1:]
+		return websocket.TextMessage, next, nil
+	}
+	if !c.acked {
+		c.acked = true
+		return websocket.TextMessage, c.callback, nil
+	}
+	return 0, nil, errors.New("simulated drop")
+}
+
+func (c *callbackConn) SetReadDeadline(time.Time) error  { return nil }
+func (c *callbackConn) SetWriteDeadline(time.Time) error { return nil }
+func (c *callbackConn) Close() error                     { c.closeOne.Do(func() {}); return nil }
+
+// runOneCallback drives a full Connect against a scripted socket carrying one
+// text message, and returns everything the channel logged.
+func runOneCallback(t *testing.T, text string) string {
+	t.Helper()
+	mc := aibotMsgCallback{MsgID: "MSG_1", ChatID: "GROUP_CHAT_ID", ChatType: "group", MsgType: "text"}
+	mc.From.UserID = "SENDER_USERID"
+	mc.Text.Content = text
+	body, err := json.Marshal(mc)
+	if err != nil {
+		t.Fatalf("marshal callback: %v", err)
+	}
+	frame, err := json.Marshal(frameEnvelope{Cmd: cmdMsgCallback, Headers: frameHeaders{ReqID: "REQ_1"}, Body: body})
+	if err != nil {
+		t.Fatalf("marshal frame: %v", err)
+	}
+
+	log, buf := capturingLogger()
+	c := &wecomChannel{
+		installationID: mustTestUUID(t),
+		botID:          "bot-1",
+		secret:         "THE_SMART_BOT_SECRET",
+		handler:        func(context.Context, channel.InboundMessage) error { return nil },
+		dialer:         scriptedDialer{conn: &callbackConn{callback: frame}},
+		wsURL:          "wss://example.test/ws",
+		logger:         log,
+		senders:        newSendersRegistry(),
+	}
+
+	done := make(chan struct{})
+	go func() { _ = c.Connect(context.Background()); close(done) }()
+	select {
+	case <-done:
+	case <-time.After(3 * time.Second):
+		t.Fatal("Connect did not return within 3s")
+	}
+	return buf.String()
+}
+
+// ---- the guards ----
+
+// TestTraceOffRecordsNothing is the one that makes the switch safe to ship:
+// with MULTICA_WECOM_TRACE unset, a real inbound message and the frames around
+// it must leave no trace line at all. The logger is at LevelDebug — the
+// package default (logger.parseLevel falls through to debug) — so a trace line
+// that is merely "debug level" would still be written here.
+func TestTraceOffRecordsNothing(t *testing.T) {
+	withTrace(t, false)
+
+	out := runOneCallback(t, "一条不该被记录的消息")
+
+	if strings.Contains(out, "wecom trace") {
+		t.Errorf("tracing is off but a trace line was written:\n%s", out)
+	}
+	if strings.Contains(out, "一条不该被记录的消息") {
+		t.Errorf("tracing is off but the message body reached the log:\n%s", out)
+	}
+}
+
+// TestTraceOnRecordsBothDirections is the other half: turned on, the switch has
+// to actually answer the question it exists for — which frame went which way,
+// addressed to which chat, from which person, and what the server said back.
+func TestTraceOnRecordsBothDirections(t *testing.T) {
+	withTrace(t, true)
+
+	out := runOneCallback(t, "hello from the room")
+
+	for _, want := range []string{
+		`dir=out`,             // the subscribe frame we wrote
+		`cmd=aibot_subscribe`, //
+		`dir=in`,              // the server's ack for it
+		`dir=in.msg`,          // the decoded user message
+		`chatid=GROUP_CHAT_ID`,
+		`sender=SENDER_USERID`,
+		`chat_type=group`,
+		`msg_id=MSG_1`,
+		`text="hello from the room"`,
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("trace output is missing %q; got:\n%s", want, out)
+		}
+	}
+}
+
+// TestTraceNeverLogsTheSmartBotSecret pins the reason traceOut reads named
+// fields instead of dumping the frame: the aibot_subscribe body carries the
+// installation's decrypted smart-bot secret. Replacing the field-by-field
+// walk with a body dump fails here.
+func TestTraceNeverLogsTheSmartBotSecret(t *testing.T) {
+	withTrace(t, true)
+
+	out := runOneCallback(t, "hi")
+
+	if !strings.Contains(out, "cmd=aibot_subscribe") {
+		t.Fatalf("the subscribe frame was not traced, so this test proves nothing:\n%s", out)
+	}
+	if strings.Contains(out, "THE_SMART_BOT_SECRET") {
+		t.Errorf("the smart-bot secret reached the log:\n%s", out)
+	}
+}
+
+// TestTraceNeverLogsABindingToken is the defect this PR had to close before
+// the switch could ship. sendBindingPrompt mints a 43-character bearer token
+// and puts it in a URL inside the message body; with a normal MULTICA_APP_URL
+// that whole URL lands inside the 120-rune preview, so an unredacted preview
+// prints a live credential. This drives the real replier path — mint, URL,
+// sendText, write, traceOut — and asserts the raw token never appears.
+//
+// A binding token is a bearer credential: RedeemAndBind checks only that the
+// redeemer belongs to the token's workspace, and the bind page redeems on load
+// as whoever is signed in. replier.go:150 already refuses to post the link
+// into a room for exactly this reason; a log the token is printed into is the
+// same hijack by another route.
+func TestTraceNeverLogsABindingToken(t *testing.T) {
+	withTrace(t, true)
+
+	rawToken := productionShapedToken(t)
+	const senderID = "SENDER_USERID"
+
+	log, buf := capturingLogger()
+	reg := newSendersRegistry()
+	inst := engine.ResolvedInstallation{ID: mustTestUUID(t)}
+	conn := &recordingConn{}
+	// autoAck, because sendBindingPrompt reads the server's verdict: a double
+	// that never answers turns the send into a 5-second timeout and the trace
+	// this test reads is never written.
+	reg.set(inst.ID, conn.autoAck(newWSSender(conn, log)))
+	r := NewOutboundReplier(OutboundReplierConfig{Senders: reg, AppURL: "https://multica.example"})
+	r.binding = fakeBinder{raw: rawToken}
+
+	msg := channel.InboundMessage{Source: channel.Source{
+		ChatID:   "GROUP_CHAT_ID",
+		ChatType: channel.ChatTypeGroup,
+		SenderID: senderID,
+	}}
+	if err := r.sendBindingPrompt(context.Background(), inst, msg, engine.Result{Sender: senderID}); err != nil {
+		t.Fatalf("sendBindingPrompt: %v", err)
+	}
+
+	out := buf.String()
+	// Guard against a vacuous pass: the prompt must have been traced at all.
+	if !strings.Contains(out, "dir=out") || !strings.Contains(out, "wecom/bind") {
+		t.Fatalf("the binding prompt was not traced, so this test proves nothing:\n%s", out)
+	}
+	if strings.Contains(out, rawToken) {
+		t.Errorf("the raw binding token reached the log:\n%s", out)
+	}
+	if !strings.Contains(out, "token=[redacted]") {
+		t.Errorf("expected the token parameter to be redacted in place; got:\n%s", out)
+	}
+}
+
+// TestBindingPromptFitsInsideThePreviewCap is the measurement behind the test
+// above: it shows the leak is reachable rather than theoretical. It rebuilds
+// the exact prompt sendBindingPrompt builds and asserts the token's LAST
+// character still falls inside tracePreviewRunes — i.e. an unredacted preview
+// would print the credential whole, not a useless fragment.
+func TestBindingPromptFitsInsideThePreviewCap(t *testing.T) {
+	rawToken := productionShapedToken(t)
+	if len(rawToken) != 43 {
+		t.Fatalf("token length = %d, want the 43 chars Mint produces", len(rawToken))
+	}
+	// Mirrors replier.go sendBindingPrompt.
+	bindURL := "https://multica.example" + "/wecom/bind" + "?token=" + url.QueryEscape(rawToken)
+	upToTokenEnd := "👋 请先绑定你的 Multica 账号，才能与我对话：\n" + bindURL
+
+	if n := utf8.RuneCountInString(upToTokenEnd); n > tracePreviewRunes {
+		t.Fatalf("the token ends at rune %d, past the %d-rune cap — the leak this "+
+			"PR redacts would not be reachable and the redaction rationale needs revisiting",
+			n, tracePreviewRunes)
+	}
+}
+
+// TestTracePreviewCutsOnARuneBoundary pins the cap to runes, not bytes. A
+// Chinese message is 3 bytes per character, so a byte-based cut both truncates
+// far too early and can split a character into invalid UTF-8 — which is how a
+// log line stops being readable in the deployment this switch exists for.
+// The offset case matters on its own: with a body that is a whole number of
+// 3-byte characters, a byte-based cut lands between characters by luck and
+// only truncates early. One ASCII character in front of the same body is
+// enough to make the same cut land mid-character and emit invalid UTF-8.
+func TestTracePreviewCutsOnARuneBoundary(t *testing.T) {
+	for _, body := range []string{
+		strings.Repeat("测", 300),
+		"x" + strings.Repeat("测", 300),
+	} {
+		got := tracePreview(body)
+
+		if !utf8.ValidString(got) {
+			t.Errorf("preview of %d-rune body is not valid UTF-8: %q", utf8.RuneCountInString(body), got)
+		}
+		trimmed := strings.TrimSuffix(got, "…")
+		if trimmed == got {
+			t.Errorf("a %d-rune body should have been marked as cut with …, got %q", utf8.RuneCountInString(body), got)
+		}
+		if n := utf8.RuneCountInString(trimmed); n != tracePreviewRunes {
+			t.Errorf("preview kept %d runes, want exactly %d", n, tracePreviewRunes)
+		}
+		if strings.ContainsRune(trimmed, utf8.RuneError) {
+			t.Errorf("preview contains a replacement character — a multi-byte rune was split: %q", trimmed)
+		}
+	}
+}
+
+// TestTracePreviewFlattensNewlines keeps one frame on one log line. The
+// binding prompt is three lines; split across log records it is far harder to
+// pair with the frame it belongs to.
+func TestTracePreviewFlattensNewlines(t *testing.T) {
+	got := tracePreview("first\nsecond\r\nthird")
+	if strings.ContainsAny(got, "\n\r") {
+		t.Errorf("preview still contains a line break: %q", got)
+	}
+	if !strings.Contains(got, "first") || !strings.Contains(got, "third") {
+		t.Errorf("preview dropped content while flattening: %q", got)
+	}
+}
+
+// TestRedactBearerTokensCoversTheTokenShapes covers the parameter names worth
+// hiding wherever they appear — the function matches on the query parameter,
+// not on the configured bind path, because BindingPath is configurable and
+// this package-level function cannot see it.
+func TestRedactBearerTokensCoversTheTokenShapes(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"binding url", "go to https://x.test/wecom/bind?token=abc123DEF now", "go to https://x.test/wecom/bind?token=[redacted] now"},
+		{"custom path", "https://x.test/custom/path?token=abc123DEF", "https://x.test/custom/path?token=[redacted]"},
+		{"binding_token param", "?binding_token=abc123DEF", "?binding_token=[redacted]"},
+		{"access_token param", "?access_token=abc123DEF", "?access_token=[redacted]"},
+		{"oauth code", "?code=abc123DEF", "?code=[redacted]"},
+		{"stops at ampersand", "?token=abc123DEF&next=/home", "?token=[redacted]&next=/home"},
+		{"leaves ordinary text alone", "the token is not in a url here", "the token is not in a url here"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := redactBearerTokens(tc.in); got != tc.want {
+				t.Errorf("redactBearerTokens(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}

--- a/server/internal/integrations/wecom/trace_test.go
+++ b/server/internal/integrations/wecom/trace_test.go
@@ -1,9 +1,11 @@
 package wecom
 
-// trace_test.go — guards for the MULTICA_WECOM_TRACE operator switch. Three
+// trace_test.go — guards for the MULTICA_WECOM_TRACE operator switch. Five
 // things have to hold or the switch is not shippable: it records nothing at
-// all when off, it records enough to be worth turning on, and what it records
-// is never a credential.
+// all when off, it records enough to be worth turning on, what it records is
+// never a credential, the order it records outbound frames in is the order
+// they reached the socket, and a frame that failed to go out does not read
+// like one that went.
 //
 // These tests do NOT call t.Parallel: `tracing` is a package-level atomic and
 // the assertions are about whether a log line exists. `go test` runs top-level
@@ -17,8 +19,10 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"log/slog"
 	"net/url"
+	"slices"
 	"strings"
 	"sync"
 	"testing"
@@ -81,7 +85,7 @@ func productionShapedToken(t *testing.T) string {
 
 // callbackConn acks the subscribe frame, then delivers one aibot_msg_callback,
 // then drops the socket so Connect returns. It is the smallest script that
-// exercises every trace point: the subscribe write (traceOut), the subscribe
+// exercises every trace point: the subscribe write (the dir=out pair), the subscribe
 // ack (traceIn in the handshake loop), the callback frame (traceIn in the read
 // loop), and the decoded message (traceInbound).
 type callbackConn struct {
@@ -208,7 +212,7 @@ func TestTraceOnRecordsBothDirections(t *testing.T) {
 	}
 }
 
-// TestTraceNeverLogsTheSmartBotSecret pins the reason traceOut reads named
+// TestTraceNeverLogsTheSmartBotSecret pins the reason traceOutFields reads named
 // fields instead of dumping the frame: the aibot_subscribe body carries the
 // installation's decrypted smart-bot secret. Replacing the field-by-field
 // walk with a body dump fails here.
@@ -365,5 +369,403 @@ func TestRedactBearerTokensCoversTheTokenShapes(t *testing.T) {
 				t.Errorf("redactBearerTokens(%q) = %q, want %q", tc.in, got, tc.want)
 			}
 		})
+	}
+}
+
+// ---- outbound ordering + outcome ----
+//
+// wsSender.write is the single writer for one connection, and the ping loop,
+// agent replies and inbox pushes all reach it concurrently. What follows pins
+// the two properties that gives the trace: the recorded order of outbound
+// frames is the order they reached WriteMessage, and every recorded attempt
+// carries a recorded outcome saying whether the socket took it.
+
+// traceLine is one "wecom trace" record with its attributes pulled apart, so a
+// test can ask for a field by name instead of matching a formatted line —
+// "dir=out" is a prefix of "dir=out.done" and substring checks confuse them.
+type traceLine struct {
+	fields map[string]string
+	raw    string
+}
+
+// hookHandler collects trace records and can run a hook after each one, with
+// its own lock already released.
+//
+// The released lock is the point of it. slog's stock handlers hold a mutex
+// across the whole of Handle, including the write to the sink, so two
+// goroutines emitting a trace line serialize inside the handler — which is
+// the very ordering under test. A handler that imposes an order of its own
+// would let these tests pass whether or not wsSender imposes one.
+type hookHandler struct {
+	mu    sync.Mutex
+	lines []traceLine
+	after func(traceLine) // set before any goroutine runs; never reassigned
+}
+
+func (h *hookHandler) Enabled(context.Context, slog.Level) bool { return true }
+func (h *hookHandler) WithAttrs([]slog.Attr) slog.Handler       { return h }
+func (h *hookHandler) WithGroup(string) slog.Handler            { return h }
+
+func (h *hookHandler) Handle(_ context.Context, r slog.Record) error {
+	if r.Message != "wecom trace" {
+		return nil
+	}
+	l := traceLine{fields: make(map[string]string)}
+	var b strings.Builder
+	b.WriteString(r.Message)
+	r.Attrs(func(a slog.Attr) bool {
+		l.fields[a.Key] = a.Value.String()
+		fmt.Fprintf(&b, " %s=%s", a.Key, a.Value.String())
+		return true
+	})
+	l.raw = b.String()
+
+	h.mu.Lock()
+	h.lines = append(h.lines, l)
+	h.mu.Unlock()
+
+	if h.after != nil {
+		h.after(l)
+	}
+	return nil
+}
+
+func (h *hookHandler) snapshot() []traceLine {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	return slices.Clone(h.lines)
+}
+
+// withDir returns the recorded lines for one direction, in the order they were
+// recorded.
+func withDir(lines []traceLine, dir string) []traceLine {
+	var out []traceLine
+	for _, l := range lines {
+		if l.fields["dir"] == dir {
+			out = append(out, l)
+		}
+	}
+	return out
+}
+
+// reqIDsOf is the recorded order of one direction, named by req_id.
+func reqIDsOf(lines []traceLine, dir string) []string {
+	var out []string
+	for _, l := range withDir(lines, dir) {
+		out = append(out, l.fields["req_id"])
+	}
+	return out
+}
+
+// wireConn records the order frames actually reached WriteMessage — by the
+// req_id each test frame carries — and can fail either half of the write.
+// deadlineErr, writeErr and onWrite are set before any goroutine starts and
+// never change afterwards.
+type wireConn struct {
+	mu      sync.Mutex
+	written []string
+
+	deadlineErr error
+	writeErr    error
+	onWrite     func()
+}
+
+func (c *wireConn) WriteMessage(_ int, data []byte) error {
+	var env frameEnvelope
+	_ = json.Unmarshal(data, &env)
+	if c.onWrite != nil {
+		c.onWrite()
+	}
+	c.mu.Lock()
+	c.written = append(c.written, env.Headers.ReqID)
+	c.mu.Unlock()
+	return c.writeErr
+}
+
+func (c *wireConn) order() []string {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return slices.Clone(c.written)
+}
+
+func (c *wireConn) ReadMessage() (int, []byte, error) {
+	return 0, nil, errors.New("wireConn is write-only")
+}
+func (c *wireConn) SetReadDeadline(time.Time) error  { return nil }
+func (c *wireConn) SetWriteDeadline(time.Time) error { return c.deadlineErr }
+func (c *wireConn) Close() error                     { return nil }
+
+// pingFrame is the smallest frame wsSender.write accepts, tagged with a req_id
+// the test can follow from the log onto the socket.
+func pingFrame(reqID string) map[string]any {
+	return map[string]any{"cmd": cmdPing, "headers": frameHeaders{ReqID: reqID}}
+}
+
+// traceParkBudget bounds how long the ordering test holds one writer inside
+// its trace emission. It is only ever paid in full when the recording happens
+// under the writer mutex — that is the case where the second writer is parked
+// on the mutex and can never signal, so the budget is what releases the first.
+// When the recording happens outside the mutex the second writer completes in
+// microseconds and the budget is not reached.
+const traceParkBudget = 750 * time.Millisecond
+
+// TestTraceOutOrderIsTheWireOrder is the deterministic guard for the ordering
+// property: the outbound trace has to name frames in the order the socket took
+// them, or an operator reading it draws the wrong conclusion about which of
+// two frames the server saw first — the question the switch exists to answer.
+//
+// The mechanism, rather than a race that may or may not show up: writer A is
+// held inside its own trace emission until writer B has run a whole write(),
+// and then both orders are compared.
+//
+//   - Recording under the writer mutex (correct): A holds the mutex while it
+//     is parked, B blocks on the mutex before recording anything, and the park
+//     ends on the budget. A is recorded first and reaches the socket first.
+//
+//   - Recording before the mutex (the reviewed defect): A holds nothing while
+//     it is parked. B records, takes the mutex, writes, and finishes — so A is
+//     recorded first but reaches the socket second, and the trace is a lie
+//     about the wire.
+func TestTraceOutOrderIsTheWireOrder(t *testing.T) {
+	withTrace(t, true)
+
+	startB := make(chan struct{})
+	bDone := make(chan struct{})
+
+	h := &hookHandler{}
+	h.after = func(l traceLine) {
+		if l.fields["dir"] != "out" || l.fields["req_id"] != "A" {
+			return
+		}
+		// A has just recorded its send attempt and has not written yet.
+		// Give B a whole write() and hold A here while it runs.
+		close(startB)
+		select {
+		case <-bDone:
+		case <-time.After(traceParkBudget):
+		}
+	}
+
+	conn := &wireConn{}
+	s := newWSSender(conn, slog.New(h))
+
+	go func() {
+		<-startB
+		if err := s.write(pingFrame("B")); err != nil {
+			t.Errorf("write B: %v", err)
+		}
+		close(bDone)
+	}()
+
+	if err := s.write(pingFrame("A")); err != nil {
+		t.Fatalf("write A: %v", err)
+	}
+	select {
+	case <-bDone:
+	case <-time.After(5 * time.Second):
+		t.Fatal("B's write never finished")
+	}
+
+	traced := reqIDsOf(h.snapshot(), "out")
+	wire := conn.order()
+	if len(wire) != 2 {
+		t.Fatalf("wire order = %v, want both frames written", wire)
+	}
+	if !slices.Equal(traced, wire) {
+		t.Errorf("trace order %v != wire order %v: the trace records a frame as "+
+			"sent before one that reached WriteMessage earlier, so it cannot be "+
+			"read as the order the server saw", traced, wire)
+	}
+}
+
+// TestTraceOutOrderUnderConcurrentWriters is the same property under the shape
+// it actually takes in production: many senders on one connection at once (the
+// ping loop, agent replies, inbox pushes). It also pins the two things that
+// make the record readable afterwards — seq counts the wire positions in
+// order, and every attempt is paired with an outcome under the same seq.
+func TestTraceOutOrderUnderConcurrentWriters(t *testing.T) {
+	withTrace(t, true)
+
+	const writers = 16
+
+	h := &hookHandler{}
+	// Hold the mutex for a moment on each write so the other writers pile up
+	// behind it; without contention nothing is being tested.
+	conn := &wireConn{onWrite: func() { time.Sleep(200 * time.Microsecond) }}
+	s := newWSSender(conn, slog.New(h))
+
+	start := make(chan struct{})
+	var wg sync.WaitGroup
+	for i := range writers {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			<-start
+			if err := s.write(pingFrame(fmt.Sprintf("W%02d", i))); err != nil {
+				t.Errorf("write W%02d: %v", i, err)
+			}
+		}(i)
+	}
+	close(start)
+	wg.Wait()
+
+	lines := h.snapshot()
+	traced := reqIDsOf(lines, "out")
+	wire := conn.order()
+
+	if len(wire) != writers {
+		t.Fatalf("%d frames reached the socket, want %d", len(wire), writers)
+	}
+	if !slices.Equal(traced, wire) {
+		t.Errorf("trace order != wire order under %d concurrent writers\n trace: %v\n  wire: %v",
+			writers, traced, wire)
+	}
+
+	// seq has to be the wire position, so a reader can recover the order from
+	// the field rather than from how the lines happen to sit in the file.
+	attempts := withDir(lines, "out")
+	for i, l := range attempts {
+		if want := fmt.Sprint(i + 1); l.fields["seq"] != want {
+			t.Errorf("attempt %d has seq=%q, want %q", i, l.fields["seq"], want)
+		}
+	}
+
+	// Every attempt is answered. An attempt with no outcome is a real signal
+	// (a write that hung, a process killed mid-write) and must not be one the
+	// tracing produces on its own.
+	outcomes := map[string]traceLine{}
+	for _, l := range withDir(lines, "out.done") {
+		outcomes[l.fields["seq"]] = l
+	}
+	if len(outcomes) != writers {
+		t.Fatalf("%d outcomes recorded for %d attempts", len(outcomes), writers)
+	}
+	for _, a := range attempts {
+		o, ok := outcomes[a.fields["seq"]]
+		if !ok {
+			t.Errorf("attempt seq=%s has no outcome", a.fields["seq"])
+			continue
+		}
+		if o.fields["req_id"] != a.fields["req_id"] {
+			t.Errorf("outcome seq=%s is for req_id %q, attempt was %q",
+				a.fields["seq"], o.fields["req_id"], a.fields["req_id"])
+		}
+		if o.fields["ok"] != "true" {
+			t.Errorf("outcome seq=%s reports %q for a write that succeeded", a.fields["seq"], o.fields["ok"])
+		}
+	}
+}
+
+// onlyOutcome returns the single "dir=out.done" line, and fails the test if
+// the attempt or the outcome is missing — an assertion about a line that was
+// never written proves nothing.
+func onlyOutcome(t *testing.T, lines []traceLine) traceLine {
+	t.Helper()
+	if n := len(withDir(lines, "out")); n != 1 {
+		t.Fatalf("%d send attempts recorded, want exactly 1", n)
+	}
+	got := withDir(lines, "out.done")
+	if len(got) != 1 {
+		t.Fatalf("%d outcomes recorded, want exactly 1 — a send with no recorded "+
+			"outcome is indistinguishable from a successful one", len(got))
+	}
+	return got[0]
+}
+
+// TestTraceOutRecordsAFailedWrite is the second half of the blocking review
+// point. "Did this frame actually reach the wire?" is what an operator turns
+// the switch on to ask, and a rejected WriteMessage used to leave a log
+// identical to a delivered frame's.
+func TestTraceOutRecordsAFailedWrite(t *testing.T) {
+	withTrace(t, true)
+
+	h := &hookHandler{}
+	conn := &wireConn{writeErr: errors.New("websocket: close sent")}
+	s := newWSSender(conn, slog.New(h))
+
+	if err := s.write(pingFrame("R1")); err == nil {
+		t.Fatal("write returned nil for a socket that rejected the frame")
+	}
+
+	o := onlyOutcome(t, h.snapshot())
+	if o.fields["ok"] != "false" {
+		t.Errorf("outcome reports ok=%q for a failed write; got %s", o.fields["ok"], o.raw)
+	}
+	if o.fields["req_id"] != "R1" {
+		t.Errorf("outcome req_id = %q, want R1 so it pairs with the attempt", o.fields["req_id"])
+	}
+	if o.fields["stage"] != traceStageWrite {
+		t.Errorf("outcome stage = %q, want %q", o.fields["stage"], traceStageWrite)
+	}
+	if !strings.Contains(o.fields["error"], "close sent") {
+		t.Errorf("outcome does not carry the socket's error; got %s", o.raw)
+	}
+}
+
+// TestTraceOutRecordsAFailedWriteDeadline covers the other early return. It
+// matters on its own because nothing reaches the socket at all here: the trace
+// must say so rather than show a send that never happened.
+func TestTraceOutRecordsAFailedWriteDeadline(t *testing.T) {
+	withTrace(t, true)
+
+	h := &hookHandler{}
+	conn := &wireConn{deadlineErr: errors.New("set tcp: use of closed network connection")}
+	s := newWSSender(conn, slog.New(h))
+
+	if err := s.write(pingFrame("R2")); err == nil {
+		t.Fatal("write returned nil when the write deadline could not be set")
+	}
+	if n := len(conn.order()); n != 0 {
+		t.Fatalf("%d frames reached WriteMessage, want 0 — the deadline failed first", n)
+	}
+
+	o := onlyOutcome(t, h.snapshot())
+	if o.fields["ok"] != "false" {
+		t.Errorf("outcome reports ok=%q though no frame was written; got %s", o.fields["ok"], o.raw)
+	}
+	if o.fields["stage"] != traceStageDeadline {
+		t.Errorf("outcome stage = %q, want %q", o.fields["stage"], traceStageDeadline)
+	}
+}
+
+// TestTraceOutRecordsASuccessfulWrite is the control for the two above: the
+// outcome of a frame that did go out says so, and says nothing about a stage.
+func TestTraceOutRecordsASuccessfulWrite(t *testing.T) {
+	withTrace(t, true)
+
+	h := &hookHandler{}
+	conn := &wireConn{}
+	s := newWSSender(conn, slog.New(h))
+
+	if err := s.write(pingFrame("R3")); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	o := onlyOutcome(t, h.snapshot())
+	if o.fields["ok"] != "true" {
+		t.Errorf("outcome reports ok=%q for a delivered frame; got %s", o.fields["ok"], o.raw)
+	}
+	if o.fields["stage"] != "" {
+		t.Errorf("outcome names stage=%q on success; a stage is only meaningful on a failure", o.fields["stage"])
+	}
+	if o.fields["error"] != "" {
+		t.Errorf("outcome carries error=%q on success", o.fields["error"])
+	}
+}
+
+// TestTraceOffRecordsNoOutcomeEither keeps the outcome line on the same switch
+// as everything else. It is a second line per outbound frame, so a deployment
+// that never asked for tracing must not get it.
+func TestTraceOffRecordsNoOutcomeEither(t *testing.T) {
+	withTrace(t, false)
+
+	h := &hookHandler{}
+	conn := &wireConn{writeErr: errors.New("websocket: close sent")}
+	s := newWSSender(conn, slog.New(h))
+
+	_ = s.write(pingFrame("R4"))
+
+	if lines := h.snapshot(); len(lines) != 0 {
+		t.Errorf("tracing is off but %d trace lines were written: %v", len(lines), lines)
 	}
 }

--- a/server/internal/integrations/wecom/wecom_channel.go
+++ b/server/internal/integrations/wecom/wecom_channel.go
@@ -279,6 +279,7 @@ func (c *wecomChannel) Connect(ctx context.Context) (err error) {
 			log.Warn("wecom: bad frame envelope", "error", err, "size", len(payload))
 			continue
 		}
+		traceIn(log, env)
 		switch env.Cmd {
 		case cmdMsgCallback, cmdEventCallback:
 			select {
@@ -351,6 +352,10 @@ func (c *wecomChannel) subscribe(ctx context.Context, conn wsConn, sender *wsSen
 		if err := json.Unmarshal(payload, &env); err != nil {
 			continue
 		}
+		// Traced before the req_id filter: a subscribe that is rejected, or
+		// answered on a req_id we never sent, is exactly the failure an
+		// operator turns tracing on to see.
+		traceIn(log, env)
 		if env.Headers.ReqID != reqID {
 			continue
 		}
@@ -372,6 +377,7 @@ func (c *wecomChannel) dispatchFrame(ctx context.Context, env frameEnvelope, sen
 			log.Warn("wecom: bad aibot_msg_callback body", "error", err)
 			return nil
 		}
+		traceInbound(log, mc, mc.Text.Content)
 		msg := channelMessageFromCallback(c.botID, c.botDisplayName, mc, env.Headers.ReqID)
 		if mc.MsgType != "text" {
 			// Iteration 1 routes only text. Rather than drop other types

--- a/server/internal/integrations/wecom/ws_sender.go
+++ b/server/internal/integrations/wecom/ws_sender.go
@@ -222,6 +222,10 @@ func (s *wsSender) write(frame map[string]any) error {
 	if err != nil {
 		return fmt.Errorf("wecom: marshal frame: %w", err)
 	}
+	// Before the writer mutex: the trace is of what we decided to send, and
+	// holding the socket lock while formatting a log line would let tracing
+	// change the serialization order it is meant to observe.
+	traceOut(s.log, frame)
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	if err := s.conn.SetWriteDeadline(time.Now().Add(writeDeadline)); err != nil {

--- a/server/internal/integrations/wecom/ws_sender.go
+++ b/server/internal/integrations/wecom/ws_sender.go
@@ -76,6 +76,13 @@ type wsSender struct {
 	// inbound callbacks must not run on it — see the note on sendTextCtx.
 	ackMu   sync.Mutex
 	replies map[string]*replyWaiter
+
+	// seq numbers outbound frames in the order they reach the socket.
+	// Guarded by mu, so it is the wire order by construction, and it is what
+	// pairs a traced send attempt with its outcome — req_id cannot do that
+	// job, because a pong echoes the server's req_id and that may be empty
+	// or repeated. It never goes on the wire.
+	seq uint64
 }
 
 func newWSSender(conn wsConn, log *slog.Logger) *wsSender {
@@ -222,16 +229,31 @@ func (s *wsSender) write(frame map[string]any) error {
 	if err != nil {
 		return fmt.Errorf("wecom: marshal frame: %w", err)
 	}
-	// Before the writer mutex: the trace is of what we decided to send, and
-	// holding the socket lock while formatting a log line would let tracing
-	// change the serialization order it is meant to observe.
-	traceOut(s.log, frame)
+	// Extract the trace fields out here, emit them in there. This mutex is
+	// the point at which the ping loop, agent replies and inbox pushes become
+	// ordered, so a record taken inside it matches the wire by construction,
+	// while one taken outside is only correlated with it — a goroutine can
+	// emit its line and be descheduled before it takes the mutex, and the log
+	// then names the wrong frame as first. Extraction is the expensive half
+	// (a regexp redaction pass and a rune-wise cut over the message body) and
+	// needs no such guarantee, so it stays out here; what runs under the
+	// mutex is a nil check when tracing is off, and two log lines when it is
+	// on, against a socket write that is already in the same section.
+	t := traceOutFields(s.log, frame)
+
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	if err := s.conn.SetWriteDeadline(time.Now().Add(writeDeadline)); err != nil {
-		return err
+	s.seq++
+	traceOutAttempt(s.log, s.seq, t)
+
+	stage := traceStageDeadline
+	err = s.conn.SetWriteDeadline(time.Now().Add(writeDeadline))
+	if err == nil {
+		stage = traceStageWrite
+		err = s.conn.WriteMessage(websocket.TextMessage, payload)
 	}
-	return s.conn.WriteMessage(websocket.TextMessage, payload)
+	traceOutResult(s.log, s.seq, t, stage, err)
+	return err
 }
 
 // sendText pushes an aibot_send_msg (proactive push) with plain text to a


### PR DESCRIPTION
## The defect

The wecom adapter logs failures and nothing else.

| Event | What lands in the log today |
|---|---|
| Undecodable frame envelope | `Warn` (`wecom_channel.go:215`) |
| Server ack with non-zero errcode | `Warn` (`wecom_channel.go:340`) |
| Non-`disconnected_event` event | `Debug` (`wecom_channel.go:317`) |
| Non-text message receipt | `Debug` (`wecom_channel.go:294`) |
| **An ordinary inbound text message** | **nothing** |
| **Every outbound frame** — subscribe, ping, send_msg | **nothing** |

So a run that fails *loudly* is visible, and a run that goes wrong **quietly** leaves no trace on the server at all: the reply addressed to the room instead of the person, the command that was silently dropped, the receipt that went out twice, the frame we believed we sent that was never written.

## The user-visible consequence

Verifying any of those needs a person to describe what they saw on their phone. That is slow and lossy, and for anything about ordering or timing it does not work at all — a user cannot tell you which of two frames the server accepted first, or distinguish "we never sent it" from "the platform rejected it". Today the only rejection that surfaces is the anonymous-ack `Warn`; a frame that was never written looks identical to one that was delivered.

`MULTICA_WECOM_TRACE=1` records every frame the adapter reads and writes — direction, `cmd`, `req_id`, the chat it was addressed to, whether that chat is a room or a person, the sender, and the server's `errcode`. Off by default.

## Sibling precedent

Slack and Lark both keep a per-frame record; wecom is the only WS adapter with none.

- `server/internal/integrations/slack/slack_channel.go:162` — `c.logger.DebugContext(ctx, "slack: socket mode", "event", evt.Type, "app_id", c.appID)`, one line per socket-mode event.
- `server/internal/integrations/lark/ws_connector.go:339` and `:348` — `log.Debug("lark ws connector: partial chunk buffered" / "chunk reassembly complete", …)`, per frame.

**Why this one is a switch rather than a `Debug` call.** `server/internal/logger/logger.go:106` — `parseLevel` falls through to `slog.LevelDebug`, so **LOG_LEVEL defaults to debug** and a `Debug` line is on in every deployment that has not set it. The siblings' lines carry an event type and an app id; this one carries a prefix of the message body, which must not be on by default. Hence a dedicated env switch that defaults to off, and a boot-time `Warn` while it is on so a session left switched on is visible in the log it is writing into.

## The credential check you asked for

**A binding token is a bearer credential, and a binding URL fits inside the trace preview. I checked, and it does — this PR closes it rather than shipping it.**

`replier.go:148-149` builds:

```go
bindURL := r.appURL + r.bindingPath + "?token=" + url.QueryEscape(token.Raw)
text := "👋 请先绑定你的 Multica 账号，才能与我对话：\n" + bindURL + "\n（链接 15 分钟内有效）"
```

`Mint` → `randomBindingToken(32)` → `base64.RawURLEncoding` = **43 characters**. Measured against the 120-rune preview cap:

| `MULTICA_APP_URL` | token's last char at rune | inside the cap? |
|---|---|---|
| `https://multica.example` | 112 | **yes** |
| `https://multica.ai` | 107 | **yes** |
| `http://localhost:3000` (compose default is `http://localhost:3000`) | 110 | **yes** |

So an unredacted preview printed the **entire live token**, not a fragment. That it is reachable is pinned by `TestBindingPromptFitsInsideThePreviewCap`, which fails loudly if a future copy change ever pushes the token past the cap and makes this rationale stale.

Why that is a leak and not just noise: `RedeemAndBind` (`binding.go:107`) checks only that the redeemer belongs to the token's workspace, and the bind page redeems on load as whoever is signed in. Anyone who could read the log could bind that sender's WeCom identity to their own Multica account before the user clicked their own link — after which the sender's messages, `/issue` included, resolve to the hijacker. This is the same hijack `replier.go:150-159` already refuses to post the link into a room to prevent; a log is the same hijack by another route.

`tracePreview` now runs `redactBearerTokens` before the cut, replacing the value of `token=` / `binding_token=` / `access_token=` / `code=` query parameters with `[redacted]`. It matches on the query parameter rather than the bind path because `BindingPath` is configurable and this package-level function cannot see it.

**The other credential:** the `aibot_subscribe` body carries the installation's decrypted smart-bot secret (`subscribeBody(c.botID, c.secret)`). `traceOut` walks named fields rather than dumping the frame, so the secret is never read — pinned by a test that fails if anyone replaces the walk with a body dump.

## Tests — every one reverse-verified

Eight guards in `server/internal/integrations/wecom/trace_test.go`. Each was confirmed to **fail** with its fix reverted, then restored. Actual output:

**1. Remove the `if !tracingOn()` guard** → `TestTraceOffRecordsNothing`:
```
--- FAIL: TestTraceOffRecordsNothing (0.00s)
    trace_test.go:179: tracing is off but a trace line was written:
        level=INFO msg="wecom trace" dir=out cmd=aibot_subscribe req_id=d73a6a67e45aeb81
        level=INFO msg="wecom trace" dir=in cmd=aibot_msg_callback req_id=REQ_1 errcode=0
        level=INFO msg="wecom trace" dir=in.msg msg_id=MSG_1 chatid=GROUP_CHAT_ID chat_type=group sender=SENDER_USERID msgtype=text len=30 text=一条不该被记录的消息
    trace_test.go:182: tracing is off but the message body reached the log:
```
The capturing logger is at `LevelDebug` on purpose — the package default — so a trace line that were "merely Debug level" would still be written here.

**2. Remove `redactBearerTokens` from `tracePreview`** → `TestTraceNeverLogsABindingToken`. This drives the real replier path (mint → URL → `sendText` → `write` → `traceOut`) with a production-shaped 43-char token:
```
--- FAIL: TestTraceNeverLogsABindingToken (0.00s)
    trace_test.go:269: the raw binding token reached the log:
        level=INFO msg="wecom trace" dir=out cmd=aibot_send_msg chatid=SENDER_USERID chat_type=1
          msgtype=markdown len=179
          text="👋 请先绑定你的 Multica 账号，才能与我对话： https://multica.example/wecom/bind?token=UdiY905i13TLlK-fFGcv8I0uMiWHFFm1xISEE6wYYvg （链接 15 …"
    trace_test.go:272: expected the token parameter to be redacted in place
```
All 43 characters, printed before the `…` cut. That is the leak.

**3. Rune cut → byte cut** → `TestTracePreviewCutsOnARuneBoundary`:
```
--- FAIL: TestTracePreviewCutsOnARuneBoundary (0.00s)
    trace_test.go:320: preview kept 40 runes, want exactly 120
    trace_test.go:313: preview of 301-rune body is not valid UTF-8: "x测测测…测\xe6\xb5…"
    trace_test.go:320: preview kept 42 runes, want exactly 120
    trace_test.go:323: preview contains a replacement character — a multi-byte rune was split
```
Two cases on purpose: a body that is a whole number of 3-byte characters only truncates early (to a third of the intended length), while one ASCII character in front makes the same cut land mid-character and emit invalid UTF-8.

**4. Make `traceOut` append the body map** → `TestTraceNeverLogsTheSmartBotSecret`:
```
--- FAIL: TestTraceNeverLogsTheSmartBotSecret (0.00s)
    trace_test.go:224: the smart-bot secret reached the log:
        level=INFO msg="wecom trace" dir=out cmd=aibot_subscribe req_id=9bbc27345628dff6
          body="map[bot_id:bot-1 secret:THE_SMART_BOT_SECRET]"
```

**5. Remove the `traceIn` / `traceInbound` call sites** → `TestTraceOnRecordsBothDirections`:
```
--- FAIL: TestTraceOnRecordsBothDirections (0.00s)
    trace_test.go:206: trace output is missing "dir=in"
    trace_test.go:206: trace output is missing "dir=in.msg"
    trace_test.go:206: trace output is missing "chatid=GROUP_CHAT_ID"
    trace_test.go:206: trace output is missing "sender=SENDER_USERID"
```

**6. Remove the `traceOut` call site** → the same test, plus both credential tests correctly refused to pass vacuously:
```
--- FAIL: TestTraceOnRecordsBothDirections: trace output is missing "dir=out"
--- FAIL: TestTraceNeverLogsTheSmartBotSecret:
    trace_test.go:221: the subscribe frame was not traced, so this test proves nothing
```
Both "never logs X" tests assert first that the frame **was** traced, so they cannot pass by the code under test not running.

**7. Remove the newline flattening** → `TestTracePreviewFlattensNewlines`:
```
    trace_test.go:334: preview still contains a line break: "first\nsecond\r\nthird"
```

**8. Narrow the redaction regex to `binding_token` only** → `TestRedactBearerTokensCoversTheTokenShapes`: 5 of 7 subtests fail (`binding_url`, `custom_path`, `access_token_param`, `oauth_code`, `stops_at_ampersand`).

`TestTraceOffRecordsNothing`, `TestTraceOnRecordsBothDirections` and `TestTraceNeverLogsTheSmartBotSecret` drive a full `Connect` against a scripted socket — subscribe write, subscribe ack, callback frame, decoded message — so every trace point is exercised through the real code path, not by calling the trace functions directly.

## Test run

```
go build ./...                                     clean
go vet ./...                                       clean
gofmt -l server/internal/integrations/wecom/ …     clean
go test ./internal/integrations/wecom/ -race       ok (all pass)
go test ./cmd/... -p 1                             ok (4/4 packages)
go test ./internal/... -p 1                        2 pre-existing failures, see below
```

The two `./internal/...` failures are unrelated to this change and reproduce identically on unmodified `main` at `47f6e97`:

- `internal/daemon` — `TestProbeAgentCLIs_QoderResolvesViaLoginShell`: `qoder path = "/Users/…/.local/bin/qoderclicn", want /fake/npm-global/bin/qodercli`. The test picks up a real binary installed on the host.
- `internal/migrations` — `TestAttributionStrictConstraintMigrations`.

(These two packages also flake on package-parallel runs: on unmodified `main` the failing set moved between `handler`/`ghsnapshot` and `migrations` across runs on identical code, which is why the numbers above are from `-p 1`.)

## Also in this PR

The env passthrough, with the preview cap stated in both files so an operator does not have to read Go to find out what "a bounded prefix" means:

- `.env.example` — described in the WeCom block's `#   NAME` header alongside `MULTICA_WECOM_SECRET_KEY`, matching this file's convention (description block first, assignments at the end), with the assignment after `MULTICA_WECOM_SECRET_KEY=`.
- `docker-compose.selfhost.yml` — `MULTICA_WECOM_TRACE: ${MULTICA_WECOM_TRACE:-}`.

## Not in this PR

The fault-injection hooks that sit next to this on our branch. They are `if` statements on the hot path of production code and need a build-tag-versus-runtime decision first; this is trace only. Nothing here touches the durable outbound queue, the rate gate, or the single-replica documentation.
