### PR TITLE
feat(wecom): say something when somebody opens the bots chat for the first time (MUL-5908)

### DIFF
--- a/server/cmd/server/router.go
+++ b/server/cmd/server/router.go
@@ -695,11 +695,21 @@ func NewRouterWithOptions(pool *pgxpool.Pool, hub *realtime.Hub, bus *events.Bus
 					Fallback: "企业微信会话",
 				})
 
+				// Welcome/Binding/AppURL are the enter_chat greeting: WeCom
+				// pushes that event the moment somebody opens the bot's chat
+				// and gives us about five seconds to answer, so the greeting
+				// is written by the connection itself rather than by the
+				// OutboundReplier (which only ever runs after a message).
+				// Same binding service and app URL the replier gets, so both
+				// hand out the same bind link.
 				wecom.RegisterWecom(channelRegistry, wecom.ChannelDeps{
 					Credentials: credsResolver,
 					Senders:     wecomSenders,
 					Metrics:     wecomMetricsOrNil(opts.WecomMetrics),
 					Logger:      slog.Default(),
+					Welcome:     queries,
+					Binding:     wecomBinding,
+					AppURL:      appURLFromEnv(),
 				})
 				// Inbound media: a callback carries a pre-signed COS url and
 				// a per-url key, so the resolver needs no WeCom credential —

--- a/server/internal/integrations/wecom/replier.go
+++ b/server/internal/integrations/wecom/replier.go
@@ -73,17 +73,12 @@ func NewOutboundReplier(cfg OutboundReplierConfig) *OutboundReplier {
 	if logger == nil {
 		logger = slog.Default()
 	}
-	bindingPath := cfg.BindingPath
-	if bindingPath == "" {
-		bindingPath = "/wecom/bind"
-	}
-	if !strings.HasPrefix(bindingPath, "/") {
-		bindingPath = "/" + bindingPath
-	}
 	r := &OutboundReplier{
-		senders:     cfg.Senders,
-		appURL:      strings.TrimRight(cfg.AppURL, "/"),
-		bindingPath: bindingPath,
+		senders: cfg.Senders,
+		appURL:  strings.TrimRight(cfg.AppURL, "/"),
+		// Shared with the enter_chat greeting (welcome.go) so the two cannot
+		// drift onto different bind pages.
+		bindingPath: normalizeBindingPath(cfg.BindingPath),
 		logger:      logger,
 	}
 	// Assign through the interface only when non-nil: a nil *BindingTokenService

--- a/server/internal/integrations/wecom/wecom_channel.go
+++ b/server/internal/integrations/wecom/wecom_channel.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"log/slog"
 	"net/url"
+	"strings"
 	"time"
 
 	cryptorand "crypto/rand"
@@ -93,6 +94,15 @@ type wecomChannel struct {
 	// through mx(), which substitutes the no-op sink for a channel built
 	// without one.
 	metrics Metrics
+
+	// welcome + binding + appURL + bindPath are the enter_chat greeting
+	// (welcome.go). Any of them nil or empty degrades to the greeting without
+	// a bind link rather than to silence — a deployment with no binding
+	// surface still wants the bot to say what it is.
+	welcome  welcomeLookup
+	binding  binder
+	appURL   string
+	bindPath string
 }
 
 var _ channel.Channel = (*wecomChannel)(nil)
@@ -232,6 +242,32 @@ func (c *wecomChannel) Connect(ctx context.Context) (err error) {
 	// so. That only holds while somebody is still receiving, so the read
 	// loop's send also watches cbDone — see the send site below.
 	callbacks := make(chan frameEnvelope, callbackQueueDepth)
+
+	// enter_chat gets its OWN worker, separate from the callback worker above.
+	// The greeting's window is short (see welcomeDeadline) and a single
+	// message callback ahead of it in one queue can take longer than the whole
+	// window on its own — sharing would reliably turn a greeting into nothing
+	// at all. It is also the one inbound frame whose handling has no error
+	// worth escalating, so this worker never reports failure.
+	//
+	// welcomeCtx is cancelled before the queue is drained, so a connection on
+	// its way out discards the greetings it can no longer address rather than
+	// holding Connect open waiting for acks that will never arrive.
+	welcomeCtx, welcomeCancel := context.WithCancel(ctx)
+	welcomes := make(chan frameEnvelope, welcomeQueueDepth)
+	welcomeDone := make(chan struct{})
+	go func() {
+		defer close(welcomeDone)
+		for env := range welcomes {
+			c.handleEnterChat(welcomeCtx, env, sender, log)
+		}
+	}()
+	defer func() {
+		welcomeCancel()
+		close(welcomes)
+		<-welcomeDone
+	}()
+
 	cbDone := make(chan struct{})
 	var cbErr error
 	go func() {
@@ -303,7 +339,33 @@ func (c *wecomChannel) Connect(ctx context.Context) (err error) {
 			log.Warn("wecom: bad frame envelope", "error", err, "size", len(payload))
 			continue
 		}
+		// Traced before the welcome intercept below, for the same reason the
+		// subscribe path traces before its req_id filter: a greeting that was
+		// skipped for a full queue is exactly what an operator turns tracing
+		// on to see, and a frame diverted before traceIn is a frame that never
+		// appears in the trace at all.
 		traceIn(log, env)
+		if isWelcomeFrame(env) {
+			// A full welcome queue DROPS. This is the OPPOSITE of the
+			// callback queue further down this loop, which blocks, and both
+			// are right for opposite reasons:
+			//
+			//   - A dropped callback is a question the user asked that nobody
+			//     ever answers, with nothing to say so. Blocking is
+			//     backpressure; at worst WeCom ends the connection and the
+			//     Supervisor reconnects, which is recoverable.
+			//   - A greeting has only its short window. One that arrives after
+			//     that lands in a chat the user has already started typing in,
+			//     which is worse than no greeting — and while it waited it
+			//     would be holding the read loop that carries the acks every
+			//     other write is parked on. A late welcome is void, not late.
+			select {
+			case welcomes <- env:
+			default:
+				log.Warn("wecom: welcome queue full, greeting skipped")
+			}
+			continue
+		}
 		switch env.Cmd {
 		case cmdMsgCallback, cmdEventCallback:
 			select {
@@ -489,6 +551,11 @@ func (c *wecomChannel) dispatchFrame(ctx context.Context, env frameEnvelope, sen
 			// one — the last writer wins).
 			return errors.New("wecom: received disconnected_event (superseded)")
 		default:
+			// enter_chat does not reach here: the read loop diverts it to the
+			// welcome worker (welcome.go) before dispatch, because it is the
+			// only inbound frame with a seconds-long deadline. What is left is
+			// template_card_event and feedback_event, neither of which we act
+			// on yet.
 			log.Debug("wecom: event", "type", ec.Event.EventType)
 			return nil
 		}
@@ -609,6 +676,16 @@ type ChannelDeps struct {
 
 	// WSURL overrides DefaultWSURL. Same test-only intent as Dialer.
 	WSURL string
+
+	// Welcome + Binding + AppURL + BindingPath drive the enter_chat greeting
+	// (welcome.go). Boot passes the same binding service and app URL the
+	// OutboundReplier already gets, so the greeting's bind link and the
+	// needs_binding prompt's are the same link. All optional: without them the
+	// bot still greets, just without offering a link it cannot mint.
+	Welcome     welcomeLookup
+	Binding     *BindingTokenService
+	AppURL      string
+	BindingPath string
 }
 
 // RegisterWecom registers the per-installation wecom smart-bot Factory so
@@ -643,7 +720,7 @@ func newWecomFactory(deps ChannelDeps) channel.Factory {
 		if err != nil {
 			return nil, fmt.Errorf("wecom: decrypt secret: %w", err)
 		}
-		return &wecomChannel{
+		ch := &wecomChannel{
 			installationID: cfg.ID,
 			botID:          creds.BotID,
 			secret:         creds.Secret,
@@ -654,7 +731,19 @@ func newWecomFactory(deps ChannelDeps) channel.Factory {
 			logger:         logger,
 			senders:        deps.Senders,
 			metrics:        orNopMetrics(deps.Metrics),
-		}, nil
+			welcome:        deps.Welcome,
+			appURL:         strings.TrimRight(deps.AppURL, "/"),
+			bindPath:       normalizeBindingPath(deps.BindingPath),
+		}
+		// Assigned through the interface only when non-nil: a nil
+		// *BindingTokenService stored in a binder would be a non-nil interface
+		// holding a typed nil, defeating the `c.binding == nil` guard in
+		// welcomeText and panicking on Mint. Same trap NewOutboundReplier
+		// documents.
+		if deps.Binding != nil {
+			ch.binding = deps.Binding
+		}
+		return ch, nil
 	}
 }
 

--- a/server/internal/integrations/wecom/welcome.go
+++ b/server/internal/integrations/wecom/welcome.go
@@ -1,0 +1,267 @@
+package wecom
+
+// welcome.go — what the bot says when somebody opens the chat for the first
+// time.
+//
+// WeCom pushes an `enter_chat` event the moment a user opens the bot's
+// conversation, and expects an `aibot_respond_welcome_msg` echoing that
+// frame's req_id. The event type was already named here (eventEnterChat) but
+// nothing acted on it, so it fell through to a log line: a first-time user
+// opened the bot and got an empty window — no statement of what the bot is
+// for, and no hint that they have to link an account before it will answer
+// them at all. Every peer platform greets: Slack posts an App Home, Lark
+// sends a welcome card.
+//
+// Two things make this path different from every other outbound write:
+//
+//   - It is a REPLY, addressed by the req_id of the frame that triggered it.
+//     A req_id is meaningless on the next connection, so a greeting that
+//     missed its window is not late, it is void — there is nothing worth
+//     holding for a reconnect.
+//   - Its window is short — see welcomeDeadline for what that is based on.
+//     It therefore gets its own worker and its own budget rather than
+//     queueing behind message callbacks, any one of which can take longer
+//     than the whole window on its own.
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"log/slog"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+
+	db "github.com/multica-ai/multica/server/pkg/db/generated"
+)
+
+// cmdRespondWelcome is the reply to an enter_chat event.
+const cmdRespondWelcome = "aibot_respond_welcome_msg"
+
+// welcomeDeadline is this handler's own budget for the whole greeting —
+// lookup, mint and write — so a slow database produces no greeting rather than
+// a frame WeCom refuses for arriving late.
+//
+// ASSUMPTION, not a documented figure: the reply window for enter_chat is
+// taken to be around five seconds, by analogy with the 5s window documented
+// for aibot_respond_msg (ws_frame.go). WeCom's long-connection docs do not
+// state one for enter_chat, and we have not measured it against a live
+// tenant. 4s is that assumption minus room for the write itself.
+//
+// What would settle it: send a respond_welcome deliberately late against a
+// real bot and read the errcode. If the real window is wider, this is merely
+// conservative; if it is narrower, greetings are being refused and the fix is
+// to cut the lookup, not this number.
+const welcomeDeadline = 4 * time.Second
+
+// welcomeQueueDepth is small on purpose, and the queue behind it DROPS when
+// full rather than blocking. See the routing comment in Connect: a greeting
+// that has been waiting is already past its window, so a deep backlog of them
+// buys nothing and a shallow one keeps a burst off the read loop.
+const welcomeQueueDepth = 8
+
+// The greeting itself. Hardcoded Chinese, the same way every other
+// user-visible string in this adapter is (replier.go, the text-only receipt in
+// dispatchFrame) — WeCom deployments are China-only and the package has no
+// locale layer.
+const (
+	// welcomeBoundText is the greeting for somebody already linked, and the
+	// fallback whenever we cannot establish that they are not. Offering a bind
+	// link to a linked user is the confusing outcome, so on doubt we do not.
+	//
+	// The parenthetical names what the bot takes, and that set is bodyText's
+	// (ws_frame.go), not this file's: text, and a voice note WeCom has already
+	// transcribed. It is the only place the bot volunteers its own limits, so
+	// TestTheBoundGreetingNamesEveryKindTheBotActuallyRoutes ties it to
+	// bodyText rather than leaving the two to drift.
+	welcomeBoundText = "👋 你好，我是 Multica 智能助手。有事直接发消息给我，或者用 “/issue 标题” 建一条任务。（目前支持文字和语音消息）"
+
+	// welcomeUnboundPrefix / Suffix wrap the bind URL. The wording matches the
+	// needs_binding prompt in replier.go on purpose — a user who sees both
+	// should not have to work out whether they are the same link.
+	welcomeUnboundPrefix = "👋 你好，我是 Multica 智能助手。请先绑定你的 Multica 账号，才能与我对话：\n"
+	welcomeUnboundSuffix = "\n（链接 15 分钟内有效）"
+)
+
+// defaultBindingPath is where the web app serves the bind page.
+const defaultBindingPath = "/wecom/bind"
+
+// normalizeBindingPath applies the one default, so the greeting and the
+// needs_binding prompt cannot drift onto two different bind pages.
+func normalizeBindingPath(p string) string {
+	if p == "" {
+		return defaultBindingPath
+	}
+	if !strings.HasPrefix(p, "/") {
+		return "/" + p
+	}
+	return p
+}
+
+// aibotEnterChat is the enter_chat body: the event envelope plus the fields
+// that say who opened which conversation.
+type aibotEnterChat struct {
+	MsgID    string `json:"msgid"`
+	AIBotID  string `json:"aibotid"`
+	ChatID   string `json:"chatid"`
+	ChatType string `json:"chattype"`
+	From     struct {
+		UserID string `json:"userid"`
+	} `json:"from"`
+}
+
+// welcomeLookup is the pair of reads the greeting needs: is this person
+// already linked, and if not, which workspace is the link for. channel.Config
+// carries no workspace id, so the installation row is where that comes from.
+// *db.Queries satisfies it.
+type welcomeLookup interface {
+	GetChannelUserBindingByUserID(ctx context.Context, arg db.GetChannelUserBindingByUserIDParams) (db.ChannelUserBinding, error)
+	GetChannelInstallation(ctx context.Context, arg db.GetChannelInstallationParams) (db.ChannelInstallation, error)
+}
+
+// isWelcomeFrame reports whether this frame is an enter_chat event — the one
+// event callback that is answered rather than logged, and the one inbound
+// frame with a deadline measured in seconds.
+func isWelcomeFrame(env frameEnvelope) bool {
+	if env.Cmd != cmdEventCallback {
+		return false
+	}
+	var ec aibotEventCallback
+	if err := json.Unmarshal(env.Body, &ec); err != nil {
+		return false
+	}
+	return ec.Event.EventType == eventEnterChat
+}
+
+// handleEnterChat answers one enter_chat event. It never reports failure: a
+// greeting that could not be sent is void, not retriable, and nothing about it
+// is worth tearing the connection down for.
+//
+// GROUP CHATS GET NOTHING, deliberately. Two reasons, either sufficient:
+//
+//   - Greeting a room is a different act from greeting a person. The event
+//     names whoever just walked in, so a greeting in a group is an
+//     announcement about that person to an audience, which is not what
+//     opening a chat asked for.
+//   - The greeting's whole job for an unlinked user is to hand them a bind
+//     link, and a binding token is a bearer credential: posted into a room,
+//     the first colleague to click owns it, and every later message from the
+//     person it was minted for resolves to the hijacker. That is the same
+//     reasoning sendBindingPrompt spells out in replier.go, and here it is
+//     simpler to obey — a room nobody has spoken in yet has nothing to be
+//     told.
+func (c *wecomChannel) handleEnterChat(ctx context.Context, env frameEnvelope, sender *wsSender, log *slog.Logger) {
+	if ctx.Err() != nil {
+		// The connection is going away. This req_id dies with it, so there is
+		// nothing to send and nothing to wait for.
+		return
+	}
+	var ev aibotEnterChat
+	if err := json.Unmarshal(env.Body, &ev); err != nil {
+		log.Warn("wecom: bad enter_chat body", "error", err)
+		return
+	}
+	if ev.ChatType != "" && ev.ChatType != "single" {
+		log.Debug("wecom: enter_chat in a group, no greeting", "chat_type", ev.ChatType)
+		return
+	}
+	if ev.From.UserID == "" {
+		log.Warn("wecom: enter_chat with no sender", "msg_id", ev.MsgID)
+		return
+	}
+	if env.Headers.ReqID == "" {
+		// Nothing to address the reply to. WeCom always sets it; a frame
+		// without one is not one we can answer.
+		log.Warn("wecom: enter_chat with no req_id", "msg_id", ev.MsgID)
+		return
+	}
+
+	ctx, cancel := context.WithTimeout(ctx, welcomeDeadline)
+	defer cancel()
+
+	text := c.welcomeText(ctx, ev.From.UserID, log)
+	if text == "" {
+		return
+	}
+	if err := sender.respondWelcome(ctx, env.Headers.ReqID, text); err != nil {
+		// Never retried. The req_id is spent either way, and the user's next
+		// message gets the ordinary binding prompt.
+		log.Warn("wecom: welcome reply failed", "error", err, "msg_id", ev.MsgID)
+	}
+}
+
+// welcomeText builds the greeting for one person, or "" when there is nothing
+// worth saying.
+func (c *wecomChannel) welcomeText(ctx context.Context, wecomUserID string, log *slog.Logger) string {
+	if c.welcome == nil || !c.installationID.Valid {
+		// No lookup wired — a deployment without the binding surface. Greet
+		// without offering a link we cannot mint. Degrading to silence would
+		// make the bot look broken over a feature it does not have.
+		return welcomeBoundText
+	}
+
+	_, err := c.welcome.GetChannelUserBindingByUserID(ctx, db.GetChannelUserBindingByUserIDParams{
+		InstallationID: c.installationID,
+		ChannelUserID:  wecomUserID,
+	})
+	switch {
+	case err == nil:
+		// Already linked: say hello and what to do, no link.
+		return welcomeBoundText
+	case !errors.Is(err, pgx.ErrNoRows):
+		// Could not tell. Offering a link to somebody already linked reads as
+		// the bot having lost their account, so on doubt we do not — and we do
+		// not mint a token for a user we cannot prove needs one.
+		log.WarnContext(ctx, "wecom: welcome binding lookup failed", "error", err)
+		return welcomeBoundText
+	}
+
+	// Unlinked, and this is a 1:1 chat, so the link goes to the one person it
+	// is about.
+	if c.binding == nil || c.appURL == "" {
+		return welcomeBoundText
+	}
+	row, err := c.welcome.GetChannelInstallation(ctx, db.GetChannelInstallationParams{
+		ID:          c.installationID,
+		ChannelType: channelTypeWecom,
+	})
+	if err != nil {
+		log.WarnContext(ctx, "wecom: welcome could not load its installation", "error", err)
+		return welcomeBoundText
+	}
+	token, err := c.binding.Mint(ctx, row.WorkspaceID, c.installationID, wecomUserID)
+	if err != nil {
+		log.WarnContext(ctx, "wecom: welcome could not mint a binding token", "error", err)
+		return welcomeBoundText
+	}
+	bindURL := c.appURL + c.bindingPath() + "?token=" + url.QueryEscape(token.Raw)
+	return welcomeUnboundPrefix + bindURL + welcomeUnboundSuffix
+}
+
+// bindingPath is where the web app serves the bind page. Read through a method
+// so a wecomChannel assembled without one still produces a usable URL rather
+// than one missing its path entirely.
+func (c *wecomChannel) bindingPath() string {
+	return normalizeBindingPath(c.bindPath)
+}
+
+// respondWelcome writes the reply to an enter_chat frame.
+//
+// It goes straight to the socket rather than through sendersRegistry: this is
+// addressed by req_id, and a req_id means nothing on the next connection, so
+// there is no version of this message worth holding for a reconnect.
+func (s *wsSender) respondWelcome(ctx context.Context, reqID, content string) error {
+	if reqID == "" {
+		return errors.New("wecom: respond_welcome requires a req_id")
+	}
+	if content == "" {
+		return errors.New("wecom: respond_welcome requires content")
+	}
+	_, err := s.requestWithID(ctx, reqID, cmdRespondWelcome, map[string]any{
+		"msgtype":  "markdown",
+		"markdown": map[string]any{"content": content},
+	})
+	return err
+}

--- a/server/internal/integrations/wecom/welcome.go
+++ b/server/internal/integrations/wecom/welcome.go
@@ -1,11 +1,14 @@
 package wecom
 
-// welcome.go — what the bot says when somebody opens the chat for the first
-// time.
+// welcome.go — what the bot says when somebody opens the chat.
 //
-// WeCom pushes an `enter_chat` event the moment a user opens the bot's
-// conversation, and expects an `aibot_respond_welcome_msg` echoing that
-// frame's req_id. The event type was already named here (eventEnterChat) but
+// WeCom pushes an `enter_chat` event on a user's FIRST entry into the bot's
+// 1:1 that DAY — not once per person and not on every open
+// (developer.work.weixin.qq.com/document/path/101463, supported event types) —
+// and expects an `aibot_respond_welcome_msg` echoing that frame's req_id. So
+// this greeting recurs daily for anyone who keeps opening the chat, which is
+// why it stays short and why the unbound branch below must not hand out a
+// fresh link every time. The event type was already named here (eventEnterChat) but
 // nothing acted on it, so it fell through to a log line: a first-time user
 // opened the bot and got an empty window — no statement of what the bot is
 // for, and no hint that they have to link an account before it will answer
@@ -44,16 +47,11 @@ const cmdRespondWelcome = "aibot_respond_welcome_msg"
 // lookup, mint and write — so a slow database produces no greeting rather than
 // a frame WeCom refuses for arriving late.
 //
-// ASSUMPTION, not a documented figure: the reply window for enter_chat is
-// taken to be around five seconds, by analogy with the 5s window documented
-// for aibot_respond_msg (ws_frame.go). WeCom's long-connection docs do not
-// state one for enter_chat, and we have not measured it against a live
-// tenant. 4s is that assumption minus room for the write itself.
-//
-// What would settle it: send a respond_welcome deliberately late against a
-// real bot and read the errcode. If the real window is wider, this is merely
-// conservative; if it is narrower, greetings are being refused and the fix is
-// to cut the lookup, not this number.
+// Five seconds is the documented window, stated for this event rather than
+// borrowed from the message path: developer.work.weixin.qq.com/document/path/101463
+// requires the reply within five seconds of the event callback or the greeting
+// cannot be sent, and WecomTeam/aibot-node-sdk says the same of
+// aibot_respond_welcome_msg. 4s is that window minus room for the write.
 const welcomeDeadline = 4 * time.Second
 
 // welcomeQueueDepth is small on purpose, and the queue behind it DROPS when
@@ -83,6 +81,17 @@ const (
 	// should not have to work out whether they are the same link.
 	welcomeUnboundPrefix = "👋 你好，我是 Multica 智能助手。请先绑定你的 Multica 账号，才能与我对话：\n"
 	welcomeUnboundSuffix = "\n（链接 15 分钟内有效）"
+
+	// welcomeLinkAlreadySent is the greeting when the mint throttle suppressed
+	// a token: a live link is already with this user and only its hash was
+	// stored, so there is no URL to rebuild. Points at the message they have
+	// rather than handing them a second one.
+	//
+	// Reachable on the ordinary first-contact path, not just in theory: the
+	// bot answers an unbound user in a group, replier mints and posts the link
+	// into their 1:1, and the user opens that 1:1 to click it — which is their
+	// first entry of the day, so enter_chat fires seconds after the mint.
+	welcomeLinkAlreadySent = "👋 你好，我是 Multica 智能助手。绑定链接刚才已经发给你了，就在上方，请直接点击完成绑定。"
 )
 
 // defaultBindingPath is where the web app serves the bind page.
@@ -235,6 +244,13 @@ func (c *wecomChannel) welcomeText(ctx context.Context, wecomUserID string, log 
 	if err != nil {
 		log.WarnContext(ctx, "wecom: welcome could not mint a binding token", "error", err)
 		return welcomeBoundText
+	}
+	if token.Reused {
+		// Raw is empty here by contract — the throttle stored only a hash, so
+		// there is no URL to rebuild. Building one anyway yields "?token=" and
+		// a link that cannot bind anyone. replier.go makes the same call at
+		// :179; this is the same answer.
+		return welcomeLinkAlreadySent
 	}
 	bindURL := c.appURL + c.bindingPath() + "?token=" + url.QueryEscape(token.Raw)
 	return welcomeUnboundPrefix + bindURL + welcomeUnboundSuffix

--- a/server/internal/integrations/wecom/welcome.go
+++ b/server/internal/integrations/wecom/welcome.go
@@ -69,12 +69,12 @@ const (
 	// fallback whenever we cannot establish that they are not. Offering a bind
 	// link to a linked user is the confusing outcome, so on doubt we do not.
 	//
-	// The parenthetical names what the bot takes, and that set is bodyText's
+	// The parenthetical names what the bot takes, and that set is ownText's
 	// (ws_frame.go), not this file's: text, and a voice note WeCom has already
 	// transcribed. It is the only place the bot volunteers its own limits, so
 	// TestTheBoundGreetingNamesEveryKindTheBotActuallyRoutes ties it to
-	// bodyText rather than leaving the two to drift.
-	welcomeBoundText = "👋 你好，我是 Multica 智能助手。有事直接发消息给我，或者用 “/issue 标题” 建一条任务。（目前支持文字和语音消息）"
+	// ownText rather than leaving the two to drift.
+	welcomeBoundText = "👋 你好，我是 Multica 智能助手。有事直接发消息给我，或者用 “/issue 标题” 建一条任务。（文字、语音、图片、文件、视频都能发给我）"
 
 	// welcomeUnboundPrefix / Suffix wrap the bind URL. The wording matches the
 	// needs_binding prompt in replier.go on purpose — a user who sees both

--- a/server/internal/integrations/wecom/welcome_test.go
+++ b/server/internal/integrations/wecom/welcome_test.go
@@ -1,0 +1,636 @@
+package wecom
+
+// welcome_test.go — the first thing a person sees.
+//
+// Before this, opening the bot's chat produced nothing: an empty window, no
+// statement of what the bot is for, and no hint that it needs an account link
+// before it will answer — findable only by messaging it and being told. Slack
+// posts an App Home and Lark sends a welcome card; WeCom was the one that said
+// nothing.
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"log/slog"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/gorilla/websocket"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgtype"
+
+	"github.com/multica-ai/multica/server/internal/integrations/channel"
+	db "github.com/multica-ai/multica/server/pkg/db/generated"
+)
+
+// ---- doubles ----
+
+// fakeWelcomeLookup stands in for the two reads the greeting makes. blockOnCtx
+// makes the binding read hang until its context ends, which is how the
+// queue-pressure test wedges the welcome worker.
+type fakeWelcomeLookup struct {
+	binding    db.ChannelUserBinding
+	bindingErr error
+	install    db.ChannelInstallation
+	installErr error
+	blockOnCtx bool
+}
+
+func (f *fakeWelcomeLookup) GetChannelUserBindingByUserID(ctx context.Context, _ db.GetChannelUserBindingByUserIDParams) (db.ChannelUserBinding, error) {
+	if f.blockOnCtx {
+		<-ctx.Done()
+		return db.ChannelUserBinding{}, ctx.Err()
+	}
+	return f.binding, f.bindingErr
+}
+
+func (f *fakeWelcomeLookup) GetChannelInstallation(_ context.Context, _ db.GetChannelInstallationParams) (db.ChannelInstallation, error) {
+	return f.install, f.installErr
+}
+
+// countingBinder mints a recognizable raw token and counts how often it was
+// asked. The count is the assertion for "no token was minted for somebody who
+// must not receive one".
+type countingBinder struct {
+	mu    sync.Mutex
+	calls int
+	raw   string
+	err   error
+}
+
+func (b *countingBinder) Mint(context.Context, pgtype.UUID, pgtype.UUID, string) (BindingToken, error) {
+	b.mu.Lock()
+	b.calls++
+	b.mu.Unlock()
+	if b.err != nil {
+		return BindingToken{}, b.err
+	}
+	return BindingToken{Raw: b.raw, ExpiresAt: time.Now().Add(BindingTokenTTL)}, nil
+}
+
+func (b *countingBinder) mintCount() int {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.calls
+}
+
+// enterChatBody is what WeCom pushes the moment somebody opens the chat.
+func enterChatBody(t *testing.T, chatType, userID string) json.RawMessage {
+	t.Helper()
+	body, err := json.Marshal(map[string]any{
+		"msgid":    "EV-1",
+		"aibotid":  "bot-1",
+		"chatid":   "T-alex",
+		"chattype": chatType,
+		"from":     map[string]any{"userid": userID},
+		"event":    map[string]any{"eventtype": eventEnterChat},
+	})
+	if err != nil {
+		t.Fatalf("marshal enter_chat: %v", err)
+	}
+	return body
+}
+
+func enterChatFrame(t *testing.T, reqID, chatType, userID string) frameEnvelope {
+	t.Helper()
+	return frameEnvelope{
+		Cmd:     cmdEventCallback,
+		Headers: frameHeaders{ReqID: reqID},
+		Body:    enterChatBody(t, chatType, userID),
+	}
+}
+
+// welcomeRig builds a channel with the binding surface wired and a socket that
+// acks whatever it is handed, for the tests that call handleEnterChat directly.
+func welcomeRig(t *testing.T, lookup *fakeWelcomeLookup, minter binder) (*wecomChannel, *recordingConn, *wsSender) {
+	t.Helper()
+	conn := &recordingConn{}
+	sender := conn.autoAck(newWSSender(conn, nil))
+	c := &wecomChannel{
+		installationID: mustTestUUID(t),
+		botID:          "bot-1",
+		logger:         slog.Default(),
+		welcome:        lookup,
+		appURL:         "https://multica.example",
+	}
+	if minter != nil {
+		c.binding = minter
+	}
+	return c, conn, sender
+}
+
+// welcomeSaid returns the single greeting written to conn, or "". It fails the
+// test on a second greeting: one enter_chat is one welcome.
+func welcomeSaid(t *testing.T, conn *recordingConn) string {
+	t.Helper()
+	var out []string
+	conn.mu.Lock()
+	frames := append([]frameEnvelope(nil), conn.frames...)
+	conn.mu.Unlock()
+	for _, f := range frames {
+		if f.Cmd != cmdRespondWelcome {
+			continue
+		}
+		var body struct {
+			Markdown struct {
+				Content string `json:"content"`
+			} `json:"markdown"`
+		}
+		if err := json.Unmarshal(f.Body, &body); err != nil {
+			t.Fatalf("decode welcome body: %v", err)
+		}
+		out = append(out, body.Markdown.Content)
+	}
+	if len(out) == 0 {
+		return ""
+	}
+	if len(out) > 1 {
+		t.Fatalf("the bot greeted %d times for one enter_chat: %v", len(out), out)
+	}
+	return out[0]
+}
+
+// ---- the greeting itself ----
+
+// An unlinked person gets the link, in the only place a bearer token may go.
+func TestOpeningTheChatUnboundHandsOverTheLink(t *testing.T) {
+	t.Parallel()
+	lookup := &fakeWelcomeLookup{
+		bindingErr: pgx.ErrNoRows,
+		install:    db.ChannelInstallation{ID: mustTestUUID(t), WorkspaceID: mustTestUUID(t)},
+	}
+	minter := &countingBinder{raw: "s3cret"}
+	c, conn, sender := welcomeRig(t, lookup, minter)
+
+	c.handleEnterChat(context.Background(), enterChatFrame(t, "req-1", "single", "T-alex"), sender, slog.Default())
+
+	said := welcomeSaid(t, conn)
+	if said == "" {
+		t.Fatal("opening the chat produced nothing — an empty window with no way to find out what to do")
+	}
+	if !strings.Contains(said, "https://multica.example/wecom/bind?token=s3cret") {
+		t.Fatalf("the greeting carries no bind link: %q", said)
+	}
+}
+
+// Somebody already linked does not need a link, and offering one reads as
+// though the bot has forgotten their account.
+func TestOpeningTheChatBoundGreetsWithoutALink(t *testing.T) {
+	t.Parallel()
+	lookup := &fakeWelcomeLookup{binding: db.ChannelUserBinding{MulticaUserID: mustTestUUID(t)}}
+	minter := &countingBinder{raw: "s3cret"}
+	c, conn, sender := welcomeRig(t, lookup, minter)
+
+	c.handleEnterChat(context.Background(), enterChatFrame(t, "req-2", "single", "T-alex"), sender, slog.Default())
+
+	said := welcomeSaid(t, conn)
+	if said == "" {
+		t.Fatal("a linked user opening the chat was greeted with nothing")
+	}
+	if strings.Contains(said, "token=") {
+		t.Fatalf("a bind link was offered to somebody already bound: %q", said)
+	}
+	if n := minter.mintCount(); n != 0 {
+		t.Fatalf("minted %d tokens for a bound user", n)
+	}
+}
+
+// A binding token is a bearer credential: whoever opens the link owns the
+// account it was minted for. It must never be posted where an audience can
+// read it — the same rule replier.go enforces for the needs_binding prompt.
+// And a greeting naming whoever just walked in, to a room, is not the act
+// opening a chat asked for.
+func TestAGroupGetsNoGreetingAndNoToken(t *testing.T) {
+	t.Parallel()
+	lookup := &fakeWelcomeLookup{
+		bindingErr: pgx.ErrNoRows,
+		install:    db.ChannelInstallation{ID: mustTestUUID(t), WorkspaceID: mustTestUUID(t)},
+	}
+	minter := &countingBinder{raw: "s3cret"}
+	c, conn, sender := welcomeRig(t, lookup, minter)
+
+	c.handleEnterChat(context.Background(), enterChatFrame(t, "req-3", "group", "T-alex"), sender, slog.Default())
+
+	if said := welcomeSaid(t, conn); said != "" {
+		t.Fatalf("a room was greeted: %q", said)
+	}
+	if minter.mintCount() != 0 {
+		t.Fatal("a binding token was minted for a group, where anyone in the room could redeem it first")
+	}
+}
+
+// A deployment with no binding surface still greets. Degrading to silence
+// would make the bot look broken over a feature it does not have.
+func TestNoBindingSurfaceStillGreets(t *testing.T) {
+	t.Parallel()
+	conn := &recordingConn{}
+	sender := conn.autoAck(newWSSender(conn, nil))
+	c := &wecomChannel{installationID: mustTestUUID(t), logger: slog.Default()}
+
+	c.handleEnterChat(context.Background(), enterChatFrame(t, "req-5", "single", "T-alex"), sender, slog.Default())
+
+	if said := welcomeSaid(t, conn); said != welcomeBoundText {
+		t.Fatalf("said %q, want the plain greeting", said)
+	}
+}
+
+// A database that cannot answer must not turn into a bind link offered to
+// somebody who is already linked — that reads as the bot having lost their
+// account — nor into a token minted for a user we cannot prove needs one.
+func TestAnUnreadableBindingDoesNotOfferALink(t *testing.T) {
+	t.Parallel()
+	lookup := &fakeWelcomeLookup{bindingErr: errors.New("connection refused")}
+	minter := &countingBinder{raw: "s3cret"}
+	c, conn, sender := welcomeRig(t, lookup, minter)
+
+	c.handleEnterChat(context.Background(), enterChatFrame(t, "req-6", "single", "T-alex"), sender, slog.Default())
+
+	if said := welcomeSaid(t, conn); strings.Contains(said, "token=") {
+		t.Fatalf("a link was offered on a failed lookup: %q", said)
+	}
+	if n := minter.mintCount(); n != 0 {
+		t.Fatalf("minted %d tokens without knowing whether the user was bound", n)
+	}
+}
+
+// The reply has to echo the frame's req_id. WeCom addresses a welcome by that
+// and nothing else, so a fresh id means the greeting is refused.
+func TestTheGreetingEchoesTheFramesReqID(t *testing.T) {
+	t.Parallel()
+	lookup := &fakeWelcomeLookup{binding: db.ChannelUserBinding{MulticaUserID: mustTestUUID(t)}}
+	c, conn, sender := welcomeRig(t, lookup, nil)
+
+	c.handleEnterChat(context.Background(), enterChatFrame(t, "req-echo-me", "single", "T-alex"), sender, slog.Default())
+
+	conn.mu.Lock()
+	frames := append([]frameEnvelope(nil), conn.frames...)
+	conn.mu.Unlock()
+	for _, f := range frames {
+		if f.Cmd != cmdRespondWelcome {
+			continue
+		}
+		if f.Headers.ReqID != "req-echo-me" {
+			t.Fatalf("req_id = %q, want the frame's own — WeCom refuses anything else", f.Headers.ReqID)
+		}
+		return
+	}
+	t.Fatal("no welcome frame was written")
+}
+
+// The read loop must recognise enter_chat and nothing else as a welcome, or it
+// either greets on the wrong event or never greets at all.
+func TestOnlyEnterChatRoutesToTheWelcomeWorker(t *testing.T) {
+	t.Parallel()
+	if !isWelcomeFrame(enterChatFrame(t, "r", "single", "T-alex")) {
+		t.Fatal("enter_chat was not recognised; the greeting would never fire")
+	}
+	for _, ev := range []string{eventDisconnected, eventTemplateCard, eventFeedback} {
+		body, err := json.Marshal(map[string]any{"event": map[string]any{"eventtype": ev}})
+		if err != nil {
+			t.Fatalf("marshal: %v", err)
+		}
+		if isWelcomeFrame(frameEnvelope{Cmd: cmdEventCallback, Body: body}) {
+			t.Fatalf("%s was routed to the welcome worker, which never escalates and never reaches the engine", ev)
+		}
+	}
+	if isWelcomeFrame(frameEnvelope{Cmd: cmdMsgCallback, Body: json.RawMessage(`{}`)}) {
+		t.Fatal("a message callback was routed to the welcome worker, which never calls the engine")
+	}
+}
+
+// ---- the live connection ----
+
+// welcomeConn is a socket double for the whole read loop. It acks the
+// subscribe handshake, then delivers a scripted sequence of server frames, and
+// answers every frame we write the way WeCom does — with a separate ack frame
+// carrying the same req_id, delivered back over the socket. That last part is
+// what makes this a real exercise of the path: the greeting waits for a server
+// verdict, and the read loop is the only thing that delivers one.
+type welcomeConn struct {
+	mu     sync.Mutex
+	frames []frameEnvelope
+
+	script []json.RawMessage
+	sent   bool
+
+	reads  chan []byte
+	closed chan struct{}
+	once   sync.Once
+}
+
+func newWelcomeConn(script ...json.RawMessage) *welcomeConn {
+	return &welcomeConn{
+		script: script,
+		reads:  make(chan []byte, 256),
+		closed: make(chan struct{}),
+	}
+}
+
+func (c *welcomeConn) WriteMessage(_ int, data []byte) error {
+	var env frameEnvelope
+	if err := json.Unmarshal(data, &env); err != nil {
+		return err
+	}
+	c.mu.Lock()
+	c.frames = append(c.frames, env)
+	c.mu.Unlock()
+	if env.Headers.ReqID == "" {
+		return nil
+	}
+	ack, err := json.Marshal(frameEnvelope{Headers: frameHeaders{ReqID: env.Headers.ReqID}})
+	if err != nil {
+		return err
+	}
+	select {
+	case c.reads <- ack:
+	case <-c.closed:
+	}
+	return nil
+}
+
+func (c *welcomeConn) ReadMessage() (int, []byte, error) {
+	select {
+	case b := <-c.reads:
+		c.mu.Lock()
+		first := !c.sent
+		c.sent = true
+		script := c.script
+		c.mu.Unlock()
+		if first {
+			// That was the subscribe ack. The main read loop takes over from
+			// here, so the scripted frames can go out now.
+			go func() {
+				for _, f := range script {
+					select {
+					case c.reads <- f:
+					case <-c.closed:
+						return
+					}
+				}
+			}()
+		}
+		return websocket.TextMessage, b, nil
+	case <-c.closed:
+		return 0, nil, errors.New("wecom test: socket closed")
+	}
+}
+
+func (c *welcomeConn) SetReadDeadline(time.Time) error  { return nil }
+func (c *welcomeConn) SetWriteDeadline(time.Time) error { return nil }
+func (c *welcomeConn) Close() error {
+	c.once.Do(func() { close(c.closed) })
+	return nil
+}
+
+// waitForCmd polls the recorded writes for a frame with the given cmd.
+func (c *welcomeConn) waitForCmd(cmd string, d time.Duration) (frameEnvelope, bool) {
+	deadline := time.Now().Add(d)
+	for time.Now().Before(deadline) {
+		c.mu.Lock()
+		for _, f := range c.frames {
+			if f.Cmd == cmd {
+				c.mu.Unlock()
+				return f, true
+			}
+		}
+		c.mu.Unlock()
+		time.Sleep(5 * time.Millisecond)
+	}
+	return frameEnvelope{}, false
+}
+
+// serverFrame renders one frame the way the server would push it.
+func serverFrame(t *testing.T, cmd, reqID string, body json.RawMessage) json.RawMessage {
+	t.Helper()
+	b, err := json.Marshal(frameEnvelope{Cmd: cmd, Headers: frameHeaders{ReqID: reqID}, Body: body})
+	if err != nil {
+		t.Fatalf("marshal server frame: %v", err)
+	}
+	return b
+}
+
+func textCallbackFrame(t *testing.T, reqID, text string) json.RawMessage {
+	t.Helper()
+	mc := aibotMsgCallback{MsgID: "m-1", ChatID: "T-alex", ChatType: "single", MsgType: "text"}
+	mc.From.UserID = "T-alex"
+	mc.Text.Content = text
+	body, err := json.Marshal(mc)
+	if err != nil {
+		t.Fatalf("marshal msg callback: %v", err)
+	}
+	return serverFrame(t, cmdMsgCallback, reqID, body)
+}
+
+func connectedChannel(t *testing.T, conn wsConn, lookup *fakeWelcomeLookup, handler channel.InboundHandler) *wecomChannel {
+	t.Helper()
+	return &wecomChannel{
+		installationID: mustTestUUID(t),
+		botID:          "bot-1",
+		secret:         "secret-1",
+		handler:        handler,
+		dialer:         scriptedDialer{conn: conn},
+		wsURL:          "wss://example.test/ws",
+		logger:         slog.Default(),
+		welcome:        lookup,
+		appURL:         "https://multica.example",
+	}
+}
+
+// The whole point, driven through Connect: WeCom pushes enter_chat, and the
+// bot answers on the live socket. Before this the frame reached dispatchFrame's
+// default arm and became a debug log line, so a brand-new user opened the bot
+// and got an empty window.
+func TestOpeningTheChatIsAnsweredOverTheLiveConnection(t *testing.T) {
+	t.Parallel()
+	conn := newWelcomeConn(serverFrame(t, cmdEventCallback, "req-live", enterChatBody(t, "single", "T-alex")))
+	c := connectedChannel(t, conn,
+		&fakeWelcomeLookup{binding: db.ChannelUserBinding{MulticaUserID: mustTestUUID(t)}},
+		func(context.Context, channel.InboundMessage) error { return nil })
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() { done <- c.Connect(ctx) }()
+
+	f, ok := conn.waitForCmd(cmdRespondWelcome, 3*time.Second)
+	cancel()
+	<-done
+
+	if !ok {
+		t.Fatal("enter_chat arrived on a live connection and the bot said nothing — a first-time user is looking at an empty window")
+	}
+	if f.Headers.ReqID != "req-live" {
+		t.Errorf("welcome req_id = %q, want the enter_chat frame's own req-live", f.Headers.ReqID)
+	}
+}
+
+// The deliberate asymmetry, made observable. The welcome queue is shallow and
+// DROPS; the callback queue is deep and BLOCKS. If the welcome queue blocked
+// instead, a wedged greeting would stop the read loop, and every message that
+// arrived behind the burst — including the ones the user typed — would go
+// unread until the socket died.
+func TestAFullWelcomeQueueDoesNotStallTheReadLoop(t *testing.T) {
+	t.Parallel()
+	// Far more enter_chat frames than the welcome queue can hold, then one
+	// ordinary message. The lookup hangs, so the welcome worker takes exactly
+	// one frame and stops.
+	var script []json.RawMessage
+	for i := 0; i < welcomeQueueDepth*3; i++ {
+		script = append(script, serverFrame(t, cmdEventCallback, "req-burst", enterChatBody(t, "single", "T-alex")))
+	}
+	script = append(script, textCallbackFrame(t, "req-text", "are you there"))
+
+	conn := newWelcomeConn(script...)
+	delivered := make(chan string, 1)
+	c := connectedChannel(t, conn, &fakeWelcomeLookup{blockOnCtx: true},
+		func(_ context.Context, m channel.InboundMessage) error {
+			select {
+			case delivered <- m.Text:
+			default:
+			}
+			return nil
+		})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() { done <- c.Connect(ctx) }()
+
+	var got string
+	var ok bool
+	select {
+	case got, ok = <-delivered:
+	case <-time.After(3 * time.Second):
+	}
+	cancel()
+	<-done
+
+	if !ok {
+		t.Fatal("a burst of enter_chat frames stalled the read loop: the message the user typed behind them was never read")
+	}
+	if got != "are you there" {
+		t.Errorf("handler got %q, want the user's message", got)
+	}
+}
+
+// ---- what the greeting is made of ----
+
+// Every other test in this file compares what was said against the same
+// constants that produced it, so the whole pack could be replaced with
+// placeholder text and the suite would stay green. These pin the parts that
+// are not ours to choose or that carry the greeting's whole purpose.
+
+// The command name is WeCom's, not ours. Get it wrong and no greeting is ever
+// delivered, while every test here — which builds its expectation from this
+// same constant — keeps passing.
+func TestRespondWelcomeUsesThePlatformsCommandName(t *testing.T) {
+	t.Parallel()
+	if cmdRespondWelcome != "aibot_respond_welcome_msg" {
+		t.Errorf("cmdRespondWelcome = %q; WeCom answers enter_chat on aibot_respond_welcome_msg and refuses anything else", cmdRespondWelcome)
+	}
+}
+
+// The two greetings have jobs that differ, so they must differ. The unbound
+// one exists to hand over a link and say how long it lasts; the bound one
+// exists NOT to, and to say what to do instead.
+func TestTheTwoGreetingsSayDifferentThings(t *testing.T) {
+	t.Parallel()
+	if welcomeBoundText == "" || welcomeUnboundPrefix == "" || welcomeUnboundSuffix == "" {
+		t.Fatal("a greeting is empty — opening the chat would produce the empty window this exists to fix")
+	}
+	if welcomeBoundText == welcomeUnboundPrefix {
+		t.Error("the bound and unbound greetings are the same text; one of them is not doing its job")
+	}
+	if strings.Contains(welcomeBoundText, "token=") || strings.Contains(welcomeBoundText, "http") {
+		t.Errorf("the bound greeting carries a link: %q", welcomeBoundText)
+	}
+	// A linked user has nothing to do next unless the greeting says what the
+	// bot takes. Naming the one command is the whole reason this text is
+	// longer than "hello".
+	if !strings.Contains(welcomeBoundText, "/issue") {
+		t.Errorf("the bound greeting never says what the bot can be asked to do: %q", welcomeBoundText)
+	}
+	if !strings.Contains(welcomeUnboundPrefix, "绑定") {
+		t.Errorf("the unbound greeting never asks the user to link an account: %q", welcomeUnboundPrefix)
+	}
+	// The suffix states the token's lifetime, which is the one fact a user
+	// needs to know whether the link in front of them is still good.
+	if !strings.Contains(welcomeUnboundSuffix, "15") {
+		t.Errorf("the unbound greeting does not state how long the link lasts: %q", welcomeUnboundSuffix)
+	}
+}
+
+// The greeting names what the bot accepts, in copy. dispatchFrame decides it
+// in code, off bodyText. Nothing connected the two, and they came apart the
+// moment voice routing landed: the greeting went on telling every linked user
+// that only text worked while a spoken message was already being answered —
+// including a spoken "/issue", which files a task.
+//
+// The failure is silent by construction. A capability arrives by widening
+// bodyText, which is a different file from the one holding the sentence that
+// describes it, so nothing about that change draws the eye here. This asserts
+// the relation directly: whatever bodyText routes, the greeting has to name.
+func TestTheBoundGreetingNamesEveryKindTheBotActuallyRoutes(t *testing.T) {
+	t.Parallel()
+
+	// Each kind the adapter can route, the frame that carries it, and the word
+	// a user would look for in the greeting to know it is allowed. Add a row
+	// when bodyText learns a kind — that is the point of the test.
+	kinds := []struct {
+		what string
+		mc   aibotMsgCallback
+		word string
+	}{
+		{what: "a typed message", word: "文字", mc: func() aibotMsgCallback {
+			var mc aibotMsgCallback
+			mc.MsgType = "text"
+			mc.Text.Content = "在吗"
+			return mc
+		}()},
+		{what: "a voice note WeCom transcribed", word: "语音", mc: func() aibotMsgCallback {
+			var mc aibotMsgCallback
+			mc.MsgType = "voice"
+			mc.Voice.Content = "在吗"
+			return mc
+		}()},
+	}
+
+	// Anti-vacuity: if bodyText routed nothing, every assertion below would
+	// pass without testing anything.
+	var routed int
+	for _, k := range kinds {
+		if _, ok := k.mc.bodyText(); ok {
+			routed++
+		}
+	}
+	if routed == 0 {
+		t.Fatal("bodyText routes none of the kinds listed here, so this guard asserts nothing. " +
+			"Re-point it at whatever decides a routable message now")
+	}
+
+	for _, k := range kinds {
+		_, routable := k.mc.bodyText()
+		if !routable {
+			t.Errorf("bodyText no longer routes %s. If that was deliberate, drop the row and take %q "+
+				"out of the greeting — leaving it in promises a user something the bot will refuse",
+				k.what, k.word)
+			continue
+		}
+		if !strings.Contains(welcomeBoundText, k.word) {
+			t.Errorf("the bot routes %s, but the greeting does not say %q: %q.\n"+
+				"Every linked user reads this sentence before trying anything, so a capability missing "+
+				"from it is a capability most of them never discover.",
+				k.what, k.word, welcomeBoundText)
+		}
+	}
+
+	// The other half: the greeting must not promise a kind that gets the
+	// text-only receipt instead. "只能" (only) is how the stale wording said it.
+	var img aibotMsgCallback
+	img.MsgType = "image"
+	if _, routable := img.bodyText(); !routable && strings.Contains(welcomeBoundText, "只能处理文字") {
+		t.Errorf("the greeting still says text is the only thing that works, which stopped being true "+
+			"when voice routing landed: %q", welcomeBoundText)
+	}
+}

--- a/server/internal/integrations/wecom/welcome_test.go
+++ b/server/internal/integrations/wecom/welcome_test.go
@@ -59,6 +59,10 @@ type countingBinder struct {
 	calls int
 	raw   string
 	err   error
+	// reused makes Mint answer the way the throttle does: a live link is
+	// already with this user, so only its expiry comes back and Raw stays
+	// empty — the raw secret was never stored.
+	reused bool
 }
 
 func (b *countingBinder) Mint(context.Context, pgtype.UUID, pgtype.UUID, string) (BindingToken, error) {
@@ -67,6 +71,9 @@ func (b *countingBinder) Mint(context.Context, pgtype.UUID, pgtype.UUID, string)
 	b.mu.Unlock()
 	if b.err != nil {
 		return BindingToken{}, b.err
+	}
+	if b.reused {
+		return BindingToken{ExpiresAt: time.Now().Add(BindingTokenTTL), Reused: true}, nil
 	}
 	return BindingToken{Raw: b.raw, ExpiresAt: time.Now().Add(BindingTokenTTL)}, nil
 }
@@ -173,6 +180,36 @@ func TestOpeningTheChatUnboundHandsOverTheLink(t *testing.T) {
 	}
 	if !strings.Contains(said, "https://multica.example/wecom/bind?token=s3cret") {
 		t.Fatalf("the greeting carries no bind link: %q", said)
+	}
+}
+
+// The throttle suppressed the mint, so there is no raw secret to put in a URL.
+// Building one anyway yields "?token=" and a link that binds nobody.
+//
+// Not a corner case: the bot answers an unbound user in a group, replier mints
+// and posts the link into their 1:1, and the user opens that 1:1 to click it —
+// their first entry of the day, so enter_chat fires seconds after the mint and
+// lands inside the throttle window.
+func TestOpeningTheChatWithALinkAlreadySentDoesNotSendAnEmptyToken(t *testing.T) {
+	t.Parallel()
+	lookup := &fakeWelcomeLookup{
+		bindingErr: pgx.ErrNoRows,
+		install:    db.ChannelInstallation{ID: mustTestUUID(t), WorkspaceID: mustTestUUID(t)},
+	}
+	minter := &countingBinder{raw: "s3cret", reused: true}
+	c, conn, sender := welcomeRig(t, lookup, minter)
+
+	c.handleEnterChat(context.Background(), enterChatFrame(t, "req-1", "single", "T-alex"), sender, slog.Default())
+
+	said := welcomeSaid(t, conn)
+	if said == "" {
+		t.Fatal("opening the chat produced nothing")
+	}
+	if strings.Contains(said, "token=") {
+		t.Errorf("the greeting carries a bind link built from a suppressed mint: %q", said)
+	}
+	if said != welcomeLinkAlreadySent {
+		t.Errorf("greeting = %q, want the one pointing at the link already in the chat", said)
 	}
 }
 

--- a/server/internal/integrations/wecom/welcome_test.go
+++ b/server/internal/integrations/wecom/welcome_test.go
@@ -599,21 +599,21 @@ func TestTheTwoGreetingsSayDifferentThings(t *testing.T) {
 }
 
 // The greeting names what the bot accepts, in copy. dispatchFrame decides it
-// in code, off bodyText. Nothing connected the two, and they came apart the
+// in code, off ownText. Nothing connected the two, and they came apart the
 // moment voice routing landed: the greeting went on telling every linked user
 // that only text worked while a spoken message was already being answered —
 // including a spoken "/issue", which files a task.
 //
 // The failure is silent by construction. A capability arrives by widening
-// bodyText, which is a different file from the one holding the sentence that
+// ownText, which is a different file from the one holding the sentence that
 // describes it, so nothing about that change draws the eye here. This asserts
-// the relation directly: whatever bodyText routes, the greeting has to name.
+// the relation directly: whatever ownText routes, the greeting has to name.
 func TestTheBoundGreetingNamesEveryKindTheBotActuallyRoutes(t *testing.T) {
 	t.Parallel()
 
 	// Each kind the adapter can route, the frame that carries it, and the word
 	// a user would look for in the greeting to know it is allowed. Add a row
-	// when bodyText learns a kind — that is the point of the test.
+	// when ownText learns a kind — that is the point of the test.
 	kinds := []struct {
 		what string
 		mc   aibotMsgCallback
@@ -631,25 +631,43 @@ func TestTheBoundGreetingNamesEveryKindTheBotActuallyRoutes(t *testing.T) {
 			mc.Voice.Content = "在吗"
 			return mc
 		}()},
+		{what: "a photo", word: "图片", mc: func() aibotMsgCallback {
+			var mc aibotMsgCallback
+			mc.MsgType = "image"
+			mc.Image.URL = "https://cos.example/i"
+			return mc
+		}()},
+		{what: "a file", word: "文件", mc: func() aibotMsgCallback {
+			var mc aibotMsgCallback
+			mc.MsgType = "file"
+			mc.File.URL = "https://cos.example/f"
+			return mc
+		}()},
+		{what: "a video", word: "视频", mc: func() aibotMsgCallback {
+			var mc aibotMsgCallback
+			mc.MsgType = "video"
+			mc.Video.URL = "https://cos.example/v"
+			return mc
+		}()},
 	}
 
-	// Anti-vacuity: if bodyText routed nothing, every assertion below would
+	// Anti-vacuity: if ownText routed nothing, every assertion below would
 	// pass without testing anything.
 	var routed int
 	for _, k := range kinds {
-		if _, ok := k.mc.bodyText(); ok {
+		if _, ok := k.mc.ownText(); ok {
 			routed++
 		}
 	}
 	if routed == 0 {
-		t.Fatal("bodyText routes none of the kinds listed here, so this guard asserts nothing. " +
+		t.Fatal("ownText routes none of the kinds listed here, so this guard asserts nothing. " +
 			"Re-point it at whatever decides a routable message now")
 	}
 
 	for _, k := range kinds {
-		_, routable := k.mc.bodyText()
+		_, routable := k.mc.ownText()
 		if !routable {
-			t.Errorf("bodyText no longer routes %s. If that was deliberate, drop the row and take %q "+
+			t.Errorf("ownText no longer routes %s. If that was deliberate, drop the row and take %q "+
 				"out of the greeting — leaving it in promises a user something the bot will refuse",
 				k.what, k.word)
 			continue
@@ -662,12 +680,23 @@ func TestTheBoundGreetingNamesEveryKindTheBotActuallyRoutes(t *testing.T) {
 		}
 	}
 
-	// The other half: the greeting must not promise a kind that gets the
-	// text-only receipt instead. "只能" (only) is how the stale wording said it.
-	var img aibotMsgCallback
-	img.MsgType = "image"
-	if _, routable := img.bodyText(); !routable && strings.Contains(welcomeBoundText, "只能处理文字") {
-		t.Errorf("the greeting still says text is the only thing that works, which stopped being true "+
-			"when voice routing landed: %q", welcomeBoundText)
+	// The other half: the greeting must not narrow what the bot takes. It has
+	// said "text only" and then "text and voice", and both stopped being true
+	// while the sentence stayed put — first when voice routing landed, then
+	// when media did.
+	for _, stale := range []string{"只能处理文字", "只支持文字", "目前支持文字和语音消息"} {
+		if strings.Contains(welcomeBoundText, stale) {
+			t.Errorf("the greeting still says %q, which is narrower than what the bot routes: %q",
+				stale, welcomeBoundText)
+		}
+	}
+
+	// A kind the adapter genuinely refuses still has to read as refused, or the
+	// loop above would pass on a greeting that promised everything.
+	var unknown aibotMsgCallback
+	unknown.MsgType = "link"
+	if _, routable := unknown.ownText(); routable {
+		t.Error("ownText routes an unknown msgtype, so the rows above no longer distinguish " +
+			"what the bot accepts from what it does not")
 	}
 }

--- a/server/internal/integrations/wecom/ws_sender.go
+++ b/server/internal/integrations/wecom/ws_sender.go
@@ -188,10 +188,16 @@ func (s *wsSender) deliverReply(env frameEnvelope) bool {
 // answer. A non-nil error is either a *wecomAPIError carrying the server's
 // errcode, errAckTimeout, or a transport failure.
 func (s *wsSender) request(ctx context.Context, cmd string, body map[string]any) (json.RawMessage, error) {
+	return s.requestWithID(ctx, newReqID(), cmd, body)
+}
+
+// requestWithID is request() for a frame whose req_id is not ours to choose —
+// a reply, which must echo the req_id of the frame that opened the turn or the
+// server refuses it. The enter_chat greeting is the caller today.
+func (s *wsSender) requestWithID(ctx context.Context, reqID, cmd string, body map[string]any) (json.RawMessage, error) {
 	if err := ctx.Err(); err != nil {
 		return nil, err
 	}
-	reqID := newReqID()
 	w, ok := s.awaitReply(reqID)
 	if !ok {
 		return nil, fmt.Errorf("wecom: %s req_id %s is already awaiting a response", cmd, reqID)


### PR DESCRIPTION
> Rebased onto current `main`; the dependency this used to be stacked on has
> merged, so this is now a single commit and the whole diff is reviewable.

## What is broken

`ws_frame.go` has named the event since the original WeCom PR:

```go
eventEnterChat = "enter_chat"
```

Nothing ever handled it. The frame reached `dispatchFrame`'s event switch, missed
every case, and landed in the default arm:

```go
default:
    log.Debug("wecom: event", "type", ec.Event.EventType)
    return nil
```

WeCom pushes `enter_chat` the moment somebody opens the bot's conversation, and
expects `aibot_respond_welcome_msg` back. So the actual behaviour was: **a
brand-new user opens the bot and gets an empty window.** No statement of what
the bot is for, no hint that it needs their Multica account linked before it
will answer anything. The only way to discover that was to send it a message
and be told. Slack posts an App Home, Lark sends a welcome card; WeCom was the
one channel that said nothing.

WeCom gives roughly five seconds to answer, after which the chat window is
drawn and the user is already typing.

## What this does

`welcome.go` — `handleEnterChat`, `welcomeText`, `respondWelcome`,
`isWelcomeFrame`, `welcomeDeadline` (4s), `welcomeQueueDepth` (8) — plus the
read-loop wiring in `Connect` and the boot wiring in `router.go`.

* **Unlinked user** → greeting + a bind link, minted the same way and pointing
  at the same page as the `needs_binding` prompt in `replier.go`. The first
  thing they see is also the thing that makes the bot work.
* **Linked user** → plain greeting, no link, no token minted. Offering a bind
  link to somebody already bound reads as the bot having lost their account.
* **Can't tell** (lookup failed, no binding surface wired, mint failed) →
  plain greeting. Degrading to silence would make the bot look broken over a
  feature the deployment may simply not have.
* The reply echoes the frame's own `req_id`. That is the only address a
  welcome has; a fresh id is refused.

Copy is hardcoded Chinese, matching how every other user-visible string in this
adapter already works (`agentOfflineText`, the binding prompt, the text-only
receipt). This package has no locale layer and WeCom deployments are China-only.

## The deliberate asymmetry — please read this before flagging it

Two queues sit within a few lines of each other in `Connect` with **opposite
full-queue policies**. This is intentional, and it is the thing a mechanical
port would flatten:

| | depth | when full |
|---|---|---|
| inbound callbacks (`callbackQueueDepth`, on the base branch) | 64 | **blocks** the read loop |
| welcome (`welcomeQueueDepth`, this PR) | 8 | **drops** the frame |

Both are correct, for opposite reasons:

* A **dropped callback** is a message the user sent that nobody ever answers,
  with nothing to say so. Blocking is backpressure — at worst WeCom ends the
  connection and the Supervisor reconnects, which is recoverable. Silent loss
  is not.
* A **late welcome** is worse than no welcome. It lands in a chat the user has
  already started typing in. And a greeting is addressed by a `req_id`, which
  means nothing on the next connection — so there is no version of it worth
  holding. A late welcome is void, not late. Meanwhile, blocking on it would
  hold the read loop, which is the sole deliverer of the acks every other
  outbound write is parked on.

Same reason enter_chat gets its own worker rather than sharing the callback
worker: one message callback ahead of it in a single queue can take longer than
five seconds on its own, which would reliably turn a greeting into nothing.

`TestAFullWelcomeQueueDoesNotStallTheReadLoop` is the guard on this. Flip the
`default:` arm to a blocking send and it fails.

## Group chats get no greeting — also deliberate

`handleEnterChat` returns early on anything that is not `chattype == "single"`.
Two reasons, either sufficient:

1. Greeting a room is a different act from greeting a person. The event names
   whoever just walked in, so a welcome in a group is an announcement *about*
   that person to an audience. That is not what opening a chat asked for.
2. The bind link is a bearer credential. `binding.Redeem` only checks that the
   redeemer belongs to the token's workspace, and the bind page redeems on load
   as whoever is signed in — so posted into a room, the first colleague to
   click owns the account, and every later message from the person it was
   minted for resolves to the hijacker. Same reasoning `sendBindingPrompt`
   already spells out in `replier.go`, and easier to obey here: a room nobody
   has spoken in yet has nothing to be told.

## Reverse-verified: every test fails on the old code

Each test was checked by reverting *only* the line it claims to defend and
confirming it fails. Real output:

```
=== TestOpeningTheChatIsAnsweredOverTheLiveConnection
    revert: read loop diverts enter_chat to the welcome worker
    --- FAIL: TestOpeningTheChatIsAnsweredOverTheLiveConnection (3.00s)
        welcome_test.go:462: enter_chat arrived on a live connection and the bot
        said nothing — a first-time user is looking at an empty window

=== TestOpeningTheChatUnboundHandsOverTheLink
    revert: an unbound user is offered a bind link
    --- FAIL: TestOpeningTheChatUnboundHandsOverTheLink (0.00s)
        welcome_test.go:175: the greeting carries no bind link: "👋 你好，我是
        Multica 智能助手。有事直接发消息给我，或者用 “/issue 标题” 建一条任务。…"

=== TestOpeningTheChatBoundGreetsWithoutALink
    revert: a bound user is not offered a link and no token is minted
    --- FAIL: TestOpeningTheChatBoundGreetsWithoutALink (0.00s)
        welcome_test.go:194: a bind link was offered to somebody already bound:
        "…请先绑定你的 Multica 账号…/wecom/bind?token=s3cret…"

=== TestAGroupGetsNoGreetingAndNoToken
    revert: group chats are skipped
    --- FAIL: TestAGroupGetsNoGreetingAndNoToken (0.00s)
        welcome_test.go:218: a room was greeted: "…/wecom/bind?token=s3cret…"

=== TestNoBindingSurfaceStillGreets
    revert: no binding surface still greets instead of going silent
    --- FAIL: TestNoBindingSurfaceStillGreets (0.00s)
        welcome_test.go:236: said "", want the plain greeting

=== TestAnUnreadableBindingDoesNotOfferALink
    revert: an unreadable binding row does not become a bind link
    --- FAIL: TestAnUnreadableBindingDoesNotOfferALink (0.00s)
        welcome_test.go:252: a link was offered on a failed lookup:
        "…/wecom/bind?token=s3cret…"

=== TestTheGreetingEchoesTheFramesReqID
    revert: the welcome echoes the frame's own req_id
    --- FAIL: TestTheGreetingEchoesTheFramesReqID (0.00s)
        welcome_test.go:276: req_id = "ed5fc87b68b8306a", want the frame's own
        — WeCom refuses anything else

=== TestOnlyEnterChatRoutesToTheWelcomeWorker
    revert: only enter_chat is treated as a welcome
    --- FAIL: TestOnlyEnterChatRoutesToTheWelcomeWorker (0.00s)
        welcome_test.go:296: disconnected_event was routed to the welcome
        worker, which never escalates and never reaches the engine

=== TestAFullWelcomeQueueDoesNotStallTheReadLoop
    revert: a full welcome queue DROPS instead of blocking the read loop
    --- FAIL: TestAFullWelcomeQueueDoesNotStallTheReadLoop (3.00s)
        welcome_test.go:510: a burst of enter_chat frames stalled the read loop:
        the message the user typed behind them was never read
```

One test initially survived its revert and was rewritten rather than kept:
`TestOpeningTheChatBoundGreetsWithoutALink`. Deleting the whole `case err == nil`
arm left `case !errors.Is(err, pgx.ErrNoRows)` catching a nil error too, so the
bound path stayed correct by accident and the test passed on the reverted code.
The revert it is now checked against deletes only the `return` under
`case err == nil:`, which drops through into the mint — and the test fails, as it
must.

`TestOpeningTheChatIsAnsweredOverTheLiveConnection` drives the whole thing
through `Connect` against a socket double that acks the subscribe handshake and
answers written frames with real ack frames over the wire — so it exercises the
read loop, the welcome worker, and the ack round-trip together, not just the
handler in isolation.

## Not ported, on purpose

* **The durable outbound queue and the rate gate** — superseded by #6581.
* **`respondText`** (the passive-reply courtesy notice) shipped in the same file
  on the source branch, but it depends on a `claimPassiveReply` turn-claim that
  does not exist here, and nothing on this base calls it. Adding it would be
  untestable dead code. It belongs with the streaming-reply work.
* **The welcome metrics counters** (`RecordWelcomeSent` / `Skipped` / `Failed`).
  The `Metrics` sink has since landed on `main`, so the wiring for them exists
  now — but the interface carries connection and callback-queue counters only,
  and widening it is a decision about what the WeCom dashboard is for rather
  than part of this greeting. Log lines here, still. Say the word and I will
  add them in a follow-up.
* **The locale/copy pack** — no such layer here; hardcoded Chinese, as above.
* **`token.Reused`** (the "a live link is already with them" branch) — that
  field arrives with the mint-throttle PR. Nothing to port yet.

## Incidental

* `wsSender.request` is split into `request` / `requestWithID`. Same code, same
  behaviour; a welcome cannot choose its own `req_id`, it must echo the frame's.
* `NewOutboundReplier`'s inline bind-path defaulting moves to a shared
  `normalizeBindingPath`, so the greeting's link and the `needs_binding`
  prompt's link cannot drift onto two different bind pages.

## Checks

```
go build ./...          clean
go vet ./...            clean
gofmt -l                clean
go test ./internal/integrations/wecom/                  ok  (168 tests)
go test -race -count=3 ./internal/integrations/wecom/   ok
go test -race ./cmd/server/...                          ok
```

