### PR TITLE
fix(wecom): close the streaming bubble when a run is cancelled, not only when it fails

### DIFF
--- a/server/cmd/server/router.go
+++ b/server/cmd/server/router.go
@@ -697,16 +697,45 @@ func NewRouterWithOptions(pool *pgxpool.Pool, hub *realtime.Hub, bus *events.Bus
 					Senders:     wecomSenders,
 					Logger:      slog.Default(),
 				})
+				// Streaming replies: WeCom's smart-bot protocol has no
+				// typing indicator, no reaction and no read receipt, so the
+				// only way to say "working on it" is to open the reply early.
+				// The typing indicator paints a stream bubble the moment a
+				// message is ingested and the outbound subscriber replaces
+				// that same bubble with the answer. The store is the seam
+				// between them — it carries the inbound frame's req_id, which
+				// only the read loop ever sees and every stream frame must
+				// echo — so both sides are built with the one instance.
+				wecomStreams := wecom.NewStreamStore()
+				wecomTyping := wecom.NewTypingIndicator(wecom.TypingIndicatorConfig{
+					Senders: wecomSenders,
+					Streams: wecomStreams,
+					// A sweeper's task:failed names a task and not a chat
+					// session, so the session is read back off the task row.
+					Tasks: queries,
+					// A run that fails after its bubble is gone — the guard
+					// closed it at five minutes, or the process restarted
+					// mid-run — still owes the user the news, and the binding
+					// row is where the chat is found when no handle is left.
+					Bindings: queries,
+					Logger:   slog.Default(),
+				})
+				// Subscribes task:failed: a failed run publishes no chat:done,
+				// so this is the sole path that stops the bubble spinning
+				// after a failure.
+				wecomTyping.Register(bus)
+
 				channelRouter.Register(wecom.TypeWecom, wecom.NewResolverSet(
-					wecomStore, wecomSession, wecomReplier,
+					wecomStore, wecomSession, wecomReplier, wecomTyping,
 				))
 
 				// EventChatDone subscriber: pushes the agent's chat reply
-				// back over the same aibot WebSocket the inbound loop owns.
-				// Mirrors slack.NewOutbound(...).Register(bus). Without it
-				// the agent's reply lands only in Multica's web UI — the
-				// user in WeCom sees no response.
-				wecom.NewOutbound(queries, wecomSenders, slog.Default()).Register(bus)
+				// back over the same aibot WebSocket the inbound loop owns —
+				// into the open bubble when there is one, as a new message
+				// when there is not. Mirrors slack.NewOutbound(...).Register(bus).
+				// Without it the agent's reply lands only in Multica's web UI
+				// — the user in WeCom sees no response.
+				wecom.NewOutbound(queries, wecomSenders, wecomStreams, slog.Default()).Register(bus)
 
 				slog.Info("wecom integration enabled (smart bot, long connection)")
 				// SINGLE-REPLICA CONSTRAINT: WeCom outbound (agent replies +

--- a/server/cmd/server/wecom_bubble_wiring_test.go
+++ b/server/cmd/server/wecom_bubble_wiring_test.go
@@ -1,0 +1,62 @@
+package main
+
+import (
+	"crypto/rand"
+	"encoding/base64"
+	"testing"
+
+	"github.com/multica-ai/multica/server/internal/analytics"
+	"github.com/multica-ai/multica/server/internal/events"
+	"github.com/multica-ai/multica/server/internal/realtime"
+	"github.com/multica-ai/multica/server/internal/util/secretbox"
+	"github.com/multica-ai/multica/server/pkg/protocol"
+)
+
+// What closes the WeCom streaming bubble is a bus subscription, and a
+// subscription that is missing is invisible: the events keep being published,
+// nobody reads them, and the user watches a spinner until the five-minute
+// guard replaces it with a promise about a run that is already over. Nothing
+// in the package fails, because every unit test builds its own manager and
+// registers it by hand.
+//
+// So this asserts the subscriptions off the REAL boot path — NewRouter, the
+// same call main() makes. Two routers are built on two buses, one with the
+// WeCom key set and one without, and the WeCom one has to add a listener on
+// each event. Comparing the two is what keeps the guard honest without it
+// having to know which other subsystems subscribe to the same events.
+//
+// A nil pool is deliberate: nothing in the WeCom boot block queries the
+// database, and metrics_test.go boots the same way.
+func TestWecomBubbleClosersSubscribeOnTheRealBootPath(t *testing.T) {
+	key := make([]byte, secretbox.KeySize)
+	if _, err := rand.Read(key); err != nil {
+		t.Fatalf("generate a wecom secretbox key: %v", err)
+	}
+
+	withoutWecom := events.New()
+	NewRouter(nil, realtime.NewHub(), withoutWecom, analytics.NoopClient{}, nil)
+
+	t.Setenv("MULTICA_WECOM_SECRET_KEY", base64.StdEncoding.EncodeToString(key))
+	withWecom := events.New()
+	NewRouter(nil, realtime.NewHub(), withWecom, analytics.NoopClient{}, nil)
+
+	// Anti-vacuity: if the WeCom block did not run at all, nothing below can
+	// fail for the reason it names. chat:done is the subscription that has
+	// been wired all along, so it is the marker that the block was entered.
+	if got, base := withWecom.SubscriberCount(protocol.EventChatDone),
+		withoutWecom.SubscriberCount(protocol.EventChatDone); got <= base {
+		t.Fatalf("the WeCom boot block did not run: chat:done listeners %d with the key set vs %d without. "+
+			"Re-point this guard at wherever WeCom is wired now", got, base)
+	}
+
+	for _, event := range []string{protocol.EventTaskFailed, protocol.EventTaskCancelled} {
+		with := withWecom.SubscriberCount(event)
+		without := withoutWecom.SubscriberCount(event)
+		if with <= without {
+			t.Errorf("nothing in the WeCom boot path subscribes to %s (%d listeners with WeCom enabled, %d without). "+
+				"A run that ends on %s publishes no chat:done, so the bubble it opened is never closed and the user "+
+				"watches a spinner for an answer nobody is producing. Check TypingIndicatorManager.Register.",
+				event, with, without, event)
+		}
+	}
+}

--- a/server/internal/events/bus.go
+++ b/server/internal/events/bus.go
@@ -46,6 +46,18 @@ func (b *Bus) Subscribe(eventType string, h Handler) {
 	b.listeners[eventType] = append(b.listeners[eventType], h)
 }
 
+// SubscriberCount reports how many type-specific handlers are registered for
+// an event type. It exists for wiring guards: a subscriber that is never
+// registered fails silently — the events keep flowing and nobody reads them —
+// so "is anything listening" has to be assertable from outside the bus.
+// Global (SubscribeAll) handlers are not counted; they answer a different
+// question.
+func (b *Bus) SubscriberCount(eventType string) int {
+	b.mu.RLock()
+	defer b.mu.RUnlock()
+	return len(b.listeners[eventType])
+}
+
 // SubscribeAll registers a handler that receives ALL events regardless of type.
 // Global handlers are called after type-specific handlers.
 func (b *Bus) SubscribeAll(h Handler) {

--- a/server/internal/integrations/wecom/dispatch_test.go
+++ b/server/internal/integrations/wecom/dispatch_test.go
@@ -40,7 +40,7 @@ func TestDispatchFrame_TextReachesHandler(t *testing.T) {
 		return nil
 	})
 	conn := &recordingConn{}
-	err := c.dispatchFrame(context.Background(), msgCallbackFrame(t, "text", "hello"), newWSSender(conn, nil), slog.Default())
+	err := c.dispatchFrame(context.Background(), msgCallbackFrame(t, "text", "hello"), conn.autoAck(newWSSender(conn, nil)), slog.Default())
 	if err != nil {
 		t.Fatalf("dispatchFrame: %v", err)
 	}
@@ -63,7 +63,7 @@ func TestDispatchFrame_NonTextGetsReceiptAndSkipsHandler(t *testing.T) {
 		return nil
 	})
 	conn := &recordingConn{}
-	err := c.dispatchFrame(context.Background(), msgCallbackFrame(t, "image", ""), newWSSender(conn, nil), slog.Default())
+	err := c.dispatchFrame(context.Background(), msgCallbackFrame(t, "image", ""), conn.autoAck(newWSSender(conn, nil)), slog.Default())
 	if err != nil {
 		t.Fatalf("dispatchFrame: %v", err)
 	}
@@ -95,7 +95,7 @@ func TestDispatchFrame_ServerPingIsPonged(t *testing.T) {
 	t.Parallel()
 	c := testChannel(func(context.Context, channel.InboundMessage) error { return nil })
 	conn := &recordingConn{}
-	err := c.dispatchFrame(context.Background(), frameEnvelope{Cmd: cmdServerPing, Headers: frameHeaders{ReqID: "r1"}}, newWSSender(conn, nil), slog.Default())
+	err := c.dispatchFrame(context.Background(), frameEnvelope{Cmd: cmdServerPing, Headers: frameHeaders{ReqID: "r1"}}, conn.autoAck(newWSSender(conn, nil)), slog.Default())
 	if err != nil {
 		t.Fatalf("dispatchFrame: %v", err)
 	}

--- a/server/internal/integrations/wecom/outbound.go
+++ b/server/internal/integrations/wecom/outbound.go
@@ -54,6 +54,7 @@ type outboundQueries interface {
 type Outbound struct {
 	q       outboundQueries
 	senders *sendersRegistry
+	streams *streamStore
 	logger  *slog.Logger
 }
 
@@ -62,11 +63,14 @@ type Outbound struct {
 // built with — reply delivery goes through the live wsSender for the
 // binding's installation, so a session whose Supervisor lost the lease
 // mid-flight silently drops rather than opening a second connection.
-func NewOutbound(q outboundQueries, senders *sendersRegistry, logger *slog.Logger) *Outbound {
+//
+// streams is the same store the typing indicator writes to; nil disables the
+// in-place reply and leaves every answer going out as a new message.
+func NewOutbound(q outboundQueries, senders *sendersRegistry, streams *streamStore, logger *slog.Logger) *Outbound {
 	if logger == nil {
 		logger = slog.Default()
 	}
-	return &Outbound{q: q, senders: senders, logger: logger}
+	return &Outbound{q: q, senders: senders, streams: streams, logger: logger}
 }
 
 // Register subscribes to the chat-done event on the bus.
@@ -95,6 +99,36 @@ func (o *Outbound) processEvent(ctx context.Context, e events.Event) error {
 		// Issue / autopilot tasks carry no chat_session.
 		return nil
 	}
+	content := chatDoneContent(e.Payload)
+
+	// The bubble this run's round opened, if there is one. Taken up front and
+	// unconditionally: from here on this turn owns it, and a handle left in
+	// the store after the turn ends is a handle pointing at a sealed message.
+	if handle, streaming := o.takeStream(sessionID, e); streaming {
+		// A bubble on screen has to end in words. An empty completion is a
+		// legitimate outcome — the agent had nothing to add — but an endless
+		// spinner is not, so the copy stands in for the silence. For a round
+		// that waited in line behind another, the silence has a better
+		// explanation: the reply ahead of it already covered this message.
+		text := content
+		if !hasVisibleChar(text) {
+			text = streamCopyNoReply
+			if handle.QueuedBehind {
+				text = streamCopyMerged
+			}
+		}
+		if err := o.finishStream(ctx, handle, text); err == nil {
+			return nil
+		}
+		// The frame was refused. Say it as a new message instead — and never
+		// re-send the stream frame itself, whose req_id will have expired long
+		// before another connection could carry it.
+		content = text
+	}
+	if content == "" {
+		return nil // nothing to say, no bubble to close, nothing to send
+	}
+
 	binding, err := o.q.GetChannelChatSessionBindingBySession(ctx, db.GetChannelChatSessionBindingBySessionParams{
 		ChatSessionID: sessionID,
 		ChannelType:   channelTypeWecom,
@@ -104,10 +138,6 @@ func (o *Outbound) processEvent(ctx context.Context, e events.Event) error {
 			return nil // not a wecom session (Slack / Lark / web-only)
 		}
 		return fmt.Errorf("wecom: lookup chat binding: %w", err)
-	}
-	content := chatDoneContent(e.Payload)
-	if content == "" {
-		return nil // nothing to say (empty completion)
 	}
 	inst, err := o.q.GetChannelInstallation(ctx, db.GetChannelInstallationParams{
 		ID:          binding.InstallationID,
@@ -137,6 +167,32 @@ func (o *Outbound) processEvent(ctx context.Context, e events.Event) error {
 	}
 	chatType := aibotChatTypeFromChannel(channel.ChatType(binding.ChatType))
 	return sender.sendText(binding.ChannelChatID, chatType, content)
+}
+
+// takeStream claims the bubble this run's round opened, so the answer can
+// replace it in place. The task id is what picks the right one when a session
+// has more than one round open: the head is the running round, but only until
+// a guard has already closed it.
+func (o *Outbound) takeStream(sessionID pgtype.UUID, e events.Event) (streamHandle, bool) {
+	if o.streams == nil || o.senders == nil {
+		return streamHandle{}, false
+	}
+	return o.streams.takeTask(sessionID, taskIDFromEvent(e), roundOver)
+}
+
+// finishStream writes the answer into the bubble and seals it. A failure here
+// is not fatal to the reply — it means the caller falls back to a new message —
+// so it is logged with the one detail that explains it: whether the stream is
+// beyond saving (past its window, bad req_id) or the socket simply blinked.
+func (o *Outbound) finishStream(ctx context.Context, h streamHandle, text string) error {
+	err := o.senders.stream(ctx, h, text, true)
+	if err == nil {
+		return nil
+	}
+	o.logger.WarnContext(ctx, "wecom outbound: in-place reply failed, sending a new message instead",
+		"installation_id", uuidStringPub(h.InstallationID),
+		"stream_unusable", streamUnusable(err), "error", err)
+	return err
 }
 
 // chatDoneContent extracts the reply text from an EventChatDone payload

--- a/server/internal/integrations/wecom/outbound_test.go
+++ b/server/internal/integrations/wecom/outbound_test.go
@@ -57,7 +57,7 @@ func newOutboundWithConn(t *testing.T, q outboundQueries) (*Outbound, pgtype.UUI
 	reg := newSendersRegistry()
 	instID := mustTestUUID(t)
 	conn := &recordingConn{}
-	reg.set(instID, newWSSender(conn, nil))
+	reg.set(instID, conn.autoAck(newWSSender(conn, nil)))
 	return NewOutbound(q, reg, slog.Default()), instID, conn
 }
 

--- a/server/internal/integrations/wecom/outbound_test.go
+++ b/server/internal/integrations/wecom/outbound_test.go
@@ -58,7 +58,7 @@ func newOutboundWithConn(t *testing.T, q outboundQueries) (*Outbound, pgtype.UUI
 	instID := mustTestUUID(t)
 	conn := &recordingConn{}
 	reg.set(instID, conn.autoAck(newWSSender(conn, nil)))
-	return NewOutbound(q, reg, slog.Default()), instID, conn
+	return NewOutbound(q, reg, nil, slog.Default()), instID, conn
 }
 
 func TestProcessEvent_DeliversChatReplyToBoundChat(t *testing.T) {

--- a/server/internal/integrations/wecom/replier_test.go
+++ b/server/internal/integrations/wecom/replier_test.go
@@ -36,6 +36,23 @@ func (f fakeBinder) Mint(context.Context, pgtype.UUID, pgtype.UUID, string) (Bin
 type recordingConn struct {
 	mu     sync.Mutex
 	frames []frameEnvelope
+
+	// sender, when set, makes this double answer its writes the way the real
+	// server does: an ack frame echoing the req_id with errcode 0. Senders
+	// that read their verdict block until one arrives, so a double that never
+	// answers turns every send into a 5-second timeout.
+	//
+	// Set refuseCode to make the server refuse instead.
+	sender     *wsSender
+	refuseCode int
+	refuseMsg  string
+}
+
+// autoAck wires the double to answer the sender's writes. Call it after
+// newWSSender, which needs the conn first.
+func (c *recordingConn) autoAck(s *wsSender) *wsSender {
+	c.sender = s
+	return s
 }
 
 func (c *recordingConn) WriteMessage(_ int, data []byte) error {
@@ -45,7 +62,16 @@ func (c *recordingConn) WriteMessage(_ int, data []byte) error {
 	}
 	c.mu.Lock()
 	c.frames = append(c.frames, env)
+	s := c.sender
+	code, msg := c.refuseCode, c.refuseMsg
 	c.mu.Unlock()
+	if s != nil {
+		s.routeResponse(frameEnvelope{
+			Headers: frameHeaders{ReqID: env.Headers.ReqID},
+			ErrCode: code,
+			ErrMsg:  msg,
+		})
+	}
 	return nil
 }
 func (c *recordingConn) ReadMessage() (int, []byte, error) { return 0, nil, nil }
@@ -73,7 +99,7 @@ func newReplierWithConn(t *testing.T) (*OutboundReplier, engine.ResolvedInstalla
 	reg := newSendersRegistry()
 	inst := engine.ResolvedInstallation{ID: mustTestUUID(t)}
 	conn := &recordingConn{}
-	reg.set(inst.ID, newWSSender(conn, nil))
+	reg.set(inst.ID, conn.autoAck(newWSSender(conn, nil)))
 	r := NewOutboundReplier(OutboundReplierConfig{Senders: reg, AppURL: "https://multica.example"})
 	return r, inst, conn
 }
@@ -137,7 +163,7 @@ func TestSendBindingPrompt_GroupNeverLeaksToken(t *testing.T) {
 	reg := newSendersRegistry()
 	inst := engine.ResolvedInstallation{ID: mustTestUUID(t)}
 	conn := &recordingConn{}
-	reg.set(inst.ID, newWSSender(conn, nil))
+	reg.set(inst.ID, conn.autoAck(newWSSender(conn, nil)))
 	r := NewOutboundReplier(OutboundReplierConfig{
 		Binding: nil, // set the interface field directly with the fake below
 		Senders: reg,
@@ -209,7 +235,7 @@ func TestSendBindingPrompt_P2PSendsOnlyPrivately(t *testing.T) {
 	reg := newSendersRegistry()
 	inst := engine.ResolvedInstallation{ID: mustTestUUID(t)}
 	conn := &recordingConn{}
-	reg.set(inst.ID, newWSSender(conn, nil))
+	reg.set(inst.ID, conn.autoAck(newWSSender(conn, nil)))
 	r := NewOutboundReplier(OutboundReplierConfig{Senders: reg, AppURL: "https://multica.example"})
 	r.binding = fakeBinder{raw: rawToken}
 

--- a/server/internal/integrations/wecom/resolvers_test.go
+++ b/server/internal/integrations/wecom/resolvers_test.go
@@ -87,7 +87,7 @@ func TestSessionBinder_BindMediaIsNoop(t *testing.T) {
 
 func TestNewResolverSet_WiresAllResolvers(t *testing.T) {
 	t.Parallel()
-	set := NewResolverSet(&Store{}, &fakeSessionBinder{}, nil)
+	set := NewResolverSet(&Store{}, &fakeSessionBinder{}, nil, nil)
 	if set.Installation == nil || set.Identity == nil || set.Dedup == nil || set.Session == nil || set.Audit == nil {
 		t.Error("NewResolverSet left a required resolver nil")
 	}
@@ -175,7 +175,7 @@ func TestOutbound_RegisterAndHandleEventNoopOnNonWecom(t *testing.T) {
 	// that isn't a wecom binding must be a silent no-op (handleEvent swallows
 	// the processEvent result). Uses pgx.ErrNoRows via the fake.
 	q := &fakeOutboundQueries{sessionErr: pgx.ErrNoRows}
-	o := NewOutbound(q, newSendersRegistry(), slog.Default())
+	o := NewOutbound(q, newSendersRegistry(), nil, slog.Default())
 	bus := events.New()
 	o.Register(bus)
 	// Publishing must not panic; the handler runs synchronously on the bus.

--- a/server/internal/integrations/wecom/send_verdict_test.go
+++ b/server/internal/integrations/wecom/send_verdict_test.go
@@ -1,0 +1,61 @@
+package wecom
+
+// send_verdict_test.go — a push used to return nil as soon as the bytes left
+// the process. WeCom's answer comes back in a separate ack frame, so a frame
+// the server refused was indistinguishable from one it accepted.
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestSendTextReportsAServerRefusal(t *testing.T) {
+	conn := &recordingConn{refuseCode: 45009, refuseMsg: "rate limit"}
+	sender := conn.autoAck(newWSSender(conn, nil))
+
+	err := sender.sendText("CHAT", chatTypeSingleInt, "hello")
+	if err == nil {
+		t.Fatal("a send WeCom refused reported success — the caller records a delivery that never happened")
+	}
+	var apiErr *wecomAPIError
+	if !errors.As(err, &apiErr) {
+		t.Fatalf("error is not a *wecomAPIError, so a caller cannot tell a permanent refusal from a transient one: %v", err)
+	}
+	if apiErr.Code != 45009 {
+		t.Errorf("errcode = %d, want 45009", apiErr.Code)
+	}
+	if apiErr.Cmd != cmdSendMsg {
+		t.Errorf("cmd = %q, want %q", apiErr.Cmd, cmdSendMsg)
+	}
+}
+
+func TestSendTextSucceedsOnAZeroErrcode(t *testing.T) {
+	conn := &recordingConn{}
+	sender := conn.autoAck(newWSSender(conn, nil))
+
+	if err := sender.sendText("CHAT", chatTypeSingleInt, "hello"); err != nil {
+		t.Fatalf("an accepted send reported failure: %v", err)
+	}
+	conn.mu.Lock()
+	n := len(conn.frames)
+	conn.mu.Unlock()
+	if n != 1 {
+		t.Fatalf("wrote %d frames, want 1", n)
+	}
+}
+
+// A verdict that never arrives must not be reported as a refusal: the message
+// may well have been delivered, so the two call for opposite responses.
+func TestSendTextDistinguishesALostAckFromARefusal(t *testing.T) {
+	conn := &recordingConn{} // no autoAck: nothing ever answers
+	sender := newWSSender(conn, nil)
+
+	err := sender.sendText("CHAT", chatTypeSingleInt, "hello")
+	if !errors.Is(err, errAckTimeout) {
+		t.Fatalf("a lost ack reported as %v, want errAckTimeout", err)
+	}
+	var apiErr *wecomAPIError
+	if errors.As(err, &apiErr) {
+		t.Error("a lost ack was reported as a server refusal")
+	}
+}

--- a/server/internal/integrations/wecom/senders_registry.go
+++ b/server/internal/integrations/wecom/senders_registry.go
@@ -15,6 +15,7 @@ package wecom
 // without threading the Channel through the engine.
 
 import (
+	"context"
 	"sync"
 
 	"github.com/jackc/pgx/v5/pgtype"
@@ -58,4 +59,30 @@ func (r *sendersRegistry) get(id pgtype.UUID) *wsSender {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
 	return r.byKey[util.UUIDToString(id)]
+}
+
+// stream writes one frame of a streaming reply to the bubble h describes.
+//
+// A stream frame is only meaningful while the req_id it echoes is still fresh,
+// so a frame that cannot go out now is worthless later — there is nothing
+// useful to do with it but report the failure and let the caller say the same
+// words as an ordinary message instead.
+func (r *sendersRegistry) stream(ctx context.Context, h streamHandle, content string, finish bool) error {
+	sender := r.get(h.InstallationID)
+	if sender == nil {
+		return errNoLiveConnection
+	}
+	return sender.respondStream(ctx, h.ReqID, h.StreamID, content, finish)
+}
+
+// sendTextCtx pushes a plain message to a chat over the installation's live
+// connection — the fallback every closing frame degrades to. Separate from
+// stream because a message has no req_id to expire: this is the path that
+// still works when the bubble is beyond saving.
+func (r *sendersRegistry) sendTextCtx(ctx context.Context, id pgtype.UUID, chatID string, chatType int, content string) error {
+	sender := r.get(id)
+	if sender == nil {
+		return errNoLiveConnection
+	}
+	return sender.sendTextCtx(ctx, chatID, chatType, content)
 }

--- a/server/internal/integrations/wecom/stream_ack_test.go
+++ b/server/internal/integrations/wecom/stream_ack_test.go
@@ -1,0 +1,279 @@
+package wecom
+
+// stream_ack_test.go — a turn writes several frames on ONE req_id, and the ack
+// frame carries nothing but that req_id: no stream id, no sequence. So a
+// verdict is only identifiable by its position in the turn's write order, and
+// getting that wrong loses the user's answer silently.
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/gorilla/websocket"
+)
+
+// silentConn records writes and never answers them. Acks are fed in by the
+// test, in the order the real read loop would deliver them.
+type silentConn struct {
+	mu     sync.Mutex
+	frames []frameEnvelope
+	err    error
+}
+
+func (c *silentConn) WriteMessage(_ int, data []byte) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.err != nil {
+		return c.err
+	}
+	var env frameEnvelope
+	if err := json.Unmarshal(data, &env); err != nil {
+		return err
+	}
+	c.frames = append(c.frames, env)
+	return nil
+}
+func (c *silentConn) ReadMessage() (int, []byte, error) { return 0, nil, nil }
+func (c *silentConn) SetReadDeadline(time.Time) error   { return nil }
+func (c *silentConn) SetWriteDeadline(time.Time) error  { return nil }
+func (c *silentConn) Close() error                      { return nil }
+
+func (c *silentConn) count() int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return len(c.frames)
+}
+
+func (c *silentConn) streamBody(t *testing.T, i int) map[string]any {
+	t.Helper()
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if i >= len(c.frames) {
+		t.Fatalf("frame %d not written (have %d)", i, len(c.frames))
+	}
+	var body map[string]any
+	if err := json.Unmarshal(c.frames[i].Body, &body); err != nil {
+		t.Fatalf("decode body: %v", err)
+	}
+	stream, ok := body["stream"].(map[string]any)
+	if !ok {
+		t.Fatalf("frame %d is not a stream frame: %v", i, body)
+	}
+	return stream
+}
+
+// THE failure this bookkeeping exists to prevent.
+//
+// The opening frame's verdict is late. Its caller has already given up, the
+// answer has gone out behind it, and then the server's answer to the OPENING
+// frame arrives — errcode 0, "accepted". Handed to whoever happens to be
+// waiting, that stale acceptance satisfies the CLOSING frame: the answer reads
+// as delivered, the caller never falls back to a plain message, and the reply
+// the user was waiting for is sent nowhere at all.
+func TestALateVerdictIsNotHandedToTheNextFrame(t *testing.T) {
+	t.Parallel()
+	conn := &silentConn{}
+	sender := newWSSender(conn, nil)
+	sender.ackTimeout = 50 * time.Millisecond
+	const reqID = "REQ-1"
+
+	// Frame 1 — the opening frame. Nothing answers it, so its caller gives up.
+	if err := sender.respondStream(context.Background(), reqID, "S-1", streamThinkingPlaceholder, false); !errors.Is(err, errStreamAckTimeout) {
+		t.Fatalf("opening frame: got %v, want errStreamAckTimeout", err)
+	}
+
+	// Frame 2 — the answer. It has to wait for a verdict of its own.
+	done := make(chan error, 1)
+	go func() {
+		done <- sender.respondStream(context.Background(), reqID, "S-1", "the agent reply", true)
+	}()
+	waitForFrames(t, conn, 2)
+
+	// The opening frame's verdict finally arrives: accepted. It belongs to a
+	// frame nobody is waiting for any more and must go nowhere.
+	sender.deliverAck(reqID, 0, "")
+
+	select {
+	case err := <-done:
+		t.Fatalf("the closing frame took the opening frame's stale verdict and reported %v; the answer is now recorded as delivered and will never be re-sent", err)
+	case <-time.After(20 * time.Millisecond):
+	}
+
+	// Now the closing frame's own verdict: a refusal. THIS is the one it must
+	// read, because it is what sends the answer out as a plain message instead.
+	sender.deliverAck(reqID, errcodeStreamExpired, "stream expired")
+	select {
+	case err := <-done:
+		if !streamUnusable(err) {
+			t.Fatalf("closing frame reported %v; want the server's 846608 refusal", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("the closing frame never read its own verdict")
+	}
+}
+
+// A sealed stream is immutable. A frame that lost the race to the answer must
+// never reach the wire behind it — the server might still take it, and it would
+// paint the placeholder back over the reply the user is reading.
+func TestAFrameAfterTheClosingFrameNeverReachesTheWire(t *testing.T) {
+	t.Parallel()
+	conn := &recordingConn{}
+	sender := conn.autoAck(newWSSender(conn, nil))
+	const reqID = "REQ-2"
+
+	if err := sender.respondStream(context.Background(), reqID, "S-2", "the answer", true); err != nil {
+		t.Fatalf("closing frame: %v", err)
+	}
+	before := len(conn.frames)
+
+	err := sender.respondStream(context.Background(), reqID, "S-2", "a straggling refresh", false)
+	if !errors.Is(err, errStreamSuperseded) {
+		t.Fatalf("a frame written after the seal reported %v, want errStreamSuperseded", err)
+	}
+	if len(conn.frames) != before {
+		t.Fatalf("the straggling frame reached the wire: %d frames, want %d", len(conn.frames), before)
+	}
+}
+
+// A closing frame must be able to jump an opening frame whose ack is still in
+// flight, or the answer is held hostage by a spinner.
+func TestTheClosingFrameJumpsAnUnackedOpeningFrame(t *testing.T) {
+	t.Parallel()
+	conn := &silentConn{}
+	sender := newWSSender(conn, nil)
+	sender.ackTimeout = 2 * time.Second
+	const reqID = "REQ-3"
+
+	opening := make(chan error, 1)
+	go func() {
+		opening <- sender.respondStream(context.Background(), reqID, "S-3", streamThinkingPlaceholder, false)
+	}()
+	waitForFrames(t, conn, 1)
+
+	closing := make(chan error, 1)
+	go func() {
+		closing <- sender.respondStream(context.Background(), reqID, "S-3", "the answer", true)
+	}()
+	waitForFrames(t, conn, 2)
+
+	// The opening frame's caller is released with "superseded" rather than
+	// left to time out.
+	select {
+	case err := <-opening:
+		if !errors.Is(err, errStreamSuperseded) {
+			t.Fatalf("displaced opening frame reported %v, want errStreamSuperseded", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("the opening frame was never released")
+	}
+
+	// Two acks come back, in write order. The first belongs to the opening
+	// frame and must not settle the answer.
+	sender.deliverAck(reqID, 0, "")
+	sender.deliverAck(reqID, 0, "")
+	select {
+	case err := <-closing:
+		if err != nil {
+			t.Fatalf("closing frame: %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("the closing frame never read its verdict")
+	}
+
+	if got := conn.streamBody(t, 1)["finish"]; got != true {
+		t.Errorf("second frame finish = %v, want true", got)
+	}
+}
+
+// A non-final frame yields when the previous one on the same req_id has not
+// been acked — the backpressure the official SDK calls replyStreamNonBlocking.
+func TestANonFinalFrameYieldsToOneStillAwaitingItsVerdict(t *testing.T) {
+	t.Parallel()
+	conn := &silentConn{}
+	sender := newWSSender(conn, nil)
+	sender.ackTimeout = 2 * time.Second
+	const reqID = "REQ-4"
+
+	first := make(chan error, 1)
+	go func() {
+		first <- sender.respondStream(context.Background(), reqID, "S-4", streamThinkingPlaceholder, false)
+	}()
+	waitForFrames(t, conn, 1)
+
+	if err := sender.respondStream(context.Background(), reqID, "S-4", "another non-final frame", false); !errors.Is(err, errStreamBusy) {
+		t.Fatalf("second non-final frame reported %v, want errStreamBusy", err)
+	}
+	if n := conn.count(); n != 1 {
+		t.Fatalf("the yielding frame still reached the wire: %d frames, want 1", n)
+	}
+	sender.deliverAck(reqID, 0, "")
+	<-first
+}
+
+// A write that never reached the socket must give its place back, or every
+// later verdict on the turn is off by one — which is the misattribution above,
+// arriving through a different door.
+func TestAFailedWriteGivesBackItsPlaceInTheOrder(t *testing.T) {
+	t.Parallel()
+	conn := &silentConn{err: websocket.ErrCloseSent}
+	sender := newWSSender(conn, nil)
+	sender.ackTimeout = 50 * time.Millisecond
+	const reqID = "REQ-5"
+
+	if err := sender.respondStream(context.Background(), reqID, "S-5", streamThinkingPlaceholder, false); err == nil {
+		t.Fatal("a write that failed reported success")
+	}
+	sender.ackMu.Lock()
+	st := sender.streams[reqID]
+	sender.ackMu.Unlock()
+	if st == nil {
+		t.Fatal("no bookkeeping recorded for the turn")
+	}
+	if st.sent != 0 {
+		t.Fatalf("sent = %d after a failed write, want 0; the next frame's verdict is now off by one", st.sent)
+	}
+}
+
+// pruneStreamsLocked must never throw away a LIVE turn to stay under its cap.
+// A live turn whose counters are gone has its next frame stamped from zero, and
+// the whole misattribution above comes back — reinstated by the sweep meant to
+// protect against it. A live turn is also the OLDEST entry by construction, so
+// "evict oldest first" would pick exactly the wrong ones.
+func TestPruneKeepsLiveTurnsEvenOverTheCap(t *testing.T) {
+	t.Parallel()
+	conn := &silentConn{}
+	sender := newWSSender(conn, nil)
+
+	// One live turn, opened long ago — the shape a real one has.
+	const live = "REQ-LIVE"
+	sender.streams[live] = &streamAcks{sent: 1, at: time.Now().Add(-2 * streamMaxAge)}
+
+	// Fill past the cap with young sealed turns, which are the ones a burst
+	// produces and the only ones that may be dropped.
+	for i := 0; i < streamAcksMax; i++ {
+		sender.streams[newReqID()] = &streamAcks{sealed: true, at: time.Now()}
+	}
+	sender.ackMu.Lock()
+	sender.pruneStreamsLocked()
+	sender.ackMu.Unlock()
+
+	if _, ok := sender.streams[live]; !ok {
+		t.Fatal("the sweep dropped a live turn; its next frame is stamped from zero and a stale verdict will settle its closing frame")
+	}
+}
+
+func waitForFrames(t *testing.T, c *silentConn, n int) {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if c.count() >= n {
+			return
+		}
+		time.Sleep(time.Millisecond)
+	}
+	t.Fatalf("only %d frames written, want %d", c.count(), n)
+}

--- a/server/internal/integrations/wecom/stream_bubble_test.go
+++ b/server/internal/integrations/wecom/stream_bubble_test.go
@@ -1,0 +1,438 @@
+package wecom
+
+// stream_bubble_test.go — the whole point of the feature, end to end: a
+// question opens a bubble the user can see immediately, and the answer
+// replaces that same bubble in place instead of arriving as a new message.
+
+import (
+	"context"
+	"encoding/json"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgtype"
+
+	"github.com/multica-ai/multica/server/internal/events"
+	"github.com/multica-ai/multica/server/internal/integrations/channel"
+	"github.com/multica-ai/multica/server/internal/integrations/channel/engine"
+	"github.com/multica-ai/multica/server/internal/util"
+	db "github.com/multica-ai/multica/server/pkg/db/generated"
+	"github.com/multica-ai/multica/server/pkg/protocol"
+)
+
+// bubbleConn answers every write like the server does, and can be told to
+// refuse the CLOSING frame only — which is the case the plain-message fallback
+// exists for, and the one a conn that refuses everything cannot produce.
+type bubbleConn struct {
+	mu     sync.Mutex
+	frames []frameEnvelope
+	sender *wsSender
+
+	refuseClosingCode int
+}
+
+func (c *bubbleConn) WriteMessage(_ int, data []byte) error {
+	var env frameEnvelope
+	if err := json.Unmarshal(data, &env); err != nil {
+		return err
+	}
+	c.mu.Lock()
+	c.frames = append(c.frames, env)
+	s := c.sender
+	code := 0
+	if c.refuseClosingCode != 0 && isClosingFrame(env) {
+		code = c.refuseClosingCode
+	}
+	c.mu.Unlock()
+	if s != nil {
+		s.routeResponse(frameEnvelope{
+			Headers: frameHeaders{ReqID: env.Headers.ReqID},
+			ErrCode: code,
+			ErrMsg:  "refused",
+		})
+	}
+	return nil
+}
+func (c *bubbleConn) ReadMessage() (int, []byte, error) { return 0, nil, nil }
+func (c *bubbleConn) SetReadDeadline(time.Time) error   { return nil }
+func (c *bubbleConn) SetWriteDeadline(time.Time) error  { return nil }
+func (c *bubbleConn) Close() error                      { return nil }
+
+func isClosingFrame(env frameEnvelope) bool {
+	if env.Cmd != cmdRespondMsg {
+		return false
+	}
+	var body map[string]any
+	if json.Unmarshal(env.Body, &body) != nil {
+		return false
+	}
+	stream, _ := body["stream"].(map[string]any)
+	return stream != nil && stream["finish"] == true
+}
+
+// streamFrames returns the decoded stream bodies, in write order.
+func (c *bubbleConn) streamFrames(t *testing.T) []map[string]any {
+	t.Helper()
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	var out []map[string]any
+	for _, f := range c.frames {
+		if f.Cmd != cmdRespondMsg {
+			continue
+		}
+		var body map[string]any
+		if err := json.Unmarshal(f.Body, &body); err != nil {
+			t.Fatalf("decode frame body: %v", err)
+		}
+		stream, _ := body["stream"].(map[string]any)
+		if stream != nil {
+			out = append(out, stream)
+		}
+	}
+	return out
+}
+
+// pushes returns the decoded aibot_send_msg bodies — the "as a new message"
+// path, which a working bubble must NOT take.
+func (c *bubbleConn) pushes(t *testing.T) []map[string]any {
+	t.Helper()
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	var out []map[string]any
+	for _, f := range c.frames {
+		if f.Cmd != cmdSendMsg {
+			continue
+		}
+		var body map[string]any
+		if err := json.Unmarshal(f.Body, &body); err != nil {
+			t.Fatalf("decode frame body: %v", err)
+		}
+		out = append(out, body)
+	}
+	return out
+}
+
+// bubbleRig is one installation with a live socket, a store, the typing
+// indicator that opens bubbles and the outbound subscriber that closes them —
+// the two halves of the feature, wired to the one store the way boot wires
+// them.
+type bubbleRig struct {
+	conn    *bubbleConn
+	streams *streamStore
+	typing  *TypingIndicatorManager
+	out     *Outbound
+	instID  pgtype.UUID
+	now     time.Time
+}
+
+func newBubbleRig(t *testing.T) *bubbleRig {
+	t.Helper()
+	reg := newSendersRegistry()
+	instID := mustTestUUID(t)
+	conn := &bubbleConn{}
+	sender := newWSSender(conn, nil)
+	conn.sender = sender
+	reg.set(instID, sender)
+
+	streams := newStreamStore()
+	rig := &bubbleRig{
+		conn:    conn,
+		streams: streams,
+		instID:  instID,
+		now:     time.Date(2026, 8, 7, 12, 0, 0, 0, time.UTC),
+	}
+	streams.now = func() time.Time { return rig.now }
+
+	rig.typing = NewTypingIndicator(TypingIndicatorConfig{
+		Senders: reg,
+		Streams: streams,
+		// No guard: these tests drive the endings themselves.
+		GuardAfter: -1,
+	})
+	q := &fakeOutboundQueries{
+		sessionBinding: db.ChannelChatSessionBinding{InstallationID: instID, ChannelChatID: "CHAT_1", ChatType: "p2p"},
+		installation:   db.ChannelInstallation{ID: instID, Status: string(InstallationActive)},
+	}
+	rig.out = NewOutbound(q, reg, streams, nil)
+	return rig
+}
+
+const bubbleSession = "22222222-2222-2222-2222-222222222222"
+
+func bubbleSessionID(t *testing.T) pgtype.UUID {
+	t.Helper()
+	id, err := util.ParseUUID(bubbleSession)
+	if err != nil {
+		t.Fatalf("parse session uuid: %v", err)
+	}
+	return id
+}
+
+// ask feeds one inbound message through the typing indicator, the way the
+// Router does after a successful ingest.
+func (r *bubbleRig) ask(t *testing.T, reqID string) {
+	t.Helper()
+	raw, err := json.Marshal(InboundMessage{
+		BotID:        "BOT",
+		ChatID:       "CHAT_1",
+		ChatType:     "single",
+		SenderUserID: "USER_1",
+		ReqID:        reqID,
+	})
+	if err != nil {
+		t.Fatalf("marshal raw: %v", err)
+	}
+	r.typing.OnIngested(context.Background(),
+		engine.ResolvedInstallation{ID: r.instID},
+		channel.InboundMessage{
+			Text:   "a question",
+			Source: channel.Source{ChannelType: TypeWecom, ChatID: "CHAT_1", ChatType: channel.ChatTypeP2P, SenderID: "USER_1"},
+			Raw:    raw,
+		},
+		bubbleSessionID(t))
+}
+
+func (r *bubbleRig) answer(t *testing.T, content, taskID string) {
+	t.Helper()
+	if err := r.out.processEvent(context.Background(), events.Event{
+		ChatSessionID: bubbleSession,
+		TaskID:        taskID,
+		Payload:       protocol.ChatDonePayload{Content: content},
+	}); err != nil {
+		t.Fatalf("processEvent: %v", err)
+	}
+}
+
+// WeCom has no typing indicator, no reaction and no read receipt. The opening
+// stream frame IS the receipt — a think tag renders as the client's own
+// animated dots — and without it a slow agent looks like a dead bot.
+func TestAQuestionPaintsALoadingBubbleImmediately(t *testing.T) {
+	t.Parallel()
+	rig := newBubbleRig(t)
+	rig.ask(t, "REQ-A")
+
+	frames := rig.conn.streamFrames(t)
+	if len(frames) != 1 {
+		t.Fatalf("an ingested message wrote %d stream frames, want 1 — the user sees nothing at all until the agent finishes", len(frames))
+	}
+	if frames[0]["finish"] != false {
+		t.Error("the opening frame sealed the bubble; nothing can fill it in later")
+	}
+	if frames[0]["content"] != streamThinkingPlaceholder {
+		t.Errorf("opening frame content = %q, want the think tag %q that renders as the loading dots",
+			frames[0]["content"], streamThinkingPlaceholder)
+	}
+}
+
+// The answer replaces the bubble the question opened, in place — same stream
+// id, finish=true — rather than arriving underneath it as a new message.
+func TestTheAnswerReplacesTheBubbleInPlace(t *testing.T) {
+	t.Parallel()
+	rig := newBubbleRig(t)
+	rig.ask(t, "REQ-B")
+	rig.answer(t, "the agent reply", "task-1")
+
+	frames := rig.conn.streamFrames(t)
+	if len(frames) != 2 {
+		t.Fatalf("got %d stream frames, want 2 (open + seal)", len(frames))
+	}
+	if frames[1]["id"] != frames[0]["id"] {
+		t.Fatalf("the answer opened a SECOND bubble (%v) instead of replacing the first (%v); the loading one spins forever",
+			frames[1]["id"], frames[0]["id"])
+	}
+	if frames[1]["finish"] != true {
+		t.Error("the answer did not seal the bubble")
+	}
+	if frames[1]["content"] != "the agent reply" {
+		t.Errorf("sealed content = %q, want the agent reply", frames[1]["content"])
+	}
+	if pushes := rig.conn.pushes(t); len(pushes) != 0 {
+		t.Errorf("the answer also went out as %d plain message(s); the user reads it twice", len(pushes))
+	}
+}
+
+// A blank closing frame is DISCARDED by WeCom, and the bubble it was meant to
+// seal spins for good. An empty completion is a legitimate outcome — the agent
+// had nothing to add — so the copy stands in for the silence.
+func TestAnEmptyAnswerStillClosesTheBubbleWithWords(t *testing.T) {
+	t.Parallel()
+	rig := newBubbleRig(t)
+	rig.ask(t, "REQ-C")
+	rig.answer(t, "   \n ", "task-1")
+
+	frames := rig.conn.streamFrames(t)
+	if len(frames) != 2 {
+		t.Fatalf("got %d stream frames, want 2 — an empty answer left the bubble open", len(frames))
+	}
+	if frames[1]["finish"] != true {
+		t.Fatal("an empty answer did not seal the bubble; it spins forever")
+	}
+	content, _ := frames[1]["content"].(string)
+	if !hasVisibleChar(content) {
+		t.Fatalf("the closing frame carries nothing visible (%q); WeCom discards it and the bubble spins forever", content)
+	}
+	if content != streamCopyNoReply {
+		t.Errorf("closing copy = %q, want %q", content, streamCopyNoReply)
+	}
+}
+
+// A message that arrives past the debounce window is a round of its own,
+// queued behind the run in flight — and it gets its own bubble immediately,
+// because a wait with nothing on screen reads as a message that was lost.
+func TestAQueuedQuestionGetsItsOwnBubble(t *testing.T) {
+	t.Parallel()
+	rig := newBubbleRig(t)
+	rig.ask(t, "REQ-D1")
+	rig.now = rig.now.Add(sameRoundWindow + time.Second)
+	rig.ask(t, "REQ-D2")
+
+	frames := rig.conn.streamFrames(t)
+	if len(frames) != 2 {
+		t.Fatalf("two questions a window apart wrote %d bubbles, want 2 — the second looks lost", len(frames))
+	}
+	if frames[0]["id"] == frames[1]["id"] {
+		t.Fatal("the second question reused the first bubble; one of the two answers has nowhere to land")
+	}
+	if rig.streams.depth() != 2 {
+		t.Fatalf("store holds %d open rounds, want 2", rig.streams.depth())
+	}
+}
+
+// Two messages inside the debounce window are ONE run, so they share one
+// bubble. A second bubble here is one nobody would ever close.
+func TestMessagesInsideTheDebounceWindowShareOneBubble(t *testing.T) {
+	t.Parallel()
+	rig := newBubbleRig(t)
+	rig.ask(t, "REQ-E1")
+	rig.now = rig.now.Add(sameRoundWindow / 3)
+	rig.ask(t, "REQ-E2")
+
+	if n := len(rig.conn.streamFrames(t)); n != 1 {
+		t.Fatalf("two messages in one debounce window opened %d bubbles, want 1 — the extra one is never closed", n)
+	}
+	if rig.streams.depth() != 1 {
+		t.Fatalf("store holds %d open rounds, want 1", rig.streams.depth())
+	}
+}
+
+// A queued round whose run finished with nothing of its own to say has a
+// better explanation than plain silence: the reply ahead of it already covered
+// the message.
+func TestAQueuedRoundWithNothingToSaySaysItWasMerged(t *testing.T) {
+	t.Parallel()
+	rig := newBubbleRig(t)
+	rig.ask(t, "REQ-F1")
+	rig.now = rig.now.Add(sameRoundWindow + time.Second)
+	rig.ask(t, "REQ-F2")
+
+	rig.answer(t, "the first reply", "task-1") // seals the head
+	rig.answer(t, "", "task-2")                // seals the queued one
+
+	frames := rig.conn.streamFrames(t)
+	if len(frames) != 4 {
+		t.Fatalf("got %d stream frames, want 4 (two opens, two seals)", len(frames))
+	}
+	if frames[3]["content"] != streamCopyMerged {
+		t.Errorf("a queued round's empty answer closed with %q, want %q",
+			frames[3]["content"], streamCopyMerged)
+	}
+}
+
+// When the server refuses the closing frame the bubble cannot be sealed, but
+// the ANSWER still has to reach the user — as an ordinary message.
+func TestARefusedClosingFrameStillDeliversTheAnswer(t *testing.T) {
+	t.Parallel()
+	rig := newBubbleRig(t)
+	rig.conn.refuseClosingCode = errcodeStreamExpired
+	rig.ask(t, "REQ-G")
+	rig.answer(t, "the agent reply", "task-1")
+
+	pushes := rig.conn.pushes(t)
+	if len(pushes) != 1 {
+		t.Fatalf("a refused closing frame produced %d plain messages, want 1 — the answer went nowhere", len(pushes))
+	}
+	md, _ := pushes[0]["markdown"].(map[string]any)
+	if md == nil || md["content"] != "the agent reply" {
+		t.Fatalf("the fallback message did not carry the answer: %v", pushes[0])
+	}
+}
+
+// A run that fails publishes no chat:done, so the failure subscriber is the
+// only thing that ever stops that spinner.
+func TestAFailedRunClosesTheBubble(t *testing.T) {
+	t.Parallel()
+	rig := newBubbleRig(t)
+	rig.ask(t, "REQ-H")
+
+	rig.typing.handleTaskFailed(events.Event{
+		Type:          protocol.EventTaskFailed,
+		ChatSessionID: bubbleSession,
+		TaskID:        "task-1",
+	})
+
+	frames := rig.conn.streamFrames(t)
+	if len(frames) != 2 {
+		t.Fatalf("a failed run wrote %d stream frames, want 2 — the bubble spins with no news at all", len(frames))
+	}
+	if frames[1]["finish"] != true {
+		t.Fatal("the failure did not seal the bubble")
+	}
+	if frames[1]["content"] != streamCopyFailed {
+		t.Errorf("failure copy = %q, want %q", frames[1]["content"], streamCopyFailed)
+	}
+}
+
+// The guard is what keeps a run longer than the protocol's window from leaving
+// a spinner nobody can touch. It ends the BUBBLE without ending the round: the
+// reply is still owed, and the note it leaves is what lets a later failure be
+// reported at all.
+func TestTheGuardClosesABubbleTheWindowIsAboutToStrand(t *testing.T) {
+	t.Parallel()
+	rig := newBubbleRig(t)
+	rig.typing.guardAfter = time.Millisecond
+	rig.ask(t, "REQ-I")
+
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) && len(rig.conn.streamFrames(t)) < 2 {
+		time.Sleep(time.Millisecond)
+	}
+	frames := rig.conn.streamFrames(t)
+	if len(frames) != 2 {
+		t.Fatalf("the guard wrote %d stream frames, want 2 — the bubble runs into the window and strands", len(frames))
+	}
+	if frames[1]["content"] != streamCopyStillWorking {
+		t.Errorf("guard copy = %q, want %q", frames[1]["content"], streamCopyStillWorking)
+	}
+	// The round is NOT over: the guard promised a separate reply.
+	if _, verdict := rig.streams.claimEnding(bubbleSessionID(t)); verdict != roundOwesAnEnding {
+		t.Fatalf("after a guard close the store says %v, want roundOwesAnEnding — the promised reply would never be sent", verdict)
+	}
+}
+
+// A run whose bubble the guard already closed must not seize the NEXT
+// question's bubble as its own ending: that question's asker would read the
+// previous answer, and its own run would find no bubble left.
+func TestAGuardClosedRunDoesNotSealTheNextQuestionsBubble(t *testing.T) {
+	t.Parallel()
+	rig := newBubbleRig(t)
+	sessionID := bubbleSessionID(t)
+
+	rig.ask(t, "REQ-J1")
+	// The first round's run is known, and its bubble is guard-closed mid-run.
+	if _, ok := rig.streams.takeTask(sessionID, "task-1", roundOver); !ok {
+		t.Fatal("could not match the first round to its run")
+	}
+	rig.streams.remember(sessionID, roundAddress{InstallationID: rig.instID, ChatID: "CHAT_1", ChatType: chatTypeSingleInt}, roundContinues, "task-1")
+
+	// The next question opens a bubble of its own.
+	rig.now = rig.now.Add(sameRoundWindow + time.Second)
+	rig.ask(t, "REQ-J2")
+
+	if _, ok := rig.streams.takeTask(sessionID, "task-1", roundOver); ok {
+		t.Fatal("the first run seized the second question's bubble; that question's asker reads the wrong answer and its own run has nowhere to land")
+	}
+	if rig.streams.depth() != 1 {
+		t.Fatalf("store holds %d open rounds, want 1 — the second question kept its bubble", rig.streams.depth())
+	}
+}

--- a/server/internal/integrations/wecom/stream_cancelled_test.go
+++ b/server/internal/integrations/wecom/stream_cancelled_test.go
@@ -1,0 +1,59 @@
+package wecom
+
+// stream_cancelled_test.go — a cancelled run has to close the bubble it opened.
+//
+// The bubble is a promise that an answer is coming. task:failed was the only
+// ending subscribed for, and it is not the only ending there is: the engine
+// cancels a turn it cannot serve and publishes task:cancelled, which nothing
+// here was listening to. The spinner then outlived the run by design — until
+// the five-minute guard replaced it with "still working, I'll reply
+// separately", a promise about a run that had already been abandoned.
+//
+// These drive a real events.Bus from the publisher's side, the way the engine
+// does, so they fail if the subscription is missing rather than if a helper is.
+
+import (
+	"testing"
+
+	"github.com/multica-ai/multica/server/internal/events"
+	"github.com/multica-ai/multica/server/pkg/protocol"
+)
+
+// Both endings mean the same thing to the person watching: no answer is
+// coming. Running them as one table is what stops the cancelled case being
+// treated as the special one — they share a handler and must share a fate.
+func TestARunThatEndsWithoutAnAnswerClosesTheBubble(t *testing.T) {
+	for _, ending := range []string{protocol.EventTaskFailed, protocol.EventTaskCancelled} {
+		t.Run(ending, func(t *testing.T) {
+			rig := newBubbleRig(t)
+			bus := events.New()
+			rig.typing.Register(bus)
+
+			rig.ask(t, "REQ-X")
+			if n := len(rig.conn.streamFrames(t)); n != 1 {
+				t.Fatalf("the question painted %d frames, want the 1 opening bubble", n)
+			}
+
+			bus.Publish(events.Event{
+				Type:          ending,
+				ChatSessionID: bubbleSession,
+				TaskID:        "task-1",
+			})
+
+			frames := rig.conn.streamFrames(t)
+			if len(frames) != 2 {
+				t.Fatalf("a %s run produced %d frames, want 2 (the bubble and its closing frame) — "+
+					"nothing subscribes to %s, so the spinner runs on for an answer nobody is producing",
+					ending, len(frames), ending)
+			}
+			closing := frames[1]
+			if closing["finish"] != true {
+				t.Errorf("the second frame does not seal the bubble: %v", closing)
+			}
+			if content, _ := closing["content"].(string); content != streamCopyFailed {
+				t.Errorf("the closing frame says %q, want %q — a bubble that closes on empty text is one WeCom discards, "+
+					"and the spinner never stops", content, streamCopyFailed)
+			}
+		})
+	}
+}

--- a/server/internal/integrations/wecom/stream_frame_test.go
+++ b/server/internal/integrations/wecom/stream_frame_test.go
@@ -1,0 +1,126 @@
+package wecom
+
+// stream_frame_test.go — the two rules of the closing frame that are not
+// visible in the wire format, and that a spinning bubble is the price of
+// getting wrong.
+
+import (
+	"strings"
+	"testing"
+)
+
+// A closing frame carrying nothing the client will render is DISCARDED by
+// WeCom. The bubble it was meant to seal keeps spinning, with no edit and no
+// unsend to rescue it — so the body builder refuses to produce one and every
+// caller inherits the check.
+func TestClosingFrameWithNothingVisibleIsRefused(t *testing.T) {
+	t.Parallel()
+	for _, content := range []string{"", "   ", "\n\t ", "\r\n", " \t"} {
+		if _, err := respondStreamBody("S1", content, true); err == nil {
+			t.Errorf("closing frame with content %q was accepted; WeCom discards it and the bubble spins forever", content)
+		}
+	}
+}
+
+// The same emptiness is fine on a frame that is not closing anything: the
+// opening frame's whole job is to paint a bubble with no words in it.
+func TestNonClosingFrameMayCarryNothingVisible(t *testing.T) {
+	t.Parallel()
+	if _, err := respondStreamBody("S1", streamThinkingPlaceholder, false); err != nil {
+		t.Fatalf("the opening frame was refused: %v", err)
+	}
+}
+
+func TestClosingFrameWithVisibleContentIsAccepted(t *testing.T) {
+	t.Parallel()
+	body, err := respondStreamBody("S1", "答案", true)
+	if err != nil {
+		t.Fatalf("respondStreamBody: %v", err)
+	}
+	stream, _ := body["stream"].(map[string]any)
+	if stream["finish"] != true {
+		t.Errorf("finish = %v, want true", stream["finish"])
+	}
+	if stream["id"] != "S1" {
+		t.Errorf("stream id = %v, want S1", stream["id"])
+	}
+}
+
+// defuseThinkTags used to walk the answer while reading strings.ToLower of it
+// at the same offsets. Case folding is not length-preserving — U+212A KELVIN
+// SIGN is three bytes and folds to a one-byte "k" — so the folded copy can be
+// SHORTER than the original and an offset taken from the original can land
+// past its end. The string being scanned is the agent's own answer, so any
+// text a user can talk the agent into echoing took the backend down with it.
+func TestDefuseThinkTagsSurvivesRunesThatShrinkWhenFolded(t *testing.T) {
+	t.Parallel()
+	const kelvin = "K" // three bytes; folds to a one-byte "k"
+	for _, in := range []string{
+		kelvin + kelvin + "<x",
+		strings.Repeat(kelvin, 8) + "<",
+		strings.Repeat(kelvin, 8) + "</think>",
+		"Temperature: 300" + kelvin + " vs 301" + kelvin + ". Now <think>tail</think>",
+	} {
+		// A panic here fails the test by crashing it, which is the point.
+		_ = defuseThinkTags(in)
+	}
+}
+
+// The quieter half of the same bug: reading a shrunken copy at the original's
+// offsets also makes the scanner MISS tags it should have defused, so a real
+// <think> in the answer survives into the frame and folds half the reply away.
+func TestDefuseThinkTagsStillDefusesAfterAShrinkingRune(t *testing.T) {
+	t.Parallel()
+	const kelvin = "K"
+	out := defuseThinkTags(kelvin + kelvin + "<think>hi</think>")
+	if strings.Contains(out, "<think>") {
+		t.Errorf("a <think> tag preceded by a shrinking rune survived defusing: %q", out)
+	}
+	if !strings.Contains(out, "hi") {
+		t.Errorf("defusing dropped the answer's own text: %q", out)
+	}
+}
+
+func TestDefuseThinkTagsNeutralisesBothEnds(t *testing.T) {
+	t.Parallel()
+	out := defuseThinkTags("prefix <think>a</think> suffix")
+	if strings.Contains(out, "<think>") || strings.Contains(out, "</think>") {
+		t.Errorf("tags survived: %q", out)
+	}
+	if !strings.Contains(out, "prefix ") || !strings.Contains(out, " suffix") {
+		t.Errorf("surrounding text was altered: %q", out)
+	}
+}
+
+// Angle brackets that are not the tag are the common case — comparisons,
+// generics, HTML samples — and must come through as written. (The match is a
+// prefix, so a hypothetical <thinking> would also be defused; that is a
+// deliberate false positive, not something this asserts against.)
+func TestDefuseThinkTagsLeavesOtherAngleBracketsAlone(t *testing.T) {
+	t.Parallel()
+	for _, in := range []string{"a < b && c > d", "Vec<String>", "<div>x</div>", "if x<y then"} {
+		if out := defuseThinkTags(in); out != in {
+			t.Errorf("defuseThinkTags(%q) = %q, want it unchanged", in, out)
+		}
+	}
+}
+
+// A body past the protocol's cap is refused whole rather than clipped by the
+// server, so the clip has to happen here — and on a character boundary, or the
+// frame carries invalid utf8.
+func TestTruncateStreamContentCutsOnARuneBoundary(t *testing.T) {
+	t.Parallel()
+	long := strings.Repeat("中", streamContentLimit) // three bytes each
+	out := truncateStreamContent(long)
+	if len(out) > streamContentLimit {
+		t.Fatalf("truncated to %d bytes, over the %d cap", len(out), streamContentLimit)
+	}
+	if !strings.HasSuffix(out, "…") {
+		t.Error("a clipped answer does not say it was clipped")
+	}
+	for i, r := range out {
+		if r == '�' {
+			t.Fatalf("truncation cut a rune in half at byte %d", i)
+		}
+	}
+}

--- a/server/internal/integrations/wecom/stream_store.go
+++ b/server/internal/integrations/wecom/stream_store.go
@@ -1,0 +1,685 @@
+package wecom
+
+// stream_store.go — the handles that let each answer land in the bubble its
+// question opened.
+//
+// WeCom's aibot API has no typing indicator, no reaction, no read receipt, and
+// no way to edit a message after the fact. The one affordance it does have is
+// the streaming message: an aibot_respond_msg frame with finish=false paints a
+// bubble the client renders as "working", and a later frame carrying the SAME
+// stream.id replaces that bubble's body in place — finish=true seals it and
+// nothing can touch it again
+// (https://developer.work.weixin.qq.com/document/path/101463).
+//
+// A session holds a LIST of open bubbles, not one. Messages inside one
+// debounce window share a run and share a bubble; a message past the window
+// starts a round of its own, queued behind the run in flight — and it gets its
+// own bubble immediately, because a message that produces nothing on screen
+// reads as a message that was lost. The rounds are FIFO: the engine serializes
+// chat tasks per session (ClaimAgentTask), so the oldest open round is the one
+// running and everything behind it is waiting. That ordering is what lets an
+// ending find its bubble without carrying a task id everywhere: the answer
+// seals the head, a flush that produced no task seals the tail, and a task id,
+// when there is one, overrides both.
+//
+// The catch is req_id. Every frame of one stream has to echo the req_id of the
+// aibot_msg_callback that started the turn, and that value is only ever seen
+// by the WebSocket read loop. The answer shows up minutes later on an event
+// bus subscriber holding nothing but a chat_session_id. This store is the seam
+// between the two: session in, {req_id, stream id, addressing} out.
+//
+// IN-MEMORY IS THE RIGHT STORAGE, and deliberately so. One bot is one long
+// connection, and the Supervisor's WS lease already guarantees at most one
+// replica holds it, so a handle is only ever useful in the process that
+// created it. A restart loses the handles, which is exactly right: the socket
+// the req_ids belonged to is gone too, so the answers fall back to plain
+// messages — degraded, not corrupted. Persisting them would buy nothing and
+// promise a bubble no surviving socket could write to.
+//
+// Replay is not this file's problem. WeCom redelivers callbacks after a
+// reconnect, but a redelivered frame loses the dedup claim in
+// channel_inbound_message_dedup and never reaches OutcomeIngested, so it never
+// reaches the typing indicator either. What this file does bound is the
+// protocol's own window: a stream past streamMaxAge is refused by the server,
+// and a handle past that age is worse than no handle at all — it would swallow
+// the answer instead of delivering it.
+
+import (
+	"sync"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgtype"
+
+	"github.com/multica-ai/multica/server/internal/integrations/channel/engine"
+	"github.com/multica-ai/multica/server/internal/util"
+)
+
+// streamMaxAge is how long a handle is worth keeping. The long-connection doc
+// gives a stream 10 minutes before the server ends it; the one production
+// implementation we can read — Tencent's own OpenClaw plugin — treats errcode
+// 846608 as a 6-minute ceiling. The two do not agree, so we take the shorter
+// number: being early costs a fallback message, being late costs the answer.
+//
+// The window applies to a queued round's bubble the same as a running one's:
+// the clock starts at the opening frame, and waiting in line does not stop it.
+const streamMaxAge = 6 * time.Minute
+
+// streamGuardAfter is when we close a bubble ourselves rather than let it run
+// into streamMaxAge. A minute of headroom covers a slow frame and leaves the
+// user with a sentence instead of a spinner the server will no longer let us
+// replace.
+const streamGuardAfter = 5 * time.Minute
+
+// roundMemory is how long a session keeps the note the last handle left
+// behind. It has to outlast the bubble by a lot: the guard closes at five
+// minutes and the run it made a promise about carries on for as long as the
+// agent needs, so the window between the promise and the failure it accounts
+// for is the length of a long run, not the length of a stream. An hour covers
+// those and still bounds the map to the sessions answered in the last hour.
+const roundMemory = time.Hour
+
+// sameRoundWindow is how close two messages have to be to be one agent run.
+//
+// It is the engine's debounce window rather than a number of its own, because
+// it is the same question asked twice. The engine's batcher re-arms a
+// per-session timer on every inbound message and fires one run when the session
+// has been quiet for that long (engine/batcher.go), so messages less than a
+// window apart are collected into a single run and anything later is a run of
+// its own. A local constant here would be a second copy of that rule, free to
+// drift from the one that decides.
+//
+// The gap is measured from the PREVIOUS message on the NEWEST round, not from
+// any bubble's opening: the timer re-arms, so a message every two seconds is
+// one run no matter how long the burst goes on, and a bubble's age says
+// nothing about which run the next message belongs to.
+//
+// Known divergence: this re-measures with its own clock what the batcher
+// already decided with its. OnIngested runs on a detached goroutine, so the
+// two measurements of one gap can differ by scheduling jitter, and a gap
+// within jitter of the window can be classified differently on the two sides
+// — a bubble for a round the batcher merged, or one bubble for two runs.
+// Removing it means threading the batcher's own verdict through the engine's
+// TypingNotifier seam (an upstream API change); until then the window is 3s
+// and the jitter is milliseconds.
+const sameRoundWindow = engine.DefaultChatRunBatchWindow
+
+// roundEnding says whether the words a closer is writing are the last this
+// round will need. Only the guard's are not: "still working, I'll reply
+// separately" is a promise, and whatever the run does next is still owed.
+type roundEnding bool
+
+const (
+	roundOver      roundEnding = true
+	roundContinues roundEnding = false
+)
+
+// roundVerdict is the store's answer to "may I speak for this round, and where".
+type roundVerdict int
+
+const (
+	// roundForgotten — nothing on file. A turn from before a restart, or one
+	// that never opened a bubble at all. The caller has to find the chat some
+	// other way.
+	roundForgotten roundVerdict = iota
+	// roundOwesAnEnding — a bubble was closed early and its run went on, so
+	// the real ending has never been said. Addressing follows.
+	roundOwesAnEnding
+	// roundToldAlready — the answer landed, or another publisher's failure got
+	// here first. Nothing to add.
+	roundToldAlready
+)
+
+// openVerdict is the store's answer to "a message just arrived — does it get a
+// bubble of its own".
+type openVerdict int
+
+const (
+	// roundOpened — a new round. The caller paints the opening frame and arms
+	// the guard; from here on the round owns the handle it registered.
+	roundOpened openVerdict = iota
+	// roundJoined — inside the debounce window of the newest open round. The
+	// engine's batcher folds this message into that round's run, so the bubble
+	// already on screen is this message's receipt too and nothing is painted.
+	roundJoined
+)
+
+// streamHandle is everything needed to keep writing to one open bubble. The
+// addressing is captured at ingest rather than looked up later: by the time
+// the answer arrives the binding row may have been re-pointed, and the frame
+// has to go back to the chat that asked.
+type streamHandle struct {
+	// ReqID is the aibot_msg_callback's req_id. WeCom refuses a stream frame
+	// carrying any other value, including a req_id from an event callback
+	// (errcode 846605). Each round's bubble runs on the req_id of the message
+	// that opened it.
+	ReqID string
+
+	// StreamID is ours to choose. Reusing it updates the message; a new one
+	// opens another — which is exactly how a session comes to hold several
+	// bubbles at once.
+	StreamID string
+
+	// InstallationID finds the live socket. ChatID and ChatType address the
+	// conversation for the fallback plain message a closing frame degrades to
+	// when the stream cannot take it (typing_indicator.go).
+	InstallationID pgtype.UUID
+	ChatID         string
+	ChatType       int
+
+	// QueuedBehind records that this round was opened while another round was
+	// still open — it spent its life waiting in line. An empty answer for such
+	// a round means "handled together with the previous reply", which is worth
+	// saying differently from a first round's plain silence. Set by the store
+	// at open; callers registering a handle leave it false.
+	QueuedBehind bool
+
+	CreatedAt time.Time
+}
+
+// roundAddress is where a round's words go once its bubble is gone: the
+// installation whose socket carries them and the chat that asked. The stream
+// ids are deliberately not here — they name a bubble nobody can write to any
+// more, and carrying them would invite another attempt.
+type roundAddress struct {
+	InstallationID pgtype.UUID
+	ChatID         string
+	ChatType       int
+}
+
+func (h streamHandle) address() roundAddress {
+	return roundAddress{
+		InstallationID: h.InstallationID,
+		ChatID:         h.ChatID,
+		ChatType:       h.ChatType,
+	}
+}
+
+// endedRound is what a session keeps once a handle is gone: where the round
+// was speaking, whether anything is still owed to it, and which run it was.
+//
+// owed is the heart of it. A handle is taken by whichever ending gets there
+// first, and the five-minute guard is allowed to be that one — it writes
+// "still working, I'll reply separately" while the run carries on. The failure
+// that arrives afterwards finds no handle, and without this note it would
+// return without a word: a promise, and then nothing.
+//
+// taskID is the adoption fence. Once the guard has consumed a round's handle,
+// the round's run is still going, and the next open bubble in line — a QUEUED
+// message's — must not be sealed by it.
+//
+// One note per session, but the promises inside it are counted per ROUND. A
+// single flag could not hold two: with rounds A and B both guard-closed, A's
+// own answer — the separate reply its guard promised — would clear the flag,
+// and when B's run failed the store would say "already told" and B's asker
+// would hear nothing at all. The address is still shared, which is fine
+// because both rounds name the same chat; it is the promises that have to be
+// individual.
+type endedRound struct {
+	addr roundAddress
+	at   time.Time
+	// owed lists the rounds promised a separate reply that have not had one,
+	// oldest first, each holding its run id — empty when the guard fired
+	// before the run had a name. A round's own ending settles its own entry;
+	// another round's cannot.
+	owed []string
+	// fenced lists every run whose own bubble is already over, so none of them
+	// may seize a bubble opened later. A single slot could not do it: it would
+	// hold whichever run ended LAST, and a slow first question's ending then
+	// walks straight past it into the third question's bubble — sealing it
+	// with the wrong answer, and leaving that question's own run locked out of
+	// its own bubble.
+	fenced []string
+}
+
+// isFenced reports whether this run's own bubble is already over.
+func (e endedRound) isFenced(taskID string) bool {
+	if taskID == "" {
+		return false
+	}
+	for _, id := range e.fenced {
+		if id == taskID {
+			return true
+		}
+	}
+	return false
+}
+
+// fence adds a run to the list, keeping it bounded: a session that runs for
+// days should not accumulate ids forever, and a run old enough to have fallen
+// off cannot still have a bubble to protect.
+func (e endedRound) fence(taskID string) []string {
+	if taskID == "" || e.isFenced(taskID) {
+		return e.fenced
+	}
+	next := append(e.fenced, taskID)
+	if len(next) > maxFencedRuns {
+		next = next[len(next)-maxFencedRuns:]
+	}
+	return next
+}
+
+// maxFencedRuns bounds the fence list. Ten rounds back is far more than a run
+// can outlive — the platform stops accepting frames for a bubble after six
+// minutes, and rounds serialize per session.
+const maxFencedRuns = 10
+
+// isOwed reports whether anything is still promised.
+func (e endedRound) isOwed() bool { return len(e.owed) > 0 }
+
+// settle removes one promise: this round's own, matched by run id. Returns the
+// remaining list.
+func settle(owed []string, taskID string) []string {
+	for i, id := range owed {
+		if id == taskID {
+			return append(owed[:i:i], owed[i+1:]...)
+		}
+	}
+	if taskID == "" {
+		return owed
+	}
+	// A named ending with no matching promise settles nothing: the promise on
+	// file belongs to a different round, and taking it would leave that
+	// round's asker with silence.
+	return owed
+}
+
+// roundEntry pairs one bubble's handle with everything scoped to its life: the
+// guard timer that closes it if nothing else does, and the run it belongs to.
+// Whoever takes or drops the round disposes of all of it in one lock.
+type roundEntry struct {
+	handle streamHandle
+	guard  *time.Timer
+
+	// taskID is the run this bubble belongs to, adopted by the first ending
+	// that reaches it. A chat session outlives its turns, so a previous turn's
+	// ending can still be arriving after the user has asked the next question
+	// — it resolves to the same session and would otherwise seal the new
+	// bubble with the old answer.
+	taskID string
+
+	// lastIngest is when this round last took a message — the bubble's own
+	// opening for the first one, and every joined follow-up after that. On the
+	// newest round it is what separates a burst from a queue (sameRoundWindow).
+	lastIngest time.Time
+}
+
+// streamStore maps chat_session_id to that session's open bubbles, oldest
+// first, and — for a while after the last bubble is gone — to what the round
+// it belonged to still owes.
+type streamStore struct {
+	mu       sync.Mutex
+	sessions map[string][]*roundEntry
+	ended    map[string]endedRound
+
+	// unadoptedDebt counts, per session, the rounds the guard closed before
+	// any run was matched to them. Their runs are still coming and have no id
+	// on file to be fenced by; see settleUnadoptedDebtLocked.
+	unadoptedDebt map[string]int
+
+	maxAge time.Duration
+	now    func() time.Time
+}
+
+func newStreamStore() *streamStore {
+	return &streamStore{
+		sessions:      make(map[string][]*roundEntry),
+		ended:         make(map[string]endedRound),
+		unadoptedDebt: make(map[string]int),
+		maxAge:        streamMaxAge,
+		now:           time.Now,
+	}
+}
+
+// NewStreamStore is the constructor boot uses to mint the one store shared by
+// the typing indicator (writer) and the chat-done subscriber (reader).
+func NewStreamStore() *streamStore { return newStreamStore() }
+
+// clock reads the store's own time source, so callers that need to stamp a
+// moment (a message's arrival, before any of the work that delays it) use the
+// same clock the store compares against — including the fake one tests drive.
+func (s *streamStore) clock() time.Time { return s.now() }
+
+// open registers a message against a session and says whether it starts a
+// bubble of its own. Inside the debounce window of the newest open round it
+// joins that round — the engine's batcher is about to fold the two messages
+// into one run, and two bubbles for one answer is one bubble nobody ever
+// closes. Past the window it is a round of its own, opened immediately: it
+// will wait for as long as the run ahead of it needs, and that wait must not
+// look like silence.
+func (s *streamStore) open(sessionID pgtype.UUID, h streamHandle) openVerdict {
+	key := util.UUIDToString(sessionID)
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.sweepLocked()
+
+	// Both sides of this comparison are ARRIVAL times, not "when the code got
+	// here" times: the caller stamps CreatedAt before the lookups that delay
+	// it, so a slow database moves neither. Measuring with now() here is what
+	// would let this disagree with the engine's debouncer, which has always
+	// judged the same gap from arrival.
+	if h.CreatedAt.IsZero() {
+		h.CreatedAt = s.now()
+	}
+	rounds := s.sessions[key]
+	if n := len(rounds); n > 0 {
+		newest := rounds[n-1]
+		if h.CreatedAt.Sub(newest.lastIngest) < sameRoundWindow {
+			newest.lastIngest = h.CreatedAt
+			return roundJoined
+		}
+		h.QueuedBehind = true
+	}
+	s.sessions[key] = append(rounds, &roundEntry{handle: h, lastIngest: h.CreatedAt})
+	return roundOpened
+}
+
+// arm attaches the expiry guard to the round holding streamID. A round that
+// ended between the open and this call has already left the list, so there is
+// nothing to guard and the timer is stopped instead of leaked.
+func (s *streamStore) arm(sessionID pgtype.UUID, streamID string, t *time.Timer) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for _, r := range s.sessions[util.UUIDToString(sessionID)] {
+		if r.handle.StreamID == streamID {
+			r.guard = t
+			return
+		}
+	}
+	t.Stop()
+}
+
+// takeTail removes and returns the newest open round — the one whose flush
+// just settled without producing a task (OnSettled). The rounds ahead of it
+// belong to runs that are still real.
+func (s *streamStore) takeTail(sessionID pgtype.UUID, ending roundEnding) (streamHandle, bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	key := util.UUIDToString(sessionID)
+	rounds := s.sessions[key]
+	if len(rounds) == 0 {
+		return streamHandle{}, false
+	}
+	return s.takeAtLocked(key, len(rounds)-1, ending)
+}
+
+// takeTask removes and returns the round belonging to taskID.
+//
+// An exact match anywhere in the list wins. Failing that, the head is taken if
+// no run has been matched to it yet — the tasks serialize per session, so an
+// unmatched head IS the running round. A head already matched to a DIFFERENT
+// run is refused: taking it would seal the wrong bubble, and the caller has the
+// ended-notes path for a run whose bubble is already gone. An empty taskID is a
+// caller whose event named no run at all, and gets the head unconditionally.
+func (s *streamStore) takeTask(sessionID pgtype.UUID, taskID string, ending roundEnding) (streamHandle, bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	key := util.UUIDToString(sessionID)
+	rounds := s.sessions[key]
+	if len(rounds) == 0 {
+		// Settle before leaving: a debt from a guard close that emptied the
+		// session is this run's, and left standing it is paid by the next
+		// question — which then loses its own answer's bubble.
+		s.settleUnadoptedDebtLocked(key, taskID)
+		return streamHandle{}, false
+	}
+	if taskID == "" {
+		return s.takeAtLocked(key, 0, ending)
+	}
+	for i, r := range rounds {
+		if r.taskID == taskID {
+			return s.takeAtLocked(key, i, ending)
+		}
+	}
+	if rounds[0].taskID == "" {
+		// Two fences, because taking IS adopting: a run whose own bubble the
+		// guard already closed may not seize the queued round's bubble as its
+		// ending. The note names the run when the guard fired after the run
+		// had a name; the debt covers the one that died wordless —
+		// per-session serialization makes the first unseen run to end the dead
+		// round's. Either way the caller's plain-message path delivers the
+		// words to the right chat, and the queued round keeps its bubble for
+		// its own run.
+		if note, has := s.ended[key]; has && note.isFenced(taskID) {
+			return streamHandle{}, false
+		}
+		if s.settleUnadoptedDebtLocked(key, taskID) {
+			return streamHandle{}, false
+		}
+		// Record whose ending this was, so the note the take files carries the
+		// run's real id rather than an empty one.
+		rounds[0].taskID = taskID
+		return s.takeAtLocked(key, 0, ending)
+	}
+	return streamHandle{}, false
+}
+
+// settleUnadoptedDebtLocked answers "does this run belong to a round whose
+// bubble the guard closed before the run was ever matched to it". Such a round
+// had no task id to leave a fence under, so the store counts them instead:
+// tasks serialize per session, so the first never-seen run to end after such a
+// close is that round's. Settling the debt stamps the session's note with the
+// run's id, which restores the exact-id fence for the rest of that run's
+// events. Caller holds s.mu.
+func (s *streamStore) settleUnadoptedDebtLocked(key, taskID string) bool {
+	if s.unadoptedDebt[key] <= 0 {
+		return false
+	}
+	s.unadoptedDebt[key]--
+	if s.unadoptedDebt[key] == 0 {
+		delete(s.unadoptedDebt, key)
+	}
+	if note, has := s.ended[key]; has {
+		note.fenced = note.fence(taskID)
+		s.ended[key] = note
+	}
+	return true
+}
+
+// takeStream removes and returns the round holding streamID — the guard's own
+// closer, which must end exactly the bubble whose timer fired and no other.
+func (s *streamStore) takeStream(sessionID pgtype.UUID, streamID string, ending roundEnding) (streamHandle, bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	key := util.UUIDToString(sessionID)
+	for i, r := range s.sessions[key] {
+		if r.handle.StreamID == streamID {
+			return s.takeAtLocked(key, i, ending)
+		}
+	}
+	return streamHandle{}, false
+}
+
+// takeAtLocked removes rounds[i] and hands its handle over — the ending of a
+// round, whichever ending it is. A handle past maxAge is dropped and reported
+// as absent: the server would refuse the frame, and a caller that believed it
+// had a bubble would leave the user with nothing.
+//
+// ending is the caller's account of what it is about to write. Everything but
+// the guard ends the round; the guard's copy promises a separate reply, and the
+// note left behind is what makes that promise keepable — the failure that
+// arrives ten minutes later has no handle and needs both the address and the
+// knowledge that nobody has spoken yet. Caller holds s.mu.
+func (s *streamStore) takeAtLocked(key string, i int, ending roundEnding) (streamHandle, bool) {
+	rounds := s.sessions[key]
+	entry := rounds[i]
+	rounds = append(rounds[:i], rounds[i+1:]...)
+	if len(rounds) == 0 {
+		delete(s.sessions, key)
+	} else {
+		s.sessions[key] = rounds
+	}
+	if entry.guard != nil {
+		entry.guard.Stop()
+	}
+	if s.expiredLocked(entry.handle) {
+		return streamHandle{}, false
+	}
+	if ending == roundContinues && entry.taskID == "" {
+		// The guard closed a round no run had been matched to yet. Its run is
+		// still coming, with an id nobody knows — count it, so the first
+		// unseen run to end is recognised as this round's rather than allowed
+		// to take the next bubble in line.
+		s.unadoptedDebt[key]++
+	}
+	s.rememberLocked(key, entry.handle.address(), ending, entry.taskID)
+	return entry.handle, true
+}
+
+// remember files where a round was speaking without taking a handle for it —
+// the answer that went out as a plain message because the bubble was already
+// gone, and the failure notice that had to find its chat in the binding row.
+// Both are endings, and both have to be on file or the next publisher of the
+// same news repeats it.
+func (s *streamStore) remember(sessionID pgtype.UUID, addr roundAddress, ending roundEnding, taskID string) {
+	key := util.UUIDToString(sessionID)
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.rememberLocked(key, addr, ending, taskID)
+}
+
+// rememberLocked files a round's ending, with one refusal: a finished ending
+// for one round must not erase a still-OWED note left by ANOTHER round's
+// guard. The owed note is a promise ("I'll reply separately") whose keeping
+// depends on this record existing when the failure arrives; dedup of the
+// finished round's own ending is what gets sacrificed, and that costs at most
+// a repeated notice where losing the note costs a broken promise.
+func (s *streamStore) rememberLocked(key string, addr roundAddress, ending roundEnding, taskID string) {
+	next := endedRound{addr: addr, at: s.now()}
+	if prev, ok := s.ended[key]; ok {
+		next.owed = prev.owed
+		next.fenced = prev.fence(taskID)
+	} else if taskID != "" {
+		next.fenced = []string{taskID}
+	}
+	switch ending {
+	case roundContinues:
+		next.owed = append(next.owed, taskID)
+	case roundOver:
+		next.owed = settle(next.owed, taskID)
+	}
+	s.ended[key] = next
+}
+
+// claimEnding asks whether a round with no bubble left is still owed an ending,
+// and claims the right to say it. The claim is the point: task:failed has two
+// publishers and a sweeper tick can repeat one, so whoever gets here first
+// speaks and everyone after reads roundToldAlready.
+//
+// roundForgotten is not a refusal. It means this process never saw the round —
+// a restart mid-run, a turn whose opening frame the server refused — so there
+// is no address on file and the caller has to find the chat itself.
+func (s *streamStore) claimEnding(sessionID pgtype.UUID) (roundAddress, roundVerdict) {
+	key := util.UUIDToString(sessionID)
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	round, ok := s.ended[key]
+	if !ok {
+		return roundAddress{}, roundForgotten
+	}
+	if s.now().Sub(round.at) > roundMemory {
+		delete(s.ended, key)
+		return roundAddress{}, roundForgotten
+	}
+	if !round.isOwed() {
+		return round.addr, roundToldAlready
+	}
+	round.owed = round.owed[1:]
+	s.ended[key] = round
+	return round.addr, roundOwesAnEnding
+}
+
+// remembered reports how many rounds are on file past their bubble.
+// Diagnostics, and the cheap rejection at the head of the failure subscriber.
+func (s *streamStore) remembered() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return len(s.ended)
+}
+
+// drop forgets the round holding streamID without sending anything — used when
+// the opening frame was refused and the bubble the handle describes never
+// existed.
+func (s *streamStore) drop(sessionID pgtype.UUID, streamID string) {
+	key := util.UUIDToString(sessionID)
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	rounds := s.sessions[key]
+	for i, r := range rounds {
+		if r.handle.StreamID != streamID {
+			continue
+		}
+		if r.guard != nil {
+			r.guard.Stop()
+		}
+		rounds = append(rounds[:i], rounds[i+1:]...)
+		if len(rounds) == 0 {
+			delete(s.sessions, key)
+		} else {
+			s.sessions[key] = rounds
+		}
+		return
+	}
+}
+
+// depth reports how many bubbles are open across all sessions. Diagnostics,
+// tests, and the cheap rejection at the head of the failure subscriber.
+func (s *streamStore) depth() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	n := 0
+	for _, rounds := range s.sessions {
+		n += len(rounds)
+	}
+	return n
+}
+
+func (s *streamStore) expiredLocked(h streamHandle) bool {
+	return s.now().Sub(h.CreatedAt) > s.maxAge
+}
+
+// sweepLocked evicts rounds the server would no longer accept, and the notes
+// left by rounds too old to still be running. The guard timer normally retires
+// a round long before this fires; the sweep is what keeps a process whose
+// timers were beaten by a clock jump from accumulating entries forever, and it
+// is the only thing that bounds the notes, which no timer touches. Caller
+// holds s.mu.
+func (s *streamStore) sweepLocked() {
+	for key, rounds := range s.sessions {
+		live := rounds[:0]
+		for _, r := range rounds {
+			if s.expiredLocked(r.handle) {
+				if r.guard != nil {
+					r.guard.Stop()
+				}
+				continue
+			}
+			live = append(live, r)
+		}
+		if len(live) == 0 {
+			delete(s.sessions, key)
+		} else {
+			s.sessions[key] = live
+		}
+	}
+	now := s.now()
+	for key, round := range s.ended {
+		if now.Sub(round.at) > roundMemory {
+			delete(s.ended, key)
+		}
+	}
+	// A debt is only meaningful while the session is still live enough to
+	// have a note or a bubble; past both, the run it waited for is long gone.
+	for key := range s.unadoptedDebt {
+		if _, hasRounds := s.sessions[key]; hasRounds {
+			continue
+		}
+		if _, hasNote := s.ended[key]; hasNote {
+			continue
+		}
+		delete(s.unadoptedDebt, key)
+	}
+}

--- a/server/internal/integrations/wecom/typing_indicator.go
+++ b/server/internal/integrations/wecom/typing_indicator.go
@@ -1,0 +1,530 @@
+package wecom
+
+// typing_indicator.go — WeCom's answer to "the bot heard you".
+//
+// Slack stamps 👀 on the user's message, Feishu a typing badge. WeCom has
+// neither: the smart-bot protocol publishes no reaction, no read receipt and
+// no typing signal at all. What it does have is the streaming message, so the
+// same engine.TypingNotifier interface means something different here — the
+// indicator IS the reply, opened early and filled in later. Two consequences
+// follow from that, and both shape this file:
+//
+//   - The bubble MUST be closed. A reaction that never clears is untidy; a
+//     stream that never finishes is a spinner sitting in the user's chat for
+//     good. So every way a turn can end — answered, failed, never started,
+//     outlived its window — writes a closing frame carrying visible text.
+//   - OnSettled is not the normal ending. As on the other platforms the Router
+//     only calls it when the flush produced no task run; the answer closes the
+//     bubble from the chat-done subscriber in outbound.go, which is the only
+//     place that has the answer to close it with.
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgtype"
+
+	"github.com/multica-ai/multica/server/internal/events"
+	"github.com/multica-ai/multica/server/internal/integrations/channel"
+	"github.com/multica-ai/multica/server/internal/integrations/channel/engine"
+	"github.com/multica-ai/multica/server/internal/util"
+	db "github.com/multica-ai/multica/server/pkg/db/generated"
+	"github.com/multica-ai/multica/server/pkg/protocol"
+)
+
+// The four ways a streaming reply ends in something other than an answer. Each
+// one closes the loading bubble the question opened, so each one has to carry
+// visible text — WeCom discards a closing frame it considers empty and the
+// bubble spins on forever (see hasVisibleChar in ws_frame.go).
+//
+// Chinese, unconditionally, the same way the rest of this adapter's
+// user-facing strings are: WeCom deployments are China-only.
+const (
+	// streamCopyNoReply — the agent finished with nothing to say.
+	streamCopyNoReply = "（这轮没有需要回复的内容）"
+	// streamCopyMerged closes a QUEUED round's bubble whose run finished with
+	// nothing of its own to say — the reply ahead of it already covered this
+	// message. A first round's empty finish keeps streamCopyNoReply; this one
+	// has an earlier answer to point at.
+	streamCopyMerged = "✅ 这条已并入上一条回复一起处理了。"
+	// streamCopyNotStarted — no run was triggered at all (agent offline or
+	// archived, or the enqueue failed); the replier's own notice follows as a
+	// separate message with the detail.
+	streamCopyNotStarted = "已收到，但这条暂时没能开始处理。"
+	// streamCopyFailed — the run failed.
+	streamCopyFailed = "⚠️ 这次没跑通，请稍后再试一次。"
+	// streamCopyStillWorking — the run outlived the protocol's stream window,
+	// so we close the bubble ourselves and answer separately later.
+	streamCopyStillWorking = "还在处理，完成后我再单独回复你。"
+)
+
+// streamCloseTimeout bounds a closing frame written from a timer or a bus
+// subscriber, neither of which has a caller's context to inherit.
+const streamCloseTimeout = 10 * time.Second
+
+// taskLookup resolves a task id to the chat session it belongs to.
+// task:failed's sweeper publisher carries no session, so it has to come off
+// the task row. *db.Queries satisfies it.
+type taskLookup interface {
+	GetAgentTask(ctx context.Context, id pgtype.UUID) (db.AgentTaskQueue, error)
+}
+
+// chatBindingLookup finds which WeCom chat a session belongs to. It is the
+// address of last resort for a failure notice: the handle is gone and this
+// process has no note of the round, which is what a restart mid-run looks like.
+// The two queries are the ones outbound.go already makes on the same path for
+// the answer, so *db.Queries satisfies both interfaces without a new query.
+type chatBindingLookup interface {
+	GetChannelChatSessionBindingBySession(ctx context.Context, arg db.GetChannelChatSessionBindingBySessionParams) (db.ChannelChatSessionBinding, error)
+	GetChannelInstallation(ctx context.Context, arg db.GetChannelInstallationParams) (db.ChannelInstallation, error)
+}
+
+// TypingIndicatorManager opens a streaming bubble per round when messages are
+// ingested and owns each one until something closes it.
+type TypingIndicatorManager struct {
+	senders  *sendersRegistry
+	streams  *streamStore
+	tasks    taskLookup
+	bindings chatBindingLookup
+	log      *slog.Logger
+
+	// guardAfter is when the manager closes a bubble nobody else has. Zero
+	// disables the guard (tests that drive the clock themselves).
+	guardAfter time.Duration
+}
+
+// TypingIndicatorConfig wires the manager. Senders and Streams are the same
+// two instances the outbound subscriber holds — the bubble is opened on one
+// side of the process and closed on the other.
+type TypingIndicatorConfig struct {
+	Senders *sendersRegistry
+	Streams *streamStore
+	Logger  *slog.Logger
+
+	// Tasks resolves a task id to its chat session, for the task:failed the
+	// sweepers publish without one. Nil limits failure handling to the events
+	// that carry a session.
+	Tasks taskLookup
+
+	// Bindings finds the chat behind a session when nothing else can — a run
+	// that failed after this process was restarted, or after a bubble that was
+	// never painted. Nil keeps the failure notice to the rounds this process
+	// has a handle or a note for.
+	Bindings chatBindingLookup
+
+	// GuardAfter overrides streamGuardAfter. Test-only.
+	GuardAfter time.Duration
+}
+
+var _ engine.TypingNotifier = (*TypingIndicatorManager)(nil)
+
+// NewTypingIndicator builds the manager.
+func NewTypingIndicator(cfg TypingIndicatorConfig) *TypingIndicatorManager {
+	logger := cfg.Logger
+	if logger == nil {
+		logger = slog.Default()
+	}
+	guard := cfg.GuardAfter
+	if guard == 0 {
+		guard = streamGuardAfter
+	}
+	return &TypingIndicatorManager{
+		senders:    cfg.Senders,
+		streams:    cfg.Streams,
+		tasks:      cfg.Tasks,
+		bindings:   cfg.Bindings,
+		log:        logger,
+		guardAfter: guard,
+	}
+}
+
+// OnIngested paints a "working on it" bubble for the round this message
+// starts and records what it takes to come back and fill it in. A message
+// inside the debounce window joins the round already on screen; a message
+// past it — one that will wait behind the run in flight — opens a bubble of
+// its own immediately, because a wait with nothing on screen reads as a
+// message that was lost. The bubble carries no words while it waits: the
+// think tag renders as the client's own animated dots, which is the receipt,
+// and words would need a language before there is anything to say.
+//
+// The Router calls this on a detached goroutine with its own deadline, so
+// nothing here needs to be quick for the ACK's sake — but everything here is
+// best-effort: a bubble that fails to open costs the user a few seconds of
+// uncertainty, and the answer still arrives as a plain message.
+func (m *TypingIndicatorManager) OnIngested(ctx context.Context, inst engine.ResolvedInstallation, msg channel.InboundMessage, sessionID pgtype.UUID) {
+	if m.senders == nil || m.streams == nil || !sessionID.Valid {
+		return
+	}
+	// A standalone /issue is answered by the replier and deliberately never
+	// triggers an agent run, so no chat-done event would ever arrive to close
+	// a bubble opened for it.
+	if msg.SkipAgentRun {
+		return
+	}
+	// Stamp the arrival now, before the lookups below. Whether two messages
+	// belong to one round is a question about when they were SENT, and the
+	// engine's debouncer answers it from arrival. Reading the clock after a
+	// decode and a database round trip answers a different question — one that
+	// a loaded pool can move by seconds — so the two would disagree: a message
+	// the debouncer gave its own run could be folded into the previous round
+	// here, leaving it with no bubble and no receipt, or the reverse, leaving
+	// one run with two spinners.
+	arrivedAt := m.streams.clock()
+	wm, err := wecomMsgFromRaw(msg)
+	if err != nil {
+		m.log.WarnContext(ctx, "wecom typing: cannot read the inbound envelope",
+			"chat_session_id", util.UUIDToString(sessionID), "error", err)
+		return
+	}
+	// Without the callback's req_id there is no stream to open: the server
+	// refuses a frame carrying anything else, and an event callback's req_id
+	// is refused outright (846605).
+	if wm.ReqID == "" {
+		return
+	}
+	chatID := msg.Source.ChatID
+	if chatID == "" {
+		chatID = wm.ChatID
+	}
+	if chatID == "" {
+		return
+	}
+
+	h := streamHandle{
+		ReqID:          wm.ReqID,
+		StreamID:       newStreamID(),
+		InstallationID: inst.ID,
+		ChatID:         chatID,
+		ChatType:       aibotChatTypeFromChannel(msg.Source.ChatType),
+		CreatedAt:      arrivedAt,
+	}
+	if m.streams.open(sessionID, h) == roundJoined {
+		// Inside the debounce window: the batcher is about to fold this
+		// message into the round whose bubble is already on screen, and that
+		// bubble is this message's receipt too.
+		return
+	}
+
+	// Three ways the opening frame does not land, and only one of them is a
+	// reason to give the bubble up.
+	//
+	// An ack that did not come back says nothing about whether the frame did:
+	// re-sending the same stream id later creates the message if the opening
+	// frame was lost, so the worst case is a user who waits without a spinner
+	// rather than one who never gets an answer.
+	//
+	// Busy and superseded mean something stronger. Both say another frame on
+	// this req_id got to the socket first, and that frame carried a stream id
+	// of its own, which is exactly how a bubble is created. So the spinner is
+	// on the user's screen. Dropping the handle there arms no guard and leaves
+	// nothing that could ever close it.
+	//
+	// A verdict from the server is the one that ends it: 846605 and 846608 mean
+	// this stream will never take a frame, so no bubble was painted and keeping
+	// the handle would swallow the answer rather than deliver it.
+	if err := m.senders.stream(ctx, h, streamThinkingPlaceholder, false); err != nil {
+		switch {
+		case errors.Is(err, errStreamAckTimeout),
+			errors.Is(err, errStreamBusy),
+			errors.Is(err, errStreamSuperseded):
+			m.log.DebugContext(ctx, "wecom typing: opening frame did not land, keeping the handle",
+				"chat_session_id", util.UUIDToString(sessionID), "error", err)
+		default:
+			m.streams.drop(sessionID, h.StreamID)
+			m.log.WarnContext(ctx, "wecom typing: opening frame refused",
+				"chat_session_id", util.UUIDToString(sessionID), "error", err)
+			return
+		}
+	}
+	m.armGuard(sessionID, h)
+}
+
+// OnSettled closes the bubble of a round that never became a run — agent
+// offline or archived, or an enqueue that failed. This is the only chance to
+// stop that spinner: with no task there is no task lifecycle event, so neither
+// the chat-done subscriber nor the failure subscriber will ever fire. The copy
+// is deliberately thin because the replier's own notice follows as a separate
+// message with the reason.
+//
+// The TAIL is the right bubble: OnSettled answers the flush that just
+// settled, which is the newest round — the ones ahead of it belong to runs
+// that are already real and end through their own events.
+func (m *TypingIndicatorManager) OnSettled(ctx context.Context, sessionID pgtype.UUID) {
+	m.closeBubble(ctx, sessionID,
+		func(s *streamStore) (streamHandle, bool) { return s.takeTail(sessionID, roundOver) },
+		streamCopyNotStarted, "settled")
+}
+
+// Register subscribes the manager to the run failure event.
+//
+// EventChatDone is deliberately NOT subscribed here: the answer belongs in the
+// bubble, and only the outbound subscriber holds the answer. Registering for
+// it here would close the bubble first and leave the reply to arrive
+// underneath it.
+func (m *TypingIndicatorManager) Register(bus *events.Bus) {
+	bus.Subscribe(protocol.EventTaskFailed, m.handleTaskFailed)
+}
+
+// handleTaskFailed says a run died, in the bubble if there still is one and as
+// a plain message if there is not.
+//
+// task:failed has two publishers and they do not agree on the payload.
+// broadcastTaskEvent, which FailTask uses, carries chat_session_id.
+// HandleFailedTasks — every sweeper, recover-orphans, and the daemon heartbeat
+// timeout — carries task_id, agent_id, issue_id, status and failure_reason, and
+// no session anywhere. That second publisher is the whole crashed-daemon path,
+// so without the task-id fallback the bubble spins on until the guard replaces
+// it with "still working, I'll reply separately" — a promise about a run that
+// has been dead for five minutes. The fallback stays on this side of the
+// boundary: the adapter carries its own routing rather than widening a payload
+// three other consumers read.
+//
+// The bubble is not the whole of it. A handle is consumed by whichever ending
+// gets there first, and the guard is allowed to be that one at the five-minute
+// mark while the run carries on — so every run longer than five minutes that
+// then failed finds no handle here. This notice is the only "that run did not
+// go through" WeCom ever produces: the replier speaks for needs_binding,
+// offline, archived and issue_created and for nothing else. So the handle is
+// one address among three, and sayTheRunFailed works down the rest.
+func (m *TypingIndicatorManager) handleTaskFailed(e events.Event) {
+	if m.streams == nil {
+		return
+	}
+	if m.bindings == nil && m.streams.depth() == 0 && m.streams.remembered() == 0 {
+		// Nothing open, nothing owed, and no way to find a chat: no reason to
+		// read a row for someone else's run.
+		return
+	}
+	sessionID, ok := m.sessionFor(e)
+	if !ok {
+		return // an issue / autopilot run, with no chat session and no bubble
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), streamCloseTimeout)
+	defer cancel()
+	taskID := taskIDFromEvent(e)
+	if m.closeBubble(ctx, sessionID,
+		func(s *streamStore) (streamHandle, bool) { return s.takeTask(sessionID, taskID, roundOver) },
+		streamCopyFailed, "task failed") {
+		return
+	}
+	m.sayTheRunFailed(ctx, sessionID, taskID)
+}
+
+// sayTheRunFailed delivers the failure to a round whose bubble is already gone.
+//
+// Two addresses, in the order of how much they are trusted. The note the handle
+// left behind is the chat the question came from, which is what the guard's
+// promise was made in and what the binding row may no longer point at. Failing
+// that — a restart mid-run, a turn whose opening frame the server refused —
+// the binding row is the only address there is.
+//
+// A round the store says is accounted for gets nothing. That is the whole of
+// the not-twice rule: the answer took the handle the same way the guard does,
+// and a task:failed arriving behind a delivered answer — an auto-retry's first
+// attempt, a sweeper that ran late — must not contradict it.
+func (m *TypingIndicatorManager) sayTheRunFailed(ctx context.Context, sessionID pgtype.UUID, taskID string) {
+	if m.senders == nil {
+		return
+	}
+	addr, verdict := m.streams.claimEnding(sessionID)
+	switch verdict {
+	case roundToldAlready:
+		return
+	case roundForgotten:
+		found, ok := m.addressFromBinding(ctx, sessionID)
+		if !ok {
+			return
+		}
+		addr = found
+		// No handle was consumed and no note was claimed on this path, so
+		// filing one is the only thing that stops the next publisher of the
+		// same news from repeating it.
+		m.streams.remember(sessionID, addr, roundOver, taskID)
+	}
+	if err := m.senders.sendTextCtx(ctx, addr.InstallationID, addr.ChatID, addr.ChatType, streamCopyFailed); err != nil {
+		m.log.WarnContext(ctx, "wecom typing: could not say the run failed",
+			"chat_session_id", util.UUIDToString(sessionID),
+			"installation_id", util.UUIDToString(addr.InstallationID), "error", err)
+	}
+}
+
+// addressFromBinding reads the chat a session belongs to off the binding row —
+// the same two queries outbound.go makes when an answer has no bubble to land
+// in. A session with no wecom binding is not ours to speak in: this subscriber
+// sees every failed run on a shared bus, including Slack's and the web UI's.
+func (m *TypingIndicatorManager) addressFromBinding(ctx context.Context, sessionID pgtype.UUID) (roundAddress, bool) {
+	if m.bindings == nil {
+		return roundAddress{}, false
+	}
+	binding, err := m.bindings.GetChannelChatSessionBindingBySession(ctx, db.GetChannelChatSessionBindingBySessionParams{
+		ChatSessionID: sessionID,
+		ChannelType:   channelTypeWecom,
+	})
+	if err != nil {
+		if !errors.Is(err, pgx.ErrNoRows) {
+			m.log.WarnContext(ctx, "wecom typing: cannot find the chat a failed run belongs to",
+				"chat_session_id", util.UUIDToString(sessionID), "error", err)
+		}
+		return roundAddress{}, false
+	}
+	// The installation row answers whether the bot is still installed. The
+	// binding row outlives a revoke, so a session keeps looking reachable
+	// after the bot has been removed.
+	inst, err := m.bindings.GetChannelInstallation(ctx, db.GetChannelInstallationParams{
+		ID:          binding.InstallationID,
+		ChannelType: channelTypeWecom,
+	})
+	if err != nil {
+		m.log.WarnContext(ctx, "wecom typing: cannot load the installation a failed run belongs to",
+			"installation_id", util.UUIDToString(binding.InstallationID), "error", err)
+		return roundAddress{}, false
+	}
+	if inst.Status != string(InstallationActive) {
+		return roundAddress{}, false
+	}
+	return roundAddress{
+		InstallationID: binding.InstallationID,
+		ChatID:         binding.ChannelChatID,
+		ChatType:       aibotChatTypeFromChannel(channel.ChatType(binding.ChatType)),
+	}, true
+}
+
+// sessionFor finds the chat session behind a task lifecycle event. The
+// sweeper's task:failed does not carry one, so it comes off the task row.
+//
+// Everything here runs on the goroutine that published the event: the daemon's
+// own HTTP handler, or a sweeper tick. Hence the short deadline.
+func (m *TypingIndicatorManager) sessionFor(e events.Event) (pgtype.UUID, bool) {
+	if sessionID, ok := sessionIDFromEvent(e); ok {
+		return sessionID, true
+	}
+	if m.tasks == nil {
+		return pgtype.UUID{}, false
+	}
+	taskID := taskIDFromEvent(e)
+	if taskID == "" {
+		return pgtype.UUID{}, false
+	}
+	id, err := util.ParseUUID(taskID)
+	if err != nil || !id.Valid {
+		return pgtype.UUID{}, false
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), taskLookupTimeout)
+	defer cancel()
+	task, err := m.tasks.GetAgentTask(ctx, id)
+	if err != nil {
+		return pgtype.UUID{}, false
+	}
+	return task.ChatSessionID, task.ChatSessionID.Valid
+}
+
+// taskLookupTimeout is the whole budget this subscriber may spend on somebody
+// else's goroutine. The bus is synchronous: a task:failed subscriber runs on
+// the goroutine that published the event, and a sweeper tick is not ours to
+// hold while a loaded pool answers.
+const taskLookupTimeout = 800 * time.Millisecond
+
+// taskIDFromEvent prefers the envelope's routing hint and falls back to the
+// payload. ChatDonePayload matters most: broadcastChatDone sets no TaskID on
+// the envelope, and on the in-process bus the payload stays typed — miss it
+// and every answer takes the HEAD round unconditionally, which is the wrong
+// bubble whenever a guard has already closed the running round's.
+func taskIDFromEvent(e events.Event) string {
+	if e.TaskID != "" {
+		return e.TaskID
+	}
+	switch p := e.Payload.(type) {
+	case protocol.ChatDonePayload:
+		return p.TaskID
+	case protocol.TaskProgressPayload:
+		return p.TaskID
+	case map[string]any:
+		s, _ := p["task_id"].(string)
+		return s
+	}
+	return ""
+}
+
+// armGuard schedules the close that happens when nothing else does. WeCom
+// stops accepting frames for a stream past streamMaxAge, so a bubble that
+// outlives the window — a long run, or a round stuck in the queue behind one —
+// would otherwise become a spinner we can no longer touch. The guard closes
+// exactly the bubble it was armed for, by stream id: with several bubbles open
+// in one session, a timer that took the head could seal a newer round's bubble
+// with an older round's promise.
+//
+// This is the one closer that does not end the round. Its copy says the reply
+// is coming separately, and the run is still going — so the handle it consumes
+// leaves a note behind, and whatever the run does next is said against that.
+func (m *TypingIndicatorManager) armGuard(sessionID pgtype.UUID, h streamHandle) {
+	if m.guardAfter <= 0 {
+		return
+	}
+	t := time.AfterFunc(m.guardAfter, func() {
+		ctx, cancel := context.WithTimeout(context.Background(), streamCloseTimeout)
+		defer cancel()
+		m.closeBubble(ctx, sessionID,
+			func(s *streamStore) (streamHandle, bool) { return s.takeStream(sessionID, h.StreamID, roundContinues) },
+			streamCopyStillWorking, "window expiring")
+	})
+	m.streams.arm(sessionID, h.StreamID, t)
+}
+
+// closeBubble seals one bubble with text, if take finds one to seal, and
+// reports whether it did. take names WHICH bubble — the failed task's, the
+// settled flush's (tail), the guard's own (by stream id) — and consuming the
+// handle inside the store makes this idempotent: two closers racing produce one
+// closing frame. The ending each take carries is what the caller's words amount
+// to for the round; every closer ends it except the guard, whose copy promises
+// a separate reply while the run goes on.
+//
+// A closing frame that cannot go out falls back to a plain message, the same
+// way the answer does in outbound.go. The words matter more here than there:
+// streamCopyFailed is the only "that run did not go through" WeCom ever
+// produces, so a frame lost to a reconnect window would otherwise leave the
+// user with a spinner and no explanation that would ever arrive. The addressing
+// comes off the handle, captured at ingest, because by now the binding row may
+// point at a different chat.
+func (m *TypingIndicatorManager) closeBubble(ctx context.Context, sessionID pgtype.UUID, take func(*streamStore) (streamHandle, bool), text, why string) bool {
+	if m.senders == nil || m.streams == nil || !sessionID.Valid {
+		return false
+	}
+	h, ok := take(m.streams)
+	if !ok {
+		return false
+	}
+	err := m.senders.stream(ctx, h, text, true)
+	if err == nil {
+		return true
+	}
+	m.log.WarnContext(ctx, "wecom typing: closing frame failed, saying it as a new message",
+		"chat_session_id", util.UUIDToString(sessionID),
+		"reason", why, "unusable", streamUnusable(err), "error", err)
+	if sendErr := m.senders.sendTextCtx(ctx, h.InstallationID, h.ChatID, h.ChatType, text); sendErr != nil {
+		m.log.WarnContext(ctx, "wecom typing: the fallback message was unsendable too",
+			"chat_session_id", util.UUIDToString(sessionID), "reason", why, "error", sendErr)
+	}
+	return true
+}
+
+// sessionIDFromEvent recovers the chat session from a task lifecycle event.
+// EventChatDone puts it on the envelope; EventTaskFailed carries it only in the
+// broadcast payload, and only for chat runs — so both places are checked.
+func sessionIDFromEvent(e events.Event) (pgtype.UUID, bool) {
+	if e.ChatSessionID != "" {
+		if id, err := util.ParseUUID(e.ChatSessionID); err == nil && id.Valid {
+			return id, true
+		}
+	}
+	if p, ok := e.Payload.(map[string]any); ok {
+		if s, _ := p["chat_session_id"].(string); s != "" {
+			if id, err := util.ParseUUID(s); err == nil && id.Valid {
+				return id, true
+			}
+		}
+	}
+	return pgtype.UUID{}, false
+}

--- a/server/internal/integrations/wecom/typing_indicator.go
+++ b/server/internal/integrations/wecom/typing_indicator.go
@@ -54,7 +54,10 @@ const (
 	// archived, or the enqueue failed); the replier's own notice follows as a
 	// separate message with the detail.
 	streamCopyNotStarted = "已收到，但这条暂时没能开始处理。"
-	// streamCopyFailed — the run failed.
+	// streamCopyFailed — the run ended without producing an answer, whether it
+	// failed or was cancelled. The two are one outcome to the person watching
+	// the bubble, and naming which one it was would explain nothing they can
+	// act on.
 	streamCopyFailed = "⚠️ 这次没跑通，请稍后再试一次。"
 	// streamCopyStillWorking — the run outlived the protocol's stream window,
 	// so we close the bubble ourselves and answer separately later.
@@ -258,7 +261,9 @@ func (m *TypingIndicatorManager) OnSettled(ctx context.Context, sessionID pgtype
 		streamCopyNotStarted, "settled")
 }
 
-// Register subscribes the manager to the run failure event.
+// Register subscribes the manager to the two events that end a run without an
+// answer. Both close the bubble the question opened, so both go to the same
+// handler.
 //
 // EventChatDone is deliberately NOT subscribed here: the answer belongs in the
 // bubble, and only the outbound subscriber holds the answer. Registering for
@@ -266,10 +271,18 @@ func (m *TypingIndicatorManager) OnSettled(ctx context.Context, sessionID pgtype
 // underneath it.
 func (m *TypingIndicatorManager) Register(bus *events.Bus) {
 	bus.Subscribe(protocol.EventTaskFailed, m.handleTaskFailed)
+	// A cancelled task ends the run just as finally as a failed one, and the
+	// bubble is on screen either way. The engine cancels a turn it cannot
+	// serve — a task claimed with no user input attached, for one — and
+	// publishes task:cancelled rather than task:failed. Without this the
+	// spinner outlives the run it was painted for and never resolves: the
+	// user is left watching a bubble for an answer nobody is producing.
+	bus.Subscribe(protocol.EventTaskCancelled, m.handleTaskFailed)
 }
 
-// handleTaskFailed says a run died, in the bubble if there still is one and as
-// a plain message if there is not.
+// handleTaskFailed says a run ended without an answer — failed or cancelled,
+// which the user experiences identically — in the bubble if there still is one
+// and as a plain message if there is not.
 //
 // task:failed has two publishers and they do not agree on the payload.
 // broadcastTaskEvent, which FailTask uses, carries chat_session_id.

--- a/server/internal/integrations/wecom/wecom_channel.go
+++ b/server/internal/integrations/wecom/wecom_channel.go
@@ -102,7 +102,7 @@ func (c *wecomChannel) Disconnect(ctx context.Context) error { return nil }
 // goroutine to observe it, so a transient failure tears the live connection
 // down before the Supervisor reconnects — no leaked socket goroutine
 // consuming events into an unread channel.
-func (c *wecomChannel) Connect(ctx context.Context) error {
+func (c *wecomChannel) Connect(ctx context.Context) (err error) {
 	if c.handler == nil {
 		return errors.New("wecom: inbound handler not configured")
 	}
@@ -190,6 +190,43 @@ func (c *wecomChannel) Connect(ctx context.Context) error {
 		<-pingDone
 	}()
 
+	// Inbound callbacks run on their own worker, not on the read loop. The
+	// read loop is the sole deliverer of server verdicts, so anything that
+	// handles a callback inline cannot also wait for the ack of a frame it
+	// writes — it would be waiting on itself. DingTalk's adapter is already
+	// shaped this way.
+	//
+	// ONE worker, not a pool: WeCom delivers a chat's messages in order, and
+	// the engine's dedup and turn batching assume that order survives.
+	//
+	// A full queue BLOCKS the read loop rather than dropping. Backpressure
+	// costs a reconnect; dropping costs a user's message with nothing to say
+	// so.
+	callbacks := make(chan frameEnvelope, callbackQueueDepth)
+	cbDone := make(chan struct{})
+	var cbErr error
+	go func() {
+		defer close(cbDone)
+		for env := range callbacks {
+			if e := c.dispatchFrame(ctx, env, sender, log); e != nil {
+				cbErr = e
+				// Wake the read loop; it is parked in ReadMessage and a
+				// cancelled context alone will not move it.
+				_ = conn.Close()
+				return
+			}
+		}
+	}()
+	defer func() {
+		close(callbacks)
+		<-cbDone
+		// The worker's error is the real cause; the read error that followed
+		// it is just the socket we closed to get here.
+		if cbErr != nil {
+			err = cbErr
+		}
+	}()
+
 	// Read loop. Every frame comes back through the same decode → dispatch
 	// → (maybe) reply path. A single bad frame does NOT tear the socket
 	// down — only transport / handler errors escalate.
@@ -215,11 +252,29 @@ func (c *wecomChannel) Connect(ctx context.Context) error {
 			log.Warn("wecom: bad frame envelope", "error", err, "size", len(payload))
 			continue
 		}
-		if err := c.dispatchFrame(ctx, env, sender, log); err != nil {
-			return err
+		switch env.Cmd {
+		case cmdMsgCallback, cmdEventCallback:
+			select {
+			case callbacks <- env:
+			case <-ctx.Done():
+				return nil
+			}
+		default:
+			// Acks, pings and pongs stay on the read loop: they are the
+			// frames the worker's own writes are waiting for.
+			if err := c.dispatchFrame(ctx, env, sender, log); err != nil {
+				return err
+			}
 		}
 	}
 }
+
+// callbackQueueDepth is how far the callback worker may fall behind the read
+// loop before the read loop blocks. Past this the socket stops being drained,
+// WeCom notices, and the connection is replaced — which is the correct
+// outcome: a replica that cannot keep up should hand the bot to one that can,
+// not quietly discard the messages it could not reach.
+const callbackQueueDepth = 64
 
 // subscribe sends the aibot_subscribe frame and waits (up to
 // subscribeTimeout) for the server's ack. The ack shape is a frame with
@@ -330,6 +385,12 @@ func (c *wecomChannel) dispatchFrame(ctx context.Context, env frameEnvelope, sen
 		// (e.g. wrong msgtype, rate limit, chat not writable). Log the
 		// error so a failed outbound is visible without having to
 		// packet-capture the socket.
+		// Hand it to whoever wrote the frame, if anybody is waiting. An
+		// unclaimed ack is not an error — the pushes that do not wait for a
+		// verdict share this connection.
+		if sender.routeResponse(env) {
+			return nil
+		}
 		if env.ErrCode != 0 {
 			log.Warn("wecom: server ack error",
 				"errcode", env.ErrCode,

--- a/server/internal/integrations/wecom/wecom_channel.go
+++ b/server/internal/integrations/wecom/wecom_channel.go
@@ -555,3 +555,14 @@ func newReqID() string {
 	}
 	return hex.EncodeToString(buf[:])
 }
+
+// newStreamID mints the developer-chosen id that names one streaming message.
+// Reusing an id replaces that message's body; a fresh one opens another
+// bubble, which is why this must never collide across concurrent turns.
+func newStreamID() string {
+	var buf [12]byte
+	if _, err := cryptorand.Read(buf[:]); err != nil {
+		return fmt.Sprintf("wecom-stream-%d", time.Now().UnixNano())
+	}
+	return "s" + hex.EncodeToString(buf[:])
+}

--- a/server/internal/integrations/wecom/wecom_channel.go
+++ b/server/internal/integrations/wecom/wecom_channel.go
@@ -230,10 +230,28 @@ func (c *wecomChannel) Connect(ctx context.Context) (err error) {
 	// Read loop. Every frame comes back through the same decode → dispatch
 	// → (maybe) reply path. A single bad frame does NOT tear the socket
 	// down — only transport / handler errors escalate.
-	_ = conn.SetReadDeadline(time.Now().Add(readDeadline))
 	for {
 		if ctx.Err() != nil {
 			return nil
+		}
+		// Armed immediately before the read, and nowhere else.
+		//
+		// It used to be armed after ReadMessage returned, which put
+		// everything the loop then did inside the window. Only the server's
+		// pong resets the deadline on a quiet bot and our ping goes out every
+		// 30s, so on a loaded pool the next read could time out on a socket
+		// that was perfectly healthy. The idle window should measure idleness.
+		//
+		// The error is no longer discarded: a socket that refuses a deadline
+		// is not one to keep reading from.
+		if err := conn.SetReadDeadline(time.Now().Add(readDeadline)); err != nil {
+			// The shutdown path closes the socket, and a closed socket
+			// refuses a deadline. That is an ordinary stop, not a failure to
+			// report to the Supervisor.
+			if ctx.Err() != nil {
+				return nil
+			}
+			return fmt.Errorf("wecom: set read deadline: %w", err)
 		}
 		typ, payload, err := conn.ReadMessage()
 		if err != nil {
@@ -242,7 +260,6 @@ func (c *wecomChannel) Connect(ctx context.Context) (err error) {
 			}
 			return fmt.Errorf("wecom: read: %w", err)
 		}
-		_ = conn.SetReadDeadline(time.Now().Add(readDeadline))
 		if typ != websocket.TextMessage && typ != websocket.BinaryMessage {
 			continue
 		}

--- a/server/internal/integrations/wecom/wecom_resolvers.go
+++ b/server/internal/integrations/wecom/wecom_resolvers.go
@@ -43,15 +43,17 @@ func wecomMsgFromRaw(msg channel.InboundMessage) (InboundMessage, error) {
 }
 
 // NewResolverSet assembles the wecom ResolverSet from the store, the shared
-// chat-session service, and an outbound replier. wecom has no typing-
-// indicator affordance, so Typing is left nil — the Router treats a nil
-// Typing as a no-op.
+// chat-session service, an outbound replier and the typing indicator.
 //
-// The replier is optional: pass nil to disable outbound binding prompts.
+// The last two are optional: pass nil to disable outbound binding prompts or
+// the streaming bubble. Both are taken as concrete types rather than
+// interfaces so a nil argument leaves the field nil instead of a typed-nil
+// interface the Router would happily call.
 func NewResolverSet(
 	store *Store,
 	session engineSessionBinder,
 	replier engine.OutboundReplier,
+	typing *TypingIndicatorManager,
 ) engine.ResolverSet {
 	set := engine.ResolverSet{
 		Installation: &installationResolver{store: store},
@@ -63,6 +65,9 @@ func NewResolverSet(
 	}
 	if replier != nil {
 		set.Replier = replier
+	}
+	if typing != nil {
+		set.Typing = typing
 	}
 	return set
 }

--- a/server/internal/integrations/wecom/ws_frame.go
+++ b/server/internal/integrations/wecom/ws_frame.go
@@ -13,7 +13,10 @@ package wecom
 import (
 	"encoding/json"
 	"errors"
+	"fmt"
 	"strings"
+	"unicode"
+	"unicode/utf8"
 
 	"github.com/multica-ai/multica/server/internal/integrations/channel"
 )
@@ -277,4 +280,176 @@ func aibotChatTypeFromChannel(t channel.ChatType) int {
 		return chatTypeGroupInt
 	}
 	return chatTypeSingleInt
+}
+
+// ---- streaming replies ----
+
+// streamContentLimit is aibot's cap on stream.content: 20480 bytes of utf8
+// (https://developer.work.weixin.qq.com/document/path/101031). Content is a
+// FULL replacement of the bubble's body on every frame, never a delta, so this
+// bounds the whole answer rather than one chunk of it.
+const streamContentLimit = 20480
+
+// streamThinkingPlaceholder is what the opening frame says. Per 101031 a
+// content carrying <think></think> renders as the client's own thinking
+// affordance — the animated dots — which is exactly the "working on it" bubble
+// we want and costs no copy in any language. Tencent's own OpenClaw plugin
+// opens its streams with the same literal.
+const streamThinkingPlaceholder = "<think></think>"
+
+// aibot errcodes worth branching on. Neither of the two stream codes is in the
+// published error tables; both come from Tencent's OpenClaw plugin, which
+// handles them in production.
+const (
+	// errcodeStreamExpired — the stream ran past its window and the server
+	// will not take another frame for it. The two sources disagree on how long
+	// that window is: the long-connection doc says 10 minutes, while the
+	// plugin's own comment puts it at 6. streamMaxAge takes the shorter number
+	// (stream_store.go) — being early costs a fallback message, being late
+	// costs the answer.
+	errcodeStreamExpired = 846608
+
+	// errcodeStreamBadReqID — this req_id may not carry a stream. An event
+	// callback's req_id looks usable and is not; only a message callback's
+	// works, so the event path has to use aibot_send_msg.
+	errcodeStreamBadReqID = 846605
+)
+
+// streamError is a server rejection of a stream frame, carrying the errcode so
+// callers can tell "this bubble is beyond saving" from "that frame did not
+// land".
+type streamError struct {
+	Code int
+	Msg  string
+}
+
+func (e *streamError) Error() string {
+	return fmt.Sprintf("wecom: stream frame rejected errcode=%d errmsg=%s", e.Code, e.Msg)
+}
+
+// Unusable reports whether the rejection means this stream can never be
+// written to again — the caller must fall back to a plain message rather than
+// retry.
+func (e *streamError) Unusable() bool {
+	return e.Code == errcodeStreamExpired || e.Code == errcodeStreamBadReqID
+}
+
+// streamUnusable is the package-level predicate over any error, so callers do
+// not each re-implement the type assertion.
+func streamUnusable(err error) bool {
+	var se *streamError
+	if errors.As(err, &se) {
+		return se.Unusable()
+	}
+	return false
+}
+
+// respondStreamBody builds an aibot_respond_msg body carrying one frame of a
+// streaming reply. finish=false paints or updates the bubble; finish=true
+// seals it, after which the message is immutable.
+//
+// The blank-closing-frame check is the one rule that is not obvious from the
+// wire format: WeCom ignores content with nothing visible in it, so a closing
+// frame of spaces closes nothing and leaves the user with a bubble that spins
+// forever. Refusing here means every caller inherits the check.
+func respondStreamBody(streamID, content string, finish bool) (map[string]any, error) {
+	if streamID == "" {
+		return nil, errors.New("wecom: stream frame requires a stream id")
+	}
+	if finish {
+		content = defuseThinkTags(content)
+	}
+	content = truncateStreamContent(content)
+	if finish && !hasVisibleChar(content) {
+		return nil, errors.New("wecom: closing stream frame needs visible content")
+	}
+	return map[string]any{
+		"msgtype": "stream",
+		"stream": map[string]any{
+			"id":      streamID,
+			"finish":  finish,
+			"content": content,
+		},
+	}, nil
+}
+
+// defuseThinkTags stops an answer that talks about <think> from being read as
+// one.
+//
+// The tag is the client's, not ours: per 101031 a stream body wrapped in
+// <think></think> renders as WeCom's own collapsed thinking affordance, which
+// is what the opening frame is built from. An answer that happens to contain
+// the literal — quoting a prompt, explaining this very feature, pasting XML —
+// gets the same treatment, and half the reply disappears into a fold with no
+// edit and no unsend to undo it with.
+//
+// A zero-width space after the angle bracket is enough: the scanner no longer
+// matches, and the reader sees the same characters they would have seen. Only
+// the tag's own opening is touched, so comparisons, generics and HTML samples
+// in the rest of the answer come through as written. Callers apply this to
+// closing frames only — the opening frame IS the affordance.
+func defuseThinkTags(s string) string {
+	if !strings.Contains(s, "<") {
+		return s
+	}
+	const zwsp = "​"
+	var b strings.Builder
+	last := 0
+	// Indexing s directly, never a case-folded copy of it. Walking s while
+	// reading strings.ToLower(s) at the same offsets looks equivalent and is
+	// not: case folding does not preserve length. U+212A KELVIN SIGN is three
+	// bytes and lowercases to a one-byte "k", so the folded copy can be
+	// SHORTER than the original and an offset taken from s can be past its
+	// end. "KK<x" — two Kelvin signs and an angle bracket — is enough to slice
+	// out of range, and the string being scanned is the agent's own answer, so
+	// any text a user can talk the agent into echoing would take the backend
+	// down with it.
+	for i := 0; i < len(s); i++ {
+		if s[i] != '<' {
+			continue
+		}
+		j := i + 1
+		if j < len(s) && s[j] == '/' {
+			j++
+		}
+		if j+len("think") > len(s) || !strings.EqualFold(s[j:j+len("think")], "think") {
+			continue
+		}
+		b.WriteString(s[last : i+1])
+		b.WriteString(zwsp)
+		last = i + 1
+	}
+	if last == 0 {
+		return s
+	}
+	b.WriteString(s[last:])
+	return b.String()
+}
+
+// truncateStreamContent cuts content to the protocol's byte limit on a
+// character boundary. An answer that arrives clipped still answers; one the
+// server rejects for length does not.
+func truncateStreamContent(s string) string {
+	if len(s) <= streamContentLimit {
+		return s
+	}
+	const ellipsis = "…"
+	cut := streamContentLimit - len(ellipsis)
+	for cut > 0 && !utf8.RuneStart(s[cut]) {
+		cut--
+	}
+	return s[:cut] + ellipsis
+}
+
+// hasVisibleChar reports whether s contains anything the WeCom client will
+// render. Whitespace and control runes do not count — that is the whole point:
+// a closing frame the server considers empty is discarded, and the bubble it
+// was meant to seal spins for good.
+func hasVisibleChar(s string) bool {
+	for _, r := range s {
+		if !unicode.IsSpace(r) && !unicode.IsControl(r) {
+			return true
+		}
+	}
+	return false
 }

--- a/server/internal/integrations/wecom/ws_sender.go
+++ b/server/internal/integrations/wecom/ws_sender.go
@@ -68,22 +68,74 @@ type gorillaWSConn struct {
 // Connect() call and dropped when the connection ends.
 type wsSender struct {
 	conn wsConn
-	mu   sync.Mutex
 	log  *slog.Logger
+
+	// wmu serializes writes — gorilla forbids concurrent ones. A one-slot
+	// channel rather than a Mutex because a caller with a deadline has to be
+	// able to stop waiting for its turn: a stream frame closing a bubble runs
+	// on the bus subscriber's ten-second budget, and queueing behind a 20KB
+	// push would spend all of it before the frame ever reached the socket.
+	wmu chan struct{}
 
 	// replies holds the callers waiting on a server verdict, keyed by the
 	// req_id they wrote. Only the read loop delivers into these, which is why
 	// inbound callbacks must not run on it — see the note on sendTextCtx.
 	ackMu   sync.Mutex
 	replies map[string]*replyWaiter
+
+	// waiters holds the STREAM frames whose verdict somebody is standing by
+	// for, keyed by the callback req_id the frame echoes. Separate from
+	// replies because the two answer different questions and their keys come
+	// from different places: a req_id in replies is one we minted for one
+	// frame, while a stream's is the server's own and carries a whole turn's
+	// frames. Guarded by ackMu.
+	waiters map[string]*ackWaiter
+
+	// streams is the per-turn bookkeeping that makes a verdict trustworthy and
+	// a sealed bubble final. Guarded by ackMu; entries are created only by a
+	// stream frame, so the ordinary pushes that share this connection never
+	// touch it.
+	streams map[string]*streamAcks
+
+	// ackTimeout is how long a stream frame waits for its verdict. A field
+	// rather than the constant so a test can exercise the give-up path without
+	// standing still for five seconds.
+	ackTimeout time.Duration
 }
 
 func newWSSender(conn wsConn, log *slog.Logger) *wsSender {
 	if log == nil {
 		log = slog.Default()
 	}
-	return &wsSender{conn: conn, log: log, replies: make(map[string]*replyWaiter)}
+	return &wsSender{
+		conn:       conn,
+		log:        log,
+		wmu:        make(chan struct{}, 1),
+		replies:    make(map[string]*replyWaiter),
+		waiters:    make(map[string]*ackWaiter),
+		streams:    make(map[string]*streamAcks),
+		ackTimeout: ackTimeout,
+	}
 }
+
+// lockWriter takes the writer, or gives up when ctx does. A caller with no
+// deadline of its own — the ping, the subscribe handshake, a proactive push —
+// passes context.Background() and waits as long as it takes.
+func (s *wsSender) lockWriter(ctx context.Context) error {
+	select {
+	case s.wmu <- struct{}{}:
+		return nil
+	default:
+	}
+	select {
+	case s.wmu <- struct{}{}:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+func (s *wsSender) unlockWriter() { <-s.wmu }
 
 // ackTimeout caps the wait for a verdict. WeCom answers in a few hundred
 // milliseconds; past this we assume the ack was lost rather than the frame
@@ -109,6 +161,77 @@ func (e *wecomAPIError) Error() string {
 	return fmt.Sprintf("wecom: %s rejected errcode=%d errmsg=%s", e.Cmd, e.Code, e.Msg)
 }
 
+// ackSuperseded is the pseudo-code handed to a waiter whose frame was
+// displaced by a closing frame on the same stream.
+const ackSuperseded = -1
+
+var (
+	// errStreamBusy — a mid-stream frame was skipped because the previous
+	// frame on this req_id has not been acked. This is the backpressure the
+	// official SDK calls replyStreamNonBlocking: non-final frames yield,
+	// closing frames never do.
+	errStreamBusy = errors.New("wecom: previous stream frame still unacked")
+
+	// errStreamAckTimeout — the frame went out and no verdict came back. The
+	// frame may well have landed, so callers weigh a possible duplicate
+	// against a possible silence rather than assuming failure.
+	errStreamAckTimeout = errors.New("wecom: stream frame ack timed out")
+
+	// errStreamSuperseded — a frame was overtaken by the closing frame, either
+	// while waiting for its verdict or on the way to the wire.
+	errStreamSuperseded = errors.New("wecom: stream frame superseded by the closing frame")
+
+	// errNoLiveConnection — the installation has no socket right now.
+	errNoLiveConnection = errors.New("wecom: no live connection for installation")
+)
+
+// ackWaiter is one stream frame's standing request for a verdict. seq is where
+// the frame sits in its req_id's write order, stamped at the moment it goes on
+// the wire — see streamAcks for why a verdict has to be matched rather than
+// simply handed to whoever is waiting.
+type ackWaiter struct {
+	ch  chan ackResult
+	seq uint64 // 0 until the frame is written
+}
+
+// ackResult is one server verdict.
+type ackResult struct {
+	code int
+	msg  string
+}
+
+// streamAcks counts one req_id's stream frames in and its verdicts out, and
+// remembers when the closing frame has gone.
+//
+// Both halves exist because a bubble is written to more than once per turn.
+// The ack frame carries nothing but the req_id — no stream id, no sequence —
+// so a verdict is only identifiable by its position: acks come back over one
+// TCP connection in the order the frames went out. Without the count, an
+// opening frame whose ack is still on the wire when the answer goes out hands
+// ITS verdict to the closing frame, and a closing frame the server actually
+// refused reads as delivered — which loses the answer entirely, since the
+// caller then has no reason to fall back to a plain message.
+//
+// sealed is the other half: a finished stream is immutable, so a frame that
+// lost the race to the answer must never reach the wire behind it.
+//
+// acked counts verdicts that arrived and only those. Nothing ever advances it
+// on a caller's behalf — see cancelAck for why a write-off is worse than a
+// count that stays short.
+type streamAcks struct {
+	sent   uint64
+	acked  uint64
+	sealed bool
+	at     time.Time
+}
+
+// streamAcksMax bounds the per-turn bookkeeping on a long-lived connection.
+// Entries are retired by age and this is only the backstop, so it is set well
+// past any number of turns one bot can have inside the stream window — a sweep
+// that had to drop live entries would put their closing frames out of step, and
+// 2048 of these costs under a hundred kilobytes.
+const streamAcksMax = 2048
+
 // replyWaiter is one caller parked on one req_id.
 type replyWaiter struct{ ch chan replyResult }
 
@@ -124,8 +247,174 @@ type replyResult struct {
 // reports whether anybody was. The read loop calls it for every frame that
 // answers one of our writes; an unclaimed ack is not an error, since the
 // pushes that do not wait share this connection.
+//
+// Order matters: a request waiting on the body is asked first, because those
+// req_ids are ours and a stream's are the server's — one lookup settles which
+// kind of answer this is without the frame having to say. A stream ack that
+// gets routed still reports false, so the read loop keeps logging a non-zero
+// errcode the way it always has.
 func (s *wsSender) routeResponse(env frameEnvelope) bool {
-	return s.deliverReply(env)
+	if s.deliverReply(env) {
+		return true
+	}
+	s.deliverAck(env.Headers.ReqID, env.ErrCode, env.ErrMsg)
+	return false
+}
+
+// deliverAck hands a server ack to the stream frame it belongs to. The read
+// loop calls it for every anonymous ack frame; acks for anything that is not a
+// stream — the heartbeat, an ordinary push — fall straight through.
+//
+// "The frame it belongs to" is the whole point, and it is not the same as
+// "whoever is waiting". A req_id carries a whole turn's frames and its acks say
+// nothing about which one they answer, so the count decides: the Nth verdict on
+// a req_id belongs to its Nth frame. A verdict for a frame whose caller has
+// already given up is dropped here rather than handed to the next one.
+func (s *wsSender) deliverAck(reqID string, code int, msg string) {
+	if reqID == "" {
+		return
+	}
+	s.ackMu.Lock()
+	st, tracked := s.streams[reqID]
+	if !tracked {
+		s.ackMu.Unlock()
+		return // not a stream frame's ack
+	}
+	st.acked++
+	w, ok := s.waiters[reqID]
+	if ok && w.seq == st.acked {
+		delete(s.waiters, reqID)
+	} else {
+		ok = false
+	}
+	s.ackMu.Unlock()
+	if !ok {
+		return
+	}
+	select {
+	case w.ch <- ackResult{code: code, msg: msg}:
+	default:
+	}
+}
+
+// awaitAck registers interest in the verdict for the stream frame about to be
+// written. force is what makes a closing frame able to jump an in-flight
+// frame: without it the answer would be held hostage by an opening frame whose
+// ack is late.
+func (s *wsSender) awaitAck(reqID string, force bool) (*ackWaiter, bool) {
+	s.ackMu.Lock()
+	defer s.ackMu.Unlock()
+	if prev, taken := s.waiters[reqID]; taken {
+		if !force {
+			return nil, false
+		}
+		select {
+		case prev.ch <- ackResult{code: ackSuperseded}:
+		default:
+		}
+	}
+	w := &ackWaiter{ch: make(chan ackResult, 1)}
+	s.waiters[reqID] = w
+	return w, true
+}
+
+// cancelAck retires a waiter whose caller has stopped waiting, for either of
+// the two reasons a caller stops: its own budget ran out, or the full ack
+// timeout elapsed with nothing on the wire.
+//
+// Both leave the count alone, and that is the whole attribution rule: acked
+// counts verdicts that ARRIVED, never verdicts we gave up on. Advancing it to
+// cover a frame nobody is waiting for would hand that frame's real verdict —
+// which lands a moment later, because the server does answer every frame — to
+// whoever wrote next, and every frame after it in the turn as well. The one
+// that pays is the closing frame: a stale "accepted" makes a refused answer
+// read as delivered, so the caller never falls back and the reply is sent
+// nowhere at all. Leaving the count short costs a turn whose verdict is truly
+// lost its bubble, since every later frame then times out — and an ack timeout
+// is exactly the signal that sends the answer as a plain message.
+func (s *wsSender) cancelAck(reqID string, w *ackWaiter) {
+	s.ackMu.Lock()
+	defer s.ackMu.Unlock()
+	if cur, ok := s.waiters[reqID]; ok && cur == w {
+		delete(s.waiters, reqID)
+	}
+}
+
+// beginStreamFrameLocked reserves the next place in a req_id's write order for
+// the frame that is about to go out, and refuses a non-final frame once the
+// closing frame has been written. Caller holds the writer, which is what makes
+// the refusal airtight: the seal and the write it fences are decided inside the
+// same critical section, so a later frame can never slip between the two and
+// land on top of the answer.
+func (s *wsSender) beginStreamFrameLocked(reqID string, w *ackWaiter, finish bool) bool {
+	s.ackMu.Lock()
+	defer s.ackMu.Unlock()
+	st, ok := s.streams[reqID]
+	if !ok {
+		s.pruneStreamsLocked()
+		st = &streamAcks{at: time.Now()}
+		s.streams[reqID] = st
+	}
+	if st.sealed && !finish {
+		return false
+	}
+	st.sent++
+	if finish {
+		st.sealed = true
+	}
+	if w != nil {
+		w.seq = st.sent
+	}
+	return true
+}
+
+// abortStreamFrameLocked gives back the place reserved for a frame that never
+// reached the socket, so one failed write does not put every later verdict on
+// this req_id out of step. The seal is not given back: a turn whose closing
+// frame failed is over either way, and the caller has already fallen back to a
+// plain message. Caller holds the writer.
+func (s *wsSender) abortStreamFrameLocked(reqID string) {
+	s.ackMu.Lock()
+	defer s.ackMu.Unlock()
+	if st, ok := s.streams[reqID]; ok && st.sent > 0 {
+		st.sent--
+	}
+}
+
+// pruneStreamsLocked retires turns the protocol has already forgotten. A sealed
+// entry has to outlive its last ack — it is what stops a straggling frame from
+// reopening a bubble the answer already closed — so age is the only thing that
+// retires it. Caller holds s.ackMu.
+func (s *wsSender) pruneStreamsLocked() {
+	if len(s.streams) < streamAcksMax {
+		return
+	}
+	now := time.Now()
+	for k, st := range s.streams {
+		if st.sealed && now.Sub(st.at) > streamMaxAge {
+			delete(s.streams, k)
+		}
+	}
+	// Whatever is left is either sealed and young, or still open. Neither may
+	// be thrown away. A live turn whose counters are gone has its next frame
+	// stamped from zero: a stale verdict for an earlier frame then matches the
+	// closing one, the refusal that closing frame actually got is never seen,
+	// and the answer is reported delivered while it went nowhere — the exact
+	// misattribution the sequence numbers exist to prevent.
+	//
+	// A live turn is also the OLDEST entry by construction — its opening frame
+	// is minutes older than the burst that filled the map — so "evict oldest
+	// first" would pick exactly the wrong ones.
+	//
+	// The map can therefore exceed streamAcksMax under sustained load. That is
+	// the right trade: the cap is a memory bound on bookkeeping that is small
+	// per entry and self-clears as turns end, and losing a user's answer to
+	// save a few kilobytes is not a trade anyone would make on purpose. The
+	// warning is what says it is happening.
+	if len(s.streams) >= streamAcksMax {
+		s.log.Warn("wecom: stream bookkeeping over its cap and every entry is live or young; keeping them",
+			"entries", len(s.streams), "cap", streamAcksMax)
+	}
 }
 
 // awaitReply registers interest in the response for the frame about to be
@@ -214,7 +503,64 @@ func (s *wsSender) request(ctx context.Context, cmd string, body map[string]any)
 	}
 }
 
-// write marshals frame to JSON and pushes it under the writer mutex. The
+// respondStream writes one frame of a streaming reply and waits for the
+// server's verdict. ctx bounds the whole thing — the wait for the writer, the
+// write itself and the wait for the ack — because the callers here run on a bus
+// subscriber's own budget and none of those three is otherwise bounded by
+// anything the caller chose.
+//
+// reqID is not ours to choose: every frame of one stream must echo the req_id
+// of the aibot_msg_callback that opened the turn, or the server refuses it
+// (846605). streamID is ours — reuse it to replace the bubble's body, and set
+// finish once the content is final.
+func (s *wsSender) respondStream(ctx context.Context, reqID, streamID, content string, finish bool) error {
+	if reqID == "" {
+		return errors.New("wecom: stream frame requires the callback req_id")
+	}
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	body, err := respondStreamBody(streamID, content, finish)
+	if err != nil {
+		return err
+	}
+
+	w, ok := s.awaitAck(reqID, finish)
+	if !ok {
+		return errStreamBusy
+	}
+	if err := s.writeStreamFrame(ctx, reqID, w, finish, map[string]any{
+		"cmd":     cmdRespondMsg,
+		"headers": frameHeaders{ReqID: reqID},
+		"body":    body,
+	}); err != nil {
+		s.cancelAck(reqID, w)
+		return err
+	}
+
+	timer := time.NewTimer(s.ackTimeout)
+	defer timer.Stop()
+	select {
+	case res := <-w.ch:
+		switch {
+		case res.code == ackSuperseded:
+			return errStreamSuperseded
+		case res.code != 0:
+			return &streamError{Code: res.code, Msg: res.msg}
+		}
+		return nil
+	case <-timer.C:
+		s.cancelAck(reqID, w)
+		return errStreamAckTimeout
+	case <-ctx.Done():
+		s.cancelAck(reqID, w)
+		return errStreamAckTimeout
+	}
+}
+
+// write marshals frame to JSON and pushes it under the writer mutex. Used by
+// the callers with nobody waiting on them — the ping, the subscribe handshake,
+// a proactive push — which wait for their turn however long it takes. The
 // caller must not hold sendMu on wecomChannel — nothing here reaches back
 // into the Channel.
 func (s *wsSender) write(frame map[string]any) error {
@@ -222,9 +568,54 @@ func (s *wsSender) write(frame map[string]any) error {
 	if err != nil {
 		return fmt.Errorf("wecom: marshal frame: %w", err)
 	}
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	if err := s.conn.SetWriteDeadline(time.Now().Add(writeDeadline)); err != nil {
+	ctx := context.Background()
+	if err := s.lockWriter(ctx); err != nil {
+		return err
+	}
+	defer s.unlockWriter()
+	return s.writeLocked(ctx, payload)
+}
+
+// writeStreamFrame is write() for a stream frame: the same serialized push,
+// with the turn's bookkeeping done inside the writer's own critical section so
+// two frames of one turn cannot interleave. A frame that arrives after the
+// closing frame is dropped here rather than sent — the bubble is sealed, and a
+// frame the server might still accept would paint the placeholder back over
+// the answer.
+//
+// Unlike write() this one honours a deadline, at both places a write can stall:
+// waiting for the writer and waiting for the socket.
+func (s *wsSender) writeStreamFrame(ctx context.Context, reqID string, w *ackWaiter, finish bool, frame map[string]any) error {
+	payload, err := json.Marshal(frame)
+	if err != nil {
+		return fmt.Errorf("wecom: marshal frame: %w", err)
+	}
+	if err := s.lockWriter(ctx); err != nil {
+		return err
+	}
+	defer s.unlockWriter()
+	if !s.beginStreamFrameLocked(reqID, w, finish) {
+		return errStreamSuperseded
+	}
+	if err := s.writeLocked(ctx, payload); err != nil {
+		s.abortStreamFrameLocked(reqID)
+		return err
+	}
+	return nil
+}
+
+// writeLocked pushes one already-marshalled frame. Caller holds the writer.
+//
+// The socket deadline is the sooner of the connection's own writeDeadline and
+// whatever the caller gave itself. A frame is a few kilobytes, so a socket that
+// cannot take one inside a caller's budget is congested rather than busy, and
+// the Supervisor's reconnect is the designed answer to that.
+func (s *wsSender) writeLocked(ctx context.Context, payload []byte) error {
+	deadline := time.Now().Add(writeDeadline)
+	if d, ok := ctx.Deadline(); ok && d.Before(deadline) {
+		deadline = d
+	}
+	if err := s.conn.SetWriteDeadline(deadline); err != nil {
 		return err
 	}
 	return s.conn.WriteMessage(websocket.TextMessage, payload)

--- a/server/internal/integrations/wecom/ws_sender.go
+++ b/server/internal/integrations/wecom/ws_sender.go
@@ -8,6 +8,7 @@ package wecom
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log/slog"
 	"net/http"
@@ -69,13 +70,148 @@ type wsSender struct {
 	conn wsConn
 	mu   sync.Mutex
 	log  *slog.Logger
+
+	// replies holds the callers waiting on a server verdict, keyed by the
+	// req_id they wrote. Only the read loop delivers into these, which is why
+	// inbound callbacks must not run on it — see the note on sendTextCtx.
+	ackMu   sync.Mutex
+	replies map[string]*replyWaiter
 }
 
 func newWSSender(conn wsConn, log *slog.Logger) *wsSender {
 	if log == nil {
 		log = slog.Default()
 	}
-	return &wsSender{conn: conn, log: log}
+	return &wsSender{conn: conn, log: log, replies: make(map[string]*replyWaiter)}
+}
+
+// ackTimeout caps the wait for a verdict. WeCom answers in a few hundred
+// milliseconds; past this we assume the ack was lost rather than the frame
+// refused, which matters because the two call for opposite responses.
+const ackTimeout = 5 * time.Second
+
+// errAckTimeout — the frame went out and no verdict came back. Distinct from a
+// refusal: the message may well have been delivered, so a caller retries at
+// its own risk rather than reporting failure.
+var errAckTimeout = errors.New("wecom: timed out waiting for the server verdict")
+
+// wecomAPIError is a refusal the server stated. Carrying the errcode rather
+// than a string is what lets a caller tell a permanent refusal (bad frame,
+// bot removed from the chat) from a transient one (rate limited) instead of
+// pattern-matching prose.
+type wecomAPIError struct {
+	Cmd  string
+	Code int
+	Msg  string
+}
+
+func (e *wecomAPIError) Error() string {
+	return fmt.Sprintf("wecom: %s rejected errcode=%d errmsg=%s", e.Cmd, e.Code, e.Msg)
+}
+
+// replyWaiter is one caller parked on one req_id.
+type replyWaiter struct{ ch chan replyResult }
+
+// replyResult is a server answer. body is nil for the acks that carry nothing
+// but a verdict.
+type replyResult struct {
+	code int
+	msg  string
+	body json.RawMessage
+}
+
+// routeResponse hands a server response to whoever is waiting for it and
+// reports whether anybody was. The read loop calls it for every frame that
+// answers one of our writes; an unclaimed ack is not an error, since the
+// pushes that do not wait share this connection.
+func (s *wsSender) routeResponse(env frameEnvelope) bool {
+	return s.deliverReply(env)
+}
+
+// awaitReply registers interest in the response for the frame about to be
+// written. false means the req_id is already spoken for — with minted ids
+// that is a collision we would rather fail on than silently cross wires.
+func (s *wsSender) awaitReply(reqID string) (*replyWaiter, bool) {
+	s.ackMu.Lock()
+	defer s.ackMu.Unlock()
+	if _, taken := s.replies[reqID]; taken {
+		return nil, false
+	}
+	w := &replyWaiter{ch: make(chan replyResult, 1)}
+	s.replies[reqID] = w
+	return w, true
+}
+
+// cancelReply retires a waiter. Called on every exit path including the happy
+// one — a request is one frame and one answer, so the entry is never useful
+// twice, and leaving it would leak an entry per send.
+func (s *wsSender) cancelReply(reqID string, w *replyWaiter) {
+	s.ackMu.Lock()
+	defer s.ackMu.Unlock()
+	if cur, ok := s.replies[reqID]; ok && cur == w {
+		delete(s.replies, reqID)
+	}
+}
+
+// deliverReply hands a response to the request that asked for it, if there is
+// one, and reports whether it was taken.
+func (s *wsSender) deliverReply(env frameEnvelope) bool {
+	if env.Headers.ReqID == "" {
+		return false
+	}
+	s.ackMu.Lock()
+	w, ok := s.replies[env.Headers.ReqID]
+	if ok {
+		delete(s.replies, env.Headers.ReqID)
+	}
+	s.ackMu.Unlock()
+	if !ok {
+		return false
+	}
+	// Buffered channel, and the entry is removed above, so this never blocks
+	// and never delivers twice.
+	select {
+	case w.ch <- replyResult{code: env.ErrCode, msg: env.ErrMsg, body: env.Body}:
+	default:
+	}
+	return true
+}
+
+// request writes one frame under a req_id of our own and waits for the whole
+// answer. A non-nil error is either a *wecomAPIError carrying the server's
+// errcode, errAckTimeout, or a transport failure.
+func (s *wsSender) request(ctx context.Context, cmd string, body map[string]any) (json.RawMessage, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	reqID := newReqID()
+	w, ok := s.awaitReply(reqID)
+	if !ok {
+		return nil, fmt.Errorf("wecom: %s req_id %s is already awaiting a response", cmd, reqID)
+	}
+	defer s.cancelReply(reqID, w)
+
+	if err := s.write(map[string]any{
+		"cmd":     cmd,
+		"headers": frameHeaders{ReqID: reqID},
+		"body":    body,
+	}); err != nil {
+		return nil, err
+	}
+
+	timer := time.NewTimer(ackTimeout)
+	defer timer.Stop()
+	select {
+	case res := <-w.ch:
+		if res.code != 0 {
+			return nil, &wecomAPIError{Cmd: cmd, Code: res.code, Msg: res.msg}
+		}
+		return res.body, nil
+	case <-timer.C:
+		return nil, errAckTimeout
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	}
 }
 
 // write marshals frame to JSON and pushes it under the writer mutex. The
@@ -99,13 +235,23 @@ func (s *wsSender) write(frame map[string]any) error {
 // (1=single, 2=group) is decided at the wecom-side boundary, not the
 // engine's. Used by wecomChannel.Send and OutboundReplier.
 func (s *wsSender) sendText(chatID string, chatTypeInt int, content string) error {
+	return s.sendTextCtx(context.Background(), chatID, chatTypeInt, content)
+}
+
+// sendTextCtx is sendText that reads the server's verdict. Before this, a push
+// was fire-and-forget: a frame WeCom refused — over the size cap, addressed to
+// a chat the bot is no longer in, rate limited — returned nil, so the caller
+// recorded a delivery that never happened and the operator saw only
+// unattributed ack lines go past.
+//
+// Safe to block here only because inbound callbacks no longer run on the read
+// loop (wecom_channel.go): the read loop is the sole deliverer of acks, so a
+// send that waited for one from inside a callback would have waited on itself.
+func (s *wsSender) sendTextCtx(ctx context.Context, chatID string, chatTypeInt int, content string) error {
 	body, err := sendMsgTextBody(chatID, chatTypeInt, content)
 	if err != nil {
 		return err
 	}
-	return s.write(map[string]any{
-		"cmd":     cmdSendMsg,
-		"headers": frameHeaders{ReqID: newReqID()},
-		"body":    body,
-	})
+	_, err = s.request(ctx, cmdSendMsg, body)
+	return err
 }


### PR DESCRIPTION
**Stacked on #6606 — review from d4b617760 onward.** The diff below also carries #6606's three commits (0dfc2e685, 74bd75c74, 909b5a5f0); only the last one is new here. Merge #6606 first.

## What the user sees

A spinner that never stops, on a run the system already gave up on.

The WeCom bubble opens as soon as a question arrives — it promises an answer is coming. When the run ends without one, something has to close it. `TypingIndicatorManager.Register` subscribed to `task:failed` and nothing else, so a run that ended any other way left the bubble spinning. Five minutes later the stream-window guard swapped it for "still working, I'll reply separately" — a promise about a run that had already been abandoned. A real user hit this.

## Why `task:cancelled` is its own event

`task:failed` is not the only way a run ends without an answer. The engine cancels a turn it cannot serve — a task claimed with no user input attached is one real case — and `internal/service/task.go` publishes `task:cancelled` for it, not `task:failed`. No `chat:done` follows either, so nothing else closes the bubble on the way past.

Failed and cancelled are two different facts about the engine and one fact about the person watching: no answer is coming. Saying which one it was would tell them nothing they can act on. So the new subscription goes to the existing `handleTaskFailed` rather than to a parallel handler — same closing frame, same copy. The test drives both endings as one table, so the cancelled case can't drift into being treated as the special one.

## Why there is a test in `cmd/server`

What closes the bubble is a subscription, and a missing subscription is invisible. The events keep being published, nobody reads them, and nothing anywhere logs a complaint. Every unit test in `internal/integrations/wecom` builds its own manager and registers it by hand, so all of them would keep passing even if the server stopped wiring one up at all. Wiring, not logic, is what breaks silently here.

`TestWecomBubbleClosersSubscribeOnTheRealBootPath` asserts against `NewRouter` — the same call `main()` makes. It builds two routers on two buses, one with `MULTICA_WECOM_SECRET_KEY` set and one without, and requires the WeCom one to add a listener on each event. Comparing the two keeps the guard honest without it needing to know which other subsystems subscribe to the same events (`autopilot_listeners.go` also takes `task:cancelled`, for one). It checks `chat:done` first as an anti-vacuity marker: if the WeCom boot block never ran, that assertion says so, instead of letting the real ones pass for the wrong reason.

`events.Bus.SubscriberCount` comes with it, to make that assertable from outside the bus — read-only, `RLock`, counts type-specific handlers only.

## Verification

`go build ./...` and `go vet ./internal/...` both clean.

```
go test ./internal/integrations/wecom/ ./cmd/server/ ./internal/events/ -count=1
ok  	github.com/multica-ai/multica/server/internal/integrations/wecom	5.457s
ok  	github.com/multica-ai/multica/server/cmd/server	3.522s
ok  	github.com/multica-ai/multica/server/internal/events	0.177s
```

Reverse check — with the one new `Subscribe` line in `Register` deleted, both new tests fail, and each names the user-visible consequence rather than a symptom:

```
=== RUN   TestARunThatEndsWithoutAnAnswerClosesTheBubble
=== RUN   TestARunThatEndsWithoutAnAnswerClosesTheBubble/task:failed
=== RUN   TestARunThatEndsWithoutAnAnswerClosesTheBubble/task:cancelled
    stream_cancelled_test.go:45: a task:cancelled run produced 1 frames, want 2 (the bubble and its closing frame) — nothing subscribes to task:cancelled, so the spinner runs on for an answer nobody is producing
--- FAIL: TestARunThatEndsWithoutAnAnswerClosesTheBubble (0.00s)
    --- PASS: TestARunThatEndsWithoutAnAnswerClosesTheBubble/task:failed (0.00s)
    --- FAIL: TestARunThatEndsWithoutAnAnswerClosesTheBubble/task:cancelled (0.00s)
FAIL	github.com/multica-ai/multica/server/internal/integrations/wecom	0.486s
```

```
=== RUN   TestWecomBubbleClosersSubscribeOnTheRealBootPath
    wecom_bubble_wiring_test.go:56: nothing in the WeCom boot path subscribes to task:cancelled (0 listeners with WeCom enabled, 0 without). A run that ends on task:cancelled publishes no chat:done, so the bubble it opened is never closed and the user watches a spinner for an answer nobody is producing. Check TypingIndicatorManager.Register.
--- FAIL: TestWecomBubbleClosersSubscribeOnTheRealBootPath (0.00s)
FAIL	github.com/multica-ai/multica/server/cmd/server	0.744s
```

The `task:failed` subtest passing throughout is what shows the rig itself is not vacuous. Restoring the line puts all three packages back to green.
