### PR TITLE
MUL-5912: fix(mobile): preserve offline auth session

### DIFF
--- a/apps/mobile/app/(app)/_layout.tsx
+++ b/apps/mobile/app/(app)/_layout.tsx
@@ -1,8 +1,10 @@
-import { Stack, Redirect } from "expo-router";
+import { Stack, Redirect, usePathname } from "expo-router";
 import { useAuthStore } from "@/data/auth-store";
 
 /**
- * Auth-required layout. Redirects to /login when no user is loaded.
+ * Auth-required layout. A valid credential remains admitted while offline;
+ * only the one-time upgrade edge case without a user snapshot lands on the
+ * explicit /offline screen.
  *
  * Workspace membership is enforced one level deeper at [workspace]/_layout —
  * not here — because select-workspace.tsx itself is auth-required but
@@ -10,6 +12,9 @@ import { useAuthStore } from "@/data/auth-store";
  */
 export default function AppLayout() {
   const user = useAuthStore((s) => s.user);
-  if (!user) return <Redirect href="/login" />;
+  const hasToken = useAuthStore((s) => s.hasToken);
+  const pathname = usePathname();
+  if (!hasToken) return <Redirect href="/login" />;
+  if (!user && pathname !== "/offline") return <Redirect href="/offline" />;
   return <Stack screenOptions={{ headerShown: false }} />;
 }

--- a/apps/mobile/app/(app)/offline.tsx
+++ b/apps/mobile/app/(app)/offline.tsx
@@ -15,7 +15,14 @@ export default function OfflineAccountInfo() {
   const isLoading = useAuthStore((s) => s.isLoading);
 
   const retry = async () => {
-    await initialize();
+    // initialize() resets isLoading in a finally, so a rejection here only
+    // means "still no answer" — stay on this screen rather than surface an
+    // unhandled rejection from the press handler.
+    try {
+      await initialize();
+    } catch {
+      return;
+    }
     const { user, hasToken } = useAuthStore.getState();
     if (user) router.replace("/");
     else if (!hasToken) router.replace("/login");

--- a/apps/mobile/app/(app)/offline.tsx
+++ b/apps/mobile/app/(app)/offline.tsx
@@ -1,0 +1,43 @@
+import { ActivityIndicator, View } from "react-native";
+import { SafeAreaView } from "react-native-safe-area-context";
+import { router } from "expo-router";
+import { Button } from "@/components/ui/button";
+import { Text } from "@/components/ui/text";
+import { useAuthStore } from "@/data/auth-store";
+
+/**
+ * Upgrade edge case: a pre-offline-release session has a token but no saved
+ * user snapshot. It is intentionally not treated as a login failure.
+ */
+export default function OfflineAccountInfo() {
+  const initialize = useAuthStore((s) => s.initialize);
+  const logout = useAuthStore((s) => s.logout);
+  const isLoading = useAuthStore((s) => s.isLoading);
+
+  const retry = async () => {
+    await initialize();
+    const { user, hasToken } = useAuthStore.getState();
+    if (user) router.replace("/");
+    else if (!hasToken) router.replace("/login");
+  };
+
+  return (
+    <SafeAreaView className="flex-1 bg-background">
+      <View className="flex-1 justify-center gap-4 px-6">
+        <Text className="text-2xl font-semibold text-foreground">
+          Account info unavailable offline
+        </Text>
+        <Text className="text-sm leading-5 text-muted-foreground">
+          This session is still saved on this device, but it was created before
+          offline account details could be stored. Connect once to restore it.
+        </Text>
+        <Button variant="outline" onPress={retry} disabled={isLoading}>
+          {isLoading ? <ActivityIndicator /> : <Text>Retry</Text>}
+        </Button>
+        <Button variant="destructive" onPress={() => void logout()}>
+          <Text>Sign out</Text>
+        </Button>
+      </View>
+    </SafeAreaView>
+  );
+}

--- a/apps/mobile/app/index.tsx
+++ b/apps/mobile/app/index.tsx
@@ -7,12 +7,14 @@ import { useWorkspaceStore } from "@/data/workspace-store";
  * Entry redirect. AuthInitializer (in _layout.tsx) finishes auth + slug
  * hydration before this renders meaningfully — until then, isLoading is true.
  *
- *   no user            → /login
+ *   no credential      → /login
+ *   credential, no user snapshot → /offline (upgrade edge case)
  *   user, no slug      → /select-workspace
  *   user, slug         → /[slug]/inbox
  */
 export default function Index() {
   const user = useAuthStore((s) => s.user);
+  const hasToken = useAuthStore((s) => s.hasToken);
   const isLoading = useAuthStore((s) => s.isLoading);
   const slug = useWorkspaceStore((s) => s.currentWorkspaceSlug);
 
@@ -24,7 +26,8 @@ export default function Index() {
     );
   }
 
-  if (!user) return <Redirect href="/login" />;
+  if (!hasToken) return <Redirect href="/login" />;
+  if (!user) return <Redirect href="/offline" />;
   if (!slug) return <Redirect href="/select-workspace" />;
   return <Redirect href={`/${slug}/inbox`} />;
 }

--- a/apps/mobile/data/auth-store.test.ts
+++ b/apps/mobile/data/auth-store.test.ts
@@ -15,12 +15,10 @@ class ApiError extends Error {
 }
 
 const secureStorage = {
-  clearCachedUser: vi.fn(),
-  clearToken: vi.fn(),
-  getCachedUser: vi.fn(),
-  getToken: vi.fn(),
-  setCachedUser: vi.fn(),
-  setToken: vi.fn(),
+  clearSession: vi.fn(),
+  getSession: vi.fn(),
+  saveSession: vi.fn(),
+  saveSessionUser: vi.fn(),
 };
 
 vi.mock("./api", () => ({ api, ApiError }));
@@ -33,21 +31,33 @@ const { useAuthStore } = await import("./auth-store");
 
 const USER = { id: "user-1", email: "offline@example.com" } as User;
 
-describe("useAuthStore.initialize", () => {
-  beforeEach(() => {
-    vi.clearAllMocks();
-    secureStorage.getToken.mockResolvedValue(null);
-    secureStorage.getCachedUser.mockResolvedValue(null);
-    api.getMe.mockResolvedValue(USER);
-    useAuthStore.setState({
-      user: null,
-      isLoading: true,
-      hasToken: false,
-      isOffline: false,
-    });
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (reason: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
   });
+  return { promise, resolve, reject };
+}
 
-  it("keeps the login gate closed when no token exists", async () => {
+beforeEach(() => {
+  vi.clearAllMocks();
+  secureStorage.getSession.mockResolvedValue(null);
+  secureStorage.clearSession.mockResolvedValue(undefined);
+  secureStorage.saveSession.mockResolvedValue(undefined);
+  secureStorage.saveSessionUser.mockResolvedValue(undefined);
+  api.getMe.mockResolvedValue(USER);
+  useAuthStore.setState({
+    user: null,
+    isLoading: true,
+    hasToken: false,
+    isOffline: false,
+  });
+});
+
+describe("useAuthStore.initialize", () => {
+  it("keeps the login gate closed when no session exists", async () => {
     await useAuthStore.getState().initialize();
 
     expect(api.getMe).not.toHaveBeenCalled();
@@ -59,13 +69,12 @@ describe("useAuthStore.initialize", () => {
   });
 
   it("hydrates a saved user after a non-401 network failure", async () => {
-    secureStorage.getToken.mockResolvedValue("token");
-    secureStorage.getCachedUser.mockResolvedValue(USER);
+    secureStorage.getSession.mockResolvedValue({ token: "t", user: USER });
     api.getMe.mockRejectedValue(new Error("network unavailable"));
 
     await useAuthStore.getState().initialize();
 
-    expect(secureStorage.clearToken).not.toHaveBeenCalled();
+    expect(secureStorage.clearSession).not.toHaveBeenCalled();
     expect(useAuthStore.getState()).toMatchObject({
       user: USER,
       hasToken: true,
@@ -74,13 +83,13 @@ describe("useAuthStore.initialize", () => {
     });
   });
 
-  it("keeps a legacy token admitted when offline but no snapshot exists", async () => {
-    secureStorage.getToken.mockResolvedValue("token");
+  it("keeps a legacy credential admitted when offline but no snapshot exists", async () => {
+    secureStorage.getSession.mockResolvedValue({ token: "t", user: null });
     api.getMe.mockRejectedValue(new Error("network unavailable"));
 
     await useAuthStore.getState().initialize();
 
-    expect(secureStorage.clearToken).not.toHaveBeenCalled();
+    expect(secureStorage.clearSession).not.toHaveBeenCalled();
     expect(useAuthStore.getState()).toMatchObject({
       user: null,
       hasToken: true,
@@ -89,20 +98,128 @@ describe("useAuthStore.initialize", () => {
     });
   });
 
-  it("clears the token and cached user on a real 401", async () => {
-    secureStorage.getToken.mockResolvedValue("expired-token");
-    secureStorage.getCachedUser.mockResolvedValue(USER);
+  it("clears the session on a real 401", async () => {
+    secureStorage.getSession.mockResolvedValue({ token: "expired", user: USER });
     api.getMe.mockRejectedValue(new ApiError("expired", 401));
 
     await useAuthStore.getState().initialize();
 
-    expect(secureStorage.clearToken).toHaveBeenCalledOnce();
-    expect(secureStorage.clearCachedUser).toHaveBeenCalledOnce();
+    expect(secureStorage.clearSession).toHaveBeenCalledOnce();
     expect(useAuthStore.getState()).toMatchObject({
       user: null,
       hasToken: false,
       isOffline: false,
       isLoading: false,
     });
+  });
+
+  it("re-persists the snapshot alongside the credential it was verified with", async () => {
+    secureStorage.getSession.mockResolvedValue({ token: "t", user: null });
+
+    await useAuthStore.getState().initialize();
+
+    expect(secureStorage.saveSession).toHaveBeenCalledWith("t", USER);
+  });
+
+  it("reports isLoading while a run is in flight", async () => {
+    secureStorage.getSession.mockResolvedValue({ token: "t", user: USER });
+    const getMe = deferred<User>();
+    api.getMe.mockReturnValue(getMe.promise);
+
+    const run = useAuthStore.getState().initialize();
+    await Promise.resolve();
+
+    // The /offline Retry button and its spinner both key off this. It was
+    // previously only ever written as false, so neither ever engaged.
+    expect(useAuthStore.getState().isLoading).toBe(true);
+
+    getMe.resolve(USER);
+    await run;
+    expect(useAuthStore.getState().isLoading).toBe(false);
+  });
+
+  it("lands isLoading false even when the run throws unexpectedly", async () => {
+    secureStorage.getSession.mockRejectedValue(new Error("keychain locked"));
+
+    await expect(useAuthStore.getState().initialize()).rejects.toThrow(
+      "keychain locked",
+    );
+    expect(useAuthStore.getState().isLoading).toBe(false);
+  });
+
+  it("collapses concurrent calls into a single run", async () => {
+    secureStorage.getSession.mockResolvedValue({ token: "t", user: USER });
+    const getMe = deferred<User>();
+    api.getMe.mockReturnValue(getMe.promise);
+
+    // Tapping Retry repeatedly used to start overlapping runs whose final
+    // `set` calls raced; the loser's conclusion won.
+    const runs = [
+      useAuthStore.getState().initialize(),
+      useAuthStore.getState().initialize(),
+      useAuthStore.getState().initialize(),
+    ];
+    getMe.resolve(USER);
+    await Promise.all(runs);
+
+    expect(api.getMe).toHaveBeenCalledTimes(1);
+    expect(secureStorage.getSession).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not let a later non-401 run resurrect a session a 401 cleared", async () => {
+    secureStorage.getSession.mockResolvedValue({ token: "expired", user: USER });
+    api.getMe.mockRejectedValue(new ApiError("expired", 401));
+
+    await useAuthStore.getState().initialize();
+
+    // The 401 emptied storage; a subsequent retry must find nothing rather
+    // than write hasToken/user back on top of an invalidated credential.
+    secureStorage.getSession.mockResolvedValue(null);
+    api.getMe.mockRejectedValue(new Error("network unavailable"));
+    await useAuthStore.getState().initialize();
+
+    expect(useAuthStore.getState()).toMatchObject({
+      user: null,
+      hasToken: false,
+      isOffline: false,
+    });
+  });
+});
+
+describe("useAuthStore.verifyCode", () => {
+  it("persists the credential and its snapshot in one write", async () => {
+    api.verifyCode.mockResolvedValue({ token: "fresh", user: USER });
+
+    await useAuthStore.getState().verifyCode("a@example.com", "123456");
+
+    expect(secureStorage.saveSession).toHaveBeenCalledExactlyOnceWith(
+      "fresh",
+      USER,
+    );
+    expect(useAuthStore.getState()).toMatchObject({
+      user: USER,
+      hasToken: true,
+    });
+  });
+});
+
+describe("useAuthStore.setUser", () => {
+  it("updates the snapshot without touching the credential", async () => {
+    const next = { ...USER, email: "renamed@example.com" };
+
+    useAuthStore.getState().setUser(next);
+
+    expect(useAuthStore.getState().user).toEqual(next);
+    expect(secureStorage.saveSessionUser).toHaveBeenCalledWith(next);
+  });
+
+  it("swallows a failed background write instead of rejecting unhandled", async () => {
+    secureStorage.saveSessionUser.mockRejectedValue(new Error("keychain"));
+
+    expect(() => useAuthStore.getState().setUser(USER)).not.toThrow();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(useAuthStore.getState().user).toEqual(USER);
   });
 });

--- a/apps/mobile/data/auth-store.test.ts
+++ b/apps/mobile/data/auth-store.test.ts
@@ -1,0 +1,108 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { User } from "@multica/core/types";
+
+const api = {
+  setToken: vi.fn(),
+  getMe: vi.fn(),
+  sendCode: vi.fn(),
+  verifyCode: vi.fn(),
+};
+
+class ApiError extends Error {
+  constructor(message: string, readonly status: number) {
+    super(message);
+  }
+}
+
+const secureStorage = {
+  clearCachedUser: vi.fn(),
+  clearToken: vi.fn(),
+  getCachedUser: vi.fn(),
+  getToken: vi.fn(),
+  setCachedUser: vi.fn(),
+  setToken: vi.fn(),
+};
+
+vi.mock("./api", () => ({ api, ApiError }));
+vi.mock("./secure-storage", () => secureStorage);
+vi.mock("./workspace-store", () => ({
+  useWorkspaceStore: { getState: () => ({ restoreSlug: vi.fn() }) },
+}));
+
+const { useAuthStore } = await import("./auth-store");
+
+const USER = { id: "user-1", email: "offline@example.com" } as User;
+
+describe("useAuthStore.initialize", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    secureStorage.getToken.mockResolvedValue(null);
+    secureStorage.getCachedUser.mockResolvedValue(null);
+    api.getMe.mockResolvedValue(USER);
+    useAuthStore.setState({
+      user: null,
+      isLoading: true,
+      hasToken: false,
+      isOffline: false,
+    });
+  });
+
+  it("keeps the login gate closed when no token exists", async () => {
+    await useAuthStore.getState().initialize();
+
+    expect(api.getMe).not.toHaveBeenCalled();
+    expect(useAuthStore.getState()).toMatchObject({
+      user: null,
+      hasToken: false,
+      isLoading: false,
+    });
+  });
+
+  it("hydrates a saved user after a non-401 network failure", async () => {
+    secureStorage.getToken.mockResolvedValue("token");
+    secureStorage.getCachedUser.mockResolvedValue(USER);
+    api.getMe.mockRejectedValue(new Error("network unavailable"));
+
+    await useAuthStore.getState().initialize();
+
+    expect(secureStorage.clearToken).not.toHaveBeenCalled();
+    expect(useAuthStore.getState()).toMatchObject({
+      user: USER,
+      hasToken: true,
+      isOffline: true,
+      isLoading: false,
+    });
+  });
+
+  it("keeps a legacy token admitted when offline but no snapshot exists", async () => {
+    secureStorage.getToken.mockResolvedValue("token");
+    api.getMe.mockRejectedValue(new Error("network unavailable"));
+
+    await useAuthStore.getState().initialize();
+
+    expect(secureStorage.clearToken).not.toHaveBeenCalled();
+    expect(useAuthStore.getState()).toMatchObject({
+      user: null,
+      hasToken: true,
+      isOffline: true,
+      isLoading: false,
+    });
+  });
+
+  it("clears the token and cached user on a real 401", async () => {
+    secureStorage.getToken.mockResolvedValue("expired-token");
+    secureStorage.getCachedUser.mockResolvedValue(USER);
+    api.getMe.mockRejectedValue(new ApiError("expired", 401));
+
+    await useAuthStore.getState().initialize();
+
+    expect(secureStorage.clearToken).toHaveBeenCalledOnce();
+    expect(secureStorage.clearCachedUser).toHaveBeenCalledOnce();
+    expect(useAuthStore.getState()).toMatchObject({
+      user: null,
+      hasToken: false,
+      isOffline: false,
+      isLoading: false,
+    });
+  });
+});

--- a/apps/mobile/data/auth-store.ts
+++ b/apps/mobile/data/auth-store.ts
@@ -1,9 +1,9 @@
 /**
  * Mobile auth store — Zustand. Logic mirrors packages/core/auth/store.ts:
  *   - Token written ONLY on successful verifyCode
- *   - 401 → clear token; non-401 (5xx / network blip) → preserve token so
- *     the next launch can retry
- *   - logout = clear token + clear in-memory user + setToken(null)
+ *   - 401 → clear session; non-401 (5xx / network blip) → preserve the
+ *     credential so the next launch can retry
+ *   - logout = clear session + clear in-memory user + setToken(null)
  *
  * NOT shared with web/desktop (per Sharing Principles in root CLAUDE.md).
  * Storage backend is expo-secure-store (mobile only); web uses HttpOnly
@@ -13,12 +13,10 @@ import { create } from "zustand";
 import type { User } from "@multica/core/types";
 import { api, ApiError } from "./api";
 import {
-  clearCachedUser,
-  clearToken,
-  getCachedUser,
-  getToken,
-  setCachedUser,
-  setToken,
+  clearSession,
+  getSession,
+  saveSession,
+  saveSessionUser,
 } from "./secure-storage";
 import { useWorkspaceStore } from "./workspace-store";
 
@@ -38,73 +36,97 @@ interface AuthState {
   setUser: (user: User) => void;
 }
 
-export const useAuthStore = create<AuthState>((set) => ({
-  user: null,
-  isLoading: true,
-  hasToken: false,
-  isOffline: false,
+export const useAuthStore = create<AuthState>((set) => {
+  /**
+   * Initialization is single-flight. Overlapping runs used to race on the
+   * final `set`: a 401 run could clear the session, then a slower non-401 run
+   * would write `hasToken: true` and a user back into the store on top of a
+   * credential the server had already invalidated. Concurrent callers now
+   * share one run, so the last write is always that run's own conclusion.
+   */
+  let inFlight: Promise<void> | null = null;
 
-  initialize: async () => {
-    // Restore the persisted workspace slug alongside the auth token so the
-    // entry redirect (app/index.tsx) can route directly to the last-used
-    // workspace without flashing /select-workspace.
-    await useWorkspaceStore.getState().restoreSlug();
-
-    const token = await getToken();
-    if (!token) {
-      set({ hasToken: false, isLoading: false, isOffline: false });
-      return;
-    }
-    api.setToken(token);
-    const cachedUser = await getCachedUser();
+  const runInitialize = async () => {
+    // isLoading was previously only ever set to false, which left the
+    // /offline Retry button permanently enabled and its spinner unreachable.
+    set({ isLoading: true });
     try {
-      const user = await api.getMe();
-      await setCachedUser(user);
-      set({ user, hasToken: true, isLoading: false, isOffline: false });
-    } catch (err) {
-      // Only clear token on a genuine 401. Network blips / 5xx keep the
-      // token so the next launch (or a manual refresh) can retry.
-      if (err instanceof ApiError && err.status === 401) {
-        await clearToken();
-        await clearCachedUser();
+      // Restore the persisted workspace slug alongside the auth token so the
+      // entry redirect (app/index.tsx) can route directly to the last-used
+      // workspace without flashing /select-workspace.
+      await useWorkspaceStore.getState().restoreSlug();
+
+      const session = await getSession();
+      if (!session) {
         api.setToken(null);
-        set({ user: null, hasToken: false, isLoading: false, isOffline: false });
+        set({ user: null, hasToken: false, isOffline: false });
         return;
       }
-      // A non-401 must never turn a valid local credential into a logout.
-      // An older install may have a token but no snapshot; the route renders
-      // an explicit offline account-info screen rather than /login.
-      set({
-        user: cachedUser,
-        hasToken: true,
-        isLoading: false,
-        isOffline: true,
-      });
+      api.setToken(session.token);
+      try {
+        const user = await api.getMe();
+        await saveSession(session.token, user);
+        set({ user, hasToken: true, isOffline: false });
+      } catch (err) {
+        // Only clear on a genuine 401. Network blips / 5xx keep the
+        // credential so the next launch (or a manual refresh) can retry.
+        if (err instanceof ApiError && err.status === 401) {
+          await clearSession();
+          api.setToken(null);
+          set({ user: null, hasToken: false, isOffline: false });
+          return;
+        }
+        // A non-401 must never turn a valid local credential into a logout.
+        // An older install may have a credential but no snapshot; the route
+        // renders an explicit offline account-info screen rather than /login.
+        set({ user: session.user, hasToken: true, isOffline: true });
+      }
+    } finally {
+      // Landed in one place so an unexpected throw cannot strand the app on
+      // a permanent spinner now that isLoading starts true.
+      set({ isLoading: false });
     }
-  },
+  };
 
-  sendCode: async (email) => {
-    await api.sendCode(email);
-  },
+  return {
+    user: null,
+    isLoading: true,
+    hasToken: false,
+    isOffline: false,
 
-  verifyCode: async (email, code) => {
-    const { token, user } = await api.verifyCode(email, code);
-    await setToken(token);
-    await setCachedUser(user);
-    api.setToken(token);
-    set({ user, hasToken: true, isOffline: false });
-    return user;
-  },
+    initialize: () => {
+      inFlight ??= runInitialize().finally(() => {
+        inFlight = null;
+      });
+      return inFlight;
+    },
 
-  logout: async () => {
-    await clearToken();
-    await clearCachedUser();
-    api.setToken(null);
-    set({ user: null, hasToken: false, isOffline: false });
-  },
+    sendCode: async (email) => {
+      await api.sendCode(email);
+    },
 
-  setUser: (user) => {
-    void setCachedUser(user);
-    set({ user });
-  },
-}));
+    verifyCode: async (email, code) => {
+      const { token, user } = await api.verifyCode(email, code);
+      // One write: there is no instant at which this device holds the new
+      // credential next to the previous account's snapshot.
+      await saveSession(token, user);
+      api.setToken(token);
+      set({ user, hasToken: true, isOffline: false });
+      return user;
+    },
+
+    logout: async () => {
+      await clearSession();
+      api.setToken(null);
+      set({ user: null, hasToken: false, isOffline: false });
+    },
+
+    setUser: (user) => {
+      set({ user });
+      // Persisting the snapshot is best-effort and must not block the UI
+      // edit, but a rejected write still has to be swallowed explicitly —
+      // a bare `void` here surfaced as an unhandled rejection.
+      void saveSessionUser(user).catch(() => {});
+    },
+  };
+});

--- a/apps/mobile/data/auth-store.ts
+++ b/apps/mobile/data/auth-store.ts
@@ -12,12 +12,23 @@
 import { create } from "zustand";
 import type { User } from "@multica/core/types";
 import { api, ApiError } from "./api";
-import { clearToken, getToken, setToken } from "./secure-storage";
+import {
+  clearCachedUser,
+  clearToken,
+  getCachedUser,
+  getToken,
+  setCachedUser,
+  setToken,
+} from "./secure-storage";
 import { useWorkspaceStore } from "./workspace-store";
 
 interface AuthState {
   user: User | null;
   isLoading: boolean;
+  /** Credential presence is distinct from an online account lookup. */
+  hasToken: boolean;
+  /** True when startup fell back to a local user snapshot after a non-401. */
+  isOffline: boolean;
   initialize: () => Promise<void>;
   sendCode: (email: string) => Promise<void>;
   verifyCode: (email: string, code: string) => Promise<User>;
@@ -30,6 +41,8 @@ interface AuthState {
 export const useAuthStore = create<AuthState>((set) => ({
   user: null,
   isLoading: true,
+  hasToken: false,
+  isOffline: false,
 
   initialize: async () => {
     // Restore the persisted workspace slug alongside the auth token so the
@@ -39,21 +52,34 @@ export const useAuthStore = create<AuthState>((set) => ({
 
     const token = await getToken();
     if (!token) {
-      set({ isLoading: false });
+      set({ hasToken: false, isLoading: false, isOffline: false });
       return;
     }
     api.setToken(token);
+    const cachedUser = await getCachedUser();
     try {
       const user = await api.getMe();
-      set({ user, isLoading: false });
+      await setCachedUser(user);
+      set({ user, hasToken: true, isLoading: false, isOffline: false });
     } catch (err) {
       // Only clear token on a genuine 401. Network blips / 5xx keep the
       // token so the next launch (or a manual refresh) can retry.
       if (err instanceof ApiError && err.status === 401) {
         await clearToken();
+        await clearCachedUser();
         api.setToken(null);
+        set({ user: null, hasToken: false, isLoading: false, isOffline: false });
+        return;
       }
-      set({ user: null, isLoading: false });
+      // A non-401 must never turn a valid local credential into a logout.
+      // An older install may have a token but no snapshot; the route renders
+      // an explicit offline account-info screen rather than /login.
+      set({
+        user: cachedUser,
+        hasToken: true,
+        isLoading: false,
+        isOffline: true,
+      });
     }
   },
 
@@ -64,16 +90,21 @@ export const useAuthStore = create<AuthState>((set) => ({
   verifyCode: async (email, code) => {
     const { token, user } = await api.verifyCode(email, code);
     await setToken(token);
+    await setCachedUser(user);
     api.setToken(token);
-    set({ user });
+    set({ user, hasToken: true, isOffline: false });
     return user;
   },
 
   logout: async () => {
     await clearToken();
+    await clearCachedUser();
     api.setToken(null);
-    set({ user: null });
+    set({ user: null, hasToken: false, isOffline: false });
   },
 
-  setUser: (user) => set({ user }),
+  setUser: (user) => {
+    void setCachedUser(user);
+    set({ user });
+  },
 }));

--- a/apps/mobile/data/secure-storage.test.ts
+++ b/apps/mobile/data/secure-storage.test.ts
@@ -1,0 +1,218 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { User } from "@multica/core/types";
+
+/**
+ * The persisted session is the one place where a purely local problem — a
+ * half-finished write, a schema drift, a corrupted value — can either sign a
+ * user out or, worse, show them somebody else's identity. These tests run the
+ * real serialization logic against an in-memory SecureStore so those paths are
+ * actually exercised; auth-store.test.ts mocks this module out entirely and
+ * therefore cannot see any of them.
+ */
+const store = new Map<string, string>();
+
+vi.mock("expo-secure-store", () => ({
+  getItemAsync: vi.fn(async (k: string) => store.get(k) ?? null),
+  setItemAsync: vi.fn(async (k: string, v: string) => {
+    store.set(k, v);
+  }),
+  deleteItemAsync: vi.fn(async (k: string) => {
+    store.delete(k);
+  }),
+}));
+
+const {
+  clearSession,
+  getSession,
+  getToken,
+  saveSession,
+  saveSessionUser,
+} = await import("./secure-storage");
+
+const SESSION_KEY = "multica_session";
+const LEGACY_TOKEN_KEY = "multica_token";
+const LEGACY_USER_KEY = "multica_user";
+
+const USER = {
+  id: "user-1",
+  name: "Ada",
+  email: "ada@example.com",
+  avatar_url: null,
+  onboarded_at: null,
+  onboarding_questionnaire: {},
+  starter_content_state: null,
+  language: null,
+  profile_description: "",
+  timezone: null,
+  created_at: "",
+  updated_at: "",
+} as User;
+
+const OTHER_USER = { ...USER, id: "user-2", email: "grace@example.com" };
+
+beforeEach(() => {
+  store.clear();
+  vi.clearAllMocks();
+});
+
+describe("session record", () => {
+  it("round-trips the credential and its snapshot", async () => {
+    await saveSession("token-1", USER);
+
+    expect(await getSession()).toEqual({ token: "token-1", user: USER });
+  });
+
+  it("writes the credential and the snapshot in a single store write", async () => {
+    const SecureStore = await import("expo-secure-store");
+    await saveSession("token-1", USER);
+
+    // The whole point of the single-key format: there is no instant at which
+    // the device holds a new credential next to the previous snapshot.
+    expect(SecureStore.setItemAsync).toHaveBeenCalledTimes(1);
+    expect(store.has(LEGACY_TOKEN_KEY)).toBe(false);
+    expect(store.has(LEGACY_USER_KEY)).toBe(false);
+  });
+
+  it("never restores one account's snapshot under another's credential", async () => {
+    await saveSession("token-a", USER);
+    await saveSession("token-b", OTHER_USER);
+
+    const session = await getSession();
+    expect(session?.token).toBe("token-b");
+    expect(session?.user?.id).toBe("user-2");
+  });
+
+  it("keeps the credential when only the snapshot fails to parse", async () => {
+    store.set(
+      SESSION_KEY,
+      JSON.stringify({ v: 1, token: "token-1", user: { foo: "bar" } }),
+    );
+
+    // A drifted snapshot degrades to the /offline upgrade screen. Dropping
+    // the token here would reintroduce "a local problem logs you out".
+    expect(await getSession()).toEqual({ token: "token-1", user: null });
+  });
+
+  it("rejects a snapshot whose id is the empty-string drift sentinel", async () => {
+    store.set(
+      SESSION_KEY,
+      JSON.stringify({ v: 1, token: "token-1", user: { ...USER, id: "" } }),
+    );
+
+    expect(await getSession()).toEqual({ token: "token-1", user: null });
+  });
+
+  it("clears an unreadable record instead of trusting a token out of it", async () => {
+    store.set(SESSION_KEY, "{not json");
+
+    expect(await getSession()).toBeNull();
+    expect(store.has(SESSION_KEY)).toBe(false);
+  });
+
+  it("clears a record from an unknown future version", async () => {
+    store.set(SESSION_KEY, JSON.stringify({ v: 2, token: "token-1" }));
+
+    expect(await getSession()).toBeNull();
+    expect(store.has(SESSION_KEY)).toBe(false);
+  });
+});
+
+describe("legacy migration", () => {
+  it("adopts a bare legacy token so an upgrade does not sign the user out", async () => {
+    store.set(LEGACY_TOKEN_KEY, "legacy-token");
+
+    expect(await getSession()).toEqual({ token: "legacy-token", user: null });
+    expect(store.has(LEGACY_TOKEN_KEY)).toBe(false);
+    expect(JSON.parse(store.get(SESSION_KEY)!)).toMatchObject({
+      v: 1,
+      token: "legacy-token",
+    });
+  });
+
+  it("carries a valid legacy snapshot across with its token", async () => {
+    store.set(LEGACY_TOKEN_KEY, "legacy-token");
+    store.set(LEGACY_USER_KEY, JSON.stringify(USER));
+
+    expect(await getSession()).toEqual({ token: "legacy-token", user: USER });
+    expect(store.has(LEGACY_USER_KEY)).toBe(false);
+  });
+
+  it("drops a corrupted legacy snapshot but keeps the legacy token", async () => {
+    store.set(LEGACY_TOKEN_KEY, "legacy-token");
+    store.set(LEGACY_USER_KEY, "{not json");
+
+    expect(await getSession()).toEqual({ token: "legacy-token", user: null });
+  });
+
+  it("deletes an orphaned legacy snapshot that has no credential", async () => {
+    store.set(LEGACY_USER_KEY, JSON.stringify(USER));
+
+    expect(await getSession()).toBeNull();
+    // Left on disk it would be adopted by whatever token is written next.
+    expect(store.has(LEGACY_USER_KEY)).toBe(false);
+  });
+
+  it("is idempotent when the previous migration was interrupted mid-way", async () => {
+    // Killed after SESSION_KEY was written but before the legacy keys went.
+    await saveSession("token-1", USER);
+    store.set(LEGACY_TOKEN_KEY, "legacy-token");
+
+    expect(await getSession()).toEqual({ token: "token-1", user: USER });
+  });
+});
+
+describe("clearSession", () => {
+  it("removes the legacy keys too, so nothing resurrects the session", async () => {
+    store.set(LEGACY_TOKEN_KEY, "legacy-token");
+    store.set(LEGACY_USER_KEY, JSON.stringify(USER));
+    await saveSession("token-1", USER);
+
+    await clearSession();
+
+    expect(store.size).toBe(0);
+    expect(await getSession()).toBeNull();
+  });
+
+  it("deletes the legacy token before the current record", async () => {
+    const SecureStore = await import("expo-secure-store");
+    await clearSession();
+
+    const order = vi
+      .mocked(SecureStore.deleteItemAsync)
+      .mock.calls.map(([key]) => key);
+    expect(order.indexOf(LEGACY_TOKEN_KEY)).toBeLessThan(
+      order.indexOf(SESSION_KEY),
+    );
+  });
+});
+
+describe("saveSessionUser", () => {
+  it("replaces the snapshot without disturbing the credential", async () => {
+    await saveSession("token-1", USER);
+
+    await saveSessionUser({ ...USER, name: "Ada L." });
+
+    expect(await getSession()).toEqual({
+      token: "token-1",
+      user: { ...USER, name: "Ada L." },
+    });
+  });
+
+  it("writes nothing when there is no session to bind the snapshot to", async () => {
+    await saveSessionUser(USER);
+
+    expect(store.size).toBe(0);
+  });
+});
+
+describe("getToken", () => {
+  it("reads through the session record", async () => {
+    await saveSession("token-1", USER);
+
+    expect(await getToken()).toBe("token-1");
+  });
+
+  it("returns null when there is no session", async () => {
+    expect(await getToken()).toBeNull();
+  });
+});

--- a/apps/mobile/data/secure-storage.ts
+++ b/apps/mobile/data/secure-storage.ts
@@ -1,47 +1,155 @@
 /**
- * Thin wrapper around expo-secure-store for the auth token.
- * Keyed identically to web/desktop ("multica_token") so logic stays aligned
- * with packages/core/auth/store.ts even though storage backends differ.
+ * Thin wrapper around expo-secure-store for the persisted auth session.
+ *
+ * The credential and the last-known-good user snapshot live in ONE record
+ * under ONE key, written with a single setItemAsync. Two independent keys
+ * (the previous "multica_token" + "multica_user" pair) could not be updated
+ * atomically: a process kill between the two writes left token B next to
+ * user A, and the next offline cold start would enter the app showing A's
+ * identity while every request carried B's token. One key, one write, no
+ * intermediate state.
+ *
+ * Web/desktop still key on "multica_token" (packages/core/auth/store.ts);
+ * mobile deliberately diverges because only mobile persists a snapshot to
+ * survive an offline cold start. Legacy "multica_token" installs migrate on
+ * first read — see migrateLegacySession.
  */
 import * as SecureStore from "expo-secure-store";
+import { z } from "zod";
 import type { User } from "@multica/core/types";
+import { UserSchema } from "./schemas";
 
-const TOKEN_KEY = "multica_token";
-const USER_KEY = "multica_user";
+const SESSION_KEY = "multica_session";
+const LEGACY_TOKEN_KEY = "multica_token";
+const LEGACY_USER_KEY = "multica_user";
 
-export async function getToken(): Promise<string | null> {
-  return SecureStore.getItemAsync(TOKEN_KEY);
-}
-
-export async function setToken(token: string): Promise<void> {
-  await SecureStore.setItemAsync(TOKEN_KEY, token);
-}
-
-export async function clearToken(): Promise<void> {
-  await SecureStore.deleteItemAsync(TOKEN_KEY);
+export interface Session {
+  token: string;
+  /** null = credential present, account details not available locally. */
+  user: User | null;
 }
 
 /**
- * A last-known-good account snapshot lets an otherwise valid session enter
- * the app when a cold start cannot reach the API. It is not an auth decision:
- * the server's 401 response remains the only signal that invalidates a token.
+ * The envelope is validated separately from the snapshot on purpose. A
+ * snapshot that fails validation must NOT invalidate the credential next to
+ * it — dropping the token there would recreate the very bug this file exists
+ * to prevent (a local problem logging the user out). Envelope damage is
+ * different: if we cannot trust the record's shape we cannot trust the token
+ * we would read out of it either, so that case clears everything.
  */
-export async function getCachedUser(): Promise<User | null> {
-  const raw = await SecureStore.getItemAsync(USER_KEY);
-  if (!raw) return null;
+const SessionEnvelopeSchema = z.object({
+  v: z.literal(1),
+  token: z.string().min(1),
+  user: z.unknown().nullable().default(null),
+});
+
+/**
+ * `JSON.parse(raw) as User` only ever fails on a syntax error, so any
+ * syntactically valid JSON — including a snapshot written by an older app
+ * version whose User shape has since drifted — used to be accepted as a
+ * verified account. This is a persistence boundary feeding an auth entry
+ * point, so it parses (root CLAUDE.md, "Parse, don't cast").
+ */
+function parseUser(value: unknown): User | null {
+  if (value == null) return null;
+  const parsed = UserSchema.safeParse(value);
+  // UserSchema's `id: z.string()` accepts "", which schemas.ts uses as the
+  // "drifted / unauthenticated" sentinel. Never restore that as a session.
+  if (!parsed.success || !parsed.data.id) return null;
+  return parsed.data;
+}
+
+function serialize(session: Session): string {
+  return JSON.stringify({ v: 1, token: session.token, user: session.user });
+}
+
+export async function getSession(): Promise<Session | null> {
+  const raw = await SecureStore.getItemAsync(SESSION_KEY);
+  if (raw === null) return migrateLegacySession();
+
+  let decoded: unknown;
   try {
-    return JSON.parse(raw) as User;
+    decoded = JSON.parse(raw);
   } catch {
-    // Treat corrupted local state as absent instead of preventing startup.
-    await SecureStore.deleteItemAsync(USER_KEY);
+    await SecureStore.deleteItemAsync(SESSION_KEY);
     return null;
   }
+  const envelope = SessionEnvelopeSchema.safeParse(decoded);
+  if (!envelope.success) {
+    await SecureStore.deleteItemAsync(SESSION_KEY);
+    return null;
+  }
+  return { token: envelope.data.token, user: parseUser(envelope.data.user) };
 }
 
-export async function setCachedUser(user: User): Promise<void> {
-  await SecureStore.setItemAsync(USER_KEY, JSON.stringify(user));
+export async function saveSession(
+  token: string,
+  user: User | null,
+): Promise<void> {
+  await SecureStore.setItemAsync(SESSION_KEY, serialize({ token, user }));
 }
 
-export async function clearCachedUser(): Promise<void> {
-  await SecureStore.deleteItemAsync(USER_KEY);
+/**
+ * Replace only the snapshot, keeping the credential it is bound to. No-ops
+ * when there is no session — a snapshot without a credential is unusable and
+ * must never be left on disk for a later token to adopt.
+ */
+export async function saveSessionUser(user: User): Promise<void> {
+  const session = await getSession();
+  if (!session) return;
+  await saveSession(session.token, user);
+}
+
+/**
+ * Legacy keys are deleted BEFORE the current one. The reverse order has a
+ * resurrection window: killed after SESSION_KEY is gone but before the legacy
+ * token is, the next cold start finds no session, migrates the stale legacy
+ * token, and signs a logged-out user back in.
+ */
+export async function clearSession(): Promise<void> {
+  await SecureStore.deleteItemAsync(LEGACY_USER_KEY);
+  await SecureStore.deleteItemAsync(LEGACY_TOKEN_KEY);
+  await SecureStore.deleteItemAsync(SESSION_KEY);
+}
+
+/** Kept for realtime-provider, which only needs the credential. */
+export async function getToken(): Promise<string | null> {
+  return (await getSession())?.token ?? null;
+}
+
+/**
+ * Installs that predate the single-record format hold a bare
+ * "multica_token". Root CLAUDE.md forbids legacy adapters for internal,
+ * non-boundary code — on-device storage written by an already-distributed
+ * build is the boundary case, in the same sense API response parsing is:
+ * without this read every existing install would be signed out by the
+ * upgrade itself, which is the exact failure this PR exists to remove.
+ *
+ * Idempotent — SESSION_KEY is written before the legacy keys are removed, so
+ * an interrupted migration simply runs again on the next read.
+ */
+async function migrateLegacySession(): Promise<Session | null> {
+  const token = await SecureStore.getItemAsync(LEGACY_TOKEN_KEY);
+  const rawUser = await SecureStore.getItemAsync(LEGACY_USER_KEY);
+
+  if (token === null) {
+    // Orphaned snapshot: no credential can ever be proven to own it.
+    if (rawUser !== null) await SecureStore.deleteItemAsync(LEGACY_USER_KEY);
+    return null;
+  }
+
+  let user: User | null = null;
+  if (rawUser !== null) {
+    try {
+      user = parseUser(JSON.parse(rawUser));
+    } catch {
+      user = null;
+    }
+  }
+
+  const session: Session = { token, user };
+  await SecureStore.setItemAsync(SESSION_KEY, serialize(session));
+  await SecureStore.deleteItemAsync(LEGACY_USER_KEY);
+  await SecureStore.deleteItemAsync(LEGACY_TOKEN_KEY);
+  return session;
 }

--- a/apps/mobile/data/secure-storage.ts
+++ b/apps/mobile/data/secure-storage.ts
@@ -4,8 +4,10 @@
  * with packages/core/auth/store.ts even though storage backends differ.
  */
 import * as SecureStore from "expo-secure-store";
+import type { User } from "@multica/core/types";
 
 const TOKEN_KEY = "multica_token";
+const USER_KEY = "multica_user";
 
 export async function getToken(): Promise<string | null> {
   return SecureStore.getItemAsync(TOKEN_KEY);
@@ -17,4 +19,29 @@ export async function setToken(token: string): Promise<void> {
 
 export async function clearToken(): Promise<void> {
   await SecureStore.deleteItemAsync(TOKEN_KEY);
+}
+
+/**
+ * A last-known-good account snapshot lets an otherwise valid session enter
+ * the app when a cold start cannot reach the API. It is not an auth decision:
+ * the server's 401 response remains the only signal that invalidates a token.
+ */
+export async function getCachedUser(): Promise<User | null> {
+  const raw = await SecureStore.getItemAsync(USER_KEY);
+  if (!raw) return null;
+  try {
+    return JSON.parse(raw) as User;
+  } catch {
+    // Treat corrupted local state as absent instead of preventing startup.
+    await SecureStore.deleteItemAsync(USER_KEY);
+    return null;
+  }
+}
+
+export async function setCachedUser(user: User): Promise<void> {
+  await SecureStore.setItemAsync(USER_KEY, JSON.stringify(user));
+}
+
+export async function clearCachedUser(): Promise<void> {
+  await SecureStore.deleteItemAsync(USER_KEY);
 }


### PR DESCRIPTION
## What does this PR do?

Fix the mobile cold-start path that treated an unavailable `getMe` request as a logout. A valid local token remains admitted offline when a saved user snapshot exists; a server 401 still clears the local session.

## Related Issue

Closes #6614

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Refactor / code improvement (no behavior change)
- [ ] Documentation update
- [x] Tests (adding or improving test coverage)
- [ ] CI / infrastructure

## Changes Made

- Store the last verified user snapshot beside the existing token.
- Distinguish credential presence from an online account lookup in auth route guards.
- Preserve the explicit offline account-information screen for legacy sessions that have a token but no snapshot.
- Clear the token and snapshot on a genuine server 401.

## How to Test

Run `pnpm --filter @multica/mobile exec vitest run data/auth-store.test.ts`.

The test covers no token, non-401 failure with a snapshot, non-401 failure without a snapshot, and 401 cleanup.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots (device access was unavailable in this run)
- [ ] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] I will address all reviewer comments before requesting merge

## Risks

This patch intentionally does not persist query data, drafts, or mutation queues, and adds no dependencies. A valid local credential is not treated as proof of a valid session: the server's 401 response remains authoritative and clears both stored values.

## AI Disclosure

**AI tool used:** Codex

**Prompt / approach:** Traced the cold-start auth route and separated credential presence from the account lookup. Added isolated tests for the four initialization branches.

## Screenshots (optional)

Not included because an authenticated iOS device was not available in this run.
