### PR TITLE
MUL-5842: fix(ui): drop the write-only sidebar_state cookie and align the settings nav trigger

### DIFF
--- a/packages/ui/components/ui/sidebar.tsx
+++ b/packages/ui/components/ui/sidebar.tsx
@@ -26,8 +26,6 @@ import {
 } from "@multica/ui/components/ui/tooltip"
 import { PanelLeftIcon } from "lucide-react"
 
-const SIDEBAR_COOKIE_NAME = "sidebar_state"
-const SIDEBAR_COOKIE_MAX_AGE = 60 * 60 * 24 * 7
 const SIDEBAR_WIDTH_DEFAULT = 256
 const SIDEBAR_WIDTH_MIN = 200
 const SIDEBAR_WIDTH_MAX = 360
@@ -124,6 +122,15 @@ function SidebarProvider({
 
   // This is the internal state of the sidebar.
   // We use openProp and setOpenProp for control from outside the component.
+  //
+  // Deliberately not persisted. Upstream shadcn writes a `sidebar_state` cookie
+  // here and seeds `defaultOpen` from it on the server; we dropped the write
+  // because nothing ever read it, and restoring the pair would be a bug rather
+  // than a feature: the auto-collapse below drives `setOpen(false)` from the
+  // viewport, so persisting its result would carry a collapse the user never
+  // asked for out of the `lg`–`xl` band and into their next session on a wider
+  // display. Persisting this needs a source that distinguishes a user toggle
+  // from an automated one — not a cookie on this callback.
   const [_open, _setOpen] = React.useState(defaultOpen)
   const open = openProp ?? _open
   const setOpen = React.useCallback(
@@ -134,9 +141,6 @@ function SidebarProvider({
       } else {
         _setOpen(openState)
       }
-
-      // This sets the cookie to keep the sidebar state.
-      document.cookie = `${SIDEBAR_COOKIE_NAME}=${openState}; path=/; max-age=${SIDEBAR_COOKIE_MAX_AGE}`
     },
     [setOpenProp, open]
   )

--- a/packages/views/layout/sidebar-auto-collapse.test.tsx
+++ b/packages/views/layout/sidebar-auto-collapse.test.tsx
@@ -170,4 +170,26 @@ describe("sidebar auto-collapse between lg and xl", () => {
 
     expect(state()).toBe("expanded");
   });
+
+  it("never persists the open state, however it changed", () => {
+    // The guard for the trap upstream shadcn sets: it writes a `sidebar_state`
+    // cookie in `setOpen` and seeds `defaultOpen` from it server-side. Because
+    // the auto-collapse above drives `setOpen(false)` from the viewport rather
+    // than from the user, wiring that pair back up would carry a collapse
+    // nobody asked for out of this band and into the next session on a wider
+    // display. Asserted for both paths — a real toggle and a crossing — since
+    // it is the crossing that makes persistence wrong here.
+    renderWithI18n(
+      <SidebarProvider>
+        <Probe />
+      </SidebarProvider>,
+    );
+
+    fireEvent.click(screen.getByTestId("state"));
+    expect(document.cookie).not.toContain("sidebar_state");
+
+    setWidth(1100);
+    expect(state()).toBe("collapsed");
+    expect(document.cookie).not.toContain("sidebar_state");
+  });
 });

--- a/packages/views/settings/components/settings-page.tsx
+++ b/packages/views/settings/components/settings-page.tsx
@@ -161,9 +161,12 @@ export function SettingsPage({ extraAccountTabs }: SettingsPageProps = {}) {
         {/* This page builds its own chrome instead of a PageHeader, so it has
             to supply the nav trigger itself — below `xl` the nav is a sheet or
             auto-collapsed, and settings has no other way back to it. */}
-        <div className="flex items-center">
+        {/* The gap below this row belongs to the row, not to the heading: with
+            `items-center`, a bottom margin on the `h1` is part of the box being
+            centred, so it offsets the heading against the trigger beside it. */}
+        <div className="flex items-center md:mb-4">
           <CollapsedNavTrigger />
-          <h1 className="sr-only text-body font-semibold md:not-sr-only md:mb-4 md:px-2">{t(($) => $.page.title)}</h1>
+          <h1 className="sr-only text-body font-semibold md:not-sr-only md:px-2">{t(($) => $.page.title)}</h1>
         </div>
         <TabsList
           variant="line"


### PR DESCRIPTION
## What does this PR do?

Two follow-ups from the review of #6543, neither of which blocked that merge. They are unrelated to each other beyond both being raised in that thread, so they are separate commits.

**Thinking path (project context → change).** #6543 folded Inbox and Chat to one column below `lg` and added an auto-collapse across the `lg`–`xl` band. Reviewing it surfaced one cosmetic defect in the settings header it introduced, and one pre-existing hazard in `SidebarProvider` that the auto-collapse newly made dangerous. The second is the substantive one.

### 1. Drop the write-only `sidebar_state` cookie

`setOpen` wrote a `sidebar_state` cookie that **nothing in this repo has ever read** — no `defaultOpen` is sourced from it, on the server or anywhere else.

Dead code would normally be harmless, but this is one half of an upstream mechanism: shadcn pairs that write with seeding `defaultOpen` from the cookie server-side, and that pairing is what its docs tell you to do. Completing it here would be a bug, not a feature, because #6543 changed what `setOpen(false)` means. The auto-collapse drives it **from the viewport rather than from the user**, so persisting the result carries a collapse nobody asked for out of the band and into the next session on a wider display:

> a tablet user at 1100px gets an automatic collapse → the cookie records `false` → they open the app on a 1440px display and the nav is collapsed, with nothing to explain why.

So the write is removed rather than annotated, and the reason the state is deliberately not persisted is recorded at the declaration. Persisting it later would need a source that distinguishes a user toggle from an automated one — not a cookie on this callback.

The new test in `sidebar-auto-collapse.test.tsx` asserts the invariant across both paths that reach `setOpen` — a real toggle and a band crossing — since it is the crossing that makes persistence wrong. I verified it is not vacuous: restoring the cookie write makes it fail, and it was the only failure.

### 2. Centre the nav trigger against the settings heading

`settings-page.tsx` gained a nav trigger in #6543, in a `flex items-center` row with the `h1`. The `h1` kept `md:mb-4`, and `align-items: center` centres an item's **margin box** — so that margin counted as part of the heading and offset it against the trigger between `md` and `xl`.

The gap moves to the row, which is what it always described: spacing below the header block, not below the heading. Spacing at `md`+ is unchanged, and above `xl` the trigger is `display: none` and therefore not a flex item at all, so that layout is untouched.

## Related Issue

Follow-up to #6543 / #6539. MUL-5842.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `packages/ui/components/ui/sidebar.tsx` — remove the `document.cookie` write and the two now-unused constants; document why the open state is not persisted.
- `packages/views/layout/sidebar-auto-collapse.test.tsx` — assert the open state is never persisted, via a toggle and via a crossing.
- `packages/views/settings/components/settings-page.tsx` — move `md:mb-4` from the `h1` to the row.

3 files, +36/−7.

## How to Test

1. At ~1100px, toggle the nav and confirm no `sidebar_state` cookie appears in devtools; drag across 1280px and confirm the same.
2. Confirm nav behavior is otherwise unchanged — auto-collapse entering the band, restore on exit, sheet below 1024px.
3. Open Settings between `md` and `xl` and confirm the trigger and heading sit on a shared centre line, with the gap below the row unchanged.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] UI change — item 2 is a sub-pixel-scale alignment fix; the described devtools check is more legible than a screenshot
- [ ] Documentation — no page documents sidebar persistence or the settings header
- [x] I have considered and documented the risks above
- [x] I will address reviewer comments before requesting merge

## Verification

Run locally on this branch:

- `pnpm typecheck` — 6/6 tasks pass.
- `pnpm test` — 5/5 tasks pass (views 317 files / 3733 tests; core 1345; desktop 442; web 188; docs 17).
- `pnpm lint` — 0 errors; none of the three changed files carry a warning.
- Negative control: re-adding the cookie write fails the new test and only that test.

## Risks

Low. The removed write had no reader, so nothing can regress from losing it; the behavior change is strictly "a cookie is no longer set". The settings change is CSS-only and does not alter spacing at any breakpoint. Rollback is a revert of either commit independently.

## AI Disclosure

**AI tool used:** Claude Code (Claude models), as the Multica agent J.

**Prompt / approach:** Both items were found while reviewing #6543 and are implemented here at a maintainer's direction. The hazard analysis in item 1 was corroborated independently by that PR's author, who reached the same write-only finding and suggested guarding it. Verification commands above were run on this branch; the negative control for the new test was run explicitly rather than assumed.
