### PR TITLE
MUL-5917, YTO-17: detect WorkBuddy’s bundled CodeBuddy CLI

### DIFF
--- a/apps/docs/content/docs/install-agent-runtime.ja.mdx
+++ b/apps/docs/content/docs/install-agent-runtime.ja.mdx
@@ -38,6 +38,10 @@ Multica は現在、次のコマンドを検出します。
 
 ここでの「対応」とは、Multica が該当する CLI を呼び出せるという意味です。そのツールのアカウント、サブスクリプション、モデルの利用枠を Multica が提供するわけではありません。
 
+<Callout type="info">
+macOS では、[Tencent WorkBuddy](https://copilot.tencent.com/work/) をインストールするだけで CodeBuddy を利用できます。Multica は設定されたパスと `PATH` を確認した後、`/Applications/WorkBuddy.app` または `~/Applications/WorkBuddy.app` に同梱された `codebuddy` CLI を検出します。デーモンを起動する前に WorkBuddy でログインを完了してください。Tencent の [ヘッドレスモード](https://copilot.tencent.com/docs/cli/headless)に、このプログラムインターフェースの説明があります。
+</Callout>
+
 ## 2. ローカル環境でログインする
 
 インストール後、まずターミナルからツールを単独で起動し、各ツールの手順に従ってログインするか、モデルプロバイダーを設定してください。ターミナル上でリクエストを実行できない場合は、デーモンから呼び出しても失敗します。

--- a/apps/docs/content/docs/install-agent-runtime.ko.mdx
+++ b/apps/docs/content/docs/install-agent-runtime.ko.mdx
@@ -38,6 +38,10 @@ Multica는 현재 다음 명령을 감지합니다.
 
 "지원됨"은 Multica가 해당 CLI를 호출할 수 있다는 뜻이며 Multica가 도구의 계정, 구독, 모델 사용량을 제공한다는 뜻은 아닙니다.
 
+<Callout type="info">
+macOS에서는 [Tencent WorkBuddy](https://copilot.tencent.com/work/)만 설치해도 CodeBuddy를 사용할 수 있습니다. Multica는 설정된 경로와 `PATH`를 확인한 뒤 `/Applications/WorkBuddy.app` 또는 `~/Applications/WorkBuddy.app`에 포함된 `codebuddy` CLI를 검색합니다. 데몬을 시작하기 전에 WorkBuddy에서 로그인을 완료하세요. Tencent의 [헤드리스 모드 문서](https://copilot.tencent.com/docs/cli/headless)에서 이 프로그래밍 인터페이스를 설명합니다.
+</Callout>
+
 ## 2. 로컬에서 로그인 완료
 
 설치 후 터미널에서 도구를 한 번 직접 실행하고 도구 자체의 절차에 따라 로그인하거나 모델 서비스를 설정합니다. 터미널에서 요청을 완료하지 못하면 데몬이 호출할 때도 실패합니다.

--- a/apps/docs/content/docs/install-agent-runtime.mdx
+++ b/apps/docs/content/docs/install-agent-runtime.mdx
@@ -38,6 +38,10 @@ Multica currently detects these commands:
 
 "Supported" means Multica can invoke that CLI. It does not mean Multica provides the tool's account, subscription, or model quota for you.
 
+<Callout type="info">
+On macOS, installing [Tencent WorkBuddy](https://copilot.tencent.com/work/) is also enough for CodeBuddy. After checking the configured path and `PATH`, Multica detects the `codebuddy` CLI bundled in `/Applications/WorkBuddy.app` or `~/Applications/WorkBuddy.app`. Complete WorkBuddy's sign-in before starting the daemon. Tencent documents this programmatic interface in [Headless mode](https://copilot.tencent.com/docs/cli/headless).
+</Callout>
+
 ## 2. Sign in on your machine
 
 After installing, launch the tool once in a terminal on its own and complete its sign-in or model provider setup. If the tool cannot complete requests in the terminal, the daemon's invocations fail the same way.

--- a/apps/docs/content/docs/install-agent-runtime.zh.mdx
+++ b/apps/docs/content/docs/install-agent-runtime.zh.mdx
@@ -38,6 +38,10 @@ Multica 当前会检测以下命令：
 
 "受支持"表示 Multica 能够调用对应 CLI，不代表 Multica 会替你提供该工具的账号、订阅或模型额度。
 
+<Callout type="info">
+在 macOS 安装[腾讯 WorkBuddy](https://copilot.tencent.com/work/)后，也可以直接使用 CodeBuddy。Multica 会先检查配置路径和 `PATH`，再检测 `/Applications/WorkBuddy.app` 或 `~/Applications/WorkBuddy.app` 内置的 `codebuddy` CLI。启动守护进程前，请先在 WorkBuddy 完成登录。腾讯的[无界面模式文档](https://copilot.tencent.com/docs/cli/headless)介绍了这套编程接口。
+</Callout>
+
 ## 2. 在本机完成登录
 
 安装后，先在终端中单独启动一次工具，并按照它自己的流程登录或配置模型服务。工具在终端中无法完成请求时，守护进程调用它同样会失败。

--- a/server/internal/daemon/agents_probe.go
+++ b/server/internal/daemon/agents_probe.go
@@ -143,6 +143,20 @@ var probeAgentCLIs = func() map[string]AgentEntry {
 				}
 			}
 		}
+		if defaultCmd == "codebuddy" && cmd == defaultCmd {
+			// WorkBuddy bundles an executable CodeBuddy CLI in its macOS app
+			// resources without installing a global command. Its entrypoint is
+			// a Node script, so also expose WorkBuddy's staged Node runtime.
+			for _, p := range workbuddyDesktopAppBundlePaths() {
+				if isExecutableFile(p) && ensureWorkBuddyNodeOnPath() {
+					return AgentEntry{
+						Path:    p,
+						Command: cmd,
+						Model:   strings.TrimSpace(os.Getenv(modelEnv)),
+					}, true
+				}
+			}
+		}
 		return AgentEntry{}, false
 	}
 

--- a/server/internal/daemon/agents_probe_workbuddy_test.go
+++ b/server/internal/daemon/agents_probe_workbuddy_test.go
@@ -1,0 +1,127 @@
+//go:build !windows
+
+package daemon
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func stageWorkBuddyCLI(t *testing.T) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "WorkBuddy.app", "Contents", "Resources", "app.asar.unpacked", "cli", "bin", "codebuddy")
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("create fake WorkBuddy bundle: %v", err)
+	}
+	if err := os.WriteFile(path, []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
+		t.Fatalf("write fake WorkBuddy CLI: %v", err)
+	}
+	return path
+}
+
+func stubWorkBuddyDiscovery(t *testing.T, paths []string) {
+	t.Helper()
+	home := t.TempDir()
+	nodePath := filepath.Join(home, ".workbuddy", "binaries", "node", "versions", "22.22.2", "bin", "node")
+	if err := os.MkdirAll(filepath.Dir(nodePath), 0o755); err != nil {
+		t.Fatalf("create fake WorkBuddy Node runtime: %v", err)
+	}
+	if err := os.WriteFile(nodePath, []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
+		t.Fatalf("write fake WorkBuddy Node runtime: %v", err)
+	}
+	originalBundlePaths := workbuddyDesktopAppBundlePaths
+	originalShellResolver := resolveAgentsViaLoginShell
+	workbuddyDesktopAppBundlePaths = func() []string { return paths }
+	resolveAgentsViaLoginShell = func([]string) map[string]string { return map[string]string{} }
+	t.Cleanup(func() {
+		workbuddyDesktopAppBundlePaths = originalBundlePaths
+		resolveAgentsViaLoginShell = originalShellResolver
+	})
+	resetShellResolveCacheForTest(t)
+	t.Setenv("PATH", t.TempDir())
+	t.Setenv("HOME", home)
+	t.Setenv("MULTICA_CODEBUDDY_PATH", "")
+}
+
+func TestProbeAgentCLIs_UsesWorkBuddyAppBundleFallback(t *testing.T) {
+	fakeCodeBuddy := stageWorkBuddyCLI(t)
+	stubWorkBuddyDiscovery(t, []string{fakeCodeBuddy})
+	t.Setenv("MULTICA_CODEBUDDY_MODEL", "deepseek-v3-2-volc")
+
+	entry, ok := probeAgentCLIs()["codebuddy"]
+	if !ok {
+		t.Fatal("codebuddy was not discovered from the WorkBuddy app bundle")
+	}
+	if entry.Path != fakeCodeBuddy {
+		t.Fatalf("codebuddy path = %q, want WorkBuddy CLI %q", entry.Path, fakeCodeBuddy)
+	}
+	if entry.Command != "codebuddy" {
+		t.Fatalf("codebuddy command = %q, want codebuddy", entry.Command)
+	}
+	if entry.Model != "deepseek-v3-2-volc" {
+		t.Fatalf("codebuddy model = %q, want deepseek-v3-2-volc", entry.Model)
+	}
+	if _, err := os.Stat(filepath.Join(os.Getenv("HOME"), ".workbuddy", "binaries", "node", "versions", "22.22.2", "bin", "node")); err != nil {
+		t.Fatalf("staged WorkBuddy Node runtime is missing: %v", err)
+	}
+	if got := filepath.SplitList(os.Getenv("PATH"))[0]; got != filepath.Join(os.Getenv("HOME"), ".workbuddy", "binaries", "node", "versions", "22.22.2", "bin") {
+		t.Fatalf("PATH = %q, want WorkBuddy Node directory first", os.Getenv("PATH"))
+	}
+}
+
+func TestProbeAgentCLIs_CodeBuddyPathPrecedesWorkBuddyBundle(t *testing.T) {
+	fakeBundleCLI := stageWorkBuddyCLI(t)
+	stubWorkBuddyDiscovery(t, []string{fakeBundleCLI})
+
+	pathCLI := filepath.Join(t.TempDir(), "codebuddy")
+	if err := os.WriteFile(pathCLI, []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
+		t.Fatalf("write PATH CodeBuddy CLI: %v", err)
+	}
+	t.Setenv("PATH", filepath.Dir(pathCLI))
+
+	entry, ok := probeAgentCLIs()["codebuddy"]
+	if !ok {
+		t.Fatal("codebuddy was not discovered from PATH")
+	}
+	if entry.Path != canonicalExecutablePath(pathCLI) {
+		t.Fatalf("codebuddy path = %q, want PATH CLI %q", entry.Path, canonicalExecutablePath(pathCLI))
+	}
+}
+
+func TestProbeAgentCLIs_MissingExplicitCodeBuddyPathDoesNotUseWorkBuddyBundle(t *testing.T) {
+	fakeCodeBuddy := stageWorkBuddyCLI(t)
+	stubWorkBuddyDiscovery(t, []string{fakeCodeBuddy})
+	t.Setenv("MULTICA_CODEBUDDY_PATH", filepath.Join(t.TempDir(), "missing-codebuddy"))
+
+	if entry, ok := probeAgentCLIs()["codebuddy"]; ok {
+		t.Fatalf("missing explicit MULTICA_CODEBUDDY_PATH fell back to %q", entry.Path)
+	}
+}
+
+func TestProbeAgentCLIs_WorkBuddyBundleRequiresNodeRuntime(t *testing.T) {
+	fakeCodeBuddy := stageWorkBuddyCLI(t)
+	stubWorkBuddyDiscovery(t, []string{fakeCodeBuddy})
+	originalNodePaths := workbuddyNodeBinaryPaths
+	workbuddyNodeBinaryPaths = func() []string { return nil }
+	t.Cleanup(func() { workbuddyNodeBinaryPaths = originalNodePaths })
+
+	if entry, ok := probeAgentCLIs()["codebuddy"]; ok {
+		t.Fatalf("WorkBuddy bundle without a Node runtime was registered at %q", entry.Path)
+	}
+}
+
+func TestWorkBuddyDesktopAppBundlePaths_PrefersSystemInstallation(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	paths := workbuddyDesktopAppBundlePaths()
+	wantSystem := "/Applications/WorkBuddy.app/Contents/Resources/app.asar.unpacked/cli/bin/codebuddy"
+	wantUser := filepath.Join(home, "Applications", "WorkBuddy.app", "Contents", "Resources", "app.asar.unpacked", "cli", "bin", "codebuddy")
+	if len(paths) != 2 {
+		t.Fatalf("WorkBuddy bundle paths = %#v, want system and user candidates", paths)
+	}
+	if paths[0] != wantSystem || paths[1] != wantUser {
+		t.Fatalf("WorkBuddy bundle paths = %#v, want [%q %q]", paths, wantSystem, wantUser)
+	}
+}

--- a/server/internal/daemon/config.go
+++ b/server/internal/daemon/config.go
@@ -776,6 +776,65 @@ var codexDesktopAppBundlePaths = func() []string {
 	return paths
 }
 
+// workbuddyDesktopAppBundlePaths returns the executable CodeBuddy CLI bundled
+// with Tencent WorkBuddy for macOS. WorkBuddy does not install `codebuddy` on
+// PATH, but its unpacked Electron resources contain the same headless CLI that
+// the built-in CodeBuddy backend drives. Prefer the system-wide installation
+// before the per-user Applications directory.
+var workbuddyDesktopAppBundlePaths = func() []string {
+	const relative = "WorkBuddy.app/Contents/Resources/app.asar.unpacked/cli/bin/codebuddy"
+	paths := []string{filepath.Join("/Applications", relative)}
+	if home, err := os.UserHomeDir(); err == nil {
+		paths = append(paths, filepath.Join(home, "Applications", relative))
+	}
+	return paths
+}
+
+// workbuddyNodeBinaryPaths returns Node versions staged by WorkBuddy for its
+// bundled CLI. The `codebuddy` entrypoint is a Node script, so a GUI-launched
+// Multica daemon cannot rely on a system `node` being present on PATH.
+var workbuddyNodeBinaryPaths = func() []string {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return nil
+	}
+	paths, err := filepath.Glob(filepath.Join(home, ".workbuddy", "binaries", "node", "versions", "*", "bin", "node"))
+	if err != nil {
+		return nil
+	}
+	return paths
+}
+
+// ensureWorkBuddyNodeOnPath makes the staged Node runtime available to the
+// bundled CodeBuddy script. It is intentionally called only after the bundle
+// itself wins discovery, so unrelated agent launches keep their environment.
+func ensureWorkBuddyNodeOnPath() bool {
+	if _, err := exec.LookPath("node"); err == nil {
+		return true
+	}
+	paths := workbuddyNodeBinaryPaths()
+	for i := len(paths) - 1; i >= 0; i-- {
+		if !isExecutableFile(paths[i]) {
+			continue
+		}
+		nodeDir := filepath.Dir(paths[i])
+		for _, existing := range filepath.SplitList(os.Getenv("PATH")) {
+			if existing == nodeDir {
+				return true
+			}
+		}
+		pathValue := nodeDir
+		if existing := os.Getenv("PATH"); existing != "" {
+			pathValue += string(os.PathListSeparator) + existing
+		}
+		if err := os.Setenv("PATH", pathValue); err != nil {
+			return false
+		}
+		return true
+	}
+	return false
+}
+
 // loginShellResolveTimeout caps how long the daemon will wait for the user's
 // login shell to print canonical agent paths. A broken rc file should not
 // block startup — if the shell takes longer than this, we proceed without


### PR DESCRIPTION
## What does this PR do?

Multica already has a CodeBuddy backend, but the daemon only discovers a `codebuddy` executable from its configured path, daemon `PATH`, or login-shell `PATH`. Tencent WorkBuddy installs its headless CodeBuddy CLI inside the desktop app instead of putting it on `PATH`, so WorkBuddy users currently see no CodeBuddy runtime.

The daemon now probes the standard macOS WorkBuddy app locations after the existing sources. When that fallback wins, it also prepends WorkBuddy's staged Node runtime (`~/.workbuddy/binaries/node/versions/*/bin`) so the bundled `#!/usr/bin/env node` entrypoint can launch from a GUI-started daemon. Explicit paths and normal `PATH` installations remain authoritative.

This matches Tencent's installed WorkBuddy 5.3.5 package (`@tencent-ai/codebuddy-code` 2.115.0) and its official [headless-mode documentation](https://copilot.tencent.com/docs/cli/headless), which documents `codebuddy`/`cbc`, stream JSON input/output, MCP, resume, model, and effort flags.

## Related Issue

Closes #6623

Closes YTO-17

Related to #5861 (the broader WorkBuddy-to-Multica integration request).

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Refactor / code improvement (no behavior change)
- [x] Documentation update
- [x] Tests (adding or improving test coverage)
- [ ] CI / infrastructure

## Changes Made

- `server/internal/daemon/config.go`: add ordered system/user WorkBuddy bundle candidates and discovery of WorkBuddy's staged Node runtime.
- `server/internal/daemon/agents_probe.go`: use the WorkBuddy bundle only after configured/PATH/login-shell resolution, and reject it when no runnable Node runtime is available.
- `server/internal/daemon/agents_probe_workbuddy_test.go`: cover bundle fallback, PATH precedence, explicit-path hard misses, missing Node, and candidate ordering with staged executables.
- `apps/docs/content/docs/install-agent-runtime*.mdx`: document WorkBuddy detection and Tencent's headless CLI reference in all supported locales.

## How to Test

1. Run `go test ./internal/daemon/...` from `server/`.
2. Run `go test ./pkg/agent/...` from `server/`.
3. With WorkBuddy installed on macOS and no global `codebuddy`, start/restart the Multica daemon and confirm CodeBuddy appears under **Runtimes**.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [x] I have updated relevant documentation to reflect my changes
- [ ] If I added a new runtime / coding tool / UI tab, I synced the change to **landing copy** (`apps/web/features/landing/i18n/`) and **relevant docs** (`apps/docs/content/docs/`)
- [x] If this PR touches Chinese product copy, I checked it against `apps/docs/content/docs/developers/conventions.zh.mdx` (terminology, mixed-rule for `task` / `issue` / `skill`)
- [x] I have considered and documented any risks above
- [x] I will address all reviewer comments before requesting merge

The docs Vitest suite could not start in this checkout because JavaScript dependencies are not installed (`vitest: command not found`); the Go daemon and agent suites pass.

## AI Disclosure

**AI tool used:** Multica Agent

**Prompt / approach:** Inspected Tencent's official WorkBuddy/CodeBuddy headless documentation and the installed WorkBuddy app bundle, then traced Multica's existing CodeBuddy discovery and execution paths. Added the smallest fallback at the daemon probe boundary with isolated unit tests and localized install documentation.

## Screenshots (optional)

Not applicable; this changes daemon discovery and documentation only.
