### PR TITLE
WS-8: wake squad leaders on child review delivery

### DIFF
--- a/server/internal/handler/issue_child_done.go
+++ b/server/internal/handler/issue_child_done.go
@@ -14,7 +14,8 @@ import (
 )
 
 // notifyParentOfChildDone posts a top-level system comment on the parent
-// issue when a child issue transitions from non-done into done. This replaces
+// issue when a child issue transitions from a non-terminal status into a
+// delivered terminal status. This replaces
 // the agent-prompt rule that previously made child agents post the
 // notification themselves (PR #2918 user feedback — the agent rule caused
 // self-mention loops, planner ping-pong, and accidental `MUL-` prefix
@@ -22,9 +23,10 @@ import (
 //
 // Guards on whether the comment fires at all:
 //   - the child must transition from a non-terminal status INTO a terminal one
-//     (done or cancelled). Repeat saves of an already-terminal child do not
-//     re-fire; only the entering transition does. Cancelled counts because a
-//     cancelled sibling never finishes and so closes its stage (see the entry
+//     (in_review, done, or cancelled). Repeat saves of an already-terminal
+//     child do not re-fire; only the entering transition does. In_review counts
+//     as delivered work awaiting parent review, while cancelled counts because
+//     a cancelled sibling never finishes and so closes its stage (see the entry
 //     guard and isTerminalChildStatus).
 //   - issue.ParentIssueID must be set
 //   - parent must not be "done" or "cancelled" — the parent is already
@@ -69,13 +71,13 @@ func (h *Handler) notifyParentOfChildDone(ctx context.Context, prev, issue db.Is
 	if !issue.ParentIssueID.Valid {
 		return
 	}
-	// Fire on a transition INTO a terminal status (done OR cancelled), not only
-	// `done`. A cancelled child can close a stage too: isTerminalChildStatus
-	// treats cancelled as terminal (a cancelled sibling never finishes, so it
-	// must not hold the stage open), so the barrier has to be evaluated when the
-	// last open child of a stage is cancelled. Keying on the transition also
-	// makes a later cancelled -> done edit a no-op (terminal -> terminal), which
-	// avoids a lagging duplicate wake.
+	// Fire on a transition INTO a terminal status (in_review, done, OR
+	// cancelled), not only `done`. A delivered child can close a stage too:
+	// isTerminalChildStatus treats delivered and cancelled children as terminal,
+	// so the barrier has to be evaluated when the last open child of a stage is
+	// delivered or cancelled. Keying on the transition also makes a later
+	// in_review -> done edit a no-op (terminal -> terminal), which avoids a
+	// lagging duplicate wake.
 	if isTerminalChildStatus(prev.Status) || !isTerminalChildStatus(issue.Status) {
 		return
 	}
@@ -112,7 +114,7 @@ func (h *Handler) notifyParentOfChildDone(ctx context.Context, prev, issue db.Is
 	// sub-issue finishes" instead of the old fire-on-every-child behavior that
 	// caused the surprise cascade. A completion that does not close a stage is
 	// silent: no comment, no wake. ListChildIssues already reflects this child's
-	// committed `done` status (the status update commits before this runs).
+	// committed terminal status (the status update commits before this runs).
 	children, err := h.Queries.ListChildIssues(ctx, parent.ID)
 	if err != nil {
 		slog.Warn("child done: failed to list siblings for stage barrier",
@@ -335,10 +337,11 @@ func (h *Handler) postChildDoneComment(ctx context.Context, parent, completed db
 }
 
 // isTerminalChildStatus reports whether a child issue status counts as
-// "finished" for stage-barrier purposes. Cancelled counts as terminal: a
-// cancelled sibling will never complete, so it must not hold a stage open.
+// delivered for stage-barrier purposes. In_review means the child delivered
+// its work and is waiting for parent review; cancelled counts as terminal
+// because a cancelled sibling will never complete.
 func isTerminalChildStatus(status string) bool {
-	return status == "done" || status == "cancelled"
+	return status == "in_review" || status == "done" || status == "cancelled"
 }
 
 // siblingsAreStaged reports whether any child in the set carries an explicit

--- a/server/internal/handler/issue_child_done_stage_test.go
+++ b/server/internal/handler/issue_child_done_stage_test.go
@@ -44,6 +44,11 @@ func TestStageBarrierClosed_Unstaged(t *testing.T) {
 			children: []db.Issue{child(0, "done"), child(0, "cancelled")},
 			want:     true,
 		},
+		{
+			name:     "in_review counts as delivered terminal",
+			children: []db.Issue{child(0, "done"), child(0, "in_review")},
+			want:     true,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -80,6 +85,16 @@ func TestStageBarrierClosed_Staged(t *testing.T) {
 		}
 	})
 
+	t.Run("one in_review child does not close the stage", func(t *testing.T) {
+		children := []db.Issue{
+			child(1, "in_review"), child(1, "in_progress"),
+			child(2, "backlog"),
+		}
+		if stageBarrierClosed(children, child(1, "in_review")) {
+			t.Fatal("expected barrier to stay open while a stage sibling is still active")
+		}
+	})
+
 	t.Run("closing stage 2 fires when stages 1 and 2 are terminal", func(t *testing.T) {
 		children := []db.Issue{
 			child(1, "done"), child(1, "done"),
@@ -88,6 +103,16 @@ func TestStageBarrierClosed_Staged(t *testing.T) {
 		}
 		if !stageBarrierClosed(children, child(2, "done")) {
 			t.Fatal("expected stage 2 barrier to close")
+		}
+	})
+
+	t.Run("in_review closes a stage", func(t *testing.T) {
+		children := []db.Issue{
+			child(1, "in_review"), child(1, "in_review"),
+			child(2, "backlog"),
+		}
+		if !stageBarrierClosed(children, child(1, "in_review")) {
+			t.Fatal("expected stage 1 barrier to close when children are delivered for review")
 		}
 	})
 

--- a/server/internal/handler/issue_child_done_test.go
+++ b/server/internal/handler/issue_child_done_test.go
@@ -404,6 +404,60 @@ func TestChildDoneMentionsParentAssignee_Squad(t *testing.T) {
 	}
 }
 
+// TestChildInReviewWakesParentSquadForDirectAgentChild verifies that a direct
+// agent child hands its delivered result back to a squad-owned parent without
+// requiring an explicit @mention. Re-saving in_review and moving it to done
+// are both terminal-to-terminal transitions and must not duplicate the wake.
+func TestChildInReviewWakesParentSquadForDirectAgentChild(t *testing.T) {
+	fx := newChildDoneFixture(t, "in_progress")
+	sq := newSquadCommentTriggerFixture(t)
+
+	var childAgentID string
+	if err := testPool.QueryRow(context.Background(),
+		`SELECT id FROM agent WHERE workspace_id = $1 AND name = $2`,
+		testWorkspaceID, "Handler Test Agent").Scan(&childAgentID); err != nil {
+		t.Fatalf("locate child agent: %v", err)
+	}
+	setIssueAssigneeDirect(t, fx.parent.ID, "squad", sq.SquadID)
+	setIssueAssigneeDirect(t, fx.child.ID, "agent", childAgentID)
+	t.Cleanup(func() {
+		testPool.Exec(context.Background(),
+			`DELETE FROM agent_task_queue WHERE issue_id IN ($1, $2)`,
+			fx.parent.ID, fx.child.ID)
+	})
+
+	updateChildStatus(t, fx.child.ID, "in_review")
+
+	content := parentSystemCommentContent(t, fx.parent.ID)
+	if !strings.Contains(content, "mention://squad/"+sq.SquadID) {
+		t.Fatalf("expected parent-squad mention in system comment, got: %s", content)
+	}
+	var isLeaderTask bool
+	var queuedSquadID, triggerCommentID string
+	if err := testPool.QueryRow(context.Background(), `
+		SELECT is_leader_task, squad_id::text, trigger_comment_id::text
+		FROM agent_task_queue
+		WHERE issue_id = $1 AND agent_id = $2 AND status = 'queued'
+		ORDER BY created_at DESC
+		LIMIT 1
+	`, fx.parent.ID, sq.LeaderID).Scan(&isLeaderTask, &queuedSquadID, &triggerCommentID); err != nil {
+		t.Fatalf("load parent leader wake: %v", err)
+	}
+	if !isLeaderTask || queuedSquadID != sq.SquadID || triggerCommentID == "" {
+		t.Fatalf("leader wake provenance = leader:%v squad:%q trigger:%q", isLeaderTask, queuedSquadID, triggerCommentID)
+	}
+
+	updateChildStatus(t, fx.child.ID, "in_review")
+	updateChildStatus(t, fx.child.ID, "done")
+
+	if got := countSystemCommentsOn(t, fx.parent.ID); got != 1 {
+		t.Fatalf("terminal child re-saves must not duplicate the comment, got %d", got)
+	}
+	if got := countPendingTasksForAgent(t, fx.parent.ID, sq.LeaderID); got != 1 {
+		t.Fatalf("terminal child re-saves must not duplicate the leader wake, got %d", got)
+	}
+}
+
 // TestChildDoneTriggersParentAgentWhenSameAgentOwnsChild — when the parent
 // agent assignee is the SAME agent that owns the just-finished child, the
 // parent agent must still be triggered (MUL-2808). A child finishing and

--- a/server/internal/service/builtin_skills/multica-squads/SKILL.md
+++ b/server/internal/service/builtin_skills/multica-squads/SKILL.md
@@ -174,6 +174,11 @@ Current behavior:
   `in_review` only when a later re-trigger confirms the overall goal is met.
   Completing a leader `task` (including the first dispatch) does not itself
   change issue status;
+- when a child assigned directly to an agent enters `in_review` (or reaches
+  `done`/`cancelled`) and closes the current stage barrier, the server posts a
+  system handoff comment on the parent and wakes this squad's leader once;
+  repeated `in_review` saves and the later `in_review` → `done` transition do
+  not duplicate that handoff;
 - that status authority is granted only when the issue's `assignee_type` /
   `assignee_id` point at THIS squad. The leader briefing is injected on every
   leader path, including an `@squad` mention on an issue owned by a plain agent
@@ -264,8 +269,9 @@ authorizes them.
 - Backlog assignment does not immediately start work.
 - First leader dispatch is not parent completion — parent stays `in_progress`
   until the leader later confirms the overall goal and moves it to `in_review`.
-- The server does not auto-flip parent status when child issues finish; it only
-  wakes the leader with an explicit ask (including `in_review` when wrapping up).
+- The server does not auto-flip parent status when child issues finish or enter
+  `in_review`; it only wakes the leader with an explicit ask (including
+  `in_review` when wrapping up).
 - Getting the leader briefing does NOT imply status authority. A squad
   `@`-mentioned into an issue assigned to someone else is a guest: roster and
   delegation rules yes, `multica issue status` no.

--- a/server/internal/service/builtin_skills/multica-squads/references/squad-source-map.md
+++ b/server/internal/service/builtin_skills/multica-squads/references/squad-source-map.md
@@ -205,14 +205,19 @@ Contracts:
 Source:
 
 ```text
-server/internal/handler/issue_child_done.go       # dispatchParentAssigneeTrigger ~246, triggerChildDoneSquad ~304
+server/internal/handler/issue_child_done.go       # notifyParentOfChildDone ~70, dispatchParentAssigneeTrigger ~590, triggerChildDoneSquad ~668
 ```
 
 Contracts:
 
-- when a child issue closes a stage barrier and the parent is assigned to a
-  squad, the parent squad leader is triggered (triggerChildDoneSquad in
-  issue_child_done.go);
+- when a child issue enters `in_review`, `done`, or `cancelled` from a
+  non-terminal status, closes the current stage barrier, and the parent is
+  assigned to a squad, the parent squad leader is triggered
+  (`notifyParentOfChildDone` → `triggerChildDoneSquad` in
+  `issue_child_done.go`); a direct-agent child does not need an @mention;
+- repeated saves of a terminal child, including `in_review` → `done`, do not
+  create a second system comment or leader task because the transition guard
+  treats all three statuses as terminal;
 - routing is leader-only — one `EnqueueTaskForSquadLeader` on the leader, no
   member fan-out (triggerChildDoneSquad / dispatchParentAssigneeTrigger);
 - no self-trigger guard: a same-squad or shared-leader child still wakes the

--- a/server/internal/service/builtin_skills/multica-working-on-issues/SKILL.md
+++ b/server/internal/service/builtin_skills/multica-working-on-issues/SKILL.md
@@ -191,9 +191,11 @@ on it. These are the contracts, not advice:
   the overall goal is met.
 - **`in_review`** is an accepted issue status. Some workflows use it while a PR
   is open and awaiting review; moving to it is an explicit mutation.
-- **`done`** on a child issue posts a system comment on its parent. If a PR
-  carries close intent (`Closes MUL-XXXX`), it advances the issue to `done`
-  itself on merge — you do not also need to flip it manually.
+- **`in_review`**, **`done`**, or **`cancelled`** on a child issue counts as
+  delivered for the stage barrier; when it closes the current stage, the
+  server posts a system handoff comment on the parent and wakes its assignee.
+  If a PR carries close intent (`Closes MUL-XXXX`), it advances the issue to
+  `done` itself on merge — you do not also need to flip it manually.
 - **`cancelled`** is a terminal, user-driven decision to close the issue. Like
   `done` it enqueues no new agent work, but it does **not** stop tasks already in
   flight — a run in progress keeps going (MUL-4465). To stop a running task,
@@ -228,10 +230,10 @@ Creating every serial step as `todo` enqueues the whole chain at once.
 `--stage <N>` (N ≥ 1) groups sub-issues under the same parent into ordered
 stages. The parent assignee is woken **once, when a whole stage finishes** —
 i.e. every sub-issue in the lowest unfinished stage has reached a terminal
-status (`done`/`cancelled`). A completion that does not close a stage is silent
-(no comment, no wake). A sibling set with **no** stages is one implicit stage,
-so the parent is woken once when the *last* sub-issue finishes — not on every
-child.
+status (`in_review`/`done`/`cancelled`). A completion that does not close a
+stage is silent (no comment, no wake). A sibling set with **no** stages is one
+implicit stage, so the parent is woken once when the *last* sub-issue is
+delivered — not on every child.
 
 Advancement is agent-driven: the server only detects the closed barrier and
 wakes the parent assignee, who then decides whether to promote the next stage's
@@ -245,8 +247,9 @@ multica issue create --title "Build"      --parent <id> --assignee <agent> --sta
 multica issue create --title "Ship"       --parent <id> --assignee <agent> --stage 3 --status backlog
 ```
 
-When both Stage 1 sub-issues finish you (the parent assignee) are woken with a
-"Stage 1 complete" comment. Inspect the layout, then promote the next stage:
+When both Stage 1 sub-issues are delivered (`in_review`, `done`, or
+`cancelled`), you (the parent assignee) are woken with a "Stage 1 complete"
+comment. Inspect the layout, then promote the next stage:
 
 ```bash
 multica issue children <parent-id>             # sub-issues grouped by stage

--- a/server/internal/service/builtin_skills/multica-working-on-issues/references/working-on-issues-source-map.md
+++ b/server/internal/service/builtin_skills/multica-working-on-issues/references/working-on-issues-source-map.md
@@ -127,7 +127,7 @@ and is hidden from the PR list.
 | `shouldEnqueueAgentTask` returns false for `backlog` (parking lot) | `server/internal/handler/issue.go:2644-2648` | new citation |
 | Backlog → non-backlog (not done/cancelled) enqueues on update | `server/internal/handler/issue.go:2537-2540` | `:2523` |
 | Same contract in batch update | `server/internal/handler/issue.go:3021-3024` | new citation |
-| Child → `done` notifies + wakes the parent, gated by the stage barrier | `server/internal/handler/issue_child_done.go:66` (`notifyParentOfChildDone`; doc comment at `:15`; barrier gate at `:115`) | func def `:51` |
+| Child → `in_review`/`done`/`cancelled` notifies + wakes the parent when the stage barrier closes | `server/internal/handler/issue_child_done.go:70` (`notifyParentOfChildDone`; transition guard at `:82`; barrier gate at `:127`) | prior `done`-only contract |
 | Status change (incl. → `cancelled`) does NOT cancel in-flight tasks; only issue deletion does (MUL-4465) | no-cancel note in `server/internal/handler/issue.go:2652-2658` (`UpdateIssue`) and `:3170-3171` (`BatchUpdateIssues`); deletion still cancels at `:2863` (`DeleteIssue`) / `:3239` (`BatchDeleteIssues`) via `CancelTasksForIssue` (`server/internal/service/task.go:1229`) | new citation |
 | `StartTask` / `CompleteTask` do not write issue status (agent CLI owns progress) | `server/internal/service/task.go` (`StartTask` / `CompleteTask` comments) | new citation |
 | Assignment brief: ordinary agent `in_progress` then `in_review`; squad leader `in_progress` only on first dispatch | `server/internal/daemon/execenv/runtime_config_sections.go` (`writeWorkflowAssignment`) | new citation |
@@ -150,8 +150,8 @@ away, so no task is left orphaned.
 | Behavior | File:line |
 |---|---|
 | `issue.stage` column (nullable, `>= 1`) | `server/migrations/123_issue_stage.up.sql` |
-| Stage barrier: notify+wake fire only when the lowest unfinished stage is all-terminal; unstaged set = one implicit stage | `server/internal/handler/issue_child_done.go:231` (`stageBarrierClosed`) |
-| Per-stage summary + next stage for the wake comment | `server/internal/handler/issue_child_done.go:254` (`stageProgressSummary`) |
+| Stage barrier: `in_review`/`done`/`cancelled` are terminal; notify+wake fire only when the lowest unfinished stage is all-terminal; unstaged set = one implicit stage | `server/internal/handler/issue_child_done.go:374` (`stageBarrierClosed`; terminal predicate at `:344`) |
+| Per-stage summary + next stage for the wake comment | `server/internal/handler/issue_child_done.go:406` (`stageProgressSummary`) |
 | `--stage` on `issue create` / `issue update` | `server/cmd/multica/cmd_issue.go:328,350` |
 | `multica issue children <id>` (sub-issues grouped by stage) | `server/cmd/multica/cmd_issue.go:114,678`; route `GET /api/issues/{id}/children` → `ListChildIssues` |
 


### PR DESCRIPTION
Closes WS-8

## What changed

- Treat child `in_review` as a delivered terminal status for stage barriers.
- Reuse the existing system handoff comment, squad-leader enqueue, provenance, and pending-task deduplication paths.
- Add stage-barrier coverage for partial and complete `in_review` stages, plus a squad-parent/direct-agent integration regression covering leader-task provenance and duplicate suppression.
- Update the built-in squad and issue workflow skills and source maps.

## Root cause

Child work normally reaches `in_review`, but the shared `isTerminalChildStatus` predicate only recognized `done` and `cancelled`. `TaskService.CompleteTask` intentionally does not own issue status, so the parent wake path never ran.

## Validation

- `go test ./internal/handler -run 'TestStageBarrierClosed|TestChildInReviewWakesParentSquadForDirectAgentChild' -count=1` (package compiles; DB-backed tests were skipped because this checkout has no PostgreSQL)
- `git diff --check`
- `make test` could not start: `.env`, Docker, and PostgreSQL are unavailable in the runtime.
