### PR TITLE
test(core): cover cloud billing schema fallbacks

### DIFF
--- a/packages/core/api/schema.test.ts
+++ b/packages/core/api/schema.test.ts
@@ -626,6 +626,100 @@ describe("ApiClient schema fallback", () => {
       expect(res).toEqual({ next_runs: null });
     });
   });
+
+  describe("cloud billing", () => {
+    it("falls back to an empty balance when the response is malformed", async () => {
+      stubFetchJson({ balance_micro: "not-a-number" });
+      const client = new ApiClient("https://api.example.test");
+
+      await expect(client.getCloudBillingBalance()).resolves.toEqual({
+        owner_id: "",
+        balance_micro: 0,
+        balance_credit: 0,
+        updated_at: "",
+      });
+    });
+
+    it("falls back to an empty transactions page when items are malformed", async () => {
+      stubFetchJson({ items: "not-an-array", total: 1, page: 1, page_size: 20 });
+      const client = new ApiClient("https://api.example.test");
+
+      await expect(client.listCloudBillingTransactions()).resolves.toEqual({
+        items: [],
+        total: 0,
+        page: 1,
+        page_size: 20,
+      });
+    });
+
+    it("falls back to an empty batches page when items are malformed", async () => {
+      stubFetchJson({ items: "not-an-array", total: 1, page: 1, page_size: 20 });
+      const client = new ApiClient("https://api.example.test");
+
+      await expect(client.listCloudBillingBatches()).resolves.toEqual({
+        items: [],
+        total: 0,
+        page: 1,
+        page_size: 20,
+      });
+    });
+
+    it("falls back to an empty top-ups page when items are malformed", async () => {
+      stubFetchJson({ items: "not-an-array", total: 1, page: 1, page_size: 20 });
+      const client = new ApiClient("https://api.example.test");
+
+      await expect(client.listCloudBillingTopups()).resolves.toEqual({
+        items: [],
+        total: 0,
+        page: 1,
+        page_size: 20,
+      });
+    });
+
+    it("falls back to no price tiers when the response is not an array", async () => {
+      stubFetchJson({ tiers: [] });
+      const client = new ApiClient("https://api.example.test");
+
+      await expect(client.listCloudBillingPriceTiers()).resolves.toEqual([]);
+    });
+
+    it("falls back to an empty checkout session when the response is malformed", async () => {
+      stubFetchJson({ order_id: 123 });
+      const client = new ApiClient("https://api.example.test");
+
+      await expect(
+        client.createCloudBillingCheckoutSession({ tier_id: "starter" }),
+      ).resolves.toEqual({
+        order_id: "",
+        session_id: "",
+        url: "",
+      });
+    });
+
+    it("falls back to a pending checkout status when the response is malformed", async () => {
+      stubFetchJson({ status: 123 });
+      const client = new ApiClient("https://api.example.test");
+
+      await expect(client.getCloudBillingCheckoutSession("cs_test")).resolves.toEqual({
+        order_id: "",
+        status: "pending",
+        amount_cents: 0,
+        credits: 0,
+        bonus_credits: 0,
+        currency: "usd",
+        tier_id: "",
+      });
+    });
+
+    it("falls back to an empty portal URL when the response is malformed", async () => {
+      stubFetchJson({ url: 123 });
+      const client = new ApiClient("https://api.example.test");
+
+      await expect(client.createCloudBillingPortalSession()).resolves.toEqual({
+        url: "",
+      });
+    });
+  });
 });
 
 // Direct tests for the helper, decoupled from any specific endpoint —


### PR DESCRIPTION
Ensure malformed upstream billing responses degrade to the safe values expected by UI consumers.

## What does this PR do?

This PR adds malformed-response coverage for the cloud billing API schemas.

Cloud billing responses are proxied from `multica-cloud` without reshaping. Unexpected upstream response types must safely degrade through `parseWithFallback` instead of propagating invalid data to UI consumers.

The tests call the real `ApiClient` methods with malformed JSON responses, verifying both schema validation and endpoint-specific fallback wiring.

## Related Issue

No related issue. This PR addresses an API schema test coverage gap identified from the repository’s API compatibility requirements.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Refactor / code improvement (no behavior change)
- [ ] Documentation update
- [x] Tests (adding or improving test coverage)
- [ ] CI / infrastructure

## Changes Made

- Added malformed-response fallback tests in `packages/core/api/schema.test.ts`.
- Covered balance, transactions, batches, top-ups, price tiers, checkout sessions, checkout status, and portal sessions.
- Verified malformed responses resolve to safe fallback values rather than throwing.

## How to Test

1. Run the API schema tests:

   ```bash
   pnpm --filter @multica/core exec vitest run api/schema.test.ts
   ```

2. Run the core type check:

   ```bash
   pnpm --filter @multica/core typecheck
   ```

3. Run ESLint:

   ```bash
   pnpm --filter @multica/core exec eslint api/schema.test.ts
   ```

Expected results:

- API schema tests: 57 passed
- TypeScript type check: passed
- ESLint: passed

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] If this change affects the UI, I have included before/after screenshots (N/A — test-only change)
- [x] I have updated relevant documentation to reflect my changes (N/A — no documented behavior changed)
- [x] If I added a new runtime / coding tool / UI tab, I synced the change to **landing copy** (`apps/web/features/landing/i18n/`) and **relevant docs** (`apps/docs/content/docs/`) (N/A)
- [x] If this PR touches Chinese product copy, I checked it against `apps/docs/content/docs/developers/conventions.zh.mdx` (terminology, mixed-rule for `task` / `issue` / `skill`) (N/A)
- [x] I have considered and documented any risks above
- [x] I will address all reviewer comments before requesting merge

### Thinking path and risks

The project requires API responses consumed by UI logic to pass through Zod schemas and `parseWithFallback`, particularly because installed desktop clients may communicate with different backend versions.

The cloud billing API surface had schemas and explicit fallback values but no endpoint-level malformed-response coverage. Testing through `ApiClient` verifies that the schemas and fallback values are wired together correctly.

This is a test-only change and does not alter production behavior. The primary risk is coupling assertions to the current fallback values, but those values form the safety contract consumed by the UI and should change deliberately alongside these tests.

## AI Disclosure

**AI tool used:** Cursor

**Prompt / approach:**

I used Cursor to inspect the repository’s API compatibility rules, existing `schema.test.ts` patterns, cloud billing schemas, and `ApiClient` methods. I then used it to identify the uncovered cloud billing schema surface, add endpoint-level malformed-response tests following the existing pattern, and run focused tests, type checking, and linting.

I reviewed the changes against the existing fallback constants and kept the scope limited to cloud billing schema tests.

## Screenshots (optional)

Not applicable — this PR only adds tests and does not change the UI.