### PR TITLE
MUL-5925 fix(execenv): expand Windows `~\` in the openclaw active config path (#6630)

### DIFF
--- a/server/internal/daemon/execenv/execenv.go
+++ b/server/internal/daemon/execenv/execenv.go
@@ -409,6 +409,7 @@ func Prepare(params PrepareParams, logger *slog.Logger) (*Environment, error) {
 			OpenclawBin: params.OpenclawBin,
 			McpConfig:   params.McpConfig,
 			Gateway:     params.OpenclawGateway,
+			Logger:      logger,
 		})
 		if err != nil {
 			return nil, fmt.Errorf("execenv: prepare openclaw config: %w", err)
@@ -651,6 +652,7 @@ func Reuse(params ReuseParams, logger *slog.Logger) *Environment {
 			OpenclawBin: params.OpenclawBin,
 			McpConfig:   params.McpConfig,
 			Gateway:     params.OpenclawGateway,
+			Logger:      logger,
 		})
 		if err != nil {
 			logger.Warn("execenv: refresh openclaw config failed", "error", err)

--- a/server/internal/daemon/execenv/openclaw_config.go
+++ b/server/internal/daemon/execenv/openclaw_config.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"log/slog"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -77,6 +78,12 @@ type OpenclawConfigPrep struct {
 	// — which is the right default when the user already has a working
 	// gateway set up locally. See issue #3260.
 	Gateway OpenclawGatewayPin
+	// Logger records the config-discovery outcome. Optional; nil disables
+	// logging. Discovery used to be entirely silent, which is why #6630 —
+	// a wrapper written without `$include` — could only be diagnosed by
+	// reading the generated file and reverse-engineering the daemon. Paths
+	// and booleans are logged; config contents never are.
+	Logger *slog.Logger
 }
 
 // OpenclawGatewayPin describes the Gateway endpoint a per-task openclaw
@@ -210,6 +217,15 @@ func prepareOpenclawConfig(envRoot, workDir string, opts OpenclawConfigPrep) (Op
 	if err != nil {
 		return OpenclawConfigResult{}, fmt.Errorf("locate openclaw active config: %w", err)
 	}
+	if !exists && opts.Logger != nil {
+		// Not an error — a genuine fresh install lands here legitimately.
+		// But it is also where a failed discovery lands, and the two are
+		// indistinguishable from the outside, so say so loudly: every task
+		// prepared from this point runs without the user's model providers
+		// and auth profiles.
+		opts.Logger.Warn("execenv: openclaw active config not found; task wrapper will omit $include so the user's models and auth profiles will NOT be visible to this task",
+			"reported_path", activePath)
+	}
 
 	var resolvedList []any
 	var agentsFromRegistry bool
@@ -285,14 +301,26 @@ func prepareOpenclawConfig(envRoot, workDir string, opts OpenclawConfigPrep) (Op
 		return OpenclawConfigResult{}, fmt.Errorf("write openclaw config: %w", err)
 	}
 	result := OpenclawConfigResult{ConfigPath: outPath}
+	includeTarget := "none"
 	if snapshotPath != "" {
 		// Sanitized snapshot lives in envRoot alongside the wrapper, so the
 		// $include never crosses directories — daemon does not need to grant
 		// an extra OPENCLAW_INCLUDE_ROOTS entry.
+		includeTarget = "sanitized-snapshot"
 	} else if exists {
 		// Live user config is in its own directory; tell the daemon to grant
 		// it so OpenClaw's include-confinement check passes.
 		result.IncludeRoot = filepath.Dir(activePath)
+		includeTarget = "user-config"
+	}
+	if opts.Logger != nil {
+		opts.Logger.Info("execenv: prepared openclaw config",
+			"active_config", activePath,
+			"active_config_exists", exists,
+			"include_target", includeTarget,
+			"include_root", result.IncludeRoot,
+			"agents_from_registry", agentsFromRegistry,
+			"managed_mcp", hasManagedMcp)
 	}
 	return result, nil
 }
@@ -601,16 +629,47 @@ func appendOpenclawConfigFileCandidates(candidates []string, dir string) []strin
 	return candidates
 }
 
+// openclawTildeRest splits a `~`-shortened path into the part after the home
+// prefix, reporting whether the path was tilde-shortened at all.
+//
+// The separator after `~` is whatever the CLI's host OS uses: OpenClaw
+// prints `~/.openclaw/openclaw.json` on Unix and `~\.openclaw\openclaw.json`
+// on Windows. Matching only the forward-slash form left the Windows tilde
+// unexpanded, and since `~\...` is not absolute the path then got joined
+// onto the daemon's working directory, producing a path that can never
+// exist. The stat miss was indistinguishable from a fresh install, so the
+// wrapper silently dropped the user's `$include` and every task booted
+// without their model providers or auth profiles (issue #6630).
+//
+// Both separators are accepted regardless of runtime.GOOS, deliberately, and
+// not via os.IsPathSeparator (which rejects `\` on Unix). The daemon and the
+// CLI share a host, so only the host's own form arises in production — but
+// keying on the character rather than the host OS lets the Windows shape be
+// exercised from the normal Linux/macOS test job instead of only on a Windows
+// runner, the same trade isOpenclawShimPath makes above.
+func openclawTildeRest(path string) (string, bool) {
+	if path == "~" {
+		return "", true
+	}
+	if len(path) > 1 && path[0] == '~' && (path[1] == '/' || path[1] == '\\') {
+		return path[2:], true
+	}
+	return "", false
+}
+
 func expandOpenclawPath(path string) (string, error) {
-	if path == "~" || strings.HasPrefix(path, "~/") {
+	if rest, isTilde := openclawTildeRest(path); isTilde {
 		home, herr := os.UserHomeDir()
 		if herr != nil {
 			return "", fmt.Errorf("expand `~` in openclaw config path: %w", herr)
 		}
-		if path == "~" {
+		if rest == "" {
 			path = home
 		} else {
-			path = filepath.Join(home, strings.TrimPrefix(path, "~/"))
+			// The remainder still carries the CLI's separators. filepath.Join
+			// normalizes them to the host's on the OS that matters here
+			// (Windows accepts both), and the result is what we stat.
+			path = filepath.Join(home, rest)
 		}
 	}
 	if !filepath.IsAbs(path) {

--- a/server/internal/daemon/execenv/openclaw_config_test.go
+++ b/server/internal/daemon/execenv/openclaw_config_test.go
@@ -1577,3 +1577,126 @@ func TestPrepareOpenclawConfigNewSchemaEmptyRegistry(t *testing.T) {
 		t.Errorf("defaults.workspace not set")
 	}
 }
+
+// TestExpandOpenclawPathTildeSeparators — `openclaw config file` shortens the
+// home prefix using its host OS's separator, so Windows reports
+// `~\.openclaw\openclaw.json`. Matching only `~/` left that form unexpanded;
+// because `~\...` is not absolute it was then joined onto the daemon's working
+// directory, yielding a path that could never exist. The resulting stat miss
+// was indistinguishable from a fresh install, so the wrapper dropped the
+// user's $include and every task lost its model providers and auth profiles
+// (issue #6630).
+func TestExpandOpenclawPathTildeSeparators(t *testing.T) {
+	fakeHome := t.TempDir()
+	t.Setenv("HOME", fakeHome)
+	t.Setenv("USERPROFILE", fakeHome)
+
+	cases := []struct {
+		name string
+		in   string
+	}{
+		{name: "posix separator", in: "~/.openclaw/openclaw.json"},
+		{name: "windows separator", in: `~\.openclaw\openclaw.json`},
+		{name: "bare tilde", in: "~"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := expandOpenclawPath(tc.in)
+			if err != nil {
+				t.Fatalf("expandOpenclawPath(%q): %v", tc.in, err)
+			}
+			if strings.Contains(got, "~") {
+				t.Errorf("expandOpenclawPath(%q) = %q, want the tilde expanded (a literal ~ can never stat)", tc.in, got)
+			}
+			if !strings.HasPrefix(got, fakeHome) {
+				t.Errorf("expandOpenclawPath(%q) = %q, want it rooted at the home dir %q", tc.in, got, fakeHome)
+			}
+		})
+	}
+}
+
+// TestPrepareOpenclawConfigExpandsWindowsTilde — end-to-end guard for #6630:
+// the reporter's exact `openclaw config file` output (a config-warning banner
+// followed by a Windows-shortened path) must still produce a wrapper that
+// $includes the user's config.
+func TestPrepareOpenclawConfigExpandsWindowsTilde(t *testing.T) {
+	envRoot := t.TempDir()
+	workDir := filepath.Join(envRoot, "workdir")
+	if err := os.MkdirAll(workDir, 0o755); err != nil {
+		t.Fatalf("mkdir workdir: %v", err)
+	}
+
+	fakeHome := t.TempDir()
+	t.Setenv("HOME", fakeHome)
+	t.Setenv("USERPROFILE", fakeHome)
+
+	// filepath.Join normalizes the reported remainder to the host separator,
+	// so build the expected target the same way the production path does and
+	// materialize it. On non-Windows hosts that is a single oddly-named file;
+	// the assertion under test is the tilde expansion, not the separator.
+	wantPath := filepath.Join(fakeHome, `.openclaw\openclaw.json`)
+	if err := os.MkdirAll(filepath.Dir(wantPath), 0o755); err != nil {
+		t.Fatalf("mkdir user cfg dir: %v", err)
+	}
+	if err := os.WriteFile(wantPath, []byte(`{}`), 0o600); err != nil {
+		t.Fatalf("write user cfg: %v", err)
+	}
+
+	banner := "|\no  Config warnings ---------------------------------+\n" +
+		"|  - plugins.entries.duckduckgo: plugin not found  |\n" +
+		"+--------------------------------------------------+\n" +
+		`~\.openclaw\openclaw.json` + "\n"
+	stub := installOpenclawStub(t, map[string]openclawResponse{
+		"config file":                   {stdout: banner},
+		"config get agents.list --json": {stdout: "null"},
+	})
+
+	result, err := prepareOpenclawConfig(envRoot, workDir, OpenclawConfigPrep{OpenclawBin: stub.bin})
+	if err != nil {
+		t.Fatalf("prepareOpenclawConfig: %v", err)
+	}
+	got := mustReadJSON(t, result.ConfigPath)
+	include, ok := got["$include"].([]any)
+	if !ok {
+		t.Fatalf("wrapper has no $include — the user's models and auth profiles would be lost: %#v", got)
+	}
+	if include[0] != wantPath {
+		t.Errorf("$include[0] = %v, want %q", include[0], wantPath)
+	}
+	if result.IncludeRoot != filepath.Dir(wantPath) {
+		t.Errorf("IncludeRoot = %q, want %q", result.IncludeRoot, filepath.Dir(wantPath))
+	}
+}
+
+// TestPrepareOpenclawConfigWarnsWhenActiveConfigMissing — discovery used to be
+// silent, so a wrapper written without $include left no trace in the daemon
+// log and could only be diagnosed by reading the generated file. A fresh
+// install legitimately lands here too, but the consequence (no user models or
+// auth profiles for this task) is worth a warning either way.
+func TestPrepareOpenclawConfigWarnsWhenActiveConfigMissing(t *testing.T) {
+	envRoot := t.TempDir()
+	workDir := t.TempDir()
+	missing := filepath.Join(t.TempDir(), "absent", "openclaw.json")
+
+	stub := installOpenclawStub(t, map[string]openclawResponse{
+		"config file": {stdout: missing + "\n"},
+	})
+
+	var logs strings.Builder
+	logger := slog.New(slog.NewTextHandler(&logs, &slog.HandlerOptions{Level: slog.LevelDebug}))
+
+	result, err := prepareOpenclawConfig(envRoot, workDir, OpenclawConfigPrep{OpenclawBin: stub.bin, Logger: logger})
+	if err != nil {
+		t.Fatalf("prepareOpenclawConfig: %v", err)
+	}
+	out := logs.String()
+	if !strings.Contains(out, "openclaw active config not found") {
+		t.Errorf("missing active config was not warned about; log was:\n%s", out)
+	}
+	if !strings.Contains(out, "include_target=none") {
+		t.Errorf("prepared-config log should record include_target=none; log was:\n%s", out)
+	}
+	if result.IncludeRoot != "" {
+		t.Errorf("IncludeRoot = %q, want empty", result.IncludeRoot)
+	}
+}


### PR DESCRIPTION
Fixes the root cause of #6630 (MUL-5925).

## Problem

`openclaw config file` shortens the home prefix using its host OS's separator, so on Windows it reports:

```text
~\.openclaw\openclaw.json
```

`expandOpenclawPath` only matched the POSIX form:

```go
if path == "~" || strings.HasPrefix(path, "~/") {
```

so `~\...` fell through unexpanded. Not being absolute, it was then joined onto the **daemon's working directory**, producing a path that can never exist.

The resulting stat miss returns `exists=false`, which is the same signal a genuine fresh install produces. So `prepareOpenclawConfig` took the fresh-install branch and wrote a wrapper with no `$include` and no include root:

```json
{ "agents": { "defaults": { "workspace": "<taskWorkDir>" } } }
```

Every task then booted OpenClaw with no model providers and no auth profiles, failing with `Unknown model: openai/gpt-5.5` or `No credentials found for profile "…"`. This is **not** the documented fail-closed path — that only covers CLI *errors*. Here the CLI succeeds and we misread its output, so nothing errored and nothing was logged.

## Changes

- **`openclawTildeRest`** — new helper that recognises `~`, `~/…` and `~\…`. Both separators are accepted regardless of `GOOS` (not via `os.IsPathSeparator`, which rejects `\` on Unix) so the Windows shape stays exercisable from the normal Linux/macOS test job. Same trade `isOpenclawShimPath` already makes in this file.
- **Discovery logging** — `OpenclawConfigPrep` gains an optional `Logger`. A missing active config now warns explicitly that the task will not see the user's models or auth profiles; success logs the resolved path, whether it existed, the include target (`user-config` / `sanitized-snapshot` / `none`), the include root, and whether agents came from the registry. Paths and booleans only — never config contents. Discovery being entirely silent is why the reporter could only diagnose this by reading the generated file and reverse-engineering the daemon.

## Tests

Added to `openclaw_config_test.go`:

- `TestExpandOpenclawPathTildeSeparators` — table-driven over `~/…`, `~\…`, bare `~`; asserts no literal `~` survives and the result is rooted at the home dir.
- `TestPrepareOpenclawConfigExpandsWindowsTilde` — end-to-end with the reporter's exact output shape (config-warning banner followed by the Windows-shortened path); asserts `$include` and `IncludeRoot` are produced.
- `TestPrepareOpenclawConfigWarnsWhenActiveConfigMissing` — asserts the warning fires and `include_target=none` is recorded.

Verified locally:

```
go test ./internal/daemon/... ./pkg/agent/... -count=1   # all ok
go vet  ./internal/daemon/... ./pkg/agent/...            # clean
gofmt -l server/internal/daemon/execenv/                 # clean
```

The two new tests fail without the fix (the wrapper comes out with no `$include`) and pass with it.

## Scope

Deliberately not included:

- **Containment guard on the discovered active path.** Nothing currently checks that the path handed back isn't our own per-task wrapper; that self-`$include` would explain the reporter's separate `Circular include detected` failure. Close to the ground PR #6344 (LOOP-771) covered before it was closed. Worth its own PR.
- **The 5s CLI deadline** (MUL-5467 / #6275). Relevant here: with the config now found, `openclawResolvedAgentsList` stops being skipped, so prep goes from one CLI invocation to three. On a host where the CLI is slow to start, this fix increases exposure to that deadline — it converts a silent misconfiguration into a loud timeout, which is better, but the deadline work still matters.
- **`minOpenclawVersion`** is still `2026.5.5`; there is no 2026.7-specific handling anywhere. Not touched here.
