### PR TITLE
MUL-5937 fix(daemon): persist direct chat Codex sessions

### DIFF
--- a/server/internal/daemon/daemon.go
+++ b/server/internal/daemon/daemon.go
@@ -495,7 +495,7 @@ type Daemon struct {
 
 	activeCodexStoresMu   sync.Mutex
 	activeCodexStoresCond *sync.Cond      // signalled when an in-flight store deletion finishes, so a blocked markActive can proceed
-	activeCodexStores     map[string]int  // per-issue Codex session store path -> live-task refcount; guards the store from GC mid-task (MUL-4424)
+	activeCodexStores     map[string]int  // per-conversation Codex session store path -> live-task refcount; guards the store from GC mid-task (MUL-4424)
 	deletingCodexStores   map[string]bool // store paths a GC delete has reserved; markActive waits these out so a task never mounts a store mid-removal
 
 	// localPathLocks serialises agent tasks whose project resource is a
@@ -5837,7 +5837,7 @@ func (d *Daemon) runTask(ctx context.Context, task Task, provider string, slot i
 	// store's stale (pre-remount) mtime cannot reclaim it out from under a resume
 	// of a long-idle issue (MUL-4424). No-op for non-Codex tasks / no stable key.
 	if provider == "codex" {
-		if store := execenv.CodexSessionStorePath(d.cfg.Profile, task.AgentID, task.IssueID); store != "" {
+		if store := execenv.CodexSessionStorePath(d.cfg.Profile, taskCtx); store != "" {
 			d.markActiveCodexStore(store)
 			defer d.unmarkActiveCodexStore(store)
 		}

--- a/server/internal/daemon/execenv/codex_home.go
+++ b/server/internal/daemon/execenv/codex_home.go
@@ -70,7 +70,7 @@ type CodexHomeOptions struct {
 	// ONLY this issue's rollouts — never the machine's whole ~/.codex/sessions.
 	// See prepareCodexSessionsDir (MUL-4424).
 	IsLocalDirectory bool
-	// SessionStoreKey is a stable, per-(agent, issue) relative path segment that
+	// SessionStoreKey is a stable, per-(agent, issue-or-chat) relative path that
 	// identifies this task's persistent Codex sessions store. It survives across
 	// task IDs (unlike the task-scoped envRoot the GC reclaims) so a follow-up
 	// run resumes the same thread. Empty when no stable key is available (e.g. a
@@ -388,21 +388,24 @@ func codexSessionStoreNamespace(profile string) string {
 	return "p_" + hex.EncodeToString(sum[:])
 }
 
-// codexSessionStoreKey builds the per-(profile, agent, issue) key for a task's
-// persistent Codex sessions store. The agent/issue IDs are server-issued UUIDs;
-// all three segments are sanitized to bare path segments defensively so a
-// malformed value can never escape the store root. Returns "" when there is no
-// issue to key on (the store is issue-scoped), leaving sessions/ task-local.
-func codexSessionStoreKey(profile, agentID, issueID string) string {
-	issue := sanitizeCodexPathSegment(issueID)
-	if issue == "" {
-		return ""
+// codexSessionStoreKey builds a profile-and-task key for persistent Codex
+// sessions. Issue IDs retain their existing path;
+// direct chats use a prefixed chat_session_id so the two namespaces cannot
+// collide. Returns "" when neither stable identifier is available.
+func codexSessionStoreKey(profile string, task TaskContextForEnv) string {
+	storeID := sanitizeCodexPathSegment(task.IssueID)
+	if storeID == "" {
+		chatID := sanitizeCodexPathSegment(task.ChatSessionID)
+		if chatID == "" {
+			return ""
+		}
+		storeID = "chat_" + chatID
 	}
-	agent := sanitizeCodexPathSegment(agentID)
+	agent := sanitizeCodexPathSegment(task.AgentID)
 	if agent == "" {
 		agent = "_"
 	}
-	return filepath.Join(codexSessionStoreNamespace(profile), agent, issue)
+	return filepath.Join(codexSessionStoreNamespace(profile), agent, storeID)
 }
 
 // sanitizeCodexPathSegment reduces s to the characters a UUID uses (hex plus
@@ -665,13 +668,13 @@ func touchCodexSessionStore(storeDir string, logger *slog.Logger) {
 	}
 }
 
-// CodexSessionStorePath returns the per-issue Codex session store directory for
-// (profile, agentID, issueID) on the shared home, or "" when there is no stable
-// key. The daemon marks this path in-use for the duration of a task so
+// CodexSessionStorePath returns the per-conversation Codex session store on the
+// shared home, or "" when there is no stable issue or chat key. The daemon
+// marks this path in-use for the duration of a task so
 // PruneCodexSessionStores never reclaims a store mid-mount, closing the
 // stat→remove race the mtime refresh alone cannot (MUL-4424).
-func CodexSessionStorePath(profile, agentID, issueID string) string {
-	key := codexSessionStoreKey(profile, agentID, issueID)
+func CodexSessionStorePath(profile string, task TaskContextForEnv) string {
+	key := codexSessionStoreKey(profile, task)
 	if key == "" {
 		return ""
 	}

--- a/server/internal/daemon/execenv/codex_home_sessions_test.go
+++ b/server/internal/daemon/execenv/codex_home_sessions_test.go
@@ -511,7 +511,7 @@ func TestPruneCodexSessionStores(t *testing.T) {
 func TestPruneCodexSessionStores_ReopenedStoreNotReclaimed(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("CODEX_HOME", home)
-	storeDir := codexSessionStoreDir(home, codexSessionStoreKey("", "agent-1", "issue-old"))
+	storeDir := codexSessionStoreDir(home, codexSessionStoreKey("", TaskContextForEnv{AgentID: "agent-1", IssueID: "issue-old"}))
 	sessionID := "019f59d9-a6aa-7a53-b173-1eccc4b4c873"
 	// A long-idle (30-day) store that still holds a resumable rollout.
 	seedRolloutAt(t, filepath.Join(storeDir, "2026", "06", "01", "rollout-2026-06-01T00-00-00-"+sessionID+".jsonl"), 16)
@@ -546,7 +546,7 @@ func TestPruneCodexSessionStores_ReopenedStoreNotReclaimed(t *testing.T) {
 func TestPruneCodexSessionStores_ActiveStoreNotReclaimed(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("CODEX_HOME", home)
-	storeDir := codexSessionStoreDir(home, codexSessionStoreKey("", "agent-1", "issue-active"))
+	storeDir := codexSessionStoreDir(home, codexSessionStoreKey("", TaskContextForEnv{AgentID: "agent-1", IssueID: "issue-active"}))
 	seedRolloutAt(t, filepath.Join(storeDir, "2026", "06", "01", "rollout-2026-06-01T00-00-00-x.jsonl"), 16)
 	// Idle past retention on disk (no remount refresh), but currently in use.
 	chtimesTree(t, storeDir, time.Now().Add(-30*24*time.Hour))
@@ -579,7 +579,7 @@ func TestPruneCodexSessionStores_IsolatesProfiles(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("CODEX_HOME", home)
 	// A store owned by the "staging" profile daemon, idle past retention.
-	stagingStore := codexSessionStoreDir(home, codexSessionStoreKey("staging", "agent-1", "issue-1"))
+	stagingStore := codexSessionStoreDir(home, codexSessionStoreKey("staging", TaskContextForEnv{AgentID: "agent-1", IssueID: "issue-1"}))
 	seedRolloutAt(t, filepath.Join(stagingStore, "2026", "06", "01", "rollout-2026-06-01T00-00-00-s.jsonl"), 16)
 	chtimesTree(t, stagingStore, time.Now().Add(-30*24*time.Hour))
 
@@ -649,8 +649,8 @@ func TestPruneCodexSessionStores_NoCrossProfileCollision(t *testing.T) {
 		home := t.TempDir()
 		t.Setenv("CODEX_HOME", home)
 		a, b := pair[0], pair[1]
-		storeA := codexSessionStoreDir(home, codexSessionStoreKey(a, "agent", "issue"))
-		storeB := codexSessionStoreDir(home, codexSessionStoreKey(b, "agent", "issue"))
+		storeA := codexSessionStoreDir(home, codexSessionStoreKey(a, TaskContextForEnv{AgentID: "agent", IssueID: "issue"}))
+		storeB := codexSessionStoreDir(home, codexSessionStoreKey(b, TaskContextForEnv{AgentID: "agent", IssueID: "issue"}))
 		seedRolloutAt(t, filepath.Join(storeA, "2026", "06", "01", "rollout-2026-06-01T00-00-00-a.jsonl"), 16)
 		seedRolloutAt(t, filepath.Join(storeB, "2026", "06", "01", "rollout-2026-06-01T00-00-00-b.jsonl"), 16)
 		chtimesTree(t, storeA, time.Now().Add(-30*24*time.Hour))

--- a/server/internal/daemon/execenv/codex_real_home_test.go
+++ b/server/internal/daemon/execenv/codex_real_home_test.go
@@ -53,6 +53,80 @@ func TestPrepareCodexKeepsRealHomeAndScopesOnlyCodexHome(t *testing.T) {
 	}
 }
 
+func TestPrepareCodexLocalDirectoryChatKeepsRolloutAcrossTaskIDs(t *testing.T) {
+	// Given: a direct chat runs against the same local directory in two tasks.
+	sharedHome := t.TempDir()
+	t.Setenv("CODEX_HOME", sharedHome)
+	workspacesRoot := t.TempDir()
+	localWorkDir := t.TempDir()
+	task := TaskContextForEnv{
+		AgentID:       "agent-chat-resume",
+		ChatSessionID: "chat-session-resume",
+	}
+
+	first, err := Prepare(PrepareParams{
+		WorkspacesRoot: workspacesRoot,
+		WorkspaceID:    "ws-chat-resume",
+		TaskID:         "11111111-1111-1111-1111-111111111111",
+		AgentName:      "Codex Agent",
+		Provider:       "codex",
+		LocalWorkDir:   localWorkDir,
+		Task:           task,
+	}, testLogger())
+	if err != nil {
+		t.Fatalf("first Prepare failed: %v", err)
+	}
+	sessionID := "019fe3de-56a2-7792-8913-ee53664dfa0e"
+	seedRolloutAt(t, filepath.Join(first.CodexHome, "sessions", "2026", "08", "09", "rollout-2026-08-09T09-13-47-"+sessionID+".jsonl"), 32)
+	if err := first.Cleanup(true); err != nil {
+		t.Fatalf("cleanup first task: %v", err)
+	}
+
+	// When: the follow-up task prepares a fresh task-scoped CODEX_HOME.
+	second, err := Prepare(PrepareParams{
+		WorkspacesRoot: workspacesRoot,
+		WorkspaceID:    "ws-chat-resume",
+		TaskID:         "22222222-2222-2222-2222-222222222222",
+		AgentName:      "Codex Agent",
+		Provider:       "codex",
+		LocalWorkDir:   localWorkDir,
+		Task:           task,
+	}, testLogger())
+	if err != nil {
+		t.Fatalf("second Prepare failed: %v", err)
+	}
+	defer second.Cleanup(true)
+
+	// Then: the prior rollout is visible, so the daemon can resume the chat.
+	if !CodexResumeRolloutPresent(second.CodexHome, sessionID) {
+		t.Fatal("follow-up direct chat cannot see the prior rollout; context would be dropped")
+	}
+}
+
+func TestCodexSessionStoreKeyUsesChatSessionIDWhenIssueAbsent(t *testing.T) {
+	// Given: two direct chats belong to the same agent and have no issue ID.
+	const agentID = "agent-chat-key"
+	const chatA = "chat-session-a"
+	const chatB = "chat-session-b"
+	taskA := TaskContextForEnv{AgentID: agentID, ChatSessionID: chatA}
+
+	// When: their persistent Codex session-store keys are built.
+	keyA := codexSessionStoreKey("", taskA)
+	keyAAgain := codexSessionStoreKey("", taskA)
+	keyB := codexSessionStoreKey("", TaskContextForEnv{AgentID: agentID, ChatSessionID: chatB})
+
+	// Then: the key is stable for one chat and isolated from another chat.
+	if keyA == "" {
+		t.Fatal("direct chat must have a persistent Codex session-store key")
+	}
+	if keyA != keyAAgain {
+		t.Fatalf("same chat produced unstable keys: %q and %q", keyA, keyAAgain)
+	}
+	if keyA == keyB {
+		t.Fatalf("different chats share one Codex session-store key: %q", keyA)
+	}
+}
+
 // TestReuseCodexToleratesLegacyTaskHome covers an env root prepared by an older
 // daemon: its leftover `home/` directory (including the credential symlinks it
 // seeded) must neither break reuse nor be adopted as a HOME again.

--- a/server/internal/daemon/execenv/execenv.go
+++ b/server/internal/daemon/execenv/execenv.go
@@ -343,7 +343,7 @@ func Prepare(params PrepareParams, logger *slog.Logger) (*Environment, error) {
 	// For Codex, set up a per-task CODEX_HOME seeded from ~/.codex/ with skills.
 	if params.Provider == "codex" {
 		codexHome := filepath.Join(envRoot, codexHomeDirName)
-		if err := prepareCodexHomeWithOpts(codexHome, CodexHomeOptions{CodexVersion: params.CodexVersion, IsLocalDirectory: params.LocalWorkDir != "", SessionStoreKey: codexSessionStoreKey(params.Profile, params.Task.AgentID, params.Task.IssueID), CodexCustomArgs: params.CodexCustomArgs}, logger); err != nil {
+		if err := prepareCodexHomeWithOpts(codexHome, CodexHomeOptions{CodexVersion: params.CodexVersion, IsLocalDirectory: params.LocalWorkDir != "", SessionStoreKey: codexSessionStoreKey(params.Profile, params.Task), CodexCustomArgs: params.CodexCustomArgs}, logger); err != nil {
 			return nil, fmt.Errorf("execenv: prepare codex-home: %w", err)
 		}
 		if err := hydrateCodexSkills(codexHome, params.Task.AgentSkills, params.Task.DisabledRuntimeSkills, logger); err != nil {
@@ -566,7 +566,7 @@ func Reuse(params ReuseParams, logger *slog.Logger) *Environment {
 	// config (especially sandbox/network access) is up to date.
 	if params.Provider == "codex" {
 		codexHome := filepath.Join(env.RootDir, codexHomeDirName)
-		if err := prepareCodexHomeWithOpts(codexHome, CodexHomeOptions{CodexVersion: params.CodexVersion, ResumeSessionID: params.ResumeSessionID, IsLocalDirectory: params.LocalDirectory, SessionStoreKey: codexSessionStoreKey(params.Profile, params.Task.AgentID, params.Task.IssueID), CodexCustomArgs: params.CodexCustomArgs}, logger); err != nil {
+		if err := prepareCodexHomeWithOpts(codexHome, CodexHomeOptions{CodexVersion: params.CodexVersion, ResumeSessionID: params.ResumeSessionID, IsLocalDirectory: params.LocalDirectory, SessionStoreKey: codexSessionStoreKey(params.Profile, params.Task), CodexCustomArgs: params.CodexCustomArgs}, logger); err != nil {
 			logger.Warn("execenv: refresh codex-home failed", "error", err)
 		} else {
 			env.CodexHome = codexHome


### PR DESCRIPTION
Closes WS-88

Summary:
- use chat_session_id as the stable Codex session storage key for direct chats
- preserve issue-based session storage behavior
- isolate different direct chats and protect active chat stores from cleanup

Verification:
- regression test passes after failing without the fix
- go test -race ./internal/daemon/...
- go vet ./internal/daemon/...
- go build ./cmd/multica
- live daemon v0.4.21-ws91 resumed the same Codex thread across task IDs f89afe4d and c9a06261

Operational note:
- deployed locally with a rollback binary retained
- independent review recorded PASS in Multica WS-90