### PR TITLE
feat(issues): add saved named views to the issues header

### DIFF
--- a/packages/core/issues/stores/saved-views-store.test.ts
+++ b/packages/core/issues/stores/saved-views-store.test.ts
@@ -1,0 +1,258 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import type { IssueViewState } from "./view-store";
+import {
+  useSavedViewsStore,
+  selectSavedViews,
+  snapshotIssueViewState,
+  applySavedViewState,
+} from "./saved-views-store";
+
+function makeState(overrides: Partial<IssueViewState> = {}): IssueViewState {
+  return {
+    viewMode: "board",
+    grouping: "status",
+    statusFilters: [],
+    priorityFilters: [],
+    assigneeFilters: [],
+    includeNoAssignee: false,
+    creatorFilters: [],
+    projectFilters: [],
+    includeNoProject: false,
+    labelFilters: [],
+    propertyFilters: {},
+    dateFilter: { field: "created_at", from: "2026-08-01", to: "2026-08-09" },
+    agentRunningFilter: true,
+    sortBy: "position",
+    sortDirection: "asc",
+    cardProperties: {
+      priority: true,
+      description: true,
+      assignee: true,
+      startDate: true,
+      dueDate: true,
+      project: true,
+      childProgress: true,
+      labels: true,
+    },
+    cardPropertyIds: [],
+    showSubIssues: true,
+    listCollapsedStatuses: [],
+    ganttZoom: "week",
+    ganttShowCompleted: false,
+    swimlaneGrouping: "assignee",
+    swimlaneOrders: { parent: [], project: [], assignee: [] },
+    collapsedSwimlanes: { parent: [], project: [], assignee: [] },
+    tableColumns: [],
+    tableGrouping: "none",
+    tableCollapsedGroups: [],
+    tableCollapsedParents: [],
+    tableHierarchy: true,
+    tableCalculation: "none",
+    // Store methods — not read by snapshotting.
+    setViewMode: () => {},
+    setGanttZoom: () => {},
+    toggleGanttShowCompleted: () => {},
+    setGrouping: () => {},
+    toggleStatusFilter: () => {},
+    togglePriorityFilter: () => {},
+    toggleAssigneeFilter: () => {},
+    toggleNoAssignee: () => {},
+    toggleCreatorFilter: () => {},
+    toggleProjectFilter: () => {},
+    toggleNoProject: () => {},
+    toggleLabelFilter: () => {},
+    togglePropertyFilter: () => {},
+    setDateFilter: () => {},
+    toggleAgentRunningFilter: () => {},
+    hideStatus: () => {},
+    showStatus: () => {},
+    clearFilters: () => {},
+    setSortBy: () => {},
+    setSortDirection: () => {},
+    toggleCardProperty: () => {},
+    toggleCardPropertyId: () => {},
+    toggleShowSubIssues: () => {},
+    toggleListCollapsed: () => {},
+    setSwimlaneGrouping: () => {},
+    setSwimlaneOrder: () => {},
+    toggleSwimlaneCollapsed: () => {},
+    toggleTableColumn: () => {},
+    reorderTableColumn: () => {},
+    setTableColumnWidth: () => {},
+    setTableGrouping: () => {},
+    toggleTableGroupCollapsed: () => {},
+    toggleTableParentCollapsed: () => {},
+    toggleTableHierarchy: () => {},
+    setTableCalculation: () => {},
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  useSavedViewsStore.setState({ byWorkspace: {} });
+});
+
+describe("useSavedViewsStore.saveView", () => {
+  it("snapshots the view state and stores it under the workspace", () => {
+    const state = makeState({
+      viewMode: "table",
+      statusFilters: ["in_progress"],
+      sortBy: "due_date",
+    });
+    const id = useSavedViewsStore.getState().saveView("ws-a", state, "My queue");
+
+    const views = useSavedViewsStore.getState().byWorkspace["ws-a"] ?? [];
+    expect(views).toHaveLength(1);
+    expect(views[0]).toMatchObject({
+      id,
+      name: "My queue",
+      state: {
+        viewMode: "table",
+        statusFilters: ["in_progress"],
+        sortBy: "due_date",
+      },
+    });
+  });
+
+  it("keeps saved views namespaced by workspace", () => {
+    const { saveView } = useSavedViewsStore.getState();
+    saveView("ws-a", makeState(), "A");
+    saveView("ws-b", makeState(), "B");
+
+    const state = useSavedViewsStore.getState().byWorkspace;
+    expect(state["ws-a"]?.map((v) => v.name)).toEqual(["A"]);
+    expect(state["ws-b"]?.map((v) => v.name)).toEqual(["B"]);
+  });
+
+  it("trims the name and appends later saves to the same workspace", () => {
+    const { saveView } = useSavedViewsStore.getState();
+    saveView("ws-a", makeState(), "  First  ");
+    saveView("ws-a", makeState(), "Second");
+
+    const names = useSavedViewsStore.getState().byWorkspace["ws-a"]?.map((v) => v.name);
+    expect(names).toEqual(["First", "Second"]);
+  });
+});
+
+describe("useSavedViewsStore.renameView", () => {
+  it("renames the matching view and trims the input", () => {
+    const { saveView, renameView } = useSavedViewsStore.getState();
+    const id = saveView("ws-a", makeState(), "Old");
+
+    renameView("ws-a", id, "  New name  ");
+
+    const views = useSavedViewsStore.getState().byWorkspace["ws-a"] ?? [];
+    expect(views[0]?.name).toBe("New name");
+  });
+
+  it("is a no-op for an unknown id", () => {
+    const { saveView, renameView } = useSavedViewsStore.getState();
+    saveView("ws-a", makeState(), "Only");
+    const before = useSavedViewsStore.getState().byWorkspace;
+
+    renameView("ws-a", "missing", "Renamed");
+
+    expect(useSavedViewsStore.getState().byWorkspace).toBe(before);
+  });
+
+  it("is a no-op when the workspace has no views", () => {
+    const { renameView } = useSavedViewsStore.getState();
+    const before = useSavedViewsStore.getState().byWorkspace;
+
+    renameView("ws-missing", "id", "Renamed");
+
+    expect(useSavedViewsStore.getState().byWorkspace).toBe(before);
+  });
+});
+
+describe("useSavedViewsStore.deleteView", () => {
+  it("removes the matching view", () => {
+    const { saveView, deleteView } = useSavedViewsStore.getState();
+    saveView("ws-a", makeState(), "Keep");
+    const id = saveView("ws-a", makeState(), "Drop");
+
+    deleteView("ws-a", id);
+
+    const names = useSavedViewsStore.getState().byWorkspace["ws-a"]?.map((v) => v.name);
+    expect(names).toEqual(["Keep"]);
+  });
+
+  it("drops the bucket entirely when the last view is removed", () => {
+    const { saveView, deleteView } = useSavedViewsStore.getState();
+    const id = saveView("ws-a", makeState(), "Only");
+    saveView("ws-b", makeState(), "Other");
+
+    deleteView("ws-a", id);
+
+    const state = useSavedViewsStore.getState().byWorkspace;
+    expect(state["ws-a"]).toBeUndefined();
+    expect(state["ws-b"]?.map((v) => v.name)).toEqual(["Other"]);
+  });
+
+  it("is a no-op for an unknown id or workspace", () => {
+    const { saveView, deleteView } = useSavedViewsStore.getState();
+    saveView("ws-a", makeState(), "Only");
+    const before = useSavedViewsStore.getState().byWorkspace;
+
+    deleteView("ws-a", "missing");
+    expect(useSavedViewsStore.getState().byWorkspace).toBe(before);
+
+    deleteView("ws-missing", "id");
+    expect(useSavedViewsStore.getState().byWorkspace).toBe(before);
+  });
+});
+
+describe("snapshotIssueViewState", () => {
+  it("captures the persisted fields and drops ephemeral ones", () => {
+    const snapshot = snapshotIssueViewState(
+      makeState({
+        viewMode: "swimlane",
+        statusFilters: ["todo", "in_progress"],
+        swimlaneGrouping: "parent",
+        dateFilter: { field: "created_at", from: "2026-08-01", to: "2026-08-09" },
+        agentRunningFilter: true,
+      }),
+    );
+
+    expect(snapshot.viewMode).toBe("swimlane");
+    expect(snapshot.statusFilters).toEqual(["todo", "in_progress"]);
+    expect(snapshot.swimlaneGrouping).toBe("parent");
+    // Ephemeral by design — never part of a saved view.
+    expect(snapshot).not.toHaveProperty("dateFilter");
+    expect(snapshot).not.toHaveProperty("agentRunningFilter");
+    // Functions never make it into a snapshot.
+    expect(snapshot).not.toHaveProperty("setViewMode");
+  });
+});
+
+describe("applySavedViewState", () => {
+  it("returns a partial that can restore a view store", () => {
+    const snapshot = snapshotIssueViewState(
+      makeState({ viewMode: "table", sortDirection: "desc" }),
+    );
+
+    const partial = applySavedViewState(snapshot);
+    expect(partial.viewMode).toBe("table");
+    expect(partial.sortDirection).toBe("desc");
+    // Must be a plain object of data — safe for Zustand setState.
+    expect(typeof partial).toBe("object");
+    expect(partial.setViewMode).toBeUndefined();
+  });
+});
+
+describe("selectSavedViews", () => {
+  it("returns the views for the given workspace", () => {
+    useSavedViewsStore.getState().saveView("ws-a", makeState(), "A");
+    const views = selectSavedViews("ws-a")(useSavedViewsStore.getState());
+    expect(views.map((v) => v.name)).toEqual(["A"]);
+  });
+
+  it("returns a stable empty array when wsId is null or unknown", () => {
+    const a = selectSavedViews(null)(useSavedViewsStore.getState());
+    const b = selectSavedViews(null)(useSavedViewsStore.getState());
+    const c = selectSavedViews("missing")(useSavedViewsStore.getState());
+    expect(a).toBe(b);
+    expect(a).toBe(c);
+    expect(a).toEqual([]);
+  });
+});

--- a/packages/core/issues/stores/saved-views-store.ts
+++ b/packages/core/issues/stores/saved-views-store.ts
@@ -1,0 +1,172 @@
+"use client";
+
+import { create } from "zustand";
+import { createJSONStorage, persist } from "zustand/middleware";
+import { defaultStorage } from "../../platform/storage";
+import { createSafeId } from "../../utils";
+import type { IssueViewState } from "./view-store";
+
+const EMPTY: SavedIssueView[] = [];
+
+export interface SavedIssueView {
+  id: string;
+  name: string;
+  createdAt: number;
+  state: SavedIssueViewState;
+}
+
+/**
+ * Serializable snapshot of the persisted issue-view fields. Mirrors the
+ * `partialize` list in `viewStorePersistOptions` so a saved view restores
+ * exactly what survives a reload. `dateFilter` and `agentRunningFilter` are
+ * intentionally excluded — both are ephemeral on purpose (see the field
+ * comments on `IssueViewState`).
+ */
+export type SavedIssueViewState = Pick<
+  IssueViewState,
+  | "viewMode"
+  | "grouping"
+  | "statusFilters"
+  | "priorityFilters"
+  | "assigneeFilters"
+  | "includeNoAssignee"
+  | "creatorFilters"
+  | "projectFilters"
+  | "includeNoProject"
+  | "labelFilters"
+  | "propertyFilters"
+  | "sortBy"
+  | "sortDirection"
+  | "cardProperties"
+  | "cardPropertyIds"
+  | "showSubIssues"
+  | "listCollapsedStatuses"
+  | "ganttZoom"
+  | "ganttShowCompleted"
+  | "swimlaneGrouping"
+  | "swimlaneOrders"
+  | "collapsedSwimlanes"
+  | "tableColumns"
+  | "tableGrouping"
+  | "tableCollapsedGroups"
+  | "tableCollapsedParents"
+  | "tableHierarchy"
+  | "tableCalculation"
+>;
+
+interface SavedViewsState {
+  /** Saved views grouped by workspace id (UUID). */
+  byWorkspace: Record<string, SavedIssueView[]>;
+  /** Snapshot the current view state and persist it as a named view. */
+  saveView: (wsId: string, state: IssueViewState, name: string) => string;
+  renameView: (wsId: string, id: string, name: string) => void;
+  deleteView: (wsId: string, id: string) => void;
+}
+
+/** Extract the persisted subset of a live view state into a snapshot. */
+export function snapshotIssueViewState(state: IssueViewState): SavedIssueViewState {
+  return {
+    viewMode: state.viewMode,
+    grouping: state.grouping,
+    statusFilters: state.statusFilters,
+    priorityFilters: state.priorityFilters,
+    assigneeFilters: state.assigneeFilters,
+    includeNoAssignee: state.includeNoAssignee,
+    creatorFilters: state.creatorFilters,
+    projectFilters: state.projectFilters,
+    includeNoProject: state.includeNoProject,
+    labelFilters: state.labelFilters,
+    propertyFilters: state.propertyFilters,
+    sortBy: state.sortBy,
+    sortDirection: state.sortDirection,
+    cardProperties: state.cardProperties,
+    cardPropertyIds: state.cardPropertyIds,
+    showSubIssues: state.showSubIssues,
+    listCollapsedStatuses: state.listCollapsedStatuses,
+    ganttZoom: state.ganttZoom,
+    ganttShowCompleted: state.ganttShowCompleted,
+    swimlaneGrouping: state.swimlaneGrouping,
+    swimlaneOrders: state.swimlaneOrders,
+    collapsedSwimlanes: state.collapsedSwimlanes,
+    tableColumns: state.tableColumns,
+    tableGrouping: state.tableGrouping,
+    tableCollapsedGroups: state.tableCollapsedGroups,
+    tableCollapsedParents: state.tableCollapsedParents,
+    tableHierarchy: state.tableHierarchy,
+    tableCalculation: state.tableCalculation,
+  };
+}
+
+/** A snapshot is directly usable as a `setState` partial on a view store. */
+export function applySavedViewState(state: SavedIssueViewState): Partial<IssueViewState> {
+  return { ...state };
+}
+
+/** Selector for the saved views of one workspace. */
+export function selectSavedViews(wsId: string | null) {
+  return (state: SavedViewsState) => (wsId ? (state.byWorkspace[wsId] ?? EMPTY) : EMPTY);
+}
+
+/**
+ * Saved named issue-view presets, per workspace.
+ *
+ * Namespaced by workspace id in the data (not via `createWorkspaceAwareStorage`)
+ * for the same reason as `useRecentIssuesStore`: child effects can write to a
+ * store before WorkspaceRouteLayout has set the current slug, which would leak
+ * the preset into a shared bare key. Keying on wsId keeps presets per-workspace
+ * and survives workspace renames.
+ */
+export const useSavedViewsStore = create<SavedViewsState>()(
+  persist(
+    (set) => ({
+      byWorkspace: {},
+      saveView: (wsId, state, name) => {
+        const id = createSafeId();
+        const view: SavedIssueView = {
+          id,
+          name: name.trim(),
+          createdAt: Date.now(),
+          state: snapshotIssueViewState(state),
+        };
+        set((current) => ({
+          byWorkspace: {
+            ...current.byWorkspace,
+            [wsId]: [...(current.byWorkspace[wsId] ?? EMPTY), view],
+          },
+        }));
+        return id;
+      },
+      renameView: (wsId, id, name) =>
+        set((current) => {
+          const list = current.byWorkspace[wsId];
+          if (!list) return current;
+          let changed = false;
+          const next = list.map((view) => {
+            if (view.id !== id) return view;
+            changed = true;
+            return { ...view, name: name.trim() };
+          });
+          if (!changed) return current;
+          return { byWorkspace: { ...current.byWorkspace, [wsId]: next } };
+        }),
+      deleteView: (wsId, id) =>
+        set((current) => {
+          const list = current.byWorkspace[wsId];
+          if (!list) return current;
+          const next = list.filter((view) => view.id !== id);
+          if (next.length === list.length) return current;
+          if (next.length === 0) {
+            const { [wsId]: _removed, ...rest } = current.byWorkspace;
+            return { byWorkspace: rest };
+          }
+          return { byWorkspace: { ...current.byWorkspace, [wsId]: next } };
+        }),
+    }),
+    {
+      name: "multica_saved_views",
+      storage: createJSONStorage(() => defaultStorage),
+      version: 1,
+      partialize: (state) => ({ byWorkspace: state.byWorkspace }),
+    },
+  ),
+);

--- a/packages/views/issues/components/issues-header.tsx
+++ b/packages/views/issues/components/issues-header.tsx
@@ -97,6 +97,7 @@ import { matchesPinyin } from "../../editor/extensions/pinyin-match";
 import { FILTER_ITEM_CLASS, HoverCheck } from "../../common/hover-check";
 import { WorkspaceAgentWorkingChip } from "./workspace-agent-working-chip";
 import { TableColumnPicker } from "./table-view";
+import { SavedViewsMenu } from "./saved-views-menu";
 
 type LocalDateRange = {
   from: Date | undefined;
@@ -806,6 +807,7 @@ export function IssuesHeader({
   facetCountsExact = true,
   tableFacetCounts,
   onTableFacetChange,
+  enableSavedViews = false,
 }: {
   scopedIssues: Issue[];
   /** See IssueSurfaceController.workingAgents — the surface-scoped projection
@@ -819,6 +821,13 @@ export function IssuesHeader({
   facetCountsExact?: boolean;
   tableFacetCounts?: IssueTableFacetsResponse;
   onTableFacetChange?: (facet: IssueTableFacetSpec | null) => void;
+  /**
+   * Surface the "saved views" dropdown. Only the workspace /issues surface
+   * enables it: saved presets snapshot workspace-wide filters, so enabling on
+   * scoped surfaces (project detail, actor panels) would let a preset fight
+   * the surface's fixed scope.
+   */
+  enableSavedViews?: boolean;
 }) {
   const { t } = useT("issues");
   const scope = useIssuesScopeStore((s) => s.scope);
@@ -907,6 +916,7 @@ export function IssuesHeader({
             onToggle={toggleAgentRunningFilter}
             agents={workingAgents}
           />
+          {enableSavedViews && <SavedViewsMenu />}
           <IssueDisplayControls
             scopedIssues={scopedIssues}
             allowGantt={allowGantt}

--- a/packages/views/issues/components/issues-page.tsx
+++ b/packages/views/issues/components/issues-page.tsx
@@ -42,6 +42,7 @@ function IssuesSurfaceHeader({
       facetCountsExact={facetCountsExact}
       tableFacetCounts={tableFacetCounts}
       onTableFacetChange={onTableFacetChange}
+      enableSavedViews
     />
   );
 }

--- a/packages/views/issues/components/saved-views-menu.test.tsx
+++ b/packages/views/issues/components/saved-views-menu.test.tsx
@@ -1,0 +1,148 @@
+// @vitest-environment jsdom
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { createStore } from "zustand/vanilla";
+import { I18nProvider } from "@multica/core/i18n/react";
+import enCommon from "../../locales/en/common.json";
+import enIssues from "../../locales/en/issues.json";
+import { ViewStoreProvider } from "@multica/core/issues/stores/view-store-context";
+import {
+  viewStoreSlice,
+  type IssueViewState,
+} from "@multica/core/issues/stores/view-store";
+import { useSavedViewsStore } from "@multica/core/issues/stores/saved-views-store";
+import { SavedViewsMenu } from "./saved-views-menu";
+
+const TEST_RESOURCES = { en: { common: enCommon, issues: enIssues } };
+
+vi.mock("@multica/core/hooks", () => ({
+  useWorkspaceId: () => "ws-1",
+}));
+
+function makeViewStore() {
+  return createStore<IssueViewState>()(viewStoreSlice);
+}
+
+function renderMenu(store = makeViewStore()) {
+  const utils = render(
+    <I18nProvider locale="en" resources={TEST_RESOURCES}>
+      <ViewStoreProvider store={store}>
+        <SavedViewsMenu />
+      </ViewStoreProvider>
+    </I18nProvider>,
+  );
+  return { ...utils, store };
+}
+
+beforeEach(() => {
+  localStorage.clear();
+  useSavedViewsStore.setState({ byWorkspace: {} });
+});
+
+function openMenu() {
+  fireEvent.click(screen.getByRole("button", { name: "Saved views" }));
+}
+
+async function openViewActions(name: string, itemName: string) {
+  const user = userEvent.setup();
+  // Base UI submenus open on hover (with a 100ms delay). userEvent.hover
+  // dispatches the pointer events Base UI listens for; fireEvent.mouseEnter
+  // does not, so hover must go through userEvent.
+  await user.hover(screen.getByText(name));
+  await waitFor(() => {
+    expect(screen.getByRole("menuitem", { name: itemName })).toBeInTheDocument();
+  });
+}
+
+describe("SavedViewsMenu", () => {
+  it("renders the trigger and shows the empty state", () => {
+    renderMenu();
+
+    openMenu();
+
+    expect(
+      screen.getByText(
+        "No saved views yet. Save the current filters and layout as a reusable view.",
+      ),
+    ).toBeInTheDocument();
+  });
+
+  it("saves the current view state under a name", () => {
+    const { store } = renderMenu();
+    store.setState({
+      viewMode: "table",
+      statusFilters: ["in_progress"],
+      sortBy: "due_date",
+    });
+
+    openMenu();
+    fireEvent.click(screen.getByRole("menuitem", { name: /Save current view/ }));
+    fireEvent.change(screen.getByPlaceholderText("View name"), {
+      target: { value: "My queue" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Save" }));
+
+    expect(screen.getByText("My queue")).toBeInTheDocument();
+
+    const saved = useSavedViewsStore.getState().byWorkspace["ws-1"] ?? [];
+    expect(saved).toHaveLength(1);
+    expect(saved[0]?.name).toBe("My queue");
+    expect(saved[0]?.state.viewMode).toBe("table");
+    expect(saved[0]?.state.statusFilters).toEqual(["in_progress"]);
+    expect(saved[0]?.state.sortBy).toBe("due_date");
+  });
+
+  it("applies a saved view back onto the view store", async () => {
+    const seeded = makeViewStore();
+    seeded.setState({ viewMode: "swimlane", swimlaneGrouping: "parent" });
+    useSavedViewsStore
+      .getState()
+      .saveView("ws-1", seeded.getState(), "My lanes");
+
+    const viewStore = makeViewStore();
+    renderMenu(viewStore);
+
+    openMenu();
+    await openViewActions("My lanes", "Apply");
+    fireEvent.click(screen.getByRole("menuitem", { name: "Apply" }));
+
+    expect(viewStore.getState().viewMode).toBe("swimlane");
+    expect(viewStore.getState().swimlaneGrouping).toBe("parent");
+  });
+
+  it("renames a saved view", async () => {
+    useSavedViewsStore
+      .getState()
+      .saveView("ws-1", makeViewStore().getState(), "Old name");
+    renderMenu();
+
+    openMenu();
+    await openViewActions("Old name", "Rename");
+    fireEvent.click(screen.getByRole("menuitem", { name: "Rename" }));
+
+    const input = screen.getByPlaceholderText("View name");
+    fireEvent.change(input, { target: { value: "New name" } });
+    fireEvent.click(screen.getByRole("button", { name: "Save" }));
+
+    const saved = useSavedViewsStore.getState().byWorkspace["ws-1"] ?? [];
+    expect(saved[0]?.name).toBe("New name");
+    expect(screen.getByText("New name")).toBeInTheDocument();
+  });
+
+  it("deletes a saved view", async () => {
+    useSavedViewsStore
+      .getState()
+      .saveView("ws-1", makeViewStore().getState(), "Doomed");
+    renderMenu();
+
+    openMenu();
+    await openViewActions("Doomed", "Delete");
+    fireEvent.click(screen.getByRole("menuitem", { name: "Delete" }));
+
+    expect(useSavedViewsStore.getState().byWorkspace["ws-1"] ?? []).toHaveLength(
+      0,
+    );
+    expect(screen.queryByText("Doomed")).not.toBeInTheDocument();
+  });
+});

--- a/packages/views/issues/components/saved-views-menu.tsx
+++ b/packages/views/issues/components/saved-views-menu.tsx
@@ -1,0 +1,246 @@
+"use client";
+
+import { useState } from "react";
+import { Bookmark, Check, Pencil, Plus, Trash2, X } from "lucide-react";
+import { Button } from "@multica/ui/components/ui/button";
+import { Input } from "@multica/ui/components/ui/input";
+import {
+  DropdownMenu,
+  DropdownMenuTrigger,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuGroup,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuSub,
+  DropdownMenuSubTrigger,
+  DropdownMenuSubContent,
+} from "@multica/ui/components/ui/dropdown-menu";
+import { Tooltip, TooltipTrigger, TooltipContent } from "@multica/ui/components/ui/tooltip";
+import { useWorkspaceId } from "@multica/core/hooks";
+import {
+  useSavedViewsStore,
+  selectSavedViews,
+  applySavedViewState,
+} from "@multica/core/issues/stores/saved-views-store";
+import { useViewStoreApi } from "@multica/core/issues/stores/view-store-context";
+import { useT } from "../../i18n";
+import { cn } from "@multica/ui/lib/utils";
+
+/**
+ * "Saved views" dropdown for the issues header. Lets a user snapshot the
+ * current filter / sort / view-mode / column configuration under a name and
+ * switch between presets without re-picking filters.
+ *
+ * Phase 1 is per-user and local: presets are persisted in browser storage and
+ * namespaced by workspace id. Sharing presets with teammates is a follow-up.
+ */
+export function SavedViewsMenu({
+  triggerClassName,
+}: {
+  triggerClassName?: string;
+}) {
+  const { t } = useT("issues");
+  const wsId = useWorkspaceId();
+  const savedViews = useSavedViewsStore(selectSavedViews(wsId));
+  const saveView = useSavedViewsStore((s) => s.saveView);
+  const renameView = useSavedViewsStore((s) => s.renameView);
+  const deleteView = useSavedViewsStore((s) => s.deleteView);
+  const viewStoreApi = useViewStoreApi();
+
+  const [open, setOpen] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const [saveName, setSaveName] = useState("");
+  const [renamingId, setRenamingId] = useState<string | null>(null);
+  const [renameName, setRenameName] = useState("");
+
+  const applyView = (id: string) => {
+    const view = savedViews.find((candidate) => candidate.id === id);
+    if (!view) return;
+    viewStoreApi.setState(applySavedViewState(view.state));
+    setOpen(false);
+  };
+
+  const confirmSave = () => {
+    const name = saveName.trim();
+    if (!name) return;
+    saveView(wsId, viewStoreApi.getState(), name);
+    setSaveName("");
+    setSaving(false);
+  };
+
+  const startRename = (id: string, name: string) => {
+    setRenamingId(id);
+    setRenameName(name);
+  };
+
+  const confirmRename = () => {
+    const name = renameName.trim();
+    if (renamingId && name) renameView(wsId, renamingId, name);
+    setRenamingId(null);
+    setRenameName("");
+  };
+
+  const cancelRename = () => {
+    setRenamingId(null);
+    setRenameName("");
+  };
+
+  return (
+    <DropdownMenu open={open} onOpenChange={setOpen}>
+      <Tooltip>
+        <DropdownMenuTrigger
+          render={
+            <TooltipTrigger
+              render={
+                <Button
+                  type="button"
+                  variant="outline"
+                  size="sm"
+                  aria-label={t(($) => $.saved_views.menu_tooltip)}
+                  className={cn("shrink-0", triggerClassName)}
+                >
+                  <Bookmark className="size-3.5" />
+                  {savedViews.length > 0 && (
+                    <span className="text-caption text-muted-foreground">
+                      {savedViews.length}
+                    </span>
+                  )}
+                </Button>
+              }
+            />
+          }
+        />
+        <TooltipContent side="bottom">
+          {t(($) => $.saved_views.menu_tooltip)}
+        </TooltipContent>
+      </Tooltip>
+
+      <DropdownMenuContent align="end" className="w-64">
+        <DropdownMenuGroup>
+          <DropdownMenuLabel>{t(($) => $.saved_views.menu_label)}</DropdownMenuLabel>
+        </DropdownMenuGroup>
+
+        {savedViews.length === 0 ? (
+          <p className="px-1.5 py-1.5 text-caption text-muted-foreground">
+            {t(($) => $.saved_views.empty)}
+          </p>
+        ) : (
+          <div className="max-h-64 overflow-y-auto">
+            {savedViews.map((view) => (
+              <DropdownMenuSub key={view.id}>
+                <DropdownMenuSubTrigger className="gap-2">
+                  <Bookmark className="size-3.5 shrink-0 text-muted-foreground" />
+                  <span className="min-w-0 flex-1 truncate">{view.name}</span>
+                </DropdownMenuSubTrigger>
+                <DropdownMenuSubContent alignOffset={-4} sideOffset={-2}>
+                  {renamingId === view.id ? (
+                    <div className="flex items-center gap-1 p-1">
+                      <Input
+                        autoFocus
+                        value={renameName}
+                        onChange={(event) => setRenameName(event.target.value)}
+                        onKeyDown={(event) => {
+                          if (event.key === "Enter") confirmRename();
+                          if (event.key === "Escape") cancelRename();
+                        }}
+                        placeholder={t(($) => $.saved_views.name_placeholder)}
+                        className="h-7 text-body"
+                      />
+                      <Button
+                        type="button"
+                        size="icon-sm"
+                        aria-label={t(($) => $.saved_views.save)}
+                        onClick={confirmRename}
+                        disabled={!renameName.trim()}
+                      >
+                        <Check />
+                      </Button>
+                      <Button
+                        type="button"
+                        size="icon-sm"
+                        variant="ghost"
+                        aria-label={t(($) => $.saved_views.cancel)}
+                        onClick={cancelRename}
+                      >
+                        <X />
+                      </Button>
+                    </div>
+                  ) : (
+                    <>
+                      <DropdownMenuItem onClick={() => applyView(view.id)}>
+                        <Bookmark />
+                        {t(($) => $.saved_views.apply)}
+                      </DropdownMenuItem>
+                      <DropdownMenuItem
+                        closeOnClick={false}
+                        onClick={() => startRename(view.id, view.name)}
+                      >
+                        <Pencil />
+                        {t(($) => $.saved_views.rename)}
+                      </DropdownMenuItem>
+                      <DropdownMenuItem
+                        variant="destructive"
+                        onClick={() => deleteView(wsId, view.id)}
+                      >
+                        <Trash2 />
+                        {t(($) => $.saved_views.delete)}
+                      </DropdownMenuItem>
+                    </>
+                  )}
+                </DropdownMenuSubContent>
+              </DropdownMenuSub>
+            ))}
+          </div>
+        )}
+
+        <DropdownMenuSeparator />
+
+        {saving ? (
+          <div className="flex items-center gap-1 p-1">
+            <Input
+              autoFocus
+              value={saveName}
+              onChange={(event) => setSaveName(event.target.value)}
+              onKeyDown={(event) => {
+                if (event.key === "Enter") confirmSave();
+                if (event.key === "Escape") {
+                  setSaveName("");
+                  setSaving(false);
+                }
+              }}
+              placeholder={t(($) => $.saved_views.name_placeholder)}
+              className="h-7 text-body"
+            />
+            <Button
+              type="button"
+              size="icon-sm"
+              aria-label={t(($) => $.saved_views.save)}
+              onClick={confirmSave}
+              disabled={!saveName.trim()}
+            >
+              <Check />
+            </Button>
+            <Button
+              type="button"
+              size="icon-sm"
+              variant="ghost"
+              aria-label={t(($) => $.saved_views.cancel)}
+              onClick={() => {
+                setSaveName("");
+                setSaving(false);
+              }}
+            >
+              <X />
+            </Button>
+          </div>
+        ) : (
+          <DropdownMenuItem closeOnClick={false} onClick={() => setSaving(true)}>
+            <Plus />
+            {t(($) => $.saved_views.save_current)}
+          </DropdownMenuItem>
+        )}
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}

--- a/packages/views/locales/en/issues.json
+++ b/packages/views/locales/en/issues.json
@@ -109,6 +109,18 @@
     "gantt": "Gantt",
     "swimlane": "Swimlane"
   },
+  "saved_views": {
+    "menu_label": "Saved views",
+    "menu_tooltip": "Saved views",
+    "empty": "No saved views yet. Save the current filters and layout as a reusable view.",
+    "apply": "Apply",
+    "rename": "Rename",
+    "delete": "Delete",
+    "save_current": "Save current view…",
+    "name_placeholder": "View name",
+    "save": "Save",
+    "cancel": "Cancel"
+  },
   "table": {
     "select_all": "Select all visible issues",
     "select_issue": "Select {{identifier}}",

--- a/packages/views/locales/ja/issues.json
+++ b/packages/views/locales/ja/issues.json
@@ -107,6 +107,18 @@
     "gantt": "ガント",
     "swimlane": "スイムレーン"
   },
+  "saved_views": {
+    "menu_label": "保存したビュー",
+    "menu_tooltip": "保存したビュー",
+    "empty": "保存したビューはまだありません。現在のフィルターとレイアウトを再利用可能なビューとして保存できます。",
+    "apply": "適用",
+    "rename": "名前を変更",
+    "delete": "削除",
+    "save_current": "現在のビューを保存…",
+    "name_placeholder": "ビュー名",
+    "save": "保存",
+    "cancel": "キャンセル"
+  },
   "table": {
     "select_all": "表示中のタスクをすべて選択",
     "select_issue": "{{identifier}} を選択",

--- a/packages/views/locales/ko/issues.json
+++ b/packages/views/locales/ko/issues.json
@@ -107,6 +107,18 @@
     "gantt": "간트",
     "swimlane": "스윔레인"
   },
+  "saved_views": {
+    "menu_label": "저장된 보기",
+    "menu_tooltip": "저장된 보기",
+    "empty": "저장된 보기가 아직 없습니다. 현재 필터와 레이아웃을 재사용 가능한 보기로 저장하세요.",
+    "apply": "적용",
+    "rename": "이름 바꾸기",
+    "delete": "삭제",
+    "save_current": "현재 보기 저장…",
+    "name_placeholder": "보기 이름",
+    "save": "저장",
+    "cancel": "취소"
+  },
   "table": {
     "select_all": "표시된 모든 태스크 선택",
     "select_issue": "{{identifier}} 선택",

--- a/packages/views/locales/zh-Hans/issues.json
+++ b/packages/views/locales/zh-Hans/issues.json
@@ -107,6 +107,18 @@
     "gantt": "甘特图",
     "swimlane": "泳道"
   },
+  "saved_views": {
+    "menu_label": "已保存视图",
+    "menu_tooltip": "已保存视图",
+    "empty": "暂无已保存视图。可将当前筛选与布局保存为可复用的视图。",
+    "apply": "应用",
+    "rename": "重命名",
+    "delete": "删除",
+    "save_current": "保存当前视图…",
+    "name_placeholder": "视图名称",
+    "save": "保存",
+    "cancel": "取消"
+  },
   "table": {
     "select_all": "选择所有可见任务",
     "select_issue": "选择 {{identifier}}",


### PR DESCRIPTION
## What does this PR do?

Adds a **saved named views** feature to the workspace `/issues` header (Phase 1, frontend-only, per-user/local). Power users often work from recurring filters ("my review queue", "this week's releases"); today recreating them means re-picking filters every time. This PR lets a user snapshot the current filter / sort / view-mode / column configuration under a name and switch between presets without re-picking filters.

Scope for this PR (as agreed in the issue):
- **Save** — "Save current view…" in a new dropdown snapshots the active view state under a user-chosen name (inline name input in the menu).
- **Apply / Rename / Delete** — each saved view opens a small submenu with Apply, Rename, and Delete.
- **Per-workspace, local** — presets are persisted in browser storage, namespaced by workspace id. No backend, no sharing (follow-ups).
- **Only on the workspace /issues surface** — gated by an `enableSavedViews` flag so scoped surfaces (project detail, actor panels) keep their fixed scope.

## Related Issue

Closes #6645

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Refactor / code improvement (no behavior change)
- [ ] Documentation update
- [ ] Tests (adding or improving test coverage)
- [ ] CI / infrastructure

## Changes Made

- `packages/core/issues/stores/saved-views-store.ts` — new persisted Zustand store holding named snapshots of the persisted `IssueViewState` fields (mirrors the view store's `partialize` list; `dateFilter` / `agentRunningFilter` stay ephemeral by design). Snapshot + apply helpers.
- `packages/views/issues/components/saved-views-menu.tsx` — the dropdown UI (trigger with saved-view count, per-view submenu with Apply/Rename/Delete, inline save/rename inputs).
- `packages/views/issues/components/issues-header.tsx` — `enableSavedViews` prop; renders `SavedViewsMenu` when enabled.
- `packages/views/issues/components/issues-page.tsx` — enables saved views on the workspace /issues surface.
- `packages/views/locales/{en,zh-Hans,ja,ko}/issues.json` — `saved_views` strings.

## How to Test

1. Open `/issues`, set a combination of filters / sort / view mode / table columns.
2. Click the bookmark icon → "Save current view…" → name it.
3. The preset appears; change the filters, then click the preset → Apply → the view restores the saved configuration.
4. Rename and delete presets from the per-view submenu.
5. Reload the page — presets persist (per workspace).

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [ ] I have updated relevant documentation to reflect my changes
- [ ] If I added a new runtime / coding tool / UI tab, I synced the change to **landing copy** (`apps/web/features/landing/i18n/`) and **relevant docs** (`apps/docs/content/docs/`)
- [x] If this PR touches Chinese product copy, I checked it against `apps/docs/content/docs/developers/conventions.zh.mdx` (terminology, mixed-rule for `task` / `issue` / `skill`)
- [x] I have considered and documented any risks above
- [x] I will address all reviewer comments before requesting merge

## AI Disclosure

**AI tool used:** Multica Agent (Claude Code runtime)

**Prompt / approach:**
Implemented as part of a Multica open-source co-construction effort. The feature was scoped from a product design review: pick a no-backend Phase-1 item ("saved named views") and land it via the contribution path (worktree → tests → PR). Code was written and iterated with AI assistance, then reviewed against the repo's conventions (Zustand store placement in `packages/core`, Base UI dropdown primitives, `packages/views/locales` parity).

## Verification notes

- `pnpm typecheck` (packages/core + packages/views) — pass.
- Unit tests: packages/core full suite **1358 passing** (incl. new `saved-views-store.test.ts`); packages/views new `saved-views-menu.test.tsx` **5 passing**; `locales/parity.test.ts` **160 passing**; existing `issues-page.test.tsx` / `issue-detail.test.tsx` still green.
- **Not run in this environment:** full `make check` (needs Go + PostgreSQL + Playwright browsers, unavailable here) and before/after screenshots (app not runnable in the sandbox). CI will run the complete suite; screenshots to follow from a local run if the maintainers want them.

## Screenshots (optional)

Not available from the authoring environment; see verification notes.
