### PR TITLE
fix(daemon): auto-retry transient rate/session-limit run failures

### DIFF
--- a/server/internal/service/task.go
+++ b/server/internal/service/task.go
@@ -4929,6 +4929,23 @@ func (s *TaskService) FailTask(ctx context.Context, taskID pgtype.UUID, errMsg, 
 		}
 	}
 
+	// Visibility for a *deferred* auto-retry (MS-121): when the retry child was
+	// pushed out by a real backoff, the issue would otherwise sit silent for
+	// 15m–4h with no sign that a retry is pending. Post one system comment so the
+	// history shows this was automatic, not a manual rerun. Gated on a >=1min
+	// delay so provider_network's ~5s final-attempt deferral stays silent — only
+	// the capacity/rate/session-limit schedule is announced. The raw-error
+	// comment below is skipped whenever retried != nil, so there is no duplicate.
+	if retried != nil && retryFireAt.Valid && task.IssueID.Valid {
+		if wait := time.Until(retryFireAt.Time); wait >= time.Minute {
+			note := fmt.Sprintf(
+				"Transient provider limit hit (%s) — auto-retry scheduled in ~%s (attempt %d of %d). No manual rerun needed.",
+				failureReason, wait.Round(time.Minute), retried.Attempt, retried.MaxAttempts,
+			)
+			s.createAgentComment(ctx, task.IssueID, task.AgentID, note, "system", task.TriggerCommentID, task.ID)
+		}
+	}
+
 	// Skip the per-failure system comment when we'll immediately retry —
 	// the new task will surface its own status to the user, and we don't
 	// want to spam the issue with "task timed out" messages on every
@@ -4990,13 +5007,25 @@ func (s *TaskService) FailTask(ctx context.Context, taskID pgtype.UUID, errMsg, 
 // never started, so there is nothing to be idempotent about, and every bundle
 // that did download is already cached on disk — a retry resumes from there
 // instead of re-fetching the whole set (MUL-5370).
+//
+// The second agent_error.* exception is provider_capacity_or_rate_limit: an
+// HTTP 429 / provider overload or a session/usage-window limit
+// ("You've hit your session limit · resets 2pm") is transient infrastructure
+// backpressure, not an agent decision — waiting for the provider cooldown
+// clears it. Unattended issue runs otherwise sit on `todo` forever after a
+// single limit-hit run failed (MS-121). Unlike provider_network's seconds-scale
+// blip, this reason needs a real staggered backoff (15m / 1h / 4h) and is gated
+// to issue runs in retryEligible, so an interactive chat turn is never silently
+// deferred for hours. It is resume-safe, so the retry child continues the
+// session rather than restarting.
 var retryableReasons = map[string]bool{
-	string(taskfailure.ReasonRuntimeOffline):         true,
-	string(taskfailure.ReasonRuntimeRecovery):        true,
-	string(taskfailure.ReasonTimeout):                true,
-	"codex_semantic_inactivity":                      true,
-	string(taskfailure.ReasonAgentProviderNetwork):   true,
-	string(taskfailure.ReasonSkillBundleUnavailable): true,
+	string(taskfailure.ReasonRuntimeOffline):                   true,
+	string(taskfailure.ReasonRuntimeRecovery):                  true,
+	string(taskfailure.ReasonTimeout):                          true,
+	"codex_semantic_inactivity":                                true,
+	string(taskfailure.ReasonAgentProviderNetwork):             true,
+	string(taskfailure.ReasonSkillBundleUnavailable):           true,
+	string(taskfailure.ReasonAgentProviderCapacityOrRateLimit): true,
 }
 
 // runtime_offline retries start deferred, not queued: their positive fire_at
@@ -5017,6 +5046,17 @@ const (
 	providerNetworkFinalRetryWait = 5 * time.Second
 )
 
+// Provider capacity / rate / session limits (provider_capacity_or_rate_limit)
+// recover only after a real provider-side cooldown, so they get a staggered
+// backoff instead of provider_network's back-to-back retry (MS-121). The three
+// retries wait 15m, then 1h, then 4h; capacityRateLimitMaxAttempts is
+// 1 (original run) + len(capacityRateLimitBackoff). Once the budget is spent the
+// run stays `failed` and the issue is visibly unworked — a hard ceiling, never a
+// silent endless retry. (A dedicated test pins the two constants in sync.)
+const capacityRateLimitMaxAttempts = 4
+
+var capacityRateLimitBackoff = []time.Duration{15 * time.Minute, time.Hour, 4 * time.Hour}
+
 // retryAttemptCeiling reports how many attempts the auto-retry path allows for
 // a failure reason. It only ever WIDENS the task's generic max_attempts, and
 // only for reasons with a bespoke schedule; everything else keeps the column's
@@ -5032,8 +5072,15 @@ func retryAttemptCeiling(reason string, taskMaxAttempts int32) int32 {
 	if taskMaxAttempts <= 1 {
 		return taskMaxAttempts
 	}
-	if reason == string(taskfailure.ReasonAgentProviderNetwork) && taskMaxAttempts < providerNetworkMaxAttempts {
-		return providerNetworkMaxAttempts
+	switch reason {
+	case string(taskfailure.ReasonAgentProviderNetwork):
+		if taskMaxAttempts < providerNetworkMaxAttempts {
+			return providerNetworkMaxAttempts
+		}
+	case string(taskfailure.ReasonAgentProviderCapacityOrRateLimit):
+		if taskMaxAttempts < capacityRateLimitMaxAttempts {
+			return capacityRateLimitMaxAttempts
+		}
 	}
 	return taskMaxAttempts
 }
@@ -5045,12 +5092,20 @@ func retryAttemptCeiling(reason string, taskMaxAttempts int32) int32 {
 // the child is created 'queued', claimable at once). Callers pass the returned
 // delay to CreateRetryTask via fire_at.
 func retryDelayForAttempt(reason string, failedAttempt int32) time.Duration {
-	if reason == string(taskfailure.ReasonRuntimeOffline) {
+	switch reason {
+	case string(taskfailure.ReasonRuntimeOffline):
 		return runtimeOfflineRetryDeferral
-	}
-	if reason == string(taskfailure.ReasonAgentProviderNetwork) &&
-		failedAttempt >= providerNetworkMaxAttempts-1 {
-		return providerNetworkFinalRetryWait
+	case string(taskfailure.ReasonAgentProviderNetwork):
+		if failedAttempt >= providerNetworkMaxAttempts-1 {
+			return providerNetworkFinalRetryWait
+		}
+	case string(taskfailure.ReasonAgentProviderCapacityOrRateLimit):
+		// failedAttempt is 1-based (the attempt that just failed). Map attempt N
+		// to schedule index N-1: attempt 1 → 15m, 2 → 1h, 3 → 4h. Past the
+		// schedule the ceiling has been reached and no further child is created.
+		if idx := int(failedAttempt) - 1; idx >= 0 && idx < len(capacityRateLimitBackoff) {
+			return capacityRateLimitBackoff[idx]
+		}
 	}
 	return 0
 }
@@ -5122,8 +5177,19 @@ func ResumeUnsafeFailure(failureReason, errorText string) bool {
 // FailTask's in-transaction retry and the orphan sweeper's MaybeRetryFailedTask
 // so both agree on which failures re-run.
 func retryEligible(failureReason string, t db.AgentTaskQueue) bool {
-	return retryableReasons[failureReason] &&
-		t.Attempt < retryAttemptCeiling(failureReason, t.MaxAttempts) &&
+	if !retryableReasons[failureReason] {
+		return false
+	}
+	// Capacity / rate / session limits recover only after a 15m–4h cooldown.
+	// Deferring an interactive chat turn that long would leave the user staring
+	// at a silent pending message; the CLI's own retry plus the pending-message
+	// pattern already cover transient chat blips. Restrict this reason's
+	// staggered-backoff auto-retry to unattended issue runs (MS-121). Every other
+	// retryable reason (seconds-scale) still applies to issue and chat alike.
+	if failureReason == string(taskfailure.ReasonAgentProviderCapacityOrRateLimit) && !t.IssueID.Valid {
+		return false
+	}
+	return t.Attempt < retryAttemptCeiling(failureReason, t.MaxAttempts) &&
 		!t.AutopilotRunID.Valid &&
 		(t.IssueID.Valid || t.ChatSessionID.Valid || isSourceContextQuickCreateTask(t))
 }

--- a/server/internal/service/task.go
+++ b/server/internal/service/task.go
@@ -4045,6 +4045,23 @@ func (s *TaskService) FailTask(ctx context.Context, taskID pgtype.UUID, errMsg, 
 		}
 	}
 
+	// Visibility for a *deferred* auto-retry (MS-121): when the retry child was
+	// pushed out by a real backoff, the issue would otherwise sit silent for
+	// 15m–4h with no sign that a retry is pending. Post one system comment so the
+	// history shows this was automatic, not a manual rerun. Gated on a >=1min
+	// delay so provider_network's ~5s final-attempt deferral stays silent — only
+	// the capacity/rate/session-limit schedule is announced. The raw-error
+	// comment below is skipped whenever retried != nil, so there is no duplicate.
+	if retried != nil && retryFireAt.Valid && task.IssueID.Valid {
+		if wait := time.Until(retryFireAt.Time); wait >= time.Minute {
+			note := fmt.Sprintf(
+				"Transient provider limit hit (%s) — auto-retry scheduled in ~%s (attempt %d of %d). No manual rerun needed.",
+				failureReason, wait.Round(time.Minute), retried.Attempt, retried.MaxAttempts,
+			)
+			s.createAgentComment(ctx, task.IssueID, task.AgentID, note, "system", task.TriggerCommentID, task.ID)
+		}
+	}
+
 	// Skip the per-failure system comment when we'll immediately retry —
 	// the new task will surface its own status to the user, and we don't
 	// want to spam the issue with "task timed out" messages on every
@@ -4090,13 +4107,25 @@ func (s *TaskService) FailTask(ctx context.Context, taskID pgtype.UUID, errMsg, 
 // never started, so there is nothing to be idempotent about, and every bundle
 // that did download is already cached on disk — a retry resumes from there
 // instead of re-fetching the whole set (MUL-5370).
+//
+// The second agent_error.* exception is provider_capacity_or_rate_limit: an
+// HTTP 429 / provider overload or a session/usage-window limit
+// ("You've hit your session limit · resets 2pm") is transient infrastructure
+// backpressure, not an agent decision — waiting for the provider cooldown
+// clears it. Unattended issue runs otherwise sit on `todo` forever after a
+// single limit-hit run failed (MS-121). Unlike provider_network's seconds-scale
+// blip, this reason needs a real staggered backoff (15m / 1h / 4h) and is gated
+// to issue runs in retryEligible, so an interactive chat turn is never silently
+// deferred for hours. It is resume-safe, so the retry child continues the
+// session rather than restarting.
 var retryableReasons = map[string]bool{
 	"runtime_offline":           true,
 	"runtime_recovery":          true,
 	"timeout":                   true,
 	"codex_semantic_inactivity": true,
-	string(taskfailure.ReasonAgentProviderNetwork):   true,
-	string(taskfailure.ReasonSkillBundleUnavailable): true,
+	string(taskfailure.ReasonAgentProviderNetwork):             true,
+	string(taskfailure.ReasonSkillBundleUnavailable):           true,
+	string(taskfailure.ReasonAgentProviderCapacityOrRateLimit): true,
 }
 
 // Transient provider stream cuts (provider_network) get a bespoke three-tier
@@ -4108,6 +4137,17 @@ const (
 	providerNetworkMaxAttempts    = 3
 	providerNetworkFinalRetryWait = 5 * time.Second
 )
+
+// Provider capacity / rate / session limits (provider_capacity_or_rate_limit)
+// recover only after a real provider-side cooldown, so they get a staggered
+// backoff instead of provider_network's back-to-back retry (MS-121). The three
+// retries wait 15m, then 1h, then 4h; capacityRateLimitMaxAttempts is
+// 1 (original run) + len(capacityRateLimitBackoff). Once the budget is spent the
+// run stays `failed` and the issue is visibly unworked — a hard ceiling, never a
+// silent endless retry. (A dedicated test pins the two constants in sync.)
+const capacityRateLimitMaxAttempts = 4
+
+var capacityRateLimitBackoff = []time.Duration{15 * time.Minute, time.Hour, 4 * time.Hour}
 
 // retryAttemptCeiling reports how many attempts the auto-retry path allows for
 // a failure reason. It only ever WIDENS the task's generic max_attempts, and
@@ -4124,8 +4164,15 @@ func retryAttemptCeiling(reason string, taskMaxAttempts int32) int32 {
 	if taskMaxAttempts <= 1 {
 		return taskMaxAttempts
 	}
-	if reason == string(taskfailure.ReasonAgentProviderNetwork) && taskMaxAttempts < providerNetworkMaxAttempts {
-		return providerNetworkMaxAttempts
+	switch reason {
+	case string(taskfailure.ReasonAgentProviderNetwork):
+		if taskMaxAttempts < providerNetworkMaxAttempts {
+			return providerNetworkMaxAttempts
+		}
+	case string(taskfailure.ReasonAgentProviderCapacityOrRateLimit):
+		if taskMaxAttempts < capacityRateLimitMaxAttempts {
+			return capacityRateLimitMaxAttempts
+		}
 	}
 	return taskMaxAttempts
 }
@@ -4136,9 +4183,18 @@ func retryAttemptCeiling(reason string, taskMaxAttempts int32) int32 {
 // (zero delay → the child is created 'queued', claimable at once). Callers pass
 // the returned delay to CreateRetryTask via fire_at.
 func retryDelayForAttempt(reason string, failedAttempt int32) time.Duration {
-	if reason == string(taskfailure.ReasonAgentProviderNetwork) &&
-		failedAttempt >= providerNetworkMaxAttempts-1 {
-		return providerNetworkFinalRetryWait
+	switch reason {
+	case string(taskfailure.ReasonAgentProviderNetwork):
+		if failedAttempt >= providerNetworkMaxAttempts-1 {
+			return providerNetworkFinalRetryWait
+		}
+	case string(taskfailure.ReasonAgentProviderCapacityOrRateLimit):
+		// failedAttempt is 1-based (the attempt that just failed). Map attempt N
+		// to schedule index N-1: attempt 1 → 15m, 2 → 1h, 3 → 4h. Past the
+		// schedule the ceiling has been reached and no further child is created.
+		if idx := int(failedAttempt) - 1; idx >= 0 && idx < len(capacityRateLimitBackoff) {
+			return capacityRateLimitBackoff[idx]
+		}
 	}
 	return 0
 }
@@ -4206,8 +4262,19 @@ func ResumeUnsafeFailure(failureReason, errorText string) bool {
 // FailTask's in-transaction retry and the orphan sweeper's MaybeRetryFailedTask
 // so both agree on which failures re-run.
 func retryEligible(failureReason string, t db.AgentTaskQueue) bool {
-	return retryableReasons[failureReason] &&
-		t.Attempt < retryAttemptCeiling(failureReason, t.MaxAttempts) &&
+	if !retryableReasons[failureReason] {
+		return false
+	}
+	// Capacity / rate / session limits recover only after a 15m–4h cooldown.
+	// Deferring an interactive chat turn that long would leave the user staring
+	// at a silent pending message; the CLI's own retry plus the pending-message
+	// pattern already cover transient chat blips. Restrict this reason's
+	// staggered-backoff auto-retry to unattended issue runs (MS-121). Every other
+	// retryable reason (seconds-scale) still applies to issue and chat alike.
+	if failureReason == string(taskfailure.ReasonAgentProviderCapacityOrRateLimit) && !t.IssueID.Valid {
+		return false
+	}
+	return t.Attempt < retryAttemptCeiling(failureReason, t.MaxAttempts) &&
 		!t.AutopilotRunID.Valid &&
 		(t.IssueID.Valid || t.ChatSessionID.Valid)
 }

--- a/server/internal/service/task_retry_schedule_test.go
+++ b/server/internal/service/task_retry_schedule_test.go
@@ -1,0 +1,111 @@
+package service
+
+import (
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgtype"
+	db "github.com/multica-ai/multica/server/pkg/db/generated"
+	"github.com/multica-ai/multica/server/pkg/taskfailure"
+)
+
+const capacityRateLimit = string(taskfailure.ReasonAgentProviderCapacityOrRateLimit)
+
+// TestCapacityRateLimitConstantsInSync pins capacityRateLimitMaxAttempts to
+// 1 (original run) + len(capacityRateLimitBackoff). If the backoff schedule
+// grows or shrinks, the ceiling must move with it, otherwise the last (or a
+// non-existent) tier is never reached.
+func TestCapacityRateLimitConstantsInSync(t *testing.T) {
+	if want := int32(1 + len(capacityRateLimitBackoff)); capacityRateLimitMaxAttempts != want {
+		t.Fatalf("capacityRateLimitMaxAttempts = %d, want 1+len(backoff) = %d",
+			capacityRateLimitMaxAttempts, want)
+	}
+}
+
+// TestProviderCapacityRateLimitIsRetryable guards the MS-121 contract: a
+// classified rate/session-limit failure must be in the auto-retry allowlist.
+func TestProviderCapacityRateLimitIsRetryable(t *testing.T) {
+	if !retryableReasons[capacityRateLimit] {
+		t.Fatal("provider_capacity_or_rate_limit must be retryable (MS-121)")
+	}
+	// Quota (402 / insufficient balance / credits) is terminal and must stay
+	// non-retryable — waiting does not top up a balance.
+	if retryableReasons[string(taskfailure.ReasonAgentProviderQuotaLimit)] {
+		t.Fatal("provider_quota_limit must NOT be retryable")
+	}
+}
+
+func TestRetryAttemptCeilingCapacityRateLimit(t *testing.T) {
+	cases := []struct {
+		name        string
+		reason      string
+		maxAttempts int32
+		want        int32
+	}{
+		{"widens default 2 to 4", capacityRateLimit, 2, capacityRateLimitMaxAttempts},
+		{"keeps higher explicit budget", capacityRateLimit, 6, 6},
+		{"never revives a disabled task", capacityRateLimit, 1, 1},
+		{"unrelated reason keeps column", "timeout", 2, 2},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := retryAttemptCeiling(c.reason, c.maxAttempts); got != c.want {
+				t.Errorf("retryAttemptCeiling(%q, %d) = %d, want %d", c.reason, c.maxAttempts, got, c.want)
+			}
+		})
+	}
+}
+
+func TestRetryDelayForAttemptCapacityRateLimit(t *testing.T) {
+	cases := []struct {
+		failedAttempt int32
+		want          time.Duration
+	}{
+		{1, 15 * time.Minute},
+		{2, time.Hour},
+		{3, 4 * time.Hour},
+		{4, 0}, // past the schedule: ceiling reached, no further child
+	}
+	for _, c := range cases {
+		if got := retryDelayForAttempt(capacityRateLimit, c.failedAttempt); got != c.want {
+			t.Errorf("retryDelayForAttempt(capacity, attempt=%d) = %s, want %s", c.failedAttempt, got, c.want)
+		}
+	}
+}
+
+func issueTask(reason string, attempt, maxAttempts int32) db.AgentTaskQueue {
+	return db.AgentTaskQueue{
+		IssueID:       pgtype.UUID{Valid: true},
+		Attempt:       attempt,
+		MaxAttempts:   maxAttempts,
+		FailureReason: pgtype.Text{String: reason, Valid: true},
+	}
+}
+
+func TestRetryEligibleCapacityRateLimit(t *testing.T) {
+	// Fresh issue run that just hit a rate limit on its first attempt.
+	if !retryEligible(capacityRateLimit, issueTask(capacityRateLimit, 1, 2)) {
+		t.Error("first-attempt rate-limited issue run should be retry-eligible")
+	}
+	// Budget exhausted at the reason-aware ceiling (4).
+	if retryEligible(capacityRateLimit, issueTask(capacityRateLimit, capacityRateLimitMaxAttempts, 2)) {
+		t.Error("run at the ceiling must not be retry-eligible")
+	}
+	// max_attempts <= 1 disables retry entirely.
+	if retryEligible(capacityRateLimit, issueTask(capacityRateLimit, 1, 1)) {
+		t.Error("max_attempts=1 disables auto-retry")
+	}
+	// Chat turns are excluded from this reason's hours-long backoff.
+	chat := issueTask(capacityRateLimit, 1, 2)
+	chat.IssueID = pgtype.UUID{}
+	chat.ChatSessionID = pgtype.UUID{Valid: true}
+	if retryEligible(capacityRateLimit, chat) {
+		t.Error("chat task must not get the capacity/rate-limit staggered backoff")
+	}
+	// Autopilot owns its own cadence.
+	ap := issueTask(capacityRateLimit, 1, 2)
+	ap.AutopilotRunID = pgtype.UUID{Valid: true}
+	if retryEligible(capacityRateLimit, ap) {
+		t.Error("autopilot task must not be auto-retried here")
+	}
+}

--- a/server/pkg/taskfailure/classify.go
+++ b/server/pkg/taskfailure/classify.go
@@ -138,12 +138,23 @@ func Classify(rawError string) Reason {
 		):
 		return ReasonAgentProviderQuotaLimit
 
-	// 5. Capacity / rate limit. 429 / 529 / overloaded / rate limit.
+	// 5. Capacity / rate limit. 429 / 529 / overloaded / rate limit, plus
+	//    session / usage-window limits that recover after a provider-side
+	//    cooldown ("You've hit your session limit · resets 2pm"). The latter
+	//    is filed here rather than in the quota bucket (rule 4) precisely
+	//    because it is transient: waiting for the reset clears it, so it must
+	//    reach the retryable capacity bucket, whereas quota (402 / insufficient
+	//    balance / credits) is terminal and stays non-retryable. "session limit"
+	//    would otherwise slip past rule 4's "you've hit your limit" (the word
+	//    "session" splits that substring) and fall through to agent_error.unknown
+	//    — the MS-121 root cause. Mirror these substrings into the MUL-1949
+	//    offline backfill SQL.
 	case httpCapacityCodeRe.MatchString(lower),
 		containsAny(lower,
 			"rate limit",
 			"overloaded",
 			"no capacity available",
+			"session limit",
 		):
 		return ReasonAgentProviderCapacityOrRateLimit
 

--- a/server/pkg/taskfailure/classify_test.go
+++ b/server/pkg/taskfailure/classify_test.go
@@ -84,6 +84,12 @@ func TestClassifyRules(t *testing.T) {
 		{"rate limit", "rate limit exceeded for tier 3", ReasonAgentProviderCapacityOrRateLimit},
 		{"overloaded", "overloaded_error: please retry", ReasonAgentProviderCapacityOrRateLimit},
 		{"no capacity available", "no capacity available; try again later", ReasonAgentProviderCapacityOrRateLimit},
+		// Session / usage-window limit: transient (recovers at reset), so it must
+		// land in the retryable capacity bucket, NOT quota. "session" splits
+		// rule 4's "you've hit your limit", so without this it fell through to
+		// agent_error.unknown (MS-121).
+		{"session limit resets", "You've hit your session limit · resets 2pm", ReasonAgentProviderCapacityOrRateLimit},
+		{"session limit curly", "You’ve hit your session limit · resets 2pm", ReasonAgentProviderCapacityOrRateLimit},
 
 		// 6. Provider 5xx / server error.
 		{"server had an error", "the server had an error processing your request", ReasonAgentProviderServerError},


### PR DESCRIPTION
## Root Cause

A run that fails on a provider session limit (`You've hit your session limit · resets 2pm`) was classified as `agent_error.unknown` and **never re-queued** — the issue stayed on `todo` until someone ran `rerun` manually. An auto-retry path already exists (MUL-4910, `provider_network` only); this extends it to the transient limit class.

1. **Classification** (`server/pkg/taskfailure/classify.go`): session/usage-window limits now land in `provider_capacity_or_rate_limit` (transient, recovers at reset) instead of falling through. `session limit` used to slip past rule 4's `you've hit your limit` because `session` splits the substring. Quota errors (402 / insufficient balance / credits) stay terminal and non-retryable on purpose.
2. **Retry with backoff + ceiling** (`server/internal/service/task.go`): `provider_capacity_or_rate_limit` added to the retry allowlist, staggered backoff **15m → 1h → 4h**, hard ceiling of 4 attempts (1 run + 3 retries). After exhaustion the run stays `failed`, no silent infinite retry. Gated to **unattended issue runs** — interactive chat is not silently deferred for hours (CLI retry + pending-message handle that path).
3. **Visibility**: a delayed retry posts **one** system comment on the issue (`… auto-retry scheduled in ~15m (attempt 2 of 4)`) so it's traceable as automatic, not a manual intervention. The ~5s `provider_network` delay stays silent on purpose (no spam).

## Changed files
- `server/pkg/taskfailure/classify.go` (+ tests in `classify_test.go`)
- `server/internal/service/task.go` (+ new `task_retry_schedule_test.go`)

## Verification (local)
- `go build ./...` — green
- `go vet ./internal/service/ ./pkg/taskfailure/` — green
- `go test ./pkg/taskfailure/ ./internal/service/` — green (incl. new session-limit classification and backoff/ceiling/eligibility tests)
