### PR TITLE
fix(core): validate Mika bootstrap response with a schema

### DIFF
--- a/packages/core/api/client.test.ts
+++ b/packages/core/api/client.test.ts
@@ -1971,3 +1971,54 @@ describe("ApiClient startMikaOnboarding", () => {
     ).resolves.toEqual({ started: false });
   });
 });
+
+describe("ApiClient createMikaAgent response schema", () => {
+  it("returns the agent and onboarding session a well-formed response reports", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(
+        new Response(
+          JSON.stringify({
+            id: "agent-1",
+            system_key: "mika",
+            onboarding_session: { id: "session-1", agent_id: "agent-1", last_message: null },
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        ),
+      ),
+    );
+
+    await expect(
+      new ApiClient("https://api.example.test").createMikaAgent({
+        runtime_id: "runtime-1",
+        language: "en",
+      }),
+    ).resolves.toEqual({
+      id: "agent-1",
+      system_key: "mika",
+      onboarding_session: { id: "session-1", agent_id: "agent-1", last_message: undefined },
+    });
+  });
+
+  it("falls back to an agent without an onboarding session when the response is malformed", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(
+        new Response(JSON.stringify({ id: 42 }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        }),
+      ),
+    );
+
+    // The caller (bootstrapMika) treats a missing onboarding_session as the
+    // one recoverable failure and throws its own error, so the fallback must
+    // not fabricate a session — see use-bootstrap-mika.ts.
+    await expect(
+      new ApiClient("https://api.example.test").createMikaAgent({
+        runtime_id: "runtime-1",
+        language: "en",
+      }),
+    ).resolves.toEqual({ id: "" });
+  });
+});

--- a/packages/core/api/client.ts
+++ b/packages/core/api/client.ts
@@ -203,6 +203,7 @@ import {
   ChatMessageListSchema,
   ChatMessagesPageSchema,
   ChatPendingTaskSchema,
+  MikaBootstrapResponseSchema,
   PrioritizeQueuedChatTaskResponseSchema,
   SendChatMessageResponseSchema,
   StartMikaOnboardingResponseSchema,
@@ -234,6 +235,7 @@ import {
   EMPTY_CLOUD_RUNTIME_NODE,
   EMPTY_CLOUD_RUNTIME_NODE_LIST,
   EMPTY_CREATE_AGENT_FROM_TEMPLATE_RESPONSE,
+  EMPTY_MIKA_BOOTSTRAP_RESPONSE,
   EMPTY_AGENT_BUILDER_SESSION,
   EMPTY_GROUPED_ISSUES_RESPONSE,
   EMPTY_ISSUE_TABLE_FACETS_RESPONSE,
@@ -1213,11 +1215,17 @@ export class ApiClient {
     },
     workspaceSlug?: string,
   ): Promise<MikaBootstrapResponse> {
-    return this.fetch("/api/agents/mika", {
+    const raw = await this.fetch<unknown>("/api/agents/mika", {
       method: "POST",
       headers: workspaceHeader(workspaceSlug),
       body: JSON.stringify(data),
     });
+    return parseWithFallback(
+      raw,
+      MikaBootstrapResponseSchema,
+      EMPTY_MIKA_BOOTSTRAP_RESPONSE,
+      { endpoint: "POST /api/agents/mika" },
+    );
   }
 
   async createAgentBuilderSession(data: {

--- a/packages/core/api/schemas.ts
+++ b/packages/core/api/schemas.ts
@@ -18,6 +18,7 @@ import type {
   ChatMessage,
   ChatDraftRestoresResponse,
   ChatPendingTask,
+  MikaBootstrapResponse,
   PrioritizeQueuedChatTaskResponse,
   SendChatMessageResponse,
   StartMikaOnboardingResponse,
@@ -1315,6 +1316,31 @@ export const StartMikaOnboardingResponseSchema: z.ZodType<StartMikaOnboardingRes
   message_id: z.string().nullish().transform((id) => id ?? undefined),
   created_at: z.string().nullish().transform((at) => at ?? undefined),
 }).loose();
+
+// `POST /api/agents/mika` — like `MinimalAgentSchema` above, this deliberately
+// does not schematise the full Agent record. `onboarding_session` is required
+// because `bootstrapMika()` in onboarding/use-bootstrap-mika.ts treats its
+// absence as the one recoverable failure mode (server committed the agent but
+// not the session); everything else stays loose/optional so unrelated field
+// drift on the Agent side degrades instead of white-screening onboarding.
+const MinimalChatSessionSchema = z.object({
+  id: z.string(),
+  agent_id: z.string().optional(),
+  last_message: z.unknown().nullish().transform((v) => v ?? undefined),
+}).loose();
+
+export const MikaBootstrapResponseSchema = z.object({
+  id: z.string(),
+  system_key: z.string().optional(),
+  onboarding_session: MinimalChatSessionSchema.optional(),
+}).loose();
+
+// Fallback when the response fails to parse. `onboarding_session` stays
+// absent so `bootstrapMika()` throws its existing "session was not returned"
+// error instead of navigating to a fabricated chat session.
+export const EMPTY_MIKA_BOOTSTRAP_RESPONSE: MikaBootstrapResponse = {
+  id: "",
+} as MikaBootstrapResponse;
 
 export const PrioritizeQueuedChatTaskResponseSchema:
   z.ZodType<PrioritizeQueuedChatTaskResponse> = z.object({


### PR DESCRIPTION
## Summary
- `createMikaAgent` returned the raw fetch JSON cast directly to `MikaBootstrapResponse` instead of going through `parseWithFallback` — the only Mika endpoint skipping that path.
- Adds `MikaBootstrapResponseSchema` / `EMPTY_MIKA_BOOTSTRAP_RESPONSE` (loose, minimal fields, same pattern as `MinimalAgentSchema`) and wires `createMikaAgent` through it.
- An older desktop client talking to a changed backend would previously crash instead of degrading, per the API Compatibility rules in CLAUDE.md.

## Test plan
- [x] `pnpm --filter @multica/core typecheck`
- [x] `pnpm --filter @multica/core exec vitest run api/client.test.ts onboarding/use-bootstrap-mika.test.ts` (77 passed, incl. new malformed-response test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)