### PR TITLE
MUL-5856: fix(agent): parse tab-separated Antigravity model catalog

### DIFF
--- a/server/pkg/agent/antigravity.go
+++ b/server/pkg/agent/antigravity.go
@@ -423,16 +423,17 @@ var antigravityBlockedArgs = map[string]blockedArgMode{
 // buildAntigravityArgs assembles the argv for a daemon-compatible one-shot agy
 // invocation.
 //
-//	agy -p <prompt> --dangerously-skip-permissions [--model <display name>]
+//	agy -p <prompt> --dangerously-skip-permissions [--model <catalog id>]
 //	    --print-timeout <duration> --log-file <tmp>
 //	    [--conversation <id>] [--add-dir <cwd>]
 //
 // agy 1.0.6 added a `--model` flag (MUL-3125), so opts.Model is now wired
-// through when set. The value is the exact human display string `agy models`
-// prints (e.g. "Claude Opus 4.6 (Thinking)"), NOT a provider/model slug —
-// it's passed verbatim as a single exec arg, so spaces and parens need no
-// shell quoting. agy still exposes no --system-prompt; runtime instructions
-// are delivered via AGENTS.md in the task workdir.
+// through when set. The value is the catalog identifier parseAntigravityModels
+// read out of `agy models`: a slug (e.g. "gemini-3.6-flash-high") on agy
+// 1.1.11+, or the verbatim single-column value (e.g. "Claude Opus 4.6
+// (Thinking)") on older output. Either shape ships as one exec arg, so spaces
+// and parens need no shell quoting. agy still exposes no --system-prompt;
+// runtime instructions are delivered via AGENTS.md in the task workdir.
 //
 // agy silently no-ops on a model string it doesn't recognise (empty output,
 // exit 0), so Execute validates opts.Model against the `agy models` catalog

--- a/server/pkg/agent/antigravity.go
+++ b/server/pkg/agent/antigravity.go
@@ -472,7 +472,7 @@ func buildAntigravityArgs(prompt, logPath string, timeout time.Duration, opts Ex
 // returns nil otherwise. An empty `available` means discovery couldn't produce
 // a catalog (agy missing, transient failure) — we fail OPEN there and let agy
 // resolve the value, so a discovery hiccup never blocks a run. The match is
-// exact because agy's --model wants the precise display string; a near-miss
+// exact because agy's --model wants the precise catalog identifier; a near-miss
 // (extra space, dropped suffix) is correctly rejected since agy would silently
 // no-op on it anyway.
 func antigravityModelError(model string, available []Model) error {

--- a/server/pkg/agent/models.go
+++ b/server/pkg/agent/models.go
@@ -1919,12 +1919,12 @@ func acpModelLabel(name, modelID string) string {
 }
 
 // discoverAntigravityModels runs `agy models` and returns the catalog the
-// installed Antigravity CLI advertises (one display name per line).
+// installed Antigravity CLI advertises (one model record per line).
 //
 // Unlike cursor / pi / opencode there is deliberately NO static fallback.
-// agy's `--model` takes the exact human display string (e.g.
-// "Claude Opus 4.6 (Thinking)") and silently no-ops on any value it doesn't
-// recognise — empty output, exit 0 — so a guessed static list would risk
+// agy's `--model` takes the exact identifier advertised by the installed CLI
+// and silently no-ops on any value it doesn't recognise — empty output, exit
+// 0 — so a guessed static list would risk
 // offering a model the installed CLI can't honour, turning a typo into a
 // "successful" empty run. On any discovery failure we return an empty
 // catalog instead; agent.model stays unset and agy resolves its own
@@ -1950,24 +1950,34 @@ func discoverAntigravityModels(ctx context.Context, executablePath string) ([]Mo
 	return parseAntigravityModels(string(out)), nil
 }
 
-// parseAntigravityModels turns `agy models` output — one model display name
-// per line — into Model entries. The display string IS the value `--model`
-// expects, so ID and Label are identical and the daemon ships opts.Model
-// verbatim. Blank and duplicate lines are skipped.
+// parseAntigravityModels turns `agy models` output into Model entries. agy
+// 1.1.11 emits "id<TAB>display label" while older versions emit one value per
+// line. For legacy output the value remains both ID and Label. Blank lines and
+// duplicate IDs are skipped.
 func parseAntigravityModels(output string) []Model {
 	scanner := bufio.NewScanner(strings.NewReader(output))
 	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
 	var models []Model
 	seen := map[string]bool{}
 	for scanner.Scan() {
-		name := strings.TrimSpace(scanner.Text())
-		if name == "" || seen[name] {
+		raw := scanner.Text()
+		id := strings.TrimSpace(raw)
+		label := id
+		if idField, remaining, ok := strings.Cut(raw, "\t"); ok {
+			id = strings.TrimSpace(idField)
+			labelField, _, _ := strings.Cut(remaining, "\t")
+			label = strings.TrimSpace(labelField)
+			if label == "" {
+				label = id
+			}
+		}
+		if id == "" || seen[id] {
 			continue
 		}
-		seen[name] = true
+		seen[id] = true
 		models = append(models, Model{
-			ID:       name,
-			Label:    name,
+			ID:       id,
+			Label:    label,
 			Provider: "antigravity",
 		})
 	}

--- a/server/pkg/agent/models_test.go
+++ b/server/pkg/agent/models_test.go
@@ -1745,9 +1745,9 @@ func TestAntigravityModelSelectionSupported(t *testing.T) {
 	}
 }
 
-// TestParseAntigravityModels covers the `agy models` line-per-name format:
-// each non-blank line becomes a Model whose ID and Label are the verbatim
-// display string `--model` expects, duplicates collapse, and blanks drop.
+// TestParseAntigravityModels covers the legacy single-column `agy models`
+// format (pre-1.1.11): each non-blank tab-free line becomes a Model whose ID
+// and Label are that verbatim value, duplicates collapse, and blanks drop.
 func TestParseAntigravityModels(t *testing.T) {
 	t.Parallel()
 

--- a/server/pkg/agent/models_test.go
+++ b/server/pkg/agent/models_test.go
@@ -1775,6 +1775,32 @@ func TestParseAntigravityModels(t *testing.T) {
 	}
 }
 
+// TestParseAntigravityModelsTabSeparated covers the catalog format introduced
+// by agy 1.1.11: the first tab-delimited field is the value accepted by
+// --model, while the second field is the human-readable picker label.
+func TestParseAntigravityModelsTabSeparated(t *testing.T) {
+	t.Parallel()
+
+	out := strings.Join([]string{
+		"gemini-3.6-flash-high\tGemini 3.6 Flash (High)",
+		"claude-opus-4-6-thinking\tClaude Opus 4.6 (Thinking)\tfuture metadata is ignored",
+		"gemini-3.6-flash-high\tDuplicate label is ignored",
+	}, "\n")
+
+	got := parseAntigravityModels(out)
+	want := []Model{
+		{ID: "gemini-3.6-flash-high", Label: "Gemini 3.6 Flash (High)", Provider: "antigravity"},
+		{ID: "claude-opus-4-6-thinking", Label: "Claude Opus 4.6 (Thinking)", Provider: "antigravity"},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("parseAntigravityModels = %+v, want %+v", got, want)
+	}
+
+	if err := antigravityModelError("gemini-3.6-flash-high", got); err != nil {
+		t.Fatalf("exact model slug from tab-separated catalog was rejected: %v", err)
+	}
+}
+
 // TestParseAntigravityModelsEmpty pins that empty / whitespace-only output
 // yields no models (so cachedDiscovery treats it as a transient miss and
 // retries rather than caching a blank catalog).


### PR DESCRIPTION
## Summary

- parse the agy 1.1.11 id-tab-label model catalog format
- retain support for legacy single-column model output
- deduplicate by model ID and ignore future trailing columns
- validate exact pinned model slugs against the parsed catalog

## Testing

- go test ./pkg/agent -run TestParseAntigravityModels -count=1
- go vet ./pkg/agent

Fixes #6562