### PR TITLE
fix(mobile): support configured HTTP API endpoints

### DIFF
--- a/apps/mobile/README.md
+++ b/apps/mobile/README.md
@@ -56,6 +56,11 @@ cp apps/mobile/.env.example apps/mobile/.env.development.local
 # then edit EXPO_PUBLIC_API_URL inside it to your Mac's LAN IP, e.g. http://192.168.1.42:8080
 ```
 
+The native project automatically enables the required iOS local-network and
+Android cleartext permissions when `EXPO_PUBLIC_API_URL` uses `http://`. Rebuild
+the native app after switching the API URL between HTTP and HTTPS; restarting
+Metro alone does not update native permissions.
+
 If your Apple ID isn't on the Multica Apple Developer team yet, also uncomment and set `EXPO_BUNDLE_IDENTIFIER_DEV` to a reverse-domain you own (e.g. `com.yourname.multica.dev`). This **only** overrides the dev variant — staging / production bundle ids are intentionally not overridable so variants can coexist.
 
 ## Build it onto your iPhone

--- a/apps/mobile/app.config.ts
+++ b/apps/mobile/app.config.ts
@@ -1,5 +1,97 @@
 import type { ExpoConfig, ConfigContext } from "expo/config";
 
+const LOCAL_NETWORK_USAGE_DESCRIPTION =
+  "Allow Multica to connect to your self-hosted server on the local network.";
+
+type IosInfoPlist = {
+  NSAppTransportSecurity: {
+    NSAllowsLocalNetworking: true;
+    NSExceptionDomains?: Record<
+      string,
+      {
+        NSExceptionAllowsInsecureHTTPLoads: boolean;
+        NSIncludesSubdomains: boolean;
+      }
+    >;
+  };
+  NSLocalNetworkUsageDescription?: string;
+};
+
+type NativeNetworkConfig = {
+  androidUsesCleartextTraffic: boolean;
+  iosInfoPlist?: IosInfoPlist;
+};
+
+function normalizeHostname(rawHostname: string): string {
+  return rawHostname
+    .toLowerCase()
+    .replace(/^\[/, "")
+    .replace(/\]$/, "")
+    .replace(/\.$/, "");
+}
+
+function isIpAddress(hostname: string): boolean {
+  const parts = hostname.split(".").map(Number);
+  return (
+    hostname.includes(":") ||
+    (parts.length === 4 &&
+      parts.every(
+        (part) => Number.isInteger(part) && part >= 0 && part <= 255,
+      ))
+  );
+}
+
+function isLocalName(hostname: string): boolean {
+  return (
+    hostname === "localhost" ||
+    hostname.endsWith(".localhost") ||
+    hostname.endsWith(".local") ||
+    !hostname.includes(".")
+  );
+}
+
+/**
+ * Generates native transport exceptions only when the configured API uses
+ * cleartext HTTP. HTTPS builds keep the platform security defaults intact.
+ */
+export function getNativeNetworkConfig(
+  apiUrl: string | undefined,
+): NativeNetworkConfig {
+  let url: URL;
+  try {
+    url = new URL(apiUrl ?? "");
+  } catch {
+    return { androidUsesCleartextTraffic: false };
+  }
+
+  if (url.protocol !== "http:") {
+    return { androidUsesCleartextTraffic: false };
+  }
+
+  const hostname = normalizeHostname(url.hostname);
+  const domainExceptions = isIpAddress(hostname) || isLocalName(hostname)
+    ? {}
+    : {
+        NSExceptionDomains: {
+          [hostname]: {
+            NSExceptionAllowsInsecureHTTPLoads: true,
+            NSIncludesSubdomains: false,
+          },
+        },
+      };
+
+  return {
+    androidUsesCleartextTraffic: true,
+    iosInfoPlist: {
+      NSAppTransportSecurity: {
+        NSAllowsLocalNetworking: true,
+        ...domainExceptions,
+      },
+      NSLocalNetworkUsageDescription: LOCAL_NETWORK_USAGE_DESCRIPTION,
+    },
+  };
+}
+
 /**
  * Dynamic Expo config — replaces app.json so we can read APP_ENV at runtime
  * and switch bundleIdentifier / display name for dev / staging / production.
@@ -13,6 +105,9 @@ export default ({ config }: ConfigContext): ExpoConfig => {
   const env = process.env.APP_ENV ?? "development";
   const isProd = env === "production";
   const isStaging = env === "staging";
+  const nativeNetworkConfig = getNativeNetworkConfig(
+    process.env.EXPO_PUBLIC_API_URL,
+  );
 
   return {
     ...config,
@@ -31,6 +126,7 @@ export default ({ config }: ConfigContext): ExpoConfig => {
     // iOS icon size from this single PNG.
     icon: "./assets/icon.png",
     ios: {
+      ...config.ios,
       supportsTablet: false,
       // Per-variant bundle id overrides exist for one reason: an Apple ID
       // can only sign bundle prefixes it owns, so contributors not on the
@@ -46,6 +142,14 @@ export default ({ config }: ConfigContext): ExpoConfig => {
         : isStaging
           ? "ai.multica.mobile.staging"
           : (process.env.EXPO_BUNDLE_IDENTIFIER_DEV ?? "ai.multica.mobile.dev"),
+      ...(nativeNetworkConfig.iosInfoPlist
+        ? {
+            infoPlist: {
+              ...config.ios?.infoPlist,
+              ...nativeNetworkConfig.iosInfoPlist,
+            },
+          }
+        : {}),
     },
     plugins: [
       "expo-router",
@@ -68,6 +172,10 @@ export default ({ config }: ConfigContext): ExpoConfig => {
       [
         "expo-build-properties",
         {
+          android: {
+            usesCleartextTraffic:
+              nativeNetworkConfig.androidUsesCleartextTraffic,
+          },
           ios: {
             buildReactNativeFromSource: true,
           },

--- a/apps/mobile/lib/native-network-config.test.ts
+++ b/apps/mobile/lib/native-network-config.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from "vitest";
+
+import { getNativeNetworkConfig } from "../app.config";
+
+describe("getNativeNetworkConfig", () => {
+  it.each([undefined, "", "https://api.example.test"])(
+    "keeps native cleartext access disabled for %s",
+    (apiUrl) => {
+      expect(getNativeNetworkConfig(apiUrl)).toEqual({
+        androidUsesCleartextTraffic: false,
+      });
+    },
+  );
+
+  it.each([
+    "http://192.168.1.42:8080",
+    "http://localhost:8080",
+    "http://multica.local:8080",
+    "http://multica-server:8080",
+    "http://[fd00::42]:8080",
+  ])("enables narrow local-network access for %s", (apiUrl) => {
+    expect(getNativeNetworkConfig(apiUrl)).toEqual({
+      androidUsesCleartextTraffic: true,
+      iosInfoPlist: {
+        NSAppTransportSecurity: {
+          NSAllowsLocalNetworking: true,
+        },
+        NSLocalNetworkUsageDescription:
+          "Allow Multica to connect to your self-hosted server on the local network.",
+      },
+    });
+  });
+
+  it("enables a host-scoped ATS exception for a non-local HTTP server", () => {
+    expect(getNativeNetworkConfig("http://api.example.test:8080")).toEqual({
+      androidUsesCleartextTraffic: true,
+      iosInfoPlist: {
+        NSAppTransportSecurity: {
+          NSAllowsLocalNetworking: true,
+          NSExceptionDomains: {
+            "api.example.test": {
+              NSExceptionAllowsInsecureHTTPLoads: true,
+              NSIncludesSubdomains: false,
+            },
+          },
+        },
+        NSLocalNetworkUsageDescription:
+          "Allow Multica to connect to your self-hosted server on the local network.",
+      },
+    });
+  });
+
+  it.each([
+    "http://203.0.113.42:8080",
+    "http://[2001:db8::42]:8080",
+  ])(
+    "does not create an invalid ATS domain exception for IP address %s",
+    (apiUrl) => {
+      expect(getNativeNetworkConfig(apiUrl)).toEqual({
+        androidUsesCleartextTraffic: true,
+        iosInfoPlist: {
+          NSAppTransportSecurity: {
+            NSAllowsLocalNetworking: true,
+          },
+          NSLocalNetworkUsageDescription:
+            "Allow Multica to connect to your self-hosted server on the local network.",
+        },
+      });
+    },
+  );
+
+  it("does not weaken native networking for an invalid URL", () => {
+    expect(getNativeNetworkConfig("not-a-url")).toEqual({
+      androidUsesCleartextTraffic: false,
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- derive native transport permissions from `EXPO_PUBLIC_API_URL`
- enable iOS local-network access and host-scoped ATS exceptions for HTTP endpoints
- enable Android cleartext traffic only for HTTP-configured builds
- keep HTTPS builds on the platform security defaults
- document that switching HTTP/HTTPS requires rebuilding the native app

## Context

The mobile README already recommends a LAN URL such as `http://192.168.1.42:8080` for device development, but the generated native projects did not include the permissions required to reach it.

Related to #5128, but does not close it: runtime server selection remains outside this PR.

## Testing

- `pnpm --dir apps/mobile test` (74 tests)
- `pnpm --dir apps/mobile typecheck`
- `pnpm --dir apps/mobile lint` (0 errors; 7 existing warnings)
- `expo config --type introspect` with a LAN HTTP API URL
- `expo export --platform ios` with a LAN HTTP API URL