### PR TITLE
fix(daemon): isolate Cursor and Claude memory across issues

### DIFF
--- a/server/internal/daemon/daemon.go
+++ b/server/internal/daemon/daemon.go
@@ -6046,10 +6046,10 @@ func (d *Daemon) runTask(ctx context.Context, task Task, provider string, slot i
 	// (Hermes HERMES_HOME is applied after custom_env below so the per-task
 	// overlay can win over a user-set HERMES_HOME; see
 	// layerCustomEnvAndHermesHome.)
-	// Point Cursor at per-task project state when managed MCP is present.
-	// The workdir .cursor/mcp.json carries the managed server list, while
-	// CURSOR_DATA_DIR isolates the matching project approvals from the user's
-	// persistent ~/.cursor/projects state.
+	// Point Cursor at per-task project state. The workdir .cursor/mcp.json
+	// carries a managed server list when configured, while CURSOR_DATA_DIR keeps
+	// repository-scoped assets, terminal captures, codebase identity, and MCP
+	// approvals out of the user's persistent ~/.cursor/projects state.
 	if env.CursorDataDir != "" {
 		agentEnv["CURSOR_DATA_DIR"] = env.CursorDataDir
 	}
@@ -6079,6 +6079,7 @@ func (d *Daemon) runTask(ctx context.Context, task Task, provider string, slot i
 		agentCustomEnv = task.Agent.CustomEnv
 	}
 	layerCustomEnvAndHermesHome(agentEnv, agentCustomEnv, env.HermesHome, d.logger)
+	configureClaudeTaskMemoryEnvironment(provider, agentEnv, os.Getenv)
 	if provider == "reasonix" {
 		reasonixStateHome, err := prepareReasonixTaskStateHome(d.cfg.Profile, task.RuntimeID, task.AgentID)
 		if err != nil {
@@ -7514,10 +7515,40 @@ func isBlockedEnvKey(key string) bool {
 		return true
 	}
 	switch upper {
-	case "HOME", "PATH", "USER", "SHELL", "TERM", "TMPDIR", "TMP", "TEMP", "CODEX_HOME", "REASONIX_STATE_HOME", "CURSOR_DATA_DIR", execenv.CursorMcpAuthSourceEnv, "OPENCLAW_CONFIG_PATH", "OPENCLAW_INCLUDE_ROOTS":
+	case "HOME", "PATH", "USER", "SHELL", "TERM", "TMPDIR", "TMP", "TEMP", "CODEX_HOME", "REASONIX_STATE_HOME", "CURSOR_DATA_DIR", execenv.CursorMcpAuthSourceEnv, claudeDisableAutoMemoryEnv, "OPENCLAW_CONFIG_PATH", "OPENCLAW_INCLUDE_ROOTS":
 		return true
 	}
 	return false
+}
+
+const (
+	// multicaClaudeMemoryEnv is a daemon-level escape hatch for operators who
+	// intentionally want Claude's repository-wide auto memory despite the
+	// cross-issue context risk.
+	multicaClaudeMemoryEnv = "MULTICA_CLAUDE_MEMORY"
+	// claudeDisableAutoMemoryEnv is documented by Claude Code and prevents both
+	// loading and generating ~/.claude/projects/<repo>/memory content.
+	claudeDisableAutoMemoryEnv = "CLAUDE_CODE_DISABLE_AUTO_MEMORY"
+)
+
+// configureClaudeTaskMemoryEnvironment disables Claude Code auto memory for
+// daemon-managed tasks. Multica already resumes the exact provider session for
+// follow-ups on the same issue, so repository-wide hidden memory is unnecessary
+// and can retain deleted issue content. Explicit daemon opt-in mirrors
+// MULTICA_CODEX_MEMORY.
+func configureClaudeTaskMemoryEnvironment(provider string, agentEnv map[string]string, getenv func(string) string) {
+	if provider != "claude" {
+		return
+	}
+	raw := ""
+	if getenv != nil {
+		raw = strings.TrimSpace(getenv(multicaClaudeMemoryEnv))
+	}
+	switch strings.ToLower(raw) {
+	case "1", "true", "yes", "on":
+		return
+	}
+	agentEnv[claudeDisableAutoMemoryEnv] = "1"
 }
 
 // layerCustomEnvAndHermesHome applies the agent's custom_env onto the child env

--- a/server/internal/daemon/daemon_test.go
+++ b/server/internal/daemon/daemon_test.go
@@ -159,6 +159,7 @@ func TestIsBlockedEnvKey(t *testing.T) {
 		{key: "CURSOR_DATA_DIR", want: true},
 		{key: "cursor_data_dir", want: true},
 		{key: "CURSOR_MCP_AUTH_SOURCE", want: true},
+		{key: "CLAUDE_CODE_DISABLE_AUTO_MEMORY", want: true},
 		{key: "OPENCLAW_CONFIG_PATH", want: true},
 		{key: "OPENCLAW_INCLUDE_ROOTS", want: true},
 		{key: "ANTHROPIC_API_KEY", want: false},
@@ -178,6 +179,55 @@ func TestIsBlockedEnvKey(t *testing.T) {
 			t.Parallel()
 			if got := isBlockedEnvKey(tt.key); got != tt.want {
 				t.Fatalf("isBlockedEnvKey(%q) = %v, want %v", tt.key, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestConfigureClaudeTaskMemoryEnvironment(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		provider  string
+		optIn     string
+		initial   map[string]string
+		wantValue string
+		wantSet   bool
+	}{
+		{
+			name:      "Claude auto memory disabled by default",
+			provider:  "claude",
+			wantValue: "1",
+			wantSet:   true,
+		},
+		{
+			name:     "explicit opt-in preserves native memory",
+			provider: "claude",
+			optIn:    "true",
+		},
+		{
+			name:     "other providers unchanged",
+			provider: "cursor",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			agentEnv := map[string]string{}
+			for k, v := range tt.initial {
+				agentEnv[k] = v
+			}
+			configureClaudeTaskMemoryEnvironment(tt.provider, agentEnv, func(key string) string {
+				if key == multicaClaudeMemoryEnv {
+					return tt.optIn
+				}
+				return ""
+			})
+			got, ok := agentEnv[claudeDisableAutoMemoryEnv]
+			if ok != tt.wantSet || got != tt.wantValue {
+				t.Fatalf("%s = %q, set=%v; want %q, set=%v", claudeDisableAutoMemoryEnv, got, ok, tt.wantValue, tt.wantSet)
 			}
 		})
 	}

--- a/server/internal/daemon/execenv/cursor_mcp.go
+++ b/server/internal/daemon/execenv/cursor_mcp.go
@@ -31,18 +31,46 @@ type cursorMcpConfigFile struct {
 	McpServers map[string]json.RawMessage `json:"mcpServers"`
 }
 
-// prepareCursorMcpConfig writes the Cursor-native MCP sidecars for agents that
-// have an explicit managed mcp_config saved. A nil/null mcp_config means "let
-// Cursor behave normally", so no .cursor/mcp.json or CURSOR_DATA_DIR is created.
+// prepareCursorMcpConfig always creates a task-local CURSOR_DATA_DIR so Cursor
+// cannot reuse repository-scoped assets, terminal captures, codebase identity,
+// or other project state from an unrelated issue that used the same checkout.
+// When an explicit managed mcp_config is present it also writes the matching
+// project config, approvals, and optional auth sidecar. A nil/null mcp_config
+// leaves the user's MCP configuration untouched while retaining task-state
+// isolation.
 func prepareCursorMcpConfig(envRoot, workDir string, mcpConfig json.RawMessage, mcpAuthSource string, manifest *sidecarManifest) (string, error) {
-	if !hasManagedCursorMcpConfig(mcpConfig) {
-		return "", nil
-	}
 	if envRoot == "" {
-		return "", fmt.Errorf("env root is required for managed cursor mcp_config")
+		return "", fmt.Errorf("env root is required for cursor task state")
 	}
 
 	projectRoot := cursorProjectRoot(workDir)
+	cursorDataDir := filepath.Join(envRoot, "cursor-data")
+	projectDataDir := filepath.Join(cursorDataDir, "projects", cursorSlugifyPath(projectRoot))
+	if err := os.MkdirAll(projectDataDir, 0o700); err != nil {
+		return "", fmt.Errorf("create cursor project data dir: %w", err)
+	}
+	trustData, err := json.MarshalIndent(map[string]string{
+		"trustedAt":     "1970-01-01T00:00:00Z",
+		"workspacePath": projectRoot,
+		"trustMethod":   "multica-managed",
+	}, "", "  ")
+	if err != nil {
+		return "", fmt.Errorf("marshal cursor workspace trust: %w", err)
+	}
+	if err := os.WriteFile(filepath.Join(projectDataDir, cursorWorkspaceTrustedFile), trustData, 0o600); err != nil {
+		return "", fmt.Errorf("write cursor workspace trust: %w", err)
+	}
+
+	if !hasManagedCursorMcpConfig(mcpConfig) {
+		if err := removeCursorMcpAuthFile(projectDataDir); err != nil {
+			return "", err
+		}
+		if err := os.Remove(filepath.Join(projectDataDir, "mcp-approvals.json")); err != nil && !errors.Is(err, fs.ErrNotExist) {
+			return "", fmt.Errorf("remove prior cursor mcp approvals: %w", err)
+		}
+		return cursorDataDir, nil
+	}
+
 	servers, err := parseCursorManagedMcpServers(mcpConfig)
 	if err != nil {
 		return "", err
@@ -63,11 +91,6 @@ func prepareCursorMcpConfig(envRoot, workDir string, mcpConfig json.RawMessage, 
 		return "", fmt.Errorf("write .cursor/mcp.json: %w", err)
 	}
 
-	cursorDataDir := filepath.Join(envRoot, "cursor-data")
-	projectDataDir := filepath.Join(cursorDataDir, "projects", cursorSlugifyPath(projectRoot))
-	if err := os.MkdirAll(projectDataDir, 0o700); err != nil {
-		return "", fmt.Errorf("create cursor project data dir: %w", err)
-	}
 	if err := removeCursorMcpAuthFile(projectDataDir); err != nil {
 		return "", err
 	}
@@ -81,17 +104,6 @@ func prepareCursorMcpConfig(envRoot, workDir string, mcpConfig json.RawMessage, 
 	}
 	if err := os.WriteFile(filepath.Join(projectDataDir, "mcp-approvals.json"), approvalData, 0o600); err != nil {
 		return "", fmt.Errorf("write cursor mcp approvals: %w", err)
-	}
-	trustData, err := json.MarshalIndent(map[string]string{
-		"trustedAt":     "1970-01-01T00:00:00Z",
-		"workspacePath": projectRoot,
-		"trustMethod":   "multica-managed",
-	}, "", "  ")
-	if err != nil {
-		return "", fmt.Errorf("marshal cursor workspace trust: %w", err)
-	}
-	if err := os.WriteFile(filepath.Join(projectDataDir, cursorWorkspaceTrustedFile), trustData, 0o600); err != nil {
-		return "", fmt.Errorf("write cursor workspace trust: %w", err)
 	}
 	if strings.TrimSpace(mcpAuthSource) != "" {
 		if err := seedCursorMcpAuthFile(projectDataDir, mcpAuthSource); err != nil {

--- a/server/internal/daemon/execenv/cursor_mcp_test.go
+++ b/server/internal/daemon/execenv/cursor_mcp_test.go
@@ -208,7 +208,7 @@ func TestPrepareCursorMcpConfigRejectsArbitraryAuthSourceFile(t *testing.T) {
 	}
 }
 
-func TestPrepareCursorMcpConfigNilDoesNotTakeOwnership(t *testing.T) {
+func TestPrepareCursorMcpConfigNilStillIsolatesTaskState(t *testing.T) {
 	t.Parallel()
 
 	envRoot := t.TempDir()
@@ -220,11 +220,19 @@ func TestPrepareCursorMcpConfigNilDoesNotTakeOwnership(t *testing.T) {
 	if err != nil {
 		t.Fatalf("prepareCursorMcpConfig: %v", err)
 	}
-	if cursorDataDir != "" {
-		t.Fatalf("CursorDataDir = %q, want empty", cursorDataDir)
+	if cursorDataDir != filepath.Join(envRoot, "cursor-data") {
+		t.Fatalf("CursorDataDir = %q, want envRoot/cursor-data", cursorDataDir)
 	}
 	if _, err := os.Stat(filepath.Join(workDir, ".cursor", "mcp.json")); !os.IsNotExist(err) {
 		t.Fatalf(".cursor/mcp.json should not exist, stat err=%v", err)
+	}
+	projectRoot := cursorProjectRoot(workDir)
+	projectDataDir := filepath.Join(cursorDataDir, "projects", cursorSlugifyPath(projectRoot))
+	if _, err := os.Stat(filepath.Join(projectDataDir, cursorWorkspaceTrustedFile)); err != nil {
+		t.Fatalf("isolated workspace trust file missing: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(projectDataDir, "mcp-approvals.json")); !os.IsNotExist(err) {
+		t.Fatalf("unmanaged Cursor task should not synthesize MCP approvals, stat err=%v", err)
 	}
 }
 

--- a/server/internal/daemon/execenv/execenv.go
+++ b/server/internal/daemon/execenv/execenv.go
@@ -216,10 +216,10 @@ type Environment struct {
 	// directory holding the wrapper file. Empty when no $include is
 	// emitted (fresh install).
 	OpenclawIncludeRoot string
-	// CursorDataDir is the per-task Cursor data directory (set only for
-	// cursor provider when the agent has managed mcp_config). The daemon
-	// exports this as CURSOR_DATA_DIR so project-level MCP approvals are
-	// isolated from the user's persistent ~/.cursor/projects state.
+	// CursorDataDir is the per-task Cursor data directory (set for every Cursor
+	// task). The daemon exports this as CURSOR_DATA_DIR so provider-native
+	// repository state and project-level MCP approvals cannot leak through the
+	// user's persistent ~/.cursor/projects state.
 	CursorDataDir string
 	// HermesHome is the path to the per-task HERMES_HOME overlay (set only for
 	// the hermes provider, and only when the agent has skills bound — empty
@@ -381,11 +381,9 @@ func Prepare(params PrepareParams, logger *slog.Logger) (*Environment, error) {
 		env.QwenpawWorkspace = qwenpawWorkspace
 	}
 
-	// For Cursor, materialize managed MCP into project-local config and use
-	// an isolated CURSOR_DATA_DIR for the per-workdir approval sidecar. Cursor
-	// still reads ~/.cursor/mcp.json, but only servers with approval entries in
-	// this per-task data dir can load, so user-global MCP servers do not leak
-	// into managed-MCP runs.
+	// For Cursor, always isolate provider-native project state in a per-task
+	// CURSOR_DATA_DIR. When managed MCP is configured, also materialize its
+	// project-local config and approvals there.
 	if params.Provider == "cursor" {
 		cursorDataDir, err := prepareCursorMcpConfig(envRoot, workDir, params.McpConfig, params.CursorMcpAuthSource, manifest)
 		if err != nil {


### PR DESCRIPTION
## What does this PR do?

Prevents provider-native repository state from carrying deleted issue context into later tasks that happen to use the same workspace/project.

The server already scopes explicit session resume to `(agent_id, issue_id)`, so the leak sits below that boundary:

- Claude Code auto memory is enabled by default, stored per Git repository, and loaded into every new conversation.
- Cursor stores project assets, terminal captures, codebase identity, trust, and related state under `CURSOR_DATA_DIR`; unmanaged runs previously used the daemon user's persistent `~/.cursor` data.

This change disables Claude auto memory for daemon-managed tasks and gives every Cursor issue environment a task-local data directory. Same-issue continuity still uses the existing exact `--resume` session and reused environment.

## Related Issue

Closes #6656

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Refactor / code improvement (no behavior change)
- [ ] Documentation update
- [x] Tests (adding or improving test coverage)
- [ ] CI / infrastructure

## Changes Made

- `server/internal/daemon/daemon.go`: set `CLAUDE_CODE_DISABLE_AUTO_MEMORY=1` for Claude tasks, block custom overrides, and provide the daemon-level `MULTICA_CLAUDE_MEMORY=1` opt-in escape hatch.
- `server/internal/daemon/execenv/cursor_mcp.go`: always create and return a task-local `CURSOR_DATA_DIR`, including an isolated workspace trust marker even when no managed MCP config exists.
- `server/internal/daemon/execenv/execenv.go`: apply Cursor state isolation on both fresh prepare and reused same-issue environments.
- Added regression coverage for default Claude memory policy, the opt-in path, environment override blocking, and unmanaged Cursor task isolation.

## How to Test

1. Run `cd server && go test ./...`.
2. Run `cd server && go vet ./...`.
3. Run `cd server && go build ./...`.
4. With Claude Code, process issue A, delete it, then assign unrelated issue B in the same repository; B should not load repository auto memory from A.
5. With Cursor, verify separate issues using the same local project receive different task-local `CURSOR_DATA_DIR` roots, while a same-issue follow-up reuses the prior root/session.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] If this change affects the UI, I have included before/after screenshots (not applicable)
- [x] I have updated relevant documentation to reflect my changes (code-level operator documentation; no user-facing configuration page exists for the equivalent Codex escape hatch)
- [x] If I added a new runtime / coding tool / UI tab, I synced the change to landing copy and relevant docs (not applicable)
- [x] If this PR touches Chinese product copy, I checked conventions (not applicable)
- [x] I have considered and documented any risks above
- [x] I will address all reviewer comments before requesting merge

Risk: Cursor project-scoped state is intentionally no longer inherited from the daemon user's `~/.cursor/projects`. Authentication/config remain in Cursor's separate config store, but unmanaged project-local approvals and artifacts must be re-established inside the task environment. Managed MCP behavior is unchanged and remains explicitly hydrated.

## AI Disclosure

**AI tool used:** Codex

**Prompt / approach:** Investigated the issue deletion/cancellation path and session lookup first, verified resume is already scoped by agent and issue, then traced provider-native persistence. Confirmed Claude Code's documented repository auto memory behavior and inspected Cursor CLI's `CURSOR_DATA_DIR` layout. Added failing regression tests before implementing the isolation policies, then ran the full server test suite, vet, and build.

## Screenshots (optional)

Not applicable; daemon-only change.
