### PR TITLE
feat(github): configure the REST and GraphQL API roots separately

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -331,6 +331,16 @@ GITHUB_WEBHOOK_SECRET=
 # generated under "Private keys" on that same page; preserve newlines.
 GITHUB_APP_ID=
 GITHUB_APP_PRIVATE_KEY=
+# GITHUB_API_URL is the REST root and GITHUB_GRAPHQL_URL the GraphQL endpoint
+# used by the App-authenticated calls behind the installation lookup, the
+# repository picker, and PR-card CI / mergeability. They default to
+# https://api.github.com and https://api.github.com/graphql. Set them when the
+# App lives on a GitHub Enterprise Server instance, where the two live under
+# different paths ("https://github.example.com/api/v3" and
+# "https://github.example.com/api/graphql"), or when corporate egress requires
+# an internal proxy in front of the GitHub API. A trailing slash is ignored.
+# GITHUB_API_URL=
+# GITHUB_GRAPHQL_URL=
 
 # Self-hosted Git provider integration (Settings → Integrations): Forgejo, Gitea,
 # and GitLab. This is a SELF-HOSTED-MULTICA-ONLY feature (not offered on the

--- a/apps/docs/content/docs/environment-variables.mdx
+++ b/apps/docs/content/docs/environment-variables.mdx
@@ -161,6 +161,8 @@ The `RATE_LIMIT_*` variables above only take effect once `REDIS_URL` is set; wit
 | GitHub | `GITHUB_WEBHOOK_SECRET` | Webhook HMAC and connect-state signing secret |
 | GitHub | `GITHUB_APP_ID` | Needed for CI status and mergeability on PR cards and the "pick from GitHub" repository picker |
 | GitHub | `GITHUB_APP_PRIVATE_KEY` | Full PEM private key paired with the App ID; same uses as above |
+| GitHub | `GITHUB_API_URL` | REST API root for the App-authenticated calls; defaults to `https://api.github.com`, set it to `https://github.example.com/api/v3` for GitHub Enterprise Server or to an internal proxy fronting the GitHub API |
+| GitHub | `GITHUB_GRAPHQL_URL` | GraphQL endpoint for PR-card CI and mergeability; defaults to `https://api.github.com/graphql`, set it to `https://github.example.com/api/graphql` for GitHub Enterprise Server, which serves GraphQL outside the REST root |
 | Lark | `MULTICA_LARK_SECRET_KEY` | Base64-encoded 32-byte credential encryption key |
 | Slack | `MULTICA_SLACK_SECRET_KEY` | Base64-encoded 32-byte token encryption key |
 | Composio | `COMPOSIO_API_KEY` | Enables Composio tool connections |

--- a/server/internal/handler/github.go
+++ b/server/internal/handler/github.go
@@ -29,15 +29,31 @@ import (
 	"github.com/multica-ai/multica/server/pkg/protocol"
 )
 
-// githubAPIBase is the base URL for GitHub's REST API. Mutable so tests can
-// point App-authenticated calls at an httptest server without touching GitHub.
-var githubAPIBase = "https://api.github.com"
+// githubAPIBase is the base URL for GitHub's REST API, resolved once at
+// startup. Operators whose App lives on a GitHub Enterprise Server instance
+// (or who must reach GitHub through an internal proxy) point it elsewhere with
+// GITHUB_API_URL; unset keeps api.github.com. Mutable so tests can point
+// App-authenticated calls at an httptest server without touching GitHub.
+var githubAPIBase = githubAPIBaseFromEnv()
 
 const (
 	githubReturnToGitHub       = "github"
 	githubReturnToRepositories = "repositories"
 	githubAPIResponseLimit     = 4 << 20
+	githubAPIBaseEnv           = "GITHUB_API_URL"
+	githubAPIBaseDefault       = "https://api.github.com"
 )
+
+// githubAPIBaseFromEnv reads the configured REST API root, falling back to
+// api.github.com when the variable is unset or blank. A trailing slash is
+// dropped so the value concatenates cleanly with endpoint paths.
+func githubAPIBaseFromEnv() string {
+	configured := strings.TrimSpace(os.Getenv(githubAPIBaseEnv))
+	if configured == "" {
+		return githubAPIBaseDefault
+	}
+	return strings.TrimRight(configured, "/")
+}
 
 // ── Response shapes ─────────────────────────────────────────────────────────
 

--- a/server/internal/handler/github_test.go
+++ b/server/internal/handler/github_test.go
@@ -2454,6 +2454,74 @@ func TestListGitHubInstallationRepositoriesRejectsCrossWorkspaceRow(t *testing.T
 	}
 }
 
+// TestGitHubAPIBaseFromEnv pins the resolution of GITHUB_API_URL: an
+// unset or blank variable must keep api.github.com, so deployments that never
+// configure it are unaffected, and a configured root is normalized by dropping
+// the trailing slash callers would otherwise double up.
+func TestGitHubAPIBaseFromEnv(t *testing.T) {
+	cases := []struct {
+		name string
+		env  string
+		want string
+	}{
+		{name: "unset_keeps_default", env: "", want: "https://api.github.com"},
+		{name: "blank_keeps_default", env: "   ", want: "https://api.github.com"},
+		{
+			name: "enterprise_server_root",
+			env:  "https://github.example.com/api/v3",
+			want: "https://github.example.com/api/v3",
+		},
+		{
+			name: "trailing_slash_trimmed",
+			env:  "https://github.example.com/api/v3/",
+			want: "https://github.example.com/api/v3",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv(githubAPIBaseEnv, tc.env)
+			if got := githubAPIBaseFromEnv(); got != tc.want {
+				t.Errorf("githubAPIBaseFromEnv() = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestFetchInstallationAccount_UsesConfiguredAPIBase verifies that a
+// configured API root reaches the App-authenticated call intact, path prefix
+// included: a GitHub Enterprise Server root such as
+// `https://github.example.com/api/v3` must produce
+// `/api/v3/app/installations/{id}`, not `/app/installations/{id}`.
+func TestFetchInstallationAccount_UsesConfiguredAPIBase(t *testing.T) {
+	pemBytes, _ := generateTestRSAKeyPEM(t)
+	t.Setenv("GITHUB_APP_ID", "11111")
+	t.Setenv("GITHUB_APP_PRIVATE_KEY", string(pemBytes))
+
+	const wantInstallationID int64 = 4242
+	var sawPath string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		sawPath = r.URL.Path
+		writeJSON(w, http.StatusOK, map[string]any{
+			"account": map[string]any{"login": "enterprise-org", "type": "Organization"},
+		})
+	}))
+	t.Cleanup(srv.Close)
+
+	t.Setenv(githubAPIBaseEnv, srv.URL+"/api/v3/")
+	oldBase := githubAPIBase
+	githubAPIBase = githubAPIBaseFromEnv()
+	t.Cleanup(func() { githubAPIBase = oldBase })
+
+	login, _, _ := fetchInstallationAccount(context.Background(), wantInstallationID)
+	if login != "enterprise-org" {
+		t.Errorf("login = %q, want enterprise-org", login)
+	}
+	wantPath := fmt.Sprintf("/api/v3/app/installations/%d", wantInstallationID)
+	if sawPath != wantPath {
+		t.Errorf("request path = %q, want %q", sawPath, wantPath)
+	}
+}
+
 // TestFetchInstallationAccount_AuthenticatedPopulatesRow simulates the
 // GitHub `/app/installations/{id}` endpoint with a JWT-gated mock and
 // verifies that fetchInstallationAccount, when fully configured,

--- a/server/internal/integrations/ghsnapshot/client.go
+++ b/server/internal/integrations/ghsnapshot/client.go
@@ -37,7 +37,10 @@ import (
 )
 
 const (
-	defaultAPIBase = "https://api.github.com"
+	apiBaseEnv         = "GITHUB_API_URL"
+	defaultAPIBase     = "https://api.github.com"
+	graphQLBaseEnv     = "GITHUB_GRAPHQL_URL"
+	defaultGraphQLBase = "https://api.github.com/graphql"
 	// Renew an installation token this long before it actually expires so an
 	// in-flight request never races the expiry boundary. GitHub tokens live
 	// one hour.
@@ -59,12 +62,18 @@ func (e *RateLimitError) Error() string {
 // *Client is a valid "feature disabled" value — every method the refresh
 // pipeline calls tolerates it — so a deployment without a GitHub App private
 // key degrades cleanly (acceptance criterion 4).
+//
+// The two roots are configured separately because they only coincide on
+// github.com: a GitHub Enterprise Server instance serves REST from
+// https://HOST/api/v3 and GraphQL from https://HOST/api/graphql, so deriving
+// one from the other would produce an endpoint that does not exist.
 type Client struct {
-	appID      string
-	privateKey *rsa.PrivateKey
-	apiBase    string
-	httpClient *http.Client
-	now        func() time.Time
+	appID       string
+	privateKey  *rsa.PrivateKey
+	apiBase     string
+	graphQLBase string
+	httpClient  *http.Client
+	now         func() time.Time
 
 	mu     sync.Mutex
 	tokens map[int64]cachedToken
@@ -79,7 +88,8 @@ type cachedToken struct {
 	expiry time.Time
 }
 
-// NewClientFromEnv builds a Client from GITHUB_APP_ID and GITHUB_APP_PRIVATE_KEY.
+// NewClientFromEnv builds a Client from GITHUB_APP_ID and GITHUB_APP_PRIVATE_KEY,
+// pointed at the roots configured by GITHUB_API_URL and GITHUB_GRAPHQL_URL.
 //
 //   - Both unset → (nil, nil): the App API is simply not configured for this
 //     deployment; the caller degrades the whole feature off.
@@ -96,13 +106,25 @@ func NewClientFromEnv() (*Client, error) {
 		return nil, fmt.Errorf("parse GITHUB_APP_PRIVATE_KEY: %w", err)
 	}
 	return &Client{
-		appID:      appID,
-		privateKey: key,
-		apiBase:    defaultAPIBase,
-		httpClient: &http.Client{Timeout: 20 * time.Second},
-		now:        time.Now,
-		tokens:     map[int64]cachedToken{},
+		appID:       appID,
+		privateKey:  key,
+		apiBase:     rootFromEnv(apiBaseEnv, defaultAPIBase),
+		graphQLBase: rootFromEnv(graphQLBaseEnv, defaultGraphQLBase),
+		httpClient:  &http.Client{Timeout: 20 * time.Second},
+		now:         time.Now,
+		tokens:      map[int64]cachedToken{},
 	}, nil
+}
+
+// rootFromEnv reads a configured API root, falling back to the api.github.com
+// default when the variable is unset or blank. A trailing slash is dropped so
+// the value concatenates cleanly with endpoint paths.
+func rootFromEnv(name, fallback string) string {
+	configured := strings.TrimSpace(os.Getenv(name))
+	if configured == "" {
+		return fallback
+	}
+	return strings.TrimRight(configured, "/")
 }
 
 // Enabled reports whether the App API is configured. A nil client is disabled.
@@ -222,8 +244,7 @@ func (c *Client) graphQL(ctx context.Context, installationID int64, query string
 	if err != nil {
 		return nil, err
 	}
-	endpoint := strings.TrimRight(c.apiBase, "/") + "/graphql"
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, bytes.NewReader(payload))
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.graphQLBase, bytes.NewReader(payload))
 	if err != nil {
 		return nil, err
 	}

--- a/server/internal/integrations/ghsnapshot/client_test.go
+++ b/server/internal/integrations/ghsnapshot/client_test.go
@@ -6,6 +6,7 @@ import (
 	"crypto/rsa"
 	"crypto/x509"
 	"encoding/pem"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -15,6 +16,15 @@ import (
 	"time"
 )
 
+func testPrivateKeyPEM(t *testing.T) string {
+	t.Helper()
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return string(pem.EncodeToMemory(&pem.Block{Type: "RSA PRIVATE KEY", Bytes: x509.MarshalPKCS1PrivateKey(key)}))
+}
+
 func newTestClient(t *testing.T, apiBase string) *Client {
 	t.Helper()
 	key, err := rsa.GenerateKey(rand.Reader, 2048)
@@ -22,12 +32,13 @@ func newTestClient(t *testing.T, apiBase string) *Client {
 		t.Fatal(err)
 	}
 	return &Client{
-		appID:      "123",
-		privateKey: key,
-		apiBase:    apiBase,
-		httpClient: &http.Client{Timeout: 5 * time.Second},
-		now:        time.Now,
-		tokens:     map[int64]cachedToken{},
+		appID:       "123",
+		privateKey:  key,
+		apiBase:     apiBase,
+		graphQLBase: apiBase + "/graphql",
+		httpClient:  &http.Client{Timeout: 5 * time.Second},
+		now:         time.Now,
+		tokens:      map[int64]cachedToken{},
 	}
 }
 
@@ -193,13 +204,112 @@ func TestNewClientFromEnv(t *testing.T) {
 		}
 	})
 	t.Run("valid key enables the client", func(t *testing.T) {
-		key, _ := rsa.GenerateKey(rand.Reader, 2048)
-		pemBytes := pem.EncodeToMemory(&pem.Block{Type: "RSA PRIVATE KEY", Bytes: x509.MarshalPKCS1PrivateKey(key)})
 		t.Setenv("GITHUB_APP_ID", "1")
-		t.Setenv("GITHUB_APP_PRIVATE_KEY", string(pemBytes))
+		t.Setenv("GITHUB_APP_PRIVATE_KEY", testPrivateKeyPEM(t))
 		c, err := NewClientFromEnv()
 		if err != nil || !c.Enabled() {
 			t.Fatalf("got (%v, %v), want enabled client", c, err)
 		}
 	})
+}
+
+// TestNewClientFromEnvResolvesAPIRoots pins the resolution of both roots: unset
+// or blank keeps api.github.com, so deployments that never configure them are
+// unaffected, and a configured root is normalized by dropping the trailing
+// slash callers would otherwise double up.
+func TestNewClientFromEnvResolvesAPIRoots(t *testing.T) {
+	cases := []struct {
+		name        string
+		apiURL      string
+		graphQLURL  string
+		wantAPI     string
+		wantGraphQL string
+	}{
+		{
+			name:        "unset keeps the defaults",
+			wantAPI:     "https://api.github.com",
+			wantGraphQL: "https://api.github.com/graphql",
+		},
+		{
+			name:        "blank keeps the defaults",
+			apiURL:      "   ",
+			graphQLURL:  "   ",
+			wantAPI:     "https://api.github.com",
+			wantGraphQL: "https://api.github.com/graphql",
+		},
+		{
+			name:        "enterprise server roots",
+			apiURL:      "https://github.example.com/api/v3",
+			graphQLURL:  "https://github.example.com/api/graphql",
+			wantAPI:     "https://github.example.com/api/v3",
+			wantGraphQL: "https://github.example.com/api/graphql",
+		},
+		{
+			name:        "trailing slash trimmed",
+			apiURL:      "https://github.example.com/api/v3/",
+			graphQLURL:  "https://github.example.com/api/graphql/",
+			wantAPI:     "https://github.example.com/api/v3",
+			wantGraphQL: "https://github.example.com/api/graphql",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv("GITHUB_APP_ID", "1")
+			t.Setenv("GITHUB_APP_PRIVATE_KEY", testPrivateKeyPEM(t))
+			t.Setenv(apiBaseEnv, tc.apiURL)
+			t.Setenv(graphQLBaseEnv, tc.graphQLURL)
+
+			c, err := NewClientFromEnv()
+			if err != nil {
+				t.Fatalf("NewClientFromEnv: %v", err)
+			}
+			if c.apiBase != tc.wantAPI {
+				t.Errorf("apiBase = %q, want %q", c.apiBase, tc.wantAPI)
+			}
+			if c.graphQLBase != tc.wantGraphQL {
+				t.Errorf("graphQLBase = %q, want %q", c.graphQLBase, tc.wantGraphQL)
+			}
+		})
+	}
+}
+
+// TestEnterpriseServerRootsStaySeparate proves the two roots never bleed into
+// each other on a GitHub Enterprise Server instance, where REST lives under
+// /api/v3 and GraphQL under /api/graphql: the token mint must reach
+// /api/v3/app/installations/{id}/access_tokens and the query /api/graphql,
+// never /api/v3/graphql.
+func TestEnterpriseServerRootsStaySeparate(t *testing.T) {
+	const installationID int64 = 4242
+	var tokenPath, queryPath string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.HasSuffix(r.URL.Path, "/access_tokens") {
+			tokenPath = r.URL.Path
+			w.WriteHeader(http.StatusCreated)
+			_, _ = w.Write([]byte(`{"token":"ghs_secret","expires_at":"` +
+				time.Now().Add(time.Hour).UTC().Format(time.RFC3339) + `"}`))
+			return
+		}
+		queryPath = r.URL.Path
+		_, _ = w.Write([]byte(`{"data":{"ok":true}}`))
+	}))
+	defer srv.Close()
+
+	t.Setenv("GITHUB_APP_ID", "1")
+	t.Setenv("GITHUB_APP_PRIVATE_KEY", testPrivateKeyPEM(t))
+	t.Setenv(apiBaseEnv, srv.URL+"/api/v3")
+	t.Setenv(graphQLBaseEnv, srv.URL+"/api/graphql")
+
+	c, err := NewClientFromEnv()
+	if err != nil {
+		t.Fatalf("NewClientFromEnv: %v", err)
+	}
+	if _, err := c.graphQL(context.Background(), installationID, "query{}", nil); err != nil {
+		t.Fatalf("graphQL: %v", err)
+	}
+	if want := fmt.Sprintf("/api/v3/app/installations/%d/access_tokens", installationID); tokenPath != want {
+		t.Errorf("token path = %q, want %q", tokenPath, want)
+	}
+	if want := "/api/graphql"; queryPath != want {
+		t.Errorf("query path = %q, want %q", queryPath, want)
+	}
 }


### PR DESCRIPTION
## What does this PR do?

Two places hard-code `https://api.github.com` for App-authenticated traffic, and an operator can change neither:

- `server/internal/handler/github.go` — the REST calls behind the installation lookup and Settings → Repositories → "Choose from GitHub". The variable was mutable only so tests could point it at an `httptest` server.
- `server/internal/integrations/ghsnapshot/client.go` — the client that fills CI status and mergeability on PR cards. It reads only `GITHUB_APP_ID` and `GITHUB_APP_PRIVATE_KEY`, then pins its base to the same constant.

That blocks a self-hosted Multica whose GitHub App lives on a **GitHub Enterprise Server** instance, and it blocks corporate environments where egress to GitHub has to go through an internal proxy.

`GITHUB_API_URL` now sets the REST root and `GITHUB_GRAPHQL_URL` the GraphQL endpoint. Each is read once at startup, trimmed, and normalized by dropping a trailing slash so it concatenates cleanly with endpoint paths. **Unset or blank keeps `https://api.github.com` and `https://api.github.com/graphql`**, so deployments that never configure them are untouched, including the managed cloud. The names match the pair GitHub Actions already exposes.

### Why two variables and not one

The two roots only coincide on github.com. Enterprise Server serves REST from `https://HOST/api/v3` and GraphQL from `https://HOST/api/graphql`, [not](https://docs.github.com/en/enterprise-server@3.14/graphql/guides/forming-calls-with-graphql) under the REST root. Deriving one from the other is what `ghsnapshot` does today: it builds `<base>/graphql`, which on Enterprise Server resolves to `https://HOST/api/v3/graphql`, an endpoint that does not exist. So `ghsnapshot` now mints installation tokens against the REST root and runs queries against the GraphQL one.

The endpoints that follow the configured roots:

- REST — `GET /app/installations/{id}` (installation account enrichment on the setup callback); `POST /app/installations/{id}/access_tokens` and `GET /installation/repositories` (repository picker); `DELETE /installation/token` (the revoke that follows that listing); `POST /app/installations/{id}/access_tokens` again in `ghsnapshot`.
- GraphQL — the single PR snapshot query in `ghsnapshot`.

### Other hard-coded `api.github.com` occurrences, and why they are out of scope

`server/internal/handler/skill.go` fetches public skill repositories (`anthropics/skills`, `vercel-labs/agent-skills`, …) from github.com, and `server/internal/cli/update.go`, `packages/views/runtimes/components/update-section.tsx`, `apps/web/features/landing/utils/*` read Multica's own releases and stars from `multica-ai/multica`. None of that content lives on the operator's instance.

`docker-compose.selfhost.yml` is also unchanged: it does not forward `GITHUB_APP_ID` / `GITHUB_APP_PRIVATE_KEY` either, so forwarding only the API roots there would be inconsistent.

## Related Issue

No issue — small self-contained configuration change.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Refactor / code improvement (no behavior change)
- [x] Documentation update
- [x] Tests (adding or improving test coverage)
- [ ] CI / infrastructure

## Changes Made

- `server/internal/handler/github.go`: `githubAPIBase` is initialized from `githubAPIBaseFromEnv()`, which reads `GITHUB_API_URL` and falls back to `https://api.github.com`. The variable stays mutable for the existing tests; call sites are unchanged.
- `server/internal/integrations/ghsnapshot/client.go`: `Client` gains a `graphQLBase` field; `NewClientFromEnv` resolves both roots from the environment; the GraphQL call targets `graphQLBase` instead of `apiBase + "/graphql"`.
- `server/internal/handler/github_test.go`: `TestGitHubAPIBaseFromEnv` covers unset, blank, a GHE root, and trailing-slash normalization; `TestFetchInstallationAccount_UsesConfiguredAPIBase` asserts a configured root with a path prefix reaches the wire as `/api/v3/app/installations/{id}`.
- `server/internal/integrations/ghsnapshot/client_test.go`: `TestNewClientFromEnvResolvesAPIRoots` pins defaults, overrides, and normalization for both variables; `TestEnterpriseServerRootsStaySeparate` drives a real token mint plus a query against an `httptest` server configured with GHE-shaped roots and asserts the two paths do not mix.
- `.env.example` and `apps/docs/content/docs/environment-variables.mdx`: both variables documented next to the other GitHub App settings.

## How to Test

1. Leave both variables unset and confirm nothing changes: REST still goes to `https://api.github.com` and GraphQL to `https://api.github.com/graphql`. Pinned by `TestGitHubAPIBaseFromEnv/unset_keeps_default` and `TestNewClientFromEnvResolvesAPIRoots/unset_keeps_the_defaults`.
2. Set `GITHUB_API_URL=https://github.example.com/api/v3/` (trailing slash on purpose) and `GITHUB_GRAPHQL_URL=https://github.example.com/api/graphql/`, and confirm the installation lookup targets `/api/v3/app/installations/{id}` while the snapshot query targets `/api/graphql`. `TestFetchInstallationAccount_UsesConfiguredAPIBase` and `TestEnterpriseServerRootsStaySeparate` run exactly this against `httptest` servers.
3. Run the two touched packages:

```bash
cd server
gofmt -l internal/handler/github.go internal/handler/github_test.go \
  internal/integrations/ghsnapshot/client.go internal/integrations/ghsnapshot/client_test.go
go vet ./internal/handler/... ./internal/integrations/ghsnapshot/...
go test ./internal/handler/... ./internal/integrations/ghsnapshot/...
```

Result here: `gofmt -l` prints nothing, `go vet` is clean, and both packages pass. Reverting only the GraphQL endpoint line to the old `apiBase + "/graphql"` makes `TestEnterpriseServerRootsStaySeparate` fail with `query path = "/api/v3/graphql", want "/api/graphql"`, so the new test does catch the bug it describes.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots (no UI change)
- [x] I have updated relevant documentation to reflect my changes
- [ ] If I added a new runtime / coding tool / UI tab, I synced the change to landing copy and relevant docs (not applicable)
- [ ] If this PR touches Chinese product copy, I checked it against `conventions.zh.mdx` (not applicable)
- [x] I have considered and documented any risks above
- [x] I will address all reviewer comments before requesting merge

Risk: none for existing deployments. Unset variables resolve to today's constants, and no call site changed shape. A misconfigured value fails the same way an unreachable GitHub does today: the installation account falls back to the `unknown` placeholder, the repository picker surfaces its error, and the PR-card snapshot refresh reports a failed refresh.

I agree to the Contribution Terms in `CONTRIBUTING.md`.

## AI Disclosure

**AI tool used:** Claude Code

**Prompt / approach:** I asked Claude Code to make the hard-coded GitHub API roots configurable with the current values preserved as defaults, to check the Enterprise Server documentation for whether REST and GraphQL share a root before deciding on one variable or two, to fix `ghsnapshot`'s derived GraphQL endpoint, to add tests in the style already used in each package, and to update the existing env/docs references without inventing new sections.



Closes #6993
