### PR TITLE
MUL-5951: fix(issues): reject a cross-workspace project on issue update

### DIFF
--- a/server/internal/handler/issue.go
+++ b/server/internal/handler/issue.go
@@ -3019,6 +3019,13 @@ func (h *Handler) UpdateIssue(w http.ResponseWriter, r *http.Request) {
 			if !ok {
 				return
 			}
+			if _, err := h.Queries.GetProjectInWorkspace(r.Context(), db.GetProjectInWorkspaceParams{
+				ID:          projectUUID,
+				WorkspaceID: prevIssue.WorkspaceID,
+			}); err != nil {
+				writeError(w, http.StatusBadRequest, "project not found in this workspace")
+				return
+			}
 			params.ProjectID = projectUUID
 		} else {
 			params.ProjectID = pgtype.UUID{Valid: false}

--- a/server/internal/handler/issue.go
+++ b/server/internal/handler/issue.go
@@ -3023,6 +3023,12 @@ func (h *Handler) UpdateIssue(w http.ResponseWriter, r *http.Request) {
 				ID:          projectUUID,
 				WorkspaceID: prevIssue.WorkspaceID,
 			}); err != nil {
+				if !isNotFound(err) {
+					slog.Error("update issue: validate project scope",
+						append(logger.RequestAttrs(r), "project_id", uuidToString(projectUUID), "error", err)...)
+					writeError(w, http.StatusInternalServerError, "failed to validate project")
+					return
+				}
 				writeError(w, http.StatusBadRequest, "project not found in this workspace")
 				return
 			}
@@ -3487,6 +3493,31 @@ func (h *Handler) BatchUpdateIssues(w http.ResponseWriter, r *http.Request) {
 	if !ok {
 		return
 	}
+	// The batch shares one project_id, so it is checked once here rather than
+	// per issue, and rejected instead of skipped like the per-item guards in
+	// the loop: a foreign project invalidates the whole request.
+	batchProjectID := pgtype.UUID{Valid: false}
+	if _, ok := rawUpdates["project_id"]; ok && req.Updates.ProjectID != nil {
+		projectUUID, ok := parseUUIDOrBadRequest(w, *req.Updates.ProjectID, "project_id")
+		if !ok {
+			return
+		}
+		if _, err := h.Queries.GetProjectInWorkspace(r.Context(), db.GetProjectInWorkspaceParams{
+			ID:          projectUUID,
+			WorkspaceID: wsUUID,
+		}); err != nil {
+			if !isNotFound(err) {
+				slog.Error("batch update issues: validate project scope",
+					append(logger.RequestAttrs(r), "project_id", uuidToString(projectUUID), "error", err)...)
+				writeError(w, http.StatusInternalServerError, "failed to validate project")
+				return
+			}
+			writeError(w, http.StatusBadRequest, "project not found in this workspace")
+			return
+		}
+		batchProjectID = projectUUID
+	}
+
 	updated := 0
 	// Children that transitioned into a terminal status this batch, collected so
 	// the parent/stage notification is evaluated once against the final state
@@ -3612,15 +3643,8 @@ func (h *Handler) BatchUpdateIssues(w http.ResponseWriter, r *http.Request) {
 			}
 		}
 		if _, ok := rawUpdates["project_id"]; ok {
-			if req.Updates.ProjectID != nil {
-				projectUUID, err := util.ParseUUID(*req.Updates.ProjectID)
-				if err != nil {
-					continue
-				}
-				params.ProjectID = projectUUID
-			} else {
-				params.ProjectID = pgtype.UUID{Valid: false}
-			}
+			// Resolved before the loop; an explicit null stays invalid and clears.
+			params.ProjectID = batchProjectID
 		}
 		if _, ok := rawUpdates["stage"]; ok {
 			if req.Updates.Stage != nil {

--- a/server/internal/handler/issue_update_project_scope_test.go
+++ b/server/internal/handler/issue_update_project_scope_test.go
@@ -1,0 +1,121 @@
+package handler
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestUpdateIssueProjectStaysInWorkspace mirrors
+// TestCreateIssueRejectsCrossWorkspaceProject on the update path. UpdateIssue
+// is the canonical issue write — the legacy PUT endpoint and MoveIssue both
+// land on it — so the project boundary belongs here and not only on the entry
+// points that happen to pre-check it. Accepting a foreign project would leave
+// the issue pointing at a project from another workspace: it disappears from
+// that workspace's board, which lists by workspace, and its own board cannot
+// resolve the project.
+func TestUpdateIssueProjectStaysInWorkspace(t *testing.T) {
+	ctx := context.Background()
+	suffix := fmt.Sprintf("%d", time.Now().UnixNano())
+
+	var issueID string
+	if err := testPool.QueryRow(ctx, `
+		INSERT INTO issue (
+			workspace_id, title, status, priority, creator_type, creator_id,
+			number, position
+		)
+		VALUES (
+			$1, $2, 'todo', 'none', 'member', $3,
+			(SELECT COALESCE(MAX(number), 0) + 1 FROM issue WHERE workspace_id = $1),
+			100
+		)
+		RETURNING id
+	`, testWorkspaceID, "Project boundary test "+suffix, testUserID).Scan(&issueID); err != nil {
+		t.Fatalf("insert issue: %v", err)
+	}
+	t.Cleanup(func() {
+		testPool.Exec(context.Background(), `DELETE FROM issue WHERE id = $1`, issueID)
+	})
+
+	var localProjectID string
+	if err := testPool.QueryRow(ctx, `
+		INSERT INTO project (workspace_id, title)
+		VALUES ($1, $2)
+		RETURNING id
+	`, testWorkspaceID, "Local update project "+suffix).Scan(&localProjectID); err != nil {
+		t.Fatalf("insert local project: %v", err)
+	}
+	t.Cleanup(func() {
+		testPool.Exec(context.Background(), `DELETE FROM project WHERE id = $1`, localProjectID)
+	})
+
+	var foreignWorkspaceID string
+	if err := testPool.QueryRow(ctx, `
+		INSERT INTO workspace (name, slug, description, issue_prefix)
+		VALUES ($1, $2, '', 'UPB')
+		RETURNING id
+	`, "Update boundary foreign workspace "+suffix, "update-boundary-"+suffix).Scan(&foreignWorkspaceID); err != nil {
+		t.Fatalf("insert foreign workspace: %v", err)
+	}
+	t.Cleanup(func() {
+		testPool.Exec(context.Background(), `DELETE FROM workspace WHERE id = $1`, foreignWorkspaceID)
+	})
+
+	var foreignProjectID string
+	if err := testPool.QueryRow(ctx, `
+		INSERT INTO project (workspace_id, title)
+		VALUES ($1, $2)
+		RETURNING id
+	`, foreignWorkspaceID, "Foreign update project "+suffix).Scan(&foreignProjectID); err != nil {
+		t.Fatalf("insert foreign project: %v", err)
+	}
+
+	t.Run("same-workspace project is accepted", func(t *testing.T) {
+		w := httptest.NewRecorder()
+		req := newRequest("PUT", "/api/issues/"+issueID, map[string]any{
+			"project_id": localProjectID,
+		})
+		req = withURLParam(req, "id", issueID)
+		testHandler.UpdateIssue(w, req)
+		if w.Code != http.StatusOK {
+			t.Fatalf("UpdateIssue: expected 200, got %d: %s", w.Code, w.Body.String())
+		}
+		var updated IssueResponse
+		if err := json.NewDecoder(w.Body).Decode(&updated); err != nil {
+			t.Fatalf("decode response: %v", err)
+		}
+		if updated.ProjectID == nil || *updated.ProjectID != localProjectID {
+			t.Fatalf("UpdateIssue: expected project %s, got %v", localProjectID, updated.ProjectID)
+		}
+	})
+
+	t.Run("cross-workspace project is rejected", func(t *testing.T) {
+		w := httptest.NewRecorder()
+		req := newRequest("PUT", "/api/issues/"+issueID, map[string]any{
+			"project_id": foreignProjectID,
+		})
+		req = withURLParam(req, "id", issueID)
+		testHandler.UpdateIssue(w, req)
+		if w.Code != http.StatusBadRequest {
+			t.Fatalf("UpdateIssue: expected 400 for foreign project, got %d: %s", w.Code, w.Body.String())
+		}
+		if !strings.Contains(w.Body.String(), "project not found in this workspace") {
+			t.Fatalf("UpdateIssue: expected boundary error message, got %s", w.Body.String())
+		}
+
+		var storedProjectID string
+		if err := testPool.QueryRow(context.Background(),
+			`SELECT project_id FROM issue WHERE id = $1`, issueID,
+		).Scan(&storedProjectID); err != nil {
+			t.Fatalf("read stored project: %v", err)
+		}
+		if storedProjectID != localProjectID {
+			t.Fatalf("rejected update still wrote project %s — workspace boundary crossed", storedProjectID)
+		}
+	})
+}

--- a/server/internal/handler/issue_update_project_scope_test.go
+++ b/server/internal/handler/issue_update_project_scope_test.go
@@ -74,6 +74,9 @@ func TestUpdateIssueProjectStaysInWorkspace(t *testing.T) {
 	`, foreignWorkspaceID, "Foreign update project "+suffix).Scan(&foreignProjectID); err != nil {
 		t.Fatalf("insert foreign project: %v", err)
 	}
+	t.Cleanup(func() {
+		testPool.Exec(context.Background(), `DELETE FROM project WHERE id = $1`, foreignProjectID)
+	})
 
 	t.Run("same-workspace project is accepted", func(t *testing.T) {
 		w := httptest.NewRecorder()
@@ -118,4 +121,141 @@ func TestUpdateIssueProjectStaysInWorkspace(t *testing.T) {
 			t.Fatalf("rejected update still wrote project %s — workspace boundary crossed", storedProjectID)
 		}
 	})
+}
+
+// TestBatchUpdateIssuesProjectStaysInWorkspace covers the same boundary on
+// POST /api/issues/batch-update, reachable with a multi-select drag on the
+// board: a project from another workspace is rejected and no target row moves.
+func TestBatchUpdateIssuesProjectStaysInWorkspace(t *testing.T) {
+	ctx := context.Background()
+	suffix := fmt.Sprintf("%d", time.Now().UnixNano())
+
+	first := insertProjectScopeTestIssue(t, "Batch project boundary A "+suffix)
+	second := insertProjectScopeTestIssue(t, "Batch project boundary B "+suffix)
+
+	var localProjectID string
+	if err := testPool.QueryRow(ctx, `
+		INSERT INTO project (workspace_id, title)
+		VALUES ($1, $2)
+		RETURNING id
+	`, testWorkspaceID, "Local batch project "+suffix).Scan(&localProjectID); err != nil {
+		t.Fatalf("insert local project: %v", err)
+	}
+	t.Cleanup(func() {
+		testPool.Exec(context.Background(), `DELETE FROM project WHERE id = $1`, localProjectID)
+	})
+
+	var foreignWorkspaceID string
+	if err := testPool.QueryRow(ctx, `
+		INSERT INTO workspace (name, slug, description, issue_prefix)
+		VALUES ($1, $2, '', 'BPB')
+		RETURNING id
+	`, "Batch boundary foreign workspace "+suffix, "batch-boundary-"+suffix).Scan(&foreignWorkspaceID); err != nil {
+		t.Fatalf("insert foreign workspace: %v", err)
+	}
+	t.Cleanup(func() {
+		testPool.Exec(context.Background(), `DELETE FROM workspace WHERE id = $1`, foreignWorkspaceID)
+	})
+
+	var foreignProjectID string
+	if err := testPool.QueryRow(ctx, `
+		INSERT INTO project (workspace_id, title)
+		VALUES ($1, $2)
+		RETURNING id
+	`, foreignWorkspaceID, "Foreign batch project "+suffix).Scan(&foreignProjectID); err != nil {
+		t.Fatalf("insert foreign project: %v", err)
+	}
+	t.Cleanup(func() {
+		testPool.Exec(context.Background(), `DELETE FROM project WHERE id = $1`, foreignProjectID)
+	})
+
+	batchUpdateProject := func(projectID string) *httptest.ResponseRecorder {
+		w := httptest.NewRecorder()
+		req := newRequest("POST", "/api/issues/batch-update", map[string]any{
+			"issue_ids": []string{first, second},
+			"updates":   map[string]any{"project_id": projectID},
+		})
+		testHandler.BatchUpdateIssues(w, req)
+		return w
+	}
+
+	assertStoredProjects := func(t *testing.T, want string) {
+		t.Helper()
+		for _, issueID := range []string{first, second} {
+			var stored string
+			if err := testPool.QueryRow(context.Background(),
+				`SELECT project_id FROM issue WHERE id = $1`, issueID,
+			).Scan(&stored); err != nil {
+				t.Fatalf("read stored project for %s: %v", issueID, err)
+			}
+			if stored != want {
+				t.Fatalf("issue %s: expected project %s, got %s", issueID, want, stored)
+			}
+		}
+	}
+
+	// A non-null baseline first, so the rejection below has to preserve a real
+	// value rather than a NULL a skipped write would also leave.
+	t.Run("same-workspace project is accepted", func(t *testing.T) {
+		w := batchUpdateProject(localProjectID)
+		if w.Code != http.StatusOK {
+			t.Fatalf("BatchUpdateIssues: expected 200, got %d: %s", w.Code, w.Body.String())
+		}
+		var resp struct {
+			Updated int `json:"updated"`
+		}
+		if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+			t.Fatalf("decode response: %v", err)
+		}
+		if resp.Updated != 2 {
+			t.Fatalf("BatchUpdateIssues: expected updated 2, got %d", resp.Updated)
+		}
+		assertStoredProjects(t, localProjectID)
+	})
+
+	t.Run("cross-workspace project changes no row", func(t *testing.T) {
+		w := batchUpdateProject(foreignProjectID)
+		if w.Code != http.StatusBadRequest {
+			t.Fatalf("BatchUpdateIssues: expected 400 for foreign project, got %d: %s", w.Code, w.Body.String())
+		}
+		if !strings.Contains(w.Body.String(), "project not found in this workspace") {
+			t.Fatalf("BatchUpdateIssues: expected boundary error message, got %s", w.Body.String())
+		}
+		assertStoredProjects(t, localProjectID)
+	})
+
+	// The batch shares one project_id, so an unparseable value is a request
+	// error too, not a per-issue skip.
+	t.Run("unparseable project is rejected", func(t *testing.T) {
+		w := batchUpdateProject("not-a-uuid")
+		if w.Code != http.StatusBadRequest {
+			t.Fatalf("BatchUpdateIssues: expected 400 for unparseable project, got %d: %s", w.Code, w.Body.String())
+		}
+		assertStoredProjects(t, localProjectID)
+	})
+}
+
+// insertProjectScopeTestIssue writes the row directly, skipping the CreateIssue
+// side effects the boundary tests do not need.
+func insertProjectScopeTestIssue(t *testing.T, title string) string {
+	t.Helper()
+	var issueID string
+	if err := testPool.QueryRow(context.Background(), `
+		INSERT INTO issue (
+			workspace_id, title, status, priority, creator_type, creator_id,
+			number, position
+		)
+		VALUES (
+			$1, $2, 'todo', 'none', 'member', $3,
+			(SELECT COALESCE(MAX(number), 0) + 1 FROM issue WHERE workspace_id = $1),
+			100
+		)
+		RETURNING id
+	`, testWorkspaceID, title, testUserID).Scan(&issueID); err != nil {
+		t.Fatalf("insert issue %q: %v", title, err)
+	}
+	t.Cleanup(func() {
+		testPool.Exec(context.Background(), `DELETE FROM issue WHERE id = $1`, issueID)
+	})
+	return issueID
 }


### PR DESCRIPTION
## What does this PR do?

`UpdateIssue` accepted a `project_id` from any workspace: it parsed the UUID and assigned it, with no lookup. The write then produced an issue whose `workspace_id` differs from its project's `workspace_id`. That issue disappears from the board of the project's workspace, which lists by workspace, and points at a project its own board cannot resolve.

Every neighboring path already enforces this boundary. The `parent_issue_id` block immediately above calls `GetIssueInWorkspace` and answers `parent issue not found in this workspace`; `MoveIssue` pre-checks the project against `current.WorkspaceID`; `IssueService.Create` enforces it atomically on create. Only the update path was missing it.

The fix validates the project against `prevIssue.WorkspaceID` with the existing `GetProjectInWorkspace` query and returns 400 with `project not found in this workspace`, the message `MoveIssue` and `service.ErrProjectNotFound` already use.

`UpdateIssue` is the canonical write for both `PUT /api/issues/{id}` and `POST /api/issues/{id}/move`, which rewrites the body and delegates here. So the check closes the PUT path and leaves the move path with a redundant, harmless second check rather than a behavior change.

Transferring an issue across workspaces is a different capability and is not part of this change.

### One surface deliberately left out

`POST /api/issues/batch-update` reaches `project_id` through its own code path (`BatchUpdateIssues`) and has the same gap. That path skips an invalid per-issue update with `continue` instead of failing the request, so whether a foreign project should silently skip the issue or reject the call is a product decision, not a mechanical port of this check. I flagged it in the issue and left it alone here.

## Related Issue

Closes #6665

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Refactor / code improvement (no behavior change)
- [ ] Documentation update
- [x] Tests (adding or improving test coverage)
- [ ] CI / infrastructure

## Changes Made

- `server/internal/handler/issue.go`: the `project_id` branch of `UpdateIssue` now looks the project up with `GetProjectInWorkspace` scoped to `prevIssue.WorkspaceID` and returns 400 when it is not there. Clearing the project with an explicit `null` is untouched, and an update that does not send `project_id` still carries the current value through `refreshUntouchedNullableIssueParams` without a lookup, so pre-existing rows are not newly rejected.
- `server/internal/handler/issue_update_project_scope_test.go`: `TestUpdateIssueProjectStaysInWorkspace`, both directions on the PUT path.

## How to Test

1. Two workspaces, each with a project. `PUT /api/issues/{id}` with the foreign project's `project_id` returns 400 instead of 200, and the row keeps its previous project.
2. The same request with a project from the issue's own workspace still returns 200 with `project_id` echoed back.
3. Backend suite:

```bash
cd server && go run ./cmd/migrate up
bash scripts/test-go.sh --race
```

The new test fails on `main` (200 on the cross-workspace case) and passes with this change. The existing `TestMoveIssueRejectsUnsafeInputs/cross-workspace_project` and `TestCreateIssueRejectsCrossWorkspaceProject` still pass, so the move and create paths are unaffected. `cd server && go build ./...` and `go vet ./internal/handler/` are clean, and `gofmt -l` reports nothing for the two touched files.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots (no UI change)
- [ ] I have updated relevant documentation to reflect my changes (no documented behavior changes)
- [ ] If I added a new runtime / coding tool / UI tab, I synced the change to landing copy and relevant docs (not applicable)
- [ ] If this PR touches Chinese product copy, I checked it against `conventions.zh.mdx` (not applicable)
- [x] I have considered and documented any risks above
- [x] I will address all reviewer comments before requesting merge

Risk: a client that today moves an issue to a project in another workspace now gets 400. That is the point of the change, and no in-workspace flow reaches it. One thing worth a maintainer's eye: like the `parent_issue_id` check above it, any error from the lookup, including a transient database failure, surfaces as 400 rather than 500. I matched the neighbor instead of introducing a third error shape in the same function.

I agree to the Contribution Terms in `CONTRIBUTING.md`.

## AI Disclosure

**AI tool used:** Claude Code

**Prompt / approach:** I hit this on a self-hosted `v0.4.21` instance and asked Claude Code to confirm the gap on `main` before writing anything, to check whether `MoveIssue` really shares the write path its comment claims, to write the failing test first against a local Postgres and only then the fix, and to keep the fix to the shape the surrounding validations already use. The judgment calls I would most like a maintainer to check are leaving `batch-update` out and reusing the neighbor's 400-on-any-lookup-error behavior.
