### PR TITLE
fix(attachments): show HTML actions on touch devices

### DIFF
--- a/packages/views/editor/html-attachment-preview.test.tsx
+++ b/packages/views/editor/html-attachment-preview.test.tsx
@@ -77,6 +77,26 @@ beforeEach(() => {
 afterEach(() => vi.restoreAllMocks());
 
 describe("HtmlAttachmentPreview — visual shell (does not use file-card chrome)", () => {
+  it("keeps the toolbar visible on devices that cannot hover", async () => {
+    getAttachmentTextContentMock.mockResolvedValueOnce({
+      text: "<p>ok</p>",
+      originalContentType: "text/html",
+    });
+    renderWithQuery(
+      <HtmlAttachmentPreview
+        attachmentId="att-1"
+        filename="report.html"
+        onPreview={() => {}}
+        onDownload={() => {}}
+      />,
+    );
+
+    const toolbar = (await screen.findByTitle("Preview")).parentElement;
+    expect(toolbar?.className).toContain(
+      "[@media(hover:none)]:opacity-100",
+    );
+  });
+
   it("does not render the filename row that AttachmentCard chrome would render", async () => {
     getAttachmentTextContentMock.mockResolvedValueOnce({
       text: "<p>ok</p>",

--- a/packages/views/editor/html-attachment-preview.tsx
+++ b/packages/views/editor/html-attachment-preview.tsx
@@ -101,7 +101,7 @@ export function HtmlAttachmentPreview({
           // only user-reachable escape hatches when inline render fails.
           isError
             ? "opacity-100"
-            : "opacity-0 group-hover/html-preview:opacity-100",
+            : "opacity-0 group-hover/html-preview:opacity-100 [@media(hover:none)]:opacity-100",
         )}
       >
         <button


### PR DESCRIPTION
## What does this PR do?

Makes the HTML attachment preview toolbar reachable on phones and other devices that cannot hover.

The toolbar was always rendered but stayed at `opacity-0` until its preview container received hover. That works with a mouse, but touch-only devices have no hover interaction, so Preview, Open in new tab, and Download were effectively inaccessible. This change follows the existing touch-device pattern used elsewhere in the views package: keep the desktop hover behavior and add an `@media (hover: none)` override that makes the toolbar visible.

## Related Issue

Closes #6384

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Refactor / code improvement (no behavior change)
- [ ] Documentation update
- [x] Tests (adding or improving test coverage)
- [ ] CI / infrastructure

## Changes Made

- `packages/views/editor/html-attachment-preview.tsx`
  - Keeps the existing hover-only toolbar on hover-capable devices.
  - Makes the toolbar visible when `@media (hover: none)` matches.
- `packages/views/editor/html-attachment-preview.test.tsx`
  - Adds regression coverage for the touch-device visibility class.

## How to Test

1. Open an issue containing an HTML attachment on a phone or touch-only viewport.
2. Confirm the Preview, Open in new tab, and Download actions are visible without hovering.
3. On desktop, confirm the toolbar remains hidden until the HTML preview is hovered.

Local verification:

- `pnpm --filter @multica/views exec vitest run editor/html-attachment-preview.test.tsx` — 9 tests passed.
- Targeted ESLint passed for both changed files.
- `pnpm --filter @multica/views typecheck` passed.
- Desktop production build passed and emitted the `@media (hover: none)` rule.
- Playwright using an iPhone 13 viewport (390px wide) confirmed `(hover: none)` matched and the toolbar's computed opacity was `1`.

The root Web/Docs build reached Next.js compilation but could not fetch Google Fonts because this machine's Node TLS trust rejected the local issuer; this is unrelated to the changed files.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [ ] I have updated relevant documentation to reflect my changes
- [ ] If I added a new runtime / coding tool / UI tab, I synced the change to **landing copy** (`apps/web/features/landing/i18n/`) and **relevant docs** (`apps/docs/content/docs/`)
- [ ] If this PR touches Chinese product copy, I checked it against `apps/docs/content/docs/developers/conventions.zh.mdx` (terminology, mixed-rule for `task` / `issue` / `skill`)
- [x] I have considered and documented any risks above
- [x] I will address all reviewer comments before requesting merge

## AI Disclosure

**AI tool used:** Codex

**Prompt / approach:** Traced the mobile-only failure to the hover-gated toolbar, reused the repository's existing no-hover media-query pattern, added a focused regression test, and verified the compiled CSS in a real mobile browser viewport.

## Screenshots (optional)

Not included. This is a visibility-state fix with no layout or visual redesign; mobile behavior was verified in Playwright.
