### PR TITLE
fix(editor): classify slash-prefixed external links by origin

### DIFF
--- a/packages/views/editor/utils/link-handler.test.ts
+++ b/packages/views/editor/utils/link-handler.test.ts
@@ -95,6 +95,22 @@ describe("openLink", () => {
     );
   });
 
+  it.each([
+    ["protocol-relative", "//evil.example/acme/issues/MUL-1"],
+    ["slash-backslash", "/\\evil.example/acme/issues/MUL-1"],
+    ["UNC-style", "\\\\evil.example/acme/issues/MUL-1"],
+    ["absolute", "https://evil.example/acme/issues/MUL-1"],
+  ])("opens a %s external href in a new window", (_kind, href) => {
+    openLink(href, "acme", APP_ORIGIN);
+
+    expect(dispatched).toHaveLength(0);
+    expect(openSpy).toHaveBeenCalledWith(
+      href,
+      "_blank",
+      "noopener,noreferrer",
+    );
+  });
+
   it("still opens an app URL externally when no app origin is known", () => {
     openLink(`${APP_ORIGIN}/acme/issues/MUL-1`, "acme");
     expect(dispatched).toHaveLength(0);

--- a/packages/views/editor/utils/link-handler.ts
+++ b/packages/views/editor/utils/link-handler.ts
@@ -251,9 +251,7 @@ export function openLink(
   currentSlug?: string | null,
   appOrigin?: string | null,
 ): void {
-  const internalPath = href.startsWith("/")
-    ? href
-    : toInternalAppPath(href, appOrigin);
+  const internalPath = toSameOriginPath(href, appOrigin);
   if (internalPath) {
     let path = internalPath;
     if (currentSlug && !isGlobalPath(path)) {

--- a/packages/views/editor/utils/link-handler.ts
+++ b/packages/views/editor/utils/link-handler.ts
@@ -251,7 +251,9 @@ export function openLink(
   currentSlug?: string | null,
   appOrigin?: string | null,
 ): void {
-  const internalPath = toSameOriginPath(href, appOrigin);
+  const internalPath =
+    toInternalAppPath(href, appOrigin) ??
+    (href.startsWith("/") ? toSameOriginPath(href) : null);
   if (internalPath) {
     let path = internalPath;
     if (currentSlug && !isGlobalPath(path)) {


### PR DESCRIPTION
## What does this PR do?

Fixes the shared rich-content link handler so host-bearing hrefs that begin with a slash are not mistaken for in-app routes.

The old `href.startsWith("/")` decision trusted the string shape before URL parsing. Browsers normalize both `//other.example/x` and `/\\other.example/x` to another origin, but the handler dispatched them through `multica:navigate` as if they belonged to the current deployment.

The fix keeps the existing absolute same-origin app-route filter, then validates root-relative candidates with the existing URL-based same-origin resolver. This preserves in-app routing for genuine relative paths while sending protocol-relative, slash-backslash, UNC-style, and absolute external links through the external-window path.

The implementation also preserves the existing distinction for backend-served same-origin URLs such as `/api/attachments/...` and `/uploads/...`: they remain external to the frontend router.

## Related Issue

Closes #6238

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Refactor / code improvement (no behavior change)
- [ ] Documentation update
- [x] Tests (adding or improving test coverage)
- [ ] CI / infrastructure

## Changes Made

- `packages/views/editor/utils/link-handler.ts`: resolve root-relative candidates before dispatching in-app navigation while retaining the existing absolute app-route filter.
- `packages/views/editor/utils/link-handler.test.ts`: cover protocol-relative, slash-backslash, UNC-style, and ordinary absolute external hrefs.
- Verified the existing RichContent integration coverage still keeps attachment downloads and `/uploads` resources outside the frontend router.

## How to Test

1. Run `pnpm --filter @multica/views test`.
2. Run `pnpm --filter @multica/views typecheck`.
3. Run `pnpm --dir packages/views exec eslint editor/utils/link-handler.ts editor/utils/link-handler.test.ts`.
4. Run `pnpm --filter @multica/desktop build`.

Local results:

- `@multica/views`: 317 test files and 3748 tests passed.
- TypeScript typecheck passed.
- Focused ESLint passed with no findings.
- Desktop production build passed.
- Root `pnpm build` was attempted twice. Desktop compiled successfully, while the web/docs build stopped only because this machine could not validate the TLS issuer while Next.js fetched Google Fonts (`UNABLE_TO_GET_ISSUER_CERT_LOCALLY`).

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] If this change affects the UI, I have included before/after screenshots (not applicable: routing-only behavior with automated DOM coverage)
- [x] I have updated relevant documentation to reflect my changes (not applicable: no documented API or workflow change)
- [x] If I added a new runtime / coding tool / UI tab, I synced the change to landing copy and relevant docs (not applicable)
- [x] If this PR touches Chinese product copy, I checked it against the terminology guide (not applicable)
- [x] I have considered and documented any risks above
- [x] I will address all reviewer comments before requesting merge

Risk is limited to link classification in the shared editor and RichContent path. Same-origin app URLs and slugless workspace paths retain their routing behavior; backend-served same-origin assets remain external. No stored content, API, or navigation event shape changes.

I agree to the Contribution Terms in `CONTRIBUTING.md`.

## AI Disclosure

**AI tool used:** Codex

**Prompt / approach:**
Started from issue #6238 and followed TDD. Added a reproducer first and confirmed the two vulnerable spellings failed for the intended reason. Applied the smallest URL-origin fix, then ran the full views suite. Existing integration tests caught an overly broad first version that would have routed same-origin downloads through the app, so the implementation was narrowed to preserve the backend-served URL behavior before rerunning the focused and full suites.

## Screenshots (optional)

Not applicable; this changes click routing with no visual output.